### PR TITLE
Fix Mahou Shoujo Lyrical Nanoha A's Portable: The Battle of Aces Chinese version  booting

### DIFF
--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -127,6 +127,19 @@ static const char *altBootNames[] = {
 	"disc0:/PSP_GAME/SYSDIR/ss.RAW",
 };
 
+// Bypass another more dangerous one where the file is in USRDIR - this could collide with files in some game.
+static const char *damageAltBootNames[] = {
+	"disc0:/PSP_GAME/USRDIR/PAKFILE2.BIN",
+	"disc0:/PSP_GAME/USRDIR/Monologue_Sub/Monologue_Sub.Sub",//Traditional Chinese version:let PPSSPP fail to load in patched game,then use BOOT.BIN
+	"disc0:/PSP_GAME/USRDIR/Monologue_Sub/Sub_001.Sub",//Simplified Chinese version:let PPSSPP fail to load in patched game,then use BOOT.BIN
+};
+
+static const char *damageAltBootDISC_ID[] = {
+	"NPJH50624",
+	"ULJS00241",
+	"ULJS00241",
+};
+
 bool Load_PSP_ISO(const char *filename, std::string *error_string)
 {
 	// Mounting stuff relocated to InitMemoryForGameISO due to HD Remaster restructuring of code.
@@ -158,10 +171,12 @@ bool Load_PSP_ISO(const char *filename, std::string *error_string)
 
 	// Bypass another more dangerous one where the file is in USRDIR - this could collide with files in some game.
 	std::string id = g_paramSFO.GetValueString("DISC_ID");
-	if (id == "NPJH50624" && pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/PAKFILE2.BIN").exists) {
-		bootpath = "disc0:/PSP_GAME/USRDIR/PAKFILE2.BIN";
+	for (int i = 0; i < ARRAY_SIZE(damageAltBootNames); i++) {
+		if (id == damageAltBootDISC_ID[i] && pspFileSystem.GetFileInfo(damageAltBootNames[i]).exists) {
+			bootpath = damageAltBootNames[i];
+			break;
+		}
 	}
-
 
 	bool hasEncrypted = false;
 	u32 fd;


### PR DESCRIPTION
It is a bit trick
Let Traditional Chinese version and Simplified Chinese version fail to load.Then ppsspp load Boot.bin instead.
Japan version,Simplified Chinese version ,Traditional Chinese version work together.
![1](https://f.cloud.github.com/assets/2177532/2195408/066e2252-989e-11e3-89b8-e006f74c78d3.jpg)
![2](https://f.cloud.github.com/assets/2177532/2195409/0a6e9666-989e-11e3-87eb-45a300c0c417.jpg)
![3](https://f.cloud.github.com/assets/2177532/2195410/0d684ba0-989e-11e3-8e33-9fd8b64a636b.jpg)
