### PR TITLE
Fix savestate difference on 64/32 bit + warnings/minor

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -268,7 +268,7 @@ int VirtualDiscFileSystem::getFileListIndex(std::string& fileName)
 
 	fileList.push_back(entry);
 
-	return fileList.size()-1;
+	return (int)fileList.size()-1;
 }
 
 int VirtualDiscFileSystem::getFileListIndex(u32 accessBlock, u32 accessSize, bool blockMode)

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -124,9 +124,9 @@ private:
 		HandlerFileHandle handler;
 		VirtualFileType type;
 		u32 fileIndex;
-		u32 curOffset;
-		u32 startOffset;	// only used by lbn files
-		u32 size;			// only used by lbn files
+		u64 curOffset;
+		u64 startOffset;	// only used by lbn files
+		u64 size;			// only used by lbn files
 
 		bool Open(std::string& basePath, std::string& fileName, FileAccess access) {
 			if (handler.IsValid()) {

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -69,7 +69,10 @@ void PGF::DoState(PointerWrap &p) {
 	p.Do(header);
 	p.Do(rev3extra);
 
-	p.Do(fontDataSize);
+	// Don't savestate size_t directly, 32-bit and 64-bit are different.
+	u32 fontDataSizeTemp = (u32)fontDataSize;
+	p.Do(fontDataSizeTemp);
+	fontDataSize = (size_t)fontDataSizeTemp;
 	if (p.mode == p.MODE_READ) {
 		if (fontData) {
 			delete [] fontData;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -305,8 +305,8 @@ int sceNetAdhocTerm() {
 int sceNetEtherNtostr(const char *mac, u32 bufferPtr) {
 	DEBUG_LOG(HLE, "UNTESTED sceNetEtherNtostr(%s, %x)", mac, bufferPtr);
 	if(Memory::IsValidAddress(bufferPtr)) {
-		size_t len = strlen(mac);
-		for (size_t i = 0; i < len; i++)
+		int len = (int)strlen(mac);
+		for (int i = 0; i < len; i++)
 			Memory::Write_U8(mac[i], bufferPtr + i);
 	}
 	else

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -107,6 +107,7 @@ protected:
 	bool dumpThisFrame_;
 	bool interruptsEnabled_;
 
+private:
 	// For CPU/GPU sync.
 #ifdef ANDROID
 	std::atomic<u64> curTickEst_;
@@ -115,7 +116,7 @@ protected:
 	recursive_mutex curTickEstLock_;
 #endif
 
-	virtual void UpdateTickEstimate(u64 value) {
+	inline void UpdateTickEstimate(u64 value) {
 #if defined(_M_X64) || defined(ANDROID)
 		curTickEst_ = value;
 #elif defined(_M_SSE)

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -136,7 +136,7 @@ NewLanguageScreen::NewLanguageScreen() : ListPopupScreen("Language") {
 			}
 		}
 		if (g_Config.languageIni == code)
-			selected = i;
+			selected = (int)i;
 		listing.push_back(buttonTitle);
 	}
 


### PR DESCRIPTION
Probably my fault fixing warnings.  Now they work on both again.

Also improves performance again slightly on GPU threading, duh, why did I make it virtual?  Anyway, yeah, moving on...

-[Unknown]
