### PR TITLE
Set stencil ref value to 255 (8 bitplanes) 2^8-1=255

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -286,7 +286,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			// TODO: In clear mode, the stencil value is set to the alpha value of the vertex.
 			// A normal clear will be 2 points, the second point has the color.
 			// We should set "ref" to that value instead of 0.
-			glstate.stencilFunc.set(GL_ALWAYS, 0, 0xFF);
+			glstate.stencilFunc.set(GL_ALWAYS, 255, 0xFF);
 		} else 
 			glstate.stencilTest.disable();
 		


### PR DESCRIPTION
Since we're using 0xFF to disable the stencil mask and we have 8 bitplanes , try to set it to 2^8-1=255

This fixes NBA Live 06

-Before
![screen00028](https://f.cloud.github.com/assets/3000282/1306741/803d35f6-31b4-11e3-967f-7a178123554c.jpg)

-After
![screen00027](https://f.cloud.github.com/assets/3000282/1306742/835de316-31b4-11e3-9dc0-4325b85cdfb0.jpg)
