### PR TITLE
Regression fix : try to ignore texture match for render-to-texture

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -842,20 +842,20 @@ void TextureCache::SetTexture(bool force) {
 
 	if (iter != cache.end()) {
 		entry = &iter->second;
+		// Check for FBO - slow!
+		if (entry->framebuffer) {
+			SetTextureFramebuffer(entry);
+			lastBoundTexture = -1;
+			entry->lastFrame = gpuStats.numFlips;
+			return;
+		}
+
 		// Validate the texture still matches the cache entry.
 		u16 dim = gstate.getTextureDimension(0);
 		bool match = entry->Matches(dim, format, maxLevel);
 #ifndef USING_GLES2
 		match &= host->GPUAllowTextureCache(texaddr);
 #endif
-
-		// Check for FBO - slow!
-		if (entry->framebuffer && match) {
-			SetTextureFramebuffer(entry);
-			lastBoundTexture = -1;
-			entry->lastFrame = gpuStats.numFlips;
-			return;
-		}
 
 		bool rehash = (entry->status & TexCacheEntry::STATUS_MASK) == TexCacheEntry::STATUS_UNRELIABLE;
 		bool doDelete = true;


### PR DESCRIPTION
It seems the texture dim for render-to-texture cannot be matched in some cases and render them as black texture at all. Most obvious one is FF Type 0 , it appears throughout the game.

We may revisit it after 0.95 release as it works well before in 0.91 at least.
