### PR TITLE
Win32: Allow user to change emulated PSP nickname, and add an OSK "bypass"

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -161,6 +161,9 @@ void Config::Load(const char *iniFileName)
 	pspConfig->Get("ButtonPreference", &iButtonPreference, PSP_SYSTEMPARAM_BUTTON_CROSS);
 	pspConfig->Get("LockParentalLevel", &iLockParentalLevel, 0);
 	pspConfig->Get("WlanAdhocChannel", &iWlanAdhocChannel, PSP_SYSTEMPARAM_ADHOC_CHANNEL_AUTOMATIC);
+#ifdef _WIN32
+	pspConfig->Get("BypassOSKWithKeyboard", &bBypassOSKWithKeyboard, false);
+#endif
 	pspConfig->Get("WlanPowerSave", &bWlanPowerSave, PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF);
 	pspConfig->Get("EncryptSave", &bEncryptSave, true);
 
@@ -281,6 +284,9 @@ void Config::Save()
 		pspConfig->Set("WlanAdhocChannel", iWlanAdhocChannel);
 		pspConfig->Set("WlanPowerSave", bWlanPowerSave);
 		pspConfig->Set("EncryptSave", bEncryptSave);
+#ifdef _WIN32
+		pspConfig->Set("BypassOSKWithKeyboard", bBypassOSKWithKeyboard);
+#endif
 
 		IniFile::Section *debugConfig = iniFile.GetOrCreateSection("Debugger");
 		debugConfig->Set("DisasmWindowX", iDisasmWindowX);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -139,6 +139,10 @@ public:
 	bool bEncryptSave;
 	int iWlanAdhocChannel;
 	bool bWlanPowerSave;
+	// TODO: Make this work with your platform, too!
+#ifdef _WIN32
+	bool bBypassOSKWithKeyboard;
+#endif
 
 	// Debugger
 	int iDisasmWindowX;

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -742,7 +742,6 @@ void PSPOskDialog::RenderKeyboard()
 
 // TODO: Why does this have a 2 button press lag/delay when
 // re-opening the dialog box? I don't get it.
-// TODO: Stop crashes when the user enters > 255 characters on _WIN32.
 // TODO: Use a wstring to allow Japanese/Russian/etc.. on _WIN32(others?)
 int PSPOskDialog::NativeKeyboard()
 {
@@ -773,7 +772,7 @@ int PSPOskDialog::NativeKeyboard()
 			sprintf(buf, "VALUE");
 		}
 
-		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input, FieldMaxLength() - 1)) {
+		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input, FieldMaxLength())) {
 			sprintf(input, "");
 		}
 #endif

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -768,9 +768,10 @@ int PSPOskDialog::NativeKeyboard()
 
 		if(initial_text.length() < buf_len)
 			sprintf(buf, initial_text.c_str());
-		else
+		else {
 			ERROR_LOG(HLE, "NativeKeyboard: initial text length is too long");
-
+			sprintf(buf, "VALUE");
+		}
 		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input)) {
 			sprintf(input, "");
 		}

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -760,19 +760,28 @@ int PSPOskDialog::NativeKeyboard()
 		std::string initial_text;
 		ConvertUCS2ToUTF8(initial_text, oskParams->fields[0].intext);
 
-		const size_t buf_len = 512;
-		char buf[buf_len];
+		const size_t defaultText_len = 512;
+		char defaultText[defaultText_len];
 
-		memset(buf, 0, sizeof(buf));
+		memset(defaultText, 0, sizeof(defaultText));
 
-		if(initial_text.length() < buf_len)
-			sprintf(buf, initial_text.c_str());
+		if(initial_text.length() < defaultText_len)
+			sprintf(defaultText, initial_text.c_str());
 		else {
 			ERROR_LOG(HLE, "NativeKeyboard: initial text length is too long");
-			sprintf(buf, "VALUE");
+			sprintf(defaultText, "VALUE");
 		}
 
