### PR TITLE
Correctly read 48-bit pts in scePsmf as well

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -231,8 +231,8 @@ Psmf::Psmf(u32 data) {
 	streamOffset = bswap32(Memory::Read_U32(data + 8));
 	streamSize = bswap32(Memory::Read_U32(data + 12));
 	streamDataTotalSize = bswap32(Memory::Read_U32(data + 0x50));
-	presentationStartTime = bswap32(Memory::Read_U32(data + PSMF_FIRST_TIMESTAMP_OFFSET));
-	presentationEndTime = bswap32(Memory::Read_U32(data + PSMF_LAST_TIMESTAMP_OFFSET));
+	presentationStartTime = getMpegTimeStamp(Memory::GetPointer(data + PSMF_FIRST_TIMESTAMP_OFFSET));
+	presentationEndTime = getMpegTimeStamp(Memory::GetPointer(data + PSMF_LAST_TIMESTAMP_OFFSET));
 	streamDataNextBlockSize = bswap32(Memory::Read_U32(data + 0x6A));
 	streamDataNextInnerBlockSize = bswap32(Memory::Read_U32(data + 0x7C));
 	numStreams = bswap16(Memory::Read_U16(data + 0x80));


### PR DESCRIPTION
Attempt to fix #2347.  This was still reading it as 32-bits from the offset, but the constant was updated to be -2 for the extra 16 bits.  Since it's big endian that's no good, it's reading the most significant 32 bits only.

-[Unknown]
