### PR TITLE
Improve displaylist signals

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -54,7 +54,7 @@ public:
 			return false;
 		}
 
-		gpu->InterruptStart();
+		gpu->InterruptStart(intrdata.listid);
 
 		u32 cmd = Memory::ReadUnchecked_U32(intrdata.pc - 4) >> 24;
 		int subintr = dl->subIntrBase | (cmd == GE_CMD_FINISH ? PSP_GE_SUBINTR_FINISH : PSP_GE_SUBINTR_SIGNAL);
@@ -74,7 +74,7 @@ public:
 		}
 
 		ge_pending_cb.pop_front();
-		gpu->InterruptEnd();
+		gpu->InterruptEnd(intrdata.listid);
 
 		WARN_LOG(HLE, "Ignoring interrupt for display list %d, already been released.", intrdata.listid);
 		return false;
@@ -109,7 +109,7 @@ public:
 
 		dl->signal = PSP_GE_SIGNAL_NONE;
 
-		gpu->InterruptEnd();
+		gpu->InterruptEnd(intrdata.listid);
 	}
 };
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -60,7 +60,9 @@ public:
 		int subintr = -1;
 		if (dl->subIntrBase >= 0)
 		{
-			if (cmd == GE_CMD_FINISH && dl->signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
+			if (dl->signal == PSP_GE_SIGNAL_SYNC)
+				subintr = -1;
+			else if (cmd == GE_CMD_FINISH && dl->signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
 				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
 			else if (cmd == GE_CMD_SIGNAL && dl->signal != PSP_GE_SIGNAL_HANDLER_PAUSE)
 				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -60,14 +60,27 @@ public:
 		int subintr = -1;
 		if (dl->subIntrBase >= 0)
 		{
-			if (dl->signal == PSP_GE_SIGNAL_SYNC)
-				subintr = -1;
-			else if (cmd == GE_CMD_FINISH && dl->signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
-				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
-			else if (cmd == GE_CMD_SIGNAL && dl->signal != PSP_GE_SIGNAL_HANDLER_PAUSE)
-				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
-			else if (cmd == GE_CMD_FINISH)
-				subintr = dl->subIntrBase | PSP_GE_SUBINTR_FINISH;
+			switch (dl->signal)
+			{
+			case PSP_GE_SIGNAL_SYNC:
+			case PSP_GE_SIGNAL_JUMP:
+			case PSP_GE_SIGNAL_CALL:
+			case PSP_GE_SIGNAL_RET:
+				// Do nothing.
+				break;
+
+			case PSP_GE_SIGNAL_HANDLER_PAUSE:
+				if (cmd == GE_CMD_FINISH)
+					subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
+				break;
+
+			default:
+				if (cmd == GE_CMD_SIGNAL)
+					subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
+				else
+					subintr = dl->subIntrBase | PSP_GE_SUBINTR_FINISH;
+				break;
+			}
 		}
 
 		SubIntrHandler* handler = get(subintr);

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -57,10 +57,19 @@ public:
 		gpu->InterruptStart(intrdata.listid);
 
 		u32 cmd = Memory::ReadUnchecked_U32(intrdata.pc - 4) >> 24;
-		int subintr = dl->subIntrBase | (cmd == GE_CMD_FINISH ? PSP_GE_SUBINTR_FINISH : PSP_GE_SUBINTR_SIGNAL);
-		SubIntrHandler* handler = get(subintr);
+		int subintr = -1;
+		if (dl->subIntrBase >= 0)
+		{
+			if (cmd == GE_CMD_FINISH && dl->signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
+				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
+			else if (cmd == GE_CMD_SIGNAL && dl->signal != PSP_GE_SIGNAL_HANDLER_PAUSE)
+				subintr = dl->subIntrBase | PSP_GE_SUBINTR_SIGNAL;
+			else if (cmd == GE_CMD_FINISH)
+				subintr = dl->subIntrBase | PSP_GE_SUBINTR_FINISH;
+		}
 
-		if(handler != NULL)
+		SubIntrHandler* handler = get(subintr);
+		if (handler != NULL)
 		{
 			DEBUG_LOG(CPU, "Entering interrupt handler %08x", handler->handlerAddress);
 			currentMIPS->pc = handler->handlerAddress;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -567,7 +567,8 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					ERROR_LOG_REPORT(G3D, "Signal with Pause UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_SYNC:
-					ERROR_LOG_REPORT(G3D, "Signal with Sync UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					currentList->signal = behaviour;
+					DEBUG_LOG(G3D, "Signal with Sync. signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_JUMP:
 					ERROR_LOG_REPORT(G3D, "Signal with Jump UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
@@ -595,6 +596,11 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					if (__GeTriggerInterrupt(currentList->id, currentList->pc))
 						gpuState = GPUSTATE_INTERRUPT;
 				}
+				break;
+
+			case PSP_GE_SIGNAL_SYNC:
+				currentList->signal = PSP_GE_SIGNAL_NONE;
+				// TODO: Technically this should still cause an interrupt.  Probably for memory sync.
 				break;
 
 			default:

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -558,10 +558,10 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					ERROR_LOG(G3D, "Signal without wait. signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_HANDLER_PAUSE:
-					ERROR_LOG(G3D, "Signal with Pause UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					ERROR_LOG_REPORT(G3D, "Signal with Pause UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_SYNC:
-					ERROR_LOG(G3D, "Signal with Sync UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					ERROR_LOG_REPORT(G3D, "Signal with Sync UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_JUMP:
 					ERROR_LOG_REPORT(G3D, "Signal with Jump UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -8,8 +8,8 @@ public:
 	GPUCommon();
 	virtual ~GPUCommon() {}
 
-	virtual void InterruptStart();
-	virtual void InterruptEnd();
+	virtual void InterruptStart(int listid);
+	virtual void InterruptEnd(int listid);
 	virtual void EnableInterrupts(bool enable) {
 		interruptsEnabled_ = enable;
 	}

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -145,8 +145,8 @@ public:
 	virtual u32  Continue() = 0;
 	virtual u32  Break(int mode) = 0;
 
-	virtual void InterruptStart() = 0;
-	virtual void InterruptEnd() = 0;
+	virtual void InterruptStart(int listid) = 0;
+	virtual void InterruptEnd(int listid) = 0;
 
 	virtual void PreExecuteOp(u32 op, u32 diff) = 0;
 	virtual void ExecuteOp(u32 op, u32 diff) = 0;


### PR DESCRIPTION
None of them are working completely perfectly, I think, but they're better than before.

The sync signal fixes 3rd Birthday, which now has hud and stuff.  Call helps Patapon 1, which shows stuff now, but it's still flickery and that's why I suspect something is still wrong with it.

Still, better is better.

-[Unknown]
