### PR TITLE
Use correct count in save data focus compares. Also fix the random data that caused the issue. Also fix time compares.

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1294,14 +1294,14 @@ int SavedataParam::GetFirstListSave()
 
 int SavedataParam::GetLastListSave()
 {
-	return saveDataListCount - 1;
+	return saveNameListDataCount - 1;
 }
 
 int SavedataParam::GetLatestSave()
 {
 	int idx = 0;
 	time_t idxTime = 0;
-	for (int i = 0; i < saveDataListCount; ++i)
+	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
 		time_t thisTime = mktime(&saveDataList[i].modif_time);
 		if (idxTime < thisTime)
@@ -1317,7 +1317,7 @@ int SavedataParam::GetOldestSave()
 {
 	int idx = 0;
 	time_t idxTime = 0;
-	for (int i = 0; i < saveDataListCount; ++i)
+	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
 		time_t thisTime = mktime(&saveDataList[i].modif_time);
 		if (idxTime > thisTime)
@@ -1332,7 +1332,7 @@ int SavedataParam::GetOldestSave()
 int SavedataParam::GetFirstDataSave()
 {
 	int idx = 0;
-	for (int i = 0; i < saveDataListCount; ++i)
+	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
 		if (saveDataList[i].size != 0)
 		{
@@ -1346,7 +1346,7 @@ int SavedataParam::GetFirstDataSave()
 int SavedataParam::GetLastDataSave()
 {
 	int idx = 0;
-	for (int i = saveDataListCount; i > 0; )
+	for (int i = saveNameListDataCount; i > 0; )
 	{
 		--i;
 		if (saveDataList[i].size != 0)
@@ -1361,7 +1361,7 @@ int SavedataParam::GetLastDataSave()
 int SavedataParam::GetFirstEmptySave()
 {
 	int idx = 0;
-	for (int i = 0; i < saveDataListCount; ++i)
+	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
 		if (saveDataList[i].size == 0)
 		{
@@ -1375,7 +1375,7 @@ int SavedataParam::GetFirstEmptySave()
 int SavedataParam::GetLastEmptySave()
 {
 	int idx = 0;
-	for (int i = saveDataListCount; i > 0; )
+	for (int i = saveNameListDataCount; i > 0; )
 	{
 		--i;
 		if (saveDataList[i].size == 0)

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1303,8 +1303,10 @@ int SavedataParam::GetLatestSave()
 	time_t idxTime = 0;
 	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
+		if (saveDataList[i].size == 0)
+			continue;
 		time_t thisTime = mktime(&saveDataList[i].modif_time);
-		if (idxTime < thisTime)
+		if ((s64)idxTime < (s64)thisTime)
 		{
 			idx = i;
 			idxTime = thisTime;
@@ -1319,8 +1321,10 @@ int SavedataParam::GetOldestSave()
 	time_t idxTime = 0;
 	for (int i = 0; i < saveNameListDataCount; ++i)
 	{
+		if (saveDataList[i].size == 0)
+			continue;
 		time_t thisTime = mktime(&saveDataList[i].modif_time);
-		if (idxTime > thisTime)
+		if ((s64)idxTime > (s64)thisTime)
 		{
 			idx = i;
 			idxTime = thisTime;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -254,6 +254,15 @@ struct SaveFileInfo
 	int textureWidth;
 	int textureHeight;
 
+	SaveFileInfo() : size(0), saveName(""), idx(0),
+	                 textureData(0), textureWidth(0), textureHeight(0)
+	{
+		memset(title, 0, 128);
+		memset(saveTitle, 0, 128);
+		memset(saveDetail, 0, 1024);
+		modif_time = {0};
+	}
+
 	void DoState(PointerWrap &p)
 	{
 		auto s = p.Section("SaveFileInfo", 1);


### PR DESCRIPTION
Currently save compares use a constant value of 100 to compare through even if there is only 1 actual save game.
The second problem is that the data for the other 99 slots is uninitialised, giving it random data. In the focus compares, this data can appear 'newer', even if it doesn't exist.
When I try to load an old game, I will often (when save dirs are populated) have the issue where it shows me the 'latest' game save which is actually a non-existent save.
saveDataListCount = 100
saveNameListDataCount = 1

Another unrelated issue I discovered was that on QNX, time_t is unsigned and a mktime(0) gives 4294967295 which should be cast so it appears as -1. Some platforms use 64-bit time as well, so I cast this with (s64).
