### PR TITLE
Fix sceKernelWakeupThread when called twice

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1404,7 +1404,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		}
 		break;
 
-	// Get UMD file start sector .
+	// Get UMD file start sector.
 	case 0x01020006:
 		INFO_LOG(HLE, "sceIoIoCtl: Asked for start sector of file %i", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
@@ -1425,7 +1425,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			char temp[256];
 			// We want the reported message to include the cmd, so it's unique.
 			sprintf(temp, "sceIoIoctl(%%s, %08x, %%08x, %%x, %%08x, %%x)", cmd);
-			Reporting::ReportMessage(temp, f->fullpath.c_str(), cmd, indataPtr, inlen, outdataPtr, outlen);
+			Reporting::ReportMessage(temp, f->fullpath.c_str(), indataPtr, inlen, outdataPtr, outlen);
 			ERROR_LOG(HLE, "UNIMPL 0=sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outLen %08x", id,cmd,indataPtr,inlen,outdataPtr,outlen);
 		}
 		break;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2238,11 +2238,12 @@ void sceKernelWakeupThread()
 	Thread *t = kernelObjects.Get<Thread>(uid, error);
 	if (t)
 	{
-		if (t->nt.waitType != WAITTYPE_SLEEP) {
+		if (!t->isWaitingFor(WAITTYPE_SLEEP, 1)) {
 			t->nt.wakeupCount++;
 			DEBUG_LOG(HLE,"sceKernelWakeupThread(%i) - wakeupCount incremented to %i", uid, t->nt.wakeupCount);
 			RETURN(0);
 		} else {
+			VERBOSE_LOG(HLE,"sceKernelWakeupThread(%i) - woke thread at %i", uid, t->nt.wakeupCount);
 			__KernelResumeThreadFromWait(uid);
 		}
 	} 
@@ -2286,7 +2287,7 @@ static void __KernelSleepThread(bool doCallbacks) {
 	} else {
 		VERBOSE_LOG(HLE, "sceKernelSleepThread()");
 		RETURN(0);
-		__KernelWaitCurThread(WAITTYPE_SLEEP, 0, 0, 0, doCallbacks, "thread slept");
+		__KernelWaitCurThread(WAITTYPE_SLEEP, 1, 0, 0, doCallbacks, "thread slept");
 	}
 }
 


### PR DESCRIPTION
This func doesn't always _switch_ to the thread, e.g. if it's a worse-priority thread.  Some games were calling sceKernelWakeupThread() a second time before the thread actually ran, and the wakeupCount was not being incremented.

This fixes that by checking that the thread is still in the wait status.

Tales of Eternia now goes to world map (has some graphics issues...) and Final Fantasy 2 works.  Hurray.  May help other games, doesn't seem to have caused any issues.

Also threw in a typo fix.

-[Unknown]
