### PR TITLE
Only return m_audiopts when it is > 0

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -703,7 +703,6 @@ int MediaEngine::getAudioRemainSize() {
 }
 
 int MediaEngine::getAudioSamples(u32 bufferPtr) {
-#ifdef USE_FFMPEG
 	if (!Memory::IsValidAddress(bufferPtr)) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);
 	}
@@ -726,9 +725,13 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 	int outbytes = 0;
 
 	if (m_audioContext != NULL) {
+#ifdef USE_FFMPEG
 		if (!AT3Decode(m_audioContext, audioFrame, frameSize, &outbytes, buffer)) {
 			ERROR_LOG(ME, "AT3 decode failed during video playback");
 		}
+#else
+		m_audiopts += 4180;
+#endif // USE_FFMPEG
 	}
 
 	if (headerCode1 == 0x24) {
@@ -743,10 +746,6 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 	}
 	m_noAudioData = false;
 	return 0x2000;
-#else
-	m_audiopts += 4180;
-	return true;
-#endif // USE_FFMPEG
 }
 
 s64 MediaEngine::getVideoTimeStamp() {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -703,6 +703,7 @@ int MediaEngine::getAudioRemainSize() {
 }
 
 int MediaEngine::getAudioSamples(u32 bufferPtr) {
+#ifdef USE_FFMPEG
 	if (!Memory::IsValidAddress(bufferPtr)) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);
 	}
@@ -740,9 +741,12 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 			outbuf[i * 2 + 1] = sample;
 		}
 	}
-	m_audiopts += 4180;
 	m_noAudioData = false;
 	return 0x2000;
+#else
+	m_audiopts += 4180;
+	return true;
+#endif // USE_FFMPEG
 }
 
 s64 MediaEngine::getVideoTimeStamp() {
@@ -750,7 +754,7 @@ s64 MediaEngine::getVideoTimeStamp() {
 }
 
 s64 MediaEngine::getAudioTimeStamp() {
-	if (m_demux)
+	if (m_demux && m_audiopts > 0)
 		return std::max(m_audiopts - 4180, (s64)0);
 	return m_videopts;
 }


### PR DESCRIPTION
m_audiopts may return negative .Add check to return m_audiopts only when m_audiopts > 0 (Tested with couples of games and confirm)

Fixes https://github.com/hrydgard/ppsspp/issues/5131
