### PR TITLE
created auto load feature

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -72,6 +72,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	general->Get("Language", &sLanguageIni, defaultLangRegion.c_str());
 	general->Get("NumWorkerThreads", &iNumWorkerThreads, cpu_info.num_cores);
+	general->Get("EnableAutoLoad", &bEnableAutoLoad, true);
 	general->Get("EnableCheats", &bEnableCheats, false);
 	general->Get("ScreenshotsAsPNG", &bScreenshotsAsPNG, false);
 	general->Get("StateSlot", &iCurrentStateSlot, 0);
@@ -336,6 +337,7 @@ void Config::Save() {
 #endif
 		general->Set("Language", sLanguageIni);
 		general->Set("NumWorkerThreads", iNumWorkerThreads);
+		general->Set("EnableAutoLoad", bEnableAutoLoad);
 		general->Set("EnableCheats", bEnableCheats);
 		general->Set("ScreenshotsAsPNG", bScreenshotsAsPNG);
 		general->Set("StateSlot", iCurrentStateSlot);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -72,7 +72,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	general->Get("Language", &sLanguageIni, defaultLangRegion.c_str());
 	general->Get("NumWorkerThreads", &iNumWorkerThreads, cpu_info.num_cores);
-	general->Get("EnableAutoLoad", &bEnableAutoLoad, true);
+	general->Get("EnableAutoLoad", &bEnableAutoLoad, false);
 	general->Get("EnableCheats", &bEnableCheats, false);
 	general->Get("ScreenshotsAsPNG", &bScreenshotsAsPNG, false);
 	general->Get("StateSlot", &iCurrentStateSlot, 0);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -92,6 +92,7 @@ public:
 	int iForceMaxEmulatedFPS;
 	int iMaxRecent;
 	int iCurrentStateSlot;
+	bool bEnableAutoLoad;
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bDisableStencilTest;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -246,7 +246,7 @@ namespace SaveState
 		return false;
 	}
 
