### PR TITLE
Don't muck with currentMIPS->r directly in the slowmem jit

### DIFF
--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -170,6 +170,16 @@ void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param
 	ABI_RestoreStack(3 * 4);
 }
 
+void XEmitter::ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3)
+{
+	ABI_AlignStack(3 * 4);
+	PUSH(32, Imm32(param3));
+	PUSH(32, arg2);
+	PUSH(32, arg1);
+	CALL(func);
+	ABI_RestoreStack(3 * 4);
+}
+
 void XEmitter::ABI_CallFunctionA(void *func, const Gen::OpArg &arg1)
 {
 	ABI_AlignStack(1 * 4);
@@ -418,6 +428,22 @@ void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param
 {
 	MOV(32, R(ABI_PARAM1), arg1);
 	MOV(32, R(ABI_PARAM2), Imm32(param2));
+	MOV(64, R(ABI_PARAM3), Imm64(param3));
+	u64 distance = u64(func) - (u64(code) + 5);
+	if (distance >= 0x0000000080000000ULL
+	 && distance <  0xFFFFFFFF80000000ULL) {
+	    // Far call
+	    MOV(64, R(RAX), Imm64((u64)func));
+	    CALLptr(R(RAX));
+	} else {
+	    CALL(func);
+	}
+}
+
+void XEmitter::ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3)
+{
+	MOV(32, R(ABI_PARAM1), arg1);
+	MOV(32, R(ABI_PARAM2), arg2);
 	MOV(64, R(ABI_PARAM3), Imm64(param3));
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL

--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -170,22 +170,21 @@ void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param
 	ABI_RestoreStack(3 * 4);
 }
 
-void XEmitter::ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3)
-{
-	ABI_AlignStack(3 * 4);
-	PUSH(32, Imm32(param3));
-	PUSH(32, arg2);
-	PUSH(32, arg1);
-	CALL(func);
-	ABI_RestoreStack(3 * 4);
-}
-
 void XEmitter::ABI_CallFunctionA(void *func, const Gen::OpArg &arg1)
 {
 	ABI_AlignStack(1 * 4);
 	PUSH(32, arg1);
 	CALL(func);
 	ABI_RestoreStack(1 * 4);
+}
+
+void XEmitter::ABI_CallFunctionAA(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2)
+{
+	ABI_AlignStack(2 * 4);
+	PUSH(32, arg2);
+	PUSH(32, arg1);
+	CALL(func);
+	ABI_RestoreStack(2 * 4);
 }
 
 void XEmitter::ABI_PushAllCalleeSavedRegsAndAdjustStack() {
@@ -440,11 +439,10 @@ void XEmitter::ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param
 	}
 }
 
-void XEmitter::ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3)
+void XEmitter::ABI_CallFunctionA(void *func, const Gen::OpArg &arg1)
 {
-	MOV(32, R(ABI_PARAM1), arg1);
-	MOV(32, R(ABI_PARAM2), arg2);
-	MOV(64, R(ABI_PARAM3), Imm64(param3));
+	if (!arg1.IsSimpleReg(ABI_PARAM1))
+		MOV(32, R(ABI_PARAM1), arg1);
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL
 	 && distance <  0xFFFFFFFF80000000ULL) {
@@ -456,10 +454,12 @@ void XEmitter::ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen
 	}
 }
 
-void XEmitter::ABI_CallFunctionA(void *func, const Gen::OpArg &arg1)
+void XEmitter::ABI_CallFunctionAA(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2)
 {
 	if (!arg1.IsSimpleReg(ABI_PARAM1))
 		MOV(32, R(ABI_PARAM1), arg1);
+	if (!arg2.IsSimpleReg(ABI_PARAM2))
+		MOV(32, R(ABI_PARAM2), arg2);
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL
 	 && distance <  0xFFFFFFFF80000000ULL) {

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -657,8 +657,8 @@ public:
 	void ABI_CallFunctionPPC(void *func, void *param1, void *param2,u32 param3);
 	void ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2);
 	void ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3);
-	void ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3);
 	void ABI_CallFunctionA(void *func, const Gen::OpArg &arg1);
