### PR TITLE
Eliminate GetSysDirectories and instead provide a new function: GetSysDirectory.

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -29,8 +29,8 @@ static void __CheatStart() {
 
 	gameTitle = g_paramSFO.GetValueString("DISC_ID");
 
-	activeCheatFile = g_Config.memCardDirectory + "PSP/Cheats/" + gameTitle + ".ini";
-	File::CreateFullPath(g_Config.memCardDirectory + "PSP/Cheats");
+	activeCheatFile = GetSysDirectory(DIRECTORY_CHEATS) + gameTitle + ".ini";
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_CHEATS));
 
 	if (!File::Exists(activeCheatFile)) {
 		File::CreateEmptyFile(activeCheatFile);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -448,15 +448,11 @@ void __IoInit() {
 	asyncNotifyEvent = CoreTiming::RegisterEvent("IoAsyncNotify", __IoAsyncNotify);
 	syncNotifyEvent = CoreTiming::RegisterEvent("IoSyncNotify", __IoSyncNotify);
 
-	std::string memstickpath;
-	std::string flash0path;
-	GetSysDirectories(memstickpath, flash0path);
-
-	memstickSystem = new DirectoryFileSystem(&pspFileSystem, memstickpath);
+	memstickSystem = new DirectoryFileSystem(&pspFileSystem, g_Config.memCardDirectory);
 #ifdef ANDROID
 	flash0System = new VFSFileSystem(&pspFileSystem, "flash0");
 #else
-	flash0System = new DirectoryFileSystem(&pspFileSystem, flash0path);
+	flash0System = new DirectoryFileSystem(&pspFileSystem, g_Config.flash0Directory);
 #endif
 	pspFileSystem.Mount("ms0:", memstickSystem);
 	pspFileSystem.Mount("fatms0:", memstickSystem);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -360,17 +360,46 @@ CoreParameter &PSP_CoreParameter() {
 	return coreParameter;
 }
 
+std::string GetSysDirectory(PSPDirectories directoryType) {
+	switch (directoryType) {
+	case DIRECTORY_CHEATS:
+		return g_Config.memCardDirectory + "/PSP/Cheats/";
+	case DIRECTORY_GAME:
+		return g_Config.memCardDirectory + "/PSP/GAME/";
+	case DIRECTORY_SAVEDATA:
+		return g_Config.memCardDirectory + "/PSP/SAVEDATA/";
+	case DIRECTORY_SCREENSHOT:
+		return g_Config.memCardDirectory + "/PSP/SCREENSHOT/";
+	case DIRECTORY_SYSTEM:
+		return g_Config.memCardDirectory + "/PSP/SYSTEM/";
+	case DIRECTORY_PAUTH:
+		return g_Config.memCardDirectory + "/PAUTH/";
+	case DIRECTORY_FLASH0:
+		return g_Config.flash0Directory;
+	case DIRECTORY_MEMSTICK:
+		return g_Config.memCardDirectory;
+	// Just return the memory stick root if we run into some sort of problem.
+	default:
+		ERROR_LOG(FILESYS, "Unknown directory type.");
+		return g_Config.memCardDirectory;
+	}
+}
 
-void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
+// Run this at startup time. Please use GetSysDirectory if you need to query where folders are.
+void InitSysDirectories() {
+
+	if (!g_Config.memCardDirectory.empty() && !g_Config.flash0Directory.empty())
+		return;
 #ifdef _WIN32
 	const std::string path = ConvertWStringToUTF8(File::GetExeDirectory());
 
 	// Mount a filesystem
-	flash0path = path + "/flash0/";
+	g_Config.flash0Directory = path + "/flash0/";
 
 	// Detect the "My Documents"(XP) or "Documents"(on Vista/7/8) folder.
 	wchar_t myDocumentsPath[MAX_PATH];
 	const HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
+	const std::string myDocsPath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
 
 	const std::string installedFile = path + "/installed.txt";
 	const bool installed = File::Exists(installedFile);
@@ -388,40 +417,44 @@ void GetSysDirectories(std::string &memstickpath, std::string &flash0path) {
 			if (tempString.substr(0, 3) == "\xEF\xBB\xBF")
 				tempString = tempString.substr(3);
 
-			memstickpath = tempString;
+			g_Config.memCardDirectory = tempString;
 		}
 		inputFile.close();
 
 		// Check if the file is empty first, before appending the slash.
-		if (memstickpath.empty())
-			memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
+		if (g_Config.memCardDirectory.empty())
+			g_Config.memCardDirectory = myDocsPath;
 
-		size_t lastSlash = memstickpath.find_last_of("/");
-		if (lastSlash != (memstickpath.length() - 1))
-			memstickpath.append("/");
+		size_t lastSlash = g_Config.memCardDirectory.find_last_of("/");
+		if (lastSlash != (g_Config.memCardDirectory.length() - 1))
+			g_Config.memCardDirectory.append("/");
 	} else {
-		memstickpath = path + "/memstick/";
+		g_Config.memCardDirectory = path + "/memstick/";
 	}
 
 	// Create the memstickpath before trying to write to it, and fall back on Documents yet again
 	// if we can't make it.
-	if (!File::Exists(memstickpath)) {
-		if(!File::CreateDir(memstickpath))
-			memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
+	if (!File::Exists(g_Config.memCardDirectory)) {
+		if (!File::CreateDir(g_Config.memCardDirectory))
+			g_Config.memCardDirectory = myDocsPath;
 	}
 
 	const std::string testFile = "/_writable_test.$$$";
 
 	// If any directory is read-only, fall back to the Documents directory.
 	// We're screwed anyway if we can't write to Documents, or can't detect it.
-	if (!File::CreateEmptyFile(memstickpath + testFile))
-		memstickpath = ConvertWStringToUTF8(myDocumentsPath) + "/PPSSPP/";
+	if (!File::CreateEmptyFile(g_Config.memCardDirectory + testFile))
+		g_Config.memCardDirectory = myDocsPath;
 
 	// Clean up our mess.
-	if (File::Exists(memstickpath + testFile))
-		File::Delete(memstickpath + testFile);
+	if (File::Exists(g_Config.memCardDirectory + testFile))
+		File::Delete(g_Config.memCardDirectory + testFile);
+
+	if (g_Config.currentDirectory.empty()) {
+		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);
+	}
 #else
-	// TODO
+	// TODO: Perhaps move your platforms' directory stuff out of NativeInit and into here.
 	memstickpath = g_Config.memCardDirectory;
 	flash0path = g_Config.flash0Directory;
 #endif

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -374,10 +374,6 @@ std::string GetSysDirectory(PSPDirectories directoryType) {
 		return g_Config.memCardDirectory + "/PSP/SYSTEM/";
 	case DIRECTORY_PAUTH:
 		return g_Config.memCardDirectory + "/PAUTH/";
-	case DIRECTORY_FLASH0:
-		return g_Config.flash0Directory;
-	case DIRECTORY_MEMSTICK:
-		return g_Config.memCardDirectory;
 	// Just return the memory stick root if we run into some sort of problem.
 	default:
 		ERROR_LOG(FILESYS, "Unknown directory type.");

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -381,12 +381,12 @@ std::string GetSysDirectory(PSPDirectories directoryType) {
 	}
 }
 
+#ifdef _WIN32
 // Run this at startup time. Please use GetSysDirectory if you need to query where folders are.
 void InitSysDirectories() {
-
 	if (!g_Config.memCardDirectory.empty() && !g_Config.flash0Directory.empty())
 		return;
-#ifdef _WIN32
+
 	const std::string path = ConvertWStringToUTF8(File::GetExeDirectory());
 
 	// Mount a filesystem
@@ -449,9 +449,5 @@ void InitSysDirectories() {
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);
 	}
-#else
-	// TODO: Perhaps move your platforms' directory stuff out of NativeInit and into here.
-	memstickpath = g_Config.memCardDirectory;
-	flash0path = g_Config.flash0Directory;
-#endif
 }
+#endif

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -363,17 +363,17 @@ CoreParameter &PSP_CoreParameter() {
 std::string GetSysDirectory(PSPDirectories directoryType) {
 	switch (directoryType) {
 	case DIRECTORY_CHEATS:
-		return g_Config.memCardDirectory + "/PSP/Cheats/";
+		return g_Config.memCardDirectory + "PSP/Cheats/";
 	case DIRECTORY_GAME:
-		return g_Config.memCardDirectory + "/PSP/GAME/";
+		return g_Config.memCardDirectory + "PSP/GAME/";
 	case DIRECTORY_SAVEDATA:
-		return g_Config.memCardDirectory + "/PSP/SAVEDATA/";
+		return g_Config.memCardDirectory + "PSP/SAVEDATA/";
 	case DIRECTORY_SCREENSHOT:
-		return g_Config.memCardDirectory + "/PSP/SCREENSHOT/";
+		return g_Config.memCardDirectory + "PSP/SCREENSHOT/";
 	case DIRECTORY_SYSTEM:
-		return g_Config.memCardDirectory + "/PSP/SYSTEM/";
+		return g_Config.memCardDirectory + "PSP/SYSTEM/";
 	case DIRECTORY_PAUTH:
-		return g_Config.memCardDirectory + "/PAUTH/";
+		return g_Config.memCardDirectory + "PAUTH/";
 	// Just return the memory stick root if we run into some sort of problem.
 	default:
 		ERROR_LOG(FILESYS, "Unknown directory type.");

--- a/Core/System.h
+++ b/Core/System.h
@@ -36,6 +36,17 @@ enum GlobalUIState {
 	UISTATE_EXIT,
 };
 
+// Use these in conjunction with GetSysDirectory.
+enum PSPDirectories {
+	DIRECTORY_MEMSTICK,
+	DIRECTORY_FLASH0,
+	DIRECTORY_CHEATS,
+	DIRECTORY_SCREENSHOT,
+	DIRECTORY_SYSTEM,
+	DIRECTORY_GAME,
+	DIRECTORY_SAVEDATA,
+	DIRECTORY_PAUTH,
+};
 
 extern GlobalUIState globalUIState;
 
@@ -58,7 +69,8 @@ void Audio_Init();
 bool IsOnSeparateCPUThread();
 bool IsAudioInitialised();
 
-void GetSysDirectories(std::string &memstickpath, std::string &flash0path);
+std::string GetSysDirectory(PSPDirectories directoryType);
+void InitSysDirectories();
 
 // RUNNING must be at 0, NEXTFRAME must be at 1.
 enum CoreState

--- a/Core/System.h
+++ b/Core/System.h
@@ -38,8 +38,6 @@ enum GlobalUIState {
 
 // Use these in conjunction with GetSysDirectory.
 enum PSPDirectories {
-	DIRECTORY_MEMSTICK,
-	DIRECTORY_FLASH0,
 	DIRECTORY_CHEATS,
 	DIRECTORY_SCREENSHOT,
 	DIRECTORY_SYSTEM,

--- a/Core/System.h
+++ b/Core/System.h
@@ -68,7 +68,9 @@ bool IsOnSeparateCPUThread();
 bool IsAudioInitialised();
 
 std::string GetSysDirectory(PSPDirectories directoryType);
+#ifdef _WIN32
 void InitSysDirectories();
+#endif
 
 // RUNNING must be at 0, NEXTFRAME must be at 1.
 enum CoreState

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -153,12 +153,10 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params)
 	std::vector<std::string> title;
 	bool finished = false, skip = false;
 	std::vector<std::string> newList;
-#if defined(ANDROID) || defined(__SYMBIAN32__) || defined(BLACKBERRY) || defined(_WIN32)
+
 	std::string cheatDir = GetSysDirectory(DIRECTORY_CHEATS) + "cheat.db";
 	is.open(cheatDir.c_str());
-#else
-	is.open("cheats/cheat.db");
-#endif
+
 	while (is.good())
 	{
 		getline(is, line); // get line from file

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -154,7 +154,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params)
 	bool finished = false, skip = false;
 	std::vector<std::string> newList;
 #if defined(ANDROID) || defined(__SYMBIAN32__) || defined(BLACKBERRY) || defined(_WIN32)
-	std::string cheatDir = g_Config.memCardDirectory + "PSP/Cheats/cheat.db";
+	std::string cheatDir = GetSysDirectory(DIRECTORY_CHEATS) + "cheat.db";
 	is.open(cheatDir.c_str());
 #else
 	is.open("cheats/cheat.db");

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -71,11 +71,10 @@ u64 GameInfo::GetGameSizeInBytes() {
 }
 
 std::vector<std::string> GameInfo::GetSaveDataDirectories() {
-	std::string memc, flash;
-	GetSysDirectories(memc, flash);
+	std::string memc = GetSysDirectory(DIRECTORY_SAVEDATA);
 
 	std::vector<FileInfo> dirs;
-	getFilesInDir((memc + "PSP/SAVEDATA/").c_str(), &dirs);
+	getFilesInDir((memc).c_str(), &dirs);
 	
 	std::vector<std::string> directories;
 	for (size_t i = 0; i < dirs.size(); i++) {

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -74,7 +74,7 @@ std::vector<std::string> GameInfo::GetSaveDataDirectories() {
 	std::string memc = GetSysDirectory(DIRECTORY_SAVEDATA);
 
 	std::vector<FileInfo> dirs;
-	getFilesInDir((memc).c_str(), &dirs);
+	getFilesInDir(memc.c_str(), &dirs);
 	
 	std::vector<std::string> directories;
 	for (size_t i = 0; i < dirs.size(); i++) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -301,12 +301,6 @@ void PathBrowser::Navigate(const std::string &path) {
 	}
 }
 
-static std::string GetMemCardDirectory() {
-	std::string memCardDirectory, ignore;
-	GetSysDirectories(memCardDirectory, ignore);
-	return memCardDirectory;
-}
-
 class GameBrowser : public UI::LinearLayout {
 public:
 	GameBrowser(std::string path, bool allowBrowsing, bool *gridStyle_, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = 0);
@@ -350,7 +344,7 @@ UI::EventReturn GameBrowser::LastClick(UI::EventParams &e) {
 }
 
 UI::EventReturn GameBrowser::HomeClick(UI::EventParams &e) {
-	path_.SetPath(GetMemCardDirectory());
+	path_.SetPath(g_Config.memCardDirectory);
 	g_Config.currentDirectory = path_.GetPath();
 	Refresh();
 	return UI::EVENT_DONE;
@@ -497,7 +491,7 @@ void MainScreen::CreateViews() {
 	GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, true, &g_Config.bGridView2, 
 		m->T("How to get games"), "http://www.ppsspp.org/getgames.html",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
-	GameBrowser *tabHomebrew = new GameBrowser(GetMemCardDirectory() + "PSP/GAME/", false, &g_Config.bGridView3,
+	GameBrowser *tabHomebrew = new GameBrowser(GetSysDirectory(DIRECTORY_GAME), false, &g_Config.bGridView3,
 		m->T("How to get homebrew & demos"), "http://www.ppsspp.org/gethomebrew.html",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -367,12 +367,6 @@ void NativeInit(int argc, const char *argv[],
 	if (!gfxLog)
 		logman->SetLogLevel(LogTypes::G3D, LogTypes::LERROR);
 	INFO_LOG(BOOT, "Logger inited.");
-#else
-	if (g_Config.currentDirectory.empty()) {
-		g_Config.currentDirectory = ConvertWStringToUTF8(File::GetExeDirectory());
-	}
-	// TODO: Is this even needed, when PPSSPP uses GetSysDirectories in multiple other places?
-	g_Config.memCardDirectory = "memstick/";
 #endif	
 
 	i18nrepo.LoadIni(g_Config.sLanguageIni);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -86,15 +86,12 @@ unsigned int WINAPI TheThread(void *)
 
 	setCurrentThreadName("EmuThread");
 
-	std::string memstick, flash0;
-	GetSysDirectories(memstick, flash0);
-
 	// Native overwrites host. Can't allow that.
 
 	Host *oldHost = host;
 	UpdateScreenScale();
 
-	NativeInit(__argc, (const char **)__argv, memstick.c_str(), memstick.c_str(), "1234");
+	NativeInit(__argc, (const char **)__argv, "1234", "1234", "1234");
 	Host *nativeHost = host;
 	host = oldHost;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1131,7 +1131,7 @@ namespace MainWindow
 					break;
 
 				case ID_FILE_MEMSTICK:
-					ShellExecuteA(NULL, "open", g_Config.memCardDirectory.c_str(), 0, 0, SW_SHOW);
+					ShellExecute(NULL, L"open", ConvertUTF8ToWString(g_Config.memCardDirectory).c_str(), 0, 0, SW_SHOW);
 					break;
 
 				case ID_TOGGLE_PAUSE:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1131,10 +1131,7 @@ namespace MainWindow
 					break;
 
 				case ID_FILE_MEMSTICK:
-					{
-						std::string memStickDir = GetSysDirectory(DIRECTORY_MEMSTICK);
-						ShellExecuteA(NULL, "open", memStickDir.c_str(), 0, 0, SW_SHOW);
-					}
+					ShellExecuteA(NULL, "open", g_Config.memCardDirectory.c_str(), 0, 0, SW_SHOW);
 					break;
 
 				case ID_TOGGLE_PAUSE:

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1127,18 +1127,12 @@ namespace MainWindow
 					break;
 
 				case ID_FILE_LOAD_MEMSTICK:
-					{
-						std::string memStickDir, flash0dir;
-						GetSysDirectories(memStickDir, flash0dir);
-						memStickDir += "PSP\\GAME\\";
-						BrowseAndBoot(memStickDir);
-					}
+					BrowseAndBoot(GetSysDirectory(DIRECTORY_GAME));
 					break;
 
 				case ID_FILE_MEMSTICK:
 					{
-						std::string memStickDir, flash0dir;
-						GetSysDirectories(memStickDir, flash0dir);
+						std::string memStickDir = GetSysDirectory(DIRECTORY_MEMSTICK);
 						ShellExecuteA(NULL, "open", memStickDir.c_str(), 0, 0, SW_SHOW);
 					}
 					break;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -218,7 +218,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	}
 
 	// On Win32 it makes more sense to initialize the system directories here 
-	// because GetSysDirectories was called much later than this..
+	// because the next place it was called was in the EmuThread, and it's too late by then.
 	InitSysDirectories();
 
 	// Load config up here, because those changes below would be overwritten

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -217,14 +217,15 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		}
 	}
 
-	std::string memstickpath, flash0path;
-	GetSysDirectories(memstickpath, flash0path);
+	// On Win32 it makes more sense to initialize the system directories here 
+	// because GetSysDirectories was called much later than this..
+	InitSysDirectories();
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
 	g_Config.AddSearchPath("");
-	g_Config.AddSearchPath(memstickpath + "PSP/SYSTEM/");
-	g_Config.SetDefaultPath(memstickpath + "PSP/SYSTEM/");
+	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.Load(configFilename, controlsConfigFilename);
 
 	// The rest is handled in NativeInit().


### PR DESCRIPTION
_I suggest thoroughly reading over this code before merging to make sure I didn't miss anything, since this can mess a lot of stuff up if I messed up. I'm not perfect._ :)

On Win32, call InitSysDirectories before the emuthread starts just to be safe.

This is more of a cleanup pull request than anything. It's really silly to keep determining the system directories over and over(which on win32, makes it keep doing the read-only test over and over), when one can just query GetSysDirectory with which directory one wants.

I was inspired by the sysprop function we have when making this, heh.
