### PR TITLE
Handle dispatch suspend/resume slightly better

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1144,6 +1144,12 @@ bool __KernelTriggerWait(WaitType type, int id, int retVal, const char *reason, 
 // makes the current thread wait for an event
 void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason)
 {
+	if (!dispatchEnabled)
+	{
+		WARN_LOG(HLE, "Ignoring wait, dispatching disabled... right thing to do?");
+		return;
+	}
+
 	// TODO: Need to defer if in callback?
 	if (g_inCbCount > 0)
 		WARN_LOG(HLE, "UNTESTED - waiting within a callback, probably bad mojo.");
@@ -1699,6 +1705,7 @@ u32 sceKernelResumeDispatchThread(u32 suspended)
 	u32 oldDispatchSuspended = !dispatchEnabled;
 	dispatchEnabled = !suspended;
 	DEBUG_LOG(HLE,"%i=sceKernelResumeDispatchThread(%i)", oldDispatchSuspended, suspended);
+	hleReSchedule("dispatch resumed");
 	return oldDispatchSuspended;
 }
 


### PR DESCRIPTION
I don't know if this is quite right, but it seems more right.  It turns out the io async merge broke Yuusha 30 Second, which this fixes.  It still breaks later though, but it gets as far as it did before.

Not many games I have actually call these funcs... Yuusha 30 Second seems to be using them as a way to prevent IO from rescheduling (which is very interesting, I need to test if the IO read still happens or not in that case, since it'll tell me if it always handles it on a thread or not.)

-[Unknown]
