### PR TITLE
Atrac finish flag fix

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -170,8 +170,10 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			ret = ATRAC_ERROR_ALL_DATA_DECODED;
 		} else {
 			// TODO: This isn't at all right, but at least it makes the music "last" some time.
-			u32 numSamples = (atrac->first.size - atrac->decodePos) / (sizeof(s16) * 2);
-			if (numSamples > ATRAC_MAX_SAMPLES) {
+			int numSamples = (atrac->first.size - atrac->decodePos) / (sizeof(s16) * 2);
+			if (atrac->decodePos >= atrac->first.size) {
+				numSamples = 0;
+			} else if (numSamples > ATRAC_MAX_SAMPLES) {
 				numSamples = ATRAC_MAX_SAMPLES;
 			}
 
@@ -260,12 +262,18 @@ u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 	return 0;
 }
 
-u32 sceAtracGetLoopStatus(int atracID, u32 loopNbr, u32 statusAddr)
+u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNbr, statusAddr );
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
+	} else {
+		if (Memory::IsValidAddress(loopNumAddr))
+			Memory::Write_U32(atrac->loopNum, loopNumAddr);
+		// TODO: What does this mean?
+		if (Memory::IsValidAddress(statusAddr))
+			Memory::Write_U32(1, statusAddr);
 	}
 	return 0;
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -107,21 +107,6 @@ void __AtracShutdown()
 	atracMap.clear();
 }
 
-// Temporary workaround to prevent excessive logging making games very slow.
-// This is just the default cycle / 10, so about 1/10 second.
-const u64 atracLogTickFrequency = 22200;
-static bool atracShouldLogUnimpl(u64 &lastTicks) {
-	u64 ticks = CoreTiming::GetTicks();
-	bool result = ticks - lastTicks >= atracLogTickFrequency;
-	lastTicks = ticks;
-
-	return result;
-}
-
-// Switch if you want all errors.
-#define ERROR_LOG_LIMITED(t, ...) { static u64 limited__lastTicks = 0; if (atracShouldLogUnimpl(limited__lastTicks)) ERROR_LOG(t, __VA_ARGS__); }
-//#define ERROR_LOG_LIMITED(t, ...) { ERROR_LOG(t, __VA_ARGS__); }
-
 Atrac *getAtrac(int atracID) {
 	if (atracMap.find(atracID) == atracMap.end()) {
 		return NULL;
@@ -154,13 +139,13 @@ int getCodecType(int addr) {
 
 u32 sceAtracGetAtracID(int codecType)
 {
-	ERROR_LOG_LIMITED(HLE, "FAKE sceAtracGetAtracID(%i)", codecType);
+	ERROR_LOG(HLE, "FAKE sceAtracGetAtracID(%i)", codecType);
 	return createAtrac(new Atrac);
 }
 
 u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
+	ERROR_LOG(HLE, "UNIMPL sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -171,7 +156,7 @@ u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 
 u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
+	ERROR_LOG(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 
 	u32 ret = 0;
@@ -226,13 +211,13 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 
 u32 sceAtracEndEntry()
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracEndEntry(.)");
+	ERROR_LOG(HLE, "UNIMPL sceAtracEndEntry(.)");
 	return 0;
 }
 
 u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetBufferInfoForReseting(%i, %i, %08x)",atracID, sample, bufferInfoAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetBufferInfoForReseting(%i, %i, %08x)",atracID, sample, bufferInfoAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		// TODO: Write the right stuff instead.
@@ -253,7 +238,7 @@ u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr
 
 u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -265,7 +250,7 @@ u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
 
 u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -277,7 +262,7 @@ u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 
 u32 sceAtracGetLoopStatus(int atracID, u32 loopNbr, u32 statusAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNbr, statusAddr );
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNbr, statusAddr );
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -287,7 +272,7 @@ u32 sceAtracGetLoopStatus(int atracID, u32 loopNbr, u32 statusAddr)
 
 u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetInternalErrorInfo(%i, %08x)", atracID, errorAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetInternalErrorInfo(%i, %08x)", atracID, errorAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -299,7 +284,7 @@ u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr)
 
 u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -311,7 +296,7 @@ u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 
 u32  sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -322,7 +307,7 @@ u32  sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 
 u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
+	ERROR_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -341,7 +326,7 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 
 u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
+	ERROR_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -354,7 +339,7 @@ u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 
 u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
+	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -366,7 +351,7 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 
 u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -379,7 +364,7 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 
 u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+	ERROR_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -392,14 +377,14 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 
 u32 sceAtracReleaseAtracID(int atracID)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracReleaseAtracID(%i)", atracID);
+	ERROR_LOG(HLE, "UNIMPL sceAtracReleaseAtracID(%i)", atracID);
 	deleteAtrac(atracID);
 	return 0;
 }
 
 u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
+	ERROR_LOG(HLE, "UNIMPL sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -412,7 +397,7 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 
 u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
 	return 0;
 }
 
@@ -428,7 +413,7 @@ u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
 
 u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac != NULL) {
 		atrac->first.addr = buffer;
@@ -439,7 +424,7 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 
 int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 {	
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -450,7 +435,7 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 
 int sceAtracSetHalfwayBufferAndGetID(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetHalfwayBufferAndGetID(%i, %08x, %08x, %08x)", atracID, halfBuffer, readSize, halfBufferSize);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBufferAndGetID(%i, %08x, %08x, %08x)", atracID, halfBuffer, readSize, halfBufferSize);
 	int codecType = getCodecType(halfBuffer);
 
 	Atrac *atrac = new Atrac();
@@ -461,13 +446,13 @@ int sceAtracSetHalfwayBufferAndGetID(int atracID, u32 halfBuffer, u32 readSize, 
 
 u32 sceAtracStartEntry()
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracStartEntry(.)");
+	ERROR_LOG(HLE, "UNIMPL sceAtracStartEntry(.)");
 	return 0;
 }
 
 u32 sceAtracSetLoopNum(int atracID, int loopNum)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
 		atrac->loopNum = loopNum;
@@ -477,13 +462,13 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum)
 
 int sceAtracReinit()
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracReinit(..)");
+	ERROR_LOG(HLE, "UNIMPL sceAtracReinit(..)");
 	return 0;
 }
 
 int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
 	if (Memory::IsValidAddress(outputChanPtr))
 		Memory::Write_U32(2, outputChanPtr);
 	return 0;
