### PR TITLE
Attempt for another matching framebuffer logic

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -663,12 +663,15 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	VirtualFramebuffer *vfb = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, fb_address) && v->width >= drawing_width && v->height >= drawing_height) {
-			// Let's not be so picky for now. Let's say this is the one.
+		if (MaskedEqual(v->fb_address, fb_address)) {
 			vfb = v;
 			// Update fb stride in case it changed
 			vfb->fb_stride = fb_stride;
-			v->format = fmt;
+			if (v->format != fmt) {
+				v->width = drawing_width;
+				v->height = drawing_height;
+				v->format = fmt;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
This one has been tested against a wide range of titles (30) in both rendering and non-rendering mode plus performance evulation as well .

Major test items 

```
1. Shadow , map and cutscene all work fine in KH
2. In-game works fine in Wildarm XF.
3. Shadow works fine in FFCC
4. Credit works fine in TOPX
5. In-game works fine in MotorStorm
6. In-game works fine in MGS peace maker
7. In-game works fine in DBZ Vs Tag
8. In-game works fine in Dissidia Duodecim 012
9. In-game works fine in Midnight Club 3.
```
