### PR TITLE
Fix types of sceKernelReferThreadProfiler

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -536,9 +536,39 @@ int sceKernelReferSystemStatus(u32 statusPtr) {
 	return 0;
 }
 
-int sceKernelReferThreadProfiler(u32 statusPtr) {
-	ERROR_LOG(HLE, "UNIMPL sceKernelReferThreadProfiler(%08x)", statusPtr);
-	// Ignore for now
+struct DebugProfilerRegs {
+	u32 enable;
+	u32 systemck;
+	u32 cpuck;
+	u32 internal;
+	u32 memory;
+	u32 copz;
+	u32 vfpu;
+	u32 sleep;
+	u32 bus_access;
+	u32 uncached_load;
+	u32 uncached_store;
+	u32 cached_load;
+	u32 cached_store;
+	u32 i_miss;
+	u32 d_miss;
+	u32 d_writeback;
+	u32 cop0_inst;
+	u32 fpu_inst;
+	u32 vfpu_inst;
+	u32 local_bus;
+};
+
+u32 sceKernelReferThreadProfiler() {
+	ERROR_LOG(HLE, "FAKE sceKernelReferThreadProfiler()");
+
+	u32 size = sizeof(DebugProfilerRegs);
+	u32 ptr = kernelMemory.Alloc(size, true);
+	if (ptr) {
+		Memory::Memset(ptr, (u8)0, sizeof(DebugProfilerRegs));
+		return ptr;
+	}
+
 	return 0;
 }
 
@@ -623,7 +653,7 @@ const HLEFunction ThreadManForUser[] =
 
 	{0x8218B4DD,WrapI_U<sceKernelReferGlobalProfiler>,"sceKernelReferGlobalProfiler"},
 	{0x627E6F3A,WrapI_U<sceKernelReferSystemStatus>,"sceKernelReferSystemStatus"},
-	{0x64D4540E,WrapI_U<sceKernelReferThreadProfiler>,"sceKernelReferThreadProfiler"},
+	{0x64D4540E,WrapU_V<sceKernelReferThreadProfiler>,"sceKernelReferThreadProfiler"},
 
 	//Fifa Street 2 uses alarms
 	{0x6652b8ca,WrapI_UUU<sceKernelSetAlarm>,"sceKernelSetAlarm"},

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -248,6 +248,11 @@ u32 scePowerGetPllClockFrequencyInt() {
 	return pllFreq;
 }
 
+float scePowerGetPllClockFrequencyFloat() {
+	INFO_LOG(HLE, "%f=scePowerGetPllClockFrequencyFloat()", (float)pllFreq);
+	return (float) pllFreq;
+}
+
 u32 scePowerGetBusClockFrequencyInt() {
 	INFO_LOG(HLE,"%i=scePowerGetBusClockFrequencyInt()", busFreq);
 	return busFreq;
@@ -305,7 +310,7 @@ static const HLEFunction scePower[] = {
 	{0x9BADB3EB,0,"scePowerGetBusClockFrequencyFloat"},
 	{0x737486F2,WrapU_UUU<scePowerSetClockFrequency>,"scePowerSetClockFrequency"},
 	{0x34f9c463,WrapU_V<scePowerGetPllClockFrequencyInt>,"scePowerGetPllClockFrequencyInt"},
-	{0xea382a27,0,"scePowerGetPllClockFrequencyFloat"},
+	{0xea382a27,WrapF_V<scePowerGetPllClockFrequencyFloat>,"scePowerGetPllClockFrequencyFloat"},
 	{0xebd177d6,WrapU_UUU<scePowerSetClockFrequency>,"scePower_driver_EBD177D6"}, //TODO: used in a few places, jpcsp says is the same as scePowerSetClockFrequency
 	{0x469989ad,WrapU_UUU<scePowerSetClockFrequency>,"scePower_469989ad"},  // This is also the same as SetClockFrequency
 	{0xa85880d0,WrapU_V<IsPSPNonFat>,"scePower_a85880d0_IsPSPNonFat"},


### PR DESCRIPTION
DebugProfilerRegs struct taken from http://psp.jim.sh/pspsdk-doc/struct__PspDebugProfilerRegs.html.
Implemented scePowerGetPllClockFrequencyFloat called by GTA:LCS. It hangs shortly after though.
