### PR TITLE
Work around a callback issue and a strange debug-only crash

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2299,6 +2299,8 @@ void sceKernelExitDeleteThread(int exitStatus)
 	{
 		INFO_LOG(SCEKERNEL,"sceKernelExitDeleteThread(%d)", exitStatus);
 		__KernelDeleteThread(currentThread, exitStatus, "thread exited with delete");
+		// Temporary hack since we don't reschedule within callbacks.
+		g_inCbCount = 0;
 
 		hleReSchedule("thread exited with delete");
 	}

--- a/ext/zlib/gzread.c
+++ b/ext/zlib/gzread.c
@@ -588,7 +588,12 @@ int ZEXPORT gzclose_r(file)
     err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
     gz_error(state, Z_OK, NULL);
     free(state->path);
+#ifdef _WIN32
+	// Strange crash in debug-only when using close() under MSVC 2010.
+    ret = _close(state->fd);
+#else
     ret = close(state->fd);
+#endif
     free(state);
     return ret ? Z_ERRNO : err;
 }


### PR DESCRIPTION
I'm not sure what's up with the zlib change, but it shouldn't be any less correct.  I thought `close()` was just a deprecated alias for `_close()`, but this nicely avoids the crashes (only when loading symbol maps.)

The callback change allows it to reschedule off the deleted thread for now (while callbacks still do not allow rescheduling off.)

-[Unknown]
