### PR TITLE
Windows Qt 5 build fixes

### DIFF
--- a/Qt/Settings.pri
+++ b/Qt/Settings.pri
@@ -13,6 +13,7 @@ INCLUDEPATH += ../ext/zlib ../native/ext/glew ../Common
 win32-msvc* {
 	QMAKE_CXXFLAGS_RELEASE += /O2 /arch:SSE2 /fp:fast
 	DEFINES += _MBCS GLEW_STATIC _CRT_SECURE_NO_WARNINGS
+	contains(DEFINES,UNICODE):DEFINES+=_UNICODE
 	PRECOMPILED_HEADER = ../Windows/stdafx.h
 	PRECOMPILED_SOURCE = ../Windows/stdafx.cpp
 	INCLUDEPATH += .. ../ffmpeg/Windows/$${QMAKE_TARGET.arch}/include

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -11,7 +11,20 @@
 #include "debugger_displaylist.h"
 
 #include <QtCore>
+#if QT_VERSION >= 0x050000
+#include <QApplication>
+#include <QKeyEvent>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QDesktopWidget>
+#include <QMenuBar>
+#include <QDesktopServices>
+#include <QMainWindow>
+#include <QActionGroup>
+#elif
 #include <QtGui>
+#endif
+
 
 class QtEmuGL;
 


### PR DESCRIPTION
The issue is that there's a distinction between UNICODE and _UNICODE
on Windows, to prevent build errors like TCHAR being a wchar but _tcsrchr
expects a char*

Additionally I get some issues under Qt5 by including <QtGui> it loads
the qt gl function loader and fucks with GLEW. I'd love to see a better
solution without an ifdef, so discuss before merging.
