### PR TITLE
ALU jit optimizations

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -142,23 +142,54 @@ namespace MIPSComp
 	}
 
 	//rd = rs X rt
-	void Jit::CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &))
+	void Jit::CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &), u32 (*doImm)(const u32, const u32))
 	{
 		int rt = _RT;
 		int rs = _RS;
 		int rd = _RD;
 
-		gpr.FlushLockX(EDX);
+		// Yes, this happens.  Let's make it fast.
+		if (doImm && gpr.IsImmediate(rs) && gpr.IsImmediate(rt))
+		{
+			gpr.SetImmediate32(rd, doImm(gpr.GetImmediate32(rs), gpr.GetImmediate32(rt)));
+			return;
+		}
+
 		gpr.Lock(rt, rs, rd);
-		MOV(32, R(EAX), gpr.R(rs));
-		MOV(32, R(EDX), gpr.R(rt));
-		gpr.BindToRegister(rd, true, true);
-		(this->*arith)(32, R(EAX), R(EDX));
-		MOV(32, gpr.R(rd), R(EAX));
+		// Use EAX as a temporary if we'd overwrite it.
+		if (rd == rt)
+			MOV(32, R(EAX), gpr.R(rt));
+		gpr.BindToRegister(rd, rs == rd, true);
+		if (rs != rd)
+			MOV(32, gpr.R(rd), gpr.R(rs));
+		(this->*arith)(32, gpr.R(rd), rd == rt ? R(EAX) : gpr.R(rt));
 		gpr.UnlockAll();
-		gpr.UnlockAllX();
 	}
 
+	static u32 RType3_ImmAdd(const u32 a, const u32 b)
+	{
+		return a + b;
+	}
+
+	static u32 RType3_ImmSub(const u32 a, const u32 b)
+	{
+		return a - b;
+	}
+
+	static u32 RType3_ImmAnd(const u32 a, const u32 b)
+	{
+		return a & b;
+	}
+
+	static u32 RType3_ImmOr(const u32 a, const u32 b)
+	{
+		return a | b;
+	}
+
+	static u32 RType3_ImmXor(const u32 a, const u32 b)
+	{
+		return a ^ b;
+	}
 
 	void Jit::Comp_RType3(u32 op)
 	{
@@ -168,6 +199,10 @@ namespace MIPSComp
 		int rs = _RS;
 		int rd = _RD;
 
+		// noop, won't write to ZERO.
+		if (rd == 0)
+			return;
+
 		switch (op & 63)
 		{
 		//case 10: if (!R(rt)) R(rd) = R(rs); break; //movz
@@ -175,25 +210,28 @@ namespace MIPSComp
 
 		// case 32: //R(rd) = R(rs) + R(rt);		break; //add
 		case 33: //R(rd) = R(rs) + R(rt);		break; //addu
-			CompTriArith(op, &XEmitter::ADD);
+			CompTriArith(op, &XEmitter::ADD, &RType3_ImmAdd);
 			break;
 		case 34: //R(rd) = R(rs) - R(rt);		break; //sub
 		case 35:
-			CompTriArith(op, &XEmitter::SUB);
+			CompTriArith(op, &XEmitter::SUB, &RType3_ImmSub);
 			break;
 		case 36: //R(rd) = R(rs) & R(rt);		break; //and
-			CompTriArith(op, &XEmitter::AND);
+			CompTriArith(op, &XEmitter::AND, &RType3_ImmAnd);
 			break;
 		case 37: //R(rd) = R(rs) | R(rt);		break; //or
-			CompTriArith(op, &XEmitter::OR);
+			CompTriArith(op, &XEmitter::OR, &RType3_ImmOr);
 			break;
 		case 38: //R(rd) = R(rs) ^ R(rt);		break; //xor
-			CompTriArith(op, &XEmitter::XOR);
+			CompTriArith(op, &XEmitter::XOR, &RType3_ImmXor);
 			break;
 
 		case 39: // R(rd) = ~(R(rs) | R(rt)); //nor
-			CompTriArith(op, &XEmitter::OR);
-			NOT(32, gpr.R(rd));
+			CompTriArith(op, &XEmitter::OR, &RType3_ImmOr);
+			if (gpr.IsImmediate(rd))
+				gpr.SetImmediate32(rd, ~gpr.GetImmediate32(rd));
+			else
+				NOT(32, gpr.R(rd));
 			break;
 
 		case 42: //R(rd) = (int)R(rs) < (int)R(rt); break; //slt

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -121,7 +121,7 @@ private:
 
 	// Utilities to reduce duplicated code
 	void CompImmLogic(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &));
-	void CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &));
+	void CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &), u32 (*doImm)(const u32, const u32));
 	void CompShiftImm(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
 	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
 	void CompITypeMemRead(u32 op, u32 bits, void (XEmitter::*mov)(int, int, X64Reg, OpArg), void *safeFunc);

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -220,6 +220,23 @@ void GPRRegCache::SetImmediate32(int preg, u32 immValue)
 	regs[preg].location = Imm32(immValue);
 }
 
+bool GPRRegCache::IsImmediate(int preg) const
+{
+	// Always say yes for ZERO, even if it's in a temp reg.
+	if (preg == 0)
+		return true;
+	return regs[preg].location.IsImm();
+}
+
+u32 GPRRegCache::GetImmediate32(int preg) const
+{
+	_dbg_assert_msg_(JIT, IsImmediate(preg), "Reg %d must be an immediate.", preg);
+	// Always 0 for ZERO.
+	if (preg == 0)
+		return 0;
+	return regs[preg].location.GetImmValue();
+}
+
 void GPRRegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats)
 {
 	RegCache::Start(mips, stats);

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -136,6 +136,8 @@ public:
 	OpArg GetDefaultLocation(int reg) const;
 	const int *GetAllocationOrder(int &count);
 	void SetImmediate32(int preg, u32 immValue);
+	bool IsImmediate(int preg) const;
+	u32 GetImmediate32(int preg) const;
 };
 
 


### PR DESCRIPTION
This just optimizes some of the most common ops in arithmetic.

Specifically:
- It ensures noops are noops (write to $0.)
- Adds a similar immediate interface to the regcache as arm has.  I did this so I could easily make $0 an immediate but also storable for compatibility.
- Optimizes some cases where immediates are used with arithmetic (e.g. lui'd values, etc.) - especially or/addu (example: lui a0, 5; or a1, a0, 6; or a2, a0, 7.)
- Avoids flushing if possible in 3-reg math.  Should mean less memory access.

-[Unknown]
