### PR TITLE
Mask clut indexes for > 8-bit clut indexes.

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -243,8 +243,14 @@ inline void DeIndexTexture(ClutT *dest, const IndexT *indexed, int length, const
 	const bool nakedIndex = (gstate.clutformat & ~3) == 0xC500FF00;
 
 	if (nakedIndex) {
-		for (int i = 0; i < length; ++i) {
-			*dest++ = clut[*indexed++];
+		if (sizeof(IndexT) == 1) {
+			for (int i = 0; i < length; ++i) {
+				*dest++ = clut[*indexed++];
+			}
+		} else {
+			for (int i = 0; i < length; ++i) {
+				*dest++ = clut[(*indexed++) & 0xFF];
+			}
 		}
 	} else {
 		for (int i = 0; i < length; ++i) {


### PR DESCRIPTION
Fixes #1532 (well, I expect it to anyway.)

Yeah, I guess this is used for the shifts and stuff, which make more sense now...

-[Unknown]
