### PR TITLE
Add support for profiling jit via VerySleepy

### DIFF
--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -840,7 +840,7 @@ public:
 		region_size = 0;
 	}
 
-	bool IsInSpace(u8 *ptr)
+	bool IsInSpace(const u8 *ptr) const
 	{
 		return ptr >= region && ptr < region + region_size;
 	}
@@ -870,7 +870,7 @@ public:
 		return region;
 	}
 
-	size_t GetOffset(u8 *ptr) {
+	size_t GetOffset(const u8 *ptr) const {
 		return ptr - region;
 	}
 };

--- a/Common/ppcEmitter.h
+++ b/Common/ppcEmitter.h
@@ -463,7 +463,7 @@ namespace PpcGen
 			region_size = 0;
 		}
 
-		bool IsInSpace(u8 *ptr)
+		bool IsInSpace(const u8 *ptr) const
 		{
 			return ptr >= region && ptr < region + region_size;
 		}
@@ -493,7 +493,7 @@ namespace PpcGen
 			return region;
 		}
 
-		size_t GetOffset(u8 *ptr) {
+		size_t GetOffset(const u8 *ptr) const {
 			return ptr - region;
 		}
 	};

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -756,7 +756,7 @@ public:
 		region_size = 0;
 	}
 
-	bool IsInSpace(u8 *ptr)
+	bool IsInSpace(const u8 *ptr) const
 	{
 		return ptr >= region && ptr < region + region_size;
 	}
@@ -782,7 +782,7 @@ public:
 		return region;
 	}
 
-	size_t GetOffset(u8 *ptr) {
+	size_t GetOffset(const u8 *ptr) const {
 		return ptr - region;
 	}
 };

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -65,6 +65,10 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
+	bool IsInDispatch(const u8 *p) {
+		return IsInSpace(p);
+	}
+
 	void CompileDelaySlot(int flags);
 	void CompileAt(u32 addr);
 	void EatInstruction(MIPSOpcode op);

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -254,6 +254,21 @@ void JitBlockCache::GetBlockNumbersFromAddress(u32 em_address, std::vector<int> 
 			block_numbers->push_back(i);
 }
 
