### PR TITLE
Add some error handling in sceSas, delay sceSasCore()

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -119,7 +119,9 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 	}
 
 	sas->Mix(outAddr);
-	return 0;
+	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
+	// Let's aim low for now.
+	return hleDelayResult(0, "sas core", 240);
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
@@ -131,7 +133,9 @@ u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume)
 	}
 
 	sas->Mix(inoutAddr, inoutAddr, leftVolume, rightVolume);
-	return 0;
+	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
+	// Let's aim low for now.
+	return hleDelayResult(0, "sas core", 240);
 }
 
 u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -261,7 +261,7 @@ u32 sceSasSetKeyOn(u32 core, int voiceNum) {
 		return ERROR_SAS_INVALID_VOICE;
 	}
 
-	if (sas->voices[voiceNum].paused) {
+	if (sas->voices[voiceNum].paused || sas->voices[voiceNum].on) {
 		return ERROR_SAS_VOICE_PAUSED;
 	}
 
@@ -282,7 +282,7 @@ u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 	} else {
 		DEBUG_LOG(HLE,"sceSasSetKeyOff(%08x, %i)", core, voiceNum);
 
-		if (sas->voices[voiceNum].paused) {
+		if (sas->voices[voiceNum].paused || !sas->voices[voiceNum].on) {
 			return ERROR_SAS_VOICE_PAUSED;
 		}
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -538,7 +538,6 @@ void SasVoice::KeyOn() {
 void SasVoice::KeyOff() {
 	on = false;
 	envelope.KeyOff();
-	vag.SetLoop(false);
 }
 
 void SasVoice::ChangedParams(bool changedVag) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -84,7 +84,6 @@ public:
 
 	void DecodeBlock(u8 *&readp);
 	bool End() const { return end_; }
-	void SetLoop(bool enabled) { loopEnabled_ = enabled; }
 
 	void DoState(PointerWrap &p);
 


### PR DESCRIPTION
Per tests, this is what the functions seem to do.  Fixes the huge delay in Kingdom Hearts.

Final Fantasy Tactics is still playing weird screwy sound effects, though...

-[Unknown]
