### PR TITLE
Assume prefixes start as default until proven wrong

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -45,8 +45,11 @@ MIPSState::MIPSState()
 
 MIPSState::~MIPSState()
 {
-	delete MIPSComp::jit;
-	MIPSComp::jit = 0;
+	if (MIPSComp::jit)
+	{
+		delete MIPSComp::jit;
+		MIPSComp::jit = 0;
+	}
 }
 
 void MIPSState::Reset()
@@ -107,6 +110,8 @@ void MIPSState::DoState(PointerWrap &p)
 	// Reset the jit if we're loading.
 	if (p.mode == p.MODE_READ)
 		Reset();
+	if (MIPSComp::jit)
+		MIPSComp::jit->DoState(p);
 
 	p.DoArray(r, sizeof(r) / sizeof(r[0]));
 	p.DoArray(f, sizeof(f) / sizeof(f[0]));

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -147,22 +147,22 @@ const MIPSInstruction tableImmediate[64] =  //xxxxxx .....
 	//48
 	INSTR("ll", &Jit::Comp_Generic, Dis_Generic, Int_StoreSync, 0),
 	INSTR("lwc1", &Jit::Comp_FPULS, Dis_FPULS, Int_FPULS, IN_RT|IN_RS_ADDR),
-	INSTR("lv.s", &Jit::Comp_SV, Dis_SV, Int_SV, IS_VFPU),
+	INSTR("lv.s", &Jit::Comp_SV, Dis_SV, Int_SV, IS_VFPU|VFPU_NO_PREFIX),
 	{-2}, // HIT THIS IN WIPEOUT
 	{VFPU4Jump},
-	INSTR("lv", &Jit::Comp_SVQ, Dis_SVLRQ, Int_SVQ, IS_VFPU),
-	INSTR("lv.q", &Jit::Comp_SVQ, Dis_SVQ, Int_SVQ, IS_VFPU), //copU
+	INSTR("lv", &Jit::Comp_SVQ, Dis_SVLRQ, Int_SVQ, IS_VFPU|VFPU_NO_PREFIX),
+	INSTR("lv.q", &Jit::Comp_SVQ, Dis_SVQ, Int_SVQ, IS_VFPU|VFPU_NO_PREFIX), //copU
 	{VFPU5},
 	//56
 	INSTR("sc", &Jit::Comp_Generic, Dis_Generic, Int_StoreSync, 0),
 	INSTR("swc1", &Jit::Comp_FPULS, Dis_FPULS, Int_FPULS, 0), //copU
-	INSTR("sv.s", &Jit::Comp_SV, Dis_SV, Int_SV,IS_VFPU),
+	INSTR("sv.s", &Jit::Comp_SV, Dis_SV, Int_SV,IS_VFPU|VFPU_NO_PREFIX),
 	{-2}, 
 	//60
 	{VFPU6},
-	INSTR("sv", &Jit::Comp_SVQ, Dis_SVLRQ, Int_SVQ, IS_VFPU), //copU
-	INSTR("sv.q", &Jit::Comp_SVQ, Dis_SVQ, Int_SVQ, IS_VFPU),
-	INSTR("vflush", &Jit::Comp_Generic, Dis_Vflush, Int_Vflush, IS_VFPU),
+	INSTR("sv", &Jit::Comp_SVQ, Dis_SVLRQ, Int_SVQ, IS_VFPU|VFPU_NO_PREFIX), //copU
+	INSTR("sv.q", &Jit::Comp_SVQ, Dis_SVQ, Int_SVQ, IS_VFPU|VFPU_NO_PREFIX),
+	INSTR("vflush", &Jit::Comp_Generic, Dis_Vflush, Int_Vflush, IS_VFPU|VFPU_NO_PREFIX),
 };
 
 const MIPSInstruction tableSpecial[64] = /// 000000 ...... ...... .......... xxxxxx

--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -45,6 +45,7 @@
 #define OUT_FPUFLAG     0x02000000
 #define OUT_EAT_PREFIX  0x04000000
 
