### PR TITLE
Fix VAG looping, validate volumes in sceSas

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -23,6 +23,7 @@
 // JPCSP is, as it often is, a pretty good reference although I didn't actually use it much yet:
 // http://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/sceSasCore.java
 
+#include <cstdlib>
 #include "base/basictypes.h"
 #include "Log.h"
 #include "HLE.h"
@@ -62,10 +63,6 @@ void __SasShutdown() {
 	sas = 0;
 }
 
-
-inline static int absVolume(int vol) {
-	return vol > 0 ? vol : -vol;
-}
 
 u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampleRate) {
 	INFO_LOG(HLE,"sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
@@ -208,8 +205,8 @@ u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effec
 		WARN_LOG(HLE, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
 	}
-	bool overVolume = absVolume(leftVol) > PSP_SAS_VOL_MAX || absVolume(rightVol) > PSP_SAS_VOL_MAX;
-	overVolume = overVolume || absVolume(effectLeftVol) > PSP_SAS_VOL_MAX || absVolume(effectRightVol) > PSP_SAS_VOL_MAX;
+	bool overVolume = abs(leftVol) > PSP_SAS_VOL_MAX || abs(rightVol) > PSP_SAS_VOL_MAX;
+	overVolume = overVolume || abs(effectLeftVol) > PSP_SAS_VOL_MAX || abs(effectRightVol) > PSP_SAS_VOL_MAX;
 	if (overVolume)
 		return ERROR_SAS_INVALID_VOLUME;
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -76,7 +76,7 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 	for (int i = 0; i < sas->maxVoices; i++) {
 		sas->voices[i].sampleRate = sampleRate;
 		sas->voices[i].playing = false;
-		sas->voices[i].loop = true;  // inverted flag
+		sas->voices[i].loop = false;
 	}
 	return 0;
 }
@@ -140,7 +140,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 	v.type = VOICETYPE_VAG;
 	v.vagAddr = vagAddr;
 	v.vagSize = size;
-	v.loop = loop ? false : true;
+	v.loop = loop ? true : false;
 	v.ChangedParams(vagAddr == prevVagAddr);
 	return 0;
 }
@@ -170,7 +170,7 @@ u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loop)
 	v.pcmAddr = pcmAddr;
 	v.pcmSize = size;
 	v.pcmIndex = 0;
-	v.loop = loop ? false : true;
+	v.loop = loop ? true : false;
 	v.playing = true;
 	v.ChangedParams(pcmAddr == prevPcmAddr);
 	return 0;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -124,14 +124,14 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 		return ERROR_SAS_INVALID_VOICE;
 	}
 
-	if (!Memory::IsValidAddress(vagAddr)) {
-		ERROR_LOG(HLE, "Ignoring invalid VAG audio address %08x", vagAddr);
-		return 0;
-	}
-
 	if (size <= 0 || (size & 0xF) != 0) {
 		WARN_LOG(HLE, "%s: invalid size %d", __FUNCTION__, size);
 		return ERROR_SAS_INVALID_SIZE;
+	}
+
+	if (!Memory::IsValidAddress(vagAddr)) {
+		ERROR_LOG(HLE, "Ignoring invalid VAG audio address %08x", vagAddr);
+		return 0;
 	}
 
 	//Real VAG header is 0x30 bytes behind the vagAddr

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -38,6 +38,7 @@ enum {
 	ERROR_SAS_INVALID_ADSR_CURVE_MODE = 0x80420013,
 	ERROR_SAS_INVALID_PARAMETER = 0x80420014,
 	ERROR_SAS_VOICE_PAUSED = 0x80420016,
+	ERROR_SAS_INVALID_VOLUME = 0x80420018,
 	ERROR_SAS_INVALID_SIZE = 0x8042001A,
 	ERROR_SAS_BUSY = 0x80420030,
 	ERROR_SAS_NOT_INIT = 0x80420100,
@@ -61,6 +62,10 @@ void __SasShutdown() {
 	sas = 0;
 }
 
+
+inline static int absVolume(int vol) {
+	return vol > 0 ? vol : -vol;
+}
 
 u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampleRate) {
 	INFO_LOG(HLE,"sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
@@ -203,6 +208,10 @@ u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effec
 		WARN_LOG(HLE, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
 	}
+	bool overVolume = absVolume(leftVol) > PSP_SAS_VOL_MAX || absVolume(rightVol) > PSP_SAS_VOL_MAX;
+	overVolume = overVolume || absVolume(effectLeftVol) > PSP_SAS_VOL_MAX || absVolume(effectRightVol) > PSP_SAS_VOL_MAX;
+	if (overVolume)
+		return ERROR_SAS_INVALID_VOLUME;
 
 	SasVoice &v = sas->voices[voiceNum];
 	v.volumeLeft = leftVol;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -97,10 +97,12 @@ void VagDecoder::GetSamples(s16 *outSamples, int numSamples) {
 	for (int i = 0; i < numSamples; i++) {
 		if (curSample == 28) {
 			if (loopAtNextBlock_) {
-				read_ = data_ + 16 * loopStartBlock_;
+				// data_ starts at curBlock = -1.
+				read_ = data_ + 16 * loopStartBlock_ + 16;
 				readp = Memory::GetPointer(read_);
 				origp = readp;
 				curBlock_ = loopStartBlock_;
+				loopAtNextBlock_ = false;
 			}
 			DecodeBlock(readp);
 			if (end_) {


### PR DESCRIPTION
AFAICT, the loop flag is not inverted.  Let me know if I got it wrong?

This fixes the background music in VectorTD and the sound effects in Legend of Heroes games.  Other games seem to play sounds fine still.

(the volume validation isn't needed for this but just was while testing.)

-[Unknown]
