### PR TITLE
Better wrapper system, warning fixes, small bugfixes, module loading implementation

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -173,9 +173,9 @@ void CPUInfo::Detect()
 	if (max_ex_fn >= 0x80000001) {
 		// Check for more features.
 		__cpuid(cpu_id, 0x80000001);
-		bool cmp_legacy = false;
+		//bool cmp_legacy = false;
 		if (cpu_id[2] & 1) bLAHFSAHF64 = true;
-		if (cpu_id[2] & 2) cmp_legacy = true; //wtf is this?
+		//if (cpu_id[2] & 2) cmp_legacy = true; //wtf is this?
 		if ((cpu_id[3] >> 29) & 1) bLongMode = true;
 	}
 

--- a/Common/FixedSizeUnorderedSet.h
+++ b/Common/FixedSizeUnorderedSet.h
@@ -20,7 +20,7 @@ public:
 
   bool remove(T item)
   {
-    for (int i = 0; i < count_; i++)
+    for (u32 i = 0; i < count_; i++)
     {
       if (data_[i] == item)
       {
@@ -62,5 +62,5 @@ public:
 
 private:
   T data_[maxCount];
-  int count_;
+  u32 count_;
 };

--- a/Common/x64Analyzer.cpp
+++ b/Common/x64Analyzer.cpp
@@ -31,12 +31,9 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo &info, int acc
 	info.hasImmediate = false;
 	info.isMemoryWrite = false;
 
-	int addressSize = 8;
 	u8 modRMbyte = 0;
 	u8 sibByte = 0;
     bool hasModRM = false;
-	bool hasSIBbyte = false;
-	bool hasDisplacement = false;
 
 	int displacementSize = 0;
 
@@ -47,7 +44,6 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo &info, int acc
 	} 
 	else if (*codePtr == 0x67)
 	{
-		addressSize = 4;
 		codePtr++;
 	}
 
@@ -113,7 +109,6 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo &info, int acc
 				info.otherReg = (sibByte & 7);
 				if (rex & 2) info.scaledReg += 8;
 				if (rex & 1) info.otherReg += 8;
-				hasSIBbyte = true;
 			}
 			else
 			{
@@ -122,7 +117,6 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo &info, int acc
 		}
 		if (mrm.mod == 1 || mrm.mod == 2)
 		{
-			hasDisplacement = true;
 			if (mrm.mod == 1)
 				displacementSize = 1;
 			else

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -24,7 +24,7 @@
 #include "MemoryUtil.h"
 
 #if !defined(_M_IX86) && !defined(_M_X64)
-#error Don't build this on arm.
+#error Do not build this on arm.
 #endif
 
 namespace Gen

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -154,7 +154,6 @@ bool ElfReader::LoadInto(u32 vaddr)
 		if (s->sh_type == SHT_PSPREL)
 		{
 			//We have a relocation table!
-			int symbolSection = s->sh_link;
 			int sectionToModify = s->sh_info;
 
 			if (!(sections[sectionToModify].sh_flags & SHF_ALLOC))
@@ -289,7 +288,6 @@ bool ElfReader::LoadInto(u32 vaddr)
 			else
 			{
 				//We have a relocation table!
-				int symbolSection = s->sh_link;
 				int sectionToModify = s->sh_info;
 				if (!(sections[sectionToModify].sh_flags & SHF_ALLOC))
 				{
@@ -341,7 +339,6 @@ bool ElfReader::LoadSymbols()
 			if (size == 0)
 				continue;
 
-			int bind = symtab[sym].st_info >> 4;
 			int type = symtab[sym].st_info & 0xF;
 			int sectionIndex = symtab[sym].st_shndx;
 			int value = symtab[sym].st_value;

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -95,6 +95,15 @@ public:
 	}
 	SectionID GetSectionByName(const char *name, int firstSection=0); //-1 for not found
 
+	u32 GetSegmentPaddr(int segment)
+	{
+	    return segments[segment].p_paddr;
+	}
+	u32 GetSegmentOffset(int segment)
+	{
+	    return segments[segment].p_offset;
+	}
+
 	bool DidRelocate() {
 		return bRelocate;
 	}

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -230,7 +230,8 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path)
 			for (size_t i=0; i<e->children.size(); i++)
 			{
 				std::string n = e->children[i]->name;
-				if (path.compare(0, n.length(), n) == 0) //TODO : bad
+				std::string curPath = path.substr(0, path.find_first_of('/'));
+				if (curPath == n)
 				{
 					//yay we got it
 					ne = e->children[i];

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -72,6 +72,10 @@ template<u32 func(int, u32)> void Wrap() {
   RETURN(retval);
 }
 
+template<u32 func(const char *, u32)> void Wrap() {
+  int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1));
+  RETURN((u32)retval);
+}
 template<int func(const char *, u32)> void Wrap() {
   int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1));
   RETURN((u32)retval);

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -21,66 +21,137 @@
 
 // For easy parameter parsing and return value processing.
 
-template<void func()> void WrapV_V() {
+template<void func()> void Wrap() {
   func();
 }
 
-template<u32 func()> void WrapU_V() {
+template<u32 func()> void Wrap() {
   RETURN(func());
 }
 
-template<float func()> void WrapF_V() {
+template<float func()> void Wrap() {
   RETURNF(func());
 }
 
-template<u32 func(u32)> void WrapU_U() {
+template<u32 func(u32)> void Wrap() {
+  u32 retval = func(PARAM(0));
+  RETURN(retval);
+}
+template<int func(int)> void Wrap() {
+  int retval = func(PARAM(0));
+  RETURN(retval);
+}
+template<u32 func(int)> void Wrap() {
   u32 retval = func(PARAM(0));
   RETURN(retval);
 }
 
-template<void func(u32)> void WrapV_U() {
+template<void func(u32)> void Wrap() {
   func(PARAM(0));
 }
 
-template<void func(u32, u32)> void WrapV_UU() {
+template <u32 func(time_t *)> void Wrap() {
+  u32 retval = func((time_t*)Memory::GetPointer(PARAM(0)));
+  RETURN(retval);
+}
+
+template<void func(u32, u32)> void Wrap() {
   func(PARAM(0), PARAM(1));
 }
 
-template<u32 func(u32, u32)> void WrapU_UU() {
+template<u32 func(u32, u32)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1));
+  RETURN(retval);
+}
+template<u32 func(timeval *, u32)> void Wrap() {
+  u32 retval = func((timeval*)Memory::GetPointer(PARAM(0)), PARAM(1));
+  RETURN(retval);
+}
+template<u32 func(int, u32)> void Wrap() {
   u32 retval = func(PARAM(0), PARAM(1));
   RETURN(retval);
 }
 
-template<int func(const char *, u32)> void WrapI_CU() {
+template<int func(const char *, u32)> void Wrap() {
   int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1));
   RETURN((u32)retval);
 }
+template<u32 func(const char *, int)> void Wrap() {
+  u32 retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1));
+  RETURN(retval);
+}
 
-template<u32 func(const char *, u32, u32)> void WrapU_CUU() {
+template<u32 func(const char *, u32, u32)> void Wrap() {
+  int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1), PARAM(2));
+  RETURN((u32)retval);
+}
+template<u32 func(const char *, int, int)> void Wrap() {
   int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1), PARAM(2));
   RETURN((u32)retval);
 }
 
-template<u32 func(u32, u32, u32)> void WrapU_UUU() {
+template<u32 func(u32, u32, u32)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1), PARAM(2));
+  RETURN(retval);
+}
+template<u32 func(int, int, u32)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1), PARAM(2));
+  RETURN(retval);
+}
+template<u32 func(int, u32, u32)> void Wrap() {
   u32 retval = func(PARAM(0), PARAM(1), PARAM(2));
   RETURN(retval);
 }
 
-template<void func(u32, u32, u32)> void WrapV_UUU() {
+template<void func(u32, u32, u32)> void Wrap() {
   func(PARAM(0), PARAM(1), PARAM(2));
 }
 
-template<u32 func(u32, u32, u32, u32)> void WrapU_UUUU() {
+template<u32 func(u32, u32, u32, u32)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+  RETURN(retval);
+}
+template<u32 func(u32, int, int, int)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+  RETURN(retval);
+}
+template<u32 func(u32, u32, u32, int)> void Wrap() {
   u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
   RETURN(retval);
 }
 
-template<u32 func(u32, u32, u32, u32, u32)> void WrapU_UUUUU() {
+template<u32 func(u32, u32, u32, u32, u32)> void Wrap() {
   u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
   RETURN(retval);
 }
 
-template<u32 func(u32, u32, u32, u32, u32, u32)> void WrapU_UUUUUU() {
+template<u32 func(u32, u32, u32, u32, u32, u32)> void Wrap() {
   u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5));
   RETURN(retval);
 }
+template<u32 func(u32, int, u32, int, u32, int)> void Wrap() {
+  u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5));
+  RETURN(retval);
+}
+
+template<u32 func(u64)> void Wrap() {
+  u32 retval = func(((u64)PARAM(1) << 32) | PARAM(0));
+  RETURN(retval);
+}
+
+template<u64 func(u32, u64, u32)> void Wrap() {
+  u64 retval = func(PARAM(0), ((u64)PARAM(3) << 32) | PARAM(2), PARAM(4));
+  RETURN(retval);
+  RETURN2(retval >> 32);
+}
+template<u64 func(int, s64, u32)> void Wrap() {
+  u64 retval = func(PARAM(0), ((u64)PARAM(3) << 32) | PARAM(2), PARAM(4));
+  RETURN(retval);
+  RETURN2(retval >> 32);
+}
+
+template<u32 func(int, s64, u32)> void Wrap() {
+  u32 retval = func(PARAM(0), ((u64)PARAM(3) << 32) | PARAM(2), PARAM(4));
+  RETURN(retval);
+}
+

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -42,6 +42,7 @@ struct HLEModule
 
 #define PARAM(n) currentMIPS->r[4+n]
 #define RETURN(n) currentMIPS->r[2]=n
+#define RETURN2(n) currentMIPS->r[3]=n
 #define RETURNF(fl) currentMIPS->f[0]=fl
 
 #ifndef ARRAY_SIZE

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -40,6 +40,13 @@ struct HLEModule
 	const HLEFunction *funcTable;
 };
 
+struct Syscall
+{
+    char moduleName[32];
+	u32 symAddr;
+	u32 nid;
+};
+
 #define PARAM(n) currentMIPS->r[4+n]
 #define RETURN(n) currentMIPS->r[2]=n
 #define RETURN2(n) currentMIPS->r[3]=n
@@ -69,6 +76,7 @@ u32 GetNibByName(const char *module, const char *function);
 u32 GetSyscallOp(const char *module, u32 nib);
 void WriteSyscall(const char *module, u32 nib, u32 address);
 void CallSyscall(u32 op);
