### PR TITLE
Jitify the rest of ARM and x86 vertex morphs + some tweaks (not ready, just review)

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -158,6 +158,13 @@ bool TryMakeFloatIMM8(u32 val, Operand2 &op2)
 	return false;
 }
 
+void ARMXEmitter::MOVI2FR(ARMReg dest, float val, bool negate)
+{
+	union {float f; u32 u;} conv;
+	conv.f = negate ? -val : val;
+	MOVI2R(dest, conv.u);
+}
+
 void ARMXEmitter::MOVI2F(ARMReg dest, float val, ARMReg tempReg, bool negate)
 {
 	union {float f; u32 u;} conv;
@@ -2146,7 +2153,7 @@ void ARMXEmitter::VDUP(u32 Size, ARMReg Vd, ARMReg Rt)
 		sizeEncoded = 0;
 
 	Write32((0xEE << 24) | (0x8 << 20) | ((sizeEncoded & 2) << 21) | (register_quad << 21) \
-		| ((Vd & 0xF) << 16) | (Rt << 12) | (0xD1 << 4) | ((Vd & 0x10) << 3) | (1 << 4));
+		| ((Vd & 0xF) << 16) | (Rt << 12) | (0xD1 << 4) | ((Vd & 0x10) << 3) | ((sizeEncoded & 1) << 5));
 }
 void ARMXEmitter::VEOR(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -1436,24 +1436,24 @@ void ARMXEmitter::VCMPE(ARMReg Vd){ WriteVFPDataOp(13, Vd, D5, D0); }
 
 void ARMXEmitter::VLDMIA(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
-	WriteVRegStoreOp(0x80 | 0x40 | 0x8 | 1, ptr, false, WriteBack, firstvreg, numvregs);
+	WriteVRegStoreOp(0x80 | 0x40 | 0x8 | 1, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VSTMIA(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
-	WriteVRegStoreOp(0x80 | 0x40 | 0x8, ptr, false, WriteBack, firstvreg, numvregs);
+	WriteVRegStoreOp(0x80 | 0x40 | 0x8, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VLDMDB(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
 	_dbg_assert_msg_(JIT, WriteBack, "Writeback is required for VLDMDB");
-	WriteVRegStoreOp(0x80 | 0x040 | 0x10 | 1, ptr, false, WriteBack, firstvreg, numvregs);
+	WriteVRegStoreOp(0x80 | 0x040 | 0x10 | 1, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VSTMDB(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
 	_dbg_assert_msg_(JIT, WriteBack, "Writeback is required for VSTMDB");
-	WriteVRegStoreOp(0x80 | 0x040 | 0x10, ptr, false, WriteBack, firstvreg, numvregs);
+	WriteVRegStoreOp(0x80 | 0x040 | 0x10, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VLDR(ARMReg Dest, ARMReg Base, s16 offset)

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -807,6 +807,7 @@ public:
 
 	// Wrapper around MOVT/MOVW with fallbacks.
 	void MOVI2R(ARMReg reg, u32 val, bool optimize = true);
+	void MOVI2FR(ARMReg dest, float val, bool negate = false);
 	void MOVI2F(ARMReg dest, float val, ARMReg tempReg, bool negate = false);
 	void MOVI2F_neon(ARMReg dest, float val, ARMReg tempReg, bool negate = false);
 

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -698,9 +698,19 @@ public:
 	void VEOR(ARMReg Vd, ARMReg Vn, ARMReg Vm);
 	void VORN(ARMReg Vd, ARMReg Vn, ARMReg Vm);
 	void VORR(ARMReg Vd, ARMReg Vn, ARMReg Vm);
-  inline void VMOV_neon(ARMReg Dest, ARMReg Src) {
-    VORR(Dest, Src, Src);
-  }
+	inline void VMOV_neon(ARMReg Dest, ARMReg Src) {
+		VORR(Dest, Src, Src);
+	}
+	void VMOV_neon(u32 Size, ARMReg Vd, u32 imm);
+	void VMOV_neon(u32 Size, ARMReg Vd, float imm) {
+		_dbg_assert_msg_(JIT, Size == F_32, "Expecting F_32 immediate for VMOV_neon float arg.");
+		union {
+			float f;
+			u32 u;
+		} val;
+		val.f = imm;
+		VMOV_neon(I_32, Vd, val.u);
+	}
 
 	void VNEG(u32 Size, ARMReg Vd, ARMReg Vm);
 	void VPADAL(u32 Size, ARMReg Vd, ARMReg Vm);

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -591,6 +591,12 @@ public:
 	void VSTMIA(ARMReg dest, bool WriteBack, ARMReg firstreg, int numregs);
 	void VLDMDB(ARMReg dest, bool WriteBack, ARMReg firstreg, int numregs);
 	void VSTMDB(ARMReg dest, bool WriteBack, ARMReg firstreg, int numregs);
+	void VPUSH(ARMReg firstvreg, int numvregs) {
+		VSTMDB(R_SP, true, firstvreg, numvregs);
+	}
+	void VPOP(ARMReg firstvreg, int numvregs) {
+		VLDMIA(R_SP, true, firstvreg, numvregs);
+	}
 	void VLDR(ARMReg Dest, ARMReg Base, s16 offset);
 	void VSTR(ARMReg Src,  ARMReg Base, s16 offset);
 	void VCMP(ARMReg Vd, ARMReg Vm);

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -616,6 +616,8 @@ public:
 	void VMOV(ARMReg Dest, Operand2 op2);
 	void VMOV(ARMReg Dest, ARMReg Src, bool high);
 	void VMOV(ARMReg Dest, ARMReg Src);
+	// Either Vd, Rt, Rt2 or Rt, Rt2, Vd.
+	void VMOV(ARMReg Dest, ARMReg Src1, ARMReg Src2);
 	void VCVT(ARMReg Dest, ARMReg Src, int flags);
 
 	// NEON, need to check for this (supported if VFP4 is supported)
@@ -711,6 +713,7 @@ public:
 		val.f = imm;
 		VMOV_neon(I_32, Vd, val.u);
 	}
+	void VMOV_neon(u32 Size, ARMReg Vd, ARMReg Rt, int lane);
 
 	void VNEG(u32 Size, ARMReg Vd, ARMReg Vm);
 	void VPADAL(u32 Size, ARMReg Vd, ARMReg Vm);
@@ -805,6 +808,7 @@ public:
 	// Wrapper around MOVT/MOVW with fallbacks.
 	void MOVI2R(ARMReg reg, u32 val, bool optimize = true);
 	void MOVI2F(ARMReg dest, float val, ARMReg tempReg, bool negate = false);
+	void MOVI2F_neon(ARMReg dest, float val, ARMReg tempReg, bool negate = false);
 
 	// Load pointers without casting
 	template <class T> void MOVP2R(ARMReg reg, T *val) {

--- a/GPU/GLES/VertexDecoder.h
+++ b/GPU/GLES/VertexDecoder.h
@@ -266,5 +266,6 @@ private:
 	bool CompileStep(const VertexDecoder &dec, int i);
 	void Jit_ApplyWeights();
 	void Jit_WriteMatrixMul(int outOff, bool pos);
+	void Jit_WriteMorphColor(int outOff);
 	const VertexDecoder *dec_;
 };

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -157,6 +157,9 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 	SetCC(CC_AL);
 
 	PUSH(6, R4, R5, R6, R7, R8, R_LR);
+	if (cpu_info.bNEON) {
+		VPUSH(D8, 8);
+	}
 
 	// Keep the scale/offset in a few fp registers if we need it.
 	// This step can be NEON-ized but the savings would be miniscule.
@@ -244,6 +247,9 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 	SUBS(counterReg, counterReg, 1);
 	B_CC(CC_NEQ, loopStart);
 
+	if (cpu_info.bNEON) {
+		VPOP(D8, 8);
+	}
 	POP(6, R4, R5, R6, R7, R8, R_PC);
 
 	FlushLitPool();

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -1043,6 +1043,7 @@ void VertexDecoderJitCache::Jit_NormalFloat() {
 
 // Through expands into floats, always. Might want to look at changing this.
 void VertexDecoderJitCache::Jit_PosS8Through() {
+	DEBUG_LOG_REPORT_ONCE(vertexS8Through, G3D, "Using S8 positions in throughmode");
 	_dbg_assert_msg_(JIT, fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScrathRegs must be in order.");
 	_dbg_assert_msg_(JIT, fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScrathRegs must be in order.");
 

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -338,7 +338,8 @@ void VertexDecoderJitCache::Jit_WeightsFloat() {
 }
 
 static const ARMReg weightRegs[8] = { S8, S9, S10, S11, S12, S13, S14, S15 };
-static const ARMReg neonWeightRegs[2] = { Q2, Q3 };
+static const ARMReg neonWeightRegsD[4] = { D4, D5, D6, D7 };
+static const ARMReg neonWeightRegsQ[2] = { Q2, Q3 };
 
 void VertexDecoderJitCache::Jit_ApplyWeights() {
 	if (NEONSkinning) {
@@ -350,24 +351,24 @@ void VertexDecoderJitCache::Jit_ApplyWeights() {
 		for (int i = 0; i < dec_->nweights; i++) {
 			switch (i) {
 			case 0:
-				VMUL_scalar(F_32, Q4, Q8, QScalar(neonWeightRegs[0], 0));
-				VMUL_scalar(F_32, Q5, Q9, QScalar(neonWeightRegs[0], 0));
-				VMUL_scalar(F_32, Q6, Q10, QScalar(neonWeightRegs[0], 0));
-				VMUL_scalar(F_32, Q7, Q11, QScalar(neonWeightRegs[0], 0));
+				VMUL_scalar(F_32, Q4, Q8, QScalar(neonWeightRegsQ[0], 0));
+				VMUL_scalar(F_32, Q5, Q9, QScalar(neonWeightRegsQ[0], 0));
+				VMUL_scalar(F_32, Q6, Q10, QScalar(neonWeightRegsQ[0], 0));
+				VMUL_scalar(F_32, Q7, Q11, QScalar(neonWeightRegsQ[0], 0));
 				break;
 			case 1:
 				// Krait likes VDUP + VFMA better than VMLA, and it's easy to do here.
 				if (cpu_info.bVFPv4) {
-					VDUP(F_32, Q1, neonWeightRegs[i >> 2], i & 1);
+					VDUP(F_32, Q1, neonWeightRegsQ[i >> 2], i & 1);
 					VFMA(F_32, Q4, Q12, Q1);
 					VFMA(F_32, Q5, Q13, Q1);
 					VFMA(F_32, Q6, Q14, Q1);
 					VFMA(F_32, Q7, Q15, Q1);
 				} else {
-					VMLA_scalar(F_32, Q4, Q12, QScalar(neonWeightRegs[0], 1));
-					VMLA_scalar(F_32, Q5, Q13, QScalar(neonWeightRegs[0], 1));
-					VMLA_scalar(F_32, Q6, Q14, QScalar(neonWeightRegs[0], 1));
-					VMLA_scalar(F_32, Q7, Q15, QScalar(neonWeightRegs[0], 1));
+					VMLA_scalar(F_32, Q4, Q12, QScalar(neonWeightRegsQ[0], 1));
+					VMLA_scalar(F_32, Q5, Q13, QScalar(neonWeightRegsQ[0], 1));
+					VMLA_scalar(F_32, Q6, Q14, QScalar(neonWeightRegsQ[0], 1));
+					VMLA_scalar(F_32, Q7, Q15, QScalar(neonWeightRegsQ[0], 1));
 				}
 				break;
 			default:
@@ -377,21 +378,21 @@ void VertexDecoderJitCache::Jit_ApplyWeights() {
 				if (dec_->nweights <= 4) {
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
 					VLD1(F_32, Q3, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q4, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
-					VMLA_scalar(F_32, Q5, Q3, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q4, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q5, Q3, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
 					VLD1(F_32, Q3, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q6, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
-					VMLA_scalar(F_32, Q7, Q3, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q6, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q7, Q3, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 				} else {
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q4, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q4, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q5, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q5, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q6, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q6, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 					VLD1(F_32, Q1, scratchReg, 2, ALIGN_128, REG_UPDATE);
-					VMLA_scalar(F_32, Q7, Q1, QScalar(neonWeightRegs[i >> 2], i & 3));
+					VMLA_scalar(F_32, Q7, Q1, QScalar(neonWeightRegsQ[i >> 2], i & 3));
 				}
 				break;
 			}
@@ -426,15 +427,18 @@ void VertexDecoderJitCache::Jit_WeightsU8Skin() {
 			ANDI2R(scratchReg2, scratchReg2, 0xFFFFFF, scratchReg);
 			break;
 		case 4:
-			LDR(scratchReg2, srcReg, 0);
+			VLD1_lane(I_32, neonScratchReg, srcReg, 0, false);
 			break;
 		}
-		VMOV(fpScratchReg, scratchReg2);
-		MOVI2F(S12, by128, scratchReg);
+		if (dec_->nweights != 4) {
+			VMOV_neon(I_32, neonScratchReg, scratchReg2, 0);
+		}
+		// This can be represented as a constant.
+		VMOV_neon(F_32, Q3, by128);
 		VMOVL(I_8 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 		VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 		VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
-		VMUL_scalar(F_32, neonWeightRegs[0], neonScratchRegQ, DScalar(D6, 0));
+		VMUL(F_32, neonWeightRegsQ[0], neonScratchRegQ, Q3);
 	} else {
 		// Fallback and non-neon
 		for (int j = 0; j < dec_->nweights; j++) {
@@ -453,22 +457,23 @@ void VertexDecoderJitCache::Jit_WeightsU16Skin() {
 		// Most common cases.
 		switch (dec_->nweights) {
 		case 1: LDRH(scratchReg, srcReg, 0); break;
-		case 2: LDR(scratchReg, srcReg, 0); break;
+		case 2: VLD1_lane(I_32, neonScratchReg, srcReg, 0, false); break;
 		case 3:
 			LDR(scratchReg, srcReg, 0);
 			LDRH(scratchReg2, srcReg, 4);
 			break;
 		case 4:
-			LDR(scratchReg, srcReg, 0);
-			LDR(scratchReg2, srcReg, 4);
+			VLD1(I_32, neonScratchReg, srcReg, 1, ALIGN_NONE);
 			break;
 		}
-		VMOV(fpScratchReg, scratchReg);
-		VMOV(fpScratchReg2, scratchReg2);
-		MOVI2F(S12, by32768, scratchReg);
+		if (dec_->nweights != 2 && dec_->nweights != 4) {
+			VMOV(neonScratchReg, scratchReg, scratchReg2);
+		}
+		// This can be represented as a constant.
+		VMOV_neon(F_32, Q3, by32768);
 		VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 		VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
-		VMUL_scalar(F_32, neonWeightRegs[0], neonScratchRegQ, DScalar(D6, 0));
+		VMUL(F_32, neonWeightRegsQ[0], neonScratchRegQ, Q3);
 	} else {
 		// Fallback and non-neon
 		for (int j = 0; j < dec_->nweights; j++) {
@@ -487,8 +492,32 @@ void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
 		_dbg_assert_msg_(JIT, weightRegs[i - 1] + 1 == weightRegs[i], "VertexDecoder weightRegs must be in order.");
 	}
 
-	ADD(tempReg1, srcReg, dec_->weightoff);
-	VLDMIA(tempReg1, false, weightRegs[0], dec_->nweights);
+	// Weights are always first, so we can use srcReg directly.
+
+	if (NEONSkinning) {
+		switch (dec_->nweights) {
+		case 1: VLD1_lane(F_32, neonWeightRegsD[0], srcReg, 0, true); break;
+		case 2: VLD1(F_32, neonWeightRegsD[0], srcReg, 1, ALIGN_NONE); break;
+		case 3:
+			// TODO: Do we really need to skip the 4th lanes?  8/16 seem so careful to do that...
+			VLD1(F_32, neonWeightRegsD[0], srcReg, 1, ALIGN_NONE);
+			VLD1_lane(F_32, neonWeightRegsD[1], srcReg, 0, true);
+			break;
+		case 4: VLD1(F_32, neonWeightRegsD[0], srcReg, 2, ALIGN_NONE); break;
+		case 5:
+			VLD1(F_32, neonWeightRegsD[0], srcReg, 2, ALIGN_NONE);
+			VLD1_lane(F_32, neonWeightRegsD[2], srcReg, 0, true);
+			break;
+		case 6: VLD1(F_32, neonWeightRegsD[0], srcReg, 3, ALIGN_NONE); break;
+		case 7:
+			VLD1(F_32, neonWeightRegsD[0], srcReg, 3, ALIGN_NONE);
+			VLD1_lane(F_32, neonWeightRegsD[3], srcReg, 0, true);
+			break;
+		case 8: VLD1(F_32, neonWeightRegsD[0], srcReg, 4, ALIGN_NONE); break;
+		}
+	} else {
+		VLDMIA(srcReg, false, weightRegs[0], dec_->nweights);
+	}
 	Jit_ApplyWeights();
 }
 

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -688,8 +688,7 @@ void VertexDecoderJitCache::Jit_Color5551() {
 }
 
 void VertexDecoderJitCache::Jit_Color8888Morph() {
-	// TODO: Test.
-	const bool useNEON = false;//NEONMorphing;
+	const bool useNEON = NEONMorphing;
 	ADDI2R(tempReg1, srcReg, dec_->coloff, scratchReg);
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
@@ -751,8 +750,7 @@ void VertexDecoderJitCache::Jit_Color8888Morph() {
 static const s16 MEMORY_ALIGNED16(color4444Shift[2][4]) = {{12, 8, 4, 0}, {-12, -12, -12, -12}};
 
 void VertexDecoderJitCache::Jit_Color4444Morph() {
-	// TODO: Test.
-	const bool useNEON = false;//NEONMorphing;
+	const bool useNEON = NEONMorphing;
 	ADDI2R(tempReg1, srcReg, dec_->coloff, scratchReg);
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
@@ -833,8 +831,7 @@ static const s16 MEMORY_ALIGNED16(color565Shift[2][4]) = {{11, 5, 0, 0}, {-11, -
 static const float MEMORY_ALIGNED16(byColor565[4]) = {255.0f / 31.0f, 255.0f / 63.0f, 255.0f / 31.0f, 0.0f};
 
 void VertexDecoderJitCache::Jit_Color565Morph() {
-	// TODO: Test.
-	const bool useNEON = false;//NEONMorphing;
+	const bool useNEON = NEONMorphing;
 	ADDI2R(tempReg1, srcReg, dec_->coloff, scratchReg);
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
@@ -912,8 +909,7 @@ static const s16 MEMORY_ALIGNED16(color5551Shift[2][4]) = {{11, 6, 1, 0}, {-11, 
 static const float MEMORY_ALIGNED16(byColor5551[4]) = {255.0f / 31.0f, 255.0f / 31.0f, 255.0f / 31.0f, 255.0f / 1.0f};
 
 void VertexDecoderJitCache::Jit_Color5551Morph() {
-	// TODO: Test.
-	const bool useNEON = false;//NEONMorphing;
+	const bool useNEON = NEONMorphing;
 	ADDI2R(tempReg1, srcReg, dec_->coloff, scratchReg);
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -1117,8 +1117,8 @@ void VertexDecoderJitCache::Jit_PosFloat() {
 void VertexDecoderJitCache::Jit_NormalS8Skin() {
 	if (NEONSkinning) {
 		ADD(scratchReg, srcReg, dec_->nrmoff);
+		MOVI2F(S15, 1.0f/128.0f, scratchReg2);
 		VLD1_lane(I_32, neonScratchReg, scratchReg, 0, false);
-		MOVI2F(S15, 1.0f/128.0f, scratchReg);
 		VMOVL(I_8 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 16-bit
 		VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 32-bit
 		VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
@@ -1144,8 +1144,8 @@ void VertexDecoderJitCache::Jit_NormalS8Skin() {
 void VertexDecoderJitCache::Jit_NormalS16Skin() {
 	if (NEONSkinning) {
 		ADD(scratchReg, srcReg, dec_->nrmoff);
+		MOVI2F(S15, 1.0f/32768, scratchReg2);
 		VLD1(I_32, neonScratchReg, scratchReg, 1, ALIGN_NONE);
-		MOVI2F(S15, 1.0f/32768, scratchReg);
 		VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 32-bit
 		VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
 		VMUL_scalar(F_32, srcNEON, neonScratchReg, QScalar(Q3, 3));  // S15
@@ -1219,8 +1219,8 @@ void VertexDecoderJitCache::Jit_WriteMatrixMul(int outOff, bool pos) {
 void VertexDecoderJitCache::Jit_PosS8Skin() {
 	if (NEONSkinning) {
 		ADD(scratchReg, srcReg, dec_->posoff);
+		MOVI2F(S15, 1.0f/128.0f, scratchReg2);
 		VLD1_lane(I_32, neonScratchReg, scratchReg, 0, false);
-		MOVI2F(S15, 1.0f/128.0f, scratchReg);
 		VMOVL(I_8 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 16-bit
 		VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 32-bit
 		VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
@@ -1246,8 +1246,8 @@ void VertexDecoderJitCache::Jit_PosS8Skin() {
 void VertexDecoderJitCache::Jit_PosS16Skin() {
 	if (NEONSkinning) {
 		ADD(scratchReg, srcReg, dec_->posoff);
+		MOVI2F(S15, 1.0f/32768, scratchReg2);
 		VLD1(I_32, neonScratchReg, scratchReg, 1, ALIGN_NONE);
-		MOVI2F(S15, 1.0f/32768, scratchReg);
 		VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);  // Widen to 32-bit
 		VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
 		VMUL_scalar(F_32, srcNEON, neonScratchReg, QScalar(Q3, 3));  // S15

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -702,13 +702,15 @@ void VertexDecoderJitCache::Jit_Color8888Morph() {
 			VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
 
 			if (first) {
 				first = false;
-				VMUL_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
-				VMLA_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
 		} else {
 			LDRB(scratchReg, tempReg1, 0);
@@ -755,10 +757,10 @@ void VertexDecoderJitCache::Jit_Color4444Morph() {
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
 	MOVI2F(S13, 255.0f / 15.0f, scratchReg);
-
 	if (useNEON) {
 		MOVP2R(scratchReg, color4444Shift);
 		VLD1(I_16, D8, scratchReg, 2, ALIGN_128);
+		VDUP(F_32, D10, D6, 1);
 	}
 
 	bool first = true;
@@ -773,14 +775,16 @@ void VertexDecoderJitCache::Jit_Color4444Morph() {
 			VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
-			VMUL(S12, S12, S13);
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
+			VMUL(F_32, Q3, Q3, Q5);
 
 			if (first) {
 				first = false;
-				VMUL_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
-				VMLA_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
 		} else {
 			LDRB(scratchReg, tempReg1, 0);
@@ -836,9 +840,8 @@ void VertexDecoderJitCache::Jit_Color565Morph() {
 
 	if (useNEON) {
 		MOVP2R(scratchReg, color565Shift);
-		VLD1(I_16, D8, scratchReg, 2, ALIGN_128);
-
 		MOVI2R(scratchReg2, (char *)byColor565 - (char *)color565Shift);
+		VLD1(I_16, D8, scratchReg, 2, ALIGN_128);
 		VLD1(F_32, D10, scratchReg, 2, ALIGN_128, scratchReg2);
 	} else {
 		MOVI2F(S14, 255.0f / 31.0f, scratchReg);
@@ -855,12 +858,14 @@ void VertexDecoderJitCache::Jit_Color565Morph() {
 			VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
-			VMUL_scalar(F_32, Q3, Q5, QScalar(Q3, 0));
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
+			VMUL(F_32, Q3, Q3, Q5);
 
 			if (first) {
 				first = false;
 				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
 				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
@@ -914,9 +919,8 @@ void VertexDecoderJitCache::Jit_Color5551Morph() {
 
 	if (useNEON) {
 		MOVP2R(scratchReg, color5551Shift);
-		VLD1(I_16, D8, scratchReg, 2, ALIGN_128);
-
 		MOVI2R(scratchReg2, (char *)byColor5551 - (char *)color5551Shift);
+		VLD1(I_16, D8, scratchReg, 2, ALIGN_128);
 		VLD1(F_32, D10, scratchReg, 2, ALIGN_128, scratchReg2);
 	} else {
 		MOVI2F(S14, 255.0f / 31.0f, scratchReg);
@@ -933,12 +937,14 @@ void VertexDecoderJitCache::Jit_Color5551Morph() {
 			VMOVL(I_16 | I_UNSIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_UNSIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
-			VMUL_scalar(F_32, Q3, Q5, QScalar(Q3, 0));
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
+			VMUL(F_32, Q3, Q3, Q5);
 
 			if (first) {
 				first = false;
 				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
 				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
@@ -1278,6 +1284,9 @@ void VertexDecoderJitCache::Jit_AnyS8Morph(int srcoff, int dstoff) {
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
 	MOVI2F(S13, by127, scratchReg);
+	if (NEONMorphing) {
+		VDUP(F_32, D10, D6, 1);
+	}
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {
@@ -1288,14 +1297,16 @@ void VertexDecoderJitCache::Jit_AnyS8Morph(int srcoff, int dstoff) {
 			VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
-			VMUL(S12, S12, S13);
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
+			VMUL(F_32, Q3, Q3, Q5);
 
 			if (first) {
 				first = false;
-				VMUL_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
-				VMLA_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
 		} else {
 			LDRSB(scratchReg, tempReg1, 0);
@@ -1334,6 +1345,9 @@ void VertexDecoderJitCache::Jit_AnyS16Morph(int srcoff, int dstoff) {
 	MOVP2R(tempReg2, &gstate_c.morphWeights[0]);
 
 	MOVI2F(S13, by32767, scratchReg);
+	if (NEONMorphing) {
+		VDUP(F_32, D10, D6, 1);
+	}
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {
@@ -1343,14 +1357,16 @@ void VertexDecoderJitCache::Jit_AnyS16Morph(int srcoff, int dstoff) {
 			VMOVL(I_16 | I_SIGNED, neonScratchRegQ, neonScratchReg);
 			VCVT(F_32 | I_SIGNED, neonScratchRegQ, neonScratchRegQ);
 
-			VLDR(S12, tempReg2, sizeof(float) * n);
-			VMUL(S12, S12, S13);
+			VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
+			VMUL(F_32, Q3, Q3, Q5);
 
 			if (first) {
 				first = false;
-				VMUL_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMUL(F_32, Q2, neonScratchRegQ, Q3);
+			} else if (cpu_info.bVFPv4) {
+				VFMA(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
-				VMLA_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMLA(F_32, Q2, neonScratchRegQ, Q3);
 			}
 		} else {
 			LDRSH(scratchReg, tempReg1, 0);
@@ -1390,14 +1406,15 @@ void VertexDecoderJitCache::Jit_AnyFloatMorph(int srcoff, int dstoff) {
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {
-		VLDMIA(tempReg1, false, fpScratchReg, 3);
+		// Load an extra float to stay in NEON mode.
+		VLD1(F_32, neonScratchRegQ, tempReg1, 2, ALIGN_NONE);
 		ADDI2R(tempReg1, tempReg1, dec_->onesize_, scratchReg);
-		VLDR(S12, tempReg2, sizeof(float) * n);
+		VLD1_all_lanes(F_32, Q3, tempReg2, true, REG_UPDATE);
 
 		if (first) {
 			first = false;
 			if (NEONMorphing) {
-				VMUL_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				VMUL(F_32, Q2, neonScratchRegQ, Q3);
 			} else {
 				VMUL(S8, fpScratchReg, S12);
 				VMUL(S9, fpScratchReg2, S12);
@@ -1405,7 +1422,11 @@ void VertexDecoderJitCache::Jit_AnyFloatMorph(int srcoff, int dstoff) {
 			}
 		} else {
 			if (NEONMorphing) {
-				VMLA_scalar(F_32, Q2, neonScratchRegQ, QScalar(Q3, 0));
+				if (cpu_info.bVFPv4) {
+					VFMA(F_32, Q2, neonScratchRegQ, Q3);
+				} else {
+					VMLA(F_32, Q2, neonScratchRegQ, Q3);
+				}
 			} else {
 				VMLA(S8, fpScratchReg, S12);
 				VMLA(S9, fpScratchReg2, S12);

--- a/GPU/GLES/VertexDecoderX86.cpp
+++ b/GPU/GLES/VertexDecoderX86.cpp
@@ -739,13 +739,7 @@ void VertexDecoderJitCache::Jit_Color8888Morph() {
 		}
 	}
 
-	// Pack back into a u32.
-	CVTPS2DQ(fpScratchReg, R(fpScratchReg));
-	PACKSSDW(fpScratchReg, R(fpScratchReg));
-	PACKUSWB(fpScratchReg, R(fpScratchReg));
-	MOVD_xmm(R(tempReg1), fpScratchReg);
-
-	MOV(32, MDisp(dstReg, dec_->decFmt.c0off), R(tempReg1));
+	Jit_WriteMorphColor(dec_->decFmt.c0off);
 }
 
 static const float MEMORY_ALIGNED16(byColor4444[4]) = { 255.0f / 15.0f, 255.0f / 15.0f, 255.0f / 15.0f, 255.0f / 15.0f, };
@@ -789,13 +783,7 @@ void VertexDecoderJitCache::Jit_Color4444Morph() {
 		}
 	}
 
-	// Pack back into a u32.
-	CVTPS2DQ(fpScratchReg, R(fpScratchReg));
-	PACKSSDW(fpScratchReg, R(fpScratchReg));
-	PACKUSWB(fpScratchReg, R(fpScratchReg));
-	MOVD_xmm(R(tempReg1), fpScratchReg);
-
-	MOV(32, MDisp(dstReg, dec_->decFmt.c0off), R(tempReg1));
+	Jit_WriteMorphColor(dec_->decFmt.c0off);
 }
 
 // Intentionally in reverse order.
@@ -849,13 +837,7 @@ void VertexDecoderJitCache::Jit_Color565Morph() {
 		}
 	}
 
-	// Pack back into a u32.
-	CVTPS2DQ(fpScratchReg, R(fpScratchReg));
-	PACKSSDW(fpScratchReg, R(fpScratchReg));
-	PACKUSWB(fpScratchReg, R(fpScratchReg));
-	MOVD_xmm(R(tempReg1), fpScratchReg);
-
-	MOV(32, MDisp(dstReg, dec_->decFmt.c0off), R(tempReg1));
+	Jit_WriteMorphColor(dec_->decFmt.c0off);
 }
 
 // Intentionally in reverse order.
@@ -911,13 +893,15 @@ void VertexDecoderJitCache::Jit_Color5551Morph() {
 		}
 	}
 
+	Jit_WriteMorphColor(dec_->decFmt.c0off);
+}
+
+void VertexDecoderJitCache::Jit_WriteMorphColor(int outOff) {
 	// Pack back into a u32.
 	CVTPS2DQ(fpScratchReg, R(fpScratchReg));
 	PACKSSDW(fpScratchReg, R(fpScratchReg));
 	PACKUSWB(fpScratchReg, R(fpScratchReg));
-	MOVD_xmm(R(tempReg1), fpScratchReg);
-
-	MOV(32, MDisp(dstReg, dec_->decFmt.c0off), R(tempReg1));
+	MOVD_xmm(MDisp(dstReg, outOff), fpScratchReg);
 }
 
 // Copy 3 bytes and then a zero. Might as well copy four.

--- a/GPU/GLES/VertexDecoderX86.cpp
+++ b/GPU/GLES/VertexDecoderX86.cpp
@@ -361,11 +361,7 @@ void VertexDecoderJitCache::Jit_WeightsFloat() {
 }
 
 void VertexDecoderJitCache::Jit_WeightsU8Skin() {
-#ifdef _M_X64
-	MOV(PTRBITS, R(tempReg2), Imm64((uintptr_t)&bones));
-#else
-	MOV(PTRBITS, R(tempReg2), Imm32((uintptr_t)&bones));
-#endif
+	MOV(PTRBITS, R(tempReg2), ImmPtr(&bones));
 	for (int j = 0; j < dec_->nweights; j++) {
 		MOVZX(32, 8, tempReg1, MDisp(srcReg, dec_->weightoff + j));
 		CVTSI2SS(XMM1, R(tempReg1));
@@ -399,11 +395,7 @@ void VertexDecoderJitCache::Jit_WeightsU8Skin() {
 }
 
 void VertexDecoderJitCache::Jit_WeightsU16Skin() {
-#ifdef _M_X64
-	MOV(PTRBITS, R(tempReg2), Imm64((uintptr_t)&bones));
-#else
-	MOV(PTRBITS, R(tempReg2), Imm32((uintptr_t)&bones));
-#endif
+	MOV(PTRBITS, R(tempReg2), ImmPtr(&bones));
 	for (int j = 0; j < dec_->nweights; j++) {
 		MOVZX(32, 16, tempReg1, MDisp(srcReg, dec_->weightoff + j * 2));
 		CVTSI2SS(XMM1, R(tempReg1));
@@ -437,11 +429,7 @@ void VertexDecoderJitCache::Jit_WeightsU16Skin() {
 }
 
 void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
-#ifdef _M_X64
-	MOV(PTRBITS, R(tempReg2), Imm64((uintptr_t)&bones));
-#else
-	MOV(PTRBITS, R(tempReg2), Imm32((uintptr_t)&bones));
-#endif
+	MOV(PTRBITS, R(tempReg2), ImmPtr(&bones));
 	for (int j = 0; j < dec_->nweights; j++) {
 		MOVSS(XMM1, MDisp(srcReg, dec_->weightoff + j * 4));
 		SHUFPS(XMM1, R(XMM1), _MM_SHUFFLE(0, 0, 0, 0));

--- a/GPU/GLES/VertexDecoderX86.cpp
+++ b/GPU/GLES/VertexDecoderX86.cpp
@@ -984,6 +984,7 @@ void VertexDecoderJitCache::Jit_NormalFloatSkin() {
 
 // Through expands into floats, always. Might want to look at changing this.
 void VertexDecoderJitCache::Jit_PosS8Through() {
+	DEBUG_LOG_REPORT_ONCE(vertexS8Through, G3D, "Using S8 positions in throughmode");
 	// TODO: SIMD
 	for (int i = 0; i < 3; i++) {
 		MOVSX(32, 8, tempReg1, MDisp(srcReg, dec_->posoff + i));


### PR DESCRIPTION
This code is not well tested.  It does improve performance in Valkyria Chronicles 3 (while moving a character), but even when I had mistakes, I did not notice anything drawn wrong.  So I don't know if it is working right, and I have not tested it on any other games yet.

On x86, I also added SSE4.1 support, mainly to get rid of a comment.  It is slightly faster, but not majorly.  Also, in the cpu jit, switched a few memory copies to MOVD.

-[Unknown]
