### PR TITLE
Basic Atrac3 Support in sceAtrac using ffmpeg

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -31,21 +31,34 @@
 #define ATRAC_ERROR_ALL_DATA_DECODED         0x80630024
 #define ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED 0x80630022
 #define ATRAC_ERROR_INCORRECT_READ_SIZE	     0x80630013
-
-#define FMT_CHUNK_MAGIC		0x20746D66
-#define DATA_CHUNK_MAGIC	0x61746164
-#define SMPL_CHUNK_MAGIC	0x6C706D73
-#define FACT_CHUNK_MAGIC	0x74636166
+#define ATRAC_ERROR_UNSET_PARAM              0x80630021
+#define ATRAC_ERROR_NO_ATRACID               0x80630003
+#define ATRAC_ERROR_BAD_CODECTYPE            0x80630004
+#define ATRAC_ERROR_ADD_DATA_IS_TOO_BIG      0x80630018
 
 #define AT3_MAGIC			0x0270
 #define AT3_PLUS_MAGIC		0xFFFE
-#define RIFF_MAGIC			0x46464952
-#define WAVE_MAGIC			0x45564157
-
 #define PSP_MODE_AT_3_PLUS	0x00001000
 #define PSP_MODE_AT_3		0x00001001
 
+const int FMT_CHUNK_MAGIC	= 0x20746D66;
+const int DATA_CHUNK_MAGIC	= 0x61746164;
+const int SMPL_CHUNK_MAGIC	= 0x6C706D73;
+const int FACT_CHUNK_MAGIC	= 0x74636166;
+
+const int PSP_ATRAC_ALLDATA_IS_ON_MEMORY = -1;
+const int PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY = -2;
+const int PSP_ATRAC_LOOP_STREAM_DATA_IS_ON_MEMORY = -3;
+
 const u32 ATRAC_MAX_SAMPLES = 1024;
