### PR TITLE
Improve blending with two fixed colors

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -178,8 +178,19 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 					didReportBlend = true;
 
 					DEBUG_LOG(HLE, "ERROR INVALID blendcolorstate: FixA=%06x FixB=%06x FuncA=%i FuncB=%i", gstate.getFixA(), gstate.getFixB(), gstate.getBlendFuncA(), gstate.getBlendFuncB());
-					glBlendFuncA = GL_ONE;
-					glBlendFuncB = GL_ONE;
+					// Let's approximate, at least.
+					int blendSumA = (fixA & 0xFF) + ((fixA >> 8) & 0xFF) +  ((fixA >> 16) & 0xFF);
+					int blendSumB = (fixB & 0xFF) + ((fixB >> 8) & 0xFF) +  ((fixB >> 16) & 0xFF);
+					if (blendSumA < 64 * 3 && blendSumB > 192 * 3) {
+						glBlendFuncA = GL_ZERO;
+						glBlendFuncB = GL_ONE;
+					} else if (blendSumA > 192 * 3 && blendSumB < 64 * 3) {
+						glBlendFuncA = GL_ONE;
+						glBlendFuncB = GL_ZERO;
+					} else {
+						glBlendFuncA = GL_ONE;
+						glBlendFuncB = GL_ONE;
+					}
 				}
 			}
 			// At this point, through all paths above, glBlendFuncA and glBlendFuncB will be set somehow.


### PR DESCRIPTION
It's not right, but it's less bad.  There may be better ways to do this correctly, but I saw it [was in fact happening](http://report.ppsspp.org/temp/recent/kind/83), so I wanted to give a shot at improving it.

Maybe a better way would be to use a fixed color on one side only if possible?

It seemed like Lunar was using this for some battle effects (there are still some with weird issues, and this doesn't obviously replicate the effect properly.)

In Popolocrois, this fixes the menu (but it looks UGLY when it opens and when you select things.)  It seems to use this to implement a crossfade type effect or something.

-[Unknown]
