### PR TITLE
Improve audio blocking and some sceAudio functions

### DIFF
--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -276,6 +276,11 @@ template<u32 func(u32, int, int)> void WrapU_UII() {
 	RETURN(retval);
 }
 
+template<u32 func(u32, int, int, u32)> void WrapU_UIIU() {
+	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+	RETURN(retval);
+}
+
 template<int func(u32, int, int, u32, u32)> void WrapI_UIIUU() {
 	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
 	RETURN(retval);

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -49,7 +49,7 @@ const int hostAttemptBlockSize = 512;
 const int audioIntervalUs = (int)(1000000ULL * hwBlockSize / hwSampleRate);
 const int audioHostIntervalUs = (int)(1000000ULL * hostAttemptBlockSize / hwSampleRate);
 
-// High and low watermarks, basically.
+// High and low watermarks, basically.  For perfect emulation, the correct values are 0 and 1, respectively.
 // TODO: Tweak
 #ifdef ANDROID
 	const int chanQueueMaxSizeFactor = 4;
@@ -122,24 +122,38 @@ void __AudioShutdown()
 
 u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking)
 {
-	u32 ret = 0;
-	if (chan.sampleAddress == 0)
-		return SCE_ERROR_AUDIO_NOT_OUTPUT;
-	if (chan.sampleQueue.size() > chan.sampleCount*2*chanQueueMaxSizeFactor) {
-		// Block!
-		if (blocking) {
-			chan.waitingThread = __KernelGetCurThread();
-			// WARNING: This changes currentThread so must grab waitingThread before (line above).
-			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum, 0, 0, false, "blocking audio waited");
-			// Fall through to the sample queueing, don't want to lose the samples even though
-			// we're getting full.
+	u32 ret = chan.sampleCount;
+
+	if (chan.sampleAddress == 0) {
+		// For some reason, multichannel audio lies and returns the sample count here.
+		if (chanNum == PSP_AUDIO_CHANNEL_SRC || chanNum == PSP_AUDIO_CHANNEL_OUTPUT2) {
+			ret = 0;
 		}
-		else
-		{
-			chan.waitingThread = 0;
+	}
+
+	// If there's anything on the queue at all, it should be busy, but we try to be a bit lax.
+	if (chan.sampleQueue.size() > chan.sampleCount * 2 * chanQueueMaxSizeFactor || chan.sampleAddress == 0) {
+		if (blocking) {
+			// TODO: Regular multichannel audio seems to block for 64 samples less?  Or enqueue the first 64 sync?
+			int blockSamples = chan.sampleQueue.size() / 2 / chanQueueMinSizeFactor;
+
+			AudioChannelWaitInfo waitInfo = {__KernelGetCurThread(), blockSamples};
+			chan.waitingThreads.push_back(waitInfo);
+			// Also remember the value to return in the waitValue.
+			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum + 1, ret, 0, false, "blocking audio waited");
+
+			// Fall through to the sample queueing, don't want to lose the samples even though
+			// we're getting full.  The PSP would enqueue after blocking.
+		} else {
+			// Non-blocking doesn't even enqueue, but it's not commonly used.
 			return SCE_ERROR_AUDIO_CHANNEL_BUSY;
 		}
 	}
+
+	if (chan.sampleAddress == 0) {
+		return ret;
+	}
+
 	if (chan.format == PSP_AUDIO_FORMAT_STEREO)
 	{
 		const u32 totalSamples = chan.sampleCount * 2;
@@ -160,8 +174,6 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking)
 			for (u32 i = 0; i < totalSamples; i++)
 				chan.sampleQueue.push((s16)Memory::Read_U16(chan.sampleAddress + sizeof(s16) * i));
 		}
-
-		ret = chan.sampleCount;
 	}
 	else if (chan.format == PSP_AUDIO_FORMAT_MONO)
 	{
@@ -172,8 +184,6 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking)
 			chan.sampleQueue.push(sample);
 			chan.sampleQueue.push(sample);
 		}
