### PR TITLE
Clean up alarm struct alignment, don't set pad to anything

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1069,7 +1069,6 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		}
 
 		entry->st_mode = 0x21FF;
-		entry->st_unk0 = 0;     // TODO: check on the PSP
 		entry->st_size = file->size + sizeOffset;
 		__IoCopyDate(entry->st_ctime, file->ctime);
 		__IoCopyDate(entry->st_atime, file->atime);

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -30,6 +30,7 @@ std::list<SceUID> triggeredAlarm;
 struct NativeAlarm
 {
 	SceSize_le size;
+	u32_le pad;
 	u64_le schedule;
 	u32_le handlerPtr;
 	u32_le commonPtr;


### PR DESCRIPTION
Doesn't seem to have any value set, stays 0x1337 if I set it to that.

-[Unknown]
