### PR TITLE
Dispatch thread fixes

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -443,7 +443,17 @@ void CallSyscall(u32 op)
 	HLEFunc func = moduleDB[modulenum].funcTable[funcnum].func;
 	if (func)
 	{
-		func();
+		// TODO: Move to jit/interp.
+		u32 flags = moduleDB[modulenum].funcTable[funcnum].flags;
+		if (flags & HLE_NOT_DISPATCH_SUSPENDED)
+		{
+			if (!__KernelIsDispatchEnabled())
+				RETURN(SCE_KERNEL_ERROR_CAN_NOT_WAIT);
+			else
+				func();
+		}
+		else
+			func();
 
 		if (hleAfterSyscall != HLE_AFTER_NOTHING)
 			hleFinishSyscall(modulenum, funcnum);

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -20,14 +20,17 @@
 #include "../Globals.h"
 #include "../MIPS/MIPS.h"
 
-#define STACKTOP 0x09F00000
-#define STACKSIZE 0x10000
-
 typedef void (* HLEFunc)();
 
 enum {
-	NOT_IN_INTERRUPT,
-	NOT_DISPATCH_SUSPENDED,
+	// The low 8 bits are a value, indicating special jit handling.
+	// Currently there are none.
+
+	// The remaining 24 bits are flags.
+	// Don't allow the call within an interrupt.  Not yet implemented.
+	HLE_NOT_IN_INTERRUPT = 1 << 8,
+	// Don't allow the call if dispatch or interrupts are disabled.
+	HLE_NOT_DISPATCH_SUSPENDED = 1 << 9,
 };
 
 struct HLEFunction

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -619,8 +619,8 @@ const HLEFunction ThreadManForUser[] =
 	// NOTE: LockLwMutex, UnlockLwMutex, and ReferLwMutexStatus are in Kernel_Library, see sceKernelInterrupt.cpp.
 
 	{0xf8170fbe,&WrapI_I<sceKernelDeleteMutex>,                "sceKernelDeleteMutex"},
-	{0xB011B11F,&WrapI_IIU<sceKernelLockMutex>,                "sceKernelLockMutex"},
-	{0x5bf4dd27,&WrapI_IIU<sceKernelLockMutexCB>,              "sceKernelLockMutexCB"},
+	{0xB011B11F,&WrapI_IIU<sceKernelLockMutex>,                "sceKernelLockMutex", HLE_NOT_DISPATCH_SUSPENDED},
+	{0x5bf4dd27,&WrapI_IIU<sceKernelLockMutexCB>,              "sceKernelLockMutexCB", HLE_NOT_DISPATCH_SUSPENDED},
 	{0x6b30100f,&WrapI_II<sceKernelUnlockMutex>,               "sceKernelUnlockMutex"},
 	{0xb7d098c6,&WrapI_CUIU<sceKernelCreateMutex>,             "sceKernelCreateMutex"},
 	{0x0DDCD2C9,&WrapI_II<sceKernelTryLockMutex>,              "sceKernelTryLockMutex"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -610,8 +610,8 @@ const HLEFunction ThreadManForUser[] =
 	{0x58b1f937,&WrapI_II<sceKernelPollSema>,                  "sceKernelPollSema"},
 	{0xBC6FEBC5,&WrapI_IU<sceKernelReferSemaStatus>,           "sceKernelReferSemaStatus"},
 	{0x3F53E640,&WrapI_II<sceKernelSignalSema>,                "sceKernelSignalSema"},
-	{0x4E3A1105,&WrapI_IIU<sceKernelWaitSema>,                 "sceKernelWaitSema"},
-	{0x6d212bac,&WrapI_IIU<sceKernelWaitSemaCB>,               "sceKernelWaitSemaCB"},
+	{0x4E3A1105,&WrapI_IIU<sceKernelWaitSema>,                 "sceKernelWaitSema", HLE_NOT_DISPATCH_SUSPENDED},
+	{0x6d212bac,&WrapI_IIU<sceKernelWaitSemaCB>,               "sceKernelWaitSemaCB", HLE_NOT_DISPATCH_SUSPENDED},
 
 	{0x60107536,&WrapI_U<sceKernelDeleteLwMutex>,              "sceKernelDeleteLwMutex"},
 	{0x19CFF145,&WrapI_UCUIU<sceKernelCreateLwMutex>,          "sceKernelCreateLwMutex"},

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -128,6 +128,7 @@ private:
 	std::map<int, SubIntrHandler> subIntrHandlers;
 };
 
+bool __InterruptsEnabled();
 bool __IsInInterrupt();
 void __InterruptsInit();
 void __InterruptsDoState(PointerWrap &p);

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -232,9 +232,8 @@ void __KernelMbxTimeout(u64 userdata, int cyclesLate)
 		// So, we need to remember it or we won't be able to mark it DELETE instead later.
 
 		// TODO: Should numWaitThreads be decreased yet?
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 	}
-
-	__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 }
 
 void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -982,9 +982,9 @@ void __KernelVplTimeout(u64 userdata, int cyclesLate)
 		// actually running, it will get a DELETE result instead of a TIMEOUT.
 		// So, we need to remember it or we won't be able to mark it DELETE instead later.
 		vpl->nv.numWaitThreads--;
