### PR TITLE
New attempt for depth change using gstate_c.framebufChanged

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -215,14 +215,14 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		
 		// Depth Test
 		bool depthMask = (gstate.clearmode >> 10) & 1;
-		if (gstate.isDepthTestEnabled()) {
-			glstate.depthTest.enable();
-			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(depthMask || !gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
-		} else {
+		if (gstate_c.framebufChanged) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);
 			glstate.depthWrite.set(GL_TRUE);
+		} else {
+			glstate.depthTest.enable();
+			glstate.depthFunc.set(GL_ALWAYS);
+			glstate.depthWrite.set(depthMask ? GL_TRUE : GL_FALSE);
 		}
 
 		// Color Test

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -173,12 +173,17 @@ TextureCache::TexCacheEntry *TextureCache::GetEntryAt(u32 texaddr) {
 
 void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer) {
 	// Must be in VRAM so | 0x04000000 it is.
+	gstate_c.framebufChanged = false;
 	TexCacheEntry *entry = GetEntryAt(address | 0x04000000);
 	if (entry) {
 		DEBUG_LOG(HLE, "Render to texture detected at %08x!", address);
-		if (!entry->framebuffer)
+		if (!entry->framebuffer) {
 			entry->framebuffer = framebuffer;
-		// TODO: Delete the original non-fbo texture too.
+		} else {
+			glBindTexture(GL_TEXTURE_2D, 0);
+			lastBoundTexture = -1;
+		}
+		gstate_c.framebufChanged = true;
 	}
 }
 


### PR DESCRIPTION
New attempt to use gstate_c.framebufChanged inside TextureCache::NotifyFramebuffer() to detect those render-to-texture for depth setting .

It fixes all the issues i tested so far . 
1. Saint Seiya Omega
   ![screen00006](https://f.cloud.github.com/assets/3000282/827692/d9b3e610-f0a1-11e2-89d0-563fbd65d35c.jpg)
2. Gundam AGE Universe
   ![screen00009](https://f.cloud.github.com/assets/3000282/827693/dd388aca-f0a1-11e2-8016-0bf7d84906c9.jpg)
3. Untold.Legends.2.The.Warriors.Code
   ![screen00007](https://f.cloud.github.com/assets/3000282/827695/df88ef5e-f0a1-11e2-8c48-69faeecf26a0.jpg)
4. Ridge Race 2
   ![screen00008](https://f.cloud.github.com/assets/3000282/827696/e20a5772-f0a1-11e2-9ef5-7a576a857e90.jpg)
