### PR TITLE
Use flags to avoid hashing textures when unchanged

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -226,7 +226,7 @@ void __DisplayDoState(PointerWrap &p) {
 	CoreTiming::RestoreRegisterEvent(afterFlipEvent, "AfterFlip", &hleAfterFlip);
 
 	p.Do(gstate);
-	p.Do(gstate_c);
+	gstate_c.DoState(p);
 #ifndef _XBOX
 	if (s < 2) {
 		// This shouldn't have been savestated anyway, but it was.

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -428,7 +428,7 @@ void FramebufferManagerDX9::SetRenderFrameBuffer() {
 
 	// None found? Create one.
 	if (!vfb) {
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		vfb = new VirtualFramebufferDX9();
 		vfb->fbo = 0;
 		vfb->fb_address = fb_address;
@@ -512,7 +512,7 @@ void FramebufferManagerDX9::SetRenderFrameBuffer() {
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		vfb->last_frame_render = gpuStats.numFlips;
 		frameLastFramebufUsed = gpuStats.numFlips;
 		vfb->dirtyAfterDisplay = true;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -520,7 +520,7 @@ void DIRECTX9_GPU::CopyDisplayToOutputInternal() {
 
 	shaderManager_->EndFrame();
 
-	gstate_c.textureChanged = true;
+	gstate_c.textureChanged = TEXCHANGE_UPDATED;
 }
 
 // Maybe should write this in ASM...
@@ -737,7 +737,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_REGION2:
 		if (diff) {
 			gstate_c.framebufChanged = true;
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		}
 		break;
 
@@ -751,7 +751,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 
 	case GE_CMD_TEXTUREMAPENABLE:
 		if (diff)
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		break;
 
 	case GE_CMD_LIGHTINGENABLE:
@@ -829,7 +829,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFPIXFORMAT:
 		if (diff) {
 			gstate_c.framebufChanged = true;
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		}
 		break;
 
@@ -841,7 +841,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_TEXADDR5:
 	case GE_CMD_TEXADDR6:
 	case GE_CMD_TEXADDR7:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		shaderManager_->DirtyUniform(DIRTY_UVSCALEOFFSET);
 		break;
 
@@ -853,18 +853,18 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_TEXBUFWIDTH5:
 	case GE_CMD_TEXBUFWIDTH6:
 	case GE_CMD_TEXBUFWIDTH7:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		break;
 
 	case GE_CMD_CLUTADDR:
 	case GE_CMD_CLUTADDRUPPER:
 	case GE_CMD_CLUTFORMAT:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		// This could be used to "dirty" textures with clut.
 		break;
 
 	case GE_CMD_LOADCLUT:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		textureCache_.LoadClut();
 		// This could be used to "dirty" textures with clut.
 		break;
@@ -897,7 +897,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 			DoBlockTransfer();
 
 			// Fixes Gran Turismo's funky text issue.
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 			break;
 		}
 
@@ -913,7 +913,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_TEXSIZE5:
 	case GE_CMD_TEXSIZE6:
 	case GE_CMD_TEXSIZE7:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		break;
 
 	case GE_CMD_ZBUFPTR:
@@ -1046,7 +1046,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_VIEWPORTZ2:
 		if (diff) {
 			gstate_c.framebufChanged = true;
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		}
 		break;
 
@@ -1381,7 +1381,7 @@ void DIRECTX9_GPU::DoState(PointerWrap &p) {
 	textureCache_.Clear(true);
 	transformDraw_.ClearTrackedVertexArrays();
 
-	gstate_c.textureChanged = true;
+	gstate_c.textureChanged = TEXCHANGE_UPDATED;
 	framebufferManager_.DestroyAllFBOs();
 	shaderManager_->ClearCache(true);
 }

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -112,11 +112,11 @@ static bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margin = 0.1
 void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
-	if (gstate_c.textureChanged) {
+	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED) {
 		if (gstate.isTextureMapEnabled()) {
 			textureCache_->SetTexture();
 		}
-		gstate_c.textureChanged = false;
+		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
 	}
 
 	// TODO: The top bit of the alpha channel should be written to the stencil bit somehow. This appears to require very expensive multipass rendering :( Alternatively, one could do a

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -755,9 +755,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 
 	// None found? Create one.
 	if (!vfb) {
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		vfb = new VirtualFramebuffer();
 		vfb->fbo = 0;
 		vfb->fb_address = fb_address;
@@ -861,9 +859,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		vfb->last_frame_render = gpuStats.numFlips;
 		frameLastFramebufUsed = gpuStats.numFlips;
 		vfb->dirtyAfterDisplay = true;
@@ -1195,9 +1191,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 			glEnable(GL_DITHER);
 		} else {
 			nvfb->usageFlags |= FB_USAGE_RENDERTARGET;
-			if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-			}
+			gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 			nvfb->last_frame_render = gpuStats.numFlips;
 			nvfb->dirtyAfterDisplay = true;
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -755,7 +755,9 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 
 	// None found? Create one.
 	if (!vfb) {
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		vfb = new VirtualFramebuffer();
 		vfb->fbo = 0;
 		vfb->fb_address = fb_address;
@@ -859,7 +861,9 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		vfb->last_frame_render = gpuStats.numFlips;
 		frameLastFramebufUsed = gpuStats.numFlips;
 		vfb->dirtyAfterDisplay = true;
@@ -1191,7 +1195,9 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 			glEnable(GL_DITHER);
 		} else {
 			nvfb->usageFlags |= FB_USAGE_RENDERTARGET;
-			gstate_c.textureChanged = true;
+			if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+			}
 			nvfb->last_frame_render = gpuStats.numFlips;
 			nvfb->dirtyAfterDisplay = true;
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -906,9 +906,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_REGION1:
 	case GE_CMD_REGION2:
 		gstate_c.framebufChanged = true;
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_CLIPENABLE:
@@ -970,9 +968,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_SCISSOR1:
 	case GE_CMD_SCISSOR2:
 		gstate_c.framebufChanged = true;
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 		///
@@ -984,9 +980,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFWIDTH:
 	case GE_CMD_FRAMEBUFPIXFORMAT:
 		gstate_c.framebufChanged = true;
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_TEXADDR0:
@@ -1001,9 +995,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXADDR5:
 	case GE_CMD_TEXADDR6:
 	case GE_CMD_TEXADDR7:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_TEXBUFWIDTH0:
@@ -1017,15 +1009,11 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXBUFWIDTH5:
 	case GE_CMD_TEXBUFWIDTH6:
 	case GE_CMD_TEXBUFWIDTH7:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_CLUTFORMAT:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		// This could be used to "dirty" textures with clut.
 		break;
 
@@ -1035,9 +1023,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_LOADCLUT:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		textureCache_.LoadClut();
 		// This could be used to "dirty" textures with clut.
 		break;
@@ -1080,9 +1066,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 			gstate_c.curTextureHeight = gstate.getTextureHeight(0);
 			shaderManager_->DirtyUniform(DIRTY_UVSCALEOFFSET);
 			// We will need to reset the texture now.
-			if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-			}
+			gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		}
 		break;
 
@@ -1093,9 +1077,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXSIZE5:
 	case GE_CMD_TEXSIZE6:
 	case GE_CMD_TEXSIZE7:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_ZBUFPTR:
@@ -1216,9 +1198,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_VIEWPORTZ1:
 	case GE_CMD_VIEWPORTZ2:
 		gstate_c.framebufChanged = true;
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	case GE_CMD_LIGHTENABLE0:
@@ -1292,9 +1272,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXMODE:
 	case GE_CMD_TEXFILTER:
 	case GE_CMD_TEXWRAP:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	//////////////////////////////////////////////////////////////////
@@ -1573,9 +1551,7 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 #endif
 
 	case GE_CMD_TEXLEVEL:
-		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
-		}
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 		break;
 
 	//////////////////////////////////////////////////////////////////

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -610,7 +610,7 @@ void GLES_GPU::CopyDisplayToOutputInternal() {
 #endif
 #endif
 
-	gstate_c.textureChanged = true;
+	gstate_c.textureChanged = TEXCHANGE_UPDATED;
 }
 
 // Maybe should write this in ASM...
@@ -906,7 +906,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_REGION1:
 	case GE_CMD_REGION2:
 		gstate_c.framebufChanged = true;
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_CLIPENABLE:
@@ -968,7 +970,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_SCISSOR1:
 	case GE_CMD_SCISSOR2:
 		gstate_c.framebufChanged = true;
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 		///
@@ -980,11 +984,13 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_FRAMEBUFWIDTH:
 	case GE_CMD_FRAMEBUFPIXFORMAT:
 		gstate_c.framebufChanged = true;
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_TEXADDR0:
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		shaderManager_->DirtyUniform(DIRTY_UVSCALEOFFSET);
 		break;
 
@@ -995,10 +1001,15 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXADDR5:
 	case GE_CMD_TEXADDR6:
 	case GE_CMD_TEXADDR7:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_TEXBUFWIDTH0:
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
+		break;
+
 	case GE_CMD_TEXBUFWIDTH1:
 	case GE_CMD_TEXBUFWIDTH2:
 	case GE_CMD_TEXBUFWIDTH3:
@@ -1006,11 +1017,15 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXBUFWIDTH5:
 	case GE_CMD_TEXBUFWIDTH6:
 	case GE_CMD_TEXBUFWIDTH7:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_CLUTFORMAT:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		// This could be used to "dirty" textures with clut.
 		break;
 
@@ -1020,7 +1035,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_LOADCLUT:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		textureCache_.LoadClut();
 		// This could be used to "dirty" textures with clut.
 		break;
@@ -1051,19 +1068,21 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 			DoBlockTransfer();
 
 			// Fixes Gran Turismo's funky text issue, since it overwrites the current texture.
-			gstate_c.textureChanged = true;
+			gstate_c.textureChanged = TEXCHANGE_UPDATED;
 			break;
 		}
 
 	case GE_CMD_TEXSIZE0:
 		// Render to texture may have overridden the width/height.
 		// Don't reset it unless the size is different / the texture has changed.
