### PR TITLE
PSPPointer adjustments in savedata

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1210,15 +1210,14 @@ void SavedataParam::ClearFileInfo(SaveFileInfo &saveInfo, std::string saveName)
 	saveInfo.idx = 0;
 	saveInfo.textureData = 0;
 
-	if (Memory::IsValidAddress(GetPspParam()->newData))
+	if (GetPspParam()->newData.Valid() && Memory::IsValidAddress(GetPspParam()->newData->buf))
 	{
 		// We have a png to show
 		if (!noSaveIcon)
 		{
 			noSaveIcon = new SaveFileInfo();
-			PspUtilitySavedataFileData newData;
-			Memory::ReadStruct(GetPspParam()->newData, &newData);
-			CreatePNGIcon(Memory::GetPointer(newData.buf), (int)newData.size, *noSaveIcon);
+			PspUtilitySavedataFileData *newData = GetPspParam()->newData;
+			CreatePNGIcon(Memory::GetPointer(newData->buf), (int)newData->size, *noSaveIcon);
 		}
 		saveInfo.textureData = noSaveIcon->textureData;
 		saveInfo.textureWidth = noSaveIcon->textureWidth;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -264,7 +264,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 		cryptedSize = param->dataSize;
 		if(cryptedSize == 0 || (SceSize)cryptedSize > param->dataBufSize)
 			cryptedSize = param->dataBufSize; // fallback, should never use this
-		u8* data_ = (u8*)Memory::GetPointer(param->dataBuf);
+		u8 *data_ = param->dataBuf;
 
 		int aligned_len = align16(cryptedSize);
 		cryptedData = new u8[aligned_len + 0x10];
@@ -369,7 +369,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 	if(param->dataBuf != 0)	// Can launch save without save data in mode 13
 	{
 		std::string filePath = dirPath+"/"+GetFileName(param);
-		u8* data_ = 0;
+		u8 *data_ = 0;
 		SceSize saveSize = 0;
 		if(cryptedData == 0) // Save decrypted data
 		{
@@ -377,7 +377,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 			if(saveSize == 0 || saveSize > param->dataBufSize)
 				saveSize = param->dataBufSize; // fallback, should never use this
 
-			data_ = (u8*)Memory::GetPointer(param->dataBuf);
+			data_ = param->dataBuf;
 		}
 		else
 		{
@@ -438,7 +438,7 @@ bool SavedataParam::Load(SceUtilitySavedataParam *param, const std::string &save
 		return false;
 	}
 
-	u8 *data_ = (u8*)Memory::GetPointer(param->dataBuf);
+	u8 *data_ = param->dataBuf;
 
 	std::string dirPath = GetSaveFilePath(param, GetSaveDir(param, saveDirName));
 	if (saveId >= 0 && saveNameListDataCount > 0) // if user selection, use it
@@ -1036,14 +1036,13 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 		listEmptyFile = false;
 	}
 
-	typedef char (*SaveNameListData_t)[20];
-	SaveNameListData_t saveNameListData;
+	SceUtilitySavedataSaveName *saveNameListData;
 	bool hasMultipleFileName = false;
-	if (param->saveNameList != 0)
+	if (param->saveNameList.Valid())
 	{
 		Clear();
 
-		saveNameListData = (SaveNameListData_t)Memory::GetPointer(param->saveNameList);
+		saveNameListData = param->saveNameList;
 
 		// Get number of fileName in array
 		saveDataListCount = 0;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -404,33 +404,29 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 
 
 	// SAVE ICON0
-	if (param->icon0FileData.buf)
+	if (param->icon0FileData.buf.Valid())
 	{
-		u8* data_ = (u8*)Memory::GetPointer(param->icon0FileData.buf);
 		std::string icon0path = dirPath + "/" + ICON0_FILENAME;
-		WritePSPFile(icon0path, data_, param->icon0FileData.bufSize);
+		WritePSPFile(icon0path, param->icon0FileData.buf, param->icon0FileData.bufSize);
 	}
 	// SAVE ICON1
-	if (param->icon1FileData.buf)
+	if (param->icon1FileData.buf.Valid())
 	{
-		u8* data_ = (u8*)Memory::GetPointer(param->icon1FileData.buf);
 		std::string icon1path = dirPath + "/" + ICON1_FILENAME;
-		WritePSPFile(icon1path, data_, param->icon1FileData.bufSize);
+		WritePSPFile(icon1path, param->icon1FileData.buf, param->icon1FileData.bufSize);
 	}
 	// SAVE PIC1
-	if (param->pic1FileData.buf)
+	if (param->pic1FileData.buf.Valid())
 	{
-		u8* data_ = (u8*)Memory::GetPointer(param->pic1FileData.buf);
 		std::string pic1path = dirPath + "/" + PIC1_FILENAME;
-		WritePSPFile(pic1path, data_, param->pic1FileData.bufSize);
+		WritePSPFile(pic1path, param->pic1FileData.buf, param->pic1FileData.bufSize);
 	}
 
 	// Save SND
-	if (param->snd0FileData.buf)
+	if (param->snd0FileData.buf.Valid())
 	{
-		u8* data_ = (u8*)Memory::GetPointer(param->snd0FileData.buf);
 		std::string snd0path = dirPath + "/" + SND0_FILENAME;
-		WritePSPFile(snd0path, data_, param->snd0FileData.bufSize);
+		WritePSPFile(snd0path, param->snd0FileData.buf, param->snd0FileData.bufSize);
 	}
 
 	return true;
@@ -1210,14 +1206,14 @@ void SavedataParam::ClearFileInfo(SaveFileInfo &saveInfo, std::string saveName)
 	saveInfo.idx = 0;
 	saveInfo.textureData = 0;
 
-	if (GetPspParam()->newData.Valid() && Memory::IsValidAddress(GetPspParam()->newData->buf))
+	if (GetPspParam()->newData.Valid() && GetPspParam()->newData->buf.Valid())
 	{
 		// We have a png to show
 		if (!noSaveIcon)
 		{
 			noSaveIcon = new SaveFileInfo();
 			PspUtilitySavedataFileData *newData = GetPspParam()->newData;
-			CreatePNGIcon(Memory::GetPointer(newData->buf), (int)newData->size, *noSaveIcon);
+			CreatePNGIcon(newData->buf, (int)newData->size, *noSaveIcon);
 		}
 		saveInfo.textureData = noSaveIcon->textureData;
 		saveInfo.textureWidth = noSaveIcon->textureWidth;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -128,6 +128,8 @@ struct SceUtilitySavedataFileListInfo
 	PSPPointer<SceUtilitySavedataFileListEntry> systemEntries;
 };
 
+typedef char SceUtilitySavedataSaveName[20];
+
 // Structure to hold the parameters for the sceUtilitySavedataInitStart function.
 struct SceUtilitySavedataParam
 {
@@ -142,14 +144,14 @@ struct SceUtilitySavedataParam
 	char gameName[13];
 	char unused[3];
 	/** saveName: name of the particular save, normally a number */
-	char saveName[20];
-	u32 saveNameList;
+	SceUtilitySavedataSaveName saveName;
+	PSPPointer<SceUtilitySavedataSaveName> saveNameList;
 	/** fileName: name of the data file of the game for example DATA.BIN */
 	char fileName[13];
 	char unused2[3];
 
 	/** pointer to a buffer that will contain data file unencrypted data */
-	u32 dataBuf; // Initially void*, but void* in 64bit system take 8 bytes.
+	PSPPointer<u8> dataBuf;
 	/** size of allocated space to dataBuf */
 	SceSize dataBufSize;
 	SceSize dataSize;  // Size of the actual save data

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -77,7 +77,7 @@ struct PspUtilitySavedataSFOParam
 };
 
 struct PspUtilitySavedataFileData {
-	int buf;
+	PSPPointer<u8> buf;
 	SceSize bufSize;  // Size of the buffer pointed to by buf
 	SceSize size;	    // Actual file size to write / was read
 	int unknown;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -161,7 +161,7 @@ struct SceUtilitySavedataParam
 	PspUtilitySavedataFileData pic1FileData;
 	PspUtilitySavedataFileData snd0FileData;
 
-	u32 newData;
+	PSPPointer<PspUtilitySavedataFileData> newData;
 	int focus;
 	int abortStatus;
 


### PR DESCRIPTION
Tried to keep these light, removes some casts and stuff so things are clearer.

The only behavior change: if newData.buf is not a valid pointer, no longer logs an error message / tries to load the png data there.

-[Unknown]
