### PR TITLE
Build scripts: Use strict error checking to propogate errors to underlyi...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,33 @@ compiler:
 
 before_install:
   - git submodule update --init --recursive
-  - sudo apt-get install lib32z1-dev lib32stdc++6 -qq
-# Travis uses CMake 2.8.7. We require 2.8.8. Grab latest
-  - wget http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh
-  - chmod a+x cmake-2.8.12.1-Linux-i386.sh
-  - sudo ./cmake-2.8.12.1-Linux-i386.sh --skip-license --prefix=/usr
+  - sudo apt-get install lib32z1-dev lib32stdc++6 aria2 -qq
+# Travis uses CMake 2.8.7. We require 2.8.8 for Linux/Blackberry. Grab latest
+  - if [ "$PPSSPP_BUILD_TYPE" != "Android" ]; then
+      aria2c -x 16 http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh &&
+      chmod a+x cmake-2.8.12.1-Linux-i386.sh &&
+      sudo ./cmake-2.8.12.1-Linux-i386.sh --skip-license --prefix=/usr;
+    fi
 # Linux Setup
   - if [ "$PPSSPP_BUILD_TYPE" == "Linux" ]; then sudo apt-get install libsdl1.2-dev -qq; fi
 # Android NDK
   - if [ "$PPSSPP_BUILD_TYPE" == "Android" ]; then
+      NDK_VER=android-ndk-r9b
+      NDK_TAR=${NDK_VER}-linux-x86_64.tar.bz2 &&
       sudo apt-get install openjdk-7-jdk ant -qq &&
-      wget --timeout=30 http://dl.google.com/android/ndk/android-ndk-r9-linux-x86_64.tar.bz2 -O ndk.tar.bz2 &&
-      tar -xf ndk.tar.bz2 &&
-      export ANDROID_HOME=$(pwd)/android-ndk-r9 NDK=$(pwd)/android-ndk-r9;
+      aria2c -x 16 http://dl.google.com/android/ndk/${NDK_TAR} &&
+      tar -xf ${NDK_TAR} &&
+      export ANDROID_HOME=$(pwd)/${NDK_VER} NDK=$(pwd)/${NDK_VER};
+      if [[ "$CXX" == *clang* ]]; then export NDK_TOOLCHAIN_VERSION=clang; fi
     fi
-  - if [[ "$CXX" == *clang* ]]; then export NDK_TOOLCHAIN_VERSION=clang; fi
 # Blackberry NDK
   - if [ "$PPSSPP_BUILD_TYPE" == "Blackberry" ]; then
-      BB_NDK=http://downloads.blackberry.com/upr/developers/update/bbndk/ndktarget_10.2.0.1155/ndktargetrepo_10.2.0.1155/packages/bbndk.linux. &&
-      wget --timeout=30 ${BB_NDK}libraries.10.2.0.1155.tar.gz -O libs.tar.gz &&
-      tar -xf libs.tar.gz &&
-      wget --timeout=30 ${BB_NDK}tools.10.2.0.15.tar.gz -O tools.tar.gz &&
-      tar -xf tools.tar.gz &&
+      BB_NDK=http://downloads.blackberry.com/upr/developers/update/bbndk/ndktarget_10.2.0.1155/ndktargetrepo_10.2.0.1155/packages/
+      BB_LIBS=bbndk.linux.libraries.10.2.0.1155.tar.gz &&
+      BB_TOOLS=bbndk.linux.tools.10.2.0.15.tar.gz &&
+      aria2c -x 16 ${BB_NDK}${BB_LIBS} https://googledrive.com/host/0B5UBD4wjtpZ-QVdzSElobzNTOU0 -o libs.tar.gz &&
+      aria2c -x 16 ${BB_NDK}${BB_TOOLS} https://googledrive.com/host/0B5UBD4wjtpZ-NV80UzFYMVRkSXM -o tools.tar.gz &&
+      tar -xf libs.tar.gz && tar -xf tools.tar.gz &&
       export QNX_TARGET="$(pwd)/target_10_2_0_1155/qnx6" QNX_HOST="$(pwd)/host_10_2_0_15/linux/x86" && PATH="$QNX_HOST/usr/bin:$PATH";
     fi
 

