### PR TITLE
cast not needed

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -118,7 +118,7 @@ public:
 	template<class K, class T>
 	void Do(std::multimap<K, T> &x)
 	{
-		unsigned int number = (unsigned int)x.size();
+		unsigned int number = x.size();
 		Do(number);
 		switch (mode) {
 		case MODE_READ:


### PR DESCRIPTION
according to the standard, size_t is 32bit unsigned so the casts is invalid, and I tend to use C++ casts anyway (they're safer to use, in my opinion).

Compiled on Linux (g++ 4.7.2).
