### PR TITLE
Rewrite some core functions for sceMpeg with ffmpeg.

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -233,6 +233,7 @@
     <ClCompile Include="HW\atrac3plus.cpp" />
     <ClCompile Include="HW\MediaEngine.cpp" />
     <ClCompile Include="HW\MemoryStick.cpp" />
+    <ClCompile Include="HW\MpegDemux.cpp" />
     <ClCompile Include="HW\OMAConvert.cpp" />
     <ClCompile Include="HW\SasAudio.cpp" />
     <ClCompile Include="Loaders.cpp" />
@@ -411,6 +412,7 @@
     <ClInclude Include="Host.h" />
     <ClInclude Include="HW\atrac3plus.h" />
     <ClInclude Include="HW\MediaEngine.h" />
+    <ClInclude Include="HW\MpegDemux.h" />
     <ClInclude Include="HW\OMAConvert.h" />
     <ClInclude Include="HW\SasAudio.h" />
     <ClInclude Include="HW\MemoryStick.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -430,6 +430,9 @@
     <ClCompile Include="HW\atrac3plus.cpp">
       <Filter>HW</Filter>
     </ClCompile>
+    <ClCompile Include="HW\MpegDemux.cpp">
+      <Filter>HW</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -793,6 +796,9 @@
       <Filter>Core</Filter>
     </ClInclude>
     <ClInclude Include="HW\atrac3plus.h">
+      <Filter>HW</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\MpegDemux.h">
       <Filter>HW</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -62,18 +62,16 @@ struct SceMpegAu {
 
 	void read(u32 addr) {
 		Memory::ReadStruct(addr, this);
-		pts = (pts & 0xFFFFFFFFULL) << 32 | (pts >> 32);
-		dts = (dts & 0xFFFFFFFFULL) << 32 | (dts >> 32);
+		pts = (pts & 0xFFFFFFFFULL) << 32 | (((u64)pts) >> 32);
+		dts = (dts & 0xFFFFFFFFULL) << 32 | (((u64)dts) >> 32);
 	}
 
 	void write(u32 addr) {
-		pts = (pts & 0xFFFFFFFFULL) << 32 | (pts >> 32);
-		dts = (dts & 0xFFFFFFFFULL) << 32 | (dts >> 32);
+		pts = (pts & 0xFFFFFFFFULL) << 32 | (((u64)pts) >> 32);
+		dts = (dts & 0xFFFFFFFFULL) << 32 | (((u64)dts) >> 32);
 		Memory::WriteStruct(addr, this);
 	}
 };
-
-const int videoTimestampStep = 3003;
 
 // As native in PSP ram
 struct SceMpegRingBuffer {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -17,27 +17,500 @@
 
 #include "MediaEngine.h"
 #include "../MemMap.h"
+#include "GPU/GPUInterface.h"
+#include "Core/HW/atrac3plus.h"
 
-static const int modeBpp[4] = { 2, 2, 2, 4 };
+#ifdef USE_FFMPEG
+extern "C" {
 
+#include "libavcodec/avcodec.h"
+#include "libavformat/avformat.h"
+#include "libswscale/swscale.h"
 
-void MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMode)
+}
+#endif // USE_FFMPEG
+
+static const int TPSM_PIXEL_STORAGE_MODE_16BIT_BGR5650 = 0x00;
+static const int TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR5551 = 0x01;
+static const int TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR4444 = 0x02;
+static const int TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888 = 0x03;
+
+inline void YUV444toRGB888(u8 ypos, u8 upos, u8 vpos, u8 &r, u8 &g, u8 &b)
 {
-	if (videoPixelMode >= (int)(sizeof(modeBpp) / sizeof(modeBpp[0])) || videoPixelMode < 0)
-	{
-		ERROR_LOG(ME, "Unexpected videoPixelMode %d, using 0 instead.", videoPixelMode);
-		videoPixelMode = 0;
-	}
+	u8 u = upos - 128;
+	u8 v = vpos -128;
+	int rdif = v + ((v * 103) >> 8);
+	int invgdif = ((u * 88) >> 8) + ((v * 183) >> 8);
+	int bdif = u + ((u * 198) >> 8);
 
-	int bpp = modeBpp[videoPixelMode];
-
-	// fake image. To be improved.
-	if (Memory::IsValidAddress(bufferPtr))
-		// Use Dark Grey to identify CG is running 
-		Memory::Memset(bufferPtr, 0x69, frameWidth * videoHeight_ * bpp);
+	r = (u8)(ypos + rdif);
+	g = (u8)(ypos - invgdif);
+	b = (u8)(ypos + bdif);
 }
 
