### PR TITLE
Another attempt to sizing framebuffer based on fmt

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -663,14 +663,18 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address) && v->width >= drawing_width && v->height >= drawing_height) {
-			// Let's not be so picky for now. Let's say this is the one.
-			vfb = v;
-			// Update fb stride in case it changed
-			vfb->fb_stride = fb_stride;
-			v->format = fmt;
-			break;
-		}
+		if (MaskedEqual(v->fb_address, fb_address)) {
+			if (v->format == fmt) {
+				// Let's not be so picky for now. Let's say this is the one.
+				vfb = v;
+				vfb->fb_stride = fb_stride;
+				break;
+			} else {
+				DestroyFramebuf(v);
+				vfbs_.erase(vfbs_.begin() + i--);
+				break;
+			}   
+		} 
 	}
 
 	float renderWidthFactor = (float)PSP_CoreParameter().renderWidth / 480.0f;


### PR DESCRIPTION
I don't mean to ask for merge with this commit and it may look totally wrong in logic 

I open it for testing and get idea to how to get it better as my initial testing reflected it interestingly fixes ALL the issues in framebuffer sizing in TOPX, Wildarm XF , Midnight Club 3 , FF CC etc however i can see there are excessive FBO create in some cases  .
1. Shadow , map and  cutscene all work fine in KH
2. In-game works fine for both Wildarm XF and Midnight Club 3.
3. Shadow works fine in FFCC 
4. Credit works fine in TOPX
5. In-game works fine in MotorStorm
