### PR TITLE
sceIoRename() ignores any path on dest

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -64,7 +64,7 @@ public:
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);
-	bool RenameFile(const std::string &from, const std::string &to);
+	int  RenameFile(const std::string &from, const std::string &to);
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 
@@ -114,7 +114,7 @@ public:
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);
-	bool RenameFile(const std::string &from, const std::string &to);
+	int  RenameFile(const std::string &from, const std::string &to);
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -116,7 +116,7 @@ public:
 	virtual bool     OwnsHandle(u32 handle) = 0;
 	virtual bool     MkDir(const std::string &dirname) = 0;
 	virtual bool     RmDir(const std::string &dirname) = 0;
-	virtual bool     RenameFile(const std::string &from, const std::string &to) = 0;
+	virtual int      RenameFile(const std::string &from, const std::string &to) = 0;
 	virtual bool     RemoveFile(const std::string &filename) = 0;
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 };
@@ -136,9 +136,9 @@ public:
 	bool     OwnsHandle(u32 handle) {return false;}
 	virtual bool MkDir(const std::string &dirname) {return false;}
 	virtual bool RmDir(const std::string &dirname) {return false;}
-	virtual bool RenameFile(const std::string &from, const std::string &to) {return false;}
+	virtual int RenameFile(const std::string &from, const std::string &to) {return -1;}
 	virtual bool RemoveFile(const std::string &filename) {return false;}
-	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
+	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 };
 
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -43,7 +43,7 @@ public:
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 	virtual bool MkDir(const std::string &dirname) {return false;}
 	virtual bool RmDir(const std::string &dirname) {return false;}
-	virtual bool RenameFile(const std::string &from, const std::string &to) {return false;}
+	virtual int  RenameFile(const std::string &from, const std::string &to) {return -1;}
 	virtual bool RemoveFile(const std::string &filename) {return false;}
 
 private:

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -374,18 +374,34 @@ bool MetaFileSystem::RmDir(const std::string &dirname)
 	}
 }
 
-bool MetaFileSystem::RenameFile(const std::string &from, const std::string &to)
+int MetaFileSystem::RenameFile(const std::string &from, const std::string &to)
 {
 	std::string of;
 	std::string rf;
-	IFileSystem *system;
-	if (MapFilePath(from, of, &system) && MapFilePath(to, rf, &system))
+	IFileSystem *osystem;
+	IFileSystem *rsystem = NULL;
+	if (MapFilePath(from, of, &osystem))
 	{
-		return system->RenameFile(of, rf);
+		// If it's a relative path, it seems to always use from's filesystem.
+		if (to.find(':/') != to.npos)
+		{
+			if (!MapFilePath(to, rf, &rsystem))
+				return -1;
+		}
+		else
+		{
+			rf = to;
+			rsystem = osystem;
+		}
+
+		if (osystem != rsystem)
+			return SCE_KERNEL_ERROR_XDEV;
+
+		return osystem->RenameFile(of, rf);
 	}
 	else
 	{
-		return false;
+		return -1;
 	}
 }
 

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -88,7 +88,7 @@ public:
 
 	virtual bool MkDir(const std::string &dirname);
 	virtual bool RmDir(const std::string &dirname);
-	virtual bool RenameFile(const std::string &from, const std::string &to);
+	virtual int  RenameFile(const std::string &from, const std::string &to);
 	virtual bool RemoveFile(const std::string &filename);
 
 	// TODO: void IoCtl(...)

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1223,9 +1223,10 @@ u32 sceIoRename(const char *from, const char *to) {
 	if (!pspFileSystem.GetFileInfo(from).exists)
 		return hleDelayResult(ERROR_ERRNO_FILE_NOT_FOUND, "file renamed", 1000);
 
-	if (!pspFileSystem.RenameFile(from, to))
+	int result = pspFileSystem.RenameFile(from, to);
+	if (result < 0)
 		WARN_LOG(HLE, "Could not move %s to %s", from, to);
-	return hleDelayResult(0, "file renamed", 1000);
+	return hleDelayResult(result, "file renamed", 1000);
 }
 
 u32 sceIoChdir(const char *dirname) {


### PR DESCRIPTION
Also, change the interface so it can return an error code.  Currently not returning perfect error codes but it's better than before.

Thanks to @thedax for debugging Metal Gear Solid: Peace Walker.  It was simply failing to rename temporary files to dest files since it didn't qualify the destination path.  With this, it no longer complains about install every time.

May improve other games which use temp files to manage save or install data.

-[Unknown]
