### PR TITLE
Match the lighting/alpha logic in the sw transform

### DIFF
--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -292,7 +292,7 @@ void GenerateVertexShader(int prim, char *buffer) {
 		}
 		// TODO: Declare variables for dots for shade mapping if needed.
 
-		const char *ambient = (gstate.materialupdate & 1) ? "unlitColor" : "u_matambientalpha.rgb";
+		const char *ambient = (gstate.materialupdate & 1) ? (hasColor ? "a_color0" : "u_matambientalpha") : "vec4(u_matambient, 1.0)";
 		const char *diffuse = (gstate.materialupdate & 2) ? "unlitColor" : "u_matdiffuse";
 		const char *specular = (gstate.materialupdate & 4) ? "unlitColor" : "u_matspecular.rgb";
 
@@ -345,11 +345,7 @@ void GenerateVertexShader(int prim, char *buffer) {
 
 		if (gstate.lightingEnable & 1) {
 			// Sum up ambient, emissive here.
-			if (hasColor) {
-				WRITE(p, "  v_color0 = clamp(lightSum0 + u_ambient * vec4(%s, a_color0.a) + vec4(u_matemissive, 0.0), 0.0, 1.0);\n", ambient);
-			} else {
-				WRITE(p, "  v_color0 = clamp(lightSum0 + u_ambient * vec4(%s, u_matambientalpha.a) + vec4(u_matemissive, 0.0), 0.0, 1.0);\n", ambient);
-			}
+			WRITE(p, "  v_color0 = clamp(lightSum0 + u_ambient * %s + vec4(u_matemissive, 0.0), 0.0, 1.0);\n", ambient);
 			if (lmode) {
 				WRITE(p, "  v_color1 = clamp(lightSum1, 0.0, 1.0);\n");
 			} else {


### PR DESCRIPTION
This just makes the logic match the sw transform logic as far as I could tell.

Should be similar to #597, but handle a few cases more like sw does currently.

-[Unknown]
