### PR TITLE
Software GPU width tweak

### DIFF
--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -31,16 +31,6 @@ NullGPU::~NullGPU()
 {
 }
 
-u32 NullGPU::DrawSync(int mode)
-{
-	if (mode == 0)  // Wait for completion
-	{
-		__RunOnePendingInterrupt();
-	}
-
-	return GPUCommon::DrawSync(mode);
-}
-
 void NullGPU::FastRunLoop(DisplayList &list) {
 	for (; downcount > 0; --downcount) {
 		u32 op = Memory::ReadUnchecked_U32(list.pc);

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -28,7 +28,6 @@ public:
 	~NullGPU();
 	virtual void InitClear() {}
 	virtual void ExecuteOp(u32 op, u32 diff);
-	virtual u32  DrawSync(int mode);
 
 	virtual void BeginFrame() {}
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -213,6 +213,11 @@ void CopyToCurrentFboFromRam(u8* data, int srcwidth, int srcheight, int dstwidth
 
 void SoftGPU::CopyDisplayToOutput()
 {
+	ScheduleEvent(GPU_EVENT_COPY_DISPLAY_TO_OUTPUT);
+}
+
+void SoftGPU::CopyDisplayToOutputInternal()
+{
 	// TODO: How to get the correct dimensions?
 	CopyToCurrentFboFromRam(fb, gstate.fbwidth & 0x3C0, FB_HEIGHT, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 }
@@ -225,6 +230,17 @@ u32 SoftGPU::DrawSync(int mode)
 	}
 
 	return GPUCommon::DrawSync(mode);
+}
+
+void SoftGPU::ProcessEvent(GPUEvent ev) {
+	switch (ev.type) {
+	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
+		CopyDisplayToOutputInternal();
+		break;
+
+	default:
+		GPUCommon::ProcessEvent(ev);
+	}
 }
 
 void SoftGPU::FastRunLoop(DisplayList &list) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -222,16 +222,6 @@ void SoftGPU::CopyDisplayToOutputInternal()
 	CopyToCurrentFboFromRam(fb, gstate.fbwidth & 0x3C0, FB_HEIGHT, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 }
 
-u32 SoftGPU::DrawSync(int mode)
-{
-	if (mode == 0)  // Wait for completion
-	{
-		__RunOnePendingInterrupt();
-	}
-
-	return GPUCommon::DrawSync(mode);
-}
-
 void SoftGPU::ProcessEvent(GPUEvent ev) {
 	switch (ev.type) {
 	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -16,16 +16,17 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 
-#include "../GPUState.h"
-#include "../ge_constants.h"
-#include "../../Core/MemMap.h"
-#include "../../Core/HLE/sceKernelInterrupt.h"
-#include "../../Core/HLE/sceGe.h"
+#include "GPU/GPUState.h"
+#include "GPU/ge_constants.h"
+#include "Core/MemMap.h"
+#include "Core/HLE/sceKernelInterrupt.h"
+#include "Core/HLE/sceGe.h"
+#include "Core/Reporting.h"
 #include "gfx/gl_common.h"
 
-#include "SoftGpu.h"
-#include "TransformUnit.h"
-#include "Colors.h"
+#include "GPU/Software/SoftGpu.h"
+#include "GPU/Software/TransformUnit.h"
+#include "GPU/Software/Colors.h"
 
 static GLuint temp_texture = 0;
 
@@ -34,6 +35,7 @@ static GLint uni_tex = -1;
 
 static GLuint program;
 
+const int FB_WIDTH = 480;
 const int FB_HEIGHT = 272;
 u8* fb = NULL;
 u8* depthbuf = NULL;
@@ -157,26 +159,45 @@ void CopyToCurrentFboFromRam(u8* data, int srcwidth, int srcheight, int dstwidth
 
 	glBindTexture(GL_TEXTURE_2D, temp_texture);
 
+	GLfloat texvert_u;
 	if (gstate.FrameBufFormat() == GE_FORMAT_8888) {
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)srcwidth, (GLsizei)srcheight, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)gstate.FrameBufStride(), (GLsizei)srcheight, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		texvert_u = (float)srcwidth / gstate.FrameBufStride();
 	} else {
 		// TODO: This should probably be converted in a shader instead..
 		// TODO: Do something less brain damaged to manage this buffer...
-		u32* buf = new u32[srcwidth*srcheight];
+		u32 *buf = new u32[srcwidth * srcheight];
+		u16 *fb16 = (u16 *)fb;
 		for (int y = 0; y < srcheight; ++y) {
-			for (int x = 0; x < srcwidth; ++x) {
-				u16 src = *(u16*)&fb[2*x + 2*y*gstate.FrameBufStride()];
+			u32 *buf_line = &buf[y * srcwidth];
+			u16 *fb_line = &fb16[y * gstate.FrameBufStride()];
 
-				if (gstate.FrameBufFormat() == GE_FORMAT_565)
-					buf[x+y*srcwidth] = DecodeRGB565(src);
-				else if (gstate.FrameBufFormat() == GE_FORMAT_5551)
-					buf[x+y*srcwidth] = DecodeRGBA5551(src);
-				else if (gstate.FrameBufFormat() == GE_FORMAT_4444)
-					buf[x+y*srcwidth] = DecodeRGBA4444(src);
+			switch (gstate.FrameBufFormat()) {
+			case GE_FORMAT_565:
+				for (int x = 0; x < srcwidth; ++x) {
+					buf_line[x] = DecodeRGB565(fb_line[x]);
+				}
+				break;
+
+			case GE_FORMAT_5551:
+				for (int x = 0; x < srcwidth; ++x) {
+					buf_line[x] = DecodeRGBA5551(fb_line[x]);
+				}
+				break;
+
+			case GE_FORMAT_4444:
+				for (int x = 0; x < srcwidth; ++x) {
+					buf_line[x] = DecodeRGBA4444(fb_line[x]);
+				}
+				break;
+
+			default:
+				ERROR_LOG_REPORT(G3D, "Unexpected framebuffer format: %d", gstate.FrameBufFormat());
 			}
 		}
 
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)srcwidth, (GLsizei)srcheight, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf);
+		texvert_u = 1.0f;
 
 		delete[] buf;
 	}
@@ -191,11 +212,11 @@ void CopyToCurrentFboFromRam(u8* data, int srcwidth, int srcheight, int dstwidth
 		{  1,  1}, // right bottom
 		{  1, -1}  // right top
 	};
-	static const GLfloat texverts[4][2] = {
+	const GLfloat texverts[4][2] = {
 		{0, 1},
 		{0, 0},
-		{1, 0},
-		{1, 1}
+		{texvert_u, 0},
+		{texvert_u, 1}
 	};
 
 	glVertexAttribPointer(attr_pos, 2, GL_FLOAT, GL_FALSE, 0, verts);
@@ -218,8 +239,8 @@ void SoftGPU::CopyDisplayToOutput()
 
 void SoftGPU::CopyDisplayToOutputInternal()
 {
-	// TODO: How to get the correct dimensions?
-	CopyToCurrentFboFromRam(fb, gstate.fbwidth & 0x3C0, FB_HEIGHT, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+	// The display always shows 480x272.
+	CopyToCurrentFboFromRam(fb, FB_WIDTH, FB_HEIGHT, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 }
 
 void SoftGPU::ProcessEvent(GPUEvent ev) {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -49,4 +49,8 @@ public:
 
 protected:
 	virtual void FastRunLoop(DisplayList &list);
+	virtual void ProcessEvent(GPUEvent ev);
+
+private:
+	void CopyDisplayToOutputInternal();
 };

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -28,7 +28,6 @@ public:
 	~SoftGPU();
 	virtual void InitClear() {}
 	virtual void ExecuteOp(u32 op, u32 diff);
-	virtual u32  DrawSync(int mode);
 
 	virtual void BeginFrame() {}
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {}

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -43,8 +43,8 @@ public:
 
 	virtual void Resized() {}
 	virtual void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) {
-		primaryInfo = "NULL";
-		fullInfo = "NULL";
+		primaryInfo = "Software";
+		fullInfo = "Software";
 	}
 
 protected:


### PR DESCRIPTION
- Support the "multithreaded" option by doing GL operations on the GL thread (doesn't actually make it multithread internally.)
- Removes some questionable code from the NULL and Software GPUs that probably was a holdover.
- Mostly properly locks the display width to 480, fixes rendering artifacts in some games.

@neobrain let me know if this looks okay to you.

-[Unknown]
