### PR TITLE
Implement _sceSasCoreWithMix correctly.

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -95,7 +95,6 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
 
-	//Memory::Memset(outAddr, 0, sas->GetGrainSize() * 2 * 2);
 	sas->Mix(outAddr);
 	return 0;
 }

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -95,20 +95,20 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
 
-	Memory::Memset(outAddr, 0, sas->GetGrainSize() * 2 * 2);
+	//Memory::Memset(outAddr, 0, sas->GetGrainSize() * 2 * 2);
 	sas->Mix(outAddr);
 	return 0;
 }
 
-// Another way of running the mixer, what was the difference again?
-u32 _sceSasCoreWithMix(u32 core, u32 outAddr, int leftVolume, int rightVolume) {
-	DEBUG_LOG(HLE,"sceSasCoreWithMix(%08x, %08x, %i, %i)", core , outAddr, leftVolume, rightVolume);
+// Another way of running the mixer, the inoutAddr should be both input and output
+u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume) {
+	DEBUG_LOG(HLE,"sceSasCoreWithMix(%08x, %08x, %i, %i)", core , inoutAddr, leftVolume, rightVolume);
 
-	if (!Memory::IsValidAddress(outAddr)) {
+	if (!Memory::IsValidAddress(inoutAddr)) {
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
 
-	sas->Mix(outAddr);
+	sas->Mix(inoutAddr, inoutAddr);
 	return 0;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -265,7 +265,7 @@ static inline s16 clamp_s16(int i) {
 	return i;
 }
 
-void SasInstance::Mix(u32 outAddr) {
+void SasInstance::Mix(u32 outAddr, u32 inAddr) {
 	int voicesPlayingCount = 0;
 	for (int v = 0; v < PSP_SAS_VOICES_MAX; v++) {
 		SasVoice &voice = voices[v];
@@ -373,12 +373,17 @@ void SasInstance::Mix(u32 outAddr) {
 
 	// Alright, all voices mixed. Let's convert and clip, and at the same time, wipe mixBuffer for next time. Could also dither.
 	s16 *outp = (s16 *)Memory::GetPointer(outAddr);
+	s16 *inp = inAddr ? (s16*)Memory::GetPointer(inAddr) : 0;
 	for (int i = 0; i < grainSize * 2; i += 2) {
 		int sampleL = mixBuffer[i] + sendBuffer[i];
+		if (inp)
+			sampleL += *inp++;
 		*outp++ = clamp_s16(sampleL);
 		if (outputMode == 0) {
 			// stereo
 			int sampleR = mixBuffer[i + 1] + sendBuffer[i + 1];
+			if (inp)
+				sampleR += *inp++;
 			*outp++ = clamp_s16(sampleR);
 		}
 	}

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -237,7 +237,7 @@ public:
 
 	FILE *audioDump;
 
-	void Mix(u32 outAddr);
+	void Mix(u32 outAddr, u32 inAddr = 0);
 
 	void DoState(PointerWrap &p);
 


### PR DESCRIPTION
The inoutAddr should be both input and output buffer address. 
Tested FF Dissidia 012 and FF7CC with my media build which only supports ffmpeg. Those games decode atrac3/atrac3plus audios, and then mix it with _sceSasCoreWithMix .
