### PR TITLE
Detach framebuffers when texcache match fails, properly

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -312,7 +312,9 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 	}
 
 	// TODO: We can just change the texture format and flip some bits around instead of this.
+	bool useConvBuf = false;
 	if (pixelFormat != GE_FORMAT_8888 || linesize != 512) {
+		useConvBuf = true;
 		if (!convBuf) {
 			convBuf = new u8[512 * 272 * 4];
 		}
@@ -385,7 +387,7 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 	if (g_Config.iTexFiltering == LINEAR || (g_Config.iTexFiltering == LINEARFMV && g_iNumVideos)) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	}
-	glTexSubImage2D(GL_TEXTURE_2D,0,0,0,512,272, GL_RGBA, GL_UNSIGNED_BYTE, pixelFormat == GE_FORMAT_8888 ? framebuf : convBuf);
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 512, 272, GL_RGBA, GL_UNSIGNED_BYTE, useConvBuf ? convBuf : framebuf);
 
 	// This draws directly at the backbuffer so if there's a post shader, we need to apply it here. Should try to unify this path
 	// with the regular path somehow, but this simple solution works for most of the post shaders (it always runs at output resolution so FXAA may look odd).

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1008,6 +1008,11 @@ void TextureCache::SetTexture(bool force) {
 	gstate_c.curTextureWidth = w;
 	gstate_c.curTextureHeight = h;
 
+	// Always generate a texture name, we might need it if the texture is replaced later.
+	if (!replaceImages) {
+		glGenTextures(1, &entry->texture);
+	}
+
 	// Before we go reading the texture from memory, let's check for render-to-texture.
 	for (size_t i = 0, n = fbCache_.size(); i < n; ++i) {
 		auto framebuffer = fbCache_[i];
@@ -1031,10 +1036,6 @@ void TextureCache::SetTexture(bool force) {
 		lastBoundTexture = -1;
 		entry->lastFrame = gpuStats.numFlips;
 		return;
-	}
-
-	if (!replaceImages) {
-		glGenTextures(1, &entry->texture);
 	}
 	glBindTexture(GL_TEXTURE_2D, entry->texture);
 	lastBoundTexture = entry->texture;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -861,6 +861,7 @@ void TextureCache::SetTexture(bool force) {
 			} else {
 				// Make sure we re-evaluate framebuffers.
 				DetachFramebuffer(entry, texaddr, entry->framebuffer);
+				match = false;
 			}
 		}
 


### PR DESCRIPTION
Otherwise, `entry->framebuffer` stays set, even if another framebuffer (or even the same one) might be valid.  This allows it to reset the cache entry settings.

Also, I noticed a small bug in DrawPixels(), but it's probably super unlikely to ever be hit.

This might help the FF Type-0 issue, but I am not seeing it currently... Tactics Ogre, Valkyrie Profile, and Mana Khemia (which are picky about these renders) seem to be no worse.  @solarmystic and @raven02, I could use some help testing this with other games that are temperamental in this area.

(not sure, might be better to wait until after 0.9.5...)

-[Unknown]
