### PR TITLE
Fps limit fixes

### DIFF
--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -723,7 +723,7 @@ void GraphicsScreenP2::render() {
 	I18NCategory *g = GetI18NCategory("General");
 	I18NCategory *gs = GetI18NCategory("Graphics");
 
-	ui_draw2d.SetFontScale(1.5f, 1.5f);
+	ui_draw2d.SetFontScale(1.0f, 1.0f);
 	ui_draw2d.DrawText(UBUNTU24, gs->T("Graphics Settings"), dp_xres / 2, 20, 0xFFFFFFFF, ALIGN_HCENTER);
 	ui_draw2d.SetFontScale(1.0f, 1.0f);
 
@@ -782,7 +782,7 @@ void GraphicsScreenP2::render() {
 		if (UIButton(GEN_ID, hlinear1, 45, 0, "240", ALIGN_LEFT))
 			g_Config.iFpsLimit = 240;
 	} else {
-			g_Config.iFpsLimit = 60;
+			g_Config.iFpsLimit = 0;
 				}
 	bool TexScaling = g_Config.iTexScalingLevel > 1;
 	UICheckBox(GEN_ID, x, y += stride + 15, gs->T("xBRZ Texture Scaling"), ALIGN_TOPLEFT, &TexScaling);

--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -19,6 +19,7 @@ unsigned int key_pad_map[] = {
 	VK_DOWN,  PAD_BUTTON_DOWN,
 	VK_LEFT,  PAD_BUTTON_LEFT,
 	VK_RIGHT, PAD_BUTTON_RIGHT,
+	VK_F3,	  PAD_BUTTON_LEFT_THUMB,
 };
 
 unsigned short analog_ctrl_map[] = {


### PR DESCRIPTION
Add 'F3' on keyboard as a toggle for fps-limit (for keyboard user)

Fix graphics screen 'Fps Limit' from being unable to close out, making options below it unreadable.
