### PR TITLE
windows: Ignore key/mouse input while menu focused

### DIFF
--- a/Windows/RawInput.h
+++ b/Windows/RawInput.h
@@ -21,5 +21,6 @@ namespace WindowsRawInput {
 	void Init();
 	LRESULT Process(HWND hWnd, WPARAM wParam, LPARAM lParam);
 	void LoseFocus();
+	void NotifyMenu();
 	void Shutdown();
 };

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1584,6 +1584,7 @@ namespace MainWindow
 			// Unfortunately, accelerate keys (hotkeys) shares the same enabled/disabled states
 			// with corresponding menu items.
 			UpdateMenus();
+			WindowsRawInput::NotifyMenu();
 			break;
 
 		// Turn off the screensaver.


### PR DESCRIPTION
This prevents arrow and shortcut keys from being considered inputs to the game or UI.

Open PPSSPP, then press alt, then press left, right, down, etc. to select a menu item.  Go to Game Settings, using the keyboard, and and change a setting by pressing enter.  Oh.  See what just happened, heh?

-[Unknown]
