### PR TITLE
Headless w/GLES GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,7 +886,7 @@ if(WIN32)
 endif()
 
 if(HEADLESS)
-	add_executable(PPSSPPHeadless headless/Headless.cpp)
+	add_executable(PPSSPPHeadless headless/Headless.cpp headless/StubHost.h)
 	target_link_libraries(PPSSPPHeadless ${CoreLibName}
 		${COCOA_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 	setup_target_project(PPSSPPHeadless headless)

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -78,12 +78,6 @@ typedef s32 SceMode;
 typedef s64 SceOff;
 typedef u64 SceIores;
 
-std::string emuDebugOutput;
-
-const std::string &EmuDebugOutput() {
-	return emuDebugOutput;
-}
-
 typedef u32 (*DeferredAction)(SceUID id, int param);
 DeferredAction defAction = 0;
 u32 defParam = 0;
@@ -646,9 +640,6 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 				if (PSP_CoreParameter().printfEmuLog)
 				{
 					host->SendDebugOutput(data.c_str());
-
-					// Also collect the debug output
-					emuDebugOutput += data;
 				}
 				else
 				{

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -22,6 +22,7 @@
 
 #include "../System.h"
 #include "../Config.h"
+#include "../Host.h"
 #include "../SaveState.h"
 #include "HLE.h"
 #include "../MIPS/MIPS.h"
@@ -644,10 +645,8 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 				std::string data(Memory::GetCharPointer(argAddr), argLen);
 				if (PSP_CoreParameter().printfEmuLog)
 				{
-					printf("%s", data.c_str());
-#ifdef _WIN32
-					OutputDebugString(data.c_str());
-#endif
+					host->SendDebugOutput(data.c_str());
+
 					// Also collect the debug output
 					emuDebugOutput += data;
 				}

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -29,5 +29,3 @@ KernelObject *__KernelDirListingObject();
 
 void Register_IoFileMgrForUser();
 void Register_StdioForUser();
-
-const std::string &EmuDebugOutput();

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -182,20 +182,18 @@ bool __KernelIsRunning() {
 void sceKernelExitGame()
 {
 	INFO_LOG(HLE,"sceKernelExitGame");
-	if (PSP_CoreParameter().headLess)
-		exit(0);
-	else
+	if (!PSP_CoreParameter().headLess)
 		PanicAlert("Game exited");
+	__KernelSwitchOffThread("game exited");
 	Core_Stop();
 }
 
 void sceKernelExitGameWithStatus()
 {
 	INFO_LOG(HLE,"sceKernelExitGameWithStatus");
-	if (PSP_CoreParameter().headLess)
-		exit(0);
-	else
+	if (!PSP_CoreParameter().headLess)
 		PanicAlert("Game exited (with status)");
+	__KernelSwitchOffThread("game exited");
 	Core_Stop();
 }
 

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -60,6 +60,9 @@ public:
 	virtual bool IsDebuggingEnabled() {return true;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
 	virtual void SetWindowTitle(const char *message) {}
+
+	// Used for headless.
+	virtual void SendDebugOutput(const std::string &output) {}
 };
 
 extern Host *host;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -12,8 +12,6 @@
 #include "../Core/Host.h"
 #include "Log.h"
 #include "LogManager.h"
-#include "file/vfs.h"
-#include "file/zip_read.h"
 
 #include "StubHost.h"
 #ifdef _WIN32
@@ -28,20 +26,20 @@ public:
 		switch (level)
 		{
 		case LogTypes::LDEBUG:
-			printf("D %s", msg);
+			fprintf(stderr, "D %s", msg);
 			break;
 		case LogTypes::LINFO:
-			printf("I %s", msg);
+			fprintf(stderr, "I %s", msg);
 			break;
 		case LogTypes::LERROR:
-			printf("E %s", msg);
+			fprintf(stderr, "E %s", msg);
 			break;
 		case LogTypes::LWARNING:
-			printf("W %s", msg);
+			fprintf(stderr, "W %s", msg);
 			break;
 		case LogTypes::LNOTICE:
 		default:
-			printf("N %s", msg);
+			fprintf(stderr, "N %s", msg);
 			break;
 		}
 	}
@@ -118,9 +116,6 @@ int main(int argc, const char* argv[])
 		return 1;
 	}
 
-	VFSRegister("", new DirectoryAssetReader("assets/"));
-	VFSRegister("", new DirectoryAssetReader(""));
-
 	HeadlessHost *headlessHost = new HEADLESSHOST_CLASS();
 	host = headlessHost;
 	host->InitGL();
@@ -160,8 +155,9 @@ int main(int argc, const char* argv[])
 		return 1;
 	}
 
-	coreState = CORE_RUNNING;
+	host->BootDone();
 
+	coreState = CORE_RUNNING;
 	while (coreState == CORE_RUNNING)
 	{
 		// Run for a frame at a time, just because.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -55,6 +55,12 @@ void printUsage(const char *progname, const char *reason)
 	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "  -m, --mount umd.cso   mount iso on umd:\n");
 	fprintf(stderr, "  -l, --log             full log output, not just emulated printfs\n");
+
+	HEADLESSHOST_CLASS h1;
+	HeadlessHost h2;
+	if (typeid(h1) != typeid(h2))
+		fprintf(stderr, "  --graphics            use the full gpu backend (slower)\n");
+
 	fprintf(stderr, "  -f                    use the fast interpreter\n");
 	fprintf(stderr, "  -j                    use jit (overrides -f)\n");
 	fprintf(stderr, "  -c, --compare         compare with output in file.expected\n");
@@ -67,6 +73,7 @@ int main(int argc, const char* argv[])
 	bool useJit = false;
 	bool fastInterpreter = false;
 	bool autoCompare = false;
+	bool useGraphics = false;
 	
 	const char *bootFilename = 0;
 	const char *mountIso = 0;
@@ -90,6 +97,8 @@ int main(int argc, const char* argv[])
 			fastInterpreter = true;
 		else if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compare"))
 			autoCompare = true;
+		else if (!strcmp(argv[i], "--graphics"))
+			useGraphics = true;
 		else if (bootFilename == 0)
 			bootFilename = argv[i];
 		else
@@ -116,7 +125,7 @@ int main(int argc, const char* argv[])
 		return 1;
 	}
 
