### PR TITLE
fixed iterator bug

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -42,7 +42,7 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head)
 void GPUCommon::UpdateStall(int listid, u32 newstall)
 {
 	
-	for (auto iter = DlQueue.begin(); iter !=dlQueue.end(); ++iter) // equal to DisplayListQueue::iterator 
+	for (auto iter = dlQueue.begin(); iter !=dlQueue.end(); ++iter) // equal to DisplayListQueue::iterator 
 	{	
 		if (iter->id == listid)
 		{

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -41,12 +41,12 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head)
 
 void GPUCommon::UpdateStall(int listid, u32 newstall)
 {
-	// simple references rage for
-	for (auto &i : DisplayListQueue) //vector
+	
+	for (auto iter = DlQueue.begin(); iter !=dlQueue.end(); ++iter) 
 	{	
-		if (i.id == listid)
+		if (iter->id == listid)
 		{
-			i.stall = newstall & 0xFFFFFFF;
+			iter->stall = newstall & 0xFFFFFFF;
 		}
 	}
 	

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -41,13 +41,12 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head)
 
 void GPUCommon::UpdateStall(int listid, u32 newstall)
 {
-	// this needs improvement....
-	for (DisplayListQueue::iterator iter = dlQueue.begin(); iter != dlQueue.end(); iter++)
-	{
-		DisplayList &l = *iter;
-		if (l.id == listid)
+	// simple references rage for
+	for (auto &i : DisplayListQueue) //vector
+	{	
+		if (i.id == listid)
 		{
-			l.stall = newstall & 0xFFFFFFF;
+			i.stall = newstall & 0xFFFFFFF;
 		}
 	}
 	

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -42,7 +42,7 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head)
 void GPUCommon::UpdateStall(int listid, u32 newstall)
 {
 	
-	for (auto iter = DlQueue.begin(); iter !=dlQueue.end(); ++iter) 
+	for (auto iter = DlQueue.begin(); iter !=dlQueue.end(); ++iter) // equal to DisplayListQueue::iterator 
 	{	
 		if (iter->id == listid)
 		{


### PR DESCRIPTION
I accessed the object via it's data member instead of using a reference. It's clearer and probably easier to read. I had to change this as I was using a reference in a range-based-for.  
