### PR TITLE
Simply break when anti-aliasing enabled

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -693,16 +693,8 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 				break;
 				
 			// Discard AA lines as we can't do anything that makes sense with these anyway. The SW plugin might, though.
-			
-
 			if (gstate.isAntiAliasEnabled()) {
-				// Discard AA lines in DOA
-				if (prim == GE_PRIM_LINE_STRIP)
-					break;
-				// Discard AA lines in Summon Night 5
-				if ((prim == GE_PRIM_LINES) && vertTypeIsSkinningEnabled(gstate.vertType))
-					break;
-			}
+				break;
 
 			// This also make skipping drawing very effective.
 			framebufferManager_.SetRenderFrameBuffer();


### PR DESCRIPTION
Looks like we don't need to specifiy GE_PRIM_LINE_STRIP and GE_PRIM_LINES .

Tested with both DOA and Summon Night 5 , both work fine .
