### PR TITLE
Fix LDRH emitter bug, use STMIA where possible

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -816,7 +816,7 @@ void ARMXEmitter::WriteStoreOp(u32 Op, ARMReg Rt, ARMReg Rn, Operand2 Rm, bool R
 			Data = abs(Temp);
 			// The offset is encoded differently on this one.
 			if (SpecialOp)
-				Data = (Data & 0xF0 << 4) | (Data & 0xF);
+				Data = ((Data & 0xF0) << 4) | (Data & 0xF);
 			if (Temp >= 0) Add = true;
 		}
 		break;

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -1078,7 +1078,7 @@ void VertexDecoderJitCache::Jit_PosS8() {
 // Copy 6 bytes and then 2 zeroes.
 void VertexDecoderJitCache::Jit_PosS16() {
 	LDR(tempReg1, srcReg, dec_->posoff);
-	LDR(tempReg2, srcReg, dec_->posoff + 4);  // WARNING: This SHOULD be an LDRH but things break! why?
+	LDRH(tempReg2, srcReg, dec_->posoff + 4);
 	STR(tempReg1, dstReg, dec_->decFmt.posoff);
 	STR(tempReg2, dstReg, dec_->decFmt.posoff + 4);
 }
@@ -1474,7 +1474,7 @@ void VertexDecoderJitCache::Jit_PosFloat() {
 
 bool VertexDecoderJitCache::CompileStep(const VertexDecoder &dec, int step) {
 	// See if we find a matching JIT function
-	for (int i = 0; i < ARRAY_SIZE(jitLookup); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(jitLookup); i++) {
 		if (dec.steps_[step] == jitLookup[i].func) {
 			((*this).*jitLookup[i].jitFunc)();
 			return true;


### PR DESCRIPTION
This fixes the issue with LDRH for me in Dissidia.  By the way, disarm seems to mishandle LDRH/LDRB/etc.

Unfortunately, the Lunar bug still persists.  It goes away if I don't jit Jit_PosS16Through (although I'm not 100% sure that it's in that func, or just another thing I'm disabling as well.)  I was hoping it'd be the same issue because of LDRSH.

Armjit was never using this form of LDRH/etc. afaict.

-[Unknown]
