### PR TITLE
Improve Linux flash0 path handling, fix __cpuidex() in some gccs

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -62,23 +62,18 @@ void __cpuidex(int regs[4], int cpuid_leaf, int ecxval)
 #if defined(__i386__)
 		"pushl %%ebx;\n\t"
 #endif
-		"movl %4, %%eax;\n\t"
-		"movl %5, %%ecx;\n\t"
 		"cpuid;\n\t"
-		"movl %%eax, %0;\n\t"
 		"movl %%ebx, %1;\n\t"
-		"movl %%ecx, %2;\n\t"
-		"movl %%edx, %3;\n\t"
 #if defined(__i386__)
 		"popl %%ebx;\n\t"
 #endif
-		:"=m" (regs[0]), "=m" (regs[1]), "=m" (regs[2]), "=m" (regs[3])
-		:"r" (cpuid_leaf), "r" (ecxval)
-		:"%eax",
+		:"=a" (regs[0]), "=m" (regs[1]), "=c" (regs[2]), "=d" (regs[3])
+		:"a" (cpuid_leaf), "c" (ecxval)
 #if !defined(__i386__)
-		"%ebx",
+		:"%ebx");
+#else
+		);
 #endif
-		"%ecx", "%edx");
 #endif
 }
 void __cpuid(int regs[4], int cpuid_leaf)

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -3,6 +3,7 @@
 #include <QFileInfo>
 #include <QDebug>
 #include <QDir>
+#include <QCoreApplication>
 
 #include "QtHost.h"
 #include "LogManager.h"
@@ -313,8 +314,19 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 		g_Config.currentDirectory = QDir::homePath().toStdString();
 	}
 
-	g_Config.memCardDirectory = QDir::homePath().toStdString()+"/.ppsspp/";
-	g_Config.flash0Directory = g_Config.memCardDirectory+"/flash0/";
+	g_Config.memCardDirectory = QDir::homePath().toStdString() + "/.ppsspp/";
+
+#if defined(Q_OS_LINUX) && !defined(ARM)
+	std::string program_path = QCoreApplication::applicationDirPath().toStdString();
+	if (File::Exists(program_path + "/flash0"))
+		g_Config.flash0Directory = program_path + "/flash0/";
+	else if (File::Exists(program_path + "/../flash0"))
+		g_Config.flash0Directory = program_path + "/../flash0/";
+	else
+		g_Config.flash0Directory = g_Config.memCardDirectory + "/flash0/";
+#else
+	g_Config.flash0Directory = g_Config.memCardDirectory + "/flash0/";
+#endif
 
 	LogManager::Init();
 	if (fileToLog != NULL)

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -26,7 +26,7 @@
 class MultiTouchButton : public UI::View {
 public:
 	MultiTouchButton(int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: UI::View(layoutParams), pointerDownMask_(0), bgImg_(bgImg), img_(img), scale_(scale), angle_(0.0f), flipImageH_(false) {
+		: UI::View(layoutParams), pointerDownMask_(0), scale_(scale), bgImg_(bgImg), img_(img), angle_(0.0f), flipImageH_(false) {
 	}
 
 	virtual void Key(const KeyInput &input) {}

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -329,8 +329,9 @@ int main(int argc, const char* argv[])
 #if defined(ANDROID)
 #elif defined(BLACKBERRY) || defined(__SYMBIAN32__)
 #elif !defined(_WIN32)
-	g_Config.memCardDirectory = std::string(getenv("HOME"))+"/.ppsspp/";
-	g_Config.flash0Directory = g_Config.memCardDirectory+"/flash/";
+	g_Config.memCardDirectory = std::string(getenv("HOME")) + "/.ppsspp/";
+	// TODO: This isn't a great place.
+	g_Config.flash0Directory = g_Config.memCardDirectory + "/flash0/";
 #endif
 
 	if (screenshotFilename != 0)


### PR DESCRIPTION
This way you don't have to copy anything, it should just work normally as on e.g. Windows.  One less gotcha.

@skardach: does this __cpuidex() work for you as well?  I was trying to test 32-bit (for some jit stuff), and gcc (should be 4.8) was telling me it had "impossible constraints."  I think this version should work fine, and it compiled for me.  Unfortunately I couldn't get Ubuntu to install the proper 32-bit libs side by side.  It does work on 64 bit.

-[Unknown]
