### PR TITLE
Try to use game's default PGF Font

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -56,6 +56,7 @@ void CConfig::Load(const char *iniFileName)
 	general->Get("ShowDebuggerOnLoad", &bShowDebuggerOnLoad, false);
 	// "default" means let emulator decide, "" means disable.
 	general->Get("ReportHost", &sReportHost, "default");
+	general->Get("UseGamePGFFont", &bUseGamePGFFont, true);
 
 	IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 	cpu->Get("Jit", &bJit, true);
@@ -124,6 +125,7 @@ void CConfig::Save()
 		general->Set("CurrentDirectory", currentDirectory);
 		general->Set("ShowDebuggerOnLoad", bShowDebuggerOnLoad);
 		general->Set("ReportHost", sReportHost);
+		general->Set("UseGamePGFFont", bUseGamePGFFont);
 
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 		cpu->Set("Jit", bJit);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -44,6 +44,7 @@ public:
 	bool bConfirmOnQuit;
 	bool bAutoRun;  // start immediately
 	bool bBrowse;
+	bool bUseGamePGFFont;
 
 	// Core
 	bool bIgnoreBadMemAccess;


### PR DESCRIPTION
In many games, their default PGF Font is in disc0:/PSP_GAME/USRDIR/. So I try to load them as the default PGF font if they exist.
And I also add an option for it. If you just want to use your own fonts, you can set it to false.
