### PR TITLE
Don't autorun when there's no file (windows cli)

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -156,7 +156,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	else
 		MainWindow::BrowseAndBoot();
 
-	if (autoRun)
+	if (autoRun && fileToLog != NULL)
 		MainWindow::SetNextState(CORE_RUNNING);
 
 	//so.. we're at the message pump of the GUI thread


### PR DESCRIPTION
I hadn't intended to make it autorun when you open a file without using cli (although I don't entirely hate it), this reverts that change.

-[Unknown]
