### PR TITLE
Tell media engine to change channel when psmf specifies stream.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -336,7 +336,7 @@ void __MpegInit() {
 }
 
 void __MpegDoState(PointerWrap &p) {
-	auto s = p.Section("sceMpeg", 1);
+	auto s = p.Section("sceMpeg", 1, 2);
 	if (!s)
 		return;
 
@@ -345,7 +345,8 @@ void __MpegDoState(PointerWrap &p) {
 	p.Do(isCurrentMpegAnalyzed);
 	p.Do(isMpegInit);
 	p.Do(actionPostPut);
-	p.Do(RegisteredMpeg);
+	if (s >= 2)
+		p.Do(RegisteredMpeg);
 	__KernelRestoreActionType(actionPostPut, PostPutAction::Create);
 
 	p.Do(mpegMap);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1103,8 +1103,6 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		return -1;
 	}
 
-	ctx->mediaengine->setVideoStream(streamInfo->second.num);
-
 	if (streamInfo->second.needsReset) {
 		sceAu.pts = 0;
 		streamInfo->second.needsReset = false;
@@ -1184,9 +1182,7 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		sceAu.pts = 0;
 		streamInfo->second.needsReset = false;
 	}
-	if (streamInfo != ctx->streamMap.end())
-		ctx->mediaengine->setAudioStream(streamInfo->second.num);
-	else
+	if (streamInfo == ctx->streamMap.end())
 		WARN_LOG_REPORT(ME, "sceMpegGetAtracAu: invalid audio stream %08x", streamId);
 
 	// The audio can end earlier than the video does.

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -16,7 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 
-// This code is part shamelessly "inspired" from JPSCP.
+// This code is part shamelessly "inspired" from JPCSP.
 #include <map>
 #include <algorithm>
 

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -97,4 +97,7 @@ void __MpegInit();
 void __MpegDoState(PointerWrap &p);
 void __MpegShutdown();
 
+void __MpegChangeVideoChannel(int channel);
+void __MpegChangeAudioChannel(int channel);
+
 void Register_sceMpeg();

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -385,7 +385,8 @@ void Psmf::setStreamNum(int num) {
 	switch (type) {
 	case PSMF_AVC_STREAM:
 		if (currentVideoStreamNum != num) {
-			// TODO: Tell video mediaengine or something about channel.
+			// Tell video mediaengine about channel.
+			__MpegChangeVideoChannel(channel);
 			currentVideoStreamNum = num;
 		}
 		break;
@@ -393,7 +394,8 @@ void Psmf::setStreamNum(int num) {
 	case PSMF_ATRAC_STREAM:
 	case PSMF_PCM_STREAM:
 		if (currentAudioStreamNum != num) {
-			// TODO: Tell audio mediaengine or something about channel.
+			// Tell audio mediaengine about channel.
+			__MpegChangeAudioChannel(channel);
 			currentAudioStreamNum = num;
 		}
 		break;


### PR DESCRIPTION
Idolmaster use scePsmfSpecifyStreamWithStreamTypeNumber to specify streams and change streams,now Idolmaster Shiny Festa Honey works fine to me.Maybe help other games using scePsmfSpecifyStreamWithStreamTypeNumber/scePsmfSpecifyStreamWithStreamType.

 I found #4993 produced the same issue like #5075 in other games like Naruto Shippuden UN Heroes 3(US).
Since #5073,I tested Naruto Shippuden UN Heroes 3(US) and can go in-game even if not Set the audio/video streams per sceMpegGet*Au(),I think the problem of #2226 might be buffer queue issue,so I  remove that to fix #5075 and other same issue.Not pretty sure though.
