### PR TITLE
Put the DirectX9 stuff into a namespace.

### DIFF
--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <list>
+#include "d3d9.h"
 
 #include "GPU/Directx9/helper/fbo.h"
 // Keeps track of allocated FBOs.
@@ -27,6 +28,8 @@
 
 #include "Globals.h"
 #include "GPU/GPUCommon.h"
+
+namespace DX9 {
 
 struct GLSLProgram;
 class TextureCacheDX9;
@@ -44,7 +47,7 @@ enum {
 	FB_READFBOMEMORY_GPU = 3,
 };
 
-struct VirtualFramebuffer {
+struct VirtualFramebufferDX9 {
 	int last_frame_used;
 	int last_frame_render;
 	bool memoryUpdated; 
@@ -79,6 +82,7 @@ struct VirtualFramebuffer {
 void CenterRect(float *x, float *y, float *w, float *h,
 								float origW, float origH, float frameW, float frameH);
 
+
 class ShaderManagerDX9;
 
 class FramebufferManagerDX9 {
@@ -107,10 +111,10 @@ public:
 	void SetRenderFrameBuffer();  // Uses parameters computed from gstate
 	void UpdateFromMemory(u32 addr, int size);
 
-	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync = true);
+	void ReadFramebufferToMemory(VirtualFramebufferDX9 *vfb, bool sync = true);
 
 	// TODO: Break out into some form of FBO manager
-	VirtualFramebuffer *GetDisplayFBO();
+	VirtualFramebufferDX9 *GetDisplayFBO();
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format);
 	size_t NumVFBs() const { return vfbs_.size(); }
 
@@ -128,7 +132,7 @@ public:
 		return displayFramebuf_ ? (0x04000000 | displayFramebuf_->fb_address) : 0;
 	}
 
-	void DestroyFramebuf(VirtualFramebuffer *vfb);
+	void DestroyFramebuf(VirtualFramebufferDX9 *vfb);
 
 private:
 	u32 ramDisplayFramebufPtr_;  // workaround for MotoGP insanity
@@ -136,20 +140,20 @@ private:
 	u32 displayStride_;
 	GEBufferFormat displayFormat_;
 
-	VirtualFramebuffer *displayFramebuf_;
-	VirtualFramebuffer *prevDisplayFramebuf_;
-	VirtualFramebuffer *prevPrevDisplayFramebuf_;
+	VirtualFramebufferDX9 *displayFramebuf_;
+	VirtualFramebufferDX9 *prevDisplayFramebuf_;
+	VirtualFramebufferDX9 *prevPrevDisplayFramebuf_;
 	int frameLastFramebufUsed;
 
-	std::vector<VirtualFramebuffer *> vfbs_;
+	std::vector<VirtualFramebufferDX9 *> vfbs_;
 
-	VirtualFramebuffer *currentRenderVfb_;
+	VirtualFramebufferDX9 *currentRenderVfb_;
 
 	// Used by ReadFramebufferToMemory
-	void BlitFramebuffer_(VirtualFramebuffer *src, VirtualFramebuffer *dst, bool flip = false, float upscale = 1.0f, float vscale = 1.0f);
-	void PackFramebufferDirectx9_(VirtualFramebuffer *vfb);
+	void BlitFramebuffer_(VirtualFramebufferDX9 *src, VirtualFramebufferDX9 *dst, bool flip = false, float upscale = 1.0f, float vscale = 1.0f);
+	void PackFramebufferDirectx9_(VirtualFramebufferDX9 *vfb);
 	int gpuVendor;
-	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
+	std::vector<VirtualFramebufferDX9 *> bvfbs_; // blitting FBOs
 	
 	// Used by DrawPixels
 	LPDIRECT3DTEXTURE9 drawPixelsTex_;
@@ -164,4 +168,6 @@ private:
 
 	bool resized_;
 	bool useBufferedRendering_;
+};
+
 };

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -37,6 +37,8 @@
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceGe.h"
 
