### PR TITLE
Add a VERBOSE logging level + show thread name in log

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -22,6 +22,7 @@
 #define	WARNING_LEVEL 3  // Something is suspicious.
 #define	INFO_LEVEL    4  // General information.
 #define	DEBUG_LEVEL   5  // Detailed debugging - might make things slow.
+#define	VERBOSE_LEVEL 6  // Noisy debugging - sometimes needed but usually unimportant.
 
 #if !defined(_WIN32) && !defined(PANDORA)
 #include <signal.h>
@@ -64,6 +65,7 @@ enum LOG_LEVELS {
 	LWARNING = WARNING_LEVEL,
 	LINFO = INFO_LEVEL,
 	LDEBUG = DEBUG_LEVEL,
+	LVERBOSE = VERBOSE_LEVEL,
 };
 
 #define LOGTYPES_LEVELS LogTypes::LOG_LEVELS
@@ -92,11 +94,12 @@ void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
 		GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__); \
 	}
 
-#define ERROR_LOG(t,...)  { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) }
-#define WARN_LOG(t,...)   { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) }
-#define NOTICE_LOG(t,...) { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) }
-#define INFO_LOG(t,...)   { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) }
-#define DEBUG_LOG(t,...)  { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) }
+#define ERROR_LOG(t,...)   { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) }
+#define WARN_LOG(t,...)    { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) }
+#define NOTICE_LOG(t,...)  { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) }
+#define INFO_LOG(t,...)    { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) }
+#define DEBUG_LOG(t,...)   { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) }
+#define VERBOSE_LOG(t,...) { GENERIC_LOG(LogTypes::t, LogTypes::LVERBOSE, __VA_ARGS__) }
 
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
 #define _dbg_assert_(_t_, _a_) \

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -168,7 +168,7 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 	if (!log || !log->IsEnabled() || level > log->GetLevel() || ! log->HasListeners())
 		return;
 
-	static const char level_to_char[7] = "-NEWID";
+	static const char level_to_char[8] = "-NEWIDV";
 	char formattedTime[13];
 	Common::Timer::GetTimeFormatted(formattedTime);
 

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -26,6 +26,9 @@
 #include <e32debug.h>
 #endif
 
+// Don't need to savestate this.
+const char *hleCurrentThreadName = NULL;
+
 // Unfortunately this is quite slow.
 #define LOG_MSC_OUTPUTDEBUG false
 // #define LOG_MSC_OUTPUTDEBUG true
@@ -169,11 +172,30 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 	char formattedTime[13];
 	Common::Timer::GetTimeFormatted(formattedTime);
 
+#ifdef _WIN32
+	const char *fileshort = strrchr(file, '\\');
+#else
+	const char *fileshort = strrchr(file, '/');
+#endif
+	if (fileshort != NULL)
+		file = fileshort + 1;
+
 	char *msgPos = msg;
-	msgPos += sprintf(msgPos, "%s %s:%d %c[%s]: ",
-		formattedTime,
-		file, line, level_to_char[(int)level],
-		log->GetShortName());
+	if (hleCurrentThreadName != NULL)
+	{
+		msgPos += sprintf(msgPos, "%s %-12.12s %c[%s]: %s:%d ",
+			formattedTime,
+			hleCurrentThreadName, level_to_char[(int)level],
+			log->GetShortName(),
+			file, line);
+	}
+	else
+	{
+		msgPos += sprintf(msgPos, "%s %s:%d %c[%s]: ",
+			formattedTime,
+			file, line, level_to_char[(int)level],
+			log->GetShortName());
+	}
 
 	msgPos += vsnprintf(msgPos, MAX_MSGLEN, format, args);
 	// This will include the null terminator.

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -30,6 +30,7 @@
 #define	MAX_MESSAGES 8000   
 #define MAX_MSGLEN  1024
 
+extern const char *hleCurrentThreadName;
 
 // pure virtual interface
 class LogListener

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -527,7 +527,7 @@ void Idle(int maxIdle)
 		}
 	}
 
