### PR TITLE
Fix improper clearing of the sample queue in sceAtrac.

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -113,7 +113,7 @@ struct Atrac {
 		pFrame = 0;
 #endif // USE_FFMPEG
 		decoder_context = 0;
-		sampleQueue.empty();
+		sampleQueue.clear();
 	}
 
 	~Atrac() {
@@ -130,7 +130,7 @@ struct Atrac {
 		data_buf = 0;
 
 		Atrac3plus_Decoder::closeContext(&decoder_context);
-		sampleQueue.empty();
+		sampleQueue.clear();
 	}
 
 	void DoState(PointerWrap &p) {


### PR DESCRIPTION
sampleQueue.empty() is a bool function that checks if the queue is empty. It doesn't actually clear the queue.
