### PR TITLE
Ignore alpha when writing to display

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -40,6 +40,7 @@ static const char tex_fs[] =
 	"varying vec2 v_texcoord0;\n"
 	"void main() {\n"
 	"	gl_FragColor = texture2D(sampler0, v_texcoord0);\n"
+	"	gl_FragColor.a = 1.0;\n"
 	"}\n";
 
 static const char basic_vs[] =


### PR DESCRIPTION
Fixes #2290, I tested a bunch of games without issue but I'm a bit worried this may not be right..

But I wrote 0 alpha to the framebuffer on a PSP and it was visible...

-[Unknown]
