### PR TITLE
Minor texture cache optimizations + blend fix

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1063,11 +1063,16 @@ void *TextureCache::DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 
 	case GE_TFMT_8888:
 		dstFmt = GL_UNSIGNED_BYTE;
 		if (!(gstate.texmode & 1)) {
-			int len = bufw * h;
-			tmpTexBuf32.resize(std::max(bufw, w) * h);
-			tmpTexBufRearrange.resize(std::max(bufw, w) * h);
-			Memory::Memcpy(tmpTexBuf32.data(), texaddr, len * sizeof(u32));
-			finalBuf = tmpTexBuf32.data();
+			// Special case: if we don't need to deal with packing, we don't need to copy.
+			if (w == bufw) {
+				finalBuf = Memory::GetPointer(texaddr);
+			} else {
+				int len = bufw * h;
+				tmpTexBuf32.resize(std::max(bufw, w) * h);
+				tmpTexBufRearrange.resize(std::max(bufw, w) * h);
+				Memory::Memcpy(tmpTexBuf32.data(), texaddr, len * sizeof(u32));
+				finalBuf = tmpTexBuf32.data();
+			}
 		}
 		else {
 			tmpTexBuf32.resize(std::max(bufw, w) * h);

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -92,7 +92,7 @@ private:
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
 	void *UnswizzleFromMem(u32 texaddr, u32 bufw, u32 bytesPerPixel, u32 level);
-	void *readIndexedTex(int level, u32 texaddr, int bytesPerIndex);
+	void *readIndexedTex(int level, u32 texaddr, int bytesPerIndex, GLuint dstFmt);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level);
 	void *DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);


### PR DESCRIPTION
Three things:
- Do the `convertColors()` on the CLUT, not after expanding the texture.<br />
  Affects e.g. Star Ocean, 3rd Birthday, FF3, and A Space Shooter for 2 Bucks
- When no packing is needed, read the texture directly from PSP RAM (no copy.)<br />
  Affects e.g. LittleBigPlanet, Ys Seven, Hexyz Force, Crimson Gem Saga, etc.
- Don't double alpha blend when the non-doubled alpha is used in the other blend func (fixes LittleBigPlanet vignette.)

The performance impact in game is non-existent, since the textures are already loaded.  But it can improve churn in other games, and may help load times a little bit when things initially come on screen.

-[Unknown]
