### PR TITLE
Add 4X/5X to texture scaling level for windows

### DIFF
--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -894,7 +894,12 @@ void GraphicsScreenP2::render() {
 			g_Config.iTexScalingLevel = 2;
 		if (UIButton(GEN_ID, hlinear2, 45, 0, gs->T("3x"), ALIGN_LEFT))
 			g_Config.iTexScalingLevel = 3;
-
+#ifdef _WIN32
+		if (UIButton(GEN_ID, hlinear2, 45, 0, gs->T("4x"), ALIGN_LEFT))
+			g_Config.iTexScalingLevel = 4;
+		if (UIButton(GEN_ID, hlinear2, 45, 0, gs->T("5x"), ALIGN_LEFT))
+			g_Config.iTexScalingLevel = 5;
+#endif
 		UICheckBox(GEN_ID, x + 60, y += stride + 20, gs->T("Deposterize"), ALIGN_LEFT, &g_Config.bTexDeposterize);
 	} else 
 		g_Config.iTexScalingLevel = 1;


### PR DESCRIPTION
Seen in forum asking why 4x/5x not appears as an option in texure scaling level for windows platform .Here it is .
