### PR TITLE
Add option Mipmap to Android , make default true

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -94,6 +94,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("FullScreen", &bFullScreen, false);	
 	graphics->Get("StretchToDisplay", &bStretchToDisplay, false);
 	graphics->Get("TrueColor", &bTrueColor, true);
+	graphics->Get("MipMap", &bMipMap, true);
 
 	IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 	sound->Get("Enable", &bEnableSound, true);
@@ -162,6 +163,7 @@ void Config::Save()
 		graphics->Set("FullScreen", bFullScreen);
 		graphics->Set("StretchToDisplay", bStretchToDisplay);
 		graphics->Set("TrueColor", bTrueColor);
+		graphics->Set("MipMap", bMipMap);
 
 		IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 		sound->Set("Enable", bEnableSound);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -67,6 +67,7 @@ public:
 	bool bFullScreen;
 	int iAnisotropyLevel;
 	bool bTrueColor;
+	bool bMipMap;
 
 	// Sound
 	bool bEnableSound;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -853,7 +853,7 @@ void TextureCache::SetTexture() {
 			break;
 		}
 	}
-
+	if (g_Config.bMipMap) {
 #ifdef USING_GLES2
 	// GLES2 doesn't have support for a "Max lod" which is critical as PSP games often
 	// don't specify mips all the way down. As a result, we either need to manually generate
@@ -863,16 +863,18 @@ void TextureCache::SetTexture() {
 	// For now, I choose to use autogen mips on GLES2 and the game's own on other platforms.
 	// As is usual, GLES3 will solve this problem nicely but wide distribution of that is
 	// years away.
-	LoadTextureLevel(*entry, 0);
-	if (maxLevel > 0)
-		glGenerateMipmap(GL_TEXTURE_2D);
+		LoadTextureLevel(*entry, 0);
+		if (maxLevel > 0)
+			glGenerateMipmap(GL_TEXTURE_2D);
 #else
-	for (int i = 0; i <= maxLevel; i++) {
-		LoadTextureLevel(*entry, i);
-	}
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, maxLevel);
+		for (int i = 0; i <= maxLevel; i++) {
+			LoadTextureLevel(*entry, i);
+		}
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, maxLevel);
 #endif
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)maxLevel);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)maxLevel);
+	}
+
 	float anisotropyLevel = (float) g_Config.iAnisotropyLevel > maxAnisotropyLevel ? maxAnisotropyLevel : (float) g_Config.iAnisotropyLevel;
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropyLevel);
 	// NOTICE_LOG(G3D,"AnisotropyLevel = %0.1f , MaxAnisotropyLevel = %0.1f ", anisotropyLevel, maxAnisotropyLevel );

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -324,7 +324,7 @@ void PauseScreen::render() {
 		ctx->RebindTexture();
 	}
 
-	ui_draw2d.DrawText(UBUNTU48, title, 10+144+10, 30, 0xFFFFFFFF, ALIGN_LEFT);
+	ui_draw2d.DrawText(UBUNTU24, title, 10+144+10, 20, 0xFFFFFFFF, ALIGN_LEFT);
 
 	int x = 30;
 	int y = 50;
@@ -403,7 +403,7 @@ void SettingsScreen::render() {
 	int stride = 40;
 	int columnw = 400;
 	UICheckBox(GEN_ID, x, y += stride, "Sound Emulation", ALIGN_TOPLEFT, &g_Config.bEnableSound);
-	UICheckBox(GEN_ID, x + columnw, y, "True Color", ALIGN_TOPLEFT, &g_Config.bTrueColor);
+	UICheckBox(GEN_ID, x + columnw, y, "Mipmaps", ALIGN_TOPLEFT, &g_Config.bMipMap);
 	if (UICheckBox(GEN_ID, x, y += stride, "Buffered Rendering", ALIGN_TOPLEFT, &g_Config.bBufferedRendering)) {
 		if (gpu)
 			gpu->Resized();


### PR DESCRIPTION
As requested by Carter07 from issue #628 , seems like it blurry textures on android build when mipmap enabled .
