### PR TITLE
Add two options to adjust the texture cache

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -187,6 +187,13 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		iAnisotropyLevel = 4;
 	}
 	graphics->Get("VertexCache", &bVertexCache, true);
+	graphics->Get("TextureBackoffCache", &bTextureBackoffCache, true);
+	// The secondary cache uses lots of VRAM, so disable by default on mobile/Xbox.
+#if !defined(USING_GLES2) && !defined(_XBOX)
+	graphics->Get("TextureSecondaryCache", &bTextureSecondaryCache, true);
+#else
+	graphics->Get("TextureSecondaryCache", &bTextureSecondaryCache, false);
+#endif
 #ifdef IOS
 	graphics->Get("VertexDecJit", &bVertexDecoderJit, iosCanUseJit);
 #else
@@ -499,6 +506,8 @@ void Config::Save() {
 		graphics->Set("ForceMaxEmulatedFPS", iForceMaxEmulatedFPS);
 		graphics->Set("AnisotropyLevel", iAnisotropyLevel);
 		graphics->Set("VertexCache", bVertexCache);
+		graphics->Set("TextureBackoffCache", bTextureBackoffCache);
+		graphics->Set("TextureSecondaryCache", bTextureSecondaryCache);
 #ifdef _WIN32
 		graphics->Set("FullScreen", bFullScreen);
 #endif

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -187,13 +187,8 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		iAnisotropyLevel = 4;
 	}
 	graphics->Get("VertexCache", &bVertexCache, true);
-	graphics->Get("TextureBackoffCache", &bTextureBackoffCache, true);
-	// The secondary cache uses lots of VRAM, so disable by default on mobile/Xbox.
-#if !defined(USING_GLES2) && !defined(_XBOX)
-	graphics->Get("TextureSecondaryCache", &bTextureSecondaryCache, true);
-#else
+	graphics->Get("TextureBackoffCache", &bTextureBackoffCache, false);
 	graphics->Get("TextureSecondaryCache", &bTextureSecondaryCache, false);
-#endif
 #ifdef IOS
 	graphics->Get("VertexDecJit", &bVertexDecoderJit, iosCanUseJit);
 #else

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -97,6 +97,8 @@ public:
 	int iWindowHeight;
 
 	bool bVertexCache;
