### PR TITLE
Reset latch when latch is going to be updated,not in sceCtrlReadLatch.

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -109,6 +109,7 @@ void __CtrlUpdateLatch()
 		buttons &= CTRL_EMU_RAPIDFIRE_MASK;
 	}
 
+	memset(&latch, 0, sizeof(CtrlLatch));
 	u32 changed = buttons ^ ctrlOldButtons;
 	latch.btnMake |= buttons & changed;
 	latch.btnBreak |= ctrlOldButtons & changed;
@@ -498,7 +499,9 @@ u32 sceCtrlReadLatch(u32 latchDataPtr)
 	if (Memory::IsValidAddress(latchDataPtr))
 		Memory::WriteStruct(latchDataPtr, &latch);
 
-	return __CtrlResetLatch();
+	int oldBufs = ctrlLatchBufs;
+	ctrlLatchBufs = 0;
+	return oldBufs;
 }
 
 static const HLEFunction sceCtrl[] = 


### PR DESCRIPTION
Fix Osk issue in Gintama no Sugoroku.
