### PR TITLE
CWcheat Rewrite Part1

### DIFF
--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -12,7 +12,7 @@
 void __CheatInit();
 void __CheatShutdown();
 
-std::vector<std::string> makeCodeParts();
+std::vector<std::string> makeCodeParts(std::vector<std::string> CodesList);
 
 class CWCheatEngine {
 public:
@@ -24,19 +24,15 @@ public:
 	void Exit();
 	void Run();
 	std::vector<int> GetNextCode();
+	
 
 private:
 	void SkipCodes(int count);
 	void SkipAllCodes();
-	
+	bool cheatsOn, exit2, cheatEnabled;
 	int GetAddress(int value);
+	std::vector<std::string> codeNameList;
 
-	static uint64_t const serialVersionUID = 6791588139795694296ULL;
-	static const int cheatsThreadSleepMillis = 5;
-
-	bool cheatsOn;
-	std::vector<std::string> codes;
+	std::vector<std::string> codes, initialCodesList, parts;
 	size_t currentCode;
-	bool exit2;
-	std::vector<std::string> parts;
 };


### PR DESCRIPTION
Part 1 of 2 for CwCheat.

This is prep work for the in-game UI for CwCheats. This part does two things(besides cleanup):
1.Changes titles of .ini files for better identification
2.Changes format of cheats to match cheat.db files.

This will break people's current INI cheats. All thats needed to fix is the reformat them. Afterwards, creating/using the UI will be painless.

This is okay to merge to master (Assuming its up to standards :D) I wanted to get this part in before the 0.8 release. The UI will wait until Henrik is finished with the New UI stuff.
