### PR TITLE
Update PSPOskDialog.cpp

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -899,6 +899,8 @@ int PSPOskDialog::Update()
 
 		if (!strcmp(countryCode, "English Full-width"))
 			language = "English Full-width";
+			
+		countryCode = OskKeyboardNames[currentKeyboardLanguage].c_str();
 		
 		if (strcmp(countryCode, "ko_KR"))
 		{


### PR DESCRIPTION
A shift menu not to display changes only when the language is Korean.
(fix a some problems with previous commit)

I'm sorry, fixed it again.
