### PR TITLE
Implemented sceKernelLoadModuleByID, better logs

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -271,6 +271,7 @@ bool ElfReader::LoadInto(u32 loadAddress)
 	}
 
 	DEBUG_LOG(LOADER,"Relocations:");
+	bool oldRelocs = false;
 
 	// Second pass: Do necessary relocations
 	for (int i=0; i<GetNumSections(); i++)
@@ -305,16 +306,13 @@ bool ElfReader::LoadInto(u32 loadAddress)
 			}
 			else
 			{
-				//We have a relocation table!
-				int sectionToModify = s->sh_info;
-				if (!(sections[sectionToModify].sh_flags & SHF_ALLOC))
-				{
-					ERROR_LOG(LOADER,"Trying to relocate non-loaded section %s, ignoring",GetSectionName(sectionToModify));
-					continue;
-				}
-				ERROR_LOG(LOADER,"Traditional relocations unsupported.");
+				oldRelocs = true;
 			}
 		}
+	}
+	if (oldRelocs)
+	{
+		INFO_LOG(LOADER, "Game uses old relocations (often for debugging, should be harmless)");
 	}
 
 	// Segment relocations (a few games use them)

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -271,7 +271,6 @@ bool ElfReader::LoadInto(u32 loadAddress)
 	}
 
 	DEBUG_LOG(LOADER,"Relocations:");
-	bool oldRelocs = false;
 
 	// Second pass: Do necessary relocations
 	for (int i=0; i<GetNumSections(); i++)
@@ -300,19 +299,22 @@ bool ElfReader::LoadInto(u32 loadAddress)
 		else if (s->sh_type == SHT_REL)
 		{
 			DEBUG_LOG(LOADER, "Traditional relocation section found.");
-			if (bRelocate)
+			if (!bRelocate)
 			{
 				DEBUG_LOG(LOADER, "Binary is prerelocated. Skipping relocations.");
 			}
 			else
 			{
-				oldRelocs = true;
+				//We have a relocation table!
+				int sectionToModify = s->sh_info;
+				if (!(sections[sectionToModify].sh_flags & SHF_ALLOC))
+				{
+					ERROR_LOG(LOADER,"Trying to relocate non-loaded section %s, ignoring",GetSectionName(sectionToModify));
+					continue;
+				}
+				ERROR_LOG(LOADER,"Traditional relocations unsupported.");
 			}
 		}
-	}
-	if (oldRelocs)
-	{
-		INFO_LOG(LOADER, "Game uses old relocations (often for debugging, should be harmless)");
 	}
 
 	// Segment relocations (a few games use them)

--- a/Core/ELF/PrxDecrypter.h
+++ b/Core/ELF/PrxDecrypter.h
@@ -19,6 +19,8 @@
 
 #include "../../Globals.h"
 
+#define MISSING_KEY -10
+
 #ifdef _MSC_VER
 #pragma pack(push, 1)
 #endif

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -490,19 +490,22 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 		return x;
 #endif
 	}
-	x.type = File::IsDirectory(fullName) ? FILETYPE_NORMAL : FILETYPE_DIRECTORY;
+	x.type = File::IsDirectory(fullName) ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 	x.exists = true;
 
+	if (x.type != FILETYPE_DIRECTORY)
+	{
 #ifdef _WIN32
-	WIN32_FILE_ATTRIBUTE_DATA data;
-	GetFileAttributesEx(fullName.c_str(), GetFileExInfoStandard, &data);
+		WIN32_FILE_ATTRIBUTE_DATA data;
+		GetFileAttributesEx(fullName.c_str(), GetFileExInfoStandard, &data);
 
-	x.size = data.nFileSizeLow | ((u64)data.nFileSizeHigh<<32);
+		x.size = data.nFileSizeLow | ((u64)data.nFileSizeHigh<<32);
 #else
-	x.size = File::GetSize(fullName);
-	//TODO
+		x.size = File::GetSize(fullName);
+		//TODO
 #endif
-	x.mtime = File::GetModifTime(fullName);
+		x.mtime = File::GetModifTime(fullName);
+	}
 
 	return x;
 }

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -240,7 +240,7 @@ nextblock:
 
 }
 
-ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path)
+ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catchError)
 {
 	if (path.length() == 0)
 	{
@@ -297,7 +297,10 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path)
 		}
 		else
 		{
-			ERROR_LOG(FILESYS,"File %s not found", path.c_str());
+			if (catchError)
+			{
+				ERROR_LOG(FILESYS,"File %s not found", path.c_str());
+			}
 			return 0;
 		}
 	}
