### PR TITLE
Turn off graphics tests by default

### DIFF
--- a/test.py
+++ b/test.py
@@ -309,7 +309,7 @@ def run_tests(test_list, args):
 
   if len(test_filenames):
     # TODO: Maybe --compare should detect --graphics?
-    cmdline = [PPSSPP_EXE, '--graphics', '--compare', '--timeout=' + str(TIMEOUT), '@-']
+    cmdline = [PPSSPP_EXE, '--compare', '--timeout=' + str(TIMEOUT), '@-']
     cmdline.extend([i for i in args if i not in ['-g']])
 
     c = Command(cmdline, '\n'.join(test_filenames))

--- a/test.py
+++ b/test.py
@@ -326,6 +326,7 @@ def main():
   for arg in sys.argv[1:]:
     if arg == '--teamcity':
       teamcity_mode = True
+      args.append(arg)
     elif arg[0] == '-':
       args.append(arg)
     else:


### PR DESCRIPTION
Looks like the buildbot can't handle it and just crashes or something.  Not sure what's going on, even if gl fails it should just fallback...

-[Unknown]
