### PR TITLE
HW mode : Fix incorrect texture in Dragon Ball Z Shin Budokai 2

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -313,7 +313,7 @@ void LinkedShader::updateUniforms() {
 			uvscaleoff[2] /= gstate_c.curTextureWidth;
 			uvscaleoff[3] /= gstate_c.curTextureHeight;
 		} else {
-			static const float rescale[4] = {0, 2*127.5f/128.f, 2*32767.5f/32768.f, 2.0f};
+			static const float rescale[4] = {2.0f, 2*127.5f/128.f, 2*32767.5f/32768.f, 2.0f};
 			float factor = rescale[(gstate.vertType & GE_VTYPE_TC_MASK) >> GE_VTYPE_TC_SHIFT];
 			uvscaleoff[0] *= factor;
 			uvscaleoff[1] *= factor;


### PR DESCRIPTION
HW mode
![sw](https://f.cloud.github.com/assets/3000282/591519/34006140-ca03-11e2-8386-942e95119cbd.jpg)

SW mode
![hw](https://f.cloud.github.com/assets/3000282/591521/37190c24-ca03-11e2-96b5-399c2ce4f11c.jpg)
