### PR TITLE
Clean up RE code in sceChnnlsv.{cpp,h}

### DIFF
--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -27,321 +27,217 @@ extern "C"
 u8 dataBuf[2048+20];
 u8* dataBuf2 = dataBuf + 20;
 
-static const u8 hash198C[16] = {0xFA, 0xAA, 0x50, 0xEC, 0x2F, 0xDE, 0x54, 0x93, 0xAD, 0x14, 0xB2, 0xCE, 0xA5, 0x30, 0x05, 0xDF };
-static const u8 hash19BC[16] = {0xCB, 0x15, 0xF4, 0x07, 0xF9, 0x6A, 0x52, 0x3C, 0x04, 0xB9, 0xB2, 0xEE, 0x5C, 0x53, 0xFA, 0x86 };
+static const u8 hash198C[16] = {0xFA, 0xAA, 0x50, 0xEC, 0x2F, 0xDE, 0x54, 0x93, 0xAD, 0x14, 0xB2, 0xCE, 0xA5, 0x30, 0x05, 0xDF};
+static const u8 hash19BC[16] = {0xCB, 0x15, 0xF4, 0x07, 0xF9, 0x6A, 0x52, 0x3C, 0x04, 0xB9, 0xB2, 0xEE, 0x5C, 0x53, 0xFA, 0x86};
 
-static const u8 key000019CC[16] = {0x70, 0x44, 0xA3, 0xAE, 0xEF, 0x5D, 0xA5, 0xF2, 0x85, 0x7F, 0xF2, 0xD6, 0x94, 0xF5, 0x36, 0x3B};
-static const u8 key000019DC[16] = {0xEC, 0x6D, 0x29, 0x59, 0x26, 0x35, 0xA5, 0x7F, 0x97, 0x2A, 0x0D, 0xBC, 0xA3, 0x26, 0x33, 0x00};
-static const u8 key0000199C[16] = {0x36, 0xA5, 0x3E, 0xAC, 0xC5, 0x26, 0x9E, 0xA3, 0x83, 0xD9, 0xEC, 0x25, 0x6C, 0x48, 0x48, 0x72};
-static const u8 key000019AC[16] = {0xD8, 0xC0, 0xB0, 0xF3, 0x3E, 0x6B, 0x76, 0x85, 0xFD, 0xFB, 0x4D, 0x7D, 0x45, 0x1E, 0x92, 0x03};
+static const u8 key19CC[16]  = {0x70, 0x44, 0xA3, 0xAE, 0xEF, 0x5D, 0xA5, 0xF2, 0x85, 0x7F, 0xF2, 0xD6, 0x94, 0xF5, 0x36, 0x3B};
+static const u8 key19DC[16]  = {0xEC, 0x6D, 0x29, 0x59, 0x26, 0x35, 0xA5, 0x7F, 0x97, 0x2A, 0x0D, 0xBC, 0xA3, 0x26, 0x33, 0x00};
+static const u8 key199C[16]  = {0x36, 0xA5, 0x3E, 0xAC, 0xC5, 0x26, 0x9E, 0xA3, 0x83, 0xD9, 0xEC, 0x25, 0x6C, 0x48, 0x48, 0x72};
+static const u8 key19AC[16]  = {0xD8, 0xC0, 0xB0, 0xF3, 0x3E, 0x6B, 0x76, 0x85, 0xFD, 0xFB, 0x4D, 0x7D, 0x45, 0x1E, 0x92, 0x03};
 
-int sub_000014BC(u8* data, int length)
+void *memxor(void * dest, const void * src, size_t n)
 {
-	*(s32*)(data + 0) = 5;
-	*(s32*)(data + 12) = 256;
-	*(s32*)(data + 4) = 0;
-	*(s32*)(data + 8) = 0;
-	*(s32*)(data + 16) = length;
-	int res = sceUtilsBufferCopyWithRange(data, length + 20, data, length + 20, 8);
-	if (res == 0)
-		return 0;
-	return -258;
+  char const *s = (char const*)src;
+  char *d = (char*)dest;
+
+  for (; n > 0; n--)
+    *d++ ^= *s++;
+
+  return dest;
 }
 
