### PR TITLE
Small optimizations in the emulated GPU

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -497,6 +497,8 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFPTR:
 	case GE_CMD_FRAMEBUFWIDTH:
 	case GE_CMD_FRAMEBUFPIXFORMAT:
+		if (diff)
+			gstate_c.framebufChanged = true;
 		break;
 
 	case GE_CMD_TEXADDR0:
@@ -693,6 +695,10 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_VIEWPORTX1:
 	case GE_CMD_VIEWPORTY1:
+		if (diff)
+			gstate_c.framebufChanged = true;
+		break;
+
 	case GE_CMD_VIEWPORTX2:
 	case GE_CMD_VIEWPORTY2:
 	case GE_CMD_VIEWPORTZ1:

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -290,6 +290,12 @@ void GuessDrawingSize(int &drawing_width, int &drawing_height) {
 }
 
 void FramebufferManager::SetRenderFrameBuffer() {
+	if (!gstate_c.framebufChanged && currentRenderVfb_) {
+		currentRenderVfb_->last_frame_used = gpuStats.numFrames;
+		return;
+	}
+	gstate_c.framebufChanged = false;
+
 	// Get parameters
 	u32 fb_address = (gstate.fbptr & 0xFFE000) | ((gstate.fbwidth & 0xFF0000) << 8);
 	int fb_stride = gstate.fbwidth & 0x3C0;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -4,6 +4,7 @@
 #include "GPUCommon.h"
 #include "GPUState.h"
 #include "ChunkFile.h"
+#include "Core/Config.h"
 #include "Core/CoreTiming.h"
 #include "Core/MemMap.h"
 #include "Core/Host.h"
@@ -359,12 +360,18 @@ u32 GPUCommon::Break(int mode)
 
 bool GPUCommon::InterpretList(DisplayList &list)
 {
+	// Initialized to avoid a race condition with bShowDebugStats changing.
+	double start = 0.0;
+	if (g_Config.bShowDebugStats)
+	{
+		time_update();
+		start = time_now_d();
+	}
+
 	// TODO: This has to be right... but it freezes right now?
 	//if (list.state == PSP_GE_DL_STATE_PAUSED)
 	//	return false;
 
-	time_update();
-	double start = time_now_d();
 	currentList = &list;
 	u32 op = 0;
 	gpuState = GPUSTATE_RUNNING;
@@ -425,8 +432,11 @@ bool GPUCommon::InterpretList(DisplayList &list)
 
 	UpdateCycles(list.pc - 4, list.pc);
 
-	time_update();
-	gpuStats.msProcessingDisplayLists += time_now_d() - start;
+	if (g_Config.bShowDebugStats)
+	{
+		time_update();
+		gpuStats.msProcessingDisplayLists += time_now_d() - start;
+	}
 	return gpuState == GPUSTATE_DONE || gpuState == GPUSTATE_ERROR;
 }
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -252,6 +252,7 @@ struct GPUStateCache
 	u32 offsetAddr;
 
 	bool textureChanged;
+	bool framebufChanged;
 
 	int skipDrawReason;
 

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -82,6 +82,13 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 	// Handle control and drawing commands here directly. The others we delegate.
 	switch (cmd)
 	{
+	case GE_CMD_NOP:
+		if (data != 0)
+			sprintf(buffer, "NOP: %06x", data);
+		else
+			sprintf(buffer, "NOP", data);
+		break;
+
 	case GE_CMD_BASE:
 		sprintf(buffer, "BASE: %06x", data & 0xFFFFFF);
 		break;

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -33,9 +33,9 @@ void GeDescribeVertexType(u32 op, char *buffer, int len) {
 
 	static const char *colorNames[] = {
 		NULL,
-		"unsupported",
-		"unsupported",
-		"unsupported",
+		"unsupported1",
+		"unsupported2",
+		"unsupported3",
 		"BGR 565",
 		"ABGR 1555",
 		"ABGR 4444",
@@ -226,7 +226,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_VERTEXTYPE:
-		sprintf(buffer, "SetVertexType: %06x", data);
+		{
+			int len = sprintf(buffer, "SetVertexType: ");
+			GeDescribeVertexType(op, buffer + len, 256 - len);
+		}
 		break;
 
 	case GE_CMD_OFFSETADDR:

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -90,15 +90,15 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_BASE:
-		sprintf(buffer, "BASE: %06x", data & 0xFFFFFF);
+		sprintf(buffer, "BASE: %06x", data);
 		break;
 
-	case GE_CMD_VADDR:		/// <<8????
-		sprintf(buffer, "VADDR: %06x", gstate_c.vertexAddr);
+	case GE_CMD_VADDR:
+		sprintf(buffer, "VADDR: %06x => %08x", data, gstate_c.getRelativeAddress(data));
 		break;
 
 	case GE_CMD_IADDR:
-		sprintf(buffer, "IADDR: %06x", gstate_c.indexAddr);
+		sprintf(buffer, "IADDR: %06x => %08x", data, gstate_c.getRelativeAddress(data));
 		break;
 
 	case GE_CMD_PRIM:
@@ -126,7 +126,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			int bz_ucount = data & 0xFF;
 			int bz_vcount = (data >> 8) & 0xFF;
-			sprintf(buffer, "DRAW BEZIER: %i x %i", bz_ucount, bz_vcount);
+			if (data & 0xFF0000)
+				sprintf(buffer, "DRAW BEZIER: %i x %i (extra %x)", bz_ucount, bz_vcount, data >> 16);
+			else
+				sprintf(buffer, "DRAW BEZIER: %i x %i", bz_ucount, bz_vcount);
 		}
 		break;
 
@@ -136,7 +139,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 			int sp_vcount = (data >> 8) & 0xFF;
 			int sp_utype = (data >> 16) & 0x3;
 			int sp_vtype = (data >> 18) & 0x3;
-			sprintf(buffer, "DRAW SPLINE: %i x %i, %i x %i", sp_ucount, sp_vcount, sp_utype, sp_vtype);
+			if (data & 0xF00000)
+				sprintf(buffer, "DRAW SPLINE: %i x %i, %i x %i (extra %x)", sp_ucount, sp_vcount, sp_utype, sp_vtype, data >> 20);
+			else
+				sprintf(buffer, "DRAW SPLINE: %i x %i, %i x %i", sp_ucount, sp_vcount, sp_utype, sp_vtype);
 		}
 		break;
 
@@ -156,7 +162,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_RET:
-		sprintf(buffer, "CMD RET");
+		if (data)
+			sprintf(buffer, "CMD RET: %06x", data);
+		else
+			sprintf(buffer, "CMD RET");
 		break;
 
 	case GE_CMD_SIGNAL:
@@ -168,57 +177,64 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_END:
-		sprintf(buffer, "CMD END");
 		switch (prev >> 24)
 		{
 		case GE_CMD_SIGNAL:
 			{
+				sprintf(buffer, "CMD END - ");
 				// TODO: see http://code.google.com/p/jpcsp/source/detail?r=2935#
 				int behaviour = (prev >> 16) & 0xFF;
 				int signal = prev & 0xFFFF;
-				int enddata = data & 0xFFFF;
+				int enddata = data & 0xFFFFFF;
 				// We should probably defer to sceGe here, no sense in implementing this stuff in every GPU
 				switch (behaviour) {
-				case 1:  // Signal with Wait
-					sprintf(buffer, "Signal with Wait UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+				case 1:
+					sprintf(buffer, "Signal with wait. signal/end: %04x %04x", signal, enddata);
 					break;
 				case 2:
 					sprintf(buffer, "Signal without wait. signal/end: %04x %04x", signal, enddata);
 					break;
 				case 3:
-					sprintf(buffer, "Signal with Pause UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					sprintf(buffer, "Signal with pause. signal/end: %04x %04x", signal, enddata);
+					break;
+				case 8:
+					sprintf(buffer, "Signal with sync. signal/end: %04x %04x", signal, enddata);
 					break;
 				case 0x10:
-					sprintf(buffer, "Signal with Jump UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					sprintf(buffer, "Signal with jump. signal/end: %04x %04x", signal, enddata);
 					break;
 				case 0x11:
-					sprintf(buffer, "Signal with Call UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					sprintf(buffer, "Signal with call. signal/end: %04x %04x", signal, enddata);
 					break;
 				case 0x12:
-					sprintf(buffer, "Signal with Return UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
+					sprintf(buffer, "Signal with return. signal/end: %04x %04x", signal, enddata);
 					break;
 				default:
-					sprintf(buffer, "UNKNOWN Signal UNIMPLEMENTED %i ! signal/end: %04x %04x", behaviour, signal, enddata);
+					sprintf(buffer, "UNKNOWN Signal UNIMPLEMENTED %i! signal/end: %04x %04x", behaviour, signal, enddata);
 					break;
 				}
 			}
 			break;
 		case GE_CMD_FINISH:
+			if (data)
+				sprintf(buffer, "CMD END: %06x", data);
+			else
+				sprintf(buffer, "CMD END");
 			break;
 		default:
-			sprintf(buffer, "Ah, not finished: %06x", prev & 0xFFFFFF);
+			sprintf(buffer, "CMD END: %06x, not finished (%08x)", data, prev);
 			break;
 		}
 		break;
 
 	case GE_CMD_BJUMP:
 		// bounding box jump. Let's just not jump, for now.
-		sprintf(buffer, "BBOX JUMP - unimplemented");
+		sprintf(buffer, "BBOX JUMP - unimplemented: %06x", data);
 		break;
 
 	case GE_CMD_BOUNDINGBOX:
 		// bounding box test. Let's do nothing.
-		sprintf(buffer, "BBOX TEST - unimplemented");
+		sprintf(buffer, "BBOX TEST - unimplemented: %06x", data);
 		break;
 
 	case GE_CMD_ORIGIN:
@@ -240,8 +256,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			int x1 = data & 0x3ff;
 			int y1 = data >> 10;
-			//topleft
-			sprintf(buffer, "Region TL: %d %d", x1, y1);
+			if (data & 0xF00000)
+				sprintf(buffer, "Region TL: %d %d (extra %x)", x1, y1, data >> 20);
+			else
+				sprintf(buffer, "Region TL: %d %d", x1, y1);
 		}
 		break;
 
@@ -249,16 +267,19 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			int x2 = data & 0x3ff;
 			int y2 = data >> 10;
-			sprintf(buffer, "Region BR: %d %d", x2, y2);
+			if (data & 0xF00000)
+				sprintf(buffer, "Region BR: %d %d (extra %x)", x2, y2, data >> 20);
+			else
+				sprintf(buffer, "Region BR: %d %d", x2, y2);
 		}
 		break;
 
 	case GE_CMD_CLIPENABLE:
-		sprintf(buffer, "Clip Enable: %i", data);
+		sprintf(buffer, "Clip enable: %i", data);
 		break;
 
 	case GE_CMD_CULLFACEENABLE:
-		sprintf(buffer, "CullFace Enable: %i", data);
+		sprintf(buffer, "CullFace enable: %i", data);
 		break;
 
 	case GE_CMD_TEXTUREMAPENABLE:
@@ -270,11 +291,11 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_FOGENABLE:
-		sprintf(buffer, "Fog Enable: %i", data);
+		sprintf(buffer, "Fog enable: %i", data);
 		break;
 
 	case GE_CMD_DITHERENABLE:
-		sprintf(buffer, "Dither Enable: %i", data);
+		sprintf(buffer, "Dither enable: %i", data);
 		break;
 
 	case GE_CMD_OFFSETX:
@@ -286,33 +307,39 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_TEXSCALEU:
-		sprintf(buffer, "Texture U Scale: %f", gstate_c.uScale);
+		sprintf(buffer, "Texture U scale: %f", getFloat24(data));
 		break;
 
 	case GE_CMD_TEXSCALEV:
-		sprintf(buffer, "Texture V Scale: %f", gstate_c.vScale);
+		sprintf(buffer, "Texture V scale: %f", getFloat24(data));
 		break;
 
 	case GE_CMD_TEXOFFSETU:
-		sprintf(buffer, "Texture U Offset: %f", gstate_c.uOff);
+		sprintf(buffer, "Texture U offset: %f", getFloat24(data));
 		break;
 
 	case GE_CMD_TEXOFFSETV:
-		sprintf(buffer, "Texture V Offset: %f", gstate_c.vOff);
+		sprintf(buffer, "Texture V offset: %f", getFloat24(data));
 		break;
 
 	case GE_CMD_SCISSOR1:
 		{
 			int x1 = data & 0x3ff;
 			int y1 = data >> 10;
-			sprintf(buffer, "Scissor TL: %i, %i", x1,y1);
+			if (data & 0xF00000)
+				sprintf(buffer, "Scissor TL: %i, %i (extra %x)", x1, y1, data >> 20);
+			else
+				sprintf(buffer, "Scissor TL: %i, %i", x1, y1);
 		}
 		break;
 	case GE_CMD_SCISSOR2:
 		{
 			int x2 = data & 0x3ff;
 			int y2 = data >> 10;
-			sprintf(buffer, "Scissor BR: %i, %i", x2, y2);
+			if (data & 0xF00000)
+				sprintf(buffer, "Scissor BR: %i, %i (extra %x)", x2, y2, data >> 20);
+			else
+				sprintf(buffer, "Scissor BR: %i, %i", x2, y2);
 		}
 		break;
 
@@ -333,7 +360,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 	case GE_CMD_FRAMEBUFPTR:
 		{
 			u32 ptr = op & 0xFFE000;
-			sprintf(buffer, "FramebufPtr: %08x", ptr);
+			if (data & ~0xFFE000)
+				sprintf(buffer, "FramebufPtr: %08x (extra %x)", ptr, data);
+			else
+				sprintf(buffer, "FramebufPtr: %08x", ptr);
 		}
 		break;
 
@@ -379,7 +409,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_LOADCLUT:
 		// This could be used to "dirty" textures with clut.
-		sprintf(buffer, "Clut load");
+		if (data)
+			sprintf(buffer, "Clut load: %06x", data);
+		else
+			sprintf(buffer, "Clut load");
 		break;
 
 	case GE_CMD_TEXMAPMODE:
@@ -392,13 +425,19 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_CLUTFORMAT:
 		{
-			sprintf(buffer, "Clut format: %06x", data);
+			const char *clutformats[] = {
+				"BGR 5650",
+				"ABGR 1555",
+				"ABGR 4444",
+				"ABGR 8888",
+			};
+			sprintf(buffer, "Clut format: %06x (%s)", data, clutformats[data & 3]);
 		}
 		break;
 
 	case GE_CMD_TRANSFERSRC:
 		{
-			sprintf(buffer, "Block Transfer Src: %06x", data);
+			sprintf(buffer, "Block transfer src: %06x", data);
 			// Nothing to do, the next one prints
 		}
 		break;
@@ -407,14 +446,17 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			u32 xferSrc = (gstate.transfersrc & 0x00FFFFFF) | ((data & 0xFF0000) << 8);
 			u32 xferSrcW = gstate.transfersrcw & 1023;
-			sprintf(buffer, "Block Transfer Src: %08x	W: %i", xferSrc, xferSrcW);
+			if (data & ~0xFF03FF)
+				sprintf(buffer, "Block transfer src: %08x	W: %i (extra %x)", xferSrc, xferSrcW, data);
+			else
+				sprintf(buffer, "Block transfer src: %08x	W: %i", xferSrc, xferSrcW);
 			break;
 		}
 
 	case GE_CMD_TRANSFERDST:
 		{
 			// Nothing to do, the next one prints
-			sprintf(buffer, "Block Transfer Dst: %06x", data);
+			sprintf(buffer, "Block transfer dst: %06x", data);
 		}
 		break;
 
@@ -422,7 +464,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			u32 xferDst = (gstate.transferdst & 0x00FFFFFF) | ((data & 0xFF0000) << 8);
 			u32 xferDstW = gstate.transferdstw & 1023;
-			sprintf(buffer, "Block Transfer Dest: %08x	W: %i", xferDst, xferDstW);
+			if (data & ~0xFF03FF)
+				sprintf(buffer, "Block transfer dest: %08x	W: %i (extra %x)", xferDst, xferDstW, data);
+			else
+				sprintf(buffer, "Block transfer dest: %08x	W: %i", xferDst, xferDstW);
 			break;
 		}
 
@@ -430,7 +475,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			u32 x = (data & 1023)+1;
 			u32 y = ((data>>10) & 1023)+1;
-			sprintf(buffer, "Block Transfer Src Rect TL: %i, %i", x, y);
+			if (data & 0xF00000)
+				sprintf(buffer, "Block transfer src rect TL: %i, %i (extra %x)", x, y, data >> 20);
+			else
+				sprintf(buffer, "Block transfer src rect TL: %i, %i", x, y);
 			break;
 		}
 
@@ -438,7 +486,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			u32 x = (data & 1023)+1;
 			u32 y = ((data>>10) & 1023)+1;
-			sprintf(buffer, "Block Transfer Dest Rect TL: %i, %i", x, y);
+			if (data & 0xF00000)
+				sprintf(buffer, "Block transfer dest rect TL: %i, %i (extra %x)", x, y, data >> 20);
+			else
+				sprintf(buffer, "Block transfer dest rect TL: %i, %i", x, y);
 			break;
 		}
 
@@ -446,15 +497,19 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			u32 w = (data & 1023)+1;
 			u32 h = ((data>>10) & 1023)+1;
-			sprintf(buffer, "Block Transfer Rect Size: %i x %i", w, h);
+			if (data & 0xF00000)
+				sprintf(buffer, "Block transfer rect size: %i x %i (extra %x)", w, h, data >> 20);
+			else
+				sprintf(buffer, "Block transfer rect size: %i x %i", w, h);
 			break;
 		}
 
 	case GE_CMD_TRANSFERSTART:  // Orphis calls this TRXKICK
