### PR TITLE
Fix some video hang issues

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -740,8 +740,10 @@ s64 MediaEngine::getVideoTimeStamp() {
 }
 
 s64 MediaEngine::getAudioTimeStamp() {
+	/*
 	if (m_demux)
 		return std::max(m_audiopts - 4180, (s64)0);
+	*/
 	return m_videopts;
 }
 


### PR DESCRIPTION
Looks like the original assumption is not good enough and return not expected pts value .This fixes video issue in "The Warrior" and "Dead Head Fred"

This fixes #5003
