### PR TITLE
Improve remainFrame for sceAtrac.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -160,6 +160,10 @@ struct Atrac {
 		int remainFrame;
 		if (first.fileoffset >= first.filesize || currentSample >= endSample)
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
+		else if (decodePos > first.size) {
+			// There are not enough atrac data right now to play at a certain position.
+			// Must load more atrac data first
+			remainFrame = 0;
 		else {
 			// guess the remain frames. 
 			// games would add atrac data when remainFrame = 0 or -1 


### PR DESCRIPTION
New finding in remainFrame.

Some games may start to play atrac audio at a certain position (not at beginning), such as Taiko no Tatsujin DX.