+void ResolveSyscall(const char *moduleName, u32 nib, u32 address);
 
 // Need to be able to save entire kernel state
 int GetStateSize();

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -65,9 +65,9 @@ const HLEFunction FakeSysCalls[] =
 
 const HLEFunction UtilsForUser[] = 
 {
-	{0x91E4F6A7, sceKernelLibcClock, "sceKernelLibcClock"},
-	{0x27CC57F0, sceKernelLibcTime, "sceKernelLibcTime"},
-	{0x71EC4271, sceKernelLibcGettimeofday, "sceKernelLibcGettimeofday"},
+	{0x91E4F6A7, &Wrap<sceKernelLibcClock>, "sceKernelLibcClock"},
+	{0x27CC57F0, &Wrap<sceKernelLibcTime>, "sceKernelLibcTime"},
+	{0x71EC4271, &Wrap<sceKernelLibcGettimeofday>, "sceKernelLibcGettimeofday"},
 	{0xBFA98062, 0, "sceKernelDcacheInvalidateRange"},
 	{0xC8186A58, 0, "sceKernelUtilsMd5Digest"},
 	{0x9E5C5086, 0, "sceKernelUtilsMd5BlockInit"},
@@ -79,28 +79,28 @@ const HLEFunction UtilsForUser[] =
 	{0x585F1C09, 0, "sceKernelUtilsSha1BlockResult"},
 	{0xE860E75E, 0, "sceKernelUtilsMt19937Init"},
 	{0x06FB8A63, 0, "sceKernelUtilsMt19937UInt"},
-	{0x37FB5C42, sceKernelGetGPI, "sceKernelGetGPI"},
-	{0x6AD345D7, sceKernelSetGPO, "sceKernelSetGPO"},
-	{0x79D1C3FA, sceKernelDcacheWritebackAll, "sceKernelDcacheWritebackAll"},
-	{0xB435DEC5, sceKernelDcacheWritebackInvalidateAll, "sceKernelDcacheWritebackInvalidateAll"},
-	{0x3EE30821, sceKernelDcacheWritebackRange, "sceKernelDcacheWritebackRange"},
-	{0x34B9FA9E, sceKernelDcacheWritebackInvalidateRange, "sceKernelDcacheWritebackInvalidateRange"},
+	{0x37FB5C42, &Wrap<sceKernelGetGPI>, "sceKernelGetGPI"},
+	{0x6AD345D7, &Wrap<sceKernelSetGPO>, "sceKernelSetGPO"},
+	{0x79D1C3FA, &Wrap<sceKernelDcacheWritebackAll>, "sceKernelDcacheWritebackAll"},
+	{0xB435DEC5, &Wrap<sceKernelDcacheWritebackInvalidateAll>, "sceKernelDcacheWritebackInvalidateAll"},
+	{0x3EE30821, &Wrap<sceKernelDcacheWritebackRange>, "sceKernelDcacheWritebackRange"},
+	{0x34B9FA9E, &Wrap<sceKernelDcacheWritebackInvalidateRange>, "sceKernelDcacheWritebackInvalidateRange"},
 	{0x80001C4C, 0, "sceKernelDcacheProbe"},
 	{0x16641D70, 0, "sceKernelDcacheReadTag"},
 	{0x4FD31C9D, 0, "sceKernelIcacheProbe"},
 	{0xFB05FAD0, 0, "sceKernelIcacheReadTag"},
-	{0x920f104a, sceKernelIcacheInvalidateAll, "sceKernelIcacheInvalidateAll"}
+	{0x920f104a, &Wrap<sceKernelIcacheInvalidateAll>, "sceKernelIcacheInvalidateAll"}
 };				   
 
 
 const HLEFunction sceRtc[] = 
 {
-  {0xC41C2853, sceRtcGetTickResolution, "sceRtcGetTickResolution"},
-  {0x3f7ad767, sceRtcGetCurrentTick, "sceRtcGetCurrentTick"},	
+  {0xC41C2853, &Wrap<sceRtcGetTickResolution>, "sceRtcGetTickResolution"},
+  {0x3f7ad767, &Wrap<sceRtcGetCurrentTick>, "sceRtcGetCurrentTick"},	
   {0x011F03C1, 0, "sceRtcGetAccumulativeTime"},
   {0x029CA3B3, 0, "sceRtcGetAccumlativeTime"},
   {0x4cfa57b0, 0, "sceRtcGetCurrentClock"},
-  {0xE7C27D1B, sceRtcGetCurrentClockLocalTime, "sceRtcGetCurrentClockLocalTime"},
+  {0xE7C27D1B, &Wrap<sceRtcGetCurrentClockLocalTime>, "sceRtcGetCurrentClockLocalTime"},
   {0x34885E0D, 0, "sceRtcConvertUtcToLocalTime"},
   {0x779242A2, 0, "sceRtcConvertLocalTimeToUTC"},
   {0x42307A17, 0, "sceRtcIsLeapYear"},
@@ -114,7 +114,7 @@ const HLEFunction sceRtc[] =
   {0x7ACE4C04, 0, "sceRtcSetWin32FileTime"},
   {0xCF561893, 0, "sceRtcGetWin32FileTime"},
   {0x7ED29E40, 0, "sceRtcSetTick"},
-  {0x6FF40ACC, sceRtcGetTick, "sceRtcGetTick"},
+  {0x6FF40ACC, &Wrap<sceRtcGetTick>, "sceRtcGetTick"},
   {0x9ED0AE87, 0, "sceRtcCompareTick"},
   {0x44F45E05, 0, "sceRtcTickAddTicks"},
   {0x26D25A5D, 0, "sceRtcTickAddMicroseconds"},
@@ -179,7 +179,7 @@ const HLEFunction LoadCoreForKernel[] =
   {0xCCE4A157, 0, "sceKernelFindModuleByUID"},
   {0x82CE54ED, 0, "sceKernelModuleCount"},
   {0xC0584F0C, 0, "sceKernelGetModuleList"},
-  {0xCF8A41B1, sceKernelFindModuleByName,"sceKernelFindModuleByName"},
+  {0xCF8A41B1, &Wrap<sceKernelFindModuleByName>,"sceKernelFindModuleByName"},
 };
 
 
@@ -189,7 +189,7 @@ const HLEFunction KDebugForKernel[] =
 	{0x2FF4E9F9, 0, "sceKernelAssert"},
 	{0x9B868276, 0, "sceKernelGetDebugPutchar"},
 	{0xE146606D, 0, "sceKernelRegisterDebugPutchar"},
-	{0x7CEB2C09, sceKernelRegisterKprintfHandler, "sceKernelRegisterKprintfHandler"},
+	{0x7CEB2C09, &Wrap<sceKernelRegisterKprintfHandler>, "sceKernelRegisterKprintfHandler"},
 	{0x84F370BC, 0, "Kprintf"},
 	{0x5CE9838B, 0, "sceKernelDebugWrite"},
 	{0x66253C4E, 0, "sceKernelRegisterDebugWrite"},

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -28,19 +28,14 @@
 #define ATRAC_ERROR_API_FAIL 0x80630002
 #define ATRAC_ERROR_ALL_DATA_DECODED 0x80630024
 
-void sceAtracAddStreamData()
+u32 sceAtracAddStreamData(u32 atracID, u32 addByte)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracAddStreamData(%i, %i)", PARAM(0), PARAM(1));
-	RETURN(0);
+	ERROR_LOG(HLE, "UNIMPL sceAtracAddStreamData(%i, %i)", atracID, addByte);
+	return 0;
 }
 
