### PR TITLE
Fix a duplicate branch in Loaders.cpp

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -56,7 +56,7 @@ EmuFileType Identify_File(const char *filename)
 			return FILETYPE_PSP_ELF;
 		}
 		else
-			return FILETYPE_PSP_ELF;
+			return FILETYPE_UNKNOWN_ELF;
 	}
 	else if (id == 'PBP\x00')
 	{

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -139,7 +139,7 @@ namespace MIPSDis
 		int o = op>>26;
 		if (o==4 && rs == rt)//beq
 			sprintf(out,"b\t->$%08x",off);
-		else if (o==4 && rs == rt)//beq
+		else if (o==20 && rs == rt)//beql
 			sprintf(out,"bl\t->$%08x",off);
 		else
 			sprintf(out, "%s\t%s, %s, ->$%08x",name,RN(rt),RN(rs),off);


### PR DESCRIPTION
I'm almost certain this should be FILETYPE_UNKNOWN_ELF.

I'm banking on gut instinct here; so if I'm wrong, just tell me.

Oh and also there was a duplicate branch in MIPSDis.
