### PR TITLE
Have .zip files detected in curent directory browser

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -640,7 +640,7 @@ void MainScreen::update(InputState &input) {
 
 UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
 #if defined(USING_QT_UI)
-	QString fileName = QFileDialog::getOpenFileName(NULL, "Load ROM", g_Config.currentDirectory.c_str(), "PSP ROMs (*.iso *.cso *.pbp *.elf)");
+	QString fileName = QFileDialog::getOpenFileName(NULL, "Load ROM", g_Config.currentDirectory.c_str(), "PSP ROMs (*.iso *.cso *.pbp *.elf *.zip)");
 	if (QFile::exists(fileName)) {
 		QDir newPath;
 		g_Config.currentDirectory = newPath.filePath(fileName).toStdString();


### PR DESCRIPTION
Unfortunately it only shows empty blocks as seen here:
![screen00000](https://f.cloud.github.com/assets/1138235/1703634/1d20cb0c-60b9-11e3-80a6-ba1132d53947.jpg)
 It should show at least the file name if not a picture. I need help with this. 
