### PR TITLE
Improve separate CPU thread performance, fix condition variable misuse

### DIFF
--- a/Core/ThreadEventQueue.h
+++ b/Core/ThreadEventQueue.h
@@ -58,6 +58,7 @@ struct ThreadEventQueue : public B {
 	}
 
 	void RunEventsUntil(u64 globalticks) {
+		lock_guard guard(eventsWaitLock_);
 		do {
 			for (Event ev = GetNextEvent(); EventType(ev) != EVENT_INVALID; ev = GetNextEvent()) {
 				switch (EventType(ev)) {
@@ -89,6 +90,7 @@ struct ThreadEventQueue : public B {
 			return;
 		}
 
+		lock_guard guard(eventsDrainLock_);
 		// While processing the last event, HasEvents() will be false even while not done.
 		// So we schedule a nothing event and wait for that to finish.
 		ScheduleEvent(EVENT_SYNC);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -37,7 +37,9 @@ public:
 	virtual void ReapplyGfxState();
 
 	virtual u64 GetTickEstimate() {
+#ifndef _M_X64
 		lock_guard guard(curTickEstLock_);
+#endif
 		return curTickEst_;
 	}
 
@@ -96,7 +98,9 @@ protected:
 	recursive_mutex curTickEstLock_;
 
 	virtual void UpdateTickEstimate(u64 value) {
+#ifndef _M_X64
 		lock_guard guard(curTickEstLock_);
+#endif
 		curTickEst_ = value;
 	}
 


### PR DESCRIPTION
I had thought I'd committed this, but I guess I didn't.  On x64, treating the values as atomic should be safe enough, and is much faster of course.

Also fixes not locking around a cond var wait.  Oops.

-[Unknown]
