### PR TITLE
Fix armjit fastmem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,9 +1002,9 @@ if (IOS)
 	SET_SOURCE_FILES_PROPERTIES(${RSRC_XIB_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 	set(APP_DIR_NAME \${TARGET_BUILD_DIR}/\${FULL_PRODUCT_NAME})
 	add_custom_command(TARGET PPSSPP POST_BUILD
-		COMMAND tar -c -C . --exclude .DS_Store --exclude .git -H `find assets` | tar -x -C ${APP_DIR_NAME}
+		COMMAND tar -c -C . --exclude .DS_Store --exclude .git -H `find assets` | tar -x -C '${APP_DIR_NAME}'
 	)
-	set_target_properties(${TargetBin} PROPERTIES MACOSX_BUNDLE_INFO_PLIST "../ios/PPSSPP-Info.plist" XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer: My Name")
+	set_target_properties(${TargetBin} PROPERTIES MACOSX_BUNDLE_INFO_PLIST "../ios/PPSSPP-Info.plist")
 endif()
 
 #include(CPack)

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -656,7 +656,7 @@ void ARMXEmitter::WriteStoreOp(u32 Op, ARMReg Rt, ARMReg Rn, Operand2 Rm, bool R
 	bool Index = true;
 	bool Add = false;
 
-	// Special Encoding     
+	// Special Encoding (misc addressing mode)
 	bool SpecialOp = false;
 	bool Half = false;
 	bool SignedLoad = false;
@@ -700,13 +700,17 @@ void ARMXEmitter::WriteStoreOp(u32 Op, ARMReg Rt, ARMReg Rn, Operand2 Rm, bool R
 		}
 		break;
 		case TYPE_REG:
+			Data = Rm.GetData();
+			Add = RegAdd;
+			break;
 		case TYPE_IMMSREG:
 			if (!SpecialOp)
 			{
 				Data = Rm.GetData();
 				Add = RegAdd;
+				break;
 			}
-			break;
+			// Intentional fallthrough: TYPE_IMMSREG not supported for misc addressing.
 		default:
 			// RSR not supported for any of these
 			// We already have the warning above
@@ -717,7 +721,7 @@ void ARMXEmitter::WriteStoreOp(u32 Op, ARMReg Rt, ARMReg Rn, Operand2 Rm, bool R
 	if (SpecialOp)
 	{
 		// Add SpecialOp things
-		Data = (0x5 << 4) | (SignedLoad << 6) | (Half << 5) | Data;
+		Data = (0x9 << 4) | (SignedLoad << 6) | (Half << 5) | Data;
 	}
 	Write32(condition | (op << 20) | (Index << 24) | (Add << 23) | (Rn << 16) | (Rt << 12) | Data);
 }


### PR DESCRIPTION
It was encoded wrong, this fixes the encoding and allows the reg-indexed case (which is supported.)

Google found me some fairly concise docs and the addressing modes:
http://www.rz.uni-karlsruhe.de/rz/docs/VTune/reference/Address_Miscellaneous_Loads_and_Stores_Overview.htm
http://www.rz.uni-karlsruhe.de/rz/docs/VTune/reference/Address_Load_and_Store_Word_or_Unsigned_Byte_Overview.htm

Also some tweaks to the CMakeLists.txt for iOS.  Still doesn't seem to pick up code changes without a make clean (even tried rm'ing ArmCompLoadStore.o, libCore.a, , and the .app, still doesn't take them, driving me nuts...)

-[Unknown]
