### PR TITLE
Fix "grain will be off" by making it not actually off

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -290,6 +290,12 @@ void PathBrowser::Navigate(const std::string &path) {
 	}
 }
 
+static std::string GetMemCardDirectory() {
+	std::string memCardDirectory, ignore;
+	GetSysDirectories(memCardDirectory, ignore);
+	return memCardDirectory;
+}
+
 class GameBrowser : public UI::LinearLayout {
 public:
 	GameBrowser(std::string path, bool allowBrowsing, bool *gridStyle_, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = 0);
@@ -333,7 +339,7 @@ UI::EventReturn GameBrowser::LastClick(UI::EventParams &e) {
 }
 
 UI::EventReturn GameBrowser::HomeClick(UI::EventParams &e) {
-	path_.SetPath(g_Config.memCardDirectory);
+	path_.SetPath(GetMemCardDirectory());
 	g_Config.currentDirectory = path_.GetPath();
 	Refresh();
 	return UI::EVENT_DONE;
@@ -472,7 +478,7 @@ void MainScreen::CreateViews() {
 	GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, true, &g_Config.bGridView2, 
 		m->T("How to get games"), "http://www.ppsspp.org/faq.html",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
-	GameBrowser *tabHomebrew = new GameBrowser(g_Config.memCardDirectory + "PSP/GAME/", false, &g_Config.bGridView3, 
+	GameBrowser *tabHomebrew = new GameBrowser(GetMemCardDirectory() + "PSP/GAME/", false, &g_Config.bGridView3,
 		"", "",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 


### PR DESCRIPTION
This fixes the "Suicide Barbie" homebrew thing from dying at startup (broken by 8191ea4d76c3c97cb68de58ab7980e1b89afaa9f.)  Thanks for the link.

Might be a little dangerous, but I'm pretty sure it's the sane thing to do: downalign the off-grain pointer (that is, allocate the full 0x100 block.)  This way we don't report a free size that is off grain.  Still returns the original (unaligned) address, and I'm pretty sure the other memory was never allocatable anyway...

Meanwhile, makes it use the same logic for finding the memstick/ directory on Windows as sceIo/etc. does.

-[Unknown]
