### PR TITLE
Update buildfix for Clang 3.4

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -516,7 +516,7 @@ void __LoadInternalFonts() {
 		if (info.exists) {
 			INFO_LOG(SCEFONT, "Loading font %s (%i bytes)", fontFilename.c_str(), (int)info.size);
 			std::vector<u8> buffer;
-			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) < 0) {
+			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) <= 0) {
 				ERROR_LOG(SCEFONT, "Failed opening font");
 				continue;
 			} 


### PR DESCRIPTION
Fixes warning issue, " warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]" on line 549.
