### PR TITLE
Fix a resource leak and possible unintentionally executed code.

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2962,9 +2962,9 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 		// No longer waiting.
 		target->nt.waitType = WAITTYPE_NONE;
 		target->nt.waitID = 0;
-	}
 
-	__KernelExecutePendingMipsCalls(target, true);
+		__KernelExecutePendingMipsCalls(target, true);
+	}
 }
 
 void __KernelChangeThreadState(Thread *thread, ThreadStatus newStatus) {

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2957,9 +2957,12 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 			oldUID, oldPC, currentThread, currentMIPS->pc);
 	}
 
-	// No longer waiting.
-	target->nt.waitType = WAITTYPE_NONE;
-	target->nt.waitID = 0;
+	if (target)
+	{
+		// No longer waiting.
+		target->nt.waitType = WAITTYPE_NONE;
+		target->nt.waitID = 0;
+	}
 
 	__KernelExecutePendingMipsCalls(target, true);
 }

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -41,7 +41,10 @@ EmuFileType Identify_File(const char *filename)
 
 	size_t readSize = fread(&id,4,1,f);
 	if(readSize != 1)
+	{
+		fclose(f);
 		return FILETYPE_ERROR;
+	}
 
 	psar_id = 0;
 	fseek(f, 0x24, SEEK_SET);


### PR DESCRIPTION
Resource leak in Loaders.cpp in the case readSize doesn't equal 1.

Before it would simply return the error value, but wouldn't close the FILE instance.
## 

At line 2935 in sceKernelThread, there is a null check on the variable "target", however there is a case in the method where it assumes it would not be null.
