### PR TITLE
Jit memory access cleanup + VFPU

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -184,10 +184,12 @@ namespace MIPSComp
 		// Optimize out + 0 and | 0.
 		if ((doImm == &RType3_ImmAdd || doImm == &RType3_ImmOr) && (rs == 0 || rt == 0))
 		{
-			gpr.BindToRegister(rd, rd == rs || rd == rt, true);
 			int rsource = rt == 0 ? rs : rt;
 			if (rsource != rd)
+			{
+				gpr.BindToRegister(rd, false, true);
 				MOV(32, gpr.R(rd), gpr.R(rsource));
+			}
 		}
 		else
 		{

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -96,222 +96,46 @@ void Jit::Comp_FPULS(u32 op)
 	switch(op >> 26)
 	{
 	case 49: //FI(ft) = Memory::Read_U32(addr); break; //lwc1
-		gpr.Lock(rs);
-		fpr.SpillLock(ft);
-		fpr.BindToRegister(ft, false, true);
-
-		if (gpr.R(rs).IsImm())
 		{
-			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
-			if (data)
+			gpr.Lock(rs);
+			fpr.SpillLock(ft);
+			fpr.BindToRegister(ft, false, true);
+
+			JitSafeMem safe(this, rs, offset);
+			OpArg src;
+			if (safe.PrepareRead(src, (void *) &Memory::Read_U32))
+				MOVSS(fpr.RX(ft), src);
+			if (safe.PrepareSlowRead((void *) &Memory::Read_U32))
 			{
-#ifdef _M_IX86
-				MOVSS(fpr.RX(ft), M(data));
-#else
-				MOVSS(fpr.RX(ft), MDisp(RBX, gpr.R(rs).GetImmValue() + offset));
-#endif
-			}
-			else
-			{
-				MOV(32, R(EAX), Imm32(gpr.R(rs).GetImmValue() + offset));
-				ABI_CallFunctionA(thunks.ProtectFunction((void *) &Memory::Read_U32, 1), R(EAX));
 				MOV(32, M((void *)&ssLoadStoreTemp), R(EAX));
 				MOVSS(fpr.RX(ft), M((void *)&ssLoadStoreTemp));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
 			}
+			safe.WriteFinish();
+
+			gpr.UnlockAll();
+			fpr.ReleaseSpillLocks();
 		}
-		else
-		{
-			// We may not even need to move into EAX as a temporary.
-			X64Reg addr;
-			if (gpr.R(rs).IsSimpleReg())
-			{
-				// TODO: Maybe just add a check if it's away, don't mind copying to EAX instead...
-				gpr.BindToRegister(rs, true, false);
-				addr = gpr.RX(rs);
-			}
-			else
-			{
-				MOV(32, R(EAX), gpr.R(rs));
-				addr = EAX;
-			}
-
-			if (!g_Config.bFastMemory)
-			{
-				// Is it in physical ram?
-				CMP(32, R(addr), Imm32(0x08000000));
-				FixupBranch tooLow = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x0A000000));
-				FixupBranch tooHigh = J_CC(CC_GE);
-
-				const u8* safe = GetCodePtr();
-#ifdef _M_IX86
-				MOVSS(fpr.RX(ft), MDisp(addr, (u32)Memory::base + offset));
-#else
-				MOVSS(fpr.RX(ft), MComplex(RBX, addr, SCALE_1, offset));
-#endif
-
-				FixupBranch skip = J();
-				SetJumpTarget(tooLow);
-				SetJumpTarget(tooHigh);
-
-				// Might also be the scratchpad.
-				CMP(32, R(addr), Imm32(0x00010000));
-				FixupBranch tooLow2 = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x00014000));
-				J_CC(CC_L, safe);
-				SetJumpTarget(tooLow2);
-
-				LEA(32, EAX, MDisp(addr, offset));
-				ABI_CallFunctionA(thunks.ProtectFunction((void *) &Memory::Read_U32, 1), R(EAX));
-				MOV(32, M((void *)&ssLoadStoreTemp), R(EAX));
-				MOVSS(fpr.RX(ft), M((void *)&ssLoadStoreTemp));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-
-				SetJumpTarget(skip);
-			}
-			else
-			{
-#ifdef _M_IX86
-				// Need to modify it, too bad.
-				if (addr != EAX)
-					MOV(32, R(EAX), gpr.R(rs));
-				AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
-				MOVSS(fpr.RX(ft), MDisp(EAX, (u32)Memory::base + offset));
-#else
-				MOVSS(fpr.RX(ft), MComplex(RBX, addr, SCALE_1, offset));
-#endif
-			}
-		}
-
-		gpr.UnlockAll();
-		fpr.ReleaseSpillLocks();
 		break;
 	case 57: //Memory::Write_U32(FI(ft), addr); break; //swc1
