### PR TITLE
Win32: Fix Rendering Resolution mode bug.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -231,8 +231,15 @@ namespace MainWindow
 		ResizeDisplay();
 	}
 
-	void SetInternalResolution(int res) {
-		g_Config.iInternalResolution = res;
+	void SetInternalResolution(int res = -1) {
+		const int MAX_ZOOM = 10;
+		if (res >= 0 && res <= MAX_ZOOM)
+			g_Config.iInternalResolution = res;
+		else {
+			if (++g_Config.iInternalResolution > MAX_ZOOM)
+				g_Config.iInternalResolution = 0;
+		}
+
 	}
 
 	void CorrectCursor() {
@@ -1140,9 +1147,7 @@ namespace MainWindow
 					
 				case ID_OPTIONS_RESOLUTIONDUMMY:
 					{
-						static int resolutionMultiplier = 0;
-						resolutionMultiplier = g_Config.iInternalResolution <= 10 ? ++resolutionMultiplier : 0;
-						SetInternalResolution(resolutionMultiplier);
+						SetInternalResolution();
 						ResizeDisplay(true);
 						break;
 					}


### PR DESCRIPTION
First discussed and noticed by @DanyalZia in https://github.com/hrydgard/ppsspp/pull/3834. CTRL + 1 wasn't matching up with the DesktopUI's current status.
