### PR TITLE
Don't trash a list the GE interrupt handler needs

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -55,6 +55,11 @@ public:
 	{
 		GeInterruptData intrdata = ge_pending_cb.front();
 		DisplayList* dl = gpu->getList(intrdata.listid);
+		if (!dl->interruptsEnabled)
+		{
+			ERROR_LOG_REPORT(HLE, "Unable to run GE interrupt: list has interrupts disabled, should not happen");
+			return false;
+		}
 
 		if (dl == NULL)
 		{
@@ -120,6 +125,11 @@ public:
 		ge_pending_cb.pop_front();
 
 		DisplayList* dl = gpu->getList(intrdata.listid);
+		if (!dl->interruptsEnabled)
+		{
+			ERROR_LOG_REPORT(HLE, "Unable to finish GE interrupt: list has interrupts disabled, should not happen");
+			return;
+		}
 
 		switch (dl->signal)
 		{

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -129,6 +129,7 @@ struct DisplayList
 	bool interrupted;
 	u64 waitTicks;
 	bool interruptsEnabled;
+	bool pendingInterrupt;
 };
 
 enum GPUInvalidationType {


### PR DESCRIPTION
Even after it's marked COMPLETED, the CPU needs it to start and finish the interrupt.

In Wild Arms XF (#2956), an existing completed list was not having its interrupt run correctly, because the id got stolen and overwritten by the PPGe stuff.  By the time the interrupt actually triggered (which is a scheduled event), the data was wrong/different.

Probably the original source of the problems in Final Fantasy Type-0 and 3rd Birthday.

@raven02 is the "CoreTiming::Advance()" still needed in Type-0 here?

``` c++
int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
{
    DEBUG_LOG(HLE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
    hleEatCycles(190);
    CoreTiming::Advance();
    return gpu->UpdateStall(displayListID, stallAddress);
}
```

May also improve things related to multithreading, I think/hope.

Makes Wild Arms XF basically playable afaict.  Didn't try to go too far.

-[Unknown]
