### PR TITLE
iOS: Update Info.plist for iPad support (thanks @bsauvage1.)

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -51,5 +51,10 @@
 	<string>assets/Default.png</string>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Reportedly fixes #1015 and #1067.

Let's try it, it doesn't hurt iPhone and it sounds good.

http://developer.apple.com/library/ios/#documentation/general/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11

-[Unknown]
