### PR TITLE
MenuScreens: Add +/-10 VPS/Speed buttons under "Toggled Speed Limit".

### DIFF
--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1196,8 +1196,12 @@ void GraphicsScreenP3::render() {
 			if(g_Config.iFpsLimit > 10)
 				g_Config.iFpsLimit -= 1;
 		if (UIButton(GEN_ID, hlinear1, 50, 0, gs->T("+1"), ALIGN_LEFT))
-			if(g_Config.iFrameSkip < 240)
 				g_Config.iFpsLimit += 1;
+		if (UIButton(GEN_ID, hlinear1, 65, 0, gs->T("-10"), ALIGN_LEFT))
+			if(g_Config.iFpsLimit > 10)
+				g_Config.iFpsLimit -= 10;
+		if (UIButton(GEN_ID, hlinear1, 65, 0, gs->T("+10"), ALIGN_LEFT))
+				g_Config.iFpsLimit += 10;
 
 		y += 20;
 	} else 


### PR DESCRIPTION
And also remove the upper limit. Why was it set at 240, anyway?

![Picture](https://i.minus.com/ibqBpKgMSmgpY9.jpg)