-		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input, FieldMaxLength())) {
+		char windowTitle[defaultText_len];
+		memset(windowTitle, 0, sizeof(windowTitle));
+
+		std::string description_text;
+		ConvertUCS2ToUTF8(description_text, oskParams->fields[0].desc);
+
+		if(description_text.length() < defaultText_len)
+			sprintf(windowTitle, description_text.c_str());
+
+		if(!InputBox_GetString(0, MainWindow::hwndMain, windowTitle, defaultText, input, FieldMaxLength())) {
 			sprintf(input, "");
 		}
 #endif

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -766,10 +766,10 @@ int PSPOskDialog::NativeKeyboard()
 		memset(defaultText, 0, sizeof(defaultText));
 
 		if(initial_text.length() < defaultText_len)
-			sprintf(defaultText, initial_text.c_str());
+			strncat(defaultText, initial_text.c_str(), strlen(initial_text.c_str()));
 		else {
 			ERROR_LOG(HLE, "NativeKeyboard: initial text length is too long");
-			sprintf(defaultText, "VALUE");
+			strncat(defaultText, "VALUE", strlen("VALUE"));
 		}
 
 		char windowTitle[defaultText_len];
@@ -779,12 +779,12 @@ int PSPOskDialog::NativeKeyboard()
 		ConvertUCS2ToUTF8(description_text, oskParams->fields[0].desc);
 
 		if(description_text.length() < defaultText_len)
-			sprintf(windowTitle, description_text.c_str());
+			strncat(windowTitle, description_text.c_str(), strlen(description_text.c_str()));
 
 		size_t maxInputLength = FieldMaxLength();
 
 		if(!InputBox_GetString(0, MainWindow::hwndMain, windowTitle, defaultText, input, maxInputLength)) {
-			sprintf(input, "");
+			strncat(input, "", strlen(""));
 		}
 #endif
 		// TODO: Insert your platform's native keyboard stuff here...

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -772,7 +772,8 @@ int PSPOskDialog::NativeKeyboard()
 			ERROR_LOG(HLE, "NativeKeyboard: initial text length is too long");
 			sprintf(buf, "VALUE");
 		}
-		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input)) {
+
+		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input, FieldMaxLength() - 1)) {
 			sprintf(input, "");
 		}
 #endif

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -781,7 +781,9 @@ int PSPOskDialog::NativeKeyboard()
 		if(description_text.length() < defaultText_len)
 			sprintf(windowTitle, description_text.c_str());
 
-		if(!InputBox_GetString(0, MainWindow::hwndMain, windowTitle, defaultText, input, FieldMaxLength())) {
+		size_t maxInputLength = FieldMaxLength();
+
+		if(!InputBox_GetString(0, MainWindow::hwndMain, windowTitle, defaultText, input, maxInputLength)) {
 			sprintf(input, "");
 		}
 #endif

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -758,8 +758,22 @@ int PSPOskDialog::NativeKeyboard()
 	{
 		
 #ifdef _WIN32
-		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, "VALUE", input))
+		std::string initial_text;
+		ConvertUCS2ToUTF8(initial_text, oskParams->fields[0].intext);
+
+		const size_t buf_len = 512;
+		char buf[buf_len];
+
+		memset(buf, 0, sizeof(buf));
+
+		if(initial_text.length() < buf_len)
+			sprintf(buf, initial_text.c_str());
+		else
+			ERROR_LOG(HLE, "NativeKeyboard: initial text length is too long");
+
+		if(!InputBox_GetString(0, MainWindow::hwndMain, NULL, buf, input)) {
 			sprintf(input, "");
+		}
 #endif
 		// TODO: Insert your platform's native keyboard stuff here...
 

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -178,6 +178,7 @@ private:
 	void ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16_le> em_address);
 	void ConvertUCS2ToUTF8(std::string& _string, const wchar_t *input);
 	void RenderKeyboard();
+	int NativeKeyboard();
 
 	std::wstring CombinationString(bool isInput); // for Japanese, Korean
 	std::wstring CombinationKorean(bool isInput); // for Korea

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -178,7 +178,9 @@ private:
 	void ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16_le> em_address);
 	void ConvertUCS2ToUTF8(std::string& _string, const wchar_t *input);
 	void RenderKeyboard();
+#ifdef _WIN32
 	int NativeKeyboard();
