### PR TITLE
Minor performance improvements

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -54,7 +54,7 @@ static std::vector<HLEModule> moduleDB;
 static std::vector<Syscall> unresolvedSyscalls;
 static std::vector<Syscall> exportedCalls;
 static int hleAfterSyscall = HLE_AFTER_NOTHING;
-static char hleAfterSyscallReschedReason[512];
+static const char *hleAfterSyscallReschedReason;
 
 void HLEInit()
 {
@@ -266,15 +266,9 @@ void hleReSchedule(const char *reason)
 	hleAfterSyscall |= HLE_AFTER_RESCHED;
 
 	if (!reason)
-		strcpy(hleAfterSyscallReschedReason, "Invalid reason");
-	// You can't seriously need a reason that long, can you?
-	else if (strlen(reason) >= sizeof(hleAfterSyscallReschedReason))
-	{
-		memcpy(hleAfterSyscallReschedReason, reason, sizeof(hleAfterSyscallReschedReason) - 1);
-		hleAfterSyscallReschedReason[sizeof(hleAfterSyscallReschedReason) - 1] = 0;
-	}
+		hleAfterSyscallReschedReason = "Invalid reason";
 	else
-		strcpy(hleAfterSyscallReschedReason, reason);
+		hleAfterSyscallReschedReason = reason;
 }
 
 void hleReSchedule(bool callbacks, const char *reason)
@@ -334,13 +328,13 @@ inline void hleFinishSyscall(int modulenum, int funcnum)
 		{
 			// We'll do it next syscall.
 			hleAfterSyscall = HLE_AFTER_DEBUG_BREAK;
-			hleAfterSyscallReschedReason[0] = 0;
+			hleAfterSyscallReschedReason = 0;
 			return;
 		}
 	}
 
 	hleAfterSyscall = HLE_AFTER_NOTHING;
-	hleAfterSyscallReschedReason[0] = 0;
+	hleAfterSyscallReschedReason = 0;
 }
 
 inline void updateSyscallStats(int modulenum, int funcnum, double total)

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -116,7 +116,7 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking)
 		if (blocking) {
 			chan.waitingThread = __KernelGetCurThread();
 			// WARNING: This changes currentThread so must grab waitingThread before (line above).
-			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum, 0, 0, false);
+			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum, 0, 0, false, "blocking audio waited");
 			// Fall through to the sample queueing, don't want to lose the samples even though
 			// we're getting full.
 		}

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -408,7 +408,7 @@ void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 	else
 	{
 		waitingThreads.push_back(__KernelGetCurThread());
-		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_POSITIVE, ctrlDataPtr, 0, false);
+		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_POSITIVE, ctrlDataPtr, 0, false, "ctrl buffer waited");
 		DEBUG_LOG(HLE, "sceCtrlReadBufferPositive(%08x, %i) - waiting", ctrlDataPtr, nBufs);
 	}
 }
@@ -424,7 +424,7 @@ void sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 	else
 	{
 		waitingThreads.push_back(__KernelGetCurThread());
-		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_NEGATIVE, ctrlDataPtr, 0, false);
+		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_NEGATIVE, ctrlDataPtr, 0, false, "ctrl buffer waited");
 		DEBUG_LOG(HLE, "sceCtrlReadBufferNegative(%08x, %i) - waiting", ctrlDataPtr, nBufs);
 	}
 }

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -369,7 +369,7 @@ u32 sceDisplayGetFramebuf(u32 topaddrPtr, u32 linesizePtr, u32 pixelFormatPtr, i
 u32 sceDisplayWaitVblankStart() {
 	DEBUG_LOG(HLE,"sceDisplayWaitVblankStart()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false);
+	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank start waited");
 	return 0;
 }
 
@@ -377,7 +377,7 @@ u32 sceDisplayWaitVblank() {
 	if (!isVblank) {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblank()");
 		vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false);
+		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank waited");
 		return 0;
 	} else {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblank() - not waiting since in vBlank");
@@ -388,7 +388,7 @@ u32 sceDisplayWaitVblank() {
 u32 sceDisplayWaitVblankStartMulti() {
 	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartMulti()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false);
+	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank start multi waited");
 	return 0;
 }
 
@@ -396,7 +396,7 @@ u32 sceDisplayWaitVblankCB() {
 	if (!isVblank) {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblankCB()");
 		vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true);
+		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank waited");
 		return 0;
 	} else {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblank() - not waiting since in vBlank");
@@ -407,14 +407,14 @@ u32 sceDisplayWaitVblankCB() {
 u32 sceDisplayWaitVblankStartCB() {
 	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartCB()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true);
+	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank start waited");
 	return 0;
 }
 
 u32 sceDisplayWaitVblankStartMultiCB() {
 	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartMultiCB()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
-	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true);
+	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank start multi waited");
 	return 0;
 }
 

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -417,7 +417,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 			e->waitingThreads.push_back(th);
 
 			__KernelSetEventFlagTimeout(e, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, false);
+			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, false, "event flag waited");
 		}
 
 		return 0;
@@ -470,7 +470,7 @@ int sceKernelWaitEventFlagCB(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 
 			e->waitingThreads.push_back(th);
 
 			__KernelSetEventFlagTimeout(e, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, true);
+			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, true, "event flag waited");
 		}
 		else
 			hleCheckCurrentCallbacks();

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -450,7 +450,7 @@ int sceKernelReceiveMbx(SceUID id, u32 packetAddrPtr, u32 timeoutPtr)
 		__KernelMbxRemoveThread(m, __KernelGetCurThread());
 		m->AddWaitingThread(__KernelGetCurThread(), packetAddrPtr);
 		__KernelWaitMbx(m, timeoutPtr);
