### PR TITLE
Don't consider mipscalls proper callbacks

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -231,12 +231,17 @@ private:
 
 class ActionAfterMipsCall : public Action
 {
+	ActionAfterMipsCall()
+	{
+		chainedAction = NULL;
+	}
+
 public:
 	virtual void run(MipsCall &call);
 
 	static Action *Create()
 	{
-		return new ActionAfterMipsCall;
+		return new ActionAfterMipsCall();
 	}
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2233,7 +2233,13 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 		// Profile on Windows shows this takes time, skip it.
 		if (DEBUG_LEVEL <= MAX_LOGLEVEL)
 			oldName = cur->GetName();
+
+		if (cur->isRunning())
+			cur->nt.status = (cur->nt.status | THREADSTATUS_READY) & ~THREADSTATUS_RUNNING;
 	}
+	if (target && target->isRunning())
+		cur->nt.status = (cur->nt.status | THREADSTATUS_RUNNING) & ~THREADSTATUS_READY;
+
 	currentThread = target->GetUID();
 	__KernelLoadContext(&target->context);
 	DEBUG_LOG(HLE,"Context switched: %s -> %s (%s) (%i - pc: %08x -> %i - pc: %08x)",

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -183,7 +183,7 @@ void sceKernelReferCallbackStatus();
 class Action;
 
 // Not an official Callback object, just calls a mips function on the current thread.
-void __KernelDirectMipsCall(u32 entryPoint, Action *afterAction, bool returnVoid, u32 args[], int numargs, bool reschedAfter);
+void __KernelDirectMipsCall(u32 entryPoint, Action *afterAction, u32 args[], int numargs, bool reschedAfter);
 
 void __KernelReturnFromMipsCall();  // Called as HLE function
 bool __KernelInCallback();
@@ -218,7 +218,6 @@ struct MipsCall {
 	u32 savedPc;
 	u32 savedV0;
 	u32 savedV1;
-	bool returnVoid;
 	std::string tag;
 	u32 savedId;
 	bool reschedAfter;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -208,6 +208,11 @@ int __KernelRegisterActionType(ActionCreator creator);
 void __KernelRestoreActionType(int actionType, ActionCreator creator);
 
 struct MipsCall {
+	MipsCall()
+	{
+		doAfter = NULL;
+	}
+
 	u32 entryPoint;
 	u32 cbId;
 	u32 args[6];

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1055,7 +1055,7 @@ u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 		PostPutAction *action = (PostPutAction *) __KernelCreateAction(actionPostPut);
 		action->setRingAddr(ringbufferAddr);
 		u32 args[3] = {(u32)ringbuffer.data, numPackets, (u32)ringbuffer.callback_args};
-		__KernelDirectMipsCall(ringbuffer.callback_addr, action, false, args, 3, false);
+		__KernelDirectMipsCall(ringbuffer.callback_addr, action, args, 3, false);
 	} else {
 		ERROR_LOG(HLE, "sceMpegRingbufferPut: callback_addr zero");
 	}


### PR DESCRIPTION
Most of the time when you saw a wait within a callback, the issue was it wasn't rescheduling from a mipscall.  Since mispcalls aren't special, this simply doesn't treat them as callbacks.

The return value will be wrong for the wait though, still.  And actual callbacks still represent another bag of worms.

This improves:
- Legend of Heroes 1 (goes ingame now)
- Legend of Heroes 2/3 (wig out about atrac like Exit)
- Jewel Summoner
- Probably Sol Trigger?
- Astonishia Story (still gets stuck with mpeg)

-[Unknown]
