### PR TITLE
Read framebuffers pixel data to memory

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -114,6 +114,7 @@ void Config::Load(const char *iniFileName)
 #endif
 	graphics->Get("StretchToDisplay", &bStretchToDisplay, false);
 	graphics->Get("TrueColor", &bTrueColor, true);
+	graphics->Get("FramebuffersToMem", &bFramebuffersToMem, false);
 	graphics->Get("MipMap", &bMipMap, true);
 	graphics->Get("TexScalingLevel", &iTexScalingLevel, 1);
 	graphics->Get("TexScalingType", &iTexScalingType, 0);
@@ -216,6 +217,7 @@ void Config::Save()
 #endif
 		graphics->Set("StretchToDisplay", bStretchToDisplay);
 		graphics->Set("TrueColor", bTrueColor);
+		graphics->Set("FramebuffersToMem", bFramebuffersToMem);
 		graphics->Set("MipMap", bMipMap);
 		graphics->Set("TexScalingLevel", iTexScalingLevel);
 		graphics->Set("TexScalingType", iTexScalingType);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -79,6 +79,7 @@ public:
 	bool bFullScreen;
 	int iAnisotropyLevel;
 	bool bTrueColor;
+	bool bFramebuffersToMem;
 	bool bMipMap;
 	int iTexScalingLevel; // 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -408,8 +408,9 @@ void FramebufferManager::SetRenderFrameBuffer() {
 
 	// Save current render framebuffer to memory
 	if(currentRenderVfb_) {
-		// TODO: Add a way to disable the call since it is rather expensive.
-		ReadFramebufferToMemory(currentRenderVfb_);
+		if(g_Config.bFramebuffersToMem) {
+			ReadFramebufferToMemory(currentRenderVfb_);
+		}
 	}
 
 	// None found? Create one.
@@ -604,8 +605,9 @@ void FramebufferManager::CopyDisplayToOutput() {
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 
-	// TODO: Add a way to disable the call since it is rather expensive.
-	ReadFramebufferToMemory(vfb);
+	if(g_Config.bFramebuffersToMem) {
+		ReadFramebufferToMemory(vfb);
+	}
 
 	if (resized_) {
 		glstate.depthWrite.set(GL_TRUE);
@@ -775,31 +777,31 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb) {
 
 		int pixelType, pixelSize, pixelFormat, align;
 		switch (vfb->format) {
-				case GE_FORMAT_4444: // 16 bit ABGR
-					pixelType = GL_UNSIGNED_SHORT_4_4_4_4_REV;
-					pixelFormat = GL_RGBA;
-					pixelSize = 2;
-					align = 8;
-					break;
-				case GE_FORMAT_5551: // 16 bit ABGR
-					pixelType = GL_UNSIGNED_SHORT_1_5_5_5_REV;
-					pixelFormat = GL_RGBA;
-					pixelSize = 2;
-					align = 8;
-					break;
-				case GE_FORMAT_565: // 16 bit BGR
-					pixelType = GL_UNSIGNED_SHORT_5_6_5_REV;
-					pixelFormat = GL_RGB;
-					pixelSize = 2;
-					align = 8;
-					break;
-				case GE_FORMAT_8888: // 32 bit ABGR
-				default: // And same as above
-					pixelType = GL_UNSIGNED_INT_8_8_8_8_REV;
-					pixelFormat = GL_RGBA;
-					pixelSize = 4;
-					align = 4;
-					break;
+			case GE_FORMAT_4444: // 16 bit ABGR
+				pixelType = GL_UNSIGNED_SHORT_4_4_4_4_REV;
+				pixelFormat = GL_RGBA;
+				pixelSize = 2;
+				align = 8;
+				break;
+			case GE_FORMAT_5551: // 16 bit ABGR
+				pixelType = GL_UNSIGNED_SHORT_1_5_5_5_REV;
+				pixelFormat = GL_RGBA;
+				pixelSize = 2;
+				align = 8;
+				break;
+			case GE_FORMAT_565: // 16 bit BGR
+				pixelType = GL_UNSIGNED_SHORT_5_6_5_REV;
+				pixelFormat = GL_RGB;
+				pixelSize = 2;
+				align = 8;
+				break;
+			case GE_FORMAT_8888: // 32 bit ABGR
+			default: // And same as above
+				pixelType = GL_UNSIGNED_INT_8_8_8_8_REV;
+				pixelFormat = GL_RGBA;
+				pixelSize = 4;
+				align = 4;
+				break;
 		}
 
 		if (useBufferedRendering_) {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -105,6 +105,8 @@ public:
 	void SetRenderFrameBuffer();  // Uses parameters computed from gstate
 	void UpdateFromMemory(u32 addr, int size);
 
+	void ReadFramebufferToMemory(VirtualFramebuffer *vfb);
+
 	// TODO: Break out into some form of FBO manager
 	VirtualFramebuffer *GetDisplayFBO();
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, int format);
@@ -140,6 +142,9 @@ private:
 	std::vector<VirtualFramebuffer *> vfbs_;
 
 	VirtualFramebuffer *currentRenderVfb_;
+
+	// Used by ReadFramebufferToMemory
+	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 
 	// Used by DrawPixels
 	unsigned int drawPixelsTex_;

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -51,8 +51,14 @@ CMemoryDlg::CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu
 
 	// subclass the edit box
 	HWND editWnd = GetDlgItem(m_hDlg,IDC_ADDRESS);
+	// TODO: GWL_WNDPROC isn't defined for 64 bits windows, GWLP_WNDPROC is instead
+#if defined( _WIN64 )
+	DefAddressEditProc = (WNDPROC)GetWindowLong(editWnd,GWLP_WNDPROC);
+	SetWindowLong(editWnd,GWLP_WNDPROC,(long)AddressEditProc); 
+#else
 	DefAddressEditProc = (WNDPROC)GetWindowLong(editWnd,GWL_WNDPROC);
 	SetWindowLong(editWnd,GWL_WNDPROC,(long)AddressEditProc); 
+#endif
 	AddressEditParentHwnd = m_hDlg;
 
 	Size();


### PR DESCRIPTION
Rather simple (but large?) code using glReadPixels and Memcpy to read pixel data from framebuffers to where the game expects it to be memory-wise. I also committed a small fix for the debugger since it was referencing an undefined macro in 64 bits Windows, but that one should have gone on master; just forgot to checkout before committing.

As I think I said in issue #1686, I only tested this with Danganronpa (an English-translated demo for the game can be found at http://danganronpa.wordpress.com/downloads/ if something needs checking).
