### PR TITLE
Not using factor in texture coords mapping mode

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -417,8 +417,8 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 				// Shouldn't even get here as we won't use the uniform in the shader.
 				// We are here but are prescaling UV in the decoder? Let's do the same as in the other case
 				// except consider *Scale and *Off to be 1 and 0.
-				uvscaleoff[0] = factor * widthFactor;
-				uvscaleoff[1] = factor * heightFactor;
+				uvscaleoff[0] = widthFactor;
+				uvscaleoff[1] = heightFactor;
 				uvscaleoff[2] = 0.0f;
 				uvscaleoff[3] = 0.0f;
 			} else {


### PR DESCRIPTION
This fixes the wrong scaling in Castlevania The Dracula X Chronicles when texture coord speedhack on .Tested with Frontier Gate ,3rd birthday and RR2 and all look fine .Not too sure if may break other games .Hopefully safe.

 Issue #4583 
