### PR TITLE
Add Greek translation to Qt4 UI

### DIFF
--- a/Qt/languages/ppsspp_gr.ts
+++ b/Qt/languages/ppsspp_gr.ts
@@ -1,0 +1,1013 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="gr_EL">
+<context>
+    <name>Controls</name>
+    <message>
+        <location filename="../controls.ui" line="20"/>
+        <source>Controls</source>
+        <comment>Controls window title</comment>
+        <translation>Τίτλος παραθύρου χειρισμών</translation>
+    </message>
+</context>
+<context>
+    <name>CtrlDisAsmView</name>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="106"/>
+        <source>Copy &amp;address</source>
+        <translation>Αντιγραφή &amp;address</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="110"/>
+        <source>Copy instruction (&amp;hex)</source>
+        <translation>Αντιγραφή οδηγίας (&amp;hex)</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="114"/>
+        <source>Copy instruction (&amp;disasm)</source>
+        <translation>Αντιγραφή οδηγίας (&amp;disasm)</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="120"/>
+        <source>&amp;Run to here</source>
+        <translation>&amp;Τρέξιμο ως εδώ</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="124"/>
+        <source>&amp;Set Next Statement</source>
+        <translation>&amp;Ορισμός Επόμενη Κατάστασης</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="128"/>
+        <source>&amp;Toggle breakpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="132"/>
+        <source>&amp;Follow branch</source>
+        <translation>&amp;Ακολούθηση κλάδου</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="142"/>
+        <source>Go to in &amp;Memory View</source>
+        <translation>Μετάβαση σε &amp;Προβολέα Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="152"/>
+        <source>&amp;Rename function...</source>
+        <translation>&amp;Μετονομασία λειτουργίας...</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="240"/>
+        <source>New function name</source>
+        <translation>Νέο όνομα λειτουργίας</translation>
+    </message>
+    <message>
+        <location filename="../ctrldisasmview.cpp" line="241"/>
+        <source>New function name:</source>
+        <translation>Νέο όνομα λειτουργίας:</translation>
+    </message>
+</context>
+<context>
+    <name>CtrlMemView</name>
+    <message>
+        <location filename="../ctrlmemview.cpp" line="215"/>
+        <source>Go to in &amp;disasm</source>
+        <translation">Μετάβαση σε &amp;disasm</translation>
+    </message>
+    <message>
+        <location filename="../ctrlmemview.cpp" line="221"/>
+        <source>&amp;Copy value</source>
+        <translation>&amp;Αντιγραφή τιμής</translation>
+    </message>
+    <message>
+        <location filename="../ctrlmemview.cpp" line="225"/>
+        <source>Dump...</source>
+        <translation>Αποτύπωση...</translation>
+    </message>
+</context>
+<context>
+    <name>CtrlRegisterList</name>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="274"/>
+        <source>Go to in &amp;memory view</source>
+        <translation>Μετάβαση σε &amp;προβολής μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="278"/>
+        <source>Go to in &amp;disasm</source>
+        <translation">Μετάβαση σε &amp;disasm</translation>
+    </message>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="284"/>
+        <source>&amp;Copy value</source>
+        <translation>&amp;Αντιγραφή τιμής</translation>
+    </message>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="288"/>
+        <source>C&amp;hange...</source>
+        <translation>Α&amp;λλαγή...</translation>
+    </message>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="352"/>
+        <source>Set new value</source>
+        <translation>Ορισμός νέας τιμής</translation>
+    </message>
+    <message>
+        <location filename="../ctrlregisterlist.cpp" line="353"/>
+        <source>Set new value:</source>
+        <translation>Ορισμός νέας τιμής:</translation>
+    </message>
+</context>
+<context>
+    <name>Debugger_Disasm</name>
+    <message>
+        <location filename="../debugger_disasm.ui" line="17"/>
+        <source>Disassembler</source>
+        <comment>Window title</comment>
+        <translation>Τίτλος παραθύρου</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="30"/>
+        <source>Ctr:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="43"/>
+        <source>&amp;Go to</source>
+        <translation>&amp;Μετάβαση σε</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="78"/>
+        <source>&amp;PC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="91"/>
+        <source>&amp;LR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="128"/>
+        <source>Show VFPU</source>
+        <translation>Εμφάνιση VFPU</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="147"/>
+        <source>Regs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="198"/>
+        <source>Funcs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="223"/>
+        <source>&amp;Go</source>
+        <translation>&amp;Ξεκίνημα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="236"/>
+        <source>Stop</source>
+        <translation>Σταμάτημα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="249"/>
+        <source>Step &amp;Into</source>
+        <translation>Μεταπήδηση &amp;σε</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="265"/>
+        <source>Step &amp;Over</source>
+        <translation>Μεταπήδηση &amp;Πάνω από</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="278"/>
+        <source>S&amp;kip</source>
+        <translation>Α&amp;γνόηση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="291"/>
+        <source>Next &amp;HLE</source>
+        <translation>Επόμενο &amp;ΕΥΕ (HLE)</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="320"/>
+        <source>Breakpoints</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="339"/>
+        <source>Address</source>
+        <translation>Διεύθυνση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="362"/>
+        <source>Clear All</source>
+        <translation>Εκκαθάριση Όλων</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="372"/>
+        <source>Callstack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="382"/>
+        <source>Display Lists</source>
+        <translation>Λίστες Απεικόνισης</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="408"/>
+        <location filename="../debugger_disasm.ui" line="519"/>
+        <source>Id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="413"/>
+        <location filename="../debugger_disasm.ui" line="529"/>
+        <source>Status</source>
+        <translation>Κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="418"/>
+        <source>Start Address</source>
+        <translation>Αρχική Διεύθυνση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="423"/>
+        <source>Current Address</source>
+        <translation>Τρέχουσα Διεύθυνση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="476"/>
+        <source>Run</source>
+        <translation>Εκκίνηση</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="483"/>
+        <source>Step</source>
+        <translation>Βήμα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="497"/>
+        <source>Threads</source>
+        <translation>Νήματα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="524"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="534"/>
+        <source>Current PC</source>
+        <translation>Τρέχον PC</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.ui" line="539"/>
+        <source>Entry point</source>
+        <translation>Σημείο έναρξης</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="401"/>
+        <source>Remove breakpoint</source>
+        <translation>Αφαίρεση σημείου διακοπής</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="480"/>
+        <source>Go to entry point</source>
+        <translation>Μετάβαση στο σημείο εισόδου</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="486"/>
+        <source>Running</source>
+        <translation>Σε λειτουργία</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="490"/>
+        <source>Wait</source>
+        <translation>Αναμονή</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="494"/>
+        <source>Suspend</source>
+        <translation>Αναστολή</translation>
+    </message>
+    <message>
+        <location filename="../debugger_disasm.cpp" line="626"/>
+        <source>Show code</source>
+        <translation>Εμφάνιση κώδικα</translation>
+    </message>
+</context>
+<context>
+    <name>Debugger_Memory</name>
+    <message>
+        <location filename="../debugger_memory.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Διάλογος</translation>
+    </message>
+    <message>
+        <location filename="../debugger_memory.ui" line="22"/>
+        <source>Goto:</source>
+        <translation>Μετάβαση σε:</translation>
+    </message>
+    <message>
+        <location filename="../debugger_memory.ui" line="35"/>
+        <source>Mode</source>
+        <translation>Λειτουργία</translation>
+    </message>
+    <message>
+        <location filename="../debugger_memory.ui" line="41"/>
+        <source>Normal</source>
+        <translation>Κανονικό</translation>
+    </message>
+    <message>
+        <location filename="../debugger_memory.ui" line="48"/>
+        <source>Symbols</source>
+        <translation>Σύμβολα</translation>
+    </message>
+    <message>
+        <location filename="../debugger_memory.cpp" line="15"/>
+        <source>Memory Viewer - %1</source>
+        <translation>Προβολέας Μνήμης - %1</translation>
+    </message>
+</context>
+<context>
+    <name>Debugger_VFPU</name>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="14"/>
+        <source>VFPU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="23"/>
+        <source>Float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="28"/>
+        <source>HalfFloat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="33"/>
+        <source>Hex</source>
+        <translation>Δεκαεξαδικό</translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="38"/>
+        <source>Bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="43"/>
+        <source>Shorts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger_vfpu.ui" line="48"/>
+        <source>Ints</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GamePadDialog</name>
+    <message>
+        <location filename="../gamepaddialog.ui" line="14"/>
+        <source>Gamepad Configuration</source>
+        <translation>Διαμόρφωση Χειριστηρίου</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="22"/>
+        <source>GamePad List</source>
+        <translation>Λίστα Χειριστηρίων</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="46"/>
+        <source>Refresh</source>
+        <translation>Ανανέωση</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="53"/>
+        <source>Select</source>
+        <translation>Επιλογή</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="62"/>
+        <source>Gamepad Values :</source>
+        <translation>Τιμές Χειριστηρίου :</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="86"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="98"/>
+        <source>Assign Gamepad input</source>
+        <translation>Εκχώρηση εισόδου χειριστηρίου</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="108"/>
+        <source> to PSP button/axis</source>
+        <translation> στο κουμί/άξονα PSP</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="118"/>
+        <source>Assign</source>
+        <translation>Εκχώρηση</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.ui" line="127"/>
+        <source>Press buttons on your gamePad to verify mapping :</source>
+        <translation>Πατήστε τα κουμπιά στο χειριστήριο σας για να επιβεβαιώσετε την αντιστοίχιση:</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="134"/>
+        <location filename="../gamepaddialog.cpp" line="366"/>
+        <source>&lt;b&gt;No gamepad&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Κανένα χειριστήριο&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="146"/>
+        <source>&lt;b&gt;Unknown gamepad&lt;/b&gt;</source>
+        <translation>&lt;b&gt;’γνωστο χειριστήριο&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="287"/>
+        <source>Buttons</source>
+        <translation>Πλήκτρα</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="301"/>
+        <location filename="../gamepaddialog.cpp" line="344"/>
+        <source>Button %1</source>
+        <translation>Πλήκτρο %1</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="304"/>
+        <source>Axes</source>
+        <translation>’ξονες</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="310"/>
+        <source>%1 Neg</source>
+        <translation>%1 Αρν.</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="317"/>
+        <source>Axes %1 Neg</source>
+        <translation>’ξονες %1 Αρν.</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="320"/>
+        <source>%1 Pos</source>
+        <translation>%1 Θετ.</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="327"/>
+        <source>Axes %1 Pos</source>
+        <translation>’ξονες %1 Θετ.</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="331"/>
+        <source>Hats</source>
+        <translation>Μοχλοί</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="368"/>
+        <source>&lt;b&gt;Current gamepad: %1&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Τρέχον χειριστήριο: %1&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="20"/>
+        <source>PPSSPP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="52"/>
+        <source>&amp;File</source>
+        <translation>&amp;Αρχείο</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="66"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Εξομοίωση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="77"/>
+        <source>Debu&amp;g</source>
+        <translation>Αποσφαλμάτωσ&amp;η</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="91"/>
+        <source>&amp;Options</source>
+        <translation>&amp;Επιλογές</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="99"/>
+        <source>G3D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="108"/>
+        <source>HLE</source>
+        <translation>ΕΥΕ(HLE)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="117"/>
+        <source>Default</source>
+        <translation>Προεπιλογή</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="95"/>
+        <source>Lo&amp;g Levels</source>
+        <translation>Επ&amp;ίπεδα Καταγραφικού</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="131"/>
+        <source>&amp;Language</source>
+        <translation>&amp;Γλώσσα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="136"/>
+        <source>&amp;Video</source>
+        <translation>&amp;Βίντεο</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="140"/>
+        <source>&amp;Anisotropic filtering</source>
+        <translation>&amp;Ανισοτροπικό φιτράρισμα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="150"/>
+        <source>&amp;Zoom</source>
+        <translation>&amp;Μεγένθυση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="173"/>
+        <source>Co&amp;ntrols</source>
+        <translation>Χε&amp;ιριστήρια</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="180"/>
+        <source>&amp;Core</source>
+        <translation>&amp;Πυρήνας</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="204"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Βοήθεια</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="219"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;’νοιγμα...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="224"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Κλείσιμο</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="229"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="234"/>
+        <source>Quickload state</source>
+        <translation>Γρήγορη Φόρτωση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="237"/>
+        <source>F4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="242"/>
+        <source>Quicksave state</source>
+        <translation>Γρήγορη Αποθήκευση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="245"/>
+        <source>F2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="250"/>
+        <source>&amp;Load State File...</source>
+        <translation>&amp;Φόρτωση Σημείου Αποθήκευσης...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="255"/>
+        <source>&amp;Save State File...</source>
+        <translation>&amp;Αποθήκευση Σημείου Αποθήκευσης...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="260"/>
+        <source>E&amp;xit</source>
+        <translation>Έ&amp;ξοδος</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="265"/>
+        <source>&amp;Run</source>
+        <translation>&amp;Εκκίνηση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="268"/>
+        <source>F7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="273"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Παύση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="276"/>
+        <source>F8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="281"/>
+        <source>R&amp;eset</source>
+        <translation>Ε&amp;πανεκκίνηση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="289"/>
+        <source>&amp;Interpreter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="297"/>
+        <source>&amp;Slightly Faster Interpreter</source>
+        <translation>&amp;Ελαφρώς Γρηγορότερος Interpreter</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="305"/>
+        <source>&amp;Dynarec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="313"/>
+        <source>Load &amp;Map File...</source>
+        <translation>Φόρτωση &amp;Αρχείου Χάρτη...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="321"/>
+        <source>&amp;Save Map File...</source>
+        <translation>&amp;Αποθήκευση Αρχείου Χάρτη...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="329"/>
+        <source>&amp;Reset Symbol Table</source>
+        <translation>&amp;Επαναφορά Πίνακα Συμβόλων</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="334"/>
+        <source>&amp;Disassembly</source>
+        <translation>&amp;Αποσυναρμολόγηση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="337"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="345"/>
+        <source>&amp;Log Console</source>
+        <translation>&amp;Κονσόλα Καταγραφέα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="348"/>
+        <source>Ctrl+L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="353"/>
+        <source>Memory &amp;View...</source>
+        <translation>Εμφάνιση &amp;Μνήμης...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="356"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="361"/>
+        <source>&amp;Keyboard</source>
+        <translation>&amp;Πληκτρολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="366"/>
+        <source>&amp;Toggle fullscreen</source>
+        <translation>&amp;Μετάβαση σε πλήρη οθόνη</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="423"/>
+        <source>Show &amp;debug statistics</source>
+        <translation>Εμφάνιση &amp;στατιστικών αποσφαλμάτωσης</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="483"/>
+        <source>I&amp;gnore illegal reads/writes</source>
+        <translation>Α&amp;γνόηση αθέμιτων αναγνώσεων</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="602"/>
+        <source>&amp;Gamepad</source>
+        <translation>&amp;Χειριστήριο</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="607"/>
+        <source>Run on loa&amp;d</source>
+        <translation>Εκκίνηση στην έναρξ&amp;η<</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="681"/>
+        <source>Show &amp;FPS counter</source>
+        <translation>Εμφάνιση μετρητή &amp;FPS</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="689"/>
+        <source>S&amp;tretch to display</source>
+        <translation>Ε&amp;πέκταση στην οθόνη</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="697"/>
+        <source>&amp;Sound emulation</source>
+        <translation>&amp;Εξομοίωση ήχου</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="369"/>
+        <source>F12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="377"/>
+        <source>&amp;Buffered Rendering</source>
+        <translation>&amp;Buffered Απεικόνιση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="380"/>
+        <source>F5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="388"/>
+        <source>&amp;Hardware Transform</source>
+        <translation>Hardware Μετασχηματισμός</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="391"/>
+        <source>F6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="399"/>
+        <source>&amp;Linear Filtering</source>
+        <translation>Γραμμικό φιλτράρισμα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="407"/>
+        <source>&amp;Wireframe (experimental)</source>
+        <translation>Γράφημα Πλέγματος</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="415"/>
+        <source>&amp;Display Raw Framebuffer</source>
+        <translation>&amp;Εμφάνιση Ακατέργαστου Framebuffer</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="431"/>
+        <source>Screen &amp;1x</source>
+        <translation>Οθόνη &amp;1x</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="434"/>
+        <source>Ctrl+1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="442"/>
+        <source>Screen &amp;2x</source>
+        <translation>Οθόνη &amp;2x</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="445"/>
+        <source>Ctrl+2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="453"/>
+        <source>Screen &amp;3x</source>
+        <translation>Οθόνη &amp;3x</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="456"/>
+        <source>Ctrl+3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="464"/>
+        <source>Screen &amp;4x</source>
+        <translation>Οθόνη &amp;4x</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="467"/>
+        <source>Ctrl+4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="475"/>
+        <source>&amp;Fast Memory (dynarec, unstable)</source>
+        <translation>&amp;Γρήγορη Μνήμη (dynarec, ασταθής)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="488"/>
+        <source>&amp;Go to http://www.ppsspp.org/</source>
+        <translation>&amp;Μετάβαση σε http://www.ppsspp.org/</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="493"/>
+        <source>&amp;About PPSSPP...</source>
+        <translation>&amp;Περί του PPSSPP...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="501"/>
+        <source>&amp;Use VBO</source>
+        <translation>&amp;Χρήση VBO</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="509"/>
+        <location filename="../mainwindow.ui" line="541"/>
+        <location filename="../mainwindow.ui" line="573"/>
+        <source>Debug</source>
+        <translation>Αποσφαλμάτωση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="517"/>
+        <location filename="../mainwindow.ui" line="549"/>
+        <location filename="../mainwindow.ui" line="581"/>
+        <source>Warning</source>
+        <translation>Προειδοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="525"/>
+        <location filename="../mainwindow.ui" line="565"/>
+        <location filename="../mainwindow.ui" line="597"/>
+        <source>Error</source>
+        <translation>Σφάλμα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="533"/>
+        <location filename="../mainwindow.ui" line="557"/>
+        <location filename="../mainwindow.ui" line="589"/>
+        <source>Info</source>
+        <translation>Πληροφορίες</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="612"/>
+        <source>D&amp;ump next frame to log</source>
+        <translation>Ε&amp;ξαγωγή επόμενου καρέ στον καταγραφέα</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="620"/>
+        <source>&amp;Vertex Cache</source>
+        <translation>&amp;Προσορηνή Μνήμη Κορυφών</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="625"/>
+        <source>Memory View Texture...</source>
+        <translation>Προβολή Μνήμης Υφών...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="633"/>
+        <source>Simple 2xAA</source>
+        <translation>Απλό 2xAA</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="641"/>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="649"/>
+        <source>2x</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="657"/>
+        <source>4x</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="665"/>
+        <source>8x</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="673"/>
+        <source>16x</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="865"/>
+        <source>No translations</source>
+        <translation>Καμία Μετάφραση</translation>
+    </message>
+</context>
+<context>
+    <name>gamepadMapping</name>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="19"/>
+        <source>Cross</source>
+        <translation>Χί</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="20"/>
+        <source>Circle</source>
+        <translation>Κύκλος</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="21"/>
+        <source>Square</source>
+        <translation>Τετράγωνο</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="22"/>
+        <source>Triangle</source>
+        <translation>Τρίγωνο</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="23"/>
+        <source>Left Trigger</source>
+        <translation>Αριστερή σκανδάλη</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="24"/>
+        <source>Right Trigger</source>
+        <translation>Δεξιά σκανδάλη</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="25"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="26"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="27"/>
+        <source>Up</source>
+        <translation>Πάνω</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="28"/>
+        <source>Down</source>
+        <translation>Κάτω</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="29"/>
+        <source>Left</source>
+        <translation>Αριστερά</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="30"/>
+        <source>Right</source>
+        <translation>Δεξιά</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="32"/>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="35"/>
+        <source>Stick left</source>
+        <translation>Αναλογικό αριστερά</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="36"/>
+        <source>Stick right</source>
+        <translation>Αναλογικό δεξιά</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="37"/>
+        <source>Stick up</source>
+        <translation>Αναλογικό πάνω</translation>
+    </message>
+    <message>
+        <location filename="../gamepaddialog.cpp" line="38"/>
+        <source>Stick bottom</source>
+        <translation>Αναλογικό κάτω</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
All basic UI is fully translated, though I left some terms that have no
direct translation in Greek untouched. (Won't affect the end-user)
