### PR TITLE
Fix warning / test failure on Mac with x86 jit

### DIFF
--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -119,11 +119,6 @@ void* AllocateExecutableMemory(size_t size, bool low)
 	}
 #endif
 
-#if defined(_M_X64)
-	if ((u64)ptr >= 0x80000000 && low == true)
-		PanicAlert("Executable memory ended up above 2GB!");
-#endif
-
 	return ptr;
 }
 

--- a/Common/Thunk.cpp
+++ b/Common/Thunk.cpp
@@ -112,9 +112,9 @@ void *ThunkManager::ProtectFunction(void *function, int num_params)
 #else
 	SUB(64, R(ESP), Imm8(0x8));
 #endif
-	CALL((void*)save_regs);
-	CALL((void*)function);
-	CALL((void*)load_regs);
+	ABI_CallFunction((void*)save_regs);
+	ABI_CallFunction((void*)function);
+	ABI_CallFunction((void*)load_regs);
 #ifdef _WIN32
 	ADD(64, R(ESP), Imm8(0x28));
 #else

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -129,13 +129,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			SetJumpTarget(notfound);
 
 			//Ok, no block, let's jit
-#ifdef _M_IX86
-			ABI_AlignStack(0);
-			CALL(reinterpret_cast<void *>(&Jit));
-			ABI_RestoreStack(0);
-#elif _M_X64
-			CALL((void *)&Jit);
-#endif
+			ABI_CallFunction((void *)&Jit);
 			JMP(dispatcherNoCheck); // Let's just dispatch again, we'll enter the block since we know it's there.
 
 		SetJumpTarget(bail);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -386,7 +386,7 @@ bool Jit::CheckJitBreakpoint(u32 addr, int downcountOffset)
 	{
 		FlushAll();
 		MOV(32, M(&mips_->pc), Imm32(js.compilerPC));
-		CALL((void *)&JitBreakpoint);
+		ABI_CallFunction((void *)&JitBreakpoint);
 
 		WriteDowncount(downcountOffset);
 		JMP(asm_.dispatcherCheckCoreState, true);


### PR DESCRIPTION
AFAICT the only reason code ending up outside the low area of ram is to avoid far ptrs.

As long as we use register calls/jumps between code spaces, this should be fine, if I understand correctly.  It works on Mac already, just prints the warning.

What this does:
- Cleans up CALL() usage so it's always using ABI_CallFunction\* on 64-bit between code spaces (thunks, asm, jit.)
- Removes the warning.

This should fix the Mac build failures and hopefully any potential problems if the allocated code space is 31 bits away from the actual emulator code (which wasn't being checked for anyway, AFAICT?)

-[Unknown]
