### PR TITLE
Disable logging on mobile device

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -256,7 +256,11 @@ struct ConfigSectionSettings {
 static ConfigSetting generalSettings[] = {
 	ConfigSetting("FirstRun", &g_Config.bFirstRun, true),
 	ConfigSetting("RunCount", &g_Config.iRunCount, 0),
+#ifdef MOBILE_DEVICE
+	ConfigSetting("Enable Logging", &g_Config.bEnableLogging, false),
+#else
 	ConfigSetting("Enable Logging", &g_Config.bEnableLogging, true),
+#endif
 	ConfigSetting("AutoRun", &g_Config.bAutoRun, true),
 	ConfigSetting("Browse", &g_Config.bBrowse, false),
 	ConfigSetting("IgnoreBadMemAccess", &g_Config.bIgnoreBadMemAccess, true),


### PR DESCRIPTION
I just came across that logging make some games slower on my mobile device.I think most of the people here generate and paste log from windows platform but not from mobile device .

Probably good enough to disable logging on mobile device ? ( or somebody always getting log from mobile device using third-party tools ?)
