### PR TITLE
Fix right click->edit breakpoint

### DIFF
--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -567,7 +567,7 @@ void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 			}
 			break;
 		case ID_DISASM_EDITBREAKPOINT:
-			editBreakpoint(index);
+			editBreakpoint(itemIndex);
 			break;
 		case ID_DISASM_ADDNEWBREAKPOINT:
 			{		


### PR DESCRIPTION
Wrong index variable caused this to edit the wrong breakpoint when there were both memory and execute breakpoint.
