### PR TITLE
Improve callbacks (still not rescheduling properly inside one)

### DIFF
--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -259,7 +259,17 @@ WaitBeginEndCallbackResult WaitEndCallback(SceUID threadID, SceUID prevCallbackI
 }
 
 // Verify that a thread has not been released from waiting, e.g. by sceKernelReleaseWaitThread().
-inline bool VerifyWait(SceUID threadID, WaitType waitType, SceUID uid) {
+// For a waiting thread info struct.
+template <typename T>
+inline bool VerifyWait(const T &waitInfo, WaitType waitType, SceUID uid) {
+	u32 error;
+	SceUID waitID = __KernelGetWaitID(waitInfo.threadID, waitType, error);
+	return waitID == uid && error == 0;
+}
+
+// Verify that a thread has not been released from waiting, e.g. by sceKernelReleaseWaitThread().
+template <>
+inline bool VerifyWait(const SceUID &threadID, WaitType waitType, SceUID uid) {
 	u32 error;
 	SceUID waitID = __KernelGetWaitID(threadID, waitType, error);
 	return waitID == uid && error == 0;
@@ -273,6 +283,23 @@ inline bool ResumeFromWait(SceUID threadID, WaitType waitType, SceUID uid, T res
 		return true;
 	}
 	return false;
+}
+
+// Removes threads that are not waiting anymore from a waitingThreads list.
+template <typename T>
+inline void CleanupWaitingThreads(WaitType waitType, SceUID uid, std::vector<T> &waitingThreads) {
+	size_t size = waitingThreads.size();
+	for (size_t i = 0; i < size; ++i) {
+		if (!VerifyWait(waitingThreads[i], waitType, uid)) {
+			// Decrement size and swap what was there with i.
+			if (--size != i) {
+				std::swap(waitingThreads[i], waitingThreads[size]);
+			}
+			// Now we haven't checked the new i, so go back and do i again.
+			--i;
+		}
+	}
+	waitingThreads.resize(size);
 }
 
 };

--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -302,4 +302,9 @@ inline void CleanupWaitingThreads(WaitType waitType, SceUID uid, std::vector<T> 
 	waitingThreads.resize(size);
 }
 
+template <typename T>
+inline void RemoveWaitingThread(std::vector<T> &waitingThreads, const SceUID threadID) {
+	waitingThreads.erase(std::remove(waitingThreads.begin(), waitingThreads.end(), threadID), waitingThreads.end());
+}
+
 };

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -86,6 +86,7 @@
 static bool kernelRunning = false;
 KernelObjectPool kernelObjects;
 KernelStats kernelStats;
+// TODO: Savestate this?
 u32 registeredExitCbId;
 
 void __KernelInit()
@@ -261,10 +262,8 @@ int LoadExecForUser_362A956B()
 
 u32 sceKernelRegisterExitCallback(u32 cbId)
 {
-	DEBUG_LOG(SCEKERNEL, "sceKernelRegisterExitCallback(%i)", cbId);
-	if (__KernelRegisterCallback(THREAD_CALLBACK_EXIT, cbId) == 0) {
-		registeredExitCbId = cbId;
-	}
+	DEBUG_LOG(SCEKERNEL,"sceKernelRegisterExitCallback(%i)", cbId);
+	registeredExitCbId = cbId;
 	return 0;
 }
 

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -622,12 +622,7 @@ u32 sceKernelReferEventFlagStatus(SceUID id, u32 statusPtr)
 		if (!Memory::IsValidAddress(statusPtr))
 			return -1;
 
