### PR TITLE
ParseHexLong now occurs on init only

### DIFF
--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -23,7 +23,7 @@ public:
 	void CreateCodeList();
 	void Exit();
 	void Run();
-	std::vector<std::string> GetNextCode();
+	std::vector<int> GetNextCode();
 
 private:
 	void SkipCodes(int count);


### PR DESCRIPTION
Fixed ParseHexLong to occur along with other string parsing: only when needed.

Sorry Unknown. I wrote this up before i saw your comment about the u32 struct. Let me know if this way is okay or not.
