### PR TITLE
Reinitialize the GE on sceKernelLoadExec()

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -47,6 +47,8 @@
 #include "Core/HLE/sceIo.h"
 #include "Core/HLE/KernelWaitHelpers.h"
 
+#include "GPU/GPUState.h"
+
 enum {
 	PSP_THREAD_ATTR_USER = 0x80000000
 };
@@ -1223,6 +1225,7 @@ bool __KernelLoadExec(const char *filename, u32 paramPtr, std::string *error_str
 		//HLE needs to be reset here
 		HLEShutdown();
 		HLEInit();
+		GPU_Reinitialize();
 	}
 
 	__KernelModuleInit();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -15,22 +15,28 @@
 #include "Core/HLE/sceGe.h"
 
 GPUCommon::GPUCommon() :
-	nextListID(0),
-	currentList(NULL),
-	isbreak(false),
-	drawCompleteTicks(0),
-	busyTicks(0),
 	dumpNextFrame_(false),
-	dumpThisFrame_(false),
-	interruptsEnabled_(true),
-	curTickEst_(0)
+	dumpThisFrame_(false)
 {
+	Reinitialize();
+	SetThreadEnabled(g_Config.bSeparateCPUThread);
+}
+
+void GPUCommon::Reinitialize() {
+	easy_guard guard(listLock);
 	memset(dls, 0, sizeof(dls));
 	for (int i = 0; i < DisplayListMaxCount; ++i) {
 		dls[i].state = PSP_GE_DL_STATE_NONE;
 		dls[i].waitTicks = 0;
 	}
-	SetThreadEnabled(g_Config.bSeparateCPUThread);
+
+	nextListID = 0;
+	currentList = NULL;
+	isbreak = false;
+	drawCompleteTicks = 0;
+	busyTicks = 0;
+	interruptsEnabled_ = true;
+	UpdateTickEstimate(0);
 }
 
 void GPUCommon::PopDLQueue() {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -19,6 +19,7 @@ class GPUCommon : public GPUThreadEventQueue, public GPUDebugInterface
 public:
 	GPUCommon();
 	virtual ~GPUCommon() {}
+	virtual void Reinitialize();
 
 	virtual void InterruptStart(int listid);
 	virtual void InterruptEnd(int listid);

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -184,6 +184,7 @@ public:
 
 	// Initialization
 	virtual void InitClear() = 0;
+	virtual void Reinitialize() = 0;
 
 	virtual void RunEventsUntil(u64 globalticks) = 0;
 	virtual void FinishEventLoop() = 0;

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -81,6 +81,12 @@ void GPU_Shutdown() {
 	gpuDebug = 0;
 }
 
+void GPU_Reinitialize() {
+	if (gpu) {
+		gpu->Reinitialize();
+	}
+}
+
 void InitGfxState() {
 	memset(&gstate, 0, sizeof(gstate));
 	memset(&gstate_c, 0, sizeof(gstate_c));

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -522,6 +522,7 @@ struct GPUStatistics {
 
 bool GPU_Init();
 void GPU_Shutdown();
+void GPU_Reinitialize();
 
 void InitGfxState();
 void ShutdownGfxState();


### PR DESCRIPTION
Mostly, reset the lists and draw completion, etc.

May be required for Capcom Classic Collection Reloaded to work (#4430.)

-[Unknown]
