### PR TITLE
Windows: Make DirectSound buffer global to allow sound to be played

### DIFF
--- a/Windows/DSoundStream.cpp
+++ b/Windows/DSoundStream.cpp
@@ -49,7 +49,7 @@ namespace DSound
 		pcmwf.wBitsPerSample = 16; 
 
 		dsbdesc.dwSize = sizeof(DSBUFFERDESC); 
-		dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_STICKYFOCUS; // //DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY; 
+		dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_GLOBALFOCUS; // //DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY; 
 		dsbdesc.dwBufferBytes = bufferSize = BUFSIZE;  //FIX32(pcmwf.wf.nAvgBytesPerSec);   //change to set buffer size
 		dsbdesc.lpwfxFormat = (WAVEFORMATEX *)&pcmwf; 
 


### PR DESCRIPTION
even if other applications like Steam are brought to the foreground. If I recall, most other emulators use a global buffer, so I don't think it hurts to use one either.
