### PR TITLE
Save and restore debug/console positions

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -159,6 +159,8 @@ void Config::Load(const char *iniFileName)
 	debugConfig->Get("DisasmWindowY", &iDisasmWindowY, -1);
 	debugConfig->Get("DisasmWindowW", &iDisasmWindowW, -1);
 	debugConfig->Get("DisasmWindowH", &iDisasmWindowH, -1);
+	debugConfig->Get("ConsoleWindowX", &iConsoleWindowX, -1);
+	debugConfig->Get("ConsoleWindowY", &iConsoleWindowY, -1);
 
 	CleanRecent();
 }
@@ -261,6 +263,8 @@ void Config::Save()
 		debugConfig->Set("DisasmWindowY", iDisasmWindowY);
 		debugConfig->Set("DisasmWindowW", iDisasmWindowW);
 		debugConfig->Set("DisasmWindowH", iDisasmWindowH);
+		debugConfig->Set("ConsoleWindowX", iConsoleWindowX);
+		debugConfig->Set("ConsoleWindowY", iConsoleWindowY);
 
 		if (!iniFile.Save(iniFilename_.c_str())) {
 			ERROR_LOG(LOADER, "Error saving config - can't write ini %s", iniFilename_.c_str());

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -154,6 +154,12 @@ void Config::Load(const char *iniFileName)
 	pspConfig->Get("WlanPowerSave", &bWlanPowerSave, PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF);
 	pspConfig->Get("EncryptSave", &bEncryptSave, true);
 
+	IniFile::Section *debugConfig = iniFile.GetOrCreateSection("Debugger");
+	debugConfig->Get("DisasmWindowX", &iDisasmWindowX, -1);
+	debugConfig->Get("DisasmWindowY", &iDisasmWindowY, -1);
+	debugConfig->Get("DisasmWindowW", &iDisasmWindowW, -1);
+	debugConfig->Get("DisasmWindowH", &iDisasmWindowH, -1);
+
 	CleanRecent();
 }
 
@@ -249,6 +255,12 @@ void Config::Save()
 		pspConfig->Set("WlanAdhocChannel", iWlanAdhocChannel);
 		pspConfig->Set("WlanPowerSave", bWlanPowerSave);
 		pspConfig->Set("EncryptSave", bEncryptSave);
+
+		IniFile::Section *debugConfig = iniFile.GetOrCreateSection("Debugger");
+		debugConfig->Set("DisasmWindowX", iDisasmWindowX);
+		debugConfig->Set("DisasmWindowY", iDisasmWindowY);
+		debugConfig->Set("DisasmWindowW", iDisasmWindowW);
+		debugConfig->Set("DisasmWindowH", iDisasmWindowH);
 
 		if (!iniFile.Save(iniFilename_.c_str())) {
 			ERROR_LOG(LOADER, "Error saving config - can't write ini %s", iniFilename_.c_str());

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -127,6 +127,12 @@ public:
 	int iWlanAdhocChannel;
 	bool bWlanPowerSave;
 
+	// Debugger
+	int iDisasmWindowX;
+	int iDisasmWindowY;
+	int iDisasmWindowW;
+	int iDisasmWindowH;
+
 	std::string currentDirectory;
 	std::string externalDirectory; 
 	std::string memCardDirectory;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -132,6 +132,8 @@ public:
 	int iDisasmWindowY;
 	int iDisasmWindowW;
 	int iDisasmWindowH;
+	int iConsoleWindowX;
+	int iConsoleWindowY;
 
 	std::string currentDirectory;
 	std::string externalDirectory; 

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -22,6 +22,8 @@ private:
 	DebugInterface *cpu;
 	
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	void UpdateSize(WORD width, WORD height);
+	void SavePosition();
 
 public:
 	int index; //helper 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -191,3 +191,21 @@ bool WindowsHost::IsDebuggingEnabled()
 	return false;
 #endif
 }
+
+void WindowsHost::SetConsolePosition()
+{
+	HWND console = GetConsoleWindow();
+	if (console != NULL && g_Config.iConsoleWindowX != -1 && g_Config.iConsoleWindowY != -1)
+		SetWindowPos(console, NULL, g_Config.iConsoleWindowX, g_Config.iConsoleWindowY, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
+void WindowsHost::UpdateConsolePosition()
+{
+	RECT rc;
+	HWND console = GetConsoleWindow();
+	if (console != NULL && GetWindowRect(console, &rc))
+	{
+		g_Config.iConsoleWindowX = rc.left;
+		g_Config.iConsoleWindowY = rc.top;
+	}
+}

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -29,7 +29,13 @@ public:
 		displayWindow_ = displayWindow;
 		input = getInputDevices();
 		loadedSymbolMap_ = false;
+		SetConsolePosition();
 	}
+	~WindowsHost()
+	{
+		UpdateConsolePosition();
+	}
+
 	void UpdateMemView();
 	void UpdateDisassembly();
 	void UpdateUI();
@@ -52,6 +58,9 @@ public:
 	void SetWindowTitle(const char *message);
 
 private:
+	void SetConsolePosition();
+	void UpdateConsolePosition();
+
 	HWND displayWindow_;
 	HWND mainWindow_;
 	std::list<std::shared_ptr<InputDevice>> input;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -154,10 +154,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	VFSShutdown();
 
-	LogManager::Shutdown();
 	DialogManager::DestroyAll();
 	timeEndPeriod(1);
-	g_Config.Save();
 	delete host;
+	g_Config.Save();
+	LogManager::Shutdown();
 	return 0;
 }


### PR DESCRIPTION
I often move them around to see things more properly, so this way I don't have to, they can just start in the right places.

This does the disasm x/y/w/h, and decreases its minimum w and h, since I found the updated UI too big.  For the console, I only did x/y, but w/h could be done as well.  I put this in WindowsHost so as not to muck with Common and dependencies.  That required matching shutdown order with NativeShutdown().

I thought about ignoring the current size, so -1 could stay "default", but then figured it didn't matter.

-[Unknown]
