### PR TITLE
SceUtilitySavedataFileListEntry correction

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1069,6 +1069,7 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		}
 
 		entry->st_mode = 0x21FF;
+		entry->st_unk0 = 0;     // TODO: check on the PSP
 		entry->st_size = file->size + sizeOffset;
 		__IoCopyDate(entry->st_ctime, file->ctime);
 		__IoCopyDate(entry->st_atime, file->atime);

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -138,6 +138,7 @@ struct SceUtilitySavedataIdListInfo
 struct SceUtilitySavedataFileListEntry
 {
 	s32_le st_mode;
+	u32_le st_unk0;
 	u64_le st_size;
 	ScePspDateTime st_ctime;
 	ScePspDateTime st_atime;


### PR DESCRIPTION
SceUtilitySavedataFileListEntry should be 80 bytes long.
It worked on x86 platforms due to struct padding (sizeof(SceUtilitySavedataFileListEntry) was 80 bytes), but corrupt memory on iOS (where sizeof(SceUtilitySavedataFileListEntry) was correct 76 bytes).

Fixes "Savedata is corrupted" loading error on iOS with some games (Valkyria Chronicles 2 and 3).
