### PR TITLE
Implement sceGeGetStack(), fix sceGeGet*()

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -542,6 +542,8 @@ int sceGeGetMtx(int type, u32 matrixPtr)
 	case GE_MTX_PROJECTION:
 		Memory::Memcpy(matrixPtr, gstate.projMatrix, 16 * sizeof(float));
 		break;
+	default:
+		return SCE_KERNEL_ERROR_INVALID_INDEX;
 	}
 	return 0;
 }
@@ -549,7 +551,11 @@ int sceGeGetMtx(int type, u32 matrixPtr)
 u32 sceGeGetCmd(int cmd)
 {
 	INFO_LOG(SCEGE, "sceGeGetCmd(%i)", cmd);
-	return gstate.cmdmem[cmd];  // Does not mask away the high bits.
+	if (cmd >= 0 && cmd < ARRAY_SIZE(gstate.cmdmem)) {
+		return gstate.cmdmem[cmd];  // Does not mask away the high bits.
+	} else {
+		return SCE_KERNEL_ERROR_INVALID_INDEX;
+	}
 }
 
 int sceGeGetStack(int index, u32 stackPtr)

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -552,6 +552,12 @@ u32 sceGeGetCmd(int cmd)
 	return gstate.cmdmem[cmd];  // Does not mask away the high bits.
 }
 
+int sceGeGetStack(int index, u32 stackPtr)
+{
+	WARN_LOG_REPORT(SCEGE, "sceGeGetStack(%i, %08x)", index, stackPtr);
+	return gpu->GetStack(index, stackPtr);
+}
+
 u32 sceGeEdramSetAddrTranslation(int new_size)
 {
 	bool outsideRange = new_size != 0 && (new_size < 0x200 || new_size > 0x1000);
@@ -588,6 +594,7 @@ const HLEFunction sceGe_user[] =
 	{0x438A385A, WrapU_U<sceGeSaveContext>,             "sceGeSaveContext"},
 	{0x0BF608FB, WrapU_U<sceGeRestoreContext>,          "sceGeRestoreContext"},
 	{0x5FB86AB0, WrapI_U<sceGeListDeQueue>,             "sceGeListDeQueue"},
+	{0xE66CB92E, WrapI_IU<sceGeGetStack>,               "sceGeGetStack"},
 };
 
 void Register_sceGe_user()

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -157,6 +157,33 @@ int GPUCommon::ListSync(int listid, int mode) {
 	return PSP_GE_LIST_COMPLETED;
 }
 
