### PR TITLE
Win32: Don't write files before creating the directory in the first place.

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -381,11 +381,11 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 
 		if (!inputFile.fail() && inputFile.is_open()) {
 			std::string tempString;
-			
+
 			std::getline(inputFile, tempString);
 
 			// Skip UTF-8 encoding bytes if there are any. There are 3 of them.
-			if (tempString.substr(0, 3) == "\xEF\xBB\xBF") 
+			if (tempString.substr(0, 3) == "\xEF\xBB\xBF")
 				tempString = tempString.substr(3);
 
 			memstickpath = tempString;
@@ -403,10 +403,17 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 		memstickpath = path + "/memstick/";
 	}
 
-	// If any directory is read-only, fall back to the Documents directory.
-	// We're screwed anyway if we can't write to Documents, or can't detect it.
+	// Create the memstickpath before trying to write to it, and fall back on Documents yet again
+	// if we can't make it.
+	if (!File::Exists(memstickpath)) {
+		if(!File::CreateDir(memstickpath))
+			memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
+	}
+
 	const std::string testFile = "/_writable_test.$$$";
 
+	// If any directory is read-only, fall back to the Documents directory.
+	// We're screwed anyway if we can't write to Documents, or can't detect it.
 	if (!File::CreateEmptyFile(memstickpath + testFile))
 		memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -371,7 +371,8 @@ void NativeInit(int argc, const char *argv[],
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = ConvertWStringToUTF8(File::GetExeDirectory());
 	}
-	g_Config.memCardDirectory = "MemStick/";
+	// TODO: Is this even needed, when PPSSPP uses GetSysDirectories in multiple other places?
+	g_Config.memCardDirectory = "memstick/";
 #endif	
 
 	i18nrepo.LoadIni(g_Config.sLanguageIni);


### PR DESCRIPTION
May possibly fix https://github.com/hrydgard/ppsspp/issues/4189, but it was wrong either way; it was making the read-only directory detection fail on perfectly usable directories.
