### PR TITLE
Respect looping in sceMp3Decode()

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1447,7 +1447,11 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr)
 
 	// Nothing to decode
 	if(ctx->mp3BufPendingSize == 0 || ctx->mp3StreamPosition >= ctx->mp3StreamEnd) {
-		return 0;
+		if (ctx->mp3LoopNum == 0) {
+			return 0;
+		} else if (ctx->mp3LoopNum > 0) {
+			--ctx->mp3LoopNum;
+		}
 	}
 
 	Memory::Memset(ctx->mp3PcmBuf, 0, ctx->mp3PcmBufSize);


### PR DESCRIPTION
This fixes Orbit, which crashed if you stayed on the menu for more than a few seconds, because it kept restarting mp3 decoding and ran out of ram.

JpcspTrace says there's lots wrong with the values we're returning, but this seemed pretty reasonable, and matches sceAtrac.

-[Unknown]
