### PR TITLE
Add an optional hack to force <= 60 FPS

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -105,7 +105,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("VBO", &bUseVBO, false);
 	graphics->Get("FrameSkip", &iFrameSkip, 0);
 	graphics->Get("FrameRate", &iFpsLimit, 60);
-	graphics->Get("ForceGameFPS", &iForceGameFPS, 0);
+	graphics->Get("ForceMaxEmulatedFPS", &iForceMaxEmulatedFPS, 0);
 #ifdef USING_GLES2
 	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 0);
 #else
@@ -223,7 +223,7 @@ void Config::Save()
 		graphics->Set("VBO", bUseVBO);
 		graphics->Set("FrameSkip", iFrameSkip);
 		graphics->Set("FrameRate", iFpsLimit);
-		graphics->Set("ForceGameFPS", iForceGameFPS);
+		graphics->Set("ForceMaxEmulatedFPS", iForceMaxEmulatedFPS);
 		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
 		graphics->Set("FullScreen", bFullScreen);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -105,6 +105,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("VBO", &bUseVBO, false);
 	graphics->Get("FrameSkip", &iFrameSkip, 0);
 	graphics->Get("FrameRate", &iFpsLimit, 60);
+	graphics->Get("ForceGameFPS", &iForceGameFPS, 0);
 #ifdef USING_GLES2
 	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 0);
 #else
@@ -222,6 +223,7 @@ void Config::Save()
 		graphics->Set("VBO", bUseVBO);
 		graphics->Set("FrameSkip", iFrameSkip);
 		graphics->Set("FrameRate", iFpsLimit);
+		graphics->Set("ForceGameFPS", iForceGameFPS);
 		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
 		graphics->Set("FullScreen", bFullScreen);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -88,7 +88,7 @@ public:
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;
 	int iFpsLimit;
-	int iForceGameFPS;
+	int iForceMaxEmulatedFPS;
 	int iMaxRecent;
 	bool bEnableCheats;
 	bool bReloadCheats;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -88,6 +88,7 @@ public:
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;
 	int iFpsLimit;
