### PR TITLE
Add failure reasons to savestate OSMs.

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -73,7 +73,7 @@ struct LinkedListItem : public T
 class PointerWrap
 {
 	// This makes it a compile error if you forget to define DoState() on non-POD.
-	// Which also can be a problem, for example struct tm is non-POD on linux, for whatever false...
+	// Which also can be a problem, for example struct tm is non-POD on linux, for whatever reason...
 #ifdef _MSC_VER
 	template<typename T, bool isPOD = std::is_pod<T>::value, bool isPointer = std::is_pointer<T>::value>
 #else

--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -584,10 +584,12 @@ public:
 	static std::string Load(const std::string& _rFilename, int _Revision, T& _class) 
 	{
 		INFO_LOG(COMMON, "ChunkReader: Loading %s" , _rFilename.c_str());
+		std::string reason = "";
 
 		if (!File::Exists(_rFilename)) {
 			ERROR_LOG(COMMON, "ChunkReader: File doesn't exist");
-			return "File doesn't exist";
+			reason = "File doesn't exist";
+			return reason;
 		}
 				
 		// Check file size
@@ -596,14 +598,16 @@ public:
 		if (fileSize < headerSize)
 		{
 			ERROR_LOG(COMMON,"ChunkReader: File too small");
-			return "File too small";
+			reason = "File too small";
+			return reason;
 		}
 
 		File::IOFile pFile(_rFilename, "rb");
 		if (!pFile)
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Can't open file for reading");
-			return "Can't open file for reading";
+			reason = "Can't open file for reading";
+			return reason;
 		}
 
 		// read the header
@@ -611,7 +615,8 @@ public:
 		if (!pFile.ReadArray(&header, 1))
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Bad header size");
-			return "Bad header size";
+			reason = "Bad header size";
+			return reason;
 		}
 		
 		// Check revision
@@ -619,7 +624,8 @@ public:
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Wrong file revision, got %d expected %d",
 				header.Revision, _Revision);
-			return "Wrong file revision";
+			reason = "Wrong file revision";
+			return reason;
 		}
 		
 		// get size
@@ -628,7 +634,8 @@ public:
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Bad file size, got %d expected %d",
 				sz, header.ExpectedSize);
-			return "Bad file size";
+			reason = "Bad file size";
+			return reason;
 		}
 		
 		// read the state
@@ -636,7 +643,8 @@ public:
 		if (!pFile.ReadBytes(buffer, sz))
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Error reading file");
-			return "Error reading file";
+			reason = "Error reading file";
+			return reason;
 		}
 
 		u8 *ptr = buffer;
@@ -658,7 +666,12 @@ public:
 		delete[] buf;
 		
 		INFO_LOG(COMMON, "ChunkReader: Done loading %s" , _rFilename.c_str());
-		return p.error != p.ERROR_FAILURE? "" : "PointerWrap failure";
+		if(p.error != p.ERROR_FAILURE)
+			return reason;
+		else {
+			reason = "PointerWrap failure";
+			return reason;
+		}
 	}
 	
 	// Save file template
@@ -666,11 +679,14 @@ public:
 	static std::string Save(const std::string& _rFilename, int _Revision, T& _class)
 	{
 		INFO_LOG(COMMON, "ChunkReader: Writing %s" , _rFilename.c_str());
+		std::string reason = "";
+
 		File::IOFile pFile(_rFilename, "wb");
 		if (!pFile)
 		{
 			ERROR_LOG(COMMON,"ChunkReader: Error opening file for write");
-			return "Error opening file";
+			reason = "Error opening file";
+			return reason;
 		}
 
 		bool compress = true;
@@ -703,11 +719,13 @@ public:
 			if (!pFile.WriteArray(&header, 1))
 			{
 				ERROR_LOG(COMMON,"ChunkReader: Failed writing header");
-				return "Failed writing header";
+				reason = "Failed writing header";
+				return reason;
 			}
 			if (!pFile.WriteBytes(&compressed_buffer[0], comp_len)) {
 				ERROR_LOG(COMMON,"ChunkReader: Failed writing compressed data");
-				return "Failed writing compressed data";
+				reason = "Failed writing compressed data";
+				return reason;
 			}	else {
 				INFO_LOG(COMMON, "Savestate: Compressed %i bytes into %i", (int)sz, (int)comp_len);
 			}
@@ -716,19 +734,26 @@ public:
 			if (!pFile.WriteArray(&header, 1))
 			{
 				ERROR_LOG(COMMON,"ChunkReader: Failed writing header");
-				return "Failed writing header";
+				reason = "Failed writing header";
+				return reason;
 			}
 			if (!pFile.WriteBytes(&buffer[0], sz))
 			{
 				ERROR_LOG(COMMON,"ChunkReader: Failed writing data");
-				return "Failed writing data";
+				reason = "Failed writing data";
+				return reason;
 			}
 			delete [] buffer;
 		}
 		
 		INFO_LOG(COMMON,"ChunkReader: Done writing %s", 
 				 _rFilename.c_str());
