### PR TITLE
Save XMM regs as required by the Windows x64 ABI

### DIFF
--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -477,22 +477,33 @@ unsigned int XEmitter::ABI_GetAlignedFrameSize(unsigned int frameSize) {
 
 #ifdef _WIN32
 
+// The Windows x64 ABI requires XMM6 - XMM15 to be callee saved.  10 regs.
+const int XMM_STACK_SPACE = 10 * 16;
+
 // Win64 Specific Code
 void XEmitter::ABI_PushAllCalleeSavedRegsAndAdjustStack() {
 	//we only want to do this once
-	PUSH(RBX); 
-	PUSH(RSI); 
+	PUSH(RBX);
+	PUSH(RSI);
 	PUSH(RDI);
 	PUSH(RBP);
-	PUSH(R12); 
-	PUSH(R13); 
-	PUSH(R14); 
+	PUSH(R12);
+	PUSH(R13);
+	PUSH(R14);
 	PUSH(R15);
-	//TODO: Also preserve XMM0-3?
 	ABI_AlignStack(0);
+
+	// Do this after aligning, beacuse before it's offset by 8.
+	SUB(64, R(RSP), Imm32(XMM_STACK_SPACE));
+	for (int i = 0; i < 10; ++i)
+		MOVAPS(MDisp(RSP, i * 16), (X64Reg)(XMM6 + i));
 }
 
 void XEmitter::ABI_PopAllCalleeSavedRegsAndAdjustStack() {
+	for (int i = 0; i < 10; ++i)
+		MOVAPS((X64Reg)(XMM6 + i), MDisp(RSP, i * 16));
+	ADD(64, R(RSP), Imm32(XMM_STACK_SPACE));
+
 	ABI_RestoreStack(0);
 	POP(R15);
 	POP(R14); 
@@ -514,7 +525,7 @@ void XEmitter::ABI_PushAllCallerSavedRegsAndAdjustStack() {
 	PUSH(R9);
 	PUSH(R10);
 	PUSH(R11);
-	//TODO: Also preserve XMM0-15?
+	// Callers preserve XMM4-5 (XMM0-3 are args.)  But we don't need them usually.
 	ABI_AlignStack(0);
 }
 


### PR DESCRIPTION
Fixes jitter in analog in recent builds, possibly other bugs.  Doesn't seem like 32-bit requires saving any of these regs.

http://msdn.microsoft.com/en-us/library/9z1stfyw%28v=vs.80%29.aspx

-[Unknown]
