### PR TITLE
Don't try to load bogus isos, carnage awaits

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -192,16 +192,17 @@ ISOFileSystem::ISOFileSystem(IHandleAllocator *_hAlloc, BlockDevice *_blockDevic
 	entireISO.flags = 0;
 	entireISO.parent = NULL;
 
-	if (memcmp(desc.cd001, "CD001", 5)) {
-		ERROR_LOG(FILESYS, "ISO looks bogus? trying anyway...");
-	}
-
 	treeroot = new TreeEntry();
 	treeroot->isDirectory = true;
 	treeroot->startingPosition = 0;
 	treeroot->size = 0;
 	treeroot->flags = 0;
 	treeroot->parent = NULL;
+
+	if (memcmp(desc.cd001, "CD001", 5)) {
+		ERROR_LOG(FILESYS, "ISO looks bogus? Giving up...");
+		return;
+	}
 
 	u32 rootSector = desc.root.firstDataSector();
 	u32 rootSize = desc.root.dataLength();


### PR DESCRIPTION
@neobrain reported he ran into a problem with a bad iso.  I don't think there's any good reason for us to try to load a bogus iso, so this makes it just bail with an empty tree (it will say it can't find the executable.)

-[Unknown]
