### PR TITLE
Workaround the mp3 sound hack

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -148,9 +148,6 @@ public:
 	int iSFXVolume;
 	int iBGMVolume;
 
-	// Audio Hack
-	bool bSoundSpeedHack;
-
 	// UI
 	bool bShowDebuggerOnLoad;
 	int iShowFPSCounter;

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -160,7 +160,7 @@ bool SimpleAudio::ResetCodecCtx(int channels, int samplerate){
 	}
 
 	codecCtx_->channels = channels;
-	codecCtx_->channel_layout = channels==2?AV_CH_LAYOUT_STEREO:AV_CH_LAYOUT_MONO;
+	codecCtx_->channel_layout = channels == 2 ? AV_CH_LAYOUT_STEREO : AV_CH_LAYOUT_MONO;
 	codecCtx_->sample_rate = samplerate;
 	// Open codec
 	AVDictionary *opts = 0;
@@ -307,15 +307,9 @@ u32 AuCtx::AuDecode(u32 pcmAddr)
 	memset(outbuf, 0, PCMBufSize); // important! empty outbuf to avoid noise
 	u32 outpcmbufsize = 0;
 
-	int repeat = 1;
-	if (g_Config.bSoundSpeedHack){
-		repeat = 2;
-	}
-	int i = 0;
 	// decode frames in sourcebuff and output into PCMBuf (each time, we decode one or two frames)
 	// some games as Miku like one frame each time, some games like DOA like two frames each time
-	while (sourcebuff.size() > 0 && outpcmbufsize < PCMBufSize && i < repeat){
-		i++;
+	while (sourcebuff.size() > 0 && outpcmbufsize < PCMBufSize){
 		int pcmframesize;
 		// decode
 		decoder->Decode((void*)sourcebuff.c_str(), (int)sourcebuff.size(), outbuf, &pcmframesize);
@@ -344,6 +338,9 @@ u32 AuCtx::AuDecode(u32 pcmAddr)
 		outbuf += pcmframesize;
 		// increase FrameNum count
 		FrameNum++;
+
+		if (LoopNum)
+			break;
 	}
 	Memory::Write_U32(PCMBuf, pcmAddr);
 	return outpcmbufsize;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -246,9 +246,6 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *lowAudio = audioSettings->Add(new CheckBox(&g_Config.bLowLatencyAudio, a->T("Low latency audio")));
 	lowAudio->SetEnabledPtr(&g_Config.bEnableSound);
 
-	audioSettings->Add(new ItemHeader(a->T("Audio hacks")));
-	audioSettings->Add(new CheckBox(&g_Config.bSoundSpeedHack, a->T("Sound speed hack (DOA etc.)")));
-
 	// Control
 	ViewGroup *controlsSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	LinearLayout *controlsSettings = new LinearLayout(ORIENT_VERTICAL);


### PR DESCRIPTION
It is by observation the difference between various titles which uses mp3 on the return LoopNum so i treated it as workaround. All other titles will always return -1 for loopNum while DOA return 0 instead . 

As always , we may need test later to see how real PSP handle this case.

@sum2012 / @solarmystic can help to test a bit.
