### PR TITLE
Speed up FPURegCache::Start() on x86

### DIFF
--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -155,10 +155,15 @@ public:
 	X64Reg GetFreeXReg();
 private:
 	const int *GetAllocationOrder(int &count);
+	void SetupInitialRegs();
 
 	MIPSCachedFPReg regs[NUM_MIPS_FPRS];
 	X64CachedFPReg xregs[NUM_X_FPREGS];
 	MIPSCachedFPReg *vregs;
+
+	bool initialReady;
+	MIPSCachedFPReg regsInitial[NUM_MIPS_FPRS];
+	X64CachedFPReg xregsInitial[NUM_X_FPREGS];
 
 	// TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
 	static u32 tempValues[NUM_TEMPS];


### PR DESCRIPTION
This cuts that func by 97% when running the automated tests, and it was 8% of the total time.  Won't really affect games.

Small, but it was the top thing on the profile so I wanted it gone.

-[Unknown]
