### PR TITLE
Save labels separately from symbols

### DIFF
--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -41,7 +41,6 @@ public:
 	virtual void runToBreakpoint() {}
 	virtual int getColor(unsigned int address){return 0xFFFFFFFF;}
 	virtual const char *getDescription(unsigned int address) {return "";}
-	virtual const char *findSymbolForAddress(unsigned int address) { return NULL; };
 	virtual bool getSymbolValue(char* symbol, u32& dest) { return false; };
 	virtual bool initExpression(const char* exp, PostfixExpression& dest) { return false; };
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest) { return false; };

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -41,7 +41,6 @@ public:
 	virtual void runToBreakpoint() {}
 	virtual int getColor(unsigned int address){return 0xFFFFFFFF;}
 	virtual const char *getDescription(unsigned int address) {return "";}
-	virtual bool getSymbolValue(char* symbol, u32& dest) { return false; };
 	virtual bool initExpression(const char* exp, PostfixExpression& dest) { return false; };
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest) { return false; };
 

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -30,7 +30,7 @@ DebugInterface* DisassemblyManager::cpu;
 
 bool isInInterval(u32 start, u32 size, u32 value)
 {
-	return start <= value && value < start+size;
+	return start <= value && value <= (start+size-1);
 }
 
 void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertSymbols)

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -58,7 +58,7 @@ void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertS
 			u32 branchTarget;
 			sscanf(disasm+3,"%08x",&branchTarget);
 
-			const char* addressSymbol = DisassemblyManager::getCpu()->findSymbolForAddress(branchTarget);
+			const char* addressSymbol = symbolMap.GetLabelName(branchTarget);
 			if (addressSymbol != NULL && insertSymbols)
 			{
 				arguments += sprintf(arguments,"%s",addressSymbol);
@@ -615,7 +615,7 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool 
 	case MACRO_LI:
 		dest.name = name;
 		
-		addressSymbol = DisassemblyManager::getCpu()->findSymbolForAddress(immediate);
+		addressSymbol = symbolMap.GetLabelName(immediate);
 		if (addressSymbol != NULL && insertSymbols)
 		{
 			sprintf(buffer,"%s,%s",DisassemblyManager::getCpu()->GetRegName(0,rt),addressSymbol);
@@ -631,7 +631,7 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool 
 	case MACRO_MEMORYIMM:
 		dest.name = name;
 
-		addressSymbol = DisassemblyManager::getCpu()->findSymbolForAddress(immediate);
+		addressSymbol = symbolMap.GetLabelName(immediate);
 		if (addressSymbol != NULL && insertSymbols)
 		{
 			sprintf(buffer,"%s,%s",DisassemblyManager::getCpu()->GetRegName(0,rt),addressSymbol);

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -305,7 +305,7 @@ void DisassemblyFunction::recheck()
 
 int DisassemblyFunction::getNumLines()
 {
-	return lineAddresses.size();
+	return (int) lineAddresses.size();
 }
 
 int DisassemblyFunction::getLineNum(u32 address, bool findStart)

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -74,6 +74,7 @@ private:
 	void generateBranchLines();
 	void load();
 	void clear();
+	void addOpcodeSequence(u32 start, u32 end);
 
 	u32 address;
 	u32 size;

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -338,44 +338,6 @@ u32 SymbolMap::GetNextSymbolAddress(u32 address)
 	return containingEntry->second;
 }
 
-const char* SymbolMap::getDirectSymbol(u32 address)
-{
-	lock_guard guard(lock_);
-	SymbolInfo info;
-	if (GetSymbolInfo(&info,address) == false) return NULL;
-	if (info.address != address) return NULL;	// has to be the START of the function
-
-	// now we need the name... which we can't just get from GetSymbolInfo because of the
-	// unique entries. But, there are so many less instances where there actually IS a
-	// label that the speed up is still massive
-	for (auto it = entries.begin(), end = entries.end(); it != end; ++it)
-	{
-		const MapEntry &entry = *it;
-		unsigned int addr = entry.vaddress;
-		if (addr == address) return entry.name;
-	}
-	return NULL;
-}
-
-bool SymbolMap::getSymbolValue(char* symbol, u32& dest)
-{
-	lock_guard guard(lock_);
-	for (auto it = entries.begin(), end = entries.end(); it != end; ++it)
-	{
-		const MapEntry &entry = *it;
-#ifdef _WIN32
-		if (_stricmp(entry.name,symbol) == 0)
-#else
-		if (strcasecmp(entry.name,symbol) == 0)
-#endif
-		{
-			dest = entry.vaddress;
-			return true;
-		}
-	}
-	return false;
-}
-
 const char* SymbolMap::AddLabel(const char* name, u32 address)
 {
 	// keep a label if it already exists

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -120,6 +120,8 @@ void SymbolMap::AddSymbol(const char *symbolname, unsigned int vaddress, size_t 
 		uniqueEntries.insert((const MapEntryUniqueInfo)e);
 		entryRanges[e.vaddress + e.size] = e.vaddress;
 	}
+
+	AddLabel(symbolname,vaddress);
 }
 
 void SymbolMap::RemoveSymbolNum(int symbolnum){
@@ -250,7 +252,13 @@ bool SymbolMap::LoadNocashSym(const char *filename)
 				*seperator = 0;
 				sscanf(seperator+1,"%08X",&size);
 			}
-			AddSymbol(value,address,size,ST_FUNCTION);
+
+			if (size != 1)
+			{
+				AddSymbol(value,address,size,ST_FUNCTION);
+			} else {
+				AddLabel(value,address);
+			}
 		}
 	}
 
