### PR TITLE
Set stencil ref value to 0xFF when tex format is 5650 which is no alpha

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -327,10 +327,20 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		
 		// Stencil Test
 		if (gstate.isStencilTestEnabled() && enableStencilTest) {
-			glstate.stencilTest.enable();
-			glstate.stencilFunc.set(ztests[gstate.getStencilTestFunction()],
-				gstate.getStencilTestRef(),
-				gstate.getStencilTestMask());
+			glstate.stencilTest.enable(); 
+			int stencilValue = gstate.getStencilTestRef();
+			switch (gstate.getClutPaletteFormat()) {
+			case GE_TFMT_5650:
+				stencilValue = 0xFF;
+				break;
+			case GE_TFMT_5551:
+				stencilValue &= 0x80;
+				break;
+			case GE_TFMT_4444:
+				stencilValue &= 0xF0;
+				break;
+			}
+			glstate.stencilFunc.set(ztests[gstate.getStencilTestFunction()], stencilValue, gstate.getStencilTestMask());
 			glstate.stencilOp.set(stencilOps[gstate.getStencilOpSFail()],  // stencil fail
 				stencilOps[gstate.getStencilOpZFail()],  // depth fail
 				stencilOps[gstate.getStencilOpZPass()]); // depth pass


### PR DESCRIPTION
Tested with following games that affected by stencil testing and no regression .

-Unaffected
1. Brave Story
2. Outrun 2006
3. Star Ocean
4. FF4

-Helped
-Midnight Club 4
