### PR TITLE
Win32: Make PPSSPP have a portable mode.

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -17,7 +17,7 @@ void trim2(std::string& str);
 
 void __CheatInit() {
 	gameTitle = g_paramSFO.GetValueString("DISC_ID");
-#if defined(ANDROID) || defined(__SYMBIAN32__)
+#if defined(ANDROID) || defined(__SYMBIAN32__) || defined(_WIN32)
 	activeCheatFile = g_Config.memCardDirectory + "PSP/Cheats/" + gameTitle + ".ini";
 #else
 	activeCheatFile = CHEATS_DIR + "/" + gameTitle + ".ini";

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -153,7 +153,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params)
 	std::vector<std::string> title;
 	bool finished = false, skip = false;
 	std::vector<std::string> newList;
-#if defined(ANDROID) || defined(__SYMBIAN32__) || defined(BLACKBERRY)
+#if defined(ANDROID) || defined(__SYMBIAN32__) || defined(BLACKBERRY) || defined(_WIN32)
 	std::string cheatDir = g_Config.memCardDirectory + "PSP/Cheats/cheat.db";
 	is.open(cheatDir.c_str());
 #else


### PR DESCRIPTION
In order to prep for an eventual installer(https://github.com/hrydgard/ppsspp/issues/4061), PPSSPP should do the following:
1. Check for an "installed.txt" file in its own directory.

2a. If installed.txt doesn't exist, use the same old memstick folder it's been using since the beginning, and use PSP/Config as its new location for Controls.ini and PPSSPP.ini(this can of course be changed if nobody likes that, but it makes sense to me to do it like that, for organisation, and simpler code).

2b. If installed.txt exists and has no content/is blank, determine the user's My Documents(on XP) or Documents(on Vista/7/8) directory, and create a new folder called PPSSPP there.

2c. If installed.txt exists and has stuff in it, use the contents of the file as the path to use.

If either the current directory or the custom defined directory in installed.txt are read-only, we fall back on the detected Documents folder.
