### PR TITLE
Implement line texturing and allow force nearest (softgpu)

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -136,7 +136,7 @@ static void RotateUVThrough(VertexData &tl, VertexData &tr, VertexData &bl, Vert
 	}
 }
 
-void ProcessQuad(const VertexData& v0, const VertexData& v1)
+void ProcessRect(const VertexData& v0, const VertexData& v1)
 {
 	if (!gstate.isModeThrough()) {
 		VertexData buf[4];

--- a/GPU/Software/Clipper.h
+++ b/GPU/Software/Clipper.h
@@ -24,6 +24,6 @@ namespace Clipper {
 void ProcessPoint(VertexData& v0);
 void ProcessLine(VertexData& v0, VertexData& v1);
 void ProcessTriangle(VertexData& v0, VertexData& v1, VertexData& v2);
-void ProcessQuad(const VertexData& v0, const VertexData& v1);
+void ProcessRect(const VertexData& v0, const VertexData& v1);
 
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -18,6 +18,7 @@
 #include "base/basictypes.h"
 
 #include "Common/ThreadPools.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "GPU/GPUState.h"
@@ -858,6 +859,14 @@ void DrawTriangleSlice(
 	int maxTexLevel = (gstate.texmode >> 16) & 7;
 	u8 *texptr[8] = {NULL};
 
+	int magFilt = (gstate.texfilter>>8) & 1;
+	if (g_Config.iTexFiltering > 1) {
+		if (g_Config.iTexFiltering == 2) {
+			magFilt = 0;
+		} else if (g_Config.iTexFiltering == 3) {
+			magFilt = 1;
+		}
+	}
 	if ((gstate.texfilter & 4) == 0) {
 		// No mipmapping enabled
 		maxTexLevel = 0;
@@ -937,8 +946,6 @@ void DrawTriangleSlice(
 					int frac_u, frac_v;
 
 					int texlevel = 0;
-					
-					int magFilt = (gstate.texfilter>>8) & 1;
 
 					bool bilinear = magFilt != 0;
 					// bilinear = false;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -881,13 +881,15 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, Vec3<int> prim_color_
 		SetPixelDepth(p.x, p.y, z);
 	}
 
+	// Doubling happens only when texturing is enabled, and after tests.
+	if (gstate.isTextureMapEnabled() && gstate.isColorDoublingEnabled() && !clearMode) {
+		// TODO: Does this need to be clamped before blending?
+		prim_color_rgb *= 2;
+	}
+
 	if (gstate.isAlphaBlendEnabled() && !clearMode) {
 		Vec4<int> dst = Vec4<int>::FromRGBA(GetPixelColor(p.x, p.y));
 		prim_color_rgb = AlphaBlendingResult(prim_color_rgb, prim_color_a, dst);
-	}
-
-	if (gstate.isTextureMapEnabled() && gstate.isColorDoublingEnabled() && !clearMode) {
-		prim_color_rgb *= 2;
 	}
 
 	if (!clearMode)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1146,7 +1146,16 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 		GlobalThreadPool::Loop(std::bind(&DrawTriangleSlice<false>, v0, v1, v2, minX, minY, maxX, maxY, placeholder::_1, placeholder::_2), 0, range);
 }
 
-void DrawPixel(ScreenCoords pos, Vec3<int> prim_color_rgb, int prim_color_a, Vec3<int> sec_color, float s, float t) {
+void DrawPoint(const VertexData &v0)
+{
+	ScreenCoords pos = v0.screenpos;
+	Vec3<int> prim_color_rgb = v0.color0.rgb();
+	int prim_color_a = v0.color0.a();
+	Vec3<int> sec_color = v0.color1;
+	// TODO: UVGenMode?
+	float s = v0.texturecoords.s();
+	float t = v0.texturecoords.t();
+
 	ScreenCoords scissorTL(TransformUnit::DrawingToScreen(DrawingCoords(gstate.getScissorX1(), gstate.getScissorY1(), 0)));
 	ScreenCoords scissorBR(TransformUnit::DrawingToScreen(DrawingCoords(gstate.getScissorX2(), gstate.getScissorY2(), 0)));
 
@@ -1214,12 +1223,6 @@ void DrawPixel(ScreenCoords pos, Vec3<int> prim_color_rgb, int prim_color_a, Vec
 	} else {
 		DrawSinglePixel<false>(p, z, prim_color_rgb, prim_color_a);
 	}
-}
-
-void DrawPoint(const VertexData &v0)
-{
-	// TODO: UVGenMode?
-	DrawPixel(v0.screenpos, v0.color0.rgb(), v0.color0.a(), v0.color1, v0.texturecoords.s(), v0.texturecoords.t());
 }
 
 void DrawLine(const VertexData &v0, const VertexData &v1)

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -352,7 +352,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, u32 prim_type
 				}
 
 				case GE_PRIM_RECTANGLES:
-					Clipper::ProcessQuad(data[0], data[1]);
+					Clipper::ProcessRect(data[0], data[1]);
 					break;
 
 				case GE_PRIM_LINES:


### PR DESCRIPTION
This allows forcing nearest, which is actually much faster (though uglier.)  Forcing linear can workaround #4853 but causes other artifacts.

Also reorganizes code so that lines and points can texture.  Hexyz Force uses textured lines in its (not very good looking imho) title appearance animation.  Performance is pretty awful when it's doing this but this makes it better and actually render somewhat correctly.

Also applies #5122 since I changed the code and figure it might be right (I'm really not sure, but if it fixes a game I guess it probably is.)

-[Unknown]
