### PR TITLE
Make sceMpeg and sceAtrac basiclly workable for PC 

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -106,7 +106,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_FFMPEG_;_USE_DSHOW_;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -61,13 +61,13 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup /> 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../ffmpeg;../ffmpeg/$(Platform)/$(Configuration);../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_USE_FFMPEG_;_USE_DSHOW_;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
@@ -83,7 +83,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ffmpeg;../ffmpeg/$(Platform)/$(Configuration);../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -102,7 +102,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ffmpeg;../ffmpeg/$(Platform)/$(Configuration);../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -125,7 +125,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ffmpeg;../ffmpeg/$(Platform)/$(Configuration);../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
@@ -196,6 +196,7 @@
     <ClCompile Include="HLE\sceMpeg.cpp" />
     <ClCompile Include="HLE\sceNet.cpp" />
     <ClCompile Include="HLE\sceOpenPSID.cpp" />
+    <ClCompile Include="HLE\sceP3da.cpp" />
     <ClCompile Include="HLE\sceParseHttp.cpp" />
     <ClCompile Include="HLE\sceParseUri.cpp" />
     <ClCompile Include="HLE\scePower.cpp" />
@@ -213,11 +214,11 @@
     <ClCompile Include="HLE\__sceAudio.cpp" />
     <ClCompile Include="Host.cpp" />
     <ClCompile Include="HW\audioPlayer.cpp" />
+    <ClCompile Include="HW\MediaEngine.cpp" />
     <ClCompile Include="HW\mediaPlayer.cpp" />
+    <ClCompile Include="HW\MemoryStick.cpp" />
     <ClCompile Include="HW\MpegDemux.cpp" />
     <ClCompile Include="HW\OMAConvert.cpp" />
-    <ClCompile Include="HW\MediaEngine.cpp" />
-    <ClCompile Include="HW\MemoryStick.cpp" />
     <ClCompile Include="HW\SasAudio.cpp" />
     <ClCompile Include="Loaders.cpp" />
     <ClCompile Include="MemMap.cpp" />
@@ -375,6 +376,7 @@
     <ClInclude Include="HLE\sceMpeg.h" />
     <ClInclude Include="HLE\sceNet.h" />
     <ClInclude Include="HLE\sceOpenPSID.h" />
+    <ClInclude Include="HLE\sceP3da.h" />
     <ClInclude Include="HLE\sceParseHttp.h" />
     <ClInclude Include="HLE\sceParseUri.h" />
     <ClInclude Include="HLE\scePower.h" />
@@ -393,10 +395,10 @@
     <ClInclude Include="HLE\__sceAudio.h" />
     <ClInclude Include="Host.h" />
     <ClInclude Include="HW\audioPlayer.h" />
+    <ClInclude Include="HW\MediaEngine.h" />
     <ClInclude Include="HW\mediaPlayer.h" />
     <ClInclude Include="HW\MpegDemux.h" />
     <ClInclude Include="HW\OMAConvert.h" />
-    <ClInclude Include="HW\MediaEngine.h" />
     <ClInclude Include="HW\SasAudio.h" />
     <ClInclude Include="HW\MemoryStick.h" />
     <ClInclude Include="Loaders.h" />

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -212,6 +212,10 @@
     <ClCompile Include="HLE\sceVaudio.cpp" />
     <ClCompile Include="HLE\__sceAudio.cpp" />
     <ClCompile Include="Host.cpp" />
+    <ClCompile Include="HW\audioPlayer.cpp" />
+    <ClCompile Include="HW\mediaPlayer.cpp" />
+    <ClCompile Include="HW\MpegDemux.cpp" />
+    <ClCompile Include="HW\OMAConvert.cpp" />
     <ClCompile Include="HW\MediaEngine.cpp" />
     <ClCompile Include="HW\MemoryStick.cpp" />
     <ClCompile Include="HW\SasAudio.cpp" />
@@ -388,6 +392,10 @@
     <ClInclude Include="HLE\sceVaudio.h" />
     <ClInclude Include="HLE\__sceAudio.h" />
     <ClInclude Include="Host.h" />
+    <ClInclude Include="HW\audioPlayer.h" />
+    <ClInclude Include="HW\mediaPlayer.h" />
+    <ClInclude Include="HW\MpegDemux.h" />
+    <ClInclude Include="HW\OMAConvert.h" />
     <ClInclude Include="HW\MediaEngine.h" />
     <ClInclude Include="HW\SasAudio.h" />
     <ClInclude Include="HW\MemoryStick.h" />

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -503,8 +503,14 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 			pspFileSystem.CloseFile(h);
 			delete [] buf;
 		}
-		else
+		else if (!addAtrac3AudioByPackage(Memory::lastestAccessFile.packagefile, 
+			           Memory::lastestAccessFile.start_pos, atrac->first.filesize, 
+					   Memory::GetPointer(buffer), atracID))
+		{
+			ERROR_LOG(HLE, "failed to find audio stream from package: %s", Memory::lastestAccessFile.packagefile);
 			addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+		}
+			
 #endif // _WIN32
 	}
 	return 0;
@@ -534,8 +540,13 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 		pspFileSystem.CloseFile(h);
 		delete [] buf;
 	}
-	else
+	else if (!addAtrac3AudioByPackage(Memory::lastestAccessFile.packagefile, 
+			     Memory::lastestAccessFile.start_pos, atrac->first.filesize, 
+				 Memory::GetPointer(buffer), atracID))
+	{
+		ERROR_LOG(HLE, "failed to find audio stream from package: %s", Memory::lastestAccessFile.packagefile);
 		addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+	}
 #endif // _WIN32
 	return atracID;
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -493,6 +493,9 @@ u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 	// TODO
 	if (bytesToAdd > atrac->first.writableBytes)
 		return ATRAC_ERROR_ADD_DATA_IS_TOO_BIG;
+	// only add stream data when it need more atrac data
+	if (atrac->getRemainFrames() > 0)
+		return 0;
 
 	if (atrac->data_buf && (bytesToAdd > 0)) {
 		int addbytes = std::min(bytesToAdd, atrac->first.filesize - atrac->first.fileoffset);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -532,7 +532,8 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			u32 numSamples = 0;
 #ifdef _USE_FFMPEG_
 			if (atrac->codeType == PSP_MODE_AT_3 && atrac->pCodecCtx) {
-				atrac->SeekToSample(0);
+				int forceseekSample = atrac->currentSample * 2 > atrac->endSample ? 0 : atrac->endSample;
+				atrac->SeekToSample(forceseekSample);
 				atrac->SeekToSample(atrac->currentSample);
 				AVPacket packet;
 				int got_frame, ret;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -566,6 +566,11 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum)
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
 		atrac->loopNum = loopNum;
+#ifdef _WIN32
+		audioEngine *engine = getaudioEngineByID(atracID);
+		if (engine)
+			engine->setLoop(loopNum);
+#endif // _WIN32
 	}
 	return 0;
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -210,15 +210,14 @@ struct Atrac {
 		int remainFrame;
 		if (first.fileoffset >= first.filesize || currentSample >= endSample)
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		else if (decodePos >= first.fileoffset - atracBytesPerFrame ) {
-			// require more data
-			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		} else {
-			// This is the correct one
-			//remainFrame = (first.size - decodePos) / atracBytesPerFrame;
-
-			// Try to load all file data immediately
+		else if (decodePos > first.size) {
+			// There are not enough atrac data right now to play at a certain position.
+			// Must load more atrac data first
 			remainFrame = 0;
+		} else {
+			// guess the remain frames. 
+			// games would add atrac data when remainFrame = 0 or -1 
+			remainFrame = (first.size - decodePos) / atracBytesPerFrame - 1;
 		}
 		return remainFrame;
 	}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -453,6 +453,15 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		// TODO: Not sure what this means?
 		atrac->decodePos = sample;
 	}
+
+#ifdef _USE_DSHOW_
+	audioEngine *engine = getaudioEngineByID(atracID);
+	if (engine != NULL)
+	{
+		engine->setLoop(-1);
+	}
+#endif // _USE_DSHOW_
+
 	return 0;
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -256,6 +256,8 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 					atrac->decodePos += ATRAC_MAX_SAMPLES;
 					if (atrac->decodePos >= atrac->decodeEnd && atrac->decodeEnd < ATRAC_SAMPLES_PERSEC * 10)
 						Memory::Write_U32(1, finishFlagAddr);
