### PR TITLE
Fix ambient color in SW Transform

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -372,9 +372,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 					c1[j] = 0.0f;
 				}
 			} else {
-				c0[0] = (gstate.materialambient & 0xFF) / 255.f;
-				c0[1] = ((gstate.materialambient >> 8) & 0xFF) / 255.f;
-				c0[2] = ((gstate.materialambient >> 16) & 0xFF) / 255.f;
+				c0[0] = ((gstate.materialambient >> 16) & 0xFF) / 255.f;
+				c0[1] = ((gstate.materialambient >> 8)  & 0xFF) / 255.f;
+				c0[2] = (gstate.materialambient  & 0xFF) / 255.f;
 				c0[3] = (gstate.materialalpha & 0xFF) / 255.f;
 			}
 
@@ -431,9 +431,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			if (reader.hasColor0()) {
 				reader.ReadColor0(unlitColor);
 			} else {
-				unlitColor[0] = (gstate.materialambient & 0xFF) / 255.f;
-				unlitColor[1] = ((gstate.materialambient >> 8) & 0xFF) / 255.f;
-				unlitColor[2] = ((gstate.materialambient >> 16) & 0xFF) / 255.f;
+				unlitColor[0] = ((gstate.materialambient  >> 16) & 0xFF) / 255.f;
+				unlitColor[1] = ((gstate.materialambient >> 8)  & 0xFF) / 255.f;
+				unlitColor[2] = (gstate.materialambient & 0xFF) / 255.f;
 				unlitColor[3] = (gstate.materialalpha & 0xFF) / 255.f;
 			}
 			float litColor0[4];
@@ -462,9 +462,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 						c1[j] = 0.0f;
 					}
 				} else {
-					c0[0] = (gstate.materialambient & 0xFF) / 255.f;
-					c0[1] = ((gstate.materialambient >> 8) & 0xFF) / 255.f;
-					c0[2] = ((gstate.materialambient >> 16) & 0xFF) / 255.f;
+					c0[0] = ((gstate.materialambient >> 16) & 0xFF) / 255.f;
+					c0[1] = ((gstate.materialambient >> 8)  & 0xFF) / 255.f;
+					c0[2] = (gstate.materialambient & 0xFF) / 255.f;
 					c0[3] = (gstate.materialalpha & 0xFF) / 255.f;
 				}
 			}


### PR DESCRIPTION
Material ambient color in  SW T&L should now be exactly same as HW T&L .

It fix the wrong ambient  color in FF Type-0
