### PR TITLE
PSP-2000/3000 : Attempt to set main memory as 62M

### DIFF
--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -87,7 +87,8 @@ enum
 	RAM_NORMAL_MASK = RAM_NORMAL_SIZE - 1,
 
 	// Used if the PSP model is PSP-2000 (Slim).
-	RAM_DOUBLE_SIZE = RAM_NORMAL_SIZE * 2,
+	// Try to set it as 62M 
+	RAM_DOUBLE_SIZE = 0x03E00000,
 
 	VRAM_SIZE			 = 0x200000,
 	VRAM_MASK			 = VRAM_SIZE - 1,


### PR DESCRIPTION
I think may be on real PSP-2000/3000, it is not exactly allocate full 64M though need more testing .It still works fine for HD Remaster game like MH3 HD (Thanks @daniel299)

Also make #2183 better and no more need to switch back to PSP-1000 to run it .
