### PR TITLE
Add New Feature: Ability to turn logging on and off.

### DIFF
--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -22,6 +22,7 @@
 #include "Timer.h"
 #include "Thread.h"
 #include "FileUtil.h"
+#include "../Core/Config.h"
 #ifdef __SYMBIAN32__
 #include <e32debug.h>
 #endif
@@ -36,6 +37,8 @@ const char *hleCurrentThreadName = NULL;
 void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
 		const char *file, int line, const char* fmt, ...)
 {
+	if(!g_Config.bEnableLogging) return;
+
 	va_list args;
 	va_start(args, fmt);
 	if (LogManager::GetInstance())

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -50,6 +50,7 @@ void Config::Load(const char *iniFileName)
 	bSpeedLimit = false;
 	general->Get("FirstRun", &bFirstRun, true);
 	general->Get("NewUI", &bNewUI, false);
+	general->Get("EnableLogging", &bEnableLogging, true);
 	general->Get("AutoLoadLast", &bAutoLoadLast, false);
 	general->Get("AutoRun", &bAutoRun, true);
 	general->Get("Browse", &bBrowse, false);
@@ -192,7 +193,7 @@ void Config::Save()
 		bFirstRun = false;
 		general->Set("FirstRun", bFirstRun);
 		general->Set("NewUI", bNewUI);
-
+		general->Set("EnableLogging", bEnableLogging);
 		general->Set("AutoLoadLast", bAutoLoadLast);
 		general->Set("AutoRun", bAutoRun);
 		general->Set("Browse", bBrowse);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -50,7 +50,7 @@ void Config::Load(const char *iniFileName)
 	bSpeedLimit = false;
 	general->Get("FirstRun", &bFirstRun, true);
 	general->Get("NewUI", &bNewUI, false);
-	general->Get("EnableLogging", &bEnableLogging, true);
+	general->Get("Enable Logging", &bEnableLogging, true);
 	general->Get("AutoLoadLast", &bAutoLoadLast, false);
 	general->Get("AutoRun", &bAutoRun, true);
 	general->Get("Browse", &bBrowse, false);
@@ -193,7 +193,7 @@ void Config::Save()
 		bFirstRun = false;
 		general->Set("FirstRun", bFirstRun);
 		general->Set("NewUI", bNewUI);
-		general->Set("EnableLogging", bEnableLogging);
+		general->Set("Enable Logging", bEnableLogging);
 		general->Set("AutoLoadLast", bAutoLoadLast);
 		general->Set("AutoRun", bAutoRun);
 		general->Set("Browse", bBrowse);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -50,6 +50,7 @@ public:
 	bool bNewUI;  // "Hidden" setting, does not get saved to ini file.
 	int iNumWorkerThreads;
 	bool bScreenshotsAsPNG;
+	bool bEnableLogging; // Another "hidden" setting.
 
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -50,7 +50,7 @@ public:
 	bool bNewUI;  // "Hidden" setting, does not get saved to ini file.
 	int iNumWorkerThreads;
 	bool bScreenshotsAsPNG;
-	bool bEnableLogging; // Another "hidden" setting.
+	bool bEnableLogging;
 
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -291,7 +291,6 @@ void GlobalSettingsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader("General"));
 	list->Add(new CheckBox(&g_Config.bNewUI, gs->T("Enable New UI")));
-	list->Add(new CheckBox(&g_Config.bEnableLogging, gs->T("Enable Logging")));
 	list->Add(new CheckBox(&enableReports_, gs->T("Enable Error Reporting")));
 	list->Add(new CheckBox(&g_Config.bEnableCheats, gs->T("Enable Cheats")));
 	list->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, gs->T("Screenshots as PNG")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -291,7 +291,10 @@ void GlobalSettingsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader("General"));
 	list->Add(new CheckBox(&g_Config.bNewUI, gs->T("Enable New UI")));
-	list->Add(new CheckBox(&enableReports_, gs->T("Enable Error Reporting")));
+	list->Add(new CheckBox(&g_Config.bEnableLogging, gs->T("Enable Logging")));
+	if(g_Config.bEnableLogging)
+		 // No reason to show this if we're not logging at all, but it doesn't draw until one exits and re-enters the settings.
+		list->Add(new CheckBox(&enableReports_, gs->T("Enable Error Reporting")));
 	list->Add(new CheckBox(&g_Config.bEnableCheats, gs->T("Enable Cheats")));
 	list->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, gs->T("Screenshots as PNG")));
 	list->Add(new Choice(gs->T("Control Mapping")))->OnClick.Handle(this, &GlobalSettingsScreen::OnControlMapping);
