### PR TITLE
Fix BGM loop problem in Three Kingdom VIII

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -178,6 +178,8 @@ struct Atrac {
 			// There are not enough atrac data right now to play at a certain position.
 			// Must load more atrac data first
 			remainFrame = 0;
+		} else if (second.writableBytes <= 0) {
+			remainFrame = PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY ;
 		} else {
 			// guess the remain frames. 
 			// games would add atrac data when remainFrame = 0 or -1 
@@ -724,9 +726,9 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 		//return -1;
 	}
 	if (Memory::IsValidAddress(outposAddr))
-		Memory::Write_U32(0, outposAddr);
+		Memory::Write_U32(atrac->second.fileoffset, outposAddr);
 	if (Memory::IsValidAddress(outBytesAddr))
-		Memory::Write_U32(0x10000, outBytesAddr);
+		Memory::Write_U32(atrac->second.writableBytes, outBytesAddr);
 	// TODO: Maybe don't write the above?
 	return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
 }


### PR DESCRIPTION
I understand it may not be 100% correct but it should at least fix the BGM looping problem in Three Kingdom VIII and may be other as well .

Referencing  uofw implemetation , looks like not only remainFrames = 0 or -1 calls sceAtracAddStreamData 
but also -2 (PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY) 
 and -3 (PSP_ATRAC_LOOP_STREAM_DATA_IS_ON_MEMORY)

(Sorry that i may not able to use jpcsptrace since i don't have a real PSP on hand now)
