### PR TITLE
Add GE_CMD_COLORTEST to DirtyUniform(DIRTY_ALPHACOLORREF)

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -841,6 +841,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_COLORREF:
+	case GE_CMD_COLORTEST:
 	case GE_CMD_ALPHATEST:
 		shaderManager_->DirtyUniform(DIRTY_ALPHACOLORREF);
 		break;


### PR DESCRIPTION
This corresponds to 

```
if (u_alphacolorref != -1 && (dirtyUniforms & DIRTY_ALPHACOLORREF)) {
    SetColorUniform3Alpha(u_alphacolorref, gstate.colortest, (gstate.alphatest >> 8) & 0xFF);
```

@hrydgard  , do we need if (diff) before shaderManager_->DirtyUniform(DIRTY_ALPHACOLORREF); ?
