### PR TITLE
Fix bugs when memory size is 0x04C00000/etc.

### DIFF
--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -57,9 +57,9 @@ u8 *m_pUncachedVRAM;
 
 // Holds the ending address of the PSP's user space.
 // Required for HD Remasters to work properly.
-// These replace RAM_SIZE and RAM_MASK, respectively.
-u32 g_MemoryMask;
+// These replace RAM_NORMAL_SIZE and RAM_NORMAL_MASK, respectively.
 u32 g_MemorySize;
+u32 g_MemoryMask;
 
 // We don't declare the IO region in here since its handled by other means.
 static MemoryView views[] =
@@ -81,7 +81,10 @@ static const int num_views = sizeof(views) / sizeof(MemoryView);
 void Init()
 {
 	int flags = 0;
-	Memory::g_MemoryMask = Memory::g_MemorySize - 1;
+	// This mask is used ONLY after validating the address is in the correct range.
+	// So let's juse use a fixed mask to remove the uncached/user memory bits.
+	// Using (Memory::g_MemorySize - 1) won't work for e.g. 0x04C00000.
+	Memory::g_MemoryMask = 0x07FFFFFF;
 
 	for (size_t i = 0; i < ARRAY_SIZE(views); i++) {
 		if (views[i].flags & MV_IS_PRIMARY_RAM)

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -79,6 +79,10 @@ extern u32 g_MemoryMask;
 
 enum
 {
+	// This may be adjusted by remaster games.
+	RAM_NORMAL_SIZE = 0x02000000,
+	RAM_NORMAL_MASK = RAM_NORMAL_SIZE - 1,
+
 	VRAM_SIZE       = 0x200000,
 	VRAM_MASK       = VRAM_SIZE - 1,
 

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -40,7 +40,7 @@ namespace Memory
 u8 *GetPointer(const u32 address)
 {
 	if ((address & 0x3E000000) == 0x08000000) {
-		return m_pRAM + (address & g_MemoryMask);
+		return m_pRAM + (address & RAM_NORMAL_MASK);
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		return m_pVRAM + (address & VRAM_MASK);
@@ -48,7 +48,7 @@ u8 *GetPointer(const u32 address)
 	else if ((address & 0xBFFF0000) == 0x00010000) {
 		return m_pScratchPad + (address & SCRATCHPAD_MASK);
 	}
-	else if (g_RemasterMode && (address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
+	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return m_pRAM + (address & g_MemoryMask);
 	}
 	else {
@@ -75,7 +75,7 @@ inline void ReadFromHardware(T &var, const u32 address)
 	// Could just do a base-relative read, too.... TODO
 
 	if ((address & 0x3E000000) == 0x08000000) {
-		var = *((const T*)&m_pRAM[address & g_MemoryMask]);
+		var = *((const T*)&m_pRAM[address & RAM_NORMAL_MASK]);
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		var = *((const T*)&m_pVRAM[address & VRAM_MASK]);
@@ -84,7 +84,7 @@ inline void ReadFromHardware(T &var, const u32 address)
 		// Scratchpad
 		var = *((const T*)&m_pScratchPad[address & SCRATCHPAD_MASK]);
 	}
-	else if (g_RemasterMode && (address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
+	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		var = *((const T*)&m_pRAM[address & g_MemoryMask]);
 	}
 	else
@@ -113,7 +113,7 @@ inline void WriteToHardware(u32 address, const T data)
 	// Could just do a base-relative write, too.... TODO
 
 	if ((address & 0x3E000000) == 0x08000000) {
-		*(T*)&m_pRAM[address & g_MemoryMask] = data;
+		*(T*)&m_pRAM[address & RAM_NORMAL_MASK] = data;
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		*(T*)&m_pVRAM[address & VRAM_MASK] = data;
@@ -121,7 +121,7 @@ inline void WriteToHardware(u32 address, const T data)
 	else if ((address & 0xBFFF0000) == 0x00010000) {
 		*(T*)&m_pScratchPad[address & SCRATCHPAD_MASK] = data;
 	}
-	else if (g_RemasterMode && (address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
+	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		*(T*)&m_pRAM[address & g_MemoryMask] = data;
 	}
 	else
@@ -156,7 +156,7 @@ bool IsValidAddress(const u32 address)
 	else if ((address & 0xBFFF0000) == 0x00010000) {
 		return true;
 	}
-	else if (g_RemasterMode && (address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
+	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return true;
 	}
 	else

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -136,7 +136,7 @@ void CPU_Init() {
 
 	// Default memory settings
 	// Seems to be the safest place currently..
-	Memory::g_MemorySize = 0x02000000; // 32 MB of ram by default
+	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
 


### PR DESCRIPTION
Was experimenting with trying to match my non-phat's ram size, and realized this could be causing issues with some remasters depending on their settings.

Also removed g_RemasterMode from the ram checks since it won't change the outcome (it might just make the invalid address errors slower, which I don't care about), and it made it easier to test the change.

Not actually tested with any remasters.

-[Unknown]