-		for (auto iter = e->waitingThreads.begin(); iter != e->waitingThreads.end(); ++iter)
-		{
-			// The thread is no longer waiting for this, clean it up.
-			if (!HLEKernel::VerifyWait(iter->threadID, WAITTYPE_EVENTFLAG, id))
-				e->waitingThreads.erase(iter--);
-		}
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_EVENTFLAG, id, e->waitingThreads);
 
 		e->nef.numWaitThreads = (int) e->waitingThreads.size();
 		if (Memory::Read_U32(statusPtr) != 0)

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -583,12 +583,7 @@ int sceKernelReferMbxStatus(SceUID id, u32 infoAddr)
 	for (int i = 0, n = m->nmb.numMessages; i < n; ++i)
 		m->nmb.packetListHead = Memory::Read_U32(m->nmb.packetListHead);
 
-	for (auto iter = m->waitingThreads.begin(); iter != m->waitingThreads.end(); ++iter)
-	{
-		// The thread is no longer waiting for this, clean it up.
-		if (!HLEKernel::VerifyWait(iter->threadID, WAITTYPE_MBX, id))
-			m->waitingThreads.erase(iter--);
-	}
+	HLEKernel::CleanupWaitingThreads(WAITTYPE_MBX, id, m->waitingThreads);
 
 	// For whatever reason, it won't write if the size (first member) is 0.
 	if (Memory::Read_U32(infoAddr) != 0)

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -325,14 +325,7 @@ void __KernelSortFplThreads(FPL *fpl)
 {
 	// Remove any that are no longer waiting.
 	SceUID uid = fpl->GetUID();
-	for (size_t i = 0; i < fpl->waitingThreads.size(); i++)
-	{
-		if (!HLEKernel::VerifyWait(fpl->waitingThreads[i].threadID, WAITTYPE_FPL, uid))
-		{
-			fpl->waitingThreads.erase(fpl->waitingThreads.begin() + i);
-			--i;
-		}
-	}
+	HLEKernel::CleanupWaitingThreads(WAITTYPE_FPL, uid, fpl->waitingThreads);
 
 	if ((fpl->nf.attr & PSP_FPL_ATTR_PRIORITY) != 0)
 		std::stable_sort(fpl->waitingThreads.begin(), fpl->waitingThreads.end(), __FplThreadSortPriority);
@@ -1212,14 +1205,7 @@ void __KernelSortFplThreads(VPL *vpl)
 {
 	// Remove any that are no longer waiting.
 	SceUID uid = vpl->GetUID();
-	for (size_t i = 0; i < vpl->waitingThreads.size(); i++)
-	{
-		if (!HLEKernel::VerifyWait(vpl->waitingThreads[i].threadID, WAITTYPE_VPL, uid))
-		{
-			vpl->waitingThreads.erase(vpl->waitingThreads.begin() + i);
-			--i;
-		}
-	}
+	HLEKernel::CleanupWaitingThreads(WAITTYPE_VPL, uid, vpl->waitingThreads);
 
 	if ((vpl->nv.attr & PSP_VPL_ATTR_PRIORITY) != 0)
 		std::stable_sort(vpl->waitingThreads.begin(), vpl->waitingThreads.end(), __VplThreadSortPriority);

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -241,18 +241,7 @@ struct MsgPipe : public KernelObject
 	void SortThreads(std::vector<MsgPipeWaitingThread> &waitingThreads, bool usePrio)
 	{
 		// Clean up any not waiting at the same time.
-		size_t size = waitingThreads.size();
-		for (size_t i = 0; i < size; ++i)
-		{
-			if (!waitingThreads[i].IsStillWaiting(GetUID()))
-			{
-				// Decrement size and swap what was there with i.
-				std::swap(waitingThreads[i], waitingThreads[--size]);
-				// Now we haven't checked the new i, so go back and do i again.
-				--i;
-			}
-		}
-		waitingThreads.resize(size);
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_MSGPIPE, GetUID(), waitingThreads);
 
 		if (usePrio)
 			std::stable_sort(waitingThreads.begin(), waitingThreads.end(), __KernelMsgPipeThreadSortPriority);

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -259,19 +259,14 @@ struct MsgPipe : public KernelObject
 		SortThreads(sendWaitingThreads, usePrio);
 	}
 
-	void RemoveWaitingThread(std::vector<MsgPipeWaitingThread> &waitingThreads, SceUID threadID)
-	{
-		waitingThreads.erase(std::remove(waitingThreads.begin(), waitingThreads.end(), threadID), waitingThreads.end());
-	}
-
 	void RemoveReceiveWaitingThread(SceUID threadID)
 	{
-		RemoveWaitingThread(receiveWaitingThreads, threadID);
+		HLEKernel::RemoveWaitingThread(receiveWaitingThreads, threadID);
 	}
 
 	void RemoveSendWaitingThread(SceUID threadID)
 	{
-		RemoveWaitingThread(sendWaitingThreads, threadID);
+		HLEKernel::RemoveWaitingThread(sendWaitingThreads, threadID);
 	}
 
 	virtual void DoState(PointerWrap &p)

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -461,7 +461,7 @@ void __KernelMutexThreadEnd(SceUID threadID)
 	{
 		Mutex *mutex = kernelObjects.Get<Mutex>(waitingMutexID, error);
 		if (mutex)
-			mutex->waitingThreads.erase(std::remove(mutex->waitingThreads.begin(), mutex->waitingThreads.end(), threadID), mutex->waitingThreads.end());
+			HLEKernel::RemoveWaitingThread(mutex->waitingThreads, threadID);
 	}
 
 	// Unlock all mutexes the thread had locked.

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -517,12 +517,7 @@ int sceKernelCancelMutex(SceUID uid, int count, u32 numWaitThreadsPtr)
 		DEBUG_LOG(SCEKERNEL, "sceKernelCancelMutex(%i, %d, %08x)", uid, count, numWaitThreadsPtr);
 
 		// Remove threads no longer waiting on this first (so the numWaitThreads value is correct.)
-		for (auto iter = mutex->waitingThreads.begin(); iter != mutex->waitingThreads.end(); ++iter)
-		{
-			// The thread is no longer waiting for this, clean it up.
-			if (!HLEKernel::VerifyWait(*iter, WAITTYPE_MUTEX, uid))
-				mutex->waitingThreads.erase(iter--);
-		}
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_MUTEX, uid, mutex->waitingThreads);
 
 		if (Memory::IsValidAddress(numWaitThreadsPtr))
 			Memory::Write_U32((u32)mutex->waitingThreads.size(), numWaitThreadsPtr);
