### PR TITLE
Use a separate thread for reading/writing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -898,6 +898,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/scePauth.h
 	Core/HW/atrac3plus.cpp
 	Core/HW/atrac3plus.h
+	Core/HW/AsyncIOManager.cpp
+	Core/HW/AsyncIOManager.h
 	Core/HW/MediaEngine.cpp
 	Core/HW/MediaEngine.h
 	Core/HW/MpegDemux.cpp

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SRCS
   HLE/sceParseHttp.cpp
   HLE/sceVaudio.cpp
   HLE/sceAudiocodec.cpp
+  HW/AsyncIOManager.cpp
   HW/MemoryStick.cpp
   HW/MediaEngine.cpp
   HW/SasAudio.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -90,6 +90,7 @@ void Config::Load(const char *iniFileName)
 	cpu->Get("Jit", &bJit, true);
 #endif
 	cpu->Get("SeparateCPUThread", &bSeparateCPUThread, false);
+	cpu->Get("SeparateIOThread", &bSeparateIOThread, true);
 	cpu->Get("FastMemory", &bFastMemory, false);
 	cpu->Get("CPUSpeed", &iLockedCPUSpeed, false);
 
@@ -228,6 +229,7 @@ void Config::Save()
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 		cpu->Set("Jit", bJit);
 		cpu->Set("SeparateCPUThread", bSeparateCPUThread);
+		cpu->Set("SeparateIOThread", bSeparateIOThread);
 		cpu->Set("FastMemory", bFastMemory);
 		cpu->Set("CPUSpeed", iLockedCPUSpeed);
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -58,6 +58,7 @@ public:
 	bool bJit;
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;
+	bool bSeparateIOThread;
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;
 	std::string sReportHost;

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -251,6 +251,7 @@
     <ClCompile Include="HW\MpegDemux.cpp" />
     <ClCompile Include="HW\OMAConvert.cpp" />
     <ClCompile Include="HW\SasAudio.cpp" />
+    <ClCompile Include="HW\AsyncIOManager.cpp" />
     <ClCompile Include="Loaders.cpp" />
     <ClCompile Include="MemMap.cpp" />
     <ClCompile Include="MemmapFunctions.cpp" />
@@ -437,6 +438,7 @@
     <ClInclude Include="HW\OMAConvert.h" />
     <ClInclude Include="HW\SasAudio.h" />
     <ClInclude Include="HW\MemoryStick.h" />
+    <ClInclude Include="HW\AsyncIOManager.h" />
     <ClInclude Include="Loaders.h" />
     <ClInclude Include="MemMap.h" />
     <ClInclude Include="MIPS\ARM\ArmAsm.h">

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -451,6 +451,9 @@
     <ClCompile Include="FileSystems\VirtualDiscFileSystem.cpp">
       <Filter>FileSystems</Filter>
     </ClCompile>
+    <ClCompile Include="HW\AsyncIOManager.cpp">
+      <Filter>HW</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -839,6 +842,9 @@
     </ClInclude>
     <ClInclude Include="ThreadEventQueue.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\AsyncIOManager.h">
+      <Filter>HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -17,6 +17,7 @@
 
 #include <cstdlib>
 #include "native/thread/thread.h"
+#include "native/thread/threadutil.h"
 #include "Core/Config.h"
 #include "Core/System.h"
 #include "Core/Host.h"
