### PR TITLE
Basic .sym support

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -219,6 +219,35 @@ void SymbolMap::SaveSymbolMap(const char *filename) const
 	fclose(f);
 }
 
+bool SymbolMap::LoadNocashSym(const char *filename)
+{
+	FILE *f = fopen(filename,"r");
+	if (!f)
+		return false;
+
+	while (!feof(f))
+	{
+		char line[256],value[256];
+		char *p = fgets(line,256,f);
+		if(p == NULL)
+			break;
+
+		u32 address;
+		if (sscanf(line,"%08X %s",&address,value) != 2) continue;
+		if (address == 0 && strcmp(value,"0") == 0) continue;
+
+		if (value[0] == '.')	// data directives
+		{
+			continue;			// not supported yet
+		} else {				// labels
+			AddSymbol(value,address,0,ST_FUNCTION);
+		}
+	}
+
+	fclose(f);
+	return true;
+}
+
 int SymbolMap::GetSymbolNum(unsigned int address, SymbolType symmask) const
 {
 	for (size_t i = 0, n = entries.size(); i < n; i++)

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -45,6 +45,7 @@ public:
 	SymbolMap() {}
 	bool LoadSymbolMap(const char *filename);
 	void SaveSymbolMap(const char *filename) const;
+	bool LoadNocashSym(const char *ilename);
 	void AddSymbol(const char *symbolname, unsigned int vaddress, size_t size, SymbolType symbol);
 	void ResetSymbolMap();
 	void AnalyzeBackwards();


### PR DESCRIPTION
This adds basic .sym support, a format originally used by the no$ emulators, which is also generated by some assemblers. It's a very simple format that just maps addresses to symbols.

The format is basically like this:
%08X name

8 digits the address, then the symbol name after a space. It supports specifying data regions too, but those aren't supported yet, I will need to do bigger changes to the disassembly view to support and display arbitrary sizes.

Additionally, it now also supports loading symbols for virtual discs. It loads them from dir/.ppsspp-symbols.map or  dir/.ppsspp-symbols.sym.
