### PR TITLE
Add Square icon to LOAD/SAVE/DELETE

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -264,6 +264,7 @@ void PSPSaveDialog::DisplayBanner(int which)
 		break;
 	}
 	// TODO: Draw a hexagon icon
+	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawText(title, 30, 11, PPGE_ALIGN_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
 }
 


### PR DESCRIPTION
Get it come close to real PSP for LOAD/SAVE/DELETE dialog 

P.S : although it should be a hexagon in real PSP , it you know how to do it let me know .
