### PR TITLE
Improve performance of sceKernelSysClock2USec

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -377,7 +377,8 @@ inline void updateSyscallStats(int modulenum, int funcnum, double total)
 
 void CallSyscall(u32 op)
 {
-	time_update();
+	if (g_Config.bShowDebugStats)
+		time_update();
 	double start = time_now_d();
 	u32 callno = (op >> 6) & 0xFFFFF; //20 bits
 	int funcnum = callno & 0xFFF;
@@ -400,7 +401,9 @@ void CallSyscall(u32 op)
 	{
 		ERROR_LOG(HLE,"Unimplemented HLE function %s", moduleDB[modulenum].funcTable[funcnum].name);
 	}
-	time_update();
 	if (g_Config.bShowDebugStats)
+	{
+		time_update();
 		updateSyscallStats(modulenum, funcnum, time_now_d() - start);
+	}
 }

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -603,7 +603,7 @@ const HLEFunction ThreadManForUser[] =
 	{0x57CF62DD,WrapU_U<sceKernelGetThreadmanIdType>,"sceKernelGetThreadmanIdType"},
 
 	{0x82BC5777,sceKernelGetSystemTimeWide,"sceKernelGetSystemTimeWide"},
-	{0xdb738f35,sceKernelGetSystemTime,"sceKernelGetSystemTime"},
+	{0xdb738f35,WrapI_U<sceKernelGetSystemTime>,"sceKernelGetSystemTime"},
 	{0x369ed59d,sceKernelGetSystemTimeLow,"sceKernelGetSystemTimeLow"},
 
 	{0x8218B4DD,&WrapU_U<sceKernelReferGlobalProfiler>,"sceKernelReferGlobalProfiler"},
@@ -616,7 +616,7 @@ const HLEFunction ThreadManForUser[] =
 	{0x7e65b999,WrapI_I<sceKernelCancelAlarm>,"sceKernelCancelAlarm"},
 	{0xDAA3F564,WrapI_IU<sceKernelReferAlarmStatus>,"sceKernelReferAlarmStatus"},
 
-	{0xba6b92e2,sceKernelSysClock2USec,"sceKernelSysClock2USec"},
+	{0xba6b92e2,WrapI_UUU<sceKernelSysClock2USec>,"sceKernelSysClock2USec"},
 	{0x110DEC9A,0,"sceKernelUSec2SysClock"},
 	{0xC8CD158C,WrapU_U<sceKernelUSec2SysClockWide>,"sceKernelUSec2SysClockWide"},
 	{0xE1619D7C,sceKernelSysClock2USecWide,"sceKernelSysClock2USecWide"},

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -20,10 +20,10 @@
 u32 sceKernelLibcGettimeofday(u32 timeAddr);
 u32 sceKernelLibcTime(u32 outPtr);
 void sceKernelUSec2SysClock();
-void sceKernelGetSystemTime();
+int sceKernelGetSystemTime(u32 sysclockPtr);
 void sceKernelGetSystemTimeLow();
 void sceKernelGetSystemTimeWide();
-void sceKernelSysClock2USec();
+int sceKernelSysClock2USec(u32 sysclockPtr, u32 highPtr, u32 lowPtr);
 void sceKernelSysClock2USecWide();
 u32 sceKernelUSec2SysClockWide(u32 usec);
 u32 sceKernelLibcClock();


### PR DESCRIPTION
Legend of Heroes 1 especially was hammering this function and also `sceKernelGetSystemTime()`.  It may be (must be?) a bug but these two commits improve the performance significantly for now.

-[Unknown]
