### PR TITLE
Add back second texcache, improve perf, add memory check

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -670,32 +670,17 @@ void TextureCache::StartFrame() {
 }
 
 static const u8 bitsPerPixel[11] = {
-	16,  //GE_TFMT_5650=16,
-	16,  //GE_TFMT_5551=16,
-	16,  //GE_TFMT_4444=16,
-	32,  //GE_TFMT_8888=3,
-	4,   //GE_TFMT_CLUT4=4,
-	8,   //GE_TFMT_CLUT8=5,
-	16,  //GE_TFMT_CLUT16=6,
-	32,  //GE_TFMT_CLUT32=7,
-	4,   //GE_TFMT_DXT1=4,
-	8,   //GE_TFMT_DXT3=8,
-	8,   //GE_TFMT_DXT5=8,
-};
-
-// This is the same as (fmt & 4) != 0, heh.
-static const bool formatUsesClut[11] = {
-	false,
-	false,
-	false,
-	false,
-	true,
-	true,
-	true,
-	true,
-	false,
-	false,
-	false,
+	16,  //GE_TFMT_5650,
+	16,  //GE_TFMT_5551,
+	16,  //GE_TFMT_4444,
+	32,  //GE_TFMT_8888,
+	4,   //GE_TFMT_CLUT4,
+	8,   //GE_TFMT_CLUT8,
+	16,  //GE_TFMT_CLUT16,
+	32,  //GE_TFMT_CLUT32,
+	4,   //GE_TFMT_DXT1,
+	8,   //GE_TFMT_DXT3,
+	8,   //GE_TFMT_DXT5,
 };
 
 static inline u32 MiniHash(const u32 *ptr) {
@@ -703,10 +688,10 @@ static inline u32 MiniHash(const u32 *ptr) {
 }
 
 static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, u32 format) {
-	u32 sizeInRAM = (bitsPerPixel[format < 11 ? format : 0] * bufw * h / 2) / 8;
+	const u32 sizeInRAM = (bitsPerPixel[format < 11 ? format : 0] * bufw * h) / 8;
 	const u32 *checkp = (const u32 *) Memory::GetPointer(addr);
 	u32 check = 0;
-	for (u32 i = 0; i < (sizeInRAM * 2) / 4; ++i)
+	for (u32 i = 0; i < sizeInRAM / 4; ++i)
 		check += *checkp++;
 
 	return check;
@@ -733,7 +718,8 @@ void TextureCache::SetTexture() {
 		ERROR_LOG_REPORT(G3D, "Unknown texture format %i", format);
 		format = 0;
 	}
-	bool hasClut = formatUsesClut[format];
+	// GE_TFMT_CLUT4 - GE_TFMT_CLUT32 are 0b1xx.
+	bool hasClut = (format & 4) != 0;
 
 	u64 cachekey = texaddr;
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -108,6 +108,7 @@ private:
 	TexCache secondCache;
 
 	bool clearCacheNextFrame_;
+	bool lowMemoryMode_;
 	TextureScaler scaler;
 
 	SimpleBuf<u32> tmpTexBuf32;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -74,6 +74,7 @@ private:
 		u32 framesUntilNextFullHash;
 		u8 format;
 		u8 clutformat;
+		u32 cluthash;
 		u16 dim;
 		u32 clutaddr;
 		u32 texture;  //GLuint
@@ -88,6 +89,9 @@ private:
 		u8 minFilt;
 		bool sClamp;
 		bool tClamp;
+
+		bool Matches(u16 dim2, u32 hash2, u8 format2, int maxLevel2);
+		bool MatchesClut(bool hasClut, u8 clutformat2, u32 clutaddr2);
 	};
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
@@ -101,6 +105,7 @@ private:
 
 	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
+	TexCache secondCache;
 
 	bool clearCacheNextFrame_;
 	TextureScaler scaler;


### PR DESCRIPTION
This does a few things, all related to the texture cache:
- Adds back the secondary texture cache.  For perf, it's only checked based on # of invalidations.  For games that draw animation over a texture, this should improve perf at the cost of VRAM.
- Uses SSE2 in QuickTexHash.  This improves its performance significantly (I couldn't get MSVC to do this for me automatically, tried a couple variations...)  In Popolocrois (where this function was dominating at ~25%), it went from 500 to 600 vps with this change.
- Checks for GL_OUT_OF_MEMORY, and starts decimating more and kills the second cache if it happens.  I was able to (at least on desktop) trigger this error, and this could even improve performance on some systems (but there's no way to tell when it's swapping into RAM afaict...)

-[Unknown]
