### PR TITLE
[Qt-desktop] Make OpenGL always draw something, fix dialog crash.

### DIFF
--- a/Qt/EmuThread.h
+++ b/Qt/EmuThread.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QThread>
+#include <QMutex>
 #include "input/input_state.h"
 
 class QtEmuGL;
@@ -7,17 +8,27 @@ class QtEmuGL;
 class EmuThread : public QThread
 {
 public:
-	EmuThread() : running(false) {}
+	EmuThread() : running(false), gameRunning(false), needInitGame(false), frames_(0) {}
 	void init(InputState* inputState);
 	void run();
 	void FinalShutdown();
 	void setRunning(bool value);
+	void startGame(QString filename);
+	void stopGame();
+	QMutex gameMutex;
 public slots:
 	void Shutdown();
 private:
 	InputState* input_state;
 	bool running;
+	bool gameRunning;
+	bool needInitGame;
+	int frames_;
+
 };
 
-void EmuThread_Start(QString filename, QtEmuGL* w);
+void EmuThread_Start(QtEmuGL* w);
 void EmuThread_Stop();
+void EmuThread_StartGame(QString filename);
+void EmuThread_StopGame();
+void EmuThread_LockDraw(bool value);

--- a/Qt/controls.cpp
+++ b/Qt/controls.cpp
@@ -1,6 +1,8 @@
 #include "controls.h"
 #include "ui_controls.h"
 #include "Core/Config.h"
+#include "EmuThread.h"
+#include <QTimer>
 
 Controls_ controllist[] = {
 	{"Edit_Start",		"Start",			Qt::Key_1,		PAD_BUTTON_START,	CTRL_START},
@@ -43,6 +45,12 @@ Controls::~Controls()
 
 void Controls::showEvent(QShowEvent*)
 {
+#ifdef Q_WS_X11
+	// Hack to remove the X11 crash with threaded opengl when opening the first dialog
+	EmuThread_LockDraw(true);
+	QTimer::singleShot(100, this, SLOT(releaseLock()));
+#endif
+
 	for(int i = 0; i < controllistCount; i++)
 	{
 		if(g_Config.iMappingMap.find(i) != g_Config.iMappingMap.end())
@@ -60,6 +68,11 @@ void Controls::showEvent(QShowEvent*)
 			}
 		}
 	}
+}
+
+void Controls::releaseLock()
+{
+	EmuThread_LockDraw(false);
 }
 
 void Controls::on_buttonBox_accepted()

--- a/Qt/controls.h
+++ b/Qt/controls.h
@@ -32,6 +32,7 @@ public:
 
 	void showEvent(QShowEvent *);
 private slots:
+	void releaseLock();
 	void on_buttonBox_accepted();
 
 private:

--- a/Qt/gamepaddialog.cpp
+++ b/Qt/gamepaddialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_gamepaddialog.h"
 #include <QTimer>
 #include "Core/Config.h"
+#include "EmuThread.h"
 
 // Input
 struct GamePadInfo
@@ -94,6 +95,20 @@ GamePadDialog::~GamePadDialog()
 #endif
 
 	delete ui;
+}
+
+void GamePadDialog::showEvent(QShowEvent *)
+{
+#ifdef Q_WS_X11
+	// Hack to remove the X11 crash with threaded opengl when opening the first dialog
+	EmuThread_LockDraw(true);
+	QTimer::singleShot(100, this, SLOT(releaseLock()));
+#endif
+}
+
+void GamePadDialog::releaseLock()
+{
+	EmuThread_LockDraw(false);
 }
 
 void GamePadDialog::on_refreshListBtn_clicked()

--- a/Qt/gamepaddialog.h
+++ b/Qt/gamepaddialog.h
@@ -23,7 +23,10 @@ public:
 	void SetViewMode();
 	void SetCalibMode();
 	void CalibNextButton();
+protected:
+	void showEvent(QShowEvent *);
 private slots:
+	void releaseLock();
 	void on_refreshListBtn_clicked();
 
 	void on_SelectPadBtn_clicked();

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -55,16 +55,16 @@ MainWindow::MainWindow(QWidget *parent) :
 	if (zoom > 4) zoom = 4;
 	SetZoom(zoom);
 
+	EmuThread_Start(w);
+
 	if (!fileToStart.isNull())
 	{
 		SetPlaying(fileToStart);
 		//Update();
 		UpdateMenus();
 
-		EmuThread_Start(fileToStart, w);
+		EmuThread_StartGame(fileToStart);
 	}
-	else
-		BrowseAndBoot();
 
 	if (!fileToStart.isNull() && stateToLoad != NULL)
 		SaveState::Load(stateToLoad);
@@ -195,7 +195,7 @@ void MainWindow::BrowseAndBoot(void)
 	{
 		QFileInfo info(filename);
 		g_Config.currentDirectory = info.absolutePath().toStdString();
-		EmuThread_Start(filename, w);
+		EmuThread_StartGame(filename);
 	}
 }
 
@@ -324,7 +324,7 @@ void MainWindow::on_action_EmulationStop_triggered()
 		if (memoryWindow[i])
 			SendMessage(memoryWindow[i]->GetDlgHandle(), WM_CLOSE, 0, 0);*/
 
-	EmuThread_Stop();
+	EmuThread_StopGame();
 	SetPlaying(0);
 	//Update();
 	UpdateMenus();
@@ -485,6 +485,7 @@ void MainWindow::on_action_OptionsHardwareTransform_triggered()
 void MainWindow::on_action_FileExit_triggered()
 {
 	on_action_EmulationStop_triggered();
+	EmuThread_Stop();
 	QApplication::exit(0);
 }
 

--- a/Qt/qtemugl.cpp
+++ b/Qt/qtemugl.cpp
@@ -38,6 +38,28 @@ void QtEmuGL::stop_rendering()
 	thread.Shutdown();
 }
 
+void QtEmuGL::start_game(QString filename)
+{
+	thread.startGame(filename);
+}
+
+void QtEmuGL::stop_game()
+{
+	thread.stopGame();
+}
+
+void QtEmuGL::LockDraw(bool value)
+{
+	if(value)
+	{
+		thread.gameMutex.lock();
+	}
+	else
+	{
+		thread.gameMutex.unlock();
+	}
+}
+
 void QtEmuGL::resizeEvent(QResizeEvent *evt)
 {
 	// TODO

--- a/Qt/qtemugl.h
+++ b/Qt/qtemugl.h
@@ -16,6 +16,9 @@ public:
 
 	void start_rendering();
 	void stop_rendering();
+	void start_game(QString filename);
+	void stop_game();
+	void LockDraw(bool value);
 protected:
 	void initializeGL();
 

--- a/android/jni/MenuScreens.cpp
+++ b/android/jni/MenuScreens.cpp
@@ -451,6 +451,7 @@ static const char *credits[] =
 	"soywiz",
 	"kovensky",
 	"raven02",
+	"xele",
 	"",
 	"Written in C++ for speed and portability",
 	"",


### PR DESCRIPTION
Make OpenGL always draw something. Where there is no game, display the PPSSPP logo screen. Require ui_atlas in assets/ .
Add hack for X11 user which can have a crash when opening the first dialog and GL is drawing. The only way I found is to lock 100ms the GL display while the popup is shown.
Remove the "open file" dialog automatic display on startup, very annoying.
