### PR TITLE
Build refix for ios

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -75,6 +75,11 @@ ScreenManager *screenManager;
 std::string config_filename;
 std::string game_title;
 
+#ifdef IOS
+bool isJailed;
+#endif
+
+
 recursive_mutex pendingMutex;
 static bool isMessagePending;
 static std::string pendingMessage;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -34,7 +34,7 @@ extern ScreenManager *screenManager;
 InputState input_state;
 
 extern std::string ram_temp_file;
-bool isJailed;
+extern bool isJailed;
 
 ViewController* sharedViewController;
 


### PR DESCRIPTION
Some commits makes build error for ios(#9b831f8, isJailed was removed from NativeApp.cpp)
I've refix it, sorry for this.
