### PR TITLE
Font crash fixes

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -577,10 +577,16 @@ u32 sceFontOpenUserFile(u32 libHandle, const char *fileName, u32 mode, u32 error
 }
 
 int sceFontClose(u32 fontHandle) {
-	INFO_LOG(HLE, "sceFontClose(%x)", fontHandle);
 	LoadedFont *font = GetLoadedFont(fontHandle, false);
-	FontLib *fontLib = font->GetFontLib();
-	fontLib->CloseFont(font);
+	if (font)
+	{
+		INFO_LOG(HLE, "sceFontClose(%x)", fontHandle);
+		FontLib *fontLib = font->GetFontLib();
+		if (fontLib)
+			fontLib->CloseFont(font);
+	}
+	else
+		ERROR_LOG(HLE, "sceFontClose(%x) - font not open?", fontHandle);
 	return 0;
 }
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -443,7 +443,9 @@ void __FontInit() {
 
 void __FontShutdown() {
 	for (auto iter = fontMap.begin(); iter != fontMap.end(); iter++) {
-		iter->second->GetFontLib()->CloseFont(iter->second);
+		FontLib *fontLib = iter->second->GetFontLib();
+		if (fontLib)
+			fontLib->CloseFont(iter->second);
 	}
 	fontMap.clear();
 	for (auto iter = fontLibMap.begin(); iter != fontLibMap.end(); iter++) {


### PR DESCRIPTION
This fixes some crashes and makes Fieldrunners go in game again, but fonts still don't work.  It seems like after close, font entries aren't being properly reused...

Still, better than crashing.

-[Unknown]
