### PR TITLE
No need to init packet as 0

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -598,7 +598,7 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 				int forceseekSample = atrac->currentSample * 2 > atrac->endSample ? 0 : atrac->endSample;
 				atrac->SeekToSample(forceseekSample);
 				atrac->SeekToSample(atrac->currentSample);
-				AVPacket packet = {0};
+				AVPacket packet;
 				av_init_packet(&packet);
 				int got_frame, avret;
 				while (av_read_frame(atrac->pFormatCtx, &packet) >= 0) {
@@ -1771,7 +1771,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 		atrac->SeekToSample(atrac->currentSample);
 
 		if (!atrac->failedDecode) {
-			AVPacket packet = {0};
+			AVPacket packet;
 			av_init_packet(&packet);
 			int got_frame, avret;
 			while (av_read_frame(atrac->pFormatCtx, &packet) >= 0) {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -171,7 +171,6 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	AVFrame frame;
 	memset(&frame, 0, sizeof(frame));
 	AVPacket packet;
-	memset(&packet, 0, sizeof(packet));
 	av_init_packet(&packet);
 	int got_frame = 0, ret;
 	static int audio_frame_count = 0;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -473,7 +473,7 @@ bool MediaEngine::stepVideo(int videoPixelMode) {
 	// Update the linesize for the new format too.  We started with the largest size, so it should fit.
 	m_pFrameRGB->linesize[0] = getPixelFormatBytes(videoPixelMode) * m_desWidth;
 
-	AVPacket packet = {0};
+	AVPacket packet;
 	av_init_packet(&packet);
 	int frameFinished;
 	bool bGetFrame = false;

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -156,7 +156,7 @@ SimpleAudio::~SimpleAudio() {
 // Input is a single Audio packet.
 bool SimpleAudio::Decode(void* inbuf, int inbytes, uint8_t *outbuf, int *outbytes) {
 #ifdef USE_FFMPEG
-	AVPacket packet = { 0 };
+	AVPacket packet;
 	av_init_packet(&packet);
 	packet.data = static_cast<uint8_t *>(inbuf);
 	packet.size = inbytes;


### PR DESCRIPTION
As suggested by @unknownbrackets that av_init_packet should be already initialized.
