### PR TITLE
Minor media engine tweaks

### DIFF
--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -294,9 +294,9 @@
     <ClCompile Include="HLE\sceImpose.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
-<<<<<<< HEAD
     <ClCompile Include="HW\MediaEngine.cpp">
-=======
+      <Filter>HW</Filter>
+    </ClCompile>
     <ClCompile Include="Util\PPGeDraw.cpp">
       <Filter>Util</Filter>
     </ClCompile>
@@ -346,7 +346,6 @@
       <Filter>Dialog</Filter>
     </ClCompile>
     <ClCompile Include="HW\SasAudio.cpp">
->>>>>>> master
       <Filter>HW</Filter>
     </ClCompile>
     <ClCompile Include="HLE\sceUsb.cpp">
@@ -592,6 +591,8 @@
       <Filter>HLE\Libraries</Filter>
     </ClInclude>
     <ClInclude Include="HW\MediaEngine.h">
+      <Filter>HW</Filter>
+    </ClInclude>
     <ClInclude Include="Util\PPGeDraw.h">
       <Filter>Util</Filter>
     </ClInclude>

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -121,6 +121,10 @@ template<int func(u32, u32, u32, u32)> void WrapI_UUUU() {
 	RETURN(retval);
 }
 
+template<int func(u32, u32, u32, u32, u32)> void WrapI_UUUUU() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
+	RETURN(retval);
+}
 
 template<int func()> void WrapI_V() {
 	int retval = func();

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -52,6 +52,7 @@
 #include "sceUmd.h"
 #include "sceSsl.h"
 #include "sceSas.h"
+#include "scePsmf.h"
 
 #include "../Util/PPGeDraw.h"
 
@@ -86,6 +87,7 @@ void __KernelInit()
 	__UtilityInit();
 	__UmdInit();
 	__MpegInit(PSP_CoreParameter().useMediaEngine);
+	__PsmfInit();
 	__CtrlInit();
 	__SslInit();
 
@@ -108,6 +110,7 @@ void __KernelShutdown()
 	kernelObjects.Clear();
 
 	__MpegShutdown();
+	__PsmfShutdown();
 	__PPGeShutdown();
 
 	__GeShutdown();

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -300,6 +300,8 @@ u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 f
 	ctx->mpegRingbufferAddr = ringbufferAddr;
 	ctx->videoFrameCount = 0;
 	ctx->audioFrameCount = 0;
+	// TODO: What's the actual default?
+	ctx->videoPixelMode = 0;
 	ctx->avcRegistered = false;
 	ctx->atracRegistered = false;
 	ctx->pcmRegistered = false;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -265,9 +265,9 @@ u32 sceMpegRingbufferConstruct(u32 ringbufferAddr, u32 numPackets, u32 data, u32
 
 u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop)
 {
-	INFO_LOG(HLE, "sceMpegCreate(%i, %08x, %i, %08x, %i, %i, %i)",
-		mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
 	if (size < MPEG_MEMSIZE) {
+		WARN_LOG(HLE, "ERROR_MPEG_NO_MEMORY=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)",
+			mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
 		return ERROR_MPEG_NO_MEMORY;
 	}
 
@@ -308,6 +308,9 @@ u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 f
 	// Detailed "analysis" is done later in Query* for some reason.
 	ctx->isAnalyzed = false;
 	ctx->mediaengine = new MediaEngine();
+
+	INFO_LOG(HLE, "%08x=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)",
+		mpegHandle, mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
 	return 0;
 }
 
@@ -619,10 +622,10 @@ void sceMpegAvcDecodeStopYCbCr()
 	RETURN(0);
 }
 
-void sceMpegAvcDecodeYCbCr()
+int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 {
-	WARN_LOG(HLE, "HACK sceMpegAvcDecodeYCbCr(...)");
-	RETURN(0);
+	WARN_LOG(HLE, "HACK sceMpegAvcDecodeYCbCr(%08x, %08x, %08x, %08x)", mpeg, auAddr, bufferAddr, initAddr);
+	return 0;
 }
 
 u32 sceMpegAvcDecodeFlush(u32 mpeg)
@@ -969,7 +972,7 @@ const HLEFunction sceMpeg[] =
 	{0xd7a29f46,WrapU_I<sceMpegRingbufferQueryMemSize>,"sceMpegRingbufferQueryMemSize"},
 	{0x769BEBB6,sceMpegRingbufferQueryPackNum,"sceMpegRingbufferQueryPackNum"},
 	{0x211a057c,WrapI_UUUUU<sceMpegAvcQueryYCbCrSize>,"sceMpegAvcQueryYCbCrSize"},
-	{0xf0eb1125,sceMpegAvcDecodeYCbCr,"sceMpegAvcDecodeYCbCr"},
+	{0xf0eb1125,WrapI_UUUU<sceMpegAvcDecodeYCbCr>,"sceMpegAvcDecodeYCbCr"},
 	{0xf2930c9c,sceMpegAvcDecodeStopYCbCr,"sceMpegAvcDecodeStopYCbCr"},
 	{0x67179b1b,sceMpegAvcInitYCbCr,"sceMpegAvcInitYCbCr"},
 	{0x0558B075,sceMpegAvcCopyYCbCr,"sceMpegAvcCopyYCbCr"},

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -713,7 +713,7 @@ void PostPutAction::run() {
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringAddr_, &ringbuffer);
 
-	MpegContext *ctx = getMpegCtx(Memory::Read_U32(ringbuffer.mpeg));
+	MpegContext *ctx = getMpegCtx(ringbuffer.mpeg);
 
 	int packetsAdded = currentMIPS->r[2];
 	if (packetsAdded > 0) {
@@ -746,9 +746,9 @@ u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 
 	numPackets = std::min(numPackets, available);
 
-	MpegContext *ctx = getMpegCtx(Memory::Read_U32(ringbuffer.mpeg));
+	MpegContext *ctx = getMpegCtx(ringbuffer.mpeg);
 	if (!ctx) {
-		WARN_LOG(HLE, "sceMpegRingbufferPut(%08x, %i, %i): Bad mpeg context %08x", ringbufferAddr, numPackets, available, Memory::Read_U32(ringbuffer.mpeg));
+		WARN_LOG(HLE, "sceMpegRingbufferPut(%08x, %i, %i): bad mpeg handle %08x", ringbufferAddr, numPackets, available, ringbuffer.mpeg);
 		return 0;
 	}
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -236,7 +236,10 @@ void __MpegInit(bool useMediaEngine_) {
 void __MpegShutdown() {
 	std::map<u32, MpegContext *>::iterator it, end;
 	for (it = mpegMap.begin(), end = mpegMap.end(); it != end; ++it)
+	{
+		delete it->second->mediaengine;
 		delete it->second;
+	}
 	mpegMap.clear();
 }
 
@@ -384,7 +387,11 @@ u32 sceMpegQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 	DEBUG_LOG(HLE, "sceMpegQueryStreamSize(%08x, %08x)", bufferAddr, sizeAddr);
 
 	MpegContext temp;
+	temp.mediaengine = new MediaEngine();
+
 	AnalyzeMpeg(bufferAddr, &temp);
+
+	delete temp.mediaengine;
 
 	if (temp.mpegMagic != PSMF_MAGIC) {
 		ERROR_LOG(HLE, "sceMpegQueryStreamOffset: Bad PSMF magic");

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -164,7 +164,8 @@ Psmf::Psmf(u32 data) {
 
 std::map<u32, Psmf *> psmfMap;
 
-Psmf *getPsmf(u32 psmf) {
+Psmf *getPsmf(u32 psmf)
+{
 	auto iter = psmfMap.find(psmf);
 	if (iter != psmfMap.end())
 		return iter->second;
@@ -172,22 +173,32 @@ Psmf *getPsmf(u32 psmf) {
 		return 0;
 }
 
+void __PsmfInit()
+{
+}
+
+void __PsmfShutdown()
+{
+	for (auto it = psmfMap.begin(), end = psmfMap.end(); it != end; ++it)
+		delete it->second;
+	psmfMap.clear();
+}
 
 u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData)
 {
-  INFO_LOG(HLE, "scePsmfSetPsmf(%08x, %08x)", psmfStruct, psmfData);
+	INFO_LOG(HLE, "scePsmfSetPsmf(%08x, %08x)", psmfStruct, psmfData);
 
 	Psmf *psmf = new Psmf(psmfData);
 	psmfMap[psmfStruct] = psmf;
 
-  PsmfData data = {0};
-  data.version = psmf->version;
-  data.headerSize = 0x800;
+	PsmfData data = {0};
+	data.version = psmf->version;
+	data.headerSize = 0x800;
 	data.streamSize = psmf->streamSize;
 	data.streamNum = psmf->numStreams;
 	data.headerOffset = psmf->headerOffset;
-  Memory::WriteStruct(psmfStruct, &data);
-  return 0;
+	Memory::WriteStruct(psmfStruct, &data);
+	return 0;
 }
 
 u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
@@ -197,8 +208,8 @@ u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
 		ERROR_LOG(HLE, "scePsmfGetNumberOfStreams - invalid psmf");
 		return ERROR_PSMF_NOT_FOUND;
 	}
-  INFO_LOG(HLE, "%i=scePsmfGetNumberOfStreams(%08x)", psmf->getNumStreams(), psmf);
-  return psmf->getNumStreams();
+	INFO_LOG(HLE, "%i=scePsmfGetNumberOfStreams(%08x)", psmf->getNumStreams(), psmf);
+	return psmf->getNumStreams();
 }
 
 u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, u32 streamType)
@@ -208,14 +219,14 @@ u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, u32 streamType)
 		ERROR_LOG(HLE, "scePsmfGetNumberOfSpecificStreams - invalid psmf");
 		return ERROR_PSMF_NOT_FOUND;
 	}
-  INFO_LOG(HLE, "scePsmfGetNumberOfSpecificStreams(%08x, %08x)", psmfStruct, streamType);
-  return 1;
+	INFO_LOG(HLE, "scePsmfGetNumberOfSpecificStreams(%08x, %08x)", psmfStruct, streamType);
+	return 1;
 }
 
 u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u32 channel)
 {
-  ERROR_LOG(HLE, "UNIMPL scePsmfSpecifyStreamWithStreamType(%08x, %08x, %i)", psmfStruct, streamType, channel);
-  return 0;
+	ERROR_LOG(HLE, "UNIMPL scePsmfSpecifyStreamWithStreamType(%08x, %08x, %i)", psmfStruct, streamType, channel);
+	return 0;
 }
 
 u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32 typeNum)
