### PR TITLE
Implement sceCtrlSetSamplingCycle()

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -297,6 +297,7 @@ u32 sceCtrlSetSamplingMode(u32 mode)
 int sceCtrlGetSamplingMode(u32 modePtr)
 {
 	u32 retVal = analogEnabled == true ? CTRL_MODE_ANALOG : CTRL_MODE_DIGITAL;
+	DEBUG_LOG(HLE, "%d=sceCtrlGetSamplingMode(%i)", retVal);
 
 	if (Memory::IsValidAddress(modePtr))
 		Memory::Write_U32(retVal, modePtr);
@@ -304,10 +305,16 @@ int sceCtrlGetSamplingMode(u32 modePtr)
 	return 0;
 }
 
-void sceCtrlSetIdleCancelThreshold()
+int sceCtrlSetIdleCancelThreshold(int idleReset, int idleBack)
 {
-	ERROR_LOG(HLE,"UNIMPL sceCtrlSetIdleCancelThreshold");
-	RETURN(0);
+	ERROR_LOG(HLE, "UNIMPL sceCtrlSetIdleCancelThreshold(%d, %d)", idleReset, idleBack);
+	return 0;
+}
+
+int sceCtrlGetIdleCancelThreshold(u32 idleResetPtr, u32 idleBackPtr)
+{
+	ERROR_LOG(HLE, "UNIMPL sceCtrlSetIdleCancelThreshold(%08x, %08x)", idleResetPtr, idleBackPtr);
+	return 0;
 }
 
 void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
@@ -393,8 +400,8 @@ static const HLEFunction sceCtrl[] =
 	{0xAF5960F3, 0, "sceCtrl_AF5960F3"},
 	{0xA68FD260, 0, "sceCtrlClearRapidFire"},
 	{0x6841BE1A, 0, "sceCtrlSetRapidFire"},
-	{0xa7144800, WrapV_V<sceCtrlSetIdleCancelThreshold>, "sceCtrlSetIdleCancelThreshold"},
-	{0x687660fa, 0, "sceCtrlGetIdleCancelThreshold"},
+	{0xa7144800, WrapI_II<sceCtrlSetIdleCancelThreshold>, "sceCtrlSetIdleCancelThreshold"},
+	{0x687660fa, WrapI_UU<sceCtrlGetIdleCancelThreshold>, "sceCtrlGetIdleCancelThreshold"},
 };	
 
 void Register_sceCtrl()

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -76,6 +76,8 @@ static CtrlLatch latch;
 static int ctrlIdleReset = -1;
 static int ctrlIdleBack = -1;
 
+static u32 ctrlCycle = 0;
+
 static std::vector<SceUID> waitingThreads;
 static std::recursive_mutex ctrlMutex;
 
@@ -258,27 +260,40 @@ void __CtrlInit()
 
 	ctrlIdleReset = -1;
 	ctrlIdleBack = -1;
+	ctrlCycle = 0;
 
 	waitingThreads.clear();
 }
 
 u32 sceCtrlSetSamplingCycle(u32 cycle)
 {
+	WARN_LOG(HLE, "FAKE sceCtrlSetSamplingCycle(%u)", cycle);
+
+	if ((cycle > 0 && cycle < 5555) || cycle > 20000)
+	{
+		WARN_LOG(HLE, "SCE_KERNEL_ERROR_INVALID_VALUE=sceCtrlSetSamplingCycle(%u)", cycle);
+		return SCE_KERNEL_ERROR_INVALID_VALUE;
+	}
+
+	u32 prev = ctrlCycle;
+	ctrlCycle = cycle;
+
 	if (cycle == 0)
 	{
-		// TODO: Change to vblank when we support something else.
-		DEBUG_LOG(HLE, "sceCtrlSetSamplingCycle(%u)", cycle);
+		// TODO: Cancel the timer.
 	}
 	else
 	{
-		ERROR_LOG(HLE, "UNIMPL sceCtrlSetSamplingCycle(%u)", cycle);
+		// TODO: Setup the timer.
 	}
-	return 0;
+	return prev;
 }
 
 int sceCtrlGetSamplingCycle(u32 cyclePtr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceCtrlSetSamplingCycle(%08x)", cyclePtr);
+	DEBUG_LOG(HLE, "sceCtrlSetSamplingCycle(%08x)", cyclePtr);
+	if (Memory::IsValidAddress(cyclePtr))
+		Memory::Write_U32(ctrlCycle, cyclePtr);
 	return 0;
 }
 

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -255,14 +255,11 @@ void __CtrlInit()
 
 	for (int i = 0; i < NUM_CTRL_BUFFERS; i++)
 		memcpy(&ctrlBufs[i], &ctrlCurrent, sizeof(_ctrl_data));
-}
 
-void sceCtrlInit()
-{
-	__CtrlInit();
+	ctrlIdleReset = -1;
+	ctrlIdleBack = -1;
 
-	DEBUG_LOG(HLE,"sceCtrlInit");	
-	RETURN(0);
+	waitingThreads.clear();
 }
 
 u32 sceCtrlSetSamplingCycle(u32 cycle)
@@ -406,7 +403,7 @@ u32 sceCtrlReadLatch(u32 latchDataPtr)
 
 static const HLEFunction sceCtrl[] = 
 {
-	{0x3E65A0EA, WrapV_V<sceCtrlInit>, "sceCtrlInit"}, //(int unknown), init with 0
+	{0x3E65A0EA, 0, "sceCtrlInit"}, //(int unknown), init with 0
 	{0x1f4011e6, WrapU_U<sceCtrlSetSamplingMode>, "sceCtrlSetSamplingMode"}, //(int on);
 	{0x6A2774F3, WrapU_U<sceCtrlSetSamplingCycle>, "sceCtrlSetSamplingCycle"},
 	{0x02BAAD91, WrapI_U<sceCtrlGetSamplingCycle>,"sceCtrlGetSamplingCycle"},

--- a/test.py
+++ b/test.py
@@ -49,7 +49,9 @@ tests_good = [
   "cpu/fpu/fpu",
 
   "ctrl/ctrl",
+  "ctrl/idle/idle",
   "ctrl/sampling/sampling",
+  "ctrl/sampling2/sampling2",
   "display/display",
   "dmac/dmactest",
   "loader/bss/bss",


### PR DESCRIPTION
Updates tests, so please accept hrydgard/pspautotests#30 first.

The new test isn't super fast (although still faster than malloc, etc.) so I can move it into a separate array if you like.  I was thinking of profiling the test runner or making it run multiple tests at once to speed things up...

Anyhow, this just makes sampling more frequent.  For games that use it (seems like only newer games), they'll typically use the lowest setting (5555) or 180 times per second.  For those games, the responsiveness of controls should improve.

It'll also affect timing issues when sceCtrlReadBufferPositive() has to wait (since for those games it'll now wait 1/3 as long for a new buffer to come in, and potentially reschedule less.)

-[Unknown]
