### PR TITLE
Fix missing includes (stdio.h)

### DIFF
--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "zlib.h"
+#include <stdio.h>
 
 #include "Core/System.h"
 #include "Core/FileSystems/MetaFileSystem.h"

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -20,6 +20,7 @@
 #include "Core/MIPS/MIPSVFPUUtils.h"
 
 #include <limits>
+#include <stdio.h>
 
 #define V(i)   (currentMIPS->v[voffset[i]])
 #define VI(i)  (currentMIPS->vi[voffset[i]])


### PR DESCRIPTION
Compiling for Maemo5 needs these (gcc-4.7.2).
