### PR TITLE
Proper assembler error messages

### DIFF
--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -6,6 +6,22 @@
 namespace MIPSAsm
 {
 	
+char errorMessage[512];
+
+void SetAssembleError(char* format, ...)
+{
+	va_list args;
+
+	va_start(args,format);
+	vsprintf(errorMessage,format,args);
+	va_end (args);
+}
+
+char* GetAssembleError()
+{
+	return errorMessage;
+}
+
 void SplitLine(const char* Line, char* Name, char* Arguments)
 {
 	while (*Line == ' ' || *Line == '\t') Line++;
@@ -166,9 +182,9 @@ bool CMipsInstruction::Load(char* Name, char* Params, int RamPos)
 	{
 		if (paramfail == true)
 		{
-	//		PrintError(ERROR_ERROR,"Parameter failure \"%s\"",Params);
+			SetAssembleError("Parameter failure \"%s\"",Params);
 		} else {
-	//		PrintError(ERROR_ERROR,"Invalid opcode \"%s\"",Name);
+			SetAssembleError("Invalid opcode \"%s\"",Name);
 		}
 	}
 	return false;
@@ -301,7 +317,7 @@ bool CMipsInstruction::Validate()
 			
 			if (num > 0x20000 || num < (-0x20000))
 			{
-				//QueueError(ERROR_ERROR,"Branch target %08X out of range",Vars.Immediate);
+				SetAssembleError("Branch target %08X out of range",Vars.Immediate);
 				return false;
 			}
 			Vars.Immediate = num >> 2;
@@ -312,7 +328,7 @@ bool CMipsInstruction::Validate()
 		case MIPS_IMMEDIATE5:
 			if (Vars.Immediate > 0x1F)
 			{
-			//	QueueError(ERROR_ERROR,"Immediate value %02X out of range",Vars.OriginalImmediate);
+				SetAssembleError("Immediate value %02X out of range",Vars.OriginalImmediate);
 				return false;
 			}
 			break;
@@ -321,7 +337,7 @@ bool CMipsInstruction::Validate()
 		case MIPS_IMMEDIATE16:
 			if (abs(Vars.Immediate) > 0x0000FFFF)
 			{
-			//	QueueError(ERROR_ERROR,"Immediate value %04X out of range",Vars.OriginalImmediate);
+				SetAssembleError("Immediate value %04X out of range",Vars.OriginalImmediate);
 				return false;
 			}
 			Vars.Immediate &= 0x0000FFFF;
@@ -329,7 +345,7 @@ bool CMipsInstruction::Validate()
 		case MIPS_IMMEDIATE20:
 			if (abs(Vars.Immediate) > 0x000FFFFF)
 			{
-			//	QueueError(ERROR_ERROR,"Immediate value %08X out of range",Vars.OriginalImmediate);
+				SetAssembleError("Immediate value %08X out of range",Vars.OriginalImmediate);
 				return false;
 			}
 			Vars.Immediate &= 0x000FFFFF;
@@ -337,7 +353,7 @@ bool CMipsInstruction::Validate()
 		case MIPS_IMMEDIATE26:
 			if (abs(Vars.Immediate) > 0x03FFFFFF)
 			{
-		//		QueueError(ERROR_ERROR,"Immediate value %08X out of range",Vars.OriginalImmediate);
+				SetAssembleError("Immediate value %08X out of range",Vars.OriginalImmediate);
 				return false;
 			}
 			Vars.Immediate &= 0x03FFFFFF;

--- a/Core/MIPS/MIPSAsm.h
+++ b/Core/MIPS/MIPSAsm.h
@@ -39,4 +39,6 @@ private:
 	u32 encoding;
 };
 
+char* GetAssembleError();
+
 }

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -252,9 +252,9 @@ namespace MIPSDis
 		if (rs==0 && rt==0)
 			sprintf(out,"li\t%s, 0",RN(rd));
 		else if (rs == 0)
-			sprintf(out,"mov\t%s, %s",RN(rd),RN(rt));
+			sprintf(out,"move\t%s, %s",RN(rd),RN(rt));
 		else if (rt == 0)
-			sprintf(out,"mov\t%s, %s",RN(rd),RN(rs));
+			sprintf(out,"move\t%s, %s",RN(rd),RN(rs));
 		else
 			sprintf(out, "%s\t%s, %s, %s",name,RN(rd),RN(rs),RN(rt));
 	}

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -314,7 +314,8 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 			MIPSComp::jit->ClearCacheAt(address - 4, 8);
 		redraw();
 	} else {
-		MessageBox(wnd,L"Couldn't assemble.",L"Error",MB_OK);
+		std::wstring error = ConvertUTF8ToWString(MIPSAsm::GetAssembleError());
+		MessageBox(wnd,error.c_str(),L"Error",MB_OK);
 	}
 }
 


### PR DESCRIPTION
Now it actually displays why it couldn't assemble. I also corrected the name of the move opcode, mov isn't commonly used for it.