-	int GetMostRecentSaveSlot() {
+	int GetNewestSlot() {
 		int newestSlot = -1;
 		tm newestDate = {0};
 		for (int i = 0; i < SAVESTATESLOTS; i++) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -626,7 +626,7 @@ void EmuScreen::deviceLost() {
 		gpu->DeviceLost();
 }
 
-void EmuScreen::autoLoad(){
+void EmuScreen::autoLoad() {
 	//check if save state has save, if so, load
 	int lastSlot = SaveState::GetNewestSlot();
 	if (g_Config.bEnableAutoLoad && lastSlot != -1) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -41,6 +41,7 @@
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceDisplay.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Core/SaveState.h"
 
 #include "UI/OnScreenDisplay.h"
 #include "UI/ui_atlas.h"
@@ -122,6 +123,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 	if (strstr(renderer, "Chainfire3D") != 0) {
 		osm.Show(s->T("Chainfire3DWarning", "WARNING: Chainfire3D detected, may cause problems"), 10.0f, 0xFF30a0FF, -1, true);
 	}
+
+	autoLoad();
 }
 
 EmuScreen::~EmuScreen() {
@@ -138,6 +141,13 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	if (result == DR_OK) {
 		screenManager()->switchScreen(new MainScreen());
 	}
+	
+	//user didn't click continue. he went back to the main screen and is loading 
+	//the game from there.
+	if(result != DR_CANCEL && result != DR_BACK){
+		autoLoad();
+	}
+
 	RecreateViews();
 }
 
@@ -620,3 +630,10 @@ void EmuScreen::deviceLost() {
 	if (gpu)
 		gpu->DeviceLost();
 }
+
+void EmuScreen::autoLoad(){
+	//check if save state has save, if so, load
+	if(g_Config.bEnableAutoLoad && SaveState::HasSaveInSlot(g_Config.iCurrentStateSlot)){
+		SaveState::LoadSlot(g_Config.iCurrentStateSlot, 0, 0);
+	}
+};

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -142,13 +142,6 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	if (result == DR_OK) {
 		screenManager()->switchScreen(new MainScreen());
 	}
-	
-	//user didn't click continue. he went back to the main screen and is loading 
-	//the game from there.
-	/*
-	if (result != DR_CANCEL && result != DR_BACK){
-		autoLoad();
-	}*/
 
 	RecreateViews();
 }
@@ -636,7 +629,7 @@ void EmuScreen::deviceLost() {
 void EmuScreen::autoLoad(){
 	//check if save state has save, if so, load
 	int lastSlot = SaveState::GetNewestSlot();
-	if (g_Config.bEnableAutoLoad && lastSlot != -1){
+	if (g_Config.bEnableAutoLoad && lastSlot != -1) {
 		SaveState::LoadSlot(lastSlot, 0, 0);
 	}
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -144,7 +144,7 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	
 	//user didn't click continue. he went back to the main screen and is loading 
 	//the game from there.
-	if(result != DR_CANCEL && result != DR_BACK){
+	if (result != DR_CANCEL && result != DR_BACK){
 		autoLoad();
 	}
 
@@ -633,7 +633,7 @@ void EmuScreen::deviceLost() {
 
 void EmuScreen::autoLoad(){
 	//check if save state has save, if so, load
-	if(g_Config.bEnableAutoLoad && SaveState::HasSaveInSlot(g_Config.iCurrentStateSlot)){
+	if (g_Config.bEnableAutoLoad && SaveState::HasSaveInSlot(g_Config.iCurrentStateSlot)){
 		SaveState::LoadSlot(g_Config.iCurrentStateSlot, 0, 0);
 	}
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -110,6 +110,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 	g_gameInfoCache.FlushBGs();
 
 	NOTICE_LOG(BOOT, "Loading %s...", fileToStart.c_str());
+	autoLoad();
+
 	I18NCategory *s = GetI18NCategory("Screen"); 
 
 #ifdef _WIN32
@@ -124,7 +126,6 @@ void EmuScreen::bootGame(const std::string &filename) {
 		osm.Show(s->T("Chainfire3DWarning", "WARNING: Chainfire3D detected, may cause problems"), 10.0f, 0xFF30a0FF, -1, true);
 	}
 
-	autoLoad();
 }
 
 EmuScreen::~EmuScreen() {
@@ -144,9 +145,10 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	
 	//user didn't click continue. he went back to the main screen and is loading 
 	//the game from there.
+	/*
 	if (result != DR_CANCEL && result != DR_BACK){
 		autoLoad();
-	}
+	}*/
 
 	RecreateViews();
 }
@@ -633,7 +635,8 @@ void EmuScreen::deviceLost() {
 
 void EmuScreen::autoLoad(){
 	//check if save state has save, if so, load
-	if (g_Config.bEnableAutoLoad && SaveState::HasSaveInSlot(g_Config.iCurrentStateSlot)){
-		SaveState::LoadSlot(g_Config.iCurrentStateSlot, 0, 0);
+	int lastSlot = SaveState::GetNewestSlot();
+	if (g_Config.bEnableAutoLoad && lastSlot != -1){
+		SaveState::LoadSlot(lastSlot, 0, 0);
 	}
 };

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -55,6 +55,8 @@ private:
 	void setVKeyAnalogX(int stick, int virtualKeyMin, int virtualKeyMax);
 	void setVKeyAnalogY(int stick, int virtualKeyMin, int virtualKeyMax);
 
+	void autoLoad();
+	
 	bool booted_;
 	std::string gamePath_;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -264,7 +264,7 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new Choice(s->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
 	systemSettings->Add(new Choice(s->T("Clear Recent Games List")))->OnClick.Handle(this, &GameSettingsScreen::OnClearRecents);
 	systemSettings->Add(new Choice(s->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
-	systemSettings->Add(new CheckBox(&g_Config.bEnableAutoLoad, s->T("Enable Auto Load")));
+	systemSettings->Add(new CheckBox(&g_Config.bEnableAutoLoad, s->T("Auto Load Newest Savestate")));
 	enableReportsCheckbox_ = new CheckBox(&enableReports_, s->T("Enable Compatibility Server Reports"));
 	enableReportsCheckbox_->SetEnabled(Reporting::IsSupported());
 	systemSettings->Add(enableReportsCheckbox_);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -264,6 +264,7 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new Choice(s->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
 	systemSettings->Add(new Choice(s->T("Clear Recent Games List")))->OnClick.Handle(this, &GameSettingsScreen::OnClearRecents);
 	systemSettings->Add(new Choice(s->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
+	systemSettings->Add(new CheckBox(&g_Config.bEnableAutoLoad, s->T("Enable Auto Load")));
 	enableReportsCheckbox_ = new CheckBox(&enableReports_, s->T("Enable Compatibility Server Reports"));
 	enableReportsCheckbox_->SetEnabled(Reporting::IsSupported());
 	systemSettings->Add(enableReportsCheckbox_);


### PR DESCRIPTION
It was pretty trivial to implement.

As soon as a game is selected, if auto load is enabled, it calls SaveState::Load based on the **currently selected save slot**. This is somewhat of a problem since the save slot is global, not per-game. However, I'm not sure what the better solution is. 

Please tell me a better per-game solution if there is one.

Thanks,
bollu  
