### PR TITLE
listEmptyFile should be set to false when AUTOLOAD mode 

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1156,7 +1156,8 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 
 	bool listEmptyFile = true;
 	if (param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTLOAD ||
-			param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTDELETE)
+		param->mode == SCE_UTILITY_SAVEDATA_TYPE_AUTOLOAD ||
+		param->mode == SCE_UTILITY_SAVEDATA_TYPE_LISTDELETE)
 	{
 		listEmptyFile = false;
 	}
@@ -1234,6 +1235,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 					{
 						ClearFileInfo(saveDataList[realCount], thisSaveName);
 						DEBUG_LOG(SCEUTILITY,"Don't Exist");
+						realCount++;
 					}
 				}
 			}

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1234,7 +1234,6 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 					{
 						ClearFileInfo(saveDataList[realCount], thisSaveName);
 						DEBUG_LOG(SCEUTILITY,"Don't Exist");
-						realCount++;
 					}
 				}
 			}


### PR DESCRIPTION
ListEmptyFile should be set to false when in AUTOLOAD mode as well.During AUTOMODE mode , it should only load up valid and non-empty files .

Fixes https://github.com/hrydgard/ppsspp/issues/1525