-		{
-			sprintf(buffer, "Block Transfer Start");
-			break;
-		}
+		if (data)
+			sprintf(buffer, "Block transfer start: %x", data);
+		else
+			sprintf(buffer, "Block transfer start");
+		break;
 
 	case GE_CMD_TEXSIZE0:
 	case GE_CMD_TEXSIZE1:
@@ -467,49 +522,50 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		{
 			int w = 1 << (data & 0xf);
 			int h = 1 << ((data>>8) & 0xf);
-			sprintf(buffer, "Texture Size %i: %06x, width : %d, height : %d", cmd - GE_CMD_TEXSIZE0, data, w, h);
+			sprintf(buffer, "Texture size %i: %06x, width : %d, height : %d", cmd - GE_CMD_TEXSIZE0, data, w, h);
 		}
 		break;
 
 	case GE_CMD_ZBUFPTR:
 		{
 			u32 ptr = op & 0xFFE000;
-			sprintf(buffer, "Zbuf Ptr: %06x", ptr);
+			if (data & ~0xFFE000)
+				sprintf(buffer, "Zbuf ptr: %06x (extra %x)", ptr, data);
+			else
+				sprintf(buffer, "Zbuf ptr: %06x", ptr);
 		}
 		break;
 
 	case GE_CMD_ZBUFWIDTH:
