### PR TITLE
Ingore the uncached flag for memchecks, minor tweaks

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -248,6 +248,12 @@ void CBreakPoints::ClearAllMemChecks()
 	}
 }
 
+static inline u32 NotCached(u32 val)
+{
+	// Remove the cached part of the address.
+	return val & ~0x40000000;
+}
+
 MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 {
 	std::vector<MemCheck>::iterator iter;
@@ -256,18 +262,25 @@ MemCheck *CBreakPoints::GetMemCheck(u32 address, int size)
 		MemCheck &check = *iter;
 		if (check.end != 0)
 		{
-			if (address + size > check.start && address < check.end)
+			if (NotCached(address + size) > NotCached(check.start) && NotCached(address) < NotCached(check.end))
 				return &check;
 		}
 		else
 		{
-			if (check.start == address)
+			if (NotCached(check.start) == NotCached(address))
 				return &check;
 		}
 	}
 
 	//none found
 	return 0;
+}
+
+void CBreakPoints::ExecMemCheck(u32 address, bool write, int size, u32 pc)
+{
+	auto check = GetMemCheck(address, size);
+	if (check)
+		check->Action(address, write, size, pc);
 }
 
 void CBreakPoints::SetSkipFirst(u32 pc)
@@ -281,6 +294,22 @@ u32 CBreakPoints::CheckSkipFirst()
 	if (breakSkipFirstTicks_ == CoreTiming::GetTicks())
 		return pc;
 	return 0;
+}
+
+const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges()
+{
+	std::vector<MemCheck> ranges = memChecks_;
+	for (auto it = memChecks_.begin(), end = memChecks_.end(); it != end; ++it)
+	{
+		MemCheck check = *it;
+		// Toggle the cached part of the address.
+		check.start ^= 0x40000000;
+		if (check.end != 0)
+			check.end ^= 0x40000000;
+		ranges.push_back(check);
+	}
+
+	return ranges;
 }
 
 const std::vector<MemCheck> CBreakPoints::GetMemChecks()

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -278,7 +278,6 @@ void CBreakPoints::SetSkipFirst(u32 pc)
 u32 CBreakPoints::CheckSkipFirst()
 {
 	u32 pc = breakSkipFirstAt_;
-	breakSkipFirstAt_ = 0;
 	if (breakSkipFirstTicks_ == CoreTiming::GetTicks())
 		return pc;
 	return 0;

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -123,9 +123,13 @@ public:
 	static void ClearAllMemChecks();
 
 	static MemCheck *GetMemCheck(u32 address, int size);
+	static void ExecMemCheck(u32 address, bool write, int size, u32 pc);
 
 	static void SetSkipFirst(u32 pc);
 	static u32 CheckSkipFirst();
+
+	// Includes uncached addresses.
+	static const std::vector<MemCheck> GetMemCheckRanges();
 
 	static const std::vector<MemCheck> GetMemChecks();
 	static const std::vector<BreakPoint> GetBreakpoints();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -790,9 +790,7 @@ void JitMemCheck(u32 addr, int size, int isWrite)
 	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME)
 		return;
 
-	MemCheck *check = CBreakPoints::GetMemCheck(addr, size);
-	if (check)
-		check->Action(addr, isWrite == 1, size, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(addr, isWrite == 1, size, currentMIPS->pc);
 }
 
 void Jit::JitSafeMem::MemCheckImm(ReadType type)
@@ -817,7 +815,7 @@ void Jit::JitSafeMem::MemCheckImm(ReadType type)
 
 void Jit::JitSafeMem::MemCheckAsm(ReadType type)
 {
-	const auto memchecks = CBreakPoints::GetMemChecks();
+	const auto memchecks = CBreakPoints::GetMemCheckRanges();
 	bool possible = false;
 	for (auto it = memchecks.begin(), end = memchecks.end(); it != end; ++it)
 	{

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1023,8 +1023,7 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			break;
 		case ID_DISASM_RUNTOHERE:
 			{
-				debugger->setBreakpoint(curAddress);
-				debugger->runToBreakpoint();
+				SendMessage(GetParent(wnd), WM_COMMAND, ID_DEBUG_RUNTOLINE, 0);
 				redraw();
 			}
 			break;


### PR DESCRIPTION
If I set a breakpoint for 0x09FFFE7C, I probably want 0x49FFFE7C to trip it.  Rather than having to set two, it's easier just to check both automatically.

-[Unknown]
