### PR TITLE
Enclose extra psmfplayer calls in null checks where they belong.

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -683,7 +683,7 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		DEBUG_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmf");
+		ERROR_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmf");
 	}
 
 	return 0;
@@ -702,7 +702,7 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		DEBUG_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmfCB");
+		ERROR_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmfCB");
 	}
 
 	return 0;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -683,7 +683,7 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		WARN_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmf");
+		DEBUG_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmf");
 	}
 
 	return 0;
@@ -702,7 +702,7 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		WARN_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmfCB");
+		DEBUG_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmfCB");
 	}
 
 	return 0;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -673,22 +673,38 @@ int scePsmfPlayerBreak(u32 psmfPlayer)
 int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename) 
 {
 	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerSetPsmf(%08x, %s)", psmfPlayer, filename);
+
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (psmfplayer)
+	{
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
-	psmfplayer->mediaengine->loadFile(filename);
-	psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
+		psmfplayer->mediaengine->loadFile(filename);
+		psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
+	}
+	else
+	{
+		WARN_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmf");
+	}
+
 	return 0;
 }
 
 int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename) 
 {
 	ERROR_LOG(HLE, "UNIMPL scePsmfPlayerSetPsmfCB(%08x, %s)", psmfPlayer, filename);
+
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (psmfplayer)
+	{
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
-	psmfplayer->mediaengine->loadFile(filename);
-	psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
+		psmfplayer->mediaengine->loadFile(filename);
+		psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
+	}
+	else
+	{
+		WARN_LOG(HLE, "psmfplayer null in scePsmfPlayerSetPsmfCB");
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
These extra calls should be within the null checks.

I also add warning logs to each to help make debugging less of a pain in the ass in the future.
