### PR TITLE
Improve basic error checking in sceAtrac

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -542,13 +542,13 @@ u32 _AtracAddStreamData(int atracID, u8 *buf, u32 bytesToAdd) {
 // (We always have "first.offset + first.writableBytes = atracBufSize").
 // We only reset the temp buf when games call sceAtracGetStreamDataInfo,
 // because that function would tell games how to add the left stream data.
-u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd)
-{
-	DEBUG_LOG(ME, "sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
+u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return 0;
+		ERROR_LOG(ME, "sceAtracAddStreamData(%i, %08x): bad atrac ID", atracID, bytesToAdd);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracAddStreamData(%i, %08x)", atracID, bytesToAdd);
 		// TODO
 		if (bytesToAdd > atrac->first.writableBytes)
 			return ATRAC_ERROR_ADD_DATA_IS_TOO_BIG;
@@ -739,13 +739,13 @@ u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAdd
 	}
 }
 
-u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
+u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return -1;
+		ERROR_LOG(ME, "sceAtracGetBitrate(%i, %08x): bad atrac ID", atracID, outBitrateAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetBitrate(%i, %08x)", atracID, outBitrateAddr);
 		atrac->atracBitrate = ( atrac->atracBytesPerFrame * 352800 ) / 1000;
 		if (atrac->codecType == PSP_MODE_AT_3_PLUS)
 			atrac->atracBitrate = ((atrac->atracBitrate >> 11) + 8) & 0xFFFFFFF0;
@@ -757,26 +757,26 @@ u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr)
 	return 0;
 }
 
-u32 sceAtracGetChannel(int atracID, u32 channelAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
+u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return -1;
+		ERROR_LOG(ME, "sceAtracGetChannel(%i, %08x): bad atrac ID", atracID, channelAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetChannel(%i, %08x)", atracID, channelAddr);
 		if (Memory::IsValidAddress(channelAddr))
 			Memory::Write_U32(atrac->atracChannels, channelAddr);
 	}
 	return 0;
 }
 
-u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
+u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetLoopStatus(%i, %08x, %08x): bad atrac ID", atracID, loopNumAddr, statusAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetLoopStatus(%i, %08x, %08x)", atracID, loopNumAddr, statusAddr);
 		if (Memory::IsValidAddress(loopNumAddr))
 			Memory::Write_U32(atrac->loopNum, loopNumAddr);
 		// return audio's loopinfo in at3 file
@@ -790,26 +790,26 @@ u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr)
 	return 0;
 }
 
-u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr)
-{
-	ERROR_LOG(ME, "UNIMPL sceAtracGetInternalErrorInfo(%i, %08x)", atracID, errorAddr);
+u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetInternalErrorInfo(%i, %08x): bad atrac ID", atracID, errorAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		ERROR_LOG(ME, "UNIMPL sceAtracGetInternalErrorInfo(%i, %08x)", atracID, errorAddr);
 		if (Memory::IsValidAddress(errorAddr))
 			Memory::Write_U32(0, errorAddr);
 	}
 	return 0;
 }
 
-u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
+u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetMaxSample(%i, %08x): bad atrac ID", atracID, maxSamplesAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetMaxSample(%i, %08x)", atracID, maxSamplesAddr);
 		if (Memory::IsValidAddress(maxSamplesAddr)) {
 			int atracSamplesPerFrame = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
 			Memory::Write_U32(atracSamplesPerFrame, maxSamplesAddr);
@@ -818,13 +818,13 @@ u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr)
 	return 0;
 }
 
-u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
+u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return -1;
+		ERROR_LOG(ME, "sceAtracGetNextDecodePosition(%i, %08x): bad atrac ID", atracID, outposAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetNextDecodePosition(%i, %08x)", atracID, outposAddr);
 		if (atrac->currentSample >= atrac->endSample)
 			return ATRAC_ERROR_ALL_DATA_DECODED;
 		if (Memory::IsValidAddress(outposAddr))
@@ -833,14 +833,13 @@ u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr)
 	return 0;
 }
 
