### PR TITLE
Add GPU statistic for cycles executed

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -254,6 +254,8 @@ void __DisplayGetDebugStats(char stats[2048])
 {
 	gpu->UpdateStats();
 
+	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
+
 	sprintf(stats,
 		"Frames: %i\n"
 		"DL processing time: %0.2f ms\n"
@@ -263,6 +265,7 @@ void __DisplayGetDebugStats(char stats[2048])
 		"Draw calls: %i, flushes %i\n"
 		"Cached Draw calls: %i\n"
 		"Num Tracked Vertex Arrays: %i\n"
+		"Cycles executed: %d (%f per vertex)\n"
 		"Vertices Submitted: %i\n"
 		"Cached Vertices Drawn: %i\n"
 		"Uncached Vertices Drawn: %i\n"
@@ -283,6 +286,8 @@ void __DisplayGetDebugStats(char stats[2048])
 		gpuStats.numFlushes,
 		gpuStats.numCachedDrawCalls,
 		gpuStats.numTrackedVertexArrays,
+		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
+		vertexAverageCycles,
 		gpuStats.numVertsSubmitted,
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -390,6 +390,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 			transformDraw_.SubmitPrim(verts, inds, type, count, gstate.vertType, -1, &bytesRead);
 
 			int vertexCost = transformDraw_.EstimatePerVertexCost();
+			gpuStats.vertexGPUCycles += vertexCost * count;
 			cyclesExecuted += vertexCost * count;
 
 			// After drawing, we advance the vertexAddr (when non indexed) or indexAddr (when indexed).

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -787,7 +787,7 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_ALPHATEST:
 #ifndef USING_GLES2
-		if (((data >> 16) & 0xFF) != 0xFF && data != 0)
+		if (((data >> 16) & 0xFF) != 0xFF && (data & 7) > 1)
 			WARN_LOG_REPORT_ONCE(alphatestmask, HLE, "Unsupported alphatest mask: %02x", (data >> 16) & 0xFF);
 #endif
 	case GE_CMD_COLORREF:

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -463,6 +463,7 @@ inline void GPUCommon::UpdatePC(u32 currentPC, u32 newPC)
 {
 	// Rough estimate, 2 CPU ticks (it's double the clock rate) per GPU instruction.
 	cyclesExecuted += 2 * (currentPC - cycleLastPC) / 4;
+	gpuStats.otherGPUCycles += 2 * (currentPC - cycleLastPC) / 4;
 	cycleLastPC = newPC == 0 ? currentPC : newPC;
 
 	// Exit the runloop and recalculate things.  This isn't common.

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -302,6 +302,8 @@ struct GPUStatistics
 		numFlushes = 0;
 		numTexturesDecoded = 0;
 		msProcessingDisplayLists = 0;
+		vertexGPUCycles = 0;
+		otherGPUCycles = 0;
 	}
 
 	// Per frame statistics
@@ -317,6 +319,8 @@ struct GPUStatistics
 	int numShaderSwitches;
 	int numTexturesDecoded;
 	double msProcessingDisplayLists;
+	int vertexGPUCycles;
+	int otherGPUCycles;
 
 	// Total statistics, updated by the GPU core in UpdateStats
 	int numFrames;


### PR DESCRIPTION
Well, it's measured in CPU cycles but all the same..

This to help debug games that run too slow because of bad estimates.

Also a reporting tweak for alpha test.

-[Unknown]
