### PR TITLE
Properly jit the break instruction

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -422,4 +422,11 @@ void Jit::Comp_Syscall(u32 op)
 	js.compiling = false;
 }
 
+void Jit::Comp_Break(u32 op)
+{
+	Comp_Generic(op);
+	WriteSyscallExit();
+	js.compiling = false;
+}
+
 }   // namespace Mipscomp

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -89,6 +89,7 @@ public:
 	void Comp_Jump(u32 op);
 	void Comp_JumpReg(u32 op);
 	void Comp_Syscall(u32 op);
+	void Comp_Break(u32 op);
 
 	void Comp_IType(u32 op);
 	void Comp_RType3(u32 op);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -179,7 +179,7 @@ namespace MIPSInt
 
 	void Int_Break(u32 op)
 	{
-		DEBUG_LOG(CPU, "BREAK!");
+		ERROR_LOG(CPU, "BREAK!");
 		coreState = CORE_STEPPING;
 		PC += 4;
 	}

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -183,7 +183,7 @@ const MIPSInstruction tableSpecial[64] = /// 000000 ...... ...... .......... xxx
 	INSTR("movz",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT),
 	INSTR("movn",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT),
 	INSTR("syscall", &Jit::Comp_Syscall, Dis_Syscall, Int_Syscall,0),
-	INSTR("break", &Jit::Comp_Generic, Dis_Generic, Int_Break, 0),
+	INSTR("break", &Jit::Comp_Break, Dis_Generic, Int_Break, 0),
 	{-2},
 	INSTR("sync",  &Jit::Comp_Generic, Dis_Generic, Int_Sync, 0),
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -506,4 +506,11 @@ void Jit::Comp_Syscall(u32 op)
 	js.compiling = false;
 }
 
+void Jit::Comp_Break(u32 op)
+{
+	Comp_Generic(op);
+	WriteSyscallExit();
+	js.compiling = false;
+}
+
 }	 // namespace Mipscomp

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -122,6 +122,7 @@ public:
 	void Comp_Jump(u32 op);
 	void Comp_JumpReg(u32 op);
 	void Comp_Syscall(u32 op);
+	void Comp_Break(u32 op);
 
 	void Comp_IType(u32 op);
 	void Comp_RType3(u32 op);


### PR DESCRIPTION
Otherwise, it just keeps on going past it.  We never want to hit this anyway, but it's good to know if we do.

Warning: contains untested ARM changes because it would've broken it anyway.

Hits this in Phantasy Star Portable, not sure why but my intention is for jit to be the preferred way to debug/run/exist/etc.

-[Unknown]
