### PR TITLE
Implemented some sceMp3 functions

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -80,6 +80,8 @@ static const int PSP_ERROR_MPEG_NO_DATA = 0x80618001;
 static const int TPSM_PIXEL_STORAGE_MODE_16BIT_BGR5650 = 0X00;
 static const int TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888 = 0X03;
 
+static const int MP3_BITRATES[] = {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320};
+
 int getMaxAheadTimestamp(const SceMpegRingBuffer &ringbuf) {
 	return std::max(40000, ringbuf.packets * 700);  // empiric value from JPCSP, thanks!
 }
@@ -95,9 +97,11 @@ struct AvcContext {
 struct Mp3Context {	
 	int mp3StreamStart;
 	int mp3StreamEnd;
-	int mp3Buf;
+	int mp3StreamPosition;
+	u32 mp3Buf;
 	int mp3BufSize;
-	int mp3PcmBuf;
+	int mp3BufPendingSize;
+	u32 mp3PcmBuf;
 	int mp3PcmBufSize;
 
 	int mp3InputFileReadPos;
@@ -107,6 +111,10 @@ struct Mp3Context {
 	int mp3DecodedBytes;
 	int mp3LoopNum;
 	int mp3MaxSamples;
+
+	int mp3Channels;
+	int mp3Bitrate;
+	int mp3SamplingRate;
 };
 
 struct StreamInfo {	
@@ -744,7 +752,7 @@ u32 sceMpegUnRegistStream(u32 mpeg, int streamUid)
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx)
 	{
-		WARN_LOG(HLE, "sceMpegUnRegistStream(%08x, %i, %i): bad mpeg handle", mpeg, streamUid);
+		WARN_LOG(HLE, "sceMpegUnRegistStream(%08x, %i): bad mpeg handle", mpeg, streamUid);
 		return -1;
 	}
 
@@ -1212,15 +1220,12 @@ u32 sceMpegQueryUserdataEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)
 	return -1;
 }
 
-u32 sceMp3Decode(u32 mp3, u32 outPcmPtr)
-{
-	DEBUG_LOG(HLE, "UNIMPL sceMp3Decoder(%08x,%08x)", mp3, outPcmPtr);
-	Memory::Write_U32(0,outPcmPtr);	
-	return 0;
-}
 
