### PR TITLE
Implement sceDmacTryMemcpy(), improve sceDmacMemcpy()

### DIFF
--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -16,24 +16,30 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Globals.h"
+#include "Core/CoreTiming.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Core/HLE/HLE.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
-u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
-	if (size == 0) {
-		ERROR_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid size", dst, src, size);
-		return SCE_KERNEL_ERROR_INVALID_SIZE;
-	}
-	if (!Memory::IsValidAddress(dst) || !Memory::IsValidAddress(src)) {
-		ERROR_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid address", dst, src, size);
-		return SCE_KERNEL_ERROR_INVALID_POINTER;
+u64 dmacMemcpyDeadline;
+
+void __DmacInit() {
+	dmacMemcpyDeadline = 0;
+}
+
+void __DmacDoState(PointerWrap &p) {
+	auto s = p.Section("sceDmac", 0, 1);
+	if (s == 0) {
+		dmacMemcpyDeadline = 0;
+		return;
 	}
 
-	DEBUG_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
+	p.Do(dmacMemcpyDeadline);
+}
 
+int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 	Memory::Memcpy(dst, Memory::GetPointer(src), size);
 
 	src &= ~0x40000000;
@@ -45,9 +51,32 @@ u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
 	// This number seems strangely reproducible.
 	if (size >= 272) {
 		// Approx. 225 MiB/s or 235929600 B/s, so let's go with 236 B/us.
-		return hleDelayResult(0, "dmac copy", size / 236);
+		int delayUs = size / 236;
+		dmacMemcpyDeadline = CoreTiming::GetTicks() + usToCycles(delayUs);
+		return hleDelayResult(0, "dmac copy", delayUs);
 	}
 	return 0;
+}
+
+u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
+	if (size == 0) {
+		ERROR_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid size", dst, src, size);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	}
+	if (!Memory::IsValidAddress(dst) || !Memory::IsValidAddress(src)) {
+		ERROR_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid address", dst, src, size);
+		return SCE_KERNEL_ERROR_INVALID_POINTER;
+	}
+
+	if (dmacMemcpyDeadline > CoreTiming::GetTicks()) {
+		WARN_LOG_REPORT(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): overlapping read", dst, src, size);
+		// TODO: Should block, seems like copy doesn't start until previous finishes.
+		// Might matter for overlapping copies.
+	} else {
+		DEBUG_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
+	}
+
+	return __DmacMemcpy(dst, src, size);
 }
 
 u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
@@ -60,22 +89,14 @@ u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
 	}
 
-	DEBUG_LOG(HLE, "sceDmacTryMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
-
-	Memory::Memcpy(dst, Memory::GetPointer(src), size);
-
-	src &= ~0x40000000;
-	dst &= ~0x40000000;
-	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
-		gpu->UpdateMemory(dst, src, size);
+	if (dmacMemcpyDeadline > CoreTiming::GetTicks()) {
+		DEBUG_LOG(HLE, "sceDmacTryMemcpy(dest=%08x, src=%08x, size=%i): busy", dst, src, size);
+		return SCE_KERNEL_ERROR_BUSY;
+	} else {
+		DEBUG_LOG(HLE, "sceDmacTryMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
 	}
 
-	// This number seems strangely reproducible.
-	if (size >= 272) {
-		// Approx. 225 MiB/s or 235929600 B/s, so let's go with 236 B/us.
-		return hleDelayResult(0, "dmac copy", size / 236);
-	}
-	return 0;
+	return __DmacMemcpy(dst, src, size);
 }
 
 const HLEFunction sceDmac[] = {

--- a/Core/HLE/sceDmac.h
+++ b/Core/HLE/sceDmac.h
@@ -17,4 +17,9 @@
 
 #pragma once
 
+class PointerWrap;
+
+void __DmacInit();
+void __DmacDoState(PointerWrap &p);
+
 void Register_sceDmac();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -203,7 +203,7 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 	// Check alignment
 	// TODO Check the context and stack alignement too
 	if (((listpc | stall) & 3) != 0)
-		return 0x80000103;
+		return SCE_KERNEL_ERROR_INVALID_POINTER;
 
 	int id = -1;
 	bool oldCompatibility = true;


### PR DESCRIPTION
This mostly adds errors and rescheduling.

Doesn't actually block properly when two threads run a sceDmacMemcpy() at the same time, which doesn't really matter since in our implementation both complete "immediately."  Theoretically, they could be done asynchronously on e.g. the GPU thread.

While looking into this, I looked into the VRAM mirrors.  It seems like +6MB is a direct mirror of +0MB, and +2 and +4 are swizzled/interleaved in different ways.  CPU access with fastmem off will use one slice of 2MB VRAM for all four mirrors, and most things use GetPointer() so they'll be the same... except CLUT reads.

With this, the test passes.

-[Unknown]
