### PR TITLE
Fix crash for invalid mpeg header.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -257,17 +257,16 @@ void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 	ctx->avc.avcFrameStatus = 0;
 
-	//if (!isCurrentMpegAnalyzed) {
-	//SceMpegRingBuffer ringbuffer;
-	//InitRingbuffer(&ringbuffer, 0, 0, 0, 0, 0);
-	// ????
-	//Memory::WriteStruct(ctx->mpegRingbufferAddr, &ringbuffer);
-	//}
-
 	ctx->videoFrameCount = 0;
 	ctx->audioFrameCount = 0;
 	ctx->endOfAudioReached = false;
 	ctx->endOfVideoReached = false;
+
+	if (ctx->mpegMagic != PSMF_MAGIC || ctx->mpegVersion < 0 ||
+		(ctx->mpegOffset & 2047) != 0 || ctx->mpegOffset == 0) {
+		// mpeg header is invalid!
+		return;
+	}
 
 	if (ctx->mediaengine && (ctx->mpegStreamSize > 0) && !ctx->isAnalyzed) {
 		// init mediaEngine

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -91,6 +91,9 @@ MediaEngine::MediaEngine(): m_streamSize(0), m_readSize(0), m_pdata(0) {
 	m_buffer = 0;
 	m_demux = 0;
 	m_audioContext = 0;
+	m_pdata = 0;
+	m_streamSize = 0;
+	m_readSize = 0;
 	m_isVideoEnd = false;
 }
 
@@ -239,6 +242,8 @@ bool MediaEngine::loadStream(u8* buffer, int readSize, int StreamSize)
 	m_readSize = readSize;
 	m_streamSize = StreamSize;
 	m_pdata = new u8[StreamSize];
+	if (!m_pdata)
+		return false;
 	memcpy(m_pdata, buffer, m_readSize);
 	
 	if (readSize > 0x2000)
@@ -251,6 +256,8 @@ bool MediaEngine::loadFile(const char* filename)
 	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
 	s64 infosize = info.size;
 	u8* buf = new u8[infosize];
+	if (!buf)
+		return false;
 	u32 h = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
 	pspFileSystem.ReadFile(h, buf, infosize);
 	pspFileSystem.CloseFile(h);
@@ -275,7 +282,7 @@ bool MediaEngine::loadFile(const char* filename)
 
 int MediaEngine::addStreamData(u8* buffer, int addSize) {
 	int size = std::min(addSize, m_streamSize - m_readSize);
-	if (size > 0) {
+	if (size > 0 && m_pdata) {
 		memcpy(m_pdata + m_readSize, buffer, size);
 		m_readSize += size;
 		if (!m_pFormatCtx && m_readSize > 0x2000)


### PR DESCRIPTION
Sometimes, mpeg header is invalid in some games ( caused by some errors?). This may fix crash while mpeg header is invalid.
