### PR TITLE
Eat some cycles in a few minor places

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -446,6 +446,7 @@ int sceCtrlGetIdleCancelThreshold(u32 idleResetPtr, u32 idleBackPtr)
 void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, false, false);
+	hleEatCycles(330);
 	if (done != 0)
 	{
 		RETURN(done);
@@ -462,6 +463,7 @@ void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 void sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, true, false);
+	hleEatCycles(330);
 	if (done != 0)
 	{
 		RETURN(done);
@@ -479,6 +481,7 @@ int sceCtrlPeekBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, false, true);
 	DEBUG_LOG(SCECTRL, "%d=sceCtrlPeekBufferPositive(%08x, %i)", done, ctrlDataPtr, nBufs);
+	hleEatCycles(330);
 	return done;
 }
 
@@ -486,6 +489,7 @@ int sceCtrlPeekBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, true, true);
 	DEBUG_LOG(SCECTRL, "%d=sceCtrlPeekBufferNegative(%08x, %i)", done, ctrlDataPtr, nBufs);
+	hleEatCycles(330);
 	return done;
 }
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -629,6 +629,7 @@ u32 sceDisplaySetMode(int displayMode, int displayWidth, int displayHeight) {
 u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) {
 	FrameBufferState fbstate;
 	DEBUG_LOG(SCEDISPLAY,"sceDisplaySetFramebuf(topaddr=%08x,linesize=%d,pixelsize=%d,sync=%d)", topaddr, linesize, pixelformat, sync);
+	hleEatCycles(290);
 	if (topaddr == 0) {
 		DEBUG_LOG(SCEDISPLAY,"- screen off");
 	} else {

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -313,6 +313,7 @@ u32 sceGeEdramGetAddr()
 {
 	u32 retVal = 0x04000000;
 	DEBUG_LOG(SCEGE, "%08x = sceGeEdramGetAddr", retVal);
+	hleEatCycles(150);
 	return retVal;
 }
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -341,6 +341,7 @@ int sceKernelDcacheInvalidateRange(u32 addr, int size)
 		if (addr != 0)
 			gpu->InvalidateCache(addr, size, GPU_INVALIDATE_HINT);
 	}
+	hleEatCycles(190);
 	return 0;
 }
 
@@ -358,6 +359,7 @@ int sceKernelDcacheWritebackAll()
 	// Some games seem to use this a lot, it doesn't make sense
 	// to zap the whole texture cache.
 	gpu->InvalidateCache(0, -1, GPU_INVALIDATE_ALL);
+	hleEatCycles(3524);
 	return 0;
 }
 
@@ -372,6 +374,7 @@ int sceKernelDcacheWritebackRange(u32 addr, int size)
 	if (size > 0 && addr != 0) {
 		gpu->InvalidateCache(addr, size, GPU_INVALIDATE_HINT);
 	}
+	hleEatCycles(165);
 	return 0;
 }
 int sceKernelDcacheWritebackInvalidateRange(u32 addr, int size)
@@ -385,6 +388,7 @@ int sceKernelDcacheWritebackInvalidateRange(u32 addr, int size)
 	if (size > 0 && addr != 0) {
 		gpu->InvalidateCache(addr, size, GPU_INVALIDATE_HINT);
 	}
+	hleEatCycles(165);
 	return 0;
 }
 int sceKernelDcacheWritebackInvalidateAll()
@@ -393,6 +397,7 @@ int sceKernelDcacheWritebackInvalidateAll()
 	NOTICE_LOG(CPU,"sceKernelDcacheInvalidateAll()");
 #endif
 	gpu->InvalidateCache(0, -1, GPU_INVALIDATE_ALL);
+	hleEatCycles(1165);
 	return 0;
 }
 

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -296,6 +296,7 @@ u32 sceKernelClearEventFlag(SceUID id, u32 bits)
 		DEBUG_LOG(SCEKERNEL, "sceKernelClearEventFlag(%i, %08x)", id, bits);
 		e->nef.currentPattern &= bits;
 		// Note that it's not possible for threads to get woken up by this action.
+		hleEatCycles(430);
 		return 0;
 	}
 	else
@@ -350,6 +351,7 @@ u32 sceKernelSetEventFlag(SceUID id, u32 bitsToSet)
 		if (wokeThreads)
 			hleReSchedule("event flag set");
 
+		hleEatCycles(430);
 		return 0;
 	}
 	else
@@ -466,6 +468,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 		else
 			DEBUG_LOG(SCEKERNEL, "0=sceKernelWaitEventFlag(%i, %08x, %i, %08x, %08x)", id, bits, wait, outBitsPtr, timeoutPtr);
 
+		hleEatCycles(600);
 		return 0;
 	}
 	else

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -84,6 +84,7 @@ void sceKernelCpuSuspendIntr()
 	{
 		returnValue = 0;
 	}
+	hleEatCycles(15);
 	RETURN(returnValue);
 }
 
@@ -100,6 +101,7 @@ void sceKernelCpuResumeIntr(u32 enable)
 	{
 		__DisableInterrupts();
 	}
+	hleEatCycles(15);
 }
 
 void sceKernelIsCpuIntrEnable()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2316,6 +2316,7 @@ u32 sceKernelSuspendDispatchThread()
 	u32 oldDispatchEnabled = dispatchEnabled;
 	dispatchEnabled = false;
 	DEBUG_LOG(SCEKERNEL, "%i=sceKernelSuspendDispatchThread()", oldDispatchEnabled);
+	hleEatCycles(940);
 	return oldDispatchEnabled;
 }
 
@@ -2331,6 +2332,7 @@ u32 sceKernelResumeDispatchThread(u32 enabled)
 	dispatchEnabled = enabled != 0;
 	DEBUG_LOG(SCEKERNEL, "sceKernelResumeDispatchThread(%i) - from %i", enabled, oldDispatchEnabled);
 	hleReSchedule("dispatch resumed");
+	hleEatCycles(940);
 	return 0;
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2483,6 +2483,7 @@ u32 __KernelGetCurThreadStack()
 SceUID sceKernelGetThreadId()
 {
 	VERBOSE_LOG(SCEKERNEL, "%i = sceKernelGetThreadId()", currentThread);
+	hleEatCycles(180);
 	return currentThread;
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -3650,6 +3650,7 @@ void sceKernelCheckCallback()
 	} else {
 		RETURN(0);
 	}
+	hleEatCycles(230);
 }
 
 bool __KernelInCallback()


### PR DESCRIPTION
I originally did this quite some time ago to try to improve perf/stutter in some game (these were basically the only funcs it was calling in its main loop.)

It didn't end up helping that much, but I found a few games that were improved by sceKernelCheckCallback() eating cycles.  Since I already measured these funcs, we might as well eat cycles in them.  May improve performance and stutter, if only slightly, in several games where these funcs are used in loops.

-[Unknown]
