### PR TITLE
Put FPS code into ShowFPS() and better approach to prevent FPS overlap when debug statistics shows 

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -180,6 +180,28 @@ void __DisplayFireVblank() {
 	}
 }
 
+float showFPS()
+{
+	static double highestFps = 0.0;
+	static int lastFpsFrame = 0;
+	static double lastFpsTime = 0.0;
+	static double fps = 0.0;
+        
+	time_update();
+	double now = time_now_d();
+
+	if (now >= lastFpsTime + 1.0)
+	{
+		fps = (gpuStats.numFrames - lastFpsFrame) / (now - lastFpsTime);
+		if (fps > highestFps)
+			highestFps = fps;
+
+		lastFpsFrame = gpuStats.numFrames;	
+		lastFpsTime = now;
+	}
+	return fps;
+}
+
 void hleEnterVblank(u64 userdata, int cyclesLate) {
 	int vbCount = userdata;
 
@@ -214,46 +236,13 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	// Draw screen overlays before blitting. Saves and restores the Ge context.
 	gpuStats.numFrames++;
 
-    if (g_Config.bShowFPSCounter)
-    {
-        static double highestFps = 0.0;
-        static int lastFpsFrame = 0;
-        static double lastFpsTime = 0.0;
-        static double fps = 0.0;
-        {
-            time_update();
-            double now = time_now_d();
-
-            if (now >= lastFpsTime + 1.0)
-            {
-                fps = (gpuStats.numFrames - lastFpsFrame) / (now - lastFpsTime);
-
-                if (fps > highestFps)
-                    highestFps = fps;
-
-                lastFpsFrame = gpuStats.numFrames;
-                lastFpsTime = now;
-            }
-
-            char stats[2048];
-
-            sprintf(stats, "FPS: %f\nRecord high FPS: %f", fps, highestFps);
-
-            float zoom = 0.3f; /// g_Config.iWindowZoom;
-            float soff = 0.3f;
-            PPGeBegin();
-            PPGeDrawText(stats, 478.0f + soff, soff, PPGE_ALIGN_RIGHT, zoom, 0xCC000000);
-            PPGeDrawText(stats, 478.0f + -soff, -soff, PPGE_ALIGN_RIGHT, zoom, 0xCC000000);
-            PPGeDrawText(stats, 478.0f + 0.0f, 0, PPGE_ALIGN_RIGHT, zoom, 0xFFFFFFFF);
-            PPGeEnd();
-        }
-    }
-
 	// Now we can subvert the Ge engine in order to draw custom overlays like stat counters etc.
 	if (g_Config.bShowDebugStats && gpuStats.numDrawCalls) {
 		gpu->UpdateStats();
 		char stats[2048];
+		
 		sprintf(stats,
+			"FPS: %0.1f\n"
 			"Frames: %i\n"
 			"DL processing time: %0.2f ms\n"
 			"Kernel processing time: %0.2f ms\n"
@@ -271,6 +260,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 			"Vertex shaders loaded: %i\n"
 			"Fragment shaders loaded: %i\n"
 			"Combined shaders loaded: %i\n",
+			showFPS(),
 			gpuStats.numFrames,
 			gpuStats.msProcessingDisplayLists * 1000.0f,
 			kernelStats.msInSyscalls * 1000.0f,
@@ -304,6 +294,20 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 
 		gpuStats.resetFrame();
 		kernelStats.ResetFrame();
+	}
+
+	if (g_Config.bShowFPSCounter) {
+		char stats[50];
+
+		sprintf(stats, "FPS: %0.1f", showFPS());
+
+		float zoom = 0.3f; /// g_Config.iWindowZoom;
+		float soff = 0.3f;
+		PPGeBegin();
+		PPGeDrawText(stats, soff, soff, 0, zoom, 0xCC000000);
+		PPGeDrawText(stats, -soff, -soff, 0, zoom, 0xCC000000);
+		PPGeDrawText(stats, 0, 0, 0, zoom, 0xFFFFFFFF);
+		PPGeEnd();
 	}
 
 	// Yeah, this has to be the right moment to end the frame. Give the graphics backend opportunity

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -180,7 +180,7 @@ void __DisplayFireVblank() {
 	}
 }
 
-float showFPS()
+float calculateFPS()
 {
 	static double highestFps = 0.0;
 	static int lastFpsFrame = 0;
@@ -260,7 +260,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 			"Vertex shaders loaded: %i\n"
 			"Fragment shaders loaded: %i\n"
 			"Combined shaders loaded: %i\n",
-			showFPS(),
+			calculateFPS(),
 			gpuStats.numFrames,
 			gpuStats.msProcessingDisplayLists * 1000.0f,
 			kernelStats.msInSyscalls * 1000.0f,
@@ -299,7 +299,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	if (g_Config.bShowFPSCounter) {
 		char stats[50];
 
-		sprintf(stats, "FPS: %0.1f", showFPS());
+		sprintf(stats, "FPS: %0.1f", calculateFPS());
 
 		float zoom = 0.3f; /// g_Config.iWindowZoom;
 		float soff = 0.3f;


### PR DESCRIPTION
1. put FPS code into ShowFPS()
2. add FPS counter to debug statistics as well and should be useful during debug.
3. prevent FPS counter from overlapping :)  
