### PR TITLE
Simply break when anti-aliasing enabled

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -693,16 +693,8 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 				break;
 				
 			// Discard AA lines as we can't do anything that makes sense with these anyway. The SW plugin might, though.
-			
-
-			if (gstate.isAntiAliasEnabled()) {
-				// Discard AA lines in DOA
-				if (prim == GE_PRIM_LINE_STRIP)
-					break;
-				// Discard AA lines in Summon Night 5
-				if ((prim == GE_PRIM_LINES) && vertTypeIsSkinningEnabled(gstate.vertType))
-					break;
-			}
+			if (gstate.isAntiAliasEnabled()) 
+				break;
 
 			// This also make skipping drawing very effective.
 			framebufferManager_.SetRenderFrameBuffer();


### PR DESCRIPTION
Looks like we don't need to specifiy GE_PRIM_LINE_STRIP and GE_PRIM_LINES .

Tested with both DOA and Summon Night 5 , both work fine .

![screen00160](https://f.cloud.github.com/assets/3000282/1750441/3b6dcb92-6590-11e3-8ae1-369d1fc1cac9.jpg)
![screen00161](https://f.cloud.github.com/assets/3000282/1750442/3ef8b7ea-6590-11e3-843a-e182b7f05407.jpg)
