### PR TITLE
Basic alarm functionality and related fixes

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -245,7 +245,7 @@ void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata)
 	Event *ne = GetNewEvent();
 	ne->userdata = userdata;
 	ne->type = event_type;
-	ne->time = globalTimer + cyclesIntoFuture;
+	ne->time = GetTicks() + cyclesIntoFuture;
 	AddEventToQueue(ne);
 }
 

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -81,6 +81,8 @@ void hleCheckAllCallbacks();
 void hleReSchedule(const char *reason);
 // Reschedule and go into a callback processing state after the syscall finishes.
 void hleReSchedule(bool callbacks, const char *reason);
+// Run interrupts after the syscall finishes.
+void hleRunInterrupts();
 
 void HLEInit();
 void HLEShutdown();

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -151,7 +151,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate)
 	vblankWaitingThreads.clear();
 
 	// Trigger VBlank interrupt handlers.
-	__TriggerInterrupt(PSP_VBLANK_INTR);
+	__TriggerInterrupt(PSP_INTR_IMMEDIATE | PSP_INTR_ONLY_IF_ENABLED, PSP_VBLANK_INTR);
 
 	CoreTiming::ScheduleEvent(msToCycles(vblankMs) - cyclesLate, leaveVblankEvent, vbCount+1);
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -412,10 +412,10 @@ const HLEFunction ThreadManForUser[] =
 	{0x64D4540E,0,"sceKernelReferThreadProfiler"},
 
 	//Fifa Street 2 uses alarms
-	{0x6652b8ca,sceKernelSetAlarm,"sceKernelSetAlarm"},
-	{0xB2C25152,sceKernelSetSysClockAlarm,"sceKernelSetSysClockAlarm"},
-	{0x7e65b999,sceKernelCancelAlarm,"sceKernelCancelAlarm"},
-	{0xDAA3F564,sceKernelReferAlarmStatus,"sceKernelReferAlarmStatus"},
+	{0x6652b8ca,WrapI_UUU<sceKernelSetAlarm>,"sceKernelSetAlarm"},
+	{0xB2C25152,WrapI_UUU<sceKernelSetSysClockAlarm>,"sceKernelSetSysClockAlarm"},
+	{0x7e65b999,WrapI_I<sceKernelCancelAlarm>,"sceKernelCancelAlarm"},
+	{0xDAA3F564,WrapI_IU<sceKernelReferAlarmStatus>,"sceKernelReferAlarmStatus"},
 
 	{0xba6b92e2,sceKernelSysClock2USec,"sceKernelSysClock2USec"},
 	{0x110DEC9A,0,"sceKernelUSec2SysClock"},

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -88,10 +88,8 @@ void __KernelTriggerAlarm(u64 userdata, int cyclesLate)
 
 	u32 error;
 	Alarm *alarm = kernelObjects.Get<Alarm>(uid, error);
-
-	// TODO: Need to find out the return value.
 	if (alarm)
-		__TriggerInterrupt(PSP_SYSTIMER0_INTR, uid);
+		__TriggerInterrupt(PSP_INTR_IMMEDIATE, PSP_SYSTIMER0_INTR, uid);
 }
 
 void __KernelScheduleAlarm(Alarm *alarm, int ticks)

--- a/Core/HLE/sceKernelAlarm.h
+++ b/Core/HLE/sceKernelAlarm.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-void sceKernelSetAlarm();
-void sceKernelSetSysClockAlarm();
-void sceKernelCancelAlarm();
-void sceKernelReferAlarmStatus();
+SceUID sceKernelSetAlarm(SceUInt clock, u32 handlerPtr, u32 commonPtr);
+SceUID sceKernelSetSysClockAlarm(u32 sysClockPtr, u32 handlerPtr, u32 commonPtr);
+int sceKernelCancelAlarm(SceUID uid);
+int sceKernelReferAlarmStatus(SceUID uid, u32 infoPtr);

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -397,7 +397,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 			th.bits = bits;
 			th.wait = wait;
 			// If < 5ms, sometimes hardware doesn't write this, but it's unpredictable.
-			th.outAddr = timeout == 0 ? NULL : outBitsPtr;
+			th.outAddr = timeout == 0 ? 0 : outBitsPtr;
 			e->waitingThreads.push_back(th);
 
 			__KernelSetEventFlagTimeout(e, timeoutPtr);
