### PR TITLE
Add additional check to prevent PS1 EBOOTs from loading.

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -186,10 +186,14 @@ bool LoadFile(std::string &filename, std::string *error_string) {
 				INFO_LOG(LOADER, "File is a PBP in a directory!");
 				std::string ebootPath = filename + "/EBOOT.PBP";
 				IdentifiedFileType ebootType = Identify_File(ebootPath);
-				if(ebootType == FILETYPE_PSP_ISO_NP) {
+				if (ebootType == FILETYPE_PSP_ISO_NP) {
 					InitMemoryForGameISO(ebootPath);
 					pspFileSystem.SetStartingDirectory("disc0:/PSP_GAME/USRDIR");
 					return Load_PSP_ISO(filename.c_str(), error_string);
+				}
+				else if (ebootType == FILETYPE_PSP_PS1_PBP) {
+					*error_string = "PS1 EBOOTs are not supported by PPSSPP.";
+					return false;
 				}
 				std::string path = filename;
 				size_t pos = path.find("/PSP/GAME/");


### PR DESCRIPTION
Might fix https://github.com/hrydgard/ppsspp/issues/5563. If not, we might need to check the PARAM.SFO category for "ME" too. In either case, we shouldn't be trying to load these even if the first Identify_File decides it's a directory game.
