### PR TITLE
Fix in-game flickering in BOF3 (buffered rendering mode)

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -586,26 +586,11 @@ static void EstimateDrawingSize(int &drawing_width, int &drawing_height) {
 	}
 
 	if (fb_stride > 0 && fb_stride < 512) {
-		// Correct scissor size has to be used to render like character shadow in Mortal Kombat .
-		if (fb_stride == scissor_width && region_width != scissor_width) { 
-			drawing_width = scissor_width;
-			drawing_height = scissor_height;
-		} else {
-			drawing_width = viewport_width;
-			drawing_height = viewport_height;
-		}
+		drawing_width = viewport_width;
+		drawing_height = viewport_height;
 	} else {
-		// Correct region size has to be used when fb_width equals to region_width for exmaple GTA/Midnight Club/MSG Peace Maker .
-		if (fb_stride == region_width && region_width == viewport_width) { 
-			drawing_width = region_width;
-			drawing_height = region_height;
-		} else if (fb_stride == viewport_width) { 
-			drawing_width = viewport_width;
-			drawing_height = viewport_height;
-		} else {
-			drawing_width = default_width;
-			drawing_height = default_height;
-		}
+		drawing_width = region_width;
+		drawing_height = region_height;
 	}
 }
 


### PR DESCRIPTION
This one seems to be the logical one now .It didn't work well previously until UpdateSamplingParams() get corrected for render-to-texture by @unknownbrackets 

This simply fixes the following wrong framebuffer sizing and caused flickering.
1. BOF3 in-game flickering (buffered rendering mode). #2759 
2. Wildarm XF video flickering . #4325

Meanwile , the following testing items have been well-tested 

```
TOPX title , town/worldmap and final credit .
Wildarm XF in-game battle
Midnight Club 3 in-game race battle
Kingdom Heart in-game , cutscenes and character shadow
FF crisis character shadow.
MSG peace maker in-game and cutscene
MotoStorm in-game
Summon Night 5 character shadow
Mortal Kombat chacter shadow
MotoGP car selection 
```
