### PR TITLE
Remove an useless command in audioPlayer.

### DIFF
--- a/Core/HW/audioPlayer.cpp
+++ b/Core/HW/audioPlayer.cpp
@@ -517,7 +517,6 @@ void shutdownEngine()
 	audioMap.clear();
 	atracsection.unlock();
 	CoUninitialize();
-	system("cleanAudios.bat");
 }
 
 #endif // _USE_DSHOW_


### PR DESCRIPTION
I forgot to check about it. This command should be removed.
