### PR TITLE
Overhaul the Win32 UI with simplification and organisation.

### DIFF
--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -25,6 +25,7 @@
 #include "ui/viewgroup.h"
 
 #include "Core/HLE/sceCtrl.h"
+#include "Core/System.h"
 #include "Common/KeyMap.h"
 #include "Core/Config.h"
 #include "UI/ui_atlas.h"
@@ -191,8 +192,7 @@ void ControlMappingScreen::CreateViews() {
 	leftColumn->Add(new Choice(k->T("Clear All")))->OnClick.Handle(this, &ControlMappingScreen::OnClearMapping);
 	leftColumn->Add(new Choice(k->T("Default All")))->OnClick.Handle(this, &ControlMappingScreen::OnDefaultMapping);
 	leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
-	leftColumn->Add(new Choice(d->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-
+	leftColumn->Add(new Choice(d->T("Back")))->OnClick.Handle(this, &ControlMappingScreen::OnBack);
 	/*
 	ChoiceStrip *mode = leftColumn->Add(new ChoiceStrip(ORIENT_VERTICAL));
 	mode->AddChoice("Replace");
@@ -210,6 +210,17 @@ void ControlMappingScreen::CreateViews() {
 	for (size_t i = 0; i < mappableKeys.size(); i++) {
 		rightColumn->Add(new ControlMapper(mappableKeys[i].key, mappableKeys[i].name, screenManager(), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	}
+}
+
+UI::EventReturn ControlMappingScreen::OnBack(UI::EventParams &e) {
+	// If we're in-game, return to the game via DR_CANCEL.
+	if(PSP_IsInited()) {
+		screenManager()->finishDialog(this, DR_CANCEL);
+	} else {
+		screenManager()->finishDialog(this, DR_OK);
+	}
+
+	return UI::EVENT_DONE;
 }
 
 UI::EventReturn ControlMappingScreen::OnClearMapping(UI::EventParams &params) {

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#pragma once
+
 #include "base/functional.h"
 #include "ui/view.h"
 #include "ui/ui_screen.h"
@@ -26,6 +28,7 @@ public:
 	ControlMappingScreen() {}
 protected:
 	virtual void CreateViews();
+	virtual UI::EventReturn OnBack(UI::EventParams &e);
 
 private:
 	UI::EventReturn OnDefaultMapping(UI::EventParams &params);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -52,6 +52,8 @@
 #include "UI/DevScreens.h"
 #include "UI/GameInfoCache.h"
 #include "UI/MiscScreens.h"
+#include "UI/ControlMappingScreen.h"
+#include "UI/GameSettingsScreen.h"
 
 
 EmuScreen::EmuScreen(const std::string &filename)
@@ -160,6 +162,12 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	else if (!strcmp(message, "boot")) {
 		PSP_Shutdown();
 		bootGame(value);
+	}
+	else if (!strcmp(message, "control mapping")) {
+		screenManager()->push(new ControlMappingScreen());
+	}
+	else if (!strcmp(message, "settings")) {
+		screenManager()->push(new GameSettingsScreen(gamePath_));
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -331,7 +331,12 @@ UI::EventReturn GameSettingsScreen::OnDownloadPlugin(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnBack(UI::EventParams &e) {
-	screenManager()->finishDialog(this, DR_OK);
+	// If we're in-game, return to the game via DR_CANCEL.
+	if(PSP_IsInited()) {
+		screenManager()->finishDialog(this, DR_CANCEL);
+	} else {
+		screenManager()->finishDialog(this, DR_OK);
+	}
 
 	if(g_Config.bEnableSound) {
 		if(PSP_IsInited() && !IsAudioInitialised())

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -35,6 +35,8 @@
 #include "UI/GameSettingsScreen.h"
 #include "UI/CwCheatScreen.h"
 #include "UI/MiscScreens.h"
+#include "UI/ControlMappingScreen.h"
+#include "UI/PluginScreen.h"
 #include "UI/ui_atlas.h"
 #include "Core/Config.h"
 #include "GPU/GPUInterface.h"
@@ -554,6 +556,12 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 	if (!strcmp(message, "language")) {
 		RecreateViews();
 	}
+	if (!strcmp(message, "control mapping")) {
+		screenManager()->push(new ControlMappingScreen());
+	}
+	if (!strcmp(message, "settings")) {
+		screenManager()->push(new GameSettingsScreen(""));
+	}
 }
 
 void MainScreen::update(InputState &input) {
@@ -690,10 +698,11 @@ void GamePauseScreen::CreateViews() {
 	leftColumn->Add(leftColumnItems);
 
 	saveSlots_ = leftColumnItems->Add(new ChoiceStrip(ORIENT_HORIZONTAL, new LinearLayoutParams(300, WRAP_CONTENT)));
-	saveSlots_->AddChoice("  1  ");
-	saveSlots_->AddChoice("  2  ");
-	saveSlots_->AddChoice("  3  ");
-	saveSlots_->AddChoice("  4  ");
+	saveSlots_->AddChoice(" 1 ");
+	saveSlots_->AddChoice(" 2 ");
+	saveSlots_->AddChoice(" 3 ");
+	saveSlots_->AddChoice(" 4 ");
+	saveSlots_->AddChoice(" 5 ");
 	saveSlots_->SetSelection(g_Config.iCurrentStateSlot);
 	saveSlots_->OnChoice.Handle(this, &GamePauseScreen::OnStateSelected);
 	

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -107,7 +107,6 @@ namespace MainWindow
 	static bool hideCursor = false;
 	static void *rawInputBuffer;
 	static size_t rawInputBufferSize;
-	static int currentSavestateSlot = 0;
 	static std::map<int, std::string> initialMenuKeys;
 	static std::vector<std::string> countryCodes;
 
@@ -253,15 +252,15 @@ namespace MainWindow
 		MENU_LANGUAGE = 4,
 		MENU_HELP = 5,
 
-		// Emulation submenus
-		SUBMENU_RENDERING_BACKEND = 11,
+		// File submenus
+		SUBMENU_FILE_SAVESTATE_SLOT = 6,
 
 		// Game Settings submenus
-		SUBMENU_RENDERING_RESOLUTION = 4,
-		SUBMENU_RENDERING_MODE = 5,
-		SUBMENU_FRAME_SKIPPING = 6,
-		SUBMENU_TEXTURE_FILTERING = 7,
-		SUBMENU_TEXTURE_SCALING = 8,
+		SUBMENU_RENDERING_RESOLUTION = 7,
+		SUBMENU_RENDERING_MODE = 8,
+		SUBMENU_FRAME_SKIPPING = 9,
+		SUBMENU_TEXTURE_FILTERING = 10,
+		SUBMENU_TEXTURE_SCALING = 11,
 	};
 
 	std::string GetMenuItemText(int menuID) {
@@ -320,11 +319,11 @@ namespace MainWindow
 	void CreateLanguageMenu() {
 		// Please don't remove this boolean. 
 		// We don't want this menu to be created multiple times.
-		// We can change check mark when this menu has been created.
+		// We can change the checkmark when this menu has been created.
 		static bool langMenuCreated = false;
 
 		if(langMenuCreated) {
-			for (int index = 0; index < countryCodes.size(); ++index) {
+			for (u32 index = 0; index < countryCodes.size(); ++index) {
 				if (!strcmp(countryCodes[index].c_str(),g_Config.languageIni.c_str())) {
 					CheckMenuItem(langMenu, index, MF_BYPOSITION | MF_CHECKED);
 					continue;
@@ -433,7 +432,7 @@ namespace MainWindow
 		TranslateMenuItembyText(ID_TOGGLE_PAUSE, isPaused ? "Run" : "Pause", "DesktopUI", false, false, L"\tF8");
 		TranslateMenuItem(ID_EMULATION_STOP, desktopUI, false, false, L"\tCtrl+W");
 		TranslateMenuItem(ID_EMULATION_RESET, desktopUI, false, false, L"\tCtrl+B");
-		TranslateMenuItem(ID_EMULATION_RUNONLOAD, desktopUI);
+		TranslateMenuItem(ID_DEBUG_RUNONLOAD, desktopUI);
 		TranslateMenuItem(ID_EMULATION_SOUND, desktopUI, true, true);
 		TranslateMenuItem(ID_EMULATION_ATRAC3_SOUND, desktopUI, true, false);
 		TranslateMenuItem(ID_EMULATION_CHEATS, desktopUI,true, true, L"\tCtrl+T");
@@ -448,6 +447,7 @@ namespace MainWindow
 		TranslateMenuItem(ID_DEBUG_SAVEMAPFILE, desktopUI);
 		TranslateMenuItem(ID_DEBUG_RESETSYMBOLTABLE, desktopUI);
 		TranslateMenuItem(ID_DEBUG_DUMPNEXTFRAME, desktopUI);
+		TranslateMenuItem(ID_DEBUG_SHOWDEBUGSTATISTICS, desktopUI);
 		TranslateMenuItem(ID_DEBUG_TAKESCREENSHOT, desktopUI, true, false, L"\tF12");
 		TranslateMenuItem(ID_DEBUG_DISASSEMBLY, desktopUI, true, false, L"\tCtrl+D");
 		TranslateMenuItem(ID_DEBUG_LOG, desktopUI, true, false, L"\tCtrl+L");
@@ -485,9 +485,8 @@ namespace MainWindow
 		TranslateMenuItem(ID_OPTIONS_ANTIALIASING, desktopUI);
 		TranslateMenuItem(ID_OPTIONS_VSYNC, desktopUI);
 		TranslateMenuItem(ID_OPTIONS_SHOWFPS, desktopUI);
-		TranslateMenuItem(ID_OPTIONS_SHOWDEBUGSTATISTICS, desktopUI);
 		TranslateMenuItem(ID_OPTIONS_FASTMEMORY, desktopUI);
-		TranslateMenuItem(ID_OPTIONS_IGNOREILLEGALREADS, desktopUI);
+		TranslateMenuItem(ID_DEBUG_IGNOREILLEGALREADS, desktopUI);
 
 		// Language menu
 		TranslateMenuItem(ID_LANGUAGE_BASE, desktopUI);
@@ -502,7 +501,7 @@ namespace MainWindow
 		TranslateMenuHeader(menu, desktopUI, "Game Settings", MENU_OPTIONS);
 		TranslateMenuHeader(menu, desktopUI, "Help", MENU_HELP);
 
-		TranslateSubMenuHeader(menu, desktopUI, "Rendering Backend", MENU_EMULATION, SUBMENU_RENDERING_BACKEND);
+		TranslateSubMenuHeader(menu, desktopUI, "Savestate Slot", MENU_FILE, SUBMENU_FILE_SAVESTATE_SLOT, L"\tF3");
 		TranslateSubMenuHeader(menu, desktopUI, "Rendering Resolution", MENU_OPTIONS, SUBMENU_RENDERING_RESOLUTION, L"\tCtrl+1");
 		TranslateSubMenuHeader(menu, desktopUI, "Rendering Mode", MENU_OPTIONS, SUBMENU_RENDERING_MODE, L"\tF5");
 		TranslateSubMenuHeader(menu, desktopUI, "Frame Skipping", MENU_OPTIONS, SUBMENU_FRAME_SKIPPING, L"\tF7");
@@ -1043,21 +1042,41 @@ namespace MainWindow
 				// TODO: Improve UI for multiple slots
 				case ID_FILE_SAVESTATE_NEXT_SLOT:
 				{
-					currentSavestateSlot = (currentSavestateSlot + 1)%SaveState::SAVESTATESLOTS;
+					g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % SaveState::SAVESTATESLOTS;
 					char msg[30];
-					sprintf(msg, "Using save state slot %d.", currentSavestateSlot + 1);
+					sprintf(msg, "Using save state slot %d.", g_Config.iCurrentStateSlot + 1);
 					osm.Show(msg);
 					break;
 				}
 
+				case ID_FILE_SAVESTATE_SLOT_1:
+					g_Config.iCurrentStateSlot = 0;
+					break;
+
+				case ID_FILE_SAVESTATE_SLOT_2:
+					g_Config.iCurrentStateSlot = 1;
+					break;
+
+				case ID_FILE_SAVESTATE_SLOT_3:
+					g_Config.iCurrentStateSlot = 2;
+					break;
+
+				case ID_FILE_SAVESTATE_SLOT_4:
+					g_Config.iCurrentStateSlot = 3;
+					break;
+
+				case ID_FILE_SAVESTATE_SLOT_5:
+					g_Config.iCurrentStateSlot = 4;
+					break;
+
 				case ID_FILE_QUICKLOADSTATE:
 					SetCursor(LoadCursor(0, IDC_WAIT));
-					SaveState::LoadSlot(currentSavestateSlot, SaveStateActionFinished);
+					SaveState::LoadSlot(g_Config.iCurrentStateSlot, SaveStateActionFinished);
 					break;
 
 				case ID_FILE_QUICKSAVESTATE:
 					SetCursor(LoadCursor(0, IDC_WAIT));
-					SaveState::SaveSlot(currentSavestateSlot, SaveStateActionFinished);
+					SaveState::SaveSlot(g_Config.iCurrentStateSlot, SaveStateActionFinished);
 					break;
 
 				case ID_OPTIONS_SCREEN1X:
@@ -1154,7 +1173,7 @@ namespace MainWindow
 					setRenderingMode(g_Config.iRenderingMode);
 					break;
 
-				case ID_OPTIONS_SHOWDEBUGSTATISTICS:
+				case ID_DEBUG_SHOWDEBUGSTATISTICS:
 					g_Config.bShowDebugStats = !g_Config.bShowDebugStats;
 					break;
 
@@ -1231,7 +1250,7 @@ namespace MainWindow
 					g_Config.bSeparateIOThread = !g_Config.bSeparateIOThread;
 					break;
 
-				case ID_EMULATION_RUNONLOAD:
+				case ID_DEBUG_RUNONLOAD:
 					g_Config.bAutoRun = !g_Config.bAutoRun;
 					break;
 
@@ -1283,7 +1302,7 @@ namespace MainWindow
 					LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
 					break;
 
-				case ID_OPTIONS_IGNOREILLEGALREADS:
+				case ID_DEBUG_IGNOREILLEGALREADS:
 					g_Config.bIgnoreBadMemAccess = !g_Config.bIgnoreBadMemAccess;
 					break;
 
@@ -1335,7 +1354,11 @@ namespace MainWindow
 					break;
 
 				case ID_OPTIONS_CONTROLS:
-					MessageBox(hWnd, L"Control mapping has been moved to the in-window Settings menu.\n", L"Sorry", 0);
+					NativeMessageReceived("control mapping", "");
+					break;
+
+				case ID_OPTIONS_MORE_SETTINGS:
+					NativeMessageReceived("settings", "");
 					break;
 
 				case ID_EMULATION_SOUND:
@@ -1393,7 +1416,7 @@ namespace MainWindow
 						// Just handle language switching here.
 						// The Menu ID is contained in wParam, so subtract
 						// ID_LANGUAGE_BASE and an additional 1 off it.
-						int index = (wParam - ID_LANGUAGE_BASE - 1);
+						u32 index = (wParam - ID_LANGUAGE_BASE - 1);
 						if(index >= 0 && index < countryCodes.size()) {
 							std::string oldLang = g_Config.languageIni;
 							g_Config.languageIni = countryCodes[index];
@@ -1579,16 +1602,16 @@ namespace MainWindow
 	void UpdateMenus() {
 		HMENU menu = GetMenu(GetHWND());
 #define CHECKITEM(item,value) 	CheckMenuItem(menu,item,MF_BYCOMMAND | ((value) ? MF_CHECKED : MF_UNCHECKED));
-		CHECKITEM(ID_OPTIONS_IGNOREILLEGALREADS,g_Config.bIgnoreBadMemAccess);
-		CHECKITEM(ID_CPU_DYNAREC,g_Config.bJit == true);
+		CHECKITEM(ID_DEBUG_IGNOREILLEGALREADS, g_Config.bIgnoreBadMemAccess);
+		CHECKITEM(ID_CPU_DYNAREC, g_Config.bJit == true);
 		CHECKITEM(ID_CPU_MULTITHREADED, g_Config.bSeparateCPUThread);
 		CHECKITEM(ID_IO_MULTITHREADED, g_Config.bSeparateIOThread);
-		CHECKITEM(ID_OPTIONS_SHOWDEBUGSTATISTICS, g_Config.bShowDebugStats);
+		CHECKITEM(ID_DEBUG_SHOWDEBUGSTATISTICS, g_Config.bShowDebugStats);
 		CHECKITEM(ID_OPTIONS_HARDWARETRANSFORM, g_Config.bHardwareTransform);
 		CHECKITEM(ID_OPTIONS_FASTMEMORY, g_Config.bFastMemory);
 		CHECKITEM(ID_OPTIONS_ANTIALIASING, g_Config.bAntiAliasing);
 		CHECKITEM(ID_OPTIONS_STRETCHDISPLAY, g_Config.bStretchToDisplay);
-		CHECKITEM(ID_EMULATION_RUNONLOAD, g_Config.bAutoRun);
+		CHECKITEM(ID_DEBUG_RUNONLOAD, g_Config.bAutoRun);
 		CHECKITEM(ID_OPTIONS_VERTEXCACHE, g_Config.bVertexCache);
 		CHECKITEM(ID_OPTIONS_SHOWFPS, g_Config.iShowFPSCounter);
 		CHECKITEM(ID_OPTIONS_FRAMESKIP, g_Config.iFrameSkip != 0);
@@ -1703,6 +1726,24 @@ namespace MainWindow
 
 		for (int i = 0; i < ARRAY_SIZE(frameskipping); i++) {
 			CheckMenuItem(menu, frameskipping[i], MF_BYCOMMAND | ( i == g_Config.iFrameSkip )? MF_CHECKED : MF_UNCHECKED);
+		}
+
+		static const int savestateSlot[] = {
+			ID_FILE_SAVESTATE_SLOT_1,
+			ID_FILE_SAVESTATE_SLOT_2,
+			ID_FILE_SAVESTATE_SLOT_3,
+			ID_FILE_SAVESTATE_SLOT_4,
+			ID_FILE_SAVESTATE_SLOT_5,
+		};
+
+		if(g_Config.iCurrentStateSlot < 0)
+			g_Config.iCurrentStateSlot = 0;
+
+		else if(g_Config.iCurrentStateSlot >= SaveState::SAVESTATESLOTS)
+			g_Config.iCurrentStateSlot = SaveState::SAVESTATESLOTS - 1;
+
+		for (int i = 0; i < ARRAY_SIZE(savestateSlot); i++) {
+			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ( i == g_Config.iCurrentStateSlot )? MF_CHECKED : MF_UNCHECKED);
 		}
 
 		UpdateCommands();

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -509,6 +509,7 @@ namespace MainWindow
 		TranslateSubMenuHeader(menu, desktopUI, "Texture Scaling", MENU_OPTIONS, SUBMENU_TEXTURE_SCALING);
 
 		DrawMenuBar(hwndMain);
+		UpdateMenus();
 	}
 
 	void setTexScalingMultiplier(int level) {

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -297,68 +297,69 @@ IDR_MENU1 MENU
 BEGIN
     POPUP "File"
     BEGIN
-        MENUITEM "Load",								ID_FILE_LOAD
-        MENUITEM "Open Directory...",						ID_FILE_LOAD_DIR
-        MENUITEM "Open from MS:/PSP/GAME...",				ID_FILE_LOAD_MEMSTICK
+        MENUITEM "Load",                                    ID_FILE_LOAD
+        MENUITEM "Open Directory...",                       ID_FILE_LOAD_DIR
+        MENUITEM "Open from MS:/PSP/GAME...",               ID_FILE_LOAD_MEMSTICK
         MENUITEM SEPARATOR
-        MENUITEM "Open Memory Stick",						ID_FILE_MEMSTICK
+        MENUITEM "Open Memory Stick",                       ID_FILE_MEMSTICK
         MENUITEM SEPARATOR
-        MENUITEM "Load State",						ID_FILE_QUICKLOADSTATE
-        MENUITEM "Save State",						ID_FILE_QUICKSAVESTATE
-        MENUITEM "Load State File...",						ID_FILE_LOADSTATEFILE
-        MENUITEM "Save State File...",						ID_FILE_SAVESTATEFILE
+
+        POPUP "Savestate Slot"
+		BEGIN
+			MENUITEM "&1",                                  ID_FILE_SAVESTATE_SLOT_1
+			MENUITEM "&2",                                  ID_FILE_SAVESTATE_SLOT_2
+			MENUITEM "&3",                                  ID_FILE_SAVESTATE_SLOT_3
+			MENUITEM "&4",                                  ID_FILE_SAVESTATE_SLOT_4
+			MENUITEM "&5",                                  ID_FILE_SAVESTATE_SLOT_5
+		END
+		MENUITEM "Load State",                              ID_FILE_QUICKLOADSTATE
+		MENUITEM "Save State",                              ID_FILE_QUICKSAVESTATE 
+		MENUITEM "Load State File...",                      ID_FILE_LOADSTATEFILE
+		MENUITEM "Save State File...",                      ID_FILE_SAVESTATEFILE
         MENUITEM SEPARATOR
-        MENUITEM "Exit",									ID_FILE_EXIT
+        MENUITEM "Exit",                                    ID_FILE_EXIT
     END
+
     POPUP "Emulation"
     BEGIN
-        MENUITEM "Run",								ID_TOGGLE_PAUSE
-        MENUITEM "Stop",							ID_EMULATION_STOP
-        MENUITEM "Reset",							ID_EMULATION_RESET
-        MENUITEM SEPARATOR
-        MENUITEM "Run on Load",							ID_EMULATION_RUNONLOAD
-        MENUITEM SEPARATOR
-		MENUITEM "Enable Sound",							ID_EMULATION_SOUND, CHECKED
-		MENUITEM "Enable Atrac3+",					ID_EMULATION_ATRAC3_SOUND
-		MENUITEM SEPARATOR
-		MENUITEM "Enable Cheats",			ID_EMULATION_CHEATS
-        MENUITEM SEPARATOR
-		POPUP "Rendering Backend"
-		BEGIN
-			MENUITEM "OpenGL Rendering",                 ID_EMULATION_RENDER_MODE_OGL, CHECKED
-			MENUITEM "Software Rendering", ID_EMULATION_RENDER_MODE_SOFT
-		END
-		MENUITEM SEPARATOR
-		MENUITEM "Dynarec",							ID_CPU_DYNAREC, CHECKED
-        MENUITEM SEPARATOR
-		MENUITEM "Multithreaded (Experimental)",			ID_CPU_MULTITHREADED
-		MENUITEM "I/O on Thread (Experimental)",               ID_IO_MULTITHREADED
+        MENUITEM "Run",                                     ID_TOGGLE_PAUSE
+        MENUITEM "Stop",                                    ID_EMULATION_STOP
+        MENUITEM "Reset",                                   ID_EMULATION_RESET
     END
+
     POPUP "Debug"
     BEGIN
-        MENUITEM "Load Map File...",						ID_DEBUG_LOADMAPFILE
-        MENUITEM "Save Map File...",						ID_DEBUG_SAVEMAPFILE
-        MENUITEM "Reset Symbol Table",						ID_DEBUG_RESETSYMBOLTABLE
+        MENUITEM "Load Map File...",                        ID_DEBUG_LOADMAPFILE
+        MENUITEM "Save Map File...",                        ID_DEBUG_SAVEMAPFILE
+        MENUITEM "Reset Symbol Table",                      ID_DEBUG_RESETSYMBOLTABLE
         MENUITEM SEPARATOR
-        MENUITEM "Dump Next Frame to Log",					ID_DEBUG_DUMPNEXTFRAME
-        MENUITEM "Take Screenshot",					ID_DEBUG_TAKESCREENSHOT
+        MENUITEM "Dump Next Frame to Log",                  ID_DEBUG_DUMPNEXTFRAME
+        MENUITEM "Take Screenshot",                         ID_DEBUG_TAKESCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "Disassembly",					ID_DEBUG_DISASSEMBLY
-        MENUITEM "Log Console",					ID_DEBUG_LOG
-        MENUITEM "Memory View...",					ID_DEBUG_MEMORYVIEW
+        MENUITEM "Show Debug Statistics",                   ID_DEBUG_SHOWDEBUGSTATISTICS
+        MENUITEM "Ignore Illegal Reads/Writes",             ID_DEBUG_IGNOREILLEGALREADS
+        MENUITEM "Run on Load",                             ID_DEBUG_RUNONLOAD
+        MENUITEM SEPARATOR
+        MENUITEM "Disassembly",                             ID_DEBUG_DISASSEMBLY
+        MENUITEM "Log Console",	                            ID_DEBUG_LOG
+        MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
     END
+
     POPUP "Options"
     BEGIN
-        MENUITEM "Fullscreen",			ID_OPTIONS_FULLSCREEN
-        MENUITEM "Keep PPSSPP On Top",						ID_OPTIONS_TOPMOST
-        MENUITEM "Stretch to Display",						ID_OPTIONS_STRETCHDISPLAY
+        MENUITEM "Keep PPSSPP On Top",                      ID_OPTIONS_TOPMOST
+        MENUITEM "More Settings...",                        ID_OPTIONS_MORE_SETTINGS
+        MENUITEM "Control Mapping...",                      ID_OPTIONS_CONTROLS
         MENUITEM SEPARATOR
+        MENUITEM "Stretch to Display",                      ID_OPTIONS_STRETCHDISPLAY
+        MENUITEM "Fullscreen",                              ID_OPTIONS_FULLSCREEN
+        MENUITEM "VSync",                                   ID_OPTIONS_VSYNC
         POPUP "Rendering Resolution"
         BEGIN
-            MENUITEM "&1x",			ID_OPTIONS_SCREEN1X
-            MENUITEM "&2x",			ID_OPTIONS_SCREEN2X
-            MENUITEM "&3x",			ID_OPTIONS_SCREEN3X
-            MENUITEM "&4x",			ID_OPTIONS_SCREEN4X
+            MENUITEM "&1x",                                 ID_OPTIONS_SCREEN1X
+            MENUITEM "&2x",                                 ID_OPTIONS_SCREEN2X
+            MENUITEM "&3x",                                 ID_OPTIONS_SCREEN3X
+            MENUITEM "&4x",                                 ID_OPTIONS_SCREEN4X
         END
 		POPUP "Rendering Mode"
 		BEGIN
@@ -382,37 +383,33 @@ BEGIN
 		END
 		POPUP "Texture Filtering"
         BEGIN
-			MENUITEM "Auto",								ID_OPTIONS_TEXTUREFILTERING_AUTO
-			MENUITEM "Nearest",							ID_OPTIONS_NEARESTFILTERING
-			MENUITEM "Linear",								ID_OPTIONS_LINEARFILTERING
-			MENUITEM "Linear on FMV",							ID_OPTIONS_LINEARFILTERING_CG
+            MENUITEM "Auto",                                ID_OPTIONS_TEXTUREFILTERING_AUTO
+            MENUITEM "Nearest",                             ID_OPTIONS_NEARESTFILTERING
+            MENUITEM "Linear",                              ID_OPTIONS_LINEARFILTERING
+            MENUITEM "Linear on FMV",                       ID_OPTIONS_LINEARFILTERING_CG
 		END
         POPUP "Texture Scaling"
         BEGIN
-            MENUITEM "Off",								ID_TEXTURESCALING_OFF
-            MENUITEM "&2x",									ID_TEXTURESCALING_2X
-            MENUITEM "&3x",									ID_TEXTURESCALING_3X
-            MENUITEM "&4x",						ID_TEXTURESCALING_4X
-            MENUITEM "&5x",						ID_TEXTURESCALING_5X
+            MENUITEM "Off",                             ID_TEXTURESCALING_OFF
+            MENUITEM "&2x",                             ID_TEXTURESCALING_2X
+            MENUITEM "&3x",                             ID_TEXTURESCALING_3X
+            MENUITEM "&4x",                             ID_TEXTURESCALING_4X
+            MENUITEM "&5x",	                            ID_TEXTURESCALING_5X
             MENUITEM SEPARATOR
-            MENUITEM "xBRZ",								ID_TEXTURESCALING_XBRZ
-            MENUITEM "Hybrid",								ID_TEXTURESCALING_HYBRID
-            MENUITEM "Bicubic",							ID_TEXTURESCALING_BICUBIC
-            MENUITEM "Hybrid + Bicubic",						ID_TEXTURESCALING_HYBRID_BICUBIC
+            MENUITEM "xBRZ",                            ID_TEXTURESCALING_XBRZ
+            MENUITEM "Hybrid",                          ID_TEXTURESCALING_HYBRID
+            MENUITEM "Bicubic",                         ID_TEXTURESCALING_BICUBIC
+            MENUITEM "Hybrid + Bicubic",                ID_TEXTURESCALING_HYBRID_BICUBIC
             MENUITEM SEPARATOR
-            MENUITEM "Deposterize",						ID_TEXTURESCALING_DEPOSTERIZE
+            MENUITEM "Deposterize",                     ID_TEXTURESCALING_DEPOSTERIZE
         END
-		MENUITEM "Hardware Transform",					ID_OPTIONS_HARDWARETRANSFORM
-        MENUITEM "Vertex Cache",							ID_OPTIONS_VERTEXCACHE
-        MENUITEM "Mipmapping",								ID_OPTIONS_MIPMAP
-        MENUITEM "Anti-Aliasing",							ID_OPTIONS_ANTIALIASING
-        MENUITEM "VSync",									ID_OPTIONS_VSYNC
+		MENUITEM "Hardware Transform",                  ID_OPTIONS_HARDWARETRANSFORM
+        MENUITEM "Vertex Cache",                        ID_OPTIONS_VERTEXCACHE
+        MENUITEM "Show FPS Counter",                    ID_OPTIONS_SHOWFPS
         MENUITEM SEPARATOR
-        MENUITEM "Show FPS Counter",								ID_OPTIONS_SHOWFPS
-        MENUITEM "Show Debug Statistics",					ID_OPTIONS_SHOWDEBUGSTATISTICS
+        MENUITEM "Enable Sound",                        ID_EMULATION_SOUND, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "Fast Memory",					ID_OPTIONS_FASTMEMORY
-        MENUITEM "Ignore Illegal Reads/Writes",			ID_OPTIONS_IGNOREILLEGALREADS
+        MENUITEM "Enable Cheats",                       ID_EMULATION_CHEATS
     END
 END
 
@@ -482,17 +479,3 @@ END
 
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
-
-
-
-#ifndef APSTUDIO_INVOKED
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 3 resource.
-//
-
-
-/////////////////////////////////////////////////////////////////////////////
-#endif    // not APSTUDIO_INVOKED
-
-

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -164,7 +164,7 @@
 #define ID_FILE_LOAD                     40011
 #define ID_HELP_ABOUT                    40012
 #define ID_DISASM_FOLLOWBRANCH           40013
-#define ID_OPTIONS_IGNOREILLEGALREADS    40014
+#define ID_DEBUG_IGNOREILLEGALREADS      40014
 #define ID_DISASM_COPYADDRESS            40015
 #define ID_REGLIST_GOTOINMEMORYVIEW      40016
 #define ID_REGLIST_COPYVALUE             40017
@@ -179,7 +179,7 @@
 #define ID_OPTIONS_SCREEN4X              40026
 #define ID_OPTIONS_SCREEN2X              40027
 #define ID_OPTIONS_BUFFEREDRENDERING     40028
-#define ID_OPTIONS_SHOWDEBUGSTATISTICS   40029
+#define ID_DEBUG_SHOWDEBUGSTATISTICS     40029
 #define ID_OPTIONS_HARDWARETRANSFORM     40030
 #define ID_OPTIONS_FASTMEMORY            40031
 #define IDC_STEPHLE                      40032
@@ -187,7 +187,7 @@
 #define ID_FILE_QUICKSAVESTATE           40034
 #define ID_FILE_QUICKLOADSTATE           40035
 #define ID_OPTIONS_CONTROLS              40036
-#define ID_EMULATION_RUNONLOAD           40037
+#define ID_DEBUG_RUNONLOAD               40037
 #define ID_DEBUG_DUMPNEXTFRAME           40038
 #define ID_OPTIONS_ANTIALIASING          40039
 #define ID_OPTIONS_VERTEXCACHE           40040
@@ -247,11 +247,17 @@
 #define ID_EMULATION_RENDER_MODE_SOFT    40095
 #define ID_EMULATION_CHEATS              40096
 #define ID_HELP_CHINESE_FORUM            40097
+#define ID_OPTIONS_MORE_SETTINGS         40098
+#define ID_FILE_SAVESTATE_SLOT_1         40099
+#define ID_FILE_SAVESTATE_SLOT_2         40100
+#define ID_FILE_SAVESTATE_SLOT_3         40101
+#define ID_FILE_SAVESTATE_SLOT_4         40102
+#define ID_FILE_SAVESTATE_SLOT_5         40103
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
-#define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40200
-#define IDC_STEPOUT                       40201
-#define ID_HELP_BUYGOLD                   40202
+#define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500
+#define IDC_STEPOUT                       40501
+#define ID_HELP_BUYGOLD                   40502
 
 #define IDC_STATIC                      -1
 


### PR DESCRIPTION
 New things include:
-File -> Savestate Slot: Lets the user pick the savestate slot to be used.
-Game Settings -> More Settings...: Opens the main settings screen from anywhere.
-Game Settings -> Control Mapping...: Opens the key mapping screen from anywhere.
-Infrequently changed options were removed. They can still be accessed via More Settings or going to the main settings menu.
-Organised menus; nothing is out of place anymore.
-Simplified menus: as some options were removed or moved, it's easier to find what you're looking for, now.
-Fix a few warnings in WndMainWindow.cpp.

File:
![File Menu](https://i.minus.com/ieaPt9QYtK8CO.PNG)

Emulation:
![Emu Menu](https://i.minus.com/ixkV2UiLzgPLh.PNG)

Debug:
![Debug Menu](https://i.minus.com/iuSwh35cXjGoV.PNG)

Game Settings:
![Settings Menu](https://i.minus.com/i0lcBJDutzuNV.PNG)

So as you can see, it's still familiar, yet vastly simplified and organised.

Prior discussion: https://github.com/hrydgard/ppsspp/issues/3624
