### PR TITLE
Memory breakpoints (jit x86 only)

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -38,6 +38,8 @@ void MemCheck::Action(u32 iValue, u32 addr, bool write, int size, u32 pc)
 {
 	if ((write && bOnWrite) || (!write && bOnRead))
 	{
+		++numHits;
+
 		if (bLog)
 		{
 			char temp[256];
@@ -86,20 +88,21 @@ void CBreakPoints::ClearAllBreakPoints()
 	InvalidateJit();
 }
 
-MemCheck *CBreakPoints::GetMemCheck(u32 address)
+MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 {
 	std::vector<MemCheck>::iterator iter;
 	for (iter = MemChecks.begin(); iter != MemChecks.end(); ++iter)
 	{
-		if ((*iter).bRange)
+		MemCheck &check = *iter;
+		if (check.bRange)
 		{
-			if (address >= (*iter).iStartAddress && address <= (*iter).iEndAddress)
-				return &(*iter);
+			if (address >= check.iStartAddress && address + size < check.iEndAddress)
+				return &check;
 		}
 		else
 		{
-			if ((*iter).iStartAddress==address)
-				return &(*iter);
+			if (check.iStartAddress==address)
+				return &check;
 		}
 	}
 

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -34,18 +34,14 @@ MemCheck::MemCheck(void)
 	numHits=0;
 }
 
-void MemCheck::Action(u32 iValue, u32 addr, bool write, int size, u32 pc)
+void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
 {
 	if ((write && bOnWrite) || (!write && bOnRead))
 	{
 		++numHits;
 
 		if (bLog)
-		{
-			char temp[256];
-			sprintf(temp,"CHK %08x %s%i at %08x (%s), PC=%08x (%s)",iValue,write?"Write":"Read",size*8,addr,symbolMap.GetDescription(addr),pc,symbolMap.GetDescription(pc));
-			ERROR_LOG(MEMMAP,"%s",temp);
-		}
+			NOTICE_LOG(MEMMAP, "CHK %s%i at %08x (%s), PC=%08x (%s)", write ? "Write" : "Read", size * 8, addr, symbolMap.GetDescription(addr), pc, symbolMap.GetDescription(pc));
 		if (bBreak)
 			Core_Pause();
 	}

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -19,6 +19,7 @@
 #include "Breakpoints.h"
 #include "SymbolMap.h"
 #include "FixedSizeUnorderedSet.h"
+#include "Core/Host.h"
 #include "../MIPS/JitCommon/JitCommon.h"
 #include <cstdio>
 
@@ -43,7 +44,10 @@ void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
 		if (bLog)
 			NOTICE_LOG(MEMMAP, "CHK %s%i at %08x (%s), PC=%08x (%s)", write ? "Write" : "Read", size * 8, addr, symbolMap.GetDescription(addr), pc, symbolMap.GetDescription(pc));
 		if (bBreak)
+		{
 			Core_Pause();
+			host->SetDebugMode(true);
+		}
 	}
 }
 

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -47,7 +47,7 @@ struct MemCheck
 
 	u32 numHits;
 
-	void Action(u32 _iValue, u32 addr, bool write, int size, u32 pc);
+	void Action(u32 addr, bool write, int size, u32 pc);
 };
 
 class CBreakPoints

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -60,13 +60,14 @@ private:
 	static u32	m_iBreakOnCount;
 
 public:
+	// WARNING: Not used in interpreter or HLE, only jit CPU memory access.
 	static std::vector<MemCheck> MemChecks;
 
 	// is address breakpoint
 	static bool IsAddressBreakPoint(u32 _iAddress);
 
-	//memory breakpoint
-	static MemCheck *GetMemCheck(u32 address);
+	// WARNING: Not used in interpreter or HLE, only jit CPU memory access.
+	static MemCheck *GetMemCheck(u32 address, int size);
 
 	// is break on count
 	static bool IsBreakOnCount(u32 _iAddress);

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -106,7 +106,7 @@ void Jit::Comp_FPULS(u32 op)
 
 			JitSafeMem safe(this, rs, offset);
 			OpArg src;
