### PR TITLE
Clear the audio buffer on game reset

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -118,7 +118,9 @@ void __AudioInit() {
 	mixBuffer = new s32[hwBlockSize * 2];
 	memset(mixBuffer, 0, hwBlockSize * 2 * sizeof(s32));
 
-	
+	__blockForAudioQueueLock();
+	outAudioQueue.clear();
+	__releaseAcquiredLock();
 }
 
 void __AudioDoState(PointerWrap &p) {


### PR DESCRIPTION
Avoids blips.  Never noticed without music, heh.

-[Unknown]
