### PR TITLE
Detect bad fonts' ascenders and workaround

### DIFF
--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -516,7 +516,7 @@ bool PGF::GetCharGlyph(int charCode, int glyphType, Glyph &glyph) {
 	return true;
 }
 
-void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType, bool packagedFont) {
+void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType) {
 	Glyph glyph;
 	if (!GetCharGlyph(charCode, glyphType, glyph)) {
 		// No Glyph available for this charCode, try to use the alternate char.
@@ -571,10 +571,6 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 
 			int pixelX = x + xx;
 			int pixelY = y + yy;
-
-			// Apply offset by 1px for our packaged PSP fonts
-			if (packagedFont) 
-				pixelX += 1;
 
 			if (pixelX >= clipX && pixelX < clipX + clipWidth && pixelY >= clipY && pixelY < clipY + clipHeight) {
 				// 4-bit color value

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -30,7 +30,7 @@
 
 // These fonts, created by ttf2pgf, don't have complete glyph info and need to be identified.
 static bool isJPCSPFont(const char *fontName) {
-	return !strcmp(fontName, "Liberation") || !strcmp(fontName, "Sazanami") || !strcmp(fontName, "UnDotum");
+	return !strcmp(fontName, "Liberation Sans") || !strcmp(fontName, "Liberation Serif") || !strcmp(fontName, "Sazanami") || !strcmp(fontName, "UnDotum") || !strcmp(fontName, "Microsoft YaHei");
 }
 
 // Gets a number of bits from an offset.
@@ -180,6 +180,8 @@ void PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 	INFO_LOG(SCEFONT, "Reading %d bytes of PGF header", (int)sizeof(header));
 	memcpy(&header, ptr, sizeof(header));
 	ptr += sizeof(header);
+
+	fileName = header.fontName;
 
 	if (header.revision == 3) {
 		memcpy(&rev3extra, ptr, sizeof(rev3extra));

--- a/Core/Font/PGF.h
+++ b/Core/Font/PGF.h
@@ -266,7 +266,7 @@ public:
 
 	bool GetCharInfo(int charCode, PGFCharInfo *ci, int altCharCode);
 	void GetFontInfo(PGFFontInfo *fi);
-	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType, bool packagedFont);
+	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType);
 
 	void DoState(PointerWrap &p);
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -104,7 +104,6 @@ class LoadedFont;
 class FontLib;
 class Font;
 int GetInternalFontIndex(Font *font);
-bool packagedFont;
 
 // These should not need to be state saved.
 static std::vector<Font *> internalFonts;
@@ -519,11 +518,6 @@ void __LoadInternalFonts() {
 			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) < 0) {
 				ERROR_LOG(SCEFONT, "Failed opening font");
 				continue;
-			} 
-			// Our provided font of jpn0.pgf has size 4367080 bytes 
-			// This is an ugly hack to workaround incorrect metrics in it.
-			if (std::string(entry.fileName) == "jpn0.pgf" && (int)info.size == 4367080) {
-				packagedFont = true;
 			}
 			
 			internalFonts.push_back(new Font(buffer, entry));
@@ -885,7 +879,7 @@ int sceFontGetCharGlyphImage(u32 fontHandle, u32 charCode, u32 glyphImagePtr) {
 	DEBUG_LOG(SCEFONT, "sceFontGetCharGlyphImage(%x, %x, %x)", fontHandle, charCode, glyphImagePtr);
 	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
-	font->GetPGF()->DrawCharacter(glyph, 0, 0, 8192, 8192, charCode, altCharCode, FONT_PGF_CHARGLYPH, packagedFont);
+	font->GetPGF()->DrawCharacter(glyph, 0, 0, 8192, 8192, charCode, altCharCode, FONT_PGF_CHARGLYPH);
 	return 0;
 }
 
@@ -903,7 +897,7 @@ int sceFontGetCharGlyphImage_Clip(u32 fontHandle, u32 charCode, u32 glyphImagePt
 	INFO_LOG(SCEFONT, "sceFontGetCharGlyphImage_Clip(%08x, %i, %08x, %i, %i, %i, %i)", fontHandle, charCode, glyphImagePtr, clipXPos, clipYPos, clipWidth, clipHeight);
 	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
-	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipXPos + clipWidth, clipYPos + clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH, packagedFont);
+	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipXPos + clipWidth, clipYPos + clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #4765 with the fonts that come with PPSSPP.

There was already code to do this, `isJPCSPFont()`, it just wasn't firing properly.

Since this also corrects the horizontal adjust, it broke FF3 again, due to the "packedFont" hack, so I removed it.  The values should be right now (and I believe they're also per character, not a global 1.)  So, fixes #4404.

-[Unknown]
