### PR TITLE
Fix a couple crashes on shutdown

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -316,8 +316,8 @@ void SasInstance::SetGrainSize(int newGrainSize) {
 		delete [] resampleBuffer;
 
 	// 2 samples padding at the start, that's where we copy the two last samples from the channel
-	// so that we can do bicubic resampling if necessary.
-	resampleBuffer = new s16[grainSize * 4 + 2];
+	// so that we can do bicubic resampling if necessary.  Plus 1 for smoothness hackery.
+	resampleBuffer = new s16[grainSize * 4 + 3];
 }
 
 static inline s16 clamp_s16(int i) {
@@ -509,7 +509,7 @@ void SasInstance::DoState(PointerWrap &p) {
 		p.DoArray(sendBuffer, grainSize * 2);
 	}
 	if (resampleBuffer != NULL && grainSize > 0) {
-		p.DoArray(resampleBuffer, grainSize * 4 + 2);
+		p.DoArray(resampleBuffer, grainSize * 4 + 3);
 	}
 
 	int n = PSP_SAS_VOICES_MAX;

--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -17,6 +17,8 @@ static int xres, yres;
 // TODO: Make config?
 static bool enableGLDebug = false;
 
+#pragma optimize("", off)
+
 void GL_SetVSyncInterval(int interval=1)
 {
   if( wglSwapIntervalEXT )
@@ -219,7 +221,10 @@ void GL_Shutdown() {
 	}
 
 	if (hDC && !ReleaseDC(hWnd,hDC)) {
-		MessageBox(NULL,"Release Device Context Failed.","SHUTDOWN ERROR",MB_OK | MB_ICONINFORMATION);
+		DWORD err = GetLastError();
+		if (err != ERROR_DC_NOT_FOUND) {
+			MessageBox(NULL,"Release Device Context Failed.","SHUTDOWN ERROR",MB_OK | MB_ICONINFORMATION);
+		}
 		hDC = NULL;
 	}
 	hWnd = NULL;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -154,6 +154,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	VFSShutdown();
 
+	EmuThread_Stop();
+
 	DialogManager::DestroyAll();
 	timeEndPeriod(1);
 	delete host;


### PR DESCRIPTION
AFAICT the "smoothness hackery" (`resampleBuffer[2 + numSamples] = resampleBuffer[2 + numSamples - 1];`) could go out of bounds when `(int)numSamples == grainSize * 4`, which is allowed.  I was getting a somewhat reproducible heap warning in debug, and after changing this I can't get it anymore, so... hopefully this was it.

Also fixes a crash in #2537, since it wasn't ever shutting down the emu thread when you went through the menu to exit, it seems.

-[Unknown]
