### PR TITLE
Duplicate framebuffers that are rendered onto themselves

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -740,8 +740,10 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_REGION1:
 	case GE_CMD_REGION2:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_CLIPENABLE:
@@ -830,8 +832,10 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFPTR:
 	case GE_CMD_FRAMEBUFWIDTH:
 	case GE_CMD_FRAMEBUFPIXFORMAT:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_TEXADDR0:
@@ -1045,8 +1049,10 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_VIEWPORTY2:
 	case GE_CMD_VIEWPORTZ1:
 	case GE_CMD_VIEWPORTZ2:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_LIGHTENABLE0:

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -305,7 +305,8 @@ FramebufferManager::FramebufferManager() :
 	shaderManager_(0),
 	usePostShader_(false),
 	postShaderAtOutputResolution_(false),
-	resized_(false)
+	resized_(false),
+	renderCopy_(0)
 #ifndef USING_GLES2
 	,
 	pixelBufObj_(0),
@@ -907,6 +908,7 @@ void FramebufferManager::BindFramebufferDepth(VirtualFramebuffer *sourceframebuf
 	if (MaskedEqual(sourceframebuffer->z_address, targetframebuffer->z_address) && 
 		sourceframebuffer->renderWidth == targetframebuffer->renderWidth &&
 		sourceframebuffer->renderHeight == targetframebuffer->renderHeight) {
+		
 #ifndef USING_GLES2
 		if (gl_extensions.FBO_ARB) {
 #else
@@ -922,7 +924,48 @@ void FramebufferManager::BindFramebufferDepth(VirtualFramebuffer *sourceframebuf
 #endif
 		}
 	}
+}
 
+void FramebufferManager::BindFramebufferColor(VirtualFramebuffer *framebuffer) {
+	if (!framebuffer->fbo || !useBufferedRendering_) {
+		glBindTexture(GL_TEXTURE_2D, 0);
+		gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
+		return;
+	}
+
+	if (MaskedEqual(framebuffer->fb_address, gstate.getFrameBufRawAddress())) {
+#ifndef USING_GLES2
+		if (gl_extensions.FBO_ARB) {
+#else
+		if (gl_extensions.GLES3) {
+#endif
+#ifdef MAY_HAVE_GLES3
+
+			// TODO: Maybe merge with bvfbs_?  Not sure if those could be packing, and they're created at a different size.
+			if (!renderCopy_ || renderCopyWidth_ != framebuffer->renderWidth || renderCopyHeight_ != framebuffer->renderHeight) {
+				if (renderCopy_)
+					fbo_destroy(renderCopy_);
+				renderCopy_ = fbo_create(framebuffer->renderWidth, framebuffer->renderHeight, 1, true, framebuffer->colorDepth);
+				renderCopyWidth_ = framebuffer->renderWidth;
+				renderCopyHeight_ = framebuffer->renderHeight;
+			}
+
+			fbo_bind_as_render_target(renderCopy_);
+			glViewport(0, 0, framebuffer->renderWidth, framebuffer->renderHeight);
+			fbo_bind_for_read(framebuffer->fbo);
+			glBlitFramebuffer(0, 0, framebuffer->renderWidth, framebuffer->renderHeight, 0, 0, framebuffer->renderWidth, framebuffer->renderHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+			fbo_bind_as_render_target(currentRenderVfb_->fbo);
+			if (gl_extensions.gpuVendor != GPU_VENDOR_POWERVR)
+				glstate.viewport.restore();
+			fbo_bind_color_as_texture(renderCopy_, 0);
+#endif
+		} else {
+			fbo_bind_color_as_texture(framebuffer->fbo, 0);
+		}
+	} else {
+		fbo_bind_color_as_texture(framebuffer->fbo, 0);
+	}
 }
 
 void FramebufferManager::CopyDisplayToOutput() {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -332,6 +332,9 @@ FramebufferManager::~FramebufferManager() {
 	}
 	SetNumExtraFBOs(0);
 
+	if (renderCopy_)
+		fbo_destroy(renderCopy_);
+
 #ifndef USING_GLES2
 	delete [] pixelBufObj_;
 #endif

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -231,9 +231,7 @@ private:
 	bool useBufferedRendering_;
 
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
-	FBO *renderCopy_;
-	int renderCopyWidth_;
-	int renderCopyHeight_;
+	std::map<std::pair<int, int>, FBO *> renderCopies_;
 
 	std::set<std::pair<u32, u32>> knownFramebufferCopies_;
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -139,7 +139,10 @@ public:
 	void SetLineWidth();
 
 	void BindFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer);
-	
+
+	// For use when texturing from a framebuffer.  May create a duplicate if target.
+	void BindFramebufferColor(VirtualFramebuffer *framebuffer);
+
 	// Just for logging right now.  Might remove/change.
 	void NotifyBlockTransfer(u32 dst, u32 src);
 
@@ -228,6 +231,9 @@ private:
 	bool useBufferedRendering_;
 
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
+	FBO *renderCopy_;
+	int renderCopyWidth_;
+	int renderCopyHeight_;
 
 	std::set<std::pair<u32, u32>> knownFramebufferCopies_;
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -397,6 +397,7 @@ GLES_GPU::GLES_GPU()
 	transformDraw_.SetFramebufferManager(&framebufferManager_);
 	framebufferManager_.SetTextureCache(&textureCache_);
 	framebufferManager_.SetShaderManager(shaderManager_);
+	textureCache_.SetFramebufferManager(&framebufferManager_);
 
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -893,8 +893,10 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 
 	case GE_CMD_REGION1:
 	case GE_CMD_REGION2:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_CLIPENABLE:
@@ -970,8 +972,10 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 
 	case GE_CMD_SCISSOR1:
 	case GE_CMD_SCISSOR2:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 		///
@@ -982,8 +986,10 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFPTR:
 	case GE_CMD_FRAMEBUFWIDTH:
 	case GE_CMD_FRAMEBUFPIXFORMAT:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_TEXADDR0:
@@ -1209,8 +1215,10 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_VIEWPORTY2:
 	case GE_CMD_VIEWPORTZ1:
 	case GE_CMD_VIEWPORTZ2:
-		if (diff)
+		if (diff) {
 			gstate_c.framebufChanged = true;
+			gstate_c.textureChanged = true;
+		}
 		break;
 
 	case GE_CMD_LIGHTENABLE0:

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -115,8 +115,8 @@ private:
 	};
 
 	void Decimate();  // Run this once per frame to get rid of old textures.
-	void *UnswizzleFromMem(u32 texaddr, u32 bufw, u32 bytesPerPixel, u32 level);
-	void *ReadIndexedTex(int level, u32 texaddr, int bytesPerIndex, GLuint dstFmt, int bufw);
+	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPixel, u32 level);
+	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, GLuint dstFmt, int bufw);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, GLenum dstFmt);
 	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -24,6 +24,7 @@
 #include "TextureScaler.h"
 
 struct VirtualFramebuffer;