-		{
-			sprintf(buffer, "Zbuf Width: %06x", data);
-		}
+		sprintf(buffer, "Zbuf width: %06x", data);
 		break;
 
 	case GE_CMD_AMBIENTCOLOR:
-		sprintf(buffer, "Ambient Color: %06x",	data);
+		sprintf(buffer, "Ambient color: %06x", data);
 		break;
 
 	case GE_CMD_AMBIENTALPHA:
-		sprintf(buffer, "Ambient Alpha: %06x",	data);
+		sprintf(buffer, "Ambient alpha: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALAMBIENT:
-		sprintf(buffer, "Material Ambient Color: %06x",	data);
+		sprintf(buffer, "Material ambient color: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALDIFFUSE:
-		sprintf(buffer, "Material Diffuse Color: %06x",	data);
+		sprintf(buffer, "Material diffuse color: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALEMISSIVE:
-		sprintf(buffer, "Material Emissive Color: %06x",	data);
+		sprintf(buffer, "Material emissive color: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALSPECULAR:
-		sprintf(buffer, "Material Specular Color: %06x",	data);
+		sprintf(buffer, "Material specular color: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALALPHA:
-		sprintf(buffer, "Material Alpha Color: %06x",	data);
+		sprintf(buffer, "Material alpha color: %06x", data);
 		break;
 
 	case GE_CMD_MATERIALSPECULARCOEF:
@@ -517,11 +573,17 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_SHADEMODE:
-		sprintf(buffer, "Shade: %06x (%s)", data, data ? "gouraud" : "flat");
+		if (data & ~1)
+			sprintf(buffer, "Shade: %06x (%s, extra %x)", data, data ? "gouraud" : "flat", data);
+		else
+			sprintf(buffer, "Shade: %06x (%s)", data, data ? "gouraud" : "flat");
 		break;
 
 	case GE_CMD_LIGHTMODE:
-		sprintf(buffer, "Lightmode: %06x (%s)", data, data ? "separate spec" : "single color");
+		if (data & ~1)
+			sprintf(buffer, "Lightmode: %06x (%s, extra %x)", data, data ? "separate spec" : "single color", data);
+		else
+			sprintf(buffer, "Lightmode: %06x (%s)", data, data ? "separate spec" : "single color");
 		break;
 
 	case GE_CMD_LIGHTTYPE0:
@@ -611,14 +673,17 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_CULL:
-		sprintf(buffer, "cull: %06x", data);
+		sprintf(buffer, "Cull: %06x", data);
 		break;
 
 	case GE_CMD_PATCHDIVISION:
 		{
 			int patch_div_s = data & 0xFF;
 			int patch_div_t = (data >> 8) & 0xFF;
-			sprintf(buffer, "Patch subdivision: %i x %i", patch_div_s, patch_div_t);
+			if (data & 0xFF0000)
+				sprintf(buffer, "Patch subdivision: %i x %i (extra %x)", patch_div_s, patch_div_t, data & 0xFF0000);
+			else
+				sprintf(buffer, "Patch subdivision: %i x %i", patch_div_s, patch_div_t);
 		}
 		break;
 
@@ -635,7 +700,7 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_MATERIALUPDATE:
-		sprintf(buffer, "Material Update: %d", data);
+		sprintf(buffer, "Material update: %d", data);
 		break;
 
 
@@ -643,7 +708,6 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 	//	CLEARING
 	//////////////////////////////////////////////////////////////////
 	case GE_CMD_CLEARMODE:
-		// If it becomes a performance problem, check diff&1
 		sprintf(buffer, "Clear mode: %06x", data);
 		break;
 
@@ -672,7 +736,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_ALPHATEST:
-		sprintf(buffer, "Alpha test settings");
+		{
+			const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };	// never/always don't make sense
+			sprintf(buffer, "Alpha test settings: %x (%s)", data, alphaTestFuncs[data & 7]);
+		}
 		break;
 
 	case GE_CMD_ANTIALIASENABLE:
@@ -680,11 +747,11 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_PATCHCULLENABLE:
-		sprintf(buffer, "Antialias enable: %d", data);
+		sprintf(buffer, "Patch cull enable: %d", data);
 		break;
 
 	case GE_CMD_COLORTESTENABLE:
-		sprintf(buffer, "Color Test enable: %d", data);
+		sprintf(buffer, "Color test enable: %d", data);
 		break;
 
 	case GE_CMD_LOGICOPENABLE:
@@ -692,14 +759,32 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_TEXFUNC:
-		sprintf(buffer, "TexFunc %i", data&7);
+		{
+			const char *texfuncs[] = {
+				"modulate",
+				"decal",
+				"blend",
+				"replace",
+				"add",
+				"unsupported1",
+				"unsupported2",
+				"unsupported3",
+			};
+			if (data & ~0x107)
+				sprintf(buffer, "TexFunc %i %s (%s, extra %x)", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7], data);
+			else
+				sprintf(buffer, "TexFunc %i %s (%s)", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7]);
+		}
 		break;
 
 	case GE_CMD_TEXFILTER:
 		{
 			int min = data & 7;
 			int mag = (data >> 8) & 1;
-			sprintf(buffer, "TexFilter min: %i mag: %i", min, mag);
+			if (data & ~0x107)
+				sprintf(buffer, "TexFilter min: %i mag: %i (extra %x)", min, mag, data);
+			else
+				sprintf(buffer, "TexFilter min: %i mag: %i", min, mag);
 		}
 		break;
 
@@ -708,27 +793,56 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_TEXMODE:
-		sprintf(buffer, "TexMode %08x", data);
+		sprintf(buffer, "TexMode %06x (%s)", data, data & 1 ? "swizzle" : "no swizzle");
 		break;
 
 	case GE_CMD_TEXFORMAT:
-		sprintf(buffer, "TexFormat %08x", data);
+		{
+			const char *texformats[] = {
+				"5650",
+				"5551"
+				"4444",
+				"8888",
+				"CLUT4",
+				"CLUT8",
+				"CLUT16",
+				"CLUT32",
+				"DXT1",
+				"DXT3",
+				"DXT5",
+				"unsupported1",
+				"unsupported2",
+				"unsupported3",
+				"unsupported4",
+				"unsupported5",
+			};
+			sprintf(buffer, "TexFormat %06x (%s)", data, texformats[data & 0xF]);
+		}
 		break;
 
 	case GE_CMD_TEXFLUSH:
-		sprintf(buffer, "TexFlush");
+		if (data)
+			sprintf(buffer, "TexFlush: %x", data);
+		else
+			sprintf(buffer, "TexFlush");
 		break;
 
 	case GE_CMD_TEXSYNC:
-		sprintf(buffer, "TexSync");
+		if (data)
+			sprintf(buffer, "TexSync: %x", data);
+		else
+			sprintf(buffer, "TexSync");
 		break;
 
 	case GE_CMD_TEXWRAP:
-		sprintf(buffer, "TexWrap %08x", data);
+		sprintf(buffer, "TexWrap %06x", data);
 		break;
 
 	case GE_CMD_TEXLEVEL:
-		sprintf(buffer, "TexWrap Mode: %i Offset: %i", data&3, data >> 16);
+		if (data & ~0xFF0003)
+			sprintf(buffer, "TexWrap mode: %i Offset: %i (extra %x)", data&3, data >> 16, data);
+		else
+			sprintf(buffer, "TexWrap mode: %i Offset: %i", data&3, data >> 16);
 		break;
 
 	case GE_CMD_FOG1:
@@ -752,7 +866,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 	//////////////////////////////////////////////////////////////////
 
 	case GE_CMD_ZTESTENABLE:
-		sprintf(buffer, "Z test enable: %d", data & 1);
+		if (data & ~1)
+			sprintf(buffer, "Z test enable: %d (extra %x)", data & 1, data);
+		else
+			sprintf(buffer, "Z test enable: %d", data & 1);
 		break;
 
 	case GE_CMD_STENCILOP:
@@ -822,7 +939,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_WORLDMATRIXNUMBER:
-		sprintf(buffer, "World # %i", data & 0xF);
+		if (data & ~0xF)
+			sprintf(buffer, "World # %i (extra %x)", data & 0xF, data);
+		else
+			sprintf(buffer, "World # %i", data & 0xF);
 		break;
 
 	case GE_CMD_WORLDMATRIXDATA:
@@ -830,7 +950,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_VIEWMATRIXNUMBER:
-		sprintf(buffer, "VIEW # %i", data & 0xF);
+		if (data & ~0xF)
+			sprintf(buffer, "VIEW # %i (extra %x)", data & 0xF, data);
+		else
+			sprintf(buffer, "VIEW # %i", data & 0xF);
 		break;
 
 	case GE_CMD_VIEWMATRIXDATA:
@@ -838,7 +961,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_PROJMATRIXNUMBER:
-		sprintf(buffer, "PROJECTION # %i", data & 0xF);
+		if (data & ~0xF)
+			sprintf(buffer, "PROJECTION # %i (extra %x)", data & 0xF, data);
+		else
+			sprintf(buffer, "PROJECTION # %i", data & 0xF);
 		break;
 
 	case GE_CMD_PROJMATRIXDATA:
@@ -846,7 +972,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_TGENMATRIXNUMBER:
-		sprintf(buffer, "TGEN # %i", data & 0xF);
+		if (data & ~0xF)
+			sprintf(buffer, "TGEN # %i (extra %x)", data & 0xF, data);
+		else
+			sprintf(buffer, "TGEN # %i", data & 0xF);
 		break;
 
 	case GE_CMD_TGENMATRIXDATA:
@@ -854,7 +983,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_BONEMATRIXNUMBER:
-		sprintf(buffer, "BONE #%i", data);
+		if (data & ~0xF)
+			sprintf(buffer, "BONE #%i (extra %x)", data & 0xF, data);
+		else
+			sprintf(buffer, "BONE #%i", data & 0xF);
 		break;
 
 	case GE_CMD_BONEMATRIXDATA:

--- a/GPU/GeDisasm.h
+++ b/GPU/GeDisasm.h
@@ -17,4 +17,5 @@
 
 #include "Common/CommonTypes.h"
 
+void GeDescribeVertexType(u32 op, char *buffer, int len = 256);
 void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer);


### PR DESCRIPTION
This does a couple things:
- Adds `gstate_c.framebufChanged`, to skip the `SetRenderFrameBuffer()` logic.  Games usually do a bunch of prims to the same buffer, so this saves time.
- Does the same thing to time_update() as is done in syscalls.
- Adds a little more disasm code.

No real huge boost in performance but shaves off a few percent in some games, though usually these games are GPU-limited anyway.

-[Unknown]
