### PR TITLE
Revert incorrect warning fix

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -587,7 +587,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff)
 	case GE_CMD_CALL: 
 		{
 			u32 retval = dcontext.pc + 4;
-			if (stackptr == ARRAY_SIZE(stack) - 1) {
+			if (stackptr == ARRAY_SIZE(stack)) {
 				ERROR_LOG(G3D, "CALL: Stack full!");
 			} else {
 				stack[stackptr++] = retval;


### PR DESCRIPTION
Darn, this one I read wrong.  It was telling me stack could have a bad index and so I believed it too readily, sorry.

Fixes latest comments of #198.

-[Unknown]
