### PR TITLE
Disassembly view speedup in debug builds

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -240,7 +240,7 @@ bool SymbolMap::LoadNocashSym(const char *filename)
 		{
 			continue;			// not supported yet
 		} else {				// labels
-			AddSymbol(value,address,0,ST_FUNCTION);
+			AddSymbol(value,address,1,ST_FUNCTION);
 		}
 	}
 
@@ -308,6 +308,13 @@ bool SymbolMap::GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask)
 
 const char* SymbolMap::getDirectSymbol(u32 address)
 {
+	SymbolInfo info;
+	if (GetSymbolInfo(&info,address) == false) return NULL;
+	if (info.address != address) return NULL;	// has to be the START of the function
+
+	// now we need the name... which we can't just get from GetSymbolInfo because of the
+	// unique entries. But, there are so many less instances where there actually IS a
+	// label that the speed up is still massive
 	for (auto it = entries.begin(), end = entries.end(); it != end; ++it)
 	{
 		const MapEntry &entry = *it;

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -153,7 +153,7 @@ int MIPSDebugInterface::getColor(unsigned int address)
 {
 	int colors[6] = {0xe0FFFF,0xFFe0e0,0xe8e8FF,0xFFe0FF,0xe0FFe0,0xFFFFe0};
 	int n=symbolMap.GetSymbolNum(address);
-	if (n==-1) return 0xFFFFFF;
+	if (n==-1 || symbolMap.GetSymbolSize(n) < 4) return 0xFFFFFF;
 	return colors[n%6];
 }
 const char *MIPSDebugInterface::getDescription(unsigned int address) 


### PR DESCRIPTION
The disassembly started to become really sluggish in debug builds. This isn't a perfect solution, but it does speed it up massively if the functions are correctly identified (in which case addresses without symbols can be filtered a lot faster than with a linear search).
