### PR TITLE
Complete fix overbright issue in FF Type-0 by advancing the coretiming 

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -282,6 +282,7 @@ int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
 {
 	DEBUG_LOG(HLE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
 	hleEatCycles(190);
+	CoreTiming::Advance();
 	return gpu->UpdateStall(displayListID, stallAddress);
 }
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -255,10 +255,10 @@ void GenerateFragmentShader(char *buffer) {
 			WRITE(p, "  vec4 v = v_color0 %s;\n", secondary);
 		}
 
-		if (enableColorDoubling) {
-			WRITE(p, "  v = v * 2.0;\n");
+		if (enableAlphaDoubling) {
+			WRITE(p, "  v.a = v.a * 2.0;\n");
 		}
-
+		
 		if (enableAlphaTest) {
 			int alphaTestFunc = gstate.alphatest & 7;
 			const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };	// never/always don't make sense
@@ -266,9 +266,9 @@ void GenerateFragmentShader(char *buffer) {
 				WRITE(p, "  if (roundAndScaleTo255f(v.a) %s u_alphacolorref.a) discard;\n", alphaTestFuncs[alphaTestFunc]);
 			}
 		}
-
-		if (enableAlphaDoubling) {
-			WRITE(p, "  v.a = v.a * 2.0;\n");
+		
+		if (enableColorDoubling) {
+			WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
 		}
 		
 		if (enableColorTest) {


### PR DESCRIPTION
in sceGeListUpdateStallAddr() and correct v.a wrongly multipled to 4.0 

Issue #1410
