### PR TITLE
Temporary disable atrac3+ mono audio which crash on Android platform

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -985,14 +985,17 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 	} else if (atrac->codeType == PSP_MODE_AT_3_PLUS) {
 		if (atrac->atracChannels == 1) {
 			WARN_LOG(HLE, "This is an atrac3+ mono audio");
+#ifndef ANDROID
+			atrac->data_buf = new u8[atrac->first.filesize];
+			Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
+			return __AtracSetContext(atrac);
+#endif 
 		} else {
 			WARN_LOG(HLE, "This is an atrac3+ stereo audio");
+			atrac->data_buf = new u8[atrac->first.filesize];
+			Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
+			return __AtracSetContext(atrac);
 		}
-
-		atrac->data_buf = new u8[atrac->first.filesize];
-		Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
-		return __AtracSetContext(atrac);
-
 	}
 
 


### PR DESCRIPTION
Hopefully we can have a proper fix soon and we can remove this temporary fix .

 Issue #2017 
