### PR TITLE
Fixes to thread funcs, stack, etc.

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -681,7 +681,7 @@ const HLEFunction ThreadManForUser[] =
 	{0x912354a7,&WrapI_I<sceKernelRotateThreadReadyQueue>,"sceKernelRotateThreadReadyQueue"},
 	{0x9ACE131E,sceKernelSleepThread,"sceKernelSleepThread"},
 	{0x82826f70,sceKernelSleepThreadCB,"sceKernelSleepThreadCB"},
-	{0xF475845D,&WrapI_IUU<sceKernelStartThread>,"sceKernelStartThread"},
+	{0xF475845D,&WrapI_IIU<sceKernelStartThread>,"sceKernelStartThread"},
 	{0x9944f31f,sceKernelSuspendThread,"sceKernelSuspendThread"},
 	{0x616403ba,WrapI_I<sceKernelTerminateThread>,"sceKernelTerminateThread"},
 	{0x383f7bcc,WrapI_I<sceKernelTerminateDeleteThread>,"sceKernelTerminateDeleteThread"},

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2263,6 +2263,7 @@ void sceKernelWakeupThread()
 		} else {
 			VERBOSE_LOG(HLE,"sceKernelWakeupThread(%i) - woke thread at %i", uid, t->nt.wakeupCount);
 			__KernelResumeThreadFromWait(uid);
+			hleReSchedule("thread woken up");
 		}
 	} 
 	else {

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -336,12 +336,16 @@ public:
 			return false;
 		}
 
-		// Fill the stack.
-		Memory::Memset(stackBlock, 0xFF, stackSize);
-		context.r[MIPS_REG_SP] = stackBlock + stackSize;
-		stackEnd = context.r[MIPS_REG_SP];
 		nt.initialStack = stackBlock;
 		nt.stackSize = stackSize;
+		return true;
+	}
+
+	bool FillStack() {
+		// Fill the stack.
+		Memory::Memset(stackBlock, 0xFF, nt.stackSize);
+		context.r[MIPS_REG_SP] = stackBlock + nt.stackSize;
+		stackEnd = context.r[MIPS_REG_SP];
 		// What's this 512?
 		context.r[MIPS_REG_K0] = context.r[MIPS_REG_SP] - 256;
 		context.r[MIPS_REG_SP] -= 512;
@@ -1682,7 +1686,7 @@ void __KernelResetThread(Thread *t)
 	t->pendingMipsCalls.clear();
 
 	t->context.r[MIPS_REG_RA] = threadReturnHackAddr; //hack! TODO fix
-	t->AllocateStack(t->nt.stackSize);  // can change the stacksize!
+	t->FillStack();
 }
 
 Thread *__KernelCreateThread(SceUID &id, SceUID moduleId, const char *name, u32 entryPoint, u32 priority, int stacksize, u32 attr)
@@ -1721,6 +1725,8 @@ Thread *__KernelCreateThread(SceUID &id, SceUID moduleId, const char *name, u32 
 
 	strncpy(t->nt.name, name, KERNELOBJECT_MAX_NAME_LENGTH);
 	t->nt.name[KERNELOBJECT_MAX_NAME_LENGTH] = '\0';
+
+	t->AllocateStack(t->nt.stackSize);  // can change the stacksize!
 	return t;
 }
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -37,7 +37,7 @@ void sceKernelExitThread(int exitStatus);
 void _sceKernelExitThread(int exitStatus);
 SceUID sceKernelGetThreadId();
 void sceKernelGetThreadCurrentPriority();
-int sceKernelStartThread(SceUID threadToStartID, u32 argSize, u32 argBlockPtr);
+int sceKernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr);
 u32 sceKernelSuspendDispatchThread();
 u32 sceKernelResumeDispatchThread(u32 suspended);
 int sceKernelWaitThreadEnd(SceUID threadID, u32 timeoutPtr);


### PR DESCRIPTION
This makes a number of changes:
- Corrects `sceKernelReferThreadStatus()` and respects sdk version differences.
- Stops reallocating the stack when terminating/restarting a thread (it's just allocated on create, which is what the PSP firmware seems to do.)
- Fixes a timing issue with `sceKernelWakeupThread()`, which should reschedule to a resumed thread if better priority.
- Returns some better errors / works around potential later errors in sceKernelCreateThread (particularly when stack couldn't be allocated.)
- Returns better errors in sceKernelStartThread (for bad args.)
- Fills the initial stack correctly, with the uid and stack ptr in the right place.
- Correctly aligns args to 0x10 and doesn't corrupt the stack / k0 if there are more than 256 bytes of args.

Unfortunately, this doesn't seem to fix anything I have really, but it doesn't seem to break anything either.

-[Unknown]
