### PR TITLE
Updating the UMD ID of the Kiseki series games in the HDRemaster.h

### DIFF
--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -43,8 +43,16 @@ const struct HDRemaster g_HDRemasters[] = {
 	{ "NPJB40002", 0x4000000, 0x0BBFFFFF, true }, // K-ON Houkago Live HD Ver
 	{ "BLJM85003", 0x4000000, 0x0BBFFFFF, true }, // Shin Sangoku Musou Multi Raid 2 HD Ver
 	{ "NPJB40003", 0x4000000, 0x0BBFFFFF, true }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-	{ "BLJM85004", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
-	{ "NPJB40004", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
-	{ "BLJM85005", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
-	{ "NPJB40005", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
+	{ "BLJM85004", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition, this one is never used
+	// deactivated because it also affects the UMD version of the game
+	// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
+	// { "ULJM05170", 0x4000000, 0x0BBFFFFF, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
+	{ "BLJM85005", 0x4C00000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, this one is never used
+	// deactivated because it also affects the UMD version of the game
+	// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
+	// { "ULJM05277", 0x4C00000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, game needs 76 MB
+	{ "BLJM85006", 0x4C00000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, this one is never used
+	// deactivated because it also affects the UMD version of the game
+	// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
+	// { "ULJM05353", 0x4C00000, 0x0BBFFFFF, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, game needs 76 MB
 };


### PR DESCRIPTION
Change the UMD IDs in the source but deactivate them because they also interfer with the UMD versions. When recognized as HDRemasters, FC HD successfully loads into memory, SC HD & 3rd HD do not