--- a/Blackberry/build.sh
+++ b/Blackberry/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+# Strict errors. Any non-zero return exits this script
+set -e
 
 BB_OS=`cat ${QNX_TARGET}/etc/qversion 2>/dev/null`
 if [ -z "$BB_OS" ]; then
@@ -11,7 +12,7 @@ if [[ "$1" == "--simulator" ]]; then
 	SIM="-DSIMULATOR=ON"
 fi
 
-cmake ${SIM} -DCMAKE_TOOLCHAIN_FILE=bb.toolchain.cmake -DBLACKBERRY=${BB_OS} .. | grep -v '^-- '
+cmake ${SIM} -DCMAKE_TOOLCHAIN_FILE=bb.toolchain.cmake -DBLACKBERRY=${BB_OS} .. | (grep -v "^-- " || true)
 
 # Compile and create unsigned PPSSPP.bar with debugtoken
 make -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,24 +71,25 @@ option(HEADLESS "Set to OFF to not generate the PPSSPPHeadless target" ${HEADLES
 option(SIMULATOR "Set to ON when targeting an x86 simulator of an ARM platform" ${SIMULATOR})
 option(USE_FFMPEG "Build with FFMPEG support" ${USE_FFMPEG})
 
-if(ANDROID)
-	if(NOT ANDROID_ABI)
+if(ANDROID OR BLACKBERRY OR IOS)
+	if (NOT CMAKE_TOOLCHAIN_FILE)
+		if (ANDROID)
+			set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/android/android.toolchain.cmake)
+		elseif(BLACKBERRY)
+			set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/Blackberry/bb.toolchain.cmake)
+		elseif(IOS)
+			set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/ios/ios.toolchain.cmake)
+		endif()
 		message(FATAL_ERROR "CMAKE_TOOLCHAIN_FILE was not set!\n"
-			"Delete the CMakeCache.txt file and CMakeFiles directory."
-			"Rerun ${CMAKE_COMMAND} with \"-DCMAKE_TOOLCHAIN_FILE"
-			"=${CMAKE_SOURCE_DIR}/android/android.toolchain.cmake\"")
+			"Delete the CMakeCache.txt file and CMakeFiles directory.\n"
+			"Re-run ${CMAKE_COMMAND} with:\n"
+			"\"-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}\"")
 	endif()
+endif()
+
+if(ANDROID)
 	set(CoreLibName ppsspp_jni)
 	set(CoreLinkType SHARED)
-elseif(IOS)
-	if (NOT IOS_PLATFORM)
-		message(FATAL_ERROR "CMAKE_TOOLCHAIN_FILE was not set!\n"
-			"Delete the CMakeCache.txt file and CMakeFiles directory."
-			"Rerun ${CMAKE_COMMAND} with \"-DCMAKE_TOOLCHAIN_FILE"
-			"=${CMAKE_SOURCE_DIR}/ios/ios.toolchain.cmake\"")
-	endif()
-	set(CoreLibName Core)
-	set(CoreLinkType STATIC)
 else()
 	set(CoreLibName Core)
 	set(CoreLinkType STATIC)

--- a/b.sh
+++ b/b.sh
@@ -1,3 +1,6 @@
+# Strict errors. Any non-zero return exits this script
+set -e
+
 cp -r android/assets .
 mkdir -p build
 if [[ "$1" == "--headless" ]]; then
@@ -6,6 +9,6 @@ else
 	MAKE_OPT="$1"
 fi
 pushd build
-cmake $HEADLESS .. | grep -v '^-- '
+cmake $HEADLESS .. | (grep -v "^-- " || true)
 make -j4 $MAKE_OPT
 popd


### PR DESCRIPTION
...ng shell (hint: travis).

Stops builds from showing success when there was an error.
Had to workaround grep's issue of returning '1' when there is no matches. There is unfortunately no alternative.
Removed bin/bash header as it could restrict alternative shells.
Used set -e to break script whenever a non-zero return is encountered.
CMake was returning non-zero on CMAKE_TOOLCHAIN_FILE not being required. Now check for that in CMake instead of platform/abi. If the abi is missing and toolchain is not, that would have been the wrong advice anyway.
