### PR TITLE
Quick Save Dialog background workaround.

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -46,6 +46,7 @@ PSPDialog::DialogStatus PSPDialog::GetStatus()
 void PSPDialog::StartDraw()
 {
 	PPGeBegin();
+	PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x80000000));
 }
 
 void PSPDialog::EndDraw()


### PR DESCRIPTION
I don't know if this is enough for unreadable text/icons in some games (#2191). I just darken the current background.
