### PR TITLE
Use RemoveFile instead of DeleteFile in fs

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -31,9 +31,6 @@
 #endif
 
 
-#undef DeleteFile
-
-
 #if HOST_IS_CASE_SENSITIVE
 
 static bool FixFilenameCase(const std::string &path, std::string &filename)
@@ -248,7 +245,7 @@ bool DirectoryFileSystem::RenameFile(const std::string &from, const std::string 
 	return retValue;
 }
 
-bool DirectoryFileSystem::DeleteFile(const std::string &filename) {
+bool DirectoryFileSystem::RemoveFile(const std::string &filename) {
 	std::string fullName = GetLocalPath(filename);
 #ifdef _WIN32
 	bool retValue = (::DeleteFileA(fullName.c_str()) == TRUE);
@@ -266,7 +263,7 @@ bool DirectoryFileSystem::DeleteFile(const std::string &filename) {
 		fullName = GetLocalPath(fullName);
 
 #ifdef _WIN32
-		retValue = (::DeleteFile(fullName.c_str()) == TRUE);
+		retValue = (::DeleteFileA(fullName.c_str()) == TRUE);
 #else
 		retValue = (0 == unlink(fullName.c_str()));
 #endif

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -66,7 +66,7 @@ public:
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);
 	bool RenameFile(const std::string &from, const std::string &to);
-	bool DeleteFile(const std::string &filename);
+	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 
 private:

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -110,7 +110,7 @@ public:
 	virtual bool     MkDir(const std::string &dirname) = 0;
 	virtual bool     RmDir(const std::string &dirname) = 0;
 	virtual bool     RenameFile(const std::string &from, const std::string &to) = 0;
-	virtual bool     DeleteFile(const std::string &filename) = 0;
+	virtual bool     RemoveFile(const std::string &filename) = 0;
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 };
 
@@ -130,7 +130,7 @@ public:
 	virtual bool MkDir(const std::string &dirname) {return false;}
 	virtual bool RmDir(const std::string &dirname) {return false;}
 	virtual bool RenameFile(const std::string &from, const std::string &to) {return false;}
-	virtual bool DeleteFile(const std::string &filename) {return false;}
+	virtual bool RemoveFile(const std::string &filename) {return false;}
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 };
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -44,7 +44,7 @@ public:
 	virtual bool MkDir(const std::string &dirname) {return false;}
 	virtual bool RmDir(const std::string &dirname) {return false;}
 	virtual bool RenameFile(const std::string &from, const std::string &to) {return false;}
-	virtual bool DeleteFile(const std::string &filename) {return false;}
+	virtual bool RemoveFile(const std::string &filename) {return false;}
 
 private:
 	struct TreeEntry

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -363,13 +363,13 @@ bool MetaFileSystem::RenameFile(const std::string &from, const std::string &to)
 	}
 }
 
-bool MetaFileSystem::DeleteFile(const std::string &filename)
+bool MetaFileSystem::RemoveFile(const std::string &filename)
 {
 	std::string of;
 	IFileSystem *system;
 	if (MapFilePath(filename, of, &system))
 	{
-		return system->DeleteFile(of);
+		return system->RemoveFile(of);
 	}
 	else
 	{

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -89,7 +89,7 @@ public:
 	virtual bool MkDir(const std::string &dirname);
 	virtual bool RmDir(const std::string &dirname);
 	virtual bool RenameFile(const std::string &from, const std::string &to);
-	virtual bool DeleteFile(const std::string &filename);
+	virtual bool RemoveFile(const std::string &filename);
 
 	// TODO: void IoCtl(...)
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -17,7 +17,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#undef DeleteFile
 #endif
 
 #include "../Config.h"
@@ -552,7 +551,7 @@ u32 sceIoRemove(const char *filename) {
 	if(!pspFileSystem.GetFileInfo(filename).exists)
 		return ERROR_ERRNO_FILE_NOT_FOUND;
 
-	pspFileSystem.DeleteFile(filename);
+	pspFileSystem.RemoveFile(filename);
 	return 0;
 }
 


### PR DESCRIPTION
Windows defines DeleteFile to DeleteFileA/W, causing confusion.

Sorry, was my fault since I removed some includes.  Anyway, this fixes the debug build for me and matches sceIo<em>Remove</em> anyway.

Also I swapped one thing to ::DeleteFileA since it's using a c_str().

-[Unknown]
