### PR TITLE
Qt Update, compiler warning fix

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -299,7 +299,7 @@ u32 sceRtcGetDayOfWeek(u32 year, u32 month, u32 day)
 		return 0;
 	}
 	year -= month < 3;
-	return ( year + year/4 - year/100 + year/400 + t[month-1] + day) % 7;
+	return (year + year/4 - year/100 + year/400 + t[month-1] + day) % 7;
 }
 
 u32 sceRtcGetDaysInMonth(u32 year, u32 month)
@@ -307,7 +307,7 @@ u32 sceRtcGetDaysInMonth(u32 year, u32 month)
 	DEBUG_LOG(HLE, "sceRtcGetDaysInMonth(%d, %d)", year, month);
 	u32 numberOfDays;
 
-	if (year <= 0 || month <= 0 || month > 12)
+	if (year == 0 || month == 0 || month > 12)
 		return SCE_KERNEL_ERROR_INVALID_ARGUMENT;
 
 	switch (month)
@@ -381,36 +381,32 @@ int sceRtcCheckValid(u32 datePtr)
 		ScePspDateTime pt;
 		Memory::ReadStruct(datePtr, &pt);
 		if (pt.year < 1 || pt.year > 9999)  
-		{	
-        	ret = PSP_TIME_INVALID_YEAR;
-        } 
+		{
+			ret = PSP_TIME_INVALID_YEAR;
+        }
 		else if (pt.month < 1 || pt.month > 12) 
 		{
-        	ret = PSP_TIME_INVALID_MONTH;
+			ret = PSP_TIME_INVALID_MONTH;
         } 
-		else if (pt.day < 1 || pt.day > 31) 
+		else if (pt.day < 1 || pt.day > 31) // TODO: Needs to check actual days in month, including leaps 
 		{
-        	ret = PSP_TIME_INVALID_DAY;
-        } 
-		else if (pt.day < 0 || pt.day > 31) // TODO: Needs to check actual days in month, including leaps 
-		{ 
-        	ret = PSP_TIME_INVALID_DAY;
+			ret = PSP_TIME_INVALID_DAY;
         }
-		else if (pt.hour < 0 || pt.hour > 23) 
+		else if (pt.hour > 23) 
 		{
-        	ret = PSP_TIME_INVALID_HOUR;
+			ret = PSP_TIME_INVALID_HOUR;
         } 
-		else if (pt.minute < 0 || pt.minute > 59) 
+		else if (pt.minute > 59) 
 		{
-        	ret = PSP_TIME_INVALID_MINUTES;
+			ret = PSP_TIME_INVALID_MINUTES;
         } 
-		else if (pt.second < 0 || pt.second > 59) 
+		else if (pt.second > 59) 
 		{
-        	ret = PSP_TIME_INVALID_SECONDS;
+			ret = PSP_TIME_INVALID_SECONDS;
         } 
-		else if (pt.microsecond < 0 || pt.microsecond >= 1000000) 
+		else if (pt.microsecond >= 1000000) 
 		{
-        	ret = PSP_TIME_INVALID_MICROSECONDS;
+			ret = PSP_TIME_INVALID_MICROSECONDS;
         } 
 	}
 	else

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -80,9 +80,11 @@ SOURCES += ../Core/MIPS/ARM/Asm.cpp \ #CoreARM
 			../Core/HLE/sceSsl.cpp \
 			../Core/HLE/scesupPreAcc.cpp \
 			../Core/HLE/sceUmd.cpp \
+			../Core/HLE/sceUsb.cpp \
 			../Core/HLE/sceUtility.cpp \
 			../Core/HLE/sceVaudio.cpp \
 			../Core/HW/MemoryStick.cpp \
+			../Core/HW/SasAudio.cpp \
 			../Core/Host.cpp \
 			../Core/Loaders.cpp \
 			../Core/MIPS/JitCommon/JitCommon.cpp \
@@ -186,9 +188,11 @@ HEADERS += ../Core/MIPS/ARM/Asm.h \
 			../Core/HLE/sceSsl.h \
 			../Core/HLE/scesupPreAcc.h \
 			../Core/HLE/sceUmd.h \
+			../Core/HLE/sceUsb.h \
 			../Core/HLE/sceUtility.h \
 			../Core/HLE/sceVaudio.h \
 			../Core/HW/MemoryStick.h \
+			../Core/HW/SasAudio.h \
 			../Core/Host.h \
 			../Core/Loaders.h \
 			../Core/MIPS/JitCommon/JitCommon.h \

--- a/Qt/Native.pro
+++ b/Qt/Native.pro
@@ -189,6 +189,6 @@ QMAKE_CXXFLAGS += -std=c++0x -Wno-unused-function -Wno-unused-variable -Wno-mult
 DEFINES += ARM USING_GLES2
 blackberry: DEFINES += BLACKBERRY BLACKBERRY10
 symbian: {
-		QMAKE_CXXFLAGS += -march=armv6 -mfpu=vfp -mfloat-abi=softfp -marm -Wno-parentheses -Wno-comment
-		DEFINES += SYMBIAN
+	QMAKE_CXXFLAGS += -march=armv6 -mfpu=vfp -mfloat-abi=softfp -marm -Wno-parentheses -Wno-comment
+	DEFINES += SYMBIAN
 }

--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -42,7 +42,7 @@ symbian: {
 	assets.sources = ../android/assets/ui_atlas.zim ../android/assets/ppge_atlas.zim
 	assets.path = E:/PPSSPP
 	DEPLOYMENT += my_deployment assets
-        ICON = ../assets/icon.svg
+	ICON = ../assets/icon.svg
 # 268MB maximum
 	TARGET.EPOCHEAPSIZE = 0x40000 0x10000000
 	TARGET.EPOCSTACKSIZE = 0x10000


### PR DESCRIPTION
Update the Qt project files to stay on-par with CMakeLists.
Don't check if unsigned is < 0.