-
-		ret = chan.sampleCount;
 	}
 	return ret;
 }
@@ -184,6 +194,31 @@ static inline s16 clamp_s16(int i) {
 	if (i < -32768)
 		return -32768;
 	return i;
+}
+
+inline void __AudioWakeThreads(AudioChannel &chan, int step)
+{
+	u32 error;
+	for (size_t w = 0; w < chan.waitingThreads.size(); ++w)
+	{
+		AudioChannelWaitInfo &waitInfo = chan.waitingThreads[w];
+		waitInfo.numSamples -= hwBlockSize;
+
+		// If it's done (there will still be samples on queue) and actually still waiting, wake it up.
+		if (waitInfo.numSamples <= 0 && __KernelGetWaitID(waitInfo.threadID, WAITTYPE_AUDIOCHANNEL, error) != 0)
+		{
+			// DEBUG_LOG(HLE, "Woke thread %i for some buffer filling", waitingThread);
+			u32 ret = __KernelGetWaitValue(waitInfo.threadID, error);
+			__KernelResumeThreadFromWait(waitInfo.threadID, ret);
+
+			chan.waitingThreads.erase(chan.waitingThreads.begin() + w--);
+		}
+	}
+}
+
+void __AudioWakeThreads(AudioChannel &chan)
+{
+	__AudioWakeThreads(chan, 0x7FFFFFFF);
 }
 
 // Mix samples from the various audio channels into a single sample queue.
@@ -202,6 +237,8 @@ void __AudioUpdate()
 	{
 		if (!chans[i].reserved)
 			continue;
+		__AudioWakeThreads(chans[i], hwBlockSize);
+
 		if (!chans[i].sampleQueue.size()) {
 			// ERROR_LOG(HLE, "No queued samples, skipping channel %i", i);
 			continue;
@@ -221,17 +258,6 @@ void __AudioUpdate()
 			{
 				ERROR_LOG(HLE, "Channel %i buffer underrun at %i of %i", i, s, hwBlockSize);
 				break;
-			}
-		}
-
-		if (chans[i].sampleQueue.size() < chans[i].sampleCount * 2 * chanQueueMinSizeFactor)
-		{
-			// Ask the thread to send more samples until next time, queue is being drained.
-			if (chans[i].waitingThread) {
-				SceUID waitingThread = chans[i].waitingThread;
-				chans[i].waitingThread = 0;
-				// DEBUG_LOG(HLE, "Woke thread %i for some buffer filling", waitingThread);
-				__KernelResumeThreadFromWait(waitingThread, chans[i].sampleCount);
 			}
 		}
 	}

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -29,5 +29,7 @@ void __AudioSetOutputFrequency(int freq);
 
 // May return SCE_ERROR_AUDIO_CHANNEL_BUSY if buffer too large
 u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);
