### PR TITLE
Add a chinese forum link

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -351,8 +351,15 @@ void CreditsScreen::CreateViews() {
 #ifndef GOLD
 	root_->Add(new Button(g->T("Buy Gold"), new AnchorLayoutParams(260, 64, 10, NONE, NONE, 10, false)))->OnClick.Handle(this, &CreditsScreen::OnSupport);
 #endif
-	root_->Add(new Button(g->T("PPSSPP Forums"), new AnchorLayoutParams(260, 64, 10, NONE, NONE, 84, false)))->OnClick.Handle(this, &CreditsScreen::OnForums);
-	root_->Add(new Button("www.ppsspp.org", new AnchorLayoutParams(260, 64, 10, NONE, NONE, 158, false)))->OnClick.Handle(this, &CreditsScreen::OnPPSSPPOrg);
+	if(g_Config.languageIni == "zh_CN") {
+	  root_->Add(new Button(g->T("PPSSPP Chinese Forum"), new AnchorLayoutParams(260, 64, 10, NONE, NONE, 84, false)))->OnClick.Handle(this, &CreditsScreen::OnChineseForum);
+	  root_->Add(new Button(g->T("PPSSPP Forums"), new AnchorLayoutParams(260, 64, 10, NONE, NONE, 154, false)))->OnClick.Handle(this, &CreditsScreen::OnForums);
+	  root_->Add(new Button("www.ppsspp.org", new AnchorLayoutParams(260, 64, 10, NONE, NONE, 228, false)))->OnClick.Handle(this, &CreditsScreen::OnPPSSPPOrg);
+	}
+	else {
+	  root_->Add(new Button(g->T("PPSSPP Forums"), new AnchorLayoutParams(260, 64, 10, NONE, NONE, 84, false)))->OnClick.Handle(this, &CreditsScreen::OnForums);
+	  root_->Add(new Button("www.ppsspp.org", new AnchorLayoutParams(260, 64, 10, NONE, NONE, 158, false)))->OnClick.Handle(this, &CreditsScreen::OnPPSSPPOrg);
+	}
 #ifdef GOLD
 	root_->Add(new ImageView(I_ICONGOLD, new AnchorLayoutParams(100, 64, 10, 10, NONE, NONE, false)));
 #else
@@ -376,6 +383,11 @@ UI::EventReturn CreditsScreen::OnPPSSPPOrg(UI::EventParams &e) {
 
 UI::EventReturn CreditsScreen::OnForums(UI::EventParams &e) {
 	LaunchBrowser("http://forums.ppsspp.org");
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn CreditsScreen::OnChineseForum(UI::EventParams &e) {
+	LaunchBrowser("http://tieba.baidu.com/f?ie=utf-8&kw=ppsspp");
 	return UI::EVENT_DONE;
 }
 

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -103,6 +103,7 @@ private:
 	UI::EventReturn OnSupport(UI::EventParams &e);
 	UI::EventReturn OnPPSSPPOrg(UI::EventParams &e);
 	UI::EventReturn OnForums(UI::EventParams &e);
+	UI::EventReturn OnChineseForum(UI::EventParams &e);
 
 	int frames_;
 };


### PR DESCRIPTION
Many Chinese people cannot go to offical forum.
http://tieba.baidu.com/f?ie=utf-8&kw=ppsspp is best for them
When select zh_CN lanauge,will display the link.
![2](https://f.cloud.github.com/assets/2177532/1006676/014f34fe-0aec-11e3-9801-14a8143f91ba.jpg)
