### PR TITLE
Keep UseMediaEngine to sceMpegInit() only 

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -399,7 +399,12 @@ void __MpegShutdown() {
 
 u32 sceMpegInit()
 {
-	WARN_LOG(HLE, "sceMpegInit()");
+	if (!g_Config.bUseMediaEngine) {
+		WARN_LOG(HLE, "sceMpegInit() : Media Engine Disabled");
+		return -1;
+	}
+
+	WARN_LOG(HLE, "sceMpegInit() : Media Engine Enabled");
 	return 0;
 }
 
@@ -522,10 +527,6 @@ int sceMpegAvcDecodeMode(u32 mpeg, u32 modeAddr)
 
 int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 {
-	if (!g_Config.bUseMediaEngine){
-		WARN_LOG(HLE, "Media Engine disabled");
-		return -1;
-	}
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
 		WARN_LOG(HLE, "sceMpegQueryStreamOffset(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, offsetAddr);


### PR DESCRIPTION
For Sol Trigger and Last promise story , we can simply set UseMediaEngine = false to prevent it go through mpeg routine and hence no crash within mpeg routine 
