### PR TITLE
Use 2.0 alpha value to match real PSP 

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -156,7 +156,7 @@ char *GenerateFragmentShader()
 		}
 		// Color doubling
 		if (gstate.texfunc & 0x10000) {
-			WRITE(p, "  v = v * vec4(2.0, 2.0, 2.0, 1.0);");
+			WRITE(p, "  v = v * vec4(2.0, 2.0, 2.0, 2.0);");
 		}
 
 		if (gstate.alphaTestEnable & 1) {


### PR DESCRIPTION
Tesed with Final fantasy type-0 . 2.0 alpha value used and compared with real PSP
