### PR TITLE
Avoid repeat spamming of audio end reach in the case of audio stream present

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1174,7 +1174,7 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		result = ERROR_MPEG_NO_DATA;
 	}
 
-	if (ctx->mediaengine->IsNoAudioData() && !ctx->endOfAudioReached) {
+	if (ctx->atracRegistered && ctx->mediaengine->IsNoAudioData() && !ctx->endOfAudioReached) {
 		WARN_LOG(ME, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ctx->endOfAudioReached = true;
 		result = ERROR_MPEG_NO_DATA;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1165,18 +1165,18 @@ int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	}
 
 	int result = 0;
-
 	atracAu.pts = ctx->mediaengine->getAudioTimeStamp() + ctx->mpegFirstTimestamp;
+	
 	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(ME, "video end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		mpegRingbuffer.packetsFree = mpegRingbuffer.packets;
 		Memory::WriteStruct(ctx->mpegRingbufferAddr, &mpegRingbuffer);
-
 		result = ERROR_MPEG_NO_DATA;
 	}
 
-	if (ctx->mediaengine->IsNoAudioData()) {
-		INFO_LOG(ME, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
+	if (ctx->mediaengine->IsNoAudioData() && !ctx->endOfAudioReached) {
+		WARN_LOG(ME, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
+		ctx->endOfAudioReached = true;
 		result = ERROR_MPEG_NO_DATA;
 	}
 


### PR DESCRIPTION
It should be reached audio end only once .

This should also fix missing audio in Obsure Aftermath , probably helps others.

Just further tested , it also fixes Patapon 3 as well as Xyanide.Resurrection
