### PR TITLE
Windows keyboard analog still wrong

### DIFF
--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -43,10 +43,10 @@ int KeyboardDevice::UpdateState() {
 
 		switch (analog_ctrl_map[i + 1]) {
 		case CTRL_UP:
-			analogY -= .8f;
+			analogY += .8f;
 			break;
 		case CTRL_DOWN:
-			analogY += .8f;
+			analogY -= .8f;
 			break;
 		case CTRL_LEFT:
 			analogX -= .8f;


### PR DESCRIPTION
Arg, found the root cause, I'm stupid.  With this everything should be okay, including the keyboard on Windows.

-[Unknown]
