### PR TITLE
Load cluts when told to, improve texhash func a bit

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -576,8 +576,13 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_CLUTADDR:
 	case GE_CMD_CLUTADDRUPPER:
-	case GE_CMD_LOADCLUT:
 	case GE_CMD_CLUTFORMAT:
+		gstate_c.textureChanged = true;
+		// This could be used to "dirty" textures with clut.
+		break;
+
+	case GE_CMD_LOADCLUT:
+		gstate_c.clutChanged = true;
 		gstate_c.textureChanged = true;
 		// This could be used to "dirty" textures with clut.
 		break;

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -582,8 +582,8 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_LOADCLUT:
-		gstate_c.clutChanged = true;
 		gstate_c.textureChanged = true;
+		textureCache_.UpdateCurrentClut();
 		// This could be used to "dirty" textures with clut.
 		break;
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -222,7 +222,7 @@ void GLES_GPU::BuildReportingInfo() {
 	const char *glSlVersion = GetGLStringAlways(GL_SHADING_LANGUAGE_VERSION);
 	const char *glExtensions = GetGLStringAlways(GL_EXTENSIONS);
 
-	char temp[2048];
+	char temp[16384];
 	snprintf(temp, sizeof(temp), "%s (%s %s), %s (extensions: %s)", glVersion, glVendor, glRenderer, glSlVersion, glExtensions);
 	reportingPrimaryInfo_ = glVendor;
 	reportingFullInfo_ = temp;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -817,11 +817,6 @@ void TextureCache::SetTexture() {
 
 	u32 clutformat, cluthash;
 	if (hasClut) {
-		if (gstate_c.clutChanged) {
-			UpdateCurrentClut();
-			gstate_c.clutChanged = false;
-		}
-
 		clutformat = gstate.clutformat & 3;
 		cluthash = GetCurrentClutHash();
 		cachekey |= (u64)cluthash << 32;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -185,7 +185,7 @@ void TextureCache::NotifyFramebufferDestroyed(u32 address, VirtualFramebuffer *f
 }
 
 static u32 GetClutAddr(u32 clutEntrySize) {
-	return ((gstate.clutaddr & 0xFFFFFF) | ((gstate.clutaddrupper << 8) & 0x0F000000)) + ((gstate.clutformat >> 16) & 0x1f) * clutEntrySize;
+	return ((gstate.clutaddr & 0xFFFFFF) | ((gstate.clutaddrupper << 8) & 0x0F000000));
 }
 
 static u32 GetClutIndex(u32 index) {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -38,6 +38,7 @@ public:
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);
 	void ClearNextFrame();
+	void UpdateCurrentClut();
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory
 	// are being rendered to. This is barebones so far.
@@ -107,7 +108,6 @@ private:
 	void LoadTextureLevel(TexCacheEntry &entry, int level);
 	void *DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);
 	void CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFmt, int w, int h);
-	void UpdateCurrentClut();
 	template <typename T>
 	const T *GetCurrentClut();
 	u32 GetCurrentClutHash();

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -108,6 +108,10 @@ private:
 	void LoadTextureLevel(TexCacheEntry &entry, int level);
 	void *DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);
 	void CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFmt, int w, int h);
+	void UpdateCurrentClut();
+	template <typename T>
+	const T *GetCurrentClut();
+	u32 GetCurrentClutHash();
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
@@ -124,8 +128,8 @@ private:
 
 	SimpleBuf<u32> tmpTexBufRearrange;
 
-	u32 *clutBuf32;
-	u16 *clutBuf16;
+	u32 *clutBuf_;
+	u32 clutHash_;
 
 	u32 lastBoundTexture;
 	float maxAnisotropyLevel;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -83,7 +83,6 @@ private:
 		u8 clutformat;
 		u32 cluthash;
 		u16 dim;
-		u32 clutaddr;
 		u32 texture;  //GLuint
 		int invalidHint;
 		u32 fullhash;
@@ -98,7 +97,7 @@ private:
 		bool tClamp;
 
 		bool Matches(u16 dim2, u32 hash2, u8 format2, int maxLevel2);
-		bool MatchesClut(bool hasClut, u8 clutformat2, u32 clutaddr2);
+		bool MatchesClut(bool hasClut, u8 clutformat2);
 	};
 
 	void Decimate();  // Run this once per frame to get rid of old textures.

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -254,7 +254,6 @@ struct GPUStateCache
 	bool textureChanged;
 	bool textureFullAlpha;
 	bool framebufChanged;
-	bool clutChanged;
 
 	int skipDrawReason;
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -254,6 +254,7 @@ struct GPUStateCache
 	bool textureChanged;
 	bool textureFullAlpha;
 	bool framebufChanged;
+	bool clutChanged;
 
 	int skipDrawReason;
 


### PR DESCRIPTION
So, right after I said I hadn't found a game that the old hash didn't do the job for, I found out Final Fantasy 2 was having issues with it, heh.  I tried FletcherHash and CityHash32 (which btw, CityHash32 was faster) and they were both way slower, so I just added an xor step to the current one.  It fixes it and doesn't seem to hurt anyone.  But maybe we do need a better hash....

Anyway, that game is spending 75% of its time in the texture cache.  About 50/50 in texhash and in loading the texture.  It only happens when you're near animated water, which they do evil things with like in Popolocrois.  Worse, it animates slowly and causes the entire sprite sheet to invalidate or something.

Cranking the decimate frames up to 1200 makes it faster, but that's not a solution so I didn't commit that...

Anyway, I went ahead and also made it load cluts on LOADCLUT.  This means it's reusing the clut sometimes (I checked and games do this) on future textures.  It might be faster, and it probably matches behavior better as you said (in the case they don't load the clut.)

Also fixes the clutoffset being double-applied (I'm pretty sure.)  I don't think I have any games that actually use this, though...

-[Unknown]
