### PR TITLE
Fix a null check

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -55,15 +55,16 @@ public:
 	{
 		GeInterruptData intrdata = ge_pending_cb.front();
 		DisplayList* dl = gpu->getList(intrdata.listid);
-		if (!dl->interruptsEnabled)
-		{
-			ERROR_LOG_REPORT(HLE, "Unable to run GE interrupt: list has interrupts disabled, should not happen");
-			return false;
-		}
 
 		if (dl == NULL)
 		{
 			WARN_LOG(HLE, "Unable to run GE interrupt: list doesn't exist: %d", intrdata.listid);
+			return false;
+		}
+
+		if (!dl->interruptsEnabled)
+		{
+			ERROR_LOG_REPORT(HLE, "Unable to run GE interrupt: list has interrupts disabled, should not happen");
 			return false;
 		}
 


### PR DESCRIPTION
Previously it would evaluate the if statment starting with

`if (!dl->interruptsEnabled)` first and not the null check. This fixes that.
