### PR TITLE
Support additional prefixes, like memstick:

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -220,10 +220,15 @@ bool MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpat
 
 	if ( RealPath(*currentDirectory, inpath, realpath) )
 	{
+		std::string prefix = realpath;
+		size_t prefixPos = realpath.find(':');
+		if (prefixPos != realpath.npos)
+			prefix = NormalizePrefix(realpath.substr(0, prefixPos + 1));
+
 		for (size_t i = 0; i < fileSystems.size(); i++)
 		{
 			size_t prefLen = fileSystems[i].prefix.size();
-			if (strncasecmp(fileSystems[i].prefix.c_str(), realpath.c_str(), prefLen) == 0)
+			if (strncasecmp(fileSystems[i].prefix.c_str(), prefix.c_str(), prefLen) == 0)
 			{
 				outpath = realpath.substr(prefLen);
 				*system = &(fileSystems[i]);
@@ -237,6 +242,20 @@ bool MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpat
 
 	DEBUG_LOG(FILESYS, "MapFilePath: failed mapping \"%s\", returning false", inpath.c_str());
 	return false;
+}
+
+std::string MetaFileSystem::NormalizePrefix(std::string prefix) const {
+	// Let's apply some mapping here since it won't break savestates.
+	if (prefix == "memstick:")
+		prefix = "ms0:";
+	// Seems like umd00: etc. work just fine...
+	if (startsWith(prefix, "umd"))
+		prefix = "umd0:";
+	// Seems like umd00: etc. work just fine...
+	if (startsWith(prefix, "host"))
+		prefix = "host0:";
+
+	return prefix;
 }
 
 void MetaFileSystem::Mount(std::string prefix, IFileSystem *system)
@@ -267,7 +286,7 @@ void MetaFileSystem::Remount(IFileSystem *oldSystem, IFileSystem *newSystem) {
 
 IFileSystem *MetaFileSystem::GetSystem(const std::string &prefix) {
 	for (auto it = fileSystems.begin(); it != fileSystems.end(); ++it) {
-		if (it->prefix == prefix)
+		if (it->prefix == NormalizePrefix(prefix))
 			return it->system;
 	}
 	return NULL;

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -79,6 +79,8 @@ public:
 		return false;
 	}
 
+	std::string NormalizePrefix(std::string prefix) const;
+
 	// Only possible if a file system is a DirectoryFileSystem or similar.
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1338,7 +1338,7 @@ u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 outPtr, 
 
 	// This should really send it on to a FileSystem implementation instead.
 
-	if (!strcmp(name, "mscmhc0:") || !strcmp(name, "ms0:"))
+	if (!strcmp(name, "mscmhc0:") || !strcmp(name, "ms0:") || !strcmp(name, "memstick:"))
 	{
 		// MemorySticks Checks
 		switch (cmd) {


### PR DESCRIPTION
I also found umd01: and host01: work, etc.  May help #5377 and possibly others.

It seems like games can assign these at will and potentially even subpaths, but reporting hasn't shown many cases yet.  We can still watch it.

Avoided mapping additional systems because savestates don't handle that well currently.

-[Unknown]
