### PR TITLE
Win32/NewUI: Address debug log bug and placement in menu.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -33,6 +33,13 @@
 #include "base/timeutil.h"
 #include "math/curves.h"
 
+#ifdef _WIN32
+namespace MainWindow {
+	enum { WM_USER_LOG_STATUS_CHANGED = WM_USER + 200 };
+	extern HWND hwndMain;
+}
+#endif
+
 
 namespace UI {
 
@@ -319,6 +326,7 @@ void GlobalSettingsScreen::CreateViews() {
 	root_ = new ScrollView(ORIENT_VERTICAL);
 
 	enableReports_ = g_Config.sReportHost != "";
+	enableLogging_ = g_Config.bEnableLogging;
 
 	I18NCategory *g = GetI18NCategory("General");
 	I18NCategory *gs = GetI18NCategory("Graphics");
@@ -326,7 +334,7 @@ void GlobalSettingsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader("General"));
 	list->Add(new CheckBox(&g_Config.bNewUI, gs->T("Enable New UI")));
-	list->Add(new CheckBox(&g_Config.bEnableLogging, gs->T("Enable Debug Logging")));
+	list->Add(new CheckBox(&enableLogging_, gs->T("Enable Debug Logging")));
 	list->Add(new CheckBox(&enableReports_, gs->T("Enable Errors Reporting")));
 	list->Add(new CheckBox(&g_Config.bEnableCheats, gs->T("Enable Cheats")));
 	list->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, gs->T("Screenshots as PNG")));
@@ -358,6 +366,10 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 UI::EventReturn GlobalSettingsScreen::OnBack(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
 	g_Config.sReportHost = enableReports_ ? "report.ppsspp.org" : "";
+	g_Config.bEnableLogging = enableLogging_;
+#ifdef _WIN32
+	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_LOG_STATUS_CHANGED, 0, 0);
+#endif
 	g_Config.Save();
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -326,7 +326,6 @@ void GlobalSettingsScreen::CreateViews() {
 	root_ = new ScrollView(ORIENT_VERTICAL);
 
 	enableReports_ = g_Config.sReportHost != "";
-	enableLogging_ = g_Config.bEnableLogging;
 
 	I18NCategory *g = GetI18NCategory("General");
 	I18NCategory *gs = GetI18NCategory("Graphics");
@@ -334,7 +333,6 @@ void GlobalSettingsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader("General"));
 	list->Add(new CheckBox(&g_Config.bNewUI, gs->T("Enable New UI")));
-	list->Add(new CheckBox(&enableLogging_, gs->T("Enable Debug Logging")));
 	list->Add(new CheckBox(&enableReports_, gs->T("Enable Errors Reporting")));
 	list->Add(new CheckBox(&g_Config.bEnableCheats, gs->T("Enable Cheats")));
 	list->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, gs->T("Screenshots as PNG")));
@@ -366,10 +364,6 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 UI::EventReturn GlobalSettingsScreen::OnBack(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
 	g_Config.sReportHost = enableReports_ ? "report.ppsspp.org" : "";
-	g_Config.bEnableLogging = enableLogging_;
-#ifdef _WIN32
-	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_LOG_STATUS_CHANGED, 0, 0);
-#endif
 	g_Config.Save();
 	return UI::EVENT_DONE;
 }
@@ -378,6 +372,8 @@ void DeveloperToolsScreen::CreateViews() {
 	using namespace UI;
 	root_ = new ScrollView(ORIENT_VERTICAL);
 
+	enableLogging_ = g_Config.bEnableLogging;
+
 	I18NCategory *g = GetI18NCategory("General");
 	I18NCategory *d = GetI18NCategory("Developer");
 	I18NCategory *a = GetI18NCategory("Audio");
@@ -385,11 +381,19 @@ void DeveloperToolsScreen::CreateViews() {
 	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->Add(new ItemHeader(g->T("General")));
 	list->Add(new Choice(d->T("Run CPU Tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
+	list->Add(new CheckBox(&enableLogging_, d->T("Enable Debug Logging")));
 	list->Add(new Choice(g->T("Back")))->OnClick.Handle(this, &DeveloperToolsScreen::OnBack);
 }
 
 UI::EventReturn DeveloperToolsScreen::OnBack(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
+
+	g_Config.bEnableLogging = enableLogging_;
+#ifdef _WIN32
+	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_LOG_STATUS_CHANGED, 0, 0);
+#endif
+	g_Config.Save();
+
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -64,7 +64,6 @@ private:
 
 	// Temporaries to convert bools to other kinds of settings
 	bool enableReports_;
-	bool enableLogging_;
 };
 
 class DeveloperToolsScreen : public UIScreenWithBackground {
@@ -77,4 +76,7 @@ protected:
 private:
 	UI::EventReturn OnBack(UI::EventParams &e);
 	UI::EventReturn OnRunCPUTests(UI::EventParams &e);
+
+	// Temporary variable.
+	bool enableLogging_;
 };

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -64,6 +64,7 @@ private:
 
 	// Temporaries to convert bools to other kinds of settings
 	bool enableReports_;
+	bool enableLogging_;
 };
 
 class DeveloperToolsScreen : public UIScreenWithBackground {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1146,9 +1146,10 @@ namespace MainWindow
 			if(!g_Config.bEnableLogging) {
 				LogManager::GetInstance()->GetConsoleListener()->Show(false);
 				EnableMenuItem(menu, ID_DEBUG_LOG, MF_GRAYED);
-			}
-			else
+			} else {
+				LogManager::GetInstance()->GetConsoleListener()->Show(true);
 				EnableMenuItem(menu, ID_DEBUG_LOG, MF_ENABLED);
+			}
 			break;
 
 		case WM_MENUSELECT:


### PR DESCRIPTION
It was being enabled and disabled at weird times since the settings don't take effect until one exits the page. This mostly rectifies that, though it won't be instant like the old UI, due to how the two UIs differ when events are sent.

Also changed the behaviour of WM_USER_LOG_STATUS_CHANGED slightly to make it open a debug console when checked/true, in addition to simply re-enabling the menu bar option. If the user enables it, they probably want to see the output, so it makes sense to do it this way.

One last thing, the option to En/Disable debug logging's been moved to Developer Tools to be consistent with the Old UI. This is an option intended for developers/power users, after all..

Should fix #3047's main issues.
