### PR TITLE
Implement a few more ioctl commands

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -489,6 +489,10 @@ bool DirectoryFileSystem::OwnsHandle(u32 handle) {
 	return (iter != entries.end());
 }
 
+int DirectoryFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {
+	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
+}
+
 size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
@@ -765,6 +769,10 @@ void VFSFileSystem::CloseFile(u32 handle) {
 bool VFSFileSystem::OwnsHandle(u32 handle) {
 	EntryMap::iterator iter = entries.find(handle);
 	return (iter != entries.end());
+}
+
+int VFSFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {
+	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
 size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -493,6 +493,11 @@ int DirectoryFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u3
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
+int DirectoryFileSystem::DevType(u32 handle) {
+	EntryMap::iterator iter = entries.find(handle);
+	return PSP_DEV_TYPE_FILE;
+}
+
 size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
@@ -773,6 +778,11 @@ bool VFSFileSystem::OwnsHandle(u32 handle) {
 
 int VFSFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
+}
+
+int VFSFileSystem::DevType(u32 handle) {
+	EntryMap::iterator iter = entries.find(handle);
+	return PSP_DEV_TYPE_FILE;
 }
 
 size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -494,7 +494,6 @@ int DirectoryFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u3
 }
 
 int DirectoryFileSystem::DevType(u32 handle) {
-	EntryMap::iterator iter = entries.find(handle);
 	return PSP_DEV_TYPE_FILE;
 }
 
@@ -781,7 +780,6 @@ int VFSFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 }
 
 int VFSFileSystem::DevType(u32 handle) {
-	EntryMap::iterator iter = entries.find(handle);
 	return PSP_DEV_TYPE_FILE;
 }
 

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -95,6 +95,7 @@ public:
 	size_t   SeekFile(u32 handle, s32 position, FileMove type);
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
+	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);
@@ -132,6 +133,7 @@ public:
 	size_t   SeekFile(u32 handle, s32 position, FileMove type);
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
+	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -96,6 +96,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
+	int      DevType(u32 handle);
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);
@@ -134,6 +135,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
+	int      DevType(u32 handle);
 
 	bool MkDir(const std::string &dirname);
 	bool RmDir(const std::string &dirname);

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include "../../Globals.h"
-#include "ChunkFile.h"
+#include "Common/ChunkFile.h"
+#include "Core/HLE/sceKernel.h"
 
 enum FileAccess
 {
@@ -120,6 +121,7 @@ public:
 	virtual int      RenameFile(const std::string &from, const std::string &to) = 0;
 	virtual bool     RemoveFile(const std::string &filename) = 0;
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
+	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 };
 
 
@@ -140,6 +142,7 @@ public:
 	virtual int RenameFile(const std::string &from, const std::string &to) {return -1;}
 	virtual bool RemoveFile(const std::string &filename) {return false;}
 	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
+	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
 };
 
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -43,6 +43,13 @@ enum FileType
 	FILETYPE_DIRECTORY=2
 };
 
+enum DevType
+{
+	PSP_DEV_TYPE_BLOCK = 0x04,
+	PSP_DEV_TYPE_FILE  = 0x10,
+	PSP_DEV_TYPE_ALIAS = 0x20,
+};
+
 
 class IHandleAllocator {
 public:
@@ -122,6 +129,7 @@ public:
 	virtual bool     RemoveFile(const std::string &filename) = 0;
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
+	virtual int      DevType(u32 handle) = 0;
 };
 
 
@@ -143,6 +151,7 @@ public:
 	virtual bool RemoveFile(const std::string &filename) {return false;}
 	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
+	virtual int DevType(u32 handle) {return 0;}
 };
 
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -513,6 +513,12 @@ int ISOFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
+int ISOFileSystem::DevType(u32 handle)
+{
+	EntryMap::iterator iter = entries.find(handle);
+	return iter->second.isBlockSectorMode ? PSP_DEV_TYPE_BLOCK : PSP_DEV_TYPE_FILE;
+}
+
 size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 {
 	EntryMap::iterator iter = entries.find(handle);

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -40,6 +40,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
+	int      DevType(u32 handle);
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size);
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -39,6 +39,7 @@ public:
 	size_t   SeekFile(u32 handle, s32 position, FileMove type);
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
+	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size);
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -479,6 +479,15 @@ bool MetaFileSystem::RemoveFile(const std::string &filename)
 	}
 }
 
