### PR TITLE
Improve threadqueue performance

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -579,18 +579,21 @@ struct ThreadQueueList
 			Queue *cur = &queues[i];
 			int size = cur->end - cur->first;
 			p.Do(size);
+			int capacity = cur->capacity;
+			p.Do(capacity);
 
-			if (size == 0)
+			if (capacity == 0)
 				continue;
 
 			if (p.mode == p.MODE_READ)
 			{
-				link(i, size);
+				link(i, capacity);
 				cur->first = (cur->capacity - size) / 2;
 				cur->end = cur->first + size;
 			}
 
-			p.DoArray(&cur->data[cur->first], size);
+			if (size != 0)
+				p.DoArray(&cur->data[cur->first], size);
 		}
 
 		p.DoMarker("ThreadQueueList");


### PR DESCRIPTION
Well, the profiler made me feel like this was really a ton better, but as I compare vps, it didn't help as much after all I think... not sure.

Anyway, this significantly reduces the inclusive time spent in thread management functions on Windows and iOS, at least.  In ClaDun, for example, it was spending almost 10%, now it's at least 1/3 that.  Tested with several games and nothing broken that I can find.

The time spent in other functions rose a lot too, implying that the CPU is spending more time on other things, and less on this.

But, VPS seems barely affected on Windows or iOS for most games... bugger.  Probably means it wasn't the bottleneck anywhere...

Downsides:
- It may use more memory (worst case is 1MB, but common case will be 128k or so.)
- A hard limit of 2048 threads per priority is imposed (we don't support this many kernel objects anyway.)  This is directly linked to memory above.
- It doesn't use any STL at all, because I couldn't find a way to get what I wanted out of STL (not sure if my failing or its...)

-[Unknown]
