### PR TITLE
Headless - use auto compare, just build test list in test.py

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -312,6 +312,7 @@ void __CtrlInit()
 
 	memset(&ctrlCurrent, 0, sizeof(ctrlCurrent));
 	memset(ctrlCurrent.analog, CTRL_ANALOG_CENTER, sizeof(ctrlCurrent.analog));
+	analogEnabled = false;
 
 	for (u32 i = 0; i < NUM_CTRL_BUFFERS; i++)
 		memcpy(&ctrlBufs[i], &ctrlCurrent, sizeof(_ctrl_data));

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -424,7 +424,7 @@ u32 sceKernelIcacheClearAll()
 KernelObjectPool::KernelObjectPool()
 {
 	memset(occupied, 0, sizeof(bool)*maxCount);
-	nextID = 16;
+	nextID = initialNextID;
 }
 
 SceUID KernelObjectPool::Create(KernelObject *obj, int rangeBottom, int rangeTop)
@@ -470,6 +470,7 @@ void KernelObjectPool::Clear()
 		occupied[i]=false;
 	}
 	memset(pool, 0, sizeof(KernelObject*)*maxCount);
+	nextID = initialNextID;
 }
 
 KernelObject *&KernelObjectPool::operator [](SceUID handle)

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -427,7 +427,7 @@ public:
 	~KernelObjectPool() {}
 
 	// Allocates a UID within the range and inserts the object into the map.
-	SceUID Create(KernelObject *obj, int rangeBottom = 16, int rangeTop = 0x7fffffff);
+	SceUID Create(KernelObject *obj, int rangeBottom = initialNextID, int rangeTop = 0x7fffffff);
 
 	void DoState(PointerWrap &p);
 	static KernelObject *CreateByIDType(int type);
@@ -520,8 +520,9 @@ public:
 
 private:
 	enum {
-		maxCount=4096,
-		handleOffset=0x100
+		maxCount = 4096,
+		handleOffset = 0x100,
+		initialNextID = 0x10
 	};
 	KernelObject *pool[maxCount];
 	bool occupied[maxCount];

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -79,7 +79,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, bool useHWTransform)
 	glAttachShader(program, fs->shader);
 	glLinkProgram(program);
 
-	GLint linkStatus;
+	GLint linkStatus = GL_FALSE;
 	glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
 	if (linkStatus != GL_TRUE) {
 		GLint bufLength = 0;
@@ -98,6 +98,8 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, bool useHWTransform)
 #endif
 			delete [] buf;	// we're dead!
 		}
+		// Prevent a buffer overflow.
+		numBones = 0;
 		return;
 	}
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -352,7 +352,7 @@ int main(int argc, const char* argv[])
 		{
 			printf("Failed tests:\n");
 			for (int i = 0; i < failedTests.size(); ++i) {
-				printf("  %s", failedTests[i].c_str());
+				printf("  %s\n", failedTests[i].c_str());
 			}
 		}
 	}


### PR DESCRIPTION
Also, reset the kernel ids to start at 16 again every test.  Unfortunately, when running _all_ the tests, we were wrapping around, which causes some really edge case issues of id reuse.  Maybe we should fix those, though, or allocate ids in a smarter way...

Time taken to run tests from 16 -> 5 seconds (x64 is a bit faster.)

For some reason, one of the tests is super slow, not sure why.  Running all non good  is now 14 seconds (I didn't time this before but it was certainly much longer.)

I'm only running into one problem:
In the _second_ graphics test, `glCreateProgram()` is failing with GL_INVALID_OPERATION.  I'm not sure why.  It's okay if the test is run individually.

Anyway, the buildbot doesn't support those anyway.

-[Unknown]
