### PR TITLE
OSK: Add a button to let the user enter spaces.

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -57,7 +57,7 @@ static const wchar_t diacritics[2][103] =
 // Korean(Hangul) consonant
 static const wchar_t kor_cons[] = L"ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
 
-// Korean(Hangul) vowels, Some vowels are not used, them will be spacing
+// Korean(Hangul) vowels, Some vowels are not used, they will be spaces
 static const wchar_t kor_vowel[] = L"ㅏㅐㅑㅒㅓㅔㅕㅖㅗ   ㅛㅜ   ㅠㅡ ㅣ";
 
 // Korean(Hangul) vowel Combination key
@@ -871,6 +871,12 @@ int PSPOskDialog::Update(int animSpeed) {
 	StartDraw();
 	PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x63636363));
 	RenderKeyboard();
+
+	I18NCategory *d = GetI18NCategory("Dialog");
+
+	PPGeDrawImage(I_SQUARE, 85, 195, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(d->T("Space"), 115, 195, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
 	if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE) {
 		PPGeDrawImage(I_CROSS, 85, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawImage(I_CIRCLE, 85, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
@@ -879,13 +885,11 @@ int PSPOskDialog::Update(int animSpeed) {
 		PPGeDrawImage(I_CROSS, 85, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 	}
 
-	I18NCategory *d = GetI18NCategory("Dialog");
 	PPGeDrawText(d->T("Select"), 115, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawText(d->T("Delete"), 115, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 	PPGeDrawText("Start", 195, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawText(d->T("Finish"), 235, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-
 
 	int index = (currentKeyboardLanguage - 1) % OSK_LANGUAGE_COUNT;
 	const char *countryCode;
@@ -996,7 +1000,14 @@ int PSPOskDialog::Update(int animSpeed) {
 		}
 	} else if (IsButtonPressed(CTRL_START)) {
 		StartFade(false);
+	} else if (IsButtonPressed(CTRL_SQUARE)) {
+		// Use a regular space if the current keyboard isn't Japanese nor full-width English
+		if (currentKeyboardLanguage != OSK_LANGUAGE_JAPANESE && currentKeyboardLanguage != OSK_LANGUAGE_ENGLISH_FW)
+			inputChars += L" ";
+		else
+			inputChars += L"　";
 	}
+
 	EndDraw();
 
 	u16_le *outText = oskParams->fields[0].outtext;

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -47,29 +47,29 @@ static std::map<std::string, std::pair<std::string, int>> languageMapping;
 const int numKeyCols[OSK_KEYBOARD_COUNT] = {12, 12, 13, 13, 12, 12, 12, 12, 12};
 const int numKeyRows[OSK_KEYBOARD_COUNT] = {4, 4, 5, 5, 5, 4, 4, 4, 4};
 
-// Japanese(Kana) diacritics
+// Japanese (Kana) diacritics
 static const wchar_t diacritics[2][103] =
 {
 	{L"かがきぎくぐけげこごさざしじすずせぜそぞただちぢつづてでとどはばぱばひびぴびふぶぷぶへべぺべほぼぽぼウヴカガキギクグケゲコゴサザシジスズセゼソゾタダチヂツヅテデトドハバパバヒビピビフブプブヘベペベホボポボ"},
 	{L"はぱばぱひぴびぴふぷぶぷへぱべぱほぽぼぽハパバパヒピビピフプブプヘパベパホポボポ"}
 };
 
-// Korean(Hangul) consonant
+// Korean (Hangul) consonant
 static const wchar_t kor_cons[] = L"ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
 
-// Korean(Hangul) vowels, Some vowels are not used, they will be spaces
+// Korean (Hangul) vowels, Some vowels are not used, they will be spaces
 static const wchar_t kor_vowel[] = L"ㅏㅐㅑㅒㅓㅔㅕㅖㅗ   ㅛㅜ   ㅠㅡ ㅣ";
 
-// Korean(Hangul) vowel Combination key
+// Korean (Hangul) vowel Combination key
 const int kor_vowelCom[] = {0,8,9,1,8,10,20,8,11,4,13,14,5,13,15,20,13,16,20,18,19};
 
-// Korean(Hangul) last consonant(diacritics)
+// Korean (Hangul) last consonant(diacritics)
 static const wchar_t kor_lcons[] = L"ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ";
 
-// Korean(Hangul) last consonant Combination key
+// Korean (Hangul) last consonant Combination key
 const int kor_lconsCom[] = {18,0,2,21,3,4,26,3,5,0,7,8,15,7,9,16,7,10,18,7,11,24,7,12,25,7,13,26,7,14,18,16,17};
 
-// Korean(Hangul) last consonant Separation key
+// Korean (Hangul) last consonant Separation key
 const int kor_lconsSpr[] = {2,1,9,4,4,12,5,4,18,8,8,0,9,8,6,10,8,7,11,8,9,12,8,16,13,8,17,14,8,18,17,17,9};
 
 static const wchar_t oskKeys[OSK_KEYBOARD_COUNT][5][14] =
@@ -1000,7 +1000,7 @@ int PSPOskDialog::Update(int animSpeed) {
 		}
 	} else if (IsButtonPressed(CTRL_START)) {
 		StartFade(false);
-	} else if (IsButtonPressed(CTRL_SQUARE)) {
+	} else if (IsButtonPressed(CTRL_SQUARE) && inputChars.size() < FieldMaxLength()) {
 		// Use a regular space if the current keyboard isn't Japanese nor full-width English
 		if (currentKeyboardLanguage != OSK_LANGUAGE_JAPANESE && currentKeyboardLanguage != OSK_LANGUAGE_ENGLISH_FW)
 			inputChars += L" ";

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -171,7 +171,7 @@ enum OskKeyboardLanguage
 	OSK_LANGUAGE_JAPANESE,
 	OSK_LANGUAGE_KOREAN,
 	OSK_LANGUAGE_RUSSIAN,
-	OSK_LANGUAGE_ENGLISH_FW, //English full-width(mostly used in Japanese games)
+	OSK_LANGUAGE_ENGLISH_FW, //English full-width (mostly used in Japanese games)
 	OSK_LANGUAGE_COUNT
 };
 


### PR DESCRIPTION
Square will serve as the spacebar, and based on the language, will input an appropriate space (e.g. full-width space for Japanese or English full-width, regular space for everything else).

Fixes/implements https://github.com/hrydgard/ppsspp/issues/5634.

Here's how the OSK looks now, with 4 rows of characters (all languages except for Korean):
![Screenshot 01](http://i.minus.com/i9ODNzm4tPpNV.jpg)

With 5 rows of characters:
![Screenshot 02](http://i.minus.com/ibo5h9hv4F6qQ4.jpg)
