### PR TITLE
Workaround bug in Kurohyou 2 (uninitialized data)

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1046,7 +1046,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			for (int i = 0; i < entry->numFuncs; ++i) {
 				// This is the id of the import.
 				func.nid = nidDataPtr[i];
-				// This is the address to write the j abnd delay slot to.
+				// This is the address to write the j and delay slot to.
 				func.stubAddr = entry->firstSymAddr + i * 8;
 				module->ImportFunc(func);
 			}


### PR DESCRIPTION
The game calls scePsmfGetEPWithTimestamp(), but without any chapters.  This means nothing is written to its pointer.  But it takes the value there anyway.

It happens that the value there is 0, but only because something wrote it to the stack before the call.  It seems like scePsmfVerifyPsmf() is the one writing it, since it has a different value shortly before that call.

So, as a workaround, just write some 0s into the stack.  Games without bugs should not care.  Hard to predict what will happen to another buggy game.

Also, correct some error codes per brief tests (I was initially hoping it was just the wrong error code...)

-[Unknown]
