### PR TITLE
Micro optimizations to x86 jit mem when fastmem is off

### DIFF
--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -160,6 +160,16 @@ void XEmitter::ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2
 	ABI_RestoreStack(2 * 4);
 }
 
+void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3)
+{
+	ABI_AlignStack(3 * 4);
+	PUSH(32, Imm32(param3));
+	PUSH(32, Imm32(param2));
+	PUSH(32, arg1);
+	CALL(func);
+	ABI_RestoreStack(3 * 4);
+}
+
 void XEmitter::ABI_CallFunctionA(void *func, const Gen::OpArg &arg1)
 {
 	ABI_AlignStack(1 * 4);
@@ -393,6 +403,22 @@ void XEmitter::ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2
 	if (!arg1.IsSimpleReg(ABI_PARAM1))
 		MOV(32, R(ABI_PARAM1), arg1);
 	MOV(32, R(ABI_PARAM2), Imm32(param2));
+	u64 distance = u64(func) - (u64(code) + 5);
+	if (distance >= 0x0000000080000000ULL
+	 && distance <  0xFFFFFFFF80000000ULL) {
+	    // Far call
+	    MOV(64, R(RAX), Imm64((u64)func));
+	    CALLptr(R(RAX));
+	} else {
+	    CALL(func);
+	}
+}
+
+void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3)
+{
+	MOV(32, R(ABI_PARAM1), arg1);
+	MOV(32, R(ABI_PARAM2), Imm32(param2));
+	MOV(64, R(ABI_PARAM3), Imm64(param3));
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL
 	 && distance <  0xFFFFFFFF80000000ULL) {

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -656,6 +656,7 @@ public:
 	void ABI_CallFunctionCCCP(void *func, u32 param1, u32 param2,u32 param3, void *param4);
 	void ABI_CallFunctionPPC(void *func, void *param1, void *param2,u32 param3);
 	void ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2);
+	void ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3);
 	void ABI_CallFunctionA(void *func, const Gen::OpArg &arg1);
 
 	// Pass a register as a paremeter.

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -92,12 +92,14 @@ namespace MIPSComp
 #else
 				MOVZX(32, 16, gpr.RX(rt), MComplex(RBX, EAX, SCALE_1, offset));
 #endif
+				gpr.UnlockAll();
+				FlushAll();
+
 				FixupBranch skip = J();
 				SetJumpTarget(tooLow);
 				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &ReadMemSafe16, gpr.R(rs), rt, offset);
 				SetJumpTarget(skip);
-				gpr.UnlockAll();
 			}
 			else
 			{
@@ -137,12 +139,14 @@ namespace MIPSComp
 #else
 				MOV(32, gpr.R(rt), MComplex(RBX, EAX, SCALE_1, offset));
 #endif
+				gpr.UnlockAll();
+				FlushAll();
+
 				FixupBranch skip = J();
 				SetJumpTarget(tooLow);
 				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &ReadMemSafe32, gpr.R(rs), rt, offset);
 				SetJumpTarget(skip);
-				gpr.UnlockAll();
 			}
 			else
 			{
@@ -185,12 +189,14 @@ namespace MIPSComp
 #else
 				MOV(16, MComplex(RBX, EAX, SCALE_1, offset), gpr.R(rt));
 #endif
+				gpr.UnlockAll();
+				FlushAll();
+
 				FixupBranch skip = J();
 				SetJumpTarget(tooLow);
 				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &WriteMemSafe16, gpr.R(rs), rt, offset);
 				SetJumpTarget(skip);
-				gpr.UnlockAll();
 			}
 			else
 			{
@@ -226,12 +232,14 @@ namespace MIPSComp
 #else
 				MOV(32, MComplex(RBX, EAX, SCALE_1, offset), gpr.R(rt));
 #endif
+				gpr.UnlockAll();
+				FlushAll();
+
 				FixupBranch skip = J();
 				SetJumpTarget(tooLow);
 				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &WriteMemSafe32, gpr.R(rs), rt, offset);
 				SetJumpTarget(skip);
