### PR TITLE
Debugger changes

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -248,7 +248,7 @@ namespace MIPSAnalyst {
 		u32 addr;
 		for (addr = startAddr; addr <= endAddr; addr+=4) {
 			SymbolInfo syminfo;
-			if (symbolMap.GetSymbolInfo(&syminfo, addr, ST_FUNCTION)) {
+			if (symbolMap.GetSymbolInfo(&syminfo, addr, ST_FUNCTION) && syminfo.size >= 4) {
 				addr = syminfo.address + syminfo.size;
 				continue;
 			}

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -121,7 +121,8 @@ public:
 		switch (cat)
 		{
 		case 0:
-			cpu->r[index] = value;
+			if (index != 0)
+				cpu->r[index] = value;
 			break;
 
 		case 1:

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -31,22 +31,22 @@ extern HMENU g_hPopupMenus;
 
 void CtrlDisAsmView::init()
 {
-    WNDCLASSEX wc;
-    
-    wc.cbSize         = sizeof(wc);
-    wc.lpszClassName  = szClassName;
-    wc.hInstance      = GetModuleHandle(0);
-    wc.lpfnWndProc    = CtrlDisAsmView::wndProc;
-    wc.hCursor        = LoadCursor (NULL, IDC_ARROW);
-    wc.hIcon          = 0;
-    wc.lpszMenuName   = 0;
-    wc.hbrBackground  = (HBRUSH)GetSysColorBrush(COLOR_WINDOW);
-    wc.style          = 0;
-    wc.cbClsExtra     = 0;
-    wc.cbWndExtra     = sizeof( CtrlDisAsmView * );
-    wc.hIconSm        = 0;
+	WNDCLASSEX wc;
 	
-    RegisterClassEx(&wc);
+	wc.cbSize         = sizeof(wc);
+	wc.lpszClassName  = szClassName;
+	wc.hInstance      = GetModuleHandle(0);
+	wc.lpfnWndProc    = CtrlDisAsmView::wndProc;
+	wc.hCursor        = LoadCursor (NULL, IDC_ARROW);
+	wc.hIcon          = 0;
+	wc.lpszMenuName   = 0;
+	wc.hbrBackground  = (HBRUSH)GetSysColorBrush(COLOR_WINDOW);
+	wc.style          = 0;
+	wc.cbClsExtra     = 0;
+	wc.cbWndExtra     = sizeof( CtrlDisAsmView * );
+	wc.hIconSm        = 0;
+	
+	RegisterClassEx(&wc);
 }
 
 void CtrlDisAsmView::deinit()
@@ -220,19 +220,19 @@ LRESULT CALLBACK CtrlDisAsmView::wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPA
 {
 	CtrlDisAsmView *ccp = CtrlDisAsmView::getFrom(hwnd);
 	static bool lmbDown=false,rmbDown=false;
-    switch(msg)
-    {
-    case WM_NCCREATE:
-        // Allocate a new CustCtrl structure for this window.
-        ccp = new CtrlDisAsmView(hwnd);
+	switch(msg)
+	{
+	case WM_NCCREATE:
+		// Allocate a new CustCtrl structure for this window.
+		ccp = new CtrlDisAsmView(hwnd);
 		
-        // Continue with window creation.
-        return ccp != NULL;
+		// Continue with window creation.
+		return ccp != NULL;
 		
 		// Clean up when the window is destroyed.
-    case WM_NCDESTROY:
-        delete ccp;
-        break;
+	case WM_NCDESTROY:
+		delete ccp;
+		break;
 	case WM_SETFONT:
 		break;
 	case WM_SIZE:
@@ -293,17 +293,17 @@ LRESULT CALLBACK CtrlDisAsmView::wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPA
 			}
 		}
 		return DLGC_WANTCHARS|DLGC_WANTARROWS;
-    default:
-        break;
-    }
+	default:
+		break;
+	}
 	
-    return DefWindowProc(hwnd, msg, wParam, lParam);
+	return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
 
 CtrlDisAsmView *CtrlDisAsmView::getFrom(HWND hwnd)
 {
-    return (CtrlDisAsmView *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+	return (CtrlDisAsmView *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
 }
 
 
@@ -740,6 +740,8 @@ void CtrlDisAsmView::onVScroll(WPARAM wParam, LPARAM lParam)
 	default:
 		return;
 	}
+
+	scanFunctions();
 	redraw();
 }
 
@@ -836,6 +838,20 @@ void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 			break;
 		case 'd':	// toogle breakpoint enabled
 			toggleBreakpoint(true);
+			break;
+		case VK_UP:
+			windowStart -= instructionSize;
+			scanFunctions();
+			break;
+		case VK_DOWN:
+			windowStart += instructionSize;
+			scanFunctions();
+			break;
+		case VK_NEXT:
+			setCurAddress(windowEnd-instructionSize,KeyDownAsync(VK_SHIFT));
+			break;
+		case VK_PRIOR:
+			setCurAddress(windowStart,KeyDownAsync(VK_SHIFT));
 			break;
 		}
 	} else {

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -90,6 +90,7 @@ class CtrlDisAsmView
 	bool keyTaken;
 
 	void assembleOpcode(u32 address, std::string defaultText);
+	std::string disassembleRange(u32 start, u32 size);
 	void disassembleToFile();
 	void search(bool continueSearch);
 	void followBranch();


### PR DESCRIPTION
-workaround for symbols defined in .sym that could break the function analyzer
-change register value by assembling "reg=value"
-scan functions on vscroll
-move the window with ctrl+up/down without changing the cursor address
-improve copied disassembly
