### PR TITLE
Fix input in desktop Qt

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -15,6 +15,7 @@
 #include "Core/Config.h"
 #include "ConsoleListener.h"
 #include "base/display.h"
+#include "base/NKCodeFromQt.h"
 #include "GPU/GPUInterface.h"
 
 #include "QtHost.h"
@@ -34,8 +35,6 @@ MainWindow::MainWindow(QWidget *parent) :
 	lastUIState(UISTATE_MENU)
 {
 	ui->setupUi(this);
-
-	controls = new Controls(this);
 
 	host = new QtHost(this);
 	emugl = ui->widget;
@@ -88,19 +87,6 @@ inline float clamp1(float x) {
 void MainWindow::Update()
 {
 	emugl->updateGL();
-
-	for (int i = 0; i < controllistCount; i++)
-	{
-		if (pressedKeys.contains(controllist[i].key) ||
-				input_state.pad_buttons_down & controllist[i].emu_id)
-			__CtrlButtonDown(controllist[i].psp_id);
-		else
-			__CtrlButtonUp(controllist[i].psp_id);
-	}
-	__CtrlSetAnalogX(clamp1(input_state.pad_lstick_x), 0);
-	__CtrlSetAnalogY(clamp1(input_state.pad_lstick_y), 0);
-	__CtrlSetAnalogX(clamp1(input_state.pad_rstick_x), 1);
-	__CtrlSetAnalogY(clamp1(input_state.pad_rstick_y), 1);
 
 	if (lastUIState != globalUIState) {
 		lastUIState = globalUIState;
@@ -197,12 +183,12 @@ void MainWindow::keyPressEvent(QKeyEvent *e)
 		return;
 	}
 
-	pressedKeys.insert(e->key());
+	NativeKey(KeyInput(DEVICE_ID_KEYBOARD, KeyMapRawQttoNative.find(e->key())->second, KEY_DOWN));
 }
 
 void MainWindow::keyReleaseEvent(QKeyEvent *e)
 {
-	pressedKeys.remove(e->key());
+	NativeKey(KeyInput(DEVICE_ID_KEYBOARD, KeyMapRawQttoNative.find(e->key())->second, KEY_UP));
 }
 
 /* SLOTS */
@@ -450,11 +436,6 @@ void MainWindow::on_action_OptionsIgnoreIllegalReadsWrites_triggered()
 {
 	g_Config.bIgnoreBadMemAccess = !g_Config.bIgnoreBadMemAccess;
 	UpdateMenus();
-}
-
-void MainWindow::on_action_OptionsControls_triggered()
-{
-	controls->show();
 }
 
 void MainWindow::on_action_AFOff_triggered()

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -10,7 +10,6 @@
 #include "debugger_memory.h"
 #include "debugger_memorytex.h"
 #include "debugger_displaylist.h"
-#include "controls.h"
 
 class QtEmuGL;
 namespace Ui {
@@ -78,9 +77,6 @@ private slots:
 	void on_action_CPUInterpreter_triggered();
 	void on_action_OptionsFastMemory_triggered();
 	void on_action_OptionsIgnoreIllegalReadsWrites_triggered();
-
-	// Controls
-	void on_action_OptionsControls_triggered();
 
 	// Video
 	void on_action_AFOff_triggered();
@@ -155,9 +151,6 @@ private:
 	Debugger_Memory *memoryWindow;
 	Debugger_MemoryTex *memoryTexWindow;
 	Debugger_DisplayList *displaylistWindow;
-	Controls *controls;
-
-	QSet<int> pressedKeys;
 };
 
 #endif // MAINWINDOW_H

--- a/Qt/mainwindow.ui
+++ b/Qt/mainwindow.ui
@@ -178,12 +178,6 @@
      <addaction name="action_OptionsDisplayRawFramebuffer"/>
      <addaction name="actionFrameskip"/>
     </widget>
-    <widget class="QMenu" name="menuControls">
-     <property name="title">
-      <string>Co&amp;ntrols</string>
-     </property>
-     <addaction name="action_OptionsControls"/>
-    </widget>
     <widget class="QMenu" name="menuCore">
      <property name="title">
       <string>&amp;Core</string>
@@ -196,7 +190,6 @@
      <addaction name="separator"/>
     </widget>
     <addaction name="menuCore"/>
-    <addaction name="menuControls"/>
     <addaction name="menuVideo"/>
     <addaction name="action_Sound"/>
     <addaction name="separator"/>
@@ -355,11 +348,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+M</string>
-   </property>
-  </action>
-  <action name="action_OptionsControls">
-   <property name="text">
-    <string>&amp;Keyboard</string>
    </property>
   </action>
   <action name="action_OptionsFullScreen">

--- a/Qt/qtemugl.cpp
+++ b/Qt/qtemugl.cpp
@@ -61,3 +61,22 @@ void QtEmuGL::mouseReleaseEvent(QMouseEvent *e)
 	input.id = 0;
 	NativeTouch(input);
 }
+
+void QtEmuGL::mouseMoveEvent(QMouseEvent *e)
+{
+	TouchInput input;
+	input.x = e->x();
+	input.y = e->y();
+	input.flags = TOUCH_MOVE;
+	input.id = 0;
+	NativeTouch(input);
+}
+
+void QtEmuGL::wheelEvent(QWheelEvent *e)
+{
+	KeyInput key;
+	key.deviceId = DEVICE_ID_MOUSE;
+	key.keyCode = e->delta()<0 ? NKCODE_EXT_MOUSEWHEEL_DOWN : NKCODE_EXT_MOUSEWHEEL_UP;
+	key.flags = KEY_DOWN;
+	NativeKey(key);
+}

--- a/Qt/qtemugl.h
+++ b/Qt/qtemugl.h
@@ -24,6 +24,8 @@ protected:
 	void mouseDoubleClickEvent(QMouseEvent *);
 	void mousePressEvent(QMouseEvent *e);
 	void mouseReleaseEvent(QMouseEvent *e);
+	void mouseMoveEvent(QMouseEvent *e);
+	void wheelEvent(QWheelEvent *e);
 
 private:
 	InputState *input_state;


### PR DESCRIPTION
This make Qt work better with the new UI by adding mouse move/drag and scroll.

Alphabetic keys won't work without hrydgard/native#129
