### PR TITLE
Switch to 59.94 fps rather than 60, since we say we are 59.94

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -96,7 +96,7 @@ static double nextFrameTime;
 static int numVBlanksSinceFlip;
 
 static u64 frameStartTicks;
-const float hCountPerVblank = 285.72f; // insprired by jpcsp
+const float hCountPerVblank = 286.0f;
 
 
 std::vector<WaitVBlankInfo> vblankWaitingThreads;
@@ -111,7 +111,7 @@ std::vector<VblankCallback> vblankListeners;
 
 // The vblank period is 731.5 us (0.7315 ms)
 const double vblankMs = 0.7315;
-const double frameMs = 1000.0 / 60.0;
+const double frameMs = 1001.0 / 60.0;
 
 enum {
 	PSP_DISPLAY_SETBUF_IMMEDIATE = 0,

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -81,7 +81,7 @@ static int afterFlipEvent = -1;
 // hCount is computed now.
 static int vCount;
 // The "AccumulatedHcount" can be adjusted, this is the base.
-static double hCountBase;
+static u32 hCountBase;
 static int isVblank;
 static int numSkippedFrames;
 static bool hasSetMode;
@@ -96,7 +96,7 @@ static double nextFrameTime;
 static int numVBlanksSinceFlip;
 
 static u64 frameStartTicks;
-const float hCountPerVblank = 286.0f;
+const int hCountPerVblank = 286;
 
 
 std::vector<WaitVBlankInfo> vblankWaitingThreads;
@@ -164,7 +164,7 @@ void __DisplayInit() {
 	CoreTiming::ScheduleEvent(msToCycles(frameMs - vblankMs), enterVblankEvent, 0);
 	isVblank = 0;
 	vCount = 0;
-	hCountBase = 0.0;
+	hCountBase = 0;
 	curFrameTime = 0.0;
 	nextFrameTime = 0.0;
 
@@ -183,7 +183,7 @@ void __DisplayInit() {
 }
 
 void __DisplayDoState(PointerWrap &p) {
-	auto s = p.Section("sceDisplay", 1, 2);
+	auto s = p.Section("sceDisplay", 1, 3);
 	if (!s)
 		return;
 
@@ -192,7 +192,13 @@ void __DisplayDoState(PointerWrap &p) {
 	p.Do(framebufIsLatched);
 	p.Do(frameStartTicks);
 	p.Do(vCount);
-	p.Do(hCountBase);
+	if (s <= 2) {
+		double oldHCountBase;
+		p.Do(oldHCountBase);
+		hCountBase = (int) oldHCountBase;
+	} else {
+		p.Do(hCountBase);
+	}
 	p.Do(isVblank);
 	p.Do(hasSetMode);
 	p.Do(mode);

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1436,6 +1436,15 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 		break;
 #endif
 
+	// Handled in StateMapping.
+	case GE_CMD_STENCILTEST:
+	case GE_CMD_STENCILOP:
+		break;
+
+	case GE_CMD_MASKRGB:
+	case GE_CMD_MASKALPHA:
+		break;
+
 	case GE_CMD_UNKNOWN_03: 
 	case GE_CMD_UNKNOWN_0D:
 	case GE_CMD_UNKNOWN_11:


### PR DESCRIPTION
This fixes #4040, and the games I tested still seemed fine.  Star Ocean still okay too (no enemies soaring to the stratosphere still.)

Having hcount be an integer also improves the accuracy in the hcount test, matches the way games seem to calculate around it, and makes more sense anyway.

Might break games (so far hasn't any I tested, though...) but seems to match tests.

-[Unknown]
