### PR TITLE
Use ringbuffer as a real PSP instead the huge buffer.

### DIFF
--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -221,6 +221,11 @@ template<int func(u32, const char *)> void WrapI_UC() {
 	RETURN(retval);
 }
 
+template<int func(u32, const char *, int)> void WrapI_UCI() {
+	int retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2));
+	RETURN(retval);
+}
+
 template<u32 func(u32, int , int , int, int, int)> void WrapU_UIIIII() {
 	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5));
 	RETURN(retval);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -271,7 +271,11 @@ void AnalyzeMpeg(u32 buffer_addr, MpegContext *ctx) {
 
 	if (ctx->mediaengine && (ctx->mpegStreamSize > 0) && !ctx->isAnalyzed) {
 		// init mediaEngine
-		ctx->mediaengine->loadStream(Memory::GetPointer(buffer_addr), ctx->mpegOffset, ctx->mpegOffset + ctx->mpegStreamSize);
+		SceMpegRingBuffer ringbuffer = {0};
+		if(ctx->mpegRingbufferAddr != 0){
+			Memory::ReadStruct(ctx->mpegRingbufferAddr, &ringbuffer);
+		};
+		ctx->mediaengine->loadStream(Memory::GetPointer(buffer_addr), ctx->mpegOffset, ringbuffer.packets * ringbuffer.packetSize);
 		ctx->mediaengine->setVideoDim();
 	}
 	// When used with scePsmf, some applications attempt to use sceMpegQueryStreamOffset
@@ -643,7 +647,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 	} else {
 		ctx->avc.avcFrameStatus = 0;
 	}
-	ringbuffer.packetsFree = std::max(0, ringbuffer.packets - ctx->mediaengine->getBufferedSize() / 2048);
+	ringbuffer.packetsFree = ctx->mediaengine->getRemainSize() / 2048;
 
 	avcAu.pts = ctx->mediaengine->getVideoTimeStamp() + ctx->mpegFirstTimestamp;
 
@@ -788,7 +792,7 @@ int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 	}else {
 		ctx->avc.avcFrameStatus = 0;
 	}
-	ringbuffer.packetsFree = std::max(0, ringbuffer.packets - ctx->mediaengine->getBufferedSize() / 2048);
+	ringbuffer.packetsFree = ctx->mediaengine->getRemainSize() / 2048;
 
 	avcAu.pts = ctx->mediaengine->getVideoTimeStamp() + ctx->mpegFirstTimestamp;
 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -332,6 +332,9 @@ void PsmfPlayer::DoState(PointerWrap &p) {
 	p.Do(tempbuf);
 	p.Do(tempbufSize);
 
+	p.Do(status);
+	p.Do(psmfPlayerAvcAu);
+
 	p.DoMarker("PsmfPlayer");
 }
 
@@ -777,8 +780,10 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 		if (psmfplayer->filehandle && psmfplayer->tempbuf) {
 			u8* buf = Memory::GetPointer(psmfplayer->tempbuf);
 			int size = pspFileSystem.ReadFile(psmfplayer->filehandle, buf, psmfplayer->tempbufSize);
-			if (size)
-				psmfplayer->mediaengine->loadStream(buf, size, std::max(2048 * 500, (int)psmfplayer->tempbufSize));
+			if (size) {
+				psmfplayer->mediaengine->loadStream(buf, 2048, std::max(2048 * 500, (int)psmfplayer->tempbufSize));
+				psmfplayer->mediaengine->addStreamData(buf + 2048, size - 2048);
+			}
 			psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
 		}
 	}
@@ -802,8 +807,10 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 		if (psmfplayer->filehandle && psmfplayer->tempbuf) {
 			u8* buf = Memory::GetPointer(psmfplayer->tempbuf);
 			int size = pspFileSystem.ReadFile(psmfplayer->filehandle, buf, psmfplayer->tempbufSize);
-			if (size)
-				psmfplayer->mediaengine->loadStream(buf, size, std::max(2048 * 500, (int)psmfplayer->tempbufSize));
+			if (size) {
+				psmfplayer->mediaengine->loadStream(buf, 2048, std::max(2048 * 500, (int)psmfplayer->tempbufSize));
+				psmfplayer->mediaengine->addStreamData(buf + 2048, size - 2048);
+			}
 			psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
 		}
 	}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -798,7 +798,7 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		INFO_LOG(HLE, "scePsmfPlayerSetPsmf(%08x, %s): invalid psmf player", psmfPlayer, filename);
