### PR TITLE
Don't truncate spline/bezier through mode

### DIFF
--- a/GPU/GLES/Spline.cpp
+++ b/GPU/GLES/Spline.cpp
@@ -124,7 +124,7 @@ u32 TransformDrawEngine::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inP
 	}
 
 	// Okay, there we are! Return the new type (but keep the index bits)
-	return GE_VTYPE_TC_FLOAT | GE_VTYPE_COL_8888 | GE_VTYPE_NRM_FLOAT | GE_VTYPE_POS_FLOAT | (vertType & GE_VTYPE_IDX_MASK);
+	return GE_VTYPE_TC_FLOAT | GE_VTYPE_COL_8888 | GE_VTYPE_NRM_FLOAT | GE_VTYPE_POS_FLOAT | (vertType & (GE_VTYPE_IDX_MASK | GE_VTYPE_THROUGH));
 }
 
 u32 TransformDrawEngine::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType) {


### PR DESCRIPTION
~~This is just to test whether it breaks stuff in addition to fixing  #5087~~

~~I need people to test whether enabling this breaks other games that use Bezier Splines.~~

~~The issue is that not enabling it transforms the Bezier Splines with the Matricies and that transforms it out of screen for some like Toaru Kagaku no Railgun. I'm presuming this didn't break more games because they usually clean their matricies.~~

~~PLEASE DON'T MERGE YET, we really don't need more config options~~

edit: should be good now

Don't truncate the through mode bit in the vertex type during
normalization. Normalization is used to convert different vertex types
to a singular normalized one but the through-mode bit should be preserved.

This only affects (fixes) spline and bezier draw commands. The only thing
that was broken was games that drew splines/beziers with through-mode and
have matricies that differ significantly from the identity (didn't load
identity before drawing).

This should not break anything and fix #5087 .
