### PR TITLE
Put FPS on the right side to prevent overlap

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -242,9 +242,9 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
             float zoom = 0.3f; /// g_Config.iWindowZoom;
             float soff = 0.3f;
             PPGeBegin();
-            PPGeDrawText(stats, soff, soff, 0, zoom, 0xCC000000);
-            PPGeDrawText(stats, -soff, -soff, 0, zoom, 0xCC000000);
-            PPGeDrawText(stats, 0, 0, 0, zoom, 0xFFFFFFFF);
+            PPGeDrawText(stats, 478.0f + soff, soff, PPGE_ALIGN_RIGHT, zoom, 0xCC000000);
+            PPGeDrawText(stats, 478.0f + -soff, -soff, PPGE_ALIGN_RIGHT, zoom, 0xCC000000);
+            PPGeDrawText(stats, 478.0f + 0.0f, 0, PPGE_ALIGN_RIGHT, zoom, 0xFFFFFFFF);
             PPGeEnd();
         }
     }

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -249,16 +249,17 @@ static void PPGeMeasureText(const char *text, float scale, float *w, float *h) {
 	float maxw = 0;
 	int lines = 1;
 	while ((cval = *text++) != '\0') {
-		if (cval < 32) continue;
-		if (cval > 127) continue;
 		if (cval == '\n') {
 			if (wacc > maxw) maxw = wacc;
 			wacc = 0;
 			lines++;
 		}
+		if (cval < 32) continue;
+		if (cval > 127) continue;
 		AtlasChar c = atlasfont.chars[cval - 32];
 		wacc += c.wx * scale;
 	}
+	if (wacc > maxw) maxw = wacc;
 	if (w) *w = maxw;
 	if (h) *h = atlasfont.height * scale * lines;
 }


### PR DESCRIPTION
Also, fix `PPGeMeasureText()` to do that properly.

-[Unknown]
