### PR TITLE
Centralize destruction of FBOs, use std::vector

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -124,7 +124,7 @@ public:
 		return displayFramebuf_ ? (0x04000000 | displayFramebuf_->fb_address) : 0;
 	}
 
-	void NotifyDestroyed(VirtualFramebuffer *vfb);
+	void DestroyFramebuf(VirtualFramebuffer *vfb);
 
 private:
 	u32 ramDisplayFramebufPtr_;  // workaround for MotoGP insanity
@@ -137,7 +137,7 @@ private:
 	VirtualFramebuffer *prevPrevDisplayFramebuf_;
 	int frameLastFramebufUsed;
 
-	std::list<VirtualFramebuffer *> vfbs_;
+	std::vector<VirtualFramebuffer *> vfbs_;
 
 	VirtualFramebuffer *currentRenderVfb_;
 


### PR DESCRIPTION
This moves the actual deletion into `NotifyDestroyed()` and renames it, changes back to std::vector using `iter--` to be safe.

The only real functional change should be in `DestroyAllFBOs()`, which now logs deletions even when buffered rendering is off.

-[Unknown]
