### PR TITLE
Win32: Update the host UI to avoid an UI scaling issue after resetting settings.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -485,6 +485,8 @@ UI::EventReturn DeveloperToolsScreen::OnBack(UI::EventParams &e) {
 void DeveloperToolsScreen::CallbackRestoreDefaults(bool yes) {
 	if(yes)
 		g_Config.RestoreDefaults();
+
+	host->UpdateUI();
 }
 
 UI::EventReturn DeveloperToolsScreen::OnRestoreDefaultSettings(UI::EventParams &e) {


### PR DESCRIPTION
It caused a similar mouse event bug to the window sizing stuff, so just invalidate the window and such when we reset settings.
