### PR TITLE
Keep symbol map entries from between modules

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -173,7 +173,8 @@ bool SymbolMap::LoadSymbolMap(const char *filename)
 
 		if (!started) continue;
 		MapEntry e;
-		sscanf(line,"%08x %08x %08x %i %s",&e.address,&e.size,&e.vaddress,(int*)&e.type,e.name);
+		memset(&e, 0, sizeof(e));
+		sscanf(line,"%08x %08x %08x %i %127c",&e.address,&e.size,&e.vaddress,(int*)&e.type,e.name);
 		
 		if (e.type == ST_DATA && e.size==0)
 			e.size=4;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -19,6 +19,7 @@
 
 #include "../../Globals.h"
 #include <vector>
+#include <set>
 
 enum SymbolType
 {
@@ -36,62 +37,64 @@ class SymbolMap
 public:
 	SymbolMap() {}
 	bool LoadSymbolMap(const char *filename);
-	void SaveSymbolMap(const char *filename);
+	void SaveSymbolMap(const char *filename) const;
 	void AddSymbol(const char *symbolname, unsigned int vaddress, size_t size, SymbolType symbol);
 	void ResetSymbolMap();
 	void AnalyzeBackwards();
-	int GetSymbolNum(unsigned int address, SymbolType symmask=ST_FUNCTION);
-	char *GetDescription(unsigned int address);
+	int GetSymbolNum(unsigned int address, SymbolType symmask=ST_FUNCTION) const;
+	const char *GetDescription(unsigned int address) const;
 #ifdef _WIN32
-	void FillSymbolListBox(HWND listbox, SymbolType symmask=ST_FUNCTION);
-	void FillSymbolComboBox(HWND listbox,SymbolType symmask=ST_FUNCTION);
-	void FillListBoxBLinks(HWND listbox, int num);
+	void FillSymbolListBox(HWND listbox, SymbolType symmask=ST_FUNCTION) const;
+	void FillSymbolComboBox(HWND listbox,SymbolType symmask=ST_FUNCTION) const;
+	void FillListBoxBLinks(HWND listbox, int num) const;
 #endif
-	int GetNumSymbols();
-	char *GetSymbolName(int i);
+	int GetNumSymbols() const;
+	const char *GetSymbolName(int i) const;
 	void SetSymbolName(int i, const char *newname);
-	u32 GetSymbolSize(int i);
-	u32 GetSymbolAddr(int i);
-	SymbolType GetSymbolType(int i);
-	int FindSymbol(const char *name);
-	u32	GetAddress(int num);
+	u32 GetSymbolSize(int i) const;
+	u32 GetSymbolAddr(int i) const;
+	SymbolType GetSymbolType(int i) const;
+	int FindSymbol(const char *name) const;
+	u32	GetAddress(int num) const;
 	void IncreaseRunCount(int num);
-	unsigned int GetRunCount(int num);
+	unsigned int GetRunCount(int num) const;
 	void SortSymbols();
 	const char* getDirectSymbol(u32 address);
 	bool getSymbolValue(char* symbol, u32& dest);
 
 	void UseFuncSignaturesFile(const char *filename, u32 maxAddress);
-	void CompileFuncSignaturesFile(const char *filename);
+	void CompileFuncSignaturesFile(const char *filename) const;
 
 private:
-	struct MapEntry
+	struct MapEntryUniqueInfo
 	{
 		u32 address;
 		u32 vaddress;
 		u32 size;
-		u32 unknown;
-
-		u32 runCount;
-
 		SymbolType type;
+
+		bool operator <(const MapEntryUniqueInfo &other) const {
+			return vaddress < other.vaddress;
+		}
+	};
+
+	struct MapEntry : public MapEntryUniqueInfo
+	{
+		char name[128];
+		u32 unknown;
+		u32 runCount;
 
 #ifdef BWLINKS
 		std::vector <u32> backwardLinks;
 #endif
 
-		char name[128];
-
 		void UndecorateName()
 		{
 			// TODO
 		}
-
-		bool operator <(const MapEntry &other) const {
-			return vaddress < other.vaddress;
-		}
 	};
 
+	std::set<MapEntryUniqueInfo> uniqueEntries;
 	std::vector<MapEntry> entries;
 };
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -547,13 +547,9 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 		u32 textStart = reader.GetSectionAddr(textSection);
 		u32 textSize = reader.GetSectionSize(textSection);
 
-		host->AttemptLoadSymbolMap();
-
 		if (!reader.LoadSymbols())
 			MIPSAnalyst::ScanForFunctions(textStart, textStart+textSize);
 	}
-	else
-		host->AttemptLoadSymbolMap();
 
 	INFO_LOG(LOADER,"Module %s: %08x %08x %08x", modinfo->name, modinfo->gp, modinfo->libent,modinfo->libstub);
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -688,7 +688,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					while (addr != 0xFFFFFFFF && addr!=0 && count++<20)
 					{
 						DWORD fun = Memory::ReadUnchecked_U32(addr+4);
-						char *str = symbolMap.GetDescription(fun);
+						const char *str = symbolMap.GetDescription(fun);
 						if (strlen(str)==0)
 							str = "(unknown)";
 						ComboBox_SetItemData(list, ComboBox_AddString(list,str), fun);

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -168,16 +168,12 @@ static std::string SymbolMapFilename(const char *currentFilename)
 
 bool WindowsHost::AttemptLoadSymbolMap()
 {
-	if (loadedSymbolMap_)
-		return true;
-	loadedSymbolMap_ = symbolMap.LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
-	return loadedSymbolMap_;
+	return symbolMap.LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
 }
 
 void WindowsHost::SaveSymbolMap()
 {
 	symbolMap.SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str()).c_str());
-	loadedSymbolMap_ = false;
 }
 
 void WindowsHost::AddSymbol(std::string name, u32 addr, u32 size, int type=0) 

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -28,7 +28,6 @@ public:
 		mainWindow_ = mainWindow;
 		displayWindow_ = displayWindow;
 		input = getInputDevices();
-		loadedSymbolMap_ = false;
 		SetConsolePosition();
 	}
 	~WindowsHost()
@@ -64,5 +63,4 @@ private:
 	HWND displayWindow_;
 	HWND mainWindow_;
 	std::list<std::shared_ptr<InputDevice>> input;
-	bool loadedSymbolMap_;
 };


### PR DESCRIPTION
This helps for when we add modules (like sceCcc) and when a game loads and unloads modules.  I use these files not only for the debugger and renaming funcs, but also to scan for usage of sce\* funcs.  But it wasn't accurate since modules loaded later would either skip updating the symbol map, or erase previous entries.

This keeps a unique std::set of the address/size/types, and then always adds.

Also made a bunch of things const because I wanted to be sure I didn't miss anything that was mutating `entries`.

-[Unknown]