-int sub_00001418(u8* data, int length, int val2)
+// The reason for the values from *FromMode calculations are not known.
+int numFromMode(int mode)
 {
-	*(s32*)(data + 12) = val2;
-	*(s32*)(data + 0) = 5;
-	*(s32*)(data + 4) = 0;
-	*(s32*)(data + 8) = 0;
-	*(s32*)(data + 16) = length;
-	int res = sceUtilsBufferCopyWithRange(data, length + 20, data, length + 20, 7);
-	if (res == 0)
-		return 0;
-	return -257;
-}
-
-
-int sub_000015B0(u8* data, int alignedLen, u8* buf, int val)
-{
-	u8 sp0[16];
-
-	for(int i = 0; i < 16; i++)
-	{
-		sp0[i] = data[alignedLen+i+4];
-	}
-	int res = sub_00001418(data, alignedLen, val);
-	if (res != 0)
-	{
-		return res;
-	}
-
-	for(int i = 0; i < 16; i++)
-	{
-		data[i] = data[i] ^ buf[i];
-	}
-	for(int i = 0; i < 16; i++)
-	{
-		buf[i] = sp0[i];
-	}
-	return 0;
-}
-
-int sub_00000000(u8* data_out, u8* data, int alignedLen, u8* data2, int& data3, int mode)
-{
-	for(int i = 0; i < 16; i++)
-	{
-		data_out[20+i] = data2[i];
-	}
-	int valS4 = 100;
-	int res;
-	if (mode == 6)
-	{
-		valS4 = 100;
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[20+i] = data_out[20+i] ^ key000019DC[i];
-		}
-		res = sub_000014BC(data_out, 16);
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i] = data_out[i] ^ key000019CC[i];
-		}
-	}
-	else if (mode == 4)
-	{
-		valS4 = 87;
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[20+i] = data_out[20+i] ^ key000019AC[i];
-		}
-		res = sub_000014BC(data_out, 16);
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i] = data_out[i] ^ key0000199C[i];
-		}
-	}
-	else if (mode == 2)
-	{
-		res = sub_000014BC(data_out, 16);
-		valS4 = 83;
-	}
-	else if (mode == 1)
-	{
-		res = sub_00001418(data_out, 16, 4);
-		valS4 = 83;
-	}
-	else  if (mode == 3)
-	{
-		valS4 = 87;
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i+20] = data_out[i+20] ^ key000019AC[i];
-		}
-		res = sub_00001418(data_out, 16, 14);
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i] = data_out[i] ^ key0000199C[i];
-		}
-	}
-	else
-	{
-		valS4 = 100;
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i + 20] = data_out[i + 20] ^ key000019DC[i];
-		}
-		res = sub_00001418(data_out, 16, 18);
-		for(int i = 0; i < 16; i++)
-		{
-			data_out[i] = data_out[i] ^ key000019CC[i];
-		}
-	}
-
-	u8 sp16[16];
-	if (res != 0)
-	{
-		return res;
-	}
-	for(int i = 0; i < 16; i++)
-	{
-		sp16[i] = data_out[i];
-	}
-	u8 sp0[16];
-	if (data3 == 1)
-	{
-		for(int i = 0; i < 16; i++)
-		{
-			sp0[i] = 0;
-		}
-	}
-	else
-	{
-		for(int i = 0; i < 12; i++)
-		{
-			sp0[i] = sp16[i];
-		}
-		sp0[12] = (data3-1)  & 0xFF ;
-		sp0[13] = ((data3-1) >> 8) & 0xFF;
-		sp0[14] = ((data3-1) >> 16) & 0xFF;
-		sp0[15] = ((data3-1) >> 24) & 0xFF;
-	}
-
-	if ((u32)20 < (u32)alignedLen + 20)
-	{
-		for(int i = 20; i < alignedLen + 20; i += 16)
-		{
-			for(int j = 0; j < 12; j++)
-			{
-				data_out[i+j] = sp16[j];
-			}
-			data_out[12+i] = data3;
-			data_out[13+i] = (data3 >> 8) & 0xFF;
-			data_out[14+i] = (data3 >> 16) & 0xFF;
-			data_out[15+i] = (data3 >> 24) & 0xFF;
-			data3++;
-		}
-	}
-
-	res = sub_000015B0(data_out, alignedLen, sp0, valS4);
-	if (res != 0)
-	{
-		return res;
-	}
-	if (res >= alignedLen)
-	{
-		return 0;
-	}
-	for(int i = 0; i < alignedLen; i++)
-	{
-		data[i] = data[i] ^ data_out[i];
-	}
-
-	return 0;
-}
-
-int sub_000013C8(u8* data, int size, int num)
-{
-	*(int*)(data+0) = 4;
-	*(int*)(data+4) = 0;
-	*(int*)(data+8) = 0;
-	*(int*)(data+12) = num;
-	*(int*)(data+16) = size;
-	size = size + 20;
-
-	int res = sceUtilsBufferCopyWithRange(data,size,data,size,4);
-	if(res != 0)
-	{
-		return -257;
-	}
-	return 0;
-}
-
-int sub_00001468(u8* data, int size)
-{
-	*(int*)(data+0) = 4;
-	*(int*)(data+12) = 256;
-	*(int*)(data+4) = 0;
-	*(int*)(data+8) = 0;
-	*(int*)(data+16) = size;
-	size = size + 20;
-
-	int res = sceUtilsBufferCopyWithRange(data,size,data,size,5);
-	if(res != 0)
-	{
-		return -258;
-	}
-	return 0;
-}
-
-int sub_00001510(u8* data, int size, u8* result , int num)
-{
-	for(int i = 0; i < 16; i++)
-	{
-		int v1 = data[i+20];
-		v1 = v1 ^ result[i];
-		data[i+20] = v1;
-	}
-
-	int res = sub_000013C8(data, size,  num);
-	if(res != 0)
-	{
-		return res;
-	}
-
-	for(int i = 0; i < 16; i++)
-	{
-		result[i] = data[size + i + 4];
-	}
-	return 0;
-}
-
-int sub_000017A8(u8* data)
-	{
-	int res = sceUtilsBufferCopyWithRange(data, 20, 0, 0, 14);
-	if (res == 0)
-		return 0;
-	return -261;
-}
-
-int sceSdGetLastIndex(u32 addressCtx,u32 addressHash, u32 addressKey)
-{
-	pspChnnlsvContext1 ctx;
-	Memory::ReadStruct(addressCtx,&ctx);
-	u8* in_hash;
-	u8* in_key;
-	in_hash = Memory::GetPointer(addressHash);
-	in_key = Memory::GetPointer(addressKey);
-
-	int res = sceSdGetLastIndex_(ctx, in_hash, in_key);
-
-	Memory::WriteStruct(addressCtx,&ctx);
-	return res;
-}
-int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
-{
-	if(ctx.keyLength >= 17)
-	{
-		return -1026;
-	}
 	int num = 0;
-	switch(ctx.mode)
+	switch(mode)
 	{
-	case 6:
-		num = 17;
-		break;
-	case 4:
-		num = 13;
+	case 1:
+		num = 3;
 		break;
 	case 2:
 		num = 5;
 		break;
-	case 1:
-		num = 3;
-		break;
 	case 3:
 		num = 12;
+		break;
+	case 4:
+		num = 13;
+		break;
+	case 6:
+		num = 17;
 		break;
 	default:
 		num = 16;
 		break;
 	}
+	return num;
+}
+int numFromMode2(int mode)
+{
+	int num = 18;
+	if (mode == 1)
+		num = 4;
+	else if (mode == 3)
+		num = 14;
+	return num;
+}
 
