### PR TITLE
Some crashfixes for OSK, release crash investigation

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -108,7 +108,7 @@ void PSPOskDialog::RenderKeyboard()
 	for (int i = 0; i < limit; ++i)
 	{
 		u32 color = 0xFFFFFFFF;
-		if (i < inputChars.size())
+		if (i < (int) inputChars.size())
 			temp[0] = inputChars[i];
 		else if (i == inputChars.size())
 		{
@@ -146,7 +146,7 @@ void PSPOskDialog::RenderKeyboard()
 
 void PSPOskDialog::Update()
 {
-	buttons = __CtrlPeekButtons();
+	buttons = __CtrlReadLatch();
 	int selectedRow = selectedChar / (KEYSPERROW-1);
 	int selectedExtra = selectedChar % (KEYSPERROW-1);
 
@@ -179,7 +179,7 @@ void PSPOskDialog::Update()
 		}
 		else if (IsButtonPressed(CTRL_DOWN))
 		{
-			selectedChar -=10;
+			selectedChar -= 10;
 		}
 		else if (IsButtonPressed(CTRL_LEFT))
 		{
@@ -202,7 +202,7 @@ void PSPOskDialog::Update()
 		// TODO : Dialogs should take control over input and not send them to the game while displaying
 		if (IsButtonPressed(CTRL_CROSS))
 		{
-			if (inputChars.size() < limit)
+			if ((int) inputChars.size() < limit)
 				inputChars += oskKeys[selectedRow][selectedExtra];
 		}
 		else if (IsButtonPressed(CTRL_CIRCLE))
@@ -224,7 +224,7 @@ void PSPOskDialog::Update()
 	for (int i = 0; i < limit; ++i)
 	{
 		u16 value = 0;
-		if (i < inputChars.size())
+		if (i < (int) inputChars.size())
 			value = 0x0000 ^ inputChars[i];
 		Memory::Write_U16(value, oskData.outtextPtr + (2 * i));
 	}

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -20,9 +20,9 @@
 #include "../HLE/sceCtrl.h"
 
 #define NUMKEYROWS 4
-#define KEYSPERROW 13
-#define NUMBEROFVALIDCHARS 44
-const char oskKeys[NUMKEYROWS][KEYSPERROW] = 
+#define KEYSPERROW 12
+#define NUMBEROFVALIDCHARS (KEYSPERROW * NUMKEYROWS)
+const char oskKeys[NUMKEYROWS][KEYSPERROW + 1] =
 {
 	{'1','2','3','4','5','6','7','8','9','0','-','+','\0'}, 
 	{'Q','W','E','R','T','Y','U','I','O','P','[',']','\0'},
@@ -92,8 +92,8 @@ int PSPOskDialog::Init(u32 oskPtr)
 
 void PSPOskDialog::RenderKeyboard()
 {
-	int selectedRow = selectedChar / (KEYSPERROW-1);
-	int selectedExtra = selectedChar % (KEYSPERROW-1);
+	int selectedRow = selectedChar / KEYSPERROW;
+	int selectedExtra = selectedChar % KEYSPERROW;
 	char SelectedLine[KEYSPERROW + 1];
 
 	char temp[2];
@@ -147,8 +147,8 @@ void PSPOskDialog::RenderKeyboard()
 void PSPOskDialog::Update()
 {
 	buttons = __CtrlReadLatch();
-	int selectedRow = selectedChar / (KEYSPERROW-1);
-	int selectedExtra = selectedChar % (KEYSPERROW-1);
+	int selectedRow = selectedChar / KEYSPERROW;
+	int selectedExtra = selectedChar % KEYSPERROW;
 
 	int limit = oskData.outtextlimit;
 	// TODO: Test more thoroughly.  Encountered a game where this was 0.
@@ -175,11 +175,11 @@ void PSPOskDialog::Update()
 
 		if (IsButtonPressed(CTRL_UP))
 		{
-			selectedChar += 10;
+			selectedChar -= KEYSPERROW;
 		}
 		else if (IsButtonPressed(CTRL_DOWN))
 		{
-			selectedChar -= 10;
+			selectedChar += KEYSPERROW;
 		}
 		else if (IsButtonPressed(CTRL_LEFT))
 		{
@@ -190,14 +190,7 @@ void PSPOskDialog::Update()
 			selectedChar++;
 		}
 
-		if (selectedChar < 0)
-		{
-			selectedChar = NUMBEROFVALIDCHARS;
-		}
-		if (selectedChar > NUMBEROFVALIDCHARS)
-		{
-			selectedChar = 0;
-		}
+		selectedChar = (selectedChar + NUMBEROFVALIDCHARS) % NUMBEROFVALIDCHARS;
 
 		// TODO : Dialogs should take control over input and not send them to the game while displaying
 		if (IsButtonPressed(CTRL_CROSS))

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -94,7 +94,6 @@ void PSPOskDialog::RenderKeyboard()
 {
 	int selectedRow = selectedChar / KEYSPERROW;
 	int selectedExtra = selectedChar % KEYSPERROW;
-	char SelectedLine[KEYSPERROW + 1];
 
 	char temp[2];
 	temp[1] = '\0';
@@ -103,6 +102,9 @@ void PSPOskDialog::RenderKeyboard()
 	// TODO: Test more thoroughly.  Encountered a game where this was 0.
 	if (limit <= 0)
 		limit = 16;
+
+	const float keyboardLeftSide = (480.0f - (16.0f * KEYSPERROW)) / 2.0f;
+	float previewLeftSide = (480.0f - (16.0f * limit)) / 2.0f;
 
 	PPGeDrawText(oskDesc.c_str(), 480/2, 20, PPGE_ALIGN_CENTER, 0.5f, 0xFFFFFFFF);
 	for (int i = 0; i < limit; ++i)
@@ -118,29 +120,23 @@ void PSPOskDialog::RenderKeyboard()
 		else
 			temp[0] = '_';
 
-		PPGeDrawText(temp, 20.0f + (i * 16.0f), 40, NULL, 0.5f, color);
+		PPGeDrawText(temp, previewLeftSide + (i * 16.0f), 40.0f, NULL, 0.5f, color);
 	}
-	for (int row = 0; row < NUMKEYROWS; row++)
+	for (int row = 0; row < NUMKEYROWS; ++row)
 	{
-		u32 color = 0xFFFFFFFF;
-		if (selectedRow == row)
-			color = 0xFF7f7f7f;
-		PPGeDrawText(oskKeys[row], 20.0f, 70.0f + (25.0f * row), NULL, 0.6f, color);
-	}
-	for (int selectedItemCounter = 0; selectedItemCounter < KEYSPERROW; selectedItemCounter++ )
-	{
-		if (selectedItemCounter!=selectedExtra)
+		for (int col = 0; col < KEYSPERROW; ++col)
 		{
-			SelectedLine[selectedItemCounter] = oskKeys[selectedRow][selectedItemCounter];
-		}
-		else
-		{
-			SelectedLine[selectedItemCounter] = '_';
-		}
-	}
+			u32 color = 0xFFFFFFFF;
+			if (selectedRow == row && col == selectedExtra)
+				color = 0xFF7f7f7f;
 
-	SelectedLine[KEYSPERROW] = '\0';
-	PPGeDrawText(SelectedLine, 20, 71.0f + (25.0f * selectedRow), NULL, 0.6f, 0xFFFFFFFF);
+			temp[0] = oskKeys[row][col];
+			PPGeDrawText(temp, keyboardLeftSide + (16.0f * col), 70.0f + (25.0f * row), NULL, 0.6f, color);
+
+			if (selectedRow == row && col == selectedExtra)
+				PPGeDrawText("_", keyboardLeftSide + (16.0f * col), 70.0f + (25.0f * row), NULL, 0.6f, 0xFFFFFFFF);
+		}
+	}
 
 }
 

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -86,6 +86,9 @@ int PSPOskDialog::Init(u32 oskPtr)
 		return -1;
 	}
 
+	// Eat any keys pressed before the dialog inited.
+	__CtrlReadLatch();
+
 	return 0;
 }
 

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -183,10 +183,14 @@ void PSPOskDialog::Update()
 		else if (IsButtonPressed(CTRL_LEFT))
 		{
 			selectedChar--;
+			if (((selectedChar + KEYSPERROW) % KEYSPERROW) == KEYSPERROW - 1)
+				selectedChar += KEYSPERROW;
 		}
 		else if (IsButtonPressed(CTRL_RIGHT))
 		{
 			selectedChar++;
+			if ((selectedChar % KEYSPERROW) == 0)
+				selectedChar -= KEYSPERROW;
 		}
 
 		selectedChar = (selectedChar + NUMBEROFVALIDCHARS) % NUMBEROFVALIDCHARS;

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -104,7 +104,7 @@ void PSPOskDialog::RenderKeyboard()
 {
 	int selectedRow = selectedChar / (KEYSPERROW-1);
 	int selectedExtra = selectedChar % (KEYSPERROW-1);
-	char SelectedLine[KEYSPERROW];
+	char SelectedLine[KEYSPERROW + 1];
 
 	char temp[2];
 	temp[1] = '\0';

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -157,8 +157,7 @@ private:
 	std::string oskOuttext;
 	int oskParamsAddr;
 
-	int currentInputChar;
 	int selectedChar;
-
+	std::string inputChars;
 };
 

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -157,7 +157,6 @@ private:
 	std::string oskOuttext;
 	int oskParamsAddr;
 
-	char inputChars[255]; // must be a better way of doing this...
 	int currentInputChar;
 	int selectedChar;
 

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -125,6 +125,13 @@ u32 __CtrlPeekButtons()
 	return ctrlCurrent.buttons;
 }
 
