### PR TITLE
Server reporting (off by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/PSPLoaders.h
 	Core/PSPMixer.cpp
 	Core/PSPMixer.h
+	Core/Reporting.cpp
+	Core/Reporting.h
 	Core/SaveState.cpp
 	Core/SaveState.h
 	Core/System.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -54,6 +54,8 @@ void CConfig::Load(const char *iniFileName)
 	general->Get("IgnoreBadMemAccess", &bIgnoreBadMemAccess, true);
 	general->Get("CurrentDirectory", &currentDirectory, "");
 	general->Get("ShowDebuggerOnLoad", &bShowDebuggerOnLoad, false);
+	// "default" means let emulator decide, "" means disable.
+	general->Get("ReportHost", &sReportHost, "default");
 
 	IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 	cpu->Get("Jit", &bJit, true);
@@ -120,6 +122,8 @@ void CConfig::Save()
 		general->Set("IgnoreBadMemAccess", bIgnoreBadMemAccess);
 		general->Set("CurrentDirectory", currentDirectory);
 		general->Set("ShowDebuggerOnLoad", bShowDebuggerOnLoad);
+		general->Set("ReportHost", sReportHost);
+
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 		cpu->Set("Jit", bJit);
 		cpu->Set("FastMemory", bFastMemory);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -49,6 +49,7 @@ public:
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;
 	bool bJit;
+	std::string sReportHost;
 
 	// GFX
 	bool bDisplayFramebuffer;

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -295,6 +295,7 @@
     <ClCompile Include="MIPS\x86\RegCache.cpp" />
     <ClCompile Include="PSPLoaders.cpp" />
     <ClCompile Include="PSPMixer.cpp" />
+    <ClCompile Include="Reporting.cpp" />
     <ClCompile Include="SaveState.cpp" />
     <ClCompile Include="System.cpp" />
     <ClCompile Include="Util\BlockAllocator.cpp" />
@@ -429,6 +430,7 @@
     <ClInclude Include="MIPS\x86\RegCache.h" />
     <ClInclude Include="PSPLoaders.h" />
     <ClInclude Include="PSPMixer.h" />
+    <ClInclude Include="Reporting.h" />
     <ClInclude Include="SaveState.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="Util\BlockAllocator.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -383,6 +383,9 @@
       <Filter>Font</Filter>
     </ClCompile>
     <ClCompile Include="..\git-version.cpp" />
+    <ClCompile Include="Reporting.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -703,6 +706,9 @@
     <ClInclude Include="HLE\sceChnnlsv.h" />
     <ClInclude Include="Font\PGF.h">
       <Filter>Font</Filter>
+    </ClInclude>
+    <ClInclude Include="Reporting.h">
+      <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -19,6 +19,7 @@
 #include "../Util/PPGeDraw.h"
 #include "../HLE/sceCtrl.h"
 #include "../Core/MemMap.h"
+#include "Core/Reporting.h"
 #include "ChunkFile.h"
 
 PSPMsgDialog::PSPMsgDialog()
@@ -53,6 +54,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr)
 	if(optionsNotCoded)
 	{
 		ERROR_LOG(HLE,"PSPMsgDialog options not coded : 0x%08x",optionsNotCoded);
+		Reporting::ReportMessage("PSPMsgDialog options not coded: 0x%08x", optionsNotCoded);
 	}
 
 	flag = 0;

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -20,6 +20,7 @@
 #include "../HLE/sceCtrl.h"
 #include "../Core/MemMap.h"
 #include "../Config.h"
+#include "Core/Reporting.h"
 
 PSPSaveDialog::PSPSaveDialog()
 	: PSPDialog()
@@ -98,6 +99,7 @@ int PSPSaveDialog::Init(int paramAddr)
 		default:
 		{
 			ERROR_LOG(HLE, "Load/Save function %d not coded. Title: %s Save: %s File: %s", param.GetPspParam()->mode, param.GetGameName(param.GetPspParam()).c_str(), param.GetGameName(param.GetPspParam()).c_str(), param.GetFileName(param.GetPspParam()).c_str());
+			Reporting::ReportMessage("Load/Save function %d not coded. Title: %s Save: %s File: %s", param.GetPspParam()->mode, param.GetGameName(param.GetPspParam()).c_str(), param.GetGameName(param.GetPspParam()).c_str(), param.GetFileName(param.GetPspParam()).c_str());
 			param.GetPspParam()->result = 0;
 			status = SCE_UTILITY_STATUS_INITIALIZE;
 			display = DS_NONE;

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include "../MemMap.h"
 #include "../Config.h"
+#include "Core/Reporting.h"
 
 #include "HLETables.h"
 #include "../System.h"
@@ -164,6 +165,7 @@ u32 GetSyscallOp(const char *moduleName, u32 nib)
 		else
 		{
 			INFO_LOG(HLE, "Syscall (%s, %08x) unknown", moduleName, nib);
+			Reporting::ReportMessage("Unknown syscall in known module: %s 0x%08x", moduleName, nib);
 			return (0x0003FFCC | (modindex<<18));  // invalid syscall
 		}
 	}

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -28,6 +28,7 @@
 #include "HLE.h"
 #include "../MIPS/MIPS.h"
 #include "../HW/SasAudio.h"
