### PR TITLE
Don't rotate to portrait and fix iOS 6 compatibility

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -138,9 +138,16 @@ ViewController* sharedViewController;
 	[super dealloc];
 }
 
+// For iOS before 6.0
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
 {
-	return YES;
+	return UIInterfaceOrientationIsLandscape(toInterfaceOrientation);
+}
+
+// For iOS 6.0 and up
+- (NSUInteger)supportedInterfaceOrientations
+{
+	return UIInterfaceOrientationMaskLandscape;
 }
 
 //static BOOL menuDown = NO;


### PR DESCRIPTION
iOS 6 added [UIViewController supportedInterfaceOrientations] and deprecated [UIViewController shouldAutorotateToInterfaceOrientation:] and it's ok to do both for compatibility.

Also, the iOS UI falls partially off-screen in portrait orientation because it doesn't resize at all, so for now restrict rotation to landscape-left and landscape-right.
