### PR TITLE
Cut down on rescheduling in sceGeListEnqueue

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -112,8 +112,13 @@ void __GeShutdown()
 
 }
 
-void __GeTriggerInterrupt(int listid, u32 pc, u32 subIntrBase, u16 subIntrToken)
+void __GeTriggerInterrupt(int listid, u32 pc, int subIntrBase, u16 subIntrToken)
 {
+	// ClaDun X2 does not expect sceGeListEnqueue to reschedule (which it does not on the PSP.)
+	// Once PPSSPP's GPU is multithreaded, we can remove this check.
+	if (subIntrBase < 0)
+		return;
+
 	GeInterruptData intrdata;
 	intrdata.listid = listid;
 	intrdata.pc     = pc;

--- a/Core/HLE/sceGe.h
+++ b/Core/HLE/sceGe.h
@@ -39,7 +39,7 @@ void Register_sceGe_user();
 void __GeInit();
 void __GeDoState(PointerWrap &p);
 void __GeShutdown();
-void __GeTriggerInterrupt(int listid, u32 pc, u32 subIntrBase, u16 subIntrToken);
+void __GeTriggerInterrupt(int listid, u32 pc, int subIntrBase, u16 subIntrToken);
 bool __GeHasPendingInterrupt();
 
 


### PR DESCRIPTION
Fixes ClaDun X2.  On the real PSP, it seems like this function should never reschedule (callback or not), although it might reschedule later.  ClaDun X2 breaks if it reschedules when it passes -1 (meaning, no signal callback.)

This is a bit of a hack but it should be a safe one.  Might possibly help other games.

-[Unknown]