+#include "Core/Reporting.h"
 
 #include "sceSas.h"
 #include "sceKernel.h"
@@ -143,6 +144,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loop)
 {
 	INFO_LOG(HLE,"PLEASE REPORT issue #505 sceSasSetVoicePCM(%08x, %i, %08x, %i, %i)", core, voiceNum, pcmAddr, size, loop);
+	Reporting::ReportMessage("sceSasSetVoicePCM(%x, %i)", core, voiceNum);
 
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(HLE, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -17,6 +17,7 @@
 
 #include "../../MemMap.h"
 #include "../MIPSAnalyst.h"
+#include "Core/Reporting.h"
 
 #include "ArmJit.h"
 #include "ArmRegCache.h"
@@ -117,6 +118,7 @@ namespace MIPSComp
 				// TODO: But some ops seem to use const 0 instead?
 				if (regnum >= n) {
 					ERROR_LOG(CPU, "Invalid VFPU swizzle: %08x / %d", prefix, sz);
+					Reporting::ReportMessage("Invalid VFPU swizzle: %08x / %d", prefix, sz);
 					regnum = 0;
 				}
 				

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -357,7 +357,7 @@ void Jit::Comp_DoNothing(u32 op) { }
 #define _FS ((op>>11) & 0x1F)
 #define _FT ((op>>16) & 0x1F)
 #define _FD ((op>>6) & 0x1F)
-#define _POS((op>>6) & 0x1F)
+#define _POS ((op>>6) & 0x1F)
 #define _SIZE ((op>>11) & 0x1F)
 
 //memory regions:

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -23,6 +23,7 @@
 #include "MIPS.h"
 #include "MIPSInt.h"
 #include "MIPSTables.h"
+#include "Core/Reporting.h"
 
 #include "../HLE/HLE.h"
 #include "../System.h"
@@ -186,6 +187,7 @@ namespace MIPSInt
 
 	void Int_Break(u32 op)
 	{
+		Reporting::ReportMessage("BREAK instruction hit");
 		ERROR_LOG(CPU, "BREAK!");
 		Core_UpdateState(CORE_STEPPING);
 		PC += 4;
@@ -960,6 +962,7 @@ namespace MIPSInt
 		{
 		case 0:
 			if (!reported) {
+				Reporting::ReportMessage("INTERRUPT instruction hit");
 				WARN_LOG(CPU,"Disable/Enable Interrupt CPU instruction");
 				reported = 1;
 			}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -36,6 +36,7 @@
 // sv.s
 
 #include "../Core.h"
+#include "Core/Reporting.h"
 
 #include <cmath>
 
@@ -142,6 +143,7 @@ void ApplyPrefixST(float *v, u32 data, VectorSize size)
 			if (regnum >= n)
 			{
 				ERROR_LOG(CPU, "Invalid VFPU swizzle: %08x / %d", data, size);
+				Reporting::ReportMessage("Invalid VFPU swizzle: %08x / %d", data, size);
 				regnum = 0;
 			}
 
@@ -1822,22 +1824,26 @@ bad:
 	void Int_Vlgb(u32 op)
 	{
 		// S & D valid
+		Reporting::ReportMessage("vlgb not implemented");
 		_dbg_assert_msg_(CPU,0,"vlgb not implemented");
 	}
 
 	void Int_Vwbn(u32 op)
 	{
 		// S & D valid
+		Reporting::ReportMessage("vwbn not implemented");
 		_dbg_assert_msg_(CPU,0,"vwbn not implemented");
 	}
 
 	void Int_Vsbn(u32 op)
 	{
+		Reporting::ReportMessage("vsbn not implemented");
 		_dbg_assert_msg_(CPU,0,"vsbn not implemented");
 	}
 
 	void Int_Vsbz(u32 op)
 	{
+		Reporting::ReportMessage("vsbz not implemented");
 		_dbg_assert_msg_(CPU,0,"vsbz not implemented");
 	}
 }

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -18,6 +18,7 @@
 #include "../../MemMap.h"
 #include "../../Config.h"
 #include "../MIPSAnalyst.h"
+#include "Core/Reporting.h"
 
 #include "Jit.h"
 #include "../MIPSVFPUUtils.h"
@@ -105,6 +106,7 @@ void Jit::ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz) {
 			// TODO: But some ops seem to use const 0 instead?
 			if (regnum >= n) {
 				ERROR_LOG(CPU, "Invalid VFPU swizzle: %08x / %d", prefix, sz);
+				Reporting::ReportMessage("Invalid VFPU swizzle: %08x / %d", prefix, sz);
 				regnum = 0;
 			}
 			MOVSS(fpr.VX(vregs[i]), fpr.V(origV[regnum]));

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/Config.h"
+#include "Core/System.h"
+
+#include "net/http_client.h"
+#include "net/resolve.h"
+#include "base/buffer.h"
+
+#include <stdlib.h>
+#include <string>
+
+namespace Reporting
+{
+	const int DEFAULT_PORT = 80;
+
+	static size_t ServerHostnameLength()
+	{
+		if (g_Config.sReportHost.empty())
+			return g_Config.sReportHost.npos;
+
+		// IPv6 literal?
+		if (g_Config.sReportHost[0] == '[')
+		{
+			size_t length = g_Config.sReportHost.find("]:");
+			if (length != g_Config.sReportHost.npos)
+				++length;
+			return length;
+		}
+		else
+			return g_Config.sReportHost.find(':');
+	}
+
+	static std::string lastHostname;
+	static const char *ServerHostname()
+	{
+		if (g_Config.sReportHost.empty())
+			return NULL;
+		// Disabled by default for now.
+		if (g_Config.sReportHost.compare("default") == 0)
+			return NULL;
+
+		size_t length = ServerHostnameLength();
+		if (length == g_Config.sReportHost.npos)
+			return g_Config.sReportHost.c_str();
+
+		lastHostname = g_Config.sReportHost.substr(0, length);
+		return lastHostname.c_str();
+	}
+
+	static int ServerPort()
+	{
+		if (g_Config.sReportHost.empty())
+			return 0;
+		// Disabled by default for now.
+		if (g_Config.sReportHost.compare("default") == 0)
+			return 0;
+
+		size_t offset = ServerHostnameLength();
+		if (offset == g_Config.sReportHost.npos)
+			return DEFAULT_PORT;
+
+		// Skip the colon.
+		std::string port = g_Config.sReportHost.substr(offset + 1);
+		return atoi(port.c_str());
+	}
+
+	void ReportMessage(const char *message, ...)
+	{
+		if (g_Config.sReportHost.empty())
+			return;
+		// Disabled by default for now.
+		if (g_Config.sReportHost.compare("default") == 0)
+			return;
+
+		// TODO: Use a thread, enable on non-Windows.
+#ifdef _MSC_VER
+		char temp[32768];
+		char *tempPos = &temp[0];
+
+		// TODO: application/x-www-urlencoded?  Need to escape.
+		tempPos += sprintf(tempPos, "version=%s&game=%s_%s&message=",
+			PPSSPP_GIT_VERSION,
+			g_paramSFO.GetValueString("DISC_ID").c_str(),
+			g_paramSFO.GetValueString("DISC_VERSION").c_str());
+
+		va_list args;
+		va_start(args, message);
+		vsprintf(tempPos, message, args);
+		va_end(args);
+
+		Buffer output;
+		http::Client http;
+		net::Init();
+		if (http.Resolve(ServerHostname(), ServerPort()))
+		{
+			http.Connect();
+			http.POST("/report/message", temp, &output);
+			http.Disconnect();
+		}
+		net::Shutdown();
+#endif
+	}
+
+}

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -90,18 +90,20 @@ namespace Reporting
 
 		// TODO: Use a thread, enable on non-Windows.
 #ifdef _MSC_VER
-		char temp[32768];
+		const int MESSAGE_BUFFER_SIZE = 32768;
+		char temp[MESSAGE_BUFFER_SIZE];
 		char *tempPos = &temp[0];
 
-		// TODO: application/x-www-urlencoded?  Need to escape.
+		// TODO: Need to escape these values.
 		tempPos += sprintf(tempPos, "version=%s&game=%s_%s&message=",
 			PPSSPP_GIT_VERSION,
 			g_paramSFO.GetValueString("DISC_ID").c_str(),
 			g_paramSFO.GetValueString("DISC_VERSION").c_str());
 
+		// TODO: And escape this, plus it can't be done on thread.
 		va_list args;
 		va_start(args, message);
-		vsprintf(tempPos, message, args);
+		vsnprintf(tempPos, temp + MESSAGE_BUFFER_SIZE - tempPos, message, args);
 		va_end(args);
 
 		Buffer output;
@@ -110,7 +112,7 @@ namespace Reporting
 		if (http.Resolve(ServerHostname(), ServerPort()))
 		{
 			http.Connect();
-			http.POST("/report/message", temp, &output);
+			http.POST("/report/message", temp, "application/x-www-urlencoded", &output);
 			http.Disconnect();
 		}
 		net::Shutdown();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -46,7 +46,8 @@ namespace Reporting
 	struct Payload
 	{
 		RequestType type;
-		std::string data;
+		std::string string1;
+		std::string string2;
 	};
 	static Payload payloadBuffer[PAYLOAD_BUFFER_SIZE];
 	static int payloadBufferPos = 0;
@@ -147,8 +148,9 @@ namespace Reporting
 		{
 		case MESSAGE:
 			// TODO: Escape.
-			data = std::string(temp) + "&message=" + payload.data;
-			payload.data.clear();
+			data = std::string(temp) + "&message=" + payload.string1 + "&value=" + payload.string2;
+			payload.string1.clear();
+			payload.string2.clear();
 
 			SendReportRequest("/report/message", data);
 			break;
@@ -177,7 +179,8 @@ namespace Reporting
 		int pos = payloadBufferPos++ % PAYLOAD_BUFFER_SIZE;
 		Payload &payload = payloadBuffer[pos];
 		payload.type = MESSAGE;
-		payload.data = temp;
+		payload.string1 = message;
+		payload.string2 = temp;
 
 		std::thread th(Process, pos);
 		th.detach();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "Common/StdThread.h"
 #include "Core/Config.h"
 #include "Core/System.h"
 
@@ -24,16 +25,12 @@
 
 #include <stdlib.h>
 #include <string>
-
-// TODO: Probably this works on non-Windows/Qt too.
-#ifdef _MSC_VER
-#include "Common/StdThread.h"
-#endif
+#include <cstdarg>
 
 namespace Reporting
 {
 	const int DEFAULT_PORT = 80;
-	const int SPAM_LIMIT = 100;
+	const u32 SPAM_LIMIT = 100;
 	const int PAYLOAD_BUFFER_SIZE = 100;
 
 	// Internal limiter on number of requests per instance.
@@ -168,8 +165,6 @@ namespace Reporting
 		if (g_Config.sReportHost.compare("default") == 0)
 			return;
 
-		// TODO: Enable on non-Windows.
-#ifdef _MSC_VER
 		const int MESSAGE_BUFFER_SIZE = 32768;
 		char temp[MESSAGE_BUFFER_SIZE];
 
@@ -186,7 +181,6 @@ namespace Reporting
 
 		std::thread th(Process, pos);
 		th.detach();
-#endif
 	}
 
 }

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Common/CommonTypes.h"
+
+namespace Reporting
+{
+	void ReportMessage(const char *message, ...);
+}

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -42,6 +42,7 @@ SOURCES += ../Core/CPU.cpp \ # Core
 	../Core/MemMapFunctions.cpp \
 	../Core/PSPLoaders.cpp \
 	../Core/PSPMixer.cpp \
+	../Core/Reporting.cpp \
 	../Core/SaveState.cpp \
 	../Core/System.cpp \
 	../Core/Debugger/*.cpp \
@@ -72,6 +73,7 @@ HEADERS += ../Core/CPU.h \
 	../Core/MemMap.h \
 	../Core/PSPLoaders.h \
 	../Core/PSPMixer.h \
+	../Core/Reporting.h \
 	../Core/SaveState.h \
 	../Core/System.h \
 	../Core/Debugger/*.h \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -105,6 +105,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/Core/PSPLoaders.cpp \
   $(SRC)/Core/MemMap.cpp \
   $(SRC)/Core/MemMapFunctions.cpp \
+  $(SRC)/Core/Reporting.cpp \
   $(SRC)/Core/SaveState.cpp \
   $(SRC)/Core/System.cpp \
   $(SRC)/Core/PSPMixer.cpp \


### PR DESCRIPTION
This is basic support, there's lots of future room for improvement.

Includes:
- Buildfix for Android / iOS.
- ppsspp.ini setting: "" disables forever, "default" allows emu to decide (disabled right now), otherwise hostname of server to POST to.
- Some reporting calls for unimplemented instructions, etc.
- Launching a thread so the HTTP doesn't block (attempted to make this as quick as possible.)
- Spam limiting so it will abort if > 100 reports are sent per session (in case a game goes bonkers.)

Could in the future:
- Report more situations.
- Have UI to enable/disable (probably should before enabling...)
- Have UI to report a game is working / isn't working.
- Include more sysinfo (CPU, platform, GPU, etc.)
- Include a screenshot of the game.
- Gather performance metrics in key places.
- Maybe report crashes?  Probably better to let breakpad do that...

Haven't bothered myself to write a server for it yet but I've tested that it does post proper data.  I think we might as well merge, mostly because I keep rebasing and getting those annoying vcxproj reload warnings, but also so we can add more appropriate reporting calls as desired, and when there is a server do wider-scale testing.

But we can hold off too, if so I'll separate out the buildfix.  Found it while making sure I wouldn't break the build at least obviously.

-[Unknown]
