### PR TITLE
Fixed missing Japanese characters in the OSK.  Fixes issue 2386 and issue 2468

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -82,7 +82,7 @@ static const wchar_t oskKeys[OSK_KEYBOARD_COUNT][5][14] =
 		{L"いきしちにひみ　り　ぃ　　"},
 		{L"うくすつぬふむゆるをぅゅ゛"},
 		{L"えけせてねへめ　れ　ぇ　゜"},
-		{L"おこそとのほもよるんぉょー"},
+		{L"おこそとのほもよろんぉょー"},
 	},
 	{
 		// Katakana
@@ -90,7 +90,7 @@ static const wchar_t oskKeys[OSK_KEYBOARD_COUNT][5][14] =
 		{L"イキシチニヒミ　リ　ィ　　"},
 		{L"ウクスツヌフムユルヲゥュ゛"},
 		{L"エケセテネヘメ　レ　ェ　゜"},
-		{L"オコソトノホモヨルンォョー"},
+		{L"オコソトノホモヨロンォョー"},
 	},
 	{
 		// Korean(Hangul)

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -80,17 +80,17 @@ static const wchar_t oskKeys[OSK_KEYBOARD_COUNT][5][14] =
 		// Hiragana
 		{L"あかさたなはまやらわぁゃっ"},
 		{L"いきしちにひみ　り　ぃ　　"},
-		{L"うくすつぬふむゆるをぅゅ˝"},
-		{L"えけせてねへめ　れ　ぇ　˚"},
-		{L"おこそとのほもよるんぉょ　"},
+		{L"うくすつぬふむゆるをぅゅ゛"},
+		{L"えけせてねへめ　れ　ぇ　゜"},
+		{L"おこそとのほもよるんぉょー"},
 	},
 	{
 		// Katakana
 		{L"アカサタナハマヤラワァャッ"},
 		{L"イキシチニヒミ　リ　ィ　　"},
-		{L"ウクスツヌフムユルヲゥュ˝"},
-		{L"エケセテネヘメ　レ　ェ　˚"},
-		{L"オコソトノホモヨルンォョ　"},
+		{L"ウクスツヌフムユルヲゥュ゛"},
+		{L"エケセテネヘメ　レ　ェ　゜"},
+		{L"オコソトノホモヨルンォョー"},
 	},
 	{
 		// Korean(Hangul)
@@ -497,7 +497,7 @@ std::wstring PSPOskDialog::CombinationString(bool isInput)
 			i_level = 0;
 		}
 
-		if(oskKeys[currentKeyboard][selectedRow][selectedCol] == L'˝')
+		if(oskKeys[currentKeyboard][selectedRow][selectedCol] == L'゛')
 		{
 			for(u32 i = 0; i < inputChars.size(); i++)
 			{
@@ -524,7 +524,7 @@ std::wstring PSPOskDialog::CombinationString(bool isInput)
 				}
 			}
 		}
-		else if(oskKeys[currentKeyboard][selectedRow][selectedCol] == L'˚')
+		else if(oskKeys[currentKeyboard][selectedRow][selectedCol] == L'゜')
 		{
 			for(u32 i = 0; i < inputChars.size(); i++)
 			{


### PR DESCRIPTION
ie see Issue #2386 and #2468 
Also added the vowel lengthening character to Katakana and Hirigana

Before:
![](https://f.cloud.github.com/assets/4050814/686705/5c2dd430-da62-11e2-87e4-083c7e1ab154.png)

After:
![](https://f.cloud.github.com/assets/712067/705737/0581b0c0-dddc-11e2-838f-d609f8b031b9.png)

Ended up being garbled because they were the incorrect encoding in the file.
