### PR TITLE
scePsmfPlayerConfigPlayer(): Return invalid ERROR code for invalid config mode and config value

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -63,9 +63,7 @@ static const u32 MPEG_MEMSIZE = 0x10000;          // 64k.
 static const int MPEG_AVC_DECODE_SUCCESS = 1;       // Internal value.
 static const int MPEG_AVC_DECODE_ERROR_FATAL = 0x80628002;
 
-static const int atracDecodeDelayMs = 3000;
 static const int avcFirstDelayMs = 3600;
-static const int avcDecodeDelayMs = 5400;         // Varies between 4700 and 6000.
 static const int avcEmptyDelayMs = 320;
 static const int mpegDecodeErrorDelayMs = 100;
 static const int mpegTimestampPerSecond = 90000;  // How many MPEG Timestamp units in a second.

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -66,10 +66,8 @@ static const int MPEG_AVC_DECODE_ERROR_FATAL = 0x80628002;
 static const int avcFirstDelayMs = 3600;
 static const int avcEmptyDelayMs = 320;
 static const int mpegDecodeErrorDelayMs = 100;
-static const int mpegTimestampPerSecond = 90000;  // How many MPEG Timestamp units in a second.
 static const int videoTimestampStep = 3003;       // Value based on pmfplayer (mpegTimestampPerSecond / 29.970 (fps)).
 static const int audioTimestampStep = 4180;       // For audio play at 44100 Hz (2048 samples / 44100 * mpegTimestampPerSecond == 4180)
-//static const int audioFirstTimestamp = 89249;     // The first MPEG audio AU has always this timestamp
 static const int audioFirstTimestamp = 90000;     // The first MPEG audio AU has always this timestamp
 static const s64 UNKNOWN_TIMESTAMP = -1;
 

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -58,6 +58,9 @@ static const int PSMF_STREAM_SIZE_OFFSET = 0xC;
 static const int PSMF_FIRST_TIMESTAMP_OFFSET = 0x54;
 static const int PSMF_LAST_TIMESTAMP_OFFSET = 0x5A;
 
+static const int atracDecodeDelayMs = 3000;
+static const int avcDecodeDelayMs = 5400;
+
 struct SceMpegAu {
 	s64_le pts;  // presentation time stamp
 	s64_le dts;  // decode time stamp

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -37,6 +37,8 @@ enum {
 	ERROR_PSMF_INVALID_PSMF                             = 0x80615501,
 
 	ERROR_PSMFPLAYER_NOT_INITIALIZED                    = 0x80616001,
+	ERROR_PSMFPLAYER_INVALID_CONFIG_MODE                = 0x80616006,
+	ERROR_PSMFPLAYER_INVALID_CONFIG_VALUE               = 0x80616008,
 	ERROR_PSMFPLAYER_NO_MORE_DATA                       = 0x8061600c,
 
 	ERROR_MPEG_NO_DATA                                  = 0x80618001,

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -60,6 +60,7 @@ static const int PSMF_LAST_TIMESTAMP_OFFSET = 0x5A;
 
 static const int atracDecodeDelayMs = 3000;
 static const int avcDecodeDelayMs = 5400;
+static const int mpegTimestampPerSecond = 90000;  // How many MPEG Timestamp units in a second.
 
 struct SceMpegAu {
 	s64_le pts;  // presentation time stamp

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -46,8 +46,6 @@ const int PSMF_PLAYER_CONFIG_NO_LOOP = 1;
 const int PSMF_PLAYER_CONFIG_MODE_LOOP = 0;
 const int PSMF_PLAYER_CONFIG_MODE_PIXEL_TYPE = 1;
 
-const int TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888 = 0X03;
-
 int psmfCurrentPts = 0;
 int psmfAvcStreamNum = 1;
 int psmfAtracStreamNum = 1;
@@ -56,7 +54,7 @@ int psmfPlayerVersion = PSMF_PLAYER_VERSION_FULL;
 int psmfMaxAheadTimestamp = 40000;
 int audioSamples = 2048;  
 int audioSamplesBytes = audioSamples * 4;
-int videoPixelMode = TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888;
+int videoPixelMode = GE_CMODE_32BIT_ABGR8888;
 int videoLoopStatus = PSMF_PLAYER_CONFIG_NO_LOOP;
 
 enum PsmfPlayerStatus {
@@ -457,7 +455,7 @@ PsmfPlayer *getPsmfPlayer(u32 psmfplayer)
 
 void __PsmfInit()
 {
-	videoPixelMode = TPSM_PIXEL_STORAGE_MODE_32BIT_ABGR8888;
+	videoPixelMode = GE_CMODE_32BIT_ABGR8888;
 	videoLoopStatus = PSMF_PLAYER_CONFIG_NO_LOOP;
 }
 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1109,7 +1109,7 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	if (!ret)
 		return hleDelayResult(ret, "psmfPlayer video decode", delaytime);
 	else
-		return hleDelayResult(ret, "psmfPlayer all data decoded", 3000);
+		return hleDelayResult(ret, "psmfPlayer all data decoded", avcDecodeDelayMs);
 }
 
 int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
@@ -1126,7 +1126,7 @@ int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 		psmfplayer->mediaengine->getAudioSamples(audioDataAddr);
 	}
 	int ret = psmfplayer->mediaengine->IsNoAudioData() ? (int)ERROR_PSMFPLAYER_NO_MORE_DATA : 0;
-	return hleDelayResult(ret, "psmfPlayer audio decode", 3000);
+	return hleDelayResult(ret, "psmfPlayer audio decode", atracDecodeDelayMs);
 }
 
 int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer) 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1323,17 +1323,38 @@ u32 scePsmfPlayerConfigPlayer(u32 psmfPlayer, int configMode, int configAttr)
 		ERROR_LOG(ME, "scePsmfPlayerConfigPlayer(%08x, %i, %i): invalid psmf player", psmfPlayer, configMode, configAttr);
 		return ERROR_PSMF_NOT_FOUND;
 	}
