### PR TITLE
Correct errors for async io, other io fixes

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -309,6 +309,10 @@ void MetaFileSystem::ThreadEnded(int threadID)
 
 int MetaFileSystem::ChDir(const std::string &dir)
 {
+	// Retain the old path and fail if the arg is 1023 bytes or longer.
+	if (dir.size() >= 1023)
+		return SCE_KERNEL_ERROR_NAMETOOLONG;
+
 	int curThread = __KernelGetCurThread();
 	
 	std::string of;

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -131,6 +131,13 @@ static bool RealPath(const std::string &currentDirectory, const std::string &inP
 		inAfterColon = inPath.substr(inColon + 1);
 	}
 
+	// Special case: "disc0:" is different from "disc0:/", so keep track of the single slash.
+	if (inAfterColon == "/")
+	{
+		outPath = prefix + inAfterColon;
+		return true;
+	}
+
 	if (! ApplyPathStringToComponentsVector(cmpnts, inAfterColon) )
 	{
 		WARN_LOG(HLE, "RealPath: inPath is not a valid path: \"%s\"", inPath.c_str());
@@ -170,9 +177,9 @@ bool MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpat
 	// Special handling: host0:command.txt (as seen in Super Monkey Ball Adventures, for example)
 	// appears to mean the current directory on the UMD. Let's just assume the current directory.
 	std::string inpath = _inpath;
-	if (strncasecmp(inpath.c_str(), "host0:", 5) == 0) {
+	if (strncasecmp(inpath.c_str(), "host0:", strlen("host0:")) == 0) {
 		INFO_LOG(HLE, "Host0 path detected, stripping: %s", inpath.c_str());
-		inpath = inpath.substr(6);
+		inpath = inpath.substr(strlen("host0:"));
 	}
 
 	const std::string *currentDirectory = &startingDirectory;

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -84,7 +84,7 @@ public:
 		return SeekFile(handle, 0, FILEMOVE_CURRENT);
 	}
 
-	virtual void ChDir(const std::string &dir);
+	virtual int ChDir(const std::string &dir);
 
 	virtual bool MkDir(const std::string &dirname);
 	virtual bool RmDir(const std::string &dirname);

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -84,7 +84,6 @@ const HLEFunction sceHttp[] = {
 	{0x2255551E,0,"sceHttpGetNetworkPspError"},
 	{0xAB1540D5,0,"sceHttpsGetSslError"},
 	{0xA4496DE5,0,"sceHttpSetRedirectCallback"},
-	{0x0282A3BD,0,"sceHttpGetContentLength"},
 };				
 
 void Register_sceHttp()

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1149,8 +1149,7 @@ u32 sceIoRename(const char *from, const char *to) {
 
 u32 sceIoChdir(const char *dirname) {
 	DEBUG_LOG(HLE, "sceIoChdir(%s)", dirname);
-	pspFileSystem.ChDir(dirname);
-	return 0;
+	return pspFileSystem.ChDir(dirname);
 }
 
 int sceIoChangeAsyncPriority(int id, int priority)

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -140,7 +140,7 @@ struct dirent {
 
 class FileNode : public KernelObject {
 public:
-	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), pendingAsyncResult(false), sectorBlockMode(false), closePending(false), npdrm(0), pgdInfo(NULL) {}
+	FileNode() : callbackID(0), callbackArg(0), asyncResult(0), hasAsyncResult(false), pendingAsyncResult(false), sectorBlockMode(false), closePending(false), npdrm(0), pgdInfo(NULL) {}
 	~FileNode() {
 		pspFileSystem.CloseFile(handle);
 	}
@@ -158,6 +158,7 @@ public:
 		p.Do(callbackID);
 		p.Do(callbackArg);
 		p.Do(asyncResult);
+		p.Do(hasAsyncResult);
 		p.Do(pendingAsyncResult);
 		p.Do(sectorBlockMode);
 		p.Do(closePending);
@@ -176,6 +177,7 @@ public:
 	u32 callbackArg;
 
 	s64 asyncResult;
+	bool hasAsyncResult;
 	bool pendingAsyncResult;
 
 	bool sectorBlockMode;
@@ -333,6 +335,7 @@ void __IoCompleteAsyncIO(SceUID id) {
 			__KernelNotifyCallback(THREAD_CALLBACK_IO, f->callbackID, f->callbackArg);
 		}
 		f->pendingAsyncResult = false;
+		f->hasAsyncResult = true;
 	}
 }
 
@@ -371,6 +374,7 @@ void __IoSchedAsync(FileNode *f, SceUID fd, int usec) {
 	CoreTiming::ScheduleEvent(usToCycles(usec), asyncNotifyEvent, param);
 
 	f->pendingAsyncResult = true;
+	f->hasAsyncResult = false;
 }
 
 u32 sceIoGetstat(const char *filename, u32 addr) {
@@ -1245,20 +1249,24 @@ u32 sceIoGetAsyncStat(int id, u32 poll, u32 address)
 				DEBUG_LOG(HLE, "%lli = sceIoGetAsyncStat(%i, %i, %08x): waiting", f->asyncResult, id, poll, address);
 				__KernelWaitCurThread(WAITTYPE_IO, id, address, 0, false, "io waited");
 			}
-		} else {
+		} else if (f->hasAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoGetAsyncStat(%i, %i, %08x)", f->asyncResult, id, poll, address);
 			Memory::Write_U64((u64) f->asyncResult, address);
+			f->hasAsyncResult = false;
 
 			if (f->closePending) {
 				kernelObjects.Destroy<FileNode>(id);
 			}
+		} else {
+			WARN_LOG(HLE, "SCE_KERNEL_ERROR_NOASYNC = sceIoGetAsyncStat(%i, %i, %08x)", id, poll, address);
+			return SCE_KERNEL_ERROR_NOASYNC;
 		}
 		return 0; //completed
 	}
 	else
 	{
 		ERROR_LOG(HLE, "ERROR - sceIoGetAsyncStat with invalid id %i", id);
-		return -1;
+		return SCE_KERNEL_ERROR_BADF;
 	}
 }
 
