### PR TITLE
Win32: Add a font scaling option for NewUI.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -530,6 +530,9 @@ static ConfigSetting systemParamSettings[] = {
 	ConfigSetting("WlanAdhocChannel", &g_Config.iWlanAdhocChannel, PSP_SYSTEMPARAM_ADHOC_CHANNEL_AUTOMATIC),
 #if defined(USING_WIN_UI)
 	ConfigSetting("BypassOSKWithKeyboard", &g_Config.bBypassOSKWithKeyboard, false),
+#endif
+	// Qt can use this too.
+#ifdef _WIN32
 	ConfigSetting("FontScaleSize", &g_Config.iNewUIFontScale, 100),
 #endif
 	ConfigSetting("WlanPowerSave", &g_Config.bWlanPowerSave, (bool)PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -530,6 +530,7 @@ static ConfigSetting systemParamSettings[] = {
 	ConfigSetting("WlanAdhocChannel", &g_Config.iWlanAdhocChannel, PSP_SYSTEMPARAM_ADHOC_CHANNEL_AUTOMATIC),
 #if defined(USING_WIN_UI)
 	ConfigSetting("BypassOSKWithKeyboard", &g_Config.bBypassOSKWithKeyboard, false),
+	ConfigSetting("FontScaleSize", &g_Config.iNewUIFontScale, 100),
 #endif
 	ConfigSetting("WlanPowerSave", &g_Config.bWlanPowerSave, (bool)PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF),
 	ReportedConfigSetting("EncryptSave", &g_Config.bEncryptSave, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -72,8 +72,12 @@ public:
 	std::string sFont;
 	bool bIgnoreWindowsKey;
 	bool bEscapeExitsEmulator;
+#endif
+	// Under WIN32 because Qt can use it, too.
+#ifdef _WIN32
 	int iNewUIFontScale;
 #endif
+
 	// Core
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -72,6 +72,7 @@ public:
 	std::string sFont;
 	bool bIgnoreWindowsKey;
 	bool bEscapeExitsEmulator;
+	int iNewUIFontScale;
 #endif
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -288,8 +288,11 @@ void GameSettingsScreen::CreateViews() {
 	systemSettingsScroll->Add(systemSettings);
 	tabHolder->AddTab(ms->T("System"), systemSettingsScroll);
 
-	systemSettings->Add(new ItemHeader(s->T("UI Language")));
+	systemSettings->Add(new ItemHeader(s->T("UI Settings")));
 	systemSettings->Add(new Choice(dev->T("Language", "Language")))->OnClick.Handle(this, &GameSettingsScreen::OnLanguage);
+#ifdef USING_WIN_UI
+	systemSettings->Add(new PopupSliderChoice(&g_Config.iNewUIFontScale, 25, 200, s->T("FontScaleSize", "Font Scale Size (Requires Restart)"), screenManager()));
+#endif
 
 	systemSettings->Add(new ItemHeader(s->T("Emulation")));
 	systemSettings->Add(new CheckBox(&g_Config.bFastMemory, s->T("Fast Memory", "Fast Memory (Unstable)")));

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -434,9 +434,13 @@ void NativeInitGraphics() {
 	// memset(&ui_theme, 0, sizeof(ui_theme));
 	// New style theme
 #ifdef _WIN32
-	ui_theme.uiFont = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), 22);
-	ui_theme.uiFontSmall = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), 15);
-	ui_theme.uiFontSmaller = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), 12);
+	const int defaultFontSize = 22 * g_Config.iNewUIFontScale / 100;
+	const int defaultSmallFontSize = 15 * g_Config.iNewUIFontScale / 100;
+	const int defaultSmallerFontSize = 12 * g_Config.iNewUIFontScale / 100;
+
+	ui_theme.uiFont = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), defaultFontSize);
+	ui_theme.uiFontSmall = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), defaultSmallFontSize);
+	ui_theme.uiFontSmaller = UI::FontStyle(UBUNTU24, g_Config.sFont.c_str(), defaultSmallerFontSize);
 #else
 	ui_theme.uiFont = UI::FontStyle(UBUNTU24, "", 20);
 	ui_theme.uiFontSmall = UI::FontStyle(UBUNTU24, "", 14);


### PR DESCRIPTION
It's a bit primitive, but it works. If the user selects a gigantic size, it can cause the text to go offscreen, but my graphics coding skills aren't really that great, so I wouldn't know where to look to prevent that. Defaults to 100% (no chance), and goes from 25% to 200% size.

Anyway, it's useful for if the user prefers a different font size (due to vision issues or preference), or if the user cranked up the DPI and suddenly finds themselves staring at really huge text and wants to bring it back down.
