### PR TITLE
Clear the free packets when hitting end of video

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1022,6 +1022,10 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	if (!ctx->mediaengine->readVideoAu(&sceAu) || true) {
 		// Only return this after the video already ended.
 		if (ctx->endOfVideoReached) {
+			if (mpegRingbuffer.packetsFree < mpegRingbuffer.packets) {
+				mpegRingbuffer.packetsFree = mpegRingbuffer.packets;
+				Memory::WriteStruct(ctx->mpegRingbufferAddr, &mpegRingbuffer);
+			}
 			result = PSP_ERROR_MPEG_NO_DATA;
 		}
 		if (ctx->mpegLastTimestamp < 0 || sceAu.pts >= ctx->mpegLastTimestamp) {


### PR DESCRIPTION
This fixes #393.  However, I found another instance of the same class of problem in Crisis Core (if you don't press anything and just let the intro video play.)  It's not caused by the same thing, not sure what it's expecting.

However, that was broken before, and this at least fixes Ys Seven (and hopefully Brandish.)  Didn't break the usual suspects which use mpegs either.

-[Unknown]
