### PR TITLE
System Info screen: Add correct core count detection for i7(and maybe i5/i3?) CPUs.

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -192,8 +192,17 @@ void CPUInfo::Detect()
 		int apic_id_core_id_size = (cpu_id[2] >> 12) & 0xF;
 		if (apic_id_core_id_size == 0) {
 			if (ht) {
+				// 0x0B is the preferred method on i7(i5, i3, too? Unsure..).
+				// Inspired by https://github.com/D-Programming-Language/druntime/blob/master/src/core/cpuid.d#L562.
+				if (vendor == VENDOR_INTEL && max_std_fn >= 0x0B) {
+					__cpuidex(cpu_id, 0x0B, 0);
+					logical_cpu_count = cpu_id[1] & 0xFFFF;
+					__cpuidex(cpu_id, 0x0B, 1);
+					int totalThreads = cpu_id[1] & 0xFFFF;
+					num_cores = totalThreads / logical_cpu_count;
+				}
 				// New mechanism for modern Intel CPUs.
-				if (vendor == VENDOR_INTEL) {
+				else if (vendor == VENDOR_INTEL) {
 					__cpuid(cpu_id, 0x00000004);
 					int cores_x_package = ((cpu_id[0] >> 26) & 0x3F) + 1;
 					HTT = (cores_x_package < logical_cpu_count);

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -192,6 +192,8 @@ void CPUInfo::Detect()
 		int apic_id_core_id_size = (cpu_id[2] >> 12) & 0xF;
 		if (apic_id_core_id_size == 0) {
 			if (ht) {
+#ifdef _WIN32
+				// TODO: Make this work on non-Windows.
 				// 0x0B is the preferred method on i7(i5, i3, too? Unsure..).
 				// Inspired by https://github.com/D-Programming-Language/druntime/blob/master/src/core/cpuid.d#L562.
 				if (vendor == VENDOR_INTEL && max_std_fn >= 0x0B) {
@@ -201,8 +203,11 @@ void CPUInfo::Detect()
 					int totalThreads = cpu_id[1] & 0xFFFF;
 					num_cores = totalThreads / logical_cpu_count;
 				}
-				// New mechanism for modern Intel CPUs.
 				else if (vendor == VENDOR_INTEL) {
+#else
+				// New mechanism for modern Intel CPUs.
+				if (vendor == VENDOR_INTEL) {
+#endif
 					__cpuid(cpu_id, 0x00000004);
 					int cores_x_package = ((cpu_id[0] >> 26) & 0x3F) + 1;
 					HTT = (cores_x_package < logical_cpu_count);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -152,7 +152,9 @@ void SystemInfoScreen::CreateViews() {
 #ifdef ARM
 	deviceSpecs->Add(new InfoItem("Cores", StringFromInt(cpu_info.num_cores)));
 #else
-	deviceSpecs->Add(new InfoItem("Threads", StringFromInt(cpu_info.num_cores)));
+	int totalThreads = cpu_info.num_cores * cpu_info.logical_cpu_count;
+	std::string cores = StringFromFormat("%d (%d per core, %d cores)", totalThreads, cpu_info.logical_cpu_count, cpu_info.num_cores);
+	deviceSpecs->Add(new InfoItem("Threads", cores));
 #endif
 	deviceSpecs->Add(new ItemHeader("GPU Information"));
 	deviceSpecs->Add(new InfoItem("Vendor", (char *)glGetString(GL_VENDOR)));


### PR DESCRIPTION
Also display more information about how many threads each core possesses, as well as how many cores are in the CPU.

ECX with a value of 2 can detect multi-cpu-socket setups(thanks @unknownbrackets for that info), but I don't really think we need to care about that.
