### PR TITLE
Only double the color with color doubling

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -255,10 +255,6 @@ void GenerateFragmentShader(char *buffer) {
 			WRITE(p, "  vec4 v = v_color0 %s;\n", secondary);
 		}
 
-		if (enableColorDoubling) {
-			WRITE(p, "  v = v * 2.0;\n");
-		}
-
 		if (enableAlphaTest) {
 			int alphaTestFunc = gstate.alphatest & 7;
 			const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };	// never/always don't make sense
@@ -267,7 +263,12 @@ void GenerateFragmentShader(char *buffer) {
 			}
 		}
 
-		if (enableAlphaDoubling) {
+		// TODO: Before or after the color test?
+		if (enableColorDoubling && enableAlphaDoubling) {
+			WRITE(p, "  v = v * 2.0;\n");
+		} else if (enableColorDoubling) {
+			WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
+		} else if (enableAlphaDoubling) {
 			WRITE(p, "  v.a = v.a * 2.0;\n");
 		}
 		


### PR DESCRIPTION
Not the alpha.  Thanks to @raven02.

This improves Final Fantasy Type-0 (demo at least), and Kingdom Hearts colors (not lighting, but e.g. the hard menu alpha.)

A surprising (to me, at least) number of games use this color doubling, which weren't hurt by this change:
- Tactics Ogre
- Dissidia
- Jeanne D'Arc
- Ys Seven
- Hexyz Force
- Shadow of Destiny
- Legend of Heroes 1
- Crisis Core
- Mana Khemia
- Cladun X2

-[Unknown]
