### PR TITLE
Set the buffer values in sceAtracSetHalfwayBuffer.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -441,6 +441,15 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
+	if (readSize > halfBufferSize)
+		return ATRAC_ERROR_INCORRECT_READ_SIZE;
+
+	Atrac *atrac = getAtrac(atracID);
+	if (atrac) {
+		atrac->first.addr = halfBuffer;
+		atrac->first.size = halfBufferSize;
+		atrac->Analyze();
+	}
 	return 0;
 }
 


### PR DESCRIPTION
We set them in the GetID() one, so ought to here as well.

This is a minor change, and in fact doesn't overlap with #1263.  It does overlap with #997, which implements the same basic thing, but does a bit more.

This prevents "reading into 0" errors and the like in some games, like Zettai Hero Project, which expects `sceAtracGetStreamDataInfo()` to return a valid address after calling this func.  And ultimately that may help since sceIoRead() will return a value the game expects.

-[Unknown]
