### PR TITLE
Rehash textures a bit more often when static

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -869,14 +869,21 @@ void TextureCache::SetTexture(bool force) {
 
 		if (match) {
 			if (entry->lastFrame != gpuStats.numFlips) {
+				u32 diff = gpuStats.numFlips - entry->lastFrame;
 				entry->numFrames++;
-			}
-			if (entry->framesUntilNextFullHash == 0) {
-				// Exponential backoff up to 2048 frames.  Textures are often reused.
-				entry->framesUntilNextFullHash = std::min(2048, entry->numFrames);
-				rehash = true;
-			} else {
-				--entry->framesUntilNextFullHash;
+
+				if (entry->framesUntilNextFullHash < diff) {
+					// Exponential backoff up to 2048 frames.  Textures are often reused.
+					if (entry->numFrames > 32) {
+						// Also, try to add some "randomness" to avoid rehashing several textures the same frame.
+						entry->framesUntilNextFullHash = std::min(2048, entry->numFrames) + (entry->texture & 15);
+					} else {
+						entry->framesUntilNextFullHash = entry->numFrames;
+					}
+					rehash = true;
+				} else {
+					entry->framesUntilNextFullHash -= diff;
+				}
 			}
 
 			// If it's not huge or has been invalidated many times, recheck the whole texture.

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -873,10 +873,10 @@ void TextureCache::SetTexture(bool force) {
 				entry->numFrames++;
 
 				if (entry->framesUntilNextFullHash < diff) {
-					// Exponential backoff up to 2048 frames.  Textures are often reused.
+					// Exponential backoff up to 512 frames.  Textures are often reused.
 					if (entry->numFrames > 32) {
 						// Also, try to add some "randomness" to avoid rehashing several textures the same frame.
-						entry->framesUntilNextFullHash = std::min(2048, entry->numFrames) + (entry->texture & 15);
+						entry->framesUntilNextFullHash = std::min(512, entry->numFrames) + (entry->texture & 15);
 					} else {
 						entry->framesUntilNextFullHash = entry->numFrames;
 					}


### PR DESCRIPTION
This adjusts the frequency at which the texcache is rehashed, basically making it rehash more often for textures that aren't detected to have changed.

May hurt performance a bit in some cases.

Also fixes a bug where textures were rehashed too often if used in a certain way, which may improve performance in some games.  It's possible this could cause more temporary texcache artifacts in some cases, though.

And lastly, also tries to distribute full rehashes so they don't all hit in the same cycle.

-[Unknown]
