### PR TITLE
Add depthTest along with stencilTest since depth Fail/ZPass test used .

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -297,7 +297,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		glstate.colorMask.set(rmask, gmask, bmask, amask);
 		
 		// Stencil Test
-		if (gstate.isStencilTestEnabled()) {
+		if (gstate.isStencilTestEnabled() && gstate.isDepthTestEnabled()) {
 			glstate.stencilTest.enable();
 			glstate.stencilFunc.set(ztests[gstate.getStencilTestFunction()],
 				gstate.getStencilTestRef(),


### PR DESCRIPTION
Fix missing character in Star Ocean and FF 4 complete collection in buffered-rendering mode.

https://github.com/hrydgard/ppsspp/issues/1392 , https://github.com/hrydgard/ppsspp/issues/2018

Already tested with 20 other titles and seems to be fine.
