### PR TITLE
Don't calculate lighting when not enabled (software transform)

### DIFF
--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -398,11 +398,12 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 			} else {
 				unlitColor = Vec4f::FromRGBA(gstate.getMaterialAmbientRGBA());
 			}
-			float litColor0[4];
-			float litColor1[4];
-			lighter.Light(litColor0, litColor1, unlitColor.AsArray(), out, normal);
 
 			if (gstate.isLightingEnabled()) {
+				float litColor0[4];
+				float litColor1[4];
+				lighter.Light(litColor0, litColor1, unlitColor.AsArray(), out, normal);
+
 				// Don't ignore gstate.lmode - we should send two colors in that case
 				for (int j = 0; j < 4; j++) {
 					c0[j] = litColor0[j];


### PR DESCRIPTION
We just ignore it anyway.  2% improvement in Tales of Phantasia X.

-[Unknown]
