### PR TITLE
Detect less direct cases of render to texture

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -185,6 +185,9 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 		if (it->first == cacheKey) {
 			DEBUG_LOG(HLE, "Render to texture detected at %08x!", address);
 			if (!entry->framebuffer) {
+				if (entry->format != framebuffer->format) {
+					WARN_LOG_REPORT(HLE, "Render to texture with different formats %d != %d", entry->format, framebuffer->format);
+				}
 				entry->framebuffer = framebuffer;
 				// TODO: Delete the original non-fbo texture too.
 			} else {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1138,6 +1138,7 @@ void TextureCache::SetTexture() {
 	entry->lodBias = 0.0f;
 	
 	entry->dim = gstate.texsize[0] & 0xF0F;
+	entry->bufw = bufw;
 
 	// This would overestimate the size in many case so we underestimate instead
 	// to avoid excessive clearing caused by cache invalidations.

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -198,7 +198,7 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 				glBindTexture(GL_TEXTURE_2D, 0);
 				lastBoundTexture = -1;
 			}
-		} else {
+		} else if (g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE) {
 			// 3rd Birthday (and possibly other games) render to a 16 bit clut texture.
 			const bool compatFormat = framebuffer->format == entry->format
 				|| (framebuffer->format == GE_FORMAT_8888 && entry->format == GE_TFMT_CLUT32)

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -90,6 +90,7 @@ private:
 		u32 framesUntilNextFullHash;
 		u8 format;
 		u16 dim;
+		u16 bufw;
 		u32 texture;  //GLuint
 		int invalidHint;
 		u32 fullhash;


### PR DESCRIPTION
Specifically:
- Detects when render-to-texture is used with a different format (may mean wrong FBO, for now just logs.)  This [does in fact happen](http://report.ppsspp.org/logs/kind/253).
- Detects when render-to-texture uses a subtexture (offset y, as in Sword Art Online.)  Just binds the FBO for now, which works in [the only game I've seen this in](http://report.ppsspp.org/logs/kind/252).
- Detects when render-to-texture uses a CLUT (as in 3rd Birthday.)  Just binds the FBO as well, which isn't worse than using garbage ram, and [also seems uncommon](http://report.ppsspp.org/logs/kind/254).
- Uses the old logic when copy to VRAM is enabled.

AFAICT the perf impact should be minimal due to the bound check, even with a ton of textures.

Practical impact - not complete, but improves the graphical glitches that occur in 3rd Birthday and Sword Art Online without breaking fonts or other graphics.  Previous situation was reading garbage as a texture (unless the FBO was flushed), so even if not correct, this shouldn't be any worse.

-[Unknown]
