### PR TITLE
Remove empty lines in disasmview to remove visual noise.

### DIFF
--- a/Qt/ctrldisasmview.cpp
+++ b/Qt/ctrldisasmview.cpp
@@ -237,7 +237,7 @@ void CtrlDisAsmView::paintEvent(QPaintEvent *)
 	int numBranches=0;
 
 	int width = rect().width();
-	int numRows=(rect().height()/rowHeight)/2+1;
+	int numRows=(rect().height()/rowHeight);
 
 	QColor bgColor(0xFFFFFFFF);
 	QPen nullPen(bgColor);
@@ -253,6 +253,7 @@ void CtrlDisAsmView::paintEvent(QPaintEvent *)
 	QFont normalFont("Arial", 10);
 	QFont boldFont("Arial", 10);
 	QFont alignedFont("Monospace", 10);
+	alignedFont.setStyleHint(QFont::Monospace);
 	boldFont.setBold(true);
 	painter.setFont(normalFont);
 
@@ -262,25 +263,29 @@ void CtrlDisAsmView::paintEvent(QPaintEvent *)
 	curAddress&=~(align-1);
 
 	align=(debugger->getInstructionSize(0));
-	for (i=-numRows; i<=numRows; i++)
+	for (i=0; i<=numRows; i++)
 	{
-		unsigned int address=curAddress + i*align;
+		unsigned int address=curAddress + (i-(numRows/2))*align;
 
-		int rowY1 = rect().bottom()/2 + rowHeight*i - rowHeight/2;
-		int rowY2 = rect().bottom()/2 + rowHeight*i + rowHeight/2 - 1;
+		int rowY1 = rect().top() + rowHeight*i;
+		int rowY2 = rect().top() + rowHeight*i + rowHeight - 1;
 
 		lbr.setColor((unsigned int)marker == address ? QColor(0xFFFFEEE0) : QColor(debugger->getColor(address)));
 		QColor bg = lbr.color();
+		painter.setBrush(currentBrush);
 		painter.setPen(nullPen);
 		painter.drawRect(0,rowY1,16-1,rowY2-rowY1);
 
 		if (selecting && address == (unsigned int)selection)
 			painter.setPen(selPen);
 		else
-			painter.setPen(i==0 ? currentPen : nullPen);
-
-		QBrush mojsBrush(lbr.color());
-		painter.setBrush(mojsBrush);
+		{
+			if(i==numRows/2)
+				painter.setPen(currentPen);
+			else
+				painter.setPen(bg);
+		}
+		painter.setBrush(QBrush(bg));
 
 		if (address == debugger->getPC())
 		{
@@ -410,7 +415,8 @@ void CtrlDisAsmView::paintEvent(QPaintEvent *)
 
 int CtrlDisAsmView::yToAddress(int y)
 {
-	int ydiff=y-rect().bottom()/2-rowHeight/2;
-	ydiff=(int)(floor((float)ydiff / (float)rowHeight))+1;
-	return curAddress + ydiff * align;
+	//int ydiff=y - rect().bottom()/2;//-rowHeight/2;
+	int ydiff=(int)(floor((float)y / (float)rowHeight));
+	ydiff -= (rect().height()/rowHeight)/2;
+	return curAddress + ydiff *align;
 }

--- a/Qt/ctrlmemview.cpp
+++ b/Qt/ctrlmemview.cpp
@@ -83,7 +83,7 @@ void CtrlMemView::paintEvent(QPaintEvent *)
 
 	QFont normalFont("Arial", 10);
 	QFont alignedFont("Monospace", 10);
-    alignedFont.setStyleHint(QFont::Monospace);
+	alignedFont.setStyleHint(QFont::Monospace);
 	painter.setFont(normalFont);
 
 	int i;

--- a/Qt/debugger_disasm.cpp
+++ b/Qt/debugger_disasm.cpp
@@ -36,7 +36,8 @@ Debugger_Disasm::Debugger_Disasm(DebugInterface *_cpu, MainWindow* mainWindow_, 
 
 	QObject::connect(ui->RegListScroll,SIGNAL(actionTriggered(int)), ui->RegList, SLOT(scrollChanged(int)));
 	QObject::connect(ui->RegList,SIGNAL(GotoDisasm(u32)),this,SLOT(Goto(u32)));
-	QObject::connect(this, SIGNAL(updateDisplayList_()), this, SLOT(UpdateDisplayListGUI()));
+	QObject::connect(this, SIGNAL(UpdateCallstack_()), this, SLOT(UpdateCallstackGUI()));
+	QObject::connect(this, SIGNAL(UpdateDisplayList_()), this, SLOT(UpdateDisplayListGUI()));
 	QObject::connect(this, SIGNAL(UpdateBreakpoints_()), this, SLOT(UpdateBreakpointsGUI()));
 	QObject::connect(this, SIGNAL(UpdateThread_()), this, SLOT(UpdateThreadGUI()));
 
@@ -112,33 +113,11 @@ void Debugger_Disasm::UpdateDialog()
 	UpdateBreakpoints();
 	UpdateThread();
 	UpdateDisplayList();
+	UpdateCallstack();
 
 	char tempTicks[24];
 	sprintf(tempTicks, "%lld", CoreTiming::GetTicks());
 	ui->debugCount->setText(QString("Ctr : ") + tempTicks);
-
-	/*ui->callStack->clear();
-	u32 pc = currentMIPS->pc;
-	u32 ra = currentMIPS->r[MIPS_REG_RA];
-	u32 addr = Memory::ReadUnchecked_U32(pc);
-	int count=1;
-	char addr_[12];
-	sprintf(addr_, "0x%08x",pc);
-	ui->callStack->addItem(new QListWidgetItem(addr_));
-
-	addr = Memory::ReadUnchecked_U32(ra);
-	sprintf(addr_, "0x%08x",ra);
-	ui->callStack->addItem(new QListWidgetItem(addr_));
-	count++;
-
-	while (addr != 0xFFFFFFFF && addr!=0 && Memory::IsValidAddress(addr+4) && count++<20)
-	{
-		u32 fun = Memory::ReadUnchecked_U32(addr+4);
-		sprintf(addr_, "0x%08x",fun);
-		ui->callStack->addItem(new QListWidgetItem(addr_));
-		addr = Memory::ReadUnchecked_U32(addr);
-	}*/
-
 
 	if(mainWindow->GetDialogMemory())
 		mainWindow->GetDialogMemory()->Update();
@@ -320,6 +299,53 @@ void Debugger_Disasm::FillFunctions()
 	}
 }
 
+void Debugger_Disasm::UpdateCallstack()
+{
+	emit UpdateCallstack_();
+}
+
+void Debugger_Disasm::UpdateCallstackGUI()
+{
+
+	auto threads = GetThreadsInfo();
+
+	u32 entry = 0, stackTop = 0;
+	for (size_t i = 0; i < threads.size(); i++)
+	{
+		if (threads[i].isCurrent)
+		{
+			entry = threads[i].entrypoint;
+			stackTop = threads[i].initialStack;
+			break;
+		}
+	}
+	if (entry != 0) {
+		stackTraceModel = MIPSStackWalk::Walk(
+				cpu->GetPC(),
+				cpu->GetRegValue(0,MIPS_REG_RA),
+				cpu->GetRegValue(0,MIPS_REG_SP),
+				entry,
+				stackTop);
+	} else {
+		stackTraceModel.clear();
+	}
+
+	ui->callStack->clear();
+
+	QTreeWidgetItem* item;
+	for(auto it=stackTraceModel.begin();it!=stackTraceModel.end();it++)
+	{
+		item = new QTreeWidgetItem();
+		item->setText(0,QString("%1").arg(it->pc,8,16,QChar('0')).prepend("0x"));
+		item->setData(0,Qt::UserRole,it->pc);
+		item->setText(1,QString("%1").arg(it->entry,8,16,QChar('0')).prepend("0x"));
+		item->setData(1,Qt::UserRole,it->entry);
+		item->setText(2,QString("%1").arg(it->sp,8,16,QChar('0')).prepend("0x"));
+		item->setText(3,QString("%1").arg(it->stackSize,8,16,QChar('0')).prepend("0x"));
+		ui->callStack->addTopLevelItem(item);
+	}
+}
+
 void Debugger_Disasm::UpdateBreakpoints()
 {
 	emit UpdateBreakpoints_();
@@ -492,7 +518,7 @@ void Debugger_Disasm::SetThreadStatusSuspend()
 
 void Debugger_Disasm::UpdateDisplayList()
 {
-	emit updateDisplayList_();
+	emit UpdateDisplayList_();
 }
 
 void Debugger_Disasm::UpdateDisplayListGUI()

--- a/Qt/debugger_disasm.h
+++ b/Qt/debugger_disasm.h
@@ -1,12 +1,14 @@
 #ifndef DEBUGGER_DISASM_H
 #define DEBUGGER_DISASM_H
 
+#include "Core/MIPS/MIPSStackWalk.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "debugger_vfpu.h"
 #include <QDialog>
 #include <QListWidgetItem>
 #include <QTreeWidgetItem>
+#include <vector>
 
 class MainWindow;
 namespace Ui {
@@ -36,12 +38,14 @@ public:
 	void Update();
 	void ShowMemory(u32 addr);
 	void FillFunctions();
+	void UpdateCallstack();
 	void UpdateBreakpoints();
 	void UpdateThread();
 	void UpdateDisplayList();
 
 signals:
-	void updateDisplayList_();
+	void UpdateCallstack_();
+	void UpdateDisplayList_();
 	void UpdateBreakpoints_();
 	void UpdateThread_();
 
@@ -51,6 +55,7 @@ public slots:
 	void GotoThreadEntryPoint();
 
 private slots:
+	void UpdateCallstackGUI();
 	void UpdateDisplayListGUI();
 	void UpdateBreakpointsGUI();
 	void UpdateThreadGUI();
@@ -91,6 +96,7 @@ private:
 	u32 breakpointAddr;
 	QTreeWidgetItem* threadRowSelected;
 	QTreeWidgetItem* displayListRowSelected;
+	std::vector<MIPSStackWalk::StackFrame> stackTraceModel;
 };
 
 #endif // DEBUGGER_DISASM_H

--- a/Qt/debugger_disasm.ui
+++ b/Qt/debugger_disasm.ui
@@ -175,7 +175,7 @@
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>229</width>
+                  <width>120</width>
                   <height>20</height>
                  </size>
                 </property>
@@ -315,7 +315,7 @@
          <property name="currentIndex">
           <number>0</number>
          </property>
-         <widget class="QWidget" name="tab_3">
+         <widget class="QWidget" name="breakpointsTab">
           <attribute name="title">
            <string>Breakpoints</string>
           </attribute>
@@ -367,17 +367,41 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="tab_6">
+         <widget class="QWidget" name="callstackTab">
           <attribute name="title">
            <string>Callstack</string>
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
-            <widget class="QListWidget" name="callStack"/>
+            <widget class="QTreeWidget" name="callStack">
+             <property name="columnCount">
+              <number>4</number>
+             </property>
+             <column>
+              <property name="text">
+               <string>Address</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Entry Point</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>SP</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>length</string>
+              </property>
+             </column>
+            </widget>
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="tab_4">
+         <widget class="QWidget" name="displaylistTab">
           <attribute name="title">
            <string>Display Lists</string>
           </attribute>
@@ -428,7 +452,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="tab_5">
+         <widget class="QWidget" name="threadsTab">
           <attribute name="title">
            <string>Threads</string>
           </attribute>


### PR DESCRIPTION
Port over part of the callstack code, still missing function name lookup
and navigation on double click. This is just an intermediate commit, I
don't want to have to rebase this again when I contine to work on it.

New this:
![image](https://f.cloud.github.com/assets/465677/1608225/820aa34a-54e2-11e3-80d0-d7b667106888.png)

Old this:

![image](https://f.cloud.github.com/assets/465677/1608228/ebd6d280-54e2-11e3-9625-b3a9d04cc74e.png)
