### PR TITLE
Fix hashmap crashes with games that load modules

### DIFF
--- a/Core/HLE/ReplaceTables.h
+++ b/Core/HLE/ReplaceTables.h
@@ -58,4 +58,6 @@ int GetReplacementFuncIndex(u64 hash, int funcSize);
 const ReplacementTableEntry *GetReplacementFunc(int index);
 
 void WriteReplaceInstruction(u32 address, u64 hash, int size);
+void RestoreReplacedInstruction(u32 address);
+void RestoreReplacedInstructions(u32 startAddr, u32 endAddr);
 bool GetReplacedOpAt(u32 address, u32 *op);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -959,10 +959,11 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 	SectionID textSection = reader.GetSectionByName(".text");
 
 	if (textSection != -1) {
-		u32 textStart = reader.GetSectionAddr(textSection);
+		module->textStart = reader.GetSectionAddr(textSection);
 		u32 textSize = reader.GetSectionSize(textSection);
+		module->textEnd = module->textStart + textSize;
 
-		module->nm.text_addr = textStart;
+		module->nm.text_addr = module->textStart;
 		// TODO: This value appears to be wrong.  In one example, the PSP has a value > 0x1000 bigger.
 		module->nm.text_size = textSize;
 		// TODO: It seems like the data size excludes the text size, which kinda makes sense?
@@ -970,11 +971,11 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 
 #if !defined(MOBILE_DEVICE)
 		bool gotSymbols = reader.LoadSymbols();
-		MIPSAnalyst::ScanForFunctions(textStart, textStart + textSize, !gotSymbols);
+		MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 #else
 		if (g_Config.bFuncHashMap) {
 			bool gotSymbols = reader.LoadSymbols();
-			MIPSAnalyst::ScanForFunctions(textStart, textStart + textSize, !gotSymbols);
+			MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 		}
 #endif
 	}
@@ -1127,15 +1128,15 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 	}
 
 	if (textSection == -1) {
-		u32 textStart = reader.GetVaddr();
-		u32 textEnd = firstImportStubAddr - 4;
+		module->textStart = reader.GetVaddr();
+		module->textEnd = firstImportStubAddr - 4;
 #if !defined(MOBILE_DEVICE)
 		bool gotSymbols = reader.LoadSymbols();
-		MIPSAnalyst::ScanForFunctions(textStart, textEnd, !gotSymbols);
+		MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 #else
 		if (g_Config.bFuncHashMap) {
 			bool gotSymbols = reader.LoadSymbols();
-			MIPSAnalyst::ScanForFunctions(textStart, textEnd, !gotSymbols);
+			MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 		}
 #endif
 	}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -559,6 +559,8 @@ skip:
 			}
 		}
 
+		RestoreReplacedInstructions(startAddr, endAddr);
+
 		// TODO: Also wipe them from hash->function map
 	}
 


### PR DESCRIPTION
This should properly unload and reload the functions as necessary.

At least, this fixes Valkyrie Profile.

-[Unknown]
