### PR TITLE
MotoGP dialog flicker correction

### DIFF
--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -31,6 +31,12 @@ PSPMsgDialog::~PSPMsgDialog() {
 
 void PSPMsgDialog::Init(unsigned int paramAddr)
 {
+	// Ignore if already running
+	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
+	{
+		return;
+	}
+
 	messageDialogAddr = paramAddr;
 	if (!Memory::IsValidAddress(messageDialogAddr))
 	{

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -172,6 +172,11 @@ void PSPOskDialog::HackyGetStringWide(std::string& _string, const u32 em_address
 
 int PSPOskDialog::Init(u32 oskPtr)
 {
+	// Ignore if already running
+	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
+	{
+		return -1;
+	}
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 
 	memset(&oskParams, 0, sizeof(oskParams));

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -33,6 +33,11 @@ PSPSaveDialog::~PSPSaveDialog() {
 
 void PSPSaveDialog::Init(int paramAddr)
 {
+	// Ignore if already running
+	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
+	{
+		return;
+	}
 	param.SetPspParam((SceUtilitySavedataParam*)Memory::GetPointer(paramAddr));
 
 	DEBUG_LOG(HLE,"sceUtilitySavedataInitStart(%08x)", paramAddr);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -435,7 +435,7 @@ void SavedataParam::SetPspParam(SceUtilitySavedataParam* param)
 	}
 	else // Load info on only save
 	{
-		saveNameListData == 0;
+		saveNameListData = 0;
 
 		Clear();
 		saveDataList = new SaveFileInfo[1];

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -179,6 +179,11 @@ int sceUtilityScreenshotGetStatus()
 	return retval;
 }
 
+void sceUtilityGamedataInstallInitStart(u32 unkown)
+{
+	DEBUG_LOG(HLE,"FAKE sceUtilityGamedataInstallInitStart(%i)", unkown);
+}
+
 int sceUtilityGamedataInstallGetStatus()
 {
 	u32 retval = 0;//__UtilityGetStatus();
@@ -332,6 +337,11 @@ u32 sceUtilityUnloadNetModule(u32 module)
 	return 0;
 }
 
+void sceUtilityInstallInitStart(u32 unknown)
+{
+	DEBUG_LOG(HLE,"FAKE sceUtilityInstallInitStart()");
+}
+
 const HLEFunction sceUtility[] = 
 {
 	{0x1579a159, &WrapU_U<sceUtilityLoadNetModule>, "sceUtilityLoadNetModule"},
@@ -398,7 +408,7 @@ const HLEFunction sceUtility[] =
 	{0x0D5BC6D2, 0, "sceUtilityLoadUsbModule"},
 	{0xF64910F0, 0, "sceUtilityUnloadUsbModule"},
 
-	{0x24AC31EB, 0, "sceUtilityGamedataInstallInitStart"},
+	{0x24AC31EB, &WrapV_U<sceUtilityGamedataInstallInitStart>, "sceUtilityGamedataInstallInitStart"},
 	{0x32E32DCB, 0, "sceUtilityGamedataInstallShutdownStart"},
 	{0x4AECD179, 0, "sceUtilityGamedataInstallUpdate"},
 	{0xB57E95D9, &WrapI_V<sceUtilityGamedataInstallGetStatus>, "sceUtilityGamedataInstallGetStatus"},
@@ -409,7 +419,7 @@ const HLEFunction sceUtility[] =
 	{0xF3FBC572, 0, "sceUtilityNpSigninUpdate"},
 	{0x86ABDB1B, 0, "sceUtilityNpSigninGetStatus"},
 
-	{0x1281DA8E, 0, "sceUtilityInstallInitStart"},
+	{0x1281DA8E, &WrapV_U<sceUtilityInstallInitStart>, "sceUtilityInstallInitStart"},
 	{0x5EF1C24A, 0, "sceUtilityInstallShutdownStart"},
 	{0xA03D29BA, 0, "sceUtilityInstallUpdate"},
 	{0xC4700FA3, 0, "sceUtilityInstallGetStatus"}, 


### PR DESCRIPTION
MotoGP call start dialog every frame, so don't relaunch it. Result the popup is not shown anymore, MotoGP don't update it like it should. But the game can go to the menu and is not stuck.
