### PR TITLE
Fix black screen when fbo set in first frame

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -133,6 +133,7 @@ FramebufferManager::FramebufferManager() :
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
 	convBuf = new u8[480 * 272 * 4];
+	useBufferedRendering_ = g_Config.bBufferedRendering;
 }
 
 FramebufferManager::~FramebufferManager() {


### PR DESCRIPTION
Because BeginFrame() is actually only called after the first frame.

Well, I guess we could alternatively call BeginFrame() initially.

Fixes Senjou no Valkyria 3 black screen until toggling buffered rendering.

-[Unknown]
