### PR TITLE
Save/restore GE ctx when lists request it, use in PPGe, and minor signal call fix

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -470,10 +470,11 @@ u32 sceGeSaveContext(u32 ctxAddr)
 	DEBUG_LOG(SCEGE, "sceGeSaveContext(%08x)", ctxAddr);
 	gpu->SyncThread();
 
-	if (sizeof(gstate) > 512 * 4)
+	if (gpu->DrawSync(1) != PSP_GE_LIST_COMPLETED)
 	{
-		ERROR_LOG(SCEGE, "AARGH! sizeof(gstate) has grown too large!");
-		return 0;
+		WARN_LOG(SCEGE, "sceGeSaveContext(%08x): lists in process, aborting", ctxAddr);
+		// Real error code.
+		return -1;
 	}
 
 	// Let's just dump gstate.
@@ -492,10 +493,10 @@ u32 sceGeRestoreContext(u32 ctxAddr)
 	DEBUG_LOG(SCEGE, "sceGeRestoreContext(%08x)", ctxAddr);
 	gpu->SyncThread();
 
-	if (sizeof(gstate) > 512 * 4)
+	if (gpu->DrawSync(1) != PSP_GE_LIST_COMPLETED)
 	{
-		ERROR_LOG(SCEGE, "AARGH! sizeof(gstate) has grown too large!");
-		return 0;
+		WARN_LOG(SCEGE, "sceGeRestoreContext(%08x): lists in process, aborting", ctxAddr);
+		return SCE_KERNEL_ERROR_BUSY;
 	}
 
 	if (Memory::IsValidAddress(ctxAddr))

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -333,12 +333,12 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId,
 	DEBUG_LOG(SCEGE,
 			"sceGeListEnQueue(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
 			listAddress, stallAddress, callbackId, optParamAddr);
-	//if (!stallAddress)
-	//	stallAddress = listAddress;
-	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), false);
+	PSPPointer<PspGeListArgs> optParam;
+	optParam = optParamAddr;
+
+	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, false);
 
 	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
-	//return display list ID
 	return listID;
 }
 
@@ -348,7 +348,10 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId,
 	DEBUG_LOG(SCEGE,
 			"sceGeListEnQueueHead(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
 			listAddress, stallAddress, callbackId, optParamAddr);
-	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), true);
+	PSPPointer<PspGeListArgs> optParam;
+	optParam = optParamAddr;
+
+	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
 
 	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
 	return listID;

--- a/Core/HLE/sceGe.h
+++ b/Core/HLE/sceGe.h
@@ -36,6 +36,14 @@ struct PspGeCallbackData
 	u32_le finish_arg;
 };
 
+struct PspGeListArgs
+{
+	SceSize_le size;
+	PSPPointer<u32_le> context;
+	u32_le numStacks;
+	u32_le unknown1;
+};
+
 void Register_sceGe_user();
 
 void __GeInit();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -838,6 +838,9 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					currentList->waitTicks = startingTicks + cyclesExecuted;
 					busyTicks = std::max(busyTicks, currentList->waitTicks);
 					__GeTriggerSync(WAITTYPE_GELISTSYNC, currentList->id, currentList->waitTicks);
+					if (currentList->started && currentList->context != NULL) {
+						gstate.Restore(currentList->context);
+					}
 				}
 				break;
 			}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -683,6 +683,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 				auto &stackEntry = currentList->stack[currentList->stackptr++];
 				stackEntry.pc = retval;
 				stackEntry.offsetAddr = gstate_c.offsetAddr;
+				// The base address is NOT saved/restored for a regular call.
 				UpdatePC(currentList->pc, target - 4);
 				currentList->pc = target - 4;	// pc will be increased after we return, counteract that
 			}
@@ -777,6 +778,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 							auto &stackEntry = currentList->stack[currentList->stackptr++];
 							stackEntry.pc = currentList->pc;
 							stackEntry.offsetAddr = gstate_c.offsetAddr;
+							stackEntry.baseAddr = gstate.base;
 							UpdatePC(currentList->pc, target);
 							currentList->pc = target;
 							DEBUG_LOG(G3D, "Signal with Call. signal/end: %04x %04x", signal, enddata);
@@ -793,6 +795,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 							// TODO: This might save/restore other state...
 							auto &stackEntry = currentList->stack[--currentList->stackptr];
 							gstate_c.offsetAddr = stackEntry.offsetAddr;
+							gstate.base = stackEntry.baseAddr;
 							UpdatePC(currentList->pc, stackEntry.pc);
 							currentList->pc = stackEntry.pc;
 							DEBUG_LOG(G3D, "Signal with Return. signal/end: %04x %04x", signal, enddata);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -30,7 +30,7 @@ public:
 	virtual bool InterpretList(DisplayList &list);
 	virtual bool ProcessDLQueue();
 	virtual u32  UpdateStall(int listid, u32 newstall);
-	virtual u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head);
+	virtual u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head);
 	virtual u32  DequeueList(int listid);
 	virtual int  ListSync(int listid, int mode);
 	virtual u32  DrawSync(int mode);

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -113,6 +113,7 @@ struct DisplayListStackEntry
 {
 	u32 pc;
 	u32 offsetAddr;
+	u32 baseAddr;
 };
 
 struct DisplayList

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -20,6 +20,7 @@
 #include "Globals.h"
 #include "GPU/GPUState.h"
 #include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/sceGe.h"
 #include <list>
 #include <string>
 
@@ -130,6 +131,8 @@ struct DisplayList
 	u64 waitTicks;
 	bool interruptsEnabled;
 	bool pendingInterrupt;
+	bool started;
+	u32_le *context;
 };
 
 enum GPUInvalidationType {
@@ -186,7 +189,7 @@ public:
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;
 	// TODO: Much of this should probably be shared between the different GPU implementations.
-	virtual u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, bool head) = 0;
+	virtual u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head) = 0;
 	virtual u32  DequeueList(int listid) = 0;
 	virtual u32  UpdateStall(int listid, u32 newstall) = 0;
 	virtual u32  DrawSync(int mode) = 0;

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -139,7 +139,7 @@ void GPUgstate::Save(u32_le *ptr) {
 	ptr[6] = gstate_c.indexAddr;
 	ptr[7] = gstate_c.offsetAddr;
 
-	// Command values start 17 bytes in.
+	// Command values start 17 ints in.
 	u32_le *cmds = ptr + 17;
 	for (size_t i = 0; i < ARRAY_SIZE(contextCmdRanges); ++i) {
 		for (int n = contextCmdRanges[i].start; n <= contextCmdRanges[i].end; ++n) {
@@ -171,7 +171,7 @@ void GPUgstate::Restore(u32_le *ptr) {
 	gstate_c.indexAddr = ptr[6];
 	gstate_c.offsetAddr = ptr[7];
 
-	// Command values start 17 bytes in.
+	// Command values start 17 ints in.
 	u32_le *cmds = ptr + 17;
 	for (size_t i = 0; i < ARRAY_SIZE(contextCmdRanges); ++i) {
 		for (int n = contextCmdRanges[i].start; n <= contextCmdRanges[i].end; ++n) {


### PR DESCRIPTION
We were simply ignoring the options argument before.  Cleaning up a test that verifies this behavior.

-[Unknown]
