### PR TITLE
Let the touchscreen pause/menu button be available for everybody.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -433,6 +433,11 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("ShowAnalogStick", &g_Config.bShowTouchAnalogStick, true),
 	ConfigSetting("ShowTouchDpad", &g_Config.bShowTouchDpad, true),
 	ConfigSetting("ShowTouchUnthrottle", &g_Config.bShowTouchUnthrottle, true),
+#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
+	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, true),
+#else
+	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, false),
+#endif
 #if defined(USING_WIN_UI)
 	ConfigSetting("IgnoreWindowsKey", &g_Config.bIgnoreWindowsKey, false),
 #endif

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -433,9 +433,7 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("ShowAnalogStick", &g_Config.bShowTouchAnalogStick, true),
 	ConfigSetting("ShowTouchDpad", &g_Config.bShowTouchDpad, true),
 	ConfigSetting("ShowTouchUnthrottle", &g_Config.bShowTouchUnthrottle, true),
-#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
-	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, true),
-#else
+#if !defined(__SYMBIAN32__) && !defined(IOS) && !defined(MEEGO_EDITION_HARMATTAN)
 	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, false),
 #endif
 #if defined(USING_WIN_UI)

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -227,7 +227,9 @@ public:
 	bool bShowTouchAnalogStick;
 	bool bShowTouchDpad;
 
+#if !defined(__SYMBIAN32__) && !defined(IOS) && !defined(MEEGO_EDITION_HARMATTAN)
 	bool bShowTouchPause;
+#endif
 
 	bool bHapticFeedback;
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -227,6 +227,8 @@ public:
 	bool bShowTouchAnalogStick;
 	bool bShowTouchDpad;
 
+	bool bShowTouchPause;
+
 	bool bHapticFeedback;
 
 	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -268,6 +268,16 @@ void GameSettingsScreen::CreateViews() {
 	layoutEditorChoice_ = controlsSettings->Add(new Choice(c->T("Custom layout...")));
 	layoutEditorChoice_->OnClick.Handle(this, &GameSettingsScreen::OnTouchControlLayout);
 	layoutEditorChoice_->SetEnabledPtr(&g_Config.bShowTouchControls);
+
+	// On systems that aren't Symbian, iOS, and Meego Harmattan, offer to let the user see this button.
+	// Some Windows touch devices don't have a back button or other button to call up the menu.
+#if !defined(__SYMBIAN32__) && !defined(IOS) && !defined(MEEGO_EDITION_HARMATTAN)
+	CheckBox *enablePauseBtn = controlsSettings->Add(new CheckBox(&g_Config.bShowTouchPause, c->T("Show Touch Pause Menu Button")));
+
+	// Don't allow the user to disable it once in-game, so they can't lock themselves out of the menu.
+	enablePauseBtn->SetEnabled(!PSP_IsInited());
+#endif
+
 	CheckBox *disableDiags = controlsSettings->Add(new CheckBox(&g_Config.bDisableDpadDiagonals, c->T("Disable D-Pad diagonals (4-way touch)")));
 	disableDiags->SetEnabledPtr(&g_Config.bShowTouchControls);
 	View *opacity = controlsSettings->Add(new PopupSliderChoice(&g_Config.iTouchButtonOpacity, 0, 100, c->T("Button Opacity"), screenManager()));

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -461,7 +461,9 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 		int stickImage = g_Config.iTouchButtonStyle ? I_STICK_LINE : I_STICK;
 		int stickBg = g_Config.iTouchButtonStyle ? I_STICK_BG_LINE : I_STICK_BG;
 
+#if !defined(__SYMBIAN32__) && !defined(IOS) && !defined(MEEGO_EDITION_HARMATTAN)
 		if (g_Config.bShowTouchPause)
+#endif
 			root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 
 		if (g_Config.bShowTouchCircle)

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -28,12 +28,6 @@
 
 #include <algorithm>
 
-#if defined(__SYMBIAN32__) || defined(IOS) || defined(MEEGO_EDITION_HARMATTAN)
-#define USE_PAUSE_BUTTON 1
-#else
-#define USE_PAUSE_BUTTON 0
-#endif
-
 static u32 GetButtonColor() {
 	return g_Config.iTouchButtonStyle == 1 ? 0xFFFFFF : 0xc0b080;
 }
@@ -467,11 +461,11 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 		int stickImage = g_Config.iTouchButtonStyle ? I_STICK_LINE : I_STICK;
 		int stickBg = g_Config.iTouchButtonStyle ? I_STICK_BG_LINE : I_STICK_BG;
 
-#if USE_PAUSE_BUTTON
-		root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
-#endif
+		if (g_Config.bShowTouchPause)
+			root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
+
 		if (g_Config.bShowTouchCircle)
-		root->Add(new PSPButton(CTRL_CIRCLE, roundImage, I_CIRCLE, Action_button_scale, new AnchorLayoutParams(Action_circle_button_X, Action_circle_button_Y, NONE, NONE, true)));
+			root->Add(new PSPButton(CTRL_CIRCLE, roundImage, I_CIRCLE, Action_button_scale, new AnchorLayoutParams(Action_circle_button_X, Action_circle_button_Y, NONE, NONE, true)));
 
 		if (g_Config.bShowTouchCross)
 			root->Add(new PSPButton(CTRL_CROSS, roundImage, I_CROSS, Action_button_scale, new AnchorLayoutParams(Action_cross_button_X, Action_cross_button_Y, NONE, NONE, true)));


### PR DESCRIPTION
It's still forced ON on iOS, Symbian, and Meego Harmattan.

Not all touch devices have a back button or a hardware button to call up the pause menu (one example: Windows tablets that only have a Start button, which would bring up the start menu/screen, and not our pause menu), so it makes sense to let everyone turn it on or off at will (except iOS/Symbian/Meego Harmattan). Also, when the user is in-game, it cannot be turned off so that they can't get locked out by accident.
