### PR TITLE
Ignore MIPS break error

### DIFF
--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -25,6 +25,7 @@
 #include "MIPSInt.h"
 #include "MIPSTables.h"
 #include "Core/Reporting.h"
+#include "Core/Config.h"
 
 #include "../HLE/HLE.h"
 #include "../System.h"
@@ -194,7 +195,8 @@ namespace MIPSInt
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
 		ERROR_LOG(CPU, "BREAK!");
-		Core_UpdateState(CORE_STEPPING);
+		if (!g_Config.bIgnoreBadMemAccess) 
+			Core_UpdateState(CORE_STEPPING);
 		PC += 4;
 	}
 


### PR DESCRIPTION
This allows Sol Trigger to go much further by ignoring MIPS error .

fix issue #1204 
