### PR TITLE
Move that "missing" brace where I wanted it begin with - preserves code ...

### DIFF
--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -446,8 +446,8 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				{
 					Core_EnableStepping(false); //Resume emulation automatically
 				}
-				break;
 			}
+			break;
 			
 		case ID_MEMVIEW_COPYVALUE_8:
 			{


### PR DESCRIPTION
...style relative to the other case statements.
