### PR TITLE
Avoid CallSyscall() overhead from jit

### DIFF
--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -123,7 +123,14 @@ void XEmitter::ABI_CallFunctionCCCP(void *func, u32 param1, u32 param2,u32 param
 	ABI_RestoreStack(4 * 4);
 }
 
-void XEmitter::ABI_CallFunctionPPC(void *func, void *param1, void *param2,u32 param3) {
+void XEmitter::ABI_CallFunctionP(void *func, void *param1) {
+	ABI_AlignStack(1 * 4);
+	PUSH(32, Imm32((u32)param1));
+	CALL(func);
+	ABI_RestoreStack(1 * 4);
+}
+
+void XEmitter::ABI_CallFunctionPPC(void *func, void *param1, void *param2, u32 param3) {
 	ABI_AlignStack(3 * 4);
 	PUSH(32, Imm32(param3));
 	PUSH(32, Imm32((u32)param2));
@@ -341,6 +348,19 @@ void XEmitter::ABI_CallFunctionCCCP(void *func, u32 param1, u32 param2, u32 para
 	MOV(32, R(ABI_PARAM2), Imm32(param2));
 	MOV(32, R(ABI_PARAM3), Imm32(param3));
 	MOV(64, R(ABI_PARAM4), Imm64((u64)param4));
+	u64 distance = u64(func) - (u64(code) + 5);
+	if (distance >= 0x0000000080000000ULL
+	 && distance <  0xFFFFFFFF80000000ULL) {
+	    // Far call
+	    MOV(64, R(RAX), Imm64((u64)func));
+	    CALLptr(R(RAX));
+	} else {
+	    CALL(func);
+	}
+}
+
+void XEmitter::ABI_CallFunctionP(void *func, void *param1) {
+	MOV(64, R(ABI_PARAM1), Imm64((u64)param1));
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL
 	 && distance <  0xFFFFFFFF80000000ULL) {

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -677,8 +677,9 @@ public:
 	void ABI_CallFunctionCC(void *func, u32 param1, u32 param2);
 	void ABI_CallFunctionCCC(void *func, u32 param1, u32 param2, u32 param3);
 	void ABI_CallFunctionCCP(void *func, u32 param1, u32 param2, void *param3);
-	void ABI_CallFunctionCCCP(void *func, u32 param1, u32 param2,u32 param3, void *param4);
-	void ABI_CallFunctionPPC(void *func, void *param1, void *param2,u32 param3);
+	void ABI_CallFunctionCCCP(void *func, u32 param1, u32 param2, u32 param3, void *param4);
+	void ABI_CallFunctionP(void *func, void *param1);
+	void ABI_CallFunctionPPC(void *func, void *param1, void *param2, u32 param3);
 	void ABI_CallFunctionAC(void *func, const Gen::OpArg &arg1, u32 param2);
 	void ABI_CallFunctionACC(void *func, const Gen::OpArg &arg1, u32 param2, u32 param3);
 	void ABI_CallFunctionA(void *func, const Gen::OpArg &arg1);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -507,20 +507,21 @@ void CallSyscall(MIPSOpcode op)
 		start = time_now_d();
 	}
 	const HLEFunction *info = GetSyscallInfo(op);
-	if (info)
+	if (!info)
+		return;
+
+	if (info->func)
 	{
-		if (info->func)
-		{
-			if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
-				info->func();
-			else if (info->flags != 0)
-				CallSyscallWithFlags(info);
-			else
-				CallSyscallWithoutFlags(info);
-		}
+		if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
+			info->func();
+		else if (info->flags != 0)
+			CallSyscallWithFlags(info);
 		else
-			ERROR_LOG_REPORT(HLE, "Unimplemented HLE function %s", info->name);
+			CallSyscallWithoutFlags(info);
 	}
+	else
+		ERROR_LOG_REPORT(HLE, "Unimplemented HLE function %s", info->name);
+
 	if (g_Config.bShowDebugStats)
 	{
 		time_update();

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -120,3 +120,8 @@ bool WriteSyscall(const char *module, u32 nib, u32 address);
 void CallSyscall(MIPSOpcode op);
 void WriteFuncStub(u32 stubAddr, u32 symAddr);
 void WriteFuncMissingStub(u32 stubAddr, u32 nid);
+
+const HLEFunction *GetSyscallInfo(MIPSOpcode op);
+// For jit, takes arg: const HLEFunction *
+void *GetQuickSyscallFunc(MIPSOpcode op);
+

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -108,11 +108,11 @@ void sceKernelIsCpuIntrEnable()
 	RETURN(retVal);
 }
 
-void sceKernelIsCpuIntrSuspended()
+int sceKernelIsCpuIntrSuspended(int flag)
 {
-	u32 retVal = !__InterruptsEnabled(); 
-	DEBUG_LOG(SCEINTC, "%i=sceKernelIsCpuIntrSuspended()", retVal);
-	RETURN(retVal);
+	int retVal = flag == 0 ? 1 : 0;
+	DEBUG_LOG(SCEINTC, "%i=sceKernelIsCpuIntrSuspended(%d)", retVal, flag);
+	return retVal;
 }
 
 void sceKernelCpuResumeIntrWithSync(u32 enable)
@@ -588,7 +588,7 @@ const HLEFunction Kernel_Library[] =
 	{0x092968F4,sceKernelCpuSuspendIntr, "sceKernelCpuSuspendIntr"},
 	{0x5F10D406,WrapV_U<sceKernelCpuResumeIntr>, "sceKernelCpuResumeIntr"}, //int oldstat
 	{0x3b84732d,WrapV_U<sceKernelCpuResumeIntrWithSync>, "sceKernelCpuResumeIntrWithSync"},
-	{0x47a0b729,sceKernelIsCpuIntrSuspended, "sceKernelIsCpuIntrSuspended"}, //flags
+	{0x47a0b729,WrapI_I<sceKernelIsCpuIntrSuspended>, "sceKernelIsCpuIntrSuspended"}, //flags
 	{0xb55249d2,sceKernelIsCpuIntrEnable, "sceKernelIsCpuIntrEnable"},
 	{0xa089eca4,WrapU_UUU<sceKernelMemset>, "sceKernelMemset"},
 	{0xDC692EE3,WrapI_UI<sceKernelTryLockLwMutex>, "sceKernelTryLockLwMutex"},

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1338,7 +1338,8 @@ bool __KernelSwitchToThread(SceUID threadID, const char *reason)
 
 void __KernelIdle()
 {
-	hleSkipDeadbeef();
+	// Don't skip 0xDEADBEEF here, this is called directly bypassing CallSyscall().
+	// That means the hle flag would stick around until the next call.
 
 	CoreTiming::Idle();
 	// Advance must happen between Idle and Reschedule, so that threads that were waiting for something

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -425,9 +425,13 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	js.downcountAmount = -offset;
 
 	SaveDowncount();
-	// Skip the CallSyscall overhead for __KernelIdle, which is called a lot.
-	if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
-		QuickCallFunction(R1, (void *)GetFunc("FakeSysCalls", NID_IDLE)->func);
+	// Skip the CallSyscall where possible.
+	void *quickFunc = GetQuickSyscallFunc(op);
+	if (quickFunc)
+	{
+		MOVI2R(R0, (u32)(intptr_t)GetSyscallInfo(op));
+		QuickCallFunction(R1, quickFunc);
+	}
 	else
 	{
 		MOVI2R(R0, op.encoding);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -22,15 +22,15 @@
 #include "math/math_util.h"
 
 #include "Common/Common.h"
-#include "../Core.h"
-#include "MIPS.h"
-#include "MIPSInt.h"
-#include "MIPSTables.h"
+#include "Core/Core.h"
+#include "Core/MIPS/MIPS.h"
+#include "Core/MIPS/MIPSInt.h"
+#include "Core/MIPS/MIPSTables.h"
 #include "Core/Reporting.h"
 #include "Core/Config.h"
-
-#include "../HLE/HLE.h"
-#include "../System.h"
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/HLETables.h"
+#include "Core/System.h"
 
 #define R(i) (currentMIPS->r[i])
 #define F(i) (currentMIPS->f[i])
@@ -159,7 +159,10 @@ namespace MIPSInt
 			mipsr4k.pc += 4;
 		}
 		mipsr4k.inDelaySlot = false;
-		CallSyscall(op);
+		if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
+			GetFunc("FakeSysCalls", NID_IDLE)->func();
+		else
+			CallSyscall(op);
 	}
 
 	void Int_Sync(MIPSOpcode op)

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -159,10 +159,7 @@ namespace MIPSInt
 			mipsr4k.pc += 4;
 		}
 		mipsr4k.inDelaySlot = false;
-		if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
-			GetFunc("FakeSysCalls", NID_IDLE)->func();
-		else
-			CallSyscall(op);
+		CallSyscall(op);
 	}
 
 	void Int_Sync(MIPSOpcode op)

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -634,9 +634,10 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	WriteDowncount(offset);
 	js.downcountAmount = -offset;
 
