### PR TITLE
Fix some warnings generated by gcc 4.8 and clang

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -320,7 +320,11 @@ void ARMXEmitter::FlushIcacheSection(u8 *start, u8 *end)
 	// Header file says this is equivalent to: sys_icache_invalidate(start, end - start);
 	sys_cache_control(kCacheFunctionPrepareForExecution, start, end - start);
 #elif !defined(_WIN32)
+#ifdef __clang__
+	__clear_cache(start, end);
+#else
 	__builtin___clear_cache(start, end);
+#endif
 #endif
 }
 

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -175,7 +175,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 	int flag_bits, seg_bits, type_bits;
 	int cmd, flag, seg, type;
 	int off_seg = 0, addr_seg, rel_base, rel_offset;
-	int relocate_to, last_type, lo16;
+	int relocate_to, last_type, lo16 = 0;
 	u32 op, addr;
 	int rcount = 0;
 

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -803,10 +803,10 @@ std::string VirtualDiscFileSystem::GetLocalPath(std::string localpath) {
 
 int VirtualDiscFileSystem::getFileListIndex(std::string& fileName)
 {
-	for (int i = 0; i < fileList.size(); i++)
+	for (size_t i = 0; i < fileList.size(); i++)
 	{
 		if (fileList[i].fileName == fileName)
-			return i;
+			return (int)i;
 	}
 
 	// unknown file - add it
@@ -841,7 +841,7 @@ int VirtualDiscFileSystem::getFileListIndex(std::string& fileName)
 
 int VirtualDiscFileSystem::getFileListIndex(u32 accessBlock, u32 accessSize)
 {
-	for (int i = 0; i < fileList.size(); i++)
+	for (size_t i = 0; i < fileList.size(); i++)
 	{
 		if (fileList[i].firstBlock <= accessBlock)
 		{
@@ -849,7 +849,7 @@ int VirtualDiscFileSystem::getFileListIndex(u32 accessBlock, u32 accessSize)
 			u32 endOffset = sectorOffset+accessSize;
 			if (endOffset <= fileList[i].totalSize)
 			{
-				return i;
+				return (int)i;
 			}
 		}
 	}
@@ -883,12 +883,13 @@ u32 VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, con
 		entry.type = VFILETYPE_LBN;
 		entry.size = readSize;
 
-		entry.fileIndex = getFileListIndex(sectorStart,readSize);
-		if (entry.fileIndex == -1)
+		int fileIndex = getFileListIndex(sectorStart,readSize);
+		if (fileIndex == -1)
 		{
 			ERROR_LOG(FILESYS, "VirtualDiscFileSystem: sce_lbn used without calling fileinfo.");
 			return 0;
 		}
+		entry.fileIndex = (u32)fileIndex;
 
 		entry.startOffset = (sectorStart-fileList[entry.fileIndex].firstBlock)*2048;
 
@@ -969,6 +970,7 @@ size_t VirtualDiscFileSystem::SeekFile(u32 handle, s32 position, FileMove type) 
 				return iter->second.curOffset;
 			}
 		}
+		return 0;
 	} else {
 		//This shouldn't happen...
 		ERROR_LOG(HLE,"VirtualDiscFileSystem: Cannot seek in file that hasn't been opened: %08x", handle);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -988,7 +988,7 @@ size_t VirtualDiscFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 			int fileIndex = getFileListIndex(iter->second.curOffset,size*2048);
 			if (fileIndex == -1)
 			{
-				ERROR_LOG(HLE,"VirtualDiscFileSystem: Reading from unknown address", handle);
+				ERROR_LOG(HLE,"VirtualDiscFileSystem: Reading from unknown address %08x", handle);
 				return 0;
 			}
 			

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -641,7 +641,7 @@ void ISOFileSystem::DoState(PointerWrap &p)
 			p.Do(of.sectorStart);
 			p.Do(of.openSize);
 
-			bool hasFile;
+			bool hasFile = false;
 			p.Do(hasFile);
 			if (hasFile) {
 				std::string path;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1734,11 +1734,6 @@ int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBu
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
 	}
 
-	if (readSize < 0 || halfBufferSize < 0) {
-		ERROR_LOG_REPORT(HLE, "sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x): invalid buffer size", halfBuffer, readSize, halfBufferSize);
-		return -1;
-	}
-
 	int codecType = getCodecType(halfBuffer);
 	Atrac *atrac = new Atrac();
 	atrac->first.addr = halfBuffer;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -313,7 +313,7 @@ u32 sceAudioOutput2Reserve(u32 sampleCount) {
 
 u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr){
 	// Note: 0xFFFFF, not 0xFFFF!
-	if (vol < 0 || vol > 0xFFFFF) {
+	if (vol > 0xFFFFF) {
 		ERROR_LOG(HLE,"sceAudioOutput2OutputBlocking(%08x, %08x) - invalid volume", vol, dataPtr);
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
 	}
@@ -401,7 +401,7 @@ u32 sceAudioSRCChRelease() {
 }
 
 u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
-	if (vol < 0 || vol > 0xFFFFF) {
+	if (vol > 0xFFFFF) {
 		ERROR_LOG(HLE,"sceAudioSRCOutputBlocking(%08x, %08x) - invalid volume", vol, buf);
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
 	}

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -336,7 +336,7 @@ u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 	return dstp->ptr;
 }
 
-int sceCccDecodeUTF8(u32 dstAddrAddr)
+u32 sceCccDecodeUTF8(u32 dstAddrAddr)
 {
 	PSPPointer<PSPCharPointer> dstp;
 	dstp = dstAddrAddr;
@@ -349,7 +349,7 @@ int sceCccDecodeUTF8(u32 dstAddrAddr)
 
 	DEBUG_LOG(HLE, "sceCccDecodeUTF8(%08x)", dstAddrAddr);
 	UTF8 utf(*dstp);
-	int result = utf.next();
+	u32 result = utf.next();
 	*dstp += utf.byteIndex();
 
 	if (result == UTF8::INVALID)
@@ -357,7 +357,7 @@ int sceCccDecodeUTF8(u32 dstAddrAddr)
 	return result;
 }
 
-int sceCccDecodeUTF16(u32 dstAddrAddr)
+u32 sceCccDecodeUTF16(u32 dstAddrAddr)
 {
 	PSPPointer<PSPWCharPointer> dstp;
 	dstp = dstAddrAddr;
@@ -371,7 +371,7 @@ int sceCccDecodeUTF16(u32 dstAddrAddr)
 	DEBUG_LOG(HLE, "sceCccDecodeUTF16(%08x)", dstAddrAddr);
 	// TODO: Does it do any detection of BOM?
 	UTF16LE utf(*dstp);
-	int result = utf.next();
+	u32 result = utf.next();
 	*dstp += utf.byteIndex();
 
 	if (result == UTF16LE::INVALID)
@@ -379,7 +379,7 @@ int sceCccDecodeUTF16(u32 dstAddrAddr)
 	return result;
 }
 
-int sceCccDecodeSJIS(u32 dstAddrAddr)
+u32 sceCccDecodeSJIS(u32 dstAddrAddr)
 {
 	PSPPointer<PSPCharPointer> dstp;
 	dstp = dstAddrAddr;
@@ -392,7 +392,7 @@ int sceCccDecodeSJIS(u32 dstAddrAddr)
 
 	DEBUG_LOG(HLE, "sceCccDecodeSJIS(%08x)", dstAddrAddr);
 	ShiftJIS sjis(*dstp);
-	int result = sjis.next();
+	u32 result = sjis.next();
 	*dstp += sjis.byteIndex();
 
 	if (result == ShiftJIS::INVALID)
@@ -503,9 +503,9 @@ const HLEFunction sceCcc[] =
 	{0x92C05851, WrapU_UU<sceCccEncodeUTF8>, "sceCccEncodeUTF8"},
 	{0x8406F469, WrapV_UU<sceCccEncodeUTF16>, "sceCccEncodeUTF16"},
 	{0x068c4320, WrapU_UU<sceCccEncodeSJIS>, "sceCccEncodeSJIS"},
-	{0xc6a8bee2, WrapI_U<sceCccDecodeUTF8>, "sceCccDecodeUTF8"},
-	{0xe0cf8091, WrapI_U<sceCccDecodeUTF16>, "sceCccDecodeUTF16"},
-	{0x953e6c10, WrapI_U<sceCccDecodeSJIS>, "sceCccDecodeSJIS"},
+	{0xc6a8bee2, WrapU_U<sceCccDecodeUTF8>, "sceCccDecodeUTF8"},
+	{0xe0cf8091, WrapU_U<sceCccDecodeUTF16>, "sceCccDecodeUTF16"},
+	{0x953e6c10, WrapU_U<sceCccDecodeSJIS>, "sceCccDecodeSJIS"},
 	{0x90521ac5, WrapI_U<sceCccIsValidUTF8>, "sceCccIsValidUTF8"},
 	{0xcc0a8bda, WrapI_U<sceCccIsValidUTF16>, "sceCccIsValidUTF16"},
 	{0x67bf0d19, WrapI_U<sceCccIsValidSJIS>, "sceCccIsValidSJIS"},

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1261,7 +1261,7 @@ u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
 			WARN_LOG(HLE, "AllockMemoryBlock(SysMemUserForUser_FE707FDF) : unknown parameters with length %d", length);
 		}
 	}
-	if (type < 0 || type > 1) {
+	if (type > 1) {
 		return SCE_KERNEL_ERROR_ILLEGAL_MEMBLOCKTYPE;
 	}
 

--- a/Core/HW/OMAConvert.cpp
+++ b/Core/HW/OMAConvert.cpp
@@ -23,6 +23,11 @@ template <typename T> void BigEndianWriteBuf(u8* buf, T x, int &pos)
 	pos += k;
 }
 
+template <> void BigEndianWriteBuf<u8>(u8* buf, u8 x, int &pos)
+{
+	buf[pos++] = x;
+}
+
 template <typename T> inline T getBufValue(T* buf, int offsetbytes)
 {
 	return *(T*)(((u8*)buf) + offsetbytes);

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -56,10 +56,10 @@ void Jit::Comp_FPU3op(u32 op)
 	case 2: { //F(fd) = F(fs) * F(ft); //mul
 		u32 nextOp = Memory::Read_Instruction(js.compilerPC + 4);
 		// Optimise possible if destination is the same
-		if (fd == ((nextOp>>6) & 0x1F)) {
+		if (fd == (int)((nextOp>>6) & 0x1F)) {
 			// VMUL + VNEG -> VNMUL
 			if (!strcmp(MIPSGetName(nextOp), "neg.s")) {
-				if (fd == ((nextOp>>11) & 0x1F)) {
+				if (fd == (int)((nextOp>>11) & 0x1F)) {
 					VNMUL(fpr.R(fd), fpr.R(fs), fpr.R(ft));
 					EatInstruction(nextOp);
 				}

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -193,7 +193,7 @@ void ArmRegCache::FlushR(MIPSReg r) {
 		break;
 
 	case ML_ARMREG:
-		if (mr[r].reg == (int)INVALID_REG) {
+		if (mr[r].reg == INVALID_REG) {
 			ERROR_LOG(HLE, "FlushMipsReg: MipsReg had bad ArmReg");
 		}
 		if (ar[mr[r].reg].isDirty) {

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -329,7 +329,7 @@ void JitBlockCache::DestroyBlock(int block_num, bool invalidate)
 		return;
 	}
 	b.invalid = true;
-	if ((int)Memory::ReadUnchecked_U32(b.originalAddress) == GetEmuHackOpForBlock(block_num))
+	if (Memory::ReadUnchecked_U32(b.originalAddress) == GetEmuHackOpForBlock(block_num))
 		Memory::WriteUnchecked_U32(b.originalFirstOpcode, b.originalAddress);
 	b.normalEntry = 0;
 

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -219,7 +219,6 @@ public:
 	void Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], Vec3 pos, Vec3 normal);
 
 private:
-	bool disabled_;
 	Color4 globalAmbient;
 	Color4 materialEmissive;
 	Color4 materialAmbient;

--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -210,7 +210,7 @@ class VertexReader
 public:
 	VertexReader(u8 *base, const DecVtxFormat &decFmt, int vtype) : base_(base), data_(base), decFmt_(decFmt), vtype_(vtype) {}
 
-	void ReadPos(float pos[3]) {
+	void ReadPos(float pos[3]) const {
 		switch (decFmt_.posfmt) {
 		case DEC_FLOAT_3:
 			{
@@ -259,7 +259,7 @@ public:
 		}
 	}
 
-	void ReadNrm(float nrm[3]) {
+	void ReadNrm(float nrm[3]) const {
 		switch (decFmt_.nrmfmt) {
 		case DEC_FLOAT_3:
 			//memcpy(nrm, data_ + decFmt_.nrmoff, 12);
@@ -290,7 +290,7 @@ public:
 		}
 	}
 
-	void ReadUV(float uv[2]) {
+	void ReadUV(float uv[2]) const {
 		switch (decFmt_.uvfmt) {
 		case DEC_U8_2:
 			{
@@ -330,7 +330,7 @@ public:
 		}
 	}
 
-	void ReadColor0(float color[4]) {
+	void ReadColor0(float color[4]) const {
 		switch (decFmt_.c0fmt) {
 		case DEC_U8_4:
 			{
@@ -349,7 +349,7 @@ public:
 		}
 	}
 
-	void ReadColor1(float color[3]) {
+	void ReadColor1(float color[3]) const {
 		switch (decFmt_.c1fmt) {
 		case DEC_U8_4:
 			{
@@ -368,7 +368,7 @@ public:
 		}
 	}
 
-	void ReadWeights(float weights[8]) {
+	void ReadWeights(float weights[8]) const {
 		const float *f = (const float *)(data_ + decFmt_.w0off);
 		const u8 *b = (const u8 *)(data_ + decFmt_.w0off);
 		const u16 *s = (const u16 *)(data_ + decFmt_.w0off);


### PR DESCRIPTION
From the new NDK.  No really major ones.  Android clang builds but doesn't link, probably libc++ or something but didn't really look into it.

Oops, may overlap with #2942.

-[Unknown]
