### PR TITLE
Some armjit sync (warning: untested)

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -413,6 +413,9 @@ namespace MIPSComp
 				return;
 			}
 
+			// Reported to break Disgaea.
+			DISABLE;
+
 			gpr.MapDirtyIn(rt, rs);
 			if (useUBFXandBFI) {
 				UBFX(gpr.R(rt), gpr.R(rs), pos, size);

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -63,14 +63,12 @@ void Jit::BranchRSRTComp(u32 op, ArmGen::CCFlags cc, bool likely)
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 	
-	// The delay slot being nice doesn't really matter though...
-	
-	if (rt == 0)
-  {
+	if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0)
+	{
 		gpr.MapReg(rs);
 		CMP(gpr.R(rs), Operand2(0, TYPE_IMM));
-  }
-	else if (rs == 0 && (cc == CC_EQ || cc == CC_NEQ))  // only these are easily 'flippable'
+	}
+	else if (gpr.IsImm(rs) && gpr.GetImm(rs) == 0 && (cc == CC_EQ || cc == CC_NEQ))  // only these are easily 'flippable'
 	{
 		gpr.MapReg(rt);
 		CMP(gpr.R(rt), Operand2(0, TYPE_IMM));
@@ -79,32 +77,32 @@ void Jit::BranchRSRTComp(u32 op, ArmGen::CCFlags cc, bool likely)
 	{
 		gpr.MapInIn(rs, rt);
 		CMP(gpr.R(rs), gpr.R(rt));
-  }
+	}
 
-  ArmGen::FixupBranch ptr;
-  if (!likely)
-  {
+	ArmGen::FixupBranch ptr;
+	if (!likely)
+	{
 		if (!delaySlotIsNice)
 			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
 		else
 			FlushAll();
-    ptr = B_CC(cc);
-  }
-  else
-  {
+		ptr = B_CC(cc);
+	}
+	else
+	{
 		FlushAll();
 		ptr = B_CC(cc);
 		CompileDelaySlot(DELAYSLOT_FLUSH);
-  }
+	}
 
-  // Take the branch
-  WriteExit(targetAddr, 0);
+	// Take the branch
+	WriteExit(targetAddr, 0);
 
-  SetJumpTarget(ptr);
-  // Not taken
-  WriteExit(js.compilerPC+8, 1);
+	SetJumpTarget(ptr);
+	// Not taken
+	WriteExit(js.compilerPC+8, 1);
 
-  js.compiling = false;
+	js.compiling = false;
 }
 
 
@@ -125,23 +123,23 @@ void Jit::BranchRSZeroComp(u32 op, ArmGen::CCFlags cc, bool andLink, bool likely
 		CompileDelaySlot(DELAYSLOT_NICE);
 
 	gpr.MapReg(rs);
-  CMP(gpr.R(rs), Operand2(0, TYPE_IMM));
+	CMP(gpr.R(rs), Operand2(0, TYPE_IMM));
 
 	ArmGen::FixupBranch ptr;
 	if (!likely)
-  {
+	{
 		if (!delaySlotIsNice)
 			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
 		else
 			FlushAll();
 		ptr = B_CC(cc);
-  }
-  else
-  {
+	}
+	else
+	{
 		FlushAll();
 		ptr = B_CC(cc);
 		CompileDelaySlot(DELAYSLOT_FLUSH);
-  }
+	}
 
 	// Take the branch
 	if (andLink)
@@ -209,10 +207,10 @@ void Jit::BranchFPFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 		ERROR_LOG(JIT, "Branch in delay slot at %08x", js.compilerPC);
 		return;
 	}
-  int offset = (signed short)(op & 0xFFFF) << 2;
-  u32 targetAddr = js.compilerPC + offset + 4;
+	int offset = (signed short)(op & 0xFFFF) << 2;
+	u32 targetAddr = js.compilerPC + offset + 4;
 
-  u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
+	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceFPU(op, delaySlotOp);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
@@ -223,26 +221,26 @@ void Jit::BranchFPFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 	LDR(R0, CTXREG, offsetof(MIPSState, fpcond));
 	TST(R0, Operand2(1, TYPE_IMM));
 
-  ArmGen::FixupBranch ptr;
-  if (!likely)
-  {
+	ArmGen::FixupBranch ptr;
+	if (!likely)
+	{
 		if (!delaySlotIsNice)
 			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
-    ptr = B_CC(cc);
-  }
-  else
-  {
-    ptr = B_CC(cc);
+		ptr = B_CC(cc);
+	}
+	else
+	{
+		ptr = B_CC(cc);
 		CompileDelaySlot(DELAYSLOT_FLUSH);
-  }
+	}
 
-  // Take the branch
-  WriteExit(targetAddr, 0);
+	// Take the branch
+	WriteExit(targetAddr, 0);
 
-  SetJumpTarget(ptr);
-  // Not taken
-  WriteExit(js.compilerPC + 8, 1);
-  js.compiling = false;
+	SetJumpTarget(ptr);
+	// Not taken
+	WriteExit(js.compilerPC + 8, 1);
+	js.compiling = false;
 }
 
 void Jit::Comp_FPUBranch(u32 op)
