### PR TITLE
Fix memcpy/memmove replacements, minor tweaks

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -57,11 +57,14 @@ static int Replace_atan2f() {
 // large copies to a C function.
 static int Replace_memcpy() {
 	u32 destPtr = PARAM(0);
-	u8 *dst = Memory::GetPointer(destPtr);
-	u8 *src = Memory::GetPointer(PARAM(1));
+	u32 srcPtr = PARAM(1);
 	u32 bytes = PARAM(2);
-	if (dst && src) {
-		memcpy(dst, src, bytes);
+	if (bytes != 0) {
+		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *src = Memory::GetPointer(srcPtr);
+		if (dst && src) {
+			memmove(dst, src, bytes);
+		}
 	}
 	RETURN(destPtr);
 	return 10 + bytes / 4;  // approximation
@@ -69,11 +72,14 @@ static int Replace_memcpy() {
 
 static int Replace_memmove() {
 	u32 destPtr = PARAM(0);
-	u8 *dst = Memory::GetPointer(destPtr);
-	u8 *src = Memory::GetPointer(PARAM(1));
+	u32 srcPtr = PARAM(1);
 	u32 bytes = PARAM(2);
-	if (dst && src) {
-		memcpy(dst, src, bytes);
+	if (bytes != 0) {
+		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *src = Memory::GetPointer(srcPtr);
+		if (dst && src) {
+			memmove(dst, src, bytes);
+		}
 	}
 	RETURN(destPtr);
 	return 10 + bytes / 4;  // approximation

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1059,7 +1059,9 @@ int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
-		ERROR_LOG(ME, "scePsmfPlayerGetCurrentStatus(%08x): invalid psmf player", psmfPlayer);
+		// Mana Khemia and other games call this even when not necessary.
+		// It's annoying so the logging is verbose'd out.
+		VERBOSE_LOG(ME, "scePsmfPlayerGetCurrentStatus(%08x): invalid psmf player", psmfPlayer);
 		return ERROR_PSMF_NOT_FOUND;
 	}
 	DEBUG_LOG(ME, "%d=scePsmfPlayerGetCurrentStatus(%08x)", psmfplayer->status, psmfPlayer);

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -333,6 +333,12 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	return b->normalEntry;
 }
 
+bool Jit::DescribeCodePtr(const u8 *ptr, std::string &name)
+{
+	// TODO: Not used by anything yet.
+	return false;
+}
+
 void Jit::Comp_RunBlock(MIPSOpcode op)
 {
 	// This shouldn't be necessary, the dispatcher should catch us before we get here.

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -66,9 +66,7 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
-	bool IsInDispatch(const u8 *p) {
-		return IsInSpace(p);
-	}
+	bool DescribeCodePtr(const u8 *ptr, std::string &name);
 
 	void CompileDelaySlot(int flags);
 	void EatInstruction(MIPSOpcode op);

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -507,7 +507,7 @@ namespace MIPSAnalyst {
 		for (auto it = functions.begin(), end = functions.end(); it != end; ++it) {
 			const AnalyzedFunction &f = *it;
 			// Small functions aren't very interesting.
-			if (!f.hasHash || f.size < 12) {
+			if (!f.hasHash || f.size <= 16) {
 				continue;
 			}
 			// Functions with default names aren't very interesting either.

--- a/Core/MIPS/PPC/PpcJit.cpp
+++ b/Core/MIPS/PPC/PpcJit.cpp
@@ -74,6 +74,12 @@ void Jit::Compile(u32 em_address)
 	}
 }
 
+bool Jit::DescribeCodePtr(const u8 *ptr, std::string &name)
+{
+	// TODO: Not used by anything yet.
+	return false;
+}
+
 void Jit::MovFromPC(PPCReg r) {
 	LWZ(r, CTXREG, offsetof(MIPSState, pc));
 }

--- a/Core/MIPS/PPC/PpcJit.h
+++ b/Core/MIPS/PPC/PpcJit.h
@@ -296,9 +296,7 @@ namespace MIPSComp
 		void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 		const u8 *DoJit(u32 em_address, JitBlock *b);
 
-		bool IsInDispatch(const u8 *p) {
-			return IsInSpace(p);
-		}
+		bool DescribeCodePtr(const u8 *ptr, std::string &name);
 
 		PpcJitOptions jo;
 		PpcJitState js;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -73,9 +73,7 @@ public:
 	void Compile(u32 em_address);	// Compiles a block at current MIPS PC
 	const u8 *DoJit(u32 em_address, JitBlock *b);
 
-	bool IsInDispatch(const u8 *p) {
-		return asm_.IsInSpace(p);
-	}
+	bool DescribeCodePtr(const u8 *ptr, std::string &name);
 
 	void Comp_RunBlock(MIPSOpcode op);
 	void Comp_ReplacementFunc(MIPSOpcode op);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1555,37 +1555,15 @@ namespace MainWindow
 				{
 					VerySleepy_AddrInfo *info = (VerySleepy_AddrInfo *)lParam;
 					const u8 *ptr = (const u8 *)info->addr;
-					if (MIPSComp::jit) {
-						JitBlockCache *blocks = MIPSComp::jit->GetBlockCache();
-						u32 jitAddr = blocks->GetAddressFromBlockPtr(ptr);
+					std::string name;
 
-						// Returns 0 when it's valid, but unknown.
-						if (jitAddr == 0) {
-							wcscpy_s(info->name, L"Jit::UnknownOrDeletedBlock");
-							return TRUE;
-						}
-						if (jitAddr != (u32)-1) {
-							const char *label = symbolMap.GetDescription(jitAddr);
-							if (label != NULL) {
-								swprintf_s(info->name, L"Jit::%08x_%S", jitAddr, label);
-							} else {
-								swprintf_s(info->name, L"Jit::%08x", jitAddr);
-							}
-							return TRUE;
-						}
-
-						// Perhaps it's in jit the dispatch runloop.
-						if (MIPSComp::jit->IsInDispatch(ptr)) {
-							wcscpy_s(info->name, L"Jit::RunLoopUntil");
-							return TRUE;
-						}
+					if (MIPSComp::jit && MIPSComp::jit->DescribeCodePtr(ptr, name)) {
+						swprintf_s(info->name, L"Jit::%S", name.c_str());
+						return TRUE;
 					}
-					if (gpu) {
-						std::string name;
-						if (gpu->DescribeCodePtr(ptr, name)) {
-							swprintf_s(info->name, L"GPU::%S", name.c_str());
-							return TRUE;
-						}
+					if (gpu && gpu->DescribeCodePtr(ptr, name)) {
+						swprintf_s(info->name, L"GPU::%S", name.c_str());
+						return TRUE;
 					}
 				}
 				return FALSE;


### PR DESCRIPTION
Must ignore pointers on size = 0.

Would like to have these still trigger memory breakpoints, will definitely want to inline that.  Tested, it definitely would be a hit to check every time (which was obvious.)

With all current replacements working, Gods Eater Burst goes from 912% -> 940% or so, on x64.  Probably not as good with fastmem on, didn't try.

-[Unknown]
