### PR TITLE
Fix mp3 savestates and savestate backwards compat

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -58,6 +58,7 @@
 #include "sceKernelEventFlag.h"
 #include "sceKernelVTimer.h"
 #include "sceKernelTime.h"
+#include "sceMp3.h"
 #include "sceMpeg.h"
 #include "sceNet.h"
 #include "sceNetAdhoc.h"
@@ -157,6 +158,7 @@ void __KernelShutdown()
 	__NetAdhocShutdown();
 	__FontShutdown();
 
+	__Mp3Shutdown();
 	__MpegShutdown();
 	__PsmfShutdown();
 	__PPGeShutdown();
@@ -231,6 +233,7 @@ void __KernelDoState(PointerWrap &p)
 		__ImposeDoState(p);
 		__IoDoState(p);
 		__JpegDoState(p);
+		__Mp3DoState(p);
 		__MpegDoState(p);
 		__NetDoState(p);
 		__NetAdhocDoState(p);

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -99,14 +99,8 @@ struct Mp3Context {
 };
 
 static std::map<u32, Mp3Context *> mp3Map;
-static u32 lastMp3Handle = 0;
 
 Mp3Context *getMp3Ctx(u32 mp3) {
-	if (mp3Map.find(mp3) == mp3Map.end()) {
-		ERROR_LOG(ME, "Bad mp3 handle %08x - using last one (%08x) instead", mp3, lastMp3Handle);
-		mp3 = lastMp3Handle;
-	}
-
 	if (mp3Map.find(mp3) == mp3Map.end())
 		return NULL;
 	return mp3Map[mp3];

--- a/Core/HLE/sceMp3.h
+++ b/Core/HLE/sceMp3.h
@@ -19,4 +19,9 @@
 
 #include "HLE.h"
 
+class PointerWrap;
+
 void Register_sceMp3();
+
+void __Mp3Shutdown();
+void __Mp3DoState(PointerWrap &p);


### PR DESCRIPTION
sceMp3 wasn't being saved before, which definitely could've caused issues.  It also was not cleaned up on shutdown.

It resumes playing on load properly now.

-[Unknown]
