### PR TITLE
Cleanup texture cache code (get rid of the duplicate)

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1130,7 +1130,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 	Thread *t = kernelObjects.Get<Thread>(threadID, error);
 	if (!t)
 	{
-		ERROR_LOG(HLE, "sceKernelReferThreadStatus Error %08x", error);
+		ERROR_LOG(HLE, "%08x=sceKernelReferThreadStatus(%i, %08x): bad thread", error, threadID, statusPtr);
 		return error;
 	}
 
@@ -1140,7 +1140,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 	{
 		if (wantedSize > THREADINFO_SIZE_AFTER_260)
 		{
-			ERROR_LOG(HLE, "sceKernelReferThreadStatus Error %08x", SCE_KERNEL_ERROR_ILLEGAL_SIZE);
+			ERROR_LOG(HLE, "%08x=sceKernelReferThreadStatus(%i, %08x): bad size %d", SCE_KERNEL_ERROR_ILLEGAL_SIZE, threadID, statusPtr, wantedSize);
 			return SCE_KERNEL_ERROR_ILLEGAL_SIZE;
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1031,8 +1031,7 @@ void *TextureCache::DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 
 			int len = std::max(bufw, w) * h;
 			tmpTexBuf16.resize(len);
 			tmpTexBufRearrange.resize(len);
-			for (int i = 0; i < len; i++)
-				tmpTexBuf16[i] = Memory::ReadUnchecked_U16(texaddr + i * 2);
+			Memory::Memcpy(tmpTexBuf16.data(), texaddr, len * sizeof(u16));
 			finalBuf = tmpTexBuf16.data();
 		}
 		else {
@@ -1047,8 +1046,7 @@ void *TextureCache::DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 
 			int len = bufw * h;
 			tmpTexBuf32.resize(len);
 			tmpTexBufRearrange.resize(len);
-			for (int i = 0; i < len; i++)
-				tmpTexBuf32[i] = Memory::ReadUnchecked_U32(texaddr + i * 4);
+			Memory::Memcpy(tmpTexBuf32.data(), texaddr, len * sizeof(u32));
 			finalBuf = tmpTexBuf32.data();
 		}
 		else {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -92,6 +92,7 @@ private:
 	void *readIndexedTex(int level, u32 texaddr, int bytesPerIndex);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level);
+	void *DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 


### PR DESCRIPTION
- Small improvement to clut loading speed.
- Put a bunch of resize() calls in the right places (may help remasters.)
- Gets rid of the duplicated texture decoding code.
- Reports DXT3 textures.
- Adds a quick log fix/change.

-[Unknown]
