### PR TITLE
Search in memory view

### DIFF
--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -447,7 +447,7 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				if (asciiSelected)
 				{
 					unsigned char c = Memory::IsValidAddress(curAddress) ? Memory::ReadUnchecked_U8(curAddress) : '.';
-					if (c < 32) c = '.';
+					if (c < 32|| c >= 128) c = '.';
 					sprintf(temp,"%c",c);
 				} else {
 					sprintf(temp,"%02X",Memory::IsValidAddress(curAddress) ? Memory::ReadUnchecked_U8(curAddress) : 0xFF);

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -40,11 +40,16 @@ class CtrlMemView
 	bool ctrlDown;
 
 	int visibleRows;
+	
+	std::string searchQuery;
+	int matchAddress;
+	bool searching;
 
 	bool hasFocus;
 	static wchar_t szClassName[];
 	DebugInterface *debugger;
 	void updateStatusBarText();
+	void search(bool continueSearch);
 public:
 	CtrlMemView(HWND _wnd);
 	~CtrlMemView();


### PR DESCRIPTION
Adds a search to each memory view control. There are two modes, depending on which side is highlighted.
-if ascii is highlighted, then it'll just search for the string that was input
-if the hex data is highlighted, then it'll parse the input string as a sequence of bytes. Like "FF FF FF" or "AABBCC". Spaces are optional

Ctrl+S or Ctrl+F to start, Ctrl+C to continue, Escape to cancel an active search.
