### PR TITLE
Assemble opcode by typing

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -68,6 +68,7 @@ class CtrlDisAsmView
 	int matchAddress;
 	bool searching;
 	bool dontRedraw;
+	bool keyTaken;
 
 	void assembleOpcode(u32 address, std::string defaultText);
 	void disassembleToFile();
@@ -85,6 +86,7 @@ public:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	static CtrlDisAsmView * getFrom(HWND wnd);
 	
+	void onChar(WPARAM wParam, LPARAM lParam);
 	void onPaint(WPARAM wParam, LPARAM lParam);
 	void onVScroll(WPARAM wParam, LPARAM lParam);
 	void onKeyDown(WPARAM wParam, LPARAM lParam);

--- a/Windows/InputBox.cpp
+++ b/Windows/InputBox.cpp
@@ -5,6 +5,7 @@
 static TCHAR textBoxContents[256];
 static TCHAR out[256];
 static TCHAR windowTitle[256];
+static bool defaultSelected;
 
 static INT_PTR CALLBACK InputBoxFunc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -12,6 +13,7 @@ static INT_PTR CALLBACK InputBoxFunc(HWND hDlg, UINT message, WPARAM wParam, LPA
 	case WM_INITDIALOG:
 		SetWindowText(GetDlgItem(hDlg,IDC_INPUTBOX),textBoxContents);
 		SetWindowText(hDlg, windowTitle);
+		if (defaultSelected == false) PostMessage(GetDlgItem(hDlg,IDC_INPUTBOX),EM_SETSEL,-1,-1);
 		return TRUE;
 	case WM_COMMAND:
 		switch (wParam)
@@ -35,12 +37,18 @@ void InputBoxFunc()
 
 }
 
-bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue)
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, bool selected)
 {
+	defaultSelected = selected;
 	if (defaultvalue && strlen(defaultvalue)<255)
 		strcpy(textBoxContents,defaultvalue);
 	else
 		strcpy(textBoxContents,"");
+
+	if (title != NULL)
+		strcpy(windowTitle,title);
+	else
+		strcpy(windowTitle,"");
 
 	if (IDOK==DialogBox(hInst,(LPCSTR)IDD_INPUTBOX,hParent,InputBoxFunc))
 	{
@@ -54,6 +62,7 @@ bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defa
 bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, size_t outlength)
 {
 	const char *defaultTitle = "Input value";
+	defaultSelected = true;
 
 	if (defaultvalue && strlen(defaultvalue)<255)
 		strcpy(textBoxContents,defaultvalue);

--- a/Windows/InputBox.h
+++ b/Windows/InputBox.h
@@ -3,6 +3,6 @@
 #include "Globals.h"
 
 #include "Common/CommonWindows.h"
-bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue);
+bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, bool selected = true);
 bool InputBox_GetString(HINSTANCE hInst, HWND hParent, TCHAR *title, TCHAR *defaultvalue, TCHAR *outvalue, size_t outlength);
 bool InputBox_GetHex(HINSTANCE hInst, HWND hParent, TCHAR *title, u32 defaultvalue, u32 &outvalue);


### PR DESCRIPTION
Instead of having to press Ctrl+A, you can now simply start typing the opcode in the disassembly control to start the process. The edit control will open automatically after the first letter.
