### PR TITLE
Symbol map fixes

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -60,6 +60,7 @@ void Config::Load(const char *iniFileName)
 	general->Get("Recent", recentIsos);
 	general->Get("WindowX", &iWindowX, 40);
 	general->Get("WindowY", &iWindowY, 100);
+	general->Get("AutoSaveSymbolMap", &bAutoSaveSymbolMap, false);
 
 	if (recentIsos.size() > MAX_RECENT)
 		recentIsos.resize(MAX_RECENT);
@@ -139,6 +140,7 @@ void Config::Save()
 		general->Set("Recent", recentIsos);
 		general->Set("WindowX", iWindowX);
 		general->Set("WindowY", iWindowY);
+		general->Set("AutoSaveSymbolMap", bAutoSaveSymbolMap);
 
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 		cpu->Set("Jit", bJit);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -44,6 +44,7 @@ public:
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;
 	bool bJit;
+	bool bAutoSaveSymbolMap;
 	std::string sReportHost;
 	std::vector<std::string> recentIsos;
 

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -83,8 +83,7 @@ void Core_WaitInactive()
 
 void Core_WaitInactive(int milliseconds)
 {
-	while (!Core_IsInactive())
-		m_hInactiveEvent.wait_for(m_hInactiveMutex, milliseconds);
+	m_hInactiveEvent.wait_for(m_hInactiveMutex, milliseconds);
 }
 
 void UpdateScreenScale() {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -391,6 +391,10 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			dontadd = true;
 		}
 	}
+	else if (host->AttemptLoadSymbolMap())
+	{
+		dontadd = true;
+	}
 
 	INFO_LOG(LOADER,"Module %s: %08x %08x %08x", modinfo->name, modinfo->gp, modinfo->libent,modinfo->libstub);
 

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -57,6 +57,7 @@ public:
 
 	virtual bool IsDebuggingEnabled() {return true;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
+	virtual void SaveSymbolMap() {}
 	virtual void SetWindowTitle(const char *message) {}
 
 	virtual void SendCoreWait(bool) {}

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -76,6 +76,8 @@ bool PSP_Init(const CoreParameter &coreParam, std::string *error_string)
 	mipsr4k.Reset();
 	mipsr4k.pc = 0;
 
+	host->AttemptLoadSymbolMap();
+
 	if (coreParameter.enableSound)
 	{
 		mixer = new PSPMixer();
@@ -125,6 +127,9 @@ void PSP_Shutdown()
 	pspFileSystem.Shutdown();
 
 	CoreTiming::Shutdown();
+
+	if (g_Config.bAutoSaveSymbolMap)
+		host->SaveSymbolMap();
 
 	if (coreParameter.enableSound)
 	{

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -80,7 +80,6 @@ EmuScreen::EmuScreen(const std::string &filename) : invalid_(true) {
 	}
 
 	host->BootDone();
-	host->AttemptLoadSymbolMap();
 	host->UpdateDisassembly();
 
 #ifdef _WIN32
@@ -99,8 +98,6 @@ EmuScreen::EmuScreen(const std::string &filename) : invalid_(true) {
 EmuScreen::~EmuScreen() {
 	if (!invalid_) {
 		// If we were invalid, it would already be shutdown.
-
-		// symbolMap.SaveSymbolMap(SymbolMapFilename(coreParam.fileToStart).c_str());
 		PSP_Shutdown();
 	}
 }

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -155,7 +155,16 @@ static std::string SymbolMapFilename(const char *currentFilename)
 
 bool WindowsHost::AttemptLoadSymbolMap()
 {
-	return symbolMap.LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
+	if (loadedSymbolMap_)
+		return true;
+	loadedSymbolMap_ = symbolMap.LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
+	return loadedSymbolMap_;
+}
+
+void WindowsHost::SaveSymbolMap()
+{
+	symbolMap.SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
+	loadedSymbolMap_ = false;
 }
 
 void WindowsHost::AddSymbol(std::string name, u32 addr, u32 size, int type=0) 

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -28,6 +28,7 @@ public:
 		mainWindow_ = mainWindow;
 		displayWindow_ = displayWindow;
 		input = getInputDevices();
+		loadedSymbolMap_ = false;
 	}
 	void UpdateMemView();
 	void UpdateDisassembly();
@@ -47,10 +48,12 @@ public:
 	bool IsDebuggingEnabled();
 	void BootDone();
 	bool AttemptLoadSymbolMap();
+	void SaveSymbolMap();
 	void SetWindowTitle(const char *message);
 
 private:
 	HWND displayWindow_;
 	HWND mainWindow_;
 	std::list<std::shared_ptr<InputDevice>> input;
+	bool loadedSymbolMap_;
 };

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -356,8 +356,6 @@ namespace MainWindow
 				break;
 
 			case ID_EMULATION_STOP:
-				if (disasmWindow[0])
-					SendMessage(disasmWindow[0]->GetDlgHandle(), WM_COMMAND, IDC_STOP, 0);
 				if (memoryWindow[0])
 					SendMessage(memoryWindow[0]->GetDlgHandle(), WM_CLOSE, 0, 0);
 


### PR DESCRIPTION
Load/save the symbol map properly, add a setting to do it automatically.  Moved it to Core/System since it's already in sceKernelModule and it kinda makes more sense there anyhow.

Also fixes emulation -> stop to go back to the menu, which was kinda related since it didn't seem like quitting saved the symbol map reliably.

I've grown quite fond of symbol files now.

-[Unknown]
