### PR TITLE
Fix cheats on a default install, remove restart game requirement

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -7,7 +7,6 @@
 #include "MIPS/MIPS.h"
 #include "Core/Config.h"
 
-const static std::string CHEATS_DIR = "cheats";
 static int CheatEvent = -1;
 std::string gameTitle;
 std::string activeCheatFile;
@@ -29,13 +28,9 @@ static void __CheatStart() {
 	__CheatStop();
 
 	gameTitle = g_paramSFO.GetValueString("DISC_ID");
-#if defined(ANDROID) || defined(__SYMBIAN32__) || defined(_WIN32)
+
 	activeCheatFile = g_Config.memCardDirectory + "PSP/Cheats/" + gameTitle + ".ini";
 	File::CreateFullPath(g_Config.memCardDirectory + "PSP/Cheats");
-#else
-	activeCheatFile = CHEATS_DIR + "/" + gameTitle + ".ini";
-	File::CreateFullPath(CHEATS_DIR);
-#endif
 
 	if (!File::Exists(activeCheatFile)) {
 		File::CreateEmptyFile(activeCheatFile);

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -219,6 +219,9 @@ std::vector<std::string> CWCheatEngine::GetCodesList() { //Reads the entire chea
 	std::string line;
 	std::vector<std::string> codesList;  // Read from INI here
 	std::ifstream list(activeCheatFile.c_str());
+	if (!list) {
+		return codesList;
+	}
 	for (int i = 0; !list.eof(); i ++) {
 		getline(list, line, '\n');
 		if (line.length() > 3 && line.substr(0,1) == "_"){

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -59,13 +59,20 @@ void __CheatShutdown() {
 }
 
 void __CheatDoState(PointerWrap &p) {
-	auto s = p.Section("CwCheat", 0, 1);
+	auto s = p.Section("CwCheat", 0, 2);
 	if (!s) {
 		return;
 	}
 
 	p.Do(CheatEvent);
 	CoreTiming::RestoreRegisterEvent(CheatEvent, "CheatEvent", &hleCheat);
+
+	if (s < 2) {
+		// Before this we didn't have a checkpoint, so reset didn't work.
+		// Let's just force one in.
+		CoreTiming::RemoveEvent(CheatEvent);
+		CoreTiming::ScheduleEvent(msToCycles(cheatsEnabled ? 77 : 1000), CheatEvent, 0);
+	}
 }
 
 void hleCheat(u64 userdata, int cyclesLate) {

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -19,13 +19,14 @@ void __CheatInit() {
 	gameTitle = g_paramSFO.GetValueString("DISC_ID");
 #if defined(ANDROID) || defined(__SYMBIAN32__) || defined(_WIN32)
 	activeCheatFile = g_Config.memCardDirectory + "PSP/Cheats/" + gameTitle + ".ini";
+	File::CreateFullPath(g_Config.memCardDirectory + "PSP/Cheats");
 #else
 	activeCheatFile = CHEATS_DIR + "/" + gameTitle + ".ini";
+	File::CreateFullPath(CHEATS_DIR);
 #endif
 
 	CheatEvent = CoreTiming::RegisterEvent("CheatEvent", &hleCheat);
 
-	File::CreateFullPath(CHEATS_DIR);
 	if (g_Config.bEnableCheats) {
 		if (!File::Exists(activeCheatFile)) {
 			File::CreateEmptyFile(activeCheatFile);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1180,8 +1180,6 @@ namespace MainWindow
 				case ID_EMULATION_CHEATS:
 					g_Config.bEnableCheats = !g_Config.bEnableCheats;
 					osm.ShowOnOff(g->T("Cheats"), g_Config.bEnableCheats);
-					NativeMessageReceived("reset", "");
-					Core_EnableStepping(false);
 					break;
 
 				case ID_FILE_LOADSTATEFILE:


### PR DESCRIPTION
A checkpoint to see if the setting was enabled every second should be cheap and soon enough to make anyone happy.  This way, restarts are not necessary.

Moves to PSP/Cheats/ on all platforms.

Someone will need to update the lang file to remove "(Resets Game)" since it's no longer true.

-[Unknown]
