### PR TITLE
Math3d extensions2

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -98,7 +98,7 @@ static GLenum blendColor2Func(u32 fix) {
 	if (fix == 0)
 		return GL_ZERO;
 
-	Vec3 fix3 = Vec3::FromRGB(fix);
+	Vec3f fix3 = Vec3f::FromRGB(fix);
 	if (fix3.x >= 0.99 && fix3.y >= 0.99 && fix3.z >= 0.99)
 		return GL_ONE;
 	else if (fix3.x <= 0.01 && fix3.y <= 0.01 && fix3.z <= 0.01)
@@ -106,8 +106,8 @@ static GLenum blendColor2Func(u32 fix) {
 	return GL_INVALID_ENUM;
 }
 
-static bool blendColorSimilar(Vec3 a, Vec3 b, float margin = 0.1f) {
-	Vec3 diff = a - b;
+static bool blendColorSimilar(Vec3f a, Vec3f b, float margin = 0.1f) {
+	Vec3f diff = a - b;
 	if (fabsf(diff.x) <= margin && fabsf(diff.y) <= margin && fabsf(diff.z) <= margin)
 		return true;
 	return false;
@@ -146,8 +146,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		GLuint glBlendFuncA = blendFuncA == GE_SRCBLEND_FIXA ? blendColor2Func(gstate.getFixA()) : aLookup[blendFuncA];
 		GLuint glBlendFuncB = blendFuncB == GE_DSTBLEND_FIXB ? blendColor2Func(gstate.getFixB()) : bLookup[blendFuncB];
 		if (blendFuncA == GE_SRCBLEND_FIXA || blendFuncB == GE_DSTBLEND_FIXB) {
-			Vec3 fixA = Vec3::FromRGB(gstate.getFixA());
-			Vec3 fixB = Vec3::FromRGB(gstate.getFixB());
+			Vec3f fixA = Vec3f::FromRGB(gstate.getFixA());
+			Vec3f fixB = Vec3f::FromRGB(gstate.getFixB());
 			if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB != GL_INVALID_ENUM) {
 				// Can use blendcolor trivially.
 				const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -159,7 +159,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 				glstate.blendColor.set(blendColor);
 				glBlendFuncB = GL_CONSTANT_COLOR;
 			} else if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB == GL_INVALID_ENUM) {
-				if (blendColorSimilar(fixA, Vec3::AssignToAll(1.0f) - fixB)) {
+				if (blendColorSimilar(fixA, Vec3f::AssignToAll(1.0f) - fixB)) {
 					glBlendFuncA = GL_CONSTANT_COLOR;
 					glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
 					const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -177,9 +177,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 					DEBUG_LOG(HLE, "ERROR INVALID blendcolorstate: FixA=%06x FixB=%06x FuncA=%i FuncB=%i", gstate.getFixA(), gstate.getFixB(), gstate.getBlendFuncA(), gstate.getBlendFuncB());
 					// Let's approximate, at least.  Close is better than totally off.
-					const bool nearZeroA = blendColorSimilar(fixA, Vec3::AssignToAll(0.0f), 0.25f);
-					const bool nearZeroB = blendColorSimilar(fixB, Vec3::AssignToAll(0.0f), 0.25f);
-					if (nearZeroA || blendColorSimilar(fixA, Vec3::AssignToAll(1.0f), 0.25f)) {
+					const bool nearZeroA = blendColorSimilar(fixA, Vec3f::AssignToAll(0.0f), 0.25f);
+					const bool nearZeroB = blendColorSimilar(fixB, Vec3f::AssignToAll(0.0f), 0.25f);
+					if (nearZeroA || blendColorSimilar(fixA, Vec3f::AssignToAll(1.0f), 0.25f)) {
 						glBlendFuncA = nearZeroA ? GL_ZERO : GL_ONE;
 						glBlendFuncB = GL_CONSTANT_COLOR;
 						const float blendColor[4] = {fixB.x, fixB.y, fixB.z, 1.0f};

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -98,7 +98,7 @@ static GLenum blendColor2Func(u32 fix) {
 	if (fix == 0)
 		return GL_ZERO;
 
-	Vec3 fix3 = Vec3(fix);
+	Vec3 fix3 = Vec3::FromRGB(fix);
 	if (fix3.x >= 0.99 && fix3.y >= 0.99 && fix3.z >= 0.99)
 		return GL_ONE;
 	else if (fix3.x <= 0.01 && fix3.y <= 0.01 && fix3.z <= 0.01)
@@ -146,8 +146,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		GLuint glBlendFuncA = blendFuncA == GE_SRCBLEND_FIXA ? blendColor2Func(gstate.getFixA()) : aLookup[blendFuncA];
 		GLuint glBlendFuncB = blendFuncB == GE_DSTBLEND_FIXB ? blendColor2Func(gstate.getFixB()) : bLookup[blendFuncB];
 		if (blendFuncA == GE_SRCBLEND_FIXA || blendFuncB == GE_DSTBLEND_FIXB) {
-			Vec3 fixA = Vec3(gstate.getFixA());
-			Vec3 fixB = Vec3(gstate.getFixB());
+			Vec3 fixA = Vec3::FromRGB(gstate.getFixA());
+			Vec3 fixB = Vec3::FromRGB(gstate.getFixB());
 			if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB != GL_INVALID_ENUM) {
 				// Can use blendcolor trivially.
 				const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -159,7 +159,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 				glstate.blendColor.set(blendColor);
 				glBlendFuncB = GL_CONSTANT_COLOR;
 			} else if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB == GL_INVALID_ENUM) {
-				if (blendColorSimilar(fixA, Vec3(1.0f) - fixB)) {
+				if (blendColorSimilar(fixA, Vec3::AssignToAll(1.0f) - fixB)) {
 					glBlendFuncA = GL_CONSTANT_COLOR;
 					glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
 					const float blendColor[4] = {fixA.x, fixA.y, fixA.z, 1.0f};
@@ -177,9 +177,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 					DEBUG_LOG(HLE, "ERROR INVALID blendcolorstate: FixA=%06x FixB=%06x FuncA=%i FuncB=%i", gstate.getFixA(), gstate.getFixB(), gstate.getBlendFuncA(), gstate.getBlendFuncB());
 					// Let's approximate, at least.  Close is better than totally off.
-					const bool nearZeroA = blendColorSimilar(fixA, 0.0f, 0.25f);
-					const bool nearZeroB = blendColorSimilar(fixB, 0.0f, 0.25f);
-					if (nearZeroA || blendColorSimilar(fixA, 1.0f, 0.25f)) {
+					const bool nearZeroA = blendColorSimilar(fixA, Vec3::AssignToAll(0.0f), 0.25f);
+					const bool nearZeroB = blendColorSimilar(fixB, Vec3::AssignToAll(0.0f), 0.25f);
+					if (nearZeroA || blendColorSimilar(fixA, Vec3::AssignToAll(1.0f), 0.25f)) {
 						glBlendFuncA = nearZeroA ? GL_ZERO : GL_ONE;
 						glBlendFuncB = GL_CONSTANT_COLOR;
 						const float blendColor[4] = {fixB.x, fixB.y, fixB.z, 1.0f};

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -221,7 +221,7 @@ void TransformDrawEngine::DrawSpline(int ucount, int vcount, int utype, int vtyp
 class Lighter {
 public:
 	Lighter();
-	void Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], Vec3 pos, Vec3 normal);
+	void Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], Vec3f pos, Vec3f normal);
 
 private:
 	Color4 globalAmbient;
@@ -230,7 +230,7 @@ private:
 	Color4 materialDiffuse;
 	Color4 materialSpecular;
 	float specCoef_;
-	// Vec3 viewer_;
+	// Vec3f viewer_;
 	bool doShadeMapping_;
 	int materialUpdate_;
 };
@@ -248,11 +248,11 @@ Lighter::Lighter() {
 	materialSpecular.GetFromRGB(gstate.materialspecular);
 	materialSpecular.a = 1.0f;
 	specCoef_ = getFloat24(gstate.materialspecularcoef);
-	// viewer_ = Vec3(-gstate.viewMatrix[9], -gstate.viewMatrix[10], -gstate.viewMatrix[11]);
+	// viewer_ = Vec3f(-gstate.viewMatrix[9], -gstate.viewMatrix[10], -gstate.viewMatrix[11]);
 	materialUpdate_ = gstate.materialupdate & 7;
 }
 
-void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], Vec3 pos, Vec3 norm)
+void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], Vec3f pos, Vec3f norm)
 {
 	Color4 in(colorIn);
 
@@ -285,13 +285,13 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 
 		GELightType type = gstate.getLightType(l);
 		
-		Vec3 toLight(0,0,0);
-		Vec3 lightDir(0,0,0);
+		Vec3f toLight(0,0,0);
+		Vec3f lightDir(0,0,0);
 		
 		if (type == GE_LIGHTTYPE_DIRECTIONAL)
-			toLight = Vec3(gstate_c.lightpos[l]);  // lightdir is for spotlights
+			toLight = Vec3f(gstate_c.lightpos[l]);  // lightdir is for spotlights
 		else
-			toLight = Vec3(gstate_c.lightpos[l]) - pos;
+			toLight = Vec3f(gstate_c.lightpos[l]) - pos;
 
 		bool doSpecular = gstate.isUsingSpecularLight(l);
 		bool poweredDiffuse = gstate.isUsingPoweredDiffuseLight(l);
@@ -334,13 +334,13 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		Color4 diff = (lightDiff * *diffuse) * dot;
 
 		// Real PSP specular
-		Vec3 toViewer(0,0,1);
+		Vec3f toViewer(0,0,1);
 		// Better specular
-		// Vec3 toViewer = (viewer - pos).Normalized();
+		// Vec3f toViewer = (viewer - pos).Normalized();
 
 		if (doSpecular)
 		{
-			Vec3 halfVec = (toLight + toViewer);
+			Vec3f halfVec = (toLight + toViewer);
 			halfVec.Normalize();
 
 			dot = Dot(halfVec, norm);
@@ -570,7 +570,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			// We do software T&L for now
 			float out[3], norm[3];
 			float pos[3], nrm[3];
-			Vec3 normal(0, 0, 1);
+			Vec3f normal(0, 0, 1);
 			reader.ReadPos(pos);
 			if (reader.hasNormal())
 				reader.ReadNrm(nrm);
@@ -579,24 +579,24 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				Vec3ByMatrix43(out, pos, gstate.worldMatrix);
 				if (reader.hasNormal()) {
 					Norm3ByMatrix43(norm, nrm, gstate.worldMatrix);
-					normal = Vec3(norm).Normalized();
+					normal = Vec3f(norm).Normalized();
 				}
 			} else {
 				float weights[8];
 				reader.ReadWeights(weights);
 				// Skinning
-				Vec3 psum(0,0,0);
-				Vec3 nsum(0,0,0);
+				Vec3f psum(0,0,0);
+				Vec3f nsum(0,0,0);
 				int nweights = ((vertType & GE_VTYPE_WEIGHTCOUNT_MASK) >> GE_VTYPE_WEIGHTCOUNT_SHIFT) + 1;
 				for (int i = 0; i < nweights; i++)
 				{
 					if (weights[i] != 0.0f) {
 						Vec3ByMatrix43(out, pos, gstate.boneMatrix+i*12);
-						Vec3 tpos(out);
+						Vec3f tpos(out);
 						psum += tpos * weights[i];
 						if (reader.hasNormal()) {
 							Norm3ByMatrix43(norm, nrm, gstate.boneMatrix+i*12);
-							Vec3 tnorm(norm);
+							Vec3f tnorm(norm);
 							nsum += tnorm * weights[i];
 						}
 					}
@@ -606,7 +606,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				Vec3ByMatrix43(out, psum.AsArray(), gstate.worldMatrix);
 				if (reader.hasNormal()) {
 					Norm3ByMatrix43(norm, nsum.AsArray(), gstate.worldMatrix);
-					normal = Vec3(norm).Normalized();
+					normal = Vec3f(norm).Normalized();
 				}
 			}
 
@@ -674,29 +674,29 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			case 1:
 				{
 					// Projection mapping
-					Vec3 source;
+					Vec3f source;
 					switch (gstate.getUVProjMode())
 					{
 					case 0: // Use model space XYZ as source
 						source = pos;
 						break;
 					case 1: // Use unscaled UV as source
-						source = Vec3(ruv[0], ruv[1], 0.0f);
+						source = Vec3f(ruv[0], ruv[1], 0.0f);
 						break;
 					case 2: // Use normalized normal as source
 						if (reader.hasNormal()) {
-							source = Vec3(norm).Normalized();
+							source = Vec3f(norm).Normalized();
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3::AssignToAll(0.0f);
+							source = Vec3f::AssignToAll(0.0f);
 						}
 						break;
 					case 3: // Use non-normalized normal as source!
 						if (reader.hasNormal()) {
-							source = Vec3(norm);
+							source = Vec3f(norm);
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3::AssignToAll(0.0f);
+							source = Vec3f::AssignToAll(0.0f);
 						}
 						break;
 					}
@@ -711,8 +711,8 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			case 2:
 				// Shade mapping - use two light sources to generate U and V.
 				{
-					Vec3 lightpos0 = Vec3(gstate_c.lightpos[gstate.getUVLS0()]).Normalized();
-					Vec3 lightpos1 = Vec3(gstate_c.lightpos[gstate.getUVLS1()]).Normalized();
+					Vec3f lightpos0 = Vec3f(gstate_c.lightpos[gstate.getUVLS0()]).Normalized();
+					Vec3f lightpos1 = Vec3f(gstate_c.lightpos[gstate.getUVLS1()]).Normalized();
 
 					uv[0] = (1.0f + Dot(lightpos0, normal))/2.0f;
 					uv[1] = (1.0f - Dot(lightpos1, normal))/2.0f;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -603,9 +603,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				}
 
 				// Yes, we really must multiply by the world matrix too.
-				Vec3ByMatrix43(out, psum.v, gstate.worldMatrix);
+				Vec3ByMatrix43(out, psum.AsArray(), gstate.worldMatrix);
 				if (reader.hasNormal()) {
-					Norm3ByMatrix43(norm, nsum.v, gstate.worldMatrix);
+					Norm3ByMatrix43(norm, nsum.AsArray(), gstate.worldMatrix);
 					normal = Vec3(norm).Normalized();
 				}
 			}

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -688,7 +688,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3(norm).Normalized();
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3(0.0f);
+							source = Vec3::AssignToAll(0.0f);
 						}
 						break;
 					case 3: // Use non-normalized normal as source!
@@ -696,7 +696,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3(norm);
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3(0.0f);
+							source = Vec3::AssignToAll(0.0f);
 						}
 						break;
 					}

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -303,7 +303,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		
 		if (distanceToLight > 0.0f) {
 			toLight /= distanceToLight;
-			dot = toLight * norm;
+			dot = Dot(toLight, norm);
 		}
 		// Clamp dot to zero.
 		if (dot < 0.0f) dot = 0.0f;
@@ -321,7 +321,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 			break;
 		case GE_LIGHTTYPE_SPOT:
 			lightDir = gstate_c.lightdir[l];
-			angle = toLight.Normalized() * lightDir.Normalized();
+			angle = Dot(toLight.Normalized(), lightDir.Normalized());
 			if (angle >= gstate_c.lightangle[l])
 				lightScale = clamp(1.0f / (gstate_c.lightatt[l][0] + gstate_c.lightatt[l][1]*distanceToLight + gstate_c.lightatt[l][2]*distanceToLight*distanceToLight), 0.0f, 1.0f) * powf(angle, gstate_c.lightspotCoef[l]);
 			break;
@@ -343,7 +343,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 			Vec3 halfVec = (toLight + toViewer);
 			halfVec.Normalize();
 
-			dot = halfVec * norm;
+			dot = Dot(halfVec, norm);
 			if (dot > 0.0f)
 			{
 				Color4 lightSpec(gstate_c.lightColor[2][l], 0.0f);
@@ -714,8 +714,8 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 					Vec3 lightpos0 = Vec3(gstate_c.lightpos[gstate.getUVLS0()]).Normalized();
 					Vec3 lightpos1 = Vec3(gstate_c.lightpos[gstate.getUVLS1()]).Normalized();
 
-					uv[0] = (1.0f + (lightpos0 * normal))/2.0f;
-					uv[1] = (1.0f - (lightpos1 * normal))/2.0f;
+					uv[0] = (1.0f + Dot(lightpos0, normal))/2.0f;
+					uv[1] = (1.0f - Dot(lightpos1, normal))/2.0f;
 					uv[2] = 1.0f;
 				}
 				break;

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -68,3 +68,56 @@ float Vec3<float>::Normalize()
 	(*this) = (*this)/len;
 	return len;
 }
+
+template<>
+Vec4<float> Vec4<float>::FromRGBA(unsigned int rgba)
+{
+	return Vec4((rgba & 0xFF) * (1.0f/255.0f),
+				((rgba >> 8) & 0xFF) * (1.0f/255.0f),
+				((rgba >> 16) & 0xFF) * (1.0f/255.0f),
+				((rgba >> 24) & 0xFF) * (1.0f/255.0f));
+}
+
+template<>
+Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
+{
+	return Vec4(rgba & 0xFF, (rgba >> 8) & 0xFF, (rgba >> 16) & 0xFF, (rgba >> 24) & 0xFF);
+}
+
+template<>
+float Vec4<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec4<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+Vec4<float> Vec4<float>::WithLength(const float l) const
+{
+	return (*this) * l / Length();
+}
+
+template<>
+float Vec4<float>::Distance2To(Vec4<float> &other)
+{
+	return Vec4<float>(other-(*this)).Length2();
+}
+
+template<>
+Vec4<float> Vec4<float>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+template<>
+float Vec4<float>::Normalize()
+{
+	float len = Length();
+	(*this) = (*this)/len;
+	return len;
+}

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -70,6 +70,20 @@ Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 }
 
 template<>
+unsigned int Vec3<float>::ToRGB() const
+{
+	return ((unsigned int)(r()*255.f)) +
+			((unsigned int)(g()*255.f*256.f)) +
+			((unsigned int)(b()*255.f*256.f*256.f));
+}
+
+template<>
+unsigned int Vec3<int>::ToRGB() const
+{
+	return (r()&0xFF) | ((g()&0xFF)<<8) | ((b()&0xFF)<<16);
+}
+
+template<>
 float Vec3<float>::Length() const
 {
 	return sqrtf(Length2());
@@ -120,6 +134,21 @@ template<>
 Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
 {
 	return Vec4(rgba & 0xFF, (rgba >> 8) & 0xFF, (rgba >> 16) & 0xFF, (rgba >> 24) & 0xFF);
+}
+
+template<>
+unsigned int Vec4<float>::ToRGBA() const
+{
+	return ((unsigned int)(r()*255.f)) +
+			((unsigned int)(g()*255.f*256.f)) +
+			((unsigned int)(b()*255.f*256.f*256.f)) +
+			((unsigned int)(a()*255.f*256.f*256.f*256.f));
+}
+
+template<>
+unsigned int Vec4<int>::ToRGBA() const
+{
+	return (r()&0xFF) | ((g()&0xFF)<<8) | ((b()&0xFF)<<16) | ((a()&0xFF)<<24);
 }
 
 template<>

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -18,6 +18,44 @@
 #include "Math3D.h"
 
 template<>
+float Vec2<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec2<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+Vec2<float> Vec2<float>::WithLength(const float l) const
+{
+	return (*this) * l / Length();
+}
+
+template<>
+float Vec2<float>::Distance2To(Vec2<float> &other)
+{
+	return Vec2<float>(other-(*this)).Length2();
+}
+
+template<>
+Vec2<float> Vec2<float>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+template<>
+float Vec2<float>::Normalize()
+{
+	float len = Length();
+	(*this) = (*this)/len;
+	return len;
+}
+
+template<>
 Vec3<float> Vec3<float>::FromRGB(unsigned int rgb)
 {
 	return Vec3((rgb & 0xFF) * (1.0f/255.0f),

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -16,3 +16,55 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Math3D.h"
+
+template<>
+Vec3<float> Vec3<float>::FromRGB(unsigned int rgb)
+{
+	return Vec3((rgb & 0xFF) * (1.0f/255.0f),
+				((rgb >> 8) & 0xFF) * (1.0f/255.0f),
+				((rgb >> 16) & 0xFF) * (1.0f/255.0f));
+}
+
+template<>
+Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
+{
+	return Vec3(rgb & 0xFF, (rgb >> 8) & 0xFF, (rgb >> 16) & 0xFF);
+}
+
+template<>
+float Vec3<float>::Length() const
+{
+	return sqrtf(Length2());
+}
+
+template<>
+void Vec3<float>::SetLength(const float l)
+{
+	(*this) *= l / Length();
+}
+
+template<>
+Vec3<float> Vec3<float>::WithLength(const float l) const
+{
+	return (*this) * l / Length();
+}
+
+template<>
+float Vec3<float>::Distance2To(Vec3<float> &other)
+{
+	return Vec3<float>(other-(*this)).Length2();
+}
+
+template<>
+Vec3<float> Vec3<float>::Normalized() const
+{
+	return (*this) / Length();
+}
+
+template<>
+float Vec3<float>::Normalize()
+{
+	float len = Length();
+	(*this) = (*this)/len;
+	return len;
+}

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -163,6 +163,7 @@ public:
 
 	// Only implemented for T=int and T=float
 	static Vec3 FromRGB(unsigned int rgb);
+	unsigned int ToRGB() const; // alpha bits set to zero
 
 	static Vec3 AssignToAll(const T& f)
 	{
@@ -322,6 +323,7 @@ public:
 
 	// Only implemented for T=int and T=float
 	static Vec4 FromRGBA(unsigned int rgba);
+	unsigned int ToRGBA() const;
 
 	static Vec4 AssignToAll(const T& f)
 	{

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -131,6 +131,11 @@ public:
 	const T& v() const { return y; }
 	const T& s() const { return x; }
 	const T& t() const { return y; }
+
+	// swizzlers - create a subvector of specific components
+	Vec2 yx() const { return Vec2(y, x); }
+	Vec2 vu() const { return Vec2(y, x); }
+	Vec2 ts() const { return Vec2(y, x); }
 };
 
 template<typename T, typename V>
@@ -270,6 +275,26 @@ public:
 	const T& s() const { return x; }
 	const T& t() const { return y; }
 	const T& q() const { return z; }
+
+	// swizzlers - create a subvector of specific components
+	// e.g. Vec2 uv() { return Vec2(x,y); }
+	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+#define _DEFINE_SWIZZLER2(a, b, name) Vec2<T> name() const { return Vec2<T>(a, b); }
+#define DEFINE_SWIZZLER2(a, b, a2, b2, a3, b3, a4, b4) \
+	_DEFINE_SWIZZLER2(a, b, a##b); \
+	_DEFINE_SWIZZLER2(a, b, a2##b2); \
+	_DEFINE_SWIZZLER2(a, b, a3##b3); \
+	_DEFINE_SWIZZLER2(a, b, a4##b4); \
+	_DEFINE_SWIZZLER2(b, a, b##a); \
+	_DEFINE_SWIZZLER2(b, a, b2##a2); \
+	_DEFINE_SWIZZLER2(b, a, b3##a3); \
+	_DEFINE_SWIZZLER2(b, a, b4##a4);
+
+	DEFINE_SWIZZLER2(x, y, r, g, u, v, s, t);
+	DEFINE_SWIZZLER2(x, z, r, b, u, w, s, q);
+	DEFINE_SWIZZLER2(y, z, g, b, v, w, t, q);
+#undef DEFINE_SWIZZLER2
+#undef _DEFINE_SWIZZLER2
 };
 
 template<typename T, typename V>
@@ -395,6 +420,47 @@ public:
 	const T& g() const { return y; }
 	const T& b() const { return z; }
 	const T& a() const { return w; }
+
+	// swizzlers - create a subvector of specific components
+	// e.g. Vec2 uv() { return Vec2(x,y); }
+	// _DEFINE_SWIZZLER2 defines a single such function, DEFINE_SWIZZLER2 defines all of them for all component names (x<->r) and permutations (xy<->yx)
+#define _DEFINE_SWIZZLER2(a, b, name) Vec2<T> name() const { return Vec2<T>(a, b); }
+#define DEFINE_SWIZZLER2(a, b, a2, b2) \
+	_DEFINE_SWIZZLER2(a, b, a##b); \
+	_DEFINE_SWIZZLER2(a, b, a2##b2); \
+	_DEFINE_SWIZZLER2(b, a, b##a); \
+	_DEFINE_SWIZZLER2(b, a, b2##a2);
+
+	DEFINE_SWIZZLER2(x, y, r, g);
+	DEFINE_SWIZZLER2(x, z, r, b);
+	DEFINE_SWIZZLER2(x, w, r, a);
+	DEFINE_SWIZZLER2(y, z, g, b);
+	DEFINE_SWIZZLER2(y, w, g, a);
+	DEFINE_SWIZZLER2(z, w, b, a);
+#undef DEFINE_SWIZZLER2
+#undef _DEFINE_SWIZZLER2
+
+#define _DEFINE_SWIZZLER3(a, b, c, name) Vec3<T> name() const { return Vec3<T>(a, b, c); }
+#define DEFINE_SWIZZLER3(a, b, c, a2, b2, c2) \
+	_DEFINE_SWIZZLER3(a, b, c, a##b##c); \
+	_DEFINE_SWIZZLER3(a, c, b, a##c##b); \
+	_DEFINE_SWIZZLER3(b, a, c, b##a##c); \
+	_DEFINE_SWIZZLER3(b, c, a, b##c##a); \
+	_DEFINE_SWIZZLER3(c, a, b, c##a##b); \
+	_DEFINE_SWIZZLER3(c, b, a, c##b##a); \
+	_DEFINE_SWIZZLER3(a, b, c, a2##b2##c2); \
+	_DEFINE_SWIZZLER3(a, c, b, a2##c2##b2); \
+	_DEFINE_SWIZZLER3(b, a, c, b2##a2##c2); \
+	_DEFINE_SWIZZLER3(b, c, a, b2##c2##a2); \
+	_DEFINE_SWIZZLER3(c, a, b, c2##a2##b2); \
+	_DEFINE_SWIZZLER3(c, b, a, c2##b2##a2);
+
+	DEFINE_SWIZZLER3(x, y, z, r, g, b);
+	DEFINE_SWIZZLER3(x, y, w, r, g, a);
+	DEFINE_SWIZZLER3(x, z, w, r, b, a);
+	DEFINE_SWIZZLER3(y, z, w, g, b, a);
+#undef DEFINE_SWIZZLER3
+#undef _DEFINE_SWIZZLER3
 };
 
 template<typename T, typename V>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -32,7 +32,7 @@ public:
 	};
 	Vec3(unsigned int rgb) {
 		x = (rgb & 0xFF) * (1.0f/255.0f);
-		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f); 
+		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
 		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
 	}
 	Vec3(const float a[3]) {
@@ -67,10 +67,6 @@ public:
 	{
 		return Vec3(-x,-y,-z);
 	}
-	float operator *(const Vec3 &other) const
-	{
-		return x*other.x + y*other.y + z*other.z;
-	}
 	Vec3 Mul(const Vec3 &other) const
 	{
 		return Vec3(x*other.x, y*other.y, z*other.z);
@@ -91,10 +87,6 @@ public:
 	void operator /= (const float f)
 	{
 		*this = *this / f;
-	}
-	Vec3 operator %(const Vec3 &v) const
-	{
-		return Vec3(y*v.z-z*v.y, z*v.x-x*v.z, x*v.y-y*v.x);
 	}
 	float Length2() const
 	{
@@ -159,4 +151,14 @@ inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]
 inline float Vec3Dot(const float v1[3], const float v2[3])
 {
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+}
+
+inline float Dot(const Vec3 &a, const Vec3& b)
+{
+	return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+inline Vec3 Cross(const Vec3 &a, const Vec3& b)
+{
+	return Vec3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -64,7 +64,7 @@ public:
 	{
 		return Vec2(-x,-y);
 	}
-	Vec2 Mul(const Vec2& other) const
+	Vec2 operator * (const Vec2& other) const
 	{
 		return Vec2(x*other.x, y*other.y);
 	}
@@ -194,7 +194,7 @@ public:
 	{
 		return Vec3(-x,-y,-z);
 	}
-	Vec3 Mul(const Vec3 &other) const
+	Vec3 operator * (const Vec3 &other) const
 	{
 		return Vec3(x*other.x, y*other.y, z*other.z);
 	}
@@ -353,7 +353,7 @@ public:
 	{
 		return Vec4(-x,-y,-z,-w);
 	}
-	Vec4 Mul(const Vec4 &other) const
+	Vec4 operator * (const Vec4 &other) const
 	{
 		return Vec4(x*other.x, y*other.y, z*other.z, w*other.w);
 	}

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -22,24 +22,19 @@
 class Vec3
 {
 public:
-	union
+	struct
 	{
-		float v[3];
-		struct
-		{
-			float x,y,z;
-		};
+		float x,y,z;
 	};
+
+	float* AsArray() { return &x; }
+
 	Vec3(unsigned int rgb) {
 		x = (rgb & 0xFF) * (1.0f/255.0f);
 		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
 		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
 	}
-	Vec3(const float a[3]) {
-		v[0] = a[0];
-		v[1] = a[1];
-		v[2] = a[2];
-	}
+	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 	Vec3() {}
 	explicit Vec3(float f) : x(f), y(f), z(f) {}
@@ -132,6 +127,31 @@ public:
 	{
 		x=0;y=0;z=0;
 	}
+
+	// Common aliases: UVW (texel coordinates), RGB (colors), STQ (texture coordinates)
+	float& u() { return x; }
+	float& v() { return y; }
+	float& w() { return z; }
+
+	float& r() { return x; }
+	float& g() { return y; }
+	float& b() { return z; }
+
+	float& s() { return x; }
+	float& t() { return y; }
+	float& q() { return z; }
+
+	const float& u() const { return x; }
+	const float& v() const { return y; }
+	const float& w() const { return z; }
+
+	const float& r() const { return x; }
+	const float& g() const { return y; }
+	const float& b() const { return z; }
+
+	const float& s() const { return x; }
+	const float& t() const { return y; }
+	const float& q() const { return z; }
 };
 
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -19,36 +19,34 @@
 
 #include <cmath>
 
+template<typename T>
 class Vec3
 {
 public:
 	struct
 	{
-		float x,y,z;
+		T x,y,z;
 	};
 
-	float* AsArray() { return &x; }
+	T* AsArray() { return &x; }
 
-	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
-	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 	Vec3() {}
+	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
+	Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 
-	static Vec3 FromRGB(unsigned int rgb)
+	// Only implemented for T=int and T=float
+	static Vec3 FromRGB(unsigned int rgb);
+
+	static Vec3 AssignToAll(const T& f)
 	{
-		return Vec3((rgb & 0xFF) * (1.0f/255.0f),
-					((rgb >> 8) & 0xFF) * (1.0f/255.0f),
-					((rgb >> 16) & 0xFF) * (1.0f/255.0f));
+		return Vec3<T>(f, f, f);
 	}
 
-	static Vec3 AssignToAll(float f)
-	{
-		return Vec3(f, f, f);
-	}
-
-	void Write(float a[3])
+	void Write(T a[3])
 	{
 		a[0] = x; a[1] = y; a[2] = z;
 	}
+
 	Vec3 operator +(const Vec3 &other) const
 	{
 		return Vec3(x+other.x, y+other.y, z+other.z);
@@ -73,93 +71,92 @@ public:
 	{
 		return Vec3(x*other.x, y*other.y, z*other.z);
 	}
-	Vec3 operator * (const float f) const
+	template<typename V>
+	Vec3 operator * (const V& f) const
 	{
 		return Vec3(x*f,y*f,z*f);
 	}
-	void operator *= (const float f)
+	template<typename V>
+	void operator *= (const V& f)
 	{
 		x*=f; y*=f; z*=f;
 	}
-	Vec3 operator / (const float f) const
+	template<typename V>
+	Vec3 operator / (const V& f) const
 	{
-		float invf = (1.0f/f);
-		return Vec3(x*invf,y*invf,z*invf);
+		return Vec3(x/f,y/f,z/f);
 	}
-	void operator /= (const float f)
+	template<typename V>
+	void operator /= (const V& f)
 	{
 		*this = *this / f;
 	}
-	float Length2() const
+
+	T Length2() const
 	{
 		return x*x + y*y + z*z;
 	}
-	float Length() const
-	{
-		return sqrtf(Length2());
-	}
-	void SetLength(const float l)
-	{
-		(*this) *= l / Length();
-	}
-	Vec3 WithLength(const float l) const
-	{
-		return (*this) * l / Length();
-	}
-	float Distance2To(Vec3 &other)
-	{
-		return Vec3(other-(*this)).Length2();
-	}
-	Vec3 Normalized() const {
-		return (*this) / Length();
-	}
-	float Normalize() { //returns the previous length, is often useful
-		float len = Length();
-		(*this) = (*this)/len;
-		return len;
-	}
-	float &operator [] (int i) //allow vector[2] = 3   (vector.z=3)
+
+	// Only implemented for T=float
+	float Length() const;
+	void SetLength(const float l);
+	Vec3 WithLength(const float l) const;
+	float Distance2To(Vec3 &other);
+	Vec3 Normalized() const;
+	float Normalize(); // returns the previous length, which is often useful
+
+	T& operator [] (int i) //allow vector[2] = 3   (vector.z=3)
 	{
 		return *((&x) + i);
 	}
-	float operator [] (const int i) const
+	T operator [] (const int i) const
 	{
 		return *((&x) + i);
 	}
+
 	Vec3 Lerp(const Vec3 &other, const float t) const
 	{
 		return (*this)*(1-t) + other*t;
 	}
+
 	void SetZero()
 	{
-		x=0;y=0;z=0;
+		x=0; y=0; z=0;
 	}
 
 	// Common aliases: UVW (texel coordinates), RGB (colors), STQ (texture coordinates)
-	float& u() { return x; }
-	float& v() { return y; }
-	float& w() { return z; }
+	T& u() { return x; }
+	T& v() { return y; }
+	T& w() { return z; }
 
-	float& r() { return x; }
-	float& g() { return y; }
-	float& b() { return z; }
+	T& r() { return x; }
+	T& g() { return y; }
+	T& b() { return z; }
 
-	float& s() { return x; }
-	float& t() { return y; }
-	float& q() { return z; }
+	T& s() { return x; }
+	T& t() { return y; }
+	T& q() { return z; }
 
-	const float& u() const { return x; }
-	const float& v() const { return y; }
-	const float& w() const { return z; }
+	const T& u() const { return x; }
+	const T& v() const { return y; }
+	const T& w() const { return z; }
 
-	const float& r() const { return x; }
-	const float& g() const { return y; }
-	const float& b() const { return z; }
+	const T& r() const { return x; }
+	const T& g() const { return y; }
+	const T& b() const { return z; }
 
-	const float& s() const { return x; }
-	const float& t() const { return y; }
-	const float& q() const { return z; }
+	const T& s() const { return x; }
+	const T& t() const { return y; }
+	const T& q() const { return z; }
 };
+
+template<typename T, typename V>
+Vec3<T> operator * (const V& f, const Vec3<T>& vec)
+{
+	return Vec3<T>(f*vec.x,f*vec.y,f*vec.z);
+}
+
+typedef Vec3<float> Vec3f;
 
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
@@ -180,12 +177,14 @@ inline float Vec3Dot(const float v1[3], const float v2[3])
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }
 
-inline float Dot(const Vec3 &a, const Vec3& b)
+template<typename T>
+inline T Dot(const Vec3<T>& a, const Vec3<T>& b)
 {
 	return a.x*b.x + a.y*b.y + a.z*b.z;
 }
 
-inline Vec3 Cross(const Vec3 &a, const Vec3& b)
+template<typename T>
+inline Vec3<T> Cross(const Vec3<T>& a, const Vec3<T>& b)
 {
-	return Vec3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
+	return Vec3<T>(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -34,6 +34,12 @@ public:
 	Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
 	Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
 
+	template<typename T2>
+	Vec2<T2> Cast() const
+	{
+		return Vec2<T2>((T2)x, (T2)y);
+	}
+
 	static Vec2 AssignToAll(const T& f)
 	{
 		return Vec2<T>(f, f);
@@ -160,6 +166,12 @@ public:
 	Vec3() {}
 	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
+
+	template<typename T2>
+	Vec3<T2> Cast() const
+	{
+		return Vec3<T2>((T2)x, (T2)y, (T2)z);
+	}
 
 	// Only implemented for T=int and T=float
 	static Vec3 FromRGB(unsigned int rgb);
@@ -320,6 +332,12 @@ public:
 	Vec4() {}
 	Vec4(const T a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 	Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
+
+	template<typename T2>
+	Vec4<T2> Cast() const
+	{
+		return Vec4<T2>((T2)x, (T2)y, (T2)z, (T2)w);
+	}
 
 	// Only implemented for T=int and T=float
 	static Vec4 FromRGBA(unsigned int rgba);

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -29,15 +29,22 @@ public:
 
 	float* AsArray() { return &x; }
 
-	Vec3(unsigned int rgb) {
-		x = (rgb & 0xFF) * (1.0f/255.0f);
-		y = ((rgb >> 8) & 0xFF) * (1.0f/255.0f);
-		z = ((rgb >> 16) & 0xFF) * (1.0f/255.0f);
-	}
 	Vec3(const float a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 	Vec3() {}
-	explicit Vec3(float f) : x(f), y(f), z(f) {}
+
+	static Vec3 FromRGB(unsigned int rgb)
+	{
+		return Vec3((rgb & 0xFF) * (1.0f/255.0f),
+					((rgb >> 8) & 0xFF) * (1.0f/255.0f),
+					((rgb >> 16) & 0xFF) * (1.0f/255.0f));
+	}
+
+	static Vec3 AssignToAll(float f)
+	{
+		return Vec3(f, f, f);
+	}
+
 	void Write(float a[3])
 	{
 		a[0] = x; a[1] = y; a[2] = z;

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -20,6 +20,128 @@
 #include <cmath>
 
 template<typename T>
+class Vec2
+{
+public:
+	struct
+	{
+		T x,y;
+	};
+
+	T* AsArray() { return &x; }
+
+	Vec2() {}
+	Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
+	Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
+
+	static Vec2 AssignToAll(const T& f)
+	{
+		return Vec2<T>(f, f);
+	}
+
+	void Write(T a[2])
+	{
+		a[0] = x; a[1] = y;
+	}
+
+	Vec2 operator +(const Vec2& other) const
+	{
+		return Vec2(x+other.x, y+other.y);
+	}
+	void operator += (const Vec2 &other)
+	{
+		x+=other.x; y+=other.y;
+	}
+	Vec2 operator -(const Vec2& other) const
+	{
+		return Vec2(x-other.x, y-other.y);
+	}
+	void operator -= (const Vec2& other)
+	{
+		x-=other.x; y-=other.y;
+	}
+	Vec2 operator -() const
+	{
+		return Vec2(-x,-y);
+	}
+	Vec2 Mul(const Vec2& other) const
+	{
+		return Vec2(x*other.x, y*other.y);
+	}
+	template<typename V>
+	Vec2 operator * (const V& f) const
+	{
+		return Vec2(x*f,y*f);
+	}
+	template<typename V>
+	void operator *= (const V& f)
+	{
+		x*=f; y*=f;
+	}
+	template<typename V>
+	Vec2 operator / (const V& f) const
+	{
+		return Vec2(x/f,y/f);
+	}
+	template<typename V>
+	void operator /= (const V& f)
+	{
+		*this = *this / f;
+	}
+
+	T Length2() const
+	{
+		return x*x + y*y;
+	}
+
+	// Only implemented for T=float
+	float Length() const;
+	void SetLength(const float l);
+	Vec2 WithLength(const float l) const;
+	float Distance2To(Vec2 &other);
+	Vec2 Normalized() const;
+	float Normalize(); // returns the previous length, which is often useful
+
+	T& operator [] (int i) //allow vector[1] = 3   (vector.y=3)
+	{
+		return *((&x) + i);
+	}
+	T operator [] (const int i) const
+	{
+		return *((&x) + i);
+	}
+
+	Vec2 Lerp(const Vec2 &other, const float t) const
+	{
+		return (*this)*(1-t) + other*t;
+	}
+
+	void SetZero()
+	{
+		x=0; y=0;
+	}
+
+	// Common aliases: UV (texel coordinates), ST (texture coordinates)
+	T& u() { return x; }
+	T& v() { return y; }
+	T& s() { return x; }
+	T& t() { return y; }
+
+	const T& u() const { return x; }
+	const T& v() const { return y; }
+	const T& s() const { return x; }
+	const T& t() const { return y; }
+};
+
+template<typename T, typename V>
+Vec2<T> operator * (const V& f, const Vec2<T>& vec)
+{
+	return Vec2<T>(f*vec.x,f*vec.y);
+}
+
+typedef Vec2<float> Vec2f;
+
+template<typename T>
 class Vec3
 {
 public:
@@ -300,6 +422,12 @@ inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]
 inline float Vec3Dot(const float v1[3], const float v2[3])
 {
 	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+}
+
+template<typename T>
+inline T Dot(const Vec2<T>& a, const Vec2<T>& b)
+{
+	return a.x*b.x + a.y*b.y;
 }
 
 template<typename T>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -117,11 +117,6 @@ public:
 		return *((&x) + i);
 	}
 
-	Vec2 Lerp(const Vec2 &other, const float t) const
-	{
-		return (*this)*(1-t) + other*t;
-	}
-
 	void SetZero()
 	{
 		x=0; y=0;
@@ -252,11 +247,6 @@ public:
 	T operator [] (const int i) const
 	{
 		return *((&x) + i);
-	}
-
-	Vec3 Lerp(const Vec3 &other, const float t) const
-	{
-		return (*this)*(1-t) + other*t;
 	}
 
 	void SetZero()
@@ -420,11 +410,6 @@ public:
 		return *((&x) + i);
 	}
 
-	Vec4 Lerp(const Vec4 &other, const float t) const
-	{
-		return (*this)*(1-t) + other*t;
-	}
-
 	void SetZero()
 	{
 		x=0; y=0; z=0;
@@ -532,4 +517,18 @@ template<typename T>
 inline Vec3<T> Cross(const Vec3<T>& a, const Vec3<T>& b)
 {
 	return Vec3<T>(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
+}
+
+// linear interpolation via float: 0.0=begin, 1.0=end
+template<typename X>
+inline X Lerp(const X& begin, const X& end, const float t)
+{
+	return begin*(1.f-t) + end*t;
+}
+
+// linear interpolation via int: 0=begin, base=end
+template<typename X, int base>
+inline X LerpInt(const X& begin, const X& end, const int t)
+{
+	return (begin*(base-t) + end*t) / base;
 }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -158,6 +158,131 @@ Vec3<T> operator * (const V& f, const Vec3<T>& vec)
 
 typedef Vec3<float> Vec3f;
 
+template<typename T>
+class Vec4
+{
+public:
+	struct
+	{
+		T x,y,z,w;
+	};
+
+	T* AsArray() { return &x; }
+
+	Vec4() {}
+	Vec4(const T a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
+	Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
+
+	// Only implemented for T=int and T=float
+	static Vec4 FromRGBA(unsigned int rgba);
+
+	static Vec4 AssignToAll(const T& f)
+	{
+		return Vec4<T>(f, f, f, f);
+	}
+
+	void Write(T a[4])
+	{
+		a[0] = x; a[1] = y; a[2] = z; a[3] = w;
+	}
+
+	Vec4 operator +(const Vec4& other) const
+	{
+		return Vec4(x+other.x, y+other.y, z+other.z, w+other.w);
+	}
+	void operator += (const Vec4& other)
+	{
+		x+=other.x; y+=other.y; z+=other.z; w+=other.w;
+	}
+	Vec4 operator -(const Vec4 &other) const
+	{
+		return Vec4(x-other.x, y-other.y, z-other.z, w-other.w);
+	}
+	void operator -= (const Vec4 &other)
+	{
+		x-=other.x; y-=other.y; z-=other.z; w-=other.w;
+	}
+	Vec4 operator -() const
+	{
+		return Vec4(-x,-y,-z,-w);
+	}
+	Vec4 Mul(const Vec4 &other) const
+	{
+		return Vec4(x*other.x, y*other.y, z*other.z, w*other.w);
+	}
+	template<typename V>
+	Vec4 operator * (const V& f) const
+	{
+		return Vec4(x*f,y*f,z*f,w*f);
+	}
+	template<typename V>
+	void operator *= (const V& f)
+	{
+		x*=f; y*=f; z*=f; w*=f;
+	}
+	template<typename V>
+	Vec4 operator / (const V& f) const
+	{
+		return Vec4(x/f,y/f,z/f,w/f);
+	}
+	template<typename V>
+	void operator /= (const V& f)
+	{
+		*this = *this / f;
+	}
+
+	T Length2() const
+	{
+		return x*x + y*y + z*z + w*w;
+	}
+
+	// Only implemented for T=float
+	float Length() const;
+	void SetLength(const float l);
+	Vec4 WithLength(const float l) const;
+	float Distance2To(Vec4 &other);
+	Vec4 Normalized() const;
+	float Normalize(); // returns the previous length, which is often useful
+
+	T& operator [] (int i) //allow vector[2] = 3   (vector.z=3)
+	{
+		return *((&x) + i);
+	}
+	T operator [] (const int i) const
+	{
+		return *((&x) + i);
+	}
+
+	Vec4 Lerp(const Vec4 &other, const float t) const
+	{
+		return (*this)*(1-t) + other*t;
+	}
+
+	void SetZero()
+	{
+		x=0; y=0; z=0;
+	}
+
+	// Common alias: RGBA (colors)
+	T& r() { return x; }
+	T& g() { return y; }
+	T& b() { return z; }
+	T& a() { return w; }
+
+	const T& r() const { return x; }
+	const T& g() const { return y; }
+	const T& b() const { return z; }
+	const T& a() const { return w; }
+};
+
+template<typename T, typename V>
+Vec4<T> operator * (const V& f, const Vec4<T>& vec)
+{
+	return Vec4<T>(f*vec.x,f*vec.y,f*vec.z,f*vec.w);
+}
+
+typedef Vec4<float> Vec4f;
+
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];
@@ -181,6 +306,12 @@ template<typename T>
 inline T Dot(const Vec3<T>& a, const Vec3<T>& b)
 {
 	return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+template<typename T>
+inline T Dot(const Vec4<T>& a, const Vec4<T>& b)
+{
+	return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w;
 }
 
 template<typename T>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -548,6 +548,35 @@ private:
 };
 
 
+template<typename BaseType>
+class Mat4x4
+{
+public:
+	// Convention: first four values in arrow = first column
+	Mat4x4(const BaseType values[])
+	{
+		for (unsigned int i = 0; i < 4*4; ++i)
+		{
+			this->values[i] = values[i];
+		}
+	}
+
+	template<typename T>
+	Vec4<T> operator * (const Vec4<T>& vec)
+	{
+		Vec4<T> ret;
+		ret.x = values[0]*vec.x + values[4]*vec.y + values[8]*vec.z + values[12]*vec.w;
+		ret.y = values[1]*vec.x + values[5]*vec.y + values[9]*vec.z + values[13]*vec.w;
+		ret.z = values[2]*vec.x + values[6]*vec.y + values[10]*vec.z + values[14]*vec.w;
+		ret.w = values[3]*vec.x + values[7]*vec.y + values[11]*vec.z + values[15]*vec.w;
+		return ret;
+	}
+
+private:
+	BaseType values[4*4];
+};
+
+
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -476,6 +476,78 @@ Vec4<T> operator * (const V& f, const Vec4<T>& vec)
 
 typedef Vec4<float> Vec4f;
 
+
+template<typename BaseType>
+class Mat3x3
+{
+public:
+	// Convention: first three values = first column
+	Mat3x3(const BaseType values[])
+	{
+		for (unsigned int i = 0; i < 3*3; ++i)
+		{
+			this->values[i] = values[i];
+		}
+	}
+
+	Mat3x3(BaseType _00, BaseType _01, BaseType _02, BaseType _10, BaseType _11, BaseType _12, BaseType _20, BaseType _21, BaseType _22)
+	{
+		values[0] = _00;
+		values[1] = _01;
+		values[2] = _02;
+		values[3] = _10;
+		values[4] = _11;
+		values[5] = _12;
+		values[6] = _20;
+		values[7] = _21;
+		values[8] = _22;
+	}
+
+	template<typename T>
+	Vec3<T> operator * (const Vec3<T>& vec)
+	{
+		Vec3<T> ret;
+		ret.x = values[0]*vec.x + values[3]*vec.y + values[6]*vec.z;
+		ret.y = values[1]*vec.x + values[4]*vec.y + values[7]*vec.z;
+		ret.z = values[2]*vec.x + values[5]*vec.y + values[8]*vec.z;
+		return ret;
+	}
+
+	Mat3x3 Inverse()
+	{
+		float a = values[0];
+		float b = values[1];
+		float c = values[2];
+		float d = values[3];
+		float e = values[4];
+		float f = values[5];
+		float g = values[6];
+		float h = values[7];
+		float i = values[8];
+		return Mat3x3(e*i-f*h, f*g-d*i, d*h-e*g,
+						c*h-b*i, a*i-c*g, b*g-a*h,
+						b*f-c*e, c*d-a*f, a*e-b*d) / Det();
+	}
+
+	BaseType Det()
+	{
+		return values[0]*values[4]*values[8] + values[3]*values[7]*values[2] +
+				values[6]*values[1]*values[5] - values[2]*values[4]*values[6] -
+				values[5]*values[7]*values[0] - values[8]*values[1]*values[3];
+	}
+
+	Mat3x3 operator / (const BaseType& val) const
+	{
+		return Mat3x3(values[0]/val, values[1]/val, values[2]/val,
+						values[3]/val, values[4]/val, values[5]/val,
+						values[6]/val, values[7]/val, values[8]/val);
+	}
+
+private:
+	BaseType values[3*3];
+};
+
+
 inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];


### PR DESCRIPTION
Build tested on linux (gcc 4.7.2) and windows (msvc2010).

Enhances the feature set of the existing utility Math3D code by:
- supporting arbitrary base types in vectors (e.g. Vec3<float>, Vec3<int>) (CHANGED: Not possible to have different types for each component anymore)
- supporting two-component and four-component vectors
- supporting access of individual vector components as a subvector (e.g Vec4::rgb() returns a Vec3 consisting of values equal to the r, g, and b components of the Vec4 object) (CHANGED: It's not fast anymore because it's not using references anymore)
- supporting more flexible component naming (e.g. "rgba" or "xyzw") in vectors
- supporting 3x3 and 4x4 matrix classes (NEW)
- REMOVED: supporting vectors acting purely on references, thus being effective on memory usage (although I guess the compiler should've done this before already)

Additionally, this patch
- cleanly abstracts using Vec3 as a color or as an actual position vector.
- fixes some confusing oddities of the Vec3 API.
- might fix bugs caused by incorrect constructor usage (see below for details).
- doesn't use templates as extensively as the old, unmerged math3d-extensions code so that this also compiles on crappy compilers (NEW)

Changes for other people who used the code before:
- The star operator (_) refers to per-component product now (i.e. Vec2(v1.x_v1.x,v2.y*v2.y)) instead of the dot product. This is more consistent with what other APIs are doing (most notably GLSL/HLSL). For the dot product, a new Dot() function has been introduced. Additionally, Lerp has been made a global function instead of a VecXRef method. Existing code has been fixed to respect these changes.
- The % operator has been removed because it's not clear what it means. The new Cross() function should be used instead. There was no code using this functionality.
- The Vec3(u32 rgb) constructor has been removed due to its ambiguity. There have been some cases where the wrong constructor has been actually used, so this might even fix a bug. Anyway, instead the new static member functions Vec3::FromRGB and Vec4::FromRGBA should be used instead.
- What used to be Vec3 (i.e. a three-component vector acting on floats) is now Vec3f.
