### PR TITLE
Match the interpreter better in jit

### DIFF
--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -947,6 +947,8 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 	MIPSState *curMips = currentMIPS;
 	while (coreState == CORE_RUNNING)
 	{
+		CoreTiming::Advance();
+
 		// NEVER stop in a delay slot!
 		while (curMips->downcount >= 0 && coreState == CORE_RUNNING)
 		{
@@ -1002,8 +1004,6 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 				return 1;
 			}
 		}
-
-		CoreTiming::Advance();
 	}
 
 	return 1;
@@ -1026,6 +1026,8 @@ int MIPSInterpret_RunFastUntil(u64 globalTicks)
 	MIPSState *curMips = currentMIPS;
 	while (coreState == CORE_RUNNING) 
 	{
+		CoreTiming::Advance();
+
 		while (curMips->downcount >= 0 && coreState == CORE_RUNNING)   // TODO: Try to get rid of the latter check
 		{
 			again:
@@ -1127,8 +1129,6 @@ int MIPSInterpret_RunFastUntil(u64 globalTicks)
 				goto again;
 			}
 		}
-
-		CoreTiming::Advance();
 	}
 	return 1;
 }

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -99,8 +99,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 #ifdef _M_IX86
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
 			_assert_msg_(CPU, Memory::base != 0, "Memory base bogus");
-			MOV(32, R(EDX), Imm32((u32)Memory::base));
-			MOV(32, R(EAX), MComplex(EDX, EAX, SCALE_1, 0));
+			MOV(32, R(EAX), MDisp(EAX, (u32)Memory::base));
 #elif _M_X64
 			MOV(32, R(EAX), MComplex(RBX, RAX, SCALE_1, 0));
 #endif

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -455,7 +455,8 @@ void Jit::Comp_JumpReg(u32 op)
 
 	if (delaySlotIsNice)
 	{
-		CompileAt(js.compilerPC + 4);
+		// TODO: This flushes which is a waste, could add an extra param to skip.
+		CompileDelaySlot(false);
 		MOV(32, R(EAX), gpr.R(rs));
 		FlushAll();
 	}

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -490,6 +490,11 @@ void Jit::Comp_Syscall(u32 op)
 {
 	FlushAll();
 
+	// If we're in a delay slot, this is off by one.
+	const int offset = js.inDelaySlot ? -1 : 0;
+	WriteDowncount(offset);
+	js.downcountAmount = -offset;
+
 	ABI_CallFunctionC((void *)&CallSyscall, op);
 
 	WriteSyscallExit();

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -154,7 +154,6 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 	}
 	FlushAll();
 
-	js.inDelaySlot = true;
 	Gen::FixupBranch ptr;
 	if (!likely)
 	{
@@ -166,7 +165,6 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 		ptr = J_CC(cc, true);
 		CompileDelaySlot(false);
 	}
-	js.inDelaySlot = false;
 
 	// Take the branch
 	CONDITIONAL_LOG_EXIT(targetAddr);
@@ -205,7 +203,6 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool likely)
 	FlushAll();
 
 	Gen::FixupBranch ptr;
-	js.inDelaySlot = true;
 	if (!likely)
 	{
 		CompileDelaySlot(!delaySlotIsNice);
@@ -216,7 +213,6 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool likely)
 		ptr = J_CC(cc, true);
 		CompileDelaySlot(false);
 	}
-	js.inDelaySlot = false;
 
 	// Take the branch
 	CONDITIONAL_LOG_EXIT(targetAddr);
@@ -295,7 +291,6 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 
 	TEST(32, M((void *)&(mips_->fpcond)), Imm32(1));
 	Gen::FixupBranch ptr;
-	js.inDelaySlot = true;
 	if (!likely)
 	{
 		CompileDelaySlot(!delaySlotIsNice);
@@ -306,7 +301,6 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 		ptr = J_CC(cc, true);
 		CompileDelaySlot(false);
 	}
-	js.inDelaySlot = false;
 
 	// Take the branch
 	CONDITIONAL_LOG_EXIT(targetAddr);
@@ -365,7 +359,6 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	//int val = (mips_->vfpuCtrl[VFPU_CTRL_CC] >> imm3) & 1;
 	TEST(32, M((void *)&(mips_->vfpuCtrl[VFPU_CTRL_CC])), Imm32(1 << imm3));
 	Gen::FixupBranch ptr;
-	js.inDelaySlot = true;
 	if (!likely)
 	{
 		CompileDelaySlot(!delaySlotIsNice);
@@ -376,7 +369,6 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 		ptr = J_CC(cc, true);
 		CompileDelaySlot(false);
 	}
-	js.inDelaySlot = false;
 
 	// Take the branch
 	CONDITIONAL_LOG_EXIT(targetAddr);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -133,8 +133,10 @@ void Jit::CompileDelaySlot(bool saveFlags)
 	if (saveFlags)
 		SAVE_FLAGS; // preserve flag around the delay slot!
 
