### PR TITLE
Toggle display list breakpoints

### DIFF
--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -317,6 +317,9 @@ void CtrlDisplayListView::onKeyDown(WPARAM wParam, LPARAM lParam)
 	case VK_LEFT:
 		gotoAddr(list.pc);
 		return;
+	case VK_SPACE:
+		toggleBreakpoint();
+		break;
 	case VK_F10:
 	case VK_F11:
 		SendMessage(GetParent(wnd),WM_GEDBG_STEPDISPLAYLIST,0,0);

--- a/Windows/GEDebugger/CtrlDisplayListView.h
+++ b/Windows/GEDebugger/CtrlDisplayListView.h
@@ -26,6 +26,8 @@ class CtrlDisplayListView
 		int addressStart;
 		int opcodeStart;
 	} pixelPositions;
+
+	void toggleBreakpoint();
 public:
 	CtrlDisplayListView(HWND _wnd);
 	~CtrlDisplayListView();

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -66,6 +66,10 @@ void CGEDebugger::Init() {
 	CtrlDisplayListView::registerClass();
 }
 
+bool CGEDebugger::IsAddressBreakPoint(u32 pc) {
+	return breakPCs.find(pc) != breakPCs.end();
+}
+
 static void SetPauseAction(PauseAction act) {
 	{
 		lock_guard guard(pauseLock);
@@ -341,6 +345,19 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		breakNextOp = true;
 		breakNextDraw = false;
 		break;
+
+	case WM_GEDBG_TOGGLEPCBREAKPOINT:
+		{
+			// TODO: does this need mutexes?
+			u32 pc = wParam;
+			auto iter = breakPCs.find(pc);
+			if (iter != breakPCs.end())
+				breakPCs.erase(iter);
+			else
+				breakPCs.insert(pc);
+		}
+		break;
+
 	}
 
 	return FALSE;

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -28,6 +28,7 @@ enum {
 	WM_GEDBG_BREAK_CMD = WM_USER + 200,
 	WM_GEDBG_BREAK_DRAW,
 	WM_GEDBG_STEPDISPLAYLIST,
+	WM_GEDBG_TOGGLEPCBREAKPOINT
 };
 
 class CtrlDisplayListView;
@@ -43,6 +44,8 @@ public:
 	~CGEDebugger();
 
 	static void Init();
+
+	static bool IsAddressBreakPoint(u32 pc);
 protected:
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/Windows/GEDebugger/TabDisplayLists.cpp
+++ b/Windows/GEDebugger/TabDisplayLists.cpp
@@ -263,6 +263,11 @@ BOOL TabDisplayLists::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			displayList->gotoAddr(pc);
 		}
 		break;
+
+	case WM_GEDBG_TOGGLEPCBREAKPOINT:
+		SendMessage(GetParent(m_hDlg),message,wParam,lParam);
+		break;
+
 	}
 
 	return FALSE;


### PR DESCRIPTION
So far only through the display list viewer.
Minor issue: if a draw breaks on the position where there is also a PC breakpoint, then the latter is not skipped and also breaks.
