### PR TITLE
Fix language selection list

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -223,11 +223,7 @@ NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen
 	langValuesMapping = GetLangValuesMapping();
 
 	std::vector<FileInfo> tempLangs;
-#ifdef ANDROID
-	VFSGetFileListing("assets/lang", &tempLangs, "ini");
-#else
 	VFSGetFileListing("lang", &tempLangs, "ini");
-#endif
 	std::vector<std::string> listing;
 	int selected = -1;
 	int counter = 0;


### PR DESCRIPTION
You can´t choose any language on android, probably because of a bugfix (see https://github.com/hrydgard/ppsspp/commit/ca8311b4b814361f044c08d8f58e33eb1b2dd99c)
