### PR TITLE
Get rid of channel buffer underrun by setting hwBlockSize to 64

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -35,7 +35,7 @@ int eventHostAudioUpdate = -1;
 int mixFrequency = 44100;
 
 const int hwSampleRate = 44100;
-const int hwBlockSize = 60;
+const int hwBlockSize = 64;
 const int hostAttemptBlockSize = 256;
 const int audioIntervalUs = (int)(1000000ULL * hwBlockSize / hwSampleRate);
 const int audioHostIntervalUs = (int)(1000000ULL * hostAttemptBlockSize / hwSampleRate);


### PR DESCRIPTION
Tested with following games already and no more buffer underrun message in the debug log.
- Saint Seiya Omega
- MotoGP
- Fate Extra
- Dissidia Final Fantasy
- Project Diva 2 extend
- Ys vs Sora
- Senjou no Valkyria 3 - Extra Edition