-		if (diff || gstate_c.textureChanged) {
+		if (diff || gstate_c.textureChanged != TEXCHANGE_UNCHANGED) {
 			gstate_c.curTextureWidth = gstate.getTextureWidth(0);
 			gstate_c.curTextureHeight = gstate.getTextureHeight(0);
 			shaderManager_->DirtyUniform(DIRTY_UVSCALEOFFSET);
 			// We will need to reset the texture now.
-			gstate_c.textureChanged = true;
+			if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+			}
 		}
 		break;
 
@@ -1074,7 +1093,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXSIZE5:
 	case GE_CMD_TEXSIZE6:
 	case GE_CMD_TEXSIZE7:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_ZBUFPTR:
@@ -1195,7 +1216,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_VIEWPORTZ1:
 	case GE_CMD_VIEWPORTZ2:
 		gstate_c.framebufChanged = true;
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	case GE_CMD_LIGHTENABLE0:
@@ -1262,11 +1285,16 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	case GE_CMD_TEXFLUSH:
 		break;
 
-	case GE_CMD_TEXMODE:
 	case GE_CMD_TEXFORMAT:
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
+		break;
+
+	case GE_CMD_TEXMODE:
 	case GE_CMD_TEXFILTER:
 	case GE_CMD_TEXWRAP:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	//////////////////////////////////////////////////////////////////
