### PR TITLE
More intelligent disassembly scrolling

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -485,7 +485,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 void CtrlDisAsmView::drawBranchLine(HDC hdc, BranchLine& line)
 {
 	HPEN pen;
-	u32 windowEnd = windowStart+(visibleRows+2)*instructionSize;
+	u32 windowEnd = windowStart+visibleRows*instructionSize;
 	
 	int topY;
 	int bottomY;
@@ -600,7 +600,7 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 	HICON breakPoint = (HICON)LoadIcon(GetModuleHandle(0),(LPCWSTR)IDI_STOP);
 	HICON breakPointDisable = (HICON)LoadIcon(GetModuleHandle(0),(LPCWSTR)IDI_STOPDISABLE);
 
-	for (int i = 0; i < visibleRows+2; i++)
+	for (int i = 0; i < visibleRows; i++)
 	{
 		unsigned int address=windowStart + i*instructionSize;
 		MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(debugger,address);

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -127,6 +127,7 @@ public:
 	};
 
 	void getOpcodeText(u32 address, char* dest);
+	int getRowHeight() { return rowHeight; };
 	u32 yToAddress(int y);
 
 	void setDontRedraw(bool b) { dontRedraw = b; };

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -89,7 +89,6 @@ class CtrlDisAsmView
 	bool searching;
 	bool dontRedraw;
 	bool keyTaken;
-	bool stepScrolling;
 
 	void assembleOpcode(u32 address, std::string defaultText);
 	void disassembleToFile();

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -89,6 +89,7 @@ class CtrlDisAsmView
 	bool searching;
 	bool dontRedraw;
 	bool keyTaken;
+	bool stepScrolling;
 
 	void assembleOpcode(u32 address, std::string defaultText);
 	void disassembleToFile();
@@ -141,6 +142,8 @@ public:
 	{
 		return debugger;
 	}
+
+	u32 getWindowEnd() { return windowStart+visibleRows*instructionSize; };
 	void gotoAddr(unsigned int addr)
 	{
 		u32 windowEnd = windowStart+visibleRows*instructionSize;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -168,27 +168,30 @@ void CDisasm::stepInto()
 
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 	CBreakPoints::SetSkipFirst(currentMIPS->pc);
+	u32 newAddress = currentPc+cpu->getInstructionSize(0);
 
-	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(cpu,cpu->GetPC());
+	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(cpu,currentPc);
 	if (info.isBranch)
 	{
-		u32 newAddress = currentPc+cpu->getInstructionSize(0);
 		if (newAddress == windowEnd-4)
 			ptr->scrollWindow(1);
 		else if (newAddress == windowEnd)
 			ptr->scrollWindow(2);
 	} else {
-		if (!currentMIPS->inDelaySlot)
+		bool scroll = true;
+		if (currentMIPS->inDelaySlot)
 		{
-			MIPSAnalyst::MipsOpcodeInfo prevInfo = MIPSAnalyst::GetOpcodeInfo(cpu,cpu->GetPC()-cpu->getInstructionSize(0));
-			if (!prevInfo.isBranch || (prevInfo.isConditional && !prevInfo.conditionMet))
-			{
-				u32 newAddress = currentPc+cpu->getInstructionSize(0);
-				if (newAddress == windowEnd-4)
-					ptr->scrollWindow(1);
-				else if (newAddress == windowEnd)
-					ptr->scrollWindow(2);
-			}
+			MIPSAnalyst::MipsOpcodeInfo prevInfo = MIPSAnalyst::GetOpcodeInfo(cpu,currentPc-cpu->getInstructionSize(0));
+			if (!prevInfo.isConditional || prevInfo.conditionMet)
+				scroll = false;
+		}
+
+		if (scroll)
+		{
+			if (newAddress == windowEnd-4)
+				ptr->scrollWindow(1);
+			else if (newAddress == windowEnd)
+				ptr->scrollWindow(2);
 		}
 	}
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -679,6 +679,9 @@ void CDisasm::UpdateSize(WORD width, WORD height)
 		GetWindowRect(statusBarWnd,&windowRect);
 		topHeightOffset = (windowRect.bottom-windowRect.top);
 	}
+	
+	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	int disassemblyRowHeight = ptr->getRowHeight();
 
 	// disassembly
 	GetWindowRect(disasm,&windowRect);
@@ -686,6 +689,12 @@ void CDisasm::UpdateSize(WORD width, WORD height)
 	positions[0].x = windowRect.left;
 	positions[0].y = windowRect.top;
 	
+	// compute border height of the disassembly
+	int totalHeight = windowRect.bottom-windowRect.top;
+	GetClientRect(disasm,&windowRect);
+	int clientHeight = windowRect.bottom-windowRect.top;
+	int borderHeight = totalHeight-clientHeight;
+
 	// left tabs
 	GetWindowRect(leftTabs,&windowRect);
 	MapWindowPoints(HWND_DESKTOP,m_hDlg,(LPPOINT)&windowRect,2);
@@ -700,13 +709,14 @@ void CDisasm::UpdateSize(WORD width, WORD height)
 	int bottomHeightOffset = positions[0].y;
 	positions[0].w = width-borderMargin-positions[0].x;
 	positions[0].h = (height-bottomHeightOffset-topHeightOffset) * weight;
+	positions[0].h = ((positions[0].h-borderHeight)/disassemblyRowHeight)*disassemblyRowHeight+borderHeight;
 	positions[1].h = positions[0].h-(positions[1].y-positions[0].y);
 
 	// bottom tabs
 	positions[2].x = borderMargin;
 	positions[2].y = positions[0].y+positions[0].h+borderMargin;
 	positions[2].w = width-2*borderMargin;
-	positions[2].h = height-bottomHeightOffset-positions[2].y;
+	positions[2].h = hideBottomTabs ? 0 : height-bottomHeightOffset-positions[2].y;
 
 	// now actually move all the windows
 	MoveWindow(disasm,positions[0].x,positions[0].y,positions[0].w,positions[0].h,TRUE);


### PR DESCRIPTION
When stepping with the PC on the last two visible rows, the window will scroll down a couple of lines instead of centering on the new position when it's outside the current window.
Also enforces the height of the disassembly to always be a multiple of the row height, so that there are no partially visible rows.
