### PR TITLE
Improve game browser keyboard/controller navigation

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -277,19 +277,23 @@ static const DefMappingStruct defaultXperiaPlay[] = {
 	{VIRTKEY_AXIS_Y_MAX, JOYSTICK_AXIS_Y, +1},
 };
 
+static void KeyCodesFromPspButton(int btn, std::vector<keycode_t> *keycodes) {
+	for (auto i = g_controllerMap[btn].begin(), end = g_controllerMap[btn].end(); i != end; ++i) {
+		keycodes->push_back((keycode_t)i->keyCode);
+	}
+}
+
 void UpdateConfirmCancelKeys() {
 	std::vector<keycode_t> confirmKeys, cancelKeys;
+	std::vector<keycode_t> tabLeft, tabRight;
 
 	int confirmKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 	int cancelKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
 
-	for (auto i = g_controllerMap[confirmKey].begin(); i != g_controllerMap[confirmKey].end(); ++i) {
-		confirmKeys.push_back((keycode_t)i->keyCode);
-	}
-
-	for (auto i = g_controllerMap[cancelKey].begin(); i != g_controllerMap[cancelKey].end(); ++i) {
-		cancelKeys.push_back((keycode_t)i->keyCode);
-	}
+	KeyCodesFromPspButton(confirmKey, &confirmKeys);
+	KeyCodesFromPspButton(cancelKey, &cancelKeys);
+	KeyCodesFromPspButton(CTRL_LTRIGGER, &tabLeft);
+	KeyCodesFromPspButton(CTRL_RTRIGGER, &tabRight);
 
 	// Push several hard-coded keys before submitting to native.
 	const keycode_t hardcodedConfirmKeys[] = {
@@ -314,6 +318,7 @@ void UpdateConfirmCancelKeys() {
 	}
 
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);
+	SetTabLeftRightKeys(tabLeft, tabRight);
 }
 
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t count, bool replace) {

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -126,7 +126,7 @@ namespace KeyMap {
 
 	std::vector<KeyMap_IntStrPair> GetMappableKeys();
 
-	// Use if to translate KeyMap Keys to PSP
+	// Use to translate KeyMap Keys to PSP
 	// buttons. You should have already translated
 	// your platform's keys to KeyMap keys.
 	bool KeyToPspButton(int deviceId, int key, std::vector<int> *pspKeys);
@@ -153,7 +153,6 @@ namespace KeyMap {
 	void SetDefaultKeyMap(DefaultMaps dmap, bool replace);
 
 	void RestoreDefault();
-	void QuickMap(int device);
 
 	void UpdateConfirmCancelKeys();
 

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -51,6 +51,8 @@
 #define HID_USAGE_GENERIC_MULTIAXIS    ((USHORT) 0x07)
 #endif
 
+extern InputState input_state;
+
 namespace WindowsRawInput {
 	static std::set<int> keyboardKeysDown;
 	static void *rawInputBuffer;
@@ -147,6 +149,12 @@ namespace WindowsRawInput {
 			return;
 		}
 
+		TouchInput touch;
+		touch.id = 0;
+		touch.flags = TOUCH_MOVE;
+		touch.x = input_state.pointer_x[0];
+		touch.y = input_state.pointer_y[0];
+
 		KeyInput key;
 		key.deviceId = DEVICE_ID_MOUSE;
 
@@ -156,10 +164,12 @@ namespace WindowsRawInput {
 		if (raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN) {
 			key.flags = KEY_DOWN;
 			key.keyCode = windowsTransTable[VK_RBUTTON];
+			NativeTouch(touch);
 			NativeKey(key);
 		} else if (raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP) {
 			key.flags = KEY_UP;
 			key.keyCode = windowsTransTable[VK_RBUTTON];
+			NativeTouch(touch);
 			NativeKey(key);
 		}
 


### PR DESCRIPTION
This allows triangle/right click on a game button to go to its game screen, and l/r to switch between recent/games/demos.

-[Unknown]
