### PR TITLE
Small optimizations (armjit) for imms

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -230,48 +230,54 @@ namespace MIPSComp
 		switch (op & 63) 
 		{
 		case 10: //if (!R(rt)) R(rd) = R(rs);       break; //movz
-			if (rd == rs)
+			if (rd == rs || (gpr.IsImm(rd) && gpr.IsImm(rs) && gpr.GetImm(rd) == gpr.GetImm(rs)))
 				break;
-			if (!gpr.IsImm(rt))
-			{
-				gpr.MapDirtyInIn(rd, rt, rs, false);
+			if (!gpr.IsImm(rt)) {
+				Operand2 op2;
+				// Avoid flushing the imm if possible.
+				if (gpr.IsImm(rs) && TryMakeOperand2(gpr.GetImm(rs), op2)) {
+					gpr.MapDirtyIn(rd, rt, false);
+				} else {
+					gpr.MapDirtyInIn(rd, rt, rs, false);
+					op2 = gpr.R(rs);
+				}
 				CMP(gpr.R(rt), Operand2(0));
 				SetCC(CC_EQ);
-				MOV(gpr.R(rd), Operand2(gpr.R(rs)));
+				MOV(gpr.R(rd), op2);
 				SetCC(CC_AL);
-			}
-			else if (gpr.GetImm(rt) == 0)
-			{
+			} else if (gpr.GetImm(rt) == 0) {
 				// Yes, this actually happens.
-				if (gpr.IsImm(rs))
+				if (gpr.IsImm(rs)) {
 					gpr.SetImm(rd, gpr.GetImm(rs));
-				else
-				{
+				} else {
 					gpr.MapDirtyIn(rd, rs);
-					MOV(gpr.R(rd), Operand2(gpr.R(rs)));
+					MOV(gpr.R(rd), gpr.R(rs));
 				}
 			}
 			break;
 		case 11:// if (R(rt)) R(rd) = R(rs);		break; //movn
-			if (rd == rs)
+			if (rd == rs || (gpr.IsImm(rd) && gpr.IsImm(rs) && gpr.GetImm(rd) == gpr.GetImm(rs)))
 				break;
-			if (!gpr.IsImm(rt))
-			{
-				gpr.MapDirtyInIn(rd, rt, rs, false);
+			if (!gpr.IsImm(rt)) {
+				Operand2 op2;
+				// Avoid flushing the imm if possible.
+				if (gpr.IsImm(rs) && TryMakeOperand2(gpr.GetImm(rs), op2)) {
+					gpr.MapDirtyIn(rd, rt, false);
+				} else {
+					gpr.MapDirtyInIn(rd, rt, rs, false);
+					op2 = gpr.R(rs);
+				}
 				CMP(gpr.R(rt), Operand2(0));
 				SetCC(CC_NEQ);
-				MOV(gpr.R(rd), Operand2(gpr.R(rs)));
+				MOV(gpr.R(rd), op2);
 				SetCC(CC_AL);
-			}
-			else if (gpr.GetImm(rt) != 0)
-			{
+			} else if (gpr.GetImm(rt) != 0) {
 				// Yes, this actually happens.
-				if (gpr.IsImm(rs))
+				if (gpr.IsImm(rs)) {
 					gpr.SetImm(rd, gpr.GetImm(rs));
-				else
-				{
+				} else {
 					gpr.MapDirtyIn(rd, rs);
-					MOV(gpr.R(rd), Operand2(gpr.R(rs)));
+					MOV(gpr.R(rd), gpr.R(rs));
 				}
 			}
 			break;

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -284,16 +284,8 @@ namespace MIPSComp
 			
 		case 32: //R(rd) = R(rs) + R(rt);           break; //add
 		case 33: //R(rd) = R(rs) + R(rt);           break; //addu
-			// Some optimized special cases
-			if (gpr.IsImm(rs) && gpr.GetImm(rs) == 0) {
-				gpr.MapDirtyIn(rd, rt);
-				MOV(gpr.R(rd), gpr.R(rt));
-			} else if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0) {
-				gpr.MapDirtyIn(rd, rs);
-				MOV(gpr.R(rd), gpr.R(rs));
-			} else {
-				CompType3(rd, rs, rt, &ARMXEmitter::ADD, &EvalAdd, true);
-			}
+			// We optimize out 0 as an operand2 ADD.
+			CompType3(rd, rs, rt, &ARMXEmitter::ADD, &EvalAdd, true);
 			break;
 
 		case 34: //R(rd) = R(rs) - R(rt);           break; //sub

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -100,6 +100,10 @@ namespace MIPSComp
 
 		case 10: // R(rt) = (s32)R(rs) < simm; break; //slti
 			{
+				if (gpr.IsImm(rs)) {
+					gpr.SetImm(rt, (s32)gpr.GetImm(rs) < simm ? 1 : 0);
+					break;
+				}
 				gpr.MapDirtyIn(rt, rs);
 				CMPI2R(gpr.R(rs), simm, R0);
 				SetCC(CC_LT);
@@ -112,6 +116,10 @@ namespace MIPSComp
 
 		case 11: // R(rt) = R(rs) < uimm; break; //sltiu
 			{
+				if (gpr.IsImm(rs)) {
+					gpr.SetImm(rt, gpr.GetImm(rs) < suimm ? 1 : 0);
+					break;
+				}
 				gpr.MapDirtyIn(rt, rs);
 				CMPI2R(gpr.R(rs), suimm, R0);
 				SetCC(CC_LO);
@@ -145,10 +153,32 @@ namespace MIPSComp
 		switch (op & 63)
 		{
 		case 22: //clz
+			if (gpr.IsImm(rs)) {
+				u32 value = gpr.GetImm(rs);
+				int x = 31;
+				int count = 0;
+				while (!(value & (1 << x)) && x >= 0) {
+					count++;
+					x--;
+				}
+				gpr.SetImm(rd, count);
+				break;
+			}
 			gpr.MapDirtyIn(rd, rs);
 			CLZ(gpr.R(rd), gpr.R(rs));
 			break;
 		case 23: //clo
+			if (gpr.IsImm(rs)) {
+				u32 value = gpr.GetImm(rs);
+				int x = 31;
+				int count = 0;
+				while ((value & (1 << x)) && x >= 0) {
+					count++;
+					x--;
+				}
+				gpr.SetImm(rd, count);
+				break;
+			}
 			gpr.MapDirtyIn(rd, rs);
 			MVN(R0, gpr.R(rs));
 			CLZ(gpr.R(rd), R0);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -162,7 +162,7 @@ private:
 
 	// Utilities to reduce duplicated code
 	void CompImmLogic(int rs, int rt, u32 uimm, void (ARMXEmitter::*arith)(ARMReg dst, ARMReg src, Operand2 op2), u32 (*eval)(u32 a, u32 b));
-	void CompType3(int rd, int rs, int rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool isSub = false);
+	void CompType3(int rd, int rs, int rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool symmetric = false);
 
 	void CompShiftImm(MIPSOpcode op, ArmGen::ShiftType shiftType);
 	void CompShiftVar(MIPSOpcode op, ArmGen::ShiftType shiftType);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -162,7 +162,7 @@ private:
 
 	// Utilities to reduce duplicated code
 	void CompImmLogic(int rs, int rt, u32 uimm, void (ARMXEmitter::*arith)(ARMReg dst, ARMReg src, Operand2 op2), u32 (*eval)(u32 a, u32 b));
-	void CompType3(int rd, int rs, int rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool symmetric = false);
+	void CompType3(int rd, int rs, int rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool symmetric = false, bool useMOV = false);
 
 	void CompShiftImm(MIPSOpcode op, ArmGen::ShiftType shiftType);
 	void CompShiftVar(MIPSOpcode op, ArmGen::ShiftType shiftType);

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -96,7 +96,7 @@ namespace MIPSComp
 			break;
 
 		case 10: // R(rt) = (s32)R(rs) < simm; break; //slti
-			// There's a mips compiler out there asking it already knows the answer to...
+			// There's a mips compiler out there asking questions it already knows the answer to...
 			if (gpr.IsImmediate(rs))
 			{
 				gpr.SetImmediate32(rt, (s32)gpr.GetImmediate32(rs) < simm);

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -721,14 +721,14 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 
 			// TODO: Split this so that we can collect sequences of primitives, can greatly speed things up
 			// on platforms where draw calls are expensive like mobile and D3D
-			void *verts = Memory::GetPointer(gstate_c.vertexAddr);
+			void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
 			void *inds = 0;
 			if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 				if (!Memory::IsValidAddress(gstate_c.indexAddr)) {
 					ERROR_LOG_REPORT(G3D, "Bad index address %08x!", gstate_c.indexAddr);
 					break;
 				}
-				inds = Memory::GetPointer(gstate_c.indexAddr);
+				inds = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 			}
 
 #ifndef USING_GLES2
@@ -773,14 +773,14 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 				break;
 			}
 
-			void *control_points = Memory::GetPointer(gstate_c.vertexAddr);
+			void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
 			void *indices = NULL;
 			if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 				if (!Memory::IsValidAddress(gstate_c.indexAddr)) {
 					ERROR_LOG_REPORT(G3D, "Bad index address %08x!", gstate_c.indexAddr);
 					break;
 				}
-				indices = Memory::GetPointer(gstate_c.indexAddr);
+				indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 			}
 
 			if (gstate.getPatchPrimitiveType() != GE_PATCHPRIM_TRIANGLES) {
@@ -816,14 +816,14 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 				break;
 			}
 
-			void *control_points = Memory::GetPointer(gstate_c.vertexAddr);
+			void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
 			void *indices = NULL;
 			if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 				if (!Memory::IsValidAddress(gstate_c.indexAddr)) {
 					ERROR_LOG_REPORT(G3D, "Bad index address %08x!", gstate_c.indexAddr);
 					break;
 				}
-				indices = Memory::GetPointer(gstate_c.indexAddr);
+				indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 			}
 
 			if (gstate.getPatchPrimitiveType() != GE_PATCHPRIM_TRIANGLES) {


### PR DESCRIPTION
And also one in GLES, small but showed up on a profile.

The basic idea here is to preserve immediates longer.  This way, if we defer the flush until the end of the block, we might even be able to optimize it out.

I tested a few games with these changes and nothing broke, but I had to run so it could maybe use more testing.

-[Unknown]
