### PR TITLE
Add a travis-ci info file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# https://travis-ci.org
+
+language: cpp
+
+env:
+  - PPSSPP_BUILD_TYPE=Linux
+  - PPSSPP_BUILD_TYPE=Android
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa
+  - sudo apt-get update
+  - sudo apt-get install cmake libsdl1.2-dev openjdk-7-jdk ant lib32z1-dev lib32stdc++6
+  - git submodule update --init --recursive
+  - if [ "$PPSSPP_BUILD_TYPE" == "Android" ]; then wget --timeout=30 http://dl.google.com/android/ndk/android-ndk-r9-linux-x86_64.tar.bz2 -O ndk.tar.bz2 && tar -xf ndk.tar.bz2; fi
+  - if [[ "$CXX" == *clang* ]]; then export NDK_TOOLCHAIN_VERSION=clang; fi
+  - export ANDROID_HOME=$(pwd)/android-ndk-r9 NDK=$(pwd)/android-ndk-r9
+
+before_script:
+  - mkdir build-travis
+  - cd build-travis
+  - cmake -DHEADLESS=ON ..
+  - cd ..
+
+script:
+  - if [ "$PPSSPP_BUILD_TYPE" == "Linux" ]; then cd build-travis && make && cd ..; else cd android && ./ab.sh && cd ..; fi
+  - if [ "$PPSSPP_BUILD_TYPE" == "Linux" ]; then ./test.py; fi
+
+# For now, Android clang seems to be failing to build.
+matrix:
+  exclude:
+    - compiler: clang
+      env: PPSSPP_BUILD_TYPE=Android


### PR DESCRIPTION
I like TeamCity and think we should definitely keep it.  Travis is no replacement for it, but it has the nice feature of notating pull requests.  TeamCity could do that too, but for now it doesn't, so there's no reason we can't use both.

Things Travis CI does not do well:
- Single platform.  You can pick Mac (which I did not try) or Linux, and then you're stuck with it.
- Doesn't support Windows at all afaict.
- Build has to download the entire NDK every time (ouch.)
- Doesn't seem to do "granular" failures, e.g. x/y tests passing.

The benefits are:
- It will attempt to build any submitted pull request and [note if it would break the build](http://about.travis-ci.org/blog/2012-09-04-pull-requests-just-got-even-more-awesome/).
- Can build multiple targets simultaneously (e.g. probably could add Qt.)
- Sends an email by default if the build gets broken.

Anyway, if you want to use it, login at https://travis-ci.org/ and enable the repo after accepting this pull.  It'll request permissions through GitHub to update the pull request statuses.

-[Unknown]
