### PR TITLE
Fix mipmapping artifact in Shin Sangoku Musou Multi Raid

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1191,13 +1191,13 @@ void TextureCache::SetTexture() {
 #ifndef USING_GLES2
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 #endif
+		UpdateSamplingParams(*entry, true);
 	}
 
 	int aniso = 1 << g_Config.iAnisotropyLevel;
 	float anisotropyLevel = (float) aniso > maxAnisotropyLevel ? maxAnisotropyLevel : (float) aniso;
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropyLevel);
 
-	UpdateSamplingParams(*entry, true);
 
 	//glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);


### PR DESCRIPTION
I'm not too sure if this makes sense to force load texture sample parameters only when mipmap is disabled.

This fixes the following artifact in  Shin Sangoku Musou Multi Raid while still maintain the previous text fix for Tactic Orge

-Before
![screen00015](https://f.cloud.github.com/assets/3000282/867175/d3997f6c-f6da-11e2-82d9-de0ccdda13f9.jpg)

-After
![screen00014](https://f.cloud.github.com/assets/3000282/867177/dfaad6b6-f6da-11e2-9bda-1a2eae4a5915.jpg)
