### PR TITLE
Disassembler overhaul

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="CPU.cpp" />
     <ClCompile Include="Cwcheat.cpp" />
     <ClCompile Include="Debugger\Breakpoints.cpp" />
+    <ClCompile Include="Debugger\DisassemblyManager.cpp" />
     <ClCompile Include="Debugger\SymbolMap.cpp" />
     <ClCompile Include="Dialog\PSPGamedataInstallDialog.cpp" />
     <ClCompile Include="Dialog\PSPDialog.cpp" />
@@ -423,6 +424,7 @@
     <ClInclude Include="Cwcheat.h" />
     <ClInclude Include="Debugger\Breakpoints.h" />
     <ClInclude Include="Debugger\DebugInterface.h" />
+    <ClInclude Include="Debugger\DisassemblyManager.h" />
     <ClInclude Include="Debugger\SymbolMap.h" />
     <ClInclude Include="Dialog\PSPGamedataInstallDialog.h" />
     <ClInclude Include="Dialog\PSPDialog.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -496,6 +496,9 @@
     <ClCompile Include="Dialog\PSPNetconfDialog.cpp">
       <Filter>Dialog</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\DisassemblyManager.cpp">
+      <Filter>Debugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -918,7 +921,9 @@
     <ClInclude Include="MIPS\ARM\ArmCompVFPUNEON.cpp">
       <Filter>MIPS\ARM</Filter>
     </ClInclude>
-  </ItemGroup>
+    <ClInclude Include="Debugger\DisassemblyManager.h">
+      <Filter>Debugger</Filter>
+    </ClInclude>  </ItemGroup>
   <ItemGroup>
     <None Include="CMakeLists.txt" />
     <None Include="..\LICENSE.TXT" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -923,7 +923,8 @@
     </ClInclude>
     <ClInclude Include="Debugger\DisassemblyManager.h">
       <Filter>Debugger</Filter>
-    </ClInclude>  </ItemGroup>
+    </ClInclude>
+  </ItemGroup>
   <ItemGroup>
     <None Include="CMakeLists.txt" />
     <None Include="..\LICENSE.TXT" />

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -115,14 +115,13 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 			entries[info.address] = function;
 			address = info.address+info.size;
 		} else {
-			u32 startAddress = address;
-			address += 4;
-			while (!symbolMap.GetSymbolInfo(&info,address) && address < end)
-				address += 4;
+			u32 next = symbolMap.GetNextSymbolAddress(address);
 
 			// let's just assume anything otuside a function is a normal opcode
-			DisassemblyOpcode* opcode = new DisassemblyOpcode(startAddress,(address-startAddress)/4);
-			entries[startAddress] = opcode;
+			DisassemblyOpcode* opcode = new DisassemblyOpcode(address,(next-address)/4);
+			entries[address] = opcode;
+			
+			address = next;
 		}
 	}
 
@@ -278,6 +277,15 @@ u32 DisassemblyManager::getNthNextAddress(u32 address, int n)
 	}
 
 	return address+n*4;
