### PR TITLE
Use checkboxes in breakpoint list

### DIFF
--- a/Windows/Debugger/Debugger_Lists.h
+++ b/Windows/Debugger/Debugger_Lists.h
@@ -38,6 +38,7 @@ protected:
 	virtual int GetRowCount() { return getTotalBreakpointCount(); };
 	virtual void OnDoubleClick(int itemIndex, int column);
 	virtual void OnRightClick(int itemIndex, int column, const POINT& point);
+	virtual void OnToggle(int item, bool newValue);
 private:
 	std::vector<BreakPoint> displayedBreakPoints_;
 	std::vector<MemCheck> displayedMemChecks_;

--- a/Windows/GEDebugger/TabDisplayLists.cpp
+++ b/Windows/GEDebugger/TabDisplayLists.cpp
@@ -25,7 +25,11 @@ const GenericListViewColumn displayListStackColumns[3] = {
 	{ L"Offset", 0.33f },
 };
 
-CtrlDisplayListStack::CtrlDisplayListStack(HWND hwnd): GenericListControl(hwnd,displayListStackColumns,DLS_COLUMNCOUNT)
+GenericListViewDef displayListStackListDef = {
+	displayListStackColumns,	ARRAY_SIZE(displayListStackColumns),	NULL,	false
+};
+
+CtrlDisplayListStack::CtrlDisplayListStack(HWND hwnd): GenericListControl(hwnd,displayListStackListDef)
 {
 	list.stackptr = 0;
 	Update();
@@ -73,7 +77,11 @@ const GenericListViewColumn allDisplayListsColumns[ADL_COLUMNCOUNT] = {
 	{ L"Interrupted", 0.15f },
 };
 
-CtrlAllDisplayLists::CtrlAllDisplayLists(HWND hwnd): GenericListControl(hwnd,allDisplayListsColumns,ADL_COLUMNCOUNT)
+GenericListViewDef allDisplayListsListDef = {
+	allDisplayListsColumns,	ARRAY_SIZE(allDisplayListsColumns),	NULL,	false
+};
+
+CtrlAllDisplayLists::CtrlAllDisplayLists(HWND hwnd): GenericListControl(hwnd,allDisplayListsListDef)
 {
 	Update();
 }

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -30,6 +30,10 @@ static const GenericListViewColumn stateValuesCols[] = {
 	{ L"Value", 0.50f },
 };
 
+GenericListViewDef stateValuesListDef = {
+	stateValuesCols,	ARRAY_SIZE(stateValuesCols),	NULL,	false
+};
+
 enum StateValuesCols {
 	STATEVALUES_COL_NAME,
 	STATEVALUES_COL_VALUE,
@@ -257,7 +261,7 @@ static const TabStateRow stateSettingsRows[] = {
 //   GE_CMD_UNKNOWN_*
 
 CtrlStateValues::CtrlStateValues(const TabStateRow *rows, int rowCount, HWND hwnd)
-	: GenericListControl(hwnd, stateValuesCols, ARRAY_SIZE(stateValuesCols)),
+	: GenericListControl(hwnd, stateValuesListDef),
 	  rows_(rows), rowCount_(rowCount) {
 	Update();
 }

--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -34,6 +34,10 @@ static const GenericListViewColumn vertexListCols[] = {
 	// TODO: Normal, weight, morph?
 };
 
+GenericListViewDef vertexListDef = {
+	vertexListCols,	ARRAY_SIZE(vertexListCols),	NULL,	false
+};
+
 enum VertexListCols {
 	VERTEXLIST_COL_X,
 	VERTEXLIST_COL_Y,
@@ -49,6 +53,10 @@ static const GenericListViewColumn matrixListCols[] = {
 	{ L"1", 0.19f },
 	{ L"2", 0.19f },
 	{ L"3", 0.19f },
+};
+
+GenericListViewDef matrixListDef = {
+	matrixListCols,	ARRAY_SIZE(matrixListCols),	NULL,	false
 };
 
 enum MatrixListCols {
@@ -104,7 +112,7 @@ enum MatrixListRows {
 };
 
 CtrlVertexList::CtrlVertexList(HWND hwnd)
-	: GenericListControl(hwnd, vertexListCols, ARRAY_SIZE(vertexListCols)), raw_(false) {
+	: GenericListControl(hwnd, vertexListDef), raw_(false) {
 	decoder = new VertexDecoder();
 	Update();
 }
@@ -330,7 +338,7 @@ BOOL TabVertices::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 }
 
 CtrlMatrixList::CtrlMatrixList(HWND hwnd)
-	: GenericListControl(hwnd, matrixListCols, ARRAY_SIZE(matrixListCols)) {
+	: GenericListControl(hwnd, matrixListDef) {
 	Update();
 }
 

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -16,7 +16,19 @@ struct GenericListViewColumn
 {
 	wchar_t *name;
 	float size;
+	int flags;
 };
+
+struct GenericListViewDef
+{
+	const GenericListViewColumn* columns;
+	int columnCount;
+	int* columnOrder;
+	bool checkbox;			// the first column will always have the checkbox. specify a custom order to change its position
+};
+
+#define GLVC_CENTERED		1
+
 
 // the most significant bit states whether the key is currently down.
 // simply checking if it's != 0 is not enough, as bit0 is set if
@@ -29,7 +41,7 @@ inline bool KeyDownAsync(int vkey)
 class GenericListControl
 {
 public:
-	GenericListControl(HWND hwnd, const GenericListViewColumn* _columns, int _columnCount);
+	GenericListControl(HWND hwnd, const GenericListViewDef& def);
 	virtual ~GenericListControl() { };
 	void HandleNotify(LPARAM lParam);
 	void Update();
@@ -37,12 +49,14 @@ public:
 	HWND GetHandle() { return handle; };
 	void SetSendInvalidRows(bool enabled) { sendInvalidRows = enabled; };
 protected:
+	void SetCheckState(int item, bool state);
 	virtual bool WindowMessage(UINT msg, WPARAM wParam, LPARAM lParam, LRESULT& returnValue) = 0;
 	virtual void GetColumnText(wchar_t* dest, int row, int col) = 0;
 	virtual int GetRowCount() = 0;
 	virtual void OnDoubleClick(int itemIndex, int column) { };
 	virtual void OnRightClick(int itemIndex, int column, const POINT& point) { };
 	virtual void CopyRows(int start, int size);
+	virtual void OnToggle(int item, bool newValue) { };
 private:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	void ResizeColumns();
@@ -58,4 +72,5 @@ private:
 	bool sendInvalidRows;
 	// Used for hacky workaround to fix a rare hang (see issue #5184)
 	volatile bool inResizeColumns;
+	volatile bool updating;
 };


### PR DESCRIPTION
It allows you to toggle their state a bit faster: http://puu.sh/6UjeA/b9f91bf84c.png
Also fixes a bug where inResizeColumns was never initialized, thus randomly messing up the resize process.
