### PR TITLE
Cleanup: Remove some unused options, and move some out of the "These are broken" section.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -48,13 +48,10 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 
 	IniFile::Section *general = iniFile.GetOrCreateSection("General");
 
-	bSpeedLimit = false;
 	general->Get("FirstRun", &bFirstRun, true);
 	general->Get("Enable Logging", &bEnableLogging, true);
-	general->Get("AutoLoadLast", &bAutoLoadLast, false);
 	general->Get("AutoRun", &bAutoRun, true);
 	general->Get("Browse", &bBrowse, false);
-	general->Get("ConfirmOnQuit", &bConfirmOnQuit, false);
 	general->Get("IgnoreBadMemAccess", &bIgnoreBadMemAccess, true);
 	general->Get("CurrentDirectory", &currentDirectory, "");
 	general->Get("ShowDebuggerOnLoad", &bShowDebuggerOnLoad, false);
@@ -231,10 +228,8 @@ void Config::Save() {
 		bFirstRun = false;
 		general->Set("FirstRun", bFirstRun);
 		general->Set("Enable Logging", bEnableLogging);
-		general->Set("AutoLoadLast", bAutoLoadLast);
 		general->Set("AutoRun", bAutoRun);
 		general->Set("Browse", bBrowse);
-		general->Set("ConfirmOnQuit", bConfirmOnQuit);
 		general->Set("IgnoreBadMemAccess", bIgnoreBadMemAccess);
 		general->Set("CurrentDirectory", currentDirectory);
 		general->Set("ShowDebuggerOnLoad", bShowDebuggerOnLoad);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -34,21 +34,17 @@ public:
 	bool bSaveSettings;
 	bool bFirstRun;
 
-	// These are broken
-	bool bAutoLoadLast;
-	bool bSpeedLimit;
-	bool bConfirmOnQuit;
 	bool bAutoRun;  // start immediately
-	bool bBrowse;
-#ifdef _WIN32
-	bool bTopMost;
-#endif
+	bool bBrowse; // when opening the emulator, immediately show a file browser
+
 
 	// General
 	int iNumWorkerThreads;
 	bool bScreenshotsAsPNG;
 	bool bEnableLogging;
-
+#ifdef _WIN32
+	bool bTopMost;
+#endif
 	// Core
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -723,9 +723,6 @@ namespace MainWindow
 				case ID_EMULATION_CHEATS:
 					NativeMessageReceived("reset", "");
 					break;
-				case ID_EMULATION_SPEEDLIMIT:
-					g_Config.bSpeedLimit = !g_Config.bSpeedLimit;
-					break;
 
 				case ID_EMULATION_RENDER_MODE_OGL:
 					g_Config.bSoftwareRendering = false;
@@ -1266,7 +1263,6 @@ namespace MainWindow
 	void UpdateMenus() {
 		HMENU menu = GetMenu(GetHWND());
 #define CHECKITEM(item,value) 	CheckMenuItem(menu,item,MF_BYCOMMAND | ((value) ? MF_CHECKED : MF_UNCHECKED));
-		CHECKITEM(ID_EMULATION_SPEEDLIMIT,g_Config.bSpeedLimit);
 		CHECKITEM(ID_OPTIONS_IGNOREILLEGALREADS,g_Config.bIgnoreBadMemAccess);
 		CHECKITEM(ID_CPU_INTERPRETER,g_Config.bJit == false);
 		CHECKITEM(ID_CPU_DYNAREC,g_Config.bJit == true);


### PR DESCRIPTION
bTopMost isn't broken, nor is bBrowse. :+1: 
