### PR TITLE
change hash algorithm of QuickTexHash

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -783,32 +783,22 @@ static inline u32 QuickClutHash(const u8 *clut, u32 bytes) {
 }
 
 static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, u32 format) {
-	const u32 sizeInRAM = (bitsPerPixel[format < 11 ? format : 0] * bufw * h) / 8;
+	u32 sizeInRAM = (bitsPerPixel[format < 11 ? format : 0] * bufw * h) / 8;
 	const u32 *checkp = (const u32 *) Memory::GetPointer(addr);
-	u32 check = 0;
+	u32 check = 0x76057811;
 
-#ifdef _M_SSE
-	// Make sure both the size and start are aligned, OR will get either.
-	if ((((u32)(intptr_t)checkp | sizeInRAM) & 0x1f) == 0) {
-		__m128i cursor = _mm_set1_epi32(0);
-		const __m128i *p = (const __m128i *)checkp;
-		for (u32 i = 0; i < sizeInRAM / 16; i += 2) {
-			cursor = _mm_add_epi32(cursor, _mm_load_si128(&p[i]));
-			cursor = _mm_xor_si128(cursor, _mm_load_si128(&p[i + 1]));
-		}
-		// Add the four parts into the low i32.
-		cursor = _mm_add_epi32(cursor, _mm_srli_si128(cursor, 8));
-		cursor = _mm_add_epi32(cursor, _mm_srli_si128(cursor, 4));
-		check = _mm_cvtsi128_si32(cursor);
-	} else {
-#else
-	// TODO: ARM NEON implementation (using CPUDetect to be sure it has NEON.)
-	{
-#endif
-		for (u32 i = 0; i < sizeInRAM / 8; ++i) {
-			check += *checkp++;
-			check ^= *checkp++;
-		}
+	//for (u32 i = 0; i < sizeInRAM / 8; ++i) {
+	while(sizeInRAM>=16){
+		check = check*131 + *checkp++;
+		check = check*131 + *checkp++;
+		check = check*131 + *checkp++;
+		check = check*131 + *checkp++;
+		sizeInRAM -= 16;
+	}
+
+	while(sizeInRAM){
+		check = check*131 + *checkp++;
+		sizeInRAM -= 1;
 	}
 
 	return check;


### PR DESCRIPTION
This looks better than origin, and fix issue #2673.
I remove the SSE stuff. SSE cant make 32bit multiply.