-	memset(dataBuf2,0,16);
+int typeFromMode(int mode)
+{
+	return (mode == 1 || mode == 2) ? 83 :
+	      ((mode == 3 || mode == 4) ? 87 : 100);	
+}
 
-	int res = sub_000013C8(dataBuf,16,num);
-	if(res != 0)
-	{
+int kirkSendCmd(u8* data, int length, int num, bool encrypt)
+{
+	*(int*)(data+0) = encrypt ? KIRK_MODE_ENCRYPT_CBC : KIRK_MODE_DECRYPT_CBC;
+	*(int*)(data+4) = 0;
+	*(int*)(data+8) = 0;
+	*(int*)(data+12) = num;
+	*(int*)(data+16) = length;
+
+	if (sceUtilsBufferCopyWithRange(data, length + 20, data, length + 20, encrypt ? KIRK_CMD_ENCRYPT_IV_0 : KIRK_CMD_DECRYPT_IV_0))
+		return -257;
+
+	return 0;
+}
+
+int kirkSendFuseCmd(u8* data, int length, bool encrypt)
+{
+	*(int*)(data+0) = encrypt ? KIRK_MODE_ENCRYPT_CBC : KIRK_MODE_DECRYPT_CBC;
+	*(int*)(data+4) = 0;
+	*(int*)(data+8) = 0;
+	*(int*)(data+12) = 256;
+	*(int*)(data+16) = length;
+
+	// Note: CMD 5 and 8 are not available, will always return -1
+	if (sceUtilsBufferCopyWithRange(data, length + 20, data, length + 20, encrypt ? KIRK_CMD_ENCRYPT_IV_FUSE : KIRK_CMD_DECRYPT_IV_FUSE))
+		return -258;
+
+	return 0;
+}
+
+int sub_15B0(u8* data, int alignedLen, u8* buf, int val)
+{
+	u8 sp0[16];
+	memcpy(sp0, data+alignedLen+4, 16);
+
+	int res = kirkSendCmd(data, alignedLen, val, false);
+	if (res)
 		return res;
+
+	memxor(data, buf, 16);
+	memcpy(buf, sp0, 16);
+	return 0;
+}
+
+int sub_0000(u8* data_out, u8* data, int alignedLen, u8* data2, int& data3, int mode)
+{
+	memcpy(data_out+20, data2, 16);
+	// Mode 1:2 is 83, 3:4 is 87, 5:6 is 100
+	int type = typeFromMode(mode);
+	int res;
+
+	if (type == 87)
+		memxor(data_out+20, key19AC, 16);
+	else if (type == 100)
+		memxor(data_out+20, key19DC, 16);
+
+	// Odd is Cmd, Even is FuseCmd
+	switch(mode)
+	{
+	case 2: case 4:	case 6:	res = kirkSendFuseCmd(data_out, 16, false);
+	break;
+	case 1:	case 3:	default:res = kirkSendCmd(data_out, 16, numFromMode2(mode), false);
+	break;
 	}
 
-	u8 data1[16];
-	u8 data2[16];
+	if (type == 87)
+		memxor(data_out, key199C, 16);
+	else if (type == 100)
+		memxor(data_out, key19CC, 16);
 
-	memcpy(data1,dataBuf2,16);
-	int tmp1 = 0;
-	if((s8)data1[0] < 0)
-		tmp1 = 135;
+	if (res)
+		return res;
+
+	u8 sp0[16], sp16[16];
+	memcpy(sp16, data_out, 16);
+	if (data3 == 1)
+	{
+		memset(sp0, 0, 16);
+	}
+	else
+	{
+		memcpy(sp0, sp16, 12);
+		*(u32*)(sp0+12) = data3-1;
+	}
+
+	if (alignedLen > 0)
+	{
+		for(int i = 20; i < alignedLen + 20; i += 16)
+		{
+			memcpy(data_out+i, sp16, 12);
+			*(u32*)(data_out+12+i) = data3;
+			data3++;
+		}
+	}
+
+	res = sub_15B0(data_out, alignedLen, sp0, type);
+	if (res)
+		return res;
+
+	if (alignedLen > 0)
+		memxor(data, data_out, alignedLen);
+
+	return 0;
+}
+
+int sub_1510(u8* data, int size, u8* result , int num)
+{
+	memxor(data+20, result, 16);
+
+	int res = kirkSendCmd(data, size, num, true);
+	if(res)
+		return res;
+
+	memcpy(result, data+size+4, 16);
+	return 0;
+}
+
+int sub_17A8(u8* data)
+{
+	if (sceUtilsBufferCopyWithRange(data, 20, 0, 0, 14) == 0)
+		return 0;
+	return -261;
+}
+
+int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey)
+{
+	pspChnnlsvContext1 ctx;
+	Memory::ReadStruct(addressCtx, &ctx);
+	int res = sceSdGetLastIndex_(ctx, Memory::GetPointer(addressHash), Memory::GetPointer(addressKey));
+	Memory::WriteStruct(addressCtx, &ctx);
+	return res;
+}
+
+int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
+{
+	if(ctx.keyLength >= 17)
+		return -1026;
+
+	int num = numFromMode(ctx.mode);
+
+	memset(dataBuf2, 0, 16);
+
+	int res = kirkSendCmd(dataBuf, 16, num, true);
+	if(res)
+		return res;
+
+	u8 data1[16], data2[16];
+
+	memcpy(data1, dataBuf2, 16);
+	int tmp1 = (data1[0] & 0x80) ? 135 : 0;
 
 	for(int i = 0; i < 15; i++)
 	{
@@ -373,72 +269,37 @@ int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
 
 		int oldKeyLength = ctx.keyLength;
 		*(s8*)(ctx.key + ctx.keyLength) = -128;
-		if(oldKeyLength + 1 < 16)
-		{
-			for(int i = oldKeyLength + 1; i < 16; i++)
-			{
-				*(s8*)(ctx.key + i) = 0;
-			}
-		}
+		int i = oldKeyLength + 1;
+		if(i < 16)
+			memset(ctx.key + i, 0, 16 - i);
 	}
 
-	for(int i = 0; i < 16; i++)
-	{
-		ctx.key[i] = ctx.key[i] ^ data1[i];
-	}
+	memxor(ctx.key, data1, 16);
+	memcpy(dataBuf2, ctx.key, 16);
+	memcpy(data2, ctx.result, 16);
 
-	for(int i = 0; i < 16; i++)
-	{
-		dataBuf2[i] = ctx.key[i];
-	}
-
-	for(int i = 0; i < 16; i++)
-	{
-		data2[i] = ctx.result[i];
-	}
-	int ret = sub_00001510(dataBuf,16,data2,num);
-	if(ret != 0)
-	{
+	int ret = sub_1510(dataBuf, 16, data2, num);
+	if(ret)
 		return ret;
-	}
 
-	if((u32)(ctx.mode-3) < 2)
-	{
-		for(int i = 0; i < 16; i++)
-		{
-			data2[i] = data2[i] ^ hash198C[i];
-		}
-	}
-	else if((u32)(ctx.mode-5) < 2)
-	{
-		for(int i = 0; i < 16; i++)
-		{
-			data2[i] = data2[i] ^ hash19BC[i];
-		}
-	}
+	if(ctx.mode == 3 || ctx.mode == 4)
+		memxor(data2, hash198C, 16);
+	else if(ctx.mode == 5 || ctx.mode == 6)
+		memxor(data2, hash19BC, 16);
 
 	int cond = ((ctx.mode ^ 0x2) < 1 || (ctx.mode ^ 0x4) < 1 || ctx.mode == 6);
 	if(cond != 0)
 	{
-		for(int i = 0; i < 16; i++)
-		{
-			dataBuf2[i] = data2[i];
-		}
-		int ret = sub_00001468(dataBuf,16);
-		if(ret != 0)
-		{
+		memcpy(dataBuf2, data2, 16);
+		int ret = kirkSendFuseCmd(dataBuf, 16, true);
+		if(ret)
 			return ret;
-		}
-		int res = sub_000013C8(dataBuf,16,num);
-		if(res != 0)
-		{
-			return res;
-		}
 
-		for(int i = 0; i < 16; i++)
-		{
-			data2[i] = dataBuf2[i];
-		}
+		int res = kirkSendCmd(dataBuf, 16, num, true);
+		if(res)
+			return res;
+
+		memcpy(data2, dataBuf2, 16);
 	}
 
 	if(in_key != 0)
@@ -448,37 +309,16 @@ int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
 			data2[i] = in_key[i] ^ data2[i];
 		}
 
