### PR TITLE
Nice delay slots, ahoy

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -93,6 +93,7 @@ namespace MIPSAnalyst
 			"addi", "addiu", "slti", "sltiu", "andi", "ori", "xori", "lui",
 			"lb", "lh", "lwl", "lw", "lbu", "lhu", "lwr",
 			"sb", "sh", "swl", "sw", "swr",
+			"sll", "srl", "sra", "sllv", "srlv", "srav",
 			"add", "addu", "sub", "subu", "and", "or", "xor", "nor",
 			"slt", "sltu",
 		};
@@ -133,6 +134,13 @@ namespace MIPSAnalyst
 		if (op == 0)
 			return true;
 
+		// TODO: Once the flags are all correct on the tables, remove this safety.
+		if (IsDelaySlotInfoSafe(op))
+		{
+			// TODO: There may be IS_VFPU cases which are safe...
+			return (MIPSGetInfo(op) & IS_VFPU) == 0;
+		}
+
 		return false;
 	}
 
@@ -141,6 +149,10 @@ namespace MIPSAnalyst
 		// NOOPs are always nice.
 		if (op == 0)
 			return true;
+
+		// TODO: Once the flags are all correct on the tables, remove this safety.
+		if (IsDelaySlotInfoSafe(op))
+			return (MIPSGetInfo(op) & OUT_FPUFLAG) == 0;
 
 		return false;
 	}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -61,6 +61,7 @@ namespace MIPSAnalyst
 		return false; //TODO: there are more cases!
 	}
 
+	// TODO: Remove me?
 	bool IsDelaySlotNice(u32 branch, u32 delayslot)
 	{
 		int outReg = GetOutReg(delayslot);
@@ -83,6 +84,37 @@ namespace MIPSAnalyst
 
 			return true; //nice :)
 		}
+	}
+
+	bool IsDelaySlotNiceReg(u32 branchOp, u32 op, u32 reg1, u32 reg2)
+	{
+		// NOOPs are always nice.
+		if (op == 0)
+			return true;
+
+		// TODO: Something like this?
+		//if (GetOutReg(op) != reg1 && GetOutReg(op) != reg2)
+		//	return true;
+
+		return false;
+	}
+
+	bool IsDelaySlotNiceVFPU(u32 branchOp, u32 op)
+	{
+		// NOOPs are always nice.
+		if (op == 0)
+			return true;
+
+		return false;
+	}
+
+	bool IsDelaySlotNiceFPU(u32 branchOp, u32 op)
+	{
+		// NOOPs are always nice.
+		if (op == 0)
+			return true;
+
+		return false;
 	}
 
 	bool IsSyscall(u32 op)

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -57,7 +57,7 @@ namespace MIPSAnalyst
 	int GetOutReg(u32 op);
 	bool ReadsFromReg(u32 op, u32 reg);
 	bool IsDelaySlotNice(u32 branch, u32 delayslot);
-	bool IsDelaySlotNiceReg(u32 branchOp, u32 op, u32 reg1, u32 reg2 = 0xFF);
+	bool IsDelaySlotNiceReg(u32 branchOp, u32 op, int reg1, int reg2 = 0);
 	bool IsDelaySlotNiceVFPU(u32 branchOp, u32 op);
 	bool IsDelaySlotNiceFPU(u32 branchOp, u32 op);
 	bool IsSyscall(u32 op);

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -57,6 +57,9 @@ namespace MIPSAnalyst
 	int GetOutReg(u32 op);
 	bool ReadsFromReg(u32 op, u32 reg);
 	bool IsDelaySlotNice(u32 branch, u32 delayslot);
+	bool IsDelaySlotNiceReg(u32 branchOp, u32 op, u32 reg1, u32 reg2 = 0xFF);
+	bool IsDelaySlotNiceVFPU(u32 branchOp, u32 op);
+	bool IsDelaySlotNiceFPU(u32 branchOp, u32 op);
 	bool IsSyscall(u32 op);
 
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -47,6 +47,10 @@ using namespace MIPSAnalyst;
 // #define DO_CONDITIONAL_LOG 1
 #define DO_CONDITIONAL_LOG 0
 
+// We can also disable nice delay slots.
+// #define CONDITIONAL_NICE_DELAYSLOT delaySlotIsNice = false;
+#define CONDITIONAL_NICE_DELAYSLOT ;
+
 #if DO_CONDITIONAL_LOG
 #define CONDITIONAL_LOG BranchLog(op);
 #define CONDITIONAL_LOG_EXIT(addr) BranchLogExit(op, addr, false);
