### PR TITLE
Win32: Fix flash0/memstick folder locations.

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -328,11 +328,6 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 
 	GetModuleFileName(NULL,path_buffer,sizeof(path_buffer));
 
-	char *winpos = strstr(path_buffer, "Windows");
-	if (winpos)
-	*winpos = 0;
-	strcat(path_buffer, "dummy.txt");
-
 	_splitpath_s(path_buffer, drive, dir, file, ext );
 
 	// Mount a couple of filesystems


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/3299.

What in the world was that stuff, anyway? :-1: 
