### PR TITLE
Add option to set AnisotropyLevel , make default 4 

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -67,6 +67,7 @@ void CConfig::Load(const char *iniFileName)
 	graphics->Get("LinearFiltering", &bLinearFiltering, false);
 	graphics->Get("SSAA", &SSAntiAliasing, 0);
 	graphics->Get("VBO", &bUseVBO, false);
+	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 4);
 	graphics->Get("DisableG3DLog", &bDisableG3DLog, false);
 	graphics->Get("VertexCache", &bVertexCache, true);
 	graphics->Get("FullScreen", &bFullScreen, false);	
@@ -123,6 +124,7 @@ void CConfig::Save()
 		graphics->Set("LinearFiltering", bLinearFiltering);
 		graphics->Set("SSAA", SSAntiAliasing);
 		graphics->Set("VBO", bUseVBO);
+		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("DisableG3DLog", bDisableG3DLog);
 		graphics->Set("VertexCache", bVertexCache);
 		graphics->Set("FullScreen", bFullScreen);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -62,6 +62,7 @@ public:
 	bool bDisableG3DLog;
 	bool bVertexCache;
 	bool bFullScreen;
+	int iAnisotropyLevel;
 
 	// Sound
 	bool bEnableSound;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -26,6 +26,7 @@
 
 // If a texture hasn't been seen for 200 frames, get rid of it.
 #define TEXTURE_KILL_AGE 200
+float maxAnisotropyLevel ;
 
 TextureCache::TextureCache() {
 	// TODO: Switch to aligned allocations for alignment. AllocateMemoryPages would do the trick.
@@ -35,6 +36,7 @@ TextureCache::TextureCache() {
 	tmpTexBufRearrange = new u32[1024 * 512];   // 2MB
 	clutBuf32 = new u32[4096];  // 4K
 	clutBuf16 = new u16[4096];  // 4K
+	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropyLevel);
 }
 
 TextureCache::~TextureCache() {
@@ -857,7 +859,9 @@ void TextureCache::SetTexture() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, entry->maxLevel);
 #endif
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)entry->maxLevel);
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 4.0);
+	float anisotropyLevel = (float) g_Config.iAnisotropyLevel > maxAnisotropyLevel ? maxAnisotropyLevel : (float) g_Config.iAnisotropyLevel;
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropyLevel );
+	// NOTICE_LOG(G3D,"AnisotropyLevel = %0.1f , MaxAnisotropyLevel = %0.1f ", anisotropyLevel, maxAnisotropyLevel );
 
 	UpdateSamplingParams(*entry, true);
 


### PR DESCRIPTION
Hope this help those weak GPU to turn this off by setting AnisotropyLevel = 0 and for desktop , should be able to set AnisotropyLevel = 16 without performance impact  Issue #628 
