### PR TITLE
Windows CLI

### DIFF
--- a/Common/CommonPaths.h
+++ b/Common/CommonPaths.h
@@ -100,7 +100,7 @@
 #define LOGGER_CONFIG	"Logger.ini"
 
 // Files in the directory returned by GetUserPath(D_LOGS_IDX)
-#define MAIN_LOG	"dolphin.log"
+#define MAIN_LOG	"ppsspp.log"
 
 // Sys files
 #define TOTALDB		"totaldb.dsy"

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -179,6 +179,8 @@ public:
 	static void Init();
 	static void Shutdown();
 
+	void ChangeFileLog(const char *filename);
+
   void SaveConfig(IniFile::Section *section);
   void LoadConfig(IniFile::Section *section);
 };

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -46,6 +46,7 @@ namespace MainWindow
 	HWND hwndGameList;
 	HMENU menu;
 	BOOL skinMode = FALSE;
+	CoreState nextState = CORE_POWERDOWN;
 
 	HINSTANCE hInst;
 
@@ -244,7 +245,6 @@ namespace MainWindow
 		switch (message) 
 		{
 		case WM_CREATE:
-			PostMessage(hWnd, WM_COMMAND, ID_FILE_LOAD, 0);
 			break;
 
 		case WM_MOVE:
@@ -467,7 +467,7 @@ namespace MainWindow
 					memoryWindow[0]->Show(true);
 				break;
 			case ID_DEBUG_LOG:
-        LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
+				LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
 				break;
 
 			//////////////////////////////////////////////////////////////////////////
@@ -617,6 +617,9 @@ namespace MainWindow
 				disasmWindow[0]->NotifyMapLoaded();
 			if (memoryWindow[0])
 				memoryWindow[0]->NotifyMapLoaded();
+
+			if (nextState == CORE_RUNNING)
+				PostMessage(hwndMain, WM_COMMAND, ID_EMULATION_RUN, 0);
 			break;
 
 		default:
@@ -760,6 +763,11 @@ namespace MainWindow
 			sprintf(temp, "%s - %s", text, programname);
 			SetWindowText(hwndMain,temp);
 		}
+	}
+
+	void SetNextState(CoreState state)
+	{
+		nextState = state;
 	}
 
 	HINSTANCE GetHInstance()

--- a/Windows/WndMainWindow.h
+++ b/Windows/WndMainWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <windows.h>
+#include <Core/Core.h>
 
 namespace MainWindow
 {
@@ -14,6 +15,8 @@ namespace MainWindow
 	HINSTANCE GetHInstance();
 	HWND GetDisplayHWND();
 	void SetPlaying(const char*text);
+	void BrowseAndBoot();
+	void SetNextState(CoreState state);
 	void _ViewFullScreen(HWND hWnd);
 	void _ViewNormal(HWND hWnd);
 }

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -52,6 +52,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	Common::EnableCrashingOnCrashes();
 
 	const char *fileToStart = NULL;
+	const char *fileToLog = NULL;
 	bool showLog = false;
 	bool autoRun = true;
 
@@ -59,14 +60,14 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	VFSRegister("", new DirectoryAssetReader("assets/"));
 	VFSRegister("", new DirectoryAssetReader(""));
 
