### PR TITLE
Win32: Add a dynamically-created Postprocessing Shader popup menu.

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -834,7 +834,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 			fbo_unbind();
 
 			// Use the extra FBO, with applied FXAA, as a texture.
-			 //fbo_bind_color_as_texture(extraFBOs_[0], 0);
+			// fbo_bind_color_as_texture(extraFBOs_[0], 0);
 			if (extraFBOs_.size())
 				colorTexture = fbo_get_color_texture(extraFBOs_[0]);
 		}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -835,7 +835,8 @@ void FramebufferManager::CopyDisplayToOutput() {
 
 			// Use the extra FBO, with applied FXAA, as a texture.
 			// fbo_bind_color_as_texture(extraFBOs_[0], 0);
-			colorTexture = fbo_get_color_texture(extraFBOs_[0]);
+			if (extraFBOs_.size())
+				colorTexture = fbo_get_color_texture(extraFBOs_[0]);
 		}
 
 		glstate.viewport.set(0, 0, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -834,7 +834,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 			fbo_unbind();
 
 			// Use the extra FBO, with applied FXAA, as a texture.
-			// fbo_bind_color_as_texture(extraFBOs_[0], 0);
+			 //fbo_bind_color_as_texture(extraFBOs_[0], 0);
 			if (extraFBOs_.size())
 				colorTexture = fbo_get_color_texture(extraFBOs_[0]);
 		}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -835,8 +835,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 
 			// Use the extra FBO, with applied FXAA, as a texture.
 			// fbo_bind_color_as_texture(extraFBOs_[0], 0);
-			if (extraFBOs_.size())
-				colorTexture = fbo_get_color_texture(extraFBOs_[0]);
+			colorTexture = fbo_get_color_texture(extraFBOs_[0]);
 		}
 
 		glstate.viewport.set(0, 0, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -179,6 +179,15 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new GameSettingsScreen(gamePath_));
 	}
+	else if (!strcmp(message, "gpu resized")) {
+		if (gpu) gpu->Resized();
+	}
+	else if (!strcmp(message, "gpu clear cache")) {
+		if (gpu) gpu->ClearCacheNextFrame();
+	}
+	else if (!strcmp(message, "gpu dump next frame")) {
+		if (gpu) gpu->DumpNextFrame();
+	}
 }
 
 inline float curve1(float x) {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -449,16 +449,20 @@ namespace MainWindow
 	}
 
 	void CreateShadersSubmenu() {
-		const std::wstring key = L"HEY";
-		HMENU optionsMenu = GetSubMenu(menu, MENU_OPTIONS);
-		RemoveMenu(optionsMenu, SUBMENU_CUSTOM_SHADERS, MF_BYPOSITION);
-		HMENU shaderMenu = CreatePopupMenu();
+		I18NCategory *des = GetI18NCategory("DesktopUI");
 		
-		int item = ID_SHADERS_BASE + 1;
+		const std::wstring key = ConvertUTF8ToWString(des->T("Postprocessing Shader"));
+
+		HMENU optionsMenu = GetSubMenu(menu, MENU_OPTIONS);
+		
+		HMENU shaderMenu = CreatePopupMenu();
+
+		RemoveMenu(optionsMenu, SUBMENU_CUSTOM_SHADERS, MF_BYPOSITION);
 		InsertMenu(optionsMenu, SUBMENU_CUSTOM_SHADERS, MF_POPUP | MF_STRING | MF_BYPOSITION, (UINT_PTR)shaderMenu, key.c_str());
 
 		std::vector<ShaderInfo> info = GetAllPostShaderInfo();
 		availableShaders.clear();
+		int item = ID_SHADERS_BASE + 1;
 		for (auto i = info.begin(); i != info.end(); ++i) {
 			availableShaders.push_back(i->section);
 			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_UNCHECKED, item++, ConvertUTF8ToWString(i->name).c_str());
@@ -500,6 +504,8 @@ namespace MainWindow
 		TranslateMenu("Game Settings", MENU_OPTIONS);
 		TranslateMenu("Help", MENU_HELP);
 
+		CreateShadersSubmenu();
+
 		// File menu
 		TranslateMenuItem(ID_FILE_LOAD);
 		TranslateMenuItem(ID_FILE_LOAD_DIR);
@@ -539,7 +545,7 @@ namespace MainWindow
 		TranslateMenuItem(ID_OPTIONS_STRETCHDISPLAY);
 		TranslateMenuItem(ID_OPTIONS_FULLSCREEN, L"\tAlt+Return, F11");
 		TranslateMenuItem(ID_OPTIONS_VSYNC);
-		TranslateMenuItem(ID_OPTIONS_FXAA);
+		TranslateSubMenu("Postprocessing Shader", MENU_OPTIONS, SUBMENU_CUSTOM_SHADERS);
 		TranslateSubMenu("Rendering Resolution", MENU_OPTIONS, SUBMENU_RENDERING_RESOLUTION, L"\tCtrl+1");
 		TranslateMenuItem(ID_OPTIONS_SCREENAUTO);
 		// Skip rendering resolution 2x-5x..
@@ -579,7 +585,6 @@ namespace MainWindow
 		// Help menu: it's translated in CreateHelpMenu.
 		CreateHelpMenu();
 
-		CreateShadersSubmenu();
 
 		// TODO: Urgh! Why do we need this here?
 		// The menu is supposed to enable/disable this stuff directly afterward.

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -446,6 +446,13 @@ namespace MainWindow
 		}
 	}
 
