### PR TITLE
Memory valid check on nmb.packetListHead

### DIFF
--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -121,6 +121,9 @@ struct Mbx : public KernelObject
 	{
 		u32 ptr = nmb.packetListHead;
 
+		if (Memory::IsValidAddress(nmb.packetListHead))
+			return -1;
+
 		if (nmb.numMessages == 991)
 		{
 			u32 next = Memory::Read_U32(nmb.packetListHead);


### PR DESCRIPTION
Not too sure if it's correct or not .Only add a simply check here .

Prevent invalid address pass it to Memory::Read_U32(nmb.packetListHead).

Fixes #2927
