### PR TITLE
Remove hack for MIPSInt BREAK in Sol Trigger

### DIFF
--- a/Core/HLE/sceP3da.cpp
+++ b/Core/HLE/sceP3da.cpp
@@ -42,7 +42,7 @@ static inline int getScaleValue(u32 channelsNum) {
 
 u32 sceP3daBridgeCore(u32 p3daCoreAddr, u32 channelsNum, u32 samplesNum, u32 inputAddr, u32 outputAddr)
 {
-	INFO_LOG(HLE, "sceP3daBridgeCore(%08x, %08x, %08x, %08x, %08x)", p3daCoreAddr, channelsNum, samplesNum, inputAddr, outputAddr);
+	DEBUG_LOG(HLE, "sceP3daBridgeCore(%08x, %08x, %08x, %08x, %08x)", p3daCoreAddr, channelsNum, samplesNum, inputAddr, outputAddr);
 	if (Memory::IsValidAddress(inputAddr) && Memory::IsValidAddress(outputAddr)) {
 		int scaleval = getScaleValue(channelsNum);
 		s16* outbuf = (s16*)Memory::GetPointer(outputAddr);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -27,7 +27,6 @@
 #include "MIPSInt.h"
 #include "MIPSTables.h"
 #include "Core/Reporting.h"
-#include "Core/Config.h"
 
 #include "../HLE/HLE.h"
 #include "../System.h"
@@ -192,8 +191,7 @@ namespace MIPSInt
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
 		ERROR_LOG(CPU, "BREAK!");
-		if (!g_Config.bIgnoreBadMemAccess) 
-			Core_UpdateState(CORE_STEPPING);
+		Core_UpdateState(CORE_STEPPING);
 		PC += 4;
 	}
 


### PR DESCRIPTION
The MIPSInt BREAK issue has been fixed by #2466 .This hack should be no longer needed.