-void sceAtracDecodeData()
+u32 sceAtracDecodeData(u32 atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
 {
-	u32 atracID = PARAM(0);
-	u32 outAddr = PARAM(1);
-	u32 numSamplesAddr = PARAM(2);
-	u32 finishFlagAddr = PARAM(3);
-	u32 remainAddr = PARAM(4);
 	ERROR_LOG(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
 
 	Memory::Write_U16(0, outAddr);	// Write a single 16-bit stereo
@@ -50,199 +45,193 @@ void sceAtracDecodeData()
 	Memory::Write_U32(1, finishFlagAddr);	// Lie that decoding is finished
 	Memory::Write_U32(0, remainAddr);	// Lie that decoding is finished
 
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracEndEntry()
+u32 sceAtracEndEntry()
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracEndEntry");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetAtracID()
+u32 sceAtracGetAtracID(u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetAtracID");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetBufferInfoForReseting()
+u32 sceAtracGetBufferInfoForReseting(u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetBufferInfoForReseting");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetBitrate()
+u32 sceAtracGetBitrate(u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetBitrate");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetChannel()
+u32 sceAtracGetChannel(u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetChannel");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetLoopStatus()
+u32 sceAtracGetLoopStatus(u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetInternalErrorInfo()
+u32 sceAtracGetInternalErrorInfo(u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetInternalErrorInfo");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetMaxSample()
+u32 sceAtracGetMaxSample(u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracGetMaxSample");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetNextDecodePosition()
+u32 sceAtracGetNextDecodePosition(u32 atracID, u32 samplePositionAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", PARAM(0), PARAM(1));
-	u32 *outPos = (u32*)Memory::GetPointer(PARAM(1));
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", atracID, samplePositionAddr);
+	u32 *outPos = (u32*)Memory::GetPointer(samplePositionAddr);
 	*outPos = 1;
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetNextSample()
+u32 sceAtracGetNextSample(u32 atracID, u32 outN)
 {
-	u32 atracID = PARAM(0);
-	u32 outN = PARAM(1);
 	ERROR_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outN);
 	Memory::Write_U32(0, outN);
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetRemainFrame()
+u32 sceAtracGetRemainFrame(u32 atracID, u32 remainAddr)
 {
-	ERROR_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)",PARAM(0),PARAM(1));
-	u32 *outPos = (u32*)Memory::GetPointer(PARAM(1));
+	ERROR_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)",atracID,remainAddr);
+	u32 *outPos = (u32*)Memory::GetPointer(remainAddr);
 	*outPos = 12;
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetSecondBufferInfo()
+u32 sceAtracGetSecondBufferInfo(u32 atracID, u32 positionAddr, u32 dataAddr)
 {
-	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)",PARAM(0),PARAM(1),PARAM(2));
-	u32 *outPos = (u32*)Memory::GetPointer(PARAM(1));
-	u32 *outBytes = (u32*)Memory::GetPointer(PARAM(2));
+	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)",atracID,positionAddr,dataAddr);
+	u32 *outPos = (u32*)Memory::GetPointer(positionAddr);
+	u32 *outBytes = (u32*)Memory::GetPointer(dataAddr);
 	*outPos = 0;
 	*outBytes = 0x10000;
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetSoundSample()
+u32 sceAtracGetSoundSample(u32 atracID, u32 endSampleAddr, u32 loopStartAddr, u32 loopEndAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)",PARAM(0),PARAM(1),PARAM(2),PARAM(3));
-	u32 *outEndSample = (u32*)Memory::GetPointer(PARAM(1));
-	u32 *outLoopStartSample = (u32*)Memory::GetPointer(PARAM(2));
-	u32 *outLoopEndSample = (u32*)Memory::GetPointer(PARAM(2));
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)",atracID,endSampleAddr,loopStartAddr,loopEndAddr);
+	u32 *outEndSample = (u32*)Memory::GetPointer(endSampleAddr);
+	u32 *outLoopStartSample = (u32*)Memory::GetPointer(loopStartAddr);
+	u32 *outLoopEndSample = (u32*)Memory::GetPointer(loopEndAddr);
 	*outEndSample = 0x10000;
 	*outLoopStartSample = -1;
 	*outLoopEndSample = -1;
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracGetStreamDataInfo()
+u32 sceAtracGetStreamDataInfo(u32 atracID, u32 writePointerAddr, u32 availableBytesAddr, u32 readOffsetAddr)
 {
-	u32 atracID = PARAM(0);
-	u32 writePointerAddr = PARAM(1);
-	u32 availableBytesAddr = PARAM(2);
-	u32 readOffsetAddr = PARAM(3);
 	ERROR_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writePointerAddr, availableBytesAddr, readOffsetAddr);
 	Memory::Write_U32(0, readOffsetAddr);
 	Memory::Write_U32(0, availableBytesAddr);
 	Memory::Write_U32(0, writePointerAddr);
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracReleaseAtracID()
+u32 sceAtracReleaseAtracID(u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracReleaseAtracID");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracResetPlayPosition()
+u32 sceAtracResetPlayPosition(u32, u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracResetPlayPosition");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracSetHalfwayBuffer()
+u32 sceAtracSetHalfwayBuffer(u32, u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBuffer");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracSetSecondBuffer()
+u32 sceAtracSetSecondBuffer(u32 atracID, u32 secondBufferAddr, u32 secondBufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %i)", PARAM(0),PARAM(1),PARAM(2));
-	RETURN(0);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %i)", atracID, secondBufferAddr, secondBufferSize);
+	return 0;
 }
 
-void sceAtracSetData()
+u32 sceAtracSetData(u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracSetData");
-	RETURN(0);
-} //?
-
-void sceAtracSetDataAndGetID()
-{
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %i)", PARAM(0), PARAM(1));
-	RETURN(1);
+	return 0;
 }
 
-void sceAtracSetHalfwayBufferAndGetID()
+u32 sceAtracSetDataAndGetID(u32 bufferAddr, u32 bufferSize)
+{
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %i)", bufferAddr, bufferSize);
+	return 1;
+}
+
+u32 sceAtracSetHalfwayBufferAndGetID(u32, u32, u32)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBufferAndGetID");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracStartEntry()
+u32 sceAtracStartEntry()
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracStartEntry");
-	RETURN(0);
+	return 0;
 }
 
-void sceAtracSetLoopNum()
+u32 sceAtracSetLoopNum(u32 atracID, u32 loopNum)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", PARAM(0), PARAM(1));
-	RETURN(0);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
+	return 0;
 }
 
 
 const HLEFunction sceAtrac3plus[] =
 {
-	{0x7db31251,sceAtracAddStreamData,"sceAtracAddStreamData"},
-	{0x6a8c3cd5,sceAtracDecodeData,"sceAtracDecodeData"},
-	{0xd5c28cc0,sceAtracEndEntry,"sceAtracEndEntry"},
-	{0x780f88d1,sceAtracGetAtracID,"sceAtracGetAtracID"},
-	{0xca3ca3d2,sceAtracGetBufferInfoForReseting,"sceAtracGetBufferInfoForReseting"},
-	{0xa554a158,sceAtracGetBitrate,"sceAtracGetBitrate"},
-	{0x31668baa,sceAtracGetChannel,"sceAtracGetChannel"},
-	{0xfaa4f89b,sceAtracGetLoopStatus,"sceAtracGetLoopStatus"},
-	{0xe88f759b,sceAtracGetInternalErrorInfo,"sceAtracGetInternalErrorInfo"},
-	{0xd6a5f2f7,sceAtracGetMaxSample,"sceAtracGetMaxSample"},
-	{0xe23e3a35,sceAtracGetNextDecodePosition,"sceAtracGetNextDecodePosition"},
-	{0x36faabfb,sceAtracGetNextSample,"sceAtracGetNextSample"},
-	{0x9ae849a7,sceAtracGetRemainFrame,"sceAtracGetRemainFrame"},
-	{0x83e85ea0,sceAtracGetSecondBufferInfo,"sceAtracGetSecondBufferInfo"},
-	{0xa2bba8be,sceAtracGetSoundSample,"sceAtracGetSoundSample"},
-	{0x5d268707,sceAtracGetStreamDataInfo,"sceAtracGetStreamDataInfo"},
-	{0x61eb33f5,sceAtracReleaseAtracID,"sceAtracReleaseAtracID"},
-	{0x644e5607,sceAtracResetPlayPosition,"sceAtracResetPlayPosition"},
-	{0x3f6e26b5,sceAtracSetHalfwayBuffer,"sceAtracSetHalfwayBuffer"},
-	{0x83bf7afd,sceAtracSetSecondBuffer,"sceAtracSetSecondBuffer"},
-	{0x0E2A73AB,sceAtracSetData,"sceAtracSetData"}, //?
-	{0x7a20e7af,sceAtracSetDataAndGetID,"sceAtracSetDataAndGetID"},
-	{0x0eb8dc38,sceAtracSetHalfwayBufferAndGetID,"sceAtracSetHalfwayBufferAndGetID"},
-	{0xd1f59fdb,sceAtracStartEntry,"sceAtracStartEntry"},
-	{0x868120b5,sceAtracSetLoopNum,"sceAtracSetLoopNum"},
+	{0x7db31251,&Wrap<sceAtracAddStreamData>,"sceAtracAddStreamData"},
+	{0x6a8c3cd5,&Wrap<sceAtracDecodeData>,"sceAtracDecodeData"},
+	{0xd5c28cc0,&Wrap<sceAtracEndEntry>,"sceAtracEndEntry"},
+	{0x780f88d1,&Wrap<sceAtracGetAtracID>,"sceAtracGetAtracID"},
+	{0xca3ca3d2,&Wrap<sceAtracGetBufferInfoForReseting>,"sceAtracGetBufferInfoForReseting"},
+	{0xa554a158,&Wrap<sceAtracGetBitrate>,"sceAtracGetBitrate"},
+	{0x31668baa,&Wrap<sceAtracGetChannel>,"sceAtracGetChannel"},
+	{0xfaa4f89b,&Wrap<sceAtracGetLoopStatus>,"sceAtracGetLoopStatus"},
+	{0xe88f759b,&Wrap<sceAtracGetInternalErrorInfo>,"sceAtracGetInternalErrorInfo"},
+	{0xd6a5f2f7,&Wrap<sceAtracGetMaxSample>,"sceAtracGetMaxSample"},
+	{0xe23e3a35,&Wrap<sceAtracGetNextDecodePosition>,"sceAtracGetNextDecodePosition"},
+	{0x36faabfb,&Wrap<sceAtracGetNextSample>,"sceAtracGetNextSample"},
+	{0x9ae849a7,&Wrap<sceAtracGetRemainFrame>,"sceAtracGetRemainFrame"},
+	{0x83e85ea0,&Wrap<sceAtracGetSecondBufferInfo>,"sceAtracGetSecondBufferInfo"},
+	{0xa2bba8be,&Wrap<sceAtracGetSoundSample>,"sceAtracGetSoundSample"},
+	{0x5d268707,&Wrap<sceAtracGetStreamDataInfo>,"sceAtracGetStreamDataInfo"},
+	{0x61eb33f5,&Wrap<sceAtracReleaseAtracID>,"sceAtracReleaseAtracID"},
+	{0x644e5607,&Wrap<sceAtracResetPlayPosition>,"sceAtracResetPlayPosition"},
+	{0x3f6e26b5,&Wrap<sceAtracSetHalfwayBuffer>,"sceAtracSetHalfwayBuffer"},
+	{0x83bf7afd,&Wrap<sceAtracSetSecondBuffer>,"sceAtracSetSecondBuffer"},
+	{0x0E2A73AB,&Wrap<sceAtracSetData>,"sceAtracSetData"}, //?
+	{0x7a20e7af,&Wrap<sceAtracSetDataAndGetID>,"sceAtracSetDataAndGetID"},
+	{0x0eb8dc38,&Wrap<sceAtracSetHalfwayBufferAndGetID>,"sceAtracSetHalfwayBufferAndGetID"},
+	{0xd1f59fdb,&Wrap<sceAtracStartEntry>,"sceAtracStartEntry"},
+	{0x868120b5,&Wrap<sceAtracSetLoopNum>,"sceAtracSetLoopNum"},
 	{0x132f1eca,0,"sceAtracReinit"},
 	{0xeca32a99,0,"sceAtracIsSecondBufferNeeded"},
 	{0x0fae370e,0,"sceAtracSetHalfwayBufferAndGetID"},

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -59,11 +59,11 @@ u32 sceAudioOutputPannedBlocking(u32 chan, u32 volume1, u32 volume2, u32 sampleP
 	}
 }
 
-void sceAudioGetChannelRestLen()
+u32 sceAudioGetChannelRestLen(u32 chanId)
 {
-	ERROR_LOG(HLE,"UNIMPL sceAudioGetChannelRestLen(%i)", PARAM(0));
+	ERROR_LOG(HLE,"UNIMPL sceAudioGetChannelRestLen(%i)", chanId);
 	// Remaining samples in that channel buffer.
-	RETURN(0);
+	return 0;
 }
 
 u32 sceAudioOutputPanned(u32 chan, u32 leftVol, u32 rightVol, u32 samplePtr)
@@ -147,7 +147,7 @@ u32 sceAudioChReserve(u32 channel, u32 sampleCount, u32 format) //.Allocate soun
   {
 		WARN_LOG(HLE, "WARNING: Reserving already reserved channel. Error?");
 	}
-	DEBUG_LOG(HLE,"%i = sceAudioChReserve(%i, %i, %i)", channel, PARAM(0), sampleCount, format);
+	DEBUG_LOG(HLE,"%i = sceAudioChReserve(%i, %i, %i)", channel, channel, sampleCount, format);
 
 	chans[channel].sampleCount = sampleCount;
 	chans[channel].reserved = true;
@@ -230,10 +230,10 @@ u32 sceAudioChangeChannelVolume(u32 chan, u32 lvolume, u32 rvolume)
   }
 }
  
-void sceAudioInit()
+u32 sceAudioInit()
 {
   ERROR_LOG(HLE,"UNIMPL sceAudioInit");
-  RETURN(0);
+  return 0;
 }
 
 const HLEFunction sceAudio[] = 
@@ -246,7 +246,7 @@ const HLEFunction sceAudio[] =
   {0x210567F7, 0, "sceAudioEnd"},
   {0x38553111, 0, "sceAudioSRCChReserve"},
   {0x5C37C0AE, 0, "sceAudioSRCChRelease"},
-  {0x80F1F7E0, sceAudioInit, "sceAudioInit"},
+  {0x80F1F7E0, Wrap<sceAudioInit>, "sceAudioInit"},
   {0x927AC32B, 0, "sceAudioSetVolumeOffset"},
   {0xA2BEAA6C, 0, "sceAudioSetFrequency"},
   {0xA633048E, 0, "sceAudioPollInputEnd"},
@@ -255,15 +255,15 @@ const HLEFunction sceAudio[] =
   {0xE0727056, 0, "sceAudioSRCOutputBlocking"},
   {0xE926D3FB, 0, "sceAudioInputInitEx"},
   {0x8c1009b2, 0, "sceAudioOutput"}, 
-  {0x136CAF51, WrapU_UUU<sceAudioOutputBlocking>, "sceAudioOutputBlocking"}, 
-  {0xE2D56B2D, WrapU_UUUU<sceAudioOutputPanned>, "sceAudioOutputPanned"}, 
-  {0x13F592BC, WrapU_UUUU<sceAudioOutputPannedBlocking>, "sceAudioOutputPannedBlocking"}, //(u32, u32, u32, void *)Output sound, blocking 
-  {0x5EC81C55, WrapU_UUU<sceAudioChReserve>, "sceAudioChReserve"}, //(u32, u32 samplecount, u32) Initialize channel and allocate buffer  long, long samplecount, long);//init buffer? returns handle, minus if error
-  {0x6FC46853, WrapU_U<sceAudioChRelease>, "sceAudioChRelease"}, //(long handle)Terminate channel and deallocate buffer //free buffer?
-  {0xE9D97901, sceAudioGetChannelRestLen, "sceAudioGetChannelRestLen"}, 
-  {0xCB2E439E, WrapU_UU<sceAudioSetChannelDataLen>, "sceAudioSetChannelDataLen"}, //(u32, u32)
-  {0x95FD0C2D, WrapU_UU<sceAudioChangeChannelConfig>, "sceAudioChangeChannelConfig"}, 
-  {0xB7E1D8E7, WrapU_UUU<sceAudioChangeChannelVolume>, "sceAudioChangeChannelVolume"}, 
+  {0x136CAF51, Wrap<sceAudioOutputBlocking>, "sceAudioOutputBlocking"}, 
+  {0xE2D56B2D, Wrap<sceAudioOutputPanned>, "sceAudioOutputPanned"}, 
+  {0x13F592BC, Wrap<sceAudioOutputPannedBlocking>, "sceAudioOutputPannedBlocking"}, //(u32, u32, u32, void *)Output sound, blocking 
+  {0x5EC81C55, Wrap<sceAudioChReserve>, "sceAudioChReserve"}, //(u32, u32 samplecount, u32) Initialize channel and allocate buffer  long, long samplecount, long);//init buffer? returns handle, minus if error
+  {0x6FC46853, Wrap<sceAudioChRelease>, "sceAudioChRelease"}, //(long handle)Terminate channel and deallocate buffer //free buffer?
+  {0xE9D97901, Wrap<sceAudioGetChannelRestLen>, "sceAudioGetChannelRestLen"}, 
+  {0xCB2E439E, Wrap<sceAudioSetChannelDataLen>, "sceAudioSetChannelDataLen"}, //(u32, u32)
+  {0x95FD0C2D, Wrap<sceAudioChangeChannelConfig>, "sceAudioChangeChannelConfig"}, 
+  {0xB7E1D8E7, Wrap<sceAudioChangeChannelVolume>, "sceAudioChangeChannelVolume"}, 
   {0x41efade7, 0, "sceAudioOneshotOutput"},
   {0x086e5895, 0, "sceAudioInputBlocking"},	 
   {0x6d4bec68, 0, "sceAudioInput"},	 

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -100,11 +100,12 @@ u32 sceCtrlSetIdleCancelThreshold(u32, u32)
 u32 sceCtrlReadBufferPositive(u32 ctrlData, u32 nBufs)
 {
   std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
-	if (ctrlInited)
-	{
+  // Let's just ignore if ctrl is inited or not; some games don't init it (Super Fruit Fall)
+	//if (ctrlInited)
+	//{
 		static int frame = 0;
 		_ctrl_data &data = ctrl;
-		data.frame=frame;
+		data.frame=1;//frame;
     frame++;
 #ifdef _WIN32
     // TODO: Move this outta here!
@@ -150,7 +151,7 @@ u32 sceCtrlReadBufferPositive(u32 ctrlData, u32 nBufs)
 #endif
 
     memcpy(Memory::GetPointer(ctrlData), &data, sizeof(_ctrl_data));
-	}
+	//}
 	return 1;
 }
 

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -72,14 +72,15 @@ void __CtrlSetAnalog(float x, float y)
   ctrl.analog[1] = (u8)(y * 127.f + 128.f);
 }
 
-void sceCtrlInit()
+u32 sceCtrlInit()
 {
 	ctrlInited = true;
   memset(&ctrl, 0, sizeof(ctrl));
 	DEBUG_LOG(HLE,"sceCtrlInit");
+	return 0;
 }
 
-void sceCtrlSetSamplingMode()
+u32 sceCtrlSetSamplingMode(u32)
 {
 	DEBUG_LOG(HLE,"sceCtrlSetSamplingMode");
 	if (ctrlInited)
@@ -87,14 +88,16 @@ void sceCtrlSetSamplingMode()
     // Looks odd
 		analogEnabled = true;
 	}
+	return 0;
 }
 
-void sceCtrlSetIdleCancelThreshold()
+u32 sceCtrlSetIdleCancelThreshold(u32, u32)
 {
   DEBUG_LOG(HLE,"UNIMPL sceCtrlSetIdleCancelThreshold");
+  return 0;
 }
 
-void sceCtrlReadBufferPositive()
+u32 sceCtrlReadBufferPositive(u32 ctrlData, u32 nBufs)
 {
   std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 	if (ctrlInited)
@@ -146,20 +149,21 @@ void sceCtrlReadBufferPositive()
     data.analog[1]=analogY;
 #endif
 
-    memcpy(Memory::GetPointer(PARAM(0)), &data, sizeof(_ctrl_data));
+    memcpy(Memory::GetPointer(ctrlData), &data, sizeof(_ctrl_data));
 	}
+	return 1;
 }
 
 static const HLEFunction sceCtrl[] = 
 {
-  {0x6a2774f3, sceCtrlInit,          "sceCtrlInit"}, //(int unknown), init with 0
-  {0x1f4011e6, sceCtrlSetSamplingMode, "sceCtrlSetSamplingMode"}, //(int on);
-  {0x1f803938, sceCtrlReadBufferPositive,          "sceCtrlReadBufferPositive"}, //(ctrl_data_t* paddata, int unknown) // unknown should be 1
-  {0x6A2774F3, 0, "sceCtrlSetSamplingCycle"}, //?
-  {0x6A2774F3,sceCtrlInit,"sceCtrlSetSamplingCycle"},
+  {0x6a2774f3, Wrap<sceCtrlInit>,          "sceCtrlInit"},
+  {0x1f4011e6, Wrap<sceCtrlSetSamplingMode>, "sceCtrlSetSamplingMode"},
+  {0x1f803938, Wrap<sceCtrlReadBufferPositive>,          "sceCtrlReadBufferPositive"},
+  {0x6A2774F3, 0, "sceCtrlSetSamplingCycle"},
+  {0x6A2774F3, Wrap<sceCtrlInit>,"sceCtrlSetSamplingCycle"},
   {0x02BAAD91,0,"sceCtrlGetSamplingCycle"},
   {0xDA6B76A1,0,"sceCtrlGetSamplingMode"},
-  {0x3A622550,sceCtrlReadBufferPositive,"sceCtrlPeekBufferPositive"},
+  {0x3A622550, Wrap<sceCtrlReadBufferPositive>,"sceCtrlPeekBufferPositive"},
   {0xC152080A,0,"sceCtrlPeekBufferNegative"},
   {0x60B81F86,0,"sceCtrlReadBufferNegative"},
   {0xB1D0E5CD,0,"sceCtrlPeekLatch"},
@@ -168,7 +172,7 @@ static const HLEFunction sceCtrl[] =
   {0xAF5960F3,0,"sceCtrl_AF5960F3"},
   {0xA68FD260,0,"sceCtrlClearRapidFire"},
   {0x6841BE1A,0,"sceCtrlSetRapidFire"},
-  {0xa7144800,sceCtrlSetIdleCancelThreshold,"sceCtrlSetIdleCancelThreshold"},
+  {0xa7144800, Wrap<sceCtrlSetIdleCancelThreshold>,"sceCtrlSetIdleCancelThreshold"},
   {0x687660fa,0,"sceCtrlGetIdleCancelThreshold"},
 };	
 

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -28,7 +28,7 @@ u32 sceDmacMemcpy(u32 dst, u32 src, u32 size)
 
 const HLEFunction sceDmac[] =
 {
-	{0x617f3fe6, &WrapU_UUU<sceDmacMemcpy>, "sceDmacMemcpy"},
+	{0x617f3fe6, &Wrap<sceDmacMemcpy>, "sceDmacMemcpy"},
 };
 
 void Register_sceDmac()

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -110,10 +110,9 @@ void sceGeListSync(u32 displayListID, u32 mode) //0 : wait for completion		1:che
 	DEBUG_LOG(HLE,"sceGeListSync(dlid=%08x, mode=%08x)", displayListID,mode);
 }
 