-		return p.error != p.ERROR_FAILURE? "" : "PointerWrap failure";
+		if(p.error != p.ERROR_FAILURE)
+			return reason;
+		else {
+			reason = "PointerWrap failure";
+			return reason;
+		}
 	}
 	
 	template <class T>

--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -581,11 +581,12 @@ class CChunkFileReader
 public:
 	// Load file template
 	template<class T>
-	static bool Load(const std::string& _rFilename, int _Revision, T& _class) 
+	static bool Load(const std::string& _rFilename, int _Revision, T& _class, std::string* _failureReason) 
 	{
 		INFO_LOG(COMMON, "ChunkReader: Loading %s" , _rFilename.c_str());
 
 		if (!File::Exists(_rFilename)) {
+			_failureReason->append("StateDoesntExist");
 			ERROR_LOG(COMMON, "ChunkReader: File doesn't exist");
 			return false;
 		}
@@ -617,6 +618,7 @@ public:
 		// Check revision
 		if (header.Revision != _Revision)
 		{
+			_failureReason->append("StateWrongVersion");
 			ERROR_LOG(COMMON,"ChunkReader: Wrong file revision, got %d expected %d",
 				header.Revision, _Revision);
 			return false;

--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -584,9 +584,12 @@ public:
 	static bool Load(const std::string& _rFilename, int _Revision, T& _class, std::string* _failureReason) 
 	{
 		INFO_LOG(COMMON, "ChunkReader: Loading %s" , _rFilename.c_str());
+		_failureReason->clear();
+		_failureReason->append("LoadStateWrongVersion");
 
 		if (!File::Exists(_rFilename)) {
-			_failureReason->append("StateDoesntExist");
+			_failureReason->clear();
+			_failureReason->append("LoadStateDoesntExist");
 			ERROR_LOG(COMMON, "ChunkReader: File doesn't exist");
 			return false;
 		}
@@ -618,7 +621,6 @@ public:
 		// Check revision
 		if (header.Revision != _Revision)
 		{
-			_failureReason->append("StateWrongVersion");
 			ERROR_LOG(COMMON,"ChunkReader: Wrong file revision, got %d expected %d",
 				header.Revision, _Revision);
 			return false;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -231,9 +231,9 @@ namespace SaveState
 				INFO_LOG(COMMON, "Loading state from %s", op.filename.c_str());
 				result = CChunkFileReader::Load(op.filename, REVISION, state, &reason);
 				if(result)
-					osm.Show(s->T("LoadedState"), 2.0);
+					osm.Show(s->T("Loaded State"), 2.0);
 				else {
-					osm.Show(s->T(reason.c_str()), 2.0);
+					osm.Show(s->T(reason.c_str(), "Load savestate failed"), 2.0);
 				}
 				break;
 
@@ -243,9 +243,9 @@ namespace SaveState
 				INFO_LOG(COMMON, "Saving state to %s", op.filename.c_str());
 				result = CChunkFileReader::Save(op.filename, REVISION, state);
 				if(result)
-					osm.Show(s->T("SavedState"), 2.0);
+					osm.Show(s->T("Saved State"), 2.0);
 				else
-					osm.Show(s->T("SaveStateFailed"), 2.0);
+					osm.Show(s->T("Save State Failed"), 2.0);
 				break;
 
 			case SAVESTATE_VERIFY:

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -258,7 +258,7 @@ namespace SaveState
 			}
 
 			if (op.callback != NULL)
-				op.callback((result.length() > 0)? false : true, op.cbUserData);
+				op.callback((result.length() > 0)? false : true, op.cbUserData); //If we have a reason, we failed...
 		}
 	}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -220,7 +220,6 @@ namespace SaveState
 			Operation &op = operations[i];
 			bool result;
 			std::string reason;
-			std::string fullMessage;
 
 			I18NCategory *s = GetI18NCategory("Screen"); 
 
@@ -234,9 +233,7 @@ namespace SaveState
 				if(result)
 					osm.Show(s->T("LoadedState"), 2.0);
 				else {
-					fullMessage.append(s->T("LoadStateFailed"));
-					fullMessage.append(s->T(reason.c_str()));
-					osm.Show(fullMessage, 2.0);
+					osm.Show(s->T(reason.c_str()), 2.0);
 				}
 				break;
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -219,6 +219,9 @@ namespace SaveState
 		{
 			Operation &op = operations[i];
 			bool result;
+			std::string reason;
+			std::string fullMessage;
+
 			I18NCategory *s = GetI18NCategory("Screen"); 
 
 			switch (op.type)
@@ -227,11 +230,14 @@ namespace SaveState
 				if (MIPSComp::jit)
 					MIPSComp::jit->ClearCache();
 				INFO_LOG(COMMON, "Loading state from %s", op.filename.c_str());
-				result = CChunkFileReader::Load(op.filename, REVISION, state);
+				result = CChunkFileReader::Load(op.filename, REVISION, state, &reason);
 				if(result)
 					osm.Show(s->T("LoadedState"), 2.0);
-				else
-					osm.Show(s->T("LoadStateFailed"), 2.0);
+				else {
+					fullMessage.append(s->T("LoadStateFailed"));
+					fullMessage.append(s->T(reason.c_str()));
+					osm.Show(fullMessage, 2.0);
+				}
 				break;
 
 			case SAVESTATE_SAVE:

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -31,6 +31,7 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/System.h"
 #include "UI/OnScreenDisplay.h"
+#include "i18n/i18n.h"
 
 namespace SaveState
 {
@@ -217,8 +218,9 @@ namespace SaveState
 		for (size_t i = 0, n = operations.size(); i < n; ++i)
 		{
 			Operation &op = operations[i];
-			std::string result;
-			std::string reason;
+			bool result;
+			I18NCategory *s = GetI18NCategory("Screen"); 
+
 			switch (op.type)
 			{
 			case SAVESTATE_LOAD:
@@ -226,12 +228,10 @@ namespace SaveState
 					MIPSComp::jit->ClearCache();
 				INFO_LOG(COMMON, "Loading state from %s", op.filename.c_str());
 				result = CChunkFileReader::Load(op.filename, REVISION, state);
-				if(result.length() > 0) {
-					reason = "Failed to load state: " + result;
-					osm.Show(reason, 3.0);
-				}
+				if(result)
+					osm.Show(s->T("LoadedState"), 2.0);
 				else
-					osm.Show("Loaded state", 2.0);
+					osm.Show(s->T("LoadStateFailed"), 2.0);
 				break;
 
 			case SAVESTATE_SAVE:
@@ -239,12 +239,10 @@ namespace SaveState
 					MIPSComp::jit->ClearCache();
 				INFO_LOG(COMMON, "Saving state to %s", op.filename.c_str());
 				result = CChunkFileReader::Save(op.filename, REVISION, state);
-				if(result.length() > 0) {
-					reason = "Failed to save state: " + result;
-					osm.Show(reason, 3.0);
-				}
+				if(result)
+					osm.Show(s->T("SavedState"), 2.0);
 				else
-					osm.Show("Saved state", 2.0);
+					osm.Show(s->T("SaveStateFailed"), 2.0);
 				break;
 
 			case SAVESTATE_VERIFY:
@@ -258,7 +256,7 @@ namespace SaveState
 			}
 
 			if (op.callback != NULL)
-				op.callback((result.length() > 0)? false : true, op.cbUserData); //If we have a reason, we failed...
+				op.callback(result, op.cbUserData); //If we have a reason, we failed...
 		}
 	}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -217,24 +217,34 @@ namespace SaveState
 		for (size_t i = 0, n = operations.size(); i < n; ++i)
 		{
 			Operation &op = operations[i];
-			bool result;
-
+			std::string result;
+			std::string reason;
 			switch (op.type)
 			{
 			case SAVESTATE_LOAD:
 				if (MIPSComp::jit)
 					MIPSComp::jit->ClearCache();
 				INFO_LOG(COMMON, "Loading state from %s", op.filename.c_str());
-				osm.Show("Loaded state", 2.0);
 				result = CChunkFileReader::Load(op.filename, REVISION, state);
+				if(result.length() > 0) {
+					reason = "Failed to load state: " + result;
+					osm.Show(reason, 3.0);
+				}
+				else
+					osm.Show("Loaded state", 2.0);
 				break;
 
 			case SAVESTATE_SAVE:
 				if (MIPSComp::jit)
 					MIPSComp::jit->ClearCache();
 				INFO_LOG(COMMON, "Saving state to %s", op.filename.c_str());
-				osm.Show("Saved state", 2.0);
 				result = CChunkFileReader::Save(op.filename, REVISION, state);
+				if(result.length() > 0) {
+					reason = "Failed to save state: " + result;
+					osm.Show(reason, 3.0);
+				}
+				else
+					osm.Show("Saved state", 2.0);
 				break;
 
 			case SAVESTATE_VERIFY:
@@ -244,12 +254,11 @@ namespace SaveState
 
 			default:
 				ERROR_LOG(COMMON, "Savestate failure: unknown operation type %d", op.type);
-				result = false;
 				break;
 			}
 
 			if (op.callback != NULL)
-				op.callback(result, op.cbUserData);
+				op.callback((result.length() > 0)? false : true, op.cbUserData);
 		}
 	}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -256,7 +256,7 @@ namespace SaveState
 			}
 
 			if (op.callback != NULL)
-				op.callback(result, op.cbUserData); //If we have a reason, we failed...
+				op.callback(result, op.cbUserData);
 		}
 	}
 


### PR DESCRIPTION
It's misleading to always show save loaded/saved state, even if it fails. We should at least inform the user of what's going on.
