### PR TITLE
Delete mpeg objects properly, fixing double free.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -409,7 +409,7 @@ int sceMpegDelete(u32 mpeg)
 
 	delete ctx->mediaengine;
 	delete ctx;
-	mpegMap.erase(mpeg);
+	mpegMap.erase(Memory::Read_U32(mpeg));
 
 	return 0;
 }


### PR DESCRIPTION
A simple fix, really.  Was not removing anything from the map, so it tried to delete it again later.

-[Unknown]
