### PR TITLE
Fix texture misalignment & distortion on multiple games

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -367,8 +367,8 @@ VirtualFramebuffer *FramebufferManager::GetDisplayFBO() {
 }
 
 void GetViewportDimensions(int &w, int &h) {
-	float vpXa = getFloat24(gstate.viewportx1);
-	float vpYa = getFloat24(gstate.viewporty1);
+	float vpXa = getFloat24(gstate.viewportx2);
+	float vpYa = getFloat24(gstate.viewporty2);
 	w = (int)fabsf(vpXa * 2);
 	h = (int)fabsf(vpYa * 2);
 }
@@ -430,21 +430,16 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	int z_stride = gstate.zbwidth & 0x3C0;
 
 	// Yeah this is not completely right. but it'll do for now.
-	int drawing_width = ((gstate.region2) & 0x3FF) + 1;
-	int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
-
-	if (drawing_width > gstate.getScissorX2() + 1)
-		drawing_width = gstate.getScissorX2() + 1;
-	if (drawing_height > gstate.getScissorY2() + 1)
-		drawing_height = gstate.getScissorY2() + 1;
+	//int drawing_width = ((gstate.region2) & 0x3FF) + 1;
+	//int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
 		
 	// As there are no clear "framebuffer width" and "framebuffer height" registers,
 	// we need to infer the size of the current framebuffer somehow. Let's try the viewport.
 	
 	int fmt = gstate.framebufpixformat & 3;
 
-	//int drawing_width, drawing_height;
-	//GuessDrawingSize(drawing_width, drawing_height);
+	int drawing_width, drawing_height;
+	GuessDrawingSize(drawing_width, drawing_height);
 
 	int buffer_width = drawing_width;
 	int buffer_height = drawing_height;


### PR DESCRIPTION
This prefectly fixes the texture misalignment & distortion . The best is ... the previous fix from #2648 still maintains and no broken.
1. Saint Seiya Omega (all characters misalign issue ) 
   Note the charging around the charcter sprite , it never renders correct previously but it is prefect now !!
   ![screen00004](https://f.cloud.github.com/assets/3000282/757374/290b9de6-e695-11e2-8bf4-e0c97b735197.jpg)
2. Super Robot War Portable A (Engery bar incorrect texture issue)
   ![screen00000](https://f.cloud.github.com/assets/3000282/757371/9cf20d0e-e694-11e2-9654-102e16fe6526.jpg)
3. Kingdom Hearts Birth by Sleep (Dark Bar on the right size)
   ![screen00003](https://f.cloud.github.com/assets/3000282/757373/de458d3a-e694-11e2-91e3-c7baf96c08dd.jpg)
4. Gundam AGE Universe (characters misalign issue, it is prefectly fixed)
   ![screen00005](https://f.cloud.github.com/assets/3000282/757379/f06d1964-e695-11e2-9e34-bd6431e34652.jpg)
