### PR TITLE
Make test.py run the most recently built binary

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,9 +6,23 @@ import io
 import os
 import subprocess
 import threading
+import glob
 
 
-PPSSPP_EXECUTABLES = [ "Windows\\Release\\PPSSPPHeadless.exe", "build/PPSSPPHeadless" ]
+PPSSPP_EXECUTABLES = [
+  # Windows
+  "Windows\\Debug\\PPSSPPHeadless.exe",
+  "Windows\\Release\\PPSSPPHeadless.exe",
+  "Windows\\x64\\Debug\\PPSSPPHeadless.exe",
+  "Windows\\x64\\Release\\PPSSPPHeadless.exe",
+  # Mac
+  "build*/Debug/PPSSPPHeadless",
+  "build*/Release/PPSSPPHeadless",
+  "build*/RelWithDebInfo/PPSSPPHeadless",
+  "build*/MinSizeRel}/PPSSPPHeadless",
+  # Linux
+  "build*/PPSSPPHeadless"
+]
 PPSSPP_EXE = None
 TEST_ROOT = "pspautotests/tests/"
 teamcity_mode = False
@@ -199,10 +213,13 @@ def init():
     print("(checked for existence of cpu/cpu_alu/cpu_alu.prx)")
     sys.exit(1)
 
-  for p in PPSSPP_EXECUTABLES:
-    if os.path.exists(p):
-      PPSSPP_EXE = p
-      break
+  possible_exes = [glob.glob(f) for f in PPSSPP_EXECUTABLES]
+  possible_exes = [x for sublist in possible_exes for x in sublist]
+  existing = filter(os.path.exists, possible_exes)
+  if existing:
+    PPSSPP_EXE = max((os.path.getmtime(f), f) for f in existing)[1]
+  else:
+    PPSSPP_EXE = None
 
   if not PPSSPP_EXE:
     print("PPSSPP executable missing, please build one.")


### PR DESCRIPTION
With this, running test.py auto-selects whatever binary has the latest mtime and runs it.  Only really tested with Python 2.7 Mac/Windows, but I think it'll work...

Glob wasn't doing what I wanted for some reason on Windows, but that's fine since Windows generally always builds in the same dir anyway.

Apparently the icache test is generating an unknown syscall... who knew?

-[Unknown]
