### PR TITLE
Fix u_uvscaleoffset shader compilation error

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1436,9 +1436,12 @@ void GLES_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_UNKNOWN_FC:
 	case GE_CMD_UNKNOWN_FD:
 	case GE_CMD_UNKNOWN_FE:
-	case GE_CMD_UNKNOWN_FF:
 		if (data != 0)
 			WARN_LOG_REPORT_ONCE(unknowncmd, G3D, "Unknown GE command : %08x ", op);
+		break;
+	case GE_CMD_UNKNOWN_FF:
+		// This is hit in quite a few games, supposedly it is a no-op.
+		// Might be used for debugging or something?
 		break;
 		
 	default:

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -223,7 +223,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			}
 #endif
 		}
-		if (doTexture && (!prescale || gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP)) {
+		if (doTexture && (!prescale || gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP || gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX)) {
 			WRITE(p, "uniform vec4 u_uvscaleoffset;\n");
 		}
 		for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
Seems to be happening in Ridge Racer 2, Crisis Core, and possibly other games according to reporting.  I don't actually know how to reproduce, but I see it used in the GE_TEXMAP_TEXTURE_MATRIX case.

-[Unknown]
