### PR TITLE
Small VFPU prefix fixes

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1183,6 +1183,7 @@ namespace MIPSInt
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		float scale = V(vt);
+		ApplySwizzleT(&scale, V_Single);
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -110,6 +110,11 @@ void ApplyPrefixST(float *v, u32 data, VectorSize size)
 
 		if (!constants)
 		{
+			// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
+			// TODO: But some ops seem to use const 0 instead?
+			if (regnum >= n)
+				regnum = 0;
+
 			v[i] = origV[regnum];
 			if (abs)
 				v[i] = fabs(v[i]);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -150,7 +150,8 @@ void ApplyPrefixD(float *v, VectorSize size, bool onlyWriteMask = false)
 			if (sat == 1)
 			{
 				if (v[i] > 1.0f) v[i] = 1.0f;
-				if (v[i] < 0.0f) v[i] = 0.0f;
+				// This includes -0.0f -> +0.0f.
+				if (v[i] <= 0.0f) v[i] = 0.0f;
 			}
 			else if (sat == 3)
 			{

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -87,6 +87,7 @@ void Jit::ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz) {
 
 	for (int i = 0; i < n; i++)
 	{
+		// TODO: This needs to be the original values, not the original regs. (e.g. [-x, |x|, x])
 		origV[i] = vregs[i];
 	}
 
@@ -98,6 +99,11 @@ void Jit::ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz) {
 		int constants = (prefix >> (12+i)) & 1;
 
 		if (!constants) {
+			// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
+			// TODO: But some ops seem to use const 0 instead?
+			if (regnum > n) {
+				regnum = 0;
+			}
 			vregs[i] = origV[regnum];
 			if (abs) {
 				ANDPS(fpr.VX(vregs[i]), M((void *)&noSignMask));


### PR DESCRIPTION
The main one being clamping vd to 0:1 should clamp to +0 not -0.  I'm not sure what `MAXSS` does but it's not being used yet and there's a test when it is.

Also a small stack overflow if swizzle is used wrong, which probably never happens.

-[Unknown]
