### PR TITLE
Fix crash in MediaEngine by disabling dump log

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -175,7 +175,7 @@ bool MediaEngine::openContext() {
 		return false;
 
 	// Dump information about file onto standard error
-	av_dump_format(pFormatCtx, 0, NULL, 0);
+	//av_dump_format(pFormatCtx, 0, NULL, 0);
 
 	// Find the first video stream
 	for(int i = 0; i < (int)pFormatCtx->nb_streams; i++) {


### PR DESCRIPTION
Was causing crashes in Blackberry (Issue #2074) and potentially Windows (Issue #2024).