@@ -502,7 +505,7 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename)
 		return fileInfo;
 	}
 
-	TreeEntry *entry = GetFromPath(filename);
+	TreeEntry *entry = GetFromPath(filename, false);
 	PSPFileInfo x; 
 	if (!entry)
 	{

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -67,7 +67,7 @@ class ISOFileSystem : public IFileSystem
 	TreeEntry entireISO;
 
 	void ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root);
-	TreeEntry *GetFromPath(std::string path);
+	TreeEntry *GetFromPath(std::string path, bool catchError=true);
 	std::string EntryFullPath(TreeEntry *e);
 
 public:

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -20,7 +20,6 @@
 #undef DeleteFile
 #endif
 
-#include "../System.h"
 #include "../Config.h"
 #include "../Host.h"
 #include "../SaveState.h"
@@ -120,43 +119,6 @@ struct dirent {
 	char name[0x108];
 };
 #endif
-
-class FileNode : public KernelObject {
-public:
-	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), pendingAsyncResult(false), sectorBlockMode(false) {}
-	~FileNode() {
-		pspFileSystem.CloseFile(handle);
-	}
-	const char *GetName() {return fullpath.c_str();}
-	const char *GetTypeName() {return "OpenFile";}
-	void GetQuickInfo(char *ptr, int size) {
-		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
-	}
-	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
-	int GetIDType() const { return PPSSPP_KERNEL_TMID_File; }
-
-	virtual void DoState(PointerWrap &p) {
-		p.Do(fullpath);
-		p.Do(handle);
-		p.Do(callbackID);
-		p.Do(callbackArg);
-		p.Do(asyncResult);
-		p.Do(pendingAsyncResult);
-		p.Do(sectorBlockMode);
-		p.DoMarker("File");
-	}
-
-	std::string fullpath;
-	u32 handle;
-
-	u32 callbackID;
-	u32 callbackArg;
-
-	u32 asyncResult;
-
-	bool pendingAsyncResult;
-	bool sectorBlockMode;
-};
 
 void __IoInit() {
 	INFO_LOG(HLE, "Starting up I/O...");

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -120,6 +120,43 @@ struct dirent {
 };
 #endif
 
+class FileNode : public KernelObject {
+public:
+	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), pendingAsyncResult(false), sectorBlockMode(false) {}
+	~FileNode() {
+		pspFileSystem.CloseFile(handle);
+	}
+	const char *GetName() {return fullpath.c_str();}
+	const char *GetTypeName() {return "OpenFile";}
+	void GetQuickInfo(char *ptr, int size) {
+		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
+	}
+	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
+	int GetIDType() const { return PPSSPP_KERNEL_TMID_File; }
+
+	virtual void DoState(PointerWrap &p) {
+		p.Do(fullpath);
+		p.Do(handle);
+		p.Do(callbackID);
+		p.Do(callbackArg);
+		p.Do(asyncResult);
+		p.Do(pendingAsyncResult);
+		p.Do(sectorBlockMode);
+		p.DoMarker("File");
+	}
+
+	std::string fullpath;
+	u32 handle;
+
+	u32 callbackID;
+	u32 callbackArg;
+
+	u32 asyncResult;
+
+	bool pendingAsyncResult;
+	bool sectorBlockMode;
+};
+
 void __IoInit() {
 	INFO_LOG(HLE, "Starting up I/O...");
 
@@ -173,6 +210,15 @@ void __IoDoState(PointerWrap &p) {
 void __IoShutdown() {
 	defAction = 0;
 	defParam = 0;
+}
+
+u32 __IoGetFileHandleFromId(u32 id, u32 &outError)
+{
+	FileNode *f = kernelObjects.Get < FileNode > (id, outError);
+	if (!f) {
+		return -1;
+	}
+	return f->handle;
 }
 
 u32 sceIoAssign(const char *aliasname, const char *physname, const char *devname, u32 flag) {

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -18,8 +18,47 @@
 #pragma once
 
 #include <string>
+
+#include "../System.h"
 #include "HLE.h"
 #include "sceKernel.h"
+
+class FileNode : public KernelObject {
+public:
+	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), pendingAsyncResult(false), sectorBlockMode(false) {}
+	~FileNode() {
+		pspFileSystem.CloseFile(handle);
+	}
+	const char *GetName() {return fullpath.c_str();}
+	const char *GetTypeName() {return "OpenFile";}
+	void GetQuickInfo(char *ptr, int size) {
+		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
+	}
+	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
+	int GetIDType() const { return PPSSPP_KERNEL_TMID_File; }
+
+	virtual void DoState(PointerWrap &p) {
+		p.Do(fullpath);
+		p.Do(handle);
+		p.Do(callbackID);
+		p.Do(callbackArg);
+		p.Do(asyncResult);
+		p.Do(pendingAsyncResult);
+		p.Do(sectorBlockMode);
+		p.DoMarker("File");
+	}
+
+	std::string fullpath;
+	u32 handle;
+
+	u32 callbackID;
+	u32 callbackArg;
+
+	u32 asyncResult;
+
+	bool pendingAsyncResult;
+	bool sectorBlockMode;
+};
 
 void __IoInit();
 void __IoDoState(PointerWrap &p);

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -23,46 +23,10 @@
 #include "HLE.h"
 #include "sceKernel.h"
 
-class FileNode : public KernelObject {
-public:
-	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), pendingAsyncResult(false), sectorBlockMode(false) {}
-	~FileNode() {
-		pspFileSystem.CloseFile(handle);
-	}
-	const char *GetName() {return fullpath.c_str();}
-	const char *GetTypeName() {return "OpenFile";}
-	void GetQuickInfo(char *ptr, int size) {
-		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
-	}
-	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
-	int GetIDType() const { return PPSSPP_KERNEL_TMID_File; }
-
-	virtual void DoState(PointerWrap &p) {
-		p.Do(fullpath);
-		p.Do(handle);
-		p.Do(callbackID);
-		p.Do(callbackArg);
-		p.Do(asyncResult);
-		p.Do(pendingAsyncResult);
-		p.Do(sectorBlockMode);
-		p.DoMarker("File");
-	}
-
-	std::string fullpath;
-	u32 handle;
-
-	u32 callbackID;
-	u32 callbackArg;
-
-	u32 asyncResult;
-
-	bool pendingAsyncResult;
-	bool sectorBlockMode;
-};
-
 void __IoInit();
 void __IoDoState(PointerWrap &p);
 void __IoShutdown();
+u32 __IoGetFileHandleFromId(u32 id, u32 &outError);
 KernelObject *__KernelFileNodeObject();
 KernelObject *__KernelDirListingObject();
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -794,8 +794,8 @@ void sceKernelFindModuleByName()
 u32 sceKernelLoadModuleByID(u32 id, u32 flags, u32 lmoptionPtr)
 {
 	u32 error;
-	FileNode *f = kernelObjects.Get < FileNode > (id, error);
-	if (!f) {
+	u32 handle = __IoGetFileHandleFromId(id, error);
+	if (handle < 0) {
 		ERROR_LOG(HLE,"sceKernelLoadModuleByID(%08x, %08x, %08x): could not open file id",id,flags,lmoptionPtr);
 		return error;
 	}
@@ -803,13 +803,13 @@ u32 sceKernelLoadModuleByID(u32 id, u32 flags, u32 lmoptionPtr)
 	if (lmoptionPtr) {
 		lmoption = (SceKernelLMOption *)Memory::GetPointer(lmoptionPtr);
 	}
-	u32 pos = pspFileSystem.SeekFile(f->handle, 0, FILEMOVE_CURRENT);
-	u32 size = pspFileSystem.SeekFile(f->handle, 0, FILEMOVE_END);
+	u32 pos = pspFileSystem.SeekFile(handle, 0, FILEMOVE_CURRENT);
+	u32 size = pspFileSystem.SeekFile(handle, 0, FILEMOVE_END);
 	std::string error_string;
-	pspFileSystem.SeekFile(f->handle, pos, FILEMOVE_BEGIN);
+	pspFileSystem.SeekFile(handle, pos, FILEMOVE_BEGIN);
 	Module *module = 0;
 	u8 *temp = new u8[size];
-	pspFileSystem.ReadFile(f->handle, temp, size);
+	pspFileSystem.ReadFile(handle, temp, size);
 	module = __KernelLoadELFFromPtr(temp, 0, &error_string);
 	delete [] temp;
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -313,8 +313,8 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			{
 				delete [] newptr;
 			}
-			kernelObjects.Destroy<Module>(module->GetUID());
-			return 0;
+			module->isFake = true;
+			return module;
 		}
 	}
 


### PR DESCRIPTION
It won't output errors for nothing: I removed errors for traditional relocations (replaced with one INFO log), and the module is now kept if it couldn't be decrypted because of missing keys (added isFake member of Module in order to know if the module can be started etc. or not), etc.
Also "implemented" basic ~SCE. Should be useless anyway, only kernel modules (sometimes packed with games though) use it.

EDIT: in last commit, also added a minor fix in directory file system: in GetFileInfo, files were stated as being directories and vice-versa.
