### PR TITLE
Android : use QCOM_alpha_test if available

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -31,6 +31,7 @@
 #include "Framebuffer.h"
 #include "../ge_constants.h"
 #include "../GPUState.h"
+#include "gfx_es2/gl_state.h"
 #include <cstdio>
 
 #define WRITE p+=sprintf
@@ -57,6 +58,13 @@ const bool safeDestFactors[16] = {
 
 
 static bool IsAlphaTestTriviallyTrue() {
+
+#ifdef ANDROID
+	// Always return true when QCOM alpha test extension detected.
+	if (gl_extensions.QCOM_alpha_test)
+		return true;
+#endif
+
 	GEComparison alphaTestFunc = gstate.getAlphaTestFunction();
 	int alphaTestRef = gstate.getAlphaTestRef();
 	int alphaTestMask = gstate.getAlphaTestMask();

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -149,6 +149,11 @@ void DisableState() {
 #if !defined(USING_GLES2)
 	glstate.colorLogicOp.disable();
 #endif
+
+#ifdef ANDROID
+	if (gl_extensions.QCOM_alpha_test)
+		glstate.alphaTestQCOM.disable();
+#endif
 }
 
 void FramebufferManager::CompileDraw2DProgram() {

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -264,13 +264,14 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.stencilTest.enable();
 			glstate.stencilOp.set(GL_REPLACE, GL_REPLACE, GL_REPLACE);
 			glstate.stencilFunc.set(GL_ALWAYS, 0, 0xFF);
-		} else {
+		} else 
 			glstate.stencilTest.disable();
+			
 #ifdef ANDROID
+		// QCOM alpha test
 		if (gl_extensions.QCOM_alpha_test) 
 			glstate.alphaTestQCOM.disable();
 #endif
-		}
 	} else {
 
 #if !defined(USING_GLES2)
@@ -318,6 +319,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.stencilTest.disable();
 
 #ifdef ANDROID
+		// QCOM alpha test
 		if (gl_extensions.QCOM_alpha_test) {
 			if (gstate.isAlphaTestEnabled()) {
 				glstate.alphaTestQCOM.enable();

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -683,10 +683,14 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		bool colorMask = gstate.isClearModeColorMask();
 		bool alphaMask = gstate.isClearModeAlphaMask();
 		glstate.colorMask.set(colorMask, colorMask, colorMask, alphaMask);
-		glstate.stencilTest.set(false);
-		glstate.scissorTest.set(false);
+		glstate.scissorTest.disable();
+		glstate.stencilTest.disable();
 		bool depthMask = gstate.isClearModeDepthMask();
 
+#ifdef ANDROID
+		if (gl_extensions.QCOM_alpha_test)
+			glstate.alphaTestQCOM.disable();
+#endif
 		int target = 0;
 		if (colorMask || alphaMask) target |= GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
 		if (depthMask) target |= GL_DEPTH_BUFFER_BIT;

--- a/UI/UIShader.cpp
+++ b/UI/UIShader.cpp
@@ -98,8 +98,13 @@ void UIShader_Prepare()
 #if !defined(USING_GLES2)
   	glstate.colorLogicOp.disable();
 #endif 
-	glstate.dither.enable();
 
+#ifdef ANDROID
+	if (gl_extensions.QCOM_alpha_test) 
+		glstate.alphaTestQCOM.disable();
+#endif
+
+	glstate.dither.enable();
 	glstate.blend.enable();
 	glstate.blendFuncSeparate.set(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glstate.blendEquation.set(GL_FUNC_ADD);


### PR DESCRIPTION
Courtesy of @unknownbrackets which bring up the QCOM_alpha_test idea previously  .

Since QCOM_binning_control rolled out yesterday so i copy and paste from his branch and roll out the  QCOM_alpha_test here as well so we can have wider testing them altogether
