### PR TITLE
Common cleanup: Cleaned up Common.h and simplified MsgHandler

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -137,10 +137,6 @@ private:
 #define __chdir chdir
 #endif
 
-// Dummy macro for marking translatable strings that can not be immediately translated.
-// wxWidgets does not have a true dummy macro for this.
-#define _trans(a) a
-
 #if defined __GNUC__
 # if defined __SSE4_2__
 #  define _M_SSE 0x402

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -40,10 +40,6 @@
 #define _M_ARM32
 #endif
 
-// SVN version number
-extern const char *scm_rev_str;
-extern const char *netplay_dolphin_ver;
-
 // Force enable logging in the right modes. For some reason, something had changed
 // so that debugfast no longer logged.
 #if defined(_DEBUG) || defined(DEBUGFAST)
@@ -75,11 +71,6 @@ private:
 #undef STACKALIGN
 #define STACKALIGN __attribute__((__force_align_arg_pointer__))
 #endif
-// We use wxWidgets on OS X only if it is version 2.9+ with Cocoa support.
-#ifdef __WXOSX_COCOA__
-#define HAVE_WX 1
-#define USE_WX 1	// Use wxGLCanvas
-#endif
 
 #elif defined _WIN32
 
@@ -87,10 +78,6 @@ private:
 	#if !defined _MSC_VER || _MSC_VER <= 1000
 		#error needs at least version 1000 of MSC
 	#endif
-
-#ifndef NOMINMAX
-	#define NOMINMAX
-#endif
 
 // Memory leak checks
 	#define CHECK_HEAP_INTEGRITY()
@@ -102,11 +89,6 @@ private:
 	#define GC_ALIGNED128(x) __declspec(align(128)) x
 	#define GC_ALIGNED16_DECL(x) __declspec(align(16)) x
 	#define GC_ALIGNED64_DECL(x) __declspec(align(64)) x
-
-// Since it is always around on windows
-	#define HAVE_WX 1
-
-	#define HAVE_PORTAUDIO 1
 
 // Debug definitions
 	#if defined(_DEBUG)
@@ -212,24 +194,6 @@ inline double bswapd( double f )
 
   return dat2.f;
 }
-
-// Host communication.
-enum HOST_COMM
-{
-	// Begin at 10 in case there is already messages with wParam = 0, 1, 2 and so on
-	WM_USER_STOP = 10,
-	WM_USER_CREATE,
-	WM_USER_SETCURSOR,
-	WM_USER_KEYDOWN,
-};
-
-// Used for notification on emulation state
-enum EMUSTATE_CHANGE
-{
-	EMUSTATE_CHANGE_PLAY = 1,
-	EMUSTATE_CHANGE_PAUSE,
-	EMUSTATE_CHANGE_STOP
-};
 
 #include "Swap.h"
 

--- a/Common/MsgHandler.cpp
+++ b/Common/MsgHandler.cpp
@@ -15,31 +15,14 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
-
-
 #include "Common.h" // Local
 #include "StringUtils.h"
 #include "util/text/utf8.h"
+#include <string>
 
-bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style);
-static MsgAlertHandler msg_handler = DefaultMsgHandler;
+bool MsgHandler(const char* caption, const char* text, bool yes_no, int Style);
+
 static bool AlertEnabled = true;
-
-std::string DefaultStringTranslator(const char* text);
-static StringTranslator str_translator = DefaultStringTranslator;
-
-// Select which of these functions that are used for message boxes. If
-// wxWidgets is enabled we will use wxMsgAlert() that is defined in Main.cpp
-void RegisterMsgAlertHandler(MsgAlertHandler handler)
-{
-	msg_handler = handler;
-}
-
-// Select translation function.  For wxWidgets use wxStringTranslator in Main.cpp
-void RegisterStringTranslator(StringTranslator translator)
-{
-	str_translator = translator;
-}
 
 // enable/disable the alert handler
 void SetEnableAlert(bool enable)
@@ -52,48 +35,27 @@ void SetEnableAlert(bool enable)
 bool MsgAlert(bool yes_no, int Style, const char* format, ...)
 {
 	// Read message and write it to the log
-	std::string caption;
 	char buffer[2048];
 
-	static std::string info_caption;
-	static std::string warn_caption;
-	static std::string ques_caption;
-	static std::string crit_caption;
+	static const char *captions[] = {
+		"Information",
+		"Question",
+		"Warning",
+		"Critical"
+	};
 
-	if (!info_caption.length())
-	{
-		info_caption = str_translator(_trans("Information"));
-		ques_caption = str_translator(_trans("Question"));
-		warn_caption = str_translator(_trans("Warning"));
-		crit_caption = str_translator(_trans("Critical"));
-	}
-
-	switch(Style)
-	{
-		case INFORMATION:
-			caption = info_caption;
-			break;
-		case QUESTION:
-			caption = ques_caption;
-			break;
-		case WARNING:
-			caption = warn_caption;
-			break;
-		case CRITICAL:
-			caption = crit_caption;
-			break;
-	}
+	const char *caption = captions[Style];
 
 	va_list args;
 	va_start(args, format);
-	CharArrayFromFormatV(buffer, sizeof(buffer)-1, str_translator(format).c_str(), args);
+	CharArrayFromFormatV(buffer, sizeof(buffer)-1, format, args);
 	va_end(args);
 
-	ERROR_LOG(MASTER_LOG, "%s: %s", caption.c_str(), buffer);
+	ERROR_LOG(MASTER_LOG, "%s: %s", caption, buffer);
 
 	// Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
-	if (msg_handler && (AlertEnabled || Style == QUESTION || Style == CRITICAL))
-		return msg_handler(caption.c_str(), buffer, yes_no, Style);
+	if (AlertEnabled || Style == QUESTION || Style == CRITICAL)
+		return MsgHandler(caption, buffer, yes_no, Style);
 
 	return true;
 }
@@ -103,7 +65,7 @@ bool MsgAlert(bool yes_no, int Style, const char* format, ...)
 #endif
 
 // Default non library dependent panic alert
-bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style)
+bool MsgHandler(const char* caption, const char* text, bool yes_no, int Style)
 {
 #ifdef _WIN32
 	int STYLE = MB_ICONINFORMATION;
@@ -120,10 +82,3 @@ bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int S
 	return true;
 #endif
 }
-
-// Default (non) translator
-std::string DefaultStringTranslator(const char* text)
-{
-	return text;
-}
-

--- a/Common/MsgHandler.h
+++ b/Common/MsgHandler.h
@@ -18,8 +18,6 @@
 #ifndef _MSGHANDLER_H_
 #define _MSGHANDLER_H_
 
-#include <string>
-
 // Message alerts
 enum MSG_TYPE
 {
@@ -28,13 +26,6 @@ enum MSG_TYPE
 	WARNING,
 	CRITICAL
 };
-
-typedef bool (*MsgAlertHandler)(const char* caption, const char* text, 
-                                bool yes_no, int Style);
-typedef std::string (*StringTranslator)(const char* text);
-
-void RegisterMsgAlertHandler(MsgAlertHandler handler);
-void RegisterStringTranslator(StringTranslator translator);
 
 extern bool MsgAlert(bool yes_no, int Style, const char* format, ...)
 #ifdef __GNUC__


### PR DESCRIPTION
In Common.h, I've only deleted defines/enums that were sitting there since the initial commit and weren't used anywhere at all. NOMINMAX is defined in CommonWindows so it looks safe to remove it here.

In MsgHandler, I've removed RegisterMsgAlertHandler and RegisterStringTranslator. Since users should see the alerts as rarely as possible, I don't think there will ever be a need to translate them.
