### PR TITLE
Force 5 byte jumps to avoid jump target issues (vertex jit, x86)

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -1081,9 +1081,7 @@ u32 TransformDrawEngine::ComputeHash() {
 		}
 	}
 	if (uvScale) {
-		for (int i = 0; i < numDrawCalls; i++) {
-			fullhash += XXH32(&uvScale[i], sizeof(uvScale[0]), 0x0123e658);
-		}
+		fullhash += XXH32(&uvScale[0], sizeof(uvScale[0]) * numDrawCalls, 0x0123e658);
 	}
 
 	return fullhash;

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -1248,7 +1248,7 @@ void VertexDecoderJitCache::Jit_Color4444() {
 	// tempReg1 -> ABGR0000, then double A backwards.
 	SHL(32, R(tempReg1), Imm8(8));
 	MOV(32, R(tempReg3), R(tempReg1));
-	AND(32, R(tempReg3), Imm32(0xF000000));
+	AND(32, R(tempReg3), Imm32(0xF0000000));
 	OR(32, R(tempReg2), R(tempReg3));
 	SHR(32, R(tempReg3), Imm8(4));
 	OR(32, R(tempReg2), R(tempReg3));
@@ -1276,7 +1276,7 @@ void VertexDecoderJitCache::Jit_Color565() {
 	AND(32, R(tempReg2), Imm32(0x00FF00FF));
 
 	// Now's as good a time to put in A as any.
-	OR(32, R(tempReg2), Imm8(0xFF000000));
+	OR(32, R(tempReg2), Imm32(0xFF000000));
 
 	// Last, we need to align, extract, and expand G.
 	// 3 to align to G, and then 2 to expand to 8.

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -1127,7 +1127,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 	ADD(32, R(dstReg), Imm32(dec.decFmt.stride));
 #endif
 	SUB(32, R(counterReg), Imm8(1));
-	J_CC(CC_NZ, loopStart);
+	J_CC(CC_NZ, loopStart, true);
 
 #ifdef _M_IX86
 	// Restore register values


### PR DESCRIPTION
Some with 16-bit colors were too far.  Should've realized, my bad.

By the way, I played with drawsUntilNextFullHash and numVerts a bit.  Even much more conservative values were still way faster than vertex cache off.  But I think the situation with that one game that @raven02 was trying is much more interesting.

-[Unknown]