+int MetaFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec)
+{
+	lock_guard guard(lock);
+	IFileSystem *sys = GetHandleOwner(handle);
+	if (sys)
+		return sys->Ioctl(handle, cmd, indataPtr, inlen, outdataPtr, outlen, usec);
+	return SCE_KERNEL_ERROR_ERROR;
+}
+
 void MetaFileSystem::CloseFile(u32 handle)
 {
 	lock_guard guard(lock);

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -488,6 +488,15 @@ int MetaFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 out
 	return SCE_KERNEL_ERROR_ERROR;
 }
 
+int MetaFileSystem::DevType(u32 handle)
+{
+	lock_guard guard(lock);
+	IFileSystem *sys = GetHandleOwner(handle);
+	if (sys)
+		return sys->DevType(handle);
+	return SCE_KERNEL_ERROR_ERROR;
+}
+
 void MetaFileSystem::CloseFile(u32 handle)
 {
 	lock_guard guard(lock);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -102,8 +102,7 @@ public:
 	virtual bool RmDir(const std::string &dirname);
 	virtual int  RenameFile(const std::string &from, const std::string &to);
 	virtual bool RemoveFile(const std::string &filename);
-
-	// TODO: void IoCtl(...)
+	virtual int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 
 	// Convenience helper - returns < 0 on failure.
 	int ReadEntireFile(const std::string &filename, std::vector<u8> &data);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -103,6 +103,7 @@ public:
 	virtual int  RenameFile(const std::string &from, const std::string &to);
 	virtual bool RemoveFile(const std::string &filename);
 	virtual int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
+	virtual int  DevType(u32 handle);
 
 	// Convenience helper - returns < 0 on failure.
 	int ReadEntireFile(const std::string &filename, std::vector<u8> &data);

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -498,6 +498,11 @@ bool VirtualDiscFileSystem::OwnsHandle(u32 handle) {
 	return (iter != entries.end());
 }
 
+int VirtualDiscFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {
+	// TODO: How to support these?
+	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
+}
+
 PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 	PSPFileInfo x;
 	x.name = filename;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -503,6 +503,11 @@ int VirtualDiscFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, 
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
+int VirtualDiscFileSystem::DevType(u32 handle) {
+	EntryMap::iterator iter = entries.find(handle);
+	return iter->second.type == VFILETYPE_ISO ? PSP_DEV_TYPE_BLOCK : PSP_DEV_TYPE_FILE;
+}
+
 PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 	PSPFileInfo x;
 	x.name = filename;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -37,6 +37,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
+	int      DevType(u32 handle);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	std::vector<PSPFileInfo> GetDirListing(std::string path);
 

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -36,6 +36,7 @@ public:
 	void     CloseFile(u32 handle);
 	PSPFileInfo GetFileInfo(std::string filename);
 	bool     OwnsHandle(u32 handle);
+	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	std::vector<PSPFileInfo> GetDirListing(std::string path);
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2106,6 +2106,18 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		}
 		break;
 
+	// Get current sector seek pos from UMD device file.
+	case 0x01d20001:
+		// TODO: Should work only for umd0:/, etc. not for ms0:/ or disc0:/.
+		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
+		INFO_LOG(SCEIO, "sceIoIoctl: Sector tell from file %i", id);
+		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
+			Memory::Write_U32((u32)pspFileSystem.GetSeekPos(f->handle), outdataPtr);
+		} else {
+			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+		}
+		break;
+
 	// Read raw sectors from UMD device file.
 	case 0x01f30003:
 		// TODO: Should work only for umd0:/, etc. not for ms0:/ or disc0:/.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1979,21 +1979,6 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			return (int)f->info.size;
 		break;
 
-	// Get ISO9660 path table (from open ISO9660 file.)
-	case 0x01020002:
-		// TODO: Should not work for umd0:/, ms0:/, etc.
-		// Seems like it will accept an out size > path table size, but only write path table bytes.
-		// If not big enough, returns SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT.
-		// Probably only the LE version.
-		{
-			char temp[256];
-			// We want the reported message to include the cmd, so it's unique.
-			sprintf(temp, "sceIoIoctl(%%s, %08x, %%08x, %%x, %%08x, %%x)", cmd);
-			Reporting::ReportMessage(temp, f->fullpath.c_str(), indataPtr, inlen, outdataPtr, outlen);
-			ERROR_LOG(SCEIO, "UNIMPL 0=sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outLen %08x", id,cmd,indataPtr,inlen,outdataPtr,outlen);
-		}
-		break;
-
 	// Get UMD sector size
 	case 0x01020003:
 		// TODO: Should not work for umd0:/, ms0:/, etc.


### PR DESCRIPTION
Wonder if this will fix anything, it was silently not reading before.

Also, new discovery (not handled yet): "umd1:/super duper awesome file", "umd1:/sce_lbn0x1FFFF_size0x1", etc. should all be handled exactly the same as "umd1:" afaict.

-[Unknown]
