### PR TITLE
Fix for Qt/Symbian

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -368,7 +368,7 @@ int sceRtcConvertLocalTimeToUTC(u32 tickLocalPtr,u32 tickUTCPtr)
 	{
 		u64 srcTick = Memory::Read_U64(tickLocalPtr);
 		// TODO : Let the user select his timezone / daylight saving instead of taking system param ?
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__SYMBIAN32__)
 		time_t timezone = 0;
 		tm *time = localtime(&timezone);
 		srcTick -= time->tm_gmtoff*1000000ULL;
@@ -391,7 +391,7 @@ int sceRtcConvertUtcToLocalTime(u32 tickUTCPtr,u32 tickLocalPtr)
 	{
 		u64 srcTick = Memory::Read_U64(tickUTCPtr);
 		// TODO : Let the user select his timezone / daylight saving instead of taking system param ?
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__SYMBIAN32__)
 		time_t timezone = 0;
 		tm *time = localtime(&timezone);
 		srcTick += time->tm_gmtoff*1000000ULL;

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -23,7 +23,7 @@ arm {
 	HEADERS += ../Core/MIPS/ARM/ArmAsm.h \
 		../Core/MIPS/ARM/ArmJit.h \
 		../Core/MIPS/ARM/ArmJitCache.h \
-		../Core/MIPS/ARM/ArmRegCache.h
+		../Core/MIPS/ARM/ArmRegCache.h \
 		../Core/MIPS/ARM/ArmRegCacheFPU.h
 }
 x86 {


### PR DESCRIPTION
Fix missing slash in Qt project file
Symbian requires GLIBC usage of localtime for sceRtc.
