### PR TITLE
Allow config files and fonts to be on the memstick

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -475,6 +475,11 @@ const std::string Config::FindConfigFile(const std::string &baseFilename) {
 	if (baseFilename.size() > 1 && baseFilename[0] == '/') {
 		return baseFilename;
 	}
+#ifdef _WIN32
+	if (baseFilename.size() > 3 && baseFilename[1] == ':' && (baseFilename[2] == '/' || baseFilename[2] == '\\')) {
+		return baseFilename;
+	}
+#endif
 
 	for (size_t i = 0; i < searchPath_.size(); ++i) {
 		std::string filename = searchPath_[i] + baseFilename;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -493,9 +493,8 @@ const std::string Config::FindConfigFile(const std::string &baseFilename) {
 }
 
 void Config::RestoreDefaults() {
-	// TODO: This should probably use the correct path?
-	if(File::Exists("ppsspp.ini"))
-		File::Delete("ppsspp.ini");
+	if(File::Exists(iniFilename_))
+		File::Delete(iniFilename_);
 	recentIsos.clear();
 	currentDirectory = "";
 	Load();

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -19,6 +19,7 @@
 #include "base/NativeApp.h"
 #include "Common/KeyMap.h"
 #include "Common/FileUtil.h"
+#include "Common/StringUtils.h"
 #include "Config.h"
 #include "file/ini_file.h"
 #include "i18n/i18n.h"
@@ -36,9 +37,8 @@ Config::~Config() { }
 
 void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 {
-	iniFilename_ = iniFileName != NULL ? iniFileName : "ppsspp.ini";
-
-	controllerIniFilename_ = controllerIniFilename != NULL ? controllerIniFilename : "controls.ini";
+	iniFilename_ = FindConfigFile(iniFileName != NULL ? iniFileName : "ppsspp.ini");
+	controllerIniFilename_ = FindConfigFile(controllerIniFilename != NULL ? controllerIniFilename : "controls.ini");
 
 	INFO_LOG(LOADER, "Loading config: %s", iniFilename_.c_str());
 	bSaveSettings = true;
@@ -462,7 +462,38 @@ void Config::CleanRecent() {
 	recentIsos = cleanedRecent;
 }
 
+void Config::SetDefaultPath(const std::string &defaultPath) {
+	defaultPath_ = defaultPath;
+}
+
+void Config::AddSearchPath(const std::string &path) {
+	searchPath_.push_back(path);
+}
+
+const std::string Config::FindConfigFile(const std::string &baseFilename) {
+	// Don't search for an absolute path.
+	if (baseFilename.size() > 1 && baseFilename[0] == '/') {
+		return baseFilename;
+	}
+
+	for (size_t i = 0; i < searchPath_.size(); ++i) {
+		std::string filename = searchPath_[i] + baseFilename;
+		if (File::Exists(filename)) {
+			return filename;
+		}
+	}
+
+	const std::string filename = defaultPath_.empty() ? baseFilename : defaultPath_ + baseFilename;
+	if (!File::Exists(filename)) {
+		std::string path;
+		SplitPath(filename, &path, NULL, NULL);
+		File::CreateFullPath(path);
+	}
+	return filename;
+}
+
 void Config::RestoreDefaults() {
+	// TODO: This should probably use the correct path?
 	if(File::Exists("ppsspp.ini"))
 		File::Delete("ppsspp.ini");
 	recentIsos.clear();

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -173,7 +173,7 @@ public:
 	std::string currentDirectory;
 	std::string externalDirectory; 
 	std::string memCardDirectory;
-	std::string flashDirectory;
+	std::string flash0Directory;
 	std::string internalDataDirectory;
 
 	void Load(const char *iniFileName = "ppsspp.ini", const char *controllerIniFilename = "controls.ini");

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -180,6 +180,12 @@ public:
 	void Save();
 	void RestoreDefaults();
 
+	// Used when the file is not found in the search path.  Trailing slash.
+	void SetDefaultPath(const std::string &defaultPath);
+	// Use a trailing slash.
+	void AddSearchPath(const std::string &path);
+	const std::string FindConfigFile(const std::string &baseFilename);
+
 	// Utility functions for "recent" management
 	void AddRecent(const std::string &file);
 	void CleanRecent();
@@ -187,6 +193,8 @@ public:
 private:
 	std::string iniFilename_;
 	std::string controllerIniFilename_;
+	std::vector<std::string> searchPath_;
+	std::string defaultPath_;
 };
 
 extern Config g_Config;

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -479,14 +479,22 @@ void __LoadInternalFonts() {
 		// Fonts already loaded.
 		return;
 	}
-	std::string fontPath = "flash0:/font/";
+	const std::string fontPath = "flash0:/font/";
+	const std::string fontOverridePath = "ms0:/PSP/flash0/font/";
 	if (!pspFileSystem.GetFileInfo(fontPath).exists) {
 		pspFileSystem.MkDir(fontPath);
 	}
 	for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
 		const FontRegistryEntry &entry = fontRegistry[i];
-		std::string fontFilename = fontPath + entry.fileName;
+		std::string fontFilename = fontOverridePath + entry.fileName;
 		PSPFileInfo info = pspFileSystem.GetFileInfo(fontFilename);
+
+		if (!info.exists) {
+			// No override, let's use the default then.
+			fontFilename = fontPath + entry.fileName;
+			info = pspFileSystem.GetFileInfo(fontFilename);
+		}
+
 		if (info.exists) {
 			INFO_LOG(SCEFONT, "Loading font %s (%i bytes)", fontFilename.c_str(), (int)info.size);
 			u8 *buffer = new u8[(size_t)info.size];

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -379,6 +379,6 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 #else
 	// TODO
 	memstickpath = g_Config.memCardDirectory;
-	flash0path = g_Config.flashDirectory;
+	flash0path = g_Config.flash0Directory;
 #endif
 }

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "base/logging.h"
 #include "file/ini_file.h"
@@ -80,6 +81,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 					info.fragmentShaderFile = path + "/" + temp;
 					section.Get("Vertex", &temp, "");
 					info.vertexShaderFile = path + "/" + temp;
+					shaderInfo.erase(std::find(shaderInfo.begin(), shaderInfo.end(), info.name), shaderInfo.end());
 					shaderInfo.push_back(info);
 				}
 			}

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -26,6 +26,7 @@
 #include "file/file_util.h"
 #include "file/vfs.h"
 
+#include "Core/Config.h"
 #include "GPU/Common/PostShader.h"
 
 static std::vector<ShaderInfo> shaderInfo;
@@ -58,7 +59,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 				name = name.substr(7);
 			if (path.substr(0, 7) == "assets/")
 				path = path.substr(7);
-			if (!ini.LoadFromVFS(name)) {
+			if (!ini.LoadFromVFS(name) && !ini.Load(fileInfo[f].fullName)) {
 				// vsh load. meh.
 			} else {
 				success = true;
@@ -90,6 +91,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 void LoadAllPostShaderInfo() {
 	std::vector<std::string> directories;
 	directories.push_back("assets/shaders");
+	directories.push_back(g_Config.memCardDirectory + "PSP/shaders");
 	LoadPostShaderInfo(directories);
 }
 

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -34,6 +34,10 @@ struct ShaderInfo {
 
 	// TODO: Add support for all kinds of fun options like mapping the depth buffer,
 	// SRGB texture reads, multiple shaders chained, etc.
+
+	bool operator == (const std::string &other) {
+		return name == other;
+	}
 };
 
 const ShaderInfo *GetPostShaderInfo(std::string name);

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -29,7 +29,6 @@ Texture *uiTexture;
 UIContext *uiContext;
 
 ScreenManager *screenManager;
-std::string config_filename;
 std::string game_title;
 
 event m_hGPUStepEvent;
@@ -228,18 +227,19 @@ void QtHost::NextGPUStep()
 
 void NativeInit(int argc, const char *argv[], const char *savegame_directory, const char *external_directory, const char *installID)
 {
-	std::string config_filename;
 	Common::EnableCrashingOnCrashes();
 	isMessagePending = false;
 
 	std::string user_data_path = savegame_directory;
+	std::string memcard_path = QDir::homePath().toStdString() + "/.ppsspp/";
 
 	VFSRegister("", new DirectoryAssetReader("assets/"));
 	VFSRegister("", new DirectoryAssetReader(user_data_path.c_str()));
 
-	config_filename = user_data_path + "ppsspp.ini";
-
-	g_Config.Load(config_filename.c_str());
+	g_Config.AddSearchPath(user_data_path);
+	g_Config.AddSearchPath(memcard_path + "PSP/SYSTEM/");
+	g_Config.SetDefaultPath(g_Config.memCardDirectory + "PSP/SYSTEM/");
+	g_Config.Load();
 
 	const char *fileToLog = 0;
 

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -309,7 +309,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 	}
 
 	g_Config.memCardDirectory = QDir::homePath().toStdString()+"/.ppsspp/";
-	g_Config.flashDirectory = g_Config.memCardDirectory+"/flash0/";
+	g_Config.flash0Directory = g_Config.memCardDirectory+"/flash0/";
 
 	LogManager::Init();
 	if (fileToLog != NULL)

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -126,7 +126,7 @@ UI::EventReturn CwCheatScreen::OnEnableAll(UI::EventParams &params)
 			cheatList[j].replace(0, 3, "_C0");
 		}
 	}
-	for (int y = 0; y < bEnableCheat.size(); y++) {
+	for (size_t y = 0; y < bEnableCheat.size(); y++) {
 		bEnableCheat[y] = enableAll;
 	}
 	for (int i = 0; i < (int)cheatList.size(); i++) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -149,7 +149,7 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 	shaders_ = GetAllPostShaderInfo();
 	std::vector<std::string> items;
 	int selected = -1;
-	for (int i = 0; i < shaders_.size(); i++) {
+	for (int i = 0; i < (int)shaders_.size(); i++) {
 		if (shaders_[i].section == g_Config.sPostShaderName)
 			selected = i;
 		items.push_back(shaders_[i].name);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -246,6 +246,22 @@ void NativeInit(int argc, const char *argv[],
 
 	host = new NativeHost();
 
+#if defined(ANDROID)
+	g_Config.internalDataDirectory = savegame_directory;
+	// Maybe there should be an option to use internal memory instead, but I think
+	// that for most people, using external memory (SDCard/USB Storage) makes the
+	// most sense.
+	g_Config.memCardDirectory = std::string(external_directory) + "/";
+	g_Config.flashDirectory = std::string(external_directory) + "/flash0/";
+#elif defined(BLACKBERRY) || defined(__SYMBIAN32__) || defined(MEEGO_EDITION_HARMATTAN) || defined(IOS)
+	g_Config.memCardDirectory = user_data_path;
+	g_Config.flashDirectory = std::string(external_directory) + "/flash0/";
+#elif !defined(_WIN32)
+	// Linux, Mac.  Does this path really make sense?
+	g_Config.memCardDirectory = std::string(getenv("HOME")) + "/.ppsspp/";
+	g_Config.flashDirectory = g_Config.memCardDirectory + "/flash0/";
+#endif
+
 #ifndef _WIN32
 	logger = new AndroidLogger();
 
@@ -253,19 +269,20 @@ void NativeInit(int argc, const char *argv[],
 	LogManager *logman = LogManager::GetInstance();
 	ILOG("Logman: %p", logman);
 
-	config_filename = user_data_path + "/ppsspp.ini";
-	std::string controls_filename = user_data_path + "/controls.ini";
-	g_Config.Load(config_filename.c_str(), controls_filename.c_str());
+	g_Config.AddSearchPath(user_data_path);
+	g_Config.AddSearchPath(g_Config.memCardDirectory + "PSP/SYSTEM/");
+	g_Config.SetDefaultPath(g_Config.memCardDirectory + "PSP/SYSTEM/");
+	g_Config.Load();
 	g_Config.externalDirectory = external_directory;
 #endif
 
 #ifdef ANDROID
 	// On Android, create a PSP directory tree in the external_directory,
 	// to hopefully reduce confusion a bit. 
-	ILOG("Creating %s", (g_Config.externalDirectory + "/PSP").c_str());
-	mkDir((g_Config.externalDirectory + "/PSP").c_str());
-	mkDir((g_Config.externalDirectory + "/PSP/SAVEDATA").c_str());
-	mkDir((g_Config.externalDirectory + "/PSP/GAME").c_str());
+	ILOG("Creating %s", (g_Config.memCardDirectory + "PSP").c_str());
+	mkDir((g_Config.memCardDirectory + "PSP").c_str());
+	mkDir((g_Config.memCardDirectory + "PSP/SAVEDATA").c_str());
+	mkDir((g_Config.memCardDirectory + "PSP/GAME").c_str());
 #endif
 
 	const char *fileToLog = 0;
@@ -330,21 +347,6 @@ void NativeInit(int argc, const char *argv[],
 		g_Config.currentDirectory = getenv("HOME");
 #endif
 	}
-
-#if defined(ANDROID)
-	g_Config.internalDataDirectory = savegame_directory;
-	// Maybe there should be an option to use internal memory instead, but I think
-	// that for most people, using external memory (SDCard/USB Storage) makes the
-	// most sense.
-	g_Config.memCardDirectory = std::string(external_directory) + "/";
-	g_Config.flashDirectory = std::string(external_directory)+"/flash0/";
-#elif defined(BLACKBERRY) || defined(__SYMBIAN32__) || defined(MEEGO_EDITION_HARMATTAN) || defined(IOS) || defined(_WIN32)
-	g_Config.memCardDirectory = user_data_path;
-	g_Config.flashDirectory = std::string(external_directory)+"flash0/";
-#else
-	g_Config.memCardDirectory = std::string(getenv("HOME"))+"/.ppsspp/";
-	g_Config.flashDirectory = g_Config.memCardDirectory+"/flash0/";
-#endif
 
 	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++)
 	{

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -252,14 +252,14 @@ void NativeInit(int argc, const char *argv[],
 	// that for most people, using external memory (SDCard/USB Storage) makes the
 	// most sense.
 	g_Config.memCardDirectory = std::string(external_directory) + "/";
-	g_Config.flashDirectory = std::string(external_directory) + "/flash0/";
+	g_Config.flash0Directory = std::string(external_directory) + "/flash0/";
 #elif defined(BLACKBERRY) || defined(__SYMBIAN32__) || defined(MEEGO_EDITION_HARMATTAN) || defined(IOS)
 	g_Config.memCardDirectory = user_data_path;
-	g_Config.flashDirectory = std::string(external_directory) + "/flash0/";
+	g_Config.flash0Directory = std::string(external_directory) + "/flash0/";
 #elif !defined(_WIN32)
 	// Linux, Mac.  Does this path really make sense?
 	g_Config.memCardDirectory = std::string(getenv("HOME")) + "/.ppsspp/";
-	g_Config.flashDirectory = g_Config.memCardDirectory + "/flash0/";
+	g_Config.flash0Directory = g_Config.memCardDirectory + "/flash0/";
 #endif
 
 #ifndef _WIN32

--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -18,8 +18,6 @@ static int xres, yres;
 // TODO: Make config?
 static bool enableGLDebug = false;
 
-#pragma optimize("", off)
-
 void GL_Resized() {
 	if (!hWnd)
 		return;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -448,7 +448,7 @@ namespace MainWindow
 	void UpdateDynamicMenuCheckmarks() {
 		int item = ID_SHADERS_BASE + 1;
 
-		for (int i = 0; i < availableShaders.size(); i++)
+		for (size_t i = 0; i < availableShaders.size(); i++)
 			CheckMenuItem(menu, item++, ((g_Config.sPostShaderName == availableShaders[i]) ? MF_CHECKED : MF_UNCHECKED));
 	}
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -195,10 +195,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();
 
-	std::string configFilename;
+	const char *configFilename = NULL;
 	const char *configOption = "--config=";
 
-	std::string controlsConfigFilename;
+	const char *controlsConfigFilename = NULL;
 	const char *controlsOption = "--controlconfig=";
 
 	for (int i = 1; i < __argc; ++i)
@@ -216,15 +216,15 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		}
 	}
 
-	if(configFilename.empty())
-		configFilename = "ppsspp.ini";
-
-	if(controlsConfigFilename.empty())
-		controlsConfigFilename = "controls.ini";
+	std::string memstickpath, flash0path;
+	GetSysDirectories(memstickpath, flash0path);
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.Load(configFilename.c_str(), controlsConfigFilename.c_str());
+	g_Config.AddSearchPath("");
+	g_Config.AddSearchPath(memstickpath + "PSP/SYSTEM/");
+	g_Config.SetDefaultPath(memstickpath + "PSP/SYSTEM/");
+	g_Config.Load(configFilename, controlsConfigFilename);
 
 	// The rest is handled in NativeInit().
 	for (int i = 1; i < __argc; ++i)

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -73,7 +73,7 @@ void RunTests()
 	coreParam.updateRecent = false;
 
 #ifdef IOS
-	std::string baseDirectory = g_Config.flashDirectory + "../";
+	std::string baseDirectory = g_Config.flash0Directory + "../";
 #else
 	std::string baseDirectory = g_Config.memCardDirectory;
 #endif

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -329,7 +329,7 @@ int main(int argc, const char* argv[])
 #elif defined(BLACKBERRY) || defined(__SYMBIAN32__)
 #elif !defined(_WIN32)
 	g_Config.memCardDirectory = std::string(getenv("HOME"))+"/.ppsspp/";
-	g_Config.flashDirectory = g_Config.memCardDirectory+"/flash/";
+	g_Config.flash0Directory = g_Config.memCardDirectory+"/flash/";
 #endif
 
 	if (screenshotFilename != 0)


### PR DESCRIPTION
With this, the following happens:
- If you have a file PSP/flash0/font/ltn1.pgf under memstick/, it overrides the default flash0 font.  On Android, this should allow overriding fonts.  Fixes #1630.
- The default config file location has changed to PSP/SYSTEM/ppsspp.ini.  If you have a ppsspp.ini in the old location, it will still be used just as before.  Fixes #868.
- Resetting settings to defaults now deletes the active configuration file.  This allows you to "switch" to the memstick path.  It also applies when started with `--config=...` etc.

This overlaps slightly with #4070, but that's trying to solve a different problem.  With these changes, I'm primarily concerned with non-Windows.  I just saw now that it was Config/ not SYSTEM/, I don't care which... my PSP has a SYSTEM/ by default, so it seemed reasonable, but maybe the overlap is confusing.

-[Unknown]
