### PR TITLE
Invalidate FBOs when written to a bit more

### DIFF
--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Globals.h"
+#include "Core/Reporting.h"
 #include "Core/HLE/HLE.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
@@ -32,7 +33,12 @@ u32 sceDmacMemcpy(u32 dst, u32 src, u32 size)
 
 	Memory::Memcpy(dst, Memory::GetPointer(src), size);
 
-	gpu->InvalidateCache(dst, size, GPU_INVALIDATE_HINT);
+	src &= ~0x40000000;
+	// TODO: If we do this it'll probably black out the framebuffer?
+	if (src < PSP_GetVidMemBase() || src > PSP_GetVidMemEnd())
+		gpu->InvalidateCache(dst, size, GPU_INVALIDATE_HINT);
+	else
+		WARN_LOG_REPORT(HLE, "sceDmacMemcpy(): FBO blit?");
 	return 0;
 }
 

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -16,13 +16,23 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Globals.h"
-#include "HLE.h"
+#include "Core/HLE/HLE.h"
+#include "GPU/GPUInterface.h"
+#include "GPU/GPUState.h"
 
 u32 sceDmacMemcpy(u32 dst, u32 src, u32 size)
 {
+	if (!Memory::IsValidAddress(dst) || !Memory::IsValidAddress(src))
+	{
+		ERROR_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid address", dst, src, size);
+		return 0;
+	}
+
 	DEBUG_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
-	// TODO: check the addresses.
+
 	Memory::Memcpy(dst, Memory::GetPointer(src), size);
+
+	gpu->InvalidateCache(dst, size, GPU_INVALIDATE_HINT);
 	return 0;
 }
 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -22,6 +22,8 @@
 #include "Core/HLE/scePsmf.h"
 #include "Core/HLE/sceMpeg.h"
 #include "Core/HW/MediaEngine.h"
+#include "GPU/GPUInterface.h"
+#include "GPU/GPUState.h"
 
 #include <map>
 
@@ -873,8 +875,10 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 		int frameWidth = Memory::Read_U32(videoDataAddr);
         u32 displaybuf = Memory::Read_U32(videoDataAddr + 4);
         int displaypts = Memory::Read_U32(videoDataAddr + 8);
-		if (psmfplayer->mediaengine->stepVideo(videoPixelMode))
-			psmfplayer->mediaengine->writeVideoImage(Memory::GetPointer(displaybuf), frameWidth, videoPixelMode);
+		if (psmfplayer->mediaengine->stepVideo(videoPixelMode)) {
+			int displaybufSize = psmfplayer->mediaengine->writeVideoImage(Memory::GetPointer(displaybuf), frameWidth, videoPixelMode);
+			gpu->InvalidateCache(displaybuf, displaybufSize, GPU_INVALIDATE_SAFE);
+		}
 		psmfplayer->psmfPlayerAvcAu.pts = psmfplayer->mediaengine->getVideoTimeStamp();
 		Memory::Write_U32(psmfplayer->psmfPlayerAvcAu.pts, videoDataAddr + 8);
 	}

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -409,7 +409,7 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 #endif // USE_FFMPEG
 }
 
-bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode) {
+int MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode) {
 	if ((!m_pFrame)||(!m_pFrameRGB))
 		return false;
 #ifdef USE_FFMPEG
@@ -420,6 +420,7 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 	u8 *data = m_pFrameRGB->data[0];
 	u16 *imgbuf16 = (u16 *)buffer;
 	u16 *data16 = (u16 *)data;
+	int videoImageSize = 0;
 
 	switch (videoPixelMode) {
 	case TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888:
@@ -428,6 +429,7 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 			data += width * sizeof(u32);
 			imgbuf += frameWidth * sizeof(u32);
 		}
+		videoImageSize = frameWidth * sizeof(u32) * height;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_BGR5650:
@@ -436,6 +438,7 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 			data += width * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * height;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR5551:
@@ -445,6 +448,7 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 			}
 			imgbuf16 += (frameWidth - width);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * height;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR4444:
@@ -454,6 +458,7 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 			}
 			imgbuf16 += (frameWidth - width);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * height;
 		break;
 
 	default:
@@ -461,10 +466,10 @@ bool MediaEngine::writeVideoImage(u8* buffer, int frameWidth, int videoPixelMode
 		break;
 	}
 #endif // USE_FFMPEG
-	return true;
+	return videoImageSize;
 }
 
-bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
+int MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
 	                             int xpos, int ypos, int width, int height) {
 	if ((!m_pFrame)||(!m_pFrameRGB))
 		return false;
@@ -474,6 +479,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 	u8 *data = m_pFrameRGB->data[0];
 	u16 *imgbuf16 = (u16 *)buffer;
 	u16 *data16 = (u16 *)data;
+	int videoImageSize = 0;
 
 	if (width > m_desWidth - xpos)
 		width = m_desWidth - xpos;
@@ -488,6 +494,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 			data += m_desWidth * sizeof(u32);
 			imgbuf += frameWidth * sizeof(u32);
 		}
+		videoImageSize = frameWidth * sizeof(u32) * m_desHeight;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_BGR5650:
@@ -497,6 +504,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR5551:
@@ -508,6 +516,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 			imgbuf16 += (frameWidth - width);
 			data16 += (m_desWidth - width);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;
 
 	case TPSM_PIXEL_STORAGE_MODE_16BIT_ABGR4444:
@@ -519,6 +528,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 			imgbuf16 += (frameWidth - width);
 			data16 += (m_desWidth - width);
 		}
+		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;
 
 	default:
@@ -526,7 +536,7 @@ bool MediaEngine::writeVideoImageWithRange(u8* buffer, int frameWidth, int video
 		break;
 	}
 #endif // USE_FFMPEG
-	return true;
+	return videoImageSize;
 }
 
 static bool isHeader(u8* audioStream, int offset)

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -51,8 +51,8 @@ public:
 	int getBufferedSize();
 
 	bool stepVideo(int videoPixelMode);
-	bool writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);
-	bool writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
+	int writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);
+	int writeVideoImageWithRange(u8* buffer, int frameWidth, int videoPixelMode, 
 	                             int xpos, int ypos, int width, int height);
 	int getAudioSamples(u8* buffer);
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -1024,6 +1024,9 @@ void GLES_GPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 		textureCache_.Invalidate(addr, size, type);
 	else
 		textureCache_.InvalidateAll(type);
+
+	if (type != GPU_INVALIDATE_ALL)
+		framebufferManager_.UpdateFromMemory(addr, size);
 }
 
 void GLES_GPU::ClearCacheNextFrame() {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -96,6 +96,7 @@ public:
 	void Resized();
 	void CopyDisplayToOutput();
 	void SetRenderFrameBuffer();  // Uses parameters computed from gstate
+	void UpdateFromMemory(u32 addr, int size);
 	// TODO: Break out into some form of FBO manager
 	VirtualFramebuffer *GetDisplayFBO();
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, int format);


### PR DESCRIPTION
I have not done a huge amount of testing on this and am about to take off, but this fixes Star Ocean and I tried to be very careful to only invalidate FBOs in the most obvious of cases.

I suppose this might also improve texture invalidation a bit from sceDmacMemcpy().

That said, I'm not at all sure why simply this did not work in the FBO invalidation, it seems better:

```
DrawPixels(Memory::GetPointer(addr), vfb->format, vfb->fb_stride);
```

Left it there but commented out.

-[Unknown]
