### PR TITLE
Win32: Don't allow SavePosition to execute if we're entering fullscreen.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -159,6 +159,8 @@ namespace MainWindow
 	}
 
 	void SavePosition() {
+		if (g_Config.bFullScreen) return;
+
 		WINDOWPLACEMENT placement;
 		GetWindowPlacement(hwndMain, &placement);
 		if (placement.showCmd == SW_SHOWNORMAL) {


### PR DESCRIPTION
This brings PPSSPP's fullscreen and windowed behaviour more in line with other emulators like VBA-M. It's silly to come out of fullscreen with a huge window set to position (0, 0), so we'll only allow SavePosition to run when the user is in windowed mode.

This is persistent across sessions of PPSSPP as well; if the user begins in windowed mode and ends in fullscreen, but then re-opens PPSSPP at a later date, then exits fullscreen, it'll remember the last windowed settings they used, as expected.
