### PR TITLE
Track module imports and exports with a proper lifecycle

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -272,10 +272,11 @@ void ResolveSyscall(const char *moduleName, u32 nib, u32 address)
 			const Syscall *sysc = &syscalls[i];
 			if (sysc->nid == nib)
 			{
-				INFO_LOG(HLE,"Resolving %s/%08x",moduleName,nib);
-				// Note: doing that, we can't trace external module calls, so maybe something else should be done to debug more efficiently
+				INFO_LOG(HLE, "Resolving function symbol %s/%08x", moduleName, nib);
 				// Note that this should be J not JAL, as otherwise control will return to the stub..
 				Memory::Write_U32(MIPS_MAKE_J(address), sysc->symAddr);
+				// Note: doing that, we can't trace external module calls, so maybe something else should be done to debug more efficiently
+				// Perhaps a syscall here (and verify support in jit), marking the module by uid?
 				Memory::Write_U32(MIPS_MAKE_NOP(), sysc->symAddr + 4);
 			}
 		}

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -113,7 +113,9 @@ void HLEDoState(PointerWrap &p);
 void HLEShutdown();
 u32 GetNibByName(const char *module, const char *function);
 u32 GetSyscallOp(const char *module, u32 nib);
-void WriteSyscall(const char *module, u32 nib, u32 address);
+bool FuncImportIsSyscall(const char *module, u32 nib);
+bool WriteSyscall(const char *module, u32 nib, u32 address);
 void CallSyscall(MIPSOpcode op);
 void ResolveSyscall(const char *moduleName, u32 nib, u32 address);
-
+void WriteFuncStub(u32 stubAddr, u32 symAddr);
+void WriteFuncMissingStub(u32 stubAddr, u32 nid);


### PR DESCRIPTION
This makes a number of changes to the way module imports/exports are processed.
- Before, if a module was unloaded, its exports were still resolved when loading other modules (to garbage.)
- Similarly, if an unresolved import in an unloaded module was fulfilled, memory might be randomly overwritten.
- Exports are now "unresolved" (both var and func) when the module is unloaded (but only if the importer has not been unloaded.)
- Logging has been clarified to improve the distinction between a simple func import, and a syscall.  Yet unknown modules no longer show in red as errors.

I haven't really had much success testing this on a PSP, but games that require either var and func imports still work fine.  I'm hoping this will improve:
- Tales of the Word: Radiant Mythology 2/3, God Eater Burst 1/2 which I think have had problems in this area still.
- Potentially any of the games on these lists (although I'm mostly stabbing at the dark hoping some are affected):
  
  http://report.ppsspp.org/logs/kind/280?status=any
  http://report.ppsspp.org/logs/kind/281?status=any
  http://report.ppsspp.org/logs/kind/283?status=any

-[Unknown]
