### PR TITLE
Ignore uncached/kernel bits in texture cache

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -460,6 +460,9 @@ void RestoreReplacedInstruction(u32 address) {
 }
 
 void RestoreReplacedInstructions(u32 startAddr, u32 endAddr) {
+	// Need to be in order, or we'll hang.
+	if (endAddr > startAddr)
+		std::swap(endAddr, startAddr);
 	const auto start = replacedInstructions.lower_bound(startAddr);
 	const auto end = replacedInstructions.upper_bound(endAddr);
 	int restored = 0;


### PR DESCRIPTION
Although I suppose we could respect uncached and never cache... don't really think that makes sense, though.

Possibly #5879.  The only reason I can think of for this to hang is if cacheKeyEnd < cacheKey due to wrapping and silly parameters to sceKernelDcacheInvalidateRange() or etc.  But might as well make it so invalidation works (since we mask the top bits off there too.)

-[Unknown]
