### PR TITLE
Small perf improvements from iOS testing

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -420,9 +420,12 @@ inline void updateSyscallStats(int modulenum, int funcnum, double total)
 
 void CallSyscall(u32 op)
 {
+	double start;
 	if (g_Config.bShowDebugStats)
+	{
 		time_update();
-	double start = time_now_d();
+		start = time_now_d();
+	}
 	u32 callno = (op >> 6) & 0xFFFFF; //20 bits
 	int funcnum = callno & 0xFFF;
 	int modulenum = (callno & 0xFF000) >> 12;

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -383,10 +383,23 @@ public:
 		}
 	}
 
+	// ONLY use this when you know the handle is valid.
+	template <class T>
+	T *GetFast(SceUID handle)
+	{
+		const SceUID realHandle = handle - handleOffset;
+		if (realHandle < 0 || realHandle >= maxCount || !occupied[realHandle])
+		{
+			ERROR_LOG(HLE, "Kernel: Bad fast object handle %i (%08x)", handle, handle);
+			return 0;
+		}
+		return static_cast<T *>(pool[realHandle]);
+	}
+
 	template <class T>
 	T* GetByModuleByEntryAddr(u32 entryAddr)
 	{
-		for (int i=0; i <4096; i++)
+		for (int i = 0; i < maxCount; ++i)
 		{
 			T* t = dynamic_cast<T*>(pool[i]);
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -595,12 +595,9 @@ void MipsCall::setReturnValue(u64 value)
 	savedV1 = (value >> 32) & 0xFFFFFFFF;
 }
 
-// TODO: Should move to this wrapper so we can keep the current thread as a SceUID instead
-// of a dangerous raw pointer.
 Thread *__GetCurrentThread() {
-	u32 error;
 	if (currentThread != 0)
-		return kernelObjects.Get<Thread>(currentThread, error);
+		return kernelObjects.GetFast<Thread>(currentThread);
 	else
 		return NULL;
 }
@@ -784,9 +781,8 @@ bool __KernelSwitchOffThread(const char *reason)
 		if (current && current->isRunning())
 			__KernelChangeReadyState(current, threadID, true);
 
-		u32 error;
 		// Idle 0 chosen entirely arbitrarily.
-		Thread *t = kernelObjects.Get<Thread>(threadIdleID[0], error);
+		Thread *t = kernelObjects.GetFast<Thread>(threadIdleID[0]);
 		if (t)
 		{
 			__KernelSwitchContext(t, reason);
@@ -1275,9 +1271,9 @@ Thread *__KernelNextThread() {
 		}
 	}
 
-	u32 error;
+	// Assume threadReadyQueue has not become corrupt.
 	if (bestThread != -1)
-		return kernelObjects.Get<Thread>(bestThread, error);
+		return kernelObjects.GetFast<Thread>(bestThread);
 	else
 		return 0;
 }


### PR DESCRIPTION
A few performance improvements from profiling on iOS.

The biggest is avoiding some dynamic_casts.  It should be safe with `currentThread` and `threadReadyQueue`, and if not I think we would break horribly anyway already... saves at least a few percentage points.

-[Unknown]
