### PR TITLE
Multiply by the base color in ambient lighting.

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -350,7 +350,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		if (gstate.lightEnable[l] & 1)
 		{
 			Color4 lightAmbient(gstate_c.lightColor[0][l], 0.0f);
-			lightSum0 += (lightAmbient + diff) * lightScale;
+			lightSum0 += (lightAmbient * *ambient + diff) * lightScale;
 		}
 	}
 

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -476,7 +476,7 @@ void GenerateVertexShader(int prim, char *buffer) {
 				WRITE(p, "  if (dot%i > 0.0)\n", i);
 				WRITE(p, "    lightSum1 += u_lightspecular%i * %s * (pow(dot%i, u_matspecular.a) %s);\n", i, specularStr, i, timesLightScale);
 			}
-			WRITE(p, "  lightSum0.rgb += (u_lightambient%i + diffuse)%s;\n", i, timesLightScale);
+			WRITE(p, "  lightSum0.rgb += (u_lightambient%i * %s.rgb + diffuse)%s;\n", i, ambientStr, timesLightScale);
 		}
 
 		if (gstate.isLightingEnabled()) {


### PR DESCRIPTION
JPCSP seems to do it this way.  Fixes #1692, and makes it consistent with specular and diffuse, which seems right.

Does not fix Adventures 2 Go being too dark, though (or change it at all...)

-[Unknown]
