### PR TITLE
Set src/dst alpha to non GL_ZERO in case STENCIL_VALUE_UNIFORM

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -264,8 +264,10 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			case STENCIL_VALUE_ZERO:
 				glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, GL_ZERO);
 				break;
-			// For now, let's err at zero.
 			case STENCIL_VALUE_UNIFORM:
+				glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, glBlendFuncA, glBlendFuncB);
+				break;
+			// For now, let's err at zero.	
 			case STENCIL_VALUE_UNKNOWN:
 				glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, GL_ZERO);
 				break;


### PR DESCRIPTION
This at least renders the glowing somehow more correct (90%) in Wipeout Pulse .Also fixes the missing shadow in FF Crisis core
