### PR TITLE
Prevent psmfplayer from loading too many mpeg frames at once

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -867,6 +867,7 @@ int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
 	int addMax = std::max(2048 * 100, tempbufSize);
 	do {
 		size = std::min(psmfplayer->mediaengine->getRemainSize(), tempbufSize);
+		size = std::min(psmfplayer->mediaengine->getAudioRemainSize(), size);
 		size = std::min(psmfplayer->streamSize - psmfplayer->readSize, size);
 		if (size <= 0)
 			break;
@@ -891,13 +892,13 @@ int _PsmfPlayerSetPsmfOffset(PsmfPlayer *psmfplayer, const char * filename, int 
 		if (offset > 0)
 			pspFileSystem.SeekFile(psmfplayer->filehandle, offset, FILEMOVE_BEGIN);
 		u8* buf = psmfplayer->tempbuf;
-		u32 tempbufSize = sizeof(psmfplayer->tempbuf);
+		int tempbufSize = (int)sizeof(psmfplayer->tempbuf);
 		int size = (int)pspFileSystem.ReadFile(psmfplayer->filehandle, buf, 2048);
 		int mpegoffset = bswap32(*(u32*)(buf + PSMF_STREAM_OFFSET_OFFSET));
 		psmfplayer->readSize = size - mpegoffset;
 		psmfplayer->streamSize = bswap32(*(u32*)(buf + PSMF_STREAM_SIZE_OFFSET));
 		psmfplayer->fileoffset = offset + mpegoffset;
-		psmfplayer->mediaengine->loadStream(buf, 2048, std::max(2048 * 500, (int)tempbufSize));
+		psmfplayer->mediaengine->loadStream(buf, 2048, std::max(2048 * 500, tempbufSize));
 		_PsmfPlayerFillRingbuffer(psmfplayer);
 		psmfplayer->psmfPlayerLastTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
 	}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -861,16 +861,21 @@ int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
 	if (!psmfplayer->filehandle || !psmfplayer->tempbuf)
 		return -1;
 	u8* buf = psmfplayer->tempbuf;
-	u32 tempbufSize = sizeof(psmfplayer->tempbuf);
+	int tempbufSize = (int)sizeof(psmfplayer->tempbuf);
 	int size;
+	// Let's not burn a bunch of time adding data all at once.
+	int addMax = std::max(2048 * 100, tempbufSize);
 	do {
-		size = std::min(psmfplayer->mediaengine->getRemainSize(), (int)tempbufSize);
+		size = std::min(psmfplayer->mediaengine->getRemainSize(), tempbufSize);
 		size = std::min(psmfplayer->streamSize - psmfplayer->readSize, size);
 		if (size <= 0)
 			break;
 		size = (int)pspFileSystem.ReadFile(psmfplayer->filehandle, buf, size);
 		psmfplayer->readSize += size;
 		psmfplayer->mediaengine->addStreamData(buf, size);
+		addMax -= size;
+		if (addMax <= 0)
+			break;
 	} while (size > 0);
 	if (psmfplayer->readSize >= psmfplayer->streamSize && videoLoopStatus == PSMF_PLAYER_CONFIG_LOOP) {
 		// start looping

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -683,6 +683,15 @@ int MediaEngine::getRemainSize() {
 	return std::max(m_pdata->getRemainSize() - m_decodingsize - 2048, 0);
 }
 
+int MediaEngine::getAudioRemainSize() {
+	if (!m_demux) {
+		// No audio, so it can't be full, return video instead.
+		return getRemainSize();
+	}
+
+	return m_demux->getRemainSize();
+}
+
 int MediaEngine::getAudioSamples(u32 bufferPtr) {
 	if (!Memory::IsValidAddress(bufferPtr)) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -70,6 +70,7 @@ public:
 
 	u8 *getFrameImage();
 	int getRemainSize();
+	int getAudioRemainSize();
 
 	bool stepVideo(int videoPixelMode);
 	int writeVideoImage(u32 bufferPtr, int frameWidth = 512, int videoPixelMode = 3);

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -61,7 +61,7 @@ int MpegDemux::readPesHeader(PesHeader &pesHeader, int length, int startCode) {
 			break;
 		}
 	}
-		if ((c & 0xC0) == 0x40) {
+	if ((c & 0xC0) == 0x40) {
 		read8();
 		c = read8();
 		length -= 2;

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -19,6 +19,10 @@ public:
 	// return its framesize
 	int getNextaudioFrame(u8** buf, int *headerCode1, int *headerCode2);
 
+	inline int getRemainSize() {
+		return m_len - m_readSize;
+	}
+
 	void DoState(PointerWrap &p);
 
 private:


### PR DESCRIPTION
Fixes #4550 again.  Before these changes, it fills the video buffer and discards audio data that doesn't fit.  This worked before when audio data was immediately demuxed, but now that happens on first read.

Also, seems like psmfplayer doesn't bother selecting the proper video/audio streams, but I'm not sure...

Anyway, Naruto still works this way too.

Without the cap on adding too much data at once, there is a slight but noticeable pause after the first frame/audio samples, before the video continues playing.  I left the cap generously high in case it affects compatibility, but this kills the pause for me.

-[Unknown]