+		ERROR_LOG(HLE, "scePsmfPlayerSetPsmf(%08x, %s): invalid psmf player", psmfPlayer, filename);
 	}
 
 	return 0;
@@ -816,7 +816,7 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 	}
 	else
 	{
-		INFO_LOG(HLE, "scePsmfPlayerSetPsmfCB(%08x, %s): invalid psmf player", psmfPlayer, filename);
+		ERROR_LOG(HLE, "scePsmfPlayerSetPsmfCB(%08x, %s): invalid psmf player", psmfPlayer, filename);
 	}
 
 	return 0;
@@ -833,7 +833,7 @@ int scePsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset)
 	}
 	else
 	{
-		INFO_LOG(HLE, "scePsmfPlayerSetPsmfOffset(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
+		ERROR_LOG(HLE, "scePsmfPlayerSetPsmfOffset(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
 	}
 
 	return 0;
@@ -851,7 +851,7 @@ int scePsmfPlayerSetPsmfOffsetCB(u32 psmfPlayer, const char *filename, int offse
 	}
 	else
 	{
-		INFO_LOG(HLE, "scePsmfPlayerSetPsmfOffsetCB(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
+		ERROR_LOG(HLE, "scePsmfPlayerSetPsmfOffsetCB(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
 	}
 
 	return 0;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -307,6 +307,8 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 #ifdef USE_FFMPEG
 		if (!m_pFormatCtx) {
 			m_pdata->get_front(m_mpegheader, sizeof(m_mpegheader));
+			int mpegoffset = bswap32(*(int*)(m_mpegheader + 8));
+			m_pdata->pop_front(0, mpegoffset);
 			openContext();
 		}
 #endif // USE_FFMPEG

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -73,9 +73,7 @@ public:
 	bool IsVideoEnd() { return m_isVideoEnd; }
 	bool IsAudioEnd() { return m_isAudioEnd; }
 
-	void DoState(PointerWrap &p) {
-		p.DoMarker("MediaEngine");
-	}
+	void DoState(PointerWrap &p);
 
 private:
 	void updateSwsFormat(int videoPixelMode);
@@ -101,7 +99,6 @@ public:
 	Atrac3plus_Decoder::BufferQueue *m_pdata;
 	
 	MpegDemux *m_demux;
-	int m_audioPos;
 	void* m_audioContext;
 	s64 m_audiopts;
 
@@ -110,4 +107,8 @@ public:
 
 	bool m_isVideoEnd;
 	bool m_isAudioEnd;
+
+	int m_ringbuffersize;
+	u8 m_mpegheader[0x10000];
+	int m_mpegheaderReadPos;
 };

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -48,8 +48,7 @@ public:
 	~MediaEngine();
 
 	void closeMedia();
-	bool loadStream(u8* buffer, int readSize, int StreamSize);
-	bool loadFile(const char* filename);
+	bool loadStream(u8* buffer, int readSize, int RingbufferSize);
 	// open the mpeg context
 	bool openContext();
 	// Returns number of packets actually added.
@@ -58,8 +57,7 @@ public:
 	void setVideoStream(int streamNum) { m_videoStream = streamNum; }
 	void setAudioStream(int streamNum) { m_audioStream = streamNum; }
 
-	int getRemainSize() { return m_streamSize - m_readSize;}
-	int getBufferedSize();
+	int getRemainSize();
 
 	bool stepVideo(int videoPixelMode);
 	int writeVideoImage(u8* buffer, int frameWidth = 512, int videoPixelMode = 3);
@@ -76,8 +74,6 @@ public:
 	bool IsAudioEnd() { return m_isAudioEnd; }
 
 	void DoState(PointerWrap &p) {
-		p.Do(m_streamSize);
-		p.Do(m_readSize);
 		p.DoMarker("MediaEngine");
 	}
 
@@ -99,18 +95,18 @@ public:
 
 	int  m_desWidth;
 	int  m_desHeight;
-	int m_streamSize;
-	int m_readSize;
 	int m_decodeNextPos;
-	s64 m_decodedPos;
 	int m_bufSize;
 	s64 m_videopts;
-	u8* m_pdata;
+	Atrac3plus_Decoder::BufferQueue *m_pdata;
 	
 	MpegDemux *m_demux;
 	int m_audioPos;
 	void* m_audioContext;
 	s64 m_audiopts;
+
+	s64 m_firstTimeStamp;
+	s64 m_lastTimeStamp;
 
 	bool m_isVideoEnd;
 	bool m_isAudioEnd;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -93,7 +93,7 @@ public:
 
 	int  m_desWidth;
 	int  m_desHeight;
-	int m_decodeNextPos;
+	int m_decodingsize;
 	int m_bufSize;
 	s64 m_videopts;
 	Atrac3plus_Decoder::BufferQueue *m_pdata;

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -238,7 +238,7 @@ int MpegDemux::getNextaudioFrame(u8** buf, int *headerCode1, int *headerCode2)
 		audioPos = nextHeader;
 	} else
 		audioPos = gotsize;
-	m_audioStream.pop_front(m_audioFrame, audioPos);
+	m_audioStream.pop_front(0, audioPos);
 	*buf = m_audioFrame + 8;
 	if (headerCode1) *headerCode1 = Code1;
 	if (headerCode2) *headerCode2 = Code2;

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -18,7 +18,6 @@ public:
 
 	// return its framesize
 	int getNextaudioFrame(u8** buf, int *headerCode1, int *headerCode2);
-	int getFilePosition() { return m_index; }
 private:
 	struct PesHeader {
 		long pts;
@@ -53,7 +52,7 @@ private:
 	}
 	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
 	int demuxStream(bool bdemux, int startCode, int channel);
-
+public:
 	void DoState(PointerWrap &p) {
 		p.Do(m_index);
 		p.Do(m_len);

--- a/Core/HW/atrac3plus.h
+++ b/Core/HW/atrac3plus.h
@@ -77,12 +77,14 @@ namespace Atrac3plus_Decoder {
 			int bytesgot = getQueueSize();
 			if (wantedsize < bytesgot)
 				bytesgot = wantedsize;
-			if (start + bytesgot <= bufQueueSize) {
-				memcpy(buf, bufQueue + start, bytesgot);
-			} else {
-				int size = bufQueueSize - start;
-				memcpy(buf, bufQueue + start, size);
-				memcpy(buf + size, bufQueue, bytesgot - size);
+			if (buf) {
+				if (start + bytesgot <= bufQueueSize) {
+					memcpy(buf, bufQueue + start, bytesgot);
+				} else {
+					int size = bufQueueSize - start;
+					memcpy(buf, bufQueue + start, size);
+					memcpy(buf + size, bufQueue, bytesgot - size);
+				}
 			}
 			start = (start + bytesgot) % bufQueueSize;
 			return bytesgot;

--- a/Core/HW/atrac3plus.h
+++ b/Core/HW/atrac3plus.h
@@ -1,6 +1,8 @@
 #ifndef _ATRAC3PLUS_DECODER_
 #define _ATRAC3PLUS_DECODER_
 
+#include "Common/ChunkFile.h"
+
 namespace Atrac3plus_Decoder {
 	bool IsSupported();
 	bool IsInstalled();
@@ -49,6 +51,10 @@ namespace Atrac3plus_Decoder {
 			return (end + bufQueueSize - start) % bufQueueSize;
 		}
 
+		inline int getRemainSize() {
+			return bufQueueSize - getQueueSize();
+		}
+
 		bool push(unsigned char *buf, int addsize) {
 			int queuesz = getQueueSize();
 			int space = bufQueueSize - queuesz;
@@ -80,6 +86,30 @@ namespace Atrac3plus_Decoder {
 			}
 			start = (start + bytesgot) % bufQueueSize;
 			return bytesgot;
+		}
+
+		int get_front(unsigned char *buf, int wantedsize) {
+			if (wantedsize <= 0)
+				return 0;
+			int bytesgot = getQueueSize();
+			if (wantedsize < bytesgot)
+				bytesgot = wantedsize;
+			if (start + bytesgot <= bufQueueSize) {
+				memcpy(buf, bufQueue + start, bytesgot);
+			} else {
+				int size = bufQueueSize - start;
+				memcpy(buf, bufQueue + start, size);
+				memcpy(buf + size, bufQueue, bytesgot - size);
+			}
+			return bytesgot;
+		}
+
+		void DoState(PointerWrap &p) {
+			p.Do(bufQueueSize);
+			p.Do(start);
+			p.Do(end);
+			if (bufQueue)
+				p.DoArray(bufQueue, bufQueueSize);
 		}
 
 		unsigned char* bufQueue;


### PR DESCRIPTION
It may break some previous fixes, but it should be more like a real PSP, and it seems to work fine. I'm not sure if it broke some other games, maybe need more tests.
And the savestate for mpeg video part is still uncompleted, but at least mpeg audio part has been done.
