### PR TITLE
Reorganize OSK button a bit , nothing new

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -874,22 +874,23 @@ int PSPOskDialog::Update(int animSpeed) {
 
 	I18NCategory *d = GetI18NCategory("Dialog");
 
-	PPGeDrawImage(I_SQUARE, 85, 195, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(d->T("Space"), 115, 195, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(I_SQUARE, 365, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(d->T("Space"), 395, 220, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
 	if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE) {
-		PPGeDrawImage(I_CROSS, 85, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(I_CIRCLE, 85, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(I_CROSS, 45, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(I_CIRCLE, 45, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 	} else {
-		PPGeDrawImage(I_CIRCLE, 85, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(I_CROSS, 85, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(I_CIRCLE, 45, 220, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(I_CROSS, 45, 245, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
 	}
 
-	PPGeDrawText(d->T("Select"), 115, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(d->T("Delete"), 115, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(d->T("Select"), 75, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(d->T("Delete"), 75, 247, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 
-	PPGeDrawText("Start", 195, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(d->T("Finish"), 235, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Start", 135, 220, PPGE_ALIGN_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(d->T("Finish"), 185, 222, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+
 
 	int index = (currentKeyboardLanguage - 1) % OSK_LANGUAGE_COUNT;
 	const char *countryCode;


### PR DESCRIPTION
Probably later we'll have a new OSK from @theax  :)  

Before
![ulus10202_00001](https://cloud.githubusercontent.com/assets/3000282/2777565/6561144c-cae7-11e3-89a7-410df285b210.jpg)

After
![ulus10202_00002](https://cloud.githubusercontent.com/assets/3000282/2777566/6771c2b8-cae7-11e3-8257-2aa3ab45dac2.jpg)
