### PR TITLE
Minor reporting related tweaks

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -605,8 +605,13 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 
 		DEBUG_LOG(LOADER, "Importing Module %s, stubs at %08x", modulename, entry->firstSymAddr);
 		if (entry->size != 5 && entry->size != 6) {
-			WARN_LOG_REPORT(LOADER, "Unexpected module entry size %d", entry->size);
-			needReport = true;
+			if (entry->size != 7) {
+				WARN_LOG_REPORT(LOADER, "Unexpected module entry size %d", entry->size);
+				needReport = true;
+			} else if (entry->extra != 0) {
+				WARN_LOG_REPORT(LOADER, "Unexpected module entry with non-zero 7th value %08x", entry->extra);
+				needReport = true;
+			}
 		}
 
 		// If nidData is 0, only variables are being imported.

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -372,6 +372,7 @@ static const HLEFunction scePower[] = {
 	{0xebd177d6,WrapU_UUU<scePowerSetClockFrequency>,"scePower_EBD177D6"}, // This is also the same as SetClockFrequency
 	{0x469989ad,WrapU_UUU<scePowerSetClockFrequency>,"scePower_469989ad"},  // This is also the same as SetClockFrequency
 	{0xa85880d0,WrapU_V<IsPSPNonFat>,"scePower_a85880d0_IsPSPNonFat"},
+	{0x3951af53,0,"scePowerWaitRequestCompletion"},
 };
 
 //890129c in tyshooter looks bogus

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -350,13 +350,14 @@ const HLEFunction sceUmdUser[] =
 	{0x56202973,WrapI_UU<sceUmdWaitDriveStatWithTimer>,"sceUmdWaitDriveStatWithTimer"},
 	{0x4A9E5E29,WrapI_UU<sceUmdWaitDriveStatCB>,"sceUmdWaitDriveStatCB"},
 	{0x6af9b50a,WrapU_V<sceUmdCancelWaitDriveStat>,"sceUmdCancelWaitDriveStat"},
-	{0x6B4A146C,&WrapU_V<sceUmdGetDriveStat>,"sceUmdGetDriveStat"},
 	{0x20628E6F,&WrapU_V<sceUmdGetErrorStat>,"sceUmdGetErrorStat"},
 	{0x340B7686,WrapU_U<sceUmdGetDiscInfo>,"sceUmdGetDiscInfo"},
 	{0xAEE7404D,&WrapU_U<sceUmdRegisterUMDCallBack>,"sceUmdRegisterUMDCallBack"},
 	{0xBD2BDE07,&WrapI_I<sceUmdUnRegisterUMDCallBack>,"sceUmdUnRegisterUMDCallBack"},
 	{0x87533940,WrapU_V<sceUmdReplaceProhibit>,"sceUmdReplaceProhibit"},
 	{0xCBE9F02A,WrapU_V<sceUmdReplacePermit>,"sceUmdReplacePermit"},
+	{0x14c6c45c,0,"sceUmdUser_14C6C45C"},
+	{0xb103fa38,0,"sceUmdUser_B103FA38"},
 };
 
 void Register_sceUmdUser()


### PR DESCRIPTION
Just to not get the "unexpected size 7" and get better reporting on a couple new syscalls.

I'm hoping "0" is harmless in those, but not really sure.  I think all games that use it have issues (Tales of the World 2, God Eater Burst 2.)

-[Unknown]
