### PR TITLE
Initial VTimer fixes

### DIFF
--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -394,7 +394,7 @@ int sceKernelCreateMutex(const char *name, u32 attr, int initialCount, u32 optio
 	if (optionsPtr != 0)
 	{
 		u32 size = Memory::Read_U32(optionsPtr);
-		if (size != 0)
+		if (size > 4)
 			WARN_LOG_REPORT(HLE, "sceKernelCreateMutex(%s) unsupported options parameter, size = %d", name, size);
 	}
 	if ((attr & ~PSP_MUTEX_ATTR_KNOWN) != 0)
@@ -751,7 +751,7 @@ int sceKernelCreateLwMutex(u32 workareaPtr, const char *name, u32 attr, int init
 	if (optionsPtr != 0)
 	{
 		u32 size = Memory::Read_U32(optionsPtr);
-		if (size != 0)
+		if (size > 4)
 			WARN_LOG_REPORT(HLE, "sceKernelCreateLwMutex(%s) unsupported options parameter, size = %d", name, size);
 	}
 	if ((attr & ~PSP_MUTEX_ATTR_KNOWN) != 0)

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -292,7 +292,7 @@ int sceKernelCreateSema(const char* name, u32 attr, int initVal, int maxVal, u32
 	if (optionPtr != 0)
 	{
 		u32 size = Memory::Read_U32(optionPtr);
-		if (size != 0)
+		if (size > 4)
 			WARN_LOG_REPORT(HLE, "sceKernelCreateSema(%s) unsupported options parameter, size = %d", name, size);
 	}
 	if ((attr & ~PSP_SEMA_ATTR_PRIORITY) != 0)

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -383,7 +383,10 @@ u32 sceKernelStopVTimer(u32 uid) {
 }
 
 u32 sceKernelSetVTimerHandler(u32 uid, u32 scheduleAddr, u32 handlerFuncAddr, u32 commonAddr) {
-	DEBUG_LOG(HLE, "sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x)", uid, scheduleAddr, handlerFuncAddr, commonAddr);
+	if (uid == 0) {
+		WARN_LOG(HLE, "sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x): invalid vtimer", uid, scheduleAddr, handlerFuncAddr, commonAddr);
+		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+	}
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
@@ -393,9 +396,12 @@ u32 sceKernelSetVTimerHandler(u32 uid, u32 scheduleAddr, u32 handlerFuncAddr, u3
 		return error;
 	}
 
+	DEBUG_LOG(HLE, "sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x)", uid, scheduleAddr, handlerFuncAddr, commonAddr);
+
 	u64 schedule = Memory::Read_U64(scheduleAddr);
 	vt->nvt.handlerAddr = handlerFuncAddr;
-	vt->nvt.commonAddr = commonAddr;
+	if (handlerFuncAddr)
+		vt->nvt.commonAddr = commonAddr;
 
 	__KernelScheduleVTimer(vt, schedule);
 
@@ -403,7 +409,10 @@ u32 sceKernelSetVTimerHandler(u32 uid, u32 scheduleAddr, u32 handlerFuncAddr, u3
 }
 
 u32 sceKernelSetVTimerHandlerWide(u32 uid, u64 schedule, u32 handlerFuncAddr, u32 commonAddr) {
-	DEBUG_LOG(HLE, "sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x)", uid, schedule, handlerFuncAddr, commonAddr);
+	if (uid == 0) {
+		WARN_LOG(HLE, "sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x): invalid vtimer", uid, schedule, handlerFuncAddr, commonAddr);
+		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+	}
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
@@ -413,8 +422,11 @@ u32 sceKernelSetVTimerHandlerWide(u32 uid, u64 schedule, u32 handlerFuncAddr, u3
 		return error;
 	}
 
+	DEBUG_LOG(HLE, "sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x)", uid, schedule, handlerFuncAddr, commonAddr);
+
 	vt->nvt.handlerAddr = handlerFuncAddr;
-	vt->nvt.commonAddr = commonAddr;
+	if (handlerFuncAddr)
+		vt->nvt.commonAddr = commonAddr;
 
 	__KernelScheduleVTimer(vt, schedule);
 

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -89,8 +89,7 @@ void __KernelScheduleVTimer(VTimer *vt, u64 schedule) {
 	vt->nvt.schedule = schedule;
 
 	if (vt->nvt.active == 1 && vt->nvt.handlerAddr != 0)
-		// this delay makes the test pass, not sure if it's right
-		CoreTiming::ScheduleEvent(usToCycles(vt->nvt.schedule + 372), vtimerTimer, vt->GetUID());
+		CoreTiming::ScheduleEvent(usToCycles(vt->nvt.schedule), vtimerTimer, vt->GetUID());
 }
 
 void __rescheduleVTimer(SceUID id, int delay) {

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -177,9 +177,11 @@ void __KernelVTimerInit() {
 }
 
 u32 sceKernelCreateVTimer(const char *name, u32 optParamAddr) {
+	if (!name) {
+		WARN_LOG_REPORT(HLE, "%08x=sceKernelCreateVTimer(): invalid name", SCE_KERNEL_ERROR_ERROR);
+		return SCE_KERNEL_ERROR_ERROR;
+	}
 	DEBUG_LOG(HLE, "sceKernelCreateVTimer(%s, %08x)", name, optParamAddr);
-	if (optParamAddr != 0)
-		WARN_LOG_REPORT(HLE, "sceKernelCreateVTimer: unsupported options parameter %08x", optParamAddr);
 
 	VTimer *vtimer = new VTimer;
 	SceUID id = kernelObjects.Create(vtimer);
@@ -189,6 +191,12 @@ u32 sceKernelCreateVTimer(const char *name, u32 optParamAddr) {
 	strncpy(vtimer->nvt.name, name, KERNELOBJECT_MAX_NAME_LENGTH);
 	vtimer->nvt.name[KERNELOBJECT_MAX_NAME_LENGTH] = '\0';
 	vtimer->memoryPtr = 0;
+
+	if (optParamAddr != 0) {
+		u32 size = Memory::Read_U32(optParamAddr);
+		if (size > 4)
+			WARN_LOG_REPORT(HLE, "sceKernelCreateVTimer(%s) unsupported options parameter, size = %d", name, size);
+	}
 
 	return id;
 }

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -102,9 +102,7 @@ void __rescheduleVTimer(SceUID id, int delay) {
 	if (delay < 0)
 		delay = 100;
 
-	u64 schedule = vt->nvt.schedule + delay;
-
-	__KernelScheduleVTimer(vt, schedule);
+	__KernelScheduleVTimer(vt, delay);
 }
 
 class VTimerIntrHandler : public IntrHandler
@@ -336,8 +334,7 @@ void __startVTimer(VTimer *vt) {
 	vt->nvt.active = 1;
 	vt->nvt.base = cyclesToUs(CoreTiming::GetTicks());
 
-	// Checking for zero here breaks audio in Monster Hunter. It still doesn't work well though.
-	if (/*vt->nvt.schedule != 0 &&*/ vt->nvt.handlerAddr != 0)
+	if (vt->nvt.handlerAddr != 0)
 		__KernelScheduleVTimer(vt, vt->nvt.schedule);
 }
 


### PR DESCRIPTION
I have more tests to write, but these changes look pretty relevant, and I think they are responsible for the delay in sound for Monster Hunter.

A few notes:
- The "common" parameter is not changed when setting the handler to NULL.  Could matter if it does NULL, NULL.
- The return value of the handler is _not_ offset by the previous schedule, e.g. if the schedule was 400 and it returns 100, it runs in another 100us, not in 500us.
- There's no good reason to delay by an arbitrary 372us, which is going to depend on a bunch of things.  Will have to adjust test (tests that have to do with timing and cycles are annoying since our cycles are not 100% accurate.)
- The handler definitely does run even with a schedule of 0.

I did test this against the (few) games that link the VTimer funcs in, but nothing really changed in them, which is good.

-[Unknown]
