### PR TITLE
Revert "Remove hack for BREAK in Sol Trigger"

### DIFF
--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -27,6 +27,7 @@
 #include "MIPSInt.h"
 #include "MIPSTables.h"
 #include "Core/Reporting.h"
+#include "Core/Config.h"
 
 #include "../HLE/HLE.h"
 #include "../System.h"
@@ -191,7 +192,8 @@ namespace MIPSInt
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
 		ERROR_LOG(CPU, "BREAK!");
-		Core_UpdateState(CORE_STEPPING);
+		if (!g_Config.bIgnoreBadMemAccess) 
+			Core_UpdateState(CORE_STEPPING);
 		PC += 4;
 	}
 


### PR DESCRIPTION
This reverts commit 3d2c3c722713fc7276ab5cec71b122dac9082ec7.

This wasn't a hack dedicated to Sol Trigger.  It helps other games, and keeping it is just like allowing games to continue on bad memory address reads.

This should allow God Eater to be playable again, plus any of these games if they were playable:
http://report.ppsspp.org/logs/kind/26

-[Unknown]
