### PR TITLE
Fix swapped statements in scePsmf?

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -902,8 +902,8 @@ u32 scePsmfPlayerChangePlayMode(u32 psmfPlayer, int playMode, int playSpeed)
 		return ERROR_PSMF_NOT_FOUND;
 	}
 
-	playMode = psmfplayer->playMode;
-	playSpeed = psmfplayer->playSpeed;
+	psmfplayer->playMode = playMode;
+	psmfplayer->playSpeed = playSpeed;
 	return 0;
 }
 
@@ -940,8 +940,8 @@ u32 scePsmfPlayerSelectSpecificVideo(u32 psmfPlayer, int videoCodec, int videoSt
 		return ERROR_PSMF_NOT_FOUND;
 	}
 
-	videoCodec = psmfplayer->videoCodec;
-	videoStreamNum = psmfplayer->videoStreamNum;
+	psmfplayer->videoCodec = videoCodec;
+	psmfplayer->videoStreamNum = videoStreamNum;
 	return 0;
 }
 
@@ -954,8 +954,8 @@ u32 scePsmfPlayerSelectSpecificAudio(u32 psmfPlayer, int audioCodec, int audioSt
 		return ERROR_PSMF_NOT_FOUND;
 	}
 
-	audioCodec = psmfplayer->audioCodec;
-	audioStreamNum = psmfplayer->audioStreamNum;
+	psmfplayer->audioCodec = audioCodec;
+	psmfplayer->audioStreamNum = audioStreamNum;
 	return 0;
 }
 

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -104,7 +104,7 @@ bool LoadFile(const char *filename, std::string *error_string)
 		pspFileSystem.SetStartingDirectory("disc0:/PSP_GAME/USRDIR");
 		return Load_PSP_ISO(filename, error_string);
 	case FILETYPE_ERROR:
-		ERROR_LOG(LOADER, "Could not file");
+		ERROR_LOG(LOADER, "Could not read file");
 		*error_string = "Error reading file";
 		break;
 	case FILETYPE_UNKNOWN_BIN:


### PR DESCRIPTION
I'm assuming this was actually intended

The other way results in no actual changes happening outside of the function. There were no comments saying that was intended so I guess it was an accident or something.

If the functions aren't entirely implemented yet, just tell me and I'll close the pull request.
