### PR TITLE
Restore missing Recent tab option.

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -245,7 +245,7 @@ void UpdateConfirmCancelKeys() {
 			cancelKeys.push_back(hardcodedCancelKeys[i]);
 	}
 
-	SetConfirmCancelKeys(confirmKeys,cancelKeys);
+	SetConfirmCancelKeys(confirmKeys, cancelKeys);
 }
 
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, int count, bool replace) {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -70,7 +70,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 
 	// Fix issue from switching from uint (hex in .ini) to int (dec)
 	if (iMaxRecent == 0)
-		iMaxRecent = 30; 
+		iMaxRecent = 30;
 
 	// "default" means let emulator decide, "" means disable.
 	general->Get("ReportingHost", &sReportHost, "default");

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -61,16 +61,15 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	general->Get("Language", &languageIni, "en_US");
 	general->Get("NumWorkerThreads", &iNumWorkerThreads, cpu_info.num_cores);
 	general->Get("EnableCheats", &bEnableCheats, false);
-	general->Get("MaxRecent", &iMaxRecent, 30);
 	general->Get("ScreenshotsAsPNG", &bScreenshotsAsPNG, false);
 	general->Get("StateSlot", &iCurrentStateSlot, 0);
 	general->Get("GridView1", &bGridView1, true);
 	general->Get("GridView2", &bGridView2, true);
 	general->Get("GridView3", &bGridView3, true);
 
-	// Fix issue from switching from uint (hex in .ini) to int (dec)
-	if (iMaxRecent == 0)
-		iMaxRecent = 12;
+	// No reason to really make this configurable when
+	// the list can scroll in NewUI.
+	iMaxRecent = 30;
 
 	// "default" means let emulator decide, "" means disable.
 	general->Get("ReportingHost", &sReportHost, "default");
@@ -248,7 +247,6 @@ void Config::Save() {
 #endif
 		general->Set("Language", languageIni);
 		general->Set("NumWorkerThreads", iNumWorkerThreads);
-		general->Set("MaxRecent", iMaxRecent);
 		general->Set("EnableCheats", bEnableCheats);
 		general->Set("ScreenshotsAsPNG", bScreenshotsAsPNG);
 		general->Set("StateSlot", iCurrentStateSlot);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -61,15 +61,16 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	general->Get("Language", &languageIni, "en_US");
 	general->Get("NumWorkerThreads", &iNumWorkerThreads, cpu_info.num_cores);
 	general->Get("EnableCheats", &bEnableCheats, false);
+	general->Get("MaxRecent", &iMaxRecent, 30);
 	general->Get("ScreenshotsAsPNG", &bScreenshotsAsPNG, false);
 	general->Get("StateSlot", &iCurrentStateSlot, 0);
 	general->Get("GridView1", &bGridView1, true);
 	general->Get("GridView2", &bGridView2, true);
 	general->Get("GridView3", &bGridView3, true);
 
-	// No reason to really make this configurable when
-	// the list can scroll in NewUI.
-	iMaxRecent = 30;
+	// Fix issue from switching from uint (hex in .ini) to int (dec)
+	if (iMaxRecent == 0)
+		iMaxRecent = 30; 
 
 	// "default" means let emulator decide, "" means disable.
 	general->Get("ReportingHost", &sReportHost, "default");

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -365,6 +365,7 @@ void GameSettingsScreen::CreateViews() {
 #ifdef _WIN32
 	systemSettings->Add(new Choice(s->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 #endif
+	systemSettings->Add(new Choice(s->T("Clear Recent Section")))->OnClick.Handle(this, &GameSettingsScreen::OnClearRecents);
 	systemSettings->Add(new CheckBox(&enableReports_, s->T("Enable Compatibility Server Reports")));
 	systemSettings->Add(new Choice(s->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
 
@@ -377,6 +378,12 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iTimeFormat, s->T("Time Format"), timeFormat, 1, 2, s, screenManager()));
 	static const char *buttonPref[] = { "Use O to confirm", "Use X to confirm" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iButtonPreference, s->T("Confirmation Button"), buttonPref, 0, 2, s, screenManager()));
+}
+
+UI::EventReturn GameSettingsScreen::OnClearRecents(UI::EventParams &e) {
+	g_Config.recentIsos.clear();
+
+	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnReloadCheats(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -51,6 +51,7 @@ private:
 	UI::EventReturn OnFactoryReset(UI::EventParams &e);
 	UI::EventReturn OnDeveloperTools(UI::EventParams &e);
 	UI::EventReturn OnChangeNickname(UI::EventParams &e);
+	UI::EventReturn OnClearRecents(UI::EventParams &e);
 
 	// Temporaries to convert bools to int settings
 	bool cap60FPS_;


### PR DESCRIPTION
We seem to have missed this when finishing up NewUI. :)

Is g_Config.iMaxRecent obsolete, though, now that the recent list can scroll up and down? Hm..
