### PR TITLE
Add fake glowing effect to save icon and use 'NEW DATA' as real PSP does

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -20,7 +20,7 @@
 #include "ChunkFile.h"
 #include "i18n/i18n.h"
 
-#define FADE_TIME 0.5
+#define FADE_TIME 1.0
 const float FONT_SCALE = 0.55f;
 
 PSPDialog::PSPDialog() : status(SCE_UTILITY_STATUS_SHUTDOWN)
@@ -46,7 +46,7 @@ PSPDialog::DialogStatus PSPDialog::GetStatus()
 void PSPDialog::StartDraw()
 {
 	PPGeBegin();
-	PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x80000000));
+	PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x20000000));
 }
 
 void PSPDialog::EndDraw()

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -344,7 +344,7 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 {
 	if (param.GetFileInfo(currentSelectedSave).size == 0) {
 		I18NCategory *d = GetI18NCategory("Dialog");
-		PPGeDrawText(d->T("New Save"), 180, 136, PPGE_ALIGN_VCENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("NEW DATA"), 180, 136, PPGE_ALIGN_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
 	} else {
 		char title[512];
 		char time[512];

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -273,10 +273,10 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 	int displayCount = 0;
 	for (int i = 0; i < param.GetFilenameCount(); i++)
 	{
-		int textureColor = CalcFadedColor(0xFFFFFFFF);
+		int textureColor = 0xFFFFFFFF;
 
 		if (param.GetFileInfo(i).size == 0 && param.GetFileInfo(i).textureData == 0) 
-			textureColor = CalcFadedColor(0xFF777777);
+			textureColor = 0xFF777777;
 
 		// Calc save image position on screen
 		float w = 144;
@@ -505,11 +505,6 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 	float sy = 122.0f - h2, ey = 150.0f + h2;
 	PPGeDrawRect(202.0f, sy, 466.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawRect(202.0f, ey, 466.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));
-}
-
-void PSPSaveDialog::DisplayTitle(std::string name)
-{
-	PPGeDrawText(name.c_str(), 10, 10, PPGE_ALIGN_LEFT, 0.45f, CalcFadedColor(0xFFFFFFFF));
 }
 
 int PSPSaveDialog::Update()

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -279,15 +279,22 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 			textureColor = 0xFF777777;
 
 		// Calc save image position on screen
-		float w = 144;
-		float h = 80;
-		float x = 27;
+		float w, h , x, b;
+		float y = 97;
 		if (displayCount != currentSelectedSave) {
 			w = 81;
 			h = 45;
 			x = 58.5f;
+		} else {
+			w = 144;
+			h = 80;
+			x = 27;
+			b = 1.2;
+			PPGeDrawRect(x-b, y-b, x+w+b, y, CalcFadedColor(0xD0FFFFFF)); // top border
+			PPGeDrawRect(x-b, y, x, y+h, CalcFadedColor(0xD0FFFFFF)); // left border
+			PPGeDrawRect(x-b, y+h, x+w+b, y+h+b, CalcFadedColor(0xD0FFFFFF)); //bottom border
+			PPGeDrawRect(x-b, y, x+w+b, y+h, CalcFadedColor(0xD0FFFFFF)); //right border
 		}
-		float y = 97;
 		if (displayCount < currentSelectedSave)
 			y -= 13 + 45 * (currentSelectedSave - displayCount);
 		else if (displayCount > currentSelectedSave)
@@ -299,9 +306,9 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 			tw = param.GetFileInfo(i).textureWidth;
 			th = param.GetFileInfo(i).textureHeight;
 			PPGeSetTexture(param.GetFileInfo(i).textureData, param.GetFileInfo(i).textureWidth, param.GetFileInfo(i).textureHeight);
+			PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
 		} else
 			PPGeDisableTexture();
-		PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
 		PPGeSetDefaultTexture();
 		displayCount++;
 	}

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -293,7 +293,7 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 			PPGeDrawRect(x-b, y-b, x+w+b, y, CalcFadedColor(0xD0FFFFFF)); // top border
 			PPGeDrawRect(x-b, y, x, y+h, CalcFadedColor(0xD0FFFFFF)); // left border
 			PPGeDrawRect(x-b, y+h, x+w+b, y+h+b, CalcFadedColor(0xD0FFFFFF)); //bottom border
-			PPGeDrawRect(x-b, y, x+w+b, y+h, CalcFadedColor(0xD0FFFFFF)); //right border
+			PPGeDrawRect(x+w, y, x+w+b, y+h, CalcFadedColor(0xD0FFFFFF)); //right border
 		}
 		if (displayCount < currentSelectedSave)
 			y -= 13 + 45 * (currentSelectedSave - displayCount);


### PR DESCRIPTION
1. Save Icon should come out first then transit to save detail .
2. It should be 'NEW DATA' instead of 'New Save' on real PSP .
3. Add fake glowing effect to save icon .

![screen00025](https://f.cloud.github.com/assets/3000282/730167/de748ede-e24b-11e2-98dc-d0afc7a781b6.jpg)
