### PR TITLE
Fix MHP3 Chinese version crash in scempeg and scejpeg

### DIFF
--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -139,6 +139,10 @@ int sceJpegDecodeMJpegSuccessively(u32 jpegAddr, int jpegSize, u32 imageAddr, in
 
 int sceJpegCsc(u32 imageAddr, u32 yCbCrAddr, int widthHeight, int bufferWidth, int colourInfo)
 {
+	if (bufferWidth < 0 || widthHeight < 0){
+		WARN_LOG(ME, "sceJpegCsc(%i, %i, %i, %i, %i)", imageAddr, yCbCrAddr, widthHeight, bufferWidth, colourInfo);
+		return 0x80650051;
+	}
 	__JpegCsc(imageAddr, yCbCrAddr, widthHeight, bufferWidth);
 	DEBUG_LOG(ME, "sceJpegCsc(%i, %i, %i, %i, %i)", imageAddr, yCbCrAddr, widthHeight, bufferWidth, colourInfo);
 	return 0;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1551,6 +1551,11 @@ int sceMpegAvcConvertToYuv420(u32 mpeg, u32 bufferOutputAddr, u32 unknown1, int 
 		return -1;
 	}
 
+	if (ctx->mediaengine->m_buffer == 0){
+		WARN_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x)m_buffer = 0 ", mpeg, bufferOutputAddr, unknown1, unknown2);
+		return 0x806201FE;
+	}
+
 	DEBUG_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x)", mpeg, bufferOutputAddr, unknown1, unknown2);
 	const u8 *data = ctx->mediaengine->getFrameImage();
 	int width = ctx->mediaengine->m_desWidth;


### PR DESCRIPTION
![1](https://f.cloud.github.com/assets/2177532/2071842/c9601182-8d2f-11e3-9d1f-77589359e15f.png)
![2](https://f.cloud.github.com/assets/2177532/2071847/cf1f45a2-8d2f-11e3-8c87-83fdd87d763e.png)
![3](https://f.cloud.github.com/assets/2177532/2071849/d68121ee-8d2f-11e3-86ca-82c9c0f800d6.png)

Fix based on JPCSP trace log
07:41:31 videoThread - sceMpegAvcConvertToYuv420 0x9C02828, 0x9836F80, 0x92F4240, 0x0 = 0x806201FE
07:41:31 videoThread - sceJpegCsc 0x11E9E000, 0x9836F80, 0xFFFEFFFF, 0x200, 0x20202 = 0x80650051
