### PR TITLE
Improve remainFrame in sceAtrac

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -161,12 +161,10 @@ struct Atrac {
 		int remainFrame;
 		if (first.fileoffset >= first.filesize || currentSample >= endSample)
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		else if (decodePos >= first.fileoffset - atracBytesPerFrame ) {
-			// require more data
-			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		} else {
-			// Games expect to be told how many frames need to be read.
-			remainFrame = (first.size - decodePos) / atracBytesPerFrame;
+		else {
+			// guess the remain frames. 
+			// games would add atrac data when remainFrame = 0 or -1 
+			remainFrame = (first.size - decodePos) / atracBytesPerFrame - 1;
 		}
 		return remainFrame;
 	}


### PR DESCRIPTION
#1683 would broke some atrac3 audios (such as in Fate Unlimited Codes), because remainFrame would never become 0. Games request to add atrac data when remainFrame is 0 or PSP_ATRAC_ALLDATA_IS_ON_MEMORY(-1).
