### PR TITLE
Use the previous nickname as the default value instead of "PPSSPP".

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -476,9 +476,19 @@ UI::EventReturn GameSettingsScreen::OnChangeNickname(UI::EventParams &e) {
 	char name[name_len];
 	memset(name, 0, sizeof(name));
 
-	if (host->InputBoxGetString("Enter a new PSP nickname", "PPSSPP", name, name_len)) {
+	size_t default_len = strlen(g_Config.sNickName.c_str());
+
+	char *defaultVal = new char[default_len];
+	memset(defaultVal, 0, sizeof(default_len));
+	strcat(defaultVal, g_Config.sNickName.c_str());
+
+	if (host->InputBoxGetString("Enter a new PSP nickname", defaultVal, name, name_len)) {
 		g_Config.sNickName = name;
 	}
+
+	delete [] defaultVal;
+	defaultVal = NULL;
+
 	#endif
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
It could be potentially confusing to always see "PPSSPP" as the nickname in the box.

https://github.com/hrydgard/ppsspp/issues/3289
