### PR TITLE
Fix an oversight where sound would never be initialised if a game is started with it off, and then is enabled later.

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -74,6 +74,17 @@ volatile CoreState coreState = CORE_STEPPING;
 volatile bool coreStatePending = false;
 static volatile CPUThreadState cpuThreadState = CPU_THREAD_NOT_RUNNING;
 
+bool IsAudioInitialised() {
+	return mixer != NULL;
+}
+
+void Audio_Init() {
+	if(mixer == NULL) {
+		mixer = new PSPMixer();
+		host->InitSound(mixer);
+	}
+}
+
 bool IsOnSeparateCPUThread() {
 	if (cpuThread != NULL) {
 		return cpuThread->get_id() == std::this_thread::get_id();
@@ -81,6 +92,8 @@ bool IsOnSeparateCPUThread() {
 		return false;
 	}
 }
+
+
 
 bool CPU_NextState(CPUThreadState from, CPUThreadState to) {
 	if (cpuThreadState == from) {
@@ -148,8 +161,7 @@ void CPU_Init() {
 	host->AttemptLoadSymbolMap();
 
 	if (coreParameter.enableSound) {
-		mixer = new PSPMixer();
-		host->InitSound(mixer);
+		Audio_Init();
 	}
 
 	if (coreParameter.disableG3Dlog) {

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -93,8 +93,6 @@ bool IsOnSeparateCPUThread() {
 	}
 }
 
-
-
 bool CPU_NextState(CPUThreadState from, CPUThreadState to) {
 	if (cpuThreadState == from) {
 		cpuThreadState = to;

--- a/Core/System.h
+++ b/Core/System.h
@@ -44,7 +44,10 @@ void PSP_Shutdown();
 void PSP_RunLoopUntil(u64 globalticks);
 void PSP_RunLoopFor(int cycles);
 
+void Audio_Init();
+
 bool IsOnSeparateCPUThread();
+bool IsAudioInitialised();
 
 void GetSysDirectories(std::string &memstickpath, std::string &flash0path);
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -331,8 +331,9 @@ void GameSettingsScreen::update(InputState &input) {
 UI::EventReturn GameSettingsScreen::OnBack(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
 
-	if(PSP_IsInited() && !IsAudioInitialised()) {
-		Audio_Init();
+	if(g_Config.bEnableSound) {
+		if(PSP_IsInited() && !IsAudioInitialised())
+			Audio_Init();
 	}
 
 	return UI::EVENT_DONE;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -33,6 +33,7 @@
 #include "base/timeutil.h"
 #include "math/curves.h"
 #include "Core/HW/atrac3plus.h"
+#include "Core/System.h"
 
 #ifdef _WIN32
 namespace MainWindow {
@@ -189,7 +190,7 @@ void GameSettingsScreen::CreateViews() {
 	root_->Add(leftColumn);
 
 	leftColumn->Add(new Spacer(new LinearLayoutParams(1.0)));
-	leftColumn->Add(new Choice(g->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+	leftColumn->Add(new Choice(g->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameSettingsScreen::OnBack);
 
 	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, 200, new LinearLayoutParams(800, FILL_PARENT, actionMenuMargins));
 
@@ -325,6 +326,16 @@ void GameSettingsScreen::DrawBackground(UIContext &dc) {
 void GameSettingsScreen::update(InputState &input) {
 	UIScreen::update(input);
 	g_Config.iForceMaxEmulatedFPS = cap60FPS_ ? 60 : 0;
+}
+
+UI::EventReturn GameSettingsScreen::OnBack(UI::EventParams &e) {
+	screenManager()->finishDialog(this, DR_OK);
+
+	if(PSP_IsInited() && !IsAudioInitialised()) {
+		Audio_Init();
+	}
+
+	return UI::EVENT_DONE;
 }
 
 void GlobalSettingsScreen::CreateViews() {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -42,6 +42,7 @@ private:
 	// Event handlers
 	UI::EventReturn OnDownloadPlugin(UI::EventParams &e);
 	UI::EventReturn OnControlMapping(UI::EventParams &e);
+	UI::EventReturn OnBack(UI::EventParams &e);
 
 	// Temporaries to convert bools to int settings
 	bool cap60FPS_;

--- a/UI/MenuScreens.cpp
+++ b/UI/MenuScreens.cpp
@@ -865,6 +865,10 @@ void AudioScreen::render() {
 			UICheckBox(GEN_ID, x, y += stride, a->T("Enable Atrac3+"), ALIGN_TOPLEFT, &g_Config.bEnableAtrac3plus);
 		} 
 
+		if(PSP_IsInited() && !IsAudioInitialised()) {
+			Audio_Init();
+		}
+
 		// Show the download button even if not installed - might want to upgrade.
 		VLinear vlinear(30, 400, 20);
 		std::string atracString;


### PR DESCRIPTION
Before, if a user started a game with sound disabled, the mixer would never be initialised, even if they turn it on later, and they're still in-game. This simply checks to see if mixer isn't null(and that we're in-game via PSP_IsInited) and if it is, it initialises it.

It was just an oversight, really.