-	HeadlessHost *headlessHost = new HEADLESSHOST_CLASS();
+	HeadlessHost *headlessHost = useGraphics ? new HEADLESSHOST_CLASS() : new HeadlessHost();
 	host = headlessHost;
 	host->InitGL();
 

--- a/headless/Headless.vcxproj
+++ b/headless/Headless.vcxproj
@@ -81,7 +81,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../Common;..;../Core;../native/ext/glew;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../Common;..;../Core;../native/ext/glew;../native</AdditionalIncludeDirectories>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <Link>
@@ -112,7 +112,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../Common;..;../Core;../native/ext/glew;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../Common;..;../Core;../native/ext/glew;../native</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -151,6 +151,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="WindowsHeadlessHost.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="headless.txt" />
@@ -174,6 +175,10 @@
     <ProjectReference Include="..\ext\zlib\zlib.vcxproj">
       <Project>{f761046e-6c38-4428-a5f1-38391a37bb34}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="StubHost.h" />
+    <ClInclude Include="WindowsHeadlessHost.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/headless/Headless.vcxproj.filters
+++ b/headless/Headless.vcxproj.filters
@@ -3,8 +3,13 @@
   <ItemGroup>
     <ClCompile Include="Headless.cpp" />
     <ClCompile Include="..\native\ext\glew\glew.c" />
