### PR TITLE
Update the framebuffer directly on sceDmacCopy()

### DIFF
--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -34,11 +34,9 @@ u32 sceDmacMemcpy(u32 dst, u32 src, u32 size)
 	Memory::Memcpy(dst, Memory::GetPointer(src), size);
 
 	src &= ~0x40000000;
-	// TODO: If we do this it'll probably black out the framebuffer?
-	if (src < PSP_GetVidMemBase() || src > PSP_GetVidMemEnd())
-		gpu->InvalidateCache(dst, size, GPU_INVALIDATE_HINT);
-	else
-		WARN_LOG_REPORT(HLE, "sceDmacMemcpy(): FBO blit?");
+	dst &= ~0x40000000;
+	if ((src >= PSP_GetVidMemBase() && src < PSP_GetVidMemEnd()) || (dst >= PSP_GetVidMemBase() && dst < PSP_GetVidMemEnd()))
+		gpu->UpdateMemory(dst, src, size);
 	return 0;
 }
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -1029,6 +1029,10 @@ void GLES_GPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 		framebufferManager_.UpdateFromMemory(addr, size);
 }
 
+void GLES_GPU::UpdateMemory(u32 dest, u32 src, int size) {
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+}
+
 void GLES_GPU::ClearCacheNextFrame() {
 	textureCache_.ClearNextFrame();
 }

--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -45,6 +45,7 @@ public:
 	virtual void BeginFrame();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
+	virtual void UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -501,6 +501,7 @@ void FramebufferManager::SetRenderFrameBuffer() {
 
 void FramebufferManager::CopyDisplayToOutput() {
 	fbo_unbind();
+	currentRenderVfb_ = 0;
 
 	VirtualFramebuffer *vfb = GetDisplayFBO();
 	if (!vfb) {
@@ -531,8 +532,6 @@ void FramebufferManager::CopyDisplayToOutput() {
 		prevDisplayFramebuf_ = displayFramebuf_;
 	}
 	displayFramebuf_ = vfb;
-
-	currentRenderVfb_ = 0;
 
 	if (vfb->fbo) {
 		glstate.viewport.set(0, 0, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
@@ -622,6 +621,8 @@ std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 
 void FramebufferManager::DecimateFBOs() {
 	fbo_unbind();
+	currentRenderVfb_ = 0;
+
 	for (auto iter = vfbs_.begin(); iter != vfbs_.end();) {
 		VirtualFramebuffer *vfb = *iter;
 		if (vfb == displayFramebuf_ || vfb == prevDisplayFramebuf_ || vfb == prevPrevDisplayFramebuf_) {
@@ -646,6 +647,8 @@ void FramebufferManager::DecimateFBOs() {
 
 void FramebufferManager::DestroyAllFBOs() {
 	fbo_unbind();
+	currentRenderVfb_ = 0;
+
 	for (auto iter = vfbs_.begin(); iter != vfbs_.end(); ++iter) {
 		VirtualFramebuffer *vfb = *iter;
 		textureCache_->NotifyFramebufferDestroyed(vfb->fb_address, vfb);
@@ -670,6 +673,8 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size) {
 			return;
 
 		fbo_unbind();
+		currentRenderVfb_ = 0;
+
 		for (auto iter = vfbs_.begin(); iter != vfbs_.end(); ) {
 			VirtualFramebuffer *vfb = *iter;
 			if (MaskedEqual(vfb->fb_address, addr)) {

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -181,6 +181,8 @@ public:
 	// Invalidate any cached content sourced from the specified range.
 	// If size = -1, invalidate everything.
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type) = 0;
+	// Update either RAM from VRAM, or VRAM from RAM... or even VRAM from VRAM.
+	virtual void UpdateMemory(u32 dest, u32 src, int size) = 0;
 
 	// Will cause the texture cache to be cleared at the start of the next frame.
 	virtual void ClearCacheNextFrame() = 0;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -678,3 +678,9 @@ void NullGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type)
 {
 	// Nothing to invalidate.
 }
+
+void NullGPU::UpdateMemory(u32 dest, u32 src, int size)
+{
+	// Nothing to update.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+}

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -35,6 +35,7 @@ public:
 	virtual void CopyDisplayToOutput() {}
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
+	virtual void UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame() {};
 	virtual void Flush() {}
 


### PR DESCRIPTION
Corrects it to use DrawPixels, but I wasn't sure how to do it right when buffered rendering is off, so I left the old path.

This makes it so videos in many games are displayed properly, and fixes a few games where FBOs were being invalidated constantly (like Phantasy Star Online.)

Doesn't include FBO -> FBO logic or anything, which I didn't get working...

-[Unknown]
