### PR TITLE
Fix memchecks for halfwords and bytes

### DIFF
--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -53,7 +53,7 @@ namespace MIPSComp
 
 		JitSafeMem safe(this, rs, offset);
 		OpArg src;
-		if (safe.PrepareRead(src, 4))
+		if (safe.PrepareRead(src, bits / 8))
 			(this->*mov)(32, bits, gpr.RX(rt), src);
 		if (safe.PrepareSlowRead(safeFunc))
 			(this->*mov)(32, bits, gpr.RX(rt), R(EAX));
@@ -83,7 +83,7 @@ namespace MIPSComp
 
 		JitSafeMem safe(this, rs, offset);
 		OpArg dest;
-		if (safe.PrepareWrite(dest, 4))
+		if (safe.PrepareWrite(dest, bits / 8))
 		{
 			if (needSwap)
 			{


### PR DESCRIPTION
Sorry, one more.  Hopefully just one more, heh.

Before it was doing the range on a 4 byte read, which would trip a memcheck that wasn't actually being hit if the byte of halfword was unaligned.

-[Unknown]
