### PR TITLE
Win32: Add an option to disable the Windows key when the emulator is the active window.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -288,7 +288,9 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	control->Get("ShowAnalogStick", &bShowTouchAnalogStick, true);
 	control->Get("ShowTouchDpad", &bShowTouchDpad, true);
 	control->Get("ShowTouchUnthrottle", &bShowTouchUnthrottle, true);
-
+#if defined(_WIN32) && !defined(USING_QT_UI)
+	control->Get("IgnoreWindowsKey", &bIgnoreWindowsKey, false);
+#endif
 #if defined(USING_GLES2)
 	std::string name = System_GetProperty(SYSPROP_NAME);
 	if (KeyMap::HasBuiltinController(name)) {
@@ -626,6 +628,9 @@ void Config::Save() {
 		control->Set("AnalogStickY", fAnalogStickY);
 		control->Set("AnalogStickScale", fAnalogStickScale);
 		control->Delete("DPadRadius");
+#if defined(_WIN32) && !defined(USING_QT_UI)
+		control->Set("IgnoreWindowsKey", bIgnoreWindowsKey);
+#endif
 
 		IniFile::Section *network = iniFile.GetOrCreateSection("Network");
 		network->Set("EnableWlan", bEnableWlan);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -60,6 +60,7 @@ public:
 	bool bPauseOnLostFocus;
 	bool bTopMost;
 	std::string sFont;
+	bool bIgnoreWindowsKey;
 #endif
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -262,6 +262,7 @@ void GameSettingsScreen::CreateViews() {
 	style->SetEnabledPtr(&g_Config.bShowTouchControls);
 
 #if defined(_WIN32) && !defined(USING_QT_UI)
+	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 	controlsSettings->Add(new CheckBox(&g_Config.bIgnoreWindowsKey, c->T("Ignore Windows Key")));
 #endif
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -261,6 +261,10 @@ void GameSettingsScreen::CreateViews() {
 	View *style = controlsSettings->Add(new PopupMultiChoice(&g_Config.iTouchButtonStyle, c->T("Button style"), touchControlStyles, 0, ARRAY_SIZE(touchControlStyles), c, screenManager()));
 	style->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+#if defined(_WIN32) && !defined(USING_QT_UI)
+	controlsSettings->Add(new CheckBox(&g_Config.bIgnoreWindowsKey, c->T("Ignore Windows Key")));
+#endif
+
 	// System
 	ViewGroup *systemSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	LinearLayout *systemSettings = new LinearLayout(ORIENT_VERTICAL);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -747,6 +747,8 @@ namespace MainWindow
 		windowTitle = title;
 	}
 
+	// Taken from http://msdn.microsoft.com/en-us/library/windows/desktop/ee416808%28v=vs.85%29.aspx and adapted
+	// to our coding style.
 	LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
 		if (nCode < 0 || nCode != HC_ACTION)
 			return CallNextHookEx(g_keyboardHook, nCode, wParam, lParam);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -104,6 +104,8 @@ static std::wstring windowTitle;
 extern bool g_TakeScreenshot;
 extern InputState input_state;
 static std::set<int> keyboardKeysDown;
+static HHOOK g_keyboardHook;
+static bool g_IsWindowActive;
 
 #define TIMER_CURSORUPDATE 1
 #define TIMER_CURSORMOVEUPDATE 2
@@ -745,9 +747,29 @@ namespace MainWindow
 		windowTitle = title;
 	}
 
+	LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
+		if (nCode < 0 || nCode != HC_ACTION)
+			return CallNextHookEx(g_keyboardHook, nCode, wParam, lParam);
+
+		bool eatKeystroke = false;
+		KBDLLHOOKSTRUCT *keyboardInfo = (KBDLLHOOKSTRUCT *)lParam;
+
+		switch (wParam)	{
+		case WM_KEYDOWN:
+		case WM_KEYUP:
+			eatKeystroke = (g_Config.bIgnoreWindowsKey && g_IsWindowActive && (keyboardInfo->vkCode == VK_LWIN || keyboardInfo->vkCode == VK_RWIN));
+			break;
+		}
+
+		if (eatKeystroke)
+			return 1;
+		else
+			return CallNextHookEx(g_keyboardHook, nCode, wParam, lParam);
+	}
+
 	BOOL Show(HINSTANCE hInstance, int nCmdShow) {
 		hInst = hInstance; // Store instance handle in our global variable.
-
+		g_keyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), 0);
 		RECT rc = DetermineWindowRectangle();
 
 		u32 style = WS_OVERLAPPEDWINDOW;
@@ -804,7 +826,7 @@ namespace MainWindow
 
 		dev[0].usUsagePage = 1;
 		dev[0].usUsage = 6;
-		dev[0].dwFlags = 0;
+		dev[0].dwFlags = RIDEV_NOHOTKEYS;
 
 		dev[1].usUsagePage = HID_USAGE_PAGE_GENERIC;
 		dev[1].usUsage = HID_USAGE_GENERIC_MOUSE;
