### PR TITLE
Gods Eater Burst Savedata problem

### DIFF
--- a/Gods Eater Burst load save problem
+++ b/Gods Eater Burst load save problem
@@ -1,0 +1,8 @@
+Hi there , i wanted to report a problem with the latest builds.
+
+its about the game : Gods Eater Burst
+
+i tried to load my savegames from the real psp on ppsspp and it wont load them . it just sends me right back to the title menu. no error menu whatsoever.
+ 
+ 
+would be awesome if you could look into it


### PR DESCRIPTION
Hi there , i wanted to report a problem with the latest builds.

its about the game : Gods Eater Burst

i tried to load my savegames from the real psp on ppsspp and it wont load them . it just sends me right back to the title menu. no error menu whatsoever.

would be awesome if you could look into it
