### PR TITLE
A couple more optimizations

### DIFF
--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -150,8 +150,6 @@ struct OpArg
 	bool IsImm() const {return scale == SCALE_IMM8 || scale == SCALE_IMM16 || scale == SCALE_IMM32 || scale == SCALE_IMM64;}
 	bool IsSimpleReg() const {return scale == SCALE_NONE;}
 	bool IsSimpleReg(X64Reg reg) const {
-		if (!IsSimpleReg())
-			return false;
 		return GetSimpleReg() == reg;
 	}
 
@@ -182,9 +180,14 @@ struct OpArg
 			return INVALID_REG;
 	}
 
-  u32 GetImmValue() const {
-    return (u32)offset;
-  }
+	u32 GetImmValue() const {
+		return (u32)offset;
+	}
+
+	// For loops.
+	void IncreaseOffset(int sz) {
+		offset += sz;
+	}
 private:
 	u8 scale;
 	u16 offsetOrBaseReg;

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -376,7 +376,7 @@ u32 sceCtrlSetSamplingCycle(u32 cycle)
 
 int sceCtrlGetSamplingCycle(u32 cyclePtr)
 {
-	DEBUG_LOG(SCECTRL, "sceCtrlSetSamplingCycle(%08x)", cyclePtr);
+	DEBUG_LOG(SCECTRL, "sceCtrlGetSamplingCycle(%08x)", cyclePtr);
 	if (Memory::IsValidAddress(cyclePtr))
 		Memory::Write_U32(ctrlCycle, cyclePtr);
 	return 0;

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -56,11 +56,11 @@ void GPRRegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
 		xregs[i].dirty = false;
 		xregs[i].allocLocked = false;
 	}
+	memset(regs, 0, sizeof(regs));
+	OpArg base = GetDefaultLocation(MIPS_REG_ZERO);
 	for (int i = 0; i < NUM_MIPS_GPRS; i++) {
-		const MIPSGPReg r = MIPSGPReg(i);
-		regs[i].location = GetDefaultLocation(r);
-		regs[i].away = false;
-		regs[i].locked = false;
+		regs[i].location = base;
+		base.IncreaseOffset(sizeof(u32));
 	}
 
 	// todo: sort to find the most popular regs
@@ -245,7 +245,7 @@ void GPRRegCache::BindToRegister(MIPSGPReg i, bool doLoad, bool makeDirty) {
 				emit->MOV(32, newloc, regs[i].location);
 		}
 		for (int j = 0; j < 32; j++) {
-			if (i != MIPSGPReg(j) && regs[j].location.IsSimpleReg() && regs[j].location.GetSimpleReg() == xr) {
+			if (i != MIPSGPReg(j) && regs[j].location.IsSimpleReg(xr)) {
 				ERROR_LOG(JIT, "BindToRegister: Strange condition");
 				Crash();
 			}

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -35,11 +35,16 @@ void FPURegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
 		xregs[i].mipsReg = -1;
 		xregs[i].dirty = false;
 	}
-	for (int i = 0; i < NUM_MIPS_FPRS; i++) {
-		regs[i].location = GetDefaultLocation(i);
-		regs[i].away = false;
-		regs[i].locked = false;
-		regs[i].tempLocked = false;
+	memset(regs, 0, sizeof(regs));
+	OpArg base = GetDefaultLocation(0);
+	for (int i = 0; i < 32; i++) {
+		regs[i].location = base;
+		base.IncreaseOffset(sizeof(float));
+	}
+	base = GetDefaultLocation(32);
+	for (int i = 32; i < NUM_MIPS_FPRS; i++) {
+		regs[i].location = base;
+		base.IncreaseOffset(sizeof(float));
 	}
 }
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -323,6 +323,7 @@ int main(int argc, const char* argv[])
 	g_Config.iButtonPreference = PSP_SYSTEMPARAM_BUTTON_CROSS;
 	g_Config.iLockParentalLevel = 9;
 	g_Config.iInternalResolution = 1;
+	g_Config.bFrameSkipUnthrottle = false;
 
 #if defined(ANDROID)
 #elif defined(BLACKBERRY) || defined(__SYMBIAN32__)
@@ -361,7 +362,7 @@ int main(int argc, const char* argv[])
 		if (!failedTests.empty())
 		{
 			printf("Failed tests:\n");
-			for (int i = 0; i < failedTests.size(); ++i) {
+			for (size_t i = 0; i < failedTests.size(); ++i) {
 				printf("  %s\n", failedTests[i].c_str());
 			}
 		}


### PR DESCRIPTION
Tried to figure out why the buildbot is just dying after ~150 tests on x64.  Works fine locally, works fine on x86 on the buildbot.  Not sure how much it's worth looking into it more, I have no idea what's going on on the buildbot.  It runs for like 7 seconds and then hangs for 6+ minutes.

Anyway, this is a slight optimization (mutating an OpArg in a loop) that cuts down a lot on the Start() methods of the regcaches.  This shaves about 0.2 seconds off the total test time, or more.

-[Unknown]
