### PR TITLE
Sanity checks for shadow glyphs

### DIFF
--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -219,13 +219,13 @@ void PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 	}
 
 	// And shadow glyphs.
-	for (size_t i = 0; i < shadowGlyphs.size(); i++) {
+	for (size_t i = 0; i < glyphs.size(); i++) {
 		size_t shadowId = glyphs[i].shadowID;
 		if ((shadowId < shadowMap.size()) && (shadowId < shadowGlyphs.size())) {
 			size_t charId = shadowMap[shadowId];
 			if (charId < glyphs.size()) {
 				// TODO: check for pre existing shadow glyph
-				GetGlyph(fontData, charPointers[charId] * 4 * 8  /* ??? */, FONT_PGF_SHADOWGLYPH, shadowGlyphs[i]);
+				GetGlyph(fontData, charPointers[charId] * 4 * 8  /* ??? */, FONT_PGF_SHADOWGLYPH, shadowGlyphs[shadowId]);
 			}
 		}
 	}

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -221,9 +221,9 @@ void PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 	// And shadow glyphs.
 	for (size_t i = 0; i < shadowGlyphs.size(); i++) {
 		size_t shadowId = glyphs[i].shadowID;
-		if ((shadowId >= 0) && (shadowId < shadowMap.size()) && (shadowId < shadowGlyphs.size())) {
+		if ((shadowId < shadowMap.size()) && (shadowId < shadowGlyphs.size())) {
 			size_t charId = shadowMap[shadowId];
-			if ((charId >= 0) && (charId < glyphs.size())) {
+			if (charId < glyphs.size()) {
 				// TODO: check for pre existing shadow glyph
 				GetGlyph(fontData, charPointers[charId] * 4 * 8  /* ??? */, FONT_PGF_SHADOWGLYPH, shadowGlyphs[i]);
 			}

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -221,9 +221,9 @@ void PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 	// And shadow glyphs.
 	for (size_t i = 0; i < shadowGlyphs.size(); i++) {
 		size_t shadowId = glyphs[i].shadowID;
-		if (shadowId < shadowMap.size()) {
+		if ((shadowId >= 0) && (shadowId < shadowMap.size()) && (shadowId < shadowGlyphs.size())) {
 			size_t charId = shadowMap[shadowId];
-			if (charId < glyphs.size()) {
+			if ((charId >= 0) && (charId < glyphs.size())) {
 				// TODO: check for pre existing shadow glyph
 				GetGlyph(fontData, charPointers[charId] * 4 * 8  /* ??? */, FONT_PGF_SHADOWGLYPH, shadowGlyphs[i]);
 			}


### PR DESCRIPTION
Partially fixes text, huds and videos in Jeanne d'Arc.
These changes shouldn't negatively impact other games since all it does is makes sure shadow glyphs are within the vector sizes.
The text, huds and videos still don't fully display, but that's because of something else.
