### PR TITLE
Add reporting for alphatest mask

### DIFF
--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -22,6 +22,11 @@
 #define NOTICE_LOG_REPORT(t,...)  { NOTICE_LOG(t, __VA_ARGS__); Reporting::ReportMessage(__VA_ARGS__); }
 #define INFO_LOG_REPORT(t,...)    { INFO_LOG(t, __VA_ARGS__);   Reporting::ReportMessage(__VA_ARGS__); }
 
+#define ERROR_LOG_REPORT_ONCE(n,t,...)   { static bool n = false; if (!n) { n = true; ERROR_LOG(t, __VA_ARGS__);  Reporting::ReportMessage(__VA_ARGS__); } }
+#define WARN_LOG_REPORT_ONCE(n,t,...)    { static bool n = false; if (!n) { n = true; WARN_LOG(t, __VA_ARGS__);   Reporting::ReportMessage(__VA_ARGS__); } }
+#define NOTICE_LOG_REPORT_ONCE(n,t,...)  { static bool n = false; if (!n) { n = true; NOTICE_LOG(t, __VA_ARGS__); Reporting::ReportMessage(__VA_ARGS__); } }
+#define INFO_LOG_REPORT_ONCE(n,t,...)    { static bool n = false; if (!n) { n = true; INFO_LOG(t, __VA_ARGS__);   Reporting::ReportMessage(__VA_ARGS__); } }
+
 namespace Reporting
 {
 	bool IsEnabled();

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -18,6 +18,7 @@
 #include "Core/MemMap.h"
 #include "Core/Host.h"
 #include "Core/Config.h"
+#include "Core/Reporting.h"
 #include "Core/System.h"
 #include "gfx_es2/gl_state.h"
 
@@ -795,8 +796,12 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		shaderManager_->DirtyUniform(DIRTY_COLORMASK);
 		break;
 
-	case GE_CMD_COLORREF:
 	case GE_CMD_ALPHATEST:
+#ifndef USING_GLES2
+		if (((data >> 16) & 0xFF) != 0xFF && data != 0)
+			WARN_LOG_REPORT_ONCE(alphatestmask, HLE, "Unsupported alphatest mask: %02x", (data >> 16) & 0xFF);
+#endif
+	case GE_CMD_COLORREF:
 		shaderManager_->DirtyUniform(DIRTY_ALPHACOLORREF);
 		break;
 


### PR DESCRIPTION
Actually, maybe it being 0x00 could be advantageous...

Disabled it for GLES 2.0 (mobile) because I don't want to hurt speed for something so trivial.

-[Unknown]
