### PR TITLE
Improve thread switching performance

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1754,20 +1754,21 @@ int sceKernelRotateThreadReadyQueue(int priority)
 	if (priority <= 0x07 || priority > 0x77)
 		return SCE_KERNEL_ERROR_ILLEGAL_PRIORITY;
 
-	if (!threadReadyQueue[priority].empty())
+	auto &queue = threadReadyQueue[priority];
+	if (!queue.empty())
 	{
 		// In other words, yield to everyone else.
 		if (cur->nt.currentPriority == priority)
 		{
-			threadReadyQueue[priority].push_back(currentThread);
+			queue.push_back(currentThread);
 			cur->nt.status = THREADSTATUS_READY;
 		}
 		// Yield the next thread of this priority to all other threads of same priority.
 		else if (threadReadyQueue[priority].size() > 1)
 		{
 			SceUID first = threadReadyQueue[priority].front();
-			threadReadyQueue[priority].pop_front();
-			threadReadyQueue[priority].push_back(first);
+			queue.pop_front();
+			queue.push_back(first);
 		}
 
 		hleReSchedule("rotatethreadreadyqueue");


### PR DESCRIPTION
This improves by a few percentage points, but it'll definitely depend on the game.

This bubbles up `threadReadyQueue[priority]` being the next issue with thread switching.  I tried creating a vector (which was slower due to iteration), and then a sparse vector (with a priority field and binary search), but it wasn't really a clear win. (https://github.com/unknownbrackets/ppsspp/commits/readyqueue-perf)

Anyway, it's better already this way.  Threads often push_front() so making that faster matters.

-[Unknown]
