### PR TITLE
Improve texture and vertex caches

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -788,16 +788,20 @@ void TextureCache::SetTexture() {
 		} else {
 			INFO_LOG(G3D, "Texture different or overwritten, reloading at %08x", texaddr);
 			glDeleteTextures(1, &entry->texture);
+			if (entry->status == TexCacheEntry::STATUS_RELIABLE) {
+				entry->status = TexCacheEntry::STATUS_HASHING;
+			}
 		}
 	} else {
 		INFO_LOG(G3D,"No texture in cache, decoding...");
 		TexCacheEntry entryNew = {0};
 		cache[cachekey] = entryNew;
+
 		entry = &cache[cachekey];
+		entry->status = TexCacheEntry::STATUS_HASHING;
 	}
 
 	//we have to decode it
-	entry->status = TexCacheEntry::STATUS_HASHING;
 	entry->addr = texaddr;
 	entry->hash = texhash;
 	entry->format = format;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -64,7 +64,7 @@ void TextureCache::Clear(bool delete_them) {
 // Removes old textures.
 void TextureCache::Decimate() {
 	glBindTexture(GL_TEXTURE_2D, 0);
-	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ) {
+	for (TexCache::iterator iter = cache.begin(), end = cache.end(); iter != end; ) {
 		if (iter->second.frameCounter + TEXTURE_KILL_AGE < gpuStats.numFrames) {
 			glDeleteTextures(1, &iter->second.texture);
 			cache.erase(iter++);
@@ -78,7 +78,7 @@ void TextureCache::Invalidate(u32 addr, int size, bool force) {
 	addr &= 0xFFFFFFF;
 	u32 addr_end = addr + size;
 
-	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ) {
+	for (TexCache::iterator iter = cache.begin(), end = cache.end(); iter != end; ) {
 		u32 texAddr = iter->second.addr;
 		u32 texEnd = iter->second.addr + iter->second.sizeInRAM;
 		// Clear if either the addr or clutaddr is in the range.

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -49,7 +49,9 @@ private:
 		u32 hash;
 		FBO *fbo;  // if null, not sourced from an FBO.
 		u32 sizeInRAM;
-		int frameCounter;
+		int lastFrame;
+		int numFrames;
+		u32 framesUntilNextFullHash;
 		u8 format;
 		u8 clutformat;
 		u16 dim;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -45,6 +45,14 @@ public:
 private:
 	
 	struct TexCacheEntry {
+		enum Status {
+			STATUS_HASHING,
+			STATUS_RELIABLE,  // cache, don't hash
+			STATUS_UNRELIABLE,  // never cache
+		};
+
+		// Status, but int so we can zero initialize.
+		int status;
 		u32 addr;
 		u32 hash;
 		FBO *fbo;  // if null, not sourced from an FBO.
@@ -79,8 +87,6 @@ private:
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
 	typedef std::map<u64, TexCacheEntry> TexCache;
-
-	// TODO: Speed up by switching to ReadUnchecked*.
 	TexCache cache;
 
 	u32 *tmpTexBuf32;

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -55,9 +55,10 @@ public:
 		numDCs = 0;
 		prim = -1;
 		numDraws = 0;
+		numFrames = 0;
 		lastFrame = gpuStats.numFrames;
 		numVerts = 0;
-		drawsUntilNextFullHash = 0;
+		framesUntilNextFullHash = 0;
 	}
 	~VertexArrayInfo();
 	enum Status {
@@ -84,8 +85,9 @@ public:
 	// ID information
 	u8 numDCs;
 	int numDraws;
+	int numFrames;
 	int lastFrame;  // So that we can forget.
-	u16 drawsUntilNextFullHash;
+	u16 framesUntilNextFullHash;
 };
 
 


### PR DESCRIPTION
This does the following:
- Makes the vertex cache cache based on frames, not draws.  Fixes issues in Mimana, ClaDun, 30 Minute Hero, Patchwork Heroes, Senjou no Valkyria 3, Crystal Defenders, etc.
- Makes the texture cache use a similar system to the vertex cache (status, expontential backoff, really just based on what you did, hopefully as well.)
- No longer deletes textures on invalidate ever, only on decimate and when the hash actually fails.
- Hashes based on the w/h using bufw as a stride.

This fixes texture and vertex cache issues in the games I was seeing them in, and still seems to be pretty fast.

It's still not perfect.  In some games, the wrong texture will show for a few frames and then pop into place (similar problem to the vertex cache before.)  Before it was just never showing the right thing though, so this is an improvement.

I double-checked the speed using the FF Type-0 demo.  It's gotten faster recently and doesn't seem to have any noticeable slowdown from my changes.  Probably it could be more efficient, though.

-[Unknown]
