### PR TITLE
Improve readyqueue perf, rapid fire, small improvements

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1221,8 +1221,9 @@ u32 __KernelDeleteThread(SceUID threadID, int exitStatus, const char *reason, bo
 
 Thread *__KernelNextThread() {
 	// If the current thread is running, it's a valid candidate.
-	if (__GetCurrentThread() && __GetCurrentThread()->isRunning())
-		__KernelChangeReadyState(currentThread, true);
+	Thread *cur = __GetCurrentThread();
+	if (cur && cur->isRunning())
+		__KernelChangeReadyState(cur, currentThread, true);
 
 	SceUID bestThread = -1;
 	// This goes in priority order.

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -446,7 +446,7 @@ int g_inCbCount = 0;
 // Normally, the same as currentThread.  In an interrupt, remembers the callback's thread id.
 SceUID currentCallbackThreadID = 0;
 int readyCallbacksCount = 0;
-SceUID currentThread = 0;
+SceUID currentThread;
 u32 idleThreadHackAddr;
 u32 threadReturnHackAddr;
 u32 cbReturnHackAddr;
@@ -556,6 +556,7 @@ void __KernelThreadingInit()
 
 	dispatchEnabled = true;
 
+	currentThread = 0;
 	g_inCbCount = 0;
 	currentCallbackThreadID = 0;
 	readyCallbacksCount = 0;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1079,7 +1079,9 @@ void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 time
 void hleScheduledWakeup(u64 userdata, int cyclesLate)
 {
 	SceUID threadID = (SceUID)userdata;
-	__KernelTriggerWait(WAITTYPE_DELAY, threadID, "thread delay finished", true);
+	u32 error;
+	if (__KernelGetWaitID(threadID, WAITTYPE_DELAY, error) == threadID)
+		__KernelResumeThreadFromWait(threadID);
 }
 
 void __KernelScheduleWakeup(SceUID threadID, s64 usFromNow)

--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -26,8 +26,12 @@ static const unsigned short analog_ctrl_map[] = {
 };
 
 int KeyboardDevice::UpdateState() {
+	bool alternate = GetAsyncKeyState(VK_SHIFT) != 0;
+	static u32 alternator = 0;
+	bool doAlternate = alternate && (alternator++ % 10) < 5;
+
 	for (int i = 0; i < sizeof(key_ctrl_map)/sizeof(key_ctrl_map[0]); i += 2) {
-		if (!GetAsyncKeyState(key_ctrl_map[i]))
+		if (!GetAsyncKeyState(key_ctrl_map[i]) || doAlternate)
 			__CtrlButtonUp(key_ctrl_map[i+1]);
 		else {
 			__CtrlButtonDown(key_ctrl_map[i+1]);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -773,6 +773,7 @@ namespace MainWindow
 		"Analog Down\tK",
 		"Analog Left\tJ",
 		"Analog Right\tL",
+		"Rapid Fire\tShift",
 	};
 	// Message handler for about box.
 	LRESULT CALLBACK Controls(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
This does the following:
- Adds very basic rapid fire when holding shift (e.g. hold shift+tab+z.)  Windows keyboard only.
- Adds an atomic check variable around `MoveEvents()`, since they're rare.  I had trouble verifying this improved perf, but @KentuckyCompass's fps counter shows a reproducible improvement of maybe 2%.
- Moves threadReadyQueue back to a std::vector.  It did show up in profile, after all.  I opted to create a simple wrapper class.
- Avoids some slow runtime type casts / other minor stuff.

This significantly improves (mostly because of rapid fire, heh) the time it takes to get through the intro of Hexyz Force.  Overall, in game fps improvement by ~5% on Windows release once past the intro.

sceKernelThread.cpp is kinda big, I'm wondering if breaking callbacks and maybe some things out into another file is realistic... I guess it's not hurting anyone, though...

-[Unknown]
