### PR TITLE
Jit known prefix support

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -145,27 +145,22 @@ inline void ApplySwizzleT(float *v, VectorSize size)
 void ApplyPrefixD(float *v, VectorSize size, bool onlyWriteMask = false)
 {
 	u32 data = currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX];
-	if (!data)
+	if (!data || onlyWriteMask)
 		return;
 	int n = GetNumVectorElements(size);
-	bool writeMask[4];
 	for (int i = 0; i < n; i++)
 	{
-		int mask = (data >> (8 + i)) & 1;
-		writeMask[i] = mask ? true : false;
-		if (!onlyWriteMask) {
-			int sat = (data >> (i * 2)) & 3;
-			if (sat == 1)
-			{
-				if (v[i] > 1.0f) v[i] = 1.0f;
-				// This includes -0.0f -> +0.0f.
-				if (v[i] <= 0.0f) v[i] = 0.0f;
-			}
-			else if (sat == 3)
-			{
-				if (v[i] > 1.0f)  v[i] = 1.0f;
-				if (v[i] < -1.0f) v[i] = -1.0f;
-			}
+		int sat = (data >> (i * 2)) & 3;
+		if (sat == 1)
+		{
+			if (v[i] > 1.0f) v[i] = 1.0f;
+			// This includes -0.0f -> +0.0f.
+			if (v[i] <= 0.0f) v[i] = 0.0f;
+		}
+		else if (sat == 3)
+		{
+			if (v[i] > 1.0f)  v[i] = 1.0f;
+			if (v[i] < -1.0f) v[i] = -1.0f;
 		}
 	}
 }

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -431,6 +431,7 @@ void Jit::Comp_VecDo3(u32 op) {
 
 	if (xmmop == NULL)
 	{
+		fpr.ReleaseSpillLocks();
 		Comp_Generic(op);
 		return;
 	}

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -69,7 +69,6 @@ struct JitState
 	u32 prefixS;
 	u32 prefixT;
 	u32 prefixD;
-	bool writeMask[4];
 	PrefixState prefixSFlag;
 	PrefixState prefixTFlag;
 	PrefixState prefixDFlag;
@@ -83,7 +82,7 @@ struct JitState
 			return true;
 		} else if (prefixS != 0xE4 || prefixT != 0xE4 || prefixD != 0) {
 			return true;
-		} else if (writeMask[0] || writeMask[1] || writeMask[2] || writeMask[3]) {
+		} else if (VfpuWriteMask() != 0) {
 			return true;
 		}
 
@@ -104,11 +103,18 @@ struct JitState
 			prefixTFlag = PREFIX_KNOWN_DIRTY;
 			prefixT = 0xE4;
 		}
