### PR TITLE
Fix Android build not building git-version right

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -199,4 +199,7 @@ $(call import-module,libzip)
 $(call import-module,native)
 
 jni/$(SRC)/git-version.cpp:
-	./git-version-gen.sh
+	-./git-version-gen.sh
+	-..\Windows\git-version-gen.cmd
+
+.PHONY: jni/$(SRC)/git-version.cpp


### PR DESCRIPTION
I think this should work okay, although it ignores errors.  I'm not sure if people might use different makes...

Also marked PHONY so it runs every time.

-[Unknown]