+#endif
 
 	std::wstring CombinationString(bool isInput); // for Japanese, Korean
 	std::wstring CombinationKorean(bool isInput); // for Korea

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1552,7 +1552,7 @@ void SystemScreen::render() {
 		char name[name_len];
 		memset(name, 0, sizeof(name));
 
-		if(InputBox_GetString(MainWindow::GetHInstance(), MainWindow::hwndMain, NULL, "PPSSPP", name, name_len))
+		if(InputBox_GetString(MainWindow::GetHInstance(), MainWindow::hwndMain, "Enter a new PSP nickname", "PPSSPP", name, name_len))
 			g_Config.sNickName.assign(name);
 		else
 			g_Config.sNickName.assign("PPSSPP");

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -1540,14 +1540,19 @@ void SystemScreen::render() {
 	// so until then, this is Windows/Desktop only.
 #ifdef _WIN32
 	char nickname[512];
-	sprintf(nickname, "%s %s", s->T("System Nickname: "), g_Config.sNickName);
+	memset(nickname, 0, sizeof(nickname));
+
+	sprintf(nickname, "%s %s", s->T("System Nickname: "), g_Config.sNickName.c_str());
 	ui_draw2d.DrawTextShadow(UBUNTU24, nickname, x, y += stride, 0xFFFFFFFF, ALIGN_LEFT);
 
 	HLinear hlinearNick(x + 400, y, 10);
 	if(UIButton(GEN_ID, hlinearNick, 110, 0, s->T("Change"), ALIGN_LEFT)) {
-		char name[256];
-		memset(&name, 0, sizeof(name));
-		if(InputBox_GetString(MainWindow::GetHInstance(), MainWindow::hwndMain, NULL, "PPSSPP", name))
+		const size_t name_len = 256;
+		
+		char name[name_len];
+		memset(name, 0, sizeof(name));
+
+		if(InputBox_GetString(MainWindow::GetHInstance(), MainWindow::hwndMain, NULL, "PPSSPP", name, name_len))
 			g_Config.sNickName.assign(name);
 		else
 			g_Config.sNickName.assign("PPSSPP");

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -46,6 +46,10 @@
 #include "Core/System.h"
 #include "Core/CoreParameter.h"
 #include "Core/HW/atrac3plus.h"
+#include "Core/Dialog/PSPOskDialog.h"
+#ifdef _WIN32
+#include "Windows/InputBox.h"
+#endif
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
@@ -79,6 +83,7 @@ namespace MainWindow {
 	};
 	extern HWND hwndMain;
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory = false);
+	HINSTANCE GetHInstance();
 }
 #endif
 
@@ -1531,6 +1536,23 @@ void SystemScreen::render() {
 	}
 	y += 20;
 
+	// TODO: Come up with a way to display a keyboard for mobile users,
+	// so until then, this is Windows/Desktop only.
+#ifdef _WIN32
+	char nickname[512];
+	sprintf(nickname, "%s %s", s->T("System Nickname: "), g_Config.sNickName);
+	ui_draw2d.DrawTextShadow(UBUNTU24, nickname, x, y += stride, 0xFFFFFFFF, ALIGN_LEFT);
+
+	HLinear hlinearNick(x + 400, y, 10);
+	if(UIButton(GEN_ID, hlinearNick, 110, 0, s->T("Change"), ALIGN_LEFT)) {
+		char name[256];
+		memset(&name, 0, sizeof(name));
+		if(InputBox_GetString(MainWindow::GetHInstance(), MainWindow::hwndMain, NULL, "PPSSPP", name))
+			g_Config.sNickName.assign(name);
+		else
+			g_Config.sNickName.assign("PPSSPP");
+	}
+#endif
 	/*
 	bool time = g_Config.iTimeFormat > 0 ;
 	UICheckBox(GEN_ID, x, y += stride, s->T("Time Format"), ALIGN_TOPLEFT, &time);

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -46,10 +46,6 @@
 #include "Core/System.h"
 #include "Core/CoreParameter.h"
 #include "Core/HW/atrac3plus.h"
-#include "Core/Dialog/PSPOskDialog.h"
-#ifdef _WIN32
-#include "Windows/InputBox.h"
-#endif
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
@@ -74,6 +70,10 @@
 #include <QFileDialog>
 #include <QFile>
 #include <QDir>
+#endif
+
+#ifdef _WIN32
+#include "Windows/InputBox.h"
 #endif
 
 #ifdef _WIN32

--- a/Windows/InputBox.cpp
+++ b/Windows/InputBox.cpp
@@ -49,6 +49,22 @@ bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defa
 		return false;
 }
 
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, u32 outlength)
+{
+	if (defaultvalue && strlen(defaultvalue)<255)
+		strcpy(textBoxContents,defaultvalue);
+	else
+		strcpy(textBoxContents,"");
+
+	if (IDOK==DialogBox(hInst,(LPCSTR)IDD_INPUTBOX,hParent,InputBoxFunc))
+	{
+		strncpy(outvalue, out, outlength);
+		return true;
+	}
+	else 
+		return false;
+}
+
 bool InputBox_GetHex(HINSTANCE hInst, HWND hParent, TCHAR *title, u32 defaultvalue, u32 &outvalue)
 {
 	sprintf(textBoxContents,"%08x",defaultvalue);

--- a/Windows/InputBox.cpp
+++ b/Windows/InputBox.cpp
@@ -51,7 +51,7 @@ bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defa
 		return false;
 }
 
-bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, u32 outlength)
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, size_t outlength)
 {
 	const char *defaultTitle = "Input value";
 

--- a/Windows/InputBox.cpp
+++ b/Windows/InputBox.cpp
@@ -4,12 +4,14 @@
 
 static TCHAR textBoxContents[256];
 static TCHAR out[256];
+static TCHAR windowTitle[256];
 
 static INT_PTR CALLBACK InputBoxFunc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) {
 	case WM_INITDIALOG:
 		SetWindowText(GetDlgItem(hDlg,IDC_INPUTBOX),textBoxContents);
+		SetWindowText(hDlg, windowTitle);
 		return TRUE;
 	case WM_COMMAND:
 		switch (wParam)
@@ -51,10 +53,20 @@ bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defa
 
 bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, u32 outlength)
 {
+	const char *defaultTitle = "Input value";
+
 	if (defaultvalue && strlen(defaultvalue)<255)
 		strcpy(textBoxContents,defaultvalue);
 	else
 		strcpy(textBoxContents,"");
+
+
+	if(title && strlen(title) <= 0)
+		strcpy(windowTitle, defaultTitle);
+	else if(title && strlen(title) < 255)
+		strcpy(windowTitle, title);
+	else
+		strcpy(windowTitle, defaultTitle);
 
 	if (IDOK==DialogBox(hInst,(LPCSTR)IDD_INPUTBOX,hParent,InputBoxFunc))
 	{

--- a/Windows/InputBox.h
+++ b/Windows/InputBox.h
@@ -4,5 +4,5 @@
 
 #include "Common/CommonWindows.h"
 bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue);
-bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, u32 outlength);
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, size_t outlength);
 bool InputBox_GetHex(HINSTANCE hInst, HWND hParent, TCHAR *title, u32 defaultvalue, u32 &outvalue);

--- a/Windows/InputBox.h
+++ b/Windows/InputBox.h
@@ -3,6 +3,6 @@
 #include "Globals.h"
 
 #include "Common/CommonWindows.h"
-
 bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue);
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, u32 outlength);
 bool InputBox_GetHex(HINSTANCE hInst, HWND hParent, TCHAR *title, u32 defaultvalue, u32 &outvalue);


### PR DESCRIPTION
This pullrq addresses https://github.com/hrydgard/ppsspp/issues/3062, at least for Windows. Other platforms would need to add their own methods of popping a dialog box and grabbing text from the user.

In addition, I added the beginnings of a dialog box(re-using the same one from the win32 debugger) similar to JPCSP's, to let the user just use their hardware keyboard if they wish to type instead of dragging a cursor around the OSK. It'd be nice if eventually the keyboard would just directly interact with the OSK, but I'm not really sure how to do that at the moment.

There are a few caveats concering the "bypass" though:

<del>1. It crashes the emulator if the user enters more characters than the game expects(I can't figure out how to make the textbox in the dialog box only have X characters max).</del>
1. Russian/Japanese/non-Roman languages will simply input question marks to the game(need to use wstring I think).
2. It has a weird "delay" to it if one closes the dialog box and then tries to re-open it. After closing it, the confirm button(cross/circle) has to be pressed twice in order to bring it back up.
3. The dialog box doesn't show up right in fullscreen(on AMD/ATI cards), so I fall back to the regular OSK when the user is in fullscreen just to be safe.
4. Some games(Japanese?) won't recognize text after a space(Project Diva series, and probably others), even though they do with the regular OSK(probably again being related to not using Unicode strings?).

As a result of these snags, the OSK bypass option is Win32 only(well, until others add their versions), and is a "hidden" INI option(no UI interface to it), called bBypassOSKWithKeyboard. It's set to false by default, resulting in the old/current behaviour normally.
