### PR TITLE
Enable iTunes File sharing

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -49,5 +49,7 @@
 	</array>
 	<key>UILaunchImageFile</key>
 	<string>assets/Default.png</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Useful if you are not jailbroken and instal through testflight or iTunes
