### PR TITLE
Process module exports and listen to them

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -204,6 +204,10 @@ void WriteSyscall(const char *moduleName, u32 nib, u32 address)
 		strncpy(sysc.moduleName, moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
 		sysc.moduleName[KERNELOBJECT_MAX_NAME_LENGTH] = '\0';
 		unresolvedSyscalls.push_back(sysc);
+
+		// Write a trap so we notice this func if it's called before resolving.
+		Memory::Write_U32(MIPS_MAKE_JR_RA(), address); // jr ra
+		Memory::Write_U32(GetSyscallOp("(invalid syscall)", nib), address + 4);
 	}
 }
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -512,31 +512,33 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			switch (nid)
 			{
 			case NID_MODULE_INFO:
-				// TODO
 				break;
 			case NID_MODULE_START_THREAD_PARAMETER:
-				// TODO: What's at 0?
+				if (Memory::Read_U32(exportAddr) != 3)
+					WARN_LOG(LOADER, "Strange value at module_start_thread_parameter export: %08x", Memory::Read_U32(exportAddr));
 				module->nm.module_start_thread_priority = Memory::Read_U32(exportAddr + 4);
 				module->nm.module_start_thread_stacksize = Memory::Read_U32(exportAddr + 8);
 				module->nm.module_start_thread_attr = Memory::Read_U32(exportAddr + 12);
 				break;
 			case NID_MODULE_STOP_THREAD_PARAMETER:
-				// TODO: What's at 0?
+				if (Memory::Read_U32(exportAddr) != 3)
+					WARN_LOG(LOADER, "Strange value at module_stop_thread_parameter export: %08x", Memory::Read_U32(exportAddr));
 				module->nm.module_stop_thread_priority = Memory::Read_U32(exportAddr + 4);
 				module->nm.module_stop_thread_stacksize = Memory::Read_U32(exportAddr + 8);
 				module->nm.module_stop_thread_attr = Memory::Read_U32(exportAddr + 12);
 				break;
 			case NID_MODULE_REBOOT_BEFORE_THREAD_PARAMETER:
-				// TODO: What's at 0?
+				if (Memory::Read_U32(exportAddr) != 3)
+					WARN_LOG(LOADER, "Strange value at module_reboot_before_thread_parameter export: %08x", Memory::Read_U32(exportAddr));
 				module->nm.module_reboot_before_thread_priority = Memory::Read_U32(exportAddr + 4);
 				module->nm.module_reboot_before_thread_stacksize = Memory::Read_U32(exportAddr + 8);
 				module->nm.module_reboot_before_thread_attr = Memory::Read_U32(exportAddr + 12);
 				break;
 			case NID_MODULE_SDK_VERSION:
-				// TODO
+				DEBUG_LOG(LOADER, "Module SDK: %08x", Memory::Read_U32(exportAddr));
 				break;
 			default:
-				// TODO
+				DEBUG_LOG(LOADER, "Unexpected variable with nid: %08x", nid);
 				break;
 			}
 		}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -641,12 +641,6 @@ void __KernelStartModule(Module *m, int args, const char *argp, SceKernelSMOptio
 	{
 		if (m->nm.module_start_func != m->nm.entry_addr)
 			WARN_LOG(LOADER, "Main module has start func (%08x) different from entry (%08x)?", m->nm.module_start_func, m->nm.entry_addr);
-		if (m->nm.module_start_thread_priority != 0 && m->nm.module_start_thread_priority != options->priority)
-			WARN_LOG(LOADER, "Main module has different priority (%02x vs. %02x)", m->nm.module_start_thread_priority, options->priority);
-		if (m->nm.module_start_thread_stacksize != 0 && m->nm.module_start_thread_stacksize != options->stacksize)
-			WARN_LOG(LOADER, "Main module has different stack size (%08x vs. %08x)", m->nm.module_start_thread_stacksize, options->stacksize);
-		if (m->nm.module_start_thread_attr != 0 && m->nm.module_start_thread_attr != options->attribute)
-			WARN_LOG(LOADER, "Main module has different attr (%08x vs. %08x)", m->nm.module_start_thread_attr, options->attribute);
 	}
 
 	__KernelSetupRootThread(m->GetUID(), args, argp, options->priority, options->stacksize, options->attribute);
@@ -707,6 +701,14 @@ bool __KernelLoadExec(const char *filename, SceKernelLoadExecParam *param, std::
 	option.mpidstack = 2;
 	option.priority = 0x20;
 	option.stacksize = 0x40000;	// crazy? but seems to be the truth
+
+	// Replace start options with module-specified values if they exist.
+	if (module->nm.module_start_thread_attr != 0)
+		option.attribute = module->nm.module_start_thread_attr;
+	if (module->nm.module_start_thread_priority != 0)
+		option.priority = module->nm.module_start_thread_priority;
+	if (module->nm.module_start_thread_stacksize != 0)
+		option.stacksize = module->nm.module_start_thread_stacksize;
 
 	__KernelStartModule(module, (u32)strlen(filename) + 1, filename, &option);
 


### PR DESCRIPTION
This can affect a module start thread's stack and priority, which in turn can cause memory allocation to fail on startup.  Most credit has to go to JPCSP for the NIDs.

Fixes Fieldrunners, Ys Seven, and Shadow of Destiny to actually start.  The first two go somewhere too.  Probably other games as well.

The export linkage is ultimately needed for games like Valkyrie Profile: Lenneth which use `sceKernelLoadModule()` for internal cross-linked modules (I have code that seems to make `sceKernelStartModule()` work so this is testable, but I want to figure out how to make a test for it...)

While messing with this, I noticed that unresolved modules are left as a "jr; nop".  I had to trace it to notice it was going into nop-land.

Would it be better to encode an unknown syscall for unresolved exports?  That way, if a game is trying to call a func over and over it would show up in logs.

-[Unknown]
