### PR TITLE
Use SSE in the softgpu to improve perf

### DIFF
--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -22,7 +22,16 @@ namespace Math3D {
 template<>
 float Vec2<float>::Length() const
 {
+#if defined(_M_SSE)
+	float ret;
+	__m128 sq = _mm_mul_ps(vec, vec);
+	const __m128 r2 = _mm_shuffle_ps(sq, sq, _MM_SHUFFLE(0, 0, 0, 1));
+	const __m128 res = _mm_add_ss(sq, r2);
+	_mm_store_ps(&ret, _mm_sqrt_ss(res));
+	return ret;
+#else
 	return sqrtf(Length2());
+#endif
 }
 
 template<>
@@ -88,7 +97,17 @@ unsigned int Vec3<int>::ToRGB() const
 template<>
 float Vec3<float>::Length() const
 {
+#if defined(_M_SSE)
+	float ret;
+	__m128 sq = _mm_mul_ps(vec, vec);
+	const __m128 r2 = _mm_shuffle_ps(sq, sq, _MM_SHUFFLE(0, 0, 0, 1));
+	const __m128 r3 = _mm_shuffle_ps(sq, sq, _MM_SHUFFLE(0, 0, 0, 2));
+	const __m128 res = _mm_add_ss(sq, _mm_add_ss(r2, r3));
+	_mm_store_ps(&ret, _mm_sqrt_ss(res));
+	return ret;
+#else
 	return sqrtf(Length2());
+#endif
 }
 
 template<>
@@ -156,7 +175,16 @@ unsigned int Vec4<int>::ToRGBA() const
 template<>
 float Vec4<float>::Length() const
 {
+#if defined(_M_SSE)
+	float ret;
+	__m128 sq = _mm_mul_ps(vec, vec);
+	const __m128 r2 = _mm_add_ps(sq, _mm_movehl_ps(sq, sq));
+	const __m128 res = _mm_add_ss(r2, _mm_shuffle_ps(r2, r2, _MM_SHUFFLE(0, 0, 0, 1)));
+	_mm_store_ps(&ret, _mm_sqrt_ss(res));
+	return ret;
+#else
 	return sqrtf(Length2());
+#endif
 }
 
 template<>

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -98,7 +98,7 @@ template<>
 unsigned int Vec3<float>::ToRGB() const
 {
 #if defined(_M_SSE)
-	__m128i c = _mm_cvtps_epi32(vec);
+	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(vec, _mm_set_ps1(255.0f)));
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
 #else
@@ -200,7 +200,7 @@ template<>
 unsigned int Vec4<float>::ToRGBA() const
 {
 #if defined(_M_SSE)
-	__m128i c = _mm_cvtps_epi32(vec);
+	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(vec, _mm_set_ps1(255.0f)));
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
 #else

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -69,29 +69,54 @@ float Vec2<float>::Normalize()
 template<>
 Vec3<float> Vec3<float>::FromRGB(unsigned int rgb)
 {
+#if defined(_M_SSE)
+	__m128i z = _mm_setzero_si128();
+	__m128i c = _mm_cvtsi32_si128(rgb);
+	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
+	return Vec3<float>(_mm_cvtepi32_ps(c));
+#else
 	return Vec3((rgb & 0xFF) * (1.0f/255.0f),
 				((rgb >> 8) & 0xFF) * (1.0f/255.0f),
 				((rgb >> 16) & 0xFF) * (1.0f/255.0f));
+#endif
 }
 
 template<>
 Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 {
+#if defined(_M_SSE)
+	__m128i z = _mm_setzero_si128();
+	__m128i c = _mm_cvtsi32_si128(rgb);
+	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
+	return Vec3<int>(c);
+#else
 	return Vec3(rgb & 0xFF, (rgb >> 8) & 0xFF, (rgb >> 16) & 0xFF);
+#endif
 }
 
 template<>
 unsigned int Vec3<float>::ToRGB() const
 {
+#if defined(_M_SSE)
+	__m128i c = _mm_cvtps_epi32(vec);
+	__m128i c16 = _mm_packs_epi32(c, c);
+	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
+#else
 	return ((unsigned int)(r()*255.f)) +
 			((unsigned int)(g()*255.f*256.f)) +
 			((unsigned int)(b()*255.f*256.f*256.f));
+#endif
 }
 
 template<>
 unsigned int Vec3<int>::ToRGB() const
 {
+#if defined(_M_SSE)
+	__m128i c16 = _mm_packs_epi32(ivec, ivec);
+	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
+#else
 	return (r()&0xFF) | ((g()&0xFF)<<8) | ((b()&0xFF)<<16);
+#endif
 }
 
 template<>
@@ -145,31 +170,56 @@ float Vec3<float>::Normalize()
 template<>
 Vec4<float> Vec4<float>::FromRGBA(unsigned int rgba)
 {
+#if defined(_M_SSE)
+	__m128i z = _mm_setzero_si128();
+	__m128i c = _mm_cvtsi32_si128(rgba);
+	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
+	return Vec4<float>(_mm_cvtepi32_ps(c));
+#else
 	return Vec4((rgba & 0xFF) * (1.0f/255.0f),
 				((rgba >> 8) & 0xFF) * (1.0f/255.0f),
 				((rgba >> 16) & 0xFF) * (1.0f/255.0f),
 				((rgba >> 24) & 0xFF) * (1.0f/255.0f));
+#endif
 }
 
 template<>
 Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
 {
+#if defined(_M_SSE)
+	__m128i z = _mm_setzero_si128();
+	__m128i c = _mm_cvtsi32_si128(rgba);
+	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
+	return Vec4<int>(c);
+#else
 	return Vec4(rgba & 0xFF, (rgba >> 8) & 0xFF, (rgba >> 16) & 0xFF, (rgba >> 24) & 0xFF);
+#endif
 }
 
 template<>
 unsigned int Vec4<float>::ToRGBA() const
 {
+#if defined(_M_SSE)
+	__m128i c = _mm_cvtps_epi32(vec);
+	__m128i c16 = _mm_packs_epi32(c, c);
+	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
+#else
 	return ((unsigned int)(r()*255.f)) +
 			((unsigned int)(g()*255.f*256.f)) +
 			((unsigned int)(b()*255.f*256.f*256.f)) +
 			((unsigned int)(a()*255.f*256.f*256.f*256.f));
+#endif
 }
 
 template<>
 unsigned int Vec4<int>::ToRGBA() const
 {
+#if defined(_M_SSE)
+	__m128i c16 = _mm_packs_epi32(ivec, ivec);
+	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
+#else
 	return (r()&0xFF) | ((g()&0xFF)<<8) | ((b()&0xFF)<<16) | ((a()&0xFF)<<24);
+#endif
 }
 
 template<>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -18,6 +18,11 @@
 #pragma once
 
 #include <cmath>
+#include "Common/Common.h"
+
+#if defined(_M_SSE)
+#include <emmintrin.h>
+#endif
 
 namespace Math3D {
 
@@ -36,9 +41,16 @@ template<typename T>
 class Vec2
 {
 public:
-	struct
+	union
 	{
-		T x,y;
+		struct
+		{
+			T x,y;
+		};
+#if defined(_M_SSE)
+		__m128i ivec;
+		__m128 vec;
+#endif
 	};
 
 	T* AsArray() { return &x; }
@@ -47,6 +59,10 @@ public:
 	Vec2() {}
 	Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
 	Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
+#if defined(_M_SSE)
+	Vec2(const __m128 &_vec) : vec(_vec) {}
+	Vec2(const __m128i &_ivec) : ivec(_ivec) {}
+#endif
 
 	template<typename T2>
 	Vec2<T2> Cast() const
@@ -164,9 +180,16 @@ template<typename T>
 class Vec3
 {
 public:
-	struct
+	union
 	{
-		T x,y,z;
+		struct
+		{
+			T x,y,z;
+		};
+#if defined(_M_SSE)
+		__m128i ivec;
+		__m128 vec;
+#endif
 	};
 
 	T* AsArray() { return &x; }
@@ -176,6 +199,10 @@ public:
 	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
+#if defined(_M_SSE)
+	Vec3(const __m128 &_vec) : vec(_vec) {}
+	Vec3(const __m128i &_ivec) : ivec(_ivec) {}
+#endif
 
 	template<typename T2>
 	Vec3<T2> Cast() const
@@ -324,9 +351,16 @@ template<typename T>
 class Vec4
 {
 public:
-	struct
+	union
 	{
-		T x,y,z,w;
+		struct
+		{
+			T x,y,z,w;
+		};
+#if defined(_M_SSE)
+		__m128i ivec;
+		__m128 vec;
+#endif
 	};
 
 	T* AsArray() { return &x; }
@@ -337,6 +371,10 @@ public:
 	Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
 	Vec4(const Vec2<T>& _xy, const T& _z, const T& _w) : x(_xy.x), y(_xy.y), z(_z), w(_w) {}
 	Vec4(const Vec3<T>& _xyz, const T& _w) : x(_xyz.x), y(_xyz.y), z(_xyz.z), w(_w) {}
+#if defined(_M_SSE)
+	Vec4(const __m128 &_vec) : vec(_vec) {}
+	Vec4(const __m128i &_ivec) : ivec(_ivec) {}
+#endif
 
 	template<typename T2>
 	Vec4<T2> Cast() const

--- a/GPU/Software/Colors.h
+++ b/GPU/Software/Colors.h
@@ -49,11 +49,16 @@ static inline u32 DecodeRGB565(u16 src)
 
 static inline u32 DecodeRGBA8888(u32 src)
 {
+#if 1
+	return src;
+#else
+	// This is the order of the bits.
 	u8 r = src & 0xFF;
 	u8 g = (src >> 8) & 0xFF;
 	u8 b = (src >> 16) & 0xFF;
 	u8 a = (src >> 24) & 0xFF;
 	return (a << 24) | (b << 16) | (g << 8) | r;
+#endif
 }
 
 static inline u16 RGBA8888To565(u32 value)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1202,10 +1202,17 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 	maxY = std::min(maxY, (int)TransformUnit::DrawingToScreen(scissorBR).y);
 
 	int range = (maxY - minY) / 16 + 1;
-	if (gstate.isModeClear())
-		GlobalThreadPool::Loop(std::bind(&DrawTriangleSlice<true>, v0, v1, v2, minX, minY, maxX, maxY, placeholder::_1, placeholder::_2), 0, range);
-	else
-		GlobalThreadPool::Loop(std::bind(&DrawTriangleSlice<false>, v0, v1, v2, minX, minY, maxX, maxY, placeholder::_1, placeholder::_2), 0, range);
+	if (gstate.isModeClear()) {
+		if (range >= 24)
+			GlobalThreadPool::Loop(std::bind(&DrawTriangleSlice<true>, v0, v1, v2, minX, minY, maxX, maxY, placeholder::_1, placeholder::_2), 0, range);
+		else
+			DrawTriangleSlice<true>(v0, v1, v2, minX, minY, maxX, maxY, 0, range);
+	} else {
+		if (range >= 24)
+			GlobalThreadPool::Loop(std::bind(&DrawTriangleSlice<false>, v0, v1, v2, minX, minY, maxX, maxY, placeholder::_1, placeholder::_2), 0, range);
+		else
+			DrawTriangleSlice<false>(v0, v1, v2, minX, minY, maxX, maxY, 0, range);
+	}
 }
 
 void DrawPoint(const VertexData &v0)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1040,8 +1040,7 @@ inline void ApplyTexturing(Vec4<int> &prim_color, float s, float t, int maxTexLe
 		texcolor = (t * (0x100 - frac_v) + b * frac_v) / (256 * 256);
 #endif
 	}
-	Vec4<int> out = GetTextureFunctionOutput(prim_color, texcolor);
-	prim_color = out;
+	prim_color = GetTextureFunctionOutput(prim_color, texcolor);
 }
 
 #if defined(_M_SSE)
@@ -1194,8 +1193,15 @@ void DrawTriangleSlice(
 					}
 				}
 
-				if (!clearMode)
+				if (!clearMode) {
+					// TODO: Tried making Vec4 do this, but things got slower.
+#if defined(_M_SSE)
+					const __m128i sec = _mm_and_si128(sec_color.ivec, _mm_set_epi32(0, -1, -1, -1));
+					prim_color.ivec = _mm_add_epi32(prim_color.ivec, sec);
+#else
 					prim_color += Vec4<int>(sec_color, 0);
+#endif
+				}
 
 				// TODO: Fogging
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -754,7 +754,7 @@ static inline Vec3<int> GetSourceFactor(int source_a, const Vec4<int>& dst)
 		return Vec3<int>::AssignToAll(255 - 2 * dst.a());
 
 	case GE_SRCBLEND_FIXA:
-		return Vec4<int>::FromRGBA(gstate.getFixA()).rgb();
+		return Vec3<int>::FromRGB(gstate.getFixA());
 
 	default:
 		ERROR_LOG_REPORT(G3D, "Software: Unknown source factor %x", gstate.getBlendFuncA());
@@ -796,7 +796,7 @@ static inline Vec3<int> GetDestFactor(const Vec3<int>& source_rgb, int source_a,
 		return Vec3<int>::AssignToAll(255 - 2 * dst.a());
 
 	case GE_DSTBLEND_FIXB:
-		return Vec4<int>::FromRGBA(gstate.getFixB()).rgb();
+		return Vec3<int>::FromRGB(gstate.getFixB());
 
 	default:
 		ERROR_LOG_REPORT(G3D, "Software: Unknown dest factor %x", gstate.getBlendFuncB());

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -993,17 +993,21 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, Vec4<int> prim_color)
 	if (gstate.isAlphaBlendEnabled() && !clearMode) {
 		const Vec4<int> dst = Vec4<int>::FromRGBA(old_color);
 #if defined(_M_SSE)
-		const Vec3<int> blended = AlphaBlendingResult(prim_color, dst);
-		const __m128i blended16 = _mm_packs_epi32(blended.ivec, blended.ivec);
-		new_color = _mm_cvtsi128_si32(_mm_packus_epi16(blended16, blended16));
-		new_color = (stencil << 24) | (new_color & 0x00FFFFFF);
+		// ToRGBA() on SSE automatically clamps.
+		new_color = AlphaBlendingResult(prim_color, dst).ToRGB();
+		new_color |= stencil << 24;
 #else
 		new_color = Vec4<int>(AlphaBlendingResult(prim_color, dst).Clamp(0, 255), stencil).ToRGBA();
 #endif
 	} else {
+#if defined(_M_SSE)
+		new_color = Vec3<int>(prim_color.ivec).ToRGB();
+		new_color |= stencil << 24;
+#else
 		if (!clearMode)
 			prim_color = prim_color.Clamp(0, 255);
 		new_color = Vec4<int>(prim_color.r(), prim_color.g(), prim_color.b(), stencil).ToRGBA();
+#endif
 	}
 
 	// TODO: Is alpha blending still performed if logic ops are enabled?

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -893,17 +893,17 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, Vec4<int> prim_color)
 		prim_color.b() <<= 1;
 	}
 