@@ -365,6 +373,24 @@ bool SymbolMap::getSymbolValue(char* symbol, u32& dest)
 		}
 	}
 	return false;
+}
+
+void SymbolMap::AddLabel(const char* name, u32 address)
+{
+	Label label;
+	strcpy(label.name,name);
+	label.name[127] = 0;
+
+	labels[address] = label;
+}
+
+const char* SymbolMap::GetLabelName(u32 address)
+{
+	auto it = labels.find(address);
+	if (it == labels.end())
+		return NULL;
+
+	return it->second.name;
 }
 
 static char descriptionTemp[256];

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -75,6 +75,8 @@ public:
 	void UseFuncSignaturesFile(const char *filename, u32 maxAddress);
 	void CompileFuncSignaturesFile(const char *filename) const;
 
+	void AddLabel(const char* name, u32 address);
+	const char* GetLabelName(u32 address);
 private:
 	struct MapEntryUniqueInfo {
 		u32 address;
@@ -85,6 +87,11 @@ private:
 		bool operator < (const MapEntryUniqueInfo &other) const {
 			return vaddress < other.vaddress;
 		}
+	};
+
+	struct Label
+	{
+		char name[128];
 	};
 
 	struct MapEntry : public MapEntryUniqueInfo {
@@ -99,7 +106,8 @@ private:
 			// TODO
 		}
 	};
-
+	
+	std::map<u32,Label> labels;
 	std::set<MapEntryUniqueInfo> uniqueEntries;
 	std::vector<MapEntry> entries;
 	std::map<u32, u32> entryRanges;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -69,8 +69,6 @@ public:
 	void IncreaseRunCount(int num);
 	unsigned int GetRunCount(int num) const;
 	void SortSymbols();
-	const char* getDirectSymbol(u32 address);
-	bool getSymbolValue(char* symbol, u32& dest);
 
 	void UseFuncSignaturesFile(const char *filename, u32 maxAddress);
 	void CompileFuncSignaturesFile(const char *filename) const;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -75,8 +75,9 @@ public:
 	void UseFuncSignaturesFile(const char *filename, u32 maxAddress);
 	void CompileFuncSignaturesFile(const char *filename) const;
 
-	void AddLabel(const char* name, u32 address);
+	const char* AddLabel(const char* name, u32 address);
 	const char* GetLabelName(u32 address);
+	bool GetLabelValue(const char* name, u32& dest);
 private:
 	struct MapEntryUniqueInfo {
 		u32 address;

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -109,7 +109,7 @@ public:
 
 	virtual bool parseSymbol(char* str, uint32& symbolValue)
 	{
-		return cpu->getSymbolValue(str,symbolValue); 
+		return symbolMap.GetLabelValue(str,symbolValue); 
 	}
 
 	virtual uint32 getReferenceValue(uint32 referenceIndex)

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -230,11 +230,6 @@ const char *MIPSDebugInterface::getDescription(unsigned int address)
 	return symbolMap.GetDescription(address);
 }
 