+					if (atrac->decodePos >= atrac->decodeEnd)
+						atrac->decodePos = 0;
 				}
 			}
 			else {
@@ -392,7 +394,7 @@ u32  sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 
 u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 {
-	ERROR_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
+	DEBUG_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -413,7 +415,7 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 
 u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 {
-	ERROR_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
+	DEBUG_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -427,7 +429,7 @@ u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 
 u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 {
-	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
+	DEBUG_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -440,7 +442,7 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 
 u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
+	DEBUG_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -453,7 +455,7 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 
 u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr)
 {
-	ERROR_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+	DEBUG_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -897,7 +897,7 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 	{
 		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
 		if ((atrac->first.size >= atrac->first.filesize) || 
-			(atrac->first.filesize < 0x19000 && checkAudioFileExist(Memory::GetPointer(buffer)))) {
+			(atrac->first.filesize >= 0x19000 && checkAudioFileExist(Memory::GetPointer(buffer)))) {
 			addAtrac3Audio(Memory::GetPointer(buffer), atrac->first.filesize, atracID);
 		} else if (cache) {
 			PGD_DESC pgdinfo = cache->pgd_info;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -899,8 +899,14 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
 		if (cache) {
 			PGD_DESC pgdinfo = cache->pgd_info;
+			if (cache->npdrm) {
+				pgdinfo.block_buf = new u8[pgdinfo.block_size];
+			}
 			addAtrac3AudioByPackage(cache->packagefile, cache->start_pos, atrac->first.filesize,
 			                        Memory::GetPointer(buffer), atracID, cache->npdrm ? &pgdinfo : 0);
+			if (cache->npdrm) {
+				delete [] pgdinfo.block_buf;
+			}
 		} else {
 			if (atrac->first.size >= atrac->first.filesize)
 				addAtrac3Audio(Memory::GetPointer(buffer), atrac->first.filesize, atracID);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -140,7 +140,7 @@ struct Atrac {
 		int remainFrame;
 		if (first.fileoffset >= first.filesize || currentSample >= endSample)
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		else if (decodePos >= first.fileoffset) {
+		else if (decodePos >= first.fileoffset - atracBytesPerFrame ) {
 			// require more data
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
 		} else {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -896,7 +896,9 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 	atrac->data_buf = 0;
 	{
 		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
-		if (cache) {
+		if (checkAudioFileExist(Memory::GetPointer(buffer))) {
+			addAtrac3Audio(Memory::GetPointer(buffer), atrac->first.filesize, atracID);
+		} else if (cache) {
 			PGD_DESC pgdinfo = cache->pgd_info;
 			if (cache->npdrm) {
 				pgdinfo.block_buf = new u8[pgdinfo.block_size];

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -117,6 +117,9 @@ struct Atrac {
 	}
 
 	void DoState(PointerWrap &p) {
+		p.Do(atracChannels);
+		p.Do(atracOutputChannels);
+
 		if (atracID == -1) {
 			// loading state
 			p.Do(atracID);
@@ -177,8 +180,6 @@ struct Atrac {
 		p.Do(decodePos);
 		p.Do(decodeEnd);
 
-		p.Do(atracChannels);
-		p.Do(atracOutputChannels);
 		p.Do(atracBitrate);
 		p.Do(atracBytesPerFrame);
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -896,7 +896,8 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 	atrac->data_buf = 0;
 	{
 		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
-		if (checkAudioFileExist(Memory::GetPointer(buffer))) {
+		if ((atrac->first.size >= atrac->first.filesize) || 
+			(atrac->first.filesize < 0x19000 && checkAudioFileExist(Memory::GetPointer(buffer)))) {
 			addAtrac3Audio(Memory::GetPointer(buffer), atrac->first.filesize, atracID);
 		} else if (cache) {
 			PGD_DESC pgdinfo = cache->pgd_info;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -521,7 +521,7 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 	u32 ret = 0;
 	if (atrac != NULL) {
 		// We already passed the end - return an error (many games check for this.)
-		if (atrac->currentSample >= atrac->endSample && atrac->loopEndSample < 0) {
+		if (atrac->currentSample >= atrac->endSample && atrac->loopNum == 0) {
 			Memory::Write_U32(0, numSamplesAddr);
 			Memory::Write_U32(1, finishFlagAddr);
 			Memory::Write_U32(0, remainAddr);
@@ -576,12 +576,7 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 					numSamples = ATRAC_MAX_SAMPLES;
 				}
 				
-				// Should we loop?
-				if (numSamples == 0 && (atrac->loopStartSample >= 0)) {
-					// Restart.
-					atrac->decodePos = atrac->getDecodePosBySample(atrac->loopStartSample);
-					if (atrac->loopNum > 0)
-						atrac->loopNum--;
+				if (numSamples == 0 && (atrac->loopNum != 0)) {
 					numSamples = ATRAC_MAX_SAMPLES;
 				}
 				Memory::Memset(outAddr, 0, numSamples * sizeof(s16) * atrac->atracOutputChannels);
@@ -601,9 +596,8 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			atrac->decodePos = atrac->getDecodePosBySample(atrac->currentSample);
 			
 			int finishFlag = 0;
-			if (atrac->loopEndSample >= 0 && (atrac->currentSample >= atrac->loopEndSample || numSamples == 0)) {
+			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample || numSamples == 0)) {
 				atrac->currentSample = atrac->loopStartSample;
-				atrac->endSample = atrac->loopEndSample;
 				if (atrac->loopNum > 0)
 					atrac->loopNum --;
 			} else if (atrac->currentSample >= atrac->endSample || numSamples == 0)

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -454,14 +454,6 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		atrac->decodePos = sample;
 	}
 
-#ifdef _USE_DSHOW_
-	audioEngine *engine = getaudioEngineByID(atracID);
-	if (engine != NULL)
-	{
-		engine->setLoop(-1);
-	}
-#endif // _USE_DSHOW_
-
 	return 0;
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -23,13 +23,6 @@
 #include "../MIPS/MIPS.h"
 #include "../CoreTiming.h"
 #include "ChunkFile.h"
-#include "../Core/System.h"
-
-#ifdef _USE_DSHOW_
-#include "../HW/audioPlayer.h"
-#endif // _USE_DSHOW_
-
-#include "../HW/OMAConvert.h"
 
 #include "sceKernel.h"
 #include "sceUtility.h"
@@ -44,9 +37,31 @@
 #define PSP_MODE_AT_3_PLUS	0x00001000
 #define PSP_MODE_AT_3		0x00001001
 
+const int FMT_CHUNK_MAGIC = 0x20746D66;
+const int DATA_CHUNK_MAGIC = 0x61746164;
+const int SMPL_CHUNK_MAGIC = 0x6C706D73;
+const int FACT_CHUNK_MAGIC = 0x74636166;
+
+const int PSP_ATRAC_ALLDATA_IS_ON_MEMORY = -1;
+const int PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY = -2;
+const int PSP_ATRAC_LOOP_STREAM_DATA_IS_ON_MEMORY = -3;
+
 
 const u32 ATRAC_MAX_SAMPLES = 1024;
-const u32 ATRAC_SAMPLES_PERSEC = 44100;
+
+#ifdef _USE_FFMPEG_
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libswresample/swresample.h>
+#include <libavutil/samplefmt.h>
+}
+
+//#pragma comment(lib, "swresample.lib")
+#endif // _USE_FFMPEG_
+
+#ifdef _USE_DSHOW_
+#include "../HW/audioPlayer.h"
+#endif // _USE_DSHOW_
 
 struct InputBuffer {
 	u32 addr;
@@ -58,28 +73,138 @@ struct InputBuffer {
 	u32 fileoffset;
 };
 
+struct AtracLoopInfo {
+	int cuePointID;
+	int type;
+	int startSample;
+	int endSample;
+	int fraction;
+	int playCount;
+};
+
 struct Atrac {
-	Atrac() : decodePos(0), decodeEnd(0), loopNum(0) {
+	Atrac() : decodePos(0), decodeEnd(0), loopNum(0), atracChannels(2), 
+		atracBitrate(64), atracBytesPerFrame(0), atracBufSize(0), currentSample(0), 
+		endSample(-1), loopinfoNum(0), firstSampleoffset(0),data_buf(0){
 		memset(&first, 0, sizeof(first));
 		memset(&second, 0, sizeof(second));
+#ifdef _USE_FFMPEG_
+		pFormatCtx = 0;
+		pAVIOCtx = 0;
+		pCodecCtx = 0;
+		pSwrCtx = 0;
+		pFrame = 0;
+#endif // _USE_FFMPEG_
 	}
+
+	~Atrac() { if (data_buf) delete [] data_buf; }
+
 	void DoState(PointerWrap &p) {
 		p.Do(decodePos);
 		p.Do(decodeEnd);
+
+		p.Do(atracChannels);
+		p.Do(atracBitrate);
+		p.Do(atracBytesPerFrame);
+		p.Do(atracBufSize);
+
+		p.Do(currentSample);
+		p.Do(endSample);
+		p.Do(firstSampleoffset);
+
+		p.Do(loopinfo);
+		p.Do(loopinfoNum);
+
+		p.Do(loopStartSample);
+		p.Do(loopEndSample);
 		p.Do(loopNum);
+
+		p.Do(codeType);
+
 		p.Do(first);
 		p.Do(second);
+		p.DoArray(data_buf, first.filesize);
 		p.DoMarker("Atrac");
 	}
 
 	void Analyze();
+	u32 getDecodePosBySample(int sample) {
+		return firstSampleoffset + (decodeEnd - firstSampleoffset) * sample / endSample;
+	}
+	int getRemainFrames() {
+		int remainFrame;
+		if (first.fileoffset >= first.filesize || currentSample >= endSample)
+			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
+		else {
+			// This is the correct one
+			//remainFrame = (first.size - decodePos) / atracBytesPerFrame;
+
+			// Try to load all file data immediately
+			remainFrame = 0;
+		}
+		return remainFrame;
+	}
+
+	u8* data_buf;
 
 	u32 decodePos;
 	u32 decodeEnd;
+
+	u16 atracChannels;
+	u32 atracBitrate;
+	u16 atracBytesPerFrame;
+	u32 atracBufSize;
+
+	int currentSample;
+	int endSample;
+	// Offset of the first sample in the input buffer
+	int firstSampleoffset;
+
+	std::vector<AtracLoopInfo> loopinfo;
+	int loopinfoNum;
+
+	int loopStartSample;
+	int loopEndSample;
 	int loopNum;
+
+	u32 codeType;
 
 	InputBuffer first;
 	InputBuffer second;
+
+#ifdef _USE_FFMPEG_
+	AVFormatContext *pFormatCtx;
+	AVIOContext	    *pAVIOCtx;
+	AVCodecContext  *pCodecCtx;
+	SwrContext      *pSwrCtx;
+	AVFrame         *pFrame;
+	int audio_stream_index;
+	void ReleaseFFMPEGContext() {
+		if (pFrame)
+			av_free(pFrame);
+		if (pAVIOCtx && pAVIOCtx->buffer)
+			av_free(pAVIOCtx->buffer);
+		if (pAVIOCtx)
+			av_free(pAVIOCtx);
+		if (pSwrCtx)
+			swr_free(&pSwrCtx);
+		if (pCodecCtx)
+			avcodec_close(pCodecCtx);
+		if (pFormatCtx)
+			avformat_close_input(&pFormatCtx);
+		pFormatCtx = 0;
+		pAVIOCtx = 0;
+		pCodecCtx = 0;
+		pSwrCtx = 0;
+		pFrame = 0;
+	}
+
+	void SeekToSample(int sample) {
+		s64 seek_pos = (s64)sample;
+		av_seek_frame(pFormatCtx, audio_stream_index, seek_pos, 0);
+	}
+#endif // _USE_FFMPEG_
+
 };
 
 std::map<int, Atrac *> atracMap;
@@ -87,6 +212,10 @@ u8 nextAtracID;
 
 void __AtracInit() {
 	nextAtracID = 0;
+#ifdef _USE_FFMPEG_
+	avcodec_register_all();
+	av_register_all();
+#endif // _USE_FFMPEG_
 }
 
 void __AtracDoState(PointerWrap &p) {
@@ -138,8 +267,6 @@ int getCodecType(int addr) {
 
 void Atrac::Analyze()
 {
-	this->decodeEnd = 0;
-
 	if (first.size < 0x100)
 	{
 		ERROR_LOG(HLE, "Atrac buffer very small: %d", first.size);
@@ -157,31 +284,87 @@ void Atrac::Analyze()
 	first.filesize = Memory::Read_U32(first.addr + 4) + 8;
 
 	u32 offset = 12;
-	while (first.size > offset + 8)
-	{
-		if (!Memory::IsValidAddress(first.addr + offset))
-		{
-			ERROR_LOG(HLE, "Atrac buffer %08x-%08x not valid at %08x", first.addr, first.addr + first.size, first.addr + offset);
-			return;
-		}
+	int atracSampleoffset = 0;
 
-		u32 magic = Memory::Read_U32(first.addr + offset);
-		u32 size = Memory::Read_U32(first.addr + offset + 4);
+	this->decodeEnd = first.filesize;
+	bool bfoundData = false;
+	while ((first.filesize - offset) >= 8 && !bfoundData) {
+		int chunkMagic = Memory::Read_U32(first.addr + offset);
+		int chunkSize = Memory::Read_U32(first.addr + offset + 4);
 		offset += 8;
-
-		if (magic == *(u32 *) "fmt " && size > 14 && first.size > offset + 14)
-		{
-			u16 bytesPerFrame = Memory::Read_U16(first.addr + offset + 12);
-			// get the correct end sample
-			int endSample = OMAConvert::getRIFFendSample(Memory::GetPointer(first.addr), first.size);
-			if (endSample >= 0)
-				this->decodeEnd = endSample;
-			else {
-				// if there is no correct endsample, try to guess it
-				this->decodeEnd = (first.filesize / bytesPerFrame) * ATRAC_MAX_SAMPLES;
+		if (chunkSize > first.filesize - offset)
+			break;
+		switch (chunkMagic) {
+		case FMT_CHUNK_MAGIC:
+			{
+				if (chunkSize >= 16) {
+					int codeMagic = Memory::Read_U16(first.addr + offset);
+					if (codeMagic == AT3_MAGIC)
+						codeType = PSP_MODE_AT_3;
+					else if (codeMagic == AT3_PLUS_MAGIC)
+						codeType = PSP_MODE_AT_3_PLUS;
+					else
+						codeType = 0;
+					atracChannels = Memory::Read_U16(first.addr + offset + 2);
+					// int atracSamplerate = Memory::Read_U32(first.addr + offset + 4);    ;Should always be 44100Hz
+					int avgBytesPerSec = Memory::Read_U32(first.addr + offset + 8);
+					atracBitrate = avgBytesPerSec * 8;
+					atracBytesPerFrame = Memory::Read_U16(first.addr + offset + 12);
+				}
 			}
+			break;
+		case FACT_CHUNK_MAGIC:
+			{
+				if (chunkSize >= 8) {
+					endSample = Memory::Read_U32(first.addr + offset);
+					atracSampleoffset = Memory::Read_U32(first.addr + offset + 4);
+				}
+			}
+			break;
+		case SMPL_CHUNK_MAGIC:
+			{
+				if (chunkSize < 36)
+					break;
+				int checkNumLoops = Memory::Read_U32(first.addr + offset + 28);
+				if (chunkSize >= 36 + checkNumLoops * 24) {
+					loopinfoNum = checkNumLoops;
+					loopinfo.resize(loopinfoNum);
+					u32 loopinfoAddr = first.addr + offset + 36;
+					for (int i = 0; i < loopinfoNum; i++, loopinfoAddr += 24) {
+						loopinfo[i].cuePointID = Memory::Read_U32(loopinfoAddr);
+						loopinfo[i].type = Memory::Read_U32(loopinfoAddr + 4);
+						loopinfo[i].startSample = Memory::Read_U32(loopinfoAddr + 8) - atracSampleoffset;
+						loopinfo[i].endSample = Memory::Read_U32(loopinfoAddr + 12) - atracSampleoffset;
+						loopinfo[i].fraction = Memory::Read_U32(loopinfoAddr + 16);
+						loopinfo[i].playCount = Memory::Read_U32(loopinfoAddr + 20);
+
+						if (loopinfo[i].endSample > endSample)
+							loopinfo[i].endSample = endSample;
+					}
+				}
+			}
+			break;
+		case DATA_CHUNK_MAGIC:
+			{
+				bfoundData = true;
+				firstSampleoffset = offset;
+			}
+			break;
 		}
+		offset += chunkSize;
 	}
+
+	// set the loopStartSample and loopEndSample by loopinfo
+	if (loopinfoNum > 0) {
+		loopStartSample = loopinfo[0].startSample;
+		loopEndSample = loopinfo[0].endSample;
+	} else {
+		loopStartSample = loopEndSample = -1;
+	}
+
+	// if there is no correct endsample, try to guess it
+	if (endSample < 0)
+		endSample = (first.filesize / atracBytesPerFrame) * ATRAC_MAX_SAMPLES;
 }
 
 u32 sceAtracGetAtracID(int codecType)
@@ -192,18 +375,33 @@ u32 sceAtracGetAtracID(int codecType)
 
 u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
+	INFO_LOG(HLE, "sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
+		return 0;
 	}
 	// TODO
+	if (atrac->data_buf && (bytesToAdd > 0)) {
+		int addbytes = std::min(bytesToAdd, atrac->first.filesize - atrac->first.fileoffset);
+		Memory::Memcpy(atrac->data_buf + atrac->first.fileoffset, atrac->first.addr, addbytes);
+#ifdef _USE_DSHOW_
+		if (atrac->first.fileoffset + addbytes >= atrac->first.filesize)
+			addAtrac3Audio(atrac->data_buf, atrac->first.filesize, atracID);
+#endif
+	}
+	atrac->first.size += bytesToAdd;
+	if (atrac->first.size > atrac->first.filesize)
+		atrac->first.size = atrac->first.filesize;
+	atrac->first.fileoffset = atrac->first.size;
+	atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->atracBufSize);
 	return 0;
 }
 
 u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
 {
 	DEBUG_LOG(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
+	Atrac *atrac = getAtrac(atracID);
 #ifdef _USE_DSHOW_
 	audioEngine *engine = getaudioEngineByID(atracID);
 	if (engine != NULL)
@@ -211,12 +409,11 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 		engine->play();
 	}
 #endif // _USE_DSHOW_
-	Atrac *atrac = getAtrac(atracID);
 
 	u32 ret = 0;
 	if (atrac != NULL) {
 		// We already passed the end - return an error (many games check for this.)
-		if (atrac->decodePos >= atrac->decodeEnd && atrac->loopNum == 0) {
+		if (atrac->currentSample >= atrac->endSample && atrac->loopEndSample < 0) {
 			Memory::Write_U32(0, numSamplesAddr);
 			Memory::Write_U32(1, finishFlagAddr);
 			Memory::Write_U32(0, remainAddr);
@@ -224,58 +421,82 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			ret = ATRAC_ERROR_ALL_DATA_DECODED;
 		} else {
 			// TODO: This isn't at all right, but at least it makes the music "last" some time.
-			u32 numSamples = (atrac->decodeEnd - atrac->decodePos) / (sizeof(s16) * 2);
-			if (atrac->decodePos >= atrac->decodeEnd) {
-				numSamples = 0;
-			} else if (numSamples > ATRAC_MAX_SAMPLES) {
-				numSamples = ATRAC_MAX_SAMPLES;
-			}
+			u32 numSamples = 0;
+#ifdef _USE_FFMPEG_
+			if (atrac->codeType == PSP_MODE_AT_3 && atrac->pCodecCtx) {
+				atrac->SeekToSample(atrac->currentSample);
+				AVPacket packet;
+				int got_frame, ret;
+				while (av_read_frame(atrac->pFormatCtx, &packet) >= 0) {
+					if (packet.stream_index == atrac->audio_stream_index) {
+						got_frame = 0;
+						ret = avcodec_decode_audio4(atrac->pCodecCtx, atrac->pFrame, &got_frame, &packet);
+						if (ret < 0) {
+							ERROR_LOG(HLE, "avcodec_decode_audio4: Error decoding audio %d", ret);
+							break;
+						}
 
-			// Should we loop?
-			if (numSamples == 0 && atrac->loopNum != 0) {
-				// Restart.
-				atrac->decodePos = 0;
-				if (atrac->loopNum > 0)
-					atrac->loopNum--;
-				numSamples = ATRAC_MAX_SAMPLES;
-			}
+						if (got_frame) {
+							// got a frame
+							int decoded = av_samples_get_buffer_size(NULL, atrac->pFrame->channels, 
+								atrac->pFrame->nb_samples, (AVSampleFormat)atrac->pFrame->format, 1);
+							u8* out = Memory::GetPointer(outAddr);
+							numSamples = atrac->pFrame->nb_samples;
+							ret = swr_convert(atrac->pSwrCtx, &out, atrac->pFrame->nb_samples, 
+								(const u8**)atrac->pFrame->extended_data, atrac->pFrame->nb_samples);
+							if (ret < 0) {
+								ERROR_LOG(HLE, "swr_convert: Error while converting %d", ret);
+							}
 
-			Memory::Memset(outAddr, 0, numSamples * sizeof(s16) * 2);
-			Memory::Write_U32(numSamples, numSamplesAddr);
-#ifdef _USE_DSHOW_
-			Memory::Write_U32(0, finishFlagAddr);
-			if (engine) {
-				if (!engine->isneedLoop()) {
-					if (engine->isEnd()) {
-						atrac->decodePos = atrac->decodeEnd;
-					    atrac->loopNum = 0;
-						Memory::Write_U32(1, finishFlagAddr);
+						}
+						av_free_packet(&packet);
+						if (got_frame)
+							break;
 					}
 				}
-				else {
-					atrac->decodePos += ATRAC_MAX_SAMPLES;
-					if (atrac->decodePos >= atrac->decodeEnd && atrac->decodeEnd < ATRAC_SAMPLES_PERSEC * 10)
-						Memory::Write_U32(1, finishFlagAddr);
-					if (atrac->decodePos >= atrac->decodeEnd)
-						atrac->decodePos = 0;
+
+			} else
+#endif // _USE_FFMPEG_
+			{
+				numSamples = atrac->endSample - atrac->currentSample;
+				if (atrac->currentSample >= atrac->endSample) {
+					numSamples = 0;
+				} else if (numSamples > ATRAC_MAX_SAMPLES) {
+					numSamples = ATRAC_MAX_SAMPLES;
 				}
-			}
-			else {
-				atrac->decodePos = atrac->decodeEnd;
-				atrac->loopNum = 0;
-				Memory::Write_U32(1, finishFlagAddr);
-			}
-#else
-			atrac->decodePos += ATRAC_MAX_SAMPLES;
-
-			if (numSamples < ATRAC_MAX_SAMPLES) {
-				Memory::Write_U32(1, finishFlagAddr);
-			} else {
-				Memory::Write_U32(0, finishFlagAddr);
+				
+				// Should we loop?
+				if (numSamples == 0 && (atrac->loopStartSample >= 0)) {
+					// Restart.
+					atrac->decodePos = atrac->getDecodePosBySample(atrac->loopStartSample);
+					if (atrac->loopNum > 0)
+						atrac->loopNum--;
+					numSamples = ATRAC_MAX_SAMPLES;
+				}
+				Memory::Memset(outAddr, 0, numSamples * sizeof(s16) * 2);
 			}
 
+			Memory::Write_U32(numSamples, numSamplesAddr);
+#ifdef _USE_DSHOW_
+			if (engine) {
+				if (!engine->isneedLoop() && engine->isEnd()) {
+					atrac->currentSample = atrac->endSample;
+				}
+			} else
 #endif // _USE_DSHOW_
-			Memory::Write_U32(-1, remainAddr);
+			atrac->currentSample += numSamples;
+			int finishFlag = 0;
+			if (atrac->loopEndSample >= 0 && (atrac->currentSample >= atrac->loopEndSample)) {
+				atrac->currentSample = atrac->loopStartSample;
+				atrac->endSample = atrac->loopEndSample;
+				if (atrac->loopNum > 0)
+					atrac->loopNum --;
+			} else if (atrac->currentSample >= atrac->endSample)
+				finishFlag = 1;
+
+			Memory::Write_U32(finishFlag, finishFlagAddr);
+			int remains = atrac->getRemainFrames();
+			Memory::Write_U32(remains, remainAddr);
 		}
 	// TODO: Can probably remove this after we validate no wrong ids?
 	} else {
@@ -305,10 +526,11 @@ u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr
 		Memory::Memset(bufferInfoAddr, 0, 32);
 		//return -1;
 	} else {
+		int Sampleoffset = atrac->getDecodePosBySample(sample);
 		Memory::Write_U32(atrac->first.addr, bufferInfoAddr);
 		Memory::Write_U32(atrac->first.writableBytes, bufferInfoAddr + 4);
 		Memory::Write_U32(atrac->first.neededBytes, bufferInfoAddr + 8);
-		Memory::Write_U32(atrac->first.fileoffset, bufferInfoAddr + 12);
+		Memory::Write_U32(Sampleoffset, bufferInfoAddr + 12);
 		Memory::Write_U32(atrac->second.addr, bufferInfoAddr + 16);
 		Memory::Write_U32(atrac->second.writableBytes, bufferInfoAddr + 20);
 		Memory::Write_U32(atrac->second.neededBytes, bufferInfoAddr + 24);
@@ -319,40 +541,47 @@ u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr
 
 u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
+	DEBUG_LOG(HLE, "sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		return -1;
 	}
+
+	// I wonder which result should be returned. Such as a 64kbps bitrate audio,
+	// should we return 64 or 64 * 1000 ? Here returns the second one.
 	if (Memory::IsValidAddress(outBitrateAddr))
-		Memory::Write_U32(64, outBitrateAddr);
+		Memory::Write_U32(atrac->atracBitrate, outBitrateAddr);
 	return 0;
 }
 
 u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
+	DEBUG_LOG(HLE, "sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		return -1;
 	}
 	if (Memory::IsValidAddress(channelAddr))
-		Memory::Write_U32(2, channelAddr);
+		Memory::Write_U32(atrac->atracChannels, channelAddr);
 	return 0;
 }
 
 u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
+	DEBUG_LOG(HLE, "sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 	} else {
 		if (Memory::IsValidAddress(loopNumAddr))
 			Memory::Write_U32(atrac->loopNum, loopNumAddr);
-		// TODO: What does this mean?
-		if (Memory::IsValidAddress(statusAddr))
-			Memory::Write_U32(1, statusAddr);
+		// return audio's loopinfo in at3 file
+		if (Memory::IsValidAddress(statusAddr)) {
+			if (atrac->loopinfoNum > 0)
+				Memory::Write_U32(1, statusAddr);
+			else
+				Memory::Write_U32(0, statusAddr);
+		}
 	}
 	return 0;
 }
@@ -371,7 +600,7 @@ u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr)
 
 u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
+	DEBUG_LOG(HLE, "sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -383,28 +612,30 @@ u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 
 u32  sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
+	DEBUG_LOG(HLE, "sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		return -1;
 	}
-	Memory::Write_U32(atrac != NULL ? atrac->decodePos : 0, outposAddr); // outpos
+	if (atrac->currentSample >= atrac->endSample)
+		return ATRAC_ERROR_ALL_DATA_DECODED;
+	Memory::Write_U32(atrac->currentSample, outposAddr); // outpos
 	return 0;
 }
 
 u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 {
-	DEBUG_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
+	DEBUG_LOG(HLE, "sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 		Memory::Write_U32(1, outNAddr);
 	} else {
-		if (atrac->decodePos >= atrac->decodeEnd) {
+		if (atrac->currentSample >= atrac->endSample) {
 			Memory::Write_U32(0, outNAddr);
 		} else {
 			// TODO: This is not correct.
-			u32 numSamples = (atrac->decodeEnd - atrac->decodePos) / (sizeof(s16) * 2);
+			u32 numSamples = atrac->endSample - atrac->currentSample;
 			if (numSamples > ATRAC_MAX_SAMPLES)
 				numSamples = ATRAC_MAX_SAMPLES;
 			Memory::Write_U32(numSamples, outNAddr);
@@ -421,15 +652,14 @@ u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 		//return -1;
 		Memory::Write_U32(12, remainAddr); // outpos
 	} else {
-		// TODO: Seems like this is the number of bytes remaining to read from the file (or -1 if none)?
-		Memory::Write_U32(-1, remainAddr);
+		Memory::Write_U32(atrac->getRemainFrames(), remainAddr);
 	}
 	return 0;
 }
 
 u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 {
-	DEBUG_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
+	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -447,15 +677,15 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 	if (!atrac) {
 		//return -1;
 	}
-	Memory::Write_U32(atrac->decodeEnd, outEndSampleAddr); // outEndSample
-	Memory::Write_U32(-1, outLoopStartSampleAddr); // outLoopStartSample
-	Memory::Write_U32(-1, outLoopEndSampleAddr); // outLoopEndSample
+	Memory::Write_U32(atrac->endSample, outEndSampleAddr); // outEndSample
+	Memory::Write_U32(atrac->loopStartSample, outLoopStartSampleAddr); // outLoopStartSample
+	Memory::Write_U32(atrac->loopEndSample, outLoopEndSampleAddr); // outLoopEndSample
 	return 0;
 }
 
 u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr)
 {
-	DEBUG_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+	ERROR_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -469,7 +699,13 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 
 u32 sceAtracReleaseAtracID(int atracID)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracReleaseAtracID(%i)", atracID);
+	INFO_LOG(HLE, "sceAtracReleaseAtracID(%i)", atracID);
+#ifdef _USE_FFMPEG_
+	Atrac *atrac = getAtrac(atracID);
+	if (atrac)
+		atrac->ReleaseFFMPEGContext();
+#endif // _USE_FFMPEG_
+
 #ifdef _USE_DSHOW_
 	deleteAtrac3Audio(atracID);
 #endif // _USE_DSHOW_
@@ -479,14 +715,22 @@ u32 sceAtracReleaseAtracID(int atracID)
 
 u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
+	INFO_LOG(HLE, "sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 	} else {
-		// TODO: Not sure what this means?
-		atrac->decodePos = sample;
+		atrac->currentSample = sample;
+#ifdef _USE_FFMPEG_
+		if (atrac->codeType == PSP_MODE_AT_3 && atrac->pCodecCtx) {
+			atrac->SeekToSample(sample);
+		} else
+#endif // _USE_FFMPEG_
+		{
+			atrac->decodePos = atrac->getDecodePosBySample(sample);
+		}
 	}
+
 #ifdef _USE_DSHOW_
 	audioEngine *engine = getaudioEngineByID(atracID);
 	if (engine != NULL)
@@ -494,15 +738,58 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		engine->setPlaySample(sample);
 	}
 #endif // _USE_DSHOW_
+
 	return 0;
 }
 
-void _AtracSetData(int atracID, u32 buffer, u32 bufferSize)
+#ifdef _USE_FFMPEG_
+int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size)
 {
-#ifdef _USE_DSHOW_
+	Atrac *atrac = (Atrac*)opaque;
+	int size = std::min((int)atrac->atracBufSize, buf_size);
+	size = std::max(std::min(((int)atrac->first.size - (int)atrac->decodePos), size), 0);
+	if (size > 0)
+		memcpy(buf, atrac->data_buf + atrac->decodePos, size);
+	atrac->decodePos += size;
+	return size;
+}
+
+int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence)
+{
+	Atrac *atrac = (Atrac*)opaque;
+	switch (whence) {
+	case SEEK_SET:
+		atrac->decodePos = offset;
+		break;
+	case SEEK_CUR:
+		atrac->decodePos += offset;
+		break;
+	case SEEK_END:
+		atrac->decodePos = atrac->first.filesize - offset;
+		break;
+	}
+	return offset;
+}
+
+#endif // _USE_FFMPEG_
+
+int _AtracSetData(int atracID, u32 buffer, u32 bufferSize)
+{
 	Atrac *atrac = getAtrac(atracID);
-	if (!atrac || getaudioEngineByID(atracID))
-		return;
+	if (!atrac)
+		return -1;
+	if (atrac->first.size > atrac->first.filesize)
+		atrac->first.size = atrac->first.filesize;
+	atrac->first.fileoffset = atrac->first.size;
+	atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->atracBufSize);
+	atrac->atracBufSize = bufferSize;
+
+#ifdef _USE_DSHOW_
+	if (getaudioEngineByID(atracID))
+		return -1;
+
+	if (atrac->data_buf) 
+			delete [] atrac->data_buf;
 	if (Memory::lastestAccessFile.data_addr == buffer)
 	{
 		PSPFileInfo info = pspFileSystem.GetFileInfo(Memory::lastestAccessFile.filename);
@@ -523,11 +810,92 @@ void _AtracSetData(int atracID, u32 buffer, u32 bufferSize)
 			addAtrac3AudioByPackage(cache->packagefile, cache->start_pos, atrac->first.filesize,
 			                        Memory::GetPointer(buffer), atracID, cache->npdrm ? &pgdinfo : 0);
 		} else {
-			ERROR_LOG(HLE, "Atrac3 file not cache");
-			addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+			ERROR_LOG(HLE, "Atrac3/Atrac3plus file not cache");
+			atrac->data_buf = new u8[atrac->first.filesize];
+			Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
+			if (atrac->first.size >= atrac->first.filesize)
+				addAtrac3Audio(atrac->data_buf, atrac->first.filesize, atracID);
 		}
 	}
+	return 0;
 #endif // _USE_DSHOW_
+
+#ifdef _USE_FFMPEG_
+	if (atrac->codeType == PSP_MODE_AT_3) {
+		INFO_LOG(HLE, "This is an atrac3 audio");
+		if (atrac->data_buf) 
+			delete [] atrac->data_buf;
+
+		atrac->data_buf = new u8[atrac->first.filesize];
+		Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
+		u8* tempbuf = (u8*)av_malloc(atrac->atracBufSize);
+
+		atrac->pFormatCtx = avformat_alloc_context();
+		atrac->pAVIOCtx = avio_alloc_context(tempbuf, atrac->atracBufSize, 0, (void*)atrac, _AtracReadbuffer, NULL, _AtracSeekbuffer);
+		atrac->pFormatCtx->pb = atrac->pAVIOCtx;
+		
+		int ret;
+		// Load audio buffer
+		if((ret = avformat_open_input((AVFormatContext**)&atrac->pFormatCtx, NULL, NULL, NULL)) != 0) {
+			ERROR_LOG(HLE, "avformat_open_input: Cannot open input %d", ret);
+			return -1;
+		}
+
+		if((ret = avformat_find_stream_info(atrac->pFormatCtx, NULL)) < 0) {
+			ERROR_LOG(HLE, "avformat_find_stream_info: Cannot find stream information %d", ret);
+			return -1;
+		}
+		
+		AVCodec *pCodec;
+		// select the audio stream 
+		ret = av_find_best_stream(atrac->pFormatCtx, AVMEDIA_TYPE_AUDIO, -1, -1, &pCodec, 0);
+		if (ret < 0) {
+			ERROR_LOG(HLE, "av_find_best_stream: Cannot find a audio stream in the input file %d", ret);
+			return -1;
+		}
+		atrac->audio_stream_index = ret;
+		atrac->pCodecCtx= atrac->pFormatCtx->streams[atrac->audio_stream_index]->codec;
+
+		// open codec
+		if ((ret = avcodec_open2(atrac->pCodecCtx, pCodec, NULL)) < 0) {
+			ERROR_LOG(HLE, "avcodec_open2: Cannot open audio decoder %d", ret);
+			return -1;
+		}
+		
+		int wanted_channels = 2;
+		int wanted_channel_layout = av_get_default_channel_layout(wanted_channels);
+		int dec_channel_layout = av_get_default_channel_layout(atrac->pCodecCtx->channels);
+
+		atrac->pSwrCtx = 
+			swr_alloc_set_opts
+			(
+				NULL,
+				wanted_channel_layout,
+				AV_SAMPLE_FMT_S16,
+				atrac->pCodecCtx->sample_rate,
+				dec_channel_layout,
+				atrac->pCodecCtx->sample_fmt,
+				atrac->pCodecCtx->sample_rate,
+				0, 
+				NULL
+			);
+		if (!atrac->pSwrCtx) {
+			ERROR_LOG(HLE, "swr_alloc_set_opts: Could not allocate resampler context %d", ret);
+			return -1;
+		}
+		if ((ret = swr_init(atrac->pSwrCtx)) < 0) {
+			ERROR_LOG(HLE, "swr_init: Failed to initialize the resampling context %d", ret);
+			return -1;
+		}
+
+		// alloc audio frame
+		atrac->pFrame = avcodec_alloc_frame();
+		
+		return 0;
+	}
+#endif // _USE_FFMPEG
+
+	return 0;
 }
 
 u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
@@ -541,9 +909,9 @@ u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 half
 		atrac->first.addr = halfBuffer;
 		atrac->first.size = halfBufferSize;
 		atrac->Analyze();
-		_AtracSetData(atracID, halfBuffer, halfBufferSize);
 	}
-	return 0;
+	int ret = _AtracSetData(atracID, halfBuffer, halfBufferSize);
+	return ret;
 }
 
 u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
@@ -558,20 +926,21 @@ u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
 
 u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
+	INFO_LOG(HLE, "sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
 	Atrac *atrac = getAtrac(atracID);
+	int ret = 0;
 	if (atrac != NULL) {
 		atrac->first.addr = buffer;
 		atrac->first.size = bufferSize;
 		atrac->Analyze();
-		_AtracSetData(atracID, buffer, bufferSize);
+		ret = _AtracSetData(atracID, buffer, bufferSize);
 	}
-	return 0;
+	return ret;
 } 
 
 int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 {	
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
+	INFO_LOG(HLE, "sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -579,7 +948,9 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 	atrac->first.size = bufferSize;
 	atrac->Analyze();
 	int atracID = createAtrac(atrac);
-	_AtracSetData(atracID, buffer, bufferSize);
+	int ret = _AtracSetData(atracID, buffer, bufferSize);
+	if (ret < 0)
+		return ret;
 	return atracID;
 }
 
@@ -595,7 +966,9 @@ int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBuffe
 	atrac->first.size = halfBufferSize;
 	atrac->Analyze();
 	int newatracID = createAtrac(atrac);
-	_AtracSetData(newatracID, halfBuffer, halfBufferSize);
+	int ret = _AtracSetData(newatracID, halfBuffer, halfBufferSize);
+	if (ret < 0)
+		return ret;
 	return newatracID;
 }
 
@@ -607,10 +980,15 @@ u32 sceAtracStartEntry()
 
 u32 sceAtracSetLoopNum(int atracID, int loopNum)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
+	INFO_LOG(HLE, "sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
 		atrac->loopNum = loopNum;
+		if (loopNum != 0 && atrac->loopinfoNum == 0) {
+			// Just loop the whole audio
+			atrac->loopStartSample = 0;
+			atrac->loopEndSample = atrac->endSample;
+		}
 #ifdef _USE_DSHOW_
 		audioEngine *engine = getaudioEngineByID(atracID);
 		if (engine)
@@ -628,7 +1006,7 @@ int sceAtracReinit()
 
 int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
+	DEBUG_LOG(HLE, "sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
 	if (Memory::IsValidAddress(outputChanPtr))
 		Memory::Write_U32(2, outputChanPtr);
 	return 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -453,7 +453,6 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		// TODO: Not sure what this means?
 		atrac->decodePos = sample;
 	}
-
 	return 0;
 }
 
@@ -504,12 +503,15 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 			pspFileSystem.CloseFile(h);
 			delete [] buf;
 		}
-		else if (!addAtrac3AudioByPackage(Memory::lastestAccessFile.packagefile, 
-			           Memory::lastestAccessFile.start_pos, atrac->first.filesize, 
-					   Memory::GetPointer(buffer), atracID))
-		{
-			ERROR_LOG(HLE, "failed to find audio stream from package: %s", Memory::lastestAccessFile.packagefile);
-			addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+		else {
+			Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
+			if (cache) {
+				addAtrac3AudioByPackage(cache->packagefile, cache->start_pos, atrac->first.filesize,
+				                        Memory::GetPointer(buffer), atracID);
+			} else {
+				ERROR_LOG(HLE, "Atrac3 file not cache");
+				addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+			}
 		}
 			
 #endif // _USE_DSHOW_
@@ -541,12 +543,15 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 		pspFileSystem.CloseFile(h);
 		delete [] buf;
 	}
-	else if (!addAtrac3AudioByPackage(Memory::lastestAccessFile.packagefile, 
-			     Memory::lastestAccessFile.start_pos, atrac->first.filesize, 
-				 Memory::GetPointer(buffer), atracID))
-	{
-		ERROR_LOG(HLE, "failed to find audio stream from package: %s", Memory::lastestAccessFile.packagefile);
-		addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+	else {
+		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(buffer));
+		if (cache) {
+			addAtrac3AudioByPackage(cache->packagefile, cache->start_pos, atrac->first.filesize,
+			                        Memory::GetPointer(buffer), atracID);
+		} else {
+			ERROR_LOG(HLE, "Atrac3 file not cache");
+			addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
+		}
 	}
 #endif // _USE_DSHOW_
 	return atracID;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -25,9 +25,9 @@
 #include "ChunkFile.h"
 #include "../Core/System.h"
 
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 #include "../HW/audioPlayer.h"
-#endif // _WIN32
+#endif // _USE_DSHOW_
 
 #include "sceKernel.h"
 #include "sceUtility.h"
@@ -98,9 +98,9 @@ void __AtracShutdown() {
 		delete it->second;
 	}
 	atracMap.clear();
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 	shutdownEngine();
-#endif //_WIN32
+#endif // _USE_DSHOW_
 }
 
 Atrac *getAtrac(int atracID) {
@@ -196,13 +196,13 @@ u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
 {
 	DEBUG_LOG(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 	audioEngine *engine = getaudioEngineByID(atracID);
 	if (engine != NULL)
 	{
 		engine->play();
 	}
-#endif // _WIN32
+#endif // _USE_DSHOW_
 	Atrac *atrac = getAtrac(atracID);
 
 	u32 ret = 0;
@@ -436,9 +436,9 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 u32 sceAtracReleaseAtracID(int atracID)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracReleaseAtracID(%i)", atracID);
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 	deleteAtrac3Audio(atracID);
-#endif //_WIN32
+#endif // _USE_DSHOW_
 	deleteAtrac(atracID);
 	return 0;
 }
@@ -489,7 +489,7 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 		atrac->first.addr = buffer;
 		atrac->first.size = bufferSize;
 		atrac->Analyze();
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 		if (Memory::lastestAccessFile.data_addr == buffer)
 		{
 			PSPFileInfo info = pspFileSystem.GetFileInfo(Memory::lastestAccessFile.filename);
@@ -511,7 +511,7 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 			addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
 		}
 			
-#endif // _WIN32
+#endif // _USE_DSHOW_
 	}
 	return 0;
 } 
@@ -526,7 +526,7 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 	atrac->first.size = bufferSize;
 	atrac->Analyze();
 	int atracID = createAtrac(atrac);
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 	if (Memory::lastestAccessFile.data_addr == buffer)
 	{
 		PSPFileInfo info = pspFileSystem.GetFileInfo(Memory::lastestAccessFile.filename);
@@ -547,7 +547,7 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 		ERROR_LOG(HLE, "failed to find audio stream from package: %s", Memory::lastestAccessFile.packagefile);
 		addAtrac3Audio(Memory::GetPointer(buffer), bufferSize, atracID);
 	}
-#endif // _WIN32
+#endif // _USE_DSHOW_
 	return atracID;
 }
 
@@ -577,11 +577,11 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum)
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
 		atrac->loopNum = loopNum;
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 		audioEngine *engine = getaudioEngineByID(atracID);
 		if (engine)
 			engine->setLoop(loopNum);
-#endif // _WIN32
+#endif // _USE_DSHOW_
 	}
 	return 0;
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -31,6 +31,7 @@
 #define ATRAC_ERROR_ALL_DATA_DECODED         0x80630024
 #define ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED 0x80630022
 #define ATRAC_ERROR_INCORRECT_READ_SIZE	     0x80630013
+#define ATRAC_ERROR_UNSET_PARAM              0x80630021
 
 #define AT3_MAGIC		0x0270
 #define AT3_PLUS_MAGIC		0xFFFE
@@ -1080,6 +1081,8 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum)
 	INFO_LOG(HLE, "sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
+		if (atrac->loopinfoNum == 0)
+			return ATRAC_ERROR_UNSET_PARAM;
 		atrac->loopNum = loopNum;
 		if (loopNum != 0 && atrac->loopinfoNum == 0) {
 			// Just loop the whole audio

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -296,6 +296,10 @@ void __AtracInit() {
 	avcodec_register_all();
 	av_register_all();
 #endif // _USE_FFMPEG_
+
+#ifdef _USE_DSHOW_
+	initaudioEngine();
+#endif //_USE_DSHOW_
 }
 
 void __AtracDoState(PointerWrap &p) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -477,6 +477,13 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		// TODO: Not sure what this means?
 		atrac->decodePos = sample;
 	}
+#ifdef _USE_DSHOW_
+	audioEngine *engine = getaudioEngineByID(atracID);
+	if (engine != NULL)
+	{
+		engine->setPlaySample(sample);
+	}
+#endif // _USE_DSHOW_
 	return 0;
 }
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -468,6 +468,11 @@ int __IoRead(int id, u32 data_addr, int size) {
 				strcpy(Memory::lastestAccessFile.filename, f->fullpath.c_str());
 				Memory::lastestAccessFile.data_addr = data_addr;
 			}
+			if (size > 0x20)
+			{
+				strcpy(Memory::lastestAccessFile.packagefile, f->fullpath.c_str());
+				Memory::lastestAccessFile.start_pos = pspFileSystem.GetSeekPos(f->handle);
+			}
 #endif // _WIN32
 			u8 *data = (u8*) Memory::GetPointer(data_addr);
 			if(f->npdrm){
@@ -673,7 +678,7 @@ s64 sceIoLseek(int id, s64 offset, int whence) {
 u32 sceIoLseek32(int id, int offset, int whence) {
 	s32 result = (s32) __IoLseek(id, offset, whence);
 	if (result >= 0) {
-		DEBUG_LOG(HLE, "%i = sceIoLseek(%d, %x, %i)", result, id, offset, whence);
+		DEBUG_LOG(HLE, "%lli = sceIoLseek(%d, %x, %i)", result, id, offset, whence);
 		// Educated guess at timing.
 		return hleDelayResult(result, "io seek", 100);
 	} else {
@@ -929,6 +934,7 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 		case 0x02425824:  // Check if write protected
 			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
 				Memory::Write_U32(0, outPtr);
+				hleDebugBreak();
 				return 0;
 			} else {
 				ERROR_LOG(HLE, "Failed 0x02425824 fat");
@@ -1381,7 +1387,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			pspFileSystem.ReadFile(f->handle, pgd_header, 0x90);
 			f->pgdInfo = pgd_open(pgd_header, 2, keybuf);
 			if(f->pgdInfo==NULL){
-				ERROR_LOG(HLE, "Not a valid PGD file. Open as normal file.");
+				DEBUG_LOG(HLE, "Not a valid PGD file. Open as normal file.");
 				f->npdrm = false;
 				pspFileSystem.SeekFile(f->handle, (s32)0, FILEMOVE_BEGIN);
 				if(memcmp(pgd_header, pgd_magic, 4)==0){

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -458,7 +458,7 @@ int __IoRead(int id, u32 data_addr, int size) {
 			return ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
 		}
 		else if (Memory::IsValidAddress(data_addr)) {
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 			if (f->fullpath.find(".AT3") != std::string::npos ||
 				f->fullpath.find(".at3") != std::string::npos ||
 				f->fullpath.find(".PMF") != std::string::npos ||
@@ -473,7 +473,7 @@ int __IoRead(int id, u32 data_addr, int size) {
 				strcpy(Memory::lastestAccessFile.packagefile, f->fullpath.c_str());
 				Memory::lastestAccessFile.start_pos = pspFileSystem.GetSeekPos(f->handle);
 			}
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 			u8 *data = (u8*) Memory::GetPointer(data_addr);
 			if(f->npdrm){
 				return npdrmRead(f, data, size);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -631,7 +631,7 @@ u32 npdrmLseek(FileNode *f, s32 where, FileMove whence)
 
 s64 __IoLseek(SceUID id, s64 offset, int whence) {
 	u32 error;
-	FileNode *f = kernelObjects.Get<FileNode>(id, error);
+	FileNode *f = kernelObjects.Get < FileNode > (id, error);
 	if (f) {
 		FileMove seek = FILEMOVE_BEGIN;
 
@@ -678,7 +678,7 @@ s64 sceIoLseek(int id, s64 offset, int whence) {
 u32 sceIoLseek32(int id, int offset, int whence) {
 	s32 result = (s32) __IoLseek(id, offset, whence);
 	if (result >= 0) {
-		DEBUG_LOG(HLE, "%lli = sceIoLseek(%d, %x, %i)", result, id, offset, whence);
+		DEBUG_LOG(HLE, "%i = sceIoLseek(%d, %x, %i)", result, id, offset, whence);
 		// Educated guess at timing.
 		return hleDelayResult(result, "io seek", 100);
 	} else {
@@ -934,7 +934,6 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 		case 0x02425824:  // Check if write protected
 			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
 				Memory::Write_U32(0, outPtr);
-				hleDebugBreak();
 				return 0;
 			} else {
 				ERROR_LOG(HLE, "Failed 0x02425824 fat");
@@ -1387,7 +1386,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			pspFileSystem.ReadFile(f->handle, pgd_header, 0x90);
 			f->pgdInfo = pgd_open(pgd_header, 2, keybuf);
 			if(f->pgdInfo==NULL){
-				DEBUG_LOG(HLE, "Not a valid PGD file. Open as normal file.");
+				ERROR_LOG(HLE, "Not a valid PGD file. Open as normal file.");
 				f->npdrm = false;
 				pspFileSystem.SeekFile(f->handle, (s32)0, FILEMOVE_BEGIN);
 				if(memcmp(pgd_header, pgd_magic, 4)==0){

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -498,7 +498,7 @@ int __IoRead(int id, u32 data_addr, int size) {
 #ifdef _USE_FFMPEG_
 			if (idbuf) {
 				if (memcmp(data, "PSMF", 4) == 0) {
-					memcpy(idbuf, data, 0x20);
+					Memory::lastestAccessFile.generateidbuf(data, idbuf);
 					Memory::lastestAccessFile.cachepos++;
 				}
 #ifdef _USE_DSHOW_
@@ -506,7 +506,7 @@ int __IoRead(int id, u32 data_addr, int size) {
 					int end = std::max(std::min(size - 8, 0x100), 1);
 					for (int i = 0; i < end; i++) {
 						if (memcmp(data + i, "RIFF", 4) == 0) {
-							memcpy(idbuf, data + i, 0x20);
+							Memory::lastestAccessFile.generateidbuf(data + i, idbuf);
 							Memory::lastestAccessFile.cachepos++;
 							break;
 						}

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -458,6 +458,17 @@ int __IoRead(int id, u32 data_addr, int size) {
 			return ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
 		}
 		else if (Memory::IsValidAddress(data_addr)) {
+#ifdef _WIN32
+			if (f->fullpath.find(".AT3") != std::string::npos ||
+				f->fullpath.find(".at3") != std::string::npos ||
+				f->fullpath.find(".PMF") != std::string::npos ||
+				f->fullpath.find(".pmf") != std::string::npos
+				)
+			{
+				strcpy(Memory::lastestAccessFile.filename, f->fullpath.c_str());
+				Memory::lastestAccessFile.data_addr = data_addr;
+			}
+#endif // _WIN32
 			u8 *data = (u8*) Memory::GetPointer(data_addr);
 			if(f->npdrm){
 				return npdrmRead(f, data, size);
@@ -615,7 +626,7 @@ u32 npdrmLseek(FileNode *f, s32 where, FileMove whence)
 
 s64 __IoLseek(SceUID id, s64 offset, int whence) {
 	u32 error;
-	FileNode *f = kernelObjects.Get < FileNode > (id, error);
+	FileNode *f = kernelObjects.Get<FileNode>(id, error);
 	if (f) {
 		FileMove seek = FILEMOVE_BEGIN;
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -468,7 +468,7 @@ int __IoRead(int id, u32 data_addr, int size) {
 				strcpy(Memory::lastestAccessFile.filename, f->fullpath.c_str());
 				Memory::lastestAccessFile.data_addr = data_addr;
 			}
-			if (size > 0x20)
+			if (f->info.size > 0x19000)
 			{
 				strcpy(Memory::lastestAccessFile.packagefile, f->fullpath.c_str());
 				Memory::lastestAccessFile.start_pos = pspFileSystem.GetSeekPos(f->handle);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -496,10 +496,23 @@ int __IoRead(int id, u32 data_addr, int size) {
 				result = (int) pspFileSystem.ReadFile(f->handle, data, size);
 			}
 #ifdef _USE_FFMPEG_
-			if (idbuf && (memcmp(data, "RIFF", 4) == 0 || memcmp(data, "riff", 4) == 0 
-				|| memcmp(data, "PSMF", 4) == 0)) {
-				memcpy(idbuf, data, 0x20);
-				Memory::lastestAccessFile.cachepos++;
+			if (idbuf) {
+				if (memcmp(data, "PSMF", 4) == 0) {
+					memcpy(idbuf, data, 0x20);
+					Memory::lastestAccessFile.cachepos++;
+				}
+#ifdef _USE_DSHOW_
+				else {
+					int end = std::max(std::min(size - 8, 0x100), 1);
+					for (int i = 0; i < end; i++) {
+						if (memcmp(data + i, "RIFF", 4) == 0) {
+							memcpy(idbuf, data + i, 0x20);
+							Memory::lastestAccessFile.cachepos++;
+							break;
+						}
+					}
+				}
+#endif // _USE_DSHOW_
 			}
 #endif // _USE_FFMPEG_
 			return result;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -572,7 +572,9 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 		if (cache)
 		{
 			DEBUG_LOG(HLE, "package file: %s, start pos: %08x, buffer addr: %08x", cache->packagefile, cache->start_pos, bufferAddr);
-			loadPMFPackageFile(cache->packagefile, cache->start_pos, ctx->mpegStreamSize + ctx->mpegOffset, Memory::GetPointer(bufferAddr));
+			PGD_DESC pgdinfo = cache->pgd_info;
+			loadPMFPackageFile(cache->packagefile, cache->start_pos, ctx->mpegStreamSize + ctx->mpegOffset, 
+				               Memory::GetPointer(bufferAddr), cache->npdrm ? &pgdinfo : 0);
 		}
 	}
 #endif // _USE_FFMPEG_
@@ -763,8 +765,8 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 
 	if (ctx->mediaengine->stepVideo()) {
 #ifdef _USE_FFMPEG_
-		//if (!playPMFVideo())
-		if (!writePMFVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode))
+		if (!playPMFVideo())
+		//if (!writePMFVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode))
 		{
 			iresult = -1;
 		}
@@ -1405,9 +1407,9 @@ u32 sceMpegAvcCsc(u32 mpeg, u32 sourceAddr, u32 rangeAddr, int frameWidth, u32 d
 	int width    = Memory::Read_U32(rangeAddr + 8);
 	int height   = Memory::Read_U32(rangeAddr + 12);
 #ifdef _USE_FFMPEG_
-	//playPMFVideo();
-	writePMFVideoImageWithRange(Memory::GetPointer(destAddr), frameWidth, ctx->videoPixelMode, 
-		                        x, y, width, height);
+	playPMFVideo();
+	//writePMFVideoImageWithRange(Memory::GetPointer(destAddr), frameWidth, ctx->videoPixelMode, 
+		//                        x, y, width, height);
 #endif // _USE_FFMPEG_
 	return 0;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -24,7 +24,9 @@
 #include "HLE.h"
 #include "../HW/MediaEngine.h"
 #include "../../Core/Config.h"
+#ifdef _USE_FFMPEG_
 #include "../HW/mediaPlayer.h"
+#endif // _USE_FFMPEG_
 
 static bool useMediaEngine;
 
@@ -397,9 +399,9 @@ void __MpegShutdown() {
 		delete it->second;
 	}
 	mpegMap.clear();
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 	deletePMFStream();
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 }
 
 u32 sceMpegInit()
@@ -506,9 +508,9 @@ int sceMpegDelete(u32 mpeg)
 
 	delete ctx;
 	mpegMap.erase(Memory::Read_U32(mpeg));
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 	deletePMFStream();
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 	return 0;
 }
 
@@ -555,7 +557,7 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 	// Kinda destructive, no?
 	AnalyzeMpeg(bufferAddr, ctx);
 
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 	DEBUG_LOG(HLE, "last loaded file: %s", Memory::lastestAccessFile.filename);
 	if (Memory::lastestAccessFile.data_addr != 0)
 	{
@@ -574,7 +576,7 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 			Memory::lastestAccessFile.start_pos, 
 			ctx->mpegStreamSize, Memory::GetPointer(bufferAddr));
 	}
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 
 	if (ctx->mpegMagic != PSMF_MAGIC) {
 		ERROR_LOG(HLE, "sceMpegQueryStreamOffset: Bad PSMF magic");
@@ -761,7 +763,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 	}
 
 	if (ctx->mediaengine->stepVideo()) {
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 		//getPMFPlayer()->writeVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode);
 		if (!playPMFVideo())
 		{
@@ -769,7 +771,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 		}
 #else
 		//ctx->mediaengine->writeVideoImage(buffer, frameWidth, ctx->videoPixelMode);
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 		packetsConsumed += ctx->mediaengine->readLength() / ringbuffer.packetSize;
 
 		// The MediaEngine is already consuming all the remaining
@@ -949,7 +951,7 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 	int iresult = 0;
 
 	if (ctx->mediaengine->stepVideo()) {
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 		//getPMFPlayer()->writeVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode);
 		if (!playPMFVideo())
 		{
@@ -957,7 +959,7 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 		}
 #else
 		//ctx->mediaengine->writeVideoImage(buffer, frameWidth, ctx->videoPixelMode);
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 		// TODO: Write it somewhere or buffer it or something?
 		packetsConsumed += ctx->mediaengine->readLength() / ringbuffer.packetSize;
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -765,8 +765,8 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 
 	if (ctx->mediaengine->stepVideo()) {
 #ifdef _USE_FFMPEG_
-		if (!playPMFVideo())
-		//if (!writePMFVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode))
+		//if (!playPMFVideo())
+		if (!writePMFVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode))
 		{
 			iresult = -1;
 		}
@@ -1062,14 +1062,6 @@ int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringbufferAddr, &ringbuffer);
 	DEBUG_LOG(HLE, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer.packetsFree, ringbufferAddr);
-
-	static int c = 0;
-	if (ringbuffer.packetsFree == 0)
-		c++;
-	else
-		c = 0;
-	//if (c > 1000)
-		//hleDebugBreak();
 	return ringbuffer.packetsFree;
 }
 
@@ -1407,9 +1399,9 @@ u32 sceMpegAvcCsc(u32 mpeg, u32 sourceAddr, u32 rangeAddr, int frameWidth, u32 d
 	int width    = Memory::Read_U32(rangeAddr + 8);
 	int height   = Memory::Read_U32(rangeAddr + 12);
 #ifdef _USE_FFMPEG_
-	playPMFVideo();
-	//writePMFVideoImageWithRange(Memory::GetPointer(destAddr), frameWidth, ctx->videoPixelMode, 
-		//                        x, y, width, height);
+	//playPMFVideo();
+	writePMFVideoImageWithRange(Memory::GetPointer(destAddr), frameWidth, ctx->videoPixelMode, 
+		                        x, y, width, height);
 #endif // _USE_FFMPEG_
 	return 0;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -562,8 +562,14 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 		{
 			DEBUG_LOG(HLE, "package file: %s, start pos: %08x, buffer addr: %08x", cache->packagefile, cache->start_pos, bufferAddr);
 			PGD_DESC pgdinfo = cache->pgd_info;
+			if (cache->npdrm) {
+				pgdinfo.block_buf = new u8[pgdinfo.block_size];
+			}
 			loadPMFPackageFile(cache->packagefile, cache->start_pos, ctx->mpegStreamSize + ctx->mpegOffset, 
 				               Memory::GetPointer(bufferAddr), cache->npdrm ? &pgdinfo : 0);
+			if (cache->npdrm) {
+				delete [] pgdinfo.block_buf;
+			}
 		}
 	}
 #endif // _USE_FFMPEG_

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -558,6 +558,7 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 	AnalyzeMpeg(bufferAddr, ctx);
 
 #ifdef _USE_FFMPEG_
+	deletePMFStream();
 	DEBUG_LOG(HLE, "last loaded file: %s", Memory::lastestAccessFile.filename);
 	if (Memory::lastestAccessFile.data_addr != 0)
 	{
@@ -567,7 +568,7 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 		}
 		else
 			loadPMFPSFFile(Memory::lastestAccessFile.filename, ctx->mpegStreamSize);
-		Memory::lastestAccessFile.data_addr = 0;
+		//Memory::lastestAccessFile.data_addr = 0;
 	}
 	else
 	{

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1060,6 +1060,14 @@ int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	SceMpegRingBuffer ringbuffer;
 	Memory::ReadStruct(ringbufferAddr, &ringbuffer);
 	DEBUG_LOG(HLE, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer.packetsFree, ringbufferAddr);
+
+	static int c = 0;
+	if (ringbuffer.packetsFree == 0)
+		c++;
+	else
+		c = 0;
+	//if (c > 1000)
+		//hleDebugBreak();
 	return ringbuffer.packetsFree;
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -556,17 +556,6 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 #ifdef _USE_FFMPEG_
 	deletePMFStream();
 	DEBUG_LOG(HLE, "last loaded file: %s", Memory::lastestAccessFile.filename);
-	if (Memory::lastestAccessFile.data_addr != 0)
-	{
-		if (bufferAddr == Memory::lastestAccessFile.data_addr)
-		{
-			loadPMFPSFFile(Memory::lastestAccessFile.filename, -1);
-		}
-		else
-			loadPMFPSFFile(Memory::lastestAccessFile.filename, ctx->mpegStreamSize + ctx->mpegOffset);
-		//Memory::lastestAccessFile.data_addr = 0;
-	}
-	else
 	{
 		Memory::LASTESTFILECACHE *cache = Memory::lastestAccessFile.findmatchcache(Memory::GetPointer(bufferAddr));
 		if (cache)

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -21,6 +21,10 @@
 #include "scePsmf.h"
 #include "sceMpeg.h"
 
+#ifdef _USE_FFMPEG_
+#include "../HW/mediaPlayer.h"
+#endif // _USE_FFMPEG_
+
 #include <map>
 
 // "Go Sudoku" is a good way to test this code...
@@ -357,6 +361,9 @@ void __PsmfShutdown()
 		delete it->second;
 	psmfMap.clear();
 	psmfPlayerMap.clear();
+#ifdef _USE_FFMPEG_
+	deletePMFStream();
+#endif // _USE_FFMPEG_
 }
 
 u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData)
@@ -668,6 +675,11 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (psmfplayer)
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
+
+#ifdef _USE_FFMPEG_
+	loadPMFPSFFile(filename, -1);
+#endif // _USE_FFMPEG_
+
 	return 0;
 }
 
@@ -677,6 +689,11 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (psmfplayer)
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
+
+#ifdef _USE_FFMPEG_
+	loadPMFPSFFile(filename, -1);
+#endif // _USE_FFMPEG_
+
 	return 0;
 }
 
@@ -724,6 +741,9 @@ int scePsmfPlayerDelete(u32 psmfPlayer)
 		delete psmfplayer;
 		psmfPlayerMap.erase(psmfPlayer);
 	}
+#ifdef _USE_FFMPEG_
+	deletePMFStream();
+#endif // _USE_FFMPEG_
 	return 0;
 }
 
@@ -742,7 +762,14 @@ int scePsmfPlayerUpdate(u32 psmfPlayer)
 		}
 	}
 	// TODO: Once we start increasing pts somewhere, and actually know the last timestamp, do this better.
+#ifdef _USE_FFMPEG_
+	if (!playPMFVideo())
+	{
+		psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
+	}
+#else
 	psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
+#endif // _USE_FFMPEG_
 	return 0;
 }
 
@@ -757,21 +784,28 @@ int scePsmfPlayerReleasePsmf(u32 psmfPlayer)
 
 int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerGetVideoData(%08x, %08x)", psmfPlayer, videoDataAddr);
+	DEBUG_LOG(HLE, "UNIMPL scePsmfPlayerGetVideoData(%08x, %08x)", psmfPlayer, videoDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(HLE, "scePsmfPlayerGetVideoData - invalid psmf");
 		return ERROR_PSMF_NOT_FOUND;
 	}
 
-	// TODO: Once we start increasing pts somewhere, and actually know the last timestamp, do this better.
+#ifdef _USE_FFMPEG_
+	if (!playPMFVideo())
+	{
+		psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
+	}
+#else
 	psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
+#endif // _USE_FFMPEG_
+
 	return 0;
 }
 
 int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerGetAudioData(%08x, %08x)", psmfPlayer, audioDataAddr);
+	DEBUG_LOG(HLE, "UNIMPL scePsmfPlayerGetAudioData(%08x, %08x)", psmfPlayer, audioDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(HLE, "scePsmfPlayerGetAudioData - invalid psmf");

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -784,13 +784,14 @@ int scePsmfPlayerReleasePsmf(u32 psmfPlayer)
 
 int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 {
-	DEBUG_LOG(HLE, "UNIMPL scePsmfPlayerGetVideoData(%08x, %08x)", psmfPlayer, videoDataAddr);
+	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerGetVideoData(%08x, %08x)", psmfPlayer, videoDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(HLE, "scePsmfPlayerGetVideoData - invalid psmf");
 		return ERROR_PSMF_NOT_FOUND;
 	}
 
+	// TODO: Once we start increasing pts somewhere, and actually know the last timestamp, do this better.
 #ifdef _USE_FFMPEG_
 	if (!playPMFVideo())
 	{
@@ -799,13 +800,12 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 #else
 	psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
 #endif // _USE_FFMPEG_
-
 	return 0;
 }
 
 int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 {
-	DEBUG_LOG(HLE, "UNIMPL scePsmfPlayerGetAudioData(%08x, %08x)", psmfPlayer, audioDataAddr);
+	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerGetAudioData(%08x, %08x)", psmfPlayer, audioDataAddr);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(HLE, "scePsmfPlayerGetAudioData - invalid psmf");

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -1,0 +1,182 @@
+#include "MpegDemux.h"
+
+const int PACKET_START_CODE_MASK   = 0xffffff00;
+const int PACKET_START_CODE_PREFIX = 0x00000100;
+
+const int SEQUENCE_START_CODE      = 0x000001b3;
+const int EXT_START_CODE           = 0x000001b5;
+const int SEQUENCE_END_CODE        = 0x000001b7;
+const int GOP_START_CODE           = 0x000001b8;
+const int ISO_11172_END_CODE       = 0x000001b9;
+const int PACK_START_CODE          = 0x000001ba;
+const int SYSTEM_HEADER_START_CODE = 0x000001bb;
+const int PROGRAM_STREAM_MAP       = 0x000001bc;
+const int PRIVATE_STREAM_1         = 0x000001bd;
+const int PADDING_STREAM           = 0x000001be;
+const int PRIVATE_STREAM_2         = 0x000001bf;
+
+MpegDemux::MpegDemux(u8* buffer, int size, int offset)
+{
+	m_buf = buffer;
+	m_len = size;
+	m_index = offset;
+	m_audioStream = 0;
+	m_audiopos = 0;
+}
+
+
+MpegDemux::~MpegDemux(void)
+{
+	if (m_audioStream)
+		delete [] m_audioStream;
+}
+
+int MpegDemux::readPesHeader(PesHeader &pesHeader, int length, int startCode) {
+	int c = 0;
+	while (length > 0) {
+		c = read8();
+		length--;
+		if (c != 0xFF) {
+			break;
+		}
+	}
+		if ((c & 0xC0) == 0x40) {
+		read8();
+		c = read8();
+		length -= 2;
+	}
+	pesHeader.pts = 0;
+	pesHeader.dts = 0;
+	if ((c & 0xE0) == 0x20) {
+		pesHeader.dts = pesHeader.pts = readPts(c);
+		length -= 4;
+		if ((c & 0x10) != 0) {
+			pesHeader.dts = readPts();
+			length -= 5;
+		}
+	} else if ((c & 0xC0) == 0x80) {
+		int flags = read8();
+		int headerLength = read8();
+		length -= 2;
+		length -= headerLength;
+		if ((flags & 0x80) != 0) {
+			pesHeader.dts = pesHeader.pts = readPts();
+			headerLength -= 5;
+			if ((flags & 0x40) != 0) {
+				pesHeader.dts = readPts();
+				headerLength -= 5;
+			}
+		}
+		if ((flags & 0x3F) != 0 && headerLength == 0) {
+			flags &= 0xC0;
+		}
+		if ((flags & 0x01) != 0) {
+			int pesExt = read8();
+			headerLength--;
+			int skip = (pesExt >> 4) & 0x0B;
+			skip += skip & 0x09;
+			if ((pesExt & 0x40) != 0 || skip > headerLength) {
+				pesExt = skip = 0;
+			}
+			this->skip(skip);
+			headerLength -= skip;
+			if ((pesExt & 0x01) != 0) {
+				int ext2Length = read8();
+				headerLength--;
+				 if ((ext2Length & 0x7F) != 0) {
+					 int idExt = read8();
+					 headerLength--;
+					 if ((idExt & 0x80) == 0) {
+						 startCode = ((startCode & 0xFF) << 8) | idExt;
+					 }
+				 }
+			}
+		}
+		skip(headerLength);
+	}
+	if (startCode == PRIVATE_STREAM_1) {
+		int channel = read8();
+		pesHeader.channel = channel;
+		length--;
+		if (channel >= 0x80 && channel <= 0xCF) {
+			// Skip audio header
+			skip(3);
+			length -= 3;
+			if (channel >= 0xB0 && channel <= 0xBF) {
+				skip(1);
+				length--;
+			}
+		} else {
+			// PSP audio has additional 3 bytes in header
+			skip(3);
+			length -= 3;
+		}
+	}
+	return length;
+}
+
+void MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
+{
+	int length = read16();
+	if (bdemux) {
+		PesHeader pesHeader(channel);
+		length = readPesHeader(pesHeader, length, startCode);
+		if (pesHeader.channel == channel || channel < 0) {
+			memcpy(m_audioStream + m_audiopos, m_buf + m_index, length);
+			m_audiopos += length;
+		}
+		skip(length);
+	} else {
+		skip(length);
+	}
+}
+
+void MpegDemux::demux(int audioChannel)
+{
+	if (!m_audioStream)
+		m_audioStream = new u8[m_len - m_index];
+	while (m_index < m_len)
+	{
+		// Search for start code
+		int startIndex = m_index;
+		int startCode = 0xFF;
+		while ((startCode & PACKET_START_CODE_MASK) != PACKET_START_CODE_PREFIX && !isEOF()) {
+			startCode = (startCode << 8) | read8();
+		}
+		switch (startCode) {
+		    case PACK_START_CODE: {
+			    skip(10);
+			    break;
+			}
+			case SYSTEM_HEADER_START_CODE: {
+				skip(14);
+				break;
+			}
+		    case PADDING_STREAM:
+		    case PRIVATE_STREAM_2: {
+				int length = read16();
+				skip(length);
+				break;
+			}
+			case PRIVATE_STREAM_1: {
+				// Audio stream
+				demuxStream(true, startCode, audioChannel);
+				break;
+			}
+			case 0x1E0: case 0x1E1: case 0x1E2: case 0x1E3:
+			case 0x1E4: case 0x1E5: case 0x1E6: case 0x1E7:
+			case 0x1E8: case 0x1E9: case 0x1EA: case 0x1EB:
+			case 0x1EC: case 0x1ED: case 0x1EE: case 0x1EF: {
+				// Video Stream
+				demuxStream(false, startCode, -1);
+				break;
+			}
+		}
+	}
+}
+
+int MpegDemux::getaudioStream(u8** audioStream)
+{
+	*audioStream = m_audioStream;
+	return m_audiopos;
+}

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -115,13 +115,14 @@ int MpegDemux::readPesHeader(PesHeader &pesHeader, int length, int startCode) {
 	return length;
 }
 
-void MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
+int MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
 {
 	int length = read16();
 	if (bdemux) {
 		PesHeader pesHeader(channel);
 		length = readPesHeader(pesHeader, length, startCode);
 		if (pesHeader.channel == channel || channel < 0) {
+			channel = pesHeader.channel;
 			memcpy(m_audioStream + m_audiopos, m_buf + m_index, length);
 			m_audiopos += length;
 		}
@@ -129,6 +130,7 @@ void MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
 	} else {
 		skip(length);
 	}
+	return channel;
 }
 
 void MpegDemux::demux(int audioChannel)
@@ -160,7 +162,7 @@ void MpegDemux::demux(int audioChannel)
 			}
 			case PRIVATE_STREAM_1: {
 				// Audio stream
-				demuxStream(true, startCode, audioChannel);
+				audioChannel = demuxStream(true, startCode, audioChannel);
 				break;
 			}
 			case 0x1E0: case 0x1E1: case 0x1E2: case 0x1E3:

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -1,0 +1,60 @@
+// This is a simple version MpegDemux that can get media's audio stream.
+// Thanks to JPCSP project.
+
+#pragma once
+
+#include "../../Globals.h"
+
+class MpegDemux
+{
+public:
+	MpegDemux(u8* buffer, int size, int offset);
+	~MpegDemux(void);
+
+	// If you don't know the channel, just simply use -1 instead
+	void demux(int audioChannel = -1);
+
+	// return it's size
+	int getaudioStream(u8 **audioStream);
+private:
+	struct PesHeader {
+		long pts;
+		long dts;
+		int channel;
+
+		PesHeader(int chan) {
+			pts = 0;
+			dts = 0;
+			channel = chan;
+		}
+	};
+	int read8() {
+		return m_buf[m_index++] & 0xFF;
+	}
+	int read16() {
+		return (read8() << 8) | read8();
+	}
+	long readPts() {
+		return readPts(read8());
+	}
+	long readPts(int c) {
+		return (((long) (c & 0x0E)) << 29) | ((read16() >> 1) << 15) | (read16() >> 1);
+	}
+	bool isEOF() {
+		return m_index >= m_len;
+	}
+	void skip(int n) {
+		if (n > 0) {
+			m_index += n;
+		}
+	}
+	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
+	void demuxStream(bool bdemux, int startCode, int channel);
+private:
+	int m_index;
+	int m_len;
+	u8* m_buf;
+	u8* m_audioStream;
+	int m_audiopos;
+};
+

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -49,7 +49,7 @@ private:
 		}
 	}
 	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
-	void demuxStream(bool bdemux, int startCode, int channel);
+	int demuxStream(bool bdemux, int startCode, int channel);
 private:
 	int m_index;
 	int m_len;

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -140,6 +140,19 @@ int getChunkOffset(u8* riff, int limit, int chunkMagic, int offset) {
 	return -1;
 }
 
+// atrac3plus radio
+// 352kbps 0xff
+// 320kbps 0xe8
+// 256kbps 0xb9
+// 192kbps 0x8b
+// 160kbps 0x74
+// 128kbps 0x5c
+//  96kbps 0x45
+//  64kbps 0x2e
+//  48kbps 0x22
+const u8 atrac3plusradio[] = {0xff, 0xe8, 0xb9, 0x8b, 0x74, 0x5c, 0x45, 0x2e, 0x22};
+const int atrac3plusradiosize = sizeof(atrac3plusradio);
+
 int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
 {
 	const int firstChunkOffset = 12;
@@ -166,6 +179,28 @@ int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
 		//headerCode0 = 0x00;
 		//headerCode1 = 0x20;
 		//headerCode2 = 0x30;
+	}
+	else if (magic == AT3_PLUS_MAGIC && headerCode0 == 0x00 
+		&& headerCode1 == 0x28)
+	{
+		bool bsupported = false;
+		for (int i = 0; i < atrac3plusradiosize; i++) {
+			if (atrac3plusradio[i] == headerCode2)
+			{
+				bsupported = true;
+				break;
+			}
+		}
+		if (bsupported == false)
+		{
+			*outputStream = 0;
+			return 0;
+		}
+	}
+	else
+	{
+		*outputStream = 0;
+		return 0;
 	}
 
 	int dataChunkOffset = getChunkOffset(riff, riffSize, DATA_CHUNK_MAGIC, firstChunkOffset);

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -1,0 +1,179 @@
+#include "OMAConvert.h"
+
+namespace OMAConvert {
+
+const u32 OMA_EA3_MAGIC = 0x45413301;
+const u8 OMA_CODECID_ATRAC3P = 1;
+const int OMAHeaderSize = 96;
+const int FMT_CHUNK_MAGIC = 0x20746D66;
+const int DATA_CHUNK_MAGIC = 0x61746164;
+
+template <typename T> void BigEndianWriteBuf(u8* buf, T x, int &pos)
+{
+	int k = sizeof(T);
+	for (int i = k - 1; i >= 0; i--)
+	{
+		buf[pos + i] = (u8)(x & 0xFF);
+		x >>= 8;
+	}
+	pos += k;
+}
+
+template <typename T> inline T getBufValue(T* buf, int offsetbytes)
+{
+	return *(T*)(((u8*)buf) + offsetbytes);
+}
+
+inline void WriteBuf(u8* dst, int &pos, u8* src, int size)
+{
+	memcpy(dst + pos, src, size);
+	pos += size;
+}
+
+bool isHeader(u8* audioStream, int offset)
+{
+	const u8 header1 = (u8)0x0F;
+	const u8 header2 = (u8)0xD0;
+	return (audioStream[offset] == header1) && (audioStream[offset+1] == header2);
+}
+
+// header set to the headerbuf, and return it's size
+int getOmaHeader(u8 codecId, u8 headerCode1, u8 headerCode2, u8* headerbuf)
+{
+	int pos = 0;
+	BigEndianWriteBuf(headerbuf, (u32)OMA_EA3_MAGIC, pos);
+	BigEndianWriteBuf(headerbuf, (u16)OMAHeaderSize, pos);
+	BigEndianWriteBuf(headerbuf, (u16)-1, pos);
+
+	// Unknown 24 bytes...
+	BigEndianWriteBuf(headerbuf, (u32)0x00000000, pos);
+	BigEndianWriteBuf(headerbuf, (u32)0x010f5000, pos);
+	BigEndianWriteBuf(headerbuf, (u32)0x00040000, pos);
+	BigEndianWriteBuf(headerbuf, (u32)0x0000f5ce, pos);
+	BigEndianWriteBuf(headerbuf, (u32)0xd2929132, pos);
+	BigEndianWriteBuf(headerbuf, (u32)0x2480451c, pos);
+
+	BigEndianWriteBuf(headerbuf, (u8)codecId, pos);
+	BigEndianWriteBuf(headerbuf, (u8)0, pos);
+	BigEndianWriteBuf(headerbuf, (u8)headerCode1, pos);
+	BigEndianWriteBuf(headerbuf, (u8)headerCode2, pos);
+
+	while (pos < OMAHeaderSize) BigEndianWriteBuf(headerbuf, (u8)0, pos);
+
+	return pos;
+}
+
+int getNextHeaderPosition(u8* audioStream, int curpos, int limit, int frameSize)
+{
+	int endScan = limit - 1;
+
+	// Most common case: the header can be found at each frameSize
+	int offset = curpos + frameSize - 8;
+	if (offset < endScan && isHeader(audioStream, offset))
+		return offset;
+	for (int scan = curpos; scan < endScan; scan++) {
+		if (isHeader(audioStream, scan))
+			return scan;
+	}
+
+	return -1;
+}
+
+void releaseStream(u8** stream)
+{
+	if (*stream) delete [] (*stream);
+	*stream = 0;
+}
+
+int convertStreamtoOMA(u8* audioStream, int audioSize, u8** outputStream)
+{
+	if (!isHeader(audioStream, 0))
+	{
+		*outputStream = 0;
+		return 0;
+	}
+	u8 headerCode1 = audioStream[2];
+	u8 headerCode2 = audioStream[3];
+
+	int frameSize = ((headerCode1 & 0x03) << 8) | (headerCode2 & 0xFF) * 8 + 0x10;
+	int numCompleteFrames = audioSize / (frameSize + 8);
+	int lastFrameSize = audioSize - (numCompleteFrames * (frameSize + 8));
+
+	int omaStreamSize = OMAHeaderSize + numCompleteFrames * frameSize + lastFrameSize;
+
+	// Allocate an OMA stream size large enough (better too large than too short)
+	if (audioSize > omaStreamSize) omaStreamSize = audioSize;
+	u8* oma = new u8[omaStreamSize];
+	int omapos = 0;
+	int audiopos = 0;
+
+	omapos += getOmaHeader(OMA_CODECID_ATRAC3P, headerCode1, headerCode2, oma);
+	while (audioSize - audiopos > 8) {
+		// Skip 8 bytes frame header
+		audiopos += 8;
+		int nextHeader = getNextHeaderPosition(audioStream, audiopos, audioSize, frameSize);
+		u8* frame = audioStream + audiopos;
+		int framelimit = audioSize - audiopos;
+		if (nextHeader >= 0) {
+			framelimit = nextHeader - audiopos;
+			audiopos = nextHeader;
+		} else
+			audiopos = audioSize;
+		WriteBuf(oma, omapos, frame, framelimit);
+	}
+
+	*outputStream = oma;
+	return omapos;
+}
+
+int getChunkOffset(u8* riff, int limit, int chunkMagic, int offset) {
+	for (int i = offset; i <= limit - 4;) {
+		if (getBufValue((int*)riff, i) == chunkMagic)
+			return i;
+		// Move to next chunk
+		int chunkSize = getBufValue((int*)riff, i + 4);
+		i += chunkSize + 8;
+	}
+
+	return -1;
+}
+
+int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
+{
+	const int firstChunkOffset = 12;
+	int fmtChunkOffset = getChunkOffset(riff, riffSize, FMT_CHUNK_MAGIC, firstChunkOffset);
+	if (fmtChunkOffset < 0) {
+		*outputStream = 0;
+		return 0;
+	}
+	u8 codecId = getBufValue(riff, fmtChunkOffset + 0x30);
+	u8 headerCode1 = getBufValue(riff, fmtChunkOffset + 0x32);
+	u8 headerCode2 = getBufValue(riff, fmtChunkOffset + 0x33);
+
+	int dataChunkOffset = getChunkOffset(riff, riffSize, DATA_CHUNK_MAGIC, firstChunkOffset);
+	if (dataChunkOffset < 0) {
+		*outputStream = 0;
+		return 0;
+	}
+	int dataSize = getBufValue((int*)riff, dataChunkOffset + 4);
+	int datapos = dataChunkOffset + 8;
+
+	u8* oma = new u8[OMAHeaderSize + dataSize];
+	int omapos = 0;
+
+	omapos += getOmaHeader(codecId, headerCode1, headerCode2, oma);
+	WriteBuf(oma, omapos, riff + datapos, dataSize);
+
+	*outputStream = oma;
+	return omapos;
+}
+
+int getOMANumberAudioChannels(u8* oma)
+{
+	int headerParameters = getBufValue((int*)oma, 0x20);
+	int channels = (headerParameters >> 18) & 0x7;
+
+	return channels;
+}
+
+} // namespace OMAConvert

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -194,4 +194,15 @@ int getOMANumberAudioChannels(u8* oma)
 	return channels;
 }
 
+int getRIFFSize(u8* riff, int bufsize)
+{
+	const int firstChunkOffset = 12;
+	int fmtChunkOffset = getChunkOffset(riff, bufsize, FMT_CHUNK_MAGIC, firstChunkOffset);
+	int dataChunkOffset = getChunkOffset(riff, bufsize, DATA_CHUNK_MAGIC, firstChunkOffset);
+	if (fmtChunkOffset < 0 || dataChunkOffset < 0)
+		return 0;
+	int dataSize = getBufValue((int*)riff, dataChunkOffset + 4);
+	return dataSize + dataChunkOffset + 8;
+}
+
 } // namespace OMAConvert

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -189,10 +189,12 @@ int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
 	u8 headerCode1 = getBufValue(riff, fmtChunkOffset + 0x32);
 	u8 headerCode2 = getBufValue(riff, fmtChunkOffset + 0x33);
 
+	bool bsupported = false;
 	u16 magic = getBufValue((u16*)riff, fmtChunkOffset + 0x08);
 	if (magic == AT3_MAGIC)
 	{
 		u8 key = getBufValue((u8*)riff, fmtChunkOffset + 0x11);
+		u8 channel = getBufValue((u8*)riff, fmtChunkOffset + 0x0a);
 		switch (key)
 		{
 		case 0x20:
@@ -223,11 +225,14 @@ int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
 			}
 			break;
 		}
+		if (channel == 2)
+			bsupported = true;
+		else 
+			bsupported = false;
 	}
 	else if (magic == AT3_PLUS_MAGIC && headerCode0 == 0x00 
 		&& headerCode1 == 0x28)
 	{
-		bool bsupported = false;
 		for (int i = 0; i < atrac3plusradiosize; i++) {
 			if (atrac3plusradio[i] == headerCode2)
 			{
@@ -235,13 +240,9 @@ int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream)
 				break;
 			}
 		}
-		if (bsupported == false)
-		{
-			*outputStream = 0;
-			return 0;
-		}
 	}
-	else
+
+	if (bsupported == false)
 	{
 		*outputStream = 0;
 		return 0;

--- a/Core/HW/OMAConvert.h
+++ b/Core/HW/OMAConvert.h
@@ -1,0 +1,20 @@
+// It can simply convert a at3+ file or stream to oma format
+// Thanks to JPCSP project
+
+#pragma once
+
+#include "../../Globals.h"
+
+namespace OMAConvert {
+
+	// output OMA to outputStream, and return it's size. You need to release it by use releaseStream()
+	int convertStreamtoOMA(u8* audioStream, int audioSize, u8** outputStream);
+	// output OMA to outputStream, and return it's size. You need to release it by use releaseStream()
+	int convertRIFFtoOMA(u8* riff, int riffSize, u8** outputStream);
+
+	void releaseStream(u8** stream);
+
+	int getOMANumberAudioChannels(u8* oma);
+
+} // namespace OMAConvert
+

--- a/Core/HW/OMAConvert.h
+++ b/Core/HW/OMAConvert.h
@@ -16,5 +16,6 @@ namespace OMAConvert {
 
 	int getOMANumberAudioChannels(u8* oma);
 
+	int getRIFFSize(u8* riff, int bufsize);
 } // namespace OMAConvert
 

--- a/Core/HW/OMAConvert.h
+++ b/Core/HW/OMAConvert.h
@@ -17,5 +17,7 @@ namespace OMAConvert {
 	int getOMANumberAudioChannels(u8* oma);
 
 	int getRIFFSize(u8* riff, int bufsize);
+
+	int getRIFFLoopNum(u8* riff, int bufsize);
 } // namespace OMAConvert
 

--- a/Core/HW/OMAConvert.h
+++ b/Core/HW/OMAConvert.h
@@ -18,6 +18,8 @@ namespace OMAConvert {
 
 	int getRIFFSize(u8* riff, int bufsize);
 
-	int getRIFFLoopNum(u8* riff, int bufsize);
+	int getRIFFLoopNum(u8* riff, int bufsize, int *startsample = 0, int *endsample = 0);
+
+	int getRIFFendSample(u8* riff, int bufsize);
 } // namespace OMAConvert
 

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -298,11 +298,14 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 	}
 	pspFileSystem.CloseFile(h);
 
-	bool bResult = true;
-	if (memcmp(buffer, buf , 0x20) == 0)
-		addAtrac3Audio(buf, filesize, atracID);
-	else
-		bResult = false;
+	bool bResult = false;
+	for (int i = 0; i < 0x100; i++) {
+		if (memcmp(buffer, buf + i , 0x20) == 0) {
+			addAtrac3Audio(buf + i, filesize, atracID);
+			bResult = true;
+			break;
+		}
+	}
 	delete [] buf;
 	return bResult;
 }

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -154,6 +154,12 @@ bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
 		return false;
 	}*/
 	m_ID = atracID;
+	/*{
+	sprintf(m_filename, "tmp\\%d.at3", m_ID);
+	FILE *wfp = fopen(m_filename, "wb");
+	fwrite(stream, 1, streamsize, wfp);
+	fclose(wfp);
+	}*/
 	sprintf(m_filename, "tmp\\%d.oma", m_ID);
 	FILE *wfp = fopen(m_filename, "wb");
 	fwrite(oma, 1, omasize, wfp);
@@ -249,8 +255,6 @@ void addAtrac3Audio(u8* stream, int streamsize, int atracID)
 bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize, 
 	u8* buffer, int atracID)
 {
-	if (strlen(package) < 10)
-		return false;
 	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
 	if (h == 0) 
 		return false;
@@ -259,7 +263,10 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 		return false;
 	u8* buf = new u8[filesize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
-	filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	if (strlen(package) >= 10)
+		filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	else
+		pspFileSystem.ReadFile(h, buf, filesize / 2048);
 	pspFileSystem.CloseFile(h);
 
 	bool bResult = true;

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -1,4 +1,4 @@
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 
 #include "audioPlayer.h"
 #include <dshow.h>
@@ -295,4 +295,4 @@ void shutdownEngine()
 	audioMap.clear();
 }
 
-#endif // _WIN32
+#endif // _USE_DSHOW_

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -352,20 +352,21 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 	int filesize = OMAConvert::getRIFFSize(buffer, 0x2000);
 	if (filesize <= 0)
 		return false;
-	u8* buf = new u8[filesize];
+	int readsize = filesize + 0x800;
+	u8* buf = new u8[readsize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
 
 	if (strlen(package) >= 10) {
 		if (pgd_info)
-			filesize = npdrmRead(pgd_info, h, buf, filesize);
+			readsize = npdrmRead(pgd_info, h, buf, readsize);
 		else
-			filesize = pspFileSystem.ReadFile(h, buf, filesize);
+			readsize = pspFileSystem.ReadFile(h, buf, readsize);
 	}
 	else {
 		if (pgd_info)
-			npdrmRead(pgd_info, h, buf, filesize / 2048);
+			npdrmRead(pgd_info, h, buf, readsize / 2048);
 		else
-			pspFileSystem.ReadFile(h, buf, filesize / 2048);
+			pspFileSystem.ReadFile(h, buf, readsize / 2048);
 	}
 	pspFileSystem.CloseFile(h);
 

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -270,8 +270,10 @@ void addAtrac3Audio(u8* stream, int streamsize, int atracID)
 		temp->closeMedia();
 }
 
+extern u32 npdrmRead(void* pgd_info, u32 handle, u8 *data, int size);
+
 bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize, 
-	u8* buffer, int atracID)
+	u8* buffer, int atracID, void* pgd_info)
 {
 	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
 	if (h == 0) 
@@ -281,10 +283,19 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 		return false;
 	u8* buf = new u8[filesize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
-	if (strlen(package) >= 10)
-		filesize = pspFileSystem.ReadFile(h, buf, filesize);
-	else
-		pspFileSystem.ReadFile(h, buf, filesize / 2048);
+
+	if (strlen(package) >= 10) {
+		if (pgd_info)
+			filesize = npdrmRead(pgd_info, h, buf, filesize);
+		else
+			filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	}
+	else {
+		if (pgd_info)
+			npdrmRead(pgd_info, h, buf, filesize / 2048);
+		else
+			pspFileSystem.ReadFile(h, buf, filesize / 2048);
+	}
 	pspFileSystem.CloseFile(h);
 
 	bool bResult = true;

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -18,7 +18,7 @@
 #define LIF(x) if (FAILED(hr=(x))) \
     {}
 
-static volatile int g_volume = 20;
+static volatile int g_volume = 60;
 
 audioPlayer::audioPlayer(void)
 {
@@ -27,14 +27,12 @@ audioPlayer::audioPlayer(void)
 	m_pMC = 0;
 	m_pGB = 0;
 	m_pMS = 0;
-	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 }
 
 
 audioPlayer::~audioPlayer(void)
 {
 	closeMedia();
-	CoUninitialize();
 }
 
 bool audioPlayer::load(const char* filename)
@@ -284,14 +282,15 @@ UINT WINAPI loopAtrac3Audio(LPVOID)
 	{
 		bool bChangeVolume = false;
 		int sleeptime = 300;
-		if (GetAsyncKeyState('1') < 0 && g_volume > 0)
+		const int deltavolume = 3;
+		if (GetAsyncKeyState('1') < 0 && g_volume >= deltavolume)
 		{
-			g_volume--;
+			g_volume -= deltavolume;
 			bChangeVolume = true;
 		}
-		else if (GetAsyncKeyState('2') < 0 && g_volume < 100)
+		else if (GetAsyncKeyState('2') < 0 && g_volume <= 100 - deltavolume)
 		{
-			g_volume++;
+			g_volume += deltavolume;
 			bChangeVolume = true;
 		}
 		for (auto it = audioMap.begin(); it != audioMap.end(); ++it) {
@@ -394,12 +393,18 @@ void deleteAtrac3Audio(int atracID)
 	}
 }
 
+void initaudioEngine()
+{
+	CoInitialize(0);
+}
+
 void shutdownEngine()
 {
 	for (auto it = audioMap.begin(); it != audioMap.end(); ++it) {
 		delete it->second;
 	}
 	audioMap.clear();
+	CoUninitialize();
 }
 
 void stopAllAtrac3Audio()

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -157,25 +157,32 @@ bool audioPlayer::setPlayPos(long ms)
 bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
 {
 	u8 *oma = 0;
-	int omasize = OMAConvert::convertRIFFtoOMA(stream, streamsize, &oma);
-	if (omasize <= 0)
-		return false;
-	/*else if (omasize <= 70*1024) {
-		OMAConvert::releaseStream(&oma);
-		return false;
-	}*/
 	m_ID = atracID;
-	/*{
-	sprintf(m_filename, "tmp\\%d.at3", m_ID);
-	FILE *wfp = fopen(m_filename, "wb");
-	fwrite(stream, 1, streamsize, wfp);
-	fclose(wfp);
-	}*/
-	sprintf(m_filename, "tmp\\%d.oma", m_ID);
-	FILE *wfp = fopen(m_filename, "wb");
-	fwrite(oma, 1, omasize, wfp);
-	fclose(wfp);
-	OMAConvert::releaseStream(&oma);
+	int omasize = OMAConvert::convertRIFFtoOMA(stream, streamsize, &oma);
+	if (omasize <= 0) {
+		char strtemp[260];
+		sprintf(m_filename, "tmp\\%d.at3", m_ID);
+		FILE *wfp = fopen(m_filename, "wb");
+		fwrite(stream, 1, streamsize, wfp);
+		fclose(wfp);
+		sprintf(strtemp, "at3tool\\at3tool.exe -d tmp\\%d.at3 tmp\\%d.wav", m_ID, m_ID);
+		system(strtemp);
+		DeleteFileA(m_filename);
+
+		sprintf(m_filename, "tmp\\%d.wav", m_ID);
+		wfp = fopen(m_filename, "rb");
+		if (!wfp) {
+			m_ID = -1;
+			return false;
+		}
+		fclose(wfp);
+	} else {
+		sprintf(m_filename, "tmp\\%d.oma", m_ID);
+		FILE *wfp = fopen(m_filename, "wb");
+		fwrite(oma, 1, omasize, wfp);
+		fclose(wfp);
+		OMAConvert::releaseStream(&oma);
+	}
 
 	m_iloop = OMAConvert::getRIFFLoopNum(stream, streamsize);
 

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -173,11 +173,16 @@ bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
 {
 	u8 *oma = 0;
 	m_ID = atracID;
-	bool isexist = checkAudioFileExist(stream, m_filename);
+	bool isneedcache = streamsize >= 0x19000;
+	bool isexist = isneedcache ? checkAudioFileExist(stream, m_filename) : false;
 	if (!isexist) {
 		int omasize = OMAConvert::convertRIFFtoOMA(stream, streamsize, &oma);
 		if (omasize <= 0) {
-			int pos = generateAudioFilename(stream, m_filename);
+			int pos;
+			if (isneedcache)
+				pos = generateAudioFilename(stream, m_filename);
+			else
+				pos = sprintf(m_filename, "tmp\\%d", m_ID);
 			char strtemp[260];
 			sprintf(strtemp, "%s.at3", m_filename);
 			FILE *wfp = fopen(strtemp, "wb");
@@ -196,7 +201,11 @@ bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
 			}
 			fclose(wfp);
 		} else {
-			int pos = generateAudioFilename(stream, m_filename);
+			int pos;
+			if (isneedcache)
+				pos = generateAudioFilename(stream, m_filename);
+			else
+				pos = sprintf(m_filename, "tmp\\%d", m_ID);
 			memcpy(m_filename + pos, ".oma", 5);
 			FILE *wfp = fopen(m_filename, "wb");
 			fwrite(oma, 1, omasize, wfp);

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -182,7 +182,7 @@ bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
 		FILE *wfp = fopen(m_filename, "wb");
 		fwrite(stream, 1, streamsize, wfp);
 		fclose(wfp);
-		sprintf(strtemp, "at3tool\\at3tool.exe -d tmp\\%d.at3 tmp\\%d.wav", m_ID, m_ID);
+		sprintf(strtemp, "at3tool\\at3tool.exe -d -repeat 1 tmp\\%d.at3 tmp\\%d.wav", m_ID, m_ID);
 		system(strtemp);
 		DeleteFileA(m_filename);
 

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -9,6 +9,8 @@
 #include <map>
 #include <process.h>
 
+#include "../Core/System.h"
+
 #define JIF(x) if (FAILED(hr=(x))) \
     {return false;}
 #define KIF(x) if (FAILED(hr=(x))) \
@@ -242,6 +244,31 @@ void addAtrac3Audio(u8* stream, int streamsize, int atracID)
 	audioMap[atracID] = temp;
 	if (!bResult)
 		temp->closeMedia();
+}
+
+bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize, 
+	u8* buffer, int atracID)
+{
+	if (strlen(package) < 10)
+		return false;
+	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
+	if (h == 0) 
+		return false;
+	int filesize = OMAConvert::getRIFFSize(buffer, 0x2000) + 0x2000;
+	if (filesize == 0x2000)
+		return false;
+	u8* buf = new u8[filesize];
+	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
+	filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	pspFileSystem.CloseFile(h);
+
+	bool bResult = true;
+	if (memcmp(buffer, buf , 0x20) == 0)
+		addAtrac3Audio(buf, filesize, atracID);
+	else
+		bResult = false;
+	delete [] buf;
+	return bResult;
 }
 
 audioEngine* getaudioEngineByID(int atracID)

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -249,6 +249,12 @@ bool audioEngine::setPlaySample(int sample)
 	return setPlayPos(((s64)sample) * 1000 / 44100);
 }
 
+bool audioEngine::play()
+{
+	m_lenstoplay = 2;
+	return audioPlayer::play();
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 
@@ -273,6 +279,11 @@ UINT WINAPI loopAtrac3Audio(LPVOID)
 		}
 		for (auto it = audioMap.begin(); it != audioMap.end(); ++it) {
 			audioEngine *temp = it->second;
+			if (temp->m_lenstoplay == 0)
+				temp->pause();
+			else {
+				temp->m_lenstoplay--;
+			}
 			if (temp->isneedLoop()) {
 				long timetoend;
 				bool bEnd = temp->isEnd(&timetoend);
@@ -318,8 +329,8 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
 	if (h == 0) 
 		return false;
-	int filesize = OMAConvert::getRIFFSize(buffer, 0x2000) + 0x2000;
-	if (filesize == 0x2000)
+	int filesize = OMAConvert::getRIFFSize(buffer, 0x2000);
+	if (filesize <= 0)
 		return false;
 	u8* buf = new u8[filesize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);

--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -1,0 +1,253 @@
+#ifdef _WIN32
+
+#include "audioPlayer.h"
+#include <dshow.h>
+#pragma comment(lib, "Strmiids.lib")
+#pragma comment(lib, "Quartz.lib")
+
+#include "OMAConvert.h"
+#include <map>
+#include <process.h>
+
+#define JIF(x) if (FAILED(hr=(x))) \
+    {return false;}
+#define KIF(x) if (FAILED(hr=(x))) \
+    {return hr;}
+#define LIF(x) if (FAILED(hr=(x))) \
+    {}
+
+static volatile int g_volume = 20;
+
+audioPlayer::audioPlayer(void)
+{
+	m_playmode = -1;
+	m_volume = g_volume;
+	m_pMC = 0;
+	m_pGB = 0;
+	m_pMS = 0;
+	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+}
+
+
+audioPlayer::~audioPlayer(void)
+{
+	closeMedia();
+	CoUninitialize();
+}
+
+bool audioPlayer::load(const char* filename)
+{
+	if (m_playmode == 1) 
+		return false;
+	WCHAR wstrfilename[MAX_PATH + 1];
+	MultiByteToWideChar( CP_ACP, 0, filename, -1, 
+         wstrfilename, MAX_PATH );
+	wstrfilename[MAX_PATH] = 0;
+
+	HRESULT hr;
+	JIF(CoCreateInstance(CLSID_FilterGraph, NULL, CLSCTX_INPROC_SERVER,
+		IID_IGraphBuilder, (void **)&m_pGB));
+	IGraphBuilder *pGB=(IGraphBuilder*)m_pGB;
+	JIF(pGB->QueryInterface(IID_IMediaControl, (void **)&m_pMC));
+	JIF(pGB->QueryInterface(IID_IMediaSeeking, (void **)&m_pMS));
+
+	JIF(pGB->RenderFile(wstrfilename, 0));
+	setVolume(m_volume);
+	m_playmode = 0;
+
+	return true;
+}
+
+bool audioPlayer::play()
+{
+	if ((!m_pMC) || (m_playmode == -1))
+		return false;
+	IMediaControl *pMC = (IMediaControl*)m_pMC;
+	HRESULT hr;
+	JIF(pMC->Run());
+	m_playmode = 1;
+	return true;
+}
+
+bool audioPlayer::stop()
+{
+	if ((!m_pMC) || (m_playmode <= 0))
+		return true;
+	IMediaControl *pMC = (IMediaControl*)m_pMC;
+	HRESULT hr;
+	JIF(pMC->Stop());
+	m_playmode = 0;
+	return true;
+}
+
+bool audioPlayer::closeMedia()
+{
+	stop();
+	if (m_pMS)
+		((IMediaSeeking*)m_pMS)->Release();
+	if (m_pMC)
+		((IMediaControl*)m_pMC)->Release();
+	if (m_pGB)
+		((IGraphBuilder*)m_pGB)->Release();
+	m_pMS = 0;
+	m_pMC = 0;
+	m_pGB = 0;
+	m_playmode = -1;
+	return true;
+}
+
+bool audioPlayer::setVolume(int volume)
+{
+	if ((volume < 0) || (volume > 100))
+		return false;
+	m_volume = volume;
+	if (!m_pGB)
+		return true;
+	IBasicAudio *pBA = NULL;
+	HRESULT hr;
+	int now = -(int)(exp(log((double)10001)/100*(100-volume))-1+0.5);
+	JIF(((IGraphBuilder*)m_pGB)->QueryInterface(IID_IBasicAudio, (void**)&pBA));
+	pBA->put_Volume(now);
+	pBA->Release();
+	return true;
+}
+
+bool audioPlayer::isEnd()
+{
+	if (!m_pMS)
+		return false;
+	IMediaSeeking *pMS=(IMediaSeeking*)m_pMS;
+	LONGLONG stoppos, curpos;
+	HRESULT hr;
+	JIF(pMS->GetStopPosition(&stoppos));
+	JIF(pMS->GetCurrentPosition(&curpos));
+	if (curpos >= stoppos)
+		return true;
+	return false;
+}
+
+bool audioPlayer::setPlayPos(long ms)
+{
+	if (!m_pGB)
+		return false;
+	HRESULT hr;
+	IMediaSeeking *pMS = (IMediaSeeking*)m_pMS;
+	LONGLONG pos = ((LONGLONG)ms)*10000;
+	JIF(pMS->SetPositions(&pos, AM_SEEKING_AbsolutePositioning,
+		NULL, AM_SEEKING_NoPositioning));
+	return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+// audioEngine
+
+bool audioEngine::loadRIFFStream(u8* stream, int streamsize, int atracID)
+{
+	u8 *oma = 0;
+	int omasize = OMAConvert::convertRIFFtoOMA(stream, streamsize, &oma);
+	if (omasize <= 0)
+		return false;
+	else if (omasize <= 70*1024) {
+		OMAConvert::releaseStream(&oma);
+		return false;
+	}
+	m_ID = atracID;
+	sprintf(m_filename, "tmp\\%d.oma", m_ID);
+	FILE *wfp = fopen(m_filename, "wb");
+	fwrite(oma, 1, omasize, wfp);
+	fclose(wfp);
+	OMAConvert::releaseStream(&oma);
+
+	return load(m_filename);
+}
+
+bool audioEngine::closeStream()
+{
+	bool bResult = closeMedia();
+	if (m_ID >= 0)
+		DeleteFileA(m_filename);
+	m_ID = -1;
+	return bResult;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+
+std::map<int, audioEngine*> audioMap;
+static bool bFirst = true;
+
+UINT WINAPI loopAtrac3Audio(LPVOID)
+{
+	while (1)
+	{
+		bool bChangeVolume = false;
+		if (GetAsyncKeyState('1') < 0 && g_volume > 0)
+		{
+			g_volume--;
+			bChangeVolume = true;
+		}
+		else if (GetAsyncKeyState('2') < 0 && g_volume < 100)
+		{
+			g_volume++;
+			bChangeVolume = true;
+		}
+		for (auto it = audioMap.begin(), end = audioMap.end(); it != end; ++it) {
+			audioEngine *temp = it->second;
+			if (temp->isEnd())
+			{
+				temp->setPlayPos(0);
+				temp->play();
+			}
+			if (bChangeVolume)
+				temp->setVolume(g_volume);
+		}
+		Sleep(300);
+	}
+	return 0;
+}
+
+void addAtrac3Audio(u8* stream, int streamsize, int atracID)
+{
+	if (bFirst)
+	{
+		CreateDirectory("tmp", NULL);
+		UINT uiThread;
+		HANDLE hThread=(HANDLE)::_beginthreadex(NULL, 0, loopAtrac3Audio,
+			                                   0, 0, &uiThread);
+		CloseHandle(hThread);
+		bFirst = false;
+	}
+	if (audioMap.find(atracID) != audioMap.end()) 
+		return;
+	audioEngine *temp = new audioEngine();
+	bool bResult = temp->loadRIFFStream(stream, streamsize, atracID);
+	audioMap[atracID] = temp;
+	if (!bResult)
+		temp->closeMedia();
+}
+
+audioEngine* getaudioEngineByID(int atracID)
+{
+	if (audioMap.find(atracID) == audioMap.end()) {
+		return NULL;
+	}
+	return audioMap[atracID];
+}
+
+void deleteAtrac3Audio(int atracID)
+{
+	if (audioMap.find(atracID) != audioMap.end()) {
+		delete audioMap[atracID];
+		audioMap.erase(atracID);
+	}
+}
+
+void shutdownEngine()
+{
+	for (auto it = audioMap.begin(), end = audioMap.end(); it != end; ++it) {
+		delete it->second;
+	}
+	audioMap.clear();
+}
+
+#endif // _WIN32

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -31,9 +31,13 @@ public:
 	~audioEngine(void){ closeStream();}
 	bool loadRIFFStream(u8* stream, int streamsize, int atracID);
 	bool closeStream();
+	void setLoop(int iloop);
+	void decLoopcount();
+	bool isneedLoop();
 private:
 	int m_ID;
 	char m_filename[256];
+	int m_iloop;
 };
 
 void addAtrac3Audio(u8* stream, int streamsize, int atracID);

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -15,7 +15,7 @@ public:
 	bool stop();
 	bool closeMedia();
     bool setVolume(int volume);
-    bool isEnd();
+    bool isEnd(long *mstimetoend = 0);
     bool setPlayPos(long ms);
 private:
 	void *m_pGB;
@@ -24,6 +24,9 @@ private:
 	// 0 for stop, 1 for playing, 2 for pause, -1 for not loaded files
 	int m_playmode;
     int m_volume;
+protected:
+	s64 m_startpos;
+	s64 m_endpos;
 };
 
 class audioEngine: public audioPlayer{
@@ -35,6 +38,10 @@ public:
 	void setLoop(int iloop);
 	void decLoopcount();
 	bool isneedLoop();
+	bool setLoopStart(int sample);
+	bool setLoopEnd(int sample);
+	bool setPlaySample(int sample);
+	bool replayLoopPart();
 private:
 	int m_ID;
 	char m_filename[256];

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -17,6 +17,7 @@ public:
     bool setVolume(int volume);
     bool isEnd(long *mstimetoend = 0);
     bool setPlayPos(long ms);
+    bool getPlayPos(long *ms);
 private:
 	void *m_pGB;
 	void *m_pMC;
@@ -47,6 +48,7 @@ private:
 	int m_ID;
 	char m_filename[256];
 	int m_iloop;
+	s64 m_stopPosforAudio;
 public:
 	int m_lenstoplay;
 };

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -31,7 +31,7 @@ protected:
 
 class audioEngine: public audioPlayer{
 public:
-	audioEngine(void):audioPlayer(), m_ID(-1){}
+	audioEngine(void):audioPlayer(), m_ID(-1), m_lenstoplay(0){}
 	~audioEngine(void){ closeStream();}
 	bool loadRIFFStream(u8* stream, int streamsize, int atracID);
 	bool closeStream();
@@ -42,10 +42,13 @@ public:
 	bool setLoopEnd(int sample);
 	bool setPlaySample(int sample);
 	bool replayLoopPart();
+	bool play();
 private:
 	int m_ID;
 	char m_filename[256];
 	int m_iloop;
+public:
+	int m_lenstoplay;
 };
 
 void addAtrac3Audio(u8* stream, int streamsize, int atracID);

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -58,6 +58,7 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 	                        u8* buffer, int atracID, void* pgd_info = 0);
 audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
+void initaudioEngine();
 void shutdownEngine();
 void stopAllAtrac3Audio();
 

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -43,7 +43,7 @@ private:
 
 void addAtrac3Audio(u8* stream, int streamsize, int atracID);
 bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize, 
-	                        u8* buffer, int atracID);
+	                        u8* buffer, int atracID, void* pgd_info = 0);
 audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
 void shutdownEngine();

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -58,6 +58,10 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 	                        u8* buffer, int atracID, void* pgd_info = 0);
 audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
+
+int generateAudioFilename(u8* buf, char* outfilename);
+bool checkAudioFileExist(u8* buf, char* outfilename = 0);
+
 void initaudioEngine();
 void shutdownEngine();
 void stopAllAtrac3Audio();

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _WIN32
+#ifdef _USE_DSHOW_
 
 #include "../../Globals.h"
 
@@ -47,4 +47,4 @@ audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
 void shutdownEngine();
 
-#endif // _WIN32
+#endif // _USE_DSHOW_

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include "../../Globals.h"
+
+class audioPlayer
+{
+public:
+	audioPlayer(void);
+	~audioPlayer(void);
+	bool load(const char* filename);
+	bool play();
+	bool stop();
+	bool closeMedia();
+    bool setVolume(int volume);
+    bool isEnd();
+    bool setPlayPos(long ms);
+private:
+	void *m_pGB;
+	void *m_pMC;
+	void *m_pMS;
+	// 0 for stop, 1 for playing
+	int m_playmode;
+    int m_volume;
+};
+
+class audioEngine: public audioPlayer{
+public:
+	audioEngine(void):audioPlayer(), m_ID(-1){}
+	~audioEngine(void){ closeStream();}
+	bool loadRIFFStream(u8* stream, int streamsize, int atracID);
+	bool closeStream();
+private:
+	int m_ID;
+	char m_filename[256];
+};
+
+void addAtrac3Audio(u8* stream, int streamsize, int atracID);
+audioEngine* getaudioEngineByID(int atracID);
+void deleteAtrac3Audio(int atracID);
+void shutdownEngine();
+
+#endif // _WIN32

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -41,6 +41,8 @@ private:
 };
 
 void addAtrac3Audio(u8* stream, int streamsize, int atracID);
+bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize, 
+	                        u8* buffer, int atracID);
 audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
 void shutdownEngine();

--- a/Core/HW/audioPlayer.h
+++ b/Core/HW/audioPlayer.h
@@ -11,6 +11,7 @@ public:
 	~audioPlayer(void);
 	bool load(const char* filename);
 	bool play();
+	bool pause();
 	bool stop();
 	bool closeMedia();
     bool setVolume(int volume);
@@ -20,7 +21,7 @@ private:
 	void *m_pGB;
 	void *m_pMC;
 	void *m_pMS;
-	// 0 for stop, 1 for playing
+	// 0 for stop, 1 for playing, 2 for pause, -1 for not loaded files
 	int m_playmode;
     int m_volume;
 };
@@ -46,5 +47,6 @@ bool addAtrac3AudioByPackage(const char* package, u32 startpos, int audiosize,
 audioEngine* getaudioEngineByID(int atracID);
 void deleteAtrac3Audio(int atracID);
 void shutdownEngine();
+void stopAllAtrac3Audio();
 
 #endif // _USE_DSHOW_

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -496,7 +496,7 @@ mediaPlayer* getPMFPlayer()
 	return &g_pmfPlayer;
 }
 
-UINT loopPlaying(void * lpvoid)
+u32 loopPlaying(void * lpvoid)
 {
 	int count = 0;
 	long counttime = clock();
@@ -526,7 +526,10 @@ UINT loopPlaying(void * lpvoid)
 				return 0;
 			}
 			movieInfo.iPlayVideo--;
+			g_FramebufferMoviePlaying = true;
 		}
+		else
+			g_FramebufferMoviePlaying = false;
 		clock_t endtime = clock();
 		// keep the movie frames 30FPS
 		count = (count + 1) % 30;

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -625,7 +625,7 @@ bool writePMFVideoImage(u8* buffer, int frameWidth, int videoPixelMode)
 	}
 	if (buffer)
 	{
-		memcpy(buffer, g_MoviePlayingbuf, frameWidth * 272 * modeBpp[videoPixelMode]);
+		memcpy(buffer, g_MoviePlayingbuf, frameWidth * g_pmfPlayer.getDesHeight() * modeBpp[videoPixelMode]);
 	}
 	return true;
 }

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -534,7 +534,7 @@ UINT loopPlaying(void * lpvoid)
 		{
 			long curtime = clock();
 			long reftime = 1000 - (curtime - counttime) * 1000 / CLOCKS_PER_SEC;
-			if (reftime) {
+			if (reftime > 0) {
 				Common::SleepCurrentThread(reftime);
 			}
 			counttime += CLOCKS_PER_SEC;

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -467,7 +467,9 @@ bool loadPMFPSFFile(const char *filename, int mpegsize)
 	return bResult;
 }
 
-bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer)
+extern u32 npdrmRead(void* pgd_info, u32 handle, u8 *data, int size);
+
+bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer, void* pgd_info)
 {
 	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
 	if (h == 0) 
@@ -475,10 +477,18 @@ bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buf
 	int filesize = mpegsize;
 	u8* buf = new u8[filesize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
-	if (strlen(package) >= 10)
-		filesize = pspFileSystem.ReadFile(h, buf, filesize);
-	else
-		pspFileSystem.ReadFile(h, buf, filesize / 2048);
+	if (strlen(package) >= 10) {
+		if (pgd_info)
+			filesize = npdrmRead(pgd_info, h, buf, filesize);
+		else
+			filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	}
+	else {
+		if (pgd_info)
+			npdrmRead(pgd_info, h, buf, filesize / 2048);
+		else
+			pspFileSystem.ReadFile(h, buf, filesize / 2048);
+	}
 	pspFileSystem.CloseFile(h);
 
 	bool bResult;

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -144,35 +144,6 @@ bool mediaPlayer::load(const char* filename)
 	AVDictionary *optionsDict = 0;
 	if(avcodec_open2(pCodecCtx, pCodec, &optionsDict)<0)
 		return false; // Could not open codec
-  
-	// Allocate video frame
-	m_pFrame = avcodec_alloc_frame();
-
-	// make the image size the same as PSP window
-	int desWidth = 480;
-	int desHeight = 272;
-	m_sws_ctx = (void*)
-    sws_getContext
-    (
-        pCodecCtx->width,
-        pCodecCtx->height,
-        pCodecCtx->pix_fmt,
-        desWidth,
-        desHeight,
-        PIX_FMT_RGB24,
-        SWS_BILINEAR,
-        NULL,
-        NULL,
-        NULL
-    );
-
-	// Allocate video frame for RGB24
-	m_pFrameRGB = avcodec_alloc_frame();
-	int numBytes = avpicture_get_size(PIX_FMT_RGB24, desWidth, desHeight);  
-    m_buffer = (u8 *)av_malloc(numBytes*sizeof(uint8_t));
-  
-    // Assign appropriate parts of buffer to image planes in pFrameRGB   
-    avpicture_fill((AVPicture *)m_pFrameRGB, m_buffer, PIX_FMT_RGB24, desWidth, desHeight);  
 
 	return true;
 }

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -269,6 +269,8 @@ bool mediaPlayer::closeMedia()
 		av_free(m_pFrameRGB);
 	if (m_pFrame)
 		av_free(m_pFrame);
+	if (m_pIOContext && ((AVIOContext*)m_pIOContext)->buffer)
+		av_free(((AVIOContext*)m_pIOContext)->buffer);
 	if (m_pIOContext)
 		av_free(m_pIOContext);
 	if (m_pCodecCtx)
@@ -402,7 +404,8 @@ bool loadPMFaudioStream(u8* audioStream, int audioSize)
 bool loadPMFStream(u8* pmf, int pmfsize)
 {
 #ifdef _USE_DSHOW_
-	MpegDemux *demux = new MpegDemux(pmf, pmfsize, 0);
+	int mpegoffset = bswap32(*(int*)(pmf + 8));
+	MpegDemux *demux = new MpegDemux(pmf, pmfsize, mpegoffset);
 	demux->demux(-1);
 	u8 *audioStream;
 	int audioSize = demux->getaudioStream(&audioStream);

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -407,15 +407,16 @@ bool loadPMFPSFFile(const char *filename, int mpegsize)
 
 bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer)
 {
-	if (strlen(package) < 10)
-		return false;
 	u32 h = pspFileSystem.OpenFile(package, (FileAccess) FILEACCESS_READ);
 	if (h == 0) 
 		return false;
 	int filesize = mpegsize + 0x2000;
 	u8* buf = new u8[filesize];
 	pspFileSystem.SeekFile(h, startpos, FILEMOVE_BEGIN);
-	filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	if (strlen(package) >= 10)
+		filesize = pspFileSystem.ReadFile(h, buf, filesize);
+	else
+		pspFileSystem.ReadFile(h, buf, filesize / 2048);
 	pspFileSystem.CloseFile(h);
 
 	bool bResult;

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -262,10 +262,12 @@ bool loadPMFStream(u8* pmf, int pmfsize)
 	return bResult;
 }
 
-bool loadPMFPSFFile(const char *filename)
+bool loadPMFPSFFile(const char *filename, int mpegsize)
 {
 	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
 	s64 infosize = info.size;
+	if ((mpegsize >= 0) && (abs(((int)infosize) - mpegsize) > 0x2000))
+		return false;
 	u8* buf = new u8[infosize];
 	u32 h = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
 	pspFileSystem.ReadFile(h, buf, infosize);

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -330,7 +330,7 @@ bool mediaPlayer::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 							*(imgbuf++) = b;
 							*(imgbuf++) = 0xFF;
 						}
-						imgbuf += (frameWidth - width)*4;
+						imgbuf += (frameWidth - width) * 4;
 					}
 				}
 				else
@@ -344,7 +344,7 @@ bool mediaPlayer::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 							getPixelColor(r, g, b, 0xFF, videoPixelMode, (u16*)imgbuf);
 							imgbuf += 2;
 						}
-						imgbuf += (frameWidth - width)*2;
+						imgbuf += (frameWidth - width) * 2;
 					}
 				} 
 				bGetFrame = true;
@@ -579,7 +579,7 @@ bool playPMFVideo(u8* buffer, int frameWidth, int videoPixelMode)
 			// use the orginal video size
 			g_pmfPlayer.setVideoSize(0, 0);
 		}
-		movieInfo.frameWidth = frameWidth;
+		movieInfo.frameWidth = std::max(frameWidth, g_pmfPlayer.getDesWidth());
 		movieInfo.videoPixelMode = videoPixelMode;
 
 #ifdef _USE_DSHOW_
@@ -612,12 +612,12 @@ bool writePMFVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode,
 	if (buffer)
 	{
 		int bpp = modeBpp[videoPixelMode];
-		u8* data = g_MoviePlayingbuf + (ypos * frameWidth + xpos) * bpp;
+		u8* data = g_MoviePlayingbuf + (ypos * movieInfo.frameWidth + xpos) * bpp;
 		u8* imgbuf = buffer;
 		for (int y = 0; y < height; y++){
 			memcpy(imgbuf, data, width * bpp);
 			imgbuf += frameWidth * bpp;
-			data += frameWidth * bpp;
+			data += movieInfo.frameWidth * bpp;
 		}
 	}
 	return true;

--- a/Core/HW/mediaPlayer.cpp
+++ b/Core/HW/mediaPlayer.cpp
@@ -1,0 +1,341 @@
+#ifdef _WIN32
+
+#include "mediaPlayer.h"
+#include "OMAConvert.h"
+#include "MpegDemux.h"
+#include "audioPlayer.h"
+
+#include "../../GPU/GLES/Framebuffer.h"
+#include "../Core/System.h"
+
+#include <Windows.h>
+#include <process.h>
+
+extern "C" {
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+
+}
+
+// use the ffmpeg lib
+//#pragma comment(lib, "avcodec.lib")
+//#pragma comment(lib, "avformat.lib")
+//#pragma comment(lib, "swscale.lib")
+//#pragma comment(lib, "avutil.lib")
+
+inline void YUV444toRGB888(u8 ypos, u8 upos, u8 vpos, u8 &r, u8 &g, u8 &b)
+{
+	u8 u = upos - 128;
+	u8 v = vpos -128;
+	int rdif = v + ((v * 103) >> 8);
+	int invgdif = ((u * 88) >> 8) + ((v * 183) >> 8);
+	int bdif = u + ((u * 198) >> 8);
+
+	r = (u8)(ypos + rdif);
+	g = (u8)(ypos - invgdif);
+	b = (u8)(ypos + bdif);
+}
+
+mediaPlayer::mediaPlayer(void)
+{
+	m_pFormatCtx = 0;
+	m_pCodecCtx = 0;
+	m_pFrame = 0;
+	m_pFrameRGB = 0;
+	m_videoStream = -1;
+	m_buffer = 0;
+	if (!g_FramebufferMoviePlayingbuf)
+		g_FramebufferMoviePlayingbuf = new u8[g_FramebufferMoviePlayinglinesize*280*4];
+}
+
+
+mediaPlayer::~mediaPlayer(void)
+{
+	closeMedia();
+	if (g_FramebufferMoviePlayingbuf)
+		delete [] g_FramebufferMoviePlayingbuf;
+	g_FramebufferMoviePlayingbuf = 0;
+}
+
+bool mediaPlayer::load(const char* filename)
+{
+	// Register all formats and codecs
+	av_register_all();
+
+	// Open video file
+	if(avformat_open_input((AVFormatContext**)&m_pFormatCtx, filename, NULL, NULL) != 0)
+		return false;
+
+	AVFormatContext *pFormatCtx = (AVFormatContext*)m_pFormatCtx;
+	if(avformat_find_stream_info(pFormatCtx, NULL) < 0)
+		return false;
+
+	// Find the first video stream
+	for(int i = 0; i < pFormatCtx->nb_streams; i++) {
+		if(pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
+			m_videoStream = i;
+			break;
+		}
+	}
+	if(m_videoStream == -1)
+		return false;
+
+	// Get a pointer to the codec context for the video stream
+	m_pCodecCtx = (void*)pFormatCtx->streams[m_videoStream]->codec;
+	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
+  
+	// Find the decoder for the video stream
+	AVCodec *pCodec = avcodec_find_decoder(pCodecCtx->codec_id);
+	if(pCodec == NULL)
+		return false;
+  
+	// Open codec
+	AVDictionary *optionsDict = 0;
+	if(avcodec_open2(pCodecCtx, pCodec, &optionsDict)<0)
+		return false; // Could not open codec
+  
+	// Allocate video frame
+	m_pFrame = avcodec_alloc_frame();
+
+	m_sws_ctx = (void*)
+    sws_getContext
+    (
+        pCodecCtx->width,
+        pCodecCtx->height,
+        pCodecCtx->pix_fmt,
+        pCodecCtx->width,
+        pCodecCtx->height,
+        PIX_FMT_RGB24,
+        SWS_BILINEAR,
+        NULL,
+        NULL,
+        NULL
+    );
+
+	// Allocate video frame for RGB24
+	m_pFrameRGB = avcodec_alloc_frame();
+	int numBytes = avpicture_get_size(PIX_FMT_RGB24, pCodecCtx->width, pCodecCtx->height);  
+    m_buffer = (u8 *)av_malloc(numBytes*sizeof(uint8_t));
+  
+    // Assign appropriate parts of buffer to image planes in pFrameRGB   
+    avpicture_fill((AVPicture *)m_pFrameRGB, m_buffer, PIX_FMT_RGB24, pCodecCtx->width, pCodecCtx->height);  
+
+	return true;
+}
+
+bool mediaPlayer::closeMedia()
+{
+	if (m_buffer)
+		av_free(m_buffer);
+	if (m_pFrameRGB)
+		av_free(m_pFrameRGB);
+	if (m_pFrame)
+		av_free(m_pFrame);
+	if (m_pCodecCtx)
+		avcodec_close((AVCodecContext*)m_pCodecCtx);
+	if (m_pFormatCtx)
+		avformat_close_input((AVFormatContext**)&m_pFormatCtx);
+	m_buffer = 0;
+	m_pFrame = 0;
+	m_pFrameRGB = 0;
+	m_pCodecCtx = 0;
+	m_pFormatCtx = 0;
+	m_videoStream = -1;
+	return true;
+}
+
+bool mediaPlayer::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode)
+{
+	AVFormatContext *pFormatCtx = (AVFormatContext*)m_pFormatCtx;
+	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
+	AVFrame *pFrame = (AVFrame*)m_pFrame;
+	AVFrame *pFrameRGB = (AVFrame*)m_pFrameRGB;
+	if ((!m_pFrame)||(!m_pFrameRGB))
+		return false;
+	AVPacket packet;
+	int frameFinished;
+	bool bGetFrame = false;
+	while(av_read_frame(pFormatCtx, &packet)>=0) {
+		if(packet.stream_index == m_videoStream) {
+			// Decode video frame
+			avcodec_decode_video2(pCodecCtx, pFrame, &frameFinished, &packet);
+      
+			if(frameFinished) {
+				sws_scale((SwsContext*)m_sws_ctx, pFrame->data, pFrame->linesize, 0, 
+					pCodecCtx->height, pFrameRGB->data, pFrameRGB->linesize);
+				int height = pCodecCtx->height;
+				int width = pCodecCtx->width;
+				u8* imgbuf = buffer;
+				u8* data = pFrameRGB->data[0];
+				if (videoPixelMode == 3)
+				{
+					// RGBA8888
+					for (int y = 0; y < height; y++) {
+						for (int x = 0; x < width; x++)
+						{
+							u8 r = *(data++);
+							u8 g = *(data++);
+							u8 b = *(data++);
+							*(imgbuf++) = r;
+							*(imgbuf++) = g;
+							*(imgbuf++) = b;
+							*(imgbuf++) = 0xFF;
+						}
+						imgbuf += (frameWidth - width)*4;
+					}
+				}
+				else
+				{
+					for (int y = 0; y < height; y++) {
+						for (int x = 0; x < width; x++)
+						{
+							*(imgbuf++) = 0xFF;
+							*(imgbuf++) = 0xFF;
+						}
+						imgbuf += (frameWidth - width)*2;
+					}
+				} 
+				bGetFrame = true;
+			}
+		}
+		av_free_packet(&packet);
+		if (bGetFrame) break;
+	}
+	return bGetFrame;
+}
+
+static bool bFirst = true;
+static volatile bool bPlaying = false;
+static volatile bool bStop = true;
+static mediaPlayer g_pmfPlayer;
+static audioPlayer *g_pmfaudioPlayer = 0;
+
+bool loadPMFaudioStream(u8* audioStream, int audioSize)
+{
+	u8 *oma = 0;
+	int omasize = OMAConvert::convertStreamtoOMA(audioStream, audioSize, &oma);
+	if (omasize <= 0)
+		return false;
+
+	FILE *wfp = fopen("tmp\\movie.oma", "wb");
+	fwrite(oma, 1, omasize, wfp);
+	fclose(wfp);
+
+	OMAConvert::releaseStream(&oma);
+
+	g_pmfaudioPlayer = new audioPlayer;
+	bool bResult = g_pmfaudioPlayer->load("tmp\\movie.oma");
+	if (!bResult)
+		g_pmfaudioPlayer->closeMedia();
+	return bResult;
+}
+
+bool loadPMFStream(u8* pmf, int pmfsize)
+{
+	if (bFirst)
+	{
+		CreateDirectory("tmp", NULL);
+		bFirst = false;
+	}
+	FILE *wfp = fopen("tmp\\movie.pmf", "wb");
+	fwrite(pmf, 1, pmfsize, wfp);
+	fclose(wfp);
+
+	MpegDemux *demux = new MpegDemux(pmf, pmfsize, 0);
+	demux->demux(-1);
+	u8 *audioStream;
+	int audioSize = demux->getaudioStream(&audioStream);
+	if (audioSize > 0)
+	{
+		loadPMFaudioStream(audioStream, audioSize);
+	}
+	delete demux;
+
+	bool bResult = g_pmfPlayer.load("tmp\\movie.pmf");
+	if (!bResult)
+		g_pmfPlayer.closeMedia();
+	else
+		g_FramebufferMoviePlaying = true;
+	bStop = false;
+	return bResult;
+}
+
+bool loadPMFPSFFile(const char *filename)
+{
+	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
+	s64 infosize = info.size;
+	u8* buf = new u8[infosize];
+	u32 h = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
+	pspFileSystem.ReadFile(h, buf, infosize);
+	pspFileSystem.CloseFile(h);
+
+	bool bResult = loadPMFStream(buf, infosize);
+	delete [] buf;
+
+	return bResult;
+}
+
+bool deletePMFStream()
+{
+	if (!bPlaying)
+		return true;
+	bStop = true;
+	bPlaying = false;
+	g_FramebufferMoviePlaying = false;
+
+	if (g_pmfaudioPlayer) delete g_pmfaudioPlayer;
+	g_pmfaudioPlayer = 0;
+	g_pmfPlayer.closeMedia();
+
+	DeleteFileA("tmp\\movie.pmf");
+	DeleteFileA("tmp\\movie.oma");
+	return true;
+}
+
+mediaPlayer* getPMFPlayer()
+{
+	return &g_pmfPlayer;
+}
+
+UINT WINAPI loopPlaying(LPVOID lpvoid)
+{
+	if (g_pmfaudioPlayer) 
+		g_pmfaudioPlayer->play();
+
+	while (bPlaying)
+	{
+		clock_t starttime = clock();
+		if (!g_pmfPlayer.writeVideoImage(g_FramebufferMoviePlayingbuf, 
+			g_FramebufferMoviePlayinglinesize, 3))
+		{
+			bStop = true;
+			return 0;
+		}
+		clock_t endtime = clock();
+		// keep the movie frames 30FPS
+		long idletime = 33 - (endtime - starttime) * 1000 / CLOCKS_PER_SEC;
+		if (idletime > 0)
+			Sleep(idletime);
+	}
+
+	return 0;
+}
+
+bool playPMFVideo()
+{
+	if (bStop)
+		return false;
+	if (!bPlaying)
+	{
+		bPlaying = true;
+		UINT uiThread;
+		HANDLE hThread=(HANDLE)::_beginthreadex(NULL, 0, loopPlaying,
+			                                   0, 0, &uiThread);
+		CloseHandle(hThread);
+	}
+	return true;
+}
+
+#endif // _WIN32

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -24,6 +24,7 @@ private:
 
 bool loadPMFStream(u8* pmf, int pmfsize);
 bool loadPMFPSFFile(const char *filename, int mpegsize = -1);
+bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer);
 bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
 bool playPMFVideo();

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -23,7 +23,6 @@ private:
     void *m_sws_ctx;
     u8* m_buffer;
 	void *m_videobuf;
-	u8* m_tempbuf;
 };
 
 bool loadPMFStream(u8* pmf, int pmfsize);

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -14,6 +14,8 @@ public:
 	bool closeMedia();
 	bool writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode);
 	bool setVideoSize(int width = 0, int height = 0);
+	int getDesHeight() { return m_desHeight;}
+	int getDesWidth()  { return m_desWidth; }
 private:
 	void *m_pFormatCtx;
 	void *m_pCodecCtx;

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -13,6 +13,7 @@ public:
 	bool loadStream(u8* buffer, int size, bool bAutofreebuffer = true);
 	bool closeMedia();
 	bool writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode);
+	bool setVideoSize(int width = 0, int height = 0);
 private:
 	void *m_pFormatCtx;
 	void *m_pCodecCtx;
@@ -23,6 +24,8 @@ private:
     void *m_sws_ctx;
     u8* m_buffer;
 	void *m_videobuf;
+	int  m_desWidth;
+	int  m_desHeight;
 };
 
 bool loadPMFStream(u8* pmf, int pmfsize);

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 #include "../../Globals.h"
 
 class mediaPlayer
@@ -33,4 +33,4 @@ bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
 bool playPMFVideo();
 
-#endif // WIN32
+#endif // _USE_FFMPEG_

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -23,7 +23,7 @@ private:
 };
 
 bool loadPMFStream(u8* pmf, int pmfsize);
-bool loadPMFPSFFile(const char *filename);
+bool loadPMFPSFFile(const char *filename, int mpegsize = -1);
 bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
 bool playPMFVideo();

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -30,6 +30,9 @@ bool loadPMFPSFFile(const char *filename, int mpegsize = -1);
 bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer);
 bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
-bool playPMFVideo();
-
+bool playPMFVideo(u8* buffer = 0, int frameWidth = 512, int videoPixelMode = 3);
+bool writePMFVideoImage(u8* buffer = 0, int frameWidth = 512, int videoPixelMode = 3);
+bool writePMFVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
+	                             int xpos, int ypos, int width, int height);
+bool isPMFVideoEnd();
 #endif // _USE_FFMPEG_

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef _WIN32
+#include "../../Globals.h"
+
+class mediaPlayer
+{
+public:
+	mediaPlayer(void);
+	~mediaPlayer(void);
+
+	bool load(const char* filename);
+	bool closeMedia();
+	bool writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode);
+private:
+	void *m_pFormatCtx;
+	void *m_pCodecCtx;
+	void *m_pFrame;
+    void *m_pFrameRGB;
+	int  m_videoStream;
+    void *m_sws_ctx;
+    u8* m_buffer;
+};
+
+bool loadPMFStream(u8* pmf, int pmfsize);
+bool loadPMFPSFFile(const char *filename);
+bool deletePMFStream();
+mediaPlayer* getPMFPlayer();
+bool playPMFVideo();
+
+#endif

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -30,7 +30,7 @@ private:
 
 bool loadPMFStream(u8* pmf, int pmfsize);
 bool loadPMFPSFFile(const char *filename, int mpegsize = -1);
-bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer);
+bool loadPMFPackageFile(const char* package, u32 startpos, int mpegsize, u8* buffer, void* pgd_info = 0);
 bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
 bool playPMFVideo(u8* buffer = 0, int frameWidth = 512, int videoPixelMode = 3);

--- a/Core/HW/mediaPlayer.h
+++ b/Core/HW/mediaPlayer.h
@@ -10,6 +10,7 @@ public:
 	~mediaPlayer(void);
 
 	bool load(const char* filename);
+	bool loadStream(u8* buffer, int size, bool bAutofreebuffer = true);
 	bool closeMedia();
 	bool writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode);
 private:
@@ -17,9 +18,12 @@ private:
 	void *m_pCodecCtx;
 	void *m_pFrame;
     void *m_pFrameRGB;
+	void *m_pIOContext;
 	int  m_videoStream;
     void *m_sws_ctx;
     u8* m_buffer;
+	void *m_videobuf;
+	u8* m_tempbuf;
 };
 
 bool loadPMFStream(u8* pmf, int pmfsize);
@@ -29,4 +33,4 @@ bool deletePMFStream();
 mediaPlayer* getPMFPlayer();
 bool playPMFVideo();
 
-#endif
+#endif // WIN32

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -55,6 +55,9 @@ u8 *m_pKernelRAM;	// RAM mirrored up to "kernel space". Fully accessible at all 
 u8 *m_pPhysicalVRAM;
 u8 *m_pUncachedVRAM;
 
