### PR TITLE
Fix iOS Crash

### DIFF
--- a/Common/MemArena.cpp
+++ b/Common/MemArena.cpp
@@ -34,6 +34,10 @@
 #endif
 #endif
 
+#ifndef _WIN32
+void* globalbase=NULL;
+#endif
+
 #ifdef ANDROID
 
 // Hopefully this ABI will never change...
@@ -230,13 +234,18 @@ u8* MemArena::Find4GBBase()
 	}
 	return base;
 #else
-	void* base = mmap(0, 0x10000000, PROT_READ | PROT_WRITE,
-		MAP_ANON | MAP_SHARED, -1, 0);
-	if (base == MAP_FAILED) {
-		PanicAlert("Failed to map 256 MB of memory space: %s", strerror(errno));
-		return 0;
-	}
-	munmap(base, 0x10000000);
+    void* base = NULL;
+    if (globalbase==NULL){
+        base = mmap(0, 0x08000000, PROT_READ | PROT_WRITE,
+                    MAP_ANON | MAP_SHARED, -1, 0);
+        if (base == MAP_FAILED) {
+            PanicAlert("Failed to map 128 MB of memory space: %s", strerror(errno));
+            return 0;
+        }
+        munmap(base, 0x08000000);
+        globalbase=base;
+    }
+    else{base=globalbase;}
 	return static_cast<u8*>(base);
 #endif
 #endif


### PR DESCRIPTION
Map a 256M memory space on iOS may yields NULL point that will lead crash when calling memcpy this after. This commite works well on my device, and hopefuly to fix this bug.
See https://github.com/hrydgard/ppsspp/issues/5483 for details and discussion.
