### PR TITLE
ISOFileSystem support for umd0:umd0

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -306,6 +306,9 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 	if (path[0] == '/')
 		path.erase(0,1);
 
+	if (path == "umd0")
+		return &entireISO;
+
 	TreeEntry *e = treeroot;
 	if (path.length() == 0)
 		return e;


### PR DESCRIPTION
Allows Bleach: Soul Carnival 2 to find what it's looking for in its boot process (umd0:umd0). The game is still stuck in a blackscreen, but the boot process seems better than before (judging from the logs).

Prior to requesting umd0:umd0 the log is interesting. This is the second game I've seen waiting within a callback, and having something other than hleDelayResultFinish waking up an HLE-blocked thread.
