### PR TITLE
Check kernel object types when looking up ids

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -158,6 +158,7 @@ public:
 		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
 	}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
+	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_File; }
 	int GetIDType() const { return PPSSPP_KERNEL_TMID_File; }
 
 	virtual void DoState(PointerWrap &p) {
@@ -1441,6 +1442,7 @@ public:
 	const char *GetName() {return name.c_str();}
 	const char *GetTypeName() {return "DirListing";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
+	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_DirList; }
 	int GetIDType() const { return PPSSPP_KERNEL_TMID_DirList; }
 
 	virtual void DoState(PointerWrap &p) {

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -40,6 +40,7 @@ struct Alarm : public KernelObject
 	const char *GetName() {return "[Alarm]";}
 	const char *GetTypeName() {return "Alarm";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_ALMID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Alarm; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Alarm; }
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -64,6 +64,7 @@ public:
 	static u32 GetMissingErrorCode() {
 		return SCE_KERNEL_ERROR_UNKNOWN_EVFID;
 	}
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_EventFlag; }
 	int GetIDType() const { return SCE_KERNEL_TMID_EventFlag; }
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -53,6 +53,7 @@ struct Mbx : public KernelObject
 	const char *GetName() {return nmb.name;}
 	const char *GetTypeName() {return "Mbx";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MBXID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mbox; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Mbox; }
 
 	void AddWaitingThread(SceUID id, u32 addr)

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -72,6 +72,7 @@ struct FPL : public KernelObject
 	const char *GetName() {return nf.name;}
 	const char *GetTypeName() {return "FPL";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_FPLID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Fpl; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Fpl; }
 
 	int findFreeBlock() {
@@ -133,6 +134,7 @@ struct VPL : public KernelObject
 	const char *GetName() {return nv.name;}
 	const char *GetTypeName() {return "VPL";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_VPLID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Vpl; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Vpl; }
 
 	VPL() : alloc(8) {}
@@ -424,6 +426,7 @@ public:
 		sprintf(ptr, "MemPart: %08x - %08x	size: %08x", address, address + sz, sz);
 	}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_UID; }
+	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_PMB; }
 	int GetIDType() const { return PPSSPP_KERNEL_TMID_PMB; }
 
 	PartitionMemoryBlock(BlockAllocator *_alloc, const char *_name, u32 size, MemblockType type, u32 alignment)
@@ -1331,6 +1334,7 @@ struct TLS : public KernelObject
 	const char *GetName() {return ntls.name;}
 	const char *GetTypeName() {return "TLS";}
 	static u32 GetMissingErrorCode() { return PSP_ERROR_UNKNOWN_TLS_ID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Tls; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Tls; }
 
 	TLS() : next(0) {}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -179,6 +179,7 @@ public:
 			nm.entry_addr);
 	}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MODULE; }
+	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_Module; }
 	int GetIDType() const { return PPSSPP_KERNEL_TMID_Module; }
 
 	virtual void DoState(PointerWrap &p)
@@ -1349,7 +1350,7 @@ u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
 	state.addr = moduleAddr;
 	state.result = SCE_KERNEL_ERROR_UNKNOWN_MODULE;
 
-	kernelObjects.Iterate(&__GetModuleIdByAddressIterator, &state, PPSSPP_KERNEL_TMID_Module);
+	kernelObjects.Iterate(&__GetModuleIdByAddressIterator, &state);
 	if (state.result == SCE_KERNEL_ERROR_UNKNOWN_MODULE)
 		ERROR_LOG(HLE, "sceKernelGetModuleIdByAddress(%08x): module not found", moduleAddr)
 	else

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -55,6 +55,7 @@ struct MsgPipe : public KernelObject
 	const char *GetName() {return nmp.name;}
 	const char *GetTypeName() {return "MsgPipe";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MPPID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mpipe; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Mpipe; }
 
 	MsgPipe() : buffer(NULL) {}

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -64,6 +64,7 @@ struct Mutex : public KernelObject
 	const char *GetName() {return nm.name;}
 	const char *GetTypeName() {return "Mutex";}
 	static u32 GetMissingErrorCode() { return PSP_MUTEX_ERROR_NO_SUCH_MUTEX; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mutex; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Mutex; }
 
 	virtual void DoState(PointerWrap &p)
@@ -125,6 +126,7 @@ struct LwMutex : public KernelObject
 	const char *GetName() {return nm.name;}
 	const char *GetTypeName() {return "LwMutex";}
 	static u32 GetMissingErrorCode() { return PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_LwMutex; }
 	int GetIDType() const { return SCE_KERNEL_TMID_LwMutex; }
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -57,6 +57,7 @@ struct Semaphore : public KernelObject
 	const char *GetTypeName() {return "Semaphore";}
 
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_SEMID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Semaphore; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Semaphore; }
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -82,6 +82,7 @@ public:
 	}
 
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_CBID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Callback; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Callback; }
 
 	virtual void DoState(PointerWrap &p)
@@ -295,7 +296,7 @@ public:
 	}
 
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_THID; }
-
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Thread; }
 	int GetIDType() const { return SCE_KERNEL_TMID_Thread; }
 
 	bool AllocateStack(u32 &stackSize)

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -42,6 +42,7 @@ struct VTimer : public KernelObject {
 	const char *GetName() {return nvt.name;}
 	const char *GetTypeName() {return "VTimer";}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_VTID; }
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_VTimer; }
 	int GetIDType() const { return SCE_KERNEL_TMID_VTimer; }
 
 	virtual void DoState(PointerWrap &p) {


### PR DESCRIPTION
Some games misuse it, need to return an error.  Just adds a new static method.

-[Unknown]
