### PR TITLE
Don't enable Run CPU Tests without the presence of g_Config.memCardDirectory/pspautotests/tests.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -487,7 +487,12 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new ItemHeader(s->T("General")));
 	list->Add(new Choice(de->T("System Information")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSysInfo);
 	list->Add(new CheckBox(&g_Config.bShowDeveloperMenu, de->T("Show Developer Menu")));
-	list->Add(new Choice(de->T("Run CPU Tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
+
+	Choice *cpuTests = new Choice(de->T("Run CPU Tests"));
+	list->Add(cpuTests)->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
+	if (!File::Exists(g_Config.memCardDirectory + "pspautotests/tests/"))
+		cpuTests->SetEnabled(false);
+
 	list->Add(new CheckBox(&enableLogging_, de->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
 	list->Add(new Choice(de->T("Logging Channels")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLogConfig);
 	list->Add(new ItemHeader(de->T("Language")));

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -92,6 +92,8 @@ void RunTests()
 		output = "";
 		if (!PSP_Init(coreParam, &error_string)) {
 			ELOG("Failed to init unittest %s : %s", testsToRun[i], error_string.c_str());
+			PSP_CoreParameter().pixelWidth = pixel_xres;
+			PSP_CoreParameter().pixelHeight = pixel_yres;
 			return;
 		}
 
@@ -114,6 +116,8 @@ void RunTests()
 		std::ifstream expected(expectedFile.c_str(), std::ios_base::in);
 		if (!expected) {
 			ELOG("Error opening expectedFile %s", expectedFile.c_str());
+			PSP_CoreParameter().pixelWidth = pixel_xres;
+			PSP_CoreParameter().pixelHeight = pixel_yres;
 			return;
 		}
 
@@ -146,6 +150,7 @@ void RunTests()
 	}
 	glstate.Restore();
 	glstate.viewport.set(0,0,pixel_xres,pixel_yres);
-
+	PSP_CoreParameter().pixelWidth = pixel_xres;
+	PSP_CoreParameter().pixelHeight = pixel_yres;
 	g_Config.sReportHost = savedReportHost;
 }


### PR DESCRIPTION
Also, don't shrink the UI when exiting RunCPUTests by restoring the proper pixelWidth/pixelHeight.
