### PR TITLE
Better blacklisting, fixed exports

### DIFF
--- a/Core/ELF/PrxDecrypter.cpp
+++ b/Core/ELF/PrxDecrypter.cpp
@@ -382,7 +382,7 @@ static int DecryptPRX1(const u8* pbIn, u8* pbOut, int cbTotal, u32 tag)
 	memcpy(buffer1+0xD0, b00, 0x80);
 	if (pti->codeExtra != 0)
 		ExtraV2Mangle(buffer1+0x10, pti->codeExtra);
-	memcpy(pbOut+0x40 /* 0x2C+20 */, buffer1+0x40, 0x40);
+	memcpy(pbOut+0x40, buffer1+0x40, 0x40);
 
 	int ret;
 	int iXOR;

--- a/Core/ELF/PrxDecrypter.h
+++ b/Core/ELF/PrxDecrypter.h
@@ -32,8 +32,8 @@ typedef struct
 	char    modname[28]; // 0A
 	u8      version; // 26
 	u8      nsegments; // 27
-	int     elf_size; // 28
-	int     psp_size; // 2C
+	u32     elf_size; // 28
+	u32     psp_size; // 2C
 	u32     entry;  // 30
 	u32     modinfo_offset; // 34
 	int     bss_size; // 38


### PR DESCRIPTION
Blacklisting is now based on the modules names, and not on PRXes name (way more efficient because games can actually name their PRXes like they want, even if it's a Sony module, whereas they can't change the module name).
Undecryptable PRXes (there are actually some missing keys for some sorts of kernel PRXes, probably for the ones included in games) are automatically blacklisted, so loading errors aren't taken in account.

I also fixed a stupid mistake I made with exports which should fix memory errors/segmentation faults.
