### PR TITLE
If the RMB is bound to a cancel key, don't show the info menu.

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -97,16 +97,16 @@ public:
 		std::vector<int> pspKeys;
 		bool showInfo = false;
 
-		if (HasFocus() && (key.flags & KEY_UP) && KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys)) {
+		if (KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys)) {
 			for (auto it = pspKeys.begin(), end = pspKeys.end(); it != end; ++it) {
 				// If the button mapped to triangle, then show the info.
-				if (*it == CTRL_TRIANGLE) {
+				if (HasFocus() && (key.flags & KEY_UP) && *it == CTRL_TRIANGLE) {
 					showInfo = true;
 				}
 			}
 		} else if (hovering_ && key.deviceId == DEVICE_ID_MOUSE && key.keyCode == NKCODE_EXT_MOUSEBUTTON_2) {
 			// If it's the right mouse button, and it's not otherwise mapped, show the info also.
-			if (HasFocus() && (key.flags & KEY_UP)) {
+			if (key.flags & KEY_UP) {
 				showInfo = true;
 			}
 		}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -106,7 +106,7 @@ public:
 			}
 		} else if (hovering_ && key.deviceId == DEVICE_ID_MOUSE && key.keyCode == NKCODE_EXT_MOUSEBUTTON_2) {
 			// If it's the right mouse button, and it's not otherwise mapped, show the info also.
-			if (key.flags & KEY_UP) {
+			if (HasFocus() && (key.flags & KEY_UP)) {
 				showInfo = true;
 			}
 		}


### PR DESCRIPTION
This fixes a small bug where if the user has the right mouse button bound to a cancel key, it still shows a game's "info menu" anyway, regardless of the comment.

https://github.com/hrydgard/ppsspp/commit/8f98fa78aa759f77dcca43c1daf18fc3a203c9a0#commitcomment-5234565
