### PR TITLE
Update buildfix for Clang 3.4

### DIFF
--- a/ext/disarm.cpp
+++ b/ext/disarm.cpp
@@ -60,6 +60,12 @@
  *                    (Thanks to Vincent Zweije for reporting this.)
  */
 
+#ifdef clang-3.4
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare" //used to avoid warning, force compiler to accept it.
+#endif clang-3.4
+
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1047,3 +1053,8 @@ void ArmDis(unsigned int addr, unsigned int w, char *output, bool includeWord) {
 		output++;
 	}
 }
+
+#ifdef clang-3.4
+#pragma GCC diagnostic pop
+#endif clang-3.4
+


### PR DESCRIPTION
Adding the wrapper to avoid warning "-Wtautological-compare":
# ifdef clang-3.4
# pragma GCC diagnostic push
# pragma GCC diagnostic ignored "-Wtautological-compare" //used to avoid warning, force compiler to accept it.
# endif clang-3.4

$Code_Content_Here
# ifdef clang-3.4
# pragma GCC diagnostic pop
# endif clang-3.4

Tested on both GCC and Clang compilers and none of these compilers have this problem.
