### PR TITLE
sceMpegRingbufferPut fix (Handle  numPackets <= 0)

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1039,16 +1039,12 @@ void PostPutAction::run(MipsCall &call) {
 u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 {
 	DEBUG_LOG(HLE, "sceMpegRingbufferPut(%08x, %i, %i)", ringbufferAddr, numPackets, available);
-	if (numPackets < 0) {
+	numPackets = std::min(numPackets, available);
+	if (numPackets <= 0) {
 		ERROR_LOG(HLE, "sub-zero number of packets put");
 		return 0;
 	}
 
-	numPackets = std::min(numPackets, available);
-	if (numPackets <= 0) {
-		ERROR_LOG(HLE, "zero or sub-zero number of packets put");
-		return 0;
-	}
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringbufferAddr, &ringbuffer);
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1044,10 +1044,13 @@ u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 		return 0;
 	}
 
+	numPackets = std::min(numPackets, available);
+	if (numPackets <= 0) {
+		ERROR_LOG(HLE, "zero or sub-zero number of packets put");
+		return 0;
+	}
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringbufferAddr, &ringbuffer);
-
-	numPackets = std::min(numPackets, available);
 
 	MpegContext *ctx = getMpegCtx(ringbuffer.mpeg);
 	if (!ctx) {


### PR DESCRIPTION
No need disable media engine more in Saigo no Yakusoku no Monogatari
