### PR TITLE
Add option to toggle ignore MIPS error , default true

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -57,6 +57,7 @@ void Config::Load(const char *iniFileName)
 	general->Get("Browse", &bBrowse, false);
 	general->Get("ConfirmOnQuit", &bConfirmOnQuit, false);
 	general->Get("IgnoreBadMemAccess", &bIgnoreBadMemAccess, true);
+	general->Get("IgnoreMipsError", &bIgnoreMipsError, true);
 	general->Get("CurrentDirectory", &currentDirectory, "");
 	general->Get("ShowDebuggerOnLoad", &bShowDebuggerOnLoad, false);
 	// "default" means let emulator decide, "" means disable.
@@ -139,6 +140,7 @@ void Config::Save()
 		general->Set("Browse", bBrowse);
 		general->Set("ConfirmOnQuit", bConfirmOnQuit);
 		general->Set("IgnoreBadMemAccess", bIgnoreBadMemAccess);
+		general->Set("IgnoreMipsError", bIgnoreMipsError);
 		general->Set("CurrentDirectory", currentDirectory);
 		general->Set("ShowDebuggerOnLoad", bShowDebuggerOnLoad);
 		general->Set("ReportHost", sReportHost);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -42,6 +42,7 @@ public:
 
 	// Core
 	bool bIgnoreBadMemAccess;
+	bool bIgnoreMipsError;
 	bool bFastMemory;
 	bool bJit;
 	bool bAutoSaveSymbolMap;

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -25,9 +25,11 @@
 #include "MIPSInt.h"
 #include "MIPSTables.h"
 #include "Core/Reporting.h"
+#include "Core/Config.h"
 
 #include "../HLE/HLE.h"
 #include "../System.h"
+
 
 #ifdef __APPLE__
 using std::isnan;
@@ -194,7 +196,9 @@ namespace MIPSInt
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
 		ERROR_LOG(CPU, "BREAK!");
-		Core_UpdateState(CORE_STEPPING);
+		if (!g_Config.bIgnoreMipsError) {
+			Core_UpdateState(CORE_STEPPING);
+		}
 		PC += 4;
 	}
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -529,6 +529,10 @@ namespace MainWindow
 				g_Config.bIgnoreBadMemAccess = !g_Config.bIgnoreBadMemAccess;
 				break;
 
+			case ID_OPTIONS_IGNOREMIPSERROR:
+				g_Config.bIgnoreMipsError = !g_Config.bIgnoreMipsError;
+				break;
+
 			case ID_OPTIONS_FULLSCREEN:
 				g_Config.bFullScreen = !g_Config.bFullScreen ;
 				if(g_bFullScreen) {
@@ -684,6 +688,7 @@ namespace MainWindow
 //		CHECK(ID_OPTIONS_EMULATESYSCALL,g_bEmulateSyscall);
 		CHECKITEM(ID_OPTIONS_DISPLAYRAWFRAMEBUFFER, g_Config.bDisplayFramebuffer);
 		CHECKITEM(ID_OPTIONS_IGNOREILLEGALREADS,g_Config.bIgnoreBadMemAccess);
+		CHECKITEM(ID_OPTIONS_IGNOREMIPSERROR,g_Config.bIgnoreMipsError);
 		CHECKITEM(ID_CPU_INTERPRETER,g_Config.bJit == false);
 		CHECKITEM(ID_CPU_DYNAREC,g_Config.bJit == true);
 		CHECKITEM(ID_OPTIONS_BUFFEREDRENDERING, g_Config.bBufferedRendering);

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -267,6 +267,8 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "&Fast Memory (dynarec, unstable)", ID_OPTIONS_FASTMEMORY
         MENUITEM "&Ignore illegal reads/writes", ID_OPTIONS_IGNOREILLEGALREADS
+        MENUITEM "&Ignore MIPS error", ID_OPTIONS_IGNOREMIPSERROR
+
     END
     POPUP "&Help"
     BEGIN

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -221,6 +221,7 @@
 #define ID_OPTIONS_USEMEDIAENGINE       40141
 #define ID_FILE_MEMSTICK                40142
 #define ID_FILE_LOAD_MEMSTICK           40143
+#define ID_OPTIONS_IGNOREMIPSERROR      40144
 #define IDC_STATIC                      -1
 
 // Next default values for new objects


### PR DESCRIPTION
This allows Sol Trigger to go much further by ignoring MIPS error and may help other games with similar issues 
