### PR TITLE
Fix headless on buildbot (command line length), speed up further

### DIFF
--- a/Core/Host.h
+++ b/Core/Host.h
@@ -73,6 +73,7 @@ public:
 #endif
 
 	// Used for headless.
+	virtual bool ShouldSkipUI() { return false; }
 	virtual void SendDebugOutput(const std::string &output) {}
 	virtual void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {}
 };

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -103,7 +103,6 @@ void Clear();
 
 struct Opcode {
 	Opcode() {
-		encoding = 0;
 	}
 
 	explicit Opcode(u32 v) : encoding (v) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -135,7 +135,8 @@ static u32 __PPGeDoAlloc(u32 &size, bool fromTop, const char *name) {
 
 void __PPGeInit()
 {
-	if (PSP_CoreParameter().gpuCore == GPU_NULL) {
+	// PPGe isn't really important for headless, and LoadZIM takes a long time.
+	if (PSP_CoreParameter().gpuCore == GPU_NULL || host->ShouldSkipUI()) {
 		// Let's just not bother.
 		dlPtr = 0;
 		NOTICE_LOG(SCEGE, "Not initializing PPGe - GPU is NullGpu");

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -123,7 +123,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 		fprintf(stderr, "Failed to start %s. Error: %s\n", coreParameter.fileToStart.c_str(), error_string.c_str());
 		printf("TESTERROR\n");
 		TeamCityPrint("##teamcity[testIgnored name='%s' message='PRX/ELF missing']\n", teamCityName.c_str());
-		return 1;
+		return false;
 	}
 
 	TeamCityPrint("##teamcity[testStarted name='%s' captureStandardOutput='true']\n", teamCityName.c_str());
@@ -239,6 +239,17 @@ int main(int argc, const char* argv[])
 		}
 		else
 			testFilenames.push_back(argv[i]);
+	}
+
+	// TODO: Allow a filename here?
+	if (testFilenames.size() == 1 && testFilenames[0] == "@-")
+	{
+		testFilenames.clear();
+		char temp[2048];
+		temp[2047] = '\0';
+
+		while (scanf("%2047s", temp) == 1)
+			testFilenames.push_back(temp);
 	}
 
 	if (readMount)

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -160,7 +160,6 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 		}
 	}
 
-	host->ShutdownGL();
 	PSP_Shutdown();
 
 	headlessHost->FlushDebugOutput();
@@ -357,10 +356,10 @@ int main(int argc, const char* argv[])
 		}
 	}
 
+	host->ShutdownGL();
 	delete host;
 	host = NULL;
 	headlessHost = NULL;
 
 	return 0;
 }
-

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -46,6 +46,8 @@ public:
 	virtual bool IsDebuggingEnabled() {return false;}
 	virtual bool AttemptLoadSymbolMap() {return false;}
 
+	virtual bool ShouldSkipUI() { return true; }
+
 	virtual void SendDebugOutput(const std::string &output) {
 		if (output.find('\n') != output.npos) {
 			DoFlushDebugOutput();

--- a/headless/WindowsHeadlessHostDx9.h
+++ b/headless/WindowsHeadlessHostDx9.h
@@ -37,6 +37,8 @@ public:
 	virtual void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h);
 	virtual void SetComparisonScreenshot(const std::string &filename);
 
+	virtual bool ShouldSkipUI() { return false; }
+
 private:
 	bool ResizeGL();
 	void LoadNativeAssets();

--- a/test.py
+++ b/test.py
@@ -30,8 +30,9 @@ teamcity_mode = False
 TIMEOUT = 5
 
 class Command(object):
-  def __init__(self, cmd):
+  def __init__(self, cmd, data = None):
     self.cmd = cmd
+    self.data = data
     self.process = None
     self.output = None
     self.timeout = False
@@ -39,6 +40,8 @@ class Command(object):
   def run(self, timeout):
     def target():
       self.process = subprocess.Popen(self.cmd, bufsize=1, stdin=subprocess.PIPE, stdout=sys.stdout, stderr=subprocess.STDOUT)
+      self.process.stdin.write(self.data)
+      self.process.stdin.close()
       self.process.communicate()
 
     thread = threading.Thread(target=target)
@@ -306,10 +309,10 @@ def run_tests(test_list, args):
 
   if len(test_filenames):
     # TODO: Maybe --compare should detect --graphics?
-    cmdline = [PPSSPP_EXE, '--graphics', '--compare', '--timeout=' + str(TIMEOUT)] + test_filenames
+    cmdline = [PPSSPP_EXE, '--graphics', '--compare', '--timeout=' + str(TIMEOUT), '@-']
     cmdline.extend([i for i in args if i not in ['-g']])
 
-    c = Command(cmdline)
+    c = Command(cmdline, '\n'.join(test_filenames))
     c.run(TIMEOUT * len(test_filenames))
 
     print("Ran " + PPSSPP_EXE)

--- a/test.py
+++ b/test.py
@@ -38,7 +38,7 @@ class Command(object):
 
   def run(self, timeout):
     def target():
-      self.process = subprocess.Popen(self.cmd, stdin=subprocess.PIPE)
+      self.process = subprocess.Popen(self.cmd, bufsize=1, stdin=subprocess.PIPE, stdout=sys.stdout, stderr=subprocess.STDOUT)
       self.process.communicate()
 
     thread = threading.Thread(target=target)


### PR DESCRIPTION
As far as I can guess, I think it's hitting command line limits.  So let's just send via stdin, it's easy and safe.  I did some experimenting with the build steps so I'm mostly sure this is the problem.

PPGe was taking 55% of the total test execution time in LoadZIM(), which isn't something I think is important to test anyway, so I just disabled it in headless.

After that, it was JitBlockCache::Init() taking like 35%, because MIPSOpcode had a constructor.  Killing that improved perf even more.

So now, `test.py -g` takes about 1.6-1.7 seconds, or 10% what it did when it was mostly Python.

FWIW, it now spends 15% of its time in `FPURegCache::Start()`, 7% in `SymbolMap::GetSymbolInfo()` (the lock_guard), 2.5% in `MIPSGetInstruction()`, and 2% in `GPRRegCache::Start()`.

-[Unknown]
