### PR TITLE
Minor armjit optimizations, fix B/BL encoding

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -806,6 +806,11 @@ void ARMXEmitter::UBFX(ARMReg dest, ARMReg rn, u8 lsb, u8 width)
 	Write32(condition | (0x7E0 << 16) | ((width - 1) << 16) | (dest << 12) | (lsb << 7) | (5 << 4) | rn);
 }
 
+void ARMXEmitter::SBFX(ARMReg dest, ARMReg rn, u8 lsb, u8 width)
+{
+	Write32(condition | (0x7A0 << 16) | ((width - 1) << 16) | (dest << 12) | (lsb << 7) | (5 << 4) | rn);
+}
+
 void ARMXEmitter::CLZ(ARMReg rd, ARMReg rm)
 {
 	Write32(condition | (0x16F << 16) | (rd << 12) | (0xF1 << 4) | rm);
@@ -827,6 +832,13 @@ void ARMXEmitter::BFI(ARMReg rd, ARMReg rn, u8 lsb, u8 width)
 	u32 msb = (lsb + width - 1);
 	if (msb > 31) msb = 31;
 	Write32(condition | (0x7C0 << 16) | (msb << 16) | (rd << 12) | (lsb << 7) | (1 << 4) | rn);
+}
+
+void ARMXEmitter::BFC(ARMReg rd, u8 lsb, u8 width)
+{
+	u32 msb = (lsb + width - 1);
+	if (msb > 31) msb = 31;
+	Write32(condition | (0x7C0 << 16) | (msb << 16) | (rd << 12) | (lsb << 7) | (1 << 4) | 15);
 }
 
 void ARMXEmitter::SXTB (ARMReg dest, ARMReg op2)

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -228,6 +228,27 @@ bool ARMXEmitter::TryANDI2R(ARMReg rd, ARMReg rs, u32 val)
 		}
 		return true;
 	} else {
+#ifdef HAVE_ARMV7
+		// Check if we have a single pattern of sequential bits.
+		int seq = -1;
+		for (int i = 0; i < 32; ++i) {
+			if (((val >> i) & 1) == 0) {
+				if (seq == -1) {
+					// The width is all bits previous to this, set to 1.
+					seq = i;
+				}
+			} else if (seq != -1) {
+				// Uh oh, more than one sequence.
+				seq = -2;
+			}
+		}
+
+		if (seq > 0) {
+			UBFX(rd, rs, 0, seq);
+			return true;
+		}
+#endif
+
 		int ops = 0;
 		for (int i = 0; i < 32; i += 2) {
 			u8 bits = RotR(val, i) & 0xFF;

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -556,7 +556,7 @@ void ARMXEmitter::SetJumpTarget(FixupBranch const &branch)
 	_assert_msg_(JIT, distance > -0x2000000 && distance <=  0x2000000,
 	             "SetJumpTarget out of range (%p calls %p)", code, branch.ptr);
 	u32 instr = (u32)(branch.condition | ((distance >> 2) & 0x00FFFFFF));
-	instr |= branch.type ? /* B */ 0x0A000000 : /* BL */ 0x0B000000;
+	instr |= branch.type == 0 ? /* B */ 0x0A000000 : /* BL */ 0x0B000000;
 	*(u32*)branch.ptr = instr;
 }
 void ARMXEmitter::B (const void *fnptr)

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -204,6 +204,20 @@ bool ARMXEmitter::TryADDI2R(ARMReg rd, ARMReg rs, u32 val)
 	}
 }
 
