### PR TITLE
Speed up memory access in armjit, even without fastmem

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -83,6 +83,13 @@ bool TryMakeOperand2_AllowNegation(s32 imm, Operand2 &op2, bool *negated)
 	}
 }
 
+Operand2 AssumeMakeOperand2(u32 imm) {
+	Operand2 op2;
+	bool result = TryMakeOperand2(imm, op2);
+	_dbg_assert_msg_(JIT, result, "Could not make assumed Operand2.");
+	return op2;
+}
+
 void ARMXEmitter::MOVI2F(ARMReg dest, float val, ARMReg tempReg)
 {
 	union {float f; u32 u;} conv;

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -320,6 +320,9 @@ bool TryMakeOperand2(u32 imm, Operand2 &op2);
 bool TryMakeOperand2_AllowInverse(u32 imm, Operand2 &op2, bool *inverse);
 bool TryMakeOperand2_AllowNegation(s32 imm, Operand2 &op2, bool *negated);
 
+// Use this only when you know imm can be made into an Operand2.
+Operand2 AssumeMakeOperand2(u32 imm);
+
 inline Operand2 R(ARMReg Reg)	{ return Operand2(Reg, TYPE_REG); }
 inline Operand2 IMM(u32 Imm)	{ return Operand2(Imm, TYPE_IMM); }
 inline Operand2 Mem(void *ptr)	{ return Operand2((u32)ptr, TYPE_IMM); }

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -90,33 +90,33 @@ namespace MIPSComp
 		SetR0ToEffectiveAddress(rs, offset);
 
 		// There are three valid ranges.  Each one gets a bit.
-		MOVI2R(tempReg, 7);
+		const u32 BIT_SCRATCH = 1, BIT_RAM = 2, BIT_VRAM = 4;
+		MOVI2R(tempReg, BIT_SCRATCH | BIT_RAM | BIT_VRAM);
 
 		CMP(R0, AssumeMakeOperand2(PSP_GetScratchpadMemoryBase()));
 		SetCC(CC_LO);
-		BIC(tempReg, tempReg, 1);
+		BIC(tempReg, tempReg, BIT_SCRATCH);
 		SetCC(CC_HS);
 		CMP(R0, AssumeMakeOperand2(PSP_GetScratchpadMemoryEnd()));
-		BIC(tempReg, tempReg, 1);
-		SetCC(CC_AL);
+		BIC(tempReg, tempReg, BIT_SCRATCH);
 
+		// If it was in that range, later compares don't matter.
 		CMP(R0, AssumeMakeOperand2(PSP_GetKernelMemoryBase()));
 		SetCC(CC_LO);
-		BIC(tempReg, tempReg, 2);
+		BIC(tempReg, tempReg, BIT_RAM);
 		SetCC(CC_HS);
 		CMP(R0, AssumeMakeOperand2(PSP_GetUserMemoryEnd()));
-		BIC(tempReg, tempReg, 2);
-		SetCC(CC_AL);
+		BIC(tempReg, tempReg, BIT_RAM);
 
 		CMP(R0, AssumeMakeOperand2(PSP_GetVidMemBase()));
 		SetCC(CC_LO);
-		BIC(tempReg, tempReg, 2);
+		BIC(tempReg, tempReg, BIT_VRAM);
 		SetCC(CC_HS);
 		CMP(R0, AssumeMakeOperand2(PSP_GetVidMemEnd()));
-		BIC(tempReg, tempReg, 2);
-		SetCC(CC_AL);
+		BIC(tempReg, tempReg, BIT_VRAM);
 
 		// If we left any bit set, the address is OK.
+		SetCC(CC_AL);
 		CMP(tempReg, 0);
 		SetCC(CC_GT);
 	}

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -173,8 +173,6 @@ namespace MIPSComp
 			}
 			if (doCheck) {
 				if (load) {
-					// Loads/stores affect flags, so we have to check again.
-					CMP(R1, 0);
 					SetCC(CC_EQ);
 					MOVI2R(gpr.R(rt), 0);
 				}

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -249,6 +249,7 @@ private:
 
 	// Utils
 	void SetR0ToEffectiveAddress(int rs, s16 offset);
+	void SetCCAndR0ForSafeAddress(int rs, s16 offset, ARMReg tempReg);
 
 	ArmJitBlockCache blocks;
 	ArmJitOptions jo;

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -69,6 +69,7 @@ inline u32 PSP_GetUserMemoryEnd()  { return 0x0A000000;}
 inline u32 PSP_GetDefaultLoadAddress() { return 0x08804000;}
 //inline u32 PSP_GetDefaultLoadAddress() { return 0x0898dab0;}
 inline u32 PSP_GetVidMemBase() { return 0x04000000;}
+inline u32 PSP_GetVidMemEnd() { return 0x04800000;}
 
 namespace Memory
 {


### PR DESCRIPTION
I tried the same concept as JitSafeMem, but it got ugly (and didn't want to write my own thunks.)  So I decided to try another route: this.  There's no branching, and it seems quite fast to me.  Definitely faster than before, anyway.

Since it's doing the wraparound, this should catch all cases.  At least, it passes tests and runs the games I tested okay.

-[Unknown]
