### PR TITLE
Skip pads if their analog is not set

### DIFF
--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -150,6 +150,8 @@ int DinputDevice::UpdateState(InputState &input_state)
 		}
 	}
 
+	if (js.lX != 0.0f || js.lY != 0.0f)
+		return UPDATESTATE_SKIP_NEXT;
 	return 0;
 }
 

--- a/Windows/InputDevice.cpp
+++ b/Windows/InputDevice.cpp
@@ -8,8 +8,8 @@
 #define PUSH_BACK(Cls) do { list.push_back(std::shared_ptr<InputDevice>(new Cls())); } while (0)
 std::list<std::shared_ptr<InputDevice>> getInputDevices() {
 	std::list<std::shared_ptr<InputDevice>> list;
-	PUSH_BACK(KeyboardDevice);
 	PUSH_BACK(XinputDevice);
 	PUSH_BACK(DinputDevice);
+	PUSH_BACK(KeyboardDevice);
 	return list;
 }

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -55,7 +55,9 @@ int XinputDevice::UpdateState(InputState &input_state) {
 
 		// If there's an XInput pad, skip following pads. This prevents DInput and XInput
 		// from colliding.
-		return UPDATESTATE_SKIP_NEXT;
+		if (left.x != 0.0f || left.y != 0.0f)
+			return UPDATESTATE_SKIP_NEXT;
+		return 0;
 	} else {
 		// wait check_delay frames before polling the controller again
 		this->gamepad_idx = -1;


### PR DESCRIPTION
Not sure if a deadzone is needed... or if some pads may do a constant bottom left or something...

Doesn't include the native change since I already had a pull that updates native.  Not dependent anyway.

-[Unknown]
