### PR TITLE
Add xBRZ texture scaling to Android/iOS

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -99,7 +99,9 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("LinearFiltering", &bLinearFiltering, false);
 	graphics->Get("SSAA", &SSAntiAliasing, 0);
 	graphics->Get("VBO", &bUseVBO, false);
-	graphics->Get("FrameSkip", &bFrameSkip, 0);
+	graphics->Get("FrameSkip", &bFrameSkip, false);
+	graphics->Get("XBRZTexScaling", &bXBRZTexScaling, false);
+	graphics->Get("XBRZTexScalingLevel", &iXBRZTexScalingLevel, 1);
 	graphics->Get("UseMediaEngine", &bUseMediaEngine, true);
 #ifdef USING_GLES2
 	graphics->Get("AnisotropicFiltering", &bAnisotropicFiltering, true);
@@ -115,7 +117,6 @@ void Config::Load(const char *iniFileName)
 #else
 	graphics->Get("MipMap", &bMipMap, false);
 #endif
-	graphics->Get("XBRZTexScalingLevel", &iXBRZTexScalingLevel, 1);
 
 	IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 	sound->Get("Enable", &bEnableSound, true);
@@ -190,6 +191,8 @@ void Config::Save()
 		graphics->Set("SSAA", SSAntiAliasing);
 		graphics->Set("VBO", bUseVBO);
 		graphics->Set("FrameSkip", bFrameSkip);
+		graphics->Set("XBRZTexScaling", bXBRZTexScaling);
+		graphics->Set("XBRZTexScalingLevel", iXBRZTexScalingLevel);
 		graphics->Set("UseMediaEngine", bUseMediaEngine);	
 		graphics->Set("AnisotropicFiltering", bAnisotropicFiltering);
 		graphics->Set("VertexCache", bVertexCache);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -60,7 +60,7 @@ public:
 	bool bLinearFiltering;
 	bool bUseVBO;
 	bool bStretchToDisplay;
-	bool bFrameSkip;  // 0 = off;  1 = auto;  (future:  2 = skip every 2nd frame;  3 = skip every 3rd frame etc).
+	bool bFrameSkip;  
 	int iNumSkip;
 	bool bUseMediaEngine;
 
@@ -74,7 +74,8 @@ public:
 	bool bTrueColor;
 	bool bMipMap;
 	bool bAnisotropicFiltering;
-	int iXBRZTexScalingLevel; // 1 = off, 2 = 2xBRZ, ..., 5 = 5xBRZ
+	bool bXBRZTexScaling;
+	int iXBRZTexScalingLevel; 
 
 	// Sound
 	bool bEnableSound;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -742,10 +742,6 @@ void GraphicsScreenP2::render() {
 			g_Config.iXBRZTexScalingLevel = 2;
 		if (UIButton(GEN_ID, hlinear1, 45, 0, "3x", ALIGN_LEFT))
 			g_Config.iXBRZTexScalingLevel = 3;
-		if (UIButton(GEN_ID, hlinear1, 45, 0, "4x", ALIGN_LEFT))
-			g_Config.iXBRZTexScalingLevel = 4;
-		if (UIButton(GEN_ID, hlinear1, 60, 0, "5x", ALIGN_LEFT))
-			g_Config.iXBRZTexScalingLevel = 5;
 	} else
 		g_Config.iXBRZTexScalingLevel = 1;
 	UIEnd();

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -734,6 +734,20 @@ void GraphicsScreenP2::render() {
 	} else
 		g_Config.iAnisotropyLevel = 0;
 
+	UICheckBox(GEN_ID, x, y += stride, gs->T("xBRZ Texture Scaling"), ALIGN_TOPLEFT, &g_Config.bXBRZTexScaling);
+	if (g_Config.bXBRZTexScaling) {
+		ui_draw2d.DrawText(UBUNTU24, gs->T("Level :"), x + 60, y += stride + 10, 0xFFFFFFFF, ALIGN_LEFT);
+		HLinear hlinear1(x + 160 , y + 5, 20);
+		if (UIButton(GEN_ID, hlinear1, 45, 0, "2x", ALIGN_LEFT))
+			g_Config.iXBRZTexScalingLevel = 2;
+		if (UIButton(GEN_ID, hlinear1, 45, 0, "3x", ALIGN_LEFT))
+			g_Config.iXBRZTexScalingLevel = 3;
+		if (UIButton(GEN_ID, hlinear1, 45, 0, "4x", ALIGN_LEFT))
+			g_Config.iXBRZTexScalingLevel = 4;
+		if (UIButton(GEN_ID, hlinear1, 60, 0, "5x", ALIGN_LEFT))
+			g_Config.iXBRZTexScalingLevel = 5;
+	} else
+		g_Config.iXBRZTexScalingLevel = 1;
 	UIEnd();
 }
 


### PR DESCRIPTION
Although xBRZ texture scaling is bit heavy for Android/iOS , 2x should be light-weight enough to replace linear filtering in the case of facial issues in some games .
