### PR TITLE
Toggle Atrac3+ in [Sound] section

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -128,7 +128,8 @@ void Config::Load(const char *iniFileName)
 
 	IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 	sound->Get("Enable", &bEnableSound, true);
-
+	sound->Get("EnableAtrac3plus", &bEnableAtrac3plus, true);
+	
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("ShowStick", &bShowAnalogStick, false);
 #ifdef BLACKBERRY10
@@ -218,7 +219,8 @@ void Config::Save()
 
 		IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 		sound->Set("Enable", bEnableSound);
-
+		sound->Set("EnableAtrac3plus", bEnableAtrac3plus);
+		
 		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 		control->Set("ShowStick", bShowAnalogStick);
 		control->Set("ShowTouchControls", bShowTouchControls);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -85,7 +85,8 @@ public:
 
 	// Sound
 	bool bEnableSound;
-
+	bool bEnableAtrac3plus;
+	
 	// UI
 	bool bShowTouchControls;
 	bool bShowDebuggerOnLoad;

--- a/Core/HW/atrac3plus.cpp
+++ b/Core/HW/atrac3plus.cpp
@@ -42,7 +42,7 @@ namespace Atrac3plus_Decoder {
 #else
 		hlib = LoadLibraryA("at3plusdecoder.dll");
 #endif
-		if (hlib) {
+		if (hlib && g_Config.bEnableAtrac3plus) {
 			frame_decoder = (ATRAC3PLUS_DECODEFRAME)GetProcAddress(hlib, "Atrac3plusDecoder_decodeFrame");
 			open_context = (ATRAC3PLUS_OPENCONTEXT)GetProcAddress(hlib, "Atrac3plusDecoder_openContext");
 			close_context = (ATRAC3PLUS_CLOSECONTEXT)GetProcAddress(hlib, "Atrac3plusDecoder_closeContext");

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -664,7 +664,8 @@ void AudioScreen::render() {
 	int stride = 40;
 	int columnw = 400;
 	UICheckBox(GEN_ID, x, y += stride, a->T("Enable Sound"), ALIGN_TOPLEFT, &g_Config.bEnableSound);
-
+	UICheckBox(GEN_ID, x, y += stride, a->T("Enable Atrac3+"), ALIGN_TOPLEFT, &g_Config.bEnableAtrac3plus);
+	
 	UIEnd();
 }
 


### PR DESCRIPTION
It targets for Android/iOS platfrom to allow us toggle the atrac3+ audio since it keeps random crash in some games and renders them unplayable .

(Note : Windows platform has been worked prefectly fine with atrac3+ audio though)