-		gpr.Lock(rs);
-		fpr.SpillLock(ft);
-		fpr.BindToRegister(ft, true, false);
-
-		if (gpr.R(rs).IsImm())
 		{
-			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
-			if (data)
+			gpr.Lock(rs);
+			fpr.SpillLock(ft);
+			fpr.BindToRegister(ft, true, false);
+
+			JitSafeMem safe(this, rs, offset);
+			OpArg dest;
+			if (safe.PrepareWrite(dest))
+				MOVSS(dest, fpr.RX(ft));
+			if (safe.PrepareSlowWrite())
 			{
-#ifdef _M_IX86
-				MOVSS(M(data), fpr.RX(ft));
-#else
-				MOVSS(MDisp(RBX, gpr.R(rs).GetImmValue() + offset), fpr.RX(ft));
-#endif
-			}
-			else
-			{
-				MOV(32, R(EAX), Imm32(gpr.R(rs).GetImmValue() + offset));
 				MOVSS(M((void *)&ssLoadStoreTemp), fpr.RX(ft));
-				ABI_CallFunctionAA(thunks.ProtectFunction((void *) &Memory::Write_U32, 2), M((void *)&ssLoadStoreTemp), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
+				safe.DoSlowWrite((void *) &Memory::Write_U32, M((void *)&ssLoadStoreTemp));
 			}
+			safe.WriteFinish();
+
+			gpr.UnlockAll();
+			fpr.ReleaseSpillLocks();
 		}
-		else
-		{
-			// We may not even need to move into EAX as a temporary.
-			X64Reg addr;
-			if (gpr.R(rs).IsSimpleReg())
-			{
-				// TODO: Maybe just add a check if it's away, don't mind copying to EAX instead...
-				gpr.BindToRegister(rs, true, false);
-				addr = gpr.RX(rs);
-			}
-			else
-			{
-				MOV(32, R(EAX), gpr.R(rs));
-				addr = EAX;
-			}
-
-			if (!g_Config.bFastMemory)
-			{
-				// Is it in physical ram?
-				CMP(32, R(addr), Imm32(0x08000000));
-				FixupBranch tooLow = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x0A000000));
-				FixupBranch tooHigh = J_CC(CC_GE);
-
-				const u8* safe = GetCodePtr();
-#ifdef _M_IX86
-				MOVSS(MDisp(addr, (u32)Memory::base + offset), fpr.RX(ft));
-#else
-				MOVSS(MComplex(RBX, addr, SCALE_1, offset), fpr.RX(ft));
-#endif
-
-				FixupBranch skip = J();
-				SetJumpTarget(tooLow);
-				SetJumpTarget(tooHigh);
-
-				// Might also be the scratchpad.
-				CMP(32, R(addr), Imm32(0x00010000));
-				FixupBranch tooLow2 = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x00014000));
-				J_CC(CC_L, safe);
-				SetJumpTarget(tooLow2);
-
-				LEA(32, EAX, MDisp(addr, offset));
-				MOVSS(M((void *)&ssLoadStoreTemp), fpr.RX(ft));
-				ABI_CallFunctionAA(thunks.ProtectFunction((void *) &Memory::Write_U32, 2), M((void *)&ssLoadStoreTemp), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-
-				SetJumpTarget(skip);
-			}
-			else
-			{
-#ifdef _M_IX86
-				// Need to modify it, too bad.
-				if (addr != EAX)
-					MOV(32, R(EAX), gpr.R(rs));
-				AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
-				MOVSS(MDisp(EAX, (u32)Memory::base + offset), fpr.RX(ft));
-#else
-				MOVSS(MComplex(RBX, addr, SCALE_1, offset), fpr.RX(ft));
-#endif
-			}
-		}
-
-		gpr.UnlockAll();
-		fpr.ReleaseSpillLocks();
 		break;
 
 	default:

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -164,6 +164,16 @@ void Jit::Comp_FPULS(u32 op)
 				MOV(32, M((void *)&ssLoadStoreTemp), R(EAX));
 				MOVSS(fpr.RX(ft), M((void *)&ssLoadStoreTemp));
 
