### PR TITLE
Win32 Menubar: Allow postprocessing shader names to be translated.

### DIFF
--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -109,8 +109,7 @@ void DoState(PointerWrap &p)
 		if (!g_RemasterMode)
 			g_MemorySize = RAM_NORMAL_SIZE;
 		g_PSPModel = PSP_MODEL_FAT;
-	}
-	else {
+	} else {
 		p.Do(g_PSPModel);
 		p.DoMarker("PSPModel");
 		if (!g_RemasterMode)

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -472,7 +472,7 @@ namespace MainWindow
 
 	void CreateShadersSubmenu() {
 		I18NCategory *des = GetI18NCategory("DesktopUI");
-		
+		I18NCategory *shdr = GetI18NCategory("PostShaders");
 		const std::wstring key = ConvertUTF8ToWString(des->T("Postprocessing Shader"));
 
 		HMENU optionsMenu = GetSubMenu(menu, MENU_OPTIONS);
@@ -488,6 +488,8 @@ namespace MainWindow
 		int item = ID_SHADERS_BASE + 1;
 		int checkedStatus = -1;
 
+		const char *translatedShaderName = nullptr;
+
 		for (auto i = info.begin(); i != info.end(); ++i) {
 			checkedStatus = MF_UNCHECKED;
 			availableShaders.push_back(i->section);
@@ -495,7 +497,9 @@ namespace MainWindow
 				checkedStatus = MF_CHECKED;
 			}
 
-			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(i->name).c_str());
+			translatedShaderName = shdr->T(i->section.c_str());
+
+			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		}
 	}
 


### PR DESCRIPTION
Also fix a quick styling issue/nitpick in Memmap.
