### PR TITLE
MIPS interpreter: Log 2 more instructions. JIT(x86): Log more info when an instruction can't be interpreted.

### DIFF
--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -798,6 +798,29 @@ namespace MIPSInt
 		PC += 4;
 	}
 
+	void Int_Special2(MIPSOpcode op)
+	{
+		static int reported = 0;
+		switch (op & 0x3F)
+		{
+		case 36:
+			if (!reported) {
+				Reporting::ReportMessage("MFIC instruction hit (%08x) at %08x", op, currentMIPS->pc);
+				WARN_LOG(CPU,"MFIC Disable/Enable Interrupt CPU instruction");
+				reported = 1;
+			}
+			break;
+		case 38:
+			if (!reported) {
+				Reporting::ReportMessage("MTIC instruction hit (%08x) at %08x", op, currentMIPS->pc);
+				WARN_LOG(CPU,"MTIC Disable/Enable Interrupt CPU instruction");
+				reported = 1;
+			}
+			break;
+		}
+		PC += 4;
+	}
+
 	void Int_Special3(MIPSOpcode op)
 	{
 		int rs = _RS;

--- a/Core/MIPS/MIPSInt.h
+++ b/Core/MIPS/MIPSInt.h
@@ -48,6 +48,7 @@ namespace MIPSInt
 	void Int_FPUComp(MIPSOpcode op);
 	void Int_FPUBranch(MIPSOpcode op);
 	void Int_Emuhack(MIPSOpcode op);
+	void Int_Special2(MIPSOpcode op);
 	void Int_Special3(MIPSOpcode op);
 	void Int_Interrupt(MIPSOpcode op);
 	void Int_Cache(MIPSOpcode op);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -257,9 +257,9 @@ const MIPSInstruction tableSpecial2[64] = // 011100 ..... ..... ..... ..... xxxx
 	INVALID_X_8,
 	//32
 	INVALID, INVALID, INVALID, INVALID,
-	INSTR("mfic", &Jit::Comp_Generic, Dis_Generic, 0, 0),
+	INSTR("mfic", &Jit::Comp_Generic, Dis_Generic, Int_Special2, 0),
 	INVALID,
-	INSTR("mtic", &Jit::Comp_Generic, Dis_Generic, 0, 0),
+	INSTR("mtic", &Jit::Comp_Generic, Dis_Generic, Int_Special2, 0),
 	INVALID,
 	//40
 	INVALID_X_8,

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -366,7 +366,7 @@ void Jit::Comp_Generic(MIPSOpcode op)
 			ABI_CallFunctionC((void *)func, op.encoding);
 	}
 	else
-		ERROR_LOG_REPORT(JIT, "Trying to compile instruction that can't be interpreted");
+		ERROR_LOG_REPORT(JIT, "Trying to compile instruction %08x that can't be interpreted", op.encoding);
 
 	const MIPSInfo info = MIPSGetInfo(op);
 	if ((info & IS_VFPU) != 0 && (info & VFPU_NO_PREFIX) == 0)


### PR DESCRIPTION
Thanks to Unknown for the assistance.
