### PR TITLE
Fix #3979 and #3883 in non-multithread mode 

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -524,7 +524,7 @@ void ForceCheck()
 	int cyclesExecuted = slicelength - currentMIPS->downcount;
 	globalTimer += cyclesExecuted;
 	// This will cause us to check for new events immediately.
-	currentMIPS->downcount = 0;
+	currentMIPS->downcount += 0;
 	// But let's not eat a bunch more time in Advance() because of this.
 	slicelength = 0;
 }


### PR DESCRIPTION
I reference it from here in advance()

currentMIPS->downcount += 10000;
