### PR TITLE
Load ELFs at the correct place

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -201,10 +201,21 @@ bool ElfReader::LoadInto(u32 loadAddress)
 		}
 	}
 	u32 totalSize = totalEnd - totalStart;
-	if (loadAddress)
-		vaddr = userMemory.AllocAt(loadAddress, totalSize, "ELF");
+	if (!bRelocate)
+	{
+		// Binary is prerelocated, load it where the first segment starts
+		vaddr = userMemory.AllocAt(totalStart, totalSize, "ELF");
+	}
+	else if (loadAddress)
+	{
+		// Binary needs to be relocated: add loadAddress to the binary start address
+		vaddr = userMemory.AllocAt(loadAddress + totalStart, totalSize, "ELF");
+	}
 	else
+	{
+		// Just put it where there is room
 		vaddr = userMemory.Alloc(totalSize, false, "ELF");
+	}
 
 	if (vaddr == -1) {
 		ERROR_LOG(LOADER, "Failed to allocate memory for ELF!");


### PR DESCRIPTION
Makes ELF allocate the correct size for the binary: when the binary doesn't start at 0 (or 0x08800000 if prerelocated), it still allocated at the offset 0, so the allocated memory space ended before the end of the space the ELF needed.
Fixes Little Big Planet bootstart (the game fails after choosing the language though), Project Diva 1 and 2, and probably others.
