### PR TITLE
Add an ini option to allow the emulated PSP model to be changed. 

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -294,6 +294,8 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 	
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
+	// 0 = PSP Fat, 1 = PSP Slim
+	pspConfig->Get("PSPModel", &iPSPModel, 0);
 	pspConfig->Get("NickName", &sNickName, "PPSSPP");
 	pspConfig->Get("proAdhocServer", &proAdhocServer, "localhost");
 	pspConfig->Get("MacAddress", &localMacAddress, "01:02:03:04:05:06");
@@ -520,6 +522,7 @@ void Config::Save() {
 
 
 		IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
+		pspConfig->Set("PSPModel", iPSPModel);
 		pspConfig->Set("NickName", sNickName.c_str());
         pspConfig->Set("proAdhocServer", proAdhocServer.c_str());
         pspConfig->Set("MacAddress", localMacAddress.c_str());

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -294,8 +294,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 	
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
-	// 0 = PSP Fat, 1 = PSP Slim
-	pspConfig->Get("PSPModel", &iPSPModel, 0);
+	pspConfig->Get("PSPModel", &iPSPModel, PSP_MODEL_SLIM);
 	pspConfig->Get("NickName", &sNickName, "PPSSPP");
 	pspConfig->Get("proAdhocServer", &proAdhocServer, "localhost");
 	pspConfig->Get("MacAddress", &localMacAddress, "01:02:03:04:05:06");

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -213,6 +213,7 @@ public:
 	bool bEncryptSave;
 	int iWlanAdhocChannel;
 	bool bWlanPowerSave;
+	int iPSPModel;
 	// TODO: Make this work with your platform, too!
 #ifdef _WIN32
 	bool bBypassOSKWithKeyboard;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -27,6 +27,8 @@ extern const char *PPSSPP_GIT_VERSION;
 #endif
 
 const int MAX_CONFIG_VOLUME = 8;
+const int PSP_MODEL_FAT = 0;
+const int PSP_MODEL_SLIM = 1;
 
 namespace http {
 	class Download;

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -55,7 +55,7 @@ static bool volatileMemLocked;
 static int powerCbSlots[numberOfCBPowerSlots];
 static std::vector<VolatileWaitingThread> volatileWaitingThreads;
 
-// this should belong here on in CoreTiming?
+// Should this belong here, or in CoreTiming?
 static int pllFreq = 222;
 static int busFreq = 111;
 
@@ -412,7 +412,9 @@ int scePowerTick() {
 
 
 u32 IsPSPNonFat() {
-	return PSP_MODEL_FAT;  
+	DEBUG_LOG(HLE, "%d=scePower_a85880d0_IsPSPNonFat()", g_Config.iPSPModel);
+
+	return g_Config.iPSPModel;  
 }
 
 static const HLEFunction scePower[] = {

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -45,9 +45,6 @@ const int PSP_POWER_CB_BATTERY_FULL = 0x00000064;
 
 const int POWER_CB_AUTO = -1;
 
-const int PSP_MODEL_FAT	= 0;
-const int PSP_MODEL_SLIM = 1;
-
 const int numberOfCBPowerSlots = 16;
 const int numberOfCBPowerSlotsPrivate = 32;
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -101,7 +101,7 @@ void Init()
 
 void DoState(PointerWrap &p)
 {
-	auto s = p.Section("Memory", 0, 2);
+	auto s = p.Section("Memory", 1, 2);
 	if (!s)
 		return;
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -27,6 +27,7 @@
 #include "HLE/HLE.h"
 #include "CPU.h"
 #include "Debugger/SymbolMap.h"
+#include "Core/Config.h"
 
 namespace Memory
 {
@@ -108,6 +109,8 @@ void DoState(PointerWrap &p)
 	p.DoMarker("VRAM");
 	p.DoArray(m_pScratchPad, SCRATCHPAD_SIZE);
 	p.DoMarker("ScratchPad");
+	p.Do(g_Config.iPSPModel);
+	p.DoMarker("PSPModel");
 }
 
 void Shutdown()

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -106,14 +106,15 @@ void DoState(PointerWrap &p)
 		return;
 
 	if (s < 2) {
-		g_MemorySize = RAM_NORMAL_SIZE;
+		if (!g_RemasterMode)
+			g_MemorySize = RAM_NORMAL_SIZE;
 		g_PSPModel = PSP_MODEL_FAT;
 	}
 	else {
 		p.Do(g_PSPModel);
 		p.DoMarker("PSPModel");
-
-		g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
+		if (!g_RemasterMode)
+			g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
 	}
 
 	p.DoArray(m_pRAM, g_MemorySize);

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -61,6 +61,8 @@ u8 *m_pUncachedVRAM;
 // These replace RAM_NORMAL_SIZE and RAM_NORMAL_MASK, respectively.
 u32 g_MemorySize;
 u32 g_MemoryMask;
+// Used to store the PSP model on game startup.
+u32 g_PSPModel;
 
 // We don't declare the IO region in here since its handled by other means.
 static MemoryView views[] =
@@ -99,18 +101,27 @@ void Init()
 
 void DoState(PointerWrap &p)
 {
-	auto s = p.Section("Memory", 1);
+	auto s = p.Section("Memory", 0, 2);
 	if (!s)
 		return;
 
+	if (s < 2) {
+		g_MemorySize = RAM_NORMAL_SIZE;
+		g_PSPModel = PSP_MODEL_FAT;
+	}
+	else {
+		g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
+		p.Do(g_PSPModel);
+		p.DoMarker("PSPModel");
+	}
+
 	p.DoArray(m_pRAM, g_MemorySize);
 	p.DoMarker("RAM");
+
 	p.DoArray(m_pVRAM, VRAM_SIZE);
 	p.DoMarker("VRAM");
 	p.DoArray(m_pScratchPad, SCRATCHPAD_SIZE);
 	p.DoMarker("ScratchPad");
-	p.Do(g_Config.iPSPModel);
-	p.DoMarker("PSPModel");
 }
 
 void Shutdown()

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -110,9 +110,10 @@ void DoState(PointerWrap &p)
 		g_PSPModel = PSP_MODEL_FAT;
 	}
 	else {
-		g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
 		p.Do(g_PSPModel);
 		p.DoMarker("PSPModel");
+
+		g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
 	}
 
 	p.DoArray(m_pRAM, g_MemorySize);

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -82,6 +82,9 @@ enum
 	RAM_NORMAL_SIZE = 0x02000000,
 	RAM_NORMAL_MASK = RAM_NORMAL_SIZE - 1,
 
+	// Used if the PSP model is PSP-2000 (Slim).
+	RAM_DOUBLE_SIZE = RAM_NORMAL_SIZE * 2,
+
 	VRAM_SIZE       = 0x200000,
 	VRAM_MASK       = VRAM_SIZE - 1,
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -75,6 +75,7 @@ extern u8 *m_pUncachedVRAM;
 // These replace RAM_NORMAL_SIZE and RAM_NORMAL_MASK, respectively.
 extern u32 g_MemorySize;
 extern u32 g_MemoryMask;
+extern u32 g_PSPModel;
 
 enum
 {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -41,6 +41,7 @@
 #include "HLE/sceKernelModule.h"
 #include "HLE/sceKernelMemory.h"
 #include "ELF/ParamSFO.h"
+#include "Core/Config.h"
 
 // We gather the game info before actually loading/booting the ISO
 // to determine if the emulator should enable extra memory and

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -160,6 +160,7 @@ void CPU_Init() {
 
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
+	Memory::g_PSPModel = g_Config.iPSPModel;
 
 	std::string filename = coreParameter.fileToStart;
 	IdentifiedFileType type = Identify_File(filename);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -153,7 +153,11 @@ void CPU_Init() {
 
 	// Default memory settings
 	// Seems to be the safest place currently..
-	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
+	if (g_Config.iPSPModel == PSP_MODEL_FAT)
+		Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
+	else
+		Memory::g_MemorySize = Memory::RAM_DOUBLE_SIZE;
+
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -295,9 +295,6 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iTimeFormat, s->T("Time Format"), timeFormat, 1, 2, s, screenManager()));
 	static const char *buttonPref[] = { "Use O to confirm", "Use X to confirm" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iButtonPreference, s->T("Confirmation Button"), buttonPref, 0, 2, s, screenManager()));
-	static const char *pspModels[] = { "PSP-1000 (Fat)", "PSP-2000 (Slim)" };
-	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, s->T("PSP Model"), pspModels, 0, 2, s, screenManager()));
-
 }
 
 UI::EventReturn GameSettingsScreen::OnRenderingMode(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -295,6 +295,9 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iTimeFormat, s->T("Time Format"), timeFormat, 1, 2, s, screenManager()));
 	static const char *buttonPref[] = { "Use O to confirm", "Use X to confirm" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iButtonPreference, s->T("Confirmation Button"), buttonPref, 0, 2, s, screenManager()));
+	static const char *pspModels[] = { "PSP-1000 (Fat)", "PSP-2000 (Slim)" };
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, s->T("PSP Model"), pspModels, 0, 2, s, screenManager()));
+
 }
 
 UI::EventReturn GameSettingsScreen::OnRenderingMode(UI::EventParams &e) {


### PR DESCRIPTION
[Some games require a PSP-2000 for certain features such as multiplayer (e.g. God Eater 2 and its demo)](https://github.com/hrydgard/ppsspp/issues/4659#issuecomment-29468183).
