### PR TITLE
fix fps and dev stats not using Qt renderer

### DIFF
--- a/Qt/qtemugl.cpp
+++ b/Qt/qtemugl.cpp
@@ -1,6 +1,7 @@
 #include "qtemugl.h"
 
 #include <QMouseEvent>
+#include <QThread>
 
 #include "base/display.h"
 #include "base/timeutil.h"
@@ -36,7 +37,7 @@ void QtEmuGL::paintGL()
 		startTime = time_now_d();
 		int sleepTime = (int) (1000000.0 / 60.0) - (int) (diffTime * 1000000.0);
 		if (sleepTime > 0)
-			usleep(sleepTime);
+			QThread::usleep(sleepTime);
 	}
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -596,10 +596,11 @@ void EmuScreen::render() {
 		if (statbuf[4095]) {
 			ELOG("Statbuf too small! :(");
 		}
-		ui_draw2d.SetFontScale(.7f, .7f);
-		ui_draw2d.DrawText(UBUNTU24, statbuf, 11, 11, 0xc0000000, FLAG_DYNAMIC_ASCII);
-		ui_draw2d.DrawText(UBUNTU24, statbuf, 10, 10, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
-		ui_draw2d.SetFontScale(1.0f, 1.0f);
+		UIContext *ctx = screenManager()->getUIContext();
+		ctx->SetFontScale(0.7f,0.7f);
+		ctx->DrawText(statbuf, 11, 11, 0xc0000000, FLAG_DYNAMIC_ASCII);
+		ctx->DrawText(statbuf, 10, 10, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+		ctx->SetFontScale(1.0f,1.0f);
 	}
 
 	if (g_Config.iShowFPSCounter) {
@@ -616,10 +617,11 @@ void EmuScreen::render() {
 		default:
 			return;
 		}
-		ui_draw2d.SetFontScale(0.7f, 0.7f);
-		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 8, 12, 0xc0000000, ALIGN_TOPRIGHT | FLAG_DYNAMIC_ASCII);
-		ui_draw2d.DrawText(UBUNTU24, fpsbuf, dp_xres - 10, 10, 0xFF3fFF3f, ALIGN_TOPRIGHT | FLAG_DYNAMIC_ASCII);
-		ui_draw2d.SetFontScale(1.0f, 1.0f);
+		UIContext *ctx = screenManager()->getUIContext();
+		ctx->SetFontScale(0.7f,0.7f);
+		ctx->DrawText(fpsbuf,dp_xres - 8, 12, 0xc0000000, ALIGN_TOPRIGHT | FLAG_DYNAMIC_ASCII);
+		ctx->DrawText(fpsbuf,dp_xres - 10, 10, 0xFF3fFF3f, ALIGN_TOPRIGHT| FLAG_DYNAMIC_ASCII );
+		ctx->SetFontScale(1.0f,1.0f);
 	}
 
 	glsl_bind(UIShader_Get());


### PR DESCRIPTION
I would like to find a more elegant solution but I couldn't come up with anything else than either this or an `#ifdef USING_QT_UI`

The issue is that the Qt build now no longer uses a font atlas so every
call to DrawBuffer::DrawText will crash the program

Also, use QThread::usleep because Windows doesn't have usleep.

bump native version to include atlas check
