### PR TITLE
Remove IsAudioEnd(), use IsNoAudioData() instead.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1063,7 +1063,7 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	}
 
 	// The audio can end earlier than the video does.
-	if (mpegRingbuffer.packetsFree == mpegRingbuffer.packets || (ctx->mediaengine->IsAudioEnd() && !ctx->mediaengine->IsVideoEnd())) {
+	if (mpegRingbuffer.packetsFree == mpegRingbuffer.packets) {
 		DEBUG_LOG(HLE, "PSP_ERROR_MPEG_NO_DATA=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
 		// TODO: Does this really delay?
 		return hleDelayResult(PSP_ERROR_MPEG_NO_DATA, "mpeg get atrac", mpegDecodeErrorDelayMs);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1016,7 +1016,7 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 
 	s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 	int delaytime = 3000;
-	if (deltapts > 0 && !psmfplayer->mediaengine->IsAudioEnd())
+	if (deltapts > 0 && !psmfplayer->mediaengine->IsNoAudioData())
 		delaytime = deltapts * 1000000 / 90000;
 	if (!ret)
 		return hleDelayResult(ret, "psmfPlayer video decode", delaytime);
@@ -1037,7 +1037,7 @@ int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 		Memory::Memset(audioDataAddr, 0, audioSamplesBytes);
 		psmfplayer->mediaengine->getAudioSamples(Memory::GetPointer(audioDataAddr));
 	}
-	int ret = psmfplayer->mediaengine->IsAudioEnd() ? ERROR_PSMFPLAYER_NO_MORE_DATA : 0;
+	int ret = psmfplayer->mediaengine->IsNoAudioData() ? ERROR_PSMFPLAYER_NO_MORE_DATA : 0;
 	return hleDelayResult(ret, "psmfPlayer audio decode", 3000);
 }
 

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -71,7 +71,7 @@ public:
 	s64 getLastTimeStamp();
 
 	bool IsVideoEnd() { return m_isVideoEnd; }
-	bool IsAudioEnd() { return m_isAudioEnd; }
+	bool IsNoAudioData() { return m_noAudioData; }
 
 	void DoState(PointerWrap &p);
 
@@ -106,7 +106,7 @@ public:
 	s64 m_lastTimeStamp;
 
 	bool m_isVideoEnd;
-	bool m_isAudioEnd;
+	bool m_noAudioData;
 
 	int m_ringbuffersize;
 	u8 m_mpegheader[0x10000];


### PR DESCRIPTION
It may fix #2577 as @unknownbrackets mentioned. 
And I remove a hack in sceMpegGetAtracAu which is not necessary now, it was for FF7CC videos.
