### PR TITLE
Win32: Fullscreen launch arg and adjustments.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -157,7 +157,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	graphics->Get("VertexCache", &bVertexCache, true);
 #ifdef _WIN32
 	graphics->Get("FullScreen", &bFullScreen, false);
-	graphics->Get("FullScreenOnLaunch", &bFullScreenOnLaunch, false);
 #endif
 #ifdef BLACKBERRY
 	graphics->Get("PartialStretch", &bPartialStretch, pixel_xres == pixel_yres);
@@ -316,7 +315,6 @@ void Config::Save() {
 		graphics->Set("VertexCache", bVertexCache);
 #ifdef _WIN32
 		graphics->Set("FullScreen", bFullScreen);
-		graphics->Set("FullScreenOnLaunch", bFullScreenOnLaunch);
 #endif		
 #ifdef BLACKBERRY
 		graphics->Set("PartialStretch", bPartialStretch);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -78,9 +78,6 @@ public:
 
 	bool bVertexCache;
 	bool bFullScreen;
-#ifdef _WIN32
-	bool bFullScreenOnLaunch;
-#endif
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	bool bTrueColor;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -250,7 +250,7 @@ namespace MainWindow
 	void _ViewNormal(HWND hWnd) {
 		// Put caption and border styles back.
 		DWORD dwOldStyle = ::GetWindowLong(hWnd, GWL_STYLE);
-		DWORD dwNewStyle = dwOldStyle | WS_CAPTION | WS_THICKFRAME;
+		DWORD dwNewStyle = dwOldStyle | WS_CAPTION | WS_THICKFRAME | WS_SYSMENU;
 		::SetWindowLong(hWnd, GWL_STYLE, dwNewStyle);
 
 		// Put back the menu bar.
@@ -277,7 +277,7 @@ namespace MainWindow
 
 		// Remove caption and border styles.
 		DWORD dwOldStyle = ::GetWindowLong(hWnd, GWL_STYLE);
-		DWORD dwNewStyle = dwOldStyle & ~(WS_CAPTION | WS_THICKFRAME);
+		DWORD dwNewStyle = dwOldStyle & ~(WS_CAPTION | WS_THICKFRAME | WS_SYSMENU);
 		::SetWindowLong(hWnd, GWL_STYLE, dwNewStyle);
 
 		// Remove the menu bar.

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -706,9 +706,7 @@ namespace MainWindow
 		hideCursor = true;
 		SetTimer(hwndMain, TIMER_CURSORUPDATE, CURSORUPDATE_INTERVAL_MS, 0);
 		
-		// Update();
-
-		if(g_Config.bFullScreenOnLaunch)
+		if(g_Config.bFullScreen)
 			_ViewFullScreen(hwndMain);
 		
 		ShowWindow(hwndMain, nCmdShow);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -83,12 +83,15 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	}
 	SetCurrentDirectory(modulePath);
 	// GetCurrentDirectory(MAX_PATH, modulePath);  // for checking in the debugger
-
+#ifndef _DEBUG
 	bool hideLog = true;
-
-#ifdef _DEBUG
-	hideLog = false;
+#else
+	bool hideLog = false;
 #endif
+
+	// Load config up here, because those changes below would be overwritten
+	// if it's not loaded here first.
+	g_Config.Load();
 
 	// The rest is handled in NativeInit().
 	for (int i = 1; i < __argc; ++i)
@@ -107,7 +110,15 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				g_Config.bAutoRun = false;
 				g_Config.bSaveSettings = false;
 				break;
+			case '-':
+			    break;
 			}
+
+			if (!strncmp(__argv[i], "--fullscreen", strlen("--fullscreen")))
+				g_Config.bFullScreen = true;
+
+			if (!strncmp(__argv[i], "--windowed", strlen("--windowed")))
+				g_Config.bFullScreen = false;
 		}
 	}
 
@@ -127,8 +138,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	} else {
 		langRegion = "en_US";
 	}
-
-	g_Config.Load();
 
 	LogManager::Init();
 	LogManager::GetInstance()->GetConsoleListener()->Open(hideLog, 150, 120, "PPSSPP Debug Console");

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -110,8 +110,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				g_Config.bAutoRun = false;
 				g_Config.bSaveSettings = false;
 				break;
-			case '-':
-			    break;
 			}
 
 			if (!strncmp(__argv[i], "--fullscreen", strlen("--fullscreen")))


### PR DESCRIPTION
This is long overdue, but this should finally close #2734. I'll probably also change how the WindowX/WindowY/WindowHeight/WindowWidth variables work in the future, to more closely resemble VBA-M. It's kinda useless to come out of fullscreen with it set to (0,0) for position and (windowwidth, windowheight) as the size. VBA-M remembers the previous sizes.

Also fixes the alt button trying to open the System Menu when in fullscreen by removing it altogether. After exiting FS it reinstates it.
