### PR TITLE
Fix savestates from before v0.9.6-536-g62e9e42

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -259,8 +259,6 @@ void RegisterAllModules() {
 	Register_ThreadManForUser();
 	Register_ThreadManForKernel();
 	Register_LoadExecForUser();
-	Register_LoadExecForKernel();
-	Register_SysMemForKernel();
 	Register_UtilsForKernel();
 	Register_SysMemUserForUser();
 	Register_InterruptManager();
@@ -319,5 +317,9 @@ void RegisterAllModules() {
 	{
 		RegisterModule(moduleList[i].name, moduleList[i].numFunctions, moduleList[i].funcTable);
 	}
+
+	// New modules have to be added at the end, or they will break savestates.
+	Register_LoadExecForKernel();
+	Register_SysMemForKernel();
 }
 


### PR DESCRIPTION
Unfortunately, this breaks savestates made since then until this is merged.  However, that's only a day or so.

This is because syscalls are linked in the module loader as an instruction that references the module index in the array.

-[Unknown]
