### PR TITLE
Switch to 64-bit hash, minor debugger stuff

### DIFF
--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -137,6 +137,9 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 
 	while (address < end && start <= address)
 	{
+		if (!PSP_IsInited())
+			return;
+
 		auto it = findDisassemblyEntry(entries,address,false);
 		if (it != entries.end())
 		{

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -20,6 +20,7 @@
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Core/HLE/HLE.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
@@ -41,6 +42,10 @@ void __DmacDoState(PointerWrap &p) {
 
 int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 	Memory::Memcpy(dst, Memory::GetPointer(src), size);
+#ifndef USING_GLES2
+	CBreakPoints::ExecMemCheck(src, false, size, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(dst, true, size, currentMIPS->pc);
+#endif
 
 	src &= ~0x40000000;
 	dst &= ~0x40000000;

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -19,15 +19,16 @@
 #include <list>
 #include <map>
 
-#include "HLE.h"
-#include "../MIPS/MIPS.h"
-#include "ChunkFile.h"
+#include "Core/HLE/HLE.h"
+#include "Core/MIPS/MIPS.h"
+#include "Common/ChunkFile.h"
 
-#include "sceKernel.h"
-#include "sceKernelThread.h"
-#include "sceKernelInterrupt.h"
-#include "sceKernelMemory.h"
-#include "sceKernelMutex.h"
+#include "Core/Debugger/Breakpoints.h"
+#include "Core/HLE/sceKernel.h"
+#include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/sceKernelInterrupt.h"
+#include "Core/HLE/sceKernelMemory.h"
+#include "Core/HLE/sceKernelMutex.h"
 #include "GPU/GPUCommon.h"
 
 void __DisableInterrupts();
@@ -580,6 +581,10 @@ u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 				*dstp++ = *srcp++;
 		}
 	}
+#ifndef USING_GLES2
+	CBreakPoints::ExecMemCheck(src, false, size, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(dst, true, size, currentMIPS->pc);
+#endif
 	return dst;
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -915,7 +915,13 @@ int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	}
 
 	hleEatCycles(2020);
-	DEBUG_LOG(ME, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer->packetsFree, ringbufferAddr);
+	static int lastFree = 0;
+	if (lastFree != ringbuffer->packetsFree) {
+		DEBUG_LOG(ME, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer->packetsFree, ringbufferAddr);
+		lastFree = ringbuffer->packetsFree;
+	} else {
+		VERBOSE_LOG(ME, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer->packetsFree, ringbufferAddr);
+	}
 	return ringbuffer->packetsFree;
 }
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -28,7 +28,8 @@
 #include "MIPS/JitCommon/JitCommon.h"
 #include "HLE/HLE.h"
 #include "CPU.h"
-#include "Debugger/SymbolMap.h"
+#include "Core/Debugger/SymbolMap.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/Config.h"
 
 namespace Memory
@@ -210,6 +211,9 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength)
 		for (size_t i = 0; i < _iLength; i++)
 			Write_U8(_iValue, (u32)(_Address + i));
 	}
+#ifndef USING_GLES2
+	CBreakPoints::ExecMemCheck(_Address, true, _iLength, currentMIPS->pc);
+#endif
 }
 
 void GetString(std::string& _string, const u32 em_address)

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -18,6 +18,7 @@
 #include "base/logging.h"
 #include "gfx_es2/gl_state.h"
 
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMap.h"
 #include "Core/Host.h"
 #include "Core/Config.h"
@@ -1562,6 +1563,11 @@ void GLES_GPU::DoBlockTransfer() {
 			dstStride == 512 && height == 272) {
 		framebufferManager_.DrawPixels(Memory::GetPointerUnchecked(dstBasePtr), GE_FORMAT_8888, 512);
 	}
+
+#ifndef USING_GLES2
+	CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
+#endif
 }
 
 void GLES_GPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -19,6 +19,7 @@
 #include "GPU/GPUState.h"
 #include "GPU/ge_constants.h"
 #include "GPU/Common/TextureDecoder.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceGe.h"
@@ -563,6 +564,11 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 				u8 *dst = Memory::GetPointer(dstBasePtr + ((y + dstY) * dstStride + dstX) * bpp);
 				memcpy(dst, src, width * bpp);
 			}
+
+#ifndef USING_GLES2
+			CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
+			CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
+#endif
 
 			break;
 		}


### PR DESCRIPTION
This uses cityhash64 (which unfortunately means copying...), and tries to prevent the debugger shutdown crash.

Also added memchecks to at least the common memory copy operations, ifdef'd out on mobile to not impact perf (just in case.)

-[Unknown]
