### PR TITLE
Display if condition is met (and more)

### DIFF
--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -71,14 +71,16 @@ namespace MIPSAnalyst
 		DebugInterface* cpu;
 		u32 opcodeAddress;
 		u32 encodedOpcode;
+		
+		// shared between branches and conditional moves
+		bool isConditional;
+		bool conditionMet;
 
 		// branches
 		u32 branchTarget;
 		bool isBranch;
 		bool isLinkedBranch;
 		bool isLikelyBranch;
-		bool isConditionalBranch;
-		bool branchConditionMet;
 		bool isBranchToRegister;
 		int branchRegisterNum;
 

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -19,6 +19,8 @@
 
 #include "../../Globals.h"
 
+class DebugInterface;
+
 namespace MIPSAnalyst
 {
 	void Analyze(u32 address);
@@ -63,5 +65,29 @@ namespace MIPSAnalyst
 	bool IsSyscall(u32 op);
 
 	void Shutdown();
+	
+	typedef struct
+	{
+		DebugInterface* cpu;
+		u32 opcodeAddress;
+		u32 encodedOpcode;
+
+		// branches
+		u32 branchTarget;
+		bool isBranch;
+		bool isLinkedBranch;
+		bool isLikelyBranch;
+		bool isConditionalBranch;
+		bool branchConditionMet;
+		bool isBranchToRegister;
+		int branchRegisterNum;
+
+		// data access
+		bool isDataAccess;
+		int dataSize;
+		u32 dataAddress;
+	} MipsOpcodeInfo;
+
+	MipsOpcodeInfo GetOpcodeInfo(DebugInterface* cpu, u32 address);
 
 }	// namespace MIPSAnalyst

