### PR TITLE
Read structs directly from PSP ram on little endian

### DIFF
--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -253,6 +253,13 @@ void WriteStruct(u32 address, T *ptr)
 	memcpy(GetPointer(address), ptr, sz);
 }
 
+// Expect this to be some form of auto class on big endian.
+template<class T>
+T *GetStruct(u32 address)
+{
+	return (T *)GetPointer(address);
+}
+
 const char *GetAddressName(u32 address);
 
 };


### PR DESCRIPTION
On big endian, which doesn't even really work atm, this can be an auto class.

Not a huge performance gain but, it also makes the code cleaner anyway.

-[Unknown]
