### PR TITLE
Use -O3 for Mac/iOS release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1013,22 +1013,26 @@ endif()
 # installs
 file(INSTALL ${NativeAssets} DESTINATION assets)
 
-# packaging and code signing
-if (IOS)
+# Fix CMake some Xcode settings.
+if(APPLE)
 	# Fix CMake breaking optimization settings.
 	set(CMAKE_CXX_FLAGS_DEBUG "-g -D_DEBUG")
 	set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -D_NDEBUG")
-	set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_NDEBUG")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -D_NDEBUG")
+	set(CMAKE_CXX_FLAGS_RELEASE "-O3 -D_NDEBUG")
+	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -D_NDEBUG")
 	set(CMAKE_C_FLAGS_DEBUG "-g -D_DEBUG")
 	set(CMAKE_C_FLAGS_MINSIZEREL "-Os -D_NDEBUG")
-	set(CMAKE_C_FLAGS_RELEASE "-O2 -D_NDEBUG")
-	set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -D_NDEBUG")
+	set(CMAKE_C_FLAGS_RELEASE "-O3 -D_NDEBUG")
+	set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -D_NDEBUG")
 
-	# These can be fast.
+	# These can be fast even for debug.
 	set_target_properties(cityhash PROPERTIES COMPILE_FLAGS "-O3")
+	set_target_properties(snappy PROPERTIES COMPILE_FLAGS "-O3")
 	set_target_properties(zlib PROPERTIES COMPILE_FLAGS "-O3")
+endif()
 
+# packaging and code signing
+if(IOS)
 	add_dependencies(PPSSPP ${CoreLibName} GPU Common native)
 
 	file(GLOB IOSAssets ios/assets/*.png)


### PR DESCRIPTION
People reported it was much faster, and I ran tests and it was fine.  It does seem faster.

There have been both types of builds for a while and no reports that there were any differences.

If anything breaks, it'd be good to know.  Maybe we shoudl set -O3 on gcc as well if it works well.

-[Unknown]
