### PR TITLE
OSX build fixes for the Qt version

### DIFF
--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -30,6 +30,7 @@ LIBS += -lCore$${XT} -lCommon$${XT} -lNative$${XT}
 # FFMPEG Path
 win32:  FFMPEG_DIR = ../ffmpeg/Windows/$${QMAKE_TARGET.arch}/lib/
 linux:  FFMPEG_DIR = ../ffmpeg/linux/$${QMAKE_TARGET.arch}/lib/
+macx|!mobile_platform:   FFMPEG_DIR = ../ffmpeg/macosx/x86_64/lib/
 qnx:    FFMPEG_DIR = ../ffmpeg/blackberry/armv7/lib/
 symbian:FFMPEG_DIR = -l
 

--- a/Qt/Settings.pri
+++ b/Qt/Settings.pri
@@ -52,6 +52,12 @@ contains(MEEGO_EDITION,harmattan) {
 	DEFINES += MEEGO_EDITION_HARMATTAN "_SYS_UCONTEXT_H=1"
 }
 
+macx:!mobile_platform {
+	INCLUDEPATH += ../ffmpeg/macosx/x86_64/include
+	#the qlist headers include <initializer_list> in QT5
+	greaterThan(QT_MAJOR_VERSION,4):CONFIG+=c++11
+}
+
 linux:!mobile_platform {
 	contains(QT_ARCH, x86_64): QMAKE_TARGET.arch = x86_64
 	else: QMAKE_TARGET.arch = x86

--- a/Qt/ctrldisasmview.cpp
+++ b/Qt/ctrldisasmview.cpp
@@ -8,6 +8,8 @@
 #include <QInputDialog>
 #include <QMessageBox>
 
+#include "math.h"
+
 #include "debugger_disasm.h"
 #include "Core/Debugger/SymbolMap.h"
 

--- a/Qt/ctrlmemview.cpp
+++ b/Qt/ctrlmemview.cpp
@@ -8,6 +8,8 @@
 #include <QClipboard>
 #include <QInputDialog>
 
+#include "math.h"
+
 #include "EmuThread.h"
 #include "Core/MemMap.h"
 #include "Core/Debugger/SymbolMap.h"


### PR DESCRIPTION
FFMpeg include and lib folders weren't set in the QMake.

Additionally the `floor` function can't be found in two of the *.cpp files.
