### PR TITLE
Send u_alphacolorref as integers

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -184,8 +184,8 @@ void GenerateFragmentShader(char *buffer) {
 			WRITE(p, "varying vec2 v_texcoord;\n");
 	}
 
-	WRITE(p, "int round255f(in float x) { return int(x * 255.0 + 0.5); }\n");
-	WRITE(p, "ivec3 round255v(in vec3 x) { return ivec3(x * 255.0 + 0.5); }\n");
+	WRITE(p, "int roundAndScaleTo255f(in float x) { return int(x * 255.0 + 0.5); }\n");
+	WRITE(p, "ivec3 roundAndScaleTo255v(in vec3 x) { return ivec3(x * 255.0 + 0.5); }\n");
 
 	WRITE(p, "void main() {\n");
 
@@ -255,7 +255,7 @@ void GenerateFragmentShader(char *buffer) {
 			int alphaTestFunc = gstate.alphatest & 7;
 			const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };	// never/always don't make sense
 			if (alphaTestFuncs[alphaTestFunc][0] != '#') {
-				WRITE(p, "  if (round255f(v.a) %s u_alphacolorref.a) discard;\n", alphaTestFuncs[alphaTestFunc]);
+				WRITE(p, "  if (roundAndScaleTo255f(v.a) %s u_alphacolorref.a) discard;\n", alphaTestFuncs[alphaTestFunc]);
 			}
 		}
 
@@ -268,7 +268,7 @@ void GenerateFragmentShader(char *buffer) {
 			const char *colorTestFuncs[] = { "#", "#", " != ", " == " };	// never/always don't make sense
 			int colorTestMask = gstate.colormask;
 			if (colorTestFuncs[colorTestFunc][0] != '#') {
-				WRITE(p, "if (round255v(v.rgb) %s u_alphacolorref.rgb) discard;\n", colorTestFuncs[colorTestFunc]);
+				WRITE(p, "if (roundAndScaleTo255v(v.rgb) %s u_alphacolorref.rgb) discard;\n", colorTestFuncs[colorTestFunc]);
 			}
 		}
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -179,6 +179,17 @@ static void SetColorUniform3Alpha(int uniform, u32 color, u8 alpha)
 	glUniform4fv(uniform, 1, col);
 }
 
+static void SetColorUniform3iAlpha(int uniform, u32 color, u8 alpha)
+{
+	const GLint col[4] = {
+		((color & 0xFF)),
+		((color & 0xFF00) >> 8),
+		((color & 0xFF0000) >> 16),
+		alpha
+	};
+	glUniform4iv(uniform, 1, col);
+}
+
 static void SetColorUniform3ExtraFloat(int uniform, u32 color, float extra)
 {
 	const float col[4] = {
@@ -262,7 +273,7 @@ void LinkedShader::updateUniforms() {
 		SetColorUniform3(u_texenv, gstate.texenvcolor);
 	}
 	if (u_alphacolorref != -1 && (dirtyUniforms & DIRTY_ALPHACOLORREF)) {
-		SetColorUniform3Alpha(u_alphacolorref, gstate.colorref, (gstate.alphatest >> 8) & 0xFF);
+		SetColorUniform3iAlpha(u_alphacolorref, gstate.colorref, (gstate.alphatest >> 8) & 0xFF);
 	}
 	if (u_colormask != -1 && (dirtyUniforms & DIRTY_COLORMASK)) {
 		SetColorUniform3(u_colormask, gstate.colormask);


### PR DESCRIPTION
It seems faster on a desktop, but harder to tell for me on Android (doesn't seem worse, anyway...)  Maybe might help #1700.  At least if it's really treated as a float, rounding issues might be proper in the driver.

Can revert if people report it doesn't help.

-[Unknown]
