### PR TITLE
Handle branches in VFPU delay slots better

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -282,6 +282,8 @@ void Jit::BranchVFPUFlag(u32 op, ArmGen::CCFlags cc, bool likely)
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
+	if (delaySlotIsBranch && (delaySlotOp & 0xFFFF) != offset - 1)
+		ERROR_LOG_REPORT(JIT, "VFPU branch in VFPU delay slot at %08x with different target", js.compilerPC);
 
 	FlushAll();
 

--- a/Core/MIPS/MIPSCodeUtils.cpp
+++ b/Core/MIPS/MIPSCodeUtils.cpp
@@ -132,4 +132,8 @@ namespace MIPSCodeUtils
 		else
 			return INVALIDTARGET;
 	}
+
+	bool IsVFPUBranch(u32 op) {
+		return (MIPSGetInfo(op) & (IS_VFPU | IS_CONDBRANCH)) == (IS_VFPU | IS_CONDBRANCH);
+	}
 }

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -57,5 +57,5 @@ namespace MIPSCodeUtils
 	u32 GetBranchTargetNoRA(u32 addr);
 	u32 GetJumpTarget(u32 addr);
 	u32 GetSureBranchTarget(u32 addr);
-	void RewriteSysCalls(u32 startAddr, u32 endAddr);
+	bool IsVFPUBranch(u32 op);
 }

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -348,7 +348,12 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	u32 delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
-	bool delaySlotIsNice = IsDelaySlotNiceVFPU(op, delaySlotOp);
+
+	// Sometimes there's a VFPU branch in a delay slot (Disgaea 2: Dark Hero Days, Zettai Hero Project, La Pucelle)
+	// The behavior is undefined - the CPU may take the second branch even if the first one passes.
+	// However, it does consistently try each branch, which these games seem to expect.
+	bool delaySlotIsBranch = MIPSCodeUtils::IsVFPUBranch(delaySlotOp);
+	bool delaySlotIsNice = !delaySlotIsBranch && IsDelaySlotNiceVFPU(op, delaySlotOp);
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
@@ -363,14 +368,15 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	Gen::FixupBranch ptr;
 	if (!likely)
 	{
-		if (!delaySlotIsNice)
+		if (!delaySlotIsNice && !delaySlotIsBranch)
 			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
 		ptr = J_CC(cc, true);
 	}
 	else
 	{
 		ptr = J_CC(cc, true);
-		CompileDelaySlot(DELAYSLOT_FLUSH);
+		if (!delaySlotIsBranch)
+			CompileDelaySlot(DELAYSLOT_FLUSH);
 	}
 
 	// Take the branch
@@ -379,8 +385,9 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 
 	SetJumpTarget(ptr);
 	// Not taken
-	CONDITIONAL_LOG_EXIT(js.compilerPC + 8);
-	WriteExit(js.compilerPC + 8, 1);
+	u32 notTakenTarget = js.compilerPC + (delaySlotIsBranch ? 4 : 8);
+	CONDITIONAL_LOG_EXIT(notTakenTarget);
+	WriteExit(notTakenTarget, 1);
 
 	js.compiling = false;
 }

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -357,6 +357,8 @@ void Jit::BranchVFPUFlag(u32 op, Gen::CCFlags cc, bool likely)
 	CONDITIONAL_NICE_DELAYSLOT;
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
+	if (delaySlotIsBranch && (signed short)(delaySlotOp & 0xFFFF) != (signed short)(op & 0xFFFF) - 1)
+		ERROR_LOG(JIT, "VFPU branch in VFPU delay slot at %08x with different target %d / %d", js.compilerPC, (signed short)(delaySlotOp & 0xFFFF), (signed short)(op & 0xFFFF) - 1);
 
 	FlushAll();
 


### PR DESCRIPTION
The interpreter seems to already have the correct behavior and match the PSP.  From my tests, although I'm not 100% confident for all cases it's true, the logic is as follows:
- If a branch test passes, and its delay slot also passes, take the delay slot target.
- If a branch test passes, but its delay slot does not pass, take the branch target.
- If a branch test fails, then evaluate the delay slot as the branch per the above rules.

That is, if 4 in a row pass and each has a different target, take target 2.  If only 2 and 3 pass, take 3.  If only 1 and 3 pass, take 1.

However, we've [only seen 3 games do this](http://report.ppsspp.org/logs/kind/161), and they're all by the same developer, I'm assuming the important thing is to handle their case: multiple tests with the same target.  This is relatively easy.

Fixes #1926.

-[Unknown]
