### PR TITLE
Callback fixes

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2369,7 +2369,6 @@ void __KernelReturnFromMipsCall()
 	g_inCbCount--;
 
 	// yeah! back in the real world, let's keep going. Should we process more callbacks?
-	__KernelCheckThreadCallbacks(cur, !call->reschedAfter);
 	if (!__KernelExecutePendingMipsCalls(call->reschedAfter))
 	{
 		// Sometimes, we want to stay on the thread.
@@ -2440,6 +2439,13 @@ void ActionAfterCallback::run(MipsCall &call) {
 		Callback *cb = kernelObjects.Get<Callback>(cbId, error);
 		if (cb)
 		{
+			Thread *t = kernelObjects.Get<Thread>(cb->nc.threadId, error);
+			if (t)
+			{
+				// Check for other callbacks to run (including ones this callback scheduled.)
+				__KernelCheckThreadCallbacks(t, true);
+			}
+
 			DEBUG_LOG(HLE, "Left callback %i - %s", cbId, cb->nc.name);
 			// Callbacks that don't return 0 are deleted. But should this be done here?
 			if (currentMIPS->r[MIPS_REG_V0] != 0 || cb->forceDelete)


### PR DESCRIPTION
Incomplete, I need to do more and write more tests, which my tests are currently failing/hanging.

However, this fixes a few games (probably more I don't have) and also includes perf fixes / cleanup:
- Moves delete thread logic into a function instead of several places, and uses SceUID instead of ptrs.
- Saves ~1.6% of time by not checking for callbacks on every resched (Win32 release, probably not as good elsewhere.)
- Fixes running multiple callbacks in a row.
- Fixes interrupts stalling the game if they happened during a callback.

I've tested this on a lot of my games just now, and it didn't hurt any of them.  It fixes at least Exit, and Hexyz Force.

-[Unknown]
