### PR TITLE
Stick a cork in some memory leaks

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -258,8 +258,23 @@ public:
 	LoadedFont() : font_(NULL) {
 	}
 
-	LoadedFont(Font *font, u32 fontLibID, u32 handle)
-		: fontLibID_(fontLibID), font_(font), handle_(handle), open_(true) {}
+	LoadedFont(Font *font, FontOpenMode mode, u32 fontLibID, u32 handle)
+		: fontLibID_(fontLibID), font_(font), handle_(handle), open_(true), mode_(mode) {}
+
+	~LoadedFont() {
+		switch (mode_) {
+		case FONT_OPEN_USERBUFFER:
+		case FONT_OPEN_USERFILE_FULL:
+		case FONT_OPEN_USERFILE_HANDLERS:
+			// For these types, it's our responsibility to delete.
+			delete font_;
+			font_ = NULL;
+			break;
+		default:
+			// Otherwise, it's an internal font, we keep those.
+			break;
+		}
+	}
 
 	const Font *GetFont() const { return font_; }
 	const PGF *GetPGF() const { return font_->GetPGF(); }
@@ -278,7 +293,7 @@ public:
 	}
 
 	void DoState(PointerWrap &p) {
-		auto s = p.Section("LoadedFont", 1, 2);
+		auto s = p.Section("LoadedFont", 1, 3);
 		if (!s)
 			return;
 
@@ -304,12 +319,18 @@ public:
 		} else {
 			open_ = fontLibID_ != (u32)-1;
 		}
+		if (s >= 3) {
+			p.Do(mode_);
+		} else {
+			mode_ = FONT_OPEN_INTERNAL_FULL;
+		}
 	}
 
 private:
 	u32 fontLibID_;
 	Font *font_;
 	u32 handle_;
+	FontOpenMode mode_;
 	bool open_;
 	DISALLOW_COPY_AND_ASSIGN(LoadedFont);
 };
@@ -468,6 +489,7 @@ public:
 		return fonts_[index];
 	}
 
+	// For FONT_OPEN_USER* modes, the font will automatically be freed.
 	LoadedFont *OpenFont(Font *font, FontOpenMode mode, int &error) {
 		// TODO: Do something with mode, possibly save it where the PSP does in the struct.
 		// Maybe needed in Font, though?  Handlers seem... difficult to emulate.
@@ -488,8 +510,15 @@ public:
 			error = ERROR_FONT_INVALID_FONT_DATA;
 			return 0;
 		}
-		LoadedFont *loadedFont = new LoadedFont(font, GetListID(), fonts_[freeFontIndex]);
+		LoadedFont *loadedFont = new LoadedFont(font, mode, GetListID(), fonts_[freeFontIndex]);
 		isfontopen_[freeFontIndex] = 1;
+
+		auto prevFont = fontMap.find(loadedFont->Handle());
+		if (prevFont != fontMap.end()) {
+			// Before replacing it and forgetting about it, let's free it.
+			delete prevFont->second;
+		}
+		fontMap[loadedFont->Handle()] = loadedFont;
 		return loadedFont;
 	}
 
