### PR TITLE
Warning fix in DisassemblyManager.cpp (Visual Studio 2013)

### DIFF
--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -400,7 +400,7 @@ void DisassemblyFunction::getBranchLines(u32 start, u32 size, std::vector<Branch
 {
 	u32 end = start+size;
 
-	for (int i = 0; i < lines.size(); i++)
+	for (size_t i = 0; i < lines.size(); i++)
 	{
 		BranchLine& line = lines[i];
 


### PR DESCRIPTION
I also noticed in Visual Studio 2013 that when native submodule is rebuilt, it spawns 32 warnings. It doesn't spawns them at first build.
