### PR TITLE
Do it same way as sceMpegQueryStreamSize()

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -262,6 +262,11 @@ void AnalyzeMpeg(u8 *buffer, MpegContext *ctx) {
 	ctx->audioFrameCount = 0;
 	ctx->endOfAudioReached = false;
 	ctx->endOfVideoReached = false;
+
+	// Sanity Check ctx->mpegFirstTimestamp
+	if (ctx->mpegFirstTimestamp != 90000) {
+		WARN_LOG_REPORT(ME, "Unexpected mpeg first timestamp: %llx / %lld", ctx->mpegFirstTimestamp, ctx->mpegFirstTimestamp);
+	}
 	
 	if (ctx->mpegMagic != PSMF_MAGIC || ctx->mpegVersion < 0 ||
 		(ctx->mpegOffset & 2047) != 0 || ctx->mpegOffset == 0) {

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -263,11 +263,6 @@ void AnalyzeMpeg(u8 *buffer, MpegContext *ctx) {
 	ctx->endOfAudioReached = false;
 	ctx->endOfVideoReached = false;
 	
-	// Sanity Check ctx->mpegFirstTimestamp
-	if (ctx->mpegFirstTimestamp != 90000) {
-		WARN_LOG_REPORT(ME, "Unexpected mpeg first timestamp: %llx / %lld", ctx->mpegFirstTimestamp, ctx->mpegFirstTimestamp);
-	}
-	
 	if (ctx->mpegMagic != PSMF_MAGIC || ctx->mpegVersion < 0 ||
 		(ctx->mpegOffset & 2047) != 0 || ctx->mpegOffset == 0) {
 		// mpeg header is invalid!
@@ -515,32 +510,28 @@ int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 		return -1;
 	}
 
-	MpegContext *ctx = getMpegCtx(mpeg);
-	if (!ctx) {
-		WARN_LOG(ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, offsetAddr);
-		return -1;
-	}
-
 	DEBUG_LOG(ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x)", mpeg, bufferAddr, offsetAddr);
 
-	// Kinda destructive, no?
-	AnalyzeMpeg(Memory::GetPointer(bufferAddr), ctx);
+	MpegContext ctx;
+	ctx.mediaengine = 0;
 
-	if (ctx->mpegMagic != PSMF_MAGIC) {
+	AnalyzeMpeg(Memory::GetPointer(bufferAddr), &ctx);
+
+	if (ctx.mpegMagic != PSMF_MAGIC) {
 		ERROR_LOG(ME, "sceMpegQueryStreamOffset: Bad PSMF magic");
 		Memory::Write_U32(0, offsetAddr);
 		return ERROR_MPEG_INVALID_VALUE;
-	} else if (ctx->mpegVersion < 0) {
+	} else if (ctx.mpegVersion < 0) {
 		ERROR_LOG(ME, "sceMpegQueryStreamOffset: Bad version");
 		Memory::Write_U32(0, offsetAddr);
 		return ERROR_MPEG_BAD_VERSION;
-	} else if ((ctx->mpegOffset & 2047) != 0 || ctx->mpegOffset == 0) {
+	} else if ((ctx.mpegOffset & 2047) != 0 || ctx.mpegOffset == 0) {
 		ERROR_LOG(ME, "sceMpegQueryStreamOffset: Bad offset");
 		Memory::Write_U32(0, offsetAddr);
 		return ERROR_MPEG_INVALID_VALUE;
 	}
 
-	Memory::Write_U32(ctx->mpegOffset, offsetAddr);
+	Memory::Write_U32(ctx.mpegOffset, offsetAddr);
 	return 0;
 }
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -761,9 +761,7 @@ s64 MediaEngine::getVideoTimeStamp() {
 }
 
 s64 MediaEngine::getAudioTimeStamp() {
-	if (m_demux)
-		return std::max(m_audiopts - 4180, (s64)0);
-	return m_videopts;
+	return m_audiopts;
 }
 
 s64 MediaEngine::getLastTimeStamp() {


### PR DESCRIPTION
Try to do AnalyzeMpeg() as sceMpegQueryStreamSize() and return simply return the m_audiopts from getAudioTimeStamp() 

Fixes https://github.com/hrydgard/ppsspp/issues/5131 and bit regression from #5381 
