### PR TITLE
Fix PSN eboot crashes

### DIFF
--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -24,7 +24,7 @@ extern "C"
 {
 #include "zlib.h"
 #include "ext/libkirk/amctrl.h"
-
+#include "ext/libkirk/kirk_engine.h"
 };
 
 BlockDevice *constructBlockDevice(const char *filename) {
@@ -221,6 +221,8 @@ NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FILE *file)
 	if(readSize!=256){
 		ERROR_LOG(LOADER, "Invalid NPUMDIMG header!");
 	}
+
+	kirk_init();
 
 	// getkey
 	sceDrmBBMacInit(&mkey, 3);


### PR DESCRIPTION
Using funcs without initing? Tsk tsk.

Thanks to @tpunix for noticing it.

Fixes the now-closed https://github.com/hrydgard/ppsspp/issues/2581.
