### PR TITLE
Flesh out the netconf dialog a bit by having it display an error, and add a stub for sceNetApctlDisconnect.

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -77,7 +77,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 		StartDraw();
 		DrawBanner();
 		PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x63636363));
-		PPGeDrawTextWrapped(err->T("PPSSPP currently does not support connecting to the Internet for DLC, PSN, or game updates."), 241, 132, WRAP_WIDTH, PPGE_ALIGN_CENTER, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawTextWrapped(err->T("PPSSPPDoesNotSupportInternet", "PPSSPP currently does not support connecting to the Internet for DLC, PSN, or game updates."), 241, 132, WRAP_WIDTH, PPGE_ALIGN_CENTER, 0.5f, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawImage(confirmBtnImage, 195, 250, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawText(d->T("OK"), 225, 252, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012- PPSSPP Project.
+﻿// Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -47,7 +47,10 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 	Memory::Memcpy(&request, paramAddr, size);
 
 	status = SCE_UTILITY_STATUS_INITIALIZE;
+
+	// Eat any keys pressed before the dialog inited.
 	__CtrlReadLatch();
+
 	StartFade(true);
 	return 0;
 }
@@ -55,6 +58,8 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 void PSPNetconfDialog::DrawBanner() {
 
 	PPGeDrawRect(0, 0, 480, 23, CalcFadedColor(0x65636358));
+
+	// TODO: Draw a hexagon icon
 	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
 	I18NCategory *d = GetI18NCategory("Dialog");
 	PPGeDrawText(d->T("Network Connection"), 30, 11, PPGE_ALIGN_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
@@ -84,6 +89,8 @@ int PSPNetconfDialog::Update(int animSpeed) {
 		if (IsButtonPressed(confirmBtn)) {
 			StartFade(false);
 			status = SCE_UTILITY_STATUS_FINISHED;
+			// TODO: When the dialog is aborted, does it really set the result to this?
+			// It seems to make Phantasy Star Portable 2 happy, so it should be okay for now.
 			request.common.result = SCE_UTILITY_DIALOG_RESULT_ABORT;
 		}
 		

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -46,5 +46,6 @@ public:
 	virtual void DoState(PointerWrap &p);
 
 private:
+	void DrawBanner();
 	SceUtilityNetconfParam request;
 };

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -359,7 +359,7 @@ int sceNetInetConnect(int socket, u32 sockAddrInternetPtr, int addressLength) {
 int sceNetApctlDisconnect() {
 	ERROR_LOG(SCENET, "UNIMPL %s()", __FUNCTION__);
 	// Like its 'sister' function sceNetAdhocctlDisconnect, we need to alert Apctl handlers that a disconnect took place
-	// or else games like Phantasy Star Portable 2 will hang.
+	// or else games like Phantasy Star Portable 2 will hang at certain points (e.g. returning to the main menu after trying to connect to PSN).
 	__UpdateApctlHandlers(0, 0, PSP_NET_APCTL_EVENT_DISCONNECT_REQUEST, 0);
 	return 0;
 }

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -48,6 +48,10 @@ enum {
 	ERROR_NET_ADHOCCTL_TOO_MANY_HANDLERS         = 0x80410b12,
 };
 
+enum {
+	PSP_NET_APCTL_EVENT_DISCONNECT_REQUEST = 5,
+};
+
 struct ProductStruct {
 	s32_le unknown; // Unknown, set to 0
 	char product[9]; // Game ID (Example: ULUS10000)
@@ -352,6 +356,14 @@ int sceNetInetConnect(int socket, u32 sockAddrInternetPtr, int addressLength) {
 	return -1;
 }
 
+int sceNetApctlDisconnect() {
+	ERROR_LOG(SCENET, "UNIMPL %s()", __FUNCTION__);
+	// Like its 'sister' function sceNetAdhocctlDisconnect, we need to alert Apctl handlers that a disconnect took place
+	// or else games like Phantasy Star Portable 2 will hang.
+	__UpdateApctlHandlers(0, 0, PSP_NET_APCTL_EVENT_DISCONNECT_REQUEST, 0);
+	return 0;
+}
+
 const HLEFunction sceNet[] = {
 	{0x39AF39A6, WrapU_UUUUU<sceNetInit>, "sceNetInit"},
 	{0x281928A9, WrapU_V<sceNetTerm>, "sceNetTerm"},
@@ -413,7 +425,7 @@ const HLEFunction sceNetInet[] = {
 
 const HLEFunction sceNetApctl[] = {
 	{0xCFB957C6, 0, "sceNetApctlConnect"},
-	{0x24fe91a1, 0, "sceNetApctlDisconnect"},
+	{0x24fe91a1, &WrapI_V<sceNetApctlDisconnect>, "sceNetApctlDisconnect" },
 	{0x5deac81b, 0, "sceNetApctlGetState"},
 	{0x8abadd51, WrapU_UU<sceNetApctlAddHandler>, "sceNetApctlAddHandler"},
 	{0xe2f91f9b, WrapI_V<sceNetApctlInit>, "sceNetApctlInit"},


### PR DESCRIPTION
The latter fixes a hang in Phantasy Star Portable 2 when trying to connect to PSN/online multiplayer, and the former prevents a hang in the Monster Hunter games when trying to download DLC.

![Screenshot 01](http://i.minus.com/iBaC9DEv3WTFv.jpg)

It needs a bit of work before it looks exactly like the PSP's Network Connection dialog, but it's a good start.
