### PR TITLE
Add Greek translation

### DIFF
--- a/lang/gr_EL.ini
+++ b/lang/gr_EL.ini
@@ -1,0 +1,49 @@
+﻿[MainMenu]
+Credits = Συντελεστές
+Exit = Έξοδος
+Load = Φόρτωση...
+Settings = Ρυθμίσεις
+Recent = Πρόσφατα
+[Developer]
+Dump frame to log = Αποτύπωση πλαισίου στον καταγραφέα
+Load language ini = Φόρτωση ini γλώσσας
+Run CPU tests = Εκκίνηση τέστ CPU
+Save language ini = Αποθήκευση ini γλώσσας
+[General]
+Back = Πίσω
+[MainSettings]
+Audio = Ήχος
+AudioDesc = Προσαρμογή Ρυθμίσεων Ήχου
+Controls = Χειριστήριο
+ControlsDesc = Χειριστήριο οθόνης, Μεγάλα Πλήκτρα
+Developer = Προγραμματισμός
+DeveloperDesc = Εκκίνηση τέστ CPU, Αποτύπωση επόμενου πλαισίου στον καταγραφέα
+Graphics = Γραφικά
+GraphicsDesc = Αλλαγή επιλογών γραφικών
+Settings = Ρυθμίσεις
+System = Σύστημα
+SystemDesc = Ενεργοπόιηση Dynarec (JIT), Γρήγορη Μνήμη
+[System]
+Dynarec = Dynarec (JIT)
+Fast Memory = Γρήγορη Μνήμη (ασταθής)
+Show Debug Statistics = Εμφάνιση Στατιστικών Αποσφαλμάτωσης
+Show FPS = Εμφάνιση FPS (ΚΑΔ)
+System Settings = Ρυθμίσεις Συστήματος
+[Audio]
+Audio Settings = Ρυθμίσεις Ήχου
+Enable Sound = Ενεργοποίηση Ήχου
+[Controls]
+Controls Settings = Ρυθμίσεις Χειριστηρίου
+OnScreen = Χειριστήριο Οθόνης Αφής
+Tilt = Κλίση σε Αναλογικό (οριζόντια)
+[Graphics]
+2X = 2x Ανταποδιδόμενη Ανάλυση
+Buffered Rendering = Απεικόνιση με Buffer
+Frame Skipping = Παράκαμψη καρέ
+Graphics Settings = Ρυθμίσεις γραφικών
+Hardware Transform = Hardware Μετασχηματισμός
+Linear Filtering = Γραμμικό φιλτράρισμα
+Media Engine = Media Engine
+Mipmapping = Mipmapping
+Stream VBO = Ροή VBO
+Vertex Cache = Προσορηνή Μνήμη Κορυφών


### PR DESCRIPTION
Same issue with all non western language translations. (Fonts have weird
spacing, missing letters).
I'm pretty positive this is because western fonts include non-western
letters in a weird way, it's exactly the same thing when you see the
full contents of a chinese or japanese font you will notice that there
are some weirdly shaped (they don't follow the artistic style of the
actual font) latin letters that indeed seem to have that extra space
around them compared to the actual native font you use. Feel free to
merge it if and when you believe it's worth it (bug and quality wise).
