### PR TITLE
Eat cycles in sceMpegRingbufferAvailableSize() and cut down memcpy()

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -873,6 +873,7 @@ int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	DEBUG_LOG(HLE, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer.packetsFree, ringbufferAddr);
 	MpegContext *ctx = getMpegCtx(ringbuffer.mpeg);
 	int result = std::min(ringbuffer.packetsFree, ctx->mediaengine->getRemainSize() / 2048);
+	hleEatCycles(2020);
 	return ringbuffer.packetsFree;
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -863,18 +863,23 @@ int sceMpegQueryAtracEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)
 
 int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 {
-	if (!Memory::IsValidAddress(ringbufferAddr)) {
+	PSPPointer<SceMpegRingBuffer> ringbuffer;
+	ringbuffer = ringbufferAddr;
+
+	if (!ringbuffer.Valid()) {
 		ERROR_LOG(HLE, "sceMpegRingbufferAvailableSize(%08x) - bad address", ringbufferAddr);
 		return -1;
 	}
 
-	SceMpegRingBuffer ringbuffer;
-	Memory::ReadStruct(ringbufferAddr, &ringbuffer);
-	DEBUG_LOG(HLE, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer.packetsFree, ringbufferAddr);
-	MpegContext *ctx = getMpegCtx(ringbuffer.mpeg);
-	int result = std::min(ringbuffer.packetsFree, ctx->mediaengine->getRemainSize() / 2048);
+	MpegContext *ctx = getMpegCtx(ringbuffer->mpeg);
+	if (!ctx) {
+		ERROR_LOG(HLE, "sceMpegRingbufferAvailableSize(%08x) - bad mpeg", ringbufferAddr);
+		return -1;
+	}
+
 	hleEatCycles(2020);
-	return ringbuffer.packetsFree;
+	DEBUG_LOG(HLE, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer->packetsFree, ringbufferAddr);
+	return ringbuffer->packetsFree;
 }
 
 void PostPutAction::run(MipsCall &call) {


### PR DESCRIPTION
PQ2 seems to call this a lot, so I measured cycles and made it eat the same.

It eats surprisingly many cycles making me think it does quite a bit more work than I had assumed...

Unfortunately, the video in PQ2 is still strobing away, and I'm not sure why...

-[Unknown]
