### PR TITLE
add scePauth support

### DIFF
--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -18,17 +18,60 @@
 #include "HLE.h"
 
 #include "scePauth.h"
+#include "zlib.h"
 
 int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
-	ERROR_LOG(HLE, "UNIMPL scePauth_F7AA47F6(%d, %d, %d, %d)", srcPtr, srcLength, destLengthPtr, workArea);
+	ERROR_LOG(HLE, "UNIMPL scePauth_F7AA47F6(%08x, %08x, %08x, %08x)", srcPtr, srcLength, destLengthPtr, workArea);
 	return 0;
 }
 
 int scePauth_98B83B5D(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
-	ERROR_LOG(HLE, "UNIMPL scePauth_98B83B5D(%d, %d, %d, %d)", srcPtr, srcLength, destLengthPtr, workArea);
-	return 0;
+	u8 *src, *key;
+	u32 crc;
+	char path[256], name[256];
+	std::string hostPath;
+	FILE *fp;
+	int size;
+
+	INFO_LOG(HLE, "scePauth_98B83B5D(%08x, %08x, %08x, %08x)", srcPtr, srcLength, destLengthPtr, workArea);
+
+	sprintf(name, "ms0:/PAUTH");
+	pspFileSystem.GetHostPath(std::string(name), hostPath);
+
+	src = (u8*) Memory::GetPointer(srcPtr);
+	key = (u8*) Memory::GetPointer(workArea);
+	crc = crc32(0, src, srcLength);
+
+	sprintf(name, "%s/pauth_%08x.bin.decrypt", hostPath.c_str(), crc);
+	fp = fopen(name, "rb");
+	if(fp){
+		fseek(fp, 0, SEEK_END);
+		size = ftell(fp);
+		fseek(fp, 0, SEEK_SET);
+		fread(src, 1, size, fp);
+		fclose(fp);
+		Memory::Write_U32(size, destLengthPtr);
+		INFO_LOG(HLE, "    read from decrypted file %s", name);
+		return 0;
+	}
+
+	pspFileSystem.MkDir("ms0:/PAUTH");
+
+	sprintf(name, "%s/pauth_%08x.bin", hostPath.c_str(), crc);
+	ERROR_LOG(HLE, "    no decrypted file found! save as %s", name);
+
+	fp = fopen(name, "wb");
+	fwrite(src, 1, srcLength, fp);
+	fclose(fp);
+
+	sprintf(name, "%s/pauth_%08x.key", hostPath.c_str(), crc);
+	fp = fopen(name, "wb");
+	fwrite(key, 1, 16, fp);
+	fclose(fp);
+
+	return -1;
 }
 
 const HLEFunction scePauth[] = {


### PR DESCRIPTION
test with Monster Hunter Portable 3rd.
How it work:
When first times run, it will write encrypted data to ms0:/PAUTH.  This data can be decrypt on real PSP. The second times run, it will load the decrypted data and continue.

The tools: http://pan.baidu.com/s/1gigSO
