### PR TITLE
Use NEON for unswizzling, minor tweak to texcache

### DIFF
--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -22,9 +22,13 @@
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 
-void SetupQuickTexHash();
+void SetupTextureDecoder();
+
 typedef u32 (*QuickTexHashFunc)(const void *checkp, u32 size);
 extern QuickTexHashFunc DoQuickTexHash;
+
+typedef void (*UnswizzleTex16Func)(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 pitch, u32 rowWidth);
+extern UnswizzleTex16Func DoUnswizzleTex16;
 
 // All these DXT structs are in the reverse order, as compared to PC.
 // On PC, alpha comes before color, and interpolants are before the tile data.

--- a/GPU/Common/TextureDecoderNEON.cpp
+++ b/GPU/Common/TextureDecoderNEON.cpp
@@ -84,7 +84,8 @@ u32 QuickTexHashNEON(const void *checkp, u32 size) {
 			// Okay, do the memory hashing.
 			"QuickTexHashNEON_next:\n"
 			"pld [%2, #0xc0]\n"
-			"vldmia %2!, {d16-d23}\n"
+			"vld1.32 {d16, d17, d18, d19}, [%2, :128]!\n"
+			"vld1.32 {d20, d21, d22, d23}, [%2, :128]!\n"
 			"vmla.i32 q0, q1, q8\n"
 			"vmul.i32 q11, q11, q1\n"
 			"veor.i32 q0, q0, q9\n"

--- a/GPU/Common/TextureDecoderNEON.h
+++ b/GPU/Common/TextureDecoderNEON.h
@@ -18,3 +18,4 @@
 #include "GPU/Common/TextureDecoder.h"
 
 u32 QuickTexHashNEON(const void *checkp, u32 size);
+void DoUnswizzleTex16NEON(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 pitch, u32 rowWidth);

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -66,7 +66,7 @@ TextureCache::TextureCache() : clearCacheNextFrame_(false), lowMemoryMode_(false
 	clutBufConverted_ = (u32 *)AllocateAlignedMemory(4096 * sizeof(u32), 16);  // 16KB
 	clutBufRaw_ = (u32 *)AllocateAlignedMemory(4096 * sizeof(u32), 16);  // 16KB
 	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropyLevel);
-	SetupQuickTexHash();
+	SetupTextureDecoder();
 }
 
 TextureCache::~TextureCache() {
@@ -285,51 +285,6 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 	}
 }
 
-static void Unswizzle16(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 pitch, u32 rowWidth) {
-#ifdef _M_SSE
-	const __m128i *src = (const __m128i *)texptr;
-	for (int by = 0; by < byc; by++) {
-		__m128i *xdest = (__m128i *)ydestp;
-		for (int bx = 0; bx < bxc; bx++) {
-			__m128i *dest = xdest;
-			for (int n = 0; n < 2; n++) {
-				// Textures are always 16-byte aligned so this is fine.
-				__m128i temp1 = _mm_load_si128(src);
-				__m128i temp2 = _mm_load_si128(src + 1);
-				__m128i temp3 = _mm_load_si128(src + 2);
-				__m128i temp4 = _mm_load_si128(src + 3);
-				_mm_store_si128(dest, temp1);
-				dest += pitch >> 2;
-				_mm_store_si128(dest, temp2);
-				dest += pitch >> 2;
-				_mm_store_si128(dest, temp3);
-				dest += pitch >> 2;
-				_mm_store_si128(dest, temp4);
-				dest += pitch >> 2;
-				src += 4;
-			}
-			xdest ++;
-		}
-		ydestp += (rowWidth * 8) / 4;
-	}
-#else
-	const u32 *src = (const u32 *)texptr;
-	for (int by = 0; by < byc; by++) {
-		u32 *xdest = ydestp;
-		for (int bx = 0; bx < bxc; bx++) {
-			u32 *dest = xdest;
-			for (int n = 0; n < 8; n++) {
-				memcpy(dest, src, 16);
-				dest += pitch;
-				src += 4;
-			}
-			xdest += 4;
-		}
-		ydestp += (rowWidth * 8) / 4;
-	}
-#endif
-}
-
 void *TextureCache::UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPixel, u32 level) {
 	const u32 rowWidth = (bytesPerPixel > 0) ? (bufw * bytesPerPixel) : (bufw / 2);
 	const u32 pitch = rowWidth / 4;
@@ -342,7 +297,7 @@ void *TextureCache::UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPix
 	if (rowWidth >= 16) {
 		u32 *ydestp = tmpTexBuf32.data();
 		// The most common one, so it gets an optimized implementation.
-		Unswizzle16(texptr, ydestp, bxc, byc, pitch, rowWidth);
+		DoUnswizzleTex16(texptr, ydestp, bxc, byc, pitch, rowWidth);
 	} else if (rowWidth == 8) {
 		const u32 *src = (const u32 *) texptr;
 		for (int by = 0; by < byc; by++) {


### PR DESCRIPTION
Not using aligned loads in unswizzling because I'm not sure it's worth handwriting and I don't know how to specify it with the intrinsics.

But, now using aligned loads in QuickTexHashNEON.  Unfortunately my tests are showing it's the same speed but it may help some devices/games more than others.  Possibly the writeback is causing a penalty maybe..

It's really hard to get anything useful performance wise on Android it seems like.  Everything varies so much by run, and my FPS dances up and down and is never stable (I have power saving on so I can get < 100% speed and not deal with the impact of frameskip.)  But it seems like this is averaging faster per profile and fps.

Note: VLDM was already a NEON instr, this just makes it aligned.

-[Unknown]
