### PR TITLE
Only set m_audioChannel when audioChannel more than one channel

### DIFF
--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -155,7 +155,7 @@ int MpegDemux::demuxStream(bool bdemux, int startCode, int channel)
 
 void MpegDemux::demux(int audioChannel)
 {
-	if (audioChannel >= 0)
+	if (audioChannel > 1)
 		m_audioChannel = audioChannel;
 	while (m_index < m_len)
 	{


### PR DESCRIPTION
Fixes #2226
