### PR TITLE
Let the language be changed in the touch control editor screens.

### DIFF
--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -214,9 +214,10 @@ void ControlMappingScreen::CreateViews() {
 }
 
 void ControlMappingScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
+	// Always call the base class method first, to handle common messages, then
+	// handle other specific messages after.
+	UIDialogScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "settings")) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new GameSettingsScreen(""));

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -92,12 +92,6 @@ void CwCheatScreen::CreateViews() {
 	}
 }
 
-void CwCheatScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
-}
-
 UI::EventReturn CwCheatScreen::OnBack(UI::EventParams &params)
 {
 	screenManager()->finishDialog(this, DR_OK);

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -42,7 +42,6 @@ public:
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
 protected:
 	virtual void CreateViews();
-	virtual void sendMessage(const char *message, const char *value);
 
 private:
 	UI::EventReturn OnCheckBox(UI::EventParams &params);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -196,7 +196,9 @@ void SystemInfoScreen::CreateViews() {
 	deviceSpecs->Add(new InfoItem("Vendor", (char *)glGetString(GL_VENDOR)));
 	deviceSpecs->Add(new InfoItem("Model", (char *)glGetString(GL_RENDERER)));
 	deviceSpecs->Add(new ItemHeader("OpenGL Version Information"));
-	deviceSpecs->Add(new InfoItem("OpenGL", (char *)glGetString(GL_VERSION)));
+	std::string openGL = (char *)glGetString(GL_VERSION);
+	openGL.resize(30);
+	deviceSpecs->Add(new InfoItem("OpenGL", openGL));
 	deviceSpecs->Add(new InfoItem("GLSL", (char *)glGetString(GL_SHADING_LANGUAGE_VERSION)));
 	
 	ViewGroup *oglExtensionsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -353,9 +353,10 @@ void GameSettingsScreen::update(InputState &input) {
 }
 
 void GameSettingsScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
+	// Always call the base class method first, to handle common messages, then
+	// handle other specific messages after.
+	UIDialogScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "control mapping")) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new ControlMappingScreen());
@@ -500,12 +501,6 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new Choice(de->T("Load language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoadLanguageIni);
 	list->Add(new Choice(de->T("Save language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSaveLanguageIni);
 	list->Add(new Choice(d->T("Back")))->OnClick.Handle(this, &DeveloperToolsScreen::OnBack);
-}
-
-void DeveloperToolsScreen::sendMessage(const char *message, const char *value){
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
 }
 
 UI::EventReturn DeveloperToolsScreen::OnBack(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -93,7 +93,6 @@ public:
 
 protected:
 	virtual void CreateViews();
-	virtual void sendMessage(const char *message, const char *value);
 
 private:
 	UI::EventReturn OnBack(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -586,11 +586,12 @@ void MainScreen::CreateViews() {
 }
 
 void MainScreen::sendMessage(const char *message, const char *value) {
+	// Always call the base class method first, to handle common messages, then
+	// handle other specific messages after.
+	UIScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "boot")) {
 		screenManager()->switchScreen(new EmuScreen(value));
-	}
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
 	}
 	if (!strcmp(message, "control mapping")) {
 		UpdateUIState(UISTATE_MENU);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -30,6 +30,8 @@
 #include "UI/MiscScreens.h"
 #include "UI/EmuScreen.h"
 #include "UI/MainScreen.h"
+#include "UI/GameSettingsScreen.h"
+#include "UI/ControlMappingScreen.h"
 #include "Core/Config.h"
 #include "Core/System.h"
 #include "Core/HLE/sceUtility.h"
@@ -99,9 +101,21 @@ void UIScreenWithBackground::DrawBackground(UIContext &dc) {
 	dc.Flush();
 }
 
+void UIScreenWithBackground::sendMessage(const char *message, const char *value) {
+	if (!strcmp(message, "language")) {
+		screenManager()->RecreateAllViews();
+	}
+}
+
 void UIDialogScreenWithBackground::DrawBackground(UIContext &dc) {
 	::DrawBackground(1.0f);
 	dc.Flush();
+}
+
+void UIDialogScreenWithBackground::sendMessage(const char *message, const char *value) {
+	if (!strcmp(message, "language")) {
+		screenManager()->RecreateAllViews();
+	}
 }
 
 PromptScreen::PromptScreen(std::string message, std::string yesButtonText, std::string noButtonText, std::function<void(bool)> callback)

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -33,6 +33,7 @@ public:
 	UIScreenWithBackground() : UIScreen() {}
 protected:
 	virtual void DrawBackground(UIContext &dc);
+	virtual void sendMessage(const char *message, const char *value);
 };
 
 class UIDialogScreenWithBackground : public UIDialogScreen {
@@ -40,6 +41,7 @@ public:
 	UIDialogScreenWithBackground() : UIDialogScreen() {}
 protected:
 	virtual void DrawBackground(UIContext &dc);
+	virtual void sendMessage(const char *message, const char *value);
 };
 
 class PromptScreen : public UIDialogScreenWithBackground {

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -101,6 +101,8 @@ UI::EventReturn TouchControlVisibilityScreen::OnToggleAll(UI::EventParams &e) {
 	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i) {
 		*i->second = toggleSwitch;
 	}
+
 	toggleSwitch = !toggleSwitch;
+
 	return UI::EVENT_DONE;
 }

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -26,7 +26,6 @@ public:
 	TouchControlVisibilityScreen() { }
 
 	virtual void CreateViews();
-	bool toggleSwitch;
 
 protected:
 	virtual UI::EventReturn OnBack(UI::EventParams &e);
@@ -34,4 +33,5 @@ protected:
 
 private:
 	std::map<std::string, bool*> keyToggles;
+	bool toggleSwitch;
 };


### PR DESCRIPTION
I don't see much of a point in making it respond to More Settings or Control Mapping(because if the user presses Back, they'll be in the middle of control settings + all the other options), so I won't bother.
