### PR TITLE
Implement --compare in headless

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -24,6 +24,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/Reporting.h"
 #include "Core/Config.h"
+#include "Core/HW/MediaEngine.h"
 #include "Common/ChunkFile.h"
 
 #include "sceKernel.h"
@@ -1089,6 +1090,8 @@ int __AtracSetContext(Atrac *atrac)
 	}
 
 #ifdef USE_FFMPEG
+	InitFFmpeg();
+
 	u8* tempbuf = (u8*)av_malloc(atrac->atracBufSize);
 
 	atrac->pFormatCtx = avformat_alloc_context();

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -20,7 +20,7 @@
 #include "Core/HLE/sceMp3.h"
 #include "Core/HW/MediaEngine.h"
 #include "Core/Reporting.h"
-#include "../HW/MediaEngine.h"
+#include "Core/HW/MediaEngine.h"
 
 #ifdef USE_FFMPEG
 #ifndef PRId64
@@ -337,6 +337,8 @@ int sceMp3Init(u32 mp3) {
 	ctx->mp3Version = ((header >> 19) & 0x3);
 
 #ifdef USE_FFMPEG
+	InitFFmpeg();
+
 	u8* avio_buffer = static_cast<u8*>(av_malloc(ctx->mp3BufSize));
 	ctx->avio_context = avio_alloc_context(avio_buffer, ctx->mp3BufSize, 0, ctx, readFunc, NULL, NULL);
 	ctx->avformat_context = avformat_alloc_context();

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -192,21 +192,22 @@ int _MpegReadbuffer(void *opaque, uint8_t *buf, int buf_size)
 	return size;
 }
 
-#ifdef _DEBUG
 void ffmpeg_logger(void *, int, const char *format, va_list va_args) {
 	char tmp[1024];
 	vsprintf(tmp, format, va_args);
 	INFO_LOG(ME, "%s", tmp);
 }
-#endif
 
 bool MediaEngine::openContext() {
 #ifdef USE_FFMPEG
 
 #ifdef _DEBUG
 	av_log_set_level(AV_LOG_VERBOSE);
-	av_log_set_callback(&ffmpeg_logger);
+#else
+	av_log_set_level(AV_LOG_ERROR);
 #endif 
+	av_log_set_callback(&ffmpeg_logger);
+
 	if (m_pFormatCtx || !m_pdata)
 		return false;
 	m_mpegheaderReadPos = 0;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -83,6 +83,23 @@ static int getPixelFormatBytes(int pspFormat)
 	}
 }
 
+void ffmpeg_logger(void *, int, const char *format, va_list va_args) {
+	char tmp[1024];
+	vsprintf(tmp, format, va_args);
+	INFO_LOG(ME, "%s", tmp);
+}
+
+bool InitFFmpeg() {
+#ifdef _DEBUG
+	av_log_set_level(AV_LOG_VERBOSE);
+#else
+	av_log_set_level(AV_LOG_ERROR);
+#endif
+	av_log_set_callback(&ffmpeg_logger);
+
+	return true;
+}
+
 MediaEngine::MediaEngine(): m_pdata(0) {
 	m_pFormatCtx = 0;
 	m_pCodecCtx = 0;
@@ -192,21 +209,9 @@ int _MpegReadbuffer(void *opaque, uint8_t *buf, int buf_size)
 	return size;
 }
 
-void ffmpeg_logger(void *, int, const char *format, va_list va_args) {
-	char tmp[1024];
-	vsprintf(tmp, format, va_args);
-	INFO_LOG(ME, "%s", tmp);
-}
-
 bool MediaEngine::openContext() {
 #ifdef USE_FFMPEG
-
-#ifdef _DEBUG
-	av_log_set_level(AV_LOG_VERBOSE);
-#else
-	av_log_set_level(AV_LOG_ERROR);
-#endif 
-	av_log_set_callback(&ffmpeg_logger);
+	InitFFmpeg();
 
 	if (m_pFormatCtx || !m_pdata)
 		return false;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -41,6 +41,8 @@ inline s64 getMpegTimeStamp(u8* buf) {
 		| ((s64)buf[1] << 32) | ((s64)buf[0] << 36);
 }
 
+bool InitFFmpeg();
+
 class MediaEngine
 {
 public:

--- a/headless/Compare.h
+++ b/headless/Compare.h
@@ -19,5 +19,9 @@
 
 #include "Globals.h"
 
-bool CompareOutput(std::string bootFilename);
+extern bool teamCityMode;
+extern std::string teamCityName;
+void TeamCityPrint(const char *fmt, ...);
+
+bool CompareOutput(const std::string &bootFilename, const std::string &output);
 double CompareScreenshot(const u8 *pixels, int w, int h, int stride, const std::string screenshotFilename, std::string &error);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -276,6 +276,7 @@ int main(int argc, const char* argv[])
 	host->ShutdownGL();
 	PSP_Shutdown();
 
+	headlessHost->FlushDebugOutput();
 	delete host;
 	host = NULL;
 	headlessHost = NULL;

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -46,11 +46,29 @@ public:
 	virtual bool IsDebuggingEnabled() {return false;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
 
-	virtual void SendDebugOutput(const std::string &output) { fwrite(output.data(), sizeof(char), output.length(), stdout); }
+	virtual void SendDebugOutput(const std::string &output) {
+		if (output.find('\n') != output.npos) {
+			DoFlushDebugOutput();
+			fwrite(output.data(), sizeof(char), output.length(), stdout);
+		} else {
+			debugOutputBuffer_ += output;
+		}
+	}
+	virtual void FlushDebugOutput() {
+		DoFlushDebugOutput();
+	}
+	inline void DoFlushDebugOutput() {
+		if (!debugOutputBuffer_.empty()) {
+			fwrite(debugOutputBuffer_.data(), sizeof(char), debugOutputBuffer_.length(), stdout);
+			debugOutputBuffer_.clear();
+		}
+	}
 	virtual void SetComparisonScreenshot(const std::string &filename) {}
 
 
 	// Unique for HeadlessHost
 	virtual void SwapBuffers() {}
 
+protected:
+	std::string debugOutputBuffer_;
 };

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -40,6 +40,7 @@ public:
 private:
 	bool ResizeGL();
 	void LoadNativeAssets();
+	void SendOrCollectDebugOutput(const std::string &output);
 
 	HWND hWnd;
 	HDC hDC;

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -44,6 +44,5 @@ private:
 	HWND hWnd;
 	HDC hDC;
 	HGLRC hRC;
-	FILE *out;
 	std::string comparisonScreenshot;
 };


### PR DESCRIPTION
Notes:
- Not used yet by test.py.
- This compare is very slightly smarter, and detects simple 1 inserted/omitted line drift.
- The intention is for this to be faster (takes 16 seconds currently to run all tests for me.)
- Kills some ffmpeg stdout/stderr logging in release, redirects to console.
- Supports timeouts but won't detect hangs.
- Should support the teamcity output just fine.
- Might add support for running multiple tests in a row for even better perf, not yet supported.

-[Unknown]
