### PR TITLE
Add a screen to toggle onscreen touch control visibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1137,6 +1137,7 @@ set(NativeAppSource
 	UI/GameScreen.cpp
 	UI/GameSettingsScreen.cpp
 	UI/TouchControlLayoutScreen.cpp
+	UI/TouchControlVisibilityScreen.cpp
 	UI/GamepadEmu.cpp
 	UI/UIShader.cpp
 	UI/OnScreenDisplay.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -191,7 +191,18 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("HapticFeedback", &bHapticFeedback, true);
-	control->Get("ShowAnalogStick", &bShowAnalogStick, true);
+	control->Get("ShowAnalogStick", &bShowTouchAnalogStick, true);
+	control->Get("ShowTouchCross", bShowTouchCross);
+	control->Get("ShowTouchCircle", bShowTouchCircle);
+	control->Get("ShowTouchSquare", bShowTouchSquare);
+	control->Get("ShowTouchTriangle", bShowTouchTriangle);
+	control->Get("ShowTouchStart", bShowTouchStart);
+	control->Get("ShowTouchSelect", bShowTouchSelect);
+	control->Get("ShowTouchLTrigger", bShowTouchLTrigger);
+	control->Get("ShowTouchRTrigger", bShowTouchRTrigger);
+	control->Get("ShowAnalogStick", bShowTouchAnalogStick);
+	control->Get("ShowTouchUnthrottle", bShowTouchUnthrottle);
+
 #if defined(USING_GLES2)
 	std::string name = System_GetProperty(SYSPROP_NAME);
 	if (KeyMap::HasBuiltinController(name)) {
@@ -380,8 +391,19 @@ void Config::Save() {
 
 		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 		control->Set("HapticFeedback", bHapticFeedback);
-		control->Set("ShowAnalogStick", bShowAnalogStick);
+		
 		control->Set("ShowTouchControls", bShowTouchControls);
+		control->Set("ShowTouchCross", bShowTouchCross);
+		control->Set("ShowTouchCircle", bShowTouchCircle);
+		control->Set("ShowTouchSquare", bShowTouchSquare);
+		control->Set("ShowTouchTriangle", bShowTouchTriangle);
+		control->Set("ShowTouchStart", bShowTouchStart);
+		control->Set("ShowTouchSelect", bShowTouchSelect);
+		control->Set("ShowTouchLTrigger", bShowTouchLTrigger);
+		control->Set("ShowTouchRTrigger", bShowTouchRTrigger);
+		control->Set("ShowAnalogStick", bShowTouchAnalogStick);
+		control->Set("ShowTouchUnthrottle", bShowTouchUnthrottle);
+
 		// control->Set("KeyMapping",iMappingMap);
 #ifdef USING_GLES2
 		control->Set("AccelerometerToAnalogHoriz", bAccelerometerToAnalogHoriz);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -192,16 +192,16 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("HapticFeedback", &bHapticFeedback, true);
 	control->Get("ShowAnalogStick", &bShowTouchAnalogStick, true);
-	control->Get("ShowTouchCross", bShowTouchCross);
-	control->Get("ShowTouchCircle", bShowTouchCircle);
-	control->Get("ShowTouchSquare", bShowTouchSquare);
-	control->Get("ShowTouchTriangle", bShowTouchTriangle);
-	control->Get("ShowTouchStart", bShowTouchStart);
-	control->Get("ShowTouchSelect", bShowTouchSelect);
-	control->Get("ShowTouchLTrigger", bShowTouchLTrigger);
-	control->Get("ShowTouchRTrigger", bShowTouchRTrigger);
-	control->Get("ShowAnalogStick", bShowTouchAnalogStick);
-	control->Get("ShowTouchUnthrottle", bShowTouchUnthrottle);
+	control->Get("ShowTouchCross", &bShowTouchCross);
+	control->Get("ShowTouchCircle", &bShowTouchCircle);
+	control->Get("ShowTouchSquare", &bShowTouchSquare);
+	control->Get("ShowTouchTriangle", &bShowTouchTriangle);
+	control->Get("ShowTouchStart", &bShowTouchStart);
+	control->Get("ShowTouchSelect", &bShowTouchSelect);
+	control->Get("ShowTouchLTrigger", &bShowTouchLTrigger);
+	control->Get("ShowTouchRTrigger", &bShowTouchRTrigger);
+	control->Get("ShowAnalogStick", &bShowTouchAnalogStick);
+	control->Get("ShowTouchUnthrottle", &bShowTouchUnthrottle);
 
 #if defined(USING_GLES2)
 	std::string name = System_GetProperty(SYSPROP_NAME);
@@ -391,7 +391,6 @@ void Config::Save() {
 
 		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 		control->Set("HapticFeedback", bHapticFeedback);
-		
 		control->Set("ShowTouchControls", bShowTouchControls);
 		control->Set("ShowTouchCross", bShowTouchCross);
 		control->Set("ShowTouchCircle", bShowTouchCircle);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -192,16 +192,16 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename)
 	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
 	control->Get("HapticFeedback", &bHapticFeedback, true);
 	control->Get("ShowAnalogStick", &bShowTouchAnalogStick, true);
-	control->Get("ShowTouchCross", &bShowTouchCross);
-	control->Get("ShowTouchCircle", &bShowTouchCircle);
-	control->Get("ShowTouchSquare", &bShowTouchSquare);
-	control->Get("ShowTouchTriangle", &bShowTouchTriangle);
-	control->Get("ShowTouchStart", &bShowTouchStart);
+	control->Get("ShowTouchCross", &bShowTouchCross, true);
+	control->Get("ShowTouchCircle", &bShowTouchCircle, true);
+	control->Get("ShowTouchSquare", &bShowTouchSquare, true);
+	control->Get("ShowTouchTriangle", &bShowTouchTriangle, true);
+	control->Get("ShowTouchStart", &bShowTouchStart, true);
 	control->Get("ShowTouchSelect", &bShowTouchSelect);
-	control->Get("ShowTouchLTrigger", &bShowTouchLTrigger);
-	control->Get("ShowTouchRTrigger", &bShowTouchRTrigger);
-	control->Get("ShowAnalogStick", &bShowTouchAnalogStick);
-	control->Get("ShowTouchUnthrottle", &bShowTouchUnthrottle);
+	control->Get("ShowTouchLTrigger", &bShowTouchLTrigger, true);
+	control->Get("ShowTouchRTrigger", &bShowTouchRTrigger, true);
+	control->Get("ShowAnalogStick", &bShowTouchAnalogStick, true);
+	control->Get("ShowTouchUnthrottle", &bShowTouchUnthrottle, true);
 
 #if defined(USING_GLES2)
 	std::string name = System_GetProperty(SYSPROP_NAME);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -105,7 +105,17 @@ public:
 
 	// Controls
 	bool bShowTouchControls;
-	bool bShowAnalogStick;
+	bool bShowTouchCross;
+	bool bShowTouchCircle;
+	bool bShowTouchSquare;
+	bool bShowTouchTriangle;
+	bool bShowTouchStart;
+	bool bShowTouchSelect;
+	bool bShowTouchLTrigger;
+	bool bShowTouchRTrigger;
+	bool bShowTouchAnalogStick;
+	bool bShowTouchUnthrottle;
+	bool bShowTouchDpad;
 	bool bHapticFeedback;
 
 	// UI

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -29,8 +29,8 @@
 #include "UI/MiscScreens.h"
 #include "UI/ControlMappingScreen.h"
 #include "UI/DevScreens.h"
-//yuck. need a better name
 #include "UI/TouchControlLayoutScreen.h"
+#include "UI/TouchControlVisibilityScreen.h"
 
 #include "Core/Config.h"
 #include "Core/Host.h"
@@ -214,9 +214,10 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new ItemHeader(c->T("OnScreen", "On-Screen Touch Controls")));
 	controlsSettings->Add(new CheckBox(&g_Config.bShowTouchControls, c->T("OnScreen", "On-Screen Touch Controls")));
 	controlsSettings->Add(new Choice(c->T("Custom layout...")))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlLayout);
+	controlsSettings->Add(new Choice("Control Visibility..."))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
 	controlsSettings->Add(new PopupSliderChoice(&g_Config.iTouchButtonOpacity, 0, 100, c->T("Button Opacity"), screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fButtonScale, 0.80, 2.0, c->T("Button Scaling"), screenManager()));
-	controlsSettings->Add(new CheckBox(&g_Config.bShowAnalogStick, c->T("Show Left Analog Stick")));
+	controlsSettings->Add(new Choice("Control Visibility..."))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
 
 	// System
 	ViewGroup *systemSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
@@ -458,6 +459,11 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e){
 	screenManager()->push(new TouchControlLayoutScreen());
+	return UI::EVENT_DONE;
+};
+
+UI::EventReturn GameSettingsScreen::OnTouchControlVisibility(UI::EventParams &e){
+	screenManager()->push(new TouchControlVisibilityScreen());
 	return UI::EVENT_DONE;
 };
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -214,7 +214,7 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new ItemHeader(c->T("OnScreen", "On-Screen Touch Controls")));
 	controlsSettings->Add(new CheckBox(&g_Config.bShowTouchControls, c->T("OnScreen", "On-Screen Touch Controls")));
 	controlsSettings->Add(new Choice(c->T("Custom layout...")))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlLayout);
