### PR TITLE
Warning fixes

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include "CommonTypes.h"
 
 extern const char *PPSSPP_GIT_VERSION;
 
@@ -78,7 +79,7 @@ public:
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;
 	int iFpsLimit;
-	int iMaxRecent;
+	u32 iMaxRecent;
 
 	// Sound
 	bool bEnableSound;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -494,8 +494,8 @@ u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) 
 	return 0;
 }
 
-bool __DisplayGetFramebuf(u8 **topaddr, u32 *linesize, u32 *pixelFormat, int mode) {
-	const FrameBufferState &fbState = mode == 1 ? latchedFramebuf : framebuf;
+bool __DisplayGetFramebuf(u8 **topaddr, u32 *linesize, u32 *pixelFormat, int latchedMode) {
+	const FrameBufferState &fbState = latchedMode == 1 ? latchedFramebuf : framebuf;
 	if (topaddr != NULL)
 		*topaddr = Memory::GetPointer(fbState.topaddr);
 	if (linesize != NULL)
@@ -506,8 +506,8 @@ bool __DisplayGetFramebuf(u8 **topaddr, u32 *linesize, u32 *pixelFormat, int mod
 	return true;
 }
 
-u32 sceDisplayGetFramebuf(u32 topaddrPtr, u32 linesizePtr, u32 pixelFormatPtr, int mode) {
-	const FrameBufferState &fbState = mode == 1 ? latchedFramebuf : framebuf;
+u32 sceDisplayGetFramebuf(u32 topaddrPtr, u32 linesizePtr, u32 pixelFormatPtr, int latchedMode) {
+	const FrameBufferState &fbState = latchedMode == 1 ? latchedFramebuf : framebuf;
 	DEBUG_LOG(HLE,"sceDisplayGetFramebuf(*%08x = %08x, *%08x = %08x, *%08x = %08x, %i)", topaddrPtr, fbState.topaddr, linesizePtr, fbState.pspFramebufLinesize, pixelFormatPtr, fbState.pspFramebufFormat, mode);
 
 	if (Memory::IsValidAddress(topaddrPtr))
@@ -602,9 +602,9 @@ u32 sceDisplayGetAccumulatedHcount() {
 }
 
 float sceDisplayGetFramePerSec() {
-	float fps = 59.9400599f;
-	DEBUG_LOG(HLE,"%f=sceDisplayGetFramePerSec()", fps);
-	return fps;	// (9MHz * 1)/(525 * 286)
+	const static float framePerSec = 59.9400599f;
+	DEBUG_LOG(HLE,"%f=sceDisplayGetFramePerSec()", framePerSec);
+	return framePerSec;	// (9MHz * 1)/(525 * 286)
 }
 
 u32 sceDisplayIsForeground() {

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -431,6 +431,8 @@ SubIntrHandler *__RegisterSubIntrHandler(u32 intrNumber, u32 subIntrNumber, u32 
 
 int __ReleaseSubIntrHandler(int intrNumber, int subIntrNumber)
 {
+	if (intrNumber >= PSP_NUMBER_INTERRUPTS)
+		return -1;
 	if (!intrHandlers[intrNumber]->has(subIntrNumber))
 		return -1;
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -651,8 +651,12 @@ private:
 		int size = cur->end - cur->first;
 		if (size >= cur->capacity - 2)
 		{
-			cur->capacity *= 2;
-			cur->data = (SceUID *)realloc(cur->data, cur->capacity * sizeof(SceUID));
+			SceUID *new_data = (SceUID *)realloc(cur->data, cur->capacity * sizeof(SceUID));
+			if (new_data != NULL)
+			{
+				cur->capacity *= 2;
+				cur->data = new_data;
+			}
 		}
 
 		int newFirst = (cur->capacity - size) / 2;
@@ -2735,14 +2739,14 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 		hleCurrentThreadName = target->nt.name;
 		__KernelChangeReadyState(target, currentThread, false);
 		target->nt.status = (target->nt.status | THREADSTATUS_RUNNING) & ~THREADSTATUS_READY;
+
+		__KernelLoadContext(&target->context, (target->nt.attr & PSP_THREAD_ATTR_VFPU) != 0);
 	}
 	else
 	{
 		currentThread = 0;
 		hleCurrentThreadName = NULL;
 	}
-
-	__KernelLoadContext(&target->context, (target->nt.attr & PSP_THREAD_ATTR_VFPU) != 0);
 
 	bool fromIdle = oldUID == threadIdleID[0] || oldUID == threadIdleID[1];
 	bool toIdle = currentThread == threadIdleID[0] || currentThread == threadIdleID[1];

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -23,7 +23,7 @@ static const int modeBpp[4] = { 2, 2, 2, 4 };
 
 void MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMode)
 {
-	if (videoPixelMode > (int)(sizeof(modeBpp) / sizeof(modeBpp[0])) || videoPixelMode < 0)
+	if (videoPixelMode >= (int)(sizeof(modeBpp) / sizeof(modeBpp[0])) || videoPixelMode < 0)
 	{
 		ERROR_LOG(ME, "Unexpected videoPixelMode %d, using 0 instead.", videoPixelMode);
 		videoPixelMode = 0;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -47,7 +47,7 @@ void VagDecoder::DecodeBlock(u8 *&readp) {
 	int predict_nr = *readp++;
 	int shift_factor = predict_nr & 0xf;
 	predict_nr >>= 4;
-	if (predict_nr >= sizeof(f) / sizeof(s8)) {
+	if (predict_nr >= sizeof(f) / sizeof(f[0])) {
 		predict_nr = 0;
 	}
 	int flags = *readp++;
@@ -311,7 +311,7 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 				break;
 			case VOICETYPE_PCM:
 				{
-					int size = std::min(voice.pcmSize, (int)(numSamples * sizeof(s16)));
+					u32 size = std::min(voice.pcmSize, (int)(numSamples * sizeof(s16)));
 					Memory::Memcpy(resampleBuffer + 2, voice.pcmAddr, size);
 					if (numSamples * sizeof(s16) > size)
 						memset(resampleBuffer + 2 + voice.pcmSize, 0, numSamples * sizeof(s16) - size);

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -243,7 +243,8 @@ namespace Reporting
 		Payload &payload = payloadBuffer[pos];
 
 		std::string gpuPrimary, gpuFull;
-		gpu->GetReportingInfo(gpuPrimary, gpuFull);
+		if (gpu)
+			gpu->GetReportingInfo(gpuPrimary, gpuFull);
 
 		UrlEncoder postdata;
 		postdata.Add("version", PPSSPP_GIT_VERSION);

--- a/ext/zlib/zlib.vcxproj
+++ b/ext/zlib/zlib.vcxproj
@@ -141,7 +141,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FloatingPointModel>Fast</FloatingPointModel>


### PR DESCRIPTION
And a small crash fix.

But I still can't figure out what is causing this for Headless:

Core.lib(bprint.o) : warning LNK4049: locally defined symbol _avpriv_vsnprintf imported

It's set up the same as PPSSPPWindows and Unittest, which both work fine...

-[Unknown]
