### PR TITLE
Fix VFPU instruction VF2IN/Z/U/D when handling NaN values

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -37,6 +37,7 @@
 
 #include "../Core.h"
 
+
 #include <cmath>
 
 #include "MIPS.h"
@@ -85,6 +86,14 @@
 #ifdef __APPLE__
 using std::isnan;
 #endif
+
+#ifndef isnan 
+#define isnan(x) ((x)!=(x)) 
+#endif
+
+float rint(float x){
+return floor(x+0.5);
+}
 
 void ApplyPrefixST(float *v, u32 data, VectorSize size)
 {
@@ -589,15 +598,16 @@ namespace MIPSInt
 		for (int i = 0; i < GetNumVectorElements(sz); i++)
 		{
 			float sv = s[i] * mult;
+			int dsv;
 			// Cap/floor it to 0x7fffffff / 0x80000000
 			if (sv > 0x7fffffff) sv = 0x7fffffff;
 			if (sv < (int)0x80000000) sv = (int)0x80000000;
 			switch ((op >> 21) & 0x1f)
 			{
-			case 16: d[i] = (int)round_ieee_754(sv); break; //n
-			case 17: d[i] = s[i]>=0 ? (int)floor(sv) : (int)ceil(sv); break; //z
-			case 18: d[i] = (int)ceil(sv); break; //u
-			case 19: d[i] = (int)floor(sv); break; //d
+			case 16: if (isnan(sv)) d[i] = 0x7FFFFFFF; else d[i] = (int) (int)rint(sv); break; //n
+			case 17: dsv = s[i]>=0 ? (int)floor(sv) : (int)ceil(sv); if (isnan(dsv)) d[i] = 0x7FFFFFFF; else d[i] = (int) dsv; break; //z
+			case 18: dsv = (int)ceil(sv); if (isnan(dsv)) d[i] = 0x7FFFFFFF; else d[i] = (int) dsv; break; //u
+			case 19: dsv = (int)floor(sv); if (isnan(dsv)) d[i] = 0x7FFFFFFF; else d[i] = (int) dsv; break; //d
 			}
 		}
 		ApplyPrefixD((float*)d, sz, true);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1591,9 +1591,12 @@ namespace MIPSInt
 		ApplySwizzleT(t, sz);
 		// positive NAN always loses, unlike SSE
 		// negative NAN seems different? TODO
-		for (int i = 0; i < GetNumVectorElements(sz); i++)
-			d[i] = s[i] >= t[i] ? 1.0f : 0.0f;
-
+		for (int i = 0; i < GetNumVectorElements(sz); i++) {
+			if ( isnan(s[i]) || isnan(t[i]) )
+				d[i] = 0.0f;
+			else
+				d[i] = s[i] >= t[i] ? 1.0f : 0.0f;
+		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1616,9 +1619,12 @@ namespace MIPSInt
 		ApplySwizzleT(t, sz);
 		// positive NAN always loses, unlike SSE
 		// negative NAN seems different? TODO
-		for (int i = 0; i < GetNumVectorElements(sz); i++)
-			d[i] = s[i] < t[i] ? 1.0f : 0.0f;
-
+		for (int i = 0; i < GetNumVectorElements(sz); i++) {
+			if ( isnan(s[i]) || isnan(t[i]) )
+				d[i] = 0.0f;
+			else
+				d[i] = s[i] < t[i] ? 1.0f : 0.0f;
+		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -87,8 +87,8 @@
 using std::isnan;
 #endif
 
-#ifndef isnan 
-#define isnan(x) ((x)!=(x)) 
+#ifdef _MSC_VER
+#define isnan _isnan
 #endif
 
 float rint(float x){
@@ -1452,10 +1452,6 @@ namespace MIPSInt
 		VC_NI,
 		VC_NS
 	};
-
-#ifdef _MSC_VER
-#define isnan _isnan
-#endif
 
 	void Int_Vcmp(u32 op)
 	{


### PR DESCRIPTION
also fix VFPU instructions Vsge/Vslt when handling NaN values , courtesy of Jpcsp
