### PR TITLE
Fix crash with GE interrupts

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -47,6 +47,12 @@ public:
 		GeInterruptData intrdata = ge_pending_cb.front();
 		DisplayList* dl = gpu->getList(intrdata.listid);
 
+		if (dl == NULL)
+		{
+			WARN_LOG(HLE, "Unable to run GE interrupt: list doesn't exist: %d", intrdata.listid);
+			return false;
+		}
+
 		gpu->InterruptStart();
 
 		u32 cmd = Memory::ReadUnchecked_U32(intrdata.pc) >> 24;


### PR DESCRIPTION
Not sure if something changed (dlist-rewrite has pause/unpause I think?), but it crashed after merge.  This fixes it although it logs this warning quite a lot.

-[Unknown]
