### PR TITLE
Adhoc/Network: Default to off and save the value to the ini properly.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -312,7 +312,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 
 	IniFile::Section *network = iniFile.GetOrCreateSection("Network");
-	network->Get("EnableWlan", &bEnableWlan, true);
+	network->Get("EnableWlan", &bEnableWlan, false);
 	
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
 #ifndef ANDROID
@@ -550,7 +550,7 @@ void Config::Save() {
 		control->Set("AnalogStickScale", fAnalogStickScale);
 
 		IniFile::Section *network = iniFile.GetOrCreateSection("Network");
-		network->Set("EnableWlan", &bEnableWlan, true);
+		network->Set("EnableWlan", bEnableWlan);
 
 		IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
 		pspConfig->Set("PSPModel", iPSPModel);

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -148,13 +148,13 @@ u32 sceNetGetLocalEtherAddr(u32 addrAddr) {
 }
 
 u32 sceWlanDevIsPowerOn() {
-	DEBUG_LOG(SCENET, "UNTESTED 0=sceWlanDevIsPowerOn()");
-	return 1;
+	DEBUG_LOG(SCENET, "UNTESTED sceWlanDevIsPowerOn()");
+	return g_Config.bEnableWlan ? 1 : 0;
 }
 
 u32 sceWlanGetSwitchState() {
 	DEBUG_LOG(SCENET, "UNTESTED sceWlanGetSwitchState()");
-	return 1;
+	return g_Config.bEnableWlan ? 1 : 0;
 }
 
 // Probably a void function, but often returns a useful value.


### PR DESCRIPTION
 If it's on by default, Peace Walker and other games are broken for now. It needs more testing before defaulting to on.
