### PR TITLE
sceUtility / savedata fixes

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -53,14 +53,15 @@ void PSPDialog::DisplayMessage(std::string text)
 	PPGeDrawText(text.c_str(), 480/2, 100, PPGE_ALIGN_CENTER, 0.5f, 0xFFFFFFFF);
 }
 
-void PSPDialog::Shutdown()
+int PSPDialog::Shutdown()
 {
 	status = SCE_UTILITY_STATUS_SHUTDOWN;
+	return 0;
 }
 
-void PSPDialog::Update()
+int PSPDialog::Update()
 {
-
+	return 0;
 }
 
 bool PSPDialog::IsButtonPressed(int checkButton)

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -45,8 +45,8 @@ public:
 	PSPDialog();
 	virtual ~PSPDialog();
 
-	virtual void Update();
-	virtual void Shutdown();
+	virtual int Update();
+	virtual int Shutdown();
 
 	enum DialogStatus
 	{

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -29,18 +29,18 @@ PSPMsgDialog::PSPMsgDialog()
 PSPMsgDialog::~PSPMsgDialog() {
 }
 
-void PSPMsgDialog::Init(unsigned int paramAddr)
+int PSPMsgDialog::Init(unsigned int paramAddr)
 {
 	// Ignore if already running
 	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
 	{
-		return;
+		return 0;
 	}
 
 	messageDialogAddr = paramAddr;
 	if (!Memory::IsValidAddress(messageDialogAddr))
 	{
-		return;
+		return 0;
 	}
 	Memory::ReadStruct(messageDialogAddr, &messageDialog);
 
@@ -63,7 +63,7 @@ void PSPMsgDialog::Init(unsigned int paramAddr)
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 
 	lastButtons = __CtrlPeekButtons();
-
+	return 0;
 }
 
 void PSPMsgDialog::DisplayBack()
@@ -95,7 +95,7 @@ void PSPMsgDialog::DisplayEnterBack()
 	PPGeDrawText("Back", 320, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
 }
 
-void PSPMsgDialog::Update()
+int PSPMsgDialog::Update()
 {
 	switch (status) {
 	case SCE_UTILITY_STATUS_FINISHED:
@@ -105,7 +105,7 @@ void PSPMsgDialog::Update()
 
 	if (status != SCE_UTILITY_STATUS_RUNNING)
 	{
-		return;
+		return 0;
 	}
 
 	const char *text;
@@ -191,17 +191,18 @@ void PSPMsgDialog::Update()
 		break;
 		default:
 			status = SCE_UTILITY_STATUS_FINISHED;
-			return;
+			return 0;
 		break;
 	}
 
 	lastButtons = buttons;
 
 	Memory::WriteStruct(messageDialogAddr, &messageDialog);
+	return 0;
 }
 
-void PSPMsgDialog::Shutdown()
+int PSPMsgDialog::Shutdown()
 {
-	PSPDialog::Shutdown();
+	return PSPDialog::Shutdown();
 }
 

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -41,9 +41,9 @@ public:
 	PSPMsgDialog();
 	virtual ~PSPMsgDialog();
 
-	virtual void Init(unsigned int paramAddr);
-	virtual void Update();
-	void Shutdown();
+	virtual int Init(unsigned int paramAddr);
+	virtual int Update();
+	int Shutdown();
 
 private :
 	void DisplayBack();

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -143,7 +143,7 @@ void PSPOskDialog::RenderKeyboard()
 
 }
 
-void PSPOskDialog::Update()
+int PSPOskDialog::Update()
 {
 	buttons = __CtrlReadLatch();
 	int selectedRow = selectedChar / KEYSPERROW;
@@ -230,4 +230,6 @@ void PSPOskDialog::Update()
 	oskData.result = PSP_UTILITY_OSK_RESULT_CHANGED;
 	Memory::WriteStruct(oskParams.SceUtilityOskDataPtr, &oskData);
 	Memory::WriteStruct(oskParamsAddr, &oskParams);
+
+	return 0;
 }

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -145,7 +145,7 @@ public:
 	virtual ~PSPOskDialog();
 
 	virtual int Init(u32 oskPtr);
