### PR TITLE
When displaying an FBO, pick the most recent used

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -241,13 +241,20 @@ void FramebufferManager::DrawActiveTexture(float x, float y, float w, float h, b
 }
 
 VirtualFramebuffer *FramebufferManager::GetDisplayFBO() {
+	VirtualFramebuffer *match = NULL;
 	for (auto iter = vfbs_.begin(); iter != vfbs_.end(); ++iter) {
 		VirtualFramebuffer *v = *iter;
 		if (MaskedEqual(v->fb_address, displayFramebufPtr_) && v->format == displayFormat_) {
 			// Could check w too but whatever
-			return *iter;
+			if (match == NULL || match->last_frame_used < v->last_frame_used) {
+				match = v;
+			}
 		}
 	}
+	if (match != NULL) {
+		return match;
+	}
+
 	DEBUG_LOG(HLE, "Finding no FBO matching address %08x", displayFramebufPtr_);
 #if 0  // defined(_DEBUG)
 	std::string debug = "FBOs: ";

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -808,10 +808,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 				"unsupported2",
 				"unsupported3",
 			};
-			if (data & ~0x107)
-				sprintf(buffer, "TexFunc %i %s (%s, extra %x)", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7], data);
+			if (data & ~0x10107)
+				sprintf(buffer, "TexFunc %i %s %s%s (extra %x)", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7], data & 0x10000 ? " color double" : "", data);
 			else
-				sprintf(buffer, "TexFunc %i %s (%s)", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7]);
+				sprintf(buffer, "TexFunc %i %s %s%s", data & 7, data & 0x100 ? "RGBA" : "RGB", texfuncs[data & 7], data & 0x10000 ? " color double" : "");
 		}
 		break;
 


### PR DESCRIPTION
Fixes Jewel Summoner flicker, makes sense, and improves Shadow of Destiny (which was black before with buffered rendering off, but still displays 512x512 but seems to render 480x272...)

Also a GE disasm fix.

-[Unknown]
