### PR TITLE
Move the language message into the base classes "UIScreenWithBackground" and "UIDialogScreenWithBackground".

### DIFF
--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -214,9 +214,9 @@ void ControlMappingScreen::CreateViews() {
 }
 
 void ControlMappingScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
+	// Always call the base class method first to handle the most common messages.
+	UIDialogScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "settings")) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new GameSettingsScreen(""));

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -92,12 +92,6 @@ void CwCheatScreen::CreateViews() {
 	}
 }
 
-void CwCheatScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
-}
-
 UI::EventReturn CwCheatScreen::OnBack(UI::EventParams &params)
 {
 	screenManager()->finishDialog(this, DR_OK);

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -42,7 +42,6 @@ public:
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
 protected:
 	virtual void CreateViews();
-	virtual void sendMessage(const char *message, const char *value);
 
 private:
 	UI::EventReturn OnCheckBox(UI::EventParams &params);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -353,9 +353,9 @@ void GameSettingsScreen::update(InputState &input) {
 }
 
 void GameSettingsScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
+	// Always call the base class method first to handle the most common messages.
+	UIDialogScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "control mapping")) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new ControlMappingScreen());
@@ -500,12 +500,6 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new Choice(de->T("Load language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoadLanguageIni);
 	list->Add(new Choice(de->T("Save language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSaveLanguageIni);
 	list->Add(new Choice(d->T("Back")))->OnClick.Handle(this, &DeveloperToolsScreen::OnBack);
-}
-
-void DeveloperToolsScreen::sendMessage(const char *message, const char *value){
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
 }
 
 UI::EventReturn DeveloperToolsScreen::OnBack(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -93,7 +93,6 @@ public:
 
 protected:
 	virtual void CreateViews();
-	virtual void sendMessage(const char *message, const char *value);
 
 private:
 	UI::EventReturn OnBack(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -586,11 +586,11 @@ void MainScreen::CreateViews() {
 }
 
 void MainScreen::sendMessage(const char *message, const char *value) {
+	// Always call the base class method first to handle the most common messages.
+	UIScreenWithBackground::sendMessage(message, value);
+
 	if (!strcmp(message, "boot")) {
 		screenManager()->switchScreen(new EmuScreen(value));
-	}
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
 	}
 	if (!strcmp(message, "control mapping")) {
 		UpdateUIState(UISTATE_MENU);
@@ -845,6 +845,8 @@ UI::EventReturn GamePauseScreen::OnCwCheat(UI::EventParams &e) {
 }
 
 void GamePauseScreen::sendMessage(const char *message, const char *value) {
+	// Since the language message isn't allowed to be in native, we have to have add this
+	// to every screen which directly inherits from UIScreen(which are few right now, luckily).
 	if (!strcmp(message, "language")) {
 		screenManager()->RecreateAllViews();
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -94,14 +94,28 @@ void DrawBackground(float alpha) {
 	}
 }
 
+void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager) {
+	if (!strcmp(message, "language")) {
+		manager->RecreateAllViews();
+	}
+}
+
 void UIScreenWithBackground::DrawBackground(UIContext &dc) {
 	::DrawBackground(1.0f);
 	dc.Flush();
 }
 
+void UIScreenWithBackground::sendMessage(const char *message, const char *value) {
+	HandleCommonMessages(message, value, screenManager());
+}
+
 void UIDialogScreenWithBackground::DrawBackground(UIContext &dc) {
 	::DrawBackground(1.0f);
 	dc.Flush();
+}
+
+void UIDialogScreenWithBackground::sendMessage(const char *message, const char *value) {
+	HandleCommonMessages(message, value, screenManager());
 }
 
 PromptScreen::PromptScreen(std::string message, std::string yesButtonText, std::string noButtonText, std::function<void(bool)> callback)

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -33,6 +33,7 @@ public:
 	UIScreenWithBackground() : UIScreen() {}
 protected:
 	virtual void DrawBackground(UIContext &dc);
+	virtual void sendMessage(const char *message, const char *value);
 };
 
 class UIDialogScreenWithBackground : public UIDialogScreen {
@@ -40,6 +41,7 @@ public:
 	UIDialogScreenWithBackground() : UIDialogScreen() {}
 protected:
 	virtual void DrawBackground(UIContext &dc);
+	virtual void sendMessage(const char *message, const char *value);
 };
 
 class PromptScreen : public UIDialogScreenWithBackground {

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -101,6 +101,8 @@ UI::EventReturn TouchControlVisibilityScreen::OnToggleAll(UI::EventParams &e) {
 	for (auto i = keyToggles.begin(); i != keyToggles.end(); ++i) {
 		*i->second = toggleSwitch;
 	}
+
 	toggleSwitch = !toggleSwitch;
+
 	return UI::EVENT_DONE;
 }

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -26,7 +26,6 @@ public:
 	TouchControlVisibilityScreen() { }
 
 	virtual void CreateViews();
-	bool toggleSwitch;
 
 protected:
 	virtual UI::EventReturn OnBack(UI::EventParams &e);
@@ -34,4 +33,5 @@ protected:
 
 private:
 	std::map<std::string, bool*> keyToggles;
+	bool toggleSwitch;
 };


### PR DESCRIPTION
This will make it so all screens that don't override their base class sendMessage function will automatically switch languages when a different language is chosen, and those that do can just make a call to their base class sendMessage function to get the language event to be supported.