-u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
+u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
-		Memory::Write_U32(1, outNAddr);
+		ERROR_LOG(ME, "sceAtracGetNextSample(%i, %08x): bad atrac ID", atracID, outNAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetNextSample(%i, %08x)", atracID, outNAddr);
 		if (atrac->currentSample >= atrac->endSample) {
 			if (Memory::IsValidAddress(outNAddr))
 				Memory::Write_U32(0, outNAddr);
@@ -858,25 +857,25 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr)
 
 u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr)
 {
-	DEBUG_LOG(ME, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		if (Memory::IsValidAddress(remainAddr))
-			Memory::Write_U32(12, remainAddr);
+		ERROR_LOG(ME, "sceAtracGetRemainFrame(%i, %08x): bad atrac ID", atracID, remainAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetRemainFrame(%i, %08x)", atracID, remainAddr);
 		if (Memory::IsValidAddress(remainAddr))
 			Memory::Write_U32(atrac->getRemainFrames(), remainAddr);
 	}
 	return 0;
 }
 
-u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
-{
-	ERROR_LOG(ME, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
+u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetSecondBufferInfo(%i, %08x, %08x): bad atrac ID", atracID, outposAddr, outBytesAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	}
+	ERROR_LOG(ME, "sceAtracGetSecondBufferInfo(%i, %08x, %08x)", atracID, outposAddr, outBytesAddr);
 	if (Memory::IsValidAddress(outposAddr) && atrac)
 		Memory::Write_U32(atrac->second.fileoffset, outposAddr);
 	if (Memory::IsValidAddress(outBytesAddr) && atrac)
@@ -887,11 +886,12 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr)
 
 u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr)
 {
-	DEBUG_LOG(ME, "sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetSoundSample(%i, %08x, %08x, %08x): bad atrac ID", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 		if (Memory::IsValidAddress(outEndSampleAddr))
 			Memory::Write_U32(atrac->endSample, outEndSampleAddr); // outEndSample
 		if (Memory::IsValidAddress(outLoopStartSampleAddr))
@@ -905,13 +905,13 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 // Games call this function to get some info for add more stream data,
 // such as where the data read from, where the data add to,
 // and how many bytes are allowed to add.
-u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr)
-{
-	DEBUG_LOG(ME, "sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x): bad atrac ID", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		DEBUG_LOG(ME, "sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x)", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
 		// reset the temp buf for adding more stream data
 		atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->atracBufSize);
 		atrac->first.offset = 0;
@@ -932,13 +932,13 @@ u32 sceAtracReleaseAtracID(int atracID)
 	return deleteAtrac(atracID);
 }
 
-u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf)
-{
-	INFO_LOG(ME, "sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
+u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracResetPlayPosition(%i, %i, %i, %i): bad atrac ID", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
+		return ATRAC_ERROR_BAD_ATRACID;
 	} else {
+		INFO_LOG(ME, "sceAtracResetPlayPosition(%i, %i, %i, %i)", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
 		if (bytesWrittenFirstBuf > 0)
 			sceAtracAddStreamData(atracID, bytesWrittenFirstBuf);
 		atrac->currentSample = sample;
@@ -1140,13 +1140,17 @@ int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracI
 	return hleDelayResult(ret, "atrac set data", 100);
 }
 
-u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize)
-{
+u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x): bad atrac ID", atracID, halfBuffer, readSize, halfBufferSize);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
+
 	INFO_LOG(ME, "sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x)", atracID, halfBuffer, readSize, halfBufferSize);
 	if (readSize > halfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
 
-	Atrac *atrac = getAtrac(atracID);
 	int ret = 0;
 	if (atrac != NULL) {
 		atrac->first.addr = halfBuffer;
@@ -1158,13 +1162,14 @@ u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 half
 	return ret;
 }
 
-u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
-{
-	ERROR_LOG(ME, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %8x)", atracID, secondBuffer, secondBufferSize);
+u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracSetSecondBuffer(%i, %08x, %8x): bad atrac ID", atracID, secondBuffer, secondBufferSize);
+		return ATRAC_ERROR_BAD_ATRACID;
 	}
+
+	ERROR_LOG(ME, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %8x)", atracID, secondBuffer, secondBufferSize);
 	return 0;
 }
 
@@ -1249,20 +1254,22 @@ u32 sceAtracStartEntry()
 	return 0;
 }
 
-u32 sceAtracSetLoopNum(int atracID, int loopNum)
-{
+u32 sceAtracSetLoopNum(int atracID, int loopNum) {
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracSetLoopNum(%i, %i): bad atrac ID", atracID, loopNum);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
+
 	// Spammed in MHU
 	DEBUG_LOG(ME, "sceAtracSetLoopNum(%i, %i)", atracID, loopNum);
-	Atrac *atrac = getAtrac(atracID);
-	if (atrac) {
-		if (atrac->loopinfoNum == 0)
-			return ATRAC_ERROR_NO_LOOP_INFORMATION;
-		atrac->loopNum = loopNum;
-		if (loopNum != 0 && atrac->loopinfoNum == 0) {
-			// Just loop the whole audio
-			atrac->loopStartSample = 0;
-			atrac->loopEndSample = atrac->endSample;
-		}
+	if (atrac->loopinfoNum == 0)
+		return ATRAC_ERROR_NO_LOOP_INFORMATION;
+	atrac->loopNum = loopNum;
+	if (loopNum != 0 && atrac->loopinfoNum == 0) {
+		// Just loop the whole audio
+		atrac->loopStartSample = 0;
+		atrac->loopEndSample = atrac->endSample;
 	}
 	return 0;
 }
@@ -1315,32 +1322,41 @@ int sceAtracReinit(int at3Count, int at3plusCount)
 	}
 }
 
-int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr)
-{
-	DEBUG_LOG(ME, "sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
+int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracGetOutputChannel(%i, %08x): bad atrac ID", atracID, outputChanPtr);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
+
+	DEBUG_LOG(ME, "sceAtracGetOutputChannel(%i, %08x)", atracID, outputChanPtr);
 	if (Memory::IsValidAddress(outputChanPtr))
-		Memory::Write_U32(atrac ? atrac->atracOutputChannels : 2, outputChanPtr);
+		Memory::Write_U32(atrac->atracOutputChannels, outputChanPtr);
 	return 0;
 }
 
-int sceAtracIsSecondBufferNeeded(int atracID)
-{
-	ERROR_LOG(ME, "UNIMPL sceAtracIsSecondBufferNeeded(%i)", atracID);
+int sceAtracIsSecondBufferNeeded(int atracID) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
-		//return -1;
+		ERROR_LOG(ME, "sceAtracIsSecondBufferNeeded(%i): bad atrac ID", atracID);
+		return ATRAC_ERROR_BAD_ATRACID;
 	}
+	WARN_LOG(ME, "UNIMPL sceAtracIsSecondBufferNeeded(%i)", atracID);
 	return 0;
 }
 
 int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, u32 readSize, u32 MOutHalfBufferSize)
 {
+	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracSetMOutHalfwayBuffer(%i, %08x, %08x, %08x): bad atrac ID", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
+
 	INFO_LOG(ME, "sceAtracSetMOutHalfwayBuffer(%i, %08x, %08x, %08x)", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
 	if (readSize > MOutHalfBufferSize)
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
 
-	Atrac *atrac = getAtrac(atracID);
 	int ret = 0;
 	if (atrac != NULL) {
 		atrac->first.addr = MOutHalfBuffer;
@@ -1351,11 +1367,10 @@ int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, u32 readSize, 
 	}
 	return ret;
 }
-
-u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize)
-{
+u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	INFO_LOG(ME, "sceAtracSetMOutData(%i, %08x, %08x)", atracID, buffer, bufferSize);
 	Atrac *atrac = getAtrac(atracID);
+	// TODO: What is the proper error code here?
 	int ret = 0;
 	if (atrac != NULL) {
 		atrac->first.addr = buffer;
@@ -1591,11 +1606,15 @@ bool initAT3plusDecoder(Atrac *atrac, u32 dataSize = 0xffb4a8)
 	return false;
 }
 
-int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr)
-{
-	INFO_LOG(ME, "sceAtracLowLevelInitDecoder(%i, %08x)", atracID, paramsAddr);
+int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	Atrac *atrac = getAtrac(atracID);
-	if (atrac && Memory::IsValidAddress(paramsAddr)) {
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracLowLevelInitDecoder(%i, %08x): bad atrac ID", atracID, paramsAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
+
+	INFO_LOG(ME, "sceAtracLowLevelInitDecoder(%i, %08x)", atracID, paramsAddr);
+	if (Memory::IsValidAddress(paramsAddr)) {
 		atrac->atracChannels = Memory::Read_U32(paramsAddr);
 		atrac->atracOutputChannels = Memory::Read_U32(paramsAddr + 4);
 		atrac->atracBufSize = Memory::Read_U32(paramsAddr + 8);
@@ -1645,11 +1664,14 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr)
 	return 0;
 }
 
-int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr)
-{
-	DEBUG_LOG(ME, "UNIMPL sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x)", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
+int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
 	Atrac *atrac = getAtrac(atracID);
+	if (!atrac) {
+		ERROR_LOG(ME, "sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x): bad atrac ID", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
+		return ATRAC_ERROR_BAD_ATRACID;
+	}
 
+	DEBUG_LOG(ME, "UNIMPL sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x)", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
 #ifdef USE_FFMPEG
 	if (atrac && atrac->pCodecCtx && Memory::IsValidAddress(sourceAddr) && Memory::IsValidAddress(sourceBytesConsumedAddr) &&
   		Memory::IsValidAddress(samplesAddr) && Memory::IsValidAddress(sampleBytesAddr)) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1528,6 +1528,10 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 	if (context->info.endSample > 0) {
 		// do not change info.state if this was not called at first time
 		// In Sol Trigger, it would set info.state = 0x10 outside
+		// TODO: Should we just keep this in PSP ram then, or something?
+	} else if (!atrac->data_buf) {
+		// State 1, no buffer yet.
+		context->info.state = 1;
 	} else if (atrac->first.size >= atrac->first.filesize) {
 		// state 2, all data loaded
 		context->info.state = 2;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -378,8 +378,7 @@ int getCodecType(u32 addr) {
 	return 0;
 }
 
-int Atrac::Analyze()
-{
+int Atrac::Analyze() {
 	// reset some values
 	codecType = 0;
 	currentSample = 0;
@@ -509,7 +508,7 @@ u32 sceAtracGetAtracID(int codecType) {
 	atrac->codecType = codecType;
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracGetAtracID(%i): no free ID", codecType);
+		ERROR_LOG(ME, "sceAtracGetAtracID(%i): no free ID", codecType);
 		delete atrac;
 		return atracID;
 	}
@@ -570,8 +569,7 @@ u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 	return 0;
 }
 
-u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int *remains)
-{
+u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int *remains) {
 	Atrac *atrac = getAtrac(atracID);
 
 	u32 ret = 0;
@@ -671,8 +669,7 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 	return ret;
 }
 
-u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr)
-{
+u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr) {
 	u32 numSamples = 0;
 	u32 finish = 0;
 	int remains = 0;
@@ -690,9 +687,8 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 	return ret;
 }
 
-u32 sceAtracEndEntry()
-{
-	ERROR_LOG(ME, "UNIMPL sceAtracEndEntry()");
+u32 sceAtracEndEntry() {
+	ERROR_LOG_REPORT(ME, "UNIMPL sceAtracEndEntry()");
 	return 0;
 }
 
@@ -964,8 +960,7 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 	return 0;
 }
 
-u32 sceAtracReleaseAtracID(int atracID)
-{
+u32 sceAtracReleaseAtracID(int atracID) {
 	INFO_LOG(ME, "sceAtracReleaseAtracID(%i)", atracID);
 	return deleteAtrac(atracID);
 }
@@ -996,8 +991,7 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 }
 
 #ifdef USE_FFMPEG
-static int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size)
-{
+static int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size) {
 	Atrac *atrac = (Atrac *)opaque;
 	if (atrac->decodePos > atrac->first.filesize)
 		return -1;
@@ -1009,8 +1003,7 @@ static int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size)
 	return size;
 }
 
-static int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence)
-{
+static int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence) {
 	Atrac *atrac = (Atrac*)opaque;
 	if (offset > atrac->first.filesize)
 		return -1;
@@ -1126,8 +1119,7 @@ int __AtracSetContext(Atrac *atrac) {
 	return 0;
 }
 
-int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
-{
+int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
 	if (atrac->first.size > atrac->first.filesize)
 		atrac->first.size = atrac->first.filesize;
 	atrac->first.fileoffset = atrac->first.size;
@@ -1169,8 +1161,7 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize)
 	return 0;
 }
 
-int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracID = false)
-{
+int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracID = false) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac)
 		return -1;
