### PR TITLE
Minor adjustments to the menu screen

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -22,7 +22,11 @@
 
 Config g_Config;
 
+#ifdef _WIN32
+#define MAX_RECENT 12
+#else
 #define MAX_RECENT 4
+#endif
 
 Config::Config()
 {

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -137,7 +137,7 @@ again:
 	if (startsWith(gamePath, "ms0:/PSP/GAME")) {
 		return 0;
 	// TODO: The case of these extensions is not perfect.
-	} else if (endsWith(gamePath, ".PBP") || endsWith(gamePath, ".elf")) {
+	} else if (endsWith(gamePath, ".PBP") || endsWith(gamePath, ".elf") || endsWith(gamePath, ".prx")) {
 		return 0;
 	} else {
 		SequentialHandleAllocator handles;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -200,7 +200,7 @@ void MenuScreen::render() {
 	ui_draw2d.DrawTextShadow(UBUNTU24, PPSSPP_GIT_VERSION, dp_xres + xoff, 85, 0xFFFFFFFF, ALIGN_RIGHT | ALIGN_BOTTOM);
 	ui_draw2d.SetFontScale(1.0f, 1.0f);
 	VLinear vlinear(dp_xres + xoff, 100, 20);
-	VLinear vlinear2(-xoff, 100, 20);
+	VGrid vgrid_recent(-xoff, 100, 480, 20, 20);
 
 	if (UIButton(GEN_ID, vlinear, w, "Load...", ALIGN_RIGHT)) {
 #if defined(USING_QT_UI)
@@ -267,11 +267,11 @@ void MenuScreen::render() {
 		GameInfo *ginfo = g_gameInfoCache.GetInfo(g_Config.recentIsos[i], false);
 
 		if (ginfo) {
-			if (UITextureButton(ctx, (int)GEN_ID_LOOP(i), vlinear2, 144, 80, ginfo->iconTexture, ALIGN_LEFT)) {
+			if (UITextureButton(ctx, (int)GEN_ID_LOOP(i), vgrid_recent, 144, 80, ginfo->iconTexture, ALIGN_LEFT)) {
 				screenManager()->switchScreen(new EmuScreen(g_Config.recentIsos[i]));
 			}
 		} else {
-			if (UIButton((int)GEN_ID_LOOP(i), vlinear2, recentW, filename.c_str(), ALIGN_LEFT)) {
+			if (UIButton((int)GEN_ID_LOOP(i), vgrid_recent, recentW, filename.c_str(), ALIGN_LEFT)) {
 				screenManager()->switchScreen(new EmuScreen(g_Config.recentIsos[i]));
 			}
 		}

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -200,7 +200,7 @@ void MenuScreen::render() {
 	ui_draw2d.DrawTextShadow(UBUNTU24, PPSSPP_GIT_VERSION, dp_xres + xoff, 85, 0xFFFFFFFF, ALIGN_RIGHT | ALIGN_BOTTOM);
 	ui_draw2d.SetFontScale(1.0f, 1.0f);
 	VLinear vlinear(dp_xres + xoff, 100, 20);
-	VGrid vgrid_recent(-xoff, 100, 480, 20, 20);
+	VGrid vgrid_recent(-xoff + 40, 100, 480, 40, 20);
 
 	if (UIButton(GEN_ID, vlinear, w, "Load...", ALIGN_RIGHT)) {
 #if defined(USING_QT_UI)
@@ -252,7 +252,7 @@ void MenuScreen::render() {
 
 	int recentW = 350;
 	if (g_Config.recentIsos.size()) {
-		ui_draw2d.DrawText(UBUNTU24, "Recent", -xoff, 80, 0xFFFFFFFF, ALIGN_BOTTOMLEFT);
+		ui_draw2d.DrawText(UBUNTU24, "Recent", -xoff + 20, 80, 0xFFFFFFFF, ALIGN_BOTTOMLEFT);
 	}
 	for (size_t i = 0; i < g_Config.recentIsos.size(); i++) {
 		std::string filename;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -239,14 +239,12 @@ void MenuScreen::render() {
 		UIReset();
 	}
 
-#ifndef _WIN32
 	if (UIButton(GEN_ID, vlinear, w, "Exit", ALIGN_RIGHT)) {
 		// TODO: Save when setting changes, rather than when we quit
 		NativeShutdown();
 		// TODO: Need a more elegant way to quit
 		exit(0);
 	}
-#endif
 
 	if (UIButton(GEN_ID, vlinear, w, "www.ppsspp.org", ALIGN_RIGHT)) {
 		LaunchBrowser("http://www.ppsspp.org/");

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -608,11 +608,13 @@ namespace MainWindow
 					TCHAR *type = filename+_tcslen(filename)-3;
 
 					SendMessage(hWnd, WM_COMMAND, ID_EMULATION_STOP, 0);
+					// Ugly, need to wait for the stop message to process in the EmuThread.
+					Sleep(20);
 					
 					MainWindow::SetPlaying(filename);
 					MainWindow::Update();
 
-					NativeMessageReceived("run", filename);
+					NativeMessageReceived("boot", filename);
 				}
 			}
 			break;


### PR DESCRIPTION
I think there's better improvements coming, but I wanted a few more recent since I've come to quite like the feature.

Needs hrydgard/native#59 accepted first.

This:
- Avoids analyzing prx files (I open these sometimes) - maybe we should make the ISO reader bail on an invalid file instead of "trying anyway."
- Makes it 12 recent items on Windows and aligns in a grid.
- Fixes Minis icons (square) being stretched and looking horrid.
- Shows the Exit button on Windows for #1193.  Just did it always.
- Also threw in a fix for drag and drop in the Windows UI.

-[Unknown]
