### PR TITLE
Win32: Add a command-line (no GUI or ini) option to let the escape button exit the emulator.

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -69,6 +69,7 @@ public:
 	bool bTopMost;
 	std::string sFont;
 	bool bIgnoreWindowsKey;
+	bool bEscapeExitsEmulator;
 #endif
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -118,6 +118,11 @@ namespace WindowsRawInput {
 			return;
 		}
 
+		if (g_Config.bEscapeExitsEmulator && raw->data.keyboard.VKey == VK_ESCAPE) {
+			DestroyWindow(MainWindow::GetHWND());
+			return;
+		}
+
 		KeyInput key;
 		key.deviceId = DEVICE_ID_KEYBOARD;
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -297,6 +297,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 			if (!strncmp(__argv[i], "--windowed", strlen("--windowed")))
 				g_Config.bFullScreen = false;
+
+			if (!strncmp(__argv[i], "--escapeexitsemu", strlen("--escapeexitsemu")))
+				g_Config.bEscapeExitsEmulator = true;
 		}
 	}
 #ifdef _DEBUG


### PR DESCRIPTION
This should make PPSSPP a bit more front-end friendly by letting the user simply hit escape to quit the program. The only drawback I could really see is changing UMDs in multi-disc games becomes a bit problematic, but I suppose we could make a hotkey for it, if it ends up becoming a problem for front-end users.

This doesn't save to or read from the ini file, since there's no real point currently. The users of such an option would likely be adding other command-line options for PPSSPP to parse, I would think.
