### PR TITLE
Warning fixes

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -170,7 +170,7 @@ public:
 	template<class K, class T>
 	void Do(std::map<K, T> &x)
 	{
-		T dv;
+		T dv = T();
 		DoMap(x, dv);
 	}
 
@@ -230,7 +230,7 @@ public:
 	template<class K, class T>
 	void Do(std::multimap<K, T> &x)
 	{
-		T dv;
+		T dv = T();
 		DoMultimap(x, dv);
 	}
 

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -437,7 +437,7 @@ void CWCheatEngine::Run() {
 				break;
 			case 0x8: // 8-bit and 16-bit patch code
 				code = GetNextCode();
-				if (code[0] != NULL) {
+				if (code[0] != 0) {
 					int data = code[0];
 					int dataAdd = code[1];
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -319,7 +319,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 	{
 		const int FILE_LIST_ITEM_SIZE = 13 + 16 + 3;
 		const int FILE_LIST_COUNT_MAX = 99;
-		const int FILE_LIST_TOTAL_SIZE = FILE_LIST_ITEM_SIZE * FILE_LIST_COUNT_MAX;
+		const u32 FILE_LIST_TOTAL_SIZE = FILE_LIST_ITEM_SIZE * FILE_LIST_COUNT_MAX;
 		u32 tmpDataSize = 0;
 		u8 *tmpDataOrig = sfoFile.GetValueData("SAVEDATA_FILE_LIST", &tmpDataSize);
 		u8 *tmpData = new u8[FILE_LIST_TOTAL_SIZE];
@@ -346,7 +346,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 			if (fName + 13 + 16 <= (char*)tmpData + FILE_LIST_TOTAL_SIZE)
 				memcpy(fName+13, cryptedHash, 16);
 		}
-		sfoFile.SetValue("SAVEDATA_FILE_LIST", tmpData, FILE_LIST_TOTAL_SIZE, FILE_LIST_TOTAL_SIZE);
+		sfoFile.SetValue("SAVEDATA_FILE_LIST", tmpData, FILE_LIST_TOTAL_SIZE, (int)FILE_LIST_TOTAL_SIZE);
 		delete[] tmpData;
 	}
 
@@ -892,7 +892,7 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		u32 sfoFileListSize = 0;
 		char *sfoFileList = (char *)sfoFile.GetValueData("SAVEDATA_FILE_LIST", &sfoFileListSize);
 		const int FILE_LIST_ITEM_SIZE = 13 + 16 + 3;
-		const int FILE_LIST_COUNT_MAX = 99;
+		const u32 FILE_LIST_COUNT_MAX = 99;
 
 		// Filenames are 13 bytes long at most.  Add a NULL so there's no surprises.
 		char temp[14];

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -314,7 +314,7 @@ bool NPDRMDemoBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 		readBuf = blockBuf;
 
 	readSize = fread(readBuf, 1, table[block].size, f);
-	if(readSize!=table[block].size){
+	if(readSize != (size_t)table[block].size){
 		if(block==(numBlocks-1))
 			return true;
 		else

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -22,6 +22,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
 #include "Core/Font/PGF.h"
 #include "Core/HLE/HLE.h"
 
@@ -489,6 +490,12 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 					pixelColor |= pixelColor << 4;
 					pixelColor |= pixelColor << 8;
 					pixelColor |= pixelColor << 16;
+					break;
+				case PSP_FONT_PIXELFORMAT_4:
+				case PSP_FONT_PIXELFORMAT_4_REV:
+					break;
+				default:
+					ERROR_LOG_REPORT(HLE, "Unhandled font pixel format: %d", image->pixelFormat);
 					break;
 				}
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1389,7 +1389,7 @@ int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfB
 		delete atrac;
 		return atracID;
 	}
-	INFO_LOG(HLE, "sceAtracSetMOutHalfwayBufferAndGetID(%08x, %08x, %08x)", atracID, halfBuffer, readSize, halfBufferSize);
+	INFO_LOG(HLE, "%d=sceAtracSetMOutHalfwayBufferAndGetID(%08x, %08x, %08x)", atracID, halfBuffer, readSize, halfBufferSize);
 	int ret = _AtracSetData(atracID, halfBuffer, halfBufferSize, true);
 	if (ret < 0)
 		return ret;

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -107,7 +107,7 @@ int sceHttpSetSendTimeOut(int id, u32 timeout) {
 }
 
 u32 sceHttpSetProxy(u32 id, u32 activateFlagPtr, u32 mode, u32 newProxyHostPtr, u32 newProxyPort) {
-	ERROR_LOG(HLE, "UNIMPL sceHttpSetProxy(%d, %x, %x, %x, %d, %x)", id, activateFlagPtr, mode, newProxyHostPtr, newProxyPort);
+	ERROR_LOG(HLE, "UNIMPL sceHttpSetProxy(%d, %x, %x, %x, %d)", id, activateFlagPtr, mode, newProxyHostPtr, newProxyPort);
 	return 0;
 }
 
@@ -143,7 +143,7 @@ int sceHttpsEnd() {
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
 int sceHttpCreateRequest(int connectionID, int method, const char *path, u64 contentLength) {
-	ERROR_LOG(HLE, "UNIMPL sceHttpCreateRequest(%d, %d, %s, %x)", connectionID, method, path, contentLength);
+	ERROR_LOG(HLE, "UNIMPL sceHttpCreateRequest(%d, %d, %s, %llx)", connectionID, method, path, contentLength);
 	return 0;
 }
 
@@ -229,7 +229,7 @@ int sceHttpCreateTemplate(const char *agent, int unknown1, int unknown2) {
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
 int sceHttpCreateRequestWithURL(int connectionID, int method, const char *url, u64 contentLength) {
-	ERROR_LOG(HLE, "UNIMPL sceHttpCreateRequestWithURL(%d, %d, %s, %x)", connectionID, method, url, contentLength);
+	ERROR_LOG(HLE, "UNIMPL sceHttpCreateRequestWithURL(%d, %d, %s, %llx)", connectionID, method, url, contentLength);
 	return 0;
 }
 
@@ -249,7 +249,7 @@ int sceHttpGetAllHeader(int request, u32 headerPtrToPtr, u32 headerSize) {
 }
 
 int sceHttpGetContentLength(int requestID, u64 contentLengthPtr) {
-	ERROR_LOG(HLE, "UNIMPL sceHttpGetContentLength(%d, %x)", requestID, contentLengthPtr);
+	ERROR_LOG(HLE, "UNIMPL sceHttpGetContentLength(%d, %llx)", requestID, contentLengthPtr);
 	return 0;
 }
 

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -398,7 +398,7 @@ int sceKernelSendMbx(SceUID id, u32 packetAddr)
 		m->AddInitialMessage(packetAddr);
 	else
 	{
-		u32 next = m->nmb.packetListHead, prev;
+		u32 next = m->nmb.packetListHead, prev = 0;
 		for (int i = 0, n = m->nmb.numMessages; i < n; i++)
 		{
 			if (next == packetAddr)

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1349,7 +1349,7 @@ u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
 	state.result = SCE_KERNEL_ERROR_UNKNOWN_MODULE;
 
 	kernelObjects.Iterate(&__GetModuleIdByAddressIterator, &state);
-	if (state.result == SCE_KERNEL_ERROR_UNKNOWN_MODULE)
+	if (state.result == (SceUID)SCE_KERNEL_ERROR_UNKNOWN_MODULE)
 		ERROR_LOG(HLE, "sceKernelGetModuleIdByAddress(%08x): module not found", moduleAddr)
 	else
 		DEBUG_LOG(HLE, "%x=sceKernelGetModuleIdByAddress(%08x)", state.result, moduleAddr);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -41,7 +41,7 @@
 typedef struct
 {
 	WaitType type;
-	char* name;
+	const char *name;
 } WaitTypeNames;
 
 const WaitTypeNames waitTypeNames[] = {
@@ -68,7 +68,7 @@ const WaitTypeNames waitTypeNames[] = {
 	{ WAITTYPE_HLEDELAY,		"HleDelay" }
 };
 
-char* getWaitTypeName(WaitType type)
+const char *getWaitTypeName(WaitType type)
 {
 	int waitTypeNamesAmount = sizeof(waitTypeNames)/sizeof(WaitTypeNames);
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -96,7 +96,7 @@ enum WaitType
 	NUM_WAITTYPES
 };
 
-char* getWaitTypeName(WaitType type);
+const char *getWaitTypeName(WaitType type);
 
 // Suspend wait and timeout while a thread enters a callback.
 typedef void (* WaitBeginCallbackFunc)(SceUID threadID, SceUID prevCallbackId);

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -441,5 +441,5 @@ u32 sceKernelReferVTimerStatus(u32 uid, u32 statusAddr) {
 
 // Not sure why this is exposed...
 void _sceKernelReturnFromTimerHandler() {
-	ERROR_LOG(HLE,"_sceKernelReturnFromTimerHandler - should not be called!");
+	ERROR_LOG_REPORT(HLE,"_sceKernelReturnFromTimerHandler - should not be called!");
 }

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -114,7 +114,7 @@ public:
 	void DoState(PointerWrap &p);
 	
 	bool isValidCurrentStreamNumber() {
-		return currentStreamNum >= 0 && currentStreamNum < streamMap.size();  // urgh, checking size isn't really right here.
+		return currentStreamNum >= 0 && currentStreamNum < (int)streamMap.size();  // urgh, checking size isn't really right here.
 	}
 
 	void setStreamNum(int num);
@@ -467,7 +467,7 @@ u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
 	return psmf->numStreams;
 }
 
-u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, u32 streamType)
+u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -630,7 +630,7 @@ u32 scePsmfGetPsmfVersion(u32 psmfStruct)
 
 u32 scePsmfVerifyPsmf(u32 psmfAddr)
 {
-	int magic = Memory::Read_U32(psmfAddr);
+	u32 magic = Memory::Read_U32(psmfAddr);
 	if (magic != PSMF_MAGIC) {
 		ERROR_LOG(HLE, "scePsmfVerifyPsmf(%08x): bad magic %08x", psmfAddr, magic);
 		return ERROR_PSMF_NOT_FOUND;
@@ -1263,7 +1263,7 @@ const HLEFunction scePsmf[] = {
 	{0x0BA514E5, WrapU_UU<scePsmfGetVideoInfo>, "scePsmfGetVideoInfo"},
 	{0xA83F7113, WrapU_UU<scePsmfGetAudioInfo>, "scePsmfGetAudioInfo"},
 	{0x971A3A90, WrapU_U<scePsmfCheckEPMap>, "scePsmfCheckEPmap"},
-	{0x68d42328, WrapU_UU<scePsmfGetNumberOfSpecificStreams>, "scePsmfGetNumberOfSpecificStreams"},
+	{0x68d42328, WrapU_UI<scePsmfGetNumberOfSpecificStreams>, "scePsmfGetNumberOfSpecificStreams"},
 	{0x5b70fcc1, WrapU_UU<scePsmfQueryStreamOffset>, "scePsmfQueryStreamOffset"},
 	{0x9553cc91, WrapU_UU<scePsmfQueryStreamSize>, "scePsmfQueryStreamSize"},
 	{0xB78EB9E9, WrapU_UU<scePsmfGetHeaderSize>, "scePsmfGetHeaderSize"},

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -229,7 +229,7 @@ int MpegDemux::getNextaudioFrame(u8** buf, int *headerCode1, int *headerCode2)
 		return 0;
 	u8 Code1 = m_audioFrame[2];
 	u8 Code2 = m_audioFrame[3];
-	int frameSize = ((Code1 & 0x03) << 8) | (Code2 & 0xFF) * 8 + 0x10;
+	int frameSize = (((Code1 & 0x03) << 8) | ((Code2 & 0xFF) * 8)) + 0x10;
 	if (frameSize > gotsize)
 		return 0;
 	int audioPos = 8;

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -134,7 +134,7 @@ int convertStreamtoOMA(u8* audioStream, int audioSize, u8** outputStream)
 		return 0;
 	}
 
-	int frameSize = ((headerCode1 & 0x03) << 8) | (headerCode2 & 0xFF) * 8 + 0x10;
+	int frameSize = (((headerCode1 & 0x03) << 8) | ((headerCode2 & 0xFF) * 8)) + 0x10;
 	int numCompleteFrames = audioSize / (frameSize + 8);
 	int lastFrameSize = audioSize - (numCompleteFrames * (frameSize + 8));
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -687,14 +687,14 @@ static int getExpCurveAt(int index, int duration) {
 
 ADSREnvelope::ADSREnvelope()
 	: 	attackRate(0),
-		attackType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
 		decayRate(0),
-		decayType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
 		sustainRate(0),
-		sustainType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
 		releaseRate(0),
-		releaseType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
+		attackType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
+		decayType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
+		sustainType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
 		sustainLevel(0x100),
+		releaseType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
 		state_(STATE_OFF),
 		steps_(0),
 		height_(0) {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -72,7 +72,7 @@ void InitMemoryForGameISO(std::string fileToStart) {
 		{
 			gameID = g_paramSFO.GetValueString("DISC_ID");
 
-			for(int i = 0; i < ARRAY_SIZE(g_HDRemasters); i++) {
+			for (size_t i = 0; i < ARRAY_SIZE(g_HDRemasters); i++) {
 				if(g_HDRemasters[i].gameID == gameID) {
 					g_RemasterMode = true;
 					Memory::g_MemorySize = g_HDRemasters[i].MemorySize;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -255,6 +255,7 @@ namespace SaveState
 
 			default:
 				ERROR_LOG(COMMON, "Savestate failure: unknown operation type %d", op.type);
+				result = false;
 				break;
 			}
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -71,7 +71,7 @@ Shader::~Shader() {
 }
 
 LinkedShader::LinkedShader(Shader *vs, Shader *fs, bool useHWTransform)
-		: program(0), dirtyUniforms(0), useHWTransform_(useHWTransform) {
+		: useHWTransform_(useHWTransform), program(0), dirtyUniforms(0) {
 	program = glCreateProgram();
 	glAttachShader(program, vs->shader);
 	glAttachShader(program, fs->shader);

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -945,10 +945,8 @@ void TextureCache::SetTexture() {
 	bool hasClut = (format & 4) != 0;
 
 	u64 cachekey = (u64)texaddr << 32;
-
-	u32 clutformat, cluthash;
+	u32 cluthash;
 	if (hasClut) {
-		clutformat = gstate.clutformat & 3;
 		if (clutLastFormat_ != gstate.clutformat) {
 			// We update here because the clut format can be specified after the load.
 			UpdateCurrentClut();
@@ -956,7 +954,6 @@ void TextureCache::SetTexture() {
 		cluthash = GetCurrentClutHash() ^ gstate.clutformat;
 		cachekey |= cluthash;
 	} else {
-		clutformat = 0;
 		cluthash = 0;
 	}
 

--- a/GPU/GLES/TextureScaler.cpp
+++ b/GPU/GLES/TextureScaler.cpp
@@ -526,7 +526,7 @@ TextureScaler::TextureScaler() {
 
 bool TextureScaler::IsEmptyOrFlat(u32* data, int pixels, GLenum fmt) {
 	int pixelsPerWord = (fmt == GL_UNSIGNED_BYTE) ? 1 : 2;
-	int ref = data[0];
+	u32 ref = data[0];
 	for(int i=0; i<pixels/pixelsPerWord; ++i) {
 		if(data[i]!=ref) return false;
 	}

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -676,10 +676,20 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 						source = Vec3(ruv[0], ruv[1], 0.0f);
 						break;
 					case 2: // Use normalized normal as source
-						source = Vec3(norm).Normalized();
+						if (reader.hasNormal()) {
+							source = Vec3(norm).Normalized();
+						} else {
+							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
+							source = Vec3(0.0f);
+						}
 						break;
 					case 3: // Use non-normalized normal as source!
-						source = Vec3(norm);
+						if (reader.hasNormal()) {
+							source = Vec3(norm);
+						} else {
+							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
+							source = Vec3(0.0f);
+						}
 						break;
 					}
 

--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -20,6 +20,7 @@
 #include "../GPUState.h"
 #include "../Globals.h"
 #include "base/basictypes.h"
+#include "Core/Reporting.h"
 
 // DecVtxFormat - vertex formats for PC
 // Kind of like a D3D VertexDeclaration.
@@ -252,7 +253,8 @@ public:
 			}
 			break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported Pos Format");
+			ERROR_LOG_REPORT_ONCE(fmt, G3D, "Reader: Unsupported Pos Format %d", decFmt_.posfmt);
+			memset(pos, 0, sizeof(pos));
 			break;
 		}
 	}
@@ -282,7 +284,8 @@ public:
 			}
 			break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported Nrm Format");
+			ERROR_LOG_REPORT_ONCE(fmt, G3D, "Reader: Unsupported Nrm Format %d", decFmt_.nrmfmt);
+			memset(nrm, 0, sizeof(nrm));
 			break;
 		}
 	}
@@ -321,7 +324,8 @@ public:
 			}
 			break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported UV Format");
+			ERROR_LOG_REPORT_ONCE(fmt, G3D, "Reader: Unsupported UV Format %d", decFmt_.uvfmt);
+			memset(uv, 0, sizeof(uv));
 			break;
 		}
 	}
@@ -339,7 +343,8 @@ public:
 			memcpy(color, data_ + decFmt_.c0off, 16); 
 			break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported C0 Format");
+			ERROR_LOG_REPORT_ONCE(fmt, G3D, "Reader: Unsupported C0 Format %d", decFmt_.c0fmt);
+			memset(color, 0, sizeof(color));
 			break;
 		}
 	}
@@ -357,7 +362,8 @@ public:
 			memcpy(color, data_ + decFmt_.c1off, 12); 
 			break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported C1 Format");
+			ERROR_LOG_REPORT_ONCE(fmt, G3D, "Reader: Unsupported C1 Format %d", decFmt_.c0fmt);
+			memset(color, 0, sizeof(color));
 			break;
 		}
 	}
@@ -383,7 +389,8 @@ public:
 		case DEC_U16_3: for (int i = 0; i < 3; i++) weights[i] = s[i] * (1.f / 32768.f); break;
 		case DEC_U16_4: for (int i = 0; i < 4; i++) weights[i] = s[i] * (1.f / 32768.f); break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported W0 Format");
+			ERROR_LOG_REPORT_ONCE(fmt0, G3D, "Reader: Unsupported W0 Format %d", decFmt_.w0fmt);
+			weights[0] = 0.0f;
 			break;
 		}
 
@@ -410,7 +417,8 @@ public:
 		case DEC_U16_3: for (int i = 0; i < 3; i++) weights[i+4] = s[i] * (1.f / 32768.f); break;
 		case DEC_U16_4: for (int i = 0; i < 4; i++) weights[i+4] = s[i]  * (1.f / 32768.f); break;
 		default:
-			ERROR_LOG(G3D, "Reader: Unsupported W1 Format");
+			ERROR_LOG_REPORT_ONCE(fmt1, G3D, "Reader: Unsupported W1 Format %d", decFmt_.w1fmt);
+			weights[4] = 0.0f;
 			break;
 		}
 	}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -316,7 +316,7 @@ void EmuScreen::update(InputState &input) {
 		UpdateGamepad(fakeInputState);
 		UpdateInputState(&fakeInputState);
 
-		for (int i = 0; i < ARRAY_SIZE(legacy_touch_mapping); i++) {
+		for (size_t i = 0; i < ARRAY_SIZE(legacy_touch_mapping); i++) {
 			if (fakeInputState.pad_buttons_down & legacy_touch_mapping[i].from)
 				__CtrlButtonDown(legacy_touch_mapping[i].to);
 			if (fakeInputState.pad_buttons_up & legacy_touch_mapping[i].from)

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -181,7 +181,7 @@ void PathBrowser::Navigate(const std::string &path) {
 		if (path_.size() == 3 && path_[1] == ':') {
 			path_ = "/";
 		} else {
-			int slash = path_.rfind('/', path_.size() - 2);
+			size_t slash = path_.rfind('/', path_.size() - 2);
 			if (slash != std::string::npos)
 				path_ = path_.substr(0, slash + 1);
 		}
@@ -212,9 +212,8 @@ private:
 	UI::EventReturn GameButtonClick(UI::EventParams &e);
 	UI::EventReturn NavigateClick(UI::EventParams &e);
 
-
-	bool allowBrowsing_;
 	PathBrowser path_;
+	bool allowBrowsing_;
 };
 
 GameBrowser::GameBrowser(std::string path, bool allowBrowsing, UI::LayoutParams *layoutParams) 

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1079,6 +1079,7 @@ void GraphicsScreenP3::render() {
 		case 1: type = gs->T("Display: Speed"); break;
 		case 2:	type = gs->T("Display: FPS"); break;
 		case 3: type = gs->T("Display: Both"); break;
+		default: type = ""; break;
 		}
 
 		ui_draw2d.DrawText(UBUNTU24, type, x + 60, y += stride , 0xFFFFFFFF, ALIGN_LEFT);
@@ -1159,7 +1160,6 @@ void LanguageScreen::render() {
 
 	I18NCategory *s = GetI18NCategory("System");
 	I18NCategory *g = GetI18NCategory("General");
-	I18NCategory *l = GetI18NCategory("Language");
 
 	bool small = dp_xres < 790;
 
@@ -1251,7 +1251,6 @@ void LanguageScreen::render() {
 				// After this, g and s are no longer valid. Let's return, some flicker is okay.
 				g = GetI18NCategory("General");
 				s = GetI18NCategory("System");
-				l = GetI18NCategory("Language");
 			} else {
 				g_Config.languageIni = oldLang;
 			}


### PR DESCRIPTION
The one I'm a little unsure about is f56802453eac08cf7e3be875cb8853fe414a7b33, but I think it's correct.

This makes things much closer to warning free.  There's an incorrect (afaict) warning in `SoftwareTransformAndDraw()`, 2 in snappy, 1 in native, and a multiline comment warning.  There's more with clang but meh.

There's also the imported thing with ffmpeg on Windows, but I dunno why.

-[Unknown]
