### PR TITLE
FBO to memory : Llimit frameskip to 8 and code cleanup

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1150,7 +1150,7 @@ std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 void FramebufferManager::DecimateFBOs() {
 	fbo_unbind();
 	currentRenderVfb_ = 0;
-	int num = g_Config.iFrameSkip > 0 ? g_Config.iFrameSkip - 1 : 3;
+	int num = g_Config.iFrameSkip > 0 && g_Config.iFrameSkip != 9 ? g_Config.iFrameSkip : 3;
 	bool skipFrame = (gpuStats.numFrames % num == 0);
 	bool useFramebufferToMem = g_Config.iRenderingMode != FB_BUFFERED_MODE ? 1 : 0;
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1150,8 +1150,8 @@ std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 void FramebufferManager::DecimateFBOs() {
 	fbo_unbind();
 	currentRenderVfb_ = 0;
-	int skip = g_Config.iFrameSkip > 0 ? g_Config.iFrameSkip : 3;
-	bool thirdFrame = (gpuStats.numFrames % skip == 0);
+	int num = g_Config.iFrameSkip > 0 ? g_Config.iFrameSkip - 1 : 3;
+	bool skipFrame = (gpuStats.numFrames % num == 0);
 	bool useFramebufferToMem = g_Config.iRenderingMode != FB_BUFFERED_MODE ? 1 : 0;
 
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
@@ -1159,10 +1159,9 @@ void FramebufferManager::DecimateFBOs() {
 		int age = frameLastFramebufUsed - vfb->last_frame_used;
 
 		if(useFramebufferToMem) {
-			// Every third frame we'll commit framebuffers to memory
-			if(thirdFrame && age <= FBO_OLD_AGE) {
+			// Commit framebuffers to memory
+			if(skipFrame && age <= FBO_OLD_AGE) 
 				ReadFramebufferToMemory(vfb);
-			}
 		}
 
 		if (vfb == displayFramebuf_ || vfb == prevDisplayFramebuf_ || vfb == prevPrevDisplayFramebuf_) {


### PR DESCRIPTION
When frameskipping set to 9 , it will decimate every FBO with read framebuffer to memory ON.
