### PR TITLE
Hack render-to-rexture height in HW/SW mode

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -650,7 +650,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			if (throughmode)
 				transformed[index].v = 1.0f - transformed[index].v;
 			else 
-				transformed[index].v = 1.0f - transformed[index].v * 2.0f;
+				transformed[index].v = 1.1f - transformed[index].v * 2.0f;
 		}
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -412,7 +412,7 @@ void GenerateVertexShader(int prim, char *buffer) {
 				if (gstate.isModeThrough())	
 					WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y;\n");
 				else
-					WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y * 2.0;\n");
+					WRITE(p, "  v_texcoord.y = 1.1 - v_texcoord.y * 2.0;\n");
 			}
 		}
 


### PR DESCRIPTION
This one is dirty .... however i cannot find better solution to fix the render-to-texture height .This fixes some characters floating issues we encountered in different games like Saint Seiya Omega , Gundam AGE Universe , Fat Princess etc 
