### PR TITLE
Improve function symbol detection

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -29,7 +29,7 @@ const char *ElfReader::GetSectionName(int section)
 		return 0;
 
 	int nameOffset = sections[section].sh_name;
-	char *ptr = (char*)GetSectionDataPtr(header->e_shstrndx);
+	const char *ptr = (const char *)GetSectionDataPtr(header->e_shstrndx);
 
 	if (ptr)
 		return ptr + nameOffset;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -262,9 +262,10 @@ namespace MIPSAnalyst {
 				}
 			}
 			if (op == MIPS_MAKE_JR_RA()) {
-				if (furthestBranch >= addr) {
+				// If a branch goes to the jr ra, it's still ending here.
+				if (furthestBranch > addr) {
 					looking = true;
-					addr+=4;
+					addr += 4;
 				} else {
 					end = true;
 				}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -249,7 +249,16 @@ namespace MIPSAnalyst {
 		for (addr = startAddr; addr <= endAddr; addr+=4) {
 			SymbolInfo syminfo;
 			if (symbolMap.GetSymbolInfo(&syminfo, addr, ST_FUNCTION)) {
-				addr = syminfo.address + syminfo.size;
+				addr = syminfo.address + syminfo.size - 4;
+
+				// We still need to insert the func for hashing purposes.
+				currentFunction.start = syminfo.address;
+				currentFunction.end = syminfo.address + syminfo.size - 4;
+				functions.push_back(currentFunction);
+				currentFunction.start = addr + 4;
+				furthestBranch = 0;
+				looking = false;
+				end = false;
 				continue;
 			}
 


### PR DESCRIPTION
It's a little bit messy, probably should turn that func into a class/struct since it's getting awfully stateful...

Anyway, this makes some major changes to function detection:

When there's no text section, scan the initial load address -> the first stub address.  There may be garbage, but almost always it's just functions.  Impact of scanning garbage should be low...?

When there's already a symbol map, correctly step through them and insert into the func table so we can hash later.

Improves detection of this form of code:

```
// Something like...
if (a0 != 0)
   *a0 = 0;
return 0;

func:
   beq a0, zero, exit
   li v0, 0
   sw v0, 0(a0)

exit:
   jr ra
   nop
```

The branch to jr ra was preventing a function end and it would end at the next j/branch/etc.

Improves detection of this form of code:

```
// Something like...
if (a0 != 0)
{
   *a0 = 0;
   return a0;
}
else
   return 0;

func:
   beq a0, zero, func_fatal
   li v0, 0
   j func_safe
   sw zero, 0(a0)

func_fatal:
   jr ra
   nop

func_safe:
   j func_fatal
   move v0, a0
```

Before it would end early (at the func_fatal return.)  There are still cases it doesn't detect, though...

And finally attempts to detect tail call and end the func early, e.g.:

```
// Something like
return otherFunc(a0 * 2 + a2, a3, a1);

addu a0, a0, a0
addu a0, a0, a2
move a2, a1
j otherFunc
move a1, a3
```

Before it would keep going until it hit a jr ra.

This _significantly_ improves the accuracy, although I would guess it's still misdetecting sometimes.  I find a lot more instances of common funcs in games with these changes, and all the cases I've noted where it guessed wrong seem okay.

-[Unknown]
