### PR TITLE
Add a couple unknown syscalls hit in games

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -377,6 +377,7 @@ const HLEFunction sceAtrac3plus[] =
 	{0x9CD7DE03,0,"sceAtracSetMOutHalfwayBufferAndGetID"},
 	{0x5622B7C1,WrapI_UIIU<sceAtracSetAA3DataAndGetID>,"sceAtracSetAA3DataAndGetID"},
 	{0x5DD66588,0,"sceAtracSetAA3HalfwayBufferAndGetID"},
+	{0x231FC6B7,0,"_sceAtracGetContextAddress"},
 };
 
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1144,6 +1144,8 @@ const HLEFunction sceMp3[] =
 	{0xD0A56296,WrapI_U<sceMp3CheckStreamDataNeeded>,"sceMp3CheckStreamDataNeeded"},
 	{0xD8F54A51,0,"sceMp3GetLoopNum"},
 	{0xF5478233,0,"sceMp3ReleaseMp3Handle"},
+	{0xAE6D2027,0,"sceMp3GetVersion"},
+	{0x3548AEC8,0,"sceMp3GetFrameNum"},
 };
 
 void Register_sceMpeg()


### PR DESCRIPTION
Specifically Velocity and Mad Blocker Alpha.  Suspect stubbing these properly would make those games get past loading, but I'll do it later (or someone else will.)  Anyway, easier for logs.

-[Unknown]
