### PR TITLE
Windows: Add option to let DirectInput controllers swap right stick axes

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -141,6 +141,7 @@ void Config::Load(const char *iniFileName)
 	control->Get("AccelerometerToAnalogHoriz", &bAccelerometerToAnalogHoriz, false);
 	control->Get("ForceInputDevice", &iForceInputDevice, -1);
 	control->Get("RightStickBind", &iRightStickBind, 0);
+	control->Get("SwapDInputRightAxes", &iSwapRightAxes, 0);
 	control->Get("TouchButtonOpacity", &iTouchButtonOpacity, 65);
 	control->Get("ButtonScale", &fButtonScale, 1.15);
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -110,6 +110,7 @@ public:
 	// 3 = L/R
 	// 4 = L/R + triangle/cross
 	int iRightStickBind;
+	int iSwapRightAxes;
 
 	// Control
 	std::map<int,int> iMappingMap; // Can be used differently depending on systems

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -216,30 +216,66 @@ int DinputDevice::UpdateState(InputState &input_state)
 	case 0:
 		break;
 	case 1:
-		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
-		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
-		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_UP;
-		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_DOWN;
+		if(!g_Config.iSwapRightAxes) {
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_UP;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_DOWN;
+		}
+		else {
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_UP;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_DOWN;
+		}
 		break;
 	case 2:
-		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_B;
-		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_X;
-		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
-		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		if(!g_Config.iSwapRightAxes) {
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_B;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_X;
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		}
+		else {
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_B;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_X;
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		}
 		break;
 	case 3:
-		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
-		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		if(!g_Config.iSwapRightAxes) {
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		}
+		else {
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+		}
 		break;
 	case 4:
-		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
-		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
-		if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
-		else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		if(!g_Config.iSwapRightAxes) {
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		}
+		else {
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RBUMPER;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LBUMPER;
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_Y;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_A;
+		}
 		break;
 	case 5:
-		if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
-		else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		if(!g_Config.iSwapRightAxes) {
+			if      (js.lRz >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+			else if (js.lRz < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		}
+		else {
+			if      (js.lZ >  rthreshold) input_state.pad_buttons |= PAD_BUTTON_RIGHT;
+			else if (js.lZ < -rthreshold) input_state.pad_buttons |= PAD_BUTTON_LEFT;
+		}
 		break;
 	}
 


### PR DESCRIPTION
Some controllers have their axes mixed up, making the RightStickBind option annoying to use. This fixes that by letting the user swap the axes with a simple INI option.