+				// Should we check the core state?
+				if (!g_Config.bIgnoreBadMemAccess)
+				{
+					CMP(32, M((void*)&coreState), Imm32(0));
+					FixupBranch skip2 = J_CC(CC_E);
+					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
+					WriteSyscallExit();
+					SetJumpTarget(skip2);
+				}
+
 				SetJumpTarget(skip);
 			}
 			else
@@ -245,6 +255,16 @@ void Jit::Comp_FPULS(u32 op)
 				LEA(32, EAX, MDisp(addr, offset));
 				MOVSS(M((void *)&ssLoadStoreTemp), fpr.RX(ft));
 				ABI_CallFunctionAA(thunks.ProtectFunction((void *) &Memory::Write_U32, 2), M((void *)&ssLoadStoreTemp), R(EAX));
+
+				// Should we check the core state?
+				if (!g_Config.bIgnoreBadMemAccess)
+				{
+					CMP(32, M((void*)&coreState), Imm32(0));
+					FixupBranch skip2 = J_CC(CC_E);
+					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
+					WriteSyscallExit();
+					SetJumpTarget(skip2);
+				}
 
 				SetJumpTarget(skip);
 			}

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -110,7 +110,7 @@ void Jit::Comp_FPULS(u32 op)
 				MOV(32, M((void *)&ssLoadStoreTemp), R(EAX));
 				MOVSS(fpr.RX(ft), M((void *)&ssLoadStoreTemp));
 			}
-			safe.WriteFinish();
+			safe.Finish();
 
 			gpr.UnlockAll();
 			fpr.ReleaseSpillLocks();
@@ -131,7 +131,7 @@ void Jit::Comp_FPULS(u32 op)
 				MOVSS(M((void *)&ssLoadStoreTemp), fpr.RX(ft));
 				safe.DoSlowWrite((void *) &Memory::Write_U32, M((void *)&ssLoadStoreTemp));
 			}
-			safe.WriteFinish();
+			safe.Finish();
 
 			gpr.UnlockAll();
 			fpr.ReleaseSpillLocks();

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -103,7 +103,7 @@ void Jit::Comp_FPULS(u32 op)
 
 			JitSafeMem safe(this, rs, offset);
 			OpArg src;
-			if (safe.PrepareRead(src, (void *) &Memory::Read_U32))
+			if (safe.PrepareRead(src))
 				MOVSS(fpr.RX(ft), src);
 			if (safe.PrepareSlowRead((void *) &Memory::Read_U32))
 			{

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -112,6 +112,16 @@ namespace MIPSComp
 				ABI_CallFunctionA(thunks.ProtectFunction(safeFunc, 1), R(EAX));
 				(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
 
+				// Should we check the core state?
+				if (!g_Config.bIgnoreBadMemAccess)
+				{
+					CMP(32, M((void*)&coreState), Imm32(0));
+					FixupBranch skip2 = J_CC(CC_E);
+					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
+					WriteSyscallExit();
+					SetJumpTarget(skip2);
+				}
+
 				SetJumpTarget(skip);
 			}
 			else
@@ -217,6 +227,16 @@ namespace MIPSComp
 
 				LEA(32, EAX, MDisp(addr, offset));
 				ABI_CallFunctionAA(thunks.ProtectFunction(safeFunc, 2), gpr.R(rt), R(EAX));
+
+				// Should we check the core state?
+				if (!g_Config.bIgnoreBadMemAccess)
+				{
+					CMP(32, M((void*)&coreState), Imm32(0));
+					FixupBranch skip2 = J_CC(CC_E);
+					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
+					WriteSyscallExit();
+					SetJumpTarget(skip2);
+				}
 
 				SetJumpTarget(skip);
 			}

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -51,106 +51,13 @@ namespace MIPSComp
 		gpr.Lock(rt, rs);
 		gpr.BindToRegister(rt, rt == rs, true);
 
