### PR TITLE
Allow attach valid FB in FB_BUFFERED_MODE only (exactMatch)

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -195,7 +195,7 @@ inline void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, V
 	// If they match exactly, it's non-CLUT and from the top left.
 	if (exactMatch) {
 		DEBUG_LOG(G3D, "Render to texture detected at %08x!", address);
-		if (!entry->framebuffer || entry->invalidHint == -1) {
+		if (!entry->framebuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE || entry->invalidHint == -1) {
 			if (entry->format != framebuffer->format) {
 				WARN_LOG_REPORT_ONCE(diffFormat1, G3D, "Render to texture with different formats %d != %d", entry->format, framebuffer->format);
 				// If it already has one, let's hope that one is correct.


### PR DESCRIPTION
This hacky fixes the flickering issue at least in Framebuffer to memory (GPU/CPU) mode for Breath of Fire III .
(I think non-buffered one and copy to memory shouldn't need it)

Issue #2759
