### PR TITLE
Load games asynchronously (instead of stalling), fix keyboard

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -143,7 +143,7 @@ static inline void UpdateRunLoop() {
 }
 
 void Core_RunLoop() {
-	while (globalUIState != UISTATE_INGAME && globalUIState != UISTATE_EXIT) {
+	while ((globalUIState != UISTATE_INGAME || !PSP_IsInited()) && globalUIState != UISTATE_EXIT) {
 		time_update();
 
 #if defined(_WIN32) && !defined(USING_QT_UI)

--- a/Core/System.h
+++ b/Core/System.h
@@ -49,6 +49,9 @@ extern GlobalUIState globalUIState;
 void UpdateUIState(GlobalUIState newState);
 
 bool PSP_Init(const CoreParameter &coreParam, std::string *error_string);
+bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string);
+bool PSP_InitUpdate(std::string *error_string);
+bool PSP_IsIniting();
 bool PSP_IsInited();
 void PSP_Shutdown();
 void PSP_RunLoopUntil(u64 globalticks);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -48,6 +48,7 @@ protected:
 
 private:
 	void bootGame(const std::string &filename);
+	void bootComplete();
 	void processAxis(const AxisInput &axis, int direction);
 
 	void pspKey(int pspKeyCode, int flags);


### PR DESCRIPTION
~~Keyboards were broken on some systems, I reproduced it.  This seems to fix it.~~ Pushed it directly, seemed to be affecting most everyone.

Also, this makes (multithreaded only) game loading asynchronous.  It's not faster, but the UI updates quicker.  If the disc is slow, it's from network, or your disk needs to spin up, this looks nicer.

-[Unknown]
