### PR TITLE
add Linux debug menus Qt Windows build 

### DIFF
--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -38,8 +38,11 @@ win32|symbian: LIBS += $${FFMPEG_DIR}avformat.lib $${FFMPEG_DIR}avcodec.lib $${F
 else: LIBS += $${FFMPEG_DIR}libavformat.a $${FFMPEG_DIR}libavcodec.a $${FFMPEG_DIR}libavutil.a $${FFMPEG_DIR}libswresample.a $${FFMPEG_DIR}libswscale.a
 
 win32 {
+	#Use a fixed base-address under windows
+	QMAKE_LFLAGS += /FIXED /BASE:"0x00400000"
+	QMAKE_LFLAGS += /DYNAMICBASE:NO
 	LIBS += -lwinmm -lws2_32 -lShell32 -lAdvapi32
-	contains($$QMAKE_TARGET.arch, x86_64): LIBS += $$files(../dx9sdk/Lib/x64/*.lib)
+	contains(QMAKE_TARGET.arch, x86_64): LIBS += $$files(../dx9sdk/Lib/x64/*.lib)
 	else: LIBS += $$files(../dx9sdk/Lib/x86/*.lib)
 }
 linux {
@@ -75,8 +78,8 @@ SOURCES += ../UI/*Screen.cpp \
 HEADERS += ../UI/*.h
 INCLUDEPATH += .. ../Common ../native
 
-# Use forms UI for Linux desktop
-linux:!mobile_platform {
+# Use forms UI for desktop platforms
+!mobile_platform {
 	SOURCES += *.cpp
 	HEADERS += *.h
 	FORMS += *.ui

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -80,7 +80,6 @@ void QtHost::UpdateDisassembly()
 {
 	if(mainWindow->GetDialogDisasm())
 	{
-		mainWindow->GetDialogDisasm()->GotoPC();
 		mainWindow->GetDialogDisasm()->Update();
 	}
 	if(mainWindow->GetDialogDisplaylist())
@@ -334,7 +333,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 
 	g_gameInfoCache.Init();
 
-#if defined(Q_OS_LINUX) && !defined(ARM)
+#if !defined(ARM)
 	// Start Desktop UI
 	MainWindow* mainWindow = new MainWindow();
 	mainWindow->show();

--- a/Qt/ctrlmemview.cpp
+++ b/Qt/ctrlmemview.cpp
@@ -82,6 +82,7 @@ void CtrlMemView::paintEvent(QPaintEvent *)
 
 	QFont normalFont("Arial", 10);
 	QFont alignedFont("Monospace", 10);
+    alignedFont.setStyleHint(QFont::Monospace);
 	painter.setFont(normalFont);
 
 	int i;
@@ -162,12 +163,16 @@ void CtrlMemView::paintEvent(QPaintEvent *)
 					if (align==4)
 					{
 						u32 value = Memory::ReadUnchecked_U32(address);
-						sprintf(temp, "%08x [%s]", value, symbolMap.GetSymbolName(symbolMap.GetSymbolNum(value)));
+						int symbolnum = symbolMap.GetSymbolNum(value);
+						if(symbolnum>=0)
+							sprintf(temp, "%08x [%s]", value, symbolMap.GetSymbolName(symbolnum));
 					}
 					else if (align==2)
 					{
 						u16 value = Memory::ReadUnchecked_U16(address);
-						sprintf(temp, "%04x [%s]", value, symbolMap.GetSymbolName(symbolMap.GetSymbolNum(value)));
+						int symbolnum = symbolMap.GetSymbolNum(value);
+						if(symbolnum>=0)
+							sprintf(temp, "%04x [%s]", value, symbolMap.GetSymbolName(symbolnum));
 					}
 
 					painter.drawText(85,rowY1 - 2 + rowHeight, temp);

--- a/Qt/ctrlregisterlist.cpp
+++ b/Qt/ctrlregisterlist.cpp
@@ -137,7 +137,7 @@ void CtrlRegisterList::paintEvent(QPaintEvent *)
 	int maxRowsDisplay =rect().bottom()/rowHeight - 1;
 
 	selection = std::min(std::max(selection,0),numRowsTotal);
-	curVertOffset = std::min(std::max(curVertOffset, 0),numRowsTotal - maxRowsDisplay);
+	curVertOffset = std::max(std::min(curVertOffset,numRowsTotal - maxRowsDisplay),0);
 
 	QScrollBar *bar = findChild<QScrollBar*>("RegListScroll");
 	if(bar)


### PR DESCRIPTION
Makes the windows Qt build behave like the Linux version. This doesn't affect the normal Windows build with the *.sln and only makes a difference if you compile with the Qt/PPSSPPQt.pro.

details about of the build and crashes fixes are in the commit log of 2401582

I have no clue whether this `native Subproject commit` is helping or hurting my cause but I'd like to know if I should just not change the subproject revision at all in pull requests or make sure it has a compatible revision.