-const char *MIPSDebugInterface::findSymbolForAddress(unsigned int address)
-{
-	return symbolMap.getDirectSymbol(address);
-}
-
 bool MIPSDebugInterface::getSymbolValue(char* symbol, u32& dest)
 {
 	return symbolMap.getSymbolValue(symbol,dest);

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -230,11 +230,6 @@ const char *MIPSDebugInterface::getDescription(unsigned int address)
 	return symbolMap.GetDescription(address);
 }
 
-bool MIPSDebugInterface::getSymbolValue(char* symbol, u32& dest)
-{
-	return symbolMap.getSymbolValue(symbol,dest);
-}
-
 bool MIPSDebugInterface::initExpression(const char* exp, PostfixExpression& dest)
 {
 	MipsExpressionFunctions funcs(this);

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -40,7 +40,6 @@ public:
 	virtual void runToBreakpoint();
 	virtual int getColor(unsigned int address);
 	virtual const char *getDescription(unsigned int address);
-	virtual bool getSymbolValue(char* symbol, u32& dest);
 	virtual bool initExpression(const char* exp, PostfixExpression& dest);
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest);
 

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -40,7 +40,6 @@ public:
 	virtual void runToBreakpoint();
 	virtual int getColor(unsigned int address);
 	virtual const char *getDescription(unsigned int address);
