### PR TITLE
User controllable CPU speed option

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -85,6 +85,7 @@ void Config::Load(const char *iniFileName)
 #endif
 	//FastMemory Default set back to True when solve UNIMPL _sceAtracGetContextAddress making game crash
 	cpu->Get("FastMemory", &bFastMemory, false);
+	cpu->Get("CPUSpeed", &iLockedCPUSpeed, false);
 
 	IniFile::Section *graphics = iniFile.GetOrCreateSection("Graphics");
 	graphics->Get("ShowFPSCounter", &iShowFPSCounter, false);
@@ -203,6 +204,7 @@ void Config::Save()
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 		cpu->Set("Jit", bJit);
 		cpu->Set("FastMemory", bFastMemory);
+		cpu->Set("CPUSpeed", iLockedCPUSpeed);
 
 		IniFile::Section *graphics = iniFile.GetOrCreateSection("Graphics");
 		graphics->Set("ShowFPSCounter", iShowFPSCounter);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -52,6 +52,7 @@ public:
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;
 	bool bJit;
+	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;
 	std::string sReportHost;
 	std::vector<std::string> recentIsos;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1189,6 +1189,18 @@ void SystemScreen::render() {
 	if (g_Config.bJit)
 		UICheckBox(GEN_ID, x, y += stride, s->T("Fast Memory", "Fast Memory (unstable)"), ALIGN_TOPLEFT, &g_Config.bFastMemory);
 
+	bool LockCPUSpeed = g_Config.iLockedCPUSpeed != 0;
+	UICheckBox(GEN_ID, x, y += stride, s->T("Lock PSP CPU Speed"), ALIGN_TOPLEFT, &LockCPUSpeed);
+	if(LockCPUSpeed) {
+		if(g_Config.iLockedCPUSpeed <= 0)
+			g_Config.iLockedCPUSpeed = 222;
+		char showCPUSpeed[256];
+		sprintf(showCPUSpeed, "%s %d", s->T("Locked CPU Speed: "), g_Config.iLockedCPUSpeed);
+		ui_draw2d.DrawText(UBUNTU24, showCPUSpeed, x + 60, (y += stride) - 5, 0xFFFFFFFF, ALIGN_LEFT);
+	}
+	else {
+		g_Config.iLockedCPUSpeed = 0;
+	}
 	//UICheckBox(GEN_ID, x, y += stride, s->T("Daylight Savings"), ALIGN_TOPLEFT, &g_Config.bDayLightSavings);
 
 	const char *buttonPreferenceTitle;


### PR DESCRIPTION
Useful as a workaround for games that lag after a while due to changing CPU frequencies often(see #2104), or to experiment with. It doesn't seem to break any games that I have, so here it is. It's off by default to allow PPSSPP to have its typical behaviour.

To use it: edit ppsspp.ini's CPUSpeed = 0 line to whatever you want the CPU speed to be locked to. If the option is unchecked and re-enabled at a later date, it defaults to 222mhz.
