### PR TITLE
WIN32: Use glLineWidth to specify the width of rasterized lines

### DIFF
--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -32,6 +32,9 @@ void GL_Resized() {
 		yres = 1;
 	glstate.viewport.set(0, 0, xres, yres);
 	glstate.viewport.restore();
+#ifndef USING_GLES2
+	glLineWidth(g_Config.iInternalResolution == 0 ? yres : g_Config.iInternalResolution);
+#endif 
 }
 
 void GL_SwapBuffers() {


### PR DESCRIPTION
Fix https://github.com/hrydgard/ppsspp/issues/3871
