### PR TITLE
Try fixing sceJpegGetOutputInfo again

### DIFF
--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -95,14 +95,6 @@ int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dht
 {
 	ERROR_LOG_REPORT(HLE, "sceJpegGetOutputInfo(%i, %i, %i, %i)", jpegAddr, jpegSize, colourInfoAddr, dhtMode);
 
-	// Buffer to store info about the color space in use.
-	// - Bits 24 to 32 (Always empty): 0x00
-	// - Bits 16 to 24 (Color mode): 0x00 (Unknown), 0x01 (Greyscale) or 0x02 (YCbCr) 
-	// - Bits 8 to 16 (Vertical chroma subsampling value): 0x00, 0x01 or 0x02
-	// - Bits 0 to 8 (Horizontal chroma subsampling value): 0x00, 0x01 or 0x02
-	if (Memory::IsValidAddress(colourInfoAddr))
-		Memory::Write_U32(0x00020202, colourInfoAddr);
-
 	int w = 0, h = 0, actual_components = 0;
 
 	if (!Memory::IsValidAddress(jpegAddr))
@@ -128,6 +120,14 @@ int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dht
 			return getYCbCrBufferSize(0, 0);
 		}
 	}
+
+	// Buffer to store info about the color space in use.
+	// - Bits 24 to 32 (Always empty): 0x00
+	// - Bits 16 to 24 (Color mode): 0x00 (Unknown), 0x01 (Greyscale) or 0x02 (YCbCr) 
+	// - Bits 8 to 16 (Vertical chroma subsampling value): 0x00, 0x01 or 0x02
+	// - Bits 0 to 8 (Horizontal chroma subsampling value): 0x00, 0x01 or 0x02
+	if (Memory::IsValidAddress(colourInfoAddr))
+		Memory::Write_U32(0x00020202, colourInfoAddr);
 
 #ifdef JPEG_DEBUG
 		char jpeg_fname[256];


### PR DESCRIPTION
I guess the colour info address isn't supposed to be updated if the jpeg errors out, or I think so based on reports from the God Eater Burst thread in the forums. This shouldn't affect working jpegs since the address is still being updated before returning, just not if it errors out. If this doesn't work for the save from the forums, the save would have never worked in PPSSPP builds up to today (it basically makes the function _only_ return null without updating the colour address if it errors out, making it the equivalent of the only implementation other than mine, which was a stub). The previous commit I made worked in the Japanese version, but still bounced back in the US version (wtf?).