-		__KernelWaitCurThread(WAITTYPE_MBX, id, 0, timeoutPtr, false);
+		__KernelWaitCurThread(WAITTYPE_MBX, id, 0, timeoutPtr, false, "mbx waited");
 		return 0;
 	}
 }
@@ -478,7 +478,7 @@ int sceKernelReceiveMbxCB(SceUID id, u32 packetAddrPtr, u32 timeoutPtr)
 		__KernelMbxRemoveThread(m, __KernelGetCurThread());
 		m->AddWaitingThread(__KernelGetCurThread(), packetAddrPtr);
 		__KernelWaitMbx(m, timeoutPtr);
-		__KernelWaitCurThread(WAITTYPE_MBX, id, 0, timeoutPtr, true);
+		__KernelWaitCurThread(WAITTYPE_MBX, id, 0, timeoutPtr, true, "mbx waited");
 		return 0;
 	}
 }

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -976,7 +976,7 @@ int sceKernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr)
 			}
 
 			__KernelSetVplTimeout(timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_VPL, uid, size, timeoutPtr, false);
+			__KernelWaitCurThread(WAITTYPE_VPL, uid, size, timeoutPtr, false, "vpl waited");
 		}
 	}
 	return error;
@@ -1002,7 +1002,7 @@ int sceKernelAllocateVplCB(SceUID uid, u32 size, u32 addrPtr, u32 timeoutPtr)
 			}
 
 			__KernelSetVplTimeout(timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_VPL, uid, size, timeoutPtr, true);
+			__KernelWaitCurThread(WAITTYPE_VPL, uid, size, timeoutPtr, true, "vpl waited");
 		}
 	}
 	return error;

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -289,7 +289,7 @@ void __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode
 			{
 				m->AddSendWaitingThread(__KernelGetCurThread(), curSendAddr, sendSize, waitMode, resultAddr);
 				RETURN(0);
-				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled);
+				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled, "msgpipe waited");
 				return;
 			}
 		}
@@ -321,7 +321,7 @@ void __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode
 			{
 				m->AddSendWaitingThread(__KernelGetCurThread(), curSendAddr, sendSize, waitMode, resultAddr);
 				RETURN(0);
-				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled);
+				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled, "msgpipe waited");
 				return;
 			}
 		}
@@ -461,7 +461,7 @@ void __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int
 			{
 				m->AddReceiveWaitingThread(__KernelGetCurThread(), curReceiveAddr, receiveSize, waitMode, resultAddr);
 				RETURN(0);
-				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled);
+				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled, "msgpipe waited");
 				return;
 			}
 		}
@@ -497,7 +497,7 @@ void __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int
 			{
 				m->AddReceiveWaitingThread(__KernelGetCurThread(), curReceiveAddr, receiveSize, waitMode, resultAddr);
 				RETURN(0);
-				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled);
+				__KernelWaitCurThread(WAITTYPE_MSGPIPE, 0, 0, 0, cbEnabled, "msgpipe waited");
 				return;
 			}
 		}

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -464,7 +464,7 @@ int sceKernelLockMutex(SceUID id, int count, u32 timeoutPtr)
 		if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
 			mutex->waitingThreads.push_back(threadID);
 		__KernelWaitMutex(mutex, timeoutPtr);
-		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, false);
+		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, false, "mutex waited");
 
 		// Return value will be overwritten by wait.
 		return 0;
@@ -492,7 +492,7 @@ int sceKernelLockMutexCB(SceUID id, int count, u32 timeoutPtr)
 		if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
 			mutex->waitingThreads.push_back(threadID);
 		__KernelWaitMutex(mutex, timeoutPtr);
