### PR TITLE
More of Orphis' dlist rewrite (signal handling)

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -115,7 +115,7 @@ void __GeShutdown()
 void __GeTriggerInterrupt(int listid, u32 pc, int subIntrBase, u16 subIntrToken)
 {
 	// ClaDun X2 does not expect sceGeListEnqueue to reschedule (which it does not on the PSP.)
-	// Once PPSSPP's GPU is multithreaded, we can remove this check.
+	// Once PPSSPP's GPU uses cycles, we can remove this check.
 	if (subIntrBase < 0)
 		return;
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -19,6 +19,7 @@
 #include "../MIPS/MIPS.h"
 #include "../System.h"
 #include "../CoreParameter.h"
+#include "../Reporting.h"
 #include "sceGe.h"
 #include "sceKernelMemory.h"
 #include "sceKernelThread.h"
@@ -33,8 +34,6 @@ struct GeInterruptData
 {
 	int listid;
 	u32 pc;
-	u32 subIntrBase;
-	u16 subIntrToken;
 };
 
 static std::list<GeInterruptData> ge_pending_cb;
@@ -52,21 +51,20 @@ public:
 		if (dl == NULL)
 		{
 			WARN_LOG(HLE, "Unable to run GE interrupt: list doesn't exist: %d", intrdata.listid);
-			// TODO: Use dl instead of just saving everything instead?
-			//return false;
+			return false;
 		}
 
 		gpu->InterruptStart();
 
 		u32 cmd = Memory::ReadUnchecked_U32(intrdata.pc - 4) >> 24;
-		int subintr = intrdata.subIntrBase | (cmd == GE_CMD_FINISH ? PSP_GE_SUBINTR_FINISH : PSP_GE_SUBINTR_SIGNAL);
+		int subintr = dl->subIntrBase | (cmd == GE_CMD_FINISH ? PSP_GE_SUBINTR_FINISH : PSP_GE_SUBINTR_SIGNAL);
 		SubIntrHandler* handler = get(subintr);
 
 		if(handler != NULL)
 		{
 			DEBUG_LOG(CPU, "Entering interrupt handler %08x", handler->handlerAddress);
 			currentMIPS->pc = handler->handlerAddress;
-			u32 data = intrdata.subIntrToken;
+			u32 data = dl->subIntrToken;
 			currentMIPS->r[MIPS_REG_A0] = data & 0xFFFF;
 			currentMIPS->r[MIPS_REG_A1] = handler->handlerArg;
 			currentMIPS->r[MIPS_REG_A2] = sceKernelGetCompiledSdkVersion() <= 0x02000010 ? 0 : intrdata.pc + 4;
@@ -86,6 +84,30 @@ public:
 	{
 		GeInterruptData intrdata = ge_pending_cb.front();
 		ge_pending_cb.pop_front();
+
+		DisplayList* dl = gpu->getList(intrdata.listid);
+
+		switch (dl->signal)
+		{
+		case PSP_GE_SIGNAL_HANDLER_SUSPEND:
+			if (sceKernelGetCompiledSdkVersion() <= 0x02000010)
+			{
+				// uofw says dl->state = endCmd & 0xFF;
+				DisplayListState newState = static_cast<DisplayListState>(Memory::ReadUnchecked_U32(intrdata.pc - 4) & 0xFF);
+				//dl->status = static_cast<DisplayListStatus>(Memory::ReadUnchecked_U32(intrdata.pc) & 0xFF);
+				//if(dl->status < 0 || dl->status > PSP_GE_LIST_PAUSED)
+				//	ERROR_LOG(HLE, "Weird DL status after signal suspend %x", dl->status);
+				if (newState != PSP_GE_DL_STATE_RUNNING)
+					WARN_LOG_REPORT(HLE, "GE Interrupt: newState might be %d", newState);
+
+				dl->state = PSP_GE_DL_STATE_RUNNING;
+			}
+			break;
+		default:
+			break;
+		}
+
+		dl->signal = PSP_GE_SIGNAL_NONE;
 
 		gpu->InterruptEnd();
 	}
@@ -112,18 +134,17 @@ void __GeShutdown()
 
 }
 
-void __GeTriggerInterrupt(int listid, u32 pc, int subIntrBase, u16 subIntrToken)
+void __GeTriggerInterrupt(int listid, u32 pc)
 {
 	// ClaDun X2 does not expect sceGeListEnqueue to reschedule (which it does not on the PSP.)
 	// Once PPSSPP's GPU uses cycles, we can remove this check.
-	if (subIntrBase < 0)
+	DisplayList* dl = gpu->getList(listid);
+	if (dl != NULL && dl->subIntrBase < 0)
 		return;
 
 	GeInterruptData intrdata;
 	intrdata.listid = listid;
 	intrdata.pc     = pc;
-	intrdata.subIntrBase = subIntrBase;
-	intrdata.subIntrToken = subIntrToken;
 	ge_pending_cb.push_back(intrdata);
 	__TriggerInterrupt(PSP_INTR_HLE, PSP_GE_INTR, PSP_INTR_SUB_NONE);
 }

--- a/Core/HLE/sceGe.h
+++ b/Core/HLE/sceGe.h
@@ -39,7 +39,7 @@ void Register_sceGe_user();
 void __GeInit();
 void __GeDoState(PointerWrap &p);
 void __GeShutdown();
-void __GeTriggerInterrupt(int listid, u32 pc, int subIntrBase, u16 subIntrToken);
+void __GeTriggerInterrupt(int listid, u32 pc);
 bool __GeHasPendingInterrupt();
 
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -542,8 +542,10 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					ERROR_LOG(G3D, "UNKNOWN Signal UNIMPLEMENTED %i ! signal/end: %04x %04x", behaviour, signal, enddata);
 					break;
 				}