+}
+
+void DisassemblyManager::clear()
+{
+	for (auto it = entries.begin(); it != entries.end(); it++)
+	{
+		delete it->second;
+	}
+	entries.clear();
 }
 
 DisassemblyFunction::DisassemblyFunction(u32 _address, u32 _size): address(_address), size(_size)

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -1,0 +1,522 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "DisassemblyManager.h"
+#include "DebugInterface.h"
+#include "Core/Debugger/SymbolMap.h"
+#include "Core/MIPS/MIPSCodeUtils.h"
+#include "Core/MIPS/MIPSTables.h"
+#include "Common/Common.h"
+#include "ext/xxhash.h"
+
+#include <algorithm>
+
+std::map<u32,DisassemblyEntry*> DisassemblyManager::entries;
+DebugInterface* DisassemblyManager::cpu;
+
+
+void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertSymbols)
+{
+	// copy opcode
+	while (*disasm != 0 && *disasm != '\t')
+	{
+		*opcode++ = *disasm++;
+	}
+	*opcode = 0;
+
+	if (*disasm++ == 0)
+	{
+		*arguments = 0;
+		return;
+	}
+
+	const char* jumpAddress = strstr(disasm,"->$");
+	const char* jumpRegister = strstr(disasm,"->");
+	while (*disasm != 0)
+	{
+		// parse symbol
+		if (disasm == jumpAddress)
+		{
+			u32 branchTarget;
+			sscanf(disasm+3,"%08x",&branchTarget);
+
+			const char* addressSymbol = DisassemblyManager::getCpu()->findSymbolForAddress(branchTarget);
+			if (addressSymbol != NULL && insertSymbols)
+			{
+				arguments += sprintf(arguments,"%s",addressSymbol);
+			} else {
+				arguments += sprintf(arguments,"0x%08X",branchTarget);
+			}
+			
+			disasm += 3+8;
+			continue;
+		}
+
+		if (disasm == jumpRegister)
+			disasm += 2;
+
+		if (*disasm == ' ')
+		{
+			disasm++;
+			continue;
+		}
+		*arguments++ = *disasm++;
+	}
+
+	*arguments = 0;
+}
+
+void DisassemblyManager::analyze(u32 address, u32 size)
+{
+	u32 end = address+size;
+	u32 start = address;
+
+	while (address < end && start <= address)
+	{
+		auto it = entries.lower_bound(address);
+		if (it != entries.end())
+		{
+			DisassemblyEntry* entry = it->second;
+			u32 entryStart = entry->getLineAddress(0);
+			u32 entryEnd = entryStart+entry->getTotalSize();
+
+			if (entryStart <= address && entryEnd > address)
+			{
+				entry->recheck();
+				address = entryEnd;
+				continue;
+			}
+		}
+
+		SymbolInfo info;
+		if (symbolMap.GetSymbolInfo(&info,address))
+		{
+			DisassemblyFunction* function = new DisassemblyFunction(info.address,info.size);
+			entries[info.address] = function;
+			address = info.address+info.size;
+		} else {
+			// let's just assume anything otuside a function is a normal opcode
+			DisassemblyOpcode* opcode = new DisassemblyOpcode(address);
+			entries[address] = opcode;
+			address += 4;
+		}
+	}
+
+}
+
+// TODO: use a faster search (and probably a different data structure)
+std::map<u32,DisassemblyEntry*>::iterator findDisassemblyEntry(std::map<u32,DisassemblyEntry*>& entries, u32 address, bool exact)
+{
+	if (exact)
+		return entries.find(address);
+
+	for (auto it = entries.begin(); it != entries.end(); it++)
+	{
+		DisassemblyEntry* entry = it->second;
+		u32 entryStart = entry->getLineAddress(0);
+		u32 entryEnd = entryStart+entry->getTotalSize();
+		
+		if (entryStart <= address && entryEnd > address)
+		{
+			return it;
+		}
+	}
+
+	return entries.end();
+}
+
+DisassemblyLineInfo DisassemblyManager::getLine(u32 address, bool insertSymbols)
+{
+	DisassemblyLineInfo result;
+
+	auto it = findDisassemblyEntry(entries,address,false);
+	if (it == entries.end())
+	{
+		analyze(address,1);
+		it = findDisassemblyEntry(entries,address,false);
+
+		if (it == entries.end())
+		{
+			result.totalSize = 4;
+			result.name = "ERROR";
+			result.params = "Disassembly failure";
+			return result;
+		}
+	}
+
+	DisassemblyEntry* entry = it->second;
+	
+	result.info = MIPSAnalyst::GetOpcodeInfo(cpu,address);
+	if (entry->disassemble(address,result))
+		return result;
+
+	result.totalSize = 4;
+	result.name = "ERROR";
+	result.params = "Disassembly failure";
+	return result;
+}
+
+
+u32 DisassemblyManager::getNthPreviousAddress(u32 address, int n)
+{
+	while (Memory::IsValidAddress(address))
+	{
+		auto it = findDisassemblyEntry(entries,address,false);
+	
+		while (it != entries.end())
+		{
+			DisassemblyEntry* entry = it->second;
+			int oldLineNum = entry->getLineNum(address,true);
+			int oldNumLines = entry->getNumLines();
+			if (n <= oldLineNum)
+			{
+				return entry->getLineAddress(oldLineNum-n);
+			}
+
+			address = entry->getLineAddress(0)-1;
+			n -= oldLineNum+1;
+			it = findDisassemblyEntry(entries,address,false);
+		}
+	
+		analyze(address,1);
+	}
+	
+	return address-n*4;
+}
+
+u32 DisassemblyManager::getNthNextAddress(u32 address, int n)
+{
+	while (Memory::IsValidAddress(address))
+	{
+		auto it = findDisassemblyEntry(entries,address,false);
+	
+		while (it != entries.end())
+		{
+			DisassemblyEntry* entry = it->second;
+			int oldLineNum = entry->getLineNum(address,true);
+			int oldNumLines = entry->getNumLines();
+			if (oldLineNum+n < oldNumLines)
+			{
+				return entry->getLineAddress(oldLineNum+n);
+			}
+
+			address = entry->getLineAddress(0)+entry->getTotalSize();
+			n -= (oldNumLines-oldLineNum);
+			it = findDisassemblyEntry(entries,address,false);
+		}
+
+		analyze(address,1);
+	}
+
+	return address+n*4;
+}
+
+DisassemblyFunction::DisassemblyFunction(u32 _address, u32 _size): address(_address), size(_size)
+{
+	hash = computeHash();
+	load();
+}
+
+u32 DisassemblyFunction::computeHash()
+{
+	return XXH32(Memory::GetPointer(address),size,0xBACD7814);
+}
+
+void DisassemblyFunction::recheck()
+{
+	u32 newHash = computeHash();
+	if (hash != newHash)
+	{
+		hash = newHash;
+		clear();
+		load();
+	}
+}
+
+int DisassemblyFunction::getNumLines()
+{
+	int lines = 0;
+	for (auto it = entries.begin(); it != entries.end(); it++)
+	{
+		lines += it->second->getNumLines();
+	}
+
+	return lines;
+}
+
+int DisassemblyFunction::getLineNum(u32 address, bool findStart)
+{
+	for (int i = 0; i < lineAddresses.size(); i++)
+	{
+		if (lineAddresses[i] == address)
+			return i;
+		if (findStart && lineAddresses[i] <= address && lineAddresses[i]+4 > address)
+			return i;
+	}
+
+	return 0;
+}
+
+u32 DisassemblyFunction::getLineAddress(int line)
+{
+	return lineAddresses[line];
+}
+
+bool DisassemblyFunction::disassemble(u32 address, DisassemblyLineInfo& dest)
+{
+	auto it = findDisassemblyEntry(entries,address,true);
+	if (it == entries.end())
+		return false;
+
+	return it->second->disassemble(address,dest);
+}
+
+
+#define NUM_LANES 16
+
+void DisassemblyFunction::generateBranchLines()
+{
+	struct LaneInfo
+	{
+		bool used;
+		u32 end;
+	};
+
+	LaneInfo lanes[NUM_LANES];
+	for (int i = 0; i < NUM_LANES; i++)
+		lanes[i].used = false;
+
+	u32 end = address+size;
+
+	DebugInterface* cpu = DisassemblyManager::getCpu();
+	for (u32 funcPos = address; funcPos < end; funcPos += 4)
+	{
+		MIPSAnalyst::MipsOpcodeInfo opInfo = MIPSAnalyst::GetOpcodeInfo(cpu,funcPos);
+
+		bool inFunction = (opInfo.branchTarget >= address && opInfo.branchTarget < end);
+		if (opInfo.isBranch && !opInfo.isBranchToRegister && !opInfo.isLinkedBranch && inFunction)
+		{
+			BranchLine line;
+			if (opInfo.branchTarget < funcPos)
+			{
+				line.first = opInfo.branchTarget;
+				line.second = funcPos;
+				line.type = LINE_UP;
+			} else {
+				line.first = funcPos;
+				line.second = opInfo.branchTarget;
+				line.type = LINE_DOWN;
+			}
+
+			lines.push_back(line);
+		}
+	}
+			
+	std::sort(lines.begin(),lines.end());
+	for (size_t i = 0; i < lines.size(); i++)
+	{
+		for (int l = 0; l < NUM_LANES; l++)
+		{
+			if (lines[i].first > lanes[l].end)
+				lanes[l].used = false;
+		}
+
+		int lane = -1;
+		for (int l = 0; l < NUM_LANES; l++)
+		{
+			if (lanes[l].used == false)
+			{
+				lane = l;
+				break;
+			}
+		}
+
+		if (lane == -1)
+		{
+			// error
+			continue;
+		}
+
+		lanes[lane].end = lines[i].second;
+		lanes[lane].used = true;
+		lines[i].laneIndex = lane;
+	}
+}
+
+
+void DisassemblyFunction::load()
+{
+	generateBranchLines();
+
+	// gather all branch targets
+	std::set<u32> branchTargets;
+	for (size_t i = 0; i < lines.size(); i++)
+	{
+		switch (lines[i].type)
+		{
+		case LINE_DOWN:
+			branchTargets.insert(lines[i].second);
+			break;
+		case LINE_UP:
+			branchTargets.insert(lines[i].first);
+			break;
+		}
+	}
+	
+	DebugInterface* cpu = DisassemblyManager::getCpu();
+	u32 funcPos = address;
+	u32 funcEnd = address+size;
+
+	while (funcPos < funcEnd)
+	{
+		MIPSAnalyst::MipsOpcodeInfo opInfo = MIPSAnalyst::GetOpcodeInfo(cpu,funcPos);
+		u32 opAddress = funcPos;
+		funcPos += 4;
+
+		// skip branches and their delay slots
+		if (opInfo.isBranch)
+		{
+			DisassemblyOpcode* opcode = new DisassemblyOpcode(opAddress);
+			entries[opAddress] = opcode;
+			lineAddresses.push_back(opAddress);
+			
+			DisassemblyOpcode* delaySlot = new DisassemblyOpcode(funcPos);
+			entries[funcPos] = delaySlot;
+			lineAddresses.push_back(funcPos);
+
+			funcPos += 4;
+			continue;
+		}
+
+		// lui
+		if (MIPS_GET_OP(opInfo.encodedOpcode) == 0x0F && funcPos < funcEnd)
+		{
+			MIPSOpcode next = Memory::Read_Instruction(funcPos);
+
+			u32 immediate = ((opInfo.encodedOpcode & 0xFFFF) << 16) + (s16)(next.encoding & 0xFFFF);
+			int rt = MIPS_GET_RT(opInfo.encodedOpcode);
+
+			int nextRs = MIPS_GET_RS(next.encoding);
+			int nextRt = MIPS_GET_RT(next.encoding);
+
+			// both rs and rt of the second op have to match rt of the first,
+			// otherwise there may be hidden consequences if the macro is displayed.
+			// also, don't create a macro if something branches into the middle of it
+			if (nextRs == rt && nextRt == rt && branchTargets.find(funcPos) == branchTargets.end())
+			{
+				DisassemblyMacro* macro = NULL;
+				switch (MIPS_GET_OP(next.encoding))
+				{
+				case 0x09:	// addiu
+					macro = new DisassemblyMacro(opAddress);
+					macro->setMacroLi(immediate,rt);
+					funcPos += 4;
+					break;
+				case 0x20:	// lb
+				case 0x21:	// lh
+				case 0x23:	// lw
+				case 0x24:	// lbu
+				case 0x25:	// lhu
+				case 0x28:	// sb
+				case 0x29:	// sh
+				case 0x2B:	// sw
+					macro = new DisassemblyMacro(opAddress);
+					macro->setMacroMemory(MIPSGetName(next),immediate,rt);
+					funcPos += 4;
+					break;
+				}
+
+				if (macro != NULL)
+				{
+					entries[opAddress] = macro;
+					for (int i = 0; i < macro->getNumLines(); i++)
+					{
+						lineAddresses.push_back(macro->getLineAddress(i));
+					}
+					continue;
+				}
+			}
+		}
+
+		// just a normal opcode
+		DisassemblyOpcode* opcode = new DisassemblyOpcode(opAddress);
+		entries[opAddress] = opcode;
+		lineAddresses.push_back(opAddress);
+	}
+}
+
+void DisassemblyFunction::clear()
+{
+	for (auto it = entries.begin(); it != entries.end(); it++)
+	{
+		delete it->second;
+	}
+
+	entries.clear();
+	lines.clear();
+	hash = 0;
+}
+
+bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo& dest)
+{
+	char opcode[64],arguments[256];
+	const char *dizz = DisassemblyManager::getCpu()->disasm(address,4);
+	parseDisasm(dizz,opcode,arguments,true);
+	dest.name = opcode;
+	dest.params = arguments;
+	dest.totalSize = 4;
+	return true;
+}
+
+
+void DisassemblyMacro::setMacroLi(u32 _immediate, u8 _rt)
+{
+	type = MACRO_LI;
+	name = "li";
+	immediate = _immediate;
+	rt = _rt;
+	numOpcodes = 2;
+}
+
+void DisassemblyMacro::setMacroMemory(std::string _name, u32 _immediate, u8 _rt)
+{
+	type = MACRO_MEMORYIMM;
+	name = _name;
+	immediate = _immediate;
+	rt = _rt;
+	numOpcodes = 2;
+}
+
+bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest)
+{
+	char buffer[64];
+
+	switch (type)
+	{
+	case MACRO_LI:
+	case MACRO_MEMORYIMM:
+		dest.name = name;
+		sprintf(buffer,"%s,%08X",DisassemblyManager::getCpu()->GetRegName(0,rt),immediate);
+		dest.params = buffer;
+		break;
+	default:
+		return false;
+	}
+
+	dest.totalSize = getTotalSize();
+	return true;
+}

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -312,9 +312,11 @@ int DisassemblyFunction::getLineNum(u32 address, bool findStart)
 {
 	for (int i = 0; i < lineAddresses.size(); i++)
 	{
+		u32 next = (i == lineAddresses.size()-1) ? this->address+this->size : lineAddresses[i+1];
+
 		if (lineAddresses[i] == address)
 			return i;
-		if (findStart && lineAddresses[i] <= address && lineAddresses[i]+4 > address)
+		if (findStart && lineAddresses[i] <= address && next > address)
 			return i;
 	}
 

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -312,13 +312,7 @@ void DisassemblyFunction::recheck()
 
 int DisassemblyFunction::getNumLines()
 {
-	int lines = 0;
-	for (auto it = entries.begin(); it != entries.end(); it++)
-	{
-		lines += it->second->getNumLines();
-	}
-
-	return lines;
+	return lineAddresses.size();
 }
 
 int DisassemblyFunction::getLineNum(u32 address, bool findStart)

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -182,10 +182,8 @@ std::vector<BranchLine> DisassemblyManager::getBranchLines(u32 start, u32 size)
 	return result;
 }
 
