### PR TITLE
Fix to make Pangya Fantasy Golf boot

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1530,6 +1530,17 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		}
 		break;
 
+	//Unknown command, always expects return value of 1 according to JPCSP, used by Pangya Fantasy Golf.
+	case 0x1f30003:
+		INFO_LOG(HLE, "sceIoioCtl: Unknown cmd %08x always returns 1", cmd);
+		if(inlen != 4 || outlen != 1 || Memory::Read_U32(indataPtr) != outlen) {
+			INFO_LOG(HLE, "sceIoIoCtl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outlen %08x has invalid parameters", id, cmd, indataPtr, inlen, outdataPtr, outlen);
+			return SCE_KERNEL_ERROR_INVALID_ARGUMENT;
+		}
+		else {
+			return 1;
+		}
+
 	default:
 		{
 			char temp[256];


### PR DESCRIPTION
The game won't show anything past the developer logos, but it plays music on the title screen, so it's not crashed, just failing to show any graphics.
