### PR TITLE
Focus the main window when showing the log

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -161,6 +161,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	}
 	// else
 	//	MainWindow::BrowseAndBoot();
+	if (!hideLog)
+		SetForegroundWindow(hwndMain);
 
 	if (fileToStart != NULL && stateToLoad != NULL)
 		SaveState::Load(stateToLoad);


### PR DESCRIPTION
Just a small tweak to raise the main window on startup when using `-l`, which I always use.  It's annoying to switch back manually.

-[Unknown]
