### PR TITLE
Use a base time throughout rtc and kernel time

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -57,6 +57,7 @@
 #include "scePower.h"
 #include "sceUtility.h"
 #include "sceUmd.h"
+#include "sceRtc.h"
 #include "sceSsl.h"
 #include "sceSas.h"
 #include "scePsmf.h"
@@ -108,6 +109,7 @@ void __KernelInit()
 	__MpegInit(PSP_CoreParameter().useMediaEngine);
 	__PsmfInit();
 	__CtrlInit();
+	__RtcInit();
 	__SslInit();
 	__ImposeInit();
 	__UsbInit();
@@ -201,6 +203,7 @@ void __KernelDoState(PointerWrap &p)
 	__PowerDoState(p);
 	__PsmfDoState(p);
 	__PsmfPlayerDoState(p);
+	__RtcDoState(p);
 	__SasDoState(p);
 	__SslDoState(p);
 	__UmdDoState(p);

--- a/Core/HLE/sceRtc.h
+++ b/Core/HLE/sceRtc.h
@@ -17,9 +17,12 @@
 
 #pragma once
 
-void sceRtcGetCurrentTick();
-int sceRtcGetLastAdjustedTime(u32 tickPtr);
+struct timeval;
+void __RtcTimeOfDay(timeval *tv);
+
 void Register_sceRtc();
+void __RtcInit();
+void __RtcDoState(PointerWrap &p);
 
 struct ScePspDateTime {
 	unsigned short year;


### PR DESCRIPTION
This way, time doesn't move abnormally as far as the game can tell, even when savestates and fast forward and pause are used.

I think I got everything?

-[Unknown]
