### PR TITLE
Delete framebuffers on format change

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -491,17 +491,22 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address) && (g_Config.bTrueColor || v->format == fmt)) {
-			// Let's not be so picky for now. Let's say this is the one.
-			vfb = v;
-			// Update fb stride in case it changed
-			vfb->fb_stride = fb_stride;
-			vfb->format = fmt;
-			if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) { 
-				v->width = drawing_width;
-				v->height = drawing_height;
-			} 
-			break; 
+		if (MaskedEqual(v->fb_address, fb_address)) {
+			// Let's not be so picky, format is enough to match.
+			if (v->format == fmt) {
+				vfb = v;
+				// Update fb stride in case it changed
+				vfb->fb_stride = fb_stride;
+				if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) { 
+					v->width = drawing_width;
+					v->height = drawing_height;
+				} 
+				break; 
+			} else {
+				// Okay, let's burn this with fire, it's the wrong format, we're replacing it.
+				DestroyFramebuf(v);
+				vfbs_.erase(vfbs_.begin() + i--);
+			}
 		} 
 	}
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -491,11 +491,12 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address) &&  v->format == fmt) {
+		if (MaskedEqual(v->fb_address, fb_address) && (g_Config.bTrueColor || v->format == fmt)) {
 			// Let's not be so picky for now. Let's say this is the one.
 			vfb = v;
 			// Update fb stride in case it changed
 			vfb->fb_stride = fb_stride;
+			vfb->format = fmt;
 			if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) { 
 				v->width = drawing_width;
 				v->height = drawing_height;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -195,7 +195,7 @@ inline void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, V
 	// If they match exactly, it's non-CLUT and from the top left.
 	if (exactMatch) {
 		DEBUG_LOG(HLE, "Render to texture detected at %08x!", address);
-		if (!entry->framebuffer) {
+		if (!entry->framebuffer || entry->invalidHint == -1) {
 			if (entry->format != framebuffer->format) {
 				WARN_LOG_REPORT_ONCE(diffFormat1, HLE, "Render to texture with different formats %d != %d", entry->format, framebuffer->format);
 				// If it already has one, let's hope that one is correct.


### PR DESCRIPTION
This fixes #2758 and seems likely to fix other games mentioned there too.

The only dangerous thing is it might churn if the game uses the same memory as two types of framebuffers over and over.

-[Unknown]
