### PR TITLE
Retry opening the mpeg context if it fails

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -188,7 +188,7 @@ void MediaEngine::closeMedia() {
 }
 
 void MediaEngine::DoState(PointerWrap &p){
-	auto s = p.Section("MediaEngine", 1);
+	auto s = p.Section("MediaEngine", 1, 2);
 	if (!s)
 		return;
 
@@ -218,6 +218,11 @@ void MediaEngine::DoState(PointerWrap &p){
 
 	p.Do(m_videopts);
 	p.Do(m_audiopts);
+
+	if (s >= 2) {
+		p.Do(m_firstTimeStamp);
+		p.Do(m_lastTimeStamp);
+	}
 
 	p.Do(m_isVideoEnd);
 	p.Do(m_noAudioData);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -344,7 +344,7 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 			m_demux->demux(m_audioStream);
 		}
 #ifdef USE_FFMPEG
-		if (!m_pFormatCtx && m_pdata->getQueueSize() >= 2048 * 5) {
+		if (!m_pFormatCtx && m_pdata->getQueueSize() >= 2048) {
 			m_pdata->get_front(m_mpegheader, sizeof(m_mpegheader));
 			int mpegoffset = bswap32(*(int*)(m_mpegheader + 8));
 			m_pdata->pop_front(0, mpegoffset);

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -60,6 +60,7 @@ public:
 	bool loadStream(u8* buffer, int readSize, int RingbufferSize);
 	// open the mpeg context
 	bool openContext();
+	void closeContext();
 
 	// Returns number of packets actually added. I guess the buffer might be full.
 	int addStreamData(u8* buffer, int addSize);


### PR DESCRIPTION
This fixes FF4 (at least the crash video, more savedata welcome), and also fixes Valkrie Profile a better way.

-[Unknown]
