### PR TITLE
Log unsupported blending mode : 2.0 * src, 1.0 - src

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -253,6 +253,10 @@ static bool CanDoubleSrcBlendMode() {
 	// LittleBigPlanet, for example, uses 2.0 * src, 1.0 - src, which can't double.
 	// Persona 2 uses the same function, which is the reason for its darkness. It only ever passes
 	// 1.0 as src alpha though, so in effect it's a color doubling.
+	if (funcA == GE_SRCBLEND_DOUBLESRCALPHA && funcB == GE_DSTBLEND_INVSRCALPHA) {
+		ERROR_LOG_REPORT(HLE, "Unsupported blending mode: 2.0 * src, 1.0 - src");
+	}
+	
 	switch (funcB) {
 	case GE_DSTBLEND_SRCALPHA:
 	case GE_DSTBLEND_INVSRCALPHA:

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -254,7 +254,7 @@ static bool CanDoubleSrcBlendMode() {
 	// Persona 2 uses the same function, which is the reason for its darkness. It only ever passes
 	// 1.0 as src alpha though, so in effect it's a color doubling.
 	if (funcA == GE_SRCBLEND_DOUBLESRCALPHA && funcB == GE_DSTBLEND_INVSRCALPHA) {
-		ERROR_LOG_REPORT(HLE, "Unsupported blending mode: 2.0 * src, 1.0 - src");
+		ERROR_LOG_REPORT_ONCE(HLE, "Unsupported blending mode: 2.0 * src, 1.0 - src");
 	}
 	
 	switch (funcB) {


### PR DESCRIPTION
Would like to see how many games we are facing this unsupported blending mode other than LittlePlanet and Persona 2
