### PR TITLE
Make ctrl use sampling and buffers

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -226,7 +226,7 @@ void __CtrlInit()
 		ctrlInited = true;
 	}
 
-	ctrlBuf = 0;
+	ctrlBuf = 1;
 	ctrlBufRead = 0;
 	ctrlOldButtons = 0;
 	ctrlLatchBufs = 0;
@@ -239,6 +239,8 @@ void __CtrlInit()
 	memset(&ctrlBufs, 0, sizeof(ctrlBufs));
 	ctrlCurrent.analog[0] = 128;
 	ctrlCurrent.analog[1] = 128;
+	ctrlBufs[0].analog[0] = 128;
+	ctrlBufs[0].analog[1] = 128;
 }
 
 void sceCtrlInit()

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -157,7 +157,13 @@ u32 sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 	//if (ctrlInited)
 	//{
 		SampleControls();
-		Memory::WriteStruct(ctrlDataPtr, &ctrl);
+		_ctrl_data *ctrlData = (_ctrl_data*) Memory::GetPointer(ctrlDataPtr);
+		memcpy(ctrlData, &ctrl, sizeof(_ctrl_data));
+		if (!analogEnabled)
+		{
+			ctrlData->analog[0] = 128;
+			ctrlData->analog[1] = 128;
+		}
 	//}
 	return 1;
 }

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -294,7 +294,7 @@ int sceCtrlPeekBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 
 u32 sceCtrlPeekLatch(u32 latchDataPtr)
 {
-	ERROR_LOG(HLE, "sceCtrlPeekLatch(%08x)", latchDataPtr);
+	DEBUG_LOG(HLE, "sceCtrlPeekLatch(%08x)", latchDataPtr);
 
 	if (Memory::IsValidAddress(latchDataPtr))
 		Memory::WriteStruct(latchDataPtr, &latch);
@@ -304,7 +304,7 @@ u32 sceCtrlPeekLatch(u32 latchDataPtr)
 
 u32 sceCtrlReadLatch(u32 latchDataPtr)
 {
-	ERROR_LOG(HLE, "sceCtrlReadLatch(%08x)", latchDataPtr);
+	DEBUG_LOG(HLE, "sceCtrlReadLatch(%08x)", latchDataPtr);
 
 	if (Memory::IsValidAddress(latchDataPtr))
 		Memory::WriteStruct(latchDataPtr, &latch);

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -149,6 +149,9 @@ void sceCtrlInit()
 	std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 
 	memset(&latch, 0, sizeof(latch));
+	// Start with everything released.
+	latch.btnRelease = 0xffffffff;
+
 	memset(&ctrl, 0, sizeof(ctrl));
 	ctrl.analog[0] = 128;
 	ctrl.analog[1] = 128;

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -214,9 +214,9 @@ u32 sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 
 	std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 
-	if (Memory::IsValidAddress(ctrlDataPtr))
+	_ctrl_data *ctrlData = (_ctrl_data*) Memory::GetPointer(ctrlDataPtr);
+	if (Memory::IsValidAddress(ctrlDataPtr) && ctrlData)
 	{
-		_ctrl_data *ctrlData = (_ctrl_data*) Memory::GetPointer(ctrlDataPtr);
 		memcpy(ctrlData, &ctrl, sizeof(_ctrl_data));
 
 		ctrlData->frame = (u32) (CoreTiming::GetTicks() / CoreTiming::GetClockFrequencyMHz());
@@ -241,9 +241,9 @@ u32 sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 
 	std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 
-	if (Memory::IsValidAddress(ctrlDataPtr))
+	_ctrl_data *ctrlData = (_ctrl_data*) Memory::GetPointer(ctrlDataPtr);
+	if (Memory::IsValidAddress(ctrlDataPtr) && ctrlData)
 	{
-		_ctrl_data *ctrlData = (_ctrl_data*) Memory::GetPointer(ctrlDataPtr);
 		memcpy(ctrlData, &ctrl, sizeof(_ctrl_data));
 
 		ctrlData->buttons = ~ctrlData->buttons;

--- a/Core/HLE/sceCtrl.h
+++ b/Core/HLE/sceCtrl.h
@@ -32,6 +32,8 @@ void Register_sceCtrl();
 #define CTRL_LTRIGGER   0x0100
 #define CTRL_RTRIGGER   0x0200
 
+void __CtrlInit();
+
 void __CtrlButtonDown(u32 buttonBit);
 void __CtrlButtonUp(u32 buttonBit);
 // -1 to 1, try to keep it in the circle

--- a/Core/HLE/sceDisplay.h
+++ b/Core/HLE/sceDisplay.h
@@ -23,3 +23,6 @@ void Register_sceDisplay();
 
 // will return true once after every end-of-frame.
 bool __DisplayFrameDone();
+
+typedef void (*VblankCallback)();
+void __DisplayListenVblank(VblankCallback callback);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -29,6 +29,7 @@
 
 #include "__sceAudio.h"
 #include "sceAudio.h"
+#include "sceCtrl.h"
 #include "sceDisplay.h"
 #include "sceGe.h"
 #include "sceIo.h"
@@ -80,6 +81,7 @@ void __KernelInit()
 	__PowerInit();
 	__UtilityInit();
 	__UmdInit();
+	__CtrlInit();
 	
 	// "Internal" PSP libraries
 	__PPGeInit();

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -73,6 +73,7 @@ const char *waitTypeStrings[] =
   "Vblank",
   "Mutex",
   "LwMutex",
+  "Ctrl",
 };
 
 struct SceKernelSysClock {

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -70,6 +70,7 @@ enum WaitType //probably not the real values
 	WAITTYPE_VBLANK = 12,           // fake
 	WAITTYPE_MUTEX = 13,
 	WAITTYPE_LWMUTEX = 14,
+	WAITTYPE_CTRL = 15,
 	// Remember to update sceKernelThread.cpp's waitTypeStrings to match.
 };
 

--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -17,30 +17,46 @@ static const unsigned short key_ctrl_map[] = {
 	VK_LEFT,  CTRL_LEFT,
 	VK_RIGHT, CTRL_RIGHT,
 };
+
+static const unsigned short analog_ctrl_map[] = {
+	'I', CTRL_UP,
+	'K', CTRL_DOWN,
+	'J', CTRL_LEFT,
+	'L', CTRL_RIGHT,
+};
+
 int KeyboardDevice::UpdateState() {
-	float analogX = 0;
-	float analogY = 0;
 	for (int i = 0; i < sizeof(key_ctrl_map)/sizeof(key_ctrl_map[0]); i += 2) {
 		if (!GetAsyncKeyState(key_ctrl_map[i]))
 			__CtrlButtonUp(key_ctrl_map[i+1]);
 		else {
 			__CtrlButtonDown(key_ctrl_map[i+1]);
-			switch (key_ctrl_map[i]) {
-			case VK_UP:
-				analogY -= .8f;
-				break;
-			case VK_DOWN:
-				analogY += .8f;
-				break;
-			case VK_LEFT:
-				analogX -= .8f;
-				break;
-			case VK_RIGHT:
-				analogX += .8f;
-				break;
-			}
 		}
 	}
+
+	float analogX = 0;
+	float analogY = 0;
+	for (int i = 0; i < sizeof(analog_ctrl_map)/sizeof(analog_ctrl_map[0]); i += 2) {
+		if (!GetAsyncKeyState(analog_ctrl_map[i])) {
+			continue;
+		}
+
+		switch (analog_ctrl_map[i + 1]) {
+		case CTRL_UP:
+			analogY -= .8f;
+			break;
+		case CTRL_DOWN:
+			analogY += .8f;
+			break;
+		case CTRL_LEFT:
+			analogX -= .8f;
+			break;
+		case CTRL_RIGHT:
+			analogX += .8f;
+			break;
+		}
+	}
+
 	__CtrlSetAnalog(analogX, analogY);
 	return 0;
 }

--- a/test.py
+++ b/test.py
@@ -47,6 +47,8 @@ tests_good = [
   "cpu/lsu/lsu",
   "cpu/fpu/fpu",
 
+  "ctrl/ctrl",
+  "ctrl/sampling/sampling",
   "display/display",
   "dmac/dmactest",
   "loader/bss/bss",
@@ -95,7 +97,6 @@ tests_next = [
   "threads/vpl/vpl",
   "threads/vtimers/vtimer",
   "threads/wakeup/wakeup",
-  "ctrl/ctrl",
   "gpu/simple/simple",
   "gpu/triangle/triangle",
   "hle/check_not_used_uids",


### PR DESCRIPTION
This makes a few changes:
- On Windows, maps the analog stick to ikjl (wsad was taken.) 
  
  This fixes the menu and movement in Tales of Eternia, which can't wrap its head around the analog stick and digital pad doing the same thing simultaneously.
- Implements vblank-based sampling of the controls, adding a listener to sceDisplay.
- Corrects the implementation of `sceCtrlReadLatch()` etc.
- No longer expects the user to call `sceCtrlInit()` (it doesn't seem like a user func based on docs I can find, and none of my games call it.)
- Adds buffer support and waits when no buffers are available (`sceCtrlReadBufferPositive()` can be used like `sceDisplayWaitVblank()` it seems like.)

Now Telegraph Sudoku gets ingame and Pix'n' Love Rush gets to the menu.

-[Unknown]
