### PR TITLE
Win32: Fix infinite loading on Peace Walker

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -809,7 +809,7 @@ u32 sceNetAdhocctlAddHandler(u32 handlerPtr, u32 handlerArg) {
 
 	if (!foundHandler && Memory::IsValidAddress(handlerPtr)) {
 		if (adhocctlHandlers.size() >= MAX_ADHOCCTL_HANDLERS) {
-			ERROR_LOG(SCENET, "UNTESTED UNTESTED sceNetAdhocctlAddHandler(%x, %x): Too many handlers", handlerPtr, handlerArg);
+			ERROR_LOG(SCENET, "UNTESTED sceNetAdhocctlAddHandler(%x, %x): Too many handlers", handlerPtr, handlerArg);
 			retval = ERROR_NET_ADHOCCTL_TOO_MANY_HANDLERS;
 			return retval;
 		}
@@ -891,6 +891,7 @@ u32 sceNetAdhocctlDelHandler(u32 handlerID) {
 int sceNetAdhocctlTerm() {
 	DEBUG_LOG(SCENET, "sceNetAdhocctlTerm()");
 	if (!g_Config.bEnableWlan) {
+		netAdhocctlInited = false;
 		return 0;
 	}
 
@@ -1009,6 +1010,7 @@ int sceNetAdhocctlJoinEnterGameMode(const char *groupName, const char *macAddr, 
 int sceNetAdhocTerm() {
 	DEBUG_LOG(SCENET, "sceNetAdhocTerm()");
 	if (!g_Config.bEnableWlan) {
+		netAdhocInited = false;
 		return 0;
 	}
 


### PR DESCRIPTION
Not sure if this'll fix the perpetually broken status on Android, but it brings the game back to a usable status on Windows, at least. These booleans can and will break Peace Walker if they're not set to false properly.

Without this, the game hangs on subsequent missions (e.g. you complete a mission, then pick another one, and it hangs forever).
