### PR TITLE
fix maxim-at3plus crash

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1680,7 +1680,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 				}
 			}
 			atrac->currentSample += numSamples;
-			numSamples = ATRAC3_MAX_SAMPLES;
+			numSamples = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
 			Memory::Write_U32(numSamples * sizeof(s16) * atrac->atracOutputChannels, sampleBytesAddr);
 			atrac->SeekToSample(atrac->currentSample);
 			if (atrac->decodePos >= atrac->first.size) {


### PR DESCRIPTION
Thanks @unknownbrackets
https://github.com/hrydgard/ppsspp/issues/4248
Digimon Adventure Voice probrem can be fixed later
(Hope this can be also fixed later : E[ME]: HLE\sceAtrac.cpp:1666 atracID: 1, avcodec_decode_audio4: Error decoding audio -22 )
