### PR TITLE
Fix things broken from the last Atrac changes

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -386,6 +386,9 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
+	} else {
+		// TODO: Not sure what this means?
+		atrac->decodePos = sample;
 	}
 	return 0;
 }


### PR DESCRIPTION
Fixes:
   Yggdra Union (loading -> ingame)

Unbroken:
   Senjou no Valkyria 3 (had regressed)
   Savage Moon (had regressed)
   Wipeout Pure (had regressed)
   Ys Seven (had regressed)
   Canabalt (had regressed)
   PixelJunk Monsters (had started spewing errors to stdout, still played fine)

Still works:
   Lunar (locks up later still)
   Trails in the Sky (still seems playable now)

Still broken:
   Exit (dies when decode doesn't loop, but doesn't ask for a loop...)

-[Unknown]