+void ARMXEmitter::SUBI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch)
+{
+	if (!TrySUBI2R(rd, rs, val)) {
+		MOVI2R(scratch, val);
+		SUB(rd, rs, scratch);
+	}
+}
+
+bool ARMXEmitter::TrySUBI2R(ARMReg rd, ARMReg rs, u32 val)
+{
+	// Just add a negative.
+	return TryADDI2R(rd, rs, (u32)-(s32)val);
+}
+
 void ARMXEmitter::ANDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch)
 {
 	if (!TryANDI2R(rd, rs, val)) {

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -538,7 +538,9 @@ public:
 	void SXTH(ARMReg dest, ARMReg op2, u8 rotation = 0);
 	void SXTAH(ARMReg dest, ARMReg src, ARMReg op2, u8 rotation = 0);
 	void BFI(ARMReg rd, ARMReg rn, u8 lsb, u8 width);
+	void BFC(ARMReg rd, u8 lsb, u8 width);
 	void UBFX(ARMReg dest, ARMReg op2, u8 lsb, u8 width);
+	void SBFX(ARMReg dest, ARMReg op2, u8 lsb, u8 width);
 	void CLZ(ARMReg rd, ARMReg rm);
 	void PLD(ARMReg rd, int offset, bool forWrite = false);
 

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -796,6 +796,8 @@ public:
 
 	void ADDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
 	bool TryADDI2R(ARMReg rd, ARMReg rs, u32 val);
+	void SUBI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
+	bool TrySUBI2R(ARMReg rd, ARMReg rs, u32 val);
 	void ANDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
 	bool TryANDI2R(ARMReg rd, ARMReg rs, u32 val);
 	void CMPI2R(ARMReg rs, u32 val, ARMReg scratch);

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -795,10 +795,17 @@ public:
 	}
 
 	void ADDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
+	bool TryADDI2R(ARMReg rd, ARMReg rs, u32 val);
 	void ANDI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
+	bool TryANDI2R(ARMReg rd, ARMReg rs, u32 val);
 	void CMPI2R(ARMReg rs, u32 val, ARMReg scratch);
+	bool TryCMPI2R(ARMReg rs, u32 val);
 	void TSTI2R(ARMReg rs, u32 val, ARMReg scratch);
+	bool TryTSTI2R(ARMReg rs, u32 val);
 	void ORI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
+	bool TryORI2R(ARMReg rd, ARMReg rs, u32 val);
+	void EORI2R(ARMReg rd, ARMReg rs, u32 val, ARMReg scratch);
+	bool TryEORI2R(ARMReg rd, ARMReg rs, u32 val);
 };  // class ARMXEmitter
 
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -173,7 +173,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 		return ERROR_SAS_INVALID_PARAMETER;
 	}
 	if (loop != 0 && loop != 1) {
-		WARN_LOG_REPORT(SCESAS, "%s: invalid loop mode %d", __FUNCTION__, size);
+		WARN_LOG_REPORT(SCESAS, "%s: invalid loop mode %d", __FUNCTION__, loop);
 		return ERROR_SAS_INVALID_LOOP_POS;
 	}
 

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -60,6 +60,11 @@ namespace MIPSComp
 			Operand2 op2;
 			if (TryMakeOperand2(uimm, op2)) {
 				(this->*arith)(gpr.R(rt), gpr.R(rs), op2);
+#ifdef HAVE_ARMV7
+			} else if (eval == &EvalAnd && uimm == 0xFFFF) {
+				// This is common (e.g. a cast to a short.)
+				UBFX(gpr.R(rt), gpr.R(rs), 0, 16);
+#endif
 			} else {
 				gpr.SetRegImm(R0, (u32)uimm);
 				(this->*arith)(gpr.R(rt), gpr.R(rs), R0);
@@ -115,7 +120,7 @@ namespace MIPSComp
 			}
 			break;
 
-		case 11: // R(rt) = R(rs) < uimm; break; //sltiu
+		case 11: // R(rt) = R(rs) < suimm; break; //sltiu
 			{
 				if (gpr.IsImm(rs)) {
 					gpr.SetImm(rt, gpr.GetImm(rs) < suimm ? 1 : 0);

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -488,7 +488,9 @@ namespace MIPSComp
 			return;
 		}
 		gpr.MapDirtyInIn(rd, rs, rt);
-		AND(R0, gpr.R(rs), Operand2(0x1F));
+		// A rotate will be the same even if >= 32.
+		if (shiftType != ST_ROR)
+			AND(R0, gpr.R(rs), Operand2(0x1F));
 		MOV(gpr.R(rd), Operand2(gpr.R(rt), shiftType, R0));
 	}
 

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -109,6 +109,11 @@ namespace MIPSComp
 				if (gpr.IsImm(rs)) {
 					gpr.SetImm(rt, (s32)gpr.GetImm(rs) < simm ? 1 : 0);
 					break;
+				} else if (simm == 0) {
+					gpr.MapDirtyIn(rt, rs);
+					// Shift to get the sign bit only (for < 0.)
+					LSR(gpr.R(rt), gpr.R(rs), 31);
+					break;
 				}
 				gpr.MapDirtyIn(rt, rs);
 				CMPI2R(gpr.R(rs), simm, R0);

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -100,7 +100,10 @@ namespace MIPSComp
 					break;
 				}
 				gpr.MapDirtyIn(rt, rs);
-				CMPI2R(gpr.R(rs), simm, R0);
+				if (!TryCMPI2R(gpr.R(rs), simm)) {
+					gpr.SetRegImm(R0, simm);
+					CMP(gpr.R(rs), R0);
+				}
 				SetCC(CC_LT);
 				MOVI2R(gpr.R(rt), 1);
 				SetCC(CC_GE);
