### PR TITLE
Fix savestate ruining the host audio update.

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -80,7 +80,7 @@ void __AudioDoState(PointerWrap &p)
 	p.Do(eventAudioUpdate);
 	CoreTiming::RestoreRegisterEvent(eventAudioUpdate, "AudioUpdate", &hleAudioUpdate);
 	p.Do(eventHostAudioUpdate);
-	CoreTiming::RestoreRegisterEvent(eventHostAudioUpdate, "AudioUpdateHost", &hleAudioUpdate);
+	CoreTiming::RestoreRegisterEvent(eventHostAudioUpdate, "AudioUpdateHost", &hleHostAudioUpdate);
 
 	p.Do(mixFrequency);
 	outAudioQueue.DoState(p);


### PR DESCRIPTION
Fixes #541.  A dump typo is as a dumb typo does.

-[Unknown]
