### PR TITLE
Fix some date conversions in sceRtc

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -476,15 +476,15 @@ int sceRtcCheckValid(u32 datePtr)
 		{
 			return PSP_TIME_INVALID_DAY;
 		}
-		else if (pt.hour > 23)
+		else if (pt.hour < 0 || pt.hour > 23)
 		{
 			return PSP_TIME_INVALID_HOUR;
 		}
-		else if (pt.minute > 59)
+		else if (pt.minute < 0 || pt.minute > 59)
 		{
 			return PSP_TIME_INVALID_MINUTES;
 		}
-		else if (pt.second > 59)
+		else if (pt.second < 0 || pt.second > 59)
 		{
 			return PSP_TIME_INVALID_SECONDS;
 		}

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -775,7 +775,7 @@ int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
 		s64 srcTick = (s64)Memory::Read_U64(srcTickPtr);
-		srcTick += numHours*3600000000UL;
+		srcTick += numHours * 3600ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
 	DEBUG_LOG(SCERTC, "sceRtcTickAddMinutes(%d,%d,%d)", destTickPtr, srcTickPtr, numHours);
@@ -788,7 +788,7 @@ int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
 	{
 		s64 srcTick = (s64)Memory::Read_U64(srcTickPtr);
 
-		srcTick += numDays*86400000000UL;
+		srcTick += numDays * 86400ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
 	DEBUG_LOG(SCERTC, "sceRtcTickAddDays(%d,%d,%d)", destTickPtr, srcTickPtr, numDays);
@@ -801,7 +801,7 @@ int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
 	{
 		s64 srcTick = (s64)Memory::Read_U64(srcTickPtr);
 
-		srcTick += numWeeks*604800000000UL;
+		srcTick += numWeeks * 7ULL * 86400ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
 	DEBUG_LOG(SCERTC, "sceRtcTickAddWeeks(%d,%d,%d)", destTickPtr, srcTickPtr, numWeeks);

--- a/test.py
+++ b/test.py
@@ -337,7 +337,7 @@ def run_tests(test_list, args):
   if len(test_filenames):
     # TODO: Maybe --compare should detect --graphics?
     cmdline = [PPSSPP_EXE, '--compare', '--timeout=' + str(TIMEOUT), '@-']
-    cmdline.extend([i for i in args if i not in ['-g']])
+    cmdline.extend([i for i in args if i not in ['-g', '-m']])
 
     c = Command(cmdline, '\n'.join(test_filenames))
     c.run(TIMEOUT * len(test_filenames))
@@ -364,6 +364,8 @@ def main():
       tests = tests_good
     else:
       tests = tests_next + tests_good
+  elif '-m' in args:
+    tests = [i for i in tests_next + tests_good if i.startswith(tests[0])]
 
   run_tests(tests, args)
 


### PR DESCRIPTION
On Windows especially, years like 9998 are not really supported.  This adjusts things to fit in a range it can handle, and then just offset the ticks/years afterward.  This may fix things on other platforms too.

Also adjusts some things in sceRtcCheckValid() to be more correct, and fixes sceRtcTickAddYears() to not even write when the date is invalid (matching tests.)

This may help Prince of Persia, but I don't have it to test.  At least it does match tests.  There are more things wrong here, I'm guessing sceRtcTickAddMonths() probably doesn't update dest on invalid either, but have not even looked at it.

-[Unknown]
