### PR TITLE
Don't just say 0 for remainFrame in sceAtrac

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -165,11 +165,8 @@ struct Atrac {
 			// require more data
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
 		} else {
-			// This is the correct one
-			//remainFrame = (first.size - decodePos) / atracBytesPerFrame;
-
-			// Try to load all file data immediately
-			remainFrame = 0;
+			// Games expect to be told how many frames need to be read.
+			remainFrame = (first.size - decodePos) / atracBytesPerFrame;
 		}
 		return remainFrame;
 	}


### PR DESCRIPTION
Fixes LittleBigPlanet, which expects a reasonable number here (and I would think that 0 would mean "there are no remaining frames I need you to read from the file" not "please read everything," although I don't really get this API.)

-[Unknown]