-		if (gpr.R(rs).IsImm())
-		{
-			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
-			if (data)
-			{
-#ifdef _M_IX86
-				(this->*mov)(32, bits, gpr.RX(rt), M(data));
-#else
-				(this->*mov)(32, bits, gpr.RX(rt), MDisp(RBX, gpr.R(rs).GetImmValue() + offset));
-#endif
-			}
-			else
-			{
-				MOV(32, R(EAX), Imm32(gpr.R(rs).GetImmValue() + offset));
-				ABI_CallFunctionA(thunks.ProtectFunction(safeFunc, 1), R(EAX));
-				(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-			}
-		}
-		else
-		{
-			// We may not even need to move into EAX as a temporary.
-			X64Reg addr;
-			if (gpr.R(rs).IsSimpleReg())
-			{
-				// TODO: Maybe just add a check if it's away, don't mind copying to EAX instead...
-				if (rs != rt)
-					gpr.BindToRegister(rs, true, false);
-				addr = gpr.RX(rs);
-			}
-			else
-			{
-				MOV(32, R(EAX), gpr.R(rs));
-				addr = EAX;
-			}
-
-			if (!g_Config.bFastMemory)
-			{
-				// Is it in physical ram?
-				CMP(32, R(addr), Imm32(0x08000000));
-				FixupBranch tooLow = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x0A000000));
-				FixupBranch tooHigh = J_CC(CC_GE);
-
-				const u8* safe = GetCodePtr();
-#ifdef _M_IX86
-				(this->*mov)(32, bits, gpr.RX(rt), MDisp(addr, (u32)Memory::base + offset));
-#else
-				(this->*mov)(32, bits, gpr.RX(rt), MComplex(RBX, addr, SCALE_1, offset));
-#endif
-
-				FixupBranch skip = J();
-				SetJumpTarget(tooLow);
-				SetJumpTarget(tooHigh);
-
-				// Might also be the scratchpad.
-				CMP(32, R(addr), Imm32(0x00010000));
-				FixupBranch tooLow2 = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x00014000));
-				J_CC(CC_L, safe);
-				SetJumpTarget(tooLow2);
-
-				LEA(32, EAX, MDisp(addr, offset));
-				ABI_CallFunctionA(thunks.ProtectFunction(safeFunc, 1), R(EAX));
-				(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-
-				SetJumpTarget(skip);
-			}
-			else
-			{
-#ifdef _M_IX86
-				// Need to modify it, too bad.
-				if (addr != EAX)
-					MOV(32, R(EAX), gpr.R(rs));
-				AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
-				(this->*mov)(32, bits, gpr.RX(rt), MDisp(EAX, (u32)Memory::base + offset));
-#else
-				(this->*mov)(32, bits, gpr.RX(rt), MComplex(RBX, addr, SCALE_1, offset));
-#endif
-			}
-		}
+		JitSafeMem safe(this, rs, offset);
+		OpArg src;
+		if (safe.PrepareRead(src, safeFunc))
+			(this->*mov)(32, bits, gpr.RX(rt), src);
+		if (safe.PrepareSlowRead(safeFunc))
+			(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
+		safe.WriteFinish();
 
 		gpr.UnlockAll();
 	}
@@ -170,129 +77,28 @@ namespace MIPSComp
 		const bool needSwap = bits == 8 && !gpr.R(rt).IsSimpleReg(EDX) && !gpr.R(rt).IsSimpleReg(ECX);
 		if (needSwap)
 			gpr.FlushLockX(EDX);
