### PR TITLE
Proper VPL rescheduling/waiting

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -765,7 +765,7 @@ void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info, std::string saveName
 		u32 atlasPtr;
 		if (success)
 			atlasPtr = kernelMemory.Alloc(texSize, true, "SaveData Icon");
-		if (success && atlasPtr > 0)
+		if (success && atlasPtr != -1)
 		{
 			saveDataList[idx].textureData = atlasPtr;
 			Memory::Memcpy(atlasPtr, textureData, texSize);

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -334,6 +334,12 @@ template<int func(const char *, u32, u32, int, u32, u32)> void WrapI_CUUIUU() {
 	RETURN(retval);
 }
 
+template<int func(const char *, int, u32, u32, u32)> void WrapI_CIUUU() {
+	int retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1), PARAM(2),
+			PARAM(3), PARAM(4));
+	RETURN(retval);
+}
+
 template<u32 func(const char *, u32)> void WrapU_CU() {
 	u32 retval = func(Memory::GetCharPointer(PARAM(0)), PARAM(1));
 	RETURN((u32) retval);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -627,7 +627,7 @@ const HLEFunction ThreadManForUser[] =
 	{0xBED27435,WrapI_IUUU<sceKernelAllocateVpl>,"sceKernelAllocateVpl"},
 	{0xEC0A693F,WrapI_IUUU<sceKernelAllocateVplCB>,"sceKernelAllocateVplCB"},
 	{0xAF36D708,WrapI_IUU<sceKernelTryAllocateVpl>,"sceKernelTryAllocateVpl"},
-	{0xB736E9FF,sceKernelFreeVpl,"sceKernelFreeVpl"},
+	{0xB736E9FF,WrapI_IU<sceKernelFreeVpl>,"sceKernelFreeVpl"},
 	{0x1D371B8A,sceKernelCancelVpl,"sceKernelCancelVpl"},
 	{0x39810265,sceKernelReferVplStatus,"sceKernelReferVplStatus"},
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -624,9 +624,9 @@ const HLEFunction ThreadManForUser[] =
 
 	{0x56C039B5,WrapI_CIUUU<sceKernelCreateVpl>,"sceKernelCreateVpl"},
 	{0x89B3D48C,sceKernelDeleteVpl,"sceKernelDeleteVpl"},
-	{0xBED27435,sceKernelAllocateVpl,"sceKernelAllocateVpl"},
-	{0xEC0A693F,sceKernelAllocateVplCB,"sceKernelAllocateVplCB"},
-	{0xAF36D708,sceKernelTryAllocateVpl,"sceKernelTryAllocateVpl"},
+	{0xBED27435,WrapI_IUUU<sceKernelAllocateVpl>,"sceKernelAllocateVpl"},
+	{0xEC0A693F,WrapI_IUUU<sceKernelAllocateVplCB>,"sceKernelAllocateVplCB"},
+	{0xAF36D708,WrapI_IUU<sceKernelTryAllocateVpl>,"sceKernelTryAllocateVpl"},
 	{0xB736E9FF,sceKernelFreeVpl,"sceKernelFreeVpl"},
 	{0x1D371B8A,sceKernelCancelVpl,"sceKernelCancelVpl"},
 	{0x39810265,sceKernelReferVplStatus,"sceKernelReferVplStatus"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -623,13 +623,13 @@ const HLEFunction ThreadManForUser[] =
 	{0x33BE4024,sceKernelReferMsgPipeStatus,"sceKernelReferMsgPipeStatus"},
 
 	{0x56C039B5,WrapI_CIUUU<sceKernelCreateVpl>,"sceKernelCreateVpl"},
-	{0x89B3D48C,sceKernelDeleteVpl,"sceKernelDeleteVpl"},
+	{0x89B3D48C,WrapI_I<sceKernelDeleteVpl>,"sceKernelDeleteVpl"},
 	{0xBED27435,WrapI_IUUU<sceKernelAllocateVpl>,"sceKernelAllocateVpl"},
 	{0xEC0A693F,WrapI_IUUU<sceKernelAllocateVplCB>,"sceKernelAllocateVplCB"},
 	{0xAF36D708,WrapI_IUU<sceKernelTryAllocateVpl>,"sceKernelTryAllocateVpl"},
 	{0xB736E9FF,WrapI_IU<sceKernelFreeVpl>,"sceKernelFreeVpl"},
-	{0x1D371B8A,sceKernelCancelVpl,"sceKernelCancelVpl"},
-	{0x39810265,sceKernelReferVplStatus,"sceKernelReferVplStatus"},
+	{0x1D371B8A,WrapI_IU<sceKernelCancelVpl>,"sceKernelCancelVpl"},
+	{0x39810265,WrapI_IU<sceKernelReferVplStatus>,"sceKernelReferVplStatus"},
 
 	{0xC07BB470,sceKernelCreateFpl,"sceKernelCreateFpl"},
 	{0xED1410E0,sceKernelDeleteFpl,"sceKernelDeleteFpl"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -622,7 +622,7 @@ const HLEFunction ThreadManForUser[] =
 	{0x349B864D,sceKernelCancelMsgPipe,"sceKernelCancelMsgPipe"},
 	{0x33BE4024,sceKernelReferMsgPipeStatus,"sceKernelReferMsgPipeStatus"},
 
-	{0x56C039B5,sceKernelCreateVpl,"sceKernelCreateVpl"},
+	{0x56C039B5,WrapI_CIUUU<sceKernelCreateVpl>,"sceKernelCreateVpl"},
 	{0x89B3D48C,sceKernelDeleteVpl,"sceKernelDeleteVpl"},
 	{0xBED27435,sceKernelAllocateVpl,"sceKernelAllocateVpl"},
 	{0xEC0A693F,sceKernelAllocateVplCB,"sceKernelAllocateVplCB"},

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -106,7 +106,7 @@ public:
 	SceUID alarmID;
 };
 
-static int alarmTimer = 0;
+static int alarmTimer = -1;
 
 void __KernelTriggerAlarm(u64 userdata, int cyclesLate)
 {

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -98,7 +98,7 @@ enum PspEventFlagWaitTypes
 	PSP_EVENT_WAITKNOWN = PSP_EVENT_WAITCLEAR | PSP_EVENT_WAITCLEARALL | PSP_EVENT_WAITOR,
 };
 
-int eventFlagWaitTimer = 0;
+int eventFlagWaitTimer = -1;
 
 void __KernelEventFlagInit()
 {
@@ -160,7 +160,7 @@ bool __KernelUnlockEventFlagForThread(EventFlag *e, EventFlagTh &th, u32 &error,
 			Memory::Write_U32(e->nef.currentPattern, th.outAddr);
 	}
 
-	if (timeoutPtr != 0 && eventFlagWaitTimer != 0)
+	if (timeoutPtr != 0 && eventFlagWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(eventFlagWaitTimer, th.tid);
@@ -347,7 +347,7 @@ void __KernelEventFlagTimeout(u64 userdata, int cycleslate)
 
 void __KernelSetEventFlagTimeout(EventFlag *e, u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || eventFlagWaitTimer == 0)
+	if (timeoutPtr == 0 || eventFlagWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -30,7 +30,7 @@ const int PSP_MBX_ERROR_DUPLICATE_MSG = 0x800201C9;
 typedef std::pair<SceUID, u32> MbxWaitingThread;
 void __KernelMbxTimeout(u64 userdata, int cyclesLate);
 
-static int mbxWaitTimer = 0;
+static int mbxWaitTimer = -1;
 
 struct NativeMbx
 {
@@ -192,7 +192,7 @@ bool __KernelUnlockMbxForThread(Mbx *m, MbxWaitingThread &th, u32 &error, int re
 	if (waitID != m->GetUID())
 		return true;
 
-	if (timeoutPtr != 0 && mbxWaitTimer != 0)
+	if (timeoutPtr != 0 && mbxWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(mbxWaitTimer, th.first);
@@ -230,7 +230,7 @@ void __KernelMbxTimeout(u64 userdata, int cyclesLate)
 
 void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || mbxWaitTimer == 0)
+	if (timeoutPtr == 0 || mbxWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -32,7 +32,7 @@
 BlockAllocator userMemory(256);
 BlockAllocator kernelMemory(256);
 
-static int vplWaitTimer = 0;
+static int vplWaitTimer = -1;
 // STATE END
 //////////////////////////////////////////////////////////////////////////
 
@@ -754,7 +754,7 @@ bool __KernelUnlockVplForThread(VPL *vpl, VplWaitingThread &threadInfo, u32 &err
 		vpl->nv.numWaitThreads--;
 	}
 
-	if (timeoutPtr != 0 && vplWaitTimer != 0)
+	if (timeoutPtr != 0 && vplWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(vplWaitTimer, threadID);
@@ -929,7 +929,7 @@ void __KernelVplTimeout(u64 userdata, int cyclesLate)
 
 void __KernelSetVplTimeout(u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || vplWaitTimer == 0)
+	if (timeoutPtr == 0 || vplWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);

--- a/Core/HLE/sceKernelMemory.h
+++ b/Core/HLE/sceKernelMemory.h
@@ -37,13 +37,13 @@ KernelObject *__KernelMemoryVPLObject();
 KernelObject *__KernelMemoryPMBObject();
 
 SceUID sceKernelCreateVpl(const char *name, int partition, u32 attr, u32 vplSize, u32 optPtr);
-void sceKernelDeleteVpl();
+int sceKernelDeleteVpl(SceUID uid);
 int sceKernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
 int sceKernelAllocateVplCB(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
 int sceKernelTryAllocateVpl(SceUID uid, u32 size, u32 addrPtr);
 int sceKernelFreeVpl(SceUID uid, u32 addr);
-void sceKernelCancelVpl();
-void sceKernelReferVplStatus();
+int sceKernelCancelVpl(SceUID uid, u32 numWaitThreadsPtr);
+int sceKernelReferVplStatus(SceUID uid, u32 infoPtr);
 
 void sceKernelCreateFpl();
 void sceKernelDeleteFpl();

--- a/Core/HLE/sceKernelMemory.h
+++ b/Core/HLE/sceKernelMemory.h
@@ -38,9 +38,9 @@ KernelObject *__KernelMemoryPMBObject();
 
 SceUID sceKernelCreateVpl(const char *name, int partition, u32 attr, u32 vplSize, u32 optPtr);
 void sceKernelDeleteVpl();
-void sceKernelAllocateVpl();
-void sceKernelAllocateVplCB();
-void sceKernelTryAllocateVpl();
+int sceKernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
+int sceKernelAllocateVplCB(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
+int sceKernelTryAllocateVpl(SceUID uid, u32 size, u32 addrPtr);
 void sceKernelFreeVpl();
 void sceKernelCancelVpl();
 void sceKernelReferVplStatus();

--- a/Core/HLE/sceKernelMemory.h
+++ b/Core/HLE/sceKernelMemory.h
@@ -41,7 +41,7 @@ void sceKernelDeleteVpl();
 int sceKernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
 int sceKernelAllocateVplCB(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr);
 int sceKernelTryAllocateVpl(SceUID uid, u32 size, u32 addrPtr);
-void sceKernelFreeVpl();
+int sceKernelFreeVpl(SceUID uid, u32 addr);
 void sceKernelCancelVpl();
 void sceKernelReferVplStatus();
 

--- a/Core/HLE/sceKernelMemory.h
+++ b/Core/HLE/sceKernelMemory.h
@@ -36,7 +36,7 @@ KernelObject *__KernelMemoryFPLObject();
 KernelObject *__KernelMemoryVPLObject();
 KernelObject *__KernelMemoryPMBObject();
 
-void sceKernelCreateVpl();
+SceUID sceKernelCreateVpl(const char *name, int partition, u32 attr, u32 vplSize, u32 optPtr);
 void sceKernelDeleteVpl();
 void sceKernelAllocateVpl();
 void sceKernelAllocateVplCB();

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -125,8 +125,8 @@ struct LwMutex : public KernelObject
 	std::vector<SceUID> waitingThreads;
 };
 
-static int mutexWaitTimer = 0;
-static int lwMutexWaitTimer = 0;
+static int mutexWaitTimer = -1;
+static int lwMutexWaitTimer = -1;
 // Thread -> Mutex locks for thread end.
 typedef std::multimap<SceUID, SceUID> MutexMap;
 static MutexMap mutexHeldLocks;
@@ -280,7 +280,7 @@ bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int
 		__KernelMutexAcquireLock(mutex, wVal, threadID);
 	}
 
-	if (timeoutPtr != 0 && mutexWaitTimer != 0)
+	if (timeoutPtr != 0 && mutexWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(mutexWaitTimer, threadID);
@@ -428,7 +428,7 @@ void __KernelMutexThreadEnd(SceUID threadID)
 
 void __KernelWaitMutex(Mutex *mutex, u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || mutexWaitTimer == 0)
+	if (timeoutPtr == 0 || mutexWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);
@@ -604,7 +604,7 @@ bool __KernelUnlockLwMutexForThread(LwMutex *mutex, NativeLwMutexWorkarea &worka
 		workarea.lockThread = threadID;
 	}
 
-	if (timeoutPtr != 0 && lwMutexWaitTimer != 0)
+	if (timeoutPtr != 0 && lwMutexWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(lwMutexWaitTimer, threadID);
@@ -745,7 +745,7 @@ void __KernelLwMutexTimeout(u64 userdata, int cyclesLate)
 
 void __KernelWaitLwMutex(LwMutex *mutex, u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || lwMutexWaitTimer == 0)
+	if (timeoutPtr == 0 || lwMutexWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -135,26 +135,6 @@ bool __KernelClearSemaThreads(Semaphore *s, int reason)
 	return wokeThreads;
 }
 
-std::vector<SceUID>::iterator __KernelSemaFindPriority(std::vector<SceUID> &waiting, std::vector<SceUID>::iterator begin)
-{
-	_dbg_assert_msg_(HLE, !waiting.empty(), "__KernelSemaFindPriority: Trying to find best of no threads.");
-
-	std::vector<SceUID>::iterator iter, end, best = waiting.end();
-	u32 best_prio = 0xFFFFFFFF;
-	for (iter = begin, end = waiting.end(); iter != end; ++iter)
-	{
-		u32 iter_prio = __KernelGetThreadPrio(*iter);
-		if (iter_prio < best_prio)
-		{
-			best = iter;
-			best_prio = iter_prio;
-		}
-	}
-
-	_dbg_assert_msg_(HLE, best != waiting.end(), "__KernelSemaFindPriority: Returning invalid best thread.");
-	return best;
-}
-
 int sceKernelCancelSema(SceUID id, int newCount, u32 numWaitThreadsPtr)
 {
 	DEBUG_LOG(HLE, "sceKernelCancelSema(%i)", id);
@@ -273,19 +253,16 @@ int sceKernelSignalSema(SceUID id, int signal)
 		s->ns.currentCount += signal;
 		DEBUG_LOG(HLE, "sceKernelSignalSema(%i, %i) (old: %i, new: %i)", id, signal, oldval, s->ns.currentCount);
 
-		bool wokeThreads = false;
-		std::vector<SceUID>::iterator iter, end, best;
-retry:
-		for (iter = s->waitingThreads.begin(), end = s->waitingThreads.end(); iter != end; ++iter)
-		{
-			if ((s->ns.attr & PSP_SEMA_ATTR_PRIORITY) != 0)
-				best = __KernelSemaFindPriority(s->waitingThreads, iter);
-			else
-				best = iter;
+		if ((s->ns.attr & PSP_SEMA_ATTR_PRIORITY) != 0)
+			std::stable_sort(s->waitingThreads.begin(), s->waitingThreads.end(), __KernelThreadSortPriority);
 
-			if (__KernelUnlockSemaForThread(s, *best, error, 0, wokeThreads))
+		bool wokeThreads = false;
+retry:
+		for (auto iter = s->waitingThreads.begin(), end = s->waitingThreads.end(); iter != end; ++iter)
+		{
+			if (__KernelUnlockSemaForThread(s, *iter, error, 0, wokeThreads))
 			{
-				s->waitingThreads.erase(best);
+				s->waitingThreads.erase(iter);
 				goto retry;
 			}
 		}

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -69,7 +69,7 @@ struct Semaphore : public KernelObject
 	std::vector<SceUID> waitingThreads;
 };
 
-static int semaWaitTimer = 0;
+static int semaWaitTimer = -1;
 
 void __KernelSemaInit()
 {
@@ -109,7 +109,7 @@ bool __KernelUnlockSemaForThread(Semaphore *s, SceUID threadID, u32 &error, int 
 		s->ns.numWaitThreads--;
 	}
 
-	if (timeoutPtr != 0 && semaWaitTimer != 0)
+	if (timeoutPtr != 0 && semaWaitTimer != -1)
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(semaWaitTimer, threadID);
@@ -137,7 +137,7 @@ bool __KernelClearSemaThreads(Semaphore *s, int reason)
 
 int sceKernelCancelSema(SceUID id, int newCount, u32 numWaitThreadsPtr)
 {
-	DEBUG_LOG(HLE, "sceKernelCancelSema(%i)", id);
+	DEBUG_LOG(HLE, "sceKernelCancelSema(%i, %i, %08x)", id, newCount, numWaitThreadsPtr);
 
 	u32 error;
 	Semaphore *s = kernelObjects.Get<Semaphore>(id, error);
@@ -304,7 +304,7 @@ void __KernelSemaTimeout(u64 userdata, int cycleslate)
 
 void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)
 {
-	if (timeoutPtr == 0 || semaWaitTimer == 0)
+	if (timeoutPtr == 0 || semaWaitTimer == -1)
 		return;
 
 	int micro = (int) Memory::Read_U32(timeoutPtr);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -355,7 +355,7 @@ public:
 		{
 			stackBlock = userMemory.Alloc(stackSize, true, (std::string("stack/") + nt.name).c_str());
 		}
-		if (stackBlock == (u32)-1 || stackBlock == 0)
+		if (stackBlock == (u32)-1)
 		{
 			stackBlock = 0;
 			ERROR_LOG(HLE, "Failed to allocate stack for thread");

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1793,6 +1793,11 @@ u32 __KernelGetThreadPrio(SceUID id)
 	return 0;
 }
 
+bool __KernelThreadSortPriority(SceUID thread1, SceUID thread2)
+{
+	return __KernelGetThreadPrio(thread1) < __KernelGetThreadPrio(thread2);
+}
+
 //////////////////////////////////////////////////////////////////////////
 // WAIT/SLEEP ETC
 //////////////////////////////////////////////////////////////////////////

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -160,6 +160,7 @@ void __KernelSetupRootThread(SceUID moduleId, int args, const char *argp, int pr
 void __KernelStartIdleThreads();
 void __KernelReturnFromThread();  // Called as HLE function
 u32 __KernelGetThreadPrio(SceUID id);
+bool __KernelThreadSortPriority(SceUID thread1, SceUID thread2);
 
 void __KernelIdle();
 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -35,7 +35,7 @@ static u8 umdActivated = 1;
 static u32 umdStatus = 0;
 static u32 umdErrorStat = 0;
 static int driveCBId = -1;
-static int umdStatTimer = 0;
+static int umdStatTimer = -1;
 
 
 #define PSP_UMD_TYPE_GAME 0x10

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -27,7 +27,7 @@ void BlockAllocator::Shutdown()
 	blocks.clear();
 }
 
-u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
+u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char *tag)
 {
 	// Sanity check
 	if (size == 0 || size > rangeSize_) {
@@ -35,8 +35,12 @@ u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 		return -1;
 	}
 
+	// It could be off step, but the grain should generally be a power of 2.
+	if (grain < grain_)
+		grain = grain_;
+
 	// upalign size to grain
-	size = (size + grain_ - 1) & ~(grain_ - 1);
+	size = (size + grain - 1) & ~(grain - 1);
 
 	if (!fromTop)
 	{
@@ -44,23 +48,24 @@ u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 		for (std::list<Block>::iterator iter = blocks.begin(); iter != blocks.end(); iter++)
 		{
 			BlockAllocator::Block &b = *iter;
-			if (b.taken == false && b.size >= size)
+			u32 offset = b.start % grain;
+			u32 needed = offset + size;
+			if (b.taken == false && b.size >= needed)
 			{
-				if (b.size == size)
+				if (b.size == needed)
 				{
 					b.taken = true;
 					b.SetTag(tag);
-					return b.start;
+					return b.start + offset;
 				}
 				else
 				{
-					blocks.insert(++iter, Block(b.start+size, b.size-size, false));
+					blocks.insert(++iter, Block(b.start + needed, b.size - needed, false));
 					b.taken = true;
-					b.size = size;
+					b.size = needed;
 					b.SetTag(tag);
-					return b.start;
+					return b.start + offset;
 				}
-				//Got one!
 			}
 		}
 	}
@@ -71,24 +76,25 @@ u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 		{
 			std::list<Block>::reverse_iterator hey = iter;
 			BlockAllocator::Block &b = *((++hey).base()); //yes, confusing syntax. reverse_iterators are confusing
-			if (b.taken == false && b.size >= size)
+			u32 offset = b.start % grain;
+			u32 needed = offset + size;
+			if (b.taken == false && b.size >= needed)
 			{
-				if (b.size == size)
+				if (b.size == needed)
 				{
 					b.taken = true;
 					b.SetTag(tag);
-					return b.start;
+					return b.start + offset;
 				}
 				else
 				{
-					blocks.insert(hey.base(), Block(b.start, b.size-size, false));
+					blocks.insert(hey.base(), Block(b.start, b.size - needed, false));
 					b.taken = true;
-					b.start += b.size-size;
-					b.size = size;
+					b.start += b.size - needed;
+					b.size = needed;
 					b.SetTag(tag);
-					return b.start;
+					return b.start + offset;
 				}
-				//Got one!
 			}
 		}
 	}
@@ -97,6 +103,12 @@ u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 	ListBlocks();
 	ERROR_LOG(HLE, "Block Allocator failed to allocate %i (%08x) bytes of contiguous memory", size, size);
 	return -1;
+}
+
+u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
+{
+	// We want to make sure it's aligned in case AllocAt() was used.
+	return AllocAligned(size, grain_, fromTop, tag);
 }
 
 u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -32,7 +32,7 @@ u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 	// Sanity check
 	if (size == 0 || size > rangeSize_) {
 		ERROR_LOG(HLE, "Clearly bogus size: %08x - failing allocation", size);
-		return 0;
+		return -1;
 	}
 
 	// upalign size to grain
@@ -104,7 +104,7 @@ u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)
 	CheckBlocks();
 	if (size > rangeSize_) {
 		ERROR_LOG(HLE, "Clearly bogus size: %08x - failing allocation", size);
-		return 0;
+		return -1;
 	}
 
 	// upalign size to grain

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -219,6 +219,18 @@ bool BlockAllocator::Free(u32 position)
 	}
 }
 
+bool BlockAllocator::FreeExact(u32 position)
+{
+	BlockAllocator::Block *b = GetBlockFromAddress(position);
+	if (b && b->taken && b->start == position)
+		return Free(position);
+	else
+	{
+		ERROR_LOG(HLE, "BlockAllocator : invalid free %08x", position);
+		return false;
+	}
+}
+
 void BlockAllocator::CheckBlocks()
 {
 	for (std::list<Block>::iterator iter = blocks.begin(); iter != blocks.end(); iter++)

--- a/Core/Util/BlockAllocator.h
+++ b/Core/Util/BlockAllocator.h
@@ -25,6 +25,7 @@ public:
 
 	// WARNING: size can be modified upwards!
 	u32 Alloc(u32 &size, bool fromTop = false, const char *tag = 0);
+	u32 AllocAligned(u32 &size, u32 grain, bool fromTop = false, const char *tag = 0);
 	u32 AllocAt(u32 position, u32 size, const char *tag = 0);
 
 	bool Free(u32 position);

--- a/Core/Util/BlockAllocator.h
+++ b/Core/Util/BlockAllocator.h
@@ -29,6 +29,7 @@ public:
 	u32 AllocAt(u32 position, u32 size, const char *tag = 0);
 
 	bool Free(u32 position);
+	bool FreeExact(u32 position);
 	bool IsBlockFree(u32 position) {
 		Block *b = GetBlockFromAddress(position);
 		if (b)

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -97,6 +97,14 @@ static void EndVertexDataAndDraw(int prim) {
 	WriteCmd(GE_CMD_PRIM, (prim << 16) | vertexCount);
 }
 
+static u32 __PPGeDoAlloc(u32 &size, bool fromTop, const char *name) {
+	u32 ptr = kernelMemory.Alloc(size, fromTop, name);
+	// Didn't get it.
+	if (ptr == -1)
+		return 0;
+	return ptr;
+}
+
 void __PPGeInit()
 {
 	if (PSP_CoreParameter().gpuCore == GPU_NULL) {
@@ -117,10 +125,10 @@ void __PPGeInit()
 	u32 atlasSize = height * width * 2;  // it's a 4444 texture
 	atlasWidth = width;
 	atlasHeight = height;
-	dlPtr = kernelMemory.Alloc(dlSize, false, "PPGe Display List");
-	dataPtr = kernelMemory.Alloc(dataSize, false, "PPGe Vertex Data");
-	atlasPtr = kernelMemory.Alloc(atlasSize, false, "PPGe Atlas Texture");
-	savedContextPtr = kernelMemory.Alloc(savedContextSize, false, "PPGe Saved Context");
+	dlPtr = __PPGeDoAlloc(dlSize, false, "PPGe Display List");
+	dataPtr = __PPGeDoAlloc(dataSize, false, "PPGe Vertex Data");
+	atlasPtr = __PPGeDoAlloc(atlasSize, false, "PPGe Atlas Texture");
+	savedContextPtr = __PPGeDoAlloc(savedContextSize, false, "PPGe Saved Context");
 
 	u16 *imagePtr = (u16 *)imageData;
 	// component order change


### PR DESCRIPTION
Not too many games use VPLs (probably because of the confusing way you can't allocate 0x10 \* 0x100 blocks of a 0x1000 VPL...), but for those that do, this should help.

I'd messed up some of my earlier tests on these and thought they were wiping memory - which they don't.  But this makes waiting, cancel, delete, etc. all work correctly.

Unfortunately, it doesn't currently pass all tests (although it passes almost all, and is much better than before.)  Some notes:
- My PSP will happily provide a 24 MB VPL (up to I think 28 or 29 MB.)  I'm not sure the correct way to replicate this, and I assume it doesn't happen on PSP-1000's (of which I have none.)  This makes threads/vpl/create fail currently.
- It seems like `sceKernelAllocateVpl()` might reschedule on success, but I'm not sure.  I tested the games I have that import the vpl funcs, and the only one that cared was echochrome (demo)... and it made it crash.  But the game isn't working anyway.  I decided to err on not rescheduling, since JPCSP doesn't either.
- This also corrects an issue with semaphores waking by priority.  My old code was just wrong.  I'm planning to do some refactoring soon...
- BlockAllocator now maintains alignment even when `AllocAt()` is used, because I've seen the warning a couple times from ELF loading.  It also returns consistent values on error now

By the way, memory alignment is definitely 256, but VPLs not aligned to 256 just waste that space.  FPLs too, in fact, but not thread stacks (which is another issue I need to fix, they should be rounding up...)

I didn't update tests since they're not passing.  At least threads/vpl/vpl does pass now.

-[Unknown]
