### PR TITLE
add sprx support (sceKernelLoadModuleNpDrm)

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1060,6 +1060,13 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 	return hleDelayResult(module->GetUID(), "module loaded", 500);
 }
 
+u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr)
+{
+	DEBUG_LOG(LOADER, "sceKernelLoadModuleNpDrm(%s, %08x)", name, flags);
+
+	return sceKernelLoadModule(name, flags, optionAddr);
+}
+
 void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
 {
 	u32 priority = 0x20;
@@ -1424,7 +1431,7 @@ const HLEFunction ModuleMgrForUser[] =
 	{0x8f2df740,WrapU_UUUUU<sceKernelStopUnloadSelfModuleWithStatus>,"sceKernelStopUnloadSelfModuleWithStatus"},
 	{0xfef27dc1,&WrapU_CU<sceKernelLoadModuleDNAS> , "sceKernelLoadModuleDNAS"},
 	{0x644395e2,0,"sceKernelGetModuleIdList"},
-	{0xf2d8d1b4,0,"ModuleMgrForUser_F2D8D1B4"},
+	{0xf2d8d1b4,&WrapU_CUU<sceKernelLoadModuleNpDrm>,"sceKernelLoadModuleNpDrm"},
 };
 
 

--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -43,18 +43,6 @@ int sceNpDrmOpen()
 	return 0;
 }
 
-int sceKernelLoadModuleNpDrm()
-{
-	ERROR_LOG(HLE, "UNIMPL sceKernelLoadModuleNpDrm");
-	return 0;
-}
-
-int sceKernelLoadExecNpDrm()
-{
-	ERROR_LOG(HLE, "UNIMPL sceKernelLoadExecNpDrm");
-	return 0;
-}
-
 const HLEFunction sceNpDrm[] =
 { 
 	{0xA1336091, WrapI_U<sceNpDrmSetLicenseeKey>, "sceNpDrmSetLicenseeKey"},
@@ -63,8 +51,6 @@ const HLEFunction sceNpDrm[] =
 	{0x08d98894, WrapI_U<sceNpDrmEdataSetupKey>, "sceNpDrmEdataSetupKey"},
 	{0x219EF5CC, WrapI_U<sceNpDrmEdataGetDataSize>, "sceNpDrmEdataGetDataSize"},
 	{0x2BAA4294, 0, "sceNpDrmOpen"},
-	{0xC618D0B1, 0, "sceKernelLoadModuleNpDrm"},
-	{0xAA5FC85B, 0, "sceKernelLoadExecNpDrm"},
 };
 
 void Register_sceNpDrm()


### PR DESCRIPTION
sprx must be decrypted on psp first. we dont have key used by sprx.
