### PR TITLE
Debugger changes, mostly reorganizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1006,6 +1006,8 @@ add_library(GPU OBJECT
 	GPU/Common/SplineCommon.h
 	GPU/Debugger/Breakpoints.cpp
 	GPU/Debugger/Breakpoints.h
+	GPU/Debugger/Stepping.cpp
+	GPU/Debugger/Stepping.h
 	GPU/GLES/GLES_GPU.cpp
 	GPU/GLES/GLES_GPU.h
 	GPU/GLES/FragmentShaderGenerator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1004,6 +1004,8 @@ add_library(GPU OBJECT
 	GPU/Common/PostShader.cpp
 	GPU/Common/PostShader.h
 	GPU/Common/SplineCommon.h
+	GPU/Debugger/Breakpoints.cpp
+	GPU/Debugger/Breakpoints.h
 	GPU/GLES/GLES_GPU.cpp
 	GPU/GLES/GLES_GPU.h
 	GPU/GLES/FragmentShaderGenerator.cpp

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -141,8 +141,7 @@ static inline void UpdateRunLoop() {
 	NativeRender();
 }
 
-void Core_RunLoop()
-{
+void Core_RunLoop() {
 	while (globalUIState != UISTATE_INGAME && globalUIState != UISTATE_EXIT) {
 		time_update();
 
@@ -162,7 +161,7 @@ void Core_RunLoop()
 #endif
 	}
 
-	while (!coreState) {
+	while (!coreState && globalUIState == UISTATE_INGAME) {
 		time_update();
 		UpdateRunLoop();
 #ifdef _WIN32

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -321,8 +321,13 @@ int ElfReader::LoadInto(u32 loadAddress)
 		return SCE_KERNEL_ERROR_UNSUPPORTED_PRX_TYPE;
 
 	// technically ELFCLASSNONE would freeze the system, but that's not really desireable
-	if (header->e_ident[EI_CLASS] != ELFCLASS32)
-		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
+	if (header->e_ident[EI_CLASS] != ELFCLASS32) {
+		if (header->e_ident[EI_CLASS] != 0) {
+			return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
+		}
+
+		ERROR_LOG(LOADER, "Bad ELF, EI_CLASS (fifth byte) is 0x00, should be 0x01 - would lock up a PSP.");
+	}
 
 	if (header->e_ident[EI_DATA] != ELFDATA2LSB)
 		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -26,7 +26,7 @@ char* GetAssembleError()
 void SplitLine(const char* Line, char* Name, char* Arguments)
 {
 	while (*Line == ' ' || *Line == '\t') Line++;
-	while (*Line != ' ')
+	while (*Line != ' ' && *Line != '\t')
 	{
 		if (*Line  == 0)
 		{

--- a/GPU/Debugger/Breakpoints.cpp
+++ b/GPU/Debugger/Breakpoints.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include <vector>
+#include <set>
+#include "base/mutex.h"
+#include "GPU/Debugger/Breakpoints.h"
+
+namespace GPUBreakpoints {
+
+static recursive_mutex breaksLock;
+static std::vector<bool> breakCmds;
+static std::set<u32> breakPCs;
+
+// If these are set, the above are also, but they should be temporary.
+static std::vector<bool> breakCmdsTemp;
+static std::set<u32> breakPCsTemp;
+
+void Init() {
+	ClearAllBreakpoints();
+}
+
+bool IsAddressBreakpoint(u32 addr, bool &temp) {
+	lock_guard guard(breaksLock);
+
+	temp = breakPCsTemp.find(addr) != breakPCsTemp.end();
+	return breakPCs.find(addr) != breakPCs.end();
+}
+
+bool IsAddressBreakpoint(u32 addr) {
+	lock_guard guard(breaksLock);
+
+	return breakPCs.find(addr) != breakPCs.end();
+}
+
+bool IsCmdBreakpoint(u8 cmd, bool &temp) {
+	temp = breakCmdsTemp[cmd];
+	return breakCmds[cmd];
+}
+
+bool IsCmdBreakpoint(u8 cmd) {
+	return breakCmds[cmd];
+}
+
+void AddAddressBreakpoint(u32 addr, bool temp) {
+	lock_guard guard(breaksLock);
+
+	if (temp) {
+		if (breakPCs.find(addr) == breakPCs.end()) {
+			breakPCsTemp.insert(addr);
+			breakPCs.insert(addr);
+		}
+		// Already normal breakpoint, let's not make it temporary.
+	} else {
+		// Remove the temporary marking.
+		breakPCsTemp.erase(addr);
+		breakPCs.insert(addr);
+	}
+}
+
+void AddCmdBreakpoint(u8 cmd, bool temp) {
+	if (temp) {
+		if (!breakCmds[cmd]) {
+			breakCmdsTemp[cmd] = true;
+			breakCmds[cmd] = true;
+		}
+		// Ignore adding a temp breakpoint when a normal one exists.
+	} else {
+		// This is no longer temporary.
+		breakCmdsTemp[cmd] = false;
+		breakCmds[cmd] = true;
+	}
+}
+
+void RemoveAddressBreakpoint(u32 addr) {
+	lock_guard guard(breaksLock);
+
+	breakPCsTemp.erase(addr);
+	breakPCs.erase(addr);
+}
+
+void RemoveCmdBreakpoint(u8 cmd) {
+	breakCmdsTemp[cmd] = false;
+	breakCmds[cmd] = false;
+}
+
+void ClearAllBreakpoints() {
+	lock_guard guard(breaksLock);
+
+	breakCmds.clear();
+	breakCmds.resize(256, false);
+	breakPCs.clear();
+
+	breakCmdsTemp.clear();
+	breakCmdsTemp.resize(256, false);
+	breakPCsTemp.clear();
+}
+
+void ClearTempBreakpoints() {
+	lock_guard guard(breaksLock);
+
+	// Reset ones that were temporary back to non-breakpoints in the primary arrays.
+	for (int i = 0; i < 256; ++i) {
+		if (breakCmdsTemp[i]) {
+			breakCmds[i] = false;
+			breakCmdsTemp[i] = false;
+		}
+	}
+
+	for (auto it = breakPCsTemp.begin(), end = breakPCsTemp.end(); it != end; ++it) {
+		breakPCs.erase(*it);
+	}
+	breakPCsTemp.clear();
+}
+
+};

--- a/GPU/Debugger/Breakpoints.h
+++ b/GPU/Debugger/Breakpoints.h
@@ -26,10 +26,17 @@ namespace GPUBreakpoints {
 	bool IsAddressBreakpoint(u32 addr);
 	bool IsCmdBreakpoint(u8 cmd, bool &temp);
 	bool IsCmdBreakpoint(u8 cmd);
+	bool IsTextureBreakpoint(u32 addr, bool &temp);
+	bool IsTextureBreakpoint(u32 addr);
+
 	void AddAddressBreakpoint(u32 addr, bool temp = false);
 	void AddCmdBreakpoint(u8 cmd, bool temp = false);
+	void AddTextureBreakpoint(u32 addr, bool temp = false);
+
 	void RemoveAddressBreakpoint(u32 addr);
 	void RemoveCmdBreakpoint(u8 cmd);
+	void RemoveTextureBreakpoint(u32 addr);
+
 	void ClearAllBreakpoints();
 	void ClearTempBreakpoints();
 

--- a/GPU/Debugger/Breakpoints.h
+++ b/GPU/Debugger/Breakpoints.h
@@ -22,6 +22,8 @@
 namespace GPUBreakpoints {
 	void Init();
 
+	bool IsBreakpoint(u32 pc, u32 op);
+
 	bool IsAddressBreakpoint(u32 addr, bool &temp);
 	bool IsAddressBreakpoint(u32 addr);
 	bool IsCmdBreakpoint(u8 cmd, bool &temp);

--- a/GPU/Debugger/Breakpoints.h
+++ b/GPU/Debugger/Breakpoints.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+namespace GPUBreakpoints {
+	void Init();
+
+	bool IsAddressBreakpoint(u32 addr, bool &temp);
+	bool IsAddressBreakpoint(u32 addr);
+	bool IsCmdBreakpoint(u8 cmd, bool &temp);
+	bool IsCmdBreakpoint(u8 cmd);
+	void AddAddressBreakpoint(u32 addr, bool temp = false);
+	void AddCmdBreakpoint(u8 cmd, bool temp = false);
+	void RemoveAddressBreakpoint(u32 addr);
+	void RemoveCmdBreakpoint(u8 cmd);
+	void ClearAllBreakpoints();
+	void ClearTempBreakpoints();
+
+	static inline bool IsOpBreakpoint(u32 op, bool &temp) {
+		return IsCmdBreakpoint(op >> 24, temp);
+	}
+
+	static inline bool IsOpBreakpoint(u32 op) {
+		return IsCmdBreakpoint(op >> 24);
+	}
+};

--- a/GPU/Debugger/Breakpoints.h
+++ b/GPU/Debugger/Breakpoints.h
@@ -34,10 +34,14 @@ namespace GPUBreakpoints {
 	void AddAddressBreakpoint(u32 addr, bool temp = false);
 	void AddCmdBreakpoint(u8 cmd, bool temp = false);
 	void AddTextureBreakpoint(u32 addr, bool temp = false);
+	void AddTextureChangeTempBreakpoint();
 
 	void RemoveAddressBreakpoint(u32 addr);
 	void RemoveCmdBreakpoint(u8 cmd);
 	void RemoveTextureBreakpoint(u32 addr);
+	void RemoveTextureChangeTempBreakpoint();
+
+	void UpdateLastTexture(u32 addr);
 
 	void ClearAllBreakpoints();
 	void ClearTempBreakpoints();

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "base/mutex.h"
+#include "GPU/Common/GPUDebugInterface.h"
+#include "GPU/Debugger/Stepping.h"
+#include "Core/Core.h"
+
+namespace GPUStepping {
+
+enum PauseAction {
+	PAUSE_CONTINUE,
+	PAUSE_BREAK,
+	PAUSE_GETFRAMEBUF,
+	PAUSE_GETDEPTHBUF,
+	PAUSE_GETSTENCILBUF,
+	PAUSE_GETTEX,
+	PAUSE_SETCMDVALUE,
+};
+	
+static bool isStepping;
+
+static recursive_mutex pauseLock;
+static condition_variable pauseWait;
+static PauseAction pauseAction = PAUSE_CONTINUE;
+static recursive_mutex actionLock;
+static condition_variable actionWait;
+// In case of accidental wakeup.
+static bool actionComplete;
+
+// Many things need to run on the GPU thread.  For example, reading the framebuffer.
+// A message system is used to achieve this (temporarily "unpausing" the thread.)
+// Below are values used to perform actions that return results.
+
+static bool bufferResult;
+static GPUDebugBuffer bufferFrame;
+static GPUDebugBuffer bufferDepth;
+static GPUDebugBuffer bufferStencil;
+static GPUDebugBuffer bufferTex;
+static u32 pauseSetCmdValue;
+
+static void SetPauseAction(PauseAction act, bool waitComplete = true) {
+	{
+		lock_guard guard(pauseLock);
+		actionLock.lock();
+		pauseAction = act;
+	}
+
+	actionComplete = false;
+	pauseWait.notify_one();
+	while (waitComplete && !actionComplete) {
+		actionWait.wait(actionLock);
+	}
+	actionLock.unlock();
+}
+
+static void RunPauseAction() {
+	lock_guard guard(actionLock);
+
+	switch (pauseAction) {
+	case PAUSE_CONTINUE:
+		// Don't notify, just go back, woke up by accident.
+		return;
+
+	case PAUSE_BREAK:
+		break;
+
+	case PAUSE_GETFRAMEBUF:
+		bufferResult = gpuDebug->GetCurrentFramebuffer(bufferFrame);
+		break;
+
+	case PAUSE_GETDEPTHBUF:
+		bufferResult = gpuDebug->GetCurrentDepthbuffer(bufferDepth);
+		break;
+
+	case PAUSE_GETSTENCILBUF:
+		bufferResult = gpuDebug->GetCurrentStencilbuffer(bufferStencil);
+		break;
+
+	case PAUSE_GETTEX:
+		bufferResult = gpuDebug->GetCurrentTexture(bufferTex);
+		break;
+
+	case PAUSE_SETCMDVALUE:
+		gpuDebug->SetCmdValue(pauseSetCmdValue);
+		break;
+
+	default:
+		ERROR_LOG(HLE, "Unsupported pause action, forgot to add it to the switch.");
+	}
+
+	actionComplete = true;
+	actionWait.notify_one();
+	pauseAction = PAUSE_BREAK;
+}
+
+bool EnterStepping(std::function<void()> callback) {
+	lock_guard guard(pauseLock);
+	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME) {
+		// Shutting down, don't try to step.
+		return false;
+	}
+	if (!gpuDebug) {
+		return false;
+	}
+
+	// Just to be sure.
+	if (pauseAction == PAUSE_CONTINUE) {
+		pauseAction = PAUSE_BREAK;
+	}
+	isStepping = true;
+
+	callback();
+
+	do {
+		RunPauseAction();
+		pauseWait.wait(pauseLock);
+	} while (pauseAction != PAUSE_CONTINUE);
+
+	isStepping = false;
+	return true;
+}
+
+static bool GetBuffer(const GPUDebugBuffer *&buffer, PauseAction type, const GPUDebugBuffer &resultBuffer) {
+	if (!isStepping) {
+		return false;
+	}
+
+	SetPauseAction(type);
+	buffer = &resultBuffer;
+	return bufferResult;
+}
+
+bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer) {
+	return GetBuffer(buffer, PAUSE_GETFRAMEBUF, bufferFrame);
+}
+
+bool GPU_GetCurrentDepthbuffer(const GPUDebugBuffer *&buffer) {
+	return GetBuffer(buffer, PAUSE_GETDEPTHBUF, bufferDepth);
+}
+
+bool GPU_GetCurrentStencilbuffer(const GPUDebugBuffer *&buffer) {
+	return GetBuffer(buffer, PAUSE_GETSTENCILBUF, bufferStencil);
+}
+
+bool GPU_GetCurrentTexture(const GPUDebugBuffer *&buffer) {
+	return GetBuffer(buffer, PAUSE_GETTEX, bufferTex);
+}
+
+bool GPU_SetCmdValue(u32 op) {
+	if (!isStepping) {
+		return false;
+	}
+
+	pauseSetCmdValue = op;
+	SetPauseAction(PAUSE_SETCMDVALUE);
+	return true;
+}
+
+void ResumeFromStepping() {
+	SetPauseAction(PAUSE_CONTINUE, false);
+}
+
+void ForceUnpause() {
+	SetPauseAction(PAUSE_CONTINUE, false);
+	actionComplete = true;
+	actionWait.notify_one();
+}
+
+};

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "base/functional.h"
+#include "Common/CommonTypes.h"
+#include "GPU/Common/GPUDebugInterface.h"
+
+namespace GPUStepping {
+	// Should be called from the GPU thread.
+	// Begins stepping and calls callback while inside a lock preparing stepping.
+	// This would be a good place to deliver a message to code that stepping is ready.
+	bool EnterStepping(std::function<void()> callback);
+
+	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer);
+	bool GPU_GetCurrentDepthbuffer(const GPUDebugBuffer *&buffer);
+	bool GPU_GetCurrentStencilbuffer(const GPUDebugBuffer *&buffer);
+	bool GPU_GetCurrentTexture(const GPUDebugBuffer *&buffer);
+	bool GPU_SetCmdValue(u32 op);
+
+	void ResumeFromStepping();
+	void ForceUnpause();
+};

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -160,6 +160,7 @@
     <ClInclude Include="Common\PostShader.h" />
     <ClInclude Include="Common\SplineCommon.h" />
     <ClInclude Include="Common\VertexDecoderCommon.h" />
+    <ClInclude Include="Debugger\Breakpoints.h" />
     <ClInclude Include="Directx9\GPU_DX9.h" />
     <ClInclude Include="Directx9\helper\dx_state.h" />
     <ClInclude Include="Directx9\helper\fbo.h" />
@@ -203,6 +204,7 @@
     <ClCompile Include="Common\IndexGenerator.cpp" />
     <ClCompile Include="Common\PostShader.cpp" />
     <ClCompile Include="Common\VertexDecoderCommon.cpp" />
+    <ClCompile Include="Debugger\Breakpoints.cpp" />
     <ClCompile Include="Directx9\GPU_DX9.cpp" />
     <ClCompile Include="Directx9\helper\dx_state.cpp" />
     <ClCompile Include="Directx9\helper\fbo.cpp" />

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -161,6 +161,7 @@
     <ClInclude Include="Common\SplineCommon.h" />
     <ClInclude Include="Common\VertexDecoderCommon.h" />
     <ClInclude Include="Debugger\Breakpoints.h" />
+    <ClInclude Include="Debugger\Stepping.h" />
     <ClInclude Include="Directx9\GPU_DX9.h" />
     <ClInclude Include="Directx9\helper\dx_state.h" />
     <ClInclude Include="Directx9\helper\fbo.h" />
@@ -205,6 +206,7 @@
     <ClCompile Include="Common\PostShader.cpp" />
     <ClCompile Include="Common\VertexDecoderCommon.cpp" />
     <ClCompile Include="Debugger\Breakpoints.cpp" />
+    <ClCompile Include="Debugger\Stepping.cpp" />
     <ClCompile Include="Directx9\GPU_DX9.cpp" />
     <ClCompile Include="Directx9\helper\dx_state.cpp" />
     <ClCompile Include="Directx9\helper\fbo.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -154,6 +154,9 @@
     <ClInclude Include="Debugger\Breakpoints.h">
       <Filter>Debugger</Filter>
     </ClInclude>
+    <ClInclude Include="Debugger\Stepping.h">
+      <Filter>Debugger</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -275,6 +278,9 @@
     </ClCompile>
     <ClCompile Include="Common\PostShader.cpp" />
     <ClCompile Include="Debugger\Breakpoints.cpp">
+      <Filter>Debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="Debugger\Stepping.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
   </ItemGroup>

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="DirectX9\helper">
       <UniqueIdentifier>{ba434472-5d5e-4b08-ab16-bfb7ec8e7068}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Debugger">
+      <UniqueIdentifier>{0cbddc00-4aa3-41d0-bed2-a454d37f838e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ge_constants.h">
@@ -148,6 +151,9 @@
       <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\PostShader.h" />
+    <ClInclude Include="Debugger\Breakpoints.h">
+      <Filter>Debugger</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -268,6 +274,9 @@
       <Filter>Common</Filter>
     </ClCompile>
     <ClCompile Include="Common\PostShader.cpp" />
+    <ClCompile Include="Debugger\Breakpoints.cpp">
+      <Filter>Debugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="CMakeLists.txt" />

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -3,6 +3,7 @@
 #include "Windows/InputBox.h"
 #include "Windows/Main.h"
 #include "Core/Config.h"
+#include "GPU/Debugger/Breakpoints.h"
 #include <algorithm>
 
 const PTCHAR CtrlDisplayListView::windowClass = _T("CtrlDisplayListView");
@@ -205,7 +206,7 @@ void CtrlDisplayListView::onPaint(WPARAM wParam, LPARAM lParam)
 		DeleteObject(backgroundPen);
 
 		// display address/symbol
-		if (CGEDebugger::IsAddressBreakPoint(address))
+		if (GPUBreakpoints::IsAddressBreakpoint(address))
 		{
 			textColor = 0x0000FF;
 			int yOffset = std::max(-1,(rowHeight-14+1)/2);

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -113,14 +113,7 @@ bool CGEDebugger::IsTextureBreak(u32 op) {
 		breakNext = BREAK_NEXT_NONTEX;
 	}
 
-	if (IsTextureBreakpoint(state.getTextureAddress(level)) && breakNext == BREAK_NONE) {
-		breakNext = BREAK_NEXT_NONTEX;
-	}
 	return false;
-}
-
-bool CGEDebugger::IsOpOrTextureBreakPoint(u32 op) {
-	return IsOpBreakpoint(op) || IsTextureBreak(op);
 }
 
 static void SetPauseAction(PauseAction act, bool waitComplete = true) {
@@ -561,7 +554,7 @@ void WindowsHost::GPUNotifyCommand(u32 pc) {
 	u32 op = Memory::ReadUnchecked_U32(pc);
 	u8 cmd = op >> 24;
 
-	if (breakNext == BREAK_NEXT_OP || CGEDebugger::IsOpOrTextureBreakPoint(op) || IsAddressBreakpoint(pc)) {
+	if (breakNext == BREAK_NEXT_OP || CGEDebugger::IsTextureBreak(op) || IsBreakpoint(pc, op)) {
 		PauseWithMessage(WM_GEDBG_BREAK_CMD, (WPARAM) pc);
 	}
 }

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -57,8 +57,6 @@ public:
 	static void Init();
 
 	static bool IsTextureBreak(u32 op);
-	// Separate so the UI can just show op break points separately.
-	static bool IsOpOrTextureBreakPoint(u32 op);
 
 protected:
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -56,7 +56,7 @@ public:
 
 	static void Init();
 
-	static bool IsTextureBreakPoint(u32 op);
+	static bool IsTextureBreak(u32 op);
 	// Separate so the UI can just show op break points separately.
 	static bool IsOpOrTextureBreakPoint(u32 op);
 

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -56,8 +56,6 @@ public:
 
 	static void Init();
 
-	static bool IsTextureBreak(u32 op);
-
 protected:
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -56,8 +56,6 @@ public:
 
 	static void Init();
 
-	static bool IsAddressBreakPoint(u32 pc);
-	static bool IsOpBreakPoint(u32 op);
 	static bool IsTextureBreakPoint(u32 op);
 	// Separate so the UI can just show op break points separately.
 	static bool IsOpOrTextureBreakPoint(u32 op);

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -197,6 +197,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/GPU/Common/VertexDecoderCommon.cpp.arm \
   $(SRC)/GPU/Common/TextureDecoder.cpp \
   $(SRC)/GPU/Common/PostShader.cpp \
+  $(SRC)/GPU/Debugger/Breakpoints.cpp \
   $(SRC)/GPU/GLES/Framebuffer.cpp \
   $(SRC)/GPU/GLES/GLES_GPU.cpp.arm \
   $(SRC)/GPU/GLES/TextureCache.cpp.arm \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -198,6 +198,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/GPU/Common/TextureDecoder.cpp \
   $(SRC)/GPU/Common/PostShader.cpp \
   $(SRC)/GPU/Debugger/Breakpoints.cpp \
+  $(SRC)/GPU/Debugger/Stepping.cpp \
   $(SRC)/GPU/GLES/Framebuffer.cpp \
   $(SRC)/GPU/GLES/GLES_GPU.cpp.arm \
   $(SRC)/GPU/GLES/TextureCache.cpp.arm \


### PR DESCRIPTION
This moves some things from Windows/GEDebugger to GPU/Debugger.  Should reduce effort to create a non-Windows debugger, although could probably adjust more.

Also:
- Switch EI_CLASS thing to an ERROR_LOG.  Since there are things out there that are wrong, it's better to run them and just note that it's wrong imho.
- Small tweak to "Assemble Opcode".
- Some fixes to texture breakpoint handling (was breaking on change FROM a texture, not TO.)
- Adds temporary breakpoints for more things (step next prim should be easy now.)
- Better error checking (in case things get called incorrectly.)

Mostly no functional changes.

Also fixed a scrolling issue completely unrelated to the debugger from my shutdown changes.

-[Unknown]
