### PR TITLE
Fix glitch when a file is closed while its io thread operation is pending

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -289,6 +289,10 @@ void __IoFreeFd(int fd, u32 &error) {
 			for (size_t i = 0; i < f->waitingThreads.size(); ++i) {
 				HLEKernel::ResumeFromWait(f->waitingThreads[i], WAITTYPE_ASYNCIO, f->GetUID(), (int)SCE_KERNEL_ERROR_WAIT_DELETE);
 			}
+
+			// Discard any pending results.
+			AsyncIOResult managerResult;
+			ioManager.WaitResult(f->handle, managerResult);
 		}
 		error = kernelObjects.Destroy<FileNode>(fds[fd]);
 		fds[fd] = 0;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -503,6 +503,7 @@ void __IoShutdown() {
 	if (ioManagerThread != NULL) {
 		delete ioManagerThread;
 		ioManagerThread = NULL;
+		ioManager.Shutdown();
 	}
 
 	pspFileSystem.Unmount("ms0:", memstickSystem);

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -29,6 +29,12 @@ void AsyncIOManager::ScheduleOperation(AsyncIOEvent ev) {
 	ScheduleEvent(ev);
 }
 
+void AsyncIOManager::Shutdown() {
+	lock_guard guard(resultsLock_);
+	resultsPending_.clear();
+	results_.clear();
+}
+
 bool AsyncIOManager::PopResult(u32 handle, AsyncIOResult &result) {
 	lock_guard guard(resultsLock_);
 	if (results_.find(handle) != results_.end()) {

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -23,7 +23,9 @@
 
 void AsyncIOManager::ScheduleOperation(AsyncIOEvent ev) {
 	lock_guard guard(resultsLock_);
-	resultsPending_.insert(ev.handle);
+	if (!resultsPending_.insert(ev.handle).second) {
+		ERROR_LOG_REPORT(SCEIO, "Scheduling operation for file %d while one is pending (type %d)", ev.handle, ev.type);
+	}
 	ScheduleEvent(ev);
 }
 
@@ -66,7 +68,7 @@ void AsyncIOManager::ProcessEvent(AsyncIOEvent ev) {
 		break;
 
 	default:
-		ERROR_LOG(SCEIO, "Unsupported IO event type");
+		ERROR_LOG_REPORT(SCEIO, "Unsupported IO event type");
 	}
 }
 

--- a/Core/HW/AsyncIOManager.h
+++ b/Core/HW/AsyncIOManager.h
@@ -52,6 +52,7 @@ public:
 	void DoState(PointerWrap &p);
 
 	void ScheduleOperation(AsyncIOEvent ev);
+	void Shutdown();
 
 	bool PopResult(u32 handle, AsyncIOResult &result);
 	bool WaitResult(u32 handle, AsyncIOResult &result);


### PR DESCRIPTION
I think this only affected if you ran multiple games in the same run, since it didn't clear between.  Caused the second game to hang if there were pending results for it.

I'm still not sure what's causing the other issues, though...

-[Unknown]
