### PR TITLE
When writing stencil to alpha, consider fb format

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -101,8 +101,8 @@ static const GLushort stencilOps[] = {
 	GL_ZERO,
 	GL_REPLACE,
 	GL_INVERT,
-	GL_INCR_WRAP,
-	GL_DECR_WRAP,  // don't know if these should be wrap or not
+	GL_INCR,
+	GL_DECR,
 	GL_KEEP, // reserved
 	GL_KEEP, // reserved
 };


### PR DESCRIPTION
This may work in more cases, except that most games almost always use alpha blending.

Not that we should kinda do the same on stencil testing as well, but it seems mucky.  For example, if I write 0x80 to a 5551 buffer, it should only be equal to 0xFF after that...

-[Unknown]
