### PR TITLE
Texture scaling parallelization

### DIFF
--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -34,4 +34,48 @@ std::string MemUsage();
 
 inline int GetPageSize() { return 4096; }
 
+template <typename T>
+class SimpleBuf {
+public:
+	SimpleBuf() : buf_(NULL), size_(0) {
+	}
+
+	SimpleBuf(size_t size) : buf_(NULL) {
+		resize(size);
+	}
+
+	~SimpleBuf() {
+		if (buf_ != NULL) {
+			FreeMemoryPages(buf_, size_ * sizeof(T));
+		}
+	}
+
+	inline T &operator[](size_t index) {
+		return buf_[index];
+	}
+
+	// Doesn't preserve contents.
+	void resize(size_t size) {
+		if (size_ < size) {
+			if (buf_ != NULL) {
+				FreeMemoryPages(buf_, size_ * sizeof(T));
+			}
+			buf_ = (T *)AllocateMemoryPages(size * sizeof(T));
+			size_ = size;
+		}
+	}
+
+	T *data() {
+		return buf_;
+	}
+
+	size_t size() {
+		return size_;
+	}
+
+private:
+	T *buf_;
+	size_t size_;
+};
+
 #endif

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -27,7 +27,6 @@
 #include "Core/Config.h"
 
 #include "native/ext/cityhash/city.h"
-#include "ext/xbrz/xbrz.h"
 
 // If a texture hasn't been seen for this many frames, get rid of it.
 #define TEXTURE_KILL_AGE 200
@@ -1206,78 +1205,10 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level) {
 	// INFO_LOG(G3D, "Creating texture level %i/%i from %08x: %i x %i (stride: %i). fmt: %i", level, entry.maxLevel, texaddr, w, h, bufw, entry.format);
 
 	u32* pixelData = (u32*)finalBuf;
-	ScaleTexture(pixelData, dstFmt, w, h);
+	scaler.Scale(pixelData, dstFmt, w, h);
 
 	GLuint components = dstFmt == GL_UNSIGNED_SHORT_5_6_5 ? GL_RGB : GL_RGBA;
 	glTexImage2D(GL_TEXTURE_2D, level, components, w, h, 0, components, dstFmt, pixelData);
-}
-
-void TextureCache::ScaleTexture(u32* &data, GLenum &dstFmt, int &width, int &height) {
-	if(g_Config.iXBRZTexScalingLevel > 1) {
-		int factor = g_Config.iXBRZTexScalingLevel;
-
-		// I tried to reuse the existing tmpTexBuf initially, but that's not a good idea as data could already be stored in it
-		// depending on the factor and texture sizes, these can be pretty large (25 MB for a 512 by 512 texture with scaling factor 5)
-		tmpTexBufScalingInput.resize(width*height); // used to store the input image image if it needs to be reformatted
-		tmpTexBufScalingOutput.resize(width*height*factor*factor); // used to store the upscaled image
-		u32 *xbrzInputBuf = tmpTexBufScalingInput.data();
-		u32 *xbrzBuf = tmpTexBufScalingOutput.data();
-
-		// convert texture to correct format for xBRZ
-		switch(dstFmt) {
-		case GL_UNSIGNED_BYTE:
-			xbrzInputBuf = data; // already fine
-			break;
-
-		case GL_UNSIGNED_SHORT_4_4_4_4:
-			for(int y = 0; y < height; ++y) {
-				for(int x = 0; x < width; ++x) {
-					u32 val = ((u16*)data)[y*width + x];
-					u32 r = ((val>>12) & 0xF) * 17;
-					u32 g = ((val>> 8) & 0xF) * 17;
-					u32 b = ((val>> 4) & 0xF) * 17;
-					u32 a = ((val>> 0) & 0xF) * 17;
-					xbrzInputBuf[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
-				}
-			}
-			break;
-
-		case GL_UNSIGNED_SHORT_5_6_5:
-			for(int y = 0; y < height; ++y) {
-				for(int x = 0; x < width; ++x) {
-					u32 val = ((u16*)data)[y*width + x];
-					u32 r = ((val>>11) & 0x1F) * 8;
-					u32 g = ((val>> 5) & 0x3F) * 4;
-					u32 b = ((val    ) & 0x1F) * 8;
-					xbrzInputBuf[y*width + x] = (0xFF << 24) | (b << 16) | (g << 8) | r;
-				}
-			}
-			break;
-
-		case GL_UNSIGNED_SHORT_5_5_5_1:
-			for(int y = 0; y < height; ++y) {
-				for(int x = 0; x < width; ++x) {
-					u32 val = ((u16*)data)[y*width + x];
-					u32 r = ((val>>11) & 0x1F) * 8;
-					u32 g = ((val>> 6) & 0x1F) * 8;
-					u32 b = ((val>> 1) & 0x1F) * 8;
-					u32 a = (val & 0x1) * 255;
-					xbrzInputBuf[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
-				}
-			}
-			break;
-
-		default:
-			ERROR_LOG(G3D, "iXBRZTexScaling: unsupported texture format");
-		}
-
-		// scale and update values accordingly
-		xbrz::scale(factor, xbrzInputBuf, xbrzBuf, width, height);
-		data = xbrzBuf;
-		dstFmt = GL_UNSIGNED_BYTE;
-		width *= factor;
-		height *= factor;
-	}
 }
 
 bool TextureCache::DecodeTexture(u8* output, GPUgstate state)

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include "../Globals.h"
-#include "Common/MemoryUtil.h"
 #include "gfx_es2/fbo.h"
 #include "GPU/GPUState.h"
+#include "TextureScaler.h"
 
 struct VirtualFramebuffer;
 
@@ -94,7 +94,6 @@ private:
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level);
 	void *DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);
