### PR TITLE
Enable MAKEDATA/READDATA/WRITEDATA

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -90,11 +90,11 @@ int PSPSaveDialog::Init(int paramAddr)
 		case SCE_UTILITY_SAVEDATA_TYPE_FILES:
 		case SCE_UTILITY_SAVEDATA_TYPE_GETSIZE:
 		case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE:
-		//case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
+		case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
 		case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATASECURE:
-		//case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA:
+		case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA:
 		case SCE_UTILITY_SAVEDATA_TYPE_READDATASECURE:
-		//case SCE_UTILITY_SAVEDATA_TYPE_READDATA:
+		case SCE_UTILITY_SAVEDATA_TYPE_READDATA:
 		case SCE_UTILITY_SAVEDATA_TYPE_SINGLEDELETE:
 		case SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA:
 			display = DS_NONE;
@@ -755,7 +755,7 @@ int PSPSaveDialog::Update()
 				break;
 				case SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA:
 					// TODO: This should probably actually delete something.
-					// For now, since MAKEDATA doesn't work anyway, always say it couldn't be deleted.
+					// For now, always say it couldn't be deleted.
 					WARN_LOG(HLE, "FAKE sceUtilitySavedata DELETEDATA: %s", param.GetPspParam()->saveName);
 					param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_STATUS;
 					status = SCE_UTILITY_STATUS_FINISHED;
@@ -772,25 +772,25 @@ int PSPSaveDialog::Update()
 					}
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
-				//case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
+				case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
 				case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE:
-					if(param.Save(param.GetPspParam(),param.GetSelectedSave()))
+					if (param.Save(param.GetPspParam(), param.GetSelectedSave(), param.GetPspParam()->mode == SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE))
 						param.GetPspParam()->result = 0;
 					else
 						param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_RW_NO_DATA;
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
-				//case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA:
+				case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA:
 				case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATASECURE:
-					if(param.Save(param.GetPspParam(),param.GetSelectedSave()))
+					if (param.Save(param.GetPspParam(), param.GetSelectedSave(), param.GetPspParam()->mode == SCE_UTILITY_SAVEDATA_TYPE_WRITEDATASECURE))
 						param.GetPspParam()->result = 0;
 					else
 						param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_RW_NO_DATA;
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
-				//case SCE_UTILITY_SAVEDATA_TYPE_READDATA:
+				case SCE_UTILITY_SAVEDATA_TYPE_READDATA:
 				case SCE_UTILITY_SAVEDATA_TYPE_READDATASECURE:
-					if(param.Load(param.GetPspParam(),param.GetSelectedSave()))
+					if (param.Load(param.GetPspParam(), param.GetSelectedSave(), param.GetPspParam()->mode == SCE_UTILITY_SAVEDATA_TYPE_READDATASECURE))
 						param.GetPspParam()->result = 0;
 					else
 						param.GetPspParam()->result = SCE_UTILITY_SAVEDATA_ERROR_RW_NO_DATA; // not sure if correct code

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -241,7 +241,7 @@ bool SavedataParam::Delete(SceUtilitySavedataParam* param, int saveId)
 	return true;
 }
 
-bool SavedataParam::Save(SceUtilitySavedataParam* param, int saveId)
+bool SavedataParam::Save(SceUtilitySavedataParam* param, int saveId, bool secureMode)
 {
 	if (!param) {
 		return false;
@@ -257,7 +257,8 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, int saveId)
 	u8 cryptedHash[0x10];
 	memset(cryptedHash,0,0x10);
 	// Encrypt save.
-	if(param->dataBuf != 0 && g_Config.bEncryptSave)
+	// TODO: Is this the correct difference between MAKEDATA and MAKEDATASECURE?
+	if (param->dataBuf != 0 && g_Config.bEncryptSave && secureMode)
 	{
 		cryptedSize = param->dataSize;
 		if(cryptedSize == 0 || (SceSize)cryptedSize > param->dataBufSize)
@@ -445,7 +446,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, int saveId)
 	return true;
 }
 
-bool SavedataParam::Load(SceUtilitySavedataParam *param, int saveId)
+bool SavedataParam::Load(SceUtilitySavedataParam *param, int saveId, bool secureMode)
 {
 	if (!param) {
 		return false;
@@ -499,7 +500,7 @@ bool SavedataParam::Load(SceUtilitySavedataParam *param, int saveId)
 	// Don't know what it is, but PSP always respond this and this unlock some game
 	param->bind = 1021;
 
-	bool isCrypted = IsSaveEncrypted(param,saveId);
+	bool isCrypted = IsSaveEncrypted(param,saveId) && secureMode;
 	bool saveDone = false;
 	if(isCrypted)// Try to decrypt
 	{

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -31,18 +31,18 @@ enum SceUtilitySavedataType
 	SCE_UTILITY_SAVEDATA_TYPE_DELETE          = 6,
 	SCE_UTILITY_SAVEDATA_TYPE_LISTDELETE      = 7,
 	SCE_UTILITY_SAVEDATA_TYPE_SIZES           = 8,
-	SCE_UTILITY_SAVEDATA_TYPE_AUTODELETE	  = 9,
+	SCE_UTILITY_SAVEDATA_TYPE_AUTODELETE      = 9,
 	SCE_UTILITY_SAVEDATA_TYPE_SINGLEDELETE    = 10,
 	SCE_UTILITY_SAVEDATA_TYPE_LIST            = 11,
 	SCE_UTILITY_SAVEDATA_TYPE_FILES           = 12,
 	SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE  = 13,
-	SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA		  = 14,
+	SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA        = 14,
 	SCE_UTILITY_SAVEDATA_TYPE_READDATASECURE  = 15,
-	SCE_UTILITY_SAVEDATA_TYPE_READDATA		  = 16,
+	SCE_UTILITY_SAVEDATA_TYPE_READDATA        = 16,
 	SCE_UTILITY_SAVEDATA_TYPE_WRITEDATASECURE = 17,
-	SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA		  = 18,
-	SCE_UTILITY_SAVEDATA_TYPE_ERASESECURE 	  = 19,
-	SCE_UTILITY_SAVEDATA_TYPE_ERASE			  = 20,
+	SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA       = 18,
+	SCE_UTILITY_SAVEDATA_TYPE_ERASESECURE     = 19,
+	SCE_UTILITY_SAVEDATA_TYPE_ERASE           = 20,
 	SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA      = 21,
 	SCE_UTILITY_SAVEDATA_TYPE_GETSIZE         = 22,
 };
@@ -197,8 +197,8 @@ public:
 	std::string GetSaveDirName(SceUtilitySavedataParam* param, int saveId = -1);
 	std::string GetSaveDir(SceUtilitySavedataParam* param, int saveId = -1);
 	bool Delete(SceUtilitySavedataParam* param, int saveId = -1);
-	bool Save(SceUtilitySavedataParam* param, int saveId = -1);
-	bool Load(SceUtilitySavedataParam* param, int saveId = -1);
+	bool Save(SceUtilitySavedataParam* param, int saveId = -1, bool secureMode = true);
+	bool Load(SceUtilitySavedataParam* param, int saveId = -1, bool secureMode = true);
 	bool GetSizes(SceUtilitySavedataParam* param);
 	bool GetList(SceUtilitySavedataParam* param);
 	bool GetFilesList(SceUtilitySavedataParam* param);


### PR DESCRIPTION
Not sure if there's more to them, but LBP saves work between the PSP and PPSSPP with this.

Note that I had a patch/update on my PSP, which generated totally different savedata and confused me initially.  Once I archived the DLC/patches and wiped the savedata, it worked clean.

-[Unknown]
