### PR TITLE
Jit: lwl/lwr/swl/swr, shift var

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -297,17 +297,16 @@ namespace MIPSComp
 	// "over-shifts" work the same as on x86 - only bottom 5 bits are used to get the shift value
 	void Jit::CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg))
 	{
-		DISABLE;
 		int rd = _RD;
 		int rt = _RT;
 		int rs = _RS;
 		gpr.FlushLockX(ECX);
 		gpr.Lock(rd, rt, rs);
-		gpr.BindToRegister(rd, true, true);
-		if (rd != rt)
-			MOV(32, gpr.R(rd), gpr.R(rt));
+		gpr.BindToRegister(rd, rd == rt || rd == rs, true);
 		MOV(32, R(ECX), gpr.R(rs));	// Only ECX can be used for variable shifts.
 		AND(32, R(ECX), Imm32(0x1f));
+		if (rd != rt)
+			MOV(32, gpr.R(rd), gpr.R(rt));
 		(this->*shift)(32, gpr.R(rd), R(ECX));
 		gpr.UnlockAll();
 		gpr.UnlockAllX();

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -136,7 +136,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 	int rs = _RS;
 	u32 targetAddr = js.compilerPC + offset + 4;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC+4);
+	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC+4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rt, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
@@ -191,7 +191,7 @@ void Jit::BranchRSZeroComp(u32 op, Gen::CCFlags cc, bool andLink, bool likely)
 	int rs = _RS;
 	u32 targetAddr = js.compilerPC + offset + 4;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
+	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
@@ -285,7 +285,7 @@ void Jit::BranchFPFlag(u32 op, Gen::CCFlags cc, bool likely)
 	int offset = (signed short)(op & 0xFFFF) << 2;
 	u32 targetAddr = js.compilerPC + offset + 4;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
+	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceFPU(op, delaySlotOp);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
@@ -346,7 +346,7 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	int offset = (signed short)(op & 0xFFFF) << 2;
 	u32 targetAddr = js.compilerPC + offset + 4;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
+	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceVFPU(op, delaySlotOp);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
@@ -443,7 +443,7 @@ void Jit::Comp_JumpReg(u32 op)
 	}
 	int rs = _RS;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
+	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
 

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -148,44 +148,70 @@ namespace MIPSComp
 			CompITypeMemWrite(op, 32, (void *) &Memory::Write_U32);
 			break;
 
-		case 134: //lwl
+		case 34: //lwl
 			{
-				Crash();
-				//u32 shift = (addr & 3) << 3;
-				//u32 mem = ReadMem32(addr & 0xfffffffc);
-				//R(rt) = ( u32(R(rt)) & (0x00ffffff >> shift) ) | ( mem << (24 - shift) );
+				u32 nextOp = Memory::Read_Instruction(js.compilerPC + 4);
+				// Looking for lwr rd, offset-3(rs) which makes a pair.
+				u32 desiredOp = ((op + (4 << 26)) & 0xFFFF0000) + (offset - 3);
+				if (!js.inDelaySlot && nextOp == desiredOp)
+				{
+					EatInstruction(nextOp);
+					// nextOp has the correct address.
+					CompITypeMemRead(nextOp, 32, &XEmitter::MOVZX, (void *) &Memory::Read_U32);
+				}
+				else
+					Comp_Generic(op);
 			}
 			break;
 
-		case 138: //lwr
+		case 38: //lwr
 			{
-				Crash();
-				//u32 shift = (addr & 3) << 3;
-				//u32 mem = ReadMem32(addr & 0xfffffffc);
-
-				//R(rt) = ( u32(rt) & (0xffffff00 << (24 - shift)) ) | ( mem	>> shift );
+				u32 nextOp = Memory::Read_Instruction(js.compilerPC + 4);
+				// Looking for lwl rd, offset+3(rs) which makes a pair.
+				u32 desiredOp = ((op - (4 << 26)) & 0xFFFF0000) + (offset + 3);
+				if (!js.inDelaySlot && nextOp == desiredOp)
+				{
+					EatInstruction(nextOp);
+					// op has the correct address.
+					CompITypeMemRead(op, 32, &XEmitter::MOVZX, (void *) &Memory::Read_U32);
+				}
+				else
+					Comp_Generic(op);
 			}
 			break;
 
-		case 142: //swl
+		case 42: //swl
 			{
-				Crash();
-				//u32 shift = (addr & 3) << 3;
-				//u32 mem = ReadMem32(addr & 0xfffffffc);
-				//WriteMem32((addr & 0xfffffffc),	( ( u32(R(rt)) >>	(24 - shift) ) ) |
-				//	(	mem & (0xffffff00 << shift) ));
+				u32 nextOp = Memory::Read_Instruction(js.compilerPC + 4);
+				// Looking for swr rd, offset-3(rs) which makes a pair.
+				u32 desiredOp = ((op + (4 << 26)) & 0xFFFF0000) + (offset - 3);
+				if (!js.inDelaySlot && nextOp == desiredOp)
+				{
+					EatInstruction(nextOp);
+					// nextOp has the correct address.
+					CompITypeMemWrite(nextOp, 32, (void *) &Memory::Write_U32);
+				}
+				else
+					Comp_Generic(op);
 			}
 			break;
-		case 146: //swr
+
+		case 46: //swr
 			{
-				Crash();
-				//	u32 shift = (addr & 3) << 3;
-			//	u32 mem = ReadMem32(addr & 0xfffffffc);
-//
-//				WriteMem32((addr & 0xfffffffc), ( ( u32(R(rt)) << shift ) |
-//					(mem	& (0x00ffffff >> (24 - shift)) ) ) );
+				u32 nextOp = Memory::Read_Instruction(js.compilerPC + 4);
+				// Looking for swl rd, offset+3(rs) which makes a pair.
+				u32 desiredOp = ((op - (4 << 26)) & 0xFFFF0000) + (offset + 3);
+				if (!js.inDelaySlot && nextOp == desiredOp)
+				{
+					EatInstruction(nextOp);
+					// op has the correct address.
+					CompITypeMemWrite(op, 32, (void *) &Memory::Write_U32);
+				}
+				else
+					Comp_Generic(op);
 			}
 			break;
+
 		default:
 			Comp_Generic(op);
 			return ;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -53,6 +53,7 @@ struct JitState
 	bool cancel;
 	bool inDelaySlot;
 	int downcountAmount;
+	int numInstructions;
 	bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
 	JitBlock *curBlock;
 
@@ -107,8 +108,6 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
-	// See CompileDelaySlotFlags for flags.
-	void CompileDelaySlot(int flags);
 	void CompileAt(u32 addr);
 	void Comp_RunBlock(u32 op);
 
@@ -150,6 +149,10 @@ public:
 private:
 	void FlushAll();
 	void WriteDowncount(int offset = 0);
+
+	// See CompileDelaySlotFlags for flags.
+	void CompileDelaySlot(int flags);
+	void EatInstruction(u32 op);
 
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInEAX();


### PR DESCRIPTION
Not really a huge improvement in performance at all, but speeds up debug a bit.

Also a tiny fix in case code ever jumps into a delay slot (don't try to compile the emuhack.)  I've never actually seen a game do this, though.

By the way, I noticed numInstructions doesn't account for delay slots, but I'm not sure if this is intentional.

-[Unknown]
