### PR TITLE
Actually apply restored ge contexts

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -893,6 +893,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					__GeTriggerSync(WAITTYPE_GELISTSYNC, currentList->id, currentList->waitTicks);
 					if (currentList->started && currentList->context != NULL) {
 						gstate.Restore(currentList->context);
+						ReapplyGfxStateInternal();
 					}
 				}
 				break;
@@ -952,6 +953,7 @@ void GPUCommon::InterruptEnd(int listid) {
 	if (dl.state == PSP_GE_DL_STATE_COMPLETED || dl.state == PSP_GE_DL_STATE_NONE) {
 		if (dl.started && dl.context != NULL) {
 			gstate.Restore(dl.context);
+			ReapplyGfxState();
 		}
 		dl.waitTicks = 0;
 		__GeTriggerWait(WAITTYPE_GELISTSYNC, listid);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -653,6 +653,9 @@ void GPUCommon::ProcessDLQueueInternal() {
 	cyclesExecuted = 0;
 	UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
 
+	// Game might've written new texture data.
+	gstate_c.textureChanged = true;
+
 	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {
 		DEBUG_LOG(G3D, "Can't execute a list yet, still busy for %lld ticks", busyTicks - startingTicks);


### PR DESCRIPTION
Heh, otherwise some things won't get executed, etc. which might cause glitches.

Also, set textureChanged when starting to process lists, in case the game was evil and overwrote the memory between lists without setting a new texture.  That sounds like a thing I might innocently do/have done in a test.

(I don't know of anything this fixes, though.)

-[Unknown]
