### PR TITLE
Use #version 130 for OpenGL 3.0+ to support out

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -319,6 +319,8 @@ void GenerateFragmentShader(char *buffer) {
 	if (gl_extensions.VersionGEThan(3, 3, 0)) {
 		glslES30 = true;
 		WRITE(p, "#version 330\n");
+	} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
+		WRITE(p, "#version 130\n");
 	} else {
 		WRITE(p, "#version 110\n");
 		// Remove lowp/mediump in non-mobile non-glsl 3 implementations


### PR DESCRIPTION
Otherwise it just gives errors on cards that support dual source blending.

This is the minimum version required to make it function for me, so I'm assuming no one can have a card with dual-source blending without also supporting 3.0+.

-[Unknown]
