### PR TITLE
fixed dPad visibility bug in layout screen

### DIFF
--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -310,7 +310,7 @@ void TouchControlLayoutScreen::CreateViews() {
 
 	controls_.push_back(actionButtons);
 
-	if (g_Config.bShowTouchCross) {
+	if (g_Config.bShowTouchDpad) {
 		controls_.push_back(new PSPDPadButtons(g_Config.iDpadX, g_Config.iDpadY, g_Config.iDpadRadius, scale));
 	}
 


### PR DESCRIPTION
simple bug. Don't know how this slipped past me. (Cross stands for the PSP cross button)
