### PR TITLE
Win32 UI: Fix frameskipping menu & minor cleanup.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1209,7 +1209,7 @@ namespace MainWindow
 			ID_OPTIONS_SCREEN3X,
 			ID_OPTIONS_SCREEN4X,
 		};
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < ARRAY_SIZE(zoomitems); i++) {
 			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iWindowZoom - 1) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
@@ -1220,7 +1220,7 @@ namespace MainWindow
 			ID_TEXTURESCALING_4X,
 			ID_TEXTURESCALING_5X,
 		};
-		for (int i = 0; i < 5; i++) {
+		for (int i = 0; i < ARRAY_SIZE(texscalingitems); i++) {
 			CheckMenuItem(menu, texscalingitems[i], MF_BYCOMMAND | ((i == g_Config.iTexScalingLevel - 1) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
@@ -1230,7 +1230,7 @@ namespace MainWindow
 			ID_TEXTURESCALING_BICUBIC,
 			ID_TEXTURESCALING_HYBRID_BICUBIC,
 		};
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < ARRAY_SIZE(texscalingtypeitems); i++) {
 			CheckMenuItem(menu, texscalingtypeitems[i], MF_BYCOMMAND | ((i == g_Config.iTexScalingType) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
@@ -1240,7 +1240,7 @@ namespace MainWindow
 			ID_OPTIONS_LINEARFILTERING,
 			ID_OPTIONS_LINEARFILTERING_CG,
 		};
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < ARRAY_SIZE(texfilteringitems); i++) {
 			CheckMenuItem(menu, texfilteringitems[i], MF_BYCOMMAND | ( (i + 1) == g_Config.iTexFiltering )? MF_CHECKED : MF_UNCHECKED);
 		}
 
@@ -1250,7 +1250,7 @@ namespace MainWindow
 			ID_OPTIONS_READFBOTOMEMORYCPU,
 			ID_OPTIONS_READFBOTOMEMORYGPU,
 		};
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < ARRAY_SIZE(renderingmode); i++) {
 			CheckMenuItem(menu, renderingmode[i], MF_BYCOMMAND | ( i == g_Config.iRenderingMode )? MF_CHECKED : MF_UNCHECKED);
 		}
 
@@ -1266,7 +1266,7 @@ namespace MainWindow
 			ID_OPTIONS_FRAMESKIP_8,
 			ID_OPTIONS_FRAMESKIP_9,
 		};
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < ARRAY_SIZE(frameskipping); i++) {
 			CheckMenuItem(menu, frameskipping[i], MF_BYCOMMAND | ( i == g_Config.iFrameSkip )? MF_CHECKED : MF_UNCHECKED);
 		}
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1221,7 +1221,7 @@ namespace MainWindow
 			ID_TEXTURESCALING_5X,
 		};
 		for (int i = 0; i < 5; i++) {
-			CheckMenuItem(menu, texscalingitems[i], MF_BYCOMMAND | ((i == g_Config.iTexScalingLevel-1) ? MF_CHECKED : MF_UNCHECKED));
+			CheckMenuItem(menu, texscalingitems[i], MF_BYCOMMAND | ((i == g_Config.iTexScalingLevel - 1) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
 		static const int texscalingtypeitems[] = {
@@ -1266,7 +1266,7 @@ namespace MainWindow
 			ID_OPTIONS_FRAMESKIP_8,
 			ID_OPTIONS_FRAMESKIP_9,
 		};
-		for (int i = 0; i < 9; i++) {
+		for (int i = 0; i < 10; i++) {
 			CheckMenuItem(menu, frameskipping[i], MF_BYCOMMAND | ( i == g_Config.iFrameSkip )? MF_CHECKED : MF_UNCHECKED);
 		}
 


### PR DESCRIPTION
Picking frameskipping level 9 would never work due to how the loop was configured(it was set to check 0 to 8 instead of the full 0 to 9 range). Also clean up by removing magic numbers, instead using ARRAY_SIZE to loop. Fixes another issue with https://github.com/hrydgard/ppsspp/pull/2934.
