### PR TITLE
Fix some video -> framebuffer issues

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1395,11 +1395,11 @@ void FramebufferManager::DestroyAllFBOs() {
 	vfbs_.clear();
 }
 
-void FramebufferManager::UpdateFromMemory(u32 addr, int size) {
+void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 	addr &= ~0x40000000;
 	// TODO: Could go through all FBOs, but probably not important?
 	// TODO: Could also check for inner changes, but video is most important.
-	if (addr == DisplayFramebufAddr() || addr == PrevDisplayFramebufAddr()) {
+	if (addr == DisplayFramebufAddr() || addr == PrevDisplayFramebufAddr() || safe) {
 		// TODO: Deleting the FBO is a heavy hammer solution, so let's only do it if it'd help.
 		if (!Memory::IsValidAddress(displayFramebufPtr_))
 			return;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1416,6 +1416,8 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size) {
 				// TODO: This without the fbo_unbind() above would be better than destroying the FBO.
 				// However, it doesn't seem to work for Star Ocean, at least
 				if (useBufferedRendering_ && vfb->fbo) {
+					DisableState();
+					glstate.viewport.set(0, 0, vfb->renderWidth, vfb->renderHeight);
 					fbo_bind_as_render_target(vfb->fbo);
 					needUnbind = true;
 					DrawPixels(Memory::GetPointer(addr | 0x04000000), vfb->format, vfb->fb_stride);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -128,7 +128,7 @@ public:
 	void DeviceLost();
 	void CopyDisplayToOutput();
 	void SetRenderFrameBuffer();  // Uses parameters computed from gstate
-	void UpdateFromMemory(u32 addr, int size);
+	void UpdateFromMemory(u32 addr, int size, bool safe);
 	void SetLineWidth();
 
 #ifdef USING_GLES2

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1536,7 +1536,7 @@ void GLES_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType t
 		textureCache_.InvalidateAll(type);
 
 	if (type != GPU_INVALIDATE_ALL)
-		framebufferManager_.UpdateFromMemory(addr, size);
+		framebufferManager_.UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
 }
 
 void GLES_GPU::UpdateMemory(u32 dest, u32 src, int size) {


### PR DESCRIPTION
This kills some of the flicker and size problems with videos, and even a missing video (#3771, #4273.)

It's still not perfect.  As noted in https://github.com/hrydgard/ppsspp/pull/4270#issuecomment-27074266, some games don't use the fbo for both video frames.  The result is that some filtering is slightly different, so you see very slight artifacts.  The effect of this reduces at higher rendering resolutions (or did for me anyway.)

Anyway, this is a lot better already.  That said, I could use testing on more games (@solarmystic, wanna test a few?)

-[Unknown]
