### PR TITLE
Remove a redundant wcsncat call.

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -788,11 +788,7 @@ int PSPOskDialog::NativeKeyboard()
 
 		std::wstring inputWide;
 
-		if(!host->InputBoxGetWString(titleText.c_str(), defaultText, inputWide)) 
-		{
-			wcsncat(input, L"", wcslen(L""));
-		}
-		else 
+		if(host->InputBoxGetWString(titleText.c_str(), defaultText, inputWide)) 
 		{
 			size_t maxInputLength = FieldMaxLength();
 


### PR DESCRIPTION
Just makes the else statement the dominant branch.