+#else
+		const bool needSwap = false;
 #endif
 
-		if (gpr.R(rs).IsImm())
+		JitSafeMem safe(this, rs, offset);
+		OpArg dest;
+		if (safe.PrepareWrite(dest))
 		{
-			void *data = Memory::GetPointer(gpr.R(rs).GetImmValue() + offset);
-			if (data)
+			if (needSwap)
 			{
-#ifdef _M_IX86
-				if (needSwap)
-				{
-					MOV(32, R(EDX), gpr.R(rt));
-					MOV(bits, M(data), R(EDX));
-				}
-				else
-					MOV(bits, M(data), gpr.R(rt));
-#else
-				MOV(bits, MDisp(RBX, gpr.R(rs).GetImmValue() + offset), gpr.R(rt));
-#endif
+				MOV(32, R(EDX), gpr.R(rt));
+				MOV(bits, dest, R(EDX));
 			}
 			else
-			{
-				MOV(32, R(EAX), Imm32(gpr.R(rs).GetImmValue() + offset));
-				ABI_CallFunctionAA(thunks.ProtectFunction(safeFunc, 2), gpr.R(rt), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-			}
+				MOV(bits, dest, gpr.R(rt));
 		}
-		else
-		{
-			// We may not even need to move into EAX as a temporary.
-			X64Reg addr;
-			if (gpr.R(rs).IsSimpleReg())
-			{
-				// TODO: Maybe just add a check if it's away, don't mind copying to EAX instead...
-				if (rs != rt)
-					gpr.BindToRegister(rs, true, false);
-				addr = gpr.RX(rs);
-			}
-			else
-			{
-				MOV(32, R(EAX), gpr.R(rs));
-				addr = EAX;
-			}
+		if (safe.PrepareSlowWrite())
+			safe.DoSlowWrite(safeFunc, gpr.R(rt));
+		safe.WriteFinish();
 
-			if (!g_Config.bFastMemory)
-			{
-				// Is it in physical ram?
-				CMP(32, R(addr), Imm32(0x08000000));
-				FixupBranch tooLow = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x0A000000));
-				FixupBranch tooHigh = J_CC(CC_GE);
-
-				const u8* safe = GetCodePtr();
-#ifdef _M_IX86
-				if (needSwap)
-				{
-					MOV(32, R(EDX), gpr.R(rt));
-					MOV(bits, MDisp(addr, (u32)Memory::base + offset), R(EDX));
-				}
-				else
-					MOV(bits, MDisp(addr, (u32)Memory::base + offset), gpr.R(rt));
-#else
-				MOV(bits, MComplex(RBX, addr, SCALE_1, offset), gpr.R(rt));
-#endif
-
-				FixupBranch skip = J();
-				SetJumpTarget(tooLow);
-				SetJumpTarget(tooHigh);
-
-				// Might also be the scratchpad.
-				CMP(32, R(addr), Imm32(0x00010000));
-				FixupBranch tooLow2 = J_CC(CC_L);
-				CMP(32, R(addr), Imm32(0x00014000));
-				J_CC(CC_L, safe);
-				SetJumpTarget(tooLow2);
-
-				LEA(32, EAX, MDisp(addr, offset));
-				ABI_CallFunctionAA(thunks.ProtectFunction(safeFunc, 2), gpr.R(rt), R(EAX));
-
-				// Should we check the core state?
-				if (!g_Config.bIgnoreBadMemAccess)
-				{
-					CMP(32, M((void*)&coreState), Imm32(0));
-					FixupBranch skip2 = J_CC(CC_E);
-					MOV(32, M(&currentMIPS->pc), Imm32(js.compilerPC + 4));
-					WriteSyscallExit();
-					SetJumpTarget(skip2);
-				}
-
-				SetJumpTarget(skip);
-			}
-			else
-			{
-#ifdef _M_IX86
-				// Need to modify it, too bad.
-				if (addr != EAX)
-					MOV(32, R(EAX), gpr.R(rs));
-				AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
-				if (needSwap)
-				{
-					MOV(32, R(EDX), gpr.R(rt));
-					MOV(bits, MDisp(EAX, (u32)Memory::base + offset), R(EDX));
-				}
-				else
-					MOV(bits, MDisp(EAX, (u32)Memory::base + offset), gpr.R(rt));
-#else
-				MOV(bits, MComplex(RBX, addr, SCALE_1, offset), gpr.R(rt));
-#endif
-			}
-		}
-
-#ifdef _M_IX86
 		if (needSwap)
 			gpr.UnlockAllX();
