### PR TITLE
Shows "OpenGL Extensions" instead of "OpenGL ES 2.0 Extensions" for Wind...

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -331,7 +331,11 @@ void SystemInfoScreen::CreateViews() {
 	scroll->Add(new InfoItem("GPU Model :", (char *)glGetString(GL_RENDERER)));
 	scroll->Add(new InfoItem("OpenGL Version Supported :", (char *)glGetString(GL_VERSION)));
 	
+#ifdef _WIN32
+	scroll->Add(new ItemHeader("OpenGL Extensions"));
+#else
 	scroll->Add(new ItemHeader("OpenGL ES 2.0 Extensions"));
+#endif
 	std::vector<std::string> exts;
 	SplitString(g_all_gl_extensions, ' ', exts);
 	for (size_t i = 0; i < exts.size(); i++) {


### PR DESCRIPTION
...ows

That "ES" part doesn't make sense for windows.