-	virtual void Update();
+	virtual int Update();
 private:
 	void HackyGetStringWide(std::string& _string, const u32 em_address);
 	void RenderKeyboard();

--- a/Core/Dialog/PSPPlaceholderDialog.cpp
+++ b/Core/Dialog/PSPPlaceholderDialog.cpp
@@ -25,12 +25,13 @@ PSPPlaceholderDialog::~PSPPlaceholderDialog() {
 }
 
 
-void PSPPlaceholderDialog::Init()
+int PSPPlaceholderDialog::Init()
 {
 	status = SCE_UTILITY_STATUS_INITIALIZE;
+	return 0;
 }
 
-void PSPPlaceholderDialog::Update()
+int PSPPlaceholderDialog::Update()
 {
 	//__UtilityUpdate();
 	if (status == SCE_UTILITY_STATUS_INITIALIZE)
@@ -45,4 +46,5 @@ void PSPPlaceholderDialog::Update()
 	{
 		status = SCE_UTILITY_STATUS_SHUTDOWN;
 	}
+	return 0;
 }

--- a/Core/Dialog/PSPPlaceholderDialog.h
+++ b/Core/Dialog/PSPPlaceholderDialog.h
@@ -24,7 +24,7 @@ public:
 	PSPPlaceholderDialog();
 	virtual ~PSPPlaceholderDialog();
 
-	virtual void Init();
-	virtual void Update();
+	virtual int Init();
+	virtual int Update();
 };
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -31,7 +31,7 @@ PSPSaveDialog::PSPSaveDialog()
 PSPSaveDialog::~PSPSaveDialog() {
 }
 
-u32 PSPSaveDialog::Init(int paramAddr)
+int PSPSaveDialog::Init(int paramAddr)
 {
 	// Ignore if already running
 	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
@@ -315,7 +315,7 @@ void PSPSaveDialog::DisplayBack()
 	PPGeDrawText("Back", 270, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
 }
 
-void PSPSaveDialog::Update()
+int PSPSaveDialog::Update()
 {
 	switch (status) {
 	case SCE_UTILITY_STATUS_FINISHED:
@@ -327,12 +327,12 @@ void PSPSaveDialog::Update()
 
 	if (status != SCE_UTILITY_STATUS_RUNNING)
 	{
-		return;
+		return 0;
 	}
 
 	if (!param.GetPspParam()) {
 		status = SCE_UTILITY_STATUS_SHUTDOWN;
-		return;
+		return 0;
 	}
 
 	buttons = __CtrlPeekButtons();
@@ -684,11 +684,14 @@ void PSPSaveDialog::Update()
 		Memory::Memcpy(requestAddr,&request,request.size);
 	}
 	
+	return 0;
 }
 
-void PSPSaveDialog::Shutdown()
+int PSPSaveDialog::Shutdown()
 {
 	PSPDialog::Shutdown();
 	param.SetPspParam(0);
+
+	return 0;
 }
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -238,7 +238,9 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 	}
 	else
 	{
-		char txt[1024];
+		char txt[2048];
+		_dbg_assert_msg_(HLE, sizeof(txt) > sizeof(SaveFileInfo), "Local buffer is too small.");
+
 		sprintf(txt,"%s\n%02d/%02d/%d %02d:%02d %lld KB\n%s\n%s"
 				, param.GetFileInfo(currentSelectedSave).title
 				, param.GetFileInfo(currentSelectedSave).modif_time.tm_mday

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -62,9 +62,9 @@ public:
 	PSPSaveDialog();
 	virtual ~PSPSaveDialog();
 
-	virtual u32 Init(int paramAddr);
-	virtual void Update();
-	void Shutdown();
+	virtual int Init(int paramAddr);
+	virtual int Update();
+	int Shutdown();
 
 private :
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -378,7 +378,7 @@ void SavedataParam::Clear()
 	}
 }
 
