### PR TITLE
Better replacement mode for GE_BLENDMODE_ABSDIFF 

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -64,11 +64,12 @@ static const GLushort eqLookup[] = {
 #if defined(USING_GLES2)
 	GL_FUNC_ADD,
 	GL_FUNC_ADD,
+	GL_FUNC_ADD, // this is GE_BLENDMODE_ABSDIFF
 #else
 	GL_MIN,
 	GL_MAX,
+	GL_MAX, // this is GE_BLENDMODE_ABSDIFF
 #endif
-	GL_FUNC_ADD, // should be abs(diff)
 };
 
 static const GLushort cullingMode[] = {


### PR DESCRIPTION
This used as an intermediate solution to workaround the unsupported absdiff blending mode anyway .

This should get rid of those black box in SRW Z2 though only work on desktop OpenGL 

https://github.com/hrydgard/ppsspp/issues/1982
