### PR TITLE
Flip in throughmode for SW/HW T&L

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -238,8 +238,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 	if (g_Config.bBufferedRendering) {
 		renderX = 0;
 		renderY = 0;
-	  renderWidth = framebufferManager_->GetRenderWidth();
-	  renderHeight = framebufferManager_->GetRenderHeight();
+	  	renderWidth = framebufferManager_->GetRenderWidth();
+	  	renderHeight = framebufferManager_->GetRenderHeight();
 		renderWidthFactor = (float)renderWidth / framebufferManager_->GetTargetWidth();
 		renderHeightFactor = (float)renderHeight / framebufferManager_->GetTargetHeight();
 	} else {
@@ -261,8 +261,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 	// This is a bit of a hack as the render buffer isn't always that size
 	if (scissorX1 == 0 && scissorY1 == 0 &&
-		  scissorX2 >= gstate_c.curRTWidth - 1 &&
-			scissorY2 >= gstate_c.curRTHeight - 1) {
+		scissorX2 >= gstate_c.curRTWidth - 1 &&
+		scissorY2 >= gstate_c.curRTHeight - 1) {
 		glstate.scissorTest.disable();
 	} else {
 		glstate.scissorTest.enable();

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -640,10 +640,13 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		transformed[index].fog = fogCoef;
 		memcpy(&transformed[index].u, uv, 2 * sizeof(float));
 		if (gstate_c.flipTexture) {
-			//if (throughmode)
-			//	transformed[index].v = (float)gstate_c.actualTextureHeight / gstate_c.curTextureHeight - transformed[index].v;
-			//else
-				transformed[index].v = 1.0f - transformed[index].v; // * 2.0f;
+			if (throughmode)
+				transformed[index].v = 1.0f - transformed[index].v;
+			else 
+				transformed[index].v = 1.0f - transformed[index].v * 2.0f;
+		}
+		for (int i = 0; i < 4; i++) {
+			transformed[index].color0[i] = c0[i] * 255.0f;
 		}
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -649,9 +649,6 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			transformed[index].color0[i] = c0[i] * 255.0f;
 		}
 		for (int i = 0; i < 4; i++) {
-			transformed[index].color0[i] = c0[i] * 255.0f;
-		}
-		for (int i = 0; i < 4; i++) {
 			transformed[index].color1[i] = c1[i] * 255.0f;
 		}
 	}

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -408,7 +408,10 @@ void GenerateVertexShader(int prim, char *buffer) {
 				break;
 			}
 			if (flipV)
-				WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y * 2.0;\n");
+				if (gstate.isModeThrough())	
+					WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y;\n");
+				else
+					WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y * 2.0;\n");
 		}
 
 		// Compute fogdepth


### PR DESCRIPTION
I try the use the logic from  the following UV texturing 

```
    if (gstate.isModeThrough()) {
        // We never get here because we don't use HW transform with through mode.
        // Although - why don't we?
        uvscaleoff[0] /= gstate_c.curTextureWidth;
        uvscaleoff[1] /= gstate_c.curTextureHeight;
        uvscaleoff[2] /= gstate_c.curTextureWidth;
        uvscaleoff[3] /= gstate_c.curTextureHeight;
    } else {
        uvscaleoff[0] *= 2.0f;
        uvscaleoff[1] *= 2.0f;
    }
```
