### PR TITLE
Use dark grey color to identify CG is running instead of black

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -33,7 +33,8 @@ void MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelM
 
 	// fake image. To be improved.
 	if (Memory::IsValidAddress(bufferPtr))
-		Memory::Memset(bufferPtr, 0x00, frameWidth * videoHeight_ * bpp);
+		// Use Dark Grey to identify CG is running 
+		Memory::Memset(bufferPtr, 0x69, frameWidth * videoHeight_ * bpp);
 }
 
 void MediaEngine::feedPacketData(u32 addr, int size)


### PR DESCRIPTION
Users always report black screen issue however it is indeed CG is running . It would be of course much better if a better fake image feed into it . Since we will soon have ffmpeg import , i will simply use other color to better identifiy the CG
