### PR TITLE
Double colors only when texturing, and after test

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1007,12 +1007,6 @@ void DrawTriangleSlice(
 					prim_color_a = out.a();
 				}
 
-				if (gstate.isColorDoublingEnabled() && !clearMode) {
-					// TODO: Do we need to clamp here?
-					prim_color_rgb *= 2;
-					sec_color *= 2;
-				}
-
 				if (!clearMode)
 					prim_color_rgb += sec_color;
 
@@ -1071,6 +1065,11 @@ void DrawTriangleSlice(
 					Vec4<int> dst = Vec4<int>::FromRGBA(GetPixelColor(p.x, p.y));
 					prim_color_rgb = AlphaBlendingResult(prim_color_rgb, prim_color_a, dst);
 				}
+
+				if (gstate.isTextureMapEnabled() && gstate.isColorDoublingEnabled() && !clearMode) {
+					prim_color_rgb *= 2;
+				}
+
 				if (!clearMode)
 					prim_color_rgb = prim_color_rgb.Clamp(0, 255);
 


### PR DESCRIPTION
Per tests.  It definitely does nothing when texturing is disabled, which makes sense since it's part of a texturing register.

But, it does double the result of the texture func (not just the texture color), and it definitely applies after the color test was applied (which is applied on the result of the texture func, undoubled.)

Not sure if the alpha doubling (which is really for blending...) should be applied after the fog or not...

-[Unknown]
