### PR TITLE
Hack: Toggle vertex hashing (massive speedup)

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -177,8 +177,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	graphics->Get("TexScalingType", &iTexScalingType, 0);
 	graphics->Get("TexDeposterize", &bTexDeposterize, false);
 	graphics->Get("VSyncInterval", &bVSync, false);
-	graphics->Get("DisableStencilTest", &bDisableStencilTest, false);
-	graphics->Get("AlwaysDepthWrite", &bAlwaysDepthWrite, false);
 	graphics->Get("LowQualitySplineBezier", &bLowQualitySplineBezier, false);
 	graphics->Get("PostShader", &sPostShaderName, "Off");
 
@@ -278,6 +276,9 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	IniFile::Section *speedhacks = iniFile.GetOrCreateSection("SpeedHacks");
 	speedhacks->Get("PrescaleUV", &bPrescaleUV, false);
 	speedhacks->Get("DisableAlphaTest", &bDisableAlphaTest, false);
+	speedhacks->Get("DisableStencilTest", &bDisableStencilTest, false);
+	speedhacks->Get("AlwaysDepthWrite", &bAlwaysDepthWrite, false);
+	speedhacks->Get("DisableVertexHashing", &bDisableVertexHashing, false);
 
 	INFO_LOG(LOADER, "Loading controller config: %s", controllerIniFilename_.c_str());
 	bSaveSettings = true;
@@ -379,8 +380,6 @@ void Config::Save() {
 		graphics->Set("TexScalingType", iTexScalingType);
 		graphics->Set("TexDeposterize", bTexDeposterize);
 		graphics->Set("VSyncInterval", bVSync);
-		graphics->Set("DisableStencilTest", bDisableStencilTest);
-		graphics->Set("AlwaysDepthWrite", bAlwaysDepthWrite);
 		graphics->Set("LowQualitySplineBezier", bLowQualitySplineBezier);
 		graphics->Set("PostShader", sPostShaderName);
 
@@ -468,6 +467,9 @@ void Config::Save() {
 		IniFile::Section *speedhacks = iniFile.GetOrCreateSection("SpeedHacks");
 		speedhacks->Set("PrescaleUV", bPrescaleUV);
 		speedhacks->Set("DisableAlphaTest", bDisableAlphaTest);
+		speedhacks->Set("DisableStencilTest", bDisableStencilTest);
+		speedhacks->Set("AlwaysDepthWrite", bAlwaysDepthWrite);
+		speedhacks->Set("DisableVertexTexHashing", bDisableVertexHashing);
 
 		if (!iniFile.Save(iniFilename_.c_str())) {
 			ERROR_LOG(LOADER, "Error saving config - can't write ini %s", iniFilename_.c_str());

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -95,6 +95,7 @@ public:
 	bool bDisableStencilTest;
 	bool bAlwaysDepthWrite;
 	bool bLowQualitySplineBezier;
+	bool bDisableVertexHashing;
 	std::string sPostShaderName;  // Off for off.
 
 	// Sound

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -1175,7 +1175,8 @@ void TransformDrawEngine::DoFlush() {
 						vai->numFrames++;
 					}
 					if (vai->drawsUntilNextFullHash == 0) {
-						u32 newHash = ComputeHash();
+						// When DisableVertexHashing is true , set newHash = vai->hash 
+						u32 newHash = g_Config.bDisableVertexHashing ? vai->hash : ComputeHash();
 						if (newHash != vai->hash) {
 							vai->status = VertexArrayInfo::VAI_UNRELIABLE;
 							if (vai->vbo) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -160,6 +160,7 @@ void GameSettingsScreen::CreateViews() {
 	// Maybe hide this on non-PVR?
 	graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
 	graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gs->T("Disable Stencil Test")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bDisableVertexHashing, gs->T("Disable Vertex Hashing")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
 	CheckBox *prescale = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Speedhack")));
 	if (PSP_IsInited())


### PR DESCRIPTION
Attempt to disable vertex hasing to provide massive speedup for those games which use sparse indexes intersively.
For example , Gundam VS Gundam Next Plus 

This should benefit mobile massively.

Before
![screen00015](https://f.cloud.github.com/assets/3000282/1408407/a96d813c-3d81-11e3-97c3-40f104ae33d4.jpg)

After
![screen00016](https://f.cloud.github.com/assets/3000282/1408409/abeace92-3d81-11e3-999d-3f8c398b1e6f.jpg)
