### PR TITLE
Fix render-to-texture sizing in SW T&L

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -725,9 +725,19 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		memcpy(&transformed[index].x, v, 3 * sizeof(float));
 		transformed[index].fog = fogCoef;
 		memcpy(&transformed[index].u, uv, 3 * sizeof(float));
+		int w = 1 << (gstate.texsize[0] & 0xf);
+		int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
 
-		if (gstate_c.flipTexture) 
-			transformed[index].v = 1.0f - transformed[index].v;
+		if (gstate_c.flipTexture) {
+				if (throughmode) {
+					transformed[index].v = 1.0f - transformed[index].v;
+				} else {
+					int widthFactor = gstate_c.curTextureWidth/w ;
+					int heightFactor = gstate_c.curTextureHeight/h;
+					transformed[index].u = transformed[index].u / widthFactor ;
+					transformed[index].v = 1.0f - transformed[index].v / heightFactor;
+				}
+		}
 
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -521,6 +521,11 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		vscale /= gstate_c.curTextureHeight;
 	}
 
+	int w = 1 << (gstate.texsize[0] & 0xf);
+	int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
+	float widthFactor = (float) w / (float) gstate_c.curTextureWidth;
+	float heightFactor = (float) h / (float) gstate_c.curTextureHeight;
+
 	Lighter lighter;
 	float fog_end = getFloat24(gstate.fog1);
 	float fog_slope = getFloat24(gstate.fog2);
@@ -725,20 +730,14 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		memcpy(&transformed[index].x, v, 3 * sizeof(float));
 		transformed[index].fog = fogCoef;
 		memcpy(&transformed[index].u, uv, 3 * sizeof(float));
-		int w = 1 << (gstate.texsize[0] & 0xf);
-		int h = 1 << ((gstate.texsize[0] >> 8) & 0xf);
-
 		if (gstate_c.flipTexture) {
 				if (throughmode) {
 					transformed[index].v = 1.0f - transformed[index].v;
 				} else {
-					int widthFactor = gstate_c.curTextureWidth/w ;
-					int heightFactor = gstate_c.curTextureHeight/h;
-					transformed[index].u = transformed[index].u / widthFactor ;
-					transformed[index].v = 1.0f - transformed[index].v / heightFactor;
+					transformed[index].u = transformed[index].u * (float) widthFactor ;
+					transformed[index].v = 1.0f - transformed[index].v * (float) heightFactor;
 				}
 		}
-
 		for (int i = 0; i < 4; i++) {
 			transformed[index].color0[i] = c0[i] * 255.0f;
 		}


### PR DESCRIPTION
It basically make render-to-texture correct at least in these 2 games . 
1. FF Type-0 (Title scren - bloom effect)
   ![screen00001](https://f.cloud.github.com/assets/3000282/770024/faa1c71a-e8c3-11e2-9979-f31a5e1fdd61.png)
2. Yu-Gi-Oh! 5D's Tag Force 6 (incorrect playing card sizing)
   ![screen00002](https://f.cloud.github.com/assets/3000282/770027/17fb1104-e8c4-11e2-99fa-76ef4d06a20d.png)