@@ -1213,12 +1204,11 @@ u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
 		return ATRAC_ERROR_NO_DATA;
 	}
 
-	ERROR_LOG(ME, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %8x)", atracID, secondBuffer, secondBufferSize);
+	ERROR_LOG_REPORT(ME, "UNIMPL sceAtracSetSecondBuffer(%i, %08x, %8x)", atracID, secondBuffer, secondBufferSize);
 	return 0;
 }
 
-u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
-{
+u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac != NULL) {
 		INFO_LOG(ME, "sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
@@ -1240,8 +1230,7 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize)
 	}
 }
 
-int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
-{
+int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize) {
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -1255,7 +1244,7 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 	atrac->atracOutputChannels = 2;
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetDataAndGetID(%08x, %08x): no free ID", buffer, bufferSize);
+		ERROR_LOG(ME, "sceAtracSetDataAndGetID(%08x, %08x): no free ID", buffer, bufferSize);
 		delete atrac;
 		return atracID;
 	}
@@ -1266,8 +1255,7 @@ int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize)
 	return atracID;
 }
 
-int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
-{
+int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x): incorrect read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
@@ -1281,7 +1269,7 @@ int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBuffe
 	atrac->atracOutputChannels = 2;
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
+		ERROR_LOG(ME, "sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
 		delete atrac;
 		return atracID;
 	}