-		for(int i = 0; i < 16; i++)
-		{
-			dataBuf2[i] = data2[i];
-		}
+		memcpy(dataBuf2, data2, 16);
 
-		int res = sub_000013C8(dataBuf,16,num);
-		if(res != 0)
-		{
+		int res = kirkSendCmd(dataBuf, 16, num, true);
+		if(res)
 			return res;
-		}
-		for(int i = 0; i < 16; i++)
-		{
-			data2[i] = dataBuf2[i];
-		}
-	}
-	for(int i = 0; i < 16; i++)
-	{
-		in_hash[i] = data2[i];
-	}
 
-	for(int i = 0; i < 16; i++)
-	{
-		ctx.result[i] = 0;
+		memcpy(data2, dataBuf2, 16);
 	}
-
-	for(int i = 0; i < 16; i++)
-	{
-		ctx.key[i] = 0;
-	}
-	ctx.keyLength = 0;
-	ctx.mode = 0;
+	memcpy(in_hash, data2, 16);
+	sceSdSetIndex_(ctx, 0);
 
 	return 0;
 }
@@ -495,8 +335,8 @@ int sceSdSetIndex(u32 addressCtx, int value)
 int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
 {
 	ctx.mode = value;
-	memset(ctx.result,0,16);
-	memset(ctx.key,0,16);
+	memset(ctx.result, 0, 16);
+	memset(ctx.key, 0, 16);
 	ctx.keyLength = 0;
 	return 0;
 }
