### PR TITLE
Don't process threadsafe events from HLE.

### DIFF
--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -100,6 +100,7 @@ namespace CoreTiming
 	void RemoveAllEvents(int event_type);
 	bool IsScheduled(int event_type);
 	void Advance();
+	void AdvanceQuick();
 	void MoveEvents();
 	void ProcessFifoWaitEvents();
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -795,7 +795,7 @@ void __KernelIdle()
 	CoreTiming::Idle();
 	// Advance must happen between Idle and Reschedule, so that threads that were waiting for something
 	// that was triggered at the end of the Idle period must get a chance to be scheduled.
-	CoreTiming::Advance();
+	CoreTiming::AdvanceQuick();
 
 	// We must've exited a callback?
 	if (__KernelInCallback())
@@ -1263,7 +1263,7 @@ void __KernelReSchedule(const char *reason)
 	}
 
 	// Execute any pending events while we're doing scheduling.
-	CoreTiming::Advance();
+	CoreTiming::AdvanceQuick();
 	if (__IsInInterrupt() || __KernelInCallback())
 	{
 		reason = "In Interrupt Or Callback";


### PR DESCRIPTION
Only from the runloop where blowing the jit cache is safe.  Probably shouldn't hurt perf any more than it helps it.

I'm hoping this is the cause of the jit savestate crashes.

-[Unknown]
