### PR TITLE
Add arm color conversions for the vertex decoder jit

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -192,6 +192,17 @@ void ARMXEmitter::CMPI2R(ARMReg rs, u32 val, ARMReg scratch)
 	}
 }
 
+void ARMXEmitter::TSTI2R(ARMReg rs, u32 val, ARMReg scratch)
+{
+	Operand2 op2;
+	if (TryMakeOperand2(val, op2)) {
+		TST(rs, op2);
+	} else {
+		MOVI2R(scratch, val);
+		TST(rs, scratch);
+	}
+}
+
 void ARMXEmitter::ORI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch)
 {
 	Operand2 op2;

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -593,6 +593,7 @@ public:
 	void ADDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
 	void ANDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
 	void CMPI2R(ARMReg rs, u32 val, ARMReg scratch);
+	void TSTI2R(ARMReg rs, u32 val, ARMReg scratch);
 	void ORI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
 
 

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -194,7 +194,7 @@ public:
 				shift = 0;
 			break;
 		case ST_ASR:
-			_assert_msg_(JIT, shift < 32, "Invalid Operand2: LSR %u", shift);
+			_assert_msg_(JIT, shift < 32, "Invalid Operand2: ASR %u", shift);
 			if (!shift)
 				type = ST_LSL;
 			if (shift == 32)
@@ -524,6 +524,10 @@ public:
 
 	void STMFD(ARMReg dest, bool WriteBack, const int Regnum, ...);
 	void LDMFD(ARMReg dest, bool WriteBack, const int Regnum, ...);
+	void STMIA(ARMReg dest, bool WriteBack, const int Regnum, ...);
+	void LDMIA(ARMReg dest, bool WriteBack, const int Regnum, ...);
+	void STM(ARMReg dest, bool Add, bool Before, bool WriteBack, const int Regnum, ...);
+	void LDM(ARMReg dest, bool Add, bool Before, bool WriteBack, const int Regnum, ...);
 
 	// Exclusive Access operations
 	void LDREX(ARMReg dest, ARMReg base);

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -964,20 +964,23 @@ void VertexDecoderJitCache::Jit_NormalS8() {
 
 // Copy 6 bytes and then 2 zeroes.
 void VertexDecoderJitCache::Jit_NormalS16() {
-	LDR(tempReg1, srcReg, dec_->nrmoff, false);
-	LDRH(tempReg2, srcReg, dec_->nrmoff + 4, false);
-	STR(tempReg1, dstReg, dec_->decFmt.nrmoff, false);
-	STR(tempReg2, dstReg, dec_->decFmt.nrmoff + 4, false);
+	LDR(tempReg1, srcReg, dec_->nrmoff);
+	LDRH(tempReg2, srcReg, dec_->nrmoff + 4);
+	STR(tempReg1, dstReg, dec_->decFmt.nrmoff);
+	STR(tempReg2, dstReg, dec_->decFmt.nrmoff + 4);
 }
 
 void VertexDecoderJitCache::Jit_NormalFloat() {
-	// ldmia?
-	LDR(tempReg1, srcReg, dec_->nrmoff, false);
-	LDR(tempReg2, srcReg, dec_->nrmoff + 4, false);
-	LDR(tempReg3, srcReg, dec_->nrmoff + 8, false);
-	STR(tempReg1, dstReg, dec_->decFmt.nrmoff, false);
-	STR(tempReg2, dstReg, dec_->decFmt.nrmoff + 4, false);
-	STR(tempReg3, dstReg, dec_->decFmt.nrmoff + 8, false);
+	//ADD(scratchReg, srcReg, dec_->nrmoff);
+	//LDMIA(scratchReg, false, 3, tempReg1, tempReg2, tempReg3);
+	//ADD(scratchReg, dstReg, dec_->decFmt.nrmoff);
+	//STMIA(scratchReg, false, 3, tempReg1, tempReg2, tempReg3);
+	LDR(tempReg1, srcReg, dec_->nrmoff);
+	LDR(tempReg2, srcReg, dec_->nrmoff + 4);
+	LDR(tempReg3, srcReg, dec_->nrmoff + 8);
+	STR(tempReg1, dstReg, dec_->decFmt.nrmoff);
+	STR(tempReg2, dstReg, dec_->decFmt.nrmoff + 4);
+	STR(tempReg3, dstReg, dec_->decFmt.nrmoff + 8);
 }
 
 // Through expands into floats, always. Might want to look at changing this.
@@ -1019,7 +1022,10 @@ void VertexDecoderJitCache::Jit_PosS16() {
 
 // Just copy 12 bytes.
 void VertexDecoderJitCache::Jit_PosFloat() {
-	// ldmia?
+	//ADD(scratchReg, srcReg, dec_->posoff);
+	//LDMIA(scratchReg, false, 3, tempReg1, tempReg2, tempReg3);
+	//ADD(scratchReg, dstReg, dec_->decFmt.posoff);
+	//STMIA(scratchReg, false, 3, tempReg1, tempReg2, tempReg3);
 	LDR(tempReg1, srcReg, dec_->posoff);
 	LDR(tempReg2, srcReg, dec_->posoff + 4);
 	LDR(tempReg3, srcReg, dec_->posoff + 8);


### PR DESCRIPTION
May not be the most perfectly optimal, but they seem to work okay (I'm least confident about 5551, but I'm sure about the others.)

I tried LDMIA/STMIA, they worked great for me.  However, they only work on aligned addresses AFAIK.  Not sure if that's a problem.  Maybe we can at least use STMIA?  I left the code in but commented out.

Note: the I2Rs in the jit code are for readability.  None of them should actually be using anything but and Operand2.  Also, I got confused, it'd be nice if it was a compile time error to pass an imm that's outside a u8 if it's not gonna auto-shift, took me a while to realize why 0xF000 didn't work and switch to I2R...

With this, Dissidia at least seemed faster to me, but I forgot to carefully time it.  Before it was spending a lot of time in the vertex step funcs per a profile (due to Color4444.)

-[Unknown]
