### PR TITLE
Zeroize destination alpha as well when stencil test disabled.

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -217,7 +217,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		}
 
 		// At this point, through all paths above, glBlendFuncA and glBlendFuncB will be set right somehow.
-		if (!gstate.isStencilTestEnabled()) {
+		if (!gstate.isStencilTestEnabled() && !gstate.isDepthTestEnabled()) {
 			// Fixes some Persona 2 issues, may be correct? (that is, don't change dest alpha at all if blending)
 			// If this doesn't break anything else, it's likely to be right.
 			// I guess an alternative solution would be to simply disable alpha writes if alpha blending is enabled.

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -221,7 +221,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			// Fixes some Persona 2 issues, may be correct? (that is, don't change dest alpha at all if blending)
 			// If this doesn't break anything else, it's likely to be right.
 			// I guess an alternative solution would be to simply disable alpha writes if alpha blending is enabled.
-			glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, glBlendFuncB);
+			glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, GL_ZERO);
 		} else {
 			glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, glBlendFuncA, glBlendFuncB);
 		}


### PR DESCRIPTION
This makes on FF Type-0 and 3rd birthday looks better while Persona still good at rendering the title screen correctly with alpha blending here.

![screen00067](https://f.cloud.github.com/assets/3000282/1144707/9f1ae9ce-1dc2-11e3-99d6-56c6ad8638b2.jpg)
![screen00066](https://f.cloud.github.com/assets/3000282/1144708/a28f5158-1dc2-11e3-8a7c-3da64ae13f5c.jpg)
![screen00065](https://f.cloud.github.com/assets/3000282/1144709/a837255e-1dc2-11e3-8e4c-8e6b5b9cb322.jpg)
