### PR TITLE
Avoid some memory writes on jr in jit

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -85,6 +85,12 @@ namespace MIPSAnalyst
 		}
 	}
 
+	bool IsSyscall(u32 op)
+	{
+		// Syscalls look like this: 0000 00-- ---- ---- ---- --00 1100
+		return (op >> 26) == 0 && (op & 0x3f) == 12;
+	}
+
 	void Analyze(u32 address)
 	{
 		//set everything to -1 (FF)

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -57,6 +57,7 @@ namespace MIPSAnalyst
 	int GetOutReg(u32 op);
 	bool ReadsFromReg(u32 op, u32 reg);
 	bool IsDelaySlotNice(u32 branch, u32 delayslot);
+	bool IsSyscall(u32 op);
 
 
 }	// namespace MIPSAnalyst


### PR DESCRIPTION
Should improve tight mips function-calling loops a bit.  Probably could apply to arm the same way.

Also, I couldn't divine a clean way to check for the syscall op from the tables (I didn't think it was worth a dedicated info flag, there aren't many left...), so I just checked the encoding directly (pretty sure it's right.)  If there's a better way, I can change it to that.

-[Unknown]
