### PR TITLE
Get a chance to toggle linear filtering in Andriod/iOS

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -23,11 +23,7 @@
 
 Config g_Config;
 
-#ifdef _WIN32
 #define MAX_RECENT 12
-#else
-#define MAX_RECENT 8
-#endif
 
 Config::Config()
 {

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -258,7 +258,7 @@ void MenuScreen::render() {
 
 	int recentW = 350;
 	if (g_Config.recentIsos.size()) {
-		ui_draw2d.DrawText(UBUNTU24, "Recent", -xoff + 20, 80, 0xFFFFFFFF, ALIGN_BOTTOMLEFT);
+		ui_draw2d.DrawText(UBUNTU24, "Recent", -xoff, 80, 0xFFFFFFFF, ALIGN_BOTTOMLEFT);
 	}
 
 	int spacing = 15;
@@ -274,7 +274,7 @@ void MenuScreen::render() {
 		textureButtonWidth = (textureButtonHeight / 80) * 144;
 	}
 
-	VGrid vgrid_recent(-xoff + 20, 100, std::min(dp_yres-spacing*2, 480), spacing, spacing);
+	VGrid vgrid_recent(-xoff, 100, std::min(dp_yres-spacing*2, 480), spacing, spacing);
 
 	for (size_t i = 0; i < g_Config.recentIsos.size(); i++) {
 		std::string filename;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -473,7 +473,7 @@ void SettingsScreen::render() {
 	UICheckBox(GEN_ID, x + columnw, y, "Use Stream VBO", ALIGN_TOPLEFT, &g_Config.bUseVBO);
 #endif
 	UICheckBox(GEN_ID, x, y += stride, "Vertex Cache", ALIGN_TOPLEFT, &g_Config.bVertexCache);
-	UICheckBox(GEN_ID, x + columnw, y, "Use Media Engine", ALIGN_TOPLEFT, &g_Config.bUseMediaEngine);
+	UICheckBox(GEN_ID, x + columnw, y, "Linear Filtering", ALIGN_TOPLEFT, &g_Config.bLinearFiltering);
 
 	UICheckBox(GEN_ID, x, y += stride, "JIT (Dynarec)", ALIGN_TOPLEFT, &g_Config.bJit);
 	if (g_Config.bJit)


### PR DESCRIPTION
Getting few feedback from forum , this option is pretty useful for many games to toggle on and off for those 2D pixelated graphic , hoping to keep it in setting 
menu .

Also pack the recent item close to keep 12 recent items for both small/large screen . 
