### PR TITLE
Allocate the temp texcache buffers dynamically

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -43,7 +43,6 @@ u32 RoundUpToPowerOf2(u32 v)
 
 TextureCache::TextureCache() {
 	lastBoundTexture = -1;
-	// TODO: Switch to aligned allocations for alignment. AllocateMemoryPages would do the trick.
 	// This is 5MB of temporary storage. Might be possible to shrink it.
 	tmpTexBuf32.resize(1024 * 512);  // 2MB
 	tmpTexBuf16.resize(1024 * 512);  // 1MB

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "../Globals.h"
+#include "Common/MemoryUtil.h"
 #include "gfx_es2/fbo.h"
 #include "GPU/GPUState.h"
 
@@ -108,7 +109,7 @@ private:
 
 		~SimpleBuf() {
 			if (buf_ != NULL) {
-				delete [] buf_;
+				FreeMemoryPages(buf_, size_ * sizeof(T));
 			}
 		}
 
@@ -120,9 +121,9 @@ private:
 		void resize(size_t size) {
 			if (size_ < size) {
 				if (buf_ != NULL) {
-					delete [] buf_;
+					FreeMemoryPages(buf_, size_ * sizeof(T));
 				}
-				buf_ = new T[size];
+				buf_ = (T *)AllocateMemoryPages(size * sizeof(T));
 				size_ = size;
 			}
 		}

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -96,10 +96,54 @@ private:
 	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
 
-	u32 *tmpTexBuf32;
-	u16 *tmpTexBuf16;
+	template <typename T>
+	class SimpleBuf {
+	public:
+		SimpleBuf() : buf_(NULL), size_(0) {
+		}
 
-	u32 *tmpTexBufRearrange;
+		SimpleBuf(size_t size) : buf_(NULL) {
+			resize(size);
+		}
+
+		~SimpleBuf() {
+			if (buf_ != NULL) {
+				delete [] buf_;
+			}
+		}
+
+		inline T &operator[](size_t index) {
+			return buf_[index];
+		}
+
+		// Doesn't preserve contents.
+		void resize(size_t size) {
+			if (size_ < size) {
+				if (buf_ != NULL) {
+					delete [] buf_;
+				}
+				buf_ = new T[size];
+				size_ = size;
+			}
+		}
+
+		T *data() {
+			return buf_;
+		}
+
+		size_t size() {
+			return size_;
+		}
+
+	private:
+		T *buf_;
+		size_t size_;
+	};
+
+	SimpleBuf<u32> tmpTexBuf32;
+	SimpleBuf<u16> tmpTexBuf16;
+
+	SimpleBuf<u32> tmpTexBufRearrange;
 
 	u32 *clutBuf32;
 	u16 *clutBuf16;


### PR DESCRIPTION
Fixes Tactics Ogre (which now goes in game to some degree), which wants a 0x400 x 0x400 texture.  I only did the 16 bit cases since that's what it uses.

Also made it use the page alloc per the comment.

-[Unknown]
