### PR TITLE
New Option for Blackberry keyboard devices: Partial Vertical Stretch

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 
+#include "base/display.h"
 #include "Common/FileUtil.h"
 #include "Config.h"
 #include "file/ini_file.h"
@@ -76,10 +77,7 @@ void Config::Load(const char *iniFileName)
 
 	IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 #ifdef IOS
-	if(isJailed == true)
-		cpu->Get("Jit", &bJit, false);
-	else
-		cpu->Get("Jit", &bJit, true);
+	cpu->Get("Jit", &bJit, !isJailed);
 #else
 	cpu->Get("Jit", &bJit, true);
 #endif
@@ -107,7 +105,10 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 8);
 #endif
 	graphics->Get("VertexCache", &bVertexCache, true);
-	graphics->Get("FullScreen", &bFullScreen, false);	
+	graphics->Get("FullScreen", &bFullScreen, false);
+#ifdef BLACKBERRY10
+	graphics->Get("PartialStretch", &bPartialStretch, pixel_xres == pixel_yres);
+#endif
 	graphics->Get("StretchToDisplay", &bStretchToDisplay, false);
 	graphics->Get("TrueColor", &bTrueColor, true);
 #ifdef USING_GLES2
@@ -124,7 +125,9 @@ void Config::Load(const char *iniFileName)
 
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("ShowStick", &bShowAnalogStick, false);
-#ifdef USING_GLES2
+#ifdef BLACKBERRY10
+	control->Get("ShowTouchControls", &bShowTouchControls, pixel_xres != pixel_yres);
+#elif defined(USING_GLES2)
 	control->Get("ShowTouchControls", &bShowTouchControls, true);
 #else
 	control->Get("ShowTouchControls", &bShowTouchControls,false);
@@ -196,6 +199,9 @@ void Config::Save()
 		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
 		graphics->Set("FullScreen", bFullScreen);
+#ifdef BLACKBERRY10
+		graphics->Set("PartialStretch", bPartialStretch);
+#endif
 		graphics->Set("StretchToDisplay", bStretchToDisplay);
 		graphics->Set("TrueColor", bTrueColor);
 		graphics->Set("MipMap", bMipMap);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -59,6 +59,9 @@ public:
 	bool bDrawWireframe;
 	bool bLinearFiltering;
 	bool bUseVBO;
+#ifdef BLACKBERRY10
+	bool bPartialStretch;
+#endif
 	bool bStretchToDisplay;
 	int iFrameSkip;
 	bool bUseMediaEngine;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -87,6 +87,11 @@ void CenterRect(float *x, float *y, float *w, float *h,
 		*x = 0.0f;
 		*w = frameW;
 		*h = frameW / origRatio;
+#ifdef BLACKBERRY10
+		// Stretch a little bit
+		if (g_Config.bPartialStretch)
+			*h = (frameH + *h) / 2.0f; // (408 + 720) / 2 = 564
+#endif
 		*y = (frameH - *h) / 2.0f;
 	}
 	else

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -413,6 +413,10 @@ void PauseScreen::render() {
 	UICheckBox(GEN_ID, x, y += stride, ss->T("Show FPS"), ALIGN_TOPLEFT, &g_Config.bShowFPSCounter);
 	UICheckBox(GEN_ID, x, y += stride, a->T("Enable Sound"), ALIGN_TOPLEFT, &g_Config.bEnableSound);
 	// TODO: Maybe shouldn't show this if the screen ratios are very close...
+#ifdef BLACKBERRY10
+	if (pixel_xres == pixel_yres)
+		UICheckBox(GEN_ID, x, y += stride, gs->T("Partial Vertical Stretch"), ALIGN_TOPLEFT, &g_Config.bPartialStretch);
+#endif
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Stretch to Display"), ALIGN_TOPLEFT, &g_Config.bStretchToDisplay);
 
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Hardware Transform"), ALIGN_TOPLEFT, &g_Config.bHardwareTransform);


### PR DESCRIPTION
Stretches screen vertically by ~38% (midpoint of stretched and non-stretched).
Set this on by default for keyboard devices. Also set 'Show Touch' off by default.

Blackberry keyboard devices have a 1:1 aspect ratio (720x720 pixels).

The normal Stretch to Display setting does not suffice for these devices because the stretch from 408 -> 720 looks comical and very distorted.
So, I propose to meet mid-way at 564 where the stretch is not as obvious and yet it still takes up most of the screen.
