### PR TITLE
Fixes for Qt, Symbian and Blackberry.

### DIFF
--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -15,11 +15,11 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "ArmEmitter.h"
 
 #include "../../MemMap.h"
 
 #include "../MIPS.h"
+#include "ArmEmitter.h"
 #include "../../CoreTiming.h"
 #include "MemoryUtil.h"
 

--- a/Core/MIPS/ARM/ArmAsm.h
+++ b/Core/MIPS/ARM/ArmAsm.h
@@ -18,8 +18,8 @@
 #ifndef _JIT64ASM_H
 #define _JIT64ASM_H
 
-#include <ArmEmitter.h>
 #include "../MIPS.h"
+#include <ArmEmitter.h>
 
 // Runtime generated assembly routines, like the Dispatcher.
 

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -16,8 +16,6 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ArmJit.h"
-#include "ArmRegCache.h"
-#include "ArmEmitter.h"
 
 using namespace MIPSAnalyst;
 #define _RS ((op>>21) & 0x1F)

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -18,11 +18,10 @@
 #pragma once
 
 #include "../../../Globals.h"
-#include "ArmAsm.h"
 
-#include <ArmEmitter.h>
 #include "ArmJitCache.h"
 #include "ArmRegCache.h"
+#include "ArmAsm.h"
 
 namespace MIPSComp
 {

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include "ArmEmitter.h"
 #include "../MIPS.h"
 #include "../MIPSAnalyst.h"
+#include "ArmEmitter.h"
 
 using namespace ArmGen;
 
@@ -58,6 +58,8 @@ struct RegMIPS {
 	// If loc == ML_MEM, it's back in its location in the CPU context struct.
 };
 
+#undef MAP_DIRTY
+#undef MAP_NOINIT
 // Initing is the default so the flag is reversed.
 enum {
 	MAP_DIRTY = 1,

--- a/Qt/Common.pro
+++ b/Qt/Common.pro
@@ -7,19 +7,18 @@ CONFIG += staticlib
 include(Settings.pri)
 
 arm {
-	SOURCES +=	../Common/ArmABI.cpp \
+	SOURCES += ../Common/ArmCPUDetect.cpp \
 		../Common/ArmEmitter.cpp \
-		../Common/ThunkARM.cpp
-	HEADERS +=	../Common/ArmABI.h \
-		../Common/ArmEmitter.h
+		../Common/ArmThunk.cpp
+	HEADERS += ../Common/ArmEmitter.h
 }
 x86 {
-	SOURCES +=	../Common/ABI.cpp \
+	SOURCES += ../Common/ABI.cpp \
 		../Common/CPUDetect.cpp \
 		../Common/Thunk.cpp \
 		../Common/x64Analyzer.cpp \
 		../Common/x64Emitter.cpp
-	HEADERS += 	../Common/ABI.h \
+	HEADERS +=  ../Common/ABI.h \
 		../Common/CPUDetect.h \
 		../Common/Thunk.h \
 		../Common/x64Analyzer.h \
@@ -30,7 +29,7 @@ win32 {
 	HEADERS += ../Common/stdafx.h
 }
 
-SOURCES +=		../Common/ColorUtil.cpp \
+SOURCES += ../Common/ColorUtil.cpp \
 	../Common/ConsoleListener.cpp \
 	../Common/Crypto/aes_cbc.cpp \
 	../Common/Crypto/aes_core.cpp \
@@ -54,7 +53,7 @@ SOURCES +=		../Common/ColorUtil.cpp \
 	../Common/Thread.cpp \
 	../Common/Timer.cpp \
 	../Common/Version.cpp
-HEADERS +=		../Common/ColorUtil.h \
+HEADERS += ../Common/ColorUtil.h \
 	../Common/ConsoleListener.h \
 	../Common/Crypto/md5.h \
 	../Common/Crypto/sha1.h \

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -6,7 +6,7 @@ CONFIG += staticlib
 
 include(Settings.pri)
 
-INCLUDEPATH += ../native ../Common ../
+INCLUDEPATH += ../native ../Core/MIPS ../Common ../
 
 arm {
 	SOURCES += ../Core/MIPS/ARM/ArmAsm.cpp \ #CoreARM

--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -32,6 +32,7 @@ SOURCES += ../android/jni/EmuScreen.cpp \
 
 INCLUDEPATH += .. ../Common ../native
 
+# Temporarily only use new UI for Linux desktop
 linux:!mobile_platform {
 	SOURCES += mainwindow.cpp \
 		debugger_disasm.cpp \
@@ -49,6 +50,8 @@ linux:!mobile_platform {
 		ctrldisasmview.h \
 		ctrlregisterlist.h \
 		controls.h
+} else {
+	SOURCES += ../android/jni/NativeApp.cpp
 }
 
 # Packaging


### PR DESCRIPTION
Fixes for Qt, Symbian and Blackberry. Reorder and remove some redundant ArmEmitter includes so that _SP doesn't conflict.
