### PR TITLE
Flush vfpu prefixes, initial implementation of VecDo3

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -35,6 +35,11 @@ namespace MIPSComp
 		DISABLE;
 	}
 
+	void Jit::Comp_VecDo3(u32 op)
+	{
+		DISABLE;
+	}
+
 	void Jit::Comp_Mftv(u32 op)
 	{
 		DISABLE;

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -110,6 +110,7 @@ public:
 	void Comp_SVQ(u32 op);
 	void Comp_VPFX(u32 op);
 	void Comp_VDot(u32 op);
+	void Comp_VecDo3(u32 op);
 	void Comp_Mftv(u32 op);
 	void Comp_Vmtvc(u32 op);
 

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -478,17 +478,17 @@ const MIPSInstruction tableCop1BC[32] =
 
 const MIPSInstruction tableVFPU0[8] = 
 {
-	INSTR("vadd",&Jit::Comp_Generic, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
-	INSTR("vsub",&Jit::Comp_Generic, Dis_VectorSet3, Int_VecDo3, IS_VFPU), 
+	INSTR("vadd",&Jit::Comp_VecDo3, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
+	INSTR("vsub",&Jit::Comp_VecDo3, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
 	INSTR("vsbn",&Jit::Comp_Generic, Dis_VectorSet3, Int_Vsbn, IS_VFPU), 
 	{-2}, {-2}, {-2}, {-2}, 
 	
-	INSTR("vdiv",&Jit::Comp_Generic, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
+	INSTR("vdiv",&Jit::Comp_VecDo3, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
 };
 
 const MIPSInstruction tableVFPU1[8] = 
 {
-	INSTR("vmul",&Jit::Comp_Generic, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
+	INSTR("vmul",&Jit::Comp_VecDo3, Dis_VectorSet3, Int_VecDo3, IS_VFPU),
 	INSTR("vdot",&Jit::Comp_VDot, Dis_VectorDot, Int_VDot, IS_VFPU), 
 	INSTR("vscl",&Jit::Comp_Generic, Dis_VScl, Int_VScl, IS_VFPU),
 	{-2},

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -363,11 +363,11 @@ const MIPSInstruction tableCop2[32] =
 	INSTR("mfc2", &Jit::Comp_Generic, Dis_Generic, 0, OUT_RT),
 	{-2},
 	INSTR("cfc2", &Jit::Comp_Generic, Dis_Generic, 0, 0),
-	INSTR("mfv", &Jit::Comp_Mftv, Dis_Mftv, Int_Mftv, 0),
+	INSTR("mfv", &Jit::Comp_Mftv, Dis_Mftv, Int_Mftv, IS_VFPU),
 	INSTR("mtc2", &Jit::Comp_Generic, Dis_Generic, 0, IN_RT),
 	{-2},
 	INSTR("ctc2", &Jit::Comp_Generic, Dis_Generic, 0, 0),
-	INSTR("mtv", &Jit::Comp_Mftv, Dis_Mftv, Int_Mftv, 0),
+	INSTR("mtv", &Jit::Comp_Mftv, Dis_Mftv, Int_Mftv, IS_VFPU),
 
 	{Cop2BC2},
 	INSTR("??", &Jit::Comp_Generic, Dis_Generic, 0, 0),

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -32,9 +32,9 @@ using namespace MIPSAnalyst;
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
 
-//#define CONDITIONAL_DISABLE Comp_Generic(op); return;
+//#define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
-#define DISABLE Comp_Generic(op); return;
+#define DISABLE { Comp_Generic(op); return; }
 
 namespace MIPSComp
 {

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -34,9 +34,9 @@
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
 
-// #define CONDITIONAL_DISABLE Comp_Generic(op); return;
+// #define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
-#define DISABLE Comp_Generic(op); return;
+#define DISABLE { Comp_Generic(op); return; }
 
 namespace MIPSComp
 {

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -35,9 +35,9 @@
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
 
-// #define CONDITIONAL_DISABLE Comp_Generic(op); return;
+// #define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
-#define DISABLE Comp_Generic(op); return;
+#define DISABLE { Comp_Generic(op); return; }
 
 namespace MIPSComp
 {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -28,9 +28,9 @@
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
 
-// #define CONDITIONAL_DISABLE Comp_Generic(op); return;
+// #define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
-#define DISABLE Comp_Generic(op); return;
+#define DISABLE { Comp_Generic(op); return; }
 
 
 #define _RS ((op>>21) & 0x1F)
@@ -202,8 +202,7 @@ void Jit::Comp_SV(u32 op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
-		break;
+		DISABLE;
 	}
 }
 
@@ -381,8 +380,6 @@ void Jit::Comp_Mftv(u32 op) {
 
 	default:
 		DISABLE;
-		_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
-		break;
 	}
 }
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -288,7 +288,13 @@ void Jit::Comp_SVQ(u32 op)
 
 void Jit::Comp_VDot(u32 op) {
 	DISABLE;
+
 	// WARNING: No prefix support!
+	if (js.MayHavePrefix()) {
+		Comp_Generic(op);
+		js.EatPrefix();
+		return;
+	}
 
 	int vd = _VD;
 	int vs = _VS;
@@ -306,7 +312,6 @@ void Jit::Comp_VDot(u32 op) {
 	MOVSS(XMM0, fpr.V(sregs[0]));
 	MULSS(XMM0, fpr.V(tregs[0]));
 
-	float sum = 0.0f;
 	int n = GetNumVectorElements(sz);
 	for (int i = 1; i < n; i++)
 	{

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -420,7 +420,7 @@ void Jit::Comp_Mftv(u32 op) {
 				MOV(32, gpr.R(rt), fpr.V(imm));
 			} else if (imm < 128 + VFPU_CTRL_MAX) { //mtvc
 				// In case we have a saved prefix.
-				FlushAll();
+				FlushPrefixV();
 				gpr.BindToRegister(rt, false, true);
 				MOV(32, gpr.R(rt), M(&currentMIPS->vfpuCtrl[imm - 128]));
 			} else {

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -109,6 +109,34 @@ void Jit::FlushAll()
 {
 	gpr.Flush();
 	fpr.Flush();
+	FlushPrefixV();
+}
+
+void Jit::FlushPrefixV()
+{
+	if ((js.prefixSFlag & JitState::PREFIX_DIRTY) != 0)
+	{
+		MOV(32, M((void *)&mips_->vfpuCtrl[VFPU_CTRL_SPREFIX]), Imm32(js.prefixS));
+		js.prefixSFlag = (JitState::PrefixState) (js.prefixSFlag & ~JitState::PREFIX_DIRTY);
+	}
+
+	if ((js.prefixTFlag & JitState::PREFIX_DIRTY) != 0)
+	{
+		MOV(32, M((void *)&mips_->vfpuCtrl[VFPU_CTRL_TPREFIX]), Imm32(js.prefixT));
+		js.prefixTFlag = (JitState::PrefixState) (js.prefixTFlag & ~JitState::PREFIX_DIRTY);
+	}
+
+	if ((js.prefixDFlag & JitState::PREFIX_DIRTY) != 0)
+	{
+		MOV(32, M((void *)&mips_->vfpuCtrl[VFPU_CTRL_DPREFIX]), Imm32(js.prefixD));
+
+		_dbg_assert_msg_(JIT, sizeof(bool) <= 4, "Bools shouldn't be that big?");
+		const size_t bool_stride = 4 / sizeof(bool);
+		for (size_t i = 0; i < ARRAY_SIZE(mips_->vfpuWriteMask); i += bool_stride)
+			MOV(32, M((void *)&mips_->vfpuWriteMask[i]), Imm32(*(u32 *)&js.writeMask[i]));
+
+		js.prefixDFlag = (JitState::PrefixState) (js.prefixDFlag & ~JitState::PREFIX_DIRTY);
+	}
 }
 
 void Jit::WriteDowncount(int offset)

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -287,6 +287,10 @@ void Jit::Comp_Generic(u32 op)
 	}
 	else
 		_dbg_assert_msg_(JIT, 0, "Trying to compile instruction that can't be interpreted");
+
+	// Might have eaten prefixes, hard to tell...
+	if ((MIPSGetInfo(op) & IS_VFPU) != 0)
+		js.PrefixStart();
 }
 
 void Jit::WriteExit(u32 destination, int exit_num)

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -78,6 +78,17 @@ struct JitState
 		prefixTFlag = PREFIX_UNKNOWN;
 		prefixDFlag = PREFIX_UNKNOWN;
 	}
+	bool MayHavePrefix() const {
+		if (!(prefixSFlag & PREFIX_KNOWN) || !(prefixTFlag & PREFIX_KNOWN) || !(prefixDFlag & PREFIX_KNOWN)) {
+			return true;
+		} else if (prefixS != 0xE4 || prefixT != 0xE4 || prefixD != 0) {
+			return true;
+		} else if (writeMask[0] || writeMask[1] || writeMask[2] || writeMask[3]) {
+			return true;
+		}
+
+		return false;
+	}
 	void EatPrefix() {
 		if ((prefixSFlag & PREFIX_KNOWN) == 0 || prefixS != 0xE4) {
 			prefixSFlag = PREFIX_KNOWN_DIRTY;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -165,6 +165,7 @@ public:
 	void Comp_SVQ(u32 op);
 	void Comp_VPFX(u32 op);
 	void Comp_VDot(u32 op);
+	void Comp_VecDo3(u32 op);
 	void Comp_Mftv(u32 op);
 	void Comp_Vmtvc(u32 op);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -48,6 +48,14 @@ struct JitOptions
 
 struct JitState
 {
+	enum PrefixState
+	{
+		PREFIX_UNKNOWN = 0x00,
+		PREFIX_KNOWN = 0x01,
+		PREFIX_DIRTY = 0x10,
+		PREFIX_KNOWN_DIRTY = 0x11,
+	};
+
 	u32 compilerPC;
 	u32 blockStart;
 	bool cancel;
@@ -62,22 +70,28 @@ struct JitState
 	u32 prefixT;
 	u32 prefixD;
 	bool writeMask[4];
-	bool prefixSKnown;
-	bool prefixTKnown;
-	bool prefixDKnown;
+	PrefixState prefixSFlag;
+	PrefixState prefixTFlag;
+	PrefixState prefixDFlag;
 	void PrefixStart() {
-		prefixSKnown = false;
-		prefixTKnown = false;
-		prefixDKnown = false;
+		prefixSFlag = PREFIX_UNKNOWN;
+		prefixTFlag = PREFIX_UNKNOWN;
+		prefixDFlag = PREFIX_UNKNOWN;
 	}
 	void EatPrefix() {
-		prefixSKnown = true;
-		prefixTKnown = true;
-		prefixDKnown = true;
-		prefixS = 0xE4;
-		prefixT = 0xE4;
-		prefixD = 0x0;
-		writeMask[0] = writeMask[1] = writeMask[2] = writeMask[3] = false;
+		if ((prefixSFlag & PREFIX_KNOWN) == 0 || prefixS != 0xE4) {
+			prefixSFlag = PREFIX_KNOWN_DIRTY;
+			prefixS = 0xE4;
+		}
+		if ((prefixTFlag & PREFIX_KNOWN) == 0 || prefixT != 0xE4) {
+			prefixTFlag = PREFIX_KNOWN_DIRTY;
+			prefixT = 0xE4;
+		}
+		if ((prefixDFlag & PREFIX_KNOWN) == 0 || prefixD != 0x0 || writeMask[0] || writeMask[1] || writeMask[2] || writeMask[3]) {
+			prefixDFlag = PREFIX_KNOWN_DIRTY;
+			prefixD = 0x0;
+			writeMask[0] = writeMask[1] = writeMask[2] = writeMask[3] = false;
+		}
 	}
 };
 
@@ -155,6 +169,7 @@ public:
 	void ClearCacheAt(u32 em_address);
 private:
 	void FlushAll();
+	void FlushPrefixV();
 	void WriteDowncount(int offset = 0);
 
 	// See CompileDelaySlotFlags for flags.


### PR DESCRIPTION
This implements a dirty flag for prefixes and conservatively assumes a `Comp_Generic()` with `IS_VFPU` might or might not eat prefixes (therefore they are unknown after the call.)

It also implements a probably-not-very-fast VecDo3, and makes it and VDot bail if prefixes aren't known or if they have some effect.

So far it works (it didn't when I was accidentally using `.R()`, heh), but I'm planning to write something to generate tests for each of these.  I left them both disabled for now in case there are issues.

-[Unknown]
