### PR TITLE
Disable scaling to odd multiples when unsupported.

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1537,14 +1537,18 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level, bool replac
 
 	int scaleFactor;
 	//Auto-texture scale upto 5x rendering resolution
-	if (g_Config.iTexScalingLevel == 0)
+	if (g_Config.iTexScalingLevel == 0) {
 #ifndef USING_GLES2
-		scaleFactor = std::min(5, g_Config.iInternalResolution);
+		scaleFactor = std::min(gl_extensions.OES_texture_npot ? 5 : 4, g_Config.iInternalResolution);
+		if (!gl_extensions.OES_texture_npot && scaleFactor == 3) {
+			scaleFactor = 2;
+		}
 #else
-		scaleFactor = std::min(3, g_Config.iInternalResolution);
+		scaleFactor = std::min(gl_extensions.OES_texture_npot ? 3 : 2, g_Config.iInternalResolution);
 #endif
-	else
+	} else {
 		scaleFactor = g_Config.iTexScalingLevel;
+	}
 
 	// Don't scale the PPGe texture.
 	if (entry.addr > 0x05000000 && entry.addr < 0x08800000)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -18,6 +18,7 @@
 #include "base/colorutil.h"
 #include "base/timeutil.h"
 #include "math/curves.h"
+#include "gfx_es2/gpu_features.h"
 #include "gfx_es2/draw_buffer.h"
 #include "i18n/i18n.h"
 #include "ui/view.h"
@@ -168,11 +169,23 @@ void GameSettingsScreen::CreateViews() {
 	// graphicsSettings->Add(new CheckBox(&g_Config.bFXAA, gs->T("FXAA")));
 	graphicsSettings->Add(new ItemHeader(gs->T("Texture Scaling")));
 #ifndef USING_GLES2
-	static const char *texScaleLevels[] = {"Auto", "Off", "2x", "3x","4x", "5x"};
+	static const char *texScaleLevelsNPOT[] = {"Auto", "Off", "2x", "3x", "4x", "5x"};
+	static const char *texScaleLevelsPOT[] = {"Auto", "Off", "2x", "4x"};
 #else
-	static const char *texScaleLevels[] = {"Auto", "Off", "2x", "3x"};
+	static const char *texScaleLevelsNPOT[] = {"Auto", "Off", "2x", "3x"};
+	static const char *texScaleLevelsPOT[] = {"Auto", "Off", "2x"};
 #endif
-	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingLevel, gs->T("Upscale Level"), texScaleLevels, 0, ARRAY_SIZE(texScaleLevels), gs, screenManager()));
+
+	static const char **texScaleLevels;
+	static int numTexScaleLevels;
+	if (gl_extensions.OES_texture_npot) {
+		texScaleLevels = texScaleLevelsNPOT;
+		numTexScaleLevels = ARRAY_SIZE(texScaleLevelsNPOT);
+	} else {
+		texScaleLevels = texScaleLevelsPOT;
+		numTexScaleLevels = ARRAY_SIZE(texScaleLevelsPOT);
+	}
+	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingLevel, gs->T("Upscale Level"), texScaleLevels, 0, numTexScaleLevels, gs, screenManager()));
 	static const char *texScaleAlgos[] = { "xBRZ", "Hybrid", "Bicubic", "Hybrid + Bicubic", };
 	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingType, gs->T("Upscale Type"), texScaleAlgos, 0, ARRAY_SIZE(texScaleAlgos), gs, screenManager()));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTexDeposterize, gs->T("Deposterize")));

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -64,6 +64,7 @@
 #include "Windows/RawInput.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
+#include "gfx_es2/gpu_features.h"
 #include "GPU/GLES/TextureScaler.h"
 #include "GPU/GLES/TextureCache.h"
 #include "GPU/GLES/Framebuffer.h"
@@ -1673,6 +1674,11 @@ namespace MainWindow
 
 		for (int i = 0; i < ARRAY_SIZE(texscalingitems); i++) {
 			CheckMenuItem(menu, texscalingitems[i], MF_BYCOMMAND | ((i == g_Config.iTexScalingLevel) ? MF_CHECKED : MF_UNCHECKED));
+		}
+
+		if (!gl_extensions.OES_texture_npot) {
+			EnableMenuItem(menu, ID_TEXTURESCALING_3X, MF_GRAYED);
+			EnableMenuItem(menu, ID_TEXTURESCALING_5X, MF_GRAYED);
 		}
 
 		static const int texscalingtypeitems[] = {


### PR DESCRIPTION
May help #4000.  Not actually tested on a device that doesn't support power of two sizes.

-[Unknown]