+#define VFPU_NO_PREFIX  0x08000000
 #define IS_VFPU         0x80000000
 
 #ifndef CDECL

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -303,10 +303,13 @@ void Jit::Comp_Generic(u32 op)
 	else
 		_dbg_assert_msg_(JIT, 0, "Trying to compile instruction that can't be interpreted");
 
-	// Might have eaten prefixes, hard to tell...
 	const int info = MIPSGetInfo(op);
-	if ((info & IS_VFPU) != 0 && (info & OUT_EAT_PREFIX) == 0)
-		js.PrefixUnknown();
+	if ((info & IS_VFPU) != 0 && (info & VFPU_NO_PREFIX) == 0)
+	{
+		// If it does eat them, it'll happen in MIPSCompileOp().
+		if ((info & OUT_EAT_PREFIX) == 0)
+			js.PrefixUnknown();
+	}
 }
 
 void Jit::WriteExit(u32 destination, int exit_num)

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include "Common/ChunkFile.h"
 #include "../../Core.h"
 #include "../../CoreTiming.h"
 #include "../../Config.h"
@@ -103,6 +104,15 @@ Jit::Jit(MIPSState *mips) : blocks(mips), mips_(mips)
 	gpr.SetEmitter(this);
 	fpr.SetEmitter(this);
 	AllocCodeSpace(1024 * 1024 * 16);
+
+	// TODO: If it becomes possible to switch from the interpreter, this should be set right.
+	js.startDefaultPrefix = true;
+}
+
+void Jit::DoState(PointerWrap &p)
+{
+	p.Do(js.startDefaultPrefix);
+	p.DoMarker("Jit");
 }
 
 void Jit::FlushAll()
@@ -202,6 +212,17 @@ void Jit::Compile(u32 em_address)
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);
 	blocks.FinalizeBlock(block_num, jo.enableBlocklink, DoJit(em_address, b));
+
+	// Drat.  The VFPU hit an uneaten prefix at the end of a block.
+	if (js.startDefaultPrefix && js.MayHavePrefix())
+	{
+		js.startDefaultPrefix = false;
+		// Our assumptions are all wrong so it's clean-slate time.
+		ClearCache();
+
+		// Let's try that one more time.  We won't get back here because we toggled the value.
+		Compile(em_address);
+	}
 }
 
 void Jit::RunLoopUntil(u64 globalticks)
@@ -285,7 +306,7 @@ void Jit::Comp_Generic(u32 op)
 	// Might have eaten prefixes, hard to tell...
 	const int info = MIPSGetInfo(op);
 	if ((info & IS_VFPU) != 0 && (info & OUT_EAT_PREFIX) == 0)
-		js.PrefixStart();
+		js.PrefixUnknown();
 }
 
 void Jit::WriteExit(u32 destination, int exit_num)

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -66,6 +66,7 @@ struct JitState
 	JitBlock *curBlock;
 
 	// VFPU prefix magic
+	bool startDefaultPrefix;
 	u32 prefixS;
 	u32 prefixT;
 	u32 prefixD;
@@ -73,6 +74,13 @@ struct JitState
 	PrefixState prefixTFlag;
 	PrefixState prefixDFlag;
 	void PrefixStart() {
+		if (startDefaultPrefix) {
+			EatPrefix();
+		} else {
+			PrefixUnknown();
+		}
+	}
+	void PrefixUnknown() {
 		prefixSFlag = PREFIX_UNKNOWN;
 		prefixTFlag = PREFIX_UNKNOWN;
 		prefixDFlag = PREFIX_UNKNOWN;
@@ -134,6 +142,7 @@ class Jit : public Gen::XCodeBlock
 {
 public:
 	Jit(MIPSState *mips);
+	void DoState(PointerWrap &p);
 
 	// Compiled ops should ignore delay slots
 	// the compiler will take care of them by itself


### PR DESCRIPTION
You meant like this, right?

Right now, since it doesn't have many flags, it'll blow the cache once the first time it hits a vfpu op.  The ones I've set flags on I've all tested to make sure they actually do/don't take prefixes.

It won't blow the cache if it hits (vfpu without flag) -> vmov.q -> branch, because the vmov will eat prefixes.  Now it's just a matter of marking the rest and implementing more.

-[Unknown]
