### PR TITLE
Enable --escape-exit for all relevant (e.g. non-mobile) platforms. 

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -75,7 +75,7 @@ public:
 #endif
 
 #if !defined(MOBILE_DEVICE)
-	bool bEscapeExitsEmulator;
+	bool bPauseExitsEmulator;
 #endif
 
 	// Core

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -72,8 +72,12 @@ public:
 	bool bTopMost;
 	std::string sFont;
 	bool bIgnoreWindowsKey;
+#endif
+
+#if !defined(MOBILE_DEVICE)
 	bool bEscapeExitsEmulator;
 #endif
+
 	// Core
 	bool bIgnoreBadMemAccess;
 	bool bFastMemory;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -28,6 +28,11 @@
 // in NativeShutdown.
 
 #include <locale.h>
+// Linux doesn't like using std::find with std::vector<int> without this :/
+#if !defined(MOBILE_DEVICE)
+#include <algorithm>
+#endif
+
 #ifdef _WIN32
 #include <libpng16/png.h>
 #include "ext/jpge/jpge.h"

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -79,6 +79,10 @@
 #include "UI/MiscScreens.h"
 #include "UI/TiltEventProcessor.h"
 
+#if !defined(MOBILE_DEVICE)
+#include "Common/KeyMap.h"
+#endif
+
 // The new UI framework, for initialization
 
 static UI::Theme ui_theme;
@@ -322,7 +326,7 @@ void NativeInit(int argc, const char *argv[],
 					stateToLoad = argv[i] + strlen("--state=");
 #if !defined(MOBILE_DEVICE)
 				if (!strncmp(argv[i], "--escape-exit", strlen("--escape-exit")))
-					g_Config.bEscapeExitsEmulator = true;
+					g_Config.bPauseExitsEmulator = true;
 #endif
 				break;
 			}
@@ -689,8 +693,15 @@ void NativeTouch(const TouchInput &touch) {
 void NativeKey(const KeyInput &key) {
 	// ILOG("Key code: %i flags: %i", key.keyCode, key.flags);
 #if !defined(MOBILE_DEVICE)
-	if (g_Config.bEscapeExitsEmulator && key.keyCode == NKCODE_ESCAPE) {
-		System_SendMessage("finish", "");
+	if (g_Config.bPauseExitsEmulator) {
+		static std::vector<int> pspKeys;
+		pspKeys.clear();
+		if (KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys)) {
+			if (std::find(pspKeys.begin(), pspKeys.end(), VIRTKEY_PAUSE) != pspKeys.end()) {
+				System_SendMessage("finish", "");
+				return;
+			}
+		}
 	}
 #endif
 	g_buttonTracker.Process(key);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -320,6 +320,10 @@ void NativeInit(int argc, const char *argv[],
 					fileToLog = argv[i] + strlen("--log=");
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))
 					stateToLoad = argv[i] + strlen("--state=");
+#if !defined(MOBILE_DEVICE)
+				if (!strncmp(__argv[i], "--escape-exit", strlen("--escape-exit")))
+					g_Config.bEscapeExitsEmulator = true;
+#endif
 				break;
 			}
 		} else {
@@ -684,6 +688,11 @@ void NativeTouch(const TouchInput &touch) {
 
 void NativeKey(const KeyInput &key) {
 	// ILOG("Key code: %i flags: %i", key.keyCode, key.flags);
+#if !defined(MOBILE_DEVICE)
+	if (g_Config.bEscapeExitsEmulator && key.keyCode == NKCODE_ESCAPE) {
+		System_SendMessage("finish", "");
+	}
+#endif
 	g_buttonTracker.Process(key);
 	if (screenManager)
 		screenManager->key(key);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -321,7 +321,7 @@ void NativeInit(int argc, const char *argv[],
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))
 					stateToLoad = argv[i] + strlen("--state=");
 #if !defined(MOBILE_DEVICE)
-				if (!strncmp(__argv[i], "--escape-exit", strlen("--escape-exit")))
+				if (!strncmp(argv[i], "--escape-exit", strlen("--escape-exit")))
 					g_Config.bEscapeExitsEmulator = true;
 #endif
 				break;

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -118,11 +118,6 @@ namespace WindowsRawInput {
 			return;
 		}
 
-		if (g_Config.bEscapeExitsEmulator && raw->data.keyboard.VKey == VK_ESCAPE) {
-			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
-			return;
-		}
-
 		KeyInput key;
 		key.deviceId = DEVICE_ID_KEYBOARD;
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -168,7 +168,11 @@ std::string System_GetProperty(SystemProperty prop) {
 	}
 }
 
-void System_SendMessage(const char *command, const char *parameter) {}
+void System_SendMessage(const char *command, const char *parameter) {
+	if (!strcmp(command, "finish")) {
+		PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+	}
+}
 
 void EnableCrashingOnCrashes() 
 { 
@@ -340,9 +344,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 			if (!strncmp(__argv[i], "--windowed", strlen("--windowed")))
 				g_Config.bFullScreen = false;
-
-			if (!strncmp(__argv[i], "--escapeexitsemu", strlen("--escapeexitsemu")))
-				g_Config.bEscapeExitsEmulator = true;
 		}
 	}
 #ifdef _DEBUG


### PR DESCRIPTION
Whoops, branch name should've been escapeExitOption. Whatever.

It makes PPSSPP more front-end friendly by letting escape (and whatever else is bound to Pause) quit the emu. Its name makes more sense now, and *nix users can join in the fun.

The option will stay named as escape-exit though, since the primary audience likely uses escape anyway.
