### PR TITLE
Change PSPPointer function name Valid to IsValid. Also fix some signed/unsigned mismatch warnings in __sceAudio.cpp

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -128,7 +128,7 @@ PSPOskDialog::~PSPOskDialog() {
 
 void PSPOskDialog::ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16> em_address)
 {
-	if (!em_address.Valid())
+	if (!em_address.IsValid())
 	{
 		_string = "";
 		return;
@@ -198,7 +198,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 		return SCE_ERROR_UTILITY_INVALID_PARAM_SIZE;
 	}
 	// Also seems to crash.
-	if (!oskParams->fields.Valid())
+	if (!oskParams->fields.IsValid())
 	{
 		ERROR_LOG_REPORT(HLE, "sceUtilityOskInitStart: invalid field data (%08x)", oskParams->fields.ptr);
 		return -1;
@@ -221,7 +221,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 
 	inputChars = L"";
 
-	if (oskParams->fields[0].intext.Valid()) {
+	if (oskParams->fields[0].intext.IsValid()) {
 		auto src = oskParams->fields[0].intext;
 		int c;
 		while ((c = *src++) != 0)

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -263,7 +263,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 	memset(cryptedHash,0,0x10);
 	// Encrypt save.
 	// TODO: Is this the correct difference between MAKEDATA and MAKEDATASECURE?
-	if (param->dataBuf.Valid() && g_Config.bEncryptSave && secureMode)
+	if (param->dataBuf.IsValid() && g_Config.bEncryptSave && secureMode)
 	{
 		cryptedSize = param->dataSize;
 		if(cryptedSize == 0 || (SceSize)cryptedSize > param->dataBufSize)
@@ -329,7 +329,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 		else
 			memset(tmpData, 0, FILE_LIST_TOTAL_SIZE);
 
-		if (param->dataBuf.Valid())
+		if (param->dataBuf.IsValid())
 		{
 			char *fName = (char*)tmpData;
 			for(int i = 0; i < FILE_LIST_COUNT_MAX; i++)
@@ -370,7 +370,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 	WritePSPFile(sfopath, sfoData, (SceSize)sfoSize);
 	delete[] sfoData;
 
-	if(param->dataBuf.Valid())	// Can launch save without save data in mode 13
+	if(param->dataBuf.IsValid())	// Can launch save without save data in mode 13
 	{
 		std::string filePath = dirPath+"/"+GetFileName(param);
 		u8 *data_ = 0;
@@ -408,26 +408,26 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 
 
 	// SAVE ICON0
-	if (param->icon0FileData.buf.Valid())
+	if (param->icon0FileData.buf.IsValid())
 	{
 		std::string icon0path = dirPath + "/" + ICON0_FILENAME;
 		WritePSPFile(icon0path, param->icon0FileData.buf, param->icon0FileData.bufSize);
 	}
 	// SAVE ICON1
-	if (param->icon1FileData.buf.Valid())
+	if (param->icon1FileData.buf.IsValid())
 	{
 		std::string icon1path = dirPath + "/" + ICON1_FILENAME;
 		WritePSPFile(icon1path, param->icon1FileData.buf, param->icon1FileData.bufSize);
 	}
 	// SAVE PIC1
-	if (param->pic1FileData.buf.Valid())
+	if (param->pic1FileData.buf.IsValid())
 	{
 		std::string pic1path = dirPath + "/" + PIC1_FILENAME;
 		WritePSPFile(pic1path, param->pic1FileData.buf, param->pic1FileData.bufSize);
 	}
 
 	// Save SND
-	if (param->snd0FileData.buf.Valid())
+	if (param->snd0FileData.buf.IsValid())
 	{
 		std::string snd0path = dirPath + "/" + SND0_FILENAME;
 		WritePSPFile(snd0path, param->snd0FileData.buf, param->snd0FileData.bufSize);
@@ -733,7 +733,7 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 
 	int ret = 0;
 
-	if (param->msFree.Valid())
+	if (param->msFree.IsValid())
 	{
 		param->msFree->clusterSize = (u32)MemoryStick_SectorSize();
 		param->msFree->freeClusters = (u32)(MemoryStick_FreeSpace() / MemoryStick_SectorSize());
@@ -742,7 +742,7 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		memset(param->msFree->freeSpaceStr, 0, sizeof(param->msFree->freeSpaceStr));
 		strncpy(param->msFree->freeSpaceStr, spaceTxt.c_str(), sizeof(param->msFree->freeSpaceStr));
 	}
-	if (param->msData.Valid())
+	if (param->msData.IsValid())
 	{
 		const std::string gameName(param->msData->gameName, strnlen(param->msData->gameName, sizeof(param->msData->gameName)));
 		const std::string saveName(param->msData->saveName, strnlen(param->msData->saveName, sizeof(param->msData->saveName)));
@@ -767,7 +767,7 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 			ret = SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA;
 		}
 	}
-	if (param->utilityData.Valid())
+	if (param->utilityData.IsValid())
 	{
 		int total_size = 0;
 		total_size += getSizeNormalized(1); // SFO;
@@ -799,14 +799,14 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 		return false;
 	}
 
-	if (param->idList.Valid())
+	if (param->idList.IsValid())
 	{
 		u32 maxFile = param->idList->maxCount;
 
 		std::vector<PSPFileInfo> validDir;
 		std::vector<PSPFileInfo> allDir = pspFileSystem.GetDirListing(savePath);
 
-		if (param->idList.Valid())
+		if (param->idList.IsValid())
 		{
 			std::string searchString = GetGameName(param)+GetSaveName(param);
 			for (size_t i = 0; i < allDir.size() && validDir.size() < maxFile; i++)
@@ -844,23 +844,23 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_STATUS;
 	}
 
-	if (!param->fileList.Valid()) {
+	if (!param->fileList.IsValid()) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): bad fileList address %08x", param->fileList.ptr);
 		// Should crash.
 		return -1;
 	}
 
 	auto &fileList = param->fileList;
-	if (fileList->secureEntries.Valid() && fileList->maxSecureEntries > 99) {
+	if (fileList->secureEntries.IsValid() && fileList->maxSecureEntries > 99) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many secure entries, %d", fileList->maxSecureEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
-	if (fileList->normalEntries.Valid() && fileList->maxNormalEntries > 8192) {
+	if (fileList->normalEntries.IsValid() && fileList->maxNormalEntries > 8192) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many normal entries, %d", fileList->maxNormalEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
 	// TODO: This may depend on sdk version or something?  Not returned by default.
-	if (false && fileList->systemEntries.Valid() && fileList->maxSystemEntries > 5) {
+	if (false && fileList->systemEntries.IsValid() && fileList->maxSystemEntries > 5) {
 		ERROR_LOG_REPORT(HLE, "SavedataParam::GetFilesList(): too many system entries, %d", fileList->maxSystemEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
@@ -927,11 +927,11 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		SceUtilitySavedataFileListEntry *entry = NULL;
 		int sizeOffset = 0;
 		if (isSystemFile) {
-			if (fileList->systemEntries.Valid() && fileList->resultNumSystemEntries < fileList->maxSystemEntries) {
+			if (fileList->systemEntries.IsValid() && fileList->resultNumSystemEntries < fileList->maxSystemEntries) {
 				entry = &fileList->systemEntries[fileList->resultNumSystemEntries++];
 			}
 		} else if (secureFilenames.find(file->name) != secureFilenames.end()) {
-			if (fileList->secureEntries.Valid() && fileList->resultNumSecureEntries < fileList->maxSecureEntries) {
+			if (fileList->secureEntries.IsValid() && fileList->resultNumSecureEntries < fileList->maxSecureEntries) {
 				entry = &fileList->secureEntries[fileList->resultNumSecureEntries++];
 			}
 			// Secure files are slightly bigger.
@@ -940,7 +940,7 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 				sizeOffset = -0x10;
 			}
 		} else {
-			if (fileList->normalEntries.Valid() && fileList->resultNumNormalEntries < fileList->maxNormalEntries) {
+			if (fileList->normalEntries.IsValid() && fileList->resultNumNormalEntries < fileList->maxNormalEntries) {
 				entry = &fileList->normalEntries[fileList->resultNumNormalEntries++];
 			}
 		}
@@ -976,7 +976,7 @@ bool SavedataParam::GetSize(SceUtilitySavedataParam *param)
 	PSPFileInfo info = pspFileSystem.GetFileInfo(saveDir);
 	bool exists = info.exists;
 
-	if (param->sizeInfo.Valid())
+	if (param->sizeInfo.IsValid())
 	{
 		// TODO: Read the entries and count up the size vs. existing size?
 
@@ -1042,7 +1042,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 
 	SceUtilitySavedataSaveName *saveNameListData;
 	bool hasMultipleFileName = false;
-	if (param->saveNameList.Valid())
+	if (param->saveNameList.IsValid())
 	{
 		Clear();
 
@@ -1209,7 +1209,7 @@ void SavedataParam::ClearFileInfo(SaveFileInfo &saveInfo, std::string saveName)
 	saveInfo.idx = 0;
 	saveInfo.textureData = 0;
 
-	if (GetPspParam()->newData.Valid() && GetPspParam()->newData->buf.Valid())
+	if (GetPspParam()->newData.IsValid() && GetPspParam()->newData->buf.IsValid())
 	{
 		// We have a png to show
 		if (!noSaveIcon)

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -290,18 +290,18 @@ void __AudioUpdate() {
 		chans[i].sampleQueue.popPointers(hwBlockSize * 2, &buf1, &sz1, &buf2, &sz2);
 
 		if (firstChannel) {
-			for (int s = 0; s < sz1; s++)
+			for (size_t s = 0; s < sz1; s++)
 				mixBuffer[s] = buf1[s];
 			if (buf2) {
-				for (int s = 0; s < sz2; s++)
+				for (size_t s = 0; s < sz2; s++)
 					mixBuffer[s + sz1] = buf2[s];
 			}
 			firstChannel = false;
 		} else {
-			for (int s = 0; s < sz1; s++)
+			for (size_t s = 0; s < sz1; s++)
 				mixBuffer[s] += buf1[s];
 			if (buf2) {
-				for (int s = 0; s < sz2; s++)
+				for (size_t s = 0; s < sz2; s++)
 					mixBuffer[s + sz1] += buf2[s];
 			}
 		}
@@ -317,10 +317,10 @@ void __AudioUpdate() {
 			s16 *buf1 = 0, *buf2 = 0;
 			size_t sz1, sz2;
 			outAudioQueue.pushPointers(hwBlockSize * 2, &buf1, &sz1, &buf2, &sz2);
-			for (int s = 0; s < sz1; s++)
+			for (size_t s = 0; s < sz1; s++)
 				buf1[s] = clamp_s16(mixBuffer[s]);
 			if (buf2) {
-				for (int s = 0; s < sz2; s++)
+				for (size_t s = 0; s < sz2; s++)
 					buf2[s] = clamp_s16(mixBuffer[s + sz1]);
 			}
 		} else {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -137,7 +137,7 @@ struct Atrac {
 		Atrac3plus_Decoder::CloseContext(&decoder_context);
 		sampleQueue.clear();
 
-		if (atracContext.Valid())
+		if (atracContext.IsValid())
 			kernelMemory.Free(atracContext.ptr);
 	}
 
@@ -513,7 +513,7 @@ u32 _AtracAddStreamData(int atracID, u8 *buf, u32 bytesToAdd) {
 		atrac->first.size = atrac->first.filesize;
 	atrac->first.fileoffset = atrac->first.size;
 	atrac->first.writableBytes = 0;
-	if (atrac->atracContext.Valid()) {
+	if (atrac->atracContext.IsValid()) {
 		// refresh atracContext
 		_AtracGenarateContext(atrac, atrac->atracContext);
 	}
@@ -670,7 +670,7 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 			*finish = finishFlag;
 			*remains = atrac->getRemainFrames();
 		}
-		if (atrac->atracContext.Valid()) {
+		if (atrac->atracContext.IsValid()) {
 			// refresh atracContext
 			_AtracGenarateContext(atrac, atrac->atracContext);
 		}
@@ -1456,18 +1456,18 @@ int _sceAtracGetContextAddress(int atracID)
 		ERROR_LOG(HLE, "_sceAtracGetContextAddress(%i): bad atrac id", atracID);
 		return 0;
 	}
-	if (!atrac->atracContext.Valid()) {
+	if (!atrac->atracContext.IsValid()) {
 		// allocate a new atracContext
 		u32 contextsize = 256;
 		atrac->atracContext = kernelMemory.Alloc(contextsize, false, "Atrac Context");
-		if (atrac->atracContext.Valid())
+		if (atrac->atracContext.IsValid())
 			Memory::Memset(atrac->atracContext.ptr, 0, 256);
 
 		WARN_LOG(HLE, "%08x=_sceAtracGetContextAddress(%i): allocated new context", atrac->atracContext.ptr, atracID);
 	}
 	else
 		WARN_LOG(HLE, "%08x=_sceAtracGetContextAddress(%i)", atrac->atracContext.ptr, atracID);
-	if (atrac->atracContext.Valid())
+	if (atrac->atracContext.IsValid())
 		_AtracGenarateContext(atrac, atrac->atracContext);
 	if (atrac->currentSample >= atrac->endSample && atrac->loopNum == 0) {
 		// This is a hack method to release those already finished atrac3 voice.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1676,7 +1676,7 @@ u32 sceIoGetFdList(u32 outAddr, int outSize, u32 fdNumAddr) {
 	// Always have the first three.
 	for (int i = 0; i < PSP_MIN_FD; ++i) {
 		// TODO: Technically it seems like these are fixed ids > PSP_COUNT_FDS.
-		if (count < outSize && out.Valid()) {
+		if (count < outSize && out.IsValid()) {
 			out[count] = i;
 		}
 		++count;
@@ -1686,7 +1686,7 @@ u32 sceIoGetFdList(u32 outAddr, int outSize, u32 fdNumAddr) {
 		if (fds[i] == 0) {
 			continue;
 		}
-		if (count < outSize && out.Valid()) {
+		if (count < outSize && out.IsValid()) {
 			out[count] = i;
 		}
 		++count;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -871,7 +871,7 @@ int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	PSPPointer<SceMpegRingBuffer> ringbuffer;
 	ringbuffer = ringbufferAddr;
 
-	if (!ringbuffer.Valid()) {
+	if (!ringbuffer.IsValid()) {
 		ERROR_LOG(HLE, "sceMpegRingbufferAvailableSize(%08x) - bad address", ringbufferAddr);
 		return -1;
 	}

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -349,7 +349,7 @@ struct PSPPointer
 		return (T *)(Memory::base + ptr);
 	}
 
-	bool Valid() const
+	bool IsValid() const
 	{
 		return Memory::IsValidAddress(ptr);
 	}


### PR DESCRIPTION
Changed the function name to "IsValid()" because it shows intent much better than simply "Valid()"
