### PR TITLE
Fix aborting msgdialogs

### DIFF
--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -278,7 +278,8 @@ int PSPMsgDialog::Update(int animSpeed)
 		lastButtons = buttons;
 	}
 
-	Memory::Memcpy(messageDialogAddr,&messageDialog,messageDialog.common.size);
+	messageDialog.result = 0;
+	Memory::Memcpy(messageDialogAddr, &messageDialog ,messageDialog.common.size);
 	return 0;
 }
 

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -284,8 +284,8 @@ int PSPMsgDialog::Update(int animSpeed)
 
 int PSPMsgDialog::Abort()
 {
-	// TODO: Probably not exactly the same?
-	return PSPDialog::Shutdown();
+	status = SCE_UTILITY_STATUS_FINISHED;
+	return 0;
 }
 
 int PSPMsgDialog::Shutdown(bool force)

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -309,10 +309,9 @@ int sceUtilityMsgDialogAbort()
 {
 	if (currentDialogType != UTILITY_DIALOG_MSG)
 	{
-		WARN_LOG(SCEUTILITY, "sceUtilityMsgDialogShutdownStart(): wrong dialog type");
+		WARN_LOG(SCEUTILITY, "sceUtilityMsgDialogAbort(): wrong dialog type");
 		return SCE_ERROR_UTILITY_WRONG_TYPE;
 	}
-	currentDialogActive = false;
 
 	DEBUG_LOG(SCEUTILITY, "sceUtilityMsgDialogAbort()");
 	return msgDialog.Abort();


### PR DESCRIPTION
And also properly set the result on success.  Matches tests I did with a PSP, except timing.  I think this one (since Abort avoids the need for any button press) can probably be an auto test.

-[Unknown]
