### PR TITLE
Display label name in status bar

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1160,6 +1160,12 @@ void CtrlDisAsmView::updateStatusBarText()
 	}
 
 	SendMessage(GetParent(wnd),WM_DEB_SETSTATUSBARTEXT,0,(LPARAM)text);
+
+	const std::string label = symbolMap.GetLabelString(line.info.opcodeAddress);
+	if (!label.empty())
+	{
+		SendMessage(GetParent(wnd),WM_DEB_SETSTATUSBARTEXT,1,(LPARAM)label.c_str());
+	}
 }
 
 u32 CtrlDisAsmView::yToAddress(int y)


### PR DESCRIPTION
This is useful for really long names, like when mangling is involved. Example: http://puu.sh/7QMWv/a1ecce7dcf.png
