### PR TITLE
Avoid rehashing an unchanged texture

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -115,7 +115,7 @@ static const CommandTableEntry commandTable[] = {
 
 	// These affect the fragment shader so need flushing.
 	{GE_CMD_CLEARMODE, FLAG_FLUSHBEFOREONCHANGE},
-	{GE_CMD_TEXTUREMAPENABLE, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTEONCHANGE},
+	{GE_CMD_TEXTUREMAPENABLE, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_FOGENABLE, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_TEXMODE, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTEONCHANGE},
 	{GE_CMD_TEXSHADELS, FLAG_FLUSHBEFOREONCHANGE},
@@ -918,7 +918,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_TEXTUREMAPENABLE:
-		gstate_c.textureChanged = true;
+		// Don't need to dirty the texture here, already dirtied at list start/etc.
 		break;
 
 	case GE_CMD_LIGHTINGENABLE:

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -166,10 +166,8 @@ static inline bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margi
 void TransformDrawEngine::ApplyDrawState(int prim) {
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
-	if (gstate_c.textureChanged && !gstate.isModeClear()) {
-		if (gstate.isTextureMapEnabled()) {
-			textureCache_->SetTexture();
-		}
+	if (gstate_c.textureChanged && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
+		textureCache_->SetTexture();
 		gstate_c.textureChanged = false;
 	}
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -116,6 +116,18 @@ private:
 		bool sClamp;
 		bool tClamp;
 
+		Status GetHashStatus() {
+			return Status(status & STATUS_MASK);
+		}
+		void SetHashStatus(Status newStatus) {
+			status = (status & ~STATUS_MASK) | newStatus;
+		}
+		Status GetAlphaStatus() {
+			return Status(status & STATUS_ALPHA_MASK);
+		}
+		void SetAlphaStatus(Status newStatus) {
+			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
+		}
 		bool Matches(u16 dim2, u8 format2, int maxLevel2);
 	};
 


### PR DESCRIPTION
Every time SetTexture() is called, textures are rehashed (with default settings.)  Enabling texturing was causing this, even if the texture didn't change - which was causing the horrible slowdown in #5788.
#5788 is still slow, but it's now bearable even with "lazy texture hashing" off.

-[Unknown]
