### PR TITLE
Improve some shutdown problems on Windows

### DIFF
--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -126,7 +126,7 @@ unsigned int MIPSDebugInterface::readMemory(unsigned int address)
 
 bool MIPSDebugInterface::isAlive()
 {
-	return PSP_IsInited();
+	return PSP_IsInited() && coreState != CORE_ERROR && coreState != CORE_POWERDOWN;
 }
 
 bool MIPSDebugInterface::isBreakpoint(unsigned int address) 

--- a/Core/System.h
+++ b/Core/System.h
@@ -40,7 +40,8 @@ enum GlobalUIState {
 extern GlobalUIState globalUIState;
 
 inline static void UpdateUIState(GlobalUIState newState) {
-	if (globalUIState != newState) {
+	// Never leave the EXIT state.
+	if (globalUIState != newState && globalUIState != UISTATE_EXIT) {
 		globalUIState = newState;
 		host->UpdateDisassembly();
 	}

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -487,6 +487,7 @@ ShaderManager::~ShaderManager() {
 }
 
 void ShaderManager::Clear() {
+	DirtyLastShader();
 	for (auto iter = linkedShaderCache_.begin(); iter != linkedShaderCache_.end(); ++iter) {
 		delete iter->ls;
 	}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -147,7 +147,8 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	if (!strcmp(message, "pause")) {
 		screenManager()->push(new GamePauseScreen(gamePath_));
 	} else if (!strcmp(message, "stop")) {
-		screenManager()->switchScreen(new MainScreen());
+		// We will push MainScreen in update().
+		PSP_Shutdown();
 	} else if (!strcmp(message, "reset")) {
 		PSP_Shutdown();
 		std::string resetError;
@@ -497,6 +498,7 @@ void EmuScreen::render() {
 	} else if (coreState == CORE_POWERDOWN)	{
 		ILOG("SELF-POWERDOWN!");
 		screenManager()->switchScreen(new MainScreen());
+		invalid_ = true;
 	}
 
 	if (invalid_)

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -130,11 +130,12 @@ unsigned int WINAPI TheThread(void *)
 
 	while (globalUIState != UISTATE_EXIT)
 	{
-		Core_Run();
-
 		// We're here again, so the game quit.  Restart Core_Run() which controls the UI.
 		// This way they can load a new game.
-		Core_UpdateState(CORE_RUNNING);
+		if (!Core_IsActive())
+			UpdateUIState(UISTATE_MENU);
+
+		Core_Run();
 	}
 
 shutdown:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -782,10 +782,6 @@ namespace MainWindow
 		DialogManager::AddDlg(memoryWindow[0]);
 	}
 
-	void WaitForCore() {
-		Core_Stop();
-	}
-
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory) {
 		std::string fn;
 		std::string filter = "PSP ROMs (*.iso *.cso *.pbp *.elf)|*.pbp;*.elf;*.iso;*.cso;*.prx|All files (*.*)|*.*||";
@@ -1131,8 +1127,9 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_STOP:
-					WaitForCore();
+					Core_Stop();
 					NativeMessageReceived("stop", "");
+					Core_WaitInactive();
 					Update();
 					break;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1137,15 +1137,15 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_RESET:
-					WaitForCore();
 					NativeMessageReceived("reset", "");
+					Core_EnableStepping(false);
 					break;
 
 				case ID_EMULATION_CHEATS:
 					g_Config.bEnableCheats = !g_Config.bEnableCheats;
 					osm.ShowOnOff(g->T("Cheats"), g_Config.bEnableCheats);
-					WaitForCore();
 					NativeMessageReceived("reset", "");
+					Core_EnableStepping(false);
 					break;
 
 				case ID_FILE_LOADSTATEFILE:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -783,16 +783,7 @@ namespace MainWindow
 	}
 
 	void WaitForCore() {
-		if (Core_IsStepping()) {
-			// If the current PC is on a breakpoint, disabling stepping doesn't work without
-			// explicitly skipping it
-			CBreakPoints::SetSkipFirst(currentMIPS->pc);
-			Core_EnableStepping(false);
-		}
-
-		Core_EnableStepping(true);
-		Core_WaitInactive();
-		Core_EnableStepping(false);
+		Core_Stop();
 	}
 
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory) {


### PR DESCRIPTION
@thedax I'm not sure which issues you were seeing before, so I'd like to know if these changes cover them or not.

Changes:
- glDisableVertexAttribArray on shutdown (fixes crashes in UI / GL.)
- Switch the run loop on Windows to care more about globalUIState.
- Don't keep on truckin' in EmuScreen when CORE_POWERDOWN is hit, avoiding crashes.
- Avoid another 32-bit cond var issue with multithreading (happened during shutdown sometimes.)

-[Unknown]
