### PR TITLE
Win32: When games hang, don't deadlock with Stop, Reset, and Enable Cheats.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1093,12 +1093,8 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_STOP:
-					if (Core_IsStepping()) {
-						// If the current PC is on a breakpoint, disabling stepping doesn't work without
-						// explicitly skipping it
-						CBreakPoints::SetSkipFirst(currentMIPS->pc);
-						Core_EnableStepping(false);
-					}
+					Core_Stop();
+
 					NativeMessageReceived("stop", "");
 					Update();
 					break;
@@ -1111,8 +1107,13 @@ namespace MainWindow
 						Core_EnableStepping(false);
 					}
 
+					Core_EnableStepping(true);
+					Core_WaitInactive();
+					Core_EnableStepping(false);
+
 					NativeMessageReceived("reset", "");
 					break;
+
 				case ID_EMULATION_CHEATS:
 					g_Config.bEnableCheats = !g_Config.bEnableCheats;
 					osm.ShowOnOff(g->T("Cheats"), g_Config.bEnableCheats);
@@ -1123,6 +1124,10 @@ namespace MainWindow
 						CBreakPoints::SetSkipFirst(currentMIPS->pc);
 						Core_EnableStepping(false);
 					}
+
+					Core_EnableStepping(true);
+					Core_WaitInactive();
+					Core_EnableStepping(false);
 
 					NativeMessageReceived("reset", "");
 					break;


### PR DESCRIPTION
When games hang, the stop, reset, and enable cheat options don't stop/reset the game as they should. This addresses that. I did relatively thorough testing and it seems to work alright, for me at least. It shouldn't affect the Disassembler's breakpoint functionality either.

Should fix https://github.com/hrydgard/ppsspp/issues/3940. Big, big thanks to @unknownbrackets for helping me out.
