### PR TITLE
Add log for atrac3+ audio

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -433,10 +433,6 @@ u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
 	if (atrac->data_buf && (bytesToAdd > 0)) {
 		int addbytes = std::min(bytesToAdd, atrac->first.filesize - atrac->first.fileoffset);
 		Memory::Memcpy(atrac->data_buf + atrac->first.fileoffset, atrac->first.addr, addbytes);
-#ifdef _USE_DSHOW_
-		if (atrac->first.fileoffset + addbytes >= atrac->first.filesize)
-			addAtrac3Audio(atrac->data_buf, atrac->first.filesize, atracID);
-#endif
 	}
 	atrac->first.size += bytesToAdd;
 	if (atrac->first.size > atrac->first.filesize)
@@ -880,7 +876,8 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 		Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
 
 		return __AtracSetContext(atrac, buffer, bufferSize);
-	}
+	} else if (atrac->codeType == PSP_MODE_AT_3_PLUS) 
+		INFO_LOG(HLE, "This is an atrac3+ audio");
 #endif // _USE_FFMPEG
 
 	return 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -864,7 +864,7 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 
 #ifdef USE_FFMPEG
 	if (atrac->codeType == PSP_MODE_AT_3) {
-		INFO_LOG(HLE, "This is an atrac3 audio");
+		WARN_LOG(HLE, "This is an atrac3 audio");
 
 		// some games may reuse an atracID for playing sound
 		atrac->ReleaseFFMPEGContext();
@@ -877,7 +877,7 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 
 		return __AtracSetContext(atrac, buffer, bufferSize);
 	} else if (atrac->codeType == PSP_MODE_AT_3_PLUS) 
-		INFO_LOG(HLE, "This is an atrac3+ audio");
+		WARN_LOG(HLE, "This is an atrac3+ audio");
 #endif // _USE_FFMPEG
 
 	return 0;


### PR DESCRIPTION
It simply shows "This is an atrac3+ audio" when detects PSP_MODE_AT_3_PLUS codec , nothing else but in yellow color so we easy to see it in debug log .

![log](https://f.cloud.github.com/assets/3000282/488834/eca8385c-b988-11e2-964a-fca4b7f345ae.jpg)
 .
