### PR TITLE
Fix Comp_VRot on x86 non-Windows

### DIFF
--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1926,13 +1926,33 @@ void Jit::Comp_Vfim(MIPSOpcode op) {
 
 static float sincostemp[2];
 
-void SinCos(float angle) {
+union u32float {
+	u32 u;
+	float f;
+
+	operator float() const {
+		return f;
+	}
+
+	inline u32float &operator *=(const float &other) {
+		f *= other;
+		return *this;
+	}
+};
+
+#ifdef _M_X64
+typedef float SinCosArg;
+#else
+typedef u32float SinCosArg;
+#endif
+
+void SinCos(SinCosArg angle) {
 	angle *= (float)1.57079632679489661923;  // pi / 2
 	sincostemp[0] = sinf(angle);
 	sincostemp[1] = cosf(angle);
 }
 
-void SinCosNegSin(float angle) {
+void SinCosNegSin(SinCosArg angle) {
 	angle *= (float)1.57079632679489661923;  // pi / 2
 	sincostemp[0] = -sinf(angle);
 	sincostemp[1] = cosf(angle);
@@ -1940,13 +1960,7 @@ void SinCosNegSin(float angle) {
 
 // Very heavily used by FF:CC
 void Jit::Comp_VRot(MIPSOpcode op) {
-	// DISABLE;
 	CONDITIONAL_DISABLE;
-
-	// Keeping it enabled in x64 non-windows as it seems fine there.
-#if defined(_M_IX86) && !defined(_WIN32)
-	DISABLE;
-#endif
 
 	int vd = _VD;
 	int vs = _VS;
@@ -1970,12 +1984,8 @@ void Jit::Comp_VRot(MIPSOpcode op) {
 	MOVSS(XMM0, fpr.V(sreg));
 	ABI_CallFunction(negSin ? (void *)&SinCosNegSin : (void *)&SinCos);
 #else
-	// Sigh, passing floats with cdecl isn't pretty.
-	MOVSS(XMM0, fpr.V(sreg));
-	SUB(32, R(ESP), Imm32(4));
-	MOVSS(MatR(ESP), XMM0);
-	ABI_CallFunction(negSin ? (void *)&SinCosNegSin : (void *)&SinCos);
-	ADD(32, R(ESP), Imm32(4));
+	// Sigh, passing floats with cdecl isn't pretty, ends up on the stack.
+	ABI_CallFunction(negSin ? (void *)&SinCosNegSin : (void *)&SinCos, fpr.V(sreg));
 #endif
 
 	MOVSS(XMM0, M(&sincostemp[0]));

--- a/test.py
+++ b/test.py
@@ -282,10 +282,13 @@ tests_ignored = [
 
 
 def init():
-  global PPSSPP_EXE
+  global PPSSPP_EXE, TEST_ROOT
   if not os.path.exists("pspautotests"):
-    print("Please run git submodule init; git submodule update;")
-    sys.exit(1)
+    if os.path.exists(os.path.dirname(__file__) + "/pspautotests"):
+      TEST_ROOT = os.path.dirname(__file__) + "/pspautotests/tests/";
+    else:
+      print("Please run git submodule init; git submodule update;")
+      sys.exit(1)
 
   if not os.path.exists(TEST_ROOT + "cpu/cpu_alu/cpu_alu.prx"):
     print("Please install the pspsdk and run make in common/ and in all the tests")


### PR DESCRIPTION
It works to pass it as a u32, and I assume it ends up on the stack anyway.  We could still do it more tightly or with SSE or something, but at least this is more like x64 and probably faster.  Was just bugging me.

-[Unknown]
