### PR TITLE
Enable frameskip when fps limit is at turbo

### DIFF
--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -183,6 +183,7 @@ int main(int argc, const char* argv[])
 	coreParameter.pixelWidth = 480;
 	coreParameter.pixelHeight = 272;
 	coreParameter.useMediaEngine = false;
+	coreParameter.unthrottle = true;
 
 	g_Config.bEnableSound = false;
 	g_Config.bFirstRun = false;


### PR DESCRIPTION
This simplifies a bit.

The reason custom fps doesn't work on Android when > 60 is because it doesn't enable frameskip automatically.  I didn't fix that, but at least turbo mode can easily.

-[Unknown]
