### PR TITLE
Ctrl+G shortcut for goto

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -248,7 +248,7 @@ bool SymbolMap::getSymbolValue(char* symbol, u32& dest)
 		if (strcasecmp(entry.name,symbol) == 0)
 #endif
 		{
-			dest = entries[i].address;
+			dest = entries[i].vaddress;
 			return true;
 		}
 	}

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -194,9 +194,6 @@ bool CtrlDisAsmView::getDisasmAddressText(u32 address, char* dest, bool abbrevia
 		const char* addressSymbol = debugger->findSymbolForAddress(address);
 		if (addressSymbol != NULL)
 		{
-			if (memcmp(addressSymbol,"z_",2) == 0) addressSymbol += 2;
-			if (memcmp(addressSymbol,"zz_",3) == 0) addressSymbol += 3;
-
 			for (int k = 0; addressSymbol[k] != 0; k++)
 			{
 				// abbreviate long names
@@ -250,8 +247,6 @@ void CtrlDisAsmView::parseDisasm(const char* disasm, char* opcode, char* argumen
 			const char* addressSymbol = debugger->findSymbolForAddress(branchTarget);
 			if (addressSymbol != NULL && displaySymbols)
 			{
-				if (memcmp(addressSymbol,"z_",2) == 0) addressSymbol += 2;
-				if (memcmp(addressSymbol,"zz_",3) == 0) addressSymbol += 3;
 				arguments += sprintf(arguments,"%s",addressSymbol);
 			} else {
 				arguments += sprintf(arguments,"0x%08X",branchTarget);
@@ -490,19 +485,24 @@ void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 
 	if (controlHeld)
 	{
-		switch (wParam & 0xFFFF)
+		switch (tolower(wParam & 0xFFFF))
 		{
-		case 'S':
 		case 's':
 			search(false);
 			break;
-		case 'C':
 		case 'c':
 			search(true);
 			break;
 		case 'x':
-		case 'X':
 			disassembleToFile();
+			break;
+		case 'g':
+			{
+				u32 addr;
+				controlHeld = false;
+				if (executeExpressionWindow(wnd,debugger,addr) == false) return;
+				gotoAddr(addr);
+			}
 			break;
 		}
 	} else {

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -44,6 +44,7 @@ class CtrlMemView
 	int asciiStart;
 	bool asciiSelected;
 	int selectedNibble;
+	bool ctrlDown;
 
 	int visibleRows;
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -362,8 +362,6 @@ void CDisasm::handleBreakpointNotify(LPARAM lParam)
 					const char* sym = cpu->findSymbolForAddress(CBreakPoints::GetBreakpointAddress(index));
 					if (sym != NULL)
 					{
-						if (memcmp(sym,"z_",2) == 0) sym += 2;
-						if (memcmp(sym,"zz_",3) == 0) sym += 3;
 						strcpy(breakpointText,sym);
 					} else {
 						strcpy(breakpointText,"-");

--- a/Windows/Debugger/ExpressionParser.cpp
+++ b/Windows/Debugger/ExpressionParser.cpp
@@ -222,7 +222,7 @@ bool parseExpression(char* infix, DebugInterface* cpu, u32& dest)
 	while (infixPos < infixLen)
 	{
 		char first = tolower(infix[infixPos]);
-		char subStr[12];
+		char subStr[256];
 		int subPos = 0;
 
 		if (first == ' ' || first == '\t')


### PR DESCRIPTION
Adds a shortcut for a quick goto in the disassembly and memory viewer. Also fixes some mist stuff I messed up last time and removes the zz_/z_ skip in the disassembly view.