-	for (int i = 1; i < __argc; i++)
+	for (int i = 1; i < __argc; ++i)
 	{
-		if (__targv[i][0] == '\0')
+		if (__argv[i][0] == '\0')
 			continue;
 
-		if (__targv[i][0] == '-')
+		if (__argv[i][0] == '-')
 		{
-			switch (__targv[i][1])
+			switch (__argv[i][1])
 			{
 			case 'j':
 				g_Config.iCpuCore = CPU_JIT;
@@ -80,11 +81,17 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			case 's':
 				autoRun = false;
 				break;
+			case '-':
+				if (!strcmp(__argv[i], "--log") && i < __argc - 1)
+					fileToLog = __argv[++i];
+				if (!strncmp(__argv[i], "--log=", strlen("--log=")) && strlen(__argv[i]) > strlen("--log="))
+					fileToLog = __argv[i] + strlen("--log=");
+				break;
 			}
 		}
 		else if (fileToStart == NULL)
 		{
-			fileToStart = __targv[i];
+			fileToStart = __argv[i];
 			if (!File::Exists(fileToStart))
 			{
 				fprintf(stderr, "File not found: %s\n", fileToStart);
@@ -127,6 +134,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	MainWindow::UpdateMenus();
 
 	LogManager::Init();
+	if (fileToLog != NULL)
+		LogManager::GetInstance()->ChangeFileLog(fileToLog);
 	bool hidden = false;
 #ifndef _DEBUG
 	hidden = true;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -53,8 +53,12 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	const char *fileToStart = NULL;
 	const char *fileToLog = NULL;
-	bool showLog = false;
+	bool hideLog = true;
 	bool autoRun = true;
+
+#ifdef _DEBUG
+	hideLog = false;
+#endif
 
 	g_Config.Load();
 	VFSRegister("", new DirectoryAssetReader("assets/"));
@@ -79,7 +83,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				g_Config.iCpuCore = CPU_FASTINTERPRETER;
 				break;
 			case 'l':
-				showLog = true;
+				hideLog = false;
 				break;
 			case 's':
 				autoRun = false;
@@ -139,11 +143,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	LogManager::Init();
 	if (fileToLog != NULL)
 		LogManager::GetInstance()->ChangeFileLog(fileToLog);
-	bool hidden = false;
-#ifndef _DEBUG
-	hidden = true;
-#endif
-	LogManager::GetInstance()->GetConsoleListener()->Open(hidden, 150, 120, "PPSSPP Debug Console");
+	LogManager::GetInstance()->GetConsoleListener()->Open(hideLog, 150, 120, "PPSSPP Debug Console");
 	LogManager::GetInstance()->SetLogLevel(LogTypes::G3D, LogTypes::LERROR);
 	if (fileToStart != NULL)
 	{
@@ -156,8 +156,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	else
 		MainWindow::BrowseAndBoot();
 
-	if (showLog)
-		PostMessage(hwndMain, WM_COMMAND, ID_DEBUG_LOG, 0);
 	if (autoRun)
 		MainWindow::SetNextState(CORE_RUNNING);
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -75,6 +75,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			case 'i':
 				g_Config.iCpuCore = CPU_INTERPRETER;
 				break;
+			case 'f':
+				g_Config.iCpuCore = CPU_FASTINTERPRETER;
+				break;
 			case 'l':
 				showLog = true;
 				break;

--- a/android/jni/NativeApp.cpp
+++ b/android/jni/NativeApp.cpp
@@ -185,6 +185,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 			case 'j':
 				g_Config.iCpuCore = CPU_JIT;
 				break;
+			case 'f':
+				g_Config.iCpuCore = CPU_FASTINTERPRETER;
+				break;
 			case 'i':
 				g_Config.iCpuCore = CPU_INTERPRETER;
 				break;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -74,8 +74,8 @@ void printUsage(const char *progname, const char *reason)
 	if (reason != NULL)
 		fprintf(stderr, "Error: %s\n\n", reason);
 	fprintf(stderr, "PPSSPP Headless\n");
-	fprintf(stderr, "This is primarily meant for non-inactive test tool.\n\n");
-	fprintf(stderr, "Usage: %s [options] file.elf\n\n", progname);
+	fprintf(stderr, "This is primarily meant as a non-interactive test tool.\n\n");
+	fprintf(stderr, "Usage: %s file.elf [options]\n\n", progname);
 	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "  -m, --mount umd.cso   mount iso on umd:\n");
 	fprintf(stderr, "  -l, --log             full log output, not just emulated printfs\n");


### PR DESCRIPTION
Basically implements #143.  Wanted it while debugging so figured I'd implement it really quick, similar to Android arguments.

I'm sure it could be better.  Current behavior:
- -j, -i, -f work like headless/Android.
- -l (show log) shows the log window by default.
- a single filename is loaded like in Android.
- the -s switch allows you to load a game without running it automatically.
- --log filename.log or --log=filename.log saves to the specified log file.

The changes shouldn't, but could, affect Android and I don't have anything to test that at the moment, unfortunately.

-[Unknown]
