### PR TITLE
Make it invalid for subarea texture

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -222,8 +222,8 @@ inline void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, V
 			} else if ((entry->addr - address) / entry->bufw < framebuffer->height) {
 				WARN_LOG_REPORT_ONCE(subarea, HLE, "Render to area containing texture at %08x", address);
 				// TODO: Keep track of the y offset.
-				// Affected game List : God of War Ghost of Sparta , Tactic Orge , Sword Art Online
-				AttachFramebufferValid(entry, framebuffer);
+				// Affected game List : God of War Ghost of Sparta , God of War Chains of Olympus
+				AttachFramebufferInvalid(entry, framebuffer);
 			}
 		}
 	}


### PR DESCRIPTION
I just gonna touch this area only but not others as should be pretty safe as Tactic Orge/SOA etc are not going into it when testing.

This fixes the GOW series graphics significally.
