### PR TITLE
On desktop, blit depth when not cleared

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -863,6 +863,17 @@ void FramebufferManager::SetRenderFrameBuffer() {
 			ClearBuffer();
 		}
 #endif
+
+#ifndef USING_GLES2
+		if (gl_extensions.FBO_ARB && currentRenderVfb_ != NULL && MaskedEqual(currentRenderVfb_->z_address, vfb->z_address)) {
+			// Let's only do this if not clearing.
+			if (!gstate.isModeClear() || !gstate.isClearModeDepthMask()) {
+				fbo_bind_for_read(currentRenderVfb_->fbo);
+				glBlitFramebuffer(0, 0, currentRenderVfb_->renderWidth, currentRenderVfb_->renderHeight, 0, 0, vfb->renderWidth, vfb->renderHeight, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+			}
+		}
+#endif
+
 		currentRenderVfb_ = vfb;
 	} else {
 		vfb->last_frame_render = gpuStats.numFlips;


### PR DESCRIPTION
Workaround for #1283, makes Jeanne d'Arc playable afaict.

If hrydgard/native#185 is not merged (and native updated), it will actually make Jeanne d'Arc (and any other games not clearing depth when switching) _significantly_ worse on cards with OpenGL < 4.3.

This could work on GLES3 but it probably has a perf penalty even for games that don't need it.

-[Unknown]
