### PR TITLE
Just save XMM0-XMM15 on x64 + more headless

### DIFF
--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -52,7 +52,7 @@ struct BufferedLineReader {
 	}
 
 	void Fill() {
-		while (valid_ < MAX_BUFFER && HasLines()) {
+		while (valid_ < MAX_BUFFER && HasMoreLines()) {
 			buffer_[valid_++] = ReadLine();
 		}
 	}
@@ -84,8 +84,17 @@ struct BufferedLineReader {
 		return result;
 	}
 
-	virtual bool HasLines() {
-		return pos_ != data_.npos;
+	bool HasLines() {
+		if (HasMoreLines()) {
+			return true;
+		}
+		// Don't say yes if it's a blank line.
+		for (int i = 0; i < valid_; ++i) {
+			if (!buffer_[i].empty()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	bool Compare(BufferedLineReader &other) {
@@ -100,6 +109,10 @@ struct BufferedLineReader {
 
 protected:
 	BufferedLineReader() : valid_(0) {
+	}
+
+	virtual bool HasMoreLines() {
+		return pos_ != data_.npos;
 	}
 
 	virtual std::string ReadLine() {
@@ -125,11 +138,11 @@ struct BufferedLineReaderFile : public BufferedLineReader {
 	BufferedLineReaderFile(std::ifstream &in) : BufferedLineReader(), in_(in) {
 	}
 
-	virtual bool HasLines() {
+protected:
+	virtual bool HasMoreLines() {
 		return !in_.eof();
 	}
 
-protected:
 	virtual std::string ReadLine() {
 		char temp[TEMP_BUFFER_SIZE];
 		in_.getline(temp, TEMP_BUFFER_SIZE);
@@ -164,10 +177,10 @@ bool CompareOutput(const std::string &bootFilename, const std::string &output)
 			// This is a really dirt simple comparing algorithm.
 
 			// Perhaps it was an extra line?
-			if (expected.Peek(0) == actual.Peek(1))
+			if (expected.Peek(0) == actual.Peek(1) || !expected.HasLines())
 				printf("+ %s\n", actual.Consume().c_str());
 			// A single missing line?
-			else if (expected.Peek(1) == actual.Peek(0))
+			else if (expected.Peek(1) == actual.Peek(0) || !actual.HasLines())
 				printf("- %s\n", expected.Consume().c_str());
 			else
 			{
@@ -185,7 +198,7 @@ bool CompareOutput(const std::string &bootFilename, const std::string &output)
 			printf("+ %s\n", actual.Consume().c_str());
 		}
 
-		return failed;
+		return !failed;
 	}
 	else
 	{

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -152,9 +152,19 @@ protected:
 	std::ifstream &in_;
 };
 
+std::string ExpectedFromFilename(const std::string &bootFilename)
+{
+	return bootFilename.substr(0, bootFilename.length() - 4) + ".expected";
+}
+
+std::string ExpectedScreenshotFromFilename(const std::string &bootFilename)
+{
+	return bootFilename.substr(0, bootFilename.length() - 4) + ".expected.bmp";
+}
+
 bool CompareOutput(const std::string &bootFilename, const std::string &output)
 {
-	std::string expect_filename = bootFilename.substr(0, bootFilename.length() - 4) + ".expected";
+	std::string expect_filename = ExpectedFromFilename(bootFilename);
 	std::ifstream in;
 	in.open(expect_filename.c_str(), std::ios::in);
 	if (!in.fail())

--- a/headless/Compare.h
+++ b/headless/Compare.h
@@ -23,5 +23,8 @@ extern bool teamCityMode;
 extern std::string teamCityName;
 void TeamCityPrint(const char *fmt, ...);
 
+std::string ExpectedFromFilename(const std::string &bootFilename);
+std::string ExpectedScreenshotFromFilename(const std::string &bootFilename);
+
 bool CompareOutput(const std::string &bootFilename, const std::string &output);
 double CompareScreenshot(const u8 *pixels, int w, int h, int stride, const std::string screenshotFilename, std::string &error);

--- a/headless/Compare.h
+++ b/headless/Compare.h
@@ -25,6 +25,7 @@ void TeamCityPrint(const char *fmt, ...);
 
 std::string ExpectedFromFilename(const std::string &bootFilename);
 std::string ExpectedScreenshotFromFilename(const std::string &bootFilename);
+std::string GetTestName(const std::string &bootFilename);
 
-bool CompareOutput(const std::string &bootFilename, const std::string &output);
+bool CompareOutput(const std::string &bootFilename, const std::string &output, bool verbose);
 double CompareScreenshot(const u8 *pixels, int w, int h, int stride, const std::string screenshotFilename, std::string &error);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -347,14 +347,37 @@ int main(int argc, const char* argv[])
 	if (screenshotFilename != 0)
 		headlessHost->SetComparisonScreenshot(screenshotFilename);
 
+	std::vector<std::string> failedTests;
+	std::vector<std::string> passedTests;
 	for (size_t i = 0; i < testFilenames.size(); ++i)
 	{
 		coreParameter.fileToStart = testFilenames[i];
 		if (autoCompare)
 			printf("%s:\n", coreParameter.fileToStart.c_str());
 		bool passed = RunAutoTest(headlessHost, coreParameter, autoCompare, timeout);
-		if (autoCompare && passed)
-			printf("  %s - passed!\n", GetTestName(coreParameter).c_str());
+		if (autoCompare)
+		{
+			std::string testName = GetTestName(coreParameter);
+			if (passed)
+			{
+				passedTests.push_back(testName);
+				printf("  %s - passed!\n", testName.c_str());
+			}
+			else
+				failedTests.push_back(testName);
+		}
+	}
+
+	if (autoCompare)
+	{
+		printf("%d tests passed, %d tests failed.\n", (int)passedTests.size(), (int)failedTests.size());
+		if (!failedTests.empty())
+		{
+			printf("Failed tests:\n");
+			for (int i = 0; i < failedTests.size(); ++i) {
+				printf("  %s", failedTests[i].c_str());
+			}
+		}
 	}
 
 	delete host;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -138,7 +138,7 @@ int main(int argc, const char* argv[])
 	const char *mountIso = 0;
 	const char *screenshotFilename = 0;
 	bool readMount = false;
-	double timeout = -1.0;
+	float timeout = std::numeric_limits<float>::infinity();
 
 	for (int i = 1; i < argc; i++)
 	{
@@ -304,7 +304,7 @@ int main(int argc, const char* argv[])
 
 	time_update();
 	bool doCompare = true;
-	double deadline = timeout < 0.0 ? std::numeric_limits<float>::infinity() : time_now() + timeout;
+	double deadline = time_now() + timeout;
 
 	coreState = CORE_RUNNING;
 	while (coreState == CORE_RUNNING)
@@ -318,7 +318,7 @@ int main(int argc, const char* argv[])
 			headlessHost->SwapBuffers();
 		}
 		time_update();
-		if (time_now() > deadline) {
+		if (time_now_d() > deadline) {
 			// Don't compare, print the output at least up to this point, and bail.
 			printf("%s", output.c_str());
 			doCompare = false;


### PR DESCRIPTION
Not really sure why but seems like VS2010 expects XMM4 to be preserved.

Fixes headless on x64.

When the accuracy is there, I figure I might as well, but changing to floats didn't help either.  I found out that timeout was infinity before `PSP_RunLoopFor()`, and 0.0 afterward.  Even if I set it to 86400.0f or anything, it became 0.  Saving XMM4 fixes that.

Anyway, also got the headless auto compare basically feature complete.  Now I just have to make test.py pass the lists of tests to it and nothing else, so it doesn't have to slow down the whole process.  I think it's all the threading and subprocess stuff that is not efficient or something.

-[Unknown]
