### PR TITLE
Clear the shader ids when clearing the cache

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -351,6 +351,7 @@ void ShaderManager::Clear() {
 	fsCache.clear();
 	vsCache.clear();
 	globalDirty = 0xFFFFFFFF;
+	DirtyShader();
 }
 
 void ShaderManager::ClearCache(bool deleteThem)


### PR DESCRIPTION
Hit this while mashing F2.  I don't know this code much, but I crashed on `lastShader->dirtyUniforms |= globalDirty;` so it seems right to clear those here.

-[Unknown]
