### PR TITLE
Mac OS X 10.6 support

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -34,7 +34,7 @@
 #include <list>
 #include <set>
 #ifndef __SYMBIAN32__
-#ifdef IOS
+#if defined(IOS) || (defined(__APPLE__) && !defined(__MAC_10_7))
 #include <tr1/type_traits>
 #else
 #include <type_traits>
@@ -45,7 +45,7 @@
 #include "FileUtil.h"
 #include "../ext/snappy/snappy-c.h"
 
-#if defined(ANDROID) || defined(IOS)
+#if defined(ANDROID) || defined(IOS) || (defined(__APPLE__) && !defined(__MAC_10_7))
 namespace std {
 	using tr1::is_pointer;
 }

--- a/Common/StdMutex.h
+++ b/Common/StdMutex.h
@@ -5,9 +5,10 @@
 #define GCC_VER(x,y,z)	((x) * 10000 + (y) * 100 + (z))
 #define GCC_VERSION GCC_VER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 
-#if (GCC_VERSION >= GCC_VER(4,4,0) && __GXX_EXPERIMENTAL_CXX0X__ || defined(__APPLE__)) \
+// Note: __MAC_10_7 is defined on 10.7+.
+#if (GCC_VERSION >= GCC_VER(4,4,0) && __GXX_EXPERIMENTAL_CXX0X__ || defined(__MAC_10_7)) \
 /* GCC 4.4 provides <mutex>, except on these platforms: */ \
-	&& !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(IOS) && !defined(__MAC_10_6)
+    && !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(IOS)
 #include <mutex>
 #else
 

--- a/Common/StdMutex.h
+++ b/Common/StdMutex.h
@@ -7,7 +7,7 @@
 
 #if (GCC_VERSION >= GCC_VER(4,4,0) && __GXX_EXPERIMENTAL_CXX0X__ || defined(__APPLE__)) \
 /* GCC 4.4 provides <mutex>, except on these platforms: */ \
-	&& !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(IOS)
+	&& !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(IOS) && !defined(__MAC_10_6)
 #include <mutex>
 #else
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -57,6 +57,10 @@
 #include "../../android/jni/ArmEmitterTest.h"
 #endif
 
+#if defined(__APPLE__) && !defined(IOS)
+#include <mach-o/dyld.h>
+#endif
+
 Texture *uiTexture;
 
 ScreenManager *screenManager;
@@ -185,6 +189,15 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 #elif defined(IOS)
 	VFSRegister("", new DirectoryAssetReader(external_directory));
 	user_data_path += "/";
+#elif defined(__APPLE__)
+    char program_path[4090];
+    uint32_t program_path_size = sizeof(program_path);
+    _NSGetExecutablePath(program_path,&program_path_size);
+    *(strrchr(program_path, '/')+1) = '\0';
+    char assets_path[4096];
+    sprintf(assets_path,"%sassets/",program_path);
+    VFSRegister("", new DirectoryAssetReader(assets_path));
+    VFSRegister("", new DirectoryAssetReader("assets/"));
 #else
 	VFSRegister("", new DirectoryAssetReader("assets/"));
 #endif


### PR DESCRIPTION
Changes from vit9696.  For notes (especially the `!defined()` thing not working), see here:

http://forums.ppsspp.org/showthread.php?tid=1826&pid=12402#pid12402

Tested on 10.6 and 10.8, expected to work on 10.7  Also includes a change to no longer look in the user directory for assets/.

-[Unknown]
