### PR TITLE
Fix negative texel wrapping in softgpu

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -104,15 +104,15 @@ static inline void GetTexelCoordinates(int level, float s, float t, unsigned int
 		if (s > 1.0) s = 1.0;
 		if (s < 0) s = 0;
 	} else {
-		// TODO: Does this work for negative coords?
-		s = fmod(s, 1.0f);
+		// Subtracting floor works for negative and positive to discard the non-fractional part.
+		s -= floor(s);
 	}
 	if (gstate.isTexCoordClampedT()) {
 		if (t > 1.0) t = 1.0;
 		if (t < 0.0) t = 0.0;
 	} else {
-		// TODO: Does this work for negative coords?
-		t = fmod(t, 1.0f);
+		// Subtracting floor works for negative and positive to discard the non-fractional part.
+		t -= floor(t);
 	}
 
 	int width = 1 << (gstate.texsize[level] & 0xf);


### PR DESCRIPTION
Answer to the comment: no, it doesn't.  So it was crashing.  Adding abs() helped, but I found that using floor() was faster (we're only talking 2-3% speed -> 3.6% speed, though... I guess that's 20% faster, heh, but probably only for that scene.)

No longer crashes in Jeanne d'Arc, still looks awful.  Was wondering if maybe it showed the characters.

To confirm my math:

```
  -0.3 - floor(-0.3)
= -0.3 - -1.0
=  0.7

   0.6 - floor(0.6)
=  0.6 - 0.0
=  0.6
```

-[Unknown]
