### PR TITLE
Show unknown.png regardless of PARAM.SFO when an ISO lacks an icon0.

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -362,7 +362,6 @@ handleELF:
 					info_->paramSFO.ReadSFO((const u8 *)paramSFOcontents.data(), paramSFOcontents.size());
 					info_->ParseParamSFO();
 
-					ReadFileToString(&umd, "/PSP_GAME/ICON0.PNG", &info_->iconTextureData, &info_->lock);
 					if (info_->wantBG) {
 						ReadFileToString(&umd, "/PSP_GAME/PIC0.PNG", &info_->pic0TextureData, &info_->lock);
 					}
@@ -370,7 +369,10 @@ handleELF:
 				} else {
 					// Fall back to the filename for title if ISO is broken
 					info_->title = gamePath_;
-					// Fall back to unknown icon if ISO is broken, override is allowed though
+				}
+
+				// Fall back to unknown icon if ISO is broken/is a homebrew ISO, override is allowed though
+				if (!ReadFileToString(&umd, "/PSP_GAME/ICON0.PNG", &info_->iconTextureData, &info_->lock)) {
 					size_t sz;
 					uint8_t *contents = VFSReadFile("unknown.png", &sz);
 					DEBUG_LOG(LOADER, "Loading unknown.png because no icon was found");


### PR DESCRIPTION
It seems weird to show only a black rectangle that has nothing in it (and nothing when viewing the right-click details page) when certain ISOs (e.g. homebrew ISOs, or broken ISOs) have no icon0, so let's show the unknown.png file instead.

![screenshot 01](http://i.minus.com/itemKPShLJkhR.jpg)

![screenshot 02](http://i.minus.com/iyoDNOmxHCLGk.jpg)
