### PR TITLE
Clean up sceUtilityScreenshot*

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -52,6 +52,7 @@ static PSPSaveDialog saveDialog;
 static PSPMsgDialog msgDialog;
 static PSPOskDialog oskDialog;
 static PSPPlaceholderDialog netDialog;
+static PSPPlaceholderDialog screenshotDialog;
 
 static std::set<int> currentlyLoadedModules;
 
@@ -382,27 +383,24 @@ int sceUtilityNetconfGetStatus()
 u32 sceUtilityScreenshotInitStart(u32 unknown1, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5, u32 unknown6)
 {
 	WARN_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotInitStart(%x, %x, %x, %x, %x, %x)", 0, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6);
-	return 0;
+	return screenshotDialog.Init();
 }
 
 u32 sceUtilityScreenshotShutdownStart()
 {
 	WARN_LOG(HLE, "UNTESTED sceUtilityScreenshotShutdownStart()");
-	return 0;
+	return screenshotDialog.Shutdown();
 }
 
 u32 sceUtilityScreenshotUpdate(u32 unknown)
 {
 	ERROR_LOG(HLE, "UNIMPL sceUtilityScreenshotUpdate(%d)", unknown);
-	return 0;
+	return screenshotDialog.Update();
 }
 
-//Fake success, because Diva 2nd(and other games?) hang(s) in an infinite loop
-//if you try to take a screenshot without it, due to waiting for success forever
 int sceUtilityScreenshotGetStatus()
 {
-	//u32 retval =  __UtilityGetStatus();
-	u32 retval = 0; 
+	u32 retval = screenshotDialog.GetStatus(); 
 
 	WARN_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotGetStatus()", retval);
 	return retval;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -382,8 +382,9 @@ int sceUtilityNetconfGetStatus()
 //but it requires more investigation
 u32 sceUtilityScreenshotInitStart(u32 unknown1, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5, u32 unknown6)
 {
-	WARN_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotInitStart(%x, %x, %x, %x, %x, %x)", 0, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6);
-	return screenshotDialog.Init();
+	u32 retval = screenshotDialog.Init();
+	WARN_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotInitStart(%x, %x, %x, %x, %x, %x)", retval, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6);
+	return retval;
 }
 
 u32 sceUtilityScreenshotShutdownStart()
@@ -401,7 +402,6 @@ u32 sceUtilityScreenshotUpdate(u32 unknown)
 int sceUtilityScreenshotGetStatus()
 {
 	u32 retval = screenshotDialog.GetStatus(); 
-
 	WARN_LOG(HLE, "UNIMPL %i=sceUtilityScreenshotGetStatus()", retval);
 	return retval;
 }


### PR DESCRIPTION
Sorry for the sloppiness before. I'll try to make cleaner commits like this in the future. I tend to do things on a whim. :)

Now it's properly using a placeholder dialog to return values to the game, instead of faked values. Much cleaner.