@@ -339,7 +342,6 @@ void DeveloperToolsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader(g->T("General")));
 	list->Add(new Choice(d->T("Run CPU Tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
-
 	list->Add(new Choice(g->T("Back")))->OnClick.Handle(this, &DeveloperToolsScreen::OnBack);
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -292,9 +292,7 @@ void GlobalSettingsScreen::CreateViews() {
 	list->Add(new ItemHeader("General"));
 	list->Add(new CheckBox(&g_Config.bNewUI, gs->T("Enable New UI")));
 	list->Add(new CheckBox(&g_Config.bEnableLogging, gs->T("Enable Logging")));
-	if(g_Config.bEnableLogging)
-		 // No reason to show this if we're not logging at all, but it doesn't draw until one exits and re-enters the settings.
-		list->Add(new CheckBox(&enableReports_, gs->T("Enable Error Reporting")));
+	list->Add(new CheckBox(&enableReports_, gs->T("Enable Error Reporting")));
 	list->Add(new CheckBox(&g_Config.bEnableCheats, gs->T("Enable Cheats")));
 	list->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, gs->T("Screenshots as PNG")));
 	list->Add(new Choice(gs->T("Control Mapping")))->OnClick.Handle(this, &GlobalSettingsScreen::OnControlMapping);

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -769,8 +769,15 @@ void DeveloperScreen::render() {
 
 	bool reportingEnabled = Reporting::IsEnabled();
 	const static std::string reportHostOfficial = "report.ppsspp.org";
-	if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
-		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
+
+	UICheckBox(GEN_ID, x, y += stride, d->T("EnableLogging", "Enable Logging"), ALIGN_TOPLEFT, &g_Config.bEnableLogging);
+	if(g_Config.bEnableLogging) {
+		if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
+			g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
+		}
+	}
+	else {
+		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : ""; // Shouldn't be necessary, but just including it for safety..
 	}
 	UICheckBox(GEN_ID, x, y += stride, d->T("New UI"), ALIGN_TOPLEFT, &g_Config.bNewUI);
 

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -65,6 +65,7 @@
 #include "GameInfoCache.h"
 #include "android/jni/TestRunner.h"
 
+
 #ifdef USING_QT_UI
 #include <QFileDialog>
 #include <QFile>
@@ -73,6 +74,9 @@
 
 #ifdef _WIN32
 namespace MainWindow {
+	enum {
+		WM_USER_LOG_STATUS_CHANGED = WM_USER + 200
+	};
 	extern HWND hwndMain;
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory = false);
 }
@@ -771,6 +775,10 @@ void DeveloperScreen::render() {
 	const static std::string reportHostOfficial = "report.ppsspp.org";
 
 	UICheckBox(GEN_ID, x, y += stride, d->T("Enable Logging"), ALIGN_TOPLEFT, &g_Config.bEnableLogging);
+#ifdef _WIN32
+	// Update the main menu bar.
+	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_LOG_STATUS_CHANGED, 0, 0);
+#endif
 
 	if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
 		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -770,7 +770,7 @@ void DeveloperScreen::render() {
 	bool reportingEnabled = Reporting::IsEnabled();
 	const static std::string reportHostOfficial = "report.ppsspp.org";
 
-	UICheckBox(GEN_ID, x, y += stride, d->T("EnableLogging", "Enable Logging"), ALIGN_TOPLEFT, &g_Config.bEnableLogging);
+	UICheckBox(GEN_ID, x, y += stride, d->T("Enable Logging"), ALIGN_TOPLEFT, &g_Config.bEnableLogging);
 
 	if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
 		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -771,14 +771,11 @@ void DeveloperScreen::render() {
 	const static std::string reportHostOfficial = "report.ppsspp.org";
 
 	UICheckBox(GEN_ID, x, y += stride, d->T("EnableLogging", "Enable Logging"), ALIGN_TOPLEFT, &g_Config.bEnableLogging);
-	if(g_Config.bEnableLogging) {
-		if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
-			g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
-		}
+
+	if (UICheckBox(GEN_ID, x, y += stride, d->T("Report","Enable Compatibility Server Reports"), ALIGN_TOPLEFT, &reportingEnabled)) {
+		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : "";
 	}
-	else {
-		g_Config.sReportHost = reportingEnabled ? reportHostOfficial : ""; // Shouldn't be necessary, but just including it for safety..
-	}
+
 	UICheckBox(GEN_ID, x, y += stride, d->T("New UI"), ALIGN_TOPLEFT, &g_Config.bNewUI);
 
 	VLinear vlinear(x, y + stride + 12, 16);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -965,7 +965,6 @@ namespace MainWindow
 			case ID_DEBUG_LOG:
 				if(g_Config.bEnableLogging)
 					LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
-				//else LogManager::GetInstance()->GetConsoleListener()->Close();
 				break;
 
 			case ID_OPTIONS_IGNOREILLEGALREADS:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -963,7 +963,9 @@ namespace MainWindow
 					memoryWindow[0]->Show(true);
 				break;
 			case ID_DEBUG_LOG:
-				LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
+				if(g_Config.bEnableLogging)
+					LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
+				//else LogManager::GetInstance()->GetConsoleListener()->Close();
 				break;
 
 			case ID_OPTIONS_IGNOREILLEGALREADS:
@@ -1304,6 +1306,9 @@ namespace MainWindow
 		EnableMenuItem(menu,ID_TOGGLE_PAUSE, !menuEnable);
 		EnableMenuItem(menu,ID_EMULATION_STOP, !menuEnable);
 		EnableMenuItem(menu,ID_EMULATION_RESET, !menuEnable);
+		EnableMenuItem(menu, ID_DEBUG_LOG, g_Config.bEnableLogging ? MF_ENABLED : MF_GRAYED);
+		if(!g_Config.bEnableLogging && !LogManager::GetInstance()->GetConsoleListener()->Hidden())
+			LogManager::GetInstance()->GetConsoleListener()->Show(false);
 	}
 
 	// Message handler for about box.

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -961,8 +961,7 @@ namespace MainWindow
 					memoryWindow[0]->Show(true);
 				break;
 			case ID_DEBUG_LOG:
-				if(g_Config.bEnableLogging)
-					LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
+				LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
 				break;
 
 			case ID_OPTIONS_IGNOREILLEGALREADS:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -88,8 +88,6 @@ namespace MainWindow
 	LRESULT CALLBACK DisplayProc(HWND, UINT, WPARAM, LPARAM);
 	LRESULT CALLBACK About(HWND, UINT, WPARAM, LPARAM);
 
-	const UINT WM_USER_SAVESTATE_FINISH = WM_USER + 100;
-
 	HWND GetHWND() {
 		return hwndMain;
 	}
@@ -1150,6 +1148,15 @@ namespace MainWindow
 			SetCursor(LoadCursor(0, IDC_ARROW));
 			break;
 
+		case WM_USER_LOG_STATUS_CHANGED:
+			if(!g_Config.bEnableLogging) {
+				LogManager::GetInstance()->GetConsoleListener()->Show(false);
+				EnableMenuItem(menu, ID_DEBUG_LOG, MF_GRAYED);
+			}
+			else
+				EnableMenuItem(menu, ID_DEBUG_LOG, MF_ENABLED);
+			break;
+
 		case WM_MENUSELECT:
 			// Unfortunately, accelerate keys (hotkeys) shares the same enabled/disabled states
 			// with corresponding menu items.
@@ -1181,7 +1188,6 @@ namespace MainWindow
 	{
 		HMENU menu = GetMenu(GetHWND());
 #define CHECKITEM(item,value) 	CheckMenuItem(menu,item,MF_BYCOMMAND | ((value) ? MF_CHECKED : MF_UNCHECKED));
-
 		CHECKITEM(ID_EMULATION_SPEEDLIMIT,g_Config.bSpeedLimit);
 //		CHECK(ID_OPTIONS_ENABLEFRAMEBUFFER,g_Config.bEnableFrameBuffer);
 //		CHECK(ID_OPTIONS_EMULATESYSCALL,g_bEmulateSyscall);
@@ -1203,7 +1209,7 @@ namespace MainWindow
 		CHECKITEM(ID_OPTIONS_TOPMOST, g_Config.bTopMost);
 		CHECKITEM(ID_EMULATION_SOUND, g_Config.bEnableSound);
 		CHECKITEM(ID_TEXTURESCALING_DEPOSTERIZE, g_Config.bTexDeposterize);
-		
+
 		static const int zoomitems[4] = {
 			ID_OPTIONS_SCREEN1X,
 			ID_OPTIONS_SCREEN2X,
@@ -1305,9 +1311,7 @@ namespace MainWindow
 		EnableMenuItem(menu,ID_TOGGLE_PAUSE, !menuEnable);
 		EnableMenuItem(menu,ID_EMULATION_STOP, !menuEnable);
 		EnableMenuItem(menu,ID_EMULATION_RESET, !menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_LOG, g_Config.bEnableLogging ? MF_ENABLED : MF_GRAYED);
-		if(!g_Config.bEnableLogging && !LogManager::GetInstance()->GetConsoleListener()->Hidden())
-			LogManager::GetInstance()->GetConsoleListener()->Show(false);
+		EnableMenuItem(menu,ID_DEBUG_LOG, !g_Config.bEnableLogging);
 	}
 
 	// Message handler for about box.

--- a/Windows/WndMainWindow.h
+++ b/Windows/WndMainWindow.h
@@ -7,6 +7,10 @@
 
 namespace MainWindow
 {
+	enum {
+		WM_USER_SAVESTATE_FINISH = WM_USER + 100,
+		WM_USER_LOG_STATUS_CHANGED = WM_USER + 200,
+	};
 	void Init(HINSTANCE hInstance);
 	BOOL Show(HINSTANCE hInstance, int nCmdShow);
 	void Close();


### PR DESCRIPTION
I couldn't get it to work the same in NewUI as it does in the old UI, so I've not included support for it at this point. It basically just makes GenericLog do nothing/return immediately if logging is disabled, and when the user presses the checkbox, it sends a message to the Win32 UI to tell it to enable or disable the Debug Console option, and hide the window if logging is being disabled. Compatibility report logging should still work even if regular logging is disabled.

The benefit of this is: Some games spam the log like crazy and lose performance/VPS as a result, so it'd be nice to be able to toggle it on and off if one isn't particularly looking for bugs. For example, the Monster Hunter series spams the log dozens or hundreds of times per second, causing a massive, massive VPS drop(iirc it was about a 10% drop in performance, at least). Disabling logging on these games definitely speeds them back up.

Note: Logging is still enabled by default for those of us who love to always have the debug log open and on(@unknownbrackets :P).