+u32 JitBlockCache::GetAddressFromBlockPtr(const u8 *ptr) const {
+	if (!codeBlock_->IsInSpace(ptr))
+		return (u32)-1;
+
+	for (int i = 0; i < num_blocks; ++i) {
+		const auto &b = blocks[i];
+		if (!b.invalid && ptr >= b.normalEntry && ptr < b.normalEntry + b.codeSize) {
+			return b.originalAddress;
+		}
+	}
+
+	// It's in jit somewhere, but we must've deleted it.
+	return 0;
+}
+
 MIPSOpcode JitBlockCache::GetOriginalFirstOp(int block_num)
 {
 	if (block_num >= num_blocks || block_num < 0)

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -183,7 +183,7 @@ void JitBlockCache::FinalizeBlock(int block_num, bool block_link)
 	char buf[100];
 	sprintf(buf, "EmuCode%x", b.originalAddress);
 	const u8* blockStart = blocks[block_num].checkedEntry;
-	op_write_native_code(agent, buf, (uint64_t)blockStart, blockStart, b.codeSize);
+	op_write_native_code(agent, buf, (uint64_t)blockStart, blockStart, b.normalEntry + b.codeSize - b.checkedEntry);
 #endif
 
 #ifdef USE_VTUNE
@@ -194,7 +194,7 @@ void JitBlockCache::FinalizeBlock(int block_num, bool block_link)
 	jmethod.class_file_name = "";
 	jmethod.source_file_name = __FILE__;
 	jmethod.method_load_address = (void*)blocks[block_num].checkedEntry;
-	jmethod.method_size = b.codeSize;
+	jmethod.method_size = b.normalEntry + b.codeSize - b.checkedEntry;
 	jmethod.line_number_size = 0;
 	jmethod.method_name = b.blockName;
 	iJIT_NotifyEvent(iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED, (void*)&jmethod);
@@ -260,7 +260,7 @@ u32 JitBlockCache::GetAddressFromBlockPtr(const u8 *ptr) const {
 
 	for (int i = 0; i < num_blocks; ++i) {
 		const auto &b = blocks[i];
-		if (!b.invalid && ptr >= b.normalEntry && ptr < b.normalEntry + b.codeSize) {
+		if (!b.invalid && ptr >= b.checkedEntry && ptr < b.normalEntry + b.codeSize) {
 			return b.originalAddress;
 		}
 	}

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -109,6 +109,8 @@ public:
 	void GetBlockNumbersFromAddress(u32 em_address, std::vector<int> *block_numbers);
 	int GetBlockNumberFromEmuHackOp(MIPSOpcode inst) const;
 
+	u32 GetAddressFromBlockPtr(const u8 *ptr) const;
+
 	MIPSOpcode GetOriginalFirstOp(int block_num);
 
 	// DOES NOT WORK CORRECTLY WITH JIT INLINING

--- a/Core/MIPS/PPC/PpcJit.h
+++ b/Core/MIPS/PPC/PpcJit.h
@@ -294,6 +294,10 @@ namespace MIPSComp
 		void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 		const u8 *DoJit(u32 em_address, JitBlock *b);
 
+		bool IsInDispatch(const u8 *p) {
+			return IsInSpace(p);
+		}
+
 		PpcJitOptions jo;
 		PpcJitState js;
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -72,6 +72,10 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
+	bool IsInDispatch(const u8 *p) {
+		return asm_.IsInSpace(p);
+	}
+
 	void CompileAt(u32 addr);
 	void Comp_RunBlock(MIPSOpcode op);
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1661,3 +1661,11 @@ bool GLES_GPU::GetCurrentTexture(GPUDebugBuffer &buffer) {
 bool GLES_GPU::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {
 	return transformDraw_.GetCurrentSimpleVertices(count, vertices, indices);
 }
+
+bool GLES_GPU::DescribeCodePtr(const u8 *ptr, std::string &name) {
+	if (transformDraw_.IsCodePtrVertexDecoder(ptr)) {
+		name = "VertexDecoderJit";
+		return true;
+	}
+	return false;
+}

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -73,6 +73,8 @@ public:
 	bool GetCurrentTexture(GPUDebugBuffer &buffer);
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 
+	virtual bool DescribeCodePtr(const u8 *ptr, std::string &name);
+
 protected:
 	virtual void FastRunLoop(DisplayList &list);
 	virtual void ProcessEvent(GPUEvent ev);

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -128,6 +128,10 @@ public:
 		DoFlush();
 	}
 
+	bool IsCodePtrVertexDecoder(const u8 *ptr) const {
+		return decJitCache_->IsInSpace(ptr);
+	}
+
 private:
 	void DecodeVerts();
 	void DecodeVertsStep();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -73,6 +73,10 @@ public:
 		FreeAlignedMemory(p);
 	}
 
+	virtual bool DescribeCodePtr(const u8 *ptr, std::string &name) {
+		return false;
+	}
+
 protected:
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -243,6 +243,9 @@ public:
 	virtual bool FramebufferReallyDirty() = 0;
 	virtual bool BusyDrawing() = 0;
 
+	// If any jit is being used inside the GPU.
+	virtual bool DescribeCodePtr(const u8 *ptr, std::string &name) = 0;
+
 	// Debugging
 	virtual void DumpNextFrame() = 0;
 	virtual void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) = 0;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -46,6 +46,8 @@
 #include "Core/SaveState.h"
 #include "Core/System.h"
 #include "Core/Config.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Windows/EmuThread.h"
 
 #include "resource.h"
@@ -74,6 +76,24 @@
 #endif
 
 #define ENABLE_TOUCH 0
+
+int verysleepy__useSendMessage = 1;
+
+const UINT WM_VERYSLEEPY_MSG = WM_APP + 0x3117;
+// Respond TRUE to a message with this param value to indicate support.
+const WPARAM VERYSLEEPY_WPARAM_SUPPORTED = 0;
+// Respond TRUE to a message wit this param value after filling in the addr name.
+const WPARAM VERYSLEEPY_WPARAM_GETADDRINFO = 1;
+
+struct VerySleepy_AddrInfo
+{
+	// Always zero for now.
+	int flags;
+	// This is the pointer (always passed as 64 bits.)
+	unsigned long long addr;
+	// Write the name here.
+	wchar_t name[256];
+};
 
 extern std::map<int, int> windowsTransTable;
 static RECT g_normalRC = {0};
@@ -1522,6 +1542,43 @@ namespace MainWindow
 				}
 			}
 			return 0;
