### PR TITLE
Fix some memcheck bugs

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -248,12 +248,12 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 		MemCheck &check = *iter;
 		if (check.end != 0)
 		{
-			if (address >= check.start && address + size < check.end)
+			if (address + size >= check.start && address < check.end)
 				return &check;
 		}
 		else
 		{
-			if (check.start==address)
+			if (check.start == address)
 				return &check;
 		}
 	}

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -732,7 +732,7 @@ void Jit::JitSafeMem::MemCheckImm(ReadType type)
 
 		jit_->CMP(32, M((void*)&coreState), Imm32(0));
 		skipChecks_.push_back(jit_->J_CC(CC_NE, true));
-		jit_->js.afterOp = JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE;
+		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE;
 	}
 }
 
@@ -749,9 +749,9 @@ void Jit::JitSafeMem::MemCheckAsm(ReadType type)
 		FixupBranch skipNext, skipNextRange;
 		if (it->end != 0)
 		{
-			jit_->CMP(32, R(xaddr_), Imm32(it->start - offset_));
+			jit_->CMP(32, R(xaddr_), Imm32(it->start - offset_ - size_));
 			skipNext = jit_->J_CC(CC_B);
-			jit_->CMP(32, R(xaddr_), Imm32(it->end - offset_ - size_));
+			jit_->CMP(32, R(xaddr_), Imm32(it->end - offset_));
 			skipNextRange = jit_->J_CC(CC_AE);
 		}
 		else
@@ -768,7 +768,7 @@ void Jit::JitSafeMem::MemCheckAsm(ReadType type)
 
 		jit_->CMP(32, M((void*)&coreState), Imm32(0));
 		skipChecks_.push_back(jit_->J_CC(CC_NE, true));
-		jit_->js.afterOp = JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE;
+		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE;
 
 		jit_->SetJumpTarget(skipNext);
 		if (it->end != 0)

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -742,9 +742,9 @@ void Jit::JitSafeMem::MemCheckAsm(ReadType type)
 	for (auto it = memchecks.begin(), end = memchecks.end(); it != end; ++it)
 	{
 		if (!(it->cond & MEMCHECK_READ) && type == MEM_READ)
-			return;
+			continue;
 		if (!(it->cond & MEMCHECK_WRITE) && type == MEM_WRITE)
-			return;
+			continue;
 
 		FixupBranch skipNext, skipNextRange;
 		if (it->end != 0)


### PR DESCRIPTION
The slightly concerning one here is that I was (in one place, but not all memory checks) getting errors when a memcheck did not hit.

I tried making everything far jumps but it didn't help, but when I made the jump targets earlier, it did help.  So I just moved it out of the loop, better that way anyway.  But I feel like I'm still missing something important.

The specific code was (doesn't take the imm path because `rs == rt`):
lui a0, 0x08A0
lbu a0, a0(3550)

If I put a memcheck like 0x08A03550, then it worked.  If I used 0x07A03550, it said "invalid address 00003500".  In this case the reg is ESI, so it seems like it's getting cleared... or not saved properly. but I'm not seeing it.

Hmm...

-[Unknown]
