### PR TITLE
Start sceRtc at now, not 1970

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -115,14 +115,14 @@ void __RtcInit()
 	rtcBaseTime.tv_sec = tv.tv_sec;
 	rtcBaseTime.tv_usec = tv.tv_usec;
 	// Precalculate the current time in microseconds (rtcMagicOffset is offset to 1970.)
-	rtcBaseTicks = 1000000ULL * rtcBaseTime.tv_sec + rtcMagicOffset;
+	rtcBaseTicks = 1000000ULL * rtcBaseTime.tv_sec + rtcBaseTime.tv_usec + rtcMagicOffset;
 }
 
 void __RtcDoState(PointerWrap &p)
 {
 	p.Do(rtcBaseTime);
 	// Update the precalc, pointless to savestate this as it's just based on the other value.
-	rtcBaseTicks = 1000000ULL * rtcBaseTime.tv_sec + rtcMagicOffset;
+	rtcBaseTicks = 1000000ULL * rtcBaseTime.tv_sec + rtcBaseTime.tv_usec + rtcMagicOffset;
 
 	p.DoMarker("sceRtc");
 }


### PR DESCRIPTION
This fixes one of the other dates in God Eater Burst, maybe the others.

I didn't bother to account for the less than 1 second resolution, I'm not sure it's strictly important... ahh, maybe I will change it.

-[Unknown]
