### PR TITLE
Various debug UI fixes and enhancements

### DIFF
--- a/Windows/Debugger/BreakpointWindow.cpp
+++ b/Windows/Debugger/BreakpointWindow.cpp
@@ -264,7 +264,6 @@ void BreakpointWindow::loadFromBreakpoint(BreakPoint& breakpoint)
 
 	enabled = breakpoint.enabled;
 	address = breakpoint.addr;
-	enabled = breakpoint.enabled;
 	size = 1;
 
 	if (breakpoint.hasCond)
@@ -273,4 +272,13 @@ void BreakpointWindow::loadFromBreakpoint(BreakPoint& breakpoint)
 	} else {
 		condition[0] = 0;
 	}
+}
+
+void BreakpointWindow::initBreakpoint(u32 _address)
+{
+	memory = false;
+	enabled = true;
+	address = _address;
+	size = 1;
+	condition[0] = 0;
 }

--- a/Windows/Debugger/BreakpointWindow.h
+++ b/Windows/Debugger/BreakpointWindow.h
@@ -43,5 +43,5 @@ public:
 	void addBreakpoint();
 	void loadFromMemcheck(MemCheck& memcheck);
 	void loadFromBreakpoint(BreakPoint& memcheck);
-
+	void initBreakpoint(u32 address);
 };

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -83,7 +83,6 @@ class CtrlDisAsmView
 
 	std::vector<u32> jumpStack;
 
-	bool controlHeld;
 	std::string searchQuery;
 	int matchAddress;
 	bool searching;
@@ -171,7 +170,8 @@ public:
 		showHex=s;
 	}
 
-	void toggleBreakpoint();
+	void toggleBreakpoint(bool toggleEnabled = false);
+	void editBreakpoint();
 
 	void scrollWindow(int lines)
 	{

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -44,7 +44,6 @@ CtrlMemView::CtrlMemView(HWND _wnd)
 	matchAddress = -1;
 	searching = false;
 
-	ctrlDown = false;
 	hasFocus = false;
 	windowStart = curAddress;
 	asciiSelected = false;
@@ -133,7 +132,6 @@ LRESULT CALLBACK CtrlMemView::wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
 		ccp->onChar(wParam,lParam);
 		return 0;
 	case WM_KEYUP:
-		if (wParam == VK_CONTROL) ccp->ctrlDown = false;
 		return 0;
 	case WM_LBUTTONDOWN: SetFocus(hwnd); lmbDown=true; ccp->onMouseDown(wParam,lParam,1); break;
 	case WM_RBUTTONDOWN: SetFocus(hwnd); rmbDown=true; ccp->onMouseDown(wParam,lParam,2); break;
@@ -304,13 +302,12 @@ void CtrlMemView::onVScroll(WPARAM wParam, LPARAM lParam)
 
 void CtrlMemView::onKeyDown(WPARAM wParam, LPARAM lParam)
 {
-	if (ctrlDown)
+	if (GetAsyncKeyState(VK_CONTROL))
 	{	
 		switch (tolower(wParam & 0xFFFF))
 		{
 		case 'g':
 			{
-				ctrlDown = false;
 				u32 addr;
 				if (executeExpressionWindow(wnd,debugger,addr) == false) return;
 				gotoAddr(addr);
@@ -347,9 +344,6 @@ void CtrlMemView::onKeyDown(WPARAM wParam, LPARAM lParam)
 	case VK_PRIOR:
 		scrollWindow(-visibleRows);
 		break;
-	case VK_CONTROL:
-		ctrlDown = true;
-		break;
 	case VK_TAB:
 		SendMessage(GetParent(wnd),WM_DEB_TABPRESSED,0,0);
 		break;
@@ -360,7 +354,7 @@ void CtrlMemView::onKeyDown(WPARAM wParam, LPARAM lParam)
 
 void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam)
 {
-	if (ctrlDown || wParam == VK_TAB) return;
+	if (GetAsyncKeyState(VK_CONTROL) || wParam == VK_TAB) return;
 
 	if (!Memory::IsValidAddress(curAddress))
 	{
@@ -584,7 +578,6 @@ void CtrlMemView::search(bool continueSearch)
 	u32 searchAddress;
 	if (continueSearch == false || searchQuery[0] == 0)
 	{
-		ctrlDown = false;
 		if (InputBox_GetString(GetModuleHandle(NULL),wnd,L"Search for", "",searchQuery) == false)
 		{
 			SetFocus(wnd);

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -37,7 +37,6 @@ class CtrlMemView
 	int asciiStart;
 	bool asciiSelected;
 	int selectedNibble;
-	bool ctrlDown;
 
 	int visibleRows;
 	

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -370,15 +370,11 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 			case ID_DEBUG_DSIPLAYREGISTERLIST:
-				TabCtrl_SetCurSel(GetDlgItem(m_hDlg, IDC_LEFTTABS),0);
-				ShowWindow(GetDlgItem(m_hDlg, IDC_REGLIST), SW_NORMAL);
-				ShowWindow(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), SW_HIDE);
+				leftTabs->ShowTab(0);
 				break;
 				
 			case ID_DEBUG_DSIPLAYFUNCTIONLIST:
-				TabCtrl_SetCurSel(GetDlgItem(m_hDlg, IDC_LEFTTABS),1);
-				ShowWindow(GetDlgItem(m_hDlg, IDC_REGLIST), SW_HIDE);
-				ShowWindow(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), SW_NORMAL);
+				leftTabs->ShowTab(1);
 				break;
 
 			case ID_DEBUG_ADDBREAKPOINT:
@@ -644,12 +640,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			memory->gotoAddr(wParam);
 			
 			// display the memory viewer too
-			HWND bp = GetDlgItem(m_hDlg, IDC_BREAKPOINTLIST);
-			HWND mem = GetDlgItem(m_hDlg, IDC_DEBUGMEMVIEW);
-			HWND threads = GetDlgItem(m_hDlg, IDC_THREADLIST);
-			ShowWindow(bp,SW_HIDE);
-			ShowWindow(mem,SW_NORMAL);
-			ShowWindow(threads,SW_HIDE);
+			bottomTabs->ShowTab(GetDlgItem(m_hDlg,IDC_DEBUGMEMVIEW));
 		}
 		break;
 	case WM_SIZE:


### PR DESCRIPTION
-fixed some instances where tabs were incorrectly handled
-fixed an issue where you couldn't enter text in the memory view after a search failed
-can now edit breakpoints in the disassembly with ctrl+e
-can now toggle the enable status of a breakpoint in the disassembly with ctrl+d
