### PR TITLE
Implement the majority of functions in sceCcc

### DIFF
--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -22,8 +22,8 @@
 #include "Core/HLE/HLE.h"
 #include "Core/Reporting.h"
 
-typedef PSPPointer<const char> PSPCharPointer;
-typedef PSPPointer<const u16> PSPWCharPointer;
+typedef PSPPointer<char> PSPCharPointer;
+typedef PSPPointer<u16> PSPWCharPointer;
 
 static u16 errorUTF8;
 static u16 errorUTF16;
@@ -133,22 +133,49 @@ int sceCccStrlenSJIS(u32 strAddr)
 	return ShiftJIS(str).length();
 }
 
-int sceCccEncodeUTF8(u32 dstAddr, u32 ucs)
+int sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
 {
-	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccEncodeUTF8(%08x, U+%04x)", dstAddr, ucs);
-	return 0;
+	PSPPointer<PSPCharPointer> dstp;
+	dstp = dstAddrAddr;
+
+	if (!dstp.IsValid() || !dstp->IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccEncodeUTF8(%08x, U+%04x): invalid pointer", dstAddrAddr, ucs);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccEncodeUTF8(%08x, U+%04x)", dstAddrAddr, ucs);
+	*dstp += UTF8::encode(*dstp, ucs);
+	return dstp->ptr;
 }
 
-int sceCccEncodeUTF16(u32 dstAddr, u32 ucs)
+int sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
 {
-	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccEncodeUTF8(%08x, U+%04x)", dstAddr, ucs);
-	return 0;
+	PSPPointer<PSPWCharPointer> dstp;
+	dstp = dstAddrAddr;
+
+	if (!dstp.IsValid() || !dstp->IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccEncodeUTF16(%08x, U+%04x): invalid pointer", dstAddrAddr, ucs);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccEncodeUTF16(%08x, U+%04x)", dstAddrAddr, ucs);
+	*dstp += UTF16LE::encode(*dstp, ucs);
+	return dstp->ptr;
 }
 
-int sceCccEncodeSJIS(u32 dstAddr, u32 ucs)
+int sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 {
-	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccEncodeSJIS(%08x, U+%04x)", dstAddr, ucs);
-	return 0;
+	PSPPointer<PSPCharPointer> dstp;
+	dstp = dstAddrAddr;
+
+	if (!dstp.IsValid() || !dstp->IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccEncodeSJIS(%08x, U+%04x): invalid pointer", dstAddrAddr, jis);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccEncodeSJIS(%08x, U+%04x)", dstAddrAddr, jis);
+	*dstp += ShiftJIS::encode(*dstp, jis);
+	return dstp->ptr;
 }
 
 int sceCccDecodeUTF8(u32 dstAddrAddr)

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -398,6 +398,42 @@ int sceCccDecodeSJIS(u32 dstAddrAddr)
 	return result;
 }
 
