### PR TITLE
Don't ignore the low bits of the framebuf pointer

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -466,10 +466,10 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	gstate_c.framebufChanged = false;
 
 	// Get parameters
-	u32 fb_address = (gstate.fbptr & 0xFFE000) | ((gstate.fbwidth & 0xFF0000) << 8);
+	u32 fb_address = (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8);
 	int fb_stride = gstate.fbwidth & 0x3C0;
 
-	u32 z_address = (gstate.zbptr & 0xFFE000) | ((gstate.zbwidth & 0xFF0000) << 8);
+	u32 z_address = (gstate.zbptr & 0xFFFFFF) | ((gstate.zbwidth & 0xFF0000) << 8);
 	int z_stride = gstate.zbwidth & 0x3C0;
 
 	// Yeah this is not completely right. but it'll do for now.

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -359,11 +359,7 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_FRAMEBUFPTR:
 		{
-			u32 ptr = op & 0xFFE000;
-			if (data & ~0xFFE000)
-				sprintf(buffer, "FramebufPtr: %08x (extra %x)", ptr, data);
-			else
-				sprintf(buffer, "FramebufPtr: %08x", ptr);
+			sprintf(buffer, "FramebufPtr: %08x", data);
 		}
 		break;
 
@@ -534,11 +530,7 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer) {
 
 	case GE_CMD_ZBUFPTR:
 		{
-			u32 ptr = op & 0xFFE000;
-			if (data & ~0xFFE000)
-				sprintf(buffer, "Zbuf ptr: %06x (extra %x)", ptr, data);
-			else
-				sprintf(buffer, "Zbuf ptr: %06x", ptr);
+			sprintf(buffer, "Zbuf ptr: %06x", data);
 		}
 		break;
 

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -214,17 +214,11 @@ void NullGPU::ExecuteOp(u32 op, u32 diff)
 		break;
 
 	case GE_CMD_FRAMEBUFPTR:
-		{
-			u32 ptr = op & 0xFFE000;
-			DEBUG_LOG(G3D, "DL FramebufPtr: %08x", ptr);
-		}
+		DEBUG_LOG(G3D, "DL FramebufPtr: %08x", data);
 		break;
 
 	case GE_CMD_FRAMEBUFWIDTH:
-		{
-			u32 w = data & 0xFFFFFF;
-			DEBUG_LOG(G3D, "DL FramebufWidth: %i", w);
-		}
+		DEBUG_LOG(G3D, "DL FramebufWidth: %i", data);
 		break;
 
 	case GE_CMD_FRAMEBUFPIXFORMAT:
@@ -346,17 +340,11 @@ void NullGPU::ExecuteOp(u32 op, u32 diff)
 		break;
 
 	case GE_CMD_ZBUFPTR:
-		{
-			u32 ptr = op & 0xFFE000;
-			DEBUG_LOG(G3D,"Zbuf Ptr: %06x", ptr);
-		}
+		DEBUG_LOG(G3D,"Zbuf Ptr: %06x", data);
 		break;
 
 	case GE_CMD_ZBUFWIDTH:
-		{
-			u32 w = data & 0xFFFFFF;
-			DEBUG_LOG(G3D,"Zbuf Width: %i", w);
-		}
+		DEBUG_LOG(G3D,"Zbuf Width: %i", data);
 		break;
 
 	case GE_CMD_AMBIENTCOLOR:

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -476,19 +476,13 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 		break;
 
 	case GE_CMD_FRAMEBUFPTR:
-		{
-			u32 ptr = op & 0xFFE000;
-			fb = Memory::GetPointer(0x44000000 | (gstate.fbptr & 0xFFE000) | ((gstate.fbwidth & 0xFF0000) << 8));
-			DEBUG_LOG(G3D, "DL FramebufPtr: %08x", ptr);
-		}
+		fb = Memory::GetPointer(0x44000000 | (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8));
+		DEBUG_LOG(G3D, "DL FramebufPtr: %08x", data);
 		break;
 
 	case GE_CMD_FRAMEBUFWIDTH:
-		{
-			u32 w = data & 0xFFFFFF;
-			fb = Memory::GetPointer(0x44000000 | (gstate.fbptr & 0xFFE000) | ((gstate.fbwidth & 0xFF0000) << 8));
-			DEBUG_LOG(G3D, "DL FramebufWidth: %i", w);
-		}
+		fb = Memory::GetPointer(0x44000000 | (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8));
+		DEBUG_LOG(G3D, "DL FramebufWidth: %i", data);
 		break;
 
 	case GE_CMD_FRAMEBUFPIXFORMAT:
@@ -605,19 +599,13 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 		break;
 
 	case GE_CMD_ZBUFPTR:
-		{
-			u32 ptr = op & 0xFFE000;
-			depthbuf = Memory::GetPointer(0x44000000 | (gstate.zbptr & 0xFFE000) | ((gstate.zbwidth & 0xFF0000) << 8));
-			DEBUG_LOG(G3D,"Zbuf Ptr: %06x", ptr);
-		}
+		depthbuf = Memory::GetPointer(0x44000000 | (gstate.zbptr & 0xFFFFFF) | ((gstate.zbwidth & 0xFF0000) << 8));
+		DEBUG_LOG(G3D,"Zbuf Ptr: %06x", data);
 		break;
 
 	case GE_CMD_ZBUFWIDTH:
-		{
-			u32 w = data & 0xFFFFFF;
-			depthbuf = Memory::GetPointer(0x44000000 | (gstate.zbptr & 0xFFE000) | ((gstate.zbwidth & 0xFF0000) << 8));
-			DEBUG_LOG(G3D,"Zbuf Width: %i", w);
-		}
+		depthbuf = Memory::GetPointer(0x44000000 | (gstate.zbptr & 0xFFFFFF) | ((gstate.zbwidth & 0xFF0000) << 8));
+		DEBUG_LOG(G3D,"Zbuf Width: %i", data);
 		break;
 
 	case GE_CMD_AMBIENTCOLOR:

--- a/Qt/debugger_displaylist.cpp
+++ b/Qt/debugger_displaylist.cpp
@@ -611,7 +611,6 @@ QString Debugger_DisplayList::DisassembleOp(u32 pc, u32 op, u32 prev, const GPUg
 
 	case GE_CMD_FRAMEBUFPTR:
 		{
-			u32 ptr = op & 0xFFE000;
 			return QString("FramebufPtr: %1").arg(data,8,16,QChar('0'));
 		}
 		break;
@@ -781,8 +780,7 @@ QString Debugger_DisplayList::DisassembleOp(u32 pc, u32 op, u32 prev, const GPUg
 
 	case GE_CMD_ZBUFPTR:
 		{
-			u32 ptr = op & 0xFFE000;
-			return QString("Zbuf Ptr: %1").arg(ptr,6,16,QChar('0'));
+			return QString("Zbuf Ptr: %1").arg(data,6,16,QChar('0'));
 		}
 		break;
 


### PR DESCRIPTION
This fixes graphics in Brave Story under softgpu.

Also, it stops seeing "subarea" renders in Brave Story and SAO with this change, because they weren't subareas (and that's why offsetting the y made it render wrong.)  They were just framebuffers with the wrong address.

I'm not 100% sure of this change, it could probably use more testing, maybe still some of the low bits should be ignored?

Also, JPCSP ignores some of the high bits of fbwidth.  JPCSP does not ignore any of the low bits.

-[Unknown]
