### PR TITLE
included <algorithm> to make sure all compilers find std::max 

### DIFF
--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -1,6 +1,7 @@
 ﻿#include "Windows/GEDebugger/CtrlDisplayListView.h"
 #include "Core/Config.h"
 #include "Windows/GEDebugger/GEDebugger.h"
+#include <algorithm>
 
 const PTCHAR CtrlDisplayListView::windowClass = _T("CtrlDisplayListView");
 


### PR DESCRIPTION
can't compile on VS 2013 preview otherwise. 