+int GPUCommon::GetStack(int index, u32 stackPtr) {
+	easy_guard guard(listLock);
+	if (currentList == NULL) {
+		// Seems like it doesn't return an error code?
+		return 0;
+	}
+
+	if (currentList->stackptr <= index) {
+		return SCE_KERNEL_ERROR_INVALID_INDEX;
+	}
+
+	if (index >= 0) {
+		PSPPointer<u32> stack;
+		stack = stackPtr;
+		if (stack.IsValid()) {
+			auto entry = currentList->stack[index];
+			// Not really sure what most of these values are.
+			stack[0] = 0;
+			stack[1] = entry.pc + 4;
+			stack[2] = entry.offsetAddr;
+			stack[7] = entry.baseAddr;
+		}
+	}
+
+	return currentList->stackptr;
+}
+
 u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head) {
 	easy_guard guard(listLock);
 	// TODO Check the stack values in missing arg and ajust the stack depth

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -34,6 +34,7 @@ public:
 	virtual u32  DequeueList(int listid);
 	virtual int  ListSync(int listid, int mode);
 	virtual u32  DrawSync(int mode);
+	virtual int  GetStack(int index, u32 stackPtr);
 	virtual void DoState(PointerWrap &p);
 	virtual bool FramebufferDirty() {
 		SyncThread();

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -197,6 +197,7 @@ public:
 	virtual int  ListSync(int listid, int mode) = 0;
 	virtual u32  Continue() = 0;
 	virtual u32  Break(int mode) = 0;
+	virtual int  GetStack(int index, u32 stackPtr) = 0;
 
 	virtual void InterruptStart(int listid) = 0;
 	virtual void InterruptEnd(int listid) = 0;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -589,53 +589,71 @@ void NullGPU::ExecuteOp(u32 op, u32 diff)
 		break;
 
 	case GE_CMD_WORLDMATRIXNUMBER:
-		DEBUG_LOG(G3D,"DL World matrix # %i", data);
 		gstate.worldmtxnum = data&0xF;
 		break;
 
 	case GE_CMD_WORLDMATRIXDATA:
-		DEBUG_LOG(G3D,"DL World matrix data # %f", getFloat24(data));
-		gstate.worldMatrix[gstate.worldmtxnum++] = getFloat24(data);
+		{
+			int num = gstate.worldmtxnum & 0xF;
+			if (num < 12) {
+				gstate.worldMatrix[num] = getFloat24(data);
+			}
+			gstate.worldmtxnum = (++num) & 0xF;
+		}
 		break;
 
 	case GE_CMD_VIEWMATRIXNUMBER:
-		DEBUG_LOG(G3D,"DL VIEW matrix # %i", data);
 		gstate.viewmtxnum = data&0xF;
 		break;
 
 	case GE_CMD_VIEWMATRIXDATA:
-		DEBUG_LOG(G3D,"DL VIEW matrix data # %f", getFloat24(data));
-		gstate.viewMatrix[gstate.viewmtxnum++] = getFloat24(data);
+		{
+			int num = gstate.viewmtxnum & 0xF;
+			if (num < 12) {
+				gstate.viewMatrix[num] = getFloat24(data);
+			}
+			gstate.viewmtxnum = (++num) & 0xF;
+		}
 		break;
 
 	case GE_CMD_PROJMATRIXNUMBER:
-		DEBUG_LOG(G3D,"DL PROJECTION matrix # %i", data);
 		gstate.projmtxnum = data&0xF;
 		break;
 
 	case GE_CMD_PROJMATRIXDATA:
-		DEBUG_LOG(G3D,"DL PROJECTION matrix data # %f", getFloat24(data));
-		gstate.projMatrix[gstate.projmtxnum++] = getFloat24(data);
+		{
+			int num = gstate.projmtxnum & 0xF;
+			gstate.projMatrix[num] = getFloat24(data);
+			gstate.projmtxnum = (++num) & 0xF;
+		}
 		break;
 
 	case GE_CMD_TGENMATRIXNUMBER:
-		DEBUG_LOG(G3D,"DL TGEN matrix # %i", data);
 		gstate.texmtxnum = data&0xF;
 		break;
 
 	case GE_CMD_TGENMATRIXDATA:
-		DEBUG_LOG(G3D,"DL TGEN matrix data # %f", getFloat24(data));
-		gstate.tgenMatrix[gstate.texmtxnum++] = getFloat24(data);
+		{
+			int num = gstate.texmtxnum & 0xF;
+			if (num < 12) {
+				gstate.tgenMatrix[num] = getFloat24(data);
+			}
+			gstate.texmtxnum = (++num) & 0xF;
+		}
 		break;
 
 	case GE_CMD_BONEMATRIXNUMBER:
-		DEBUG_LOG(G3D,"DL BONE matrix #%i", data);
-		gstate.boneMatrixNumber = data;
+		gstate.boneMatrixNumber = data & 0x7F;
 		break;
 
 	case GE_CMD_BONEMATRIXDATA:
-		DEBUG_LOG(G3D,"DL BONE matrix data #%i %f", gstate.boneMatrixNumber, getFloat24(data));
-		gstate.boneMatrix[gstate.boneMatrixNumber++] = getFloat24(data);
+		{
+			int num = gstate.boneMatrixNumber & 0x7F;
+			if (num < 96) {
+				gstate.boneMatrix[num] = getFloat24(data);
+			}
+			gstate.boneMatrixNumber = (++num) & 0x7F;
+		}
 		break;
 
 	default:


### PR DESCRIPTION
I'm not sure what games use these, but sceGeGetMtx() was not returning correct results, so it could help some game calling it.

I don't think any games use sceGeGetStack(), but it's useful for debugging and verifying the stack anyway.  This way we can test that offset/base are saved in the stack properly much more easily.

-[Unknown]
