### PR TITLE
All platforms: Fix a crash where enabling Debug Statistics before entering a game, then disabling it after exiting a game causes the JIT to try to clear cache, when it's pointless

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -434,9 +434,7 @@ void GameSettingsScreen::update(InputState &input) {
 	g_Config.iFpsLimit = alternateSpeedTable[iAlternateSpeedPercent_];
 	if (g_Config.bShowDebugStats != showDebugStats_) {
 		// This affects the jit.
-		if (MIPSComp::jit) {
-			MIPSComp::jit->ClearCache();
-		}
+		NativeMessageReceived("clear jit", "");
 		g_Config.bShowDebugStats = showDebugStats_;
 	}
 }

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -101,7 +101,7 @@ void DrawBackground(float alpha) {
 
 void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager) {
 	if (!strcmp(message, "clear jit")) {
-		if (MIPSComp::jit) {
+		if (MIPSComp::jit && PSP_IsInited()) {
 			MIPSComp::jit->ClearCache();
 		}
 	}


### PR DESCRIPTION
Should fix https://github.com/hrydgard/ppsspp/issues/5250.
