### PR TITLE
Add a check to avoid overwriting cheat file with old content.

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -92,6 +92,8 @@ void CwCheatScreen::CreateViews() {
 }
 
 void CwCheatScreen::onFinish(DialogResult result) {
+	if (result != DR_BACK) // This only works for BACK here.
+		return;
 	os.open(activeCheatFile.c_str());
 	for (int j = 0; j < (int)cheatList.size(); j++) {
 		os << cheatList[j];


### PR DESCRIPTION
Like overwriting cheat file with empty content when use import cheat.db.

Related to #4457.
