### PR TITLE
Use GL_EXT_unpack_subimage to speed up non-pow-2 texture loads when available

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1248,7 +1248,7 @@ void *TextureCache::DecodeTextureLevel(GETextureFormat format, GEPaletteFormat c
 	case GE_TFMT_8888:
 		if (!gstate.isTextureSwizzled()) {
 			// Special case: if we don't need to deal with packing, we don't need to copy.
-			if (w == bufw) {
+			if (gl_extensions.EXT_unpack_subimage || w == bufw) {
 				finalBuf = Memory::GetPointer(texaddr);
 			} else {
 				int len = bufw * h;
@@ -1262,7 +1262,6 @@ void *TextureCache::DecodeTextureLevel(GETextureFormat format, GEPaletteFormat c
 			tmpTexBuf32.resize(std::max(bufw, w) * h);
 			finalBuf = UnswizzleFromMem(texaddr, bufw, 4, level);
 		}
-		ConvertColors(finalBuf, finalBuf, dstFmt, bufw * h);
 		break;
 
 	case GE_TFMT_DXT1:

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1444,12 +1444,10 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level, bool replac
 	bool useUnpack = false;
 	if (gl_extensions.EXT_unpack_subimage && w != bufw) {
 		glPixelStorei(GL_UNPACK_ROW_LENGTH, bufw);
-		glPixelStorei(GL_PACK_ROW_LENGTH, bufw);
 		useUnpack = true;
 	}
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT, texByteAlign);
-	glPixelStorei(GL_PACK_ALIGNMENT, texByteAlign);
 
 	int scaleFactor;
 	//Auto-texture scale upto 5x rendering resolution
@@ -1492,7 +1490,6 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level, bool replac
 
 	if (useUnpack) {
 		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-		glPixelStorei(GL_PACK_ROW_LENGTH, 0);
 	}
 }
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -118,7 +118,7 @@ private:
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, GLenum dstFmt);
 	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, GLenum dstFmt);
+	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, GLenum dstFmt, int *bufw = 0);
 	void CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFmt, int w, int h);
 	template <typename T>
 	const T *GetCurrentClut();


### PR DESCRIPTION
Unpacksubimage is supported on all OpenGL ES 3.0 capable chips and actually quite a few OpenGL ES 2.0 too, like Tegra. This lets us skip the rearranging step for non-pow2-sized textures.

I'm planning to merge this after 0.9.5, who knows what driver bugs we might unearth.
