### PR TITLE
Improvements to sceMpeg: fix end cutoff, early audio end, and minor

### DIFF
--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -493,6 +493,11 @@ public:
 
 	bool GetIDType(SceUID handle, int *type) const
 	{
+		if (handle < handleOffset || handle >= handleOffset+maxCount || !occupied[handle-handleOffset])
+		{
+			ERROR_LOG(HLE, "Kernel: Bad object handle %i (%08x)", handle, handle);
+			return false;
+		}
 		KernelObject *t = pool[handle - handleOffset];
 		*type = t->GetIDType();
 		return true;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1053,7 +1053,8 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		streamInfo->second.needsReset = false;
 	}
 
-	if (mpegRingbuffer.packetsFree == mpegRingbuffer.packets) {
+	// The audio can end earlier than the video does.
+	if (mpegRingbuffer.packetsFree == mpegRingbuffer.packets || (ctx->mediaengine->IsAudioEnd() && !ctx->mediaengine->IsVideoEnd())) {
 		DEBUG_LOG(HLE, "PSP_ERROR_MPEG_NO_DATA=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
 		// TODO: Does this really delay?
 		return hleDelayResult(PSP_ERROR_MPEG_NO_DATA, "mpeg get atrac", mpegDecodeErrorDelayMs);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -928,9 +928,13 @@ u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
 
 	// Execute callback function as a direct MipsCall, no blocking here so no messing around with wait states etc
 	if (ringbuffer.callback_addr) {
-		PostPutAction *action = (PostPutAction *) __KernelCreateAction(actionPostPut);
+		PostPutAction *action = (PostPutAction *)__KernelCreateAction(actionPostPut);
 		action->setRingAddr(ringbufferAddr);
-		u32 args[3] = {(u32)ringbuffer.data, numPackets, (u32)ringbuffer.callback_args};
+		// TODO: Should call this multiple times until we get numPackets.
+		// Normally this would be if it did not read enough, but also if available > packets.
+		// Should ultimately return the TOTAL number of returned packets.
+		u32 packetsThisRound = std::min(numPackets, (u32)ringbuffer.packets);
+		u32 args[3] = {(u32)ringbuffer.data, packetsThisRound, (u32)ringbuffer.callback_args};
 		__KernelDirectMipsCall(ringbuffer.callback_addr, action, args, 3, false);
 	} else {
 		ERROR_LOG(HLE, "sceMpegRingbufferPut: callback_addr zero");

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -359,7 +359,7 @@ u32 sceMpegRingbufferConstruct(u32 ringbufferAddr, u32 numPackets, u32 data, u32
 
 u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop)
 {
-	if (!g_Config.bUseMediaEngine){
+	if (!g_Config.bUseMediaEngine) {
 		WARN_LOG(HLE, "Media Engine disabled");
 		return -1;
 	}
@@ -418,7 +418,7 @@ u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 f
 
 	INFO_LOG(HLE, "%08x=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)",
 		mpegHandle, mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
-	return 0;
+	return hleDelayResult(0, "mpeg create", 29000);
 }
 
 int sceMpegDelete(u32 mpeg)

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -40,6 +40,8 @@ enum {
 	ERROR_PSMFPLAYER_NO_MORE_DATA                       = 0x8061600c,
 
 	ERROR_MPEG_NO_DATA                                  = 0x80618001,
+	ERROR_MPEG_ALREADY_INIT                             = 0x80618005,
+	ERROR_MPEG_NOT_YET_INIT                             = 0x80618009,
 };
 
 // MPEG statics.

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -555,8 +555,7 @@ u32 scePsmfQueryStreamOffset(u32 bufferAddr, u32 offsetAddr)
 	if (Memory::IsValidAddress(offsetAddr)) {
 		Memory::Write_U32(bswap32(Memory::Read_U32(bufferAddr + PSMF_STREAM_OFFSET_OFFSET)), offsetAddr);
 	}
-	// return 0 breaks history mode in Saint Seiya Omega
-	return 1; 
+	return 0;
 }
 
 u32 scePsmfQueryStreamSize(u32 bufferAddr, u32 sizeAddr)

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -367,8 +367,6 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 
 	AVFormatContext *pFormatCtx = (AVFormatContext*)m_pFormatCtx;
 	AVCodecContext *pCodecCtx = (AVCodecContext*)m_pCodecCtx;
-	AVFrame *pFrame = (AVFrame*)m_pFrame;
-	AVFrame *pFrameRGB = (AVFrame*)m_pFrameRGB;
 	if ((!m_pFrame)||(!m_pFrameRGB))
 		return false;
 	AVPacket packet;
@@ -390,7 +388,7 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 					pCodecCtx->height, m_pFrameRGB->data, m_pFrameRGB->linesize);
 
 				int firstTimeStamp = bswap32(*(int*)(m_pdata + 86));
-				m_videopts = pFrame->pkt_dts + pFrame->pkt_duration - firstTimeStamp;
+				m_videopts = m_pFrame->pkt_dts + av_frame_get_pkt_duration(m_pFrame) - firstTimeStamp;
 				bGetFrame = true;
 			}
 			if (result <= 0 && dataEnd) {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -394,13 +394,12 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 				bGetFrame = true;
 			}
 			if (result <= 0 && dataEnd) {
+				m_isVideoEnd = !bGetFrame && m_readSize >= m_streamSize;
 				break;
 			}
 		}
 		av_free_packet(&packet);
 	}
-	if (!bGetFrame && m_readSize >= m_streamSize)
-		m_isVideoEnd = true;
 	return bGetFrame;
 #else
 	return true;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -92,6 +92,7 @@ MediaEngine::MediaEngine(): m_streamSize(0), m_readSize(0), m_decodedPos(0), m_p
 	m_demux = 0;
 	m_audioContext = 0;
 	m_isVideoEnd = false;
+	m_isAudioEnd = false;
 }
 
 MediaEngine::~MediaEngine() {
@@ -130,6 +131,7 @@ void MediaEngine::closeMedia() {
 	m_demux = 0;
 	Atrac3plus_Decoder::CloseContext(&m_audioContext);
 	m_isVideoEnd = false;
+	m_isAudioEnd = false;
 }
 
 int _MpegReadbuffer(void *opaque, uint8_t *buf, int buf_size)
@@ -220,6 +222,7 @@ bool MediaEngine::openContext() {
 	m_audioPos = 0;
 	m_audioContext = Atrac3plus_Decoder::OpenContext();
 	m_isVideoEnd = false;
+	m_isAudioEnd = false;
 	m_decodedPos = mpegoffset;
 #endif // USE_FFMPEG
 	return true;
@@ -561,6 +564,7 @@ int MediaEngine::getAudioSamples(u8* buffer) {
 	int audioSize = m_demux->getaudioStream(&audioStream);
 	if (m_audioPos >= audioSize || !isHeader(audioStream, m_audioPos))
 	{
+		m_isAudioEnd = m_demux->getFilePosition() >= m_streamSize;
 		return 0;
 	}
 	u8 headerCode1 = audioStream[2];
@@ -588,6 +592,7 @@ int MediaEngine::getAudioSamples(u8* buffer) {
 	} else
 		m_audioPos = audioSize;
 	m_audiopts += 4180;
+	m_decodedPos += frameSize;
 	return outbytes;
 }
 

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -32,6 +32,7 @@
 
 struct SwsContext;
 struct AVFrame;
+struct AVIOContext;
 
 class MediaEngine
 {
@@ -45,7 +46,7 @@ public:
 	// Returns number of packets actually added.
 	int addStreamData(u8* buffer, int addSize);
 	int getRemainSize() { return m_streamSize - m_readSize;}
-	int getBufferedSize() { return m_readSize - m_decodePos; }
+	int getBufferedSize();
 
 	bool stepVideo(int videoPixelMode);
 	bool writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);
@@ -76,7 +77,7 @@ public:
 	void *m_pCodecCtx;
 	AVFrame *m_pFrame;
 	AVFrame *m_pFrameRGB;
-	void *m_pIOContext;
+	AVIOContext *m_pIOContext;
 	int  m_videoStream;
 	SwsContext *m_sws_ctx;
 	int m_sws_fmt;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -33,6 +33,8 @@
 struct SwsContext;
 struct AVFrame;
 struct AVIOContext;
+struct AVFormatContext;
+struct AVCodecContext;
 
 class MediaEngine
 {
@@ -73,8 +75,8 @@ private:
 
 public:
 
-	void *m_pFormatCtx;
-	void *m_pCodecCtx;
+	AVFormatContext *m_pFormatCtx;
+	AVCodecContext *m_pCodecCtx;
 	AVFrame *m_pFrame;
 	AVFrame *m_pFrameRGB;
 	AVIOContext *m_pIOContext;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -89,7 +89,8 @@ public:
 	int  m_desHeight;
 	int m_streamSize;
 	int m_readSize;
-	int m_decodePos;
+	int m_decodeNextPos;
+	s64 m_decodedPos;
 	int m_bufSize;
 	s64 m_videopts;
 	u8* m_pdata;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -61,7 +61,8 @@ public:
 	s64 getAudioTimeStamp();
 	s64 getLastTimeStamp();
 
-	bool IsVideoEnd() { return m_isVideoEnd;}
+	bool IsVideoEnd() { return m_isVideoEnd; }
+	bool IsAudioEnd() { return m_isAudioEnd; }
 
 	void DoState(PointerWrap &p) {
 		p.Do(m_streamSize);
@@ -101,4 +102,5 @@ public:
 	s64 m_audiopts;
 
 	bool m_isVideoEnd;
+	bool m_isAudioEnd;
 };

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -15,8 +15,9 @@ public:
 
 	void demux();
 
-	// return it's size
+	// return its size
 	int getaudioStream(u8 **audioStream);
+	int getFilePosition() { return m_index; }
 private:
 	struct PesHeader {
 		long pts;


### PR DESCRIPTION
Unfortunately it's a bunch of changes, but most are needed for the games I tested to all be happy.

First, there are a few that aren't really necessary, but match my tests / fix crashes in it:
- sceKernelGetThreadmanIdType() crash fix (was using this to decipher the sceMpeg structs in my tests.)
- sceMpeg() double init error (this clearly happens on firmware, but didn't see any games that cared.)
- Correct scePsmfQueryStreamOffset() return value (@raven02 confirmed 1 was no longered needed in #2128.)
- Makes sceMpegCreate() delay a bit, might improve timing, definitely happens on firmware.

Aside from that, this:
- Tries to calculate the packets on the ringbuffer much more accurately, since Wipeout _does not_ like it when all the packets are consumed right away.
- Makes minor adjustments to how mpeg put works (it's still not correct but it should avoid overflow now like the firmware actually does, see comment on how it's off but it's a pain to fix and probably not important.)
- Decodes re-ordered I/P frames.  These get moved to the end based on how MPEGs are decoded, so if you don't keep calling decode, you never get them.  FFmpeg's example shows that you should keep calling it with a NULL packet (but almost no other examples actually do, go figure..?)
- Detects end of video more accurately to go along with that.
- Detects end of audio more accurately because the above made the Crisis Core video never end (since the audio ends earlier.)  Also confirmed via a test with the Senjou no Valkyria 3 SEGA video, which ends audio early.

I pulled out this commit, but my tests show this happening: c656df2d6eb89217476675bf4ed6e09a800b24eb
I can't hear audio in virtually any video so no idea if it's correct.

@oioitff, if you want to take a look at these changes and tell me if anything looks wrong I'd appreciate it.

-[Unknown]