+	void UpdateDynamicMenuCheckmarks() {
+		int item = ID_SHADERS_BASE + 1;
+
+		for (int i = 0; i < availableShaders.size(); i++)
+			CheckMenuItem(menu, item++, ((g_Config.sPostShaderName == availableShaders[i]) ? MF_CHECKED : MF_UNCHECKED));
+	}
+
 	void CreateShadersSubmenu() {
 		I18NCategory *des = GetI18NCategory("DesktopUI");
 		
@@ -460,10 +467,18 @@ namespace MainWindow
 
 		std::vector<ShaderInfo> info = GetAllPostShaderInfo();
 		availableShaders.clear();
+
 		int item = ID_SHADERS_BASE + 1;
+		int checkedStatus = -1;
+
 		for (auto i = info.begin(); i != info.end(); ++i) {
+			checkedStatus = MF_UNCHECKED;
 			availableShaders.push_back(i->section);
-			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_UNCHECKED, item++, ConvertUTF8ToWString(i->name).c_str());
+			if (g_Config.sPostShaderName == i->section) {
+				checkedStatus = MF_CHECKED;
+			}
+
+			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(i->name).c_str());
 		}
 	}
 
@@ -1647,7 +1662,6 @@ namespace MainWindow
 		CHECKITEM(ID_OPTIONS_SHOWFPS, g_Config.iShowFPSCounter);
 		CHECKITEM(ID_OPTIONS_FRAMESKIP, g_Config.iFrameSkip != 0);
 		CHECKITEM(ID_OPTIONS_VSYNC, g_Config.bVSync);
-		// CHECKITEM(ID_OPTIONS_FXAA, g_Config.bFXAA);  TODO: Replace with list of loaded post processing shaders
 		CHECKITEM(ID_OPTIONS_TOPMOST, g_Config.bTopMost);
 		CHECKITEM(ID_OPTIONS_PAUSE_FOCUS, g_Config.bPauseOnLostFocus);
 		CHECKITEM(ID_EMULATION_SOUND, g_Config.bEnableSound);
@@ -1798,6 +1812,7 @@ namespace MainWindow
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | (( i == g_Config.iCurrentStateSlot )? MF_CHECKED : MF_UNCHECKED));
 		}
 
+		UpdateDynamicMenuCheckmarks();
 		UpdateCommands();
 	}
 	

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1463,7 +1463,7 @@ namespace MainWindow
 						// The Menu ID is contained in wParam, so subtract
 						// ID_SHADERS_BASE and an additional 1 off it.
 						index = (wParam - ID_SHADERS_BASE - 1);
