### PR TITLE
fix cwcheat list incompletely shown and resize the check button

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -67,7 +67,7 @@ void CwCheatScreen::CreateViews() {
 	I18NCategory *d = GetI18NCategory("Dialog");
 	formattedList = CreateCodeList();
 	root_ = new LinearLayout(ORIENT_HORIZONTAL);
-	Margins actionMenuMargins(50, 100, 100, 50);
+	Margins actionMenuMargins(50, -15, 15, 0);
 
 	LinearLayout *leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(400, FILL_PARENT));
 	leftColumn->Add(new ItemHeader(k->T("Options")));


### PR DESCRIPTION
When cheat list is long, some of the cheat items at the bottom can not been shown. This will fix it.
Moreover, the check button is resized according to the marge of the screen, to fit better and contain long button title.
