### PR TITLE
New updates for Simplified Chinese translation.

### DIFF
--- a/lang/zh_CN.ini
+++ b/lang/zh_CN.ini
@@ -5,12 +5,19 @@ Load = 载入游戏...
 Settings = 设置
 Recent = 最近
 [Developer]
+Developer Tools = 开发工具
 Dump frame to log = 将帧转储为日志
 Load language ini = 载入语言初始化文件
 Run CPU tests = 执行CPU测试
 Save language ini = 保存语言初始化文件
 [General]
-Back = 后退
+Back = 返回
+[Pause]
+Save State = 状态保存
+Load State = 状态载入
+Continue = 继续
+Settings = 设定
+Back to Menu = 返回菜单
 [MainSettings]
 Audio = 音频
 AudioDesc = 调整音频设置
@@ -49,3 +56,4 @@ Media Engine = 媒体引擎
 Mipmapping = 纹理映射贴图
 Stream VBO = 顶点缓冲对象流
 Vertex Cache = 顶点缓存
+Stretch to Display = 拉伸显示


### PR DESCRIPTION
Added 4 sections as follows:
[Developer]
 Developer Tools = 开发工具
 [General]
 Back = 返回
 [Pause]
 Save State = 状态保存
 Load State = 状态载入
 Continue = 继续
 Settings = 设定
 Back to Menu = 返回菜单
[Graphics]
Stretch to Display = 拉伸显示

Thanks for the help of @raven02 !
