### PR TITLE
Update ADSR exponent curves and fix some small issues in ADSR

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -753,7 +753,7 @@ void ADSREnvelope::Step() {
 	switch (state_) {
 	case STATE_ATTACK:
 		WalkCurve(type_);
-		if (height_ > PSP_SAS_ENVELOPE_HEIGHT_MAX || height_ < 0)
+		if (height_ >= PSP_SAS_ENVELOPE_HEIGHT_MAX || height_ < 0)
 			SetState(STATE_DECAY);
 		break;
 	case STATE_DECAY:

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -705,13 +705,15 @@ void ADSREnvelope::WalkCurve(int type) {
 
 	case PSP_SAS_ADSR_CURVE_MODE_EXPONENT_DECREASE:
 		expDelta = height_ - PSP_SAS_ENVELOPE_HEIGHT_MAX;
-		expDelta -= (expDelta * (s64)rate_) / 0x100000000LL;
-		height_ = expDelta + PSP_SAS_ENVELOPE_HEIGHT_MAX - ((u32)rate_ + 3UL) / 4UL;
+		// Flipping the sign so that we can shift in the top bits.
+		expDelta += (-expDelta * rate_) >> 32;
+		height_ = expDelta + PSP_SAS_ENVELOPE_HEIGHT_MAX - (rate_ + 3UL) / 4UL;
 		break;
 
 	case PSP_SAS_ADSR_CURVE_MODE_EXPONENT_INCREASE:
 		expDelta = height_ - PSP_SAS_ENVELOPE_HEIGHT_MAX;
-		expDelta -= (expDelta * (s64)rate_) / 0x100000000LL;
+		// Flipping the sign so that we can shift in the top bits.
+		expDelta += (-expDelta * rate_) >> 32;
 		height_ = expDelta + 0x4000 + PSP_SAS_ENVELOPE_HEIGHT_MAX;
 		break;
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -676,7 +676,7 @@ ADSREnvelope::ADSREnvelope()
 		attackType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
 		decayType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
 		sustainType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_INCREASE),
-		sustainLevel(0x100),
+		sustainLevel(0),
 		releaseType(PSP_SAS_ADSR_CURVE_MODE_LINEAR_DECREASE),
 		rate_(0),
 		type_(0),
@@ -722,6 +722,10 @@ void ADSREnvelope::WalkCurve(int type) {
 }
 
 void ADSREnvelope::SetState(ADSRState state) {
+	if (height_ > PSP_SAS_ENVELOPE_HEIGHT_MAX) {
+		height_ = PSP_SAS_ENVELOPE_HEIGHT_MAX;
+	}
+
 	state_ = state;
 	switch (state) {
 	case STATE_ATTACK:

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -758,7 +758,7 @@ void ADSREnvelope::Step() {
 		break;
 	case STATE_DECAY:
 		WalkCurve(type_);
-		if (height_ > PSP_SAS_ENVELOPE_HEIGHT_MAX || height_ < sustainLevel)
+		if (height_ < sustainLevel)
 			SetState(STATE_SUSTAIN);
 		break;
 	case STATE_SUSTAIN:

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -706,7 +706,7 @@ void ADSREnvelope::WalkCurve(int type) {
 	case PSP_SAS_ADSR_CURVE_MODE_EXPONENT_DECREASE:
 		expDelta = height_ - PSP_SAS_ENVELOPE_HEIGHT_MAX;
 		expDelta -= (expDelta * (s64)rate_) / 0x100000000LL;
-		height_ = expDelta + PSP_SAS_ENVELOPE_HEIGHT_MAX - (rate_ + 3) / 4;
+		height_ = expDelta + PSP_SAS_ENVELOPE_HEIGHT_MAX - ((u32)rate_ + 3UL) / 4UL;
 		break;
 
 	case PSP_SAS_ADSR_CURVE_MODE_EXPONENT_INCREASE:

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -168,7 +168,6 @@ private:
 	// No need to save in state
 	int rate_;
 	int type_;
-	float invDuration_;
 
 	enum ADSRState {
 		STATE_ATTACK,
@@ -180,7 +179,6 @@ private:
 	void SetState(ADSRState state);
 
 	ADSRState state_;
-	int steps_;
 	s64 height_;  // s64 to avoid having to care about overflow when calculating. TODO: this should be fine as s32
 };
 


### PR DESCRIPTION
These formulas seem to accurately reproduce the heights from a PSP.  May improve the quality and possibly timing of sound effects in some games.

There are a few other things to change still.  I tested bent a while ago and it seemed to be inaccurate as well, and keyon seems to take 32 samples to "kick in" (before which it mixes as zeroes.)  But I need to do more tests.

@gid15, fyi - the original code here came from JPCSP.  This should more accurately reproduce the curve.

Hopefully there are no regressions I missed.

-[Unknown]
