### PR TITLE
The total size of umd0: is in blocks

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -192,7 +192,7 @@ ISOFileSystem::ISOFileSystem(IHandleAllocator *_hAlloc, BlockDevice *_blockDevic
 	entireISO.name = "";
 	entireISO.isDirectory = false;
 	entireISO.startingPosition = 0;
-	entireISO.size = _blockDevice->GetNumBlocks() * _blockDevice->GetBlockSize();
+	entireISO.size = _blockDevice->GetNumBlocks();
 	entireISO.flags = 0;
 	entireISO.parent = NULL;
 


### PR DESCRIPTION
Therefore sceIoLseek(umd0:, 0, 2) should return the number of blocks, not the number of bytes, in the iso.

Looks like this may help Zero no Kiseki.

-[Unknown]
