### PR TITLE
Allow up to 6 lines for translator names.

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -472,7 +472,12 @@ void CreditsScreen::render() {
 		"all the forum mods",
 		"",
 		c->T("this translation by", ""),   // Empty string as this is the original :)
-		"",
+		c->T("translators1", ""),
+		c->T("translators2", ""),
+		c->T("translators3", ""),
+		c->T("translators4", ""),
+		c->T("translators5", ""),
+		c->T("translators6", ""),
 		c->T("written", "Written in C++ for speed and portability"),
 		"",
 		"",

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -478,6 +478,7 @@ void CreditsScreen::render() {
 		c->T("translators4", ""),
 		c->T("translators5", ""),
 		c->T("translators6", ""),
+		"",
 		c->T("written", "Written in C++ for speed and portability"),
 		"",
 		"",


### PR DESCRIPTION
Or I guess 7 if you add some to the "this translation by" line.

Useful for English, Chinese, and others that have like 5 or more contributors, since newlines don't work well in the credits.
