### PR TITLE
Fall back the depth test to the simplest and correct one

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -215,15 +215,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		
 		// Depth Test
 		bool depthMask = (gstate.clearmode >> 10) & 1;
-		if (gstate.isDepthTestEnabled()) {
-			glstate.depthTest.enable();
-			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(depthMask || !gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
-		} else {
-			glstate.depthTest.enable();
-			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(GL_TRUE);
-		}
+		glstate.depthTest.enable();
+		glstate.depthFunc.set(GL_ALWAYS);
+		glstate.depthWrite.set(depthMask ? GL_TRUE : GL_FALSE);
 
 		// Color Test
 		bool colorMask = (gstate.clearmode >> 8) & 1;


### PR DESCRIPTION
This fixes the previous breaking of character rendering in Untold Legend .
https://github.com/hrydgard/ppsspp/issues/2826

This also fixes the previous breaking of depth issue on rendering those lava in Ys 7
https://github.com/hrydgard/ppsspp/issues/2774
