### PR TITLE
Win32: Make PPSSPP aware of the Windows Vista/7/8/8.1 Virtual Store.

### DIFF
--- a/Windows/rt_manif.bin
+++ b/Windows/rt_manif.bin
@@ -19,4 +19,14 @@
          processorArchitecture="*"/>
   </dependentAssembly>
  </dependency>
+  <!-- Identify the application security requirements. -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel
+          level="asInvoker"
+          uiAccess="false"/>
+        </requestedPrivileges>
+       </security>
+  </trustInfo> 
 </assembly>

--- a/Windows/rt_manif.bin
+++ b/Windows/rt_manif.bin
@@ -18,15 +18,15 @@
          language="*"
          processorArchitecture="*"/>
   </dependentAssembly>
- </dependency>
-  <!-- Identify the application security requirements. -->
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel
-          level="asInvoker"
-          uiAccess="false"/>
-        </requestedPrivileges>
-       </security>
-  </trustInfo> 
+ </dependency> 
+<!-- Identify the application security requirements. -->
+ <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+  <security>
+   <requestedPrivileges>
+    <requestedExecutionLevel
+     level="asInvoker"
+     uiAccess="false"/>
+   </requestedPrivileges>
+  </security>
+ </trustInfo> 
 </assembly>


### PR DESCRIPTION
I had intended on committing this in my last pull request regarding portable mode, but I ended up forgetting. This'll make it so when PPSSPP is run from a read only directory(e.g. program files), it'll really fail when trying to create files and not use the Virtual Store UAC provides(http://stackoverflow.com/questions/11830864/how-can-i-make-that-when-i-run-my-application-thorugh-the-vs-it-will-prompt-for, http://stackoverflow.com/questions/4730053/how-to-disable-virtualstore-for-c-programs, except we use asinvoker, since we _don't_ want admin access), so the fallbacks work correctly.
