### PR TITLE
Improve callbacks with waits

### DIFF
--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -71,11 +71,14 @@ struct Mutex : public KernelObject
 		p.Do(nm);
 		SceUID dv = 0;
 		p.Do(waitingThreads, dv);
+		p.Do(pausedWaitTimeouts);
 		p.DoMarker("Mutex");
 	}
 
 	NativeMutex nm;
 	std::vector<SceUID> waitingThreads;
+	// Key is the callback id it was for, or if no callback, the thread id.
+	std::map<SceUID, u64> pausedWaitTimeouts;
 };
 
 
@@ -142,12 +145,16 @@ static int lwMutexWaitTimer = -1;
 typedef std::multimap<SceUID, SceUID> MutexMap;
 static MutexMap mutexHeldLocks;
 
+void __KernelMutexBeginCallback(SceUID threadID, SceUID prevCallbackId);
+void __KernelMutexEndCallback(SceUID threadID, SceUID prevCallbackId, u32 &returnValue);
+
 void __KernelMutexInit()
 {
 	mutexWaitTimer = CoreTiming::RegisterEvent("MutexTimeout", __KernelMutexTimeout);
 	lwMutexWaitTimer = CoreTiming::RegisterEvent("LwMutexTimeout", __KernelLwMutexTimeout);
 
 	__KernelListenThreadEnd(&__KernelMutexThreadEnd);
+	__KernelRegisterWaitTypeFuncs(WAITTYPE_MUTEX, __KernelMutexBeginCallback, __KernelMutexEndCallback);
 }
 
 void __KernelMutexDoState(PointerWrap &p)
@@ -232,6 +239,109 @@ std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUID> &wai
 	return best;
 }
 
+bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int result)
+{
+	SceUID waitID = __KernelGetWaitID(threadID, WAITTYPE_MUTEX, error);
+	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
+
+	// The waitID may be different after a timeout.
+	if (waitID != mutex->GetUID())
+		return false;
+
+	// If result is an error code, we're just letting it go.
+	if (result == 0)
+	{
+		int wVal = (int)__KernelGetWaitValue(threadID, error);
+		__KernelMutexAcquireLock(mutex, wVal, threadID);
+	}
+
+	if (timeoutPtr != 0 && mutexWaitTimer != -1)
+	{
+		// Remove any event for this thread.
+		u64 cyclesLeft = CoreTiming::UnscheduleEvent(mutexWaitTimer, threadID);
+		Memory::Write_U32((u32) cyclesToUs(cyclesLeft), timeoutPtr);
+	}
+
+	__KernelResumeThreadFromWait(threadID, result);
+	return true;
+}
+
+void __KernelMutexBeginCallback(SceUID threadID, SceUID prevCallbackId)
+{
+	SceUID pauseKey = prevCallbackId == 0 ? threadID : prevCallbackId;
+
+	u32 error;
+	SceUID mutexID = __KernelGetWaitID(threadID, WAITTYPE_MUTEX, error);
+	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
+	Mutex *mutex = mutexID == 0 ? NULL : kernelObjects.Get<Mutex>(mutexID, error);
+	if (mutex)
+	{
+		if (mutex->pausedWaitTimeouts.find(pauseKey) != mutex->pausedWaitTimeouts.end())
+			WARN_LOG_REPORT(HLE, "sceKernelLockMutexCB: Callback %08x triggered within itself, should not happen (PSP crashes.)", prevCallbackId);
+
+		if (timeoutPtr != 0 && mutexWaitTimer != -1)
+		{
+			u64 cyclesLeft = CoreTiming::UnscheduleEvent(mutexWaitTimer, threadID);
+			mutex->pausedWaitTimeouts[pauseKey] = CoreTiming::GetTicks() + cyclesLeft;
+		}
+		else
+			mutex->pausedWaitTimeouts[pauseKey] = 0;
+
+		// TODO: Hmm, what about priority/fifo order?  Does it lose its place in line?
+		mutex->waitingThreads.erase(std::remove(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID), mutex->waitingThreads.end());
+
+		DEBUG_LOG(HLE, "sceKernelLockMutexCB: Suspending lock wait for callback");
+	}
+	else
+		WARN_LOG_REPORT(HLE, "sceKernelLockMutexCB: beginning callback with bad wait id?");
+}
+
+void __KernelMutexEndCallback(SceUID threadID, SceUID prevCallbackId, u32 &returnValue)
+{
+	SceUID pauseKey = prevCallbackId == 0 ? threadID : prevCallbackId;
+
+	u32 error;
+	SceUID mutexID = __KernelGetWaitID(threadID, WAITTYPE_MUTEX, error);
+	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
+	Mutex *mutex = mutexID == 0 ? NULL : kernelObjects.Get<Mutex>(mutexID, error);
+	if (!mutex || mutex->pausedWaitTimeouts.find(pauseKey) == mutex->pausedWaitTimeouts.end())
+	{
+		// TODO: Since it was deleted, we don't know how long was actually left.
+		// For now, we just say the full time was taken.
+		if (timeoutPtr != 0 && mutexWaitTimer != -1)
+			Memory::Write_U32(0, timeoutPtr);
+
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_DELETE);
+		return;
+	}
+
+	u64 waitDeadline = mutex->pausedWaitTimeouts[pauseKey];
+	mutex->pausedWaitTimeouts.erase(pauseKey);
+
+	// TODO: Don't wake up if __KernelCurHasReadyCallbacks()?
+
+	// Attempt to unlock.
+	if (mutex->nm.lockThread == -1 && __KernelUnlockMutexForThread(mutex, threadID, error, 0))
+		return;
+
+	// We only check if it timed out if it couldn't unlock.
+	s64 cyclesLeft = waitDeadline - CoreTiming::GetTicks();
+	if (cyclesLeft < 0 && waitDeadline != 0)
+	{
+		if (timeoutPtr != 0 && mutexWaitTimer != -1)
+			Memory::Write_U32(0, timeoutPtr);
+
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+	}
+	else
+	{
+		// TODO: Should this not go at the end?
+		mutex->waitingThreads.push_back(threadID);
+
+		DEBUG_LOG(HLE, "sceKernelLockMutexCB: Resuming lock wait for callback");
+	}
+}
+
 int sceKernelCreateMutex(const char *name, u32 attr, int initialCount, u32 optionsPtr)
 {
 	if (!name)
@@ -276,33 +386,6 @@ int sceKernelCreateMutex(const char *name, u32 attr, int initialCount, u32 optio
 	return id;
 }
 
-bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int result)
-{
-	SceUID waitID = __KernelGetWaitID(threadID, WAITTYPE_MUTEX, error);
-	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
-
-	// The waitID may be different after a timeout.
-	if (waitID != mutex->GetUID())
-		return false;
-
-	// If result is an error code, we're just letting it go.
-	if (result == 0)
-	{
-		int wVal = (int)__KernelGetWaitValue(threadID, error);
-		__KernelMutexAcquireLock(mutex, wVal, threadID);
-	}
-
-	if (timeoutPtr != 0 && mutexWaitTimer != -1)
-	{
-		// Remove any event for this thread.
-		u64 cyclesLeft = CoreTiming::UnscheduleEvent(mutexWaitTimer, threadID);
-		Memory::Write_U32((u32) cyclesToUs(cyclesLeft), timeoutPtr);
-	}
-
-	__KernelResumeThreadFromWait(threadID, result);
-	return true;
-}
-
 int sceKernelDeleteMutex(SceUID id)
 {
 	DEBUG_LOG(HLE,"sceKernelDeleteMutex(%i)", id);
@@ -328,20 +411,38 @@ int sceKernelDeleteMutex(SceUID id)
 		return error;
 }
 
