### PR TITLE
Remove some warnings, fix old proj files

### DIFF
--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -137,10 +137,15 @@ void __PPGeInit()
 
 void __PPGeShutdown()
 {
-	kernelMemory.Free(atlasPtr);
-	kernelMemory.Free(dataPtr);
-	kernelMemory.Free(dlPtr);
-	kernelMemory.Free(savedContextPtr);
+	if (atlasPtr)
+		kernelMemory.Free(atlasPtr);
+	if (dataPtr)
+		kernelMemory.Free(dataPtr);
+	if (dlPtr)
+		kernelMemory.Free(dlPtr);
+	if (savedContextPtr)
+		kernelMemory.Free(savedContextPtr);
+
 	atlasPtr = 0;
 	dataPtr = 0;
 	dlPtr = 0;

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -316,7 +316,7 @@
     <ClInclude Include="..\Globals.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="resource.h" />
-    <ClInclude Include="..\stdafx.h" />
+    <ClInclude Include="stdafx.h" />
     <ClInclude Include="XinputDevice.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -70,9 +70,6 @@
     <ClCompile Include="WindowsHost.cpp">
       <Filter>Windows\System</Filter>
     </ClCompile>
-    <ClCompile Include="..\Globals.cpp" />
-    <ClCompile Include="..\main.cpp" />
-    <ClCompile Include="..\stdafx.cpp" />
     <ClCompile Include="Debugger\Debugger_Disasm.cpp">
       <Filter>Windows\Debugger</Filter>
     </ClCompile>
@@ -104,6 +101,9 @@
     <ClCompile Include="InputDevice.cpp">
       <Filter>Windows\Input</Filter>
     </ClCompile>
+    <ClCompile Include="Globals.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="stdafx.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Debugger\CtrlDisAsmView.h">
@@ -154,7 +154,6 @@
     <ClInclude Include="..\Globals.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="resource.h" />
-    <ClInclude Include="..\stdafx.h" />
     <ClInclude Include="Debugger\Debugger_Disasm.h">
       <Filter>Windows\Debugger</Filter>
     </ClInclude>
@@ -182,6 +181,7 @@
     <ClInclude Include="KeyboardDevice.h">
       <Filter>Windows\Input</Filter>
     </ClInclude>
+    <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icon1.ico">


### PR DESCRIPTION
Not sure if these project files are meant to be kept but noticed there was a file missed.

The other change is just if you open a game and then close it right away, it won't spit out warnings.

-[Unknown]
