### PR TITLE
Add thoughmode for fliptexture

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -639,8 +639,12 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		memcpy(&transformed[index].x, v, 3 * sizeof(float));
 		transformed[index].fog = fogCoef;
 		memcpy(&transformed[index].u, uv, 2 * sizeof(float));
-		if (gstate_c.flipTexture)
-			transformed[index].v = 1.0f - transformed[index].v; //(float)gstate_c.actualTextureHeight / gstate_c.curTextureHeight - transformed[index].v;
+		if (gstate_c.flipTexture) {
+			if (throughmode)
+				transformed[index].v = (float)gstate_c.actualTextureHeight / gstate_c.curTextureHeight - transformed[index].v;
+			else
+				transformed[index].v = 1.0f - transformed[index].v * 2.0f;
+		}
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;
 		}


### PR DESCRIPTION
This fixes vertical stretch issue in Saint Seiya Omega's character and Super Robot Taisen A 

(However width issue in Super Robot Taisen A  is not yet resolved ......)