-DisassemblyLineInfo DisassemblyManager::getLine(u32 address, bool insertSymbols)
+void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLineInfo& dest)
 {
-	DisassemblyLineInfo result;
-
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
 	{
@@ -194,23 +192,22 @@ DisassemblyLineInfo DisassemblyManager::getLine(u32 address, bool insertSymbols)
 
 		if (it == entries.end())
 		{
-			result.totalSize = 4;
-			result.name = "ERROR";
-			result.params = "Disassembly failure";
-			return result;
+			dest.totalSize = 4;
+			dest.name = "ERROR";
+			dest.params = "Disassembly failure";
+			return;
 		}
 	}
 
 	DisassemblyEntry* entry = it->second;
 	
-	result.info = MIPSAnalyst::GetOpcodeInfo(cpu,address);
-	if (entry->disassemble(address,result,insertSymbols))
-		return result;
+	dest.info = MIPSAnalyst::GetOpcodeInfo(cpu,address);
+	if (entry->disassemble(address,dest,insertSymbols))
+		return;
 
-	result.totalSize = 4;
-	result.name = "ERROR";
-	result.params = "Disassembly failure";
-	return result;
+	dest.totalSize = 4;
+	dest.name = "ERROR";
+	dest.params = "Disassembly failure";
 }
 
 u32 DisassemblyManager::getStartAddress(u32 address)

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -145,6 +145,23 @@ std::map<u32,DisassemblyEntry*>::iterator findDisassemblyEntry(std::map<u32,Disa
 	return entries.end();
 }
 