+class FramebufferManager;
 
 enum TextureFiltering {
 	AUTO = 1,
@@ -55,6 +56,10 @@ public:
 	// FramebufferManager keeps TextureCache updated about what regions of memory
 	// are being rendered to. This is barebones so far.
 	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg);
+
+	void SetFramebufferManager(FramebufferManager *fbManager) {
+		framebufferManager_ = fbManager;
+	}
 
 	size_t NumLoadedTextures() const {
 		return cache.size();
@@ -160,5 +165,6 @@ private:
 	float maxAnisotropyLevel;
 
 	int decimationCounter_;
+	FramebufferManager *framebufferManager_;
 };
 


### PR DESCRIPTION
We're logging this for a bunch of games, I'm not really sure how it can be this many.
http://report.ppsspp.org/logs/kind/428

But either way, Brave Story and 3rd Birthday very clearly do this, and it causes weird behavior in OpenGL.  This creates a separate FBO to use as a temporary.  It might be better to create a cache of fbos but I wasn't sure about lifetime etc.  This does at least help the existing issues.

However, some games (like even 3rd Birthday I think, and Dragon Ball Z Tag Team), even when doing this _also_ render with a CLUT.  I think this can use the same temporary FBO (I think it should always render 1:1 to a temporary FBO when using a CLUT) but instead render to it using a shader and a 1D attachment of the CLUT.  Seems like a bit of a pain.

Anyway, this doesn't really help those CLUT games, but it may impact them by making their behavior more consistent (before it would sometimes have weird stuff in the source framebuffer.)

-[Unknown]
