### PR TITLE
Added iCade support to the iOS Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,10 @@ elseif(IOS)
 		ios/ViewController.mm
 		ios/ViewController.h
 		ios/AudioEngine.mm
-		ios/AudioEngine.h)
+		ios/AudioEngine.h
+		ios/iCade/iCadeReaderView.h
+		ios/iCade/iCadeReaderView.m
+		ios/iCade/iCadeState.h)
 	set(nativeExtraLibs ${nativeExtraLibs} "-framework Foundation -framework AudioToolbox -framework CoreGraphics -framework QuartzCore -framework OpenGLES -framework UIKit -framework GLKit -framework OpenAL")
 	set(TargetBin PPSSPP)
 elseif(USING_QT_UI)

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -167,7 +167,7 @@ std::vector<std::string> CWCheatEngine::GetCodesList() {
 
 	char* skip = "//";
 	std::vector<std::string> codesList;  // Read from INI here
-	std::ifstream list(title3);
+	std::ifstream list(title3.c_str());
 	for (int i = 0; !list.eof(); i ++) {
 		getline(list, line, '\n');
 		if (line.substr(0,2) == skip) {

--- a/ios/ViewController.h
+++ b/ios/ViewController.h
@@ -3,6 +3,8 @@
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
 
-@interface ViewController : GLKViewController
+#import "iCade/iCadeReaderView.h"
+
+@interface ViewController : GLKViewController <iCadeEventDelegate>
 
 @end

--- a/ios/iCade/iCadeReaderView.h
+++ b/ios/iCade/iCadeReaderView.h
@@ -1,0 +1,66 @@
+/*
+ Copyright (C) 2011 by Stuart Carnie
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import <UIKit/UIKit.h>
+#import "iCadeState.h"
+
+/*
+ UP ON,OFF  = w,e
+ RT ON,OFF  = d,c
+ DN ON,OFF  = x,z
+ LT ON,OFF  = a,q
+ A  ON,OFF  = y,t
+ B  ON,OFF  = h,r
+ C  ON,OFF  = u,f
+ D  ON,OFF  = j,n
+ E  ON,OFF  = i,m
+ F  ON,OFF  = k,p
+ G  ON,OFF  = o,g
+ H  ON,OFF  = l,v
+*/
+
+@protocol iCadeEventDelegate <NSObject>
+
+@optional
+- (void)stateChanged:(iCadeState)state;
+- (void)buttonDown:(iCadeState)button;
+- (void)buttonUp:(iCadeState)button;
+
+@end
+
+@interface iCadeReaderView : UIView<UIKeyInput> {
+    UIView                  *inputView;
+    iCadeState              _iCadeState;
+    id<iCadeEventDelegate>  _delegate;
+    
+    struct {
+        bool stateChanged:1;
+        bool buttonDown:1;
+        bool buttonUp:1;
+    } _delegateFlags;
+}
+
+@property (nonatomic, assign) iCadeState iCadeState;
+@property (nonatomic, assign) id<iCadeEventDelegate> delegate;
+@property (nonatomic, assign) BOOL active;
+
+@end

--- a/ios/iCade/iCadeReaderView.m
+++ b/ios/iCade/iCadeReaderView.m
@@ -1,0 +1,141 @@
+/*
+ Copyright (C) 2011 by Stuart Carnie
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import "iCadeReaderView.h"
+
+static const char *ON_STATES  = "wdxayhujikol";
+static const char *OFF_STATES = "eczqtrfnmpgv";
+
+@interface iCadeReaderView()
+
+- (void)didEnterBackground;
+- (void)didBecomeActive;
+
+@end
+
+@implementation iCadeReaderView
+
+@synthesize iCadeState=_iCadeState, delegate=_delegate, active;
+
+- (id)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    inputView = [[UIView alloc] initWithFrame:CGRectZero];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
+    
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
+    [super dealloc];
+}
+
+- (void)didEnterBackground {
+    if (self.active)
+        [self resignFirstResponder];
+}
+
+- (void)didBecomeActive {
+    if (self.active)
+        [self becomeFirstResponder];
+}
+
+- (BOOL)canBecomeFirstResponder { 
+    return YES; 
+}
+
+- (void)setActive:(BOOL)value {
+    if (active == value) return;
+    
+    active = value;
+    if (active) {
+        [self becomeFirstResponder];
+    } else {
+        [self resignFirstResponder];
+    }
+}
+
+- (UIView*) inputView {
+    return inputView;
+}
+
+- (void)setDelegate:(id<iCadeEventDelegate>)delegate {
+    _delegate = delegate;
+    if (!_delegate) return;
+    
+    _delegateFlags.stateChanged = [_delegate respondsToSelector:@selector(stateChanged:)];
+    _delegateFlags.buttonDown = [_delegate respondsToSelector:@selector(buttonDown:)];
+    _delegateFlags.buttonUp = [_delegate respondsToSelector:@selector(buttonUp:)];
+}
+
+#pragma mark -
+#pragma mark UIKeyInput Protocol Methods
+
+- (BOOL)hasText {
+    return NO;
+}
+
+- (void)insertText:(NSString *)text {
+    
+    char ch = [text characterAtIndex:0];
+    char *p = strchr(ON_STATES, ch);
+    bool stateChanged = false;
+    if (p) {
+        int index = p-ON_STATES;
+        _iCadeState |= (1 << index);
+        stateChanged = true;
+        if (_delegateFlags.buttonDown) {
+            [_delegate buttonDown:(1 << index)];
+        }
+    } else {
+        p = strchr(OFF_STATES, ch);
+        if (p) {
+            int index = p-OFF_STATES;
+            _iCadeState &= ~(1 << index);
+            stateChanged = true;
+            if (_delegateFlags.buttonUp) {
+                [_delegate buttonUp:(1 << index)];
+            }
+        }
+    }
+
+    if (stateChanged && _delegateFlags.stateChanged) {
+        [_delegate stateChanged:_iCadeState];
+    }
+    
+    static int cycleResponder = 0;
+    if (++cycleResponder > 20) {
+        // necessary to clear a buffer that accumulates internally
+        cycleResponder = 0;
+        [self resignFirstResponder];
+        [self becomeFirstResponder];
+    }
+}
+
+- (void)deleteBackward {
+    // This space intentionally left blank to complete protocol
+}
+
+@end

--- a/ios/iCade/iCadeState.h
+++ b/ios/iCade/iCadeState.h
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2011 by Stuart Carnie
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+typedef enum iCadeState {
+    iCadeJoystickNone       = 0x000,
+    iCadeJoystickUp         = 0x001,
+    iCadeJoystickRight      = 0x002,
+    iCadeJoystickDown       = 0x004,
+    iCadeJoystickLeft       = 0x008,
+    
+    iCadeJoystickUpRight    = iCadeJoystickUp   | iCadeJoystickRight,
+    iCadeJoystickDownRight  = iCadeJoystickDown | iCadeJoystickRight,
+    iCadeJoystickUpLeft     = iCadeJoystickUp   | iCadeJoystickLeft,
+    iCadeJoystickDownLeft   = iCadeJoystickDown | iCadeJoystickLeft,
+    
+    iCadeButtonA            = 0x010,
+    iCadeButtonB            = 0x020,
+    iCadeButtonC            = 0x040,
+    iCadeButtonD            = 0x080,
+    iCadeButtonE            = 0x100,
+    iCadeButtonF            = 0x200,
+    iCadeButtonG            = 0x400,
+    iCadeButtonH            = 0x800,
+    
+} iCadeState;


### PR DESCRIPTION
I've added in iCade support for the iOS build.  I have an iCade 8-bitty that I used to test with on both an iPad 3 and iPhone 5.  I've mapped the four buttons like so:

[] /\
X O

Double-pressing the Select button within 1 second will switch the DPad between normal DPad operation and simulating the Analog Stick (so you can navigate menus, then switch to driving a car, eg.).

I don't have one of the bigger iCade cabinets to test with, but I believe the buttons would be mapped like this:

L R [] /\
Select Start X O

Supposedly the Gametel controller emulates an iCade controller, and the iControlPad controller can emulate an iCade controller too, so those might work as well, though the buttons may be mapped wrong.
