### PR TITLE
CMakeLists fixes for building on APPLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else() # Assume x86
 	set(X86 ON)
 endif()
 
-if(ARM OR APPLE)
+if(ANDROID OR BLACKBERRY OR IOS)
 	set(HEADLESS OFF)
 elseif(NOT DEFINED HEADLESS)
 	set(HEADLESS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# vim:noexpandtab:
 cmake_minimum_required(VERSION 2.8.8)
 project(PPSSPP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ else()
 endif()
 include(FindSDL)
 include(FindThreads)
+if(APPLE)
+	find_library(COCOA_LIBRARY Cocoa)
+endif()
 
 # Needed for Globals.h
 include_directories("${CMAKE_SOURCE_DIR}")
@@ -816,7 +819,8 @@ endif()
 
 if(HEADLESS)
 	add_executable(PPSSPPHeadless headless/Headless.cpp)
-	target_link_libraries(PPSSPPHeadless ${CoreLibName}	${CMAKE_THREAD_LIBS_INIT})
+	target_link_libraries(PPSSPPHeadless ${CoreLibName}
+		${COCOA_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 	setup_target_project(PPSSPPHeadless headless)
 endif()
 
@@ -849,7 +853,6 @@ if(SDL_FOUND)
 			set(SDL_Main ${SDL_Main}
 				SDL/SDLMain.h
 				SDL/SDLMain.mm)
-			find_library(COCOA_LIBRARY Cocoa)
 			set(LinkCommon ${LinkCommon} ${COCOA_LIBRARY})
 		endif()
 


### PR DESCRIPTION
Reenables the HEADLESS target (APPLE != IOS), make it build under OSX.

By the way, the Xcode cmake generator also works :)
