### PR TITLE
GE debugger - fix some preview issues, softgpu stencil fix

### DIFF
--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -112,7 +112,9 @@ struct GPUDebugBuffer {
 		u32 pixelSize = 2;
 		if (fmt == GPU_DBG_FORMAT_8888 || fmt == GPU_DBG_FORMAT_FLOAT) {
 			pixelSize = 4;
-		};
+		} else if (fmt == GPU_DBG_FORMAT_8BIT) {
+			pixelSize = 1;
+		}
 
 		data_ = new u8[pixelSize * stride * height];
 	}

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1562,7 +1562,7 @@ bool GLES_GPU::GetCurrentTexture(GPUDebugBuffer &buffer) {
 	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
 	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
 
-	buffer.Allocate(w, h, GE_FORMAT_8888, false);
+	buffer.Allocate(w, h, GE_FORMAT_8888, gstate_c.flipTexture);
 	glPixelStorei(GL_PACK_ALIGNMENT, 4);
 	glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.GetData());
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -973,4 +973,25 @@ bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer)
 	return true;
 }
 
+bool GetCurrentTexture(GPUDebugBuffer &buffer)
+{
+	int w = gstate.getTextureWidth(0);
+	int h = gstate.getTextureHeight(0);
+	buffer.Allocate(w, h, GE_FORMAT_8888, false);
+
+	GETextureFormat texfmt = gstate.getTextureFormat();
+	u32 texaddr = gstate.getTextureAddress(0);
+	int texbufwidthbits = GetTextureBufw(0, texaddr, texfmt) * 8;
+	u8 *texptr = Memory::GetPointer(texaddr);
+
+	u32 *row = (u32 *)buffer.GetData();
+	for (int y = 0; y < h; ++y) {
+		for (int x = 0; x < w; ++x) {
+			row[x] = SampleNearest(0, x, y, texptr, texbufwidthbits);
+		}
+		row += w;
+	}
+	return true;
+}
+
 } // namespace

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -319,22 +319,33 @@ static inline u8 GetPixelStencil(int x, int y)
 	if (gstate.FrameBufFormat() == GE_FORMAT_565) {
 		// TODO: Should we return 0xFF instead here?
 		return 0;
-	} else if (gstate.FrameBufFormat() != GE_FORMAT_8888) {
+	} else if (gstate.FrameBufFormat() == GE_FORMAT_5551) {
 		return ((fb.Get16(x, y, gstate.FrameBufStride()) & 0x8000) != 0) ? 0xFF : 0;
+	} else if (gstate.FrameBufFormat() != GE_FORMAT_4444) {
+		return fb.Get16(x, y, gstate.FrameBufStride()) >> 12;
 	} else {
-		// TODO: Not the whole value?
-		return ((fb.Get32(x, y, gstate.FrameBufStride()) & 0x80000000) != 0) ? 0xFF : 0;
+		return fb.Get32(x, y, gstate.FrameBufStride()) >> 24;
 	}
 }
 
 static inline void SetPixelStencil(int x, int y, u8 value)
 {
+	// TODO: This seems like it maybe respects the alpha mask (at least in some scenarios?)
+
 	if (gstate.FrameBufFormat() == GE_FORMAT_565) {
 		// Do nothing
-	} else if (gstate.FrameBufFormat() != GE_FORMAT_8888) {
-		fb.Set16(x, y, gstate.FrameBufStride(), (fb.Get16(x, y, gstate.FrameBufStride()) & ~0x8000) | ((value&0x80)<<8));
+	} else if (gstate.FrameBufFormat() == GE_FORMAT_5551) {
+		u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & ~0x8000;
+		pixel |= value != 0 ? 0x8000 : 0;
+		fb.Set16(x, y, gstate.FrameBufStride(), pixel);
+	} else if (gstate.FrameBufFormat() != GE_FORMAT_4444) {
+		u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & ~0xF000;
+		pixel |= (u16)value << 12;
+		fb.Set16(x, y, gstate.FrameBufStride(), pixel);
 	} else {
-		fb.Set32(x, y, gstate.FrameBufStride(), (fb.Get32(x, y, gstate.FrameBufStride()) & ~0x80000000) | ((value&0x80)<<24));
+		u32 pixel = fb.Get32(x, y, gstate.FrameBufStride()) & ~0xFF000000;
+		pixel |= (u32)value << 24;
+		fb.Set32(x, y, gstate.FrameBufStride(), pixel);
 	}
 }
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -959,4 +959,18 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 	}
 }
 
+bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer)
+{
+	buffer.Allocate(gstate.DepthBufStride(), 512, GPU_DBG_FORMAT_8BIT);
+
+	u8 *row = buffer.GetData();
+	for (int y = 0; y < 512; ++y) {
+		for (int x = 0; x < gstate.DepthBufStride(); ++x) {
+			row[x] = GetPixelStencil(x, y);
+		}
+		row += gstate.DepthBufStride();
+	}
+	return true;
+}
+
 } // namespace

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -27,5 +27,6 @@ namespace Rasterizer {
 void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& v2);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
+bool GetCurrentTexture(GPUDebugBuffer &buffer);
 
 }

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -19,9 +19,13 @@
 
 #include "TransformUnit.h" // for DrawingCoords
 
+struct GPUDebugBuffer;
+
 namespace Rasterizer {
 
 // Draws a triangle if its vertices are specified in counter-clockwise order
 void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& v2);
+
+bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 
 }

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -771,23 +771,5 @@ bool SoftGPU::GetCurrentStencilbuffer(GPUDebugBuffer &buffer)
 
 bool SoftGPU::GetCurrentTexture(GPUDebugBuffer &buffer)
 {
-	static const int level = 0;
-
-	WARN_LOG(G3D, "Software texture preview currently very broken.");
-
-	u32 bufw = GetTextureBufw(level, gstate.getTextureAddress(level), gstate.getTextureFormat());
-	switch (gstate.getTextureFormat())
-	{
-	case GE_TFMT_5650:
-	case GE_TFMT_5551:
-	case GE_TFMT_4444:
-	case GE_TFMT_8888:
-		// TODO: Swizzling, of course.
-		buffer = GPUDebugBuffer(Memory::GetPointer(gstate.getTextureAddress(level)), bufw, gstate.getTextureHeight(level), gstate.getTextureFormat());
-		return true;
-
-	default:
-		// TODO: Support these...
-		return false;
-	}
+	return Rasterizer::GetCurrentTexture(buffer);
 }


### PR DESCRIPTION
Now the previews basically show properly for the GLES and software renderers.

Also, my tests so far have shown that e.g. INCR works for stencil, so the way the softgpu was doing stencil (forcing to one bit) just could not have been right.  Changed it to allow the full range.

Lastly, using 32-bit again I ran into more issues, I think this should solve the spurious wakes now.

-[Unknown]
