### PR TITLE
Add stubs for _sceAtracGetContextAddress 

### DIFF
--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -240,6 +240,11 @@ template<u32 func(u32, int, u32, int, int)> void WrapU_UIUII() {
 	RETURN(retval);
 }
 
+template<u32 func(u32, int, u32, int)> void WrapU_UIUI() {
+	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+	RETURN(retval);
+}
+
 template<u32 func(u32, int, u32)> void WrapU_UIU() {
 	u32 retval = func(PARAM(0), PARAM(1), PARAM(2));
 	RETURN(retval);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -520,6 +520,16 @@ int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 met
 	return createAtrac(atrac);
 }
 
+int _sceAtracGetContextAddress(int atracID)
+{
+	ERROR_LOG_LIMITED(HLE, "UNIMPL _sceAtracGetContextAddress(%i)", atracID);
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		//return -1;
+	}
+	return 0;
+}
+
 const HLEFunction sceAtrac3plus[] =
 {
 	{0x7db31251,WrapU_IU<sceAtracAddStreamData>,"sceAtracAddStreamData"},
@@ -557,7 +567,7 @@ const HLEFunction sceAtrac3plus[] =
 	{0x9CD7DE03,0,"sceAtracSetMOutHalfwayBufferAndGetID"},
 	{0x5622B7C1,WrapI_UIIU<sceAtracSetAA3DataAndGetID>,"sceAtracSetAA3DataAndGetID"},
 	{0x5DD66588,0,"sceAtracSetAA3HalfwayBufferAndGetID"},
-	{0x231FC6B7,0,"_sceAtracGetContextAddress"},
+	{0x231FC6B7,WrapI_I<_sceAtracGetContextAddress>,"_sceAtracGetContextAddress"},
 };
 
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -439,6 +439,23 @@ u32 sceSasSetSteepWave(u32 sasCore, int voice, int unknown)
 	return 0;
 }
 
+u32 __sceSasSetVoiceATRAC3(u32 core, int voice, int atrac3Context)
+{
+	ERROR_LOG(HLE,"UNIMPL __sceSasSetVoiceATRAC3(%08x, %i, %i)", core, voice, atrac3Context);
+	return 0;
+}
+
+u32 __sceSasConcatenateATRAC3(u32 core, int voice, u32 atrac3DataAddr, int atrac3DataLength)
+{
+	ERROR_LOG(HLE,"UNIMPL __sceSasConcatenateATRAC3(%08x, %i, %i)", core, voice, atrac3DataAddr, atrac3DataLength);
+	return 0;
+}
+
+u32 __sceSasUnsetATRAC3(u32 core, int voice)
+{
+	ERROR_LOG(HLE,"UNIMPL __sceSasUnsetATRAC3(%08x, %i, %i)", core, voice);
+	return 0;
+}
 const HLEFunction sceSasCore[] =
 {
 	{0x42778a9f, WrapU_UUUUU<sceSasInit>, "__sceSasInit"}, 
@@ -470,6 +487,9 @@ const HLEFunction sceSasCore[] =
 	{0xe855bf76, WrapU_UU<sceSasSetOutputMode>, "__sceSasSetOutputmode"},
 	{0x07f58c24, WrapU_UU<sceSasGetAllEnvelopeHeights>, "__sceSasGetAllEnvelopeHeights"},
 	{0xE1CD9561, WrapU_UIUII<sceSasSetVoicePCM>, "__sceSasSetVoicePCM"},
+	{0x4AA9EAD6, WrapU_UII<__sceSasSetVoiceATRAC3>,"__sceSasSetVoiceATRAC3"},
+	{0x7497EA85, WrapU_UIUI<__sceSasConcatenateATRAC3>,"__sceSasConcatenateATRAC3"},
+	{0xF6107F00, WrapU_UI<__sceSasUnsetATRAC3>,"__sceSasUnsetATRAC3"},
 };
 
 void Register_sceSasCore()


### PR DESCRIPTION
It is used by Sol Trigger in-game 

Also added three co-related stubs for 

__sceSasSetVoiceATRAC3
__sceSasConcatenateATRAC3
__sceSasUnsetATRAC3
