### PR TITLE
Initialize m_decodingsize to 0

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -142,6 +142,7 @@ MediaEngine::MediaEngine(): m_pdata(0) {
 	m_noAudioData = false;
 	m_bufSize = 0x2000;
 	m_mpegheaderReadPos = 0;
+	m_decodingsize = 0;
 	g_iNumVideos++;
 }
 


### PR DESCRIPTION
Fixes #4609, intermittent video issues in Lunar.

_PsmfPlayerFillRingbuffer() expects getRemainSize() to return something useful even before the context is opened.

-[Unknown]
