### PR TITLE
Fix fake sceFontGetCharGlyphImage() overflowing

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -316,7 +316,7 @@ int sceFontGetCharGlyphImage(u32 libHandler, u32 charCode, u32 glyphImagePtr)
 	int bytesPerLine = Memory::Read_U16(glyphImagePtr+16);
 	int buffer =Memory::Read_U32(glyphImagePtr+20);
 
-	Memory::Memset(buffer, 0x7F, bytesPerLine*bufHeight*pixelFormat);
+	Memory::Memset(buffer, 0x7F, bytesPerLine * bufHeight);
 
 	return 0;
 }


### PR DESCRIPTION
This gets VC2 farther (hangs on loading) and takes Senjou no Valkyria 3 in game.  Could be properly implemented/loading the kernel module, but this just fixes overflowing the game code's buffer.

It's got some bugs, but Senjou no Valkyria 3 looks _better_ in PPSSPP than JPCSP.  A lot of things that aren't drawn properly in JPCSP are properly drawn in PPSSPP, etc.  Really cool.

But there's some bug going on in semaphores, or else some bug affecting them - I got a semaphore with 16k waiting threads.  Still have to debug that.

-[Unknown]
