### PR TITLE
Fix wrong drawing region in Digimon Re : Digitize

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -227,8 +227,8 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	int z_stride = gstate.zbwidth & 0x3C0;
 
 	// Yeah this is not completely right. but it'll do for now.
-	int drawing_width = ((gstate.region2) & 0x3FF) + 1;
-	int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
+	int drawing_width = ((gstate.region1) & 0x3FF) + 1;
+	int drawing_height = ((gstate.region1 >> 10) & 0x3FF) + 1;
 
 	// HACK for first frame where some games don't init things right
 	if (drawing_width == 1 && drawing_height == 1) {


### PR DESCRIPTION
This fixes wrong drawing region in Digimon Re : Digitize in buffered rendering mode : #619 
however oversize OSK not yet fixed 

Tested with following games and no broken .

MotoGP 
FF type-0
FF Crisis Core
Saint Seiya Omega
Fate Extra
Dragon Ball Evolution

![1](https://f.cloud.github.com/assets/3000282/142135/d76d6c9e-72c7-11e2-9d5c-b0feed907008.jpg)
