### PR TITLE
Add some debugging stuff to highlight textures

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -302,6 +302,7 @@ void GenerateFragmentShader(char *buffer) {
 #ifdef DEBUG_SHADER
 	if (doTexture) {
 		WRITE(p, "  gl_FragColor = texture2D(tex, v_texcoord.xy);\n");
+		WRITE(p, "  gl_FragColor += vec4(0.3,0,0.3,0.3);\n");
 	} else {
 		WRITE(p, "  gl_FragColor = vec4(1,0,1,1);\n");
 	}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -700,6 +700,8 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 	default:
 		{
 			// No need to convert RGBA8888, right order already
+			if (dst != src)
+				memcpy(dst, src, numPixels * sizeof(u32));
 		}
 		break;
 	}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -75,8 +75,8 @@ TextureCache::~TextureCache() {
 
 void TextureCache::Clear(bool delete_them) {
 	glBindTexture(GL_TEXTURE_2D, 0);
+	lastBoundTexture = -1;
 	if (delete_them) {
-		lastBoundTexture = -1;
 		for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ++iter) {
 			DEBUG_LOG(G3D, "Deleting texture %i", iter->second.texture);
 			glDeleteTextures(1, &iter->second.texture);
@@ -96,6 +96,7 @@ void TextureCache::Clear(bool delete_them) {
 // Removes old textures.
 void TextureCache::Decimate() {
 	glBindTexture(GL_TEXTURE_2D, 0);
+	lastBoundTexture = -1;
 	int killAge = lowMemoryMode_ ? TEXTURE_KILL_AGE_LOWMEM : TEXTURE_KILL_AGE;
 	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ) {
 		if (iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFrames) {
@@ -868,6 +869,7 @@ void TextureCache::SetTexture() {
 	if (!Memory::IsValidAddress(texaddr)) {
 		// Bind a null texture and return.
 		glBindTexture(GL_TEXTURE_2D, 0);
+		lastBoundTexture = -1;
 		return;
 	}
 
@@ -918,12 +920,14 @@ void TextureCache::SetTexture() {
 				if (entry->framebuffer->fbo)
 					entry->framebuffer->fbo = 0;
 				glBindTexture(GL_TEXTURE_2D, 0);
+				lastBoundTexture = -1;
 				entry->lastFrame = gpuStats.numFrames;
 			} else {
 				if (entry->framebuffer->fbo) {
 					fbo_bind_color_as_texture(entry->framebuffer->fbo, 0);
 				} else {
 					glBindTexture(GL_TEXTURE_2D, 0);
+					lastBoundTexture = -1;
 					gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
 				}
 				UpdateSamplingParams(*entry, false);


### PR DESCRIPTION
I've been using this to identify textures quickly.  There are probably better ways but it's a quick and dirty one.

Also some minor tweaks.  I don't think we hit any of the cases where we unbind the texture and then think we still did, but figure it's better to be safe.

-[Unknown]
