### PR TITLE
Cap imm branch instructions, reset compiling

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -31,15 +31,16 @@
 
 #include "Common/ArmEmitter.h"
 
-#define _RS ((op>>21) & 0x1F)
-#define _RT ((op>>16) & 0x1F)
-#define _RD ((op>>11) & 0x1F)
-#define _FS ((op>>11) & 0x1F)
-#define _FT ((op>>16) & 0x1F)
-#define _FD ((op>>6 ) & 0x1F)
-#define _POS  ((op>>6 ) & 0x1F)
-#define _SIZE ((op>>11 ) & 0x1F)
-#define _IMM16 (signed short)(op&0xFFFF)
+#define _RS MIPS_GET_RS(op)
+#define _RT MIPS_GET_RT(op)
+#define _RD MIPS_GET_RD(op)
+#define _FS MIPS_GET_FS(op)
+#define _FT MIPS_GET_FT(op)
+#define _FD MIPS_GET_FD(op)
+#define _SA MIPS_GET_SA(op)
+#define _POS  ((op>> 6) & 0x1F)
+#define _SIZE ((op>>11) & 0x1F)
+#define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
 
 #define LOOPOPTIMIZATION 0
@@ -60,8 +61,8 @@ void Jit::BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 		return;
 	}
 	int offset = _IMM16 << 2;
-	int rt = _RT;
-	int rs = _RS;
+	MIPSGPReg rt = _RT;
+	MIPSGPReg rs = _RS;
 	u32 targetAddr = js.compilerPC + offset + 4;
 		
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC+4);
@@ -120,7 +121,7 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, ArmGen::CCFlags cc, bool andLink, bool
 		return;
 	}
 	int offset = _IMM16 << 2;
-	int rs = _RS;
+	MIPSGPReg rs = _RS;
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
@@ -370,7 +371,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		ERROR_LOG_REPORT(JIT, "Branch in JumpReg delay slot at %08x in block starting at %08x", js.compilerPC, js.blockStart);
 		return;
 	}
-	int rs = _RS;
+	MIPSGPReg rs = _RS;
 
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -14,21 +14,26 @@
 
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
 #include "Core/Config.h"
 #include "Core/MIPS/MIPS.h"
+#include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/MIPS/MIPSTables.h"
 
-#include "ArmJit.h"
-#include "ArmRegCache.h"
+#include "Core/MIPS/ARM/ArmJit.h"
+#include "Core/MIPS/ARM/ArmRegCache.h"
 
-#define _RS   ((op>>21) & 0x1F)
-#define _RT   ((op>>16) & 0x1F)
-#define _RD   ((op>>11) & 0x1F)
-#define _FS   ((op>>11) & 0x1F)
-#define _FT   ((op>>16) & 0x1F)
-#define _FD   ((op>>6 ) & 0x1F)
-#define _POS  ((op>>6 ) & 0x1F)
+#define _RS MIPS_GET_RS(op)
+#define _RT MIPS_GET_RT(op)
+#define _RD MIPS_GET_RD(op)
+#define _FS MIPS_GET_FS(op)
+#define _FT MIPS_GET_FT(op)
+#define _FD MIPS_GET_FD(op)
+#define _SA MIPS_GET_SA(op)
+#define _POS  ((op>> 6) & 0x1F)
 #define _SIZE ((op>>11) & 0x1F)
+#define _IMM16 (signed short)(op & 0xFFFF)
+#define _IMM26 (op & 0x03FFFFFF)
 
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
@@ -84,7 +89,7 @@ void Jit::Comp_FPULS(MIPSOpcode op)
 
 	s32 offset = (s16)(op & 0xFFFF);
 	int ft = _FT;
-	int rs = _RS;
+	MIPSGPReg rs = _RS;
 	// u32 addr = R(rs) + offset;
 	// logBlocks = 1;
 	bool doCheck = false;