+namespace DX9 {
+
 enum {
 	FLAG_FLUSHBEFORE = 1,
 	FLAG_FLUSHBEFOREONCHANGE = 2,
@@ -478,7 +480,7 @@ bool DIRECTX9_GPU::FramebufferDirty() {
 		// Allow it to process fully before deciding if it's dirty.
 		SyncThread();
 	}
-	VirtualFramebuffer *vfb = framebufferManager_.GetDisplayFBO();
+	VirtualFramebufferDX9 *vfb = framebufferManager_.GetDisplayFBO();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
 		vfb->dirtyAfterDisplay = false;
@@ -495,7 +497,7 @@ bool DIRECTX9_GPU::FramebufferReallyDirty() {
 		SyncThread();
 	}
 
-	VirtualFramebuffer *vfb = framebufferManager_.GetDisplayFBO();
+	VirtualFramebufferDX9 *vfb = framebufferManager_.GetDisplayFBO();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;
 		vfb->reallyDirtyAfterDisplay = false;
@@ -1379,3 +1381,5 @@ void DIRECTX9_GPU::DoState(PointerWrap &p) {
 	framebufferManager_.DestroyAllFBOs();
 	shaderManager_->ClearCache(true);
 }
+
+};

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -27,6 +27,8 @@
 #include "GPU/Directx9/TextureCacheDX9.h"
 #include "GPU/Directx9/helper/fbo.h"
 
+namespace DX9 {
+
 class ShaderManagerDX9;
 class LinkedShaderDX9;
 
@@ -95,3 +97,7 @@ private:
 	std::string reportingPrimaryInfo_;
 	std::string reportingFullInfo_;
 };
+
+};
+
+typedef DX9::DIRECTX9_GPU DIRECTX9_GPU;

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -27,6 +27,8 @@
 
 // GL_NV_shader_framebuffer_fetch looks interesting....
 
+namespace DX9 {
+
 static bool IsAlphaTestTriviallyTrue() {
 	GEComparison alphaTestFunc = gstate.getAlphaTestFunction();
 	int alphaTestRef = gstate.getAlphaTestRef();
@@ -300,3 +302,5 @@ void GenerateFragmentShaderDX9(char *buffer) {
 	}
 	WRITE(p, "}\n");
 }
+
+};

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -19,6 +19,8 @@
 
 #include "Globals.h"
 
+namespace DX9 {
+
 struct FragmentShaderIDDX9
 {
 	FragmentShaderIDDX9() {d[0] = 0xFFFFFFFF;}
@@ -50,3 +52,5 @@ struct FragmentShaderIDDX9
 void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id);
 
 void GenerateFragmentShaderDX9(char *buffer);
+
+};

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -36,6 +36,8 @@
 // For matrices convertions
 #include <xnamath.h>
 
+namespace DX9 {
+
 PSShader::PSShader(const char *code, bool useHWTransform) : failed_(false), useHWTransform_(useHWTransform) {
 	source_ = code;
 #ifdef SHADERLOG
@@ -653,3 +655,5 @@ LinkedShaderDX9 *ShaderManagerDX9::ApplyShader(int prim) {
 	lastShader_ = ls;
 	return ls;
 }
+
+};

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -23,6 +23,8 @@
 #include "GPU/Directx9/VertexShaderGeneratorDX9.h"
 #include "GPU/Directx9/PixelShaderGeneratorDX9.h"
 
+namespace DX9 {
+
 class PSShader;
 class VSShader;
 
@@ -226,5 +228,7 @@ private:
 
 	typedef std::map<VertexShaderIDDX9, VSShader *> VSCache;
 	VSCache vsCache_;
+
+};
 
 };

--- a/GPU/Directx9/SplineDX9.cpp
+++ b/GPU/Directx9/SplineDX9.cpp
@@ -17,6 +17,9 @@
 
 #include "Core/MemMap.h"
 #include "GPU/Directx9/TransformPipelineDX9.h"
+#include "Gpu/Common/VertexDecoderCommon.h"
+
+namespace DX9 {
 
 // Just to get something on the screen, we'll just not subdivide correctly.
 void TransformDrawEngineDX9::DrawBezier(int ucount, int vcount) {
@@ -192,3 +195,5 @@ void TransformDrawEngineDX9::SubmitBezier(void* control_points, void* indices, i
 
 	Flush();
 }
+
+};

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -28,6 +28,8 @@
 #include "GPU/Directx9/TextureCacheDX9.h"
 #include "GPU/Directx9/FramebufferDX9.h"
 
+namespace DX9 {
+
 static const D3DBLEND aLookup[11] = {
 	D3DBLEND_DESTCOLOR,
 	D3DBLEND_INVDESTCOLOR,
@@ -367,3 +369,5 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 		dxstate.viewport.set(vpX0 + renderX, vpY0 + renderY, vpWidth, vpHeight, depthRangeMin, depthRangeMax);
 	}
 }
+
+};

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -30,6 +30,8 @@
 #include "math/math_util.h"
 #include "native/ext/cityhash/city.h"
 
