### PR TITLE
Implement vsbn.s and vwbn.s

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1797,12 +1797,11 @@ bad:
 		for (int i = 0; i < GetNumVectorElements(sz); ++i) {
 			u32 sigbit = s.u[i] & 0x80000000;
 			u32 prevExp = (s.u[i] & 0x7F800000) >> 23;
-			u32 mantissa = s.u[i] & 0x007FFFFF;
+			u32 mantissa = (s.u[i] & 0x007FFFFF) | 0x00800000;
 			if (prevExp != 0xFF && prevExp != 0) {
 				if (exp > prevExp) {
 					s8 shift = (exp - prevExp) & 0xF;
 					mantissa = mantissa >> shift;
-					mantissa |= 1 << (23 - shift);
 				} else {
 					s8 shift = (prevExp - exp) & 0xF;
 					mantissa = mantissa << shift;


### PR DESCRIPTION
Both match tests and appear to work properly.  I still won't pretend to understand exactly what vwbn.s is doing... but I think I kinda understand it.  The `1 << (23 - shift)` is for the implicit leading bit of the mantissa.... actually, I should simplify that.  I'm just not really sure how 0xF is relevant here.

Did not actually test prefixes.

-[Unknown]
