### PR TITLE
Avoid clearing some caches on save/load state

### DIFF
--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -115,6 +115,11 @@ public:
 	void InvalidateICache(u32 address, const u32 length);
 	void DestroyBlock(int block_num, bool invalidate);
 
+	// No jit operations may be run between these calls.
+	// Meant to be used to make memory safe for savestates, memcpy, etc.
+	std::vector<u32> SaveAndClearEmuHackOps();
+	void RestoreSavedEmuHackOps(std::vector<u32> saved);
+
 	int GetNumBlocks() const { return num_blocks; }
 
 private:

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1508,11 +1508,15 @@ std::vector<FramebufferInfo> GLES_GPU::GetFramebufferList()
 void GLES_GPU::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 
-	textureCache_.Clear(true);
-	transformDraw_.ClearTrackedVertexArrays();
+	// TODO: Some of these things may not be necessary.
+	// None of these are necessary when saving.
+	if (p.mode == p.MODE_READ) {
+		textureCache_.Clear(true);
+		transformDraw_.ClearTrackedVertexArrays();
 
-	gstate_c.textureChanged = true;
-	framebufferManager_.DestroyAllFBOs();
+		gstate_c.textureChanged = true;
+		framebufferManager_.DestroyAllFBOs();
+	}
 }
 
 bool GLES_GPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {


### PR DESCRIPTION
This should make loading and saving states faster.  A downside is that previously, saving state would clear the jit cache (possibly working around jit bugs), which it no longer does.

It will also require save/load state to clear FBO/texture caches (which I realize some people savestate to workaround texture cache issues.)  Loading state has that effect, still.

This also means saving state won't cause the display to blink.

With these changes, a "rewind" feature based on savestates becomes mostly possible.  I can only see it being practical on desktop, however, mostly due to memory requirements (and Snappy seems still too slow to run against such large data constantly.)

-[Unknown]