+#ifdef _WIN32
+struct LASTESTACCESSFILE lastestAccessFile;
+#endif // _WIN32
 
 // We don't declare the IO region in here since its handled by other means.
 static const MemoryView views[] =

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -55,9 +55,9 @@ u8 *m_pKernelRAM;	// RAM mirrored up to "kernel space". Fully accessible at all 
 u8 *m_pPhysicalVRAM;
 u8 *m_pUncachedVRAM;
 
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 struct LASTESTACCESSFILE lastestAccessFile;
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 
 // We don't declare the IO region in here since its handled by other means.
 static const MemoryView views[] =

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -115,6 +115,13 @@ enum
 #endif
 };
 
+#ifdef _WIN32
+extern struct LASTESTACCESSFILE{
+	char filename[256];
+	u32 data_addr;
+} lastestAccessFile;
+#endif // _WIN32
+
 // Init and Shutdown
 void Init();
 void Shutdown();

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -163,7 +163,7 @@ extern struct LASTESTACCESSFILE {
 			else 
 				idbuf[0] = 2;
 			memcpy(idbuf + 1, inbuf + 4, 4);
-			memcpy(idbuf + 5, inbuf + 0x60, 0x20 - 5);
+			memcpy(idbuf + 5, inbuf + 0xa0, 0x20 - 5);
 		}
 		else {
 			memcpy(idbuf, inbuf, 0x20);

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -117,8 +117,12 @@ enum
 
 #ifdef _WIN32
 extern struct LASTESTACCESSFILE{
+// media file
 	char filename[256];
 	u32 data_addr;
+// package file
+	char packagefile[256];
+	u32 start_pos;
 } lastestAccessFile;
 #endif // _WIN32
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -142,14 +142,32 @@ extern struct LASTESTACCESSFILE {
 	{
 		if (!buffer)
 			return 0;
+		u8 idbuf[0x20];
+		generateidbuf(buffer, idbuf);
 		for (int i = 0; i < 256; i++) {
 			int pos = (256 + cachepos - i) & 0xFF;
-			if (memcmp(buffer, cache[pos].idbuf, 0x20) == 0)
+			if (memcmp(idbuf, cache[pos].idbuf, 0x20) == 0)
 			{
 				return &cache[pos];
 			}
 		}
 		return 0;
+	}
+	void generateidbuf(u8* inbuf, u8* idbuf) {
+		if (inbuf[0] == 'R') {
+			u16 codeType = *(u16*)(inbuf + 0x14);
+			if (codeType == 0xfffe)
+				idbuf[0] = 0;
+			else if (codeType == 0x270)
+				idbuf[0] = 1;
+			else 
+				idbuf[0] = 2;
+			memcpy(idbuf + 1, inbuf + 4, 4);
+			memcpy(idbuf + 5, inbuf + 0x60, 0x20 - 5);
+		}
+		else {
+			memcpy(idbuf, inbuf, 0x20);
+		}
 	}
 } lastestAccessFile;
 #endif // _USE_FFMPEG_

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -115,7 +115,7 @@ enum
 #endif
 };
 
