### PR TITLE
full tilt based analog controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1139,6 +1139,7 @@ set(NativeAppSource
 	UI/MiscScreens.cpp
 	UI/GameScreen.cpp
 	UI/GameSettingsScreen.cpp
+	UI/TiltAnalogSettingsScreen.cpp
 	UI/TouchControlLayoutScreen.cpp
 	UI/TouchControlVisibilityScreen.cpp
 	UI/GamepadEmu.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -219,7 +219,14 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	// control->Get("KeyMapping",iMappingMap);
 #ifdef USING_GLES2
 	control->Get("AccelerometerToAnalogHoriz", &bAccelerometerToAnalogHoriz, false);
-	control->Get("TiltSensitivity", &iTiltSensitivity, 100);
+	
+	control->Get("TiltBaseX", &fTiltBaseX, 0);
+	control->Get("TiltBaseY", &fTiltBaseY, 0);
+	control->Get("InvertTiltX", &bInvertTiltX, false);
+	control->Get("InvertTiltY", &bInvertTiltY, true);
+	control->Get("TiltSensitivityX", &iTiltSensitivityX, 100);
+	control->Get("TiltSensitivityY", &iTiltSensitivityY, 100);
+
 #endif
 	control->Get("TouchButtonOpacity", &iTouchButtonOpacity, 65);
 	control->Get("ButtonScale", &fButtonScale, 1.15);
@@ -411,7 +418,12 @@ void Config::Save() {
 		// control->Set("KeyMapping",iMappingMap);
 #ifdef USING_GLES2
 		control->Set("AccelerometerToAnalogHoriz", bAccelerometerToAnalogHoriz);
-		control->Set("TiltSensitivity", iTiltSensitivity);
+		control->Set("TiltBaseX", fTiltBaseX);
+		control->Set("TiltBaseY", fTiltBaseY);
+		control->Set("InvertTiltX", bInvertTiltX);
+		control->Set("InvertTiltY", bInvertTiltY);
+		control->Set("TiltSensitivityX", iTiltSensitivityX);
+		control->Set("TiltSensitivityY", iTiltSensitivityY);
 #endif
 		control->Set("TouchButtonOpacity", iTouchButtonOpacity);
 		control->Set("ButtonScale", fButtonScale);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -226,6 +226,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	control->Get("InvertTiltY", &bInvertTiltY, true);
 	control->Get("TiltSensitivityX", &iTiltSensitivityX, 100);
 	control->Get("TiltSensitivityY", &iTiltSensitivityY, 100);
+	control->Get("DeadzoneRadius", &fDeadzoneRadius, 0.35);
 
 #endif
 	control->Get("TouchButtonOpacity", &iTouchButtonOpacity, 65);
@@ -424,6 +425,7 @@ void Config::Save() {
 		control->Set("InvertTiltY", bInvertTiltY);
 		control->Set("TiltSensitivityX", iTiltSensitivityX);
 		control->Set("TiltSensitivityY", iTiltSensitivityY);
+		control->Set("DeadzoneRadius", fDeadzoneRadius);
 #endif
 		control->Set("TouchButtonOpacity", iTouchButtonOpacity);
 		control->Set("ButtonScale", fButtonScale);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -119,6 +119,8 @@ public:
 	int iTiltSensitivityX;
 	//the sensitivity of the tilt in the Y direction
 	int iTiltSensitivityY;
+	//the deadzone radius of the tilt
+	float fDeadzoneRadius;
 
 	// The three tabs.
 	bool bGridView1;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -108,7 +108,17 @@ public:
 	int iShowFPSCounter;
 	bool bShowDebugStats;
 	bool bAccelerometerToAnalogHoriz;
-	int iTiltSensitivity;
+
+	//Analog stick tilting
+	//the base x and y tilt. this inclination is treated as (0,0) and the tilt input
+	//considers this orientation to be equal to no movement of the analog stick.
+	float fTiltBaseX, fTiltBaseY;
+	//whether the x axes and y axes should invert directions (left becomes right, top becomes bottom.)
+	bool bInvertTiltX, bInvertTiltY; 
+	//the sensitivity of the tilt in the x direction
+	int iTiltSensitivityX;
+	//the sensitivity of the tilt in the Y direction
+	int iTiltSensitivityY;
 
 	// The three tabs.
 	bool bGridView1;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -192,7 +192,7 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 //curve1 implements a smooth deadzone as described here:
 //http://www.gamasutra.com/blogs/JoshSutphin/20130416/190541/Doing_Thumbstick_Dead_Zones_Right.php
 inline float curve1(float x) {
-    const float deadzone = 0.03f;
+    const float deadzone = g_Config.fDeadzoneRadius;
     const float factor = 1.0f / (1.0f - deadzone);
     if (x > deadzone) {
             return (x - deadzone) * (x - deadzone) * factor;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -189,9 +189,9 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	}
 }
 
-//curve1 implements a smooth deadzone as described here:
+//tiltInputCurve implements a smooth deadzone as described here:
 //http://www.gamasutra.com/blogs/JoshSutphin/20130416/190541/Doing_Thumbstick_Dead_Zones_Right.php
-inline float curve1(float x) {
+inline float tiltInputCurve(float x) {
 	const float deadzone = g_Config.fDeadzoneRadius;
 	const float factor = 1.0f / (1.0f - deadzone);
 
@@ -482,14 +482,14 @@ void EmuScreen::update(InputState &input) {
 		float normalized_input_y = (input.acc.x - base_y) / 50.0 ;
 
 		//TODO: need a better name for computed x and y.
-		float delta_x =  curve1(normalized_input_x * 2.0 * (g_Config.iTiltSensitivityX)) ;
+		float delta_x =  tiltInputCurve(normalized_input_x * 2.0 * (g_Config.iTiltSensitivityX)) ;
 
 		//if the invert is enabled, invert the motion
 		if (g_Config.bInvertTiltX){
 			delta_x *= -1;
 		}
 
-		float delta_y =  curve1(normalized_input_y * 2.0 * (g_Config.iTiltSensitivityY)) ;
+		float delta_y =  tiltInputCurve(normalized_input_y * 2.0 * (g_Config.iTiltSensitivityY)) ;
 		
 		if (g_Config.bInvertTiltY){
 			delta_y *= -1;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -192,15 +192,16 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 //curve1 implements a smooth deadzone as described here:
 //http://www.gamasutra.com/blogs/JoshSutphin/20130416/190541/Doing_Thumbstick_Dead_Zones_Right.php
 inline float curve1(float x) {
-    const float deadzone = g_Config.fDeadzoneRadius;
-    const float factor = 1.0f / (1.0f - deadzone);
-    if (x > deadzone) {
-            return (x - deadzone) * (x - deadzone) * factor;
-    } else if (x < -deadzone) {
-            return -(x + deadzone) * (x + deadzone) * factor;
-    } else {
-            return 0.0f;
-    }
+	const float deadzone = g_Config.fDeadzoneRadius;
+	const float factor = 1.0f / (1.0f - deadzone);
+
+	if (x > deadzone) {
+		return (x - deadzone) * (x - deadzone) * factor;
+	} else if (x < -deadzone) {
+		return -(x + deadzone) * (x + deadzone) * factor;
+	} else {
+		return 0.0f;
+	}
 
 }
 
@@ -484,13 +485,13 @@ void EmuScreen::update(InputState &input) {
 		float delta_x =  curve1(normalized_input_x * 2.0 * (g_Config.iTiltSensitivityX)) ;
 
 		//if the invert is enabled, invert the motion
-		if(g_Config.bInvertTiltX){
+		if (g_Config.bInvertTiltX){
 			delta_x *= -1;
 		}
 
 		float delta_y =  curve1(normalized_input_y * 2.0 * (g_Config.iTiltSensitivityY)) ;
 		
-		if(g_Config.bInvertTiltY){
+		if (g_Config.bInvertTiltY){
 			delta_y *= -1;
 		}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -485,13 +485,13 @@ void EmuScreen::update(InputState &input) {
 		float delta_x =  tiltInputCurve(normalized_input_x * 2.0 * (g_Config.iTiltSensitivityX)) ;
 
 		//if the invert is enabled, invert the motion
-		if (g_Config.bInvertTiltX){
+		if (g_Config.bInvertTiltX) {
 			delta_x *= -1;
 		}
 
 		float delta_y =  tiltInputCurve(normalized_input_y * 2.0 * (g_Config.iTiltSensitivityY)) ;
 		
-		if (g_Config.bInvertTiltY){
+		if (g_Config.bInvertTiltY) {
 			delta_y *= -1;
 		}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -31,6 +31,7 @@
 #include "UI/DevScreens.h"
 #include "UI/TouchControlLayoutScreen.h"
 #include "UI/TouchControlVisibilityScreen.h"
+#include "UI/TiltAnalogSettingsScreen.h"
 
 #include "Core/Config.h"
 #include "Core/Host.h"
@@ -211,7 +212,9 @@ void GameSettingsScreen::CreateViews() {
 #ifdef USING_GLES2
 	controlsSettings->Add(new CheckBox(&g_Config.bHapticFeedback, c->T("HapticFeedback", "Haptic Feedback (vibration)")));
 	controlsSettings->Add(new CheckBox(&g_Config.bAccelerometerToAnalogHoriz, c->T("Tilt", "Tilt to Analog (horizontal)")));
-	controlsSettings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivity, 10, 200, c->T("Tilt Sensitivity"), screenManager()));
+	Choice *tiltAnalog = controlsSettings->Add(new Choice(c->T("Customize tilt")));
+	tiltAnalog->OnClick.Handle(this, &GameSettingsScreen::OnTiltAnalogSettings);
+	tiltAnalog->SetEnabled(g_Config.bAccelerometerToAnalogHoriz);
 #endif
 	controlsSettings->Add(new ItemHeader(c->T("OnScreen", "On-Screen Touch Controls")));
 	controlsSettings->Add(new CheckBox(&g_Config.bShowTouchControls, c->T("OnScreen", "On-Screen Touch Controls")))->OnClick.Handle(this, &GameSettingsScreen::OnToggleTouchControls);
@@ -464,6 +467,11 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e) {
 	screenManager()->push(new TouchControlLayoutScreen());
+	return UI::EVENT_DONE;
+};
+
+UI::EventReturn GameSettingsScreen::OnTiltAnalogSettings(UI::EventParams &e){
+	screenManager()->push(new TiltAnalogSettingsScreen());
 	return UI::EVENT_DONE;
 };
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -55,6 +55,8 @@ private:
 	UI::EventReturn OnBack(UI::EventParams &e);
 	UI::EventReturn OnReloadCheats(UI::EventParams &e);
 	UI::EventReturn OnToggleTouchControls(UI::EventParams &e);
+	UI::EventReturn OnTiltAnalogSettings(UI::EventParams &e);
+	
 
 	// Global settings handlers
 	UI::EventReturn OnLanguage(UI::EventParams &e);

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -1,0 +1,67 @@
+#include "TiltAnalogSettingsScreen.h"
+#include "Core/Config.h"
+#include "Core/System.h"
+#include "i18n/i18n.h"
+
+TiltAnalogSettingsScreen::TiltAnalogSettingsScreen() : currentTiltX_(0), currentTiltY_(0) {};
+
+void TiltAnalogSettingsScreen::CreateViews(){
+	using namespace UI;
+
+	I18NCategory *c = GetI18NCategory("Controls");
+
+	root_ = root_ = new ScrollView(ORIENT_VERTICAL);
+
+	LinearLayout *settings = new LinearLayout(ORIENT_VERTICAL);
+	settings->SetSpacing(0);
+	
+
+	settings->Add(new ItemHeader(c->T("Invert Axes")));
+	settings->Add(new CheckBox(&g_Config.bInvertTiltX, c->T("Invert Tilt along X axis")));
+	settings->Add(new CheckBox(&g_Config.bInvertTiltY, c->T("Invert Tilt along Y axis")));
+
+	settings->Add(new ItemHeader(c->T("Sensitivity")));
+	//TODO: allow values greater than 100? I'm not sure if that's needed.
+	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityX, 0, 100, c->T("Tilt Sensitivity along X axis"), screenManager()));
+	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityY, 0, 100, c->T("Tilt Sensitivity along Y axis"), screenManager()));
+
+	settings->Add(new ItemHeader(c->T("Calibration")));
+	InfoItem *calibrationInfo = new InfoItem("To calibrate, keep device on a flat surface and press calibrate.", "");
+	settings->Add(calibrationInfo);
+
+	Choice *calibrate = new Choice(c->T("Calibrate D-Pad"));
+	calibrate->OnClick.Handle(this, &TiltAnalogSettingsScreen::OnCalibrate);
+	settings->Add(calibrate);
+
+	root_->Add(settings);
+};
+
+void TiltAnalogSettingsScreen::update(InputState &input){
+	UIScreen::update(input);
+	//I'm not sure why y is x and x is y. i's probably because of the orientation
+	//of the screen (the x and y are in portrait coordinates). once portrait and 
+	//reverse-landscape is enabled, this will probably have to change.
+	//If needed, we can add a "swap x and y" option. 
+	currentTiltX_ = input.acc.y;
+	currentTiltY_ = input.acc.x;
+};
+
+
+UI::EventReturn TiltAnalogSettingsScreen::OnBack(UI::EventParams &e){
+	if (PSP_IsInited()) {
+		screenManager()->finishDialog(this, DR_CANCEL);
+	} else {
+		screenManager()->finishDialog(this, DR_OK);
+	}
+
+	return UI::EVENT_DONE;
+};
+
+
+UI::EventReturn TiltAnalogSettingsScreen::OnCalibrate(UI::EventParams &e){
+	g_Config.fTiltBaseX = currentTiltX_;
+	g_Config.fTiltBaseY = currentTiltY_;
+
+	return UI::EVENT_DONE;
+};
+

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -24,6 +24,8 @@ void TiltAnalogSettingsScreen::CreateViews(){
 	//TODO: allow values greater than 100? I'm not sure if that's needed.
 	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityX, 0, 100, c->T("Tilt Sensitivity along X axis"), screenManager()));
 	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityY, 0, 100, c->T("Tilt Sensitivity along Y axis"), screenManager()));
+	settings->Add(new PopupSliderChoiceFloat(&g_Config.fDeadzoneRadius, 0.0, 1.0, c->T("Deadzone Radius"), screenManager()));
+	
 
 	settings->Add(new ItemHeader(c->T("Calibration")));
 	InfoItem *calibrationInfo = new InfoItem("To calibrate, keep device on a flat surface and press calibrate.", "");

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -5,7 +5,7 @@
 
 TiltAnalogSettingsScreen::TiltAnalogSettingsScreen() : currentTiltX_(0), currentTiltY_(0) {};
 
-void TiltAnalogSettingsScreen::CreateViews(){
+void TiltAnalogSettingsScreen::CreateViews() {
 	using namespace UI;
 
 	I18NCategory *c = GetI18NCategory("Controls");
@@ -38,7 +38,7 @@ void TiltAnalogSettingsScreen::CreateViews(){
 	root_->Add(settings);
 };
 
-void TiltAnalogSettingsScreen::update(InputState &input){
+void TiltAnalogSettingsScreen::update(InputState &input) {
 	UIScreen::update(input);
 	//I'm not sure why y is x and x is y. i's probably because of the orientation
 	//of the screen (the x and y are in portrait coordinates). once portrait and 
@@ -49,7 +49,7 @@ void TiltAnalogSettingsScreen::update(InputState &input){
 };
 
 
-UI::EventReturn TiltAnalogSettingsScreen::OnBack(UI::EventParams &e){
+UI::EventReturn TiltAnalogSettingsScreen::OnBack(UI::EventParams &e) {
 	if (PSP_IsInited()) {
 		screenManager()->finishDialog(this, DR_CANCEL);
 	} else {
@@ -60,7 +60,7 @@ UI::EventReturn TiltAnalogSettingsScreen::OnBack(UI::EventParams &e){
 };
 
 
-UI::EventReturn TiltAnalogSettingsScreen::OnCalibrate(UI::EventParams &e){
+UI::EventReturn TiltAnalogSettingsScreen::OnCalibrate(UI::EventParams &e) {
 	g_Config.fTiltBaseX = currentTiltX_;
 	g_Config.fTiltBaseY = currentTiltY_;
 

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "base/functional.h"
+#include "ui/view.h"
+#include "MiscScreens.h"
+
+class TiltAnalogSettingsScreen : public UIDialogScreenWithBackground {
+public:
+	TiltAnalogSettingsScreen();
+
+	virtual void CreateViews();
+	virtual void update(InputState &input);
+protected:
+	virtual UI::EventReturn OnBack(UI::EventParams &e);
+private:
+	UI::EventReturn OnCalibrate(UI::EventParams &e);
+	float currentTiltX_, currentTiltY_;
+};
+

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -110,6 +110,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/UI/GameScreen.cpp \
   $(SRC)/UI/ControlMappingScreen.cpp \
   $(SRC)/UI/GameSettingsScreen.cpp \
+  $(SRC)/UI/TiltAnalogSettingsScreen.cpp \
   $(SRC)/UI/TouchControlLayoutScreen.cpp \
   $(SRC)/UI/TouchControlVisibilityScreen.cpp \
   $(SRC)/UI/CwCheatScreen.cpp \


### PR DESCRIPTION
Decided to implement this after trying to play Gods Eater Burst without a controller :P It's definitely playable now (but worse than a controller obviously)  

A couple of notes:
 1) I'm not a fan of the name. If someone has a better name for the class `TiltAnalogSettingsScreen`, please tell.
 2) Once portrait mode is reintroduced, the definition of `x axis` and `y axis` will have to be dynamic.
 3) I'm not sure how it'll behave on iOS (the normalization of coordinates mostly).
 4) the deadzone needs some tweaking. maybe make it configurable too?  
 5) could @thedax please help and add the `TiltAnalogSettingsScreen.h` and `TiltAnalogSettingsScreen.cpp` to the visual studio project? Thanks!

Screenie of the menu:

 ![screenshot_2013-10-27-23-34-05](https://f.cloud.github.com/assets/1694861/1416056/a11445cc-3f32-11e3-941c-8f743134cdda.png)
