### PR TITLE
Hack current texture width/height to be multiple 2 of framebuffer 

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -934,8 +934,8 @@ void TextureCache::SetTexture() {
 			}
 
 			// This isn't right.
-			gstate_c.curTextureWidth = entry->framebuffer->width;
-			gstate_c.curTextureHeight = entry->framebuffer->height;
+			gstate_c.curTextureWidth = entry->framebuffer->width * 2;
+			gstate_c.curTextureHeight = entry->framebuffer->height * 2 ;
 			int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
 			gstate_c.actualTextureHeight = h;
 			gstate_c.flipTexture = true;


### PR DESCRIPTION
It is a dirty hack and works for some games that required width and height to be 960 and 544 respectivity.

This fixes the the graphic issues before Shin Sangoku Musou Multi Raid
![before](https://f.cloud.github.com/assets/3000282/657956/0527423a-d5a2-11e2-81d1-9bb9f18aa9a4.jpg)

![fix](https://f.cloud.github.com/assets/3000282/657957/07c6a76a-d5a2-11e2-993b-d8c8f3e136c8.jpg)
