### PR TITLE
Fix headless.

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -33,6 +33,8 @@
 #include "../Dialog/PSPOskDialog.h"
 #include "../Dialog/PSPGamedataInstallDialog.h"
 
+#include "../native/file/ini_file.h"
+
 const int SCE_ERROR_MODULE_BAD_ID = 0x80111101;
 const int SCE_ERROR_MODULE_ALREADY_LOADED = 0x80111102;
 const int SCE_ERROR_MODULE_NOT_LOADED = 0x80111103;
@@ -812,3 +814,42 @@ void Register_sceUtility()
 {
 	RegisterModule("sceUtility", ARRAY_SIZE(sceUtility), sceUtility);
 }
+
+std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
+	std::map<std::string, std::pair<std::string, int>> langValuesMapping;
+	IniFile mapping;
+	mapping.LoadFromVFS("langregion.ini");
+	std::vector<std::string> keys;
+	mapping.GetKeys("LangRegionNames", keys);
+
+
+	std::map<std::string, int> langCodeMapping;
+	langCodeMapping["JAPANESE"] = PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
+	langCodeMapping["ENGLISH"] = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+	langCodeMapping["FRENCH"] = PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
+	langCodeMapping["SPANISH"] = PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
+	langCodeMapping["GERMAN"] = PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
+	langCodeMapping["ITALIAN"] = PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
+	langCodeMapping["DUTCH"] = PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
+	langCodeMapping["PORTUGUESE"] = PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
+	langCodeMapping["RUSSIAN"] = PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
+	langCodeMapping["KOREAN"] = PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
+	langCodeMapping["CHINESE_TRADITIONAL"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
+	langCodeMapping["CHINESE_SIMPLIFIED"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
+
+	IniFile::Section *langRegionNames = mapping.GetOrCreateSection("LangRegionNames");
+	IniFile::Section *systemLanguage = mapping.GetOrCreateSection("SystemLanguage");
+
+	for (size_t i = 0; i < keys.size(); i++) {
+		std::string langName;
+		langRegionNames->Get(keys[i].c_str(), &langName, "ERROR");
+		std::string langCode;
+		systemLanguage->Get(keys[i].c_str(), &langCode, "ENGLISH");
+		int iLangCode = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+		if (langCodeMapping.find(langCode) != langCodeMapping.end())
+			iLangCode = langCodeMapping[langCode];
+		langValuesMapping[keys[i]] = std::make_pair(langName, iLangCode);
+	}
+	return langValuesMapping;
+}
+

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -81,3 +81,4 @@ void __UtilityDoState(PointerWrap &p);
 void __UtilityShutdown();
 
 void Register_sceUtility();
+std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -42,7 +42,6 @@
 #pragma execution_character_set("utf-8")
 #endif
 
-
 #include "base/timeutil.h"
 #include "base/colorutil.h"
 #include "gfx_es2/draw_buffer.h"
@@ -93,44 +92,6 @@ void DrawBackground(float alpha) {
 		int n = i & 3;
 		ui_draw2d.DrawImageRotated(symbols[n], x, y, 1.0f, angle, colorAlpha(colors[n], alpha * 0.1f));
 	}
-}
-
-std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
-	std::map<std::string, std::pair<std::string, int>> langValuesMapping;
-	IniFile mapping;
-	mapping.LoadFromVFS("langregion.ini");
-	std::vector<std::string> keys;
-	mapping.GetKeys("LangRegionNames", keys);
-
-
-	std::map<std::string, int> langCodeMapping;
-	langCodeMapping["JAPANESE"] = PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
-	langCodeMapping["ENGLISH"] = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
-	langCodeMapping["FRENCH"] = PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
-	langCodeMapping["SPANISH"] = PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
-	langCodeMapping["GERMAN"] = PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
-	langCodeMapping["ITALIAN"] = PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
-	langCodeMapping["DUTCH"] = PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
-	langCodeMapping["PORTUGUESE"] = PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
-	langCodeMapping["RUSSIAN"] = PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
-	langCodeMapping["KOREAN"] = PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
-	langCodeMapping["CHINESE_TRADITIONAL"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
-	langCodeMapping["CHINESE_SIMPLIFIED"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
-
-	IniFile::Section *langRegionNames = mapping.GetOrCreateSection("LangRegionNames");
-	IniFile::Section *systemLanguage = mapping.GetOrCreateSection("SystemLanguage");
-
-	for (size_t i = 0; i < keys.size(); i++) {
-		std::string langName;
-		langRegionNames->Get(keys[i].c_str(), &langName, "ERROR");
-		std::string langCode;
-		systemLanguage->Get(keys[i].c_str(), &langCode, "ENGLISH");
-		int iLangCode = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
-		if (langCodeMapping.find(langCode) != langCodeMapping.end())
-			iLangCode = langCodeMapping[langCode];
-		langValuesMapping[keys[i]] = std::make_pair(langName, iLangCode);
-	}
-	return langValuesMapping;
 }
 
 void UIScreenWithBackground::DrawBackground(UIContext &dc) {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -91,8 +91,6 @@ extern InputState input_state;
 #define HID_USAGE_GENERIC_MOUSE        ((USHORT) 0x02)
 #endif
 
-extern std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();
-
 namespace MainWindow
 {
 	HWND hwndMain;


### PR DESCRIPTION
Move GetLangValuesMapping out of MiscScreens.cpp so it can be used globally.

Thanks to @solarmystic for noticing(https://github.com/hrydgard/ppsspp/pull/3922#issuecomment-25127636).
