### PR TITLE
Make sure Windows shuts down its audio properly.

### DIFF
--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -150,8 +150,8 @@ unsigned int WINAPI TheThread(void *)
 shutdown:
 	_InterlockedExchange(&emuThreadReady, THREAD_SHUTDOWN);
 
-	host = nativeHost;
 	NativeShutdownGraphics();
+	host = nativeHost;
 	NativeShutdown();
 	host = oldHost;
 	host->ShutdownGL();


### PR DESCRIPTION
`~EmuScreen()` can call `PSP_Shutdown()`, which calls `host->ShutdownSound()`.

Because of this, we really need `host` to be a `WindowsHost` during `NativeShutdownGraphics()`.  This fixes crashes when the dsound thread tries to access things that are being destructed by the CRT, like mutexes.

-[Unknown]
