### PR TITLE
Win32: Fix critical bug with GetSysDirectories.

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -652,13 +652,13 @@ std::string GetBundleDirectory()
 #endif
 
 #ifdef _WIN32
-std::string &GetExeDirectory()
+std::wstring &GetExeDirectory()
 {
-	static std::string DolphinPath;
+	static std::wstring DolphinPath;
 	if (DolphinPath.empty())
 	{
-		char Dolphin_exe_Path[2048];
-		GetModuleFileNameA(NULL, Dolphin_exe_Path, 2048);
+		wchar_t Dolphin_exe_Path[2048];
+		GetModuleFileName(NULL, Dolphin_exe_Path, 2048);
 		DolphinPath = Dolphin_exe_Path;
 		DolphinPath = DolphinPath.substr(0, DolphinPath.find_last_of('\\'));
 	}

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -125,7 +125,7 @@ std::string GetBundleDirectory();
 #endif
 
 #ifdef _WIN32
-std::string &GetExeDirectory();
+std::wstring &GetExeDirectory();
 #endif
 
 // simple wrapper for cstdlib file functions to

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -363,7 +363,7 @@ CoreParameter &PSP_CoreParameter() {
 
 void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 #ifdef _WIN32
-	std::string path = File::GetExeDirectory();
+	std::string path = ConvertWStringToUTF8(File::GetExeDirectory());
 
 	// Mount a filesystem
 	flash0path = path + "/flash0/";
@@ -402,7 +402,7 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 	// We're screwed anyway if we can't write to Documents, or can't detect it.
 	std::string testFile = "/_writable_test.$$$";
 
-	if (!File::CreateEmptyFile(path + testFile))
+	if (!File::CreateEmptyFile(memstickpath + testFile))
 		memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
 
 	// Clean up our mess.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -36,6 +36,7 @@
 #include "file/zip_read.h"
 #include "native/ext/stb_image_write/stb_image_writer.h"
 #include "native/ext/jpge/jpge.h"
+#include "native/util/text/utf8.h"
 #include "gfx_es2/gl_state.h"
 #include "gfx_es2/draw_text.h"
 #include "gfx/gl_lost_manager.h"
@@ -368,7 +369,7 @@ void NativeInit(int argc, const char *argv[],
 	INFO_LOG(BOOT, "Logger inited.");
 #else
 	if (g_Config.currentDirectory.empty()) {
-		g_Config.currentDirectory = File::GetExeDirectory();
+		g_Config.currentDirectory = ConvertWStringToUTF8(File::GetExeDirectory());
 	}
 	g_Config.memCardDirectory = "MemStick/";
 #endif	


### PR DESCRIPTION
It needs to use GetModuleFileName instead of GetModuleFileNameA, and it also needs to create the empty file in memstickpath, not path.

Apologies to users with non-ASCII characters in their paths.