-	virtual const char *findSymbolForAddress(unsigned int address);
 	virtual bool getSymbolValue(char* symbol, u32& dest);
 	virtual bool initExpression(const char* exp, PostfixExpression& dest);
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -206,7 +206,7 @@ bool CtrlDisAsmView::getDisasmAddressText(u32 address, char* dest, bool abbrevia
 {
 	if (displaySymbols)
 	{
-		const char* addressSymbol = debugger->findSymbolForAddress(address);
+		const char* addressSymbol = symbolMap.GetLabelName(address);
 		if (addressSymbol != NULL)
 		{
 			for (int k = 0; addressSymbol[k] != 0; k++)
@@ -1023,7 +1023,7 @@ void CtrlDisAsmView::updateStatusBarText()
 				// TODO: Could also be a float...
 				{
 					u32 data = Memory::Read_U32(line.info.dataAddress);
-					const char* addressSymbol = debugger->findSymbolForAddress(data);
+					const char* addressSymbol = symbolMap.GetLabelName(data);
 					if (addressSymbol)
 					{
 						sprintf(text,"[%08X] = %s (%08X)",line.info.dataAddress,addressSymbol,data);
@@ -1041,7 +1041,7 @@ void CtrlDisAsmView::updateStatusBarText()
 
 	if (line.info.isBranch)
 	{
-		const char* addressSymbol = debugger->findSymbolForAddress(line.info.branchTarget);
+		const char* addressSymbol = symbolMap.GetLabelName(line.info.branchTarget);
 		if (addressSymbol == NULL)
 		{
 			sprintf(text,"%08X",line.info.branchTarget);
@@ -1157,7 +1157,7 @@ std::string CtrlDisAsmView::disassembleRange(u32 start, u32 size)
 	{
 		MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(debugger,start+i);
 
-		if (info.isBranch && debugger->findSymbolForAddress(info.branchTarget) == NULL)
+		if (info.isBranch && symbolMap.GetLabelName(info.branchTarget) == NULL)
 		{
 			if (branchAddresses.find(info.branchTarget) == branchAddresses.end())
 			{
@@ -1189,7 +1189,7 @@ std::string CtrlDisAsmView::disassembleRange(u32 start, u32 size)
 		}
 
 		if (line.info.isBranch && !line.info.isBranchToRegister
-			&& debugger->findSymbolForAddress(line.info.branchTarget) == NULL
+			&& symbolMap.GetLabelName(line.info.branchTarget) == NULL
 			&& branchAddresses.find(line.info.branchTarget) != branchAddresses.end())
 		{
 			sprintf(buffer,"pos_%08X",line.info.branchTarget);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -167,7 +167,6 @@ CtrlDisAsmView::CtrlDisAsmView(HWND _wnd)
 	boldfont = CreateFont(rowHeight-2,charWidth,0,0,FW_DEMIBOLD,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,
 		L"Lucida Console");
 	curAddress=0;
-	instructionSize=4;
 	showHex=false;
 	hasFocus = false;
 	dontRedraw = false;
@@ -655,11 +654,11 @@ void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 			toggleBreakpoint(true);
 			break;
 		case VK_UP:
-			windowStart -= instructionSize;
+			scrollWindow(-1);
 			scanFunctions();
 			break;
 		case VK_DOWN:
-			windowStart += instructionSize;
+			scrollWindow(1);
 			scanFunctions();
 			break;
 		case VK_NEXT:
@@ -819,10 +818,10 @@ void CtrlDisAsmView::onMouseDown(WPARAM wParam, LPARAM lParam, int button)
 
 void CtrlDisAsmView::copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm)
 {
-	int count = (endAddr - startAddr) / instructionSize;
-
 	if (withDisasm == false)
 	{
+		int instructionSize = debugger->getInstructionSize(0);
+		int count = (endAddr - startAddr) / instructionSize;
 		int space = count * 32;
 		char *temp = new char[space];
 
@@ -1153,7 +1152,7 @@ std::string CtrlDisAsmView::disassembleRange(u32 start, u32 size)
 
 	// gather all branch targets without labels
 	std::set<u32> branchAddresses;
-	for (u32 i = 0; i < size; i += instructionSize)
+	for (u32 i = 0; i < size; i += debugger->getInstructionSize(0))
 	{
 		MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(debugger,start+i);
 

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -50,7 +50,6 @@ class CtrlDisAsmView
 
 	u32 windowStart;
 	int visibleRows;
-	int instructionSize;
 	bool whiteBackground;
 	bool displaySymbols;
 
@@ -110,7 +109,6 @@ public:
 	{
 		debugger=deb;
 		curAddress=debugger->getPC();
-		instructionSize=debugger->getInstructionSize(0);
 		manager.setCpu(deb);
 	}
 	DebugInterface *getDebugger()
@@ -123,13 +121,12 @@ public:
 
 	void gotoAddr(unsigned int addr)
 	{
-		addr = manager.getStartAddress(addr);
-		u32 windowEnd = windowStart+visibleRows*instructionSize;
-		u32 newAddress = addr&(~(instructionSize-1));
+		u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+		u32 newAddress = manager.getStartAddress(addr);
 
 		if (newAddress < windowStart || newAddress >= windowEnd)
 		{
-			windowStart = newAddress-visibleRows/2*instructionSize;
+			windowStart = manager.getNthPreviousAddress(newAddress,visibleRows/2);
 		}
 
 		setCurAddress(newAddress);
@@ -138,7 +135,7 @@ public:
 	}
 	void gotoPC()
 	{
-		gotoAddr(debugger->getPC()&(~(instructionSize-1)));
+		gotoAddr(debugger->getPC());
 	}
 	u32 getSelection()
 	{

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -457,7 +457,7 @@ void CtrlBreakpointList::GetColumnText(wchar_t* dest, int row, int col)
 				else
 					wsprintf(dest,L"0x%08X",mc.end-mc.start);
 			} else {
-				const char* sym = cpu->findSymbolForAddress(displayedBreakPoints_[index].addr);
+				const char* sym = symbolMap.GetLabelName(displayedBreakPoints_[index].addr);
 				if (sym != NULL)
 				{
 					std::wstring s = ConvertUTF8ToWString(sym);
@@ -625,7 +625,7 @@ void CtrlStackTraceView::GetColumnText(wchar_t* dest, int row, int col)
 		break;
 	case SF_ENTRYNAME:
 		{
-			const char* sym = cpu->findSymbolForAddress(frames[row].entry);
+			const char* sym = symbolMap.GetLabelName(frames[row].entry);
 			if (sym != NULL) {
 				wcscpy(dest, ConvertUTF8ToWString(sym).c_str());
 			} else {


### PR DESCRIPTION
This is a problem that became apparent with the new disassembler (naturally right after it was merged),

.sym is a simple format, I hacked function sizes into it, but generally it just supported plain mappings of addresses to labels, which had no size. I just registered them as one byte functions, and it wasn't a problem so far. But now it led to a lot crashes, because labels that were in the middle of a function really screwed the analysis up.

With this the names and all labels are saved in a separate map that is accessed whenever the name associated with an address is needed. It actually speeds the disassembler a bit up, too.