-		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, true);
+		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, true, "mutex waited");
 
 		// Return value will be overwritten by wait.
 		return 0;
@@ -846,7 +846,7 @@ int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 			if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
 				mutex->waitingThreads.push_back(threadID);
 			__KernelWaitLwMutex(mutex, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, false);
+			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, false, "lwmutex waited");
 
 			// Return value will be overwritten by wait.
 			return 0;
@@ -882,7 +882,7 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 			if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
 				mutex->waitingThreads.push_back(threadID);
 			__KernelWaitLwMutex(mutex, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, true);
+			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, true, "lwmutex waited");
 
 			// Return value will be overwritten by wait.
 			return 0;

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -343,7 +343,7 @@ int __KernelWaitSema(SceUID id, int wantedCount, u32 timeoutPtr, const char *bad
 			if (std::find(s->waitingThreads.begin(), s->waitingThreads.end(), threadID) == s->waitingThreads.end())
 				s->waitingThreads.push_back(threadID);
 			__KernelSetSemaTimeout(s, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_SEMA, id, wantedCount, timeoutPtr, processCallbacks);
+			__KernelWaitCurThread(WAITTYPE_SEMA, id, wantedCount, timeoutPtr, processCallbacks, "sema waited");
 		}
 
 		return 0;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -887,48 +887,34 @@ u32 sceKernelGetThreadmanIdList(u32 type, u32 readBufPtr, u32 readBufSize, u32 i
 // Saves the current CPU context
 void __KernelSaveContext(ThreadContext *ctx)
 {
-	for (int i = 0; i < 32; i++)
-	{
-		ctx->r[i] = currentMIPS->r[i];
-		ctx->f[i] = currentMIPS->f[i];
-	}
-	for (int i=0; i<128; i++)
-	{
-		ctx->v[i] = currentMIPS->v[i];
-	}
-	for (int i=0; i<16; i++)
-	{
-		ctx->vfpuCtrl[i] = currentMIPS->vfpuCtrl[i];
-	}
+	memcpy(ctx->r, currentMIPS->r, sizeof(ctx->r));
+	memcpy(ctx->f, currentMIPS->f, sizeof(ctx->f));
+
+	// TODO: Make VFPU saving optional/delayed, only necessary between VFPU-attr-marked threads
+	memcpy(ctx->v, currentMIPS->v, sizeof(ctx->v));
+	memcpy(ctx->vfpuCtrl, currentMIPS->vfpuCtrl, sizeof(ctx->vfpuCtrl));
+
+	ctx->pc = currentMIPS->pc;
 	ctx->hi = currentMIPS->hi;
 	ctx->lo = currentMIPS->lo;
-	ctx->pc = currentMIPS->pc;
 	ctx->fcr0 = currentMIPS->fcr0;
 	ctx->fcr31 = currentMIPS->fcr31;
 	ctx->fpcond = currentMIPS->fpcond;
-
-	// TODO: Make VFPU saving optional/delayed, only necessary between VFPU-attr-marked threads
 }
 
 // Loads a CPU context
 void __KernelLoadContext(ThreadContext *ctx)
 {
-	for (int i=0; i<32; i++)
-	{
-		currentMIPS->r[i] = ctx->r[i];
-		currentMIPS->f[i] = ctx->f[i];
-	}
-	for (int i=0; i<128; i++)
-	{
-		currentMIPS->v[i] = ctx->v[i];
-	}
-	for (int i=0; i<15; i++)
-	{
-		currentMIPS->vfpuCtrl[i] = ctx->vfpuCtrl[i];
-	}
+	memcpy(currentMIPS->r, ctx->r, sizeof(ctx->r));
+	memcpy(currentMIPS->f, ctx->f, sizeof(ctx->f));
+
+	// TODO: Make VFPU saving optional/delayed, only necessary between VFPU-attr-marked threads
+	memcpy(currentMIPS->v, ctx->v, sizeof(ctx->v));
+	memcpy(currentMIPS->vfpuCtrl, ctx->vfpuCtrl, sizeof(ctx->vfpuCtrl));
+
+	currentMIPS->pc = ctx->pc;
 	currentMIPS->hi = ctx->hi;
 	currentMIPS->lo = ctx->lo;
-	currentMIPS->pc = ctx->pc;
 	currentMIPS->fcr0 = ctx->fcr0;
 	currentMIPS->fcr31 = ctx->fcr31;
 	currentMIPS->fpcond = ctx->fpcond;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -129,7 +129,7 @@ u32 __KernelResumeThreadFromWait(SceUID threadID, int retval);
 u32 __KernelGetWaitValue(SceUID threadID, u32 &error);
 u32 __KernelGetWaitTimeoutPtr(SceUID threadID, u32 &error);
 SceUID __KernelGetWaitID(SceUID threadID, WaitType type, u32 &error);
-void __KernelWaitCurThread(WaitType type, SceUID waitId, u32 waitValue, u32 timeoutPtr, bool processCallbacks);
+void __KernelWaitCurThread(WaitType type, SceUID waitId, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason);
 void __KernelReSchedule(const char *reason = "no reason");
 void __KernelReSchedule(bool doCallbacks, const char *reason);
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -93,13 +93,14 @@ struct ThreadContext
 	float v[128];
 	u32 vfpuCtrl[16];
 
+	u32 pc;
+
 	u32 hi;
 	u32 lo;
-	u32 pc;
-	u32 fpcond;
 
 	u32 fcr0;
 	u32 fcr31;
+	u32 fpcond;
 };
 
 // Internal API, used by implementations of kernel functions

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -82,7 +82,6 @@ enum WaitType //probably not the real values
 	WAITTYPE_MUTEX = 13,
 	WAITTYPE_LWMUTEX = 14,
 	WAITTYPE_CTRL = 15,
-	// Remember to update sceKernelThread.cpp's waitTypeStrings to match.
 };
 
 
