### PR TITLE
Only copy dirty depth buffers between FBOs

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -58,6 +58,7 @@ struct VirtualFramebuffer {
 	int last_frame_used;
 	int last_frame_render;
 	bool memoryUpdated;
+	bool depthUpdated;
 
 	u32 fb_address;
 	u32 z_address;
@@ -172,6 +173,12 @@ public:
 	}
 	u32 DisplayFramebufAddr() {
 		return displayFramebuf_ ? (0x04000000 | displayFramebuf_->fb_address) : 0;
+	}
+
+	void SetDepthUpdated() {
+		if (currentRenderVfb_) {
+			currentRenderVfb_->depthUpdated = true;
+		}
 	}
 
 	void NotifyFramebufferCopy(u32 src, u32 dest, int size);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -356,6 +356,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		glstate.depthTest.enable();
 		glstate.depthFunc.set(GL_ALWAYS);
 		glstate.depthWrite.set(gstate.isClearModeDepthMask() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
+		if (gstate.isClearModeDepthMask() || alwaysDepthWrite) {
+			framebufferManager_->SetDepthUpdated();
+		}
 
 		// Color Test
 		bool colorMask = gstate.isClearModeColorMask();
@@ -398,6 +401,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(ztests[gstate.getDepthTestFunction()]);
 			glstate.depthWrite.set(gstate.isDepthWriteEnabled() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
+			framebufferManager_->SetDepthUpdated();
 		} else {
 			glstate.depthTest.disable();
 		}


### PR DESCRIPTION
This is a bit of a hack.

We can remove this if/when we track them separately.  This may break a game that depends on the depth carrying over between several FBOs, but that's not extremely likely.

This improves performance in Gods Eater Burst.

I've only really tested it with Jeanne d'Arc, I don't know if this hurts other games that were improved by the depth copying.

-[Unknown]
