### PR TITLE
Disable mipmapping when texture scaling enabled

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1206,7 +1206,9 @@ void TextureCache::SetTexture() {
 			break;
 		}
 	}
-	if (g_Config.bMipMap) {
+	
+	//Disable Mipmapping when texture scaling enabled
+	if (g_Config.bMipMap && !g_Config.iTexScalingLevel) {) {
 #ifdef USING_GLES2
 		// GLES2 doesn't have support for a "Max lod" which is critical as PSP games often
 		// don't specify mips all the way down. As a result, we either need to manually generate


### PR DESCRIPTION
Fix issue #2891
