### PR TITLE
Small project file cleanup / warnings

### DIFF
--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="HW">
       <UniqueIdentifier>{9696662f-7398-489a-a358-5ebbf4ad4d97}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Dialog">
+      <UniqueIdentifier>{41034c99-9b76-477f-8a77-bffaaffd5e82}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ELF\ElfReader.cpp">
@@ -321,11 +324,21 @@
     <ClCompile Include="HLE\sceVaudio.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
-    <ClCompile Include="Dialog\PSPDialog.cpp" />
-    <ClCompile Include="Dialog\PSPMsgDialog.cpp" />
-    <ClCompile Include="Dialog\PSPPlaceholderDialog.cpp" />
-    <ClCompile Include="Dialog\PSPSaveDialog.cpp" />
-    <ClCompile Include="Dialog\SavedataParam.cpp" />
+    <ClCompile Include="Dialog\PSPDialog.cpp">
+      <Filter>Dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Dialog\PSPMsgDialog.cpp">
+      <Filter>Dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Dialog\PSPPlaceholderDialog.cpp">
+      <Filter>Dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Dialog\PSPSaveDialog.cpp">
+      <Filter>Dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Dialog\SavedataParam.cpp">
+      <Filter>Dialog</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -595,11 +608,21 @@
     <ClInclude Include="HLE\sceVaudio.h">
       <Filter>HLE\Libraries</Filter>
     </ClInclude>
-    <ClInclude Include="Dialog\SavedataParam.h" />
-    <ClInclude Include="Dialog\PSPDialog.h" />
-    <ClInclude Include="Dialog\PSPMsgDialog.h" />
-    <ClInclude Include="Dialog\PSPPlaceholderDialog.h" />
-    <ClInclude Include="Dialog\PSPSaveDialog.h" />
+    <ClInclude Include="Dialog\PSPDialog.h">
+      <Filter>Dialog</Filter>
+    </ClInclude>
+    <ClInclude Include="Dialog\PSPMsgDialog.h">
+      <Filter>Dialog</Filter>
+    </ClInclude>
+    <ClInclude Include="Dialog\PSPPlaceholderDialog.h">
+      <Filter>Dialog</Filter>
+    </ClInclude>
+    <ClInclude Include="Dialog\PSPSaveDialog.h">
+      <Filter>Dialog</Filter>
+    </ClInclude>
+    <ClInclude Include="Dialog\SavedataParam.h">
+      <Filter>Dialog</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="CMakeLists.txt" />

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -174,6 +174,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions>/ignore:4049 %(AdditionalOptions)</AdditionalOptions>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Windows/stdafx.h
+++ b/Windows/stdafx.h
@@ -25,11 +25,15 @@
 
 //#ifdef WINDOWS
 
+#undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600
+#undef WINVER
 #define WINVER 0x0600
 #ifndef _WIN32_IE
 #define _WIN32_IE 0x0600       // Default value is 0x0400
 #endif
+
+#undef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
 //#define UNICODE
 


### PR DESCRIPTION
- Put Dialog stuff into a filter.
- Enable LTCG in Release to prevent a "restarting linker with LTCG" warning.
- Added some #undefs to suppress macro redefinition warnings.

By the way, I've locally added `_CRT_SECURE_NO_WARNINGS;GLEW_STATIC;` to my .vcxproj.user files in all projects (except native, only GLEW_STATIC there since it already defines the other) which really reduces the warning noise.

I don't know how to add a define for native without altering it upstream, though... stdafx.h isn't included there, etc.

-[Unknown]
