### PR TITLE
Send GPU, CPU, and platform info into the reporting server

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -213,6 +213,8 @@ namespace Reporting
 		// TODO: Do we care about OS version?
 #if defined(ANDROID)
 		return "Android";
+#elif defined(_WIN64)
+		return "Windows 64";
 #elif defined(_WIN32)
 		return "Windows";
 #elif defined(IOS)
@@ -227,6 +229,10 @@ namespace Reporting
 		return "Blackberry";
 #elif defined(LOONGSON)
 		return "Loongson";
+#elif defined(MEEGO_EDITION_HARMATTAN)
+		return "Nokia N9/N950";
+#elif defined(__linux__)
+		return "Linux";
 #else
 		return "Unknown";
 #endif

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -42,6 +42,60 @@ namespace Reporting
 	// Temporarily stores a reference to the hostname.
 	static std::string lastHostname;
 
+	struct UrlEncoder
+	{
+		UrlEncoder() : paramCount(0)
+		{
+			data.reserve(256);
+		};
+
+		void Add(const std::string &key, const std::string &value)
+		{
+			if (++paramCount > 1)
+				data += '&';
+			AppendEscaped(key);
+			data += '=';
+			AppendEscaped(value);
+		}
+
+		// Percent encoding, aka application/x-www-form-urlencoded.
+		void AppendEscaped(const std::string &value)
+		{
+			for (size_t lastEnd = 0; lastEnd < value.length(); )
+			{
+				size_t pos = value.find_first_not_of(unreservedChars, lastEnd);
+				if (pos == value.npos)
+				{
+					data += value.substr(lastEnd);
+					break;
+				}
+
+				if (pos != lastEnd)
+					data += value.substr(lastEnd, pos - lastEnd);
+				lastEnd = pos;
+
+				// Encode the reserved character.
+				char c = value[pos];
+				data += '%';
+				data += hexChars[(c >> 4) & 15];
+				data += hexChars[(c >> 0) & 15];
+				++lastEnd;
+			}
+		}
+
+		std::string &ToString()
+		{
+			return data;
+		}
+
+		std::string data;
+		int paramCount;
+		static const char *unreservedChars;
+		static const char *hexChars;
+	};
+	const char *UrlEncoder::unreservedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~";
+	const char *UrlEncoder::hexChars = "0123456789ABCDEF";
+
 	enum RequestType
 	{
 		MESSAGE,
@@ -145,34 +199,37 @@ namespace Reporting
 		return result;
 	}
 
