### PR TITLE
ClearBuffer(): Clear depth to 1.0

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -157,6 +157,7 @@ static void ClearBuffer() {
 	glstate.stencilFunc.set(GL_ALWAYS, 0xFF, 0xFF);
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClearStencil(0xFF);
+	glClearDepth(1.0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 }
 


### PR DESCRIPTION
It didn't help anything .Just do similar thing as color and stencil before doing glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
