### PR TITLE
[Experimental] Repair corrupt saves

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -96,6 +96,7 @@ public:
 	bool bButtonPreference;
 	int iLockParentalLevel;
 	bool bEncryptSave;
+	bool bSaveCorruptRepair;
 	int iWlanAdhocChannel;
 	bool bWlanPowerSave;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -608,6 +608,9 @@ namespace MainWindow
 			case ID_OPTIONS_FASTMEMORY:
 				g_Config.bFastMemory = !g_Config.bFastMemory;
 				break;
+			case ID_OPTIONS_REPAIR_SAVE:
+				g_Config.bSaveCorruptRepair = !g_Config.bSaveCorruptRepair;
+				break;
 			case ID_OPTIONS_USEVBO:
 				g_Config.bUseVBO = !g_Config.bUseVBO;
 				break;
@@ -748,6 +751,7 @@ namespace MainWindow
 		CHECKITEM(ID_OPTIONS_WIREFRAME, g_Config.bDrawWireframe);
 		CHECKITEM(ID_OPTIONS_HARDWARETRANSFORM, g_Config.bHardwareTransform);
 		CHECKITEM(ID_OPTIONS_FASTMEMORY, g_Config.bFastMemory);
+		CHECKITEM(ID_OPTIONS_REPAIR_SAVE, g_Config.bSaveCorruptRepair);
 		CHECKITEM(ID_OPTIONS_LINEARFILTERING, g_Config.bLinearFiltering);
 		CHECKITEM(ID_OPTIONS_SIMPLE2XSSAA, g_Config.SSAntiAliasing);
 		CHECKITEM(ID_OPTIONS_STRETCHDISPLAY, g_Config.bStretchToDisplay);

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -269,6 +269,8 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "&Fast Memory (unstable)",		 ID_OPTIONS_FASTMEMORY
         MENUITEM "&Ignore illegal reads/writes", ID_OPTIONS_IGNOREILLEGALREADS
+        MENUITEM SEPARATOR
+        MENUITEM "&Repair Corrupt Save [EXPERIMENTAL]",	ID_OPTIONS_REPAIR_SAVE
     END
     POPUP "&Help"
     BEGIN

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -224,6 +224,7 @@
 #define ID_FILE_LOAD_MEMSTICK           40143
 #define ID_EMULATION_SOUND              40144
 #define ID_OPTIONS_MIPMAP	              40145
+#define ID_OPTIONS_REPAIR_SAVE          40164
 #define IDB_IMAGE_PSP                   40146
 #define IDC_EDIT_KEY_TURBO              40147
 #define IDC_EDIT_KEY_START              40148


### PR DESCRIPTION
Essentially this is a semi-SED implementation for PPSSPP. (since SED/FreeCheat doesn't work very well on emulators)

I say "semi" because this is for cases where you have some encrypted and some decrypted files*\* in your "ms0:/PSP/SAVEDATA/game_id/" folder which may result in the game thinking the save is corrupted.

For example, my testing case was Shining Ark.
While playing Shining Ark I had EncryptSave turned on (default) but later I got curious about what the plaintext save file looked like so I turned off EncryptSave and saved my game. In consecutive runs my save was reported as corrupted. The problem with this is Shining Ark doesn't change all of the files*\* (13) in its savedata folder every time it saves, so this resulted in some files*\* being saved decrypted (the ones it changed) and some files*\* being saved encrypted (the ones it didn't change) which resulted in my save as a whole being "corrupted" when I tried saving or loading the game.

Basically what this does is it replaces the file the game saves with a plaintext save file from "ms0:/PSP/SAVEDATA/<id>/INJECT/". This allows the user to fix corruption if they switch between "EncryptSave = True" and "EncryptSave = False" and not all of the files were saved decrypted.

The drawback with using this implementation for repairing a save file is if you save with this on and you have a plaintext save in the /INJECT/ folder, you won't actually save your progress (since the save in /INJECT/ will replace it). This is why I implemented an option to toggle it in the UI.

*\* = not including always plaintext files (like encrypt_info.bin and param.sfo)
