### PR TITLE
Measure flips per second

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -337,7 +337,7 @@ void EmuScreen::render() {
 		float vps, fps;
 		__DisplayGetFPS(&vps, &fps);
 		char fpsbuf[256];
-		sprintf(fpsbuf, "VPS: %0.1f", vps);
+		sprintf(fpsbuf, "VPS: %0.1f\nFPS: %0.1f", vps, fps);
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 8, 12, 0xc0000000, ALIGN_TOPRIGHT);
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 10, 10, 0xFF3fFF3f, ALIGN_TOPRIGHT);
 	}


### PR DESCRIPTION
Well, I like it but I dunno if other people will (even if you fast forward, it shows e.g. 30, as it's scaled by VPS.)  This means if the game is emulating slow (vps = 30) but internally the game is not frame skipping, it will stll show 60 fps (which was intentional...)

Also does not account for the frameskip setting.

-[Unknown]
