### PR TITLE
Automatically pause core when changing breakpoints

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -324,13 +324,24 @@ const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
 
 void CBreakPoints::Update(u32 addr)
 {
-	if (MIPSComp::jit && Core_IsInactive())
+	if (MIPSComp::jit)
 	{
+		bool resume = false;
+		if (Core_IsStepping() == false)
+		{
+			Core_EnableStepping(true);
+			Core_WaitInactive();
+			resume = true;
+		}
+		
 		// In case this is a delay slot, clear the previous instruction too.
 		if (addr != 0)
 			MIPSComp::jit->ClearCacheAt(addr - 4, 8);
 		else
 			MIPSComp::jit->ClearCache();
+
+		if (resume)
+			Core_EnableStepping(false);
 	}
 
 	// Redraw in order to show the breakpoint.


### PR DESCRIPTION
No need to pause the core anymore before adding or removing breakpoints. Seems to work well.

https://github.com/hrydgard/ppsspp/blob/master/Core/Core.cpp#L289
The ifdefs here cause the disassembly to lose the current position in debug builds (it jumps to the PC on SetDebugMode). I wasn't sure what the purpose of the calls was, so I didn't want to remove them.
