### PR TITLE
Use 100% because 80% is in some games' deadzone

### DIFF
--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -43,16 +43,16 @@ int KeyboardDevice::UpdateState() {
 
 		switch (analog_ctrl_map[i + 1]) {
 		case CTRL_UP:
-			analogY += .8f;
+			analogY += 1.0f;
 			break;
 		case CTRL_DOWN:
-			analogY -= .8f;
+			analogY -= 1.0f;
 			break;
 		case CTRL_LEFT:
-			analogX -= .8f;
+			analogX -= 1.0f;
 			break;
 		case CTRL_RIGHT:
-			analogX += .8f;
+			analogX += 1.0f;
 			break;
 		}
 	}


### PR DESCRIPTION
Like Senjou no Valkyria 3.  Also some games register it but move slow.

I suppose it'd be nice to be able to half press it but controls that work too fast are better than controls that don't work at all.

-[Unknown]
