### PR TITLE
HD Remasters: Fix Shin Sangoku Texture size issue.

### DIFF
--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -42,7 +42,6 @@ const struct HDRemaster g_HDRemasters[] = {
 { "NPJB40002", 0x4000000, true }, // K-ON Houkago Live HD Ver
 { "BLJM85003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
 { "NPJB40003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-{ "NPJB00274", 0x4000000, false }, //Dynasty Warriors Strikeforce 2 HD Edition (JP)
 { "BLJM85004", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition, this one is never used
 // deactivated because it also affects the UMD version of the game
 // TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -24,6 +24,7 @@
 // We keep it set to false by default in PSPLoaders.cpp
 // in order to keep the 99% of other PSP games working happily.
 extern bool g_RemasterMode;
+
 extern bool g_DoubleTextureCoordinates;
 
 struct HDRemaster {
@@ -32,27 +33,13 @@ struct HDRemaster {
 	bool DoubleTextureCoordinates;
 };
 
-// TODO: Are those BLJM* IDs really valid? They seem to be the physical PS3 disk IDs,
-// but they're included for safety.
-// TODO: Do all of the remasters aside from Monster Hunter use double texture coordinates?
-// TODO: Are all remasters happy with this end address?
+// TODO: Use UMD_DATA.bin to differentiate the Eiyuu games from the regular PSP editions.
+// TODO: Do all of the remasters aside from Monster Hunter/Shin Sangoku use double texture coordinates?
 const struct HDRemaster g_HDRemasters[] = {
 { "NPJB40001", 0x4000000, false }, // MONSTER HUNTER PORTABLE 3rd HD Ver.
-{ "BLJM85002", 0x4000000, true }, // K-ON Houkago Live HD Ver
 { "NPJB40002", 0x4000000, true }, // K-ON Houkago Live HD Ver
-{ "BLJM85003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
 { "NPJB40003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-{ "BLJM85004", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition, this one is never used
-// deactivated because it also affects the UMD version of the game
-// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
 // { "ULJM05170", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
-{ "BLJM85005", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, this one is never used
-// deactivated because it also affects the UMD version of the game
-// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
 // { "ULJM05277", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, game needs 76 MB
-{ "BLJM85006", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, this one is never used
-// deactivated because it also affects the UMD version of the game
-// TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
 // { "ULJM05353", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, game needs 76 MB
-
 };

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -40,8 +40,8 @@ const struct HDRemaster g_HDRemasters[] = {
 { "NPJB40001", 0x4000000, false }, // MONSTER HUNTER PORTABLE 3rd HD Ver.
 { "BLJM85002", 0x4000000, true }, // K-ON Houkago Live HD Ver
 { "NPJB40002", 0x4000000, true }, // K-ON Houkago Live HD Ver
-{ "BLJM85003", 0x4000000, true }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-{ "NPJB40003", 0x4000000, true }, // Shin Sangoku Musou Multi Raid 2 HD Ver
+{ "BLJM85003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
+{ "NPJB40003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
 { "BLJM85004", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition, this one is never used
 // deactivated because it also affects the UMD version of the game
 // TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -42,6 +42,7 @@ const struct HDRemaster g_HDRemasters[] = {
 { "NPJB40002", 0x4000000, true }, // K-ON Houkago Live HD Ver
 { "BLJM85003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
 { "NPJB40003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
+{ "NPJB00274", 0x4000000, false }, //Dynasty Warriors Strikeforce 2 HD Edition (JP)
 { "BLJM85004", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition, this one is never used
 // deactivated because it also affects the UMD version of the game
 // TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
@@ -54,4 +55,5 @@ const struct HDRemaster g_HDRemasters[] = {
 // deactivated because it also affects the UMD version of the game
 // TODO: Differentiate between UMD version and HD version (either through reading of UMD_DATA.BIN or ISO size)
 // { "ULJM05353", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, game needs 76 MB
+
 };


### PR DESCRIPTION
It doesn't use double texture coordinates/sizes.

Fixes #2795.
