### PR TITLE
Fix "for The variable 'ringbuffer' is being used without being initialized"

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -392,9 +392,10 @@ u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 f
 
 	Memory::Memcpy(mpegHandle, "LIBMPEG.001", 12);
 	Memory::Write_U32(-1, mpegHandle + 12);
-	Memory::Write_U32(ringbufferAddr, mpegHandle + 16);
-	Memory::Write_U32(ringbuffer.dataUpperBound, mpegHandle + 20);
-
+	if (ringbufferAddr){
+		Memory::Write_U32(ringbufferAddr, mpegHandle + 16);
+		Memory::Write_U32(ringbuffer.dataUpperBound, mpegHandle + 20);
+	}
 	MpegContext *ctx = new MpegContext;
 	mpegMap[mpegHandle] = ctx;
 	lastMpegHandle = mpegHandle;


### PR DESCRIPTION
in Second Novel Kanojo no Natsu 15 fun no Kioku
(I careless run debug build in the game .I find that error.)
