### PR TITLE
Render correct fog in 3rd birthday and menu transparency in Kurohyou 2

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1465,7 +1465,7 @@ void FramebufferManager::DecimateFBOs() {
 		VirtualFramebuffer *vfb = vfbs_[i];
 		int age = frameLastFramebufUsed - std::max(vfb->last_frame_render, vfb->last_frame_used);
 
-		if (updateVram && age == 0 && !vfb->memoryUpdated && vfb == displayFramebuf_) 
+		if (updateVram && age == 0 && !vfb->memoryUpdated) 
 				ReadFramebufferToMemory(vfb);
 
 		if (vfb == displayFramebuf_ || vfb == prevDisplayFramebuf_ || vfb == prevPrevDisplayFramebuf_) {


### PR DESCRIPTION
I compared it with real PSP and should be 100% matching now .

![screen00136](https://f.cloud.github.com/assets/3000282/1725031/2c6ecbe6-627a-11e3-9ce0-6cf98dafaeac.jpg)
![screen00137](https://f.cloud.github.com/assets/3000282/1725032/2f9ed400-627a-11e3-8be9-3ebbd4c534c1.jpg)
![screen00138](https://f.cloud.github.com/assets/3000282/1725034/32b94c06-627a-11e3-8c1d-a451e2a3e847.jpg)
