### PR TITLE
Make it possible to build headless on Android

### DIFF
--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -1,0 +1,49 @@
+# These are definitions for LOCAL_ variables for PPSSPP.
+# They are shared between ppsspp_jni (lib for Android app) and ppsspp_headless.
+
+LOCAL_CFLAGS := -DUSE_FFMPEG -DUSE_PROFILER -DUSING_GLES2 -O3 -fsigned-char -Wall -Wno-multichar -Wno-psabi -Wno-unused-variable -fno-strict-aliasing
+# yes, it's really CPPFLAGS for C++
+LOCAL_CPPFLAGS := -fno-exceptions -std=gnu++11 -fno-rtti -Wno-reorder -Wno-literal-suffix
+LOCAL_C_INCLUDES := \
+  $(LOCAL_PATH)/../../Common \
+  $(LOCAL_PATH)/../.. \
+  $(LOCAL_PATH)/$(NATIVE)/base \
+  $(LOCAL_PATH)/$(NATIVE)/ext/libzip \
+  $(LOCAL_PATH)/$(NATIVE) \
+  $(LOCAL_PATH)
+
+LOCAL_STATIC_LIBRARIES := native libzip
+LOCAL_LDLIBS := -lz -lGLESv2 -lEGL -ldl -llog
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavformat.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavcodec.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libswresample.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libswscale.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavutil.a
+  LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/armv7/include
+  LOCAL_CFLAGS += -DARMEABI_V7A
+
+  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMV7
+endif
+ifeq ($(TARGET_ARCH_ABI),armeabi)
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libavformat.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libavcodec.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libswresample.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libswscale.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libavutil.a
+  LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/armv6/include
+  LOCAL_CFLAGS += -DARMEABI
+
+  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM
+endif
+ifeq ($(TARGET_ARCH_ABI),x86)
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavformat.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavcodec.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libswresample.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libswscale.a
+  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavutil.a
+  LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/x86/include
+
+  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_M_IX86 -fomit-frame-pointer -mtune=atom -mssse3
+endif

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -79,14 +79,13 @@ void printUsage(const char *progname, const char *reason)
 	fprintf(stderr, "  -m, --mount umd.cso   mount iso on umd:\n");
 	fprintf(stderr, "  -l, --log             full log output, not just emulated printfs\n");
 
-	HEADLESSHOST_CLASS h1;
-	HeadlessHost h2;
-	if (typeid(h1) != typeid(h2))
+#if HEADLESSHOST_CLASS != HeadlessHost
 	{
 		fprintf(stderr, "  --graphics=BACKEND    use the full gpu backend (slower)\n");
 		fprintf(stderr, "                        options: gles, software, directx9\n");
 		fprintf(stderr, "  --screenshot=FILE     compare against a screenshot\n");
 	}
+#endif
 	fprintf(stderr, "  --timeout=SECONDS     abort test it if takes longer than SECONDS\n");
 
 	fprintf(stderr, "  -v, --verbose         show the full passed/failed result\n");
@@ -100,8 +99,10 @@ static HeadlessHost * getHost(GPUCore gpuCore) {
 	switch(gpuCore) {
 	case GPU_NULL:
 		return new HeadlessHost();
+#ifdef _WIN32
 	case GPU_DIRECTX9:
 		return new WindowsHeadlessHostDx9();
+#endif
 	default:
 		return new HEADLESSHOST_CLASS();
 	}


### PR DESCRIPTION
All you need to do is add HEADLESS=1 to your command line.

Or, like me, you can use a custom script, I have ab2.cmd that just calls it with `NDK_DEBUG=1 APP_ABI=armeabi-v7a HEADLESS=1` and my own NDK path.

-[Unknown]
