### PR TITLE
Handle async IO more correctly (testing/review)

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -65,7 +65,9 @@ void hleDelayResultFinish(u64 userdata, int cycleslate)
 	u32 error;
 	SceUID threadID = (SceUID) userdata;
 	SceUID verify = __KernelGetWaitID(threadID, WAITTYPE_DELAY, error);
-	u64 result = (userdata ^ threadID) | __KernelGetWaitValue(threadID, error);
+	// The top 32 bits of userdata are the top 32 bits of the 64 bit result.
+	// We can't just put it all in userdata because we need to know the threadID...
+	u64 result = (userdata & 0xFFFFFFFF00000000ULL) | __KernelGetWaitValue(threadID, error);
 
 	if (error == 0 && verify == 1)
 		__KernelResumeThreadFromWait(threadID, result);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -65,7 +65,7 @@ void hleDelayResultFinish(u64 userdata, int cycleslate)
 	u32 error;
 	SceUID threadID = (SceUID) userdata;
 	SceUID verify = __KernelGetWaitID(threadID, WAITTYPE_DELAY, error);
-	SceUID result = __KernelGetWaitValue(threadID, error);
+	u64 result = (userdata ^ threadID) | __KernelGetWaitValue(threadID, error);
 
 	if (error == 0 && verify == 1)
 		__KernelResumeThreadFromWait(threadID, result);
@@ -332,6 +332,14 @@ u32 hleDelayResult(u32 result, const char *reason, int usec)
 {
 	CoreTiming::ScheduleEvent(usToCycles(usec), delayedResultEvent, __KernelGetCurThread());
 	__KernelWaitCurThread(WAITTYPE_DELAY, 1, result, 0, false, reason);
+	return result;
+}
+
+u64 hleDelayResult(u64 result, const char *reason, int usec)
+{
+	u64 param = (result & 0xFFFFFFFF00000000) | __KernelGetCurThread();
+	CoreTiming::ScheduleEvent(usToCycles(usec), delayedResultEvent, param);
+	__KernelWaitCurThread(WAITTYPE_DELAY, 1, (u32) result, 0, false, reason);
 	return result;
 }
 

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -89,7 +89,18 @@ void hleDebugBreak();
 
 // Delays the result for usec microseconds, allowing other threads to run during this time.
 u32 hleDelayResult(u32 result, const char *reason, int usec);
+u64 hleDelayResult(u64 result, const char *reason, int usec);
 void hleEatMicro(int usec);
