### PR TITLE
Implemented DELETEDATA mode of saveDialog.

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -924,10 +924,8 @@ int PSPSaveDialog::Update(int animSpeed)
 					}
 				break;
 				case SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA:
-					// TODO: This should probably actually delete something.
-					// For now, always say it couldn't be deleted.
-					WARN_LOG(SCEUTILITY, "FAKE sceUtilitySavedata DELETEDATA: %s", param.GetPspParam()->saveName);
-					param.GetPspParam()->common.result = SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_STATUS;
+					DEBUG_LOG(SCEUTILITY, "FAKE sceUtilitySavedata DELETEDATA: %s", param.GetPspParam()->saveName);
+					param.GetPspParam()->common.result = param.DeleteData(param.GetPspParam());
 					status = SCE_UTILITY_STATUS_FINISHED;
 				break;
 				//case SCE_UTILITY_SAVEDATA_TYPE_AUTODELETE:

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -261,6 +261,20 @@ bool SavedataParam::Delete(SceUtilitySavedataParam* param, int saveId)
 	return true;
 }
 
+int  SavedataParam::DeleteData(SceUtilitySavedataParam* param) {
+	if(!param)
+		return SCE_UTILITY_SAVEDATA_ERROR_DELETE_NO_DATA;
+	if (param->fileName == NULL)
+		return SCE_UTILITY_SAVEDATA_ERROR_DELETE_NO_DATA;
+
+	std::string filename = savePath + GetGameName(param) + GetSaveName(param) + "/" + param->fileName;
+	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
+	if (info.exists)
+		pspFileSystem.RemoveFile(filename);
+
+	return 0;
+}
+
 bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode)
 {
 	if (!param) {

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -296,6 +296,7 @@ public:
 	std::string GetSaveDir(SceUtilitySavedataParam* param, int saveId = -1);
 	std::string GetSaveDir(SceUtilitySavedataParam* param, const std::string &saveDirName);
 	bool Delete(SceUtilitySavedataParam* param, int saveId = -1);
+	int DeleteData(SceUtilitySavedataParam* param);
 	bool Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode = true);
 	bool Load(SceUtilitySavedataParam* param, const std::string &saveDirName, int saveId = -1, bool secureMode = true);
 	int GetSizes(SceUtilitySavedataParam* param);


### PR DESCRIPTION
In FF4,when you reinstall the gamedata(this means you have had gamedata in memstick),the game will ask you `Would you like to replace this previous data?`,select yes,the game will call DELETEDATA mode.Now only return `Error code:8011032c`.
