### PR TITLE
Improve mpeg timestamp.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -158,8 +158,8 @@ struct MpegContext {
 	u32 mpegRawVersion;
 	u32 mpegOffset;
 	u32 mpegStreamSize;
-	u32 mpegFirstTimestamp;
-	u32 mpegLastTimestamp;
+	s64 mpegFirstTimestamp;
+	s64 mpegLastTimestamp;
 	u32 mpegFirstDate;
 	u32 mpegLastDate;
 	u32 mpegRingbufferAddr;
@@ -249,8 +249,8 @@ void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 	}
 	ctx->mpegOffset = bswap32(Memory::Read_U32(buffer_addr + PSMF_STREAM_OFFSET_OFFSET));
 	ctx->mpegStreamSize = bswap32(Memory::Read_U32(buffer_addr + PSMF_STREAM_SIZE_OFFSET));
-	ctx->mpegFirstTimestamp = bswap32(Memory::Read_U32(buffer_addr + PSMF_FIRST_TIMESTAMP_OFFSET));
-	ctx->mpegLastTimestamp = bswap32(Memory::Read_U32(buffer_addr + PSMF_LAST_TIMESTAMP_OFFSET));
+	ctx->mpegFirstTimestamp = getMpegTimeStamp(Memory::GetPointer(buffer_addr + PSMF_FIRST_TIMESTAMP_OFFSET));
+	ctx->mpegLastTimestamp = getMpegTimeStamp(Memory::GetPointer(buffer_addr + PSMF_LAST_TIMESTAMP_OFFSET));
 	ctx->mpegFirstDate = convertTimestampToDate(ctx->mpegFirstTimestamp);
 	ctx->mpegLastDate = convertTimestampToDate(ctx->mpegLastTimestamp);
 	ctx->avc.avcDetailFrameWidth = (Memory::Read_U8(buffer_addr + 142) * 0x10);
@@ -281,7 +281,7 @@ void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 	ctx->isAnalyzed = true;
 
 	INFO_LOG(ME, "Stream offset: %d, Stream size: 0x%X", ctx->mpegOffset, ctx->mpegStreamSize);
-	INFO_LOG(ME, "First timestamp: %d, Last timestamp: %d", ctx->mpegFirstTimestamp, ctx->mpegLastTimestamp);
+	INFO_LOG(ME, "First timestamp: %lld, Last timestamp: %lld", ctx->mpegFirstTimestamp, ctx->mpegLastTimestamp);
 }
 
 class PostPutAction : public Action {

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -53,8 +53,8 @@ static const int PSMF_VERSION_0015 = 0x35313030;
 static const int PSMF_STREAM_VERSION_OFFSET = 0x4;
 static const int PSMF_STREAM_OFFSET_OFFSET = 0x8;
 static const int PSMF_STREAM_SIZE_OFFSET = 0xC;
-static const int PSMF_FIRST_TIMESTAMP_OFFSET = 0x56;
-static const int PSMF_LAST_TIMESTAMP_OFFSET = 0x5C;
+static const int PSMF_FIRST_TIMESTAMP_OFFSET = 0x54;
+static const int PSMF_LAST_TIMESTAMP_OFFSET = 0x5A;
 
 struct SceMpegAu {
 	s64 pts;  // presentation time stamp

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -275,7 +275,7 @@ PsmfPlayer::PsmfPlayer(u32 data) {
 	audioStreamNum = Memory::Read_U32(data + 12);
 	playMode = Memory::Read_U32(data+ 16);
 	playSpeed = Memory::Read_U32(data + 20);
-	psmfPlayerLastTimestamp = bswap32(Memory::Read_U32(data + PSMF_LAST_TIMESTAMP_OFFSET)) ;
+	psmfPlayerLastTimestamp = getMpegTimeStamp(Memory::GetPointer(data + PSMF_LAST_TIMESTAMP_OFFSET)) ;
 	status = PSMF_PLAYER_STATUS_INIT;
 	mediaengine = new MediaEngine;
 }

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -394,7 +394,7 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 				sws_scale(m_sws_ctx, m_pFrame->data, m_pFrame->linesize, 0,
 					m_pCodecCtx->height, m_pFrameRGB->data, m_pFrameRGB->linesize);
 
-				int firstTimeStamp = bswap32(*(int*)(m_pdata + 86));
+				s64 firstTimeStamp = getMpegTimeStamp(m_pdata + PSMF_FIRST_TIMESTAMP_OFFSET);
 				m_videopts = m_pFrame->pkt_dts + av_frame_get_pkt_duration(m_pFrame) - firstTimeStamp;
 				bGetFrame = true;
 			}
@@ -623,7 +623,7 @@ s64 MediaEngine::getAudioTimeStamp() {
 s64 MediaEngine::getLastTimeStamp() {
 	if (!m_pdata)
 		return 0;
-	int firstTimeStamp = bswap32(*(int*)(m_pdata + 86));
-	int lastTimeStamp = bswap32(*(int*)(m_pdata + 92));
+	s64 firstTimeStamp = getMpegTimeStamp(m_pdata + PSMF_FIRST_TIMESTAMP_OFFSET);
+	s64 lastTimeStamp = getMpegTimeStamp(m_pdata + PSMF_LAST_TIMESTAMP_OFFSET);
 	return lastTimeStamp - firstTimeStamp;
 }

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -36,6 +36,11 @@ struct AVIOContext;
 struct AVFormatContext;
 struct AVCodecContext;
 
+inline s64 getMpegTimeStamp(u8* buf) {
+	return (s64)buf[5] | ((s64)buf[4] << 8) | ((s64)buf[3] << 16) | ((s64)buf[2] << 24) 
+		| ((s64)buf[1] << 32) | ((s64)buf[0] << 36);
+}
+
 class MediaEngine
 {
 public:


### PR DESCRIPTION
The mpeg timestamp is actually 6 bytes in mpeg file, and we just use 4 bytes right now. It may be an issue, so I try to read 6 bytes timestamp instead. 
Hopes it would help #2172
