### PR TITLE
Small fix to framebuffer sizing

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -687,12 +687,13 @@ void FramebufferManager::SetRenderFrameBuffer() {
 		VirtualFramebuffer *v = vfbs_[i];
 		if (MaskedEqual(v->fb_address, fb_address)) {
 			vfb = v;
-			// Update fb stride in case it changed
-			vfb->fb_stride = fb_stride;
-			if (v->width < drawing_width && v->height < drawing_height) {
+			// fb_stride changed , set it 
+			if (v->fb_stride != fb_stride) {
 				v->width = drawing_width;
 				v->height = drawing_height;
+				v->fb_stride = fb_stride;
 			}
+			// v->format changed, set it 
 			if (v->format != fmt) {
 				v->width = drawing_width;
 				v->height = drawing_height;


### PR DESCRIPTION
This try to fix the previously video flickering in Wildarm XF  Issue #4325  (It is tested without using savestate)

Meanwhile , i try to focus to test all those items that we may break .
1. TOPX title , town/worldmap and final credit .
2. Wildarm XF in-game battle
3. Midnight Club 3 in-game race battle
4. Kingdom Heart in-game , cutscenes and character shadow
5. FF crisis character shadow.
6. MSG peace maker in-game and cutscene
7. MotoStorm in-game
8. Summon Night 5 character shadow

Hoepfully no regression this time .