+std::vector<BranchLine> DisassemblyManager::getBranchLines(u32 start, u32 size)
+{
+	std::vector<BranchLine> result;
+	
+	auto it = findDisassemblyEntry(entries,start,false);
+	if (it != entries.end())
+	{
+		do 
+		{
+			it->second->getBranchLines(start,size,result);
+			it++;
+		} while (it != entries.end() && start+size > it->second->getLineAddress(0));
+	}
+
+	return result;
+}
+
 DisassemblyLineInfo DisassemblyManager::getLine(u32 address, bool insertSymbols)
 {
 	DisassemblyLineInfo result;
@@ -306,6 +323,13 @@ bool DisassemblyFunction::disassemble(u32 address, DisassemblyLineInfo& dest, bo
 	return it->second->disassemble(address,dest,insertSymbols);
 }
 
+void DisassemblyFunction::getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest)
+{
+	for (int i = 0; i < lines.size(); i++)
+	{
+		dest.push_back(lines[i]);
+	}
+}
 
 #define NUM_LANES 16
 

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -133,6 +133,7 @@ class DebugInterface;
 class DisassemblyManager
 {
 public:
+	void clear();
 
 	void setCpu(DebugInterface* _cpu) { cpu = _cpu; };
 	void getLine(u32 address, bool insertSymbols, DisassemblyLineInfo& dest);

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -1,0 +1,146 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+#include "Globals.h"
+#include "Core/MIPS/MIPSAnalyst.h"
+
+enum DisassemblyLineType { DISTYPE_OPCODE, DISTYPE_DATA };
+
+struct DisassemblyLineInfo
+{
+	DisassemblyLineType type;
+	MIPSAnalyst::MipsOpcodeInfo info;
+	std::string name;
+	std::string params;
+	u32 totalSize;
+};
+
+enum LineType { LINE_UP, LINE_DOWN, LINE_RIGHT };
+
+struct BranchLine
+{
+	u32 first;
+	u32 second;
+	LineType type;
+	int laneIndex;
+
+	bool operator<(const BranchLine& other) const
+	{
+		return first < other.first;
+	}
+};
+
+class DisassemblyEntry
+{
+public:
+	virtual ~DisassemblyEntry() { };
+	virtual void recheck() = 0;
+	virtual int getNumLines() = 0;
+	virtual int getLineNum(u32 address, bool findStart) = 0;
+	virtual u32 getLineAddress(int line) = 0;
+	virtual u32 getTotalSize() = 0;
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest) = 0;
+};
+
+class DisassemblyFunction: public DisassemblyEntry
+{
+public:
+	DisassemblyFunction(u32 _address, u32 _size);
+	virtual void recheck();
+	virtual int getNumLines();
+	virtual int getLineNum(u32 address, bool findStart);
+	virtual u32 getLineAddress(int line);
+	virtual u32 getTotalSize() { return size; };
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest);
+private:
+	u32 computeHash();
+	void generateBranchLines();
+	void load();
+	void clear();
+
+	u32 address;
+	u32 size;
+	u32 hash;
+	std::vector<BranchLine> lines;
+	std::map<u32,DisassemblyEntry*> entries;
+	std::vector<u32> lineAddresses;
+};
+
+class DisassemblyOpcode: public DisassemblyEntry
+{
+public:
+	DisassemblyOpcode(u32 _address): address(_address) { };
+	virtual ~DisassemblyOpcode() { };
+	virtual void recheck() { };
+	virtual int getNumLines() { return 1; };
+	virtual int getLineNum(u32 address, bool findStart) { return 0; };
+	virtual u32 getLineAddress(int line) { return address; };
+	virtual u32 getTotalSize() { return 4; };
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest);
+private:
+	u32 address;
+};
+
+
+class DisassemblyMacro: public DisassemblyEntry
+{
+public:
+	DisassemblyMacro(u32 _address): address(_address) { };
+	virtual ~DisassemblyMacro() { };
+	
+	void setMacroLi(u32 _immediate, u8 _rt);
+	void setMacroMemory(std::string _name, u32 _immediate, u8 _rt);
+	
+	virtual void recheck() { };
+	virtual int getNumLines() { return 1; };
+	virtual int getLineNum(u32 address, bool findStart) { return 0; };
+	virtual u32 getLineAddress(int line) { return address; };
+	virtual u32 getTotalSize() { return numOpcodes*4; };
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest) ;
+private:
+	enum MacroType { MACRO_LI, MACRO_MEMORYIMM };
+
+	MacroType type;
+	std::string name;
+	u32 immediate;
+	u32 address;
+	u32 numOpcodes;
+	u8 rt;
+};
+
+
+class DebugInterface;
+
+class DisassemblyManager
+{
+public:
+
+	void setCpu(DebugInterface* _cpu) { cpu = _cpu; };
+	DisassemblyLineInfo getLine(u32 address, bool insertSymbols);
+	void analyze(u32 address, u32 size);
+
+	u32 getStartAddress(u32 address);
+	u32 getNthPreviousAddress(u32 address, int n = 1);
+	u32 getNthNextAddress(u32 address, int n = 1);
+
+	static DebugInterface* getCpu() { return cpu; };
+private:
+	DisassemblyEntry* getEntry(u32 address);
+	static std::map<u32,DisassemblyEntry*> entries;
+	static DebugInterface* cpu;
+};

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -55,6 +55,7 @@ public:
 	virtual u32 getLineAddress(int line) = 0;
 	virtual u32 getTotalSize() = 0;
 	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols) = 0;
