### PR TITLE
Convert videos directly to the desired format

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -631,7 +631,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 	u32 init = Memory::Read_U32(initAddr);
 	DEBUG_LOG(HLE, "*buffer = %08x, *init = %08x", buffer, init);
 
-	if (ctx->mediaengine->stepVideo()) {
+	if (ctx->mediaengine->stepVideo(ctx->videoPixelMode)) {
 		ctx->mediaengine->writeVideoImage(Memory::GetPointer(buffer), frameWidth, ctx->videoPixelMode);
 	}
 	ringbuffer.packetsFree = std::max(0, ringbuffer.packets - ctx->mediaengine->getBufferedSize() / 2048);
@@ -775,7 +775,7 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 	u32 init = Memory::Read_U32(initAddr);
 	DEBUG_LOG(HLE, "*buffer = %08x, *init = %08x", buffer, init);
 
-	if (ctx->mediaengine->stepVideo()) {
+	if (ctx->mediaengine->stepVideo(ctx->videoPixelMode)) {
 		// do nothing
 		;
 	}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -763,7 +763,7 @@ int scePsmfPlayerUpdate(u32 psmfPlayer)
 		}
 	}
 	// TODO: Once we start increasing pts somewhere, and actually know the last timestamp, do this better.
-	psmfplayer->mediaengine->stepVideo();
+	psmfplayer->mediaengine->stepVideo(videoPixelMode);
 	psmfplayer->psmfPlayerAvcAu.pts = psmfplayer->mediaengine->getVideoTimeStamp();
 	// This seems to be crazy!
 	return  hleDelayResult(0, "psmfPlayer update", 30000);

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -30,6 +30,9 @@
 #include "ChunkFile.h"
 #include "Core/HW/MpegDemux.h"
 
+enum AVPixelFormat;
+struct SwsContext;
+
 class MediaEngine
 {
 public:
@@ -44,7 +47,7 @@ public:
 	int getRemainSize() { return m_streamSize - m_readSize;}
 	int getBufferedSize() { return m_readSize - m_decodePos; }
 
-	bool stepVideo();
+	bool stepVideo(int videoPixelMode);
 	bool writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);
 	bool writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
 	                             int xpos, int ypos, int width, int height);
@@ -63,17 +66,19 @@ public:
 
 private:
     bool openContext();
+	void updateSwsFormat(int videoPixelMode);
 
 public:
 
 	void *m_pFormatCtx;
 	void *m_pCodecCtx;
 	void *m_pFrame;
-    void *m_pFrameRGB;
+	void *m_pFrameRGB;
 	void *m_pIOContext;
 	int  m_videoStream;
-    void *m_sws_ctx;
-	u8* m_buffer;
+	SwsContext *m_sws_ctx;
+	AVPixelFormat m_sws_fmt;
+	u8 *m_buffer;
 
 	int  m_desWidth;
 	int  m_desHeight;


### PR DESCRIPTION
This still converts from after YUV at least in some cases I think, but one step less anyway.

But these seem backwards, why are the BGR formats converting to RGB?  Well, I tried to keep the formats the same and videos seem to play fine...

This cuts down on time both in sws and in writeVideoImage in the common case.

-[Unknown]
