### PR TITLE
Win32/NVidia: go fullscreen later than previous builds, to avoid vsync being ignored

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -384,12 +384,14 @@ GLES_GPU::GLES_GPU()
 : resized_(false) {
 #ifdef _WIN32
 	lastVsync_ = g_Config.bVSync ? 1 : 0;
-	if (gl_extensions.EXT_swap_control_tear) {
+	// Disabled EXT_swap_control_tear for now, it never seems to settle at the correct timing
+	// so it just keeps tearing. Not what I hoped for...
+	//if (false && gl_extensions.EXT_swap_control_tear) {
 		// See http://developer.download.nvidia.com/opengl/specs/WGL_EXT_swap_control_tear.txt
-		glstate.SetVSyncInterval(g_Config.bVSync ? -1 :0);
-	} else {
+	//	glstate.SetVSyncInterval(g_Config.bVSync ? -1 :0);
+	//} else {
 		glstate.SetVSyncInterval(g_Config.bVSync ? 1 : 0);
-	}
+	//}
 #endif
 
 	shaderManager_ = new ShaderManager();
@@ -517,12 +519,12 @@ void GLES_GPU::BeginFrameInternal() {
 	if (desiredVSyncInterval != lastVsync_) {
 		// Disabled EXT_swap_control_tear for now, it never seems to settle at the correct timing
 		// so it just keeps tearing. Not what I hoped for...
-		if (false && gl_extensions.EXT_swap_control_tear) {
+		//if (false && gl_extensions.EXT_swap_control_tear) {
 			// See http://developer.download.nvidia.com/opengl/specs/WGL_EXT_swap_control_tear.txt
-			glstate.SetVSyncInterval(-desiredVSyncInterval);
-		} else {
+		//	glstate.SetVSyncInterval(-desiredVSyncInterval);
+		//} else {
 			glstate.SetVSyncInterval(desiredVSyncInterval);
-		}
+		//}
 		lastVsync_ = desiredVSyncInterval;
 	}
 #endif

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -806,9 +806,6 @@ namespace MainWindow
 		hideCursor = true;
 		SetTimer(hwndMain, TIMER_CURSORUPDATE, CURSORUPDATE_INTERVAL_MS, 0);
 		
-		if(g_Config.bFullScreen)
-			_ViewFullScreen(hwndMain);
-		
 		ShowWindow(hwndMain, nCmdShow);
 
 		W32Util::MakeTopMost(hwndMain, g_Config.bTopMost);
@@ -818,6 +815,10 @@ namespace MainWindow
 		WindowsRawInput::Init();
 
 		SetFocus(hwndMain);
+
+		if (g_Config.bFullScreen)
+			_ViewFullScreen(hwndMain);
+
 		return TRUE;
 	}
 


### PR DESCRIPTION
It seems like vsync is ignored if we go fullscreen before showing the window, resulting in tearing regardless of settings until fullscreen is exited and reentered, so moving it down a bit seems to help, at least on my system.

Also, it seems pointless to have the swap_control_tear checks running at all if they're disabled for now, so I turned them off.

May help https://github.com/hrydgard/ppsspp/issues/4440.
