### PR TITLE
Fix wide char usage in the debugger (garbage func names) and file handling

### DIFF
--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -59,6 +59,9 @@ struct FSTEntry
 	std::vector<FSTEntry> children;
 };
 
+// Mostly to handle utf-8 filenames better on Windows.
+FILE *OpenCFile(const std::string &filename, const char *mode);
+
 // Returns true if file filename exists
 bool Exists(const std::string &filename);
 

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -336,7 +336,7 @@ bool SymbolMap::getSymbolValue(char* symbol, u32& dest)
 	{
 		const MapEntry &entry = *it;
 #ifdef _WIN32
-		if (stricmp(entry.name,symbol) == 0)
+		if (_stricmp(entry.name,symbol) == 0)
 #else
 		if (strcasecmp(entry.name,symbol) == 0)
 #endif
@@ -388,8 +388,8 @@ void SymbolMap::FillSymbolListBox(HWND listbox,SymbolType symmask) const
 	{
 		for (int i = 0; i < defaultSymbolsAmount; i++)
 		{
-			char temp[256];
-			sprintf(temp,"0x%08X (%s)",defaultSymbolsAddresses[i],defaultSymbolsNames[i]);
+			wchar_t temp[256];
+			wsprintf(temp, L"0x%08X (%S)", defaultSymbolsAddresses[i], defaultSymbolsNames[i]);
 			int index = ListBox_AddString(listbox,temp);
 			ListBox_SetItemData(listbox,index,defaultSymbolsAddresses[i]);
 		}
@@ -404,12 +404,12 @@ void SymbolMap::FillSymbolListBox(HWND listbox,SymbolType symmask) const
 		const MapEntry &entry = *it;
 		if (entry.type & symmask)
 		{
-			char temp[256];
+			wchar_t temp[256];
 			if (entry.type & ST_FUNCTION || !(entry.type & ST_DATA))
 			{
-				sprintf(temp,"%s",entry.name);
+				wsprintf(temp, L"%S", entry.name);
 			} else {
-				sprintf(temp,"0x%08X (%s)",entry.vaddress,entry.name);
+				wsprintf(temp, L"0x%08X (%S)", entry.vaddress, entry.name);
 			}
 
 			int index = ListBox_AddString(listbox,temp);
@@ -429,23 +429,23 @@ void SymbolMap::FillSymbolComboBox(HWND listbox,SymbolType symmask) const
 
 	//int style = GetWindowLong(listbox,GWL_STYLE);
 
-	ComboBox_AddString(listbox,"(0x02000000)");
-	ComboBox_SetItemData(listbox,0,0x02000000);
+	ComboBox_AddString(listbox, L"(0x02000000)");
+	ComboBox_SetItemData(listbox, 0, 0x02000000);
 
-	//ListBox_AddString(listbox,"(0x80002000)");
-	//ListBox_SetItemData(listbox,1,0x80002000);
+	//ListBox_AddString(listbox, L"(0x80002000)");
+	//ListBox_SetItemData(listbox, 1, 0x80002000);
 
 	lock_guard guard(lock_);
 
 	SendMessage(listbox, WM_SETREDRAW, FALSE, 0);
-	SendMessage(listbox, CB_INITSTORAGE, (WPARAM)entries.size(), (LPARAM)entries.size() * 30);
+	SendMessage(listbox, CB_INITSTORAGE, (WPARAM)entries.size(), (LPARAM)entries.size() * 30 * sizeof(wchar_t));
 	for (size_t i = 0, end = entries.size(); i < end; ++i)
 	{
 		const MapEntry &entry = entries[i];
 		if (entry.type & symmask)
 		{
-			char temp[256];
-			sprintf(temp,"%s (%d)",entry.name,entry.size);
+			wchar_t temp[256];
+			wsprintf(temp, L"%S (%d)", entry.name, entry.size);
 			int index = ComboBox_AddString(listbox,temp);
 			ComboBox_SetItemData(listbox,index,entry.vaddress);
 		}
@@ -469,6 +469,7 @@ void SymbolMap::FillListBoxBLinks(HWND listbox, int num) const
 	for (int i=0; i<e.backwardLinks.size(); i++)
 	{
 		u32 addr = e.backwardLinks[i];
+		// TODO: wchar_t
 		int index = ListBox_AddString(listbox,SymbolMap::GetSymbolName(SymbolMap::GetSymbolNum(addr)));
 		ListBox_SetItemData(listbox,index,addr);
 	}

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -23,12 +23,12 @@
 #endif
 
 #include <algorithm>
-
-#include "../../Globals.h"
-#include "../../Core/MemMap.h"
-#include "SymbolMap.h"
-
 #include <map>
+
+#include "Common/FileUtil.h"
+#include "Globals.h"
+#include "Core/MemMap.h"
+#include "Core/Debugger/SymbolMap.h"
 
 SymbolMap symbolMap;
 
@@ -139,7 +139,7 @@ bool SymbolMap::LoadSymbolMap(const char *filename)
 {
 	lock_guard guard(lock_);
 	SymbolMap::ResetSymbolMap();
-	FILE *f = fopen(filename,"r");
+	FILE *f = File::OpenCFile(filename, "r");
 	if (!f)
 		return false;
 	//char temp[256];
@@ -212,7 +212,7 @@ bool SymbolMap::LoadSymbolMap(const char *filename)
 void SymbolMap::SaveSymbolMap(const char *filename) const
 {
 	lock_guard guard(lock_);
-	FILE *f = fopen(filename,"w");
+	FILE *f = File::OpenCFile(filename, "w");
 	if (!f)
 		return;
 	fprintf(f,".text\n");
@@ -227,7 +227,7 @@ void SymbolMap::SaveSymbolMap(const char *filename) const
 bool SymbolMap::LoadNocashSym(const char *filename)
 {
 	lock_guard guard(lock_);
-	FILE *f = fopen(filename,"r");
+	FILE *f = File::OpenCFile(filename, "r");
 	if (!f)
 		return false;
 
@@ -538,7 +538,7 @@ unsigned int SymbolMap::GetRunCount(int num) const
 void SymbolMap::CompileFuncSignaturesFile(const char *filename) const
 {
 	// Store name,length,first instruction,hash into file
-	FILE *f = fopen(filename, "w");
+	FILE *f = File::OpenCFile(filename, "w");
 	fprintf(f,"00000000\n");
 	int count=0;
 	for (auto it = entries.begin(), end = entries.end(); it != end; ++it)
@@ -589,7 +589,7 @@ void SymbolMap::UseFuncSignaturesFile(const char *filename, u32 maxAddress)
 	sigs.clear();
 	//SymbolMap::ResetSymbolMap();
 	//#1: Read the signature file and put them in a fast data structure
-	FILE *f = fopen(filename, "r");
+	FILE *f = File::OpenCFile(filename, "r");
 	int count;
 	if (fscanf(f, "%08x\n", &count) != 1)
 		count = 0;

--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -20,10 +20,11 @@
 #include <cstring>
 
 #include "Common/Log.h"
+#include "Common/FileUtil.h"
 #include "Core/ELF/PBPReader.h"
 
 PBPReader::PBPReader(const char *filename) : header_() {
-	file_ = fopen(filename, "rb");
+	file_ = File::OpenCFile(filename, "rb");
 	if (!file_) {
 		return;
 	}

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -16,7 +16,8 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 
-#include "BlockDevices.h"
+#include "Common/FileUtil.h"
+#include "Core/FileSystems/BlockDevices.h"
 #include <cstdio>
 #include <cstring>
 
@@ -29,7 +30,7 @@ extern "C"
 
 BlockDevice *constructBlockDevice(const char *filename) {
 	// Check for CISO
-	FILE *f = fopen(filename, "rb");
+	FILE *f = File::OpenCFile(filename, "rb");
 	if (!f)
 		return 0;
 	char buffer[4];

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "file/file_util.h"
+#include "Common/FileUtil.h"
 #include "MIPS/MIPS.h"
 #include "MIPS/MIPSCodeUtils.h"
 
@@ -71,7 +72,7 @@ IdentifiedFileType Identify_File(std::string &filename)
 		return FILETYPE_NORMAL_DIRECTORY;
 	}
 
-	FILE *f = fopen(filename.c_str(), "rb");
+	FILE *f = File::OpenCFile(filename.c_str(), "rb");
 	if (!f)	{
 		// File does not exists
 		return FILETYPE_ERROR;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include "Globals.h"
 
+#include "Common/FileUtil.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
@@ -326,7 +327,7 @@ namespace MIPSAnalyst
 
 	void StoreHashMap(const char *filename)
 	{
-		FILE *file = fopen(filename,"wb");
+		FILE *file = File::OpenCFile(filename,"wb");
 		u32 num = 0;
 		if(fwrite(&num,4,1,file) != 1) //fill in later
 			WARN_LOG(CPU, "Could not store hash map %s", filename);
@@ -360,7 +361,7 @@ namespace MIPSAnalyst
 		HashFunctions();
 		UpdateHashToFunctionMap();
 
-		FILE *file = fopen(filename, "rb");
+		FILE *file = File::OpenCFile(filename, "rb");
 		int num;
 		if(fread(&num,4,1,file) == 1) {
 			for (int i=0; i<num; i++)

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1005,7 +1005,7 @@ void CtrlDisAsmView::disassembleToFile()
 
 	if (GetSaveFileName(&ofn) == false) return;
 
-	FILE* output = fopen(ConvertWStringToUTF8(fileName).c_str(),"w");
+	FILE* output = _wfopen(fileName, L"w");
 	if (output == NULL) {
 		MessageBox(wnd,L"Could not open file!",L"Error",MB_OK);
 		return;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -555,19 +555,19 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					u32 ra = currentMIPS->r[MIPS_REG_RA];
 					DWORD addr = Memory::ReadUnchecked_U32(pc);
 					int count=1;
-					ComboBox_SetItemData(list,ComboBox_AddString(list,symbolMap.GetDescription(pc)),pc);
+					ComboBox_SetItemData(list, ComboBox_AddString(list, ConvertUTF8ToWString(symbolMap.GetDescription(pc)).c_str()), pc);
 					if (symbolMap.GetDescription(pc) != symbolMap.GetDescription(ra))
 					{
-						ComboBox_SetItemData(list,ComboBox_AddString(list,symbolMap.GetDescription(ra)),ra);
+						ComboBox_SetItemData(list, ComboBox_AddString(list, ConvertUTF8ToWString(symbolMap.GetDescription(ra)).c_str()), ra);
 						count++;
 					}
 					//walk the stack chain
 					while (addr != 0xFFFFFFFF && addr!=0 && count++<20)
 					{
 						DWORD fun = Memory::ReadUnchecked_U32(addr+4);
-						const char *str = symbolMap.GetDescription(fun);
-						if (strlen(str)==0)
-							str = "(unknown)";
+						const wchar_t *str = ConvertUTF8ToWString(symbolMap.GetDescription(fun)).c_str();
+						if (wcslen(str) == 0)
+							str = L"(unknown)";
 						ComboBox_SetItemData(list, ComboBox_AddString(list,str), fun);
 						addr = Memory::ReadUnchecked_U32(addr);
 					}
@@ -836,6 +836,7 @@ void CDisasm::UpdateDialog(bool _bComplete)
 	ComboBox_ResetContent(gotoInt);
 	for (int i=0; i<numRegions; i++)
 	{
+		// TODO: wchar_t
 		int n = ComboBox_AddString(gotoInt,regions[i].name);
 		ComboBox_SetItemData(gotoInt,n,regions[i].start);
 	}

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -49,16 +49,16 @@ LRESULT CALLBACK AddressEditProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM 
 
 CMemoryDlg::CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Dialog((LPCSTR)IDD_MEMORY, _hInstance,_hParent)
 {
-  cpu = _cpu;
+	cpu = _cpu;
 	wchar_t temp[256];
-	wsprintf(temp,L"Memory Viewer - %s",cpu->GetName());
+	wsprintf(temp,L"Memory Viewer - %S",cpu->GetName());
 	SetWindowText(m_hDlg,temp);
 
 	ShowWindow(m_hDlg,SW_HIDE);
 	CtrlMemView *ptr = CtrlMemView::getFrom(GetDlgItem(m_hDlg,IDC_MEMVIEW));
-  ptr->setDebugger(_cpu);
+	ptr->setDebugger(_cpu);
 
-  Button_SetCheck(GetDlgItem(m_hDlg,IDC_RAM), TRUE);
+	Button_SetCheck(GetDlgItem(m_hDlg,IDC_RAM), TRUE);
 	Button_SetCheck(GetDlgItem(m_hDlg,IDC_MODESYMBOLS), TRUE);
 
 	GetWindowRect(GetDlgItem(m_hDlg,IDC_SYMBOLS),&slRect);
@@ -99,6 +99,7 @@ void CMemoryDlg::NotifyMapLoaded()
     /*
 		for (int i = 0; i < cpu->getMemMap()->numRegions; i++)
 		{
+			// TODO: wchar_t
 			int n = ComboBox_AddString(lb,cpu->getMemMap()->regions[i].name);
 			ComboBox_SetItemData(lb,n,cpu->getMemMap()->regions[i].start);
 		}*/

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -19,7 +19,7 @@ CVFPUDlg::CVFPUDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu_) : 
 {
 	cpu = cpu_;
 	wchar_t temp[256];
-	wsprintf(temp,L"VFPU - %s",ConvertUTF8ToWString(cpu->GetName()).c_str());
+	wsprintf(temp, L"VFPU - %S", cpu->GetName());
 	SetWindowText(m_hDlg,temp);
 
 	ShowWindow(m_hDlg,SW_HIDE);


### PR DESCRIPTION
Files need to be opened using the wide functions, which makes ones with Japanese and Chinese in their names open properly at least from the limited filenames I attempted.

Accept hrydgard/native#118 first.

-[Unknown]
