### PR TITLE
Send games a free packet count that makes sense to them

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -23,7 +23,8 @@
 #include "sceKernelThread.h"
 #include "HLE.h"
 #include "../HW/MediaEngine.h"
-#include "../../Core/Config.h"
+#include "Core/Config.h"
+#include "Core/Reporting.h"
 
 static bool useMediaEngine;
 
@@ -193,7 +194,7 @@ MpegContext *getMpegCtx(u32 mpegAddr) {
 	// TODO: Remove.
 	if (mpegMap.find(mpeg) == mpegMap.end())
 	{
-		ERROR_LOG(HLE, "Bad mpeg handle %08x - using last one (%08x) instead", mpeg, lastMpegHandle);
+		ERROR_LOG_REPORT(HLE, "Bad mpeg handle %08x - using last one (%08x) instead", mpeg, lastMpegHandle);
 		mpeg = lastMpegHandle;
 	}
 
@@ -633,7 +634,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 	if (ctx->mediaengine->stepVideo()) {
 		ctx->mediaengine->writeVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode);
 	}
-	ringbuffer.packetsFree = std::min(16, ctx->mediaengine->getRemainSize() / 2048);
+	ringbuffer.packetsFree = std::max(0, ringbuffer.packets - ctx->mediaengine->getBufferedSize() / 2048);
 
 	avcAu.pts = ctx->mediaengine->getVideoTimeStamp();
 
@@ -779,7 +780,7 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 		;
 	}
 
-	ringbuffer.packetsFree = std::min(16, ctx->mediaengine->getRemainSize() / 2048);
+	ringbuffer.packetsFree = std::max(0, ringbuffer.packets - ctx->mediaengine->getBufferedSize() / 2048);
 
 	avcAu.pts = ctx->mediaengine->getVideoTimeStamp();
 	ctx->avc.avcFrameStatus = 1;
@@ -886,13 +887,15 @@ void PostPutAction::run(MipsCall &call) {
 			WARN_LOG(HLE, "sceMpegRingbufferPut clamping packetsAdded old=%i new=%i", packetsAdded, ringbuffer.packetsFree);
 			packetsAdded = ringbuffer.packetsFree;
 		}
-		ctx->mediaengine->addStreamData(Memory::GetPointer(ringbuffer.data), packetsAdded * 2048);
+		int actuallyAdded = ctx->mediaengine->addStreamData(Memory::GetPointer(ringbuffer.data), packetsAdded * 2048) / 2048;
+		if (actuallyAdded != packetsAdded) {
+			WARN_LOG_REPORT(HLE, "sceMpegRingbufferPut(): unable to enqueue all added packets, going to overwrite some frames.");
+		}
 		ringbuffer.packetsRead += packetsAdded;
 		ringbuffer.packetsWritten += packetsAdded;
-		//ringbuffer.packetsFree = std::min(16, ctx->mediaengine->getRemainSize() / 2048);
-		ringbuffer.packetsFree = 0;
+		ringbuffer.packetsFree -= packetsAdded;
 	}
-	DEBUG_LOG(HLE, "packetAdded: %i packetsRead: %i packetsTotol: %i", packetsAdded, ringbuffer.packetsRead, ringbuffer.packets);
+	DEBUG_LOG(HLE, "packetAdded: %i packetsRead: %i packetsTotal: %i", packetsAdded, ringbuffer.packetsRead, ringbuffer.packets);
 
 	Memory::WriteStruct(ringAddr_, &ringbuffer);
 	call.setReturnValue(packetsAdded);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -178,7 +178,7 @@ bool MediaEngine::openContext() {
 	av_dump_format(pFormatCtx, 0, NULL, 0);
 
 	// Find the first video stream
-	for(int i = 0; i < pFormatCtx->nb_streams; i++) {
+	for(int i = 0; i < (int)pFormatCtx->nb_streams; i++) {
 		if(pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
 			m_videoStream = i;
 			break;
@@ -259,7 +259,7 @@ bool MediaEngine::loadFile(const char* filename)
 	return true;
 }
 
-void MediaEngine::addStreamData(u8* buffer, int addSize) {
+int MediaEngine::addStreamData(u8* buffer, int addSize) {
 	int size = std::min(addSize, m_streamSize - m_readSize);
 	if (size > 0) {
 		memcpy(m_pdata + m_readSize, buffer, size);
@@ -271,6 +271,7 @@ void MediaEngine::addStreamData(u8* buffer, int addSize) {
 			m_demux->demux();
 		}
 	}
+	return size;
 }
 
 bool MediaEngine::setVideoDim(int width, int height)

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -39,8 +39,10 @@ public:
 	void closeMedia();
 	bool loadStream(u8* buffer, int readSize, int StreamSize);
 	bool loadFile(const char* filename);
-	void addStreamData(u8* buffer, int addSize);
+	// Returns number of packets actually added.
+	int addStreamData(u8* buffer, int addSize);
 	int getRemainSize() { return m_streamSize - m_readSize;}
+	int getBufferedSize() { return m_readSize - m_decodePos; }
 
 	bool stepVideo();
 	bool writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);


### PR DESCRIPTION
And also, since we don't actually use a ringbuffer (maybe we should?), it reports the situation if we ever throw away data instead of writing it.

Fixes Star Ocean, Patapon, and PQ2.  Other games seem to still work fine.

-[Unknown]
