### PR TITLE
add function symbol and remove function symbol added to DisAsm debugger view 

### DIFF
--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -45,6 +45,7 @@ public:
 	void SaveSymbolMap(const char *filename) const;
 	bool LoadNocashSym(const char *ilename);
 	void AddSymbol(const char *symbolname, unsigned int vaddress, size_t size, SymbolType symbol);
+	void RemoveSymbolNum(int symbolnum);
 	void Clear();
 	void AnalyzeBackwards();
 	int GetSymbolNum(unsigned int address, SymbolType symmask=ST_FUNCTION) const;
@@ -58,6 +59,7 @@ public:
 	int GetNumSymbols() const;
 	const char *GetSymbolName(int i) const;
 	void SetSymbolName(int i, const char *newname);
+	void SetSymbolSize(int i, int newSize);
 	u32 GetSymbolSize(int i) const;
 	u32 GetSymbolAddr(int i) const;
 	SymbolType GetSymbolType(int i) const;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1079,6 +1079,63 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				}
 			}
 			break;
+		case ID_DISASM_REMOVEFUNCTION:
+			{
+				char statusBarTextBuff[256];
+				int sym = symbolMap.GetSymbolNum(curAddress);
+				if (sym != -1)
+				{
+					u32 funcBegin = symbolMap.GetAddress(sym);
+					int prev = symbolMap.GetSymbolNum(funcBegin - 1);
+					if (prev != -1)
+					{
+						int expandedSize = symbolMap.GetSymbolSize(prev) + symbolMap.GetSymbolSize(sym);
+						symbolMap.SetSymbolSize(prev, expandedSize);
+					}
+					symbolMap.RemoveSymbolNum(sym);
+					SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
+				}
+				else
+				{
+					snprintf(statusBarTextBuff,256, "WARNING: unable to find function symbol here");
+					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+				}
+				redraw();
+			}
+			break;
+		case ID_DISASM_ADDFUNCTION:
+			{
+				char statusBarTextBuff[256];
+				int sym = symbolMap.GetSymbolNum(curAddress);
+				if (sym != -1)
+				{
+					if (symbolMap.GetAddress(sym) == curAddress)
+					{
+						snprintf(statusBarTextBuff,256, "WARNING: There's already a function entry point at this adress");
+						SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+					}
+					else
+					{
+						char symname[128];
+						int prevSize = symbolMap.GetSymbolSize(sym);
+						u32 prevAddr = symbolMap.GetSymbolAddr(sym);
+						int newSize = curAddress - prevAddr;
+						symbolMap.SetSymbolSize(sym, newSize);
+						newSize = prevSize - newSize;
+						snprintf(symname,128,"u_un_%08X",curAddress);
+						symbolMap.AddSymbol(symname, curAddress, newSize, ST_FUNCTION);
+						symbolMap.SortSymbols();
+						SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
+					}
+				}
+				else
+				{
+					snprintf(statusBarTextBuff, 256, "WARNING: unable to add function symbol here");
+					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+				}
+				redraw();
+			}
+			break;
 		case ID_DISASM_DISASSEMBLETOFILE:
 			disassembleToFile();
 			break;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1048,6 +1048,63 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				}
 			}
 			break;
+		case ID_DISASM_REMOVEFUNCTION:
+			{
+				char statusBarTextBuff[256];
+				int sym = symbolMap.GetSymbolNum(curAddress);
+				if (sym != -1)
+				{
+					u32 funcBegin = symbolMap.GetAddress(sym);
+					int prev = symbolMap.GetSymbolNum(funcBegin - 1);
+					if (prev != -1)
+					{
+						int expandedSize = symbolMap.GetSymbolSize(prev) + symbolMap.GetSymbolSize(sym);
+						symbolMap.SetSymbolSize(prev, expandedSize);
+					}
+					symbolMap.RemoveSymbolNum(sym);
+					SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
+				}
+				else
+				{
+					snprintf(statusBarTextBuff,256, "WARNING: unable to find function symbol here");
+					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+				}
+				redraw();
+			}
+			break;
+		case ID_DISASM_ADDFUNCTION:
+			{
+				char statusBarTextBuff[256];
+				int sym = symbolMap.GetSymbolNum(curAddress);
+				if (sym != -1)
+				{
+					if (symbolMap.GetAddress(sym) == curAddress)
+					{
+						snprintf(statusBarTextBuff,256, "WARNING: There's already a function entry point at this adress");
+						SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+					}
+					else
+					{
+						char symname[128];
+						int prevSize = symbolMap.GetSymbolSize(sym);
+						u32 prevAddr = symbolMap.GetSymbolAddr(sym);
+						int newSize = curAddress - prevAddr;
+						symbolMap.SetSymbolSize(sym, newSize);
+						newSize = prevSize - newSize;
+						snprintf(symname,128,"u_un_%08X",curAddress);
+						symbolMap.AddSymbol(symname, curAddress, newSize, ST_FUNCTION);
+						symbolMap.SortSymbols();
+						SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
+					}
+				}
+				else
+				{
+					snprintf(statusBarTextBuff, 256, "WARNING: unable to add function symbol here");
+					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+				}
+				redraw();
+			}
+			break;
 		case ID_DISASM_DISASSEMBLETOFILE:
 			disassembleToFile();
 			break;

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -524,7 +524,9 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Kill Function",              ID_DISASM_ADDHLE
         MENUITEM "Rename Function...",         ID_DISASM_RENAMEFUNCTION
-    END
+		MENUITEM "Remove Function",            ID_DISASM_REMOVEFUNCTION
+		MENUITEM "Add Function here",          ID_DISASM_ADDFUNCTION
+		END
     POPUP "funclist"
     BEGIN
         MENUITEM "Kill Function",              ID_FUNCLIST_KILLFUNCTION

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -297,6 +297,9 @@
 #define ID_OPTIONS_PAUSE_FOCUS           40136
 #define ID_TEXTURESCALING_AUTO           40137
 #define IDC_GEDBG_STEPPRIM               40138
+#define ID_DISASM_ADDFUNCTION            40139
+#define ID_DISASM_REMOVEFUNCTION         40140
+
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
Right click adds these two options.

Before merging consider that this uses the status bar to output failure conditions `SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);`

Also, the math for symbol insertion is done in the view class `int newSize = curAddress - prevAddr;`. Can be moved to an `InsertSymbol` function in the symbolMap but I wrote this before I made the modifications in the symbol map. So if this is wished before the merge, just comment underneath.

I don't particularly enjoy the `char statusBarTextBuff[256];` allocations everywhere, as the magic numbers are questionable but it's used in the surrounding code, so I just used it.

Last point of discussion would be default name "u_un_%08X" for new user placed function symbols.

As always, if this isn't considered useful for the project, feel free to reject.

![image](https://f.cloud.github.com/assets/465677/1438225/f73b13ce-4179-11e3-89f6-5443cbb1cc20.png)