@@ -682,12 +677,7 @@ int sceKernelReferMutexStatus(SceUID id, u32 infoAddr)
 	// Don't write if the size is 0.  Anything else is A-OK, though, apparently.
 	if (Memory::Read_U32(infoAddr) != 0)
 	{
-		for (auto iter = m->waitingThreads.begin(); iter != m->waitingThreads.end(); ++iter)
-		{
-			// The thread is no longer waiting for this, clean it up.
-			if (!HLEKernel::VerifyWait(*iter, WAITTYPE_MUTEX, id))
-				m->waitingThreads.erase(iter--);
-		}
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_MUTEX, id, m->waitingThreads);
 
 		m->nm.numWaitThreads = (int) m->waitingThreads.size();
 		Memory::WriteStruct(infoAddr, &m->nm);
@@ -1065,12 +1055,7 @@ int __KernelReferLwMutexStatus(SceUID uid, u32 infoPtr)
 	{
 		auto workarea = m->nm.workarea;
 
-		for (auto iter = m->waitingThreads.begin(); iter != m->waitingThreads.end(); ++iter)
-		{
-			// The thread is no longer waiting for this, clean it up.
-			if (!HLEKernel::VerifyWait(*iter, WAITTYPE_LWMUTEX, uid))
-				m->waitingThreads.erase(iter--);
-		}
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_LWMUTEX, uid, m->waitingThreads);
 
 		// Refresh and write
 		m->nm.currentCount = workarea->lockLevel;

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -266,12 +266,7 @@ int sceKernelReferSemaStatus(SceUID id, u32 infoPtr)
 		if (!Memory::IsValidAddress(infoPtr))
 			return -1;
 
