### PR TITLE
Fix a null check in sceKernel.cpp

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -511,11 +511,12 @@ void KernelObjectPool::DoState(PointerWrap &p)
 		{
 			p.Do(type);
 			pool[i] = CreateByIDType(type);
-			pool[i]->uid = i + handleOffset;
 
 			// Already logged an error.
 			if (pool[i] == NULL)
 				return;
+
+			pool[i]->uid = i + handleOffset;
 		}
 		else
 		{


### PR DESCRIPTION
Since CreateByIDType() can return null, it seems odd that the null check would be after the statement `pool[i]->uid = i + handleOffset;`
