### PR TITLE
Remember the GE offset in the stack on call/ret

### DIFF
--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -109,6 +109,12 @@ struct FramebufferInfo
 	void* fbo;
 };
 
+struct DisplayListStackEntry
+{
+	u32 pc;
+	u32 offsetAddr;
+};
+
 struct DisplayList
 {
 	int id;
@@ -119,7 +125,7 @@ struct DisplayList
 	SignalBehavior signal;
 	int subIntrBase;
 	u16 subIntrToken;
-	u32 stack[32];
+	DisplayListStackEntry stack[32];
 	int stackptr;
 	bool interrupted;
 	u64 waitTicks;


### PR DESCRIPTION
Tested a bunch of games, none of them seem to mind this either, and LittleBigPlanet still works.  Hopefully fixes the other games in cbbc4e2c9e (none of which I have, though), and seems more reasonable than setting to 0.

Shouldn't merge until someone confirms if it helps anything, probably.

Interestingly, the first time I tested Crisis Core, it broke in the same way it usually breaks later.  After I bisected to be sure, and then retested, it worked fine.  So that proves it's either a badly initialized variable or a timing issue.

-[Unknown]
