### PR TITLE
Apply offset by 1px for our provided fonts

### DIFF
--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -453,7 +453,7 @@ bool PGF::GetCharGlyph(int charCode, int glyphType, Glyph &glyph) {
 	return true;
 }
 
-void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType) {
+void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType, bool original) {
 	Glyph glyph;
 	if (!GetCharGlyph(charCode, glyphType, glyph)) {
 		// No Glyph available for this charCode, try to use the alternate char.
@@ -511,6 +511,11 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 
 			int pixelX = x + xx;
 			int pixelY = y + yy;
+
+			// Apply offset by 1px for non-original PSP fonts
+			if (!original) 
+				pixelX += 1;
+
 			if (pixelX >= clipX && pixelX < clipX + clipWidth && pixelY >= clipY && pixelY < clipY + clipHeight) {
 				// 4-bit color value
 				int pixelColor = value;

--- a/Core/Font/PGF.h
+++ b/Core/Font/PGF.h
@@ -262,7 +262,7 @@ public:
 
 	bool GetCharInfo(int charCode, PGFCharInfo *ci);
 	void GetFontInfo(PGFFontInfo *fi);
-	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType);
+	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType, bool original = true);
 
 	void DoState(PointerWrap &p);
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -104,6 +104,7 @@ class LoadedFont;
 class FontLib;
 class Font;
 int GetInternalFontIndex(Font *font);
+bool original;
 
 // These should not need to be state saved.
 static std::vector<Font *> internalFonts;
@@ -503,7 +504,12 @@ void __LoadInternalFonts() {
 				ERROR_LOG(SCEFONT, "Failed opening font");
 				delete [] buffer;
 				continue;
+			} 
+			// Our provided font of jpn0.pgf has size 4367080 bytes 
+			if (entry.fileName == "jpn0.pgf" && (int)info.size == 4367080) {
+				original = false;
 			}
+
 			pspFileSystem.ReadFile(handle, buffer, info.size);
 			pspFileSystem.CloseFile(handle);
 			
@@ -867,7 +873,7 @@ int sceFontGetCharGlyphImage(u32 fontHandle, u32 charCode, u32 glyphImagePtr) {
 	DEBUG_LOG(SCEFONT, "sceFontGetCharGlyphImage(%x, %x, %x)", fontHandle, charCode, glyphImagePtr);
 	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
-	font->GetPGF()->DrawCharacter(glyph, 0, 0, 8192, 8192, charCode, altCharCode, FONT_PGF_CHARGLYPH);
+	font->GetPGF()->DrawCharacter(glyph, 0, 0, 8192, 8192, charCode, altCharCode, FONT_PGF_CHARGLYPH, original);
 	return 0;
 }
 
@@ -885,7 +891,7 @@ int sceFontGetCharGlyphImage_Clip(u32 fontHandle, u32 charCode, u32 glyphImagePt
 	INFO_LOG(SCEFONT, "sceFontGetCharGlyphImage_Clip(%08x, %i, %08x, %i, %i, %i, %i)", fontHandle, charCode, glyphImagePtr, clipXPos, clipYPos, clipWidth, clipHeight);
 	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
-	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipXPos + clipWidth, clipYPos + clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH);
+	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipXPos + clipWidth, clipYPos + clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH, original);
 	return 0;
 }
 


### PR DESCRIPTION
Trying to detect original PSP fonts here (only jpn0.pgf ) and apply offset by 1px for non original one which is the one we provided in our package

Partially fix #2675