@@ -505,104 +345,52 @@ int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
 int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length)
 {
 	pspChnnlsvContext1 ctx;
-	Memory::ReadStruct(addressCtx,&ctx);
-	u8* data;
-	data = Memory::GetPointer(addressData);
+	Memory::ReadStruct(addressCtx, &ctx);
+	int res = sceSdRemoveValue_(ctx, Memory::GetPointer(addressData), length);
+	Memory::WriteStruct(addressCtx, &ctx);
 
-	int res = sceSdRemoveValue_(ctx, data, length);
-
-	Memory::WriteStruct(addressCtx,&ctx);
 	return res;
 }
 
 int sceSdRemoveValue_(pspChnnlsvContext1& ctx, u8* data, int length)
 {
 	if(ctx.keyLength >= 17)
-	{
 		return -1026;
-	}
+
 	if(ctx.keyLength + length < 17)
 	{
-		if(length == 0)
-		{
-			return 0;
-		}
-		for(int i = 0; i < length; i++)
-		{
-			ctx.key[ctx.keyLength+i] = data[i];
-		}
+		memcpy(ctx.key+ctx.keyLength, data, length);
 		ctx.keyLength = ctx.keyLength + length;
 		return 0;
 	}
-	int mode = ctx.mode;
-	int num = 0;
-	switch(mode)
-	{
-	case 6:
-		num = 17;
-		break;
-	case 4:
-		num = 13;
-		break;
-	case 2:
-		num = 5;
-		break;
-	case 1:
-		num = 3;
-		break;
-	case 3:
-		num = 12;
-		break;
-	default:
-		num = 16;
-		break;
-	}
+	int num = numFromMode(ctx.mode);
 
-	memset(dataBuf2,0,2048);
+	memset(dataBuf2, 0, 2048);
+	memcpy(dataBuf2, ctx.key, ctx.keyLength);
 
-	if(ctx.keyLength > 0)
-	{
-		memcpy(dataBuf2,ctx.key,ctx.keyLength);
-	}
 	int len = (ctx.keyLength + length) & 0xF;
 	if(len == 0) len = 16;
 
-	int oldLength = ctx.keyLength;
+	int newSize = ctx.keyLength;
 	ctx.keyLength = len;
 
 	int diff = length - len;
-	if(len != 0)
+	memcpy(ctx.key, data+diff, len);
+	for(int i = 0; i < diff; i++)
 	{
-		memcpy(ctx.key,data+diff,len);
-	}
-
-	int newSize = oldLength;
-	if(diff != 0)
-	{
-		for(int i = 0; i < diff; i++)
+		if(newSize == 2048)
 		{
-			if(newSize == 2048)
-			{
-				int res = sub_00001510(dataBuf,2048,ctx.result,num);
-				if(res != 0)
-				{
-					return res;
-				}
-				newSize = 0;
-			}
-			dataBuf2[newSize] = data[i];
-			newSize++;
+			int res = sub_1510(dataBuf, 2048, ctx.result, num);
+			if(res)
+				return res;
+			newSize = 0;
 		}
+		dataBuf2[newSize] = data[i];
+		newSize++;
 	}
-	if(newSize == 0)
-	{
-		return 0;
-	}
-	int res = sub_00001510(dataBuf,newSize,ctx.result, num);
-	if(res == 0)
-	{
-		return res;
-	}
+	if(newSize)
+		sub_1510(dataBuf, newSize, ctx.result, num);
+	// The RE code showed this always returning 0. I suspect it would want to return res instead.
 	return 0;
 }
 
