### PR TITLE
Fix some bugs in auto savedata modes, use structs

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -219,9 +219,7 @@ const std::string PSPSaveDialog::GetSelectedSaveDirName()
 	case SCE_UTILITY_SAVEDATA_TYPE_AUTOLOAD:
 	case SCE_UTILITY_SAVEDATA_TYPE_SAVE:
 	case SCE_UTILITY_SAVEDATA_TYPE_AUTOSAVE:
-		if (param.GetSaveName(param.GetPspParam()).length() != 0)
-			return param.GetSaveDirName(param.GetPspParam());
-		// Intentional fallthrough when saveName not valid.
+		return param.GetSaveDirName(param.GetPspParam());
 
 	case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE:
 	case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
@@ -232,9 +230,7 @@ const std::string PSPSaveDialog::GetSelectedSaveDirName()
 	case SCE_UTILITY_SAVEDATA_TYPE_ERASESECURE:
 	case SCE_UTILITY_SAVEDATA_TYPE_ERASE:
 	case SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA:
-		if (param.GetSaveName(param.GetPspParam()).length() != 0)
-			return param.GetSaveDirName(param.GetPspParam());
-		// Intentional fallthrough when saveName not valid.
+		return param.GetSaveDirName(param.GetPspParam());
 
 	// TODO: Maybe also SINGLEDELETE/etc?
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -528,6 +528,16 @@ int PSPSaveDialog::Update()
 		return 0;
 	}
 
+	// The struct may have been updated by the game.  This happens in "Where Is My Heart?"
+	// Check if it has changed, reload it.
+	// TODO: Cut down on preloading?  This rebuilds the list from scratch.
+	int size = Memory::Read_U32(requestAddr);
+	if (memcmp(Memory::GetPointer(requestAddr), &request, size) != 0) {
+		memset(&request, 0, sizeof(request));
+		Memory::Memcpy(&request, requestAddr, size);
+		param.SetPspParam(&request);
+	}
+
 	buttons = __CtrlPeekButtons();
 	UpdateFade();
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -872,10 +872,7 @@ int PSPSaveDialog::Update()
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
 				case SCE_UTILITY_SAVEDATA_TYPE_SIZES:
-					if (param.GetSizes(param.GetPspParam()))
-						param.GetPspParam()->common.result = 0;
-					else
-						param.GetPspParam()->common.result = SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA;
+					param.GetPspParam()->common.result = param.GetSizes(param.GetPspParam());
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
 				case SCE_UTILITY_SAVEDATA_TYPE_LIST:

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -234,6 +234,8 @@ const std::string PSPSaveDialog::GetSelectedSaveDirName()
 
 	// TODO: Maybe also SINGLEDELETE/etc?
 
+	// SZIES ignores saveName it seems.
+
 	default:
 		return param.GetSaveDirName(param.GetPspParam(), currentSelectedSave);
 		break;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -734,13 +734,15 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		param->msFree->clusterSize = (u32)MemoryStick_SectorSize();
 		param->msFree->freeClusters = (u32)(MemoryStick_FreeSpace() / MemoryStick_SectorSize());
 		param->msFree->freeSpaceKB = (u32)(MemoryStick_FreeSpace() / 0x400);
