### PR TITLE
Block dlist execution while in virtual progress

### DIFF
--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -45,6 +45,7 @@ protected:
 	GPUState gpuState;
 	bool isbreak;
 	u64 drawCompleteTicks;
+	u64 busyTicks;
 
 	u64 startingTicks;
 	u32 cycleLastPC;


### PR DESCRIPTION
Fixes #1224.

Also, fix drawsync late by a GPU cycle, so interrupts line up.  It would break at least Ys Seven without that.

-[Unknown]