@@ -626,116 +414,49 @@ int sceSdCreateList_(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, u8*
 	ctx2.unkn = 1;
 	if (uknw == 2)
 	{
-		for(int i = 0; i < 16; i++)
-		{
-			ctx2.unknown[i] = data[i];
-		}
-		if (cryptkey == 0)
-		{
-			return 0;
-		}
+		memcpy(ctx2.cryptedData, data, 16);
+		if (cryptkey)
+			memxor(ctx2.cryptedData, cryptkey, 16);
 
-		for(int i = 0; i < 16; i++)
-		{
-			ctx2.unknown[i] = ctx2.unknown[i] ^ cryptkey[i];
-		}
 		return 0;
 	}
 	else if (uknw == 1)
 	{
 		u8 kirkHeader[37];
 		u8* kirkData = kirkHeader+20;
-		int res = sub_000017A8(kirkHeader);
-		if (res != 0)
-		{
+		int res = sub_17A8(kirkHeader);
+		if (res)
 			return res;
-		}
-		for(int i = 15; i >= 0 ; i--)
+
+		memcpy(kirkHeader+20, kirkHeader, 16);
+		memset(kirkHeader+32, 0, 4);
+
+		int type = typeFromMode(mode);
+		if (type == 87)
+			memxor(kirkData, key199C, 16);
+		else if (type == 100)
+			memxor(kirkData, key19CC, 16);
+
+		switch (mode)
 		{
-			kirkHeader[i+20] = kirkHeader[i];
-		}
-		for(int i = 0; i < 4; i++)
-		{
-			kirkHeader[i+32] = 0;
+		case 2:	case 4:	case 6:	res = kirkSendFuseCmd(kirkHeader, 16, true);
+		break;
+		case 1:	case 3:	default:res = kirkSendCmd(kirkHeader, 16, numFromMode2(mode), true);
+		break;
 		}
 
-		if (mode == 6)
-		{
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key000019CC[i];
-			}
-			res = sub_00001468(kirkHeader, 16);
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key000019DC[i];
-			}
-		}
-		else if (mode == 4)
-		{
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key0000199C[i];
-			}
-			res = sub_00001468(kirkHeader, 16);
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key000019AC[i];
-			}
-		}
-		else if (mode == 2)
-		{
-			res = sub_00001468(kirkHeader, 16);
-		}
-		else if (mode == 1)
-		{
-			res = sub_000013C8(kirkHeader, 16, 4);
-		}
-		else if (mode == 3)
-		{
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key0000199C[i];
-			}
-			res = sub_000013C8(kirkHeader, 16, 14);
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] =  kirkData[i] ^ key000019AC[i];
-			}
-		}
-		else
-		{
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key000019CC[i];
-			}
-			res = sub_000013C8(kirkHeader, 16, 18);
-			for(int i = 0; i < 16; i++)
-			{
-				kirkData[i] = kirkData[i] ^ key000019DC[i];
-			}
-		}
+		if (type == 87)
+			memxor(kirkData, key19AC, 16);
+		else if (type == 100)
+			memxor(kirkData, key19DC, 16);
 
