### PR TITLE
armjit: Don't MapReg before checking for IsImm()

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -274,10 +274,11 @@ namespace MIPSComp
 			break;
 
 		case 39: // R(rd) = ~(R(rs) | R(rt));       break; //nor
-			gpr.MapDirtyInIn(rd, rs, rt);
 			if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0) {
+				gpr.MapDirtyIn(rd, rs);
 				MVN(gpr.R(rd), gpr.R(rs));
 			} else {
+				gpr.MapDirtyInIn(rd, rs, rt);
 				ORR(gpr.R(rd), gpr.R(rs), gpr.R(rt));
 				MVN(gpr.R(rd), gpr.R(rd));
 			}


### PR DESCRIPTION
Minor optimization to nor.  Untested, and theoretically the imm path was never being followed before...

Found when looking at #922's log.  I don't see any GetImm()s that aren't protected...

-[Unknown]
