### PR TITLE
Highlight arguments from the selected range

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -78,6 +78,9 @@ class CtrlDisAsmView
 	void updateStatusBarText();
 	void drawBranchLine(HDC hdc, std::map<u32,int>& addressPositions, BranchLine& line);
 	void copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm);
+	std::set<std::string> getSelectedLineArguments();
+	void drawArguments(HDC hdc, const DisassemblyLineInfo &line, int x, int y, int textColor, const std::set<std::string> &currentArguments);
+
 public:
 	CtrlDisAsmView(HWND _wnd);
 	~CtrlDisAsmView();


### PR DESCRIPTION
For example, if "lui v0,0x8000" is selected, highlight "v0" or "0x8000" used as arguments on other lines.  Makes it a bit easier to follow.

Not sure if I picked an ideal color, when with cyan.

-[Unknown]
