### PR TITLE
For now, ignore duplicate sceMpegInit()/Finish()'s.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -327,10 +327,11 @@ void __MpegShutdown() {
 u32 sceMpegInit() {
 	if (isMpegInit) {
 		WARN_LOG(HLE, "sceMpegInit(): already initialized");
-		return ERROR_MPEG_ALREADY_INIT;
+		// TODO: Need to properly hook module load/unload for this to work right.
+		//return ERROR_MPEG_ALREADY_INIT;
+	} else {
+		INFO_LOG(HLE, "sceMpegInit()");
 	}
-
-	INFO_LOG(HLE, "sceMpegInit()");
 	isMpegInit = true;
 	return hleDelayResult(0, "mpeg init", 750);
 }
@@ -1009,10 +1010,11 @@ u32 sceMpegFinish()
 	if (!isMpegInit)
 	{
 		WARN_LOG(HLE, "sceMpegFinish(...): not initialized");
-		return ERROR_MPEG_NOT_YET_INIT;
+		// TODO: Need to properly hook module load/unload for this to work right.
+		//return ERROR_MPEG_NOT_YET_INIT;
+	} else {
+		INFO_LOG(HLE, "sceMpegFinish(...)");
 	}
-
-	INFO_LOG(HLE, "sceMpegFinish(...)");
 	isMpegInit = false;
 	//__MpegFinish();
 	return hleDelayResult(0, "mpeg finish", 250);


### PR DESCRIPTION
Need to properly handle module unload for this to work right.  I was worried some games would call it until it returned an error or something silly like that, but I haven't actually seen any games that depend on this returning an already init error.  I think it's safer to ignore it for now.

Fixes #2364, or at least, I think it will based on the log.

-[Unknown]
