### PR TITLE
Win32/Debugger: Don't crash when the virtual PSP isn't inited.

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -813,10 +813,10 @@ void CDisasm::UpdateDialog(bool _bComplete)
 	rl->redraw();						
 	// Update Debug Counter
 	wchar_t tempTicks[24];
-	if (PSP_IsInited())
-		_snwprintf(tempTicks, 24, L"%lld", CoreTiming::GetTicks()-lastTicks);
-	SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
-
+	if (PSP_IsInited()) {
+		_snwprintf(tempTicks, 24, L"%lld", CoreTiming::GetTicks() - lastTicks);
+		SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
+	}
 	// Update Register Dialog
 	for (int i=0; i<numCPUs; i++)
 		if (memoryWindow[i])

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -813,7 +813,8 @@ void CDisasm::UpdateDialog(bool _bComplete)
 	rl->redraw();						
 	// Update Debug Counter
 	wchar_t tempTicks[24];
-	_snwprintf(tempTicks, 24, L"%lld", CoreTiming::GetTicks()-lastTicks);
+	if (PSP_IsInited())
+		_snwprintf(tempTicks, 24, L"%lld", CoreTiming::GetTicks()-lastTicks);
 	SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
 
 	// Update Register Dialog


### PR DESCRIPTION
Attempts to fix https://github.com/hrydgard/ppsspp/issues/4953. It's a threading issue where the debugger tries to access currentMIPS when it's null (after the virtual PSP has been uninitialised). This seems to help.
