### PR TITLE
Fix sce_lbn handling

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -337,6 +337,12 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access)
 	{
 		u32 sectorStart = 0xFFFFFFFF, readSize = 0xFFFFFFFF;
 		parseLBN(filename, &sectorStart, &readSize);
+		if (sectorStart >= blockDevice->GetNumBlocks())
+		{
+			WARN_LOG(FILESYS, "Unable to open raw sector: %s, sector %08x, max %08x", filename.c_str(), sectorStart, blockDevice->GetNumBlocks());
+			return 0;
+		}
+
 		INFO_LOG(FILESYS, "Got a raw sector open: %s, sector %08x, size %08x", filename.c_str(), sectorStart, readSize);
 		u32 newHandle = hAlloc->GetNewHandle();
 		entry.seekPos = 0;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -411,8 +411,7 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 		u32 positionOnIso;
 		if (e.isRawSector)
 		{
-			// TODO: this seems bogus
-			positionOnIso = e.sectorStart * 2048;
+			positionOnIso = e.sectorStart * 2048 + e.seekPos;
 			
 			if (e.seekPos + size > e.openSize)
 			{
@@ -487,7 +486,7 @@ size_t ISOFileSystem::SeekFile(u32 handle, s32 position, FileMove type)
 			break;
 		case FILEMOVE_END:
 			if (e.isRawSector)
-				e.seekPos = e.openSize;
+				e.seekPos = e.openSize + position;
 			else
 				e.seekPos = (unsigned int)(e.file->size + position);
 			break;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -27,15 +27,29 @@ const int sectorSize = 2048;
 
 static bool parseLBN(std::string filename, u32 *sectorStart, u32 *readSize)
 {
-	if (filename.substr(0, 8) != "/sce_lbn")
+	// Looks like: /sce_lbn0x10_size0x100 or /sce_lbn10_size100 (always hex.)
+	if (filename.compare(0, sizeof("/sce_lbn") - 1, "/sce_lbn") != 0)
 		return false;
-	std::string prev = filename;
-	filename.erase(0, 10);
-	if (sscanf(filename.c_str(), "%08x", sectorStart) != 1)
-		WARN_LOG(FILESYS, "Invalid LBN reference: %s", prev.c_str());
-	filename.erase(0, filename.find("_size") + 7);
-	if (sscanf(filename.c_str(), "%08x", readSize) != 1)
-		WARN_LOG(FILESYS, "Incomplete LBN reference: %s", prev.c_str());
+
+	size_t pos = sizeof("/sce_lbn") - 1;
+	const char *filename_c = filename.c_str();
+
+	int offset = 0;
+	if (sscanf(filename_c + pos, "%x%n", sectorStart, &offset) != 1)
+		WARN_LOG(FILESYS, "Invalid LBN reference: %s", filename_c);
+	pos += offset;
+
+	if (filename.compare(pos, sizeof("_size") - 1, "_size") != 0)
+		WARN_LOG(FILESYS, "Invalid LBN reference: %s", filename_c);
+	pos += sizeof("_size") - 1;
+
+	offset = 0;
+	if (sscanf(filename_c + pos, "%x%n", readSize, &offset) != 1)
+		WARN_LOG(FILESYS, "Invalid LBN reference: %s", filename_c);
+	pos += offset;
+
+	if (filename.size() > pos)
+		WARN_LOG(FILESYS, "Incomplete LBN reference: %s", filename_c);
 	return true;
 }
 

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -169,7 +169,7 @@ bool MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpat
 	// Special handling: host0:command.txt (as seen in Super Monkey Ball Adventures, for example)
 	// appears to mean the current directory on the UMD. Let's just assume the current directory.
 	std::string inpath = _inpath;
-	if (inpath.substr(0, 6) == "host0:") {
+	if (strncasecmp(inpath.c_str(), "host0:", 5) == 0) {
 		INFO_LOG(HLE, "Host0 path detected, stripping: %s", inpath.c_str());
 		inpath = inpath.substr(6);
 	}
@@ -179,7 +179,7 @@ bool MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpat
 		for (size_t i = 0; i < fileSystems.size(); i++)
 		{
 			size_t prefLen = fileSystems[i].prefix.size();
-			if (fileSystems[i].prefix == realpath.substr(0, prefLen))
+			if (strncasecmp(fileSystems[i].prefix.c_str(), realpath.c_str(), prefLen) == 0)
 			{
 				outpath = realpath.substr(prefLen);
 				*system = fileSystems[i].system;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -64,10 +64,6 @@ bool Load_PSP_ISO(const char *filename, std::string *error_string)
 	pspFileSystem.Mount("umd1:", umd2);
 	pspFileSystem.Mount("disc0:", umd2);
 	pspFileSystem.Mount("umd:", umd2);
-	pspFileSystem.Mount("UMD0:", umd2);
-	pspFileSystem.Mount("UMD1:", umd2);
-	pspFileSystem.Mount("DISC0:", umd2);
-	pspFileSystem.Mount("UMD:", umd2);
 
 	std::string sfoPath("disc0:/PSP_GAME/PARAM.SFO");
 	PSPFileInfo fileInfo = pspFileSystem.GetFileInfo(sfoPath.c_str());
@@ -124,9 +120,6 @@ bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string)
 		pspFileSystem.Mount("umd1:", umd2);
 		pspFileSystem.Mount("disc0:", umd2);
 		pspFileSystem.Mount("umd:", umd2);
-		pspFileSystem.Mount("UMD1:", umd2);
-		pspFileSystem.Mount("DISC0:", umd2);
-		pspFileSystem.Mount("UMD:", umd2);
 	}
 
 	std::string full_path = filename;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -62,7 +62,7 @@ bool Load_PSP_ISO(const char *filename, std::string *error_string)
 	//pspFileSystem.Mount("host0:",umd2);
 	pspFileSystem.Mount("umd0:", umd2);
 	pspFileSystem.Mount("umd1:", umd2);
-	pspFileSystem.Mount("disc0:", umd2);	
+	pspFileSystem.Mount("disc0:", umd2);
 	pspFileSystem.Mount("umd:", umd2);
 	pspFileSystem.Mount("UMD0:", umd2);
 	pspFileSystem.Mount("UMD1:", umd2);
@@ -116,6 +116,19 @@ bool Load_PSP_ISO(const char *filename, std::string *error_string)
 
 bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string)
 {
+	// This is really just for headless, might need tweaking later.
+	if (!PSP_CoreParameter().mountIso.empty())
+	{
+		ISOFileSystem *umd2 = new ISOFileSystem(&pspFileSystem, constructBlockDevice(PSP_CoreParameter().mountIso.c_str()));
+
+		pspFileSystem.Mount("umd1:", umd2);
+		pspFileSystem.Mount("disc0:", umd2);
+		pspFileSystem.Mount("umd:", umd2);
+		pspFileSystem.Mount("UMD1:", umd2);
+		pspFileSystem.Mount("DISC0:", umd2);
+		pspFileSystem.Mount("UMD:", umd2);
+	}
+
 	std::string full_path = filename;
 	std::string path, file, extension;
 	SplitPath(ReplaceAll(full_path, "\\", "/"), &path, &file, &extension);


### PR DESCRIPTION
Fixes a few games that weren't starting, fixes #212 (at least, the game loads for me), maybe / maye not fixes #343 (don't have that one to check.)

The changes:
- allow sce_lbn%x_size%x (with lots of logging in case there's more variants), not just sce_lbn0x%08x_size%x08x.
- allow seeking on a sce_lbn virtual file.
- actually respect the mount option in headless.
- fail for sce_lbnfffffff etc. that would be outside the iso.

And I also threw in making prefix matching case insensitive (because disC0:/ works fine too.)  I don't know that it will actually affect any games.

All of these were verified on a real PSP but, it's kind of hard to write a good test for this...

-[Unknown]
