### PR TITLE
Win32: when an invalid OpenGL driver is detected, don't offer a choice of quitting or not, just quit.

### DIFF
--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -159,16 +159,15 @@ bool GL_Init(HWND window, std::string *error_message) {
 		const char *defaultError = "Insufficient OpenGL driver support detected!\n\n"
 			"Your GPU reports that it does not support OpenGL 2.0, which is currently required for PPSSPP to run.\n\n"
 			"Please check that your GPU is compatible with OpenGL 2.0.If it is, you need to find and install new graphics drivers from your GPU vendor's website.\n\n"
-			"Visit the forums at http://forums.ppsspp.org for more information.\n\n"
-			"Exit now?";
+			"Visit the forums at http://forums.ppsspp.org for more information.\n\n";
 
 		std::wstring error = ConvertUTF8ToWString(err->T("InsufficientOpenGLDriver", defaultError));
 		std::wstring title = ConvertUTF8ToWString(err->T("OpenGLDriverError", "OpenGL driver error"));
 
-		if (MessageBox(hWnd, error.c_str(), title.c_str(), MB_ICONERROR | MB_YESNO) == IDYES) {
-			// Avoid further error messages. Let's just bail, it's safe.
-			ExitProcess(0);
-		}
+		MessageBox(hWnd, error.c_str(), title.c_str(), MB_ICONERROR);
+
+		// Avoid further error messages. Let's just bail, it's safe, and we can't continue.
+		ExitProcess(0);
 	}
 
 	if (GLEW_OK != glewInit()) {

--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -161,10 +161,12 @@ bool GL_Init(HWND window, std::string *error_message) {
 			"Please check that your GPU is compatible with OpenGL 2.0.If it is, you need to find and install new graphics drivers from your GPU vendor's website.\n\n"
 			"Visit the forums at http://forums.ppsspp.org for more information.\n\n";
 
+		std::wstring versionDetected = ConvertUTF8ToWString(glVersion + "\n\n");
 		std::wstring error = ConvertUTF8ToWString(err->T("InsufficientOpenGLDriver", defaultError));
 		std::wstring title = ConvertUTF8ToWString(err->T("OpenGLDriverError", "OpenGL driver error"));
+		std::wstring combined = versionDetected + error;
 
-		MessageBox(hWnd, error.c_str(), title.c_str(), MB_ICONERROR);
+		MessageBox(hWnd, combined.c_str(), title.c_str(), MB_ICONERROR);
 
 		// Avoid further error messages. Let's just bail, it's safe, and we can't continue.
 		ExitProcess(0);


### PR DESCRIPTION
It's pointless to offer a yes/no choice, and all of the translations don't even have the "Exit now?" part as far as I know, so yeah..

Here's how the error message will look, if this is merged:
![Screenshot 01](http://i.minus.com/iqYOqpRiDx2LX.png)
