### PR TITLE
UI: Toggle to select PSP models (1000, 2000/3000)

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -313,6 +313,8 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->SetSpacing(0);
 
 	systemSettings->Add(new ItemHeader(s->T("PSP Settings")));
+	static const char *models[] = {"PSP-2000/3000", "PSP-1000"};
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, s->T("PSP Model"), models, 0, ARRAY_SIZE(models), s, screenManager()));
 	// TODO: Come up with a way to display a keyboard for mobile users,
 	// so until then, this is Windows/Desktop only.
 #if defined(_WIN32) || defined(USING_QT_UI)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -313,7 +313,7 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->SetSpacing(0);
 
 	systemSettings->Add(new ItemHeader(s->T("PSP Settings")));
-	static const char *models[] = {"PSP-2000/3000", "PSP-1000"};
+	static const char *models[] = {"PSP-1000" , "PSP-2000/3000"};
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, s->T("PSP Model"), models, 0, ARRAY_SIZE(models), s, screenManager()));
 	// TODO: Come up with a way to display a keyboard for mobile users,
 	// so until then, this is Windows/Desktop only.


### PR DESCRIPTION
I think may not be all ppl here agree to have this option here.

Default now is PSP-1000

PSP-1000 - for homebrew
PSP-2000 - for multiplayer game like FF Type-0 , God Eat Buster 2

There are some games required PSP-2000 to run properly , like Killzone Liberation , WWE SMVR 2011
