### PR TITLE
Fix recent ADSR regressions

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -389,7 +389,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	network->Get("EnableWlan", &bEnableWlan, false);
 
 	IniFile::Section *pspConfig = iniFile.GetOrCreateSection("SystemParam");
-	pspConfig->Get("PSPModel", &iPSPModel, PSP_MODEL_SLIM);
 	pspConfig->Get("PSPFirmwareVersion", &iFirmwareVersion, PSP_DEFAULT_FIRMWARE);
 	// TODO: Can probably default this on, but not sure about its memory differences.
 #if !defined(_M_X64) && !defined(_WIN32) && !defined(__SYMBIAN32__)

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -20,6 +20,7 @@
 #include "Core/MemMap.h"
 #include "Core/HLE/sceAtrac.h"
 #include "Core/Config.h"
+#include "Core/Reporting.h"
 #include "SasAudio.h"
 
 #include <algorithm>
@@ -286,6 +287,8 @@ static int getReleaseRate(int bitfield2) {
 		}
 		return 0x10000000 >> n;
 	}
+	if (n == 0)
+		return 0x7FFFFFFF;
 	return 0x80000000 >> n;
 }
 
@@ -303,6 +306,10 @@ void ADSREnvelope::SetSimpleEnvelope(u32 ADSREnv1, u32 ADSREnv2) {
 	releaseRate 	= getReleaseRate(ADSREnv2);
 	releaseType 	= getReleaseType(ADSREnv2);
 	sustainLevel 	= getSustainLevel(ADSREnv1);
+
+	if (attackRate < 0 || decayRate < 0 || sustainRate < 0 || releaseRate < 0) {
+		ERROR_LOG_REPORT(SCESAS, "Simple ADSR resulted in invalid rates: %04x, %04x", ADSREnv1, ADSREnv2);
+	}
 }
 
 SasInstance::SasInstance()

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -367,7 +367,8 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 				// NOTICE_LOG(SCESAS, "Hit end of VAG audio");
 				playing = false;
 				on = false;  // ??
-				envelope.KeyOff();
+				// TODO: Should this remain on somehow or just hit rock bottom immediately?
+				envelope.End();
 			}
 		}
 		break;
@@ -396,7 +397,7 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 				// Hit atrac3 voice end
 				playing = false;
 				on = false;  // ??
-				envelope.KeyOff();
+				envelope.End();
 			}
 		}
 		break;
@@ -878,6 +879,11 @@ void ADSREnvelope::KeyOff() {
 	// Does this really make sense? I don't think so, the release-decay should happen
 	// from whatever level we are at, although the weirdo exponentials we have start at a fixed state :(
 	height_ = sustainLevel;
+}
+
+void ADSREnvelope::End() {
+	SetState(STATE_OFF);
+	height_ = 0;
 }
 
 void ADSREnvelope::DoState(PointerWrap &p) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -139,6 +139,7 @@ public:
 
 	void KeyOn();
 	void KeyOff();
+	void End();
 
 	void Step();
 


### PR DESCRIPTION
Fixes #5383, probably/hopefully also #5379.

We can't really key off when we set playing = false.  If it's not playing, it won't step, and if it doesn't step, it'll never end.

Although, I'm not sure, maybe it instead forces the height to zero for an ended voice.... I don't think it will matter since the voice will not play either way until reset to attack.

-[Unknown]