+u32 __CtrlReadLatch()
+{
+	u32 ret = latch.btnMake;
+	__CtrlResetLatch();
+	return ret;
+}
+
 // Functions so that the rest of the emulator can control what the sceCtrl interface should return
 // to the game:
 

--- a/Core/HLE/sceCtrl.h
+++ b/Core/HLE/sceCtrl.h
@@ -41,3 +41,4 @@ void __CtrlSetAnalog(float x, float y);
 
 // For use by internal UI like MsgDialog
 u32 __CtrlPeekButtons();
+u32 __CtrlReadLatch();


### PR DESCRIPTION
Fixes #229, but I'm not satisfied with it.  This was only crashing in Release.  It's one of _those_.

I tested with Trails in the Sky, but a bunch of games were crashing in the ELF loader code when 8586bb3 was applied.

Maybe I'm missing something, but I tried:
- Allocating the entire OSK dialog on the heap instead (thinking maybe too much global mem?)
- Using a std::string instead of inputChars (which was imho cleaner.)
- Allocating just inputChars on the heap (just a ptr should be okay, right?)

All crashed same place.  I think it was even crashing as a global std::string, so I reverted and just moved the thing out of the class.

Note that the OSK code is not even running.  PPSSPP crashes prior to even starting the game.

-[Unknown]
