### PR TITLE
Stick to a single config entry per option

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -99,14 +99,13 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("LinearFiltering", &bLinearFiltering, false);
 	graphics->Get("SSAA", &SSAntiAliasing, 0);
 	graphics->Get("VBO", &bUseVBO, false);
-	graphics->Get("FrameSkip", &bFrameSkip, false);
-	graphics->Get("XBRZTexScaling", &bXBRZTexScaling, false);
+	graphics->Get("FrameSkip", &iFrameSkip, 0);
 	graphics->Get("XBRZTexScalingLevel", &iXBRZTexScalingLevel, 1);
 	graphics->Get("UseMediaEngine", &bUseMediaEngine, true);
 #ifdef USING_GLES2
-	graphics->Get("AnisotropicFiltering", &bAnisotropicFiltering, true);
+	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 0);
 #else
-	graphics->Get("AnisotropicFiltering", &bAnisotropicFiltering, false);
+	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 8);
 #endif
 	graphics->Get("VertexCache", &bVertexCache, true);
 	graphics->Get("FullScreen", &bFullScreen, false);	
@@ -190,11 +189,10 @@ void Config::Save()
 		graphics->Set("LinearFiltering", bLinearFiltering);
 		graphics->Set("SSAA", SSAntiAliasing);
 		graphics->Set("VBO", bUseVBO);
-		graphics->Set("FrameSkip", bFrameSkip);
-		graphics->Set("XBRZTexScaling", bXBRZTexScaling);
+		graphics->Set("FrameSkip", iFrameSkip);
 		graphics->Set("XBRZTexScalingLevel", iXBRZTexScalingLevel);
 		graphics->Set("UseMediaEngine", bUseMediaEngine);	
-		graphics->Set("AnisotropicFiltering", bAnisotropicFiltering);
+		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
 		graphics->Set("FullScreen", bFullScreen);
 		graphics->Set("StretchToDisplay", bStretchToDisplay);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -60,8 +60,7 @@ public:
 	bool bLinearFiltering;
 	bool bUseVBO;
 	bool bStretchToDisplay;
-	bool bFrameSkip;  
-	int iNumSkip;
+	bool iFrameSkip;
 	bool bUseMediaEngine;
 
 	int iWindowX;
@@ -73,8 +72,6 @@ public:
 	int iAnisotropyLevel;
 	bool bTrueColor;
 	bool bMipMap;
