### PR TITLE
Fake VOICETYPE_PCM code

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -143,7 +143,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 
 u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loop)
 {
-	INFO_LOG(HLE,"PLEASE REPORT issue #505 sceSasSetVoicePCM(%08x, %i, %08x, %i, %i)", core, voiceNum, pcmAddr, size, loop);
+	INFO_LOG(HLE,"sceSasSetVoicePCM(%08x, %i, %08x, %i, %i)", core, voiceNum, pcmAddr, size, loop);
 	Reporting::ReportMessage("sceSasSetVoicePCM(%x, %i)", core, voiceNum);
 
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
@@ -162,12 +162,13 @@ u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loop)
 	}
 
 	SasVoice &v = sas->voices[voiceNum];
+	u32 prevPcmAddr = v.pcmAddr;
 	v.type = VOICETYPE_PCM;
 	v.pcmAddr = pcmAddr;
 	v.pcmSize = size;
 	v.loop = loop ? false : true;
 	v.playing = true;
-	v.ChangedParams(true);
+	v.ChangedParams(pcmAddr == prevPcmAddr);
 	return 0;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -330,7 +330,34 @@ void SasInstance::Mix(u32 outAddr) {
 			}
 		}
 		else if (voice.type == VOICETYPE_PCM && voice.pcmAddr != 0) {
-			// PCM mixing should be easy, can share code with VAG
+			resampleBuffer[0] = voice.resampleHist[0];
+			resampleBuffer[1] = voice.resampleHist[1];
+			u32 numSamples = voice.sampleFrac + grainSize ;
+			if ((int)numSamples > grainSize * 4) {
+				ERROR_LOG(SAS, "numSamples too large, clamping: %i vs %i", numSamples, grainSize * 4);
+				numSamples = grainSize * 4;
+			}
+			resampleBuffer[2 + numSamples] = resampleBuffer[2 + numSamples - 1];
+			voice.resampleHist[0] = resampleBuffer[2 + numSamples - 2];
+			voice.resampleHist[1] = resampleBuffer[2 + numSamples - 1];
+			u32 sampleFrac = voice.sampleFrac;
+			for (int i = 0; i < grainSize; i++) {
+				int sample = resampleBuffer[sampleFrac + 2];
+				int envelopeValue = voice.envelope.GetHeight();
+				envelopeValue = ((envelopeValue >> 15) + 1) >> 1;
+				sample = sample * envelopeValue >> 15;
+				mixBuffer[i * 2] += sample * voice.volumeLeft >> 15;
+				mixBuffer[i * 2 + 1] += sample * voice.volumeRight >> 15;
+				sendBuffer[i * 2] += sample * voice.volumeLeftSend >> 15;
+				sendBuffer[i * 2 + 1] += sample * voice.volumeRightSend >> 15;
+				voice.envelope.Step();
+			}
+			voice.sampleFrac = sampleFrac;
+			voice.sampleFrac -= numSamples ;
+			if (voice.envelope.HasEnded()) {
+				NOTICE_LOG(SAS, "Hit end of envelope");
+				voice.playing = false;
+			}
 		}
 		else if (voice.type == VOICETYPE_NOISE && voice.noiseFreq != 0) {
 			// Generate noise?


### PR DESCRIPTION
I simply copy the VAG code to fake the PCM one and removed the pitch to take out noise . It allow games which rely on sceSetVoicePCM to pass through only , nothing else . 

It is fake one :) therefore i expect the PCM voice is not working .

Tested game : Kidou_Senshi_Gundam_AGE_Universe_Accel

Issue #870 
