### PR TITLE
Reschedule in sceKernelReferThreadStatus()

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1319,6 +1319,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 	}
 
 	hleEatCycles(1220);
+	hleReSchedule("refer thread status");
 	return 0;
 }
 


### PR DESCRIPTION
It's often called in loops waiting for a thread to wake up.

Fixes .hack//Link's sluggish performance, hopefully also the video from #2188.

-[Unknown]
