### PR TITLE
Rewrite CBreakPoints, fix MemCheck bugs

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -53,7 +53,7 @@ size_t CBreakPoints::FindBreakpoint(u32 addr, bool matchTemp, bool temp)
 {
 	for (size_t i = 0; i < breakPoints_.size(); ++i)
 	{
-		if (breakPoints_[i].iAddress == addr && (!matchTemp || breakPoints_[i].bTemporary == temp))
+		if (breakPoints_[i].addr == addr && (!matchTemp || breakPoints_[i].temporary == temp))
 			return i;
 	}
 
@@ -74,7 +74,7 @@ size_t CBreakPoints::FindMemCheck(u32 start, u32 end)
 bool CBreakPoints::IsAddressBreakPoint(u32 addr)
 {
 	size_t bp = FindBreakpoint(addr);
-	return bp != INVALID_BREAKPOINT && breakPoints_[bp].bOn;
+	return bp != INVALID_BREAKPOINT && breakPoints_[bp].enabled;
 }
 
 bool CBreakPoints::IsTempBreakPoint(u32 addr)
@@ -89,16 +89,16 @@ void CBreakPoints::AddBreakPoint(u32 addr, bool temp)
 	if (bp == INVALID_BREAKPOINT)
 	{
 		BreakPoint pt;
-		pt.bOn = true;
-		pt.bTemporary = temp;
-		pt.iAddress = addr;
+		pt.enabled = true;
+		pt.temporary = temp;
+		pt.addr = addr;
 
 		breakPoints_.push_back(pt);
 		Update(addr);
 	}
-	else if (!breakPoints_[bp].bOn)
+	else if (!breakPoints_[bp].enabled)
 	{
-		breakPoints_[bp].bOn = true;
+		breakPoints_[bp].enabled = true;
 		Update(addr);
 	}
 }
@@ -124,7 +124,7 @@ void CBreakPoints::ChangeBreakPoint(u32 addr, bool status)
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT)
 	{
-		breakPoints_[bp].bOn = status;
+		breakPoints_[bp].enabled = status;
 		Update(addr);
 	}
 }
@@ -146,7 +146,7 @@ void CBreakPoints::ClearTemporaryBreakPoints()
 	bool update = false;
 	for (int i = (int)breakPoints_.size()-1; i >= 0; --i)
 	{
-		if (breakPoints_[i].bTemporary)
+		if (breakPoints_[i].temporary)
 		{
 			breakPoints_.erase(breakPoints_.begin() + i);
 			update = true;
@@ -258,21 +258,6 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 
 	//none found
 	return 0;
-}
-
-int CBreakPoints::GetNumBreakpoints()
-{
-	return (int)breakPoints_.size();
-}
-
-const BreakPoint CBreakPoints::GetBreakpoint(size_t i)
-{
-	return breakPoints_[i];
-}
-
-int CBreakPoints::GetBreakpointAddress(size_t i)
-{
-	return breakPoints_[i].iAddress;
 }
 
 const std::vector<MemCheck> CBreakPoints::GetMemChecks()

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -157,6 +157,35 @@ void CBreakPoints::ClearTemporaryBreakPoints()
 		Update();
 }
 
+void CBreakPoints::ChangeBreakPointAddCond(u32 addr, const BreakPointCond &cond)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].hasCond = true;
+		breakPoints_[bp].cond = cond;
+		Update();
+	}
+}
+
+void CBreakPoints::ChangeBreakPointRemoveCond(u32 addr)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].hasCond = false;
+		Update();
+	}
+}
+
+BreakPointCond *CBreakPoints::GetBreakPointCondition(u32 addr)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp != INVALID_BREAKPOINT && breakPoints_[bp].hasCond)
+		return &breakPoints_[bp].cond;
+	return NULL;
+}
+
 void CBreakPoints::AddMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result)
 {
 	size_t mc = FindMemCheck(start, end);
@@ -236,12 +265,12 @@ int CBreakPoints::GetNumBreakpoints()
 	return (int)breakPoints_.size();
 }
 
-const BreakPoint CBreakPoints::GetBreakpoint(int i)
+const BreakPoint CBreakPoints::GetBreakpoint(size_t i)
 {
 	return breakPoints_[i];
 }
 