@@ -1269,18 +1277,22 @@ int sceIoWaitAsync(int id, u32 address) {
 		if (f->pendingAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoWaitAsync(%i, %08x): waiting", f->asyncResult, id, address);
 			__KernelWaitCurThread(WAITTYPE_IO, id, address, 0, false, "io waited");
-		} else {
+		} else if (f->hasAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoWaitAsync(%i, %08x)", f->asyncResult, id, address);
 			Memory::Write_U64((u64) f->asyncResult, address);
+			f->hasAsyncResult = false;
 
 			if (f->closePending) {
 				kernelObjects.Destroy<FileNode>(id);
 			}
+		} else {
+			WARN_LOG(HLE, "SCE_KERNEL_ERROR_NOASYNC = sceIoWaitAsync(%i, %08x)", id, address);
+			return SCE_KERNEL_ERROR_NOASYNC;
 		}
 		return 0; //completed
 	} else {
 		ERROR_LOG(HLE, "ERROR - sceIoWaitAsync waiting for invalid id %i", id);
-		return -1;
+		return SCE_KERNEL_ERROR_BADF;
 	}
 }
 
@@ -1293,18 +1305,22 @@ int sceIoWaitAsyncCB(int id, u32 address) {
 		if (f->pendingAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoWaitAsyncCB(%i, %08x): waiting", f->asyncResult, id, address);
 			__KernelWaitCurThread(WAITTYPE_IO, id, address, 0, false, "io waited");
-		} else {
+		} else if (f->hasAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoWaitAsyncCB(%i, %08x)", f->asyncResult, id, address);
 			Memory::Write_U64((u64) f->asyncResult, address);
+			f->hasAsyncResult = false;
 
 			if (f->closePending) {
 				kernelObjects.Destroy<FileNode>(id);
 			}
+		} else {
+			WARN_LOG(HLE, "SCE_KERNEL_ERROR_NOASYNC = sceIoWaitAsyncCB(%i, %08x)", id, address);
+			return SCE_KERNEL_ERROR_NOASYNC;
 		}
 		return 0; //completed
 	} else {
 		ERROR_LOG(HLE, "ERROR - sceIoWaitAsyncCB waiting for invalid id %i", id);
-		return -1;
+		return SCE_KERNEL_ERROR_BADF;
 	}
 }
 
@@ -1315,18 +1331,22 @@ u32 sceIoPollAsync(int id, u32 address) {
 		if (f->pendingAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoPollAsync(%i, %08x): not ready", f->asyncResult, id, address);
 			return 1;
-		} else {
+		} else if (f->hasAsyncResult) {
 			DEBUG_LOG(HLE, "%lli = sceIoPollAsync(%i, %08x)", f->asyncResult, id, address);
 			Memory::Write_U64((u64) f->asyncResult, address);
+			f->hasAsyncResult = false;
 
 			if (f->closePending) {
 				kernelObjects.Destroy<FileNode>(id);
 			}
 			return 0; //completed
+		} else {
+			WARN_LOG(HLE, "SCE_KERNEL_ERROR_NOASYNC = sceIoWaitAsyncCB(%i, %08x)", id, address);
+			return SCE_KERNEL_ERROR_NOASYNC;
 		}
 	} else {
 		ERROR_LOG(HLE, "ERROR - sceIoPollAsync waiting for invalid id %i", id);
-		return -1;  // TODO: correct error code
+		return SCE_KERNEL_ERROR_BADF;
 	}
 }
 


### PR DESCRIPTION
Fixes:
- Opening disc0:/ as a directory was opening umd0:.
- Ensure umd0: savestates are done properly.
- sceIoChdir error handling.
- Proper error codes when there's no async operation pending when waiting/polling.

Tested a number of games fixed by async IO, and others using async IO, and they seemed fine.  Still need to clean up my async IO tests, can probably do at least these without requiring a umd.  But they do match, anyway.

-[Unknown]
