### PR TITLE
Fixes to various thread functions + heap corruption fix

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -429,9 +429,15 @@ void CallSyscall(MIPSOpcode op)
 		if (flags != 0)
 		{
 			if ((flags & HLE_NOT_DISPATCH_SUSPENDED) && !__KernelIsDispatchEnabled())
+			{
+				DEBUG_LOG(HLE, "%s: dispatch suspended", moduleDB[modulenum].funcTable[funcnum].name);
 				RETURN(SCE_KERNEL_ERROR_CAN_NOT_WAIT);
+			}
 			else if ((flags & HLE_NOT_IN_INTERRUPT) && __IsInInterrupt())
+			{
+				DEBUG_LOG(HLE, "%s: in interrupt", moduleDB[modulenum].funcTable[funcnum].name);
 				RETURN(SCE_KERNEL_ERROR_ILLEGAL_CONTEXT);
+			}
 			else
 				func();
 		}

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -114,6 +114,11 @@ const HLEFunction sceImpose[] =
 	{0xE0887BC8, WrapU_V<sceImposeGetUMDPopup>, "sceImposeGetUMDPopup"},
 	{0x8F6E3518, WrapU_V<sceImposeGetBacklightOffTime>, "sceImposeGetBacklightOffTime"},
 	{0x967F6D4A, WrapU_I<sceImposeSetBacklightOffTime>, "sceImposeSetBacklightOffTime"},
+	{0xfcd44963, 0, "sceImpose_FCD44963"},
+	{0xa9884b00, 0, "sceImpose_A9884B00"},
+	{0xbb3f5dec, 0, "sceImpose_BB3F5DEC"},
+	{0x9ba61b49, 0, "sceImpose_9BA61B49"},
+	{0xff1a2f07, 0, "sceImpose_FF1A2F07"},
 };
 
 void Register_sceImpose()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2368,6 +2368,8 @@ int sceKernelTerminateThread(SceUID threadID)
 		}
 
 		INFO_LOG(SCEKERNEL, "sceKernelTerminateThread(%i)", threadID);
+		// On terminate, we reset the thread priority.  On exit, we don't always (see __KernelResetThread.)
+		t->nt.currentPriority = t->nt.initialPriority;
 		// TODO: Should this reschedule?  Seems like not.
 		__KernelStopThread(threadID, SCE_KERNEL_ERROR_THREAD_TERMINATED, "thread terminated");
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1738,6 +1738,10 @@ void __KernelStopThread(SceUID threadID, int exitStatus, const char *reason)
 			}
 		}
 		t->waitingThreads.clear();
+
+		// Stopped threads are never waiting.
+		t->nt.waitType = WAITTYPE_NONE;
+		t->nt.waitID = 0;
 	}
 	else
 		ERROR_LOG_REPORT(SCEKERNEL, "__KernelStopThread: thread %d does not exist", threadID);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1934,6 +1934,8 @@ Thread *__KernelCreateThread(SceUID &id, SceUID moduleId, const char *name, u32 
 	t->nt.entrypoint = entryPoint;
 	t->nt.nativeSize = sizeof(t->nt);
 	t->nt.attr = attr;
+	// TODO: I have no idea what this value is but the PSP firmware seems to add it on create.
+	t->nt.attr |= 0xFF;
 	t->nt.initialPriority = t->nt.currentPriority = priority;
 	t->nt.stackSize = stacksize;
 	t->nt.status = THREADSTATUS_DORMANT;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -770,7 +770,7 @@ private:
 		int size = cur->end - cur->first;
 		if (size >= cur->capacity - 2)
 		{
-			SceUID *new_data = (SceUID *)realloc(cur->data, cur->capacity * sizeof(SceUID));
+			SceUID *new_data = (SceUID *)realloc(cur->data, cur->capacity * 2 * sizeof(SceUID));
 			if (new_data != NULL)
 			{
 				cur->capacity *= 2;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2049,6 +2049,11 @@ int __KernelCreateThread(const char *threadName, SceUID moduleID, u32 entry, u32
 	INFO_LOG(SCEKERNEL, "%i=sceKernelCreateThread(name=%s, entry=%08x, prio=%x, stacksize=%i)", id, threadName, entry, prio, stacksize);
 	if (optionAddr != 0)
 		WARN_LOG_REPORT(SCEKERNEL, "sceKernelCreateThread(name=%s): unsupported options parameter %08x", threadName, optionAddr);
+
+	hleEatCycles(32000);
+	// This won't schedule to the new thread, but it may to one woken from eating cycles.
+	// Technically, this should not eat all at once, and reschedule in the middle, but that's hard.
+	hleReSchedule("thread created");
 	return id;
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1393,7 +1393,7 @@ SceUID __KernelGetWaitID(SceUID threadID, WaitType type, u32 &error)
 	else
 	{
 		ERROR_LOG(SCEKERNEL, "__KernelGetWaitID ERROR: thread %i", threadID);
-		return 0;
+		return -1;
 	}
 }
 
@@ -2587,7 +2587,7 @@ int sceKernelWakeupThread(SceUID uid)
 	Thread *t = kernelObjects.Get<Thread>(uid, error);
 	if (t)
 	{
-		if (!t->isWaitingFor(WAITTYPE_SLEEP, 1)) {
+		if (!t->isWaitingFor(WAITTYPE_SLEEP, 0)) {
 			t->nt.wakeupCount++;
 			DEBUG_LOG(SCEKERNEL,"sceKernelWakeupThread(%i) - wakeupCount incremented to %i", uid, t->nt.wakeupCount);
 		} else {
@@ -2633,7 +2633,7 @@ static int __KernelSleepThread(bool doCallbacks) {
 		DEBUG_LOG(SCEKERNEL, "sceKernelSleepThread() - wakeupCount decremented to %i", thread->nt.wakeupCount);
 	} else {
 		VERBOSE_LOG(SCEKERNEL, "sceKernelSleepThread()");
-		__KernelWaitCurThread(WAITTYPE_SLEEP, 1, 0, 0, doCallbacks, "thread slept");
+		__KernelWaitCurThread(WAITTYPE_SLEEP, 0, 0, 0, doCallbacks, "thread slept");
 	}
 	return 0;
 }


### PR DESCRIPTION
Well, that's been there a while (ada492febe0ab62f08f9672f74de4137e5ed747f.)  Oops.  Wasn't actually growing the queue.

Otherwise, this is a lot of really small shot-gun changes that make threads/threads/ tests pass better.  Mainly:
- Support some more attrs of sceKernelCreateThread() and report unsupported ones.
- Eat cycles when creating a thread to better match tests, correct anyway (sure takes a while...)
- Match tests a little better with attr handling.
- Reset a few things on thread termination.

It's possible this may help games that create and run more than 32 threads on the same priority, or maybe some memory alloc issues.

-[Unknown]
