### PR TITLE
Finish implementing savestates for fonts

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -84,7 +84,7 @@ class PointerWrap
 		static void DoArray(PointerWrap *p, T *x, int count)
 		{
 			for (int i = 0; i < count; ++i)
-				p->DoClass(x[i]);
+				p->Do(x[i]);
 		}
 
 		static void Do(PointerWrap *p, T &x)

--- a/Core/Font/PGF.h
+++ b/Core/Font/PGF.h
@@ -91,8 +91,7 @@ struct PGFFontStyle {
 };
 
 
-class Glyph {
-public:
+struct Glyph {
 	int x;
 	int y;
 	int w;
@@ -275,10 +274,6 @@ private:
 	// Unused
 	std::vector<int> charmapCompressionTable1[2];
 	std::vector<int> charmapCompressionTable2[2];
-
-	u8 *charMap;
-	u8 *shadowCharMap;
-	u8 *charPointerTable;
 
 	std::vector<int> charmap_compr;
 	std::vector<int> charmap;

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -183,7 +183,7 @@ private:
 class LoadedFont {
 public:
 	// For savestates only.
-	LoadedFont() {
+	LoadedFont() : font_(NULL) {
 	}
 
 	LoadedFont(Font *font, u32 fontLibID, u32 handle)


### PR DESCRIPTION
Oops, missed this before.  Was crashing FF3 and games using custom fonts.

I assume these one-shot pointer arrays don't need to be member variables...

-[Unknown]
