### PR TITLE
Use additional memory map mirrors for 32-bit

### DIFF
--- a/Common/MemArena.cpp
+++ b/Common/MemArena.cpp
@@ -268,6 +268,8 @@ static bool Memory_TryBase(u8 *base, const MemoryView *views, int num_views, u32
 	for (i = 0; i < num_views; i++)
 	{
 		const MemoryView &view = views[i];
+		if (view.size == 0)
+			continue;
 		SKIP(flags, view.flags);
 		if (view.flags & MV_MIRROR_PREVIOUS) {
 			position = last_position;
@@ -308,6 +310,8 @@ bail:
 	// Argh! ERROR! Free what we grabbed so far so we can try again.
 	for (int j = 0; j <= i; j++)
 	{
+		if (views[i].size == 0)
+			continue;
 		SKIP(flags, views[i].flags);
 		if (views[j].out_ptr_low && *views[j].out_ptr_low)
 		{
@@ -337,6 +341,8 @@ u8 *MemoryMap_Setup(const MemoryView *views, int num_views, u32 flags, MemArena 
 
 	for (int i = 0; i < num_views; i++)
 	{
+		if (views[i].size == 0)
+			continue;
 		SKIP(flags, views[i].flags);
 		if ((views[i].flags & MV_MIRROR_PREVIOUS) == 0)
 			total_mem += roundup(views[i].size);
@@ -403,6 +409,8 @@ void MemoryMap_Shutdown(const MemoryView *views, int num_views, u32 flags, MemAr
 {
 	for (int i = 0; i < num_views; i++)
 	{
+		if (views[i].size == 0)
+			continue;
 		SKIP(flags, views[i].flags);
 		if (views[i].out_ptr_low && *views[i].out_ptr_low)
 			arena->ReleaseView(*views[i].out_ptr_low, views[i].size);

--- a/Common/MemArena.h
+++ b/Common/MemArena.h
@@ -60,6 +60,8 @@ enum {
 	// MV_FAKE_VMEM = 2,
 	// MV_WII_ONLY = 4,
 	MV_IS_PRIMARY_RAM = 0x100,
+	MV_IS_EXTRA1_RAM = 0x200,
+	MV_IS_EXTRA2_RAM = 0x400,
 };
 
 struct MemoryView

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -60,7 +60,10 @@ extern u8 *base;
 // These are guaranteed to point to "low memory" addresses (sub-32-bit).
 // 64-bit: Pointers to low-mem (sub-0x10000000) mirror
 // 32-bit: Same as the corresponding physical/virtual pointers.
+// Broken into three chunks to workaround 32-bit mmap() limits.
 extern u8 *m_pRAM;
+extern u8 *m_pRAM2;
+extern u8 *m_pRAM3;
 extern u8 *m_pScratchPad;
 extern u8 *m_pVRAM;
 

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -40,7 +40,7 @@ namespace Memory
 u8 *GetPointer(const u32 address)
 {
 	if ((address & 0x3E000000) == 0x08000000) {
-		return m_pRAM + (address & RAM_NORMAL_MASK);
+		return GetPointerUnchecked(address);
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		return m_pVRAM + (address & VRAM_MASK);
@@ -49,7 +49,7 @@ u8 *GetPointer(const u32 address)
 		return m_pScratchPad + (address & SCRATCHPAD_MASK);
 	}
 	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
-		return m_pRAM + (address & g_MemoryMask);
+		return GetPointerUnchecked(address);
 	}
 	else {
 		ERROR_LOG(MEMMAP, "Unknown GetPointer %08x PC %08x LR %08x", address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
@@ -75,7 +75,7 @@ inline void ReadFromHardware(T &var, const u32 address)
 	// Could just do a base-relative read, too.... TODO
 
 	if ((address & 0x3E000000) == 0x08000000) {
-		var = *((const T*)&m_pRAM[address & RAM_NORMAL_MASK]);
+		var = *((const T*)GetPointerUnchecked(address));
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		var = *((const T*)&m_pVRAM[address & VRAM_MASK]);
@@ -85,7 +85,7 @@ inline void ReadFromHardware(T &var, const u32 address)
 		var = *((const T*)&m_pScratchPad[address & SCRATCHPAD_MASK]);
 	}
 	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
-		var = *((const T*)&m_pRAM[address & g_MemoryMask]);
+		var = *((const T*)GetPointerUnchecked(address));
 	}
 	else
 	{
@@ -113,7 +113,7 @@ inline void WriteToHardware(u32 address, const T data)
 	// Could just do a base-relative write, too.... TODO
 
 	if ((address & 0x3E000000) == 0x08000000) {
-		*(T*)&m_pRAM[address & RAM_NORMAL_MASK] = data;
+		*(T*)GetPointerUnchecked(address) = data;
 	}
 	else if ((address & 0x3F800000) == 0x04000000) {
 		*(T*)&m_pVRAM[address & VRAM_MASK] = data;
@@ -122,7 +122,7 @@ inline void WriteToHardware(u32 address, const T data)
 		*(T*)&m_pScratchPad[address & SCRATCHPAD_MASK] = data;
 	}
 	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
-		*(T*)&m_pRAM[address & g_MemoryMask] = data;
+		*(T*)GetPointerUnchecked(address) = data;
 	}
 	else
 	{


### PR DESCRIPTION
Well, use them always for simplicity, but this works around (apparent?) 32-bit limitations on mmap() size for Android and Linux.

I'm not sure if we actually want to do this, since I don't know _why_ this happens.  But, creating separate maps does work around the problem.  I went with 31MB because I didn't know if 32MB would work everywhere (40MB even does not work for @xsacha.)  This is a good enough way for discussion anyhow...

Not tested on iOS but I suppose it'd fix it there too.

The only thing I could find was FCSE, which allows 128 32MB blocks for fast thread switching or something, but it seems like it's not in modern usage.  And it doesn't match the 40MB limit anyway.

-[Unknown]
