### PR TITLE
Allow Default All to generate a keymap for Directinput, too.

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -625,6 +625,7 @@ void RestoreDefault() {
 #if defined(_WIN32)
 	SetDefaultKeyMap(DEFAULT_MAPPING_KEYBOARD, true);
 	SetDefaultKeyMap(DEFAULT_MAPPING_X360, false);
+	SetDefaultKeyMap(DEFAULT_MAPPING_PAD, false);
 #elif defined(ANDROID)
 	// Autodetect a few common devices
 	std::string name = System_GetName();


### PR DESCRIPTION
A simple oversight?