+	js.inDelaySlot = true;
 	u32 op = Memory::Read_Instruction(addr);
 	MIPSCompileOp(op);
+	js.inDelaySlot = false;
 
 	FlushAll();
 	if (saveFlags)

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -103,6 +103,7 @@ public:
 	void ClearCacheAt(u32 em_address);
 private:
 	void FlushAll();
+	void WriteDowncount(int offset = 0);
 
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInEAX();

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -108,7 +108,7 @@ private:
 	void WriteExitDestInEAX();
 //	void WriteRfiExitDestInEAX();
 	void WriteSyscallExit();
-	bool CheckJitBreakpoint(u32 addr);
+	bool CheckJitBreakpoint(u32 addr, int downcountOffset);
 
 	// Utility compilation functions
 	void BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely);

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -15,6 +15,7 @@
 #include "../../Core/Core.h"
 #include "../../Core/CPU.h"
 #include "../../Core/HLE/HLE.h"
+#include "../../Core/CoreTiming.h"
 
 #include "base/stringutil.h"
 
@@ -183,7 +184,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					Sleep(1);
 					_dbg_update_();
 					ptr->gotoPC();
-					reglist->redraw();
+					UpdateDialog();
 					vfpudlg->Update();
 				}
 				break;
@@ -197,7 +198,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					MainWindow::UpdateMenus();
 					Sleep(1);
 					ptr->gotoPC();
-					reglist->redraw();
+					UpdateDialog();
 				}
 				break;
 				
@@ -217,10 +218,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					Core_EnableStepping(true);
 					_dbg_update_();
 					MainWindow::UpdateMenus();
-					UpdateDialog();
 					Sleep(1); //let cpu catch up
 					ptr->gotoPC();
-					reglist->redraw();
+					UpdateDialog();
 					vfpudlg->Update();
 				}
 				break;
@@ -359,6 +359,7 @@ void CDisasm::SetDebugMode(bool _bDebug)
 		ptr->gotoPC();
 		// update the callstack
 		//CDisam::blah blah
+		UpdateDialog();
 	}
 	else
 	{
@@ -368,9 +369,9 @@ void CDisasm::SetDebugMode(bool _bDebug)
 		EnableWindow( GetDlgItem(hDlg, IDC_STEPHLE), FALSE);
 		EnableWindow( GetDlgItem(hDlg, IDC_STOP), TRUE);
 		EnableWindow( GetDlgItem(hDlg, IDC_SKIP), FALSE);		
+		CtrlRegisterList *reglist = CtrlRegisterList::getFrom(GetDlgItem(m_hDlg,IDC_REGLIST));
+		reglist->redraw();
 	}
-	CtrlRegisterList *reglist = CtrlRegisterList::getFrom(GetDlgItem(m_hDlg,IDC_REGLIST));
-	reglist->redraw();
 }
 
 void CDisasm::NotifyMapLoaded()
@@ -408,11 +409,10 @@ void CDisasm::UpdateDialog(bool _bComplete)
 	CtrlRegisterList *rl = CtrlRegisterList::getFrom(GetDlgItem(m_hDlg,IDC_REGLIST));
 	rl->redraw();						
 	// Update Debug Counter
-	/*
-	char szBuffer[32];
-	sprintf(szBuffer, "%04X%08X", PowerPC::ppcState.TU,PowerPC::ppcState.TL);
-	SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, szBuffer);
-*/
+	char tempTicks[24];
+	sprintf(tempTicks, "%lld", CoreTiming::GetTicks());
+	SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
+
 	// Update Register Dialog
 	for (int i=0; i<numCPUs; i++)
 		if (memoryWindow[i])


### PR DESCRIPTION
This includes a few random things, sorry.  I haven't nailed down the difference yet, but wanted to make sure everything else matched up so comparison was easier.

Changes:
- On x86, read the emuhack using a disp32 instead of using EDX as a temporary (same as lw.)  I just did this while reading the dispatcher.  If there was a good reason to use the SEB and MOV to EDX, probably deserves a comment and changing lw too.
- Makes the interpreter count skipped likely slots as a cycle.  This matches jit, and my understanding is they are changed to a nop in the pipeline but still waste a cycle.
- Adds the current tick count to the Windows disasm.  I know the debug count is probably meant to be there, but it was commented out anyway.
- Fixes jit breakpoints eating extra cycles when set in delay slots.
- Correctly adjusts downcount before syscalls.  Otherwise, they are off by one (including Advance() reschedules.)  This does add a SUB for every syscall, but it also makes timing match more exactly between interpreter and jit which I think is worth it.
- Moves Advance() to the top of the interpreter loop, instead of the bottom.  Makes timing match better and can't find any negative effects.

Now my cycles match exactly until the point where jit breaks.  Hurray.

-[Unknown]
