### PR TITLE
Implement an option to continue invisible touchscreen control processing...

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -141,6 +141,8 @@ void Config::Load(const char *iniFileName)
 #else
 	control->Get("ShowTouchControls", &bShowTouchControls,false);
 #endif
+
+	control->Get("ProcessInvisibleTouchControls", &bProcessInvisibleTouchControls, true);
 	control->Get("LargeControls", &bLargeControls, false);
 	control->Get("KeyMapping",iMappingMap);
 	control->Get("AccelerometerToAnalogHoriz", &bAccelerometerToAnalogHoriz, false);
@@ -233,6 +235,7 @@ void Config::Save()
 		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 		control->Set("ShowStick", bShowAnalogStick);
 		control->Set("ShowTouchControls", bShowTouchControls);
+		control->Set("ProcessInvisibleTouchControls", bProcessInvisibleTouchControls);
 		control->Set("LargeControls", bLargeControls);
 		control->Set("KeyMapping",iMappingMap);
 		control->Set("AccelerometerToAnalogHoriz", bAccelerometerToAnalogHoriz);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -92,6 +92,7 @@ public:
 	
 	// UI
 	bool bShowTouchControls;
+	bool bProcessInvisibleTouchControls;
 	bool bShowDebuggerOnLoad;
 	bool bShowAnalogStick;
 	bool bShowFPSCounter;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -176,12 +176,12 @@ void EmuScreen::update(InputState &input) {
 		return;
 
 	// First translate touches into native pad input.
-	// Do this no matter the value of g_Config.bShowTouchControls, some people
-	// like to use invisible controls...
-	UpdateGamepad(input);
+	// People can have their invisible touch controls, but make it optional, not forced.
+	if(g_Config.bProcessInvisibleTouchControls || g_Config.bShowTouchControls) {
+		UpdateGamepad(input);
 
-	UpdateInputState(&input);
-
+		UpdateInputState(&input);
+	}
 	// Then translate pad input into PSP pad input. Also, add in tilt.
 	static const int mapping[12][2] = {
 		{PAD_BUTTON_A, CTRL_CROSS},

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1097,6 +1097,7 @@ void ControlsScreen::render() {
 		UICheckBox(GEN_ID, x, y += stride, c->T("Large Controls"), ALIGN_TOPLEFT, &g_Config.bLargeControls);
 		UICheckBox(GEN_ID, x, y += stride, c->T("Show Analog Stick"), ALIGN_TOPLEFT, &g_Config.bShowAnalogStick);
 	} 
+	UICheckBox(GEN_ID, x, y += stride, c->T("ProcessInvisControls", "Process touch controls even when hidden"), ALIGN_TOPLEFT, &g_Config.bProcessInvisibleTouchControls);
 	UICheckBox(GEN_ID, x, y += stride, c->T("Tilt", "Tilt to Analog (horizontal)"), ALIGN_TOPLEFT, &g_Config.bAccelerometerToAnalogHoriz);
 
 	UIEnd();


### PR DESCRIPTION
... or to disable it. It's an annoyance for platforms that don't have touchscreens(think Windows/Mac/Linux/most PCs in general), when switching back to/clicking inside of the emulator window. Enabled by default to keep the default behaviour.
