### PR TITLE
Don't save/restore VFPU regs for threads that don't use them

### DIFF
--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -289,12 +289,12 @@ bool __CanExecuteInterrupt()
 
 void InterruptState::save()
 {
-	__KernelSaveContext(&savedCpu);
+	__KernelSaveContext(&savedCpu, true);
 }
 
 void InterruptState::restore()
 {
-	__KernelLoadContext(&savedCpu);
+	__KernelLoadContext(&savedCpu, true);
 }
 
 void InterruptState::clear()

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -130,8 +130,8 @@ SceUID __KernelGetCurThread();
 u32 __KernelGetCurThreadStack();
 const char *__KernelGetThreadName(SceUID threadID);
 
-void __KernelSaveContext(ThreadContext *ctx);
-void __KernelLoadContext(ThreadContext *ctx);
+void __KernelSaveContext(ThreadContext *ctx, bool vfpuEnabled);
+void __KernelLoadContext(ThreadContext *ctx, bool vfpuEnabled);
 
 // TODO: Replace this with __KernelResumeThreadFromWait over time as it's misguided.
 // It's better that each subsystem keeps track of the list of waiting threads


### PR DESCRIPTION
I can't find any games this breaks, and it should help idle0/idle1 switching especially.  Cut off 0.4% on a profile... not much but not nothing.

Also includes another optimization to `__KernelNextThread()` which was push/popping a value unnecessarily sometimes.  Also skips calling `__KernelSwitchContext()` at all if it's the same thread (which does sometimes happen), but doesn't save much time - maybe 0.2%.

-[Unknown]
