### PR TITLE
Reset resample hist on keyon, round up read

### DIFF
--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -452,7 +452,7 @@ void SasInstance::MixVoice(SasVoice &voice) {
 		// Actually this is not entirely correct - we need to get one extra sample, and store it
 		// for the next time around. A little complicated...
 		// But for now, see Smoothness HACKERY below :P
-		u32 numSamples = ((u32)voice.sampleFrac + (u32)grainSize * (u32)voice.pitch) >> PSP_SAS_PITCH_BASE_SHIFT;
+		u32 numSamples = ((u32)voice.sampleFrac + (u32)grainSize * (u32)voice.pitch + PSP_SAS_PITCH_BASE - 1) >> PSP_SAS_PITCH_BASE_SHIFT;
 		if ((int)numSamples > grainSize * 4) {
 			ERROR_LOG(SASMIX, "numSamples too large, clamping: %i vs %i", numSamples, grainSize * 4);
 			numSamples = grainSize * 4;
@@ -507,6 +507,7 @@ void SasInstance::MixSamples(SasVoice &voice) {
 	if (g_Config.iSFXVolume >= 0 && g_Config.iSFXVolume < MAX_CONFIG_VOLUME)
 		volumeShift += MAX_CONFIG_VOLUME - g_Config.iSFXVolume;
 
+	// The first two are resample history, were we done with the last one?
 	const int offset = sampleFrac == 0 ? 2 : 1;
 	for (int i = 0; i < grainSize; i++) {
 		const int readIndex = sampleFrac >> PSP_SAS_PITCH_BASE_SHIFT;
@@ -528,10 +529,11 @@ void SasInstance::MixSamplesHalfPitch(SasVoice &voice) {
 	if (g_Config.iSFXVolume >= 0 && g_Config.iSFXVolume < MAX_CONFIG_VOLUME)
 		volumeShift += MAX_CONFIG_VOLUME - g_Config.iSFXVolume;
 
-	int readIndex2 = voice.sampleFrac == 0 ? 0 : -1;
+	// The first two are resample history, were we done with the last one?
+	int readIndex2 = voice.sampleFrac == 0 ? 4 : 3;
 	for (int i = 0; i < grainSize; i++) {
-		int sample1 = resampleBuffer[(readIndex2 >> 1) + 2];
-		int sample2 = resampleBuffer[(readIndex2 >> 1) + 1 + 2];
+		int sample1 = resampleBuffer[(readIndex2 >> 1)];
+		int sample2 = resampleBuffer[(readIndex2 >> 1) + 1];
 		int sample = readIndex2 & 1 ? ((sample1 + sample2) >> 1) : sample1;
 		++readIndex2;
 
@@ -547,6 +549,7 @@ void SasInstance::MixSamplesOptimal(SasVoice &voice) {
 	if (g_Config.iSFXVolume >= 0 && g_Config.iSFXVolume < MAX_CONFIG_VOLUME)
 		volumeShift += MAX_CONFIG_VOLUME - g_Config.iSFXVolume;
 
+	// The first two are resample history.
 	int readIndex = 2;
 	for (int i = 0; i < grainSize; i++) {
 		int sample = resampleBuffer[readIndex++];
@@ -700,6 +703,7 @@ void SasVoice::KeyOn() {
 	on = true;
 	paused = false;
 	sampleFrac = 0;
+	Reset();
 }
 
 void SasVoice::KeyOff() {


### PR DESCRIPTION
If we have an uneven pitch, round up so that we get the next sample to resample in.

I don't really hear any crackling in Valkyria Chronicles 3 (mentioned in #5538), but I realized we weren't rounding up (need to, and we would go backwards in the resample history if we stopped in the middle of a sample) and that maybe the keyon is affecting resampling.

-[Unknown]
