### PR TITLE
Invalidate icache on stub/var import update

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -323,6 +323,54 @@
     <ClCompile Include="MIPS\MIPSIntVFPU.cpp" />
     <ClCompile Include="Mips\MIPSTables.cpp" />
     <ClCompile Include="MIPS\MIPSVFPUUtils.cpp" />
+    <ClCompile Include="MIPS\PPC\PpcAsm.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompAlu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompBranch.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompFpu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompLoadStore.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompVFPU.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcJit.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcRegCache.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="MIPS\x86\Asm.cpp" />
     <ClCompile Include="MIPS\x86\CompALU.cpp" />
     <ClCompile Include="MIPS\x86\CompBranch.cpp" />
@@ -481,6 +529,18 @@
     <ClInclude Include="MIPS\MIPSIntVFPU.h" />
     <ClInclude Include="Mips\MIPSTables.h" />
     <ClInclude Include="MIPS\MIPSVFPUUtils.h" />
+    <ClInclude Include="MIPS\PPC\PpcJit.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="MIPS\PPC\PpcRegCache.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="MIPS\x86\Asm.h" />
     <ClInclude Include="MIPS\x86\RegCacheFPU.h" />
     <ClInclude Include="MIPS\x86\Jit.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -52,6 +52,9 @@
     <Filter Include="Font">
       <UniqueIdentifier>{1c79e88d-1c48-450b-8af6-f22ce7d40c66}</UniqueIdentifier>
     </Filter>
+    <Filter Include="MIPS\PPC">
+      <UniqueIdentifier>{ac0e396a-6e16-4796-a0a0-b8ebf46ea74c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ELF\ElfReader.cpp">
@@ -460,6 +463,30 @@
     <ClCompile Include="..\ext\xxhash.c">
       <Filter>Ext</Filter>
     </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompLoadStore.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompVFPU.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcJit.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcRegCache.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompAlu.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompBranch.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcCompFpu.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\PPC\PpcAsm.cpp">
+      <Filter>MIPS\PPC</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -857,6 +884,12 @@
     </ClInclude>
     <ClInclude Include="..\ext\xxhash.h">
       <Filter>Ext</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\PPC\PpcJit.h">
+      <Filter>MIPS\PPC</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\PPC\PpcRegCache.h">
+      <Filter>MIPS\PPC</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -298,8 +298,9 @@ void CBreakPoints::Update(u32 addr)
 {
 	if (MIPSComp::jit && Core_IsInactive())
 	{
+		// In case this is a delay slot, clear the previous instruction too.
 		if (addr != 0)
-			MIPSComp::jit->ClearCacheAt(addr);
+			MIPSComp::jit->ClearCacheAt(addr - 4, 8);
 		else
 			MIPSComp::jit->ClearCache();
 	}

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -177,7 +177,6 @@ u32 GetSyscallOp(const char *moduleName, u32 nib)
 		else
 		{
 			INFO_LOG(HLE, "Syscall (%s, %08x) unknown", moduleName, nib);
-			Reporting::ReportMessage("Unknown syscall in known module: %s 0x%08x", moduleName, nib);
 			return (0x0003FFCC | (modindex<<18));  // invalid syscall
 		}
 	}

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -116,6 +116,5 @@ u32 GetSyscallOp(const char *module, u32 nib);
 bool FuncImportIsSyscall(const char *module, u32 nib);
 bool WriteSyscall(const char *module, u32 nib, u32 address);
 void CallSyscall(MIPSOpcode op);
-void ResolveSyscall(const char *moduleName, u32 nib, u32 address);
 void WriteFuncStub(u32 stubAddr, u32 symAddr);
 void WriteFuncMissingStub(u32 stubAddr, u32 nid);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -599,7 +599,7 @@ void ImportFuncSymbol(const FuncSymbolImport &func) {
 
 	// It hasn't been exported yet, but hopefully it will later.
 	if (GetModuleIndex(func.moduleName) != -1) {
-		WARN_LOG_REPORT(LOADER, "Unknown syscall (%s,%08x) imported", func.moduleName, func.nid);
+		WARN_LOG_REPORT(LOADER, "Unknown syscall in known module: %s 0x%08x", func.moduleName, func.nid);
 	} else {
 		INFO_LOG(LOADER, "Function (%s,%08x) unresolved, storing for later resolving", func.moduleName, func.nid);
 	}

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -118,10 +118,9 @@ void Jit::ClearCache()
 	GenerateFixedCode();
 }
 
-void Jit::ClearCacheAt(u32 em_address)
+void Jit::ClearCacheAt(u32 em_address, int length)
 {
-	// TODO: Properly.
-	ClearCache();
+	blocks.InvalidateICache(em_address, length);
 }
 
 void Jit::CompileAt(u32 addr)

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -230,7 +230,7 @@ public:
 	JitBlockCache *GetBlockCache() { return &blocks; }
 
 	void ClearCache();
-	void ClearCacheAt(u32 em_address);
+	void ClearCacheAt(u32 em_address, int length = 4);
 
 	void EatPrefix() { js.EatPrefix(); }
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -230,6 +230,13 @@ u32 MIPSState::ReadFCR(int reg)
 	return 0;
 }
 
