### PR TITLE
Pass arguments to root threads same way as regular threads

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2018,12 +2018,13 @@ SceUID __KernelSetupRootThread(SceUID moduleID, int args, const char *argp, int 
 
 	__KernelLoadContext(&thread->context, (attr & PSP_THREAD_ATTR_VFPU) != 0);
 	currentMIPS->r[MIPS_REG_A0] = args;
-	currentMIPS->r[MIPS_REG_SP] -= 256;
-	u32 location = currentMIPS->r[MIPS_REG_SP];
 	currentMIPS->r[MIPS_REG_SP] -= (args + 0xf) & ~0xf;
+	u32 location = currentMIPS->r[MIPS_REG_SP];
 	currentMIPS->r[MIPS_REG_A1] = location;
-	for (int i = 0; i < args; i++)
-		Memory::Write_U8(argp[i], location + i);
+	if (argp)
+		Memory::Memcpy(location, argp, args);
+	// Let's assume same as starting a new thread, 64 bytes for safety/kernel.
+	currentMIPS->r[MIPS_REG_SP] -= 64;
 
 	return id;
 }


### PR DESCRIPTION
Fixes Ys 1 & 2 Chronicles.

Before it would have issues or crash if the args were > 256 bytes (since it reserved space and then wrote the arg after that space.)

Should primarily affect games that use sceKernelLoadExec(), and actually gives slightly more stack space to the root thread (it was reducing by 256 also in __KernelResetThread().)

-[Unknown]
