### PR TITLE
Make the texcache evict less often

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -88,9 +88,6 @@ void TextureCache_Decimate()
 	{
 		if (iter->second.frameCounter + TEXTURE_KILL_AGE < gpuStats.numFrames)
 		{
-			TexCacheEntry &entry = iter->second;
-			NOTICE_LOG(G3D, "Deleted texture %i from %08x: fmt: %i", entry.texture, entry.addr, entry.format);
-
 			glDeleteTextures(1, &iter->second.texture);
 			cache.erase(iter++);
 		}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -84,16 +84,18 @@ void TextureCache_Clear(bool delete_them)
 // Removes old textures.
 void TextureCache_Decimate()
 {
-	// TODO: Need a better way to keep looping
-restart:
-	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ++iter)
+	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); )
 	{
 		if (iter->second.frameCounter + TEXTURE_KILL_AGE < gpuStats.numFrames)
 		{
+			TexCacheEntry &entry = iter->second;
+			NOTICE_LOG(G3D, "Deleted texture %i from %08x: fmt: %i", entry.texture, entry.addr, entry.format);
+
 			glDeleteTextures(1, &iter->second.texture);
-			cache.erase(iter);
-			goto restart;
+			cache.erase(iter++);
 		}
+		else
+			++iter;
 	}
 }
 


### PR DESCRIPTION
This just widens the key to include more values.  Using xor, but collision should not be likely (and would just cause evictions anyway.)

This makes the slow parts of Tales of Eternia run much faster.

-[Unknown]