@@ -1545,7 +1573,9 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 #endif
 
 	case GE_CMD_TEXLEVEL:
-		gstate_c.textureChanged = true;
+		if (gstate_c.textureChanged == TEXCHANGE_UNCHANGED) {
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+		}
 		break;
 
 	//////////////////////////////////////////////////////////////////
@@ -1785,7 +1815,7 @@ void GLES_GPU::DoState(PointerWrap &p) {
 		textureCache_.Clear(true);
 		transformDraw_.ClearTrackedVertexArrays();
 
-		gstate_c.textureChanged = true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		framebufferManager_.DestroyAllFBOs();
 	}
 }

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -166,9 +166,9 @@ static inline bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margi
 void TransformDrawEngine::ApplyDrawState(int prim) {
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
-	if (gstate_c.textureChanged && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
+	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
 		textureCache_->SetTexture();
-		gstate_c.textureChanged = false;
+		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
 	}
 
 	// TODO: The top bit of the alpha channel should be written to the stencil bit somehow. This appears to require very expensive multipass rendering :( Alternatively, one could do a

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -923,7 +923,7 @@ void TextureCache::SetTexture(bool force) {
 		bool doDelete = true;
 
 		// If we only loaded a clut, or changed framebuf or something, we don't need to rehash the texture data.
-		if (gstate_c.textureChanged == TEXCHANGE_PARAMSONLY) {
+		if ((gstate_c.textureChanged & TEXCHANGE_UPDATED) == 0) {
 			rehash = false;
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -922,6 +922,11 @@ void TextureCache::SetTexture(bool force) {
 		bool rehash = entry->GetHashStatus() == TexCacheEntry::STATUS_UNRELIABLE;
 		bool doDelete = true;
 
+		// If we only loaded a clut, or changed framebuf or something, we don't need to rehash the texture data.
+		if (gstate_c.textureChanged == TEXCHANGE_PARAMSONLY) {
+			rehash = false;
+		}
+
 		if (match) {
 			if (entry->lastFrame != gpuStats.numFlips) {
 				u32 diff = gpuStats.numFlips - entry->lastFrame;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -648,7 +648,7 @@ void GPUCommon::ProcessDLQueueInternal() {
 	UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
 
 	// Game might've written new texture data.
-	gstate_c.textureChanged = true;
+	gstate_c.textureChanged = TEXCHANGE_UPDATED;
 
 	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -23,6 +23,8 @@
 #include "ge_constants.h"
 #include "Common/Common.h"
 
+class PointerWrap;
+
 // PSP uses a curious 24-bit float - it's basically the top 24 bits of a regular IEEE754 32-bit float.
 // This is used for light positions, transform matrices, you name it.
 inline float getFloat24(unsigned int data)
@@ -432,6 +434,12 @@ struct UVScale {
 	float uOff, vOff;
 };
 
+enum TextureChangeReason {
+	TEXCHANGE_UNCHANGED,
+	TEXCHANGE_UPDATED,
+	TEXCHANGE_PARAMSONLY,
+};
+
 struct GPUStateCache
 {
 	u32 vertexAddr;
@@ -439,7 +447,7 @@ struct GPUStateCache
 
 	u32 offsetAddr;
 
-	bool textureChanged;
+	TextureChangeReason textureChanged;
 	bool textureFullAlpha;
 	bool vertexFullAlpha;
 	bool framebufChanged;
@@ -468,6 +476,7 @@ struct GPUStateCache
 	u32 curRTHeight;
 
 	u32 getRelativeAddress(u32 data) const;
+	void DoState(PointerWrap &p);
 };
 
 // TODO: Implement support for these.

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -435,9 +435,9 @@ struct UVScale {
 };
 
 enum TextureChangeReason {
-	TEXCHANGE_UNCHANGED,
-	TEXCHANGE_UPDATED,
-	TEXCHANGE_PARAMSONLY,
+	TEXCHANGE_UNCHANGED = 0x00,
+	TEXCHANGE_UPDATED = 0x01,
+	TEXCHANGE_PARAMSONLY = 0x02,
 };
 
 struct GPUStateCache
@@ -447,7 +447,7 @@ struct GPUStateCache
 
 	u32 offsetAddr;
 
-	TextureChangeReason textureChanged;
+	u8 textureChanged;
 	bool textureFullAlpha;
 	bool vertexFullAlpha;
 	bool framebufChanged;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -214,7 +214,7 @@ void NullGPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_TEXADDR0:
-		gstate_c.textureChanged=true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 	case GE_CMD_TEXADDR1:
 	case GE_CMD_TEXADDR2:
 	case GE_CMD_TEXADDR3:
@@ -226,7 +226,7 @@ void NullGPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_TEXBUFWIDTH0:
-		gstate_c.textureChanged=true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 	case GE_CMD_TEXBUFWIDTH1:
 	case GE_CMD_TEXBUFWIDTH2:
 	case GE_CMD_TEXBUFWIDTH3:
@@ -314,7 +314,7 @@ void NullGPU::ExecuteOp(u32 op, u32 diff) {
 		}
 
 	case GE_CMD_TEXSIZE0:
-		gstate_c.textureChanged=true;
+		gstate_c.textureChanged = TEXCHANGE_UPDATED;
 		gstate_c.curTextureWidth = 1 << (gstate.texsize[0] & 0xf);
 		gstate_c.curTextureHeight = 1 << ((gstate.texsize[0]>>8) & 0xf);
 		//fall thru - ignoring the mipmap sizes for now


### PR DESCRIPTION
If only parameters change (like wrapping or clut, etc.) we don't need to rehash the data - we know it hasn't changed.

Should reduce the distance between lazy texture hashing on and off.

This improves performance mainly in 2D games.  For example Popolocrois is quite happy with this change, as well as Valkyrie Profile.  However, some 3D games benefited from it as well.

-[Unknown]
