### PR TITLE
Add support for new atrac3plus decoder

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="HLE\sceVaudio.cpp" />
     <ClCompile Include="HLE\__sceAudio.cpp" />
     <ClCompile Include="Host.cpp" />
+    <ClCompile Include="HW\atrac3plus.cpp" />
     <ClCompile Include="HW\audioPlayer.cpp" />
     <ClCompile Include="HW\MediaEngine.cpp" />
     <ClCompile Include="HW\MemoryStick.cpp" />
@@ -406,6 +407,7 @@
     <ClInclude Include="HLE\sceVaudio.h" />
     <ClInclude Include="HLE\__sceAudio.h" />
     <ClInclude Include="Host.h" />
+    <ClInclude Include="HW\atrac3plus.h" />
     <ClInclude Include="HW\audioPlayer.h" />
     <ClInclude Include="HW\MediaEngine.h" />
     <ClInclude Include="HW\OMAConvert.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -427,6 +427,9 @@
     <ClCompile Include="MIPS\JitCommon\JitBlockCache.cpp">
       <Filter>MIPS\JitCommon</Filter>
     </ClCompile>
+    <ClCompile Include="HW\atrac3plus.cpp">
+      <Filter>HW</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -791,6 +794,9 @@
     </ClInclude>
     <ClInclude Include="MIPS\JitCommon\JitBlockCache.h">
       <Filter>MIPS\JitCommon</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\atrac3plus.h">
+      <Filter>HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/HW/atrac3plus.cpp
+++ b/Core/HW/atrac3plus.cpp
@@ -1,0 +1,80 @@
+
+#ifdef _WIN32 
+#include <Windows.h>
+#endif // _WIN32
+
+#include <string.h>
+
+namespace Atrac3plus_Decoder {
+
+#ifdef _WIN32 
+	HMODULE hlib = 0;
+#endif // _WIN32
+
+	typedef int   (* ATRAC3PLUS_DECODEFRAME)(void* context, void* inbuf, int inbytes, int* channels, void** outbuf);
+	typedef void* (* ATRAC3PLUS_OPENCONTEXT)();
+	typedef int   (* ATRAC3PLUS_CLOSECONTEXT)(void* context);
+	ATRAC3PLUS_DECODEFRAME frame_decoder = 0;
+	ATRAC3PLUS_OPENCONTEXT open_context = 0;
+	ATRAC3PLUS_CLOSECONTEXT close_context = 0;
+
+	int initdecoder() {
+
+#ifdef _WIN32 
+		hlib = LoadLibraryA("MaiAT3PlusDecoder.dll");
+		if (hlib) {
+			frame_decoder = (ATRAC3PLUS_DECODEFRAME)GetProcAddress(hlib, "Atrac3plusDecoder_decodeFrame");
+			open_context = (ATRAC3PLUS_OPENCONTEXT)GetProcAddress(hlib, "Atrac3plusDecoder_openContext");
+			close_context = (ATRAC3PLUS_CLOSECONTEXT)GetProcAddress(hlib, "Atrac3plusDecoder_closeContext");
+		} else {
+			return -1;
+		}
+#endif // _WIN32
+
+		return 0;
+	}
+
+	int shutdowndecoder() {
+
+#ifdef _WIN32 
+		if (hlib) {
+			FreeLibrary(hlib);
+			hlib = 0;
+		}
+#endif // _WIN32
+
+		return 0;
+	}
+
+	void* openContext() {
+		if (!open_context)
+			return 0;
+		return open_context();
+	}
+
+	int closeContext(void** context) {
+		if (!close_context || !context)
+			return 0;
+		close_context(*context);
+		*context = 0;
+		return 0;
+	}
+
+	bool atrac3plus_decode(void* context, void* inbuf, int inbytes, int *outbytes, void* outbuf) {
+		if (!frame_decoder) {
+			*outbytes = 0;
+			return false;
+		}
+		int channels = 0;
+		void* buf;
+		int ret = frame_decoder(context, inbuf, inbytes, &channels, &buf);
+		if (ret != 0) {
+			*outbytes = 0;
+			return false;
+		}
+		*outbytes = channels * 2 * 0x800;
+		memcpy(outbuf, buf, *outbytes);
+		return true;
+	}
+
+} // Atrac3plus_Decoder

