### PR TITLE
Handle fragmented atrac IDs better.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -74,19 +74,20 @@ struct Atrac {
 };
 
 std::map<int, Atrac *> atracMap;
+u8 nextAtracID;
 
-void __AtracInit()
-{
+void __AtracInit() {
+	nextAtracID = 0;
 }
 
 void __AtracDoState(PointerWrap &p) {
 	p.Do(atracMap);
+	p.Do(nextAtracID);
 
 	p.DoMarker("sceAtrac");
 }
 
-void __AtracShutdown()
-{
+void __AtracShutdown() {
 	for (auto it = atracMap.begin(), end = atracMap.end(); it != end; ++it) {
 		delete it->second;
 	}
@@ -101,7 +102,7 @@ Atrac *getAtrac(int atracID) {
 }
 
 int createAtrac(Atrac *atrac) {
-	int id = (int) atracMap.size();
+	int id = nextAtracID++;
 	atracMap[id] = atrac;
 	return id;
 }


### PR DESCRIPTION
This avoids conflicts when ids are deleted.

Indeed fixes Lord of Arcana (at least the demo version.)  Didn't start at non-0 because it wasn't before, and from one test I suspect the PSP may start at 0... need to create more tests though.

Anyway, this is a minimal change that fixes things.

Pointed out by @oioitff.

-[Unknown]
