### PR TITLE
More error handling in sas, bitrate info fix in mp3

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -380,7 +380,7 @@ int sceMp3Init(u32 mp3) {
 
 	ctx->mp3SamplingRate = ctx->decoder_context->sample_rate;
 	ctx->mp3Channels = ctx->decoder_context->channels;
-	ctx->mp3Bitrate = ctx->decoder_context->bit_rate;
+	ctx->mp3Bitrate = ctx->decoder_context->bit_rate / 1000;
 
 	if (!ctx->resampler_context) {
 		ERROR_LOG(HLE, "Could not allocate resampler context %d", ret);

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -86,6 +86,10 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 		ERROR_LOG_REPORT(HLE, "sceSasInit(%08x, %i, %i, %i, %i): bad output mode", core, grainSize, maxVoices, outputMode, sampleRate);
 		return ERROR_SAS_INVALID_OUTPUT_MODE;
 	}
+	if (sampleRate != 44100) {
+		ERROR_LOG_REPORT(HLE, "sceSasInit(%08x, %i, %i, %i, %i): bad sample rate", core, grainSize, maxVoices, outputMode, sampleRate);
+		return ERROR_SAS_INVALID_SAMPLE_RATE;
+	}
 	INFO_LOG(HLE, "sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
 
 	sas->SetGrainSize(grainSize);

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -66,11 +66,11 @@ struct WaveformEffect
 enum VoiceType {
 	VOICETYPE_OFF,
 	VOICETYPE_VAG,  // default
-	VOICETYPE_PCM,
 	VOICETYPE_NOISE,
-	VOICETYPE_ATRAC3,
 	VOICETYPE_TRIWAVE,  // are these used? there are functions for them (sceSetTriangularWave)
 	VOICETYPE_PULSEWAVE,
+	VOICETYPE_PCM,
+	VOICETYPE_ATRAC3,
 };
 
 // VAG is a Sony ADPCM audio compression format, which goes all the way back to the PSX.

--- a/test.py
+++ b/test.py
@@ -69,6 +69,8 @@ tests_good = [
   "cpu/fpu/fpu",
 
   "audio/atrac/ids",
+  "audio/mp3/mp3test",
+  "audio/sascore/sascore",
   "ctrl/ctrl",
   "ctrl/idle/idle",
   "ctrl/sampling/sampling",
@@ -185,8 +187,6 @@ tests_good = [
 tests_next = [
 # These are the next tests up for fixing. These run by default.
   "audio/atrac/atractest",
-  "audio/mp3/mp3test",
-  "audio/sascore/sascore",
   "audio/sceaudio/datalen",
   "audio/sceaudio/output",
   "audio/sceaudio/reserve",


### PR DESCRIPTION
Neither should really affect functionality, although maybe user mp3s might've been failing validation before or something.

Accept hrydgard/pspautotests#98 first.  Now both tests pass.

-[Unknown]
