### PR TITLE
Use a timer to keep gpu/cpu in sync periodically

### DIFF
--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -36,6 +36,11 @@ public:
 	virtual u32  Break(int mode);
 	virtual void ReapplyGfxState();
 
+	virtual u64 GetTickEstimate() {
+		lock_guard guard(curTickEstLock_);
+		return curTickEst_;
+	}
+
 protected:
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;
@@ -85,6 +90,15 @@ protected:
 	bool dumpNextFrame_;
 	bool dumpThisFrame_;
 	bool interruptsEnabled_;
+
+	// For CPU/GPU sync.
+	volatile u64 curTickEst_;
+	recursive_mutex curTickEstLock_;
+
+	virtual void UpdateTickEstimate(u64 value) {
+		lock_guard guard(curTickEstLock_);
+		curTickEst_ = value;
+	}
 
 public:
 	virtual DisplayList* getList(int listid)

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -224,6 +224,7 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void ReapplyGfxState() = 0;
 	virtual void SyncThread() = 0;
+	virtual u64  GetTickEstimate() = 0;
 	virtual void DoState(PointerWrap &p) = 0;
 
 	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.


### PR DESCRIPTION
This implements my idea from before.  I had to do a number of adjustments to it, but the Diva Extend demo, at least, sticks near 30 fps now, and God Eater Burst, for example, didn't really lose any performance.

I'm sure it could use more fine tuning potentially.

-[Unknown]
