### PR TITLE
Always use fastmem for sw/lw offset from SP

### DIFF
--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -163,7 +163,7 @@ namespace MIPSComp
 				_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address?  CPU bug?");
 				load ? gpr.MapDirtyIn(rt, rs) : gpr.MapInIn(rt, rs);
 
-				if (!g_Config.bFastMemory) {
+				if (!g_Config.bFastMemory && rs != MIPS_REG_SP) {
 					SetCCAndR0ForSafeAddress(rs, offset, R1);
 					doCheck = true;
 				} else {

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -385,6 +385,7 @@ private:
 		bool needsCheck_;
 		bool needsSkip_;
 		bool far_;
+		bool fast_;
 		u32 alignMask_;
 		u32 iaddr_;
 		X64Reg xaddr_;


### PR DESCRIPTION
At first I was thinking we should check SP maybe, but the likelyhood of it being wrong is pretty low now.  We could still validate it, but that seems like a lot of work.

Unfortunately, it doesn't help as much as I hoped on Android.  I think it was ~3% improvement in ClaDun.  On x64, the improvement was 23%, and 15% in another game (which crashed on my Android due to running out of VRAM.)

Of course, fastmem is still better (much better.)

-[Unknown]