-int CBreakPoints::GetBreakpointAddress(int i)
+int CBreakPoints::GetBreakpointAddress(size_t i)
 {
 	return breakPoints_[i].iAddress;
 }

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -23,12 +23,9 @@
 #include "../MIPS/JitCommon/JitCommon.h"
 #include <cstdio>
 
-#define MAX_BREAKPOINTS 16
-
-static FixedSizeUnorderedSet<BreakPoint, MAX_BREAKPOINTS> m_iBreakPoints;
-
-std::vector<MemCheck>		CBreakPoints::MemChecks;
+std::vector<BreakPoint> CBreakPoints::breakPoints_;
 u32 CBreakPoints::breakSkipFirstAt_ = 0;
+std::vector<MemCheck> CBreakPoints::memChecks_;
 
 MemCheck::MemCheck(void)
 {
@@ -37,13 +34,14 @@ MemCheck::MemCheck(void)
 
 void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
 {
-	if ((write && bOnWrite) || (!write && bOnRead))
+	int mask = write ? MEMCHECK_WRITE : MEMCHECK_READ;
+	if (cond & mask)
 	{
 		++numHits;
 
-		if (bLog)
+		if (result & MEMCHECK_LOG)
 			NOTICE_LOG(MEMMAP, "CHK %s%i at %08x (%s), PC=%08x (%s)", write ? "Write" : "Read", size * 8, addr, symbolMap.GetDescription(addr), pc, symbolMap.GetDescription(pc));
-		if (bBreak)
+		if (result & MEMCHECK_BREAK)
 		{
 			Core_EnableStepping(true);
 			host->SetDebugMode(true);
@@ -51,76 +49,180 @@ void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
 	}
 }
 
-bool CBreakPoints::IsAddressBreakPoint(u32 _iAddress)
+size_t CBreakPoints::FindBreakpoint(u32 addr, bool matchTemp, bool temp)
 {
-	for (size_t i = 0; i < m_iBreakPoints.size(); i++)
-		if (m_iBreakPoints[i].iAddress == _iAddress)
-			return true;
-
-	return false;
-}
-
-bool CBreakPoints::IsTempBreakPoint(u32 _iAddress)
-{
-	for (size_t i = 0; i < m_iBreakPoints.size(); i++)
-		if (m_iBreakPoints[i].iAddress == _iAddress && m_iBreakPoints[i].bTemporary)
-			return true;
-
-	return false;
-}
-
-void CBreakPoints::RemoveBreakPoint(u32 _iAddress)
-{
-	for (size_t i = 0; i < m_iBreakPoints.size(); i++)
+	for (size_t i = 0; i < breakPoints_.size(); ++i)
 	{
-		if (m_iBreakPoints[i].iAddress == _iAddress)
-		{
-			m_iBreakPoints.remove(m_iBreakPoints[i]);
-			InvalidateJit(_iAddress);
-			host->UpdateDisassembly();	// redraw in order to not show the breakpoint anymore
-			break;
-		}
+		if (breakPoints_[i].iAddress == addr && (!matchTemp || breakPoints_[i].bTemporary == temp))
+			return i;
+	}
+
+	return INVALID_BREAKPOINT;
+}
+
+size_t CBreakPoints::FindMemCheck(u32 start, u32 end)
+{
+	for (size_t i = 0; i < memChecks_.size(); ++i)
+	{
+		if (memChecks_[i].start == start && memChecks_[i].end == end)
+			return i;
+	}
+
+	return INVALID_MEMCHECK;
+}
+
+bool CBreakPoints::IsAddressBreakPoint(u32 addr)
+{
+	size_t bp = FindBreakpoint(addr);
+	return bp != INVALID_BREAKPOINT && breakPoints_[bp].bOn;
+}
+
+bool CBreakPoints::IsTempBreakPoint(u32 addr)
+{
+	size_t bp = FindBreakpoint(addr, true, true);
+	return bp != INVALID_BREAKPOINT;
+}
+
+void CBreakPoints::AddBreakPoint(u32 addr, bool temp)
+{
+	size_t bp = FindBreakpoint(addr, true, temp);
+	if (bp == INVALID_BREAKPOINT)
+	{
+		BreakPoint pt;
+		pt.bOn = true;
+		pt.bTemporary = temp;
+		pt.iAddress = addr;
+
+		breakPoints_.push_back(pt);
+		Update(addr);
+	}
+	else if (!breakPoints_[bp].bOn)
+	{
+		breakPoints_[bp].bOn = true;
+		Update(addr);
+	}
+}
+
+void CBreakPoints::RemoveBreakPoint(u32 addr)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_.erase(breakPoints_.begin() + bp);
+
+		// Check again, there might've been an overlapping temp breakpoint.
+		bp = FindBreakpoint(addr);
+		if (bp != INVALID_BREAKPOINT)
+			breakPoints_.erase(breakPoints_.begin() + bp);
+
+		Update(addr);
+	}
+}
+
+void CBreakPoints::ChangeBreakPoint(u32 addr, bool status)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].bOn = status;
+		Update(addr);
 	}
 }
 
 void CBreakPoints::ClearAllBreakPoints()
 {
-	m_iBreakPoints.clear();
-	InvalidateJit();
+	if (!breakPoints_.empty())
+	{
+		breakPoints_.clear();
+		Update();
+	}
 }
 
 void CBreakPoints::ClearTemporaryBreakPoints()
 {
-	if (m_iBreakPoints.size() == 0) return;
+	if (breakPoints_.empty())
+		return;
 
 	bool update = false;
-	for (int i = (int)m_iBreakPoints.size()-1; i >= 0; --i)
+	for (int i = (int)breakPoints_.size()-1; i >= 0; --i)
 	{
-		if (m_iBreakPoints[i].bTemporary)
+		if (breakPoints_[i].bTemporary)
 		{
-			InvalidateJit(m_iBreakPoints[i].iAddress);
-			m_iBreakPoints.remove(m_iBreakPoints[i]);
+			breakPoints_.erase(breakPoints_.begin() + i);
 			update = true;
 		}
 	}
 	
-	if (update) host->UpdateDisassembly();	// redraw in order to not show the breakpoint anymore
+	if (update)
+		Update();
+}
+
+void CBreakPoints::AddMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result)
+{
+	size_t mc = FindMemCheck(start, end);
+	if (mc == INVALID_MEMCHECK)
+	{
+		MemCheck check;
+		check.start = start;
+		check.end = end;
+		check.cond = cond;
+		check.result = result;
+
+		memChecks_.push_back(check);
+		Update();
+	}
+	else
+	{
+		memChecks_[mc].cond = (MemCheckCondition)(memChecks_[mc].cond | cond);
+		memChecks_[mc].result = (MemCheckResult)(memChecks_[mc].result | result);
+		Update();
+	}
+}
+
+void CBreakPoints::RemoveMemCheck(u32 start, u32 end)
+{
+	size_t mc = FindMemCheck(start, end);
+	if (mc != INVALID_MEMCHECK)
+	{
+		memChecks_.erase(memChecks_.begin() + mc);
+		Update();
+	}
+}
+
+void CBreakPoints::ChangeMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result)
+{
+	size_t mc = FindMemCheck(start, end);
+	if (mc != INVALID_MEMCHECK)
+	{
+		memChecks_[mc].cond = cond;
+		memChecks_[mc].result = result;
+		Update();
+	}
+}
+
+void CBreakPoints::ClearAllMemChecks()
+{
+	if (!memChecks_.empty())
+	{
+		memChecks_.clear();
+		Update();
+	}
 }
 
 MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 {
 	std::vector<MemCheck>::iterator iter;
-	for (iter = MemChecks.begin(); iter != MemChecks.end(); ++iter)
+	for (iter = memChecks_.begin(); iter != memChecks_.end(); ++iter)
 	{
 		MemCheck &check = *iter;
-		if (check.bRange)
+		if (check.end != 0)
 		{
-			if (address >= check.iStartAddress && address + size < check.iEndAddress)
+			if (address >= check.start && address + size < check.end)
 				return &check;
 		}
 		else
 		{
-			if (check.iStartAddress==address)
+			if (check.start==address)
 				return &check;
 		}
 	}
@@ -129,46 +231,41 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 	return 0;
 }
 
