### PR TITLE
Don't use clamp on framebuffers on pre-HD ATI cards

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -867,11 +867,14 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 #ifdef USING_GLES2
 		PackFramebufferSync_(nvfb); // synchronous glReadPixels
 #else
+	if(gl_extensions.PBO_ARB || !gl_extensions.ATIClampBug)
+	{
 		if(!sync) {
 			PackFramebufferAsync_(nvfb); // asynchronous glReadPixels using PBOs
 		} else {
 			PackFramebufferSync_(nvfb); // synchronous glReadPixels
 		}
+	}
 #endif
 	}
 }

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -30,6 +30,7 @@
 #include "ext/xxhash.h"
 #include "math/math_util.h"
 #include "native/ext/cityhash/city.h"
+#include "native/gfx_es2/gl_state.h"
 
 #ifdef _M_SSE
 #include <xmmintrin.h>
@@ -510,13 +511,22 @@ void TextureCache::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, MagFiltGL[magFilt]);
 		entry.magFilt = magFilt;
 	}
-	if (force || entry.sClamp != sClamp) {
+	
+	//Workaround to fix a clamping bug in pre-HD ATI/AMD drivers
+	if (gl_extensions.ATIClampBug && entry.framebuffer)
+	{
+		return;
+	}
+	else
+	{
+		if (force || entry.sClamp != sClamp) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, sClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT);
 		entry.sClamp = sClamp;
-	}
-	if (force || entry.tClamp != tClamp) {
+		}
+		if (force || entry.tClamp != tClamp) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, tClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT);
 		entry.tClamp = tClamp;
+		}
 	}
 }
 


### PR DESCRIPTION
#3837
