### PR TITLE
Improve sceKernelStartModule handling

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -902,11 +902,11 @@ void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValu
 			int priority = 0x20;
 			int stackSize = 0x40000;
 
-            if ((optionAddr) && (smoption.stacksize > 0)) {
-                stackSize = smoption.stacksize;
-            } else if (module->nm.module_start_thread_stacksize > 0) {
-                stackSize = module->nm.module_start_thread_stacksize;
-            }
+            		if ((optionAddr) && (smoption.stacksize > 0)) {
+                		stackSize = smoption.stacksize;
+            		} else if (module->nm.module_start_thread_stacksize > 0) {
+                		stackSize = module->nm.module_start_thread_stacksize;
+            		}
 
 			if (optionAddr)
 			{


### PR DESCRIPTION
Fixes 'bogus priority' errors (and maybe more).
Tested on God Eater Burst and fixed its "bogus priority".
I haven't found any games this breaks.
