### PR TITLE
Copy over temp fpu regs, enable VecDo3/VDot

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -113,7 +113,10 @@ void ApplyPrefixST(float *v, u32 data, VectorSize size)
 			// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
 			// TODO: But some ops seem to use const 0 instead?
 			if (regnum >= n)
+			{
+				ERROR_LOG(CPU, "Invalid VFPU swizzle: %08x / %d", data, size);
 				regnum = 0;
+			}
 
 			v[i] = origV[regnum];
 			if (abs)
@@ -1185,7 +1188,11 @@ namespace MIPSInt
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		float scale = V(vt);
-		ApplySwizzleT(&scale, V_Single);
+		if (currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX] != 0xE4)
+		{
+			WARN_LOG(CPU, "Broken T prefix used with VScl: %08x / %08x", currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX], op);
+			ApplySwizzleT(&scale, V_Single);
+		}
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -310,7 +310,7 @@ void Jit::Comp_SVQ(u32 op)
 }
 
 void Jit::Comp_VDot(u32 op) {
-	DISABLE;
+	CONDITIONAL_DISABLE;
 
 	// WARNING: No prefix support!
 	if (js.MayHavePrefix()) {
@@ -357,7 +357,7 @@ void Jit::Comp_VDot(u32 op) {
 }
 
 void Jit::Comp_VecDo3(u32 op) {
-	DISABLE;
+	CONDITIONAL_DISABLE;
 
 	// WARNING: No prefix support!
 	if (js.MayHavePrefix())

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -49,7 +49,7 @@ namespace MIPSComp
 
 static const float one = 1.0f;
 static const float minus_one = -1.0f;
-static const float zero = -1.0f;
+static const float zero = 0.0f;
 
 const u32 GC_ALIGNED16( noSignMask[4] ) = {0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF};
 const u32 GC_ALIGNED16( signBitLower[4] ) = {0x80000000, 0, 0, 0};
@@ -341,9 +341,10 @@ void Jit::Comp_VDot(u32 op) {
 		tempxreg = fpr.VX(dregs[0]);
 	}
 
-	if (!fpr.V(sregs[0]).IsSimpleReg(tempxreg))
-		MOVSS(tempxreg, fpr.V(sregs[0]));
-	MULSS(tempxreg, fpr.V(tregs[0]));
+	MOVSS(tempxreg, M((void *) &zero));
+	MOVSS(XMM1, fpr.V(sregs[0]));
+	MULSS(XMM1, fpr.V(tregs[0]));
+	ADDSS(tempxreg, R(XMM1));
 
 	for (int i = 1; i < n; i++)
 	{

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -97,7 +97,9 @@ void FPURegCache::BindToRegister(const int i, bool doLoad, bool makeDirty) {
 			if (!regs[i].location.IsImm() && (regs[i].location.offset & 0x3)) {
 				PanicAlert("WARNING - misaligned fp register location %i", i);
 			}
-			emit->MOVSS(xr, regs[i].location);
+			if (i < TEMP0) {
+				emit->MOVSS(xr, regs[i].location);
+			}
 		}
 		regs[i].location = newloc;
 		regs[i].away = true;
@@ -124,8 +126,24 @@ void FPURegCache::StoreFromRegister(int i) {
 	}
 }
 
+void FPURegCache::DiscardR(int i)
+{
+	_assert_msg_(DYNA_REC, !regs[i].location.IsImm(), "FPU can't handle imm yet.");
+	if (regs[i].away) {
+		X64Reg xr = regs[i].location.GetSimpleReg();
+		_assert_msg_(DYNA_REC, xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
+		// Note that we DO NOT write it back here. That's the whole point of Discard.
+		xregs[xr].dirty = false;
+		xregs[xr].mipsReg = -1;
+		regs[i].location = GetDefaultLocation(i);
+		regs[i].away = false;
+	} else {
+		//	_assert_msg_(DYNA_REC,0,"already stored");
+	}
+}
+
 void FPURegCache::Flush() {
-	for (int i = 0; i < NUM_MIPS_FPRS; i++) {
+	for (int i = 0; i < TEMP0; i++) {
 		if (regs[i].locked) {
 			PanicAlert("Somebody forgot to unlock MIPS reg %i.", i);
 		}
@@ -140,6 +158,9 @@ void FPURegCache::Flush() {
 				_assert_msg_(DYNA_REC,0,"Jit64 - Flush unhandled case, reg %i PC: %08x", i, mips->pc);
 			}
 		}
+	}
+	for (int i = TEMP0; i < TEMP0 + NUM_TEMPS; ++i) {
+		DiscardR(i);
 	}
 }
 
@@ -189,6 +210,15 @@ X64Reg FPURegCache::GetFreeXReg() {
 	}
 	//Okay, not found :( Force grab one
 
+	// Maybe a temp reg?
+	for (int i = TEMP0; i < NUM_MIPS_FPRS; ++i) {
+		if (regs[i].away && !regs[i].locked) {
+			X64Reg xr = regs[i].location.GetSimpleReg();
+			DiscardR(i);
+			return xr;
+		}
+	}
+
 	//TODO - add a pass to grab xregs whose mipsreg is not used in the next 3 instructions
 	for (int i = 0; i < aCount; i++) {
 		X64Reg xr = (X64Reg)aOrder[i];
@@ -203,7 +233,7 @@ X64Reg FPURegCache::GetFreeXReg() {
 	return (X64Reg) -1;
 }
 
-void FPURegCache::FlushR(X64Reg reg) {
+void FPURegCache::FlushX(X64Reg reg) {
 	if (reg >= NUM_X_FPREGS)
 		PanicAlert("Flushing non existent reg");
 	if (xregs[reg].mipsReg != -1) {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -28,7 +28,14 @@ using namespace Gen;
 // GPRs are numbered 0 to 31
 // VFPU regs are numbered 32 to 160.
 
-#define NUM_MIPS_FPRS (32 + 128)
+enum {
+	NUM_TEMPS = 4,
+	TEMP0 = 32 + 128,
+	TEMP1 = TEMP0 + 1,
+	TEMP2 = TEMP0 + 2,
+	TEMP3 = TEMP0 + 3,
+	NUM_MIPS_FPRS = 32 + 128 + NUM_TEMPS,
+};
 
 #ifdef _M_X64
 #define NUM_X_FPREGS 16
@@ -68,6 +75,7 @@ public:
 		StoreFromRegister(preg + 32);
 	}
 	OpArg GetDefaultLocation(int reg) const;
+	void DiscardR(int preg);
 
 	void SetEmitter(XEmitter *emitter) {emit = emitter;}
 
@@ -100,6 +108,9 @@ public:
 	void MapRegV(int vreg, int flags);
 	void MapRegsV(int vec, VectorSize vsz, int flags);
 	void MapRegsV(const u8 *v, VectorSize vsz, int flags);
+	void SpillLockV(int vreg) {
+		SpillLock(vreg + 32);
+	}
 	void SpillLockV(const u8 *v, VectorSize vsz);
 	void SpillLockV(int vec, VectorSize vsz);
 
@@ -107,7 +118,7 @@ public:
 
 private:
 	X64Reg GetFreeXReg();
-	void FlushR(X64Reg reg); 
+	void FlushX(X64Reg reg);
 	const int *GetAllocationOrder(int &count);
 
 	MIPSCachedFPReg regs[NUM_MIPS_FPRS];

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -26,7 +26,8 @@ using namespace Gen;
 
 
 // GPRs are numbered 0 to 31
-// VFPU regs are numbered 32 to 160.
+// VFPU regs are numbered 32 to 159.
+// Then we have some temp regs for VFPU handling from 160 to 167.
 
 enum {
 	NUM_TEMPS = 4,
@@ -34,6 +35,7 @@ enum {
 	TEMP1 = TEMP0 + 1,
 	TEMP2 = TEMP0 + 2,
 	TEMP3 = TEMP0 + 3,
+	TEMP4 = TEMP0 + 4,
 	NUM_MIPS_FPRS = 32 + 128 + NUM_TEMPS,
 };
 
@@ -75,7 +77,11 @@ public:
 		StoreFromRegister(preg + 32);
 	}
 	OpArg GetDefaultLocation(int reg) const;
-	void DiscardR(int preg);
+	void DiscardR(int freg);
+	void DiscardV(int vreg) {
+		DiscardR(vreg + 32);
+	}
+	bool IsTemp(X64Reg xreg);
 
 	void SetEmitter(XEmitter *emitter) {emit = emitter;}
 


### PR DESCRIPTION
They seem to work, they don't make Bink any less happy, and it should be a bit faster (even though it's not running much right now due to prefixes being unknown most of the time.)

Probably need to expand it to 8 - or worse 12, maybe avoidable - to enable prefixes.  And then just have a DefaultLocation as a temporary place for them and allow memory swapping?

-[Unknown]
