### PR TITLE
Fix audio crash in FF type-0 

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -215,7 +215,7 @@ void SasInstance::Mix(u32 outAddr) {
 			// Figure out number of samples to read.
 			int curSample = voice.samplePos / PSP_SAS_PITCH_BASE;
 			int lastSample = (voice.samplePos + grainSize * voice.pitch) / PSP_SAS_PITCH_BASE;
-			int numSamples = lastSample - curSample;
+			u32 numSamples = lastSample - curSample;
 			if (numSamples > grainSize * 4) {
 				ERROR_LOG(SAS, "numSamples too large, clamping: %i vs %i", numSamples, grainSize * 4);
 				numSamples = grainSize * 4;


### PR DESCRIPTION
The game will crash few minutes in-game at this line

voice.resampleHist[0] = resampleBuffer[2 + numSamples - 2];

Setting back int to u32 fix the crash 

u32 numSamples = lastSample - curSample;
