### PR TITLE
Attempt to fix broken texture filering

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -482,6 +482,7 @@ static const GLuint MagFiltGL[2] = {
 void TextureCache::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 	int minFilt = gstate.texfilter & 0x7;
 	int magFilt = (gstate.texfilter>>8) & 1;
+	bool CanDoFiltering = !gstate.isColorTestEnabled() && (gstate.isDepthWriteEnabled() && gstate.isDitherEnabled() || !gstate.isAlphaTestEnabled());
 	bool sClamp = gstate.isTexCoordClampedS();
 	bool tClamp = gstate.isTexCoordClampedT();
 
@@ -501,7 +502,7 @@ void TextureCache::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 		}
 	}
 
-	if ((g_Config.iTexFiltering == LINEAR || (g_Config.iTexFiltering == LINEARFMV && g_iNumVideos)) && !gstate.isColorTestEnabled() && !gstate.isAlphaTestEnabled()) {
+	if ((g_Config.iTexFiltering == LINEAR || (g_Config.iTexFiltering == LINEARFMV && g_iNumVideos)) && CanDoFiltering) {
 		magFilt |= 1;
 		minFilt |= 1;
 	}


### PR DESCRIPTION
Well, the original commit was supposed to fix black squares in FFVII:CC during battles but that broke other things (e.g, videos in some games doesn't get filtered etc), possibly due to the developer choice for using alpha testing in videos for no apparent reason.

Now, there are three possibilities to tackle FFVII:CC issue:

1) Do filter only when alpha testing is disabled. (fails!, reason provided above)
2) Do filter only when depth testing is enabled. (fails!, videos don't use depth testing as per gDEBugger so they will never get filtered)
3) Do filter only when depth write is disabled. (fails!, most videos use depth write as per gDEBugger)

This commit will fail as well if the affected videos (that uses alpha testing) does not use depth write along with dither like most videos use. FFVII:CC (and some other games that I own) are happy with it.

I don't own those games so I can not say which states are enable/disabled during video playback in affected games, it's merely based on assumptions.

@solarmystic it requires your testing (if you have free time though) to see if this can fix those videos.
