### PR TITLE
Fix a bunch of things in softgpu (save dialogs, swizzle, bilinear, depth)

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -406,7 +406,7 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 		snprintf(saveTitle, 512, "%s", param.GetFileInfo(currentSelectedSave).saveTitle);
 		snprintf(saveDetail, 512, "%s", param.GetFileInfo(currentSelectedSave).saveDetail);
 		
-		PPGeDrawRect(180, 136, 980, 137, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawRect(180, 136, 480, 137, CalcFadedColor(0xFFFFFFFF));
 		std::string titleTxt = title;
 		std::string timeTxt = time;
 		std::string saveTitleTxt = saveTitle;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -462,7 +462,7 @@ void DoFrameTiming(bool &throttle, bool &skipFrame, float timestep) {
 		if (curFrameTime > nextFrameTime && doFrameSkip) {
 			skipFrame = true;
 		}
-	}	else if (g_Config.iFrameSkip > 1)	{
+	} else if (g_Config.iFrameSkip > 1)	{
 		// Other values = fixed frameskip
 		if (numSkippedFrames >= g_Config.iFrameSkip - 1)
 			skipFrame = false;
@@ -563,9 +563,15 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 		// 1.001f to compensate for the classic 59.94 NTSC framerate that the PSP seems to have.
 		DoFrameTiming(throttle, skipFrame, (float)numVBlanksSinceFlip * (1.001f / 60.0f));
 
-		// Max 4 skipped frames in a row - 15 fps is really the bare minimum for playability.
-		// We check for 3 here so it's 3 skipped frames, 1 non skipped, 3 skipped, etc.
-		int maxFrameskip = throttle ? g_Config.iFrameSkip : 8;
+		int maxFrameskip = 8;
+		if (throttle) {
+			if (g_Config.iFrameSkip == 1) {
+				// 4 here means 1 drawn, 4 skipped - so 12 fps minimum.
+				maxFrameskip = 4;
+			} else {
+				maxFrameskip = g_Config.iFrameSkip - 1;
+			}
+		}
 		if (numSkippedFrames >= maxFrameskip) {
 			skipFrame = false;
 		}

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -287,7 +287,7 @@ void PPGeBegin()
 	PPGeSetDefaultTexture();
 
 	WriteCmd(GE_CMD_SCISSOR1, (0 << 10) | 0);
-	WriteCmd(GE_CMD_SCISSOR2, (1023 << 10) | 1023);
+	WriteCmd(GE_CMD_SCISSOR2, (271 << 10) | 479);
 	WriteCmd(GE_CMD_MINZ, 0);
 	WriteCmd(GE_CMD_MAXZ, 0xFFFF);
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -570,7 +570,7 @@ static void EstimateDrawingSize(int &drawing_width, int &drawing_height) {
 	int region_height = gstate.getRegionY2() + 1;
 	int scissor_width = gstate.getScissorX2() + 1;
 	int scissor_height = gstate.getScissorY2() + 1;
-	int fb_stride = gstate.fbwidth & 0x3C0;
+	int fb_stride = gstate.FrameBufStride();
 
 	DEBUG_LOG(SCEGE,"viewport : %ix%i, region : %ix%i , scissor: %ix%i, stride: %i, %i", viewport_width,viewport_height, region_width, region_height, scissor_width, scissor_height, fb_stride, gstate.isModeThrough());
 
@@ -662,10 +662,10 @@ void FramebufferManager::SetRenderFrameBuffer() {
 
 	// Get parameters
 	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.fbwidth & 0x3C0;
+	int fb_stride = gstate.FrameBufStride();
 
 	u32 z_address = gstate.getDepthBufRawAddress();
-	int z_stride = gstate.zbwidth & 0x3C0;
+	int z_stride = gstate.DepthBufStride();
 
 	// Yeah this is not completely right. but it'll do for now.
 	//int drawing_width = ((gstate.region2) & 0x3FF) + 1;
@@ -1557,7 +1557,7 @@ void FramebufferManager::Resized() {
 
 bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
 	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.fbwidth & 0x3C0;
+	int fb_stride = gstate.FrameBufStride();
 
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (!vfb) {
@@ -1584,10 +1584,10 @@ bool FramebufferManager::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
 
 bool FramebufferManager::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.fbwidth & 0x3C0;
+	int fb_stride = gstate.FrameBufStride();
 
 	u32 z_address = gstate.getDepthBufRawAddress();
-	int z_stride = gstate.zbwidth & 0x3C0;
+	int z_stride = gstate.DepthBufStride();
 
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (!vfb) {
@@ -1617,7 +1617,7 @@ bool FramebufferManager::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 
 bool FramebufferManager::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
 	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.fbwidth & 0x3C0;
+	int fb_stride = gstate.FrameBufStride();
 
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (!vfb) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -218,10 +218,10 @@ struct GPUgstate
 	// 0x44000000 is uncached VRAM.
 	u32 getFrameBufAddress() const { return 0x44000000 | getFrameBufRawAddress(); }
 	GEBufferFormat FrameBufFormat() const { return static_cast<GEBufferFormat>(framebufpixformat & 3); }
-	int FrameBufStride() const { return fbwidth&0x7C0; }
+	int FrameBufStride() const { return fbwidth&0x7FC; }
 	u32 getDepthBufRawAddress() const { return (zbptr & 0xFFFFFF) | ((zbwidth & 0xFF0000) << 8); }
 	u32 getDepthBufAddress() const { return 0x44000000 | getDepthBufRawAddress(); }
-	int DepthBufStride() const { return zbwidth&0x7C0; }
+	int DepthBufStride() const { return zbwidth&0x7FC; }
 
 	// Pixel Pipeline
 	bool isModeClear()   const { return clearmode & 1; }

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -173,6 +173,7 @@ public:
 	Vec3() {}
 	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
+	Vec3(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
 
 	template<typename T2>
 	Vec3<T2> Cast() const
@@ -334,6 +335,8 @@ public:
 	Vec4() {}
 	Vec4(const T a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 	Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
+	Vec4(const Vec2<T>& _xy, const T& _z, const T& _w) : x(_xy.x), y(_xy.y), z(_z), w(_w) {}
+	Vec4(const Vec3<T>& _xyz, const T& _w) : x(_xyz.x), y(_xyz.y), z(_xyz.z), w(_w) {}
 
 	template<typename T2>
 	Vec4<T2> Cast() const

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -70,8 +70,7 @@ static inline int GetPixelDataOffset(unsigned int row_pitch_bits, unsigned int u
 					(tile_u % tiles_in_block_horizontal) +
 					(tile_u / tiles_in_block_horizontal) * (tiles_in_block_horizontal*tiles_in_block_vertical);
 
-	// TODO: HACK: for some reason, the second part needs to be diviced by two for CLUT4 textures to work properly.
-	return tile_idx * tile_size_bits/8 + ((u % (tile_size_bits / texel_size_bits)))/((texel_size_bits == 4) ? 2 : 1);
+	return tile_idx * (tile_size_bits / 8) + ((u % texels_per_tile) * texel_size_bits) / 8;
 }
 
 static inline u32 LookupColor(unsigned int index, unsigned int level)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -997,9 +997,10 @@ void DrawTriangleSlice(
 						Vec4<int> texcolor_tr = Vec4<int>::FromRGBA(SampleNearest(texlevel, u[1], v[1], tptr, bufwbits));
 						Vec4<int> texcolor_bl = Vec4<int>::FromRGBA(SampleNearest(texlevel, u[2], v[2], tptr, bufwbits));
 						Vec4<int> texcolor_br = Vec4<int>::FromRGBA(SampleNearest(texlevel, u[3], v[3], tptr, bufwbits));
-						Vec4<int> t = texcolor_tl * (0xff - frac_u) + texcolor_tr * frac_u;
-						Vec4<int> b = texcolor_bl * (0xff - frac_u) + texcolor_br * frac_u;
-						texcolor = (t * (0xff - frac_v) + b * frac_v) / (256 * 256);
+						// 0x100 causes a slight bias to tl, but without it we'd have to divide by 255 * 255.
+						Vec4<int> t = texcolor_tl * (0x100 - frac_u) + texcolor_tr * frac_u;
+						Vec4<int> b = texcolor_bl * (0x100 - frac_u) + texcolor_br * frac_u;
+						texcolor = (t * (0x100 - frac_v) + b * frac_v) / (256 * 256);
 					}
 					Vec4<int> out = GetTextureFunctionOutput(prim_color_rgb, prim_color_a, texcolor);
 					prim_color_rgb = out.rgb();

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -882,6 +882,10 @@ void DrawTriangleSlice(
 	w1_base += orient2dIncY(-d02.x) * 16 * y1;
 	w2_base += orient2dIncY(d01.x) * 16 * y1;
 
+	// All the z values are the same, no interpolation required.
+	// This is common, and when we interpolate, we lose accuracy.
+	const bool flatZ = v0.screenpos.z == v1.screenpos.z && v0.screenpos.z == v2.screenpos.z;
+
 	for (pprime.y = minY + y1 * 16; pprime.y < minY + y2 * 16; pprime.y += 16,
 										w0_base += orient2dIncY(d12.x)*16,
 										w1_base += orient2dIncY(-d02.x)*16,
@@ -1013,9 +1017,11 @@ void DrawTriangleSlice(
 
 				// TODO: Fogging
 
+				u16 z = v2.screenpos.z;
 				// TODO: Is that the correct way to interpolate?
 				// Without the (u32), this causes an ICE in some versions of gcc.
-				u16 z = (u16)(u32)(((float)v0.screenpos.z * w0 + (float)v1.screenpos.z * w1 + (float)v2.screenpos.z * w2) * wsum);
+				if (!flatZ)
+					z = (u16)(u32)(((float)v0.screenpos.z * w0 + (float)v1.screenpos.z * w1 + (float)v2.screenpos.z * w2) * wsum);
 
 				// Depth range test
 				// TODO: Clear mode?

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -206,10 +206,18 @@ static inline void GetTextureCoordinates(const VertexData& v0, const VertexData&
 		{
 			// projection mapping, TODO: Move this code to TransformUnit!
 			Vec3<float> source;
-			if (gstate.getUVProjMode() == GE_PROJMAP_POSITION) {
+			switch (gstate.getUVProjMode()) {
+			case GE_PROJMAP_POSITION:
 				source = ((v0.modelpos * w0 + v1.modelpos * w1 + v2.modelpos * w2) / (w0+w1+w2));
-			} else {
+				break;
+
+			case GE_PROJMAP_UV:
+				source = Vec3f((v0.texturecoords * w0 + v1.texturecoords * w1 + v2.texturecoords * w2) / (w0 + w1 + w2), 0.0f);
+				break;
+
+			default:
 				ERROR_LOG_REPORT(G3D, "Software: Unsupported UV projection mode %x", gstate.getUVProjMode());
+				break;
 			}
 
 			Mat3x3<float> tgen(gstate.tgenMatrix);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -56,6 +56,9 @@ public:
 
 	virtual void BeginFrame() {}
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {
+		displayFramebuf_ = framebuf;
+		displayStride_ = stride;
+		displayFormat_ = format;
 		host->GPUNotifyDisplay(framebuf, stride, format);
 	}
 	virtual void CopyDisplayToOutput();
@@ -85,8 +88,12 @@ public:
 protected:
 	virtual void FastRunLoop(DisplayList &list);
 	virtual void ProcessEvent(GPUEvent ev);
-	void CopyToCurrentFboFromRam(u8* data, int srcwidth, int srcheight, int dstwidth, int dstheight);
+	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight, int dstwidth, int dstheight);
 
 private:
 	void CopyDisplayToOutputInternal();
+
+	u32 displayFramebuf_;
+	u32 displayStride_;
+	GEBufferFormat displayFormat_;
 };

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -343,6 +343,7 @@ int main(int argc, const char* argv[])
 	g_Config.iInternalResolution = 1;
 	g_Config.bFrameSkipUnthrottle = false;
 	g_Config.bEnableLogging = fullLog;
+	g_Config.iNumWorkerThreads = 1;
 
 #ifdef _WIN32
 	InitSysDirectories();


### PR DESCRIPTION
The commits each have notes, with the end result:
- Depth testing seems correct now in Phantasy Star dialogs at least.  Still something funny in Tales of Eternia.  I'm not sure if it should always be v2.z, or at least in throughmode?  But at least when they match we should retain accuracy, which is common (>= test was failing.)
- Save dialogs now show properly without glitches (it was actually incorrectly working in gles partially.)
- 16-bit textures are now swizzled correctly.  Probably 32 also?
- Render-to-texture works properly in more places (stride was being masked incorrectly, verified on a PSP.)
- Bilinear filtering was 255^2 / 256^2, which lost bits and caused black in Tales of Eternia's world map, so made it (1 + 255)^2 / 256^2 to retain speed.
- Attempted to implement GE_PROJMAP_UV.  Least confident about this one, but I think it works?
- Displays the _display_ buffer, not the current render target.  Fixes flickering in save dialogs and transitions in some games.

-[Unknown]
