### PR TITLE
GLES3: enable PSP-based mipmapping generation

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -204,7 +204,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	graphics->Get("StretchToDisplay", &bStretchToDisplay, false);
 	graphics->Get("TrueColor", &bTrueColor, true);
 
-	graphics->Get("MipMap", &bMipMap, false);
+	graphics->Get("MipMap", &bMipMap, true);
 
 	graphics->Get("TexScalingLevel", &iTexScalingLevel, 1);
 	graphics->Get("TexScalingType", &iTexScalingType, 0);


### PR DESCRIPTION
Tested with Outrun 2006 and definitely improved .We can see the background textures progressively rendered right now instead of pre-rendered .
