### PR TITLE
Defer initialiazation of the GE debugger preview window

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -124,7 +124,7 @@ void CtrlDisAsmView::scanFunctions()
 			}
 			
 			std::sort(func.lines.begin(),func.lines.end(),compareBranchLines);
-			for (int i = 0; i < func.lines.size(); i++)
+			for (size_t i = 0; i < func.lines.size(); i++)
 			{
 				for (int l = 0; l < NUM_LANES; l++)
 				{
@@ -184,7 +184,7 @@ void CtrlDisAsmView::scanFunctions()
 		lanes[i].used = false;
 	
 	std::sort(strayLines.begin(),strayLines.end(),compareBranchLines);
-	for (int i = 0; i < strayLines.size(); i++)
+	for (size_t i = 0; i < strayLines.size(); i++)
 	{
 		for (int l = 0; l < NUM_LANES; l++)
 		{
@@ -666,19 +666,19 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 	}
 
 	SelectObject(hdc,condPen);
-	for (int i = 0; i < visibleFunctionAddresses.size(); i++)
+	for (size_t i = 0; i < visibleFunctionAddresses.size(); i++)
 	{
 		auto it = functions.find(visibleFunctionAddresses[i]);
 		if (it == functions.end()) continue;
 		DisassemblyFunction& func = it->second;
 		
-		for (int l = 0; l < func.lines.size(); l++)
+		for (size_t l = 0; l < func.lines.size(); l++)
 		{
 			drawBranchLine(hdc,func.lines[l]);
 		}
 	}
 
-	for (int i = 0; i < strayLines.size(); i++)
+	for (size_t i = 0; i < strayLines.size(); i++)
 	{
 		drawBranchLine(hdc,strayLines[i]);
 	}

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -86,16 +86,21 @@ static void RunPauseAction() {
 }
 
 CGEDebugger::CGEDebugger(HINSTANCE _hInstance, HWND _hParent)
-	: Dialog((LPCSTR)IDD_GEDEBUGGER, _hInstance, _hParent) {
+	: Dialog((LPCSTR)IDD_GEDEBUGGER, _hInstance, _hParent), frameWindow(NULL) {
 	breakCmds.resize(256, false);
-	// TODO: Could be scrollable in case the framebuf is larger?  Also should be better positioned.
-	frameWindow = new SimpleGLWindow(m_hInstance, m_hDlg, (750 - 512) / 2, 40, 512, 272);
-	// TODO: Why doesn't this work?
-	frameWindow->Clear();
 }
 
 CGEDebugger::~CGEDebugger() {
 	delete frameWindow;
+}
+
+void CGEDebugger::SetupFrameWindow() {
+	if (frameWindow == NULL) {
+		// TODO: Could be scrollable in case the framebuf is larger?  Also should be better positioned.
+		frameWindow = new SimpleGLWindow(m_hInstance, m_hDlg, (750 - 512) / 2, 40, 512, 272);
+		// TODO: Why doesn't this work?
+		frameWindow->Clear();
+	}
 }
 
 BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
@@ -111,10 +116,15 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		Show(false);
 		return TRUE;
 
+	case WM_SHOWWINDOW:
+		SetupFrameWindow();
+		break;
+
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
 		case IDC_GEDBG_BREAK:
 			attached = true;
+			SetupFrameWindow();
 			//breakNextOp = true;
 			pauseWait.notify_one();
 			breakNextDraw = true;

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -31,5 +31,8 @@ public:
 protected:
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
+private:
+	void SetupFrameWindow();
+
 	SimpleGLWindow *frameWindow;
 };

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -101,7 +101,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	// Really should find a way to do this in XP too :/
 	if (0 != GetLocaleInfo(LOCALE_NAME_USER_DEFAULT, LOCALE_SNAME, lcCountry, 256)) {
 		langRegion = ConvertWStringToUTF8(lcCountry);
-		for (int i = 0; i < langRegion.size(); i++) {
+		for (size_t i = 0; i < langRegion.size(); i++) {
 			if (langRegion[i] == '-')
 				langRegion[i] = '_';
 		}


### PR DESCRIPTION
Might be causing slowdowns for @solarmystic.  I can't think of anything else.  This way will probably use less memory anyway, no reason to set it up if it's not used.

-[Unknown]
