### PR TITLE
Win32: When going into fullscreen, just place PPSSPP at the top of the Z(window) order.

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -832,9 +832,7 @@ int PSPOskDialog::Update()
 	// TODO: Add your platforms here when you have a NativeKeyboard func.
 
 #ifdef _WIN32
-	// Fall back to the OSK/continue normally if we're in fullscreen. The dialog box
-	// doesn't work right if in fullscreen.
-	if(g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen)
+	if(g_Config.bBypassOSKWithKeyboard)
 		return NativeKeyboard();
 #endif
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -293,7 +293,7 @@ namespace MainWindow
 		const int y = 0;
 		const int cx = ::GetSystemMetrics(SM_CXSCREEN);
 		const int cy = ::GetSystemMetrics(SM_CYSCREEN);
-		::SetWindowPos(hWnd, HWND_TOPMOST, x, y, cx, cy, SWP_FRAMECHANGED);
+		::SetWindowPos(hWnd, HWND_TOP, x, y, cx, cy, SWP_FRAMECHANGED);
 
 		// Set full screen indicator.
 		g_bFullScreen = TRUE;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -293,7 +293,8 @@ namespace MainWindow
 		const int y = 0;
 		const int cx = ::GetSystemMetrics(SM_CXSCREEN);
 		const int cy = ::GetSystemMetrics(SM_CYSCREEN);
-		::SetWindowPos(hWnd, HWND_TOP, x, y, cx, cy, SWP_FRAMECHANGED);
+		W32Util::MakeTopMost(hwndMain, g_Config.bTopMost);
+		::SetWindowPos(hWnd, HWND_NOTOPMOST, x, y, cx, cy, SWP_FRAMECHANGED);
 
 		// Set full screen indicator.
 		g_bFullScreen = TRUE;


### PR DESCRIPTION
Making it topmost seems to glitch out any open file dialogs, dialog boxes such as "Change Nickname", etc. May fix #2755.
