### PR TITLE
Remove obsolete option: alwaysDepthWrite

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -213,7 +213,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	graphics->Get("TexDeposterize", &bTexDeposterize, false);
 	graphics->Get("VSyncInterval", &bVSync, false);
 	graphics->Get("DisableStencilTest", &bDisableStencilTest, false);
-	graphics->Get("AlwaysDepthWrite", &bAlwaysDepthWrite, false);
 // Has been in use on Symbian since v0.7. Preferred option.
 #ifdef __SYMBIAN32__
 	graphics->Get("TimerHack", &bTimerHack, true);
@@ -515,7 +514,6 @@ void Config::Save() {
 		graphics->Set("TexDeposterize", bTexDeposterize);
 		graphics->Set("VSyncInterval", bVSync);
 		graphics->Set("DisableStencilTest", bDisableStencilTest);
-		graphics->Set("AlwaysDepthWrite", bAlwaysDepthWrite);
 		graphics->Set("TimerHack", bTimerHack);
 		graphics->Set("LowQualitySplineBezier", bLowQualitySplineBezier);
 		graphics->Set("PostShader", sPostShaderName);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -117,7 +117,6 @@ public:
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bDisableStencilTest;
-	bool bAlwaysDepthWrite;
 	bool bTimerHack;
 	bool bLowQualitySplineBezier;
 	std::string sPostShaderName;  // Off for off.

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -334,7 +334,6 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		}
 	}
 
-	bool alwaysDepthWrite = g_Config.bAlwaysDepthWrite;
 	bool enableStencilTest = !g_Config.bDisableStencilTest;
 
 	// Dither
@@ -355,7 +354,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		// Depth Test
 		glstate.depthTest.enable();
 		glstate.depthFunc.set(GL_ALWAYS);
-		glstate.depthWrite.set(gstate.isClearModeDepthMask() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
+		glstate.depthWrite.set(gstate.isClearModeDepthMask() ? GL_TRUE : GL_FALSE);
 
 		// Color Test
 		bool colorMask = gstate.isClearModeColorMask();
@@ -397,7 +396,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		if (gstate.isDepthTestEnabled()) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(ztests[gstate.getDepthTestFunction()]);
-			glstate.depthWrite.set(gstate.isDepthWriteEnabled() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
+			glstate.depthWrite.set(gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
 		} else {
 			glstate.depthTest.disable();
 		}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -19,6 +19,7 @@
 #include "base/timeutil.h"
 #include "math/curves.h"
 #include "gfx_es2/draw_buffer.h"
+#include "gfx_es2/gpu_features.h"
 #include "i18n/i18n.h"
 #include "ui/view.h"
 #include "ui/viewgroup.h"
@@ -181,11 +182,10 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTimerHack, gs->T("Timer Hack")));
-	// Maybe hide this on non-PVR?
-	graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
+	if (gl_extensions.gpuVendor == GPU_VENDOR_POWERVR)
+		graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
 	graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gs->T("Disable Stencil Test")));
-	graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
-	CheckBox *prescale = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Speedhack")));
+	CheckBox *prescale = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Hack (speedup)")));
 	if (PSP_IsInited())
 		prescale->SetEnabled(false);
 


### PR DESCRIPTION
This option should be okay to remove it and not necessary since depth clear has been implemented.
