### PR TITLE
Don't delay psmf video when the audio has ended

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -888,7 +888,7 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 
 	s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 	int delaytime = 3000;
-	if (deltapts > 0)
+	if (deltapts > 0 && !psmfplayer->mediaengine->IsAudioEnd())
 		delaytime = deltapts * 1000000 / 90000;
 	if (!ret)
 		return hleDelayResult(ret, "psmfPlayer video decode", delaytime);


### PR DESCRIPTION
Lunar shows logos without any audio, which means the audio pts is always 0.  That meant it delayed more each frame...

The timing is not accurate still, but it's better.  Also, the PSP seems to return each frame twice, while we return it once (just going off pts)... but, it seems to look fine so it may not matter / it may just be the way I'm using it somehow.

-[Unknown]