-				if (interruptsEnabled_)
-					__GeTriggerInterrupt(currentList->id, currentList->pc, currentList->subIntrBase, currentList->subIntrToken);
+				if (interruptsEnabled_) {
+					gpuState = GPUSTATE_INTERRUPT;
+					__GeTriggerInterrupt(currentList->id, currentList->pc);
+				}
 			}
 			break;
 		case GE_CMD_FINISH:
@@ -551,7 +553,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 			gpuState = GPUSTATE_DONE;
 			currentList->subIntrToken = prev & 0xFFFF;
 			if (interruptsEnabled_)
-				__GeTriggerInterrupt(currentList->id, currentList->pc, currentList->subIntrBase, currentList->subIntrToken);
+				__GeTriggerInterrupt(currentList->id, currentList->pc);
 			break;
 		default:
 			DEBUG_LOG(G3D,"Ah, not finished: %06x", prev & 0xFFFFFF);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -451,7 +451,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					ERROR_LOG(G3D, "UNKNOWN Signal UNIMPLEMENTED %i ! signal/end: %04x %04x", behaviour, signal, enddata);
 					break;
 				}
-				if (currentList->subIntrBase >= 0 && interruptsEnabled_)
+				if (interruptsEnabled_)
 					__GeTriggerInterrupt(currentList->id, currentList->pc, currentList->subIntrBase, currentList->subIntrToken);
 			}
 			break;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -194,14 +194,30 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head)
 
 u32 GPUCommon::DequeueList(int listid)
 {
-	// TODO
+	if (listid < 0 || listid >= DisplayListMaxCount || dls[listid].state == PSP_GE_DL_STATE_NONE)
+		return SCE_KERNEL_ERROR_INVALID_ID;
+
+	if (dls[listid].state == PSP_GE_DL_STATE_RUNNING || dls[listid].state == PSP_GE_DL_STATE_PAUSED)
+		return 0x80000021;
+
+	dls[listid].state = PSP_GE_DL_STATE_NONE;
+
+	if (listid == dlQueue.front())
+		PopDLQueue();
+	else
+		dlQueue.remove(listid);
+
+	// TODO: Release any list wait.
+
+	CheckDrawSync();
+
 	return 0;
 }
 
 u32 GPUCommon::UpdateStall(int listid, u32 newstall)
 {
 	if (listid < 0 || listid >= DisplayListMaxCount || dls[listid].state == PSP_GE_DL_STATE_NONE)
-		return 0x80000100;
+		return SCE_KERNEL_ERROR_INVALID_ID;
 
 	dls[listid].stall = newstall & 0xFFFFFFF;
 	

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -425,6 +425,8 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 
 				switch (behaviour) {
 				case PSP_GE_SIGNAL_HANDLER_SUSPEND:
+					if (sceKernelGetCompiledSdkVersion() <= 0x02000010)
+						currentList->state = PSP_GE_DL_STATE_PAUSED;
 					currentList->signal = behaviour;
 					ERROR_LOG(G3D, "Signal with Wait UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
 					break;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -5,14 +5,8 @@
 class GPUCommon : public GPUInterface
 {
 public:
-	GPUCommon() :
-		dlIdGenerator(1),
-		currentList(NULL),
-		isbreak(false),
-		dumpNextFrame_(false),
-		dumpThisFrame_(false),
-		interruptsEnabled_(true)
-	{}
+	GPUCommon();
+	virtual ~GPUCommon() {}
 
 	virtual void InterruptStart();
 	virtual void InterruptEnd();
@@ -36,10 +30,12 @@ public:
 
 protected:
 	void UpdateCycles(u32 pc, u32 newPC = 0);
+	void PopDLQueue();
+	void CheckDrawSync();
 
-	typedef std::deque<DisplayList> DisplayListQueue;
+	typedef std::list<int> DisplayListQueue;
 
-	int dlIdGenerator;
+	DisplayList dls[DisplayListMaxCount];
 	DisplayList *currentList;
 	DisplayListQueue dlQueue;
 
@@ -59,17 +55,10 @@ protected:
 public:
 	virtual DisplayList* getList(int listid)
 	{
-		if (currentList && currentList->id == listid)
-			return currentList;
-		for(auto it = dlQueue.begin(); it != dlQueue.end(); ++it)
-		{
-			if(it->id == listid)
-				return &*it;
-		}
-		return NULL;
+		return &dls[listid];
 	}
 
-	const std::deque<DisplayList>& GetDisplayLists()
+	const std::list<int>& GetDisplayLists()
 	{
 		return dlQueue;
 	}

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -45,7 +45,7 @@ protected:
 
 	bool interruptRunning;
 	u32 prev;
-	bool finished;
+	GPUState gpuState;
 	bool isbreak;
 
 	u64 startingTicks;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -19,7 +19,7 @@
 
 #include "../Globals.h"
 #include "GPUState.h"
-#include <deque>
+#include <list>
 
 class PointerWrap;
 
@@ -128,16 +128,19 @@ class GPUInterface
 public:
 	virtual ~GPUInterface() {}
 
+	static const int DisplayListMaxCount = 64;
+
 	// Initialization
 	virtual void InitClear() = 0;
 
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;
 	// TODO: Much of this should probably be shared between the different GPU implementations.
-	virtual u32 EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head) = 0;
-	virtual u32  UpdateStall(int listid, u32 newstall) = 0;
+	virtual u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head) = 0;
 	virtual u32  DequeueList(int listid) = 0;
+	virtual u32  UpdateStall(int listid, u32 newstall) = 0;
 	virtual u32  DrawSync(int mode) = 0;
+	virtual int  ListSync(int listid, int mode) = 0;
 	virtual u32  Continue() = 0;
 	virtual u32  Break(int mode) = 0;
 
@@ -147,7 +150,6 @@ public:
 	virtual void PreExecuteOp(u32 op, u32 diff) = 0;
 	virtual void ExecuteOp(u32 op, u32 diff) = 0;
 	virtual bool InterpretList(DisplayList& list) = 0;
-	virtual int  ListSync(int listid, int mode) = 0;
 
 	// Framebuffer management
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, int format) = 0;
@@ -175,7 +177,7 @@ public:
 
 	// Debugging
 	virtual void DumpNextFrame() = 0;
-	virtual const std::deque<DisplayList>& GetDisplayLists() = 0;
+	virtual const std::list<int>& GetDisplayLists() = 0;
 	virtual DisplayList* GetCurrentDisplayList() = 0;
 	virtual bool DecodeTexture(u8* dest, GPUgstate state) = 0;
 	virtual std::vector<FramebufferInfo> GetFramebufferList() = 0;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -88,6 +88,14 @@ enum SignalBehavior
 	PSP_GE_SIGNAL_BREAK2           = 0xFF,
 };
 
+enum GPUState
+{
+	GPUSTATE_RUNNING = 0,
+	GPUSTATE_DONE = 1,
+	GPUSTATE_STALL = 2,
+	GPUSTATE_INTERRUPT = 3,
+	GPUSTATE_ERROR = 4,
+};
 
 // Used for debug
 struct FramebufferInfo


### PR DESCRIPTION
Unfortunately, I think this breaks Qt's debugger, but I think Qt's still broken.  Sorry.  I don't think it'll be hard to fix, just need to use getList()...

This is again just Orphis' changes.  Gets rid of that warning in a bunch of games, and also:
- Handles state more correctly when signals are used.
- Runs signal handlers immediately before resuming the list.
- Implements a fixed-size displaylist queue.
- Implements dequeue (mainly interesting for stalled/etc. lists.)

At this point, there are some smaller changes that aren't merged in, but mostly it's just waits.

Couldn't find any games broken with this or hitting no DL ids left.

-[Unknown]
