### PR TITLE
Fix delay when quitting with game paused

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -88,7 +88,8 @@ void Core_WaitInactive()
 
 void Core_WaitInactive(int milliseconds)
 {
-	m_hInactiveEvent.wait_for(m_hInactiveMutex, milliseconds);
+	if (Core_IsActive())
+		m_hInactiveEvent.wait_for(m_hInactiveMutex, milliseconds);
 }
 
 void UpdateScreenScale() {

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -73,8 +73,7 @@ void EmuThread_Stop()
 	Core_WaitInactive(800);
 	if (WAIT_TIMEOUT == WaitForSingleObject(emuThread, 800))
 	{
-		MessageBox(MainWindow::GetHWND(),"Wait for emuthread timed out! :(\n"
-			"please alert the developer to possible deadlock or infinite loop in emuthread!", 0, 0);
+		_dbg_assert_msg_(COMMON, false, "Wait for EmuThread timed out.");
 	}
 	{
 		EmuThreadLockGuard lock;


### PR DESCRIPTION
Kept wondering what this was.

Also removes the "wait for EmuThread timed out" dialog, which was recently uncommented.  Just made it debug only.  I don't think it has any negative impact, although it's not supposed to happen.

-[Unknown]
