### PR TITLE
Remove fast interpreter option

### DIFF
--- a/Qt/EmuThread.cpp
+++ b/Qt/EmuThread.cpp
@@ -185,7 +185,7 @@ void EmuThread::run()
 				coreParameter.fileToStart = fileToStart.toStdString();
 				coreParameter.enableSound = true;
 				coreParameter.gpuCore = GPU_GLES;
-				coreParameter.cpuCore = (CPUCore)g_Config.iCpuCore;
+				coreParameter.cpuCore = g_Config.bJit ? CPU_JIT : CPU_INTERPRETER;
 				coreParameter.enableDebugging = true;
 				coreParameter.printfEmuLog = false;
 				coreParameter.headLess = false;

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -109,15 +109,11 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 				gfxLog = true;
 				break;
 			case 'j':
-				g_Config.iCpuCore = CPU_JIT;
-				g_Config.bSaveSettings = false;
-				break;
-			case 'f':
-				g_Config.iCpuCore = CPU_FASTINTERPRETER;
+				g_Config.bJit = true;
 				g_Config.bSaveSettings = false;
 				break;
 			case 'i':
-				g_Config.iCpuCore = CPU_INTERPRETER;
+				g_Config.bJit = false;
 				g_Config.bSaveSettings = false;
 				break;
 			case 'l':
@@ -231,9 +227,8 @@ void MainWindow::UpdateMenus()
 {
 	ui->action_OptionsDisplayRawFramebuffer->setChecked(g_Config.bDisplayFramebuffer);
 	ui->action_OptionsIgnoreIllegalReadsWrites->setChecked(g_Config.bIgnoreBadMemAccess);
-	ui->action_CPUInterpreter->setChecked(g_Config.iCpuCore == CPU_INTERPRETER);
-	ui->action_CPUFastInterpreter->setChecked(g_Config.iCpuCore == CPU_FASTINTERPRETER);
-	ui->action_CPUDynarec->setChecked(g_Config.iCpuCore == CPU_JIT);
+	ui->action_CPUInterpreter->setChecked(!g_Config.bJit);
+	ui->action_CPUDynarec->setChecked(g_Config.bJit);
 	ui->action_OptionsBufferedRendering->setChecked(g_Config.bBufferedRendering);
 	ui->action_OptionsShowDebugStatistics->setChecked(g_Config.bShowDebugStats);
 	ui->action_OptionsWireframe->setChecked(g_Config.bDrawWireframe);
@@ -518,19 +513,13 @@ void MainWindow::on_action_FileExit_triggered()
 
 void MainWindow::on_action_CPUDynarec_triggered()
 {
-	g_Config.iCpuCore = CPU_JIT;
+	g_Config.bJit = true;
 	UpdateMenus();
 }
 
 void MainWindow::on_action_CPUInterpreter_triggered()
 {
-	g_Config.iCpuCore = CPU_INTERPRETER;
-	UpdateMenus();
-}
-
-void MainWindow::on_action_CPUFastInterpreter_triggered()
-{
-	g_Config.iCpuCore = CPU_FASTINTERPRETER;
+	g_Config.bJit = false;
 	UpdateMenus();
 }
 

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -81,8 +81,6 @@ private slots:
 
 	void on_action_CPUInterpreter_triggered();
 
-	void on_action_CPUFastInterpreter_triggered();
-
 	void on_action_DebugLoadMapFile_triggered();
 
 	void on_action_DebugSaveMapFile_triggered();

--- a/Qt/mainwindow.ui
+++ b/Qt/mainwindow.ui
@@ -180,7 +180,6 @@
       <string>&amp;Core</string>
      </property>
      <addaction name="action_CPUInterpreter"/>
-     <addaction name="action_CPUFastInterpreter"/>
      <addaction name="action_CPUDynarec"/>
      <addaction name="separator"/>
      <addaction name="action_OptionsFastMemory"/>
@@ -287,14 +286,6 @@
    </property>
    <property name="text">
     <string>&amp;Interpreter</string>
-   </property>
-  </action>
-  <action name="action_CPUFastInterpreter">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Slightly Faster Interpreter</string>
    </property>
   </action>
   <action name="action_CPUDynarec">


### PR DESCRIPTION
I didn't update .ts files, because I want you to decide what to do with line numbers in them which changed once again. In issue #689 I wrote what I'll do with them and I'd like to know what others think.

Sorry for second pull request, I don't know how to change that in-place.
