### PR TITLE
Fix some file-related savestate issues

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -147,9 +147,10 @@ public:
 		p.Do(callbackID);
 		p.Do(callbackArg);
 		p.Do(asyncResult);
-		p.Do(closePending);
 		p.Do(pendingAsyncResult);
 		p.Do(sectorBlockMode);
+		p.Do(closePending);
+		p.Do(info);
 		p.Do(openMode);
 		p.DoMarker("File");
 	}

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -157,6 +157,7 @@ void __KernelDoState(PointerWrap &p)
 	p.DoMarker("KernelObjects");
 
 	__InterruptsDoState(p);
+	// Memory needs to be after kernel objects, which may free kernel memory.
 	__KernelMemoryDoState(p);
 	__KernelThreadingDoState(p);
 	__KernelAlarmDoState(p);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -77,9 +77,10 @@ namespace SaveState
 		Memory::DoState(p);
 		MemoryStick_DoState(p);
 		currentMIPS->DoState(p);
-		pspFileSystem.DoState(p);
 		HLEDoState(p);
 		__KernelDoState(p);
+		// Kernel object destructors might close open files, so do the filesystem last.
+		pspFileSystem.DoState(p);
 	}
 
 	void Enqueue(SaveState::Operation op)


### PR DESCRIPTION
Turned out not to be that hard to find.

Changes:
- A new member was added to files, now it's part of DoState() as well.
- The destructor for file kernel objects was closing handles, after the handles had been loaded.  Now the order is reversed.

This fixes savestates in Patchwork Heroes, and may fix #622.

-[Unknown]