@@ -121,8 +120,8 @@ void __KernelLoadContext(ThreadContext *ctx);
 // TODO: Replace this with __KernelResumeThreadFromWait over time as it's misguided.
 // It's better that each subsystem keeps track of the list of waiting threads
 // and resumes them manually one by one using __KernelResumeThreadFromWait.
-bool __KernelTriggerWait(WaitType type, int id, bool dontSwitch = false);
-bool __KernelTriggerWait(WaitType type, int id, int retVal, bool dontSwitch);
+bool __KernelTriggerWait(WaitType type, int id, const char *reason, bool dontSwitch = false);
+bool __KernelTriggerWait(WaitType type, int id, int retVal, const char *reason, bool dontSwitch);
 u32 __KernelResumeThreadFromWait(SceUID threadID); // can return an error value
 u32 __KernelResumeThreadFromWait(SceUID threadID, int retval);
 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -249,7 +249,7 @@ int sceUmdWaitDriveStat(u32 stat)
 	DEBUG_LOG(HLE,"0=sceUmdWaitDriveStat(stat = %08x)", stat);
 
 	if ((stat & __KernelUmdGetState()) == 0)
-		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, 0);
+		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, 0, "umd stat waited");
 
 	return 0;
 }
@@ -261,7 +261,7 @@ int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout)
 	if ((stat & __KernelUmdGetState()) == 0)
 	{
 		__UmdWaitStat(timeout);
-		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, 0);
+		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, 0, "umd stat waited");
 	}
 	else
 		hleReSchedule("umd stat waited with timer");
@@ -287,7 +287,7 @@ int sceUmdWaitDriveStatCB(u32 stat, u32 timeout)
 			timeout = 8000;
 
 		__UmdWaitStat(timeout);
-		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, true);
+		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, true, "umd stat waited");
 	}
 	else
 		hleReSchedule("umd stat waited");

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -299,7 +299,7 @@ u32 sceUmdCancelWaitDriveStat()
 {
 	DEBUG_LOG(HLE,"0=sceUmdCancelWaitDriveStat()");
 
-	__KernelTriggerWait(WAITTYPE_UMD, 1, SCE_KERNEL_ERROR_WAIT_CANCEL, true);
+	__KernelTriggerWait(WAITTYPE_UMD, 1, SCE_KERNEL_ERROR_WAIT_CANCEL, "umd stat ready", true);
 	// TODO: We should call UnscheduleEvent() event here?
 	// But it's not often used anyway, and worst-case it will just do nothing unless it waits again.
 	return 0;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -850,7 +850,7 @@ void TransformDrawEngine::Flush() {
 			u32 id = ComputeFastDCID();
 			auto iter = vai_.find(id);
 			VertexArrayInfo *vai;
-			if (vai_.find(id) != vai_.end()) {
+			if (iter != vai_.end()) {
 				// We've seen this before. Could have been a cached draw.
 				vai = iter->second;
 			} else {


### PR DESCRIPTION
Based on profiling 32-bit Windows release.  Probably helps ARM/etc. a tiny bit too but, can never say...
- Gets rid of resched sprintf()'ing. (~0.5%)
- Copies thread context in larger blocks. (~1%)
- Skips a map.find() call. (~0.2%)

Nothing major (and percentages are probably much smaller on arm vs. Comp_Generic), but noticed the resched in the profiler and had a note in my todo about it already.

-[Unknown]
