### PR TITLE
Minor tweaks

### DIFF
--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -77,7 +77,6 @@ struct PSPFileInfo
 		p.Do(isOnSectorSystem);
 		p.Do(startSector);
 		p.Do(numSectors);
-		p.Do(fpointer);
 		p.Do(sectorSize);
 		p.DoMarker("PSPFileInfo");
 	}
@@ -95,7 +94,6 @@ struct PSPFileInfo
 	bool isOnSectorSystem;
 	u32 startSector;
 	u32 numSectors;
-	u32 fpointer;
 	u32 sectorSize;
 };
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -304,7 +304,8 @@ void GameInfoCache::Decimate() {
 }
 
 void GameInfoCache::Clear() {
-	gameInfoWQ_->Flush();
+	if (gameInfoWQ_)
+		gameInfoWQ_->Flush();
 	for (auto iter = info_.begin(); iter != info_.end(); iter++) {
 		lock_guard lock(iter->second->lock);
 		if (!iter->second->pic0TextureData.empty()) {

--- a/ext/snappy/snappy-stubs-internal.h
+++ b/ext/snappy/snappy-stubs-internal.h
@@ -47,7 +47,7 @@
 
 #include "snappy-stubs-public.h"
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(_M_X64)
 
 // Enable 64-bit optimized versions of some routines.
 #define ARCH_K8 1
@@ -98,7 +98,11 @@ static const int64 kint64max = static_cast<int64>(0x7FFFFFFFFFFFFFFFLL);
 
 // x86 and PowerPC can simply do these loads and stores native.
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__)
+#if defined(_M_IX86) && defined(_MSC_VER) && !defined(ARM) && !defined(MIPS)
+#define __i386__ 1
+#endif
+
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || defined(_M_X64)
 
 #define UNALIGNED_LOAD16(_p) (*reinterpret_cast<const uint16 *>(_p))
 #define UNALIGNED_LOAD32(_p) (*reinterpret_cast<const uint32 *>(_p))


### PR DESCRIPTION
Fixes #2741 (would crash on any early exit), enables x64 optimizations in Snappy on x64 Windows, remove some dead code.

-[Unknown]
