### PR TITLE
Fix some const char * conversion warnings

### DIFF
--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -198,7 +198,7 @@ bool CMipsInstruction::LoadEncoding(const tMipsOpcode& SourceOpcode, char* Line)
 	int RetLen;
 	bool Immediate = false;
 
-	char* SourceEncoding = SourceOpcode.encoding;
+	const char *SourceEncoding = SourceOpcode.encoding;
 	char* OriginalLine = Line;
 
 	while (*Line == ' ' || *Line == '\t') Line++;

--- a/Core/MIPS/MIPSAsmTables.h
+++ b/Core/MIPS/MIPSAsmTables.h
@@ -4,14 +4,14 @@ namespace MIPSAsm
 {
 
 typedef struct {
-	char* name;
-	char* encoding;
+	const char *name;
+	const char *encoding;
 	unsigned int destencoding;
 	unsigned int flags;
 } tMipsOpcode;
 
 typedef struct {
-	char* name;
+	const char *name;
 	short num;
 	short len;
 } tMipsRegister;


### PR DESCRIPTION
Since they are used with constant strings.  Should fix the warnings referred to here:
https://github.com/hrydgard/ppsspp/commit/1189f103973e4cbc7f9c1f51e5fb4cd738de5eda#commitcomment-3991277

-[Unknown]
