### PR TITLE
64-bit PPSSPP(Windows): Attempt to fix games that crash with atrac3+ DLLs.

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -590,7 +590,7 @@ int MediaEngine::getAudioSamples(u8* buffer) {
 	}
 	int outbytes = 0;
 
-	if(m_audioContext != nullptr)
+	if(m_audioContext != NULL)
 		Atrac3plus_Decoder::Decode(m_audioContext, audioFrame, frameSize, &outbytes, buffer);
 
 	if (headerCode1 == 0x24) {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -589,7 +589,10 @@ int MediaEngine::getAudioSamples(u8* buffer) {
 		return 0;
 	}
 	int outbytes = 0;
-	Atrac3plus_Decoder::Decode(m_audioContext, audioFrame, frameSize, &outbytes, buffer);
+
+	if(m_audioContext != nullptr)
+		Atrac3plus_Decoder::Decode(m_audioContext, audioFrame, frameSize, &outbytes, buffer);
+
 	if (headerCode1 == 0x24) {
 		// it a mono atrac3plus, convert it to stereo
 		s16 *outbuf = (s16*)buffer;


### PR DESCRIPTION
It seems to be caused by m_audiocontext being null..

Fixes at least:
1. Pangya Fantasy Golf(US)
2. Growlanser (seems to have the same issue? https://github.com/hrydgard/ppsspp/issues/2675)
