### PR TITLE
Fix texture cache invalidation...

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -138,8 +138,8 @@ void TextureCache::Invalidate(u32 addr, int size, GPUInvalidationType type) {
 
 	// They could invalidate inside the texture, let's just give a bit of leeway.
 	const int LARGEST_TEXTURE_SIZE = 512 * 512 * 4;
-	u64 startKey = addr - LARGEST_TEXTURE_SIZE;
-	u64 endKey = addr + size + LARGEST_TEXTURE_SIZE;
+	u64 startKey = (u64)(addr - LARGEST_TEXTURE_SIZE) << 32;
+	u64 endKey = (u64)(addr + size + LARGEST_TEXTURE_SIZE) << 32;
 	for (TexCache::iterator iter = cache.lower_bound(startKey), end = cache.upper_bound(endKey); iter != end; ++iter) {
 		u32 texAddr = iter->second.addr;
 		u32 texEnd = iter->second.addr + iter->second.sizeInRAM;


### PR DESCRIPTION
Uhh, so this has apparently been broken for a while.  The address is intentionally in the high bits.

With the backoff off (default), we don't use this code.  It's only used with backoff on.  It definitely may have been causing graphical glitches.

This could potentially:
- Make the backoff cache slower, hashing more often.
- Fix glitches with backoff on without much perf hit.
- Have almost no impact whatsoever.

I haven't really tested this and don't have time atm, but I'm worried it will just make it slower mainly.  If so, we should just remove the invalidation altogether I guess, since it's not been actually... invalidating.

-[Unknown]
