### PR TITLE
Finally got how sceAtracAddStreamData should work.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -163,14 +163,10 @@ struct Atrac {
 		// when remainFrames = PSP_ATRAC_ALLDATA_IS_ON_MEMORY .
 		// Still need to find out how getRemainFrames() should work.
 
-		if (currentSample >= endSample)
-			return PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-
-		if ((first.fileoffset >= first.filesize) && (currentSample > loopEndSample))
-			return PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-
 		int remainFrame;
-		if (decodePos > first.size) {
+		if (first.fileoffset >= first.filesize || currentSample >= endSample)
+			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
+		else if (decodePos > first.size) {
 			// There are not enough atrac data right now to play at a certain position.
 			// Must load more atrac data first
 			remainFrame = 0;


### PR DESCRIPTION
I did some tests for that function, and finally find out how it works.
PSP allow games to add stream data to a temp buf, the buf size is given by "atracbufsize "here. "first.offset" means how many bytes the temp buf has been written, and "first.writableBytes" means how many bytes the temp buf is allowed to write (We always have "first.offset + first.writableBytes = atracbufsize").  We only reset the temp buf when games call sceAtracGetStreamDataInfo, because that function would tell games how to add the left stream data.
It finally fixes issue #1771.