+int sceCccIsValidUTF8(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidUTF8(%08x)", c);
+	return c != 0;
+}
+
+int sceCccIsValidUTF16(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidUTF16(%08x)", c);
+	return c != 0;
+}
+
+int sceCccIsValidSJIS(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidSJIS(%08x)", c);
+	return c != 0;
+}
+
+int sceCccIsValidUCS2(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidUCS2(%08x)", c);
+	return c != 0;
+}
+
+int sceCccIsValidUCS4(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidUCS4(%08x)", c);
+	return c != 0;
+}
+
+int sceCccIsValidJIS(u32 c)
+{
+	WARN_LOG(HLE, "UNIMPL sceCccIsValidJIS(%08x)", c);
+	return c != 0;
+}
+
 u32 sceCccSetErrorCharUTF8(u32 c)
 {
 	DEBUG_LOG(HLE, "sceCccSetErrorCharUTF8(%08x)", c);
@@ -468,12 +504,12 @@ const HLEFunction sceCcc[] =
 	{0xc6a8bee2, WrapI_U<sceCccDecodeUTF8>, "sceCccDecodeUTF8"},
 	{0xe0cf8091, WrapI_U<sceCccDecodeUTF16>, "sceCccDecodeUTF16"},
 	{0x953e6c10, WrapI_U<sceCccDecodeSJIS>, "sceCccDecodeSJIS"},
-	{0x90521ac5, 0, "sceCccIsValidUTF8"},
-	{0xcc0a8bda, 0, "sceCccIsValidUTF16"},
-	{0x67bf0d19, 0, "sceCccIsValidSJIS"},
-	{0x76e33e9c, 0, "sceCccIsValidUCS2"},
-	{0xd2b18485, 0, "sceCccIsValidUCS4"},
-	{0xa2d5d209, 0, "sceCccIsValidJIS"},
+	{0x90521ac5, WrapI_U<sceCccIsValidUTF8>, "sceCccIsValidUTF8"},
+	{0xcc0a8bda, WrapI_U<sceCccIsValidUTF16>, "sceCccIsValidUTF16"},
+	{0x67bf0d19, WrapI_U<sceCccIsValidSJIS>, "sceCccIsValidSJIS"},
+	{0x76e33e9c, WrapI_U<sceCccIsValidUCS2>, "sceCccIsValidUCS2"},
+	{0xd2b18485, WrapI_U<sceCccIsValidUCS4>, "sceCccIsValidUCS4"},
+	{0xa2d5d209, WrapI_U<sceCccIsValidJIS>, "sceCccIsValidJIS"},
 	{0x17e1d813, WrapU_U<sceCccSetErrorCharUTF8>, "sceCccSetErrorCharUTF8"},
 	{0xb8476cf4, WrapU_U<sceCccSetErrorCharUTF16>, "sceCccSetErrorCharUTF16"},
 	{0xc56949ad, WrapU_U<sceCccSetErrorCharSJIS>, "sceCccSetErrorCharSJIS"},

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -93,20 +93,44 @@ int sceCccSJIStoUTF16(u32 dstAddr, int dstSize, u32 srcAddr)
 
 int sceCccStrlenUTF8(u32 strAddr)
 {
-	DEBUG_LOG(HLE, "sceCccStrlenUTF8(%08x)", strAddr);
-	return u8_strlen(Memory::GetCharPointer(strAddr));
+	PSPCharPointer str;
+	str = strAddr;
+
+	if (!str.IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccStrlenUTF8(%08x): invalid pointer", strAddr);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccStrlenUTF8(%08x): invalid pointer", strAddr);
+	return UTF8(str).length();
 }
 
 int sceCccStrlenUTF16(u32 strAddr)
 {
-	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccStrlenUTF16(%08x)", strAddr);
-	return 0;
+	PSPWCharPointer str;
+	str = strAddr;
+
+	if (!str.IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccStrlenUTF16(%08x): invalid pointer", strAddr);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccStrlenUTF16(%08x): invalid pointer", strAddr);
+	return UTF16LE(str).length();
 }
 
 int sceCccStrlenSJIS(u32 strAddr)
 {
-	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccStrlenSJIS(%08x)", strAddr);
-	return 0;
+	PSPCharPointer str;
+	str = strAddr;
+
+	if (!str.IsValid())
+	{
+		ERROR_LOG(HLE, "sceCccStrlenSJIS(%08x): invalid pointer", strAddr);
+		return 0;
+	}
+	DEBUG_LOG(HLE, "sceCccStrlenSJIS(%08x): invalid pointer", strAddr);
+	return ShiftJIS(str).length();
 }
 
 int sceCccEncodeUTF8(u32 dstAddr, u32 ucs)

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -20,6 +20,25 @@
 #include "Core/HLE/HLE.h"
 #include "Core/Reporting.h"
 
+static u16 errorUTF8;
+static u16 errorUTF16;
+static u16 errorSJIS;
+
+void __CccInit()
+{
+	errorUTF8 = 0;
+	errorUTF16 = 0;
+	errorSJIS = 0;
+}
+
+void __CccDoState(PointerWrap &p)
+{
+	p.Do(errorUTF8);
+	p.Do(errorUTF16);
+	p.Do(errorSJIS);
+	p.DoMarker("sceCcc");
+}
+
 int sceCccSetTable(u32 jis2ucs, u32 ucs2jis)
 {
 	// Both tables jis2ucs and ucs2jis have a size of 0x20000 bytes
@@ -132,6 +151,30 @@ int sceCccDecodeSJIS(u32 dstAddrAddr)
 	return 0;
 }
 
+u32 sceCccSetErrorCharUTF8(u32 c)
+{
+	DEBUG_LOG(HLE, "sceCccSetErrorCharUTF8(%08x)", c);
+	int result = errorUTF8;
+	errorUTF8 = c;
+	return result;
+}
+
+u32 sceCccSetErrorCharUTF16(u32 c)
+{
+	DEBUG_LOG(HLE, "sceCccSetErrorCharUTF16(%08x)", c);
+	int result = errorUTF16;
+	errorUTF16 = c;
+	return result;
+}
+
+u32 sceCccSetErrorCharSJIS(u32 c)
+{
+	DEBUG_LOG(HLE, "sceCccSetErrorCharSJIS(%04x)", c);
+	int result = errorSJIS;
+	errorSJIS = c;
+	return result;
+}
+
 int sceCccUCStoJIS()
 {
 	ERROR_LOG_REPORT(HLE, "UNIMPL sceCccUCStoJIS(?)");
@@ -168,9 +211,9 @@ const HLEFunction sceCcc[] =
 	{0x76e33e9c, 0, "sceCccIsValidUCS2"},
 	{0xd2b18485, 0, "sceCccIsValidUCS4"},
 	{0xa2d5d209, 0, "sceCccIsValidJIS"},
-	{0x17e1d813, 0, "sceCccSetErrorCharUTF8"},
-	{0xb8476cf4, 0, "sceCccSetErrorCharUTF16"},
-	{0xc56949ad, 0, "sceCccSetErrorCharSJIS"},
+	{0x17e1d813, WrapU_U<sceCccSetErrorCharUTF8>, "sceCccSetErrorCharUTF8"},
+	{0xb8476cf4, WrapU_U<sceCccSetErrorCharUTF16>, "sceCccSetErrorCharUTF16"},
+	{0xc56949ad, WrapU_U<sceCccSetErrorCharSJIS>, "sceCccSetErrorCharSJIS"},
 	{0x70ecaa10, WrapI_V<sceCccUCStoJIS>, "sceCccUCStoJIS"},
 	{0xfb7846e2, WrapI_V<sceCccJIStoUCS>, "sceCccJIStoUCS"},
 };

--- a/Core/HLE/sceCcc.h
+++ b/Core/HLE/sceCcc.h
@@ -19,4 +19,8 @@
 
 #include "HLE.h"
 
+class PointerWrap;
+
 void Register_sceCcc();
+void __CccInit();
+void __CccDoState(PointerWrap &p);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -37,6 +37,7 @@
 #include "__sceAudio.h"
 #include "sceAtrac.h"
 #include "sceAudio.h"
+#include "sceCcc.h"
 #include "sceCtrl.h"
 #include "sceDisplay.h"
 #include "sceFont.h"
@@ -107,6 +108,7 @@ void __KernelInit()
 	__AudioInit();
 	__SasInit();
 	__AtracInit();
+	__CccInit();
 	__DisplayInit();
 	__GeInit();
 	__PowerInit();
@@ -194,6 +196,7 @@ void __KernelDoState(PointerWrap &p)
 
 	__AtracDoState(p);
 	__AudioDoState(p);
+	__CccDoState(p);
 	__CtrlDoState(p);
 	__DisplayDoState(p);
 	__FontDoState(p);


### PR DESCRIPTION
With this, the full-width characters in Adventures To Go actually convert correctly.  I don't have any other games to test these funcs with.

Accept hrydgard/native#98 first.

Other games this may improve, probably only slightly:
- [Ape Escape Academy 2](http://report.ppsspp.org/logs/game/UCAS40052_1.00)
- [METAL SLUG Anthology](http://report.ppsspp.org/logs/game/ULUS10154_1.03) / [METAL SLUG Complete](http://report.ppsspp.org/logs/game/ULJS00090_1.06)
- [RIDGE RACER 2](http://report.ppsspp.org/logs/game/UCES00422_1.00)
- [Mystic Chronicles](http://report.ppsspp.org/logs/game/NPUH10189_1.03)
- [Corpse Party](http://report.ppsspp.org/logs/game/ULJM05704_1.03)
- [Akiba's Trip](http://report.ppsspp.org/logs/game/NPJH50412_1.07)
- [Patapon 3](http://report.ppsspp.org/logs/game/UCAS40318_1.00)
- [Super Robot Taisen 2nd](http://report.ppsspp.org/logs/game/ULJS00460_1.01)
- [One Piece: Romance Dawn](http://report.ppsspp.org/logs/game/NPJH50679_1.01)
- [Yu-Gi-Oh! 5D's Tag Force5](http://report.ppsspp.org/logs/game/ULUS10555_1.00)
- [God of War](http://report.ppsspp.org/logs/game/UCAS40198_1.00)
- [Trails in the Sky](http://report.ppsspp.org/logs/game/ULUS10540_1.00) (somewhere...)

Among others.

-[Unknown]
