### PR TITLE
Add methods to grab the depth/stencil buffers too

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1380,6 +1380,7 @@ bool FramebufferManager::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 
 	if (!vfb) {
 		// If there's no vfb and we're drawing there, must be memory?
+		// TODO: Is the value 16-bit?  It seems to be.
 		buffer = GPUDebugBuffer(Memory::GetPointer(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
 		return true;
 	}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1342,8 +1342,7 @@ void FramebufferManager::Resized() {
 	resized_ = true;
 }
 
-bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer)
-{
+bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
 	u32 fb_address = (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8);
 	int fb_stride = gstate.fbwidth & 0x3C0;
 
@@ -1365,4 +1364,63 @@ bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer)
 	glReadPixels(0, 0, vfb->renderWidth, vfb->renderHeight, GL_RGBA, GL_UNSIGNED_BYTE, buffer.GetData());
 
 	return true;
+}
+
+bool FramebufferManager::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
+	u32 fb_address = (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8);
+	int fb_stride = gstate.fbwidth & 0x3C0;
+
+	u32 z_address = (gstate.zbptr & 0xFFFFFF) | ((gstate.zbwidth & 0xFF0000) << 8);
+	int z_stride = gstate.zbwidth & 0x3C0;
+
+	VirtualFramebuffer *vfb = currentRenderVfb_;
+	if (!vfb) {
+		vfb = GetVFBAt(fb_address);
+	}
+
+	if (!vfb) {
+		// If there's no vfb and we're drawing there, must be memory?
+		buffer = GPUDebugBuffer(Memory::GetPointer(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
+		return true;
+	}
+
+#ifndef USING_GLES2
+	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GPU_DBG_FORMAT_FLOAT, true);
+
+	fbo_bind_for_read(vfb->fbo);
+	glPixelStorei(GL_PACK_ALIGNMENT, 4);
+	glReadPixels(0, 0, vfb->renderWidth, vfb->renderHeight, GL_DEPTH_COMPONENT, GL_FLOAT, buffer.GetData());
+
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool FramebufferManager::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
+	u32 fb_address = (gstate.fbptr & 0xFFFFFF) | ((gstate.fbwidth & 0xFF0000) << 8);
+	int fb_stride = gstate.fbwidth & 0x3C0;
+
+	VirtualFramebuffer *vfb = currentRenderVfb_;
+	if (!vfb) {
+		vfb = GetVFBAt(fb_address);
+	}
+
+	if (!vfb) {
+		// If there's no vfb and we're drawing there, must be memory?
+		buffer = GPUDebugBuffer(Memory::GetPointer(fb_address), fb_stride, 512, GPU_DBG_FORMAT_8888);
+		return true;
+	}
+
+#ifndef USING_GLES2
+	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GPU_DBG_FORMAT_16BIT, true);
+
+	fbo_bind_for_read(vfb->fbo);
+	glPixelStorei(GL_PACK_ALIGNMENT, 2);
+	glReadPixels(0, 0, vfb->renderWidth, vfb->renderHeight, GL_STENCIL_INDEX, GL_UNSIGNED_SHORT, buffer.GetData());
+
+	return true;
+#else
+	return false;
+#endif
 }

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -171,6 +171,8 @@ public:
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
 
 	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
+	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
+	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 
 private:
 	void CompileDraw2DProgram();

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1519,6 +1519,14 @@ bool GLES_GPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
 	return framebufferManager_.GetCurrentFramebuffer(buffer);
 }
 
+bool GLES_GPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
+	return framebufferManager_.GetCurrentDepthbuffer(buffer);
+}
+
+bool GLES_GPU::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
+	return framebufferManager_.GetCurrentStencilbuffer(buffer);
+}
+
 bool GLES_GPU::GetCurrentTexture(GPUDebugBuffer &buffer) {
 	if (!gstate.isTextureMapEnabled()) {
 		return false;

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -67,6 +67,8 @@ public:
 	std::vector<FramebufferInfo> GetFramebufferList();
 
 	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
+	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
+	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentTexture(GPUDebugBuffer &buffer);
 
 protected:

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -752,3 +752,18 @@ bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer)
 	buffer = GPUDebugBuffer(fb.data, gstate.FrameBufStride(), 512, gstate.FrameBufFormat());
 	return true;
 }
+
+bool SoftGPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer)
+{
+	// We don't know the height, so just use 512, which should be the max (hopefully?)
+	// TODO: Could check clipping and such, though...?
+	// TODO: Is the value 16-bit?  It seems to be.
+	buffer = GPUDebugBuffer(depthbuf.data, gstate.DepthBufStride(), 512, GPU_DBG_FORMAT_16BIT);
+	return true;
+}
+
+bool SoftGPU::GetCurrentStencilbuffer(GPUDebugBuffer &buffer)
+{
+	// TODO: Just need the alpha value from the framebuffer...
+	return false;
+}

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -78,6 +78,14 @@ public:
 		// TODO
 		return false;
 	}
+	virtual bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
+		// TODO
+		return false;
+	}
+	virtual bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
+		// TODO
+		return false;
+	}
 
 protected:
 	virtual void FastRunLoop(DisplayList &list);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -74,15 +74,9 @@ public:
 	}
 
 	virtual bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
-	bool GetCurrentTexture(GPUDebugBuffer &buffer) {
-		// TODO
-		return false;
-	}
-	virtual bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
-		// TODO
-		return false;
-	}
-	virtual bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
+	virtual bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
+	virtual bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
+	virtual bool GetCurrentTexture(GPUDebugBuffer &buffer) {
 		// TODO
 		return false;
 	}

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -219,6 +219,9 @@ void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
 	if (fmt == FORMAT_8888) {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		glfmt = GL_UNSIGNED_BYTE;
+	} else if (fmt == FORMAT_FLOAT) {
+		glfmt = GL_FLOAT;
+		components = GL_RED;
 	} else {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
 		if (fmt == FORMAT_4444) {
@@ -228,6 +231,11 @@ void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
 		} else if (fmt == FORMAT_565) {
 			glfmt = GL_UNSIGNED_SHORT_5_6_5;
 			components = GL_RGB;
+		} else if (fmt == FORMAT_16BIT) {
+			glfmt = GL_UNSIGNED_SHORT;
+			components = GL_RED;
+		} else {
+			_dbg_assert_msg_(COMMON, false, "Invalid SimpleGLWindow format.");
 		}
 	}
 

--- a/Windows/GEDebugger/SimpleGLWindow.h
+++ b/Windows/GEDebugger/SimpleGLWindow.h
@@ -29,6 +29,9 @@ struct SimpleGLWindow {
 		FORMAT_5551 = 1,
 		FORMAT_4444 = 2,
 		FORMAT_8888 = 3,
+
+		FORMAT_FLOAT = 0x10,
+		FORMAT_16BIT = 0x11,
 	};
 
 	enum Flags {


### PR DESCRIPTION
Could probably use help here, I'm not sure if I'm doing it wrong or it's just that the games I tested had no values here (I seemed to just be getting 0s.)

The idea is there might be some toggle to show stencil / depth for the framebuffer preview.  That would make it easier to check depth write issues, etc., I think.

It can be tested by changing this line:

```
    case PAUSE_GETFRAMEBUF:
        bufferResult = gpuDebug->GetCurrentFramebuffer(bufferFrame);
        break;
```

To `GetCurrentDepthbuffer()` or etc.

-[Unknown]