+namespace DX9 {
+
 #define INVALID_TEX (LPDIRECT3DTEXTURE9)(-1)
 
 // If a texture hasn't been seen for this many frames, get rid of it.
@@ -164,7 +166,7 @@ void TextureCacheDX9::ClearNextFrame() {
 
 
 template <typename T>
-inline void AttachFramebufferValid(T &entry, VirtualFramebuffer *framebuffer) {
+inline void AttachFramebufferValid(T &entry, VirtualFramebufferDX9 *framebuffer) {
 	const bool hasInvalidFramebuffer = entry->framebuffer == 0 || entry->invalidHint == -1;
 	const bool hasOlderFramebuffer = entry->framebuffer != 0 && entry->framebuffer->last_frame_render < framebuffer->last_frame_render;
 	if (hasInvalidFramebuffer || hasOlderFramebuffer) {
@@ -174,14 +176,14 @@ inline void AttachFramebufferValid(T &entry, VirtualFramebuffer *framebuffer) {
 }
 
 template <typename T>
-inline void AttachFramebufferInvalid(T &entry, VirtualFramebuffer *framebuffer) {
+inline void AttachFramebufferInvalid(T &entry, VirtualFramebufferDX9 *framebuffer) {
 	if (entry->framebuffer == 0 || entry->framebuffer == framebuffer) {
 		entry->framebuffer = framebuffer;
 		entry->invalidHint = -1;
 	}
 }
 
-inline void TextureCacheDX9::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch) {
+inline void TextureCacheDX9::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer, bool exactMatch) {
 		// If they match exactly, it's non-CLUT and from the top left.
 	if (exactMatch) {
 		DEBUG_LOG(G3D, "Render to texture detected at %08x!", address);
@@ -220,13 +222,13 @@ inline void TextureCacheDX9::AttachFramebuffer(TexCacheEntry *entry, u32 address
 	}
 }
 
-inline void TextureCacheDX9::DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer) {
+inline void TextureCacheDX9::DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer) {
 	if (entry->framebuffer == framebuffer) {
 		entry->framebuffer = 0;
 	}
 }
 
-void TextureCacheDX9::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg) {
+void TextureCacheDX9::NotifyFramebuffer(u32 address, VirtualFramebufferDX9 *framebuffer, FramebufferNotification msg) {
 	// This is a rough heuristic, because sometimes our framebuffers are too tall.
 	static const u32 MAX_SUBAREA_Y_OFFSET = 32;
 
@@ -1759,3 +1761,5 @@ bool TextureCacheDX9::DecodeTexture(u8* output, GPUgstate state)
 	OutputDebugStringA("TextureCache::DecodeTexture : FixMe\r\n");
 	return true;
 }
+
+};

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -24,7 +24,9 @@
 #include "GPU/GPUState.h"
 #include "GPU/Directx9/TextureScalerDX9.h"
 
-struct VirtualFramebuffer;
+namespace DX9 {
+
+struct VirtualFramebufferDX9;
 
 enum TextureFiltering {
 	AUTO = 1,
@@ -56,7 +58,7 @@ public:
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory
 	// are being rendered to. This is barebones so far.
-	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg);
+	void NotifyFramebuffer(u32 address, VirtualFramebufferDX9 *framebuffer, FramebufferNotification msg);
 
 	size_t NumLoadedTextures() const {
 		return cache.size();
@@ -88,7 +90,7 @@ private:
 		int status;
 		u32 addr;
 		u32 hash;
-		VirtualFramebuffer *framebuffer;  // if null, not sourced from an FBO.
+		VirtualFramebufferDX9 *framebuffer;  // if null, not sourced from an FBO.
 		u32 sizeInRAM;
 		int lastFrame;
 		int numFrames;
@@ -125,8 +127,8 @@ private:
 	const T *GetCurrentClut();
 	u32 GetCurrentClutHash();
 	void UpdateCurrentClut();
-	void AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch);
-	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
+	void AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer, bool exactMatch);
+	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry);
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
@@ -134,7 +136,7 @@ private:
 	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
 	TexCache secondCache;
-	std::vector<VirtualFramebuffer *> fbCache_;
+	std::vector<VirtualFramebufferDX9 *> fbCache_;
 
 	bool clearCacheNextFrame_;
 	bool lowMemoryMode_;
@@ -161,3 +163,4 @@ private:
 	int decimationCounter_;
 };
 
+};

--- a/GPU/Directx9/TextureScalerDX9.cpp
+++ b/GPU/Directx9/TextureScalerDX9.cpp
@@ -28,6 +28,10 @@
 #include <stdlib.h>
 #include <math.h>
 
+#ifndef _XBOX
+#include <D3D9Types.h>
+#endif
+
 #undef min
 #undef max
 
@@ -523,6 +527,8 @@ namespace {
 
 /////////////////////////////////////// Texture Scaler
 
+namespace DX9 {
+
 TextureScalerDX9::TextureScalerDX9() {
 	initBicubicWeights();
 }
@@ -677,3 +683,5 @@ void TextureScalerDX9::ConvertTo8888(u32 format, u32* source, u32* &dest, int wi
 		ERROR_LOG(G3D, "iXBRZTexScaling: unsupported texture format");
 	}
 }
+
+};

--- a/GPU/Directx9/TextureScalerDX9.h
+++ b/GPU/Directx9/TextureScalerDX9.h
@@ -24,6 +24,8 @@
 
 #include <vector>
 
+namespace DX9 {
+
 
 class TextureScalerDX9 {
 public:
@@ -49,4 +51,6 @@ private:
 	// maximum is (100 MB total for a 512 by 512 texture with scaling factor 5 and hybrid scaling)
 	// of course, scaling factor 5 is totally silly anyway
 	SimpleBuf<u32> bufInput, bufDeposter, bufOutput, bufTmp1, bufTmp2, bufTmp3;
+};
+
 };

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -40,6 +40,8 @@
 #include "GPU/Directx9/ShaderManagerDX9.h"
 #include "GPU/Directx9/GPU_DX9.h"
 
+namespace DX9 {
+
 const D3DPRIMITIVETYPE glprim[8] = {
 	D3DPT_POINTLIST,
 	D3DPT_LINELIST,
@@ -128,6 +130,7 @@ void TransformDrawEngineDX9::DestroyDeviceObjects() {
 }
 
 namespace {
+using namespace DX9;
 
 // Convenient way to do precomputation to save the parts of the lighting calculation
 // that's common between the many vertices of a draw call.
@@ -1330,3 +1333,5 @@ rotateVBO:
 		numDrawCalls = 0;
 		prevPrim_ = GE_PRIM_INVALID;
 }
+
+};

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -23,12 +23,14 @@
 #include "GPU/Common/IndexGenerator.h"
 #include "GPU/Directx9/VertexDecoderDX9.h"
 
+struct DecVtxFormat;
+
+namespace DX9 {
+
 class LinkedShaderDX9;
 class ShaderManagerDX9;
 class TextureCacheDX9;
 class FramebufferManagerDX9;
-
-struct DecVtxFormat;
 
 // States transitions:
 // On creation: DRAWN_NEW
@@ -226,4 +228,6 @@ struct Color4 {
 	void GetFromA(u32 col) {
 		a = (col&0xff)/255.0f;
 	}
+};
+
 };

--- a/GPU/Directx9/VertexDecoderDX9.cpp
+++ b/GPU/Directx9/VertexDecoderDX9.cpp
@@ -24,6 +24,8 @@
 #include "GPU/Directx9/VertexDecoderDX9.h"
 #include "GPU/Directx9/VertexShaderGeneratorDX9.h"
 
+namespace DX9 {
+
 
 // Always use float for decoding data
 #define USE_WEIGHT_HACK
@@ -1002,3 +1004,5 @@ int VertexDecoderDX9::ToString(char *output) const {
 	output += sprintf(output, " (size: %i)", VertexSize());
 	return output - start;
 }
+
+};

--- a/GPU/Directx9/VertexDecoderDX9.h
+++ b/GPU/Directx9/VertexDecoderDX9.h
@@ -24,6 +24,8 @@
 
 #include "GPU/Common/VertexDecoderCommon.h"
 
+namespace DX9 {
+
 class VertexDecoderDX9;
 
 typedef void (VertexDecoderDX9::*StepFunction)() const;
@@ -150,3 +152,4 @@ public:
 	int stats_[NUM_VERTEX_DECODER_STATS];
 };
 
+};

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -33,6 +33,8 @@
 
 #define WRITE p+=sprintf
 
+namespace DX9 {
+
 bool CanUseHardwareTransformDX9(int prim) {
 	if (!g_Config.bHardwareTransform)
 		return false;
@@ -575,3 +577,5 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 	}
 	WRITE(p, "}\n");
 }
+
+};

