### PR TITLE
Fixed slowdown in mhp3

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -310,10 +310,10 @@ namespace Reporting
 
 	bool IsEnabled()
 	{
-		if (g_Config.sReportHost.empty() || !IsSupported() || everUnsupported)
-			return false;
 		// Disabled by default for now.
 		if (g_Config.sReportHost.compare("default") == 0)
+			return false;
+		if (g_Config.sReportHost.empty() || !IsSupported() || everUnsupported)
 			return false;
 		return true;
 	}


### PR DESCRIPTION
Reporting::IsSupported can hit the hard drive, so make sure that it's not
called unless it's actually needed.  Mhp3 appears to be so unusually hit
by this because it hits an ERROR_LOG_REPORT dozens of times per frame.
