### PR TITLE
Set VertexReader's vtype_ to prevent oddness

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -454,7 +454,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 	float fog_end = getFloat24(gstate.fog1);
 	float fog_slope = getFloat24(gstate.fog2);
 
-	VertexReader reader(decoded, decVtxFormat);
+	VertexReader reader(decoded, decVtxFormat, vertType);
 	for (int index = 0; index < maxIndex; index++) {
 		reader.Goto(index);
 

--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -186,7 +186,7 @@ public:
 class VertexReader
 {
 public:
-	VertexReader(u8 *base, const DecVtxFormat &decFmt) : base_(base), data_(base), decFmt_(decFmt) {}
+	VertexReader(u8 *base, const DecVtxFormat &decFmt, int vtype) : base_(base), data_(base), decFmt_(decFmt), vtype_(vtype) {}
 
 	void ReadPos(float pos[3]) {
 		switch (decFmt_.posfmt) {


### PR DESCRIPTION
This was causing debug builds never to render textures correctly, and I think it was causing issues on some mobile devices.  Hard to say what/when and could cause some of the strange regressions from the texture cache changes potentially.

See also 6b3ddae5545fe64262b907bb08941b599b50023d, vtype_ wasn't used before this commit AFAICT.

-[Unknown]