+
+	if (psmfplayer->status == PSMF_PLAYER_STATUS_NONE) {
+		 return ERROR_PSMFPLAYER_NOT_INITIALIZED;
+	}
+
 	if (configMode == PSMF_PLAYER_CONFIG_MODE_LOOP) {
 		INFO_LOG(ME, "scePsmfPlayerConfigPlayer(%08x, loop, %i)", psmfPlayer, configAttr);
+		if (configAttr < 0 || configAttr > 1) 
+			return ERROR_PSMFPLAYER_INVALID_CONFIG_VALUE;
+
 		videoLoopStatus = configAttr;
 	} else if (configMode == PSMF_PLAYER_CONFIG_MODE_PIXEL_TYPE) {
 		INFO_LOG(ME, "scePsmfPlayerConfigPlayer(%08x, pixelType, %i)", psmfPlayer, configAttr);
-		// Does -1 mean default or something?
-		if (configAttr != -1) {
-			videoPixelMode = configAttr;
-		}
+			switch (configAttr) {
+				case PSMF_PLAYER_PIXEL_TYPE_NONE:
+					// -1 means nothing to change
+					break;
+				case GE_CMODE_16BIT_BGR5650:
+				case GE_CMODE_16BIT_ABGR5551:
+				case GE_CMODE_16BIT_ABGR4444:
+				case GE_CMODE_32BIT_ABGR8888:
+					videoPixelMode = configAttr;
+					break;
+				case 4:
+					ERROR_LOG_REPORT(ME, "scePsmfPlayerConfigPlayer(%08x, %i): invalid config value %i", psmfPlayer, configMode, configAttr);
+					break;
+				default:
+					return ERROR_PSMFPLAYER_INVALID_CONFIG_VALUE;
+			}
 	} else {
-		ERROR_LOG_REPORT(ME, "scePsmfPlayerConfigPlayer(%08x, %i, %i): unknown parameter", psmfPlayer, configMode, configAttr);
+		ERROR_LOG_REPORT(ME, "scePsmfPlayerConfigPlayer(%08x, %i): invalid config mode %i", psmfPlayer, configAttr, configMode);
+		return ERROR_PSMFPLAYER_INVALID_CONFIG_MODE;
 	}
 
 	return 0;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -45,6 +45,7 @@ const int PSMF_PLAYER_CONFIG_LOOP = 0;
 const int PSMF_PLAYER_CONFIG_NO_LOOP = 1;
 const int PSMF_PLAYER_CONFIG_MODE_LOOP = 0;
 const int PSMF_PLAYER_CONFIG_MODE_PIXEL_TYPE = 1;
+const int PSMF_PLAYER_PIXEL_TYPE_NONE = -1;
 
 int psmfCurrentPts = 0;
 int psmfAvcStreamNum = 1;
@@ -858,8 +859,9 @@ int scePsmfPlayerStop(u32 psmfPlayer)
 {
 	INFO_LOG(ME, "scePsmfPlayerStop(%08x)", psmfPlayer);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
+	if (psmfplayer) {
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
+	}
 	return 0;
 }
 
@@ -867,8 +869,10 @@ int scePsmfPlayerBreak(u32 psmfPlayer)
 {
 	ERROR_LOG(ME, "UNIMPL scePsmfPlayerBreak(%08x)", psmfPlayer);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
-		psmfplayer->status = PSMF_PLAYER_STATUS_INIT;//Fix everybody stress buster
+	if (psmfplayer) {
+		// Fix everybody stress buster
+		psmfplayer->status = PSMF_PLAYER_STATUS_INIT;
+	}
 	return 0;
 }
 