@@ -134,6 +138,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC+4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rt, rs);
+	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -187,6 +192,7 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool andLink, bool likely)
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
+	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -278,6 +284,7 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceFPU(op, delaySlotOp);
+	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -338,6 +345,7 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceVFPU(op, delaySlotOp);
+	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -434,6 +442,7 @@ void Jit::Comp_JumpReg(u32 op)
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
+	CONDITIONAL_NICE_DELAYSLOT;
 
 	if (IsSyscall(delaySlotOp))
 	{

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -133,16 +133,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC+4);
-
-	//Compile the delay slot
-	bool delaySlotIsNice = GetOutReg(delaySlotOp) != rt && GetOutReg(delaySlotOp) != rs;// IsDelaySlotNice(op, delaySlotOp);
-	if (!delaySlotIsNice)
-	{
-		//ERROR_LOG(CPU, "Not nice delay slot in BranchRSRTComp :( %08x", js.compilerPC);
-	}
-	delaySlotIsNice = false;	// Until we have time to fully fix this
-
-	// Cool, we can do the compare afterward.
+	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rt, rs);
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -195,15 +186,7 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool andLink, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
-
-	bool delaySlotIsNice = GetOutReg(delaySlotOp) != rs; //IsDelaySlotNice(op, delaySlotOp);
-	if (!delaySlotIsNice)
-	{
-		//ERROR_LOG(CPU, "Not nice delay slot in BranchRSZeroComp :( %08x", js.compilerPC);
-	}
-	delaySlotIsNice = false;	// Until we have time to fully fix this
-	
-	// Cool, we can do the compare afterward.
+	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -294,15 +277,7 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
-
-	bool delaySlotIsNice = IsDelaySlotNice(op, delaySlotOp);
-	if (!delaySlotIsNice)
-	{
-		//ERROR_LOG(CPU, "Not nice delay slot in BranchFPFlag :(");
-	}
-
-	delaySlotIsNice = false;	// Until we have time to fully fix this
-
+	bool delaySlotIsNice = IsDelaySlotNiceFPU(op, delaySlotOp);
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -362,15 +337,7 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
-
-	bool delaySlotIsNice = IsDelaySlotNice(op, delaySlotOp);
-	if (!delaySlotIsNice)
-	{
-		//ERROR_LOG(CPU, "Not nice delay slot in BranchVFPUFlag :(");
-	}
-
-	delaySlotIsNice = false;	// Until we have time to fully fix this
-
+	bool delaySlotIsNice = IsDelaySlotNiceVFPU(op, delaySlotOp);
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
@@ -466,9 +433,7 @@ void Jit::Comp_JumpReg(u32 op)
 	int rs = _RS;
 
 	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
-	bool delaySlotIsNice = GetOutReg(delaySlotOp) != rs;
-	// Do what with that information?
-	delaySlotIsNice = false;	// Until we have time to fully fix this
+	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 
 	if (IsSyscall(delaySlotOp))
 	{

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -128,7 +128,7 @@ void Jit::ClearCacheAt(u32 em_address)
 	ClearCache();
 }
 
-void Jit::CompileDelaySlot(bool saveFlags)
+void Jit::CompileDelaySlot(int flags)
 {
 	const u32 addr = js.compilerPC + 4;
 
@@ -136,7 +136,7 @@ void Jit::CompileDelaySlot(bool saveFlags)
 	// Need to offset the downcount which was already incremented for the branch + delay slot.
 	CheckJitBreakpoint(addr, -2);
 
-	if (saveFlags)
+	if (flags & DELAYSLOT_SAFE)
 		SAVE_FLAGS; // preserve flag around the delay slot!
 
 	js.inDelaySlot = true;
@@ -144,8 +144,9 @@ void Jit::CompileDelaySlot(bool saveFlags)
 	MIPSCompileOp(op);
 	js.inDelaySlot = false;
 
-	FlushAll();
-	if (saveFlags)
+	if (flags & DELAYSLOT_FLUSH)
+		FlushAll();
+	if (flags & DELAYSLOT_SAFE)
 		LOAD_FLAGS; // restore flag!
 }
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -56,6 +56,18 @@ struct JitState
 	JitBlock *curBlock;
 };
 
+enum CompileDelaySlotFlags
+{
+	// Easy, nothing extra.
+	DELAYSLOT_NICE = 0,
+	// Flush registers after delay slot.
+	DELAYSLOT_FLUSH = 1,
+	// Preserve flags.
+	DELAYSLOT_SAFE = 2,
+	// Flush registers after and preserve flags.
+	DELAYSLOT_SAFE_FLUSH = DELAYSLOT_FLUSH | DELAYSLOT_SAFE,
+};
+
 class Jit : public Gen::XCodeBlock
 {
 public:
@@ -71,7 +83,8 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
-	void CompileDelaySlot(bool saveFlags = false);
+	// See CompileDelaySlotFlags for flags.
+	void CompileDelaySlot(int flags);
 	void CompileAt(u32 addr);
 	void Comp_RunBlock(u32 op);
 


### PR DESCRIPTION
This takes a conservative approach to enabling nice delay slots:
- Moved FPU/VFPU/ALU checks to separate functions to be safe.
- Whitelisted common ops (based on profiling) in delay slots with correct info flags.
- Added a define to quickly disable nice delay slots in debugging.
- Should apply well to ARM as well.

There may be a better way to do the op whitelist (than string compare), but since it's only on compile time I think it shouldn't be expensive.  The most common is noop for sure.

Should reduce memory reads/writes, both from no need for pushf/popf/savedPC and from less regcache flushing.

-[Unknown]
