### PR TITLE
Advance cursor after assembling

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -473,6 +473,10 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 		if (MIPSComp::jit)
 			MIPSComp::jit->ClearCacheAt(address - 4, 8);
 		scanFunctions();
+
+		if (address == curAddress)
+			gotoAddr(curAddress+4);
+
 		redraw();
 	} else {
 		std::wstring error = ConvertUTF8ToWString(MIPSAsm::GetAssembleError());


### PR DESCRIPTION
This way you can keep typing code if you want to change more than one instruction, and don't have to move the cursor manually after every opcode.
