### PR TITLE
Fix some minor things in sceAudio

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -155,7 +155,7 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking) {
 
 	// If there's anything on the queue at all, it should be busy, but we try to be a bit lax.
 	//if (chan.sampleQueue.size() > chan.sampleCount * 2 * chanQueueMaxSizeFactor || chan.sampleAddress == 0) {
-	if (chan.sampleQueue.size() > 0 || chan.sampleAddress == 0) {
+	if (chan.sampleQueue.size() > 0) {
 		if (blocking) {
 			// TODO: Regular multichannel audio seems to block for 64 samples less?  Or enqueue the first 64 sync?
 			int blockSamples = (int)chan.sampleQueue.size() / 2 / chanQueueMinSizeFactor;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -340,7 +340,7 @@ u32 sceAudioOutput2GetRestSample(){
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
 	DEBUG_LOG(HLE,"sceAudioOutput2GetRestSample()");
-	return (u32) chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleQueue.size() * 2;
+	return (u32) chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleQueue.size() / 2;
 }
 
 u32 sceAudioOutput2Release(){

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -92,7 +92,8 @@ u32 sceAudioOutputBlocking(u32 chan, int vol, u32 samplePtr) {
 }
 
 u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
-	if (leftvol > 0xFFFF || rightvol > 0xFFFF) {
+	// For some reason, this is the only one that checks for negative.
+	if (leftvol > 0xFFFF || rightvol > 0xFFFF || leftvol < 0 || rightvol < 0) {
 		ERROR_LOG(HLE, "sceAudioOutputPannedBlocking() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
 	} else if (chan >= PSP_AUDIO_CHANNEL_MAX) {


### PR DESCRIPTION
sceAudioOutput2GetRestSample() should be samples, not bytes, I'm pretty sure.

Not sure if these will help anything, improves the audio test slightly.

-[Unknown]