+	int iForceGameFPS;
 	int iMaxRecent;
 	bool bEnableCheats;
 	bool bReloadCheats;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -514,9 +514,9 @@ u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) 
 
 	if (topaddr != framebuf.topaddr) {
 		++numFlips;
-		if (g_Config.iForceGameFPS) {
+		if (g_Config.iForceMaxEmulatedFPS) {
 			u64 now = CoreTiming::GetTicks();
-			u64 expected = msToCycles(1000) / g_Config.iForceGameFPS;
+			u64 expected = msToCycles(1000) / g_Config.iForceMaxEmulatedFPS;
 			u64 actual = now - lastFlipCycles;
 			if (actual < expected)
 				hleEatCycles((int)(expected - actual));

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -216,6 +216,7 @@ namespace Reporting
 			float vps, fps;
 			__DisplayGetAveragedFPS(&vps, &fps);
 			postdata.Add("vps", vps);
+			postdata.Add("fps", fps);
 		}
 
 		// TODO: Settings, savestate/savedata status, some measure of speed/fps?

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -915,7 +915,7 @@ int TransformDrawEngine::EstimatePerVertexCost() {
 
 	for (int i = 0; i < 4; i++) {
 		if (gstate.lightEnable[i] & 1)
-			cost += 20;
+			cost += 10;
 	}
 	if (gstate.getUVGenMode() != 0) {
 		cost += 20;
@@ -924,11 +924,6 @@ int TransformDrawEngine::EstimatePerVertexCost() {
 		cost += 5 * dec_->morphcount;
 	}
 
-	if (CoreTiming::GetClockFrequencyMHz() == 333) {
-		// Just brutally double to make God of War happier.
-		// FUDGE FACTORS! Delicious fudge factors!
-		cost *= 2;
-	}
 	return cost;
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -358,9 +358,9 @@ void EmuScreen::render() {
 		case 1:
 			sprintf(fpsbuf, "Speed: %0.1f", vps); break;
 		case 2:
-			sprintf(fpsbuf, "FPES: %0.1f", fps); break;
+			sprintf(fpsbuf, "FPS: %0.1f", fps); break;
 		case 3:
-			sprintf(fpsbuf, "Speed: %5.1f\nFPES: %0.1f", vps, fps); break;
+			sprintf(fpsbuf, "Speed: %5.1f\nFPS: %0.1f", vps, fps); break;
 		}
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 8, 12, 0xc0000000, ALIGN_TOPRIGHT);
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 10, 10, 0xFF3fFF3f, ALIGN_TOPRIGHT);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -356,11 +356,11 @@ void EmuScreen::render() {
 		char fpsbuf[256];
 		switch (g_Config.iShowFPSCounter) {
 		case 1:
-			sprintf(fpsbuf, "VPS: %0.1f", vps); break;
+			sprintf(fpsbuf, "Speed: %0.1f", vps); break;
 		case 2:
-			sprintf(fpsbuf, "FPS: %0.1f", fps); break;
+			sprintf(fpsbuf, "FPES: %0.1f", fps); break;
 		case 3:
-			sprintf(fpsbuf, "VPS: %0.1f\nFPS: %0.1f", vps, fps); break;
+			sprintf(fpsbuf, "Speed: %5.1f\nFPES: %0.1f", vps, fps); break;
 		}
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 8, 12, 0xc0000000, ALIGN_TOPRIGHT);
 		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 10, 10, 0xFF3fFF3f, ALIGN_TOPRIGHT);

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -971,14 +971,14 @@ void GraphicsScreenP3::render() {
 		g_Config.iForceMaxEmulatedFPS = ForceMaxEmulatedFPS60 ? 60 : 0;
 
 	bool ShowCounter = g_Config.iShowFPSCounter > 0;
-	UICheckBox(GEN_ID, x, y += stride, gs->T("Show speed / frames per emusecond"), ALIGN_TOPLEFT, &ShowCounter);
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Show speed / internal FPS"), ALIGN_TOPLEFT, &ShowCounter);
 	if (ShowCounter) {
 #ifdef _WIN32
 	const int checkboxH = 32;
 #else
 	const int checkboxH = 48;
 #endif
-		ui_draw2d.DrawTextShadow(UBUNTU24, gs->T("(60.0 is full speed, FPES depends on game)"), x + UI_SPACE + 29, (y += stride) + checkboxH / 2, 0xFFFFFFFF, ALIGN_LEFT | ALIGN_VCENTER);
+		ui_draw2d.DrawTextShadow(UBUNTU24, gs->T("(60.0 is full speed, internal FPS depends on game)"), x + UI_SPACE + 29, (y += stride) + checkboxH / 2, 0xFFFFFFFF, ALIGN_LEFT | ALIGN_VCENTER);
 
 		if (g_Config.iShowFPSCounter <= 0)
 			g_Config.iShowFPSCounter = 1;
@@ -986,7 +986,7 @@ void GraphicsScreenP3::render() {
 		const char *type;
 		switch (g_Config.iShowFPSCounter) {
 		case 1: type = gs->T("Display: Speed"); break;
-		case 2:	type = gs->T("Display: FPES"); break;
+		case 2:	type = gs->T("Display: FPS"); break;
 		case 3: type = gs->T("Display: Both"); break;
 		}
 
@@ -994,7 +994,7 @@ void GraphicsScreenP3::render() {
 		HLinear hlinear1(x + 260, y, 20);
 		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("Speed"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 1;
-		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("FPES"), ALIGN_LEFT))
+		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("FPS"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 2;
 		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("Both"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 3;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -966,9 +966,9 @@ void GraphicsScreenP3::render() {
 	int stride = 40;
 	int columnw = 400;
 	
-	bool forceGameFPS60 = g_Config.iForceGameFPS == 60;
-	if (UICheckBox(GEN_ID, x, y += stride, gs->T("Force 60 FPS or less"), ALIGN_TOPLEFT, &forceGameFPS60))
-		g_Config.iForceGameFPS = forceGameFPS60 ? 60 : 0;
+	bool ForceMaxEmulatedFPS60 = g_Config.iForceMaxEmulatedFPS == 60;
+	if (UICheckBox(GEN_ID, x, y += stride, gs->T("Force 60 FPS or less"), ALIGN_TOPLEFT, &ForceMaxEmulatedFPS60))
+		g_Config.iForceMaxEmulatedFPS = ForceMaxEmulatedFPS60 ? 60 : 0;
 
 	bool ShowCounter = g_Config.iShowFPSCounter > 0;
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Show speed / frames per emusecond"), ALIGN_TOPLEFT, &ShowCounter);

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -966,6 +966,10 @@ void GraphicsScreenP3::render() {
 	int stride = 40;
 	int columnw = 400;
 	
+	bool forceGameFPS60 = g_Config.iForceGameFPS == 60;
+	if (UICheckBox(GEN_ID, x, y += stride, gs->T("Force 60 FPS or less"), ALIGN_TOPLEFT, &forceGameFPS60))
+		g_Config.iForceGameFPS = forceGameFPS60 ? 60 : 0;
+
 	bool ShowCounter = g_Config.iShowFPSCounter > 0;
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Show speed / frames per emusecond"), ALIGN_TOPLEFT, &ShowCounter);
 	if (ShowCounter) {
@@ -998,7 +1002,7 @@ void GraphicsScreenP3::render() {
 		y += 20;
 	} else 
 		g_Config.iShowFPSCounter = 0;
-		
+
 	bool FpsLimit = g_Config.iFpsLimit != 0;
 	UICheckBox(GEN_ID, x, y += stride, gs->T("Toggled Speed Limit"), ALIGN_TOPLEFT, &FpsLimit);
 	if (FpsLimit) {

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -967,27 +967,32 @@ void GraphicsScreenP3::render() {
 	int columnw = 400;
 	
 	bool ShowCounter = g_Config.iShowFPSCounter > 0;
-	UICheckBox(GEN_ID, x, y += stride, gs->T("Show VPS/FPS"), ALIGN_TOPLEFT, &ShowCounter);
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Show speed / frames per emusecond"), ALIGN_TOPLEFT, &ShowCounter);
 	if (ShowCounter) {
+#ifdef _WIN32
+	const int checkboxH = 32;
+#else
+	const int checkboxH = 48;
+#endif
+		ui_draw2d.DrawTextShadow(UBUNTU24, gs->T("(60.0 is full speed, FPES depends on game)"), x + UI_SPACE + 29, (y += stride) + checkboxH / 2, 0xFFFFFFFF, ALIGN_LEFT | ALIGN_VCENTER);
+
 		if (g_Config.iShowFPSCounter <= 0)
 			g_Config.iShowFPSCounter = 1;
 
-		char counter[256];
-		std::string type;
-
+		const char *type;
 		switch (g_Config.iShowFPSCounter) {
-		case 1: type = "VPS";break;
-		case 2:	type = "FPS";break;
-		case 3: type = "Both";break;
+		case 1: type = gs->T("Display: Speed"); break;
+		case 2:	type = gs->T("Display: FPES"); break;
+		case 3: type = gs->T("Display: Both"); break;
 		}
-		sprintf(counter, "%s %s", gs->T("Format :"), type.c_str());
-		ui_draw2d.DrawText(UBUNTU24, counter, x + 60, y += stride , 0xFFFFFFFF, ALIGN_LEFT);
-		HLinear hlinear1(x + 250, y, 20);
-		if (UIButton(GEN_ID, hlinear1, 80, 0, gs->T("VPS"), ALIGN_LEFT))
+
+		ui_draw2d.DrawText(UBUNTU24, type, x + 60, y += stride , 0xFFFFFFFF, ALIGN_LEFT);
+		HLinear hlinear1(x + 260, y, 20);
+		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("Speed"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 1;
-		if (UIButton(GEN_ID, hlinear1, 80, 0, gs->T("FPS"), ALIGN_LEFT))
+		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("FPES"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 2;
-		if (UIButton(GEN_ID, hlinear1, 90, 0, gs->T("Both"), ALIGN_LEFT))
+		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("Both"), ALIGN_LEFT))
 			g_Config.iShowFPSCounter = 3;
 
 		y += 20;
@@ -995,22 +1000,22 @@ void GraphicsScreenP3::render() {
 		g_Config.iShowFPSCounter = 0;
 		
 	bool FpsLimit = g_Config.iFpsLimit != 0;
-	UICheckBox(GEN_ID, x, y += stride, gs->T("FPS Limit"), ALIGN_TOPLEFT, &FpsLimit);
+	UICheckBox(GEN_ID, x, y += stride, gs->T("Toggled Speed Limit"), ALIGN_TOPLEFT, &FpsLimit);
 	if (FpsLimit) {
 		if (g_Config.iFpsLimit == 0)
 			g_Config.iFpsLimit = 60;
 		
 		char showFps[256];
-		sprintf(showFps, "%s %d", gs->T("FPS :"), g_Config.iFpsLimit);
+		sprintf(showFps, "%s %d", gs->T("Speed :"), g_Config.iFpsLimit);
 		ui_draw2d.DrawText(UBUNTU24, showFps, x + 60, y += stride , 0xFFFFFFFF, ALIGN_LEFT);
-		HLinear hlinear1(x + 250, y, 20);
-		if (UIButton(GEN_ID, hlinear1, 80, 0, gs->T("Auto"), ALIGN_LEFT))
+		HLinear hlinear1(x + 260, y, 20);
+		if (UIButton(GEN_ID, hlinear1, 100, 0, gs->T("Auto"), ALIGN_LEFT))
 			g_Config.iFpsLimit = 60;
-		if (UIButton(GEN_ID, hlinear1, 40, 0, gs->T("-1"), ALIGN_LEFT))
-			if(g_Config.iFpsLimit > 30)
+		if (UIButton(GEN_ID, hlinear1, 50, 0, gs->T("-1"), ALIGN_LEFT))
+			if(g_Config.iFpsLimit > 10)
 				g_Config.iFpsLimit -= 1;
-		if (UIButton(GEN_ID, hlinear1, 40, 0, gs->T("+1"), ALIGN_LEFT))
-			if(g_Config.iFrameSkip != 120)
+		if (UIButton(GEN_ID, hlinear1, 50, 0, gs->T("+1"), ALIGN_LEFT))
+			if(g_Config.iFrameSkip < 240)
 				g_Config.iFpsLimit += 1;
 
 		y += 20;


### PR DESCRIPTION
I don't really like hacks, especially options that just add complexity for users.  But this is actually a relatively safe option we could theoretically even consider defaulting on.  It simply doesn't let the game flip more than 60 times per second (KISS, it applies this enforcement each frame with no smoothing, which works great AFAICT.)  This is a workaround hack for #862, separated to fix #2010.

This vastly improves the performance of God of War and Fat Princess (namely in the intros/menus where this problem is most severe), which can render at a mostly stable 60 / 60 on my hardware.  The only problem I've found is that it makes the battle animation worse in Tales of Phantasia X (there's something else going on there, but maxing out fps makes the problem wiz by faster.)

Anyway, there are other related changes included:
- Instead of "VPS", uses "Speed" to be clearer.  "FPS" is replaced with "FPES" (it describes this in settings as "frames per emusecond.")  The rationale here is to prevent users getting confused about the meaning of the two values.
- Reduces the fudge factors for GPU cycles.  This improves games that see an incorrect slowdown in some areas.  So far, it seems like these games can also tolerate the 60 FPS limit hack.  Side note: in the menu, God of War (demo at least) was actually affected by this slowdown, and rendering 45 FPS incorrectly.
- Adds a setting to the old UI for forcing the FPS, and cleans up the other FPS related UI a tiny bit, adding a bit more space for translations and making a few strings translatable.

Note that the setting is intentionally set up so that other values, such as 45, 30, 20, 15, and 10 are configurable.  This is so power users/testers can investigate problems.  The UI also intentionally does not provide these options because anything lower than 60 is much more likely to cause issues.

New strings added by these changes:
- Show 60 FPS or less
- Show speed / internal FPS
- (60.0 is full speed, internal FPS depends on game)
- Display: Speed
- Display: FPS
- Display: Both
- Speed
- Toggled Speed Limit
- Speed :

Removed strings:
- Show VPS/FPS
- VPS
- FPS Limit
- FPS :

-[Unknown]