-u32 sceGeDrawSync(u32)
+u32 sceGeDrawSync(u32 mode)
 {
 	//wait/check entire drawing state
-	u32 mode = PARAM(0); //0 : wait for completion		1:check and return
 	DEBUG_LOG(HLE,"FAKE sceGeDrawSync(mode=%d)",mode);
 	if (mode == 1)
 	{
@@ -125,16 +124,16 @@ u32 sceGeDrawSync(u32)
 	}
 }
 
-void sceGeBreak()
+u32 sceGeBreak(u32 mode, u32)
 {
-	u32 mode = PARAM(0); //0 : current dlist 1: all drawing
 	ERROR_LOG(HLE,"UNIMPL sceGeBreak(mode=%d)",mode);
+	return 0;
 }
 
-void sceGeContinue()
+u32 sceGeContinue()
 {
 	ERROR_LOG(HLE,"UNIMPL sceGeContinue");
-	// no arguments
+	return 0;
 }
 
 u32 sceGeSetCallback(u32 structAddr)
@@ -172,32 +171,31 @@ void sceGeGetMtx()
 	ERROR_LOG(HLE,"UNIMPL sceGeGetMtx()");
 }
 
-void sceGeEdramSetAddrTranslation()
+int sceGeEdramSetAddrTranslation(int new_size)
 {
-	int new_size = PARAM(0);
 	INFO_LOG(HLE,"sceGeEdramSetAddrTranslation(%i)", new_size);
 	static int EDRamWidth;
 	int last = EDRamWidth;
 	EDRamWidth = new_size;
-	RETURN(last);
+	return last;
 }
 
 const HLEFunction sceGe_user[] =
 {
-	{0xE47E40E4,&WrapU_V<sceGeEdramGetAddr>,					"sceGeEdramGetAddr"},
-	{0xAB49E76A,&WrapU_UUUU<sceGeListEnQueue>,				"sceGeListEnQueue"},
-	{0x1C0D95A6,&WrapU_UUUU<sceGeListEnQueueHead>,		"sceGeListEnQueueHead"},
-	{0xE0D68148,&WrapV_UU<sceGeListUpdateStallAddr>,	"sceGeListUpdateStallAddr"},
-	{0x03444EB4,&WrapV_UU<sceGeListSync>,						 "sceGeListSync"},
-	{0xB287BD61,&WrapU_U<sceGeDrawSync>,							"sceGeDrawSync"},
-	{0xB448EC0D,sceGeBreak,							"sceGeBreak"},
-	{0x4C06E472,sceGeContinue,					 "sceGeContinue"},
-	{0xA4FC06A4,&WrapU_U<sceGeSetCallback>,	"sceGeSetCallback"},
-	{0x05DB22CE,&WrapV_U<sceGeUnsetCallback>,					 "sceGeUnsetCallback"},
-	{0x1F6752AD,&WrapU_V<sceGeEdramGetSize>, "sceGeEdramGetSize"},
-	{0xB77905EA,&sceGeEdramSetAddrTranslation,"sceGeEdramSetAddrTranslation"},
+	{0xE47E40E4,&Wrap<sceGeEdramGetAddr>,					"sceGeEdramGetAddr"},
+	{0xAB49E76A,&Wrap<sceGeListEnQueue>,				"sceGeListEnQueue"},
+	{0x1C0D95A6,&Wrap<sceGeListEnQueueHead>,		"sceGeListEnQueueHead"},
+	{0xE0D68148,&Wrap<sceGeListUpdateStallAddr>,	"sceGeListUpdateStallAddr"},
+	{0x03444EB4,&Wrap<sceGeListSync>,						 "sceGeListSync"},
+	{0xB287BD61,&Wrap<sceGeDrawSync>,							"sceGeDrawSync"},
+	{0xB448EC0D,&Wrap<sceGeBreak>,							"sceGeBreak"},
+	{0x4C06E472,&Wrap<sceGeContinue>,					 "sceGeContinue"},
+	{0xA4FC06A4,&Wrap<sceGeSetCallback>,	"sceGeSetCallback"},
+	{0x05DB22CE,&Wrap<sceGeUnsetCallback>,					 "sceGeUnsetCallback"},
+	{0x1F6752AD,&Wrap<sceGeEdramGetSize>, "sceGeEdramGetSize"},
+	{0xB77905EA,&Wrap<sceGeEdramSetAddrTranslation>,"sceGeEdramSetAddrTranslation"},
 	{0xDC93CFEF,0,"sceGeGetCmd"},
-	{0x57C8945B,&sceGeGetMtx,"sceGeGetMtx"},
+	{0x57C8945B,&Wrap<sceGeGetMtx>,"sceGeGetMtx"},
 	{0x438A385A,0,"sceGeSaveContext"},
 	{0x0BF608FB,0,"sceGeRestoreContext"},
 	{0x5FB86AB0,0,"sceGeListDeQueue"},

--- a/Core/HLE/sceHprm.cpp
+++ b/Core/HLE/sceHprm.cpp
@@ -30,7 +30,7 @@ u32 sceHprmPeekCurrentKey(u32 keyAddress)
 const HLEFunction sceHprm[] = 
 {
 	{0x089fdfa4, 0, "sceHprm_0x089fdfa4"},
-	{0x1910B327, &WrapU_U<sceHprmPeekCurrentKey>, "sceHprmPeekCurrentKey"},
+	{0x1910B327, &Wrap<sceHprmPeekCurrentKey>, "sceHprmPeekCurrentKey"},
 	{0x208DB1BD, 0, "sceHprmIsRemoteExist"},
 	{0x7E69EDA4, 0, "sceHprmIsHeadphoneExist"},
 	{0x219C58F1, 0, "sceHprmIsMicrophoneExist"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -137,45 +137,45 @@ void sceKernelDevkitVersion()
 //////////////////////////////////////////////////////////////////////////
 
 
-void sceKernelRegisterKprintfHandler()
+void sceKernelRegisterKprintfHandler(u32, u32)
 {
 	ERROR_LOG(HLE,"UNIMPL sceKernelRegisterKprintfHandler()");
 	RETURN(0);
 }
+
 void sceKernelRegisterDefaultExceptionHandler()
 {
 	ERROR_LOG(HLE,"UNIMPL sceKernelRegisterDefaultExceptionHandler()");
 	RETURN(0);
 }
 
-void sceKernelSetGPO()
+void sceKernelSetGPO(u32 num)
 {
 	// Sets debug LEDs.
-	INFO_LOG(HLE,"sceKernelSetGPO(%02x)", PARAM(0));
+	INFO_LOG(HLE,"sceKernelSetGPO(%02x)", num);
 }
 
-void sceKernelGetGPI()
+u32 sceKernelGetGPI()
 {
 	// Always returns 0 on production systems.
 	INFO_LOG(HLE,"0=sceKernelGetGPI()");
-	RETURN(0);
+	return 0;
 }
 
 void sceKernelDcacheWritebackAll()
 {
-	//RETURN(0);
 }
-void sceKernelDcacheWritebackRange()
+
+void sceKernelDcacheWritebackRange(u32, u32)
 {
-	//RETURN(0);
 }
-void sceKernelDcacheWritebackInvalidateRange()
+
+void sceKernelDcacheWritebackInvalidateRange(u32, u32)
 {
-	//RETURN(0);
 }
+
 void sceKernelDcacheWritebackInvalidateAll()
 {
-	// RETURN(0)
 }
 
 KernelObjectPool kernelObjects;
@@ -269,71 +269,71 @@ void sceKernelIcacheInvalidateAll()
 
 const HLEFunction ThreadManForUser[] =
 {
-	{0x55C20A00,sceKernelCreateEventFlag, "sceKernelCreateEventFlag"},
-	{0x812346E4,sceKernelClearEventFlag,	"sceKernelClearEventFlag"},
-	{0xEF9E4C70,sceKernelDeleteEventFlag, "sceKernelDeleteEventFlag"},
-	{0x1fb15a32,sceKernelSetEventFlag,		"sceKernelSetEventFlag"},
-	{0x402FCF22,sceKernelWaitEventFlag,	 "sceKernelWaitEventFlag"},
-	{0x328C546A,sceKernelWaitEventFlagCB, "sceKernelWaitEventFlagCB"},
-	{0x30FD48F0,sceKernelPollEventFlag,	 "sceKernelPollEventFlag"},
-	{0xCD203292,sceKernelCancelEventFlag, "sceKernelCancelEventFlag"},
-	{0xA66B0120,sceKernelReferEventFlagStatus,"sceKernelReferEventFlagStatus"},
+	{0x55C20A00,&Wrap<sceKernelCreateEventFlag>, "sceKernelCreateEventFlag"},
+	{0x812346E4,&Wrap<sceKernelClearEventFlag>,	"sceKernelClearEventFlag"},
+	{0xEF9E4C70,&Wrap<sceKernelDeleteEventFlag>, "sceKernelDeleteEventFlag"},
+	{0x1fb15a32,&Wrap<sceKernelSetEventFlag>,		"sceKernelSetEventFlag"},
+	{0x402FCF22,&Wrap<sceKernelWaitEventFlag>,	 "sceKernelWaitEventFlag"},
+	{0x328C546A,&Wrap<sceKernelWaitEventFlagCB>, "sceKernelWaitEventFlagCB"},
+	{0x30FD48F0,&Wrap<sceKernelPollEventFlag>,	 "sceKernelPollEventFlag"},
+	{0xCD203292,&Wrap<sceKernelCancelEventFlag>, "sceKernelCancelEventFlag"},
+	{0xA66B0120,&Wrap<sceKernelReferEventFlagStatus>,"sceKernelReferEventFlagStatus"},
 
-	{0x8FFDF9A2,sceKernelCancelSema,		"sceKernelCancelSema"},
-	{0xD6DA4BA1,sceKernelCreateSema,		"sceKernelCreateSema"},
-	{0x28b6489c,sceKernelDeleteSema,		"sceKernelDeleteSema"},
-	{0x58b1f937,sceKernelPollSema,			"sceKernelPollSema"},
-	{0xBC6FEBC5,sceKernelReferSemaStatus,"sceKernelReferSemaStatus"},
-	{0x3F53E640,sceKernelSignalSema,		"sceKernelSignalSema"},
-	{0x4E3A1105,sceKernelWaitSema,			"sceKernelWaitSema"},
-	{0x6d212bac,sceKernelWaitSemaCB,		 "sceKernelWaitSemaCB"},
+	{0x8FFDF9A2,&Wrap<sceKernelCancelSema>,		"sceKernelCancelSema"},
+	{0xD6DA4BA1,&Wrap<sceKernelCreateSema>,		"sceKernelCreateSema"},
+	{0x28b6489c,&Wrap<sceKernelDeleteSema>,		"sceKernelDeleteSema"},
+	{0x58b1f937,&Wrap<sceKernelPollSema>,			"sceKernelPollSema"},
+	{0xBC6FEBC5,&Wrap<sceKernelReferSemaStatus>,"sceKernelReferSemaStatus"},
+	{0x3F53E640,&Wrap<sceKernelSignalSema>,		"sceKernelSignalSema"},
+	{0x4E3A1105,&Wrap<sceKernelWaitSema>,			"sceKernelWaitSema"},
+	{0x6d212bac,&Wrap<sceKernelWaitSemaCB>,		 "sceKernelWaitSemaCB"},
 
 	{0x60107536,0,"sceKernelDeleteLwMutex"},
 	{0x19CFF145,0,"sceKernelCreateLwMutex"},
-	{0xf8170fbe,&WrapU_U<sceKernelDeleteMutex>,"sceKernelDeleteMutex"},
-	{0xB011B11F,&WrapU_UUU<sceKernelLockMutex>,"sceKernelLockMutex"},
-	{0x5bf4dd27,&WrapU_UUU<sceKernelLockMutexCB>,"sceKernelLockMutexCB"},
-	{0x6b30100f,&WrapU_UU<sceKernelUnlockMutex>,"sceKernelUnlockMutex"},
-	{0xb7d098c6,&WrapU_CUU<sceKernelCreateMutex>,"sceKernelCreateMutex"},
+	{0xf8170fbe,&Wrap<sceKernelDeleteMutex>,"sceKernelDeleteMutex"},
+	{0xB011B11F,&Wrap<sceKernelLockMutex>,"sceKernelLockMutex"},
+	{0x5bf4dd27,&Wrap<sceKernelLockMutexCB>,"sceKernelLockMutexCB"},
+	{0x6b30100f,&Wrap<sceKernelUnlockMutex>,"sceKernelUnlockMutex"},
+	{0xb7d098c6,&Wrap<sceKernelCreateMutex>,"sceKernelCreateMutex"},
 	// NOTE: LockLwMutex and UnlockLwMutex are in Kernel_Library, see sceKernelInterrupt.cpp.
 
 	{0xFCCFAD26,0,"sceKernelCancelWakeupThread"},
-	{0xea748e31,sceKernelChangeCurrentThreadAttr,"sceKernelChangeCurrentThreadAttr"},
-	{0x71bc9871,sceKernelChangeThreadPriority,"sceKernelChangeThreadPriority"},
-	{0x446D8DE6,sceKernelCreateThread,"sceKernelCreateThread"},
-	{0x9fa03cd3,sceKernelDeleteThread,"sceKernelDeleteThread"},
+	{0xea748e31,&Wrap<sceKernelChangeCurrentThreadAttr>,"sceKernelChangeCurrentThreadAttr"},
+	{0x71bc9871,&Wrap<sceKernelChangeThreadPriority>,"sceKernelChangeThreadPriority"},
+	{0x446D8DE6,&Wrap<sceKernelCreateThread>,"sceKernelCreateThread"},
+	{0x9fa03cd3,&Wrap<sceKernelDeleteThread>,"sceKernelDeleteThread"},
 	{0xBD123D9E,0,"sceKernelDelaySysClockThread"},
 	{0x1181E963,0,"sceKernelDelaySysClockThreadCB"},
-	{0xceadeb47,sceKernelDelayThread,"sceKernelDelayThread"},
-	{0x68da9e36,sceKernelDelayThreadCB,"sceKernelDelayThreadCB"},
-	{0xaa73c935,sceKernelExitThread,"sceKernelExitThread"},
-	{0x809ce29b,sceKernelExitDeleteThread,"sceKernelExitDeleteThread"},
+	{0xceadeb47,&Wrap<sceKernelDelayThread>,"sceKernelDelayThread"},
+	{0x68da9e36,&Wrap<sceKernelDelayThreadCB>,"sceKernelDelayThreadCB"},
+	{0xaa73c935,&Wrap<sceKernelExitThread>,"sceKernelExitThread"},
+	{0x809ce29b,&Wrap<sceKernelExitDeleteThread>,"sceKernelExitDeleteThread"},
 	{0x94aa61ee,0,"sceKernelGetThreadCurrentPriority"},
-	{0x293b45b8,sceKernelGetThreadId,"sceKernelGetThreadId"},
-	{0x3B183E26,sceKernelGetThreadExitStatus,"sceKernelGetThreadExitStatus"},
-	{0x52089CA1,sceKernelGetThreadStackFreeSize,"sceKernelGetThreadStackFreeSize"},
+	{0x293b45b8,&Wrap<sceKernelGetThreadId>,"sceKernelGetThreadId"},
+	{0x3B183E26,&Wrap<sceKernelGetThreadExitStatus>,"sceKernelGetThreadExitStatus"},
+	{0x52089CA1,&Wrap<sceKernelGetThreadStackFreeSize>,"sceKernelGetThreadStackFreeSize"},
 	{0xFFC36A14,0,"sceKernelReferThreadRunStatus"},
-	{0x17c1684e,sceKernelReferThreadStatus,"sceKernelReferThreadStatus"},
+	{0x17c1684e,&Wrap<sceKernelReferThreadStatus>,"sceKernelReferThreadStatus"},
 	{0x2C34E053,0,"sceKernelReleaseWaitThread"},
-	{0x75156e8f,sceKernelResumeThread,"sceKernelResumeThread"},
+	{0x75156e8f,&Wrap<sceKernelResumeThread>,"sceKernelResumeThread"},
 	{0x27e22ec2,0,"sceKernelResumeDispatchThread"},
-	{0x912354a7,sceKernelRotateThreadReadyQueue,"sceKernelRotateThreadReadyQueue"},
-	{0x9ACE131E,sceKernelSleepThread,"sceKernelSleepThread"},
-	{0x82826f70,sceKernelSleepThreadCB,"sceKernelSleepThreadCB"},
-	{0xF475845D,sceKernelStartThread,"sceKernelStartThread"},
-	{0x9944f31f,sceKernelSuspendThread,"sceKernelSuspendThread"},
+	{0x912354a7,&Wrap<sceKernelRotateThreadReadyQueue>,"sceKernelRotateThreadReadyQueue"},
+	{0x9ACE131E,&Wrap<sceKernelSleepThread>,"sceKernelSleepThread"},
+	{0x82826f70,&Wrap<sceKernelSleepThreadCB>,"sceKernelSleepThreadCB"},
+	{0xF475845D,&Wrap<sceKernelStartThread>,"sceKernelStartThread"},
+	{0x9944f31f,&Wrap<sceKernelSuspendThread>,"sceKernelSuspendThread"},
 	{0x3ad58b8c,0,"sceKernelSuspendDispatchThread"},
 	{0x616403ba,0,"sceKernelTerminateThread"},
-	{0x383f7bcc,sceKernelTerminateDeleteThread,"sceKernelTerminateDeleteThread"},
-	{0x840E8133,sceKernelWaitThreadEndCB,"sceKernelWaitThreadEndCB"},
-	{0xd13bde95,sceKernelCheckThreadStack,"sceKernelCheckThreadStack"},
+	{0x383f7bcc,&Wrap<sceKernelTerminateDeleteThread>,"sceKernelTerminateDeleteThread"},
+	{0x840E8133,&Wrap<sceKernelWaitThreadEndCB>,"sceKernelWaitThreadEndCB"},
+	{0xd13bde95,&Wrap<sceKernelCheckThreadStack>,"sceKernelCheckThreadStack"},
 
 	{0x94416130,0,"sceKernelGetThreadmanIdList"},
-	{0x57CF62DD,sceKernelGetThreadmanIdType,"sceKernelGetThreadmanIdType"},
+	{0x57CF62DD,&Wrap<sceKernelGetThreadmanIdType>,"sceKernelGetThreadmanIdType"},
 
-	{0x20fff560,sceKernelCreateVTimer,"sceKernelCreateVTimer"},
+	{0x20fff560,&Wrap<sceKernelCreateVTimer>,"sceKernelCreateVTimer"},
 	{0x328F9E52,0,"sceKernelDeleteVTimer"},
-	{0xc68d9437,sceKernelStartVTimer,"sceKernelStartVTimer"},
+	{0xc68d9437,&Wrap<sceKernelStartVTimer>,"sceKernelStartVTimer"},
 	{0xD0AEEE87,0,"sceKernelStopVTimer"},
 	{0xD2D615EF,0,"sceKernelCancelVTimerHandler"},
 	{0xB3A59970,0,"sceKernelGetVTimerBase"},
@@ -343,82 +343,82 @@ const HLEFunction ThreadManForUser[] =
 	{0x5F32BEAA,0,"sceKernelReferVTimerStatus"},
 	{0x542AD630,0,"sceKernelSetVTimerTime"},
 	{0xFB6425C3,0,"sceKernelSetVTimerTimeWide"},
-	{0xd8b299ae,sceKernelSetVTimerHandler,"sceKernelSetVTimerHandler"},
+	{0xd8b299ae,&Wrap<sceKernelSetVTimerHandler>,"sceKernelSetVTimerHandler"},
 	{0x53B00E9A,0,"sceKernelSetVTimerHandlerWide"},
 
-	{0x82BC5777,sceKernelGetSystemTimeWide,"sceKernelGetSystemTimeWide"},
-	{0xdb738f35,sceKernelGetSystemTime,"sceKernelGetSystemTime"},
-	{0x369ed59d,sceKernelGetSystemTimeLow,"sceKernelGetSystemTimeLow"},
+	{0x82BC5777,&Wrap<sceKernelGetSystemTimeWide>,"sceKernelGetSystemTimeWide"},
+	{0xdb738f35,&Wrap<sceKernelGetSystemTime>,"sceKernelGetSystemTime"},
+	{0x369ed59d,&Wrap<sceKernelGetSystemTimeLow>,"sceKernelGetSystemTimeLow"},
 
 	{0x8218B4DD,0,"sceKernelReferGlobalProfiler"},
 	{0x627E6F3A,0,"sceKernelReferSystemStatus"},
 	{0x64D4540E,0,"sceKernelReferThreadProfiler"},
 
 	//Fifa Street 2 uses alarms
-	{0x6652b8ca,sceKernelSetAlarm,"sceKernelSetAlarm"},
-	{0xB2C25152,sceKernelSetSysClockAlarm,"sceKernelSetSysClockAlarm"},
-	{0x7e65b999,sceKernelCancelAlarm,"sceKernelCancelAlarm"},
-	{0xDAA3F564,sceKernelReferAlarmStatus,"sceKernelReferAlarmStatus"},
+	{0x6652b8ca,&Wrap<sceKernelSetAlarm>,"sceKernelSetAlarm"},
+	{0xB2C25152,&Wrap<sceKernelSetSysClockAlarm>,"sceKernelSetSysClockAlarm"},
+	{0x7e65b999,&Wrap<sceKernelCancelAlarm>,"sceKernelCancelAlarm"},
+	{0xDAA3F564,&Wrap<sceKernelReferAlarmStatus>,"sceKernelReferAlarmStatus"},
 
-	{0xba6b92e2,sceKernelSysClock2USec,"sceKernelSysClock2USec"},
+	{0xba6b92e2,&Wrap<sceKernelSysClock2USec>,"sceKernelSysClock2USec"},
 	{0x110DEC9A,0,"sceKernelUSec2SysClock"},
 	{0xC8CD158C,0,"sceKernelUSec2SysClockWide"},
-	{0xE1619D7C,sceKernelSysClock2USecWide,"sceKernelSysClock2USecWide"},
+	{0xE1619D7C,&Wrap<sceKernelSysClock2USecWide>,"sceKernelSysClock2USecWide"},
 
-	{0x110dec9a,sceKernelUSec2SysClock,"sceKernelUSec2SysClock"},
-	{0x278C0DF5,sceKernelWaitThreadEnd,"sceKernelWaitThreadEnd"},
-	{0xd59ead2f,sceKernelWakeupThread,"sceKernelWakeupThread"}, //AI Go, audio?
+	{0x110dec9a,&Wrap<sceKernelUSec2SysClock>,"sceKernelUSec2SysClock"},
+	{0x278C0DF5,&Wrap<sceKernelWaitThreadEnd>,"sceKernelWaitThreadEnd"},
+	{0xd59ead2f,&Wrap<sceKernelWakeupThread>,"sceKernelWakeupThread"}, //AI Go, audio?
 
 	{0x0C106E53,0,"sceKernelRegisterThreadEventHandler"},
 	{0x72F3C145,0,"sceKernelReleaseThreadEventHandler"},
 	{0x369EEB6B,0,"sceKernelReferThreadEventHandlerStatus"},
 
-	{0x349d6d6c,sceKernelCheckCallback,"sceKernelCheckCallback"},
-	{0xE81CAF8F,sceKernelCreateCallback,"sceKernelCreateCallback"},
-	{0xEDBA5844,sceKernelDeleteCallback,"sceKernelDeleteCallback"},
-	{0xC11BA8C4,sceKernelNotifyCallback,"sceKernelNotifyCallback"},
-	{0xBA4051D6,sceKernelCancelCallback,"sceKernelCancelCallback"},
-	{0x2A3D44FF,sceKernelGetCallbackCount,"sceKernelGetCallbackCount"},
-	{0x349D6D6C,sceKernelCheckCallback,"sceKernelCheckCallback"},
-	{0x730ED8BC,sceKernelReferCallbackStatus,"sceKernelReferCallbackStatus"},
+	{0x349d6d6c,&Wrap<sceKernelCheckCallback>,"sceKernelCheckCallback"},
+	{0xE81CAF8F,&Wrap<sceKernelCreateCallback>,"sceKernelCreateCallback"},
+	{0xEDBA5844,&Wrap<sceKernelDeleteCallback>,"sceKernelDeleteCallback"},
+	{0xC11BA8C4,&Wrap<sceKernelNotifyCallback>,"sceKernelNotifyCallback"},
+	{0xBA4051D6,&Wrap<sceKernelCancelCallback>,"sceKernelCancelCallback"},
+	{0x2A3D44FF,&Wrap<sceKernelGetCallbackCount>,"sceKernelGetCallbackCount"},
+	{0x349D6D6C,&Wrap<sceKernelCheckCallback>,"sceKernelCheckCallback"},
+	{0x730ED8BC,&Wrap<sceKernelReferCallbackStatus>,"sceKernelReferCallbackStatus"},
 
-	{0x8125221D,sceKernelCreateMbx,"sceKernelCreateMbx"},
-	{0x86255ADA,sceKernelDeleteMbx,"sceKernelDeleteMbx"},
-	{0xE9B3061E,sceKernelSendMbx,"sceKernelSendMbx"},
-	{0x18260574,sceKernelReceiveMbx,"sceKernelReceiveMbx"},
-	{0xF3986382,sceKernelReceiveMbxCB,"sceKernelReceiveMbxCB"},
-	{0x0D81716A,sceKernelPollMbx,"sceKernelPollMbx"},
-	{0x87D4DD36,sceKernelCancelReceiveMbx,"sceKernelCancelReceiveMbx"},
-	{0xA8E8C846,sceKernelReferMbxStatus,"sceKernelReferMbxStatus"},
+	{0x8125221D,&Wrap<sceKernelCreateMbx>,"sceKernelCreateMbx"},
+	{0x86255ADA,&Wrap<sceKernelDeleteMbx>,"sceKernelDeleteMbx"},
+	{0xE9B3061E,&Wrap<sceKernelSendMbx>,"sceKernelSendMbx"},
+	{0x18260574,&Wrap<sceKernelReceiveMbx>,"sceKernelReceiveMbx"},
+	{0xF3986382,&Wrap<sceKernelReceiveMbxCB>,"sceKernelReceiveMbxCB"},
+	{0x0D81716A,&Wrap<sceKernelPollMbx>,"sceKernelPollMbx"},
+	{0x87D4DD36,&Wrap<sceKernelCancelReceiveMbx>,"sceKernelCancelReceiveMbx"},
+	{0xA8E8C846,&Wrap<sceKernelReferMbxStatus>,"sceKernelReferMbxStatus"},
 
-	{0x7C0DC2A0,sceKernelCreateMsgPipe,"sceKernelCreateMsgPipe"},
-	{0xF0B7DA1C,sceKernelDeleteMsgPipe,"sceKernelDeleteMsgPipe"},
-	{0x876DBFAD,sceKernelSendMsgPipe,"sceKernelSendMsgPipe"},
-	{0x7C41F2C2,sceKernelSendMsgPipeCB,"sceKernelSendMsgPipeCB"},
-	{0x884C9F90,sceKernelTrySendMsgPipe,"sceKernelTrySendMsgPipe"},
-	{0x74829B76,sceKernelReceiveMsgPipe,"sceKernelReceiveMsgPipe"},
-	{0xFBFA697D,sceKernelReceiveMsgPipeCB,"sceKernelReceiveMsgPipeCB"},
-	{0xDF52098F,sceKernelTryReceiveMsgPipe,"sceKernelTryReceiveMsgPipe"},
-	{0x349B864D,sceKernelCancelMsgPipe,"sceKernelCancelMsgPipe"},
-	{0x33BE4024,sceKernelReferMsgPipeStatus,"sceKernelReferMsgPipeStatus"},
+	{0x7C0DC2A0,&Wrap<sceKernelCreateMsgPipe>,"sceKernelCreateMsgPipe"},
+	{0xF0B7DA1C,&Wrap<sceKernelDeleteMsgPipe>,"sceKernelDeleteMsgPipe"},
+	{0x876DBFAD,&Wrap<sceKernelSendMsgPipe>,"sceKernelSendMsgPipe"},
+	{0x7C41F2C2,&Wrap<sceKernelSendMsgPipeCB>,"sceKernelSendMsgPipeCB"},
+	{0x884C9F90,&Wrap<sceKernelTrySendMsgPipe>,"sceKernelTrySendMsgPipe"},
+	{0x74829B76,&Wrap<sceKernelReceiveMsgPipe>,"sceKernelReceiveMsgPipe"},
+	{0xFBFA697D,&Wrap<sceKernelReceiveMsgPipeCB>,"sceKernelReceiveMsgPipeCB"},
+	{0xDF52098F,&Wrap<sceKernelTryReceiveMsgPipe>,"sceKernelTryReceiveMsgPipe"},
+	{0x349B864D,&Wrap<sceKernelCancelMsgPipe>,"sceKernelCancelMsgPipe"},
+	{0x33BE4024,&Wrap<sceKernelReferMsgPipeStatus>,"sceKernelReferMsgPipeStatus"},
 
-	{0x56C039B5,sceKernelCreateVpl,"sceKernelCreateVpl"},
-	{0x89B3D48C,sceKernelDeleteVpl,"sceKernelDeleteVpl"},
-	{0xBED27435,sceKernelAllocateVpl,"sceKernelAllocateVpl"},
-	{0xEC0A693F,sceKernelAllocateVplCB,"sceKernelAllocateVplCB"},
-	{0xAF36D708,sceKernelTryAllocateVpl,"sceKernelTryAllocateVpl"},
-	{0xB736E9FF,sceKernelFreeVpl,"sceKernelFreeVpl"},
-	{0x1D371B8A,sceKernelCancelVpl,"sceKernelCancelVpl"},
-	{0x39810265,sceKernelReferVplStatus,"sceKernelReferVplStatus"},
+	{0x56C039B5,&Wrap<sceKernelCreateVpl>,"sceKernelCreateVpl"},
+	{0x89B3D48C,&Wrap<sceKernelDeleteVpl>,"sceKernelDeleteVpl"},
+	{0xBED27435,&Wrap<sceKernelAllocateVpl>,"sceKernelAllocateVpl"},
+	{0xEC0A693F,&Wrap<sceKernelAllocateVplCB>,"sceKernelAllocateVplCB"},
+	{0xAF36D708,&Wrap<sceKernelTryAllocateVpl>,"sceKernelTryAllocateVpl"},
+	{0xB736E9FF,&Wrap<sceKernelFreeVpl>,"sceKernelFreeVpl"},
+	{0x1D371B8A,&Wrap<sceKernelCancelVpl>,"sceKernelCancelVpl"},
+	{0x39810265,&Wrap<sceKernelReferVplStatus>,"sceKernelReferVplStatus"},
 
-	{0xC07BB470,sceKernelCreateFpl,"sceKernelCreateFpl"},
-	{0xED1410E0,sceKernelDeleteFpl,"sceKernelDeleteFpl"},
-	{0xD979E9BF,sceKernelAllocateFpl,"sceKernelAllocateFpl"},
-	{0xE7282CB6,sceKernelAllocateFplCB,"sceKernelAllocateFplCB"},
-	{0x623AE665,sceKernelTryAllocateFpl,"sceKernelTryAllocateFpl"},
-	{0xF6414A71,sceKernelFreeFpl,"sceKernelFreeFpl"},
-	{0xA8AA591F,sceKernelCancelFpl,"sceKernelCancelFpl"},
-	{0xD8199E4C,sceKernelReferFplStatus,"sceKernelReferFplStatus"},
+	{0xC07BB470,&Wrap<sceKernelCreateFpl>,"sceKernelCreateFpl"},
+	{0xED1410E0,&Wrap<sceKernelDeleteFpl>,"sceKernelDeleteFpl"},
+	{0xD979E9BF,&Wrap<sceKernelAllocateFpl>,"sceKernelAllocateFpl"},
+	{0xE7282CB6,&Wrap<sceKernelAllocateFplCB>,"sceKernelAllocateFplCB"},
+	{0x623AE665,&Wrap<sceKernelTryAllocateFpl>,"sceKernelTryAllocateFpl"},
+	{0xF6414A71,&Wrap<sceKernelFreeFpl>,"sceKernelFreeFpl"},
+	{0xA8AA591F,&Wrap<sceKernelCancelFpl>,"sceKernelCancelFpl"},
+	{0xD8199E4C,&Wrap<sceKernelReferFplStatus>,"sceKernelReferFplStatus"},
 
 	{0x0E927AED, _sceKernelReturnFromTimerHandler, "_sceKernelReturnFromTimerHandler"},
 	{0x532A522E, _sceKernelExitThread,"_sceKernelExitThread"},

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -253,16 +253,16 @@ void sceKernelSleepThreadCB();
 
 void sceKernelDevkitVersion();
 
-void sceKernelRegisterKprintfHandler();
+void sceKernelRegisterKprintfHandler(u32, u32);
 void sceKernelRegisterDefaultExceptionHandler();
 
-void sceKernelFindModuleByName();
+u32 sceKernelFindModuleByName(u32);
 
-void sceKernelSetGPO();
-void sceKernelGetGPI();
+void sceKernelSetGPO(u32);
+u32 sceKernelGetGPI();
 void sceKernelDcacheWritebackAll();
-void sceKernelDcacheWritebackRange();
-void sceKernelDcacheWritebackInvalidateRange();
+void sceKernelDcacheWritebackRange(u32, u32);
+void sceKernelDcacheWritebackInvalidateRange(u32, u32);
 void sceKernelDcacheWritebackInvalidateAll();
 void sceKernelGetThreadStackFreeSize();
 void sceKernelIcacheInvalidateAll();

--- a/Core/HLE/sceKernelCallback.h
+++ b/Core/HLE/sceKernelCallback.h
@@ -28,6 +28,8 @@ void sceKernelNotifyCallback();
 void sceKernelCancelCallback();
 void sceKernelGetCallbackCount();
 void _sceKernelReturnFromCallback();
-void sceKernelCheckCallback();
+u32 sceKernelCheckCallback();
 void sceKernelGetCallbackCount();
 void sceKernelReferCallbackStatus();
+bool __KernelInCallback();
+

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -178,6 +178,13 @@ retry:
 				goto retry;
 			}
 		}
+
+		if (wokeThreads)
+		{
+			// Probably useful to make things go faster: trigger thread change directly after the event flag has been set
+			__KernelReSchedule();
+		}
+
 		RETURN(0);
 	}
 	else
@@ -211,9 +218,9 @@ void sceKernelWaitEventFlag()
 			th.wait = wait;
 			th.outAddr = outBitsPtr;
 			e->waitingThreads.push_back(th);
-			u32 timeout;
-			if (Memory::IsValidAddress(timeoutPtr))
-				timeout = Memory::Read_U32(timeoutPtr);
+			//u32 timeout;
+			//if (Memory::IsValidAddress(timeoutPtr))
+			//	timeout = Memory::Read_U32(timeoutPtr);
 
 			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, 0, false);
 		}
