### PR TITLE
Minor GE debugger tweaks, fpu/vfpu expression support

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -529,7 +529,7 @@ int ElfReader::LoadInto(u32 loadAddress)
 		for (int i = 0; i < header->e_phnum; i++)
 		{
 			Elf32_Phdr *p = &segments[i];
-			if (p->p_type == 0x700000A0) 	{
+			if (p->p_type == PT_PSPREL1) {
 				INFO_LOG(LOADER,"Loading segment relocations");
 				int numRelocs = p->p_filesz / sizeof(Elf32_Rel);
 
@@ -537,7 +537,7 @@ int ElfReader::LoadInto(u32 loadAddress)
 				if (!LoadRelocations(rels, numRelocs)) {
 					ERROR_LOG(LOADER, "LoadInto: Relocs failed, trying anyway (2)");
 				}
-			} else if (p->p_type == 0x700000A1) {
+			} else if (p->p_type == PT_PSPREL2) {
 				INFO_LOG(LOADER,"Loading segment relocations2");
 				LoadRelocations2(i);
 			}

--- a/Core/ELF/ElfTypes.h
+++ b/Core/ELF/ElfTypes.h
@@ -32,6 +32,7 @@ enum ElfType
 	ET_CORE        =4,
 	ET_LOPROC =0xFF00,
 	ET_HIPROC =0xFFFF,
+	ET_PSP_PRX=0xFFA0,
 };
 
 // Machine/Architecture
@@ -77,6 +78,34 @@ enum ElfMachine
 #define ELFDATANONE 0
 #define ELFDATA2LSB 1
 #define ELFDATA2MSB 2
+
+// MIPS-specific header flags.
+#define EF_MIPS_NOREORDER 0x00000001
+#define EF_MIPS_PIC       0x00000002
+#define EF_MIPS_CPIC      0x00000004
+#define EF_MIPS_XGOT      0x00000008
+#define EF_MIPS_UCODE     0x00000010
+#define EF_MIPS_ABI2      0x00000020
+#define EF_MIPS_DYNAMIC   0x00000040
+#define EF_MIPS_32BITMODE 0x00000100
+#define EF_MIPS_ABI_MASK  0x0000f000
+#define EF_MIPS_ABI_O32   0x00001000
+#define EF_MIPS_ABI_O64   0x00002000
+#define E_MIPS_ABI_EABI32 0x00003000
+#define E_MIPS_ABI_EABI64 0x00004000
+#define EF_MIPS_MACH_MASK 0x00ff0000
+#define EF_MIPS_MACH_PSP  0x00a20000
+#define EF_MIPS_ARCH_MASK 0xf0000000
+#define EF_MIPS_ARCH_1    0x00000000
+#define EF_MIPS_ARCH_2    0x10000000
+#define EF_MIPS_ARCH_3    0x20000000
+#define EF_MIPS_ARCH_4    0x30000000
+#define EF_MIPS_ARCH_5    0x40000000
+#define EF_MIPS_ARCH_32   0x50000000
+#define EF_MIPS_ARCH_64   0x60000000
+#define EF_MIPS_ARCH_32R2 0x70000000
+#define EF_MIPS_ARCH_64R2 0x80000000
+
 
 
 /////////////////////
@@ -164,6 +193,10 @@ enum ElfSectionFlags
 #define PT_PHDR             6
 #define PT_LOPROC  0x70000000
 #define PT_HIPROC  0x7FFFFFFF
+
+// Custom segment types
+#define PT_PSPREL1 0x700000a0
+#define PT_PSPREL2 0x700000a1
 
 // Segment flags
 #define PF_X 1

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -26,6 +26,17 @@
 #include "../MIPS/MIPS.h"
 #include "../System.h"
 
+enum ReferenceIndexType {
+	REF_INDEX_PC = 32,
+	REF_INDEX_HI = 33,
+	REF_INDEX_LO = 34,
+	REF_INDEX_FPU = 0x1000,
+	REF_INDEX_FPU_INT = 0x2000,
+	REF_INDEX_VFPU = 0x4000,
+	REF_INDEX_VFPU_INT = 0x8000,
+	REF_INDEX_IS_FLOAT = REF_INDEX_FPU | REF_INDEX_VFPU,
+};
+
 
 class MipsExpressionFunctions: public IExpressionFunctions
 {
@@ -37,20 +48,61 @@ public:
 		for (int i = 0; i < 32; i++)
 		{
 			char reg[8];
-			sprintf(reg,"r%d",i);
+			sprintf(reg, "r%d", i);
 
-			if (strcasecmp(str,reg) == 0 || strcasecmp(str,cpu->GetRegName(0,i)) == 0)
+			if (strcasecmp(str, reg) == 0 || strcasecmp(str, cpu->GetRegName(0, i)) == 0)
 			{
 				referenceIndex = i;
 				return true;
 			}
+			else if (strcasecmp(str, cpu->GetRegName(1, i)) == 0)
+			{
+				referenceIndex = REF_INDEX_FPU | i;
+				return true;
+			}
+
+			sprintf(reg, "fi%d", i);
+			if (strcasecmp(str, reg) == 0)
+			{
+				referenceIndex = REF_INDEX_FPU_INT | i;
+				return true;
+			}
 		}
 
-		if (strcasecmp(str,"pc") == 0)
+		for (int i = 0; i < 128; i++)
 		{
-			referenceIndex = 32;
+			if (strcasecmp(str, cpu->GetRegName(2, i)) == 0)
+			{
+				referenceIndex = REF_INDEX_VFPU | i;
+				return true;
+			}
+
+			char reg[8];
+			sprintf(reg, "vi%d", i);
+			if (strcasecmp(str, reg) == 0)
+			{
+				referenceIndex = REF_INDEX_VFPU_INT | i;
+				return true;
+			}
+		}
+
+		if (strcasecmp(str, "pc") == 0)
+		{
+			referenceIndex = REF_INDEX_PC;
 			return true;
-		} 
+		}
+
+		if (strcasecmp(str, "hi") == 0)
+		{
+			referenceIndex = REF_INDEX_HI;
+			return true;
+		}
+
+		if (strcasecmp(str, "lo") == 0)
+		{
+			referenceIndex = REF_INDEX_LO;
+			return true;
+		}
 
 		return false;
 	}
