### PR TITLE
Call GetImm() before Map* in case of overlap

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -347,8 +347,8 @@ namespace MIPSComp
 		int rs = _RS;
 		if (gpr.IsImm(rs))
 		{
-			gpr.MapDirtyIn(rd, rt);
 			int sa = gpr.GetImm(rs) & 0x1F;
+			gpr.MapDirtyIn(rd, rt);
 			MOV(gpr.R(rd), Operand2(gpr.R(rt), shiftType, sa));
 			return;
 		}


### PR DESCRIPTION
Untested, but I expect this to fix the GetImm() issue reported in #922 and the reports on the forum.

Could be optimized for more imm cases.  Anyway, this occurs in the common case of rs == rt or even rs == rd for sllv, srlv, etc.

-[Unknown]
