### PR TITLE
Add preliminary volume control for BGM and SE

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -68,11 +68,11 @@ void Config::Load(const char *iniFileName)
 	// "default" means let emulator decide, "" means disable.
 	general->Get("ReportHost", &sReportHost, "default");
 	general->Get("Recent", recentIsos);
-	general->Get("WindowX", &iWindowX, 40);
-	general->Get("WindowY", &iWindowY, 100);
 	general->Get("AutoSaveSymbolMap", &bAutoSaveSymbolMap, false);
 #ifdef _WIN32
 	general->Get("TopMost", &bTopMost);
+	general->Get("WindowX", &iWindowX, 40);
+	general->Get("WindowY", &iWindowY, 100);
 #endif
 
 	if (recentIsos.size() > iMaxRecent)
@@ -84,7 +84,6 @@ void Config::Load(const char *iniFileName)
 #else
 	cpu->Get("Jit", &bJit, true);
 #endif
-	//FastMemory Default set back to True when solve UNIMPL _sceAtracGetContextAddress making game crash
 	cpu->Get("FastMemory", &bFastMemory, false);
 	cpu->Get("CPUSpeed", &iLockedCPUSpeed, false);
 
@@ -102,7 +101,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("SSAA", &SSAntiAliasing, 0);
 	graphics->Get("VBO", &bUseVBO, false);
 	graphics->Get("FrameSkip", &iFrameSkip, 0);
-	graphics->Get("FrameRate", &iFpsLimit, 60);
+	graphics->Get("FrameRate", &iFpsLimit, 0);
 	graphics->Get("ForceMaxEmulatedFPS", &iForceMaxEmulatedFPS, 0);
 #ifdef USING_GLES2
 	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 0);
@@ -110,7 +109,9 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("AnisotropyLevel", &iAnisotropyLevel, 8);
 #endif
 	graphics->Get("VertexCache", &bVertexCache, true);
+#ifdef _WIN32
 	graphics->Get("FullScreen", &bFullScreen, false);
+#endif
 #ifdef BLACKBERRY
 	graphics->Get("PartialStretch", &bPartialStretch, pixel_xres == pixel_yres);
 #endif
@@ -126,6 +127,8 @@ void Config::Load(const char *iniFileName)
 	IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 	sound->Get("Enable", &bEnableSound, true);
 	sound->Get("EnableAtrac3plus", &bEnableAtrac3plus, true);
+	sound->Get("BGMVolume", &iBGMVolume, 8);
+	sound->Get("SEVolume", &iSEVolume, 8);
 	
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("ShowStick", &bShowAnalogStick, false);
@@ -134,7 +137,7 @@ void Config::Load(const char *iniFileName)
 #elif defined(USING_GLES2)
 	control->Get("ShowTouchControls", &bShowTouchControls, true);
 #else
-	control->Get("ShowTouchControls", &bShowTouchControls,false);
+	control->Get("ShowTouchControls", &bShowTouchControls, false);
 #endif
 	control->Get("LargeControls", &bLargeControls, false);
 	control->Get("KeyMapping",iMappingMap);
@@ -145,7 +148,7 @@ void Config::Load(const char *iniFileName)
 	control->Get("ButtonScale", &fButtonScale, 1.15);
 
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
-	pspConfig->Get("NickName", &sNickName, "shadow");
+	pspConfig->Get("NickName", &sNickName, "PPSSPP");
 	pspConfig->Get("Language", &ilanguage, PSP_SYSTEMPARAM_LANGUAGE_ENGLISH);
 	pspConfig->Get("TimeFormat", &iTimeFormat, PSP_SYSTEMPARAM_TIME_FORMAT_24HR);
 	pspConfig->Get("DateFormat", &iDateFormat, PSP_SYSTEMPARAM_DATE_FORMAT_YYYYMMDD);
@@ -192,11 +195,11 @@ void Config::Save()
 		general->Set("ShowDebuggerOnLoad", bShowDebuggerOnLoad);
 		general->Set("ReportHost", sReportHost);
 		general->Set("Recent", recentIsos);
-		general->Set("WindowX", iWindowX);
-		general->Set("WindowY", iWindowY);
 		general->Set("AutoSaveSymbolMap", bAutoSaveSymbolMap);
 #ifdef _WIN32
 		general->Set("TopMost", bTopMost);
+		general->Set("WindowX", iWindowX);
+		general->Set("WindowY", iWindowY);
 #endif
 		general->Set("Language", languageIni);
 		general->Set("NumWorkerThreads", iNumWorkerThreads);
@@ -222,7 +225,9 @@ void Config::Save()
 		graphics->Set("ForceMaxEmulatedFPS", iForceMaxEmulatedFPS);
 		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