@@ -250,9 +257,9 @@ void sceKernelWaitEventFlagCB()
 			th.wait = wait;
 			th.outAddr = outBitsPtr;
 			e->waitingThreads.push_back(th);
-			u32 timeout;
-			if (Memory::IsValidAddress(timeoutPtr))
-				timeout = Memory::Read_U32(timeoutPtr);
+			//u32 timeout;
+			//if (Memory::IsValidAddress(timeoutPtr))
+			//	timeout = Memory::Read_U32(timeoutPtr);
 
 			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, 0, true);
 		}

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -183,6 +183,7 @@ public:
 		if (has(subIntrNum))
 			return subIntrHandlers[subIntrNum];
 		// what to do, what to do...
+		return voidSubIntr;
 	}
 
 	void queueUp()
@@ -197,6 +198,8 @@ public:
 
 private:
 	std::map<int, SubIntrHandler> subIntrHandlers;
+	// Only useful to handle when the subIntr doesn't exist
+	SubIntrHandler voidSubIntr;
 };
 
 
@@ -261,7 +264,7 @@ bool __RunOnePendingInterrupt()
 void __TriggerInterrupt(PSPInterrupt intno)
 {
 	intrHandlers[intno].queueUp();
-	DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i (%i in queue)", intno, pendingInterrupts.size());
+	DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i (%li in queue)", intno, pendingInterrupts.size());
 	if (!inInterrupt)
 		__RunOnePendingInterrupt();
 }
