### PR TITLE
Write only changed characters from OSK

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -945,7 +945,11 @@ int PSPOskDialog::Update()
 	}
 
 	u16_le *outText = oskParams->fields[0].outtext;
-	for (u32 i = 0, end = oskParams->fields[0].outtextlength; i < end; ++i)
+	size_t end = oskParams->fields[0].outtextlength;
+	// Only write the bytes of the output and the null terminator, don't write the rest.
+	if (end > inputChars.size())
+		end = inputChars.size() + 1;
+	for (size_t i = 0; i < end; ++i)
 	{
 		u16 value = 0;
 		if (i < inputChars.size())


### PR DESCRIPTION
It seems like it doesn't write out null bytes at the end, we've been doing this basically always.

If the game specifies a limit that is actually too long, could've been corrupting memory.  I think this may be #718.

-[Unknown]
