### PR TITLE
Trigger ReadFramebufferToMemory() only when block transfer from VRAM to RAM

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -766,9 +766,11 @@ void FramebufferManager::SetRenderFrameBuffer() {
 	} else if (vfb != currentRenderVfb_) {
 		bool updateVRAM = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 
-		if (updateVRAM && !vfb->memoryUpdated) {
+		if ((updateVRAM && !vfb->memoryUpdated) || gstate_c.blocktransfer) {
 			ReadFramebufferToMemory(vfb, true);
+			gstate_c.blocktransfer = false;
 		}
+		
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1058,6 +1058,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 
 			// Fixes Gran Turismo's funky text issue, since it overwrites the current texture.
 			gstate_c.textureChanged = true;
+			gstate_c.blocktransfer = true;
 			break;
 		}
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1058,7 +1058,6 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 
 			// Fixes Gran Turismo's funky text issue, since it overwrites the current texture.
 			gstate_c.textureChanged = true;
-			gstate_c.blocktransfer = true;
 			break;
 		}
 
@@ -1542,7 +1541,11 @@ void GLES_GPU::DoBlockTransfer() {
 		ERROR_LOG_REPORT(G3D, "BlockTransfer: Bad destination transfer address %08x!", dstBasePtr);
 		return;
 	}
-	
+
+	// From VRAM to RAM , trigger ReadFramebufferToMemory()
+	if (Memory::IsVRAMAddress(srcBasePtr) && !Memory::IsVRAMAddress(dstBasePtr) )
+		gstate_c.blocktransfer = true;
+		
 	// Do the copy! (Hm, if we detect a drawn video frame (see below) then we could maybe skip this?)
 	for (int y = 0; y < height; y++) {
 		const u8 *src = Memory::GetPointer(srcBasePtr + ((y + srcY) * srcStride + srcX) * bpp);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -437,6 +437,7 @@ struct GPUStateCache
 	bool textureChanged;
 	bool textureFullAlpha;
 	bool framebufChanged;
+	bool blocktransfer;
 
 	int skipDrawReason;
 


### PR DESCRIPTION
It is a dirty way .....to trigger ReadFramebufferToMemory when block transfer from VRAM to RAM .

This only slow down a bit when those games uses block transfer from VRAM to RAM which should be rare for example , screenshot saving in Ys Seven 