@@ -382,12 +385,12 @@ void sceKernelMemset()
 
 const HLEFunction Kernel_Library[] = 
 {
-	{0x092968F4,sceKernelCpuSuspendIntr,"sceKernelCpuSuspendIntr"},
-	{0x5F10D406,WrapV_U<sceKernelCpuResumeIntr>, "sceKernelCpuResumeIntr"}, //int oldstat
-	{0x3b84732d,WrapV_U<sceKernelCpuResumeIntrWithSync>, "sceKernelCpuResumeIntrWithSync"},
-	{0x47a0b729,sceKernelIsCpuIntrSuspended, "sceKernelIsCpuIntrSuspended"}, //flags
-	{0xb55249d2,sceKernelIsCpuIntrEnable, "sceKernelIsCpuIntrEnable"}, 
-	{0xa089eca4,sceKernelMemset, "sceKernelMemset"}, 
+	{0x092968F4,&Wrap<sceKernelCpuSuspendIntr>,"sceKernelCpuSuspendIntr"},
+	{0x5F10D406,&Wrap<sceKernelCpuResumeIntr>, "sceKernelCpuResumeIntr"}, //int oldstat
+	{0x3b84732d,&Wrap<sceKernelCpuResumeIntrWithSync>, "sceKernelCpuResumeIntrWithSync"},
+	{0x47a0b729,&Wrap<sceKernelIsCpuIntrSuspended>, "sceKernelIsCpuIntrSuspended"}, //flags
+	{0xb55249d2,&Wrap<sceKernelIsCpuIntrEnable>, "sceKernelIsCpuIntrEnable"}, 
+	{0xa089eca4,&Wrap<sceKernelMemset>, "sceKernelMemset"}, 
 	{0xbea46419,0, "sceKernelLockLwMutex"}, 
 	{0x15b6446b,0, "sceKernelUnlockLwMutex"}, 
 	{0x293b45b8,0, "sceKernelGetThreadId"}, 
@@ -403,10 +406,10 @@ void Register_Kernel_Library()
 
 const HLEFunction InterruptManager[] = 
 {
-	{0xCA04A2B9, WrapU_UUUU<sceKernelRegisterSubIntrHandler>, "sceKernelRegisterSubIntrHandler"},
-	{0xD61E6961, WrapU_UU<sceKernelReleaseSubIntrHandler>, "sceKernelReleaseSubIntrHandler"},
-	{0xFB8E22EC, WrapU_UU<sceKernelEnableSubIntr>, "sceKernelEnableSubIntr"},
-	{0x8A389411, WrapU_UU<sceKernelDisableSubIntr>, "sceKernelDisableSubIntr"},
+	{0xCA04A2B9, &Wrap<sceKernelRegisterSubIntrHandler>, "sceKernelRegisterSubIntrHandler"},
+	{0xD61E6961, &Wrap<sceKernelReleaseSubIntrHandler>, "sceKernelReleaseSubIntrHandler"},
+	{0xFB8E22EC, &Wrap<sceKernelEnableSubIntr>, "sceKernelEnableSubIntr"},
+	{0x8A389411, &Wrap<sceKernelDisableSubIntr>, "sceKernelDisableSubIntr"},
 	{0x5CB5A78B, 0, "sceKernelSuspendSubIntr"},
 	{0x7860E0DC, 0, "sceKernelResumeSubIntr"},
 	{0xFC4374B8, 0, "sceKernelIsSubInterruptOccurred"},

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -113,7 +113,7 @@ static SceUID mainModuleID;	// hack
 Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, SceUID &id, std::string *error_string)
 {
 	Module *m = new Module;
-	SceUID uid = kernelObjects.Create(m);
+	kernelObjects.Create(m);
 
 	u32 magic = *((u32*)ptr);
 
@@ -188,7 +188,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, SceUID &id, std::
 
 	if (entSection != -1)
 	{
-		libent *lib = (libent *)(Memory::GetPointer(reader.GetSectionAddr(entSection)));
+		//libent *lib = (libent *)(Memory::GetPointer(reader.GetSectionAddr(entSection)));
 		//what's this for?
 		//lib->l1+=0;
 	}
@@ -206,7 +206,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, SceUID &id, std::
 
 	DEBUG_LOG(LOADER,"Resident data addr: %08x",	sceResidentAddr);
 
-	PspResidentData *resdata = (PspResidentData *)Memory::GetPointer(sceResidentAddr);
+	//PspResidentData *resdata = (PspResidentData *)Memory::GetPointer(sceResidentAddr);
 
 	struct PspModuleInfo
 	{
@@ -267,7 +267,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, SceUID &id, std::
 	{
 		const char *modulename = (const char*)Memory::GetPointer(entry[m].moduleNameSymbol);
 		u32 *nidDataPtr = (u32*)Memory::GetPointer(entry[m].nidData);
-		u32 *stubs = (u32*)Memory::GetPointer(entry[m].firstSymAddr);
+		//u32 *stubs = (u32*)Memory::GetPointer(entry[m].firstSymAddr);
 
 		DEBUG_LOG(LOADER,"Importing Module %s, stubs at %08x",modulename,entry[m].firstSymAddr);
 
@@ -295,11 +295,11 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, SceUID &id, std::
 
 bool __KernelLoadPBP(const char *filename, std::string *error_string)
 {
-	static const char *FileNames[] =
-	{
-		"PARAM.SFO", "ICON0.PNG", "ICON1.PMF", "UNKNOWN.PNG",
-		"PIC1.PNG", "SND0.AT3", "UNKNOWN.PSP", "UNKNOWN.PSAR"
-	};
+	//static const char *FileNames[] =
+	//{
+	//	"PARAM.SFO", "ICON0.PNG", "ICON1.PMF", "UNKNOWN.PNG",
+	//	"PIC1.PNG", "SND0.AT3", "UNKNOWN.PSP", "UNKNOWN.PSAR"
+	//};
 
 	std::ifstream in(filename, std::ios::binary);
 
@@ -485,9 +485,9 @@ void sceKernelStartModule()
 	int argsize = PARAM(1);
 	u32 argptr = PARAM(2);
 	u32 ptrReturn = PARAM(3);
-	if (PARAM(4)) {
-		SceKernelSMOption *smoption = (SceKernelSMOption*)Memory::GetPointer(PARAM(4));
-	}
+	//if (PARAM(4)) {
+		//SceKernelSMOption *smoption = (SceKernelSMOption*)Memory::GetPointer(PARAM(4));
+	//}
 	ERROR_LOG(HLE,"UNIMPL sceKernelStartModule(%d,asize=%08x,aptr=%08x,retptr=%08x,...)",
 		id,argsize,argptr,ptrReturn);
 	RETURN(0);
@@ -522,13 +522,11 @@ void sceKernelGetModuleId()
 
 }
 
-void sceKernelFindModuleByName()
+u32 sceKernelFindModuleByName(u32)
 {
 	ERROR_LOG(HLE,"UNIMPL sceKernelFindModuleByName()");
-	RETURN(1);
+	return 1;
 }
-
-
 
 const HLEFunction ModuleMgrForUser[] = 
 {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -466,11 +466,9 @@ void sceKernelLoadModule()
 		//If it is, don't load it.
 		//Else, actually do load it and resolve pointers!
 
-		DEBUG_LOG(HLE,"%i=sceKernelLoadModule(name=%s,flag=%08x,%08x,%08x,%08x,%08x(...))",
+		INFO_LOG(HLE,"%i=sceKernelLoadModule(name=%s,flag=%08x,%08x,%08x,%08x,%08x(...))",
 			numLoadedModules+1,name,flags,
 			lmoption->size,lmoption->mpidtext,lmoption->mpiddata,lmoption->position);
-
-			
 	}
 	else
 	{

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -49,10 +49,10 @@ struct MsgPipe : public KernelObject
 void sceKernelCreateMsgPipe()
 {
 	const char *name = Memory::GetCharPointer(PARAM(0));
-	int memoryPartition = PARAM(1);
+	//int memoryPartition = PARAM(1);
 	SceUInt attr = PARAM(2);
 	int size = PARAM(3);
-	int opt = PARAM(4);
+	//int opt = PARAM(4);
 
 	MsgPipe *m = new MsgPipe();
 	SceUID id = kernelObjects.Create(m);
@@ -188,3 +188,4 @@ void sceKernelReferMsgPipeStatus()
 		RETURN(error);
 	}
 }
+

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -127,7 +127,7 @@ void sceKernelSignalSema()
 		s->ns.currentCount += signal;
 		DEBUG_LOG(HLE,"sceKernelSignalSema(%i, %i) (old: %i, new: %i)", id, signal, oldval, s->ns.currentCount);
 			
-		bool wokeThreads = false;
+		//bool wokeThreads = false;
 retry:
 		//TODO: check for threads to wake up - wake them
 		std::vector<SceUID>::iterator iter;
@@ -139,7 +139,7 @@ retry:
 			{
 				__KernelResumeThread(id);
 				s->ns.currentCount -= wVal;
-				wokeThreads = true;
+				//wokeThreads = true;
 				s->waitingThreads.erase(iter);
 				goto retry;
 			}

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -318,10 +318,10 @@ void __KernelNotifyCallback(SceUID threadID, SceUID cbid, u32 notifyArg)
         return;
       }
     }
-    CallbackNotification cb;
-    cb.cbid = cbid;
-    cb.arg = notifyArg;
-    cb.count = 1;
+    //CallbackNotification cb;
+    //cb.cbid = cbid;
+    //cb.arg = notifyArg;
+    //cb.count = 1;
   }
   // TODO: error checking
 }
@@ -449,7 +449,7 @@ void __KernelLoadContext(ThreadContext *ctx)
 // If any changes were made, it will context switch
 bool __KernelTriggerWait(WaitType type, int id, bool dontSwitch)
 {
-	bool doneAnything = false;
+	//bool doneAnything = false;
 
 	for (std::vector<Thread *>::iterator iter = threadqueue.begin(); iter != threadqueue.end(); iter++)
 	{
@@ -464,7 +464,7 @@ bool __KernelTriggerWait(WaitType type, int id, bool dontSwitch)
         {
 					t->nt.status = THREADSTATUS_READY;
         }
-				doneAnything = true;
+				//doneAnything = true;
 			}
 		}
 	}
