### PR TITLE
Eat cycles in sceUtilitySavedataGetStatus()

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -145,11 +145,13 @@ int sceUtilitySavedataGetStatus()
 	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
 		DEBUG_LOG(SCEUTILITY, "sceUtilitySavedataGetStatus(): wrong dialog type");
+		hleEatCycles(200);
 		return SCE_ERROR_UTILITY_WRONG_TYPE;
 	}
 
 	int status = saveDialog.GetStatus();
 	DEBUG_LOG(SCEUTILITY, "%08x=sceUtilitySavedataGetStatus()", status);
+	hleEatCycles(200);
 	return status;
 }
 


### PR DESCRIPTION
Matching tests.  Improves performance in Fieldrunners startup and I think in game even?  Well, there were slowdowns before that I can't reproduce with this but it seems odd that it would do it during the game...

Anyway, saving does not appear to actually work (with or without this change), but this makes the game a lot smoother on Android for me.  Still need to check into saving...

-[Unknown]
