### PR TITLE
Fix sceKernelPartitionMemory() alignment

### DIFF
--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -427,7 +427,7 @@ public:
 				address = alloc->AllocAt(alignment, size, name);
 			}
 			else if (type == PSP_SMEM_LowAligned || type == PSP_SMEM_HighAligned)
-				address = alloc->AllocAligned(size, alignment, type == PSP_SMEM_HighAligned, name);
+				address = alloc->AllocAligned(size, 0x100, alignment, type == PSP_SMEM_HighAligned, name);
 			else
 				address = alloc->Alloc(size, type == PSP_SMEM_High, name);
 			alloc->ListBlocks();

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -65,7 +65,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 		//Allocate from bottom of mem
 		for (std::list<Block>::iterator iter = blocks.begin(); iter != blocks.end(); iter++)
 		{
-			BlockAllocator::Block &b = *iter;
+			Block &b = *iter;
 			u32 offset = b.start % grain;
 			if (offset != 0)
 				offset = grain - offset;
@@ -94,8 +94,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 		// Allocate from top of mem.
 		for (std::list<Block>::reverse_iterator iter = blocks.rbegin(); iter != blocks.rend(); ++iter)
 		{
-			std::list<Block>::reverse_iterator hey = iter;
-			BlockAllocator::Block &b = *((++hey).base()); //yes, confusing syntax. reverse_iterators are confusing
+			Block &b = *iter;
 			u32 offset = (b.start + b.size - size) % grain;
 			u32 needed = offset + size;
 			if (b.taken == false && b.size >= needed)
@@ -108,7 +107,8 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 				}
 				else
 				{
-					blocks.insert(hey.base(), Block(b.start, b.size - needed, false));
+					std::list<Block>::iterator pos = iter.base();
+					blocks.insert(--pos, Block(b.start, b.size - needed, false));
 					b.taken = true;
 					b.start += b.size - needed;
 					b.size = needed;

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -45,7 +45,7 @@ void BlockAllocator::Shutdown()
 	blocks.clear();
 }
 
-u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char *tag)
+u32 BlockAllocator::AllocAligned(u32 &size, u32 sizeGrain, u32 grain, bool fromTop, const char *tag)
 {
 	// Sanity check
 	if (size == 0 || size > rangeSize_) {
@@ -56,9 +56,11 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 	// It could be off step, but the grain should generally be a power of 2.
 	if (grain < grain_)
 		grain = grain_;
+	if (sizeGrain < grain_)
+		sizeGrain = grain_;
 
 	// upalign size to grain
-	size = (size + grain - 1) & ~(grain - 1);
+	size = (size + sizeGrain - 1) & ~(sizeGrain - 1);
 
 	if (!fromTop)
 	{
@@ -128,7 +130,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 u32 BlockAllocator::Alloc(u32 &size, bool fromTop, const char *tag)
 {
 	// We want to make sure it's aligned in case AllocAt() was used.
-	return AllocAligned(size, grain_, fromTop, tag);
+	return AllocAligned(size, grain_, grain_, fromTop, tag);
 }
 
 u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -67,6 +67,8 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 		{
 			BlockAllocator::Block &b = *iter;
 			u32 offset = b.start % grain;
+			if (offset != 0)
+				offset = grain - offset;
 			u32 needed = offset + size;
 			if (b.taken == false && b.size >= needed)
 			{
@@ -94,7 +96,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 		{
 			std::list<Block>::reverse_iterator hey = iter;
 			BlockAllocator::Block &b = *((++hey).base()); //yes, confusing syntax. reverse_iterators are confusing
-			u32 offset = b.start % grain;
+			u32 offset = (b.start + b.size - size) % grain;
 			u32 needed = offset + size;
 			if (b.taken == false && b.size >= needed)
 			{
@@ -102,7 +104,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 				{
 					b.taken = true;
 					b.SetTag(tag);
-					return b.start + offset;
+					return b.start;
 				}
 				else
 				{
@@ -111,7 +113,7 @@ u32 BlockAllocator::AllocAligned(u32 &size, u32 grain, bool fromTop, const char 
 					b.start += b.size - needed;
 					b.size = needed;
 					b.SetTag(tag);
-					return b.start + offset;
+					return b.start;
 				}
 			}
 		}

--- a/Core/Util/BlockAllocator.h
+++ b/Core/Util/BlockAllocator.h
@@ -40,7 +40,7 @@ public:
 
 	// WARNING: size can be modified upwards!
 	u32 Alloc(u32 &size, bool fromTop = false, const char *tag = 0);
-	u32 AllocAligned(u32 &size, u32 grain, bool fromTop = false, const char *tag = 0);
+	u32 AllocAligned(u32 &size, u32 sizeGrain, u32 grain, bool fromTop = false, const char *tag = 0);
 	u32 AllocAt(u32 position, u32 size, const char *tag = 0);
 
 	bool Free(u32 position);


### PR DESCRIPTION
It wasn't giving properly aligned addresses, actually.  Oops.

-[Unknown]
