### PR TITLE
Support larger iso files (more than 2GB)

### DIFF
--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -63,7 +63,7 @@ public:
 
 private:
 	FILE *f;
-	size_t filesize;
+	u64 filesize;
 };
 
 


### PR DESCRIPTION
No actual PSP games are this big (a UMD can only go up to 1.8 GB), but it can be convenient for combined multi-game discs.  Fixes #5169.

Not sure what ftell() returns for > INT_MAX, so better to be safe.  The main fix is using fseeko().

Also applied to cso just in case.  It's probably not super likely to see a compressed iso > 2GB but might as well support it.

-[Unknown]
