### PR TITLE
Windows UI: Fix topmost not working when checked & user starts the application again

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -272,6 +272,8 @@ namespace MainWindow
 		
 		ShowWindow(hwndMain, nCmdShow);
 
+		W32Util::MakeTopMost(hwndMain, g_Config.bTopMost);
+
 #if ENABLE_TOUCH
 		RegisterTouchWindow(hwndDisplay, TWF_WANTPALM);
 #endif


### PR DESCRIPTION
Before, it wouldn't set the always on top property(to g_Config.bTopMost) when the application opened, resulting in the user having to uncheck and recheck the menu option for it to take effect.
