### PR TITLE
Improve breakpoint handling

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -28,7 +28,7 @@
 static FixedSizeUnorderedSet<BreakPoint, MAX_BREAKPOINTS> m_iBreakPoints;
 
 std::vector<MemCheck>		CBreakPoints::MemChecks;
-u32 CBreakPoints::m_iBreakOnCount = 0;
+u32 CBreakPoints::breakSkipFirstAt_ = 0;
 
 MemCheck::MemCheck(void)
 {
@@ -127,15 +127,6 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 
 	//none found
 	return 0;
-}
-
-bool CBreakPoints::IsBreakOnCount(u32 _iCount)
-{
-	if ((_iCount == m_iBreakOnCount) && 
-		(m_iBreakOnCount != 0))
-		return true;
-
-	return false;
 }
 
 void CBreakPoints::AddBreakPoint(u32 _iAddress, bool temp)

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -57,7 +57,7 @@ private:
 	enum { MAX_NUMBER_OF_CALLSTACK_ENTRIES = 16384};
 	enum { MAX_NUMBER_OF_BREAKPOINTS = 16};
 
-	static u32	m_iBreakOnCount;
+	static u32 breakSkipFirstAt_;
 
 public:
 	// WARNING: Not used in interpreter or HLE, only jit CPU memory access.
@@ -89,6 +89,9 @@ public:
 	static int GetNumBreakpoints();
 	static BreakPoint GetBreakpoint(int i);
 	static int GetBreakpointAddress(int i);
