### PR TITLE
Round texture bufw down to nearest 16 byte multiple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,6 +1002,8 @@ add_library(GPU OBJECT
 	GPU/Common/VertexDecoderCommon.h
 	GPU/Common/IndexGenerator.cpp
 	GPU/Common/IndexGenerator.h
+	GPU/Common/TextureDecoder.cpp
+	GPU/Common/TextureDecoder.h
 	GPU/GLES/GLES_GPU.cpp
 	GPU/GLES/GLES_GPU.h
 	GPU/GLES/FragmentShaderGenerator.cpp

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "GPU/Common/TextureDecoder.h"
+
+// TODO: Move some common things into here.

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/MemMap.h"
+#include "GPU/ge_constants.h"
+#include "GPU/GPUState.h"
+
+static const u8 textureBitsPerPixel[16] = {
+	16,  //GE_TFMT_5650,
+	16,  //GE_TFMT_5551,
+	16,  //GE_TFMT_4444,
+	32,  //GE_TFMT_8888,
+	4,   //GE_TFMT_CLUT4,
+	8,   //GE_TFMT_CLUT8,
+	16,  //GE_TFMT_CLUT16,
+	32,  //GE_TFMT_CLUT32,
+	4,   //GE_TFMT_DXT1,
+	8,   //GE_TFMT_DXT3,
+	8,   //GE_TFMT_DXT5,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+};
+
+// Masks to downalign bufw to 16 bytes, and wrap at 2048.
+static const u32 textureAlignMask16[16] = {
+	0x7FF & ~(((8 * 16) / 16) - 1),  //GE_TFMT_5650,
+	0x7FF & ~(((8 * 16) / 16) - 1),  //GE_TFMT_5551,
+	0x7FF & ~(((8 * 16) / 16) - 1),  //GE_TFMT_4444,
+	0x7FF & ~(((8 * 16) / 32) - 1),  //GE_TFMT_8888,
+	0x7FF & ~(((8 * 16) / 4) - 1),   //GE_TFMT_CLUT4,
+	0x7FF & ~(((8 * 16) / 8) - 1),   //GE_TFMT_CLUT8,
+	0x7FF & ~(((8 * 16) / 16) - 1),  //GE_TFMT_CLUT16,
+	0x7FF & ~(((8 * 16) / 32) - 1),  //GE_TFMT_CLUT32,
+	0x7FF & ~(((8 * 16) / 4) - 1),   //GE_TFMT_DXT1,
+	0x7FF & ~(((8 * 16) / 8) - 1),   //GE_TFMT_DXT3,
+	0x7FF & ~(((8 * 16) / 8) - 1),   //GE_TFMT_DXT5,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+};
+
+static inline u32 GetTextureBufw(int level, u32 texaddr, GETextureFormat format) {
+	// This is a hack to allow for us to draw the huge PPGe texture, which is always in kernel ram.
+	if (texaddr < PSP_GetUserMemoryBase())
+		return gstate.texbufwidth[level] & 0x1FFF;
+
+	u32 bufw = gstate.texbufwidth[level] & textureAlignMask16[format];
+	if (bufw == 0) {
+		// If it's less than 16 bytes, use 16 bytes.
+		bufw = (8 * 16) / textureBitsPerPixel[format];
+	}
+	return bufw;
+}

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -1027,7 +1027,7 @@ void TextureCacheDX9::SetTexture() {
 	}
 #endif
 
-	u32 texaddr = (gstate.texaddr[0] & 0xFFFFF0) | ((gstate.texbufwidth[0]<<8) & 0x0F000000);
+	u32 texaddr = gstate.getTextureAddress(0);
 	if (!Memory::IsValidAddress(texaddr)) {
 		// Bind a null texture and return.
 		pD3Ddevice->SetTexture(0, NULL);
@@ -1249,7 +1249,7 @@ void TextureCacheDX9::SetTexture() {
 	// Adjust maxLevel to actually present levels..
 	for (int i = 0; i <= maxLevel; i++) {
 		// If encountering levels pointing to nothing, adjust max level.
-		u32 levelTexaddr = (gstate.texaddr[i] & 0xFFFFF0) | ((gstate.texbufwidth[i] << 8) & 0x0F000000);
+		u32 levelTexaddr = gstate.getTextureAddress(i);
 		if (!Memory::IsValidAddress(levelTexaddr)) {
 			maxLevel = i - 1;
 			break;
@@ -1273,7 +1273,7 @@ void TextureCacheDX9::SetTexture() {
 void *TextureCacheDX9::DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, u32 &dstFmt) {
 	void *finalBuf = NULL;
 
-	u32 texaddr = (gstate.texaddr[level] & 0xFFFFF0) | ((gstate.texbufwidth[level] << 8) & 0x0F000000);
+	u32 texaddr = gstate.getTextureAddress(level);
 
 	int bufw = GetTextureBufw(level, texaddr, format);
 

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -118,7 +118,7 @@ private:
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
 	void *UnswizzleFromMem(u32 texaddr, u32 bufw, u32 bytesPerPixel, u32 level);
-	void *readIndexedTex(int level, u32 texaddr, int bytesPerIndex, u32 dstFmt);
+	void *ReadIndexedTex(int level, u32 texaddr, int bytesPerIndex, u32 dstFmt, int bufw);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages);
 	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, u32 &dstFmt);

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -982,7 +982,7 @@ void TextureCache::SetTexture() {
 	}
 #endif
 
-	u32 texaddr = (gstate.texaddr[0] & 0xFFFFF0) | ((gstate.texbufwidth[0]<<8) & 0x0F000000);
+	u32 texaddr = gstate.getTextureAddress(0);
 	if (!Memory::IsValidAddress(texaddr)) {
 		// Bind a null texture and return.
 		glBindTexture(GL_TEXTURE_2D, 0);
@@ -1210,7 +1210,7 @@ void TextureCache::SetTexture() {
 	// Adjust maxLevel to actually present levels..
 	for (int i = 0; i <= maxLevel; i++) {
 		// If encountering levels pointing to nothing, adjust max level.
-		u32 levelTexaddr = (gstate.texaddr[i] & 0xFFFFF0) | ((gstate.texbufwidth[i] << 8) & 0x0F000000);
+		u32 levelTexaddr = gstate.getTextureAddress(i);
 		if (!Memory::IsValidAddress(levelTexaddr)) {
 			maxLevel = i - 1;
 			break;
@@ -1261,7 +1261,7 @@ void TextureCache::SetTexture() {
 void *TextureCache::DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, GLenum &dstFmt) {
 	void *finalBuf = NULL;
 
-	u32 texaddr = (gstate.texaddr[level] & 0xFFFFF0) | ((gstate.texbufwidth[level] << 8) & 0x0F000000);
+	u32 texaddr = gstate.getTextureAddress(level);
 
 	int bufw = GetTextureBufw(level, texaddr, format);
 	int w = gstate.getTextureWidth(level);
@@ -1615,7 +1615,7 @@ bool TextureCache::DecodeTexture(u8* output, GPUgstate state)
 	GPUgstate oldState = gstate;
 	gstate = state;
 
-	u32 texaddr = (gstate.texaddr[0] & 0xFFFFF0) | ((gstate.texbufwidth[0]<<8) & 0x0F000000);
+	u32 texaddr = gstate.getTextureAddress(0);
 
 	if (!Memory::IsValidAddress(texaddr)) {
 		return false;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -115,7 +115,7 @@ private:
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
 	void *UnswizzleFromMem(u32 texaddr, u32 bufw, u32 bytesPerPixel, u32 level);
-	void *readIndexedTex(int level, u32 texaddr, int bytesPerIndex, GLuint dstFmt);
+	void *ReadIndexedTex(int level, u32 texaddr, int bytesPerIndex, GLuint dstFmt, int bufw);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages);
 	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, GLenum &dstFmt);

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -193,6 +193,7 @@
     <ClInclude Include="Software\Rasterizer.h" />
     <ClInclude Include="Software\SoftGpu.h" />
     <ClInclude Include="Software\TransformUnit.h" />
+    <ClInclude Include="Common\TextureDecoder.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ext\xbrz\xbrz.cpp" />
@@ -243,6 +244,7 @@
     <ClCompile Include="Software\Rasterizer.cpp" />
     <ClCompile Include="Software\SoftGpu.cpp" />
     <ClCompile Include="Software\TransformUnit.cpp" />
+    <ClCompile Include="Common\TextureDecoder.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.vcxproj">

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="Directx9\helper\global.h">
       <Filter>DirectX9\helper</Filter>
     </ClInclude>
+    <ClInclude Include="Common\TextureDecoder.h">
+      <Filter>Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -253,6 +256,9 @@
     </ClCompile>
     <ClCompile Include="Directx9\helper\global.cpp">
       <Filter>DirectX9\helper</Filter>
+    </ClCompile>
+    <ClCompile Include="Common\TextureDecoder.cpp">
+      <Filter>Common</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -276,6 +276,8 @@ struct GPUgstate
 	u32 getColorTestMask() const { return colormask & 0xFFFFFF; }
 
 	// Texturing
+	// TODO: Verify getTextureAddress() alignment?
+	u32 getTextureAddress(int level) const { return (texaddr[level] & 0xFFFFF0) | ((texbufwidth[level] << 8) & 0x0F000000); }
 	int getTextureWidth(int level) const { return 1 << (texsize[level] & 0xf);}
 	int getTextureHeight(int level) const { return 1 << ((texsize[level] >> 8) & 0xf);}
 	u16 getTextureDimension(int level) const { return  texsize[level] & 0xf0f;}

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -166,54 +166,50 @@ static inline void GetTextureCoordinates(const VertexData& v0, const VertexData&
 	}	
 }
 
-static inline u32 SampleNearest(int level, unsigned int u, unsigned int v)
+static inline u32 SampleNearest(int level, unsigned int u, unsigned int v, u8 *srcptr, int texbufwidthbits)
 {
 	GETextureFormat texfmt = gstate.getTextureFormat();
-	u32 texaddr = (gstate.texaddr[level] & 0xFFFFF0) | ((gstate.texbufwidth[level] << 8) & 0x0F000000);
-	u8* srcptr = (u8*)Memory::GetPointer(texaddr); // TODO: not sure if this is the right place to load from...?
-
-	int texbufwidth = GetTextureBufw(level, texaddr, texfmt);
 
 	// TODO: Should probably check if textures are aligned properly...
 
 	switch (texfmt) {
 	case GE_TFMT_4444:
-		srcptr += GetPixelDataOffset(16, texbufwidth*8, u, v);
+		srcptr += GetPixelDataOffset(16, texbufwidthbits, u, v);
 		return DecodeRGBA4444(*(u16*)srcptr);
 	
 	case GE_TFMT_5551:
-		srcptr += GetPixelDataOffset(16, texbufwidth*8, u, v);
+		srcptr += GetPixelDataOffset(16, texbufwidthbits, u, v);
 		return DecodeRGBA5551(*(u16*)srcptr);
 
 	case GE_TFMT_5650:
-		srcptr += GetPixelDataOffset(16, texbufwidth*8, u, v);
+		srcptr += GetPixelDataOffset(16, texbufwidthbits, u, v);
 		return DecodeRGB565(*(u16*)srcptr);
 
 	case GE_TFMT_8888:
-		srcptr += GetPixelDataOffset(32, texbufwidth*8, u, v);
+		srcptr += GetPixelDataOffset(32, texbufwidthbits, u, v);
 		return DecodeRGBA8888(*(u32*)srcptr);
 
 	case GE_TFMT_CLUT32:
 		{
-			srcptr += GetPixelDataOffset(32, texbufwidth*8, u, v);
+			srcptr += GetPixelDataOffset(32, texbufwidthbits, u, v);
 			u32 val = srcptr[0] + (srcptr[1] << 8) + (srcptr[2] << 16) + (srcptr[3] << 24);
 			return LookupColor(gstate.transformClutIndex(val), level);
 		}
 	case GE_TFMT_CLUT16:
 		{
-			srcptr += GetPixelDataOffset(16, texbufwidth*8, u, v);
+			srcptr += GetPixelDataOffset(16, texbufwidthbits, u, v);
 			u16 val = srcptr[0] + (srcptr[1] << 8);
 			return LookupColor(gstate.transformClutIndex(val), level);
 		}
 	case GE_TFMT_CLUT8:
 		{
-			srcptr += GetPixelDataOffset(8, texbufwidth*8, u, v);
+			srcptr += GetPixelDataOffset(8, texbufwidthbits, u, v);
 			u8 val = *srcptr;
 			return LookupColor(gstate.transformClutIndex(val), level);
 		}
 	case GE_TFMT_CLUT4:
 		{
-			srcptr += GetPixelDataOffset(4, texbufwidth*8, u, v);
+			srcptr += GetPixelDataOffset(4, texbufwidthbits, u, v);
 			u8 val = (u & 1) ? (srcptr[0] >> 4) : (srcptr[0] & 0xF);
 			return LookupColor(gstate.transformClutIndex(val), level);
 		}
@@ -750,6 +746,17 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 	int bias1 = IsRightSideOrFlatBottomLine(v1.screenpos.xy(), v2.screenpos.xy(), v0.screenpos.xy()) ? -1 : 0;
 	int bias2 = IsRightSideOrFlatBottomLine(v2.screenpos.xy(), v0.screenpos.xy(), v1.screenpos.xy()) ? -1 : 0;
 
+	int texlevel = 0;
+	int texbufwidthbits = 0;
+	u8 *texptr = NULL;
+	if (gstate.isTextureMapEnabled() && !gstate.isModeClear()) {
+		// TODO: Always using level 0.
+		GETextureFormat texfmt = gstate.getTextureFormat();
+		u32 texaddr = gstate.getTextureAddress(texlevel);
+		texbufwidthbits = GetTextureBufw(texlevel, texaddr, texfmt) * 8;
+		texptr = Memory::GetPointer(texaddr);
+	}
+
 	ScreenCoords pprime(minX, minY, 0);
 	int w0_base = orient2d(v1.screenpos, v2.screenpos, pprime);
 	int w1_base = orient2d(v2.screenpos, v0.screenpos, pprime);
@@ -806,7 +813,7 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 						GetTexelCoordinates(0, s, t, u, v);
 					}
 
-					Vec4<int> texcolor = Vec4<int>::FromRGBA(SampleNearest(0, u, v));
+					Vec4<int> texcolor = Vec4<int>::FromRGBA(SampleNearest(texlevel, u, v, texptr, texbufwidthbits));
 					Vec4<int> out = GetTextureFunctionOutput(prim_color_rgb, prim_color_a, texcolor);
 					prim_color_rgb = out.rgb();
 					prim_color_a = out.a();

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -19,6 +19,7 @@
 #include "Core/Reporting.h"
 #include "GPU/GPUState.h"
 
+#include "GPU/Common/TextureDecoder.h"
 #include "GPU/Software/SoftGpu.h"
 #include "GPU/Software/Rasterizer.h"
 #include "GPU/Software/Colors.h"
@@ -171,8 +172,7 @@ static inline u32 SampleNearest(int level, unsigned int u, unsigned int v)
 	u32 texaddr = (gstate.texaddr[level] & 0xFFFFF0) | ((gstate.texbufwidth[level] << 8) & 0x0F000000);
 	u8* srcptr = (u8*)Memory::GetPointer(texaddr); // TODO: not sure if this is the right place to load from...?
 
-	// Special rules for kernel textures (PPGe), TODO: Verify!
-	int texbufwidth = (texaddr < PSP_GetUserMemoryBase()) ? gstate.texbufwidth[level] & 0x1FFF : gstate.texbufwidth[level] & 0x7FF;
+	int texbufwidth = GetTextureBufw(level, texaddr, texfmt);
 
 	// TODO: Should probably check if textures are aligned properly...
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -194,6 +194,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/GPU/GeDisasm.cpp \
   $(SRC)/GPU/Common/IndexGenerator.cpp.arm \
   $(SRC)/GPU/Common/VertexDecoderCommon.cpp.arm \
+  $(SRC)/GPU/Common/TextureDecoder.cpp \
   $(SRC)/GPU/GLES/Framebuffer.cpp \
   $(SRC)/GPU/GLES/GLES_GPU.cpp.arm \
   $(SRC)/GPU/GLES/TextureCache.cpp.arm \


### PR DESCRIPTION
This is the correct functionality, and what I think JPCSP in fact does (where I first got this idea from, so my bad.)  This also corrects indexed textures, which weren't respecting the previous code properly.

Values of 1, 3, 4, and 7 are identical for a 32-bit texture, clut or otherwise.  It's the same for every type.

@daniel229 let me know if this causes problems for Super Robot Taisen OE.

See also #3239 / #3263.

-[Unknown]
