### PR TITLE
Convert the OSK params to utf-8, not ASCII

### DIFF
--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -148,7 +148,7 @@ public:
 	virtual int Update();
 	virtual void DoState(PointerWrap &p);
 private:
-	void HackyGetStringWide(std::string& _string, const u32 em_address);
+	void ConvertUCS2ToUTF8(std::string& _string, const u32 em_address);
 	void RenderKeyboard();
 
 	SceUtilityOskParams oskParams;


### PR DESCRIPTION
This fixes Japanese text display for the OSK prompt.  Still can't enter anything but ASCII.

I'm assuming it's UCS-2, but I guess it could also be UTF-16...

-[Unknown]
