### PR TITLE
Use atomic operations on a few more platforms

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -90,7 +90,7 @@ void Config::Load(const char *iniFileName)
 	cpu->Get("Jit", &bJit, true);
 #endif
 	cpu->Get("SeparateCPUThread", &bSeparateCPUThread, false);
-	cpu->Get("SeparateIOThread", &bSeparateIOThread, true);
+	cpu->Get("SeparateIOThread", &bSeparateIOThread, false);
 	cpu->Get("FastMemory", &bFastMemory, false);
 	cpu->Get("CPUSpeed", &iLockedCPUSpeed, false);
 

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -74,7 +74,7 @@ volatile u32 hasTsEvents = false;
 // as we can already reach that structure through a register.
 int slicelength;
 
-s64 globalTimer;
+MEMORY_ALIGNED16(s64) globalTimer;
 s64 idledCycles;
 
 static std::recursive_mutex externalEventSection;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -141,7 +141,7 @@ namespace MIPSAnalyst
 				int rd = MIPS_GET_RD(op);
 
 				if (
-					((info & IN_RS) && !(info & IN_RS_ADDR) && (rs == reg)) ||
+					((info & IN_RS) && (info & IN_RS_ADDR) == IN_RS && (rs == reg)) ||
 					((info & IN_RT) && (rt == reg)))
 				{
 					if (regAnal[reg].firstRead == -1)

--- a/Core/MIPS/MIPSCodeUtils.cpp
+++ b/Core/MIPS/MIPSCodeUtils.cpp
@@ -114,6 +114,9 @@ namespace MIPSCodeUtils
 					sure = _RS == 0;
 					takeBranch = false;
 					break;
+
+				default:
+					sure = false;
 				}
 
 				if (sure && takeBranch)

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -558,7 +558,7 @@ void GPUCommon::ProcessEvent(GPUEvent ev) {
 		break;
 
 	default:
-		ERROR_LOG(G3D, "Unexpected GPU event type: %d", ev);
+		ERROR_LOG(G3D, "Unexpected GPU event type: %d", (int)ev);
 	}
 }
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -4,7 +4,9 @@
 #include "Core/ThreadEventQueue.h"
 #include "GPU/GPUInterface.h"
 
-#ifdef _M_SSE
+#if defined(ANDROID)
+#include <atomic>
+#elif defined(_M_SSE)
 #include <xmmintrin.h>
 #pragma warning(disable:4799)
 #endif
@@ -43,7 +45,7 @@ public:
 	virtual void ReapplyGfxState();
 
 	virtual u64 GetTickEstimate() {
-#if defined(_M_X64)
+#if defined(_M_X64) || defined(ANDROID)
 		return curTickEst_;
 #elif defined(_M_SSE)
 		__m64 result = *(__m64 *)&curTickEst_;
@@ -105,11 +107,15 @@ protected:
 	bool interruptsEnabled_;
 
 	// For CPU/GPU sync.
+#ifdef ANDROID
+	std::atomic<u64> curTickEst_;
+#else
 	volatile MEMORY_ALIGNED16(u64) curTickEst_;
 	recursive_mutex curTickEstLock_;
+#endif
 
 	virtual void UpdateTickEstimate(u64 value) {
-#if defined(_M_X64)
+#if defined(_M_X64) || defined(ANDROID)
 		curTickEst_ = value;
 #elif defined(_M_SSE)
 		__m64 result = *(__m64 *)&value;

--- a/ext/disarm.cpp
+++ b/ext/disarm.cpp
@@ -142,7 +142,7 @@ bool DisasmVFP(uint32_t op, char *text) {
 				if ((op & 0xFFF) != 0xA10)
 					break;
 				if (op == 0xEEF1FA10) {
-					sprintf(text, "VMRS APSR", cond);
+					sprintf(text, "VMRS%s APSR", cond);
 				} else {
 					sprintf(text, "VMRS%s r%i", cond, (op >> 12) & 0xF);
 				}


### PR DESCRIPTION
Improves performance on 32-bit Windows at least.

Maybe std::atomic works more places, I played it safe.  VS2010 doesn't have it, of course.

-[Unknown]
