### PR TITLE
Copy only a screen's worth of pixels from FBO to output

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -36,9 +36,6 @@
 #include "../../Core/HLE/sceKernelInterrupt.h"
 #include "../../Core/HLE/sceGe.h"
 
-extern u32 curTextureWidth;
-extern u32 curTextureHeight;
-
 static const u8 flushOnChangedBeforeCommandList[] = {
 	GE_CMD_REGION1,GE_CMD_REGION2,
 	GE_CMD_VERTEXTYPE,

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -257,10 +257,11 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, int pixelFormat, int lin
 	DrawActiveTexture(x, y, w, h, false, 480.0f / 512.0f);
 }
 
-void FramebufferManager::DrawActiveTexture(float x, float y, float w, float h, bool flip, float uscale) {
+void FramebufferManager::DrawActiveTexture(float x, float y, float w, float h, bool flip, float uscale, float vscale) {
 	float u2 = uscale;
-	float v1 = flip ? 1.0f : 0.0f;
-	float v2 = flip ? 0.0f : 1.0f;
+	// Since we're flipping, 0 is down.  That's where the scale goes.
+	float v1 = flip ? 1.0f : 1.0f - vscale;
+	float v2 = flip ? 1.0f - vscale : 1.0f;
 
 	const float pos[12] = {x,y,0, x+w,y,0, x+w,y+h,0, x,y+h,0};
 	const float texCoords[8] = {0, v1, u2, v1, u2, v2, 0, v2};
@@ -615,7 +616,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 	// These are in the output display coordinates
 		float x, y, w, h;
 		CenterRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight);
-		DrawActiveTexture(x, y, w, h, true);
+		DrawActiveTexture(x, y, w, h, true, 480.0f / (float)vfb->width, 272.0f / (float)vfb->height);
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -92,7 +92,7 @@ public:
 	}
 
 	void DrawPixels(const u8 *framebuf, int pixelFormat, int linesize);
-	void DrawActiveTexture(float x, float y, float w, float h, bool flip = false, float uscale = 1.0f);
+	void DrawActiveTexture(float x, float y, float w, float h, bool flip = false, float uscale = 1.0f, float vscale = 1.0f);
 
 	void DestroyAllFBOs();
 	void DecimateFBOs();

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1002,7 +1002,7 @@ void TextureCache::SetTexture() {
 			int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
 			gstate_c.actualTextureHeight = h;
 			gstate_c.flipTexture = true;
-			gstate_c.textureFullAlpha = (entry->status & TexCacheEntry::STATUS_ALPHA_MASK) == TexCacheEntry::STATUS_ALPHA_FULL;
+			gstate_c.textureFullAlpha = false;
 			entry->lastFrame = gpuStats.numFrames;
 			return;
 		}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1002,7 +1002,7 @@ void TextureCache::SetTexture() {
 			int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
 			gstate_c.actualTextureHeight = h;
 			gstate_c.flipTexture = true;
-			gstate_c.textureFullAlpha = false;
+			gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
 			entry->lastFrame = gpuStats.numFrames;
 			return;
 		}


### PR DESCRIPTION
Fixes #2308 (the rest of it), at least for Tales of Destiny 2 and Star Ocean (Valkyrie Profile still has issues but they seem different.)  It also corrects the size in Shadow of Destiny and Wild Arms XF, but you still can't see things in those...

Of course, Star Ocean still doesn't show the character with buffered rendering on in towns, but Tales of Destiny 2 needs buffered rendering enabled if you want to be able to read dialog text.

From my tests, the displayed (screen) region is always the top left 480x272 of what's pointed to by `sceDisplaySetFrameBuf()`.  It might be good to test this in GTA first, but I tested a few other games and they weren't affected by it.

Also fixes a typo I noticed.  There's no good reason to assume render-to-texture is ever full alpha.

-[Unknown]
