### PR TITLE
Fix a crash when switching between jit and interpreter

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -53,7 +53,11 @@ MIPSState::~MIPSState()
 void MIPSState::Reset()
 {
 	if (MIPSComp::jit)
+	{
 		delete MIPSComp::jit;
+		MIPSComp::jit = 0;
+	}
+
 	if (PSP_CoreParameter().cpuCore == CPU_JIT)
 		MIPSComp::jit = new MIPSComp::Jit(this);
 


### PR DESCRIPTION
Sorry, this was my mistake.  Classic double free.

-[Unknown]
