### PR TITLE
iOS: Don't lock input state for so long

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -163,11 +163,13 @@ ViewController* sharedViewController;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-	lock_guard guard(input_state.lock);
-	pad_buttons_down |= pad_buttons_async_set;
-	pad_buttons_down &= ~pad_buttons_async_clear;
-	input_state.pad_buttons = pad_buttons_down;
-	UpdateInputState(&input_state);
+	{
+		lock_guard guard(input_state.lock);
+		pad_buttons_down |= pad_buttons_async_set;
+		pad_buttons_down &= ~pad_buttons_async_clear;
+		input_state.pad_buttons = pad_buttons_down;
+		UpdateInputState(&input_state);
+	}
 
 	{
 		lock_guard guard(input_state.lock);


### PR DESCRIPTION
Shouldn't be for the entire duration of the function.

-[Unknown]
