### PR TITLE
Add thread delays to sceMpeg

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1339,7 +1339,7 @@ u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 	DEBUG_LOG(HLE, "UNIMPL sceMpegAtracDecode(%08x, %08x, %08x, %i)", mpeg, auAddr, bufferAddr, init);
 	if (Memory::IsValidAddress(bufferAddr))
 		Memory::Memset(bufferAddr, 0, MPEG_ATRAC_ES_OUTPUT_SIZE);
-	return 0;
+	return hleDelayResult(0, "mpeg atrac decode", atracDecodeDelayMs);
 }
 
 // YCbCr -> RGB color space conversion

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -59,7 +59,7 @@ static const int MPEG_AU_MODE_SKIP = 1;
 static const u32 MPEG_MEMSIZE = 0x10000;          // 64k.
 
 static const int MPEG_AVC_DECODE_SUCCESS = 1;       // Internal value.
-static const int MPEG_AVC_DECODE_ERROR_FATAL = -8;
+static const int MPEG_AVC_DECODE_ERROR_FATAL = 0x80628002;
 
 static const int atracDecodeDelay = 3000;         // Microseconds
 static const int avcDecodeDelay = 5400;           // Microseconds

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1100,9 +1100,9 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	sceAu.read(auAddr);
 
 	if (mpegRingbuffer.packetsRead == 0 || mpegRingbuffer.packetsFree == mpegRingbuffer.packets) {
-		// delayThread(mpegErrorDecodeDelay)
 		DEBUG_LOG(HLE, "PSP_ERROR_MPEG_NO_DATA=sceMpegGetAvcAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
-		return PSP_ERROR_MPEG_NO_DATA;
+		// TODO: Does this really reschedule?
+		return hleDelayResult(PSP_ERROR_MPEG_NO_DATA, "mpeg get avc", mpegDecodeErrorDelayMs);
 	}
 
 	auto streamInfo = ctx->streamMap.find(streamId);
@@ -1122,7 +1122,8 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	if (ctx->atracRegistered && (sceAu.pts > sceAu.pts + getMaxAheadTimestamp(mpegRingbuffer)))
 	{
 		ERROR_LOG(HLE, "sceMpegGetAvcAu - video too much ahead");
-		return PSP_ERROR_MPEG_NO_DATA;
+		// TODO: Does this really reschedule?
+		return hleDelayResult(PSP_ERROR_MPEG_NO_DATA, "mpeg get avc", mpegDecodeErrorDelayMs);
 	}
 
 	int result = 0;
@@ -1154,7 +1155,9 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	}
 
 	DEBUG_LOG(HLE, "%x=sceMpegGetAvcAu(%08x, %08x, %08x, %08x)", result, mpeg, streamId, auAddr, attrAddr);
-	return result;
+	// TODO: sceMpegGetAvcAu seems to modify esSize, and delay when it's > 1000 or something.
+	// There's definitely more to it, but ultimately it seems games should expect it to delay randomly.
+	return hleDelayResult(result, "mpeg get avc", 100);
 }
 
 u32 sceMpegFinish()
@@ -1195,7 +1198,8 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 
 	if (mpegRingbuffer.packetsFree == mpegRingbuffer.packets) {
 		DEBUG_LOG(HLE, "PSP_ERROR_MPEG_NO_DATA=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
-		return PSP_ERROR_MPEG_NO_DATA;
+		// TODO: Does this really delay?
+		return hleDelayResult(PSP_ERROR_MPEG_NO_DATA, "mpeg get atrac", mpegDecodeErrorDelayMs);
 	}
 
 	//...
@@ -1217,7 +1221,8 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	}
 
 	DEBUG_LOG(HLE, "%x=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", result, mpeg, streamId, auAddr, attrAddr);
-	return result;
+	// TODO: Not clear on exactly when this delays.
+	return hleDelayResult(result, "mpeg get atrac", 100);
 }
 
 int sceMpegQueryPcmEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)


### PR DESCRIPTION
This is partly based on my testing and partly based on JPCSP.  From testing, the actual delays seem inconsistent (e.g. it doesn't always delay, probably only when it needs to pull or sync something), but JPCSP seems to get away with delaying every time.

After I verified some of the delays happened, I just tested with these delays in a number of games and most of them seemed unaffected.  Still didn't fix the ones that hang, but it did fix Crisis Core.

I'm wanting to construct a reasonable test but mpegs are pretty messy and have a ton of state in actual firmware it seems like.

-[Unknown]