-u32 SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
+int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 {
 	pspParam = param;
 	if (!pspParam)

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -504,15 +504,22 @@ void SavedataParam::LoadFileInfo(int idx, PSPFileInfo &info)
 		pspFileSystem.CloseFile(handle);
 		unsigned char *textureData;
 		int w,h;
-		pngLoadPtr(textureDataPNG, (int)info2.size, &w, &h, &textureData, false);
+
+		int success = pngLoadPtr(textureDataPNG, (int)info2.size, &w, &h, &textureData, false);
 		delete[] textureDataPNG;
-		u32 texSize = w*h*4;
-		u32 atlasPtr = kernelMemory.Alloc(texSize, true, "SaveData Icon");
-		saveDataList[idx].textureData = atlasPtr;
-		Memory::Memcpy(atlasPtr, textureData, texSize);
-		free(textureData);
-		saveDataList[idx].textureWidth = w;
-		saveDataList[idx].textureHeight = h;
+
+		if (success)
+		{
+			u32 texSize = w*h*4;
+			u32 atlasPtr = kernelMemory.Alloc(texSize, true, "SaveData Icon");
+			saveDataList[idx].textureData = atlasPtr;
+			Memory::Memcpy(atlasPtr, textureData, texSize);
+			free(textureData);
+			saveDataList[idx].textureWidth = w;
+			saveDataList[idx].textureHeight = h;
+		}
+		else
+			saveDataList[idx].textureData = 0;
 	}
 	else
 	{

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -419,6 +419,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 			if (info.exists)
 			{
 				SetFileInfo(realCount, info);
+				saveDataList[realCount].saveName = saveNameListData[i];
 
 				DEBUG_LOG(HLE,"%s Exist",fileDataPath.c_str());
 				realCount++;
@@ -453,6 +454,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 		if (info.exists)
 		{
 			SetFileInfo(0, info);
+			saveDataList[0].saveName = GetSaveName(pspParam);
 
 			DEBUG_LOG(HLE,"%s Exist",fileDataPath.c_str());
 			saveNameListDataCount = 1;
@@ -477,7 +479,6 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info)
 {
 	saveDataList[idx].size = info.size;
-	saveDataList[idx].saveName = GetSaveName(pspParam);
 	saveDataList[idx].idx = 0;
 	saveDataList[idx].modif_time = info.mtime;
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -37,6 +37,13 @@ namespace
 		int sizeCluster = (int)MemoryStick_SectorSize();
 		return ((int)((size + sizeCluster - 1) / sizeCluster)) * sizeCluster;
 	}
+
+	void SetStringFromSFO(ParamSFOData &sfoFile, const char *name, char *str, int strLength)
+	{
+		std::string value = sfoFile.GetValueString(name);
+		strncpy(str, value.c_str(), strLength - 1);
+		str[strLength - 1] = 0;
+	}
 }
 
 SavedataParam::SavedataParam()
@@ -543,17 +550,9 @@ void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info)
 		ParamSFOData sfoFile;
 		if (sfoFile.ReadSFO(sfoParam,(size_t)info2.size))
 		{
-			std::string title = sfoFile.GetValueString("TITLE");
-			memcpy(saveDataList[idx].title,title.c_str(),title.size());
-			saveDataList[idx].title[title.size()] = 0;
-
-			std::string savetitle = sfoFile.GetValueString("SAVEDATA_TITLE");
-			memcpy(saveDataList[idx].saveTitle,savetitle.c_str(),savetitle.size());
-			saveDataList[idx].saveTitle[savetitle.size()] = 0;
-
-			std::string savedetail = sfoFile.GetValueString("SAVEDATA_DETAIL");
-			memcpy(saveDataList[idx].saveDetail,savedetail.c_str(),savedetail.size());
-			saveDataList[idx].saveDetail[savedetail.size()] = 0;
+			SetStringFromSFO(sfoFile, "TITLE", saveDataList[idx].title, sizeof(saveDataList[idx].title));
+			SetStringFromSFO(sfoFile, "SAVEDATA_TITLE", saveDataList[idx].saveTitle, sizeof(saveDataList[idx].saveTitle));
+			SetStringFromSFO(sfoFile, "SAVEDATA_DETAIL", saveDataList[idx].saveDetail, sizeof(saveDataList[idx].saveDetail));
 		}
 		delete [] sfoParam;
 	}

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -34,7 +34,7 @@ namespace
 {
 	int getSizeNormalized(int size)
 	{
-		int sizeCluster = MemoryStick_SectorSize();
+		int sizeCluster = (int)MemoryStick_SectorSize();
 		return ((int)((size + sizeCluster - 1) / sizeCluster)) * sizeCluster;
 	}
 }
