### PR TITLE
Fix audio crash on shutdown, log thread names more

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #endif
 
+#include "thread/threadutil.h"
 #include "Common.h"
 #include "LogManager.h" // Common
 #include "ConsoleListener.h" // Common
@@ -248,6 +249,7 @@ COORD ConsoleListener::GetCoordinates(int BytesRead, int BufferWidth)
 
 unsigned int WINAPI ConsoleListener::RunThread(void *lpParam)
 {
+	setCurrentThreadName("ConsoleThread");
 	ConsoleListener *consoleLog = (ConsoleListener *)lpParam;
 	consoleLog->LogWriterThread();
 	return 0;

--- a/Windows/DSoundStream.cpp
+++ b/Windows/DSoundStream.cpp
@@ -1,3 +1,4 @@
+#include "native/thread/threadutil.h"
 #include "Common/CommonWindows.h"
 #include <dsound.h>
 
@@ -112,6 +113,7 @@ namespace DSound
 
 	unsigned int WINAPI soundThread(void *)
 	{
+		setCurrentThreadName("DSoundThread");
 		currentPos = 0;
 		lastPos = 0;
 		//writeDataToBuffer(0,realtimeBuffer,bufferSize);
@@ -190,18 +192,27 @@ namespace DSound
 
 	void DSound_StopSound()
 	{
-		threadData=1;
-		WaitForSingleObject(hThread,1000);
-		CloseHandle(hThread);
-		/*
-		while (threadData!=2)
-			;*/
-		if (dsBuffer != NULL)
-			dsBuffer->Release();
-		if (ds != NULL)
-			ds->Release();
+		if (threadData == 0)
+			threadData = 1;
 
-		CloseHandle(soundSyncEvent);
+		if (hThread != NULL)
+		{
+			WaitForSingleObject(hThread, 1000);
+			CloseHandle(hThread);
+		}
+
+		if (threadData == 2)
+		{
+			if (dsBuffer != NULL)
+				dsBuffer->Release();
+			dsBuffer = NULL;
+			if (ds != NULL)
+				ds->Release();
+			ds = NULL;
+		}
+
+		if (soundSyncEvent != NULL)
+			CloseHandle(soundSyncEvent);
 		soundSyncEvent = NULL;
 	}
 

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -139,6 +139,7 @@ shutdown:
 	_InterlockedExchange(&emuThreadReady, THREAD_SHUTDOWN);
 
 	NativeShutdownGraphics();
+	host->ShutdownSound();
 	host = nativeHost;
 	NativeShutdown();
 	host = oldHost;


### PR DESCRIPTION
It was calling native's ShutdownSound(), so doing nothing.  This shuts it down a bit early and adds some guards in case it's called twice.

Also adds some thread names for easier debugging.

-[Unknown]
