### PR TITLE
GLES SW: inline with HW using 0,0,1 for non-normal case

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -604,7 +604,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3f(norm).Normalized();
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3f::AssignToAll(0.0f);
+							source = Vec3f(0.0f, 0.0f, 1.0f);
 						}
 						break;
 					case GE_PROJMAP_NORMAL: // Use non-normalized normal as source!
@@ -612,7 +612,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 							source = Vec3f(norm);
 						} else {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
-							source = Vec3f::AssignToAll(0.0f);
+							source = Vec3f(0.0f, 0.0f, 1.0f);
 						}
 						break;
 					}


### PR DESCRIPTION
This is HW equivalent

```
                case GE_PROJMAP_NORMALIZED_NORMAL:  // Use normalized transformed normal as source
                    if (hasNormal)
                        temp_tc = "vec4(normalize(a_normal), 1.0)";
                    else
                        temp_tc = "vec4(0.0, 0.0, 1.0, 1.0)";
                    break;
                case GE_PROJMAP_NORMAL:  // Use non-normalized transformed normal as source
                    if (hasNormal)
                        temp_tc = "vec4(a_normal, 1.0)";
                    else
                        temp_tc = "vec4(0.0, 0.0, 1.0, 1.0)";
                    break;
                }
```