@@ -309,7 +309,7 @@ bool SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		Memory::Write_U32((u32)MemoryStick_SectorSize(),param->msFree); // cluster Size
 		Memory::Write_U32((u32)(MemoryStick_FreeSpace() / MemoryStick_SectorSize()),param->msFree+4);	// Free cluster
 		Memory::Write_U32((u32)(MemoryStick_FreeSpace() / 0x400),param->msFree+8); // Free space (in KB)
-		std::string spaceTxt = SavedataParam::GetSpaceText(MemoryStick_FreeSpace());
+		std::string spaceTxt = SavedataParam::GetSpaceText((int)MemoryStick_FreeSpace());
 		Memory::Memset(param->msFree+12,0,spaceTxt.size()+1);
 		Memory::Memcpy(param->msFree+12,spaceTxt.c_str(),spaceTxt.size()); // Text representing free space
 	}
@@ -346,7 +346,7 @@ bool SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		total_size += getSizeNormalized(param->pic1FileData.size);
 		total_size += getSizeNormalized(param->snd0FileData.size);
 
-		Memory::Write_U32(total_size / MemoryStick_SectorSize(),param->utilityData);	// num cluster
+		Memory::Write_U32(total_size / (u32)MemoryStick_SectorSize(),param->utilityData);	// num cluster
 		Memory::Write_U32(total_size / 0x400,param->utilityData+4);	// save size in KB
 		std::string spaceTxt = SavedataParam::GetSpaceText(total_size);
 		Memory::Memset(param->utilityData+8,0,spaceTxt.size()+1);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -418,8 +418,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 			PSPFileInfo info = pspFileSystem.GetFileInfo(fileDataPath);
 			if (info.exists)
 			{
-				SetFileInfo(realCount, info);
-				saveDataList[realCount].saveName = saveNameListData[i];
+				SetFileInfo(realCount, info, saveNameListData[i]);
 
 				DEBUG_LOG(HLE,"%s Exist",fileDataPath.c_str());
 				realCount++;
@@ -453,8 +452,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 		PSPFileInfo info = pspFileSystem.GetFileInfo(fileDataPath);
 		if (info.exists)
 		{
-			SetFileInfo(0, info);
-			saveDataList[0].saveName = GetSaveName(pspParam);
+			SetFileInfo(0, info, GetSaveName(pspParam));
 
 			DEBUG_LOG(HLE,"%s Exist",fileDataPath.c_str());
 			saveNameListDataCount = 1;
@@ -476,15 +474,22 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 	return 0;
 }
 
-void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info)
+void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info, std::string saveName)
 {
 	saveDataList[idx].size = info.size;
+	saveDataList[idx].saveName = saveName;
 	saveDataList[idx].idx = 0;
 	saveDataList[idx].modif_time = info.mtime;
 
+	// Start with a blank slate.
+	saveDataList[idx].textureData = 0;
+	saveDataList[idx].title[0] = 0;
+	saveDataList[idx].saveTitle[0] = 0;
+	saveDataList[idx].saveDetail[0] = 0;
+
 	// Search save image icon0
 	// TODO : If icon0 don't exist, need to use icon1 which is a moving icon. Also play sound
-	std::string fileDataPath2 = savePath+GetGameName(pspParam)+GetSaveName(pspParam)+"/"+icon0Name;
+	std::string fileDataPath2 = savePath + GetGameName(pspParam) + saveName + "/" + icon0Name;
 	PSPFileInfo info2 = pspFileSystem.GetFileInfo(fileDataPath2);
 	if (info2.exists)
 	{
@@ -509,18 +514,11 @@ void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info)
 			saveDataList[idx].textureHeight = h;
 		}
 		else
