### PR TITLE
Improve performance of the GE list interpreter

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -62,9 +62,13 @@ public:
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 
+protected:
+	virtual void FastRunLoop(DisplayList &list);
+
 private:
 	void DoBlockTransfer();
 	void ApplyDrawState(int prim);
+	void CheckFlushOp(u32 op, u32 diff);
 
 	// Applies states for debugging if enabled.
 	void BeginDebugDraw();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -373,8 +373,6 @@ bool GPUCommon::InterpretList(DisplayList &list)
 	//	return false;
 
 	currentList = &list;
-	u32 op = 0;
-	gpuState = GPUSTATE_RUNNING;
 
 	// I don't know if this is the correct place to zero this, but something
 	// need to do it. See Sol Trigger title screen.
@@ -396,6 +394,8 @@ bool GPUCommon::InterpretList(DisplayList &list)
 	downcount = list.stall == 0 ? 0xFFFFFFF : (list.stall - list.pc) / 4;
 	list.state = PSP_GE_DL_STATE_RUNNING;
 	list.interrupted = false;
+
+	gpuState = list.pc == list.stall ? GPUSTATE_STALL : GPUSTATE_RUNNING;
 
 	const bool dumpThisFrame = dumpThisFrame_;
 	// TODO: Add check for displaylist debugger.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -465,7 +465,8 @@ inline void GPUCommon::UpdatePC(u32 currentPC, u32 newPC)
 	cyclesExecuted += 2 * (currentPC - cycleLastPC) / 4;
 	cycleLastPC = newPC == 0 ? currentPC : newPC;
 
-	downcount = currentList->stall == 0 ? 0xFFFFFFF : (currentList->stall - currentList->pc) / 4;
+	// Exit the runloop and recalculate things.  This isn't common.
+	downcount = 0;
 }
 
 inline void GPUCommon::UpdateState(GPUState state)

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -30,7 +30,8 @@ public:
 	virtual u32  Break(int mode);
 
 protected:
-	void UpdateCycles(u32 pc, u32 newPC = 0);
+	void UpdatePC(u32 currentPC, u32 newPC = 0);
+	void UpdateState(GPUState state);
 	void PopDLQueue();
 	void CheckDrawSync();
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -30,6 +30,9 @@ public:
 	virtual u32  Break(int mode);
 
 protected:
+	// To avoid virtual calls to PreExecuteOp().
+	virtual void FastRunLoop(DisplayList &list) = 0;
+	void SlowRunLoop(DisplayList &list);
 	void UpdatePC(u32 currentPC, u32 newPC = 0);
 	void UpdateState(GPUState state);
 	void PopDLQueue();
@@ -47,6 +50,7 @@ protected:
 	u64 drawCompleteTicks;
 	u64 busyTicks;
 
+	int downcount;
 	u64 startingTicks;
 	u32 cycleLastPC;
 	int cyclesExecuted;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -41,6 +41,19 @@ u32 NullGPU::DrawSync(int mode)
 	return GPUCommon::DrawSync(mode);
 }
 
+void NullGPU::FastRunLoop(DisplayList &list) {
+	for (; downcount > 0; --downcount) {
+		u32 op = Memory::ReadUnchecked_U32(list.pc);
+		u32 cmd = op >> 24;
+
+		u32 diff = op ^ gstate.cmdmem[cmd];
+		gstate.cmdmem[cmd] = op;
+		ExecuteOp(op, diff);
+
+		list.pc += 4;
+	}
+}
+
 void NullGPU::ExecuteOp(u32 op, u32 diff)
 {
 	u32 cmd = op >> 24;

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -42,4 +42,7 @@ public:
 	virtual void DumpNextFrame() {}
 
 	virtual void Resized() {}
+
+protected:
+	virtual void FastRunLoop(DisplayList &list);
 };


### PR DESCRIPTION
This adds a `FastRunLoop()` to GPU_GLES and NullGPU.

It has the following benefits:
- stall and gpuState aren't both checked, instead just a downcount.
- when debugging features (like dump frame) are enabled, runs `SlowRunLoop()`, so those can be near-free without compile flags.
- runs `PreExecuteOp()` much faster since it isn't a virtual call.

This wasn't really a bottleneck, but it was showing up in some profiles (mostly for games that already run faster.)  With this change, Lunar and Unchained Blades for example gain 5% performance.

LittleBigPlanet, Final Fantasy Type-0, Tales of Eternia, etc. aren't really affected (well might be, but a tiny bit.)

-[Unknown]
