### PR TITLE
Write the retaddr to rd, not always ra, in jalr.

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -372,6 +372,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		return;
 	}
 	MIPSGPReg rs = _RS;
+	MIPSGPReg rd = _RD:
 
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
@@ -402,7 +403,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		break;
 	case 9: //jalr
 		MOVI2R(R0, js.compilerPC + 8);
-		STR(R0, CTXREG, MIPS_REG_RA * 4);
+		STR(R0, CTXREG, (int)rd * 4);
 		break;
 	default:
 		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -328,10 +328,13 @@ namespace MIPSDis
 	}
 	void Dis_JumpRegType(MIPSOpcode op, char *out)
 	{
-		int rs = (op>>21)&0x1f;
+		int rs = _RS;
+		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t->%s",name,RN(rs));
-
+		if ((op & 0x3f) == 9 && rd != MIPS_REG_RA)
+			sprintf(out, "%s\t%s,->%s", name, RN(rd), RN(rs));
+		else
+			sprintf(out, "%s\t->%s", name, RN(rs));
 	}
 
 	void Dis_Allegrex(MIPSOpcode op, char *out)

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -292,6 +292,7 @@ namespace MIPSInt
 		}
 
 		int rs = _RS;
+		int rd = _RD;
 		u32 addr = R(rs);
 		switch (op & 0x3f) 
 		{
@@ -300,7 +301,7 @@ namespace MIPSInt
 			DelayBranchTo(addr);
 			break;
 		case 9: //jalr
-			R(31) = PC + 8;
+			R(rd) = PC + 8;
 			DelayBranchTo(addr);
 			break;
 		}

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -184,7 +184,7 @@ const MIPSInstruction tableSpecial[64] = // 000000 ..... ..... ..... ..... xxxxx
 
 	//8
 	INSTR("jr",    &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, IS_JUMP|IN_RS|DELAYSLOT),
-	INSTR("jalr",  &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, IS_JUMP|IN_RS|OUT_RA|DELAYSLOT),
+	INSTR("jalr",  &Jit::Comp_JumpReg, Dis_JumpRegType, Int_JumpRegType, IS_JUMP|IN_RS|OUT_RD|DELAYSLOT),
 	INSTR("movz",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT|IS_CONDMOVE|CONDTYPE_EQ),
 	INSTR("movn",  &Jit::Comp_RType3, Dis_RType3, Int_RType3, OUT_RD|IN_RS|IN_RT|IS_CONDMOVE|CONDTYPE_NE),
 	INSTR("syscall", &Jit::Comp_Syscall, Dis_Syscall, Int_Syscall, IN_MEM|IN_OTHER|OUT_MEM|OUT_OTHER),

--- a/Core/MIPS/PPC/PpcCompBranch.cpp
+++ b/Core/MIPS/PPC/PpcCompBranch.cpp
@@ -360,6 +360,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op) {
 		return;
 	}
 	MIPSGPReg rs = _RS;
+	MIPSGPReg rd = _RD;
 
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
@@ -394,7 +395,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op) {
 	case 9: //jalr
 		// mips->reg = js.compilerPC + 8;
 		MOVI2R(SREG, js.compilerPC + 8);
-		STW(SREG, CTXREG, MIPS_REG_RA * 4);
+		STW(SREG, CTXREG, (int)rd * 4);
 		break;
 	default:
 		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -575,6 +575,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		return;
 	}
 	MIPSGPReg rs = _RS;
+	MIPSGPReg rd = _RD;
 
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
@@ -612,7 +613,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 	case 8: //jr
 		break;
 	case 9: //jalr
-		MOV(32, M(&mips_->r[MIPS_REG_RA]), Imm32(js.compilerPC + 8));
+		MOV(32, M(&mips_->r[rd]), Imm32(js.compilerPC + 8));
 		break;
 	default:
 		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");


### PR DESCRIPTION
Thanks go entirely to @Kingcom for pointing this out.

Don't know of any games not using RA as the rd.  Phantasy Star Portable 2, which uses jalr a lot, didn't seem to at all for example.

-[Unknown]
