### PR TITLE
Added printing of game save key to debug log when loading/saving

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -65,6 +65,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	int retval = param.SetPspParam(&request);
 
 	INFO_LOG(SCEUTILITY,"sceUtilitySavedataInitStart(%08x) : Mode = %i", paramAddr, (SceUtilitySavedataType)(u32)param.GetPspParam()->mode);
+	INFO_LOG(SCEUTILITY,"sceUtilitySavedataInitStart(%08x) : Game key (hex): %s", paramAddr, param.GetKey(param.GetPspParam()).c_str());
 
 	yesnoChoice = 1;
 	switch ((SceUtilitySavedataFocus)(u32)param.GetPspParam()->focus)

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -279,6 +279,24 @@ std::string SavedataParam::GetFileName(const SceUtilitySavedataParam *param) con
 	return FixedToString(param->fileName, ARRAY_SIZE(param->fileName));
 }
 
+std::string SavedataParam::GetKey(const SceUtilitySavedataParam *param) const
+{
+	static const char* const lut = "0123456789ABCDEF";
+
+	std::string output;
+	if (param->key[0])
+	{
+		output.reserve(2 * sizeof(param->key));
+		for (size_t i = 0; i < sizeof(param->key); ++i)
+		{
+			const unsigned char c = param->key[i];
+			output.push_back(lut[c >> 4]);
+			output.push_back(lut[c & 15]);
+		}
+	}
+	return output;
+}
+
 bool SavedataParam::Delete(SceUtilitySavedataParam* param, int saveId)
 {
 	if (!param)

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -294,6 +294,7 @@ public:
 	std::string GetGameName(const SceUtilitySavedataParam *param) const;
 	std::string GetSaveName(const SceUtilitySavedataParam *param) const;
 	std::string GetFileName(const SceUtilitySavedataParam *param) const;
+	std::string GetKey(const SceUtilitySavedataParam *param) const;
 
 	static std::string GetSpaceText(int size);
 


### PR DESCRIPTION
This simple addition will print the game's save key in hex to the debug log whenever a load/save happens. This is useful for those of us who do not own a PSP (to run Deemer) and wish to modify save files. The key can be used with a tool like https://github.com/hgoel0974/SED-PC
