### PR TITLE
Fix VS2013 build.

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <cmath>
+#include <algorithm>
 
 #include "base/colorutil.h"
 #include "base/timeutil.h"


### PR DESCRIPTION
More std::min / std::max complaints from 2013 as usual.