@@ -450,7 +450,7 @@ int sceKernelWaitEventFlagCB(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 
 			th.bits = bits;
 			th.wait = wait;
 			// If < 5ms, sometimes hardware doesn't write this, but it's unpredictable.
-			th.outAddr = timeout == 0 ? NULL : outBitsPtr;
+			th.outAddr = timeout == 0 ? 0 : outBitsPtr;
 			e->waitingThreads.push_back(th);
 
 			__KernelSetEventFlagTimeout(e, timeoutPtr);

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -320,12 +320,8 @@ void __KernelReturnFromInterrupt()
 	// All should now be back to normal, including PC.
 
 	// Alright, let's see if there's any more interrupts queued...
-
 	if (!__RunOnePendingInterrupt())
-	{
-		// Hmmm...
-		//__KernelReSchedule("return from interrupt");
-	}
+		__KernelReSchedule("return from interrupt");
 }
 
 u32 __RegisterSubInterruptHandler(u32 intrNumber, u32 subIntrNumber, SubIntrHandler *subIntrHandler)

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -259,7 +259,6 @@ bool __RunOnePendingInterrupt()
 		__KernelSwitchOffThread("interrupt");
 
 		PendingInterrupt pend = pendingInterrupts.front();
-		pendingInterrupts.pop_front();
 		intState.save();
 		pend.handler->copyArgsToCPU(pend);
 
@@ -294,6 +293,12 @@ void __KernelReturnFromInterrupt()
 {
 	DEBUG_LOG(CPU, "Left interrupt handler at %08x", currentMIPS->pc);
 	inInterrupt = false;
+
+	// This is what we just ran.
+	PendingInterrupt pend = pendingInterrupts.front();
+	pendingInterrupts.pop_front();
+	pend.handler->handleResult(currentMIPS->r[MIPS_REG_V0]);
+
 	// Restore context after running the interrupt.
 	intState.restore();
 	// All should now be back to normal, including PC.

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -273,20 +273,36 @@ bool __RunOnePendingInterrupt()
 	}
 }
 
-void __TriggerInterrupt(PSPInterrupt intno, int subintr)
+void __TriggerInterrupt(int type, PSPInterrupt intno, int subintr)
 {
-	intrHandlers[intno].queueUp(subintr);
-	DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i sub %i (%i in queue)", intno, subintr, pendingInterrupts.size());
-	if (!inInterrupt)
-		__RunOnePendingInterrupt();
+	if (interruptsEnabled || (type & PSP_INTR_ONLY_IF_ENABLED) == 0)
+	{
+		intrHandlers[intno].queueUp(subintr);
+		DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i sub %i (%i in queue)", intno, subintr, pendingInterrupts.size());
+		if (!inInterrupt)
+		{
+			if ((type & PSP_INTR_HLE) != 0)
+				hleRunInterrupts();
+			else
+				__RunOnePendingInterrupt();
+		}
+	}
 }
 
-void __TriggerInterruptWithArg(PSPInterrupt intno, int subintr, int arg)
+void __TriggerInterruptWithArg(int type, PSPInterrupt intno, int subintr, int arg)
 {
-	intrHandlers[intno].queueUpWithArg(subintr, arg);
-	DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i sub %i with arg %i (%i in queue)", intno, subintr, arg, pendingInterrupts.size());
-	if (!inInterrupt)
-		__RunOnePendingInterrupt();
+	if (interruptsEnabled || (type & PSP_INTR_ONLY_IF_ENABLED) == 0)
+	{
+		intrHandlers[intno].queueUpWithArg(subintr, arg);
+		DEBUG_LOG(HLE, "Triggering subinterrupts for interrupt %i sub %i with arg %i (%i in queue)", intno, subintr, arg, pendingInterrupts.size());
+		if (!inInterrupt)
+		{
+			if ((type & PSP_INTR_HLE) != 0)
+				hleRunInterrupts();
+			else
+				__RunOnePendingInterrupt();
+		}
+	}
 }
 
 void __KernelReturnFromInterrupt()

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -69,6 +69,8 @@ struct PendingInterrupt {
 	AllegrexInterruptHandler *handler;
 	int arg;
 	bool hasArg;
+	int intr;
+	int subintr;
 };
 
 
@@ -92,6 +94,7 @@ public:
 	virtual void handleResult(int result) {}
 
 	bool enabled;
