### PR TITLE
Jit breakpoints (x86 only)

### DIFF
--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -80,6 +80,9 @@ public:
 	static void RemoveBreakPoint(u32 _iAddress);
 
 	static void ClearAllBreakPoints();
+
+	static void InvalidateJit(u32 _iAddress);
+	static void InvalidateJit();
 };
 
 

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -76,6 +76,12 @@ void Jit::ClearCache()
 	GenerateFixedCode();
 }
 
+void Jit::ClearCacheAt(u32 em_address)
+{
+	// TODO: Properly.
+	ClearCache();
+}
+
 void Jit::CompileAt(u32 addr)
 {
 	u32 op = Memory::Read_Instruction(addr);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -89,6 +89,7 @@ public:
 	ArmJitBlockCache *GetBlockCache() { return &blocks; }
 
 	void ClearCache();
+	void ClearCacheAt(u32 em_address);
 
 private:
 	void GenerateFixedCode();

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -96,6 +96,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 	Gen::FixupBranch ptr;
 	if (!likely)
 	{
+		CheckJitBreakpoint(js.compilerPC + 4);
 		if (!delaySlotIsNice)
 			SAVE_FLAGS; // preserve flag around the delay slot!
 		CompileAt(js.compilerPC + 4);
@@ -107,6 +108,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 	else
 	{
 		ptr = J_CC(cc, true);
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		FlushAll();
 	}
@@ -149,6 +151,7 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool likely)
 	js.inDelaySlot = true;
 	if (!likely)
 	{
+		CheckJitBreakpoint(js.compilerPC + 4);
 		if (!delaySlotIsNice)
 			SAVE_FLAGS; // preserve flag around the delay slot! Better hope the delay slot instruction doesn't need to fall back to interpreter...
 		CompileAt(js.compilerPC + 4);
@@ -160,6 +163,7 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool likely)
 	else
 	{
 		ptr = J_CC(cc, true);
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		FlushAll();
 	}
@@ -241,6 +245,7 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 	js.inDelaySlot = true;
 	if (!likely)
 	{
+		CheckJitBreakpoint(js.compilerPC + 4);
 		if (!delaySlotIsNice)
 			SAVE_FLAGS; // preserve flag around the delay slot!
 		CompileAt(js.compilerPC + 4);
@@ -252,6 +257,7 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 	else
 	{
 		ptr = J_CC(cc, true);
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		FlushAll();
 	}
@@ -314,6 +320,7 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	js.inDelaySlot = true;
 	if (!likely)
 	{
+		CheckJitBreakpoint(js.compilerPC + 4);
 		if (!delaySlotIsNice)
 			SAVE_FLAGS; // preserve flag around the delay slot!
 		CompileAt(js.compilerPC + 4);
@@ -325,6 +332,7 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	else
 	{
 		ptr = J_CC(cc, true);
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		FlushAll();
 	}
@@ -364,6 +372,7 @@ void Jit::Comp_Jump(u32 op)
 	}
 	u32 off = ((op & 0x3FFFFFF) << 2);
 	u32 targetAddr = (js.compilerPC & 0xF0000000) | off;
+	CheckJitBreakpoint(js.compilerPC + 4);
 	CompileAt(js.compilerPC + 4);
 	FlushAll();
 
@@ -402,6 +411,7 @@ void Jit::Comp_JumpReg(u32 op)
 
 	if (delaySlotIsNice)
 	{
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		MOV(32, R(EAX), gpr.R(rs));
 		FlushAll();
@@ -412,6 +422,7 @@ void Jit::Comp_JumpReg(u32 op)
 		gpr.BindToRegister(rs, true, false);
 		MOV(32, M(&currentMIPS->pc), gpr.R(rs));	// for syscalls in delay slot - could be avoided
 		MOV(32, M(&savedPC), gpr.R(rs));
+		CheckJitBreakpoint(js.compilerPC + 4);
 		CompileAt(js.compilerPC + 4);
 		FlushAll();
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -61,6 +61,12 @@ void Jit::ClearCache()
 	ClearCodeSpace();
 }
 
+void Jit::ClearCacheAt(u32 em_address)
+{
+	// TODO: Properly.
+	ClearCache();
+}
+
 void Jit::CompileAt(u32 addr)
 {
 	u32 op = Memory::Read_Instruction(addr);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -70,6 +70,7 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
+	void CompileDelaySlot(u32 addr, bool saveFlags = false);
 	void CompileAt(u32 addr);
 	void Comp_RunBlock(u32 op);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -95,6 +95,7 @@ public:
 	AsmRoutineManager &Asm() { return asm_; }
 
 	void ClearCache();
+	void ClearCacheAt(u32 em_address);
 private:
 	void FlushAll();
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -31,6 +31,9 @@
 namespace MIPSComp
 {
 
+// This is called when Jit hits a breakpoint.
+void JitBreakpoint();
+
 struct JitOptions
 {
 	JitOptions()
@@ -103,6 +106,7 @@ private:
 	void WriteExitDestInEAX();
 //	void WriteRfiExitDestInEAX();
 	void WriteSyscallExit();
+	bool CheckJitBreakpoint(u32 addr);
 
 	// Utility compilation functions
 	void BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely);

--- a/Core/MIPS/x86/JitCache.cpp
+++ b/Core/MIPS/x86/JitCache.cpp
@@ -62,7 +62,7 @@ using namespace Gen;
 
 bool JitBlock::ContainsAddress(u32 em_address)
 {
-	// WARNING - THIS DOES NOT WORK WITH INLINING ENABLED.
+	// WARNING - THIS DOES NOT WORK WITH JIT INLINING ENABLED.
 	return (em_address >= originalAddress && em_address < originalAddress + 4 * originalSize);
 }
 

--- a/Core/MIPS/x86/JitCache.h
+++ b/Core/MIPS/x86/JitCache.h
@@ -118,7 +118,7 @@ public:
 	int GetBlockNumberFromStartAddress(u32 em_address);
 
 	// slower, but can get numbers from within blocks, not just the first instruction.
-	// WARNING! WILL NOT WORK WITH INLINING ENABLED (not yet a feature but will be soon)
+	// WARNING! WILL NOT WORK WITH JIT INLINING ENABLED (not yet a feature but will be soon)
 	// Returns a list of block numbers - only one block can start at a particular address, but they CAN overlap.
 	// This one is slow so should only be used for one-shots from the debugger UI, not for anything during runtime.
 	void GetBlockNumbersFromAddress(u32 em_address, std::vector<int> *block_numbers);
@@ -126,7 +126,7 @@ public:
 	u32 GetOriginalFirstOp(int block_num);
 	CompiledCode GetCompiledCodeFromBlock(int block_num);
 
-	// DOES NOT WORK CORRECTLY WITH INLINING
+	// DOES NOT WORK CORRECTLY WITH JIT INLINING
 	void InvalidateICache(u32 address, const u32 length);
 	void DestroyBlock(int block_num, bool invalidate);
 


### PR DESCRIPTION
I wanted to mess with the jit a bit just because it's interesting.  If these changes aren't good I won't feel bad at all if you don't pull them.

This adds breakpoints for jit, which work reasonably well except around branches.  Even so, it can make debugging easier and more straight-forward.  It's only for x86, and should have minimal impact on perf since it's compile time.

I also made it clear cache as you suggested.  But there were fixups I wasn't too sure about, so I left it at clearing all cache.  Also, I don't clear while running since I assume that would be bad...

We probably need a flag for whether the jit is currently running or not, what do you think?  That would fix some crashes when you exit while the game is running in jit, and a possible crash here if you don't wait long enough.

Also, since the comments said inlining broke some things, I added optimize pragmas around those funcs.  But I'm not sure what compiler it breaks in.

-[Unknown]
