### PR TITLE
Improve endian define handling and fix a couple typos

### DIFF
--- a/Common/CommonTypes.h
+++ b/Common/CommonTypes.h
@@ -54,13 +54,51 @@ typedef signed long long s64;
 
 #endif // _WIN32
 
+// Android
+#if defined(ANDROID)
+#include <sys/endian.h>
 
-#ifdef ANDROID
-#undef BIG_ENDIAN
-#undef __BIG_ENDIAN__
+#if _BYTE_ORDER == _LITTLE_ENDIAN && !defined(COMMON_LITTLE_ENDIAN)
+#define COMMON_LITTLE_ENDIAN 1
+#elif _BYTE_ORDER == _BIG_ENDIAN && !defined(COMMON_BIG_ENDIAN)
+#define COMMON_BIG_ENDIAN 1
 #endif
 
-#if !BIG_ENDIAN && !__BIG_ENDIAN__
+// GCC 4.6+
+#elif __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+
+#if __BYTE_ORDER__ && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && !defined(COMMON_LITTLE_ENDIAN)
+#define COMMON_LITTLE_ENDIAN 1
+#elif __BYTE_ORDER__ && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && !defined(COMMON_BIG_ENDIAN)
+#define COMMON_BIG_ENDIAN 1
+#endif
+
+// LLVM/clang
+#elif __clang__
+
+#if __LITTLE_ENDIAN__ && !defined(COMMON_LITTLE_ENDIAN)
+#define COMMON_LITTLE_ENDIAN 1
+#elif __BIG_ENDIAN__ && !defined(COMMON_BIG_ENDIAN)
+#define COMMON_BIG_ENDIAN 1
+#endif
+
+// MSVC
+#elif defined(_MSC_VER) && !defined(COMMON_BIG_ENDIAN) && !defined(COMMON_LITTLE_ENDIAN)
+
+#ifdef _XBOX
+#define COMMON_BIG_ENDIAN 1
+#else
+#define COMMON_LITTLE_ENDIAN 1
+#endif
+
+#endif
+
+// Worst case, default to little endian.
+#if !COMMON_BIG_ENDIAN && !COMMON_LITTLE_ENDIAN
+#define COMMON_LITTLE_ENDIAN 1
+#endif
+
+#if COMMON_LITTLE_ENDIAN
 typedef u32 u32_le;
 typedef u16 u16_le;
 typedef u64 u64_le;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -702,7 +702,7 @@ VirtualDiscFileSystem::VirtualDiscFileSystem(IHandleAllocator *_hAlloc, std::str
 
 VirtualDiscFileSystem::~VirtualDiscFileSystem() {
 	for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
-		if (!iter->second.type != VFILETYPE_ISO)
+		if (iter->second.type != VFILETYPE_ISO)
 			iter->second.hFile.Close();
 	}
 }

--- a/Core/Font/PGF.h
+++ b/Core/Font/PGF.h
@@ -109,12 +109,7 @@ struct Glyph {
 };
 
 
-#ifdef ANDROID
-#undef BIG_ENDIAN
-#undef __BIG_ENDIAN__
-#endif
-
-#if !BIG_ENDIAN && !__BIG_ENDIAN__
+#if COMMON_LITTLE_ENDIAN
 typedef FontPixelFormat FontPixelFormat_le;
 #else
 #error FIX ME

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -46,7 +46,7 @@ const int hostAttemptBlockSize = 256;
 #else
 const int hwBlockSize = 64;
 const int hostAttemptBlockSize = 512;
-#endif;
+#endif
 
 const int audioIntervalUs = (int)(1000000ULL * hwBlockSize / hwSampleRate);
 const int audioHostIntervalUs = (int)(1000000ULL * hostAttemptBlockSize / hwSampleRate);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include "Common/LogManager.h"
+#include "Common/CommonTypes.h"
 #include "HLE.h"
 #include "HLETables.h"
 #include "../MIPS/MIPSInt.h"
@@ -149,7 +150,7 @@ public:
 	u32 savedIdRegister;
 };
 
-#if !defined(BIG_ENDIAN) && !defined(__BIG_ENDIAN__)
+#if COMMON_LITTLE_ENDIAN
 typedef WaitType WaitType_le;
 #else
 #error FIX ME


### PR DESCRIPTION
On Android, `BIG_ENDIAN` is 4321 and `LITTLE_ENDIAN` is 1234.  It also defines `__BIG_ENDIAN` and `_BIG_ENDIAN`.  These are meant to be tested against `_BYTE_ORDER`, and come from `<sys/endian.h>`.

GCC 4.6 normally uses `__BYTE_ORDER__` and `__ORDER_LITTLE_ENDIAN__` / `__ORDER_BIG_ENDIAN__` however.  They work the same way.

LLVM simply uses `__LITTLE_ENDIAN__` as 1, the obvious simple option.

MSVC provides nothing, but `_XBOX` seems like a reasonable test to make (ignoring the existence of the Xbox One.)

Because of this, I made it use `COMMON_LITTLE_ENDIAN` and `COMMON_BIG_ENDIAN`, which should have less conflicts.  They can be defined in e.g. CMake / Qt / etc. in the case that the above detections fail.

This implements the above, and updates native with similar fixes + a quickfix for an iOS build error.  See hrydgard/native#100 which should be merged first.

Tested on iOS, Mac, Windows, and Android.  Not actually tested on anything that isn't little endian, though.

-[Unknown]
