### PR TITLE
Fix a case where the wrong array was used.

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -611,7 +611,7 @@ void PSPOskDialog::RemoveKorean()
 		{
 			if(kor_lconsCom[i] == i_value[2])
 			{
-				tmp = kor_vowelCom[i - 1];
+				tmp = kor_lconsCom[i - 1];
 				break;
 			}
 		}


### PR DESCRIPTION
I believe this was a copy paste error from the branch above this one.

It's like 4AM, so I really don't want to retype this, so have the 'raw copy' of the work, haha.

![Image](http://i.imgur.com/5EW8TSM.jpg)
