### PR TITLE
Change several translation keys so that they don't have a newline in them. 

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -196,17 +196,17 @@ bool LoadFile(std::string &filename, std::string *error_string) {
 
 	case FILETYPE_ARCHIVE_RAR:
 #ifdef WIN32
-		*error_string = "File is compressed (RAR).\nPlease decompress first (try WinRAR)";
+		*error_string = "File is compressed (RAR). Please decompress first (try WinRAR)";
 #else
-		*error_string = "File is compressed (RAR).\nPlease decompress first (try UnRAR)";
+		*error_string = "File is compressed (RAR). Please decompress first (try UnRAR)";
 #endif
 		break;
 
 	case FILETYPE_ARCHIVE_ZIP:
 #ifdef WIN32
-		*error_string = "File is compressed (ZIP).\nPlease decompress first (try WinRAR)";
+		*error_string = "File is compressed (ZIP). Please decompress first (try WinRAR)";
 #else
-		*error_string = "File is compressed (ZIP).\nPlease decompress first (try UnRAR)";
+		*error_string = "File is compressed (ZIP). Please decompress first (try UnRAR)";
 #endif
 		break;
 


### PR DESCRIPTION
Before, using Russian as an example:
![Screenshot 01](https://i.minus.com/imoB52x66mupV.jpg)

After(with an ini modification to reflect the new key):
![Screenshot 02](https://i.minus.com/ibsQoLt5ZMla49.jpg)

I didn't realize previously that newlines in keys weren't permitted/couldn't be translated.
