### PR TITLE
Make sure frag shader ID matches generated code

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -176,10 +176,10 @@ void ComputeFragmentShaderID(FragmentShaderID *id) {
 		}
 
 		id->d[0] |= (lmode & 1) << 7;
-		id->d[0] |= gstate.isAlphaTestEnabled() << 8;
+		id->d[0] |= enableAlphaTest << 8;
 		if (enableAlphaTest)
 			id->d[0] |= gstate.getAlphaTestFunction() << 9;
-		id->d[0] |= gstate.isColorTestEnabled() << 12;
+		id->d[0] |= enableColorTest << 12;
 		if (enableColorTest)
 			id->d[0] |= gstate.getColorTestFunction() << 13;	 // color test func
 		id->d[0] |= (enableFog & 1) << 15;


### PR DESCRIPTION
If `IsAlphaTestTriviallyTrue()` returned true, we would compute an id with the alpha test flag on, since gstate.isAlphaTestEnabled() is true.  Then we would generate a shader that skips alpha testing.

If later, `IsAlphaTestTriviallyTrue()` was false, we would still use this shader - and not get alpha testing at all.

The reverse was also true; we might use a shader with alpha testing even when we detected that we don't need to apply the test.

I found this in Tales of Phantasia X, since it switches between shaders a ton, I wondered if any of the shaders had the same code, which they did - these.  It looks like color testing is affected too.

This could break games that this was "accidentally working" for, it could also improve performance by correctly skipping testing when we can.  I haven't tested it a ton, since it seems obviously correct, but at least games are still generally applying alpha testing correctly.

-[Unknown]
