### PR TITLE
Add a bunch of HLE funcs + fix bad reloc masking and warnings

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -127,7 +127,7 @@ void ARMXEmitter::MOVI2F(ARMReg dest, float val, ARMReg tempReg, bool negate)
 		// VFP Encoding for Imms: <7> Not(<6>) Repeat(<6>,5) <5:0> Zeros(19)
 		bool bit6 = (conv.u & 0x40000000) == 0x40000000;
 		bool canEncode = true;
-		for (u32 mask = 0x20000000; mask >= 0x2000000; mask >>= 1)
+		for (u32 mask = 0x20000000; mask >= 0x02000000; mask >>= 1)
 		{
 			if (((conv.u & mask) == mask) == bit6)
 				canEncode = false;
@@ -136,7 +136,7 @@ void ARMXEmitter::MOVI2F(ARMReg dest, float val, ARMReg tempReg, bool negate)
 		{
 			u32 imm8 = (conv.u & 0x80000000) >> 24; // sign bit
 			imm8 |= (!bit6 << 6);
-			imm8 |= (conv.u & 0x1F80000) >> 19;
+			imm8 |= (conv.u & 0x01F80000) >> 19;
 			VMOV(dest, IMM(imm8));
 			return;
 		}
@@ -434,7 +434,7 @@ void ARMXEmitter::B (const void *fnptr)
 
 void ARMXEmitter::B(ARMReg src)
 {
-	Write32(condition | 0x12FFF10 | src);
+	Write32(condition | 0x012FFF10 | src);
 }
 
 bool ARMXEmitter::BLInRange(const void *fnptr) {
@@ -455,7 +455,7 @@ void ARMXEmitter::BL(const void *fnptr)
 }
 void ARMXEmitter::BL(ARMReg src)
 {
-	Write32(condition | 0x12FFF30 | src);
+	Write32(condition | 0x012FFF30 | src);
 }
 void ARMXEmitter::PUSH(const int num, ...)
 {
@@ -1104,7 +1104,7 @@ void ARMXEmitter::VSTR(ARMReg Src, ARMReg Base, s16 offset)
 }
 
 void ARMXEmitter::VMRS_APSR() {
-	Write32(condition | 0xEF10A10 | (15 << 12));
+	Write32(condition | 0x0EF10A10 | (15 << 12));
 }
 void ARMXEmitter::VMRS(ARMReg Rt) {
 	Write32(condition | (0xEF << 20) | (1 << 16) | (Rt << 12) | 0xA10);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -126,17 +126,17 @@ namespace
 
 	int GetSDKMainVersion(int sdkVersion)
 	{
-		if(sdkVersion > 0x307FFFF)
+		if(sdkVersion > 0x0307FFFF)
 			return 6;
-		if(sdkVersion > 0x300FFFF)
+		if(sdkVersion > 0x0300FFFF)
 			return 5;
-		if(sdkVersion > 0x206FFFF)
+		if(sdkVersion > 0x0206FFFF)
 			return 4;
-		if(sdkVersion > 0x205FFFF)
+		if(sdkVersion > 0x0205FFFF)
 			return 3;
-		if(sdkVersion >= 0x2000000)
+		if(sdkVersion >= 0x02000000)
 			return 2;
-		if(sdkVersion >= 0x1000000)
+		if(sdkVersion >= 0x01000000)
 			return 1;
 		return 0;
 	};

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -91,7 +91,7 @@ void ElfReader::LoadRelocations(Elf32_Rel *rels, int numRelocs)
 			//add on to put in correct address space
 			if (log)
 				DEBUG_LOG(LOADER,"j/jal reloc %08x", addr);
-			op = (op & 0xFC000000) | (((op&0x03FFFFFF)+(relocateTo>>2))&0x03FFFFFFF);
+			op = (op & 0xFC000000) | (((op&0x03FFFFFF)+(relocateTo>>2))&0x03FFFFFF);
 			break;
 
 		case R_MIPS_HI16: //lui part of lui-addiu pairs
@@ -288,7 +288,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 			case 3: // R_MIPS_26
 			case 6: // R_MIPS_J26
 			case 7: // R_MIPS_JAL26
-				op = (op&0xFC000000) | (((op&0x03FFFFFF)+(relocate_to>>2))&0x03FFFFFFF);
+				op = (op&0xFC000000) | (((op&0x03FFFFFF)+(relocate_to>>2))&0x03FFFFFF);
 				break;
 			case 4: // R_MIPS_HI16
 				addr = ((op<<16)+lo16)+relocate_to;
@@ -297,7 +297,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 				op = (op&0xffff0000) | (addr>>16 );
 				break;
 			case 1:
-			case 5: // R)MIPS_LO16
+			case 5: // R_MIPS_LO16
 				op = (op&0xffff0000) | (((op&0xffff)+relocate_to)&0xffff);
 				break;
 			default:

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -36,10 +36,10 @@ struct HDRemaster {
 // TODO: Use UMD_DATA.bin to differentiate the Eiyuu games from the regular PSP editions.
 // TODO: Do all of the remasters aside from Monster Hunter/Shin Sangoku use double texture coordinates?
 const struct HDRemaster g_HDRemasters[] = {
-	{ "NPJB40001", 0x4000000, false }, // MONSTER HUNTER PORTABLE 3rd HD Ver.
-	{ "NPJB40002", 0x4000000, true }, // K-ON Houkago Live HD Ver
-	{ "NPJB40003", 0x4000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-	// { "ULJM05170", 0x4000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
-	// { "ULJM05277", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, game needs 76 MB
-	// { "ULJM05353", 0x4C00000, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, game needs 76 MB
+	{ "NPJB40001", 0x04000000, false }, // MONSTER HUNTER PORTABLE 3rd HD Ver.
+	{ "NPJB40002", 0x04000000, true }, // K-ON Houkago Live HD Ver
+	{ "NPJB40003", 0x04000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
+	// { "ULJM05170", 0x04000000, true }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
+	// { "ULJM05277", 0x04C00000, true }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition, game needs 76 MB
+	// { "ULJM05353", 0x04C00000, true }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition, game needs 76 MB
 };

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -128,14 +128,40 @@ const HLEFunction IoFileMgrForKernel[] =
 	{0xe3eb004c, 0, "sceIoDread"},
 	{0xeb092469, 0, "sceIoDclose"},
 	{0x109f50bc, 0, "sceIoOpen"},
+	{0x6a638d83, 0, "sceIoRead"},
+	{0x42ec03ac, 0, "sceIoWrite"},
+	{0x68963324, 0, "sceIoLseek32"},
+	{0x27eb27b8, 0, "sceIoLseek"},
 	{0x810c4bc3, 0, "sceIoClose"},
 	{0x779103a0, 0, "sceIoRename"},
+	{0xf27a9c51, 0, "sceIoRemove"},
+	{0x55f4717d, 0, "sceIoChdir"},
+	{0x06a70004, 0, "sceIoMkdir"},
+	{0x1117c65f, 0, "sceIoRmdir"},
+	{0x54f5fb11, 0, "sceIoDevctl"},
+	{0x63632449, 0, "sceIoIoctl"},
+	{0xab96437f, 0, "sceIoSync"},
+	{0xb2a628c1, 0, "sceIoAssign"},
+	{0x6d08a871, 0, "sceIoUnassign"},
+	{0xace946e8, 0, "sceIoGetstat"},
+	{0xb8a740f4, 0, "sceIoChstat"},
+	{0xa0b5a7c2, 0, "sceIoReadAsync"},
+	{0x3251ea56, 0, "sceIoPollAsync"},
+	{0xe23eec33, 0, "sceIoWaitAsync"},
+	{0x35dbd746, 0, "sceIoWaitAsyncCB"},
+	{0xbd17474f, 0, "IoFileMgrForKernel_BD17474F"},
+	{0x76da16e3, 0, "IoFileMgrForKernel_76DA16E3"},
 };
 const HLEFunction StdioForKernel[] = 
 {
 	{0x98220F3E, 0, "sceKernelStdoutReopen"},
 	{0xFB5380C5, 0, "sceKernelStderrReopen"},
+	{0xcab439df, 0, "printf"},
 	{0x2CCF071A, 0, "fdprintf"},
+	{0xd97c8cb9, 0, "puts"},
+	{0x172D316E, 0, "sceKernelStdin"},
+	{0xA6BAB2E9, 0, "sceKernelStdout"},
+	{0xF78BA90A, 0, "sceKernelStderr"},
 };
 const HLEFunction LoadCoreForKernel[] = 
 {
@@ -169,6 +195,7 @@ const HLEFunction LoadCoreForKernel[] =
 	{0x82CE54ED, 0, "sceKernelModuleCount"},
 	{0xC0584F0C, 0, "sceKernelGetModuleList"},
 	{0xCF8A41B1, WrapU_C<sceKernelFindModuleByName>,"sceKernelFindModuleByName"},
+	{0xb95fa50d, 0, "LoadCoreForKernel_B95FA50D"},
 };
 
 

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -41,6 +41,7 @@ const HLEFunction sceAudiocodec[] = {
 	{0x3A20A200, 0, "sceAudiocodecGetEDRAM"},
 	{0x29681260, 0, "sceAudiocodecReleaseEDRAM"},
 	{0x9D3F790C, 0, "sceAudiocodecCheckNeedMem"},
+	{0x59176a0f, 0, "sceAudiocodec_59176A0F"},
 };
 
 void Register_sceAudiocodec()

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -304,6 +304,7 @@ const HLEFunction sceHttp[] = {
 	{0x1F0FC3E3,WrapI_IU<sceHttpSetRecvTimeOut>,"sceHttpSetRecvTimeOut"},
 	{0xDB266CCF,WrapI_IUU<sceHttpGetAllHeader>,"sceHttpGetAllHeader"},
 	{0x0282A3BD,WrapI_IU64<sceHttpGetContentLength>,"sceHttpGetContentLength"},
+	{0x7774bf4c,0,"sceHttpAddCookie"},
 	{0x68AB0F86,0,"sceHttpsInitWithPath"},
 	{0xB3FAF831,0,"sceHttpsDisableOption"},
 	{0x2255551E,0,"sceHttpGetNetworkPspError"},

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1936,9 +1936,15 @@ void Register_IoFileMgrForUser() {
 const HLEFunction StdioForUser[] = {
 	{ 0x172D316E, &WrapU_V<sceKernelStdin>, "sceKernelStdin" },
 	{ 0xA6BAB2E9, &WrapU_V<sceKernelStdout>, "sceKernelStdout" },
-	{ 0xF78BA90A, &WrapU_V<sceKernelStderr>, "sceKernelStderr" }, 
+	{ 0xF78BA90A, &WrapU_V<sceKernelStderr>, "sceKernelStderr" },
 	{ 0x432D8F5C, &WrapU_U<sceKernelRegisterStdoutPipe>, "sceKernelRegisterStdoutPipe" },
 	{ 0x6F797E03, &WrapU_U<sceKernelRegisterStderrPipe>, "sceKernelRegisterStderrPipe" },
+	{ 0xa46785c9, 0, "sceKernelStdioSendChar" },
+	{ 0x0cbb0571, 0, "sceKernelStdioLseek" },
+	{ 0x3054d478, 0, "sceKernelStdioRead" },
+	{ 0xa3b931db, 0, "sceKernelStdioWrite" },
+	{ 0x924aba61, 0, "sceKernelStdioOpen" },
+	{ 0x9d061c19, 0, "sceKernelStdioClose" },
 };
 
 void Register_StdioForUser() {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1788,7 +1788,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		break;
 
 	//Unknown command, always expects return value of 1 according to JPCSP, used by Pangya Fantasy Golf.
-	case 0x1f30003:
+	case 0x01f30003:
 		INFO_LOG(HLE, "sceIoIoCtl: Unknown cmd %08x always returns 1", cmd);
 		if(inlen != 4 || outlen != 1 || Memory::Read_U32(indataPtr) != outlen) {
 			INFO_LOG(HLE, "sceIoIoCtl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outlen %08x has invalid parameters", id, cmd, indataPtr, inlen, outdataPtr, outlen);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -866,11 +866,21 @@ const HLEFunction UtilsForKernel[] = {
 	{0x78934841, 0, "sceKernelGzipDecompress"},
 	{0xe8db3ce6, 0, "sceKernelDeflateDecompress"},
 	{0x840259f1, 0, "sceKernelUtilsSha1Digest"},
+	{0x9e5c5086, 0, "sceKernelUtilsMd5BlockInit"},
+	{0x61e1e525, 0, "sceKernelUtilsMd5BlockUpdate"},
+	{0xb8d24e78, 0, "sceKernelUtilsMd5BlockResult"},
+	{0xc8186a58, 0, "sceKernelUtilsMd5Digest"},
 	{0x6c6887ee, 0, "UtilsForKernel_6C6887EE"},
 	{0x91e4f6a7, 0, "sceKernelLibcClock"},
+	{0x27cc57f0, 0, "sceKernelLibcTime"},
 	{0x79d1c3fa, 0, "sceKernelDcacheWritebackAll"},
+	{0x3ee30821, 0, "sceKernelDcacheWritebackRange"},
 	{0x34b9fa9e, 0, "sceKernelDcacheWritebackInvalidateRange"},
+	{0xb435dec5, 0, "sceKernelDcacheWritebackInvalidateAll"},
+	{0xbfa98062, 0, "sceKernelDcacheInvalidateRange"},
 	{0x920f104a, 0, "sceKernelIcacheInvalidateAll"},
+	{0xe860e75e, 0, "sceKernelUtilsMt19937Init"},
+	{0x06fb8a63, 0, "sceKernelUtilsMt19937UInt"},
 };
 
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -655,19 +655,19 @@ void sceKernelSetCompiledSdkVersion(int sdkVersion)
 	bool valiSDK = false;
 	switch(sdkMainVersion)
 	{
-	case 0x1000000:
-	case 0x1050000:
-	case 0x2000000:
-	case 0x2050000:
-	case 0x2060000:
-	case 0x2070000:
-	case 0x2080000:
-	case 0x3000000:
-	case 0x3010000:
-	case 0x3030000:
-	case 0x3040000:
-	case 0x3050000:
-	case 0x3060000:
+	case 0x01000000:
+	case 0x01050000:
+	case 0x02000000:
+	case 0x02050000:
+	case 0x02060000:
+	case 0x02070000:
+	case 0x02080000:
+	case 0x03000000:
+	case 0x03010000:
+	case 0x03030000:
+	case 0x03040000:
+	case 0x03050000:
+	case 0x03060000:
 		valiSDK = true;
 		break;
 	default:
@@ -690,7 +690,7 @@ void sceKernelSetCompiledSdkVersion(int sdkVersion)
 void sceKernelSetCompiledSdkVersion370(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x3070000)
+	if(sdkMainVersion == 0x03070000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -705,7 +705,7 @@ void sceKernelSetCompiledSdkVersion370(int sdkVersion)
 void sceKernelSetCompiledSdkVersion380_390(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x3080000 || sdkMainVersion == 0x3090000)
+	if(sdkMainVersion == 0x03080000 || sdkMainVersion == 0x03090000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -720,11 +720,11 @@ void sceKernelSetCompiledSdkVersion380_390(int sdkVersion)
 void sceKernelSetCompiledSdkVersion395(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFFFF00;
-	if(sdkMainVersion == 0x4000000
-			|| sdkMainVersion == 0x4000100
-			|| sdkMainVersion == 0x4000500
-			|| sdkMainVersion == 0x3090500
-			|| sdkMainVersion == 0x3090600)
+	if(sdkMainVersion == 0x04000000
+			|| sdkMainVersion == 0x04000100
+			|| sdkMainVersion == 0x04000500
+			|| sdkMainVersion == 0x03090500
+			|| sdkMainVersion == 0x03090600)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -739,9 +739,9 @@ void sceKernelSetCompiledSdkVersion395(int sdkVersion)
 void sceKernelSetCompiledSdkVersion600_602(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x6010000
-			|| sdkMainVersion == 0x6000000
-			|| sdkMainVersion == 0x6020000)
+	if(sdkMainVersion == 0x06010000
+			|| sdkMainVersion == 0x06000000
+			|| sdkMainVersion == 0x06020000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -756,8 +756,8 @@ void sceKernelSetCompiledSdkVersion600_602(int sdkVersion)
 void sceKernelSetCompiledSdkVersion500_505(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x5000000
-			|| sdkMainVersion == 0x5050000)
+	if(sdkMainVersion == 0x05000000
+			|| sdkMainVersion == 0x05050000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -772,8 +772,8 @@ void sceKernelSetCompiledSdkVersion500_505(int sdkVersion)
 void sceKernelSetCompiledSdkVersion401_402(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x4010000
-			|| sdkMainVersion == 0x4020000)
+	if(sdkMainVersion == 0x04010000
+			|| sdkMainVersion == 0x04020000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -788,7 +788,7 @@ void sceKernelSetCompiledSdkVersion401_402(int sdkVersion)
 void sceKernelSetCompiledSdkVersion507(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x5070000)
+	if(sdkMainVersion == 0x05070000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -803,9 +803,9 @@ void sceKernelSetCompiledSdkVersion507(int sdkVersion)
 void sceKernelSetCompiledSdkVersion603_605(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x6040000
-			|| sdkMainVersion == 0x6030000
-			|| sdkMainVersion == 0x6050000)
+	if(sdkMainVersion == 0x06040000
+			|| sdkMainVersion == 0x06030000
+			|| sdkMainVersion == 0x06050000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;
@@ -820,7 +820,7 @@ void sceKernelSetCompiledSdkVersion603_605(int sdkVersion)
 void sceKernelSetCompiledSdkVersion606(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
-	if(sdkMainVersion == 0x6060000)
+	if(sdkMainVersion == 0x06060000)
 	{
 		sdkVersion_ = sdkVersion;
 		flags_ |=  SCE_KERNEL_HASCOMPILEDSDKVERSION;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1514,6 +1514,8 @@ const HLEFunction ModuleMgrForUser[] =
 	{0xfef27dc1,&WrapU_CU<sceKernelLoadModuleDNAS> , "sceKernelLoadModuleDNAS"},
 	{0x644395e2,0,"sceKernelGetModuleIdList"},
 	{0xf2d8d1b4,&WrapU_CUU<sceKernelLoadModuleNpDrm>,"sceKernelLoadModuleNpDrm"},
+	{0xe4c4211c,0,"ModuleMgrForUser_E4C4211C"},
+	{0xfbe27467,0,"ModuleMgrForUser_FBE27467"},
 };
 
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -964,7 +964,7 @@ bool __KernelLoadExec(const char *filename, u32 paramPtr, std::string *error_str
 
 	u32 handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
 
-	u8 *temp = new u8[(int)info.size + 0x1000000];
+	u8 *temp = new u8[(int)info.size + 0x01000000];
 
 	pspFileSystem.ReadFile(handle, temp, (size_t)info.size);
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1291,7 +1291,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 
 	u32 wantedSize = Memory::Read_U32(statusPtr);
 
-	if (sceKernelGetCompiledSdkVersion() > 0x2060010)
+	if (sceKernelGetCompiledSdkVersion() > 0x02060010)
 	{
 		if (wantedSize > THREADINFO_SIZE_AFTER_260)
 		{

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -617,7 +617,7 @@ u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr, u32 i
 		return 0;
 	}
 
-	if (frameWidth == 0) {  // wtf, go sudoku passes in 0xccccccccc
+	if (frameWidth == 0) {  // wtf, go sudoku passes in 0xcccccccc
 		if (!ctx->defaultFrameWidth) {
 			frameWidth = ctx->avc.avcDetailFrameWidth;
 		} else {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -682,8 +682,11 @@ const HLEFunction sceNetApctl[] = {
 	{0xb3edd0ec, WrapI_V<sceNetApctlTerm>, "sceNetApctlTerm"},
 	{0x2BEFDF23, 0, "sceNetApctlGetInfo"},
 	{0xa3e77e13, 0, "sceNetApctlScanSSID2"},
+	{0xe9b2e5e6, 0, "sceNetApctlScanUser"},
 	{0xf25a5006, 0, "sceNetApctlGetBSSDescIDList2"},
 	{0x2935c45b, 0, "sceNetApctlGetBSSDescEntry2"},
+	{0x04776994, 0, "sceNetApctlGetBSSDescEntryUser"},
+	{0x6bddcb8c, 0, "sceNetApctlGetBSSDescIDListUser"},
 };
 
 const HLEFunction sceWlanDrv[] = {

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -345,6 +345,7 @@ static const HLEFunction scePower[] = {
 	{0x28E12023,&WrapI_V<scePowerGetBatteryTemp>,"scePowerGetBatteryTemp"},
 	{0x862AE1A6,0,"scePowerGetBatteryElec"},
 	{0x483CE86B,0,"scePowerGetBatteryVolt"},
+	{0xcb49f5ce,0,"scePowerGetBatteryChargeCycle"},
 	{0x23436A4A,0,"scePowerGetInnerTemp"},
 	{0x0CD21B1F,0,"scePowerSetPowerSwMode"},
 	{0x165CE085,0,"scePowerGetPowerSwMode"},
@@ -370,9 +371,17 @@ static const HLEFunction scePower[] = {
 	{0x34f9c463,WrapU_V<scePowerGetPllClockFrequencyInt>,"scePowerGetPllClockFrequencyInt"},
 	{0xea382a27,WrapF_V<scePowerGetPllClockFrequencyFloat>,"scePowerGetPllClockFrequencyFloat"},
 	{0xebd177d6,WrapU_UUU<scePowerSetClockFrequency>,"scePower_EBD177D6"}, // This is also the same as SetClockFrequency
-	{0x469989ad,WrapU_UUU<scePowerSetClockFrequency>,"scePower_469989ad"},  // This is also the same as SetClockFrequency
+	{0x469989ad,WrapU_UUU<scePowerSetClockFrequency>,"scePower_469989ad"}, // This is also the same as SetClockFrequency
+	{0x545a7f3c,0,"scePower_545A7F3C"}, // TODO: Supposedly the same as SetClockFrequency also?
+	{0xa4e93389,0,"scePower_A4E93389"}, // TODO: Supposedly the same as SetClockFrequency also?
 	{0xa85880d0,WrapU_V<IsPSPNonFat>,"scePower_a85880d0_IsPSPNonFat"},
 	{0x3951af53,0,"scePowerWaitRequestCompletion"},
+	{0x0442d852,0,"scePowerRequestColdReset"},
+	{0xbafa3df0,0,"scePowerGetCallbackMode"},
+	{0xa9d22232,0,"scePowerSetCallbackMode"},
+	{0x23c31ffe,0,"scePowerVolatileMemLock"},
+	{0xfa97a599,0,"scePowerVolatileMemTryLock"},
+	{0xb3edd801,0,"scePowerVolatileMemUnlock"},
 };
 
 //890129c in tyshooter looks bogus

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1273,6 +1273,8 @@ const HLEFunction scePsmf[] = {
 	{0x4E624A34, WrapU_UIU<scePsmfGetEPWithId>, "scePsmfGetEPWithId"},
 	{0x7C0E7AC3, WrapU_UUU<scePsmfGetEPWithTimestamp>, "scePsmfGetEPWithTimestamp"},
 	{0x5F457515, WrapU_UU<scePsmfGetEPidWithTimestamp>, "scePsmfGetEPidWithTimestamp"},
+	{0x43ac7dbb, 0, "scePsmf_43AC7DBB"},
+	{0xde78e9fc, 0, "scePsmf_DE78E9FC"},
 };
 
 const HLEFunction scePsmfPlayer[] =

--- a/Core/HLE/sceUsb.cpp
+++ b/Core/HLE/sceUsb.cpp
@@ -50,6 +50,7 @@ const HLEFunction sceUsb[] =
 	{0x586db82c, WrapU_V<sceUsbActivate>, "sceUsbActivate"},
 	{0xc572a9c8, 0, "sceUsbDeactivate"},
 	{0x5be0e002, 0, "sceUsbWaitState"},
+	{0x616f2b61, 0, "sceUsbWaitStateCB"},
 	{0x1c360735, 0, "sceUsbWaitCancel"},
 };
 

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -579,6 +579,11 @@ const HLEFunction sceUtility[] =
 	{0xf5ce1134, 0, "sceUtilityHtmlViewerShutdownStart"},
 	{0x05afb9e4, 0, "sceUtilityHtmlViewerUpdate"},
 
+	{0x16a1a8d8, 0, "sceUtilityAuthDialogGetStatus"},
+	{0x943cba46, 0, "sceUtilityAuthDialogInitStart"},
+	{0x0f3eeaac, 0, "sceUtilityAuthDialogShutdownStart"},
+	{0x147f7c85, 0, "sceUtilityAuthDialogUpdate"},
+
 	{0xc629af26, &WrapU_U<sceUtilityLoadAvModule>, "sceUtilityLoadAvModule"},
 	{0xf7d8d092, &WrapU_U<sceUtilityUnloadAvModule>, "sceUtilityUnloadAvModule"},
 
@@ -639,6 +644,32 @@ const HLEFunction sceUtility[] =
 	{0x4B0A8FE5, 0, "sceUtilityRssSubscriberInitStart"},
 	{0xA084E056, 0, "sceUtilityRssSubscriberUpdate"},
 	{0x2B96173B, 0, "sceUtilityRssSubscriberGetStatus"},
+
+	{0x149a7895, 0, "sceUtilityDNASShutdownStart"},
+	{0xdde5389d, 0, "sceUtilityDNASInitStart"},
+	{0x4a833ba4, 0, "sceUtilityDNASUpdate"},
+	{0xa50e5b30, 0, "sceUtilityDNASGetStatus"},
+
+	{0xe7b778d8, 0, "sceUtilityRssReaderShutdownStart"},
+	{0x81c44706, 0, "sceUtilityRssReaderInitStart"},
+	{0x6f56f9cf, 0, "sceUtilityRssReaderUpdate"},
+	{0x8326ab05, 0, "sceUtilityRssReaderGetStatus"},
+	{0xb0fb7ff5, 0, "sceUtilityRssReaderContStart"},
+
+	{0xbc6b6296, 0, "sceNetplayDialogShutdownStart"},
+	{0x3ad50ae7, 0, "sceNetplayDialogInitStart"},
+	{0x417bed54, 0, "sceNetplayDialogUpdate"},
+	{0xb6cee597, 0, "sceNetplayDialogGetStatus"},
+
+	{0x28d35634, 0, "sceUtility_28D35634"},
+	{0x6f56f9cf, 0, "sceUtility_6F56F9CF"},
+	{0x70267adf, 0, "sceUtility_70267ADF"},
+	{0x81c44706, 0, "sceUtility_81C44706"},
+	{0x8326ab05, 0, "sceUtility_8326AB05"},
+	{0xb0fb7ff5, 0, "sceUtility_B0fB7FF5"},
+	{0xe7b778d8, 0, "sceUtility_E7B778D8"},
+	{0xece1d3e5, 0, "sceUtility_ECE1D3E5"},
+	{0xef3582b2, 0, "sceUtility_EF3582B2"},
 
 	{0x0e0c27af, 0, "sceUtility_0E0C27AF"},
 };

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -250,7 +250,7 @@ static int getReleaseRate(int bitfield2) {
 	if (getReleaseType(bitfield2) == PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE) {
 		return (0x40000000 >> (n + 2));
 	}
-	return (0x8000000 >> n);
+	return (0x08000000 >> n);
 }
 
 static int getSustainLevel(int bitfield1) {

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -200,7 +200,7 @@ namespace MIPSComp
 				                      : (op - (4<<26) + 3)))
 				{
 					EatInstruction(nextOp);
-					nextOp = ((load ? 35 : 43) << 26) | ((isLeft ? nextOp : op) & 0x3FFFFFF); //lw, sw
+					nextOp = ((load ? 35 : 43) << 26) | ((isLeft ? nextOp : op) & 0x03FFFFFF); //lw, sw
 					Comp_ITypeMem(nextOp);
 					return;
 				}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -276,7 +276,7 @@ namespace MIPSAnalyst
 				if (flags & IN_IMM16)
 					validbits&=~0xFFFF;
 				if (flags & IN_IMM26)
-					validbits&=~0x3FFFFFF;
+					validbits&=~0x03FFFFFF;
 				hash = __rotl(hash,13);
 				hash ^= (instr&validbits);
 			}

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -294,7 +294,7 @@ bool CMipsInstruction::Validate()
  
 		if (Opcode.flags & O_IPCA)	// absolute value >> 2)
 		{
-			Vars.Immediate = (Vars.Immediate >> 2) & 0x3FFFFFF;
+			Vars.Immediate = (Vars.Immediate >> 2) & 0x03FFFFFF;
 		} else if (Opcode.flags & O_IPCR)	// relative 16 bit value
 		{
 			int num = (Vars.Immediate-RamPos-4);
@@ -319,28 +319,28 @@ bool CMipsInstruction::Validate()
 			Vars.Immediate &= 0x1F;
 			break;
 		case MIPS_IMMEDIATE16:
-			if (abs(Vars.Immediate) > 0xFFFF)
+			if (abs(Vars.Immediate) > 0x0000FFFF)
 			{
 			//	QueueError(ERROR_ERROR,"Immediate value %04X out of range",Vars.OriginalImmediate);
 				return false;
 			}
-			Vars.Immediate &= 0xFFFF;
+			Vars.Immediate &= 0x0000FFFF;
 			break;
 		case MIPS_IMMEDIATE20:
-			if (abs(Vars.Immediate) > 0xFFFFF)
+			if (abs(Vars.Immediate) > 0x000FFFFF)
 			{
 			//	QueueError(ERROR_ERROR,"Immediate value %08X out of range",Vars.OriginalImmediate);
 				return false;
 			}
-			Vars.Immediate &= 0xFFFFF;
+			Vars.Immediate &= 0x000FFFFF;
 			break;
 		case MIPS_IMMEDIATE26:
-			if (abs(Vars.Immediate) > 0x3FFFFFF)
+			if (abs(Vars.Immediate) > 0x03FFFFFF)
 			{
 		//		QueueError(ERROR_ERROR,"Immediate value %08X out of range",Vars.OriginalImmediate);
 				return false;
 			}
-			Vars.Immediate &= 0x3FFFFFF;
+			Vars.Immediate &= 0x03FFFFFF;
 			break;
 		}
 	}
@@ -393,16 +393,16 @@ void CMipsInstruction::Encode()
 	switch (Vars.ImmediateType)
 	{
 	case MIPS_IMMEDIATE5:
-		encoding |= ((Vars.Immediate & 0x1F) << 6);
+		encoding |= (Vars.Immediate & 0x0000001F) << 6;
 		break;
 	case MIPS_IMMEDIATE16:
-		encoding |= (Vars.Immediate & 0xFFFF);
+		encoding |= (Vars.Immediate & 0x0000FFFF);
 		break;
 	case MIPS_IMMEDIATE20:
-		encoding |= (Vars.Immediate & 0xFFFFF) << 6;
+		encoding |= (Vars.Immediate & 0x000FFFFF) << 6;
 		break;
 	case MIPS_IMMEDIATE26:
-		encoding |= Vars.Immediate & 0x3FFFFFF;
+		encoding |= (Vars.Immediate & 0x03FFFFFF);
 		break;
 	}
 }

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -318,7 +318,7 @@ namespace MIPSDis
 
 	void Dis_JumpType(u32 op, char *out)
 	{
-		u32 off = ((op & 0x3FFFFFF) << 2);
+		u32 off = ((op & 0x03FFFFFF) << 2);
 		u32 addr = (disPC & 0xF0000000) | off;
 		const char *name = MIPSGetName(op);
 		sprintf(out, "%s\t->$%08x",name,addr);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -264,7 +264,7 @@ namespace MIPSInt
 		if (mipsr4k.inDelaySlot)
 			_dbg_assert_msg_(CPU,0,"Jump in delay slot :(");
 
-		u32 off = ((op & 0x3FFFFFF) << 2);
+		u32 off = ((op & 0x03FFFFFF) << 2);
 		u32 addr = (currentMIPS->pc & 0xF0000000) | off;
 
 		switch (op>>26) 

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -23,7 +23,7 @@
 #include <limits>
 
 #define V(i)   (currentMIPS->v[i])
-#define VI(i)   (*(u32*)(&(currentMIPS->v[i])))
+#define VI(i)  (currentMIPS->vi[i])
 
 void GetVectorRegs(u8 regs[4], VectorSize N, int vectorReg) {
 	int mtx = (vectorReg >> 2) & 7;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -135,7 +135,7 @@ void CPU_Init() {
 
 	// Default memory settings
 	// Seems to be the safest place currently..
-	Memory::g_MemorySize = 0x2000000; // 32 MB of ram by default
+	Memory::g_MemorySize = 0x02000000; // 32 MB of ram by default
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -76,7 +76,7 @@ enum {
 };
 
 static bool MaskedEqual(u32 addr1, u32 addr2) {
-	return (addr1 & 0x3FFFFFF) == (addr2 & 0x3FFFFFF);
+	return (addr1 & 0x03FFFFFF) == (addr2 & 0x03FFFFFF);
 }
 
 inline u16 RGBA8888toRGB565(u32 px) {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -130,7 +130,7 @@ void TextureCache::Decimate() {
 }
 
 void TextureCache::Invalidate(u32 addr, int size, GPUInvalidationType type) {
-	addr &= 0xFFFFFFF;
+	addr &= 0x0FFFFFFF;
 	u32 addr_end = addr + size;
 
 	// They could invalidate inside the texture, let's just give a bit of leeway.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -196,9 +196,9 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head) {
 
 	DisplayList &dl = dls[id];
 	dl.id = id;
-	dl.startpc = listpc & 0xFFFFFFF;
-	dl.pc = listpc & 0xFFFFFFF;
-	dl.stall = stall & 0xFFFFFFF;
+	dl.startpc = listpc & 0x0FFFFFFF;
+	dl.pc = listpc & 0x0FFFFFFF;
+	dl.stall = stall & 0x0FFFFFFF;
 	dl.subIntrBase = std::max(subIntrBase, -1);
 	dl.stackptr = 0;
 	dl.signal = PSP_GE_SIGNAL_NONE;
@@ -263,7 +263,7 @@ u32 GPUCommon::UpdateStall(int listid, u32 newstall) {
 	if (listid < 0 || listid >= DisplayListMaxCount || dls[listid].state == PSP_GE_DL_STATE_NONE)
 		return SCE_KERNEL_ERROR_INVALID_ID;
 
-	dls[listid].stall = newstall & 0xFFFFFFF;
+	dls[listid].stall = newstall & 0x0FFFFFFF;
 
 	if (dls[listid].signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
 		dls[listid].signal = PSP_GE_SIGNAL_HANDLER_SUSPEND;
@@ -412,7 +412,7 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 #endif
 
 	cycleLastPC = list.pc;
-	downcount = list.stall == 0 ? 0xFFFFFFF : (list.stall - list.pc) / 4;
+	downcount = list.stall == 0 ? 0x0FFFFFFF : (list.stall - list.pc) / 4;
 	list.state = PSP_GE_DL_STATE_RUNNING;
 	list.interrupted = false;
 
@@ -439,7 +439,7 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 
 		{
 			easy_guard innerGuard(listLock);
-			downcount = list.stall == 0 ? 0xFFFFFFF : (list.stall - list.pc) / 4;
+			downcount = list.stall == 0 ? 0x0FFFFFFF : (list.stall - list.pc) / 4;
 
 			if (gpuState == GPUSTATE_STALL && list.stall != list.pc) {
 				// Unstalled.
@@ -512,7 +512,7 @@ void GPUCommon::ReapplyGfxState() {
 void GPUCommon::ReapplyGfxStateInternal() {
 	// ShaderManager_DirtyShader();
 	// The commands are embedded in the command memory so we can just reexecute the words. Convenient.
-	// To be safe we pass 0xFFFFFFF as the diff.
+	// To be safe we pass 0xFFFFFFFF as the diff.
 	/*
 	ExecuteOp(gstate.cmdmem[GE_CMD_ALPHABLENDENABLE], 0xFFFFFFFF);
 	ExecuteOp(gstate.cmdmem[GE_CMD_ALPHATESTENABLE], 0xFFFFFFFF);

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -281,7 +281,7 @@ void CtrlMemView::onPaint(WPARAM wParam, LPARAM lParam)
                         sprintf(temp, "%s (0x%x b)", symbolMap.GetSymbolName(fn),symbolMap.GetSymbolSize(fn));
 					TextOut(hdc,200,rowY1,temp,(int)strlen(temp));
 
-					SetTextColor(hdc,0x0000000);
+					SetTextColor(hdc,0x000000);
 					
 					if (align==4)
 					{
@@ -464,7 +464,7 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			else
 			{
 				outputfile = fopen("Ram.dump","wb");		// Could also dump Vram, but not useful for now.
-				fwrite(Memory::GetPointer(0x08800000), 1, 0x1800000, outputfile); 
+				fwrite(Memory::GetPointer(0x08800000), 1, 0x01800000, outputfile);
 				fclose(outputfile);
 				break;
 			}

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -167,7 +167,7 @@ BOOL CVFPUDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					for (int row = 0; row<4; row++)
 					{
 						float val = mipsr4k.v[column*32+row+matrix*4];
-						u32 hex = *((u32*)&val);
+						u32 hex = mipsr4k.vi[column*32+row+matrix*4];
 						switch (mode)
 						{
 						case 0: temp_len = sprintf_s(temp,"%f",val); break;

--- a/ext/disarm.cpp
+++ b/ext/disarm.cpp
@@ -535,7 +535,7 @@ instr_disassemble(word instr, address addr, pDisOptions opts) {
 				mnemonic = "B";
 				format = "0";
 				break;
-			} else if ((instr & 0x0FFFFFF0) == 0x12FFF30) {
+			} else if ((instr & 0x0FFFFFF0) == 0x012FFF30) {
 				mnemonic = "BL";
 				format = "0";
 				break;


### PR DESCRIPTION
Heh, I thought the reporting thing was great.  Wish I'd known ahead of time.  Anyway, got a bunch of HLE reported, so added them (so we can see when they're called, at least for those who re-enable it.)  I noticed some were for games that are broken, and we'll get better logs too.

Also happened to notice that the R_MIPS_26 reloc mask was 0x03FFFFFFF.  That's 9 digits or 30 bits, and an overflow could incorrectly change a j to a jal or something.  Pretty sure it was wrong.

While I was at it, I did a pass on hex constants >= 6 digits in length in case there were others.

-[Unknown]
