### PR TITLE
Update buildfix for Clang 3.4

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -977,7 +977,7 @@ u32 npdrmLseek(FileNode *f, s32 where, FileMove whence)
 		newPos = f->pgdInfo->data_size+where;
 	}
 
-	if(newPos<0 || newPos>f->pgdInfo->data_size){
+	if(newPos<=0 || newPos>f->pgdInfo->data_size){
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Update for fixing issue "warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]" on line 980
