### PR TITLE
Show the most active syscall too

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -244,7 +244,9 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 
 		float zoom = 0.5f; /// g_Config.iWindowZoom;
 		PPGeBegin();
-		PPGeDrawText(stats, 0, 0, 0, zoom, 0xFFc0c0c0);
+		PPGeDrawText(stats, 1, 1, 0, zoom, 0xFF000000);
+		PPGeDrawText(stats, -1, -1, 0, zoom, 0xFF000000);
+		PPGeDrawText(stats, 0, 0, 0, zoom, 0xFFFFFFFF);
 		PPGeEnd();
 
 		gpuStats.resetFrame();

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -214,12 +214,11 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 			"DL processing time: %0.2f ms\n"
 			"Kernel processing time: %0.2f ms\n"
 			"Slowest syscall: %s : %0.2f ms\n"
-			"Draw calls: %i\n"
-			"Draw flushes: %i\n"
+			"Most active syscall: %s : %0.2f ms\n"
+			"Draw calls: %i, flushes %i\n"
 			"Vertices Transformed: %i\n"
 			"FBOs active: %i\n"
-			"Textures active: %i\n"
-			"Textures decoded: %i\n"
+			"Textures active: %i, decoded: %i\n"
 			"Texture invalidations: %i\n"
 			"Vertex shaders loaded: %i\n"
 			"Fragment shaders loaded: %i\n"
@@ -229,6 +228,8 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 			kernelStats.msInSyscalls * 1000.0f,
 			kernelStats.slowestSyscallName ? kernelStats.slowestSyscallName : "(none)",
 			kernelStats.slowestSyscallTime * 1000.0f,
+			kernelStats.summedSlowestSyscallName ? kernelStats.summedSlowestSyscallName : "(none)",
+			kernelStats.summedSlowestSyscallTime * 1000.0f,
 			gpuStats.numDrawCalls,
 			gpuStats.numFlushes,
 			gpuStats.numVertsTransformed,

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -421,19 +421,27 @@ private:
 
 extern KernelObjectPool kernelObjects;
 
+typedef std::pair<int, int> KernelStatsSyscall;
+
 struct KernelStats {
 	void Reset() {
-		memset(this, 0, sizeof(*this));
+		ResetFrame();
 	}
 	void ResetFrame() {
 		msInSyscalls = 0;
 		slowestSyscallTime = 0;
 		slowestSyscallName = 0;
+		summedMsInSyscalls.clear();
+		summedSlowestSyscallTime = 0;
+		summedSlowestSyscallName = 0;
 	}
 
 	double msInSyscalls;
 	double slowestSyscallTime;
 	const char *slowestSyscallName;
+	std::map<KernelStatsSyscall, double> summedMsInSyscalls;
+	double summedSlowestSyscallTime;
+	const char *summedSlowestSyscallName;
 };
 
 extern KernelStats kernelStats;


### PR DESCRIPTION
Sometimes this shows atrac actually taking a lot of time, etc.  Usually it's the same function.

I made msInSyscalls skip idle, and also made it draw a really basic shadow around the text.  Could look much better, but this makes it way more readable for me against e.g. mpeg grey.

-[Unknown]
