### PR TITLE
Default off for enable logging

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -52,7 +52,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	IniFile::Section *general = iniFile.GetOrCreateSection("General");
 
 	general->Get("FirstRun", &bFirstRun, true);
-	general->Get("Enable Logging", &bEnableLogging, true);
+	general->Get("Enable Logging", &bEnableLogging, false);
 	general->Get("AutoRun", &bAutoRun, true);
 	general->Get("Browse", &bBrowse, false);
 	general->Get("IgnoreBadMemAccess", &bIgnoreBadMemAccess, true);


### PR DESCRIPTION
I think this option should be default off and standard users don't need it to be ON .If advance user need it ,they can turn it on simply from developer menu
