### PR TITLE
Improve threadend waits, add callback handlers, some cleanup

### DIFF
--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -262,10 +262,12 @@ inline bool VerifyWait(SceUID threadID, WaitType waitType, SceUID uid) {
 
 // Resume a thread from waiting for a particular object.
 template <typename T>
-inline void ResumeFromWait(SceUID threadID, WaitType waitType, SceUID uid, T result) {
+inline bool ResumeFromWait(SceUID threadID, WaitType waitType, SceUID uid, T result) {
 	if (VerifyWait(threadID, waitType, uid)) {
 		__KernelResumeThreadFromWait(threadID, result);
+		return true;
 	}
+	return false;
 }
 
 };

--- a/Core/HLE/sceGe.h
+++ b/Core/HLE/sceGe.h
@@ -44,7 +44,7 @@ void __GeShutdown();
 bool __GeTriggerSync(WaitType waitType, int id, u64 atTicks);
 bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks);
 void __GeWaitCurrentThread(WaitType type, SceUID waitId, const char *reason);
-void __GeTriggerWait(WaitType type, SceUID waitId, const char *reason, bool noSwitch = false);
+bool __GeTriggerWait(WaitType type, SceUID waitId);
 bool __GeHasPendingInterrupt();
 
 

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -206,7 +206,7 @@ void __KernelEventFlagEndCallback(SceUID threadID, SceUID prevCallbackId)
 {
 	auto result = HLEKernel::WaitEndCallback<EventFlag, WAITTYPE_EVENTFLAG, EventFlagTh>(threadID, prevCallbackId, eventFlagWaitTimer, __KernelUnlockEventFlagForThread);
 	if (result == HLEKernel::WAIT_CB_RESUMED_WAIT)
-		DEBUG_LOG(SCEKERNEL, "sceKernelWaitEventFlagCB: Resuming lock wait for callback");
+		DEBUG_LOG(SCEKERNEL, "sceKernelWaitEventFlagCB: Resuming lock wait from callback");
 }
 
 //SceUID sceKernelCreateEventFlag(const char *name, int attr, int bits, SceKernelEventFlagOptParam *opt);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1548,22 +1548,6 @@ void __KernelLoadContext(ThreadContext *ctx, bool vfpuEnabled)
 	currentMIPS->llBit = 0;
 }
 
-u32 __KernelResumeThreadFromWait(SceUID threadID)
-{
-	u32 error;
-	Thread *t = kernelObjects.Get<Thread>(threadID, error);
-	if (t)
-	{
-		t->resumeFromWait();
-		return 0;
-	}
-	else
-	{
-		ERROR_LOG(SCEKERNEL, "__KernelResumeThreadFromWait(%d): bad thread: %08x", threadID, error);
-		return error;
-	}
-}
-
 u32 __KernelResumeThreadFromWait(SceUID threadID, u32 retval)
 {
 	u32 error;
@@ -1655,7 +1639,7 @@ void hleScheduledWakeup(u64 userdata, int cyclesLate)
 	SceUID threadID = (SceUID)userdata;
 	u32 error;
 	if (__KernelGetWaitID(threadID, WAITTYPE_DELAY, error) == threadID)
-		__KernelResumeThreadFromWait(threadID);
+		__KernelResumeThreadFromWait(threadID, 0);
 }
 
 void __KernelScheduleWakeup(SceUID threadID, s64 usFromNow)
@@ -2543,7 +2527,7 @@ int sceKernelWakeupThread(SceUID uid)
 			DEBUG_LOG(SCEKERNEL,"sceKernelWakeupThread(%i) - wakeupCount incremented to %i", uid, t->nt.wakeupCount);
 		} else {
 			VERBOSE_LOG(SCEKERNEL,"sceKernelWakeupThread(%i) - woke thread at %i", uid, t->nt.wakeupCount);
-			__KernelResumeThreadFromWait(uid);
+			__KernelResumeThreadFromWait(uid, 0);
 			hleReSchedule("thread woken up");
 		}
 		return 0;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -151,8 +151,7 @@ const char *__KernelGetThreadName(SceUID threadID);
 void __KernelSaveContext(ThreadContext *ctx, bool vfpuEnabled);
 void __KernelLoadContext(ThreadContext *ctx, bool vfpuEnabled);
 
-u32 __KernelResumeThreadFromWait(SceUID threadID); // can return an error value
-u32 __KernelResumeThreadFromWait(SceUID threadID, u32 retval);
+u32 __KernelResumeThreadFromWait(SceUID threadID, u32 retval); // can return an error value
 u32 __KernelResumeThreadFromWait(SceUID threadID, u64 retval);
 
 inline u32 __KernelResumeThreadFromWait(SceUID threadID, int retval)

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -151,11 +151,6 @@ const char *__KernelGetThreadName(SceUID threadID);
 void __KernelSaveContext(ThreadContext *ctx, bool vfpuEnabled);
 void __KernelLoadContext(ThreadContext *ctx, bool vfpuEnabled);
 
-// TODO: Replace this with __KernelResumeThreadFromWait over time as it's misguided.
-// It's better that each subsystem keeps track of the list of waiting threads
-// and resumes them manually one by one using __KernelResumeThreadFromWait.
-bool __KernelTriggerWait(WaitType type, int id, const char *reason, bool dontSwitch = false);
-bool __KernelTriggerWait(WaitType type, int id, int retVal, const char *reason, bool dontSwitch);
 u32 __KernelResumeThreadFromWait(SceUID threadID); // can return an error value
 u32 __KernelResumeThreadFromWait(SceUID threadID, u32 retval);
 u32 __KernelResumeThreadFromWait(SceUID threadID, u64 retval);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -265,7 +265,7 @@ u32 GPUCommon::DequeueList(int listid) {
 		dlQueue.remove(listid);
 
 	dls[listid].waitTicks = 0;
-	__GeTriggerWait(WAITTYPE_GELISTSYNC, listid, "GeListSync");
+	__GeTriggerWait(WAITTYPE_GELISTSYNC, listid);
 
 	CheckDrawSync();
 
@@ -893,7 +893,7 @@ void GPUCommon::InterruptEnd(int listid) {
 	// TODO: Unless the signal handler could change it?
 	if (dl.state == PSP_GE_DL_STATE_COMPLETED || dl.state == PSP_GE_DL_STATE_NONE) {
 		dl.waitTicks = 0;
-		__GeTriggerWait(WAITTYPE_GELISTSYNC, listid, "GeListSync", true);
+		__GeTriggerWait(WAITTYPE_GELISTSYNC, listid);
 	}
 
 	if (dl.signal == PSP_GE_SIGNAL_HANDLER_PAUSE)

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -652,7 +652,7 @@ void CtrlMemView::search(bool continueSearch)
 		if (searchAddress >= segmentEnd) continue;
 
 		int index = searchAddress-segmentStart;
-		int endIndex = segmentEnd-segmentStart-searchData.size();
+		int endIndex = segmentEnd-segmentStart-(int)searchData.size();
 
 		while (index < endIndex)
 		{


### PR DESCRIPTION
This cleanup may actually improve performance, since in one profile I saw it spending a lot of time inclusive in __GeTriggerWait().  We barely even use `threadqueue` anymore now, mostly just the ready queues.

Anyway, it mostly cleans up thread end and removes some of the old wait handling code that's not used anymore with these changes.

Just msgpipes left now, nothing else uses CB waits.

-[Unknown]
