### PR TITLE
sceAudio: ARM optimisation.

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -330,14 +330,6 @@ void SasInstance::SetGrainSize(int newGrainSize) {
 	resampleBuffer = new s16[grainSize * 4 + 3];
 }
 
-static inline s16 clamp_s16(int i) {
-	if (i > 32767)
-		return 32767;
-	if (i < -32768)
-		return -32768;
-	return i;
-}
-
 void SasVoice::ReadSamples(s16 *output, int numSamples) {
 	// Read N samples into the resample buffer. Could do either PCM or VAG here.
 	switch (type) {

--- a/Globals.h
+++ b/Globals.h
@@ -48,6 +48,18 @@ inline u8 Convert6To8(u8 v)
 	return (v << 2) | (v >> 4);
 }
 
+static inline s16 clamp_s16(int i) {
+#ifdef ARM
+	asm("ssat %0, #16, %1" : "=r"(i) : "r"(i));
+#else
+	if (i > 32767)
+		return 32767;
+	if (i < -32768)
+		return -32768;
+#endif
+	return i;
+}
+
 #ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(t) \
  private: \


### PR DESCRIPTION
Use ARMv6+ assembly for the clamping and volume adjustment code.

Also note that when volume is 1<<15 that adjustvolume(sample, volume) becomes equal to sample. Every game I tested had left and right volume fixed to 1<<15 but it could just be a coincidence.
