### PR TITLE
Fix for broken pull #4575: Automatic pause/resume when memory dumping - by using a simpler and more safer coding

### DIFF
--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -440,6 +440,7 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				Core_EnableStepping(true); //force paused state
 				DumpMemoryWindow dump(wnd,debugger);
 			        dump.exec();
+			        Core_EnableStepping(false); //Resume emulation automatically
 			        break;
 			}
 			else

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -435,18 +435,19 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		{
 		case ID_MEMVIEW_DUMP:
      
-			bool PriorDumpIsPaused=Core_IsStepping();
-			if (!PriorDumpIsPaused) // If emulator isn't paused
+			if (!Core_IsStepping()) // If emulator isn't paused
 			{
 				Core_EnableStepping(true); //force paused state
+				DumpMemoryWindow dump(wnd,debugger);
+			        dump.exec();
+			        break;
 			}
-			DumpMemoryWindow dump(wnd,debugger);
-			dump.exec();
-			if (!PriorDumpIsPaused) // If emulator wasn't paused before dumping
+			else
 			{
-				Core_EnableStepping(false);//resume emulation
-			}
-			break;
+				DumpMemoryWindow dump(wnd,debugger);
+			        dump.exec();
+			        break;
+			}       
 
 		case ID_MEMVIEW_COPYVALUE_8:
 			{

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -439,15 +439,15 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			{
 				Core_EnableStepping(true); //force paused state
 				DumpMemoryWindow dump(wnd,debugger);
-			        dump.exec();
-			        Core_EnableStepping(false); //Resume emulation automatically
-			        break;
+				dump.exec();
+				Core_EnableStepping(false); //Resume emulation automatically
+				break;
 			}
 			else
 			{
 				DumpMemoryWindow dump(wnd,debugger);
-			        dump.exec();
-			        break;
+				dump.exec();
+				break;
 			}       
 
 		case ID_MEMVIEW_COPYVALUE_8:


### PR DESCRIPTION
Fix for broken pull #4575: Automatic pause/resume when memory dumping - by using a simpler and more precautious coding