-	}
 
-	__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+	}
 }
 
 void __KernelSetVplTimeout(u32 timeoutPtr)

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -400,7 +400,9 @@ void __KernelMutexTimeout(u64 userdata, int cyclesLate)
 	if (timeoutPtr != 0)
 		Memory::Write_U32(0, timeoutPtr);
 
-	__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+	SceUID mutexID = __KernelGetWaitID(threadID, WAITTYPE_MUTEX, error);
+	if (mutexID != 0)
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 
 	// We intentionally don't remove from waitingThreads here yet.
 	// The reason is, if it times out, but what it was waiting on is DELETED prior to it
@@ -773,7 +775,9 @@ void __KernelLwMutexTimeout(u64 userdata, int cyclesLate)
 	if (timeoutPtr != 0)
 		Memory::Write_U32(0, timeoutPtr);
 
-	__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+	SceUID mutexID = __KernelGetWaitID(threadID, WAITTYPE_LWMUTEX, error);
+	if (mutexID != 0)
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 
 	// We intentionally don't remove from waitingThreads here yet.
 	// The reason is, if it times out, but what it was waiting on is DELETED prior to it

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -329,7 +329,7 @@ int __KernelWaitSema(SceUID id, int wantedCount, u32 timeoutPtr, const char *bad
 		if (wantedCount > s->ns.maxCount || wantedCount <= 0)
 			return SCE_KERNEL_ERROR_ILLEGAL_COUNT;
 
-		if (s->ns.currentCount >= wantedCount)
+		if (s->ns.currentCount >= wantedCount && s->ns.numWaitThreads == 0)
 		{
 			s->ns.currentCount -= wantedCount;
 			if (processCallbacks)
@@ -382,7 +382,7 @@ int sceKernelPollSema(SceUID id, int wantedCount)
 	Semaphore *s = kernelObjects.Get<Semaphore>(id, error);
 	if (s)
 	{
-		if (s->ns.currentCount >= wantedCount)
+		if (s->ns.currentCount >= wantedCount && s->ns.numWaitThreads == 0)
 		{
 			s->ns.currentCount -= wantedCount;
 			return 0;

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -298,9 +298,9 @@ void __KernelSemaTimeout(u64 userdata, int cycleslate)
 		// actually running, it will get a DELETE result instead of a TIMEOUT.
 		// So, we need to remember it or we won't be able to mark it DELETE instead later.
 		s->ns.numWaitThreads--;
-	}
 
-	__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+	}
 }
 
 void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1692,19 +1692,19 @@ void sceKernelExitDeleteThread()
 
 u32 sceKernelSuspendDispatchThread()
 {
-	u32 oldDispatchSuspended = !dispatchEnabled;
+	u32 oldDispatchEnabled = dispatchEnabled;
 	dispatchEnabled = false;
-	DEBUG_LOG(HLE,"%i=sceKernelSuspendDispatchThread()", oldDispatchSuspended);
-	return oldDispatchSuspended;
+	DEBUG_LOG(HLE,"%i=sceKernelSuspendDispatchThread()", oldDispatchEnabled);
+	return oldDispatchEnabled;
 }
 
-u32 sceKernelResumeDispatchThread(u32 suspended)
+u32 sceKernelResumeDispatchThread(u32 enabled)
 {
-	u32 oldDispatchSuspended = !dispatchEnabled;
-	dispatchEnabled = !suspended;
-	DEBUG_LOG(HLE,"%i=sceKernelResumeDispatchThread(%i)", oldDispatchSuspended, suspended);
+	u32 oldDispatchEnabled = dispatchEnabled;
+	dispatchEnabled = enabled != 0;
+	DEBUG_LOG(HLE,"%i=sceKernelResumeDispatchThread(%i)", oldDispatchEnabled, enabled);
 	hleReSchedule("dispatch resumed");
-	return oldDispatchSuspended;
+	return oldDispatchEnabled;
 }
 
 int sceKernelRotateThreadReadyQueue(int priority)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -26,8 +26,9 @@
 #include "../MIPS/MIPSInt.h"
 #include "../MIPS/MIPSCodeUtils.h"
 #include "../MIPS/MIPS.h"
-#include "../../Core/CoreTiming.h"
-#include "../../Core/MemMap.h"
+#include "Core/CoreTiming.h"
+#include "Core/MemMap.h"
+#include "Core/Reporting.h"
 #include "ChunkFile.h"
 
 #include "sceAudio.h"
@@ -1565,8 +1566,17 @@ int sceKernelStartThread(SceUID threadToStartID, u32 argSize, u32 argBlockPtr)
 		// Smaller is better for priority.  Only switch if the new thread is better.
 		if (cur && cur->nt.currentPriority > startThread->nt.currentPriority)
 		{
+			// Starting a thread automatically resumes the dispatch thread.
+			// TODO: Maybe this happens even for worse-priority started threads?
+			dispatchEnabled = true;
+
 			__KernelChangeReadyState(currentThread, true);
 			hleReSchedule("thread started");
+		}
+		else if (!dispatchEnabled)
+		{
+			WARN_LOG(HLE, "UNTESTED Dispatch disabled while starting worse-priority thread");
+			Reporting::ReportMessage("UNTESTED Dispatch disabled while starting worse-priority thread");
 		}
 		__KernelChangeReadyState(startThread, threadToStartID, true);
 		return 0;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1704,7 +1704,7 @@ u32 sceKernelSuspendDispatchThread()
 {
 	u32 oldDispatchEnabled = dispatchEnabled;
 	dispatchEnabled = false;
-	DEBUG_LOG(HLE,"%i=sceKernelSuspendDispatchThread()", oldDispatchEnabled);
+	DEBUG_LOG(HLE, "%i=sceKernelSuspendDispatchThread()", oldDispatchEnabled);
 	return oldDispatchEnabled;
 }
 
@@ -1712,9 +1712,9 @@ u32 sceKernelResumeDispatchThread(u32 enabled)
 {
 	u32 oldDispatchEnabled = dispatchEnabled;
 	dispatchEnabled = enabled != 0;
-	DEBUG_LOG(HLE,"%i=sceKernelResumeDispatchThread(%i)", oldDispatchEnabled, enabled);
+	DEBUG_LOG(HLE, "sceKernelResumeDispatchThread(%i) - from %i", enabled, oldDispatchEnabled);
 	hleReSchedule("dispatch resumed");
-	return oldDispatchEnabled;
+	return 0;
 }
 
 int sceKernelRotateThreadReadyQueue(int priority)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1284,7 +1284,7 @@ Thread *__KernelNextThread() {
 void __KernelReSchedule(const char *reason)
 {
 	// cancel rescheduling when in interrupt or callback, otherwise everything will be fucked up
-	if (__IsInInterrupt() || __KernelInCallback() || !__InterruptsEnabled())
+	if (__IsInInterrupt() || __KernelInCallback() || !__KernelIsDispatchEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;
@@ -1299,7 +1299,7 @@ void __KernelReSchedule(const char *reason)
 
 	// Execute any pending events while we're doing scheduling.
 	CoreTiming::AdvanceQuick();
-	if (__IsInInterrupt() || __KernelInCallback() || !__InterruptsEnabled())
+	if (__IsInInterrupt() || __KernelInCallback() || !__KernelIsDispatchEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;
@@ -1715,6 +1715,12 @@ u32 sceKernelResumeDispatchThread(u32 enabled)
 	DEBUG_LOG(HLE, "sceKernelResumeDispatchThread(%i) - from %i", enabled, oldDispatchEnabled);
 	hleReSchedule("dispatch resumed");
 	return 0;
+}
+
+bool __KernelIsDispatchEnabled()
+{
+	// Dispatch can never be enabled when interrupts are disabled.
+	return dispatchEnabled && __InterruptsEnabled();
 }
 
 int sceKernelRotateThreadReadyQueue(int priority)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1283,7 +1283,7 @@ Thread *__KernelNextThread() {
 void __KernelReSchedule(const char *reason)
 {
 	// cancel rescheduling when in interrupt or callback, otherwise everything will be fucked up
-	if (__IsInInterrupt() || __KernelInCallback())
+	if (__IsInInterrupt() || __KernelInCallback() || !__InterruptsEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;
@@ -1298,7 +1298,7 @@ void __KernelReSchedule(const char *reason)
 
 	// Execute any pending events while we're doing scheduling.
 	CoreTiming::AdvanceQuick();
-	if (__IsInInterrupt() || __KernelInCallback())
+	if (__IsInInterrupt() || __KernelInCallback() || !__InterruptsEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -176,6 +176,7 @@ void __KernelStartIdleThreads();
 void __KernelReturnFromThread();  // Called as HLE function
 u32 __KernelGetThreadPrio(SceUID id);
 bool __KernelThreadSortPriority(SceUID thread1, SceUID thread2);
+bool __KernelIsDispatchEnabled();
 
 void __KernelIdle();
 


### PR DESCRIPTION
Fixes #339.  Can't find any games that it breaks, although it makes a number of changes.

Planning to move the HLE checks to the jit since that way, they won't take time from most calls that could be hot.  But it's not really important now.  It may make a few games a bit slower at the moment though (ones that hammer HLE funcs to death.)

There's more to fix: this just does mutexes and semaphores, which are all I've tested so far.

-[Unknown]
