### PR TITLE
ExactMatch : should be applied to all rendering mode

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -196,10 +196,6 @@ inline void AttachFramebufferInvalid(T &entry, VirtualFramebuffer *framebuffer) 
 inline void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch) {
 	// If they match exactly, it's non-CLUT and from the top left.
 	if (exactMatch) {
-		// Apply to non-buffered and buffered mode only.
-		if (!(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE))
-			return;
-
 		DEBUG_LOG(G3D, "Render to texture detected at %08x!", address);
 		if (!entry->framebuffer || entry->invalidHint == -1) {
 			if (entry->format != framebuffer->format) {


### PR DESCRIPTION
In exactmatch mode , framebuffer should be applied to all rendering mode. Confirmed by God Eater Burst .Pretty sure it is correct

-Before.
![screen00139](https://f.cloud.github.com/assets/3000282/1724966/f46968b0-6278-11e3-9a3e-0d3ec7c0aeb5.jpg)

-After
![screen00140](https://f.cloud.github.com/assets/3000282/1724967/f7ea8afa-6278-11e3-8711-bfa48765e59c.jpg)