-	// Skip the CallSyscall overhead for __KernelIdle, which is called a lot.
-	if (op == GetSyscallOp("FakeSysCalls", NID_IDLE))
-		ABI_CallFunction((void *)GetFunc("FakeSysCalls", NID_IDLE)->func);
+	// Skip the CallSyscall where possible.
+	void *quickFunc = GetQuickSyscallFunc(op);
+	if (quickFunc)
+		ABI_CallFunctionP(quickFunc, (void *)GetSyscallInfo(op));
 	else
 		ABI_CallFunctionC((void *)&CallSyscall, op.encoding);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -41,6 +41,7 @@
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceDisplay.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
 
 #include "UI/OnScreenDisplay.h"
 #include "UI/ui_atlas.h"
@@ -186,6 +187,11 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	}
 	else if (!strcmp(message, "gpu dump next frame")) {
 		if (gpu) gpu->DumpNextFrame();
+	}
+	if (!strcmp(message, "clear jit")) {
+		if (MIPSComp::jit) {
+			MIPSComp::jit->ClearCache();
+		}
 	}
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -74,6 +74,7 @@ private:
 	bool cap60FPS_;
 	int iAlternateSpeedPercent_;
 	bool enableReports_;
+	bool showDebugStats_;
 };
 
 /*

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -843,22 +843,10 @@ UI::EventReturn GamePauseScreen::OnCwCheat(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn GamePauseScreen::OnLanguageChange(UI::EventParams &e) {
-	RecreateViews();
-	if (host) {
-		host->UpdateUI();
-	}
-
-	return UI::EVENT_DONE;
-}
-
 void GamePauseScreen::sendMessage(const char *message, const char *value) {
 	// Since the language message isn't allowed to be in native, we have to have add this
 	// to every screen which directly inherits from UIScreen(which are few right now, luckily).
-	I18NCategory *de = GetI18NCategory("Developer");
-	if (!strcmp(message, "language screen")) {
-		auto langScreen = new NewLanguageScreen(de->T("Language"));
-		langScreen->OnChoice.Handle(this, &GamePauseScreen::OnLanguageChange);
-		screenManager()->push(langScreen);
+	if (!strcmp(message, "language")) {
+		screenManager()->RecreateAllViews();
 	}
 }

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -32,6 +32,7 @@
 #include "UI/MainScreen.h"
 #include "Core/Config.h"
 #include "Core/System.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/HLE/sceUtility.h"
 #include "Common/CPUDetect.h"
 
@@ -48,7 +49,6 @@
 #include "gfx_es2/gl_state.h"
 #include "util/random/rng.h"
 
-#include "Core/HLE/sceUtility.h"
 #include "UI/ui_atlas.h"
 
 static const int symbols[4] = {
@@ -94,12 +94,21 @@ void DrawBackground(float alpha) {
 	}
 }
 
+void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager) {
+	if (!strcmp(message, "clear jit")) {
+		if (MIPSComp::jit) {
+			MIPSComp::jit->ClearCache();
+		}
+	}
+}
+
 void UIScreenWithBackground::DrawBackground(UIContext &dc) {
 	::DrawBackground(1.0f);
 	dc.Flush();
 }
 
 void UIScreenWithBackground::sendMessage(const char *message, const char *value) {
+	HandleCommonMessages(message, value, screenManager());
 	I18NCategory *de = GetI18NCategory("Developer");
 	if (!strcmp(message, "language screen")) {
 		auto langScreen = new NewLanguageScreen(de->T("Language"));
@@ -132,6 +141,7 @@ void UIDialogScreenWithBackground::DrawBackground(UIContext &dc) {
 }
 
 void UIDialogScreenWithBackground::sendMessage(const char *message, const char *value) {
+	HandleCommonMessages(message, value, screenManager());
 	I18NCategory *de = GetI18NCategory("Developer");
 	if (!strcmp(message, "language screen")) {
 		auto langScreen = new NewLanguageScreen(de->T("Language"));

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1255,6 +1255,7 @@ namespace MainWindow
 
 				case ID_DEBUG_SHOWDEBUGSTATISTICS:
 					g_Config.bShowDebugStats = !g_Config.bShowDebugStats;
+					NativeMessageReceived("clear jit", "");
 					break;
 
 				case ID_OPTIONS_HARDWARETRANSFORM:


### PR DESCRIPTION
Most of the things it does are affected by relatively static variables, or direct results of the parameters.  We can avoid all that by calling it directly from jit to the degree possible.

Cuts +/- 0.6% from profile in ClaDun on Android (~2.46% -> ~1.21% + ~0.44%)  Not huge but I had actually started it already, finished it since I saw it would probably matter a bit.

Also a sceKernelIsCpuIntrSuspended() fix, I don't have any games that actually call it though, but test results seem pretty clear.

-[Unknown]
