### PR TITLE
Support pinning paths in the game browser

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -131,6 +131,12 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		}
 	}
 
+	auto pinnedPaths = iniFile.GetOrCreateSection("PinnedPaths")->ToMap();
+	vPinnedPaths.clear();
+	for (auto it = pinnedPaths.begin(), end = pinnedPaths.end(); it != end; ++it) {
+		vPinnedPaths.push_back(it->second);
+	}
+
 	IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");
 #ifdef IOS
 	cpu->Get("Jit", &bJit, iosCanUseJit);
@@ -462,6 +468,14 @@ void Config::Save() {
 			} else {
 				recent->Delete(keyName); // delete the nonexisting FileName
 			}
+		}
+
+		IniFile::Section *pinnedPaths = iniFile.GetOrCreateSection("PinnedPaths");
+		pinnedPaths->Clear();
+		for (size_t i = 0; i < vPinnedPaths.size(); ++i) {
+			char keyName[64];
+			snprintf(keyName, sizeof(keyName), "Path%d", i);
+			pinnedPaths->Set(keyName, vPinnedPaths[i]);
 		}
 
 		IniFile::Section *cpu = iniFile.GetOrCreateSection("CPU");

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -74,6 +74,7 @@ public:
 	bool bAutoSaveSymbolMap;
 	std::string sReportHost;
 	std::vector<std::string> recentIsos;
+	std::vector<std::string> vPinnedPaths;
 	std::string sLanguageIni;
 
 

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -296,8 +296,12 @@
     <ClCompile Include="Common\TextureDecoderNEON.cpp">
       <Filter>Common</Filter>
     </ClCompile>
-    <ClCompile Include="GLES\VertexDecoderX86.cpp" />
-    <ClCompile Include="GLES\VertexDecoderArm.cpp" />
+    <ClCompile Include="GLES\VertexDecoderArm.cpp">
+      <Filter>GLES</Filter>
+    </ClCompile>
+    <ClCompile Include="GLES\VertexDecoderX86.cpp">
+      <Filter>GLES</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="CMakeLists.txt" />

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -54,11 +54,13 @@ void GameScreen::CreateViews() {
 	leftColumn->Add(new Choice(d->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameScreen::OnSwitchBack);
 	if (info) {
 		texvGameIcon_ = leftColumn->Add(new TextureView(0, IS_DEFAULT, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
-		tvTitle_ = leftColumn->Add(new TextView(info->title, ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 200, NONE, NONE)));
-		tvGameSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 250, NONE, NONE)));
-		tvSaveDataSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 290, NONE, NONE)));
-		tvInstallDataSize_ = leftColumn->Add(new TextView("", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 330, NONE, NONE)));
-		tvRegion_ = leftColumn->Add(new TextView("", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 370, NONE, NONE)));
+		tvTitle_ = leftColumn->Add(new TextView(info->title, ALIGN_LEFT, false, new AnchorLayoutParams(10, 200, NONE, NONE)));
+		// This one doesn't need to be updated.
+		leftColumn->Add(new TextView(gamePath_, ALIGN_LEFT, true, new AnchorLayoutParams(10, 250, NONE, NONE)));
+		tvGameSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, true, new AnchorLayoutParams(10, 290, NONE, NONE)));
+		tvSaveDataSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, true, new AnchorLayoutParams(10, 320, NONE, NONE)));
+		tvInstallDataSize_ = leftColumn->Add(new TextView("", ALIGN_LEFT, true, new AnchorLayoutParams(10, 350, NONE, NONE)));
+		tvRegion_ = leftColumn->Add(new TextView("", ALIGN_LEFT, true, new AnchorLayoutParams(10, 380, NONE, NONE)));
 	}
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -472,8 +472,14 @@ void GameBrowser::Refresh() {
 		std::vector<FileInfo> fileInfo;
 		path_.GetListing(fileInfo, "iso:cso:pbp:elf:prx:");
 		for (size_t i = 0; i < fileInfo.size(); i++) {
-			if (fileInfo[i].isDirectory && (path_.GetPath().size() < 4 || !File::Exists(path_.GetPath() + fileInfo[i].name + "/EBOOT.PBP"))) {
-				// Check if eboot directory
+			bool isGame = !fileInfo[i].isDirectory;
+			// Check if eboot directory
+			if (!isGame && path_.GetPath().size() >= 4 && File::Exists(path_.GetPath() + fileInfo[i].name + "/EBOOT.PBP"))
+				isGame = true;
+			else if (!isGame && File::Exists(path_.GetPath() + fileInfo[i].name + "/PSP_GAME/SYSDIR"))
+				isGame = true;
+
+			if (!isGame) {
 				if (allowBrowsing_) {
 					dirButtons.push_back(new DirButton(fileInfo[i].name, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)));
 				}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -534,7 +534,7 @@ void GameBrowser::Refresh() {
 	if (allowBrowsing_) {
 		std::string caption = IsCurrentPathPinned() ? "-" : "+";
 		if (!*gridStyle_) {
-			caption = IsCurrentPathPinned() ? "Unpin" : "Pin";
+			caption = IsCurrentPathPinned() ? m->T("UnpinPath", "Unpin") : m->T("PinPath", "Pin");
 		}
 		gameList_->Add(new UI::Button(caption, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
 			OnClick.Handle(this, &GameBrowser::PinToggleClick);

--- a/headless/Headless.vcxproj
+++ b/headless/Headless.vcxproj
@@ -202,6 +202,7 @@
     <ClCompile Include="WindowsHeadlessHostDx9.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\test.py" />
     <None Include="headless.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/headless/Headless.vcxproj.filters
+++ b/headless/Headless.vcxproj.filters
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="headless.txt" />
+    <None Include="..\test.py" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StubHost.h" />


### PR DESCRIPTION
This is an alternate idea for the same basic functionality of #4390.  I think it's cleaner UI and isn't in the way as much, but is still useful.

It adds a "+" button at the end of directories.  When clicked, the path is now "pinned" and the button changes to "-" (in listing, this is shows as "Pin" and "Unpin".)

When in other directories, these now show up at the top.  It might be ideal to show a pin icon or something...

Also, makes it so you can start extracted isos by browsing, and small tweaks to the game detail screen.

-[Unknown]
