### PR TITLE
Fix some more GPU thread sync issues

### DIFF
--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include "../../Globals.h"
+#include "Globals.h"
+#include "native/base/mutex.h"
 #include <vector>
 #include <set>
 #include <map>
@@ -106,6 +107,7 @@ private:
 	std::set<MapEntryUniqueInfo> uniqueEntries;
 	std::vector<MapEntry> entries;
 	std::map<u32, u32> entryRanges;
+	mutable recursive_mutex lock_;
 };
 
 extern SymbolMap symbolMap;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -215,6 +215,16 @@ bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks)
 	return true;
 }
 
+void __GeWaitCurrentThread(WaitType type, SceUID waitId, const char *reason)
+{
+	__KernelWaitCurThread(type, waitId, 0, 0, false, reason);
+}
+
+void __GeTriggerWait(WaitType type, SceUID waitId, const char *reason, bool noSwitch)
+{
+	__KernelTriggerWait(type, waitId, 0, reason, noSwitch);
+}
+
 bool __GeHasPendingInterrupt()
 {
 	return !ge_pending_cb.empty();

--- a/Core/HLE/sceGe.h
+++ b/Core/HLE/sceGe.h
@@ -43,6 +43,8 @@ void __GeDoState(PointerWrap &p);
 void __GeShutdown();
 bool __GeTriggerSync(WaitType waitType, int id, u64 atTicks);
 bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks);
+void __GeWaitCurrentThread(WaitType type, SceUID waitId, const char *reason);
+void __GeTriggerWait(WaitType type, SceUID waitId, const char *reason, bool noSwitch = false);
 bool __GeHasPendingInterrupt();
 
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -112,7 +112,7 @@ bool CPU_HasPendingAction() {
 void CPU_WaitStatus(bool (*pred)()) {
 	cpuThreadLock.lock();
 	while (!pred())
-		cpuThreadCond.wait(cpuThreadLock);
+		cpuThreadCond.wait_for(cpuThreadLock, 16);
 	cpuThreadLock.unlock();
 }
 

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -304,6 +304,9 @@ void GLES_GPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat fo
 }
 
 bool GLES_GPU::FramebufferDirty() {
+	// Allow it to process fully before deciding if it's dirty.
+	SyncThread();
+
 	VirtualFramebuffer *vfb = framebufferManager_.GetDisplayFBO();
 	if (vfb)
 		return vfb->dirtyAfterDisplay;

--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -304,6 +304,8 @@ void GLES_GPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat fo
 }
 
 bool GLES_GPU::FramebufferDirty() {
+	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
+	ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
 	// Allow it to process fully before deciding if it's dirty.
 	SyncThread();
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -130,7 +130,6 @@ int GPUCommon::ListSync(int listid, int mode) {
 	}
 
 	if (dl.waitTicks > CoreTiming::GetTicks()) {
-		guard.unlock();
 		__KernelWaitCurThread(WAITTYPE_GELISTSYNC, listid, 0, 0, false, "GeListSync");
 	}
 	return PSP_GE_LIST_COMPLETED;
@@ -244,7 +243,6 @@ u32 GPUCommon::DequeueList(int listid) {
 		dlQueue.remove(listid);
 
 	dls[listid].waitTicks = 0;
-	guard.unlock();
 	__KernelTriggerWait(WAITTYPE_GELISTSYNC, listid, 0, "GeListSync");
 
 	CheckDrawSync();
@@ -599,7 +597,6 @@ void GPUCommon::ProcessDLQueueInternal() {
 
 	easy_guard guard(listLock);
 	currentList = NULL;
-	guard.unlock();
 
 	drawCompleteTicks = startingTicks + cyclesExecuted;
 	busyTicks = std::max(busyTicks, drawCompleteTicks);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -46,6 +46,8 @@ void GPUCommon::PopDLQueue() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
+	ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
 	// Sync first, because the CPU is usually faster than the emulated GPU.
 	SyncThread();
 
@@ -93,6 +95,8 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
+	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
+	ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
 	// Sync first, because the CPU is usually faster than the emulated GPU.
 	SyncThread();
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -28,7 +28,10 @@ public:
 	virtual int  ListSync(int listid, int mode);
 	virtual u32  DrawSync(int mode);
 	virtual void DoState(PointerWrap &p);
-	virtual bool FramebufferDirty() { return true; }
+	virtual bool FramebufferDirty() {
+		SyncThread();
+		return true;
+	}
 	virtual u32  Continue();
 	virtual u32  Break(int mode);
 	virtual void ReapplyGfxState();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -65,13 +65,6 @@ protected:
 	DisplayListQueue dlQueue;
 	recursive_mutex listLock;
 
-	std::deque<GPUEvent> events;
-	recursive_mutex eventsLock;
-	recursive_mutex eventsWaitLock;
-	recursive_mutex eventsDrainLock;
-	condition_variable eventsWait;
-	condition_variable eventsDrain;
-
 	bool interruptRunning;
 	GPUState gpuState;
 	bool isbreak;


### PR DESCRIPTION
Mostly I was trying to hunt for a very random and hard to repro hang I'm getting in Tales of Phantasia X.  I'm not sure if I got it...

Anyway, this fixes a problem with the dirty FB check skipping way too many frames, since it didn't give the GE time to finish.  Should not hurt performance, and fixes at least God Eater Burst.

Could maybe fix Virtua Tennis too.

-[Unknown]
