### PR TITLE
Implement left/right load/store, clz/clo, and vmone/vmzero/vmidt in x86 jit

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -431,6 +431,11 @@ namespace MIPSComp
 		fpr.ReleaseSpillLocks();
 	}
 
+	void Jit::Comp_VMatrixInit(u32 op)
+	{
+		CONDITIONAL_DISABLE;
+	}
+
 	void Jit::Comp_VDot(u32 op)
 	{
 		// DISABLE;

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -192,6 +192,7 @@ public:
 	void Comp_SVQ(u32 op);
 	void Comp_VPFX(u32 op);
 	void Comp_VVectorInit(u32 op);
+	void Comp_VMatrixInit(u32 op);
 	void Comp_VDot(u32 op);
 	void Comp_VecDo3(u32 op);
 	void Comp_VV2Op(u32 op);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -331,8 +331,8 @@ namespace MIPSInt
 		switch ((op >> 16) & 0xF)
 		{
 		case 3: m=idt; break; //identity   // vmidt
-		case 6: m=zero; break;             // vzero
-		case 7: m=one; break;              // vone
+		case 6: m=zero; break;             // vmzero
+		case 7: m=one; break;              // vmone
 		default:
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
 			return;

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -672,12 +672,12 @@ const MIPSInstruction tableVFPUMatrixSet1[16] = //111100 11100 0xxxx   (rm x is 
 	INSTR("vmmov",&Jit::Comp_Vmmov, Dis_MatrixSet2, Int_Vmmov, IS_VFPU|OUT_EAT_PREFIX),
 	{-2},
 	{-2},
-	INSTR("vmidt",&Jit::Comp_Generic, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
+	INSTR("vmidt",&Jit::Comp_VMatrixInit, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
 
 	{-2},
 	{-2},
-	INSTR("vmzero", &Jit::Comp_Generic, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
-	INSTR("vmone",  &Jit::Comp_Generic, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
+	INSTR("vmzero", &Jit::Comp_VMatrixInit, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
+	INSTR("vmone",  &Jit::Comp_VMatrixInit, Dis_MatrixSet1, Int_VMatrixInit, IS_VFPU|OUT_EAT_PREFIX),
 
 	{-2},{-2},{-2},{-2},
   {-2},{-2},{-2},{-2},

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -172,6 +172,19 @@ namespace MIPSComp
 		switch (op & 63)
 		{
 		case 22: //clz
+			if (gpr.IsImmediate(rs))
+			{
+				u32 value = gpr.GetImmediate32(rs);
+				int x = 31;
+				int count = 0;
+				while (!(value & (1 << x)) && x >= 0)
+				{
+					count++;
+					x--;
+				}
+				gpr.SetImmediate32(rd, count);
+			}
+			else
 			{
 				gpr.Lock(rd, rs);
 				gpr.BindToRegister(rd, rd == rs, true);
@@ -187,9 +200,22 @@ namespace MIPSComp
 
 				SetJumpTarget(skip);
 				gpr.UnlockAll();
-				break;
 			}
+			break;
 		case 23: //clo
+			if (gpr.IsImmediate(rs))
+			{
+				u32 value = gpr.GetImmediate32(rs);
+				int x = 31;
+				int count = 0;
+				while ((value & (1 << x)) && x >= 0)
+				{
+					count++;
+					x--;
+				}
+				gpr.SetImmediate32(rd, count);
+			}
+			else
 			{
 				gpr.Lock(rd, rs);
 				gpr.BindToRegister(rd, rd == rs, true);
@@ -207,8 +233,8 @@ namespace MIPSComp
 
 				SetJumpTarget(skip);
 				gpr.UnlockAll();
-				break;
 			}
+			break;
 		default:
 			DISABLE;
 		}

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -172,11 +172,43 @@ namespace MIPSComp
 		switch (op & 63)
 		{
 		case 22: //clz
-			DISABLE;
-			break;
+			{
+				gpr.Lock(rd, rs);
+				gpr.BindToRegister(rd, rd == rs, true);
+				BSR(32, EAX, gpr.R(rs));
+				FixupBranch notFound = J_CC(CC_Z);
+
+				MOV(32, gpr.R(rd), Imm32(31));
+				SUB(32, gpr.R(rd), R(EAX));
+				FixupBranch skip = J();
+
+				SetJumpTarget(notFound);
+				MOV(32, gpr.R(rd), Imm32(32));
+
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
+				break;
+			}
 		case 23: //clo
-			DISABLE;
-			break;
+			{
+				gpr.Lock(rd, rs);
+				gpr.BindToRegister(rd, rd == rs, true);
+				MOV(32, R(EAX), gpr.R(rs));
+				NOT(32, R(EAX));
+				BSR(32, EAX, R(EAX));
+				FixupBranch notFound = J_CC(CC_Z);
+
+				MOV(32, gpr.R(rd), Imm32(31));
+				SUB(32, gpr.R(rd), R(EAX));
+				FixupBranch skip = J();
+
+				SetJumpTarget(notFound);
+				MOV(32, gpr.R(rd), Imm32(32));
+
+				SetJumpTarget(skip);
+				gpr.UnlockAll();
+				break;
+			}
 		default:
 			DISABLE;
 		}

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -824,6 +824,49 @@ void Jit::Comp_Vmtvc(u32 op) {
 	}
 }
 
+void Jit::Comp_VMatrixInit(u32 op) {
+	CONDITIONAL_DISABLE;
+
+	if (js.HasUnknownPrefix())
+		DISABLE;
+
+	MatrixSize sz = GetMtxSize(op);
+	int n = GetMatrixSide(sz);
+
+	u8 dregs[16];
+	GetMatrixRegs(dregs, sz, _VD);
+
+	switch ((op >> 16) & 0xF) {
+	case 3: // vmidt
+		MOVSS(XMM0, M((void *) &zero));
+		MOVSS(XMM1, M((void *) &one));
+		for (int a = 0; a < n; a++) {
+			for (int b = 0; b < n; b++) {
+				MOVSS(fpr.V(dregs[a * 4 + b]), a == b ? XMM1 : XMM0);
+			}
+		}
+		break;
+	case 6: // vmzero
+		MOVSS(XMM0, M((void *) &zero));
+		for (int a = 0; a < n; a++) {
+			for (int b = 0; b < n; b++) {
+				MOVSS(fpr.V(dregs[a * 4 + b]), XMM0);
+			}
+		}
+		break;
+	case 7: // vmone
+		MOVSS(XMM0, M((void *) &one));
+		for (int a = 0; a < n; a++) {
+			for (int b = 0; b < n; b++) {
+				MOVSS(fpr.V(dregs[a * 4 + b]), XMM0);
+			}
+		}
+		break;
+	}
+
+	fpr.ReleaseSpillLocks();
+}
+
 void Jit::Comp_Vmmov(u32 op) {
 	CONDITIONAL_DISABLE;
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -347,8 +347,8 @@ void Jit::Comp_SVQ(u32 op)
 			}
 			safe.Finish();
 
-			fpr.ReleaseSpillLocks();
 			gpr.UnlockAll();
+			fpr.ReleaseSpillLocks();
 		}
 		break;
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -201,6 +201,7 @@ public:
 	void Comp_SVQ(u32 op);
 	void Comp_VPFX(u32 op);
 	void Comp_VVectorInit(u32 op);
+	void Comp_VMatrixInit(u32 op);
 	void Comp_VDot(u32 op);
 	void Comp_VecDo3(u32 op);
 	void Comp_VV2Op(u32 op);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -292,7 +292,7 @@ private:
 	class JitSafeMem
 	{
 	public:
-		JitSafeMem(Jit *jit, int raddr, s32 offset);
+		JitSafeMem(Jit *jit, int raddr, s32 offset, u32 alignMask = 0xFFFFFFFF);
 
 		// Emit code necessary for a memory write, returns true if MOV to dest is needed.
 		bool PrepareWrite(OpArg &dest, int size);
@@ -336,6 +336,7 @@ private:
 		bool needsCheck_;
 		bool needsSkip_;
 		bool far_;
+		u32 alignMask_;
 		u32 iaddr_;
 		X64Reg xaddr_;
 		FixupBranch tooLow_, tooHigh_, skip_;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -273,6 +273,8 @@ private:
 	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32));
 	void CompITypeMemRead(u32 op, u32 bits, void (XEmitter::*mov)(int, int, X64Reg, OpArg), void *safeFunc);
 	void CompITypeMemWrite(u32 op, u32 bits, void *safeFunc);
+	void CompITypeMemUnpairedLR(u32 op);
+	void CompITypeMemUnpairedLRInner(u32 op);
 
 	void CompFPTriArith(u32 op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 	void CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN = false);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -273,7 +273,7 @@ private:
 	void CompShiftVar(u32 op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32));
 	void CompITypeMemRead(u32 op, u32 bits, void (XEmitter::*mov)(int, int, X64Reg, OpArg), void *safeFunc);
 	void CompITypeMemWrite(u32 op, u32 bits, void *safeFunc);
-	void CompITypeMemUnpairedLR(u32 op);
+	void CompITypeMemUnpairedLR(u32 op, bool isStore);
 	void CompITypeMemUnpairedLRInner(u32 op);
 
 	void CompFPTriArith(u32 op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);


### PR DESCRIPTION
For the load/stores, I feel like there ought to be a simpler way, and on 32-bit it's barely better than interpreter (it has to use like half the regs...)  At least this way does work, and it seems to gain a small bit of speed over the interpreter.  It doesn't result in a tiny amount of code, especially when fastmem is off...

The others are relatively straight forward.  Yeah, I realize x86 doesn't really _need_ to be faster.

Anyway, this gives a 3-4% improvement in Senjou no Valkyria 3.

-[Unknown]