-	bool bAnisotropicFiltering;
-	bool bXBRZTexScaling;
 	int iXBRZTexScalingLevel; 
 
 	// Sound

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -286,7 +286,7 @@ void DoFrameTiming(bool &throttle, bool &skipFrame) {
 
 	// Check if the frameskipping code should be enabled. If neither throttling or frameskipping is on,
 	// we have nothing to do here.
-	bool doFrameSkip = g_Config.bFrameSkip;
+	bool doFrameSkip = g_Config.iFrameSkip != 0;
 
 	// On non windows, which is always vsync locked, we need to force frameskip when
 	// unthrottled.
@@ -343,7 +343,7 @@ void DoFrameTiming(bool &throttle, bool &skipFrame) {
 
 	// Max 4 skipped frames in a row - 15 fps is really the bare minimum for playability.
 	// We check for 3 here so it's 3 skipped frames, 1 non skipped, 3 skipped, etc.
-	if (numSkippedFrames >= g_Config.iNumSkip) {
+	if (numSkippedFrames >= g_Config.iFrameSkip) {
 		skipFrame = false;
 	}
 }

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -424,16 +424,24 @@ void PauseScreen::render() {
 		if (gpu)
 			gpu->Resized();
 	}
-	UICheckBox(GEN_ID, x, y += stride, gs->T("Frame Skipping"), ALIGN_TOPLEFT, &g_Config.bFrameSkip);
-	if (g_Config.bFrameSkip) {
+
+	bool enableFrameSkip = g_Config.iFrameSkip != 0;
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Frame Skipping"), ALIGN_TOPLEFT, &enableFrameSkip);
+	if (enableFrameSkip) {
+		if (g_Config.iFrameSkip == 0)
+			g_Config.iFrameSkip = 3;
+
 		ui_draw2d.DrawText(UBUNTU24, gs->T("Skip Frames :"), x + 60, y += stride + 10, 0xFFFFFFFF, ALIGN_LEFT);
 		HLinear hlinear1(x + 250 , y + 5, 20);
 		if (UIButton(GEN_ID, hlinear1, 80, 0, "Auto", ALIGN_LEFT))
-			g_Config.iNumSkip = 3;
+			g_Config.iFrameSkip = 3;
 		if (UIButton(GEN_ID, hlinear1, 30, 0, "1", ALIGN_LEFT))
-			g_Config.iNumSkip = 1;
+			g_Config.iFrameSkip = 1;
 		if (UIButton(GEN_ID, hlinear1, 30, 0, "2", ALIGN_LEFT))
-			g_Config.iNumSkip = 2;
+			g_Config.iFrameSkip = 2;
+	}
+	else {
+		g_Config.iFrameSkip = 0;
 	}
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Media Engine"), ALIGN_TOPLEFT, &g_Config.bUseMediaEngine);
 
@@ -680,7 +688,18 @@ void GraphicsScreenP1::render() {
 #endif
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Media Engine"), ALIGN_TOPLEFT, &g_Config.bUseMediaEngine);
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Linear Filtering"), ALIGN_TOPLEFT, &g_Config.bLinearFiltering);
-	UICheckBox(GEN_ID, x, y += stride, gs->T("Frame Skipping"), ALIGN_TOPLEFT, &g_Config.bFrameSkip);
+	bool enableFrameSkip = g_Config.iFrameSkip != 0;
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Frame Skipping"), ALIGN_TOPLEFT, &enableFrameSkip);
+	if (enableFrameSkip) {
+		// This one doesn't have the # of frame options, so only change the setting if they flipped it.
+		// 3 means auto.
+		if (g_Config.iFrameSkip == 0)
+			g_Config.iFrameSkip = 3;
+	}
+	else {
+		g_Config.iFrameSkip = 0;
+	}
+
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Mipmapping"), ALIGN_TOPLEFT, &g_Config.bMipMap);
 	if (UICheckBox(GEN_ID, x, y += stride, gs->T("Buffered Rendering"), ALIGN_TOPLEFT, &g_Config.bBufferedRendering)) {
 		if (gpu)
@@ -719,8 +738,13 @@ void GraphicsScreenP2::render() {
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Draw Wireframe"), ALIGN_TOPLEFT, &g_Config.bDrawWireframe);
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Display Raw Framebuffer"), ALIGN_TOPLEFT, &g_Config.bDisplayFramebuffer);
 	UICheckBox(GEN_ID, x, y += stride, gs->T("True Color"), ALIGN_TOPLEFT, &g_Config.bTrueColor);
-	UICheckBox(GEN_ID, x, y += stride, gs->T("Anisotropic Filtering"), ALIGN_TOPLEFT, &g_Config.bAnisotropicFiltering);
-	if (g_Config.bAnisotropicFiltering) {
+
+	bool AnisotropicFiltering = g_Config.iAnisotropyLevel != 0;
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Anisotropic Filtering"), ALIGN_TOPLEFT, &AnisotropicFiltering);
+	if (AnisotropicFiltering) {
+		if (g_Config.iAnisotropyLevel == 0)
+			g_Config.iAnisotropyLevel = 2;
+
 		ui_draw2d.DrawText(UBUNTU24, gs->T("Level :"), x + 60, y += stride + 10, 0xFFFFFFFF, ALIGN_LEFT);
 		HLinear hlinear1(x + 160 , y + 5, 20);
 		if (UIButton(GEN_ID, hlinear1, 45, 0, "2x", ALIGN_LEFT))
@@ -731,19 +755,25 @@ void GraphicsScreenP2::render() {
 			g_Config.iAnisotropyLevel = 8;
 		if (UIButton(GEN_ID, hlinear1, 60, 0, "16x", ALIGN_LEFT))
 			g_Config.iAnisotropyLevel = 16;
-	} else
+	} else {
 		g_Config.iAnisotropyLevel = 0;
+	}
 
-	UICheckBox(GEN_ID, x, y += stride, gs->T("xBRZ Texture Scaling"), ALIGN_TOPLEFT, &g_Config.bXBRZTexScaling);
-	if (g_Config.bXBRZTexScaling) {
+	bool XBRZTexScaling = g_Config.iXBRZTexScalingLevel <= 1;
+	UICheckBox(GEN_ID, x, y += stride, gs->T("xBRZ Texture Scaling"), ALIGN_TOPLEFT, &XBRZTexScaling);
+	if (XBRZTexScaling) {
+		if (g_Config.iXBRZTexScalingLevel <= 1)
+			g_Config.iXBRZTexScalingLevel = 2;
+
 		ui_draw2d.DrawText(UBUNTU24, gs->T("Level :"), x + 60, y += stride + 10, 0xFFFFFFFF, ALIGN_LEFT);
 		HLinear hlinear1(x + 160 , y + 5, 20);
 		if (UIButton(GEN_ID, hlinear1, 45, 0, "2x", ALIGN_LEFT))
 			g_Config.iXBRZTexScalingLevel = 2;
 		if (UIButton(GEN_ID, hlinear1, 45, 0, "3x", ALIGN_LEFT))
 			g_Config.iXBRZTexScalingLevel = 3;
-	} else
+	} else {
 		g_Config.iXBRZTexScalingLevel = 1;
+	}
 	UIEnd();
 }
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -537,7 +537,7 @@ namespace MainWindow
 				break;
 
 			case ID_OPTIONS_FRAMESKIP:
-				g_Config.bFrameSkip = !g_Config.bFrameSkip;
+				g_Config.iFrameSkip = g_Config.iFrameSkip == 0 ? 1 : 0;
 				break;
 
 			case ID_OPTIONS_USEMEDIAENGINE:
@@ -776,7 +776,7 @@ namespace MainWindow
 		CHECKITEM(ID_OPTIONS_USEVBO, g_Config.bUseVBO);
 		CHECKITEM(ID_OPTIONS_VERTEXCACHE, g_Config.bVertexCache);
 		CHECKITEM(ID_OPTIONS_SHOWFPS, g_Config.bShowFPSCounter);
-		CHECKITEM(ID_OPTIONS_FRAMESKIP, g_Config.bFrameSkip);
+		CHECKITEM(ID_OPTIONS_FRAMESKIP, g_Config.iFrameSkip != 0);
 		CHECKITEM(ID_OPTIONS_USEMEDIAENGINE, g_Config.bUseMediaEngine);
 		CHECKITEM(ID_OPTIONS_MIPMAP, g_Config.bMipMap);
 		CHECKITEM(ID_EMULATION_SOUND, g_Config.bEnableSound); 


### PR DESCRIPTION
We don't need a bool in the ini AND an int setting.  After seeing the XBRZ change I finally realized why raven02 was adding these.

This should also fix the anistropy setting, which appears to have been pretty much broken.  Also makes frameskip enable even if you don't tap auto, which is what I'd assumed it did before.

-[Unknown]
