### PR TITLE
Prevent duplicate waiting threads in sema/mutex

### DIFF
--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -456,7 +456,10 @@ int sceKernelLockMutex(SceUID id, int count, u32 timeoutPtr)
 		return error;
 	else
 	{
-		mutex->waitingThreads.push_back(__KernelGetCurThread());
+		SceUID threadID = __KernelGetCurThread();
+		// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
+		if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
+			mutex->waitingThreads.push_back(threadID);
 		__KernelWaitMutex(mutex, timeoutPtr);
 		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, false);
 
@@ -481,7 +484,10 @@ int sceKernelLockMutexCB(SceUID id, int count, u32 timeoutPtr)
 		return error;
 	else
 	{
-		mutex->waitingThreads.push_back(__KernelGetCurThread());
+		SceUID threadID = __KernelGetCurThread();
+		// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
+		if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
+			mutex->waitingThreads.push_back(threadID);
 		__KernelWaitMutex(mutex, timeoutPtr);
 		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, true);
 
@@ -813,7 +819,10 @@ int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 		LwMutex *mutex = kernelObjects.Get<LwMutex>(workarea.uid, error);
 		if (mutex)
 		{
-			mutex->waitingThreads.push_back(__KernelGetCurThread());
+			SceUID threadID = __KernelGetCurThread();
+			// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
+			if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
+				mutex->waitingThreads.push_back(threadID);
 			__KernelWaitLwMutex(mutex, timeoutPtr);
 			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, false);
 
@@ -846,7 +855,10 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 		LwMutex *mutex = kernelObjects.Get<LwMutex>(workarea.uid, error);
 		if (mutex)
 		{
-			mutex->waitingThreads.push_back(__KernelGetCurThread());
+			SceUID threadID = __KernelGetCurThread();
+			// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
+			if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
+				mutex->waitingThreads.push_back(threadID);
 			__KernelWaitLwMutex(mutex, timeoutPtr);
 			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, true);
 

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -360,7 +360,11 @@ int __KernelWaitSema(SceUID id, int wantedCount, u32 timeoutPtr, const char *bad
 		else
 		{
 			s->ns.numWaitThreads++;
-			s->waitingThreads.push_back(__KernelGetCurThread());
+
+			SceUID threadID = __KernelGetCurThread();
+			// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
+			if (std::find(s->waitingThreads.begin(), s->waitingThreads.end(), threadID) == s->waitingThreads.end())
+				s->waitingThreads.push_back(threadID);
 			__KernelSetSemaTimeout(s, timeoutPtr);
 			__KernelWaitCurThread(WAITTYPE_SEMA, id, wantedCount, timeoutPtr, processCallbacks);
 		}


### PR DESCRIPTION
If something did a tight loop of a short wait/timeout, it might end up getting on the waitingThreads list multiple times (since removing was deferred.)  Eventually, this build up could cause a massive perf problem.

This (along with #303) fixes Senjou no Valkyria 3, which appears to now be fully playable (minor graphical issues and PGD aside.)  It gets through the first chapter just fine, you can buy things and train, everything works.  Some font characters are missing and there are only minor graphical issues (mainly shadows and lighting) with hardware transform disabled.

I was thinking about it, I guess the correct thing might be to check for timeouts of semas/etc. when considering thread switching.  It seems like the hardware may only be checking a thread's timeout then.  Maybe that would be simpler / have better performance.

That said, this is an easy improvement now and still passes all tests.

-[Unknown]
