### PR TITLE
Block updates in sceKernelLoadModule

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -69,6 +69,7 @@ enum {
 static const char *lieAboutSuccessModules[] = {
 	"flash0:/kd/audiocodec.prx",
 	"flash0:/kd/libatrac3plus.prx",
+	"disc0:/PSP_GAME/SYSDIR/UPDATE/EBOOT.BIN",
 };
 
 static const char *blacklistedModules[] = {
@@ -1409,6 +1410,12 @@ u32 sceKernelGetModuleId()
 u32 sceKernelFindModuleByName(const char *name)
 {
 	ERROR_LOG_REPORT(HLE, "UNIMPL sceKernelFindModuleByName(%s)", name);
+	
+	int index = GetModuleIndex(name);
+
+	if (index == -1)
+		return 0;
+	
 	return 1;
 }
 


### PR DESCRIPTION
Might help #3450

Also stop always lying the module was found in sceKernelFindModuleByName.
This was causing the homebrew CSPSP to think tempAR is installed in PPSSPP when trying to go online/multiplayer. Online obviously isn't implemented in PPSSPP so going online doesn't actually work, but by lying that the tempAR module is being used, CSPSP will give an error telling users to disable tempAR, which isn't used.
