### PR TITLE
Manage atrac IDs like the PSP does per tests

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -304,7 +304,16 @@ void __AtracInit() {
 
 void __AtracDoState(PointerWrap &p) {
 	p.Do(atracInited);
-	p.DoArray(atracIDs, PSP_NUM_ATRAC_IDS);
+	for (int i = 0; i < PSP_NUM_ATRAC_IDS; ++i) {
+		bool valid = atracIDs[i] != NULL;
+		p.Do(valid);
+		if (valid) {
+			p.Do(atracIDs[i]);
+		} else {
+			delete atracIDs[i];
+			atracIDs[i] = NULL;
+		}
+	}
 	p.DoArray(atracIDTypes, PSP_NUM_ATRAC_IDS);
 
 	p.DoMarker("sceAtrac");

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -347,8 +347,14 @@ int createAtrac(Atrac *atrac, int codecType) {
 }
 
 int deleteAtrac(int atracID) {
-	delete atracIDs[atracID];
-	atracIDs[atracID] = NULL;
+	if (atracID >= 0 && atracID < PSP_NUM_ATRAC_IDS) {
+		if (atracIDs[atracID] != NULL) {
+			delete atracIDs[atracID];
+			atracIDs[atracID] = NULL;
+
+			return 0;
+		}
+	}
 
 	return ATRAC_ERROR_BAD_ATRACID;
 }
@@ -1266,11 +1272,13 @@ int sceAtracReinit(int at3Count, int at3plusCount)
 
 	// If we ran out of space, we still initialize some, but return an error.
 	int result = space >= 0 ? 0 : SCE_KERNEL_ERROR_OUT_OF_MEMORY;
-	if (atracInited) {
+	if (atracInited || next == 0) {
 		INFO_LOG(HLE, "sceAtracReinit(%d, %d)", at3Count, at3plusCount);
+		atracInited = true;
 		return result;
 	} else {
 		INFO_LOG(HLE, "sceAtracReinit(%d, %d): init", at3Count, at3plusCount);
+		atracInited = true;
 		return hleDelayResult(result, "atrac reinit", 400);
 	}
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -484,7 +484,7 @@ u32 sceAtracGetAtracID(int codecType) {
 
 	Atrac *atrac = new Atrac();
 	atrac->codeType = codecType;
-	int atracID = createAtrac(new Atrac, codecType);
+	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
 		ERROR_LOG_REPORT(HLE, "sceAtracGetAtracID(%i): no free ID", codecType);
 		delete atrac;


### PR DESCRIPTION
This is again a bit of a larger change, it could probably wait until 0.8.  I only know of one game it fixes, Ridge Racer.  If you wait in the mini game while loading, it'll die eventually.  This makes it run fine.

I'm not sure what games might depend on this.  For example, a game could reinit so there's only one ID available, and then depend on errors in some way.  Or it might expect the id reuse and range (<= 6) the PSP firmware uses.

That said, if there's something that's supposed to free ids and we're not doing it yet (I'm not clear on the context address issue, but I know a hack was used there...), this could break things for sure.

-[Unknown]
