### PR TITLE
Fix for string parsing

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -81,6 +81,7 @@ public:
 	int iFpsLimit;
 	int iMaxRecent;
 	bool bEnableCheats;
+	bool bReloadCheats;
 
 	// Sound
 	bool bEnableSound;

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -12,7 +12,7 @@
 void __CheatInit();
 void __CheatShutdown();
 
-std::vector<std::string> makeCodeParts(std::string l);
+std::vector<std::string> makeCodeParts();
 
 class CWCheatEngine {
 public:
@@ -20,14 +20,15 @@ public:
 	std::string String();
 	void AddCheatLine(std::string& line);
 	std::vector<std::string> GetCodesList();
-
+	void CreateCodeList();
 	void Exit();
 	void Run();
-	std::string GetNextCode();
+	std::vector<std::string> GetNextCode();
 
 private:
 	void SkipCodes(int count);
 	void SkipAllCodes();
+	
 	int GetAddress(int value);
 
 	static uint64_t const serialVersionUID = 6791588139795694296ULL;
@@ -37,4 +38,5 @@ private:
 	std::vector<std::string> codes;
 	int currentCode;
 	bool exit2;
+	std::vector<std::string> parts;
 };

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -949,7 +949,9 @@ void SystemScreen::render() {
 	if (UICheckBox(GEN_ID, x, y += stride, s->T("Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
 		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
 	}
-
+	if (UIButton(GEN_ID, Pos(x+300, y += stride * 3), LARGE_BUTTON_WIDTH, 0, s->T("Language"), ALIGN_BOTTOMLEFT)) {
+    screenManager()->push(new LanguageScreen());
+  } 
 	
 	UIEnd();
 }

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -940,16 +940,17 @@ void SystemScreen::render() {
 		g_Config.itimeformat = tf ? 1 : 0;
 	}
 	UICheckBox(GEN_ID, x, y += stride, s->T("Enable Cheats"), ALIGN_TOPLEFT, &g_Config.bEnableCheats);
-	
+	HLinear hlinear2(x, y+110, 20);
+	if (UIButton(GEN_ID, hlinear2, 210, 0, "Reload Cheats", ALIGN_TOPLEFT)) {
+		g_Config.bReloadCheats = true;
+	}
 	bool reportingEnabled = Reporting::IsEnabled();
 	const static std::string reportHostOfficial = "report.ppsspp.org";
 	if (UICheckBox(GEN_ID, x, y += stride, s->T("Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
 		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
 	}
 
-	if (UIButton(GEN_ID, Pos(x, y += stride * 3), LARGE_BUTTON_WIDTH, 0, s->T("Language"), ALIGN_BOTTOMLEFT)) {
-		screenManager()->push(new LanguageScreen());
-	}
+	
 	UIEnd();
 }
 


### PR DESCRIPTION
String parsing now occurs only on start up and when pressing "reload cheats" button on system settings screen.

Path variable deleted, since it was unneeded.
