### PR TITLE
Fix buffer queue when filled in one shot

### DIFF
--- a/Core/HW/BufferQueue.h
+++ b/Core/HW/BufferQueue.h
@@ -49,7 +49,11 @@ struct BufferQueue {
 	}
 
 	inline int getQueueSize() {
-		return (end + bufQueueSize - start) % bufQueueSize;
+		if (end >= start) {
+			return end - start;
+		} else {
+			return bufQueueSize + end - start;
+		}
 	}
 
 	inline int getRemainSize() {
@@ -63,12 +67,13 @@ struct BufferQueue {
 			return false;
 		if (end + addsize <= bufQueueSize) {
 			memcpy(bufQueue + end, buf, addsize);
+			end += addsize;
 		} else {
-			int size = bufQueueSize - end;
-			memcpy(bufQueue + end, buf, size);
-			memcpy(bufQueue, buf + size, addsize - size);
+			int firstSize = bufQueueSize - end;
+			memcpy(bufQueue + end, buf, firstSize);
+			memcpy(bufQueue, buf + firstSize, addsize - firstSize);
+			end = addsize - firstSize;
 		}
-		end = (end + addsize) % bufQueueSize;
 		return true;
 	}
 
@@ -82,9 +87,9 @@ struct BufferQueue {
 			if (start + bytesgot <= bufQueueSize) {
 				memcpy(buf, bufQueue + start, bytesgot);
 			} else {
-				int size = bufQueueSize - start;
-				memcpy(buf, bufQueue + start, size);
-				memcpy(buf + size, bufQueue, bytesgot - size);
+				int firstSize = bufQueueSize - start;
+				memcpy(buf, bufQueue + start, firstSize);
+				memcpy(buf + firstSize, bufQueue, bytesgot - firstSize);
 			}
 		}
 		start = (start + bytesgot) % bufQueueSize;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -330,6 +330,7 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 		if (!m_pdata->push(buffer, size)) 
 			size  = 0;
 		if (m_demux) {
+			m_noAudioData = false;
 			m_demux->addStreamData(buffer, addSize);
 		}
 #ifdef USE_FFMPEG


### PR DESCRIPTION
It would mod by the size and think it was empty, even though it had plenty of data.  This could happen if a game creates a ringbuffer with 512 packets and then does a single put operation with 512 packets.

Such behavior is rare though, since it will cause lag in starting the video.  But, may fix some game or possibly music (since this is used for atrac also.)

-[Unknown]
