### PR TITLE
Prep work for GE and CPU on separate threads

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -519,12 +519,14 @@ void MoveEvents()
 	}
 }
 
-void AdvanceQuick()
+void Advance()
 {
 	int cyclesExecuted = slicelength - currentMIPS->downcount;
 	globalTimer += cyclesExecuted;
 	currentMIPS->downcount = slicelength;
 
+	if (Common::AtomicLoadAcquire(hasTsEvents))
+		MoveEvents();
 	ProcessFifoWaitEvents();
 
 	if (!first)
@@ -541,14 +543,6 @@ void AdvanceQuick()
 	}
 	if (advanceCallback)
 		advanceCallback(cyclesExecuted);
-}
-
-void Advance()
-{
-	if (Common::AtomicLoadAcquire(hasTsEvents))
-		MoveEvents();
-
-	AdvanceQuick();
 }
 
 void LogPendingEvents()

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -204,7 +204,7 @@ void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata
 {
 	std::lock_guard<std::recursive_mutex> lk(externalEventSection);
 	Event *ne = GetNewTsEvent();
-	ne->time = globalTimer + cyclesIntoFuture;
+	ne->time = GetTicks() + cyclesIntoFuture;
 	ne->type = event_type;
 	ne->next = 0;
 	ne->userdata = userdata;

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -99,7 +99,6 @@ namespace CoreTiming
 	void RemoveAllEvents(int event_type);
 	bool IsScheduled(int event_type);
 	void Advance();
-	void AdvanceQuick();
 	void MoveEvents();
 	void ProcessFifoWaitEvents();
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -279,7 +279,7 @@ int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
 {
 	DEBUG_LOG(HLE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
 	hleEatCycles(190);
-	CoreTiming::AdvanceQuick();
+	CoreTiming::Advance();
 	return gpu->UpdateStall(displayListID, stallAddress);
 }
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -199,11 +199,11 @@ bool __GeTriggerSync(WaitType waitType, int id, u64 atTicks)
 	s64 future = atTicks - CoreTiming::GetTicks();
 	if (waitType == WAITTYPE_GEDRAWSYNC)
 	{
-		s64 left = CoreTiming::UnscheduleEvent(geSyncEvent, userdata);
+		s64 left = CoreTiming::UnscheduleThreadsafeEvent(geSyncEvent, userdata);
 		if (left > future)
 			future = left;
 	}
-	CoreTiming::ScheduleEvent(future, geSyncEvent, userdata);
+	CoreTiming::ScheduleEvent_Threadsafe(future, geSyncEvent, userdata);
 	return true;
 }
 
@@ -211,7 +211,7 @@ bool __GeTriggerSync(WaitType waitType, int id, u64 atTicks)
 bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks)
 {
 	u64 userdata = (u64)listid << 32 | (u64) pc;
-	CoreTiming::ScheduleEvent(atTicks - CoreTiming::GetTicks(), geInterruptEvent, userdata);
+	CoreTiming::ScheduleEvent_Threadsafe(atTicks - CoreTiming::GetTicks(), geInterruptEvent, userdata);
 	return true;
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1169,7 +1169,7 @@ void __KernelIdle()
 	CoreTiming::Idle();
 	// Advance must happen between Idle and Reschedule, so that threads that were waiting for something
 	// that was triggered at the end of the Idle period must get a chance to be scheduled.
-	CoreTiming::AdvanceQuick();
+	CoreTiming::Advance();
 
 	// We must've exited a callback?
 	if (__KernelInCallback())
@@ -1724,7 +1724,7 @@ void __KernelReSchedule(const char *reason)
 	}
 
 	// Execute any pending events while we're doing scheduling.
-	CoreTiming::AdvanceQuick();
+	CoreTiming::Advance();
 	if (__IsInInterrupt() || __KernelInCallback() || !__KernelIsDispatchEnabled())
 	{
 		reason = "In Interrupt Or Callback";

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -31,7 +31,9 @@ namespace SaveState
 
 	void SaveSlot(int slot, Callback callback, void *cbUserData = 0);
 	void LoadSlot(int slot, Callback callback, void *cbUserData = 0);
+	// Checks whether there's an existing save in the specified slot.
 	bool HasSaveInSlot(int slot);
+	// Returns -1 if there's no newest slot.
 	int GetNewestSlot();
 
 	// Load the specified file into the current state (async.)
@@ -45,4 +47,7 @@ namespace SaveState
 	// For testing / automated tests.  Runs a save state verification pass (async.)
 	// Warning: callback will be called on a different thread.
 	void Verify(Callback callback = 0, void *cbUserData = 0);
+
+	// Check if there's any save stating needing to be done.  Normally called once per frame.
+	void Process();
 };

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -38,6 +38,7 @@
 #include "Core/Loaders.h"
 #include "Core/PSPLoaders.h"
 #include "Core/ELF/ParamSFO.h"
+#include "Core/SaveState.h"
 #include "Common/LogManager.h"
 
 MetaFileSystem pspFileSystem;
@@ -151,6 +152,7 @@ void PSP_Shutdown()
 }
 
 void PSP_RunLoopUntil(u64 globalticks) {
+	SaveState::Process();
 	mipsr4k.RunLoopUntil(globalticks);
 }
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -326,12 +326,6 @@ void GLES_GPU::CopyDisplayToOutput() {
 
 // Render queue
 
-u32 GLES_GPU::DrawSync(int mode)
-{
-	transformDraw_.Flush();
-	return GPUCommon::DrawSync(mode);
-}
-
 void GLES_GPU::FastRunLoop(DisplayList &list) {
 	for (; downcount > 0; --downcount) {
 		u32 op = Memory::ReadUnchecked_U32(list.pc);

--- a/GPU/GLES/DisplayListInterpreter.h
+++ b/GPU/GLES/DisplayListInterpreter.h
@@ -38,7 +38,6 @@ public:
 	virtual void InitClear();
 	virtual void PreExecuteOp(u32 op, u32 diff);
 	virtual void ExecuteOp(u32 op, u32 diff);
-	virtual u32  DrawSync(int mode);
 
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format);
 	virtual void CopyDisplayToOutput();

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -130,6 +130,7 @@ struct DisplayList
 	int stackptr;
 	bool interrupted;
 	u64 waitTicks;
+	bool interruptsEnabled;
 };
 
 enum GPUInvalidationType {


### PR DESCRIPTION
This time there shouldn't be any deviation in behavior.  It might hurt performance a tiny bit but afaict the difference is negligible.

Threadsafe events were kinda buggy before, especially with remove and the added unschedule.  More importantly, they weren't based on the same starting time, which I had not realized.  I don't think GetTicks() will ever return garbage, so I just called it like always.

Because savestates need to be run _outside_ a syscall, and the above makes threadsafe events run inside them (so there's no change in behavior), this just handles savestates more specially.  They've already got a good chunk of code throughout dedicated to them, so they might as well be special.

Fixes the differences I could reproduce, but makes savestate actions slightly more delayed.  Does open the door better for "rewind" (frame based) if that can be practical.

-[Unknown]