-	DEBUG_LOG(CPU, "Idle for %i cycles! (%f ms)", cyclesDown, cyclesDown / (float)(CPU_HZ * 0.001f));
+	VERBOSE_LOG(CPU, "Idle for %i cycles! (%f ms)", cyclesDown, cyclesDown / (float)(CPU_HZ * 0.001f));
 
 	idledCycles += cyclesDown;
 	currentMIPS->downcount -= cyclesDown;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -529,7 +529,7 @@ u32 sceDisplayGetFramebuf(u32 topaddrPtr, u32 linesizePtr, u32 pixelFormatPtr, i
 }
 
 u32 sceDisplayWaitVblankStart() {
-	DEBUG_LOG(HLE,"sceDisplayWaitVblankStart()");
+	VERBOSE_LOG(HLE,"sceDisplayWaitVblankStart()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
 	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank start waited");
 	return 0;
@@ -537,7 +537,7 @@ u32 sceDisplayWaitVblankStart() {
 
 u32 sceDisplayWaitVblank() {
 	if (!isVblank) {
-		DEBUG_LOG(HLE,"sceDisplayWaitVblank()");
+		VERBOSE_LOG(HLE,"sceDisplayWaitVblank()");
 		vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
 		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank waited");
 		return 0;
@@ -549,7 +549,7 @@ u32 sceDisplayWaitVblank() {
 }
 
 u32 sceDisplayWaitVblankStartMulti(int vblanks) {
-	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartMulti()");
+	VERBOSE_LOG(HLE,"sceDisplayWaitVblankStartMulti()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread(), vblanks));
 	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, false, "vblank start multi waited");
 	return 0;
@@ -557,7 +557,7 @@ u32 sceDisplayWaitVblankStartMulti(int vblanks) {
 
 u32 sceDisplayWaitVblankCB() {
 	if (!isVblank) {
-		DEBUG_LOG(HLE,"sceDisplayWaitVblankCB()");
+		VERBOSE_LOG(HLE,"sceDisplayWaitVblankCB()");
 		vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
 		__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank waited");
 		return 0;
@@ -569,22 +569,21 @@ u32 sceDisplayWaitVblankCB() {
 }
 
 u32 sceDisplayWaitVblankStartCB() {
-	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartCB()");
+	VERBOSE_LOG(HLE,"sceDisplayWaitVblankStartCB()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread()));
 	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank start waited");
 	return 0;
 }
 
 u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
-	DEBUG_LOG(HLE,"sceDisplayWaitVblankStartMultiCB()");
+	VERBOSE_LOG(HLE,"sceDisplayWaitVblankStartMultiCB()");
 	vblankWaitingThreads.push_back(WaitVBlankInfo(__KernelGetCurThread(), vblanks));
 	__KernelWaitCurThread(WAITTYPE_VBLANK, 0, 0, 0, true, "vblank start multi waited");
 	return 0;
 }
 
 u32 sceDisplayGetVcount() {
-	// Too spammy
-	// DEBUG_LOG(HLE,"%i=sceDisplayGetVcount()", vCount);
+	VERBOSE_LOG(HLE,"%i=sceDisplayGetVcount()", vCount);
 
 	hleEatMicro(2);
 	return vCount;

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -128,6 +128,7 @@ void __KernelShutdown()
 	}
 	kernelObjects.List();
 	INFO_LOG(HLE, "Shutting down kernel - %i kernel objects alive", kernelObjects.GetCount());
+	hleCurrentThreadName = NULL;
 	kernelObjects.Clear();
 
 	__FontShutdown();

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -20,6 +20,7 @@
 #include "../MIPS/MIPSCodeUtils.h"
 #include "../MIPS/MIPSInt.h"
 
+#include "Common/LogManager.h"
 #include "../FileSystems/FileSystem.h"
 #include "../FileSystems/MetaFileSystem.h"
 #include "../PSPLoaders.h"
@@ -28,7 +29,6 @@
 #include "../../Core/System.h"
 #include "../../GPU/GPUInterface.h"
 #include "../../GPU/GPUState.h"
-
 
 #include "__sceAudio.h"
 #include "sceAtrac.h"
@@ -442,7 +442,10 @@ void KernelObjectPool::DoState(PointerWrap &p)
 		ERROR_LOG(HLE, "Unable to load state: different kernel object storage.");
 
 	if (p.mode == p.MODE_READ)
+	{
+		hleCurrentThreadName = NULL;
 		kernelObjects.Clear();
+	}
 
 	p.DoArray(occupied, maxCount);
 	for (int i = 0; i < maxCount; ++i)

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -66,7 +66,7 @@ static bool inInterrupt;
 
 void sceKernelCpuSuspendIntr()
 {
-	//LOG(HLE,"sceKernelCpuSuspendIntr");	// very spammy
+	VERBOSE_LOG(HLE, "sceKernelCpuSuspendIntr");
 	int returnValue;
 	if (__InterruptsEnabled())
 	{
@@ -82,7 +82,7 @@ void sceKernelCpuSuspendIntr()
 
 void sceKernelCpuResumeIntr(u32 enable)
 {
-	//LOG(HLE,"sceKernelCpuResumeIntr(%i)", enable);	// very spammy
+	VERBOSE_LOG(HLE, "sceKernelCpuResumeIntr(%i)", enable);
 	if (enable)
 	{
 		__EnableInterrupts();

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -839,7 +839,7 @@ int sceKernelTryLockLwMutex_600(u32 workareaPtr, int count)
 
 int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 {
-	DEBUG_LOG(HLE, "sceKernelLockLwMutex(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
+	VERBOSE_LOG(HLE, "sceKernelLockLwMutex(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
 
 	NativeLwMutexWorkarea workarea;
 	Memory::ReadStruct(workareaPtr, &workarea);
@@ -874,7 +874,7 @@ int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 
 int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 {
-	DEBUG_LOG(HLE, "sceKernelLockLwMutexCB(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
+	VERBOSE_LOG(HLE, "sceKernelLockLwMutexCB(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
 
 	NativeLwMutexWorkarea workarea;
 	Memory::ReadStruct(workareaPtr, &workarea);
@@ -898,7 +898,7 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 			if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
 				mutex->waitingThreads.push_back(threadID);
 			__KernelWaitLwMutex(mutex, timeoutPtr);
-			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, true, "lwmutex waited");
+			__KernelWaitCurThread(WAITTYPE_LWMUTEX, workarea.uid, count, timeoutPtr, true, "lwmutex cb waited");
 
 			// Return value will be overwritten by wait.
 			return 0;
@@ -910,7 +910,7 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 
 int sceKernelUnlockLwMutex(u32 workareaPtr, int count)
 {
-	DEBUG_LOG(HLE, "sceKernelUnlockLwMutex(%08x, %i)", workareaPtr, count);
+	VERBOSE_LOG(HLE, "sceKernelUnlockLwMutex(%08x, %i)", workareaPtr, count);
 
 	NativeLwMutexWorkarea workarea;
 	Memory::ReadStruct(workareaPtr, &workarea);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1989,11 +1989,12 @@ static void __KernelSleepThread(bool doCallbacks) {
 		return;
 	}
 
-	DEBUG_LOG(HLE,"sceKernelSleepThread() - wakeupCount decremented to %i", thread->nt.wakeupCount);
 	if (thread->nt.wakeupCount > 0) {
 		thread->nt.wakeupCount--;
+		DEBUG_LOG(HLE, "sceKernelSleepThread() - wakeupCount decremented to %i", thread->nt.wakeupCount);
 		RETURN(0);
 	} else {
+		VERBOSE_LOG(HLE, "sceKernelSleepThread()", thread->nt.wakeupCount);
 		RETURN(0);
 		__KernelWaitCurThread(WAITTYPE_SLEEP, 0, 0, 0, doCallbacks, "thread slept");
 	}
@@ -2007,7 +2008,7 @@ void sceKernelSleepThread()
 //the homebrew PollCallbacks
 void sceKernelSleepThreadCB()
 {
-	DEBUG_LOG(HLE, "sceKernelSleepThreadCB()");
+	VERBOSE_LOG(HLE, "sceKernelSleepThreadCB()");
 	__KernelSleepThread(true);
 	__KernelCheckCallbacks();
 }

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -24,7 +24,6 @@
 #include "sceKernelModule.h"
 #include "HLE.h"
 
-
 void sceKernelChangeThreadPriority();
 int __KernelCreateThread(const char *threadName, SceUID moduleID, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
 int sceKernelCreateThread(const char *threadName, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
@@ -116,6 +115,7 @@ KernelObject *__KernelCallbackObject();
 
 void __KernelScheduleWakeup(int threadnumber, s64 usFromNow);
 SceUID __KernelGetCurThread();
+const char *__KernelGetThreadName(SceUID threadID);
 
 void __KernelSaveContext(ThreadContext *ctx);
 void __KernelLoadContext(ThreadContext *ctx);

--- a/android/jni/NativeApp.cpp
+++ b/android/jni/NativeApp.cpp
@@ -65,6 +65,7 @@ public:
 	{
 		switch (level)
 		{
+		case LogTypes::LVERBOSE:
 		case LogTypes::LDEBUG:
 		case LogTypes::LINFO:
 			ILOG("%s", msg);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -27,6 +27,9 @@ public:
 	{
 		switch (level)
 		{
+		case LogTypes::LVERBOSE:
+			fprintf(stderr, "V %s", msg);
+			break;
 		case LogTypes::LDEBUG:
 			fprintf(stderr, "D %s", msg);
 			break;


### PR DESCRIPTION
I wanted to go with NOISE but N was already taken.  V works too.

This does add a bit of coupling between Core and Common - Common publishes a `const char *` that a consumer can update to set the current thread name.  Personally, I think having the thread name in the log is worth it.

There may also be a small penalty for getting the thread name on thread switching, but I think I minimized it successfully.

I've also marked some things as VERBOSE.  Only a few, and either common ones (like lwmutexes, etc.) that appear very stable, or or things that can be easily inferred from the next log line (like `sceDisplayWaitVblank()`.)

And lastly, it chops off the path from the filename in debug to make it shorter.

The main point of all this is to make debug logs more readable so they can be scanned more easily/quickly.

-[Unknown]
