### PR TITLE
Win32 crash fix: Don't execute the 0x0B CPUID code on non-Core i CPUs.

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -196,7 +196,7 @@ void CPUInfo::Detect()
 				// TODO: Make this work on non-Windows.
 				// 0x0B is the preferred method on i7(i5, i3, too? Unsure..).
 				// Inspired by https://github.com/D-Programming-Language/druntime/blob/master/src/core/cpuid.d#L562.
-				if (vendor == VENDOR_INTEL && max_std_fn >= 0x0B) {
+				if (vendor == VENDOR_INTEL && max_std_fn >= 0x0B && std::string(brand_string).find("Core(TM) i") != std::string::npos) {
 					__cpuidex(cpu_id, 0x0B, 0);
 					logical_cpu_count = cpu_id[1] & 0xFFFF;
 					__cpuidex(cpu_id, 0x0B, 1);


### PR DESCRIPTION
Apparently checking for 0x0B isn't enough on Core 2 Duos, so check the brand string, too. If there's a better way to prevent non Core-i CPUs from executing this, please chime in. Checking max_std_fn isn't enough.

Should fix https://github.com/hrydgard/ppsspp/issues/4229.
