### PR TITLE
Remove !gstate.isFogEnabled()

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -218,7 +218,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		if (gstate.isDepthTestEnabled()) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(depthMask || !gstate.isFogEnabled() || !gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
+			glstate.depthWrite.set(depthMask || !gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
 		} else {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);


### PR DESCRIPTION
Revert it to unbreak games like Tactic Urge and may be more.
