### PR TITLE
Fix PSPSaveDialog::Update

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -534,19 +534,8 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 
 int PSPSaveDialog::Update(int animSpeed)
 {
-	switch (status) {
-	case SCE_UTILITY_STATUS_FINISHED:
-		status = SCE_UTILITY_STATUS_SHUTDOWN;
-		break;
-	default:
-		break;
-	}
-
 	if (status != SCE_UTILITY_STATUS_RUNNING)
-	{
-		status = SCE_UTILITY_STATUS_FINISHED;
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
-	}
 
 	if (!param.GetPspParam()) {
 		status = SCE_UTILITY_STATUS_SHUTDOWN;

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -543,7 +543,10 @@ int PSPSaveDialog::Update(int animSpeed)
 	}
 
 	if (status != SCE_UTILITY_STATUS_RUNNING)
+	{
+		status = SCE_UTILITY_STATUS_FINISHED;
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
+	}
 
 	if (!param.GetPspParam()) {
 		status = SCE_UTILITY_STATUS_SHUTDOWN;


### PR DESCRIPTION
Fix Miyako lock up in saving screen

My changed PPSSPP log
https://gist.github.com/sum2012/03ba496b0760a160e63b

JPCSP trace log
https://gist.github.com/sum2012/4ac98b8de6d69fca6b22

Match JPCSP trace log except
HLE\sceUtility.cpp:152 00000004=sceUtilitySavedataGetStatus()