@@ -1292,9 +1280,8 @@ int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBuffe
 	return atracID;
 }
 
-u32 sceAtracStartEntry()
-{
-	ERROR_LOG(ME, "UNIMPL sceAtracStartEntry(.)");
+u32 sceAtracStartEntry() {
+	ERROR_LOG_REPORT(ME, "UNIMPL sceAtracStartEntry()");
 	return 0;
 }
 
@@ -1321,8 +1308,7 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 	return 0;
 }
 
-int sceAtracReinit(int at3Count, int at3plusCount)
-{
+int sceAtracReinit(int at3Count, int at3plusCount) {
 	for (int i = 0; i < PSP_NUM_ATRAC_IDS; ++i) {
 		if (atracIDs[i] != NULL) {
 			ERROR_LOG_REPORT(ME, "sceAtracReinit(%d, %d): cannot reinit while IDs in use", at3Count, at3plusCount);
@@ -1398,8 +1384,7 @@ int sceAtracIsSecondBufferNeeded(int atracID) {
 	return 0;
 }
 
-int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, u32 readSize, u32 MOutHalfBufferSize)
-{
+int sceAtracSetMOutHalfwayBuffer(int atracID, u32 MOutHalfBuffer, u32 readSize, u32 MOutHalfBufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetMOutHalfwayBuffer(%i, %08x, %08x, %08x): bad atrac ID", atracID, MOutHalfBuffer, readSize, MOutHalfBufferSize);
@@ -1435,8 +1420,7 @@ u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	return ret;
 }
 
-int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize)
-{
+int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -1446,7 +1430,7 @@ int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize)
 	atrac->atracOutputChannels = 1;
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x): no free ID", buffer, bufferSize);
+		ERROR_LOG(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x): no free ID", buffer, bufferSize);
 		delete atrac;
 		return atracID;
 	}
@@ -1457,8 +1441,7 @@ int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize)
 	return atracID;
 }
 
