### PR TITLE
Fix sceAudio shutdown and bogus priority errors

### DIFF
--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -40,6 +40,12 @@ void AudioChannel::DoState(PointerWrap &p)
 	p.DoMarker("AudioChannel");
 }
 
+void AudioChannel::reset()
+{
+	__AudioWakeThreads(*this);
+	clear();
+}
+
 void AudioChannel::clear()
 {
 	reserved = false;
@@ -49,8 +55,7 @@ void AudioChannel::clear()
 	sampleAddress = 0;
 	sampleCount = 0;
 	sampleQueue.clear();
-
-	__AudioWakeThreads(*this);
+	waitingThreads.clear();
 }
 
 // There's a second Audio api called Audio2 that only has one channel, I guess the 8 channel api was overkill.
@@ -224,7 +229,7 @@ u32 sceAudioChRelease(u32 chan) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
 	DEBUG_LOG(HLE, "sceAudioChRelease(%i)", chan);
-	chans[chan].clear();
+	chans[chan].reset();
 	chans[chan].reserved = false;
 	return 1;
 }
@@ -340,7 +345,7 @@ u32 sceAudioOutput2GetRestSample(){
 
 u32 sceAudioOutput2Release(){
 	DEBUG_LOG(HLE,"sceAudioOutput2Release()");
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].clear();
+	chans[PSP_AUDIO_CHANNEL_OUTPUT2].reset();
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved = false;
 	return 0;
 }
@@ -390,7 +395,7 @@ u32 sceAudioSRCChRelease() {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
 	DEBUG_LOG(HLE, "sceAudioSRCChRelease()");
-	chans[PSP_AUDIO_CHANNEL_SRC].clear();
+	chans[PSP_AUDIO_CHANNEL_SRC].reset();
 	chans[PSP_AUDIO_CHANNEL_SRC].reserved = false;
 	return 0;
 }

--- a/Core/HLE/sceAudio.h
+++ b/Core/HLE/sceAudio.h
@@ -81,6 +81,7 @@ struct AudioChannel
 
 	void DoState(PointerWrap &p);
 
+	void reset();
 	void clear();
 };
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -878,9 +878,13 @@ void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValu
 	if (optionAddr) {
 		SceKernelSMOption smoption;
 		Memory::ReadStruct(optionAddr, &smoption);;
-		priority = smoption.priority;
+		if (smoption.priority != 0) {
+			priority = smoption.priority;
+		}
 		attr = smoption.attribute;
-		stacksize = smoption.stacksize;
+		if (smoption.stacksize != 0) {
+			stacksize = smoption.stacksize;
+		}
 		stackPartition = smoption.mpidstack;
 	}
 	u32 error;
@@ -900,9 +904,13 @@ void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValu
 			// TODO: Do these always take effect, or do they not override optionAddr?
 			if (module->nm.module_start_func != 0 && module->nm.module_start_func != (u32)-1) {
 				entryAddr = module->nm.module_start_func;
-				priority = module->nm.module_start_thread_priority;
+				if (module->nm.module_start_thread_priority != 0) {
+					priority = module->nm.module_start_thread_priority;
+				}
 				attr = module->nm.module_start_thread_attr;
-				stacksize = module->nm.module_start_thread_stacksize;
+				if (module->nm.module_start_thread_stacksize != 0) {
+					stacksize = module->nm.module_start_thread_stacksize;
+				}
 			} else {
 				// TODO: Fix, check return value?  Or do we call nothing?
 				RETURN(moduleId);

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -61,6 +61,7 @@ u32 sceVaudioChRelease() {
 	if (!chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
+		chans[PSP_AUDIO_CHANNEL_VAUDIO].reset();
 		chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved = false;
 		vaudioReserved = false;
 		return 0;


### PR DESCRIPTION
Stupid goof, trying to wake threads that aren't there anymore, heh.

Also pretty sure 0s should be ignored in these values (at least, JPCSP seems to, and I'm relatively sure that's where the invalid priorities are coming from in logs.)

Edit: sorry for all the scattershot.

-[Unknown]
