### PR TITLE
Fix scePsmfPlayerStart to not corrupt the stack

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -656,8 +656,9 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 psmfPlayerDataAddr)
 	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerCreate(%08x, %08x)", psmfPlayer, psmfPlayerDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
-		ERROR_LOG(HLE, "scePsmfPlayerCreate - invalid psmf");
-		return ERROR_PSMF_NOT_FOUND;
+		// TODO: This is the wrong data.  PsmfPlayer needs a new interface.
+		psmfplayer = new PsmfPlayer(psmfPlayerDataAddr);
+		psmfPlayerMap[psmfPlayer] = psmfplayer;
 	}
 
 	if (Memory::IsValidAddress(psmfPlayerDataAddr)) {
@@ -711,7 +712,7 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
-		PsmfPlayer *psmfplayer = new PsmfPlayer(psmfPlayerData);
+		psmfplayer = new PsmfPlayer(psmfPlayerData);
 		psmfPlayerMap[psmfPlayer] = psmfplayer;
 	}
 
@@ -723,7 +724,7 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 	data.playMode = psmfplayer->playMode;
 	data.playSpeed = psmfplayer->playSpeed;
 	data.psmfPlayerLastTimestamp = psmfplayer->psmfPlayerLastTimestamp;
-	Memory::WriteStruct(psmfPlayer, &data);
+	Memory::WriteStruct(psmfPlayerData, &data);
 
 	psmfplayer->psmfPlayerAtracAu.dts = initPts;
 	psmfplayer->psmfPlayerAtracAu.pts = initPts;


### PR DESCRIPTION
It seems like the psmfPlayer parameter is in fact a pointer to a 4 bytes which tend to contain a pointer to something else.  I haven't figured out how deep the rabbit hole goes, but tests _definitely_ confirm that scePsmfPlayerCreate() does _not_ return an error for a previously unknown psmfPlayer parameter.

I found that `scePsmfPlayerStart()` was corrupting the stack, which is probably why the only way to make scePsmfPlayer "work" was by making sure games didn't call it if possible.

This fixes Shadow of Destiny (although black) and Lunar (which has problems going ingame due to what look like atrac issues.)  I found it corrupting the stack in Mimana, which still works with this change.  I don't have Naruto.

Also tested in (don't have many games which use scePsmfPlayer...):
- PixelJunk Monsters Deluxe
- Final Fantasy 3
- Unchained Blades (with intervention)
- Patchwork Heroes (with intervention)

-[Unknown]
