### PR TITLE
Fix scheduling when starting a thread + potential crash

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -163,7 +163,10 @@ public:
 		return id;
 	}
 	MipsCall *get(u32 id) {
-		return calls_[id];
+		auto iter = calls_.find(id);
+		if (iter == calls_.end())
+			return NULL;
+		return iter->second;
 	}
 	MipsCall *pop(u32 id) {
 		MipsCall *temp = calls_[id];

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1614,7 +1614,9 @@ int sceKernelStartThread(SceUID threadToStartID, u32 argSize, u32 argBlockPtr)
 			// TODO: Maybe this happens even for worse-priority started threads?
 			dispatchEnabled = true;
 
-			__KernelChangeReadyState(currentThread, true);
+			if (cur && cur->isRunning())
+				cur->nt.status &= ~THREADSTATUS_RUNNING;
+			__KernelChangeReadyState(cur, currentThread, true);
 			hleReSchedule("thread started");
 		}
 		else if (!dispatchEnabled)


### PR DESCRIPTION
When starting a better-priority thread, the previous thread is put at the end of the queue, not at the start.  Found this while debugging Crisis Core with JpcspTrace (which is neat, but crashes things if not used carefully...)

Also fix mipsCalls.get() to not insert when not found.  Callers were expecting this behavior.  Caused a crash saving state for me.

-[Unknown]