+
+	static void SetSkipFirst(u32 pc) { breakSkipFirstAt_ = pc; }
+	static u32 CheckSkipFirst() { u32 pc = breakSkipFirstAt_; breakSkipFirstAt_ = 0; return pc; }
 };
 
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -179,7 +179,6 @@ void Jit::CompileDelaySlot(int flags)
 {
 	const u32 addr = js.compilerPC + 4;
 
-	// TODO: If we ever support conditional breakpoints, we need to handle the flags more carefully.
 	// Need to offset the downcount which was already incremented for the branch + delay slot.
 	CheckJitBreakpoint(addr, -2);
 
@@ -444,6 +443,7 @@ bool Jit::CheckJitBreakpoint(u32 addr, int downcountOffset)
 {
 	if (CBreakPoints::IsAddressBreakPoint(addr))
 	{
+		SAVE_FLAGS;
 		FlushAll();
 		MOV(32, M(&mips_->pc), Imm32(js.compilerPC));
 		ABI_CallFunction((void *)&JitBreakpoint);
@@ -452,8 +452,12 @@ bool Jit::CheckJitBreakpoint(u32 addr, int downcountOffset)
 		CMP(32, R(EAX), Imm32(0));
 		FixupBranch skip = J_CC(CC_Z);
 		WriteDowncount(downcountOffset);
+		// Just to fix the stack.
+		LOAD_FLAGS;
 		JMP(asm_.dispatcherCheckCoreState, true);
 		SetJumpTarget(skip);
+
+		LOAD_FLAGS;
 
 		return true;
 	}

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -64,9 +64,6 @@ void JitBreakpoint()
 	Core_EnableStepping(true);
 	host->SetDebugMode(true);
 
-	if (CBreakPoints::IsTempBreakPoint(currentMIPS->pc))
-		CBreakPoints::RemoveBreakPoint(currentMIPS->pc);
-
 	// There's probably a better place for this.
 	if (USE_JIT_MISSMAP)
 	{

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -33,8 +33,8 @@
 namespace MIPSComp
 {
 
-// This is called when Jit hits a breakpoint.
-void JitBreakpoint();
+// This is called when Jit hits a breakpoint.  Returns 1 when hit.
+u32 JitBreakpoint();
 
 struct JitOptions
 {

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -846,7 +846,7 @@ void CtrlDisAsmView::disassembleToFile()
 
 	// gather all branch targets without labels
 	std::set<u32> branchAddresses;
-	for (int i = 0; i < size; i += instructionSize)
+	for (u32 i = 0; i < size; i += instructionSize)
 	{
 		char opcode[64],arguments[256];
 		const char *dis = debugger->disasm(curAddress+i, instructionSize);
@@ -862,7 +862,7 @@ void CtrlDisAsmView::disassembleToFile()
 	}
 
 	bool previousLabel = true;
-	for (int i = 0; i < size; i += instructionSize)
+	for (u32 i = 0; i < size; i += instructionSize)
 	{
 		u32 disAddress = curAddress+i;
 
@@ -897,7 +897,7 @@ void CtrlDisAsmView::disassembleToFile()
 
 void CtrlDisAsmView::getOpcodeText(u32 address, char* dest)
 {
-	char addressText[64],opcode[64],arguments[256];
+	char opcode[64],arguments[256];
 	const char *dis = debugger->disasm(address, instructionSize);
 	parseDisasm(dis,opcode,arguments);
 

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -30,7 +30,7 @@ class CtrlDisAsmView
 	HFONT boldfont;
 	RECT rect;
 
-	int curAddress;
+	u32 curAddress;
 	int rowHeight;
 
 	bool hasFocus;
@@ -38,7 +38,7 @@ class CtrlDisAsmView
 	DebugInterface *debugger;
 	static TCHAR szClassName[];
 
-	int windowStart;
+	u32 windowStart;
 	int visibleRows;
 	int instructionSize;
 	bool whiteBackground;
@@ -115,7 +115,7 @@ public:
 	{
 		gotoAddr(debugger->getPC()&(~(instructionSize-1)));
 	}
-	unsigned int getSelection()
+	u32 getSelection()
 	{
 		return curAddress;
 	}

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -512,7 +512,7 @@ void CtrlMemView::gotoPoint(int x, int y)
 void CtrlMemView::gotoAddr(unsigned int addr)
 {	
 	int lines=(rect.bottom/rowHeight);
-	int windowEnd = windowStart+lines*rowSize;
+	u32 windowEnd = windowStart+lines*rowSize;
 
 	curAddress = addr;
 	selectedNibble = 0;
@@ -555,7 +555,7 @@ void CtrlMemView::scrollCursor(int bytes)
 
 	curAddress += bytes;
 		
-	int windowEnd = windowStart+visibleRows*rowSize;
+	u32 windowEnd = windowStart+visibleRows*rowSize;
 	if (curAddress < windowStart)
 	{
 		windowStart = curAddress & ~15;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -40,6 +40,9 @@ float breakpointColumnSizes[] = {
 
 enum { BPL_TYPE, BPL_OFFSET, BPL_SIZELABEL, BPL_OPCODE, BPL_HITS, BPL_ENABLED, BPL_COLUMNCOUNT };
 
+// How long (max) to wait for Core to pause before clearing temp breakpoints.
+const int TEMP_BREAKPOINT_WAIT_MS = 100;
+
 static FAR WNDPROC DefBreakpointListProc;
 
 static LRESULT CALLBACK BreakpointListProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
@@ -817,6 +820,7 @@ void CDisasm::SetDebugMode(bool _bDebug)
 	// Update Dialog Windows
 	if (_bDebug)
 	{
+		Core_WaitInactive(TEMP_BREAKPOINT_WAIT_MS);
 		CBreakPoints::ClearTemporaryBreakPoints();
 		updateBreakpointList();
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -191,7 +191,7 @@ CDisasm::~CDisasm()
 
 int getTotalBreakpointCount()
 {
-	int count = CBreakPoints::MemChecks.size();
+	int count = (int)CBreakPoints::MemChecks.size();
 	for (int i = 0; i < CBreakPoints::GetNumBreakpoints(); i++)
 	{
 		if (!CBreakPoints::GetBreakpoint(i).bTemporary) count++;
@@ -239,7 +239,7 @@ int getBreakpointIndex(int itemIndex, bool& isMemory)
 		return itemIndex;
 	}
 
-	itemIndex -= CBreakPoints::MemChecks.size();
+	itemIndex -= (int)CBreakPoints::MemChecks.size();
 
 	int i = 0;
 	while (i < CBreakPoints::GetNumBreakpoints())

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -500,6 +500,10 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			case IDC_GO:
 				{
 					lastTicks = CoreTiming::GetTicks();
+
+					// If the current PC is on a breakpoint, the user doesn't want to do nothing.
+					CBreakPoints::SetSkipFirst(currentMIPS->pc);
+
 					SetDebugMode(false);
 					Core_EnableStepping(false);
 				}
@@ -509,6 +513,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				{
 					if (Core_IsActive()) break;
 					lastTicks = CoreTiming::GetTicks();
+
+					// If the current PC is on a breakpoint, the user doesn't want to do nothing.
+					CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
 					Core_DoSingleStep();		
 					Sleep(1);
@@ -523,6 +530,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				{
 					if (Core_IsActive()) break;
 					lastTicks = CoreTiming::GetTicks();
+
+					// If the current PC is on a breakpoint, the user doesn't want to do nothing.
+					CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
 					const char* dis = cpu->disasm(cpu->GetPC(),4);
 					const char* pos = strstr(dis,"->$");
@@ -574,6 +584,13 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				
 			case IDC_STEPHLE:
 				{
+					if (Core_IsActive())
+						break;
+					lastTicks = CoreTiming::GetTicks();
+
+					// If the current PC is on a breakpoint, the user doesn't want to do nothing.
+					CBreakPoints::SetSkipFirst(currentMIPS->pc);
+
 					hleDebugBreak();
 					SetDebugMode(false);
 					_dbg_update_();

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -732,6 +732,11 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			UpdateDialog();
 		}
 		break;
+
+	case WM_DISASM_SETDEBUG:
+		SetDebugMode(lParam != 0);
+		return TRUE;
+
 	case WM_SIZE:
 		{
 			UpdateSize(LOWORD(lParam), HIWORD(lParam));

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -12,6 +12,9 @@
 
 #include <windows.h>
 
+// Takes lParam for debug mode, zero or non zero.
+const int WM_DISASM_SETDEBUG = WM_APP + 0;
+
 class CDisasm : public Dialog
 {
 private:

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -124,9 +124,11 @@ void WindowsHost::UpdateDisassembly()
 
 void WindowsHost::SetDebugMode(bool mode)
 {
-	for (int i=0; i<numCPUs; i++)
+	for (int i = 0; i < numCPUs; i++)
+	{
 		if (disasmWindow[i])
-			disasmWindow[i]->SetDebugMode(mode);
+			PostMessage(disasmWindow[i]->GetDlgHandle(), WM_DISASM_SETDEBUG, 0, (LPARAM)mode);
+	}
 }
 
 extern BOOL g_bFullScreen;


### PR DESCRIPTION
This fixes #2519, by making sure the disasm stuff runs on its thread, not on the CPU thread.  Seems better that way even if it didn't fix anything.

Also allows hitting go when the pc is on a breakpoint, and actually going as you'd expect.  It doesn't work for branches or delay slots, though.  Maybe a vector would work, but I think it's checking for the breakpoint too much in those cases... anyway, this improves the common case in a definite way.

-[Unknown]