+void MIPSState::InvalidateICache(u32 address, int length)
+{
+	// Only really applies to jit.
+	if (MIPSComp::jit)
+		MIPSComp::jit->ClearCacheAt(address, length);
+}
+
 
 // Interrupts should be served directly on the running thread.
 void MIPSState::Irq()

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -168,6 +168,8 @@ public:
 
 	void SingleStep();
 	int RunLoopUntil(u64 globalTicks);
+	// To clear jit caches, etc.
+	void InvalidateICache(u32 address, int length = 4);
 
 	// for logging messages only.
 	const char *DisasmAt(u32 compilerPC);
@@ -181,12 +183,6 @@ extern MIPSState *currentMIPS;
 extern MIPSDebugInterface *currentDebugMIPS;
 extern MIPSState mipsr4k;
 
-void MIPS_Init();
 int MIPS_SingleStep();
-
-void MIPS_Shutdown();
-
-void MIPS_Irq();
-void MIPS_SWI();
 
 extern const float cst_constants[32];

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -121,7 +121,7 @@ const char *MIPSDebugInterface::disasm(unsigned int address, unsigned int align)
 }
 unsigned int MIPSDebugInterface::readMemory(unsigned int address)
 {
-	return Memory::Read_U32(address);
+	return Memory::Read_Instruction(address).encoding;
 }
 
 bool MIPSDebugInterface::isAlive()

--- a/Core/MIPS/PPC/PpcJit.cpp
+++ b/Core/MIPS/PPC/PpcJit.cpp
@@ -169,8 +169,8 @@ void Jit::ClearCache() {
 	GenerateFixedCode();
 }
 
-void Jit::ClearCacheAt(u32 em_address) {
-	ClearCache();
+void Jit::ClearCacheAt(u32 em_address, int length) {
+	blocks.InvalidateICache(em_address, length);
 }
 
 Jit::Jit(MIPSState *mips) : blocks(mips, this), gpr(mips, &jo),mips_(mips)

--- a/Core/MIPS/PPC/PpcJit.h
+++ b/Core/MIPS/PPC/PpcJit.h
@@ -242,7 +242,7 @@ namespace MIPSComp
 		void WriteSyscallExit();
 
 		void ClearCache();
-		void ClearCacheAt(u32 em_address);	
+		void ClearCacheAt(u32 em_address, int length = 4);
 
 		void RunLoopUntil(u64 globalticks);
 		void GenerateFixedCode();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -188,10 +188,9 @@ void Jit::ClearCache()
 	ClearCodeSpace();
 }
 
-void Jit::ClearCacheAt(u32 em_address)
+void Jit::ClearCacheAt(u32 em_address, int length)
 {
-	// TODO: Properly.
-	ClearCache();
+	blocks.InvalidateICache(em_address, length);
 }
 
 void Jit::CompileDelaySlot(int flags, RegCacheState *state)

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -266,7 +266,7 @@ public:
 	AsmRoutineManager &Asm() { return asm_; }
 
 	void ClearCache();
-	void ClearCacheAt(u32 em_address);
+	void ClearCacheAt(u32 em_address, int length = 4);
 private:
 	void GetStateAndFlushAll(RegCacheState &state);
 	void RestoreState(const RegCacheState state);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -867,8 +867,6 @@ void GPUCommon::DoState(PointerWrap &p) {
 		currentList = &dls[currentID];
 	}
 	p.Do(interruptRunning);
-	u32 prev;  // TODO: kill. just didn't want to break states right now...
-	p.Do(prev);
 	p.Do(gpuState);
 	p.Do(isbreak);
 	p.Do(drawCompleteTicks);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -308,9 +308,10 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 	result = MIPSAsm::MipsAssembleOpcode(op.c_str(),debugger,address,encoded);
 	if (result == true)
 	{
-		Memory::Write_U32(encoded,address);
+		Memory::Write_U32(encoded, address);
+		// In case this is a delay slot or combined instruction, clear cache above it too.
 		if (MIPSComp::jit)
-			MIPSComp::jit->ClearCacheAt(address);
+			MIPSComp::jit->ClearCacheAt(address - 4, 8);
 		redraw();
 	} else {
 		MessageBox(wnd,L"Couldn't assemble.",L"Error",MB_OK);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -309,7 +309,8 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 	if (result == true)
 	{
 		Memory::Write_U32(encoded,address);
-		MIPSComp::jit->ClearCacheAt(address);
+		if (MIPSComp::jit)
+			MIPSComp::jit->ClearCacheAt(address);
 		redraw();
 	} else {
 		MessageBox(wnd,L"Couldn't assemble.",L"Error",MB_OK);


### PR DESCRIPTION
Because this needs to be done within a syscall, uses `blocks.InvalidateICache()`.  Took me a while to realize why that was glitching out at first, but I figured it out.

I hope I didn't make `JitBlockCache::GetBlockNumberFromEmuHackOp()` noticeably slower (I don't think so.)

Also worth noting is that `JitBlockCache::InvalidateICache()` probably won't work if continuing is enabled.  I think we'd need to keep two maps to make that work (one for start, one for end)?

We could probably also now implement sceKernelInvalidateICache and friends now, although didn't want to do that in this pull.

-[Unknown]
