### PR TITLE
Fix sceKernelLibcTime() when time_t is 64 bit

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -75,7 +75,7 @@ const HLEFunction FakeSysCalls[] =
 const HLEFunction UtilsForUser[] = 
 {
 	{0x91E4F6A7, WrapU_V<sceKernelLibcClock>, "sceKernelLibcClock"},
-	{0x27CC57F0, sceKernelLibcTime, "sceKernelLibcTime"},
+	{0x27CC57F0, WrapU_U<sceKernelLibcTime>, "sceKernelLibcTime"},
 	{0x71EC4271, sceKernelLibcGettimeofday, "sceKernelLibcGettimeofday"},
 	{0xBFA98062, WrapV_UI<sceKernelDcacheInvalidateRange>, "sceKernelDcacheInvalidateRange"},
 	{0xC8186A58, 0, "sceKernelUtilsMd5Digest"},

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -112,14 +112,17 @@ u32 sceKernelLibcClock()
 	return retVal;
 }
 
-void sceKernelLibcTime()
+u32 sceKernelLibcTime(u32 outPtr)
 {
-	time_t *t = 0;
-	if (PARAM(0))
-		t = (time_t*)Memory::GetPointer(PARAM(0));
-	u32 retVal = (u32)time(t);
-	DEBUG_LOG(HLE,"%i = sceKernelLibcTime()",retVal);
-	RETURN(retVal);
+	time_t t;
+	time(&t);
+
+	DEBUG_LOG(HLE, "%i = sceKernelLibcTime(%08X)", (u32) t, outPtr);
+
+	if (Memory::IsValidAddress(outPtr))
+		Memory::Write_U32((u32) t, outPtr);
+
+	return (u32) t;
 }
 
 void sceKernelLibcGettimeofday()

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -18,7 +18,7 @@
 #pragma once
 
 void sceKernelLibcGettimeofday();
-void sceKernelLibcTime();
+u32 sceKernelLibcTime(u32 outPtr);
 void sceKernelUSec2SysClock();
 void sceKernelGetSystemTime();
 void sceKernelGetSystemTimeLow();


### PR DESCRIPTION
Brings Aero Racer in game (had been corrupting its stack.)  May fix other games.

Aero Racer is interesting, its graphics are totally messed up with hardware transforms on or off, but in different ways.  Also it locks up in jit but works fine in interp.

-[Unknown]
