### PR TITLE
Should be either or for blendFuncEq

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -243,7 +243,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		}
 #endif
 
-		if (blendFuncEq >= GE_BLENDMODE_MIN && gl_extensions.EXT_blend_minmax) {
+		if (blendFuncEq >= GE_BLENDMODE_MIN || gl_extensions.EXT_blend_minmax) {
 			glstate.blendEquation.set(eqLookup[blendFuncEq]);
 		} else {
 			glstate.blendEquation.set(eqLookupNoMinMax[blendFuncEq]);


### PR DESCRIPTION
I think blendFuncEq >= GE_BLENDMODE_MIN is for desktop which support GL_MIN/MAX natively while latter one is for mobile which support that extension ,so should be either or 