-		if (res != 0)
-		{
+		if (res)
 			return res;
-		}
 
-		for(int i = 0; i < 16; i++)
-		{
-			ctx2.unknown[i] = kirkData[i];
-		}
-		for(int i = 0; i < 16; i++)
-		{
-			data[i] = kirkData[i];
-		}
-		if (cryptkey != 0)
-		{
-			for(int i = 0; i < 16; i++)
-			{
-				ctx2.unknown[i] = ctx2.unknown[i] ^ cryptkey[i];
-			}
-		}
+		memcpy(ctx2.cryptedData, kirkData, 16);
+		memcpy(data, kirkData, 16);
+		if (cryptkey)
+			memxor(ctx2.cryptedData, cryptkey, 16);
 	}
 
 	return 0;
@@ -770,12 +491,10 @@ int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
 	{
 		for(i = 0; alignedLen >= 2048; i += 2048)
 		{
-			int res = sub_00000000(kirkData, data + i, 2048, ctx.unknown, ctx.unkn, ctx.mode);
-			alignedLen = alignedLen - 2048;
-			if (res != 0)
-			{
+			int res = sub_0000(kirkData, data + i, 2048, ctx.cryptedData, ctx.unkn, ctx.mode);
+			alignedLen -= 2048;
+			if (res)
 				return res;
-			}
 		}
 	}
 	if (alignedLen == 0)
