### PR TITLE
delete source of buffer overrun on Windows

### DIFF
--- a/Core/PSPMixer.cpp
+++ b/Core/PSPMixer.cpp
@@ -28,11 +28,9 @@ int PSPMixer::Mix(short *stereoout, int numSamples)
 {
 	int numFrames = __AudioMix(stereoout, numSamples);
 #ifdef _WIN32
-	if (numFrames < numSamples) {
-		// Our dsound backend will not stop playing, let's just feed it zeroes if we miss data.
-		memset(stereoout + 2 * 2 * numFrames, 0, 2 * 2 * (numSamples - numFrames));
-		numFrames = numSamples;
-	}
+	// Our dsound backend will not stop playing.
+	//__AudioMix fills the rest of the buffer with 0 already
+    numFrames = numSamples;
 #endif
 	return numFrames;
 }


### PR DESCRIPTION
The Windows Qt build just got crash after crash because of this

Just to explain `memset(stereoout + 2 * 2 * numFrames, 0, 2 * 2 * (numSamples - numFrames));` assumed that `stereoout` was a `char *` but it's a `short *` so it writes outside of the buffer `stereoout`

The problem was that on windows the full buffersize was never passed, so this error was masked by the fact that the buffer is way larger than in needs to be by default, but in the Qt build we pass the actual size.
