### PR TITLE
Add  GL_ONE_MINUS_CONSTANT_COLOR /GL_ZERO/GL_ONE to aLookup[]

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -9,7 +9,7 @@
 #include "ShaderManager.h"
 #include "TextureCache.h"
 
-const GLint aLookup[11] = {
+const GLint aLookup[14] = {
 	GL_DST_COLOR,
 	GL_ONE_MINUS_DST_COLOR,
 	GL_SRC_ALPHA,
@@ -21,9 +21,12 @@ const GLint aLookup[11] = {
 	GL_DST_ALPHA,	 // should be 2x
 	GL_ONE_MINUS_DST_ALPHA,	 // should be 2x	-	and COLOR?
 	GL_CONSTANT_COLOR,	// FIXA
+	GL_ONE_MINUS_CONSTANT_COLOR,
+	GL_ZERO,
+	GL_ONE,
 };
 
-const GLint bLookup[11] = {
+const GLint bLookup[14] = {
 	GL_SRC_COLOR,
 	GL_ONE_MINUS_SRC_COLOR,
 	GL_SRC_ALPHA,
@@ -35,6 +38,9 @@ const GLint bLookup[11] = {
 	GL_DST_ALPHA,	 // should be 2x
 	GL_ONE_MINUS_DST_ALPHA,	 // should be 2x
 	GL_CONSTANT_COLOR,	// FIXB
+	GL_ONE_MINUS_CONSTANT_COLOR,
+	GL_ZERO,
+	GL_ONE,
 };
 
 const GLint eqLookup[] = {


### PR DESCRIPTION
I spot glBlendFuncB uses GL_ONE_MINUS_CONSTANT_COLOR , therefore i add it to aLookup[] , i'm not quite sure it is doing right .If not necessary , let me know and i will close it :)

```
            if (fixA == (fixB ^ 0xFFFFFF)) {
                glBlendFuncA = GL_CONSTANT_COLOR;
                glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
                const float blendColor[4] = {(fixA & 0xFF)/255.0f, ((fixA >> 8) & 0xFF)/255.0f, ((fixA >> 16) & 0xFF)/255.0f, 1.0f};
                glstate.blendColor.set(blendColor);
            } else if (fixA == fixB) {
                glBlendFuncA = GL_CONSTANT_COLOR;
                glBlendFuncB = GL_CONSTANT_COLOR;
```