+    <ClCompile Include="WindowsHeadlessHost.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="headless.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="StubHost.h" />
+    <ClInclude Include="WindowsHeadlessHost.h" />
   </ItemGroup>
 </Project>

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "../Core/Host.h"
+
+#define HEADLESSHOST_CLASS HeadlessHost
+
+// TODO: Get rid of this junk
+class HeadlessHost : public Host
+{
+public:
+	// virtual void StartThread()
+	virtual void UpdateUI() {}
+
+	virtual void UpdateMemView() {}
+	virtual void UpdateDisassembly() {}
+
+	virtual void SetDebugMode(bool mode) { }
+
+	virtual void InitGL() {}
+	virtual void BeginFrame() {}
+	virtual void EndFrame() {}
+	virtual void ShutdownGL() {}
+
+	virtual void InitSound(PMixer *mixer) {}
+	virtual void UpdateSound() {}
+	virtual void ShutdownSound() {}
+
+	// this is sent from EMU thread! Make sure that Host handles it properly
+	virtual void BootDone() {}
+	virtual void PrepareShutdown() {}
+
+	virtual bool IsDebuggingEnabled() {return false;}
+	virtual bool AttemptLoadSymbolMap() {return false;}
+
+	virtual bool isGLWorking() { return false; }
+};

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -49,5 +49,7 @@ public:
 	virtual bool IsDebuggingEnabled() {return false;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
 
+	virtual void SendDebugOutput(const std::string &output) { printf("%s", output.c_str()); }
+
 	virtual bool isGLWorking() { return false; }
 };

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "WindowsHeadlessHost.h"
+
+#include <stdio.h>
+#include <windows.h>
+
+#include "../native/gfx_es2/gl_state.h"
+#include "../native/gfx/gl_common.h"
+
+const bool WINDOW_VISIBLE = false;
+const int WINDOW_WIDTH = 480;
+const int WINDOW_HEIGHT = 272;
+
+typedef BOOL (APIENTRY *PFNWGLSWAPINTERVALFARPROC)(int value);
+PFNWGLSWAPINTERVALFARPROC wglSwapIntervalEXT = NULL;
+
+HWND CreateHiddenWindow()
+{
+	static WNDCLASSEX wndClass = {
+		sizeof(WNDCLASSEX),
+		CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+		DefWindowProc,
+		0,
+		0,
+		NULL,
+		NULL,
+		LoadCursor(NULL, IDC_ARROW),
+		(HBRUSH) GetStockObject(BLACK_BRUSH),
+		NULL,
+		"PPSSPPHeadless",
+		NULL,
+	};
+	RegisterClassEx(&wndClass);
+
+	DWORD style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP;
+	return CreateWindowEx(0, "PPSSPPHeadless", "PPSSPPHeadless", style, CW_USEDEFAULT, CW_USEDEFAULT, WINDOW_WIDTH, WINDOW_HEIGHT, NULL, NULL, NULL, NULL);
+}
+
+void SetVSync(int value)
+{
+	const char *extensions = (const char *) glGetString(GL_EXTENSIONS);
+
+	if (!strstr(extensions, "WGL_EXT_swap_control"))
+		return;
+
+	wglSwapIntervalEXT = (PFNWGLSWAPINTERVALFARPROC) wglGetProcAddress("wglSwapIntervalEXT");
+	if (wglSwapIntervalEXT != NULL)
+		wglSwapIntervalEXT(value);
+}
+
+void WindowsHeadlessHost::InitGL()
+{
+	glOkay = false;
+	hWnd = CreateHiddenWindow();
+
+	if (WINDOW_VISIBLE)
+	{
+		ShowWindow(hWnd, TRUE);
+		SetFocus(hWnd);
+	}
+
+	int pixelFormat;
+
+	static PIXELFORMATDESCRIPTOR pfd = {0};
+	pfd.nSize = sizeof(pfd);
+	pfd.nVersion = 1;
+	pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+	pfd.iPixelType = PFD_TYPE_RGBA;
+	pfd.cColorBits = 32;
+	pfd.cDepthBits = 16;
+	pfd.iLayerType = PFD_MAIN_PLANE;
+
+#define ENFORCE(x, msg) { if (!(x)) { fprintf(stderr, msg); return; } }
+
+	ENFORCE(hDC = GetDC(hWnd), "Unable to create DC.");
+	ENFORCE(pixelFormat = ChoosePixelFormat(hDC, &pfd), "Unable to match pixel format.");
+	ENFORCE(SetPixelFormat(hDC, pixelFormat, &pfd), "Unable to set pixel format.");
+	ENFORCE(hRC = wglCreateContext(hDC), "Unable to create GL context.");
+	ENFORCE(wglMakeCurrent(hDC, hRC), "Unable to activate GL context.");
+
+	SetVSync(0);
+
+	glewInit();
+	glstate.Initialize();
+
+	if (ResizeGL())
+		glOkay = true;
+}
+
+void WindowsHeadlessHost::ShutdownGL()
+{
+	if (hRC)
+	{
+		wglMakeCurrent(NULL, NULL);
+		wglDeleteContext(hRC);
+		hRC = NULL;
+	}
+
+	if (hDC)
+		ReleaseDC(hWnd, hDC);
+	hDC = NULL;
+	DestroyWindow(hWnd);
+	hWnd = NULL;
+}
+
+bool WindowsHeadlessHost::ResizeGL()
+{
+	if (!hWnd)
+		return false;
+
+	RECT rc;
+	GetWindowRect(hWnd, &rc);
+
+	glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrtho(0.0f, WINDOW_WIDTH, WINDOW_HEIGHT, 0.0f, -1.0f, 1.0f);
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	return true;
+}
+
+void WindowsHeadlessHost::BeginFrame()
+{
+
+}
+
+void WindowsHeadlessHost::EndFrame()
+{
+	SwapBuffers(hDC);
+}

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -34,11 +34,15 @@ public:
 	virtual void ShutdownGL();
 	virtual bool isGLWorking() { return glOkay; }
 