-		for (auto iter = s->waitingThreads.begin(); iter != s->waitingThreads.end(); ++iter)
-		{
-			// The thread is no longer waiting for this, clean it up.
-			if (!HLEKernel::VerifyWait(*iter, WAITTYPE_SEMA, id))
-				s->waitingThreads.erase(iter--);
-		}
+		HLEKernel::CleanupWaitingThreads(WAITTYPE_SEMA, id, s->waitingThreads);
 
 		s->ns.numWaitThreads = (int) s->waitingThreads.size();
 		if (Memory::Read_U32(infoPtr) != 0)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -498,7 +498,7 @@ public:
 		p.Do(currentCallbackId);
 		p.Do(context);
 
-		p.Do(readyCallbacks);
+		p.Do(callbacks);
 
 		p.Do(pendingMipsCalls);
 		p.Do(pushedStacks);
@@ -518,7 +518,7 @@ public:
 
 	ThreadContext context;
 
-	std::list<SceUID> readyCallbacks;
+	std::vector<SceUID> callbacks;
 
 	std::list<u32> pendingMipsCalls;
 
@@ -1750,7 +1750,14 @@ u32 __KernelDeleteThread(SceUID threadID, int exitStatus, const char *reason)
 	u32 error;
 	Thread *t = kernelObjects.Get<Thread>(threadID, error);
 	if (t)
-		readyCallbacksCount -= (int)t->readyCallbacks.size();
+	{
+		for (auto it = t->callbacks.begin(), end = t->callbacks.end(); it != end; ++it)
+		{
+			Callback *callback = kernelObjects.Get<Callback>(*it, error);
+			if (callback && callback->nc.notifyCount != 0)
+				readyCallbacksCount--;
+		}
+	}
 
 	return kernelObjects.Destroy<Thread>(threadID);
 }
@@ -2810,6 +2817,10 @@ SceUID sceKernelCreateCallback(const char *name, u32 entrypoint, u32 signalArg)
 	cb->nc.notifyCount = 0;
 	cb->nc.notifyArg = 0;
 
+	Thread *thread = __GetCurrentThread();
+	if (thread)
+		thread->callbacks.push_back(id);
+
 	DEBUG_LOG(SCEKERNEL, "%i=sceKernelCreateCallback(name=%s, entry=%08x, callbackArg=%08x)", id, name, entrypoint, signalArg);
 
 	return id;
@@ -2819,9 +2830,19 @@ int sceKernelDeleteCallback(SceUID cbId)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelDeleteCallback(%i)", cbId);
 
-	// TODO: Make sure it's gone from all threads first!
+	u32 error;
+	Callback *cb = kernelObjects.Get<Callback>(cbId, error);
+	if (cb)
+	{
+		Thread *thread = kernelObjects.Get<Thread>(cb->nc.threadId, error);
+		if (thread)
+			thread->callbacks.erase(std::find(thread->callbacks.begin(), thread->callbacks.end(), cbId), thread->callbacks.end());
+		if (cb->nc.notifyCount != 0)
+			readyCallbacksCount--;
 
-	return kernelObjects.Destroy<Callback>(cbId);
+		return kernelObjects.Destroy<Callback>(cbId);
+	}
+	return error;
 }
 
 // Generally very rarely used, but Numblast uses it like candy.
