### PR TITLE
Fix sceSasSetPause() error code, update default SAS values

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -210,15 +210,14 @@ u32 sceSasGetPauseFlag(u32 core) {
 	return pauseFlag;
 }
 
-u32 sceSasSetPause(u32 core, int voicebit, int pause) {
+u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
 	DEBUG_LOG(HLE,"sceSasSetPause(%08x, %08x, %i)", core, voicebit, pause);
 
-	for (int i = 0; voicebit != 0; i++, voicebit >>= 1)	{
+	for (int i = 0; voicebit != 0; i++, voicebit >>= 1) {
 		if (i < PSP_SAS_VOICES_MAX && i >= 0) {
 			if ((voicebit & 1) != 0)
 				sas->voices[i].paused = pause ? true : false;
-		} else // TODO: Correct error code?  Mimana crashes otherwise.
-			return ERROR_SAS_INVALID_VOICE;
+		}
 	}
 
 	return 0;
@@ -505,7 +504,7 @@ const HLEFunction sceSasCore[] =
 	{0x33d4ab37, WrapU_UI<sceSasRevType>, "__sceSasRevType"},
 	{0x267a6dd2, WrapU_UII<sceSasRevParam>, "__sceSasRevParam"},
 	{0x2c8e6ab3, WrapU_U<sceSasGetPauseFlag>, "__sceSasGetPauseFlag"},
-	{0x787d04d5, WrapU_UII<sceSasSetPause>, "__sceSasSetPause"},
+	{0x787d04d5, WrapU_UUI<sceSasSetPause>, "__sceSasSetPause"},
 	{0xa232cbe6, WrapU_UII<sceSasSetTriangularWave>, "__sceSasSetTrianglarWave"}, // Typo.
 	{0xd5ebbbcd, WrapU_UII<sceSasSetSteepWave>, "__sceSasSetSteepWave"},
 	{0xBD11B7C2, WrapU_U<sceSasGetGrain>, "__sceSasGetGrain"},

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -404,8 +404,8 @@ u32 sceSasRevEVOL(u32 core, int lv, int rv) {
 
 u32 sceSasRevVON(u32 core, int dry, int wet) {
 	DEBUG_LOG(HLE,"sceSasRevVON(%08x, %i, %i)", core, dry, wet);
-	sas->waveformEffect.isDryOn = (dry > 0);
-	sas->waveformEffect.isWetOn = (wet > 0);
+	sas->waveformEffect.isDryOn = dry & 1;
+	sas->waveformEffect.isWetOn = wet & 1;
 	return 0;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -280,6 +280,8 @@ SasInstance::SasInstance()
 	audioDump = fopen("D:\\audio.raw", "wb");
 #endif
 	memset(&waveformEffect, 0, sizeof(waveformEffect));
+	waveformEffect.type = -1;
+	waveformEffect.isDryOn = 1;
 }
 
 SasInstance::~SasInstance() {

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -678,10 +678,10 @@ ADSREnvelope::ADSREnvelope()
 		decayRate(0),
 		decayType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
 		sustainRate(0),
-		sustainType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
+		sustainType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
 		releaseRate(0),
 		releaseType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
-		sustainLevel(0),
+		sustainLevel(0x100),
 		state_(STATE_OFF),
 		steps_(0),
 		height_(0) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -191,8 +191,8 @@ struct SasVoice
 			volumeRight(PSP_SAS_VOL_MAX),
 			volumeLeftSend(0),
 			volumeRightSend(0),
-			effectLeft(0),
-			effectRight(0) {
+			effectLeft(PSP_SAS_VOL_MAX),
+			effectRight(PSP_SAS_VOL_MAX) {
 		memset(resampleHist, 0, sizeof(resampleHist));
 	}
 


### PR DESCRIPTION
Based on dumping the SasCore struct and tests.

`sceSasSetPause(&sasCore, -1, 0)` is completely valid, and should not return any error.  We just had an infinite loop.  Mimana still works.

Also `sceSasRevVON(&sasCore, 2, 2)` is the same as 0, since it seems to only check the lsb.  We don't use it yet anyway, but might as well fix it since it's easy.

-[Unknown]
