### PR TITLE
When the language changes, recreate all views

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -490,7 +490,7 @@ UI::EventReturn GameSettingsScreen::OnLanguage(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnLanguageChange(UI::EventParams &e) {
-	RecreateViews();
+	screenManager()->RecreateAllViews();
 
 	if (host) {
 		host->UpdateUI();

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -162,7 +162,7 @@ void UIScreenWithBackground::sendMessage(const char *message, const char *value)
 }
 
 UI::EventReturn UIScreenWithBackground::OnLanguageChange(UI::EventParams &e) {
-	RecreateViews();
+	screenManager()->RecreateAllViews();
 	if (host) {
 		host->UpdateUI();
 	}
@@ -171,7 +171,7 @@ UI::EventReturn UIScreenWithBackground::OnLanguageChange(UI::EventParams &e) {
 }
 
 UI::EventReturn UIDialogScreenWithBackground::OnLanguageChange(UI::EventParams &e) {
-	RecreateViews();
+	screenManager()->RecreateAllViews();
 	if (host) {
 		host->UpdateUI();
 	}


### PR DESCRIPTION
Not just the current screen's views.  Fixes language not switching on main screen when changed in settings.

Possible alternative to #5495.

-[Unknown]
