### PR TITLE
Fix two memory leaks in ArmCPUDetect.cpp

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -71,6 +71,9 @@ unsigned char GetCPUImplementer()
 		sscanf(implementer_string, "0x%02hhx", &implementer);
 		break;
 	}
+
+	delete implementer_string;
+
 	return implementer;
 }
 
@@ -95,6 +98,9 @@ unsigned short GetCPUPart()
 		sscanf(part_string, "0x%03hx", &part);
 		break;
 	}
+
+	delete part_string;
+
 	return part;
 }
 

--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -72,7 +72,7 @@ unsigned char GetCPUImplementer()
 		break;
 	}
 
-	delete implementer_string;
+	free(implementer_string);
 
 	return implementer;
 }
@@ -99,7 +99,7 @@ unsigned short GetCPUPart()
 		break;
 	}
 
-	delete part_string;
+	free(part_string);
 
 	return part;
 }


### PR DESCRIPTION
These char pointers weren't deleted before the functions ended.
