### PR TITLE
Win32: Revise how the language system/menu works.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -435,7 +435,7 @@ UI::EventReturn GameSettingsScreen::OnLanguage(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnLanguageChange(UI::EventParams &e) {
 	RecreateViews();
-	OnLanguageChanged.Trigger(e);
+
 	if (host) {
 		host->UpdateUI();
 	}

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -30,7 +30,6 @@ public:
 	virtual void update(InputState &input);
 	virtual void onFinish(DialogResult result);
 
-	UI::Event OnLanguageChanged;
 	UI::Event OnRecentChanged;
 
 protected:

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -650,17 +650,8 @@ UI::EventReturn MainScreen::OnGameSelectedInstant(UI::EventParams &e) {
 UI::EventReturn MainScreen::OnGameSettings(UI::EventParams &e) {
 	// screenManager()->push(new SettingsScreen());
 	auto gameSettings = new GameSettingsScreen("", "");
-	gameSettings->OnLanguageChanged.Handle(this, &MainScreen::OnLanguageChange);
 	gameSettings->OnRecentChanged.Handle(this, &MainScreen::OnRecentChange);
 	screenManager()->push(gameSettings);
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn MainScreen::OnLanguageChange(UI::EventParams &e) {
-	RecreateViews();
-	if (host) {
-		host->UpdateUI();
-	}
 	return UI::EVENT_DONE;
 }
 
@@ -852,10 +843,22 @@ UI::EventReturn GamePauseScreen::OnCwCheat(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
+UI::EventReturn GamePauseScreen::OnLanguageChange(UI::EventParams &e) {
+	RecreateViews();
+	if (host) {
+		host->UpdateUI();
+	}
+
+	return UI::EVENT_DONE;
+}
+
 void GamePauseScreen::sendMessage(const char *message, const char *value) {
 	// Since the language message isn't allowed to be in native, we have to have add this
 	// to every screen which directly inherits from UIScreen(which are few right now, luckily).
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
+	I18NCategory *de = GetI18NCategory("Developer");
+	if (!strcmp(message, "language screen")) {
+		auto langScreen = new NewLanguageScreen(de->T("Language"));
+		langScreen->OnChoice.Handle(this, &GamePauseScreen::OnLanguageChange);
+		screenManager()->push(langScreen);
 	}
 }

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -43,7 +43,6 @@ private:
 	// Event handlers
 	UI::EventReturn OnLoadFile(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
-	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 	UI::EventReturn OnRecentChange(UI::EventParams &e);
 	UI::EventReturn OnCredits(UI::EventParams &e);
 	UI::EventReturn OnSupport(UI::EventParams &e);
@@ -73,6 +72,8 @@ private:
 	UI::EventReturn OnSaveState(UI::EventParams &e);
 	UI::EventReturn OnLoadState(UI::EventParams &e);
 	UI::EventReturn OnRewind(UI::EventParams &e);
+
+	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 
 	UI::EventReturn OnStateSelected(UI::EventParams &e);
 	UI::EventReturn OnCwCheat(UI::EventParams &e);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -94,19 +94,36 @@ void DrawBackground(float alpha) {
 	}
 }
 
-void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager) {
-	if (!strcmp(message, "language")) {
-		manager->RecreateAllViews();
-	}
-}
-
 void UIScreenWithBackground::DrawBackground(UIContext &dc) {
 	::DrawBackground(1.0f);
 	dc.Flush();
 }
 
 void UIScreenWithBackground::sendMessage(const char *message, const char *value) {
-	HandleCommonMessages(message, value, screenManager());
+	I18NCategory *de = GetI18NCategory("Developer");
+	if (!strcmp(message, "language screen")) {
+		auto langScreen = new NewLanguageScreen(de->T("Language"));
+		langScreen->OnChoice.Handle(this, &UIScreenWithBackground::OnLanguageChange);
+		screenManager()->push(langScreen);
+	}
+}
+
+UI::EventReturn UIScreenWithBackground::OnLanguageChange(UI::EventParams &e) {
+	RecreateViews();
+	if (host) {
+		host->UpdateUI();
+	}
+
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn UIDialogScreenWithBackground::OnLanguageChange(UI::EventParams &e) {
+	RecreateViews();
+	if (host) {
+		host->UpdateUI();
+	}
+
+	return UI::EVENT_DONE;
 }
 
 void UIDialogScreenWithBackground::DrawBackground(UIContext &dc) {
@@ -115,7 +132,12 @@ void UIDialogScreenWithBackground::DrawBackground(UIContext &dc) {
 }
 
 void UIDialogScreenWithBackground::sendMessage(const char *message, const char *value) {
-	HandleCommonMessages(message, value, screenManager());
+	I18NCategory *de = GetI18NCategory("Developer");
+	if (!strcmp(message, "language screen")) {
+		auto langScreen = new NewLanguageScreen(de->T("Language"));
+		langScreen->OnChoice.Handle(this, &UIDialogScreenWithBackground::OnLanguageChange);
+		screenManager()->push(langScreen);
+	}
 }
 
 PromptScreen::PromptScreen(std::string message, std::string yesButtonText, std::string noButtonText, std::function<void(bool)> callback)

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -36,6 +36,7 @@ public:
 protected:
 	virtual void DrawBackground(UIContext &dc);
 	virtual void sendMessage(const char *message, const char *value);
+	virtual UI::EventReturn OnLanguageChange(UI::EventParams &e);
 };
 
 class UIDialogScreenWithBackground : public UIDialogScreen {
@@ -44,6 +45,7 @@ public:
 protected:
 	virtual void DrawBackground(UIContext &dc);
 	virtual void sendMessage(const char *message, const char *value);
+	virtual UI::EventReturn OnLanguageChange(UI::EventParams &e);
 };
 
 class PromptScreen : public UIDialogScreenWithBackground {

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -416,6 +416,7 @@ BEGIN
         MENUITEM "Pause When Not Focused",                  ID_OPTIONS_PAUSE_FOCUS
         MENUITEM "More Settings...",                        ID_OPTIONS_MORE_SETTINGS
         MENUITEM "Control Mapping...",                      ID_OPTIONS_CONTROLS
+        MENUITEM "Language...",                             ID_OPTIONS_LANGUAGE
         MENUITEM SEPARATOR
         MENUITEM "Stretch to Display",                      ID_OPTIONS_STRETCHDISPLAY
         MENUITEM "Fullscreen",                              ID_OPTIONS_FULLSCREEN

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -159,9 +159,6 @@
 #define IDC_GEDBG_TEXADDR               1192
 #define IDC_GEDBG_FBTABS                1193
 
-// Don't define anything else in the 3000 range.
-// It's reserved for languages.
-#define ID_LANGUAGE_BASE 3000
 #define ID_SHADERS_BASE  5000
 
 #define ID_FILE_EXIT                     40000
@@ -299,7 +296,7 @@
 #define IDC_GEDBG_STEPPRIM               40138
 #define ID_DISASM_ADDFUNCTION            40139
 #define ID_DISASM_REMOVEFUNCTION         40140
-
+#define ID_OPTIONS_LANGUAGE              40141
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
The Language menu is eliminated in favour of displaying a NewLanguageScreen on screens that are of type UIDialogScreenWithBackground/UIScreenWithBackground, which comes from a new "Language..." menu item under Game Settings. UIScreen inheriting screens (e.g. GamePauseScreen) still require manual additions.

Addresses https://github.com/hrydgard/ppsspp/issues/4414.

Not that it really needs any screenshots, but..

![Screenshot 01](https://i.minus.com/ibcn6tURt3pnKH.jpg)

![Screenshot 02](https://i.minus.com/iMB3frkT0wpvL.PNG)
