### PR TITLE
Win32 UI: Fix Window Zoom menu.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1210,7 +1210,7 @@ namespace MainWindow
 			ID_OPTIONS_SCREEN4X,
 		};
 		for (int i = 0; i < 4; i++) {
-			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iWindowZoom - 1) ? MF_CHECKED : MF_UNCHECKED));
+			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iWindowZoom-1) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
 		static const int texscalingitems[] = {
@@ -1268,16 +1268,6 @@ namespace MainWindow
 		};
 		for (int i = 0; i < 9; i++) {
 			CheckMenuItem(menu, frameskipping[i], MF_BYCOMMAND | ( i == g_Config.iFrameSkip )? MF_CHECKED : MF_UNCHECKED);
-		}
-
-		static const int zoommode[] = {
-			ID_OPTIONS_SCREEN1X,
-			ID_OPTIONS_SCREEN2X,
-			ID_OPTIONS_SCREEN3X,
-			ID_OPTIONS_SCREEN4X,
-		};
-		for (int i = 0; i < 4; i++) {
-			CheckMenuItem(menu, zoommode[i], MF_BYCOMMAND | ( i == g_Config.iWindowZoom )? MF_CHECKED : MF_UNCHECKED);
 		}
 
 		UpdateCommands();

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1210,7 +1210,7 @@ namespace MainWindow
 			ID_OPTIONS_SCREEN4X,
 		};
 		for (int i = 0; i < 4; i++) {
-			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iWindowZoom-1) ? MF_CHECKED : MF_UNCHECKED));
+			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iWindowZoom - 1) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
 		static const int texscalingitems[] = {


### PR DESCRIPTION
For some reason a second loop was added to check or uncheck the items in #2934, and it was off by one, resulting in the option that was checked to be incorrect.