-				gpr.UnlockAll();
 			}
 			else
 			{

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -78,7 +78,26 @@ namespace MIPSComp
 			if (!g_Config.bFastMemory)
 			{
 				FlushAll();
+
+				gpr.Lock(rt, rs);
+				gpr.BindToRegister(rt, rt == rs, true);
+
+				MOV(32, R(EAX), gpr.R(rs));
+				CMP(32, R(EAX), Imm32(0x08000000));
+				FixupBranch tooLow = J_CC(CC_L);
+				CMP(32, R(EAX), Imm32(0x0A000000));
+				FixupBranch tooHigh = J_CC(CC_GE);
+#ifdef _M_IX86
+				MOVZX(32, 16, gpr.RX(rt), MDisp(EAX, (u32)Memory::base + offset));
+#else
+				MOVZX(32, 16, gpr.RX(rt), MComplex(RBX, EAX, SCALE_1, offset));
+#endif
+				FixupBranch skip = J();
+				SetJumpTarget(tooLow);
+				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &ReadMemSafe16, gpr.R(rs), rt, offset);
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
 			}
 			else
 			{
@@ -87,12 +106,10 @@ namespace MIPSComp
 #ifdef _M_IX86
 				MOV(32, R(EAX), gpr.R(rs));
 				AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
-				MOV(32, gpr.R(rt), Imm32(0));
-				MOV(16, gpr.R(rt), MDisp(EAX, (u32)Memory::base + offset));
+				MOVZX(32, 16, gpr.RX(rt), MDisp(EAX, (u32)Memory::base + offset));
 #else
 				MOV(32, R(EAX), gpr.R(rs));
-				MOV(32, gpr.R(rt), Imm32(0));
-				MOV(16, gpr.R(rt), MComplex(RBX, EAX, SCALE_1, offset));
+				MOVZX(32, 16, gpr.RX(rt), MComplex(RBX, EAX, SCALE_1, offset));
 #endif
 				gpr.UnlockAll();
 			}
@@ -106,7 +123,26 @@ namespace MIPSComp
 			if (!g_Config.bFastMemory)
 			{
 				FlushAll();
+
+				gpr.Lock(rt, rs);
+				gpr.BindToRegister(rt, rt == rs, true);
+
+				MOV(32, R(EAX), gpr.R(rs));
+				CMP(32, R(EAX), Imm32(0x08000000));
+				FixupBranch tooLow = J_CC(CC_L);
+				CMP(32, R(EAX), Imm32(0x0A000000));
+				FixupBranch tooHigh = J_CC(CC_GE);
+#ifdef _M_IX86
+				MOV(32, gpr.R(rt), MDisp(EAX, (u32)Memory::base + offset));
+#else
+				MOV(32, gpr.R(rt), MComplex(RBX, EAX, SCALE_1, offset));
+#endif
+				FixupBranch skip = J();
+				SetJumpTarget(tooLow);
+				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &ReadMemSafe32, gpr.R(rs), rt, offset);
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
 			}
 			else
 			{
@@ -135,7 +171,26 @@ namespace MIPSComp
 			if (!g_Config.bFastMemory)
 			{
 				FlushAll();
+
+				gpr.Lock(rt, rs);
+				gpr.BindToRegister(rt, true, true);
+
+				MOV(32, R(EAX), gpr.R(rs));
+				CMP(32, R(EAX), Imm32(0x08000000));
+				FixupBranch tooLow = J_CC(CC_L);
+				CMP(32, R(EAX), Imm32(0x0A000000));
+				FixupBranch tooHigh = J_CC(CC_GE);
+#ifdef _M_IX86
+				MOV(16, MDisp(EAX, (u32)Memory::base + offset), gpr.R(rt));
+#else
+				MOV(16, MComplex(RBX, EAX, SCALE_1, offset), gpr.R(rt));
+#endif
+				FixupBranch skip = J();
+				SetJumpTarget(tooLow);
+				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &WriteMemSafe16, gpr.R(rs), rt, offset);
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
 			}
 			else
 			{
@@ -157,7 +212,26 @@ namespace MIPSComp
 			if (!g_Config.bFastMemory)
 			{
 				FlushAll();
+
+				gpr.Lock(rt, rs);
+				gpr.BindToRegister(rt, true, true);
+
+				MOV(32, R(EAX), gpr.R(rs));
+				CMP(32, R(EAX), Imm32(0x08000000));
+				FixupBranch tooLow = J_CC(CC_L);
+				CMP(32, R(EAX), Imm32(0x0A000000));
+				FixupBranch tooHigh = J_CC(CC_GE);
+#ifdef _M_IX86
+				MOV(32, MDisp(EAX, (u32)Memory::base + offset), gpr.R(rt));
+#else
+				MOV(32, MComplex(RBX, EAX, SCALE_1, offset), gpr.R(rt));
+#endif
+				FixupBranch skip = J();
+				SetJumpTarget(tooLow);
+				SetJumpTarget(tooHigh);
 				ABI_CallFunctionACC((void *) &WriteMemSafe32, gpr.R(rs), rt, offset);
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
 			}
 			else
 			{


### PR DESCRIPTION
I wanted to play around with jit a bit, so I picked this since it seemed simple.  It doesn't really provide a huge perf boost or anything, so the code complexity might not be worth it.

If this doesn't look right at all, please don't merge.  I won't feel bad at all.

This:
- Removes the overhead for sw/lw updating the pc, reshifting the opcode, etc. when fastmem is off by going more directly to the mem.
- Implements lhu/sh in jit (they don't run as much, but they were the next most popular variants in that function for me.)

I'm assuming this is correct for movw:

```
MOV(16, gpr.R(rt), MDisp(EAX, (u32)Memory::base + offset));
```

But I'm not sure, since I tried the same for lbu and it did not work properly (even if I used MOV 32 / AND 32, not sure why...)  That said, everything seems stable with fastmem on or off and lhu/sh only, 32 and 64 bit.

-[Unknown]
