### PR TITLE
Avoid flashing the console window on startup

### DIFF
--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -30,7 +30,8 @@ public:
 	ConsoleListener();
 	~ConsoleListener();
 
-	void Open(bool Hidden = false, int Width = 200, int Height = 100, const char * Name = "DebugConsole (PPSSPP)");
+	void Init(bool AutoOpen = true, int Width = 200, int Height = 100, const char * Name = "DebugConsole (PPSSPP)");
+	void Open();
 	void UpdateHandle();
 	void Close();
 	bool IsOpen();
@@ -63,6 +64,10 @@ private:
 	static char *logPending;
 	static volatile u32 logPendingReadPos;
 	static volatile u32 logPendingWritePos;
+
+	int openWidth_;
+	int openHeight_;
+	std::wstring title_;
 #endif
 	bool bHidden;
 	bool bUseColor;

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -661,7 +661,7 @@ void CtrlStackTraceView::loadStackTrace()
 {
 	auto threads = GetThreadsInfo();
 
-	u32 entry, stackTop;
+	u32 entry = 0, stackTop = 0;
 	for (size_t i = 0; i < threads.size(); i++)
 	{
 		if (threads[i].isCurrent)
@@ -672,6 +672,10 @@ void CtrlStackTraceView::loadStackTrace()
 		}
 	}
 
-	frames = MIPSStackWalk::Walk(cpu->GetPC(),cpu->GetRegValue(0,31),cpu->GetRegValue(0,29),entry,stackTop);
+	if (entry != 0) {
+		frames = MIPSStackWalk::Walk(cpu->GetPC(),cpu->GetRegValue(0,31),cpu->GetRegValue(0,29),entry,stackTop);
+	} else {
+		frames.clear();
+	}
 	Update();
 }

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -358,8 +358,10 @@ namespace MainWindow
 		// Then center if necessary.
 		if (g_Config.iWindowX == -1 && g_Config.iWindowY == -1) {
 			// Center the window.
-			g_Config.iWindowX = screenX + (screenWidth - g_Config.iWindowWidth) / 2;
-			g_Config.iWindowY = screenY + (screenHeight - g_Config.iWindowHeight) / 2;
+			const int primaryScreenWidth = GetSystemMetrics(SM_CXSCREEN);
+			const int primaryScreenHeight = GetSystemMetrics(SM_CYSCREEN);
+			g_Config.iWindowX = (primaryScreenWidth - g_Config.iWindowWidth) / 2;
+			g_Config.iWindowY = (primaryScreenHeight - g_Config.iWindowHeight) / 2;
 			rc.left = g_Config.iWindowX;
 			rc.top = g_Config.iWindowY;
 			rc.right = rc.left + g_Config.iWindowWidth;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1556,14 +1556,11 @@ namespace MainWindow
 					TCHAR filename[512];
 					DragQueryFile(hdrop,0,filename,512);
 					TCHAR *type = filename+_tcslen(filename)-3;
-
-					SendMessage(hWnd, WM_COMMAND, ID_EMULATION_STOP, 0);
-					// Ugly, need to wait for the stop message to process in the EmuThread.
-					Sleep(20);
 					
 					Update();
 
 					NativeMessageReceived("boot", ConvertWStringToUTF8(filename).c_str());
+					Core_EnableStepping(false);
 				}
 			}
 			break;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -172,9 +172,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	// GetCurrentDirectory(MAX_PATH, modulePath);  // for checking in the debugger
 
 #ifndef _DEBUG
-	bool hideLog = true;
+	bool showLog = false;
 #else
-	bool hideLog = false;
+	bool showLog = false;
 #endif
 
 	VFSRegister("", new DirectoryAssetReader("assets/"));
@@ -239,7 +239,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			switch (__argv[i][1])
 			{
 			case 'l':
-				hideLog = false;
+				showLog = true;
 				g_Config.bEnableLogging = true;
 				break;
 			case 's':
@@ -265,7 +265,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	//   - By default in Debug, the console should be shown by default.
 	//   - The -l switch is expected to show the log console, REGARDLESS of config settings.
 	//   - It should be possible to log to a file without showing the console.
-	LogManager::GetInstance()->GetConsoleListener()->Open(hideLog, 150, 120, "PPSSPP Debug Console");
+	LogManager::GetInstance()->GetConsoleListener()->Init(showLog, 150, 120, "PPSSPP Debug Console");
 
 
 	//Windows, API init stuff


### PR DESCRIPTION
Also, center on the primary screen only by default (some would say the active screen is better, I'm not sure how to detect that...)  Fixes #4207, which was mostly just my todo item.

Anyway, this just doesn't even open the console until it's shown.  It's already buffering the output for the thread, so you'll still get log data even if you don't open it immediately.

The only possible problem is if it overflows the buffer, which is more likely now (since nothing's reading it.)  But, I'm sure I tested that before, so it should be fine, I think... it could be slightly slower (when logging), though, if it hits the buffer size.  I don't think it's a big deal.

Also added two smaller fixes, one unrelated (crash in debugger), and the other also ui related - drag and drop was hanging when no game was loaded yet.

-[Unknown]
