### PR TITLE
Win32: Add command-line arguments to allow different ppsspp/control ini files.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -36,14 +36,16 @@ Config::~Config() { }
 
 void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 {
-	iniFilename_ = iniFileName;
-	controllerIniFilename_ = controllerIniFilename;
-	INFO_LOG(LOADER, "Loading config: %s", iniFileName);
+	iniFilename_ = iniFileName != NULL ? iniFileName : "ppsspp.ini";
+
+	controllerIniFilename_ = controllerIniFilename != NULL ? controllerIniFilename : "controls.ini";
+
+	INFO_LOG(LOADER, "Loading config: %s", iniFilename_);
 	bSaveSettings = true;
 
 	IniFile iniFile;
-	if (!iniFile.Load(iniFileName)) {
-		ERROR_LOG(LOADER, "Failed to read %s. Setting config to default.", iniFileName);
+	if (!iniFile.Load(iniFilename_)) {
+		ERROR_LOG(LOADER, "Failed to read %s. Setting config to default.", iniFilename_);
 		// Continue anyway to initialize the config.
 	}
 
@@ -229,12 +231,12 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	IniFile::Section *gleshacks = iniFile.GetOrCreateSection("GLESHacks");
 	gleshacks->Get("PrescaleUV", &bPrescaleUV, false);
 
-	INFO_LOG(LOADER, "Loading controller config: %s", controllerIniFilename);
+	INFO_LOG(LOADER, "Loading controller config: %s", controllerIniFilename_);
 	bSaveSettings = true;
 
 	IniFile controllerIniFile;
-	if (!controllerIniFile.Load(controllerIniFilename)) {
-		ERROR_LOG(LOADER, "Failed to read %s. Setting controller config to default.", controllerIniFilename);
+	if (!controllerIniFile.Load(controllerIniFilename_)) {
+		ERROR_LOG(LOADER, "Failed to read %s. Setting controller config to default.", controllerIniFilename_);
 		KeyMap::RestoreDefault();
 	} else {
 		// Continue anyway to initialize the config. It will just restore the defaults.

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -106,9 +106,36 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		langRegion = "en_US";
 	}
 
+	std::string configFilename;
+	const char *configOption = "--config=";
+
+	std::string controlsConfigFilename;
+	const char *controlsOption = "--controlconfig=";
+
+	for (int i = 1; i < __argc; ++i)
+	{
+		if (__argv[i][0] == '\0')
+			continue;
+		if (__argv[i][0] == '-')
+		{
+			if (!strncmp(__argv[i], controlsOption, strlen(controlsOption)) && strlen(__argv[i]) > strlen(controlsOption)) {
+				configFilename = __argv[i] + strlen(controlsOption);
+			}
+			if (!strncmp(__argv[i], controlsOption, strlen(controlsOption)) && strlen(__argv[i]) > strlen(controlsOption)) {
+				controlsConfigFilename = __argv[i] + strlen(controlsOption);
+			}
+		}
+	}
+
+	if(configFilename.empty())
+		configFilename = "ppsspp.ini";
+
+	if(controlsConfigFilename.empty())
+		controlsConfigFilename = "controls.ini";
+
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.Load();
+	g_Config.Load(configFilename, controlsConfigFilename);
 
 	// The rest is handled in NativeInit().
 	for (int i = 1; i < __argc; ++i)

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -118,8 +118,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			continue;
 		if (__argv[i][0] == '-')
 		{
-			if (!strncmp(__argv[i], controlsOption, strlen(controlsOption)) && strlen(__argv[i]) > strlen(controlsOption)) {
-				configFilename = __argv[i] + strlen(controlsOption);
+			if (!strncmp(__argv[i], configOption, strlen(configOption)) && strlen(__argv[i]) > strlen(configOption)) {
+				configFilename = __argv[i] + strlen(configOption);
 			}
 			if (!strncmp(__argv[i], controlsOption, strlen(controlsOption)) && strlen(__argv[i]) > strlen(controlsOption)) {
 				controlsConfigFilename = __argv[i] + strlen(controlsOption);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -135,7 +135,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.Load(configFilename, controlsConfigFilename);
+	g_Config.Load(configFilename.c_str(), controlsConfigFilename.c_str());
 
 	// The rest is handled in NativeInit().
 	for (int i = 1; i < __argc; ++i)


### PR DESCRIPTION
Can be used as a really primitive per-game settings system, if one takes the time to make shortcuts/bat files for their games, or if testing something.

Also fixes a possible crash when passing null values to Config::Load.
