### PR TITLE
Add mappable virtual keys

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -42,6 +42,9 @@ struct DefaultKeyMap {
 		m[KEYCODE_DPAD_DOWN] = CTRL_DOWN;
 		m[KEYCODE_DPAD_LEFT] = CTRL_LEFT;
 		m[KEYCODE_DPAD_RIGHT] = CTRL_RIGHT;
+		m[KEYCODE_TAB] = VIRT_UNTHROTTLE;
+		m[KEYCODE_BUTTON_THUMBL] = VIRT_CYCLE_THROTTLE;
+		m[KEYCODE_BACK] = VIRT_BACK;
 		return m;
 	}
 	static std::map<int,int> KeyMap;

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -22,6 +22,35 @@
 #include "input/keycodes.h"     // keyboard keys
 #include "../Core/HLE/sceCtrl.h"   // psp keys
 
+
+// sceCtrl does not use all 32 bits
+// We will use some bits to define
+// our virtual buttons.
+// Provides room for 2^7 virt keys
+#define VIRTBIT1        0x0002
+#define VIRTBIT2        0x0004
+#define VIRTBIT3        0x0040
+#define VIRTBIT4        0x0080
+#define VIRTBIT5        0x0400
+#define VIRTBIT6        0x0800
+#define VIRT_BTN_MASK \
+	(VIRTBIT1 | VIRTBIT2 | VIRTBIT3 | VIRTBIT4 |\
+	 VIRTBIT5 | VIRTBIT6)
+#define CTRL_BTN_MASK (~VIRT_BTN_MASK)
+
+// Virtual PSP Buttons
+// Can be mapped to
+// but are never sent
+// Core
+#define VIRT_UNTHROTTLE        (VIRTBIT1)
+#define VIRT_CYCLE_THROTTLE    (VIRTBIT1 | VIRTBIT2)
+#define VIRT_ANALOG_UP         (VIRTBIT1 | VIRTBIT3)
+#define VIRT_ANALOG_DOWN       (VIRTBIT1 | VIRTBIT4)
+#define VIRT_ANALOG_LEFT       (VIRTBIT1 | VIRTBIT5)
+#define VIRT_ANALOG_RIGHT      (VIRTBIT1 | VIRTBIT6)
+#define VIRT_BACK              (VIRTBIT2 | VIRTBIT3)
+
+// KeyMap error codes
 #define KEYMAP_ERROR_KEY_ALREADY_USED -1
 #define KEYMAP_ERROR_UNKNOWN_KEY 0
 

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -49,6 +49,7 @@
 #define VIRT_ANALOG_LEFT       (VIRTBIT1 | VIRTBIT5)
 #define VIRT_ANALOG_RIGHT      (VIRTBIT1 | VIRTBIT6)
 #define VIRT_BACK              (VIRTBIT2 | VIRTBIT3)
+#define VIRT_PAUSE             (VIRTBIT2 | VIRTBIT4)
 
 // KeyMap error codes
 #define KEYMAP_ERROR_KEY_ALREADY_USED -1

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -208,7 +208,7 @@ void EmuScreen::update(InputState &input) {
 	float stick_y = input.pad_lstick_y;
 	float rightstick_x = input.pad_rstick_x;
 	float rightstick_y = input.pad_rstick_y;
-	bool leave_emu_screen = false;
+	bool pause_emu_screen = false;
 	bool unthrottle = false;
 	bool cycle_throttles = false;
 	
@@ -262,7 +262,8 @@ void EmuScreen::update(InputState &input) {
 				break;
 
 			case VIRT_BACK:
-				leave_emu_screen = true;
+			case VIRT_PAUSE:
+				pause_emu_screen = true;
 				break;
 
 			case VIRT_ANALOG_UP:
@@ -329,7 +330,7 @@ void EmuScreen::update(InputState &input) {
 		PSP_CoreParameter().fpsLimit = (fpsLimit + 1) % 3;
 	}
 
-	if (leave_emu_screen || (input.pad_buttons_down & 
+	if (pause_emu_screen || (input.pad_buttons_down & 
 	          (PAD_BUTTON_MENU | PAD_BUTTON_BACK | PAD_BUTTON_RIGHT_THUMB))) {
 
 		if (g_Config.bBufferedRendering)

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -107,6 +107,8 @@ EmuScreen::EmuScreen(const std::string &filename) : invalid_(true) {
 	}
 #endif
 	pressedLastUpdate = 0;
+	unthrottle_last_update = false;
+	cycle_throttles_last_update = false;
 }
 
 EmuScreen::~EmuScreen() {
@@ -208,6 +210,10 @@ void EmuScreen::update(InputState &input) {
 	float stick_y = input.pad_lstick_y;
 	float rightstick_x = input.pad_rstick_x;
 	float rightstick_y = input.pad_rstick_y;
+
+	// TODO: add member *_last_update
+	// then only switch when button
+	// goes false -> true
 	bool pause_emu_screen = false;
 	bool unthrottle = false;
 	bool cycle_throttles = false;
@@ -254,11 +260,13 @@ void EmuScreen::update(InputState &input) {
 			// Special keys
 			switch (key) {
 			case VIRT_UNTHROTTLE:
-				unthrottle = true;
+				if (unthrottle_last_update == false)
+					unthrottle = true;
 				break;
 
 			case VIRT_CYCLE_THROTTLE:
-				cycle_throttles = true;
+				if (cycle_throttles_last_update == false)
+					cycle_throttles = true;
 				break;
 
 			case VIRT_BACK:
@@ -286,7 +294,11 @@ void EmuScreen::update(InputState &input) {
 	}
 	__CtrlButtonDown(pressed);
 	__CtrlButtonUp(pressedLastUpdate & ~pressed);
+
+	// Save state for next update
 	pressedLastUpdate = pressed;
+	unthrottle_last_update = unthrottle;
+	cycle_throttles_last_update = cycle_throttles;
 
 
 	// Act on Speical keys ------------

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -38,5 +38,7 @@ private:
 	// Something invalid was loaded, don't try to emulate
 	bool invalid_;
 	std::string errorMessage_;
-	uint32_t pressedLastUpdate;
+	int32_t pressedLastUpdate;
+	bool unthrottle_last_update;
+	bool cycle_throttles_last_update;
 };


### PR DESCRIPTION
Virtual keys can change throttling, pause, or control the analog stick.

TODO: I need to add a default mapping for the analog stick virt keys. Its too late and my thinking is not straight. Wait until tomorrow and I'll have everything ready.

TODO: I broke the type, should be uint32_t
