### PR TITLE
Set default case with A as the fixed color for alpha blending

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -229,6 +229,11 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 						glstate.blendColor.set(blendColor);
 					}
 				}
+			} else {
+				// Default case : Let's go with A as the fixed color 
+				glBlendFuncA = GL_CONSTANT_COLOR;
+				const float blendColor[4] = {fixA.x, fixA.y, fixA.z, constantAlpha};
+				glstate.blendColor.set(blendColor);
 			}
 		}
 


### PR DESCRIPTION
It is not 100% correct however make the Naruto Ultimate Ninja Impact in-game looks a lot better though shading may be missing in some cases.

Fixes the top left corner black box in-game mentioned in  Issue #2304 

Please merge only when constant alpha commit merged.