@@ -226,7 +237,7 @@ u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32
 
 u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr)
 {
-  INFO_LOG(HLE, "scePsmfGetVideoInfo(%08x, %08x)", psmfStruct, videoInfoAddr);
+	INFO_LOG(HLE, "scePsmfGetVideoInfo(%08x, %08x)", psmfStruct, videoInfoAddr);
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(HLE, "scePsmfGetNumberOfSpecificStreams - invalid psmf");
@@ -236,12 +247,12 @@ u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr)
 		Memory::Write_U32(psmf->videoWidth, videoInfoAddr);
 		Memory::Write_U32(psmf->videoWidth, videoInfoAddr + 4);
 	}
-  return 0;
+	return 0;
 }
 
 u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr)
 {
-  INFO_LOG(HLE, "scePsmfGetAudioInfo(%08x, %08x)", psmfStruct, audioInfoAddr);
+	INFO_LOG(HLE, "scePsmfGetAudioInfo(%08x, %08x)", psmfStruct, audioInfoAddr);
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(HLE, "scePsmfGetNumberOfSpecificStreams - invalid psmf");
@@ -251,31 +262,31 @@ u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr)
 		Memory::Write_U32(psmf->audioChannels, audioInfoAddr);
 		Memory::Write_U32(psmf->audioFrequency, audioInfoAddr + 4);
 	}
