### PR TITLE
Fix UTF-16 surrogate pairs and sceCccEncodeUTF16() return value

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1184,9 +1184,9 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 		case 2:	// EMULATOR_DEVCTL__SEND_OUTPUT
 			{
 				std::string data(Memory::GetCharPointer(argAddr), argLen);
-				if (PSP_CoreParameter().printfEmuLog)	{
-					host->SendDebugOutput(data.c_str());
-				}	else {
+				if (PSP_CoreParameter().printfEmuLog) {
+					host->SendDebugOutput(data);
+				} else {
 					if (PSP_CoreParameter().collectEmuLog) {
 						*PSP_CoreParameter().collectEmuLog += data;
 					} else {

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -46,7 +46,7 @@ public:
 	virtual bool IsDebuggingEnabled() {return false;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
 
-	virtual void SendDebugOutput(const std::string &output) { printf("%s", output.c_str()); }
+	virtual void SendDebugOutput(const std::string &output) { fwrite(output.data(), sizeof(char), output.length(), stdout); }
 	virtual void SetComparisonScreenshot(const std::string &filename) {}
 
 

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -88,7 +88,7 @@ void WindowsHeadlessHost::LoadNativeAssets()
 
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)
 {
-	fprintf_s(out, "%s", output.c_str());
+	fwrite(output.data(), sizeof(char), output.length(), out);
 	OutputDebugString(output.c_str());
 }
 


### PR DESCRIPTION
It's pretty clear it returns a void.  Updates with a typo fix (both halves of the pair were being written to the same place, duh.)

It's possible the others might be void too...

Attempt at #2736.

-[Unknown]
