### PR TITLE
Highlight disabled breakpoints and use font sizes in more controls

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -78,6 +78,14 @@ bool CBreakPoints::IsAddressBreakPoint(u32 addr)
 	return bp != INVALID_BREAKPOINT && breakPoints_[bp].enabled;
 }
 
+bool CBreakPoints::IsAddressBreakPoint(u32 addr, bool* enabled)
+{
+	size_t bp = FindBreakpoint(addr);
+	if (bp == INVALID_BREAKPOINT) return false;
+	if (enabled != NULL) *enabled = breakPoints_[bp].enabled;
+	return true;
+}
+
 bool CBreakPoints::IsTempBreakPoint(u32 addr)
 {
 	size_t bp = FindBreakpoint(addr, true, true);

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -100,6 +100,7 @@ public:
 	static const size_t INVALID_MEMCHECK = -1;
 
 	static bool IsAddressBreakPoint(u32 addr);
+	static bool IsAddressBreakPoint(u32 addr, bool* enabled);
 	static bool IsTempBreakPoint(u32 addr);
 	static void AddBreakPoint(u32 addr, bool temp = false);
 	static void RemoveBreakPoint(u32 addr);

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -128,11 +128,7 @@ public:
 		showHex=s;
 	}
 
-	void toggleBreakpoint()
-	{
-		debugger->toggleBreakpoint(curAddress);
-		redraw();
-	}
+	void toggleBreakpoint();
 
 	void scrollWindow(int lines)
 	{

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -5,6 +5,7 @@
 
 #include "../../globals.h"
 
+#include "Core/Config.h"
 #include "../resource.h"
 #include "../../Core/MemMap.h"
 #include "../W32Util/Misc.h"
@@ -24,14 +25,17 @@ CtrlMemView::CtrlMemView(HWND _wnd)
   SetWindowLongPtr(wnd, GWLP_USERDATA, (LONG)this);
   SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
   SetScrollRange(wnd, SB_VERT, -1,1,TRUE);
+
+  rowHeight = g_Config.iFontHeight;
+  charWidth = g_Config.iFontWidth;
+
   font =
-	  CreateFont(12,8,0,0,FW_DONTCARE,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,
-		"Lucida Console");
+	  CreateFont(rowHeight,charWidth,0,0,FW_DONTCARE,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,
+		  CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,"Lucida Console");
   underlineFont =
-	  CreateFont(12,8,0,0,FW_DONTCARE,FALSE,TRUE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,
-		"Lucida Console");
+	  CreateFont(rowHeight,charWidth,0,0,FW_DONTCARE,FALSE,TRUE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,
+		  CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,"Lucida Console");
   curAddress=0;
-  rowHeight=12;
   mode=MV_NORMAL;
   debugger = 0;
   
@@ -41,7 +45,6 @@ CtrlMemView::CtrlMemView(HWND _wnd)
 	asciiSelected = false;
 
 	selectedNibble = 0;
-	charWidth = 8;
 	rowSize = 16;
 	addressStart = charWidth;
 	hexStart = addressStart + 9*charWidth;

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -11,6 +11,7 @@
 #include "CtrlRegisterList.h"
 #include "Debugger_MemoryDlg.h"
 
+#include "Core/Config.h"
 #include "../../globals.h"
 #include "Debugger_Disasm.h"
 #include "DebuggerShared.h"
@@ -127,9 +128,11 @@ CtrlRegisterList::CtrlRegisterList(HWND _wnd)
 	SetWindowLongPtr(wnd, GWLP_USERDATA, (LONG_PTR)this);
 	//SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
 	//SetScrollRange(wnd, SB_VERT, -1,1,TRUE);
-	font = CreateFont(12,0,0,0,FW_DONTCARE,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,
-		"Lucida Console");
-	rowHeight=12;
+	
+	rowHeight=g_Config.iFontHeight;
+
+	font = CreateFont(rowHeight,g_Config.iFontWidth,0,0,FW_DONTCARE,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,
+		DEFAULT_QUALITY,DEFAULT_PITCH,"Lucida Console");
 	selecting=false;
 	selection=0;
 	category=0;


### PR DESCRIPTION
Puts a previously unused icon to use to highlight disabled breakpoints in the disassembly view. Toggling them will re-enable them, and toggling a breakpoint with an enabled condition will ask for a confirmation (as they aren't as simple to recreate than those without a condition).
Also makes the memory viewer and register list use the configurable font size.
![psp8](https://f.cloud.github.com/assets/4809758/773706/e300c6b0-e940-11e2-87fa-e156b472b0bc.png)
