### PR TITLE
Sync the GPU thread on list/draw sync

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -48,6 +48,9 @@ void GPUCommon::PopDLQueue() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	// Sync first, because the CPU is usually faster than the emulated GPU.
+	SyncThread();
+
 	easy_guard guard(listLock);
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
@@ -92,6 +95,9 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
+	// Sync first, because the CPU is usually faster than the emulated GPU.
+	SyncThread();
+
 	easy_guard guard(listLock);
 	if (listid < 0 || listid >= DisplayListMaxCount)
 		return SCE_KERNEL_ERROR_INVALID_ID;


### PR DESCRIPTION
Otherwise, the CPU gets ahead (inside the frame) and games get confused.  I don't think there's any good workaround to avoid this, at least I can't think of one.

Fixes the FPS drops in most games (since they ended up waiting until the end of the frame and thought they were behind.)  Hurts performance too, of course, but it's still better than with the thread disabled.

-[Unknown]