-			if (safe.PrepareRead(src))
+			if (safe.PrepareRead(src, 4))
 				MOVSS(fpr.RX(ft), src);
 			if (safe.PrepareSlowRead((void *) &Memory::Read_U32))
 			{
@@ -127,7 +127,7 @@ void Jit::Comp_FPULS(u32 op)
 
 			JitSafeMem safe(this, rs, offset);
 			OpArg dest;
-			if (safe.PrepareWrite(dest))
+			if (safe.PrepareWrite(dest, 4))
 				MOVSS(dest, fpr.RX(ft));
 			if (safe.PrepareSlowWrite())
 			{

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -53,7 +53,7 @@ namespace MIPSComp
 
 		JitSafeMem safe(this, rs, offset);
 		OpArg src;
-		if (safe.PrepareRead(src))
+		if (safe.PrepareRead(src, 4))
 			(this->*mov)(32, bits, gpr.RX(rt), src);
 		if (safe.PrepareSlowRead(safeFunc))
 			(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
@@ -83,7 +83,7 @@ namespace MIPSComp
 
 		JitSafeMem safe(this, rs, offset);
 		OpArg dest;
-		if (safe.PrepareWrite(dest))
+		if (safe.PrepareWrite(dest, 4))
 		{
 			if (needSwap)
 			{

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -210,7 +210,7 @@ void Jit::Comp_SV(u32 op) {
 			JitSafeMem safe(this, rs, imm);
 			safe.SetFar();
 			OpArg src;
-			if (safe.PrepareRead(src))
+			if (safe.PrepareRead(src, 4))
 			{
 				MOVSS(fpr.VX(vt), safe.NextFastAddress(0));
 			}
@@ -236,7 +236,7 @@ void Jit::Comp_SV(u32 op) {
 			JitSafeMem safe(this, rs, imm);
 			safe.SetFar();
 			OpArg dest;
-			if (safe.PrepareWrite(dest))
+			if (safe.PrepareWrite(dest, 4))
 			{
 				MOVSS(safe.NextFastAddress(0), fpr.VX(vt));
 			}
@@ -278,7 +278,7 @@ void Jit::Comp_SVQ(u32 op)
 			JitSafeMem safe(this, rs, imm);
 			safe.SetFar();
 			OpArg src;
-			if (safe.PrepareRead(src))
+			if (safe.PrepareRead(src, 16))
 			{
 				// Just copy 4 words the easiest way while not wasting registers.
 				for (int i = 0; i < 4; i++)
@@ -312,7 +312,7 @@ void Jit::Comp_SVQ(u32 op)
 			JitSafeMem safe(this, rs, imm);
 			safe.SetFar();
 			OpArg dest;
-			if (safe.PrepareWrite(dest))
+			if (safe.PrepareWrite(dest, 16))
 			{
 				for (int i = 0; i < 4; i++)
 					MOVSS(safe.NextFastAddress(i * 4), fpr.VX(vregs[i]));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -722,19 +722,20 @@ void Jit::JitSafeMem::MemCheckAsm(ReadType type)
 		FixupBranch skipNext, skipNextRange;
 		if (it->bRange)
 		{
-			jit_->CMP(32, R(xaddr_), Imm32(it->iStartAddress));
+			jit_->CMP(32, R(xaddr_), Imm32(it->iStartAddress - offset_));
 			skipNext = jit_->J_CC(CC_B);
-			jit_->CMP(32, R(xaddr_), Imm32(it->iEndAddress - size_));
+			jit_->CMP(32, R(xaddr_), Imm32(it->iEndAddress - offset_ - size_));
 			skipNextRange = jit_->J_CC(CC_AE);
 		}
 		else
 		{
-			jit_->CMP(32, R(xaddr_), Imm32(it->iStartAddress));
+			jit_->CMP(32, R(xaddr_), Imm32(it->iStartAddress - offset_));
 			skipNext = jit_->J_CC(CC_NE);
 		}
 
 		jit_->PUSH(xaddr_);
 		jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->js.compilerPC));
+		jit_->ADD(32, R(xaddr_), Imm32(offset_));
 		jit_->ABI_CallFunctionACC(jit_->thunks.ProtectFunction((void *)&JitMemCheck, 3), R(xaddr_), size_, type == MEM_WRITE ? 1 : 0);
 		jit_->POP(xaddr_);
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -632,10 +632,12 @@ void Jit::JitSafeMem::NextSlowRead(void *safeFunc, int suboffset)
 
 void Jit::JitSafeMem::Finish()
 {
-	if (needsCheck_)
+	// Memory::Read_U32/etc. may have tripped coreState.
+	if (needsCheck_ && !g_Config.bIgnoreBadMemAccess)
 	{
-		// Memory::Read_U32/etc. may have tripped coreState.
-		if (!g_Config.bIgnoreBadMemAccess)
+		if (jit_->js.inDelaySlot)
+			jit_->js.needCheckCoreState = true;
+		else
 		{
 			jit_->CMP(32, M((void*)&coreState), Imm32(0));
 			FixupBranch skipCheck = jit_->J_CC(CC_E);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -356,9 +356,9 @@ void Jit::WriteExitDestInEAX()
 	if (!g_Config.bFastMemory)
 	{
 		CMP(32, R(EAX), Imm32(PSP_GetKernelMemoryBase()));
-		FixupBranch tooLow = J_CC(CC_L);
+		FixupBranch tooLow = J_CC(CC_B);
 		CMP(32, R(EAX), Imm32(PSP_GetUserMemoryEnd()));
-		FixupBranch tooHigh = J_CC(CC_GE);
+		FixupBranch tooHigh = J_CC(CC_AE);
 
 		// Need to set neg flag again if necessary.
 		SUB(32, M(&currentMIPS->downcount), Imm32(0));
@@ -519,9 +519,9 @@ OpArg Jit::JitSafeMem::PrepareMemoryOpArg(ReadType type)
 	{
 		// Is it in physical ram?
 		jit_->CMP(32, R(xaddr_), Imm32(PSP_GetKernelMemoryBase() - offset_));
-		tooLow_ = jit_->J_CC(CC_L);
+		tooLow_ = jit_->J_CC(CC_B);
 		jit_->CMP(32, R(xaddr_), Imm32(PSP_GetUserMemoryEnd() - offset_ - (size_ - 1)));
-		tooHigh_ = jit_->J_CC(CC_GE);
+		tooHigh_ = jit_->J_CC(CC_AE);
 
 		// We may need to jump back up here.
 		safe_ = jit_->GetCodePtr();
@@ -554,9 +554,9 @@ void Jit::JitSafeMem::PrepareSlowAccess()
 
 	// Might also be the scratchpad.
 	jit_->CMP(32, R(xaddr_), Imm32(PSP_GetScratchpadMemoryBase() - offset_));
-	FixupBranch tooLow = jit_->J_CC(CC_L);
+	FixupBranch tooLow = jit_->J_CC(CC_B);
 	jit_->CMP(32, R(xaddr_), Imm32(PSP_GetScratchpadMemoryEnd() - offset_ - (size_ - 1)));
-	jit_->J_CC(CC_L, safe_);
+	jit_->J_CC(CC_B, safe_);
 	jit_->SetJumpTarget(tooLow);
 }
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -56,11 +56,19 @@ struct JitState
 		PREFIX_KNOWN_DIRTY = 0x11,
 	};
 
+	enum AfterOp
+	{
+		AFTER_NONE = 0x00,
+		AFTER_CORE_STATE = 0x01,
+		AFTER_REWIND_PC_BAD_STATE = 0x02,
+	};
+
 	u32 compilerPC;
 	u32 blockStart;
 	bool cancel;
 	bool inDelaySlot;
-	bool needCheckCoreState;
+	// See JitState::AfterOp for values.
+	int afterOp;
 	int downcountAmount;
 	int numInstructions;
 	bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
@@ -309,11 +317,12 @@ private:
 		s32 offset_;
 		int size_;
 		bool needsCheck_;
-		bool needsSkip_, needsSkipCheck_;
+		bool needsSkip_;
 		bool far_;
 		u32 iaddr_;
 		X64Reg xaddr_;
-		FixupBranch tooLow_, tooHigh_, skip_, skipCheck_;
+		FixupBranch tooLow_, tooHigh_, skip_;
+		std::vector<FixupBranch> skipChecks_;
 		const u8 *safe_;
 	};
 	friend class JitSafeMem;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -298,14 +298,16 @@ private:
 			MEM_WRITE,
 		};
 
-		OpArg PrepareMemoryOpArg(ReadType type, int size);
+		OpArg PrepareMemoryOpArg(ReadType type);
 		void PrepareSlowAccess();
-		void MemCheckImm(ReadType type, int size);
-		void MemCheckAsm(ReadType type, int size);
+		void MemCheckImm(ReadType type);
+		void MemCheckAsm(ReadType type);
+		bool ImmValid();
 
 		Jit *jit_;
 		int raddr_;
 		s32 offset_;
+		int size_;
 		bool needsCheck_;
 		bool needsSkip_;
 		bool far_;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -309,11 +309,11 @@ private:
 		s32 offset_;
 		int size_;
 		bool needsCheck_;
-		bool needsSkip_;
+		bool needsSkip_, needsSkipCheck_;
 		bool far_;
 		u32 iaddr_;
 		X64Reg xaddr_;
-		FixupBranch tooLow_, tooHigh_, skip_;
+		FixupBranch tooLow_, tooHigh_, skip_, skipCheck_;
 		const u8 *safe_;
 	};
 	friend class JitSafeMem;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -60,6 +60,7 @@ struct JitState
 	u32 blockStart;
 	bool cancel;
 	bool inDelaySlot;
+	bool needCheckCoreState;
 	int downcountAmount;
 	int numInstructions;
 	bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
@@ -269,14 +270,14 @@ private:
 		JitSafeMem(Jit *jit, int raddr, s32 offset);
 
 		// Emit code necessary for a memory write, returns true if MOV to dest is needed.
-		bool PrepareWrite(OpArg &dest);
+		bool PrepareWrite(OpArg &dest, int size);
 		// Emit code proceeding a slow write call, returns true if slow write is needed.
 		bool PrepareSlowWrite();
 		// Emit a slow write from src.
 		void DoSlowWrite(void *safeFunc, const OpArg src, int suboffset = 0);
 
 		// Emit code necessary for a memory read, returns true if MOV from src is needed.
-		bool PrepareRead(OpArg &src);
+		bool PrepareRead(OpArg &src, int size);
 		// Emit code for a slow read call, and returns true if result is in EAX.
 		bool PrepareSlowRead(void *safeFunc);
 		
@@ -291,8 +292,16 @@ private:
 		void NextSlowRead(void *safeFunc, int suboffset);
 
 	private:
-		OpArg PrepareMemoryOpArg();
+		enum ReadType
+		{
+			MEM_READ,
+			MEM_WRITE,
+		};
+
+		OpArg PrepareMemoryOpArg(ReadType type, int size);
 		void PrepareSlowAccess();
+		void MemCheckImm(ReadType type, int size);
+		void MemCheckAsm(ReadType type, int size);
 
 		Jit *jit_;
 		int raddr_;


### PR DESCRIPTION
This is just a basic version - for example, I opted to ignore the value for now.  Also, there's no user interface so it's essentially not enabled right now...

Performance impact should be negligible when there are no memory breakpoints.  But they should not be super slow even when they do exist.

Also fixes "ignore invalid memory access" when off breaking in a delay slot.  And uses unsigned B/AE instead of L/GE... oops.

This is only for CPU access though, not for HLE.  I was thinking I could make special (not unchecked but skipping memory breakpoints...) functions for the interpreter and maybe enable memchecks in at least Write*/Memset/Memcpy?  But I'm not sure.

Anyway, it's a first step.

-[Unknown]