+	bool bTextureBackoffCache;
+	bool bTextureSecondaryCache;
 	bool bVertexDecoderJit;
 	bool bFullScreen;
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -103,7 +103,7 @@ void TextureCache::Decimate() {
 	lastBoundTexture = -1;
 	int killAge = lowMemoryMode_ ? TEXTURE_KILL_AGE_LOWMEM : TEXTURE_KILL_AGE;
 	for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ) {
-		if (iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFlips) {
+		if (iter->second.lastFrame + killAge < gpuStats.numFlips) {
 			glDeleteTextures(1, &iter->second.texture);
 			cache.erase(iter++);
 		} else {
@@ -113,7 +113,8 @@ void TextureCache::Decimate() {
 
 	if (g_Config.bTextureSecondaryCache) {
 		for (TexCache::iterator iter = secondCache.begin(); iter != secondCache.end(); ) {
-			if (lowMemoryMode_ || iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFlips) {
+			// In low memory mode, we kill them all.
+			if (lowMemoryMode_ || iter->second.lastFrame + TEXTURE_SECOND_KILL_AGE < gpuStats.numFlips) {
 				glDeleteTextures(1, &iter->second.texture);
 				secondCache.erase(iter++);
 			} else {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -370,11 +370,11 @@ void *TextureCache::ReadIndexedTex(int level, u32 texaddr, int bytesPerIndex, GL
 				break;
 
 			case 2:
-				DeIndexTexture<u16>(tmpTexBuf16.data(), texaddr, length, clut);
+				DeIndexTexture<u16_le>(tmpTexBuf16.data(), texaddr, length, clut);
 				break;
 
 			case 4:
-				DeIndexTexture<u32>(tmpTexBuf16.data(), texaddr, length, clut);
+				DeIndexTexture<u32_le>(tmpTexBuf16.data(), texaddr, length, clut);
 				break;
 			}
 		} else {
@@ -410,11 +410,11 @@ void *TextureCache::ReadIndexedTex(int level, u32 texaddr, int bytesPerIndex, GL
 				break;
 
 			case 2:
-				DeIndexTexture<u16>(tmpTexBuf32.data(), texaddr, length, clut);
+				DeIndexTexture<u16_le>(tmpTexBuf32.data(), texaddr, length, clut);
 				break;
 
 			case 4:
-				DeIndexTexture<u32>(tmpTexBuf32.data(), texaddr, length, clut);
+				DeIndexTexture<u32_le>(tmpTexBuf32.data(), texaddr, length, clut);
 				break;
 			}
 			buf = tmpTexBuf32.data();
@@ -655,7 +655,7 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 
 void TextureCache::StartFrame() {
 	lastBoundTexture = -1;
-	if(clearCacheNextFrame_) {
+	if (clearCacheNextFrame_) {
 		Clear(true);
 		clearCacheNextFrame_ = false;
 	} else {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -51,14 +51,6 @@
 #define GL_UNPACK_ROW_LENGTH 0x0CF2
 #endif
 
-// TODO: This helps when you have plenty of VRAM, sometimes quite a bit.
-// But on Android, it sometimes causes out of memory that isn't recovered from.
-#if !defined(USING_GLES2) && !defined(_XBOX)
-#define USE_SECONDARY_CACHE 1
-#else
-#define USE_SECONDARY_CACHE 0
-#endif
-
 extern int g_iNumVideos;
 
 TextureCache::TextureCache() : clearCacheNextFrame_(false), lowMemoryMode_(false), clutBuf_(NULL) {
@@ -114,23 +106,29 @@ void TextureCache::Decimate() {
 		if (iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFlips) {
 			glDeleteTextures(1, &iter->second.texture);
 			cache.erase(iter++);
-		}
-		else
+		} else {
 			++iter;
-	}
-#if USE_SECONDARY_CACHE
-	for (TexCache::iterator iter = secondCache.begin(); iter != secondCache.end(); ) {
-		if (lowMemoryMode_ || iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFlips) {
-			glDeleteTextures(1, &iter->second.texture);
-			secondCache.erase(iter++);
 		}
-		else
-			++iter;
 	}
-#endif
+
+	if (g_Config.bTextureSecondaryCache) {
+		for (TexCache::iterator iter = secondCache.begin(); iter != secondCache.end(); ) {
+			if (lowMemoryMode_ || iter->second.lastFrame + TEXTURE_KILL_AGE < gpuStats.numFlips) {
+				glDeleteTextures(1, &iter->second.texture);
+				secondCache.erase(iter++);
+			} else {
+				++iter;
+			}
+		}
+	}
 }
 
 void TextureCache::Invalidate(u32 addr, int size, GPUInvalidationType type) {
+	// If we're hashing every use, without backoff, then this isn't needed.
+	if (!g_Config.bTextureBackoffCache) {
+		return;
+	}
+
 	addr &= 0x0FFFFFFF;
 	u32 addr_end = addr + size;
 
@@ -160,6 +158,11 @@ void TextureCache::Invalidate(u32 addr, int size, GPUInvalidationType type) {
 }
 
 void TextureCache::InvalidateAll(GPUInvalidationType /*unused*/) {
+	// If we're hashing every use, without backoff, then this isn't needed.
+	if (!g_Config.bTextureBackoffCache) {
+		return;
+	}
+
 	for (TexCache::iterator iter = cache.begin(), end = cache.end(); iter != end; ++iter) {
 		if ((iter->second.status & TexCacheEntry::STATUS_MASK) == TexCacheEntry::STATUS_RELIABLE) {
 			// Clear status -> STATUS_HASHING.
@@ -973,7 +976,9 @@ void TextureCache::SetTexture(bool force) {
 					hashFail = true;
 				} else if ((entry->status & TexCacheEntry::STATUS_MASK) == TexCacheEntry::STATUS_UNRELIABLE && entry->numFrames > TexCacheEntry::FRAMES_REGAIN_TRUST) {
 					// Reset to STATUS_HASHING.
-					entry->status &= ~TexCacheEntry::STATUS_MASK;
+					if (g_Config.bTextureBackoffCache) {
+						entry->status &= ~TexCacheEntry::STATUS_MASK;
+					}
 				}
 			}
 
@@ -984,27 +989,27 @@ void TextureCache::SetTexture(bool force) {
 
 				// Don't give up just yet.  Let's try the secondary cache if it's been invalidated before.
 				// If it's failed a bunch of times, then the second cache is just wasting time and VRAM.
-#if USE_SECONDARY_CACHE
-				if (entry->numInvalidated > 2 && entry->numInvalidated < 128 && !lowMemoryMode_) {
-					u64 secondKey = fullhash | (u64)cluthash << 32;
-					TexCache::iterator secondIter = secondCache.find(secondKey);
-					if (secondIter != secondCache.end()) {
-						TexCacheEntry *secondEntry = &secondIter->second;
-						if (secondEntry->Matches(dim, format, maxLevel)) {
-							// Reset the numInvalidated value lower, we got a match.
-							if (entry->numInvalidated > 8) {
-								--entry->numInvalidated;
+				if (g_Config.bTextureSecondaryCache) {
+					if (entry->numInvalidated > 2 && entry->numInvalidated < 128 && !lowMemoryMode_) {
+						u64 secondKey = fullhash | (u64)cluthash << 32;
+						TexCache::iterator secondIter = secondCache.find(secondKey);
+						if (secondIter != secondCache.end()) {
+							TexCacheEntry *secondEntry = &secondIter->second;
+							if (secondEntry->Matches(dim, format, maxLevel)) {
+								// Reset the numInvalidated value lower, we got a match.
+								if (entry->numInvalidated > 8) {
+									--entry->numInvalidated;
+								}
+								entry = secondEntry;
+								match = true;
 							}
-							entry = secondEntry;
-							match = true;
+						} else {
+							secondKey = entry->fullhash | (u64)entry->cluthash << 32;
+							secondCache[secondKey] = *entry;
+							doDelete = false;
 						}
-					} else {
-						secondKey = entry->fullhash | (u64)entry->cluthash << 32;
-						secondCache[secondKey] = *entry;
-						doDelete = false;
 					}
 				}
-#endif
 			}
 		}
 
@@ -1046,7 +1051,11 @@ void TextureCache::SetTexture(bool force) {
 		cache[cachekey] = entryNew;
 
 		entry = &cache[cachekey];
-		entry->status = TexCacheEntry::STATUS_HASHING;
+		if (g_Config.bTextureBackoffCache) {
+			entry->status = TexCacheEntry::STATUS_HASHING;
+		} else {
+			entry->status = TexCacheEntry::STATUS_UNRELIABLE;
+		}
 	}
 
 	if ((bufw == 0 || (gstate.texbufwidth[0] & 0xf800) != 0) && texaddr >= PSP_GetUserMemoryBase()) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -148,6 +148,8 @@ void GameSettingsScreen::CreateViews() {
 	graphicsSettings->Add(new CheckBox(&g_Config.bHardwareTransform, gs->T("Hardware Transform")));
 	CheckBox *swSkin = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareSkinning, gs->T("Software Skinning")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bVertexCache, gs->T("Vertex Cache")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gs->T("Lazy texture caching", "Lazy texture caching (speedup)")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bTextureSecondaryCache, gs->T("Retain changed textures", "Retain changed textures (speedup, mem hog)")));
 
 	// Seems solid, so we hide the setting.
 	// CheckBox *vtxJit = graphicsSettings->Add(new CheckBox(&g_Config.bVertexDecoderJit, gs->T("Vertex Decoder JIT")));


### PR DESCRIPTION
Recent tests on my Android and desktop show that hashing every frame is usually not very expensive (I remember it being before, though... might be worse without NEON), and gets rid of most of the glitches seen in games with text, etc.  This seems like one of the most common complaints about PPSSPP (even heard about it in person recently), so if the performance hit is not great it may not be worth it.

For this reason, I've changed it to an option, now defaulted off, to use a backoff on hashing.

The "secondary" cache also causes some glitches in games that "manually fade" textures, e.g. Crimson Gem Saga, because it makes hash collisions significantly more likely.  It seems it no longer helps FF2 really at all, so the only game I know of that it helps is Popolocrois (which it helps _significantly_, more than doubling speed from 300% -> 670% in an area with only a couple lamps.)  I guess we could even remove it if that's the only game it helps, I was always figuring there were more (maybe Tactics...)

Anyway, I've defaulted that off now too (was always off before on mobile.)

I know more options are bad but I think it's a good transitional step.

-[Unknown]
