### PR TITLE
HLE needs to be reset after kernel shutdown

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -677,7 +677,12 @@ bool __KernelLoadExec(const char *filename, SceKernelLoadExecParam *param, std::
 {
 	// Wipe kernel here, loadexec should reset the entire system
 	if (__KernelIsRunning())
+	{
 		__KernelShutdown();
+		//HLE needs to be reset here
+		HLEShutdown();
+		HLEInit();
+	}
 
 	__KernelModuleInit();
 	__KernelInit();


### PR DESCRIPTION
the changes should fix those game which rely on the function sceKernelLoadExec 

Games tested:

Crazy Taxi: Fare Wars
Power Stone Collection
