### PR TITLE
Fix build with gcc 4.8.0

### DIFF
--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -60,24 +60,24 @@ template<> struct CompileTimeAssert<true> {};
 #endif
 #define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 
-inline u32 _rotl(u32 x, int shift) {
+inline u32 __rotl(u32 x, int shift) {
     shift &= 31;
     if (!shift) return x;
     return (x << shift) | (x >> (32 - shift));
 }
 
-inline u64 _rotl64(u64 x, unsigned int shift){
+inline u64 __rotl64(u64 x, unsigned int shift){
 	unsigned int n = shift % 64;
 	return (x << n) | (x >> (64 - n));
 }
 
-inline u32 _rotr(u32 x, int shift) {
+inline u32 __rotr(u32 x, int shift) {
     shift &= 31;
     if (!shift) return x;
     return (x >> shift) | (x << (32 - shift));
 }
 
-inline u64 _rotr64(u64 x, unsigned int shift){
+inline u64 __rotr64(u64 x, unsigned int shift){
 	unsigned int n = shift % 64;
 	return (x >> n) | (x << (64 - n));
 }

--- a/Common/Hash.cpp
+++ b/Common/Hash.cpp
@@ -135,15 +135,15 @@ inline u64 getblock(const u64 * p, int i)
 inline void bmix64(u64 & h1, u64 & h2, u64 & k1, u64 & k2, u64 & c1, u64 & c2)
 {
     k1 *= c1; 
-    k1  = _rotl64(k1,23); 
+    k1  = __rotl64(k1,23); 
     k1 *= c2;
     h1 ^= k1;
     h1 += h2;
 
-    h2 = _rotl64(h2,41);
+    h2 = __rotl64(h2,41);
 
     k2 *= c2; 
-    k2  = _rotl64(k2,23);
+    k2  = __rotl64(k2,23);
     k2 *= c1;
     h2 ^= k2;
     h2 += h1;
@@ -369,15 +369,15 @@ inline u32 fmix32(u32 h)
 inline void bmix32(u32 & h1, u32 & h2, u32 & k1, u32 & k2, u32 & c1, u32 & c2)
 {
 	k1 *= c1; 
-	k1  = _rotl(k1,11); 
+	k1  = __rotl(k1,11); 
 	k1 *= c2;
 	h1 ^= k1;
 	h1 += h2;
 
-	h2 = _rotl(h2,17);
+	h2 = __rotl(h2,17);
 
 	k2 *= c2; 
-	k2  = _rotl(k2,11);
+	k2  = __rotl(k2,11);
 	k2 *= c1;
 	h2 ^= k2;
 	h2 += h1;

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -37,7 +37,7 @@ SymbolMap symbolMap;
 //need improvement
 static u32 hasher(u32 last, u32 value)
 {
-	return _rotl(last,3) ^ value;
+	return __rotl(last,3) ^ value;
 }
 
 //#define BWLINKS

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -326,7 +326,7 @@ namespace MIPSAnalyst
 					validbits&=~0xFFFF;
 				if (flags & IN_IMM26)
 					validbits&=~0x3FFFFFF;
-				hash = _rotl(hash,13);
+				hash = __rotl(hash,13);
 				hash ^= (instr&validbits);
 			}
 			f.hash=hash;

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -719,7 +719,7 @@ namespace MIPSInt
 			} 
 			else if (_RS == 1) //rotr
 			{
-				R(rd) = _rotr(R(rt), sa);
+				R(rd) = __rotr(R(rt), sa);
 				break;
 			}
 			else
@@ -735,7 +735,7 @@ namespace MIPSInt
 			}
 			else if (_FD == 1) // rotrv
 			{
-				R(rd) = _rotr(R(rt), R(rs));
+				R(rd) = __rotr(R(rt), R(rs));
 				break;
 			}
 			else goto wrong;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -903,13 +903,13 @@ u32 TransformDrawEngine::ComputeFastDCID() {
 	u32 hash = 0;
 	for (int i = 0; i < numDrawCalls; i++) {
 		hash ^= *(u32*)&drawCalls[i].verts;
-		hash = _rotl(hash, 13);
+		hash = __rotl(hash, 13);
 		hash ^= *(u32*)&drawCalls[i].inds;
-		hash = _rotl(hash, 13);
+		hash = __rotl(hash, 13);
 		hash ^= (u32)drawCalls[i].vertType;
-		hash = _rotl(hash, 13);
+		hash = __rotl(hash, 13);
 		hash ^= (u32)drawCalls[i].vertexCount;
-		hash = _rotl(hash, 13);
+		hash = __rotl(hash, 13);
 		hash ^= (u32)drawCalls[i].prim;
 	}
 	return hash;


### PR DESCRIPTION
New GCC 4.8.0 defines own verions of _rot\* functions, so to fix build on 4.8.0 and not break it on older versions, i've added '_' for every _rot\* function. Tested and works with 4.7.2 and 4.8.0.