@@ -491,7 +476,7 @@ int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr)
 
 int sceAtracIsSecondBufferNeeded(int atracID)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracIsSecondBufferNeeded(%i)", atracID);
+	ERROR_LOG(HLE, "UNIMPL sceAtracIsSecondBufferNeeded(%i)", atracID);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -501,7 +486,7 @@ int sceAtracIsSecondBufferNeeded(int atracID)
 
 int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, int readSize, int MOutHalfBufferSize)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetMOutHalfwayBuffer(%i, %08x, %i, %i)", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetMOutHalfwayBuffer(%i, %08x, %i, %i)", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -511,7 +496,7 @@ int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, int readSize, 
 
 int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x)", buffer, bufferSize, fileSize, metadataSizeAddr);
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x)", buffer, bufferSize, fileSize, metadataSizeAddr);
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -522,7 +507,7 @@ int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 met
 
 int _sceAtracGetContextAddress(int atracID)
 {
-	ERROR_LOG_LIMITED(HLE, "UNIMPL _sceAtracGetContextAddress(%i)", atracID);
+	ERROR_LOG(HLE, "UNIMPL _sceAtracGetContextAddress(%i)", atracID);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -192,13 +192,12 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			Memory::Write_U32(numSamples, numSamplesAddr);
 			atrac->decodePos += ATRAC_MAX_SAMPLES;
 
-			if (numSamples == 0) {
+			if (numSamples < ATRAC_MAX_SAMPLES) {
 				Memory::Write_U32(1, finishFlagAddr);
-				Memory::Write_U32(-1, remainAddr);
 			} else {
 				Memory::Write_U32(0, finishFlagAddr);
-				Memory::Write_U32(-1, remainAddr);
 			}
+			Memory::Write_U32(-1, remainAddr);
 		}
 	// TODO: Can probably remove this after we validate no wrong ids?
 	} else {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -326,6 +326,8 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 		} else {
 			// TODO: This is not correct.
 			u32 numSamples = (atrac->first.size - atrac->decodePos) / (sizeof(s16) * 2);
+			if (numSamples > ATRAC_MAX_SAMPLES)
+				numSamples = ATRAC_MAX_SAMPLES;
 			Memory::Write_U32(numSamples, outNAddr);
 		}
 	}


### PR DESCRIPTION
This implements a few things:
- Properly sets the finishFlag on the last sample (before returning an error.)
- Estimates the decoded PCM at 3x as long as the Atrac3+ data.  This was true of one song I tested (well, 3.54x) so I figured it's a better estimate than 1x.
- Removes the log limiting.  Confuses debugging and no longer needed because games to hammer as much with better return data, and the separated console makes it less a problem anyway.
- Takes a stab at implementing `sceAtracGetLoopStatus()`.

This fixes:
- Legend of Heroes 1 - 3
- Exit (and probably Exit 2)
- Maybe Fat Princess in some modes (I hear more sounds now... still green.)
- Games that weren't breaking but were complaining to stdout.

-[Unknown]
