### PR TITLE
Fix capping in vf2i

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -622,7 +622,7 @@ namespace MIPSInt
 				d[i] = 0x7FFFFFFF;
 				continue;
 			}
-			float sv = s[i] * mult;
+			double sv = s[i] * mult; // (float)0x7fffffff == (float)0x80000000
 			int dsv;
 			// Cap/floor it to 0x7fffffff / 0x80000000
 			if (sv > 0x7fffffff) sv = 0x7fffffff;


### PR DESCRIPTION
A quick and rough skim lead me to this quick and lazy fix. In short , IEEE 754 single-precision float is not precise enough for storing every int32 value, and you need double for that ;)

BTW, should there be a default case for the switch ((op >> 21) & 0x1f) right following below or dsv could be uninitialized?