+#ifdef _WIN32
 		graphics->Set("FullScreen", bFullScreen);
+#endif		
 #ifdef BLACKBERRY
 		graphics->Set("PartialStretch", bPartialStretch);
 #endif
@@ -238,7 +243,9 @@ void Config::Save()
 		IniFile::Section *sound = iniFile.GetOrCreateSection("Sound");
 		sound->Set("Enable", bEnableSound);
 		sound->Set("EnableAtrac3plus", bEnableAtrac3plus);
-		
+		sound->Set("BGMVolume", iBGMVolume);
+		sound->Set("SEVolume", iSEVolume);
+
 		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 		control->Set("ShowStick", bShowAnalogStick);
 		control->Set("ShowTouchControls", bShowTouchControls);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -94,6 +94,8 @@ public:
 	// Sound
 	bool bEnableSound;
 	bool bEnableAtrac3plus;
+	int iSEVolume;
+	int iBGMVolume;
 
 	// UI
 	bool bShowTouchControls;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -23,6 +23,7 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/CoreTiming.h"
 #include "Core/Reporting.h"
+#include "Core/Config.h"
 #include "Common/ChunkFile.h"
 
 #include "sceKernel.h"
@@ -622,16 +623,17 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 						atrac->sampleQueue.push(buf, decodebytes);
 					}
 				}
+				const int MAX_CONFIG_VOLUME = 5;
 				s16* out = (s16*)outbuf;
 				memset(out, 0, ATRAC3PLUS_MAX_SAMPLES * sizeof(s16) * atrac->atracOutputChannels);
 				int gotsize = atrac->sampleQueue.pop_front(buf, ATRAC3PLUS_MAX_SAMPLES * sizeof(s16) * atrac->atracChannels);
 				numSamples = gotsize / sizeof(s16) / atrac->atracChannels;
 				s16* in = (s16*)buf;
 				for (u32 i = 0; i < numSamples; i++) {
-					s16 sampleL = *in++;
+					s16 sampleL = *in++ >> (MAX_CONFIG_VOLUME - g_Config.iBGMVolume); // Max = 4 and Min = 0(no shift)
 					s16 sampleR = sampleL;
 					if (atrac->atracChannels == 2)
-						sampleR = *in++;
+						sampleR = *in++ >> (MAX_CONFIG_VOLUME - g_Config.iBGMVolume); // Max = 4 and Min = 0(no shift)
 					*out++ = sampleL;
 					if (atrac->atracOutputChannels == 2)
 						*out++ = sampleR;
@@ -1686,16 +1688,17 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 				Atrac3plus_Decoder::Decode(atrac->decoder_context, Memory::GetPointer(sourceAddr), sourcebytes, &decodebytes, buf);
 				atrac->sampleQueue.push(buf, decodebytes);
 			}