-	void ScaleTexture(u32* &data, GLenum &dstfmt, int &width, int &height);
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
@@ -102,58 +101,12 @@ private:
 	TexCache cache;
 
 	bool clearCacheNextFrame_;
-
-	template <typename T>
-	class SimpleBuf {
-	public:
-		SimpleBuf() : buf_(NULL), size_(0) {
-		}
-
-		SimpleBuf(size_t size) : buf_(NULL) {
-			resize(size);
-		}
-
-		~SimpleBuf() {
-			if (buf_ != NULL) {
-				FreeMemoryPages(buf_, size_ * sizeof(T));
-			}
-		}
-
-		inline T &operator[](size_t index) {
-			return buf_[index];
-		}
-
-		// Doesn't preserve contents.
-		void resize(size_t size) {
-			if (size_ < size) {
-				if (buf_ != NULL) {
-					FreeMemoryPages(buf_, size_ * sizeof(T));
-				}
-				buf_ = (T *)AllocateMemoryPages(size * sizeof(T));
-				size_ = size;
-			}
-		}
-
-		T *data() {
-			return buf_;
-		}
-
-		size_t size() {
-			return size_;
-		}
-
-	private:
-		T *buf_;
-		size_t size_;
-	};
+	TextureScaler scaler;
 
 	SimpleBuf<u32> tmpTexBuf32;
 	SimpleBuf<u16> tmpTexBuf16;
 
 	SimpleBuf<u32> tmpTexBufRearrange;
-
-	SimpleBuf<u32> tmpTexBufScalingInput;
-	SimpleBuf<u32> tmpTexBufScalingOutput;
 
 	u32 *clutBuf32;
 	u16 *clutBuf16;

