### PR TITLE
Rotate UVs and fix crash in softgpu

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -15,10 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "../GPUState.h"
+#include <algorithm>
 
-#include "Clipper.h"
-#include "Rasterizer.h"
+#include "GPU/GPUState.h"
+
+#include "GPU/Software/Clipper.h"
+#include "GPU/Software/Rasterizer.h"
 
 namespace Clipper {
 
@@ -123,6 +125,17 @@ static inline int CalcClipMask(const ClipCoords& v)
 	}															\
 }
 
+static void RotateUVThrough(VertexData &tl, VertexData &tr, VertexData &bl, VertexData &br) {
+	const fixed16 x1 = tl.screenpos.x;
+	const fixed16 x2 = br.screenpos.x;
+	const fixed16 y1 = tl.screenpos.y;
+	const fixed16 y2 = br.screenpos.y;
+
+	if ((x1 < x2 && y1 > y2) || (x1 > x2 && y1 < y2)) {
+		std::swap(bl.texturecoords, tr.texturecoords);
+	}
+}
+
 void ProcessQuad(const VertexData& v0, const VertexData& v1)
 {
 	if (!gstate.isModeThrough()) {
@@ -197,6 +210,8 @@ void ProcessQuad(const VertexData& v0, const VertexData& v1)
 			if (buf[i].screenpos.x > bottomright->screenpos.x && buf[i].screenpos.y > bottomright->screenpos.y)
 				bottomright = &buf[i];
 		}
+
+		RotateUVThrough(*topleft, *topright, *bottomleft, *bottomright);
 
 		// Four triangles to do backfaces as well. Two of them will get backface culled.
 		Rasterizer::DrawTriangle(*topleft, *topright, *bottomright);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -172,7 +172,8 @@ SoftGPU::~SoftGPU()
 }
 
 void SoftGPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {
-	displayFramebuf_ = framebuf;
+	// Seems like this can point into RAM, but should be VRAM if not in RAM.
+	displayFramebuf_ = (framebuf & 0xFF000000) == 0 ? 0x44000000 | framebuf : framebuf;
 	displayStride_ = stride;
 	displayFormat_ = format;
 	host->GPUNotifyDisplay(framebuf, stride, format);


### PR DESCRIPTION
This rotation logic is just copied from GLES.  I'm sure it's right and it fixes some glitches, but I don't really understand why it happens...

-[Unknown]
