### PR TITLE
Fix savestates with non equal pspmodel, revert mpeg->gp

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -235,7 +235,8 @@ static void InitRingbuffer(SceMpegRingBuffer *buf, int packets, int data, int si
 	buf->dataUpperBound = data + packets * 2048;
 	buf->semaID = 0;
 	buf->mpeg = 0;
-	buf->gp = __KernelGetModuleGP(__KernelGetCurThreadModuleId());
+	// TODO: This appears in tests, but may not be in all versions.
+	//buf->gp = __KernelGetModuleGP(__KernelGetCurThreadModuleId());
 }
 
 u32 convertTimestampToDate(u32 ts) {

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -89,7 +89,8 @@ struct SceMpegRingBuffer {
 	s32_le dataUpperBound;
 	s32_le semaID; // unused?
 	u32_le mpeg; // pointer to mpeg struct, fixed up in sceMpegCreate
-	u32_le gp;
+	// TODO: This appears in tests, but may not be in all versions.
+	//u32_le gp;
 };
 
 void __MpegInit();

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -136,10 +136,16 @@ void DoState(PointerWrap &p)
 			g_MemorySize = RAM_NORMAL_SIZE;
 		g_PSPModel = PSP_MODEL_FAT;
 	} else {
+		u32 oldMemorySize = g_MemorySize;
 		p.Do(g_PSPModel);
 		p.DoMarker("PSPModel");
-		if (!g_RemasterMode)
+		if (!g_RemasterMode) {
 			g_MemorySize = g_PSPModel == PSP_MODEL_FAT ? RAM_NORMAL_SIZE : RAM_DOUBLE_SIZE;
+			if (oldMemorySize < g_MemorySize) {
+				Shutdown();
+				Init();
+			}
+		}
 	}
 
 	p.DoArray(GetPointer(PSP_GetKernelMemoryBase()), g_MemorySize);


### PR DESCRIPTION
I think the mpeg->gp might be causing a stack overflow in some versions of the mpeg lib or something.

-[Unknown]
