### PR TITLE
Compare with the old savedata params, not current.

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -45,12 +45,13 @@ int PSPSaveDialog::Init(int paramAddr)
 		ERROR_LOG(HLE,"A save request is already running !");
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
-
-	int size = Memory::Read_U32(paramAddr);
-	memset(&request,0,sizeof(request));
-	// Only copy the right size to support different save request format
-	Memory::Memcpy(&request,paramAddr,size);
+	
 	requestAddr = paramAddr;
+	int size = Memory::Read_U32(requestAddr);
+	memset(&request, 0, sizeof(request));
+	// Only copy the right size to support different save request format
+	Memory::Memcpy(&request, requestAddr, size);
+	Memory::Memcpy(&originalRequest, requestAddr, size);
 
 	u32 retval = param.SetPspParam(&request);
 
@@ -532,7 +533,7 @@ int PSPSaveDialog::Update()
 	// Check if it has changed, reload it.
 	// TODO: Cut down on preloading?  This rebuilds the list from scratch.
 	int size = Memory::Read_U32(requestAddr);
-	if (memcmp(Memory::GetPointer(requestAddr), &request, size) != 0) {
+	if (memcmp(Memory::GetPointer(requestAddr), &originalRequest, size) != 0) {
 		memset(&request, 0, sizeof(request));
 		Memory::Memcpy(&request, requestAddr, size);
 		param.SetPspParam(&request);
@@ -963,7 +964,7 @@ int PSPSaveDialog::Update()
 	lastButtons = buttons;
 
 	if (status == SCE_UTILITY_STATUS_FINISHED)
-		Memory::Memcpy(requestAddr,&request,request.common.size);
+		Memory::Memcpy(requestAddr, &request, request.common.size);
 	
 	return 0;
 }

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -119,6 +119,8 @@ private :
 
 	SavedataParam param;
 	SceUtilitySavedataParam request;
+	// For detecting changes made by the game.
+	SceUtilitySavedataParam originalRequest;
 	u32 requestAddr;
 	int currentSelectedSave;
 


### PR DESCRIPTION
Some savedata modes make changes that aren't flushed to memory right away.  Although, maybe/probably they shouldn't...

Fixes #2440, fixes #2439 (which is a duplicate.)

-[Unknown]