-u32 sceMp3ResetPlayPosition(u32 mp3)
+/* MP3 */
+int sceMp3Decode(u32 mp3, u32 outPcmPtr)
 {
+	DEBUG_LOG(HLE, "sceMp3Decode(%08x,%08x)", mp3, outPcmPtr);
+
 	Mp3Context *ctx = getMp3Ctx(mp3);
 	if (!ctx)
 	{
@@ -1228,56 +1233,160 @@ u32 sceMp3ResetPlayPosition(u32 mp3)
 		return -1;
 	}
 
-	DEBUG_LOG(HLE, "SceMp3ResetPlayPosition(%08x, %i)", mp3);
-	ctx->mp3InputFileReadPos = 0;
-	ctx->mp3InputBufWritePos = 0;
-	ctx->mp3InputBufSize = 0;
-	ctx->mp3InputFileSize = 0;
-	ctx->mp3DecodedBytes = 0;
+	// Nothing to decode
+	if(ctx->mp3BufPendingSize == 0 || ctx->mp3StreamPosition >= ctx->mp3StreamEnd) {
+		return 0;
+	}
+
+	Memory::Memset(ctx->mp3PcmBuf, 0, ctx->mp3PcmBufSize);
+	Memory::Write_U32(ctx->mp3PcmBuf, outPcmPtr);
+
+	// TODO: Actually decode the data
+#ifdef _DEBUG
+	char fileName[256];
+	sprintf(fileName, "%i.mp3", ctx->mp3StreamPosition);
+
+	FILE * file = fopen(fileName, "wb");
+	if(file) {
+		if(!Memory::IsValidAddress(ctx->mp3Buf)) {
+			ERROR_LOG(HLE, "sceMp3Decode mp3Buf %08X is not a valid address!", ctx->mp3Buf);
+		}
+
+		u8 * ptr = Memory::GetPointer(ctx->mp3Buf);
+		fwrite(ptr, 1, ctx->mp3BufPendingSize, file);
+		
+		fclose(file);
+	}
+#endif
+
+	ctx->mp3StreamPosition += ctx->mp3BufPendingSize;
+	if(ctx->mp3StreamPosition > ctx->mp3StreamEnd)
+		ctx->mp3StreamPosition = ctx->mp3StreamEnd;
+
+	// Reset the pending buffer size so the program will know that we need to buffer more data
+	ctx->mp3BufPendingSize = (ctx->mp3StreamPosition < ctx->mp3StreamEnd)?-1:0;
+
+	return ctx->mp3PcmBufSize;
+}
+
+int sceMp3ResetPlayPosition(u32 mp3)
+{
+	DEBUG_LOG(HLE, "SceMp3ResetPlayPosition(%08x)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	ctx->mp3StreamPosition = 0;
+	ctx->mp3BufPendingSize = -1;
 	return 0;
 }
 
-u32 sceMp3CheckStreamDataNeeded(u32 mp3)
+int sceMp3CheckStreamDataNeeded(u32 mp3)
 {
-	DEBUG_LOG(HLE, "UNIMPL sceMp3CheckStreamDataNeeded(%08x)", mp3);
-	return 0;
+	DEBUG_LOG(HLE, "sceMp3CheckStreamDataNeeded(%08x)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	return (ctx->mp3BufPendingSize < 0) && (ctx->mp3StreamPosition < ctx->mp3StreamEnd);
 }
 
 u32 sceMp3ReserveMp3Handle(u32 mp3Addr)
 {
 	DEBUG_LOG(HLE, "sceMp3ReserveMp3Handle(%08x)", mp3Addr);
 	Mp3Context *ctx = new Mp3Context;
+
+	memset(ctx, 0, sizeof(Mp3Context));
+
 	ctx->mp3StreamStart = Memory::Read_U64(mp3Addr);
 	ctx->mp3StreamEnd = Memory::Read_U64(mp3Addr+8);
 	ctx->mp3Buf = Memory::Read_U32(mp3Addr+16);
 	ctx->mp3BufSize = Memory::Read_U32(mp3Addr+20);
 	ctx->mp3PcmBuf = Memory::Read_U32(mp3Addr+24);
 	ctx->mp3PcmBufSize = Memory::Read_U32(mp3Addr+28);
+
+	ctx->mp3StreamPosition = ctx->mp3StreamStart;
+	ctx->mp3BufPendingSize = -1;
+	ctx->mp3MaxSamples = ctx->mp3PcmBufSize / 4 ;
+
+	/*ctx->mp3Channels = 2;
+	ctx->mp3Bitrate = 128;
+	ctx->mp3SamplingRate = 44100;*/
+
 	mp3Map[mp3Addr] = ctx;
 	return mp3Addr;
 }
 
-u32 sceMp3InitResource()
+int sceMp3InitResource()
 {
-	DEBUG_LOG(HLE, "sceMp3InitResource");
+	WARN_LOG(HLE, "UNIML: sceMp3InitResource");
 	// Do nothing here 
 	return 0;
 }
 
-u32 sceMp3TermResource()
+int sceMp3TermResource()
 {
-	DEBUG_LOG(HLE, "sceMp3TermResource");
+	WARN_LOG(HLE, "UNIML: sceMp3TermResource");
 	// Do nothing here 
 	return 0;
 }
 
-u32 sceMp3Init(u32 mp3)
+int sceMp3Init(u32 mp3)
 {
-	DEBUG_LOG(HLE, "UNIMPL sceMp3Init(%08x)", mp3);
+	DEBUG_LOG(HLE, "sceMp3Init(%08x)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	// Read in the header and swap the endian
+	int header = Memory::Read_U32(ctx->mp3Buf);
+	header = (header >> 24) |
+         ((header<<8) & 0x00FF0000) |
+         ((header>>8) & 0x0000FF00) |
+         (header << 24);
+
+	int channels = ((header >> 6) & 0x3);
+	if(channels == 0 || channels == 1 || channels == 2)
+		ctx->mp3Channels = 2;
+	else if(channels == 3)
+		ctx->mp3Channels = 1;
+	else 
+		ctx->mp3Channels = 0;
+
+	// 0 == VBR
+	int bitrate = ((header >> 10) & 0x3);
+	if(bitrate < sizeof(MP3_BITRATES) / sizeof(MP3_BITRATES[0]))
+		ctx->mp3Bitrate = MP3_BITRATES[bitrate];
+	else
+		ctx->mp3Bitrate = -1;
+
+	int samplerate = ((header >> 12) & 0x3);
+	if (samplerate == 0) {
+		ctx->mp3SamplingRate = 44100;
+	} else if (samplerate == 1) {
+		ctx->mp3SamplingRate = 48000;
+	} else if (samplerate == 2) {
+		ctx->mp3SamplingRate = 32000;
+	} else {
+		ctx->mp3SamplingRate = 0;
+	}
+
 	return 0;
 }
 
-u32 sceMp3GetLoopNum(u32 mp3)
+int sceMp3GetLoopNum(u32 mp3)
 {
 	DEBUG_LOG(HLE, "sceMp3GetLoopNum(%08x)", mp3);
 	Mp3Context *ctx = getMp3Ctx(mp3);
@@ -1287,11 +1396,10 @@ u32 sceMp3GetLoopNum(u32 mp3)
 		return -1;
 	}
 
-	ctx->mp3LoopNum = -1 ;
 	return ctx->mp3LoopNum;
 }
 
-u32 sceMp3GetMaxOutputSample(u32 mp3)
+int sceMp3GetMaxOutputSample(u32 mp3)
 {
 	DEBUG_LOG(HLE, "sceMp3GetMaxOutputSample(%08x)", mp3);
 	Mp3Context *ctx = getMp3Ctx(mp3);
@@ -1301,8 +1409,111 @@ u32 sceMp3GetMaxOutputSample(u32 mp3)
 		return -1;
 	}
 
-	ctx->mp3MaxSamples = ctx->mp3PcmBufSize / 4 ;
 	return ctx->mp3MaxSamples;
+}
+
+int sceMp3NotifyAddStreamData(u32 mp3, int size) {
+	DEBUG_LOG(HLE, "sceMp3NotifyAddStreamData(%08X, %i)", mp3, size);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	ctx->mp3BufPendingSize = size;
+
+	return 0;
+}
+int sceMp3GetSumDecodedSample(u32 mp3) {
+	DEBUG_LOG(HLE, "UNIMPL: sceMp3GetSumDecodedSample(%08X)", mp3);
+	return 0;
+}
+int sceMp3SetLoopNum(u32 mp3, int loop) {
+	DEBUG_LOG(HLE, "sceMp3SetLoopNum(%08X, %i)", mp3, loop);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	ctx->mp3LoopNum = loop;
+
+	return 0;
+}
+int sceMp3GetMp3ChannelNum(u32 mp3) {
+	DEBUG_LOG(HLE, "sceMp3GetMp3ChannelNum(%08X)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	return ctx->mp3Channels;
+}
+int sceMp3GetBitRate(u32 mp3) {
+	DEBUG_LOG(HLE, "sceMp3GetBitRate(%08X)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	return ctx->mp3Bitrate;
+}
+int sceMp3GetSamplingRate(u32 mp3) {
+	DEBUG_LOG(HLE, "sceMp3GetSamplingRate(%08X)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	return ctx->mp3SamplingRate;
+}
+int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcposPtr) {
+	DEBUG_LOG(HLE, "HACK: sceMp3GetInfoToAddStreamData(%08X, %08X, %08X, %08X)", mp3, dstPtr, towritePtr, srcposPtr);
+	
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	if(Memory::IsValidAddress(dstPtr))
+		Memory::Write_U32(ctx->mp3Buf, dstPtr);
+	if(Memory::IsValidAddress(towritePtr))
+		Memory::Write_U32(ctx->mp3BufSize, towritePtr);
+	if(Memory::IsValidAddress(srcposPtr))
+		Memory::Write_U32(ctx->mp3StreamPosition, srcposPtr);
+
+	return 0;
+}
+int sceMp3ReleaseMp3Handle(u32 mp3) {
+	DEBUG_LOG(HLE, "sceMp3ReleaseMp3Handle(%08X)", mp3);
+
+	Mp3Context *ctx = getMp3Ctx(mp3);
+	if (!ctx)
+	{
+		ERROR_LOG(HLE, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
+		return -1;
+	}
+
+	mp3Map.erase(mp3Map.find(mp3));
+
+	delete ctx;
+
+	return 0;
 }
 
 const HLEFunction sceMpeg[] =
@@ -1352,24 +1563,24 @@ const HLEFunction sceMpeg[] =
 const HLEFunction sceMp3[] =
 {
 	{0x07EC321A,WrapU_U<sceMp3ReserveMp3Handle>,"sceMp3ReserveMp3Handle"},
-	{0x0DB149F4,0,"sceMp3NotifyAddStreamData"},
-	{0x2A368661,WrapU_U<sceMp3ResetPlayPosition>,"sceMp3ResetPlayPosition"},
-	{0x354D27EA,0,"sceMp3GetSumDecodedSample"},
-	{0x35750070,WrapU_V<sceMp3InitResource>,"sceMp3InitResource"},
-	{0x3C2FA058,WrapU_V<sceMp3TermResource>,"sceMp3TermResource"},
-	{0x3CEF484F,0,"sceMp3SetLoopNum"},
-	{0x44E07129,WrapU_U<sceMp3Init>,"sceMp3Init"},
+	{0x0DB149F4,WrapI_UI<sceMp3NotifyAddStreamData>,"sceMp3NotifyAddStreamData"},
+	{0x2A368661,WrapI_U<sceMp3ResetPlayPosition>,"sceMp3ResetPlayPosition"},
+	{0x354D27EA,WrapI_U<sceMp3GetSumDecodedSample>,"sceMp3GetSumDecodedSample"},
+	{0x35750070,WrapI_V<sceMp3InitResource>,"sceMp3InitResource"},
+	{0x3C2FA058,WrapI_V<sceMp3TermResource>,"sceMp3TermResource"},
+	{0x3CEF484F,WrapI_UI<sceMp3SetLoopNum>,"sceMp3SetLoopNum"},
+	{0x44E07129,WrapI_U<sceMp3Init>,"sceMp3Init"},
 	{0x732B042A,0,"sceMp3EndEntry"},
-	{0x7F696782,0,"sceMp3GetMp3ChannelNum"},
-	{0x87677E40,0,"sceMp3GetBitRate"},
-	{0x87C263D1,WrapU_U<sceMp3GetMaxOutputSample>,"sceMp3GetMaxOutputSample"},
+	{0x7F696782,WrapI_U<sceMp3GetMp3ChannelNum>,"sceMp3GetMp3ChannelNum"},
+	{0x87677E40,WrapI_U<sceMp3GetBitRate>,"sceMp3GetBitRate"},
+	{0x87C263D1,WrapI_U<sceMp3GetMaxOutputSample>,"sceMp3GetMaxOutputSample"},
 	{0x8AB81558,0,"sceMp3StartEntry"},
-	{0x8F450998,0,"sceMp3GetSamplingRate"},
-	{0xA703FE0F,0,"sceMp3GetInfoToAddStreamData"},
-	{0xD021C0FB,WrapU_UU<sceMp3Decode>,"sceMp3Decode"},
-	{0xD0A56296,WrapU_U<sceMp3CheckStreamDataNeeded>,"sceMp3CheckStreamDataNeeded"},
-	{0xD8F54A51,WrapU_U<sceMp3GetLoopNum>,"sceMp3GetLoopNum"},
-	{0xF5478233,0,"sceMp3ReleaseMp3Handle"},
+	{0x8F450998,WrapI_U<sceMp3GetSamplingRate>,"sceMp3GetSamplingRate"},
+	{0xA703FE0F,WrapI_UUUU<sceMp3GetInfoToAddStreamData>,"sceMp3GetInfoToAddStreamData"},
+	{0xD021C0FB,WrapI_UU<sceMp3Decode>,"sceMp3Decode"},
+	{0xD0A56296,WrapI_U<sceMp3CheckStreamDataNeeded>,"sceMp3CheckStreamDataNeeded"},
+	{0xD8F54A51,WrapI_U<sceMp3GetLoopNum>,"sceMp3GetLoopNum"},
+	{0xF5478233,WrapI_U<sceMp3ReleaseMp3Handle>,"sceMp3ReleaseMp3Handle"},
 	{0xAE6D2027,0,"sceMp3GetVersion"},
 	{0x3548AEC8,0,"sceMp3GetFrameNum"},
 };


### PR DESCRIPTION
I have started work on implementing the sceMp3 functions. It's probably a bit unstable right now (though I have tested it with Aqua Panic, and a test eboot I made and they both seem to work). 
Currently it doesn't do any decoding at all, but it should be quite easy to add if we use an external mp3 library.

If you have DEBUG set it'll output the buffered mp3 data as separate files to the current directory.
