### PR TITLE
Fixed $k0 overwriting $sp content, and the stack address given by sceKernelReferThreadStatus

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -366,10 +366,10 @@ public:
 		// Fill the stack.
 		Memory::Memset(stackBlock, 0xFF, stackSize);
 		context.r[MIPS_REG_SP] = stackBlock + stackSize;
-		nt.initialStack = context.r[MIPS_REG_SP];
+		nt.initialStack = stackBlock;
 		nt.stackSize = stackSize;
 		// What's this 512?
-		context.r[MIPS_REG_K0] = context.r[MIPS_REG_SP] - 512;
+		context.r[MIPS_REG_K0] = context.r[MIPS_REG_SP] - 256;
 		context.r[MIPS_REG_SP] -= 512;
 		return true;
 	}


### PR DESCRIPTION
Fixes Bomberman Panic Bomber along with Harvest Moon: Innocent Life's main menu screen (and maybe others; who knows?).
However, it may include regressions, although I don't think I've seen any (I think I'm seeing more memory errors, but they're not fatal and I'm not sure my changes caused them). To include or not to include in 0.5, that'll be the tricky question you'll have to answer. ;)