--- a/Core/MIPS/MIPSCodeUtils.cpp
+++ b/Core/MIPS/MIPSCodeUtils.cpp
@@ -32,8 +32,8 @@ namespace MIPSCodeUtils
 		u32 op = Memory::Read_Instruction(addr);
 		if (op)
 		{
-			op &= 0xFC000000;
-			if (op == 0x0C000000 || op == 0x08000000) //jal
+			u32 maskedOp = op & 0xFC000000;
+			if (maskedOp == 0x0C000000 || maskedOp == 0x08000000) //jal
 			{
 				u32 target = (addr & 0xF0000000) | ((op&0x03FFFFFF) << 2);
 				return target;
@@ -53,7 +53,7 @@ namespace MIPSCodeUtils
 			u32 info = MIPSGetInfo(op);
 			if (info & IS_CONDBRANCH)
 			{
-				return addr + ((signed short)(op&0xFFFF)<<2);
+				return addr + 4 + ((signed short)(op&0xFFFF)<<2);
 			}
 			else
 				return INVALIDTARGET;
@@ -70,7 +70,7 @@ namespace MIPSCodeUtils
 			u32 info = MIPSGetInfo(op);
 			if ((info & IS_CONDBRANCH) && !(info & OUT_RA))
 			{
-				return addr + ((signed short)(op&0xFFFF)<<2);
+				return addr + 4 + ((signed short)(op&0xFFFF)<<2);
 			}
 			else
 				return INVALIDTARGET;

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -36,6 +36,10 @@
 #define MIPS_MAKE_SYSCALL(module, function) GetSyscallOp(module, GetNibByName(module, function))
 #define MIPS_MAKE_BREAK() (13)  // ! :)
 
+#define MIPS_GET_OP(op)   ((op>>26) & 0x3F)
+#define MIPS_GET_FUNC(op) (op & 0x3F)
+#define MIPS_GET_SA(op)   (op>>6 & 0x1F)
+
 #define MIPS_GET_RS(op) ((op>>21) & 0x1F)
 #define MIPS_GET_RT(op) ((op>>16) & 0x1F)
 #define MIPS_GET_RD(op) ((op>>11) & 0x1F)

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -94,10 +94,10 @@ const MIPSInstruction tableImmediate[64] =  //xxxxxx .....
 	ENCODING(RegI),
 	INSTR("j",    &Jit::Comp_Jump, Dis_JumpType, Int_JumpType, IS_JUMP|IN_IMM26|DELAYSLOT),
 	INSTR("jal",  &Jit::Comp_Jump, Dis_JumpType, Int_JumpType, IS_JUMP|IN_IMM26|OUT_RA|DELAYSLOT),
-	INSTR("beq",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT),
-	INSTR("bne",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT),
-	INSTR("blez", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT),
-	INSTR("bgtz", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT),
+	INSTR("beq",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|CONDTYPE_EQ),
+	INSTR("bne",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|CONDTYPE_NE),
+	INSTR("blez", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|CONDTYPE_LEZ),
+	INSTR("bgtz", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|CONDTYPE_GTZ),
 	//8
 	INSTR("addi",  &Jit::Comp_IType, Dis_addi,   Int_IType, IN_RS|IN_IMM16|OUT_RT),
 	INSTR("addiu", &Jit::Comp_IType, Dis_addi,   Int_IType, IN_RS|IN_IMM16|OUT_RT),
@@ -113,10 +113,10 @@ const MIPSInstruction tableImmediate[64] =  //xxxxxx .....
 	ENCODING(Cop2), //cop2
 	INVALID, //copU
 
-	INSTR("beql",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|LIKELY), //L = likely
-	INSTR("bnel",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|LIKELY),
-	INSTR("blezl", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY),
-	INSTR("bgtzl", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY),
+	INSTR("beql",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|LIKELY|CONDTYPE_EQ), //L = likely
+	INSTR("bnel",  &Jit::Comp_RelBranch, Dis_RelBranch2, Int_RelBranch, IS_CONDBRANCH|IN_RS|IN_RT|DELAYSLOT|LIKELY|CONDTYPE_NE),
+	INSTR("blezl", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY|CONDTYPE_LEZ),
+	INSTR("bgtzl", &Jit::Comp_RelBranch, Dis_RelBranch,  Int_RelBranch, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY|CONDTYPE_GTZ),
 	//24
 	{VFPU0},
 	{VFPU1},
@@ -127,22 +127,22 @@ const MIPSInstruction tableImmediate[64] =  //xxxxxx .....
 	{-2},
 	{Spe3},//special3
 	//32
-	INSTR("lb",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lh",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lwl", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lw",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lbu", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lhu", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
-	INSTR("lwr", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT),
+	INSTR("lb",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_BYTE),
+	INSTR("lh",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_HWORD),
+	INSTR("lwl", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_WORD),
+	INSTR("lw",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_WORD),
+	INSTR("lbu", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_BYTE),
+	INSTR("lhu", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_HWORD),
+	INSTR("lwr", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_MEM|IN_IMM16|IN_RS_ADDR|OUT_RT|MEMTYPE_WORD),
 	{-2},
 	//40
-	INSTR("sb",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM),
-	INSTR("sh",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM),
-	INSTR("swl", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM),
-	INSTR("sw",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM),
+	INSTR("sb",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM|MEMTYPE_BYTE),
+	INSTR("sh",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM|MEMTYPE_HWORD),
+	INSTR("swl", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM|MEMTYPE_WORD),
+	INSTR("sw",  &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM|MEMTYPE_WORD),
 	{-2},
 	{-2},
-	INSTR("swr", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM),
+	INSTR("swr", &Jit::Comp_ITypeMem, Dis_ITypeMem, Int_ITypeMem, IN_IMM16|IN_RS_ADDR|IN_RT|OUT_MEM|MEMTYPE_WORD),
 	INSTR("cache", &Jit::Comp_Generic, Dis_Generic, Int_Cache, 0),
 	//48
 	INSTR("ll", &Jit::Comp_Generic, Dis_Generic, Int_StoreSync, 0),
@@ -178,10 +178,10 @@ const MIPSInstruction tableSpecial[64] = /// 000000 ...... ...... .......... xxx
 	INSTR("srav",  &Jit::Comp_ShiftType, Dis_VarShiftType, Int_ShiftType, OUT_RD|IN_RT|IN_RS_SHIFT),
 
 	//8
-	INSTR("jr",    &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, DELAYSLOT),
-	INSTR("jalr",  &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, DELAYSLOT),
-	INSTR("movz",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT),
-	INSTR("movn",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT),
+	INSTR("jr",    &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, IS_JUMP|IN_RS|DELAYSLOT),
+	INSTR("jalr",  &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, IS_JUMP|IN_RS|OUT_RA|DELAYSLOT),
+	INSTR("movz",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT|IS_CONDMOVE|CONDTYPE_EQ),
+	INSTR("movn",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT|IS_CONDMOVE|CONDTYPE_NE),
 	INSTR("syscall", &Jit::Comp_Syscall, Dis_Syscall, Int_Syscall,0),
 	INSTR("break", &Jit::Comp_Break, Dis_Generic, Int_Break, 0),
 	{-2},
@@ -327,10 +327,10 @@ const MIPSInstruction tableSpecial3[64] =
 
 const MIPSInstruction tableRegImm[32] = 
 {
-	INSTR("bltz",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT),
-	INSTR("bgez",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT),
-	INSTR("bltzl", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY),
-	INSTR("bgezl", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY),
+	INSTR("bltz",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|CONDTYPE_LTZ),
+	INSTR("bgez",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|CONDTYPE_GEZ),
+	INSTR("bltzl", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY|CONDTYPE_LTZ),
+	INSTR("bgezl", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|DELAYSLOT|LIKELY|CONDTYPE_GEZ),
 	{-2},
 	{-2},
 	{-2},
@@ -345,10 +345,10 @@ const MIPSInstruction tableRegImm[32] =
 	INSTR("tnei",  &Jit::Comp_Generic, Dis_Generic, 0, 0),
 	{-2},
 
-	INSTR("bltzal",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT),  
-	INSTR("bgezal",  &Jit::Comp_RelBranchRI, Dis_RelBranch,	Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT),
-	INSTR("bltzall", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|LIKELY), //L = likely
-	INSTR("bgezall", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|LIKELY),
+	INSTR("bltzal",  &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|CONDTYPE_LTZ),  
+	INSTR("bgezal",  &Jit::Comp_RelBranchRI, Dis_RelBranch,	Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|CONDTYPE_GEZ),
+	INSTR("bltzall", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|LIKELY|CONDTYPE_LTZ), //L = likely
+	INSTR("bgezall", &Jit::Comp_RelBranchRI, Dis_RelBranch, Int_RelBranchRI, IS_CONDBRANCH|IN_RS|OUT_RA|DELAYSLOT|LIKELY|CONDTYPE_GEZ),
 	{-2},
 	{-2},
 	{-2},

--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -19,6 +19,23 @@
 
 #include "../../Globals.h"
 
+#define CONDTYPE_MASK	0x00000007
+#define CONDTYPE_EQ		0x00000001
+#define CONDTYPE_NE		0x00000002
+#define CONDTYPE_LEZ	0x00000003
+#define CONDTYPE_GTZ	0x00000004
+#define CONDTYPE_LTZ	0x00000005
+#define CONDTYPE_GEZ	0x00000006
+
+// as long as the other flags are checked,
+// there is no way to misinterprete these
+// as CONDTYPE_X
+#define MEMTYPE_MASK	0x00000003
+#define MEMTYPE_BYTE	0x00000001
+#define MEMTYPE_HWORD	0x00000002
+#define MEMTYPE_WORD	0x00000003
+
+#define IS_CONDMOVE		0x00000008
 #define DELAYSLOT       0x00000010
 #define BAD_INSTRUCTION 0x00000020
 #define UNCONDITIONAL   0x00000040

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -406,9 +406,9 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 		parseDisasm(dizz,opcode,arguments);
 
 		// display whether the condition of a branch is met
-		if (info.isConditionalBranch && address == debugger->getPC())
+		if (info.isConditional && address == debugger->getPC())
 		{
-			strcat(arguments,info.branchConditionMet ? "  ; true" : "  ; false");
+			strcat(arguments,info.conditionMet ? "  ; true" : "  ; false");
 		}
 
 		int length = (int) strlen(arguments);
@@ -418,7 +418,7 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 		TextOut(hdc,pixelPositions.opcodeStart,rowY1+2,opcode,(int)strlen(opcode));
 		SelectObject(hdc,font);
 
-		if (info.isConditionalBranch)
+		if (info.isBranch && info.isConditional)
 		{
 			branches[numBranches].src=rowY1 + rowHeight/2;
 			branches[numBranches].srcAddr=address/instructionSize;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -293,7 +293,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					u32 breakpointAddress = cpu->GetPC()+cpu->getInstructionSize(0);
 					if (info.isBranch)
 					{
-						if (info.isConditionalBranch == false)
+						if (info.isConditional == false)
 						{
 							if (info.isLinkedBranch)	// jal, jalr
 							{


### PR DESCRIPTION
This adds a function that decodes all information that the disassembly can make use of out of an opcode. Some of that is used to simplify other code, some will be used later on (the data acess variables), and then it allows displaying if a condition is met taken: http://puu.sh/3OWq6/5bb721b3f1.png

I changed the MIPSTables for this, so it would probably be best if someone else also looked over it before merging.
There were also some bugs in MIPSCodeUtils. Some of these functions were actually used, so maybe it changes things slightly somewhere.
