### PR TITLE
Add fade in and out in dialogs

### DIFF
--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -66,8 +66,18 @@ public:
 protected:
 	bool IsButtonPressed(int checkButton);
 	void DisplayMessage(std::string text);
+
+	void StartFade(bool fadeIn_);
+	void UpdateFade();
+	u32 CalcFadedColor(u32 inColor);
+
 	DialogStatus status;
 
 	unsigned int lastButtons;
 	unsigned int buttons;
+
+	float fadeTimer;
+	bool isFading;
+	bool fadeIn;
+	u32 fadeValue;
 };

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -121,20 +121,21 @@ int PSPMsgDialog::Init(unsigned int paramAddr)
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 
 	lastButtons = __CtrlPeekButtons();
+	StartFade(true);
 	return 0;
 }
 
 void PSPMsgDialog::DisplayBack()
 {
-	PPGeDrawImage(cancelButtonImg, 290, 220, 20, 20, 0, 0xFFFFFFFF);
-	PPGeDrawText("Back", 320, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+	PPGeDrawImage(cancelButtonImg, 290, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Back", 320, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 }
 
 void PSPMsgDialog::DisplayYesNo()
 {
 
-	PPGeDrawText("Yes", 200, 150, PPGE_ALIGN_LEFT, 0.5f, (yesnoChoice == 1?0xFF0000FF:0xFFFFFFFF));
-	PPGeDrawText("No", 320, 150, PPGE_ALIGN_LEFT, 0.5f, (yesnoChoice == 0?0xFF0000FF:0xFFFFFFFF));
+	PPGeDrawText("Yes", 200, 150, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(yesnoChoice == 1?0xFF0000FF:0xFFFFFFFF));
+	PPGeDrawText("No", 320, 150, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(yesnoChoice == 0?0xFF0000FF:0xFFFFFFFF));
 
 	if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0)
 	{
@@ -148,22 +149,17 @@ void PSPMsgDialog::DisplayYesNo()
 
 void PSPMsgDialog::DisplayOk()
 {
-	PPGeDrawText("OK", 250, 150, PPGE_ALIGN_LEFT, 0.5f, 0xFF0000FF);
+	PPGeDrawText("OK", 250, 150, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFF0000FF));
 }
 
 void PSPMsgDialog::DisplayEnter()
 {
-	PPGeDrawImage(okButtonImg, 200, 220, 20, 20, 0, 0xFFFFFFFF);
-	PPGeDrawText("Enter", 230, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+	PPGeDrawImage(okButtonImg, 200, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Enter", 230, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 }
 
 int PSPMsgDialog::Update()
 {
-	switch (status) {
-	case SCE_UTILITY_STATUS_FINISHED:
-		status = SCE_UTILITY_STATUS_SHUTDOWN;
-		break;
-	}
 
 	if (status != SCE_UTILITY_STATUS_RUNNING)
 	{
@@ -176,6 +172,8 @@ int PSPMsgDialog::Update()
 	}
 	else
 	{
+		UpdateFade();
+
 		buttons = __CtrlPeekButtons();
 
 		okButtonImg = I_CIRCLE;
@@ -205,30 +203,26 @@ int PSPMsgDialog::Update()
 		if(flag & DS_CANCELBUTTON)
 			DisplayBack();
 
-
-		// TODO : Dialogs should take control over input and not send them to the game while displaying
 		if (IsButtonPressed(cancelButtonFlag) && (flag & DS_CANCELBUTTON))
 		{
-			status = SCE_UTILITY_STATUS_FINISHED;
 			if(messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ||
 					((messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V2) && (flag & DS_YESNO)))
 				messageDialog.buttonPressed = 3;
 			else
 				messageDialog.buttonPressed = 0;
+			StartFade(false);
 		}
 		else if(IsButtonPressed(okButtonFlag) && (flag & DS_VALIDBUTTON))
 		{
-			status = SCE_UTILITY_STATUS_FINISHED;
 			if(yesnoChoice == 0)
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				messageDialog.buttonPressed = 2;
 			}
 			else
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				messageDialog.buttonPressed = 1;
 			}
+			StartFade(false);
 		}
 
 

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -89,6 +89,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 	// Eat any keys pressed before the dialog inited.
 	__CtrlReadLatch();
 
+	StartFade(true);
 	return 0;
 }
 
@@ -109,16 +110,16 @@ void PSPOskDialog::RenderKeyboard()
 	const float keyboardLeftSide = (480.0f - (23.0f * KEYSPERROW)) / 2.0f;
 	float previewLeftSide = (480.0f - (15.0f * limit)) / 2.0f;
 
-	PPGeDrawText(oskDesc.c_str(), 480/2, 20, PPGE_ALIGN_CENTER, 0.5f, 0xFFFFFFFF);
+	PPGeDrawText(oskDesc.c_str(), 480/2, 20, PPGE_ALIGN_CENTER, 0.5f, CalcFadedColor(0xFFFFFFFF));
 	for (int i = 0; i < limit; ++i)
 	{
-		u32 color = 0xFFFFFFFF;
+		u32 color = CalcFadedColor(0xFFFFFFFF);
 		if (i < (int) inputChars.size())
 			temp[0] = inputChars[i];
 		else if (i == inputChars.size())
 		{
 			temp[0] = oskKeys[selectedRow][selectedExtra];
-			color = 0xFF3060FF;
+			color = CalcFadedColor(0xFF3060FF);
 		}
 		else
 			temp[0] = '_';
@@ -129,15 +130,15 @@ void PSPOskDialog::RenderKeyboard()
 	{
 		for (int col = 0; col < KEYSPERROW; ++col)
 		{
-			u32 color = 0xFFFFFFFF;
+			u32 color = CalcFadedColor(0xFFFFFFFF);
 			if (selectedRow == row && col == selectedExtra)
-				color = 0xFF7f7f7f;
+				color = CalcFadedColor(0xFF7f7f7f);
 
 			temp[0] = oskKeys[row][col];
 			PPGeDrawText(temp, keyboardLeftSide + (25.0f * col), 70.0f + (25.0f * row), 0, 0.6f, color);
 
 			if (selectedRow == row && col == selectedExtra)
-				PPGeDrawText("_", keyboardLeftSide + (25.0f * col), 70.0f + (25.0f * row), 0, 0.6f, 0xFFFFFFFF);
+				PPGeDrawText("_", keyboardLeftSide + (25.0f * col), 70.0f + (25.0f * row), 0, 0.6f, CalcFadedColor(0xFFFFFFFF));
 		}
 	}
 
@@ -160,17 +161,19 @@ int PSPOskDialog::Update()
 	}
 	else if (status == SCE_UTILITY_STATUS_RUNNING)
 	{		
+		UpdateFade();
+
 		StartDraw();
 		RenderKeyboard();
-		PPGeDrawImage(I_CROSS, 100, 220, 20, 20, 0, 0xFFFFFFFF);
-		PPGeDrawText("Select", 130, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+		PPGeDrawImage(I_CROSS, 100, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("Select", 130, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
-		PPGeDrawImage(I_CIRCLE, 200, 220, 20, 20, 0, 0xFFFFFFFF);
-		PPGeDrawText("Delete", 230, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+		PPGeDrawImage(I_CIRCLE, 200, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("Delete", 230, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
-		PPGeDrawImage(I_BUTTON, 290, 220, 50, 20, 0, 0xFFFFFFFF);
-		PPGeDrawText("Start", 305, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
-		PPGeDrawText("Finish", 350, 220, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+		PPGeDrawImage(I_BUTTON, 290, 220, 50, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("Start", 305, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("Finish", 350, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 		if (IsButtonPressed(CTRL_UP))
 		{
@@ -195,7 +198,6 @@ int PSPOskDialog::Update()
 
 		selectedChar = (selectedChar + NUMBEROFVALIDCHARS) % NUMBEROFVALIDCHARS;
 
-		// TODO : Dialogs should take control over input and not send them to the game while displaying
 		if (IsButtonPressed(CTRL_CROSS))
 		{
 			if ((int) inputChars.size() < limit)
@@ -208,7 +210,7 @@ int PSPOskDialog::Update()
 		}
 		else if (IsButtonPressed(CTRL_START))
 		{
-			status = SCE_UTILITY_STATUS_FINISHED;
+			StartFade(false);
 		}
 		EndDraw();
 	}

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -108,6 +108,7 @@ int PSPSaveDialog::Init(int paramAddr)
 
 	currentSelectedSave = 0;
 	lastButtons = __CtrlPeekButtons();
+	StartFade(true);
 
 	/*INFO_LOG(HLE,"Dump Param :");
 	INFO_LOG(HLE,"size : %d",param.GetPspParam()->size);
@@ -148,11 +149,11 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 	int displayCount = 0;
 	for(int i = 0; i < param.GetFilenameCount(); i++)
 	{
-		int textureColor = 0xFFFFFFFF;
+		int textureColor = CalcFadedColor(0xFFFFFFFF);
 
 		if(param.GetFileInfo(i).size == 0 && param.GetFileInfo(i).textureData == 0)
 		{
-			textureColor = 0xFF777777;
+			textureColor = CalcFadedColor(0xFF777777);
 		}
 
 		// Calc save image position on screen
@@ -205,11 +206,11 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 
 void PSPSaveDialog::DisplaySaveIcon()
 {
-	int textureColor = 0xFFFFFFFF;
+	int textureColor = CalcFadedColor(0xFFFFFFFF);
 
 	if(param.GetFileInfo(currentSelectedSave).size == 0)
 	{
-		textureColor = 0xFF777777;
+		textureColor = CalcFadedColor(0xFF777777);
 	}
 
 	// Calc save image position on screen
@@ -241,7 +242,7 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 {
 	if(param.GetFileInfo(currentSelectedSave).size == 0)
 	{
-		PPGeDrawText("New Save", 180, 100, PPGE_ALIGN_LEFT, 0.5f, 0xFFFFFFFF);
+		PPGeDrawText("New Save", 180, 100, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 	}
 	else
 	{
@@ -263,15 +264,15 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 		snprintf(saveDetail,512,"%s", param.GetFileInfo(currentSelectedSave).saveDetail);
 
 		
-		PPGeDrawRect(180, 139, 980, 140, 0xFFFFFFFF);
+		PPGeDrawRect(180, 139, 980, 140, CalcFadedColor(0xFFFFFFFF));
 		std::string titleTxt = title;
-		PPGeDrawText(titleTxt.c_str(), 180, 120, PPGE_ALIGN_LEFT, 0.5f, 0xFFC0C0C0);
+		PPGeDrawText(titleTxt.c_str(), 180, 120, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFC0C0C0));
 		std::string timeTxt = time;
-		PPGeDrawText(timeTxt.c_str(), 180, 141, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+		PPGeDrawText(timeTxt.c_str(), 180, 141, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 		std::string saveTitleTxt = saveTitle;
-		PPGeDrawText(saveTitleTxt.c_str(), 175, 163, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+		PPGeDrawText(saveTitleTxt.c_str(), 175, 163, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 		std::string saveDetailTxt = saveDetail;
-		PPGeDrawText(saveDetailTxt.c_str(), 175, 185, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+		PPGeDrawText(saveDetailTxt.c_str(), 175, 185, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 	}
 }
 
@@ -293,7 +294,7 @@ void PSPSaveDialog::DisplaySaveDataInfo2()
 						, param.GetFileInfo(currentSelectedSave).size / 1024
 						);
 		std::string saveinfoTxt = txt;
-		PPGeDrawText(saveinfoTxt.c_str(), 10, 180, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+		PPGeDrawText(saveinfoTxt.c_str(), 10, 180, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 	}
 }
 
@@ -301,8 +302,8 @@ void PSPSaveDialog::DisplayConfirmationYesNo(std::string text)
 {
 	PPGeDrawText(text.c_str(), 180, 100, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
 
-	PPGeDrawText("Yes", 230, 140, PPGE_ALIGN_LEFT, 0.45f, (yesnoChoice == 1?0xFF0000FF:0xFFFFFFFF));
-	PPGeDrawText("No", 330, 140, PPGE_ALIGN_LEFT, 0.45f, (yesnoChoice == 0?0xFF0000FF:0xFFFFFFFF));
+	PPGeDrawText("Yes", 230, 140, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(yesnoChoice == 1?0xFF0000FF:0xFFFFFFFF));
+	PPGeDrawText("No", 330, 140, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(yesnoChoice == 0?0xFF0000FF:0xFFFFFFFF));
 
 	if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0)
 	{
@@ -316,25 +317,25 @@ void PSPSaveDialog::DisplayConfirmationYesNo(std::string text)
 
 void PSPSaveDialog::DisplayInfo(std::string text)
 {
-	PPGeDrawRect(180, 105, 460, 106, 0xFFFFFFFF);
-	PPGeDrawText(text.c_str(), 270, 110, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
-	PPGeDrawRect(180, 130, 460, 131, 0xFFFFFFFF);
+	PPGeDrawRect(180, 105, 460, 106, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(text.c_str(), 270, 110, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawRect(180, 130, 460, 131, CalcFadedColor(0xFFFFFFFF));
 }
 void PSPSaveDialog::DisplayTitle(std::string name)
 {
-	PPGeDrawText(name.c_str(), 10, 10, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+	PPGeDrawText(name.c_str(), 10, 10, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 }
 void PSPSaveDialog::DisplayEnterBack()
 {
-	PPGeDrawImage(okButtonImg, 180, 257, 11, 11, 0, 0xFFFFFFFF);
-	PPGeDrawText("Enter", 195, 255, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
-	PPGeDrawImage(cancelButtonImg, 270, 257, 11, 11, 0, 0xFFFFFFFF);
-	PPGeDrawText("Back", 285, 255, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+	PPGeDrawImage(okButtonImg, 180, 257, 11, 11, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Enter", 195, 255, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(cancelButtonImg, 270, 257, 11, 11, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Back", 285, 255, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 }
 void PSPSaveDialog::DisplayBack()
 {
-	PPGeDrawImage(cancelButtonImg, 180, 257, 11, 11, 0, 0xFFFFFFFF);
-	PPGeDrawText("Back", 195, 255, PPGE_ALIGN_LEFT, 0.45f, 0xFFFFFFFF);
+	PPGeDrawImage(cancelButtonImg, 180, 257, 11, 11, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Back", 195, 255, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 }
 
 int PSPSaveDialog::Update()
@@ -358,6 +359,7 @@ int PSPSaveDialog::Update()
 	}
 
 	buttons = __CtrlPeekButtons();
+	UpdateFade();
 
 	okButtonImg = I_CIRCLE;
 	cancelButtonImg = I_CROSS;
@@ -376,16 +378,15 @@ int PSPSaveDialog::Update()
 		case DS_SAVE_LIST_CHOICE:
 			StartDraw();
 			
-			// TODO : use focus for selected save by default, and don't modify global selected save,use local var
+			// TODO : use focus param for selected save by default
 			DisplaySaveList();
 			DisplaySaveDataInfo1();
 
-			// TODO : Dialogs should take control over input and not send them to the game while displaying
 			DisplayEnterBack();
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_DIALOG_RESULT_CANCEL;
+				StartFade(false);
 			}
 			else if (IsButtonPressed(okButtonFlag))
 			{
@@ -471,10 +472,10 @@ int PSPSaveDialog::Update()
 
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_DIALOG_RESULT_SUCCESS;
 				// Set the save to use for autosave and autoload
 				param.SetSelectedSave(param.GetFileInfo(currentSelectedSave).idx);
+				StartFade(false);
 			}
 
 			EndDraw();
@@ -486,12 +487,11 @@ int PSPSaveDialog::Update()
 			DisplaySaveList();
 			DisplaySaveDataInfo1();
 
-			// TODO : Dialogs should take control over input and not send them to the game while displaying
 			DisplayEnterBack();
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_DIALOG_RESULT_CANCEL;
+				StartFade(false);
 			}
 			else if (IsButtonPressed(okButtonFlag))
 			{
@@ -527,10 +527,10 @@ int PSPSaveDialog::Update()
 
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_DIALOG_RESULT_SUCCESS;
 				// Set the save to use for autosave and autoload
 				param.SetSelectedSave(param.GetFileInfo(currentSelectedSave).idx);
+				StartFade(false);
 			}
 
 			EndDraw();
@@ -545,8 +545,8 @@ int PSPSaveDialog::Update()
 
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_LOAD_NO_DATA;
+				StartFade(false);
 			}
 
 			EndDraw();
@@ -558,12 +558,11 @@ int PSPSaveDialog::Update()
 			DisplaySaveList();
 			DisplaySaveDataInfo1();
 
-			// TODO : Dialogs should take control over input and not send them to the game while displaying
 			DisplayEnterBack();
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_DIALOG_RESULT_CANCEL;
+				StartFade(false);
 			}
 			else if (IsButtonPressed(okButtonFlag))
 			{
@@ -646,8 +645,8 @@ int PSPSaveDialog::Update()
 
 			if (IsButtonPressed(cancelButtonFlag))
 			{
-				status = SCE_UTILITY_STATUS_FINISHED;
 				param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_DELETE_NO_DATA;
+				StartFade(false);
 			}
 
 			EndDraw();

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -770,7 +770,11 @@ bool SavedataParam::CreatePNGIcon(u8* pngData, int pngSize, SaveFileInfo& info)
 		info.textureHeight = h;
 	}
 	else
+	{
 		WARN_LOG(HLE, "Unable to load PNG data for savedata.");
+		return false;
+	}
+	return true;
 }
 
 void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info, std::string saveName)


### PR DESCRIPTION
Allow time for the user to release button so the games like Tales of Eternia don't close the menu directly.
And removed comments about the dialog which need to lock input cause it's not the case on PSP.
