### PR TITLE
Fix hang in Project Diva 2nd in single-threaded mode.

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -590,9 +590,10 @@ void GPUCommon::ProcessDLQueueInternal() {
 	cyclesExecuted = 0;
 	UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
 
+	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {
 		DEBUG_LOG(HLE, "Can't execute a list yet, still busy for %lld ticks", busyTicks - startingTicks);
-		return;
+		//return;
 	}
 
 	for (int listIndex = GetNextListIndex(); listIndex != -1; listIndex = GetNextListIndex()) {


### PR DESCRIPTION
Doesn't seem to affect other games, but I don't have every game in existence, so there could be one or two out there that might break from this. @unknownbrackets and I did a lot of logging and testing, and it seems to all boil down to this one line messing it all up. It's his opinion that it's not likely safe to be skipping processing display lists.

https://github.com/hrydgard/ppsspp/issues/3080 is fixed by this.
