### PR TITLE
Add option to bind right analog stick to left/right dpad buttons only.

### DIFF
--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -237,6 +237,10 @@ int DinputDevice::UpdateState(InputState &input_state)
 		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
 		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
 		break;
+	case 5:
+		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		break;
 	}
 
 	return UPDATESTATE_SKIP_PAD;

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -199,6 +199,10 @@ void XinputDevice::ApplyDiff(XINPUT_STATE &state, InputState &input_state) {
 		if      (state.Gamepad.sThumbRY >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
 		else if (state.Gamepad.sThumbRY < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
 		break;
+	case 5:
+		if      (state.Gamepad.sThumbRX >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+		else if (state.Gamepad.sThumbRX < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		break;
 	}
 }
 


### PR DESCRIPTION
Can be useful for games that use the dpad as a camera, and horizontal camera movement is more common than vertical(i.e. Monster Hunter).