@@ -906,6 +928,7 @@ namespace MainWindow
 		case WM_ACTIVATE:
 			if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
 				g_activeWindow = WINDOW_MAINWINDOW;
+				g_IsWindowActive = true;
 			}
 			break;
 
@@ -1073,6 +1096,7 @@ namespace MainWindow
 				bool pause = true;
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
 					g_activeWindow = WINDOW_MAINWINDOW;
+					g_IsWindowActive = true;
 					pause = false;
 				}
 				if (!noFocusPause && g_Config.bPauseOnLostFocus && globalUIState == UISTATE_INGAME) {
@@ -1089,7 +1113,7 @@ namespace MainWindow
 					KeyInput key;
 					key.deviceId = DEVICE_ID_KEYBOARD;
 					key.flags = KEY_UP;
-
+					g_IsWindowActive = false;
 					for (auto i = keyboardKeysDown.begin(); i != keyboardKeysDown.end(); ++i) {
 						key.keyCode = *i;
 						NativeKey(key);
@@ -1548,6 +1572,7 @@ namespace MainWindow
 					if (raw->data.keyboard.Message == WM_KEYDOWN || raw->data.keyboard.Message == WM_SYSKEYDOWN) {
 						key.flags = KEY_DOWN;
 						key.keyCode = windowsTransTable[GetTrueVKey(raw->data.keyboard)];
+
 						if (key.keyCode) {
 							NativeKey(key);
 							keyboardKeysDown.insert(key.keyCode);
@@ -1649,6 +1674,7 @@ namespace MainWindow
 		case WM_DESTROY:
 			KillTimer(hWnd, TIMER_CURSORUPDATE);
 			KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
+			UnhookWindowsHookEx(g_keyboardHook);
 			PostQuitMessage(0);
 			break;
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1582,6 +1582,7 @@ namespace MainWindow
 					} else if (raw->data.keyboard.Message == WM_KEYUP) {
 						key.flags = KEY_UP;
 						key.keyCode = windowsTransTable[GetTrueVKey(raw->data.keyboard)];
+
 						if (key.keyCode) {
 							NativeKey(key);
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -603,6 +603,7 @@ namespace MainWindow
 		TranslateMenuItem(ID_OPTIONS_LANGUAGE);
 		TranslateMenuItem(ID_OPTIONS_TOPMOST);
 		TranslateMenuItem(ID_OPTIONS_PAUSE_FOCUS);
+		TranslateMenuItem(ID_OPTIONS_IGNOREWINKEY);
 		TranslateMenuItem(ID_OPTIONS_MORE_SETTINGS);
 		TranslateMenuItem(ID_OPTIONS_CONTROLS);
 		TranslateMenuItem(ID_OPTIONS_STRETCHDISPLAY);
@@ -1283,6 +1284,10 @@ namespace MainWindow
 					NativeMessageReceived("language screen", "");
 					break;
 
+				case ID_OPTIONS_IGNOREWINKEY:
+					g_Config.bIgnoreWindowsKey = !g_Config.bIgnoreWindowsKey;
+					break;
+
 				case ID_OPTIONS_SCREENAUTO: SetInternalResolution(RESOLUTION_AUTO); break;
 				case ID_OPTIONS_SCREEN1X:   SetInternalResolution(RESOLUTION_NATIVE); break;
 				case ID_OPTIONS_SCREEN2X:   SetInternalResolution(RESOLUTION_2X); break;
@@ -1750,6 +1755,7 @@ namespace MainWindow
 		CHECKITEM(ID_EMULATION_SOUND, g_Config.bEnableSound);
 		CHECKITEM(ID_TEXTURESCALING_DEPOSTERIZE, g_Config.bTexDeposterize);
 		CHECKITEM(ID_EMULATION_CHEATS, g_Config.bEnableCheats);
+		CHECKITEM(ID_OPTIONS_IGNOREWINKEY, g_Config.bIgnoreWindowsKey);
 
 		static const int zoomitems[11] = {
 			ID_OPTIONS_SCREENAUTO,

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -416,6 +416,7 @@ BEGIN
     BEGIN
         MENUITEM "Keep PPSSPP On Top",                      ID_OPTIONS_TOPMOST
         MENUITEM "Pause When Not Focused",                  ID_OPTIONS_PAUSE_FOCUS
+		MENUITEM "Ignore Windows Key",                      ID_OPTIONS_IGNOREWINKEY
         MENUITEM "More Settings...",                        ID_OPTIONS_MORE_SETTINGS
         MENUITEM "Control Mapping...",                      ID_OPTIONS_CONTROLS
         MENUITEM "Language...",                             ID_OPTIONS_LANGUAGE

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -299,6 +299,7 @@
 #define ID_MEMVIEW_COPYVALUE_32          40143
 #define ID_EMULATION_SWITCH_UMD          40144
 #define ID_DEBUG_EXTRACTFILE             40145
+#define ID_OPTIONS_IGNOREWINKEY          40146
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
I don't think every keyboard comes with a hardware switch to disable the Windows key, and I'm sure we've all felt the annoyance of hitting this key by accident in the middle of an intense game.
