### PR TITLE
Crash fix and more scanning

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -103,7 +103,9 @@ void CtrlDisAsmView::scanFunctions()
 			for (int funcPos = info.address; funcPos < funcEnd; funcPos += instructionSize)
 			{
 				MIPSAnalyst::MipsOpcodeInfo opInfo = MIPSAnalyst::GetOpcodeInfo(debugger,funcPos);
-				if (opInfo.isBranch && !opInfo.isBranchToRegister && !opInfo.isLinkedBranch)
+
+				bool inFunction = (opInfo.branchTarget >= info.address && opInfo.branchTarget < funcEnd);
+				if (opInfo.isBranch && !opInfo.isBranchToRegister && !opInfo.isLinkedBranch && inFunction)
 				{
 					BranchLine line;
 					if (opInfo.branchTarget < funcPos)
@@ -666,6 +668,7 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 	for (int i = 0; i < visibleFunctionAddresses.size(); i++)
 	{
 		auto it = functions.find(visibleFunctionAddresses[i]);
+		if (it == functions.end()) continue;
 		DisassemblyFunction& func = it->second;
 		
 		for (int l = 0; l < func.lines.size(); l++)
@@ -859,6 +862,8 @@ void CtrlDisAsmView::scrollAddressIntoView()
 		windowStart = curAddress;
 	else if (curAddress >= windowEnd)
 		windowStart = curAddress - visibleRows * instructionSize + instructionSize;
+
+	scanFunctions();
 }
 
 bool CtrlDisAsmView::curAddressIsVisible()

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -473,6 +473,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 		// In case this is a delay slot or combined instruction, clear cache above it too.
 		if (MIPSComp::jit)
 			MIPSComp::jit->ClearCacheAt(address - 4, 8);
+		scanFunctions();
 		redraw();
 	} else {
 		std::wstring error = ConvertUTF8ToWString(MIPSAsm::GetAssembleError());

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -119,7 +119,12 @@ public:
 	bool curAddressIsVisible();
 	void redraw();
 	void scanFunctions();
-	void clearFunctions() { functions.clear(); };
+	void clearFunctions()
+	{
+		functions.clear();
+		visibleFunctionAddresses.clear();
+		strayLines.clear();
+	};
 
 	void getOpcodeText(u32 address, char* dest);
 	u32 yToAddress(int y);
@@ -146,6 +151,7 @@ public:
 		}
 
 		setCurAddress(newAddress);
+		scanFunctions();
 		redraw();
 	}
 	void gotoPC()
@@ -178,6 +184,5 @@ public:
 		selectRangeStart = extend ? std::min(selectRangeStart, newAddress) : newAddress;
 		selectRangeEnd = extend ? std::max(selectRangeEnd, after) : after;
 		updateStatusBarText();
-		scanFunctions();
 	}
 };


### PR DESCRIPTION
Sorry... but that's really all now.

It crashed when you stopped a game and then loaded another. There were also more places where it had to scan the visible functions.
Sometimes compilers turn a function call at the end into a simple jump to the start of the called function. In these cases the lines are not drawn now.