+	virtual void SendDebugOutput(const std::string &output);
+
 private:
 	bool ResizeGL();
+	void LoadNativeAssets();
 
 	bool glOkay;
 	HWND hWnd;
 	HDC hDC;
 	HGLRC hRC;
+	FILE *out;
 };

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "StubHost.h"
+
+#undef HEADLESSHOST_CLASS
+#define HEADLESSHOST_CLASS WindowsHeadlessHost
+
+#include <windows.h>
+
+// TODO: Get rid of this junk
+class WindowsHeadlessHost : public HeadlessHost
+{
+public:
+	virtual void InitGL();
+	virtual void BeginFrame();
+	virtual void EndFrame();
+	virtual void ShutdownGL();
+	virtual bool isGLWorking() { return glOkay; }
+
+private:
+	bool ResizeGL();
+
+	bool glOkay;
+	HWND hWnd;
+	HDC hDC;
+	HGLRC hRC;
+};


### PR DESCRIPTION
This adds a switch, --graphics, to make headless use the GLES_GPU offscreen.  It starts up slower, though, which is why I made it use a switch.  I didn't use -g for parity with Android (-g = gfx log.)

Not yet tested on Linux, but I tried to make sure it would work just as it did before (same as without --graphics.)  I think it wouldn't be hard to add the actual graphics support for other platforms.

There is a bit of a hack to ignore the printf() logging from native, redirecting stdout to NUL.  That's why I added the hook to Host to get the debug messages instead of printf()'ing them directly, which I personally like better anyway (even if the freopen() is removed.)

That said, there's still no facility to automatically compare, and it doesn't dump shots or anything.  You can change the const WINDOW_VISIBLE to get a visual comparison, though.  Possibly if it does/should update the vram we could even test that way.

Related to #109.

-[Unknown]
