### PR TITLE
Timing fix

### DIFF
--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -122,7 +122,7 @@ public:
 
 	u32 pc;
 	u32 nextPC;
-	u32 downcount;  // This really doesn't belong here, it belongs in CoreTiming. But you gotta do what you gotta do, this needs to be reachable in the ARM JIT.
+	int downcount;  // This really doesn't belong here, it belongs in CoreTiming. But you gotta do what you gotta do, this needs to be reachable in the ARM JIT.
 
 	u32 hi;
 	u32 lo;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -65,6 +65,8 @@ bool PSP_Init(const CoreParameter &coreParam, std::string *error_string)
 		LogManager::GetInstance()->SetEnable(LogTypes::G3D, false);
 	}
 
+	CoreTiming::Init();
+
 	// Init all the HLE modules
 	HLEInit();
 
@@ -73,8 +75,7 @@ bool PSP_Init(const CoreParameter &coreParam, std::string *error_string)
 	if (!LoadFile(coreParameter.fileToStart.c_str(), error_string))
 	{
 		pspFileSystem.Shutdown();
-		CoreTiming::ClearPendingEvents();
-		CoreTiming::UnregisterAllEvents();
+		CoreTiming::Shutdown();
 		__KernelShutdown();
 		HLEShutdown();
 		host->ShutdownSound();
@@ -102,8 +103,7 @@ void PSP_Shutdown()
 
 	TextureCache_Clear(true);
 
-	CoreTiming::ClearPendingEvents();
-	CoreTiming::UnregisterAllEvents();
+	CoreTiming::Shutdown();
 
 	if (coreParameter.enableSound)
 	{


### PR DESCRIPTION
This fixes a regression related to downcount after the armjit merge, and makes us actually call `CoreTiming::Init()` and `CoreTiming::Shutdown()`.  Calling those didn't fix anything, but I had assumed they were being called, so better to fix them if they are wrong.

-[Unknown]
