### PR TITLE
Fix depth issues in multiple games

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -221,7 +221,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		if (gstate.isDepthTestEnabled()) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(depthMask ? GL_TRUE : GL_FALSE);
+			glstate.depthWrite.set(depthMask || !gstate.isFogEnabled() || !gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
 		} else {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);


### PR DESCRIPTION
Finally fixes all the depth issues in Saint Seiya Omega , Gundam AGE Universe while not breaking Ridge Racer 2 .

![screen00039](https://f.cloud.github.com/assets/3000282/793237/1c08417c-ebee-11e2-9d4b-f15968f4f544.jpg)

![screen00038](https://f.cloud.github.com/assets/3000282/793238/2012bc7a-ebee-11e2-9c96-cd8ddff9c269.jpg)

![screen00041](https://f.cloud.github.com/assets/3000282/793266/fb4f22e0-ebf0-11e2-9a3d-a4856cbbb7c2.jpg)

![screen00042](https://f.cloud.github.com/assets/3000282/793267/ff4dc77a-ebf0-11e2-8b50-e6c802ef5296.jpg)

![screen00040](https://f.cloud.github.com/assets/3000282/793239/22955f0c-ebee-11e2-9985-e8d3fbbf893b.jpg)
