### PR TITLE
Win32: Remove keyboard hook and make the ignore Windows key option work properly.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1073,7 +1073,6 @@ namespace MainWindow
 				bool pause = true;
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
 					g_activeWindow = WINDOW_MAINWINDOW;
-					g_IsWindowActive = true;
 					pause = false;
 				}
 				if (!noFocusPause && g_Config.bPauseOnLostFocus && globalUIState == UISTATE_INGAME) {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -104,8 +104,6 @@ static std::wstring windowTitle;
 extern bool g_TakeScreenshot;
 extern InputState input_state;
 static std::set<int> keyboardKeysDown;
-static HHOOK g_keyboardHook;
-static bool g_IsWindowActive;
 
 #define TIMER_CURSORUPDATE 1
 #define TIMER_CURSORMOVEUPDATE 2
@@ -748,31 +746,8 @@ namespace MainWindow
 		windowTitle = title;
 	}
 
-	// Taken from http://msdn.microsoft.com/en-us/library/windows/desktop/ee416808%28v=vs.85%29.aspx and adapted
-	// to our coding style.
-	LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
-		if (nCode < 0 || nCode != HC_ACTION)
-			return CallNextHookEx(g_keyboardHook, nCode, wParam, lParam);
-
-		bool eatKeystroke = false;
-		KBDLLHOOKSTRUCT *keyboardInfo = (KBDLLHOOKSTRUCT *)lParam;
-
-		switch (wParam)	{
-		case WM_KEYDOWN:
-		case WM_KEYUP:
-			eatKeystroke = (g_Config.bIgnoreWindowsKey && g_IsWindowActive && (keyboardInfo->vkCode == VK_LWIN || keyboardInfo->vkCode == VK_RWIN));
-			break;
-		}
-
-		if (eatKeystroke)
-			return 1;
-		else
-			return CallNextHookEx(g_keyboardHook, nCode, wParam, lParam);
-	}
-
 	BOOL Show(HINSTANCE hInstance, int nCmdShow) {
 		hInst = hInstance; // Store instance handle in our global variable.
-		g_keyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), 0);
 		RECT rc = DetermineWindowRectangle();
 
 		u32 style = WS_OVERLAPPEDWINDOW;
@@ -829,7 +804,7 @@ namespace MainWindow
 
 		dev[0].usUsagePage = 1;
 		dev[0].usUsage = 6;
-		dev[0].dwFlags = RIDEV_NOHOTKEYS;
+		dev[0].dwFlags = g_Config.bIgnoreWindowsKey ? RIDEV_NOHOTKEYS : 0;
 
 		dev[1].usUsagePage = HID_USAGE_PAGE_GENERIC;
 		dev[1].usUsage = HID_USAGE_GENERIC_MOUSE;
@@ -931,7 +906,6 @@ namespace MainWindow
 		case WM_ACTIVATE:
 			if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
 				g_activeWindow = WINDOW_MAINWINDOW;
-				g_IsWindowActive = true;
 			}
 			break;
 
@@ -1116,7 +1090,6 @@ namespace MainWindow
 					KeyInput key;
 					key.deviceId = DEVICE_ID_KEYBOARD;
 					key.flags = KEY_UP;
-					g_IsWindowActive = false;
 					for (auto i = keyboardKeysDown.begin(); i != keyboardKeysDown.end(); ++i) {
 						key.keyCode = *i;
 						NativeKey(key);
@@ -1678,7 +1651,6 @@ namespace MainWindow
 		case WM_DESTROY:
 			KillTimer(hWnd, TIMER_CURSORUPDATE);
 			KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
-			UnhookWindowsHookEx(g_keyboardHook);
 			PostQuitMessage(0);
 			break;
 


### PR DESCRIPTION
The hook is useless when used with RawInput, and devices can't be re-registered dynamically, it seems, so this'll have to be one of those options that requires a restart of the emulator, unfortunately.

Should fix https://github.com/hrydgard/ppsspp/issues/5055.
