### PR TITLE
Change test line numbers to match IDEs

### DIFF
--- a/test.py
+++ b/test.py
@@ -218,15 +218,15 @@ def run_tests(test_list, args):
     
     for i in range(0, min(len(output_lines), len(expected_lines))):
       if output_lines[i] != expected_lines[i]:
-        print "E%i < %s" % (i, expected_lines[i])
-        print "O%i > %s" % (i, output_lines[i])
+        print "E%i < %s" % (i + 1, expected_lines[i])
+        print "O%i > %s" % (i + 1, output_lines[i])
         different = True
 
     if len(output_lines) != len(expected_lines):
       for i in range(len(output_lines), len(expected_lines)):
-        print "E%i < %s" % (i, expected_lines[i])
+        print "E%i < %s" % (i + 1, expected_lines[i])
       for i in range(len(expected_lines), len(output_lines)):
-        print "O%i > %s" % (i, output_lines[i])
+        print "O%i > %s" % (i + 1, output_lines[i])
       print "*** Different number of lines!"
       different = True
 


### PR DESCRIPTION
Pretty simple.  Makes it easier to debug when there are context lines you need to look at in an editor.  Also, funny enough, I had added O / E as well (but replacing the < and >.)

That said, sometimes it's easier to just run:
ppssppheadless testfile.prx | diff -U3 testfile.expected -

-[Unknown]