@@ -62,9 +114,26 @@ public:
 
 	virtual uint32 getReferenceValue(uint32 referenceIndex)
 	{
-		if (referenceIndex < 32) return cpu->GetRegValue(0,referenceIndex);
-		if (referenceIndex == 32) return cpu->GetPC();
+		if (referenceIndex < 32)
+			return cpu->GetRegValue(0, referenceIndex);
+		if (referenceIndex == REF_INDEX_PC)
+			return cpu->GetPC();
+		if (referenceIndex == REF_INDEX_HI)
+			return cpu->GetHi();
+		if (referenceIndex == REF_INDEX_LO)
+			return cpu->GetLo();
+		if ((referenceIndex & ~(REF_INDEX_FPU | REF_INDEX_FPU_INT)) < 32)
+			return cpu->GetRegValue(1, referenceIndex & ~(REF_INDEX_FPU | REF_INDEX_FPU_INT));
+		if ((referenceIndex & ~(REF_INDEX_VFPU | REF_INDEX_VFPU_INT)) < 128)
+			return cpu->GetRegValue(2, referenceIndex & ~(REF_INDEX_VFPU | REF_INDEX_VFPU_INT));
 		return -1;
+	}
+
+	virtual ExpressionType getReferenceType(uint32 referenceIndex) {
+		if (referenceIndex & REF_INDEX_IS_FLOAT) {
+			return EXPR_TYPE_FLOAT;
+		}
+		return EXPR_TYPE_UINT;
 	}
 	
 	virtual bool getMemoryValue(uint32 address, int size, uint32& dest, char* error)

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -103,6 +103,7 @@ public:
 		{
 		case 0:
 			return cpu->r[index];
+
 		case 1:
 			memcpy(&temp, &cpu->f[index], 4);
 			return temp;

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -38,22 +38,39 @@ enum GPUDebugBufferFormat {
 	GPU_DBG_FORMAT_8888 = 3,
 	GPU_DBG_FORMAT_INVALID = 0xFF,
 
+	// These are reversed versions.
+	GPU_DBG_FORMAT_REVERSE_FLAG = 4,
+	GPU_DBG_FORMAT_565_REV = 4,
+	GPU_DBG_FORMAT_5551_REV = 5,
+	GPU_DBG_FORMAT_4444_REV = 6,
+
 	// These don't, they're for depth/stencil buffers.
 	GPU_DBG_FORMAT_FLOAT = 0x10,
 	GPU_DBG_FORMAT_16BIT = 0x11,
 	GPU_DBG_FORMAT_8BIT = 0x12,
 };
 
+inline GPUDebugBufferFormat &operator |=(GPUDebugBufferFormat &lhs, const GPUDebugBufferFormat &rhs) {
+	lhs = GPUDebugBufferFormat((int)lhs | (int)rhs);
+	return lhs;
+}
+
 struct GPUDebugBuffer {
 	GPUDebugBuffer() : alloc_(false), data_(NULL) {
 	}
 
-	GPUDebugBuffer(void *data, u32 stride, u32 height, GEBufferFormat fmt)
+	GPUDebugBuffer(void *data, u32 stride, u32 height, GEBufferFormat fmt, bool reversed = false)
 		: alloc_(false), data_((u8 *)data), stride_(stride), height_(height), fmt_(GPUDebugBufferFormat(fmt)), flipped_(false) {
+		if (reversed && fmt_ < GPU_DBG_FORMAT_8888) {
+			fmt_ |= GPU_DBG_FORMAT_REVERSE_FLAG;
+		}
 	}
 
-	GPUDebugBuffer(void *data, u32 stride, u32 height, GETextureFormat fmt)
+	GPUDebugBuffer(void *data, u32 stride, u32 height, GETextureFormat fmt, bool reversed = false)
 		: alloc_(false), data_((u8 *)data), stride_(stride), height_(height), fmt_(GPUDebugBufferFormat(fmt)), flipped_(false) {
+		if (reversed && fmt_ < GPU_DBG_FORMAT_8888) {
+			fmt_ |= GPU_DBG_FORMAT_REVERSE_FLAG;
+		}
 	}
 
 	GPUDebugBuffer(void *data, u32 stride, u32 height, GPUDebugBufferFormat fmt)
@@ -91,8 +108,12 @@ struct GPUDebugBuffer {
 		return *this;
 	}
 
-	void Allocate(u32 stride, u32 height, GEBufferFormat fmt, bool flipped = false) {
-		Allocate(stride, height, GPUDebugBufferFormat(fmt), flipped);
+	void Allocate(u32 stride, u32 height, GEBufferFormat fmt, bool flipped = false, bool reversed = false) {
+		GPUDebugBufferFormat actualFmt = GPUDebugBufferFormat(fmt);
+		if (reversed && actualFmt < GPU_DBG_FORMAT_8888) {
+			actualFmt |= GPU_DBG_FORMAT_REVERSE_FLAG;
+		}
+		Allocate(stride, height, actualFmt, flipped);
 	}
 
 	void Allocate(u32 stride, u32 height, GPUDebugBufferFormat fmt, bool flipped = false) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1533,7 +1533,7 @@ bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
 		return true;
 	}
 
-	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GE_FORMAT_8888, true);
+	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GE_FORMAT_8888, true, true);
 	if (vfb->fbo)
 		fbo_bind_for_read(vfb->fbo);
 #ifndef USING_GLES2

