### PR TITLE
Minor dialog tweaks

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -18,6 +18,7 @@
 #include "i18n/i18n.h"
 
 #include "Common/ChunkFile.h"
+#include "Core/HLE/sceCtrl.h"
 #include "Core/Util/PPGeDraw.h"
 #include "Core/Dialog/PSPDialog.h"
 
@@ -124,14 +125,20 @@ pspUtilityDialogCommon *PSPDialog::GetCommonParam()
 	return 0;
 }
 
+void PSPDialog::UpdateButtons()
+{
+	lastButtons = __CtrlPeekButtons();
+	buttons = __CtrlReadLatch();
+}
+
 bool PSPDialog::IsButtonPressed(int checkButton)
 {
-	return !isFading && !(lastButtons & checkButton) && (buttons & checkButton);
+	return !isFading && (buttons & checkButton);
 }
 
 bool PSPDialog::IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold, int framesHeldRepeatRate)
 {
-	bool btnWasHeldLastFrame = (lastButtons & checkButton) && (buttons & checkButton);
+	bool btnWasHeldLastFrame = (lastButtons & checkButton) && (__CtrlPeekButtons() & checkButton);
 	if (!isFading && btnWasHeldLastFrame) {
 		framesHeld++;
 	}

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -78,6 +78,7 @@ public:
 	void StartDraw();
 	void EndDraw();
 protected:
+	void UpdateButtons();
 	bool IsButtonPressed(int checkButton);
 	bool IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold = 30, int framesHeldRepeatRate = 10);
 	// The caption override is assumed to have a size of 64 bytes.

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -131,7 +131,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr)
 
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 
-	lastButtons = __CtrlPeekButtons();
+	UpdateButtons();
 	StartFade(true);
 	return 0;
 }
@@ -222,9 +222,8 @@ int PSPMsgDialog::Update(int animSpeed)
 	}
 	else
 	{
+		UpdateButtons();
 		UpdateFade(animSpeed);
-
-		buttons = __CtrlPeekButtons();
 
 		okButtonImg = I_CIRCLE;
 		cancelButtonImg = I_CROSS;
@@ -280,7 +279,6 @@ int PSPMsgDialog::Update(int animSpeed)
 
 		EndDraw();
 
-		lastButtons = buttons;
 		messageDialog.result = 0;
 	}
 

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -49,7 +49,7 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 	status = SCE_UTILITY_STATUS_INITIALIZE;
 
 	// Eat any keys pressed before the dialog inited.
-	__CtrlReadLatch();
+	UpdateButtons();
 
 	StartFade(true);
 	return 0;
@@ -66,7 +66,7 @@ void PSPNetconfDialog::DrawBanner() {
 }
 
 int PSPNetconfDialog::Update(int animSpeed) {
-	buttons = __CtrlPeekButtons();
+	UpdateButtons();
 	I18NCategory *d = GetI18NCategory("Dialog");
 	I18NCategory *err = GetI18NCategory("Error");
 	const float WRAP_WIDTH = 254.0f;

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -706,7 +706,7 @@ void PSPOskDialog::RenderKeyboard()
 
 	std::string buffer;
 
-	u32 FIELDDRAWMAX = 15;
+	static const u32 FIELDDRAWMAX = 16;
 	u32 limit = FieldMaxLength();
 	u32 drawLimit = std::min(FIELDDRAWMAX, limit);   // Field drew length limit.
 

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -279,7 +279,7 @@ int PSPOskDialog::Init(u32 oskPtr)
 	languageMapping = GetLangValuesMapping();
 
 	// Eat any keys pressed before the dialog inited.
-	__CtrlReadLatch();
+	UpdateButtons();
 
 	StartFade(true);
 	return 0;
@@ -860,7 +860,7 @@ int PSPOskDialog::Update(int animSpeed)
 	const int framesHeldThreshold = 10;
 	const int framesHeldRepeatRate = 5;
 
-	buttons = __CtrlPeekButtons();
+	UpdateButtons();
 	int selectedRow = selectedChar / numKeyCols[currentKeyboard];
 	int selectedExtra = selectedChar % numKeyCols[currentKeyboard];
 
@@ -1062,7 +1062,6 @@ int PSPOskDialog::Update(int animSpeed)
 
 	oskParams->base.result = 0;
 	oskParams->fields[0].result = PSP_UTILITY_OSK_RESULT_CHANGED;
-	lastButtons = buttons;
 	return 0;
 }
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -762,7 +762,10 @@ int PSPSaveDialog::Update(int animSpeed)
 			DisplayButtons(DS_BUTTON_CANCEL);
 			DisplayBanner(DB_LOAD);
 
-			if (IsButtonPressed(cancelButtonFlag)) {
+			// Allow OK to be pressed as well to confirm the save.
+			// The PSP only allows cancel, but that's generally not great UX.
+			// Allowing this here makes it quicker for most users to get into the actual game.
+			if (IsButtonPressed(cancelButtonFlag) || IsButtonPressed(okButtonFlag)) {
 				param.GetPspParam()->common.result = SCE_UTILITY_DIALOG_RESULT_SUCCESS;
 				// Set the save to use for autosave and autoload
 				param.SetSelectedSave(param.GetFileInfo(currentSelectedSave).idx);

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -176,7 +176,7 @@ int PSPSaveDialog::Init(int paramAddr)
 
 	status = (int)retval < 0 ? SCE_UTILITY_STATUS_SHUTDOWN : SCE_UTILITY_STATUS_INITIALIZE;
 
-	lastButtons = __CtrlPeekButtons();
+	UpdateButtons();
 	StartFade(true);
 
 	/*INFO_LOG(SCEUTILITY,"Dump Param :");
@@ -553,7 +553,7 @@ int PSPSaveDialog::Update(int animSpeed)
 		param.SetPspParam(&request);
 	}
 
-	buttons = __CtrlPeekButtons();
+	UpdateButtons();
 	UpdateFade(animSpeed);
 
 	okButtonImg = I_CIRCLE;
@@ -976,8 +976,6 @@ int PSPSaveDialog::Update(int animSpeed)
 			status = SCE_UTILITY_STATUS_FINISHED;
 		break;
 	}
-
-	lastButtons = buttons;
 
 	if (status == SCE_UTILITY_STATUS_FINISHED)
 		Memory::Memcpy(requestAddr, &request, request.common.size);


### PR DESCRIPTION
Draw 16 characters at a time to reduce confusion about Valkyria Chronicles passwords, and anyway, 16 seems like a likely limit compared to 15, and gives more than enough room still.

Also use the latch to read characters.  Unlike `__CtrlPeekButtons()` which tells you exactly what buttons are pressed now, the latch alternates with rapid fire.  This allows rapid fire to apply to save dialogs as well, which I prefer.

Lastly is the most possibly controversial change (for those who prefer dialogs to be emulated exactly): allow OK/confirm to accept a "Savedata loaded" confirmation screen.  The PSP itself requires you to press back/cancel, but this message is not a message users generally need to confirm in that way.

In contrast, saved, deleted, no data, etc. are messages that it makes more sense for users to read, even if they're mashing x.

This UX choice can be found in most games that use their own custom save UI (rather than the PSP's dialog.)

-[Unknown]
