### PR TITLE
Fix black/missing textures in few games

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -211,7 +211,7 @@ inline void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, V
 			if (framebuffer->format != entry->format) {
 				WARN_LOG_REPORT_ONCE(diffFormat2, HLE, "Render to texture with different formats %d != %d at %08x", entry->format, framebuffer->format, address);
 				// TODO: Use an FBO to translate the palette?
-				AttachFramebufferInvalid(entry, framebuffer);
+				AttachFramebufferValid(entry, framebuffer);
 			} else if ((entry->addr - address) / entry->bufw < framebuffer->height) {
 				WARN_LOG_REPORT_ONCE(subarea, HLE, "Render to area containing texture at %08x", address);
 				// TODO: Keep track of the y offset.


### PR DESCRIPTION
I do hesitate to pull out this request as not too sure @unknownbrackets would be okay with this minor change ....

I've retested many time on this and fixes the following .
1. The black box shadowing in FF Type-0
2. Missing scenes and textures in Kurohyou 2
3. Missing scenes and textures in Evangelion Jo
4. Better than all black in DBZ Tag VS
