### PR TITLE
Allow the language ini path to be overridden for translation testing purposes.

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -36,6 +36,7 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/HLE/sceUtility.h"
 #include "Common/CPUDetect.h"
+#include "Common/FileUtil.h"
 
 #include "ui_atlas.h"
 
@@ -320,7 +321,18 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 
 	g_Config.sLanguageIni = code;
 
-	if (i18nrepo.LoadIni(g_Config.sLanguageIni)) {
+	bool iniLoadedSuccessfully = false;
+	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to 
+	// test new languages without recompiling the entire app, which is a hassle).
+	const std::string langOverridePath = g_Config.memCardDirectory + "PSP/SYSTEM/lang/";
+
+	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
+	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))
+		iniLoadedSuccessfully = i18nrepo.LoadIni(g_Config.sLanguageIni);
+	else
+		iniLoadedSuccessfully = i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
+
+	if (iniLoadedSuccessfully) {
 		// Dunno what else to do here.
 		if (langValuesMapping.find(code) == langValuesMapping.end()) {
 			// Fallback to English

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -383,8 +383,16 @@ void NativeInit(int argc, const char *argv[],
 	if (!gfxLog)
 		logman->SetLogLevel(LogTypes::G3D, LogTypes::LERROR);
 #endif
+	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to 
+	// test new languages without recompiling the entire app, which is a hassle).
+	const std::string langOverridePath = g_Config.memCardDirectory + "PSP/SYSTEM/lang/";
 
-	i18nrepo.LoadIni(g_Config.sLanguageIni);
+	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
+	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))
+		i18nrepo.LoadIni(g_Config.sLanguageIni);
+	else
+		i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
+
 	I18NCategory *d = GetI18NCategory("DesktopUI");
 	// Note to translators: do not translate this/add this to PPSSPP-lang's files.
 	// It's intended to be custom for every user.


### PR DESCRIPTION
~~Related to https://github.com/hrydgard/native/pull/196, so please accept that first if this is to be accepted too.~~

Currently we have to keep updating lang and waiting for or compiling new Android/iOS builds before being able to test translations, which is a hassle, so if we let the user override the built-in language files with those in g_Config.memCardDirectory/PSP/SYSTEM/lang, the problem should be mostly relieved. :)
