### PR TITLE
Don't blacklist an invalidated texture forever

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -94,7 +94,9 @@ void TextureCache::Invalidate(u32 addr, int size, bool force) {
 			}
 			if (force) {
 				gpuStats.numTextureInvalidations++;
-				iter->second.status = TexCacheEntry::STATUS_UNRELIABLE;
+				// Start it over from 0.
+				iter->second.numFrames = 0;
+				iter->second.framesUntilNextFullHash = 0;
 			} else {
 				iter->second.invalidHint++;
 			}
@@ -771,6 +773,9 @@ void TextureCache::SetTexture() {
 				match = false;
 				gpuStats.numTextureInvalidations++;
 				entry->status = TexCacheEntry::STATUS_UNRELIABLE;
+				entry->numFrames = 0;
+			} else if (entry->status == TexCacheEntry::STATUS_UNRELIABLE && entry->numFrames > TexCacheEntry::FRAMES_REGAIN_TRUST) {
+				entry->status = TexCacheEntry::STATUS_HASHING;
 			}
 		}
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -45,6 +45,9 @@ public:
 private:
 	
 	struct TexCacheEntry {
+		// After marking STATUS_UNRELIABLE, if it stays the same this many frames we'll trust it again.
+		const static int FRAMES_REGAIN_TRUST = 1000;
+
 		enum Status {
 			STATUS_HASHING,
 			STATUS_RELIABLE,  // cache, don't hash


### PR DESCRIPTION
Adds a number of frames to "regain trust" for the texture, and doesn't set STATUS_UNRELIABLE on invalidate - just resets the numFrames / framesUntilNextFullHash.

FF Type-0:
Before texcache improvements: 42 fps
After texcache improvements (before this patch): 62 fps
With this patch: 75 fps

All with vsync disabled, Windows 32-bit Release.

-[Unknown]
