### PR TITLE
Avoid unknown get pointer in Rasterizer.cpp

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1193,7 +1193,10 @@ void DrawTriangleSlice(
 		for (int i = 0; i <= maxTexLevel; i++) {
 			u32 texaddr = gstate.getTextureAddress(i);
 			texbufwidthbits[i] = GetTextureBufw(i, texaddr, texfmt) * 8;
-			texptr[i] = Memory::GetPointer(texaddr);
+			if (Memory::IsValidAddress(texaddr))
+				texptr[i] = Memory::GetPointer(texaddr);
+			else
+				texptr[i] = 0;
 		}
 	}
 


### PR DESCRIPTION
Find in #5350 in softgpu
Not sure correct fix
![1](https://cloud.githubusercontent.com/assets/2177532/2688327/4682d520-c294-11e3-9333-061c24715b06.png)
