### PR TITLE
Fix black screen in non-buffered rendering mode

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -994,18 +994,16 @@ void TextureCache::SetTexture() {
 					gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
 				}
 				UpdateSamplingParams(*entry, false);
+				// This isn't right.
+				gstate_c.curTextureWidth = entry->framebuffer->width;
+				gstate_c.curTextureHeight = entry->framebuffer->height;
+				gstate_c.flipTexture = true;
+				gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
+				entry->lastFrame = gpuStats.numFrames;
+				return;
 			}
 
-			// This isn't right.
-			gstate_c.curTextureWidth = entry->framebuffer->width;
-			gstate_c.curTextureHeight = entry->framebuffer->height;
-			int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
-			gstate_c.actualTextureHeight = h;
-			gstate_c.flipTexture = true;
-			gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
-			entry->lastFrame = gpuStats.numFrames;
-			return;
-		}
+	}
 		//Validate the texture here (width, height etc)
 
 		int dim = gstate.texsize[0] & 0xF0F;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -973,22 +973,17 @@ void TextureCache::SetTexture() {
 	gstate_c.flipTexture = false;
 	gstate_c.skipDrawReason &= ~SKIPDRAW_BAD_FB_TEXTURE;
 
+bool useBufferedRendering_ = g_Config.bBufferedRendering;
 	bool replaceImages = false;
 	if (iter != cache.end()) {
 		entry = &iter->second;
 		// Check for FBO - slow!
 		if (entry->framebuffer) {
 			entry->framebuffer->usageFlags |= FB_USAGE_TEXTURE;
-			if (!g_Config.bBufferedRendering) {
-				if (entry->framebuffer->fbo)
-					entry->framebuffer->fbo = 0;
-				glBindTexture(GL_TEXTURE_2D, 0);
-				lastBoundTexture = -1;
-				entry->lastFrame = gpuStats.numFrames;
-			} else {
-				if (entry->framebuffer->fbo) {
+			if (useBufferedRendering_) {
+				if (entry->framebuffer->fbo) 
 					fbo_bind_color_as_texture(entry->framebuffer->fbo, 0);
-				} else {
+				else {
 					glBindTexture(GL_TEXTURE_2D, 0);
 					lastBoundTexture = -1;
 					gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
@@ -1001,9 +996,16 @@ void TextureCache::SetTexture() {
 				gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
 				entry->lastFrame = gpuStats.numFrames;
 				return;
+			} else {
+				if (entry->framebuffer->fbo)
+					entry->framebuffer->fbo = 0;
+				glBindTexture(GL_TEXTURE_2D, 0);
+				lastBoundTexture = -1;
+				entry->lastFrame = gpuStats.numFrames;
 			}
 
-	}
+		}
+		
 		//Validate the texture here (width, height etc)
 
 		int dim = gstate.texsize[0] & 0xF0F;


### PR DESCRIPTION
For example , Saint Seiya Omega now shows stuff in non-buffered rendering mode instead of black screen. Should help other games with similar issue.
