### PR TITLE
Don't step when the core is active

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -21,7 +21,8 @@ private:
 	RECT breakpointRect;
 
 	DebugInterface *cpu;
-	
+	u64 lastTicks;
+
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void UpdateSize(WORD width, WORD height);
 	void SavePosition();


### PR DESCRIPTION
This fixes some odd behavior when holding the Step Over key, especially with debug builds.
Also resets the cycle counter every time the core is resumed, so that it actually shows the execution time of the last run (ie, when skipping over a function call).
