### PR TITLE
Not to loop or end audios when numSamples is 0.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -538,11 +538,11 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			atrac->decodePos = atrac->getDecodePosBySample(atrac->currentSample);
 			
 			int finishFlag = 0;
-			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample || numSamples == 0)) {
+			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample)) {
 				atrac->currentSample = atrac->loopStartSample;
 				if (atrac->loopNum > 0)
 					atrac->loopNum --;
-			} else if (atrac->currentSample >= atrac->endSample || numSamples == 0)
+			} else if (atrac->currentSample >= atrac->endSample)
 				finishFlag = 1;
 
 			Memory::Write_U32(finishFlag, finishFlagAddr);


### PR DESCRIPTION
Some games may check for it first and then add more data.
It was originally a hack way to force audio to loop or end when "Error decoding audio" occurs, and I think it's time to remove it for better performance.
