### PR TITLE
Handle fixed-length strings in savedata properly

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -213,7 +213,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	return retval;
 }
 
-const std::string PSPSaveDialog::GetSelectedSaveDirName()
+const std::string PSPSaveDialog::GetSelectedSaveDirName() const
 {
 	switch ((SceUtilitySavedataType)(u32)param.GetPspParam()->mode)
 	{
@@ -236,7 +236,7 @@ const std::string PSPSaveDialog::GetSelectedSaveDirName()
 
 	// TODO: Maybe also SINGLEDELETE/etc?
 
-	// SZIES ignores saveName it seems.
+	// SIZES ignores saveName it seems.
 
 	default:
 		return param.GetSaveDirName(param.GetPspParam(), currentSelectedSave);

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -73,7 +73,7 @@ public:
 	virtual void DoState(PointerWrap &p);
 	virtual pspUtilityDialogCommon *GetCommonParam();
 
-private :
+private:
 
 	void DisplayBanner(int which);
 	void DisplaySaveList(bool canMove = true);
@@ -82,7 +82,7 @@ private :
 	void DisplaySaveDataInfo1();
 	void DisplaySaveDataInfo2();
 	void DisplayMessage(std::string text, bool hasYesNo = false);
-	const std::string GetSelectedSaveDirName();
+	const std::string GetSelectedSaveDirName() const;
 
 	enum DisplayState
 	{

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -273,11 +273,11 @@ public:
 	SavedataParam();
 
 	static void Init();
-	std::string GetSaveFilePath(SceUtilitySavedataParam* param, int saveId = -1);
-	std::string GetSaveFilePath(SceUtilitySavedataParam* param, const std::string &saveDir);
-	std::string GetSaveDirName(SceUtilitySavedataParam* param, int saveId = -1);
-	std::string GetSaveDir(SceUtilitySavedataParam* param, int saveId = -1);
-	std::string GetSaveDir(SceUtilitySavedataParam* param, const std::string &saveDirName);
+	std::string GetSaveFilePath(const SceUtilitySavedataParam *param, int saveId = -1) const;
+	std::string GetSaveFilePath(const SceUtilitySavedataParam *param, const std::string &saveDir) const;
+	std::string GetSaveDirName(const SceUtilitySavedataParam *param, int saveId = -1) const;
+	std::string GetSaveDir(const SceUtilitySavedataParam *param, int saveId = -1) const;
+	std::string GetSaveDir(const SceUtilitySavedataParam *param, const std::string &saveDirName) const;
 	bool Delete(SceUtilitySavedataParam* param, int saveId = -1);
 	int DeleteData(SceUtilitySavedataParam* param);
 	bool Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode = true);
@@ -290,18 +290,19 @@ public:
 	bool IsInSaveDataList(std::string saveName, int count);
 	bool secureCanSkip(SceUtilitySavedataParam* param, bool secureMode);
 
-	std::string GetGameName(SceUtilitySavedataParam* param);
-	std::string GetSaveName(SceUtilitySavedataParam* param);
-	std::string GetFileName(SceUtilitySavedataParam* param);
+	std::string GetGameName(const SceUtilitySavedataParam *param) const;
+	std::string GetSaveName(const SceUtilitySavedataParam *param) const;
+	std::string GetFileName(const SceUtilitySavedataParam *param) const;
 
 	static std::string GetSpaceText(int size);
 
 	int SetPspParam(SceUtilitySavedataParam* param);
-	SceUtilitySavedataParam* GetPspParam();
+	SceUtilitySavedataParam *GetPspParam();
+	const SceUtilitySavedataParam *GetPspParam() const;
 
 	int GetFilenameCount();
 	const SaveFileInfo& GetFileInfo(int idx);
-	std::string GetFilename(int idx);
+	std::string GetFilename(int idx) const;
 
 	int GetSelectedSave();
 	void SetSelectedSave(int idx);


### PR DESCRIPTION
I originally was profiling this to see if it was causing some sort of tearing / slowdown, and noticed that some places where treating fixed-length strings as null-terminated.  I'm not sure if any games use the full length, but in case they do, this should be safer.

-[Unknown]