+
+		case WM_VERYSLEEPY_MSG:
+			switch (wParam) {
+			case VERYSLEEPY_WPARAM_SUPPORTED:
+				return TRUE;
+
+			case VERYSLEEPY_WPARAM_GETADDRINFO:
+				{
+					VerySleepy_AddrInfo *info = (VerySleepy_AddrInfo *)lParam;
+					const u8 *ptr = (const u8 *)info->addr;
+					if (MIPSComp::jit) {
+						JitBlockCache *blocks = MIPSComp::jit->GetBlockCache();
+						u32 jitAddr = blocks->GetAddressFromBlockPtr(ptr);
+
+						// Returns 0 when it's valid, but unknown.
+						if (jitAddr == 0) {
+							wcscpy_s(info->name, L"Jit::UnknownOrDeletedBlock");
+							return TRUE;
+						}
+						if (jitAddr != (u32)-1) {
+							swprintf_s(info->name, L"Jit::%08x", jitAddr);
+							return TRUE;
+						}
+
+						// Perhaps it's in jit the dispatch runloop.
+						if (MIPSComp::jit->IsInDispatch(ptr)) {
+							wcscpy_s(info->name, L"Jit::RunLoopUntil");
+							return TRUE;
+						}
+					}
+				}
+				return FALSE;
+
+			default:
+				return FALSE;
+			}
+			break;
 
 		case WM_DROPFILES:
 			{

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1572,6 +1572,13 @@ namespace MainWindow
 							return TRUE;
 						}
 					}
+					if (gpu) {
+						std::string name;
+						if (gpu->DescribeCodePtr(ptr, name)) {
+							swprintf_s(info->name, L"GPU::%S", name.c_str());
+							return TRUE;
+						}
+					}
 				}
 				return FALSE;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1562,7 +1562,12 @@ namespace MainWindow
 							return TRUE;
 						}
 						if (jitAddr != (u32)-1) {
-							swprintf_s(info->name, L"Jit::%08x", jitAddr);
+							const char *label = symbolMap.GetDescription(jitAddr);
+							if (label != NULL) {
+								swprintf_s(info->name, L"Jit::%08x_%S", jitAddr, label);
+							} else {
+								swprintf_s(info->name, L"Jit::%08x", jitAddr);
+							}
 							return TRUE;
 						}
 


### PR DESCRIPTION
Use this version of VerySleepy which supports this functionality:
https://github.com/unknownbrackets/verysleepy/releases/tag/v0.90-pre-jit

Tried to KISS.  Reports the vertex decoder, dispatch run loop, and functions / blocks.  I think this approach could be potentially used (by dumping to a file or something...) on Android as well.

Sample results from Gods Eater Burst (with vertex cache disabled):

15.18% GPU::VertexDecoderJit
2.84% Jit::0880b098_strcmp
1.13% Jit::RunLoopUntil
0.89% Jit::0880b0b4_strcmp
0.76% Jit::088e067c_z_un_088e0608
0.51% Jit::088e0690_z_un_088e0608
0.49% Jit::UnknownOrDeletedBlock
...

I'm pretty sure the funcs it identifies are hot, but I'm not sure why it's identifying unknown/deleted blocks, which makes me think I have a mistake somewhere.  That means it's inside the jit code space, but not inside any valid block.

-[Unknown]
