### PR TITLE
Return as ERROR_PSMF_INVALID_ID

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -764,8 +764,9 @@ u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
 		return ERROR_PSMF_NOT_FOUND;
 	}
 	DEBUG_LOG(ME, "scePsmfGetEPWithId(%08x, %i, %08x)", psmfStruct, epid, entryAddr);
+
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
-		// TODO: Just a guess.
+		ERROR_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i): invalid id", psmfStruct, epid);
 		return ERROR_PSMF_INVALID_ID;
 	}
 	if (Memory::IsValidAddress(entryAddr)) {
@@ -782,13 +783,15 @@ u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
 		return ERROR_PSMF_NOT_FOUND;
 	}
 	DEBUG_LOG(ME, "scePsmfGetEPWithTimestamp(%08x, %i, %08x)", psmfStruct, ts, entryAddr);
+
 	if (ts < psmf->presentationStartTime) {
+		ERROR_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i): invalid timestamp", psmfStruct, ts);
 		return ERROR_PSMF_INVALID_TIMESTAMP;
 	}
 
 	int epid = psmf->FindEPWithTimestamp(ts);
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
-		// TODO: Just a guess.
+		ERROR_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i): invalid id", psmfStruct, epid);
 		return ERROR_PSMF_INVALID_ID;
 	}
 
@@ -806,13 +809,15 @@ u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
 		return ERROR_PSMF_NOT_FOUND;
 	}
 	DEBUG_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i)", psmfStruct, ts);
+
 	if (ts < psmf->presentationStartTime) {
+		ERROR_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i): invalid timestamp", psmfStruct, ts);
 		return ERROR_PSMF_INVALID_TIMESTAMP;
 	}
 
 	int epid = psmf->FindEPWithTimestamp(ts);
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
-		// TODO: Just a guess.
+		ERROR_LOG(ME, "scePsmfGetEPidWithTimestamp(%08x, %i): invalid id", psmfStruct, epid);
 		return ERROR_PSMF_INVALID_ID;
 	}
 	return epid;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -766,7 +766,7 @@ u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
 	DEBUG_LOG(ME, "scePsmfGetEPWithId(%08x, %i, %08x)", psmfStruct, epid, entryAddr);
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
 		// TODO: Just a guess.
-		return ERROR_PSMF_INVALID_TIMESTAMP;
+		return ERROR_PSMF_INVALID_ID;
 	}
 	if (Memory::IsValidAddress(entryAddr)) {
 		Memory::WriteStruct(entryAddr, &psmf->EPMap[epid]);
@@ -789,7 +789,7 @@ u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
 	int epid = psmf->FindEPWithTimestamp(ts);
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
 		// TODO: Just a guess.
-		return ERROR_PSMF_INVALID_TIMESTAMP;
+		return ERROR_PSMF_INVALID_ID;
 	}
 
 	if (Memory::IsValidAddress(entryAddr)) {
@@ -813,7 +813,7 @@ u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
 	int epid = psmf->FindEPWithTimestamp(ts);
 	if (epid < 0 || epid >= (int)psmf->EPMap.size()) {
 		// TODO: Just a guess.
-		return ERROR_PSMF_INVALID_TIMESTAMP;
+		return ERROR_PSMF_INVALID_ID;
 	}
 	return epid;
 }


### PR DESCRIPTION
I think it makes more sense to return as ERROR_PSMF_INVALID_ID rather than ERROR_PSMF_INVALID_TIMESTAMP here 
