### PR TITLE
Partially implement SCE_UTILITY_SAVEDATA_FOCUS_NAME

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -61,8 +61,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	switch ((SceUtilitySavedataFocus)(u32)param.GetPspParam()->focus)
 	{
 	case SCE_UTILITY_SAVEDATA_FOCUS_NAME:
-		// TODO: This should probably force not using the list?
-		currentSelectedSave = 0;
+		currentSelectedSave = param.GetSaveNameIndex(param.GetPspParam());
 		break;
 	case SCE_UTILITY_SAVEDATA_FOCUS_FIRSTLIST:
 		currentSelectedSave = param.GetFirstListSave();

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1465,6 +1465,21 @@ int SavedataParam::GetLastEmptySave()
 	return idx;
 }
 
+int SavedataParam::GetSaveNameIndex(SceUtilitySavedataParam* param)
+{
+	std::string saveName = GetSaveName(param);
+	for (int i = 0; i < saveNameListDataCount; i++)
+	{
+		// TODO: saveName may contain wildcards
+		if (saveDataList[i].saveName == saveName)
+		{
+			return i;
+		}
+	}
+
+	return 0;
+}
+
 void SavedataParam::DoState(PointerWrap &p)
 {
 	auto s = p.Section("SavedataParam", 1);

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -330,6 +330,7 @@ public:
 	int GetLastDataSave();
 	int GetFirstEmptySave();
 	int GetLastEmptySave();
+	int GetSaveNameIndex(SceUtilitySavedataParam* param);
 
 	void DoState(PointerWrap &p);
 


### PR DESCRIPTION
This makes Tales of Phantasia X behave correctly. It passes a wildcard to this function right after boot ("-P*" instead of the usual "-PXX"), which isn't handled. I'm not sure what it tries to do with that though. It defaults to 0 if no match is found, so in the worst case it doesn't behave worse than before.
