### PR TITLE
Win32: Disable the Pause/Run/Reset buttons appropriately when More Settings/Control Mapping are selected.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1356,10 +1356,12 @@ namespace MainWindow
 
 				case ID_OPTIONS_CONTROLS:
 					NativeMessageReceived("control mapping", "");
+					globalUIState = UISTATE_MENU;
 					break;
 
 				case ID_OPTIONS_MORE_SETTINGS:
 					NativeMessageReceived("settings", "");
+					globalUIState = UISTATE_MENU;
 					break;
 
 				case ID_EMULATION_SOUND:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -467,6 +467,8 @@ namespace MainWindow
 		TranslateMenuItem(ID_OPTIONS_READFBOTOMEMORYGPU, desktopUI, true, false);
 		TranslateMenuItem(ID_OPTIONS_FRAMESKIP_0, desktopUI);
 		TranslateMenuItem(ID_OPTIONS_FRAMESKIP_AUTO, desktopUI);
+		TranslateMenuItem(ID_OPTIONS_MORE_SETTINGS, desktopUI);
+		TranslateMenuItem(ID_OPTIONS_CONTROLS, desktopUI);
 		// Skip frameskipping 2-8..
 		TranslateMenuItem(ID_OPTIONS_TEXTUREFILTERING_AUTO, desktopUI);
 		TranslateMenuItem(ID_OPTIONS_NEARESTFILTERING, desktopUI);


### PR DESCRIPTION
Also, I forgot to make the Control Mapping/More Settings options translatable.
