### PR TITLE
Add delays in some timing funcs that games tightloop

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -345,10 +345,15 @@ u64 hleDelayResult(u64 result, const char *reason, int usec)
 	return result;
 }
 
-void hleEatMicro(int usec)
+void hleEatCycles(int cycles)
 {
 	// Maybe this should Idle, at least for larger delays?  Could that cause issues?
-	currentMIPS->downcount -= (int) usToCycles(usec);
+	currentMIPS->downcount -= cycles;
+}
+
+void hleEatMicro(int usec)
+{
+	hleEatCycles((int) usToCycles(usec));
 }
 
 inline void hleFinishSyscall(int modulenum, int funcnum)

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -90,6 +90,7 @@ void hleDebugBreak();
 // Delays the result for usec microseconds, allowing other threads to run during this time.
 u32 hleDelayResult(u32 result, const char *reason, int usec);
 u64 hleDelayResult(u64 result, const char *reason, int usec);
+void hleEatCycles(int cycles);
 void hleEatMicro(int usec);
 
 inline int hleDelayResult(int result, const char *reason, int usec)

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -543,7 +543,7 @@ u32 sceDisplayWaitVblank() {
 		return 0;
 	} else {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblank() - not waiting since in vBlank");
-		hleEatMicro(5);
+		hleEatCycles(5 * 222);
 		return 1;
 	}
 }
@@ -563,7 +563,7 @@ u32 sceDisplayWaitVblankCB() {
 		return 0;
 	} else {
 		DEBUG_LOG(HLE,"sceDisplayWaitVblank() - not waiting since in vBlank");
-		hleEatMicro(5);
+		hleEatCycles(5 * 222);
 		return 1;
 	}
 }
@@ -585,7 +585,7 @@ u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
 u32 sceDisplayGetVcount() {
 	VERBOSE_LOG(HLE,"%i=sceDisplayGetVcount()", vCount);
 
-	hleEatMicro(2);
+	hleEatCycles(2 * 222);
 	return vCount;
 }
 

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -64,6 +64,7 @@ int sceKernelGetSystemTime(u32 sysclockPtr)
 	u64 t = CoreTiming::GetTicks() / CoreTiming::GetClockFrequencyMHz();
 	Memory::Write_U64(t, sysclockPtr);
 	DEBUG_LOG(HLE, "sceKernelGetSystemTime(out:%16llx)", t);
+	hleEatCycles(2 * 222);
 	return 0;
 }
 
@@ -107,6 +108,7 @@ int sceKernelSysClock2USec(u32 sysclockPtr, u32 highPtr, u32 lowPtr)
 		Memory::Write_U32(highResult, highPtr);
 	if (Memory::IsValidAddress(lowPtr))
 		Memory::Write_U32(lowResult, lowPtr);
+	hleEatCycles(2 * 222);
 	return 0;
 }
 


### PR DESCRIPTION
Greatly improves performance in Legend of Heroes 1, which calls `sceKernelGetSystemTime()` and `sceKernelSysClock2USec()` over and over again.  Intro went from ~7 fps to ~60, but in game is only ~25 fps now (and still spending 5% time in these funcs.)  Dunno what it was before because I didn't have the patience to find out.

I'm not sure this timing is right, but it's hard to get accurate, and it can't be that far off I think.

May help other games that spin these funcs.

-[Unknown]