@@ -783,8 +502,7 @@ int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
 		return 0;
 	}
 
-	int res = sub_00000000(kirkData, data + i, alignedLen, ctx.unknown, ctx.unkn, ctx.mode);
-	return res;
+	return sub_0000(kirkData, data + i, alignedLen, ctx.cryptedData, ctx.unkn, ctx.mode);
 }
 
 int sceChnnlsv_21BE78B4(u32 ctxAddr)
@@ -800,10 +518,7 @@ int sceChnnlsv_21BE78B4(u32 ctxAddr)
 
 int sceChnnlsv_21BE78B4_(pspChnnlsvContext2& ctx)
 {
-	for(int i = 0; i < 16; i++)
-	{
-		ctx.unknown[i] = 0;
-	}
+	memset(ctx.cryptedData, 0, 16);
 	ctx.unkn = 0;
 	ctx.mode = 0;
 
@@ -822,6 +537,6 @@ const HLEFunction sceChnnlsv[] =
 
 void Register_sceChnnlsv()
 {
-	RegisterModule("sceChnnlsv",ARRAY_SIZE(sceChnnlsv),sceChnnlsv);
+	RegisterModule("sceChnnlsv", ARRAY_SIZE(sceChnnlsv), sceChnnlsv);
 	kirk_init();
 }

--- a/Core/HLE/sceChnnlsv.h
+++ b/Core/HLE/sceChnnlsv.h
@@ -23,7 +23,7 @@ typedef struct _pspChnnlsvContext1 {
 
 	/** Context data */
 	u8	result[0x10];
-	u8    key[0x10];
+	u8  key[0x10];
 	int	keyLength;
 } pspChnnlsvContext1;
 
@@ -31,7 +31,7 @@ typedef struct _pspChnnlsvContext2 {
 	/** Context data */
 	int mode;
 	int unkn;
-	u8    unknown[0x92];
+	u8  cryptedData[0x92];
 } pspChnnlsvContext2;
 
 int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value);


### PR DESCRIPTION
Name some functions.
Make functions more consistent (same prototypes, order, structure for eg.).
Make functions more readable.
Avoid redundancies that IDA has pushed in there.
Remove length checks where they would be otherwise handled anyway.
Remove about 50 for loops. Instead opt for memset, memcpy and memxor where possible.

Might want to look over in case I made a typo somewhere.
