### PR TITLE
Blackberry Buildfix

### DIFF
--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "zlib.h"
+#include <stdio.h>
 
 #include "Core/System.h"
 #include "Core/FileSystems/MetaFileSystem.h"


### PR DESCRIPTION
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp: In function 'int scePauth_98B83B5D(u32, int, u32, u32)':
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:37:2: error: 'FILE' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:37:2: note: suggested alternative:
/home/travis/build/hrydgard/ppsspp/target_10_2_0_1155/qnx6//usr/include/wchar.h:82:25: note:   'std::FILE'
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:37:8: error: 'fp' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:42:28: error: 'sprintf' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:50:23: error: 'fopen' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:52:24: error: 'fseek' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:53:18: error: 'ftell' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:55:25: error: 'fread' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:56:12: error: 'fclose' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:68:30: error: 'fwrite' was not declared in this scope
/home/travis/build/hrydgard/ppsspp/Core/HLE/scePauth.cpp:69:11: error: 'fclose' was not declared in this scope