-#endif
 		gpr.UnlockAll();
 	}
 

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -53,7 +53,7 @@ namespace MIPSComp
 
 		JitSafeMem safe(this, rs, offset);
 		OpArg src;
-		if (safe.PrepareRead(src, safeFunc))
+		if (safe.PrepareRead(src))
 			(this->*mov)(32, bits, gpr.RX(rt), src);
 		if (safe.PrepareSlowRead(safeFunc))
 			(this->*mov)(32, bits, gpr.RX(rt), R(EAX));

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -57,7 +57,7 @@ namespace MIPSComp
 			(this->*mov)(32, bits, gpr.RX(rt), src);
 		if (safe.PrepareSlowRead(safeFunc))
 			(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
-		safe.WriteFinish();
+		safe.Finish();
 
 		gpr.UnlockAll();
 	}
@@ -95,7 +95,7 @@ namespace MIPSComp
 		}
 		if (safe.PrepareSlowWrite())
 			safe.DoSlowWrite(safeFunc, gpr.R(rt));
-		safe.WriteFinish();
+		safe.Finish();
 
 		if (needSwap)
 			gpr.UnlockAllX();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -477,7 +477,7 @@ bool Jit::JitSafeMem::PrepareSlowRead(void *safeFunc)
 		return false;
 }
 
