### PR TITLE
Save/Load dialogs: Allow held directional buttons to scroll up and down the list repeatedly.

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -128,6 +128,25 @@ bool PSPDialog::IsButtonPressed(int checkButton)
 	return !isFading && !(lastButtons & checkButton) && (buttons & checkButton);
 }
 
+bool PSPDialog::IsButtonHeld(int checkButton, int &framesHeld)
+{
+	bool btnWasHeldLastFrame = (lastButtons & checkButton) && (buttons & checkButton);
+	if (!isFading && btnWasHeldLastFrame) {
+		framesHeld++;
+	}
+	else {
+		framesHeld = 0;
+		return false;
+	}
+
+	// It's considered held for dialog purposes after 30 frames (~0.5 seconds).
+	// Seems to give the best responsiveness. Maybe this should be configurable?
+	if (framesHeld >= 30 && ((framesHeld % 10) == 0))
+		return true;
+
+	return false;
+}
+
 void PSPDialog::DisplayButtons(int flags)
 {
 	I18NCategory *d = GetI18NCategory("Dialog");

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -79,6 +79,7 @@ public:
 	void EndDraw();
 protected:
 	bool IsButtonPressed(int checkButton);
+	bool IsButtonHeld(int checkButton, int &framesHeld);
 	void DisplayButtons(int flags);
 
 	void StartFade(bool fadeIn_);

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -269,6 +269,9 @@ void PSPSaveDialog::DisplayBanner(int which)
 void PSPSaveDialog::DisplaySaveList(bool canMove)
 {
 	int displayCount = 0;
+	static int upFramesHeld = 0;
+	static int downFramesHeld = 0;
+
 	for (int i = 0; i < param.GetFilenameCount(); i++)
 	{
 		int textureColor = 0xFFFFFFFF;
@@ -312,9 +315,10 @@ void PSPSaveDialog::DisplaySaveList(bool canMove)
 	}
 
 	if (canMove) {
-		if (IsButtonPressed(CTRL_UP) && currentSelectedSave > 0)
+		if ( (IsButtonPressed(CTRL_UP) || IsButtonHeld(CTRL_UP, upFramesHeld)) && currentSelectedSave > 0)
 			currentSelectedSave--;
-		else if (IsButtonPressed(CTRL_DOWN) && currentSelectedSave < (param.GetFilenameCount()-1))
+
+		else if ( (IsButtonPressed(CTRL_DOWN) || IsButtonHeld(CTRL_DOWN, downFramesHeld)) && currentSelectedSave < (param.GetFilenameCount() - 1))
 			currentSelectedSave++;
 	}
 }


### PR DESCRIPTION
The current behaviour does not allow for holding up/down to repeatedly scroll items in save/load lists, which can result in frustration or tired fingers. For the sake of usability, this request intends on letting the list scroll after holding a directional button for ~0.5 seconds (30 frames), at a reasonable rate.

Thanks to @hrydgard for his tip on using modulus to slow down the scrolling (https://github.com/hrydgard/ppsspp/issues/4757).
