### PR TITLE
Only multiply light by ambient color if mat update flag set

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -354,7 +354,10 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		if (gstate.isLightChanEnabled(l))
 		{
 			Color4 lightAmbient(gstate_c.lightColor[0][l], 0.0f);
-			lightSum0 += (lightAmbient * *ambient + diff) * lightScale;
+			if (materialUpdate_ & 1)
+				lightSum0 += (lightAmbient * *ambient + diff) * lightScale;
+			else
+				lightSum0 += (lightAmbient + diff) * lightScale;
 		}
 	}
 

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -482,7 +482,10 @@ void GenerateVertexShader(int prim, char *buffer, bool useHWTransform) {
 				WRITE(p, "  if (dot%i > 0.0)\n", i);
 				WRITE(p, "    lightSum1 += u_lightspecular%i * %s * (pow(dot%i, u_matspecular.a) %s);\n", i, specularStr, i, timesLightScale);
 			}
-			WRITE(p, "  lightSum0.rgb += (u_lightambient%i * %s.rgb + diffuse)%s;\n", i, ambientStr, timesLightScale);
+			if (gstate.materialupdate & 1)
+				WRITE(p, "  lightSum0.rgb += (u_lightambient%i * %s.rgb + diffuse)%s;\n", i, ambientStr, timesLightScale);
+			else
+				WRITE(p, "  lightSum0.rgb += (u_lightambient%i + diffuse)%s;\n", i, timesLightScale);
 		}
 
 		if (gstate.isLightingEnabled()) {


### PR DESCRIPTION
This is just an idea, and I don't really have enough games to test it properly.

Does not fix the lighting problem in Tales of the World (or affect it at all), nor the different lighting problem in Adventures to Go.  However, it does fix Blade Dancer, which once again shows things.

Kingdom Hearts and several other games still seem to have okay lighting.  The trouble is, I don't have a ton of 3D games.  I think the ambient lighting fixed hair color in Monster Hunter games, certain enemies in some Naruto game(s), and chests in Ghosts and Goblins.  I don't have any of those to test, though.

Also, it's possible this line should be affected (maybe only keeping the alpha?) as well, if this pull is even correct:

```
WRITE(p, "  lowp vec4 lightSum0 = u_ambient * %s + vec4(u_matemissive, 0.0);\n", ambientStr);
```

But, changing that _does_ break lighting in games.  This kinda makes me worried this change is not correct.

-[Unknown]
