### PR TITLE
Fix a possible memory leak in BlockDevices.cpp.

### DIFF
--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -135,10 +135,18 @@ CISOFileBlockDevice::CISOFileBlockDevice(FILE *file)
 #else
 	index = new u32[indexSize];
 	u32_le *indexTemp = new u32_le[indexSize];
+
 	if (fread(indexTemp, sizeof(u32), indexSize, f) != indexSize)
+	{
 		memset(indexTemp, 0, indexSize * sizeof(u32_le));
+	}
+
 	for (u32 i = 0; i < indexSize; i++)
+	{
 		index[i] = indexTemp[i];
+	}
+
+	delete[] indexTemp;
 #endif
 }
 


### PR DESCRIPTION
I quickly read through the definition of u32_le and couldn't find anything that would say otherwise about this. If this is intended, or I overlooked some other aspect, just tell me.
