### PR TITLE
Remove the gpu->Resized() on video play.

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -259,8 +259,6 @@ bool MediaEngine::openContext() {
 bool MediaEngine::loadStream(u8* buffer, int readSize, int RingbufferSize)
 {
 	closeMedia();
-	// force to clear the useless FBO
-	gpu->Resized();
 
 	m_videopts = 0;
 	m_audiopts = 0;


### PR DESCRIPTION
Doesn't seem necessary anymore, can cause blinking.  Or maybe it's needed for some game, but we'll have to find out.

May improve #3244.

-[Unknown]