-void Jit::JitSafeMem::WriteFinish()
+void Jit::JitSafeMem::Finish()
 {
 	if (needsCheck_)
 	{

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -197,7 +197,7 @@ private:
 		void DoSlowWrite(void *safeFunc, const OpArg src);
 
 		// Emit code necessary for a memory read, returns true if MOV from src is needed.
-		bool PrepareRead(OpArg &src, void *safeFunc);
+		bool PrepareRead(OpArg &src);
 		// Emit code for a slow read call, and returns true if result is in EAX.
 		bool PrepareSlowRead(void *safeFunc);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -183,6 +183,41 @@ private:
 	ThunkManager thunks;
 
 	MIPSState *mips_;
+
+	class JitSafeMem
+	{
+	public:
+		JitSafeMem(Jit *jit, int raddr, s32 offset);
+
+		// Emit code necessary for a memory write, returns true if MOV to dest is needed.
+		bool PrepareWrite(OpArg &dest);
+		// Emit code proceeding a slow write call, returns true if slow write is needed.
+		bool PrepareSlowWrite();
+		// Emit a slow write from src.
+		void DoSlowWrite(void *safeFunc, const OpArg src);
+
+		// Emit code necessary for a memory read, returns true if MOV from src is needed.
+		bool PrepareRead(OpArg &src, void *safeFunc);
+		// Emit code for a slow read call, and returns true if result is in EAX.
+		bool PrepareSlowRead(void *safeFunc);
+
+		// Cleans up final code for the memory access.
+		void WriteFinish();
+
+	private:
+		OpArg PrepareMemoryOpArg();
+		void PrepareSlowAccess();
+
+		Jit *jit_;
+		int raddr_;
+		s32 offset_;
+		bool needsCheck_;
+		bool needsSkip_;
+		X64Reg xaddr_;
+		FixupBranch tooLow_, tooHigh_, skip_;
+		const u8 *safe_;
+	};
+	friend class JitSafeMem;
 };
 
 typedef void (Jit::*MIPSCompileFunc)(u32 opcode);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -194,12 +194,17 @@ private:
 		// Emit code proceeding a slow write call, returns true if slow write is needed.
 		bool PrepareSlowWrite();
 		// Emit a slow write from src.
-		void DoSlowWrite(void *safeFunc, const OpArg src);
+		void DoSlowWrite(void *safeFunc, const OpArg src, int suboffset = 0);
 
 		// Emit code necessary for a memory read, returns true if MOV from src is needed.
 		bool PrepareRead(OpArg &src);
 		// Emit code for a slow read call, and returns true if result is in EAX.
 		bool PrepareSlowRead(void *safeFunc);
+		
+		// WARNING: Only works for non-GPR.  Do not use for reads into GPR.
+		OpArg NextFastAddress(int suboffset);
+		// WARNING: Only works for non-GPR.  Do not use for reads into GPR.
+		void NextSlowRead(void *safeFunc, int suboffset);
 
 		// Cleans up final code for the memory access.
 		void Finish();

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -202,7 +202,7 @@ private:
 		bool PrepareSlowRead(void *safeFunc);
 
 		// Cleans up final code for the memory access.
-		void WriteFinish();
+		void Finish();
 
 	private:
 		OpArg PrepareMemoryOpArg();

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -55,6 +55,8 @@ typedef void (*readFn16)(u16&, const u32);
 typedef void (*readFn32)(u32&, const u32);
 typedef void (*readFn64)(u64&, const u32);
 
+inline u32 PSP_GetScratchpadMemoryBase() { return 0x00010000;}
+inline u32 PSP_GetScratchpadMemoryEnd() { return 0x00014000;}
 
 inline u32 PSP_GetKernelMemoryBase() { return 0x08000000;}
 inline u32 PSP_GetKernelMemoryEnd()  { return 0x08400000;} 

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -83,7 +83,11 @@ inline void ReadFromHardware(T &var, const u32 address)
 	}
 	else
 	{
-		WARN_LOG(MEMMAP, "ReadFromHardware: Invalid address %08x PC %08x LR %08x", address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
+		if (g_Config.iCpuCore == CPU_JIT) {
+			WARN_LOG(MEMMAP, "ReadFromHardware: Invalid address %08x", address);
+		} else {
+			WARN_LOG(MEMMAP, "ReadFromHardware: Invalid address %08x PC %08x LR %08x", address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
+		}
 		if (!g_Config.bIgnoreBadMemAccess) {
 			Core_EnableStepping(true);
 			host->SetDebugMode(true);
@@ -111,7 +115,11 @@ inline void WriteToHardware(u32 address, const T data)
 	}
 	else
 	{
-		WARN_LOG(MEMMAP, "WriteToHardware: Invalid address %08x	PC %08x LR %08x", address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
+		if (g_Config.iCpuCore == CPU_JIT) {
+			WARN_LOG(MEMMAP, "WriteToHardware: Invalid address %08x", address);
+		} else {
+			WARN_LOG(MEMMAP, "WriteToHardware: Invalid address %08x	PC %08x LR %08x", address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
+		}
 		if (!g_Config.bIgnoreBadMemAccess) {
 			Core_EnableStepping(true);
 			host->SetDebugMode(true);


### PR DESCRIPTION
Well, this does three things.

One is properly supporting "ignore invalid memory access" being off in jit (minor performance penalty, only when option is off.)

It also fixes logging on an immediate bad address (although, that should never happen, I don't want to not know if it does...)

The other is, I decided it was time to refactor.  Turned out more complicated and automagical than I was initially planning, though.  Hmm.  It significantly simplifies safe memory implementation, though.

A read now looks like this:

```
        JitSafeMem safe(this, rs, offset);
        OpArg src;
        if (safe.PrepareRead(src, safeFunc))
            (this->*mov)(32, bits, gpr.RX(rt), src);
        if (safe.PrepareSlowRead(safeFunc))
            (this->*mov)(32, bits, gpr.RX(rt), R(EAX));
        safe.WriteFinish();
```

But it emits all sorts of code for you so it's far less to the metal than before (even transparently handling direct immediate address access.)  I'll still need to adjust it for VFPU, but it shouldn't be too bad.

Is there a cleaner way?  Also, should I instead move it outside Jit into a separate file?  Wasn't sure... it's very coupled.

-[Unknown]
