### PR TITLE
Support \ paths within filenames (Linux/Android?/etc.)

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -29,7 +29,8 @@ static bool ApplyPathStringToComponentsVector(std::vector<std::string> &vector, 
 
 	while (start < len)
 	{
-		size_t i = pathString.find('/', start);
+		// TODO: This should only be done for ms0:/ etc.
+		size_t i = pathString.find_first_of('/\\', start);
 		if (i == std::string::npos)
 			i = len;
 


### PR DESCRIPTION
Technically, these should not be handled for disc0:/ paths, nor should case folding.

In fact, the rules seem different, since "disc0:/blah/../PSP_GAME/PARAM.SFO" fails, but "ms0:/PSP/blah/../__pspautotests_testfile.txt" passes.

But, anyway, this may fix issues with wrong slashes for savedata and homebrews on Linux (and I assume Android, Mac, etc.)

-[Unknown]
