### PR TITLE
Match message dialog with real PSP

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -139,13 +139,15 @@ void PSPDialog::DisplayButtons(int flags)
 		x2 = 183.5f;
 	}
 	if (flags & DS_BUTTON_OK) {
+		PPGeDrawImage(okButtonImg, x2, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));
 		PPGeDrawImage(okButtonImg, x2, 256, 11.5f, 11.5f, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T("Enter"), x2 + 15.5f, 253, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x30000000));
+		PPGeDrawText(d->T("Enter"), x2 + 15.5f, 252, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(d->T("Enter"), x2 + 14.5f, 250, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
 	}
 	if (flags & DS_BUTTON_CANCEL) {
-		PPGeDrawText(d->T("Back"), x1 + 15.5f, 253, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x30000000));
+		PPGeDrawText(d->T("Back"), x1 + 15.5f, 252, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(d->T("Back"), x1 + 14.5f, 250, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(cancelButtonImg, x1, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));
 		PPGeDrawImage(cancelButtonImg, x1, 256, 11.5f, 11.5f, 0, CalcFadedColor(0xFFFFFFFF));
 	}
 }

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -150,25 +150,25 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 		float x, w;
 		if (yesnoChoice == 1) {
 			choiceText = d->T("Yes");
-			x = 208.0f;
+			x = 204.0f;
 			yesColor = 0xFFFFFFFF;
 			noColor  = 0xFFFFFFFF;
 		}
 		else {
 			choiceText = d->T("No");
-			x = 272.0f;
+			x = 273.0f;
 			yesColor = 0xFFFFFFFF;
 			noColor  = 0xFFFFFFFF;
 		}
 		PPGeMeasureText(&w, &h, 0, choiceText, FONT_SCALE);
-		w = w / 2.0f + 4.0f;
+		w = w / 2.0f + 5.0f;
 		h /= 2.0f;
 		float y2 = y + h2 + 10.0f;
 		h2 += h + 4.0f;
 		y = 132.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
-		PPGeDrawText(d->T("Yes"), 209.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(d->T("Yes"), 208.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
+		PPGeDrawText(d->T("Yes"), 204.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
+		PPGeDrawText(d->T("Yes"), 203.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
 		PPGeDrawText(d->T("No"), 273.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(d->T("No"), 272.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(noColor));
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {
@@ -181,14 +181,14 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 		I18NCategory *d = GetI18NCategory("Dialog");
 		float x, w;
 		x = 240.0f;
-		w = w / 2.0f + 12.0f;
+		w = w / 2.0f + 16.0f;
 		h /= 2.0f;
 		float y2 = y + h2 + 10.0f;
 		h2 += h + 4.0f;
 		y = 132.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
-		PPGeDrawText(d->T("OK"), 241.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(d->T("OK"), 240.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("OK"), 240.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
+		PPGeDrawText(d->T("OK"), 239.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
 	}
 	PPGeDrawTextWrapped(text.c_str(), 241.0f, y+2, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
 	PPGeDrawTextWrapped(text.c_str(), 240.0f, y, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -22,6 +22,7 @@
 #include "Core/Reporting.h"
 #include "ChunkFile.h"
 #include "i18n/i18n.h"
+#include "util/text/utf8.h"
 
 const float FONT_SCALE = 0.65f;
 
@@ -132,8 +133,11 @@ int PSPMsgDialog::Init(unsigned int paramAddr)
 
 void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 {
-	const float WRAP_WIDTH = 300.0f;
-	float y = 125.0f;
+	float WRAP_WIDTH = 300.0f;
+	if (UTF8StringNonASCIICount(text.c_str()) > 3)
+		WRAP_WIDTH = 372.0f;
+	
+	float y = 130.0f;
 	float h;
 	int n;
 	PPGeMeasureText(0, &h, &n, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
@@ -157,15 +161,15 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 			noColor  = 0xFFFFFFFF;
 		}
 		PPGeMeasureText(&w, &h, 0, choiceText, FONT_SCALE);
-		w = w / 2.0f + 5.5f;
+		w = w / 2.0f + 4.0f;
 		h /= 2.0f;
-		float y2 = y + h2 + 30.0f;
+		float y2 = y + h2 + 10.0f;
 		h2 += h + 4.0f;
 		y = 132.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
-		PPGeDrawText(d->T("Yes"), 209.0f, y2+3, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x30000000));
+		PPGeDrawText(d->T("Yes"), 209.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(d->T("Yes"), 208.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
-		PPGeDrawText(d->T("No"), 273.0f, y2+3, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x30000000));
+		PPGeDrawText(d->T("No"), 273.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(d->T("No"), 272.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(noColor));
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {
 			yesnoChoice = 1;
@@ -173,10 +177,22 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo)
 		else if (IsButtonPressed(CTRL_RIGHT) && yesnoChoice == 1) {
 			yesnoChoice = 0;
 		}
-	} 
-	PPGeDrawTextWrapped(text.c_str(), 241.0f, y+3, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x30000000));
+	} else {
+		I18NCategory *d = GetI18NCategory("Dialog");
+		float x, w;
+		x = 240.0f;
+		w = w / 2.0f + 12.0f;
+		h /= 2.0f;
+		float y2 = y + h2 + 10.0f;
+		h2 += h + 4.0f;
+		y = 132.0f - h;
+		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
+		PPGeDrawText(d->T("OK"), 241.0f, y2+2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
+		PPGeDrawText(d->T("OK"), 240.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+	}
+	PPGeDrawTextWrapped(text.c_str(), 241.0f, y+2, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
 	PPGeDrawTextWrapped(text.c_str(), 240.0f, y, WRAP_WIDTH, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
-	float sy = 110.0f - h2, ey = 160.0f + h2;
+	float sy = 125.0f - h2, ey = 145.0f + h2;
 	PPGeDrawRect(50.0f, sy, 420.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawRect(50.0f, ey, 420.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));
 }


### PR DESCRIPTION
This should be come very close to real PSP message dialog . Since english and japanese font have different wrap width and that's why we cannot render them correctly previously.

Try to test it and beat me :)
![screen00000](https://f.cloud.github.com/assets/3000282/723404/1561e20c-e017-11e2-9551-ceb1b4bdfdd1.jpg)
![screen00001](https://f.cloud.github.com/assets/3000282/723405/1794d688-e017-11e2-8cc4-e8982773f83a.jpg)
![screen00002](https://f.cloud.github.com/assets/3000282/723406/197330d0-e017-11e2-98fa-f02b08edf6c1.jpg)
