### PR TITLE
Fix crash from lastShader pointer = 0xcdcdcdcd

### DIFF
--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -133,7 +133,7 @@ private:
 class ShaderManager
 {
 public:
-	ShaderManager() : globalDirty(0xFFFFFFFF) {}
+	ShaderManager() : lastShader(NULL), globalDirty(0xFFFFFFFF) {}
 
 	void ClearCache(bool deleteThem);  // TODO: deleteThem currently not respected
 	LinkedShader *ApplyShader(int prim);


### PR DESCRIPTION
ShaderManager::lastShader is uninitialized (0xcdcdcdcd), which causes a crash for me. Making the class constructor set lastShader to NULL seems to fix it.