+	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest) { };
 };
 
 class DisassemblyFunction: public DisassemblyEntry
@@ -67,6 +68,7 @@ public:
 	virtual u32 getLineAddress(int line);
 	virtual u32 getTotalSize() { return size; };
 	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest);
 private:
 	u32 computeHash();
 	void generateBranchLines();
@@ -134,6 +136,7 @@ public:
 	void setCpu(DebugInterface* _cpu) { cpu = _cpu; };
 	DisassemblyLineInfo getLine(u32 address, bool insertSymbols);
 	void analyze(u32 address, u32 size);
+	std::vector<BranchLine> getBranchLines(u32 start, u32 size);
 
 	u32 getStartAddress(u32 address);
 	u32 getNthPreviousAddress(u32 address, int n = 1);

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -144,3 +144,5 @@ private:
 	static std::map<u32,DisassemblyEntry*> entries;
 	static DebugInterface* cpu;
 };
+
+bool isInInterval(u32 start, u32 size, u32 value);

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -94,6 +94,7 @@ public:
 	virtual u32 getLineAddress(int line) { return address+line*4; };
 	virtual u32 getTotalSize() { return num*4; };
 	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest);
 private:
 	u32 address;
 	int num;

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -135,7 +135,7 @@ class DisassemblyManager
 public:
 
 	void setCpu(DebugInterface* _cpu) { cpu = _cpu; };
