### PR TITLE
Changed translation category

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -246,7 +246,7 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *lowAudio = audioSettings->Add(new CheckBox(&g_Config.bLowLatencyAudio, a->T("Low latency audio")));
 	lowAudio->SetEnabledPtr(&g_Config.bEnableSound);
 
-	audioSettings->Add(new ItemHeader(ms->T("Audio hacks")));
+	audioSettings->Add(new ItemHeader(a->T("Audio hacks")));
 	audioSettings->Add(new CheckBox(&g_Config.bSoundSpeedHack, a->T("Sound speed hack (DOA etc.)")));
 
 	// Control


### PR DESCRIPTION
"Audio hacks" is not a "Main Setting", it should belong to "Audio".
