### PR TITLE
Clear the mixbuffer when all channels empty

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -311,7 +311,7 @@ void __AudioUpdate() {
 	}
 
 	if (firstChannel) {
-		memset(mixBuffer, 0, sizeof(mixBuffer));
+		memset(mixBuffer, 0, hwBlockSize * 2 * sizeof(s32));
 	}
 
 	if (g_Config.bEnableSound) {


### PR DESCRIPTION
Well, this might be the audio glitch in #3422, but I still hear something slight.  I'm not sure if it's supposed to be there.  But this does remove most of the sound.

Anyway, it's definitely right, since sizeof(mixBuffer) is the size of a pointer now.

-[Unknown]
