### PR TITLE
Fix button preference, add another right stick setting

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -119,7 +119,6 @@ public:
 	int iDateFormat;
 	int iTimeZone;
 	bool bDayLightSavings;
-	bool bButtonPreference;
 	int iButtonPreference;
 	int iLockParentalLevel;
 	bool bEncryptSave;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -104,6 +104,7 @@ public:
 	// 1 = arrow buttons
 	// 2 = face buttons
 	// 3 = L/R
+	// 4 = L/R + triangle/cross
 	int iRightStickBind;
 
 	// Control

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -21,6 +21,7 @@
 #include "Core/Dialog/PSPOskDialog.h"
 #include "Core/Util/PPGeDraw.h"
 #include "Core/HLE/sceCtrl.h"
+#include "Core/HLE/sceUtility.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
 #include "Common/ChunkFile.h"
@@ -750,7 +751,7 @@ int PSPOskDialog::Update()
 		StartDraw();
 		PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x63636363));
 		RenderKeyboard();
-		if (g_Config.bButtonPreference)
+		if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE)
 		{
 			PPGeDrawImage(I_CROSS, 30, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 			PPGeDrawImage(I_CIRCLE, 150, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
@@ -795,7 +796,7 @@ int PSPOskDialog::Update()
 
 		selectedChar = (selectedChar + (numKeyCols[currentKeyboard] * numKeyRows[currentKeyboard])) % (numKeyCols[currentKeyboard] * numKeyRows[currentKeyboard]);
 
-		if ((IsButtonPressed(CTRL_CROSS) && g_Config.bButtonPreference) || (IsButtonPressed(CTRL_CIRCLE) && !g_Config.bButtonPreference))
+		if (IsButtonPressed(g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE ? CTRL_CROSS : CTRL_CIRCLE))
 		{
 			inputChars = CombinationString(true);
 		}
@@ -816,7 +817,7 @@ int PSPOskDialog::Update()
 
 			selectedChar = selectedRow * numKeyCols[currentKeyboard] + selectedExtra;
 		}
-		else if ((IsButtonPressed(CTRL_CIRCLE) && g_Config.bButtonPreference) || (IsButtonPressed(CTRL_CROSS) && !g_Config.bButtonPreference))
+		else if (IsButtonPressed(g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE ? CTRL_CROSS : CTRL_CIRCLE))
 		{
 			if (inputChars.size() > 0)
 			{

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -37,7 +37,7 @@ static u32 backlightOffTime;
 void __ImposeInit()
 {
 	language = g_Config.ilanguage;
-	buttonValue = g_Config.bButtonPreference?PSP_SYSTEMPARAM_BUTTON_CROSS:PSP_SYSTEMPARAM_BUTTON_CIRCLE;
+	buttonValue = g_Config.iButtonPreference;
 	umdPopup = PSP_UMD_POPUP_DISABLE;
 	backlightOffTime = 0;
 }

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1161,23 +1161,32 @@ void SystemScreen::render() {
 		UICheckBox(GEN_ID, x, y += stride, s->T("Fast Memory", "Fast Memory (unstable)"), ALIGN_TOPLEFT, &g_Config.bFastMemory);
 
 	UICheckBox(GEN_ID, x, y += stride, s->T("Daylight Savings"), ALIGN_TOPLEFT, &g_Config.bDayLightSavings);
-	UICheckBox(GEN_ID, x, y += stride, s->T("Button Preference"), ALIGN_TOPLEFT, &g_Config.bButtonPreference); 
-	if (g_Config.bButtonPreference) {
-			char button[256];
-			std::string type;
-			switch (g_Config.iButtonPreference) {
-				case 0:	type = "O to Enter";break;
-				case 1: type = "X to Enter";break;
-			}
-			sprintf(button, "%s %s", s->T("Type :"), type.c_str());
-			ui_draw2d.DrawText(UBUNTU24, button, x + 60, y += stride , 0xFFFFFFFF, ALIGN_LEFT);
-			HLinear hlinear1(x + 280, y, 20);
-			if (UIButton(GEN_ID, hlinear1, 90, 0, s->T("Use O"), ALIGN_LEFT))
-					g_Config.iButtonPreference = 0;
-			if (UIButton(GEN_ID, hlinear1, 90, 0, s->T("Use X"), ALIGN_LEFT))
-					g_Config.iButtonPreference = 1;
-			y += 10;
+
+	const char *buttonPreferenceTitle;
+	switch (g_Config.iButtonPreference) {
+	case PSP_SYSTEMPARAM_BUTTON_CIRCLE:
+		buttonPreferenceTitle = s->T("Button Preference - O to Confirm");
+		break;
+	case PSP_SYSTEMPARAM_BUTTON_CROSS:
+	default:
+		buttonPreferenceTitle = s->T("Button Preference - X to Confirm");
+		break;
 	}
+
+#ifdef _WIN32
+	const int checkboxH = 32;
+#else
+	const int checkboxH = 48;
+#endif
+	ui_draw2d.DrawTextShadow(UBUNTU24, buttonPreferenceTitle, x + UI_SPACE + 29, (y += stride) + checkboxH / 2, 0xFFFFFFFF, ALIGN_LEFT | ALIGN_VCENTER);
+	y += stride;
+	// 29 is the width of the checkbox, new UI will replace.
+	HLinear hlinearButtonPref(x + UI_SPACE + 29, y, 20);
+	if (UIButton(GEN_ID, hlinearButtonPref, 90, 0, s->T("Use O"), ALIGN_LEFT))
+		g_Config.iButtonPreference = PSP_SYSTEMPARAM_BUTTON_CIRCLE;
+	if (UIButton(GEN_ID, hlinearButtonPref, 90, 0, s->T("Use X"), ALIGN_LEFT))
+		g_Config.iButtonPreference = PSP_SYSTEMPARAM_BUTTON_CROSS;
+	y += 20 + 6;
 
 	/*
 	bool time = g_Config.iTimeFormat > 0 ;

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -210,6 +210,35 @@ int DinputDevice::UpdateState(InputState &input_state)
 		}
 	}
 
+	const LONG rthreshold = 8000;
+
+	switch (g_Config.iRightStickBind) {
+	case 0:
+		break;
+	case 1:
+		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_UP;
+		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_DOWN;
+		break;
+	case 2:
+		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_B;
+		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_X;
+		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		break;
+	case 3:
+		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		break;
+	case 4:
+		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		break;
+	}
+
 	return UPDATESTATE_SKIP_PAD;
 }
 

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -193,6 +193,12 @@ void XinputDevice::ApplyDiff(XINPUT_STATE &state, InputState &input_state) {
 		if      (state.Gamepad.sThumbRX >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
 		else if (state.Gamepad.sThumbRX < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
 		break;
+	case 4:
+		if      (state.Gamepad.sThumbRX >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+		else if (state.Gamepad.sThumbRX < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		if      (state.Gamepad.sThumbRY >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+		else if (state.Gamepad.sThumbRY < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		break;
 	}
 }
 


### PR DESCRIPTION
No reason for the bool version, and it was still being used in the code.  Caused weirdness.

Added the control style used in Valkyria Chronicles / Senjou no Valkyria as well.  I don't know if other games use it, but it's a simple layout.  Could be configurable later.  I also made it work for Z axis/rotation on DirectInput (which is what my current controller maps the right stick to, and iirc what my previous ones have as well.)

Adds new i18n strings:
- Button Preference - O to Confirm
- Button Preference - X to Confirm

Removes i18n strings:
- Button Preference
- (O to Enter and X to Enter were not translatable.)

-[Unknown]
