### PR TITLE
Add pc, hi, and lo to the register list

### DIFF
--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -46,6 +46,11 @@ public:
 	virtual bool initExpression(char* exp, PostfixExpression& dest) { return false; };
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest) { return false; };
 
+	
+	virtual u32 GetHi() { return 0; };
+	virtual u32 GetLo() { return 0; };
+	virtual void SetHi(u32 val) { };
+	virtual void SetLo(u32 val) { };
 	virtual const char *GetName() = 0;
 	virtual int GetGPRSize() = 0; //32 or 64
 	virtual u32 GetGPR32Value(int reg) {return 0;}

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -76,6 +76,26 @@ public:
 		}
 	}
 
+	u32 GetHi()
+	{
+		return cpu->hi;
+	}
+
+	u32 GetLo()
+	{
+		return cpu->lo;
+	}
+	
+	void SetHi(u32 val)
+	{
+		cpu->hi = val;
+	}
+
+	void SetLo(u32 val)
+	{
+		cpu->lo = val;
+	}
+
 	u32 GetRegValue(int cat, int index)
 	{
 		u32 temp;
@@ -83,7 +103,6 @@ public:
 		{
 		case 0:
 			return cpu->r[index];
-
 		case 1:
 			memcpy(&temp, &cpu->f[index], 4);
 			return temp;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -834,17 +834,31 @@ void CtrlDisAsmView::updateStatusBarText()
 	text[0] = 0;
 	if (info.isDataAccess)
 	{
-		switch (info.dataSize)
+		if (!Memory::IsValidAddress(info.dataAddress))
 		{
-		case 1:
-			sprintf(text,"[%08X] = %02X",info.dataAddress,Memory::Read_U8(info.dataAddress));
-			break;
-		case 2:
-			sprintf(text,"[%08X] = %04X",info.dataAddress,Memory::Read_U16(info.dataAddress));
-			break;
-		case 4:
-			sprintf(text,"[%08X] = %08X",info.dataAddress,Memory::Read_U32(info.dataAddress));
-			break;
+			sprintf(text,"Invalid address %08X",info.dataAddress);
+		} else {
+			switch (info.dataSize)
+			{
+			case 1:
+				sprintf(text,"[%08X] = %02X",info.dataAddress,Memory::Read_U8(info.dataAddress));
+				break;
+			case 2:
+				sprintf(text,"[%08X] = %04X",info.dataAddress,Memory::Read_U16(info.dataAddress));
+				break;
+			case 4:
+				{
+					u32 data = Memory::Read_U32(info.dataAddress);
+					const char* addressSymbol = debugger->findSymbolForAddress(data);
+					if (addressSymbol)
+					{
+						sprintf(text,"[%08X] = %s (%08X)",info.dataAddress,addressSymbol,data);
+					} else {
+						sprintf(text,"[%08X] = %08X",info.dataAddress,data);
+					}
+					break;
+				}
+			}
 		}
 	}
 

--- a/Windows/Debugger/CtrlRegisterList.h
+++ b/Windows/Debugger/CtrlRegisterList.h
@@ -69,10 +69,10 @@ public:
 		cpu = deb;
 
 		int regs = cpu->GetNumRegsInCategory(0);
-		lastCat0Values = new u32[regs];
-		changedCat0Regs = new bool[regs];
-		memset(lastCat0Values, 0, regs * sizeof(u32));
-		memset(changedCat0Regs, 0, regs * sizeof(bool));
+		lastCat0Values = new u32[regs+3];
+		changedCat0Regs = new bool[regs+3];
+		memset(lastCat0Values, 0, (regs+3) * sizeof(u32));
+		memset(changedCat0Regs, 0, (regs+3) * sizeof(bool));
 	}
 	DebugInterface *getCPU()
 	{


### PR DESCRIPTION
As far as I can tell, there was no way to know the content of hi and lo before. I added pc too for the convenience of copying and editing.
It now also makes sure it's reading from a valid position when creating the disassembly status bar text, and additionally displays a symbol if it exists for lw/sw opcodes.
