### PR TITLE
Don't leave a gray box behind in the Recents list when a game is deleted.

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -40,10 +40,16 @@ bool GameInfo::DeleteGame() {
 	switch (fileType) {
 	case FILETYPE_PSP_ISO:
 	case FILETYPE_PSP_ISO_NP:
-		// Just delete the one file (TODO: handle two-disk games as well somehow).
-		deleteFile(fileInfo.fullName.c_str());
-		return true;
-
+		{
+			// Just delete the one file (TODO: handle two-disk games as well somehow).
+			const char *fileToRemove = fileInfo.fullName.c_str();
+			deleteFile(fileToRemove);
+			auto i = std::find(g_Config.recentIsos.begin(), g_Config.recentIsos.end(), fileToRemove);
+			if (i != g_Config.recentIsos.end()) {
+				g_Config.recentIsos.erase(i);
+			}
+			return true;
+		}
 	case FILETYPE_PSP_PBP_DIRECTORY:
 		// Recursively deleting directories not yet supported
 		return false;


### PR DESCRIPTION
When a game is deleted via the GameScreen, remove it from g_Config.recentIsos if applicable, so that the UI doesn't draw a gray rectangle which can't be used to run anything anymore.
