### PR TITLE
Load savedata images dynamically, cleanup oneshot file reads

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -272,8 +272,9 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 	for (int i = 0; i < param.GetFilenameCount(); i++)
 	{
 		int textureColor = 0xFFFFFFFF;
+		auto fileInfo = param.GetFileInfo(i);
 
-		if (param.GetFileInfo(i).size == 0 && param.GetFileInfo(i).textureData == 0) 
+		if (fileInfo.size == 0 && fileInfo.texture != NULL)
 			textureColor = 0xFF777777;
 
 		// Calc save image position on screen
@@ -300,13 +301,12 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 
 		int tw = 256;
 		int th = 256;
-		if (param.GetFileInfo(i).textureData != 0) {
-			tw = param.GetFileInfo(i).textureWidth;
-			th = param.GetFileInfo(i).textureHeight;
-			PPGeSetTexture(param.GetFileInfo(i).textureData, param.GetFileInfo(i).textureWidth, param.GetFileInfo(i).textureHeight);
+		if (fileInfo.texture != NULL) {
+			fileInfo.texture->SetTexture();
+			tw = fileInfo.texture->Width();
+			th = fileInfo.texture->Height();
 			PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
-		} else
-			PPGeDisableTexture();
+		}
 		PPGeSetDefaultTexture();
 		displayCount++;
 	}
@@ -322,8 +322,9 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 void PSPSaveDialog::DisplaySaveIcon()
 {
 	int textureColor = CalcFadedColor(0xFFFFFFFF);
+	auto curSave = param.GetFileInfo(currentSelectedSave);
 
-	if (param.GetFileInfo(currentSelectedSave).size == 0)
+	if (curSave.size == 0)
 		textureColor = CalcFadedColor(0xFF777777);
 
 	// Calc save image position on screen
@@ -334,14 +335,15 @@ void PSPSaveDialog::DisplaySaveIcon()
 
 	int tw = 256;
 	int th = 256;
-	if (param.GetFileInfo(currentSelectedSave).textureData != 0) {
-		tw = param.GetFileInfo(currentSelectedSave).textureWidth;
-		th = param.GetFileInfo(currentSelectedSave).textureHeight;
-		PPGeSetTexture(param.GetFileInfo(currentSelectedSave).textureData, param.GetFileInfo(currentSelectedSave).textureWidth, param.GetFileInfo(currentSelectedSave).textureHeight);
-	} else
+	if (curSave.texture != NULL) {
+		curSave.texture->SetTexture();
+		tw = curSave.texture->Width();
+		th = curSave.texture->Height();
+	} else {
 		PPGeDisableTexture();
-	PPGeDrawImage(x, y, w, h, 0, 0 ,1 ,1 ,tw, th, textureColor);
-	if (param.GetFileInfo(currentSelectedSave).textureData != 0)
+	}
+	PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
+	if (curSave.texture != NULL)
 		PPGeSetDefaultTexture();
 }
 

--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -37,6 +37,10 @@ public:
 	bool ReadSFO(const u8 *paramsfo, size_t size);
 	bool WriteSFO(u8 **paramsfo, size_t *size);
 
+	bool ReadSFO(const std::vector<u8> &paramsfo) {
+		return ReadSFO(&paramsfo[0], paramsfo.size());
+	}
+
 	int GetDataOffset(const u8 *paramsfo, std::string dataName);
 
 private:

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -517,7 +517,7 @@ size_t MetaFileSystem::SeekFile(u32 handle, s32 position, FileMove type)
 		return 0;
 }
 
