### PR TITLE
Update mainscreen when back to (effect ui language changes, game list update etc.)

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -959,8 +959,8 @@ UI::EventReturn MainScreen::OnExit(UI::EventParams &e) {
 void MainScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	if (dialog->tag() == "store") {
 		backFromStore_ = true;
-		RecreateViews();
 	}
+	RecreateViews();
 }
 
 void GamePauseScreen::update(InputState &input) {


### PR DESCRIPTION
When press button back to mainscreen, the main screen ui is not updated. So this commit is force to recreate the mainscreen view which will update all informations as language changes, recent game list etc.
