### PR TITLE
Return PSP_UMD_READY when sceKernelGetCompiledSdkVersion() != 0

### DIFF
--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -131,6 +131,10 @@ void __UmdStatChange(u64 userdata, int cyclesLate)
 void __KernelUmdActivate()
 {
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE;
+	// PSP_UMD_READY will be returned when sceKernelGetCompiledSdkVersion() != 0
+	if (sceKernelGetCompiledSdkVersion() != 0) {
+		notifyArg |= PSP_UMD_READY;
+	}
 	if (driveCBId != 0)
 		__KernelNotifyCallback(driveCBId, notifyArg);
 


### PR DESCRIPTION
When sceKernelGetCompiledSdkVersion() != 0 , sdkVersion set and PSP_UMD_READY will be |= to notifyArg and return as 0x32 instead of 0x22 .

Fixes #4969 & #4546

Thanks @daniel229 for finding out this fix.
