### PR TITLE
Undisable the vertex hash backoff

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -921,7 +921,7 @@ void TransformDrawEngine::Flush() {
 					u32 dataHash = ComputeHash();
 					vai->hash = dataHash;
 					vai->status = VertexArrayInfo::VAI_HASHING;
-					vai->framesUntilNextFullHash = 0;
+					vai->drawsUntilNextFullHash = 0;
 					DecodeVerts(); // writes to indexGen
 					goto rotateVBO;
 				}
@@ -934,10 +934,10 @@ void TransformDrawEngine::Flush() {
 					if (vai->lastFrame != gpuStats.numFrames) {
 						vai->numFrames++;
 					}
-					if (vai->framesUntilNextFullHash == 0) {
+					if (vai->drawsUntilNextFullHash == 0) {
 						u32 newHash = ComputeHash();
-						// exponential backoff up to 16 frames
-						vai->framesUntilNextFullHash = std::min(16, vai->numFrames);
+						// exponential backoff up to 16 draws, then every 24
+						vai->drawsUntilNextFullHash = std::min(24, vai->numFrames);
 						// TODO: tweak
 						//if (vai->numFrames > 1000) {
 						//	vai->status = VertexArrayInfo::VAI_RELIABLE;
@@ -956,7 +956,7 @@ void TransformDrawEngine::Flush() {
 							goto rotateVBO;
 						}
 					} else {
-						vai->framesUntilNextFullHash--;
+						vai->drawsUntilNextFullHash--;
 						// TODO: "mini-hashing" the first 32 bytes of the vertex/index data or something.
 					}
 

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -936,12 +936,6 @@ void TransformDrawEngine::Flush() {
 					}
 					if (vai->drawsUntilNextFullHash == 0) {
 						u32 newHash = ComputeHash();
-						// exponential backoff up to 16 draws, then every 24
-						vai->drawsUntilNextFullHash = std::min(24, vai->numFrames);
-						// TODO: tweak
-						//if (vai->numFrames > 1000) {
-						//	vai->status = VertexArrayInfo::VAI_RELIABLE;
-						//}
 						if (newHash != vai->hash) {
 							vai->status = VertexArrayInfo::VAI_UNRELIABLE;
 							if (vai->vbo) {
@@ -955,6 +949,17 @@ void TransformDrawEngine::Flush() {
 							DecodeVerts();
 							goto rotateVBO;
 						}
+						if (vai->numVerts > 100) {
+							// exponential backoff up to 16 draws, then every 24
+							vai->drawsUntilNextFullHash = std::min(24, vai->numFrames);
+						} else {
+							// Lower numbers seem much more likely to change.
+							vai->status = VertexArrayInfo::VAI_UNRELIABLE;
+						}
+						// TODO: tweak
+						//if (vai->numFrames > 1000) {
+						//	vai->status = VertexArrayInfo::VAI_RELIABLE;
+						//}
 					} else {
 						vai->drawsUntilNextFullHash--;
 						// TODO: "mini-hashing" the first 32 bytes of the vertex/index data or something.

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -954,7 +954,7 @@ void TransformDrawEngine::Flush() {
 							vai->drawsUntilNextFullHash = std::min(24, vai->numFrames);
 						} else {
 							// Lower numbers seem much more likely to change.
-							vai->status = VertexArrayInfo::VAI_UNRELIABLE;
+							vai->drawsUntilNextFullHash = 0;
 						}
 						// TODO: tweak
 						//if (vai->numFrames > 1000) {

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -913,7 +913,6 @@ void TransformDrawEngine::Flush() {
 				vai->decFmt = dec.GetDecVtxFmt();
 				vai_[id] = vai;
 			}
-			vai->lastFrame = gpuStats.numFrames;
 
 			switch (vai->status) {
 			case VertexArrayInfo::VAI_NEW:
@@ -1025,6 +1024,8 @@ void TransformDrawEngine::Flush() {
 					goto rotateVBO;
 				}
 			}
+
+			vai->lastFrame = gpuStats.numFrames;
 		} else {
 			DecodeVerts();
 rotateVBO:

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -58,7 +58,7 @@ public:
 		numFrames = 0;
 		lastFrame = gpuStats.numFrames;
 		numVerts = 0;
-		framesUntilNextFullHash = 0;
+		drawsUntilNextFullHash = 0;
 	}
 	~VertexArrayInfo();
 	enum Status {
@@ -87,7 +87,7 @@ public:
 	int numDraws;
 	int numFrames;
 	int lastFrame;  // So that we can forget.
-	u16 framesUntilNextFullHash;
+	u16 drawsUntilNextFullHash;
 };
 
 


### PR DESCRIPTION
Well, my previous change just broke it which is why it fixed it for me.  numFrames was never being incremented.

I tried a few different things, and it ended up that vertices with < 100 frames are just more likely to abruptly change in some games (mostly ui or sprite sheets.)  Since I had a bunch with hundreds and thousands, I'm hoping those are the ones that are better to cache, anyway?

But maybe I should use `dec.GetDecVtxFmt().stride` instead, or a combination thereof...

Anyway, this fixes it without the glitches while retaining 80% of the performance improvement, so it's at least better than current.  I think it could be improved more.

-[Unknown]