@@ -3421,38 +3442,37 @@ void ActionAfterCallback::run(MipsCall &call) {
 }
 
 bool __KernelCurHasReadyCallbacks() {
-	if (readyCallbacksCount == 0)
+	if (readyCallbacksCount == 0) {
 		return false;
-
-	Thread *thread = __GetCurrentThread();
-	if (thread->readyCallbacks.size()) {
-		return true;
 	}
 
+	Thread *thread = __GetCurrentThread();
+	u32 error;
+	for (auto it = thread->callbacks.begin(), end = thread->callbacks.end(); it != end; ++it) {
+		Callback *callback = kernelObjects.Get<Callback>(*it, error);
+		if (callback && callback->nc.notifyCount != 0) {
+			return true;
+		}
+	}
 	return false;
 }
 
 // Check callbacks on the current thread only.
 // Returns true if any callbacks were processed on the current thread.
-bool __KernelCheckThreadCallbacks(Thread *thread, bool force)
-{
-	if (!thread || (!thread->isProcessingCallbacks && !force))
+bool __KernelCheckThreadCallbacks(Thread *thread, bool force) {
+	if (!thread || (!thread->isProcessingCallbacks && !force)) {
 		return false;
+	}
 
-	if (thread->readyCallbacks.size()) {
-		SceUID readyCallback = thread->readyCallbacks.front();
-		thread->readyCallbacks.pop_front();
-		readyCallbacksCount--;
-
-		// If the callback was deleted, we're good.  Just skip it.
-		if (kernelObjects.IsValid(readyCallback))
-		{
-			__KernelRunCallbackOnThread(readyCallback, thread, !force);   // makes pending
-			return true;
-		}
-		else
-		{
-			WARN_LOG(SCEKERNEL, "Ignoring deleted callback %08x", readyCallback);
+	if (!thread->callbacks.empty()) {
+		u32 error;
+		for (auto it = thread->callbacks.begin(), end = thread->callbacks.end(); it != end; ++it) {
+			Callback *callback = kernelObjects.Get<Callback>(*it, error);
+			if (callback && callback->nc.notifyCount != 0) {
+				__KernelRunCallbackOnThread(callback->GetUID(), thread, !force);
+				readyCallbacksCount--;
+				return true;
+			}
 		}
 	}
 	return false;
@@ -3468,23 +3488,20 @@ bool __KernelCheckCallbacks() {
 		ERROR_LOG_REPORT(SCEKERNEL, "readyCallbacksCount became negative: %i", readyCallbacksCount);
 	}
 
-	// SceUID currentThread = __KernelGetCurThread();
-	// __GetCurrentThread()->isProcessingCallbacks = true;
-	// do {
-		bool processed = false;
+	bool processed = false;
 
-		u32 error;
-		for (std::vector<SceUID>::iterator iter = threadqueue.begin(); iter != threadqueue.end(); iter++) {
-			Thread *thread = kernelObjects.Get<Thread>(*iter, error);
-			if (thread && __KernelCheckThreadCallbacks(thread, false)) {
-				processed = true;
-			}
+	u32 error;
+	for (std::vector<SceUID>::iterator iter = threadqueue.begin(); iter != threadqueue.end(); iter++) {
+		Thread *thread = kernelObjects.Get<Thread>(*iter, error);
+		if (thread && __KernelCheckThreadCallbacks(thread, false)) {
+			processed = true;
 		}
-	// } while (processed && currentThread == __KernelGetCurThread());
+	}
 
-	if (processed)
+	if (processed) {
 		return __KernelExecutePendingMipsCalls(__GetCurrentThread(), true);
-	return processed;
+	}
+	return false;
 }
 
 bool __KernelForceCallbacks()
@@ -3536,16 +3553,11 @@ void __KernelNotifyCallback(SceUID cbId, int notifyArg)
 		ERROR_LOG(SCEKERNEL, "__KernelNotifyCallback - invalid callback %08x", cbId);
 		return;
 	}
-	cb->nc.notifyCount++;
-	cb->nc.notifyArg = notifyArg;
-
-	Thread *t = kernelObjects.Get<Thread>(cb->nc.threadId, error);
-	auto iter = std::find(t->readyCallbacks.begin(), t->readyCallbacks.end(), cbId);
-	if (iter == t->readyCallbacks.end())
-	{
-		t->readyCallbacks.push_back(cbId);
+	if (cb->nc.notifyCount == 0) {
 		readyCallbacksCount++;
 	}
+	cb->nc.notifyCount++;
+	cb->nc.notifyArg = notifyArg;
 }
 
 void __KernelRegisterWaitTypeFuncs(WaitType type, WaitBeginCallbackFunc beginFunc, WaitEndCallbackFunc endFunc)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2969,7 +2969,7 @@ void ActionAfterMipsCall::run(MipsCall &call) {
 
 ActionAfterMipsCall *Thread::getRunningCallbackAction()
 {
-	if (this->GetUID() == currentThread && g_inCbCount > 0) 	{
+	if (this->GetUID() == currentThread && g_inCbCount > 0) {
 		MipsCall *call = mipsCalls.get(this->currentMipscallId);
 		ActionAfterMipsCall *action = 0;
 		if (call)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -464,6 +464,10 @@ public:
 
 	~Thread()
 	{
+		// Callbacks are automatically deleted when their owning thread is deleted.
+		for (auto it = callbacks.begin(), end = callbacks.end(); it != end; ++it)
+			kernelObjects.Destroy<Callback>(*it);
+
 		if (pushedStacks.size() != 0)
 		{
 			WARN_LOG_REPORT(SCEKERNEL, "Thread ended within an extended stack");

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -173,27 +173,6 @@ void __KernelWaitCallbacksCurThread(WaitType type, SceUID waitID, u32 waitValue,
 void __KernelReSchedule(const char *reason = "no reason");
 void __KernelReSchedule(bool doCallbacks, const char *reason);
 
-// Registered callback types
-enum RegisteredCallbackType {
-	THREAD_CALLBACK_UMD = 0,
-	THREAD_CALLBACK_IO = 1,
-	THREAD_CALLBACK_MEMORYSTICK = 2,
-	THREAD_CALLBACK_MEMORYSTICK_FAT = 3,
-	THREAD_CALLBACK_POWER = 4,
-	THREAD_CALLBACK_EXIT = 5,
-	THREAD_CALLBACK_USER_DEFINED = 6,
-	THREAD_CALLBACK_SIZE = 7,
-	THREAD_CALLBACK_NUM_TYPES = 8,
-};
-
-// These operate on the current thread
-u32 __KernelRegisterCallback(RegisteredCallbackType type, SceUID cbId);
-u32 __KernelUnregisterCallback(RegisteredCallbackType type, SceUID cbId);
-
-// If cbId == -1, all the callbacks of the type on all the threads get notified.
-// If not, only this particular callback gets notified.
-u32 __KernelNotifyCallbackType(RegisteredCallbackType type, SceUID cbId, int notifyArg);
-
 SceUID __KernelGetCurThread();
 SceUID __KernelGetCurThreadModuleId();
 SceUID __KernelSetupRootThread(SceUID moduleId, int args, const char *argp, int prio, int stacksize, int attr); //represents the real PSP elf loader, run before execution
@@ -232,7 +211,7 @@ bool __KernelCurHasReadyCallbacks();
 class Thread;
 void __KernelSwitchContext(Thread *target, const char *reason);
 bool __KernelExecutePendingMipsCalls(Thread *currentThread, bool reschedAfter);
-void __KernelNotifyCallback(RegisteredCallbackType type, SceUID cbId, int notifyArg);
+void __KernelNotifyCallback(SceUID cbId, int notifyArg);
 
 // Switch to an idle / non-user thread, if not already on one.
 // Returns whether a switch occurred.

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -154,10 +154,8 @@ int scePowerRegisterCallback(int slot, int cbId) {
 		}
 	}
 	if (retval >= 0) {
-		__KernelRegisterCallback(THREAD_CALLBACK_POWER, cbId);
-
 		int arg = PSP_POWER_CB_AC_POWER | PSP_POWER_CB_BATTERY_EXIST | PSP_POWER_CB_BATTERY_FULL;
-		__KernelNotifyCallbackType(THREAD_CALLBACK_POWER, cbId, arg);
+		__KernelNotifyCallback(cbId, arg);
 	}
 	return retval;
 }
@@ -175,7 +173,6 @@ int scePowerUnregisterCallback(int slotId) {
 	if (powerCbSlots[slotId] != 0) {
 		int cbId = powerCbSlots[slotId];
 		DEBUG_LOG(HLE, "0=scePowerUnregisterCallback(%i) (cbid = %i)", slotId, cbId);
-		__KernelUnregisterCallback(THREAD_CALLBACK_POWER, cbId);
 		powerCbSlots[slotId] = 0;
 	} else {
 		return PSP_POWER_ERROR_EMPTY_SLOT;

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -114,7 +114,8 @@ void __UmdStatChange(u64 userdata, int cyclesLate)
 void __KernelUmdActivate()
 {
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE;
-	__KernelNotifyCallback(driveCBId, notifyArg);
+	if (driveCBId != -1)
+		__KernelNotifyCallback(driveCBId, notifyArg);
 
 	// Don't activate immediately, take time to "spin up."
 	CoreTiming::RemoveAllEvents(umdStatChangeEvent);
@@ -124,7 +125,8 @@ void __KernelUmdActivate()
 void __KernelUmdDeactivate()
 {
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READY;
-	__KernelNotifyCallback(driveCBId, notifyArg);
+	if (driveCBId != -1)
+		__KernelNotifyCallback(driveCBId, notifyArg);
 
 	CoreTiming::RemoveAllEvents(umdStatChangeEvent);
 	__UmdStatChange(0, 0);
@@ -256,7 +258,7 @@ int sceUmdDeactivate(u32 mode, const char *name)
 
 u32 sceUmdRegisterUMDCallBack(u32 cbId)
 {
-	int retVal;
+	int retVal = 0;
 
 	// TODO: If the callback is invalid, return PSP_ERROR_UMD_INVALID_PARAM.
 	if (!kernelObjects.IsValid(cbId)) {

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -150,11 +150,7 @@ void __UmdBeginCallback(SceUID threadID, SceUID prevCallbackId)
 		else
 			umdPausedWaits[pauseKey] = 0;
 
-		for (auto it = umdWaitingThreads.begin(); it < umdWaitingThreads.end(); ++it)
-		{
-			if (*it == threadID)
-				umdWaitingThreads.erase(it--);
-		}
+		HLEKernel::RemoveWaitingThread(umdWaitingThreads, threadID);
 
 		DEBUG_LOG(SCEIO, "sceUmdWaitDriveStatCB: Suspending lock wait for callback");
 	}
@@ -305,10 +301,7 @@ void __UmdStatTimeout(u64 userdata, int cyclesLate)
 	if (waitID == 1)
 		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 
-	for (size_t i = 0; i < umdWaitingThreads.size(); ++i) {
-		if (umdWaitingThreads[i] == threadID)
-			umdWaitingThreads.erase(umdWaitingThreads.begin() + i--);
-	}
+	HLEKernel::RemoveWaitingThread(umdWaitingThreads, threadID);
 }
 
 void __UmdWaitStat(u32 timeout)


### PR DESCRIPTION
This fixes some more surface-level issues with callbacks.  I still need to figure out how to get the callbacks to schedule right without tripping over each other.

Specifically:
- A callback can be notified by different things, umd, power, etc., but it's only called once.  We were calling it multiple times, with bad parameters.
- Correctly associates callbacks to the thread they were created on (not the active thread when they were registered.)
- Callbacks are executed in the order they were created, even if they were not notified in that order.  The umd/wait/wait test actually shows this, but it was working by accident because of the types.
- Callbacks are silently deleted when the thread they were tied to is deleted.

Also cleaned up waits a bit more, noticed a few debug warnings, when decrementing an iterator that's already at begin.

-[Unknown]
