### PR TITLE
Allow an mpeg to finish even not completely at stream end

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -399,7 +399,9 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 				bGetFrame = true;
 			}
 			if (result <= 0 && dataEnd) {
-				m_isVideoEnd = !bGetFrame && m_readSize >= m_streamSize;
+				// Sometimes, m_readSize is less than m_streamSize at the end, but not by much.
+				// This is kinda a hack, but the ringbuffer would have to be prematurely empty too.
+				m_isVideoEnd = !bGetFrame && m_readSize >= (m_streamSize - 4096);
 				if (m_isVideoEnd)
 					m_decodedPos = m_readSize;
 				break;


### PR DESCRIPTION
When ffmpeg says there's nothing left, the video should be over.  But as what I'm pretty sure is a safety check, we see if we're at or past the expected video size.

Patapon 3 was never reaching this, it was just a bit shy.  It clearly had no more data to give either.

This conservatively allows the video to end if it's _near_ the size by 2 packets, which fixes Patapon 3.  Removing the check all together _could_ cause a video to end early if the game allowed the ringbuffer to drain.  But that might be right.. or more likely, sceMpeg probably doesn't have an end flag at all and just tries to decode every time.

-[Unknown]