--- a/Core/HW/atrac3plus.h
+++ b/Core/HW/atrac3plus.h
@@ -1,0 +1,83 @@
+#ifndef _ATRAC3PLUS_DECODER_
+#define _ATRAC3PLUS_DECODER_
+
+namespace Atrac3plus_Decoder {
+	int initdecoder();
+	int shutdowndecoder();
+
+	void* openContext();
+	int closeContext(void** context);
+	bool atrac3plus_decode(void* context, void* inbuf, int inbytes, int *outbytes, void* outbuf);
+
+	struct BufferQueue {
+		BufferQueue(int size = 0x20000) {
+			bufQueue = 0;
+			alloc(size);
+		}
+
+		~BufferQueue() {
+			if (bufQueue)
+				delete [] bufQueue;
+		}
+
+		bool alloc(int size) {
+			if (size < 0)
+				return false;
+			if (bufQueue)
+				delete [] bufQueue;
+			bufQueue = new unsigned char[size];
+			start = 0;
+			end = 0;
+			bufQueueSize = size;
+			return true;
+		}
+
+		void empty() {
+			start = 0;
+			end = 0;
+		}
+
+		inline int getQueueSize() {
+			return (end + bufQueueSize - start) % bufQueueSize;
+		}
+
+		bool push(unsigned char *buf, int addsize) {
+			int queuesz = getQueueSize();
+			int space = bufQueueSize - queuesz;
+			if (space < addsize || addsize < 0)
+				return false;
+			if (end + addsize <= bufQueueSize) {
+				memcpy(bufQueue + end, buf, addsize);
+			} else {
+				int size = bufQueueSize - end;
+				memcpy(bufQueue + end, buf, size);
+				memcpy(bufQueue, buf + size, addsize - size);
+			}
+			end = (end + addsize) % bufQueueSize;
+			return true;
+		}
+
+		int pop_front(unsigned char *buf, int wantedsize) {
+			if (wantedsize <= 0)
+				return 0;
+			int bytesgot = getQueueSize();
+			if (wantedsize < bytesgot)
+				bytesgot = wantedsize;
+			if (start + bytesgot <= bufQueueSize) {
+				memcpy(buf, bufQueue + start, bytesgot);
+			} else {
+				int size = bufQueueSize - start;
+				memcpy(buf, bufQueue + start, size);
+				memcpy(buf + size, bufQueue, bytesgot - size);
+			}
+			start = (start + bytesgot) % bufQueueSize;
+			return bytesgot;
+		}
+
+		unsigned char* bufQueue;
+		int start, end;
+		int bufQueueSize;
+	};
+}
+
+#endif // _ATRAC3PLUS_DECODER_


### PR DESCRIPTION
Here is my way to support the new atrac3plus decoder.

If you want to support a platform, just build a lib with following export functions:

```
extern "C" void* Atrac3plusDecoder_openContext()
{
    return new MaiAT3PlusFrameDecoder;
}

extern "C" int Atrac3plusDecoder_closeContext(void* context)
{
    MaiAT3PlusFrameDecoder *frame_decoder =(MaiAT3PlusFrameDecoder*)context;
    if (frame_decoder)
        delete frame_decoder;
    return 0;
}

extern "C" int Atrac3plusDecoder_decodeFrame(void* context, void* inbuf, int inbytes, int* channels, void** outbuf)
{
    MaiAT3PlusFrameDecoder *frame_decoder = (MaiAT3PlusFrameDecoder*)context;
    return frame_decoder->decodeFrame((Mai_I8*)inbuf, inbytes, channels, (Mai_I16**)outbuf);
}
```

And then, implement the interface in Core\HW\atrac3plus.cpp.
For static link with the lib, it's really easy. Just import the lib and call those functions. 
For dynamic link with the lib, you can follow my win32 example in Core\HW\atrac3plus.cpp.

Here is a dynamic lib I build for win32: https://docs.google.com/file/d/0B1ftGc2t9-dZQ2daRTkwM3NQREE/edit?usp=sharing
Just put it in PPSSPP folder, it will start to work :)
