### PR TITLE
Add support for prescaled UV in vertex decoder JIT

### DIFF
--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -57,6 +57,7 @@ public:
 	void DecodeVerts(u8 *decoded, const void *verts, int indexLowerBound, int indexUpperBound) const;
 
 	bool hasColor() const { return col != 0; }
+	bool hasTexcoord() const { return tc != 0; }
 	int VertexSize() const { return size; }  // PSP format size
 
 	void Step_WeightsU8() const;
@@ -189,6 +190,10 @@ public:
 	void Jit_TcU8();
 	void Jit_TcU16();
 	void Jit_TcFloat();
+
+	void Jit_TcU8Prescale();
+	void Jit_TcU16Prescale();
+	void Jit_TcFloatPrescale();
 
 	void Jit_TcU16Through();
 	void Jit_TcFloatThrough();


### PR DESCRIPTION
Prescaled UV lets us avoid a very common shader uniform upload, the texture scale/offset, by baking the texture scale/offset into the vertices as we decode them. Prescaled UV can considerably help performance in games that really abuse the tex scale/offset to effectively increase the precision of its 8-bit texture coordinates, for example, by changing it every few triangle strips.

If you're using vertex caching the benefit of this change will probably not be very obvious but it's here for completeness anyway.
