### PR TITLE
Fix incorrect texture sizing in Yu-Gi-Oh! 5D's Tag Force 6

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -437,8 +437,17 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	
 	int fmt = gstate.framebufpixformat & 3;
 
-	int drawing_width, drawing_height;
-	GuessDrawingSize(drawing_width, drawing_height);
+	//GuessDrawingSize(drawing_width, drawing_height);
+
+	// Set default drawing width/height as maximum texture size 512x512
+	int drawing_width = 512;
+	int drawing_height = 512;
+	
+	// Fall back to 480x272 for non-buffered and CG mode 
+	if (!g_Config.bBufferedRendering || g_iNumVideos ) {
+		drawing_width = 480;
+		drawing_height = 272;
+	}
 
 	int buffer_width = drawing_width;
 	int buffer_height = drawing_height;


### PR DESCRIPTION
-Before
![screen00000](https://f.cloud.github.com/assets/3000282/758199/2a20c1c6-e71b-11e2-91c2-8060ad7b9cf3.jpg)

-After
![screen00013](https://f.cloud.github.com/assets/3000282/758204/5c4b71f0-e71b-11e2-8360-5dda8bce3b5d.jpg)
