### PR TITLE
Fixing scePsmf for AKB48 MPEG crash because wrong pointer

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1069,10 +1069,10 @@ u32 scePsmfPlayerGetCurrentPlayMode(u32 psmfPlayer, u32 playModeAddr, u32 playSp
 	}
 	WARN_LOG(HLE, "scePsmfPlayerGetCurrentPlayMode(%08x, %08x, %08x)", psmfPlayer, playModeAddr, playSpeedAddr);
 	if (Memory::IsValidAddress(playModeAddr)) {
-		Memory::Write_U64(psmfplayer->playMode, playModeAddr);
+		Memory::Write_U32(psmfplayer->playMode, playModeAddr); //Fixing for AKB MPEG wrong pointer
 	}
 	if (Memory::IsValidAddress(playSpeedAddr)) {
-		Memory::Write_U64(psmfplayer->playSpeed, playSpeedAddr);
+		Memory::Write_U32(psmfplayer->playSpeed, playSpeedAddr); //Fixing for AKB MPEG wrong pointer
 	}
 	return 0;
 }


### PR DESCRIPTION
Fixing for AKB48 MPEG crash because wrong pointer
Has been tested with:
- AKB148 Idol to koi shitara, Idol to Guam de Koishitara
- AKB149 Renai Sousenkyo
