### PR TITLE
Enable fast-memory by default, change the name of the setting so it resets for everyone.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -139,7 +139,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	cpu->Get("AtomicAudioLocks", &bAtomicAudioLocks, false);
 
 	cpu->Get("SeparateIOThread", &bSeparateIOThread, true);
-	cpu->Get("FastMemory", &bFastMemory, false);
+	cpu->Get("FastMemoryAccess", &bFastMemory, true);
 	cpu->Get("CPUSpeed", &iLockedCPUSpeed, 0);
 
 	IniFile::Section *graphics = iniFile.GetOrCreateSection("Graphics");
@@ -428,7 +428,7 @@ void Config::Save() {
 		cpu->Set("SeparateCPUThread", bSeparateCPUThread);
 		cpu->Set("AtomicAudioLocks", bAtomicAudioLocks);	
 		cpu->Set("SeparateIOThread", bSeparateIOThread);
-		cpu->Set("FastMemory", bFastMemory);
+		cpu->Set("FastMemoryAccess", bFastMemory);
 		cpu->Set("CPUSpeed", iLockedCPUSpeed);
 
 		IniFile::Section *graphics = iniFile.GetOrCreateSection("Graphics");


### PR DESCRIPTION
The speed boost is just too big to keep it from users who don't try all the settings.
