### PR TITLE
Win32: On Optimus systems, use the NVidia GPU, not the IGP.

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -56,13 +56,9 @@
 // Nvidia drivers >= v302 will check if the application exports a global
 // variable named NvOptimusEnablement to know if it should run the app in high
 // performance graphics mode or using the IGP.
-#ifdef WIN32
-
 extern "C" {
 	__declspec(dllexport) DWORD NvOptimusEnablement = 1;
 }
-
-#endif
 
 CDisasm *disasmWindow[MAX_CPUCOUNT] = {0};
 CGEDebugger *geDebuggerWindow = 0;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -53,6 +53,17 @@
 #include "Windows/WindowsHost.h"
 #include "Windows/main.h"
 
+// Nvidia drivers >= v302 will check if the application exports a global
+// variable named NvOptimusEnablement to know if it should run the app in high
+// performance graphics mode or using the IGP.
+#ifdef WIN32
+
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+}
+
+#endif
+
 CDisasm *disasmWindow[MAX_CPUCOUNT] = {0};
 CGEDebugger *geDebuggerWindow = 0;
 CMemoryDlg *memoryWindow[MAX_CPUCOUNT] = {0};


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/commit/b3ed3bdb910fe77dc3b1e05478258f693b5d943d and http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf. Apparently we're not using the NVidia GPU on Optimus-based systems, so this should help, according to the PDF.
