### PR TITLE
Add SceNpDrmOpen to the table so it can be logged properly.

### DIFF
--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -50,7 +50,7 @@ const HLEFunction sceNpDrm[] =
 	{0x275987D1, WrapI_C<sceNpDrmRenameCheck>, "sceNpDrmRenameCheck"},
 	{0x08d98894, WrapI_U<sceNpDrmEdataSetupKey>, "sceNpDrmEdataSetupKey"},
 	{0x219EF5CC, WrapI_U<sceNpDrmEdataGetDataSize>, "sceNpDrmEdataGetDataSize"},
-	{0x2BAA4294, 0, "sceNpDrmOpen"},
+	{0x2BAA4294, WrapI_V<sceNpDrmOpen>, "sceNpDrmOpen"},
 };
 
 void Register_sceNpDrm()


### PR DESCRIPTION
Not sure why it wasn't added before, since it has a stub written.
