### PR TITLE
Win32: Allow right mouse button to be bound to anything.

### DIFF
--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -116,7 +116,9 @@ std::map<int, int> windowsTransTable = InitConstMap<int, int>
 	(VK_F10, NKCODE_F10)
 	(VK_F11, NKCODE_F11)
 	(VK_F12, NKCODE_F12)
-	(VK_OEM_102, NKCODE_EXT_PIPE);
+	(VK_OEM_102, NKCODE_EXT_PIPE)
+	(VK_LBUTTON, NKCODE_EXT_MOUSEBUTTON_1)
+	(VK_RBUTTON, NKCODE_EXT_MOUSEBUTTON_2);
 
 int KeyboardDevice::UpdateState(InputState &input_state) {
 	// Nothing to do, all done in WM_INPUT

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1125,7 +1125,7 @@ namespace MainWindow
 					KeyInput key;
 					key.deviceId = DEVICE_ID_MOUSE;
 
-					bool mouseRightBtnPressed = raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN != 0;
+					bool mouseRightBtnPressed = raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN;
 
 					if(mouseRightBtnPressed) {
 						key.flags = KEY_DOWN;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1126,13 +1126,14 @@ namespace MainWindow
 					key.deviceId = DEVICE_ID_MOUSE;
 
 					bool mouseRightBtnPressed = raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN;
+					bool mouseRightBtnReleased = raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP;
 
 					if(mouseRightBtnPressed) {
 						key.flags = KEY_DOWN;
 						key.keyCode = windowsTransTable[VK_RBUTTON];
 						NativeKey(key);
 					}
-					else {
+					else if(mouseRightBtnReleased) {
 						key.flags = KEY_UP;
 						key.keyCode = windowsTransTable[VK_RBUTTON];
 						NativeKey(key);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1122,6 +1122,22 @@ namespace MainWindow
 					mouseDeltaX += raw->data.mouse.lLastX;
 					mouseDeltaY += raw->data.mouse.lLastY;
 
+					KeyInput key;
+					key.deviceId = DEVICE_ID_MOUSE;
+
+					bool mouseRightBtnPressed = raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN != 0;
+
+					if(mouseRightBtnPressed) {
+						key.flags = KEY_DOWN;
+						key.keyCode = windowsTransTable[VK_RBUTTON];
+						NativeKey(key);
+					}
+					else {
+						key.flags = KEY_UP;
+						key.keyCode = windowsTransTable[VK_RBUTTON];
+						NativeKey(key);
+					}
+
 					// TODO : Smooth and translate to an axis every frame.
 					// NativeAxis()
 				}


### PR DESCRIPTION
I tried adding left button support as well, but it was a bit buggy, so I'll stick with just right only for now.
