### PR TITLE
Don't measure syscall stats when not showing

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <vector>
 #include "../MemMap.h"
+#include "../Config.h"
 
 #include "HLETables.h"
 #include "../System.h"
@@ -399,5 +400,6 @@ void CallSyscall(u32 op)
 		ERROR_LOG(HLE,"Unimplemented HLE function %s", moduleDB[modulenum].funcTable[funcnum].name);
 	}
 	time_update();
-	updateSyscallStats(modulenum, funcnum, time_now_d() - start);
+	if (g_Config.bShowDebugStats)
+		updateSyscallStats(modulenum, funcnum, time_now_d() - start);
 }


### PR DESCRIPTION
Fairly straight-forward.  This helps release a little bit (like 0.5%) but it helps debug significantly, 12-15% (after the console-th merge.)

-[Unknown]
