### PR TITLE
Save patch division

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -751,6 +751,9 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_PATCHDIVISION:
+		gstate_c.patch_div_s = std::max(data & 0xFF, (unsigned int)1);
+		gstate_c.patch_div_t = std::max((data >> 8) & 0xFF, (unsigned int)1);
+		break;
 	case GE_CMD_PATCHPRIMITIVE:
 	case GE_CMD_PATCHFACING:
 		break;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -281,6 +281,8 @@ struct GPUStateCache
 	u32 curRTHeight;
 
 	u32 getRelativeAddress(u32 data) const;
+	
+	int patch_div_s, patch_div_t;
 };
 
 // TODO: Implement support for these.


### PR DESCRIPTION
Allows the potential of incorporating bezier curves (used in, for example God Eater Burst to display its sky, and other games for different reasons as well).