+
+inline int hleDelayResult(int result, const char *reason, int usec)
+{
+	return hleDelayResult((u32) result, reason, usec);
+}
+
+inline s64 hleDelayResult(s64 result, const char *reason, int usec)
+{
+	return hleDelayResult((u64) result, reason, usec);
+}
 
 void HLEInit();
 void HLEDoState(PointerWrap &p);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -627,7 +627,8 @@ s64 sceIoLseek(int id, s64 offset, int whence) {
 	s64 result = __IoLseek(id, offset, whence);
 	if (result >= 0) {
 		DEBUG_LOG(HLE, "%lli = sceIoLseek(%d, %llx, %i)", result, id, offset, whence);
-		return result;
+		// Educated guess at timing.
+		return hleDelayResult(result, "io seek", 100);
 	} else {
 		ERROR_LOG(HLE, "sceIoLseek(%d, %llx, %i) - ERROR: invalid file", id, offset, whence);
 		return result;
@@ -638,7 +639,8 @@ u32 sceIoLseek32(int id, int offset, int whence) {
 	s32 result = (s32) __IoLseek(id, offset, whence);
 	if (result >= 0) {
 		DEBUG_LOG(HLE, "%lli = sceIoLseek(%d, %x, %i)", result, id, offset, whence);
-		return result;
+		// Educated guess at timing.
+		return hleDelayResult(result, "io seek", 100);
 	} else {
 		ERROR_LOG(HLE, "sceIoLseek(%d, %x, %i) - ERROR: invalid file", id, offset, whence);
 		return result;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -780,22 +780,23 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 	// UMD checks
 	switch (cmd) {
 	case 0x01F20001:  // Get Disc Type.
-		if (Memory::IsValidAddress(outPtr)) {
-			Memory::Write_U32(0x10, outPtr);  // Game disc
+		if (Memory::IsValidAddress(outPtr + 4)) {
+			Memory::Write_U32(0x10, outPtr + 4);  // Game disc
 			return 0;
-		} else {
-			return -1;
 		}
-		break;
-	case 0x01F20002:  // Get current LBA.
+		return -1;
+	case 0x01F20002:  // Get last sector number.
+	case 0x01F20003:  // Seems identical?
 		if (Memory::IsValidAddress(outPtr)) {
-			Memory::Write_U32(0, outPtr);  // Game disc
+			PSPFileInfo info = pspFileSystem.GetFileInfo("umd1:");
+			Memory::Write_U32((u32) (info.size / 2048) - 1, outPtr);
 			return 0;
-		} else {
-			return -1;
 		}
-		break;
+		return -1;
 	case 0x01F100A3:  // Seek
+		// Timing is just a rough guess, probably takes longer.
+		return hleDelayResult(0, "dev seek", 100);
+	case 0x01F100A4:  // Cache
 		return 0;
 	}
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1271,7 +1271,6 @@ public:
 u32 sceIoDopen(const char *path) {
 	DEBUG_LOG(HLE, "sceIoDopen(\"%s\")", path);
 
-
 	if(!pspFileSystem.GetFileInfo(path).exists)
 	{
 		return ERROR_ERRNO_FILE_NOT_FOUND;
@@ -1284,6 +1283,7 @@ u32 sceIoDopen(const char *path) {
 	dir->index = 0;
 	dir->name = std::string(path);
 
+	// TODO: The result is delayed only from the memstick, it seems.
 	return id;
 }
 
@@ -1307,7 +1307,10 @@ u32 sceIoDread(int id, u32 dirent_addr) {
 		entry->d_private = 0xC0DEBABE;
 		DEBUG_LOG(HLE, "sceIoDread( %d %08x ) = %s", id, dirent_addr, entry->d_name);
 
-		dir->index++;
+		// TODO: Improve timing.  Only happens on the *first* entry read, ms and umd.
+		if (dir->index++ == 0) {
+			return hleDelayResult(1, "readdir", 1000);
+		}
 		return 1;
 	} else {
 		DEBUG_LOG(HLE, "sceIoDread - invalid listing %i, error %08x", id, error);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -798,6 +798,20 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 		return hleDelayResult(0, "dev seek", 100);
 	case 0x01F100A4:  // Cache
 		return 0;
+	case 0x01F300A5:  // Cache + status
+		if (Memory::IsValidAddress(outPtr)) {
+			Memory::Write_U32(1, outPtr);
+			return 0;
+		}
+		return -1;
+	// TODO: What does these do?  Seem to require a u32 in, no output.
+	case 0x01F100A6:
+	case 0x01F100A8:
+	case 0x01F100A9:
+	case 0x01F300A7:
+		Reporting::ReportMessage("sceIoDevctl(\"%s\", %08x, %08x, %i, %08x, %i)", name, cmd, argAddr, argLen, outPtr, outLen);
+		ERROR_LOG(HLE, "UNIMPL sceIoDevctl(\"%s\", %08x, %08x, %i, %08x, %i)", name, cmd, argAddr, argLen, outPtr, outLen);
+		return 0;
 	}
 
 	// This should really send it on to a FileSystem implementation instead.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -573,7 +573,7 @@ s64 sceIoLseek(int id, s64 offset, int whence) {
 		return (u32) f->asyncResult;
 	} else {
 		ERROR_LOG(HLE, "sceIoLseek(%d, %i, %i) - ERROR: invalid file", id, (int) offset, whence);
-		return error;
+		return (s32) error;
 	}
 }
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -883,6 +883,16 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 				ERROR_LOG(HLE, "memstick size query: bad params");
 				return ERROR_MEMSTICK_DEVCTL_BAD_PARAMS;
 			}
+
+		case 0x02425824:  // Check if write protected
+			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
+				Memory::Write_U32(0, outPtr);
+				hleDebugBreak();
+				return 0;
+			} else {
+				ERROR_LOG(HLE, "Failed 0x02425824 fat");
+				return -1;
+			}
 		}
 	}
 
@@ -928,6 +938,16 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 				return 0;
 			} else {
 				ERROR_LOG(HLE, "Failed 0x02425823 fat");
+				return -1;
+			}
+			break;
+
+		case 0x02425824:  // Check if write protected
+			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
+				Memory::Write_U32(0, outPtr);
+				return 0;
+			} else {
+				ERROR_LOG(HLE, "Failed 0x02425824 fat");
 				return -1;
 			}
 			break;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -127,7 +127,18 @@ void __KernelLoadContext(ThreadContext *ctx);
 bool __KernelTriggerWait(WaitType type, int id, const char *reason, bool dontSwitch = false);
 bool __KernelTriggerWait(WaitType type, int id, int retVal, const char *reason, bool dontSwitch);
 u32 __KernelResumeThreadFromWait(SceUID threadID); // can return an error value