+	std::string StripTrailingNull(const std::string &str)
+	{
+		size_t pos = str.find_first_of('\0');
+		if (pos != str.npos)
+			return str.substr(0, pos);
+		return str;
+	}
+
 	int Process(int pos)
 	{
 		Payload &payload = payloadBuffer[pos];
 
-		const int PARAM_BUFFER_SIZE = 4096;
-		char temp[PARAM_BUFFER_SIZE];
-
 		std::string gpuInfo;
 		gpu->GetReportingInfo(gpuInfo);
 
-		// TODO: Need to escape these values, add more.
-		snprintf(temp, PARAM_BUFFER_SIZE - 1, "version=%s&game=%s_%s&game_title=%s&gpu=%s",
-			PPSSPP_GIT_VERSION,
-			g_paramSFO.GetValueString("DISC_ID").c_str(),
-			g_paramSFO.GetValueString("DISC_VERSION").c_str(),
-			g_paramSFO.GetValueString("TITLE").c_str(),
-			gpuInfo.c_str());
+		UrlEncoder postdata;
+		postdata.Add("version", PPSSPP_GIT_VERSION);
+		// TODO: Maybe ParamSFOData shouldn't include nulls in std::strings?  Don't work to break savedata, though...
+		postdata.Add("game", StripTrailingNull(g_paramSFO.GetValueString("DISC_ID")) + "_" + StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION")));
+		postdata.Add("game_title", StripTrailingNull(g_paramSFO.GetValueString("TITLE")));
+		postdata.Add("gpu", gpuInfo);
 
-		std::string data;
 		switch (payload.type)
 		{
 		case MESSAGE:
-			// TODO: Escape.
-			data = std::string(temp) + "&message=" + payload.string1 + "&value=" + payload.string2;
+			postdata.Add("message", payload.string1);
+			postdata.Add("value", payload.string2);
 			payload.string1.clear();
 			payload.string2.clear();
 
-			SendReportRequest("/report/message", data);
+			SendReportRequest("/report/message", postdata.ToString());
 			break;
 		}
 

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -20,6 +20,8 @@
 #include "Common/StdThread.h"
 #include "Core/Config.h"
 #include "Core/System.h"
+#include "GPU/GPUInterface.h"
+#include "GPU/GPUState.h"
 
 #include "net/http_client.h"
 #include "net/resolve.h"
@@ -150,12 +152,16 @@ namespace Reporting
 		const int PARAM_BUFFER_SIZE = 4096;
 		char temp[PARAM_BUFFER_SIZE];
 
+		std::string gpuInfo;
+		gpu->GetReportingInfo(gpuInfo);
+
 		// TODO: Need to escape these values, add more.
-		snprintf(temp, PARAM_BUFFER_SIZE - 1, "version=%s&game=%s_%s&game_title=%s",
+		snprintf(temp, PARAM_BUFFER_SIZE - 1, "version=%s&game=%s_%s&game_title=%s&gpu=%s",
 			PPSSPP_GIT_VERSION,
 			g_paramSFO.GetValueString("DISC_ID").c_str(),
 			g_paramSFO.GetValueString("DISC_VERSION").c_str(),
-			g_paramSFO.GetValueString("TITLE").c_str());
+			g_paramSFO.GetValueString("TITLE").c_str(),
+			gpuInfo.c_str());
 
 		std::string data;
 		switch (payload.type)

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -242,15 +242,16 @@ namespace Reporting
 	{
 		Payload &payload = payloadBuffer[pos];
 
-		std::string gpuInfo;
-		gpu->GetReportingInfo(gpuInfo);
+		std::string gpuPrimary, gpuFull;
+		gpu->GetReportingInfo(gpuPrimary, gpuFull);
 
 		UrlEncoder postdata;
 		postdata.Add("version", PPSSPP_GIT_VERSION);
 		// TODO: Maybe ParamSFOData shouldn't include nulls in std::strings?  Don't work to break savedata, though...
 		postdata.Add("game", StripTrailingNull(g_paramSFO.GetValueString("DISC_ID")) + "_" + StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION")));
 		postdata.Add("game_title", StripTrailingNull(g_paramSFO.GetValueString("TITLE")));
-		postdata.Add("gpu", gpuInfo);
+		postdata.Add("gpu", gpuPrimary);
+		postdata.Add("gpu_full", gpuFull);
 		postdata.Add("cpu", cpu_info.Summarize());
 		postdata.Add("platform", GetPlatformIdentifer());
 

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -17,6 +17,7 @@
 
 #include "Core/Reporting.h"
 
+#include "Common/CPUDetect.h"
 #include "Common/StdThread.h"
 #include "Core/Config.h"
 #include "Core/System.h"
@@ -207,6 +208,30 @@ namespace Reporting
 		return str;
 	}
 
+	std::string GetPlatformIdentifer()
+	{
+		// TODO: Do we care about OS version?
+#if defined(ANDROID)
+		return "Android";
+#elif defined(_WIN32)
+		return "Windows";
+#elif defined(IOS)
+		return "iOS";
+#elif defined(__APPLE__)
+		return "Mac";
+#elif defined(__SYMBIAN32__)
+		return "Symbian";
+#elif defined(__FreeBSD__)
+		return "BSD";
+#elif defined(BLACKBERRY)
+		return "Blackberry";
+#elif defined(LOONGSON)
+		return "Loongson";
+#else
+		return "Unknown";
+#endif
+	}
+
 	int Process(int pos)
 	{
 		Payload &payload = payloadBuffer[pos];
@@ -220,6 +245,10 @@ namespace Reporting
 		postdata.Add("game", StripTrailingNull(g_paramSFO.GetValueString("DISC_ID")) + "_" + StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION")));
 		postdata.Add("game_title", StripTrailingNull(g_paramSFO.GetValueString("TITLE")));
 		postdata.Add("gpu", gpuInfo);
+		postdata.Add("cpu", cpu_info.Summarize());
+		postdata.Add("platform", GetPlatformIdentifer());
+
+		// TODO: Settings, savestate/savedata status, some measure of speed/fps?
 
 		switch (payload.type)
 		{

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -223,7 +223,8 @@ void GLES_GPU::BuildReportingInfo() {
 
 	char temp[2048];
 	snprintf(temp, sizeof(temp), "%s (%s %s), %s (extensions: %s)", glVersion, glVendor, glRenderer, glSlVersion, glExtensions);
-	reportingInfo_ = temp;
+	reportingPrimaryInfo_ = glVendor;
+	reportingFullInfo_ = temp;
 }
 
 void GLES_GPU::DeviceLost() {

--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -60,6 +60,7 @@ public:
 	}
 	virtual bool FramebufferDirty();
 
+	virtual void GetReportingInfo(std::string &info) { info = reportingInfo_; }
 	std::vector<FramebufferInfo> GetFramebufferList();
 
 protected:
@@ -69,6 +70,7 @@ private:
 	void DoBlockTransfer();
 	void ApplyDrawState(int prim);
 	void CheckFlushOp(u32 op, u32 diff);
+	void BuildReportingInfo();
 
 	// Applies states for debugging if enabled.
 	void BeginDebugDraw();
@@ -81,4 +83,6 @@ private:
 
 	u8 *flushBeforeCommand_;
 	bool resized_;
+
+	std::string reportingInfo_;
 };

--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -60,7 +60,10 @@ public:
 	}
 	virtual bool FramebufferDirty();
 
-	virtual void GetReportingInfo(std::string &info) { info = reportingInfo_; }
+	virtual void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) {
+		primaryInfo = reportingPrimaryInfo_;
+		fullInfo = reportingFullInfo_;
+	}
 	std::vector<FramebufferInfo> GetFramebufferList();
 
 protected:
@@ -84,5 +87,6 @@ private:
 	u8 *flushBeforeCommand_;
 	bool resized_;
 
-	std::string reportingInfo_;
+	std::string reportingPrimaryInfo_;
+	std::string reportingFullInfo_;
 };

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -21,6 +21,7 @@
 #include "GPUState.h"
 #include "Core/HLE/sceKernelThread.h"
 #include <list>
+#include <string>
 
 class PointerWrap;
 
@@ -186,6 +187,7 @@ public:
 
 	// Debugging
 	virtual void DumpNextFrame() = 0;
+	virtual void GetReportingInfo(std::string &info) = 0;
 	virtual const std::list<int>& GetDisplayLists() = 0;
 	virtual DisplayList* GetCurrentDisplayList() = 0;
 	virtual bool DecodeTexture(u8* dest, GPUgstate state) = 0;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -187,7 +187,7 @@ public:
 
 	// Debugging
 	virtual void DumpNextFrame() = 0;
-	virtual void GetReportingInfo(std::string &info) = 0;
+	virtual void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) = 0;
 	virtual const std::list<int>& GetDisplayLists() = 0;
 	virtual DisplayList* GetCurrentDisplayList() = 0;
 	virtual bool DecodeTexture(u8* dest, GPUgstate state) = 0;

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -42,7 +42,10 @@ public:
 	virtual void DumpNextFrame() {}
 
 	virtual void Resized() {}
-	virtual void GetReportingInfo(std::string &info) { info = "NULL"; }
+	virtual void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) {
+		primaryInfo = "NULL";
+		fullInfo = "NULL";
+	}
 
 protected:
 	virtual void FastRunLoop(DisplayList &list);

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -42,6 +42,7 @@ public:
 	virtual void DumpNextFrame() {}
 
 	virtual void Resized() {}
+	virtual void GetReportingInfo(std::string &info) { info = "NULL"; }
 
 protected:
 	virtual void FastRunLoop(DisplayList &list);


### PR DESCRIPTION
I think we can just bundle the entire gl info into a single string.  But, there could be benefits to splitting it out (especially vendor, I guess) - what do you think?  Also, not sure if the extensions are overkill.

Also implements a quick escape so we don't have that `+` issue anymore.

The new parameters are currently ignored by the server, though, at the moment.

-[Unknown]
