### PR TITLE
Buildfix for Blackberry

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -118,9 +118,11 @@ inline float nanclamp(float f, float lower, float upper)
 #define isnan _isnan
 #endif
 
+#ifndef BLACKBERRY
 double rint(double x){
 return floor(x+.5);
 }
+#endif
 
 void ApplyPrefixST(float *v, u32 data, VectorSize size)
 {

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -65,6 +65,10 @@ namespace MainWindow {
 #include <QDir>
 #endif
 
+#if !defined(nullptr)
+#define nullptr NULL
+#endif
+
 // Ugly communication with NativeApp
 extern std::string game_title;
 


### PR DESCRIPTION
1. nullptr is not defined
2. rint is already defined in cmath an std namespace.
