### PR TITLE
Revert sceAtracGetSecondBufferInfo()

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -503,10 +503,18 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 		Memory::Write_U32(0, outBytesAddr);
 		return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
 	}
+
+	// TODO: When sceAtracIsSecondBufferNeeded() says yes, change this function.  Maybe it's wrong anyway.
+#if 0
 	u32 pos = (((atrac->loopEndSample >> (0x100B - atrac->codeType)) + 1) * atrac->atracBytesPerFrame + atrac->second.fileoffset - 1 ) + 1;
 	Memory::Write_U32(pos, outposAddr);
 	Memory::Write_U32(atrac->second.writableBytes - pos, outBytesAddr);
 	return 0;
+#else
+	Memory::Write_U32(0, outposAddr);
+	Memory::Write_U32(0, outBytesAddr);
+	return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
+#endif
 }
 
 u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr)


### PR DESCRIPTION
I don't know if those changes fixed any games, but they seem to confuse games.

Reverting fixes Holy Invasion of Privacy and Valkyrie Profile.  I figured maybe it was just general brokenness when it was only Valkyrie Profile, but the other game works fine (with this reverted.)

-[Unknown]
