### PR TITLE
Remove redundant break in MIPSAsm.cpp.

### DIFF
--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -333,7 +333,6 @@ bool CMipsInstruction::Validate()
 				SetAssembleError("Immediate value %02X out of range",Vars.OriginalImmediate);
 				return false;
 			}
-			break;
 			Vars.Immediate &= 0x1F;
 			break;
 		case MIPS_IMMEDIATE16:


### PR DESCRIPTION
Not extremely necessary, but addresses https://github.com/hrydgard/ppsspp/issues/4817.