+	void ABI_CallFunctionAA(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2);
 
 	// Pass a register as a paremeter.
 	void ABI_CallFunctionR(void *func, Gen::X64Reg reg1);

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -657,6 +657,7 @@ public:
 	void ABI_CallFunctionPPC(void *func, void *param1, void *param2,u32 param3);
 	void ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2);
 	void ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3);
+	void ABI_CallFunctionAAC(void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2, u32 param3);
 	void ABI_CallFunctionA(void *func, const Gen::OpArg &arg1);
 
 	// Pass a register as a paremeter.

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -55,7 +55,13 @@ namespace MIPSComp
 		{
 			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
 			if (data)
+			{
+#ifdef _M_IX86
 				MOVZX(32, bits, gpr.RX(rt), M(data));
+#else
+				MOVZX(32, bits, gpr.RX(rt), MDisp(RBX, gpr.R(rs).GetImmValue() + offset));
+#endif
+			}
 			else
 				MOV(32, gpr.R(rt), Imm32(0));
 		}
@@ -120,7 +126,13 @@ namespace MIPSComp
 		{
 			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
 			if (data)
+			{
+#ifdef _M_IX86
 				MOV(bits, M(data), gpr.R(rt));
+#else
+				MOV(bits, MDisp(RBX, gpr.R(rs).GetImmValue() + offset), gpr.R(rt));
+#endif
+			}
 			else if (bits == 8)
 				MOV(bits, M(data), Imm8(0));
 			else if (bits == 16)

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -43,6 +43,7 @@ namespace MIPSComp
 {
 	void Jit::CompITypeMemRead(u32 op, u32 bits, void *func)
 	{
+		CONDITIONAL_DISABLE;
 		int offset = (signed short)(op&0xFFFF);
 		int rt = _RT;
 		int rs = _RS;
@@ -102,6 +103,7 @@ namespace MIPSComp
 
 	void Jit::CompITypeMemWrite(u32 op, u32 bits, void *func)
 	{
+		CONDITIONAL_DISABLE;
 		int offset = (signed short)(op&0xFFFF);
 		int rt = _RT;
 		int rs = _RS;
@@ -160,6 +162,7 @@ namespace MIPSComp
 
 	void Jit::Comp_ITypeMem(u32 op)
 	{
+		CONDITIONAL_DISABLE;
 		int offset = (signed short)(op&0xFFFF);
 		int rt = _RT;
 		int rs = _RS;

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -133,12 +133,6 @@ namespace MIPSComp
 				MOV(bits, MDisp(RBX, gpr.R(rs).GetImmValue() + offset), gpr.R(rt));
 #endif
 			}
-			else if (bits == 8)
-				MOV(bits, M(data), Imm8(0));
-			else if (bits == 16)
-				MOV(bits, M(data), Imm16(0));
-			else
-				MOV(bits, M(data), Imm32(0));
 		}
 		else if (!g_Config.bFastMemory)
 		{

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -121,6 +121,8 @@ private:
 	void CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &));
 	void CompShiftImm(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
 	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
+	void CompITypeMemRead(u32 op, u32 bits, void *func);
+	void CompITypeMemWrite(u32 op, u32 bits, void *func);
 
 	void CompFPTriArith(u32 op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -121,8 +121,8 @@ private:
 	void CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &));
 	void CompShiftImm(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
 	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
-	void CompITypeMemRead(u32 op, u32 bits, void *func);
-	void CompITypeMemWrite(u32 op, u32 bits, void *func);
+	void CompITypeMemRead(u32 op, u32 bits, void (XEmitter::*mov)(int, int, X64Reg, OpArg), void *safeFunc);
+	void CompITypeMemWrite(u32 op, u32 bits, void *safeFunc);
 
 	void CompFPTriArith(u32 op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "../../../Globals.h"
+#include "../../../Common/Thunk.h"
 #include "Asm.h"
 
 #if defined(ARM)
@@ -131,6 +132,7 @@ private:
 	FPURegCache fpr;
 
 	AsmRoutineManager asm_;
+	ThunkManager thunks;
 
 	MIPSState *mips_;
 };


### PR DESCRIPTION
Is this the better way to handle it?  I was having problems at first, which is why I set the regs directly.  This kills the need for the extra flush, so it seems right.

-[Unknown]
