### PR TITLE
Fix power bar graphic issue in Saint Seiya Omega

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -349,10 +349,12 @@ static void SwapUVs(TransformedVertex &a, TransformedVertex &b) {
 
 // Used by Star Soldier and Ys vs Sora.
 static void RotateUVs(TransformedVertex v[4]) {
-	if (/* (v[0].x > v[2].x && v[0].y < v[2].y) || */  // This first check seems wrong..
-		  (v[0].x < v[2].x && v[0].y > v[2].y)) {
+
+	/*  // This first check seems wrong..
+	if ( (v[0].x > v[2].x && v[0].y < v[2].y) || (v[0].x < v[2].x && v[0].y > v[2].y)) {
 		SwapUVs(v[1], v[3]);
 	}
+	*/
 }
 
 // This is the software transform pipeline, which is necessary for supporting RECT


### PR DESCRIPTION
It fixes power bar graphic issue in Saint Seiya Omega and will not break other falcom games  which requires rotateUV (they are already broken until proper fix later )
