### PR TITLE
Use PNG Icon for empty save from request

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -150,7 +150,7 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 	{
 		int textureColor = 0xFFFFFFFF;
 
-		if(param.GetFileInfo(i).size == 0)
+		if(param.GetFileInfo(i).size == 0 && param.GetFileInfo(i).textureData == 0)
 		{
 			textureColor = 0xFF777777;
 		}

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -178,6 +178,7 @@ public:
 
 private:
 	void Clear();
+	bool CreatePNGIcon(u8* pngData, int pngSize, SaveFileInfo& info);
 	void SetFileInfo(int idx, PSPFileInfo &info, std::string saveName);
 
 	SceUtilitySavedataParam* pspParam;


### PR DESCRIPTION
The newData param contain an address where there is the info for the PNG to show for empty save in the save list dialog. Tested with Tales of Eternia and the Project Diva games.
