### PR TITLE
Fix x64 Windows Debug build

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -237,7 +237,7 @@ void ARMXEmitter::MOVI2R(ARMReg reg, u32 val, bool optimize)
 			MOVW(reg, val & 0xFFFF);
 			if(val & 0xFFFF0000)
 				MOVT(reg, val, true);
-		} else if (!TrySetValue_TwoOp(reg,val) {
+		} else if (!TrySetValue_TwoOp(reg,val)) {
 			// Use literal pool for ARMv6.
 			AddNewLit(val);
 			LDR(reg, _PC); // To be backpatched later

--- a/Windows/rt_manif.bin
+++ b/Windows/rt_manif.bin
@@ -3,10 +3,10 @@
    xmlns="urn:schemas-microsoft-com:asm.v1" 
    manifestVersion="1.0">
  <assemblyIdentity 
-    processorArchitecture="x86" 
+    processorArchitecture="*" 
     version="5.1.0.0"
     type="win32"
-    name="PPSSPP.exe"/>
+    name="PPSSPPWindows.exe"/>
  <description>PPSSPP</description>
  <dependency>
   <dependentAssembly>
@@ -16,7 +16,7 @@
          version="6.0.0.0"
          publicKeyToken="6595b64144ccf1df"
          language="*"
-         processorArchitecture="x86"/>
+         processorArchitecture="*"/>
   </dependentAssembly>
  </dependency>
 </assembly>

--- a/test.py
+++ b/test.py
@@ -49,10 +49,9 @@ class Command(object):
     if thread.isAlive():
       self.timeout = True
       if sys.version_info < (2, 6):
-        os.kill(process.pid, signal.SIGKILL)
+        os.kill(self.process.pid, signal.SIGKILL)
       else:
-        process.terminate()
-      self.process.terminate()
+        self.process.terminate()
       thread.join()
 
 # Test names are the C files without the .c extension.


### PR DESCRIPTION
Manifest file was specifying comctl32 x86.  This way seems to make everyone happy.

Also sneak in a test.py fix and a buildfix.

-[Unknown]
