### PR TITLE
Set saveName to saveDataList instead of saveNameList in AUTOLOAD mode and SAVE mode.

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1116,14 +1116,19 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 
 	bool listEmptyFile = true;
 	if (param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTLOAD ||
-			param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTDELETE)
+		param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTDELETE)
 	{
 		listEmptyFile = false;
 	}
 
 	SceUtilitySavedataSaveName *saveNameListData;
 	bool hasMultipleFileName = false;
-	if (param->saveNameList.IsValid())
+	if (param->saveNameList.IsValid() && 
+		param->mode != SCE_UTILITY_SAVEDATA_TYPE_AUTOLOAD &&
+		param->mode != SCE_UTILITY_SAVEDATA_TYPE_SAVE)
+		// These modes seem only care about a save file.
+		// Set saveName to saveDataList instead of saveNameList.
+		// Inspired by seventh dragon 2020 1/2.
 	{
 		Clear();
 


### PR DESCRIPTION
Fix the issue that seventh dragon 2020 1/2 cannot find system savedata.

Not pretty sure if this is 100% correct,but I cannot find out which game was broken.
