### PR TITLE
Save more of the GPU's state, fix a crash

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -412,6 +412,7 @@ void SavedataParam::Clear()
 
 		delete[] saveDataList;
 		saveDataList = 0;
+		saveDataListCount = 0;
 	}
 }
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -109,7 +109,6 @@ void __DisplayInit() {
 	vCount = 0;
 	hCount = 0;
 	hCountTotal = 0;
-	hasSetMode = false;
 	lastFrameTime = 0;
 
 	InitGfxState();
@@ -132,6 +131,20 @@ void __DisplayDoState(PointerWrap &p) {
 	CoreTiming::RestoreRegisterEvent(enterVblankEvent, "EnterVBlank", &hleEnterVblank);
 	p.Do(leaveVblankEvent);
 	CoreTiming::RestoreRegisterEvent(leaveVblankEvent, "LeaveVBlank", &hleLeaveVblank);
+
+	p.Do(gstate);
+	p.Do(gstate_c);
+	p.Do(gpuStats);
+	gpu->DoState(p);
+
+	ReapplyGfxState();
+
+	if (p.mode == p.MODE_READ) {
+		if (hasSetMode) {
+			gpu->InitClear();
+		}
+		gpu->SetDisplayFramebuffer(framebuf.topaddr, framebuf.pspFramebufLinesize, framebuf.pspFramebufFormat);
+	}
 
 	p.DoMarker("sceDisplay");
 }

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -33,9 +33,11 @@ void __GeDoState(PointerWrap &p)
 {
 	p.Do(gstate);
 	p.Do(gstate_c);
+	p.Do(gpuStats);
 
 	ReapplyGfxState();
 	gpu->InvalidateCache(0, -1);
+	gpu->DoState(p);
 	p.DoMarker("sceGe");
 }
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -31,13 +31,7 @@ void __GeInit()
 
 void __GeDoState(PointerWrap &p)
 {
-	p.Do(gstate);
-	p.Do(gstate_c);
-	p.Do(gpuStats);
-
-	ReapplyGfxState();
-	gpu->InvalidateCache(0, -1);
-	gpu->DoState(p);
+	// Everything is done in sceDisplay.
 	p.DoMarker("sceGe");
 }
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -1057,7 +1057,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	default:
-		DEBUG_LOG(G3D,"DL Unknown: %08x @ %08x", op, currentList->pc);
+		DEBUG_LOG(G3D,"DL Unknown: %08x @ %08x", op, currentList == NULL ? 0 : currentList->pc);
 		break;
 	}
 }

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -1120,3 +1120,16 @@ void GLES_GPU::InvalidateCache(u32 addr, int size) {
 void GLES_GPU::Flush() {
 	transformDraw_.Flush();
 }
+
+void GLES_GPU::DoState(PointerWrap &p) {
+	GPUCommon::DoState(p);
+
+	TextureCache_Clear(true);
+	gstate_c.textureChanged = true;
+	for (auto iter = vfbs_.begin(); iter != vfbs_.end(); ++iter) {
+		fbo_destroy((*iter)->fbo);
+		delete (*iter);
+	}
+	vfbs_.clear();
+	shaderManager_->ClearCache(true);
+}

--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -53,6 +53,7 @@ public:
 
 	virtual void DumpNextFrame();
 	virtual void Flush();
+	virtual void DoState(PointerWrap &p);
 
 private:
 	void DoBlockTransfer();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -118,3 +118,9 @@ bool GPUCommon::ProcessDLQueue()
 void GPUCommon::PreExecuteOp(u32 op, u32 diff) {
 	// Nothing to do
 }
+
+void GPUCommon::DoState(PointerWrap &p) {
+	p.Do(dlIdGenerator);
+	p.Do<DisplayList>(dlQueue);
+	p.DoMarker("GPUCommon");
+}

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -19,6 +19,7 @@ public:
 	virtual void UpdateStall(int listid, u32 newstall);
 	virtual u32  EnqueueList(u32 listpc, u32 stall, bool head);
 	virtual int  listStatus(int listid);
+	virtual void DoState(PointerWrap &p);
 
 protected:
 	typedef std::deque<DisplayList> DisplayListQueue;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "../Globals.h"
+#include "../Common/ChunkFile.h"
 #include <deque>
 
 enum DisplayListStatus
@@ -75,6 +76,7 @@ public:
 
 	virtual void DeviceLost() = 0;
 	virtual void Flush() = 0;
+	virtual void DoState(PointerWrap &p) = 0;
 
 	// Debugging
 	virtual void DumpNextFrame() = 0;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -313,6 +313,13 @@ namespace MainWindow
 				break;
 
 			case ID_FILE_LOADSTATE:
+				if (g_State.bEmuThreadStarted)
+				{
+					nextState = Core_IsStepping() ? CORE_STEPPING : CORE_RUNNING;
+					for (int i=0; i<numCPUs; i++)
+						if (disasmWindow[i])
+							SendMessage(disasmWindow[i]->GetDlgHandle(), WM_COMMAND, IDC_STOP, 0);
+				}
 				if (W32Util::BrowseForFileName(true, hWnd, "Load state",0,"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0","ppst",fn))
 				{
 					SetCursor(LoadCursor(0,IDC_WAIT));
@@ -321,6 +328,13 @@ namespace MainWindow
 				break;
 
 			case ID_FILE_SAVESTATE:
+				if (g_State.bEmuThreadStarted)
+				{
+					nextState = Core_IsStepping() ? CORE_STEPPING : CORE_RUNNING;
+					for (int i=0; i<numCPUs; i++)
+						if (disasmWindow[i])
+							SendMessage(disasmWindow[i]->GetDlgHandle(), WM_COMMAND, IDC_STOP, 0);
+				}
 				if (W32Util::BrowseForFileName(false, hWnd, "Save state",0,"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0","ppst",fn))
 				{
 					SetCursor(LoadCursor(0,IDC_WAIT));
@@ -780,6 +794,13 @@ namespace MainWindow
 		if (!result)
 			MessageBox(0, "Savestate failure.  Please try again later.", "Sorry", MB_OK);
 		SetCursor(LoadCursor(0, IDC_ARROW));
+
+		if (g_State.bEmuThreadStarted && nextState == CORE_RUNNING)
+		{
+			for (int i=0; i<numCPUs; i++)
+				if (disasmWindow[i])
+					SendMessage(disasmWindow[i]->GetDlgHandle(), WM_COMMAND, IDC_GO, 0);
+		}
 	}
 
 	void SetNextState(CoreState state)


### PR DESCRIPTION
Well, ReapplyGfxState() seems kinda dangerous now since currentList might be NULL.

Anyway, this seems to help, not sure whether the FBOs are needed but it seems like they are recreated, so this flushes them.

I also added pausing the emulation while selecting a save state file.  I suppose slots or something ultimately make sense, but not very concerned about that atm.

-[Unknown]
