### PR TITLE
Fall back to use region instead of viewport to estimate drawing size

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -433,6 +433,11 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	int drawing_width = ((gstate.region2) & 0x3FF) + 1;
 	int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
 
+	if (drawing_width > gstate.getScissorX2() + 1)
+		drawing_width = gstate.getScissorX2() + 1;
+	if (drawing_height > gstate.getScissorY2() + 1)
+		drawing_height = gstate.getScissorY2() + 1;
+		
 	// As there are no clear "framebuffer width" and "framebuffer height" registers,
 	// we need to infer the size of the current framebuffer somehow. Let's try the viewport.
 	

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -430,16 +430,16 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	int z_stride = gstate.zbwidth & 0x3C0;
 
 	// Yeah this is not completely right. but it'll do for now.
-	//int drawing_width = ((gstate.region2) & 0x3FF) + 1;
-	//int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
+	int drawing_width = ((gstate.region2) & 0x3FF) + 1;
+	int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
 
 	// As there are no clear "framebuffer width" and "framebuffer height" registers,
 	// we need to infer the size of the current framebuffer somehow. Let's try the viewport.
 	
 	int fmt = gstate.framebufpixformat & 3;
 
-	int drawing_width, drawing_height;
-	GuessDrawingSize(drawing_width, drawing_height);
+	//int drawing_width, drawing_height;
+	//GuessDrawingSize(drawing_width, drawing_height);
 
 	int buffer_width = drawing_width;
 	int buffer_height = drawing_height;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -717,7 +717,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		memcpy(&transformed[index].u, uv, 3 * sizeof(float));
 
 		if (gstate_c.flipTexture) 
-				transformed[index].v = 1.0f - transformed[index].v;
+				transformed[index].v = 1.0f - transformed[index].v * 2.0f;
 
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -553,7 +553,7 @@ void GenerateVertexShader(int prim, char *buffer, bool useHWTransform) {
 			}
 
 			if (flipV) 
-				WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y;\n");	
+				WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y * 2.0;\n");	
 		}
 
 		// Compute fogdepth


### PR DESCRIPTION
Although the region here is not truely correct however it definitely much better than using viewport as it broken number of games in terms of graphic.

This fall back fixes multiple games with graphic issues previously in buffered rendering mode
1. MotoGP (Incorrect viewport)  Issue #702 
   ![screen00044](https://f.cloud.github.com/assets/3000282/756818/c3f68254-e649-11e2-8ca7-ad3706341822.jpg)
2. FF Type-0 (Dynamic Shadowing issue)  Issue #1272 
   ![screen00045](https://f.cloud.github.com/assets/3000282/756826/93396aea-e64a-11e2-9e03-3252c48491bd.jpg)
3. Castlevania The Dracula X Chronicles (Incorrect background size)
   ![screen00046](https://f.cloud.github.com/assets/3000282/756827/a2a3b3dc-e64a-11e2-88f4-117aa28cf7ac.jpg)

Meanwhile , the workaround of multiple with 2.0 in HW/SW mode can be reverted as the fall back here fixes issue in Castlevania as well.
