### PR TITLE
Fix YES/NO selection color in save dialog

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -499,7 +499,7 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 		float y2 = y + h2 + 4.0f;
 		h2 += h + 4.0f;
 		y = 132.0f - h;
-		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x65636358));
+		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x40C0C0C0));
 		PPGeDrawText(d->T("Yes"), 302.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
 		PPGeDrawText(d->T("No"), 366.0f, y2, PPGE_ALIGN_CENTER, FONT_SCALE, CalcFadedColor(noColor));
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {


### PR DESCRIPTION
Before
![screen00032](https://f.cloud.github.com/assets/3000282/792882/7a82ede6-ebcc-11e2-95f9-d9735b6fabd1.jpg)

After
![screen00031](https://f.cloud.github.com/assets/3000282/792881/77d6f8a8-ebcc-11e2-96d1-f06b1474bbe4.jpg)
