### PR TITLE
Fix minor crash on error screen, invalid filename on drive letter

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -29,12 +29,12 @@
 // TODO : improve, look in the file more
 EmuFileType Identify_File(std::string &filename)
 {
-	if (filename.size() < 5) {
+	if (filename.size() == 0) {
 		ERROR_LOG(LOADER, "invalid filename %s", filename.c_str());
 		return FILETYPE_ERROR;
 	}
 
-	std::string extension = filename.substr(filename.size() - 4);
+	std::string extension = filename.size() >= 5 ? filename.substr(filename.size() - 4) : "";
 	if (!strcasecmp(extension.c_str(),".iso"))
 	{
 		return FILETYPE_PSP_ISO;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -548,5 +548,6 @@ void EmuScreen::render() {
 
 void EmuScreen::deviceLost() {
 	ILOG("EmuScreen::deviceLost()");
-	gpu->DeviceLost();
+	if (gpu)
+		gpu->DeviceLost();
 }


### PR DESCRIPTION
Might as well allow any length, I guess.  I could want to run a directory `1` relative to `./`.

-[Unknown]
