### PR TITLE
Fix bug: building on MACOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,7 +420,7 @@ if(USE_FFMPEG)
 		)
 	endif()
 
-	if(IOS OR BLACKBERRY)
+	if(IOS OR BLACKBERRY OR MACOSX)
 		set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} iconv)
 	endif()
 


### PR DESCRIPTION
1) Update the CmakeLists.txt to fix missing symbols in linking phase as:

```
"_iconv", referenced from:
_avcodec_decode_subtitle2 in libavcodec.a(utils.o)
"_iconv_close", referenced from:
_avcodec_open2 in libavcodec.a(utils.o)
_avcodec_decode_subtitle2 in libavcodec.a(utils.o)
"_iconv_open", referenced from:
_avcodec_open2 in libavcodec.a(utils.o)
_avcodec_decode_subtitle2 in libavcodec.a(utils.o)
```

2) The ffmpeg lib should be rebuild in order to avoid missing symbols as:

```
"___sincos_stret", referenced from:
_ff_mdct_init in libavcodec.a(mdct_float.o)
_ff_ps_init in libavcodec.a(aacps.o)
"___sincosf_stret", referenced from:
_ff_ps_init in libavcodec.a(aacps.o)
```

3) Here is the new build commands that works fine for me, and should work fine too for everybody on all macosx:
In the ppsspp root path,
rebuilt ffmpeg

```
cd ffmpeg
./mac_x86-64.sh
```

build ppsspp

```
cd ..
mkdir build-mac
cd build-mac
cmake ../
make
```

PS1: you should have homebrew, which is installed by:

```
ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
```

PS2: if you missing command "yasm" when building ffmpeg, then try install it by:

```
brew install yasm
```
