### PR TITLE
Partially implement some sceJpeg functions

### DIFF
--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -296,6 +296,16 @@ template<int func(u32, int, int, u32, u32)> void WrapI_UIIUU() {
 	RETURN(retval);
 }
 
+template<int func(u32, u32, int, int)> void WrapI_UUII() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+	RETURN(retval);
+}
+
+template<int func(u32, u32, int, int, int)> void WrapI_UUIII() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
+	RETURN(retval);
+}
+
 template<void func(u32, int, int, int)> void WrapV_UIII() {
 	func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
 }

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -256,7 +256,17 @@ template<u32 func(u32, int, u32, int, int)> void WrapU_UIUII() {
 	RETURN(retval);
 }
 
+template<int func(u32, int, u32, int, int)> void WrapI_UIUII() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
+	RETURN(retval);
+}
+
 template<u32 func(u32, int, u32, int)> void WrapU_UIUI() {
+	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
+	RETURN(retval);
+}
+
+template<int func(u32, int, u32, int)> void WrapI_UIUI() {
 	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3));
 	RETURN(retval);
 }

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -18,7 +18,7 @@
 #include "Core/HLE/HLE.h"
 #include "Core/Reporting.h"
 #include "Common.h"
-#include "native\ext\cityhash\city.h"
+#include "native/ext/cityhash/city.h"
 
 // http://keyj.emphy.de/nanojpeg/
 #include "native\ext\njpeg\nanojpeg.h"

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -106,7 +106,8 @@ int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dht
 		unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &w, &h, &actual_components, 3);
 		if (actual_components != 3)
 		{
-			// The assumption that the 
+			// The assumption that the image was RGB was wrong...
+			// Try again.
 			int components = actual_components;
 			jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &w, &h, &actual_components, components);
 		}
@@ -149,6 +150,8 @@ int sceJpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr, int yCbCr
 	unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &width, &height, &actual_components, 3);
 	if (actual_components != 3)
 	{
+		// The assumption that the image was RGB was wrong...
+		// Try again.
 		int components = actual_components;
 		jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &width, &height, &actual_components, components);
 	}


### PR DESCRIPTION
The implementations aren't complete (and may need to corrections with what they are doing currently) but they are good enough to not cause sceKernelPrintf()'s in God Eater Burst's save file loading scene.

Additionally this implements a method to dump jpeg files sent to sceJpeg and a stub function for sceJpeg_A06A75C4 (just to notify it's been used, instead of not logging it, although I don't know if any game uses/needs it).

I used a JPEG decoder called NanoJpeg to verify the JPEGs are valid. The file can be obtained from http://keyj.emphy.de/nanojpeg/ and should be placed in (ppsspp dir)\native\ext\njpeg\ (that was where others were putting extensions, so I figure it's okay) and renamed to nanojpeg.h
The functions I sorta implemented were based on JPCSP's sceJpeg. They seem to be fine (the returns seem to be good) but it could use more testing, especially since many functions in JPCSP's sceJpeg aren't fully implemented yet.

Before (official build) : 

![scejpeg_2](https://f.cloud.github.com/assets/1909938/748771/c589feec-e492-11e2-8c42-adfbcdd76722.png)

After (my build) : 

![scejpeg_1](https://f.cloud.github.com/assets/1909938/748773/cf5bb690-e492-11e2-93a9-1092e0ee2882.png)

Although there are still calls to unimplemented functions, it doesn't sceKernelPrintf() anymore. Don't mind the whited out part in my build (it's just my name) and I log sceFontGetCharGlyphImage() as debug since I noticed it works and God Eater Burst likes to call it a lot. (ie to avoid spamming my log with something that works)