-int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
-{
+int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x, %08x): incorrect read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
@@ -1472,7 +1455,7 @@ int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfB
 	atrac->atracOutputChannels = 1;
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
+		ERROR_LOG(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
 		delete atrac;
 		return atracID;
 	}
@@ -1483,8 +1466,7 @@ int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfB
 	return atracID;
 }
 
-int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr)
-{
+int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr) {
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -1493,11 +1475,11 @@ int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 met
 	atrac->Analyze();
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x): no free ID",  buffer, bufferSize, fileSize, metadataSizeAddr);
+		ERROR_LOG(ME, "sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x): no free ID",  buffer, bufferSize, fileSize, metadataSizeAddr);
 		delete atrac;
 		return atracID;
 	}
-	ERROR_LOG(ME, "UNIMPL %d=sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x)", atracID, buffer, bufferSize, fileSize, metadataSizeAddr);
+	WARN_LOG(ME, "%d=sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x)", atracID, buffer, bufferSize, fileSize, metadataSizeAddr);
 	return atracID;
 }
 
@@ -1547,8 +1529,7 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 	*(u32*)(buf + 0xfc) = atrac->atracID;
 }
 
-int _sceAtracGetContextAddress(int atracID)
-{
+int _sceAtracGetContextAddress(int atracID) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "_sceAtracGetContextAddress(%i): bad atrac id", atracID);
@@ -1581,8 +1562,7 @@ static const u16 at3HeaderMap[][4] = {
 
 static const int at3HeaderMapSize = sizeof(at3HeaderMap)/(sizeof(u16) * 4);
 
-bool initAT3Decoder(Atrac *atrac, u32 dataSize = 0xffb4a8)
-{
+bool initAT3Decoder(Atrac *atrac, u32 dataSize = 0xffb4a8) {
 	for (int i = 0; i < at3HeaderMapSize; i ++) {
 		if (at3HeaderMap[i][0] == atrac->atracBytesPerFrame && at3HeaderMap[i][1] == atrac->atracChannels) {
 			*(u32*)(at3Header + 0x04) = dataSize + sizeof(at3Header) - 8;
@@ -1641,8 +1621,7 @@ static const u16 at3plusHeaderMap[][3] = {
 
 static const int at3plusHeaderMapSize = sizeof(at3plusHeaderMap)/(sizeof(u16) * 3);
 
-bool initAT3plusDecoder(Atrac *atrac, u32 dataSize = 0xffb4a8)
-{
+bool initAT3plusDecoder(Atrac *atrac, u32 dataSize = 0xffb4a8) {
 	for (int i = 0; i < at3plusHeaderMapSize; i += 2) {
 		if (at3plusHeaderMap[i][0] == atrac->atracBytesPerFrame && at3plusHeaderMap[i][1] == atrac->atracChannels) {
 			*(u32*)(at3plusHeader + 0x04) = dataSize + sizeof(at3plusHeader) - 8;
@@ -1795,8 +1774,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 	return 0;
 }
 
-int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize)
-{
+int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x): invalid read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
@@ -1809,7 +1787,7 @@ int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBu
 	atrac->Analyze();
 	int atracID = createAtrac(atrac, codecType);
 	if (atracID < 0) {
-		ERROR_LOG_REPORT(ME, "sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
+		ERROR_LOG(ME, "sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x): no free ID", halfBuffer, readSize, halfBufferSize);
 		delete atrac;
 		return atracID;
 	}
@@ -1817,8 +1795,7 @@ int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBu
 	return createAtrac(atrac, codecType);
 }
 
-const HLEFunction sceAtrac3plus[] =
-{
+const HLEFunction sceAtrac3plus[] = {
 	{0x7db31251,WrapU_IU<sceAtracAddStreamData>,"sceAtracAddStreamData"},
 	{0x6a8c3cd5,WrapU_IUUUU<sceAtracDecodeData>,"sceAtracDecodeData"},
 	{0xd5c28cc0,WrapU_V<sceAtracEndEntry>,"sceAtracEndEntry"},
@@ -1860,8 +1837,7 @@ const HLEFunction sceAtrac3plus[] =
 };
 
 
-void Register_sceAtrac3plus()
-{
+void Register_sceAtrac3plus() {
 	// Two names
 	RegisterModule("sceATRAC3plus_Library", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);
 	RegisterModule("sceAtrac3plus", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1236,7 +1236,13 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 	}
 }
 
-int sceAtracSetDataAndGetID(u32 buffer, u32 bufferSize) {
+int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
+	// A large value happens in Tales of VS, and isn't handled somewhere properly as a u32.
+	// It's impossible for it to be that big anyway, so cap it.
+	if (bufferSize < 0) {
+		WARN_LOG(ME, "sceAtracSetDataAndGetID(%08x, %08x): negative bufferSize", buffer, bufferSize);
+		bufferSize = 0x10000000;
+	}
 	int codecType = getCodecType(buffer);
 
 	Atrac *atrac = new Atrac();
@@ -1846,7 +1852,7 @@ const HLEFunction sceAtrac3plus[] = {
 	{0x3f6e26b5,WrapU_IUUU<sceAtracSetHalfwayBuffer>,"sceAtracSetHalfwayBuffer"},
 	{0x83bf7afd,WrapU_IUU<sceAtracSetSecondBuffer>,"sceAtracSetSecondBuffer"},
 	{0x0E2A73AB,WrapU_IUU<sceAtracSetData>,"sceAtracSetData"}, //?
-	{0x7a20e7af,WrapI_UU<sceAtracSetDataAndGetID>,"sceAtracSetDataAndGetID"},
+	{0x7a20e7af,WrapI_UI<sceAtracSetDataAndGetID>,"sceAtracSetDataAndGetID"},
 	{0xd1f59fdb,WrapU_V<sceAtracStartEntry>,"sceAtracStartEntry"},
 	{0x868120b5,WrapU_II<sceAtracSetLoopNum>,"sceAtracSetLoopNum"},
 	{0x132f1eca,WrapI_II<sceAtracReinit>,"sceAtracReinit"},

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -103,9 +103,9 @@ struct AtracLoopInfo {
 };
 
 struct Atrac {
-	Atrac() : atracID(-1), data_buf(0), decodePos(0), decodeEnd(0), atracChannels(2), atracOutputChannels(2),
+	Atrac() : atracID(-1), data_buf(0), decodePos(0), decodeEnd(0), atracChannels(0), atracOutputChannels(2),
 		atracBitrate(64), atracBytesPerFrame(0), atracBufSize(0),
-		currentSample(0), endSample(-1), firstSampleoffset(0), loopinfoNum(0), loopNum(0), codecType(0), failedDecode(false) {
+		currentSample(0), endSample(0), firstSampleoffset(0), loopinfoNum(0), loopNum(0), codecType(0), failedDecode(false) {
 		memset(&first, 0, sizeof(first));
 		memset(&second, 0, sizeof(second));
 #ifdef USE_FFMPEG
@@ -389,6 +389,7 @@ int Atrac::Analyze() {
 	loopStartSample = -1;
 	loopEndSample = -1;
 	decodePos = 0;
+	atracChannels = 2;
 
 	if (first.size < 0x100)	{
 		ERROR_LOG_REPORT(ME, "Atrac buffer very small: %d", first.size);


### PR DESCRIPTION
Almost all functions return errors when passed an invalid atrac id, but we weren't doing that.  I tested each one.  The majority of those also returned errors if there was no buffer attached yet, for a valid atrac ID.

Also, tested and verified errors when passing invalid data to a few more functions.  I couldn't test sceAtracSetMOutDataAndGetID() and sceAtracSetMOutData(), because I got "not yet linked" errors for them.  I guess they're in libraries on umds only.

Games still play music, but last time I changed atrac it broke stuff.  And I don't know of anything this fixes, but there is the possibility of a game relying on these error codes.

-[Unknown]
