### PR TITLE
Improve sync and pause GE signal handling

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -110,7 +110,7 @@ public:
 		SubIntrHandler* handler = get(subintr);
 		if (handler != NULL)
 		{
-			DEBUG_LOG(CPU, "Entering interrupt handler %08x", handler->handlerAddress);
+			DEBUG_LOG(CPU, "Entering GE interrupt handler %08x", handler->handlerAddress);
 			currentMIPS->pc = handler->handlerAddress;
 			u32 data = dl->subIntrToken;
 			currentMIPS->r[MIPS_REG_A0] = data & 0xFFFF;
@@ -161,8 +161,6 @@ public:
 		default:
 			break;
 		}
-
-		dl->signal = PSP_GE_SIGNAL_NONE;
 
 		gpu->InterruptEnd(intrdata.listid);
 	}

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -107,6 +107,12 @@ public:
 			}
 		}
 
+		// Set the list as complete once the interrupt starts.
+		// In other words, not before another interrupt finishes.
+		if (dl->signal != PSP_GE_SIGNAL_HANDLER_PAUSE && cmd == GE_CMD_FINISH) {
+			dl->state = PSP_GE_DL_STATE_COMPLETED;
+		}
+
 		SubIntrHandler* handler = get(subintr);
 		if (handler != NULL)
 		{

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -823,7 +823,7 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					// But right now, signal is always reset by interrupts, so that causes pause to not work.
 					trigger = false;
 					currentList->signal = behaviour;
-					ERROR_LOG_REPORT(G3D, "Signal with Pause. signal/end: %04x %04x", signal, enddata);
+					DEBUG_LOG(G3D, "Signal with Pause. signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_SYNC:
 					// Acts as a memory barrier, never calls any user code.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -823,6 +823,10 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 					ERROR_LOG_REPORT(G3D, "Signal with Pause UNIMPLEMENTED! signal/end: %04x %04x", signal, enddata);
 					break;
 				case PSP_GE_SIGNAL_SYNC:
+					// Technically, this ought to trigger an interrupt, but it won't do anything.
+					// Triggering here can cause incorrect rescheduling, which breaks 3rd Birthday.
+					// However, this is likely a bug in how GE signal interrupts are handled.
+					trigger = false;
 					currentList->signal = behaviour;
 					DEBUG_LOG(G3D, "Signal with Sync. signal/end: %04x %04x", signal, enddata);
 					break;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -920,11 +920,11 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 
 			default:
 				currentList->subIntrToken = prev & 0xFFFF;
-				currentList->state = PSP_GE_DL_STATE_COMPLETED;
 				UpdateState(GPUSTATE_DONE);
 				if (currentList->interruptsEnabled && __GeTriggerInterrupt(currentList->id, currentList->pc, startingTicks + cyclesExecuted)) {
 					currentList->pendingInterrupt = true;
 				} else {
+					currentList->state = PSP_GE_DL_STATE_COMPLETED;
 					currentList->waitTicks = startingTicks + cyclesExecuted;
 					busyTicks = std::max(busyTicks, currentList->waitTicks);
 					__GeTriggerSync(GPU_SYNC_LIST, currentList->id, currentList->waitTicks);

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -320,6 +320,9 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		{
 		case IDC_GEDBG_MAINTAB:
 			tabs->HandleNotify(lParam);
+			if (gpuDebug != NULL) {
+				lists->Update();
+			}
 			break;
 		case IDC_GEDBG_FBTABS:
 			fbTabs->HandleNotify(lParam);


### PR DESCRIPTION
We don't actually do the continue signal properly.  Technically, the list ought to continue while the CPU interrupt is running.  However, it should not be able to complete (until after the interrupt), and a future GE signal should queue up afaict.

Disabling sync fixes rescheduling not happening right.  It could just be bad gpu cycle timing.  Since it never needs to run any userspace code, this may be fine.  The only downside is, when multithreading it probably is good to actually "sync" with the cpu... but that's a separate problem anyway, it should be doing that "automatically."

Unfortunately, I only have a few games that even use pause:
- Hexyz Force (#3973): this fixes the pause issue, but reveals a new issue (pixel poking.)  So now the screen is black, but the text is visible.  Works in softgpu now.
- Savage Moon: not sure it fixes anything, but works fine.
- Kingdom Hearts (fixes #4541): makes it work properly with threading on or off.

Possibly may help #3669 which I do not have to test.

Other games which use PAUSE:
http://report.ppsspp.org/logs/kind/84

-[Unknown]
