### PR TITLE
Use a wait when hitting capped fps, instead of eating

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -163,7 +163,7 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking) {
 			AudioChannelWaitInfo waitInfo = {__KernelGetCurThread(), blockSamples};
 			chan.waitingThreads.push_back(waitInfo);
 			// Also remember the value to return in the waitValue.
-			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum + 1, ret, 0, false, "blocking audio waited");
+			__KernelWaitCurThread(WAITTYPE_AUDIOCHANNEL, (SceUID)chanNum + 1, ret, 0, false, "blocking audio");
 
 			// Fall through to the sample queueing, don't want to lose the samples even though
 			// we're getting full.  The PSP would enqueue after blocking.

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -407,9 +407,9 @@ void __KernelReturnFromInterrupt()
 	{
 		// Otherwise, we reschedule when dispatch was enabled, or switch back otherwise.
 		if (__KernelIsDispatchEnabled())
-			__KernelReSchedule("return from interrupt");
+			__KernelReSchedule("left interrupt");
 		else
-			__KernelSwitchToThread(threadBeforeInterrupt, "return from interrupt");
+			__KernelSwitchToThread(threadBeforeInterrupt, "left interrupt");
 	}
 }
 


### PR DESCRIPTION
Otherwise we don't schedule to threads that need to run.  This was causing Jeanne d'Arc (on top of horrible graphics) to hang.  This does lower perf a bit for God of War for me, but it probably also improves audio quality.

Also adjusts logging of context switches (how I found this was the cause) to include consumed time.

-[Unknown]
