### PR TITLE
Implemented sceKernelICacheInvalidateRange

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -351,6 +351,9 @@ int sceKernelDcacheInvalidateRange(u32 addr, int size)
 int sceKernelIcacheInvalidateRange(u32 addr, int size) {
 	DEBUG_LOG(CPU,"sceKernelIcacheInvalidateRange(%08x, %i)", addr, size);
 	// TODO: Make the JIT hash and compare the touched blocks.
+	if(MIPSComp::jit){
+		MIPSComp::jit->ClearCacheAt(addr, size);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Fixes crash in mhp3 hot springs after some missions