-  return 0;
+	return 0;
 }
 
 
 const HLEFunction scePsmf[] =
 {
-  {0xc22c8327,&WrapU_UU<scePsmfSetPsmf>,"scePsmfSetPsmfFunction"},
-  {0xC7DB3A5B,0,"scePsmfGetCurrentStreamTypeFunction"},
-  {0x28240568,0,"scePsmfGetCurrentStreamNumberFunction"},
-  {0x1E6D9013,&WrapU_UUU<scePsmfSpecifyStreamWithStreamType>,"scePsmfSpecifyStreamWithStreamTypeFunction"},
+	{0xc22c8327,&WrapU_UU<scePsmfSetPsmf>,"scePsmfSetPsmfFunction"},
+	{0xC7DB3A5B,0,"scePsmfGetCurrentStreamTypeFunction"},
+	{0x28240568,0,"scePsmfGetCurrentStreamNumberFunction"},
+	{0x1E6D9013,&WrapU_UUU<scePsmfSpecifyStreamWithStreamType>,"scePsmfSpecifyStreamWithStreamTypeFunction"},
 	{0x0C120E1D,&WrapU_UUU<scePsmfSpecifyStreamWithStreamTypeNumber>,"scePsmfSpecifyStreamWithStreamTypeNumberFunction"},
 	{0x4BC9BDE0,0,"scePsmfSpecifyStreamFunction"},
-  {0x76D3AEBA,0,"scePsmfGetPresentationStartTimeFunction"},
-  {0xBD8AE0D8,0,"scePsmfGetPresentationEndTimeFunction"},
-  {0xEAED89CD,&WrapU_U<scePsmfGetNumberOfStreams>,"scePsmfGetNumberOfStreamsFunction"},
-  {0x7491C438,0,"scePsmfGetNumberOfEPentriesFunction"},
-  {0x0BA514E5,&WrapU_UU<scePsmfGetVideoInfo>,"scePsmfGetVideoInfoFunction"},
-  {0xA83F7113,&WrapU_UU<scePsmfGetAudioInfo>,"scePsmfGetAudioInfoFunction"},
-  {0x971A3A90,0,"scePsmfCheckEPmapFunction"},
-  {0x68d42328,&WrapU_UU<scePsmfGetNumberOfSpecificStreams>,"scePsmfGetNumberOfSpecificStreamsFunction"},
-  {0x5b70fcc1,0,"scePsmfQueryStreamOffsetFunction"},
-  {0x9553cc91,0,"scePsmfQueryStreamSizeFunction"},
-  {0xc7db3a5b,0,"scePsmfGetCurrentStreamTypeFunction"},
-  {0xB78EB9E9,0,"scePsmfGetHeaderSizeFunction"},
-  {0xA5EBFE81,0,"scePsmfGetStreamSizeFunction"},
+	{0x76D3AEBA,0,"scePsmfGetPresentationStartTimeFunction"},
+	{0xBD8AE0D8,0,"scePsmfGetPresentationEndTimeFunction"},
+	{0xEAED89CD,&WrapU_U<scePsmfGetNumberOfStreams>,"scePsmfGetNumberOfStreamsFunction"},
+	{0x7491C438,0,"scePsmfGetNumberOfEPentriesFunction"},
+	{0x0BA514E5,&WrapU_UU<scePsmfGetVideoInfo>,"scePsmfGetVideoInfoFunction"},
+	{0xA83F7113,&WrapU_UU<scePsmfGetAudioInfo>,"scePsmfGetAudioInfoFunction"},
+	{0x971A3A90,0,"scePsmfCheckEPmapFunction"},
+	{0x68d42328,&WrapU_UU<scePsmfGetNumberOfSpecificStreams>,"scePsmfGetNumberOfSpecificStreamsFunction"},
+	{0x5b70fcc1,0,"scePsmfQueryStreamOffsetFunction"},
+	{0x9553cc91,0,"scePsmfQueryStreamSizeFunction"},
+	{0xc7db3a5b,0,"scePsmfGetCurrentStreamTypeFunction"},
+	{0xB78EB9E9,0,"scePsmfGetHeaderSizeFunction"},
+	{0xA5EBFE81,0,"scePsmfGetStreamSizeFunction"},
 	{0xE1283895,0,"scePsmfGetPsmfVersionFunction"},
 };
 
