### PR TITLE
Fixed a mismatched delete within PSPGamedataInstallDialog.cpp.

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -76,12 +76,12 @@ int PSPGamedataInstallDialog::Update() {
 		u64 totalLength;
 		u64 restLength;
 		u32 bytesToRead = 4096;
-		u8 *temp = new u8[4096];	
 		u32 inhandle;
 		u32 outhandle;	
 		size_t readSize;
 	
 		if (readFiles < numFiles) {
+			u8 *temp = new u8[4096];
 			fullinFileName = "disc0:/PSP_GAME/INSDIR/" + inFileNames[readFiles];
 			outFileName = GetGameDataInstallFileName(&request, inFileNames[readFiles]);
 			totalLength = pspFileSystem.GetFileInfo(fullinFileName).size;

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -108,7 +108,7 @@ int PSPGamedataInstallDialog::Update() {
 				pspFileSystem.CloseFile(inhandle);
 			}
 			updateProgress();
-			delete temp;
+			delete[] temp;
 		} else {
 			//What is this?
 			request.unknownResult1 = readFiles;

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -127,7 +127,7 @@ int sceHeapCreateHeap(const char* name, u32 heapSize, int attr, u32 paramsPtr) {
 		u32 size = Memory::Read_U32(paramsPtr);
 		WARN_LOG_REPORT(SCEKERNEL, "sceHeapCreateHeap(): unsupported options parameter, size = %d", size);
 	}	
-	if (name = NULL) {
+	if (name == NULL) {
 		WARN_LOG(SCEKERNEL,"sceHeapCreateHeap(): name is NULL");
 		return 0;
 	}


### PR DESCRIPTION
Should be delete[] since temp is an array allocated using new.