+	const u32 old_color = GetPixelColor(p.x, p.y);
+	u32 new_color;
+
 	if (gstate.isAlphaBlendEnabled() && !clearMode) {
-		Vec4<int> dst = Vec4<int>::FromRGBA(GetPixelColor(p.x, p.y));
-		// We can discard the vertex alpha at this point.
-		prim_color = Vec4<int>(AlphaBlendingResult(prim_color, dst), 0);
+		const Vec4<int> dst = Vec4<int>::FromRGBA(old_color);
+		new_color = Vec4<int>(AlphaBlendingResult(prim_color, dst).Clamp(0, 255), stencil).ToRGBA();
+	} else {
+		if (!clearMode)
+			prim_color = prim_color.Clamp(0, 255);
+		new_color = Vec4<int>(prim_color.r(), prim_color.g(), prim_color.b(), stencil).ToRGBA();
 	}
-
-	if (!clearMode)
-		prim_color = prim_color.Clamp(0, 255);
-
-	u32 new_color = Vec4<int>(prim_color.r(), prim_color.g(), prim_color.b(), stencil).ToRGBA();
-	u32 old_color = GetPixelColor(p.x, p.y);
 
 	// TODO: Is alpha blending still performed if logic ops are enabled?
 	if (gstate.isLogicOpEnabled() && !clearMode) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1125,9 +1125,8 @@ void DrawTriangleSlice(
 				if (gstate.isTextureMapEnabled() && !clearMode) {
 					if (gstate.isModeThrough()) {
 						// TODO: Is it really this simple?
-						float s = ((v0.texturecoords.s() * w0 + v1.texturecoords.s() * w1 + v2.texturecoords.s() * w2) * wsum);
-						float t = ((v0.texturecoords.t() * w0 + v1.texturecoords.t() * w1 + v2.texturecoords.t() * w2) * wsum);
-						ApplyTexturing(prim_color_rgb, prim_color_a, s, t, maxTexLevel, magFilt, texptr, texbufwidthbits);
+						Vec2<float> texcoords = Interpolate(v0.texturecoords, v1.texturecoords, v2.texturecoords, w0, w1, w2, wsum);
+						ApplyTexturing(prim_color_rgb, prim_color_a, texcoords.s(), texcoords.t(), maxTexLevel, magFilt, texptr, texbufwidthbits);
 					} else {
 						float s = 0, t = 0;
 						GetTextureCoordinates(v0, v1, v2, w0, w1, w2, s, t);


### PR DESCRIPTION
And also reduce threading a bit, improving perf for small triangles.

Star Ocean world: 40% -> 48%
Star Ocean inside: 187% -> 238%
Star Ocean battle: 53% -> 72%
Crisis Core menu: 510% -> 620%
Crisis Core ingame: 124% -> 145%
ClaDun: 95% -> 128%

Only changed parts that seemed relatively stable.

-[Unknown]
