### PR TITLE
Win32: Make NewUI's Graphics -> Fullscreen checkbox instant.

### DIFF
--- a/Core/Host.h
+++ b/Core/Host.h
@@ -45,6 +45,7 @@ public:
 	virtual void InitSound(PMixer *mixer) = 0;
 	virtual void UpdateSound() {}
 	virtual void UpdateScreen() {}
+	virtual void GoFullscreen(bool) {}
 	virtual void ShutdownSound() = 0;
 	virtual void PollControllers(InputState &input_state) {}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -136,7 +136,7 @@ void GameSettingsScreen::CreateViews() {
 	// graphicsSettings->Add(new CheckBox(&g_Config.bTrueColor, gs->T("True Color")));
 #ifdef _WIN32
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gs->T("VSync")));
-	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gs->T("FullScreen")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gs->T("FullScreen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
 #endif
 	
 	graphicsSettings->Add(new ItemHeader(gs->T("Antialiasing and postprocessing"))); 
@@ -302,6 +302,11 @@ UI::EventReturn GameSettingsScreen::OnReloadCheats(UI::EventParams &e) {
 UI::EventReturn GameSettingsScreen::OnRenderingMode(UI::EventParams &e) {
 	enableReports_ = Reporting::IsEnabled();
 	enableReportsCheckbox_->SetEnabled(Reporting::IsSupported());
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnFullscreenChange(UI::EventParams &e) {
+	host->GoFullscreen(g_Config.bFullScreen);
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -63,6 +63,7 @@ private:
 	UI::EventReturn OnChangeNickname(UI::EventParams &e);
 	UI::EventReturn OnClearRecents(UI::EventParams &e);
 	UI::EventReturn OnRenderingMode(UI::EventParams &e);
+	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -369,3 +369,10 @@ bool WindowsHost::CreateDesktopShortcut(std::string argumentPath, std::string ga
 	delete [] pathbuf;
 	return false;
 }
+
+void WindowsHost::GoFullscreen(bool viewFullscreen) {
+	if (viewFullscreen)
+		MainWindow::_ViewFullScreen(MainWindow::GetHWND());
+	else
+		MainWindow::_ViewNormal(MainWindow::GetHWND());
+}

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -66,6 +66,8 @@ public:
 	virtual bool CanCreateShortcut() {return false;}  // Turn on when fixed
 	virtual bool CreateDesktopShortcut(std::string argumentPath, std::string title);
 
+	virtual void GoFullscreen(bool);
+
 	bool InputBoxGetString(char *title, const char *defaultValue, char *outValue, size_t outlength);
 	bool InputBoxGetWString(const wchar_t *title, const std::wstring &defaultvalue, std::wstring &outvalue);
 	std::shared_ptr<KeyboardDevice> keyboard;


### PR DESCRIPTION
This fixes a bug where pressing the fullscreen checkbox would cause the UI mouse factor to get screwed up, in addition to making the fullscreen change happen instantly.
