### PR TITLE
Clamp vpX0/vpY0 to zero when negative value retured

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -364,6 +364,11 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 		// Flip vpY0 to match the OpenGL coordinate system.
 		vpY0 = renderHeight - (vpY0 + vpHeight);
+		
+		// Clamp vpX0/vpY0 to zero when negative value retured.
+		vpY0 = vpY0 < 0 ? 0 : vpY0;
+		vpX0 = vpX0 < 0 ? 0 : vpX0;
+		
 		glstate.viewport.set(vpX0 + renderX, vpY0 + renderY, vpWidth, vpHeight);
 		// Sadly, as glViewport takes integers, we will not be able to support sub pixel offsets this way. But meh.
 		// shaderManager_->DirtyUniform(DIRTY_PROJMATRIX);


### PR DESCRIPTION
This fixes negative values may return to the lower left corner of the viewport rectangle in the glviewport call and cause black screen in some games like Coded Soul and may be others

-Before
![screen00002](https://f.cloud.github.com/assets/3000282/865729/b5641234-f642-11e2-9b92-a79fb6cb372f.jpg)

-After 
![screen00000](https://f.cloud.github.com/assets/3000282/865722/8ae9e272-f642-11e2-9964-bf2f10f37f4b.jpg)
