### PR TITLE
Remove relative gl_common.h include directives

### DIFF
--- a/GPU/GLES/StateMapping.h
+++ b/GPU/GLES/StateMapping.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#include "../native/gfx/gl_common.h"
+#include "gfx/gl_common.h"

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "../Globals.h"
-#include "../native/gfx/gl_common.h"
+#include "gfx/gl_common.h"
 #include "ge_constants.h"
 
 struct GPUgstate


### PR DESCRIPTION
I've started to work on a PPSSPP core for [OpenEmu](https://github.com/OpenEmu/OpenEmu) over here: https://github.com/PGGB/PPSSPP-Core

As we don't use GLEW I use a [modified gl_common.h](https://github.com/PGGB/PPSSPP-Core/blob/master/gfx/gl_common.h), so we can have the PPSSPP source simply as a submodule. The two files I modified in this pull request are the exception to this as they use a relative include directive.

Thanks a lot for the amazing work you've been doing. I hope we will be able to provide a great way to use PPSSPP on OS X.