-	controlsSettings->Add(new Choice("Control Visibility..."))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
+	controlsSettings->Add(new Choice(c->T("Control Visibility...")))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
 	controlsSettings->Add(new PopupSliderChoice(&g_Config.iTouchButtonOpacity, 0, 100, c->T("Button Opacity"), screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fButtonScale, 0.80, 2.0, c->T("Button Scaling"), screenManager()));
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -217,7 +217,6 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new Choice("Control Visibility..."))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
 	controlsSettings->Add(new PopupSliderChoice(&g_Config.iTouchButtonOpacity, 0, 100, c->T("Button Opacity"), screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fButtonScale, 0.80, 2.0, c->T("Button Scaling"), screenManager()));
-	controlsSettings->Add(new Choice("Control Visibility..."))->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlVisibility);
 
 	// System
 	ViewGroup *systemSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -457,12 +457,12 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e){
+UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e) {
 	screenManager()->push(new TouchControlLayoutScreen());
 	return UI::EVENT_DONE;
 };
 
-UI::EventReturn GameSettingsScreen::OnTouchControlVisibility(UI::EventParams &e){
+UI::EventReturn GameSettingsScreen::OnTouchControlVisibility(UI::EventParams &e) {
 	screenManager()->push(new TouchControlVisibilityScreen());
 	return UI::EVENT_DONE;
 };

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -49,6 +49,7 @@ private:
 	// Event handlers
 	UI::EventReturn OnControlMapping(UI::EventParams &e);
 	UI::EventReturn OnTouchControlLayout(UI::EventParams &e);
+	UI::EventReturn OnTouchControlVisibility(UI::EventParams &e);
 	UI::EventReturn OnDumpNextFrameToLog(UI::EventParams &e);
 	UI::EventReturn OnBack(UI::EventParams &e);
 	UI::EventReturn OnReloadCheats(UI::EventParams &e);

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -278,7 +278,7 @@ void InitPadLayout() {
 	//space between the PSP buttons (triangle, circle, square and cross)
 	const int Action_button_spacing = 50 * scale;
 
-	if(g_Config.iActionButtonSpacing == -1){
+	if (g_Config.iActionButtonSpacing == -1) {
 		g_Config.iActionButtonSpacing = Action_button_spacing;
 	}
 
@@ -297,7 +297,7 @@ void InitPadLayout() {
 	//radius to the D-pad
 	const int D_pad_Radius = 40 * scale;
 
-	if(g_Config.iDpadRadius == -1){
+	if (g_Config.iDpadRadius == -1){
 		g_Config.iDpadRadius = D_pad_Radius;
 	}
 
@@ -307,7 +307,7 @@ void InitPadLayout() {
 		D_pad_Y -= 200 * scale;
 	}
 
-	if(g_Config.iDpadX == -1 || g_Config.iDpadY == -1 ){
+	if(g_Config.iDpadX == -1 || g_Config.iDpadY == -1 ) {
 		//setup defaults
 		g_Config.iDpadX = D_pad_X;
 		g_Config.iDpadY = D_pad_Y;
@@ -318,7 +318,7 @@ void InitPadLayout() {
 	int analog_stick_X = D_pad_X;
 	int analog_stick_Y = dp_yres - 80 * scale;
 
-	if(g_Config.iAnalogStickX == -1 || g_Config.iAnalogStickY == -1 ){
+	if (g_Config.iAnalogStickX == -1 || g_Config.iAnalogStickY == -1 ) {
 		g_Config.iAnalogStickX = analog_stick_X;
 		g_Config.iAnalogStickY = analog_stick_Y;
 	}
@@ -330,7 +330,7 @@ void InitPadLayout() {
 	int start_key_X = dp_xres / 2 + (bottom_key_spacing) * scale;
 	int start_key_Y = dp_yres - 60 * scale;
 
-	if(g_Config.iStartKeyX == -1 || g_Config.iStartKeyY == -1 ){
+	if (g_Config.iStartKeyX == -1 || g_Config.iStartKeyY == -1 ) {
 		g_Config.iStartKeyX = start_key_X;
 		g_Config.iStartKeyY = start_key_Y;
 	}
@@ -338,7 +338,7 @@ void InitPadLayout() {
 	int select_key_X = dp_xres / 2;
 	int select_key_Y = dp_yres - 60 * scale;
 
-	if (g_Config.iSelectKeyX == -1 || g_Config.iSelectKeyY == -1 ){
+	if (g_Config.iSelectKeyX == -1 || g_Config.iSelectKeyY == -1 ) {
 		g_Config.iSelectKeyX = select_key_X;
 		g_Config.iSelectKeyY = select_key_Y;
 	}
@@ -346,7 +346,7 @@ void InitPadLayout() {
 	int unthrottle_key_X = dp_xres / 2 - (bottom_key_spacing) * scale;
 	int unthrottle_key_Y = dp_yres - 60 * scale;
 
-	if (g_Config.iUnthrottleKeyX == -1 || g_Config.iUnthrottleKeyY == -1 ){
+	if (g_Config.iUnthrottleKeyX == -1 || g_Config.iUnthrottleKeyY == -1 ) {
 		g_Config.iUnthrottleKeyX = unthrottle_key_X;
 		g_Config.iUnthrottleKeyY = unthrottle_key_Y;
 	}
@@ -355,7 +355,7 @@ void InitPadLayout() {
 	int l_key_X = 70 * scale;
 	int l_key_Y = 40 * scale;
 
-	if (g_Config.iLKeyX == -1 || g_Config.iLKeyY == -1 ){
+	if (g_Config.iLKeyX == -1 || g_Config.iLKeyY == -1 ) {
 		g_Config.iLKeyX = l_key_X;
 		g_Config.iLKeyY = l_key_Y;
 	}
@@ -363,7 +363,7 @@ void InitPadLayout() {
 	int r_key_X = dp_xres - 60 * scale;
 	int r_key_Y = 40 * scale;
 
-	if (g_Config.iRKeyX == -1 || g_Config.iRKeyY == -1 ){
+	if (g_Config.iRKeyX == -1 || g_Config.iRKeyY == -1 ) {
 		g_Config.iRKeyX = r_key_X;
 		g_Config.iRKeyY = r_key_Y;
 	}

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -303,7 +303,7 @@ void InitPadLayout() {
 
 	int D_pad_X = 2.5 * D_pad_Radius;
 	int D_pad_Y = dp_yres - D_pad_Radius;
-	if (g_Config.bShowTouchAnalogStick){
+	if (g_Config.bShowTouchAnalogStick) {
 		D_pad_Y -= 200 * scale;
 	}
 
@@ -430,21 +430,12 @@ UI::ViewGroup *CreatePadLayout(bool *pause) {
 	const int halfW = dp_xres / 2;
 
 	if (g_Config.bShowTouchControls) {
-		
 		float scale = g_Config.fButtonScale;
-<<<<<<< HEAD
-<<<<<<< HEAD
 
 #if USE_PAUSE_BUTTON
 		root->Add(new BoolButton(pause, I_ROUND, I_ARROW, scale, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 #endif
-
-=======
-=======
-
->>>>>>> 4936897... Make Toggle All actually function.
 		if (g_Config.bShowTouchCircle)
->>>>>>> 86338a5... Add a touch control visibility screen. All touch controls can now be toggled on or off, except for the Pause button on platforms that have it, as a safety precaution.
 		root->Add(new PSPButton(CTRL_CIRCLE, I_ROUND, I_CIRCLE, scale, new AnchorLayoutParams(Action_circle_button_X, Action_circle_button_Y, NONE, NONE, true)));
 
 		if (g_Config.bShowTouchCross)

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -303,7 +303,7 @@ void InitPadLayout() {
 
 	int D_pad_X = 2.5 * D_pad_Radius;
 	int D_pad_Y = dp_yres - D_pad_Radius;
-	if(g_Config.bShowAnalogStick){
+	if (g_Config.bShowTouchAnalogStick){
 		D_pad_Y -= 200 * scale;
 	}
 
@@ -432,28 +432,46 @@ UI::ViewGroup *CreatePadLayout(bool *pause) {
 	if (g_Config.bShowTouchControls) {
 		
 		float scale = g_Config.fButtonScale;
+<<<<<<< HEAD
 
 #if USE_PAUSE_BUTTON
 		root->Add(new BoolButton(pause, I_ROUND, I_ARROW, scale, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 #endif
 
+=======
+		if (g_Config.bShowTouchCircle)
+>>>>>>> 86338a5... Add a touch control visibility screen. All touch controls can now be toggled on or off, except for the Pause button on platforms that have it, as a safety precaution.
 		root->Add(new PSPButton(CTRL_CIRCLE, I_ROUND, I_CIRCLE, scale, new AnchorLayoutParams(Action_circle_button_X, Action_circle_button_Y, NONE, NONE, true)));
-		root->Add(new PSPButton(CTRL_CROSS, I_ROUND, I_CROSS, scale, new AnchorLayoutParams(Action_cross_button_X, Action_cross_button_Y, NONE, NONE, true)));
-		root->Add(new PSPButton(CTRL_TRIANGLE, I_ROUND, I_TRIANGLE, scale, new AnchorLayoutParams(Action_triangle_button_X, Action_triangle_button_Y, NONE, NONE, true)));
-		root->Add(new PSPButton(CTRL_SQUARE, I_ROUND, I_SQUARE, scale, new AnchorLayoutParams(Action_square_button_X, Action_square_button_Y, NONE, NONE, true)));
 
-		root->Add(new PSPButton(CTRL_START, I_RECT, I_START, scale, new AnchorLayoutParams(start_key_X, start_key_Y, NONE, NONE, true)));
-		root->Add(new PSPButton(CTRL_SELECT, I_RECT, I_SELECT, scale, new AnchorLayoutParams(select_key_X, select_key_Y, NONE, NONE, true)));
-		root->Add(new BoolButton(&PSP_CoreParameter().unthrottle, I_RECT, I_ARROW, scale, new AnchorLayoutParams(unthrottle_key_X, unthrottle_key_Y, NONE, NONE, true)))->SetAngle(180);
+		if (g_Config.bShowTouchCross)
+			root->Add(new PSPButton(CTRL_CROSS, I_ROUND, I_CROSS, scale, new AnchorLayoutParams(Action_cross_button_X, Action_cross_button_Y, NONE, NONE, true)));
 
-		root->Add(new PSPButton(CTRL_LTRIGGER, I_SHOULDER, I_L, scale, new AnchorLayoutParams(l_key_X, l_key_Y, NONE, NONE, true)));
-		root->Add(new PSPButton(CTRL_RTRIGGER, I_SHOULDER, I_R, scale, new AnchorLayoutParams(r_key_X,r_key_Y, NONE, NONE, true)))->FlipImageH(true);
+		if (g_Config.bShowTouchTriangle)
+			root->Add(new PSPButton(CTRL_TRIANGLE, I_ROUND, I_TRIANGLE, scale, new AnchorLayoutParams(Action_triangle_button_X, Action_triangle_button_Y, NONE, NONE, true)));
 
-		root->Add(new PSPCross(I_DIR, I_ARROW, scale, D_pad_Radius, new AnchorLayoutParams(D_pad_X, D_pad_Y, NONE, NONE, true)));
+		if (g_Config.bShowTouchSquare)
+			root->Add(new PSPButton(CTRL_SQUARE, I_ROUND, I_SQUARE, scale, new AnchorLayoutParams(Action_square_button_X, Action_square_button_Y, NONE, NONE, true)));
 
-		if (g_Config.bShowAnalogStick) {
+		if (g_Config.bShowTouchStart)
+			root->Add(new PSPButton(CTRL_START, I_RECT, I_START, scale, new AnchorLayoutParams(start_key_X, start_key_Y, NONE, NONE, true)));
+
+		if (g_Config.bShowTouchSelect)
+			root->Add(new PSPButton(CTRL_SELECT, I_RECT, I_SELECT, scale, new AnchorLayoutParams(select_key_X, select_key_Y, NONE, NONE, true)));
+
+		if (g_Config.bShowTouchUnthrottle)
+			root->Add(new BoolButton(&PSP_CoreParameter().unthrottle, I_RECT, I_ARROW, scale, new AnchorLayoutParams(unthrottle_key_X, unthrottle_key_Y, NONE, NONE, true)))->SetAngle(180);
+
+		if (g_Config.bShowTouchLTrigger)
+			root->Add(new PSPButton(CTRL_LTRIGGER, I_SHOULDER, I_L, scale, new AnchorLayoutParams(l_key_X, l_key_Y, NONE, NONE, true)));
+
+		if (g_Config.bShowTouchRTrigger)
+			root->Add(new PSPButton(CTRL_RTRIGGER, I_SHOULDER, I_R, scale, new AnchorLayoutParams(r_key_X,r_key_Y, NONE, NONE, true)))->FlipImageH(true);
+
+		if (g_Config.bShowTouchDpad)
+			root->Add(new PSPCross(I_DIR, I_ARROW, scale, D_pad_Radius, new AnchorLayoutParams(D_pad_X, D_pad_Y, NONE, NONE, true)));
+
+		if (g_Config.bShowTouchAnalogStick)
 			root->Add(new PSPStick(I_STICKBG, I_STICK, 0, scale, new AnchorLayoutParams(analog_stick_X, analog_stick_Y, NONE, NONE, true)));
-		}
 	}
 
 	return root;

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -286,7 +286,7 @@ void InitPadLayout() {
 	int Action_button_center_X = dp_xres - Action_button_spacing * 2;
 	int Action_button_center_Y = dp_yres - Action_button_spacing * 2;
 
-	if(g_Config.iActionButtonCenterX == -1 || g_Config.iActionButtonCenterY == -1 ){
+	if(g_Config.iActionButtonCenterX == -1 || g_Config.iActionButtonCenterY == -1 ) {
 		//setup defaults
 		g_Config.iActionButtonCenterX = Action_button_center_X;
 		g_Config.iActionButtonCenterY = Action_button_center_Y;
@@ -297,7 +297,7 @@ void InitPadLayout() {
 	//radius to the D-pad
 	const int D_pad_Radius = 40 * scale;
 
-	if (g_Config.iDpadRadius == -1){
+	if (g_Config.iDpadRadius == -1) {
 		g_Config.iDpadRadius = D_pad_Radius;
 	}
 
@@ -433,12 +433,16 @@ UI::ViewGroup *CreatePadLayout(bool *pause) {
 		
 		float scale = g_Config.fButtonScale;
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 #if USE_PAUSE_BUTTON
 		root->Add(new BoolButton(pause, I_ROUND, I_ARROW, scale, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 #endif
 
 =======
+=======
+
+>>>>>>> 4936897... Make Toggle All actually function.
 		if (g_Config.bShowTouchCircle)
 >>>>>>> 86338a5... Add a touch control visibility screen. All touch controls can now be toggled on or off, except for the Pause button on platforms that have it, as a safety precaution.
 		root->Add(new PSPButton(CTRL_CIRCLE, I_ROUND, I_CIRCLE, scale, new AnchorLayoutParams(Action_circle_button_X, Action_circle_button_Y, NONE, NONE, true)));

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -272,7 +272,7 @@ void TouchControlLayoutScreen::CreateViews() {
 	rbutton->FlipImageH(true);
 	controls_.push_back(rbutton);
 
-	if (g_Config.bShowAnalogStick) {
+	if (g_Config.bShowTouchAnalogStick) {
 		controls_.push_back(new DragDropButton(g_Config.iAnalogStickX, g_Config.iAnalogStickY, I_STICKBG, I_STICK, scale));
 	};
 	I18NCategory *ms = GetI18NCategory("MainSettings");

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -19,6 +19,7 @@
 #include "Common/KeyMap.h"
 #include "Core/Config.h"
 #include "ui/ui_atlas.h"
+#include "i18n/i18n.h"
 
 #include <vector>
 #include <string>
@@ -68,6 +69,8 @@ void TouchControlVisibilityScreen::CreateViews() {
 
 	std::map<std::string, int>::iterator imageFinder;
 
+	I18NCategory *mc = GetI18NCategory("MappableControls");
+
 	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i) {
 		LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		row->SetSpacing(0);
@@ -78,7 +81,7 @@ void TouchControlVisibilityScreen::CreateViews() {
 		if (imageFinder != keyImages.end()) {
 			row->Add(new Choice(keyImages[imageFinder->first], new LinearLayoutParams(1.0f)));
 		} else {
-			row->Add(new Choice(i->first, new LinearLayoutParams(1.0f)));
+			row->Add(new Choice(mc->T(i->first.c_str()), new LinearLayoutParams(1.0f)));
 		}
 		grid->Add(row);
 	}

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -74,10 +74,10 @@ void TouchControlVisibilityScreen::CreateViews() {
 	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i) {
 		LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		row->SetSpacing(0);
-
-		imageFinder = keyImages.find(i->first);
 		row->Add(new CheckBox(i->second, "", "", new LinearLayoutParams(50, WRAP_CONTENT)));
 
+		imageFinder = keyImages.find(i->first);
+		
 		if (imageFinder != keyImages.end()) {
 			row->Add(new Choice(keyImages[imageFinder->first], new LinearLayoutParams(1.0f)));
 		} else {

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -16,13 +16,9 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "TouchControlVisibilityScreen.h"
-#include "Common/KeyMap.h"
 #include "Core/Config.h"
 #include "ui/ui_atlas.h"
 #include "i18n/i18n.h"
-
-#include <vector>
-#include <string>
 
 void TouchControlVisibilityScreen::CreateViews() {
 	using namespace UI;

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -73,11 +73,16 @@ void TouchControlVisibilityScreen::CreateViews() {
 		row->Add(new CheckBox(i->second, "", "", new LinearLayoutParams(50, WRAP_CONTENT)));
 
 		imageFinder = keyImages.find(i->first);
-		
+		Choice *choice;
+
 		if (imageFinder != keyImages.end()) {
-			row->Add(new Choice(keyImages[imageFinder->first], new LinearLayoutParams(1.0f)));
+			choice = new Choice(keyImages[imageFinder->first], new LinearLayoutParams(1.0f));
+			choice->SetCentered(true);
+			row->Add(choice);
 		} else {
-			row->Add(new Choice(mc->T(i->first.c_str()), new LinearLayoutParams(1.0f)));
+			choice = new Choice(mc->T(i->first.c_str()), new LinearLayoutParams(1.0f));
+			choice->SetCentered(true);
+			row->Add(choice);
 		}
 		grid->Add(row);
 	}

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -23,10 +23,6 @@
 #include <vector>
 #include <string>
 
-TouchControlVisibilityScreen::TouchControlVisibilityScreen() {
-
-}
-
 void TouchControlVisibilityScreen::CreateViews() {
 	using namespace UI;
 
@@ -58,7 +54,6 @@ void TouchControlVisibilityScreen::CreateViews() {
 	keyImages["L"] = I_L;
 	keyImages["R"] = I_R;
 
-	std::map<std::string, bool*> keyToggles;
 	keyToggles["Circle"] = &g_Config.bShowTouchCircle;
 	keyToggles["Cross"] = &g_Config.bShowTouchCross;
 	keyToggles["Square"] = &g_Config.bShowTouchSquare;
@@ -98,5 +93,8 @@ UI::EventReturn TouchControlVisibilityScreen::OnBack(UI::EventParams &e) {
 }
 
 UI::EventReturn TouchControlVisibilityScreen::OnToggleAll(UI::EventParams &e) {
+	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i)
+		*i->second = !*i->second;
+
 	return UI::EVENT_DONE;
 }

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "TouchControlVisibilityScreen.h"
+#include "Common/KeyMap.h"
+#include "Core/Config.h"
+#include "ui/ui_atlas.h"
+
+#include <vector>
+#include <string>
+
+TouchControlVisibilityScreen::TouchControlVisibilityScreen() {
+
+}
+
+void TouchControlVisibilityScreen::CreateViews() {
+	using namespace UI;
+
+	root_ = new ScrollView(ORIENT_VERTICAL);
+	LinearLayout *vert = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, FILL_PARENT)));
+	vert->SetSpacing(0);
+
+	LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL);
+	topBar->Add(new Choice("Back"))->OnClick.Handle<TouchControlVisibilityScreen>(this, &TouchControlVisibilityScreen::OnBack);
+	topBar->Add(new Choice("Toggle All"))->OnClick.Handle(this, &TouchControlVisibilityScreen::OnToggleAll);
+
+	vert->Add(topBar);
+
+	vert->Add(new ItemHeader("Touch Control Visibility"));
+
+	const int cellSize = 400;
+
+	UI::GridLayoutSettings gridsettings(cellSize, 64, 5);
+	gridsettings.fillCells = true;
+	GridLayout *grid = vert->Add(new GridLayout(gridsettings, new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
+
+	std::map<std::string, int> keyImages;
+	keyImages["Circle"] = I_CIRCLE;
+	keyImages["Cross"] = I_CROSS;
+	keyImages["Square"] = I_SQUARE;
+	keyImages["Triangle"] = I_TRIANGLE;
+	keyImages["Start"] = I_START;
+	keyImages["Select"] = I_SELECT;
+	keyImages["L"] = I_L;
+	keyImages["R"] = I_R;
+
+	std::map<std::string, bool*> keyToggles;
+	keyToggles["Circle"] = &g_Config.bShowTouchCircle;
+	keyToggles["Cross"] = &g_Config.bShowTouchCross;
+	keyToggles["Square"] = &g_Config.bShowTouchSquare;
+	keyToggles["Triangle"] = &g_Config.bShowTouchTriangle;
+	keyToggles["L"] = &g_Config.bShowTouchLTrigger;
+	keyToggles["R"] = &g_Config.bShowTouchRTrigger;
+	keyToggles["Start"] = &g_Config.bShowTouchStart;
+	keyToggles["Select"] = &g_Config.bShowTouchSelect;
+	keyToggles["Dpad"] = &g_Config.bShowTouchDpad;
+	keyToggles["Analog Stick"] = &g_Config.bShowTouchAnalogStick;
+	keyToggles["Unthrottle"] = &g_Config.bShowTouchUnthrottle;
+
+	std::map<std::string, int>::iterator imageFinder;
+
+	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i) {
+		LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		row->SetSpacing(0);
+
+		imageFinder = keyImages.find(i->first);
+		row->Add(new CheckBox(i->second, "", "", new LinearLayoutParams(50, WRAP_CONTENT)));
+
+		if (imageFinder != keyImages.end()) {
+			row->Add(new Choice(keyImages[imageFinder->first], new LinearLayoutParams(1.0f)));
+		} else {
+			row->Add(new Choice(i->first, new LinearLayoutParams(1.0f)));
+		}
+		grid->Add(row);
+	}
+}
+
+UI::EventReturn TouchControlVisibilityScreen::OnBack(UI::EventParams &e) {
+	screenManager()->finishDialog(this, DR_OK);
+
+	g_Config.Save();
+
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn TouchControlVisibilityScreen::OnToggleAll(UI::EventParams &e) {
+	return UI::EVENT_DONE;
+}

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -36,8 +36,8 @@ void TouchControlVisibilityScreen::CreateViews() {
 	topBar->Add(new Choice("Toggle All"))->OnClick.Handle(this, &TouchControlVisibilityScreen::OnToggleAll);
 
 	vert->Add(topBar);
-
-	vert->Add(new ItemHeader("Touch Control Visibility"));
+	I18NCategory *co = GetI18NCategory("Control Mapping");
+	vert->Add(new ItemHeader(co->T("Touch Control Visibility")));
 
 	const int cellSize = 400;
 

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -24,7 +24,7 @@
 
 class TouchControlVisibilityScreen : public UIScreenWithBackground {
 public:
-	TouchControlVisibilityScreen();
+	TouchControlVisibilityScreen::TouchControlVisibilityScreen() { }
 
 	virtual void CreateViews();
 
@@ -33,7 +33,5 @@ protected:
 	virtual UI::EventReturn OnToggleAll(UI::EventParams &e);
 
 private:
-	//DragDropButton *pickedControl_;
-	//std::vector<DragDropButton *> controls_;
-	//DragDropButton *getPickedControl(const int x, const int y);
+	std::map<std::string, bool*> keyToggles;
 };

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "base/functional.h"
+#include "ui/view.h"
+#include "MiscScreens.h"
+#include <vector>
+
+class TouchControlVisibilityScreen : public UIScreenWithBackground {
+public:
+	TouchControlVisibilityScreen();
+
+	virtual void CreateViews();
+
+protected:
+	virtual UI::EventReturn OnBack(UI::EventParams &e);
+	virtual UI::EventReturn OnToggleAll(UI::EventParams &e);
+
+private:
+	//DragDropButton *pickedControl_;
+	//std::vector<DragDropButton *> controls_;
+	//DragDropButton *getPickedControl(const int x, const int y);
+};

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include "base/functional.h"
-#include "ui/view.h"
 #include "MiscScreens.h"
-#include <vector>
+
+#include <map>
 
 class TouchControlVisibilityScreen : public UIScreenWithBackground {
 public:
-	TouchControlVisibilityScreen::TouchControlVisibilityScreen() { }
+	TouchControlVisibilityScreen() { }
 
 	virtual void CreateViews();
 

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="NativeApp.cpp" />
     <ClCompile Include="OnScreenDisplay.cpp" />
     <ClCompile Include="TouchControlLayoutScreen.cpp" />
+    <ClCompile Include="TouchControlVisibilityScreen.cpp" />
     <ClCompile Include="UIShader.cpp" />
     <ClCompile Include="ui_atlas.cpp" />
   </ItemGroup>
@@ -48,6 +49,7 @@
     <ClInclude Include="MiscScreens.h" />
     <ClInclude Include="OnScreenDisplay.h" />
     <ClInclude Include="TouchControlLayoutScreen.h" />
+    <ClInclude Include="TouchControlVisibilityScreen.h" />
     <ClInclude Include="UIShader.h" />
     <ClInclude Include="ui_atlas.h" />
   </ItemGroup>

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="TouchControlLayoutScreen.cpp">
       <Filter>Screens</Filter>
     </ClCompile>
+    <ClCompile Include="TouchControlVisibilityScreen.cpp">
+      <Filter>Screens</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -66,6 +69,9 @@
       <Filter>Screens</Filter>
     </ClInclude>
     <ClInclude Include="TouchControlLayoutScreen.h">
+      <Filter>Screens</Filter>
+    </ClInclude>
+    <ClInclude Include="TouchControlVisibilityScreen.h">
       <Filter>Screens</Filter>
     </ClInclude>
   </ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -113,6 +113,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/UI/ControlMappingScreen.cpp \
   $(SRC)/UI/GameSettingsScreen.cpp \
   $(SRC)/UI/TouchControlLayoutScreen.cpp \
+  $(SRC)/UI/TouchControlVisibilityScreen.cpp \
   $(SRC)/UI/CwCheatScreen.cpp \
   $(SRC)/ext/disarm.cpp \
   $(SRC)/ext/libkirk/AES.c \


### PR DESCRIPTION
This sister-screen to TouchControlLayoutScreen will allow the user to toggle every single onscreen touch control's visibility except for platforms that support the pause/menu button: that's the only button that cannot be disabled(for safety reasons). It can even be toggled in-game.

Preview(heavily influenced by the Log Channel screen as you can see):
![Screenshot 01](http://i.minus.com/iYJTpNKiBBoSU.jpg)