-		{
 			WARN_LOG(HLE, "Unable to load PNG data for savedata.");
-			saveDataList[idx].textureData = 0;
-		}
-	}
-	else
-	{
-		saveDataList[idx].textureData = 0;
 	}
 
 	// Load info in PARAM.SFO
-	fileDataPath2 = savePath+GetGameName(pspParam)+GetSaveName(pspParam)+"/"+sfoName;
+	fileDataPath2 = savePath + GetGameName(pspParam) + saveName + "/" + sfoName;
 	info2 = pspFileSystem.GetFileInfo(fileDataPath2);
 	if (info2.exists)
 	{

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -168,7 +168,7 @@ public:
 
 private:
 	void Clear();
-	void SetFileInfo(int idx, PSPFileInfo &info);
+	void SetFileInfo(int idx, PSPFileInfo &info, std::string saveName);
 
 	SceUtilitySavedataParam* pspParam;
 	int selectedSave;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -156,7 +156,7 @@ public:
 
 	SavedataParam();
 
-	u32 SetPspParam(SceUtilitySavedataParam* param);
+	int SetPspParam(SceUtilitySavedataParam* param);
 	SceUtilitySavedataParam* GetPspParam();
 
 	int GetFilenameCount();

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "../HLE/sceKernel.h"
-
+#include "../System.h"
 
 enum SceUtilitySavedataType
 {
@@ -168,6 +168,7 @@ public:
 
 private:
 	void Clear();
+	void LoadFileInfo(int idx, PSPFileInfo &info);
 
 	SceUtilitySavedataParam* pspParam;
 	int selectedSave;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -168,7 +168,7 @@ public:
 
 private:
 	void Clear();
-	void LoadFileInfo(int idx, PSPFileInfo &info);
+	void SetFileInfo(int idx, PSPFileInfo &info);
 
 	SceUtilitySavedataParam* pspParam;
 	int selectedSave;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -50,14 +50,13 @@ void __UtilityShutdown()
 int sceUtilitySavedataInitStart(u32 paramAddr)
 {
 	DEBUG_LOG(HLE,"sceUtilitySavedataInitStart(%08x)", paramAddr);
-	return (u32)saveDialog.Init(paramAddr);
+	return saveDialog.Init(paramAddr);
 }
 
 int sceUtilitySavedataShutdownStart()
 {
 	DEBUG_LOG(HLE,"sceUtilitySavedataShutdownStart()");
-	saveDialog.Shutdown();
-	return 0;
+	return saveDialog.Shutdown();
 }
 
 int sceUtilitySavedataGetStatus()
@@ -65,13 +64,10 @@ int sceUtilitySavedataGetStatus()
 	return saveDialog.GetStatus();
 }
 
-void sceUtilitySavedataUpdate(u32 unknown)
+int sceUtilitySavedataUpdate(int animSpeed)
 {
-	DEBUG_LOG(HLE,"sceUtilitySavedataUpdate()");
-
-	saveDialog.Update();
-
-	return;
+	DEBUG_LOG(HLE,"sceUtilitySavedataUpdate(%d)", animSpeed);
+	return saveDialog.Update();
 }
 
 #define PSP_AV_MODULE_AVCODEC					 0
@@ -99,26 +95,27 @@ void sceUtilityLoadModule(u32 module)
 	__KernelReSchedule("utilityloadmodule");
 }
 
-void sceUtilityMsgDialogInitStart(u32 structAddr)
+int sceUtilityMsgDialogInitStart(u32 structAddr)
 {
 	DEBUG_LOG(HLE,"sceUtilityMsgDialogInitStart(%i)", structAddr);
-	msgDialog.Init(structAddr);
+	return msgDialog.Init(structAddr);
 }
 
