### PR TITLE
Redundant checks

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -639,7 +639,7 @@ Module *__KernelLoadModule(u8 *fileptr, SceKernelLMOption *options, std::string 
 
 void __KernelStartModule(Module *m, int args, const char *argp, SceKernelSMOption *options)
 {
-	if (m->nm.module_start_func != 0 || m->nm.module_start_func != -1)
+	if (m->nm.module_start_func != 0)
 	{
 		if (m->nm.module_start_func != m->nm.entry_addr)
 			WARN_LOG(LOADER, "Main module has start func (%08x) different from entry (%08x)?", m->nm.module_start_func, m->nm.entry_addr);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -946,10 +946,6 @@ void PostPutAction::run(MipsCall &call) {
 u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 {
 	DEBUG_LOG(HLE, "sceMpegRingbufferPut(%08x, %i, %i)", ringbufferAddr, numPackets, available);
-	if (numPackets < 0) {
-		ERROR_LOG(HLE, "sub-zero number of packets put");
-		return 0;
-	}
 
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringbufferAddr, &ringbuffer);


### PR DESCRIPTION
module_start_func is unsigned, it can't be -1.

Same with numPackets
