### PR TITLE
Implement some ioctl commands for disc0:/ files

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -694,8 +694,7 @@ u32 sceAtracEndEntry() {
 }
 
 u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAddr) {
-	PSPPointer<AtracResetBufferInfo> bufferInfo;
-	bufferInfo = bufferInfoAddr;
+	auto bufferInfo = PSPPointer<AtracResetBufferInfo>::Create(bufferInfoAddr);
 
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -289,8 +289,7 @@ int sceCccStrlenSJIS(u32 strAddr)
 
 u32 sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
 {
-	PSPPointer<PSPCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid())
 	{
@@ -304,8 +303,7 @@ u32 sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
 
 void sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
 {
-	PSPPointer<PSPWCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPWCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid())
 	{
@@ -321,8 +319,7 @@ void sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
 
 u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 {
-	PSPPointer<PSPCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid())
 	{
@@ -336,8 +333,7 @@ u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 
 u32 sceCccDecodeUTF8(u32 dstAddrAddr)
 {
-	PSPPointer<PSPCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid()) {
 		ERROR_LOG(HLE, "sceCccDecodeUTF8(%08x): invalid pointer", dstAddrAddr);
@@ -357,8 +353,7 @@ u32 sceCccDecodeUTF8(u32 dstAddrAddr)
 
 u32 sceCccDecodeUTF16(u32 dstAddrAddr)
 {
-	PSPPointer<PSPWCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPWCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid()) {
 		ERROR_LOG(HLE, "sceCccDecodeUTF16(%08x): invalid pointer", dstAddrAddr);
@@ -379,8 +374,7 @@ u32 sceCccDecodeUTF16(u32 dstAddrAddr)
 
 u32 sceCccDecodeSJIS(u32 dstAddrAddr)
 {
-	PSPPointer<PSPCharPointer> dstp;
-	dstp = dstAddrAddr;
+	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
 	if (!dstp.IsValid() || !dstp->IsValid()) {
 		ERROR_LOG(HLE, "sceCccDecodeSJIS(%08x): invalid pointer", dstAddrAddr);

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -236,8 +236,7 @@ int __CtrlReadBuffer(u32 ctrlDataPtr, u32 nBufs, bool negative, bool peek)
 	ctrlBufRead = (ctrlBuf - availBufs + NUM_CTRL_BUFFERS) % NUM_CTRL_BUFFERS;
 
 	int done = 0;
-	PSPPointer<_ctrl_data> data;
-	data = ctrlDataPtr;
+	auto data = PSPPointer<_ctrl_data>::Create(ctrlDataPtr);
 	for (u32 i = 0; i < availBufs; ++i)
 		done += __CtrlReadSingleBuffer(data++, negative);
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -333,8 +333,7 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId,
 	DEBUG_LOG(SCEGE,
 			"sceGeListEnQueue(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
 			listAddress, stallAddress, callbackId, optParamAddr);
-	PSPPointer<PspGeListArgs> optParam;
-	optParam = optParamAddr;
+	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, false);
 	if ((int)listID >= 0)
@@ -352,8 +351,7 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId,
 	DEBUG_LOG(SCEGE,
 			"sceGeListEnQueueHead(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
 			listAddress, stallAddress, callbackId, optParamAddr);
-	PSPPointer<PspGeListArgs> optParam;
-	optParam = optParamAddr;
+	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
 	if ((int)listID >= 0)

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1971,10 +1971,10 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		// TODO: Should not work for umd0:/, ms0:/, etc.
 		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
 		if (!Memory::IsValidAddress(outdataPtr) || outlen < 0x800) {
-			WARN_LOG_REPORT(SCEIO, "sceIoIoCtl: Invalid out pointer while reading ISO9660 volume descriptor");
+			WARN_LOG_REPORT(SCEIO, "sceIoIoctl: Invalid out pointer while reading ISO9660 volume descriptor");
 			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		} else {
-			INFO_LOG(SCEIO, "sceIoIoCtl: reading ISO9660 volume descriptor read");
+			INFO_LOG(SCEIO, "sceIoIoctl: reading ISO9660 volume descriptor read");
 			u32 descFd = pspFileSystem.OpenFile("disc0:/sce_lbn0x10_size0x800", FILEACCESS_READ);
 			if (descFd == 0) {
 				return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
@@ -1985,47 +1985,79 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		}
 		break;
 
+	// Get ISO9660 path table (from open ISO9660 file.)
+	case 0x01020002:
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// Seems like it will accept an out size > path table size, but only write path table bytes.
+		// If not big enough, returns SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT.
+		// Probably only the LE version.
+		{
+			char temp[256];
+			// We want the reported message to include the cmd, so it's unique.
+			sprintf(temp, "sceIoIoctl(%%s, %08x, %%08x, %%x, %%08x, %%x)", cmd);
+			Reporting::ReportMessage(temp, f->fullpath.c_str(), indataPtr, inlen, outdataPtr, outlen);
+			ERROR_LOG(SCEIO, "UNIMPL 0=sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outLen %08x", id,cmd,indataPtr,inlen,outdataPtr,outlen);
+		}
+		break;
+
 	// Get UMD sector size
 	case 0x01020003:
-		INFO_LOG(SCEIO, "sceIoIoCtl: Asked for sector size of file %i", id);
-		if (Memory::IsValidAddress(outdataPtr) && outlen == 4) {
-			Memory::Write_U32(f->info.sectorSize, outdataPtr);
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Asked for sector size of file %i", id);
+		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
+			// ISOs always use 2048 sized sectors.
+			Memory::Write_U32(2048, outdataPtr);
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
 		break;
 
 	// Get UMD file offset
 	case 0x01020004:
-		{
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Asked for file offset of file %i", id);
+		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
 			u32 offset = (u32)pspFileSystem.GetSeekPos(f->handle);
-			INFO_LOG(SCEIO, "sceIoIoCtl: Asked for file offset of file %i", id);
-			if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
-				Memory::Write_U32(offset, outdataPtr);
-			}
+			Memory::Write_U32(offset, outdataPtr);
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
 		break;
 
+	// 0x01020005 - SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED
+
 	// Get UMD file start sector.
 	case 0x01020006:
-		INFO_LOG(SCEIO, "sceIoIoCtl: Asked for start sector of file %i", id);
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Asked for start sector of file %i", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
 			Memory::Write_U32(f->info.startSector, outdataPtr);
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
 		break;
 
 	// Get UMD file size in bytes.
 	case 0x01020007:
-		INFO_LOG(SCEIO, "sceIoIoCtl: Asked for size of file %i", id);
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Asked for size of file %i", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 8) {
 			Memory::Write_U64(f->info.size, outdataPtr);
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
 		break;
 
 	// Unknown command, always expects return value of 1 according to JPCSP, used by Pangya Fantasy Golf.
 	// TODO: This is unsupported on ms0:/ (SCE_KERNEL_ERROR_UNSUP.)
 	case 0x01f30003:
-		INFO_LOG(SCEIO, "sceIoIoCtl: Unknown cmd %08x always returns 1", cmd);
+		INFO_LOG(SCEIO, "sceIoIoctl: Unknown cmd %08x always returns 1", cmd);
 		if(inlen != 4 || outlen != 1 || Memory::Read_U32(indataPtr) != outlen) {
-			INFO_LOG(SCEIO, "sceIoIoCtl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outlen %08x has invalid parameters", id, cmd, indataPtr, inlen, outdataPtr, outlen);
+			INFO_LOG(SCEIO, "sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outlen %08x has invalid parameters", id, cmd, indataPtr, inlen, outdataPtr, outlen);
 			return SCE_KERNEL_ERROR_INVALID_ARGUMENT;
 		}
 		else {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2111,8 +2111,7 @@ u32 sceIoIoctlAsync(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u
 u32 sceIoGetFdList(u32 outAddr, int outSize, u32 fdNumAddr) {
 	WARN_LOG(SCEIO, "sceIoGetFdList(%08x, %i, %08x)", outAddr, outSize, fdNumAddr);
 
-	PSPPointer<SceUID> out;
-	out = outAddr;
+	auto out = PSPPointer<SceUID>::Create(outAddr);
 	int count = 0;
 
 	// Always have the first three.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2084,6 +2084,23 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		}
 		break;
 
+	// Read from UMD file.
+	case 0x01030008:
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Read from file %i", id);
+		if (Memory::IsValidAddress(indataPtr) && inlen >= 4) {
+			u32 size = Memory::Read_U32(indataPtr);
+			if (Memory::IsValidAddress(outdataPtr) && size <= outlen) {
+				return sceIoRead(id, outdataPtr, size);
+			} else {
+				return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+			}
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+		}
+		break;
+
 	// Unknown command, always expects return value of 1 according to JPCSP, used by Pangya Fantasy Golf.
 	// TODO: This is unsupported on ms0:/ (SCE_KERNEL_ERROR_UNSUP.)
 	case 0x01f30003:

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1966,6 +1966,25 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			return (int)f->info.size;
 		break;
 
+	// Get ISO9660 volume descriptor (from open ISO9660 file.)
+	case 0x01020001:
+		// TODO: Should not work for umd0:/, ms0:/, etc.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		if (!Memory::IsValidAddress(outdataPtr) || outlen < 0x800) {
+			WARN_LOG_REPORT(SCEIO, "sceIoIoCtl: Invalid out pointer while reading ISO9660 volume descriptor");
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+		} else {
+			INFO_LOG(SCEIO, "sceIoIoCtl: reading ISO9660 volume descriptor read");
+			u32 descFd = pspFileSystem.OpenFile("disc0:/sce_lbn0x10_size0x800", FILEACCESS_READ);
+			if (descFd == 0) {
+				return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+			}
+			pspFileSystem.ReadFile(descFd, Memory::GetPointer(outdataPtr), 0x800);
+			pspFileSystem.CloseFile(descFd);
+			return 0;
+		}
+		break;
+
 	// Get UMD sector size
 	case 0x01020003:
 		INFO_LOG(SCEIO, "sceIoIoCtl: Asked for sector size of file %i", id);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1803,8 +1803,7 @@ u32 sceKernelQueryModuleInfo(u32 uid, u32 infoAddr)
 		return -1;
 	}
 
-	PSPPointer<ModuleInfo> info;
-	info = infoAddr;
+	auto info = PSPPointer<ModuleInfo>::Create(infoAddr);
 
 	memcpy(info->segmentaddr, module->nm.segmentaddr, sizeof(info->segmentaddr));
 	memcpy(info->segmentsize, module->nm.segmentsize, sizeof(info->segmentsize));

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1535,8 +1535,7 @@ u32 sceKernelReferThreadRunStatus(u32 threadID, u32 statusPtr)
 	if (!Memory::IsValidAddress(statusPtr))
 		return -1;
 
-	PSPPointer<SceKernelThreadRunStatus> runStatus;
-	runStatus = statusPtr;
+	auto runStatus = PSPPointer<SceKernelThreadRunStatus>::Create(statusPtr);
 
 	// TODO: Check size?
 	runStatus->size = sizeof(SceKernelThreadRunStatus);
@@ -2575,8 +2574,7 @@ int sceKernelDelayThread(u32 usec)
 
 int sceKernelDelaySysClockThreadCB(u32 sysclockAddr)
 {
-	PSPPointer<SceKernelSysClock> sysclock;
-	sysclock = sysclockAddr;
+	auto sysclock = PSPPointer<SceKernelSysClock>::Create(sysclockAddr);
 	if (!sysclock.IsValid()) {
 		ERROR_LOG(SCEKERNEL, "sceKernelDelaySysClockThreadCB(%08x) - bad pointer", sysclockAddr);
 		return -1;
@@ -2594,8 +2592,7 @@ int sceKernelDelaySysClockThreadCB(u32 sysclockAddr)
 
 int sceKernelDelaySysClockThread(u32 sysclockAddr)
 {
-	PSPPointer<SceKernelSysClock> sysclock;
-	sysclock = sysclockAddr;
+	auto sysclock = PSPPointer<SceKernelSysClock>::Create(sysclockAddr);
 	if (!sysclock.IsValid()) {
 		ERROR_LOG(SCEKERNEL, "sceKernelDelaySysClockThread(%08x) - bad pointer", sysclockAddr);
 		return -1;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -900,8 +900,7 @@ int sceMpegQueryAtracEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)
 
 int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 {
-	PSPPointer<SceMpegRingBuffer> ringbuffer;
-	ringbuffer = ringbufferAddr;
+	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ringbufferAddr);
 
 	if (!ringbuffer.IsValid()) {
 		ERROR_LOG(ME, "sceMpegRingbufferAvailableSize(%08x) - bad address", ringbufferAddr);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -395,8 +395,7 @@ static std::map<u32, PsmfPlayer *> psmfPlayerMap;
 
 Psmf *getPsmf(u32 psmf)
 {
-	PSPPointer<PsmfData> psmfstruct;
-	psmfstruct = psmf;
+	auto psmfstruct = PSPPointer<PsmfData>::Create(psmf);
 	if (!psmfstruct.IsValid())
 		return 0;
 	auto iter = psmfMap.find(psmfstruct->headerOffset);

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -222,8 +222,7 @@ u32 sceUmdGetDiscInfo(u32 infoAddr)
 	DEBUG_LOG(SCEIO, "sceUmdGetDiscInfo(%08x)", infoAddr);
 
 	if (Memory::IsValidAddress(infoAddr)) {
-		PSPPointer<PspUmdInfo> info;
-		info = infoAddr;
+		auto info = PSPPointer<PspUmdInfo>::Create(infoAddr);
 		if (info->size != 8)
 			return PSP_ERROR_UMD_INVALID_PARAM;
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -428,6 +428,12 @@ struct PSPPointer
 	{
 		return Memory::IsValidAddress(ptr);
 	}
+
+	static PSPPointer<T> Create(u32 ptr) {
+		PSPPointer<T> p;
+		p = ptr;
+		return p;
+	}
 };
 
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -182,8 +182,7 @@ int GPUCommon::GetStack(int index, u32 stackPtr) {
 	}
 
 	if (index >= 0) {
-		PSPPointer<u32> stack;
-		stack = stackPtr;
+		auto stack = PSPPointer<u32>::Create(stackPtr);
 		if (stack.IsValid()) {
 			auto entry = currentList->stack[index];
 			// Not really sure what most of these values are.


### PR DESCRIPTION
http://report.ppsspp.org/logs/kind/59
http://report.ppsspp.org/logs/kind/33
http://report.ppsspp.org/logs/kind/110

I can't tell that my games are affected by these changes, but some of these commands seem like trouble if used and not implemented...

Still don't know what 9, a, and b do yet, and didn't implement 0x01020002 yet although I've reproduced it reading the path table.  Unfortunately my tests only work for a umd mounted so don't work with automated execution...

-[Unknown]
