### PR TITLE
Minor improvements to new UI

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -95,17 +95,19 @@ void Core_WaitInactive(int milliseconds)
 void UpdateScreenScale() {
 	dp_xres = PSP_CoreParameter().pixelWidth;
 	dp_yres = PSP_CoreParameter().pixelHeight;
+	pixel_xres = PSP_CoreParameter().pixelWidth;
+	pixel_yres = PSP_CoreParameter().pixelHeight;
+	g_dpi = 72;
+	g_dpi_scale = 1.0f;
 #ifdef _WIN32
 	if (g_Config.iWindowZoom == 1)
 	{
 		dp_xres *= 2;
 		dp_yres *= 2;
+		g_dpi_scale = 2.0f;
 	}
+	else
 #endif
-	pixel_xres = PSP_CoreParameter().pixelWidth;
-	pixel_yres = PSP_CoreParameter().pixelHeight;
-	g_dpi = 72;
-	g_dpi_scale = 1.0f;
 	pixel_in_dps = (float)pixel_xres / dp_xres;
 }
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -382,7 +382,7 @@ void GameBrowser::Refresh() {
 		b->OnHoldClick.Handle(this, &GameBrowser::GameButtonHoldClick);
 	}
 
-	if (!lastText_.empty()) {
+	if (!lastText_.empty() && gameButtons.empty()) {
 		Add(new Spacer());
 		Add(new Choice(lastText_, new UI::LinearLayoutParams(UI::WRAP_CONTENT, UI::WRAP_CONTENT)))->OnClick.Handle(this, &GameBrowser::LastClick);
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -360,6 +360,9 @@ void NativeInit(int argc, const char *argv[],
 		logman->SetLogLevel(LogTypes::G3D, LogTypes::LERROR);
 	INFO_LOG(BOOT, "Logger inited.");
 #else
+	if (g_Config.currentDirectory.empty()) {
+		g_Config.currentDirectory = File::GetExeDirectory();
+	}
 	g_Config.memCardDirectory = "MemStick/";
 #endif	
 


### PR DESCRIPTION
- Don't show a completely broken mess at 1x.
- Don't show "How to get games" when you have games in the list.
- Start out in the emulator's directory, not the root on Windows.

-[Unknown]
