### PR TITLE
Return without delay if voicesPlayingCount is zero

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -134,11 +134,11 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
 	// like a hack. Note that Mix() returns true in this case which is a little confusing.
 	if (ret) {
-		// If voicesPlayingCount == 0 , delay 240 us and reschedule
-		return hleDelayResult(0, "sas core", 240);
-	} else {
-		// if voicesPlayingCount > 0 , no delay
+		// If voicesPlayingCount == 0 , no delay
 		return 0;
+	} else {
+		// if voicesPlayingCount > 0 , delay 240 us and reschedule
+		return hleDelayResult(0, "sas core", 240);
 	}
 }
 
@@ -155,11 +155,11 @@ u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume)
 	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
 	// like a hack. Note that Mix() returns true in this case which is a little confusing.
 	if (ret) {
-		// If voicesPlayingCount == 0 , delay 240 us and reschedule
-		return hleDelayResult(0, "sas core", 240);
-	} else {
-		// if voicesPlayingCount > 0 , no delay
+		// If voicesPlayingCount == 0 , no delay
 		return 0;
+	} else {
+		// if voicesPlayingCount > 0 , delay 240 us and reschedule
+		return hleDelayResult(0, "sas core", 240);
 	}
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -484,7 +484,7 @@ bool SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 	if (voicesPlayingCount == 0) {
 		// This is fine, no need to log really.
 		// DEBUG_LOG(SASMIX,"SasInstance::Mix() : voicesPlayingCount is zero");
-		return true;
+		return false;
 	}
 
 	// Okay, apply effects processing to the Send buffer.
@@ -525,7 +525,7 @@ bool SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 	fwrite(Memory::GetPointer(outAddr), 1, grainSize * 2 * 2, audioDump);
 #endif
 
-	return false;
+	return true;
 }
 
 void SasInstance::ApplyReverb() {


### PR DESCRIPTION
Previosuly i should be messed up . As @unknownbrackets mentioned, if voicesPlayingCount does play , should be delayed and reschelduled. 
