### PR TITLE
Blacklist some network modules unlikely to work

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -64,14 +64,16 @@ static const char *blacklistedModules[] = {
 	"sceATRAC3plus_Library",
 	"sceFont_Library",
 	"SceFont_Library",
+	"SceHttp_Library",
+	"sceMpeg_library",
 	"sceNetAdhocctl_Library",
 	"sceNetAdhocDownload_Library",
 	"sceNetAdhocMatching_Library",
 	"sceNetAdhoc_Library",
 	"sceNetApctl_Library",
 	"sceNetInet_Library",
+	"sceNetResolver_Library",
 	"sceNet_Library",
-	"sceMpeg_library",
 };
 
 struct NativeModule {


### PR DESCRIPTION
Makes Wipeout Pure load again, although still too fast.  These modules probably won't run anyway?

-[Unknown]
