### PR TITLE
Win32: Create Dump Memory menu item

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -381,7 +381,7 @@ namespace MainWindow
 		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_ABOUT, aboutPPSSPP.c_str());
 	}
 
-	void CreateDumpMenu() {
+/*	void CreateDumpMenu() {
 		static bool dumpMenuCreated = false;
 
 		if (dumpMenuCreated) {
@@ -408,7 +408,7 @@ namespace MainWindow
 		AppendMenu(debugMenu, MF_STRING | MF_BYPOSITION, ID_DEBUG_DUMPMEMORY, dumpMenuKey.c_str());
 
 		dumpMenuCreated = true;
-	}
+	}*/
 
 	void CreateLanguageMenu() {
 		// Please don't remove this boolean. 
@@ -1548,7 +1548,7 @@ namespace MainWindow
 
 		case WM_USER_UPDATE_UI:
 			CreateLanguageMenu();
-			CreateDumpMenu();
+			//CreateDumpMenu();
 			TranslateMenus();
 			Update();
 			break;

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -343,6 +343,8 @@ BEGIN
         MENUITEM "Disassembly",                             ID_DEBUG_DISASSEMBLY
         MENUITEM "Log Console",	                            ID_DEBUG_LOG
         MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
+        MENUITEM SEPARATOR
+        MENUITEM "Dump Memory",                          ID_DEBUG_DUMPMEMORY
     END
 
     POPUP "Options"

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -147,6 +147,7 @@
 // It's reserved for languages.
 #define ID_LANGUAGE_BASE 3000
 
+
 #define ID_FILE_EXIT                     40000
 #define ID_DEBUG_SAVEMAPFILE             40001
 #define ID_DISASM_ADDHLE                 40002
@@ -252,6 +253,7 @@
 #define ID_OPTIONS_WINDOW5X              40108
 #define ID_OPTIONS_BUFFEREDRENDERING     40109
 #define ID_DEBUG_SHOWDEBUGSTATISTICS     40110
+#define ID_DEBUG_DUMPMEMORY              40111
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
To dump game's memory into file for special use (such as finding cwcheat code on windows)
Simplify the sequence of operations "F8 Pause->MemView Diag->right mouse button->dump...->F8 Run"