-	DisassemblyLineInfo getLine(u32 address, bool insertSymbols);
+	void getLine(u32 address, bool insertSymbols, DisassemblyLineInfo& dest);
 	void analyze(u32 address, u32 size);
 	std::vector<BranchLine> getBranchLines(u32 start, u32 size);
 

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -54,7 +54,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) = 0;
 	virtual u32 getLineAddress(int line) = 0;
 	virtual u32 getTotalSize() = 0;
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest) = 0;
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols) = 0;
 };
 
 class DisassemblyFunction: public DisassemblyEntry
@@ -66,7 +66,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart);
 	virtual u32 getLineAddress(int line);
 	virtual u32 getTotalSize() { return size; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
 private:
 	u32 computeHash();
 	void generateBranchLines();
@@ -91,7 +91,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) { return 0; };
 	virtual u32 getLineAddress(int line) { return address; };
 	virtual u32 getTotalSize() { return 4; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
 private:
 	u32 address;
 };
@@ -104,14 +104,14 @@ public:
 	virtual ~DisassemblyMacro() { };
 	
 	void setMacroLi(u32 _immediate, u8 _rt);
-	void setMacroMemory(std::string _name, u32 _immediate, u8 _rt);
+	void setMacroMemory(std::string _name, u32 _immediate, u8 _rt, int _dataSize);
 	
 	virtual void recheck() { };
 	virtual int getNumLines() { return 1; };
 	virtual int getLineNum(u32 address, bool findStart) { return 0; };
 	virtual u32 getLineAddress(int line) { return address; };
 	virtual u32 getTotalSize() { return numOpcodes*4; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest) ;
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols) ;
 private:
 	enum MacroType { MACRO_LI, MACRO_MEMORYIMM };
 
@@ -121,6 +121,7 @@ private:
 	u32 address;
 	u32 numOpcodes;
 	u8 rt;
+	int dataSize;
 };
 
 

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -86,16 +86,17 @@ private:
 class DisassemblyOpcode: public DisassemblyEntry
 {
 public:
-	DisassemblyOpcode(u32 _address): address(_address) { };
+	DisassemblyOpcode(u32 _address, int _num): address(_address), num(_num) { };
 	virtual ~DisassemblyOpcode() { };
 	virtual void recheck() { };
-	virtual int getNumLines() { return 1; };
-	virtual int getLineNum(u32 address, bool findStart) { return 0; };
-	virtual u32 getLineAddress(int line) { return address; };
-	virtual u32 getTotalSize() { return 4; };
+	virtual int getNumLines() { return num; };
+	virtual int getLineNum(u32 address, bool findStart) { return (address-this->address)/4; };
+	virtual u32 getLineAddress(int line) { return address+line*4; };
+	virtual u32 getTotalSize() { return num*4; };
 	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
 private:
 	u32 address;
+	int num;
 };
 
 

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -318,6 +318,17 @@ bool SymbolMap::GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask)
 	return false;
 }
 
+u32 SymbolMap::GetNextSymbolAddress(u32 address)
+{
+	lock_guard guard(lock_);
+
+	const auto containingEntry = entryRanges.upper_bound(address);
+	if (containingEntry == entryRanges.end())
+		return -1;
+
+	return containingEntry->second;
+}
+
 const char* SymbolMap::getDirectSymbol(u32 address)
 {
 	lock_guard guard(lock_);

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -50,6 +50,7 @@ public:
 	void AnalyzeBackwards();
 	int GetSymbolNum(unsigned int address, SymbolType symmask=ST_FUNCTION) const;
 	bool GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask = ST_FUNCTION) const;
