### PR TITLE
Correct scePsmfPlayerBreak psmfplayer's status

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -870,7 +870,7 @@ int scePsmfPlayerBreak(u32 psmfPlayer)
 	ERROR_LOG(ME, "UNIMPL scePsmfPlayerBreak(%08x)", psmfPlayer);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (psmfplayer)
-		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
+		psmfplayer->status = PSMF_PLAYER_STATUS_INIT;//Fix everybody stress buster
 	return 0;
 }
 


### PR DESCRIPTION
Fix everybody stress buster freeze after video
Base on JPCSP trace log
https://gist.github.com/sum2012/de8394179480bdfa2ed2
