### PR TITLE
Fix high pitch noise and looping issues in games

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -74,11 +74,11 @@ struct PsmfData {
 
 struct PsmfPlayerData {
 	int videoCodec;
-    int videoStreamNum;
-    int audioCodec;
-    int audioStreamNum;
-    int playMode;
-    int playSpeed;
+	int videoStreamNum;
+	int audioCodec;
+	int audioStreamNum;
+	int playMode;
+	int playSpeed;
 };
 
 struct PsmfEntry {
@@ -144,11 +144,11 @@ public:
 	void DoState(PointerWrap &p);
 
 	int videoCodec;
-    int videoStreamNum;
-    int audioCodec;
-    int audioStreamNum;
-    int playMode;
-    int playSpeed;
+	int videoStreamNum;
+	int audioCodec;
+	int audioStreamNum;
+	int playMode;
+	int playSpeed;
 
 	int displayBuffer;
 	int displayBufferSize;
@@ -683,16 +683,17 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 psmfPlayerDataAddr)
 	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerCreate(%08x, %08x)", psmfPlayer, psmfPlayerDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
-		psmfplayer = new PsmfPlayer(psmfPlayerDataAddr);
-		psmfPlayerMap[psmfPlayer] = psmfplayer;
+		ERROR_LOG(HLE, "scePsmfPlayerCreate - invalid psmf");
+		return ERROR_PSMF_NOT_FOUND;
 	}
+	
 	if (Memory::IsValidAddress(psmfPlayerDataAddr)) {
 		psmfplayer->displayBuffer = Memory::Read_U32(psmfPlayerDataAddr);          
 		psmfplayer->displayBufferSize = Memory::Read_U32(psmfPlayerDataAddr + 4);     
 		psmfplayer->playbackThreadPriority = Memory::Read_U32(psmfPlayerDataAddr + 8);
 	}
 
-    psmfplayer->psmfMaxAheadTimestamp = getMaxAheadTimestamp(581);
+    	psmfplayer->psmfMaxAheadTimestamp = getMaxAheadTimestamp(581);
 	psmfPlayerStatus = PSMF_PLAYER_STATUS_INIT;
 	return 0;
 }
@@ -751,9 +752,9 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 	Memory::WriteStruct(psmfPlayer, &data);
 
 	psmfplayer->psmfPlayerAtracAu.dts = initPts;
-    psmfplayer->psmfPlayerAtracAu.pts = initPts;
-    psmfplayer->psmfPlayerAvcAu.dts = initPts;
-    psmfplayer->psmfPlayerAvcAu.pts = initPts;
+	psmfplayer->psmfPlayerAtracAu.pts = initPts;
+	psmfplayer->psmfPlayerAvcAu.dts = initPts;
+	psmfplayer->psmfPlayerAvcAu.pts = initPts;
 
 	//TODO : analyzePSMFLastTimestamp
 	psmfPlayerStatus = PSMF_PLAYER_STATUS_PLAYING;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -134,7 +134,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop)
 	v.type = VOICETYPE_VAG;
 	v.vagAddr = vagAddr;
 	v.vagSize = size;
-	v.loop = loop ? true : false;
+	v.loop = loop ? false : true;
 	v.ChangedParams(true);
 	return 0;
 }
@@ -162,7 +162,7 @@ u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loop)
 	v.type = VOICETYPE_PCM;
 	v.pcmAddr = pcmAddr;
 	v.pcmSize = size;
-	v.loop = loop ? true : false;
+	v.loop = loop ? false : true;
 	v.playing = true;
 	v.ChangedParams(true);
 	return 0;


### PR DESCRIPTION
Tested with following games at least 
1. FF type- 0 , alarm start looping correcrly and also get rid of high pitch noise
2. MotoGP , get rid of high pitch noise in-game
3. Ys vs Sora , repeated voice 

v.loop = loop ? false : true; (0 is true and 1 is false) ( i understand it may not be the correct approach )

Meanwhile , fix black intro for Naruto Shippuden Kizuna Drive