+
+#ifdef USE_FFMPEG
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libswresample/swresample.h>
+#include <libavutil/samplefmt.h>
+}
+#endif // USE_FFMPEG
 
 struct InputBuffer {
 	u32 addr;
@@ -57,6 +70,9 @@ struct InputBuffer {
 	u32 fileoffset;
 };
 
+struct Atrac;
+int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize);
+
 struct AtracLoopInfo {
 	int cuePointID;
 	int type;
@@ -67,54 +83,181 @@ struct AtracLoopInfo {
 };
 
 struct Atrac {
-	Atrac() : decodePos(0), decodeEnd(0), loopNum(0), 
-		atracChannels(2), atracBitrate(64), atracBytesPerFrame(0x0230), atracSampleRate(0xAC44),
-		currentSample(0), endSample(-1), loopinfoNum(0), firstSampleoffset(0),
-		loopStartSample(0), loopEndSample(-1) {
+	Atrac() : decodePos(0), decodeEnd(0), loopNum(0), atracChannels(2), 
+		atracBitrate(64), atracBytesPerFrame(0), atracBufSize(0), currentSample(0), 
+		endSample(-1), loopinfoNum(0), firstSampleoffset(0),data_buf(0), 
+		atracOutputChannels(2), atracID(-1) {
 		memset(&first, 0, sizeof(first));
 		memset(&second, 0, sizeof(second));
+#ifdef USE_FFMPEG
+		pFormatCtx = 0;
+		pAVIOCtx = 0;
+		pCodecCtx = 0;
+		pSwrCtx = 0;
+		pFrame = 0;
+#endif // USE_FFMPEG
 	}
+
+	~Atrac() { 
+#ifdef USE_FFMPEG
+		ReleaseFFMPEGContext();
+#endif // USE_FFMPEG
+		if (data_buf) delete [] data_buf; 
+	}
+
 	void DoState(PointerWrap &p) {
+		p.Do(atracChannels);
+		p.Do(atracOutputChannels);
+
+		if (atracID == -1) {
+			// loading state
+			p.Do(atracID);
+			p.Do(first);
+			p.Do(atracBufSize);
+			p.Do(codeType);
+			u32 data_buf_value;
+			p.Do(data_buf_value);
+			if (data_buf_value) {
+				data_buf = new u8[first.filesize];
+				p.DoArray(data_buf, first.filesize);
+			}
+			InputBuffer temp = first;
+			if (first.addr) {
+				int size = std::min(first.size, atracBufSize);
+				first.size = size;
+				if (data_buf)
+					Memory::Memcpy(first.addr, data_buf, size);
+				u8* temp_buf = data_buf;
+				data_buf = 0;
+				_AtracSetData(this, first.addr, atracBufSize);
+				// restore the state
+				first = temp;
+				if (data_buf)
+					delete [] data_buf;
+				data_buf = temp_buf;
+			}
+		}
+		else {
+			// saving state
+			p.Do(atracID);
+			p.Do(first);
+			p.Do(atracBufSize);
+			p.Do(codeType);
+			u32 data_buf_value = (u32)data_buf;
+			p.Do(data_buf_value);
+			if (data_buf)
+				p.DoArray(data_buf, first.filesize);
+		}
+		p.Do(second);
+
 		p.Do(decodePos);
 		p.Do(decodeEnd);
-		p.Do(atracChannels);
+
 		p.Do(atracBitrate);
-		p.Do(atracSampleRate);
 		p.Do(atracBytesPerFrame);
-		p.Do(loopStartSample);
-		p.Do(loopEndSample);
-		p.Do(loopNum);
-		p.Do(loopinfoNum);
+
 		p.Do(currentSample);
 		p.Do(endSample);
 		p.Do(firstSampleoffset);
-		p.Do(first);
-		p.Do(second);
+
+		p.Do(loopinfo);
+		p.Do(loopinfoNum);
+
+		p.Do(loopStartSample);
+		p.Do(loopEndSample);
+		p.Do(loopNum);
+
 		p.DoMarker("Atrac");
 	}
 
 	void Analyze();
+	u32 getDecodePosBySample(int sample) {
+		return (u32)(firstSampleoffset + sample / ATRAC_MAX_SAMPLES * atracBytesPerFrame );
+	}
+	int getRemainFrames() {
+		// many games request to add atrac data when remainFrames = 0
+		// However, some other games request to add atrac data 
+		// when remainFrames = PSP_ATRAC_ALLDATA_IS_ON_MEMORY .
+		// Still need to find out how getRemainFrames() should work.
+
+		int remainFrame;
+		if (first.fileoffset >= first.filesize || currentSample >= endSample)
+			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
+		else if (decodePos >= first.fileoffset - atracBytesPerFrame ) {
+			// require more data
+			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
+		} else {
+			// This is the correct one
+			//remainFrame = (first.size - decodePos) / atracBytesPerFrame;
+
+			// Try to load all file data immediately
+			remainFrame = 0;
+		}
+		return remainFrame;
+	}
+
+	int atracID;
+	u8* data_buf;
 
 	u32 decodePos;
 	u32 decodeEnd;
+
 	u16 atracChannels;
+	u16 atracOutputChannels;
 	u32 atracBitrate;
 	u16 atracBytesPerFrame;
-	u32 atracSampleRate;
-	u32 codeType;
+	u32 atracBufSize;
+
+	int currentSample;
+	int endSample;
+	// Offset of the first sample in the input buffer
+	int firstSampleoffset;
+
+	std::vector<AtracLoopInfo> loopinfo;
+	int loopinfoNum;
 
 	int loopStartSample;
 	int loopEndSample;
 	int loopNum;
-	int loopinfoNum;
-	int currentSample;
-	int endSample;
-	int firstSampleoffset;
 
-	std::vector<AtracLoopInfo> loopinfo;
+	u32 codeType;
 
 	InputBuffer first;
 	InputBuffer second;
+
+#ifdef USE_FFMPEG
+	AVFormatContext *pFormatCtx;
+	AVIOContext	    *pAVIOCtx;
+	AVCodecContext  *pCodecCtx;
+	SwrContext      *pSwrCtx;
+	AVFrame         *pFrame;
+	int audio_stream_index;
+	void ReleaseFFMPEGContext() {
+		if (pFrame)
+			av_free(pFrame);
+		if (pAVIOCtx && pAVIOCtx->buffer)
+			av_free(pAVIOCtx->buffer);
+		if (pAVIOCtx)
+			av_free(pAVIOCtx);
+		if (pSwrCtx)
+			swr_free(&pSwrCtx);
+		if (pCodecCtx)
+			avcodec_close(pCodecCtx);
+		if (pFormatCtx)
+			avformat_close_input(&pFormatCtx);
+		pFormatCtx = 0;
+		pAVIOCtx = 0;
+		pCodecCtx = 0;
+		pSwrCtx = 0;
+		pFrame = 0;
+	}
+
+	void SeekToSample(int sample) {
+		s64 seek_pos = (s64)sample;
+		av_seek_frame(pFormatCtx, audio_stream_index, seek_pos, 0);
+	}
+#endif // USE_FFMPEG
+
 };
 
 std::map<int, Atrac *> atracMap;
@@ -122,9 +265,16 @@ u8 nextAtracID;
 
 void __AtracInit() {
 	nextAtracID = 0;
+#ifdef USE_FFMPEG
+	avcodec_register_all();
+	av_register_all();
+#endif // USE_FFMPEG
 }
 
 void __AtracDoState(PointerWrap &p) {
+#ifdef USE_FFMPEG
+	p.Do(Memory::lastestAccessFile);
+#endif // _USE_FFMPEG
 	p.Do(atracMap);
 	p.Do(nextAtracID);
 
@@ -148,6 +298,7 @@ Atrac *getAtrac(int atracID) {
 int createAtrac(Atrac *atrac) {
 	int id = nextAtracID++;
 	atracMap[id] = atrac;
+	atrac->atracID = id;
 	return id;
 }
 
@@ -158,8 +309,8 @@ void deleteAtrac(int atracID) {
 	}
 }
 
-int getCodecType(const u32 addr) {
-	int at3magic = Memory::Read_U16(addr + 20);
+int getCodecType(int addr) {
+	int at3magic = Memory::Read_U16(addr+20);
 	if (at3magic == AT3_MAGIC) {
 		return PSP_MODE_AT_3;
 	} else if (at3magic == AT3_PLUS_MAGIC) {
@@ -170,31 +321,30 @@ int getCodecType(const u32 addr) {
 
 void Atrac::Analyze()
 {
+	// reset some values
 	currentSample = 0;
 	endSample = -1;
 	loopNum = 0;
 	loopinfoNum = 0;
+	loopinfo.clear();
 	loopStartSample = -1;
 	loopEndSample = -1;
 	decodePos = 0;
 
-	if (first.size < 0x100)	{
+	if (first.size < 0x100)
+	{
 		ERROR_LOG(HLE, "Atrac buffer very small: %d", first.size);
 		return;
 	}
-
-	if (!Memory::IsValidAddress(first.addr)) {
+	if (!Memory::IsValidAddress(first.addr))
+	{
 		WARN_LOG(HLE, "Atrac buffer at invalid address: %08x-%08x", first.addr, first.size);
 		return;
 	}
 
-	int RIFFMagic = Memory::Read_U32(first.addr);
-	int WAVEMagic = Memory::Read_U32(first.addr + 8);
-	if (RIFFMagic != RIFF_MAGIC || WAVEMagic != WAVE_MAGIC) {
-		ERROR_LOG(HLE, "Not a RIFF or WAVE format: %08x-%08x", RIFFMagic, WAVEMagic);
-		return;
-	}
+	// TODO: Validate stuff.
 
+	// RIFF size excluding chunk header.
 	first.filesize = Memory::Read_U32(first.addr + 4) + 8;
 
 	u32 offset = 12;
@@ -208,51 +358,62 @@ void Atrac::Analyze()
 		offset += 8;
 		if (chunkSize > first.filesize - offset)
 			break;
-
 		switch (chunkMagic) {
-			case FMT_CHUNK_MAGIC: {
-					if (chunkSize >= 16) {
-						atracChannels = Memory::Read_U16(first.addr + offset + 2);
-						atracSampleRate = Memory::Read_U32(first.addr + offset + 4);  
-						atracBitrate = Memory::Read_U32(first.addr + offset + 8);
-						atracBytesPerFrame = Memory::Read_U16(first.addr + offset + 12);
-					}
+		case FMT_CHUNK_MAGIC:
+			{
+				if (chunkSize >= 16) {
+					int codeMagic = Memory::Read_U16(first.addr + offset);
+					if (codeMagic == AT3_MAGIC)
+						codeType = PSP_MODE_AT_3;
+					else if (codeMagic == AT3_PLUS_MAGIC)
+						codeType = PSP_MODE_AT_3_PLUS;
+					else
+						codeType = 0;
+					atracChannels = Memory::Read_U16(first.addr + offset + 2);
+					// int atracSamplerate = Memory::Read_U32(first.addr + offset + 4);    ;Should always be 44100Hz
+					int avgBytesPerSec = Memory::Read_U32(first.addr + offset + 8);
+					atracBitrate = avgBytesPerSec * 8;
+					atracBytesPerFrame = Memory::Read_U16(first.addr + offset + 12);
 				}
-				break;
-			case FACT_CHUNK_MAGIC: {
-					if (chunkSize >= 8) {
-						endSample = Memory::Read_U32(first.addr + offset);
-						atracSampleoffset = Memory::Read_U32(first.addr + offset + 4);
-					}
+			}
+			break;
+		case FACT_CHUNK_MAGIC:
+			{
+				if (chunkSize >= 8) {
+					endSample = Memory::Read_U32(first.addr + offset);
+					atracSampleoffset = Memory::Read_U32(first.addr + offset + 4);
 				}
-				break;
-			case SMPL_CHUNK_MAGIC: {
-					if (chunkSize >= 36) {
-						int checkNumLoops = Memory::Read_U32(first.addr + offset + 28);
-						if (chunkSize >= 36 + checkNumLoops * 24) {
-							loopinfoNum = checkNumLoops;
-							loopinfo.resize(loopinfoNum);
-							u32 loopinfoAddr = first.addr + offset + 36;
-							for (int i = 0; i < loopinfoNum; i++, loopinfoAddr += 24) {
-								loopinfo[i].cuePointID = Memory::Read_U32(loopinfoAddr);
-								loopinfo[i].type = Memory::Read_U32(loopinfoAddr + 4);
-								loopinfo[i].startSample = Memory::Read_U32(loopinfoAddr + 8) - atracSampleoffset;
-								loopinfo[i].endSample = Memory::Read_U32(loopinfoAddr + 12) - atracSampleoffset;
-								loopinfo[i].fraction = Memory::Read_U32(loopinfoAddr + 16);
-								loopinfo[i].playCount = Memory::Read_U32(loopinfoAddr + 20);
+			}
+			break;
+		case SMPL_CHUNK_MAGIC:
+			{
+				if (chunkSize < 36)
+					break;
+				int checkNumLoops = Memory::Read_U32(first.addr + offset + 28);
+				if (chunkSize >= 36 + checkNumLoops * 24) {
+					loopinfoNum = checkNumLoops;
+					loopinfo.resize(loopinfoNum);
+					u32 loopinfoAddr = first.addr + offset + 36;
+					for (int i = 0; i < loopinfoNum; i++, loopinfoAddr += 24) {
+						loopinfo[i].cuePointID = Memory::Read_U32(loopinfoAddr);
+						loopinfo[i].type = Memory::Read_U32(loopinfoAddr + 4);
+						loopinfo[i].startSample = Memory::Read_U32(loopinfoAddr + 8) - atracSampleoffset;
+						loopinfo[i].endSample = Memory::Read_U32(loopinfoAddr + 12) - atracSampleoffset;
+						loopinfo[i].fraction = Memory::Read_U32(loopinfoAddr + 16);
+						loopinfo[i].playCount = Memory::Read_U32(loopinfoAddr + 20);
 
-								if (loopinfo[i].endSample > endSample)
-									loopinfo[i].endSample = endSample;
-							}
-						}
-					} 
+						if (loopinfo[i].endSample > endSample)
+							loopinfo[i].endSample = endSample;
+					}
 				}
-				break;
-			case DATA_CHUNK_MAGIC: {
-					bfoundData = true;
-					firstSampleoffset = offset;
-				}
-				break;
+			}
+			break;
+		case DATA_CHUNK_MAGIC:
+			{
+				bfoundData = true;
+				firstSampleoffset = offset;
+			}
+			break;
 		}
 		offset += chunkSize;
 	}
@@ -272,30 +433,55 @@ void Atrac::Analyze()
 
 u32 sceAtracGetAtracID(int codecType)
 {
-	ERROR_LOG(HLE, "FAKE sceAtracGetAtracID(%i)", codecType);
-	return createAtrac(new Atrac);
+	INFO_LOG(HLE, "sceAtracGetAtracID(%i)", codecType);
+	if (codecType < 0x1000 || codecType > 0x1001)
+		return ATRAC_ERROR_BAD_CODECTYPE;
+
+	int atracID = createAtrac(new Atrac);
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac)
+		return ATRAC_ERROR_NO_ATRACID;
+	atrac->codeType = codecType;
+	return atracID;
 }
 
 u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
+	INFO_LOG(HLE, "sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
+		return 0;
 	}
 	// TODO
+	if (bytesToAdd > atrac->first.writableBytes)
+		return ATRAC_ERROR_ADD_DATA_IS_TOO_BIG;
+
+	if (atrac->data_buf && (bytesToAdd > 0)) {
+		int addbytes = std::min(bytesToAdd, atrac->first.filesize - atrac->first.fileoffset);
+		Memory::Memcpy(atrac->data_buf + atrac->first.fileoffset, atrac->first.addr, addbytes);
+#ifdef _USE_DSHOW_
+		if (atrac->first.fileoffset + addbytes >= atrac->first.filesize)
+			addAtrac3Audio(atrac->data_buf, atrac->first.filesize, atracID);
+#endif
+	}
+	atrac->first.size += bytesToAdd;
+	if (atrac->first.size > atrac->first.filesize)
+		atrac->first.size = atrac->first.filesize;
+	atrac->first.fileoffset = atrac->first.size;
+	atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->atracBufSize);
 	return 0;
 }
 
 u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
 {
-	DEBUG_LOG(HLE, "FAKE sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
+	DEBUG_LOG(HLE, "sceAtracDecodeData(%i, %08x, %08x, %08x, %08x)", atracID, outAddr, numSamplesAddr, finishFlagAddr, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 
 	u32 ret = 0;
 	if (atrac != NULL) {
 		// We already passed the end - return an error (many games check for this.)
-		if (atrac->decodePos >= atrac->decodeEnd && atrac->loopNum == 0) {
+		if (atrac->currentSample >= atrac->endSample && atrac->loopNum == 0) {
 			Memory::Write_U32(0, numSamplesAddr);
 			Memory::Write_U32(1, finishFlagAddr);
 			Memory::Write_U32(0, remainAddr);
@@ -303,32 +489,75 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			ret = ATRAC_ERROR_ALL_DATA_DECODED;
 		} else {
 			// TODO: This isn't at all right, but at least it makes the music "last" some time.
-			u32 numSamples = (atrac->decodeEnd - atrac->decodePos) / (sizeof(s16) * 2);
-			if (atrac->decodePos >= atrac->decodeEnd) {
-				numSamples = 0;
-			} else if (numSamples > ATRAC_MAX_SAMPLES) {
-				numSamples = ATRAC_MAX_SAMPLES;
+			u32 numSamples = 0;
+#ifdef USE_FFMPEG
+			if (atrac->codeType == PSP_MODE_AT_3 && atrac->pCodecCtx) {
+				int forceseekSample = atrac->currentSample * 2 > atrac->endSample ? 0 : atrac->endSample;
+				atrac->SeekToSample(forceseekSample);
+				atrac->SeekToSample(atrac->currentSample);
+				AVPacket packet;
+				int got_frame, ret;
+				while (av_read_frame(atrac->pFormatCtx, &packet) >= 0) {
+					if (packet.stream_index == atrac->audio_stream_index) {
+						got_frame = 0;
+						ret = avcodec_decode_audio4(atrac->pCodecCtx, atrac->pFrame, &got_frame, &packet);
+						if (ret < 0) {
+							ERROR_LOG(HLE, "avcodec_decode_audio4: Error decoding audio %d", ret);
+							av_free_packet(&packet);
+							break;
+						}
+
+						if (got_frame) {
+							// got a frame
+							int decoded = av_samples_get_buffer_size(NULL, atrac->pFrame->channels, 
+								atrac->pFrame->nb_samples, (AVSampleFormat)atrac->pFrame->format, 1);
+							u8* out = Memory::GetPointer(outAddr);
+							numSamples = atrac->pFrame->nb_samples;
+							ret = swr_convert(atrac->pSwrCtx, &out, atrac->pFrame->nb_samples, 
+								(const u8**)atrac->pFrame->extended_data, atrac->pFrame->nb_samples);
+							if (ret < 0) {
+								ERROR_LOG(HLE, "swr_convert: Error while converting %d", ret);
+							}
+
+						}
+						av_free_packet(&packet);
+						if (got_frame)
+							break;
+					}
+				}
+
+			} else
+#endif // USE_FFMPEG
+			{
+				numSamples = atrac->endSample - atrac->currentSample;
+				if (atrac->currentSample >= atrac->endSample) {
+					numSamples = 0;
+				} else if (numSamples > ATRAC_MAX_SAMPLES) {
+					numSamples = ATRAC_MAX_SAMPLES;
+				}
+				
+				if (numSamples == 0 && (atrac->loopNum != 0)) {
+					numSamples = ATRAC_MAX_SAMPLES;
+				}
+				Memory::Memset(outAddr, 0, numSamples * sizeof(s16) * atrac->atracOutputChannels);
 			}
 
-			// Should we loop?
-			if (numSamples == 0 && atrac->loopNum != 0) {
-				// Restart.
-				atrac->decodePos = 0;
-				if (atrac->loopNum > 0)
-					atrac->loopNum--;
-				numSamples = ATRAC_MAX_SAMPLES;
-			}
-
-			Memory::Memset(outAddr, 0, numSamples * sizeof(s16) * 2);
 			Memory::Write_U32(numSamples, numSamplesAddr);
-			atrac->decodePos += ATRAC_MAX_SAMPLES;
+			// update current sample and decodePos
+			atrac->currentSample += numSamples;
+			atrac->decodePos = atrac->getDecodePosBySample(atrac->currentSample);
+			
+			int finishFlag = 0;
+			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample || numSamples == 0)) {
+				atrac->currentSample = atrac->loopStartSample;
+				if (atrac->loopNum > 0)
+					atrac->loopNum --;
+			} else if (atrac->currentSample >= atrac->endSample || numSamples == 0)
+				finishFlag = 1;
 
-			if (numSamples < ATRAC_MAX_SAMPLES) {
-				Memory::Write_U32(1, finishFlagAddr);
-			} else {
-				Memory::Write_U32(0, finishFlagAddr);
-			}
-			Memory::Write_U32(-1, remainAddr);
+			Memory::Write_U32(finishFlag, finishFlagAddr);
+			int remains = atrac->getRemainFrames();
+			Memory::Write_U32(remains, remainAddr);
 		}
 	// TODO: Can probably remove this after we validate no wrong ids?
 	} else {
@@ -358,11 +587,11 @@ u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr
 		Memory::Memset(bufferInfoAddr, 0, 32);
 		//return -1;
 	} else {
-		int sampleOffset = (u32)(atrac->firstSampleoffset + sample / ATRAC_MAX_SAMPLES * atrac->atracBytesPerFrame);
+		int Sampleoffset = atrac->getDecodePosBySample(sample);
 		Memory::Write_U32(atrac->first.addr, bufferInfoAddr);
 		Memory::Write_U32(atrac->first.writableBytes, bufferInfoAddr + 4);
 		Memory::Write_U32(atrac->first.neededBytes, bufferInfoAddr + 8);
-		Memory::Write_U32(sampleOffset, bufferInfoAddr + 12);
+		Memory::Write_U32(Sampleoffset, bufferInfoAddr + 12);
 		Memory::Write_U32(atrac->second.addr, bufferInfoAddr + 16);
 		Memory::Write_U32(atrac->second.writableBytes, bufferInfoAddr + 20);
 		Memory::Write_U32(atrac->second.neededBytes, bufferInfoAddr + 24);
@@ -373,30 +602,24 @@ u32 sceAtracGetBufferInfoForReseting(int atracID, int sample, u32 bufferInfoAddr
 
 u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
+	DEBUG_LOG(HLE, "sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		return -1;
 	}
 
-	atrac->atracBitrate = ( atrac->atracBytesPerFrame * 352800 ) / 1000;
-	if (atrac->codeType == PSP_MODE_AT_3_PLUS) 
-		atrac->atracBitrate = ((atrac->atracBitrate >> 11) + 8) & 0xFFFFFFF0;
-	else
-		atrac->atracBitrate = (atrac->atracBitrate + 511) >> 10;
-
+	// I wonder which result should be returned. Such as a 64kbps bitrate audio,
+	// should we return 64 or 64 * 1000 ? Here returns the second one.
 	if (Memory::IsValidAddress(outBitrateAddr))
 		Memory::Write_U32(atrac->atracBitrate, outBitrateAddr);
-
 	return 0;
 }
 
 u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
+	DEBUG_LOG(HLE, "sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-//Fix Sengoku Musou 3 Z Special [JPN] crash
 		return -1;
 	}
 	if (Memory::IsValidAddress(channelAddr))
@@ -406,14 +629,14 @@ u32 sceAtracGetChannel(int atracID, u32 channelAddr)
 
 u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
+	DEBUG_LOG(HLE, "sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 	} else {
 		if (Memory::IsValidAddress(loopNumAddr))
 			Memory::Write_U32(atrac->loopNum, loopNumAddr);
-
+		// return audio's loopinfo in at3 file
 		if (Memory::IsValidAddress(statusAddr)) {
 			if (atrac->loopinfoNum > 0)
 				Memory::Write_U32(1, statusAddr);
@@ -438,7 +661,7 @@ u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr)
 
 u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
+	DEBUG_LOG(HLE, "sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -450,20 +673,20 @@ u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 
 u32  sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
+	DEBUG_LOG(HLE, "sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		return -1;
 	}
-	if (atrac->first.writableBytes - atrac->firstSampleoffset < atrac->atracBytesPerFrame || atrac->endSample < atrac->decodePos)
+	if (atrac->currentSample >= atrac->endSample)
 		return ATRAC_ERROR_ALL_DATA_DECODED;
-	Memory::Write_U32(atrac->decodePos - atrac->currentSample, outposAddr); // outpos
-	return 0; 
+	Memory::Write_U32(atrac->currentSample, outposAddr); // outpos
+	return 0;
 }
 
 u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 {
-	ERROR_LOG(HLE, "FAKE sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
+	DEBUG_LOG(HLE, "sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -483,14 +706,13 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 
 u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 {
-	ERROR_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
+	DEBUG_LOG(HLE, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 		Memory::Write_U32(12, remainAddr); // outpos
 	} else {
-		// TODO: Seems like this is the number of bytes remaining to read from the file (or -1 if none)?
-		Memory::Write_U32(-1, remainAddr);
+		Memory::Write_U32(atrac->getRemainFrames(), remainAddr);
 	}
 	return 0;
 }
@@ -500,50 +722,30 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 	ERROR_LOG(HLE, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		Memory::Write_U32(0, outposAddr);
-		Memory::Write_U32(0, outBytesAddr);
-		return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
+		//return -1;
 	}
-
-	// TODO: When sceAtracIsSecondBufferNeeded() says yes, change this function.  Maybe it's wrong anyway.
-#if 0
-	u32 pos = (((atrac->loopEndSample >> (0x100B - atrac->codeType)) + 1) * atrac->atracBytesPerFrame + atrac->second.fileoffset - 1 ) + 1;
-	Memory::Write_U32(pos, outposAddr);
-	Memory::Write_U32(atrac->second.writableBytes - pos, outBytesAddr);
-	return 0;
-#else
 	Memory::Write_U32(0, outposAddr);
-	Memory::Write_U32(0, outBytesAddr);
+	Memory::Write_U32(0x10000, outBytesAddr);
+	// TODO: Maybe don't write the above?
 	return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
-#endif
 }
 
 u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
+	DEBUG_LOG(HLE, "sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 	}
-	if (Memory::IsValidAddress(outEndSampleAddr))
-		Memory::Write_U32(atrac->endSample - atrac->currentSample, outEndSampleAddr);
-	if (atrac->loopEndSample != 0) {
-		if (Memory::IsValidAddress(outLoopStartSampleAddr))
-			Memory::Write_U32(atrac->loopStartSample - atrac->currentSample, outLoopStartSampleAddr); 
-		if (Memory::IsValidAddress(outLoopEndSampleAddr))
-			Memory::Write_U32(atrac->loopEndSample - atrac->currentSample, outLoopEndSampleAddr); 
-	} else {
-		if (Memory::IsValidAddress(outLoopStartSampleAddr))
-			Memory::Write_U32(-1, outLoopStartSampleAddr);
-		if (Memory::IsValidAddress(outLoopEndSampleAddr))
-			Memory::Write_U32(-1, outLoopEndSampleAddr);
-	}
+	Memory::Write_U32(atrac->endSample, outEndSampleAddr); // outEndSample
+	Memory::Write_U32(atrac->loopStartSample, outLoopStartSampleAddr); // outLoopStartSample
+	Memory::Write_U32(atrac->loopEndSample, outLoopEndSampleAddr); // outLoopEndSample
 	return 0;
 }
 
 u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr)
 {
-	ERROR_LOG(HLE, "FAKE sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+	DEBUG_LOG(HLE, "sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
@@ -557,37 +759,176 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 
 u32 sceAtracReleaseAtracID(int atracID)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracReleaseAtracID(%i)", atracID);
+	INFO_LOG(HLE, "sceAtracReleaseAtracID(%i)", atracID);
 	deleteAtrac(atracID);
 	return 0;
 }
 
 u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
+	INFO_LOG(HLE, "sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		//return -1;
 	} else {
-		// TODO: Not sure what this means?
-		atrac->decodePos = sample;
+		atrac->currentSample = sample;
+#ifdef USE_FFMPEG
+		if (atrac->codeType == PSP_MODE_AT_3 && atrac->pCodecCtx) {
+			atrac->SeekToSample(sample);
+		} else
+#endif // USE_FFMPEG
+		{
+			atrac->decodePos = atrac->getDecodePosBySample(sample);
+		}
 	}
 	return 0;
 }
 
+#ifdef USE_FFMPEG
+int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size)
+{
+	Atrac *atrac = (Atrac*)opaque;
+	int size = std::min((int)atrac->atracBufSize, buf_size);
+	size = std::max(std::min(((int)atrac->first.size - (int)atrac->decodePos), size), 0);
+	if (size > 0)
+		memcpy(buf, atrac->data_buf + atrac->decodePos, size);
+	atrac->decodePos += size;
+	return size;
+}
+
+int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence)
+{
+	Atrac *atrac = (Atrac*)opaque;
+	switch (whence) {
+	case SEEK_SET:
+		atrac->decodePos = offset;
+		break;
+	case SEEK_CUR:
+		atrac->decodePos += offset;
+		break;
+	case SEEK_END:
+		atrac->decodePos = atrac->first.filesize - offset;
+		break;
+	}
+	return offset;
+}
+
+#endif // USE_FFMPEG
+
+int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
+{
+	atrac->atracBufSize = bufferSize;
+	if (atrac->first.size > atrac->first.filesize)
+		atrac->first.size = atrac->first.filesize;
+	atrac->first.fileoffset = atrac->first.size;
+	atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->atracBufSize);
+
+#ifdef USE_FFMPEG
+	if (atrac->codeType == PSP_MODE_AT_3) {
+		INFO_LOG(HLE, "This is an atrac3 audio");
+
+		// some games may reuse an atracID for playing sound
+		atrac->ReleaseFFMPEGContext();
+
+		if (atrac->data_buf) 
+			delete [] atrac->data_buf;
+
+		atrac->data_buf = new u8[atrac->first.filesize];
+		Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
+		u8* tempbuf = (u8*)av_malloc(atrac->atracBufSize);
+
+		atrac->pFormatCtx = avformat_alloc_context();
+		atrac->pAVIOCtx = avio_alloc_context(tempbuf, atrac->atracBufSize, 0, (void*)atrac, _AtracReadbuffer, NULL, _AtracSeekbuffer);
+		atrac->pFormatCtx->pb = atrac->pAVIOCtx;
+		
+		int ret;
+		// Load audio buffer
+		if((ret = avformat_open_input((AVFormatContext**)&atrac->pFormatCtx, NULL, NULL, NULL)) != 0) {
+			ERROR_LOG(HLE, "avformat_open_input: Cannot open input %d", ret);
+			return -1;
+		}
+
+		if((ret = avformat_find_stream_info(atrac->pFormatCtx, NULL)) < 0) {
+			ERROR_LOG(HLE, "avformat_find_stream_info: Cannot find stream information %d", ret);
+			return -1;
+		}
+		
+		AVCodec *pCodec;
+		// select the audio stream 
+		ret = av_find_best_stream(atrac->pFormatCtx, AVMEDIA_TYPE_AUDIO, -1, -1, &pCodec, 0);
+		if (ret < 0) {
+			ERROR_LOG(HLE, "av_find_best_stream: Cannot find a audio stream in the input file %d", ret);
+			return -1;
+		}
+		atrac->audio_stream_index = ret;
+		atrac->pCodecCtx= atrac->pFormatCtx->streams[atrac->audio_stream_index]->codec;
+
+		// open codec
+		if ((ret = avcodec_open2(atrac->pCodecCtx, pCodec, NULL)) < 0) {
+			ERROR_LOG(HLE, "avcodec_open2: Cannot open audio decoder %d", ret);
+			return -1;
+		}
+		
+		int wanted_channels = atrac->atracOutputChannels;
+		int wanted_channel_layout = av_get_default_channel_layout(wanted_channels);
+		int dec_channel_layout = av_get_default_channel_layout(atrac->atracChannels);
+
+		atrac->pSwrCtx = 
+			swr_alloc_set_opts
+			(
+				NULL,
+				wanted_channel_layout,
+				AV_SAMPLE_FMT_S16,
+				atrac->pCodecCtx->sample_rate,
+				dec_channel_layout,
+				atrac->pCodecCtx->sample_fmt,
+				atrac->pCodecCtx->sample_rate,
+				0, 
+				NULL
+			);
+		if (!atrac->pSwrCtx) {
+			ERROR_LOG(HLE, "swr_alloc_set_opts: Could not allocate resampler context %d", ret);
+			return -1;
+		}
+		if ((ret = swr_init(atrac->pSwrCtx)) < 0) {
+			ERROR_LOG(HLE, "swr_init: Failed to initialize the resampling context %d", ret);
+			return -1;
+		}
+
+		// alloc audio frame
+		atrac->pFrame = avcodec_alloc_frame();
+		
+		return 0;
+	}
+#endif // _USE_FFMPEG
+
+	return 0;
+}
+
+int _AtracSetData(int atracID, u32 buffer, u32 bufferSize)
+{
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac)
+		return -1;
+	return _AtracSetData(atrac, buffer, bufferSize);
+}
+
 u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
+	INFO_LOG(HLE, "sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
 	if (readSize > halfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
 
 	Atrac *atrac = getAtrac(atracID);
-	if (atrac) {
+	int ret = 0;
+	if (atrac != NULL) {
 		atrac->first.addr = halfBuffer;
-		atrac->first.size = halfBufferSize;
+		atrac->first.size = readSize;
 		atrac->Analyze();
+		atrac->atracOutputChannels = 2;
+		ret = _AtracSetData(atracID, halfBuffer, halfBufferSize);
 	}
-	return 0;
+	return ret;
 }
 
 u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
@@ -602,43 +943,53 @@ u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
 
 u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
+	INFO_LOG(HLE, "sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
 	Atrac *atrac = getAtrac(atracID);
+	int ret = 0;
 	if (atrac != NULL) {
 		atrac->first.addr = buffer;
 		atrac->first.size = bufferSize;
 		atrac->Analyze();
+		atrac->atracOutputChannels = 2;
+		ret = _AtracSetData(atracID, buffer, bufferSize);
 	}
-	return 0;
+	return ret;
 } 
 
 int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 {	
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
+	INFO_LOG(HLE, "sceAtracSetDataAndGetID(%08x, %08x)", buffer, bufferSize);
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
 	atrac->first.addr = buffer;
 	atrac->first.size = bufferSize;
 	atrac->Analyze();
-	return createAtrac(atrac);
+	atrac->atracOutputChannels = 2;
+	int atracID = createAtrac(atrac);
+	int ret = _AtracSetData(atracID, buffer, bufferSize);
+	if (ret < 0)
+		return ret;
+	return atracID;
 }
 
 int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x)", halfBuffer, readSize, halfBufferSize);
+	INFO_LOG(HLE, "sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x)", halfBuffer, readSize, halfBufferSize);
 	if (readSize > halfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
-
-	if (readSize < 0 || halfBufferSize < 0) 
-		return -1;
-
 	int codecType = getCodecType(halfBuffer);
+
 	Atrac *atrac = new Atrac();
 	atrac->first.addr = halfBuffer;
-	atrac->first.size = halfBufferSize;
+	atrac->first.size = readSize;
 	atrac->Analyze();
-	return createAtrac(atrac);
+	atrac->atracOutputChannels = 2;
+	int atracID = createAtrac(atrac);
+	int ret = _AtracSetData(atracID, halfBuffer, halfBufferSize);
+	if (ret < 0)
+		return ret;
+	return atracID;
 }
 
 u32 sceAtracStartEntry()
@@ -649,11 +1000,14 @@ u32 sceAtracStartEntry()
 
 u32 sceAtracSetLoopNum(int atracID, int loopNum)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
+	INFO_LOG(HLE, "sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac) {
+		if (atrac->loopinfoNum == 0)
+			return ATRAC_ERROR_UNSET_PARAM;
 		atrac->loopNum = loopNum;
 		if (loopNum != 0 && atrac->loopinfoNum == 0) {
+			// Just loop the whole audio
 			atrac->loopStartSample = 0;
 			atrac->loopEndSample = atrac->endSample;
 		}
@@ -669,10 +1023,10 @@ int sceAtracReinit()
 
 int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
+	DEBUG_LOG(HLE, "sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
 	Atrac *atrac = getAtrac(atracID);
 	if (Memory::IsValidAddress(outputChanPtr))
-		Memory::Write_U32(atrac->atracChannels, outputChanPtr);
+		Memory::Write_U32(atrac ? atrac->atracOutputChannels : 2, outputChanPtr);
 	return 0;
 }
 
@@ -686,33 +1040,73 @@ int sceAtracIsSecondBufferNeeded(int atracID)
 	return 0;
 }
 
-int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, int readSize, int MOutHalfBufferSize)
+int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, u32 readSize, u32 MOutHalfBufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetMOutHalfwayBuffer(%i, %08x, %i, %i)", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
+	INFO_LOG(HLE, "sceAtracSetMOutHalfwayBuffer(%i, %08x, %08x, %08x)", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
 	if (readSize > MOutHalfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
+
 	Atrac *atrac = getAtrac(atracID);
-	if (!atrac) {
-		//return -1;
+	int ret = 0;
+	if (atrac != NULL) {
+		atrac->first.addr = MOutHalfBuffer;
+		atrac->first.size = readSize;
+		atrac->Analyze();
+		atrac->atracOutputChannels = 1;
+		ret = _AtracSetData(atracID, MOutHalfBuffer, MOutHalfBufferSize);
 	}
-	return 0;
+	return ret;
 }
 
-int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
+u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x)", halfBuffer, readSize, halfBufferSize);
+	INFO_LOG(HLE, "sceAtracSetMOutData(%i, %08x, %08x)", atracID, buffer, bufferSize);
+	Atrac *atrac = getAtrac(atracID);
+	int ret = 0;
+	if (atrac != NULL) {
+		atrac->first.addr = buffer;
+		atrac->first.size = bufferSize;
+		atrac->Analyze();
+		atrac->atracOutputChannels = 1;
+		ret = _AtracSetData(atracID, buffer, bufferSize);
+	}
+	return ret;
+} 
+
+int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize)
+{	
+	INFO_LOG(HLE, "sceAtracSetMOutDataAndGetID(%08x, %08x)", buffer, bufferSize);
+	int codecType = getCodecType(buffer);
+
+	Atrac *atrac = new Atrac();
+	atrac->first.addr = buffer;
+	atrac->first.size = bufferSize;
+	atrac->Analyze();
+	atrac->atracOutputChannels = 1;
+	int atracID = createAtrac(atrac);
+	int ret = _AtracSetData(atracID, buffer, bufferSize);
+	if (ret < 0)
+		return ret;
+	return atracID;
+}
+
+int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
+{
+	INFO_LOG(HLE, "sceAtracSetMOutHalfwayBufferAndGetID(%08x, %08x, %08x)", halfBuffer, readSize, halfBufferSize);
 	if (readSize > halfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
-
-	if (readSize < 0 || halfBufferSize < 0) 
-		return -1;
-
 	int codecType = getCodecType(halfBuffer);
+
 	Atrac *atrac = new Atrac();
 	atrac->first.addr = halfBuffer;
-	atrac->first.size = halfBufferSize;
+	atrac->first.size = readSize;
 	atrac->Analyze();
-	return createAtrac(atrac);
+	atrac->atracOutputChannels = 1;
+	int atracID = createAtrac(atrac);
+	int ret = _AtracSetData(atracID, halfBuffer, halfBufferSize);
+	if (ret < 0)
+		return ret;
+	return atracID;
 }
 
 int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr)
@@ -740,15 +1134,45 @@ int _sceAtracGetContextAddress(int atracID)
 int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr)
 {
 	ERROR_LOG(HLE, "UNIMPL sceAtracLowLevelInitDecoder(%i, %08x)", atracID, paramsAddr);
+	Atrac *atrac = getAtrac(atracID);
+	if (atrac && Memory::IsValidAddress(paramsAddr)) {
+		atrac->atracChannels = Memory::Read_U32(paramsAddr);
+		atrac->atracOutputChannels = Memory::Read_U32(paramsAddr + 4);
+		atrac->atracBufSize = Memory::Read_U32(paramsAddr + 8);
+	}
 	return 0;
 }
 
 int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr)
 {
-	ERROR_LOG(HLE, "UNIMPL sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x)", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
-	if (Memory::IsValidAddress(sampleBytesAddr))
-		Memory::Write_U32(0, sampleBytesAddr);
+	DEBUG_LOG(HLE, "UNIMPL sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x)", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
+	Atrac *atrac = getAtrac(atracID);
+	/*if (Memory::IsValidAddress(sourceBytesConsumedAddr))
+		Memory::Write_U32(0, sourceBytesConsumedAddr);
+	if (Memory::IsValidAddress(samplesAddr) && Memory::IsValidAddress(sampleBytesAddr)) {
+		Memory::Write_U32(ATRAC_MAX_SAMPLES, sampleBytesAddr);
+		int outputChannels = atrac ? atrac->atracOutputChannels : 2;
+		Memory::Memset(samplesAddr, 0, ATRAC_MAX_SAMPLES * sizeof(s16) * outputChannels);
+	}*/
+	Memory::Write_U32(0, sampleBytesAddr);
 	return 0;
+}
+
+int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
+{
+	ERROR_LOG(HLE, "UNIMPL sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x)", halfBuffer, readSize, halfBufferSize);
+	if (readSize > halfBufferSize)
+		return ATRAC_ERROR_INCORRECT_READ_SIZE;
+
+	if (readSize < 0 || halfBufferSize < 0) 
+		return -1;
+
+	int codecType = getCodecType(halfBuffer);
+	Atrac *atrac = new Atrac();
+	atrac->first.addr = halfBuffer;
+	atrac->first.size = halfBufferSize;
+	atrac->Analyze();
+	return createAtrac(atrac);
 }
 
 const HLEFunction sceAtrac3plus[] =
@@ -781,11 +1205,11 @@ const HLEFunction sceAtrac3plus[] =
 	{0xeca32a99,WrapI_I<sceAtracIsSecondBufferNeeded>,"sceAtracIsSecondBufferNeeded"},
 	{0x0fae370e,WrapI_UUU<sceAtracSetHalfwayBufferAndGetID>,"sceAtracSetHalfwayBufferAndGetID"},
 	{0x2DD3E298,WrapU_IIU<sceAtracGetBufferInfoForReseting>,"sceAtracGetBufferInfoForResetting"},
-	{0x5CF9D852,WrapI_IUII<sceAtracSetMOutHalfwayBuffer>,"sceAtracSetMOutHalfwayBuffer"},
+	{0x5CF9D852,WrapI_IUUU<sceAtracSetMOutHalfwayBuffer>,"sceAtracSetMOutHalfwayBuffer"},
+	{0xF6837A1A,WrapU_IUU<sceAtracSetMOutData>,"sceAtracSetMOutData"},
+	{0x472E3825,WrapI_UU<sceAtracSetMOutDataAndGetID>,"sceAtracSetMOutDataAndGetID"},
+	{0x9CD7DE03,WrapI_UUU<sceAtracSetMOutHalfwayBufferAndGetID>,"sceAtracSetMOutHalfwayBufferAndGetID"},
 	{0xB3B5D042,WrapI_IU<sceAtracGetOutputChannel>,"sceAtracGetOutputChannel"},
-	{0xF6837A1A,0,"sceAtracSetMOutData"},
-	{0x472E3825,0,"sceAtracSetMOutDataAndGetID"},
-	{0x9CD7DE03,0,"sceAtracSetMOutHalfwayBufferAndGetID"},
 	{0x5622B7C1,WrapI_UIIU<sceAtracSetAA3DataAndGetID>,"sceAtracSetAA3DataAndGetID"},
 	{0x5DD66588,WrapI_UUU<sceAtracSetAA3HalfwayBufferAndGetID>,"sceAtracSetAA3HalfwayBufferAndGetID"},
 	{0x231FC6B7,WrapI_I<_sceAtracGetContextAddress>,"_sceAtracGetContextAddress"},


### PR DESCRIPTION
It is a consolidated version of sceAtrac based on current one and oioitff code to provide basic support of atrac3 audio using ffmpeg library (Note : no atrac3+ and directshow support removed)

It still compiled okay in master and atrac3 audio should start working once other developer commited the windows/android static library linking like #1641

Referencing #1662 
