### PR TITLE
Fix various issues in non-buffered rendering mode. fix some & break some

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -176,11 +176,18 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 	TexCacheEntry *entry = GetEntryAt(address | 0x04000000);
 	if (entry) {
 		DEBUG_LOG(HLE, "Render to texture detected at %08x!", address);
-		if (!entry->framebuffer) {
-			entry->framebuffer = framebuffer;
-			// TODO: Delete the original non-fbo texture too.
-		}	else {
-			// Force a re-bind, fixes map in Tactics Ogre.
+		if (g_Config.bBufferedRendering) {
+			if (entry->framebuffer) {
+				// Force a re-bind, fixes map in Tactics Ogre.
+				glBindTexture(GL_TEXTURE_2D, 0);
+				lastBoundTexture = -1;
+			} else {
+				entry->framebuffer = framebuffer;
+				// TODO: Delete the original non-fbo texture too.
+			}
+		} else {
+			if (entry->framebuffer)
+				entry->framebuffer = 0;
 			glBindTexture(GL_TEXTURE_2D, 0);
 			lastBoundTexture = -1;
 		}


### PR DESCRIPTION
This fixes the following issues in non-buffered rendering mode .
1. Saint Seiya Omega (Missing background)
2. FF Crisi Core (Missing background)
3. Evangelion Jo (Overdim issue)
4. Kurohyou 2 (Overdim issue)
