### PR TITLE
removed unused import

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -29,7 +29,6 @@
 #undef _interlockedbittestandreset64
 #else
 
-//#include <config/i386/cpuid.h>
 #include <xmmintrin.h>
 
 #if defined __FreeBSD__


### PR DESCRIPTION
inline asm is now used. Anyway, the commented-import doesn't point to a valid location anymore; it's now only cpuid.h
