### PR TITLE
Use the newer interface for Qt's gpu debugging

### DIFF
--- a/Core/Host.h
+++ b/Core/Host.h
@@ -72,10 +72,6 @@ public:
 	virtual void GPUNotifyTextureAttachment(u32 addr) {}
 	virtual bool GPUAllowTextureCache(u32 addr) { return true; }
 
-	virtual bool GpuStep() { return false; }
-	virtual void SendGPUStart() {}
-	virtual void SendGPUWait(u32 cmd, u32 addr, void* data) {}
-
 	virtual bool CanCreateShortcut() {return false;}
 	virtual bool CreateDesktopShortcut(std::string argumentPath, std::string title) {return false;}
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -477,13 +477,6 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 		return true;
 	}
 
-	// TODO: Use new interface.
-#if defined(USING_QT_UI)
-	if (host->GpuStep()) {
-		host->SendGPUStart();
-	}
-#endif
-
 	cycleLastPC = list.pc;
 	cyclesExecuted += 60;
 	downcount = list.stall == 0 ? 0x0FFFFFFF : (list.stall - list.pc) / 4;
@@ -543,12 +536,6 @@ void GPUCommon::SlowRunLoop(DisplayList &list)
 		host->GPUNotifyCommand(list.pc);
 		u32 op = Memory::ReadUnchecked_U32(list.pc);
 		u32 cmd = op >> 24;
-
-		// TODO: Replace.
-#if defined(USING_QT_UI)
-		if (host->GpuStep())
-			host->SendGPUWait(cmd, list.pc, &gstate);
-#endif
 
 		u32 diff = op ^ gstate.cmdmem[cmd];
 		PreExecuteOp(op, diff);

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -156,6 +156,27 @@ bool QtHost::IsDebuggingEnabled()
 #endif
 }
 
+bool QtHost::GPUDebuggingActive()
+{
+	auto dialogDisplayList = mainWindow->GetDialogDisplaylist();
+	if (dialogDisplayList && dialogDisplayList->isVisible())
+	{
+		if (GpuStep())
+			SendGPUStart();
+
+		return true;
+	}
+	return false;
+}
+
+void QtHost::GPUNotifyCommand(u32 pc)
+{
+	u32 op = Memory::ReadUnchecked_U32(pc);
+	u32 cmd = op >> 24;
+	if (GpuStep())
+		SendGPUWait(cmd, pc, &gstate);
+}
+
 void QtHost::SendCoreWait(bool isWaiting)
 {
 	mainWindow->CoreEmitWait(isWaiting);

--- a/Qt/QtHost.h
+++ b/Qt/QtHost.h
@@ -44,10 +44,13 @@ public:
 	void ShutdownSound();
 
 	bool IsDebuggingEnabled();
+	bool GPUDebuggingActive();
 	void BootDone();
 	void PrepareShutdown();
 	bool AttemptLoadSymbolMap();
 	void SetWindowTitle(const char *message);
+
+	void GPUNotifyCommand(u32 pc);
 
 	void SendCoreWait(bool);
 	bool GpuStep();


### PR DESCRIPTION
This just makes it use the same interface.

Unfortunately, it still doesn't work, but it's because of a threading issue (ui and emu are on the same thread, unlike Windows, I think they didn't used to be.)

-[Unknown]
