### PR TITLE
Fix some more problems with scheduling / callbacks

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -226,7 +226,8 @@ void hleReSchedule(const char *reason)
 void hleReSchedule(bool callbacks, const char *reason)
 {
 	hleReSchedule(reason);
-	hleAfterSyscall |= HLE_AFTER_RESCHED_CALLBACKS;
+	if (callbacks)
+		hleAfterSyscall |= HLE_AFTER_RESCHED_CALLBACKS;
 }
 
 inline void hleFinishSyscall()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1853,8 +1853,9 @@ void __KernelReturnFromMipsCall()
 	if (!__KernelExecutePendingMipsCalls(call->reschedAfter))
 	{
 		// Sometimes, we want to stay on the thread.
-		if (call->reschedAfter)
-			hleReSchedule("return from callback");
+		int threadReady = currentThread->nt.status & (THREADSTATUS_READY | THREADSTATUS_RUNNING);
+		if (call->reschedAfter || threadReady == 0)
+			__KernelReSchedule("return from callback");
 	}
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -405,7 +405,7 @@ void __KernelIdle()
   // In Advance, we might trigger an interrupt such as vblank.
   // If we end up in an interrupt, we don't want to reschedule.
   // However, we have to reschedule... damn.
-  hleReSchedule("idle");
+  __KernelReSchedule("idle");
 }
 
 void __KernelThreadingShutdown()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1160,6 +1160,9 @@ int sceKernelDeleteThread(int threadHandle)
 			//	hleReSchedule("thread deleted");
 			return kernelObjects.Destroy<Thread>(threadHandle);
 		}
+
+		// TODO: Error when doesn't exist?
+		return 0;
 	}
 	else
 	{

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1943,8 +1943,17 @@ bool __KernelCheckThreadCallbacks(Thread *thread, bool force)
 		if (thread->readyCallbacks[i].size()) {
 			SceUID readyCallback = thread->readyCallbacks[i].front();
 			thread->readyCallbacks[i].pop_front();
-			__KernelRunCallbackOnThread(readyCallback, thread, !force);   // makes pending
-			return true;
+
+			// If the callback was deleted, we're good.  Just skip it.
+			if (kernelObjects.IsValid(readyCallback))
+			{
+				__KernelRunCallbackOnThread(readyCallback, thread, !force);   // makes pending
+				return true;
+			}
+			else
+			{
+				WARN_LOG(HLE, "Ignoring deleted callback %08x", readyCallback);
+			}
 		}
 	}
 	return false;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -283,6 +283,7 @@ int g_inCbCount = 0;
 Thread *__KernelCreateThread(SceUID &id, SceUID moduleID, const char *name, u32 entryPoint, u32 priority, int stacksize, u32 attr);
 void __KernelResetThread(Thread *t);
 void __KernelCancelWakeup(SceUID threadID);
+bool __KernelCheckThreadCallbacks(Thread *thread, bool force);
 
 //////////////////////////////////////////////////////////////////////////
 //STATE BEGIN
@@ -1848,6 +1849,7 @@ void __KernelReturnFromMipsCall()
 	g_inCbCount--;
 
 	// yeah! back in the real world, let's keep going. Should we process more callbacks?
+	__KernelCheckThreadCallbacks(currentThread, !call->reschedAfter);
 	if (!__KernelExecutePendingMipsCalls(call->reschedAfter))
 	{
 		// Sometimes, we want to stay on the thread.


### PR DESCRIPTION
Fixes here are:
- Never stay on a waiting thread after a callback.
- It's not just return values which need to be "injected" while a callback is running.
- Multiple callbacks weren't running in a row.
- Some HLE functions were going into processing callbacks mode by accident (very stupid mistake.)

a1a4a02759fff7c28c84b183afc2ee4a433c1e9a was fun, I tried to KISS as much as possible.

I'm hoping this will fix games that my previous pull broke (#153).  I've also got a few tests queued up now which I'll be sending soon.

-[Unknown]