-void sceUtilityMsgDialogShutdownStart(u32 unknown)
+int sceUtilityMsgDialogShutdownStart(u32 unknown)
 {
 	DEBUG_LOG(HLE,"FAKE sceUtilityMsgDialogShutdownStart(%i)", unknown);
-	msgDialog.Shutdown();
+	return msgDialog.Shutdown();
 }
 
-void sceUtilityMsgDialogUpdate(int animSpeed)
+int sceUtilityMsgDialogUpdate(int animSpeed)
 {
 	DEBUG_LOG(HLE,"sceUtilityMsgDialogUpdate(%i)", animSpeed);
-	msgDialog.Update();
+	return msgDialog.Update();
 }
 
-u32 sceUtilityMsgDialogGetStatus()
+int sceUtilityMsgDialogGetStatus()
 {
+	DEBUG_LOG(HLE,"sceUtilityMsgDialogGetStatus()");
 	return msgDialog.GetStatus();
 }
 
@@ -134,14 +131,13 @@ int sceUtilityOskInitStart(u32 oskPtr)
 int sceUtilityOskShutdownStart()
 {
 	ERROR_LOG(HLE,"FAKE sceUtilityOskShutdownStart(%i)", PARAM(0));
-	oskDialog.Shutdown();
-	return 0;
+	return oskDialog.Shutdown();
 }
 
-void sceUtilityOskUpdate(unsigned int unknown)
+int sceUtilityOskUpdate(unsigned int unknown)
 {
 	ERROR_LOG(HLE,"FAKE sceUtilityOskUpdate(%i)", unknown);
-	oskDialog.Update();
+	return oskDialog.Update();
 }
 
 int sceUtilityOskGetStatus()
@@ -156,25 +152,25 @@ int sceUtilityOskGetStatus()
 }
 
 
-void sceUtilityNetconfInitStart(unsigned int unknown)
+int sceUtilityNetconfInitStart(u32 structAddr)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfInitStart(%i)", unknown);
-	netDialog.Init();
+	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfInitStart(%08x)", structAddr);
+	return netDialog.Init();
 }
 
-void sceUtilityNetconfShutdownStart(unsigned int unknown)
+int sceUtilityNetconfShutdownStart(unsigned int unknown)
 {
 	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfShutdownStart(%i)", unknown);
-	netDialog.Shutdown();
+	return netDialog.Shutdown();
 }
 
-void sceUtilityNetconfUpdate(int unknown)
+int sceUtilityNetconfUpdate(int animSpeed)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfUpdate(%i)", unknown);
-	netDialog.Update();
+	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfUpdate(%i)", animSpeed);
+	return netDialog.Update();
 }
 
