### PR TITLE
Improve performance of indexed texture reading

### DIFF
--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -81,6 +81,7 @@ u64 sceKernelGetSystemTimeWide()
 {
 	u64 t = CoreTiming::GetTicks() / CoreTiming::GetClockFrequencyMHz();
 	DEBUG_LOG(HLE,"%i=sceKernelGetSystemTimeWide()",(u32)t);
+	hleEatCycles(1 * 222);
 	return t;
 }
 


### PR DESCRIPTION
This improves the performance of Crimson Gem Saga by a little over 10% on Windows release.

The optimal case seems to be the most common one: no clut shift, mask, or offset.  Knowing that in advance, we can read indexed textures with ~20% of the effort based on a profile.  Actually, there are ways to optimize even the other cases of course, but I don't think I've seen them in any games so far.

Additionally, eats some cycles in sceKernelGetSystemTimeWide() (which doesn't seem free.)  This mostly just makes the game call it less.  Still need to try to make these counts more accurate, but I don't suppose this is very far off.

-[Unknown]
