### PR TITLE
Clamp float z in throughmode rather than wrapping

### DIFF
--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -95,8 +95,8 @@ public:
 				const float *f = (const float *)(data_ + decFmt_.posoff);
 				memcpy(pos, f, 12);
 				if (isThrough()) {
-					// Integer value passed in a float. Wraps and all, required for Monster Hunter.
-					pos[2] = (float)((u16)(s32)pos[2]) * (1.0f / 65535.0f);
+					// Integer value passed in a float. Clamped to 0, 65535.
+					pos[2] = pos[2] > 65535.0f ? 1.0f : (pos[2] < 0.0f ? 0.0f : pos[2] * (1.0f / 65535.0f));
 				}
 				// See https://github.com/hrydgard/ppsspp/pull/3419, something is weird.
 			}
@@ -144,6 +144,10 @@ public:
 			{
 				const float *f = (const float *)(data_ + decFmt_.posoff);
 				memcpy(pos, f, 12);
+				if (isThrough()) {
+					// Integer value passed in a float. Clamped to 0, 65535.
+					pos[2] = pos[2] > 65535.0f ? 65535.0f : (pos[2] < 0.0f ? 0.0f : pos[2]);
+				}
 				// TODO: Does non-through need conversion?
 			}
 			break;

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -462,9 +462,10 @@ void VertexDecoder::Step_PosS16Through() const
 {
 	float *v = (float *)(decoded_ + decFmt.posoff);
 	const s16 *sv = (const s16*)(ptr_ + posoff);
+	const u16 *uv = (const u16*)(ptr_ + posoff);
 	v[0] = sv[0];
 	v[1] = sv[1];
-	v[2] = sv[2];
+	v[2] = uv[2];
 }
 
 void VertexDecoder::Step_PosFloatThrough() const

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -723,7 +723,7 @@ void VertexDecoderJitCache::Jit_PosS16Through() {
 	// TODO: SIMD
 	LDRSH(tempReg1, srcReg, dec_->posoff);
 	LDRSH(tempReg2, srcReg, dec_->posoff + 2);
-	LDRSH(tempReg3, srcReg, dec_->posoff + 4);
+	LDRH(tempReg3, srcReg, dec_->posoff + 4);
 	static const ARMReg tr[3] = { tempReg1, tempReg2, tempReg3 };
 	for (int i = 0; i < 3; i++) {
 		VMOV(fpScratchReg, tr[i]);


### PR DESCRIPTION
So, this doesn't cause any problems other games so far, and should be correct.  Could use more testing.  Fixes Tales of Eternia.

Doesn't fix Phantasy Star Portable.

-[Unknown]
