### PR TITLE
More improvement for mpeg pts.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -975,7 +975,7 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	int result = 0;
 
 	sceAu.pts = ctx->mediaengine->getVideoTimeStamp();
-	if (sceAu.pts >= ctx->mediaengine->getLastTimeStamp()) {
+	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(HLE, "video end reach. pts: %i dts: %i", (int)sceAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		mpegRingbuffer.packetsFree = mpegRingbuffer.packets;
 		Memory::WriteStruct(ctx->mpegRingbufferAddr, &mpegRingbuffer);
@@ -1039,7 +1039,7 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	int result = 0;
 
 	sceAu.pts = ctx->mediaengine->getAudioTimeStamp();
-	if (sceAu.pts >= ctx->mediaengine->getLastTimeStamp()) {
+	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(HLE, "video end reach. pts: %i dts: %i", (int)sceAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		mpegRingbuffer.packetsFree = mpegRingbuffer.packets;
 		Memory::WriteStruct(ctx->mpegRingbufferAddr, &mpegRingbuffer);

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -58,6 +58,8 @@ public:
 	s64 getAudioTimeStamp();
 	s64 getLastTimeStamp();
 
+	bool IsVideoEnd() { return m_isVideoEnd;}
+
 	void DoState(PointerWrap &p) {
 		p.Do(m_streamSize);
 		p.Do(m_readSize);
@@ -93,4 +95,6 @@ public:
 	int m_audioPos;
 	void* m_audioContext;
 	s64 m_audiopts;
+
+	bool m_isVideoEnd;
 };


### PR DESCRIPTION
The mpeglastTimeStamp is probably wrong in some videos. So a video is
end only if there is no more data for decoding.
Btw, based on my tests, it seems most games already know when the video is end, and they would end videos when the video end has reached and no needs for any error returns. So in most of time, we should not get "video end reach" info logs, and videos would end by themselves.
