### PR TITLE
Force aligned memory access for iOS

### DIFF
--- a/ext/xxhash.c
+++ b/ext/xxhash.c
@@ -38,7 +38,7 @@ You can contact the author at :
 // For others CPU, the compiler will be more cautious, and insert extra code to ensure aligned access is respected.
 // If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
 // You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
-#if defined(ARM) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#if !defined(IOS) && (defined(ARM) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64))
 #  define XXH_USE_UNALIGNED_ACCESS 1
 #endif
 


### PR DESCRIPTION
Relevant #5047, partly reverts https://github.com/hrydgard/ppsspp/commit/2e324c9842457e98bd89771cd2e97e1d22c5e82b

Fixes Monster Hunter Freedom Unite loading crash for iOS, probably some other games.