@@ -536,7 +536,7 @@ void __KernelScheduleWakeup(SceUID threadID, int usFromNow)
 
 void __KernelRemoveFromThreadQueue(Thread *t)
 {
-  for (int i = 0; i < threadqueue.size(); i++)
+  for (u32 i = 0; i < threadqueue.size(); i++)
   {
     if (threadqueue[i] == t)
     {

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -34,7 +34,7 @@ void sceKernelExitDeleteThread();
 void sceKernelExitThread();
 void _sceKernelExitThread();
 void sceKernelGetThreadId();
-void sceKernelStartThread();
+u32 sceKernelStartThread();
 void sceKernelWaitThreadEnd();
 void sceKernelReferThreadStatus();
 void sceKernelChangeCurrentThreadAttr();
@@ -85,6 +85,13 @@ struct ThreadContext
   u32 fcr31;
 };
 
+struct CallbackNotification
+{
+  SceUID cbid;
+  int count;
+  int arg;
+};
+
 
 // Internal API, used by implementations of kernel functions
 
@@ -105,6 +112,7 @@ u32 __KernelGetWaitValue(SceUID threadID, u32 &error);
 void __KernelWaitCurThread(WaitType type, SceUID waitId, u32 waitValue, int timeout, bool processCallbacks);
 void __KernelReSchedule(const char *reason = "no reason");
 void __KernelNotifyCallback(SceUID threadID, SceUID cbid, u32 arg);
+CallbackNotification *__KernelGetCallbackNotification(SceUID cbid);
 
 
 SceUID __KernelGetCurThread();

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -95,24 +95,21 @@ void sceKernelSysClock2USecWide()
 	RETURN(0);
 }
 
-void sceKernelLibcClock()
+u32 sceKernelLibcClock()
 {
 	u32 retVal = clock()*1000;
 	DEBUG_LOG(HLE,"%i = sceKernelLibcClock",retVal);
-	RETURN(retVal); // TODO: fix
+	return retVal; // TODO: fix
 }
 
-void sceKernelLibcTime()
+u32 sceKernelLibcTime(time_t *t)
 {
-	time_t *t = 0;
-	if (PARAM(0))
-		t = (time_t*)Memory::GetPointer(PARAM(0));
 	u32 retVal = (u32)time(t);
 	DEBUG_LOG(HLE,"%i = sceKernelLibcTime()",retVal);
-	RETURN(retVal);
+	return retVal;
 }
 
-void sceKernelLibcGettimeofday()
+u32 sceKernelLibcGettimeofday(timeval *tv, u32)
 {
 #ifdef _WIN32
 	union {
@@ -126,28 +123,30 @@ void sceKernelLibcGettimeofday()
 		u32 tv_usec;
 	};
 
-	timeval *tv = (timeval*)Memory::GetPointer(PARAM(0));
 	DEBUG_LOG(HLE,"sceKernelLibcGettimeofday()");
 
 	GetSystemTimeAsFileTime (&now.ft);
 	tv->tv_usec = (long) ((now.ns100 / 10LL) % 1000000LL);
 	tv->tv_sec = (long) ((now.ns100 - 116444736000000000LL) / 10000000LL);
 #endif
-	RETURN(0);
-}
-void sceRtcGetCurrentClockLocalTime()
-{
-	DEBUG_LOG(HLE,"0=sceRtcGetCurrentClockLocalTime()");
-	RETURN(0);
-}
-void sceRtcGetTick()
-{
-	DEBUG_LOG(HLE,"0=sceRtcGetTick()");
-	RETURN(0);
+	return 0;
 }
 
-void sceRtcGetTickResolution()
+u32 sceRtcGetCurrentClockLocalTime(u32)
+{
+	DEBUG_LOG(HLE,"0=sceRtcGetCurrentClockLocalTime()");
+	return 0;
+}
+
+u32 sceRtcGetTick(u32, u32)
+{
+	DEBUG_LOG(HLE,"0=sceRtcGetTick()");
+	return 0;
+}
+
+u32 sceRtcGetTickResolution()
 {
 	DEBUG_LOG(HLE,"100=sceRtcGetTickResolution()");
-	RETURN(100);
+	return 100;
 }
+

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -17,15 +17,15 @@
 
 #pragma once
 
-void sceKernelLibcGettimeofday();
-void sceKernelLibcClock();
-void sceKernelLibcTime();
+u32 sceKernelLibcGettimeofday(timeval *tv, u32);
+u32 sceKernelLibcClock();
+u32 sceKernelLibcTime(time_t*);
 void sceKernelUSec2SysClock();
 void sceKernelGetSystemTime();
 void sceKernelGetSystemTimeLow();
 void sceKernelGetSystemTimeWide();
 void sceKernelSysClock2USec();
 void sceKernelSysClock2USecWide();
-void sceRtcGetCurrentClockLocalTime();
-void sceRtcGetTickResolution();
-void sceRtcGetTick();
+u32 sceRtcGetCurrentClockLocalTime(u32);
+u32 sceRtcGetTickResolution();
+u32 sceRtcGetTick(u32, u32);

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -175,8 +175,8 @@ const HLEFunction sceNetApctl[] =
 const HLEFunction sceWlanDrv[] =
 {
 	{0xd7763699, 0, "sceWlanGetSwitchState"},
-	{0x0c622081, WrapU_U<sceWlanGetEtherAddr>, "sceWlanGetEtherAddr"},
-	{0x93440B11, WrapU_V<sceWlanDevIsPowerOn>, "sceWlanDevIsPowerOn"},
+	{0x0c622081, Wrap<sceWlanGetEtherAddr>, "sceWlanGetEtherAddr"},
+	{0x93440B11, Wrap<sceWlanDevIsPowerOn>, "sceWlanDevIsPowerOn"},
 };
 
 void Register_sceNet()

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -175,7 +175,7 @@ static const HLEFunction scePower[] =
   {0xBD681969,0,"scePowerGetBusClockFrequencyInt"},
   {0xB1A52C83,0,"scePowerGetCpuClockFrequencyFloat"},
   {0x9BADB3EB,0,"scePowerGetBusClockFrequencyFloat"},
-  {0x737486F2,&WrapV_UUU<scePowerSetClockFrequency>,"scePowerSetClockFrequency"},
+  {0x737486F2,&Wrap<scePowerSetClockFrequency>,"scePowerSetClockFrequency"},
   {0x34f9c463,0,"scePowerGetPllClockFrequencyInt"},
   {0xea382a27,0,"scePowerGetPllClockFrequencyFloat"},
   {0xebd177d6,0,"scePower_driver_EBD177D6"},

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -60,19 +60,19 @@ u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType) // possib
 
 const HLEFunction scePsmf[] =
 {
-  {0xc22c8327,&WrapU_UU<scePsmfSetPsmf>,"scePsmfSetPsmfFunction"},
+  {0xc22c8327,&Wrap<scePsmfSetPsmf>,"scePsmfSetPsmfFunction"},
   {0xC7DB3A5B,0,"scePsmfGetCurrentStreamTypeFunction"},
   {0x28240568,0,"scePsmfGetCurrentStreamNumberFunction"},
-  {0x1E6D9013,&WrapU_UU<scePsmfSpecifyStreamWithStreamType>,"scePsmfSpecifyStreamWithStreamTypeFunction"},
+  {0x1E6D9013,&Wrap<scePsmfSpecifyStreamWithStreamType>,"scePsmfSpecifyStreamWithStreamTypeFunction"},
   {0x4BC9BDE0,0,"scePsmfSpecifyStreamFunction"},
   {0x76D3AEBA,0,"scePsmfGetPresentationStartTimeFunction"},
   {0xBD8AE0D8,0,"scePsmfGetPresentationEndTimeFunction"},
-  {0xEAED89CD,&WrapU_U<scePsmfGetNumberOfStreams>,"scePsmfGetNumberOfStreamsFunction"},
+  {0xEAED89CD,&Wrap<scePsmfGetNumberOfStreams>,"scePsmfGetNumberOfStreamsFunction"},
   {0x7491C438,0,"scePsmfGetNumberOfEPentriesFunction"},
   {0x0BA514E5,0,"scePsmfGetVideoInfoFunction"},
   {0xA83F7113,0,"scePsmfGetAudioInfoFunction"},
   {0x971A3A90,0,"scePsmfCheckEPmapFunction"},
-  {0x68d42328,&WrapU_UU<scePsmfGetNumberOfSpecificStreams>,"scePsmfGetNumberOfSpecificStreamsFunction"},
+  {0x68d42328,&Wrap<scePsmfGetNumberOfSpecificStreams>,"scePsmfGetNumberOfSpecificStreamsFunction"},
   {0x5b70fcc1,0,"scePsmfQueryStreamOffsetFunction"},
   {0x9553cc91,0,"scePsmfQueryStreamSizeFunction"},
   {0x0C120E1D,0,"scePsmfSpecifyStreamWithStreamTypeNumberFunction"},

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -26,12 +26,12 @@
 
 #include "sceRtc.h"
 
-void sceRtcGetCurrentTick()
+u32 sceRtcGetCurrentTick(u64)
 {
 #ifdef _WIN32
-	RETURN(GetTickCount());
+	return GetTickCount();
 #else
 	time_update();
-	RETURN(time_now_d());
+	return time_now_d();
 #endif
 }

--- a/Core/HLE/sceRtc.h
+++ b/Core/HLE/sceRtc.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-void sceRtcGetCurrentTick();
+u32 sceRtcGetCurrentTick(u64);

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -391,10 +391,10 @@ void sceSasGetOutputMode()
 
 const HLEFunction sceSasCore[] =
 {
-	{0x42778a9f, WrapU_UUUUU<sceSasInit>, "__sceSasInit"}, // (SceUID * sasCore, int grain, int maxVoices, int outputMode, int sampleRate)
+	{0x42778a9f, Wrap<sceSasInit>, "__sceSasInit"}, // (SceUID * sasCore, int grain, int maxVoices, int outputMode, int sampleRate)
 	{0xa3589d81, _sceSasCore, "__sceSasCore"},
 	{0x50a14dfc, _sceSasCoreWithMix, "__sceSasCoreWithMix"},	// Process and mix into buffer (int sasCore, int sasInOut, int leftVolume, int rightVolume)
-	{0x68a46b95, WrapU_V<sceSasGetEndFlag>, "__sceSasGetEndFlag"},	// int sasCore
+	{0x68a46b95, Wrap<sceSasGetEndFlag>, "__sceSasGetEndFlag"},	// int sasCore
 	{0x440ca7d8, sceSasSetVolume, "__sceSasSetVolume"},
 	{0xad84d37f, sceSasSetPitch, "__sceSasSetPitch"},
 	{0x99944089, sceSasSetVoice, "__sceSasSetVoice"},	// (int sasCore, int voice, int vagAddr, int size, int loopmode)
@@ -402,8 +402,8 @@ const HLEFunction sceSasCore[] =
 	{0x019b25eb, sceSasSetADSR, "__sceSasSetADSR"},
 	{0x9ec3676a, sceSasSetADSRMode, "__sceSasSetADSRmode"},
 	{0x5f9529f6, 0, "__sceSasSetSL"},
-	{0x74ae582a, WrapU_UU<sceSasGetEnvelopeHeight>, "__sceSasGetEnvelopeHeight"},	
-	{0xcbcd4f79, WrapU_UUUU<sceSasSetSimpleADSR>, "__sceSasSetSimpleADSR"},
+	{0x74ae582a, Wrap<sceSasGetEnvelopeHeight>, "__sceSasGetEnvelopeHeight"},	
+	{0xcbcd4f79, Wrap<sceSasSetSimpleADSR>, "__sceSasSetSimpleADSR"},
 	{0xa0cf2fa4, sceSasSetKeyOff, "__sceSasSetKeyOff"},
 	{0x76f01aca, sceSasSetKeyOn, "__sceSasSetKeyOn"},	// (int sasCore, int voice)
 	{0xf983b186, sceSasRevVON, "__sceSasRevVON"},	// int sasCore, int dry, int wet

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -877,11 +877,11 @@ void GPU::ExecuteOp(u32 op, u32 diff)
 
 	case GE_CMD_ZTEST:
 		{
-			static const GLuint ztests[8] = 
-			{
-				GL_NEVER, GL_ALWAYS, GL_EQUAL, GL_NOTEQUAL, 
-				GL_LESS, GL_LEQUAL, GL_GREATER, GL_GEQUAL
-			};
+			//static const GLuint ztests[8] = 
+			//{
+			//	GL_NEVER, GL_ALWAYS, GL_EQUAL, GL_NOTEQUAL, 
+			//	GL_LESS, GL_LEQUAL, GL_GREATER, GL_GEQUAL
+			//};
 			//glDepthFunc(ztests[data&7]);
 			glDepthFunc(GL_LEQUAL);
 			DEBUG_LOG(G3D,"DL Z test mode: %i", data);

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -134,7 +134,7 @@ void Light(float colorOut[4], const float colorIn[4], Vec3 pos, Vec3 normal, flo
 		else
 			toLight = Vec3(gstate.lightpos[l]) - pos;
 
-		Vec3 dir = Vec3(gstate.lightdir[l]);
+		//Vec3 dir = Vec3(gstate.lightdir[l]);
 
 		bool doSpecular = (comp != GE_LIGHTCOMP_ONLYDIFFUSE);
 		bool poweredDiffuse = comp == GE_LIGHTCOMP_BOTHWITHPOWDIFFUSE;
@@ -225,7 +225,6 @@ void TransformAndDrawPrim(void *verts, void *inds, int prim, int vertexCount, Li
 
 
 	// TODO: Split up into multiple draw calls for Android where you can't guarantee support for more than 0x10000 verts.
-	int i = 0;
 
 #ifdef ANDROID
 	if (vertexCount > 0x10000/3)


### PR DESCRIPTION
I changed the wrapper system in order to only use &Wrap<>. I hope it works on all the compilers.
I also fixed some warnings, some small bugs (-> sceCtrlReadBuffer wrongly checking if  sceCtrlInit() has been called, a segmentation fault on an invalid thread id etc.).
I also added support for module loading (.prx loading in the ISO), but that's untested because none of my games used that properly (either modules are encrypted, it uses sceModuleLoadModuleByID(), or modules are already implemented by the HLE..).