-		std::string spaceTxt = SavedataParam::GetSpaceText((int)MemoryStick_FreeSpace());
+		const std::string spaceTxt = SavedataParam::GetSpaceText((int)MemoryStick_FreeSpace());
 		memset(param->msFree->freeSpaceStr, 0, sizeof(param->msFree->freeSpaceStr));
 		strncpy(param->msFree->freeSpaceStr, spaceTxt.c_str(), sizeof(param->msFree->freeSpaceStr));
 	}
 	if (param->msData.Valid())
 	{
-		std::string path = GetSaveFilePath(param,0);
+		const std::string gameName(param->msData->gameName, strnlen(param->msData->gameName, sizeof(param->msData->gameName)));
+		const std::string saveName(param->msData->saveName, strnlen(param->msData->saveName, sizeof(param->msData->saveName)));
+		std::string path = GetSaveFilePath(param, gameName + saveName);
 		PSPFileInfo finfo = pspFileSystem.GetFileInfo(path);
 		if(finfo.exists)
 		{

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -972,29 +972,24 @@ bool SavedataParam::GetSize(SceUtilitySavedataParam *param)
 	PSPFileInfo info = pspFileSystem.GetFileInfo(saveDir);
 	bool exists = info.exists;
 
-	if (Memory::IsValidAddress(param->sizeAddr))
+	if (param->sizeInfo.Valid())
 	{
-		PspUtilitySavedataSizeInfo sizeInfo;
-		Memory::ReadStruct(param->sizeAddr, &sizeInfo);
-
 		// TODO: Read the entries and count up the size vs. existing size?
 
-		sizeInfo.sectorSize = (int)MemoryStick_SectorSize();
-		sizeInfo.freeSectors = (int)(MemoryStick_FreeSpace() / MemoryStick_SectorSize());
+		param->sizeInfo->sectorSize = (int)MemoryStick_SectorSize();
+		param->sizeInfo->freeSectors = (int)(MemoryStick_FreeSpace() / MemoryStick_SectorSize());
 
 		// TODO: Is this after the specified files?  Before?
-		sizeInfo.freeKB = (int)(MemoryStick_FreeSpace() / 1024);
+		param->sizeInfo->freeKB = (int)(MemoryStick_FreeSpace() / 1024);
 		std::string spaceTxt = SavedataParam::GetSpaceText((int)MemoryStick_FreeSpace());
-		strncpy(sizeInfo.freeString, spaceTxt.c_str(), 8);
-		sizeInfo.freeString[7] = '\0';
+		strncpy(param->sizeInfo->freeString, spaceTxt.c_str(), 8);
+		param->sizeInfo->freeString[7] = '\0';
 
 		// TODO.
-		sizeInfo.neededKB = 0;
-		strcpy(sizeInfo.neededString, "0 KB");
-		sizeInfo.overwriteKB = 0;
-		strcpy(sizeInfo.overwriteString, "0 KB");
-
-		Memory::WriteStruct(param->sizeAddr, &sizeInfo);
+		param->sizeInfo->neededKB = 0;
+		strcpy(param->sizeInfo->neededString, "0 KB");
+		param->sizeInfo->overwriteKB = 0;
+		strcpy(param->sizeInfo->overwriteString, "0 KB");
 	}
 
 	return exists;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -721,13 +721,13 @@ std::string SavedataParam::GetSpaceText(int size)
 	return std::string(text);
 }
 
-bool SavedataParam::GetSizes(SceUtilitySavedataParam *param)
+int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 {
 	if (!param) {
-		return false;
+		return SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA;
 	}
 
-	bool ret = true;
+	int ret = 0;
 
 	if (param->msFree.Valid())
 	{
@@ -758,8 +758,7 @@ bool SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 			strncpy(param->msData->info.usedSpaceStr, "", sizeof(param->msData->info.usedSpaceStr));
 			param->msData->info.usedSpace32KB = 0;
 			strncpy(param->msData->info.usedSpace32Str, "", sizeof(param->msData->info.usedSpace32Str));
-			ret = false;
-			// this should return SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA
+			ret = SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA;
 		}
 	}
 	if (param->utilityData.Valid())

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -855,7 +855,8 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many normal entries, %d", fileList->maxNormalEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
-	if (fileList->systemEntries.Valid() && fileList->maxSystemEntries > 5) {
+	// TODO: This may depend on sdk version or something?  Not returned by default.
+	if (false && fileList->systemEntries.Valid() && fileList->maxSystemEntries > 5) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many system entries, %d", fileList->maxSystemEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
@@ -952,6 +953,10 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		strncpy(entry->name, file->name.c_str(), 16);
 		entry->name[15] = '\0';
 	}
+
+	// TODO: Does this always happen?
+	// Don't know what it is, but PSP always respond this
+	param->bind = 1021;
 
 	return 0;
 }

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -65,6 +65,8 @@ enum SceUtilitySavedataFocus
 	SCE_UTILITY_SAVEDATA_FOCUS_LASTEMPTY  = 8, // last empty (what if no empty?)
 };
 
+typedef char SceUtilitySavedataSaveName[20];
+
 // title, savedataTitle, detail: parts of the unencrypted SFO
 // data, it contains what the VSH and standard load screen shows
 struct PspUtilitySavedataSFOParam
@@ -128,7 +130,27 @@ struct SceUtilitySavedataFileListInfo
 	PSPPointer<SceUtilitySavedataFileListEntry> systemEntries;
 };
 
-typedef char SceUtilitySavedataSaveName[20];
+typedef struct SceUtilitySavedataMsFreeInfo {
+	int clusterSize;
+	int freeClusters;
+	int freeSpaceKB;
+	char freeSpaceStr[8];
+} SceUtilitySavedataMsFreeInfo;
+
+typedef struct SceUtilitySavedataUsedDataInfo {
+	int usedClusters;
+	int usedSpaceKB;
+	char usedSpaceStr[8];
+	int usedSpace32KB;
+	char usedSpace32Str[8];
+} SceUtilitySavedataUsedDataInfo;
+
+typedef struct SceUtilitySavedataMsDataInfo {
+	char gameName[13];
+	char pad[3];
+	SceUtilitySavedataSaveName saveName;
+	SceUtilitySavedataUsedDataInfo info;
+} SceUtilitySavedataMsDataInfo;
 
 // Structure to hold the parameters for the sceUtilitySavedataInitStart function.
 struct SceUtilitySavedataParam
@@ -168,9 +190,9 @@ struct SceUtilitySavedataParam
 	int abortStatus;
 
 	// Function SCE_UTILITY_SAVEDATA_TYPE_SIZES
-	u32 msFree;
-	u32 msData;
-	u32 utilityData;
+	PSPPointer<SceUtilitySavedataMsFreeInfo> msFree;
+	PSPPointer<SceUtilitySavedataMsDataInfo> msData;
+	PSPPointer<SceUtilitySavedataUsedDataInfo> utilityData;
 
 	u8 key[16];
 

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -107,6 +107,22 @@ struct PspUtilitySavedataSizeInfo {
 	char overwriteString[8];
 };
 