@@ -923,14 +927,11 @@ int _PsmfPlayerSetPsmfOffset(PsmfPlayer *psmfplayer, const char * filename, int 
 int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename) 
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
-	{
+	if (psmfplayer) {
 		INFO_LOG(ME, "scePsmfPlayerSetPsmf(%08x, %s)", psmfPlayer, filename);
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
 		_PsmfPlayerSetPsmfOffset(psmfplayer, filename, 0, false);
-	}
-	else
-	{
+	} else {
 		ERROR_LOG(ME, "scePsmfPlayerSetPsmf(%08x, %s): invalid psmf player", psmfPlayer, filename);
 	}
 
@@ -941,14 +942,11 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 {
 	// TODO: hleCheckCurrentCallbacks?
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
-	{
+	if (psmfplayer) {
 		INFO_LOG(ME, "scePsmfPlayerSetPsmfCB(%08x, %s)", psmfPlayer, filename);
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
 		_PsmfPlayerSetPsmfOffset(psmfplayer, filename, 0, true);
-	}
-	else
-	{
+	} else {
 		ERROR_LOG(ME, "scePsmfPlayerSetPsmfCB(%08x, %s): invalid psmf player", psmfPlayer, filename);
 	}
 
@@ -958,14 +956,11 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 int scePsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset) 
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
-	{
+	if (psmfplayer) {
 		INFO_LOG(ME, "scePsmfPlayerSetPsmfOffset(%08x, %s, %i)", psmfPlayer, filename, offset);
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
 		_PsmfPlayerSetPsmfOffset(psmfplayer, filename, offset, false);
-	}
-	else
-	{
+	} else {
 		ERROR_LOG(ME, "scePsmfPlayerSetPsmfOffset(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
 	}
 
@@ -976,14 +971,11 @@ int scePsmfPlayerSetPsmfOffsetCB(u32 psmfPlayer, const char *filename, int offse
 {
 	// TODO: hleCheckCurrentCallbacks?
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
-	if (psmfplayer)
-	{
+	if (psmfplayer) {
 		INFO_LOG(ME, "scePsmfPlayerSetPsmfOffsetCB(%08x, %s, %i)", psmfPlayer, filename, offset);
 		psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
 		_PsmfPlayerSetPsmfOffset(psmfplayer, filename, offset, true);
-	}
-	else
-	{
+	} else {
 		ERROR_LOG(ME, "scePsmfPlayerSetPsmfOffsetCB(%08x, %s, %i): invalid psmf player", psmfPlayer, filename, offset);
 	}
 
@@ -1191,10 +1183,12 @@ u32 scePsmfPlayerGetCurrentPlayMode(u32 psmfPlayer, u32 playModeAddr, u32 playSp
 	}
 	WARN_LOG(ME, "scePsmfPlayerGetCurrentPlayMode(%08x, %08x, %08x)", psmfPlayer, playModeAddr, playSpeedAddr);
 	if (Memory::IsValidAddress(playModeAddr)) {
-		Memory::Write_U32(psmfplayer->playMode, playModeAddr); //Fixing for AKB MPEG wrong pointer
+		// Fix AKB MPEG wrong pointer
+		Memory::Write_U32(psmfplayer->playMode, playModeAddr);
 	}
 	if (Memory::IsValidAddress(playSpeedAddr)) {
-		Memory::Write_U32(psmfplayer->playSpeed, playSpeedAddr); //Fixing for AKB MPEG wrong pointer
+		// Fix AKB MPEG wrong pointer
+		Memory::Write_U32(psmfplayer->playSpeed, playSpeedAddr);
 	}
 	return 0;
 }

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1093,9 +1093,9 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	int ret = psmfplayer->mediaengine->IsVideoEnd() ? (int)ERROR_PSMFPLAYER_NO_MORE_DATA : 0;
 
 	s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
-	int delaytime = 3000;
+	int delaytime = avcDecodeDelayMs;
 	if (deltapts > 0 && !psmfplayer->mediaengine->IsNoAudioData())
-		delaytime = deltapts * 1000000 / 90000;
+		delaytime = std::min((int)(deltapts * 1000000 / mpegTimestampPerSecond) , 200000);
 	if (!ret)
 		return hleDelayResult(ret, "psmfPlayer video decode", delaytime);
 	else


### PR DESCRIPTION
Referencing 
https://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/scePsmfPlayer.java#661

It basically try to return error code for those invalid config mode and config value.

May help some games which uses PSMF. 
