### PR TITLE
Return an error for invalid savedata sizes

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -246,7 +246,7 @@ int PSPOskDialog::Init(u32 oskPtr) {
 	oskParams = oskPtr;
 	if (oskParams->base.size != sizeof(SceUtilityOskParams))
 	{
-		ERROR_LOG(SCEUTILITY, "sceUtilityOskInitStart: invalid size (%d)", oskParams->base.size);
+		ERROR_LOG_REPORT(SCEUTILITY, "sceUtilityOskInitStart: invalid size %d", oskParams->base.size);
 		return SCE_ERROR_UTILITY_INVALID_PARAM_SIZE;
 	}
 	// Also seems to crash.

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -35,6 +35,12 @@ const static float FONT_SCALE = 0.55f;
 const static int SAVEDATA_INIT_DELAY_US = 200000;
 const static int SAVEDATA_SHUTDOWN_DELAY_US = 2000;
 
+// These are the only sizes which are allowed.
+// TODO: We should test what the different behavior is for each.
+const static int SAVEDATA_DIALOG_SIZE_V1 = 1480;
+const static int SAVEDATA_DIALOG_SIZE_V2 = 1500;
+const static int SAVEDATA_DIALOG_SIZE_V3 = 1536;
+
 
 PSPSaveDialog::PSPSaveDialog()
 	: PSPDialog()
@@ -59,6 +65,10 @@ int PSPSaveDialog::Init(int paramAddr)
 	int size = Memory::Read_U32(requestAddr);
 	memset(&request, 0, sizeof(request));
 	// Only copy the right size to support different save request format
+	if (size != SAVEDATA_DIALOG_SIZE_V1 && size != SAVEDATA_DIALOG_SIZE_V2 && size != SAVEDATA_DIALOG_SIZE_V3) {
+		ERROR_LOG_REPORT(SCEUTILITY, "sceUtilitySavedataInitStart: invalid size %d", size);
+		return SCE_ERROR_UTILITY_INVALID_PARAM_SIZE;
+	}
 	Memory::Memcpy(&request, requestAddr, size);
 	Memory::Memcpy(&originalRequest, requestAddr, size);
 


### PR DESCRIPTION
May fix WALL-E according to:
http://forums.ppsspp.org/showthread.php?tid=434

Thanks @sum2012.  I tested a bunch of values (actually, every value) between -100 and 4096 and these are the only ones that work.

-[Unknown]
