### PR TITLE
Return current status instead of previous one

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -37,12 +37,11 @@ PSPDialog::~PSPDialog() {
 
 PSPDialog::DialogStatus PSPDialog::GetStatus()
 {
-	PSPDialog::DialogStatus retval = status;
 	if (status == SCE_UTILITY_STATUS_SHUTDOWN)
 		status = SCE_UTILITY_STATUS_NONE;
 	if (status == SCE_UTILITY_STATUS_INITIALIZE)
 		status = SCE_UTILITY_STATUS_RUNNING;
-	return retval;
+	return status;
 }
 
 void PSPDialog::StartDraw()


### PR DESCRIPTION
Probably this is more correct ? Not too sure why we're returing previous status but not the current one 

// When hits status 4 (SCE_UTILITY_STATUS_SHUTDOWN) here , return status 0 (SCE_UTILITY_STATUS_NONE)
