### PR TITLE
Don't optimize for debug build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_NDEBUG")
 
 if(NOT MSVC)
 	# Disable some warnings
-	add_definitions(-O2)
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 	add_definitions(-Wno-multichar)
 	add_definitions(-fno-strict-aliasing)
 	add_definitions(-ffast-math)


### PR DESCRIPTION
Don't know if we can just remove this line, on linux -O3 is set for Release build. But perhaps it's a problem with another compiler, that's why it was put here. At least don't optimize in DEBUG build...
