### PR TITLE
Swap order of ifdefs so Android's Atrac3+ works again.

### DIFF
--- a/Core/HW/atrac3plus.cpp
+++ b/Core/HW/atrac3plus.cpp
@@ -49,10 +49,10 @@ namespace Atrac3plus_Decoder {
 	ATRAC3PLUS_CLOSECONTEXT close_context = 0;
 
 	std::string GetInstalledFilename() {
-#if defined(__linux__)
+#if defined(ANDROID) && defined(ARM)
+		return g_Config.internalDataDirectory + "libat3plusdecoder.so";	
+#elif defined(__linux__)
 		return "/usr/lib/libat3plusdecoder.so";
-#elif defined(ANDROID) && defined(ARM)
-		return g_Config.internalDataDirectory + "libat3plusdecoder.so";
 #elif defined(_WIN32)
 #ifdef _M_X64
 		return "at3plusdecoder64.dll";


### PR DESCRIPTION
Was caused by https://github.com/hrydgard/ppsspp/commit/1124ef91eafeb3ec63b01e39ccbdc8efa1572369. Fixes https://github.com/hrydgard/ppsspp/issues/3789.

Android also defines __ linux __ it seems. Thanks @unknownbrackets.