-unsigned int sceUtilityNetconfGetStatus()
+int sceUtilityNetconfGetStatus()
 {
 	DEBUG_LOG(HLE,"sceUtilityNetconfGetStatus()");
 	return netDialog.GetStatus();
@@ -356,28 +352,28 @@ const HLEFunction sceUtility[] =
 	{0x64d50c56, &WrapU_U<sceUtilityUnloadNetModule>, "sceUtilityUnloadNetModule"}, 
 
 
-	{0xf88155f6, &WrapV_U<sceUtilityNetconfShutdownStart>, "sceUtilityNetconfShutdownStart"},
-	{0x4db1e739, &WrapV_U<sceUtilityNetconfInitStart>, "sceUtilityNetconfInitStart"},
-	{0x91e70e35, &WrapV_I<sceUtilityNetconfUpdate>, "sceUtilityNetconfUpdate"},
-	{0x6332aa39, &WrapU_V<sceUtilityNetconfGetStatus>, "sceUtilityNetconfGetStatus"},
+	{0xf88155f6, &WrapI_U<sceUtilityNetconfShutdownStart>, "sceUtilityNetconfShutdownStart"},
+	{0x4db1e739, &WrapI_U<sceUtilityNetconfInitStart>, "sceUtilityNetconfInitStart"},
+	{0x91e70e35, &WrapI_I<sceUtilityNetconfUpdate>, "sceUtilityNetconfUpdate"},
+	{0x6332aa39, &WrapI_V<sceUtilityNetconfGetStatus>, "sceUtilityNetconfGetStatus"},
 	{0x5eee6548, 0, "sceUtilityCheckNetParam"}, 
 	{0x434d4b3a, 0, "sceUtilityGetNetParam"}, 
 	{0x4FED24D8, 0, "sceUtilityGetNetParamLatestID"},
 
-	{0x67af3428, &WrapV_U<sceUtilityMsgDialogShutdownStart>, "sceUtilityMsgDialogShutdownStart"},	
-	{0x2ad8e239, &WrapV_U<sceUtilityMsgDialogInitStart>, "sceUtilityMsgDialogInitStart"},			
-	{0x95fc253b, &WrapV_I<sceUtilityMsgDialogUpdate>, "sceUtilityMsgDialogUpdate"},				 
-	{0x9a1c91d7, &WrapU_V<sceUtilityMsgDialogGetStatus>, "sceUtilityMsgDialogGetStatus"},		
+	{0x67af3428, &WrapI_U<sceUtilityMsgDialogShutdownStart>, "sceUtilityMsgDialogShutdownStart"},	
+	{0x2ad8e239, &WrapI_U<sceUtilityMsgDialogInitStart>, "sceUtilityMsgDialogInitStart"},			
+	{0x95fc253b, &WrapI_I<sceUtilityMsgDialogUpdate>, "sceUtilityMsgDialogUpdate"},				 
+	{0x9a1c91d7, &WrapI_V<sceUtilityMsgDialogGetStatus>, "sceUtilityMsgDialogGetStatus"},		
 	{0x4928bd96, 0, "sceUtilityMsgDialogAbort"}, 
 
 	{0x9790b33c, &WrapI_V<sceUtilitySavedataShutdownStart>, "sceUtilitySavedataShutdownStart"},	 
 	{0x50c4cd57, &WrapI_U<sceUtilitySavedataInitStart>, "sceUtilitySavedataInitStart"},			 
-	{0xd4b95ffb, &WrapV_U<sceUtilitySavedataUpdate>, "sceUtilitySavedataUpdate"},					
+	{0xd4b95ffb, &WrapI_I<sceUtilitySavedataUpdate>, "sceUtilitySavedataUpdate"},					
 	{0x8874dbe0, &WrapI_V<sceUtilitySavedataGetStatus>, "sceUtilitySavedataGetStatus"},
 
 	{0x3dfaeba9, &WrapI_V<sceUtilityOskShutdownStart>, "sceUtilityOskShutdownStart"},
 	{0xf6269b82, &WrapI_U<sceUtilityOskInitStart>, "sceUtilityOskInitStart"},
-	{0x4b85c861, &WrapV_U<sceUtilityOskUpdate>, "sceUtilityOskUpdate"},
+	{0x4b85c861, &WrapI_U<sceUtilityOskUpdate>, "sceUtilityOskUpdate"},
 	{0xf3f76017, &WrapI_V<sceUtilityOskGetStatus>, "sceUtilityOskGetStatus"},
 
 	{0x41e30674, &WrapU_UU<sceUtilitySetSystemParamString>, "sceUtilitySetSystemParamString"},


### PR DESCRIPTION
Mostly, this makes all the current sceUtility dialog funcs return 0 (for now), and it also fixes some crashes I was hitting dealing with pngs.

This fixes Vempire and Canabalt, and quite probably other games.  Some other games still have problems but no longer go into loops.  I'm hoping it fixes Saint Seyia Omega, MotoGP, and Star Soldier (none of which I have.)

@Xele02, let me know if you don't like any of my changes, had been thinking there might be a missing `CloseFile()` at first or something.

-[Unknown]
