### PR TITLE
Adjust ctrl timing (sample and wake after vblank)

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -114,7 +114,7 @@ void __CtrlUpdateLatch()
 	latch.btnMake |= buttons & changed;
 	latch.btnBreak |= ctrlOldButtons & changed;
 	latch.btnPress |= buttons;
-	latch.btnRelease |= (ctrlOldButtons & ~buttons) & changed;
+	latch.btnRelease |= ~buttons;
 	dialogBtnMake |= buttons & changed;
 	ctrlLatchBufs++;
 		

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -195,10 +195,8 @@ void __CtrlSetRapidFire(bool state)
 	emuRapidFire = state;
 }
 
-int __CtrlReadSingleBuffer(u32 ctrlDataPtr, bool negative)
+int __CtrlReadSingleBuffer(PSPPointer<_ctrl_data> data, bool negative)
 {
-	PSPPointer<_ctrl_data> data;
-	data = ctrlDataPtr;
 	if (data.IsValid())
 	{
 		*data = ctrlBufs[ctrlBufRead];
@@ -238,11 +236,10 @@ int __CtrlReadBuffer(u32 ctrlDataPtr, u32 nBufs, bool negative, bool peek)
 	ctrlBufRead = (ctrlBuf - availBufs + NUM_CTRL_BUFFERS) % NUM_CTRL_BUFFERS;
 
 	int done = 0;
+	PSPPointer<_ctrl_data> data;
+	data = ctrlDataPtr;
 	for (u32 i = 0; i < availBufs; ++i)
-	{
-		done += __CtrlReadSingleBuffer(ctrlDataPtr, negative);
-		ctrlDataPtr += sizeof(_ctrl_data);
-	}
+		done += __CtrlReadSingleBuffer(data++, negative);
 
 	if (peek)
 		ctrlBufRead = resetRead;
@@ -268,7 +265,8 @@ retry:
 		if (wVal == 0)
 			goto retry;
 
-		u32 ctrlDataPtr = __KernelGetWaitValue(threadID, error);
+		PSPPointer<_ctrl_data> ctrlDataPtr;
+		ctrlDataPtr = __KernelGetWaitValue(threadID, error);
 		int retVal = __CtrlReadSingleBuffer(ctrlDataPtr, wVal == CTRL_WAIT_NEGATIVE);
 		__KernelResumeThreadFromWait(threadID, retVal);
 	}

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -501,9 +501,6 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	}
 	frameStartTicks = CoreTiming::GetTicks();
 
-	// Fire the vblank listeners before we wake threads.
-	__DisplayFireVblank();
-
 	// Wake up threads waiting for VBlank
 	u32 error;
 	for (size_t i = 0; i < vblankWaitingThreads.size(); i++) {
@@ -588,6 +585,9 @@ void hleLeaveVblank(u64 userdata, int cyclesLate) {
 	isVblank = 0;
 	DEBUG_LOG(SCEDISPLAY,"Leave VBlank %i", (int)userdata - 1);
 	CoreTiming::ScheduleEvent(msToCycles(frameMs - vblankMs) - cyclesLate, enterVblankEvent, userdata);
+
+	// Fire the vblank listeners after the vblank completes.
+	__DisplayFireVblank();
 }
 
 u32 sceDisplayIsVblank() {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -353,9 +353,6 @@ static inline bool DepthTestPassed(int x, int y, u16 z)
 {
 	u16 reference_z = GetPixelDepth(x, y);
 
-	if (gstate.isModeClear())
-		return true;
-
 	switch (gstate.getDepthTestFunction()) {
 	case GE_COMP_NEVER:
 		return false;


### PR DESCRIPTION
This seems to be more correct.  I'd swear I tested this before and it wasn't, but we made some other timing fixes, and I suspect may test was not accurate before.

May improve #4020, may hurt it, or may not change it.  Has the potential to break input or timing in games.

Cleaning up the test that shows this now.  Would be interested if anyone can report if this helps/hurts, though.

-[Unknown]
