### PR TITLE
Oops, timegm() is supposed to modify its argument

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -75,9 +75,7 @@ void gettimeofday(timeval *tv, void *ignore)
 
 time_t rtc_timegm(struct tm *tm)
 {
-	struct tm modified;
-	memcpy(&modified, tm, sizeof(modified));
-	return _mkgmtime(&modified);
+	return _mkgmtime(tm);
 }
 
 #elif defined(__GLIBC__) && !defined(ANDROID)


### PR DESCRIPTION
Fixes some problems in sceRtc (timezone/wrapping issues.)

-[Unknown]
