### PR TITLE
Improvements in Qt interface

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -30,7 +30,8 @@ MainWindow::MainWindow(QWidget *parent) :
 	memoryWindow(0),
 	memoryTexWindow(0),
 	timer(this),
-	displaylistWindow(0)
+	displaylistWindow(0),
+	lastUIState(UISTATE_MENU)
 {
 	ui->setupUi(this);
 
@@ -94,6 +95,11 @@ void MainWindow::Update()
 			__CtrlButtonUp(controllist[i].psp_id);
 	}
 	__CtrlSetAnalog(input_state.pad_lstick_x, input_state.pad_lstick_y);
+
+	if (lastUIState != globalUIState) {
+		lastUIState = globalUIState;
+		UpdateMenus();
+	}
 }
 
 void MainWindow::UpdateMenus()
@@ -318,19 +324,11 @@ void MainWindow::on_action_FileExit_triggered()
 void MainWindow::on_action_EmulationRun_triggered()
 {
 	NativeMessageReceived("run", "");
-
-	if(dialogDisasm)
-	{
-		dialogDisasm->Stop();
-		dialogDisasm->Go();
-	}
 }
 
 void MainWindow::on_action_EmulationPause_triggered()
 {
 	NativeMessageReceived("pause", "");
-	if(dialogDisasm)
-		dialogDisasm->Stop();
 }
 
 void MainWindow::on_action_EmulationReset_triggered()

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -155,6 +155,7 @@ private:
 	QTimer timer;
 	CoreState nextState;
 	InputState input_state;
+	GlobalUIState lastUIState;
 
 	Debugger_Disasm *dialogDisasm;
 	Debugger_Memory *memoryWindow;

--- a/Qt/qtemugl.cpp
+++ b/Qt/qtemugl.cpp
@@ -1,5 +1,7 @@
 #include "qtemugl.h"
 
+#include <QMouseEvent>
+
 #include "base/display.h"
 #include "base/timeutil.h"
 
@@ -32,4 +34,16 @@ void QtEmuGL::paintGL()
 void QtEmuGL::mouseDoubleClickEvent(QMouseEvent *)
 {
 	emit doubleClick();
+}
+
+void QtEmuGL::mousePressEvent(QMouseEvent *e)
+{
+	input_state->pointer_down[0] = true;
+	input_state->pointer_x[0] = e->x();
+	input_state->pointer_y[0] = e->y();
+}
+
+void QtEmuGL::mouseReleaseEvent(QMouseEvent *e)
+{
+	input_state->pointer_down[0] = false;
 }

--- a/Qt/qtemugl.h
+++ b/Qt/qtemugl.h
@@ -22,6 +22,8 @@ protected:
 	void initializeGL();
 	void paintGL();
 	void mouseDoubleClickEvent(QMouseEvent *);
+	void mousePressEvent(QMouseEvent *e);
+	void mouseReleaseEvent(QMouseEvent *e);
 
 private:
 	InputState *input_state;


### PR DESCRIPTION
Native UI is now clickable, just like SDL version. Pausing/resuming game works both using window menu and native UI.
