### PR TITLE
Constructor tweaks in SAS + minor fix to end/pause flag

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -74,7 +74,7 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 		ERROR_LOG_REPORT(HLE, "sceSasInit(%08x, %i, %i, %i, %i): bad core address", core, grainSize, maxVoices, outputMode, sampleRate);
 		return ERROR_SAS_BAD_ADDRESS;
 	}
-	if (maxVoices == 0 || maxVoices > 32) {
+	if (maxVoices == 0 || maxVoices > PSP_SAS_VOICES_MAX) {
 		ERROR_LOG_REPORT(HLE, "sceSasInit(%08x, %i, %i, %i, %i): bad max voices", core, grainSize, maxVoices, outputMode, sampleRate);
 		return ERROR_SAS_INVALID_MAX_VOICES;
 	}
@@ -89,7 +89,8 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 	INFO_LOG(HLE, "sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
 
 	sas->SetGrainSize(grainSize);
-	sas->maxVoices = maxVoices;
+	// Seems like maxVoiecs is actually ignored for all intents and purposes.
+	sas->maxVoices = PSP_SAS_VOICES_MAX;
 	sas->outputMode = outputMode;
 	for (int i = 0; i < sas->maxVoices; i++) {
 		sas->voices[i].sampleRate = sampleRate;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -279,6 +279,7 @@ SasInstance::SasInstance()
 #ifdef AUDIO_TO_FILE
 	audioDump = fopen("D:\\audio.raw", "wb");
 #endif
+	memset(&waveformEffect, 0, sizeof(waveformEffect));
 }
 
 SasInstance::~SasInstance() {
@@ -676,7 +677,6 @@ ADSREnvelope::ADSREnvelope()
 		state_(STATE_OFF),
 		steps_(0),
 		height_(0) {
-	memset(this, 0, sizeof(*this));
 }
 
 void ADSREnvelope::WalkCurve(int rate, int type) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -77,7 +77,7 @@ enum VoiceType {
 // It compresses 28 16-bit samples into a block of 16 bytes.
 class VagDecoder {
 public:
-	VagDecoder() : data_(0), read_(0) {}
+	VagDecoder() : data_(0), read_(0), end_(true) {}
 	void Start(u32 dataPtr, int vagSize, bool loopEnabled);
 
 	void GetSamples(s16 *outSamples, int numSamples);
@@ -185,7 +185,7 @@ struct SasVoice
 			sampleRate(44100),
 			sampleFrac(0),
 			pitch(PSP_SAS_PITCH_BASE),
-			loop(true), // true = ignore VAG loop , false = process VAG loop
+			loop(false),
 			noiseFreq(0),
 			volumeLeft(PSP_SAS_VOL_MAX),
 			volumeRight(PSP_SAS_VOL_MAX),


### PR DESCRIPTION
The memset is probably not necessary, and contradicts the constructor anyway.  Plus it has private fields so it's not pod I think?

Anyway, the rest is just an attempt to avoid uninitialized values.

Doing some initial tests on the PSP, I found that `sceSasInit()` apparently writes exactly the same data for maxVoices=1 as it does for maxVoices=32.  So then I tested `sceSasGetEndFlag()`, and it also returns `0xffffffff` on real firmware, and nothing seems to validate against `maxVoices`, just 32.

So this makes `sceSasGetEndFlag()` and `sceSasGetPauseFlag()` correct for < 32 maxVoices in `sceSasInit()`, which I've never seen used anyway...

-[Unknown]
