### PR TITLE
Better align the message context in message dialog

### DIFF
--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -132,7 +132,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr)
 
 void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 {
-	const float WRAP_WIDTH = 350.0f;
+	const float WRAP_WIDTH = 480.0f;
 	float y = 136.0f, h;
 	int n;
 	PPGeMeasureText(0, &h, &n, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
@@ -173,8 +173,8 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 	}
 	PPGeDrawTextWrapped(text.c_str(), 240.0f, y, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
 	float sy = 122.0f - h2, ey = 150.0f + h2;
-	PPGeDrawRect(60.0f, sy, 420.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawRect(60.0f, ey, 420.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawRect(30.0f, sy, 450.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawRect(30.0f, ey, 450.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));
 }
 
 int PSPMsgDialog::Update()


### PR DESCRIPTION
Keep no change to line wrapping function but display all texts as tidy and complete as possible in message dialog.

![1](https://f.cloud.github.com/assets/3000282/657725/f9245a0e-d579-11e2-8224-fbe809453457.jpg)

![2](https://f.cloud.github.com/assets/3000282/657726/0d56cbd8-d57a-11e2-86fb-72ae85db433d.jpg)

 Issue #2262 
