### PR TITLE
Skip bounding box when set to 0

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -824,6 +824,12 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_BOUNDINGBOX:
+		// Just resetting, nothing to bound.
+		if (data == 0) {
+			// TODO: Should this set the bboxResult?  Let's set it true for now.
+			currentList->bboxResult = true;
+			break;
+		}
 		if ((data % 8 == 0) && data < 64) {  // Sanity check
 			void *control_points = Memory::GetPointer(gstate_c.vertexAddr);
 			if (gstate.vertType & GE_VTYPE_IDX_MASK) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -472,7 +472,8 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 
 			if (Memory::IsValidAddress(clutAddr)) {
 				Memory::MemcpyUnchecked(clut, clutAddr, clutTotalBytes);
-			} else {
+			// TODO: Do something to the CLUT with 0?
+			} else if (clutAddr != 0) {
 				// TODO: Does this make any sense?
 				ERROR_LOG_REPORT_ONCE(badClut, G3D, "Software: Invalid CLUT address, filling with garbage instead of crashing");
 				memset(clut, 0xFF, clutTotalBytes);


### PR DESCRIPTION
VectorTD does this, for example, and it seems innocent, just resetting all cmds.  Not sure what it should set the flag to, though.

Anyway, this prevents a getpointer error (and a stall when ignore is off.)

-[Unknown]
