### PR TITLE
Fix __KernelUmdActivate()

### DIFF
--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -135,10 +135,10 @@ void __UmdStatChange(u64 userdata, int cyclesLate)
 
 void __KernelUmdActivate()
 {
-	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE; // return as 0x22
+	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE;
 	// PSP_UMD_READY will be returned when sceKernelGetCompiledSdkVersion() != 0
 	if (sceKernelGetCompiledSdkVersion() != 0)
-		notifyArg |= PSP_UMD_READY; // return as 0x32 as real PSP do 
+		notifyArg |= PSP_UMD_READY;
 
 	if (driveCBId != -1)
 		__KernelNotifyCallback(driveCBId, notifyArg);

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -28,6 +28,7 @@
 #include "Core/HLE/sceUmd.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelInterrupt.h"
+#include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/KernelWaitHelpers.h"
 
 #include "Core/FileSystems/BlockDevices.h"
@@ -134,7 +135,11 @@ void __UmdStatChange(u64 userdata, int cyclesLate)
 
 void __KernelUmdActivate()
 {
-	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE;
+	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE; // return as 0x22
+	// PSP_UMD_READY will be returned when sceKernelGetCompiledSdkVersion() != 0
+	if (sceKernelGetCompiledSdkVersion() != 0)
+		notifyArg |= PSP_UMD_READY; // return as 0x32 as real PSP do 
+
 	if (driveCBId != -1)
 		__KernelNotifyCallback(driveCBId, notifyArg);
 


### PR DESCRIPTION
When sceKernelGetCompiledSdkVersion() != 0 , sdkVersion set and PSP_UMD_READY will be |= to notifyArg and return as 0x32 instead of 0x22 .

Fixes #4969 & #4546

Thanks @daniel229 for finding out this fix.