-		if ((prefixDFlag & PREFIX_KNOWN) == 0 || prefixD != 0x0 || writeMask[0] || writeMask[1] || writeMask[2] || writeMask[3]) {
+		if ((prefixDFlag & PREFIX_KNOWN) == 0 || prefixD != 0x0 || VfpuWriteMask() != 0) {
 			prefixDFlag = PREFIX_KNOWN_DIRTY;
 			prefixD = 0x0;
-			writeMask[0] = writeMask[1] = writeMask[2] = writeMask[3] = false;
 		}
+	}
+	u8 VfpuWriteMask() const {
+		_assert_(prefixDFlag & JitState::PREFIX_KNOWN);
+		return (prefixD >> 8) & 0xF;
+	}
+	bool VfpuWriteMask(int i) const {
+		_assert_(prefixDFlag & JitState::PREFIX_KNOWN);
+		return (prefixD >> (8 + i)) & 1;
 	}
 };
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -79,7 +79,7 @@ struct JitState
 		prefixDFlag = PREFIX_UNKNOWN;
 	}
 	bool MayHavePrefix() const {
-		if (!(prefixSFlag & PREFIX_KNOWN) || !(prefixTFlag & PREFIX_KNOWN) || !(prefixDFlag & PREFIX_KNOWN)) {
+		if (HasUnknownPrefix()) {
 			return true;
 		} else if (prefixS != 0xE4 || prefixT != 0xE4 || prefixD != 0) {
 			return true;
@@ -87,6 +87,12 @@ struct JitState
 			return true;
 		}
 
+		return false;
+	}
+	bool HasUnknownPrefix() const {
+		if (!(prefixSFlag & PREFIX_KNOWN) || !(prefixTFlag & PREFIX_KNOWN) || !(prefixDFlag & PREFIX_KNOWN)) {
+			return true;
+		}
 		return false;
 	}
 	void EatPrefix() {

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -184,7 +184,18 @@ public:
 	void Comp_DoNothing(u32 op);
 
 	void ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz);
-	void ApplyPrefixD(const u8 *vregs, u32 prefix, VectorSize sz, bool onlyWriteMask = false);
+	void ApplyPrefixD(const u8 *vregs, VectorSize sz);
+	void GetVectorRegsPrefixS(u8 *regs, VectorSize sz, int vectorReg) {
+		_assert_(js.prefixSFlag & JitState::PREFIX_KNOWN);
+		GetVectorRegs(regs, sz, vectorReg);
+		ApplyPrefixST(regs, js.prefixS, sz);
+	}
+	void GetVectorRegsPrefixT(u8 *regs, VectorSize sz, int vectorReg) {
+		_assert_(js.prefixTFlag & JitState::PREFIX_KNOWN);
+		GetVectorRegs(regs, sz, vectorReg);
+		ApplyPrefixST(regs, js.prefixT, sz);
+	}
+	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);
 	void EatPrefix() { js.EatPrefix(); }
 
 	JitBlockCache *GetBlockCache() { return &blocks; }

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -27,6 +27,7 @@ FPURegCache::FPURegCache() : emit(0), mips(0) {
 	memset(regs, 0, sizeof(regs));
 	memset(xregs, 0, sizeof(xregs));
 	vregs = regs + 32;
+	tempRoundRobin = 0;
 }
 
 void FPURegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
