### PR TITLE
CWCheat: Fix ini titles (again) and add an offset for God Eater Burst codes to work properly.

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -166,7 +166,7 @@ void CWCheatEngine::SkipAllCodes() {
 
 int CWCheatEngine::GetAddress(int value) { //Returns static address used by ppsspp. Some games may not like this, and causes cheats to not work without offset
 	int address = (value + 0x08800000) & 0x3FFFFFFF;
-	if (gameTitle == "ULUS10563") //Offset to make God Eater Burst codes work
+	if (gameTitle == "ULUS10563" || gameTitle == "ULJS-00351" || gameTitle == "NPJH50352" ) //Offset to make God Eater Burst codes work
 		address -= 0x7EF00;
 	return address;
 }


### PR DESCRIPTION
God Eater Burst starts at a different address for some reason. Just added an offset for it so that codes work as they should.
