### PR TITLE
add build scripts to directly build with ant

### DIFF
--- a/android/ab-ant.sh
+++ b/android/ab-ant.sh
@@ -1,0 +1,3 @@
+ant debug
+adb install -r bin/PPSSPP-debug.apk
+adb shell am start -n org.ppsspp.ppsspp/org.ppsspp.ppsspp.PpssppActivity

--- a/android/build.xml
+++ b/android/build.xml
@@ -37,6 +37,12 @@
         <isset property="env.ANDROID_HOME" />
     </condition>
 
+    <!-- this property is needed to run the script via ANT. It requires the NDK
+        environment variable which is accessed by ant during the build process -->
+    <condition property="ndk.dir" value="${env.NDK}">
+        <isset property="env.NDK" />
+    </condition>
+    
     <!-- The project.properties file is created and updated by the 'android'
          tool, as well as ADT.
 


### PR DESCRIPTION
I personally hate Eclipse, so I decided to figure out how to build with ant (the Java build system that eclipse uses internally). 

Ant requires two environment variables - `ANDROID_HOME` and `NDK`.

ANDROID_HOME is the path to the android SDK folder. for example:
`~/me/programming/android/sdk` would be your `ANDROID_HOME` path.

NDK is the path to the [Android NDK](http://developer.android.com/tools/sdk/ndk/index.html) on your machine. It's used to compile the C++ side to things (which interfaces with the Java code). For example:
`~/me/programming/android/ndk` would be your NDK path.

Once these two paths have been exported (export them by adding these lines in your ~/.bashrc (or) ~/.zshrc), go to `ppsspp/android` and run `ab-ant.sh`. This script does 3 things:

1)  build the project and generate ppsspp-debug.apk
2)  install the ppsspp.apk into your phone
3) run the main activity in the ppsspp apk.

It's nicer since you can automate it to build every time you save / every time you push (or) whatever is up your alley :)  Just decided to add this for anyone who wants this info

Note - this does _not_ break ab.sh. You can still compile just fine by first running ab.sh and then use Eclipse.
This is just a faster one-step process.
