### PR TITLE
Update PSPOskDialog.cpp

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -902,6 +902,8 @@ int PSPOskDialog::Update()
 		if (!strcmp(countryCode, "English Full-width"))
 			language = "English Full-width";
 		
+		countryCode = OskKeyboardNames[OSK_LANGUAGE_COUNT].c_str();
+		
 		if (strcmp(countryCode, "ko_KR"))
 		{
 			PPGeDrawText("Select", 195, 245, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));


### PR DESCRIPTION
A shift menu not to display changes only when the language is Korean.
(fix a some problems with previous commit)
