### PR TITLE
Always update framebuffer tex sampling params

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -835,7 +835,8 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry)
 			glBindTexture(GL_TEXTURE_2D, 0);
 			gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
 		}
-		UpdateSamplingParams(*entry, false);
+		// We need to force it, since we may have set it on a texture before attaching.
+		UpdateSamplingParams(*entry, true);
 		gstate_c.curTextureWidth = entry->framebuffer->width;
 		gstate_c.curTextureHeight = entry->framebuffer->height;
 		gstate_c.flipTexture = true;

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -211,6 +211,19 @@ void CGEDebugger::UpdatePrimPreview(u32 op) {
 	glScissor(x, y, fw, fh);
 	BindPreviewProgram(texPreviewProgram);
 
+	// TODO: Probably there's a better way and place to do this.
+	if (indices.empty()) {
+		for (int i = 0; i < count; ++i) {
+			vertices[i].u -= floor(vertices[i].u);
+			vertices[i].v -= floor(vertices[i].v);
+		}
+	} else {
+		for (int i = 0; i < count; ++i) {
+			vertices[indices[i]].u -= floor(vertices[indices[i]].u);
+			vertices[indices[i]].v -= floor(vertices[indices[i]].v);
+		}
+	}
+
 	ortho.setOrtho(0.0, 1.0, 1.0, 0.0, -1.0, 1.0);
 	glUniformMatrix4fv(texPreviewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 	glEnableVertexAttribArray(texPreviewProgram->a_position);


### PR DESCRIPTION
Otherwise they are not always correct and cause glitches.

I was creating an issue for this when I finally found it - this and the ATIClampBug thing.

With native updated and hrydgard/native#179 merged, this fixes Wild Arms XF's scrolling lists in the shop.  It was using UV coords like 1.36,1.23 etc. and they were clamping instead of wrapping.

Alternatively, to work around the ATI bug, we could apply a fract() in the shader or something, I guess.

-[Unknown]
