### PR TITLE
Check e_ident of elf header

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -312,24 +312,22 @@ void ElfReader::LoadRelocations2(int rel_seg)
 }
 
 
-bool ElfReader::LoadInto(u32 loadAddress)
+int ElfReader::LoadInto(u32 loadAddress)
 {
 	DEBUG_LOG(LOADER,"String section: %i", header->e_shstrndx);
 
-	//TODO - Check header->e_ident here
-	//let's dump string section
-	/*
-	char *ptr = (char*)GetSectionDataPtr(header->e_shstrndx);
-	if (*ptr == 0)
-		ptr++;
-	ptr+=513;
-	while (*ptr != 0)
-	{
-		int len = strlen(ptr);
-		LOG(LOADER,"XX %s",ptr);
-		ptr+=len;
-		ptr++;
-	}*/
+	if (header->e_ident[0] != ELFMAG0 || header->e_ident[1] != ELFMAG1
+		|| header->e_ident[2] != ELFMAG2 || header->e_ident[3] != ELFMAG3)
+		return SCE_KERNEL_ERROR_UNSUPPORTED_PRX_TYPE;
+
+	// technically ELFCLASSNONE would freeze the system, but that's not really desireable
+	if (header->e_ident[EI_CLASS] != ELFCLASS32)
+		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
+
+	if (header->e_ident[EI_DATA] != ELFDATA2LSB)
+		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
+
+	// e_ident[EI_VERSION] is ignored
 
 	sectionOffsets = new u32[GetNumSections()];
 	sectionAddrs = new u32[GetNumSections()];
@@ -368,7 +366,7 @@ bool ElfReader::LoadInto(u32 loadAddress)
 
 	if (vaddr == (u32)-1) {
 		ERROR_LOG_REPORT(LOADER, "Failed to allocate memory for ELF!");
-		return false;
+		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
 	}
 	
 	if (bRelocate) {
@@ -514,7 +512,7 @@ bool ElfReader::LoadInto(u32 loadAddress)
 	}
 
 	NOTICE_LOG(LOADER,"ELF loading completed successfully.");
-	return true;
+	return SCE_KERNEL_ERROR_OK;
 }
 
 

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -133,7 +133,7 @@ public:
 	}
 
 	// More indepth stuff:)
-	bool LoadInto(u32 vaddr);
+	int LoadInto(u32 vaddr);
 	bool LoadSymbols();
 	void LoadRelocations(Elf32_Rel *rels, int numRelocs);
 	void LoadRelocations2(int rel_seg);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -736,8 +736,9 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 	// Open ELF reader
 	ElfReader reader((void*)ptr);
 
-	if (!reader.LoadInto(loadAddress)) 	{
-		ERROR_LOG(SCEMODULE, "LoadInto failed");
+	int result = reader.LoadInto(loadAddress);
+	if (result != SCE_KERNEL_ERROR_OK) 	{
+		ERROR_LOG(SCEMODULE, "LoadInto failed with error %08x",result);
 		if (newptr)
 			delete [] newptr;
 		module->Cleanup();


### PR DESCRIPTION
I tested this behavior on my PSP.

If the first 4 bytes aren't correct, it quits with an SCE_KERNEL_ERROR_UNSUPPORTED_PRX_TYPE error.
If EI_CLASS is 0, the system freezes. If it has values other than 0 or 1, it quits with an SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED error.
If EI_DATA isn't 1, it also quits with an SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED error.
The value of EI_VERSION doesn't seem to make any difference.
