### PR TITLE
Enable HEADLESS build by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(PPSSPP)
 
 if(ANDROID OR BLACKBERRY)
     set(HEADLESS OFF)
+elseif(NOT DEFINED HEADLESS)
+    set(HEADLESS ON)
 endif()
 
 if(ANDROID_ABI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ elseif(NOT DEFINED HEADLESS)
 endif()
 
 if(ANDROID_ABI)
-    set(ANDROID ON)
     if(ARMEABI OR ARMEABI_V7A)
         set(ARM ON)
     endif()


### PR DESCRIPTION
Accidentally disabled it by not setting to ON on non-portable platforms.
