### PR TITLE
Small refactoring in event queue logic, ignore multithreaded setting change

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -75,7 +75,7 @@ volatile bool coreStatePending = false;
 static volatile CPUThreadState cpuThreadState = CPU_THREAD_NOT_RUNNING;
 
 bool IsOnSeparateCPUThread() {
-	if (g_Config.bSeparateCPUThread) {
+	if (cpuThread != NULL) {
 		return cpuThread->get_id() == std::this_thread::get_id();
 	} else {
 		return false;
@@ -270,7 +270,7 @@ bool PSP_IsInited() {
 void PSP_Shutdown() {
 	if (coreState == CORE_RUNNING)
 		coreState = CORE_ERROR;
-	if (g_Config.bSeparateCPUThread) {
+	if (cpuThread != NULL) {
 		CPU_SetState(CPU_THREAD_SHUTDOWN);
 		CPU_WaitStatus(&CPU_IsShutdown);
 		delete cpuThread;
@@ -284,7 +284,7 @@ void PSP_Shutdown() {
 void PSP_RunLoopUntil(u64 globalticks) {
 	SaveState::Process();
 
-	if (g_Config.bSeparateCPUThread) {
+	if (cpuThread != NULL) {
 		cpuThreadUntil = globalticks;
 		if (CPU_NextState(CPU_THREAD_RUNNING, CPU_THREAD_EXECUTE)) {
 			// The CPU doesn't actually respect cpuThreadUntil well, especially when skipping frames.

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -373,7 +373,7 @@ void GLES_GPU::ProcessEvent(GPUEvent ev) {
 		break;
 
 	default:
-		ERROR_LOG(G3D, "Unexpected GPU event type: %d", ev);
+		GPUCommon::ProcessEvent(ev);
 	}
 }
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -2,16 +2,109 @@
 
 #include "native/base/mutex.h"
 #include "GPU/GPUInterface.h"
+#include "Core/CoreTiming.h"
 #include <deque>
 
-class GPUCommon : public GPUInterface
+template <typename B, typename Event, typename EventType, EventType EVENT_INVALID, EventType EVENT_SYNC, EventType EVENT_FINISH>
+struct ThreadEventQueue : public B {
+	void SetThreadEnabled(bool threadEnabled) {
+		threadEnabled_ = threadEnabled;
+	}
+
+	void ScheduleEvent(Event ev) {
+		{
+			lock_guard guard(eventsLock_);
+			events_.push_back(ev);
+			eventsWait_.notify_one();
+		}
+
+		if (!threadEnabled_) {
+			RunEventsUntil(0);
+		}
+	}
+
+	bool HasEvents() {
+		lock_guard guard(eventsLock_);
+		return !events_.empty();
+	}
+
+	Event GetNextEvent() {
+		lock_guard guard(eventsLock_);
+		if (events_.empty()) {
+			eventsDrain_.notify_one();
+			return EVENT_INVALID;
+		}
+
+		Event ev = events_.front();
+		events_.pop_front();
+		return ev;
+	}
+
+	void RunEventsUntil(u64 globalticks) {
+		do {
+			for (Event ev = GetNextEvent(); EventType(ev) != EVENT_INVALID; ev = GetNextEvent()) {
+				switch (EventType(ev)) {
+				case EVENT_FINISH:
+					// Stop waiting.
+					globalticks = 0;
+					break;
+
+				case EVENT_SYNC:
+					break;
+
+				default:
+					ProcessEvent(ev);
+				}
+			}
+
+			// Quit the loop if the queue is drained and coreState has tripped, or threading is disabled.
+			if (coreState != CORE_RUNNING || !threadEnabled_) {
+				return;
+			}
+
+			// coreState changes won't wake us, so recheck periodically.
+			eventsWait_.wait_for(eventsWaitLock_, 1);
+		} while (CoreTiming::GetTicks() < globalticks);
+	}
+
+	void SyncThread() {
+		if (!threadEnabled_) {
+			return;
+		}
+
+		// While processing the last event, HasEvents() will be false even while not done.
+		// So we schedule a nothing event and wait for that to finish.
+		ScheduleEvent(EVENT_SYNC);
+		while (HasEvents() && coreState == CORE_RUNNING) {
+			eventsDrain_.wait_for(eventsDrainLock_, 1);
+		}
+	}
+
+	void FinishEventLoop() {
+		if (threadEnabled_) {
+			ScheduleEvent(EVENT_FINISH);
+		}
+	}
+
+protected:
+	virtual void ProcessEvent(Event ev) = 0;
+
+private:
+	bool threadEnabled_;
+	std::deque<Event> events_;
+	recursive_mutex eventsLock_;
+	recursive_mutex eventsWaitLock_;
+	recursive_mutex eventsDrainLock_;
+	condition_variable eventsWait_;
+	condition_variable eventsDrain_;
+};
+typedef ThreadEventQueue<GPUInterface, GPUEvent, GPUEventType, GPU_EVENT_INVALID, GPU_EVENT_SYNC_THREAD, GPU_EVENT_FINISH_EVENT_LOOP> GPUThreadEventQueue;
+
+class GPUCommon : public GPUThreadEventQueue
 {
 public:
 	GPUCommon();
 	virtual ~GPUCommon() {}
-
-	virtual void RunEventsUntil(u64 globalticks);
-	virtual void FinishEventLoop();
 
 	virtual void InterruptStart(int listid);
 	virtual void InterruptEnd(int listid);
@@ -34,7 +127,6 @@ public:
 	virtual u32  Continue();
 	virtual u32  Break(int mode);
 	virtual void ReapplyGfxState();
-	virtual void SyncThread();
 
 protected:
 	// To avoid virtual calls to PreExecuteOp().
@@ -45,12 +137,9 @@ protected:
 	void PopDLQueue();
 	void CheckDrawSync();
 	int  GetNextListIndex();
-	GPUEvent GetNextEvent();
-	bool HasEvents();
-	void ScheduleEvent(GPUEvent ev);
 	void ProcessDLQueueInternal();
 	void ReapplyGfxStateInternal();
-	virtual void ProcessEvent(GPUEvent ev) = 0;
+	virtual void ProcessEvent(GPUEvent ev);
 
 	// Allows early unlocking with a guard.  Do not double unlock.
 	class easy_guard {

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -163,6 +163,10 @@ struct GPUEvent {
 			GPUInvalidationType type;
 		} invalidate_cache;
 	};
+
+	operator GPUEventType() const {
+		return type;
+	}
 };
 
 class GPUInterface

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -49,5 +49,4 @@ public:
 
 protected:
 	virtual void FastRunLoop(DisplayList &list);
-	virtual void ProcessEvent(GPUEvent ev) {}
 };


### PR DESCRIPTION
This refactors out the event queue logic into a separate class (plan to move it to a separate file.)  I'm wanting to merge it already only because it changes the interface for consumers slightly (ProcessEvent) in case the in-progress DirectX or software backends are rebased.

Also, ignores changes to `g_Config.bSeparateCPUThread` after startup, so it won't cause trouble.

-[Unknown]
