### PR TITLE
GLES: Skip GE_LOGIC_COPY for logic ops

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -266,7 +266,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 #if !defined(USING_GLES2)
 		// Logic Ops
-		if (gstate.isLogicOpEnabled() && !gstate.isAlphaBlendEnabled()) {
+		if (gstate.isLogicOpEnabled() && gstate.getLogicOp() != GE_LOGIC_COPY) {
 			glstate.colorLogicOp.enable();
 			glstate.logicOp.set(logicOps[gstate.getLogicOp()]);
 		} else


### PR DESCRIPTION
Allow alpha blending to be enabled with logic ops which is the real PSP behaviour .

Tested with Akiba Trip Plus and looks good .
