### PR TITLE
Win32 Deadlocks Part 2: Stop should do the same things Reset does.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -771,7 +771,7 @@ namespace MainWindow
 		DialogManager::AddDlg(memoryWindow[0]);
 	}
 
-	void StopEmulation() {
+	void WaitForCore() {
 		if (Core_IsStepping()) {
 			// If the current PC is on a breakpoint, disabling stepping doesn't work without
 			// explicitly skipping it
@@ -1106,31 +1106,20 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_STOP:
-					StopEmulation();
+					WaitForCore();
 					NativeMessageReceived("stop", "");
 					Update();
 					break;
 
 				case ID_EMULATION_RESET:
-					StopEmulation();
+					WaitForCore();
 					NativeMessageReceived("reset", "");
 					break;
 
 				case ID_EMULATION_CHEATS:
 					g_Config.bEnableCheats = !g_Config.bEnableCheats;
 					osm.ShowOnOff(g->T("Cheats"), g_Config.bEnableCheats);
-
-					if (Core_IsStepping()) {
-						// If the current PC is on a breakpoint, disabling stepping doesn't work without
-						// explicitly skipping it
-						CBreakPoints::SetSkipFirst(currentMIPS->pc);
-						Core_EnableStepping(false);
-					}
-
-					Core_EnableStepping(true);
-					Core_WaitInactive();
-					Core_EnableStepping(false);
-
+					WaitForCore();
 					NativeMessageReceived("reset", "");
 					break;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -771,6 +771,19 @@ namespace MainWindow
 		DialogManager::AddDlg(memoryWindow[0]);
 	}
 
+	void StopEmulation() {
+		if (Core_IsStepping()) {
+			// If the current PC is on a breakpoint, disabling stepping doesn't work without
+			// explicitly skipping it
+			CBreakPoints::SetSkipFirst(currentMIPS->pc);
+			Core_EnableStepping(false);
+		}
+
+		Core_EnableStepping(true);
+		Core_WaitInactive();
+		Core_EnableStepping(false);
+	}
+
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory) {
 		std::string fn;
 		std::string filter = "PSP ROMs (*.iso *.cso *.pbp *.elf)|*.pbp;*.elf;*.iso;*.cso;*.prx|All files (*.*)|*.*||";
@@ -1093,24 +1106,13 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_STOP:
-					Core_Stop();
-
+					StopEmulation();
 					NativeMessageReceived("stop", "");
 					Update();
 					break;
 
 				case ID_EMULATION_RESET:
-					if (Core_IsStepping()) {
-						// If the current PC is on a breakpoint, disabling stepping doesn't work without
-						// explicitly skipping it
-						CBreakPoints::SetSkipFirst(currentMIPS->pc);
-						Core_EnableStepping(false);
-					}
-
-					Core_EnableStepping(true);
-					Core_WaitInactive();
-					Core_EnableStepping(false);
-
+					StopEmulation();
 					NativeMessageReceived("reset", "");
 					break;
 


### PR DESCRIPTION
32-bit builds were having crashes with the changes I made yesterday. By unifying Stop and Reset's behaviours(except for the actual NativeMessageReceived calls), they should both work perfectly now. Many thanks to @vsub for testing.
