### PR TITLE
Add an option to restore PPSSPP's settings to default.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -372,3 +372,11 @@ void Config::CleanRecent() {
 	}
 	recentIsos = cleanedRecent;
 }
+
+void Config::RestoreDefaults() {
+	if(File::Exists("ppsspp.ini"))
+		File::Delete("ppsspp.ini");
+	recentIsos.clear();
+	currentDirectory = "";
+	Load();
+}

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -165,6 +165,7 @@ public:
 
 	void Load(const char *iniFileName = "ppsspp.ini", const char *controllerIniFilename = "controls.ini");
 	void Save();
+	void RestoreDefaults();
 
 	// Utility functions for "recent" management
 	void AddRecent(const std::string &file);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -525,6 +525,7 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new ItemHeader(g->T("General")));
 	list->Add(new Choice(d->T("System Information")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSysInfo);
 	list->Add(new Choice(d->T("Run CPU Tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
+	list->Add(new Choice(d->T("Restore PPSSPP Default Settings")))->OnClick.Handle(this, &DeveloperToolsScreen::OnRestoreDefaultSettings);
 #ifndef __SYMBIAN32__
 	list->Add(new CheckBox(&g_Config.bSoftwareRendering, gs->T("Software Rendering", "Software Rendering (experimental)")));
 #endif
@@ -543,6 +544,21 @@ UI::EventReturn DeveloperToolsScreen::OnBack(UI::EventParams &e) {
 	PostMessage(MainWindow::hwndMain, MainWindow::WM_USER_LOG_STATUS_CHANGED, 0, 0);
 #endif
 	g_Config.Save();
+
+	return UI::EVENT_DONE;
+}
+
+void DeveloperToolsScreen::CallbackRestoreDefaults(bool yes) {
+	if(yes)
+		g_Config.RestoreDefaults();
+}
+
+UI::EventReturn DeveloperToolsScreen::OnRestoreDefaultSettings(UI::EventParams &e) {
+	I18NCategory *d = GetI18NCategory("Dialog");
+	I18NCategory *g = GetI18NCategory("General");
+	screenManager()->push(
+	new PromptScreen(d->T("Are you sure you want to restore all settings(except control mapping) back to their defaults?\nYou can't undo this.\nPlease restart PPSSPP after restoring settings."), g->T("OK"), g->T("Cancel"),
+	std::bind(&DeveloperToolsScreen::CallbackRestoreDefaults, this, placeholder::_1)));
 
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -78,6 +78,7 @@ public:
 
 protected:
 	virtual void CreateViews();
+	void CallbackRestoreDefaults(bool yes);
 
 private:
 	UI::EventReturn OnBack(UI::EventParams &e);
@@ -86,6 +87,7 @@ private:
 	UI::EventReturn OnLoggingChanged(UI::EventParams &e);
 	UI::EventReturn OnLoadLanguageIni(UI::EventParams &e);
 	UI::EventReturn OnSaveLanguageIni(UI::EventParams &e);
+	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 
 	// Temporary variable.
 	bool enableLogging_;


### PR DESCRIPTION
Can be handy on platforms which don't have access to the ini file(Android..) without being rooted or if it's in a place not normally accessible for some reason.

It does not overwrite the user's control mappings or bindings. It's tucked under Developer Tools and includes a prompt screen so the user doesn't do it by accident.

I know more options aren't always the best, but something like this sort of goes without saying, I think.