+	u32 GetNextSymbolAddress(u32 address);
 	const char *GetDescription(unsigned int address) const;
 #ifdef _WIN32
 	void FillSymbolListBox(HWND listbox, SymbolType symmask=ST_FUNCTION) const;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1255,3 +1255,21 @@ void CtrlDisAsmView::getOpcodeText(u32 address, char* dest)
 	manager.getLine(address,displaySymbols,line);
 	sprintf(dest,"%s  %s",line.name.c_str(),line.params.c_str());
 }
+
+void CtrlDisAsmView::scrollStepping(u32 newPc)
+{
+	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+
+	newPc = manager.getStartAddress(newPc);
+	if (newPc >= windowEnd || newPc >= manager.getNthPreviousAddress(windowEnd,1))
+	{
+		windowStart = manager.getNthPreviousAddress(newPc,visibleRows-2);
+	}
+}
+
+u32 CtrlDisAsmView::getInstructionSizeAt(u32 address)
+{
+	u32 start = manager.getStartAddress(address);
+	u32 next  = manager.getNthNextAddress(start,1);
+	return next-address;
+}

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -56,7 +56,7 @@ void CtrlDisAsmView::deinit()
 
 void CtrlDisAsmView::scanFunctions()
 {
-
+	manager.analyze(windowStart,manager.getNthNextAddress(windowStart,visibleRows)-windowStart);
 }
 
 LRESULT CALLBACK CtrlDisAsmView::wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -503,7 +503,7 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 		COLORREF backgroundColor = whiteBackground ? 0xFFFFFF : debugger->getColor(address);
 		COLORREF textColor = 0x000000;
 
-		if (address == debugger->getPC())
+		if (isInInterval(address,line.totalSize,debugger->getPC()))
 		{
 			backgroundColor = scaleColor(backgroundColor,1.05f);
 		}
@@ -545,8 +545,8 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 		char addressText[64];
 		getDisasmAddressText(address,addressText,true);
 		TextOutA(hdc,pixelPositions.addressStart,rowY1+2,addressText,(int)strlen(addressText));
-
-		if (address == debugger->getPC())
+		
+		if (isInInterval(address,line.totalSize,debugger->getPC()))
 		{
 			TextOut(hdc,pixelPositions.opcodeStart-8,rowY1,L"■",1);
 		}

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -429,9 +429,10 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 	unsigned int address = windowStart;
 	std::map<u32,int> addressPositions;
 
