### PR TITLE
Fix headless GPU tests + x64

### DIFF
--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -149,6 +149,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <LargeAddressAware>true</LargeAddressAware>
       <BaseAddress>0x00400000</BaseAddress>
+      <FixedBaseAddress>true</FixedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -219,7 +220,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
-      <BaseAddress>0x400000</BaseAddress>
+      <BaseAddress>0x00400000</BaseAddress>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <FixedBaseAddress>true</FixedBaseAddress>
     </Link>

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -150,7 +150,7 @@ int main(int argc, const char* argv[])
 	host = headlessHost;
 
 	std::string error_string;
-	host->InitGL(&error_string);
+	bool glWorking = host->InitGL(&error_string);
 
 	LogManager::Init();
 	LogManager *logman = LogManager::GetInstance();
@@ -170,7 +170,7 @@ int main(int argc, const char* argv[])
 	coreParameter.mountIso = mountIso ? mountIso : "";
 	coreParameter.startPaused = false;
 	coreParameter.cpuCore = useJit ? CPU_JIT : CPU_INTERPRETER;
-	coreParameter.gpuCore = headlessHost->isGLWorking() ? GPU_GLES : GPU_NULL;
+	coreParameter.gpuCore = glWorking ? GPU_GLES : GPU_NULL;
 	coreParameter.enableSound = false;
 	coreParameter.headLess = true;
 	coreParameter.printfEmuLog = true;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -8,6 +8,7 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/System.h"
+#include "Core/HLE/sceUtility.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/Host.h"
 #include "Log.h"
@@ -166,14 +167,21 @@ int main(int argc, const char* argv[])
 	}
 
 	CoreParameter coreParameter;
-	coreParameter.fileToStart = bootFilename;
-	coreParameter.mountIso = mountIso ? mountIso : "";
-	coreParameter.startPaused = false;
 	coreParameter.cpuCore = useJit ? CPU_JIT : CPU_INTERPRETER;
 	coreParameter.gpuCore = glWorking ? GPU_GLES : GPU_NULL;
 	coreParameter.enableSound = false;
-	coreParameter.headLess = true;
+	coreParameter.fileToStart = bootFilename;
+	coreParameter.mountIso = mountIso ? mountIso : "";
+	coreParameter.startPaused = false;
+	coreParameter.enableDebugging = false;
 	coreParameter.printfEmuLog = true;
+	coreParameter.headLess = true;
+	coreParameter.renderWidth = 480;
+	coreParameter.renderHeight = 272;
+	coreParameter.outputWidth = 480;
+	coreParameter.outputHeight = 272;
+	coreParameter.pixelWidth = 480;
+	coreParameter.pixelHeight = 272;
 	coreParameter.useMediaEngine = false;
 
 	g_Config.bEnableSound = false;
@@ -181,6 +189,20 @@ int main(int argc, const char* argv[])
 	g_Config.bIgnoreBadMemAccess = true;
 	// Never report from tests.
 	g_Config.sReportHost = "";
+	g_Config.bAutoSaveSymbolMap = false;
+	g_Config.bBufferedRendering = true;
+	g_Config.bHardwareTransform = true;
+	g_Config.bUseMediaEngine = true;
+#ifdef USING_GLES2
+	g_Config.iAnisotropyLevel = 0;
+#else
+	g_Config.iAnisotropyLevel = 8;
+#endif
+	g_Config.bVertexCache = true;
+	g_Config.bTrueColor = true;
+	g_Config.ilanguage = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+	g_Config.itimeformat = PSP_SYSTEMPARAM_TIME_FORMAT_24HR;
+	g_Config.bEncryptSave = true;
 
 #if defined(ANDROID)
 #elif defined(BLACKBERRY) || defined(__SYMBIAN32__)
@@ -188,7 +210,6 @@ int main(int argc, const char* argv[])
 	g_Config.memCardDirectory = std::string(getenv("HOME"))+"/.ppsspp/";
 	g_Config.flashDirectory = g_Config.memCardDirectory+"/flash/";
 #endif
