### PR TITLE
Always reschedule on vblank, even without handler

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -182,6 +182,8 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	}
 	vblankWaitingThreads.clear();
 
+	// We want to "interrupt" even if there are no installed vblank handlers.
+	__KernelSwitchOffThread("vblank");
 	// Trigger VBlank interrupt handlers.
 	__TriggerInterrupt(PSP_INTR_IMMEDIATE | PSP_INTR_ONLY_IF_ENABLED, PSP_VBLANK_INTR);
 


### PR DESCRIPTION
Fixes:
- Astonishia Story
- LittleBigPlanet
- Crimson Gem Saga
- Practical Intelligence Quotient 2
- Patchwork Heroes (but hangs later again, arg)
- Stick Man Rescue (maybe, or it was fixed earlier)

Tested with a bunch of games to ensure it doesn't break anything.

-[Unknown]
