### PR TITLE
Fix Reloading cheats

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -66,6 +66,7 @@ void CwCheatScreen::CreateViews() {
 	I18NCategory *k = GetI18NCategory("CwCheats");
 	I18NCategory *d = GetI18NCategory("Dialog");
 	formattedList = CreateCodeList();
+	g_Config.bReloadCheats = true;
 	root_ = new LinearLayout(ORIENT_HORIZONTAL);
 	Margins actionMenuMargins(50, -15, 15, 0);
 


### PR DESCRIPTION
Cheats list will now flag the refresh bool when the cheats menu is opened. Fixes problems people were having with not being able to enable/disable cheats