@@ -307,18 +305,14 @@ void Jit::BranchVFPUFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 
 void Jit::Comp_VBranch(u32 op)
 {
-  switch ((op >> 16) & 3)
-  {
+	switch ((op >> 16) & 3)
+	{
 	case 0:	BranchVFPUFlag(op, CC_NEQ, false); break;  // bvf
 	case 1: BranchVFPUFlag(op, CC_EQ,  false); break;  // bvt
 	case 2: BranchVFPUFlag(op, CC_NEQ, true);  break;  // bvfl
 	case 3: BranchVFPUFlag(op, CC_EQ,  true);  break;  // bvtl
 	}
 	js.compiling = false;
-}
-
-void PrintAtExit() {
-	INFO_LOG(HLE, "at jump");
 }
 
 void Jit::Comp_Jump(u32 op)
@@ -335,8 +329,8 @@ void Jit::Comp_Jump(u32 op)
 	switch (op >> 26) 
 	{
 	case 2: //j
-    WriteExit(targetAddr, 0);
-    break; 
+		WriteExit(targetAddr, 0);
+		break;
 
 	case 3: //jal
 		MOVI2R(R0, js.compilerPC + 8);
@@ -395,7 +389,7 @@ void Jit::Comp_JumpReg(u32 op)
 		break;
 	}
 
-  WriteExitDestInR(R8);
+	WriteExitDestInR(R8);
 	js.compiling = false;
 }
 

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -220,8 +220,8 @@ void Jit::BranchFPFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 
 	FlushAll();
 
-	LDR(R0, R10, offsetof(MIPSState, fpcond));
-  TST(R0, Operand2(1, TYPE_IMM));
+	LDR(R0, CTXREG, offsetof(MIPSState, fpcond));
+	TST(R0, Operand2(1, TYPE_IMM));
 
   ArmGen::FixupBranch ptr;
   if (!likely)

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -290,28 +290,28 @@ void Jit::Comp_Generic(u32 op)
 }
 
 void Jit::MovFromPC(ARMReg r) {
-	LDR(r, R10, offsetof(MIPSState, pc));
+	LDR(r, CTXREG, offsetof(MIPSState, pc));
 }
 
 void Jit::MovToPC(ARMReg r) {
-	STR(r, R10, offsetof(MIPSState, pc));
+	STR(r, CTXREG, offsetof(MIPSState, pc));
 }
 
 void Jit::WriteDownCount(int offset)
 {
 	int theDowncount = js.downcountAmount + offset;
-	LDR(R1, R10, offsetof(MIPSState, downcount));
+	LDR(R1, CTXREG, offsetof(MIPSState, downcount));
 	Operand2 op2;
 	if (TryMakeOperand2(theDowncount, op2)) // We can enlarge this if we used rotations
 	{
 		SUBS(R1, R1, op2);
-		STR(R1, R10, offsetof(MIPSState, downcount));
+		STR(R1, CTXREG, offsetof(MIPSState, downcount));
 	} else {
 		// Should be fine to use R2 here, flushed the regcache anyway.
 		// If js.downcountAmount can be expressed as an Imm8, we don't need this anyway.
 		MOVI2R(R2, theDowncount);
 		SUBS(R1, R1, R2);
-		STR(R1, R10, offsetof(MIPSState, downcount));
+		STR(R1, CTXREG, offsetof(MIPSState, downcount));
 	}
 }
 

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -48,7 +48,7 @@ static const ARMReg *GetMIPSAllocationOrder(int &count) {
 	// R8 is used to preserve flags in nasty branches.
 	// R9 and upwards are reserved for jit basics.
 	static const ARMReg allocationOrder[] = {
-		R12, R1, R2, R3, R4, R5, R6, R7, 
+		R2, R3, R4, R5, R6, R7, R12,
 	};
 	count = sizeof(allocationOrder) / sizeof(const int);
 	return allocationOrder;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -363,21 +363,7 @@ void Jit::Comp_VVectorInit(u32 op) {
 	GetVectorRegsPrefixD(dregs, sz, _VD);
 	fpr.MapRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 	for (int i = 0; i < n; ++i)
-	{
-		switch ((op >> 16) & 0xF)
-		{
-		case 6: // v=zeros; break;  //vzero
-			MOVSS(fpr.VX(dregs[i]), R(XMM0));
-			break;
-		case 7: // v=ones; break;   //vone
-			MOVSS(fpr.VX(dregs[i]), R(XMM0));
-			break;
-		default:
-			DISABLE;
-			break;
-		}
-	}
-
+		MOVSS(fpr.VX(dregs[i]), R(XMM0));
 	ApplyPrefixD(dregs, sz);
 
 	fpr.ReleaseSpillLocks();


### PR DESCRIPTION
I just went over and compared to see if I could see anything obviously wrong / different.  I can't test the armjit though, so probably don't merge without testing.  Mostly it's:
- Replace `rs == 0` with `gpr.IsImm(rs) && gpr.GetImm(rs) == 0`.
- Add checks for writes to zero.
- Remove one redundant line since reg 0 always IsImm.
- Remove an init to rd in ext (ext always writes the value.)
- R10 -> CTXREG in more places.
- Some indentation cleanup.
- Disable ext since it's reported to break Disgaea (although not sure, we can re-enable if not.)

Edit: and unfortunately, I couldn't really find anything anyway.  Was hoping to see what the recent breakages are about...

-[Unknown]
