### PR TITLE
Mp3 file is not always have two channels

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -242,8 +242,8 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 		fclose(file);
 	}
 	#endif
-	// 2 bytes per channel and we always two channels per mp3 so it is 2 * 2
-	ctx->mp3SumDecodedSamples += bytesdecoded / 2 * 2;
+	// 2 bytes per channel and we have frame.channels in mp3 source
+	ctx->mp3SumDecodedSamples += bytesdecoded / (2 * frame.channels);
 
 	return bytesdecoded;
 }


### PR DESCRIPTION
Since my Custom audio branch https://github.com/hrydgard/ppsspp/pull/5744 and pmp video branch https://github.com/hrydgard/ppsspp/pull/5776 are always not been merged! I begin to realize that I maybe too fast... something must be revealed and corrected little by little... Ok even I've forgotten most of them where I've changed, well let's begin from some little and easy bugs. even it could not definitly solve something as what I've done before in that two branches.

First this one. since your mp3 file is not always stereo, so here is incorrect.
