### PR TITLE
Improve SAS ADSR rates and types

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -352,7 +352,7 @@ u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) 
 		return ERROR_SAS_INVALID_VOICE;
 	}
 	// Create a mask like flag for the invalid values.
-	int invalid = (a < 0 ? 0x1 : 0) | (a < 0 ? 0x1 : 0) | (s < 0 ? 0x1 : 0) | (r < 0 ? 0x1 : 0);
+	int invalid = (a < 0 ? 0x1 : 0) | (d < 0 ? 0x2 : 0) | (s < 0 ? 0x4 : 0) | (r < 0 ? 0x8 : 0);
 	if (invalid & flag) {
 		WARN_LOG_REPORT(SCESAS, "sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid value", core, voiceNum, flag, a, d, s, r)
 		return ERROR_SAS_INVALID_ADSR_RATE;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -48,6 +48,7 @@ enum {
 	ERROR_SAS_INVALID_PARAMETER = 0x80420014,
 	ERROR_SAS_VOICE_PAUSED = 0x80420016,
 	ERROR_SAS_INVALID_VOLUME = 0x80420018,
+	ERROR_SAS_INVALID_ADSR_RATE = 0x80420019,
 	ERROR_SAS_INVALID_SIZE = 0x8042001A,
 	ERROR_SAS_BUSY = 0x80420030,
 	ERROR_SAS_NOT_INIT = 0x80420100,
@@ -345,13 +346,19 @@ u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 	return 0;
 }
 
-u32 sceSasSetADSR(u32 core, int voiceNum, int flag , int a, int d, int s, int r) {
-	DEBUG_LOG(SCESAS, "0=sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x)",core, voiceNum, flag, a, d, s, r)
-
+u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
 	}
+	// Create a mask like flag for the invalid values.
+	int invalid = (a < 0 ? 0x1 : 0) | (a < 0 ? 0x1 : 0) | (s < 0 ? 0x1 : 0) | (r < 0 ? 0x1 : 0);
+	if (invalid & flag) {
+		WARN_LOG(SCESAS, "sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid value", core, voiceNum, flag, a, d, s, r)
+		return ERROR_SAS_INVALID_ADSR_RATE;
+	}
+
+	DEBUG_LOG(SCESAS, "0=sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x)", core, voiceNum, flag, a, d, s, r)
 
 	SasVoice &v = sas->voices[voiceNum];
 	if ((flag & 0x1) != 0) v.envelope.attackRate  = a;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -379,12 +379,17 @@ u32 sceSasSetADSRMode(u32 core, int voiceNum,int flag ,int a, int d, int s, int 
 
 
 u32 sceSasSetSimpleADSR(u32 core, int voiceNum, u32 ADSREnv1, u32 ADSREnv2) {
-	DEBUG_LOG(SCESAS, "sasSetSimpleADSR(%08x, %i, %08x, %08x)", core, voiceNum, ADSREnv1, ADSREnv2);
-
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
 	}
+	// This bit could be related to decay type or systain type, but gives an error if you try to set it.
+	if ((ADSREnv2 >> 13) & 1) {
+		WARN_LOG_REPORT(SCESAS, "sceSasSetSimpleADSR(%08x, %d, %04x, %04x): Invalid ADSREnv2", core, voiceNum, ADSREnv1, ADSREnv2);
+		return ERROR_SAS_INVALID_ADSR_CURVE_MODE;
+	}
+
+	DEBUG_LOG(SCESAS, "sasSetSimpleADSR(%08x, %i, %08x, %08x)", core, voiceNum, ADSREnv1, ADSREnv2);
 
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.SetSimpleEnvelope(ADSREnv1 & 0xFFFF, ADSREnv2 & 0xFFFF);

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -396,7 +396,7 @@ int sceUtilityNetconfInitStart(u32 paramsAddr)
 int sceUtilityNetconfShutdownStart(unsigned int unknown)
 {
 	if (currentDialogType != UTILITY_DIALOG_NET) {
-		WARN_LOG(SCEUTILITY, "sceUtilityNetconfShutdownStartt(): wrong dialog type");
+		WARN_LOG(SCEUTILITY, "sceUtilityNetconfShutdownStart(): wrong dialog type");
 		return SCE_ERROR_UTILITY_WRONG_TYPE;
 	}
 	currentDialogActive = false;


### PR DESCRIPTION
This does not actually affect the envelope calculation, just the initial values as set by the __sceSasSetSimpleADSR() func and validations for the other two __sceSasSetADSR*() funcs.

The simple bitfields were not being parsed entirely correctly.  Final Fantasy Tactics, at least, hits basically all of these cases.  I don't have a good ear for it, but this may possibly improve some of its sound effects.  It could also affect games hanging, since a couple cases produced negative or 0 rates incorrectly.

This passes some in-progress tests I have, but they depend on the sceSas struct being written properly, which I'm still not ready with.

Also adds reporting for the "Every Extend Extra" case which I can't reproduce returning success.  Worried this could break things, does anyone have Every Extend Extra to verify it calls it this way still (I see from blame history that this was quite a long time ago)?

@gid15 I believe the "simple ADSR" bit stuff came from JPCSP.  I checked really quick and AFAICT it's incorrect per these changes / my tests.  Just FYI.

-[Unknown]
