### PR TITLE
Fix buffer queue again.

### DIFF
--- a/Core/HW/BufferQueue.h
+++ b/Core/HW/BufferQueue.h
@@ -86,13 +86,20 @@ struct BufferQueue {
 		if (buf) {
 			if (start + bytesgot <= bufQueueSize) {
 				memcpy(buf, bufQueue + start, bytesgot);
+				start += bytesgot;
 			} else {
 				int firstSize = bufQueueSize - start;
 				memcpy(buf, bufQueue + start, firstSize);
 				memcpy(buf + firstSize, bufQueue, bytesgot - firstSize);
+				start = bytesgot - firstSize;
 			}
+		} else {
+			int firstSize = bufQueueSize - start;
+			if (start + bytesgot <= bufQueueSize)
+				start += bytesgot;
+			else 
+				start = bytesgot - firstSize;
 		}
-		start = (start + bytesgot) % bufQueueSize;
 		return bytesgot;
 	}
 


### PR DESCRIPTION
I noticed #5073 fixed video in Genso Suikoden - Tsumugareshi Hyakunen no Toki,but caused character voice repeat all the time.

The end of buffer quene was set correctly by #5073,but start not.
This fixed the issue.
