### PR TITLE
Fix jit bug with jal found in Phantasy Star Portable 2

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -324,26 +324,19 @@ void Jit::Comp_Jump(u32 op)
 	u32 off = ((op & 0x03FFFFFF) << 2);
 	u32 targetAddr = (js.compilerPC & 0xF0000000) | off;
 
-	u32 delaySlotOp = Memory::ReadUnchecked_U32(js.compilerPC + 4);
-	bool delaySlotIsNice = (op >> 26) == 2 || IsDelaySlotNiceReg(op, delaySlotOp, MIPS_REG_RA);
-	CONDITIONAL_NICE_DELAYSLOT;
-	if (!likely && delaySlotIsNice)
-		CompileDelaySlot(DELAYSLOT_NICE);
-	FlushAll();
-
 	switch (op >> 26) 
 	{
 	case 2: //j
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+		CompileDelaySlot(DELAYSLOT_NICE);
+		FlushAll();
 		WriteExit(targetAddr, 0);
 		break;
 
 	case 3: //jal
-		MOVI2R(R0, js.compilerPC + 8);
-		STR(R0, CTXREG, MIPS_REG_RA * 4);
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+		gpr.MapReg(MIPS_REG_RA, MAP_NOINIT | MAP_DIRTY);
+		MOVI2R(gpr.R(MIPS_REG_RA), js.compilerPC + 8);
+		CompileDelaySlot(DELAYSLOT_NICE);
+		FlushAll();
 		WriteExit(targetAddr, 0);
 		break;
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -410,26 +410,20 @@ void Jit::Comp_Jump(u32 op)
 	u32 off = ((op & 0x3FFFFFF) << 2);
 	u32 targetAddr = (js.compilerPC & 0xF0000000) | off;
 
-	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
-	bool delaySlotIsNice = (op >> 26) == 2 || IsDelaySlotNiceReg(op, delaySlotOp, MIPS_REG_RA);
-	CONDITIONAL_NICE_DELAYSLOT;
-	if (delaySlotIsNice)
-		CompileDelaySlot(DELAYSLOT_NICE);
-	FlushAll();
-
 	switch (op >> 26) 
 	{
 	case 2: //j
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+		CompileDelaySlot(DELAYSLOT_NICE);
+		FlushAll();
 		CONDITIONAL_LOG_EXIT(targetAddr);
 		WriteExit(targetAddr, 0);
 		break;
 
 	case 3: //jal
-		MOV(32, M(&mips_->r[MIPS_REG_RA]), Imm32(js.compilerPC + 8));	// Save return address
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+		gpr.BindToRegister(MIPS_REG_RA, false, true);
+		MOV(32, gpr.R(MIPS_REG_RA), Imm32(js.compilerPC + 8));	// Save return address
+		CompileDelaySlot(DELAYSLOT_NICE);
+		FlushAll();
 		CONDITIONAL_LOG_EXIT(targetAddr);
 		WriteExit(targetAddr, 0);
 		break;


### PR DESCRIPTION
This is a tricky one.  Either evil handcoded asm or a terrible compiler imho.

The jit was getting stuck here:

```
08c9f270   addiu sp, sp, -0x10
08c9f274   sw  ra, 0(sp)
08c9f278   jal 08c9f1d8
08c9f27c   lw  ra, 0(sp)
08c9f280   jr  ra
08c9f284   addiu sp, sp, 0x10
```

Note the "lw ra" in the delay slot.  Yep, tricky indeed.

Includes an untested fix to ARM, but I think it's right.  It compiles anyhow...  Can undo the optimization (second commit) if not, I think.

-[Unknown]
