### PR TITLE
OSK overhaul: Adjust button functionality, and some text positioning.

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -256,6 +256,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 	selectedChar = 0;
 	currentKeyboard = OSK_KEYBOARD_LATIN_LOWERCASE;
+	currentKeyboardLanguage = OSK_LANGUAGE_ENGLISH;
 
 	ConvertUCS2ToUTF8(oskDesc, oskParams->fields[0].desc);
 	ConvertUCS2ToUTF8(oskIntext, oskParams->fields[0].intext);
@@ -866,22 +867,27 @@ int PSPOskDialog::Update()
 		if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE)
 		{
 			PPGeDrawImage(I_CROSS, 30, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-			PPGeDrawImage(I_CIRCLE, 150, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+			PPGeDrawImage(I_CIRCLE, 30, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 		}
 		else
 		{
 			PPGeDrawImage(I_CIRCLE, 30, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-			PPGeDrawImage(I_CROSS, 150, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+			PPGeDrawImage(I_CROSS, 30, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 		}
 
 		I18NCategory *d = GetI18NCategory("Dialog");
 		PPGeDrawText(d->T("Select"), 60, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T("Delete"), 180, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText("Start", 245, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T("Finish"), 290, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText("Select", 365, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		// TODO: Show title of next keyboard?
-		PPGeDrawText(d->T("Shift"), 415, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("Delete"), 60, 245, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
+		PPGeDrawText("Start", 195, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("Finish"), 235, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
+		PPGeDrawText("Select", 195, 245, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("Shift"), 240, 250, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
+		PPGeDrawText(d->T("R"), 300, 245, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T(OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str()), 325, 245, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
 
 		if (IsButtonPressed(CTRL_UP))
 		{
@@ -912,8 +918,12 @@ int PSPOskDialog::Update()
 		}
 		else if (IsButtonPressed(CTRL_SELECT))
 		{
-			// TODO: Limit by allowed keyboards...
-			currentKeyboard = (OskKeyboardDisplay)((currentKeyboard + 1) % OSK_KEYBOARD_COUNT);
+			// Select now swaps case.
+			
+			if (currentKeyboard == OskKeyboardCases[currentKeyboardLanguage][UPPERCASE])
+				currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][LOWERCASE];
+			else
+				currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][UPPERCASE];
 
 			if(selectedRow >= numKeyRows[currentKeyboard])
 			{
@@ -921,6 +931,24 @@ int PSPOskDialog::Update()
 			}
 
 			if(selectedExtra >= numKeyCols[currentKeyboard])
+			{
+				selectedExtra = numKeyCols[currentKeyboard] - 1;
+			}
+
+			selectedChar = selectedRow * numKeyCols[currentKeyboard] + selectedExtra;
+		}
+		else if (IsButtonPressed(CTRL_RTRIGGER))
+		{
+			// RTRIGGER now swaps languages.
+			currentKeyboardLanguage = (OskKeyboardLanguage)((currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT);
+			currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][LOWERCASE];
+
+			if (selectedRow >= numKeyRows[currentKeyboard])
+			{
+				selectedRow = numKeyRows[currentKeyboard] - 1;
+			}
+
+			if (selectedExtra >= numKeyCols[currentKeyboard])
 			{
 				selectedExtra = numKeyCols[currentKeyboard] - 1;
 			}

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -891,15 +891,30 @@ int PSPOskDialog::Update()
 		PPGeDrawText("Select", 195, 245, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawText(d->T("Shift"), 240, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
-		PPGeDrawText(d->T("R"), 300, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		int index = (currentKeyboardLanguage - 1) % OSK_LANGUAGE_COUNT;
+		const char *countryCode;
 
-		const char *countryCode = OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str();
+		if (index >= 0)
+			countryCode = OskKeyboardNames[(currentKeyboardLanguage - 1) % OSK_LANGUAGE_COUNT].c_str();
+		else
+			countryCode = OskKeyboardNames[OSK_LANGUAGE_COUNT - 1].c_str();
+
 		const char *language = languageMapping[countryCode].first.c_str();
 
 		if (!strcmp(countryCode, "English Full-width"))
 			language = "English Full-width";
 
-		PPGeDrawText(language, 315, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("L", 300, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(language, 315, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
+		countryCode = OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str();
+		language = languageMapping[countryCode].first.c_str();
+
+		if (!strcmp(countryCode, "English Full-width"))
+			language = "English Full-width";
+
+		PPGeDrawText("R", 300, 244, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(language, 315, 244, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));	
 
 		if (IsButtonPressed(CTRL_UP))
 		{
@@ -950,8 +965,30 @@ int PSPOskDialog::Update()
 		}
 		else if (IsButtonPressed(CTRL_RTRIGGER))
 		{
-			// RTRIGGER now swaps languages.
+			// RTRIGGER now cycles languages forward.
 			currentKeyboardLanguage = (OskKeyboardLanguage)((currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT);
+			currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][LOWERCASE];
+
+			if (selectedRow >= numKeyRows[currentKeyboard])
+			{
+				selectedRow = numKeyRows[currentKeyboard] - 1;
+			}
+
+			if (selectedExtra >= numKeyCols[currentKeyboard])
+			{
+				selectedExtra = numKeyCols[currentKeyboard] - 1;
+			}
+
+			selectedChar = selectedRow * numKeyCols[currentKeyboard] + selectedExtra;
+		}
+		else if (IsButtonPressed(CTRL_LTRIGGER))
+		{
+			// LTRIGGER now cycles languages backward.
+			if (currentKeyboardLanguage - 1 >= 0)
+				currentKeyboardLanguage = (OskKeyboardLanguage)((currentKeyboardLanguage - 1) % OSK_LANGUAGE_COUNT);
+			else
+				currentKeyboardLanguage = (OskKeyboardLanguage)(OSK_LANGUAGE_COUNT - 1);
+
 			currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][LOWERCASE];
 
 			if (selectedRow >= numKeyRows[currentKeyboard])

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -883,11 +883,10 @@ int PSPOskDialog::Update()
 		PPGeDrawText(d->T("Finish"), 235, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 		PPGeDrawText("Select", 195, 245, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T("Shift"), 240, 250, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T("Shift"), 240, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
-		PPGeDrawText(d->T("R"), 300, 245, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T(OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str()), 325, 245, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-
+		PPGeDrawText(d->T("R"), 300, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(d->T(OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str()), 315, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 		if (IsButtonPressed(CTRL_UP))
 		{
@@ -919,7 +918,6 @@ int PSPOskDialog::Update()
 		else if (IsButtonPressed(CTRL_SELECT))
 		{
 			// Select now swaps case.
-			
 			if (currentKeyboard == OskKeyboardCases[currentKeyboardLanguage][UPPERCASE])
 				currentKeyboard = OskKeyboardCases[currentKeyboardLanguage][LOWERCASE];
 			else

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -36,6 +36,10 @@
 #include <math.h>
 #endif
 
+extern std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();
+
+static std::map<std::string, std::pair<std::string, int>> languageMapping;
+
 const int numKeyCols[OSK_KEYBOARD_COUNT] = {12, 12, 13, 13, 12, 12, 12, 12, 12};
 const int numKeyRows[OSK_KEYBOARD_COUNT] = {4, 4, 5, 5, 5, 4, 4, 4, 4};
 
@@ -272,6 +276,8 @@ int PSPOskDialog::Init(u32 oskPtr)
 		while ((c = *src++) != 0)
 			inputChars += c;
 	}
+
+	languageMapping = GetLangValuesMapping();
 
 	// Eat any keys pressed before the dialog inited.
 	__CtrlReadLatch();
@@ -886,7 +892,14 @@ int PSPOskDialog::Update()
 		PPGeDrawText(d->T("Shift"), 240, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 		PPGeDrawText(d->T("R"), 300, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(d->T(OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str()), 315, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
+		const char *countryCode = OskKeyboardNames[(currentKeyboardLanguage + 1) % OSK_LANGUAGE_COUNT].c_str();
+		const char *language = languageMapping[countryCode].first.c_str();
+
+		if (!strcmp(countryCode, "English Full-width"))
+			language = "English Full-width";
+
+		PPGeDrawText(language, 315, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 		if (IsButtonPressed(CTRL_UP))
 		{

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -193,10 +193,10 @@ const OskKeyboardDisplay OskKeyboardCases[OSK_LANGUAGE_COUNT][2] =
 
 static const std::string OskKeyboardNames[] =
 {
-	"English",
-	"Japanese",
-	"Korean",
-	"Russian",
+	"en_US",
+	"ja_JP",
+	"ko_KR",
+	"ru_RU",
 	"English Full-width",
 };
 

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -164,6 +164,40 @@ enum OskKeyboardDisplay
 	OSK_KEYBOARD_COUNT
 };
 
+// Internal enum, not from PSP.
+enum OskKeyboardLanguage
+{
+	OSK_LANGUAGE_ENGLISH, //English half-width
+	OSK_LANGUAGE_JAPANESE,
+	OSK_LANGUAGE_KOREAN,
+	OSK_LANGUAGE_RUSSIAN,
+	OSK_LANGUAGE_ENGLISH_FW, //English full-width(mostly used in Japanese games)
+	OSK_LANGUAGE_COUNT
+};
+
+// Internal enum, not from PSP.
+enum { 
+	LOWERCASE, 
+	UPPERCASE 
+};
+
+const OskKeyboardDisplay OskKeyboardCases[OSK_LANGUAGE_COUNT][2] =
+{
+	{ OSK_KEYBOARD_LATIN_LOWERCASE, OSK_KEYBOARD_LATIN_UPPERCASE },
+	{ OSK_KEYBOARD_HIRAGANA, OSK_KEYBOARD_KATAKANA },
+	{ OSK_KEYBOARD_KOREAN, OSK_KEYBOARD_KOREAN }, // Korean only has one case, so just repeat it.
+	{ OSK_KEYBOARD_RUSSIAN_LOWERCASE, OSK_KEYBOARD_RUSSIAN_UPPERCASE },
+	{ OSK_KEYBOARD_LATIN_FW_LOWERCASE, OSK_KEYBOARD_LATIN_FW_UPPERCASE }
+};
+
+static const std::string OskKeyboardNames[] = {
+	"English",
+	"Japanese",
+	"Korean",
+	"Russian",
+	"English Full-width",
+};
+
 
 class PSPOskDialog: public PSPDialog {
 public:
@@ -199,6 +233,7 @@ private:
 	int selectedChar;
 	std::wstring inputChars;
 	OskKeyboardDisplay currentKeyboard;
+	OskKeyboardLanguage currentKeyboardLanguage;
 	bool isCombinated;
 
 	int i_level; // for Korean Keyboard support

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -176,7 +176,8 @@ enum OskKeyboardLanguage
 };
 
 // Internal enum, not from PSP.
-enum { 
+enum
+{ 
 	LOWERCASE, 
 	UPPERCASE 
 };
@@ -190,14 +191,14 @@ const OskKeyboardDisplay OskKeyboardCases[OSK_LANGUAGE_COUNT][2] =
 	{ OSK_KEYBOARD_LATIN_FW_LOWERCASE, OSK_KEYBOARD_LATIN_FW_UPPERCASE }
 };
 
-static const std::string OskKeyboardNames[] = {
+static const std::string OskKeyboardNames[] =
+{
 	"English",
 	"Japanese",
 	"Korean",
 	"Russian",
 	"English Full-width",
 };
-
 
 class PSPOskDialog: public PSPDialog {
 public:


### PR DESCRIPTION
This pullrq makes the OSK much, much more convenient to use in the following ways:
- Makes select function as a real shift button(meaning it swaps upper/lowercase)
- Makes the R trigger cycle forward through all available keyboard languages
- Makes the L trigger cycle backward through all available keyboard languages
- Moves text around so it looks better
- Makes tasks like https://github.com/hrydgard/ppsspp/issues/3915 far easier(via the select button functionality change)

![Screenshot 01](http://i.minus.com/ibiIh99KnmGQy3.jpg)