@@ -292,29 +303,29 @@ void scePsmfPlayerReleasePsmf() {
 
 const HLEFunction scePsmfPlayer[] =
 {
-  {0x235d8787,scePsmfPlayerCreate,"scePsmfPlayerCreateFunction"},
-  {0x1078c008,0,"scePsmfPlayerStopFunction"},
-  {0x1e57a8e7,0,"scePsmfPlayerConfigPlayer"},
-  {0x2beb1569,0,"scePsmfPlayerBreak"},
-  {0x3d6d25a9,0,"scePsmfPlayerSetPsmfFunction"},
-  {0x3ea82a4b,0,"scePsmfPlayerGetAudioOutSize"},
-  {0x3ed62233,0,"scePsmfPlayerGetCurrentPts"},
-  {0x46f61f8b,0,"scePsmfPlayerGetVideoData"},
-  {0x68f07175,0,"scePsmfPlayerGetCurrentAudioStream"},
-  {0x75f03fa2,0,"scePsmfPlayerSelectSpecificVideo"},
-  {0x85461eff,0,"scePsmfPlayerSelectSpecificAudio"},
-  {0x8a9ebdcd,0,"scePsmfPlayerSelectVideo"},
-  {0x95a84ee5,0,"scePsmfPlayerStart"},
-  {0x9b71a274,0,"scePsmfPlayerDeleteFunction"},
-  {0x9ff2b2e7,0,"scePsmfPlayerGetCurrentVideoStream"},
-  {0xa0b8ca55,0,"scePsmfPlayerUpdateFunction"},
-  {0xa3d81169,0,"scePsmfPlayerChangePlayMode"},
-  {0xb8d10c56,0,"scePsmfPlayerSelectAudio"},
-  {0xb9848a74,0,"scePsmfPlayerGetAudioData"},
-  {0xdf089680,0,"scePsmfPlayerGetPsmfInfo"},
-  {0xe792cd94,scePsmfPlayerReleasePsmf,"scePsmfPlayerReleasePsmfFunction"},
-  {0xf3efaa91,0,"scePsmfPlayerGetCurrentPlayMode"},
-  {0xf8ef08a6,0,"scePsmfPlayerGetCurrentStatus"},
+	{0x235d8787,scePsmfPlayerCreate,"scePsmfPlayerCreateFunction"},
+	{0x1078c008,0,"scePsmfPlayerStopFunction"},
+	{0x1e57a8e7,0,"scePsmfPlayerConfigPlayer"},
+	{0x2beb1569,0,"scePsmfPlayerBreak"},
+	{0x3d6d25a9,0,"scePsmfPlayerSetPsmfFunction"},
+	{0x3ea82a4b,0,"scePsmfPlayerGetAudioOutSize"},
+	{0x3ed62233,0,"scePsmfPlayerGetCurrentPts"},
+	{0x46f61f8b,0,"scePsmfPlayerGetVideoData"},
+	{0x68f07175,0,"scePsmfPlayerGetCurrentAudioStream"},
+	{0x75f03fa2,0,"scePsmfPlayerSelectSpecificVideo"},
+	{0x85461eff,0,"scePsmfPlayerSelectSpecificAudio"},
+	{0x8a9ebdcd,0,"scePsmfPlayerSelectVideo"},
+	{0x95a84ee5,0,"scePsmfPlayerStart"},
+	{0x9b71a274,0,"scePsmfPlayerDeleteFunction"},
+	{0x9ff2b2e7,0,"scePsmfPlayerGetCurrentVideoStream"},
+	{0xa0b8ca55,0,"scePsmfPlayerUpdateFunction"},
+	{0xa3d81169,0,"scePsmfPlayerChangePlayMode"},
+	{0xb8d10c56,0,"scePsmfPlayerSelectAudio"},
+	{0xb9848a74,0,"scePsmfPlayerGetAudioData"},
+	{0xdf089680,0,"scePsmfPlayerGetPsmfInfo"},
+	{0xe792cd94,scePsmfPlayerReleasePsmf,"scePsmfPlayerReleasePsmfFunction"},
+	{0xf3efaa91,0,"scePsmfPlayerGetCurrentPlayMode"},
+	{0xf8ef08a6,0,"scePsmfPlayerGetCurrentStatus"},
 	{0x2D0E4E0A,0,"scePsmfPlayerSetTempBufFunction"},
 	{0x58B83577,0,"scePsmfPlayerSetPsmfCBFunction"},
 	{0x2673646B,0,"scePsmfVerifyPsmf"},
@@ -323,9 +334,9 @@ const HLEFunction scePsmfPlayer[] =
 };
 
 void Register_scePsmf() {
-  RegisterModule("scePsmf",ARRAY_SIZE(scePsmf),scePsmf);
+	RegisterModule("scePsmf",ARRAY_SIZE(scePsmf),scePsmf);
 }
 
 void Register_scePsmfPlayer() {
-  RegisterModule("scePsmfPlayer",ARRAY_SIZE(scePsmfPlayer),scePsmfPlayer);
+	RegisterModule("scePsmfPlayer",ARRAY_SIZE(scePsmfPlayer),scePsmfPlayer);
 }

--- a/Core/HLE/scePsmf.h
+++ b/Core/HLE/scePsmf.h
@@ -19,3 +19,6 @@
 
 void Register_scePsmf();
 void Register_scePsmfPlayer();
+
+void __PsmfInit();
+void __PsmfShutdown();

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -23,6 +23,12 @@ static const int modeBpp[4] = { 2, 2, 2, 4 };
 
 void MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMode)
 {
+	if (videoPixelMode > (sizeof(modeBpp) / sizeof(modeBpp[0])) || videoPixelMode < 0)
+	{
+		ERROR_LOG(ME, "Unexpected videoPixelMode %d, using 0 instead.", videoPixelMode);
+		videoPixelMode = 0;
+	}
+
 	int bpp = modeBpp[videoPixelMode];
 
 	// fake image. To be improved.


### PR DESCRIPTION
Not much just a few things:
- Cleans up the init/shutdown logic for the new code, so far anyway.
- Adds a map for sceMpeg to have multiple per TODO (with hack to use last in case something's wrong.)
- Fixes some indentation / missing log params / return -1 with u32.
- Couple crash fixes while testing my games.

Some notes:
- Jewel Summoner crashes pretty fast with ME callbacks enabled.  Comment it out and it gets farther than before.  It seems to be trying to wait from within the callback, so maybe a separate issue.
- Tales of Eternia, Blade Dancer, Popolocrois, and Fat Princess stall with the media engine.  Maybe if we can figure out why, disabling the media engine would return whatever it did before for now.
- Yggdra Union and Exit get farther but stall as well, but they get farther.

It'd be cool to merge this to master soon, although we probably have to figure out the broken games first...

-[Unknown]
