### PR TITLE
Fix Qt interface compilation

### DIFF
--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -1,5 +1,5 @@
 TARGET = PPSSPPQt
-QT += core gui opengl
+QT += core gui opengl multimedia
 
 include(Settings.pri)
 linux {


### PR DESCRIPTION
Without "multimedia" compiler can't find required Qt Audio headers.
