### PR TITLE
Improve spilling regs on ARM

### DIFF
--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -124,6 +124,7 @@ private:
 	const ARMReg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(ARMReg reg, MIPSGPReg mipsReg, int mapFlags);
 	int FlushGetSequential(MIPSGPReg startMipsReg, bool allowFlushImm);
+	ARMReg FindBestToSpill(bool unusedOnly);
 		
 	MIPSState *mips_;
 	MIPSComp::ArmJitOptions *options_;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -196,6 +196,7 @@ private:
 	void CompITypeMemWrite(MIPSOpcode op, u32 bits, void *safeFunc);
 	void CompITypeMemUnpairedLR(MIPSOpcode op, bool isStore);
 	void CompITypeMemUnpairedLRInner(MIPSOpcode op, X64Reg shiftReg);
+	void CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool delaySlotIsNice, bool likely, bool andLink);
 
 	void CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 	void CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN = false);


### PR DESCRIPTION
When spilling an imm in a reg, just turn it back into an imm.  We'll store it later anyway, but this way we might be able to optimize it out.

Also, when spilling, read ahead a few instructions.  Try to spill a reg not used in any of those instructions first before using just any reg.  I didn't test performance heavily but it should be better, and it chooses a different reg quite often.

Also, I went ahead and did the branch continuing but it's still not really faster from brief tests.

-[Unknown]
