### PR TITLE
Enable produce DEBUG_LOG rather than INFO_LOG in Windows who don't need install Visual Studio Express

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -96,7 +96,7 @@ void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
 #endif
 		;
 
-#if defined(LOGGING) || defined(_DEBUG) || defined(DEBUGFAST)
+#if defined(LOGGING) || defined(_DEBUG) || defined(DEBUGFAST) || defined(_WIN32)
 #define MAX_LOGLEVEL DEBUG_LEVEL
 #else
 #ifndef MAX_LOGLEVEL

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -183,7 +183,6 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 	char formattedTime[13];
 	Common::Timer::GetTimeFormatted(formattedTime);
 
-#ifdef _DEBUG
 #ifdef _WIN32
 	static const char sep = '\\';
 #else
@@ -197,7 +196,6 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 		if (fileshort != file)
 			file = fileshort + 1;
 	}
-#endif
 
 	char *msgPos = msg;
 	if (hleCurrentThreadName != NULL) {
@@ -233,7 +231,7 @@ LogChannel::LogChannel(const char* shortName, const char* fullName, bool enable)
 	: enable_(enable) {
 	strncpy(m_fullName, fullName, 128);
 	strncpy(m_shortName, shortName, 32);
-	level_ = LogTypes::LDEBUG;
+	level_ = LogTypes::LINFO;
 }
 
 // LogContainer

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -231,7 +231,11 @@ LogChannel::LogChannel(const char* shortName, const char* fullName, bool enable)
 	: enable_(enable) {
 	strncpy(m_fullName, fullName, 128);
 	strncpy(m_shortName, shortName, 32);
+#if defined(_DEBUG)
+	level_ = LogTypes::LDEBUG;
+#else
 	level_ = LogTypes::LINFO;
+#endif
 }
 
 // LogContainer


### PR DESCRIPTION
Default release build INFO_LOG
Default debug build DEBUG_LOG
#5477
