### PR TITLE
Jit memory access fixes

### DIFF
--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -158,6 +158,7 @@ void Jit::Comp_SVQ(u32 op)
 			fpr.MapRegsV(vregs, V_Quad, MAP_DIRTY | MAP_NOINIT);
 
 			JitSafeMem safe(this, rs, imm);
+			safe.SetFar();
 			OpArg src;
 			if (safe.PrepareRead(src))
 			{
@@ -191,6 +192,7 @@ void Jit::Comp_SVQ(u32 op)
 			fpr.MapRegsV(vregs, V_Quad, 0);
 
 			JitSafeMem safe(this, rs, imm);
+			safe.SetFar();
 			OpArg dest;
 			if (safe.PrepareWrite(dest))
 			{

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -327,7 +327,7 @@ bool Jit::JitSafeMem::PrepareWrite(OpArg &dest)
 		if (Memory::IsValidAddress(iaddr_))
 		{
 #ifdef _M_IX86
-			dest = M(Memory::base + iaddr_);
+			dest = M(Memory::base + (iaddr_ & Memory::MEMVIEW32_MASK));
 #else
 			dest = MDisp(RBX, iaddr_);
 #endif
@@ -349,7 +349,7 @@ bool Jit::JitSafeMem::PrepareRead(OpArg &src)
 		if (Memory::IsValidAddress(iaddr_))
 		{
 #ifdef _M_IX86
-			src = M(Memory::base + iaddr_);
+			src = M(Memory::base + (iaddr_ & Memory::MEMVIEW32_MASK));
 #else
 			src = MDisp(RBX, iaddr_);
 #endif
@@ -370,7 +370,7 @@ OpArg Jit::JitSafeMem::NextFastAddress(int suboffset)
 		u32 addr = jit_->gpr.GetImmediate32(raddr_) + offset_ + suboffset;
 
 #ifdef _M_IX86
-		return M(Memory::base + addr);
+		return M(Memory::base + (addr & Memory::MEMVIEW32_MASK));
 #else
 		return MDisp(RBX, addr);
 #endif

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -221,6 +221,7 @@ private:
 		bool needsCheck_;
 		bool needsSkip_;
 		bool far_;
+		u32 iaddr_;
 		X64Reg xaddr_;
 		FixupBranch tooLow_, tooHigh_, skip_;
 		const u8 *safe_;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -201,13 +201,15 @@ private:
 		// Emit code for a slow read call, and returns true if result is in EAX.
 		bool PrepareSlowRead(void *safeFunc);
 		
+		// Cleans up final code for the memory access.
+		void Finish();
+
+		// Use this before anything else if you're gonna use the below.
+		void SetFar();
 		// WARNING: Only works for non-GPR.  Do not use for reads into GPR.
 		OpArg NextFastAddress(int suboffset);
 		// WARNING: Only works for non-GPR.  Do not use for reads into GPR.
 		void NextSlowRead(void *safeFunc, int suboffset);
-
-		// Cleans up final code for the memory access.
-		void Finish();
 
 	private:
 		OpArg PrepareMemoryOpArg();
@@ -218,6 +220,7 @@ private:
 		s32 offset_;
 		bool needsCheck_;
 		bool needsSkip_;
+		bool far_;
 		X64Reg xaddr_;
 		FixupBranch tooLow_, tooHigh_, skip_;
 		const u8 *safe_;


### PR DESCRIPTION
Okay, I think I probably found the MotoGP bug.

I wasn't applying the memview mask on immediate loads/stores anymore after refactoring (since I made it use `IsValidAddess()` instead of `GetPointer()` to avoid an early console log.)

In the process, I found that sometimes, VFPU load/stores weren't far jumps and needed to be (I guess the games I tested all used immediates only?  I'm not sure how it could very in size...)  Should it just always far jump?  I'm not sure if there's a performance hit.

I also added a safety, not checking `IsImmediate()` on rs each time, but I think it can never become immediate with a load/store, anyway...

-[Unknown]
