### PR TITLE
Don't allow reporting from bad savestates

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -261,6 +261,7 @@ void __KernelDoState(PointerWrap &p)
 
 		__InterruptsDoStateLate(p);
 		__KernelThreadingDoStateLate(p);
+		Reporting::DoState(p);
 	}
 }
 

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -214,6 +214,19 @@ namespace Reporting
 		Init();
 	}
 
+	void DoState(PointerWrap &p)
+	{
+		const int LATEST_VERSION = 1;
+		auto s = p.Section("Reporting", 0, LATEST_VERSION);
+		if (!s || s < LATEST_VERSION) {
+			// Don't report from old savestates, they may "entomb" bugs.
+			everUnsupported = true;
+			return;
+		}
+
+		p.Do(everUnsupported);
+	}
+
 	void UpdateConfig()
 	{
 		currentSupported = IsSupported();

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -35,11 +35,16 @@
 #define NOTICE_LOG_ONCE(n,t,...)  { if (Reporting::ShouldLogOnce(#n)) { NOTICE_LOG(t, __VA_ARGS__); } }
 #define INFO_LOG_ONCE(n,t,...)    { if (Reporting::ShouldLogOnce(#n)) { INFO_LOG(t, __VA_ARGS__); } }
 
+struct PointerWrap;
+
 namespace Reporting
 {
 	// Should be called whenever a new game is loaded/shutdown to forget things.
 	void Init();
 	void Shutdown();
+
+	// Check savestate compatibility, mostly needed on load.
+	void DoState(PointerWrap &p);
 
 	// Should be called whenever the game configuration changes.
 	void UpdateConfig();


### PR DESCRIPTION
If the savestate was created with bad settings, or was loaded from an older version, it may be damaged.  Let's not report old problems.

We can update this periodically if there are big things we fix.

I'm trying to eliminate sources of invalid reports, because right now sometimes I see a bunch of reports for something that doesn't make sense, and it makes me not trust it.

-[Unknown]