+struct SceUtilitySavedataIdListEntry
+{
+	int st_mode;
+	ScePspDateTime st_ctime;
+	ScePspDateTime st_atime;
+	ScePspDateTime st_mtime;
+	SceUtilitySavedataSaveName name;
+};
+
+struct SceUtilitySavedataIdListInfo
+{
+	int maxCount;
+	int resultCount;
+	PSPPointer<SceUtilitySavedataIdListEntry> entries;
+};
+
 struct SceUtilitySavedataFileListEntry
 {
 	int st_mode;
@@ -130,27 +146,30 @@ struct SceUtilitySavedataFileListInfo
 	PSPPointer<SceUtilitySavedataFileListEntry> systemEntries;
 };
 
-typedef struct SceUtilitySavedataMsFreeInfo {
+struct SceUtilitySavedataMsFreeInfo
+{
 	int clusterSize;
 	int freeClusters;
 	int freeSpaceKB;
 	char freeSpaceStr[8];
-} SceUtilitySavedataMsFreeInfo;
+};
 
-typedef struct SceUtilitySavedataUsedDataInfo {
+struct SceUtilitySavedataUsedDataInfo
+{
 	int usedClusters;
 	int usedSpaceKB;
 	char usedSpaceStr[8];
 	int usedSpace32KB;
 	char usedSpace32Str[8];
-} SceUtilitySavedataUsedDataInfo;
+};
 
-typedef struct SceUtilitySavedataMsDataInfo {
+struct SceUtilitySavedataMsDataInfo
+{
 	char gameName[13];
 	char pad[3];
 	SceUtilitySavedataSaveName saveName;
 	SceUtilitySavedataUsedDataInfo info;
-} SceUtilitySavedataMsDataInfo;
+};
 
 // Structure to hold the parameters for the sceUtilitySavedataInitStart function.
 struct SceUtilitySavedataParam
@@ -200,7 +219,7 @@ struct SceUtilitySavedataParam
 	int multiStatus;
 
 	// Function 11 LIST
-	u32 idListAddr;
+	PSPPointer<SceUtilitySavedataIdListInfo> idList;
 
 	// Function 12 FILES
 	PSPPointer<SceUtilitySavedataFileListInfo> fileList;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -85,18 +85,16 @@ struct PspUtilitySavedataFileData {
 	int unknown;
 };
 
-// TODO: According to JPCSP, should verify.
 struct PspUtilitySavedataSizeEntry {
 	u64 size;
 	char name[16];
 };
 
-// TODO: According to JPCSP, should verify.
 struct PspUtilitySavedataSizeInfo {
-	int secureNumEntries;
-	int numEntries;
-	u32 secureEntriesPtr;
-	u32 entriesPtr;
+	int numSecureEntries;
+	int numNormalEntries;
+	PSPPointer<PspUtilitySavedataSizeEntry> secureEntries;
+	PSPPointer<PspUtilitySavedataSizeEntry> normalEntries;
 	int sectorSize;
 	int freeSectors;
 	int freeKB;
@@ -225,7 +223,7 @@ struct SceUtilitySavedataParam
 	PSPPointer<SceUtilitySavedataFileListInfo> fileList;
 
 	// Function 22 GETSIZES
-	u32 sizeAddr;
+	PSPPointer<PspUtilitySavedataSizeInfo> sizeInfo;
 
 };
 

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -258,7 +258,7 @@ public:
 	bool Delete(SceUtilitySavedataParam* param, int saveId = -1);
 	bool Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode = true);
 	bool Load(SceUtilitySavedataParam* param, const std::string &saveDirName, int saveId = -1, bool secureMode = true);
-	bool GetSizes(SceUtilitySavedataParam* param);
+	int GetSizes(SceUtilitySavedataParam* param);
 	bool GetList(SceUtilitySavedataParam* param);
 	int GetFilesList(SceUtilitySavedataParam* param);
 	bool GetSize(SceUtilitySavedataParam* param);


### PR DESCRIPTION
This changes a lot of situations where addresses were computed manually to simply use structs and arrays.  This makes the code look a lot clearer imho.  It also uses PSPPointers now.

Behavioral changes:
- Most importantly, does not fall back to saveNameList for automated modes, regardless of saveName value.  From my tests, it seems like this is ignored.  Fixes #2356.
- In FILELIST, with FF4's specific struct data and sdk version, I got an error for a parameter that works fine with a simpler test.  For now, I disabled the check since it's not likely games will accidentally hit it.
- FILELIST also now writes the `bind` value `Load()` does.  My best guess is it might be the directory permission (1021 = 01775, which smells like unix perms...)
- Fixes a few unlikely cases of buffer overflows (if filenames were manually made > 20 characters long in savedata dirs.)
- Respects the game/save name passed in the getsize request (rather than the usual one.)

-[Unknown]
