### PR TITLE
Math3d extensions

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -98,7 +98,7 @@ static GLenum blendColor2Func(u32 fix) {
 	if (fix == 0)
 		return GL_ZERO;
 
-	Vec3 fix3 = Vec3::FromRGB(fix);
+	Vec3f fix3 = Vec3f::FromRGB(fix);
 	if (fix3.x >= 0.99 && fix3.y >= 0.99 && fix3.z >= 0.99)
 		return GL_ONE;
 	else if (fix3.x <= 0.01 && fix3.y <= 0.01 && fix3.z <= 0.01)
@@ -106,8 +106,8 @@ static GLenum blendColor2Func(u32 fix) {
 	return GL_INVALID_ENUM;
 }
 
-static bool blendColorSimilar(Vec3 a, Vec3 b, float margin = 0.1f) {
-	Vec3 diff = a - b;
+static bool blendColorSimilar(Vec3f a, Vec3f b, float margin = 0.1f) {
+	Vec3f diff = a - b;
 	if (fabsf(diff.x) <= margin && fabsf(diff.y) <= margin && fabsf(diff.z) <= margin)
 		return true;
 	return false;
@@ -146,8 +146,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		GLuint glBlendFuncA = blendFuncA == GE_SRCBLEND_FIXA ? blendColor2Func(gstate.getFixA()) : aLookup[blendFuncA];
 		GLuint glBlendFuncB = blendFuncB == GE_DSTBLEND_FIXB ? blendColor2Func(gstate.getFixB()) : bLookup[blendFuncB];
 		if (blendFuncA == GE_SRCBLEND_FIXA || blendFuncB == GE_DSTBLEND_FIXB) {
-			Vec3 fixA = Vec3::FromRGB(gstate.getFixA());
-			Vec3 fixB = Vec3::FromRGB(gstate.getFixB());
+			Vec3f fixA = Vec3f::FromRGB(gstate.getFixA());
+			Vec3f fixB = Vec3f::FromRGB(gstate.getFixB());
 			if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB != GL_INVALID_ENUM) {
 				// Can use blendcolor trivially.
 				const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -159,7 +159,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 				glstate.blendColor.set(blendColor);
 				glBlendFuncB = GL_CONSTANT_COLOR;
 			} else if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB == GL_INVALID_ENUM) {
-				if (blendColorSimilar(fixA, Vec3::AssignToAll(1.0f) - fixB)) {
+				if (blendColorSimilar(fixA, Vec3f::AssignToAll(1.0f) - fixB)) {
 					glBlendFuncA = GL_CONSTANT_COLOR;
 					glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
 					const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -177,9 +177,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 					DEBUG_LOG(HLE, "ERROR INVALID blendcolorstate: FixA=%06x FixB=%06x FuncA=%i FuncB=%i", gstate.getFixA(), gstate.getFixB(), gstate.getBlendFuncA(), gstate.getBlendFuncB());
 					// Let's approximate, at least.  Close is better than totally off.
-					const bool nearZeroA = blendColorSimilar(fixA, Vec3::AssignToAll(0.0f), 0.25f);
-					const bool nearZeroB = blendColorSimilar(fixB, Vec3::AssignToAll(0.0f), 0.25f);
-					if (nearZeroA || blendColorSimilar(fixA, Vec3::AssignToAll(1.0f), 0.25f)) {
+					const bool nearZeroA = blendColorSimilar(fixA, Vec3f::AssignToAll(0.0f), 0.25f);
+					const bool nearZeroB = blendColorSimilar(fixB, Vec3f::AssignToAll(0.0f), 0.25f);
+					if (nearZeroA || blendColorSimilar(fixA, Vec3f::AssignToAll(1.0f), 0.25f)) {
 						glBlendFuncA = nearZeroA ? GL_ZERO : GL_ONE;
 						glBlendFuncB = GL_CONSTANT_COLOR;
 						const float blendColor[4] = {fixB.x, fixB.y, fixB.z, 1.0f};

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -98,7 +98,7 @@ static GLenum blendColor2Func(u32 fix) {
 	if (fix == 0)
 		return GL_ZERO;
 
-	Vec3 fix3 = Vec3(fix);
+	Vec3 fix3 = Vec3::FromRGB(fix);
 	if (fix3.x >= 0.99 && fix3.y >= 0.99 && fix3.z >= 0.99)
 		return GL_ONE;
 	else if (fix3.x <= 0.01 && fix3.y <= 0.01 && fix3.z <= 0.01)
@@ -146,8 +146,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		GLuint glBlendFuncA = blendFuncA == GE_SRCBLEND_FIXA ? blendColor2Func(gstate.getFixA()) : aLookup[blendFuncA];
 		GLuint glBlendFuncB = blendFuncB == GE_DSTBLEND_FIXB ? blendColor2Func(gstate.getFixB()) : bLookup[blendFuncB];
 		if (blendFuncA == GE_SRCBLEND_FIXA || blendFuncB == GE_DSTBLEND_FIXB) {
-			Vec3 fixA = Vec3(gstate.getFixA());
-			Vec3 fixB = Vec3(gstate.getFixB());
+			Vec3 fixA = Vec3::FromRGB(gstate.getFixA());
+			Vec3 fixB = Vec3::FromRGB(gstate.getFixB());
 			if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB != GL_INVALID_ENUM) {
 				// Can use blendcolor trivially.
 				const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -159,7 +159,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 				glstate.blendColor.set(blendColor);
 				glBlendFuncB = GL_CONSTANT_COLOR;
 			} else if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB == GL_INVALID_ENUM) {
-				if (blendColorSimilar(fixA, Vec3(1.0f) - fixB)) {
+				if (blendColorSimilar(fixA, Vec3::AssignToAll(1.0f) - fixB)) {
 					glBlendFuncA = GL_CONSTANT_COLOR;
 					glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
 					const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -177,9 +177,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 					DEBUG_LOG(HLE, "ERROR INVALID blendcolorstate: FixA=%06x FixB=%06x FuncA=%i FuncB=%i", gstate.getFixA(), gstate.getFixB(), gstate.getBlendFuncA(), gstate.getBlendFuncB());
 					// Let's approximate, at least.  Close is better than totally off.
-					const bool nearZeroA = blendColorSimilar(fixA, 0.0f, 0.25f);
-					const bool nearZeroB = blendColorSimilar(fixB, 0.0f, 0.25f);
-					if (nearZeroA || blendColorSimilar(fixA, 1.0f, 0.25f)) {
+					const bool nearZeroA = blendColorSimilar(fixA, Vec3::AssignToAll(0.0f), 0.25f);
+					const bool nearZeroB = blendColorSimilar(fixB, Vec3::AssignToAll(0.0f), 0.25f);
+					if (nearZeroA || blendColorSimilar(fixA, Vec3::AssignToAll(1.0f), 0.25f)) {
 						glBlendFuncA = nearZeroA ? GL_ZERO : GL_ONE;
 						glBlendFuncB = GL_CONSTANT_COLOR;
 						const float blendColor[4] = {fixB.x, fixB.y, fixB.z, 1.0f};

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -600,9 +600,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				}
 
 				// Yes, we really must multiply by the world matrix too.
-				Vec3ByMatrix43(out, psum.v, gstate.worldMatrix);
+				Vec3ByMatrix43(out, psum.AsArray(), gstate.worldMatrix);
 				if (reader.hasNormal()) {
-					Norm3ByMatrix43(norm, nsum.v, gstate.worldMatrix);
+					Norm3ByMatrix43(norm, nsum.AsArray(), gstate.worldMatrix);
 					normal = Vec3(norm).Normalized();
 				}
 			}

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -685,7 +685,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3(norm).Normalized();
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3(0.0f);
+							source = Vec3::AssignToAll(0.0f);
 						}
 						break;
 					case 3: // Use non-normalized normal as source!
@@ -693,7 +693,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3(norm);
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3(0.0f);
+							source = Vec3::AssignToAll(0.0f);
 						}
 						break;
 					}

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -300,7 +300,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		
 		if (distanceToLight > 0.0f) {
 			toLight /= distanceToLight;
-			dot = toLight * norm;
+			dot = Dot(toLight, norm);
 		}
 		// Clamp dot to zero.
 		if (dot < 0.0f) dot = 0.0f;
@@ -318,7 +318,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 			break;
 		case GE_LIGHTTYPE_SPOT:
 			lightDir = gstate_c.lightdir[l];
-			angle = toLight.Normalized() * lightDir.Normalized();
+			angle = Dot(toLight.Normalized(), lightDir.Normalized());
 			if (angle >= gstate_c.lightangle[l])
 				lightScale = clamp(1.0f / (gstate_c.lightatt[l][0] + gstate_c.lightatt[l][1]*distanceToLight + gstate_c.lightatt[l][2]*distanceToLight*distanceToLight), 0.0f, 1.0f) * powf(angle, gstate_c.lightspotCoef[l]);
 			break;
@@ -340,7 +340,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 			Vec3 halfVec = (toLight + toViewer);
 			halfVec.Normalize();
 
-			dot = halfVec * norm;
+			dot = Dot(halfVec, norm);
 			if (dot > 0.0f)
 			{
 				Color4 lightSpec(gstate_c.lightColor[2][l], 0.0f);
@@ -711,8 +711,8 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 					Vec3 lightpos0 = Vec3(gstate_c.lightpos[gstate.getUVLS0()]).Normalized();
 					Vec3 lightpos1 = Vec3(gstate_c.lightpos[gstate.getUVLS1()]).Normalized();
 
-					uv[0] = (1.0f + (lightpos0 * normal))/2.0f;
-					uv[1] = (1.0f - (lightpos1 * normal))/2.0f;
+					uv[0] = (1.0f + Dot(lightpos0, normal))/2.0f;
+					uv[1] = (1.0f - Dot(lightpos1, normal))/2.0f;
 					uv[2] = 1.0f;
 				}
 				break;

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -16,3 +16,55 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Math3D.h"
+
+
+Vec3 Vec3Ref::operator +(const Vec3Ref &other) const
+{
+	return Vec3(x+other.x, y+other.y, z+other.z);
+}
+
+Vec3 Vec3Ref::operator -(const Vec3Ref &other) const
+{
+	return Vec3(x-other.x, y-other.y, z-other.z);
+}
+
+Vec3 Vec3Ref::operator -() const
+{
+	return Vec3(-x,-y,-z);
+}
+
+Vec3 Vec3Ref::Mul(const Vec3Ref &other) const
+{
+	return Vec3(x*other.x, y*other.y, z*other.z);
+}
+
+Vec3 Vec3Ref::operator * (const float f) const
+{
+	return Vec3(x*f,y*f,z*f);
+}
+
+Vec3 Vec3Ref::operator / (const float f) const
+{
+	float invf = (1.0f/f);
+	return Vec3(x*invf,y*invf,z*invf);
+}
+
+Vec3 Vec3Ref::WithLength(const float l) const
+{
+	return (*this) * l / Length();
+}
+
+Vec3 Vec3Ref::Normalized() const
+{
+	return (*this) / Length();
+}
+
+Vec3 Vec3Ref::Lerp(const Vec3Ref &other, const float t) const
+{
+	return (*this)*(1-t) + other*t;
+}
+
+float Vec3Ref::Distance2To(Vec3Ref &other) const
+{
+	return (other-(*this)).Length2();
+}

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -32,3 +32,21 @@ Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 				(rgb >> 8) & 0xFF,
 				(rgb >> 16) & 0xFF);
 }
+
+template<>
+Vec4<float> Vec4<float>::FromRGBA(unsigned int rgba)
+{
+	return Vec4((rgba & 0xFF) * (1.0f/255.0f),
+				((rgba >> 8) & 0xFF) * (1.0f/255.0f),
+				((rgba >> 16) & 0xFF) * (1.0f/255.0f),
+				((rgba >> 24) & 0xFF) * (1.0f/255.0f));
+}
+
+template<>
+Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
+{
+	return Vec4(rgba & 0xFF,
+				(rgba >> 8) & 0xFF,
+				(rgba >> 16) & 0xFF,
+				(rgba >> 24) & 0xFF);
+}

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -17,54 +17,18 @@
 
 #include "Math3D.h"
 
-
-Vec3 Vec3Ref::operator +(const Vec3Ref &other) const
+template<>
+Vec3<float> Vec3<float>::FromRGB(unsigned int rgb)
 {
-	return Vec3(x+other.x, y+other.y, z+other.z);
+	return Vec3((rgb & 0xFF) * (1.0f/255.0f),
+				((rgb >> 8) & 0xFF) * (1.0f/255.0f),
+				((rgb >> 16) & 0xFF) * (1.0f/255.0f));
 }
 
-Vec3 Vec3Ref::operator -(const Vec3Ref &other) const
+template<>
+Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 {
-	return Vec3(x-other.x, y-other.y, z-other.z);
-}
-
-Vec3 Vec3Ref::operator -() const
-{
-	return Vec3(-x,-y,-z);
-}
-
-Vec3 Vec3Ref::Mul(const Vec3Ref &other) const
-{
-	return Vec3(x*other.x, y*other.y, z*other.z);
-}
-
-Vec3 Vec3Ref::operator * (const float f) const
-{
-	return Vec3(x*f,y*f,z*f);
-}
-
-Vec3 Vec3Ref::operator / (const float f) const
-{
-	float invf = (1.0f/f);
-	return Vec3(x*invf,y*invf,z*invf);
-}
-
-Vec3 Vec3Ref::WithLength(const float l) const
-{
-	return (*this) * l / Length();
-}
-
-Vec3 Vec3Ref::Normalized() const
-{
-	return (*this) / Length();
-}
-
-Vec3 Vec3Ref::Lerp(const Vec3Ref &other, const float t) const
-{
-	return (*this)*(1-t) + other*t;
-}
-
-float Vec3Ref::Distance2To(Vec3Ref &other) const
-{
-	return (other-(*this)).Length2();
+	return Vec3(rgb & 0xFF,
+				(rgb >> 8) & 0xFF,
+				(rgb >> 16) & 0xFF);
 }

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -34,6 +34,18 @@ Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 }
 
 template<>
+unsigned int Vec3Ref<float>::ToRGB() const
+{
+	return r*255.f + g*255.f*256.f + b*255.f*256.f*256.f;
+}
+
+template<>
+unsigned int Vec3Ref<int>::ToRGB() const
+{
+	return (r&0xFF) | ((g&0xFF)<<8) | ((b&0xFF)<<16);
+}
+
+template<>
 Vec4<float> Vec4<float>::FromRGBA(unsigned int rgba)
 {
 	return Vec4((rgba & 0xFF) * (1.0f/255.0f),
@@ -49,4 +61,16 @@ Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
 				(rgba >> 8) & 0xFF,
 				(rgba >> 16) & 0xFF,
 				(rgba >> 24) & 0xFF);
+}
+
+template<>
+unsigned int Vec4Ref<float>::ToRGBA() const
+{
+	return r*255.f + g*255.f*256.f + b*255.f*256.f*256.f + a*255.f*256.f*256.f*256.f;
+}
+
+template<>
+unsigned int Vec4Ref<int>::ToRGBA() const
+{
+	return (r&0xFF) | ((g&0xFF)<<8) | ((b&0xFF)<<16) | ((a&0xFF)<<24);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -19,6 +19,9 @@
 
 #include <cmath>
 
+/**
+ * Vec3 - three dimensional vector with arbitrary base type
+ */
 template<typename X, typename Y=X, typename Z=X>
 class Vec3;
 
@@ -219,6 +222,207 @@ float Vec3Ref<X,Y,Z>::Distance2To(const Vec3Ref<X,Y,Z>& other) const
 }
 
 
+/**
+ * Vec4 - four dimensional vector with arbitrary base type
+ */
+template<typename X, typename Y=X, typename Z=X, typename W=X>
+class Vec4;
+
+// Like a Vec3, but acts on references
+template<typename X, typename Y=X, typename Z=X, typename W=X>
+class Vec4Ref
+{
+public:
+	union
+	{
+		struct
+		{
+			X& x;
+			Y& y;
+			Z& z;
+			W& w;
+		};
+		struct
+		{
+			X& r;
+			Y& g;
+			Z& b;
+			W& a;
+		};
+	};
+
+	X* AsArray() { return &x; }
+
+	Vec4Ref(X& _x, Y& _y, Z& _z, W& _w) : x(_x), y(_y), z(_z), w(_w) {}
+
+	Vec4Ref(X a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
+
+	void Write(X a[4])
+	{
+		a[0] = x; a[1] = y; a[2] = z; a[3] = w;
+	}
+
+	// operators acting on "this"
+	void operator = (const Vec4Ref& other)
+	{
+		x = other.x;
+		y = other.y;
+		z = other.z;
+		w = other.w;
+	}
+	void operator += (const Vec4Ref &other)
+	{
+		x+=other.x; y+=other.y; z+=other.z; w+=other.w;
+	}
+	void operator -= (const Vec4Ref &other)
+	{
+		x-=other.x; y-=other.y; z-=other.z; w-=other.w;
+	}
+
+	void operator *= (const X& f)
+	{
+		x*=f; y*=f; z*=f; w*=f;
+	}
+	void operator /= (const X& f)
+	{
+		x/=f; y/=f; z/=f; w/=f;
+	}
+
+	// operators which require creating a new Vec4 object
+	Vec4<X,Y,Z,W> operator +(const Vec4Ref &other) const;
+	Vec4<X,Y,Z,W> operator -(const Vec4Ref &other) const;
+	Vec4<X,Y,Z,W> operator -() const;
+	Vec4<X,Y,Z,W> Mul(const Vec4Ref &other) const;
+	Vec4<X,Y,Z,W> operator * (const X& f) const;
+	Vec4<X,Y,Z,W> operator / (const X& f) const;
+
+	// methods which don't create new Vec4 objects
+	float Length2() const
+	{
+		return x*x + y*y + z*z + w*w;
+	}
+	float Length() const
+	{
+		return sqrtf(Length2());
+	}
+	void SetLength(const float l)
+	{
+		(*this) *= l / Length();
+	}
+	float Normalize() //returns the previous length, is often useful
+	{
+		float len = Length();
+		(*this) /= len;
+		return len;
+	}
+	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
+	{
+		return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
+	}
+	float operator [] (const int i) const
+	{
+		return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
+	}
+	void SetZero()
+	{
+		x=(X)0; y=(Y)0; z=(Z)0; w=(W)0;
+	}
+
+	// methods that create a new Vec4 object
+	Vec4<X,Y,Z,W> WithLength(const X& l) const;
+	Vec4<X,Y,Z,W> Normalized() const;
+	Vec4<X,Y,Z,W> Lerp(const Vec4Ref &other, const float t) const;
+	float Distance2To(const Vec4Ref &other) const;
+};
+
+template<typename X, typename Y, typename Z, typename W>
+class Vec4 : public Vec4Ref<X,Y,Z,W>
+{
+public:
+	X x;
+	Y y;
+	Z z;
+	W w;
+
+	Vec4() : Vec4Ref<X,Y,Z,W>(x, y, z, w) {}
+	Vec4(const X& _x, const Y& _y, const Z& _z, const W& _w) : Vec4Ref<X,Y,Z,W>(x, y, z, w), x(_x), y(_y), z(_z), w(_w) {}
+	Vec4(const X a[4]) : Vec4(a[0], a[1], a[2], a[3]) {}
+	Vec4(const Vec4Ref<X,Y,Z,W>& other) : Vec4(other.x, other.y, other.z, other.w) {}
+
+	// Only defined for X=float and X=int
+	static Vec4 FromRGBA(unsigned int rgba);
+
+	static Vec4 AssignToAll(X f)
+	{
+		return Vec4(f, f, f, f);
+	}
+};
+
+typedef Vec4<float> Vec4f;
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator +(const Vec4Ref<X,Y,Z,W> &other) const
+{
+	return Vec4<X,Y,Z,W>(x+other.x, y+other.y, z+other.z, w+other.w);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator -(const Vec4Ref<X,Y,Z,W> &other) const
+{
+	return Vec4<X,Y,Z,W>(x-other.x, y-other.y, z-other.z, w-other.w);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator -() const
+{
+	return Vec4<X,Y,Z,W>(-x,-y,-z,-w);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Mul(const Vec4Ref<X,Y,Z,W> &other) const
+{
+	return Vec4<X,Y,Z,W>(x*other.x, y*other.y, z*other.z, w*other.w);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator * (const X& f) const
+{
+	return Vec4<X,Y,Z,W>(x*f,y*f,z*f,w*f);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator / (const X& f) const
+{
+	float invf = (1.0f/f);
+	return Vec4<X,Y,Z,W>(x*invf,y*invf,z*invf,w*invf);
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::WithLength(const X& l) const
+{
+	return (*this) * l / Length();
+}
+
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+// TODO: Shouldn't be using a float parameter for all base types
+template<typename X, typename Y, typename Z, typename W>
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Lerp(const Vec4Ref<X,Y,Z,W> &other, const float t) const
+{
+	return (*this)*(1-t) + other*t;
+}
+
+template<typename X, typename Y, typename Z, typename W>
+float Vec4Ref<X,Y,Z,W>::Distance2To(const Vec4Ref<X,Y,Z,W>& other) const
+{
+	return (other-(*this)).Length2();
+}
+
+
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];
@@ -243,6 +447,12 @@ template<typename X>
 inline X Dot(const Vec3Ref<X> &a, const Vec3Ref<X>& b)
 {
 	return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+template<typename X>
+inline X Dot(const Vec4Ref<X> &a, const Vec4Ref<X>& b)
+{
+	return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w;
 }
 
 template<typename X, typename Y=X, typename Z=X>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -32,7 +32,7 @@ public:
 	};
 	Vec3(unsigned int rgb) {
 		x = (rgb & 0xFF) * (1.0f/255.0f);
-		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f); 
+		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
 		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
 	}
 	Vec3(const float a[3]) {
@@ -67,10 +67,6 @@ public:
 	{
 		return Vec3(-x,-y,-z);
 	}
-	float operator *(const Vec3 &other) const
-	{
-		return x*other.x + y*other.y + z*other.z;
-	}
 	Vec3 Mul(const Vec3 &other) const
 	{
 		return Vec3(x*other.x, y*other.y, z*other.z);
@@ -91,10 +87,6 @@ public:
 	void operator /= (const float f)
 	{
 		*this = *this / f;
-	}
-	Vec3 operator %(const Vec3 &v) const
-	{
-		return Vec3(y*v.z-z*v.y, z*v.x-x*v.z, x*v.y-y*v.x);
 	}
 	float Length2() const
 	{
@@ -159,4 +151,14 @@ inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]
 inline float Vec3Dot(const float v1[3], const float v2[3])
 {
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+}
+
+inline float Dot(const Vec3 &a, const Vec3& b)
+{
+	return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+inline Vec3 Cross(const Vec3 &a, const Vec3& b)
+{
+	return Vec3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -42,6 +42,11 @@ public:
 			X& u;
 			Y& v;
 		};
+		struct
+		{
+			X& s;
+			Y& t;
+		};
 	};
 
 	X* AsArray() { return &x; }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -257,6 +257,9 @@ public:
 		a[0] = x; a[1] = y; a[2] = z;
 	}
 
+	// Only defined for X=float and X=int; alpha bits set to zero
+	unsigned int ToRGB() const;
+
 	// operators acting on "this"
 	void operator = (const Vec3Ref& other)
 	{
@@ -467,6 +470,9 @@ public:
 	{
 		a[0] = x; a[1] = y; a[2] = z; a[3] = w;
 	}
+
+	// Only defined for X=float and X=int
+	unsigned int ToRGBA() const;
 
 	// operators acting on "this"
 	void operator = (const Vec4Ref& other)

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -124,6 +124,10 @@ public:
 	Vec2<X,Y> Normalized() const;
 	Vec2<X,Y> Lerp(const Vec2Ref &other, const float t) const;
 	float Distance2To(const Vec2Ref &other) const;
+
+	// swizzlers - create a subvector of references to specific components
+	Vec2Ref<Y,X> yx() { return Vec2Ref(y, x); }
+	Vec2Ref<Y,X> vu() { return Vec2Ref(v, u); }
 };
 
 template<typename X, typename Y>
@@ -323,6 +327,18 @@ public:
 	Vec3<X,Y,Z> Normalized() const;
 	Vec3<X,Y,Z> Lerp(const Vec3Ref &other, const float t) const;
 	float Distance2To(const Vec3Ref &other) const;
+
+	// swizzlers - create a subvector of references to specific components
+	// e.g. Vec2Ref<X,Y> xy() { return Vec2Ref<X,Y>(x,y); }
+	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+
+#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A, B> a##b() { return Vec2Ref<A,B>(a, b); }
+#define DEFINE_SWIZZLER2(a, b, a2, b2, a3, b3, A, B) _DEFINE_SWIZZLER2(a, b, A, B); _DEFINE_SWIZZLER2(a2, b2, A, B); _DEFINE_SWIZZLER2(a3, b3, A, B); _DEFINE_SWIZZLER2(b, a, B, A); _DEFINE_SWIZZLER2(b2, a2, B, A); _DEFINE_SWIZZLER2(b3, a3, B, A);
+	DEFINE_SWIZZLER2(x, y, r, g, u, v, X, Y);
+	DEFINE_SWIZZLER2(x, z, r, b, u, w, X, Z);
+	DEFINE_SWIZZLER2(y, z, g, b, v, w, Y, Z);
+#undef DEFINE_SWIZZLER2
+#undef _DEFINE_SWIZZLER2
 };
 
 template<typename X, typename Y, typename Z>
@@ -523,6 +539,43 @@ public:
 	Vec4<X,Y,Z,W> Normalized() const;
 	Vec4<X,Y,Z,W> Lerp(const Vec4Ref &other, const float t) const;
 	float Distance2To(const Vec4Ref &other) const;
+
+	// swizzlers - create a subvector of references to specific components
+	// e.g. Vec2Ref<X,Y> xy() { return Vec2Ref<X,Y>(x,y); }
+	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+
+#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A, B> a##b() { return Vec2Ref<A,B>(a, b); }
+#define DEFINE_SWIZZLER2(a, b, a2, b2, A, B) _DEFINE_SWIZZLER2(a, b, A, B); _DEFINE_SWIZZLER2(a2, b2, A, B); _DEFINE_SWIZZLER2(b, a, B, A); _DEFINE_SWIZZLER2(b2, a2, B, A);
+	DEFINE_SWIZZLER2(x, y, r, g, X, Y);
+	DEFINE_SWIZZLER2(x, z, r, b, X, Z);
+	DEFINE_SWIZZLER2(x, w, r, a, X, W);
+	DEFINE_SWIZZLER2(y, z, g, b, Y, Z);
+	DEFINE_SWIZZLER2(y, w, g, a, Y, W);
+	DEFINE_SWIZZLER2(z, w, b, a, Z, W);
+#undef DEFINE_SWIZZLER2
+#undef _DEFINE_SWIZZLER2
+
+#define _DEFINE_SWIZZLER3(a, b, c, A, B, C) Vec3Ref<A, B, C> a##b##c() { return Vec3Ref<A,B,C>(a, b, c); }
+#define DEFINE_SWIZZLER3(a, b, c, a2, b2, c2, A, B, C) \
+	_DEFINE_SWIZZLER3(a, b, c, A, B, C); \
+	_DEFINE_SWIZZLER3(a, c, b, A, C, B); \
+	_DEFINE_SWIZZLER3(b, a, c, B, A, C); \
+	_DEFINE_SWIZZLER3(b, c, a, B, C, A); \
+	_DEFINE_SWIZZLER3(c, a, b, C, A, B); \
+	_DEFINE_SWIZZLER3(c, b, a, C, B, A); \
+	_DEFINE_SWIZZLER3(a2, b2, c2, A, B, C); \
+	_DEFINE_SWIZZLER3(a2, c2, b2, A, C, B); \
+	_DEFINE_SWIZZLER3(b2, a2, c2, B, A, C); \
+	_DEFINE_SWIZZLER3(b2, c2, a2, B, C, A); \
+	_DEFINE_SWIZZLER3(c2, a2, b2, C, A, B); \
+	_DEFINE_SWIZZLER3(c2, b2, a2, C, B, A);
+
+	DEFINE_SWIZZLER3(x, y, z, r, g, b, X, Y, Z);
+	DEFINE_SWIZZLER3(x, y, w, r, g, a, X, Y, W);
+	DEFINE_SWIZZLER3(x, z, w, r, b, a, X, Z, W);
+	DEFINE_SWIZZLER3(y, z, w, g, b, a, Y, Z, W);
+#undef DEFINE_SWIZZLER3
+#undef _DEFINE_SWIZZLER3
 };
 
 template<typename X, typename Y, typename Z, typename W>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -83,7 +83,7 @@ public:
 	Vec2<X,Y> operator +(const Vec2Ref &other) const;
 	Vec2<X,Y> operator -(const Vec2Ref &other) const;
 	Vec2<X,Y> operator -() const;
-	Vec2<X,Y> Mul(const Vec2Ref &other) const;
+	Vec2<X,Y> operator *(const Vec2Ref &other) const;
 	Vec2<X,Y> operator * (const X& f) const;
 	Vec2<X,Y> operator / (const X& f) const;
 
@@ -169,7 +169,7 @@ Vec2<X,Y> Vec2Ref<X,Y>::operator -() const
 }
 
 template<typename X, typename Y>
-Vec2<X,Y> Vec2Ref<X,Y>::Mul(const Vec2Ref<X,Y> &other) const
+Vec2<X,Y> Vec2Ref<X,Y>::operator *(const Vec2Ref<X,Y> &other) const
 {
 	return Vec2<X,Y>(x*other.x, y*other.y);
 }
@@ -286,7 +286,7 @@ public:
 	Vec3<X,Y,Z> operator +(const Vec3Ref &other) const;
 	Vec3<X,Y,Z> operator -(const Vec3Ref &other) const;
 	Vec3<X,Y,Z> operator -() const;
-	Vec3<X,Y,Z> Mul(const Vec3Ref &other) const;
+	Vec3<X,Y,Z> operator *(const Vec3Ref &other) const;
 	Vec3<X,Y,Z> operator * (const X& f) const;
 	Vec3<X,Y,Z> operator / (const X& f) const;
 
@@ -384,7 +384,7 @@ Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator -() const
 }
 
 template<typename X, typename Y, typename Z>
-Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Mul(const Vec3Ref<X,Y,Z> &other) const
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator *(const Vec3Ref<X,Y,Z> &other) const
 {
 	return Vec3<X,Y,Z>(x*other.x, y*other.y, z*other.z);
 }
@@ -498,7 +498,7 @@ public:
 	Vec4<X,Y,Z,W> operator +(const Vec4Ref &other) const;
 	Vec4<X,Y,Z,W> operator -(const Vec4Ref &other) const;
 	Vec4<X,Y,Z,W> operator -() const;
-	Vec4<X,Y,Z,W> Mul(const Vec4Ref &other) const;
+	Vec4<X,Y,Z,W> operator *(const Vec4Ref &other) const;
 	Vec4<X,Y,Z,W> operator * (const X& f) const;
 	Vec4<X,Y,Z,W> operator / (const X& f) const;
 
@@ -622,7 +622,7 @@ Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator -() const
 }
 
 template<typename X, typename Y, typename Z, typename W>
-Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Mul(const Vec4Ref<X,Y,Z,W> &other) const
+Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator *(const Vec4Ref<X,Y,Z,W> &other) const
 {
 	return Vec4<X,Y,Z,W>(x*other.x, y*other.y, z*other.z, w*other.w);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -193,6 +193,12 @@ Vec2<X,Y> Vec2Ref<X,Y>::operator * (const X& f) const
 	return Vec2<X,Y>(x*f,y*f);
 }
 
+template<typename X, typename Y=X>
+Vec2<X,Y> operator * (const X& f, const Vec2Ref<X,Y>& vec)
+{
+	return Vec2<X,Y>(f*vec.x, f*vec.y);
+}
+
 template<typename X, typename Y>
 Vec2<X,Y> Vec2Ref<X,Y>::operator / (const X& f) const
 {
@@ -416,6 +422,12 @@ template<typename X, typename Y, typename Z>
 Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator * (const X& f) const
 {
 	return Vec3<X,Y,Z>(x*f,y*f,z*f);
+}
+
+template<typename X, typename Y=X, typename Z=X>
+Vec3<X,Y,Z> operator * (const X& f, const Vec3Ref<X,Y,Z>& vec)
+{
+	return Vec3<X,Y,Z>(f*vec.x, f*vec.y, f*vec.z);
 }
 
 template<typename X, typename Y, typename Z>
@@ -664,6 +676,12 @@ template<typename X, typename Y, typename Z, typename W>
 Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::operator * (const X& f) const
 {
 	return Vec4<X,Y,Z,W>(x*f,y*f,z*f,w*f);
+}
+
+template<typename X, typename Y=X, typename Z=X, typename W=X>
+Vec4<X,Y,Z,W> operator * (const X& f, const Vec4Ref<X,Y,Z,W>& vec)
+{
+	return Vec4<X,Y,Z,W>(f*vec.x, f*vec.y, f*vec.z, f*vec.w);
 }
 
 template<typename X, typename Y, typename Z, typename W>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 /**
  * Vec2 - two dimensional vector with arbitrary base type
@@ -99,32 +100,13 @@ public:
 	Vec2<X,Y> operator / (const X& f) const;
 
 	// methods which don't create new Vec2 objects
-	float Length2() const
-	{
-		return x*x + y*y;
-	}
-	float Length() const
-	{
-		return sqrtf(Length2());
-	}
-	void SetLength(const float l)
-	{
-		(*this) *= l / Length();
-	}
-	float Normalize() //returns the previous length, is often useful
-	{
-		float len = Length();
-		(*this) /= len;
-		return len;
-	}
-	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
-	{
-		return (i==0) ? x : y;
-	}
-	float operator [] (const int i) const
-	{
-		return (i==0) ? x : y;
-	}
+	// Length, SetLength and Normalize are only implemented for X=Y=Z=float
+	X Length2() const;
+	float Length() const;
+	void SetLength(const float l);
+	float Normalize(); // returns the previous length, is often useful
+	X &operator [] (int i); // allow vector[2] = 3   (vector.z=3)
+	X operator [] (const int i) const;
 	void SetZero()
 	{
 		x=(X)0; y=(Y)0;
@@ -218,7 +200,49 @@ Vec2<X,Y> Vec2Ref<X,Y>::Normalized() const
 	return (*this) / Length();
 }
 
-// TODO: Shouldn't be using a float parameter for all base types
+// Template specializations below
+// Many functions only really make sense for floating point vectors and/or when the base types for each component are equal.
+template<typename X, typename Y>
+X Vec2Ref<X,Y>::Length2() const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	return x*x + y*y;
+}
+
+template<>
+float Vec2Ref<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec2Ref<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+float Vec2Ref<float>::Normalize() //returns the previous length, is often useful
+{
+	float len = Length();
+	(*this) /= len;
+	return len;
+}
+
+template<typename X, typename Y>
+X& Vec2Ref<X,Y>::operator [] (int i) //allow vector[1] = 3   (vector.y=3)
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	return (i==0) ? x : y;
+}
+
+template<typename X, typename Y>
+X Vec2Ref<X,Y>::operator [] (const int i) const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	return (i==0) ? x : y;
+}
+
 template<typename X, typename Y>
 Vec2<X,Y> Vec2Ref<X,Y>::Lerp(const Vec2Ref<X,Y> &other, const float t) const
 {
@@ -319,32 +343,13 @@ public:
 	Vec3<X,Y,Z> operator / (const X& f) const;
 
 	// methods which don't create new Vec3 objects
-	float Length2() const
-	{
-		return x*x + y*y + z*z;
-	}
-	float Length() const
-	{
-		return sqrtf(Length2());
-	}
-	void SetLength(const float l)
-	{
-		(*this) *= l / Length();
-	}
-	float Normalize() //returns the previous length, is often useful
-	{
-		float len = Length();
-		(*this) /= len;
-		return len;
-	}
-	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
-	{
-		return (i==0) ? x : (i==1) ? y : z;
-	}
-	float operator [] (const int i) const
-	{
-		return (i==0) ? x : (i==1) ? y : z;
-	}
+	// Length, SetLength and Normalize are only implemented for X=Y=Z=float
+	X Length2() const;
+	float Length() const;
+	void SetLength(const float l);
+	float Normalize(); // returns the previous length, is often useful
+	X &operator [] (int i); // allow vector[2] = 3   (vector.z=3)
+	X operator [] (const int i) const;
 	void SetZero()
 	{
 		x=(X)0; y=(Y)0; z=(Z)0;
@@ -449,6 +454,52 @@ Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Normalized() const
 	return (*this) / Length();
 }
 
+// Template specializations below
+// Many functions only really make sense for floating point vectors and/or when the base types for each component are equal.
+template<typename X, typename Y, typename Z>
+X Vec3Ref<X,Y,Z>::Length2() const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	return x*x + y*y + z*z;
+}
+
+template<>
+float Vec3Ref<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec3Ref<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+float Vec3Ref<float>::Normalize() //returns the previous length, is often useful
+{
+	float len = Length();
+	(*this) /= len;
+	return len;
+}
+
+template<typename X, typename Y, typename Z>
+X& Vec3Ref<X,Y,Z>::operator [] (int i) //allow vector[1] = 3   (vector.y=3)
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	return (i==0) ? x : (i==1) ? y : z;
+}
+
+template<typename X, typename Y, typename Z>
+X Vec3Ref<X,Y,Z>::operator [] (const int i) const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	return (i==0) ? x : (i==1) ? y : z;
+}
+
 // TODO: Shouldn't be using a float parameter for all base types
 template<typename X, typename Y, typename Z>
 Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Lerp(const Vec3Ref<X,Y,Z> &other, const float t) const
@@ -547,32 +598,13 @@ public:
 	Vec4<X,Y,Z,W> operator / (const X& f) const;
 
 	// methods which don't create new Vec4 objects
-	float Length2() const
-	{
-		return x*x + y*y + z*z + w*w;
-	}
-	float Length() const
-	{
-		return sqrtf(Length2());
-	}
-	void SetLength(const float l)
-	{
-		(*this) *= l / Length();
-	}
-	float Normalize() //returns the previous length, is often useful
-	{
-		float len = Length();
-		(*this) /= len;
-		return len;
-	}
-	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
-	{
-		return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
-	}
-	float operator [] (const int i) const
-	{
-		return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
-	}
+	// Length, SetLength and Normalize are only implemented for X=Y=Z=float
+	X Length2() const;
+	float Length() const;
+	void SetLength(const float l);
+	float Normalize(); //returns the previous length, is often useful
+	X &operator [] (int i); // allow vector[2] = 3   (vector.z=3)
+	X operator [] (const int i) const;
 	void SetZero()
 	{
 		x=(X)0; y=(Y)0; z=(Z)0; w=(W)0;
@@ -701,6 +733,55 @@ template<typename X, typename Y, typename Z, typename W>
 Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Normalized() const
 {
 	return (*this) / Length();
+}
+
+// Template specializations below
+// Many functions only really make sense for floating point vectors and/or when the base types for each component are equal.
+template<typename X, typename Y, typename Z, typename W>
+X Vec4Ref<X,Y,Z,W>::Length2() const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	static_assert(std::is_same<X,W>::value, "base types need to be equal");
+	return x*x + y*y + z*z + w*w;
+}
+
+template<>
+float Vec4Ref<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec4Ref<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+float Vec4Ref<float>::Normalize() //returns the previous length, is often useful
+{
+	float len = Length();
+	(*this) /= len;
+	return len;
+}
+
+template<typename X, typename Y, typename Z, typename W>
+X& Vec4Ref<X,Y,Z,W>::operator [] (int i) //allow vector[1] = 3   (vector.y=3)
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	static_assert(std::is_same<X,W>::value, "base types need to be equal");
+	return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
+}
+
+template<typename X, typename Y, typename Z, typename W>
+X Vec4Ref<X,Y,Z,W>::operator [] (const int i) const
+{
+	static_assert(std::is_same<X,Y>::value, "base types need to be equal");
+	static_assert(std::is_same<X,Z>::value, "base types need to be equal");
+	static_assert(std::is_same<X,W>::value, "base types need to be equal");
+	return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
 }
 
 // TODO: Shouldn't be using a float parameter for all base types

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -19,9 +19,11 @@
 
 #include <cmath>
 
+template<typename X, typename Y=X, typename Z=X>
 class Vec3;
 
 // Like a Vec3, but acts on references
+template<typename X, typename Y=X, typename Z=X>
 class Vec3Ref
 {
 public:
@@ -29,30 +31,31 @@ public:
 	{
 		struct
 		{
-			float& x;
-			float& y;
-			float& z;
+			X& x;
+			Y& y;
+			Z& z;
 		};
 		struct
 		{
-			float& r;
-			float& g;
-			float& b;
+			X& r;
+			Y& g;
+			Z& b;
 		};
 		struct
 		{
-			float& u;
-			float& v;
-			float& w;
+			X& u;
+			Y& v;
+			Z& w;
 		};
 	};
 
-	float* AsArray() { return &x; }
+	X* AsArray() { return &x; }
 
-	Vec3Ref(float& _x, float& _y, float& _z) : x(_x), y(_y), z(_z) {}
-	Vec3Ref(float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
+	Vec3Ref(X& _x, Y& _y, Z& _z) : x(_x), y(_y), z(_z) {}
 
-	void Write(float a[3])
+	Vec3Ref(X a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
+
+	void Write(X a[3])
 	{
 		a[0] = x; a[1] = y; a[2] = z;
 	}
@@ -72,22 +75,23 @@ public:
 	{
 		x-=other.x; y-=other.y; z-=other.z;
 	}
-	void operator *= (const float f)
+
+	void operator *= (const X& f)
 	{
 		x*=f; y*=f; z*=f;
 	}
-	void operator /= (const float f)
+	void operator /= (const X& f)
 	{
 		x/=f; y/=f; z/=f;
 	}
 
 	// operators which require creating a new Vec3 object
-	Vec3 operator +(const Vec3Ref &other) const;
-	Vec3 operator -(const Vec3Ref &other) const;
-	Vec3 operator -() const;
-	Vec3 Mul(const Vec3Ref &other) const;
-	Vec3 operator * (const float f) const;
-	Vec3 operator / (const float f) const;
+	Vec3<X,Y,Z> operator +(const Vec3Ref &other) const;
+	Vec3<X,Y,Z> operator -(const Vec3Ref &other) const;
+	Vec3<X,Y,Z> operator -() const;
+	Vec3<X,Y,Z> Mul(const Vec3Ref &other) const;
+	Vec3<X,Y,Z> operator * (const X& f) const;
+	Vec3<X,Y,Z> operator / (const X& f) const;
 
 	// methods which don't create new Vec3 objects
 	float Length2() const
@@ -110,47 +114,109 @@ public:
 	}
 	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
 	{
-		return *((&x) + i);
+		return (i==0) ? x : (i==1) ? y : z;
 	}
 	float operator [] (const int i) const
 	{
-		return *((&x) + i);
+		return (i==0) ? x : (i==1) ? y : z;
 	}
 	void SetZero()
 	{
-		x=0.f;y=0.f;z=0.f;
+		x=(X)0; y=(Y)0; z=(Z)0;
 	}
 
 	// methods that create a new Vec3 object
-	Vec3 WithLength(const float l) const;
-	Vec3 Normalized() const;
-	Vec3 Lerp(const Vec3Ref &other, const float t) const;
-	float Distance2To(Vec3Ref &other) const;
+	Vec3<X,Y,Z> WithLength(const X& l) const;
+	Vec3<X,Y,Z> Normalized() const;
+	Vec3<X,Y,Z> Lerp(const Vec3Ref &other, const float t) const;
+	float Distance2To(const Vec3Ref &other) const;
 };
 
-class Vec3 : public Vec3Ref
+template<typename X, typename Y, typename Z>
+class Vec3 : public Vec3Ref<X,Y,Z>
 {
 public:
-	float x, y, z;
+	X x;
+	Y y;
+	Z z;
 
-	Vec3() : Vec3Ref(x, y, z) {}
-	Vec3(float _x, float _y, float _z) : Vec3Ref(x, y, z), x(_x), y(_y), z(_z) {}
-	Vec3(const float a[3]) : Vec3(a[0], a[1], a[2]) {}
-	Vec3(const Vec3Ref& other) : Vec3(other.x, other.y, other.z) {}
+	Vec3() : Vec3Ref<X,Y,Z>(x, y, z) {}
+	Vec3(const X& _x, const Y& _y, const Z& _z) : Vec3Ref<X,Y,Z>(x, y, z), x(_x), y(_y), z(_z) {}
+	Vec3(const X a[3]) : Vec3(a[0], a[1], a[2]) {}
+	Vec3(const Vec3Ref<X,Y,Z>& other) : Vec3(other.x, other.y, other.z) {}
 
-	static Vec3 FromRGB(unsigned int rgb)
-	{
-		return Vec3((rgb & 0xFF) * (1.0f/255.0f),
-					((rgb >> 8) & 0xFF) * (1.0f/255.0f),
-					((rgb >> 16) & 0xFF) * (1.0f/255.0f));
-	}
+	// Only defined for X=float and X=int
+	static Vec3 FromRGB(unsigned int rgb);
 
-	static Vec3 AssignToAll(float f)
+	static Vec3 AssignToAll(X f)
 	{
 		return Vec3(f, f, f);
 	}
-
 };
+
+typedef Vec3<float> Vec3f;
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator +(const Vec3Ref<X,Y,Z> &other) const
+{
+	return Vec3<X,Y,Z>(x+other.x, y+other.y, z+other.z);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator -(const Vec3Ref<X,Y,Z> &other) const
+{
+	return Vec3<X,Y,Z>(x-other.x, y-other.y, z-other.z);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator -() const
+{
+	return Vec3<X,Y,Z>(-x,-y,-z);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Mul(const Vec3Ref<X,Y,Z> &other) const
+{
+	return Vec3<X,Y,Z>(x*other.x, y*other.y, z*other.z);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator * (const X& f) const
+{
+	return Vec3<X,Y,Z>(x*f,y*f,z*f);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::operator / (const X& f) const
+{
+	float invf = (1.0f/f);
+	return Vec3<X,Y,Z>(x*invf,y*invf,z*invf);
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::WithLength(const X& l) const
+{
+	return (*this) * l / Length();
+}
+
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+// TODO: Shouldn't be using a float parameter for all base types
+template<typename X, typename Y, typename Z>
+Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Lerp(const Vec3Ref<X,Y,Z> &other, const float t) const
+{
+	return (*this)*(1-t) + other*t;
+}
+
+template<typename X, typename Y, typename Z>
+float Vec3Ref<X,Y,Z>::Distance2To(const Vec3Ref<X,Y,Z>& other) const
+{
+	return (other-(*this)).Length2();
+}
 
 
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
@@ -172,12 +238,15 @@ inline float Vec3Dot(const float v1[3], const float v2[3])
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }
 
-inline float Dot(const Vec3Ref &a, const Vec3Ref& b)
+// Dot product only really makes sense for same types
+template<typename X>
+inline X Dot(const Vec3Ref<X> &a, const Vec3Ref<X>& b)
 {
 	return a.x*b.x + a.y*b.y + a.z*b.z;
 }
 
-inline Vec3 Cross(const Vec3Ref &a, const Vec3Ref& b)
+template<typename X, typename Y=X, typename Z=X>
+inline Vec3<X,Y,Z> Cross(const Vec3Ref<X,Y,Z> &a, const Vec3Ref<X,Y,Z>& b)
 {
-	return Vec3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
+	return Vec3<X,Y,Z>(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -115,7 +115,6 @@ public:
 	// methods that create a new Vec2 object
 	Vec2<X,Y> WithLength(const X& l) const;
 	Vec2<X,Y> Normalized() const;
-	Vec2<X,Y> Lerp(const Vec2Ref &other, const float t) const;
 	float Distance2To(const Vec2Ref &other) const;
 
 	// swizzlers - create a subvector of references to specific components
@@ -244,17 +243,10 @@ X Vec2Ref<X,Y>::operator [] (const int i) const
 }
 
 template<typename X, typename Y>
-Vec2<X,Y> Vec2Ref<X,Y>::Lerp(const Vec2Ref<X,Y> &other, const float t) const
-{
-	return (*this)*(1-t) + other*t;
-}
-
-template<typename X, typename Y>
 float Vec2Ref<X,Y>::Distance2To(const Vec2Ref<X,Y>& other) const
 {
 	return (other-(*this)).Length2();
 }
-
 
 /**
  * Vec3 - three dimensional vector with arbitrary base type
@@ -358,7 +350,6 @@ public:
 	// methods that create a new Vec3 object
 	Vec3<X,Y,Z> WithLength(const X& l) const;
 	Vec3<X,Y,Z> Normalized() const;
-	Vec3<X,Y,Z> Lerp(const Vec3Ref &other, const float t) const;
 	float Distance2To(const Vec3Ref &other) const;
 
 	// swizzlers - create a subvector of references to specific components
@@ -500,19 +491,11 @@ X Vec3Ref<X,Y,Z>::operator [] (const int i) const
 	return (i==0) ? x : (i==1) ? y : z;
 }
 
-// TODO: Shouldn't be using a float parameter for all base types
-template<typename X, typename Y, typename Z>
-Vec3<X,Y,Z> Vec3Ref<X,Y,Z>::Lerp(const Vec3Ref<X,Y,Z> &other, const float t) const
-{
-	return (*this)*(1-t) + other*t;
-}
-
 template<typename X, typename Y, typename Z>
 float Vec3Ref<X,Y,Z>::Distance2To(const Vec3Ref<X,Y,Z>& other) const
 {
 	return (other-(*this)).Length2();
 }
-
 
 /**
  * Vec4 - four dimensional vector with arbitrary base type
@@ -613,7 +596,6 @@ public:
 	// methods that create a new Vec4 object
 	Vec4<X,Y,Z,W> WithLength(const X& l) const;
 	Vec4<X,Y,Z,W> Normalized() const;
-	Vec4<X,Y,Z,W> Lerp(const Vec4Ref &other, const float t) const;
 	float Distance2To(const Vec4Ref &other) const;
 
 	// swizzlers - create a subvector of references to specific components
@@ -784,13 +766,6 @@ X Vec4Ref<X,Y,Z,W>::operator [] (const int i) const
 	return (i==0) ? x : (i==1) ? y : (i==2) ? z : w;
 }
 
-// TODO: Shouldn't be using a float parameter for all base types
-template<typename X, typename Y, typename Z, typename W>
-Vec4<X,Y,Z,W> Vec4Ref<X,Y,Z,W>::Lerp(const Vec4Ref<X,Y,Z,W> &other, const float t) const
-{
-	return (*this)*(1-t) + other*t;
-}
-
 template<typename X, typename Y, typename Z, typename W>
 float Vec4Ref<X,Y,Z,W>::Distance2To(const Vec4Ref<X,Y,Z,W>& other) const
 {
@@ -840,4 +815,19 @@ template<typename X, typename Y=X, typename Z=X>
 inline Vec3<X,Y,Z> Cross(const Vec3Ref<X,Y,Z> &a, const Vec3Ref<X,Y,Z>& b)
 {
 	return Vec3<X,Y,Z>(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
+}
+
+
+// linear interpolation via float: 0.0=begin, 1.0=end
+template<typename X>
+X Lerp(const X& begin, const X& end, const float t)
+{
+	return begin*(1.f-t) + end*t;
+}
+
+// linear interpolation via int: 0=begin, base=end
+template<typename X, int base>
+X LerpInt(const X& begin, const X& end, const int t)
+{
+	return (begin*(base-t) + end*t) / base;
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -19,30 +19,124 @@
 
 #include <cmath>
 
-class Vec3
+class Vec3;
+
+// Like a Vec3, but acts on references
+class Vec3Ref
 {
 public:
 	union
 	{
 		struct
 		{
-			float x,y,z;
+			float& x;
+			float& y;
+			float& z;
 		};
 		struct
 		{
-			float r,g,b;
+			float& r;
+			float& g;
+			float& b;
 		};
 		struct
 		{
-			float u,v,w;
+			float& u;
+			float& v;
+			float& w;
 		};
 	};
 
 	float* AsArray() { return &x; }
 
-	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
-	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
-	Vec3() {}
+	Vec3Ref(float& _x, float& _y, float& _z) : x(_x), y(_y), z(_z) {}
+	Vec3Ref(float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
+
+	void Write(float a[3])
+	{
+		a[0] = x; a[1] = y; a[2] = z;
+	}
+
+	// operators acting on "this"
+	void operator = (const Vec3Ref& other)
+	{
+		x = other.x;
+		y = other.y;
+		z = other.z;
+	}
+	void operator += (const Vec3Ref &other)
+	{
+		x+=other.x; y+=other.y; z+=other.z;
+	}
+	void operator -= (const Vec3Ref &other)
+	{
+		x-=other.x; y-=other.y; z-=other.z;
+	}
+	void operator *= (const float f)
+	{
+		x*=f; y*=f; z*=f;
+	}
+	void operator /= (const float f)
+	{
+		x/=f; y/=f; z/=f;
+	}
+
+	// operators which require creating a new Vec3 object
+	Vec3 operator +(const Vec3Ref &other) const;
+	Vec3 operator -(const Vec3Ref &other) const;
+	Vec3 operator -() const;
+	Vec3 Mul(const Vec3Ref &other) const;
+	Vec3 operator * (const float f) const;
+	Vec3 operator / (const float f) const;
+
+	// methods which don't create new Vec3 objects
+	float Length2() const
+	{
+		return x*x + y*y + z*z;
+	}
+	float Length() const
+	{
+		return sqrtf(Length2());
+	}
+	void SetLength(const float l)
+	{
+		(*this) *= l / Length();
+	}
+	float Normalize() //returns the previous length, is often useful
+	{
+		float len = Length();
+		(*this) /= len;
+		return len;
+	}
+	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
+	{
+		return *((&x) + i);
+	}
+	float operator [] (const int i) const
+	{
+		return *((&x) + i);
+	}
+	void SetZero()
+	{
+		x=0.f;y=0.f;z=0.f;
+	}
+
+	// methods that create a new Vec3 object
+	Vec3 WithLength(const float l) const;
+	Vec3 Normalized() const;
+	Vec3 Lerp(const Vec3Ref &other, const float t) const;
+	float Distance2To(Vec3Ref &other) const;
+};
+
+class Vec3 : public Vec3Ref
+{
+public:
+	float x, y, z;
+
+	Vec3() : Vec3Ref(x, y, z) {}
+	Vec3(float _x, float _y, float _z) : Vec3Ref(x, y, z), x(_x), y(_y), z(_z) {}
+	Vec3(const float a[3]) : Vec3(a[0], a[1], a[2]) {}
+	Vec3(const Vec3Ref& other) : Vec3(other.x, other.y, other.z) {}
 
 	static Vec3 FromRGB(unsigned int rgb)
 	{
@@ -56,96 +150,8 @@ public:
 		return Vec3(f, f, f);
 	}
 
-	void Write(float a[3])
-	{
-		a[0] = x; a[1] = y; a[2] = z;
-	}
-	Vec3 operator +(const Vec3 &other) const
-	{
-		return Vec3(x+other.x, y+other.y, z+other.z);
-	}
-	void operator += (const Vec3 &other)
-	{
-		x+=other.x; y+=other.y; z+=other.z;
-	}
-	Vec3 operator -(const Vec3 &other) const
-	{
-		return Vec3(x-other.x, y-other.y, z-other.z);
-	}
-	void operator -= (const Vec3 &other)
-	{
-		x-=other.x; y-=other.y; z-=other.z;
-	}
-	Vec3 operator -() const
-	{
-		return Vec3(-x,-y,-z);
-	}
-	Vec3 Mul(const Vec3 &other) const
-	{
-		return Vec3(x*other.x, y*other.y, z*other.z);
-	}
-	Vec3 operator * (const float f) const
-	{
-		return Vec3(x*f,y*f,z*f);
-	}
-	void operator *= (const float f)
-	{
-		x*=f; y*=f; z*=f;
-	}
-	Vec3 operator / (const float f) const
-	{
-		float invf = (1.0f/f);
-		return Vec3(x*invf,y*invf,z*invf);
-	}
-	void operator /= (const float f)
-	{
-		*this = *this / f;
-	}
-	float Length2() const
-	{
-		return x*x + y*y + z*z;
-	}
-	float Length() const
-	{
-		return sqrtf(Length2());
-	}
-	void SetLength(const float l)
-	{
-		(*this) *= l / Length();
-	}
-	Vec3 WithLength(const float l) const
-	{
-		return (*this) * l / Length();
-	}
-	float Distance2To(Vec3 &other)
-	{
-		return Vec3(other-(*this)).Length2();
-	}
-	Vec3 Normalized() const {
-		return (*this) / Length();
-	}
-	float Normalize() { //returns the previous length, is often useful
-		float len = Length();
-		(*this) = (*this)/len;
-		return len;
-	}
-	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
-	{
-		return *((&x) + i);
-	}
-	float operator [] (const int i) const
-	{
-		return *((&x) + i);
-	}
-	Vec3 Lerp(const Vec3 &other, const float t) const
-	{
-		return (*this)*(1-t) + other*t;
-	}
-	void SetZero()
-	{
-		x=0;y=0;z=0;
-	}
 };
+
 
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
@@ -166,12 +172,12 @@ inline float Vec3Dot(const float v1[3], const float v2[3])
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }
 
-inline float Dot(const Vec3 &a, const Vec3& b)
+inline float Dot(const Vec3Ref &a, const Vec3Ref& b)
 {
 	return a.x*b.x + a.y*b.y + a.z*b.z;
 }
 
-inline Vec3 Cross(const Vec3 &a, const Vec3& b)
+inline Vec3 Cross(const Vec3Ref &a, const Vec3Ref& b)
 {
 	return Vec3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -820,14 +820,14 @@ inline Vec3<X,Y,Z> Cross(const Vec3Ref<X,Y,Z> &a, const Vec3Ref<X,Y,Z>& b)
 
 // linear interpolation via float: 0.0=begin, 1.0=end
 template<typename X>
-X Lerp(const X& begin, const X& end, const float t)
+inline X Lerp(const X& begin, const X& end, const float t)
 {
 	return begin*(1.f-t) + end*t;
 }
 
 // linear interpolation via int: 0=begin, base=end
 template<typename X, int base>
-X LerpInt(const X& begin, const X& end, const int t)
+inline X LerpInt(const X& begin, const X& end, const int t)
 {
 	return (begin*(base-t) + end*t) / base;
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -20,6 +20,196 @@
 #include <cmath>
 
 /**
+ * Vec2 - two dimensional vector with arbitrary base type
+ */
+template<typename X, typename Y=X>
+class Vec2;
+
+// Like a Vec2, but acts on references
+template<typename X, typename Y=X>
+class Vec2Ref
+{
+public:
+	union
+	{
+		struct
+		{
+			X& x;
+			Y& y;
+		};
+		struct
+		{
+			X& u;
+			Y& v;
+		};
+	};
+
+	X* AsArray() { return &x; }
+
+	Vec2Ref(X& _x, Y& _y) : x(_x), y(_y) {}
+
+	Vec2Ref(X a[2]) : x(a[0]), y(a[1]) {}
+
+	void Write(X a[2])
+	{
+		a[0] = x; a[1] = y;
+	}
+
+	// operators acting on "this"
+	void operator = (const Vec2Ref& other)
+	{
+		x = other.x;
+		y = other.y;
+	}
+	void operator += (const Vec2Ref &other)
+	{
+		x+=other.x; y+=other.y;
+	}
+	void operator -= (const Vec2Ref &other)
+	{
+		x-=other.x; y-=other.y;
+	}
+
+	void operator *= (const X& f)
+	{
+		x*=f; y*=f;
+	}
+	void operator /= (const X& f)
+	{
+		x/=f; y/=f;
+	}
+
+	// operators which require creating a new Vec2 object
+	Vec2<X,Y> operator +(const Vec2Ref &other) const;
+	Vec2<X,Y> operator -(const Vec2Ref &other) const;
+	Vec2<X,Y> operator -() const;
+	Vec2<X,Y> Mul(const Vec2Ref &other) const;
+	Vec2<X,Y> operator * (const X& f) const;
+	Vec2<X,Y> operator / (const X& f) const;
+
+	// methods which don't create new Vec2 objects
+	float Length2() const
+	{
+		return x*x + y*y;
+	}
+	float Length() const
+	{
+		return sqrtf(Length2());
+	}
+	void SetLength(const float l)
+	{
+		(*this) *= l / Length();
+	}
+	float Normalize() //returns the previous length, is often useful
+	{
+		float len = Length();
+		(*this) /= len;
+		return len;
+	}
+	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
+	{
+		return (i==0) ? x : y;
+	}
+	float operator [] (const int i) const
+	{
+		return (i==0) ? x : y;
+	}
+	void SetZero()
+	{
+		x=(X)0; y=(Y)0;
+	}
+
+	// methods that create a new Vec2 object
+	Vec2<X,Y> WithLength(const X& l) const;
+	Vec2<X,Y> Normalized() const;
+	Vec2<X,Y> Lerp(const Vec2Ref &other, const float t) const;
+	float Distance2To(const Vec2Ref &other) const;
+};
+
+template<typename X, typename Y>
+class Vec2 : public Vec2Ref<X,Y>
+{
+public:
+	X x;
+	Y y;
+
+	Vec2() : Vec2Ref<X,Y>(x, y) {}
+	Vec2(const X& _x, const Y& _y) : Vec2Ref<X,Y>(x, y), x(_x), y(_y) {}
+	Vec2(const X a[2]) : Vec2(a[0], a[1]) {}
+	Vec2(const Vec2Ref<X,Y>& other) : Vec2(other.x, other.y) {}
+
+	static Vec2 AssignToAll(X f)
+	{
+		return Vec2(f, f, f);
+	}
+};
+
+typedef Vec2<float> Vec2f;
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::operator +(const Vec2Ref<X,Y> &other) const
+{
+	return Vec2<X,Y>(x+other.x, y+other.y);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::operator -(const Vec2Ref<X,Y> &other) const
+{
+	return Vec2<X,Y>(x-other.x, y-other.y);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::operator -() const
+{
+	return Vec2<X,Y>(-x,-y);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::Mul(const Vec2Ref<X,Y> &other) const
+{
+	return Vec2<X,Y>(x*other.x, y*other.y);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::operator * (const X& f) const
+{
+	return Vec2<X,Y>(x*f,y*f);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::operator / (const X& f) const
+{
+	float invf = (1.0f/f);
+	return Vec2<X,Y>(x*invf,y*invf);
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::WithLength(const X& l) const
+{
+	return (*this) * l / Length();
+}
+
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+// TODO: Shouldn't be using a float parameter for all base types
+template<typename X, typename Y>
+Vec2<X,Y> Vec2Ref<X,Y>::Lerp(const Vec2Ref<X,Y> &other, const float t) const
+{
+	return (*this)*(1-t) + other*t;
+}
+
+template<typename X, typename Y>
+float Vec2Ref<X,Y>::Distance2To(const Vec2Ref<X,Y>& other) const
+{
+	return (other-(*this)).Length2();
+}
+
+
+/**
  * Vec3 - three dimensional vector with arbitrary base type
  */
 template<typename X, typename Y=X, typename Z=X>
@@ -443,6 +633,12 @@ inline float Vec3Dot(const float v1[3], const float v2[3])
 }
 
 // Dot product only really makes sense for same types
+template<typename X>
+inline X Dot(const Vec2Ref<X> &a, const Vec2Ref<X>& b)
+{
+	return a.x*b.x + a.y*b.y;
+}
+
 template<typename X>
 inline X Dot(const Vec3Ref<X> &a, const Vec3Ref<X>& b)
 {

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -55,6 +55,12 @@ public:
 
 	Vec2Ref(X a[2]) : x(a[0]), y(a[1]) {}
 
+	template<typename X2, typename Y2=X2>
+	Vec2<X2,Y2> Cast() const
+	{
+		return Vec2<X2,Y2>((X2)x, (Y2)y);
+	}
+
 	void Write(X a[2])
 	{
 		a[0] = x; a[1] = y;
@@ -133,6 +139,8 @@ public:
 	// swizzlers - create a subvector of references to specific components
 	Vec2Ref<Y,X> yx() { return Vec2Ref(y, x); }
 	Vec2Ref<Y,X> vu() { return Vec2Ref(v, u); }
+	const Vec2Ref<Y,X> yx() const { return Vec2Ref(y, x); }
+	const Vec2Ref<Y,X> vu() const { return Vec2Ref(v, u); }
 };
 
 template<typename X, typename Y>
@@ -257,6 +265,12 @@ public:
 
 	Vec3Ref(X a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 
+	template<typename X2, typename Y2=X2, typename Z2=X2>
+	Vec3<X2,Y2,Z2> Cast() const
+	{
+		return Vec3<X2,Y2,Z2>((X2)x, (Y2)y, (Z2)z);
+	}
+
 	void Write(X a[3])
 	{
 		a[0] = x; a[1] = y; a[2] = z;
@@ -338,9 +352,10 @@ public:
 
 	// swizzlers - create a subvector of references to specific components
 	// e.g. Vec2Ref<X,Y> xy() { return Vec2Ref<X,Y>(x,y); }
-	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+	// _DEFINE_SWIZZLER2 defines a single such function (and its "const" version)
+	// DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
 
-#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A, B> a##b() { return Vec2Ref<A,B>(a, b); }
+#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A,B> a##b() { return Vec2Ref<A,B>(a,b); }; const Vec2Ref<A,B> a##b() const { return Vec2Ref<A,B>(a,b); }
 #define DEFINE_SWIZZLER2(a, b, a2, b2, a3, b3, A, B) _DEFINE_SWIZZLER2(a, b, A, B); _DEFINE_SWIZZLER2(a2, b2, A, B); _DEFINE_SWIZZLER2(a3, b3, A, B); _DEFINE_SWIZZLER2(b, a, B, A); _DEFINE_SWIZZLER2(b2, a2, B, A); _DEFINE_SWIZZLER2(b3, a3, B, A);
 	DEFINE_SWIZZLER2(x, y, r, g, u, v, X, Y);
 	DEFINE_SWIZZLER2(x, z, r, b, u, w, X, Z);
@@ -471,6 +486,12 @@ public:
 
 	Vec4Ref(X a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 
+	template<typename X2, typename Y2=X2, typename Z2=X2, typename W2=X2>
+	Vec4<X2,Y2,Z2,W2> Cast() const
+	{
+		return Vec4<X2,Y2,Z2,W2>((X2)x, (Y2)y, (Z2)z, (W2)w);
+	}
+
 	void Write(X a[4])
 	{
 		a[0] = x; a[1] = y; a[2] = z; a[3] = w;
@@ -553,9 +574,10 @@ public:
 
 	// swizzlers - create a subvector of references to specific components
 	// e.g. Vec2Ref<X,Y> xy() { return Vec2Ref<X,Y>(x,y); }
-	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+	// _DEFINE_SWIZZLER2 defines a single such function (and its "const" version)
+	// DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
 
-#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A, B> a##b() { return Vec2Ref<A,B>(a, b); }
+#define _DEFINE_SWIZZLER2(a, b, A, B) Vec2Ref<A,B> a##b() { return Vec2Ref<A,B>(a,b); }; const Vec2Ref<A,B> a##b() const { return Vec2Ref<A,B>(a,b); }
 #define DEFINE_SWIZZLER2(a, b, a2, b2, A, B) _DEFINE_SWIZZLER2(a, b, A, B); _DEFINE_SWIZZLER2(a2, b2, A, B); _DEFINE_SWIZZLER2(b, a, B, A); _DEFINE_SWIZZLER2(b2, a2, B, A);
 	DEFINE_SWIZZLER2(x, y, r, g, X, Y);
 	DEFINE_SWIZZLER2(x, z, r, b, X, Z);
@@ -566,7 +588,7 @@ public:
 #undef DEFINE_SWIZZLER2
 #undef _DEFINE_SWIZZLER2
 
-#define _DEFINE_SWIZZLER3(a, b, c, A, B, C) Vec3Ref<A, B, C> a##b##c() { return Vec3Ref<A,B,C>(a, b, c); }
+#define _DEFINE_SWIZZLER3(a, b, c, A, B, C) Vec3Ref<A,B,C> a##b##c() { return Vec3Ref<A,B,C>(a,b,c); }; const Vec3Ref<A,B,C> a##b##c() const { return Vec3Ref<A,B,C>(a,b,c); }
 #define DEFINE_SWIZZLER3(a, b, c, a2, b2, c2, A, B, C) \
 	_DEFINE_SWIZZLER3(a, b, c, A, B, C); \
 	_DEFINE_SWIZZLER3(a, c, b, A, C, B); \

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -24,22 +24,28 @@ class Vec3
 public:
 	union
 	{
-		float v[3];
 		struct
 		{
 			float x,y,z;
 		};
+		struct
+		{
+			float r,g,b;
+		};
+		struct
+		{
+			float u,v,w;
+		};
 	};
+
+	float* AsArray() { return &x; }
+
 	Vec3(unsigned int rgb) {
 		x = (rgb & 0xFF) * (1.0f/255.0f);
 		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
 		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
 	}
-	Vec3(const float a[3]) {
-		v[0] = a[0];
-		v[1] = a[1];
-		v[2] = a[2];
-	}
+	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 	Vec3() {}
 	explicit Vec3(float f) : x(f), y(f), z(f) {}

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -40,15 +40,22 @@ public:
 
 	float* AsArray() { return &x; }
 
-	Vec3(unsigned int rgb) {
-		x = (rgb & 0xFF) * (1.0f/255.0f);
-		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
-		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
-	}
 	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 	Vec3() {}
-	explicit Vec3(float f) : x(f), y(f), z(f) {}
+
+	static Vec3 FromRGB(unsigned int rgb)
+	{
+		return Vec3((rgb & 0xFF) * (1.0f/255.0f),
+					((rgb >> 8) & 0xFF) * (1.0f/255.0f),
+					((rgb >> 16) & 0xFF) * (1.0f/255.0f));
+	}
+
+	static Vec3 AssignToAll(float f)
+	{
+		return Vec3(f, f, f);
+	}
+
 	void Write(float a[3])
 	{
 		a[0] = x; a[1] = y; a[2] = z;


### PR DESCRIPTION
Enhances the feature set of the existing utility Vec3 class by:
- supporting arbitrary base types for each component (e.g. Vec3<float>, Vec3<int, int, float>)
- supporting two-component and four-component vectors
- supporting vectors acting purely on references, thus being effective on memory usage (although I guess the compiler should've done this before already)
- supporting fast access of individual vector components as a subvector (e.g Vec4::rgb() returns a Vec3Ref consisting of references to the r, g, and b components)
- supporting more flexible component naming (e.g. "rgba" or "xyzw")

Additionally, this patch
- cleanly abstracts using Vec3 as a color or as an actual position vector.
- fixes some confusing oddities of the Vec3 API.
- might fix bugs caused by incorrect constructor usage (see below for details).

Changes for other people who used the code before:
- The star operator (_) refers to per-component product now (i.e. Vec2(v1.x_v1.x,v2.y*v2.y)) instead of the dot product. This is more consistent with what other APIs are doing (most notably GLSL/HLSL). For the dot product, a new Dot() function has been introduced. Additionally, Lerp has been made a global function instead of a VecXRef method. Existing code has been fixed to respect these changes.
- The % operator has been removed because it's not clear what it means. The new Cross() function should be used instead. There was no code using this functionality.
- The Vec3(u32 rgb) constructor has been removed due to its ambiguity. There have been some cases where the wrong constructor has been actually used, so this might even fix a bug. Anyway, instead the new static member functions Vec3::FromRGB and Vec4::FromRGBA should be used instead.
- What used to be Vec3 (i.e. a three-component vector acting on floats) is now Vec3f.
