### PR TITLE
Add scempegbase stuff

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -326,7 +326,7 @@ void RegisterAllModules() {
 	Register_SysclibForKernel();
 	Register_sceCtrl_driver();
 	Register_sceDisplay_driver();
-
+	Register_sceMpegbase();
 
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1793,3 +1793,24 @@ void Register_sceMpeg()
 {
 	RegisterModule("sceMpeg", ARRAY_SIZE(sceMpeg), sceMpeg);
 }
+
+u32 sceMpegbase_BEA18F91(u32 unknown1, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5, u32 unknown6)
+{
+	ERROR_LOG(ME, "UNIMPL sceMpegbase_BEA18F91(%08x, %08x, %08x, %08x, %08x, %08x)", unknown1, unknown2, unknown3, unknown4, unknown5, unknown6);
+	return 0;
+}
+
+const HLEFunction sceMpegbase[] =
+{
+	{ 0xBEA18F91, WrapU_UUUUUU<sceMpegbase_BEA18F91>, "sceMpegbase_BEA18F91" },
+	{ 0x492B5E4B, 0, "sceMpegBaseCscInit" },
+	{ 0x0530BE4E, 0, "sceMpegbase_0530BE4E" },
+	{ 0x91929A21, 0, "sceMpegBaseCscAvc" },
+	{ 0x304882E1, 0, "sceMpegBaseCscAvcRange" },
+	{ 0x7AC0321A, 0, "sceMpegBaseYCrCbCopy" }
+};
+
+void Register_sceMpegbase()
+{
+	RegisterModule("sceMpegbase", ARRAY_SIZE(sceMpegbase), sceMpegbase);
+};

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -77,3 +77,6 @@ void __MpegShutdown();
 void __MpegLoadModule(int version);
 
 void Register_sceMpeg();
+
+void Register_sceMpegbase();
+


### PR DESCRIPTION
Find in homebrew game
I guess parameter of sceMpegbase_BEA18F91  by JPCSPTrace log
Seem sceMpegbase_BEA18F91 make mpeg buffer  for sceMpegAvcDecode

JPCSPTrace log:
https://gist.github.com/sum2012/1bedb4380065919edb03
PPSSPP Modify log:
https://gist.github.com/sum2012/5047fc1f37da391c72e2
