### PR TITLE
Should be in VRAM so | 0x04000000

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1015,7 +1015,7 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 		}
 
 		u32 bufSize = vfb->fb_stride * vfb->height * pixelSize;
-		u32 fb_address = (0x44000000) | vfb->fb_address;
+		u32 fb_address = (0x04000000) | vfb->fb_address;
 
 		if (vfb->fbo) {
 			fbo_bind_for_read(vfb->fbo);


### PR DESCRIPTION
Both async and sync packframebuffer should use same fb_address with | 0x04000000