-void CBreakPoints::AddBreakPoint(u32 _iAddress, bool temp)
-{
-	if (!IsAddressBreakPoint(_iAddress))
-	{
-		BreakPoint pt;
-		pt.bOn=true;
-		pt.bTemporary=temp;
-		pt.iAddress = _iAddress;
-
-		m_iBreakPoints.insert(pt);
-		InvalidateJit(_iAddress);
-		host->UpdateDisassembly();	// redraw in order to show the breakpoint
-	}
-}
-
-void CBreakPoints::InvalidateJit(u32 _iAddress)
-{
-	// Don't want to clear cache while running, I think?
-	if (MIPSComp::jit && Core_IsInactive())
-		MIPSComp::jit->ClearCacheAt(_iAddress);
-}
-
-void CBreakPoints::InvalidateJit()
-{
-	// Don't want to clear cache while running, I think?
-	if (MIPSComp::jit && Core_IsInactive())
-		MIPSComp::jit->ClearCache();
-}
-
 int CBreakPoints::GetNumBreakpoints()
 {
-	return (int)m_iBreakPoints.size();
+	return (int)breakPoints_.size();
 }
 
-BreakPoint CBreakPoints::GetBreakpoint(int i)
+const BreakPoint CBreakPoints::GetBreakpoint(int i)
 {
-	return m_iBreakPoints[i];
+	return breakPoints_[i];
 }
 
 int CBreakPoints::GetBreakpointAddress(int i)
 {
-	return m_iBreakPoints[i].iAddress;
+	return breakPoints_[i].iAddress;
+}
+
+const std::vector<MemCheck> CBreakPoints::GetMemChecks()
+{
+	return memChecks_;
+}
+
+const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
+{
+	return breakPoints_;
+}
+
+void CBreakPoints::Update(u32 addr)
+{
+	if (MIPSComp::jit && Core_IsInactive())
+	{
+		if (addr != 0)
+			MIPSComp::jit->ClearCacheAt(addr);
+		else
+			MIPSComp::jit->ClearCache();
+	}
+
+	// Redraw in order to show the breakpoint.
+	host->UpdateDisassembly();
 }

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -159,7 +159,7 @@ void CBreakPoints::ClearTemporaryBreakPoints()
 
 void CBreakPoints::ChangeBreakPointAddCond(u32 addr, const BreakPointCond &cond)
 {
-	size_t bp = FindBreakpoint(addr);
+	size_t bp = FindBreakpoint(addr, true, false);
 	if (bp != INVALID_BREAKPOINT)
 	{
 		breakPoints_[bp].hasCond = true;
@@ -170,7 +170,7 @@ void CBreakPoints::ChangeBreakPointAddCond(u32 addr, const BreakPointCond &cond)
 
 void CBreakPoints::ChangeBreakPointRemoveCond(u32 addr)
 {
-	size_t bp = FindBreakpoint(addr);
+	size_t bp = FindBreakpoint(addr, true, false);
 	if (bp != INVALID_BREAKPOINT)
 	{
 		breakPoints_[bp].hasCond = false;
@@ -180,7 +180,7 @@ void CBreakPoints::ChangeBreakPointRemoveCond(u32 addr)
 
 BreakPointCond *CBreakPoints::GetBreakPointCondition(u32 addr)
 {
-	size_t bp = FindBreakpoint(addr);
+	size_t bp = FindBreakpoint(addr, true, false);
 	if (bp != INVALID_BREAKPOINT && breakPoints_[bp].hasCond)
 		return &breakPoints_[bp].cond;
 	return NULL;

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -15,16 +15,17 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "../Core.h"
-#include "Breakpoints.h"
-#include "SymbolMap.h"
-#include "FixedSizeUnorderedSet.h"
+#include "Core/Core.h"
+#include "Core/Debugger/Breakpoints.h"
+#include "Core/Debugger/SymbolMap.h"
 #include "Core/Host.h"
-#include "../MIPS/JitCommon/JitCommon.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/CoreTiming.h"
 #include <cstdio>
 
 std::vector<BreakPoint> CBreakPoints::breakPoints_;
 u32 CBreakPoints::breakSkipFirstAt_ = 0;
+u64 CBreakPoints::breakSkipFirstTicks_ = 0;
 std::vector<MemCheck> CBreakPoints::memChecks_;
 
 MemCheck::MemCheck(void)
@@ -257,6 +258,20 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 	}
 
 	//none found
+	return 0;
+}
+
+void CBreakPoints::SetSkipFirst(u32 pc)
+{
+	breakSkipFirstAt_ = pc;
+	breakSkipFirstTicks_ = CoreTiming::GetTicks();
+}
+u32 CBreakPoints::CheckSkipFirst()
+{
+	u32 pc = breakSkipFirstAt_;
+	breakSkipFirstAt_ = 0;
+	if (breakSkipFirstTicks_ == CoreTiming::GetTicks())
+		return pc;
 	return 0;
 }
 

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -35,18 +35,18 @@ struct BreakPoint
 {
 	BreakPoint() : hasCond(false) {}
 
-	u32	iAddress;
-	bool bOn;
-	bool bTemporary;
+	u32	addr;
+	bool enabled;
+	bool temporary;
 
 	bool hasCond;
 	BreakPointCond cond;
 
 	bool operator == (const BreakPoint &other) const {
-		return iAddress == other.iAddress;
+		return addr == other.addr;
 	}
 	bool operator < (const BreakPoint &other) const {
-		return iAddress < other.iAddress;
+		return addr < other.addr;
 	}
 };
 
@@ -113,9 +113,6 @@ public:
 	static void ClearAllMemChecks();
 
 	static MemCheck *GetMemCheck(u32 address, int size);
-	static int GetNumBreakpoints();
-	static const BreakPoint GetBreakpoint(size_t i);
-	static int GetBreakpointAddress(size_t i);
 
 	// TODO: MemChecks somehow too?
 	static void SetSkipFirst(u32 pc) { breakSkipFirstAt_ = pc; }

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -114,9 +114,8 @@ public:
 
 	static MemCheck *GetMemCheck(u32 address, int size);
 
-	// TODO: MemChecks somehow too?
-	static void SetSkipFirst(u32 pc) { breakSkipFirstAt_ = pc; }
-	static u32 CheckSkipFirst() { u32 pc = breakSkipFirstAt_; breakSkipFirstAt_ = 0; return pc; }
+	static void SetSkipFirst(u32 pc);
+	static u32 CheckSkipFirst();
 
 	static const std::vector<MemCheck> GetMemChecks();
 	static const std::vector<BreakPoint> GetBreakpoints();
@@ -130,6 +129,7 @@ private:
 
 	static std::vector<BreakPoint> breakPoints_;
 	static u32 breakSkipFirstAt_;
+	static u64 breakSkipFirstTicks_;
 
 	static std::vector<MemCheck> memChecks_;
 };

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -20,11 +20,27 @@
 #include "../../Globals.h"
 #include <vector>
 
+// TODO: Replace with expression or something.
+struct BreakPointCond
+{
+	u32 todo;
+
+	u32 Evaluate() const
+	{
+		return 1;
+	}
+};
+
 struct BreakPoint
 {
+	BreakPoint() : hasCond(false) {}
+
 	u32	iAddress;
 	bool bOn;
 	bool bTemporary;
+
+	bool hasCond;
+	BreakPointCond cond;
 
 	bool operator == (const BreakPoint &other) const {
 		return iAddress == other.iAddress;
@@ -86,6 +102,11 @@ public:
 	static void ClearAllBreakPoints();
 	static void ClearTemporaryBreakPoints();
 
+	// Makes a copy.  Temporary breakpoints can't have conditions.
+	static void ChangeBreakPointAddCond(u32 addr, const BreakPointCond &cond);
+	static void ChangeBreakPointRemoveCond(u32 addr);
+	static BreakPointCond *GetBreakPointCondition(u32 addr);
+
 	static void AddMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result);
 	static void RemoveMemCheck(u32 start, u32 end);
 	static void ChangeMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result);
@@ -93,8 +114,8 @@ public:
 
 	static MemCheck *GetMemCheck(u32 address, int size);
 	static int GetNumBreakpoints();
-	static const BreakPoint GetBreakpoint(int i);
-	static int GetBreakpointAddress(int i);
+	static const BreakPoint GetBreakpoint(size_t i);
+	static int GetBreakpointAddress(size_t i);
 
 	// TODO: MemChecks somehow too?
 	static void SetSkipFirst(u32 pc) { breakSkipFirstAt_ = pc; }

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-
 #include "../../Globals.h"
+#include <vector>
 
 struct BreakPoint
 {
@@ -26,72 +26,94 @@ struct BreakPoint
 	bool bOn;
 	bool bTemporary;
 
-	bool operator == (const BreakPoint &other) const	{
-		return iAddress == other.iAddress && bOn == other.bOn && bTemporary == other.bTemporary;
+	bool operator == (const BreakPoint &other) const {
+		return iAddress == other.iAddress;
 	}
+	bool operator < (const BreakPoint &other) const {
+		return iAddress < other.iAddress;
+	}
+};
+
+enum MemCheckCondition
+{
+	MEMCHECK_READ = 0x01,
+	MEMCHECK_WRITE = 0x02,
+
+	MEMCHECK_READWRITE = 0x03,
+};
+
+enum MemCheckResult
+{
+	MEMCHECK_IGNORE = 0x00,
+	MEMCHECK_LOG = 0x01,
+	MEMCHECK_BREAK = 0x02,
+
+	MEMCHECK_BOTH = 0x03,
 };
 
 struct MemCheck
 {
 	MemCheck();
-	u32 iStartAddress;
-	u32 iEndAddress;
+	u32 start;
+	u32 end;
 
-	bool	bRange;
-
-	bool	bOnRead;
-	bool	bOnWrite;
-
-	bool	bLog;
-	bool	bBreak;
+	MemCheckCondition cond;
+	MemCheckResult result;
 
 	u32 numHits;
 
 	void Action(u32 addr, bool write, int size, u32 pc);
+
+	bool operator == (const MemCheck &other) const {
+		return start == other.start && end == other.end;
+	}
 };
 
+// BreakPoints cannot overlap, only one is allowed per address.
+// MemChecks can overlap, as long as their ends are different.
+// WARNING: MemChecks are not used in the interpreter or HLE currently.
 class CBreakPoints
 {
-private:
-
-	enum { MAX_NUMBER_OF_CALLSTACK_ENTRIES = 16384};
-	enum { MAX_NUMBER_OF_BREAKPOINTS = 16};
-
-	static u32 breakSkipFirstAt_;
-
 public:
-	// WARNING: Not used in interpreter or HLE, only jit CPU memory access.
-	static std::vector<MemCheck> MemChecks;
+	static const size_t INVALID_BREAKPOINT = -1;
+	static const size_t INVALID_MEMCHECK = -1;
 
-	// is address breakpoint
-	static bool IsAddressBreakPoint(u32 _iAddress);
-
-	// WARNING: Not used in interpreter or HLE, only jit CPU memory access.
-	static MemCheck *GetMemCheck(u32 address, int size);
-
-	// is break on count
-	static bool IsBreakOnCount(u32 _iAddress);
-
-	static bool IsTempBreakPoint(u32 _iAddress);
-
-	// AddBreakPoint
-	static void AddBreakPoint(u32 _iAddress, bool temp=false);
-
-	// Remove Breakpoint
-	static void RemoveBreakPoint(u32 _iAddress);
-
+	static bool IsAddressBreakPoint(u32 addr);
+	static bool IsTempBreakPoint(u32 addr);
+	static void AddBreakPoint(u32 addr, bool temp = false);
+	static void RemoveBreakPoint(u32 addr);
+	static void ChangeBreakPoint(u32 addr, bool enable);
 	static void ClearAllBreakPoints();
 	static void ClearTemporaryBreakPoints();
 
-	static void InvalidateJit(u32 _iAddress);
-	static void InvalidateJit();
+	static void AddMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result);
+	static void RemoveMemCheck(u32 start, u32 end);
+	static void ChangeMemCheck(u32 start, u32 end, MemCheckCondition cond, MemCheckResult result);
+	static void ClearAllMemChecks();
 
+	static MemCheck *GetMemCheck(u32 address, int size);
 	static int GetNumBreakpoints();
-	static BreakPoint GetBreakpoint(int i);
+	static const BreakPoint GetBreakpoint(int i);
 	static int GetBreakpointAddress(int i);
 
+	// TODO: MemChecks somehow too?
 	static void SetSkipFirst(u32 pc) { breakSkipFirstAt_ = pc; }
 	static u32 CheckSkipFirst() { u32 pc = breakSkipFirstAt_; breakSkipFirstAt_ = 0; return pc; }
+
+	static const std::vector<MemCheck> GetMemChecks();
+	static const std::vector<BreakPoint> GetBreakpoints();
+
+	static void Update(u32 addr = 0);
+
+private:
+	static size_t FindBreakpoint(u32 addr, bool matchTemp = false, bool temp = false);
+	// Finds exactly, not using a range check.
+	static size_t FindMemCheck(u32 start, u32 end);
+
+	static std::vector<BreakPoint> breakPoints_;
+	static u32 breakSkipFirstAt_;
+
+	static std::vector<MemCheck> memChecks_;
 };
 
 

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -151,6 +151,13 @@ bool SymbolMap::LoadSymbolMap(const char *filename)
 		if(p == NULL)
 			break;
 		
+		// Chop any newlines off.
+		for (size_t i = strlen(line) - 1; i > 0; i--) {
+			if (line[i] == '\r' || line[i] == '\n') {
+				line[i] = '\0';
+			}
+		}
+
 		if (strlen(line) < 4 || sscanf(line, "%s", temp) != 1)
 			continue;
 
@@ -180,8 +187,7 @@ bool SymbolMap::LoadSymbolMap(const char *filename)
 			e.size=4;
 
 		//e.vaddress|=0x80000000;
-		if (strcmp(e.name,".text")==0 || strcmp(e.name,".init")==0 || strlen(e.name)<=1)
-		{ 
+		if (strcmp(e.name,".text")==0 || strcmp(e.name,".init")==0 || strlen(e.name)<=1) { 
 			;
 		} else {
 			e.UndecorateName();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -65,6 +65,10 @@ u32 JitBreakpoint()
 	if (CBreakPoints::CheckSkipFirst() == currentMIPS->pc)
 		return 0;
 
+	auto cond = CBreakPoints::GetBreakPointCondition(currentMIPS->pc);
+	if (cond && !cond->Evaluate())
+		return 0;
+
 	Core_EnableStepping(true);
 	host->SetDebugMode(true);
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -699,7 +699,7 @@ void Jit::JitSafeMem::Finish()
 {
 	// Memory::Read_U32/etc. may have tripped coreState.
 	if (needsCheck_ && !g_Config.bIgnoreBadMemAccess)
-		jit_->js.afterOp = JitState::AFTER_CORE_STATE;
+		jit_->js.afterOp |= JitState::AFTER_CORE_STATE;
 	if (needsSkip_)
 		jit_->SetJumpTarget(skip_);
 	for (auto it = skipChecks_.begin(), end = skipChecks_.end(); it != end; ++it)

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -708,6 +708,10 @@ void Jit::JitSafeMem::Finish()
 
 void JitMemCheck(u32 addr, int size, int isWrite)
 {
+	// Should we skip this breakpoint?
+	if (CBreakPoints::CheckSkipFirst() == currentMIPS->pc)
+		return;
+
 	MemCheck *check = CBreakPoints::GetMemCheck(addr, size);
 	if (check)
 		check->Action(addr, isWrite == 1, size, currentMIPS->pc);

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -5,10 +5,12 @@
 
 #include "../W32Util/DialogManager.h"
 #include "CtrlDisasmView.h"
-#include "../../Core/MIPS/MIPSDebugInterface.h"
 #include "CPURegsInterface.h"
-#include "../../Globals.h"
-#include "../../Core/CPU.h"
+#include "Globals.h"
+#include "Core/CPU.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/Debugger/Breakpoints.h"
+#include <vector>
 
 #include <windows.h>
 
@@ -27,6 +29,9 @@ private:
 	DebugInterface *cpu;
 	u64 lastTicks;
 
+	std::vector<BreakPoint> displayedBreakPoints_;
+	std::vector<MemCheck> displayedMemChecks_;
+
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void UpdateSize(WORD width, WORD height);
 	void SavePosition();
@@ -34,6 +39,8 @@ private:
 	void handleBreakpointNotify(LPARAM lParam);
 	void gotoBreakpointAddress(int itemIndex);
 	void removeBreakpoint(int itemIndex);
+	int getTotalBreakpointCount();
+	int getBreakpointIndex(int itemIndex, bool& isMemory);
 public:
 	int index; //helper 
 


### PR DESCRIPTION
This does a few things:
- Tries to respect the enabled/disabled status of a breakpoint properly (no UI yet.)
- Removes the limit on max # of breakpoints.
- Adds accessors for memchecks similar to breakpoints.
- Makes breakpoints unique by (addr, temporary) and memchecks by (start, end).  This way you don't have an enabled and disabled breakpoint concurrently.
- Fixes a bug I introduced earlier with the symbol map reading, oops.
- Adds skeleton for conditional breakpoints, just needs the expression parser hooked up.
- Makes memchecks work properly when "ignore invalid memory access" is off.
- Makes memchecks also not break when you hit go while on one.

-[Unknown]
