### PR TITLE
softgpu: Keep track of frame dirty for frameskip

### DIFF
--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -76,6 +76,8 @@ public:
 		fullInfo = "Software";
 	}
 
+	virtual bool FramebufferDirty();
+
 	virtual bool FramebufferReallyDirty() {
 		return !(gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME);
 	}
@@ -93,6 +95,7 @@ protected:
 private:
 	void CopyDisplayToOutputInternal();
 
+	bool framebufferDirty_;
 	u32 displayFramebuf_;
 	u32 displayStride_;
 	GEBufferFormat displayFormat_;


### PR DESCRIPTION
One more - to track when it should be 30 fps, etc.  But only when frameskip is enabled.  Let's always draw in case of pixel poking when it's off.

-[Unknown]
