### PR TITLE
Fixed infrequent segfault in CheckAlpha

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1465,7 +1465,7 @@ void TextureCache::CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFm
 						break;
 					}
 				}
-				p += stride;
+				p += stride/2;
 			}
 		}
 		break;
@@ -1477,7 +1477,7 @@ void TextureCache::CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFm
 					u32 a = p[i] & 0x00010001;
 					hitZeroAlpha |= a ^ 0x00010001;
 				}
-				p += stride;
+				p += stride/2;
 			}
 		}
 		break;


### PR DESCRIPTION
pixelData was allocated with stride shorts per row and then advanced as
stride ints per row (reading every other row).  Upshot: fully solid
16-bit textures with alpha channels should now properly categorize as
ALPHA_FULL
