### PR TITLE
Return without delay if voicesPlayingCount is zero

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -131,8 +131,8 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 
 	bool ret = sas->Mix(outAddr);
 	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
-	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
-	// like a hack. Note that Mix() returns true in this case which is a little confusing.
+	// When there's no voicesPlayingCount , we return as no delay and fixes issue #2304.
+	// Note that Mix() returns true in this case when no voicesPlayingCount.
 	if (ret) {
 		// If voicesPlayingCount == 0 , no delay
 		return 0;
@@ -152,8 +152,8 @@ u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume)
 
 	bool ret = sas->Mix(inoutAddr, inoutAddr, leftVolume, rightVolume);
 	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
-	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
-	// like a hack. Note that Mix() returns true in this case which is a little confusing.
+	// When there's no voicesPlayingCount , we return as no delay and fixes issue #2304.
+	// Note that Mix() returns true in this case when no voicesPlayingCount.
 	if (ret) {
 		// If voicesPlayingCount == 0 , no delay
 		return 0;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -134,11 +134,11 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
 	// like a hack. Note that Mix() returns true in this case which is a little confusing.
 	if (ret) {
-		// If voicesPlayingCount == 0 , delay 240 us and reschedule
-		return hleDelayResult(0, "sas core", 240);
-	} else {
-		// if voicesPlayingCount > 0 , no delay
+		// If voicesPlayingCount == 0 , no delay
 		return 0;
+	} else {
+		// if voicesPlayingCount > 0 , delay 240 us and reschedule
+		return hleDelayResult(0, "sas core", 240);
 	}
 }
 
@@ -155,11 +155,11 @@ u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume)
 	// Turns out that delaying only when there's no voicesPlayingCount fixes issue #2304. Feels a bit
 	// like a hack. Note that Mix() returns true in this case which is a little confusing.
 	if (ret) {
-		// If voicesPlayingCount == 0 , delay 240 us and reschedule
-		return hleDelayResult(0, "sas core", 240);
-	} else {
-		// if voicesPlayingCount > 0 , no delay
+		// If voicesPlayingCount == 0 , no delay
 		return 0;
+	} else {
+		// if voicesPlayingCount > 0 , delay 240 us and reschedule
+		return hleDelayResult(0, "sas core", 240);
 	}
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -481,12 +481,6 @@ bool SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 		MixVoice(voice);
 	}
 
-	if (voicesPlayingCount == 0) {
-		// This is fine, no need to log really.
-		// DEBUG_LOG(SASMIX,"SasInstance::Mix() : voicesPlayingCount is zero");
-		return true;
-	}
-
 	// Okay, apply effects processing to the Send buffer.
 	//if (waveformEffect.type != PSP_SAS_EFFECT_TYPE_OFF)
 	//	ApplyReverb();
@@ -525,7 +519,11 @@ bool SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 	fwrite(Memory::GetPointer(outAddr), 1, grainSize * 2 * 2, audioDump);
 #endif
 
-	return false;
+	if (voicesPlayingCount == 0) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 void SasInstance::ApplyReverb() {


### PR DESCRIPTION
Probably messed up previously . As @unknownbrackets mentioned, if voicesPlayingCount does play , should be delayed and reschelduled. 
