### PR TITLE
Fix videos that never end

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -659,7 +659,11 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 
 	if (ctx->mediaengine->stepVideo()) {
 		ctx->mediaengine->writeVideoImage(buffer, frameWidth, ctx->videoPixelMode);
-		packetsConsumed += ctx->mediaengine->readLength() / ringbuffer.packetSize;
+		// TODO: The idea here is to consume packets based on actual decoded bytes.
+		// We don't actually decode anything (readLength is always 0), so hardcoded for now.
+		//packetsConsumed = ctx->mediaengine->readLength() / ringbuffer.packetSize;
+		if (packetsConsumed == 0)
+			packetsConsumed = std::min(packetsInRingBuffer, 4);
 
 		// The MediaEngine is already consuming all the remaining
 		// packets when approaching the end of the video. The PSP
@@ -840,7 +844,12 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 
 	if (ctx->mediaengine->stepVideo()) {
 		// TODO: Write it somewhere or buffer it or something?
-		packetsConsumed += ctx->mediaengine->readLength() / ringbuffer.packetSize;
+
+		// TODO: The idea here is to consume packets based on actual decoded bytes.
+		// We don't actually decode anything (readLength is always 0), so hardcoded for now.
+		//packetsConsumed = ctx->mediaengine->readLength() / ringbuffer.packetSize;
+		if (packetsConsumed == 0)
+			packetsConsumed = std::min(packetsInRingBuffer, 4);
 
 		// Consuming all the remaining packets?
 		if (ringbuffer.packetsFree + packetsConsumed >= ringbuffer.packets) {


### PR DESCRIPTION
JPCSP seems to use "readLength" to track how much the decoder has read of the video stream.  It translates this into packetsConsumed, basically, to tell the game how many packets were decoded/how many more it needs.

However, in our case, we don't populate that value (although we should when using ffmpeg, or we should do something similar.)  Because of this, when it was decremented (to indicate the game had been told about that much read), it actually became negative.

Because of this, we stopped consuming packets if the pts didn't increase.  Some games would stop calling GetAvcAu to wait for audio to catch up or w/e, and we would never consume packets, so it went into an infinite loop.

I went with a low number (4) for this case, but it should not affect games that were working before - at most it'll make the video a bit faster (it may fix subtitle timing I guess, not sure.)  I tested with several of the games that are "mpeg fragile" and they all worked.

This fixes Ys 6 which now goes in game with default options.

-[Unknown]
