### PR TITLE
Mipmapping only enable when texture scaling disabled

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1206,7 +1206,9 @@ void TextureCache::SetTexture() {
 			break;
 		}
 	}
-	if (g_Config.bMipMap) {
+	
+	// Mipmapping only enable when texture scaling disabled 
+	if (g_Config.bMipMap && g_Config.iTexScalingLevel == 1) { 
 #ifdef USING_GLES2
 		// GLES2 doesn't have support for a "Max lod" which is critical as PSP games often
 		// don't specify mips all the way down. As a result, we either need to manually generate


### PR DESCRIPTION
Fix issue #2891