-#ifdef _WIN32
+#ifdef _USE_FFMPEG_
 extern struct LASTESTACCESSFILE{
 // media file
 	char filename[256];
@@ -124,7 +124,7 @@ extern struct LASTESTACCESSFILE{
 	char packagefile[256];
 	u32 start_pos;
 } lastestAccessFile;
-#endif // _WIN32
+#endif // _USE_FFMPEG_
 
 // Init and Shutdown
 void Init();

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -116,13 +116,32 @@ enum
 };
 
 #ifdef _USE_FFMPEG_
-extern struct LASTESTACCESSFILE{
+struct LASTESTFILECACHE {
+	char packagefile[256];
+	u32  start_pos;
+	u8   idbuf[0x20];
+};
+
+extern struct LASTESTACCESSFILE {
 // media file
 	char filename[256];
 	u32 data_addr;
 // package file
-	char packagefile[256];
-	u32 start_pos;
+	LASTESTFILECACHE cache[256];
+	u8  cachepos;
+	LASTESTFILECACHE* findmatchcache(u8* buffer)
+	{
+		if (!buffer)
+			return 0;
+		for (int i = 0; i < 256; i++) {
+			int pos = (256 + cachepos - i) & 0xFF;
+			if (memcmp(buffer, cache[pos].idbuf, 0x20) == 0)
+			{
+				return &cache[pos];
+			}
+		}
+		return 0;
+	}
 } lastestAccessFile;
 #endif // _USE_FFMPEG_
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -23,6 +23,12 @@
 #include "Common.h"
 #include "CommonTypes.h"
 
+#ifdef _USE_FFMPEG_
+extern "C" {
+#include "ext/libkirk/amctrl.h"
+};
+#endif // _USE_FFMPEG_
+
 // Enable memory checks in the Debug/DebugFast builds, but NOT in release
 #if defined(_DEBUG) || defined(DEBUGFAST)
 #define ENABLE_MEM_CHECK
@@ -116,10 +122,13 @@ enum
 };
 
 #ifdef _USE_FFMPEG_
