### PR TITLE
Improve CLUT load performance, tweak hashing

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -769,12 +769,11 @@ inline bool TextureCache::TexCacheEntry::Matches(u16 dim2, u32 hash2, u8 format2
 
 void TextureCache::LoadClut() {
 	u32 clutAddr = GetClutAddr();
-	u32 clutTotalBytes = (gstate.loadclut & 0x3f) * 32;
+	clutTotalBytes_ = (gstate.loadclut & 0x3f) * 32;
 	if (Memory::IsValidAddress(clutAddr)) {
-		Memory::Memcpy((u8 *)clutBuf_, clutAddr, clutTotalBytes);
-		clutHash_ = CityHash32((const char *)clutBuf_, clutTotalBytes);
+		Memory::Memcpy((u8 *)clutBuf_, clutAddr, clutTotalBytes_);
 	} else {
-		memset(clutBuf_, 0xFF, clutTotalBytes);
+		memset(clutBuf_, 0xFF, clutTotalBytes_);
 		clutHash_ = 0;
 	}
 	clutDirty_ = true;
@@ -838,6 +837,7 @@ void TextureCache::SetTexture() {
 	if (hasClut) {
 		if (clutDirty_) {
 			// We update here because the clut format can be specified after the load.
+			clutHash_ = CityHash32((const char *)clutBuf_, clutTotalBytes_);
 			UpdateCurrentClut();
 			clutDirty_ = false;
 		}

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -126,7 +126,9 @@ private:
 
 	SimpleBuf<u32> tmpTexBufRearrange;
 
-	bool clutDirty_;
+	u8 clutLastFormat_;
+	u32 *clutBufRaw_;
+	u32 *clutBufConverted_;
 	u32 *clutBuf_;
 	u32 clutHash_;
 	u32 clutTotalBytes_;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -96,7 +96,7 @@ private:
 		bool sClamp;
 		bool tClamp;
 
-		bool Matches(u16 dim2, u32 hash2, u8 format2, int maxLevel2);
+		bool Matches(u16 dim2, u8 format2, int maxLevel2);
 	};
 
 	void Decimate();  // Run this once per frame to get rid of old textures.

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -129,6 +129,7 @@ private:
 	bool clutDirty_;
 	u32 *clutBuf_;
 	u32 clutHash_;
+	u32 clutTotalBytes_;
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;


### PR DESCRIPTION
Loading the clut was expensive in some games, which were doing it in a row without any flush between (e.g. Disgaea 2.)  This makes that do less work, and simplifies the hash used (still works okay in the games that needed a more complex hash before.)

This also changes MiniHash slightly, so that it can still use the secondary cache.  Before it would fail and reload if the MiniHash failed.

I tried to change MiniHash to a sampling hash (tried ~127 samples), and use that in the cachekey for clut'd textures.  But that unfortunately did not help FF2 (which spends tons of time in SetTexture and friends due to animating the texture data.)

-[Unknown]