@@ -153,7 +154,9 @@ bool FPURegCache::IsTempX(X64Reg xr) {
 }
 
 int FPURegCache::GetTempR() {
-	for (int r = TEMP0; r < TEMP0 + NUM_TEMPS; ++r) {
+	for (int i = 0; i < NUM_TEMPS; ++i) {
+		// Make sure we don't give out the same one over and over, even if not locked.
+		int r = TEMP0 + (tempRoundRobin++ + i) % NUM_TEMPS;
 		if (!regs[r].away) {
 			return r;
 		}

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -148,8 +148,19 @@ void FPURegCache::DiscardR(int i) {
 	}
 }
 
-bool FPURegCache::IsTemp(X64Reg xr) {
+bool FPURegCache::IsTempX(X64Reg xr) {
 	return xregs[xr].mipsReg >= TEMP0;
+}
+
+int FPURegCache::GetTempR() {
+	for (int r = TEMP0; r < TEMP0 + NUM_TEMPS; ++r) {
+		if (!regs[r].away) {
+			return r;
+		}
+	}
+
+	_assert_msg_(DYNA_REC, 0, "Regcache ran out of temp regs, might need to DiscardR() some.");
+	return -1;
 }
 
 void FPURegCache::Flush() {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -27,22 +27,14 @@ using namespace Gen;
 
 // GPRs are numbered 0 to 31
 // VFPU regs are numbered 32 to 159.
-// Then we have some temp regs for VFPU handling from 160 to 171.
+// Then we have some temp regs for VFPU handling from 160 to 175.
+
+// Temp regs: 4 from S prefix, 4 from T prefix, 4 from D mask, and 4 for work (worst case.)
+// But most of the time prefixes aren't used that heavily so we won't use all of them.
 
 enum {
-	NUM_TEMPS = 12,
+	NUM_TEMPS = 16,
 	TEMP0 = 32 + 128,
-	TEMP1 = TEMP0 + 1,
-	TEMP2 = TEMP0 + 2,
-	TEMP3 = TEMP0 + 3,
-	TEMP4 = TEMP0 + 4,
-	TEMP5 = TEMP0 + 5,
-	TEMP6 = TEMP0 + 6,
-	TEMP7 = TEMP0 + 7,
-	TEMP8 = TEMP0 + 8,
-	TEMP9 = TEMP0 + 9,
-	TEMP10 = TEMP0 + 10,
-	TEMP11 = TEMP0 + 11,
 	NUM_MIPS_FPRS = 32 + 128 + NUM_TEMPS,
 };
 
@@ -148,6 +140,7 @@ private:
 
 	// TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
 	static u32 tempValues[NUM_TEMPS];
+	int tempRoundRobin;
 
 	XEmitter *emit;
 };

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -27,14 +27,22 @@ using namespace Gen;
 
 // GPRs are numbered 0 to 31
 // VFPU regs are numbered 32 to 159.
-// Then we have some temp regs for VFPU handling from 160 to 167.
+// Then we have some temp regs for VFPU handling from 160 to 171.
 
 enum {
-	NUM_TEMPS = 4,
+	NUM_TEMPS = 12,
 	TEMP0 = 32 + 128,
 	TEMP1 = TEMP0 + 1,
 	TEMP2 = TEMP0 + 2,
 	TEMP3 = TEMP0 + 3,
+	TEMP4 = TEMP0 + 4,
+	TEMP5 = TEMP0 + 5,
+	TEMP6 = TEMP0 + 6,
+	TEMP7 = TEMP0 + 7,
+	TEMP8 = TEMP0 + 8,
+	TEMP9 = TEMP0 + 9,
+	TEMP10 = TEMP0 + 10,
+	TEMP11 = TEMP0 + 11,
 	NUM_MIPS_FPRS = 32 + 128 + NUM_TEMPS,
 };
 
@@ -108,6 +116,7 @@ public:
 
 	// Register locking. Prevents them from being spilled.
 	void SpillLock(int p1, int p2=0xff, int p3=0xff, int p4=0xff);
+	void ReleaseSpillLock(int mipsrega);
 	void ReleaseSpillLocks();
 
 	void MapRegV(int vreg, int flags);
@@ -129,6 +138,9 @@ private:
 	MIPSCachedFPReg regs[NUM_MIPS_FPRS];
 	X64CachedFPReg xregs[NUM_X_FPREGS];
 	MIPSCachedFPReg *vregs;
+
+	// TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
+	static u32 tempValues[NUM_TEMPS];
 
 	XEmitter *emit;
 };

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -88,7 +88,11 @@ public:
 	void DiscardV(int vreg) {
 		DiscardR(vreg + 32);
 	}
-	bool IsTemp(X64Reg xreg);
+	bool IsTempX(X64Reg xreg);
+	int GetTempR();
+	int GetTempV() {
+		return GetTempR() - 32;
+	}
 
 	void SetEmitter(XEmitter *emitter) {emit = emitter;}
 
@@ -127,6 +131,9 @@ public:
 	}
 	void SpillLockV(const u8 *v, VectorSize vsz);
 	void SpillLockV(int vec, VectorSize vsz);
+	void ReleaseSpillLockV(int vreg) {
+		ReleaseSpillLock(vreg + 32);
+	}
 
 	MIPSState *mips;
 

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -53,6 +53,8 @@ struct MIPSCachedFPReg {
 	OpArg location;
 	bool away;  // value not in source register
 	bool locked;
+	// Only for temp regs.
+	bool tempLocked;
 };
 
 enum {
@@ -140,7 +142,6 @@ private:
 
 	// TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
 	static u32 tempValues[NUM_TEMPS];
-	int tempRoundRobin;
 
 	XEmitter *emit;
 };


### PR DESCRIPTION
This makes known prefixes work.  I mucked around a lot in the FPR cache, hope the changes are okay.

It does what's simple:
- Adds 16 temp regs just in case (need 4 for each of S and T, 4 to make D masks easy, and +4 in case an instruction needs them.)
- Since there's more than 6, adds a way to store the regs temporarily if they're swapped out.  Probably could be optimized to not swap them out if possible better.
- Uses temp regs for S/T modified values.
- Uses temp regs for D masked values (seemed like the easiest way.)

Tested a bunch of permutations of prefixes/regs and seems to work great (at least as well as the interpreter.)

-[Unknown]
