### PR TITLE
Partially implemented reverse landscape for Android/iOS

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -118,6 +118,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("TexScalingType", &iTexScalingType, 0);
 	graphics->Get("TexDeposterize", &bTexDeposterize, false);
 	graphics->Get("VSyncInterval", &iVSyncInterval, 0);
+	graphics->Get("Reverse Landscape", &bFlip, 0);
 
 	IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 	sound->Get("Enable", &bEnableSound, true);
@@ -219,6 +220,7 @@ void Config::Save()
 		graphics->Set("TexScalingType", iTexScalingType);
 		graphics->Set("TexDeposterize", bTexDeposterize);
 		graphics->Set("VSyncInterval", iVSyncInterval);
+		graphics->Set("Reverse Landscape", bFlip);
 
 		IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 		sound->Set("Enable", bEnableSound);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -106,6 +106,7 @@ public:
 	// 3 = L/R
 	// 4 = L/R + triangle/cross
 	int iRightStickBind;
+	bool bFlip;
 
 	// Control
 	std::map<int,int> iMappingMap; // Can be used differently depending on systems

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -245,11 +245,13 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, int pixelFormat, int lin
 
 void FramebufferManager::DrawActiveTexture(float x, float y, float w, float h, bool flip, float uscale) {
 	float u2 = uscale;
+	float t1 = flip ? 0.0f : 1.0f; 
+	float t2 = flip ? 1.0f : 0.0f; 
 	float v1 = flip ? 1.0f : 0.0f;
 	float v2 = flip ? 0.0f : 1.0f;
 
 	const float pos[12] = {x,y,0, x+w,y,0, x+w,y+h,0, x,y+h,0};
-	const float texCoords[8] = {0, v1, u2, v1, u2, v2, 0, v2};
+	const float texCoords[8] = {t1, v1, t2, v1, t2, v2, t1, v2};
 
 	glsl_bind(draw2dprogram);
 	Matrix4x4 ortho;
@@ -569,7 +571,10 @@ void FramebufferManager::CopyDisplayToOutput() {
 	// These are in the output display coordinates
 		float x, y, w, h;
 		CenterRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight);
-		DrawActiveTexture(x, y, w, h, true);
+		if (g_Config.bFlip)
+			DrawActiveTexture(x, y, w, h, false);
+		else
+			DrawActiveTexture(x, y, w, h, true);
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -90,8 +90,11 @@ EmuScreen::EmuScreen(const std::string &filename) : invalid_(true) {
 	globalUIState = UISTATE_INGAME;
 	host->BootDone();
 	host->UpdateDisassembly();
-
-	LayoutGamepad(dp_xres, dp_yres);
+	
+	if (g_Config.bFlip)
+		LayoutGamepadFlip(dp_xres, dp_yres);
+	else
+		LayoutGamepad(dp_xres, dp_yres);
 
 	g_gameInfoCache.FlushBGs();
 
@@ -183,7 +186,10 @@ void EmuScreen::update(InputState &input) {
 #ifdef _WIN32
 	if(g_Config.bShowTouchControls) {
 #endif
-		UpdateGamepad(input);
+		if (g_Config.bFlip)
+			UpdateGamepadFlip(input);
+		else
+			UpdateGamepad(input);
 
 		UpdateInputState(&input);
 #ifdef _WIN32
@@ -317,8 +323,12 @@ void EmuScreen::render() {
 	ui_draw2d.Begin(UIShader_Get(), DBMODE_NORMAL);
 
 	float touchOpacity = g_Config.iTouchButtonOpacity / 100.0f;
-	if (g_Config.bShowTouchControls)
-		DrawGamepad(ui_draw2d, touchOpacity);
+	if (g_Config.bShowTouchControls) {
+		if (g_Config.bFlip)
+			DrawGamepadFlip(ui_draw2d, touchOpacity);
+		else
+			DrawGamepad(ui_draw2d, touchOpacity);
+	}
 
 	DrawWatermark();
 

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -32,11 +32,19 @@ TouchButton buttonRShoulder(&ui_atlas, I_SHOULDER, I_R, PAD_BUTTON_RBUMPER, 0, t
 TouchButton buttonTurbo(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_UNTHROTTLE, 180);
 TouchButton buttonVPS(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_LEFT_THUMB, 180);
 TouchCrossPad crossPad(&ui_atlas, I_DIR, I_ARROW);
+TouchStick leftStick(&ui_atlas, I_STICKBG, I_STICK, 0);
+
+TouchButton buttonTriFlip(&ui_atlas, I_ROUND, I_TRIANGLE, PAD_BUTTON_Y,180);
+TouchButton buttonSelectFlip(&ui_atlas, I_RECT, I_SELECT, PAD_BUTTON_SELECT,180);
+TouchButton buttonStartFlip(&ui_atlas, I_RECT, I_START, PAD_BUTTON_START,180);
+TouchButton buttonLShoulderFlip(&ui_atlas, I_SHOULDER, I_L, PAD_BUTTON_LBUMPER, 180);
+TouchButton buttonRShoulderFlip(&ui_atlas, I_SHOULDER, I_R, PAD_BUTTON_RBUMPER, 180, true);
+TouchButton buttonTurboFlip(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_UNTHROTTLE, 180);
+TouchButton buttonVPSFlip(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_LEFT_THUMB, 180);
+
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 TouchButton buttonPause(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_BACK, 90);
 #endif
-
-TouchStick leftStick(&ui_atlas, I_STICKBG, I_STICK, 0);
 
 void LayoutGamepad(int w, int h)
 {
@@ -79,10 +87,59 @@ void LayoutGamepad(int w, int h)
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 	buttonPause.setPos(halfW, 15 * controlScale, controlScale);
+	buttonPauseFlip.setPos(halfW, h - 15 * controlScale, controlScale);
 #endif
 
 	leftStick.setPos(stickX, stickY, controlScale);
 }
+
+void LayoutGamepadFlip(int w, int h)
+{
+	float controlScale = g_Config.bLargeControls ? g_Config.fButtonScale : 1.15;
+	
+	const int button_spacing = 50 * controlScale;
+	const int arrow_spacing = 40 * controlScale;
+
+	const int circleX = 140 * controlScale;
+	const int circleY = 140 * controlScale;
+
+	const int leftX = w - 120 * controlScale;
+	int leftY = 120 * controlScale;
+
+	if (g_Config.bShowAnalogStick) {
+		leftY = h - 250 * controlScale;
+	}
+
+	const int stickX = leftX + arrow_spacing;
+	const int stickY = h - 80 * controlScale;
+
+	const int halfW = w / 2;
+
+	buttonO.setPos(circleX - button_spacing * 2, circleY , controlScale);
+	buttonX.setPos(circleX - button_spacing, circleY - button_spacing, controlScale);
+	buttonTriFlip.setPos(circleX - button_spacing, circleY + button_spacing, controlScale);
+	buttonSq.setPos(circleX, circleY, controlScale);
+
+	crossPad.setPos(leftX + arrow_spacing, leftY, 40, controlScale);
+
+	if (g_Config.iFpsLimit)
+		buttonVPSFlip.setPos(halfW + button_spacing * 2, 20 * controlScale, controlScale);
+	else
+		buttonTurboFlip.setPos(halfW + button_spacing * 2, 20 * controlScale, controlScale);
+	buttonSelectFlip.setPos(halfW ,  20 * controlScale, controlScale);
+	buttonStartFlip.setPos(halfW - button_spacing * 2 , 20 * controlScale, controlScale);
+	buttonLShoulderFlip.setPos(w - button_spacing - 20 + 10 * controlScale, h - 30 * controlScale, controlScale);
+	buttonRShoulderFlip.setPos(button_spacing + 10 * controlScale, h - 30 * controlScale, controlScale);
+
+
+#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
+	buttonPause.setPos(halfW, 15 * controlScale, controlScale);
+	buttonPauseFlip.setPos(halfW, h - 15 * controlScale, controlScale);
+#endif
+
+	leftStick.setPos(stickX, h - stickY, controlScale);
+}
+
 
 void UpdateGamepad(InputState &input_state)
 {
@@ -104,6 +161,36 @@ void UpdateGamepad(InputState &input_state)
 		buttonVPS.update(input_state);
 	else 
 		buttonTurbo.update(input_state);
+
+#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
+	buttonPause.update(input_state);
+#endif
+
+	if (g_Config.bShowAnalogStick)
+		leftStick.update(input_state);
+}
+
+void UpdateGamepadFlip(InputState &input_state)
+{
+	LayoutGamepadFlip(dp_xres, dp_yres);
+
+	buttonO.update(input_state);
+	buttonX.update(input_state);
+	buttonTriFlip.update(input_state);
+	buttonSq.update(input_state);
+
+	crossPad.update(input_state);
+
+	buttonSelectFlip.update(input_state);
+	buttonStartFlip.update(input_state);
+	buttonLShoulderFlip.update(input_state);
+	buttonRShoulderFlip.update(input_state);
+
+	if (g_Config.iFpsLimit) { 
+		buttonVPSFlip.update(input_state);
+	} else {
+		buttonTurboFlip.update(input_state);
+	}
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 	buttonPause.update(input_state);
@@ -137,6 +224,36 @@ void DrawGamepad(DrawBuffer &db, float opacity)
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 	buttonPause.draw(db, color, colorOverlay);
+#endif
+
+	if (g_Config.bShowAnalogStick)
+		leftStick.draw(db, color);
+}
+
+void DrawGamepadFlip(DrawBuffer &db, float opacity)
+{
+	uint32_t color = colorAlpha(0xc0b080, opacity);
+	uint32_t colorOverlay = colorAlpha(0xFFFFFF, opacity);
+
+	buttonO.draw(db, color, colorOverlay);
+	buttonX.draw(db, color, colorOverlay);
+	buttonSq.draw(db, color, colorOverlay);
+	buttonTriFlip.draw(db, color, colorOverlay);
+	buttonSelectFlip.draw(db, color, colorOverlay);
+	buttonStartFlip.draw(db, color, colorOverlay);
+	buttonLShoulderFlip.draw(db, color, colorOverlay);
+	buttonRShoulderFlip.draw(db, color, colorOverlay);
+	crossPad.draw(db, color, colorOverlay);
+
+	if (g_Config.iFpsLimit) {
+			buttonVPSFlip.draw(db, color, colorOverlay);
+	} else {
+			buttonTurboFlip.draw(db, color, colorOverlay);
+	}
+
+#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
+	buttonPause.draw(db, color, colorOverlay);
+	buttonPauseFlip.draw(db, color, colorOverlay);
 #endif
 
 	if (g_Config.bShowAnalogStick)

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -166,7 +166,7 @@ void UpdateGamepad(InputState &input_state)
 #endif
 
 	if (g_Config.bShowAnalogStick)
-		leftStick.update(input_state);
+		leftStick.update(input_state,false);
 }
 
 void UpdateGamepadFlip(InputState &input_state)
@@ -196,7 +196,7 @@ void UpdateGamepadFlip(InputState &input_state)
 #endif
 
 	if (g_Config.bShowAnalogStick)
-		leftStick.update(input_state);
+		leftStick.update(input_state, true);
 }
 
 void DrawGamepad(DrawBuffer &db, float opacity)

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -44,6 +44,7 @@ TouchButton buttonVPSFlip(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_LEFT_THUMB, 180
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 TouchButton buttonPause(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_BACK, 90);
+TouchButton buttonPauseFlip(&ui_atlas, I_RECT, I_ARROW, PAD_BUTTON_BACK, 270);
 #endif
 
 void LayoutGamepad(int w, int h)
@@ -87,7 +88,6 @@ void LayoutGamepad(int w, int h)
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
 	buttonPause.setPos(halfW, 15 * controlScale, controlScale);
-	buttonPauseFlip.setPos(halfW, h - 15 * controlScale, controlScale);
 #endif
 
 	leftStick.setPos(stickX, stickY, controlScale);
@@ -133,7 +133,6 @@ void LayoutGamepadFlip(int w, int h)
 
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
-	buttonPause.setPos(halfW, 15 * controlScale, controlScale);
 	buttonPauseFlip.setPos(halfW, h - 15 * controlScale, controlScale);
 #endif
 
@@ -193,7 +192,7 @@ void UpdateGamepadFlip(InputState &input_state)
 	}
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
-	buttonPause.update(input_state);
+	buttonPauseFlip.update(input_state);
 #endif
 
 	if (g_Config.bShowAnalogStick)
@@ -243,7 +242,7 @@ void DrawGamepadFlip(DrawBuffer &db, float opacity)
 	buttonStartFlip.draw(db, color, colorOverlay);
 	buttonLShoulderFlip.draw(db, color, colorOverlay);
 	buttonRShoulderFlip.draw(db, color, colorOverlay);
-	crossPad.draw(db, color, colorOverlay);
+	crossPad.drawFlip(db, color, colorOverlay);
 
 	if (g_Config.iFpsLimit) {
 			buttonVPSFlip.draw(db, color, colorOverlay);
@@ -252,7 +251,6 @@ void DrawGamepadFlip(DrawBuffer &db, float opacity)
 	}
 
 #if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
-	buttonPause.draw(db, color, colorOverlay);
 	buttonPauseFlip.draw(db, color, colorOverlay);
 #endif
 

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -21,5 +21,8 @@
 #include "gfx_es2/draw_buffer.h"
 
 void LayoutGamepad(int w, int h);
+void LayoutGamepadFlip(int w, int h);
 void UpdateGamepad(InputState &input_state);
+void UpdateGamepadFlip(InputState &input_state);
 void DrawGamepad(DrawBuffer &db, float opacity);
+void DrawGamepadFlip(DrawBuffer &db, float opacity);

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -800,7 +800,9 @@ void GraphicsScreenP1::render() {
 				gpu->Resized();
 		}
 	}
-
+	
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Reverse Landscape"), ALIGN_TOPLEFT, &g_Config.bFlip);
+	
 	UIEnd();
 }
 


### PR DESCRIPTION
It may not be the best approach to do it anyway .However , it works pretty well and tested with several games and all buttons including crosspad & stick work as expected in reverse landscape mode.

Reverse landscape here just viable when game loaded .UI is not reversed

![screen00004](https://f.cloud.github.com/assets/3000282/691660/cdcfc1de-dbac-11e2-8bf0-1093916a96fe.jpg)
