### PR TITLE
Yet more exactness changes for SAS

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -339,13 +339,12 @@ u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
 }
 
 u32 sceSasSetSL(u32 core, int voiceNum, int level) {
-	DEBUG_LOG(SCESAS, "sceSasSetSL(%08x, %i, %i)", core, voiceNum, level);
-
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
 	}
 
+	DEBUG_LOG(SCESAS, "sceSasSetSL(%08x, %i, %08x)", core, voiceNum, level);
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.sustainLevel = level;
 	return 0;
@@ -400,7 +399,12 @@ u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int
 		invalid |= 0x8;
 	}
 	if (invalid & flag) {
-		WARN_LOG_REPORT(SCESAS, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
+		if (a == 5 && d == 5 && s == 5 && r == 5) {
+			// Some games do this right at init.  It seems to fail even on a PSP, but let's not report it.
+			DEBUG_LOG(SCESAS, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
+		} else {
+			WARN_LOG_REPORT(SCESAS, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
+		}
 		return ERROR_SAS_INVALID_ADSR_CURVE_MODE;
 	}
 
@@ -410,7 +414,7 @@ u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int
 	if ((flag & 0x2) != 0) v.envelope.decayType   = d;
 	if ((flag & 0x4) != 0) v.envelope.sustainType = s;
 	if ((flag & 0x8) != 0) v.envelope.releaseType = r;
-	return 0 ;
+	return 0;
 }
 
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -470,8 +470,8 @@ u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
 
 u32 sceSasRevVON(u32 core, int dry, int wet) {
 	DEBUG_LOG(SCESAS, "sceSasRevVON(%08x, %i, %i)", core, dry, wet);
-	sas->waveformEffect.isDryOn = dry & 1;
-	sas->waveformEffect.isWetOn = wet & 1;
+	sas->waveformEffect.isDryOn = dry != 0;
+	sas->waveformEffect.isWetOn = wet != 0;
 	return 0;
 }
 
@@ -492,8 +492,13 @@ u32 sceSasGetOutputMode(u32 core) {
 }
 
 u32 sceSasSetOutputMode(u32 core, u32 outputMode) {
+	if (outputMode != 0 && outputMode != 1) {
+		ERROR_LOG_REPORT(SCESAS, "sceSasSetOutputMode(%08x, %i): bad output mode", core, outputMode);
+		return ERROR_SAS_INVALID_OUTPUT_MODE;
+	}
 	DEBUG_LOG(SCESAS, "sceSasSetOutputMode(%08x, %i)", core, outputMode);
 	sas->outputMode = outputMode;
+
 	return 0;
 }
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -128,26 +128,32 @@ u32 sceSasGetEndFlag(u32 core) {
 
 // Runs the mixer
 u32 _sceSasCore(u32 core, u32 outAddr) {
-	DEBUG_LOG(SCESAS, "sceSasCore(%08x, %08x)", core, outAddr);
-
 	if (!Memory::IsValidAddress(outAddr)) {
+		ERROR_LOG_REPORT(SCESAS, "sceSasCore(%08x, %08x): invalid address", core, outAddr);
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
 
+	DEBUG_LOG(SCESAS, "sceSasCore(%08x, %08x)", core, outAddr);
 	sas->Mix(outAddr);
+
 	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
 	return hleDelayResult(0, "sas core", 240);
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
 u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume) {
-	DEBUG_LOG(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i)", core, inoutAddr, leftVolume, rightVolume);
-
 	if (!Memory::IsValidAddress(inoutAddr)) {
+		ERROR_LOG_REPORT(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i): invalid address", core, inoutAddr, leftVolume, rightVolume);
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
-
+	if (sas->outputMode == PSP_SAS_OUTPUTMODE_RAW) {
+		ERROR_LOG_REPORT(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i): unsupported outputMode", core, inoutAddr, leftVolume, rightVolume);
+		return 0x80000004;
+	}
+	
+	DEBUG_LOG(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i)", core, inoutAddr, leftVolume, rightVolume);
 	sas->Mix(inoutAddr, inoutAddr, leftVolume, rightVolume);
+
 	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
 	return hleDelayResult(0, "sas core", 240);
 }

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -141,7 +141,7 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 
 // Another way of running the mixer, the inoutAddr should be both input and output
 u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume) {
-	DEBUG_LOG(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i)", core , inoutAddr, leftVolume, rightVolume);
+	DEBUG_LOG(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i)", core, inoutAddr, leftVolume, rightVolume);
 
 	if (!Memory::IsValidAddress(inoutAddr)) {
 		return ERROR_SAS_INVALID_PARAMETER;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -619,6 +619,7 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 			// The PSP seems to not update the data at all, let's report to see what games hit this.
 			ERROR_LOG_REPORT(SCESAS, "sceSasCoreWithMix: unsupported raw outputMode");
 		} else {
+			WARN_LOG_REPORT(SCESAS, "sceSasCore: raw outputMode");
 			for (int i = 0; i < grainSize * 2; i += 2) {
 				*outpL++ = clamp_s16(mixBuffer[i + 0]);
 				*outpR++ = clamp_s16(mixBuffer[i + 1]);

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -615,17 +615,12 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 		s16 *outpR = outp + grainSize * 1;
 		s16 *outpSendL = outp + grainSize * 2;
 		s16 *outpSendR = outp + grainSize * 3;
-		if (inp) {
-			// The PSP seems to not update the data at all, let's report to see what games hit this.
-			ERROR_LOG_REPORT(SCESAS, "sceSasCoreWithMix: unsupported raw outputMode");
-		} else {
-			WARN_LOG_REPORT(SCESAS, "sceSasCore: raw outputMode");
-			for (int i = 0; i < grainSize * 2; i += 2) {
-				*outpL++ = clamp_s16(mixBuffer[i + 0]);
-				*outpR++ = clamp_s16(mixBuffer[i + 1]);
-				*outpSendL++ = clamp_s16(sendBuffer[i + 0]);
-				*outpSendR++ = clamp_s16(sendBuffer[i + 1]);
-			}
+		WARN_LOG_REPORT(SCESAS, "sceSasCore: raw outputMode");
+		for (int i = 0; i < grainSize * 2; i += 2) {
+			*outpL++ = clamp_s16(mixBuffer[i + 0]);
+			*outpR++ = clamp_s16(mixBuffer[i + 1]);
+			*outpSendL++ = clamp_s16(sendBuffer[i + 0]);
+			*outpSendR++ = clamp_s16(sendBuffer[i + 1]);
 		}
 	}
 	memset(mixBuffer, 0, grainSize * sizeof(int) * 2);

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -61,6 +61,9 @@ enum {
 	PSP_SAS_EFFECT_TYPE_ECHO = 6,
 	PSP_SAS_EFFECT_TYPE_DELAY = 7,
 	PSP_SAS_EFFECT_TYPE_PIPE = 8,
+
+	PSP_SAS_OUTPUTMODE_MIXED = 0,
+	PSP_SAS_OUTPUTMODE_RAW = 1,
 };
 
 struct WaveformEffect {
@@ -205,8 +208,6 @@ struct SasVoice {
 			noiseFreq(0),
 			volumeLeft(PSP_SAS_VOL_MAX),
 			volumeRight(PSP_SAS_VOL_MAX),
-			volumeLeftSend(0),
-			volumeRightSend(0),
 			effectLeft(PSP_SAS_VOL_MAX),
 			effectRight(PSP_SAS_VOL_MAX) {
 		memset(resampleHist, 0, sizeof(resampleHist));
@@ -245,12 +246,7 @@ struct SasVoice {
 	int volumeLeft;
 	int volumeRight;
 
-	// I am pretty sure that volumeLeftSend and effectLeft really are the same thing (and same for right of course).
-	// We currently have nothing that ever modifies volume*Send.
-	// One game that uses an effect (probably a reverb) is MHU.
-
-	int volumeLeftSend;	// volume to "Send" (audio-lingo) to the effects processing engine, like reverb
-	int volumeRightSend;
+	// volume to "Send" (audio-lingo) to the effects processing engine, like reverb
 	int effectLeft;
 	int effectRight;
 	s16 resampleHist[2];


### PR DESCRIPTION
Mainly, this more correctly generates data for output mode 1.  I had logged games using mode 1, but I either did it wrong or they all change the mode to 0 before actually generating sound, so I added reporting to find games that actually use this mode (since I'd like to see how they are using it...)

Also removed the warning on ADSRmode 5, 5, 5, 5 specifically.  It seems to definitely happen on a PSP, but many games trigger it for some reason.

-[Unknown]
