### PR TITLE
Win32 UI: Add INI option to enable fullscreen on emulator launch

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -113,6 +113,7 @@ void Config::Load(const char *iniFileName)
 	graphics->Get("VertexCache", &bVertexCache, true);
 #ifdef _WIN32
 	graphics->Get("FullScreen", &bFullScreen, false);
+	graphics->Get("FullScreenOnLaunch", &bFullScreenOnLaunch, false);
 #endif
 #ifdef BLACKBERRY
 	graphics->Get("PartialStretch", &bPartialStretch, pixel_xres == pixel_yres);
@@ -233,6 +234,7 @@ void Config::Save()
 		graphics->Set("VertexCache", bVertexCache);
 #ifdef _WIN32
 		graphics->Set("FullScreen", bFullScreen);
+		graphics->Set("FullScreenOnLaunch", &bFullScreenOnLaunch);
 #endif		
 #ifdef BLACKBERRY
 		graphics->Set("PartialStretch", bPartialStretch);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -80,6 +80,9 @@ public:
 	bool SSAntiAliasing; // for Windows, too
 	bool bVertexCache;
 	bool bFullScreen;
+#ifdef _WIN32
+	bool bFullScreenOnLaunch;
+#endif
 	int iAnisotropyLevel;
 	bool bTrueColor;
 	bool bFramebuffersToMem;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -272,6 +272,9 @@ namespace MainWindow
 
 		Update();
 		SetPlaying(0);
+
+		if(g_Config.bFullScreenOnLaunch)
+			_ViewFullScreen(hwndMain);
 		
 		ShowWindow(hwndMain, nCmdShow);
 


### PR DESCRIPTION
I was initially thinking of using a command line argument, but it didn't seem to respond in NativeInit(wrong place?), so I went with the next best thing, an INI option. Thoughts?
