### PR TITLE
Fix "fog" in 3rd Birthday

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -34,7 +34,7 @@ void MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelM
 	// fake image. To be improved.
 	if (Memory::IsValidAddress(bufferPtr))
 		// Use Dark Grey to identify CG is running 
-		Memory::Memset(bufferPtr, 0x69, frameWidth * videoHeight_ * bpp);
+		Memory::Memset(bufferPtr, 0x00, frameWidth * videoHeight_ * bpp);
 }
 
 void MediaEngine::feedPacketData(u32 addr, int size)


### PR DESCRIPTION
The "fog" is basically the side effect of our current fake grey image .It can only be resolved by implmenting the video support . 

Before fix
![2](https://f.cloud.github.com/assets/3000282/492383/3ead3ec6-baa2-11e2-9a29-3a1d6148108b.jpg)

After fix
![1](https://f.cloud.github.com/assets/3000282/492386/8b3a3a3c-baa2-11e2-8975-27bfaa15d8e7.jpg)
