### PR TITLE
Win32: Implement "-d" command-line switch, and update the DebugLog batch file accordingly.

### DIFF
--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -127,6 +127,12 @@ public:
 		log_[type]->SetLevel(level);
 	}
 
+	void SetAllLogLevels(LogTypes::LOG_LEVELS level) {
+		for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i) {
+			log_[i]->SetLevel(level);
+		}
+	}
+
 	void SetEnable(LogTypes::LOG_TYPE type, bool enable) {
 		log_[type]->SetEnable(enable);
 	}

--- a/Windows/DebugLog.bat
+++ b/Windows/DebugLog.bat
@@ -2,12 +2,12 @@
 set LOGFILE=ppsspplog.txt
 
 del "%LOGFILE%" 2> NUL
-if exist PPSSPPDebug64.exe (
-    PPSSPPDebug64.exe --log="%LOGFILE%"
+if exist PPSSPPWindows64.exe (
+    start PPSSPPWindows64.exe --log="%LOGFILE%" -d
     goto exit
 )
-if exist PPSSPPDebug.exe (
-    PPSSPPDebug.exe --log="%LOGFILE%"
+if exist PPSSPPWindows.exe (
+    start PPSSPPWindows.exe --log="%LOGFILE%" -d
     goto exit
 )
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -310,6 +310,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.Load(configFilename, controlsConfigFilename);
 
+	bool debugLogLevel = false;
+
 	// The rest is handled in NativeInit().
 	for (int i = 1; i < __argc; ++i)
 	{
@@ -327,6 +329,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			case 's':
 				g_Config.bAutoRun = false;
 				g_Config.bSaveSettings = false;
+				break;
+			case 'd':
+				debugLogLevel = true;
 				break;
 			}
 
@@ -351,7 +356,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	//   - The -l switch is expected to show the log console, REGARDLESS of config settings.
 	//   - It should be possible to log to a file without showing the console.
 	LogManager::GetInstance()->GetConsoleListener()->Init(showLog, 150, 120, "PPSSPP Debug Console");
-
+	
+	if (debugLogLevel)
+		LogManager::GetInstance()->SetAllLogLevels(LogTypes::LDEBUG);
 
 	//Windows, API init stuff
 	INITCOMMONCONTROLSEX comm;


### PR DESCRIPTION
This will make it so -d (which sets all of the logging levels to debug) works on Windows, too. Previously, it didn't do anything. Also, I updated the bat file so it'll work with the new option, and close itself after launching the emulator (via the "start" command), and not linger around.

Fixes https://github.com/hrydgard/ppsspp/issues/5773.
