### PR TITLE
Add bit hacky to render alpha masking bit more correct

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -340,7 +340,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		bool rmask = (gstate.pmskc & 0xFF) < 128;
 		bool gmask = ((gstate.pmskc >> 8) & 0xFF) < 128;
 		bool bmask = ((gstate.pmskc >> 16) & 0xFF) < 128;
-		bool amask = (gstate.pmska & 0xFF) < 128;
+		bool amask = ((gstate.pmska & 0xFF) < 128) && gstate.isStencilTestEnabled() && !gstate.isDepthTestEnabled();
 		glstate.colorMask.set(rmask, gmask, bmask, amask);
 
 		// Stencil Test


### PR DESCRIPTION
Though not 100% correct and at least Wipeout Pulse and God Eat Burst 2 getting bit better

![screen00069](https://f.cloud.github.com/assets/3000282/1608267/c0c2a778-54e6-11e3-9f4d-3f6f0428ec1a.jpg)
![screen00070](https://f.cloud.github.com/assets/3000282/1608268/c531163c-54e6-11e3-8f46-d39f02cb9371.jpg)
![screen00071](https://f.cloud.github.com/assets/3000282/1608269/c827926c-54e6-11e3-90a5-b8515de62e56.jpg)
![screen00072](https://f.cloud.github.com/assets/3000282/1608271/cb48a51c-54e6-11e3-8e28-4f0255669a63.jpg)
![screen00073](https://f.cloud.github.com/assets/3000282/1608272/ce1317e6-54e6-11e3-9dd7-8943ac65abe0.jpg)
