### PR TITLE
sceMpegQueryStreamOffset : set -1 to return value

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -399,7 +399,12 @@ void __MpegShutdown() {
 
 u32 sceMpegInit()
 {
-	WARN_LOG(HLE, "sceMpegInit()");
+	if (!g_Config.bUseMediaEngine) {
+		WARN_LOG(HLE, "sceMpegInit() : Media Engine disabled");
+		return -1;
+	}
+
+	WARN_LOG(HLE, "sceMpegInit() : Media Engine Enabled");
 	return 0;
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -126,9 +126,9 @@ struct Mp3Context {
 		p.DoMarker("Mp3Context");
 	}
 
-	int mp3StreamStart;
-	int mp3StreamEnd;
-	int mp3StreamPosition;
+	u64 mp3StreamStart;
+	u64 mp3StreamEnd;
+	u64 mp3StreamPosition;
 	u32 mp3Buf;
 	int mp3BufSize;
 	int mp3BufPendingSize;
@@ -400,8 +400,8 @@ void __MpegShutdown() {
 u32 sceMpegInit()
 {
 	if (!g_Config.bUseMediaEngine) {
-		WARN_LOG(HLE, "sceMpegInit() : Media Engine disabled");
-		return -1;
+		WARN_LOG(HLE, "sceMpegInit() : Media Engine Disabled");
+		 return -1;
 	}
 
 	WARN_LOG(HLE, "sceMpegInit() : Media Engine Enabled");
@@ -1647,7 +1647,7 @@ int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcpos
 	if(Memory::IsValidAddress(towritePtr))
 		Memory::Write_U32(ctx->mp3BufSize, towritePtr);
 	if(Memory::IsValidAddress(srcposPtr))
-		Memory::Write_U32(ctx->mp3StreamPosition, srcposPtr);
+		Memory::Write_U64(ctx->mp3StreamPosition, srcposPtr);
 
 	return 0;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -297,7 +297,7 @@ u32 convertTimestampToDate(u32 ts) {
 
 void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 	ctx->mpegStreamAddr = buffer_addr;
-	ctx->mpegMagic = Memory::Read_U32(buffer_addr);
+	ctx->mpegMagic = Memory::Read_U32(buffer_addr + PSMF_MAGIC_OFFSET);
 	ctx->mpegRawVersion = Memory::Read_U32(buffer_addr + PSMF_STREAM_VERSION_OFFSET);
 	switch (ctx->mpegRawVersion) {
 	case PSMF_VERSION_0012:
@@ -322,8 +322,8 @@ void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 	ctx->mpegLastTimestamp = bswap32(Memory::Read_U32(buffer_addr + PSMF_LAST_TIMESTAMP_OFFSET));
 	ctx->mpegFirstDate = convertTimestampToDate(ctx->mpegFirstTimestamp);
 	ctx->mpegLastDate = convertTimestampToDate(ctx->mpegLastTimestamp);
-	ctx->avc.avcDetailFrameWidth = (Memory::Read_U8(buffer_addr + 142) * 0x10);
-	ctx->avc.avcDetailFrameHeight = (Memory::Read_U8(buffer_addr + 143) * 0x10);
+	ctx->avc.avcDetailFrameWidth = (Memory::Read_U8(buffer_addr + PSMF_FRAME_WIDTH_OFFSET) * 0x10);
+	ctx->avc.avcDetailFrameHeight = (Memory::Read_U8(buffer_addr + PSMF_FRAME_HEIGHT_OFFSET) * 0x10);
 	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 	ctx->avc.avcFrameStatus = 0;
 
@@ -526,6 +526,7 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 		WARN_LOG(HLE, "Media Engine disabled");
 		return -1;
 	}
+
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
 		WARN_LOG(HLE, "sceMpegQueryStreamOffset(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, offsetAddr);
@@ -1300,7 +1301,7 @@ u32 sceMpegRingbufferDestruct(u32 ringbufferAddr)
 u32 sceMpegAvcInitYCbCr(u32 mpeg, int mode, int width, int height, u32 ycbcr_addr)
 {
 	ERROR_LOG(HLE, "UNIMPL sceMpegAvcInitYCbCr(%08x, %i, %i, %i, %08x)", mpeg, mode, width, height, ycbcr_addr);
-	return 0;
+	return -1;
 }
 
 int sceMpegAvcQueryYCbCrSize(u32 mpeg, u32 mode, u32 width, u32 height, u32 resultAddr)

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -48,11 +48,14 @@ static const int PSMF_VERSION_0012 = 0x32313030;
 static const int PSMF_VERSION_0013 = 0x33313030;
 static const int PSMF_VERSION_0014 = 0x34313030;
 static const int PSMF_VERSION_0015 = 0x35313030;
+static const int PSMF_MAGIC_OFFSET = 0x0;
 static const int PSMF_STREAM_VERSION_OFFSET = 0x4;
 static const int PSMF_STREAM_OFFSET_OFFSET = 0x8;
 static const int PSMF_STREAM_SIZE_OFFSET = 0xC;
 static const int PSMF_FIRST_TIMESTAMP_OFFSET = 0x56;
 static const int PSMF_LAST_TIMESTAMP_OFFSET = 0x5C;
+static const int PSMF_FRAME_WIDTH_OFFSET = 0x8E;
+static const int PSMF_FRAME_HEIGHT_OFFSET = 0x8F;
 
 struct SceMpegAu {
 	s64 pts;  // presentation time stamp


### PR DESCRIPTION
This fixes start new game crash issue from Sol Trigger (#930) as well as the intro crash issue from last promise story 

UseMediaEngine will be kept until no more issues found  (#842)
