### PR TITLE
Add a "secondary" texture cache for 2d animation and clut changes

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -28,6 +28,8 @@
 
 // If a texture hasn't been seen for this many frames, get rid of it.
 #define TEXTURE_KILL_AGE 200
+// These are cache misses, kill them quicker.
+#define TEXTURE_SECOND_KILL_AGE 30
 
 u32 RoundUpToPowerOf2(u32 v)
 {
@@ -89,7 +91,7 @@ void TextureCache::Decimate() {
 			++iter;
 	}
 	for (TexCache::iterator iter = secondCache.begin(), end = secondCache.end(); iter != end; ) {
-		if (iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFrames) {
+		if (iter->second.lastFrame + TEXTURE_SECOND_KILL_AGE < gpuStats.numFrames) {
 			glDeleteTextures(1, &iter->second.texture);
 			secondCache.erase(iter++);
 		}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -803,6 +803,7 @@ void TextureCache::SetTexture() {
 						match = false;
 						gpuStats.numTextureInvalidations++;
 
+						secondKey = ((u64)entry->addr << 32) | (u64)(entry->fullhash ^ entry->clutaddr);
 						secondCache[secondKey] = *entry;
 						doDelete = false;
 					}

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -84,6 +84,9 @@ private:
 		u8 minFilt;
 		bool sClamp;
 		bool tClamp;
+
+		bool Matches(u16 dim2, u32 hash2, u8 format2, int maxLevel2);
+		bool MatchesClut(bool hasClut, u8 clutformat2, u32 clutaddr2);
 	};
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
@@ -96,6 +99,7 @@ private:
 
 	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
+	TexCache secondCache;
 
 	template <typename T>
 	class SimpleBuf {


### PR DESCRIPTION
I finally found the stupid mistake I made that broke this, so it works now.

The goal here is to avoid re-uploading textures.  This does however make it use more VRAM, which I think @xsacha won't thank me for.  But for 2d animation, and for games that reuse a texture with different cluts, this can be a significant improvement.

Popolocrois goes from 115 vps to 800 vps with this change, looks the same.

Crisis Core and Final Fantasy Type-0 seem unaffected, and LittleBigPlanet seems to lose 1-2 vps (but it's hard to tell for sure.)  Tales of Eternia seems faster (animations) but it's the same vps while still.

On mobile, this seems like a similar story, but there cityhash is more expensive.  But the numbers seem to indicate that, at worst, it just trades cityhash for texture upload.

Popolocrois actually crashes on my iPhone 3GS with memory warnings, though (before and after this change), and it's not allocations, so it must be GPU memory.  And Final Fantasy Tactics still glitches out (not sure if that texture cache or not yet...)

Anyway, I'm not sure how this'll affect performance but I think more testing would be nice.  If it doesn't help overall, we can revert or adjust.

-[Unknown]
