### PR TITLE
Revert deletion, fix render-to-texture cache matching instead

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -491,7 +491,7 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address) && (g_Config.bTrueColor || v->format == fmt)) {
+		if (MaskedEqual(v->fb_address, fb_address) && v->format == fmt) {
 			// Let's not be so picky for now. Let's say this is the one.
 			vfb = v;
 			// Update fb stride in case it changed

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -491,22 +491,17 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address)) {
-			// Let's not be so picky, format is enough to match.
-			if (v->format == fmt) {
-				vfb = v;
-				// Update fb stride in case it changed
-				vfb->fb_stride = fb_stride;
-				if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) { 
-					v->width = drawing_width;
-					v->height = drawing_height;
-				} 
-				break; 
-			} else {
-				// Okay, let's burn this with fire, it's the wrong format, we're replacing it.
-				DestroyFramebuf(v);
-				vfbs_.erase(vfbs_.begin() + i--);
-			}
+		if (MaskedEqual(v->fb_address, fb_address) && (g_Config.bTrueColor || v->format == fmt)) {
+			// Let's not be so picky for now. Let's say this is the one.
+			vfb = v;
+			// Update fb stride in case it changed
+			vfb->fb_stride = fb_stride;
+			vfb->format = fmt;
+			if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) { 
+				v->width = drawing_width;
+				v->height = drawing_height;
+			} 
+			break; 
 		} 
 	}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1064,18 +1064,18 @@ void TextureCache::SetTexture() {
 	
 	if (iter != cache.end()) {
 		entry = &iter->second;
+		// Validate the texture still matches the cache entry.
+		int dim = gstate.texsize[0] & 0xF0F;
+		bool match = entry->Matches(dim, format, maxLevel);
+
 		// Check for FBO - slow!
-		if (entry->framebuffer) {
+		if (entry->framebuffer && match) {
 			SetTextureFramebuffer(entry);
 			lastBoundTexture = -1;
 			entry->lastFrame = gpuStats.numFlips;
 			return;
 		}
 
-		// Validate the texture here (width, height etc)
-
-		int dim = gstate.texsize[0] & 0xF0F;
-		bool match = entry->Matches(dim, format, maxLevel);
 		bool rehash = (entry->status & TexCacheEntry::STATUS_MASK) == TexCacheEntry::STATUS_UNRELIABLE;
 		bool doDelete = true;
 


### PR DESCRIPTION
It was caching the texture at the old format, and then just never updating it if the game used the same address with a new format.  This was the real cause of the Tactics Ogre issues.

Reverting deletion because it makes Kingdom Hearts really slow.  See #2926.

-[Unknown]
