### PR TITLE
Correct clipping in sceFontGetCharGlyphImage_Clip()

### DIFF
--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -323,7 +323,7 @@ int PGF::GetCharIndex(int charCode, const std::vector<int> &charmapCompressed) {
 	return -1;
 }
 
-bool PGF::GetCharInfo(int charCode, PGFCharInfo *charInfo, int altCharCode) {
+bool PGF::GetCharInfo(int charCode, PGFCharInfo *charInfo, int altCharCode) const {
 	Glyph glyph;
 	memset(charInfo, 0, sizeof(*charInfo));
 
@@ -357,7 +357,7 @@ bool PGF::GetCharInfo(int charCode, PGFCharInfo *charInfo, int altCharCode) {
 	return true;
 }
 
-void PGF::GetFontInfo(PGFFontInfo *fi) {
+void PGF::GetFontInfo(PGFFontInfo *fi) const {
 	fi->maxGlyphWidthI = header.maxSize[0];
 	fi->maxGlyphHeightI = header.maxSize[1];
 	fi->maxGlyphAscenderI = header.maxAscender;
@@ -511,7 +511,7 @@ bool PGF::GetGlyph(const u8 *fontdata, size_t charPtr, int glyphType, Glyph &gly
 	return true;
 }
 
-bool PGF::GetCharGlyph(int charCode, int glyphType, Glyph &glyph) {
+bool PGF::GetCharGlyph(int charCode, int glyphType, Glyph &glyph) const {
 	if (charCode < firstGlyph)
 		return false;
 	charCode -= firstGlyph;
@@ -530,7 +530,7 @@ bool PGF::GetCharGlyph(int charCode, int glyphType, Glyph &glyph) {
 	return true;
 }
 
-void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType) {
+void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType) const {
 	Glyph glyph;
 	if (!GetCharGlyph(charCode, glyphType, glyph)) {
 		// No Glyph available for this charCode, try to use the alternate char.
@@ -555,6 +555,12 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 
 	int x = image->xPos64 >> 6;
 	int y = image->yPos64 >> 6;
+
+	// Negative means don't clip on that side.
+	if (clipWidth < 0)
+		clipWidth = glyph.w;
+	if (clipHeight < 0)
+		clipHeight = glyph.h;
 
 	while (pixelIndex < numberPixels && bitPtr + 8 < fontDataSize * 8) {
 		// This is some kind of nibble based RLE compression.
@@ -624,7 +630,7 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 	gpu->InvalidateCache(image->bufferPtr, image->bytesPerLine * image->bufHeight, GPU_INVALIDATE_SAFE);
 }
 
-void PGF::SetFontPixel(u32 base, int bpl, int bufWidth, int bufHeight, int x, int y, int pixelColor, int pixelformat) {
+void PGF::SetFontPixel(u32 base, int bpl, int bufWidth, int bufHeight, int x, int y, int pixelColor, int pixelformat) const {
 	if (x < 0 || x >= bufWidth || y < 0 || y >= bufHeight) {
 		return;
 	}

--- a/Core/Font/PGF.h
+++ b/Core/Font/PGF.h
@@ -264,9 +264,9 @@ public:
 
 	bool ReadPtr(const u8 *ptr, size_t dataSize);
 
-	bool GetCharInfo(int charCode, PGFCharInfo *ci, int altCharCode);
-	void GetFontInfo(PGFFontInfo *fi);
-	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType);
+	bool GetCharInfo(int charCode, PGFCharInfo *ci, int altCharCode) const;
+	void GetFontInfo(PGFFontInfo *fi) const;
+	void DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipWidth, int clipHeight, int charCode, int altCharCode, int glyphType) const;
 
 	void DoState(PointerWrap &p);
 
@@ -274,12 +274,12 @@ public:
 
 private:
 	bool GetGlyph(const u8 *fontdata, size_t charPtr, int glyphType, Glyph &glyph);
-	bool GetCharGlyph(int charCode, int glyphType, Glyph &glyph);
+	bool GetCharGlyph(int charCode, int glyphType, Glyph &glyph) const;
 
 	// Unused
 	int GetCharIndex(int charCode, const std::vector<int> &charmapCompressed);
 
-	void SetFontPixel(u32 base, int bpl, int bufWidth, int bufHeight, int x, int y, int pixelColor, int pixelformat);
+	void SetFontPixel(u32 base, int bpl, int bufWidth, int bufHeight, int x, int y, int pixelColor, int pixelformat) const;
 
 	PGFHeaderRev3Extra rev3extra;
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1074,10 +1074,10 @@ int sceFontGetCharGlyphImage_Clip(u32 fontHandle, u32 charCode, u32 glyphImagePt
 		return ERROR_FONT_INVALID_PARAMETER;
 	}
 
-	INFO_LOG(SCEFONT, "sceFontGetCharGlyphImage_Clip(%08x, %i, %08x, %i, %i, %i, %i)", fontHandle, charCode, glyphImagePtr, clipXPos, clipYPos, clipWidth, clipHeight);
+	DEBUG_LOG(SCEFONT, "sceFontGetCharGlyphImage_Clip(%08x, %i, %08x, %i, %i, %i, %i)", fontHandle, charCode, glyphImagePtr, clipXPos, clipYPos, clipWidth, clipHeight);
 	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
-	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipXPos + clipWidth, clipYPos + clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH);
+	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipWidth, clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH);
 	return 0;
 }
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -878,7 +878,7 @@ int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCodePtr) {
 
 	INFO_LOG(SCEFONT, "sceFontFindOptimumFont(%08x, %08x, %08x)", libHandle, fontStylePtr, errorCodePtr);
 
-	auto requestedStyle = Memory::GetStruct<const PGFFontStyle>(fontStylePtr);
+	auto requestedStyle = PSPPointer<const PGFFontStyle>::Create(fontStylePtr);
 
 	// Find the first nearest match for H/V, OR the last exact match for others.
 	float hRes = requestedStyle->fontHRes > 0.0f ? requestedStyle->fontHRes : fontLib->FontHRes();
@@ -941,7 +941,7 @@ int sceFontFindFont(u32 libHandle, u32 fontStylePtr, u32 errorCodePtr) {
 
 	INFO_LOG(SCEFONT, "sceFontFindFont(%x, %x, %x)", libHandle, fontStylePtr, errorCodePtr);
 
-	auto requestedStyle = Memory::GetStruct<const PGFFontStyle>(fontStylePtr);
+	auto requestedStyle = PSPPointer<const PGFFontStyle>::Create(fontStylePtr);
 
 	// Find the closest exact match for the fields specified.
 	float hRes = requestedStyle->fontHRes > 0.0f ? requestedStyle->fontHRes : fontLib->FontHRes();
@@ -979,7 +979,7 @@ int sceFontGetFontInfo(u32 fontHandle, u32 fontInfoPtr) {
 	}
 
 	DEBUG_LOG(SCEFONT, "sceFontGetFontInfo(%x, %x)", fontHandle, fontInfoPtr);
-	auto fi = Memory::GetStruct<PGFFontInfo>(fontInfoPtr);
+	auto fi = PSPPointer<PGFFontInfo>::Create(fontInfoPtr);
 	font->GetPGF()->GetFontInfo(fi);
 	fi->fontStyle = font->GetFont()->GetFontStyle();
 
@@ -1008,7 +1008,7 @@ int sceFontGetCharInfo(u32 fontHandle, u32 charCode, u32 charInfoPtr) {
 	DEBUG_LOG(SCEFONT, "sceFontGetCharInfo(%08x, %i, %08x)", fontHandle, charCode, charInfoPtr);
 	auto fontLib = font->GetFontLib();
 	int altCharCode = fontLib == NULL ? -1 : fontLib->GetAltCharCode();
-	auto charInfo = Memory::GetStruct<PGFCharInfo>(charInfoPtr);
+	auto charInfo = PSPPointer<PGFCharInfo>::Create(charInfoPtr);
 	font->GetPGF()->GetCharInfo(charCode, charInfo, altCharCode);
 
 	return 0;
@@ -1057,7 +1057,7 @@ int sceFontGetCharGlyphImage(u32 fontHandle, u32 charCode, u32 glyphImagePtr) {
 	}
 
 	DEBUG_LOG(SCEFONT, "sceFontGetCharGlyphImage(%x, %x, %x)", fontHandle, charCode, glyphImagePtr);
-	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
+	auto glyph = PSPPointer<const GlyphImage>::Create(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
 	font->GetPGF()->DrawCharacter(glyph, 0, 0, 8192, 8192, charCode, altCharCode, FONT_PGF_CHARGLYPH);
 	return 0;
@@ -1075,7 +1075,7 @@ int sceFontGetCharGlyphImage_Clip(u32 fontHandle, u32 charCode, u32 glyphImagePt
 	}
 
 	DEBUG_LOG(SCEFONT, "sceFontGetCharGlyphImage_Clip(%08x, %i, %08x, %i, %i, %i, %i)", fontHandle, charCode, glyphImagePtr, clipXPos, clipYPos, clipWidth, clipHeight);
-	auto glyph = Memory::GetStruct<const GlyphImage>(glyphImagePtr);
+	auto glyph = PSPPointer<const GlyphImage>::Create(glyphImagePtr);
 	int altCharCode = font->GetFontLib()->GetAltCharCode();
 	font->GetPGF()->DrawCharacter(glyph, clipXPos, clipYPos, clipWidth, clipHeight, charCode, altCharCode, FONT_PGF_CHARGLYPH);
 	return 0;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1649,7 +1649,7 @@ u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 returnValueA
 	// TODO: Need to test how this really works.  Let's assume it's an override.
 	if (Memory::IsValidAddress(optionAddr))
 	{
-		auto options = Memory::GetStruct<SceKernelSMOption>(optionAddr);
+		auto options = PSPPointer<SceKernelSMOption>::Create(optionAddr);
 		// TODO: Check how size handling actually works.
 		if (options->size != 0 && options->priority != 0)
 			priority = options->priority;
@@ -1728,7 +1728,7 @@ u32 sceKernelStopUnloadSelfModuleWithStatus(u32 exitCode, u32 argSize, u32 argp,
 
 		// TODO: Need to test how this really works.  Let's assume it's an override.
 		if (Memory::IsValidAddress(optionAddr)) {
-			auto options = Memory::GetStruct<SceKernelSMOption>(optionAddr);
+			auto options = PSPPointer<SceKernelSMOption>::Create(optionAddr);
 			// TODO: Check how size handling actually works.
 			if (options->size != 0 && options->priority != 0)
 				priority = options->priority;

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -721,7 +721,7 @@ int sceKernelCreateLwMutex(u32 workareaPtr, const char *name, u32 attr, int init
 	mutex->nm.uid = id;
 	mutex->nm.workarea = workareaPtr;
 	mutex->nm.initialCount = initialCount;
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 	workarea->init();
 	workarea->lockLevel = initialCount;
 	if (initialCount == 0)
@@ -777,7 +777,7 @@ int sceKernelDeleteLwMutex(u32 workareaPtr)
 	if (!workareaPtr || !Memory::IsValidAddress(workareaPtr))
 		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	u32 error;
 	LwMutex *mutex = kernelObjects.Get<LwMutex>(workarea->uid, error);
@@ -800,8 +800,7 @@ int sceKernelDeleteLwMutex(u32 workareaPtr)
 		return error;
 }
 
-template <typename T>
-bool __KernelLockLwMutex(T workarea, int count, u32 &error)
+bool __KernelLockLwMutex(NativeLwMutexWorkarea *workarea, int count, u32 &error)
 {
 	if (!error)
 	{
@@ -931,7 +930,7 @@ int sceKernelTryLockLwMutex(u32 workareaPtr, int count)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelTryLockLwMutex(%08x, %i)", workareaPtr, count);
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -947,7 +946,7 @@ int sceKernelTryLockLwMutex_600(u32 workareaPtr, int count)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelTryLockLwMutex_600(%08x, %i)", workareaPtr, count);
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -962,7 +961,7 @@ int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 {
 	VERBOSE_LOG(SCEKERNEL, "sceKernelLockLwMutex(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -993,7 +992,7 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 {
 	VERBOSE_LOG(SCEKERNEL, "sceKernelLockLwMutexCB(%08x, %i, %08x)", workareaPtr, count, timeoutPtr);
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -1024,7 +1023,7 @@ int sceKernelUnlockLwMutex(u32 workareaPtr, int count)
 {
 	VERBOSE_LOG(SCEKERNEL, "sceKernelUnlockLwMutex(%08x, %i)", workareaPtr, count);
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	if (workarea->uid == -1)
 		return PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;
@@ -1095,7 +1094,7 @@ int sceKernelReferLwMutexStatus(u32 workareaPtr, u32 infoPtr)
 	if (!Memory::IsValidAddress(workareaPtr))
 		return -1;
 
-	auto workarea = Memory::GetStruct<NativeLwMutexWorkarea>(workareaPtr);
+	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
 
 	int error = __KernelReferLwMutexStatus(workarea->uid, infoPtr);
 	if (error >= 0)

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1315,7 +1315,7 @@ u32 sceMpegFlushAllStream(u32 mpeg)
 	ctx->isAnalyzed = false;
 
 	if (Memory::IsValidAddress(ctx->mpegRingbufferAddr)) {
-		auto ringbuffer = Memory::GetStruct<SceMpegRingBuffer>(ctx->mpegRingbufferAddr);
+		auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ctx->mpegRingbufferAddr);
 
 		ringbuffer->packetsFree = ringbuffer->packets;
 		ringbuffer->packetsRead = 0;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1256,7 +1256,7 @@ int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int timeou
 
 	SceNetEtherAddr * addr = NULL;
 	if (Memory::IsValidAddress(peerMacAddrPtr)) {
-		addr = Memory::GetStruct<SceNetEtherAddr>(peerMacAddrPtr);
+		addr = PSPPointer<SceNetEtherAddr>::Create(peerMacAddrPtr);
 	}
 	uint16_t * port = NULL;
 	if (Memory::IsValidAddress(peerPortPtr)) {

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -201,7 +201,7 @@ void __RtcTicksToPspTime(ScePspDateTime &t, u64 ticks)
 	t.second = local->tm_sec;
 }
 
-u64 __RtcPspTimeToTicks(ScePspDateTime &pt)
+u64 __RtcPspTimeToTicks(const ScePspDateTime &pt)
 {
 	tm local;
 	local.tm_year = pt.year - 1900;
@@ -232,7 +232,7 @@ u64 __RtcPspTimeToTicks(ScePspDateTime &pt)
 	return result + tickOffset;
 }
 
-bool __RtcValidatePspTime(ScePspDateTime &t)
+bool __RtcValidatePspTime(const ScePspDateTime &t)
 {
 	return t.year > 0 && t.year <= 9999;
 }
@@ -672,7 +672,7 @@ int sceRtcSetWin32FileTime(u32 datePtr, u64 win32Time)
 	DEBUG_LOG(SCERTC, "sceRtcSetWin32FileTime(%08x, %lld)", datePtr, win32Time);
 
 	u64 ticks = (win32Time / 10) + rtcFiletimeOffset;
-	auto pspTime = Memory::GetStruct<ScePspDateTime>(datePtr);
+	auto pspTime = PSPPointer<ScePspDateTime>::Create(datePtr);
 	__RtcTicksToPspTime(*pspTime, ticks);
 	return 0;
 }
@@ -689,7 +689,7 @@ int sceRtcGetWin32FileTime(u32 datePtr, u32 win32TimePtr)
 	if (!Memory::IsValidAddress(win32TimePtr))
 		return SCE_KERNEL_ERROR_INVALID_VALUE;
 
-	auto pspTime = Memory::GetStruct<ScePspDateTime>(datePtr);
+	auto pspTime = PSPPointer<const ScePspDateTime>::Create(datePtr);
 	u64 result = __RtcPspTimeToTicks(*pspTime);
 
 	if (!__RtcValidatePspTime(*pspTime) || result < rtcFiletimeOffset)

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -307,13 +307,6 @@ void WriteStruct(u32 address, T *ptr)
 	memcpy(GetPointer(address), ptr, sz);
 }
 
-// Expect this to be some form of auto class on big endian.
-template<class T>
-T *GetStruct(u32 address)
-{
-	return (T *)GetPointer(address);
-}
-
 const char *GetAddressName(u32 address);
 
 };


### PR DESCRIPTION
It was not clipping completely (clip x1/y1 was being doubled in the x2/y2), and didn't handle negative clip w/h.

Also, reduce to debug log (seems to work fine now and has been working fine in most games.)

-[Unknown]
