### PR TITLE
Fix some issues with looping videos, and videos added in tiny chunks

### DIFF
--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -394,7 +394,7 @@ const HLEFunction sceNetInet[] = {
 	{0xcda85c99, WrapI_IUUU<sceNetInetRecv>, "sceNetInetRecv"},
 	{0xc91142e4, 0, "sceNetInetRecvfrom"},
 	{0xeece61d2, 0, "sceNetInetRecvmsg"},
-	{0x7aa671bc, WrapI_IUUU<sceNetInetRecv>, "sceNetInetSend"},
+	{0x7aa671bc, WrapI_IUUU<sceNetInetSend>, "sceNetInetSend"},
 	{0x05038fc7, 0, "sceNetInetSendto"},
 	{0x774e36f4, 0, "sceNetInetSendmsg"},
 	{0xfbabe411, WrapI_V<sceNetInetGetErrno>, "sceNetInetGetErrno"},

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -333,7 +333,7 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 			m_demux->demux(m_audioStream);
 		}
 #ifdef USE_FFMPEG
-		if (!m_pFormatCtx) {
+		if (!m_pFormatCtx && m_pdata->getQueueSize() >= 2048 * 6) {
 			m_pdata->get_front(m_mpegheader, sizeof(m_mpegheader));
 			int mpegoffset = bswap32(*(int*)(m_mpegheader + 8));
 			m_pdata->pop_front(0, mpegoffset);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -340,6 +340,9 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 			openContext();
 		}
 #endif // USE_FFMPEG
+
+		// We added data, so... not the end anymore?
+		m_isVideoEnd = false;
 	}
 	return size;
 }

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1548,6 +1548,8 @@ void GLES_GPU::DoBlockTransfer() {
 	// TODO: Notify all overlapping FBOs that they need to reload.
 
 	textureCache_.Invalidate(dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, GPU_INVALIDATE_HINT);
+	if (Memory::IsRAMAddress(srcBasePtr) && Memory::IsVRAMAddress(dstBasePtr))
+		framebufferManager_.UpdateFromMemory(dstBasePtr, (dstY + height) * dstStride * bpp, true);
 	
 	// A few games use this INSTEAD of actually drawing the video image to the screen, they just blast it to
 	// the backbuffer. Detect this and have the framebuffermanager draw the pixels.


### PR DESCRIPTION
This improves:
- Valkyrie Profile, which both no longer hangs and displays its videos now.
- Burnout Legends, which no longer has the video "stall" if you wait a little bit (possibly any games logging [that same error may be improved](http://report.ppsspp.org/logs/kind/178).)

I tested the usual suspects (especially Wipeout Pure) and none seemed to have problems.  May help other games hanging on video or displaying black instead of video.

-[Unknown]
