### PR TITLE
Fix sceJpegGetOutputInfo

### DIFF
--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -108,7 +108,7 @@ int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dht
 	if (!Memory::IsValidAddress(jpegAddr))
 	{
 		ERROR_LOG(HLE, "sceJpegGetOutputInfo: Bad JPEG address 0x%08x", jpegAddr);
-		return 0xC000;
+		return getYCbCrBufferSize(0, 0);
 	}
 	else // Memory address is good
 	{
@@ -125,7 +125,7 @@ int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dht
 		if (jpegBuf == NULL)
 		{
 			ERROR_LOG(HLE, "sceJpegGetOutputInfo: Bad JPEG data");
-			return 0xC000;
+			return getYCbCrBufferSize(0, 0);
 		}
 	}
 


### PR DESCRIPTION
Return better responses for errors (should allow weird God Eater Burst saves from real PSPs to not bounce back to the titlescreen). Not sure why some God Eater Burst saves would send bad jpeg data.
The data sent through sceJpeg is supposed to be a normal jpeg (ie it should be perfectly viewable in photoshop or whatever image viewer/editor).
The reason (some) God Eater Burst save files don't send a good, decodable jpeg should still be researched but in the meantime let's not push users getting that error back to the titlescreen.
Returning getYCbCrBufferSize(0, 0) on error seems like it would be more correct as well (or, at least God Eater Burst recognises that as an error unlike 0xC000...I didn't think that error code was right but no saves gave me bad jpeg data before so I couldn't test it).
