### PR TITLE
Avoid leaving the fast runloop on jumps.

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -565,8 +565,12 @@ void GPUCommon::UpdatePC(u32 currentPC, u32 newPC) {
 
 	gpuStats.gpuCommandsAtCallLevel[std::min(currentList->stackptr, 3)] += executed;
 
-	// Exit the runloop and recalculate things.  This isn't common.
-	downcount = 0;
+	// Exit the runloop and recalculate things.  This happens a lot in some games.
+	easy_guard innerGuard(listLock);
+	if (currentList)
+		downcount = currentList->stall == 0 ? 0x0FFFFFFF : (currentList->stall - cycleLastPC) / 4;
+	else
+		downcount = 0;
 }
 
 void GPUCommon::ReapplyGfxState() {


### PR DESCRIPTION
Jumps are actually very common in some games, like FF4 and Crisis Core, and tons more.  They are used to jump around vertex data.

Improves performance by a few percent in FF4.

-[Unknown]
