### PR TITLE
Avoid caching when HW T&L with morph enabled.

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -539,6 +539,10 @@ void TransformDrawEngine::DoFlush() {
 		if (g_Config.bSoftwareSkinning && (lastVType_ & GE_VTYPE_WEIGHT_MASK))
 			useCache = false;
 
+		// Also avoid caching when HW T&L with morph enabled.
+		if (g_Config.bHardwareTransform && !(lastVType_ & GE_VTYPE_MORPHCOUNT_MASK))
+			useCache = false;
+
 		if (useCache) {
 			u32 id = ComputeFastDCID();
 			auto iter = vai_.find(id);


### PR DESCRIPTION
Fix https://github.com/hrydgard/ppsspp/issues/5646

Should also help other game which has flickering textures when vertex cache enabled like Assisans Creed ,  Midnight Club Remix etc
