### PR TITLE
Key off the envelope when the VAG/etc. ends

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -350,6 +350,7 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 				// NOTICE_LOG(SAS, "Hit end of VAG audio");
 				playing = false;
 				on = false;  // ??
+				envelope.KeyOff();
 			}
 		}
 		break;
@@ -378,6 +379,7 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 				// Hit atrac3 voice end
 				playing = false;
 				on = false;  // ??
+				envelope.KeyOff();
 			}
 		}
 		break;


### PR DESCRIPTION
Fixes Yu-Gi-Oh Tag Force GX 3 hanging in some places, and fixes #2801.

I tested other games using VAG/etc. and they seemed fine to me, but this could probably use more testing.  Probably need extensive SAS autotests, really...

-[Unknown]
