### PR TITLE
Don't stretch mini icons on the pause screen

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -134,9 +134,10 @@ void Core_RunLoop()
 		// Simple throttling to not burn the GPU in the menu.
 #ifdef _WIN32
 		if (globalUIState != UISTATE_INGAME) {
-			double sleepTime = 16.666 - (time_now_d() - startTime) * 1000.0;
-			if (sleepTime > 0.0)
-				Sleep((int)sleepTime);
+			double diffTime = time_now_d() - startTime;
+			int sleepTime = (int) (1000000.0 / 60.0) - (int) (diffTime * 1000000.0);
+			if (sleepTime > 0)
+				Sleep(sleepTime / 1000);
 			GL_SwapBuffers();
 		} else if (!Core_IsStepping()) {
 			GL_SwapBuffers();

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -389,7 +389,15 @@ void PauseScreen::render() {
 	if (ginfo && ginfo->iconTexture) {
 		uint32_t color = whiteAlpha(ease((time_now_d() - ginfo->timeIconWasLoaded) * 1.5));
 		ginfo->iconTexture->Bind(0);
-		ui_draw2d.DrawTexRect(10,10,10+144, 10+80, 0,0,1,1,0xFFFFFFFF);
+
+		// Maintain the icon's aspect ratio.  Minis are square, for example.
+		float iconAspect = (float)ginfo->iconTexture->Width() / (float)ginfo->iconTexture->Height();
+		float h = 80.0f;
+		float w = 144.0f;
+		float x = 10.0f + (w - h * iconAspect) / 2.0f;
+		w = h * iconAspect;
+
+		ui_draw2d.DrawTexRect(x, 10, x + w, 10 + h, 0, 0, 1, 1, 0xFFFFFFFF);
 		ui_draw2d.Flush();
 		ctx->RebindTexture();
 	}


### PR DESCRIPTION
Also changes the sleep when not ingame, because MSVC (at least in 64-bit) was getting -0.000 from the subtraction.  This one was correct in debug mode, but I figured using ints made sense since Sleep() takes an int anyway.

-[Unknown]
