### PR TITLE
Don't call SetTexture() in clear mode

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -166,7 +166,7 @@ static bool blendColorSimilar(Vec3f a, Vec3f b, float margin = 0.1f) {
 void TransformDrawEngine::ApplyDrawState(int prim) {
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
-	if (gstate_c.textureChanged) {
+	if (gstate_c.textureChanged && !gstate.isModeClear()) {
 		if (gstate.isTextureMapEnabled()) {
 			textureCache_->SetTexture();
 		}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -885,7 +885,7 @@ void TextureCache::SetTexture(bool force) {
 
 	u32 fb_addr = gstate.getFrameBufRawAddress() | 0x04000000;
 	if (fb_addr == gstate.getTextureAddress(0)) {
-		WARN_LOG_REPORT(HLE, "Render to self texture (%08x : %ix%i)", fb_addr, w, h);
+		WARN_LOG_REPORT(HLE, "Texturing from same buffer as target (%08x : %ix%i)", fb_addr, w, h);
 	}
 
 	GETextureFormat format = gstate.getTextureFormat();


### PR DESCRIPTION
It's just a waste of time, the game is probably being lazy.  I'm opening this as a separate pull in case we want to merge it separately.

Pros:
- May correct the the incidence of the self-texture reporting.
- May prevent some texture processing that doesn't need to happen, but probably minor even then.

Cons:
- Will make the situation fixed by #5150 worse in some cases (like 3rd Birthday) since the earlier SetTexture seems to help it be less wrong somehow.

-[Unknown]
