### PR TITLE
Win32 menu: If the emulator is paused (via Emulation -> Pause) when selecting Emulation -> Stop, resume the emulation so it can stop.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1184,6 +1184,9 @@ namespace MainWindow
 					break;
 
 				case ID_EMULATION_STOP:
+					if (Core_IsStepping())
+						Core_EnableStepping(false);
+
 					Core_Stop();
 					NativeMessageReceived("stop", "");
 					Core_WaitInactive();


### PR DESCRIPTION
This will make Stop more like Reset, which resets regardless of the pause state. It's a bit silly to have to hit Emulation -> Run then Emulation -> Stop to stop the game, if it's paused.

I tested with a few games, and it didn't seem to hurt anything, but it never hurts to hear from others on their experiences.
