### PR TITLE
Console logging -> thread

### DIFF
--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -22,6 +22,12 @@
 
 #ifdef _WIN32
 #include <windows.h>
+
+struct ConsolePendingEvent
+{
+	LogTypes::LOG_LEVELS Level;
+	const char *Text;
+};
 #endif
 
 class ConsoleListener : public LogListener
@@ -43,14 +49,26 @@ public:
 	void Log(LogTypes::LOG_LEVELS, const char *Text);
 	void ClearScreen(bool Cursor = true);
 
-  void Show(bool bShow);
-  bool Hidden() const { return bHidden; }
+	void Show(bool bShow);
+	bool Hidden() const { return bHidden; }
 private:
 #ifdef _WIN32
 	HWND GetHwnd(void);
 	HANDLE hConsole;
+
+	static DWORD WINAPI RunThread(LPVOID lpParam);
+	void LogWriterThread();
+	void SendToThread(LogTypes::LOG_LEVELS Level, const char *Text);
+	void WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text);
+
+	HANDLE hThread;
+	HANDLE hTriggerEvent;
+	CRITICAL_SECTION criticalSection;
+
+	ConsolePendingEvent *logPending;
+	volatile u32 logPendingSize;
 #endif
-  bool bHidden;
+	bool bHidden;
 	bool bUseColor;
 };
 

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -59,13 +59,13 @@ private:
 	static DWORD WINAPI RunThread(LPVOID lpParam);
 	void LogWriterThread();
 	void SendToThread(LogTypes::LOG_LEVELS Level, const char *Text);
-	void WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text);
+	void WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text, size_t Len);
 
 	HANDLE hThread;
 	HANDLE hTriggerEvent;
 	CRITICAL_SECTION criticalSection;
 
-	ConsolePendingEvent *logPending;
+	char *logPending;
 	volatile u32 logPendingReadPos;
 	volatile u32 logPendingWritePos;
 #endif

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -66,7 +66,8 @@ private:
 	CRITICAL_SECTION criticalSection;
 
 	ConsolePendingEvent *logPending;
-	volatile u32 logPendingSize;
+	volatile u32 logPendingReadPos;
+	volatile u32 logPendingWritePos;
 #endif
 	bool bHidden;
 	bool bUseColor;

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -22,12 +22,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-
-struct ConsolePendingEvent
-{
-	LogTypes::LOG_LEVELS Level;
-	const char *Text;
-};
 #endif
 
 class ConsoleListener : public LogListener

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -26,6 +26,10 @@
 #include <e32debug.h>
 #endif
 
+// Unfortunately this is quite slow.
+// #define LOG_MSC_OUTPUTDEBUG true
+#define LOG_MSC_OUTPUTDEBUG false
+
 void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
 		const char *file, int line, const char* fmt, ...)
 {
@@ -82,7 +86,7 @@ LogManager::LogManager()
 		m_Log[i]->AddListener(m_fileLog);
 		m_Log[i]->AddListener(m_consoleLog);
 #ifdef _MSC_VER
-		if (IsDebuggerPresent())
+		if (IsDebuggerPresent() && m_debuggerLog != NULL && LOG_MSC_OUTPUTDEBUG)
 			m_Log[i]->AddListener(m_debuggerLog);
 #endif
 #endif


### PR DESCRIPTION
I'm not sure I like this but I'm not sure I don't either.

This has the following affects (not sure if all are good):
- Debug builds now run at usable speeds (most of the time, at least on an i7.)
- Scrolling the console no longer pauses gameplay (split on good/bad.)
- OutputDebugString is now defined off even in debug (it's just so slow.)  Personally, I'd rather use OutputDebugString for spot-debugging rather than logging.
- Log can be behind sometimes, so after hitting pause it'll take some time to catch up.
- It's no longer easy to see what's immediately going on while the game is running.

With this, debug spends most of its time in CityHash (might be nice to just make that always optimized...) and sprintf() still for logging.  But it's a lot less.

Before, in debug, it was spending 51% time in WriteFile/SetConsoleTextAttribute, and 37% time in OutputDebugStringA.  And 12% (the rest) in the CPU/GPU/sprintf part of logging/etc.  Now that 12% becomes ~95% (after overhead for copying data to logging.)  It also improves perf in release (except on single core machines where I bet it hurts), although I didn't measure too  that carefully as it wasn't my goal.  Theoretically it has no real effect on non-Windows.

It's still spending 23% time in logging in general, but CityHash (~35%) is more.  Also, updateSyscallStats is probably too expensive (~12% time in debug.)

So, some downsides and some upsides.  What do you think?

Also, not sure if I was too careful/not careful enough with the threading.  Don't have a lot of experience there as I usually just communicate using sockets/etc.  Maybe the code could be cleaner...

-[Unknown]
