### PR TITLE
include stdarg.h in Common/Common.h

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 #ifdef _MSC_VER
 #pragma warning (disable:4100)


### PR DESCRIPTION
Fixes gcc 4.7 compile error stated in #1483