@@ -334,6 +335,7 @@ static DirectoryFileSystem *flash0System = NULL;
 #endif
 
 void __IoManagerThread() {
+	setCurrentThreadName("IOThread");
 	while (ioManagerThreadEnabled) {
 		ioManager.RunEventsUntil(CoreTiming::GetTicks() + msToCycles(1000));
 	}

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -19,9 +19,9 @@
 
 #include <string>
 
-#include "../System.h"
-#include "HLE.h"
-#include "sceKernel.h"
+#include "Core/System.h"
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/sceKernel.h"
 
 void __IoInit();
 void __IoDoState(PointerWrap &p);

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/Reporting.h"
+#include "Core/System.h"
+#include "Core/HW/AsyncIOManager.h"
+#include "Core/FileSystems/MetaFileSystem.h"
+
+void AsyncIOManager::ScheduleOperation(AsyncIOEvent ev) {
+	lock_guard guard(resultsLock_);
+	resultsPending_.insert(ev.handle);
+	ScheduleEvent(ev);
+}
+
+bool AsyncIOManager::PopResult(u32 handle, AsyncIOResult &result) {
+	lock_guard guard(resultsLock_);
+	if (results_.find(handle) != results_.end()) {
+		result = results_[handle];
+		results_.erase(handle);
+		resultsPending_.erase(handle);
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool AsyncIOManager::WaitResult(u32 handle, AsyncIOResult &result) {
+	lock_guard guard(resultsLock_);
+	ScheduleEvent(IO_EVENT_SYNC);
+	while (HasEvents() && resultsPending_.find(handle) != resultsPending_.end()) {
+		if (PopResult(handle, result)) {
+			return true;
+		}
+		resultsWait_.wait_for(resultsLock_, 16);
+	}
+	if (PopResult(handle, result)) {
+		return true;
+	}
+
+	return false;
+}
+
+void AsyncIOManager::ProcessEvent(AsyncIOEvent ev) {
+	switch (ev.type) {
+	case IO_EVENT_READ:
+		Read(ev.handle, ev.buf, ev.bytes);
+		break;
+
+	case IO_EVENT_WRITE:
+		Write(ev.handle, ev.buf, ev.bytes);
+		break;
+
+	default:
+		ERROR_LOG(HLE, "Unsupported IO event type");
+	}
+}
+
+void AsyncIOManager::Read(u32 handle, u8 *buf, size_t bytes) {
+	size_t result = pspFileSystem.ReadFile(handle, buf, bytes);
+	EventResult(handle, result);
+}
+
+void AsyncIOManager::Write(u32 handle, u8 *buf, size_t bytes) {
+	size_t result = pspFileSystem.WriteFile(handle, buf, bytes);
+	EventResult(handle, result);
+}
+
+void AsyncIOManager::EventResult(u32 handle, AsyncIOResult result) {
+	lock_guard guard(resultsLock_);
+	if (results_.find(handle) != results_.end()) {
+		ERROR_LOG_REPORT(HLE, "Overwriting previous result for file action on handle %d", handle);
+	}
+	results_[handle] = result;
+	resultsWait_.notify_one();
+}
+
+void AsyncIOManager::DoState(PointerWrap &p) {
+	SyncThread();
+	lock_guard guard(resultsLock_);
+	p.Do(resultsPending_);
+	p.Do(results_);
+	p.DoMarker("AsyncIOManager");
+}

--- a/Core/HW/AsyncIOManager.h
+++ b/Core/HW/AsyncIOManager.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include <map>
+#include <set>
+#include "native/base/mutex.h"
+#include "Core/ThreadEventQueue.h"
+
+class NoBase {
+};
+
+enum AsyncIOEventType {
+	IO_EVENT_INVALID,
+	IO_EVENT_SYNC,
+	IO_EVENT_FINISH,
+	IO_EVENT_READ,
+	IO_EVENT_WRITE,
+};
+
+struct AsyncIOEvent {
+	AsyncIOEvent(AsyncIOEventType t) : type(t) {}
+	AsyncIOEventType type;
+	u32 handle;
+	u8 *buf;
+	size_t bytes;
+
+	operator AsyncIOEventType() const {
+		return type;
+	}
+};
+
+// TODO: Something better.
+typedef size_t AsyncIOResult;
+
+typedef ThreadEventQueue<NoBase, AsyncIOEvent, AsyncIOEventType, IO_EVENT_INVALID, IO_EVENT_SYNC, IO_EVENT_FINISH> IOThreadEventQueue;
+class AsyncIOManager : public IOThreadEventQueue {
+public:
+	void DoState(PointerWrap &p);
+
+	void ScheduleOperation(AsyncIOEvent ev);
+
+	bool PopResult(u32 handle, AsyncIOResult &result);
+	bool WaitResult(u32 handle, AsyncIOResult &result);
+
+protected:
+	virtual void ProcessEvent(AsyncIOEvent ref);
+	virtual bool ShouldExitEventLoop() {
+		return coreState == CORE_ERROR || coreState == CORE_POWERDOWN;
+	}
+
+private:
+	void Read(u32 handle, u8 *buf, size_t bytes);
+	void Write(u32 handle, u8 *buf, size_t bytes);
+
+	void EventResult(u32 handle, AsyncIOResult result);
+
+	recursive_mutex resultsLock_;
+	condition_variable resultsWait_;
+	std::set<u32> resultsPending_;
+	std::map<u32, AsyncIOResult> results_;
+};

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include "native/thread/thread.h"
+#include "native/thread/threadutil.h"
 #include "native/base/mutex.h"
 
 #include "Core/MemMap.h"
@@ -42,7 +43,6 @@
 #include "Core/PSPLoaders.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Core/SaveState.h"
-#include "Common/Thread.h"
 #include "Common/LogManager.h"
 
 #include "GPU/GPUState.h"
@@ -196,7 +196,7 @@ void CPU_Shutdown() {
 }
 
 void CPU_RunLoop() {
-	Common::SetCurrentThreadName("CPUThread");
+	setCurrentThreadName("CPUThread");
 	if (!CPU_NextState(CPU_THREAD_PENDING, CPU_THREAD_STARTING)) {
 		ERROR_LOG(CPU, "CPU thread in unexpected state: %d", cpuThreadState);
 		return;

--- a/Core/ThreadEventQueue.h
+++ b/Core/ThreadEventQueue.h
@@ -74,7 +74,7 @@ struct ThreadEventQueue : public B {
 			}
 
 			// Quit the loop if the queue is drained and coreState has tripped, or threading is disabled.
-			if (coreState != CORE_RUNNING || !threadEnabled_) {
+			if (ShouldExitEventLoop() || !threadEnabled_) {
 				return;
 			}
 
@@ -104,6 +104,7 @@ struct ThreadEventQueue : public B {
 
 protected:
 	virtual void ProcessEvent(Event ev) = 0;
+	virtual bool ShouldExitEventLoop() = 0;
 
 private:
 	bool threadEnabled_;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -48,6 +48,9 @@ protected:
 	void ProcessDLQueueInternal();
 	void ReapplyGfxStateInternal();
 	virtual void ProcessEvent(GPUEvent ev);
+	virtual bool ShouldExitEventLoop() {
+		return coreState != CORE_RUNNING;
+	}
 
 	// Allows early unlocking with a guard.  Do not double unlock.
 	class easy_guard {

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -186,6 +186,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/Core/ELF/PrxDecrypter.cpp \
   $(SRC)/Core/ELF/ParamSFO.cpp \
   $(SRC)/Core/HW/atrac3plus.cpp \
+  $(SRC)/Core/HW/AsyncIOManager.cpp \
   $(SRC)/Core/HW/MemoryStick.cpp \
   $(SRC)/Core/HW/MpegDemux.cpp.arm \
   $(SRC)/Core/HW/OMAConvert.cpp.arm \


### PR DESCRIPTION
This is enabled by default currently, since it should be pretty safe.

When HLE read/write functions are called, they're now read on a thread while the CPU/GPU continue doing their thing.  Primarily goal here is to reduce stutter a bit during larger disk reads especially (since they were previously synchronous.)

The IO is not actually overlapped/async (which it's possible the PSP does support.)  It uses the same blocking functions and a queue, but runs in parallel to the CPU.

Timing showed that this was also a net performance win, although a very small one (but that means the overhead of waiting and checking the thread was made up for.)

Unlike the GPU change, this change is entirely driven by the CPU.  The only observable difference is that now, after calling `sceIoReadAsync()`, the buffer will not already be filled (which is how it works on an actual PSP.)

Of course, there's more that can be done.  IO seems to happen on the PSP using actual thread scheduling and priorities, which are still ignored.

-[Unknown]
