### PR TITLE
Speed up access to the current HLE thread

### DIFF
--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -480,11 +480,7 @@ public:
 	T *GetFast(SceUID handle)
 	{
 		const SceUID realHandle = handle - handleOffset;
-		if (realHandle < 0 || realHandle >= maxCount || !occupied[realHandle])
-		{
-			ERROR_LOG(SCEKERNEL, "Kernel: Bad fast object handle %i (%08x)", handle, handle);
-			return 0;
-		}
+		_dbg_assert_(SCEKERNEL, realHandle >= 0 && realHandle < maxCount && occupied[realHandle]);
 		return static_cast<T *>(pool[realHandle]);
 	}
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -932,7 +932,7 @@ void MipsCall::setReturnValue(u64 value)
 	savedV1 = (value >> 32) & 0xFFFFFFFF;
 }
 
-Thread *__GetCurrentThread() {
+inline Thread *__GetCurrentThread() {
 	if (currentThread != 0)
 		return kernelObjects.GetFast<Thread>(currentThread);
 	else


### PR DESCRIPTION
This was showing up in a profile on ARM.  It doesn't help a ton but it does help consistently.

__KernelNextThread() is still pretty slow.  I'd improved it when profiling on iOS, but it seems to still be hovering around 2%.  Used to be higher before the specialized thread queue, of course...

-[Unknown]
