### PR TITLE
Use PSPPointer in a few more places

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -141,7 +141,7 @@ void PSPOskDialog::ConvertUCS2ToUTF8(std::string& _string, wchar_t* input)
 	char *string = stringBuffer;
 
 	int c;
-	while (c = *input++)
+	while ((c = *input++) != 0)
 	{
 		if (c < 0x80)
 			*string++ = c;
@@ -203,14 +203,8 @@ int PSPOskDialog::Init(u32 oskPtr)
 	if (oskParams->fields[0].intext.Valid()) {
 		auto src = oskParams->fields[0].intext;
 		int c;
-		while (c = *src++)
-		{
+		while ((c = *src++) != 0)
 			inputChars += c;
-			if(c == 0x00)
-			{
-				break;
-			}
-		}
 	}
 
 	// Eat any keys pressed before the dialog inited.
@@ -287,10 +281,10 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 						}
 					}
 				} else if(i_level == 2) {
-					u32 tmp = GetIndex(kor_vowel, sw);
+					int tmp = GetIndex(kor_vowel, sw);
 					if(tmp != -1) {
 						int tmp2 = -1;
-						for(int j = 0; j < sizeof(kor_vowelCom) / 4; j+=3) {
+						for(size_t j = 0; j < sizeof(kor_vowelCom) / 4; j+=3) {
 							if(kor_vowelCom[j] == tmp && kor_vowelCom[j + 1] == i_value[1]) {
 								tmp2 = kor_vowelCom[j + 2];
 								break;
@@ -317,7 +311,7 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 							}
 						}
 					} else {
-						u32 tmp = GetIndex(kor_lcons, sw);
+						int tmp = GetIndex(kor_lcons, sw);
 
 						if(tmp == -1) {
 							string += inputChars[i];
@@ -347,10 +341,10 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 						}
 					}
 				} else if(i_level == 3) {
-					u32 tmp = GetIndex(kor_lcons, sw);
+					int tmp = GetIndex(kor_lcons, sw);
 					if(tmp != -1) {
 						int tmp2 = -1;
-						for(int j = 0; j < sizeof(kor_lconsCom) / 4; j+=3) {
+						for(size_t j = 0; j < sizeof(kor_lconsCom) / 4; j+=3) {
 							if(kor_lconsCom[j] == tmp && kor_lconsCom[j + 1] == i_value[2]) {
 								tmp2 = kor_lconsCom[j + 2];
 								break;
@@ -382,7 +376,7 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 							}
 						}
 					} else {
-						u32 tmp = GetIndex(kor_vowel, sw);
+						int tmp = GetIndex(kor_vowel, sw);
 						if(tmp == -1) {
 							string += inputChars[i];
 							if (inputChars.size() < FieldMaxLength()) {
@@ -402,9 +396,9 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 						} else {
 							if (inputChars.size() < FieldMaxLength()) {
 								int tmp2 = -1;
-								for(int j = 0; j < sizeof(kor_lconsSpr) / 4; j+=3) {
+								for(size_t j = 0; j < sizeof(kor_lconsSpr) / 4; j+=3) {
 									if(kor_lconsSpr[j] == i_value[2]) {
-										tmp2 = j;
+										tmp2 = (int)j;
 										break;
 									}
 								}
@@ -421,7 +415,7 @@ std::wstring PSPOskDialog::CombinationKorean(bool isInput)
 										i_level = 2;
 									}
 								} else {
-									u32 tmp2 = GetIndex(kor_cons, kor_lcons[i_value[2]]);
+									int tmp2 = GetIndex(kor_cons, kor_lcons[i_value[2]]);
 
 									if(tmp2 != -1) {
 										u16 code = 0xAC00 + i_value[0] * 0x24C + i_value[1] * 0x1C;
@@ -563,7 +557,7 @@ void PSPOskDialog::RemoveKorean()
 	else if(i_level == 2)
 	{
 		int tmp = -1;
-		for(int i = 2; i < sizeof(kor_vowelCom) / 4; i+=3)
+		for(size_t i = 2; i < sizeof(kor_vowelCom) / 4; i+=3)
 		{
 			if(kor_vowelCom[i] == i_value[1])
 			{
@@ -587,7 +581,7 @@ void PSPOskDialog::RemoveKorean()
 	else if(i_level == 3)
 	{
 		int tmp = -1;
-		for(int i = 2; i < sizeof(kor_lconsCom) / 4; i+=3)
+		for(size_t i = 2; i < sizeof(kor_lconsCom) / 4; i+=3)
 		{
 			if(kor_lconsCom[i] == i_value[2])
 			{
@@ -611,9 +605,9 @@ void PSPOskDialog::RemoveKorean()
 	}
 }
 
-u32 PSPOskDialog::GetIndex(const wchar_t* src, wchar_t ch)
+int PSPOskDialog::GetIndex(const wchar_t* src, wchar_t ch)
 {
-	for(u32 i = 0; i < wcslen(src); i++)
+	for(int i = 0, end = (int)wcslen(src); i < end; i++)
 	{
 		if(src[i] == ch)
 		{

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -94,7 +94,7 @@ enum SceUtilityOskInputType
 /**
 * OSK Field data
 */
-typedef struct _SceUtilityOskData
+struct SceUtilityOskData
 {
 	/** Unknown. Pass 0. */
 	int unk_00;
@@ -111,19 +111,18 @@ typedef struct _SceUtilityOskData
 	/** Unknown. Pass 0. */
 	int unk_24;
 	/** Description text */
-	u32 descPtr;
+	PSPPointer<wchar_t> desc;
 	/** Initial text */
-	u32 intextPtr;
+	PSPPointer<wchar_t> intext;
 	// Length, in unsigned shorts, including the terminator.
 	u32 outtextlength;
 	/** Pointer to the output text */
-	u32 outtextPtr;
+	PSPPointer<wchar_t> outtext;
 	/** Result. One of ::SceUtilityOskResult */
 	int result;
 	// Number of characters to allow, not including terminator (if less than outtextlength - 1.)
 	u32 outtextlimit;
-
-} SceUtilityOskData;
+};
 
 // Parameters to sceUtilityOskInitStart
 struct SceUtilityOskParams
@@ -132,7 +131,7 @@ struct SceUtilityOskParams
 	// Number of fields.
 	int fieldCount;
 	// Pointer to an array of fields (see SceUtilityOskData.)
-	u32 fieldPtr;
+	PSPPointer<SceUtilityOskData> fields;
 	SceUtilityOskState state;
 	// Maybe just padding?
 	int unk_60;
@@ -164,7 +163,7 @@ public:
 	virtual int Shutdown(bool force = false);
 	virtual void DoState(PointerWrap &p);
 private:
-	void ConvertUCS2ToUTF8(std::string& _string, const u32 em_address);
+	void ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<wchar_t> em_address);
 	void ConvertUCS2ToUTF8(std::string& _string, wchar_t* input);
 	void RenderKeyboard();
 
@@ -175,8 +174,7 @@ private:
 	u32 FieldMaxLength();
 	u32 GetIndex(const wchar_t* src, wchar_t ch);
 
-	SceUtilityOskParams *oskParams;
-	SceUtilityOskData oskData;
+	PSPPointer<SceUtilityOskParams> oskParams;
 	std::string oskDesc;
 	std::string oskIntext;
 	std::string oskOuttext;

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -172,7 +172,7 @@ private:
 	void RemoveKorean(); // for Korean character removal
 	
 	u32 FieldMaxLength();
-	u32 GetIndex(const wchar_t* src, wchar_t ch);
+	int GetIndex(const wchar_t* src, wchar_t ch);
 
 	PSPPointer<SceUtilityOskParams> oskParams;
 	std::string oskDesc;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -844,13 +844,13 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_STATUS;
 	}
 
-	if (!Memory::IsValidAddress(param->fileListAddr)) {
-		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): bad fileList address %08x", param->fileListAddr);
+	if (!param->fileList.Valid()) {
+		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): bad fileList address %08x", param->fileList.ptr);
 		// Should crash.
 		return -1;
 	}
 
-	auto fileList = Memory::GetStruct<SceUtilitySavedataFileListInfo>(param->fileListAddr);
+	auto &fileList = param->fileList;
 	if (fileList->secureEntries.Valid() && fileList->maxSecureEntries > 99) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many secure entries, %d", fileList->maxSecureEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -186,7 +186,7 @@ struct SceUtilitySavedataParam
 	u32 idListAddr;
 
 	// Function 12 FILES
-	u32 fileListAddr;
+	PSPPointer<SceUtilitySavedataFileListInfo> fileList;
 
 	// Function 22 GETSIZES
 	u32 sizeAddr;

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -269,17 +269,82 @@ struct PSPPointer
 {
 	u32 ptr;
 
-	T &operator*() const
+	inline T &operator*() const
 	{
 		return *(T *)(Memory::base + ptr);
 	}
 
-	T &operator[](int i) const
+	inline T &operator[](int i) const
 	{
 		return *((T *)(Memory::base + ptr) + i);
 	}
 
-	T *operator->() const
+	inline T *operator->() const
+	{
+		return (T *)(Memory::base + ptr);
+	}
+
+	inline PSPPointer<T> operator+(int i) const
+	{
+		PSPPointer other;
+		other.ptr = ptr + i * sizeof(T);
+		return other;
+	}
+
+	inline PSPPointer<T> &operator=(u32 p)
+	{
+		ptr = p;
+		return *this;
+	}
+
+	inline PSPPointer<T> &operator+=(int i)
+	{
+		ptr = ptr + i * sizeof(T);
+		return *this;
+	}
+
+	inline PSPPointer<T> operator-(int i) const
+	{
+		PSPPointer other;
+		other.ptr = ptr - i * sizeof(T);
+		return other;
+	}
+
+	inline PSPPointer<T> &operator-=(int i)
+	{
+		ptr = ptr - i * sizeof(T);
+		return *this;
+	}
+
+	inline PSPPointer<T> &operator++()
+	{
+		ptr += sizeof(T);
+		return *this;
+	}
+
+	inline PSPPointer<T> operator++(int i)
+	{
+		PSPPointer<T> other;
+		other.ptr = ptr;
+		ptr += sizeof(T);
+		return other;
+	}
+
+	inline PSPPointer<T> &operator--()
+	{
+		ptr -= sizeof(T);
+		return *this;
+	}
+
+	inline PSPPointer<T> operator--(int i)
+	{
+		PSPPointer<T> other;
+		other.ptr = ptr;
+		ptr -= sizeof(T);
+		return other;
+	}
+
+	inline operator T*()
 	{
 		return (T *)(Memory::base + ptr);
 	}
@@ -289,6 +354,42 @@ struct PSPPointer
 		return Memory::IsValidAddress(ptr);
 	}
 };
+
+template <typename T>
+inline bool operator==(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr == rhs.ptr;
+}
+
+template <typename T>
+inline bool operator!=(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr != rhs.ptr;
+}
+
+template <typename T>
+inline bool operator<(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr < rhs.ptr;
+}
+
+template <typename T>
+inline bool operator>(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr > rhs.ptr;
+}
+
+template <typename T>
+inline bool operator<=(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr <= rhs.ptr;
+}
+
+template <typename T>
+inline bool operator>=(const PSPPointer<T> &lhs, const PSPPointer<T> &rhs)
+{
+	return lhs.ptr >= rhs.ptr;
+}
 
 #endif
 


### PR DESCRIPTION
I normally don't like to change things that aren't broken, but I think using this syntax is much clearer in general, and much easier to savestate correctly.

Also adds pointer arithmetic to PSPPointer.

-[Unknown]
