### PR TITLE
Make UseMediaEngine check for couples of sceMpeg functions

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1657,7 +1657,7 @@ int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcpos
 	if(Memory::IsValidAddress(towritePtr))
 		Memory::Write_U32(ctx->mp3BufSize, towritePtr);
 	if(Memory::IsValidAddress(srcposPtr))
-		Memory::Write_U64(ctx->mp3StreamPosition, srcposPtr);
+		Memory::Write_U32(ctx->mp3StreamPosition, srcposPtr);
 
 	return 0;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -126,9 +126,9 @@ struct Mp3Context {
 		p.DoMarker("Mp3Context");
 	}
 
-	int mp3StreamStart;
-	int mp3StreamEnd;
-	int mp3StreamPosition;
+	u64 mp3StreamStart;
+	u64 mp3StreamEnd;
+	u64 mp3StreamPosition;
 	u32 mp3Buf;
 	int mp3BufSize;
 	int mp3BufPendingSize;
@@ -399,6 +399,11 @@ void __MpegShutdown() {
 
 u32 sceMpegInit()
 {
+	if (!g_Config.bUseMediaEngine){
+		WARN_LOG(HLE, "Media Engine disabled");
+		return -1;
+	}
+
 	WARN_LOG(HLE, "sceMpegInit()");
 	return 0;
 }
@@ -421,6 +426,11 @@ u32 sceMpegRingbufferConstruct(u32 ringbufferAddr, u32 numPackets, u32 data, u32
 
 u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop)
 {
+	if (!g_Config.bUseMediaEngine){
+		WARN_LOG(HLE, "Media Engine disabled");
+		return -1;
+	}
+
 	if (size < MPEG_MEMSIZE) {
 		WARN_LOG(HLE, "ERROR_MPEG_NO_MEMORY=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)",
 			mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
@@ -522,10 +532,6 @@ int sceMpegAvcDecodeMode(u32 mpeg, u32 modeAddr)
 
 int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 {
-	if (!g_Config.bUseMediaEngine){
-		WARN_LOG(HLE, "Media Engine disabled");
-		return -1;
-	}
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
 		WARN_LOG(HLE, "sceMpegQueryStreamOffset(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, offsetAddr);
@@ -659,6 +665,11 @@ int sceMpegFreeAvcEsBuf(u32 mpeg, int esBuf)
 
 u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 initAddr)
 {
+	if (!g_Config.bUseMediaEngine){
+		WARN_LOG(HLE, "Media Engine disabled");
+		return -1;
+	}
+
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
 		WARN_LOG(HLE, "sceMpegAvcDecode(%08x, %08x, %d, %08x, %08x): bad mpeg handle", mpeg, auAddr, frameWidth, bufferAddr, initAddr);
@@ -842,6 +853,11 @@ u32 sceMpegAvcDecodeStopYCbCr(u32 mpeg, u32 bufferAddr, u32 statusAddr)
 
 int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 {
+	if (!g_Config.bUseMediaEngine){
+		WARN_LOG(HLE, "Media Engine disabled");
+		return -1;
+	}
+
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
 		WARN_LOG(HLE, "sceMpegAvcDecodeYCbCr(%08x, %08x, %08x, %08x): bad mpeg handle", mpeg, auAddr, bufferAddr, initAddr);
@@ -1641,7 +1657,7 @@ int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcpos
 	if(Memory::IsValidAddress(towritePtr))
 		Memory::Write_U32(ctx->mp3BufSize, towritePtr);
 	if(Memory::IsValidAddress(srcposPtr))
-		Memory::Write_U32(ctx->mp3StreamPosition, srcposPtr);
+		Memory::Write_U64(ctx->mp3StreamPosition, srcposPtr);
 
 	return 0;
 }


### PR DESCRIPTION
Make bUseMediaEngine with return = -1 for the following sceMpeg functions 

sceMpegInit()
sceMpegCreate()
sceMpegAvcDecode()
sceMpegAvcDecodeYCbCr()

For Sol Trigger and Last Promise Story , we can simply set UseMediaEngine = false to prevent it go through mpeg routine and hence no crash within mpeg routine 

Sort out Issue #930 
