### PR TITLE
Try to improve FBO sizing

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -708,6 +708,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 
 	int buffer_width = drawing_width;
 	int buffer_height = drawing_height;
+	bool embiggened = false;
 
 	// Find a matching framebuffer
 	VirtualFramebuffer *vfb = 0;
@@ -718,8 +719,19 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 			// Update fb stride in case it changed
 			vfb->fb_stride = fb_stride;
 			if (v->width < drawing_width && v->height < drawing_height) {
-				v->width = drawing_width;
-				v->height = drawing_height;
+				// Embiggen if it gets bigger, but only once.
+				// This prevents it happening over and over again.
+				if (!v->embiggened) {
+					// TODO: Could copy over the data.
+					embiggened = true;
+					vfb = NULL;
+					DestroyFramebuf(v);
+					vfbs_.erase(vfbs_.begin() + i);
+					break;
+				} else {
+					v->width = drawing_width;
+					v->height = drawing_height;
+				}
 			}
 			if (v->format != fmt) {
 				v->width = drawing_width;
@@ -755,6 +767,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 			vfb->reallyDirtyAfterDisplay = true;
 		vfb->memoryUpdated = false;
 		vfb->depthUpdated = false;
+		vfb->embiggened = embiggened;
 
 		if (g_Config.bTrueColor) {
 			vfb->colorDepth = FBO_8888;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -79,13 +79,16 @@ struct VirtualFramebuffer {
 
 	u16 usageFlags;
 
+	u16 newWidth;
+	u16 newHeight;
+	int lastFrameNewSize;
+
 	GEBufferFormat format;  // virtual, right now they are all RGBA8888
 	FBOColorDepth colorDepth;
 	FBO *fbo;
 
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
-	bool embiggened;
 };
 
 void CenterRect(float *x, float *y, float *w, float *h,

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -85,6 +85,7 @@ struct VirtualFramebuffer {
 
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
+	bool embiggened;
 };
 
 void CenterRect(float *x, float *y, float *w, float *h,


### PR DESCRIPTION
This is a conservative (and slightly hacky) fix for #4325 (Wild Arms XF).  It also fixes the same issue in Tales of Phantasia X (which is not always reachable, it depends on how you access the area and what framebuffers were created beforehand - but it's easy to reproduce in the demo.)

I don't really have the games with the primary issues here, but I checked shadows in Kingdom Hearts and videos in Star Ocean and there weren't any issues.  Tales of Destiny 2, which was involved in the original embiggening attempts, also seems fine.

-[Unknown]
