### PR TITLE
More x86 jit stuff

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -145,7 +145,12 @@ namespace MIPSComp
 			break;
 		}
 	}
-	
+
+	void Jit::Comp_RType2(u32 op)
+	{
+		DISABLE;
+	}
+
 	void Jit::Comp_RType3(u32 op)
 	{
 		int rt = _RT;

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -94,6 +94,7 @@ public:
 	void Comp_Break(u32 op);
 
 	void Comp_IType(u32 op);
+	void Comp_RType2(u32 op);
 	void Comp_RType3(u32 op);
 	void Comp_ShiftType(u32 op);
 	void Comp_Allegrex(u32 op);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -832,7 +832,7 @@ namespace MIPSInt
 				R(rt) = (R(rs) >> pos) & ((1<<size) - 1);
 			}
 			break;
-		case 0x4: // ins
+		case 0x4: //ins
 			{
 				int size = (_SIZE + 1) - pos;
 				int sourcemask = (1 << size) - 1;

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -194,8 +194,8 @@ const MIPSInstruction tableSpecial[64] = /// 000000 ...... ...... .......... xxx
 	INSTR("mtlo",  &Jit::Comp_MulDivType, Dis_ToHiloTransfer,   Int_MulDivType, IN_RS|OUT_OTHER),
 	{-2},
 	{-2},
-	INSTR("clz",   &Jit::Comp_Generic, Dis_RType2, Int_RType2, OUT_RD|IN_RS|IN_RT),
-	INSTR("clo",   &Jit::Comp_Generic, Dis_RType2, Int_RType2, OUT_RD|IN_RS|IN_RT),
+	INSTR("clz",   &Jit::Comp_RType2, Dis_RType2, Int_RType2, OUT_RD|IN_RS|IN_RT),
+	INSTR("clo",   &Jit::Comp_RType2, Dis_RType2, Int_RType2, OUT_RD|IN_RS|IN_RT),
 
 	//24
 	INSTR("mult",  &Jit::Comp_MulDivType, Dis_MulDivType, Int_MulDivType, IN_RS|IN_RT|OUT_OTHER),

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -91,6 +91,13 @@ namespace MIPSComp
 			break;
 
 		case 10: // R(rt) = (s32)R(rs) < simm; break; //slti
+			// There's a mips compiler out there asking it already knows the answer to...
+			if (gpr.IsImmediate(rs))
+			{
+				gpr.SetImmediate32(rt, (s32)gpr.GetImmediate32(rs) < simm);
+				break;
+			}
+
 			gpr.Lock(rt, rs);
 			gpr.BindToRegister(rs, true, false);
 			gpr.BindToRegister(rt, rt == rs, true);
@@ -102,6 +109,12 @@ namespace MIPSComp
 			break;
 
 		case 11: // R(rt) = R(rs) < uimm; break; //sltiu
+			if (gpr.IsImmediate(rs))
+			{
+				gpr.SetImmediate32(rt, gpr.GetImmediate32(rs) < uimm);
+				break;
+			}
+
 			gpr.Lock(rt, rs);
 			gpr.BindToRegister(rs, true, false);
 			gpr.BindToRegister(rt, rt == rs, true);

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -158,6 +158,29 @@ namespace MIPSComp
 		}
 	}
 
+	void Jit::Comp_RType2(u32 op)
+	{
+		CONDITIONAL_DISABLE;
+		int rs = _RS;
+		int rd = _RD;
+
+		// Don't change $zr.
+		if (rd == 0)
+			return;
+
+		switch (op & 63)
+		{
+		case 22: //clz
+			DISABLE;
+			break;
+		case 23: //clo
+			DISABLE;
+			break;
+		default:
+			DISABLE;
+		}
+	}
+
 	static u32 RType3_ImmAdd(const u32 a, const u32 b)
 	{
 		return a + b;

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -78,11 +78,14 @@ namespace MIPSComp
 
 				gpr.Lock(rt, rs);
 				gpr.BindToRegister(rt, rt == rs, true);
-				if (rt != rs)
+				if (rt == rs || gpr.R(rs).IsSimpleReg())
+					LEA(32, gpr.RX(rt), MDisp(gpr.RX(rs), simm));
+				else
+				{
 					MOV(32, gpr.R(rt), gpr.R(rs));
-				if (simm != 0)
-					ADD(32, gpr.R(rt), Imm32((u32)(s32)simm));
-				// TODO: Can also do LEA if both operands happen to be in registers.
+					if (simm != 0)
+						ADD(32, gpr.R(rt), Imm32((u32)(s32)simm));
+				}
 				gpr.UnlockAll();
 			}
 			break;

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -144,7 +144,7 @@ void Jit::BranchRSRTComp(u32 op, Gen::CCFlags cc, bool likely)
 
 	if (rt == 0)
 	{
-		gpr.KillImmediate(rs, true, true);
+		gpr.KillImmediate(rs, true, false);
 		CMP(32, gpr.R(rs), Imm32(0));
 	}
 	else

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -241,8 +241,8 @@ private:
 	// Utilities to reduce duplicated code
 	void CompImmLogic(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &));
 	void CompTriArith(u32 op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &), u32 (*doImm)(const u32, const u32));
-	void CompShiftImm(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
-	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg));
+	void CompShiftImm(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32));
+	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32));
 	void CompITypeMemRead(u32 op, u32 bits, void (XEmitter::*mov)(int, int, X64Reg, OpArg), void *safeFunc);
 	void CompITypeMemWrite(u32 op, u32 bits, void *safeFunc);
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -171,6 +171,7 @@ public:
 	void Comp_Break(u32 op);
 
 	void Comp_IType(u32 op);
+	void Comp_RType2(u32 op);
 	void Comp_RType3(u32 op);
 	void Comp_ShiftType(u32 op);
 	void Comp_Allegrex(u32 op);


### PR DESCRIPTION
Adds a lot more immediate handling, mostly because I wanted to confirm some suspicions: sometimes branches are done with values known at compile time (even rs/rt.)  At first I was surprised but then I realized this must be for/while loops.

Anyway, probably doesn't improve performance a ton, although the immediate branches I added were all hit iirc.

Not really sure the best way to implement clz/clo... tried BSR with a JNZ and 31 - EAX as the result, but must've been doing something wrong since it didn't work... not that it's super important to jit, anyway.

-[Unknown]