-u32 MetaFileSystem::ReadEntireFile(const std::string &filename, std::string &data) {
+u32 MetaFileSystem::ReadEntireFile(const std::string &filename, std::vector<u8> &data) {
 	int error = 0;
 	u32 handle = pspFileSystem.OpenWithError(error, filename, FILEACCESS_READ);
 	if (handle == 0)

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -517,6 +517,23 @@ size_t MetaFileSystem::SeekFile(u32 handle, s32 position, FileMove type)
 		return 0;
 }
 
+u32 MetaFileSystem::ReadEntireFile(const std::string &filename, std::string &data) {
+	int error = 0;
+	u32 handle = pspFileSystem.OpenWithError(error, filename, FILEACCESS_READ);
+	if (handle == 0)
+		return error;
+
+	size_t dataSize = (size_t)pspFileSystem.GetFileInfo(filename).size;
+	data.resize(dataSize);
+
+	size_t result = pspFileSystem.ReadFile(handle, (u8 *)&data[0], dataSize);
+	pspFileSystem.CloseFile(handle);
+
+	if (result != dataSize)
+		return SCE_KERNEL_ERROR_ERROR;
+	return 0;
+}
+
 void MetaFileSystem::DoState(PointerWrap &p)
 {
 	lock_guard guard(lock);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -106,7 +106,7 @@ public:
 	// TODO: void IoCtl(...)
 
 	// Convenience helper - returns < 0 on failure.
-	u32 ReadEntireFile(const std::string &filename, std::string &data);
+	u32 ReadEntireFile(const std::string &filename, std::vector<u8> &data);
 
 	void SetStartingDirectory(const std::string &dir) {
 		lock_guard guard(lock);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -105,6 +105,9 @@ public:
 
 	// TODO: void IoCtl(...)
 
+	// Convenience helper - returns < 0 on failure.
+	u32 ReadEntireFile(const std::string &filename, std::string &data);
+
 	void SetStartingDirectory(const std::string &dir) {
 		lock_guard guard(lock);
 		startingDirectory = dir;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -488,7 +488,7 @@ namespace MIPSAnalyst {
 
 			// Yay, found a function.
 			Function &f = *(iter->second);
-			if (f.hash = mf->hash && f.size == mf->size) {
+			if (f.hash == mf->hash && f.size == mf->size) {
 				strncpy(f.name, mf->name, sizeof(mf->name) - 1);
 
 				const char *existingLabel = symbolMap.GetLabelName(f.start);

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -81,11 +81,9 @@ void InitMemoryForGameISO(std::string fileToStart) {
 
 	if (fileInfo.exists)
 	{
-		u8 *paramsfo = new u8[(size_t)fileInfo.size];
-		u32 fd = pspFileSystem.OpenFile(sfoPath, FILEACCESS_READ);
-		pspFileSystem.ReadFile(fd, paramsfo, fileInfo.size);
-		pspFileSystem.CloseFile(fd);
-		if (g_paramSFO.ReadSFO(paramsfo, (size_t)fileInfo.size))
+		std::vector<u8> paramsfo;
+		pspFileSystem.ReadEntireFile(sfoPath, paramsfo);
+		if (g_paramSFO.ReadSFO(paramsfo))
 		{
 			gameID = g_paramSFO.GetValueString("DISC_ID");
 
@@ -100,7 +98,6 @@ void InitMemoryForGameISO(std::string fileToStart) {
 			}
 			DEBUG_LOG(LOADER, "HDRemaster mode is %s", g_RemasterMode? "true": "false");
 		}
-		delete [] paramsfo;
 	}
 }
 
@@ -112,18 +109,15 @@ bool Load_PSP_ISO(const char *filename, std::string *error_string)
 	PSPFileInfo fileInfo = pspFileSystem.GetFileInfo(sfoPath.c_str());
 	if (fileInfo.exists)
 	{
-		u8 *paramsfo = new u8[(size_t)fileInfo.size];
-		u32 fd = pspFileSystem.OpenFile(sfoPath, FILEACCESS_READ);
-		pspFileSystem.ReadFile(fd, paramsfo, fileInfo.size);
-		pspFileSystem.CloseFile(fd);
-		if (g_paramSFO.ReadSFO(paramsfo, (size_t)fileInfo.size))
+		std::vector<u8> paramsfo;
+		pspFileSystem.ReadEntireFile(sfoPath, paramsfo);
+		if (g_paramSFO.ReadSFO(paramsfo))
 		{
 			char title[1024];
 			sprintf(title, "%s : %s", g_paramSFO.GetValueString("DISC_ID").c_str(), g_paramSFO.GetValueString("TITLE").c_str());
 			INFO_LOG(LOADER, "%s", title);
 			host->SetWindowTitle(title);
 		}
-		delete [] paramsfo;
 	}
 
 

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -158,7 +158,7 @@ bool GameManager::InstallGame(std::string zipfile, bool deleteAfter) {
 				if (zippedName[i] == '/') {
 					slashCount++;
 					slashLocation = lastSlashLocation;
-					lastSlashLocation = i;
+					lastSlashLocation = (int)i;
 				}
 			}
 			if (slashCount >= 1 && (!isPSP || slashLocation < stripChars + 1)) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -830,7 +830,7 @@ bool PPGeImage::Load() {
 	if (filename_.empty()) {
 		success = pngLoadPtr(Memory::GetPointer(png_), size_, &width_, &height_, &textureData, false);
 	} else {
-		std::string pngData;
+		std::vector<u8> pngData;
 		if (pspFileSystem.ReadEntireFile(filename_, pngData) < 0) {
 			WARN_LOG(SCEGE, "Bad PPGeImage - cannot load file");
 			return false;

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -103,6 +103,48 @@ void PPGeDrawImage(int atlasImage, float x, float y, int align, u32 color = 0xFF
 void PPGeDrawImage(int atlasImage, float x, float y, float w, float h, int align, u32 color = 0xFFFFFFFF);
 void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color);
 
+class PPGeImage {
+public:
+	PPGeImage(const std::string &pspFilename);
+	PPGeImage(u32 pngPointer, size_t pngSize);
+	~PPGeImage();
+
+	void SetTexture();
+
+	// Does not normally need to be called (except to force preloading.)
+	bool Load();
+	void Free();
+
+	void DoState(PointerWrap &p);
+
+	// Do not use, only for savestate upgrading.
+	void CompatLoad(u32 texture, int width, int height);
+
+	int Width() {
+		return width_;
+	}
+
+	int Height() {
+		return height_;
+	}
+
+private:
+	static void Decimate();
+	static std::vector<PPGeImage *> loadedTextures_;
+
+	std::string filename_;
+
+	// Only valid if filename_.empty().
+	u32 png_;
+	size_t size_;
+
+	u32 texture_;
+	int width_;
+	int height_;
+
+	int lastFrame_;
+};
+
 void PPGeDrawRect(float x1, float y1, float x2, float y2, u32 color);
 
 void PPGeSetDefaultTexture();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -571,7 +571,7 @@ void DrawDownloadsOverlay(UIContext &ctx) {
 
 	ctx.Begin();
 	int h = 5;
-	for (int i = 0; i < progress.size(); i++) {
+	for (size_t i = 0; i < progress.size(); i++) {
 		float barWidth = 10 + (dp_xres - 10) * progress[i];
 		Bounds bounds(0, h * i, barWidth, h);
 		UI::Drawable solid(colors[i & 3]);


### PR DESCRIPTION
This manages the textures for savedata icons better, so that we shouldn't run out of memory even if there are a bunch of savedata items.

Also adds a simpler interface to read a file to a std::vector, and makes several things use it.  I'm pretty sure I saw at least two memory leaks along the way (font loading and an sfo load somewhere.)

-[Unknown]