+	int intrNumber;
 	int number;
 	u32 handlerAddress;
 	u32 handlerArg;

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -70,6 +70,7 @@ public:
 	virtual void copyArgsToCPU(const PendingInterrupt &pend) = 0;
 	virtual void queueUp() = 0;
 	virtual void queueUpWithArg(int arg) = 0;
+	virtual void handleResult(int result) = 0;
 };
 
 class SubIntrHandler : public AllegrexInterruptHandler
@@ -79,6 +80,7 @@ public:
 	virtual void queueUp();
 	virtual void queueUpWithArg(int arg);
 	virtual void copyArgsToCPU(const PendingInterrupt &pend);
+	virtual void handleResult(int result) {}
 
 	bool enabled;
 	int number;

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -54,6 +54,38 @@ enum PSPGeSubInterrupts {
   PSP_GE_SUBINTR_SIGNAL = 15
 };
 
+class AllegrexInterruptHandler;
+
+struct PendingInterrupt {
+	AllegrexInterruptHandler *handler;
+	int arg;
+	bool hasArg;
+};
+
+
+class AllegrexInterruptHandler
+{
+public:
+	virtual ~AllegrexInterruptHandler() {}
+	virtual void copyArgsToCPU(const PendingInterrupt &pend) = 0;
+	virtual void queueUp() = 0;
+	virtual void queueUpWithArg(int arg) = 0;
+};
+
+class SubIntrHandler : public AllegrexInterruptHandler
+{
+public:
+	SubIntrHandler() {}
+	virtual void queueUp();
+	virtual void queueUpWithArg(int arg);
+	virtual void copyArgsToCPU(const PendingInterrupt &pend);
+
+	bool enabled;
+	int number;
+	u32 handlerAddress;
+	u32 handlerArg;
+};
+
 bool __IsInInterrupt();
 void __InterruptsInit();
 void __InterruptsShutdown();
@@ -61,6 +93,9 @@ void __TriggerInterrupt(PSPInterrupt intno, int subInterrupts = -1);
 void __TriggerInterruptWithArg(PSPInterrupt intno, int subintr, int arg);  // For GE "callbacks"
 bool __RunOnePendingInterrupt();
 void __KernelReturnFromInterrupt();
+
+u32 __RegisterSubInterruptHandler(u32 intrNumber, u32 subIntrNumber, SubIntrHandler *subIntrHandler);
+u32 __ReleaseSubInterruptHandler(u32 intrNumber, u32 subIntrNumber);
 
 u32 sceKernelRegisterSubIntrHandler(u32 intrNumber, u32 subIntrNumber, u32 handler, u32 handlerArg);
 u32 sceKernelReleaseSubIntrHandler(u32 intrNumber, u32 subIntrNumber);

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -54,6 +54,15 @@ enum PSPGeSubInterrupts {
   PSP_GE_SUBINTR_SIGNAL = 15
 };
 
+enum PSPInterruptTriggerType {
+	// Trigger immediately, for CoreTiming events.
+	PSP_INTR_IMMEDIATE = 0x0,
+	// Trigger after the HLE syscall finishes.
+	PSP_INTR_HLE = 0x1,
+	// Only trigger (as above) if interrupts are not suspended.
+	PSP_INTR_ONLY_IF_ENABLED = 0x2,
+};
+
 class AllegrexInterruptHandler;
 
 struct PendingInterrupt {
@@ -91,8 +100,8 @@ public:
 bool __IsInInterrupt();
 void __InterruptsInit();
 void __InterruptsShutdown();
-void __TriggerInterrupt(PSPInterrupt intno, int subInterrupts = -1);
-void __TriggerInterruptWithArg(PSPInterrupt intno, int subintr, int arg);  // For GE "callbacks"
+void __TriggerInterrupt(int type, PSPInterrupt intno, int subInterrupts = -1);
+void __TriggerInterruptWithArg(int type, PSPInterrupt intno, int subintr, int arg);  // For GE "callbacks"
 bool __RunOnePendingInterrupt();
 void __KernelReturnFromInterrupt();
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1751,7 +1751,7 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 	}
 	currentThread = target;
 	__KernelLoadContext(&currentThread->context);
