### PR TITLE
Redefine translate timeout for UI menu

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -545,7 +545,7 @@ namespace MainWindow
 		hideCursor = true;
 		SetTimer(hwndMain, TIMER_CURSORUPDATE, CURSORUPDATE_INTERVAL_MS, 0);
 		
-		Update();
+		UpdateMenus();
 
 		if(g_Config.bFullScreenOnLaunch)
 			_ViewFullScreen(hwndMain);
@@ -572,6 +572,7 @@ namespace MainWindow
 
 		SetFocus(hwndDisplay);
 		SetTimer(hwndMain, TIMER_TRANSLATE, TRANSLATE_INTERVAL_MS, 0);
+
 
 		return TRUE;
 	}


### PR DESCRIPTION
Finally found why the menu can not been translated here. 
# define TRANSLATE_INTERVAL_MS 100

100MS is too short for some system to do translation.
I've tested on my VM and really nothing down. 500 is a bit too large and sensible of the translation flush. Set 200 is just ok here. 150 works too.
