### PR TITLE
Finally fix choppy cg audio, bgm, and even some missing bgm, voice, se.

### DIFF
--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -110,7 +110,10 @@ u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 sample
 			chans[chan].rightVolume = rightvol;
 		}
 		chans[chan].sampleAddress = samplePtr;
-		return __AudioEnqueue(chans[chan], chan, true);
+		int ret = __AudioEnqueue(chans[chan], chan, true);
+		if (chans[chan].waitingThreads.size() == 0)
+			return hleDelayResult(ret, "output block", 1000);
+		return ret;
 	}
 }
 
@@ -321,7 +324,10 @@ u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr){
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].leftVolume = vol;
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].rightVolume = vol;
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleAddress = dataPtr;
-	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_OUTPUT2], PSP_AUDIO_CHANNEL_OUTPUT2, true);
+	int ret = __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_OUTPUT2], PSP_AUDIO_CHANNEL_OUTPUT2, true);
+	if (chans[PSP_AUDIO_CHANNEL_OUTPUT2].waitingThreads.size() == 0)
+		return hleDelayResult(ret, "output block", 1000);
+	return ret;
 }
 
 u32 sceAudioOutput2ChangeLength(u32 sampleCount){


### PR DESCRIPTION
Tested with many games. 
Now CGs in FF7CC, 3rd birthday, Wipeout Pulse and so on had got full speed cg videos and audios. And Wipeout Pulse had also got smoothly bgm.
In addition, 7th Dragon 2020 also got those missing bgm and voice.

Btw, the delay value probably is not accurate. And I only implements for sceAudioOutputPannedBlocking and sceAudioOutput2OutputBlocking right now.
Probably sceAudioOutputBlocking and sceAudioSRCOutputBlocking do it in the same way, but I have not got any games for tests that.
