### PR TITLE
Avoid reusing uids for kernel objects.

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -368,12 +368,16 @@ u32 sceKernelIcacheClearAll()
 KernelObjectPool::KernelObjectPool()
 {
 	memset(occupied, 0, sizeof(bool)*maxCount);
+	nextID = 16;
 }
 
 SceUID KernelObjectPool::Create(KernelObject *obj, int rangeBottom, int rangeTop)
 {
 	if (rangeTop > maxCount)
 		rangeTop = maxCount;
+	if (nextID >= rangeBottom && nextID < rangeTop)
+		rangeBottom = nextID++;
+
 	for (int i = rangeBottom; i < rangeTop; i++)
 	{
 		if (!occupied[i])
@@ -462,6 +466,7 @@ void KernelObjectPool::DoState(PointerWrap &p)
 		kernelObjects.Clear();
 	}
 
+	p.Do(nextID);
 	p.DoArray(occupied, maxCount);
 	for (int i = 0; i < maxCount; ++i)
 	{

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -435,6 +435,7 @@ private:
 	};
 	KernelObject *pool[maxCount];
 	bool occupied[maxCount];
+	int nextID;
 };
 
 extern KernelObjectPool kernelObjects;


### PR DESCRIPTION
This makes logs easier to read: a uid is an X is an X.  Usually.

Still sequential, and if it runs out, falls back.

May also paper over scheduling / object lifecycle bugs.

-[Unknown]
