### PR TITLE
Game loading: Fix a bug and prevent a "file is corrupt" error for demos/np PBPs that really aren't corrupt.

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -162,6 +162,13 @@ bool LoadFile(std::string &filename, std::string *error_string) {
 
 			if (fileInfo.exists) {
 				INFO_LOG(LOADER, "File is a PBP in a directory!");
+				std::string ebootPath = filename + "/EBOOT.PBP";
+				IdentifiedFileType ebootType = Identify_File(ebootPath);
+				if(ebootType == FILETYPE_PSP_ISO_NP) {
+					InitMemoryForGameISO(ebootPath);
+					pspFileSystem.SetStartingDirectory("disc0:/PSP_GAME/USRDIR");
+					return Load_PSP_ISO(filename.c_str(), error_string);
+				}
 				std::string path = filename;
 				size_t pos = path.find("/PSP/GAME/");
 				if (pos != std::string::npos)
@@ -213,6 +220,7 @@ bool LoadFile(std::string &filename, std::string *error_string) {
 
 	case FILETYPE_NORMAL_DIRECTORY:
 		ERROR_LOG(LOADER, "Just a directory.");
+		*error_string = "Just a directory.";
 		break;
 
 	case FILETYPE_UNKNOWN_BIN:


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/3328. Also fixes a black screen that would occur if you drop a blank directory onto PPSSPP.