-						if (index >= 0) {
+						if (index >= 0 && index < availableShaders.size()) {
 							g_Config.sPostShaderName = availableShaders[index];
 
 							if (gpu)

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -110,7 +110,6 @@ namespace MainWindow
 	static std::map<int, std::string> initialMenuKeys;
 	static std::vector<std::string> countryCodes;
 	static std::vector<std::string> availableShaders;
-	static std::vector<int> testVec;
 #define MAX_LOADSTRING 100
 	const TCHAR *szTitle = TEXT("PPSSPP");
 	const TCHAR *szWindowClass = TEXT("PPSSPPWnd");
@@ -354,7 +353,6 @@ namespace MainWindow
 		SUBMENU_FRAME_SKIPPING = 12,
 		SUBMENU_TEXTURE_FILTERING = 13,
 		SUBMENU_TEXTURE_SCALING = 14,
-		
 	};
 
 	std::string GetMenuItemText(int menuID) {
@@ -584,7 +582,6 @@ namespace MainWindow
 
 		// Help menu: it's translated in CreateHelpMenu.
 		CreateHelpMenu();
-
 
 		// TODO: Urgh! Why do we need this here?
 		// The menu is supposed to enable/disable this stuff directly afterward.

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -220,8 +220,7 @@ namespace MainWindow
 			osm.Show(g->T(message), 2.0f);
 		}
 
-		if (gpu)
-			gpu->Resized();
+		NativeMessageReceived("gpu resized", "");
 	}
 
 	void SetWindowSize(int zoom) {
@@ -608,7 +607,7 @@ namespace MainWindow
 
 	void setTexScalingMultiplier(int level) {
 		g_Config.iTexScalingLevel = level;
-		if(gpu) gpu->ClearCacheNextFrame();
+		NativeMessageReceived("gpu clear cache", "");
 	}
 
 	void setTexFiltering(int type) {
@@ -617,7 +616,7 @@ namespace MainWindow
 
 	void setTexScalingType(int type) {
 		g_Config.iTexScalingType = type;
-		if(gpu) gpu->ClearCacheNextFrame();
+		NativeMessageReceived("gpu clear cache", "");
 	}
 
 	void setRenderingMode(int mode = -1) {
@@ -648,7 +647,7 @@ namespace MainWindow
 			break;
 		}
 
-		if (gpu) gpu->Resized();
+		NativeMessageReceived("gpu resized", "");
 	}
 
 	void setFpsLimit(int fps) {
@@ -1251,14 +1250,6 @@ namespace MainWindow
 				case ID_OPTIONS_VSYNC:
 					g_Config.bVSync = !g_Config.bVSync;
 					break;
-				
-				/* TODO: Add menus for post processing
-				case ID_OPTIONS_FXAA:
-					g_Config.bFXAA = !g_Config.bFXAA;
-					if (gpu)
-						gpu->Resized();
-					break;
-					*/
 
 				case ID_TEXTURESCALING_AUTO: setTexScalingMultiplier(TEXSCALING_AUTO); break;
 				case ID_TEXTURESCALING_OFF: setTexScalingMultiplier(TEXSCALING_OFF); break;
@@ -1274,8 +1265,7 @@ namespace MainWindow
 
 				case ID_TEXTURESCALING_DEPOSTERIZE:
 					g_Config.bTexDeposterize = !g_Config.bTexDeposterize;
-					if (gpu)
-						gpu->ClearCacheNextFrame();
+					NativeMessageReceived("gpu clear cache", "");
 					break;
 
 				case ID_OPTIONS_NONBUFFEREDRENDERING:   setRenderingMode(FB_NON_BUFFERED_MODE); break;
@@ -1299,8 +1289,7 @@ namespace MainWindow
 
 				case ID_OPTIONS_STRETCHDISPLAY:
 					g_Config.bStretchToDisplay = !g_Config.bStretchToDisplay;
-					if (gpu)
-						gpu->Resized();  // Easy way to force a clear...
+					NativeMessageReceived("gpu resized", "");
 					break;
 
 				case ID_OPTIONS_FRAMESKIP_0:    setFrameSkipping(FRAMESKIP_OFF); break;
@@ -1327,8 +1316,7 @@ namespace MainWindow
 					break;
 
 				case ID_DEBUG_DUMPNEXTFRAME:
-					if (gpu)
-						gpu->DumpNextFrame();
+					NativeMessageReceived("gpu dump next frame", "");
 					break;
 
 				case ID_DEBUG_LOADMAPFILE:
@@ -1481,8 +1469,7 @@ namespace MainWindow
 						if (index >= 0 && index < availableShaders.size()) {
 							g_Config.sPostShaderName = availableShaders[index];
 
-							if (gpu)
-								gpu->Resized();
+							NativeMessageReceived("gpu resized", "");
 
 							break;
 						}

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -162,6 +162,7 @@
 // Don't define anything else in the 3000 range.
 // It's reserved for languages.
 #define ID_LANGUAGE_BASE 3000
+#define ID_SHADERS_BASE  5000
 
 #define ID_FILE_EXIT                     40000
 #define ID_DEBUG_SAVEMAPFILE             40001


### PR DESCRIPTION
This adds a run-time created submenu option to the Game Settings menu which will fetch all available shaders and swap them when the user picks one.

It has a quirk:
1. Shader names aren't currently translatable(it can easily be done, but I wasn't sure if I should make them translatable or not..)

![Screenshot 01](http://i.minus.com/iXLHgC3nnLTA2.PNG)