@@ -312,7 +317,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 	CONDITIONAL_DISABLE;
 
 	int fs = _FS;
-	int rt = _RT;
+	MIPSGPReg rt = _RT;
 
 	switch ((op >> 21) & 0x1f)
 	{

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -37,20 +37,25 @@
 // (pointer or data), we could avoid many BIC instructions.
 
 
-#include "../../MemMap.h"
-#include "../MIPSAnalyst.h"
-#include "../../Config.h"
-#include "ArmJit.h"
-#include "ArmRegCache.h"
+#include "Core/MemMap.h"
+#include "Core/Config.h"
+#include "Core/MIPS/MIPS.h"
+#include "Core/MIPS/MIPSAnalyst.h"
+#include "Core/MIPS/MIPSCodeUtils.h"
+#include "Core/MIPS/ARM/ArmJit.h"
+#include "Core/MIPS/ARM/ArmRegCache.h"
 
-#define _RS ((op>>21) & 0x1F)
-#define _RT ((op>>16) & 0x1F)
-#define _RD ((op>>11) & 0x1F)
-#define _FS ((op>>11) & 0x1F)
-#define _FT ((op>>16) & 0x1F)
-#define _FD ((op>>6 ) & 0x1F)
-#define _POS	((op>>6 ) & 0x1F)
-#define _SIZE ((op>>11 ) & 0x1F)
+#define _RS MIPS_GET_RS(op)
+#define _RT MIPS_GET_RT(op)
+#define _RD MIPS_GET_RD(op)
+#define _FS MIPS_GET_FS(op)
+#define _FT MIPS_GET_FT(op)
+#define _FD MIPS_GET_FD(op)
+#define _SA MIPS_GET_SA(op)
+#define _POS  ((op>> 6) & 0x1F)
+#define _SIZE ((op>>11) & 0x1F)
+#define _IMM16 (signed short)(op & 0xFFFF)
+#define _IMM26 (op & 0x03FFFFFF)
 
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
@@ -126,10 +131,10 @@ namespace MIPSComp
 		CONDITIONAL_DISABLE;
 		int offset = (signed short)(op&0xFFFF);
 		bool load = false;
-		int rt = _RT;
-		int rs = _RS;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
 		int o = op>>26;
-		if (((op >> 29) & 1) == 0 && rt == 0) {
+		if (((op >> 29) & 1) == 0 && rt == MIPS_REG_ZERO) {
 			// Don't load anything into $zr
 			return;
 		}

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -44,5 +44,4 @@
 
 namespace MIPSComp {
 extern Jit *jit;
-extern const float cst_constants[32];
 }

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -60,7 +60,7 @@ MIPSDebugInterface *currentDebugMIPS = &debugr4k;
 #define M_SQRT1_2  0.707106781186547524401f
 #endif
 
-extern const float cst_constants[32] = {
+const float cst_constants[32] = {
 	0,
 	std::numeric_limits<float>::max(),  // all these are verified on real PSP
 	sqrtf(2.0f),

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -24,7 +24,7 @@
 
 typedef Memory::Opcode MIPSOpcode;
 
-enum
+enum MIPSGPReg
 {
 	MIPS_REG_ZERO=0,
 	MIPS_REG_COMPILER_SCRATCH=1,
@@ -56,6 +56,7 @@ enum
 
 	// ID for mipscall "callback" is stored here - from JPCSP
 	MIPS_REG_CALL_ID=MIPS_REG_S0,
+	MIPS_REG_INVALID=-1,
 };
 
 enum

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -79,12 +79,12 @@ namespace MIPSAnalyst
 	void ScanForFunctions(u32 startAddr, u32 endAddr);
 	void CompileLeafs();
 
-	std::vector<int> GetInputRegs(MIPSOpcode op);
-	std::vector<int> GetOutputRegs(MIPSOpcode op);
+	std::vector<MIPSGPReg> GetInputRegs(MIPSOpcode op);
+	std::vector<MIPSGPReg> GetOutputRegs(MIPSOpcode op);
 
-	int GetOutGPReg(MIPSOpcode op);
-	bool ReadsFromGPReg(MIPSOpcode op, u32 reg);
-	bool IsDelaySlotNiceReg(MIPSOpcode branchOp, MIPSOpcode op, int reg1, int reg2 = 0);
+	MIPSGPReg GetOutGPReg(MIPSOpcode op);
+	bool ReadsFromGPReg(MIPSOpcode op, MIPSGPReg reg);
+	bool IsDelaySlotNiceReg(MIPSOpcode branchOp, MIPSOpcode op, MIPSGPReg reg1, MIPSGPReg reg2 = MIPS_REG_ZERO);
 	bool IsDelaySlotNiceVFPU(MIPSOpcode branchOp, MIPSOpcode op);
 	bool IsDelaySlotNiceFPU(MIPSOpcode branchOp, MIPSOpcode op);
 	bool IsSyscall(MIPSOpcode op);

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -38,11 +38,11 @@
 
 #define MIPS_GET_OP(op)   ((op>>26) & 0x3F)
 #define MIPS_GET_FUNC(op) (op & 0x3F)
-#define MIPS_GET_SA(op)   (op>>6 & 0x1F)
+#define MIPS_GET_SA(op)   ((op>>6) & 0x1F)
 
-#define MIPS_GET_RS(op) ((op>>21) & 0x1F)
-#define MIPS_GET_RT(op) ((op>>16) & 0x1F)
-#define MIPS_GET_RD(op) ((op>>11) & 0x1F)
+#define MIPS_GET_RS(op) MIPSGPReg((op>>21) & 0x1F)
+#define MIPS_GET_RT(op) MIPSGPReg((op>>16) & 0x1F)
+#define MIPS_GET_RD(op) MIPSGPReg((op>>11) & 0x1F)
 
 #define MIPS_GET_FS(op) ((op>>11) & 0x1F)
 #define MIPS_GET_FT(op) ((op>>16) & 0x1F)

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -15,20 +15,24 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Jit.h"
-#include "RegCache.h"
+#include "Core/MIPS/MIPSCodeUtils.h"
+#include "Core/MIPS/x86/Jit.h"
+#include "Core/MIPS/x86/RegCache.h"
 #include <algorithm>
 
 using namespace MIPSAnalyst;
-#define _RS ((op>>21) & 0x1F)
-#define _RT ((op>>16) & 0x1F)
-#define _RD ((op>>11) & 0x1F)
-#define _FS ((op>>11) & 0x1F)
-#define _FT ((op>>16) & 0x1F)
-#define _FD ((op>>6 ) & 0x1F)
-#define _SA ((op>>6 ) & 0x1F)
-#define _POS	((op>>6 ) & 0x1F)
-#define _SIZE ((op>>11 ) & 0x1F)
+
+#define _RS MIPS_GET_RS(op)
+#define _RT MIPS_GET_RT(op)
+#define _RD MIPS_GET_RD(op)
+#define _FS MIPS_GET_FS(op)
+#define _FT MIPS_GET_FT(op)
+#define _FD MIPS_GET_FD(op)
+#define _SA MIPS_GET_SA(op)
+#define _POS  ((op>> 6) & 0x1F)
+#define _SIZE ((op>>11) & 0x1F)
+#define _IMM16 (signed short)(op & 0xFFFF)
+#define _IMM26 (op & 0x03FFFFFF)
 
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
@@ -42,8 +46,8 @@ namespace MIPSComp
 	void Jit::CompImmLogic(MIPSOpcode op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &))
 	{
 		u32 uimm = (u16)(op & 0xFFFF);
-		int rt = _RT;
-		int rs = _RS;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
 		gpr.Lock(rt, rs);
 		gpr.BindToRegister(rt, rt == rs, true);
 		if (rt != rs)
@@ -55,15 +59,15 @@ namespace MIPSComp
 	void Jit::Comp_IType(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
-		s32 simm = (s32)(s16)(op & 0xFFFF);  // sign extension
+		s32 simm = (s32)_IMM16;  // sign extension
 		u32 uimm = op & 0xFFFF;
 		u32 suimm = (u32)(s32)simm;
 
-		int rt = _RT;
-		int rs = _RS;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
 
 		// noop, won't write to ZERO.
-		if (rt == 0)
+		if (rt == MIPS_REG_ZERO)
 			return;
 
 		switch (op >> 26) 
@@ -162,11 +166,11 @@ namespace MIPSComp
 	void Jit::Comp_RType2(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
-		int rs = _RS;
-		int rd = _RD;
+		MIPSGPReg rs = _RS;
+		MIPSGPReg rd = _RD;
 
 		// Don't change $zr.
-		if (rd == 0)
+		if (rd == MIPS_REG_ZERO)
 			return;
 
 		switch (op & 63)
@@ -268,9 +272,9 @@ namespace MIPSComp
 	//rd = rs X rt
 	void Jit::CompTriArith(MIPSOpcode op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &), u32 (*doImm)(const u32, const u32))
 	{
-		int rt = _RT;
-		int rs = _RS;
-		int rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
+		MIPSGPReg rd = _RD;
 
 		// Yes, this happens.  Let's make it fast.
 		if (doImm && gpr.IsImmediate(rs) && gpr.IsImmediate(rt))
@@ -281,19 +285,19 @@ namespace MIPSComp
 
 		// Act like zero was used if the operand is equivalent.  This happens.
 		if (gpr.IsImmediate(rs) && gpr.GetImmediate32(rs) == 0)
-			rs = 0;
+			rs = MIPS_REG_ZERO;
 		if (gpr.IsImmediate(rt) && gpr.GetImmediate32(rt) == 0)
-			rt = 0;
+			rt = MIPS_REG_ZERO;
 
 		gpr.Lock(rt, rs, rd);
 		// Optimize out operations against 0... and is the only one that isn't a MOV.
-		if (rt == 0 || (rs == 0 && doImm != &RType3_ImmSub))
+		if (rt == MIPS_REG_ZERO || (rs == MIPS_REG_ZERO && doImm != &RType3_ImmSub))
 		{
 			if (doImm == &RType3_ImmAnd)
 				gpr.SetImmediate32(rd, 0);
 			else
 			{
-				int rsource = rt == 0 ? rs : rt;
+				MIPSGPReg rsource = rt == MIPS_REG_ZERO ? rs : rt;
 				if (rsource != rd)
 				{
 					gpr.BindToRegister(rd, false, true);
@@ -327,12 +331,12 @@ namespace MIPSComp
 	{
 		CONDITIONAL_DISABLE
 		
-		int rt = _RT;
-		int rs = _RS;
-		int rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
+		MIPSGPReg rd = _RD;
 
 		// noop, won't write to ZERO.
-		if (rd == 0)
+		if (rd == MIPS_REG_ZERO)
 			return;
 
 		switch (op & 63)
@@ -451,7 +455,7 @@ namespace MIPSComp
 				gpr.SetImmediate32(rd, std::max((s32)gpr.GetImmediate32(rs), (s32)gpr.GetImmediate32(rt)));
 			else
 			{
-				int rsrc = rd == rt ? rs : rt;
+				MIPSGPReg rsrc = rd == rt ? rs : rt;
 				gpr.Lock(rd, rs, rt);
 				gpr.KillImmediate(rsrc, true, false);
 				gpr.BindToRegister(rd, rd == rs || rd == rt, true);
@@ -468,7 +472,7 @@ namespace MIPSComp
 				gpr.SetImmediate32(rd, std::min((s32)gpr.GetImmediate32(rs), (s32)gpr.GetImmediate32(rt)));
 			else
 			{
-				int rsrc = rd == rt ? rs : rt;
+				MIPSGPReg rsrc = rd == rt ? rs : rt;
 				gpr.Lock(rd, rs, rt);
 				gpr.KillImmediate(rsrc, true, false);
 				gpr.BindToRegister(rd, rd == rs || rd == rt, true);
@@ -509,8 +513,8 @@ namespace MIPSComp
 
 	void Jit::CompShiftImm(MIPSOpcode op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32))
 	{
-		int rd = _RD;
-		int rt = _RT;
+		MIPSGPReg rd = _RD;
+		MIPSGPReg rt = _RT;
 		int sa = _SA;
 
 		if (doImm && gpr.IsImmediate(rt))
@@ -530,9 +534,9 @@ namespace MIPSComp
 	// "over-shifts" work the same as on x86 - only bottom 5 bits are used to get the shift value
 	void Jit::CompShiftVar(MIPSOpcode op, void (XEmitter::*shift)(int, OpArg, OpArg), u32 (*doImm)(const u32, const u32))
 	{
-		int rd = _RD;
-		int rt = _RT;
-		int rs = _RS;
+		MIPSGPReg rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
 
 		if (doImm && gpr.IsImmediate(rs) && gpr.IsImmediate(rt))
 		{
@@ -566,12 +570,12 @@ namespace MIPSComp
 	void Jit::Comp_ShiftType(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
-		int rs = _RS;
-		int rd = _RD;
-		int fd = _FD;
+		int rs = (op>>21) & 0x1F;
+		MIPSGPReg rd = _RD;
+		int fd = (op>>6) & 0x1F;
 
 		// noop, won't write to ZERO.
-		if (rd == 0)
+		if (rd == MIPS_REG_ZERO)
 			return;
 
 		// WARNING : ROTR
@@ -594,15 +598,15 @@ namespace MIPSComp
 	void Jit::Comp_Special3(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
-		int rs = _RS;
-		int rt = _RT;
+		MIPSGPReg rs = _RS;
+		MIPSGPReg rt = _RT;
 
 		int pos = _POS;
 		int size = _SIZE + 1;
 		u32 mask = 0xFFFFFFFFUL >> (32 - size);
 
 		// Don't change $zr.
-		if (rt == 0)
+		if (rt == MIPS_REG_ZERO)
 			return;
 
 		switch (op & 0x3f)
@@ -662,10 +666,10 @@ namespace MIPSComp
 	void Jit::Comp_Allegrex(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE
-		int rt = _RT;
-		int rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rd = _RD;
 		// Don't change $zr.
-		if (rd == 0)
+		if (rd == MIPS_REG_ZERO)
 			return;
 
 		switch ((op >> 6) & 31)
@@ -772,10 +776,10 @@ namespace MIPSComp
 	void Jit::Comp_Allegrex2(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE
-		int rt = _RT;
-		int rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rd = _RD;
 		// Don't change $zr.
-		if (rd == 0)
+		if (rd == MIPS_REG_ZERO)
 			return;
 
 		DISABLE;
@@ -802,9 +806,9 @@ namespace MIPSComp
 	void Jit::Comp_MulDivType(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
-		int rt = _RT;
-		int rs = _RS;
-		int rd = _RD;
+		MIPSGPReg rt = _RT;
+		MIPSGPReg rs = _RS;
+		MIPSGPReg rd = _RD;
 
 		switch (op & 63) 
 		{

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -144,7 +144,7 @@ void Jit::BranchRSRTComp(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rt, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
 
-	if (jo.immBranches && gpr.IsImmediate(rs) && gpr.IsImmediate(rt))
+	if (jo.immBranches && gpr.IsImmediate(rs) && gpr.IsImmediate(rt) && js.numInstructions < jo.continueMaxInstructions)
 	{
 		// The cc flags are opposites: when NOT to take the branch.
 		bool skipBranch;
@@ -170,6 +170,8 @@ void Jit::BranchRSRTComp(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 		CompileDelaySlot(DELAYSLOT_NICE);
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 		return;
 	}
 
@@ -216,6 +218,8 @@ void Jit::BranchRSRTComp(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 		// Account for the delay slot.
 		js.compilerPC += 4;
 		RestoreState(state);
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 	}
 	else
 	{
@@ -239,7 +243,7 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, Gen::CCFlags cc, bool andLink, bool li
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
 
-	if (jo.immBranches && gpr.IsImmediate(rs))
+	if (jo.immBranches && gpr.IsImmediate(rs) && js.numInstructions < jo.continueMaxInstructions)
 	{
 		// The cc flags are opposites: when NOT to take the branch.
 		bool skipBranch;
@@ -271,6 +275,8 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, Gen::CCFlags cc, bool andLink, bool li
 		}
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 		return;
 	}
 
@@ -312,6 +318,8 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, Gen::CCFlags cc, bool andLink, bool li
 		// Account for the delay slot.
 		js.compilerPC += 4;
 		RestoreState(state);
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 	}
 	else
 	{
@@ -410,6 +418,8 @@ void Jit::BranchFPFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 		// Account for the delay slot.
 		js.compilerPC += 4;
 		RestoreState(state);
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 	}
 	else
 	{
@@ -494,6 +504,8 @@ void Jit::BranchVFPUFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 		// Account for the delay slot.
 		js.compilerPC += 4;
 		RestoreState(state);
+		// In case the delay slot was a break or something.
+		js.compiling = true;
 	}
 	else
 	{

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -503,7 +503,7 @@ bool Jit::CheckJitBreakpoint(u32 addr, int downcountOffset)
 	return false;
 }
 
-Jit::JitSafeMem::JitSafeMem(Jit *jit, int raddr, s32 offset, u32 alignMask)
+Jit::JitSafeMem::JitSafeMem(Jit *jit, MIPSGPReg raddr, s32 offset, u32 alignMask)
 	: jit_(jit), raddr_(raddr), offset_(offset), needsCheck_(false), needsSkip_(false), alignMask_(alignMask)
 {
 	// This makes it more instructions, so let's play it safe and say we need a far jump.

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -328,6 +328,14 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 
 		js.compilerPC += 4;
 		js.numInstructions++;
+
+		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
+		if (GetSpaceLeft() < 0x800)
+		{
+			FlushAll();
+			WriteExit(js.compilerPC, js.nextExit++);
+			js.compiling = false;
+		}
 	}
 
 	b->codeSize = (u32)(GetCodePtr() - b->normalEntry);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -41,11 +41,9 @@ struct JitOptions
 	JitOptions()
 	{
 		enableBlocklink = true;
-		// Seems to hurt performance?
 		immBranches = false;
-		// Seems to hurt performance also?
 		continueBranches = false;
-		continueMaxInstructions = 100;
+		continueMaxInstructions = 300;
 	}
 
 	bool enableBlocklink;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -339,7 +339,7 @@ private:
 	class JitSafeMem
 	{
 	public:
-		JitSafeMem(Jit *jit, int raddr, s32 offset, u32 alignMask = 0xFFFFFFFF);
+		JitSafeMem(Jit *jit, MIPSGPReg raddr, s32 offset, u32 alignMask = 0xFFFFFFFF);
 
 		// Emit code necessary for a memory write, returns true if MOV to dest is needed.
 		bool PrepareWrite(OpArg &dest, int size);
@@ -377,7 +377,7 @@ private:
 		bool ImmValid();
 
 		Jit *jit_;
-		int raddr_;
+		MIPSGPReg raddr_;
 		s32 offset_;
 		int size_;
 		bool needsCheck_;

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "Common/x64Emitter.h"
+#include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 
 using namespace Gen;
@@ -38,7 +39,7 @@ struct MIPSCachedReg {
 };
 
 struct X64CachedReg {
-	int mipsReg;
+	MIPSGPReg mipsReg;
 	bool dirty;
 	bool free;
 	bool allocLocked;
@@ -56,7 +57,7 @@ public:
 	~GPRRegCache() {}
 	void Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats);
 
-	void DiscardRegContentsIfCached(int preg);
+	void DiscardRegContentsIfCached(MIPSGPReg preg);
 	void SetEmitter(XEmitter *emitter) {emit = emitter;}
 
 	void FlushR(X64Reg reg); 
@@ -71,30 +72,30 @@ public:
 	void Flush();
 	void FlushBeforeCall();
 	int SanityCheck() const;
-	void KillImmediate(int preg, bool doLoad, bool makeDirty);
+	void KillImmediate(MIPSGPReg preg, bool doLoad, bool makeDirty);
 
-	void BindToRegister(int preg, bool doLoad = true, bool makeDirty = true);
-	void StoreFromRegister(int preg);
+	void BindToRegister(MIPSGPReg preg, bool doLoad = true, bool makeDirty = true);
+	void StoreFromRegister(MIPSGPReg preg);
 
-	const OpArg &R(int preg) const {return regs[preg].location;}
-	X64Reg RX(int preg) const
+	const OpArg &R(MIPSGPReg preg) const {return regs[preg].location;}
+	X64Reg RX(MIPSGPReg preg) const
 	{
 		if (regs[preg].away && regs[preg].location.IsSimpleReg()) 
 			return regs[preg].location.GetSimpleReg(); 
 		PanicAlert("Not so simple - %i", preg); 
 		return (X64Reg)-1;
 	}
-	OpArg GetDefaultLocation(int reg) const;
+	OpArg GetDefaultLocation(MIPSGPReg reg) const;
 
 	// Register locking.
-	void Lock(int p1, int p2=0xff, int p3=0xff, int p4=0xff);
+	void Lock(MIPSGPReg p1, MIPSGPReg p2 = MIPS_REG_INVALID, MIPSGPReg p3 = MIPS_REG_INVALID, MIPSGPReg p4 = MIPS_REG_INVALID);
 	void LockX(int x1, int x2=0xff, int x3=0xff, int x4=0xff);
 	void UnlockAll();
 	void UnlockAllX();
 
-	void SetImmediate32(int preg, u32 immValue);
-	bool IsImmediate(int preg) const;
-	u32 GetImmediate32(int preg) const;
+	void SetImmediate32(MIPSGPReg preg, u32 immValue);
+	bool IsImmediate(MIPSGPReg preg) const;
+	u32 GetImmediate32(MIPSGPReg preg) const;
 
 	void GetState(GPRRegCacheState &state) const;
 	void RestoreState(const GPRRegCacheState state);


### PR DESCRIPTION
Break and other delay slot ops could've set js.compile to false, which was the problem.  It's actually sometimes faster now.  I guess it was just because of that?

Also adds a check to make sure there's free code space within the jit loop.  It could be slightly slower to compile, but I don't know of any games compiling at run time, and it's a good safety.  Could be causing crashes, who knows.  Anyway, this change is the only practical impact since the continuing options are still disabled by default.

With that, I can unlock/uncap imm branches and I get ~60% spill in God Eater Burst for example.  At least it's a definite result.

Another interesting thing: with these off, I was getting ~1340% in one game, and then I saved state and loaded state... and got ~1410%.  In comparison with these settings on I was getting ~1420%, and save/load brought me to ~1430%.  Not sure I understand why...

If anyone wants to test it, you can play with these options in MIPS/x86/Jit.h:

``` c++
        immBranches = false;
        continueBranches = false;
        continueMaxInstructions = 300;
```

Note that `continueMaxInstructions` does nothing with the others off, and can safely be set to as high a number as you like.

-[Unknown]
