### PR TITLE
Libc memcpy/etc. fixes

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -75,7 +75,7 @@ const HLEFunction FakeSysCalls[] =
 const HLEFunction UtilsForUser[] = 
 {
 	{0x91E4F6A7, WrapU_V<sceKernelLibcClock>, "sceKernelLibcClock"},
-	{0x27CC57F0, sceKernelLibcTime, "sceKernelLibcTime"},
+	{0x27CC57F0, WrapU_U<sceKernelLibcTime>, "sceKernelLibcTime"},
 	{0x71EC4271, sceKernelLibcGettimeofday, "sceKernelLibcGettimeofday"},
 	{0xBFA98062, WrapV_UI<sceKernelDcacheInvalidateRange>, "sceKernelDcacheInvalidateRange"},
 	{0xC8186A58, 0, "sceKernelUtilsMd5Digest"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -79,6 +79,7 @@ void __KernelInit()
 	}
 
 	SaveState::Init();
+	__KernelTimeInit();
 	__InterruptsInit();
 	__KernelMemoryInit();
 	__KernelThreadingInit();
@@ -154,6 +155,7 @@ void __KernelDoState(PointerWrap &p)
 	__KernelModuleDoState(p);
 	__KernelMutexDoState(p);
 	__KernelSemaDoState(p);
+	__KernelTimeDoState(p);
 
 	__AudioDoState(p);
 	__CtrlDoState(p);

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -107,8 +107,8 @@ u32 sceKernelUSec2SysClockWide(u32 usec)
 
 u32 sceKernelLibcClock()
 {
-	u32 retVal = clock()*1000;  // TODO: This can't be right
-	DEBUG_LOG(HLE,"%i = sceKernelLibcClock",retVal);
+	u32 retVal = (u32) (CoreTiming::GetTicks() / CoreTiming::GetClockFrequencyMHz());
+	DEBUG_LOG(HLE, "%i = sceKernelLibcClock", retVal);
 	return retVal;
 }
 
@@ -121,6 +121,8 @@ u32 sceKernelLibcTime(u32 outPtr)
 
 	if (Memory::IsValidAddress(outPtr))
 		Memory::Write_U32((u32) t, outPtr);
+	else if (outPtr != 0)
+		return 0;
 
 	return (u32) t;
 }

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -112,14 +112,17 @@ u32 sceKernelLibcClock()
 	return retVal;
 }
 
-void sceKernelLibcTime()
+u32 sceKernelLibcTime(u32 outPtr)
 {
-	time_t *t = 0;
-	if (PARAM(0))
-		t = (time_t*)Memory::GetPointer(PARAM(0));
-	u32 retVal = (u32)time(t);
-	DEBUG_LOG(HLE,"%i = sceKernelLibcTime()",retVal);
-	RETURN(retVal);
+	time_t t;
+	time(&t);
+
+	DEBUG_LOG(HLE, "%i = sceKernelLibcTime(%08X)", (u32) t, outPtr);
+
+	if (Memory::IsValidAddress(outPtr))
+		Memory::Write_U32((u32) t, outPtr);
+
+	return (u32) t;
 }
 
 void sceKernelLibcGettimeofday()

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -31,8 +31,26 @@
 #include "../CoreTiming.h"
 
 //////////////////////////////////////////////////////////////////////////
+// State
+//////////////////////////////////////////////////////////////////////////
+
+// The time when the game started.
+time_t start_time;
+
+//////////////////////////////////////////////////////////////////////////
 // Other clock stuff
 //////////////////////////////////////////////////////////////////////////
+
+void __KernelTimeInit()
+{
+	time(&start_time);
+}
+
+void __KernelTimeDoState(PointerWrap &p)
+{
+	p.Do(start_time);
+	p.DoMarker("sceKernelTime");
+}
 
 struct SceKernelSysClock
 {
@@ -114,17 +132,16 @@ u32 sceKernelLibcClock()
 
 u32 sceKernelLibcTime(u32 outPtr)
 {
-	time_t t;
-	time(&t);
+	u32 t = (u32) start_time + (u32) (CoreTiming::GetTicks() / CPU_HZ);
 
-	DEBUG_LOG(HLE, "%i = sceKernelLibcTime(%08X)", (u32) t, outPtr);
+	DEBUG_LOG(HLE, "%i = sceKernelLibcTime(%08X)", t, outPtr);
 
 	if (Memory::IsValidAddress(outPtr))
-		Memory::Write_U32((u32) t, outPtr);
+		Memory::Write_U32(t, outPtr);
 	else if (outPtr != 0)
 		return 0;
 
-	return (u32) t;
+	return t;
 }
 
 void sceKernelLibcGettimeofday()

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -18,7 +18,7 @@
 #pragma once
 
 void sceKernelLibcGettimeofday();
-void sceKernelLibcTime();
+u32 sceKernelLibcTime(u32 outPtr);
 void sceKernelUSec2SysClock();
 void sceKernelGetSystemTime();
 void sceKernelGetSystemTimeLow();

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -27,3 +27,6 @@ void sceKernelSysClock2USec();
 void sceKernelSysClock2USecWide();
 u32 sceKernelUSec2SysClockWide(u32 usec);
 u32 sceKernelLibcClock();
+
+void __KernelTimeInit();
+void __KernelTimeDoState(PointerWrap &p);


### PR DESCRIPTION
Includes #309.  I don't know of any games this fixes so may be better to defer until later.  That said, the return value for memcpy/memset was definitely wrong.

Probably makes `sceKernelMemcpy()` slower, but trying to be more accurate in case it matters.  I don't see it called often so I'm not too worried about speed, but I'm happy to revert that change.

Makes  hrydgard/pspautotests#35 pass.

-[Unknown]
