### PR TITLE
ARMJIT: Cache fpcond in a register to avoid store/load between compare and branch

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -287,8 +287,8 @@ void Jit::BranchFPFlag(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
-	LDR(R0, CTXREG, offsetof(MIPSState, fpcond));
-	TST(R0, Operand2(1, TYPE_IMM));
+	gpr.MapReg(MIPS_REG_FPCOND, 0);
+	TST(gpr.R(MIPS_REG_FPCOND), Operand2(1, TYPE_IMM));
 
 	ArmGen::FixupBranch ptr;
 	if (!likely)

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -532,6 +532,8 @@ int ArmRegCache::GetMipsRegOffset(MIPSGPReg r) {
 		return offsetof(MIPSState, hi);
 	case MIPS_REG_LO:
 		return offsetof(MIPSState, lo);
+	case MIPS_REG_FPCOND:
+		return offsetof(MIPSState, fpcond);
 	default:
 		ERROR_LOG(JIT, "bad mips register %i", r);
 		return 0;  // or what?

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -31,7 +31,7 @@ using namespace ArmGen;
 // R11 = base pointer
 
 enum {
-	TOTAL_MAPPABLE_MIPSREGS = 34,
+	TOTAL_MAPPABLE_MIPSREGS = 35,
 };
 
 typedef int MIPSReg;

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -68,6 +68,7 @@ enum MIPSGPReg
 	// Not real regs, just for convenience/jit mapping.
 	MIPS_REG_HI = 32,
 	MIPS_REG_LO = 33,
+	MIPS_REG_FPCOND = 34,
 };
 
 enum


### PR DESCRIPTION
Pretty self-explanatory.

This may grab an extra register at times but we save a store/load so it should be a tiny win at least.
