### PR TITLE
Eat cycles in devctl 0x02425823, fix params

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1066,12 +1066,19 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 			break;
 		case 0x02425823:  
 			// Check if FAT enabled
-			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
+			hleEatCycles(23500);
+			// If the values added together are >= 0x80000000, or less than outPtr, invalid address.
+			if (((int)outPtr + outLen) < (int)outPtr) {
+				ERROR_LOG(HLE, "sceIoDevctl: fatms0: 0x02425823 command, bad address");
+				return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
+			} else if (!Memory::IsValidAddress(outPtr)) {
+				// Technically, only checks for NULL, crashes for many bad addresses.
+				ERROR_LOG(HLE, "sceIoDevctl: fatms0: 0x02425823 command, no output address");
+				return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+			} else {
+				// Does not care about outLen, even if it's 0.
 				Memory::Write_U32(MemoryStick_FatState(), outPtr);
 				return 0;
-			} else {
-				ERROR_LOG(HLE, "Failed 0x02425823 fat");
-				return -1;
 			}
 			break;
 		case 0x02425824:  


### PR DESCRIPTION
I can't seem to reproduce a way to change its return value, though... what we have and what JPCSP says changes it doesn't work...

Significant performance improvement for Star Ocean's intro/menu.  Went from ~250 max vps to ~1500 while playing the video.  It was spending 20% of its time in `sceIoDevctl()` alone... now that's down to 0.89%.

I did confirm it calls the thing a ton on a real PSP also.  Tried to approximate real timing, although it seems to vary.

-[Unknown]
