### PR TITLE
Don't use ivec in the fragment shader.

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -171,7 +171,7 @@ void GenerateFragmentShader(char *buffer) {
 		WRITE(p, "uniform sampler2D tex;\n");
 
 	if (enableAlphaTest || enableColorTest) {
-		WRITE(p, "uniform ivec4 u_alphacolorref;\n");
+		WRITE(p, "uniform vec4 u_alphacolorref;\n");
 		WRITE(p, "uniform vec4 u_colormask;\n");
 	}
 	if (gstate.isTextureMapEnabled()) 
@@ -196,8 +196,8 @@ void GenerateFragmentShader(char *buffer) {
 			WRITE(p, "varying vec2 v_texcoord;\n");
 	}
 
-	WRITE(p, "int roundAndScaleTo255f(in float x) { return int(x * 255.0 + 0.5); }\n");
-	WRITE(p, "ivec3 roundAndScaleTo255v(in vec3 x) { return ivec3(x * 255.0 + 0.5); }\n");
+	WRITE(p, "float roundAndScaleTo255f(in float x) { return floor(x * 255.0 + 0.5); }\n");
+	WRITE(p, "vec3 roundAndScaleTo255v(in vec3 x) { return floor(x * 255.0 + 0.5); }\n");
 
 	WRITE(p, "void main() {\n");
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -179,15 +179,16 @@ static void SetColorUniform3Alpha(int uniform, u32 color, u8 alpha)
 	glUniform4fv(uniform, 1, col);
 }
 
-static void SetColorUniform3iAlpha(int uniform, u32 color, u8 alpha)
+// This passes colors unscaled (e.g. 0 - 255 not 0 - 1.)
+static void SetColorUniform3Alpha255(int uniform, u32 color, u8 alpha)
 {
-	const GLint col[4] = {
-		(GLint)((color & 0xFF)),
-		(GLint)((color & 0xFF00) >> 8),
-		(GLint)((color & 0xFF0000) >> 16),
-		(GLint)alpha
+	const float col[4] = {
+		(float)((color & 0xFF)),
+		(float)((color & 0xFF00) >> 8),
+		(float)((color & 0xFF0000) >> 16),
+		(float)alpha
 	};
-	glUniform4iv(uniform, 1, col);
+	glUniform4fv(uniform, 1, col);
 }
 
 static void SetColorUniform3ExtraFloat(int uniform, u32 color, float extra)
@@ -273,7 +274,7 @@ void LinkedShader::updateUniforms() {
 		SetColorUniform3(u_texenv, gstate.texenvcolor);
 	}
 	if (u_alphacolorref != -1 && (dirtyUniforms & DIRTY_ALPHACOLORREF)) {
-		SetColorUniform3iAlpha(u_alphacolorref, gstate.colorref, (gstate.alphatest >> 8) & 0xFF);
+		SetColorUniform3Alpha255(u_alphacolorref, gstate.colorref, (gstate.alphatest >> 8) & 0xFF);
 	}
 	if (u_colormask != -1 && (dirtyUniforms & DIRTY_COLORMASK)) {
 		SetColorUniform3(u_colormask, gstate.colormask);


### PR DESCRIPTION
Attempt at #1777.  Needs the + 0.5 to round properly on mobile.

-[Unknown]
