### PR TITLE
WinUI: Don't crash by referencing a nullptr when changing the rendering resolution.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -275,7 +275,9 @@ namespace MainWindow
 		if (g_Config.iTexScalingLevel == TEXSCALING_AUTO)
 			setTexScalingMultiplier(0);
 
-		gpu->Resized();
+		if (gpu)
+			gpu->Resized();
+
 		UpdateRenderResolution();
 		ShowScreenResolution();
 	}


### PR DESCRIPTION
Should fix https://github.com/hrydgard/ppsspp/issues/5436.
