### PR TITLE
Improve some sceAtrac functions

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -538,11 +538,13 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 			atrac->decodePos = atrac->getDecodePosBySample(atrac->currentSample);
 			
 			int finishFlag = 0;
-			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample)) {
+			if (atrac->loopNum != 0 && (atrac->currentSample >= atrac->loopEndSample || 
+				(numSamples == 0 && atrac->first.size >= atrac->first.fileoffset))) {
 				atrac->currentSample = atrac->loopStartSample;
 				if (atrac->loopNum > 0)
 					atrac->loopNum --;
-			} else if (atrac->currentSample >= atrac->endSample)
+			} else if (atrac->currentSample >= atrac->endSample || 
+				(numSamples == 0 && atrac->first.size >= atrac->first.fileoffset))
 				finishFlag = 1;
 
 			Memory::Write_U32(finishFlag, finishFlagAddr);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -168,7 +168,7 @@ struct Atrac {
 	int getRemainFrames() {
 		// many games request to add atrac data when remainFrames = 0
 		// However, some other games request to add atrac data 
-		// when remainFrames = PSP_ATRAC_ALLDATA_IS_ON_MEMORY .
+		// when remainFrames < 0 .
 		// Still need to find out how getRemainFrames() should work.
 
 		int remainFrame;
@@ -178,12 +178,12 @@ struct Atrac {
 			// There are not enough atrac data right now to play at a certain position.
 			// Must load more atrac data first
 			remainFrame = 0;
-		} else if (second.writableBytes <= 0) {
-			remainFrame = PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY ;
 		} else {
 			// guess the remain frames. 
-			// games would add atrac data when remainFrame = 0 or -1 
+			// games would add atrac data when remainFrame = 0 or < 0 
 			remainFrame = (first.size - decodePos) / atracBytesPerFrame - 1;
+			if (remainFrame < 0)
+				remainFrame = -0x100;
 		}
 		return remainFrame;
 	}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -174,16 +174,10 @@ struct Atrac {
 		int remainFrame;
 		if (first.fileoffset >= first.filesize || currentSample >= endSample)
 			remainFrame = PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
-		else if (decodePos > first.size) {
-			// There are not enough atrac data right now to play at a certain position.
-			// Must load more atrac data first
-			remainFrame = 0;
-		} else {
+		else {
 			// guess the remain frames. 
 			// games would add atrac data when remainFrame = 0 or < 0 
-			remainFrame = (first.size - decodePos) / atracBytesPerFrame - 1;
-			if (remainFrame < 0)
-				remainFrame = -0x100;
+			remainFrame = ((int)first.size - (int)decodePos) / atracBytesPerFrame - 1;
 		}
 		return remainFrame;
 	}


### PR DESCRIPTION
It's still not how it really works, but at least it fixes some bugs in previous commits.
The fix in #1797 broke some games which works normally before such as Fate Unlimited Code, God of War and game in #1815. Based on some tests by @raven02, games which fixed by #1797 only needs return a <-1 value such as -2 or even -0x100. So I make another fix for that. Based on some tests, it should not break other games.

The fix in #1805 removes a hack way for numSamples. However, it is probably still necessary for some games, because some other functions are still not working correctly. And then I make a better hack way for that. It has no affect for those games working normally, but it would not crash some games which still don't work normally right now.
