### PR TITLE
Win32: Fix 2 fullscreen bugs

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -829,8 +829,6 @@ namespace MainWindow
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
-		int factor = g_Config.iWindowWidth < (480 + 80) ? 2 : 1;
-
 		switch (message) {
 		case WM_ACTIVATE:
 			break;
@@ -856,8 +854,8 @@ namespace MainWindow
 					input_state.mouse_valid = true;
 					input_state.pointer_down[0] = true;
 
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
 				}
 
 				TouchInput touch;
@@ -886,8 +884,8 @@ namespace MainWindow
 
 				{
 					lock_guard guard(input_state.lock);
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
 				}
 
 				if (wParam & MK_LBUTTON) {
@@ -908,8 +906,8 @@ namespace MainWindow
 				{
 					lock_guard guard(input_state.lock);
 					input_state.pointer_down[0] = false;
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
 				}
 				TouchInput touch;
 				touch.id = 0;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1504,10 +1504,7 @@ namespace MainWindow
 			PostQuitMessage(0);
 			break;
 
-		case WM_USER+1:
-			if (g_Config.bFullScreen)
-				_ViewFullScreen(hWnd);
-
+		case WM_USER + 1:
 			disasmWindow[0]->NotifyMapLoaded();
 			memoryWindow[0]->NotifyMapLoaded();
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -829,6 +829,9 @@ namespace MainWindow
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
+		// Only apply a factor > 1 in windowed mode.
+		int factor = !g_Config.bFullScreen && g_Config.iWindowWidth < (480 + 80) ? 2 : 1;
+
 		switch (message) {
 		case WM_ACTIVATE:
 			break;
@@ -854,8 +857,8 @@ namespace MainWindow
 					input_state.mouse_valid = true;
 					input_state.pointer_down[0] = true;
 
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
 				}
 
 				TouchInput touch;
@@ -884,8 +887,8 @@ namespace MainWindow
 
 				{
 					lock_guard guard(input_state.lock);
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
 				}
 
 				if (wParam & MK_LBUTTON) {
@@ -906,8 +909,8 @@ namespace MainWindow
 				{
 					lock_guard guard(input_state.lock);
 					input_state.pointer_down[0] = false;
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam);
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam);
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
 				}
 				TouchInput touch;
 				touch.id = 0;


### PR DESCRIPTION
First bug: I'm not sure why this was added(it was committed here: https://github.com/hrydgard/ppsspp/commit/b74b215f349e5e5bfcbd1baa27080a92b7a3b9e5) but it causes a bug when exiting fullscreen sometimes, so let's just remove it.

It appears to be the cause of this bug:
1. Start a game in windowed mode.
2. Enter fullscreen mode.
3. Reset game via CTRL + B(current reset shortcut)
4. Exit fullscreen via F11.
5. The window size is huge, like previous bugs.

Second bug: When entering fullscreen from 1x window size, mouse events wouldn't work. Adjustment of the factor variable not to apply to fullscreen mode fixes it. Fixes https://github.com/hrydgard/ppsspp/issues/3899.
