### PR TITLE
Change "goto in memory view" behavior

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -994,9 +994,7 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,1),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
 		{
 		case ID_DISASM_GOTOINMEMORYVIEW:
-			for (int i=0; i<numCPUs; i++)
-				if (memoryWindow[i])
-					memoryWindow[i]->Goto(curAddress);
+			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,curAddress,0);
 			break;
 		case ID_DISASM_ADDHLE:
 			break;

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -534,9 +534,7 @@ void CtrlRegisterList::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,3),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
 		{
 		case ID_REGLIST_GOTOINMEMORYVIEW:
-			for (int i=0; i<numCPUs; i++)
-				if (memoryWindow[i])
-					memoryWindow[i]->Goto(val);
+			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,val,0);
 			break;
 		case ID_REGLIST_GOTOINDISASM:
 			for (int i=0; i<numCPUs; i++)


### PR DESCRIPTION
Previously this would open the memory view dialog. But with the disassembly having a tab dedicated to that, I think it makes more sense to use its own memory view.