-u32 __KernelResumeThreadFromWait(SceUID threadID, int retval);
+u32 __KernelResumeThreadFromWait(SceUID threadID, u32 retval);
+u32 __KernelResumeThreadFromWait(SceUID threadID, u64 retval);
+
+inline u32 __KernelResumeThreadFromWait(SceUID threadID, int retval)
+{
+	return __KernelResumeThreadFromWait(threadID, (u32)retval);
+}
+
+inline u32 __KernelResumeThreadFromWait(SceUID threadID, s64 retval)
+{
+	return __KernelResumeThreadFromWait(threadID, (u64)retval);
+}
 
 u32 __KernelGetWaitValue(SceUID threadID, u32 &error);
 u32 __KernelGetWaitTimeoutPtr(SceUID threadID, u32 &error);
@@ -231,6 +242,15 @@ struct MipsCall {
 
 	void DoState(PointerWrap &p);
 	void setReturnValue(u32 value);
+	void setReturnValue(u64 value);
+	inline void setReturnValue(int value)
+	{
+		setReturnValue((u32)value);
+	}
+	inline void setReturnValue(s64 value)
+	{
+		setReturnValue((u64)value);
+	}
 };
 
 class Action

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -83,6 +83,7 @@ enum WaitType //probably not the real values
 	WAITTYPE_MUTEX = 13,
 	WAITTYPE_LWMUTEX = 14,
 	WAITTYPE_CTRL = 15,
+	WAITTYPE_IO = 16,
 };
 
 


### PR DESCRIPTION
This is a larger change and probably could use more testing.  I recommend merging only after 0.7, but it'd be great to know if this helps or hurts any games I don't have / haven't tested yet.

It's still not entirely accurate, but it's much better.  This is sorta a first step, not wanting to make it too huge.  I still need to finish writing better tests also, and there's always more to do, but I'm quite optimistic so far.

Practical affects:
- Can't find any games this breaks (but there is one "hack", see below.)
- Tales of Destiny 2 -> menu
- Unchained Blades -> ingame
- Patapon 2 -> intro
- Patapon -> menu (but black)
- Final Fantasy 4 -> less errors, tiny bit farther (still nowhere)
- Shadow of Destiny -> now loading (slightly farther)
- Likely others?
- Less error messages in console even for games that do work.

Changes:
- sceIo funcs now delay/resched like on the PSP, but I kept all the delays low to be on the safe side (many were 10x or more, but often varied by a wide degree in my testing.)
- The async functions (including sceIoOpen now) call the callback with a proper delay.
- The async wait functions now actually wait.
- The async result is now properly sign extended (e.g. 0xffffffff80020325 not 0x0000000080020325)
  - Unfortunately, this change caused regressions.  Some games were sceIoReadAsync()'ing into a NULL pointer, but not failing because they thought it worked.  Afterward, they crashed.
  - For now, I'm making it return 0, and everything seems okay with that.
  - Ultimately this is caused by some other HLE func not returning an address, etc., or else timing/scheduling issues.
- I made hleDelayResult() support 64-bit.  As a side-effect, it overwrites v1 even when returning 32-bit, but I think this is safe within the ABI?
- It now closes files properly under async, which fixes a lot of spurious logged errors.
- Fixes and adds some sceIoDevctl methods I found along the way (these match tests.)  Some were used in the games that got farther with async.
- Avoids overwriting the async result for non-async calls (real firmware doesn't seem to.)

There's still more - for example errors when you try to do an async twice, or wait on no async, etc.  But I wanted to create this so others can see my code and report any games it breaks.

-[Unknown]
