### PR TITLE
Set voices as keyed off when their envelope ends

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -99,7 +99,7 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 	INFO_LOG(SCESAS, "sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
 
 	sas->SetGrainSize(grainSize);
-	// Seems like maxVoiecs is actually ignored for all intents and purposes.
+	// Seems like maxVoices is actually ignored for all intents and purposes.
 	sas->maxVoices = PSP_SAS_VOICES_MAX;
 	sas->outputMode = outputMode;
 	for (int i = 0; i < sas->maxVoices; i++) {
@@ -117,7 +117,7 @@ u32 sceSasGetEndFlag(u32 core) {
 			endFlag |= (1 << i);
 	}
 
-	DEBUG_LOG(SCESAS, "sceSasGetEndFlag(%08x)", endFlag);
+	DEBUG_LOG(SCESAS, "%08x=sceSasGetEndFlag(%08x)", endFlag, core);
 	return endFlag;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -347,7 +347,7 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 		{
 			vag.GetSamples(output, numSamples);
 			if (vag.End()) {
-				// NOTICE_LOG(SAS, "Hit end of VAG audio");
+				// NOTICE_LOG(SCESAS, "Hit end of VAG audio");
 				playing = false;
 				on = false;  // ??
 				envelope.KeyOff();
@@ -464,8 +464,9 @@ void SasInstance::MixVoice(SasVoice &voice) {
 
 		if (voice.envelope.HasEnded())
 		{
-			// NOTICE_LOG(SAS, "Hit end of envelope");
+			// NOTICE_LOG(SCESAS, "Hit end of envelope");
 			voice.playing = false;
+			voice.on = false;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4114, sounds/music stopping in Tales of the World: Radiant Mythology.

I'm a bit scared that this could break a bunch of games.  I've still not figured out fully how to autotest this, but I've been messing with it again.

I tested several games (looking specifically for ones that did hit envelope ends, which is not all of them for sure), and couldn't find any where the sound effects seemed wrong or where there were hangs or repeats.

Possibly, this end here just masked the bug that the recent Yu-Gi-Oh fix resolved, or something.

But I'd appreciate it if people could test more games, especially ones that have picky sound effects, Yu-Gi-Oh, that Naruto game, etc.

-[Unknown]
