### PR TITLE
move direct sound specific behavior into the actual direct sound function

### DIFF
--- a/Core/PSPMixer.cpp
+++ b/Core/PSPMixer.cpp
@@ -26,11 +26,5 @@
 
 int PSPMixer::Mix(short *stereoout, int numSamples)
 {
-	int numFrames = __AudioMix(stereoout, numSamples);
-#ifdef _WIN32
-	// Our dsound backend will not stop playing.
-	//__AudioMix fills the rest of the buffer with 0 already
-    numFrames = numSamples;
-#endif
-	return numFrames;
+    return __AudioMix(stereoout, numSamples);
 }

--- a/Windows/DSoundStream.cpp
+++ b/Windows/DSoundStream.cpp
@@ -128,22 +128,19 @@ namespace DSound
 			dsBuffer->GetCurrentPosition((DWORD *)&currentPos, 0);
 			int numBytesToRender = RoundDown128(ModBufferSize(currentPos - lastPos)); 
 
-			//renderStuff(numBytesToRender/2);
-			//if (numBytesToRender>bufferSize/2) numBytesToRender=0;
-
 			if (numBytesToRender >= 256)
 			{
 				int numBytesRendered = 4 * (*callback)(realtimeBuffer, numBytesToRender >> 2, 16, 44100, 2);
-
-				if (numBytesRendered != 0)
-					writeDataToBuffer(lastPos, (char *)realtimeBuffer, numBytesRendered);
+				//We need to copy the full buffer, regardless of what the mixer claims to have filled
+				//If we don't do this then the sound will loop if the sound stops and the mixer writes only zeroes
+				numBytesRendered = numBytesToRender;
+				writeDataToBuffer(lastPos, (char *) realtimeBuffer, numBytesRendered);
 
 				currentPos = ModBufferSize(lastPos + numBytesRendered);
 				totalRenderedBytes += numBytesRendered;
 
 				lastPos = currentPos;
 			}
-
 
 			LeaveCriticalSection(&soundCriticalSection);
 			WaitForSingleObject(soundSyncEvent, MAXWAIT);


### PR DESCRIPTION
I'd really like to get rid of the `#ifdef _WIN32` there, since it doesn't really gel very well with having different behavior for the Windows and Linux QT versions. This changes nothing about the windows version, it just moves around the `numFrames = numSamples;` from the mix function to the `numBytesRendered = numBytesToRender;` line in the `DSound::soundThread` function.
