### PR TITLE
Process variable imports

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -160,6 +160,7 @@ void __KernelShutdown()
 	__KernelThreadingShutdown();
 	__KernelMemoryShutdown();
 	__InterruptsShutdown();
+	__KernelModuleShutdown();
 
 	CoreTiming::ClearPendingEvents();
 	CoreTiming::UnregisterAllEvents();

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -22,6 +22,7 @@
 
 KernelObject *__KernelModuleObject();
 void __KernelModuleDoState(PointerWrap &p);
+void __KernelModuleShutdown();
 
 u32 __KernelGetModuleGP(SceUID module);
 bool __KernelLoadExec(const char *filename, SceKernelLoadExecParam *param, std::string *error_string);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1423,7 +1423,9 @@ const HLEFunction sceMpeg[] =
 	{0x01977054,WrapI_UUUU<sceMpegGetUserdataAu>,"sceMpegGetUserdataAu"},
 	{0x3c37a7a6,0,"sceMpegNextAvcRpAu"},
 	{0x11f95cf1,0,"sceMpegGetAvcNalAu"},
+	{0xab0e9556,0,"sceMpegAvcDecodeDetailIndex"},
 	{0xcf3547a2,0,"sceMpegAvcDecodeDetail2"},
+	{0x921fcccf,0,"sceMpegGetAvcEsAu"},
 };
 
 void Register_sceMpeg()


### PR DESCRIPTION
Tested with the demo of God Eater Burst (finally realized there was a demo.)

Lots of help from MIPS ABI docs and Linux MIPS code.  Also checked JPCSP, but its code looks very questionable in this area (it seems to compare R_MIPS_32 to MIPS cpu opcodes??)  Anyway, tried to leave generous comments where needed.

This fixes the memory access warnings in God Eater Burst's demo, and I hope it will improve Tales of the World: Radiant Mythology 2 (and 3?)  I didn't go past the relocation failure in the God Eater Burst demo before, but it seems to run correctly.

Also slipped in some more syscalls + some reporting changes to import/exports.

-[Unknown]
