### PR TITLE
Implement literal pools for ARMv6

### DIFF
--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -391,6 +391,7 @@ public:
 	void FlushLitPool();
 	void AddNewLit(u32 val);
 
+	CCFlags GetCC() { return CCFlags(condition >> 28); }
 	void SetCC(CCFlags cond = CC_AL);
 
 	// Special purpose instructions

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -337,9 +337,8 @@ struct FixupBranch
 struct LiteralPool
 {
     int i;
-    u32 ldr_address;
+    u8* ldr_address;
     u32 val;
-    ArmGen::ARMReg reg;
 };
 
 typedef const u8* JumpTarget;
@@ -351,7 +350,6 @@ private:
 	u8 *code, *startcode;
 	u8 *lastCacheFlushEnd;
 	u32 condition;
-	int pool_size;
 	std::vector<LiteralPool> currentLitPool;
 
 	void WriteStoreOp(u32 op, ARMReg dest, ARMReg src, Operand2 op2);
@@ -370,7 +368,7 @@ protected:
 	inline void Write32(u32 value) {*(u32*)code = value; code+=4;}
 
 public:
-	ARMXEmitter() : code(0), startcode(0), lastCacheFlushEnd(0), pool_size(0) {
+	ARMXEmitter() : code(0), startcode(0), lastCacheFlushEnd(0) {
 		condition = CC_AL << 28;
 	}
 	ARMXEmitter(u8 *code_ptr) {
@@ -378,7 +376,6 @@ public:
 		lastCacheFlushEnd = code_ptr;
 		startcode = code_ptr;
 		condition = CC_AL << 28;
-		pool_size = 0;
 	}
 	virtual ~ARMXEmitter() {}
 
@@ -392,7 +389,7 @@ public:
 	u8 *GetWritableCodePtr();
 
 	void FlushLitPool();
-	void AddNewLit(ArmGen::ARMReg reg, u32 val);
+	void AddNewLit(u32 val);
 
 	void SetCC(CCFlags cond = CC_AL);
 

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -198,6 +198,7 @@ void Jit::GenerateFixedCode()
 
 	// Don't forget to zap the instruction cache!
 	FlushIcache();
+	FlushLitPool();
 }
 
 }  // namespace

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -197,8 +197,8 @@ void Jit::GenerateFixedCode()
 	// INFO_LOG(HLE, "END OF THE DISASM ========================");
 
 	// Don't forget to zap the instruction cache!
-	FlushIcache();
 	FlushLitPool();
+	FlushIcache();
 }
 
 }  // namespace

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -25,6 +25,7 @@
 
 #include "ArmRegCache.h"
 #include "ArmJit.h"
+#include "CPUDetect.h"
 
 #include "../../../ext/disarm.h"
 
@@ -218,6 +219,16 @@ const u8 *Jit::DoJit(u32 em_address, ArmJitBlock *b)
 	
 		js.compilerPC += 4;
 		numInstructions++;
+		if (!cpu_info.bArmV7 && GetCodePtr() - b->checkedEntry >= 4088)
+		{
+			// We need to prematurely flush as we are out of range
+			CCFlags old_cc = GetCC();
+			SetCC(CC_AL);
+			FixupBranch skip = B();
+			FlushLitPool();
+			SetJumpTarget(skip);
+			SetCC(old_cc);
+		}
 	}
 	FlushLitPool();
 #ifdef LOGASM
@@ -346,7 +357,7 @@ void Jit::Comp_DoNothing(u32 op) { }
 #define _FS ((op>>11) & 0x1F)
 #define _FT ((op>>16) & 0x1F)
 #define _FD ((op>>6) & 0x1F)
-#define _POS	((op>>6) & 0x1F)
+#define _POS((op>>6) & 0x1F)
 #define _SIZE ((op>>11) & 0x1F)
 
 //memory regions:

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -219,6 +219,7 @@ const u8 *Jit::DoJit(u32 em_address, ArmJitBlock *b)
 		js.compilerPC += 4;
 		numInstructions++;
 	}
+	FlushLitPool();
 #ifdef LOGASM
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		for (u32 cpc = em_address; cpc != js.compilerPC + 4; cpc += 4) {


### PR DESCRIPTION
Uses a constant pool at the end of each block so that it is possible to directly load 32-bit values to a register in 1 cycle + memory load.
If the block goes out of range, a premature flush is executed.

A MOV or MVN will still be used if optimal to avoid the memory load.

Performance:
Depends on the game. Some games have only 5% improvement whereas others have been seen with a 30% frame rate improvement.
