### PR TITLE
Fix Gran Turismo's text

### DIFF
--- a/GPU/GLES/DisplayListInterpreter.cpp
+++ b/GPU/GLES/DisplayListInterpreter.cpp
@@ -693,6 +693,9 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 			// and take appropriate action. This is a block transfer between RAM and VRAM, or vice versa.
 			// Can we skip this on SkipDraw?
 			DoBlockTransfer();
+
+			// Fixes Gran Turismo's funky text issue.
+			gstate_c.textureChanged = true;
 			break;
 		}
 
@@ -1096,7 +1099,7 @@ void GLES_GPU::DoBlockTransfer() {
 
 	int bpp = (gstate.transferstart & 1) ? 4 : 2;
 
-	DEBUG_LOG(G3D, "Block transfer: %08x to %08x, %i x %i , ...", srcBasePtr, dstBasePtr, width, height);
+	DEBUG_LOG(G3D, "Block transfer: %08x/%x -> %08x/%x, %ix%ix%i (%i,%i)->(%i,%i)", srcBasePtr, srcStride, dstBasePtr, dstStride, width, height, bpp, srcX, srcY, dstX, dstY);
 
 	// Do the copy!
 	for (int y = 0; y < height; y++) {


### PR DESCRIPTION
Credit goes to Unknown for the fix. After a lot of code tweaking to find out where the exact issue lies, here it is. This fixes https://github.com/hrydgard/ppsspp/issues/2906, and as far as I know, doesn't affect other games, though I tested a small sample(8 games or so).

According to Unknown, the game was using the same texture address to render, even though it's being overwritten in DoBlockTransfer. The texture cache code was never even being called.

```
[18:54:59] <[Unknown]> the worst this change should theoretically be able to do is:
[18:55:06] <[Unknown]> (a) uncover a bug we already had but didn't notice
[18:55:27] <[Unknown]> or (b) spend significantly more time looking up textures in some game that does tiny block transfers a lot
```

![Screenshot 01](https://i.minus.com/iQpf0NrOSYW1o.jpg)
