### PR TITLE
Fix VirtualDiscFileSystem::GetDirListing

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -625,7 +625,9 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 		tmFromFiletime(entry.ctime, findData.ftCreationTime);
 		tmFromFiletime(entry.mtime, findData.ftLastWriteTime);
 		entry.isOnSectorSystem = true;
-		int fileIndex = getFileListIndex(entry.name);
+
+		std::string fullRelativePath = path + "/" + entry.name;
+		int fileIndex = getFileListIndex(fullRelativePath);
 		if (fileIndex != -1)
 			entry.startSector = fileList[fileIndex].firstBlock;
 		myVector.push_back(entry);

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -670,7 +670,9 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 		localtime_r((time_t*)&s.st_ctime,&entry.ctime);
 		localtime_r((time_t*)&s.st_mtime,&entry.mtime);
 		entry.isOnSectorSystem = true;
-		int fileIndex = getFileListIndex(entry.name);
+
+		std::string fullRelativePath = path + "/" + entry.name;
+		int fileIndex = getFileListIndex(fullRelativePath);
 		if (fileIndex != -1)
 			entry.startSector = fileList[fileIndex].firstBlock;
 		myVector.push_back(entry);


### PR DESCRIPTION
This took forever to find. Fixes SRW Z2 with virtual discs, and probably others.
