### PR TITLE
Don't write more than the game's savedata buffer

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -527,7 +527,7 @@ bool SavedataParam::Load(SceUtilitySavedataParam *param, const std::string &save
 		if(DecryptSave(decryptMode, data_base, &saveSize, &align_len, ((param->key[0] != 0)?cryptKey:0)) == 0)
 		{
 			if (param->dataBuf.IsValid())
-				memcpy(data_, data_base, saveSize);			
+				memcpy(data_, data_base, std::min(saveSize, (int)param->dataBufSize));
 			saveDone = true;
 		}
 		delete[] data_base;
@@ -535,7 +535,8 @@ bool SavedataParam::Load(SceUtilitySavedataParam *param, const std::string &save
 	}
 	if(!saveDone) // not crypted or decrypt fail
 	{
-		memcpy(data_, saveData, saveSize);
+		if (param->dataBuf.IsValid())
+			memcpy(data_, saveData, std::min(saveSize, (int)param->dataBufSize));
 	}
 	param->dataSize = (SceSize)saveSize;
 	delete[] saveData;


### PR DESCRIPTION
Fixes Numblast when there's savedata, probably others.  Could use more testing, maybe there are error codes, but Numblast didn't seem to check for any.

Finally.  For a while this has been one of the few games I have that totally locks up on start (only if there's savedata, but still.)  Now it works.

-[Unknown]
