### PR TITLE
More elegant way of solving #5839 (d_private in sceIoDread)

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -134,6 +134,11 @@ bool FixPathCase(std::string& basePath, std::string &path, FixPathCaseBehavior b
 
 #endif
 
+DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, int _flags) : basePath(_basePath), flags(_flags) {
+	File::CreateFullPath(basePath);
+	hAlloc = _hAlloc;
+}
+
 std::string DirectoryFileHandle::GetLocalPath(std::string& basePath, std::string localpath)
 {
 	if (localpath.empty())
@@ -324,11 +329,6 @@ void DirectoryFileHandle::Close()
 	if (hFile != -1)
 		close(hFile);
 #endif
-}
-
-DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath) : basePath(_basePath) {
-	File::CreateFullPath(basePath);
-	hAlloc = _hAlloc;
 }
 
 void DirectoryFileSystem::CloseAll() {

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -86,7 +86,7 @@ struct DirectoryFileHandle
 
 class DirectoryFileSystem : public IFileSystem {
 public:
-	DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath);
+	DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, int _flags = 0);
 	~DirectoryFileSystem();
 
 	void CloseAll();
@@ -108,6 +108,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to);
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
+	int Flags() { return flags; }
 
 private:
 	struct OpenFileEntry {
@@ -120,7 +121,7 @@ private:
 	EntryMap entries;
 	std::string basePath;
 	IHandleAllocator *hAlloc;
-
+	int flags;
 	// In case of Windows: Translate slashes, etc.
 	std::string GetLocalPath(std::string localpath);
 };

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -150,6 +150,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to);
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
+	int Flags() { return 0; }
 
 private:
 	struct OpenFileEntry {

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -50,6 +50,10 @@ enum DevType
 	PSP_DEV_TYPE_ALIAS = 0x20,
 };
 
+enum FileSystemFlags
+{
+	FILESYSTEM_SIMULATE_FAT32 = 1,
+};
 
 class IHandleAllocator {
 public:
@@ -112,6 +116,7 @@ public:
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 	virtual int      DevType(u32 handle) = 0;
+	virtual int      Flags() = 0;
 };
 
 
@@ -133,7 +138,8 @@ public:
 	virtual bool RemoveFile(const std::string &filename) {return false;}
 	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
-	virtual int DevType(u32 handle) {return 0;}
+	virtual int DevType(u32 handle) { return 0; }
+	virtual int Flags() { return 0; }
 };
 
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -41,6 +41,7 @@ public:
 	bool     OwnsHandle(u32 handle);
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 	int      DevType(u32 handle);
+	int      Flags() { return 0; }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size);
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -255,6 +255,10 @@ std::string MetaFileSystem::NormalizePrefix(std::string prefix) const {
 	if (startsWith(prefix, "host"))
 		prefix = "host0:";
 
+	// Should we simply make this case insensitive?
+	if (prefix == "DISC0:")
+		prefix = "disc0:";
+
 	return prefix;
 }
 
@@ -282,6 +286,13 @@ void MetaFileSystem::Remount(IFileSystem *oldSystem, IFileSystem *newSystem) {
 			it->system = newSystem;
 		}
 	}
+}
+
+IFileSystem *MetaFileSystem::GetSystemFromFilename(const std::string &filename) {
+	size_t prefixPos = filename.find(':');
+	if (prefixPos == filename.npos)
+		return 0;
+	return GetSystem(filename.substr(0, prefixPos + 1));
 }
 
 IFileSystem *MetaFileSystem::GetSystem(const std::string &prefix) {

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -54,6 +54,7 @@ public:
 	void Remount(IFileSystem *oldSystem, IFileSystem *newSystem);
 
 	IFileSystem *GetSystem(const std::string &prefix);
+	IFileSystem *GetSystemFromFilename(const std::string &filename);
 
 	void ThreadEnded(int threadID);
 
@@ -106,6 +107,7 @@ public:
 	virtual bool RemoveFile(const std::string &filename);
 	virtual int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 	virtual int  DevType(u32 handle);
+	virtual int  Flags() { return 0; }
 
 	// Convenience helper - returns < 0 on failure.
 	int ReadEntireFile(const std::string &filename, std::vector<u8> &data);

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -40,6 +40,7 @@ public:
 	int      DevType(u32 handle);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	std::vector<PSPFileInfo> GetDirListing(std::string path);
+	int  Flags() { return 0; }
 
 	// unsupported operations
 	size_t  WriteFile(u32 handle, const u8 *pointer, s64 size);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1927,10 +1927,10 @@ u32 sceIoDopen(const char *path) {
 
 // For some reason strncpy will fill up the entire output buffer. No reason to do that,
 // so we use this trivial replacement.
-static void strcpy_limit(char *dest, const char *src, int count) {
+static void strcpy_limit(char *dest, const char *src, int limit) {
 	int i;
-	for (i = 0; i < count; i++) {
-		if (!src[i])  // Do the check afterwards, so we don't exit before copying the null terminator.
+	for (i = 0; i < limit - 1; i++) {
+		if (!src[i])
 			break;
 		dest[i] = src[i];
 	}


### PR DESCRIPTION
Flag filesystems as being FAT32 and thus providing this extra struct with short filename etc, instead of checking for "ms0:".

Also replace the strncpy with something that won't write a lot more bytes than needed.