--- a/Windows/Debugger/BreakpointWindow.cpp
+++ b/Windows/Debugger/BreakpointWindow.cpp
@@ -148,7 +148,7 @@ bool BreakpointWindow::fetchDialogData(HWND hwnd)
 
 		if (cpu->parseExpression(exp,size) == false)
 		{
-			sprintf(errorMessage,"Invalid expression \"%s\".",str);
+			sprintf(errorMessage,"Invalid expression \"%s\".",exp);
 			MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
 			return false;
 		}

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -71,7 +71,6 @@ CGEDebugger::CGEDebugger(HINSTANCE _hInstance, HWND _hParent)
 
 	// it's ugly, but .rc coordinates don't match actual pixels and it screws
 	// up both the size and the aspect ratio
-	// TODO: Could be scrollable in case the framebuf is larger?  Also should be better positioned.
 	RECT frameRect;
 	HWND frameWnd = GetDlgItem(m_hDlg,IDC_GEDBG_FRAME);
 
@@ -140,8 +139,6 @@ void CGEDebugger::SetupPreviews() {
 }
 
 void CGEDebugger::UpdatePreviews() {
-	// TODO: Do something different if not paused?
-
 	wchar_t desc[256];
 	const GPUDebugBuffer *primaryBuffer = NULL;
 	bool bufferResult = false;
@@ -288,6 +285,10 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		return TRUE;
 
 	case WM_CLOSE:
+		attached = false;
+		ResumeFromStepping();
+		breakNext = BREAK_NONE;
+
 		Show(false);
 		return TRUE;
 
@@ -309,7 +310,6 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			break;
 		case IDC_GEDBG_FBTABS:
 			fbTabs->HandleNotify(lParam);
-			// TODO: Move this somewhere...
 			if (attached && gpuDebug != NULL) {
 				UpdatePreviews();
 			}
@@ -345,6 +345,7 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 
 		case IDC_GEDBG_BREAKTEX:
 			{
+				attached = true;
 				if (!gpuDebug) {
 					break;
 				}
@@ -367,7 +368,6 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			SetDlgItemText(m_hDlg, IDC_GEDBG_FRAMEBUFADDR, L"");
 			SetDlgItemText(m_hDlg, IDC_GEDBG_TEXADDR, L"");
 
-			// TODO: detach?  Should probably have separate UI, or just on activate?
 			ResumeFromStepping();
 			breakNext = BREAK_NONE;
 			break;
@@ -397,6 +397,7 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 
 	case WM_GEDBG_TOGGLEPCBREAKPOINT:
 		{
+			attached = true;
 			u32 pc = (u32)wParam;
 			bool temp;
 			bool isBreak = IsAddressBreakpoint(pc, temp);
@@ -410,6 +411,7 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 
 	case WM_GEDBG_RUNTOWPARAM:
 		{
+			attached = true;
 			u32 pc = (u32)wParam;
 			AddAddressBreakpoint(pc, true);
 			SendMessage(m_hDlg,WM_COMMAND,IDC_GEDBG_RESUME,0);

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -224,6 +224,13 @@ void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
 		} else if (fmt == FORMAT_565) {
 			glfmt = GL_UNSIGNED_SHORT_5_6_5;
 			components = GL_RGB;
+		} else if (fmt == FORMAT_4444_REV) {
+			glfmt = GL_UNSIGNED_SHORT_4_4_4_4_REV;
+		} else if (fmt == FORMAT_5551_REV) {
+			glfmt = GL_UNSIGNED_SHORT_1_5_5_5_REV;
+		} else if (fmt == FORMAT_565_REV) {
+			glfmt = GL_UNSIGNED_SHORT_5_6_5_REV;
+			components = GL_RGB;
 		} else if (fmt == FORMAT_16BIT) {
 			glfmt = GL_UNSIGNED_SHORT;
 			components = GL_RED;

--- a/Windows/GEDebugger/SimpleGLWindow.h
+++ b/Windows/GEDebugger/SimpleGLWindow.h
@@ -25,10 +25,13 @@ struct SimpleGLWindow {
 	static const PTCHAR windowClass;
 
 	enum Format {
-		FORMAT_565 = 0,
-		FORMAT_5551 = 1,
-		FORMAT_4444 = 2,
+		FORMAT_565_REV = 0,
+		FORMAT_5551_REV = 1,
+		FORMAT_4444_REV = 2,
 		FORMAT_8888 = 3,
+		FORMAT_565 = 4,
+		FORMAT_5551 = 5,
+		FORMAT_4444 = 6,
 
 		FORMAT_FLOAT = 0x10,
 		FORMAT_16BIT = 0x11,

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -31,7 +31,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op) {
 		return;
 	}
 	if (!gpuDebug) {
-		ERROR_LOG(COMMON, "Invalid debugging environment, shutting down?", op);
+		ERROR_LOG(COMMON, "Invalid debugging environment, shutting down?");
 		return;
 	}
 	if (count == 0) {


### PR DESCRIPTION
Fixes the display under the softgpu, and allows more regs in expression breakpoints.

hrydgard/native#169 needs to be accepted first.

-[Unknown]
