### PR TITLE
Compare the right fb address for suboffset textures

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -242,13 +242,13 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 	case NOTIFY_FB_CREATED:
 	case NOTIFY_FB_UPDATED:
 		for (auto it = cache.lower_bound(cacheKey), end = cache.upper_bound(cacheKeyEnd); it != end; ++it) {
-			AttachFramebuffer(&it->second, address, framebuffer, it->first == cacheKey);
+			AttachFramebuffer(&it->second, address | 0x04000000, framebuffer, it->first == cacheKey);
 		}
 		break;
 
 	case NOTIFY_FB_DESTROYED:
 		for (auto it = cache.lower_bound(cacheKey), end = cache.upper_bound(cacheKeyEnd); it != end; ++it) {
-			DetachFramebuffer(&it->second, address, framebuffer);
+			DetachFramebuffer(&it->second, address | 0x04000000, framebuffer);
 		}
 		break;
 	}


### PR DESCRIPTION
If that case is changed to AttachFramebufferValid(), fixes Valkyrie Profile's intro logo graphics mostly.

Still seems to hang somewhat into the game...

This is because `(entry->addr - address) / entry->bufw < framebuffer->height` ignored the VRAM address.

Not heavily tested since I don't have much time today, but might be safe to have fun breaking things now?

-[Unknown]
