### PR TITLE
Swap render targets when drawing spline/beziers

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -738,6 +738,13 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 	// The arrow and other rotary items in Puzbob are bezier patches, strangely enough.
 	case GE_CMD_BEZIER:
 		{
+			// This also make skipping drawing very effective.
+			framebufferManager_.SetRenderFrameBuffer();
+			if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
+				// TODO: Should this eat some cycles?  Probably yes.  Not sure if important.
+				return;
+			}
+
 			if (!Memory::IsValidAddress(gstate_c.vertexAddr)) {
 				ERROR_LOG_REPORT(G3D, "Bad vertex address %08x!", gstate_c.vertexAddr);
 				break;
@@ -774,6 +781,13 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_SPLINE:
 		{
+			// This also make skipping drawing very effective.
+			framebufferManager_.SetRenderFrameBuffer();
+			if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
+				// TODO: Should this eat some cycles?  Probably yes.  Not sure if important.
+				return;
+			}
+
 			if (!Memory::IsValidAddress(gstate_c.vertexAddr)) {
 				ERROR_LOG_REPORT(G3D, "Bad vertex address %08x!", gstate_c.vertexAddr);
 				break;


### PR DESCRIPTION
Jeanne d'Arc draws to some framebuffers entirely using beziers, so without this it'll never switch.  I was kinda puzzled looking at the GE debugger, then the display list, then the GE debugger... until I realized it just wasn't even checking, heh.

Alone, this doesn't take care of #1283, it's only half of the problem.  But, it's definitely correct anyway.  It could affect other games that use beziers heavily.

I also made it frameskip bezier/spline as it does other prims... I assume this is the right way.

-[Unknown]
