### PR TITLE
Fix sceCtrl analog range for all input devices.

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -161,11 +161,11 @@ void __CtrlSetAnalog(float x, float y, int stick)
 {
 	std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 	if (stick == 0) {
-		ctrlCurrent.analog[0] = (u8)(x * 127.5f + 128.f);
-		ctrlCurrent.analog[1] = (u8)(-y * 127.5f + 128.f);
+		ctrlCurrent.analog[0] = (u8)ceilf(x * 127.5f + 127.5f);
+		ctrlCurrent.analog[1] = (u8)ceilf(-y * 127.5f + 127.5f);
 	} else {
-		ctrlCurrent.analogRight[0] = (u8)(x * 127.5f + 128.f);
-		ctrlCurrent.analogRight[1] = (u8)(-y * 127.5f + 128.f);
+		ctrlCurrent.analogRight[0] = (u8)ceilf(x * 127.5f + 127.5f);
+		ctrlCurrent.analogRight[1] = (u8)ceilf(-y * 127.5f + 127.5f);
 	}
 }
 

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -161,11 +161,11 @@ void __CtrlSetAnalog(float x, float y, int stick)
 {
 	std::lock_guard<std::recursive_mutex> guard(ctrlMutex);
 	if (stick == 0) {
-		ctrlCurrent.analog[0] = (u8)(x * 127.f + 128.f);
-		ctrlCurrent.analog[1] = (u8)(-y * 127.f + 128.f);
+		ctrlCurrent.analog[0] = (u8)(x * 127.5f + 128.f);
+		ctrlCurrent.analog[1] = (u8)(-y * 127.5f + 128.f);
 	} else {
-		ctrlCurrent.analogRight[0] = (u8)(x * 127.f + 128.f);
-		ctrlCurrent.analogRight[1] = (u8)(-y * 127.f + 128.f);
+		ctrlCurrent.analogRight[0] = (u8)(x * 127.5f + 128.f);
+		ctrlCurrent.analogRight[1] = (u8)(-y * 127.5f + 128.f);
 	}
 }
 


### PR DESCRIPTION
It should map (-1.0... 0.0... 1.0) to (0... 128... 255.)  However, it was instead being mapped to (1... 128... 255.)  Close, but not good enough.  This was causing games to not respect analog movement if they checked for 100%.

Fixes #2363.  Maybe this is dependent on the rounding mode, though...

-[Unknown]
