### PR TITLE
Speed up ISO reading for the gameinfocache

### DIFF
--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include <list>
+#include <vector>
 
 #include "FileSystem.h"
 
@@ -29,7 +30,7 @@
 class ISOFileSystem : public IFileSystem
 {
 public:
-	ISOFileSystem(IHandleAllocator *_hAlloc, BlockDevice *_blockDevice);
+	ISOFileSystem(IHandleAllocator *_hAlloc, BlockDevice *_blockDevice, std::string _restrictPath = "");
 	~ISOFileSystem();
 	void DoState(PointerWrap &p);
 	std::vector<PSPFileInfo> GetDirListing(std::string path);
@@ -87,7 +88,10 @@ private:
 
 	TreeEntry entireISO;
 
-	void ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root);
+	// Don't use this in the emu, not savestated.
+	std::vector<std::string> restrictTree;
+
+	void ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root, size_t level);
 	TreeEntry *GetFromPath(std::string path, bool catchError=true);
 	std::string EntryFullPath(TreeEntry *e);
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <list>
 
 #include "FileSystem.h"
 
@@ -53,7 +54,7 @@ private:
 		~TreeEntry()
 		{
 			for (unsigned int i=0; i<children.size(); i++)
-				delete children[i];
+				ISOFileSystem::ReleaseTreeEntry(children[i]);
 			children.clear();
 		}
 
@@ -89,4 +90,8 @@ private:
 	void ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root);
 	TreeEntry *GetFromPath(std::string path, bool catchError=true);
 	std::string EntryFullPath(TreeEntry *e);
+
+	static std::list<ISOFileSystem::TreeEntry *> entryFreeList;
+	static TreeEntry *GetTreeEntry();
+	static void ReleaseTreeEntry(TreeEntry *entry);
 };

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -120,7 +120,7 @@ again:
 		BlockDevice *bd = constructBlockDevice(gamePath.c_str());
 		if (!bd)
 			return 0;  // nothing to do here..
-		ISOFileSystem umd(&handles, bd);
+		ISOFileSystem umd(&handles, bd, "/PSP_GAME");
 
 		GameInfo *info = new GameInfo();
 		info->wantBG = wantBG;


### PR DESCRIPTION
On Windows, new is the biggest consumer (I turned off caching to see what was up.)  Seems like a likely story for mobile.

After that was inflate and fread.  The best way to optimize that would be to fast-path a single directory lookup by path, so I did that.

Now fread is the top consumer by far (70%) and the next is CreateFile (13.8%.)  Most of the read is actually in the CISO constructor reading the index I presume.

-[Unknown]
