### PR TITLE
Replace alpha when blend mode allows it.

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -53,4 +53,5 @@ enum StencilValueType {
 };
 
 StencilValueType ReplaceAlphaWithStencilType();
+bool CanReplaceAlphaWithStencil();
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -249,7 +249,10 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		// do any blending in the alpha channel as that doesn't seem to happen on PSP. So lacking a better option,
 		// the only value we can set alpha to here without multipass and dual source alpha is zero (by setting
 		// the factors to zero). So let's do that.
-		if (gstate.isStencilTestEnabled()) {
+		if (CanReplaceAlphaWithStencil()) {
+			// Let the fragment shader take care of it.
+			glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ONE, GL_ZERO);
+		} else if (gstate.isStencilTestEnabled()) {
 			switch (ReplaceAlphaWithStencilType()) {
 			case STENCIL_VALUE_KEEP:
 				glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, GL_ONE);


### PR DESCRIPTION
Some games are using fixed/fixed blending modes which work in our favor (see #4740 comments.)

-[Unknown]
