### PR TITLE
Fix sceKernelLoadExec() mistreating arguments

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1279,6 +1279,8 @@ bool __KernelLoadExec(const char *filename, u32 paramPtr, std::string *error_str
 
 	if (param_argp) delete[] param_argp;
 	if (param_key) delete[] param_key;
+
+	hleSkipDeadbeef();
 	return true;
 }
 


### PR DESCRIPTION
Okay, well, one liner.  @sum2012, if you confirm this fixes it, I'll just merge.  Pretty sure it's right.

-[Unknown]
