### PR TITLE
Add a bounds check to writeVideoImageWithRange()

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1015,9 +1015,12 @@ u32 scePsmfPlayerConfigPlayer(u32 psmfPlayer, int configMode, int configAttr)
 	if (configMode == PSMF_PLAYER_CONFIG_MODE_LOOP) {
 		videoLoopStatus = configAttr;
 	} else if (configMode == PSMF_PLAYER_CONFIG_MODE_PIXEL_TYPE) {
-		videoPixelMode = configAttr;
+		// Does -1 mean default or something?
+		if (configAttr != -1) {
+			videoPixelMode = configAttr;
+		}
 	} else {
-		ERROR_LOG(HLE, "scePsmfPlayerConfigPlayer(%08x, %i, %i)", psmfPlayer , configMode, configAttr);
+		ERROR_LOG(HLE, "scePsmfPlayerConfigPlayer(%08x, %i, %i): unknown parameter", psmfPlayer, configMode, configAttr);
 	}
 
 	return 0;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -447,6 +447,11 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 	u16 *imgbuf16 = (u16 *)buffer;
 	u16 *data16 = (u16 *)data;
 
+	if (width > m_desWidth - xpos)
+		width = m_desWidth - xpos;
+	if (height > m_desHeight - ypos)
+		height = m_desHeight - ypos;
+
 	switch (videoPixelMode) {
 	case TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888:
 		data += (ypos * m_desWidth + xpos) * sizeof(u32);


### PR DESCRIPTION
Fixes crash in Jeanne d' Arc, which sends 480x480 for some reason...

-[Unknown]
