### PR TITLE
Return much more correct values for module info

### DIFF
--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -116,6 +116,10 @@ public:
 	{
 		return segmentVAddr[segment];
 	}
+	u32 GetSegmentDataSize(int segment)
+	{
+		return segments[segment].p_filesz;
+	}
 
 	bool DidRelocate() {
 		return bRelocate;


### PR DESCRIPTION
sceKernelQueryModuleInfo() was just completely wrong before, it didn't even have size so everything was off by 4.

The numbers still aren't exactly right but at least they are not hairball wrong.  Of my games, few use it, and they still work either way, but this may help God Eater 2 maybe....

-[Unknown]
