### PR TITLE
Clamp morph colors outside jit, fix other vertexjit mistakes

### DIFF
--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -263,7 +263,7 @@ void VertexDecoder::Step_Color565Morph() const
 	}
 	u8 *c = decoded_ + decFmt.c0off;
 	for (int i = 0; i < 3; i++) {
-		c[i] = (u8)col[i];
+		c[i] = clamp_u8((int)col[i]);
 	}
 	c[3] = 255;
 	// Always full alpha.
@@ -283,7 +283,7 @@ void VertexDecoder::Step_Color5551Morph() const
 	}
 	u8 *c = decoded_ + decFmt.c0off;
 	for (int i = 0; i < 4; i++) {
-		c[i] = (u8)col[i];
+		c[i] = clamp_u8((int)col[i]);
 	}
 	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
@@ -300,7 +300,7 @@ void VertexDecoder::Step_Color4444Morph() const
 	}
 	u8 *c = decoded_ + decFmt.c0off;
 	for (int i = 0; i < 4; i++) {
-		c[i] = (u8)col[i];
+		c[i] = clamp_u8((int)col[i]);
 	}
 	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
@@ -317,7 +317,7 @@ void VertexDecoder::Step_Color8888Morph() const
 	}
 	u8 *c = decoded_ + decFmt.c0off;
 	for (int i = 0; i < 4; i++) {
-		c[i] = (u8)(col[i]);
+		c[i] = clamp_u8((int)col[i]);
 	}
 	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }

--- a/Globals.h
+++ b/Globals.h
@@ -48,6 +48,18 @@ inline u8 Convert6To8(u8 v)
 	return (v << 2) | (v >> 4);
 }
 
+static inline u8 clamp_u8(int i) {
+#ifdef ARM
+	asm("usat %0, #8, %1" : "=r"(i) : "r"(i));
+#else
+	if (i > 255)
+		return 255;
+	if (i < 0)
+		return 0;
+#endif
+	return i;
+}
+
 static inline s16 clamp_s16(int i) {
 #ifdef ARM
 	asm("ssat %0, #16, %1" : "=r"(i) : "r"(i));


### PR DESCRIPTION
Oops again, had some NEON outside a check.

-[Unknown]
