### PR TITLE
Add an ini option to set the emulated PSP's firmware.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -327,6 +327,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
 	pspConfig->Get("PSPModel", &iPSPModel, PSP_MODEL_SLIM);
+	pspConfig->Get("PSPFirmwareVersion", &iFirmwareVersion, PSP_DEFAULT_FIRMWARE);
 #if !defined(_M_X64) && !defined(_WIN32) && !defined(__SYMBIAN32__)
 	// 32-bit mmap cannot map more than 32MB contiguous
 	iPSPModel = PSP_MODEL_FAT;
@@ -569,6 +570,7 @@ void Config::Save() {
 
 		IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
 		pspConfig->Set("PSPModel", iPSPModel);
+		pspConfig->Set("PSPFirmwareVersion", iFirmwareVersion);
 		pspConfig->Set("NickName", sNickName.c_str());
 		pspConfig->Set("proAdhocServer", proAdhocServer.c_str());
 		pspConfig->Set("MacAddress", localMacAddress.c_str());

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -29,6 +29,7 @@ extern const char *PPSSPP_GIT_VERSION;
 const int MAX_CONFIG_VOLUME = 8;
 const int PSP_MODEL_FAT = 0;
 const int PSP_MODEL_SLIM = 1;
+const int PSP_DEFAULT_FIRMWARE = 150;
 
 namespace http {
 	class Download;
@@ -239,6 +240,7 @@ public:
 	bool bWlanPowerSave;
 
 	int iPSPModel;
+	int iFirmwareVersion;
 	// TODO: Make this work with your platform, too!
 #if defined(_WIN32) && !defined(USING_QT_UI)
 	bool bBypassOSKWithKeyboard;

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -287,7 +287,7 @@ void sceKernelExitGameWithStatus()
 
 u32 sceKernelDevkitVersion()
 {
-	int firmwareVersion = 150;
+	int firmwareVersion = g_Config.iFirmwareVersion;
 	int major = firmwareVersion / 100;
 	int minor = (firmwareVersion / 10) % 10;
 	int revision = firmwareVersion % 10;


### PR DESCRIPTION
Some homebrew check for specific firmware versions, so it can't hurt to allow it to be changed, rather than simply hard-coding it to 1.5.
