### PR TITLE
Regression fix c69ac64

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1054,8 +1054,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXSIZE5:
 	case GE_CMD_TEXSIZE6:
 	case GE_CMD_TEXSIZE7:
-		if (diff)
-			gstate_c.textureChanged = true;
+		gstate_c.textureChanged = true;
 		break;
 
 	case GE_CMD_ZBUFPTR:


### PR DESCRIPTION
Meanwhile , there are number of place use if (diff) as well not too sure if they may cause problem.

```
case GE_CMD_TEXTUREMAPENABLE:
    if (diff)
        gstate_c.textureChanged = true;
    break;

case GE_CMD_TEXADDR7:
    if (diff) {
        gstate_c.textureChanged = true;
        shaderManager_->DirtyUniform(DIRTY_UVSCALEOFFSET);
    }
    break;

case GE_CMD_CLUTADDR:
case GE_CMD_CLUTADDRUPPER:
case GE_CMD_CLUTFORMAT:
    if (diff) {
        gstate_c.textureChanged = true;
    }
    // This could be used to "dirty" textures with clut.
    break;

case GE_CMD_TEXBUFWIDTH0:
case GE_CMD_TEXBUFWIDTH1:
case GE_CMD_TEXBUFWIDTH2:
case GE_CMD_TEXBUFWIDTH3:
case GE_CMD_TEXBUFWIDTH4:
case GE_CMD_TEXBUFWIDTH5:
case GE_CMD_TEXBUFWIDTH6:
case GE_CMD_TEXBUFWIDTH7:
    if (diff) {
        gstate_c.textureChanged = true;
    }
    break;
```