--- a/GPU/Directx9/VertexShaderGeneratorDX9.h
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.h
@@ -19,6 +19,8 @@
 
 #include "Globals.h"
 
+namespace DX9 {
+
 // #define USE_BONE_ARRAY
 
 struct VertexShaderIDDX9
@@ -55,3 +57,5 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform);
 
 // Collapse to less skinning shaders to reduce shader switching, which is expensive.
 int TranslateNumBonesDX9(int bones);
+
+};

--- a/GPU/Directx9/helper/dx_state.cpp
+++ b/GPU/Directx9/helper/dx_state.cpp
@@ -1,6 +1,8 @@
 #include "dx_state.h"
 #include <assert.h>
 
+namespace DX9 {
+
 
 DirectxState dxstate;
 GLExtensions gl_extensions;
@@ -77,3 +79,5 @@ void DirectxState::SetVSyncInterval(int interval) {
 #endif
 	*/
 }
+
+};

--- a/GPU/Directx9/helper/dx_state.h
+++ b/GPU/Directx9/helper/dx_state.h
@@ -4,6 +4,8 @@
 #include <string.h>
 #include "global.h"
 
+namespace DX9 {
+
 // OpenGL state cache. Should convert all code to use this instead of directly calling glEnable etc,
 // as GL state changes can be expensive on some hardware.
 class DirectxState
@@ -297,3 +299,5 @@ struct GLExtensions {
 extern GLExtensions gl_extensions;
 
 void CheckGLExtensions();
+
+};

--- a/GPU/Directx9/helper/fbo.cpp
+++ b/GPU/Directx9/helper/fbo.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include "fbo.h"
 
+namespace DX9 {
+
 static LPDIRECT3DSURFACE9 currentRtt;
 static LPDIRECT3DSURFACE9 workingRtt;
 static LPDIRECT3DSURFACE9 deviceRTsurf;
@@ -158,3 +160,5 @@ void SwapBuffer() {
 	// :s
 	//pD3Ddevice->Clear(0, NULL, D3DCLEAR_STENCIL|D3DCLEAR_TARGET |D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0,0 ,0), 0, 0);
 }
+
+};

--- a/GPU/Directx9/helper/fbo.h
+++ b/GPU/Directx9/helper/fbo.h
@@ -4,6 +4,8 @@
 // Very C-ish API because that's what I felt like, and it's cool to completely
 // hide the data from callers...
 
+namespace DX9 {
+
 struct FBO;
 
 enum FBOColorDepth {
@@ -37,3 +39,5 @@ void * fbo_get_rtt(FBO *fbo);
 
 // To get default depth and rt surface
 void fbo_init();
+
+};

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -1,6 +1,8 @@
 #include "global.h"
 #include "fbo.h"
 
+namespace DX9 {
+
 LPDIRECT3DDEVICE9 pD3Ddevice = NULL;
 LPDIRECT3D9 pD3D = NULL;
 
@@ -247,3 +249,5 @@ void DirectxInit() {
 
 	fbo_init();
 }
+
+};

--- a/GPU/Directx9/helper/global.h
+++ b/GPU/Directx9/helper/global.h
@@ -1,13 +1,15 @@
 #pragma once
 
+#include "Common/CommonWindows.h"
 #ifdef _XBOX
-#include <xtl.h>
 // Used on XBox to create a linear format
 // TODO: Might actually want to use nonlinear on xbox?
 #define D3DFMT(x)	(D3DFORMAT)MAKELINFMT(x)
 #else
 #define D3DFMT(x) x
 #endif
+
+namespace DX9 {
 
 #include <d3d9.h>
 #include <d3dx9.h>
@@ -24,3 +26,5 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable);
 
 #define D3DBLEND_UNK	D3DSTENCILOP_FORCE_DWORD
+
+};

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -158,6 +158,9 @@
     <ClInclude Include="Common\IndexGenerator.h" />
     <ClInclude Include="Common\VertexDecoderCommon.h" />
     <ClInclude Include="Directx9\GPU_DX9.h" />
+    <ClInclude Include="Directx9\helper\dx_state.h" />
+    <ClInclude Include="Directx9\helper\fbo.h" />
+    <ClInclude Include="Directx9\helper\global.h" />
     <ClInclude Include="Directx9\PixelShaderGeneratorDX9.h" />
     <ClInclude Include="Directx9\FramebufferDX9.h" />
     <ClInclude Include="Directx9\ShaderManagerDX9.h" />
@@ -196,6 +199,19 @@
     <ClCompile Include="Common\IndexGenerator.cpp" />
     <ClCompile Include="Common\VertexDecoderCommon.cpp" />
     <ClCompile Include="Directx9\GPU_DX9.cpp" />
+    <ClCompile Include="Directx9\helper\dx_state.cpp" />
+    <ClCompile Include="Directx9\helper\fbo.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="Directx9\helper\global.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="Directx9\PixelShaderGeneratorDX9.cpp" />
     <ClCompile Include="Directx9\FramebufferDX9.cpp" />
     <ClCompile Include="Directx9\ShaderManagerDX9.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="DirectX9">
       <UniqueIdentifier>{88629970-4774-4122-b031-2128244b795c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="DirectX9\helper">
+      <UniqueIdentifier>{ba434472-5d5e-4b08-ab16-bfb7ec8e7068}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ge_constants.h">
@@ -126,6 +129,15 @@
     <ClInclude Include="..\ext\xbrz\xbrz.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="Directx9\helper\dx_state.h">
+      <Filter>DirectX9\helper</Filter>
+    </ClInclude>
+    <ClInclude Include="Directx9\helper\fbo.h">
+      <Filter>DirectX9\helper</Filter>
+    </ClInclude>
+    <ClInclude Include="Directx9\helper\global.h">
+      <Filter>DirectX9\helper</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -232,6 +244,15 @@
     </ClCompile>
     <ClCompile Include="..\ext\xbrz\xbrz.cpp">
       <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="Directx9\helper\dx_state.cpp">
+      <Filter>DirectX9\helper</Filter>
+    </ClCompile>
+    <ClCompile Include="Directx9\helper\fbo.cpp">
+      <Filter>DirectX9\helper</Filter>
+    </ClCompile>
+    <ClCompile Include="Directx9\helper\global.cpp">
+      <Filter>DirectX9\helper</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -23,8 +23,8 @@
 #endif
 #include "GPU/Null/NullGpu.h"
 #include "GPU/Software/SoftGpu.h"
-#ifdef USE_DIRECTX
-#include "Directx9/DisplayListInterpreter.h"
+#if defined(_XBOX)
+#include "GPU/Directx9/GPU_DX9.h"
 #endif
 #include "Core/CoreParameter.h"
 #include "Core/System.h"
@@ -39,22 +39,21 @@ bool GPU_Init() {
 	case GPU_NULL:
 		gpu = new NullGPU();
 		break;
-#ifndef _XBOX	
 	case GPU_GLES:
+#ifndef _XBOX
 		gpu = new GLES_GPU();
+#endif
 		break;
-#endif		
 	case GPU_SOFTWARE:
 #if !(defined(__SYMBIAN32__) || defined(_XBOX))
 		gpu = new SoftGPU();
 #endif
 		break;
-
-#ifdef USE_DIRECTX
 	case GPU_DIRECTX9:
+#if defined(_XBOX)
 		gpu = new DIRECTX9_GPU();
-		break;
 #endif
+		break;
 	}
 
 	return gpu != NULL;


### PR DESCRIPTION
This makes it almost build on Windows, but not quite.  Some required files excluded from build, still.

With this, there are only a few errors left, and they're mostly from GPU/Directx9/helper/fbo.cpp.  I couldn't find information on the types used... missing are D3DVECTOR4, pD3Ddevice->Resolve, d3dpp.FrontBufferFormat, D3DFMT_LE_A8R8G8B8, pD3Ddevice->SetRingBufferParameters, and D3DRING_BUFFER_PARAMETERS.

-[Unknown]