-
 
 	if (!PSP_Init(coreParameter, &error_string)) {
 		fprintf(stderr, "Failed to start %s. Error: %s\n", coreParameter.fileToStart.c_str(), error_string.c_str());

--- a/headless/Headless.vcxproj
+++ b/headless/Headless.vcxproj
@@ -88,6 +88,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Winmm.lib;Ws2_32.lib;opengl32.lib;dsound.lib;glu32.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>0x00400000</BaseAddress>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <FixedBaseAddress>true</FixedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -102,6 +105,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Winmm.lib;Ws2_32.lib;opengl32.lib;dsound.lib;glu32.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>0x00400000</BaseAddress>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <FixedBaseAddress>true</FixedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -123,6 +129,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Winmm.lib;Ws2_32.lib;opengl32.lib;dsound.lib;glu32.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>0x00400000</BaseAddress>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <FixedBaseAddress>true</FixedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -141,6 +150,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Winmm.lib;Ws2_32.lib;opengl32.lib;dsound.lib;glu32.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>0x00400000</BaseAddress>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <FixedBaseAddress>true</FixedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -33,7 +33,7 @@ public:
 
 	virtual void SetDebugMode(bool mode) { }
 
-	virtual bool InitGL(std::string *error_message) {return true;}
+	virtual bool InitGL(std::string *error_message) {return false;}
 	virtual void ShutdownGL() {}
 
 	virtual void InitSound(PMixer *mixer) {}
@@ -48,8 +48,6 @@ public:
 
 	virtual void SendDebugOutput(const std::string &output) { printf("%s", output.c_str()); }
 	virtual void SetComparisonScreenshot(const std::string &filename) {}
-
-	virtual bool isGLWorking() { return false; }
 
 
 	// Unique for HeadlessHost

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -78,6 +78,8 @@ void WindowsHeadlessHost::LoadNativeAssets()
 	VFSRegister("", new DirectoryAssetReader("assets/"));
 	VFSRegister("", new DirectoryAssetReader(""));
 	VFSRegister("", new DirectoryAssetReader("../"));
+	VFSRegister("", new DirectoryAssetReader("../Windows/assets/"));
+	VFSRegister("", new DirectoryAssetReader("../Windows/"));
 
 	gl_lost_manager_init();
 
@@ -138,9 +140,8 @@ void WindowsHeadlessHost::SetComparisonScreenshot(const std::string &filename)
 	comparisonScreenshot = filename;
 }
 
-void WindowsHeadlessHost::InitGL()
+bool WindowsHeadlessHost::InitGL(std::string *error_message)
 {
-	glOkay = false;
 	hWnd = CreateHiddenWindow();
 
 	if (WINDOW_VISIBLE)
@@ -160,7 +161,7 @@ void WindowsHeadlessHost::InitGL()
 	pfd.cDepthBits = 16;
 	pfd.iLayerType = PFD_MAIN_PLANE;
 
-#define ENFORCE(x, msg) { if (!(x)) { fprintf(stderr, msg); return; } }
+#define ENFORCE(x, msg) { if (!(x)) { fprintf(stderr, msg); *error_message = msg; return false; } }
 
 	ENFORCE(hDC = GetDC(hWnd), "Unable to create DC.");
 	ENFORCE(pixelFormat = ChoosePixelFormat(hDC, &pfd), "Unable to match pixel format.");
@@ -175,8 +176,7 @@ void WindowsHeadlessHost::InitGL()
 
 	LoadNativeAssets();
 
-	if (ResizeGL())
-		glOkay = true;
+	return ResizeGL();
 }
 
 void WindowsHeadlessHost::ShutdownGL()

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -28,9 +28,8 @@
 class WindowsHeadlessHost : public HeadlessHost
 {
 public:
-	virtual void InitGL();
+	virtual bool InitGL(std::string *error_message);
 	virtual void ShutdownGL();
-	virtual bool isGLWorking() { return glOkay; }
 
 	virtual void SwapBuffers();
 
@@ -42,7 +41,6 @@ private:
 	bool ResizeGL();
 	void LoadNativeAssets();
 
-	bool glOkay;
 	HWND hWnd;
 	HDC hDC;
 	HGLRC hRC;


### PR DESCRIPTION
So, that was it.  I'm still worried about Mac and Linux and such, but I'm glad I can run x64 now.

This fixes the graphics tests crashing.  I made sure all the default settings were carried over, e.g. buffered rendering, which may have been causing some weirdness I experienced before.

The results of gpu/reflection/reflection are interesting - it's not clipped right. But it draws something so I declare it working.  The results of my in-progress material test are also interesting (I need to clean it up now.)

-[Unknown]
