### PR TITLE
Add UI for UseMediaEngine for Android

### DIFF
--- a/android/jni/MenuScreens.cpp
+++ b/android/jni/MenuScreens.cpp
@@ -340,6 +340,7 @@ void SettingsScreen::render() {
 	UICheckBox(GEN_ID, x + columnw, y, "Draw using Stream VBO", ALIGN_TOPLEFT, &g_Config.bUseVBO);
 #endif
 	UICheckBox(GEN_ID, x, y += stride, "Vertex Cache", ALIGN_TOPLEFT, &g_Config.bVertexCache);
+	UICheckBox(GEN_ID, x + columnw, y, "Use Media Engine", ALIGN_TOPLEFT, &g_Config.bUseMediaEngine);
 
 	UICheckBox(GEN_ID, x, y += stride, "JIT (Dynarec)", ALIGN_TOPLEFT, &g_Config.bJit);
 	if (g_Config.bJit)


### PR DESCRIPTION
Just in case user need it to pass through some games that when hangs up when media engine is used for example Saigo_no_Yakusoku_no_Monogatari
