### PR TITLE
Savestate dialogs properly, avoiding wrong status

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -112,6 +112,10 @@ void PSPDialog::DoState(PointerWrap &p)
 	p.Do(status);
 	p.Do(lastButtons);
 	p.Do(buttons);
+	p.Do(fadeTimer);
+	p.Do(isFading);
+	p.Do(fadeIn);
+	p.Do(fadeValue);
 	p.DoMarker("PSPDialog");
 }
 


### PR DESCRIPTION
Might cause a crash (in the game probably) if the status is set wrong due to a fade.  Fixes #2047.

The issue is that fading a certain way changes status, but fading wasn't included in the state.  Probably fixes other dialogs too.

-[Unknown]
