### PR TITLE
Fix potential crash looking up block_num

### DIFF
--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -247,7 +247,7 @@ void JitBlockCache::GetBlockNumbersFromAddress(u32 em_address, std::vector<int> 
 
 u32 JitBlockCache::GetOriginalFirstOp(int block_num)
 {
-	if (block_num >= num_blocks)
+	if (block_num >= num_blocks || block_num < 0)
 	{
 		//PanicAlert("JitBlockCache::GetOriginalFirstOp - block_num = %u is out of range", block_num);
 		return block_num;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -317,7 +317,7 @@ namespace MIPSAnalyst
 		{
 			Function &f=*iter;
 			u32 hash = 0x1337babe;
-			for (u32 addr = f.start; addr <= f.end; addr++)
+			for (u32 addr = f.start; addr <= f.end; addr += 4)
 			{
 				u32 validbits = 0xFFFFFFFF;
 				u32 instr = Memory::Read_Instruction(addr);

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -117,7 +117,12 @@ u32 Read_Instruction(u32 address)
 	if (MIPS_IS_EMUHACK(inst) && MIPSComp::jit)
 	{
 		JitBlockCache *bc = MIPSComp::jit->GetBlockCache();
-		return bc->GetOriginalFirstOp(bc->GetBlockNumberFromEmuHackOp(inst));
+		int block_num = bc->GetBlockNumberFromEmuHackOp(inst);
+		if (block_num >= 0) {
+			return bc->GetOriginalFirstOp(block_num);
+		} else {
+			return inst;
+		}
 	} else {
 		return inst;
 	}


### PR DESCRIPTION
The root cause: `HashFunctions()` not looking at aligned instructions (`++`.)  But I added a couple other checks to be safe.

Thanks to this log:
http://forums.ppsspp.org/showthread.php?tid=3042&pid=19163#pid19163

-[Unknown]
