### PR TITLE
Correct the startSector populated by sceIoDread().

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -559,7 +559,7 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path)
 		x.size = e->size;
 		x.type = e->isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 		x.isOnSectorSystem = true;
-		x.startSector = entry->startingPosition/2048;
+		x.startSector = e->startingPosition/2048;
 		myVector.push_back(x);
 	}
 	return myVector;


### PR DESCRIPTION
Sneaky little bug, took me longer to track down than it should have.

The startSector read from `sceIoDread()` was previously of the directory entry, breaking any games that used it to list a directory and then use sce_lbn reads.

Fixes Kahoots (working this time, not accidentally working, heh) and Brave Story (which has some pretty major gfx issues.)  Maybe others?  One liner fix ftw.

-[Unknown]
