### PR TITLE
Improve the texcache hash (sse only) and sse texcache color conv

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -53,14 +53,14 @@ TextureCache::TextureCache() : clearCacheNextFrame_(false), lowMemoryMode_(false
 	tmpTexBuf32.resize(1024 * 512);  // 2MB
 	tmpTexBuf16.resize(1024 * 512);  // 1MB
 	tmpTexBufRearrange.resize(1024 * 512);   // 2MB
-	clutBufConverted_ = new u32[4096];  // 16KB
-	clutBufRaw_ = new u32[4096];  // 16KB
+	clutBufConverted_ = (u32 *)AllocateAlignedMemory(4096 * sizeof(u32), 16);  // 16KB
+	clutBufRaw_ = (u32 *)AllocateAlignedMemory(4096 * sizeof(u32), 16);  // 16KB
 	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropyLevel);
 }
 
 TextureCache::~TextureCache() {
-	delete [] clutBufConverted_;
-	delete [] clutBufRaw_;
+	FreeAlignedMemory(clutBufConverted_);
+	FreeAlignedMemory(clutBufRaw_);
 }
 
 void TextureCache::Clear(bool delete_them) {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -681,8 +681,7 @@ static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, GETextureFormat
 	u32 check = 0;
 
 #ifdef _M_SSE
-	// Make sure both the size and start are aligned, OR will get either.
-	if ((((u32)(intptr_t)checkp | sizeInRAM) & 0x3f) == 0) {
+	if (((intptr_t)checkp & 0xf) == 0 && (sizeInRAM & 0x3f) == 0) {
 		__m128i cursor = _mm_set1_epi32(0);
 		__m128i cursor2 = _mm_set_epi16(0x0001U, 0x0083U, 0x4309U, 0x4d9bU, 0xb651U, 0x4b73U, 0x9bd9U, 0xc00bU);
 		__m128i update = _mm_set1_epi16(0x2455U);

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -532,20 +532,18 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 	case GL_UNSIGNED_SHORT_4_4_4_4:
 		{
 #ifdef _M_SSE
-			const __m128i maskA = _mm_set1_epi32(0x000F000F);
-			const __m128i maskB = _mm_set1_epi32(0x00F000F0);
-			const __m128i maskG = _mm_set1_epi32(0x0F000F00);
-			const __m128i maskR = _mm_set1_epi32(0xF000F000);
+			const __m128i maskB = _mm_set1_epi16(0x00F0);
+			const __m128i maskG = _mm_set1_epi16(0x0F00);
 
 			__m128i *srcp = (__m128i *)src;
 			__m128i *dstp = (__m128i *)dst;
 			const int sseChunks = numPixels / 8;
 			for (int i = 0; i < sseChunks; ++i) {
 				__m128i c = _mm_load_si128(&srcp[i]);
-				__m128i v = _mm_and_si128(_mm_srli_epi32(c, 12), maskA);
-				v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi32(c, 4), maskB));
-				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi32(c, 4), maskG));
-				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi32(c, 12), maskR));
+				__m128i v = _mm_srli_epi16(c, 12);
+				v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi16(c, 4), maskB));
+				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi16(c, 4), maskG));
+				v = _mm_or_si128(v, _mm_slli_epi16(c, 12));
 				_mm_store_si128(&dstp[i], v);
 			}
 			// The remainder is done in chunks of 2, SSE was chunks of 8.
@@ -566,20 +564,18 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 	case GL_UNSIGNED_SHORT_5_5_5_1:
 		{
 #ifdef _M_SSE
-			const __m128i maskA = _mm_set1_epi32(0x00010001);
-			const __m128i maskB = _mm_set1_epi32(0x003E003E);
-			const __m128i maskG = _mm_set1_epi32(0x07C007C0);
-			const __m128i maskR = _mm_set1_epi32(0xF800F800);
+			const __m128i maskB = _mm_set1_epi16(0x003E);
+			const __m128i maskG = _mm_set1_epi16(0x07C0);
 
 			__m128i *srcp = (__m128i *)src;
 			__m128i *dstp = (__m128i *)dst;
 			const int sseChunks = numPixels / 8;
 			for (int i = 0; i < sseChunks; ++i) {
 				__m128i c = _mm_load_si128(&srcp[i]);
-				__m128i v = _mm_and_si128(_mm_srli_epi32(c, 15), maskA);
-				v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi32(c, 9), maskB));
-				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi32(c, 1), maskG));
-				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi32(c, 11), maskR));
+				__m128i v = _mm_srli_epi16(c, 15);
+				v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi16(c, 9), maskB));
+				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi16(c, 1), maskG));
+				v = _mm_or_si128(v, _mm_slli_epi16(c, 11));
 				_mm_store_si128(&dstp[i], v);
 			}
 			// The remainder is done in chunks of 2, SSE was chunks of 8.
@@ -599,18 +595,16 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 	case GL_UNSIGNED_SHORT_5_6_5:
 		{
 #ifdef _M_SSE
-			const __m128i maskB = _mm_set1_epi32(0x001F001F);
-			const __m128i maskG = _mm_set1_epi32(0x07E007E0);
-			const __m128i maskR = _mm_set1_epi32(0xF800F800);
+			const __m128i maskG = _mm_set1_epi16(0x07E0);
 
 			__m128i *srcp = (__m128i *)src;
 			__m128i *dstp = (__m128i *)dst;
 			const int sseChunks = numPixels / 8;
 			for (int i = 0; i < sseChunks; ++i) {
 				__m128i c = _mm_load_si128(&srcp[i]);
-				__m128i v = _mm_and_si128(_mm_srli_epi32(c, 11), maskB);
+				__m128i v = _mm_srli_epi16(c, 11);
 				v = _mm_or_si128(v, _mm_and_si128(c, maskG));
-				v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi32(c, 11), maskR));
+				v = _mm_or_si128(v, _mm_slli_epi16(c, 11));
 				_mm_store_si128(&dstp[i], v);
 			}
 			// The remainder is done in chunks of 2, SSE was chunks of 8.


### PR DESCRIPTION
This texture hash doesn't seem much slower (@solarmystic, would appreciate confirmation on older hardware), and seems stronger.  Unfortunately, it makes it different from the generic / Android implementation, but that would be much slower if I changed it too.

I'm thinking of doing a NEON library/detection thing sometime soon, but expecting it to be annoying...

Also wrote the color swapping in SSE, it's faster for sure (43%?), which does seem to help FF2 for me.

This may possibly help #2673, but I don't know specifically if it does.  It definitely helps Tales of Phantasia X.  So far I have not noticed any glitches.

-[Unknown]
