### PR TITLE
Improve accuracy of sceHeap functions

### DIFF
--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -153,8 +153,9 @@ int sceHeapAllocHeapMemory(u32 heapAddr, u32 memSize) {
 	Heap *heap = heapList[heapAddr];
 	if (!heap)
 		return SCE_KERNEL_ERROR_INVALID_ID;
-	u32 addr = heap->alloc.Alloc(memSize, heap->fromtop);
-	DEBUG_LOG(HLE,"sceHeapAllocHeapMemory(%08x, %08x)", heapAddr, memSize);
+	// Always goes down, regardless of whether the heap is high or low.
+	u32 addr = heap->alloc.Alloc(memSize, true);
+	DEBUG_LOG(HLE, "sceHeapAllocHeapMemory(%08x, %08x)", heapAddr, memSize);
 	return addr;
 }
 

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -103,9 +103,12 @@ int sceHeapAllocHeapMemoryWithOption(u32 heapAddr, u32 memSize, u32 paramsPtr) {
 
 int sceHeapGetTotalFreeSize(u32 heapAddr) {
 	Heap *heap = heapList[heapAddr];
-	if (!heap)
+	if (!heap) {
+		ERROR_LOG(HLE, "sceHeapGetTotalFreeSize(%08x): invalid heap", heapAddr);
 		return SCE_KERNEL_ERROR_INVALID_ID;
-	DEBUG_LOG(HLE,"UNIMPL sceHeapGetTotalFreeSize(%08x)", heapAddr);
+	}
+
+	DEBUG_LOG(HLE, "sceHeapGetTotalFreeSize(%08x)", heapAddr);
 	u32 free = heap->alloc.GetTotalFreeBytes();
 	if (free >= 8) {
 		// Every allocation requires an extra 8 bytes.
@@ -120,10 +123,16 @@ int sceHeapIsAllocatedHeapMemory(u32 heapPtr, u32 memPtr) {
 }
 
 int sceHeapDeleteHeap(u32 heapAddr) {
-	Heap *heap = heapList[heapAddr];
-	if(heapList.erase(heapAddr) != 0)
-		delete heap;
-	ERROR_LOG_REPORT(HLE,"UNIMPL sceHeapDeleteHeap(%08x)", heapAddr);
+	auto found = heapList.find(heapAddr);
+	if (found == heapList.end()) {
+		ERROR_LOG(HLE, "sceHeapDeleteHeap(%08x): invalid heap", heapAddr);
+		return SCE_KERNEL_ERROR_INVALID_ID;
+	}
+
+	DEBUG_LOG(HLE, "sceHeapDeleteHeap(%08x)", heapAddr);
+	Heap *heap = found->second;
+	heapList.erase(found);
+	delete heap;
 	return 0;
 }
 
@@ -159,7 +168,7 @@ int sceHeapCreateHeap(const char* name, u32 heapSize, int attr, u32 paramsPtr) {
 int sceHeapAllocHeapMemory(u32 heapAddr, u32 memSize) {
 	Heap *heap = heapList[heapAddr];
 	if (!heap) {
-		WARN_LOG(HLE, "sceHeapAllocHeapMemory(%08x, %08x): invalid heap", heapAddr, memSize);
+		ERROR_LOG(HLE, "sceHeapAllocHeapMemory(%08x, %08x): invalid heap", heapAddr, memSize);
 		return SCE_KERNEL_ERROR_INVALID_ID;
 	}
 

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -79,18 +79,21 @@ int sceHeapReallocHeapMemoryWithOption(u32 heapPtr, u32 memPtr, int memSize, u32
 }
 
 int sceHeapFreeHeapMemory(u32 heapAddr, u32 memAddr) {
-	if (!Memory::IsValidAddress(memAddr))
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
 	Heap *heap = getHeap(heapAddr);
 	if (!heap) {
 		ERROR_LOG(HLE, "sceHeapFreeHeapMemory(%08x, %08x): invalid heap", heapAddr, memAddr);
 		return SCE_KERNEL_ERROR_INVALID_ID;
 	}
 
-	if(!heap->alloc.FreeExact(memAddr))
-		return SCE_KERNEL_ERROR_INVALID_POINTER;
+	DEBUG_LOG(HLE, "sceHeapFreeHeapMemory(%08x, %08x)", heapAddr, memAddr);
+	// An invalid address will crash the PSP, but 0 is always returns success.
+	if (memAddr == 0) {
+		return 0;
+	}
 
-	DEBUG_LOG(HLE,"sceHeapFreeHeapMemory(%08x, %08x)", heapAddr, memAddr);
+	if (!heap->alloc.FreeExact(memAddr)) {
+		return SCE_KERNEL_ERROR_INVALID_POINTER;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Mostly fixes error codes, implemented sceHeapIsAllocatedHeapMemory() since I saw it was being called:

http://report.ppsspp.org/logs/kind/395?status=any

And made some of the memory management numbers more accurate.  Haven't really created proper tests yet, but I did mostly test each of these changes.

@shenweip I don't have any games actually using these funcs, so please let me know if this causes any problems.  Hopefully it will help things.

-[Unknown]
