### PR TITLE
Improve GE list ids, fix a rare bug in sceGeListUpdateStallAddr, better errors

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -519,6 +519,14 @@ void MoveEvents()
 	}
 }
 
+void ForceCheck()
+{
+	int cyclesExecuted = slicelength - currentMIPS->downcount;
+	globalTimer += cyclesExecuted;
+	// This will cause us to check for new events immediately.
+	currentMIPS->downcount = 0;
+}
+
 void Advance()
 {
 	int cyclesExecuted = slicelength - currentMIPS->downcount;

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -101,6 +101,7 @@ namespace CoreTiming
 	void Advance();
 	void MoveEvents();
 	void ProcessFifoWaitEvents();
+	void ForceCheck();
 
 	// Pretend that the main CPU has executed enough cycles to reach the next event.
 	void Idle(int maxIdle = 0);

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -337,6 +337,8 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId,
 	optParam = optParamAddr;
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, false);
+	if ((int)listID >= 0)
+		listID = 0x35000000 | listID;
 
 	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
 	return listID;
@@ -352,6 +354,8 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId,
 	optParam = optParamAddr;
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
+	if ((int)listID >= 0)
+		listID = 0x35000000 ^ listID;
 
 	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
 	return listID;
@@ -360,7 +364,7 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId,
 int sceGeListDeQueue(u32 listID)
 {
 	WARN_LOG(SCEGE, "sceGeListDeQueue(%08x)", listID);
-	int result = gpu->DequeueList(listID);
+	int result = gpu->DequeueList(0x35000000 ^ listID);
 	hleReSchedule("dlist dequeued");
 	return result;
 }
@@ -370,13 +374,13 @@ int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
 	DEBUG_LOG(SCEGE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
 	hleEatCycles(190);
 	CoreTiming::Advance();
-	return gpu->UpdateStall(displayListID, stallAddress);
+	return gpu->UpdateStall(0x35000000 ^ displayListID, stallAddress);
 }
 
 int sceGeListSync(u32 displayListID, u32 mode) //0 : wait for completion		1:check and return
 {
 	DEBUG_LOG(SCEGE, "sceGeListSync(dlid=%08x, mode=%08x)", displayListID, mode);
-	return gpu->ListSync(displayListID, mode);
+	return gpu->ListSync(0x35000000 ^ displayListID, mode);
 }
 
 u32 sceGeDrawSync(u32 mode)

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -341,6 +341,7 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId,
 		listID = 0x35000000 | listID;
 
 	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
+	hleEatCycles(520);
 	return listID;
 }
 
@@ -371,9 +372,12 @@ int sceGeListDeQueue(u32 listID)
 
 int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
 {
-	DEBUG_LOG(SCEGE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
+	// Advance() might cause an interrupt, so defer the Advance but do it ASAP.
+	// Final Fantasy Type-0 has a graphical artifact without this (timing issue.)
 	hleEatCycles(190);
-	CoreTiming::Advance();
+	CoreTiming::ForceCheck();
+
+	DEBUG_LOG(SCEGE, "sceGeListUpdateStallAddr(dlid=%i, stalladdr=%08x)", displayListID, stallAddress);
 	return gpu->UpdateStall(0x35000000 ^ displayListID, stallAddress);
 }
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -313,11 +313,14 @@ u32 GPUCommon::UpdateStall(int listid, u32 newstall) {
 	easy_guard guard(listLock);
 	if (listid < 0 || listid >= DisplayListMaxCount || dls[listid].state == PSP_GE_DL_STATE_NONE)
 		return SCE_KERNEL_ERROR_INVALID_ID;
+	auto &dl = dls[listid];
+	if (dl.state == PSP_GE_DL_STATE_COMPLETED)
+		return SCE_KERNEL_ERROR_ALREADY;
 
-	dls[listid].stall = newstall & 0x0FFFFFFF;
+	dl.stall = newstall & 0x0FFFFFFF;
 
-	if (dls[listid].signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
-		dls[listid].signal = PSP_GE_SIGNAL_HANDLER_SUSPEND;
+	if (dl.signal == PSP_GE_SIGNAL_HANDLER_PAUSE)
+		dl.signal = PSP_GE_SIGNAL_HANDLER_SUSPEND;
 	
 	guard.unlock();
 	ProcessDLQueue();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -291,17 +291,18 @@ u32 GPUCommon::DequeueList(int listid) {
 	if (listid < 0 || listid >= DisplayListMaxCount || dls[listid].state == PSP_GE_DL_STATE_NONE)
 		return SCE_KERNEL_ERROR_INVALID_ID;
 
-	if (dls[listid].state == PSP_GE_DL_STATE_RUNNING || dls[listid].state == PSP_GE_DL_STATE_PAUSED)
-		return 0x80000021;
+	auto &dl = dls[listid];
+	if (dl.started)
+		return SCE_KERNEL_ERROR_BUSY;
 
-	dls[listid].state = PSP_GE_DL_STATE_NONE;
+	dl.state = PSP_GE_DL_STATE_NONE;
 
 	if (listid == dlQueue.front())
 		PopDLQueue();
 	else
 		dlQueue.remove(listid);
 
-	dls[listid].waitTicks = 0;
+	dl.waitTicks = 0;
 	__GeTriggerWait(WAITTYPE_GELISTSYNC, listid);
 
 	CheckDrawSync();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -92,6 +92,7 @@ protected:
 
 	typedef std::list<int> DisplayListQueue;
 
+	int nextListID;
 	DisplayList dls[DisplayListMaxCount];
 	DisplayList *currentList;
 	DisplayListQueue dlQueue;


### PR DESCRIPTION
List ids should go round robin, but we were returning the same id (e.g. 0) over and over.  A buggy game could have problems with our implementation and be fine on the PSP, so this is safer.

Also, ids always have some high bits set, so I figured replicating the basic range was a good idea.

I happened to run into CoreTiming::Advance() thread switching within sceGeListUpdateStallAddr(), which is probably not a common thing, but this causes the return value to be messed up.  So I made it just force the cpu to run Advance() after the return, which should be safer.  The FF Type-0 demo still seems okay.

This makes the test in hrydgard/pspautotests#111 pass.

-[Unknown]
