### PR TITLE
Rename 2X Render Resolution to "Anti-Aliasing"

### DIFF
--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -687,7 +687,7 @@ void GraphicsScreenP1::render() {
 			gpu->Resized();
 	}
 	if (g_Config.bBufferedRendering) {
-		if (UICheckBox(GEN_ID, x, y += stride, gs->T("2X", "2x Render Resolution"), ALIGN_TOPLEFT, &g_Config.SSAntiAliasing)) {
+		if (UICheckBox(GEN_ID, x, y += stride, gs->T("AA", "Anti-Aliasing"), ALIGN_TOPLEFT, &g_Config.SSAntiAliasing)) {
 			if (gpu)
 				gpu->Resized();
 		}


### PR DESCRIPTION
Looks like without enable "2x render resolution" , we can now see the same native resolution as the one without buffered rendering but instead this 2x render resolution is now working as real Anti-aliasing 