-	DEBUG_LOG(HLE,"Context switched: %s -> %s (%s) (%i - pc: %08x -> %i - pc: %08)",
+	DEBUG_LOG(HLE,"Context switched: %s -> %s (%s) (%i - pc: %08x -> %i - pc: %08x)",
 		oldName, currentThread->GetName(),
 		reason,
 		oldUID, oldPC, currentThread->GetUID(), currentMIPS->pc);

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -488,8 +488,9 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff)
 
 	case GE_CMD_FINISH:
 		DEBUG_LOG(G3D,"DL CMD FINISH");
+		// TODO: Should this run while interrupts are suspended?
 		if (interruptsEnabled_)
-			__TriggerInterruptWithArg(PSP_GE_INTR, PSP_GE_SUBINTR_FINISH, 0);
+			__TriggerInterruptWithArg(PSP_INTR_HLE, PSP_GE_INTR, PSP_GE_SUBINTR_FINISH, 0);
 		break;
 
 	case GE_CMD_END: 
@@ -525,8 +526,9 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff)
 					ERROR_LOG(G3D, "UNKNOWN Signal UNIMPLEMENTED %i ! signal/end: %04x %04x", behaviour, signal, enddata);
 					break;
 				}
+				// TODO: Should this run while interrupts are suspended?
 				if (interruptsEnabled_)
-					__TriggerInterruptWithArg(PSP_GE_INTR, PSP_GE_SUBINTR_SIGNAL, signal);
+					__TriggerInterruptWithArg(PSP_INTR_HLE, PSP_GE_INTR, PSP_GE_SUBINTR_SIGNAL, signal);
 			}
 			break;
 		case GE_CMD_FINISH:

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -206,8 +206,9 @@ void NullGPU::ExecuteOp(u32 op, u32 diff)
 			int behaviour = (data >> 16) & 0xFF;
 			int signal = data & 0xFFFF;
 
+			// TODO: Should this run while interrupts are suspended?
 			if (interruptsEnabled_)
-				__TriggerInterruptWithArg(PSP_GE_INTR, PSP_GE_SUBINTR_SIGNAL, signal);
+				__TriggerInterruptWithArg(PSP_INTR_HLE, PSP_GE_INTR, PSP_GE_SUBINTR_SIGNAL, signal);
 		}
 		break;
 
@@ -237,8 +238,9 @@ void NullGPU::ExecuteOp(u32 op, u32 diff)
 
 	case GE_CMD_FINISH:
 		DEBUG_LOG(G3D,"DL CMD FINISH");
+		// TODO: Should this run while interrupts are suspended?
 		if (interruptsEnabled_)
-			__TriggerInterruptWithArg(PSP_GE_INTR, PSP_GE_SUBINTR_FINISH, 0);
+			__TriggerInterruptWithArg(PSP_INTR_HLE, PSP_GE_INTR, PSP_GE_SUBINTR_FINISH, 0);
 		break;
 
 	case GE_CMD_END: 

--- a/test.py
+++ b/test.py
@@ -58,6 +58,7 @@ tests_good = [
   "misc/testgp",
   "string/string",
   "gpu/callbacks/ge_callbacks",
+  "threads/alarm/alarm",
   "threads/events/events",
   "threads/events/cancel/cancel",
   "threads/events/clear/clear",


### PR DESCRIPTION
Alarms aren't quite buttoned up, but they work generally well, and this includes a few related fixes which are worth knowing about:
- `hleAfterSyscall` now has a flag for running interrupts (so the HLE call returns the correct value.)
- Vblank interrupts are now called only while interrupts are enabled (verified by test.)
- I wasn't sure whether the sceGe / display list interrupts should run while suspended so added TODOs.
- `CoreTiming::ScheduleEvent()` now considers `downcount`, which seems to make the time it fires more accurate.
- The interrupt class was made more public some alarms can subclass and handle the args and return value right.

Also updates tests, so please accept hrydgard/pspautotests#28 first.

I learned some interesting things while testing this:
- Both my PSP-2000 and PSP-3000, while running psplink, fire some interrupt pretty frequently (more frequently than vblank, so maybe usb or something?), which made testing this more confusing at first.
- Even while interrupts are suspended, rescheduling sometimes happens - e.g. using `sceKernelDelayThread()` (I suspect it just doesn't reschedule unless the current thread goes into a waiting state...)
- A simple spin loop seems to take MUCH longer on hardware than PPSSPP, but I think this is because of that weird interrupt that keeps running.

-[Unknown]
