### PR TITLE
Avoid confusion with Atrac3+ plugin download button.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -32,6 +32,7 @@
 #include "base/colorutil.h"
 #include "base/timeutil.h"
 #include "math/curves.h"
+#include "Core/HW/atrac3plus.h"
 
 #ifdef _WIN32
 namespace MainWindow {
@@ -251,7 +252,11 @@ void GameSettingsScreen::CreateViews() {
 	ViewGroup *audioSettings = new LinearLayout(ORIENT_VERTICAL);
 	audioSettingsScroll->Add(audioSettings);
 	tabHolder->AddTab("Audio", audioSettingsScroll);
-	audioSettings->Add(new Choice(a->T("Download Atrac3+ plugin")))->OnClick.Handle(this, &GameSettingsScreen::OnDownloadPlugin);
+
+	std::string atracString;
+	atracString.assign(Atrac3plus_Decoder::IsInstalled() ? "Redownload Atrac3+ plugin" : "Download Atrac3+ plugin");
+	audioSettings->Add(new Choice(a->T(atracString.c_str())))->OnClick.Handle(this, &GameSettingsScreen::OnDownloadPlugin);
+
 	audioSettings->Add(new CheckBox(&g_Config.bEnableSound, a->T("Enable Sound")));
 	audioSettings->Add(new CheckBox(&g_Config.bEnableAtrac3plus, a->T("Enable Atrac3+")));
 	audioSettings->Add(new PopupSliderChoice(&g_Config.iSEVolume, 0, 8, a->T("FX volume"), screenManager()));

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -865,7 +865,9 @@ void AudioScreen::render() {
 
 		// Show the download button even if not installed - might want to upgrade.
 		VLinear vlinear(30, 400, 20);
-		if (UIButton(GEN_ID, vlinear, 400, 0, a->T("Download Atrac3+ plugin"), ALIGN_LEFT)) {
+		std::string atracString;
+		atracString.assign(Atrac3plus_Decoder::IsInstalled() ? "Redownload Atrac3+ plugin" : "Download Atrac3+ plugin");
+		if (UIButton(GEN_ID, vlinear, 400, 0, a->T(atracString.c_str()), ALIGN_LEFT)) {
 			screenManager()->push(new PluginScreen());
 		}
 


### PR DESCRIPTION
It's fine to always show the button, but maybe we should clarify to the user if they have it or not, to avoid confusion. I know the download screen will inform them they have it as well, but it's best to cover all bases..
