### PR TITLE
Fix stencil testing in the softgpu, and also some small things along the way

### DIFF
--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -232,7 +232,7 @@ struct GPUgstate
 	bool isClearModeColorMask() const { return (clearmode&0x100) != 0; }
 	bool isClearModeAlphaMask() const { return (clearmode&0x200) != 0; }
 	bool isClearModeDepthMask() const { return (clearmode&0x400) != 0; }
-	u32 getClearModeColorMask() const { return ((clearmode&0x100) ? 0xFFFFFF : 0) | ((clearmode&0x200) ? 0xFF000000 : 0); } // TODO: Different convention than getColorMask, confusing!
+	u32 getClearModeColorMask() const { return ((clearmode&0x100) ? 0 : 0xFFFFFF) | ((clearmode&0x200) ? 0 : 0xFF000000); }
 	
 	// Blend
 	GEBlendSrcFactor getBlendFuncA() const { return (GEBlendSrcFactor)(blend & 0xF); }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -983,7 +983,7 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 				}
 
 				if (gstate.isModeClear()) {
-					new_color = (new_color & gstate.getClearModeColorMask()) | (old_color & ~gstate.getClearModeColorMask());
+					new_color = (new_color & ~gstate.getClearModeColorMask()) | (old_color & gstate.getClearModeColorMask());
 				} else {
 					new_color = (new_color & ~gstate.getColorMask()) | (old_color & gstate.getColorMask());
 				}

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -321,7 +321,7 @@ static inline u8 GetPixelStencil(int x, int y)
 		return 0;
 	} else if (gstate.FrameBufFormat() == GE_FORMAT_5551) {
 		return ((fb.Get16(x, y, gstate.FrameBufStride()) & 0x8000) != 0) ? 0xFF : 0;
-	} else if (gstate.FrameBufFormat() != GE_FORMAT_4444) {
+	} else if (gstate.FrameBufFormat() == GE_FORMAT_4444) {
 		return fb.Get16(x, y, gstate.FrameBufStride()) >> 12;
 	} else {
 		return fb.Get32(x, y, gstate.FrameBufStride()) >> 24;
@@ -338,7 +338,7 @@ static inline void SetPixelStencil(int x, int y, u8 value)
 		u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & ~0x8000;
 		pixel |= value != 0 ? 0x8000 : 0;
 		fb.Set16(x, y, gstate.FrameBufStride(), pixel);
-	} else if (gstate.FrameBufFormat() != GE_FORMAT_4444) {
+	} else if (gstate.FrameBufFormat() == GE_FORMAT_4444) {
 		u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & ~0xF000;
 		pixel |= (u16)value << 12;
 		fb.Set16(x, y, gstate.FrameBufStride(), pixel);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -967,12 +967,7 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 					Vec4<int> dst = Vec4<int>::FromRGBA(GetPixelColor(p.x, p.y));
 					prim_color_rgb = AlphaBlendingResult(prim_color_rgb, prim_color_a, dst);
 				}
-				if (prim_color_rgb.r() > 255) prim_color_rgb.r() = 255;
-				if (prim_color_rgb.g() > 255) prim_color_rgb.g() = 255;
-				if (prim_color_rgb.b() > 255) prim_color_rgb.b() = 255;
-				if (prim_color_rgb.r() < 0) prim_color_rgb.r() = 0;
-				if (prim_color_rgb.g() < 0) prim_color_rgb.g() = 0;
-				if (prim_color_rgb.b() < 0) prim_color_rgb.b() = 0;
+				prim_color_rgb = prim_color_rgb.Clamp(0, 255);
 
 				u32 new_color = Vec4<int>(prim_color_rgb.r(), prim_color_rgb.g(), prim_color_rgb.b(), GetPixelStencil(p.x, p.y)).ToRGBA();
 				u32 old_color = GetPixelColor(p.x, p.y);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -946,7 +946,6 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 				}
 
 				// TODO: Is it safe to ignore gstate.isDepthTestEnabled() when clear mode is enabled?