+
 struct LASTESTFILECACHE {
 	char packagefile[256];
 	u32  start_pos;
 	u8   idbuf[0x20];
+	bool npdrm;
+	PGD_DESC pgd_info;
 };
 
 extern struct LASTESTACCESSFILE {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -349,6 +349,8 @@ void FramebufferManager::SetRenderFrameBuffer() {
 		vfb->format = fmt;
 		vfb->usageFlags = FB_USAGE_RENDERTARGET;
 		vfb->dirtyAfterDisplay = true;
+		int bpp = vfb->format == 3 ? 4 : 2;
+		Memory::Memset(vfb->fb_address | 0x04000000, 0, vfb->width * vfb->height * bpp);
 
 		if (g_Config.bTrueColor) {
 			vfb->colorDepth = FBO_8888;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -549,7 +549,7 @@ void FramebufferManager::BeginFrame() {
 #endif // _WIN32
 	// NOTE - this is all wrong. At the beginning of the frame is a TERRIBLE time to draw the fb.
 	if (g_Config.bDisplayFramebuffer && displayFramebufPtr_) {
-		//INFO_LOG(HLE, "Drawing the framebuffer");
+		INFO_LOG(HLE, "Drawing the framebuffer");
 		const u8 *pspframebuf = Memory::GetPointer((0x44000000) | (displayFramebufPtr_ & 0x1FFFFF));	// TODO - check
 		glstate.cullFace.disable();
 		glstate.depthTest.disable();

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -349,8 +349,6 @@ void FramebufferManager::SetRenderFrameBuffer() {
 		vfb->format = fmt;
 		vfb->usageFlags = FB_USAGE_RENDERTARGET;
 		vfb->dirtyAfterDisplay = true;
-		int bpp = vfb->format == 3 ? 4 : 2;
-		Memory::Memset(vfb->fb_address | 0x04000000, 0, vfb->width * vfb->height * bpp);
 
 		if (g_Config.bTrueColor) {
 			vfb->colorDepth = FBO_8888;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -32,11 +32,9 @@
 #include "GPU/GLES/TextureCache.h"
 #include "GPU/GLES/ShaderManager.h"
 
-#ifdef _WIN32
 bool g_FramebufferMoviePlaying = false;
 u8* g_FramebufferMoviePlayingbuf = 0;
 int g_FramebufferMoviePlayinglinesize = 512;
-#endif // _WIN32
 
 static const char tex_fs[] =
 	"#ifdef GL_ES\n"
@@ -537,7 +535,6 @@ void FramebufferManager::EndFrame() {
 
 void FramebufferManager::BeginFrame() {
 	DecimateFBOs();
-#ifdef _WIN32
 	if (g_FramebufferMoviePlaying && g_FramebufferMoviePlayingbuf) {
 		glstate.cullFace.disable();
 		glstate.depthTest.disable();
@@ -546,7 +543,6 @@ void FramebufferManager::BeginFrame() {
 		glstate.stencilTest.disable();
 		DrawPixels(g_FramebufferMoviePlayingbuf, PSP_DISPLAY_PIXEL_FORMAT_8888, g_FramebufferMoviePlayinglinesize);
 	}
-#endif // _WIN32
 	// NOTE - this is all wrong. At the beginning of the frame is a TERRIBLE time to draw the fb.
 	if (g_Config.bDisplayFramebuffer && displayFramebufPtr_) {
 		INFO_LOG(HLE, "Drawing the framebuffer");

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -216,7 +216,7 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, int pixelFormat, int lin
 	{
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	}
-	glTexSubImage2D(GL_TEXTURE_2D, 0,0,0,480,272, GL_RGBA, GL_UNSIGNED_BYTE, convBuf);
+	glTexSubImage2D(GL_TEXTURE_2D,0,0,0,480,272, GL_RGBA, GL_UNSIGNED_BYTE, convBuf);
 
 	float x, y, w, h;
 	CenterRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -137,8 +137,6 @@ private:
 	bool resized_;
 };
 
-#ifdef _WIN32
 extern bool g_FramebufferMoviePlaying;
 extern u8* g_FramebufferMoviePlayingbuf;
 extern int g_FramebufferMoviePlayinglinesize;
-#endif // _WIN32

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -136,3 +136,9 @@ private:
 
 	bool resized_;
 };
+
+#ifdef _WIN32
+extern bool g_FramebufferMoviePlaying;
+extern u8* g_FramebufferMoviePlayingbuf;
+extern int g_FramebufferMoviePlayinglinesize;
+#endif // _WIN32


### PR DESCRIPTION
I use ffmpeg for video decoding and dshow for at3+ audio. And I have tried my best not to break other platforms yet. In fact, the video part which using ffmpeg may also be possible for other platforms.
By the way, I haven't add the header file and lib for ffmpeg and dshow yet.  I'm not sure how to do this and need some helps.
