### PR TITLE
Fix a few warnings, report unaligned relocs, and adjust the check

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -38,7 +38,9 @@
 
 // __FUNCTION__ is misused a lot below, it's no longer a string literal but a virtual
 // variable so this use fails in some compilers. Just define it away for now.
+#ifndef _MSC_VER
 #define __FUNCTION__ "(n/a)"
+#endif
 
 namespace ArmGen
 {
@@ -166,8 +168,8 @@ void ARMXEmitter::ADDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch)
 			// Decompose into two additions.
 			ADD(rd, rs, Operand2((u8)(val >> 8), 12));   // rotation right by 12*2 == rotation left by 8
 			ADD(rd, rd, Operand2((u8)(val), 0));
-		} else if (((-(u32)(s32)val) & 0xFFFF0000) == 0) {
-			val = -(u32)(s32)val;
+		} else if ((((u32)-(s32)val) & 0xFFFF0000) == 0) {
+			val = (u32)-(s32)val;
 			SUB(rd, rs, Operand2((u8)(val >> 8), 12));
 			SUB(rd, rd, Operand2((u8)(val), 0));
 		} else {

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -69,18 +69,18 @@ bool ElfReader::LoadRelocations(Elf32_Rel *rels, int numRelocs)
 		//0 = code
 		//1 = data
 
-		if (readwrite >= ARRAY_SIZE(segmentVAddr)) {
+		if (readwrite >= (int)ARRAY_SIZE(segmentVAddr)) {
 			if (numErrors < 10) {
-				ERROR_LOG(LOADER, "Bad segment number %i", readwrite);
+				ERROR_LOG_REPORT(LOADER, "Bad segment number %i", readwrite);
 			}
 			numErrors++;
 			continue;
 		}
 
 		addr += segmentVAddr[readwrite];
-		if ((addr & 3) || !Memory::IsValidAddress(addr)) {
+		if (((addr & 3) && type != R_MIPS_32) || !Memory::IsValidAddress(addr)) {
 			if (numErrors < 10) {
-				WARN_LOG(LOADER, "Suspicious address %08x, skipping reloc", addr);
+				WARN_LOG_REPORT(LOADER, "Suspicious address %08x, skipping reloc, type = %d", addr, type);
 			} else if (numErrors == 10) {
 				WARN_LOG(LOADER, "Too many bad relocations, skipping logging");
 			}

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -169,8 +169,8 @@ void MIPSState::DoState(PointerWrap &p) {
 	p.Do(lo);
 	p.Do(fpcond);
 	if (s <= 1) {
-		u32 fcr0_unusued = 0;
-		p.Do(fcr0_unusued);
+		u32 fcr0_unused = 0;
+		p.Do(fcr0_unused);
 	}
 	p.Do(fcr31);
 	p.Do(rng.m_w);


### PR DESCRIPTION
Well, I'm not sure any really must be aligned, but at least Lunar definitely uses unaligned 32-bit ones.  This fixes #4544 and adds reporting so we can see the rest.

-[Unknown]