--- a/GPU/GLES/TextureScaler.cpp
+++ b/GPU/GLES/TextureScaler.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "TextureScaler.h"
+
+#include "Core/Config.h"
+#include "ext/xbrz/xbrz.h"
+
+void TextureScaler::Scale(u32* &data, GLenum &dstFmt, int &width, int &height) {
+	if(g_Config.iXBRZTexScalingLevel > 1) {
+		int factor = g_Config.iXBRZTexScalingLevel;
+
+		// depending on the factor and texture sizes, these can be pretty large (25 MB for a 512 by 512 texture with scaling factor 5)
+		bufInput.resize(width*height); // used to store the input image image if it needs to be reformatted
+		bufOutput.resize(width*height*factor*factor); // used to store the upscaled image
+		u32 *xbrzInputBuf = bufInput.data();
+		u32 *xbrzBuf = bufOutput.data();
+
+		// convert texture to correct format for xBRZ
+		switch(dstFmt) {
+		case GL_UNSIGNED_BYTE:
+			xbrzInputBuf = data; // already fine
+			break;
+
+		case GL_UNSIGNED_SHORT_4_4_4_4:
+			for(int y = 0; y < height; ++y) {
+				for(int x = 0; x < width; ++x) {
+					u32 val = ((u16*)data)[y*width + x];
+					u32 r = ((val>>12) & 0xF) * 17;
+					u32 g = ((val>> 8) & 0xF) * 17;
+					u32 b = ((val>> 4) & 0xF) * 17;
+					u32 a = ((val>> 0) & 0xF) * 17;
+					xbrzInputBuf[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
+				}
+			}
+			break;
+
+		case GL_UNSIGNED_SHORT_5_6_5:
+			for(int y = 0; y < height; ++y) {
+				for(int x = 0; x < width; ++x) {
+					u32 val = ((u16*)data)[y*width + x];
+					u32 r = ((val>>11) & 0x1F) * 8;
+					u32 g = ((val>> 5) & 0x3F) * 4;
+					u32 b = ((val    ) & 0x1F) * 8;
+					xbrzInputBuf[y*width + x] = (0xFF << 24) | (b << 16) | (g << 8) | r;
+				}
+			}
+			break;
+
+		case GL_UNSIGNED_SHORT_5_5_5_1:
+			for(int y = 0; y < height; ++y) {
+				for(int x = 0; x < width; ++x) {
+					u32 val = ((u16*)data)[y*width + x];
+					u32 r = ((val>>11) & 0x1F) * 8;
+					u32 g = ((val>> 6) & 0x1F) * 8;
+					u32 b = ((val>> 1) & 0x1F) * 8;
+					u32 a = (val & 0x1) * 255;
+					xbrzInputBuf[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
+				}
+			}
+			break;
+
+		default:
+			ERROR_LOG(G3D, "iXBRZTexScaling: unsupported texture format");
+		}
+
+		// scale and update values accordingly
+		xbrz::scale(factor, xbrzInputBuf, xbrzBuf, width, height);
+		data = xbrzBuf;
+		dstFmt = GL_UNSIGNED_BYTE;
+		width *= factor;
+		height *= factor;
+	}
+}

--- a/GPU/GLES/TextureScaler.h
+++ b/GPU/GLES/TextureScaler.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Common/MemoryUtil.h"
+#include "../Globals.h"
+#include "../native/ext/glew/GL/glew.h"
+
+template <typename T>
+class SimpleBuf {
+public:
+	SimpleBuf() : buf_(NULL), size_(0) {
+	}
+
+	SimpleBuf(size_t size) : buf_(NULL) {
+		resize(size);
+	}
+
+	~SimpleBuf() {
+		if (buf_ != NULL) {
+			FreeMemoryPages(buf_, size_ * sizeof(T));
+		}
+	}
+
+	inline T &operator[](size_t index) {
+		return buf_[index];
+	}
+
+	// Doesn't preserve contents.
+	void resize(size_t size) {
+		if (size_ < size) {
+			if (buf_ != NULL) {
+				FreeMemoryPages(buf_, size_ * sizeof(T));
+			}
+			buf_ = (T *)AllocateMemoryPages(size * sizeof(T));
+			size_ = size;
+		}
+	}
+
+	T *data() {
+		return buf_;
+	}
+
+	size_t size() {
+		return size_;
+	}
+
+private:
+	T *buf_;
+	size_t size_;
+};
+
+class TextureScaler {
+public:
+	void Scale(u32* &data, GLenum &dstfmt, int &width, int &height);
+
+private:
+	SimpleBuf<u32> bufInput;
+	SimpleBuf<u32> bufOutput;
+};

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -138,6 +138,7 @@
     <ClInclude Include="GLES\ShaderManager.h" />
     <ClInclude Include="GLES\StateMapping.h" />
     <ClInclude Include="GLES\TextureCache.h" />
+    <ClInclude Include="GLES\TextureScaler.h" />
     <ClInclude Include="GLES\TransformPipeline.h" />
     <ClInclude Include="GLES\VertexDecoder.h" />
     <ClInclude Include="GLES\VertexShaderGenerator.h" />
@@ -157,6 +158,7 @@
     <ClCompile Include="GLES\ShaderManager.cpp" />
     <ClCompile Include="GLES\StateMapping.cpp" />
     <ClCompile Include="GLES\TextureCache.cpp" />
+    <ClCompile Include="GLES\TextureScaler.cpp" />
     <ClCompile Include="GLES\TransformPipeline.cpp" />
     <ClCompile Include="GLES\VertexDecoder.cpp">
       <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AssemblyAndSourceCode</AssemblerOutput>

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -64,6 +64,10 @@
     <ClInclude Include="GPUCommon.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="..\ext\xbrz\xbrz.h" />
+    <ClInclude Include="GLES\TextureScaler.h">
+      <Filter>GLES</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -108,6 +112,10 @@
     <ClCompile Include="GeDisasm.cpp" />
     <ClCompile Include="GPUCommon.cpp">
       <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ext\xbrz\xbrz.cpp" />
+    <ClCompile Include="GLES\TextureScaler.cpp">
+      <Filter>GLES</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/ext/xbrz/xbrz.h
+++ b/ext/xbrz/xbrz.h
@@ -21,6 +21,13 @@
 #include <limits>
 #include "config.h"
 
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
 namespace xbrz
 {
 /*


### PR DESCRIPTION
This is not so much an immediate pull request, rather a request for comments.

I did 2 things:
- moved the texture scaling stuff to a separate file (it has nothing to do semantically with caching really, and that file is already big enough)
- parallelized the texture scaling using a pool of worker threads (adjustable in number)

It's pretty successful, on my quad-core system I go from **~160 MPixel/s sequentially to ~480 MPixel/s with 4 worker threads**, using 5xBRZ.

Now, there are a few open issues:
- Does it really make sense to have the texture scaler maintain its own private pool of worker threads? For example, the same threads and the same ParallelLoop() method I use could also be used in quite a few places in the texture cache. Should there be a global (singleton?) worker pool with a ParallelLoop() method?
- How should the number of worker threads be determined? By the number of CPU threads? Or by a configuration setting? Make the former a default for the latter?
- I moved SimpleBuf to MemoryUtil.h -- that makes sense to me, and I needed it in 2 separate files.

Oh, and I developed a hybrid scaling method that seems to almost completely fix the posterization of texture gradients issue with xBRZ, without reducing sharpness where desired... but I've only tested it in Matlab so far, and only on a couple of textures.
