### PR TITLE
Always return a file descriptor in sceIoOpenAsync

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -891,9 +891,20 @@ u32 sceIoOpenAsync(const char *filename, int flags, int mode)
 {
 	DEBUG_LOG(HLE, "sceIoOpenAsync() sorta implemented");
 	u32 fd = sceIoOpen(filename, flags, mode);
+
 	// TODO: This can't actually have a callback yet, but if it's set before waiting, it should be called.
 	__IoCompleteAsyncIO(fd);
+
 	// We have to return an fd here, which may have been destroyed when we reach Wait if it failed.
+	if (fd == ERROR_ERRNO_FILE_NOT_FOUND)
+	{
+		FileNode *f = new FileNode();
+		fd = kernelObjects.Create(f);
+		f->handle = 0;
+		f->fullpath = filename;
+		f->asyncResult = ERROR_ERRNO_FILE_NOT_FOUND;
+	}
+
 	return fd;
 }
 


### PR DESCRIPTION
Fixes #646.  The game does a delay loop retrying as long as `sceIoOpenAsync()` returns < 0.  PSP seems to do the same.

With this, it seems to go in game.

-[Unknown]