-				// TODO: Verify that through mode does not disable depth testing
 				if (gstate.isDepthTestEnabled() && !gstate.isModeClear()) {
 					// TODO: Verify that stencil op indeed needs to be applied here even if stencil testing is disabled
 					if (!DepthTestPassed(p.x, p.y, z)) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -552,7 +552,7 @@ static inline u32 ApplyLogicOp(GELogicOp op, u32 old_color, u32 new_color)
 		break;
 	}
 
-	return op;
+	return new_color;
 }
 
 static inline Vec4<int> GetTextureFunctionOutput(const Vec3<int>& prim_color_rgb, int prim_color_a, const Vec4<int>& texcolor)
@@ -958,7 +958,8 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 
 				// TODO: Is alpha blending still performed if logic ops are enabled?
 				if (gstate.isLogicOpEnabled() && !gstate.isModeClear()) {
-					new_color = ApplyLogicOp(gstate.getLogicOp(), old_color, new_color);
+					// Logic ops don't affect stencil.
+					new_color = (stencil << 24) | (ApplyLogicOp(gstate.getLogicOp(), old_color, new_color) & 0x00FFFFFF);
 				}
 
 				if (gstate.isModeClear()) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -932,6 +932,7 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 					if (!ColorTestPassed(prim_color_rgb))
 						continue;
 
+				// TODO: Does a need to be clamped?
 				if (gstate.isAlphaTestEnabled() && !gstate.isModeClear())
 					if (!AlphaTestPassed(prim_color_a))
 						continue;
@@ -969,13 +970,11 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 				if (prim_color_rgb.r() > 255) prim_color_rgb.r() = 255;
 				if (prim_color_rgb.g() > 255) prim_color_rgb.g() = 255;
 				if (prim_color_rgb.b() > 255) prim_color_rgb.b() = 255;
-				if (prim_color_a > 255) prim_color_a = 255;
 				if (prim_color_rgb.r() < 0) prim_color_rgb.r() = 0;
 				if (prim_color_rgb.g() < 0) prim_color_rgb.g() = 0;
 				if (prim_color_rgb.b() < 0) prim_color_rgb.b() = 0;
-				if (prim_color_a < 0) prim_color_a = 0;
 
-				u32 new_color = Vec4<int>(prim_color_rgb.r(), prim_color_rgb.g(), prim_color_rgb.b(), prim_color_a).ToRGBA();
+				u32 new_color = Vec4<int>(prim_color_rgb.r(), prim_color_rgb.g(), prim_color_rgb.b(), GetPixelStencil(p.x, p.y)).ToRGBA();
 				u32 old_color = GetPixelColor(p.x, p.y);
 
 				// TODO: Is alpha blending still performed if logic ops are enabled?

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -410,22 +410,22 @@ static inline bool StencilTestPassed(u8 stencil)
 			return true;
 
 		case GE_COMP_EQUAL:
-			return (stencil == ref);
+			return ref == stencil;
 
 		case GE_COMP_NOTEQUAL:
-			return (stencil != ref);
+			return ref != stencil;
 
 		case GE_COMP_LESS:
-			return (stencil < ref);
+			return ref < stencil;
 
 		case GE_COMP_LEQUAL:
-			return (stencil <= ref);
+			return ref <= stencil;
 
 		case GE_COMP_GREATER:
-			return (stencil > ref);
+			return ref > stencil;
 
 		case GE_COMP_GEQUAL:
-			return (stencil >= ref);
+			return ref >= stencil;
 	}
 	return true;
 }


### PR DESCRIPTION
With these changes, stencil is preserved and written properly in the softgpu, at least per what tests I've done so far.  Star Ocean now works and stencils correctly.

All my tests were done in throughmode since I'm not very good at 3d.

I guess this fixes #3768.  The information there is still useful, though.

-[Unknown]
