### PR TITLE
Small improvement for fade-in and fade-out sounds in Loco Roco

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -250,7 +250,7 @@ static int getReleaseRate(int bitfield2) {
 	if (getReleaseType(bitfield2) == PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE) {
 		return (0x40000000 >> (n + 2));
 	}
-	return (0x08000000 >> n);
+	return (0x40000000 >> n);
 }
 
 static int getSustainLevel(int bitfield1) {


### PR DESCRIPTION
The fade-in and fade-out sounds in Loco Roco are way too long, this  small change improves it alot. now the sound that is played after reaching the goal in a level sounds about right.
