### PR TITLE
Show more state values in the GE debugger

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -76,8 +76,8 @@ void Core_Halt(const char *msg)
 
 void Core_Stop()
 {
-	Core_NotifyShutdown();
 	Core_UpdateState(CORE_POWERDOWN);
+	Core_NotifyShutdown();
 	m_hStepEvent.notify_one();
 }
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -430,6 +430,7 @@ void __IoManagerThread() {
 
 void __IoWakeManager() {
 	ioManager.FinishEventLoop();
+	ioManager.SyncThread();
 }
 
 void __IoInit() {

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -354,7 +354,7 @@ bool WindowsHost::GPUDebuggingActive() {
 
 static void PauseWithMessage(UINT msg, WPARAM wParam = NULL, LPARAM lParam = NULL) {
 	lock_guard guard(pauseLock);
-	if (Core_IsInactive()) {
+	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME) {
 		return;
 	}
 

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -223,36 +223,30 @@ CtrlStateValues::CtrlStateValues(const TabStateRow *rows, int rowCount, HWND hwn
 }
 
 void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enabled, u32 otherValue, u32 otherValue2) {
-	const wchar_t *fmtString;
 	switch (info.fmt) {
 	case CMD_FMT_HEX:
-		fmtString = enabled ? L"%06x" : L"(%06x)";
-		swprintf(dest, fmtString, value);
+		swprintf(dest, L"%06x", value);
 		break;
 
 	case CMD_FMT_NUM:
-		fmtString = enabled ? L"%d" : L"(%d)";
-		swprintf(dest, fmtString, value);
+		swprintf(dest, L"%d", value);
 		break;
 
 	case CMD_FMT_FLOAT24:
-		fmtString = enabled ? L"%f" : L"(%f)";
-		swprintf(dest, fmtString, getFloat24(value));
+		swprintf(dest, L"%f", getFloat24(value));
 		break;
 
 	case CMD_FMT_PTRWIDTH:
 		value |= (otherValue & 0x00FF0000) << 8;
 		otherValue &= 0xFFFF;
-		fmtString = enabled ? L"%08x, w=%d" : L"(%08x, w=%d)";
-		swprintf(dest, fmtString, value, otherValue);
+		swprintf(dest, L"%08x, w=%d", value, otherValue);
 		break;
 
 	case CMD_FMT_XY:
 		{
 			int x = value & 0x3FF;
 			int y = value >> 10;
-			fmtString = enabled ? L"%d,%d" : L"(%d,%d)";
-			swprintf(dest, fmtString, x, y);
+			swprintf(dest, L"%d,%d", x, y);
 		}
 		break;
 
@@ -262,8 +256,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			int y1 = value >> 10;
 			int x2 = otherValue & 0x3FF;
 			int y2 = otherValue >> 10;
-			fmtString = enabled ? L"%d,%d - %d,%d" : L"(%d,%d - %d,%d)";
-			swprintf(dest, fmtString, x1, y1, x2, y2);
+			swprintf(dest, L"%d,%d - %d,%d", x1, y1, x2, y2);
 		}
 		break;
 
@@ -272,8 +265,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			float x = getFloat24(value);
 			float y = getFloat24(otherValue);
 			float z = getFloat24(otherValue2);
-			fmtString = enabled ? L"%f, %f, %f" : L"(%f, %f, %f)";
-			swprintf(dest, fmtString, x, y, z);
+			swprintf(dest, L"%f, %f, %f", x, y, z);
 		}
 		break;
 
@@ -281,8 +273,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 		{
 			int w = 1 << (value & 0x1f);
 			int h = 1 << ((value >> 8) & 0x1f);
-			fmtString = enabled ? L"%dx%d" : L"(%dx%d)";
-			swprintf(dest, fmtString, w, h);
+			swprintf(dest, L"%dx%d", w, h);
 		}
 		break;
 
@@ -290,8 +281,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 		{
 			float x = (float)value / 16.0f;
 			float y = (float)otherValue / 16.0f;
-			fmtString = enabled ? L"%fx%f" : L"(%fx%f)";
-			swprintf(dest, fmtString, x, y);
+			swprintf(dest, L"%fx%f", x, y);
 		}
 		break;
 
@@ -305,6 +295,11 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 
 	default:
 		swprintf(dest, L"BAD FORMAT %08x (%d)", value, enabled);
+	}
+
+	// TODO: Turn row grey or some such?
+	if (!enabled) {
+		wcscat(dest, L" (disabled)");
 	}
 }
 

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -43,6 +43,7 @@ enum CmdFormatType {
 	CMD_FMT_TEXSIZE,
 	CMD_FMT_F16_XY,
 	CMD_FMT_VERTEXTYPE,
+	CMD_FMT_TEXFMT,
 };
 
 struct TabStateRow {
@@ -137,7 +138,7 @@ static const TabStateRow stateTextureRows[] = {
 	{ L"Tex mapping mode",     GE_CMD_TEXMAPMODE,              CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
 	{ L"Tex shade srcs",       GE_CMD_TEXSHADELS,              CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
 	{ L"Tex mode",             GE_CMD_TEXMODE,                 CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
-	{ L"Tex format",           GE_CMD_TEXFORMAT,               CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
+	{ L"Tex format",           GE_CMD_TEXFORMAT,               CMD_FMT_TEXFMT, GE_CMD_TEXTUREMAPENABLE },
 	{ L"Tex filtering",        GE_CMD_TEXFILTER,               CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
 	{ L"Tex wrapping",         GE_CMD_TEXWRAP,                 CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
 	{ L"Tex level/bias",       GE_CMD_TEXLEVEL,                CMD_FMT_HEX, GE_CMD_TEXTUREMAPENABLE },
@@ -166,7 +167,7 @@ static const TabStateRow stateTextureRows[] = {
 // TODO: Many of these could use better display formats.
 static const TabStateRow stateSettingsRows[] = {
 	{ L"Framebuffer",          GE_CMD_FRAMEBUFPTR,             CMD_FMT_PTRWIDTH, 0, GE_CMD_FRAMEBUFWIDTH },
-	{ L"Framebuffer format",   GE_CMD_FRAMEBUFPIXFORMAT,       CMD_FMT_NUM },
+	{ L"Framebuffer format",   GE_CMD_FRAMEBUFPIXFORMAT,       CMD_FMT_TEXFMT },
 	{ L"Depthbuffer",          GE_CMD_ZBUFPTR,                 CMD_FMT_PTRWIDTH, 0, GE_CMD_ZBUFWIDTH },
 	{ L"Vertex type",          GE_CMD_VERTEXTYPE,              CMD_FMT_VERTEXTYPE },
 	{ L"Region",               GE_CMD_REGION1,                 CMD_FMT_XYXY, 0, GE_CMD_REGION2 },
@@ -293,8 +294,31 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 		}
 		break;
 
+	case CMD_FMT_TEXFMT:
+		{
+			const char *texformats[] = {
+				"5650",
+				"5551",
+				"4444",
+				"8888",
+				"CLUT4",
+				"CLUT8",
+				"CLUT16",
+				"CLUT32",
+				"DXT1",
+				"DXT3",
+				"DXT5",
+			};
+			if (value < (u32)ARRAY_SIZE(texformats)) {
+				swprintf(dest, L"%S", texformats[value]);
+			} else {
+				swprintf(dest, L"%06x", value);
+			}
+		}
+		break;
+
 	default:
-		swprintf(dest, L"BAD FORMAT %08x (%d)", value, enabled);
+		swprintf(dest, L"BAD FORMAT %06x", value);
 	}
 
 	// TODO: Turn row grey or some such?


### PR DESCRIPTION
Now it shows most of them.  For non-statey ones I omitted them, not sure what to do.

Also cleans up some remaining issues shutting down while things are running/paused (io thread, ge debugger.)

-[Unknown]
