### PR TITLE
Attempt to go back to the earliest logic of finding a matching framebuffer

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -659,39 +659,17 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	int buffer_width = drawing_width;
 	int buffer_height = drawing_height;
 
-	// Find a matching framebuffer, same size or bigger
+	// Find a matching framebuffer
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address)) {
-			// Okay, let's check the sizes. If the new one is bigger than the old one, recreate.
-			// If the opposite, just use it and hope that the game sets scissors accordingly.
-			if (v->bufferWidth >= drawing_width && v->bufferHeight >= drawing_height) {
-				// Let's not be so picky for now. Let's say this is the one.
-				vfb = v;
-				// Update fb stride in case it changed
-				vfb->fb_stride = fb_stride;
-				v->format = fmt;
-				// Just hack the width/height and we should be fine. also hack renderwidth/renderheight?
-				v->width = drawing_width;
-				v->height = drawing_height;
-				break;
-			} else {
-				INFO_LOG(HLE, "Enlarging framebuffer from (%i, %i) to (%i, %i)", (int)v->width, (int)v->height, drawing_width, drawing_height);
-				// drawing_width or drawing_height is bigger. Let's recreate with the max.
-				// To do this right we should copy the data over too, but meh.
-				if ((int)v->width >= drawing_width && (int)v->height >= drawing_height) {
-					buffer_width = (int)v->width;
-					buffer_height = (int)v->height;
-				} else {
-					buffer_width = drawing_width;
-					buffer_height = drawing_height;
-				}
-
-				DestroyFramebuf(v);
-				vfbs_.erase(vfbs_.begin() + i--);
-				break;
-			}
+		if (MaskedEqual(v->fb_address, fb_address) && v->width >= drawing_width && v->height >= drawing_height) {
+			// Let's not be so picky for now. Let's say this is the one.
+			vfb = v;
+			// Update fb stride in case it changed
+			vfb->fb_stride = fb_stride;
+			v->format = fmt;
+			break;
 		}
 	}
 


### PR DESCRIPTION
Looks like at the very beginning , we're trying to test out the new logic of matching framebuffer to fix some games .I tried to go back to the very original logic to see if it still works right now . Surprisingly , it fixes few framebuffer sizing issues in games (Wildarm XF, Midnight club 3 etc) and also good for Kingdom heart that we may concern .

All those problem games with framebuffer sizing previously also tested and worked okay .May be @solarmystic can help quick test as well .

Fixes Wilarm XF 
![screen00020](https://f.cloud.github.com/assets/3000282/1458230/069158b0-435a-11e3-86ef-68707536c057.jpg)

Fixes Midnight Club 3
![screen00022](https://f.cloud.github.com/assets/3000282/1458231/09935bee-435a-11e3-8326-6afae4f12df0.jpg)

Kingdom Heart still good with shadow and map
![screen00021](https://f.cloud.github.com/assets/3000282/1458232/0f1992fe-435a-11e3-9ba1-d5566d8b51a7.jpg)
