### PR TITLE
Set accept/escape buttons based on the bound CROSS/CIRCLE buttons.

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -224,16 +224,22 @@ void UpdateConfirmCancelKeys() {
 	}
 
 	// Push several hard-coded keys before submitting to native.
-	if(std::find(confirmKeys.begin(), confirmKeys.end(), NKCODE_ENTER) == confirmKeys.end())
-		confirmKeys.push_back(NKCODE_ENTER);
+	const keycode_t hardcodedConfirmKeys[] = { 
+		NKCODE_SPACE, 
+		NKCODE_ENTER,
+	};
+
+	// If they're not already bound, add them in.
+	for(int i = 0; i < ARRAY_SIZE(hardcodedConfirmKeys); i++) {
+		if(std::find(confirmKeys.begin(), confirmKeys.end(), hardcodedConfirmKeys[i]) == confirmKeys.end())
+			confirmKeys.push_back(hardcodedConfirmKeys[i]);
+	}
 
 	const keycode_t hardcodedCancelKeys[] = { 
-		NKCODE_SPACE, 
 		NKCODE_ESCAPE, 
 		NKCODE_BACK, 
 	};
 
-	// If they're not already bound, add them in.
 	for(int i = 0; i < ARRAY_SIZE(hardcodedCancelKeys); i++) {
 		if(std::find(cancelKeys.begin(), cancelKeys.end(), hardcodedCancelKeys[i]) == cancelKeys.end())
 			cancelKeys.push_back(hardcodedCancelKeys[i]);

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -21,6 +21,7 @@
 #include "base/NativeApp.h"
 #include "KeyMap.h"
 #include "../Core/HLE/sceUtility.h"
+
 #include <algorithm>
 
 
@@ -223,7 +224,7 @@ void UpdateConfirmCancelKeys() {
 	}
 
 	// Push several hard-coded keys before submitting to native.
-	if(std::find(cancelKeys.begin(), cancelKeys.end(), NKCODE_ENTER) == cancelKeys.end())
+	if(std::find(confirmKeys.begin(), confirmKeys.end(), NKCODE_ENTER) == confirmKeys.end())
 		confirmKeys.push_back(NKCODE_ENTER);
 
 	const keycode_t hardcodedCancelKeys[] = { 

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -222,11 +222,14 @@ void UpdateConfirmCancelKeys() {
 		cancelKeys.push_back((keycode_t)i->keyCode);
 	}
 
+	// Push several hard-coded keys before submitting to native.
+	if(std::find(cancelKeys.begin(), cancelKeys.end(), NKCODE_ENTER) == cancelKeys.end())
+		confirmKeys.push_back(NKCODE_ENTER);
+
 	const keycode_t hardcodedCancelKeys[] = { 
 		NKCODE_SPACE, 
 		NKCODE_ESCAPE, 
 		NKCODE_BACK, 
-		NKCODE_EXT_MOUSEBUTTON_2 
 	};
 
 	// If they're not already bound, add them in.

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -21,6 +21,8 @@
 #include "base/NativeApp.h"
 #include "KeyMap.h"
 #include "../Core/HLE/sceUtility.h"
+#include <algorithm>
+
 
 namespace KeyMap {
 
@@ -207,27 +209,33 @@ static const DefMappingStruct defaultXperiaPlay[] = {
 };
 
 void UpdateConfirmCancelKeys() {
-	std::vector<keycode_t> confirm, cancel;
+	std::vector<keycode_t> confirmKeys, cancelKeys;
 
-	int confirmBtns = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
-	int cancelBtns = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
+	int confirmKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
+	int cancelKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
 
-	for(auto i = g_controllerMap[confirmBtns].begin(); i != g_controllerMap[confirmBtns].end(); ++i)
-	{
-		confirm.push_back((keycode_t)i->keyCode);
+	for(auto i = g_controllerMap[confirmKey].begin(); i != g_controllerMap[confirmKey].end(); ++i) {
+		confirmKeys.push_back((keycode_t)i->keyCode);
 	}
 
-	for(auto i = g_controllerMap[cancelBtns].begin(); i != g_controllerMap[cancelBtns].end(); ++i)
-	{
-		cancel.push_back((keycode_t)i->keyCode);
+	for(auto i = g_controllerMap[cancelKey].begin(); i != g_controllerMap[cancelKey].end(); ++i) {
+		cancelKeys.push_back((keycode_t)i->keyCode);
 	}
 
-	cancel.push_back(NKCODE_SPACE);
-	cancel.push_back(NKCODE_ESCAPE);
-	cancel.push_back(NKCODE_BACK);
-	cancel.push_back(NKCODE_EXT_MOUSEBUTTON_2);
+	const keycode_t hardcodedCancelKeys[] = { 
+		NKCODE_SPACE, 
+		NKCODE_ESCAPE, 
+		NKCODE_BACK, 
+		NKCODE_EXT_MOUSEBUTTON_2 
+	};
 
-	SetConfirmCancelKeys(confirm, cancel);
+	// If they're not already bound, add them in.
+	for(int i = 0; i < ARRAY_SIZE(hardcodedCancelKeys); i++) {
+		if(std::find(cancelKeys.begin(), cancelKeys.end(), hardcodedCancelKeys[i]) == cancelKeys.end())
+			cancelKeys.push_back(hardcodedCancelKeys[i]);
+	}
+
+	SetConfirmCancelKeys(confirmKeys,cancelKeys);
 }
 
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, int count, bool replace) {

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -151,5 +151,6 @@ namespace KeyMap {
 
 	void RestoreDefault();
 	void QuickMap(int device);
-}
 
+	void UpdateConfirmCancelKeys();
+}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -34,6 +34,7 @@
 #include "math/curves.h"
 #include "Core/HW/atrac3plus.h"
 #include "Core/System.h"
+#include "Common/KeyMap.h"
 
 #ifdef _WIN32
 #include "Core/Host.h"
@@ -454,6 +455,8 @@ UI::EventReturn GameSettingsScreen::OnBack(UI::EventParams &e) {
 #ifdef _WIN32
 	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_ATRAC_STATUS_CHANGED, 0, 0);
 #endif
+
+	KeyMap::UpdateConfirmCancelKeys();
 
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
Please merge https://github.com/hrydgard/native/pull/113 as well if this is accepted.

This pull request removes the hard coding of cancel/confirm buttons(except a select few; we need some as a bare minimum), and allows the UI to be navigated by the user's bound X and O buttons. It also takes into account the user's iButtonPreference, meaning it'll swap O and X accordingly for confirm/cancel, before passing all of these buttons in two vectors, a confirm, and a cancel, into native.
