### PR TITLE
Fix savestates sometimes wiping thread stacks

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -487,7 +487,8 @@ public:
 		currentStack.start = 0;
 	}
 
-	~Thread()
+	// Can't use a destructor since savestates will call that too.
+	void Cleanup()
 	{
 		// Callbacks are automatically deleted when their owning thread is deleted.
 		for (auto it = callbacks.begin(), end = callbacks.end(); it != end; ++it)
@@ -1798,6 +1799,8 @@ u32 __KernelDeleteThread(SceUID threadID, int exitStatus, const char *reason)
 			if (callback && callback->nc.notifyCount != 0)
 				readyCallbacksCount--;
 		}
+
+		t->Cleanup();
 	}
 
 	return kernelObjects.Destroy<Thread>(threadID);

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -74,8 +74,8 @@ LPDIRECT3DPIXELSHADER9       pFramebufferPixelShader = NULL;  // Pixel Shader
 bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
 	LPD3DXCONSTANTTABLE shaderTable = *pShaderTable;
 
-	ID3DXBuffer* pShaderCode;
-	ID3DXBuffer* pErrorMsg;
+	ID3DXBuffer* pShaderCode = NULL;
+	ID3DXBuffer* pErrorMsg = NULL;
 
 	HRESULT hr = -1;
 
@@ -111,8 +111,8 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
 	LPD3DXCONSTANTTABLE shaderTable = *pShaderTable;
 
-	ID3DXBuffer* pShaderCode;
-	ID3DXBuffer* pErrorMsg;
+	ID3DXBuffer* pShaderCode = NULL;
+	ID3DXBuffer* pErrorMsg = NULL;
 
 	HRESULT hr = -1;
 
@@ -146,8 +146,8 @@ bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, L
 }
 
 void CompileShaders() {
-	ID3DXBuffer* pShaderCode;
-	ID3DXBuffer* pErrorMsg;
+	ID3DXBuffer* pShaderCode = NULL;
+	ID3DXBuffer* pErrorMsg = NULL;
 	HRESULT hr = -1;
 
 #ifdef _XBOX

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1141,7 +1141,7 @@ void CtrlDisAsmView::search(bool continueSearch)
 			return;
 		}
 
-		for (int i = 0; i < searchQuery.size(); i++)
+		for (size_t i = 0; i < searchQuery.size(); i++)
 		{
 			searchQuery[i] = tolower(searchQuery[i]);
 		}


### PR DESCRIPTION
Sequence of events during a load state:
1. Load memory.
2. Destruct threads, automatically zeroing out memory in some cases.
3. Create new threads and restore their state.
4. Crash because the thread's stack is all zeroed out now.

Could've been affecting many other games than FF1, and could've only randomly caused problems depending on the threads.  Ugh.

Verified all other destructors, they don't have this problem (kernel objects are loaded before everything _except_ ram.... not sure, but I think we want ram first, in case it references it...)

-[Unknown]
