### PR TITLE
Gundam vs gundam NP OSK saving fix 

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -110,7 +110,7 @@ void PSPOskDialog::RenderKeyboard()
 	u32 limit = oskData.outtextlimit;
 	// TODO: Test more thoroughly.  Encountered a game where this was 0.
 	if (limit <= 0)
-		limit = 16;
+		limit = 14;
 
 	const float keyboardLeftSide = (480.0f - (24.0f * KEYSPERROW)) / 2.0f;
 	float previewLeftSide = (480.0f - (12.0f * limit)) / 2.0f;
@@ -159,7 +159,7 @@ int PSPOskDialog::Update()
 	u32 limit = oskData.outtextlimit;
 	// TODO: Test more thoroughly.  Encountered a game where this was 0.
 	if (limit <= 0)
-		limit = 16;
+		limit = 14;
 
 	if (status == SCE_UTILITY_STATUS_INITIALIZE)
 	{


### PR DESCRIPTION
This game seems very weird when enter name in OSK screen . It seems we are specifying the limit string larger than the game itself max length and thus overwrite the memory .

This fix is a trial and error to get that limit value . Underlying problem is still unknown however it did allow the game to save .

 Issue #1022 and Issue #1171

![1](https://f.cloud.github.com/assets/3000282/338375/4c88ed7a-9d0f-11e2-8dc4-7ecd57ff5b4d.jpg)

![2](https://f.cloud.github.com/assets/3000282/338376/4feb8824-9d0f-11e2-8681-feafce32d2e0.jpg)
