### PR TITLE
Respect the bgm vol setting for at3, mp3, video

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -24,6 +24,8 @@
 
 extern const char *PPSSPP_GIT_VERSION;
 
+const int MAX_CONFIG_VOLUME = 8;
+
 struct Config {
 public:
 	Config();

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -69,8 +69,6 @@ const u32 ATRAC3PLUS_MAX_SAMPLES = 0x800;
 
 static const int atracDecodeDelay = 2300;
 
-static const int MAX_CONFIG_VOLUME = 8;
-
 #ifdef USE_FFMPEG
 
 extern "C" {
@@ -626,6 +624,7 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 							if (avret < 0) {
 								ERROR_LOG(ME, "swr_convert: Error while converting %d", avret);
 							}
+							__AdjustBGMVolume((s16 *)out, numSamples * atrac->pFrame->channels);
 						}
 					}
 					av_free_packet(&packet);
@@ -1693,6 +1692,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 					if (avret < 0) {
 						ERROR_LOG(ME, "swr_convert: Error while converting %d", avret);
 					}
+					__AdjustBGMVolume((s16 *)out, numSamples * atrac->pFrame->channels);
 				}
 				av_free_packet(&packet);
 				if (got_frame)

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <algorithm>
 
+#include "Core/Config.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/sceMp3.h"
 #include "Core/HW/MediaEngine.h"
@@ -211,6 +212,7 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 					ERROR_LOG(ME, "swr_convert: Error while converting %d", ret);
 					return -1;
 				}
+				__AdjustBGMVolume((s16 *)out, frame.nb_samples * frame.channels);
 
 				//av_samples_copy(&audio_dst_data, frame.data, 0, 0, frame.nb_samples, frame.channels, (AVSampleFormat)frame.format);
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "Core/Config.h"
 #include "Core/HW/MediaEngine.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
@@ -111,6 +112,17 @@ bool InitFFmpeg() {
 	av_log_set_callback(&ffmpeg_logger);
 
 	return true;
+}
+
+void __AdjustBGMVolume(s16 *samples, u32 count) {
+	if (g_Config.iBGMVolume < 0 || g_Config.iBGMVolume >= MAX_CONFIG_VOLUME) {
+		return;
+	}
+
+	int volumeShift = MAX_CONFIG_VOLUME - g_Config.iBGMVolume;
+	for (u32 i = 0; i < count; ++i) {
+		samples[i] >>= volumeShift;
+	}
 }
 
 MediaEngine::MediaEngine(): m_pdata(0) {

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -45,6 +45,8 @@ inline s64 getMpegTimeStamp(u8* buf) {
 
 bool InitFFmpeg();
 
+void __AdjustBGMVolume(s16 *samples, u32 count);
+
 class MediaEngine
 {
 public:

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -424,8 +424,8 @@ void SasInstance::MixVoice(SasVoice &voice) {
 		// TODO: Special case no-resample case (and 2x and 0.5x) for speed, it's not uncommon
 
 		u32 sampleFrac = voice.sampleFrac;
-		const int MAX_CONFIG_VOLUME = 20;
-		int volumeShift = (MAX_CONFIG_VOLUME - g_Config.iSFXVolume);
+		// We need to shift by 12 anyway, so combine that with the volume shift.
+		int volumeShift = (12 + MAX_CONFIG_VOLUME - g_Config.iSFXVolume);
 		if (volumeShift < 0) volumeShift = 0;
 		for (int i = 0; i < grainSize; i++) {
 			// For now: nearest neighbour, not even using the resample history at all.

--- a/Core/HW/SimpleAT3Dec.cpp
+++ b/Core/HW/SimpleAT3Dec.cpp
@@ -142,6 +142,7 @@ bool SimpleAT3::Decode(void* inbuf, int inbytes, uint8_t *outbuf, int *outbytes)
 			ERROR_LOG(ME, "swr_convert: Error while converting %d", swrRet);
 			return false;
 		}
+		__AdjustBGMVolume((s16 *)outbuf, numSamples * frame_->channels);
 	}
 
 	return true;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -193,8 +193,8 @@ void GameSettingsScreen::CreateViews() {
 
 	audioSettings->Add(new ItemHeader(ms->T("Audio")));
 
-	audioSettings->Add(new PopupSliderChoice(&g_Config.iSFXVolume, 0, 8, a->T("SFX volume"), screenManager()));
-	audioSettings->Add(new PopupSliderChoice(&g_Config.iBGMVolume, 0, 8, a->T("BGM volume"), screenManager()));
+	audioSettings->Add(new PopupSliderChoice(&g_Config.iSFXVolume, 0, MAX_CONFIG_VOLUME, a->T("SFX volume"), screenManager()));
+	audioSettings->Add(new PopupSliderChoice(&g_Config.iBGMVolume, 0, MAX_CONFIG_VOLUME, a->T("BGM volume"), screenManager()));
 
 	audioSettings->Add(new CheckBox(&g_Config.bEnableSound, a->T("Enable Sound")));
 	audioSettings->Add(new CheckBox(&g_Config.bLowLatencyAudio, a->T("Low latency audio")));


### PR DESCRIPTION
Volume was basically ignored after f311901e5eb4af957d6c6b3e8962aa0bdad8e7ea, so that setting no longer did anything.

This applies it to mp3, atrac3/+, and video.  Of course, music through sas (FF Tactics), won't have this setting, and I think at3+ sound effects through sas will have both volumes applied.  But that was the case before anyway, I think?

And obviously, music/sound effects manually decoded (LittleBigPlanet) won't have either setting applied.

-[Unknown]
