### PR TITLE
Win32: Properly shutdown when using File->Exit, or when g_Config.bEscapeExitsEmulator is true.

### DIFF
--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -119,7 +119,7 @@ namespace WindowsRawInput {
 		}
 
 		if (g_Config.bEscapeExitsEmulator && raw->data.keyboard.VKey == VK_ESCAPE) {
-			DestroyWindow(MainWindow::GetHWND());
+			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
 			return;
 		}
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1316,7 +1316,7 @@ namespace MainWindow
 					break;
 
 				case ID_FILE_EXIT:
-					DestroyWindow(hWnd);
+					PostMessage(hwndMain, WM_CLOSE, 0, 0);
 					break;
 
 				case ID_DEBUG_RUNONLOAD:


### PR DESCRIPTION
We're not shutting down properly when either of these two are used, so let's send a WM_CLOSE to tell the program that we need to clean up (WM_CLOSE is where we handle stopping all threads and turning off RawInput, etc.).
