### PR TITLE
Update zh_TW to "Taiwanese-flavored Traditional Chinese"

### DIFF
--- a/lang/zh_TW.ini
+++ b/lang/zh_TW.ini
@@ -10,7 +10,7 @@ System Settings = 系統設定
 Dynarec = 動態重新編譯 (JIT)
 Fast Memory = 快速記憶體存取 (不穩定)
 Show Debug Statistics = 顯示除錯訊息
-Show FPS = 顯示 FPS
+Show FPS = 顯示每秒張數
 Encrypt Save = 加密儲存資料
 12HR Time Format = 12 小時制
 [Graphics]
@@ -57,7 +57,7 @@ Enable Sound = 開啟聲音
 Controls Settings = 控制器設定
 OnScreen = 顯示虛擬搖桿
 Tilt = 類比左右傾斜對應
-Large Controls = 大按鈕
+Large Controls = 按鈕變大
 Show Analog Stick = 顯示類比搖桿
 [General]
 Back = 返回

--- a/lang/zh_TW.ini
+++ b/lang/zh_TW.ini
@@ -1,83 +1,83 @@
 [MainMenu]
+Load = 載入…
+Settings = 設定
 Credits = 製作人員
-Exit = 退出
-Load = 載入...
-Settings = 設定
-Recent = 最近
-[Developer]
-Developer Tools = 開發工具
-Dump frame to log = 轉儲日誌
-Load language ini = 載入語言設定
-Run CPU tests = 運行CPU測試
-Save language ini = 儲存語言設定
-[General]
-Up = 向上
-Back = 返回
-[MainSettings]
-Audio = 音頻
-AudioDesc = 調整音頻設定
-Controls = 控制
-ControlsDesc = 觸屏控制, 大按鈕
-Developer = 開發者
-DeveloperDesc = 運行CPU測試, 轉儲日誌
-Graphics = 圖形
-GraphicsDesc = 更改圖形選項
-Settings = 設定
-System = 系統
-SystemDesc = 開啟動態重新編譯(即時編譯), 快速閃存
+Exit = 離開
+Recent = 最近執行的遊戲
 [System]
-Dynarec = 動態重新編譯 (即時編譯)
-Fast Memory = 快速閃存 (不穩定)
-Show Debug Statistics = 顯示除錯信息
-Show FPS = 顯示幀數
-System Settings = 系統設定
-Encrypt Save = 加密儲存資料
-12HR Time Format = 12小時制
 Language = 語言設定
-[Audio]
-Audio Settings = 音頻設定
-Enable Sound = 開啟聲音
-[Controls]
-Controls Settings = 控制設定
-OnScreen = 觸屏控制
-Tilt = 重力感應 (水平模式)
-Large Controls = 大按鈕
-Show Analog Stick = 顯示摇杆
+System Settings = 系統設定
+Dynarec = 動態重新編譯 (JIT)
+Fast Memory = 快速記憶體存取 (不穩定)
+Show Debug Statistics = 顯示除錯訊息
+Show FPS = 顯示 FPS
+Encrypt Save = 加密儲存資料
+12HR Time Format = 12 小時制
 [Graphics]
-2X = 2倍渲染分辨率
-Buffered Rendering = 緩衝渲染
-Frame Skipping = 跳幀
-Graphics Settings = 圖形設定
-Hardware Transform = 硬件轉換
-Linear Filtering = 線性過濾
+Stretch to Display = 畫面拉伸至全螢幕
+Hardware Transform = 硬體座標轉換
+Buffered Rendering = 描繪緩衝
+Frame Skipping = 跳格
 Media Engine = 媒體引擎
-Mipmapping = Mipmap貼圖
-Stream VBO = 頂點緩衝對像
-Vertex Cache = 頂點緩存
-Stretch to Display = 延伸顯示
-Draw Wireframe = 顯示幀架
+Graphics Settings = 圖形設定
+Stream VBO = 流動式頂點緩衝物件 (Stream VBO)
+Linear Filtering = 線性過濾
+Mipmapping = Mipmap 貼圖
+2X = 2倍描繪解析度
+Vertex Cache = 頂點快取
+Draw Wireframe = 顯示線框
 [Pause]
-Save State = 儲存狀態
-Load State = 載入狀態
+Save State = 即時存檔
+Load State = 載入存檔
 Continue = 繼續
 Settings = 設定
-Back to Menu = 返回菜單
+Back to Menu = 返回主選單
+[MainSettings]
+Settings = 設定
+Audio = 聲音設定
+AudioDesc = 調整聲音設定
+Graphics = 圖形設定
+GraphicsDesc = 更改各式圖形選項
+System = 系統設定
+SystemDesc = 動態重新編譯 (JIT)、快速記憶體存取
+Controls = 控制器設定
+ControlsDesc = 虛擬搖桿、按鈕變大
+Developer = 開發者工具
+DeveloperDesc = 執行 CPU 測試、記錄執行流程
+[Developer]
+Developer Tools = 開發者工具
+Load language ini = 載入語言 ini
+Save language ini = 儲存語言 ini
+Run CPU tests = 執行 CPU 測試
+Dump frame to log = 記錄下一張畫面的執行流程
+[Audio]
+Audio Settings = 聲音設定
+Enable Sound = 開啟聲音
+[Controls]
+Controls Settings = 控制器設定
+OnScreen = 顯示虛擬搖桿
+Tilt = 類比左右傾斜對應
+Large Controls = 大按鈕
+Show Analog Stick = 顯示類比搖桿
+[General]
+Back = 返回
+Up = 回上層
 [Dialog]
-New Save = 新的存檔
+Back = 返回
 Yes = 是
 No = 否
-Do you want to overwrite the data? = 您想要覆蓋這份檔案嗎？
-Saving = 儲存中\n請稍候...
-Save completed = 儲存完畢
-Loading = 載入中\n請稍候...
-There is no data = 沒有存檔
-DeleteConfirm = 這份檔案將被移除。\n您確定要繼續嗎？
-Deleting = 移除中\n請稍候...
-Delete completed = 移除完畢
-Load completed = 載入完畢
 Enter = 決定
 Select = 選擇
-Back = 返回
-Delete = 移除
+Delete = 刪除
 Finish = 完成
-Caps = 大寫
+Shift = Shift
+New Save = 建立新的存檔
+Do you want to overwrite the data? = 您想要覆蓋這份檔案嗎？
+Saving = 儲存中\n請稍候…
+Save completed = 已儲存。
+Loading = 載入中\n請稍候…
+Load completed = 載入完成。
+There is no data = 沒有存檔
+DeleteConfirm = 這份檔案將被刪除。\n您確定要繼續嗎？
+Deleting = 刪除中\n請稍候…
+Delete completed = 已刪除。


### PR DESCRIPTION
Some of the technical translations are kept such as JIT (popular abbreviation in computer science field) and Stream VBO (difficult to find complete translation).

The order of this ini is matched to en_US so the commit diff may look totally wrong. If you want to keep the original order I may send another.

About "Dump frame to log", I tried to translated it as "Record the execution flow of the next frame". I don't know if it is OK to translate like that.

And because my real PSP is not at hand, I cannot verify some of the translations are matched to a real PSP.
