### PR TITLE
Fixed a build error on non-win32 platfroms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,6 +662,7 @@ add_library(xbrz STATIC
 include_directories(ext/xbrz)
 
 set(CoreExtra)
+set(CoreExtraLibs)
 if(ARM)
 	set(CoreExtra ${CoreExtra}
 		Core/MIPS/ARM/ArmAsm.cpp
@@ -693,6 +694,12 @@ elseif(X86)
 		Core/MIPS/x86/RegCache.h
 		Core/MIPS/x86/RegCacheFPU.cpp
 		Core/MIPS/x86/RegCacheFPU.h)
+endif()
+
+# atrac3plus.cpp used dl* functions on non-win32 platforms
+# Core needs to be linked with dl on these platforms
+if(NOT WIN32)
+  set(CoreExtraLibs ${CoreExtraLibs} dl)
 endif()
 
 # 'ppsspp_jni' on ANDROID, 'Core' everywhere else
@@ -916,7 +923,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Globals.h
 	git-version.cpp)
 target_link_libraries(${CoreLibName} Common native kirk cityhash xbrz
-	${GLEW_LIBRARIES} ${OPENGL_LIBRARIES})
+	${CoreExtraLibs} ${GLEW_LIBRARIES} ${OPENGL_LIBRARIES})
 setup_target_project(${CoreLibName} Core)
 
 # Generate git-version.cpp at build time.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,7 +698,7 @@ endif()
 
 # atrac3plus.cpp used dl* functions on non-win32 platforms
 # Core needs to be linked with dl on these platforms
-if(NOT WIN32)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CoreExtraLibs ${CoreExtraLibs} ${CMAKE_DL_LIBS})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,7 +699,7 @@ endif()
 # atrac3plus.cpp used dl* functions on non-win32 platforms
 # Core needs to be linked with dl on these platforms
 if(NOT WIN32)
-  set(CoreExtraLibs ${CoreExtraLibs} dl)
+  set(CoreExtraLibs ${CoreExtraLibs} ${CMAKE_DL_LIBS})
 endif()
 
 # 'ppsspp_jni' on ANDROID, 'Core' everywhere else


### PR DESCRIPTION
Due to dl\* functions usage in Core/HW/atrac3plus.cpp ([here](https://github.com/hrydgard/ppsspp/blob/master/Core/HW/atrac3plus.cpp#L4)) on non-windows
platforms, Core library needs to be linked with -ldl flag on these
platforms.

Added a CoreExtraLibs variable in CMakeLists.txt to handle all
platform-dependent dependencies of Core, and added dl to this variable
on non-win32 platforms.