+			const int MAX_CONFIG_VOLUME = 5;
 			s16* out = (s16*)Memory::GetPointer(samplesAddr);
 			memset(out, 0, ATRAC3PLUS_MAX_SAMPLES * sizeof(s16) * atrac->atracOutputChannels);
 			int gotsize = atrac->sampleQueue.pop_front(buf, ATRAC3PLUS_MAX_SAMPLES * sizeof(s16) * atrac->atracChannels);
 			int numSamples = gotsize / sizeof(s16) / atrac->atracChannels;
 			s16* in = (s16*)buf;
 			for (int i = 0; i < numSamples; i++) {
-				s16 sampleL = *in++;
+				s16 sampleL = *in++ >> (MAX_CONFIG_VOLUME - g_Config.iBGMVolume); // Max = 4 and Min = 0(no shift)
 				s16 sampleR = sampleL;
 				if (atrac->atracChannels == 2)
-					sampleR = *in++;
+					sampleR = *in++ >> (MAX_CONFIG_VOLUME - g_Config.iBGMVolume); // Max = 4 and Min = 0(no shift)
 				*out++ = sampleL;
 				if (atrac->atracOutputChannels == 2)
 					*out++ = sampleR;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -19,6 +19,7 @@
 #include "../Globals.h"
 #include "../MemMap.h"
 #include "Core/HLE/sceAtrac.h"
+#include "Core/Config.h" 
 #include "SasAudio.h"
 
 // #define AUDIO_TO_FILE
@@ -412,6 +413,7 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 
 			// Resample to the correct pitch, writing exactly "grainSize" samples.
 			u32 sampleFrac = voice.sampleFrac;
+			const int MAX_CONFIG_VOLUME = 17; 
 			for (int i = 0; i < grainSize; i++) {
 				// For now: nearest neighbour, not even using the resample history at all.
 				int sample = resampleBuffer[sampleFrac / PSP_SAS_PITCH_BASE + 2];
@@ -429,8 +431,8 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 				// We mix into this 32-bit temp buffer and clip in a second loop
 				// Ideally, the shift right should be there too but for now I'm concerned about
 				// not overflowing.
-				mixBuffer[i * 2] += sample * voice.volumeLeft >> 12;
-				mixBuffer[i * 2 + 1] += sample * voice.volumeRight >> 12;
+				mixBuffer[i * 2] += (sample * voice.volumeLeft ) >> (MAX_CONFIG_VOLUME - g_Config.iSEVolume); // Max = 16 and Min = 12(default)
+				mixBuffer[i * 2 + 1] += (sample * voice.volumeRight) >> (MAX_CONFIG_VOLUME - g_Config.iSEVolume); // Max = 16 and Min = 12(default)
 				sendBuffer[i * 2] += sample * voice.volumeLeftSend >> 12;
 				sendBuffer[i * 2 + 1] += sample * voice.volumeRightSend >> 12;
 				voice.envelope.Step();

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -789,17 +789,46 @@ void AudioScreen::render() {
 	int stride = 40;
 	int columnw = 400;
 	UICheckBox(GEN_ID, x, y += stride, a->T("Enable Sound"), ALIGN_TOPLEFT, &g_Config.bEnableSound);
-	if (Atrac3plus_Decoder::IsSupported()) {
-		if (Atrac3plus_Decoder::IsInstalled() && g_Config.bEnableSound) {
-			UICheckBox(GEN_ID, x + 60, y += stride, a->T("Enable Atrac3+"), ALIGN_TOPLEFT, &g_Config.bEnableAtrac3plus);
-		} else
-			g_Config.bEnableAtrac3plus = false;
-
-		VLinear vlinear(30, 200, 20);
-		if (UIButton(GEN_ID, vlinear, 400, 0, a->T("Download Atrac3+ plugin"), ALIGN_LEFT)) {
-			screenManager()->push(new PluginScreen());
+	if (g_Config.bEnableSound) {
+		if (Atrac3plus_Decoder::IsInstalled()) {
+			UICheckBox(GEN_ID, x, y += stride, a->T("Enable Atrac3+"), ALIGN_TOPLEFT, &g_Config.bEnableAtrac3plus);
+		} else {
+			VLinear vlinear(30, 250, 20);
+			if (UIButton(GEN_ID, vlinear, 400, 0, a->T("Download Atrac3+ plugin"), ALIGN_LEFT)) {
+				screenManager()->push(new PluginScreen());
+			}
 		}
-	}
+
+		y+=10;
+		char bgmvol[256];
+		sprintf(bgmvol, "%s %i", a->T("BGM Volume :"), g_Config.iBGMVolume);
+		ui_draw2d.DrawText(UBUNTU24, bgmvol, x, y += stride, 0xFFFFFFFF, ALIGN_LEFT);
+		HLinear hlinear1(x + 250, y, 20);
+		if (UIButton(GEN_ID, hlinear1, 80, 0, a->T("Auto"), ALIGN_LEFT))
+			g_Config.iBGMVolume = 3;
+		if (UIButton(GEN_ID, hlinear1, 50, 0, a->T("-1"), ALIGN_LEFT))
+			if (g_Config.iBGMVolume > 1)
+				g_Config.iBGMVolume -= 1;
+		if (UIButton(GEN_ID, hlinear1, 50, 0, a->T("+1"), ALIGN_LEFT))
+			if (g_Config.iBGMVolume < 5)
+				g_Config.iBGMVolume += 1;
+		y+=20;
+		char sevol[256];
+		sprintf(sevol, "%s %i", a->T("SE Volume     :"), g_Config.iSEVolume);
+		ui_draw2d.DrawText(UBUNTU24, sevol, x, y += stride, 0xFFFFFFFF, ALIGN_LEFT);
+		HLinear hlinear2(x + 250, y, 20);
+		if (UIButton(GEN_ID, hlinear2, 80, 0, a->T("Auto"), ALIGN_LEFT))
+			g_Config.iSEVolume = 3;
+		if (UIButton(GEN_ID, hlinear2, 50, 0, a->T("-1"), ALIGN_LEFT))
+			if (g_Config.iSEVolume > 1)
+				g_Config.iSEVolume -= 1;
+		if (UIButton(GEN_ID, hlinear2, 50, 0, a->T("+1"), ALIGN_LEFT))
+			if (g_Config.iSEVolume < 5)
+				g_Config.iSEVolume += 1;
+		y+=10;
+
+	} else
+		g_Config.bEnableAtrac3plus = false;
 
 	UIEnd();
 }


### PR DESCRIPTION
It is very preliminary to implement the volume control for BGM and SE. Tested with few games with atrac3+ BGM and working well .

Note : It only supported Atrac3+ audio only for BGM .
