### PR TITLE
Extend follow functionality of disassembly

### DIFF
--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -113,6 +113,9 @@ namespace MIPSAnalyst
 		bool isDataAccess;
 		int dataSize;
 		u32 dataAddress;
+
+		bool hasRelevantAddress;
+		u32 releventAddress;
 	} MipsOpcodeInfo;
 
 	MipsOpcodeInfo GetOpcodeInfo(DebugInterface* cpu, u32 address);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -751,10 +751,10 @@ void CtrlDisAsmView::followBranch()
 	{
 		jumpStack.push_back(curAddress);
 		gotoAddr(info.branchTarget);
-	} else if (info.isDataAccess)
+	} else if (info.hasRelevantAddress)
 	{
 		// well, not  exactly a branch, but we can do something anyway
-		SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,info.dataAddress,0);
+		SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,info.releventAddress,0);
 		SetFocus(wnd);
 	}
 }
@@ -849,7 +849,7 @@ void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 			break;
 		case VK_NEXT:
 			if (curAddress != windowEnd - instructionSize && curAddressIsVisible()) {
-				setCurAddress(windowEnd - instructionSize, GetAsyncKeyState(VK_SHIFT));
+				setCurAddress(windowEnd - instructionSize, KeyDownAsync(VK_SHIFT));
 				scrollAddressIntoView();
 			} else {
 				setCurAddress(curAddress + visibleRows * instructionSize, KeyDownAsync(VK_SHIFT));


### PR DESCRIPTION
I couldn't think of a proper name...
This allows to press right on add/sub/addiu/move opcodes to jump to the computed value in the memory viewer. Saves a few seconds in some cases, like when a register is overwritten in an operation, but you'd like to know both the original and the new value. Or when you just want to see what a register points to without manually switching to the memory viewer and going there yourself.

Another example:
jal func
addiu a0,sp,1Ch

Pressing right while the delay slot is highlighted would position the memory view to sp+1Ch.

Also changes a function call I missed last time.
