### PR TITLE
Fixed a build error of qt interface on Linux

### DIFF
--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -22,7 +22,7 @@ win32 {
 	LIBS += -lCore -lCommon -lNative -lwinmm -lws2_32
 }
 linux {
-	LIBS += -L. -lCore -lCommon -lNative
+	LIBS += -L. -lCore -lCommon -lNative -ldl
 	PRE_TARGETDEPS += ./libCommon.a ./libCore.a ./libNative.a
 	!mobile_platform {
 		CONFIG += link_pkgconfig


### PR DESCRIPTION
This fixes the build issue mentioned in #2124.
#2124 fixes the issue for building sdl application with cmake on linux.

Yet Qt interface is built with qmake, thus must be handled separately.
