### PR TITLE
Small performance improvements (textures, shader lookup)

### DIFF
--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -166,7 +166,15 @@ public:
 private:
 	void Clear();
 
-	typedef std::map<std::pair<Shader *, Shader *>, LinkedShader *> LinkedShaderCache;
+	struct LinkedShaderCacheEntry {
+		LinkedShaderCacheEntry(Shader *vs_, Shader *fs_, LinkedShader *ls_)
+			: vs(vs_), fs(fs_), ls(ls_) { }
+
+		Shader *vs;
+		Shader *fs;
+		LinkedShader *ls;
+	};
+	typedef std::vector<LinkedShaderCacheEntry> LinkedShaderCache;
 
 	LinkedShaderCache linkedShaderCache;
 	FragmentShaderID lastFSID;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -122,7 +122,11 @@ void TextureCache::Invalidate(u32 addr, int size, GPUInvalidationType type) {
 	addr &= 0xFFFFFFF;
 	u32 addr_end = addr + size;
 
-	for (TexCache::iterator iter = cache.begin(), end = cache.end(); iter != end; ++iter) {
+	// They could invalidate inside the texture, let's just give a bit of leeway.
+	const int LARGEST_TEXTURE_SIZE = 512 * 512 * 4;
+	u64 startKey = addr - LARGEST_TEXTURE_SIZE;
+	u64 endKey = addr + size + LARGEST_TEXTURE_SIZE;
+	for (TexCache::iterator iter = cache.lower_bound(startKey), end = cache.upper_bound(endKey); iter != end; ++iter) {
 		u32 texAddr = iter->second.addr;
 		u32 texEnd = iter->second.addr + iter->second.sizeInRAM;
 
@@ -159,8 +163,8 @@ void TextureCache::ClearNextFrame() {
 
 
 TextureCache::TexCacheEntry *TextureCache::GetEntryAt(u32 texaddr) {
-	// If no CLUT, as in framebuffer textures, cache key is simply texaddr.
-	auto iter = cache.find(texaddr);
+	// If no CLUT, as in framebuffer textures, cache key is simply texaddr shifted up.
+	auto iter = cache.find((u64)texaddr << 32);
 	if (iter != cache.end() && iter->second.addr == texaddr)
 		return &iter->second;
 	else
@@ -940,7 +944,7 @@ void TextureCache::SetTexture() {
 	// GE_TFMT_CLUT4 - GE_TFMT_CLUT32 are 0b1xx.
 	bool hasClut = (format & 4) != 0;
 
-	u64 cachekey = texaddr;
+	u64 cachekey = (u64)texaddr << 32;
 
 	u32 clutformat, cluthash;
 	if (hasClut) {
@@ -950,7 +954,7 @@ void TextureCache::SetTexture() {
 			UpdateCurrentClut();
 		}
 		cluthash = GetCurrentClutHash() ^ gstate.clutformat;
-		cachekey |= (u64)cluthash << 32;
+		cachekey |= cluthash;
 	} else {
 		clutformat = 0;
 		cluthash = 0;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1302,14 +1302,13 @@ void *TextureCache::DecodeTextureLevel(u8 format, u8 clutformat, int level, u32 
 			int len = std::max(bufw, w) * h;
 			tmpTexBuf16.resize(len);
 			tmpTexBufRearrange.resize(len);
-			Memory::Memcpy(tmpTexBuf16.data(), texaddr, len * sizeof(u16));
 			finalBuf = tmpTexBuf16.data();
-		}
-		else {
+			ConvertColors(finalBuf, Memory::GetPointer(texaddr), dstFmt, bufw * h);
+		} else {
 			tmpTexBuf32.resize(std::max(bufw, w) * h);
 			finalBuf = UnswizzleFromMem(texaddr, bufw, 2, level);
+			ConvertColors(finalBuf, finalBuf, dstFmt, bufw * h);
 		}
-		ConvertColors(finalBuf, finalBuf, dstFmt, bufw * h);
 		break;
 
 	case GE_TFMT_8888:


### PR DESCRIPTION
These commits improve performance a bit in God of War's demo.  Specifically:
- It uses a lot of 16-bit textures, and decodes a lot.  I'm not entirely sure why, but I reduced memory copies a bit at least so it's faster.
- In it and Tales of Phantasia X, a lot of time was being spent dirtying shaders.  AFAICT, the map was not gaining us much since we generally always have <= 10 in it.  I tried putting an `if (shaderSwitchDirty != 0)` around it (which did help), but using a `std::vector` instead helped more.  Only downside is, if there's a game that triggers tons of shader combinations, it'll probably look up slower.  I've never seen this, but if it's a concern I can change it to just the if instead (I think it's about half the performance benefit.)
- Invalidation was happening a lot.  So, I flipped the texture address to the top 32-bits of the texture cache key.  This allows us to use `lower_bound()` and `upper_bound()` for invalidation.  I gave it a bit of leeway on either side (512x512 should be the largest texture, I think has been said, right?)

God of War was really inconsistent.  I ran quite a number of trials, and things definitely averaged better and looked better in the profile with these changes.  But in some areas there was almost no difference.

Anyway, textures invalidate in about 10% the time (1.8% total time -> 0.18% total time), `ApplyShader()` takes a lot less time (5% total time exclusive to 1.5% total time exclusive, ToPX even more iirc), and the texture thing I'm least confident about, it sometimes cut a few percent, sometimes made no difference.

-[Unknown]