@@ -679,6 +708,7 @@ void __FontShutdown() {
 		FontLib *fontLib = iter->second->GetFontLib();
 		if (fontLib)
 			fontLib->CloseFont(iter->second);
+		delete iter->second;
 	}
 	fontMap.clear();
 	for (auto iter = fontLibList.begin(); iter != fontLibList.end(); iter++) {
@@ -770,7 +800,6 @@ u32 sceFontOpen(u32 libHandle, u32 index, u32 mode, u32 errorCodePtr) {
 	FontOpenMode openMode = mode == 0 ? FONT_OPEN_INTERNAL_STINGY : FONT_OPEN_INTERNAL_FULL;
 	LoadedFont *font = fontLib->OpenFont(internalFonts[index], openMode, *errorCode);
 	if (font) {
-		fontMap[font->Handle()] = font;
 		*errorCode = 0;
 		return font->Handle();
 	} else {
@@ -810,7 +839,6 @@ u32 sceFontOpenUserMemory(u32 libHandle, u32 memoryFontAddrPtr, u32 memoryFontLe
 	Font *f = new Font(fontData, memoryFontLength);
 	LoadedFont *font = fontLib->OpenFont(f, FONT_OPEN_USERBUFFER, *errorCode);
 	if (font) {
-		fontMap[font->Handle()] = font;
 		*errorCode = 0;
 		return font->Handle();
 	} else {
@@ -859,7 +887,6 @@ u32 sceFontOpenUserFile(u32 libHandle, const char *fileName, u32 mode, u32 error
 	FontOpenMode openMode = mode == 0 ? FONT_OPEN_USERFILE_HANDLERS : FONT_OPEN_USERFILE_FULL;
 	LoadedFont *font = fontLib->OpenFont(f, openMode, *errorCode);
 	if (font) {
-		fontMap[font->Handle()] = font;
 		*errorCode = 0;
 		return font->Handle();
 	} else {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -175,6 +175,7 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	memset(&frame, 0, sizeof(frame));
 	AVPacket packet;
 	memset(&packet, 0, sizeof(packet));
+	av_init_packet(&packet);
 	int got_frame = 0, ret;
 	static int audio_frame_count = 0;
 
@@ -344,6 +345,9 @@ u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
 	ctx->mp3Bitrate = 128;
 	ctx->mp3SamplingRate = 44100;
 
+	if (mp3Map.find(mp3Addr) != mp3Map.end()) {
+		delete mp3Map[mp3Addr];
+	}
 	mp3Map[mp3Addr] = ctx;
 	return mp3Addr;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -470,6 +470,11 @@ u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 f
 		Memory::Write_U32(ringbuffer->dataUpperBound, mpegHandle + 20);
 	}
 	MpegContext *ctx = new MpegContext;
+	if (mpegMap.find(mpegHandle) != mpegMap.end()) {
+		WARN_LOG_REPORT(HLE, "Replacing existing mpeg context at %08x", mpegAddr);
+		// Otherwise, it would leak.
+		delete mpegMap[mpegHandle];
+	}
 	mpegMap[mpegHandle] = ctx;
 
 	// Initialize mpeg values.

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -879,6 +879,8 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 psmfPlayerDataAddr)
 	if (!psmfplayer) {
 		// TODO: This is the wrong data.  PsmfPlayer needs a new interface.
 		psmfplayer = new PsmfPlayer(psmfPlayerDataAddr);
+		if (psmfPlayerMap.find(psmfPlayer) != psmfPlayerMap.end())
+			delete psmfPlayerMap[psmfPlayer];
 		psmfPlayerMap[psmfPlayer] = psmfplayer;
 	}
 
@@ -1086,6 +1088,8 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 
 	if (!psmfplayer) {
 		psmfplayer = new PsmfPlayer(psmfPlayerData);
+		if (psmfPlayerMap.find(psmfPlayer) != psmfPlayerMap.end())
+			delete psmfPlayerMap[psmfPlayer];
 		psmfPlayerMap[psmfPlayer] = psmfplayer;
 	}
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -301,9 +301,9 @@ void MediaEngine::closeContext()
 	if (m_buffer)
 		av_free(m_buffer);
 	if (m_pFrameRGB)
-		av_free(m_pFrameRGB);
+		av_frame_free(&m_pFrameRGB);
 	if (m_pFrame)
-		av_free(m_pFrame);
+		av_frame_free(&m_pFrame);
 	if (m_pIOContext && m_pIOContext->buffer)
 		av_free(m_pIOContext->buffer);
 	if (m_pIOContext)
@@ -313,10 +313,9 @@ void MediaEngine::closeContext()
 	m_pCodecCtxs.clear();
 	if (m_pFormatCtx)
 		avformat_close_input(&m_pFormatCtx);
-	m_pFrame = 0;
-	m_pFrameRGB = 0;
+	if (m_sws_ctx != NULL)
+		sws_freeContext(m_sws_ctx);
 	m_pIOContext = 0;
-	m_pFormatCtx = 0;
 #endif
 	m_buffer = 0;
 }
@@ -415,6 +414,9 @@ bool MediaEngine::setVideoDim(int width, int height)
 	// Allocate video frame
 	m_pFrame = av_frame_alloc();
 
+	if (m_sws_ctx != NULL) {
+		sws_freeContext(m_sws_ctx);
+	}
 	m_sws_ctx = NULL;
 	m_sws_fmt = -1;
 	updateSwsFormat(GE_CMODE_32BIT_ABGR8888);
@@ -474,6 +476,7 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 	m_pFrameRGB->linesize[0] = getPixelFormatBytes(videoPixelMode) * m_desWidth;
 
 	AVPacket packet;
+	av_init_packet(&packet);
 	int frameFinished;
 	bool bGetFrame = false;
 	while (!bGetFrame) {

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -27,7 +27,8 @@ MpegDemux::MpegDemux(int size, int offset) : m_audioStream(size) {
 	m_readSize = 0;
 }
 
-MpegDemux::~MpegDemux(void) {
+MpegDemux::~MpegDemux() {
+	delete [] m_buf;
 }
 
 void MpegDemux::DoState(PointerWrap &p) {

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -12,7 +12,7 @@ class MpegDemux
 {
 public:
 	MpegDemux(int size, int offset);
-	~MpegDemux(void);
+	~MpegDemux();
 
 	bool addStreamData(u8* buf, int addSize);
 	void demux(int audioChannel);


### PR DESCRIPTION
This improves memory leaking when for example running the auto tests, and likely actually running games (I know some games open/close fonts in ways I expect was leaking quite a bit before.)

I think I _finally_ figured out why x64 on the buildbot has never been able to complete the unit tests: it's running out of memory.  If I run all of the unit tests 4x, I also run out of memory (in fact, I got to see a new Windows error message I've never seen before about running out of RAM and closing random programs to save me.)  It fails in random places, bad_alloc, executable memory, 4gb base, etc.

With the changes here, the leaking is a lot better, and the working set actually doesn't leak much or possibly not at all (except for initialized things, like fonts or ffmpeg.)  However the commit charge leaks like a faucet.

After the first test (run 3x), the commit charge is 18 MB having peaked at 69 MB.  When it crashes (I'm not sure why this is all it takes for it to crash...?) the process commit charge is 143 MB having peaked at 194 MB.  This is after 235 tests or so (each run 3x, so I guess > 700 total.)    It seems to leak an approximate 168 KB per test.

VLD doesn't seem to detect any leaks, and didn't detect any of these that I found manually... grr.

-[Unknown]
