### PR TITLE
Fix a case where unitialized data could be used in sceKernelThread.cpp

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -225,14 +225,16 @@ public:
 
 		int chainedActionType = 0;
 		if (chainedAction != NULL)
-			chainedActionType = chainedAction->actionTypeID;
-		p.Do(chainedActionType);
-
-		if (chainedActionType != 0)
 		{
-			if (p.mode == p.MODE_READ)
-				chainedAction = __KernelCreateAction(chainedActionType);
-			chainedAction->DoState(p);
+			chainedActionType = chainedAction->actionTypeID;
+			p.Do(chainedActionType);
+
+			if (chainedActionType != 0)
+			{
+				if (p.mode == p.MODE_READ)
+					chainedAction = __KernelCreateAction(chainedActionType);
+				chainedAction->DoState(p);
+			}
 		}
 	}
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -809,13 +809,15 @@ void MipsCall::DoState(PointerWrap &p)
 
 	int actionTypeID = 0;
 	if (doAfter != NULL)
-		actionTypeID = doAfter->actionTypeID;
-	p.Do(actionTypeID);
-	if (actionTypeID != 0)
 	{
-		if (p.mode == p.MODE_READ)
-			doAfter = __KernelCreateAction(actionTypeID);
-		doAfter->DoState(p);
+		actionTypeID = doAfter->actionTypeID;
+		p.Do(actionTypeID);
+		if (actionTypeID != 0)
+		{
+			if (p.mode == p.MODE_READ)
+				doAfter = __KernelCreateAction(actionTypeID);
+			doAfter->DoState(p);
+		}
 	}
 }
 


### PR DESCRIPTION
If the "if (chainedAction != NULL)" check fails. chainedAction would still be used either way in the code below it.

This fixes that.
