### PR TITLE
Fixes to sceAudio Reserve funcs

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -83,7 +83,7 @@ void __AudioInit()
 
 	CoreTiming::ScheduleEvent(usToCycles(audioIntervalUs), eventAudioUpdate, 0);
 	CoreTiming::ScheduleEvent(usToCycles(audioHostIntervalUs), eventHostAudioUpdate, 0);
-	for (int i = 0; i < 8; i++)
+	for (int i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++)
 		chans[i].clear();
 }
 
@@ -116,7 +116,7 @@ void __AudioDoState(PointerWrap &p)
 
 void __AudioShutdown()
 {
-	for (int i = 0; i < 8; i++)
+	for (int i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++)
 		chans[i].clear();
 }
 
@@ -200,7 +200,7 @@ void __AudioUpdate()
 	s32 mixBuffer[hwBlockSize * 2];
 	memset(mixBuffer, 0, sizeof(mixBuffer));
 
-	for (int i = 0; i < PSP_AUDIO_CHANNEL_MAX; i++)
+	for (int i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++)
 	{
 		if (!chans[i].reserved)
 			continue;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -271,9 +271,12 @@ u32 sceAudioEnd(){
 	return 0;
 }
 
-u32 sceAudioOutput2Reserve(u32 sampleCount){
-	if (chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
-		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - channel already reserved ", sampleCount);
+u32 sceAudioOutput2Reserve(u32 sampleCount) {
+	if (sampleCount < 17 || sampleCount > 4111) {
+		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - invalid sample count", sampleCount);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	} else if (chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
+		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - channel already reserved", sampleCount);
 		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
 	} else {
 		DEBUG_LOG(HLE,"sceAudioOutput2Reserve(%08x)", sampleCount);
@@ -339,7 +342,10 @@ u32 sceAudioSetVolumeOffset() {
 }
 
 u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
-	if (chans[PSP_AUDIO_CHANNEL_SRC].reserved) {
+	if (sampleCount < 17 || sampleCount > 4111) {
+		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - invalid sample count", sampleCount, freq, format);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	} else if (chans[PSP_AUDIO_CHANNEL_SRC].reserved) {
 		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - channel already reserved ", sampleCount, freq, format);
 		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
 	} else {

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -163,11 +163,15 @@ static u32 GetFreeChannel() {
 }
 
 u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
-	if (chan == (u32)-1) {
+	if ((int)chan < 0) {
 		chan = GetFreeChannel();
+		if ((int)chan < 0) {
+			ERROR_LOG(HLE, "sceAudioChReserve - no channels remaining");
+			return SCE_ERROR_AUDIO_NO_CHANNELS_AVAILABLE;
+		}
 	} 
 	if (chan >= PSP_AUDIO_CHANNEL_MAX)	{
-		ERROR_LOG(HLE ,"sceAudioChReserve(%08x, %08x, %08x) - bad channel", chan, sampleCount, format);
+		ERROR_LOG(HLE, "sceAudioChReserve(%08x, %08x, %08x) - bad channel", chan, sampleCount, format);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
 	}
 	if (format != PSP_AUDIO_FORMAT_MONO && format != PSP_AUDIO_FORMAT_STEREO) {
@@ -175,8 +179,8 @@ u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
 		return SCE_ERROR_AUDIO_INVALID_FORMAT;
 	}
 	if (chans[chan].reserved) {
-		ERROR_LOG(HLE,"sceAudioChReserve - reserve channel failed");
-		return SCE_ERROR_AUDIO_NO_CHANNELS_AVAILABLE;
+		ERROR_LOG(HLE, "sceAudioChReserve - reserve channel failed");
+		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
 	}
 
 	DEBUG_LOG(HLE, "sceAudioChReserve(%08x, %08x, %08x)", chan, sampleCount, format);

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -156,9 +156,10 @@ int sceAudioGetChannelRestLength(u32 chan) {
 }
 
 static u32 GetFreeChannel() {
-	for (u32 i = 0; i < PSP_AUDIO_CHANNEL_MAX ; i++)
+	for (u32 i = PSP_AUDIO_CHANNEL_MAX - 1; i > 0; --i) {
 		if (!chans[i].reserved)
 			return i;
+	}
 	return -1;
 }
 

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -272,9 +272,14 @@ u32 sceAudioEnd(){
 }
 
 u32 sceAudioOutput2Reserve(u32 sampleCount){
-	DEBUG_LOG(HLE,"sceAudioOutput2Reserve(%08x)", sampleCount);
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleCount = sampleCount;
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved = true;
+	if (chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
+		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - channel already reserved ", sampleCount);
+		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
+	} else {
+		DEBUG_LOG(HLE,"sceAudioOutput2Reserve(%08x)", sampleCount);
+		chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleCount = sampleCount;
+		chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved = true;
+	}
 	return 0;
 }
 

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -24,6 +24,8 @@
 #include "__sceAudio.h"
 #include "HLE.h"
 
+const int PSP_AUDIO_SAMPLE_MAX = 65536 - 64;
+
 void AudioChannel::DoState(PointerWrap &p)
 {
 	p.Do(reserved);
@@ -175,6 +177,10 @@ u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
 		ERROR_LOG(HLE, "sceAudioChReserve(%08x, %08x, %08x) - bad channel", chan, sampleCount, format);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
 	}
+	if ((sampleCount & 63) != 0 || sampleCount == 0 || sampleCount > PSP_AUDIO_SAMPLE_MAX) {
+		ERROR_LOG(HLE, "sceAudioChReserve(%08x, %08x, %08x) - invalid sample count", chan, sampleCount, format);
+		return SCE_ERROR_AUDIO_OUTPUT_SAMPLE_DATA_SIZE_NOT_ALIGNED;
+	}
 	if (format != PSP_AUDIO_FORMAT_MONO && format != PSP_AUDIO_FORMAT_STEREO) {
 		ERROR_LOG(HLE, "sceAudioChReserve(%08x, %08x, %08x) - invalid format", chan, sampleCount, format);
 		return SCE_ERROR_AUDIO_INVALID_FORMAT;
@@ -188,7 +194,7 @@ u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
 	chans[chan].sampleCount = sampleCount;
 	chans[chan].format = format;
 	chans[chan].reserved = true;
-	return chan; 
+	return chan;
 }
 
 u32 sceAudioChRelease(u32 chan) {

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -274,10 +274,10 @@ u32 sceAudioEnd(){
 
 u32 sceAudioOutput2Reserve(u32 sampleCount) {
 	if (sampleCount < 17 || sampleCount > 4111) {
-		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - invalid sample count", sampleCount);
+		ERROR_LOG(HLE, "sceAudioOutput2Reserve(%08x) - invalid sample count", sampleCount);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	} else if (chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
-		DEBUG_LOG(HLE, "sceAudioOutput2Reserve(%08x) - channel already reserved", sampleCount);
+		ERROR_LOG(HLE, "sceAudioOutput2Reserve(%08x) - channel already reserved", sampleCount);
 		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
 	} else {
 		DEBUG_LOG(HLE,"sceAudioOutput2Reserve(%08x)", sampleCount);
@@ -302,21 +302,21 @@ u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr){
 }
 
 u32 sceAudioOutput2ChangeLength(u32 sampleCount){
-	DEBUG_LOG(HLE,"sceAudioOutput2ChangeLength(%08x)", sampleCount);
 	if (!chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
-		DEBUG_LOG(HLE,"sceAudioOutput2ChangeLength(%08x) - channel not reserved ", sampleCount);
+		ERROR_LOG(HLE,"sceAudioOutput2ChangeLength(%08x) - channel not reserved ", sampleCount);
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
+	DEBUG_LOG(HLE,"sceAudioOutput2ChangeLength(%08x)", sampleCount);
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleCount = sampleCount;
 	return 0;
 }
 
 u32 sceAudioOutput2GetRestSample(){
-	DEBUG_LOG(HLE,"sceAudioOutput2GetRestSample()");
 	if (!chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
-		DEBUG_LOG(HLE,"sceAudioOutput2GetRestSample() - channel not reserved ");
+		ERROR_LOG(HLE,"sceAudioOutput2GetRestSample() - channel not reserved ");
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
+	DEBUG_LOG(HLE,"sceAudioOutput2GetRestSample()");
 	return (u32) chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleQueue.size() * 2;
 }
 
@@ -345,16 +345,16 @@ u32 sceAudioSetVolumeOffset() {
 
 u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 	if (format == 4) {
-		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - unexpected format", sampleCount, freq, format);
+		ERROR_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - unexpected format", sampleCount, freq, format);
 		return PSP_AUDIO_ERROR_SRC_FORMAT_4;
 	} else if (format != 2) {
-		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - unexpected format", sampleCount, freq, format);
+		ERROR_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - unexpected format", sampleCount, freq, format);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	} else if (sampleCount < 17 || sampleCount > 4111) {
-		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - invalid sample count", sampleCount, freq, format);
+		ERROR_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - invalid sample count", sampleCount, freq, format);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	} else if (chans[PSP_AUDIO_CHANNEL_SRC].reserved) {
-		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - channel already reserved ", sampleCount, freq, format);
+		ERROR_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x) - channel already reserved ", sampleCount, freq, format);
 		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
 	} else {
 		DEBUG_LOG(HLE, "sceAudioSRCChReserve(%08x, %08x, %08x)", sampleCount, freq, format);
@@ -367,11 +367,11 @@ u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 }
 
 u32 sceAudioSRCChRelease() {
-	DEBUG_LOG(HLE, "sceAudioSRCChRelease()");
 	if (!chans[PSP_AUDIO_CHANNEL_SRC].reserved) {
-		DEBUG_LOG(HLE, "sceAudioSRCChRelease() - channel already reserved ");
+		ERROR_LOG(HLE, "sceAudioSRCChRelease() - channel already reserved ");
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
+	DEBUG_LOG(HLE, "sceAudioSRCChRelease()");
 	chans[PSP_AUDIO_CHANNEL_SRC].clear();
 	chans[PSP_AUDIO_CHANNEL_SRC].reserved = false;
 	return 0;

--- a/Core/HLE/sceAudio.h
+++ b/Core/HLE/sceAudio.h
@@ -42,7 +42,10 @@ enum  	PspAudioFrequencies { PSP_AUDIO_FREQ_44K = 44100, PSP_AUDIO_FREQ_48K = 48
 #define SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED				0x80268002
 
 
-#define PSP_AUDIO_CHANNEL_MAX 8
+const int PSP_AUDIO_CHANNEL_MAX = 8;
+
+const int PSP_AUDIO_CHANNEL_SRC = 8;
+const int PSP_AUDIO_CHANNEL_OUTPUT2 = 8;
 
 struct AudioChannel
 {
@@ -83,6 +86,7 @@ struct AudioChannel
 	}
 };
 
-extern AudioChannel chans[8];
+// The extra channel is for SRC/Output2.
+extern AudioChannel chans[PSP_AUDIO_CHANNEL_MAX + 1];
 
 void Register_sceAudio();


### PR DESCRIPTION
This does only a few things:
- Validates parameters to sceAudioOutput2Reserve / sceAudioChReserve / sceAudioSRCChReserve.
- Uses a separate channel fro SRC / Output2, since tests show they can all be reserved (especially 0) and SRC/Output2 can still work.
- Reserves the highest channel first when doing automatic (could be important in some games...?)
- Sets the channel's format to STEREO for SRC and Output2.  Wasn't initialized, but I guess STEREO is zero anyway.... I was initially worried this was a problem.

Mostly fixes tests, but the frequency validation isn't correct yet in SRC.

I tried a bunch of games that play sounds and call these functions, and they seemed unaffected.  I'm hoping these changes might help some game, though.  Making blocking audio work right is my real goal, but I wanted to understand these first to write proper tests.

-[Unknown]
