### PR TITLE
TransformedVertex::color1[3] used out-of-range

### DIFF
--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -65,7 +65,7 @@ struct TransformedVertex
 	float x, y, z, fog;     // in case of morph, preblend during decode
 	float u; float v; float w;   // scaled by uscale, vscale, if there
 	u8 color0[4];   // prelit
-	u8 color1[3];   // prelit
+	u8 color1[4];   // prelit
 };
 
 DecVtxFormat GetTransformedVtxFormat(const DecVtxFormat &fmt);


### PR DESCRIPTION
TransformedVertex::color1[3] was written to in TransformDrawEngine::SoftwareTransformAndDraw(). It worked probably thanks to structure padding on most platforms. Now just explicitly reserve it to be safe whether it should be used or not.