+	DisassemblyLineInfo line;
 	for (int i = 0; i < visibleRows; i++)
 	{
-		DisassemblyLineInfo line = manager.getLine(address,displaySymbols);
+		manager.getLine(address,displaySymbols,line);
 
 		int rowY1 = rowHeight*i;
 		int rowY2 = rowHeight*(i+1);
@@ -560,7 +561,8 @@ void CtrlDisAsmView::onVScroll(WPARAM wParam, LPARAM lParam)
 
 void CtrlDisAsmView::followBranch()
 {
-	DisassemblyLineInfo line = manager.getLine(curAddress,true);
+	DisassemblyLineInfo line;
+	manager.getLine(curAddress,true,line);
 
 	if (line.info.isBranch)
 	{
@@ -999,7 +1001,8 @@ void CtrlDisAsmView::onMouseMove(WPARAM wParam, LPARAM lParam, int button)
 void CtrlDisAsmView::updateStatusBarText()
 {
 	char text[512];
-	DisassemblyLineInfo line = manager.getLine(curAddress,true);
+	DisassemblyLineInfo line;
+	manager.getLine(curAddress,true,line);
 	
 	text[0] = 0;
 	if (line.info.isDataAccess)
@@ -1097,9 +1100,11 @@ void CtrlDisAsmView::search(bool continueSearch)
 
 	searching = true;
 	redraw();	// so the cursor is disabled
+
+	DisassemblyLineInfo lineInfo;
 	while (searchAddress < 0x0A000000)
 	{
-		DisassemblyLineInfo lineInfo = manager.getLine(searchAddress,displaySymbols);
+		manager.getLine(searchAddress,displaySymbols,lineInfo);
 
 		char addressText[64];
 		getDisasmAddressText(searchAddress,addressText,true);
@@ -1163,11 +1168,12 @@ std::string CtrlDisAsmView::disassembleRange(u32 start, u32 size)
 
 	u32 disAddress = start;
 	bool previousLabel = true;
+	DisassemblyLineInfo line;
 	while (disAddress < start+size)
 	{
 		char addressText[64],buffer[512];
 
-		DisassemblyLineInfo line = manager.getLine(disAddress,displaySymbols);
+		manager.getLine(disAddress,displaySymbols,line);
 		bool isLabel = getDisasmAddressText(disAddress,addressText,false);
 
 		if (isLabel)
@@ -1244,7 +1250,8 @@ void CtrlDisAsmView::disassembleToFile()
 
 void CtrlDisAsmView::getOpcodeText(u32 address, char* dest)
 {
+	DisassemblyLineInfo line;
 	address = manager.getStartAddress(address);
-	DisassemblyLineInfo line = manager.getLine(address,displaySymbols);
+	manager.getLine(address,displaySymbols,line);
 	sprintf(dest,"%s  %s",line.name.c_str(),line.params.c_str());
 }

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -99,7 +99,7 @@ public:
 	bool curAddressIsVisible();
 	void redraw();
 	void scanFunctions();
-	void clearFunctions() { };
+	void clearFunctions() { manager.clear(); };
 
 	void getOpcodeText(u32 address, char* dest);
 	int getRowHeight() { return rowHeight; };

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -133,6 +133,7 @@ public:
 	u32 getWindowEnd() { return windowStart+visibleRows*instructionSize; };
 	void gotoAddr(unsigned int addr)
 	{
+		addr = manager.getStartAddress(addr);
 		u32 windowEnd = windowStart+visibleRows*instructionSize;
 		u32 newAddress = addr&(~(instructionSize-1));
 
@@ -175,6 +176,7 @@ public:
 
 	void setCurAddress(u32 newAddress, bool extend = false)
 	{
+		newAddress = manager.getStartAddress(newAddress);
 		u32 after = manager.getNthNextAddress(newAddress,1);
 		curAddress = newAddress;
 		selectRangeStart = extend ? std::min(selectRangeStart, newAddress) : newAddress;

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -36,10 +36,6 @@ class CtrlDisAsmView
 	HFONT boldfont;
 	RECT rect;
 
-//	std::map<u32,DisassemblyFunc> functions;
-	std::vector<u32> visibleFunctionAddresses;
-	std::vector<BranchLine> strayLines;
-
 	DisassemblyManager manager;
 	u32 curAddress;
 	u32 selectRangeStart;
@@ -81,7 +77,7 @@ class CtrlDisAsmView
 	void calculatePixelPositions();
 	bool getDisasmAddressText(u32 address, char* dest, bool abbreviateLabels);
 	void updateStatusBarText();
-	void drawBranchLine(HDC hdc, BranchLine& line);
+	void drawBranchLine(HDC hdc, std::map<u32,int>& addressPositions, BranchLine& line);
 	void copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm);
 public:
 	CtrlDisAsmView(HWND _wnd);
@@ -103,12 +99,7 @@ public:
 	bool curAddressIsVisible();
 	void redraw();
 	void scanFunctions();
-	void clearFunctions()
-	{
-	//	functions.clear();
-		visibleFunctionAddresses.clear();
-		strayLines.clear();
-	};
+	void clearFunctions() { };
 
 	void getOpcodeText(u32 address, char* dest);
 	int getRowHeight() { return rowHeight; };

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -57,8 +57,6 @@ class CtrlDisAsmView
 	int instructionSize;
 	bool whiteBackground;
 	bool displaySymbols;
-	u32 branchTarget;
-	int branchRegister;
 
 	struct {
 		int addressStart;
@@ -82,7 +80,6 @@ class CtrlDisAsmView
 	void followBranch();
 	void calculatePixelPositions();
 	bool getDisasmAddressText(u32 address, char* dest, bool abbreviateLabels);
-	void parseDisasm(const char* disasm, char* opcode, char* arguments);
 	void updateStatusBarText();
 	void drawBranchLine(HDC hdc, BranchLine& line);
 	void copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm);

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -118,7 +118,9 @@ public:
 		return debugger;
 	}
 
-	u32 getWindowEnd() { return windowStart+visibleRows*instructionSize; };
+	void scrollStepping(u32 newPc);
+	u32 getInstructionSizeAt(u32 address);
+
 	void gotoAddr(unsigned int addr)
 	{
 		addr = manager.getStartAddress(addr);

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -100,7 +100,7 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 	return FALSE;
 }
 
-bool isInInterval(u32 start, u32 end, u32 value)
+static bool isInInterval(u32 start, u32 end, u32 value)
 {
 	return start <= value && value < end;
 }


### PR DESCRIPTION
I'm not quite done with it, but I thought it might be good to hear some opinions on it. A few things don't work properly yet (like stepping), and I'll clean it up a bit before it's merged.

Basically, this changes the way the disassembly handles its lines. Previously, it would disassemble every 4 bytes into one line, which was always one opcode. This adds a seperate manager, which analyzes the data, keeps track of it, and then feeds it to the disassembly on request. In the disassembly, everything relative is now only addressed as "x lines before/after". So to the disassembly, it doesn't matter anymore how long each line is. It could be a single opcode, a macro (a few of them are identified already), or it could be a 512kb data definition. 

So far it only supports identifying macros (and only does so if they change only a single register), but in the future I'd like to display data directives similar to no$gba (see: http://nocash.emubase.de/gba-640x.gif).

The DisassemblyManager is decoupled from the Windows debugger, so it could also be used by the Qt version, if @Bigpet is interested.

Here's a picture of how it looks now: 
![psp9](https://f.cloud.github.com/assets/4809758/1613314/56c9060a-55d6-11e3-91c4-38aa79499149.png)
