### PR TITLE
Correct sceKernelChangeThreadPriority() and sched fixes

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -678,7 +678,7 @@ const HLEFunction ThreadManForUser[] =
 
 	{0xFCCFAD26,WrapI_I<sceKernelCancelWakeupThread>,"sceKernelCancelWakeupThread"},
 	{0x1AF94D03,0,"sceKernelDonateWakeupThread"},
-	{0xea748e31,sceKernelChangeCurrentThreadAttr,"sceKernelChangeCurrentThreadAttr"},
+	{0xea748e31,WrapI_UU<sceKernelChangeCurrentThreadAttr>,"sceKernelChangeCurrentThreadAttr"},
 	{0x71bc9871,WrapI_II<sceKernelChangeThreadPriority>,"sceKernelChangeThreadPriority"},
 	{0x446D8DE6,WrapI_CUUIUU<sceKernelCreateThread>,"sceKernelCreateThread"},
 	{0x9fa03cd3,WrapI_I<sceKernelDeleteThread>,"sceKernelDeleteThread"},

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -679,7 +679,7 @@ const HLEFunction ThreadManForUser[] =
 	{0xFCCFAD26,WrapI_I<sceKernelCancelWakeupThread>,"sceKernelCancelWakeupThread"},
 	{0x1AF94D03,0,"sceKernelDonateWakeupThread"},
 	{0xea748e31,sceKernelChangeCurrentThreadAttr,"sceKernelChangeCurrentThreadAttr"},
-	{0x71bc9871,sceKernelChangeThreadPriority,"sceKernelChangeThreadPriority"},
+	{0x71bc9871,WrapI_II<sceKernelChangeThreadPriority>,"sceKernelChangeThreadPriority"},
 	{0x446D8DE6,WrapI_CUUIUU<sceKernelCreateThread>,"sceKernelCreateThread"},
 	{0x9fa03cd3,WrapI_I<sceKernelDeleteThread>,"sceKernelDeleteThread"},
 	{0xBD123D9E,sceKernelDelaySysClockThread,"sceKernelDelaySysClockThread"},

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2276,6 +2276,12 @@ int sceKernelChangeThreadPriority(SceUID threadID, int priority)
 	Thread *thread = kernelObjects.Get<Thread>(threadID, error);
 	if (thread)
 	{
+		if (thread->isStopped())
+		{
+			ERROR_LOG_REPORT(HLE, "sceKernelChangeThreadPriority(%i, %i): thread is dormant", threadID, priority);
+			return SCE_KERNEL_ERROR_DORMANT;
+		}
+
 		if (priority < 0x08 || priority > 0x77)
 		{
 			ERROR_LOG_REPORT(HLE, "sceKernelChangeThreadPriority(%i, %i): bogus priority", threadID, priority);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2248,17 +2248,22 @@ void sceKernelGetThreadCurrentPriority()
 	RETURN(retVal);
 }
 
-void sceKernelChangeCurrentThreadAttr()
+int sceKernelChangeCurrentThreadAttr(u32 clearAttr, u32 setAttr)
 {
-	int clearAttr = PARAM(0);
-	int setAttr = PARAM(1);
-	DEBUG_LOG(HLE,"0 = sceKernelChangeCurrentThreadAttr(clear = %08x, set = %08x", clearAttr, setAttr);
+	// Seems like this is the only allowed attribute?
+	if ((clearAttr & ~PSP_THREAD_ATTR_VFPU) != 0 || (setAttr & ~PSP_THREAD_ATTR_VFPU) != 0)
+	{
+		ERROR_LOG_REPORT(HLE, "0 = sceKernelChangeCurrentThreadAttr(clear = %08x, set = %08x): invalid attr", clearAttr, setAttr);
+		return SCE_KERNEL_ERROR_ILLEGAL_ATTR;
+	}
+
+	DEBUG_LOG(HLE, "0 = sceKernelChangeCurrentThreadAttr(clear = %08x, set = %08x)", clearAttr, setAttr);
 	Thread *t = __GetCurrentThread();
 	if (t)
 		t->nt.attr = (t->nt.attr & ~clearAttr) | setAttr;
 	else
-		ERROR_LOG(HLE, "%s(): No current thread?", __FUNCTION__);
-	RETURN(0);
+		ERROR_LOG_REPORT(HLE, "%s(): No current thread?", __FUNCTION__);
+	return 0;
 }
 
 int sceKernelChangeThreadPriority(SceUID threadID, int priority)

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -44,7 +44,7 @@ int sceKernelWaitThreadEnd(SceUID threadID, u32 timeoutPtr);
 u32 sceKernelReferThreadStatus(u32 uid, u32 statusPtr);
 u32 sceKernelReferThreadRunStatus(u32 uid, u32 statusPtr);
 int sceKernelReleaseWaitThread(SceUID threadID);
-void sceKernelChangeCurrentThreadAttr();
+int sceKernelChangeCurrentThreadAttr(u32 clearAttr, u32 setAttr);
 int sceKernelRotateThreadReadyQueue(int priority);
 int sceKernelCheckThreadStack();
 int sceKernelSuspendThread(SceUID threadID);

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -24,7 +24,7 @@
 #include "sceKernelModule.h"
 #include "HLE.h"
 
-void sceKernelChangeThreadPriority();
+int sceKernelChangeThreadPriority(SceUID threadID, int priority);
 int __KernelCreateThread(const char *threadName, SceUID moduleID, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
 int sceKernelCreateThread(const char *threadName, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
 int sceKernelDelayThread(u32 usec);

--- a/test.py
+++ b/test.py
@@ -166,6 +166,7 @@ tests_next = [
   "threads/mutex/cancel",
   "threads/scheduling/dispatch",
   "threads/scheduling/scheduling",
+  "threads/threads/change",
   "threads/threads/create",
   "threads/threads/refer",
   "threads/threads/start",


### PR DESCRIPTION
Please accept hrydgard/pspautotests#79 first.

May help Gran Turismo:
http://forums.ppsspp.org/showthread.php?tid=1601&pid=26924#pid26924

Has some interesting functionality, seems to work to duplicate the current thread's priority onto another, and also to yield.

Also adds checks to sceKernelChangeCurrentThreadAttr() and fixes the priority of a thread that is restarted (which has interesting logic...)  Tried a number of games that call these, and they all seem happy.

-[Unknown]
