### PR TITLE
More sceUtility* changes

### DIFF
--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -26,6 +26,9 @@ class PointerWrap;
 #define SCE_UTILITY_DIALOG_RESULT_CANCEL				1
 #define SCE_UTILITY_DIALOG_RESULT_ABORT					2
 
+const int SCE_ERROR_UTILITY_INVALID_STATUS = 0x80110001;
+const int SCE_ERROR_UTILITY_WRONG_TYPE     = 0x80110005;
+
 typedef struct
 {
 	unsigned int size;	/** Size of the structure */

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -230,6 +230,12 @@ int PSPMsgDialog::Update()
 	return 0;
 }
 
+int PSPMsgDialog::Abort()
+{
+	// TODO: Probably not exactly the same?
+	return PSPDialog::Shutdown();
+}
+
 int PSPMsgDialog::Shutdown()
 {
 	return PSPDialog::Shutdown();

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -61,6 +61,7 @@ public:
 	virtual int Update();
 	virtual int Shutdown();
 	virtual void DoState(PointerWrap &p);
+	int Abort();
 
 private :
 	void DisplayBack();

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -65,7 +65,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 	// Ignore if already running
 	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
 	{
-		return -1;
+		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -40,7 +40,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN)
 	{
 		ERROR_LOG(HLE,"A save request is already running !");
-		return 0;
+		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
 
 	int size = Memory::Read_U32(paramAddr);

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -379,7 +379,7 @@ int PSPSaveDialog::Update()
 
 	if (status != SCE_UTILITY_STATUS_RUNNING)
 	{
-		return 0;
+		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
 
 	if (!param.GetPspParam()) {
@@ -798,6 +798,9 @@ int PSPSaveDialog::Update()
 
 int PSPSaveDialog::Shutdown()
 {
+	if (status != SCE_UTILITY_STATUS_FINISHED)
+		return SCE_ERROR_UTILITY_INVALID_STATUS;
+
 	PSPDialog::Shutdown();
 	param.SetPspParam(0);
 

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -245,6 +245,19 @@ int sceUtilityMsgDialogGetStatus()
 	return status;
 }
 
+int sceUtilityMsgDialogAbort()
+{
+	if (currentDialogType != UTILITY_DIALOG_MSG)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogShutdownStart(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogActive = false;
+
+	DEBUG_LOG(HLE, "sceUtilityMsgDialogAbort()");
+	return msgDialog.Abort();
+}
+
 
 // On screen keyboard
 
@@ -504,7 +517,7 @@ const HLEFunction sceUtility[] =
 	{0x2ad8e239, &WrapI_U<sceUtilityMsgDialogInitStart>, "sceUtilityMsgDialogInitStart"},
 	{0x95fc253b, &WrapI_I<sceUtilityMsgDialogUpdate>, "sceUtilityMsgDialogUpdate"},
 	{0x9a1c91d7, &WrapI_V<sceUtilityMsgDialogGetStatus>, "sceUtilityMsgDialogGetStatus"},
-	{0x4928bd96, 0, "sceUtilityMsgDialogAbort"},
+	{0x4928bd96, &WrapI_V<sceUtilityMsgDialogAbort>, "sceUtilityMsgDialogAbort"},
 
 	{0x9790b33c, &WrapI_V<sceUtilitySavedataShutdownStart>, "sceUtilitySavedataShutdownStart"},
 	{0x50c4cd57, &WrapI_U<sceUtilitySavedataInitStart>, "sceUtilitySavedataInitStart"},
@@ -556,7 +569,7 @@ const HLEFunction sceUtility[] =
 	{0x32E32DCB, 0, "sceUtilityGamedataInstallShutdownStart"},
 	{0x4AECD179, 0, "sceUtilityGamedataInstallUpdate"},
 	{0xB57E95D9, &WrapI_V<sceUtilityGamedataInstallGetStatus>, "sceUtilityGamedataInstallGetStatus"},
-	{0x180F7B62, 0, "sceUtilityGamedataInstallAbortFunction"},
+	{0x180F7B62, 0, "sceUtilityGamedataInstallAbort"},
 
 	{0x16D02AF0, 0, "sceUtilityNpSigninInitStart"},
 	{0xE19C97D6, 0, "sceUtilityNpSigninShutdownStart"},

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -33,18 +33,33 @@
 const int SCE_ERROR_MODULE_BAD_ID = 0x80111101;
 const int SCE_ERROR_AV_MODULE_BAD_ID = 0x80110F01;
 
-PSPSaveDialog saveDialog;
-PSPMsgDialog msgDialog;
-PSPOskDialog oskDialog;
-PSPPlaceholderDialog netDialog;
+enum UtilityDialogType {
+	UTILITY_DIALOG_NONE,
+	UTILITY_DIALOG_SAVEDATA,
+	UTILITY_DIALOG_MSG,
+	UTILITY_DIALOG_OSK,
+	UTILITY_DIALOG_NET,
+};
+
+// Only a single dialog is allowed at a time.
+static UtilityDialogType currentDialogType;
+static bool currentDialogActive;
+static PSPSaveDialog saveDialog;
+static PSPMsgDialog msgDialog;
+static PSPOskDialog oskDialog;
+static PSPPlaceholderDialog netDialog;
 
 void __UtilityInit()
 {
+	currentDialogType = UTILITY_DIALOG_NONE;
+	currentDialogActive = false;
 	SavedataParam::Init();
 }
 
 void __UtilityDoState(PointerWrap &p)
 {
+	p.Do(currentDialogType);
+	p.Do(currentDialogActive);
 	saveDialog.DoState(p);
 	msgDialog.DoState(p);
 	oskDialog.DoState(p);
@@ -62,25 +77,52 @@ void __UtilityShutdown()
 
 int sceUtilitySavedataInitStart(u32 paramAddr)
 {
+	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_SAVEDATA)
+	{
+		WARN_LOG(HLE, "sceUtilitySavedataInitStart(%08x): wrong dialog type", paramAddr);
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogType = UTILITY_DIALOG_SAVEDATA;
+	currentDialogActive = true;
+
 	DEBUG_LOG(HLE,"sceUtilitySavedataInitStart(%08x)", paramAddr);
 	return saveDialog.Init(paramAddr);
 }
 
 int sceUtilitySavedataShutdownStart()
 {
+	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
+	{
+		WARN_LOG(HLE, "sceUtilitySavedataShutdownStart(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogActive = false;
+
 	DEBUG_LOG(HLE,"sceUtilitySavedataShutdownStart()");
 	return saveDialog.Shutdown();
 }
 
 int sceUtilitySavedataGetStatus()
 {
+	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
+	{
+		WARN_LOG(HLE, "sceUtilitySavedataGetStatus(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
 	int status = saveDialog.GetStatus();
-	DEBUG_LOG(HLE,"%08x=sceUtilitySavedataGetStatus()", status);
+	DEBUG_LOG(HLE, "%08x=sceUtilitySavedataGetStatus()", status);
 	return status;
 }
 
 int sceUtilitySavedataUpdate(int animSpeed)
 {
+	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
+	{
+		WARN_LOG(HLE, "sceUtilitySavedataUpdate(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
 	DEBUG_LOG(HLE,"sceUtilitySavedataUpdate(%d)", animSpeed);
 	return hleDelayResult(saveDialog.Update(), "savedata update", 300);
 }
@@ -150,26 +192,54 @@ u32 sceUtilityUnloadModule(u32 module)
 
 int sceUtilityMsgDialogInitStart(u32 structAddr)
 {
-	DEBUG_LOG(HLE,"sceUtilityMsgDialogInitStart(%i)", structAddr);
+	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_MSG)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogInitStart(%08x): wrong dialog type", structAddr);
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogType = UTILITY_DIALOG_MSG;
+	currentDialogActive = true;
+
+	DEBUG_LOG(HLE, "sceUtilityMsgDialogInitStart(%08x)", structAddr);
 	return msgDialog.Init(structAddr);
 }
 
-int sceUtilityMsgDialogShutdownStart(u32 unknown)
+int sceUtilityMsgDialogShutdownStart()
 {
-	DEBUG_LOG(HLE,"sceUtilityMsgDialogShutdownStart(%i)", unknown);
+	if (currentDialogType != UTILITY_DIALOG_MSG)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogShutdownStart(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogActive = false;
+
+	DEBUG_LOG(HLE, "sceUtilityMsgDialogShutdownStart()");
 	return msgDialog.Shutdown();
 }
 
 int sceUtilityMsgDialogUpdate(int animSpeed)
 {
+	if (currentDialogType != UTILITY_DIALOG_MSG)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogUpdate(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
 	DEBUG_LOG(HLE,"sceUtilityMsgDialogUpdate(%i)", animSpeed);
 	return msgDialog.Update();
 }
 
 int sceUtilityMsgDialogGetStatus()
 {
-	DEBUG_LOG(HLE,"sceUtilityMsgDialogGetStatus()");
-	return msgDialog.GetStatus();
+	if (currentDialogType != UTILITY_DIALOG_MSG)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogGetStatus(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
+	int status = msgDialog.GetStatus();
+	DEBUG_LOG(HLE, "%08x=sceUtilityMsgDialogGetStatus()", status);
+	return status;
 }
 
 
@@ -177,74 +247,104 @@ int sceUtilityMsgDialogGetStatus()
 
 int sceUtilityOskInitStart(u32 oskPtr)
 {
-	DEBUG_LOG(HLE,"sceUtilityOskInitStart(%i)", PARAM(0));
+	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_OSK)
+	{
+		WARN_LOG(HLE, "sceUtilityOskInitStart(%08x): wrong dialog type", oskPtr);
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogType = UTILITY_DIALOG_OSK;
+	currentDialogActive = true;
+
+	DEBUG_LOG(HLE, "sceUtilityOskInitStart(%08x)", oskPtr);
 	return oskDialog.Init(oskPtr);
 }
 
 int sceUtilityOskShutdownStart()
 {
-	DEBUG_LOG(HLE,"sceUtilityOskShutdownStart(%i)", PARAM(0));
+	if (currentDialogType != UTILITY_DIALOG_OSK)
+	{
+		WARN_LOG(HLE, "sceUtilityOskShutdownStart(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+	currentDialogActive = false;
+
+	DEBUG_LOG(HLE, "sceUtilityOskShutdownStart()");
 	return oskDialog.Shutdown();
 }
 
-int sceUtilityOskUpdate(unsigned int unknown)
+int sceUtilityOskUpdate(int animSpeed)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityOskUpdate(%i)", unknown);
+	if (currentDialogType != UTILITY_DIALOG_OSK)
+	{
+		WARN_LOG(HLE, "sceUtilityMsgDialogUpdate(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
+	DEBUG_LOG(HLE, "sceUtilityOskUpdate(%i)", animSpeed);
 	return oskDialog.Update();
 }
 
 int sceUtilityOskGetStatus()
 {
+	if (currentDialogType != UTILITY_DIALOG_OSK)
+	{
+		WARN_LOG(HLE, "sceUtilityOskGetStatus(): wrong dialog type");
+		return SCE_ERROR_UTILITY_WRONG_TYPE;
+	}
+
 	int status = oskDialog.GetStatus();
+
 	// Seems that 4 is the cancelled status for OSK?
 	if (status == 4)
 	{
 		status = 5;
 	}
+
+	DEBUG_LOG(HLE, "%08x=sceUtilityOskGetStatus()", status);
 	return status;
 }
 
 
 int sceUtilityNetconfInitStart(u32 structAddr)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfInitStart(%08x)", structAddr);
+	ERROR_LOG(HLE, "UNIMPL sceUtilityNetconfInitStart(%08x)", structAddr);
 	return netDialog.Init();
 }
 
 int sceUtilityNetconfShutdownStart(unsigned int unknown)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfShutdownStart(%i)", unknown);
+	ERROR_LOG(HLE, "UNIMPL sceUtilityNetconfShutdownStart(%i)", unknown);
 	return netDialog.Shutdown();
 }
 
 int sceUtilityNetconfUpdate(int animSpeed)
 {
-	DEBUG_LOG(HLE,"FAKE sceUtilityNetconfUpdate(%i)", animSpeed);
+	ERROR_LOG(HLE, "UNIMPL sceUtilityNetconfUpdate(%i)", animSpeed);
 	return netDialog.Update();
 }
 
 int sceUtilityNetconfGetStatus()
 {
-	DEBUG_LOG(HLE,"sceUtilityNetconfGetStatus()");
+	ERROR_LOG(HLE, "UNIMPL sceUtilityNetconfGetStatus()");
 	return netDialog.GetStatus();
 }
 
 int sceUtilityScreenshotGetStatus()
 {
 	u32 retval =  0;//__UtilityGetStatus();
-	DEBUG_LOG(HLE,"%i=sceUtilityScreenshotGetStatus()", retval);
+	ERROR_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotGetStatus()", retval);
 	return retval;
 }
 
 void sceUtilityGamedataInstallInitStart(u32 unkown)
 {
-	DEBUG_LOG(HLE,"UNIMPL sceUtilityGamedataInstallInitStart(%i)", unkown);
+	ERROR_LOG(HLE, "UNIMPL sceUtilityGamedataInstallInitStart(%i)", unkown);
 }
 
 int sceUtilityGamedataInstallGetStatus()
 {
 	u32 retval = 0;//__UtilityGetStatus();
-	DEBUG_LOG(HLE,"UNIMPL %i=sceUtilityGamedataInstallGetStatus()", retval);
+	ERROR_LOG(HLE, "UNIMPL %i=sceUtilityGamedataInstallGetStatus()", retval);
 	return retval;
 }
 
@@ -386,55 +486,55 @@ void sceUtilityInstallInitStart(u32 unknown)
 const HLEFunction sceUtility[] = 
 {
 	{0x1579a159, &WrapU_U<sceUtilityLoadNetModule>, "sceUtilityLoadNetModule"},
-	{0x64d50c56, &WrapU_U<sceUtilityUnloadNetModule>, "sceUtilityUnloadNetModule"}, 
+	{0x64d50c56, &WrapU_U<sceUtilityUnloadNetModule>, "sceUtilityUnloadNetModule"},
 
 
 	{0xf88155f6, &WrapI_U<sceUtilityNetconfShutdownStart>, "sceUtilityNetconfShutdownStart"},
 	{0x4db1e739, &WrapI_U<sceUtilityNetconfInitStart>, "sceUtilityNetconfInitStart"},
 	{0x91e70e35, &WrapI_I<sceUtilityNetconfUpdate>, "sceUtilityNetconfUpdate"},
 	{0x6332aa39, &WrapI_V<sceUtilityNetconfGetStatus>, "sceUtilityNetconfGetStatus"},
-	{0x5eee6548, 0, "sceUtilityCheckNetParam"}, 
-	{0x434d4b3a, 0, "sceUtilityGetNetParam"}, 
+	{0x5eee6548, 0, "sceUtilityCheckNetParam"},
+	{0x434d4b3a, 0, "sceUtilityGetNetParam"},
 	{0x4FED24D8, 0, "sceUtilityGetNetParamLatestID"},
 
-	{0x67af3428, &WrapI_U<sceUtilityMsgDialogShutdownStart>, "sceUtilityMsgDialogShutdownStart"},	
-	{0x2ad8e239, &WrapI_U<sceUtilityMsgDialogInitStart>, "sceUtilityMsgDialogInitStart"},			
-	{0x95fc253b, &WrapI_I<sceUtilityMsgDialogUpdate>, "sceUtilityMsgDialogUpdate"},				 
-	{0x9a1c91d7, &WrapI_V<sceUtilityMsgDialogGetStatus>, "sceUtilityMsgDialogGetStatus"},		
-	{0x4928bd96, 0, "sceUtilityMsgDialogAbort"}, 
+	{0x67af3428, &WrapI_V<sceUtilityMsgDialogShutdownStart>, "sceUtilityMsgDialogShutdownStart"},
+	{0x2ad8e239, &WrapI_U<sceUtilityMsgDialogInitStart>, "sceUtilityMsgDialogInitStart"},
+	{0x95fc253b, &WrapI_I<sceUtilityMsgDialogUpdate>, "sceUtilityMsgDialogUpdate"},
+	{0x9a1c91d7, &WrapI_V<sceUtilityMsgDialogGetStatus>, "sceUtilityMsgDialogGetStatus"},
+	{0x4928bd96, 0, "sceUtilityMsgDialogAbort"},
 
-	{0x9790b33c, &WrapI_V<sceUtilitySavedataShutdownStart>, "sceUtilitySavedataShutdownStart"},	 
-	{0x50c4cd57, &WrapI_U<sceUtilitySavedataInitStart>, "sceUtilitySavedataInitStart"},			 
-	{0xd4b95ffb, &WrapI_I<sceUtilitySavedataUpdate>, "sceUtilitySavedataUpdate"},					
+	{0x9790b33c, &WrapI_V<sceUtilitySavedataShutdownStart>, "sceUtilitySavedataShutdownStart"},
+	{0x50c4cd57, &WrapI_U<sceUtilitySavedataInitStart>, "sceUtilitySavedataInitStart"},
+	{0xd4b95ffb, &WrapI_I<sceUtilitySavedataUpdate>, "sceUtilitySavedataUpdate"},
 	{0x8874dbe0, &WrapI_V<sceUtilitySavedataGetStatus>, "sceUtilitySavedataGetStatus"},
 
 	{0x3dfaeba9, &WrapI_V<sceUtilityOskShutdownStart>, "sceUtilityOskShutdownStart"},
 	{0xf6269b82, &WrapI_U<sceUtilityOskInitStart>, "sceUtilityOskInitStart"},
-	{0x4b85c861, &WrapI_U<sceUtilityOskUpdate>, "sceUtilityOskUpdate"},
+	{0x4b85c861, &WrapI_I<sceUtilityOskUpdate>, "sceUtilityOskUpdate"},
 	{0xf3f76017, &WrapI_V<sceUtilityOskGetStatus>, "sceUtilityOskGetStatus"},
 
 	{0x41e30674, &WrapU_UU<sceUtilitySetSystemParamString>, "sceUtilitySetSystemParamString"},
 	{0x45c18506, 0, "sceUtilitySetSystemParamInt"}, 
-	{0x34b78343, &WrapU_UUU<sceUtilityGetSystemParamString>, "sceUtilityGetSystemParamString"}, 
+	{0x34b78343, &WrapU_UUU<sceUtilityGetSystemParamString>, "sceUtilityGetSystemParamString"},
 	{0xA5DA2406, &WrapU_UU<sceUtilityGetSystemParamInt>, "sceUtilityGetSystemParamInt"},
 
 
-	{0xc492f751, 0, "sceUtilityGameSharingInitStart"}, 
-	{0xefc6f80f, 0, "sceUtilityGameSharingShutdownStart"}, 
-	{0x7853182d, 0, "sceUtilityGameSharingUpdate"}, 
-	{0x946963f3, 0, "sceUtilityGameSharingGetStatus"}, 
+	{0xc492f751, 0, "sceUtilityGameSharingInitStart"},
+	{0xefc6f80f, 0, "sceUtilityGameSharingShutdownStart"},
+	{0x7853182d, 0, "sceUtilityGameSharingUpdate"},
+	{0x946963f3, 0, "sceUtilityGameSharingGetStatus"},
 
-	{0x2995d020, 0, "sceUtility_2995d020"}, 
-	{0xb62a4061, 0, "sceUtility_b62a4061"}, 
-	{0xed0fad38, 0, "sceUtility_ed0fad38"}, 
-	{0x88bc7406, 0, "sceUtility_88bc7406"}, 
+	{0x2995d020, 0, "sceUtility_2995d020"},
+	{0xb62a4061, 0, "sceUtility_b62a4061"},
+	{0xed0fad38, 0, "sceUtility_ed0fad38"},
+	{0x88bc7406, 0, "sceUtility_88bc7406"},
 
-	{0xbda7d894, 0, "sceUtilityHtmlViewerGetStatus"}, 
-	{0xcdc3aa41, 0, "sceUtilityHtmlViewerInitStart"}, 
-	{0xf5ce1134, 0, "sceUtilityHtmlViewerShutdownStart"}, 
-	{0x05afb9e4, 0, "sceUtilityHtmlViewerUpdate"}, 
+	{0xbda7d894, 0, "sceUtilityHtmlViewerGetStatus"},
+	{0xcdc3aa41, 0, "sceUtilityHtmlViewerInitStart"},
+	{0xf5ce1134, 0, "sceUtilityHtmlViewerShutdownStart"},
+	{0x05afb9e4, 0, "sceUtilityHtmlViewerUpdate"},
 
-	{0xc629af26, &WrapU_U<sceUtilityLoadAvModule>, "sceUtilityLoadAvModule"}, 
+	{0xc629af26, &WrapU_U<sceUtilityLoadAvModule>, "sceUtilityLoadAvModule"},
 	{0xf7d8d092, &WrapU_U<sceUtilityUnloadAvModule>, "sceUtilityUnloadAvModule"},
 
 	{0x2a2b3de0, &WrapU_U<sceUtilityLoadModule>, "sceUtilityLoadModule"},
@@ -463,7 +563,7 @@ const HLEFunction sceUtility[] =
 	{0x1281DA8E, &WrapV_U<sceUtilityInstallInitStart>, "sceUtilityInstallInitStart"},
 	{0x5EF1C24A, 0, "sceUtilityInstallShutdownStart"},
 	{0xA03D29BA, 0, "sceUtilityInstallUpdate"},
-	{0xC4700FA3, 0, "sceUtilityInstallGetStatus"}, 
+	{0xC4700FA3, 0, "sceUtilityInstallGetStatus"},
 
 };
 

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -124,7 +124,10 @@ int sceUtilitySavedataUpdate(int animSpeed)
 	}
 
 	DEBUG_LOG(HLE,"sceUtilitySavedataUpdate(%d)", animSpeed);
-	return hleDelayResult(saveDialog.Update(), "savedata update", 300);
+	int result = saveDialog.Update();
+	if (result >= 0)
+		return hleDelayResult(result, "savedata update", 300);
+	return result;
 }
 
 #define PSP_AV_MODULE_AVCODEC		0


### PR DESCRIPTION
This mainly keeps track of the "current dialog type."  The PSP refuses to run two dialogs at once, so this tries to mimic its error messages when you call functions at the same time.

This improves the status of a few of my minis.  There's probably more to it, though.

Also, there is the risk this will break savedata working in a game when there are other things going wrong.

(also cleaned up some whitespace in the sceUtility table, that's why there's some diff noise there.)

-[Unknown]