+bool __KernelLockMutexCheck(Mutex *mutex, int count, u32 &error)
+{
+	if (error)
+		return false;
+
+	const bool mutexIsRecursive = (mutex->nm.attr & PSP_MUTEX_ATTR_ALLOW_RECURSIVE) != 0;
+
+	if (count <= 0)
+		error = SCE_KERNEL_ERROR_ILLEGAL_COUNT;
+	else if (count > 1 && !mutexIsRecursive)
+		error = SCE_KERNEL_ERROR_ILLEGAL_COUNT;
+	// Two positive ints will always overflow to negative.
+	else if (count + mutex->nm.lockLevel < 0)
+		error = PSP_MUTEX_ERROR_LOCK_OVERFLOW;
+	// Only a recursive mutex can re-lock.
+	else if (mutex->nm.lockThread == __KernelGetCurThread())
+	{
+		if (mutexIsRecursive)
+			return true;
+
+		error = PSP_MUTEX_ERROR_ALREADY_LOCKED;
+	}
+	// Otherwise it would lock or wait.
+	else if (mutex->nm.lockLevel == 0)
+		return true;
+
+	return false;
+}
+
 bool __KernelLockMutex(Mutex *mutex, int count, u32 &error)
 {
-	if (!error)
-	{
-		if (count <= 0)
-			error = SCE_KERNEL_ERROR_ILLEGAL_COUNT;
-		else if (count > 1 && !(mutex->nm.attr & PSP_MUTEX_ATTR_ALLOW_RECURSIVE))
-			error = SCE_KERNEL_ERROR_ILLEGAL_COUNT;
-		// Two positive ints will always overflow to negative.
-		else if (count + mutex->nm.lockLevel < 0)
-			error = PSP_MUTEX_ERROR_LOCK_OVERFLOW;
-	}
-
-	if (error)
+	if (!__KernelLockMutexCheck(mutex, count, error))
 		return false;
 
 	if (mutex->nm.lockLevel == 0)
@@ -353,17 +454,9 @@ bool __KernelLockMutex(Mutex *mutex, int count, u32 &error)
 
 	if (mutex->nm.lockThread == __KernelGetCurThread())
 	{
-		// Recursive mutex, let's just increase the lock count and keep going
-		if (mutex->nm.attr & PSP_MUTEX_ATTR_ALLOW_RECURSIVE)
-		{
-			mutex->nm.lockLevel += count;
-			return true;
-		}
-		else
-		{
-			error = PSP_MUTEX_ERROR_ALREADY_LOCKED;
-			return false;
-		}
+		// __KernelLockMutexCheck() would've returned an error, so this must be recursive.
+		mutex->nm.lockLevel += count;
+		return true;
 	}
 
 	return false;
@@ -489,15 +582,11 @@ int sceKernelLockMutexCB(SceUID id, int count, u32 timeoutPtr)
 	u32 error;
 	Mutex *mutex = kernelObjects.Get<Mutex>(id, error);
 
-	if (__KernelLockMutex(mutex, count, error))
+	if (!__KernelLockMutexCheck(mutex, count, error))
 	{
-		hleCheckCurrentCallbacks();
-		return 0;
-	}
-	else if (error)
-		return error;
-	else
-	{
+		if (error)
+			return error;
+
 		SceUID threadID = __KernelGetCurThread();
 		// May be in a tight loop timing out (where we don't remove from waitingThreads yet), don't want to add duplicates.
 		if (std::find(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID) == mutex->waitingThreads.end())
@@ -506,6 +595,21 @@ int sceKernelLockMutexCB(SceUID id, int count, u32 timeoutPtr)
 		__KernelWaitCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr, true, "mutex waited");
 
 		// Return value will be overwritten by wait.
+		return 0;
+	}
+	else
+	{
+		if (__KernelCurHasReadyCallbacks())
+		{
+			// Might actually end up having to wait, so set the timeout.
+			__KernelWaitMutex(mutex, timeoutPtr);
+			__KernelWaitCallbacksCurThread(WAITTYPE_MUTEX, id, count, timeoutPtr);
+
+			// Return value will be written to callback's v0, but... that's probably fine?
+		}
+		else
+			__KernelLockMutex(mutex, count, error);
+
 		return 0;
 	}
 }

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -282,8 +282,10 @@ void __KernelMutexBeginCallback(SceUID threadID, SceUID prevCallbackId)
 	Mutex *mutex = mutexID == 0 ? NULL : kernelObjects.Get<Mutex>(mutexID, error);
 	if (mutex)
 	{
+		// This means two callbacks in a row.  PSP crashes if the same callback runs inside itself.
+		// TODO: Handle this better?
 		if (mutex->pausedWaitTimeouts.find(pauseKey) != mutex->pausedWaitTimeouts.end())
-			WARN_LOG_REPORT(HLE, "sceKernelLockMutexCB: Callback %08x triggered within itself, should not happen (PSP crashes.)", prevCallbackId);
+			return;
 
 		if (timeoutPtr != 0 && mutexWaitTimer != -1)
 		{
@@ -923,8 +925,10 @@ void __KernelLwMutexBeginCallback(SceUID threadID, SceUID prevCallbackId)
 	LwMutex *mutex = mutexID == 0 ? NULL : kernelObjects.Get<LwMutex>(mutexID, error);
 	if (mutex)
 	{
+		// This means two callbacks in a row.  PSP crashes if the same callback runs inside itself.
+		// TODO: Handle this better?
 		if (mutex->pausedWaitTimeouts.find(pauseKey) != mutex->pausedWaitTimeouts.end())
-			WARN_LOG_REPORT(HLE, "sceKernelLockLwMutexCB: Callback %08x triggered within itself, should not happen (PSP crashes.)", prevCallbackId);
+			return;
 
 		if (timeoutPtr != 0 && lwMutexWaitTimer != -1)
 		{

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -142,8 +142,10 @@ void __KernelSemaBeginCallback(SceUID threadID, SceUID prevCallbackId)
 	Semaphore *s = semaID == 0 ? NULL : kernelObjects.Get<Semaphore>(semaID, error);
 	if (s)
 	{
+		// This means two callbacks in a row.  PSP crashes if the same callback runs inside itself.
+		// TODO: Handle this better?
 		if (s->pausedWaitTimeouts.find(pauseKey) != s->pausedWaitTimeouts.end())
-			WARN_LOG_REPORT(HLE, "sceKernelWaitSemaCB: Callback %08x triggered within itself, should not happen (PSP crashes.)", prevCallbackId);
+			return;
 
 		if (timeoutPtr != 0 && semaWaitTimer != -1)
 		{

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -64,18 +64,25 @@ struct Semaphore : public KernelObject
 		p.Do(ns);
 		SceUID dv = 0;
 		p.Do(waitingThreads, dv);
+		p.Do(pausedWaitTimeouts);
 		p.DoMarker("Semaphore");
 	}
 
 	NativeSemaphore ns;
 	std::vector<SceUID> waitingThreads;
+	// Key is the callback id it was for, or if no callback, the thread id.
+	std::map<SceUID, u64> pausedWaitTimeouts;
 };
 
 static int semaWaitTimer = -1;
 
+void __KernelSemaBeginCallback(SceUID threadID, SceUID prevCallbackId);
+void __KernelSemaEndCallback(SceUID threadID, SceUID prevCallbackId, u32 &returnValue);
+
 void __KernelSemaInit()
 {
 	semaWaitTimer = CoreTiming::RegisterEvent("SemaphoreTimeout", __KernelSemaTimeout);
+	__KernelRegisterWaitTypeFuncs(WAITTYPE_SEMA, __KernelSemaBeginCallback, __KernelSemaEndCallback);
 }
 
 void __KernelSemaDoState(PointerWrap &p)
@@ -115,12 +122,94 @@ bool __KernelUnlockSemaForThread(Semaphore *s, SceUID threadID, u32 &error, int 
 	{
 		// Remove any event for this thread.
 		u64 cyclesLeft = CoreTiming::UnscheduleEvent(semaWaitTimer, threadID);
+		if (cyclesLeft < 0)
+			cyclesLeft = 0;
 		Memory::Write_U32((u32) cyclesToUs(cyclesLeft), timeoutPtr);
 	}
 
 	__KernelResumeThreadFromWait(threadID, result);
 	wokeThreads = true;
 	return true;
+}
+
+void __KernelSemaBeginCallback(SceUID threadID, SceUID prevCallbackId)
+{
+	SceUID pauseKey = prevCallbackId == 0 ? threadID : prevCallbackId;
+
+	u32 error;
+	SceUID semaID = __KernelGetWaitID(threadID, WAITTYPE_SEMA, error);
+	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
+	Semaphore *s = semaID == 0 ? NULL : kernelObjects.Get<Semaphore>(semaID, error);
+	if (s)
+	{
+		if (s->pausedWaitTimeouts.find(pauseKey) != s->pausedWaitTimeouts.end())
+			WARN_LOG_REPORT(HLE, "sceKernelWaitSemaCB: Callback %08x triggered within itself, should not happen (PSP crashes.)", prevCallbackId);
+
+		if (timeoutPtr != 0 && semaWaitTimer != -1)
+		{
+			u64 cyclesLeft = CoreTiming::UnscheduleEvent(semaWaitTimer, threadID);
+			s->pausedWaitTimeouts[pauseKey] = CoreTiming::GetTicks() + cyclesLeft;
+		}
+		else
+			s->pausedWaitTimeouts[pauseKey] = 0;
+
+		// TODO: Hmm, what about priority/fifo order?  Does it lose its place in line?
+		s->waitingThreads.erase(std::remove(s->waitingThreads.begin(), s->waitingThreads.end(), threadID), s->waitingThreads.end());
+		s->ns.numWaitThreads--;
+
+		DEBUG_LOG(HLE, "sceKernelWaitSemaCB: Suspending sema wait for callback");
+	}
+	else
+		WARN_LOG_REPORT(HLE, "sceKernelWaitSemaCB: beginning callback with bad wait id?");
+}
+
+void __KernelSemaEndCallback(SceUID threadID, SceUID prevCallbackId, u32 &returnValue)
+{
+	SceUID pauseKey = prevCallbackId == 0 ? threadID : prevCallbackId;
+
+	// Note: Cancel does not affect suspended semaphore waits.
+
+	u32 error;
+	SceUID semaID = __KernelGetWaitID(threadID, WAITTYPE_SEMA, error);
+	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
+	Semaphore *s = semaID == 0 ? NULL : kernelObjects.Get<Semaphore>(semaID, error);
+	if (!s || s->pausedWaitTimeouts.find(pauseKey) == s->pausedWaitTimeouts.end())
+	{
+		// TODO: Since it was deleted, we don't know how long was actually left.
+		// For now, we just say the full time was taken.
+		if (timeoutPtr != 0 && semaWaitTimer != -1)
+			Memory::Write_U32(0, timeoutPtr);
+
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_DELETE);
+		return;
+	}
+
+	u64 waitDeadline = s->pausedWaitTimeouts[pauseKey];
+	s->pausedWaitTimeouts.erase(pauseKey);
+	s->ns.numWaitThreads++;
+
+	bool wokeThreads;
+	// Attempt to unlock.
+	if (__KernelUnlockSemaForThread(s, threadID, error, 0, wokeThreads))
+		return;
+
+	// We only check if it timed out if it couldn't unlock.
+	s64 cyclesLeft = waitDeadline - CoreTiming::GetTicks();
+	if (cyclesLeft < 0 && waitDeadline != 0)
+	{
+		if (timeoutPtr != 0 && semaWaitTimer != -1)
+			Memory::Write_U32(0, timeoutPtr);
+
+		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+		s->ns.numWaitThreads--;
+	}
+	else
+	{
+		// TODO: Should this not go at the end?
+		s->waitingThreads.push_back(threadID);
+
+		DEBUG_LOG(HLE, "sceKernelWaitSemaCB: Resuming sema wait for callback");
+	}
 }
 
 // Resume all waiting threads (for delete / cancel.)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1195,6 +1195,26 @@ void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 time
 	// TODO: Remove thread from Ready queue?
 }
 
+void __KernelWaitCallbacksCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr)
+{
+	if (!dispatchEnabled)
+	{
+		WARN_LOG_REPORT(HLE, "Ignoring wait, dispatching disabled... right thing to do?");
+		return;
+	}
+
+	Thread *thread = __GetCurrentThread();
+	thread->nt.waitID = waitID;
+	thread->nt.waitType = type;
+	__KernelChangeThreadState(thread, THREADSTATUS_WAIT);
+	// TODO: Probably not...?
+	thread->nt.numReleases++;
+	thread->waitInfo.waitValue = waitValue;
+	thread->waitInfo.timeoutPtr = timeoutPtr;
+
+	__KernelForceCallbacks();
+}
+
 void hleScheduledWakeup(u64 userdata, int cyclesLate)
 {
 	SceUID threadID = (SceUID)userdata;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2765,6 +2765,20 @@ void ActionAfterCallback::run(MipsCall &call) {
 	}
 }
 
+bool __KernelCurHasReadyCallbacks() {
+	if (readyCallbacksCount == 0)
+		return false;
+
+	Thread *thread = __GetCurrentThread();
+	for (int i = 0; i < THREAD_CALLBACK_NUM_TYPES; i++) {
+		if (thread->readyCallbacks[i].size()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // Check callbacks on the current thread only.
 // Returns true if any callbacks were processed on the current thread.
 bool __KernelCheckThreadCallbacks(Thread *thread, bool force)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -234,6 +234,7 @@ public:
 		p.Do(waitID);
 		p.Do(waitInfo);
 		p.Do(isProcessingCallbacks);
+		p.Do(currentCallbackId);
 
 		p.DoMarker("ActionAfterMipsCall");
 
@@ -258,6 +259,7 @@ public:
 	int waitID;
 	ThreadWaitInfo waitInfo;
 	bool isProcessingCallbacks;
+	SceUID currentCallbackId;
 
 	Action *chainedAction;
 };
@@ -391,9 +393,9 @@ public:
 	{
 		p.Do(nt);
 		p.Do(waitInfo);
-		p.Do(sleeping);
 		p.Do(moduleId);
 		p.Do(isProcessingCallbacks);
+		p.Do(currentMipscallId);
 		p.Do(currentCallbackId);
 		p.Do(context);
 
@@ -417,11 +419,11 @@ public:
 	NativeThread nt;
 
 	ThreadWaitInfo waitInfo;
-	bool sleeping;
 	SceUID moduleId;
 
 	bool isProcessingCallbacks;
-	u32 currentCallbackId;
+	u32 currentMipscallId;
+	SceUID currentCallbackId;
 
 	ThreadContext context;
 
@@ -496,8 +498,13 @@ struct ThreadList
 	}
 };
 
-void __KernelExecuteMipsCallOnCurrentThread(u32 callId, bool reschedAfter);
+struct WaitTypeFuncs
+{
+	WaitBeginCallbackFunc beginFunc;
+	WaitEndCallbackFunc endFunc;
+};
 
+void __KernelExecuteMipsCallOnCurrentThread(u32 callId, bool reschedAfter);
 
 Thread *__KernelCreateThread(SceUID &id, SceUID moduleID, const char *name, u32 entryPoint, u32 priority, int stacksize, u32 attr);
 void __KernelResetThread(Thread *t);
@@ -538,6 +545,9 @@ int actionAfterMipsCall;
 
 // This seems nasty
 SceUID curModule;
+
+// Doesn't need state saving.
+WaitTypeFuncs waitTypeFuncs[NUM_WAITTYPES];
 
 //////////////////////////////////////////////////////////////////////////
 //STATE END
@@ -623,6 +633,7 @@ void __KernelThreadingInit()
 	u32 blockSize = 4 * 4 + 4 * 2 * 3;  // One 16-byte thread plus 3 8-byte "hacks"
 
 	dispatchEnabled = true;
+	memset(waitTypeFuncs, 0, sizeof(waitTypeFuncs));
 
 	currentThread = 0;
 	g_inCbCount = 0;
@@ -892,6 +903,18 @@ SceUID __KernelGetWaitID(SceUID threadID, WaitType type, u32 &error)
 	else
 	{
 		ERROR_LOG(HLE, "__KernelGetWaitID ERROR: thread %i", threadID);
+		return 0;
+	}
+}
+
+SceUID __KernelGetCurrentCallbackID(SceUID threadID, u32 &error)
+{
+	Thread *t = kernelObjects.Get<Thread>(threadID, error);
+	if (t)
+		return t->currentCallbackId;
+	else
+	{
+		ERROR_LOG(HLE, "__KernelGetCurrentCallbackID ERROR: thread %i", threadID);
 		return 0;
 	}
 }
@@ -1405,7 +1428,8 @@ void __KernelResetThread(Thread *t)
 
 	t->nt.exitStatus = SCE_KERNEL_ERROR_NOT_DORMANT;
 	t->isProcessingCallbacks = false;
-	// TODO: Is this correct?
+	t->currentCallbackId = 0;
+	t->currentMipscallId = 0;
 	t->pendingMipsCalls.clear();
 
 	t->context.r[MIPS_REG_RA] = threadReturnHackAddr; //hack! TODO fix
@@ -2283,6 +2307,7 @@ void ActionAfterMipsCall::run(MipsCall &call) {
 		thread->nt.waitID = waitID;
 		thread->waitInfo = waitInfo;
 		thread->isProcessingCallbacks = isProcessingCallbacks;
+		thread->currentCallbackId = currentCallbackId;
 	}
 
 	if (chainedAction) {
@@ -2295,7 +2320,7 @@ ActionAfterMipsCall *Thread::getRunningCallbackAction()
 {
 	if (this->GetUID() == currentThread && g_inCbCount > 0)
 	{
-		MipsCall *call = mipsCalls.get(this->currentCallbackId);
+		MipsCall *call = mipsCalls.get(this->currentMipscallId);
 		ActionAfterMipsCall *action = 0;
 		if (call)
 			action = dynamic_cast<ActionAfterMipsCall *>(call->doAfter);
@@ -2316,7 +2341,7 @@ void Thread::setReturnValue(u32 retval)
 {
 	if (this->GetUID() == currentThread) {
 		if (g_inCbCount) {
-			u32 callId = this->currentCallbackId;
+			u32 callId = this->currentMipscallId;
 			MipsCall *call = mipsCalls.get(callId);
 			if (call) {
 				call->setReturnValue(retval);
@@ -2335,7 +2360,7 @@ void Thread::setReturnValue(u64 retval)
 {
 	if (this->GetUID() == currentThread) {
 		if (g_inCbCount) {
-			u32 callId = this->currentCallbackId;
+			u32 callId = this->currentMipscallId;
 			MipsCall *call = mipsCalls.get(callId);
 			if (call) {
 				call->setReturnValue(retval);
@@ -2516,11 +2541,19 @@ void __KernelCallAddress(Thread *thread, u32 entryPoint, Action *afterAction, co
 		after->waitID = thread->nt.waitID;
 		after->waitInfo = thread->waitInfo;
 		after->isProcessingCallbacks = thread->isProcessingCallbacks;
+		after->currentCallbackId = thread->currentCallbackId;
 
 		afterAction = after;
 
-		// Release thread from waiting
-		thread->nt.waitType = WAITTYPE_NONE;
+		if (thread->nt.waitType != WAITTYPE_NONE) {
+			// If it's a callback, tell the wait to stop.
+			if (waitTypeFuncs[thread->nt.waitType].beginFunc != NULL && cbId > 0) {
+				waitTypeFuncs[thread->nt.waitType].beginFunc(after->threadID, thread->currentCallbackId);
+			}
+
+			// Release thread from waiting
+			thread->nt.waitType = WAITTYPE_NONE;
+		}
 
 		__KernelChangeThreadState(thread, THREADSTATUS_READY);
 	}
@@ -2583,7 +2616,7 @@ void __KernelExecuteMipsCallOnCurrentThread(u32 callId, bool reschedAfter)
 	call->savedV0 = currentMIPS->r[MIPS_REG_V0];
 	call->savedV1 = currentMIPS->r[MIPS_REG_V1];
 	call->savedIdRegister = currentMIPS->r[MIPS_REG_CALL_ID];
-	call->savedId = cur->currentCallbackId;
+	call->savedId = cur->currentMipscallId;
 	call->reschedAfter = reschedAfter;
 
 	// Set up the new state
@@ -2592,7 +2625,7 @@ void __KernelExecuteMipsCallOnCurrentThread(u32 callId, bool reschedAfter)
 	// We put this two places in case the game overwrites it.
 	// We may want it later to "inject" return values.
 	currentMIPS->r[MIPS_REG_CALL_ID] = callId;
-	cur->currentCallbackId = callId;
+	cur->currentMipscallId = callId;
 	for (int i = 0; i < call->numArgs; i++) {
 		currentMIPS->r[MIPS_REG_A0 + i] = call->args[i];
 	}
@@ -2611,7 +2644,7 @@ void __KernelReturnFromMipsCall()
 		return;
 	}
 
-	u32 callId = cur->currentCallbackId;
+	u32 callId = cur->currentMipscallId;
 	if (currentMIPS->r[MIPS_REG_CALL_ID] != callId)
 		WARN_LOG_REPORT(HLE, "__KernelReturnFromMipsCall(): s0 is %08x != %08x", currentMIPS->r[MIPS_REG_CALL_ID], callId);
 
@@ -2633,11 +2666,17 @@ void __KernelReturnFromMipsCall()
 	currentMIPS->r[MIPS_REG_V0] = call->savedV0;
 	currentMIPS->r[MIPS_REG_V1] = call->savedV1;
 	currentMIPS->r[MIPS_REG_CALL_ID] = call->savedIdRegister;
-	cur->currentCallbackId = call->savedId;
+	cur->currentMipscallId = call->savedId;
 
 	if (call->cbId != 0)
 		g_inCbCount--;
 	currentCallbackThreadID = 0;
+
+	if (cur->nt.waitType != WAITTYPE_NONE)
+	{
+		if (waitTypeFuncs[cur->nt.waitType].endFunc != NULL && call->cbId > 0)
+			waitTypeFuncs[cur->nt.waitType].endFunc(cur->GetUID(), cur->currentCallbackId, currentMIPS->r[MIPS_REG_V0]);
+	}
 
 	// yeah! back in the real world, let's keep going. Should we process more callbacks?
 	if (!__KernelExecutePendingMipsCalls(cur, call->reschedAfter))
@@ -2885,6 +2924,12 @@ u32 __KernelNotifyCallbackType(RegisteredCallbackType type, SceUID cbId, int not
 
 	// checkCallbacks on other threads?
 	return 0;
+}
+
+void __KernelRegisterWaitTypeFuncs(WaitType type, WaitBeginCallbackFunc beginFunc, WaitEndCallbackFunc endFunc)
+{
+	waitTypeFuncs[type].beginFunc = beginFunc;
+	waitTypeFuncs[type].endFunc = endFunc;
 }
 
 std::vector<DebugThreadInfo> GetThreadsInfo()

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -155,6 +155,7 @@ u32 __KernelGetWaitTimeoutPtr(SceUID threadID, u32 &error);
 SceUID __KernelGetWaitID(SceUID threadID, WaitType type, u32 &error);
 SceUID __KernelGetCurrentCallbackID(SceUID threadID, u32 &error);
 void __KernelWaitCurThread(WaitType type, SceUID waitId, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason);
+void __KernelWaitCallbacksCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr);
 void __KernelReSchedule(const char *reason = "no reason");
 void __KernelReSchedule(bool doCallbacks, const char *reason);
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -65,7 +65,8 @@ struct SceKernelSysClock {
 };
 
 
-enum WaitType //probably not the real values
+// TODO: Map these to PSP wait types.
+enum WaitType
 {
 	WAITTYPE_NONE = 0,
 	WAITTYPE_SLEEP = 1,
@@ -84,8 +85,16 @@ enum WaitType //probably not the real values
 	WAITTYPE_LWMUTEX = 14,
 	WAITTYPE_CTRL = 15,
 	WAITTYPE_IO = 16,
+
+	NUM_WAITTYPES
 };
 
+// Suspend wait and timeout while a thread enters a callback.
+typedef void (* WaitBeginCallbackFunc)(SceUID threadID, SceUID prevCallbackId);
+// Resume wait and timeout as a thread exits a callback.
+typedef void (* WaitEndCallbackFunc)(SceUID threadID, SceUID prevCallbackId, u32 &returnValue);
+
+void __KernelRegisterWaitTypeFuncs(WaitType type, WaitBeginCallbackFunc beginFunc, WaitEndCallbackFunc endFunc);
 
 struct ThreadContext
 {
@@ -144,6 +153,7 @@ inline u32 __KernelResumeThreadFromWait(SceUID threadID, s64 retval)
 u32 __KernelGetWaitValue(SceUID threadID, u32 &error);
 u32 __KernelGetWaitTimeoutPtr(SceUID threadID, u32 &error);
 SceUID __KernelGetWaitID(SceUID threadID, WaitType type, u32 &error);
+SceUID __KernelGetCurrentCallbackID(SceUID threadID, u32 &error);
 void __KernelWaitCurThread(WaitType type, SceUID waitId, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason);
 void __KernelReSchedule(const char *reason = "no reason");
 void __KernelReSchedule(bool doCallbacks, const char *reason);

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -216,6 +216,7 @@ bool __KernelInCallback();
 // Should be called by (nearly) all ...CB functions.
 bool __KernelCheckCallbacks();
 bool __KernelForceCallbacks();
+bool __KernelCurHasReadyCallbacks();
 class Thread;
 void __KernelSwitchContext(Thread *target, const char *reason);
 bool __KernelExecutePendingMipsCalls(Thread *currentThread, bool reschedAfter);


### PR DESCRIPTION
This only does semaphores, mutexes and lwmutexes so far.

They're still somewhat broken, this doesn't fix all the issues in #1082.  But, it does improve things, fix Patapon 2 back to how it was before again, and the games I tested were all fine still.

-[Unknown]
