### PR TITLE
Eat cycles in sceKernelReferThreadStatus()

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1163,6 +1163,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 			Memory::Memcpy(statusPtr, &t->nt, sz);
 	}
 
+	hleEatCycles(1220);
 	return 0;
 }
 


### PR DESCRIPTION
Improves .hack//Link (demo)'s perf significantly (at least up to menu), doesn't hurt anyone else.  It still spends 12% of its time in this function, but it was 60% before.

-[Unknown]
