### PR TITLE
Misc. GE changes and CLUT fix

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -938,6 +938,33 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		}
 		break;
 
+#ifndef USING_GLES2
+	case GE_CMD_LOGICOPENABLE:
+		if (data != 0)
+			ERROR_LOG_REPORT(G3D, "Unsupported logic op enabled: %x", data);
+		break;
+
+	case GE_CMD_LOGICOP:
+		if (data != 0)
+			ERROR_LOG_REPORT(G3D, "Unsupported logic op: %06x", data);
+		break;
+
+	case GE_CMD_ANTIALIASENABLE:
+		if (data != 0)
+			WARN_LOG_REPORT(G3D, "Unsupported antialias enabled: %06x", data);
+		break;
+
+	case GE_CMD_TEXLODSLOPE:
+		if (data != 0)
+			WARN_LOG_REPORT(G3D, "Unsupported texture lod slope: %06x", data);
+		break;
+
+	case GE_CMD_TEXLEVEL:
+		if (data != 0)
+			WARN_LOG_REPORT(G3D, "Unsupported texture level bias settings: %06x", data);
+		break;
+#endif
+
 	default:
 		GPUCommon::ExecuteOp(op, diff);
 		break;

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -583,7 +583,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_LOADCLUT:
 		gstate_c.textureChanged = true;
-		textureCache_.UpdateCurrentClut();
+		textureCache_.LoadClut();
 		// This could be used to "dirty" textures with clut.
 		break;
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -941,27 +941,29 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 #ifndef USING_GLES2
 	case GE_CMD_LOGICOPENABLE:
 		if (data != 0)
-			ERROR_LOG_REPORT(G3D, "Unsupported logic op enabled: %x", data);
+			ERROR_LOG_REPORT_ONCE(logicOpEnable, G3D, "Unsupported logic op enabled: %x", data);
 		break;
 
 	case GE_CMD_LOGICOP:
 		if (data != 0)
-			ERROR_LOG_REPORT(G3D, "Unsupported logic op: %06x", data);
+			ERROR_LOG_REPORT_ONCE(logicOp, G3D, "Unsupported logic op: %06x", data);
 		break;
 
 	case GE_CMD_ANTIALIASENABLE:
 		if (data != 0)
-			WARN_LOG_REPORT(G3D, "Unsupported antialias enabled: %06x", data);
+			WARN_LOG_REPORT_ONCE(antiAlias, G3D, "Unsupported antialias enabled: %06x", data);
 		break;
 
 	case GE_CMD_TEXLODSLOPE:
 		if (data != 0)
-			WARN_LOG_REPORT(G3D, "Unsupported texture lod slope: %06x", data);
+			WARN_LOG_REPORT_ONCE(texLodSlope, G3D, "Unsupported texture lod slope: %06x", data);
 		break;
 
 	case GE_CMD_TEXLEVEL:
-		if (data != 0)
-			WARN_LOG_REPORT(G3D, "Unsupported texture level bias settings: %06x", data);
+		if (data == 1)
+			WARN_LOG_REPORT_ONCE(texLevel1, G3D, "Unsupported texture level bias settings: %06x", data)
+		else if (data != 0)
+			WARN_LOG_REPORT_ONCE(texLevel2, G3D, "Unsupported texture level bias settings: %06x", data);
 		break;
 #endif
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -73,6 +73,10 @@ static bool IsColorTestTriviallyTrue() {
 }
 
 static bool CanDoubleSrcBlendMode() {
+	if (!gstate.isAlphaBlendEnabled()) {
+		return false;
+	}
+
 	int funcA = gstate.getBlendFuncA();
 	int funcB = gstate.getBlendFuncB();
 	if (funcA != GE_SRCBLEND_DOUBLESRCALPHA) {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -129,6 +129,9 @@ private:
 
 	u32 *clutBuf_;
 	u32 clutHash_;
+	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
+	bool clutAlphaLinear_;
+	u16 clutAlphaLinearColor_;
 
 	u32 lastBoundTexture;
 	float maxAnisotropyLevel;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -38,7 +38,7 @@ public:
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);
 	void ClearNextFrame();
-	void UpdateCurrentClut();
+	void LoadClut();
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory
 	// are being rendered to. This is barebones so far.
@@ -111,6 +111,7 @@ private:
 	template <typename T>
 	const T *GetCurrentClut();
 	u32 GetCurrentClutHash();
+	void UpdateCurrentClut();
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
@@ -127,6 +128,7 @@ private:
 
 	SimpleBuf<u32> tmpTexBufRearrange;
 
+	bool clutDirty_;
 	u32 *clutBuf_;
 	u32 clutHash_;
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -473,8 +473,8 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_TRANSFERSRCPOS:
 		{
-			u32 x = (data & 1023)+1;
-			u32 y = ((data>>10) & 1023)+1;
+			u32 x = (data & 1023);
+			u32 y = ((data>>10) & 1023);
 			if (data & 0xF00000)
 				sprintf(buffer, "Block transfer src rect TL: %i, %i (extra %x)", x, y, data >> 20);
 			else
@@ -484,8 +484,8 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_TRANSFERDSTPOS:
 		{
-			u32 x = (data & 1023)+1;
-			u32 y = ((data>>10) & 1023)+1;
+			u32 x = (data & 1023);
+			u32 y = ((data>>10) & 1023);
 			if (data & 0xF00000)
 				sprintf(buffer, "Block transfer dest rect TL: %i, %i (extra %x)", x, y, data >> 20);
 			else
@@ -849,7 +849,7 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_TEXMODE:
-		sprintf(buffer, "TexMode %06x (%s)", data, data & 1 ? "swizzle" : "no swizzle");
+		sprintf(buffer, "TexMode %06x (%s, %d levels, %s)", data, data & 1 ? "swizzle" : "no swizzle", (data >> 16) & 7, (data >> 8) & 1 ? "separate cluts" : "shared clut");
 		break;
 
 	case GE_CMD_TEXFORMAT:
@@ -929,7 +929,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 		break;
 
 	case GE_CMD_STENCILOP:
-		sprintf(buffer, "Stencil op: %06x", data);
+		{
+			const char *stencilOps[] = { "KEEP", "ZERO", "REPLACE", "INVERT", "INCREMENT", "DECREMENT", "unsupported1", "unsupported2" };
+			sprintf(buffer, "Stencil op: fail=%s, pass/depthfail=%s, pass=%s", stencilOps[data & 7], stencilOps[(data >> 8) & 7], stencilOps[(data >> 16) & 7]);
+		}
 		break;
 
 	case GE_CMD_STENCILTEST:


### PR DESCRIPTION
This does the following:
- Converts the CLUT on first use, but loads it on LOADCLUT.
- Implements the mipmap CLUT sharing, I think it works right, Lunar apparently uses it.
- Doesn't double alpha when alphablendenable is false.
- Checks for the CLUT font optimization once per CLUT, not every time (e.g. for mipmapping, and games also reuse CLUTs.)
- Reports a few unsupported GE commands.
- Adds some better disasm for a couple commands.

-[Unknown]
