### PR TITLE
Reschedule after resuming interrupts

### DIFF
--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -89,6 +89,7 @@ void sceKernelCpuResumeIntr(u32 enable)
 	{
 		__EnableInterrupts();
 		hleRunInterrupts();
+		hleReSchedule("interrupts resumed");
 	}
 	else
 	{


### PR DESCRIPTION
This is one line but tbh I've been scared of it.  When I did it before, it broke games.  It's also possible it could slow down games that do a lot of interrupt on/off switching, although I've optimized the no-change reschedule case specifically.

Anyway, this improves the results of the threads/scheduling/scheduling test, and I'm relatively sure it's correct.

I tested a bunch of games and they're all happy with this now, most likely it was other bugs.

-[Unknown]
