### PR TITLE
Hash cluts rather than using the address

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -787,9 +787,7 @@ void TextureCache::SetTexture() {
 			entry->hash != texhash ||
 			entry->format != format ||
 			entry->maxLevel != maxLevel ||
-			(hasClut &&
-			(entry->clutformat != clutformat ||
-				entry->cluthash != Memory::Read_U32(clutaddr)))) 
+			(hasClut && entry->clutformat != clutformat))
 			match = false;
 
 		if (match) {
@@ -874,7 +872,6 @@ void TextureCache::SetTexture() {
 	if (hasClut) {
 		entry->clutformat = clutformat;
 		entry->clutaddr = clutaddr;
-		entry->cluthash = Memory::Read_U32(clutaddr);
 	} else {
 		entry->clutaddr = 0;
 	}

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -73,7 +73,6 @@ private:
 		u8 clutformat;
 		u16 dim;
 		u32 clutaddr;
-		u32 cluthash;
 		u32 texture;  //GLuint
 		int invalidHint;
 		u32 fullhash;


### PR DESCRIPTION
This significantly improves Final Fantasy Tactics, which no longer has major graphical glitches or huge slowdowns.

Probably could be done better (more efficiently) - assuming e.g. the clutload instruction is only done so often, etc.  Maybe loading into a buffer as you mentioned, as well.  But this approach is nice and simple.

Also, I had to use CityHash32 on the (usually not large) clut, because with any simple checksum I was getting bad colors sometimes.  It seems to be fairly fast.

Also includes a small performance improvement for 4-bit textures.

-[Unknown]
