### PR TITLE
Display group name for sceNetAdhocctlConnect

### DIFF
--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -384,7 +384,12 @@ int sceNetAdhocctlGetScanInfo() {
 }
 
 int sceNetAdhocctlConnect(u32 ptrToGroupName) {
-	ERROR_LOG(HLE, "UNIMPL sceNetAdhocctlConnect(%x)", ptrToGroupName);
+	if (Memory::IsValidAddress(ptrToGroupName))
+	{
+		ERROR_LOG(HLE, "UNIMPL sceNetAdhocctlConnect(groupName=%s)", Memory::GetCharPointer(ptrToGroupName));
+	}
+	else
+		ERROR_LOG(HLE, "UNIMPL sceNetAdhocctlConnect(%x)", ptrToGroupName);
 	__UpdateAdhocctlHandlers(0, ERROR_NET_ADHOCCTL_WLAN_SWITCH_OFF);
 
 	return 0;


### PR DESCRIPTION
I noticed the God Eater 2 demo used this function, so I thought it might be nice for curious users like me to see the group name for this function.

The demo thinks the wireless switch isn't on (because of ERROR_NET_ADHOCCTL_WLAN_SWITCH_OFF), but since PPSSPP doesn't really have a full sceNet implementation yet that error should be okay for now.

![adhoc](https://f.cloud.github.com/assets/1909938/1013109/f6126b8c-0b7d-11e3-9782-c4202de21859.jpg)
