### PR TITLE
Win32 UI: Enable sound properly when Enable Sound is chosen.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1437,7 +1437,7 @@ namespace MainWindow
 
 				case ID_EMULATION_SOUND:
 					g_Config.bEnableSound = !g_Config.bEnableSound;
-					if(g_Config.bEnableSound) {
+					if (g_Config.bEnableSound) {
 						if (PSP_IsInited() && !IsAudioInitialised())
 							Audio_Init();
 					}

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1437,8 +1437,8 @@ namespace MainWindow
 
 				case ID_EMULATION_SOUND:
 					g_Config.bEnableSound = !g_Config.bEnableSound;
-					if(!g_Config.bEnableSound) {
-						if(!IsAudioInitialised())
+					if(g_Config.bEnableSound) {
+						if (PSP_IsInited() && !IsAudioInitialised())
 							Audio_Init();
 					}
 					break;


### PR DESCRIPTION
Currently it does nothing to enable sound until the user enters More Settings / NewUI. This basically mimics the behaviour of the GameSettingsScreen Back button handling of audio.
