### PR TITLE
Reverse the analog Y for everyone.

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -163,7 +163,7 @@ void __CtrlSetAnalog(float x, float y)
 	if (x < -1.0f) x = -1.0f;
 	if (y < -1.0f) y = -1.0f;
 	ctrlCurrent.analog[0] = (u8)(x * 127.f + 128.f);
-	ctrlCurrent.analog[1] = (u8)(y * 127.f + 128.f);
+	ctrlCurrent.analog[1] = (u8)(-y * 127.f + 128.f);
 }
 
 int __CtrlReadSingleBuffer(u32 ctrlDataPtr, bool negative)

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -41,7 +41,7 @@ int XinputDevice::UpdateState() {
 	if ( dwResult == ERROR_SUCCESS ) {
 		this->ApplyDiff(state);
 		Stick left = NormalizedDeadzoneFilter(state);
-		__CtrlSetAnalog(left.x, -left.y);
+		__CtrlSetAnalog(left.x, left.y);
 		this->prevState = state;
 		this->check_delay = 0;
 		return 0;


### PR DESCRIPTION
Verified XInput is still happy this way.  SDL as well (IJKL and virtual stick), so I assume this will fix #287.

-[Unknown]
