### PR TITLE
Decrement downcount in the interpreter

### DIFF
--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -995,6 +995,7 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 				}
 			}
 
+			curMips->downcount -= 1;
 			if (CoreTiming::GetTicks() > globalTicks)
 			{
 				// DEBUG_LOG(CPU, "Hit the max ticks, bailing 1 : %llu, %llu", globalTicks, CoreTiming::GetTicks());


### PR DESCRIPTION
Okay, so... what can I say?  It wasn't being decremented.

Obviously, this impacts performance.  The interpreter is slower with this change.

However, it actually fixes performance issues in at least Who's That Flying? and Worms 1 Demo.  They are most likely waiting for timers or what have you, and spinning a lot more because they weren't happening.

Let me know if I'm somehow wrong, and the downcount is actually being decremented somewhere I can't find (aside from delay slots.)

Why it was working: it was only being decremented inside delay slots.  However, delay slots are quite common, especially in loops.  I guess that was somehow often enough...

I intentionally left it out of the faster interpreter, which makes it moreso a faster interpreter.

This + the table changes in #459 help make the downcount match up with jit.

-[Unknown]
