### PR TITLE
Do the same way as sceAu.dts (sceMpegGetAvcAu)

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1167,6 +1167,7 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	int result = 0;
 
 	sceAu.pts = ctx->mediaengine->getAudioTimeStamp() + ctx->mpegFirstTimestamp;
+	sceAu.dts = sceAu.pts - audioTimestampStep;
 	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(ME, "video end reach. pts: %i dts: %i", (int)sceAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		mpegRingbuffer.packetsFree = mpegRingbuffer.packets;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -42,6 +42,9 @@ static const int TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888 = 0x03;
 
 int g_iNumVideos = 0;
 
+static const int videoTimestampStep = 3003;       // Value based on pmfplayer (mpegTimestampPerSecond / 29.970 (fps)).
+static const int audioTimestampStep = 4180;       // For audio play at 44100 Hz (2048 samples / 44100 * mpegTimestampPerSecond == 4180)
+
 #ifdef USE_FFMPEG
 static AVPixelFormat getSwsFormat(int pspFormat)
 {
@@ -441,7 +444,7 @@ void MediaEngine::updateSwsFormat(int videoPixelMode) {
 
 bool MediaEngine::stepVideo(int videoPixelMode) {
 	// if video engine is broken, force to add timestamp
-	m_videopts += 3003;
+	m_videopts += videoTimestampStep;
 #ifdef USE_FFMPEG
 	if (!m_pFormatCtx)
 		return false;
@@ -731,7 +734,7 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 			outbuf[i * 2 + 1] = sample;
 		}
 	}
-	m_audiopts += 4180;
+	m_audiopts += audioTimestampStep;
 	m_noAudioData = false;
 	return 0x2000;
 }

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -741,9 +741,7 @@ s64 MediaEngine::getVideoTimeStamp() {
 }
 
 s64 MediaEngine::getAudioTimeStamp() {
-	if (m_demux)
-		return std::max(m_audiopts - 4180, (s64)0);
-	return m_videopts;
+	return m_audiopts;
 }
 
 s64 MediaEngine::getLastTimeStamp() {


### PR DESCRIPTION
This is not fixing anything .Just doing the subtraction inside sceMpeg and getAudioTimeStamp() return m_audiopts instead of m_videopts