@@ -116,7 +119,10 @@ namespace MIPSComp
 					break;
 				}
 				gpr.MapDirtyIn(rt, rs);
-				CMPI2R(gpr.R(rs), suimm, R0);
+				if (!TryCMPI2R(gpr.R(rs), suimm)) {
+					gpr.SetRegImm(R0, suimm);
+					CMP(gpr.R(rs), R0);
+				}
 				SetCC(CC_LO);
 				MOVI2R(gpr.R(rt), 1);
 				SetCC(CC_HS);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -209,7 +209,7 @@ private:
 
 	// Utilities to reduce duplicated code
 	void CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARMXEmitter::*arith)(ARMReg dst, ARMReg src, Operand2 op2), bool (ARMXEmitter::*tryArithI2R)(ARMReg dst, ARMReg src, u32 val), u32 (*eval)(u32 a, u32 b));
-	void CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool symmetric = false, bool useMOV = false);
+	void CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), bool (ARMXEmitter::*tryArithI2R)(ARMReg dst, ARMReg rm, u32 val), u32 (*eval)(u32 a, u32 b), bool symmetric = false);
 
 	void CompShiftImm(MIPSOpcode op, ArmGen::ShiftType shiftType, int sa);
 	void CompShiftVar(MIPSOpcode op, ArmGen::ShiftType shiftType);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -208,7 +208,7 @@ private:
 	void BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely);
 
 	// Utilities to reduce duplicated code
-	void CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARMXEmitter::*arith)(ARMReg dst, ARMReg src, Operand2 op2), u32 (*eval)(u32 a, u32 b));
+	void CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARMXEmitter::*arith)(ARMReg dst, ARMReg src, Operand2 op2), bool (ARMXEmitter::*tryArithI2R)(ARMReg dst, ARMReg src, u32 val), u32 (*eval)(u32 a, u32 b));
 	void CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARMXEmitter::*arithOp2)(ARMReg dst, ARMReg rm, Operand2 rn), u32 (*eval)(u32 a, u32 b), bool symmetric = false, bool useMOV = false);
 
 	void CompShiftImm(MIPSOpcode op, ArmGen::ShiftType shiftType, int sa);

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -255,6 +255,15 @@ bool TestArmEmitter() {
 	ARMXEmitter emitter((u8 *)code);
 	emitter.LDR(R3, R7);
 	RET(CheckLast(emitter, "e5973000 LDR r3, [r7, #0]"));
+	emitter.BFI(R3, R7, 5, 9);
+	RET(CheckLast(emitter, "e7cd3297 BFI r3, r7, #5, #9"));
+	emitter.BFC(R4, 5, 9);
+	RET(CheckLast(emitter, "e7cd429f BFC r4, #5, #9"));
+	emitter.UBFX(R4, R9, 5, 9);
+	RET(CheckLast(emitter, "e7e842d9 UBFX r4, r9, #5, #9"));
+	emitter.SBFX(R0, R8, 5, 9);
+	RET(CheckLast(emitter, "e7a802d8 SBFX r0, r8, #5, #9"));
+
 	emitter.VLDR(S3, R8, 48);
 	RET(CheckLast(emitter, "edd81a0c VLDR s3, [r8, #48]"));
 	emitter.VSTR(S5, R12, -36);

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -264,6 +264,13 @@ bool TestArmEmitter() {
 	emitter.SBFX(R0, R8, 5, 9);
 	RET(CheckLast(emitter, "e7a802d8 SBFX r0, r8, #5, #9"));
 
+	emitter.B_CC(CC_NEQ, code + 128);
+	RET(CheckLast(emitter, "1a000079 BNE &000001EC"));
+	emitter.SetJumpTarget(emitter.B_CC(CC_NEQ));
+	RET(CheckLast(emitter, "1affffff BNE &00000004"));
+	emitter.SetJumpTarget(emitter.BL_CC(CC_NEQ));
+	RET(CheckLast(emitter, "1bffffff BLNE &00000004"));
+
 	emitter.VLDR(S3, R8, 48);
 	RET(CheckLast(emitter, "edd81a0c VLDR s3, [r8, #48]"));
 	emitter.VSTR(S5, R12, -36);


### PR DESCRIPTION
SetJumpTarget() wrote BL for B, and B for BL.  Luckily we were never using it in a way we cared.

Also, cut an instruction from "andi x, y, 0xFFFF" and cut some instructions from "slt x, y, 0".  Probably won't really help perf anywhere.

Technically, & (any solid uninterrupted sequence of bits) could be optimized, in ANDI2R also, I suppose.

-[Unknown]
