### PR TITLE
Revert #5044 and set ctx->avc.avcDecodeResult = 1

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -265,7 +265,7 @@ void AnalyzeMpeg(u8 *buffer, MpegContext *ctx) {
 	ctx->mpegLastDate = convertTimestampToDate(ctx->mpegLastTimestamp);
 	ctx->avc.avcDetailFrameWidth = (*(u8*)(buffer + 142)) * 0x10;
 	ctx->avc.avcDetailFrameHeight = (*(u8*)(buffer + 143)) * 0x10;
-	ctx->avc.avcDecodeResult = 0;
+	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 	ctx->avc.avcFrameStatus = 0;
 
 	ctx->videoFrameCount = 0;
@@ -1089,12 +1089,6 @@ int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		mpegRingbuffer.packetsFree = mpegRingbuffer.packets;
 		Memory::WriteStruct(ctx->mpegRingbufferAddr, &mpegRingbuffer);
 
-		result = PSP_ERROR_MPEG_NO_DATA;
-	}
-
-	if (ctx->avc.avcDecodeResult == 0) {
-		INFO_LOG(ME, "Video decode completed");
-		ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 		result = PSP_ERROR_MPEG_NO_DATA;
 	}
 


### PR DESCRIPTION
This revert #5044 and fix Killzone Liberation . set ctx->avc.avcDecodeResult = 1 is referencing JPCSP

https://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/sceMpeg.java:1279
