### PR TITLE
Ensure FFmpeg doesn't corrupt an early keyframe

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -174,7 +174,7 @@ int64_t _MpegSeekbuffer(void *opaque, int64_t offset, int whence)
 		return mpeg->m_streamSize;
 #endif
 	}
-	return offset;
+	return mpeg->m_decodeNextPos;
 }
 
 #ifdef _DEBUG

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -166,6 +166,13 @@ int64_t _MpegSeekbuffer(void *opaque, int64_t offset, int whence)
 	case SEEK_END:
 		mpeg->m_decodeNextPos = mpeg->m_streamSize - (u32)offset;
 		break;
+
+#ifdef USE_FFMPEG
+	// Don't seek, just return the full size.
+	// Returning this means FFmpeg won't think frames are truncated if we don't have them yet.
+	case AVSEEK_SIZE:
+		return mpeg->m_streamSize;
+#endif
 	}
 	return offset;
 }

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -136,7 +136,10 @@ void MediaEngine::closeMedia() {
 
 int _MpegReadbuffer(void *opaque, uint8_t *buf, int buf_size)
 {
-	MediaEngine *mpeg = (MediaEngine*)opaque;
+	MediaEngine *mpeg = (MediaEngine *)opaque;
+	if ((u32)mpeg->m_decodeNextPos > (u32)mpeg->m_streamSize)
+		return -1;
+
 	int size = std::min(mpeg->m_bufSize, buf_size);
 	int available = mpeg->m_readSize - mpeg->m_decodeNextPos;
 	int remaining = mpeg->m_streamSize - mpeg->m_decodeNextPos;


### PR DESCRIPTION
When the analyze func runs, it seems to check between 2-4% (or so?) of the stream, which for longer videos especially we don't have yet.  Returning a read failure (tried -1 or 0) here seems to truncate that keyframe sometimes.

FFmpeg asks for the total size when this happens, which we were ignoring (docs say it's okay to do that, though.)  Handling it fixes this, as FFmpeg apparently realizes we ran out of data.

I'm a bit busy atm, but Patapon 3 and Wipeout Pure still work with this, and @thedax tested a bunch of games for me and they were all happy (thanks.)

-[Unknown]
