### PR TITLE
Bail out on a delay slot in VFPU on arm also

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -265,6 +265,10 @@ void Jit::Comp_FPUBranch(u32 op)
 // If likely is set, discard the branch slot if NOT taken.
 void Jit::BranchVFPUFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 {
+	if (js.inDelaySlot) {
+		ERROR_LOG_REPORT(JIT, "Branch in VFPU delay slot at %08x", js.compilerPC);
+		return;
+	}
 	int offset = (signed short)(op & 0xFFFF) << 2;
 	u32 targetAddr = js.compilerPC + offset + 4;
 


### PR DESCRIPTION
Otherwise we loop infinitely.  Already bails in x86 jit.

Workaround for #1926.  Should fix #1679, definitely fixes Zettai Hero Project.

-[Unknown]
