### PR TITLE
Use a delay to approximate timing of savedata status changes

### DIFF
--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -83,12 +83,22 @@ protected:
 	bool IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold = 30, int framesHeldRepeatRate = 10);
 	// The caption override is assumed to have a size of 64 bytes.
 	void DisplayButtons(int flags, const char *caption = NULL);
+	void ChangeStatus(DialogStatus newStatus, int delayUs);
+	void ChangeStatusInit(int delayUs);
+	void ChangeStatusShutdown(int delayUs);
+
+	// TODO: Remove this once all dialogs are updated.
+	virtual bool UseAutoStatus() {
+		return true;
+	}
 
 	void StartFade(bool fadeIn_);
 	void UpdateFade(int animSpeed);
 	u32 CalcFadedColor(u32 inColor);
 
 	DialogStatus status;
+	DialogStatus pendingStatus;
+	u64 pendingStatusTicks;
 
 	unsigned int lastButtons;
 	unsigned int buttons;

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -73,6 +73,11 @@ public:
 	virtual void DoState(PointerWrap &p);
 	virtual pspUtilityDialogCommon *GetCommonParam();
 
+protected:
+	virtual bool UseAutoStatus() {
+		return false;
+	}
+
 private:
 
 	void DisplayBanner(int which);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1002,10 +1002,11 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 		ERROR_LOG_REPORT(SCEUTILITY, "SavedataParam::GetFilesList(): too many normal entries, %d", fileList->maxNormalEntries);
 		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
 	}
-	// TODO: This may depend on sdk version or something?  Not returned by default.
-	if (false && fileList->systemEntries.IsValid() && fileList->maxSystemEntries > 5) {
-		ERROR_LOG_REPORT(SCEUTILITY, "SavedataParam::GetFilesList(): too many system entries, %d", fileList->maxSystemEntries);
-		return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
+	if (sceKernelGetCompiledSdkVersion() >= 0x02060000) {
+		if (fileList->systemEntries.IsValid() && fileList->maxSystemEntries > 5) {
+			ERROR_LOG_REPORT(SCEUTILITY, "SavedataParam::GetFilesList(): too many system entries, %d", fileList->maxSystemEntries);
+			return SCE_UTILITY_SAVEDATA_ERROR_RW_BAD_PARAMS;
+		}
 	}
 
 	std::string dirPath = savePath + GetGameName(param) + GetSaveName(param);


### PR DESCRIPTION
Timing based on tests, but it seems to vary, and thread priority greatly affects it.  I'm hoping this will work well enough.

May improve the games that have problems when the status changes immediately or when they wait to check the status and expect it to have already changed.

-[Unknown]