+void __AudioWakeThreads(AudioChannel &chan, int step);
+void __AudioWakeThreads(AudioChannel &chan);
 
 int __AudioMix(short *outstereo, int numSamples);

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -230,11 +230,14 @@ u32 sceAudioChRelease(u32 chan) {
 
 u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
-		ERROR_LOG(HLE,"sceAudioSetChannelDataLen(%08x, %08x) - bad channel", chan, len);
+		ERROR_LOG(HLE, "sceAudioSetChannelDataLen(%08x, %08x) - bad channel", chan, len);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
 	} else if (!chans[chan].reserved)	{
-		ERROR_LOG(HLE,"sceAudioSetChannelDataLen(%08x, %08x) - channel not reserved", chan, len);
-		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
+		ERROR_LOG(HLE, "sceAudioSetChannelDataLen(%08x, %08x) - channel not reserved", chan, len);
+		return SCE_ERROR_AUDIO_CHANNEL_NOT_INIT;
+	} else if ((len & 63) != 0 || len == 0 || len > PSP_AUDIO_SAMPLE_MAX) {
+		ERROR_LOG(HLE, "sceAudioSetChannelDataLen(%08x, %08x) - invalid sample count", chan, len);
+		return SCE_ERROR_AUDIO_OUTPUT_SAMPLE_DATA_SIZE_NOT_ALIGNED;
 	} else {
 		DEBUG_LOG(HLE, "sceAudioSetChannelDataLen(%08x, %08x)", chan, len);
 		chans[chan].sampleCount = len;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -52,7 +52,7 @@ AudioChannel chans[PSP_AUDIO_CHANNEL_MAX + 1];
 // Not sure about the range of volume, I often see 0x800 so that might be either
 // max or 50%?
 
-u32 sceAudioOutputBlocking(u32 chan, u32 vol, u32 samplePtr) {
+u32 sceAudioOutputBlocking(u32 chan, int vol, u32 samplePtr) {
 	if (vol > 0xFFFF) {
 		ERROR_LOG(HLE, "sceAudioOutputBlocking() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -67,14 +67,16 @@ u32 sceAudioOutputBlocking(u32 chan, u32 vol, u32 samplePtr) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
 		DEBUG_LOG(HLE, "sceAudioOutputBlocking(%08x, %08x, %08x)", chan, vol, samplePtr);
-		chans[chan].leftVolume = vol;
-		chans[chan].rightVolume = vol;
+		if (vol >= 0) {
+			chans[chan].leftVolume = vol;
+			chans[chan].rightVolume = vol;
+		}
 		chans[chan].sampleAddress = samplePtr;
 		return __AudioEnqueue(chans[chan], chan, true);
 	}
 }
 
-u32 sceAudioOutputPannedBlocking(u32 chan, u32 leftvol, u32 rightvol, u32 samplePtr) {
+u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
 	if (leftvol > 0xFFFF || rightvol > 0xFFFF) {
 		ERROR_LOG(HLE, "sceAudioOutputPannedBlocking() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -89,14 +91,18 @@ u32 sceAudioOutputPannedBlocking(u32 chan, u32 leftvol, u32 rightvol, u32 sample
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
 		DEBUG_LOG(HLE, "sceAudioOutputPannedBlocking(%08x, %08x, %08x, %08x)", chan, leftvol, rightvol, samplePtr);
-		chans[chan].leftVolume = leftvol;
-		chans[chan].rightVolume = rightvol;
+		if (leftvol >= 0) {
+			chans[chan].leftVolume = leftvol;
+		}
+		if (rightvol >= 0) {
+			chans[chan].rightVolume = rightvol;
+		}
 		chans[chan].sampleAddress = samplePtr;
 		return __AudioEnqueue(chans[chan], chan, true);
 	}
 }
 
-u32 sceAudioOutput(u32 chan, u32 vol, u32 samplePtr) {
+u32 sceAudioOutput(u32 chan, int vol, u32 samplePtr) {
 	if (vol > 0xFFFF) {
 		ERROR_LOG(HLE, "sceAudioOutput() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -111,14 +117,16 @@ u32 sceAudioOutput(u32 chan, u32 vol, u32 samplePtr) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
 		DEBUG_LOG(HLE, "sceAudioOutputPanned(%08x, %08x, %08x)", chan, vol, samplePtr);
-		chans[chan].leftVolume = vol;
-		chans[chan].rightVolume = vol;
+		if (vol >= 0) {
+			chans[chan].leftVolume = vol;
+			chans[chan].rightVolume = vol;
+		}
 		chans[chan].sampleAddress = samplePtr;
 		return __AudioEnqueue(chans[chan], chan, false);
 	}
 }
 
-u32 sceAudioOutputPanned(u32 chan, u32 leftvol, u32 rightvol, u32 samplePtr) {
+u32 sceAudioOutputPanned(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
 	if (leftvol > 0xFFFF || rightvol > 0xFFFF) {
 		ERROR_LOG(HLE, "sceAudioOutputPannedBlocking() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -133,8 +141,12 @@ u32 sceAudioOutputPanned(u32 chan, u32 leftvol, u32 rightvol, u32 samplePtr) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
 		DEBUG_LOG(HLE,"sceAudioOutputPanned(%08x, %08x, %08x, %08x)", chan, leftvol, rightvol, samplePtr);
-		chans[chan].leftVolume = leftvol;
-		chans[chan].rightVolume = rightvol;
+		if (leftvol >= 0) {
+			chans[chan].leftVolume = leftvol;
+		}
+		if (rightvol >= 0) {
+			chans[chan].rightVolume = rightvol;
+		}
 		chans[chan].sampleAddress = samplePtr;
 		return __AudioEnqueue(chans[chan], chan, false);
 	}
@@ -166,10 +178,10 @@ static u32 GetFreeChannel() {
 	return -1;
 }
 
-u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
-	if ((int)chan < 0) {
+u32 sceAudioChReserve(int chan, u32 sampleCount, u32 format) {
+	if (chan < 0) {
 		chan = GetFreeChannel();
-		if ((int)chan < 0) {
+		if (chan < 0) {
 			ERROR_LOG(HLE, "sceAudioChReserve - no channels remaining");
 			return SCE_ERROR_AUDIO_NO_CHANNELS_AVAILABLE;
 		}
@@ -195,6 +207,8 @@ u32 sceAudioChReserve(u32 chan, u32 sampleCount, u32 format) {
 	chans[chan].sampleCount = sampleCount;
 	chans[chan].format = format;
 	chans[chan].reserved = true;
+	chans[chan].leftVolume = 0;
+	chans[chan].rightVolume = 0;
 	return chan;
 }
 
@@ -396,21 +410,21 @@ const HLEFunction sceAudio[] =
 	{0x01562ba3, WrapU_U<sceAudioOutput2Reserve>, "sceAudioOutput2Reserve"},
 	{0x2d53f36e, WrapU_UU<sceAudioOutput2OutputBlocking>, "sceAudioOutput2OutputBlocking"},
 	{0x63f2889c, WrapU_U<sceAudioOutput2ChangeLength>, "sceAudioOutput2ChangeLength"},
-	{0x647cef33, WrapU_V<sceAudioOutput2GetRestSample>, "sceAudioOutput2GetRestSample"},	
+	{0x647cef33, WrapU_V<sceAudioOutput2GetRestSample>, "sceAudioOutput2GetRestSample"},
 	{0x43196845, WrapU_V<sceAudioOutput2Release>, "sceAudioOutput2Release"},
 	{0x80F1F7E0, WrapU_V<sceAudioInit>, "sceAudioInit"},
 	{0x210567F7, WrapU_V<sceAudioEnd>, "sceAudioEnd"},
 	{0xA2BEAA6C, WrapU_U<sceAudioSetFrequency>, "sceAudioSetFrequency"},
 	{0x927AC32B, WrapU_V<sceAudioSetVolumeOffset>, "sceAudioSetVolumeOffset"},
-	{0x8c1009b2, WrapU_UUU<sceAudioOutput>, "sceAudioOutput"},
-	{0x136CAF51, WrapU_UUU<sceAudioOutputBlocking>, "sceAudioOutputBlocking"},
-	{0xE2D56B2D, WrapU_UUUU<sceAudioOutputPanned>, "sceAudioOutputPanned"},
-	{0x13F592BC, WrapU_UUUU<sceAudioOutputPannedBlocking>, "sceAudioOutputPannedBlocking"}, 
-	{0x5EC81C55, WrapU_UUU<sceAudioChReserve>, "sceAudioChReserve"}, 
-	{0x6FC46853, WrapU_U<sceAudioChRelease>, "sceAudioChRelease"}, 
+	{0x8c1009b2, WrapU_UIU<sceAudioOutput>, "sceAudioOutput"},
+	{0x136CAF51, WrapU_UIU<sceAudioOutputBlocking>, "sceAudioOutputBlocking"},
+	{0xE2D56B2D, WrapU_UIIU<sceAudioOutputPanned>, "sceAudioOutputPanned"},
+	{0x13F592BC, WrapU_UIIU<sceAudioOutputPannedBlocking>, "sceAudioOutputPannedBlocking"},
+	{0x5EC81C55, WrapU_IUU<sceAudioChReserve>, "sceAudioChReserve"},
+	{0x6FC46853, WrapU_U<sceAudioChRelease>, "sceAudioChRelease"},
 	{0xE9D97901, WrapI_U<sceAudioGetChannelRestLen>, "sceAudioGetChannelRestLen"},
-	{0xB011922F, WrapI_U<sceAudioGetChannelRestLen>, "sceAudioGetChannelRestLength"},	
-	{0xCB2E439E, WrapU_UU<sceAudioSetChannelDataLen>, "sceAudioSetChannelDataLen"}, 
+	{0xB011922F, WrapI_U<sceAudioGetChannelRestLen>, "sceAudioGetChannelRestLength"},
+	{0xCB2E439E, WrapU_UU<sceAudioSetChannelDataLen>, "sceAudioSetChannelDataLen"},
 	{0x95FD0C2D, WrapU_UU<sceAudioChangeChannelConfig>, "sceAudioChangeChannelConfig"},
 	{0xB7E1D8E7, WrapU_UUU<sceAudioChangeChannelVolume>, "sceAudioChangeChannelVolume"},
 	{0x38553111, WrapU_UUU<sceAudioSRCChReserve>, "sceAudioSRCChReserve"},

--- a/Core/HLE/sceAudio.h
+++ b/Core/HLE/sceAudio.h
@@ -47,6 +47,12 @@ const int PSP_AUDIO_CHANNEL_MAX = 8;
 const int PSP_AUDIO_CHANNEL_SRC = 8;
 const int PSP_AUDIO_CHANNEL_OUTPUT2 = 8;
 
+struct AudioChannelWaitInfo
+{
+	SceUID threadID;
+	int numSamples;
+};
+
 struct AudioChannel
 {
 	AudioChannel() {
@@ -64,7 +70,7 @@ struct AudioChannel
 	u32 rightVolume;
 	u32 format;
 
-	SceUID waitingThread;
+	std::vector<AudioChannelWaitInfo> waitingThreads;
 
 	// PC side - should probably split out
 
@@ -74,16 +80,7 @@ struct AudioChannel
 
 	void DoState(PointerWrap &p);
 
-	void clear() {
-		reserved = false;
-		waitingThread = 0;
-		leftVolume = 0;
-		rightVolume = 0;
-		format = 0;
-		sampleAddress = 0;
-		sampleCount = 0;
-		sampleQueue.clear();
-	}
+	void clear();
 };
 
 // The extra channel is for SRC/Output2.

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -786,12 +786,12 @@ int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 
 int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer) 
 {
-	ERROR_LOG(HLE, "scePsmfPlayerGetCurrentStatus(%08x)", psmfPlayer);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
-		ERROR_LOG(HLE, "scePsmfPlayerUpdate - invalid psmf");
+		ERROR_LOG(HLE, "scePsmfPlayerGetCurrentStatus(%08x) - invalid psmf", psmfPlayer);
 		return ERROR_PSMF_NOT_FOUND;
 	}
+	ERROR_LOG(HLE, "%d=scePsmfPlayerGetCurrentStatus(%08x)", psmfplayer->status, psmfPlayer);
 	return psmfplayer->status;
 }
 


### PR DESCRIPTION
This makes a few changes, mainly:
- NULL sample pointers now correctly block until queue drains.
- Blocking is done based on current buffer size, not the enqueued buffer.
- Multiple threads can wait on a channel at the same time.  It's not heavily tested, but one would hope games aren't doing something that silly anyway...
- Negative volume for multichannel audio means "don't change."
- Releasing a channel now unblocks waiting threads (not carefully tested but seems right.)

On my mobile, audio was just as awful with and without these changes.  I'm hoping it may improve some games that depend especially on the NULL blocking or volume, which probably aren't many.

-[Unknown]