-void MediaEngine::feedPacketData(u32 addr, int size)
+void getPixelColor(u8 r, u8 g, u8 b, u8 a, int pixelMode, u16* color)
 {
-	// This media engine is totally incompetent and will just ignore all data sent to it.
+	switch (pixelMode)
+	{
+	case TPSM_PIXEL_STORAGE_MODE_16BIT_BGR5650: 
+		{
+			*color = ((b >> 3) << 11) | ((g >> 2) << 5) | (r >> 3);
+		}
+		break;
+	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR5551:
+		{
+			*color = ((a >> 7) << 15) | ((b >> 3) << 10) | ((g >> 3) << 5) | (r >> 3);
+		}
+		break;
+	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR4444:
+		{
+			*color = ((a >> 4) << 12) | ((b >> 4) << 8) | ((g >> 4) << 4) | (r >> 4);
+		}
+		break;
+	default:
+		// do nothing yet
+		break;
+	}
+}
+
+MediaEngine::MediaEngine(): m_pdata(0), m_streamSize(0), m_readSize(0){
+	m_pFormatCtx = 0;
+	m_pCodecCtx = 0;
+	m_pFrame = 0;
+	m_pFrameRGB = 0;
+	m_pIOContext = 0;
+	m_videoStream = -1;
+	m_buffer = 0;
+	m_demux = 0;
+	m_audioContext = 0;
+}
+
+MediaEngine::~MediaEngine() {
+	closeMedia();
+}
+
+void MediaEngine::closeMedia() {
+#ifdef USE_FFMPEG
+	if (m_buffer)
+		av_free(m_buffer);
+	if (m_pFrameRGB)
+		av_free(m_pFrameRGB);
+	if (m_pFrame)
+		av_free(m_pFrame);
+	if (m_pIOContext && ((AVIOContext*)m_pIOContext)->buffer)
+		av_free(((AVIOContext*)m_pIOContext)->buffer);
+	if (m_pIOContext)
+		av_free(m_pIOContext);
+	if (m_pCodecCtx)
+		avcodec_close((AVCodecContext*)m_pCodecCtx);
+	if (m_pFormatCtx)
+		avformat_close_input((AVFormatContext**)&m_pFormatCtx);
+#endif // USE_FFMPEG
+	if (m_pdata)
+		delete [] m_pdata;
+	if (m_demux)
+		delete m_demux;
+	m_buffer = 0;
+	m_pFrame = 0;
+	m_pFrameRGB = 0;
+	m_pIOContext = 0;
+	m_pCodecCtx = 0;
+	m_pFormatCtx = 0;
+	m_videoStream = -1;
+	m_pdata = 0;
+	m_demux = 0;
+	Atrac3plus_Decoder::closeContext(&m_audioContext);
+}
+
+int _MpegReadbuffer(void *opaque, uint8_t *buf, int buf_size)
+{
+	MediaEngine *mpeg = (MediaEngine*)opaque;
+	int size = std::min(mpeg->m_bufSize, buf_size);
+	size = std::max(std::min((mpeg->m_readSize - mpeg->m_decodePos), size), 0);
+	if (size > 0)
+		memcpy(buf, mpeg->m_pdata + mpeg->m_decodePos, size);
+	mpeg->m_decodePos += size;
+	return size;
+}
+
+int64_t _MpegSeekbuffer(void *opaque, int64_t offset, int whence)
+{
+	MediaEngine *mpeg = (MediaEngine*)opaque;
+	switch (whence) {
+	case SEEK_SET:
+		mpeg->m_decodePos = offset;
+		break;
+	case SEEK_CUR:
+		mpeg->m_decodePos += offset;
+		break;
+	case SEEK_END:
+		mpeg->m_decodePos = mpeg->m_streamSize - (u32)offset;
+		break;
+	}
+	return offset;
+}
+
+bool MediaEngine::openContext() {
+#ifdef USE_FFMPEG
+	u8* tempbuf = (u8*)av_malloc(m_bufSize);
+
+	AVFormatContext *pFormatCtx = avformat_alloc_context();
+	m_pFormatCtx = (void*)pFormatCtx;
+	m_pIOContext = (void*)avio_alloc_context(tempbuf, m_bufSize, 0, (void*)this, _MpegReadbuffer, NULL, _MpegSeekbuffer);
+	pFormatCtx->pb = (AVIOContext*)m_pIOContext;
+  
+	// Open video file
+	if(avformat_open_input((AVFormatContext**)&m_pFormatCtx, NULL, NULL, NULL) != 0)
+		return false;
+
+	if(avformat_find_stream_info(pFormatCtx, NULL) < 0)
+		return false;
+
+	 // Dump information about file onto standard error
+	av_dump_format(pFormatCtx, 0, NULL, 0);
+
+	// Find the first video stream
+	for(int i = 0; i < pFormatCtx->nb_streams; i++) {
+		if(pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
+			m_videoStream = i;
+			break;
+		}
+	}
+	if(m_videoStream == -1)
+		return false;
+
+	// Get a pointer to the codec context for the video stream
+	m_pCodecCtx = (void*)pFormatCtx->streams[m_videoStream]->codec;
+	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
+  
+	// Find the decoder for the video stream
+	AVCodec *pCodec = avcodec_find_decoder(pCodecCtx->codec_id);
+	if(pCodec == NULL)
+		return false;
+  
+	// Open codec
+	AVDictionary *optionsDict = 0;
+	if(avcodec_open2(pCodecCtx, pCodec, &optionsDict)<0)
+		return false; // Could not open codec
+
+	setVideoDim();
+	int mpegoffset = bswap32(*(int*)(m_pdata + 8));
+	m_demux = new MpegDemux(m_pdata, m_streamSize, mpegoffset);
+	m_demux->setReadSize(m_readSize);
+	m_demux->demux();
+	m_audioPos = 0;
+	m_audioContext = Atrac3plus_Decoder::openContext();
+#endif USE_FFMPEG
+	return true;
+}
+
+bool MediaEngine::loadStream(u8* buffer, int readSize, int StreamSize)
+{
+	closeMedia();
+	// force to clear the useless FBO
+	gpu->Resized();
+
+	m_videopts = 0;
+	m_audiopts = 0;
+	m_bufSize = 0x2000;
+	m_decodePos = 0;
+	m_readSize = readSize;
+	m_streamSize = StreamSize;
+	m_pdata = new u8[StreamSize];
+	memcpy(m_pdata, buffer, m_readSize);
+	
+	if (readSize > 0x2000)
+		openContext();
+	return true;
+}
+
+bool MediaEngine::loadFile(const char* filename)
+{
+	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
+	s64 infosize = info.size;
+	u8* buf = new u8[infosize];
+	u32 h = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
+	pspFileSystem.ReadFile(h, buf, infosize);
+	pspFileSystem.CloseFile(h);
+
+	closeMedia();
+	// force to clear the useless FBO
+	gpu->Resized();
+
+	m_videopts = 0;
+	m_audiopts = 0;
+	m_bufSize = 0x2000;
+	m_decodePos = 0;
+	m_readSize = infosize;
+	m_streamSize = infosize;
+	m_pdata = buf;
+	
+	if (m_readSize > 0x2000)
+		openContext();
+
+	return true;
+}
+
+void MediaEngine::addStreamData(u8* buffer, int addSize) {
+	int size = std::min(addSize, m_streamSize - m_readSize);
+	if (size > 0) {
+		memcpy(m_pdata + m_readSize, buffer, size);
+		m_readSize += size;
+		if (!m_pFormatCtx && m_readSize > 0x2000)
+			openContext();
+		if (m_demux) {
+			m_demux->setReadSize(m_readSize);
+			m_demux->demux();
+		}
+	}
+}
+
+bool MediaEngine::setVideoDim(int width, int height)
+{
+	if (!m_pCodecCtx)
+		return false;
+#ifdef USE_FFMPEG
+	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
+	if (width == 0 && height == 0)
+	{
+		// use the orignal video size
+		m_desWidth = pCodecCtx->width;
+		m_desHeight = pCodecCtx->height;
+	}
+	else
+	{
+		m_desWidth = width;
+		m_desHeight = height;
+	}
+
+	// Allocate video frame
+	m_pFrame = avcodec_alloc_frame();
+	
+	m_sws_ctx = (void*)
+    sws_getContext
+    (
+        pCodecCtx->width,
+        pCodecCtx->height,
+        pCodecCtx->pix_fmt,
+        m_desWidth,
+        m_desHeight,
+        PIX_FMT_RGB24,
+        SWS_BILINEAR,
+        NULL,
+        NULL,
+        NULL
+    );
+
+	// Allocate video frame for RGB24
+	m_pFrameRGB = avcodec_alloc_frame();
+	int numBytes = avpicture_get_size(PIX_FMT_RGB24, m_desWidth, m_desHeight);  
+    m_buffer = (u8*)av_malloc(numBytes * sizeof(uint8_t));
+  
+    // Assign appropriate parts of buffer to image planes in pFrameRGB   
+    avpicture_fill((AVPicture *)m_pFrameRGB, m_buffer, PIX_FMT_RGB24, m_desWidth, m_desHeight);  
+#endif // USE_FFMPEG
+	return true;
+}
+
+bool MediaEngine::stepVideo() {
+
+	// if video engine is broken, force to add timestamp
+	m_videopts += 3003;
+#ifdef USE_FFMPEG
+	AVFormatContext *pFormatCtx = (AVFormatContext*)m_pFormatCtx;
+	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
+	AVFrame *pFrame = (AVFrame*)m_pFrame;
+	AVFrame *pFrameRGB = (AVFrame*)m_pFrameRGB;
+	if ((!m_pFrame)||(!m_pFrameRGB))
+		return false;
+	AVPacket packet;
+	int frameFinished;
+	bool bGetFrame = false;
+	while(av_read_frame(pFormatCtx, &packet)>=0) {
+		if(packet.stream_index == m_videoStream) {
+			// Decode video frame
+			avcodec_decode_video2(pCodecCtx, pFrame, &frameFinished, &packet);
+			sws_scale((SwsContext*)m_sws_ctx, pFrame->data, pFrame->linesize, 0, 
+					pCodecCtx->height, pFrameRGB->data, pFrameRGB->linesize);
+      
+			if(frameFinished) {
+				if (m_videopts == 3003) {
+					m_audiopts = packet.pts;
+				}
+				m_videopts = packet.pts + packet.duration;
+				bGetFrame = true;
+			}
+		}
+		av_free_packet(&packet);
+		if (bGetFrame) break;
+	}
+	if (m_audiopts > 0) {
+		if (m_audiopts - m_videopts > 5000)
+			return stepVideo();
+	}
+	return bGetFrame;
+#else
+	return true;
+#endif // USE_FFMPEG
+}
+
+bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode) {
+	if ((!m_pFrame)||(!m_pFrameRGB))
+		return false;
+#ifdef USE_FFMPEG
+	AVFrame *pFrameRGB = (AVFrame*)m_pFrameRGB;
+	// lock the image size
+	int height = m_desHeight;
+	int width = m_desWidth;
+	u8* imgbuf = buffer;
+	u8* data = pFrameRGB->data[0];
+	if (videoPixelMode == TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888)
+	{
+		// ABGR8888
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++)
+			{
+				u8 r = *(data++);
+				u8 g = *(data++);
+				u8 b = *(data++);
+				*(imgbuf++) = r;
+				*(imgbuf++) = g;
+				*(imgbuf++) = b;
+				*(imgbuf++) = 0xFF;
+			}
+			imgbuf += (frameWidth - width) * 4;
+		}
+	}
+	else
+	{
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++)
+			{
+				u8 r = *(data++);
+				u8 g = *(data++);
+				u8 b = *(data++);
+				getPixelColor(r, g, b, 0xFF, videoPixelMode, (u16*)imgbuf);
+				imgbuf += 2;
+			}
+			imgbuf += (frameWidth - width) * 2;
+		}
+	} 
+#endif // USE_FFMPEG
+	return true;
+}
+
+bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
+	                             int xpos, int ypos, int width, int height) {
+	if ((!m_pFrame)||(!m_pFrameRGB))
+		return false;
+#ifdef USE_FFMPEG
+	AVFrame *pFrameRGB = (AVFrame*)m_pFrameRGB;
+	// lock the image size
+	u8* imgbuf = buffer;
+	u8* data = pFrameRGB->data[0];
+	if (videoPixelMode == TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888)
+	{
+		// ABGR8888
+		data +=  (ypos *  m_desWidth + xpos) * 3;
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++)
+			{
+				u8 r = *(data++);
+				u8 g = *(data++);
+				u8 b = *(data++);
+				*(imgbuf++) = r;
+				*(imgbuf++) = g;
+				*(imgbuf++) = b;
+				*(imgbuf++) = 0xFF;
+			}
+			imgbuf += (frameWidth - width) * 4;
+			data += (m_desWidth - width) * 3;
+		}
+	}
+	else
+	{
+		data +=  (ypos *  m_desWidth + xpos) * 3;
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++)
+			{
+				u8 r = *(data++);
+				u8 g = *(data++);
+				u8 b = *(data++);
+				getPixelColor(r, g, b, 0xFF, videoPixelMode, (u16*)imgbuf);
+				imgbuf += 2;
+			}
+			imgbuf += (frameWidth - width) * 2;
+			data += (m_desWidth - width) * 3;
+		}
+	} 
+#endif // USE_FFMPEG
+	return true;
+}
+
+static bool isHeader(u8* audioStream, int offset)
+{
+	const u8 header1 = (u8)0x0F;
+	const u8 header2 = (u8)0xD0;
+	return (audioStream[offset] == header1) && (audioStream[offset+1] == header2);
+}
+
+static int getNextHeaderPosition(u8* audioStream, int curpos, int limit, int frameSize)
+{
+	int endScan = limit - 1;
+
+	// Most common case: the header can be found at each frameSize
+	int offset = curpos + frameSize - 8;
+	if (offset < endScan && isHeader(audioStream, offset))
+		return offset;
+	for (int scan = curpos; scan < endScan; scan++) {
+		if (isHeader(audioStream, scan))
+			return scan;
+	}
+
+	return -1;
+}
+
+int MediaEngine::getAudioSamples(u8* buffer) {
+	if (!m_demux) {
+		return 0;
+	}
+	u8* audioStream = 0;
+	int audioSize = m_demux->getaudioStream(&audioStream);
+	if (m_audioPos >= audioSize || !isHeader(audioStream, m_audioPos))
+	{
+		return 0;
+	}
+	u8 headerCode1 = audioStream[2];
+	u8 headerCode2 = audioStream[3];
+	int frameSize = ((headerCode1 & 0x03) << 8) | (headerCode2 & 0xFF) * 8 + 0x10;
+	if (m_audioPos + frameSize > audioSize)
+		return 0;
+	m_audioPos += 8;
+	int nextHeader = getNextHeaderPosition(audioStream, m_audioPos, audioSize, frameSize);
+	u8* frame = audioStream + m_audioPos;
+	int outbytes = 0;
+	Atrac3plus_Decoder::atrac3plus_decode(m_audioContext, frame, frameSize - 8, &outbytes, buffer);
+	if (nextHeader >= 0) {
+		m_audioPos = nextHeader;
+	} else
+		m_audioPos = audioSize;
+	m_audiopts += 4180;
+	return outbytes;
+}
+
+s64 MediaEngine::getVideoTimeStamp() {
+	return m_videopts;
+}
+
+s64 MediaEngine::getAudioTimeStamp() {
+	if (m_audiopts > 0)
+		return m_audiopts;
+	return m_videopts;
+}
+
+s64 MediaEngine::getLastTimeStamp() {
+	if (!m_pdata)
+		return 0;
+	int lastTimeStamp = bswap32(*(int*)(m_pdata + 92));
+	return lastTimeStamp;
 }

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -1,0 +1,192 @@
+#include "MpegDemux.h"
+
+const int PACKET_START_CODE_MASK   = 0xffffff00;
+const int PACKET_START_CODE_PREFIX = 0x00000100;
+
+const int SEQUENCE_START_CODE      = 0x000001b3;
+const int EXT_START_CODE           = 0x000001b5;
+const int SEQUENCE_END_CODE        = 0x000001b7;
+const int GOP_START_CODE           = 0x000001b8;
+const int ISO_11172_END_CODE       = 0x000001b9;
+const int PACK_START_CODE          = 0x000001ba;
+const int SYSTEM_HEADER_START_CODE = 0x000001bb;
+const int PROGRAM_STREAM_MAP       = 0x000001bc;
+const int PRIVATE_STREAM_1         = 0x000001bd;
+const int PADDING_STREAM           = 0x000001be;
+const int PRIVATE_STREAM_2         = 0x000001bf;
+
+MpegDemux::MpegDemux(u8* buffer, int size, int offset)
+{
+	m_buf = buffer;
+	m_len = size;
+	m_index = offset;
+	m_audioStream = 0;
+	m_audiopos = 0;
+	m_audioChannel = -1;
+	m_readSize = 0;
+}
+
+
+MpegDemux::~MpegDemux(void)
+{
+	if (m_audioStream)
+		delete [] m_audioStream;
+}
+
+void MpegDemux::setReadSize(int readSize)
+{
+	m_readSize = readSize;
+}
+
+int MpegDemux::readPesHeader(PesHeader &pesHeader, int length, int startCode) {
+	int c = 0;
+	while (length > 0) {
+		c = read8();
+		length--;
+		if (c != 0xFF) {
+			break;
+		}
+	}
+		if ((c & 0xC0) == 0x40) {
+		read8();
+		c = read8();
+		length -= 2;
+	}
+	pesHeader.pts = 0;
+	pesHeader.dts = 0;
+	if ((c & 0xE0) == 0x20) {
+		pesHeader.dts = pesHeader.pts = readPts(c);
+		length -= 4;
+		if ((c & 0x10) != 0) {
+			pesHeader.dts = readPts();
+			length -= 5;
+		}
+	} else if ((c & 0xC0) == 0x80) {
+		int flags = read8();
+		int headerLength = read8();
+		length -= 2;
+		length -= headerLength;
+		if ((flags & 0x80) != 0) {
+			pesHeader.dts = pesHeader.pts = readPts();
+			headerLength -= 5;
+			if ((flags & 0x40) != 0) {
+				pesHeader.dts = readPts();
+				headerLength -= 5;
+			}
+		}
+		if ((flags & 0x3F) != 0 && headerLength == 0) {
+			flags &= 0xC0;
+		}
+		if ((flags & 0x01) != 0) {
+			int pesExt = read8();
+			headerLength--;
+			int skip = (pesExt >> 4) & 0x0B;
+			skip += skip & 0x09;
+			if ((pesExt & 0x40) != 0 || skip > headerLength) {
+				pesExt = skip = 0;
+			}
+			this->skip(skip);
+			headerLength -= skip;
+			if ((pesExt & 0x01) != 0) {
+				int ext2Length = read8();
+				headerLength--;
+				 if ((ext2Length & 0x7F) != 0) {
+					 int idExt = read8();
+					 headerLength--;
+					 if ((idExt & 0x80) == 0) {
+						 startCode = ((startCode & 0xFF) << 8) | idExt;
+					 }
+				 }
+			}
+		}
+		skip(headerLength);
+	}
+	if (startCode == PRIVATE_STREAM_1) {
+		int channel = read8();
+		pesHeader.channel = channel;
+		length--;
+		if (channel >= 0x80 && channel <= 0xCF) {
+			// Skip audio header
+			skip(3);
+			length -= 3;
+			if (channel >= 0xB0 && channel <= 0xBF) {
+				skip(1);
+				length--;
+			}
+		} else {
+			// PSP audio has additional 3 bytes in header
+			skip(3);
+			length -= 3;
+		}
+	}
+	return length;
+}
+
+int MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
+{
+	int length = read16();
+	if (bdemux) {
+		PesHeader pesHeader(channel);
+		length = readPesHeader(pesHeader, length, startCode);
+		if (pesHeader.channel == channel || channel < 0) {
+			channel = pesHeader.channel;
+			memcpy(m_audioStream + m_audiopos, m_buf + m_index, length);
+			m_audiopos += length;
+		}
+		skip(length);
+	} else {
+		skip(length);
+	}
+	return channel;
+}
+
+void MpegDemux::demux()
+{
+	if (!m_audioStream)
+		m_audioStream = new u8[m_len - m_index];
+	while (m_index < m_len)
+	{
+		if (m_readSize != m_len && m_index + 2048 > m_readSize)
+			return;
+		// Search for start code
+		int startCode = 0xFF;
+		while ((startCode & PACKET_START_CODE_MASK) != PACKET_START_CODE_PREFIX && !isEOF()) {
+			startCode = (startCode << 8) | read8();
+		}
+		switch (startCode) {
+		    case PACK_START_CODE: {
+			    skip(10);
+			    break;
+			}
+			case SYSTEM_HEADER_START_CODE: {
+				skip(14);
+				break;
+			}
+		    case PADDING_STREAM:
+		    case PRIVATE_STREAM_2: {
+				int length = read16();
+				skip(length);
+				break;
+			}
+			case PRIVATE_STREAM_1: {
+				// Audio stream
+				m_audioChannel = demuxStream(true, startCode, m_audioChannel);
+				break;
+			}
+			case 0x1E0: case 0x1E1: case 0x1E2: case 0x1E3:
+			case 0x1E4: case 0x1E5: case 0x1E6: case 0x1E7:
+			case 0x1E8: case 0x1E9: case 0x1EA: case 0x1EB:
+			case 0x1EC: case 0x1ED: case 0x1EE: case 0x1EF: {
+				// Video Stream
+				demuxStream(false, startCode, -1);
+				break;
+			}
+		}
+	}
+}
+
+int MpegDemux::getaudioStream(u8** audioStream)
+{
+	*audioStream = m_audioStream;
+	return m_audiopos;
+}

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -1,0 +1,63 @@
+// This is a simple version MpegDemux that can get media's audio stream.
+// Thanks to JPCSP project.
+
+#pragma once
+
+#include "../../Globals.h"
+
+class MpegDemux
+{
+public:
+	MpegDemux(u8* buffer, int size, int offset);
+	~MpegDemux(void);
+
+	void setReadSize(int readSize);
+
+	void demux();
+
+	// return it's size
+	int getaudioStream(u8 **audioStream);
+private:
+	struct PesHeader {
+		long pts;
+		long dts;
+		int channel;
+
+		PesHeader(int chan) {
+			pts = 0;
+			dts = 0;
+			channel = chan;
+		}
+	};
+	int read8() {
+		return m_buf[m_index++] & 0xFF;
+	}
+	int read16() {
+		return (read8() << 8) | read8();
+	}
+	long readPts() {
+		return readPts(read8());
+	}
+	long readPts(int c) {
+		return (((long) (c & 0x0E)) << 29) | ((read16() >> 1) << 15) | (read16() >> 1);
+	}
+	bool isEOF() {
+		return m_index >= m_len;
+	}
+	void skip(int n) {
+		if (n > 0) {
+			m_index += n;
+		}
+	}
+	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
+	int demuxStream(bool bdemux, int startCode, int channel);
+private:
+	int m_index;
+	int m_len;
+	u8* m_buf;
+	u8* m_audioStream;
+	int m_audiopos;
+	int m_audioChannel;
+	int m_readSize;
+};
+

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -189,9 +189,9 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, int pixelFormat, int lin
 				for (int x = 0; x < 480; x++)
 				{
 					dst[x * 4] = src[x * 4];
-					dst[x * 4 + 1] = src[x * 4 + 3];
+					dst[x * 4 + 1] = src[x * 4 + 1];
 					dst[x * 4 + 2] = src[x * 4 + 2];
-					dst[x * 4 + 3] = src[x * 4 + 1];
+					dst[x * 4 + 3] = src[x * 4 + 3];
 				}
 			}
 			break;
@@ -214,6 +214,10 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, int pixelFormat, int lin
 	}
 
 	glBindTexture(GL_TEXTURE_2D,backbufTex);
+	if (g_Config.bLinearFiltering)
+	{
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	}
 	glTexSubImage2D(GL_TEXTURE_2D,0,0,0,480,272, GL_RGBA, GL_UNSIGNED_BYTE, convBuf);
 
 	float x, y, w, h;


### PR DESCRIPTION
I have tried to rewrite some core functions for video part.
There are still some issues, but at least it's more like a real PSP now.
And I have already got videos ending at right pos. And now videos, audios and subtitles are in sync. 
By the way, ffmpeg was defaultly used in my source codes, because I don't think we need to disable ffmpeg :)
