### PR TITLE
Improve performance of export resolving / module loading

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -201,7 +201,8 @@ public:
 				typename std::map<K, T>::iterator itr = x.begin();
 				while (number > 0)
 				{
-					Do(itr->first);
+					K first = itr->first;
+					Do(first);
 					Do(itr->second);
 					--number;
 					++itr;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -20,11 +20,18 @@
 #include "../../Globals.h"
 #include <vector>
 #include <set>
+#include <map>
 
 enum SymbolType
 {
 	ST_FUNCTION=1,
 	ST_DATA=2
+};
+
+struct SymbolInfo
+{
+	u32 address;
+	u32 size;
 };
 
 #ifdef _WIN32
@@ -42,6 +49,7 @@ public:
 	void ResetSymbolMap();
 	void AnalyzeBackwards();
 	int GetSymbolNum(unsigned int address, SymbolType symmask=ST_FUNCTION) const;
+	bool GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask = ST_FUNCTION) const;
 	const char *GetDescription(unsigned int address) const;
 #ifdef _WIN32
 	void FillSymbolListBox(HWND listbox, SymbolType symmask=ST_FUNCTION) const;
@@ -96,6 +104,7 @@ private:
 
 	std::set<MapEntryUniqueInfo> uniqueEntries;
 	std::vector<MapEntry> entries;
+	std::map<u32, u32> entryRanges;
 };
 
 extern SymbolMap symbolMap;

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -383,7 +383,7 @@ int MetaFileSystem::RenameFile(const std::string &from, const std::string &to)
 	if (MapFilePath(from, of, &osystem))
 	{
 		// If it's a relative path, it seems to always use from's filesystem.
-		if (to.find(':/') != to.npos)
+		if (to.find(":/") != to.npos)
 		{
 			if (!MapFilePath(to, rf, &rsystem))
 				return -1;

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -48,9 +48,11 @@ struct HLEModule
 	const HLEFunction *funcTable;
 };
 
+typedef char SyscallModuleName[32];
+
 struct Syscall
 {
-	char moduleName[32];
+	SyscallModuleName moduleName;
 	u32 symAddr;
 	u32 nid;
 };

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -351,10 +351,10 @@ namespace MIPSAnalyst
 		u32 addr;
 		for (addr = startAddr; addr<=endAddr; addr+=4)
 		{
-			int n = symbolMap.GetSymbolNum(addr,ST_FUNCTION);
-			if (n != -1)
+			SymbolInfo syminfo;
+			if (symbolMap.GetSymbolInfo(&syminfo, addr, ST_FUNCTION))
 			{
-				addr = symbolMap.GetSymbolAddr(n) + symbolMap.GetSymbolSize(n);
+				addr = syminfo.address + syminfo.size;
 				continue;
 			}
 


### PR DESCRIPTION
In games like God Eater Burst and etc. which use a lot of exports, there were noticeable lags while the linking happened.

This optimizes those functions so the delay is gone.  These two functions were eating about 0.7s all by themselves during a single scene switch in God Eater Burst on my hardware.

I don't have it, but I would expect this to fix #2602 since I think it also loads modules like this.

-[Unknown]
