### PR TITLE
Attempt to fix prince of persia that failed to bootup/psmf video playback

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -931,7 +931,8 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
 		*player = 0;
 		return SCE_KERNEL_ERROR_ILLEGAL_ADDRESS;
 	}
-	if (data->bufferSize < 0x00300000) {
+	// Prince of persia return 0x00285800 for buffer size . It is 0x00300000 from PSP test.
+	if (data->bufferSize < 0x00280000) {
 		ERROR_LOG_REPORT(ME, "scePsmfPlayerCreate(%08x, %08x): buffer too small %08x", psmfPlayer, dataPtr, data->bufferSize);
 		*player = 0;
 		return ERROR_PSMFPLAYER_BUFFER_SIZE;


### PR DESCRIPTION
It hits buffer too small and failed to create psmf player . Probably this one may break the PSP tests that done earlier by @unknownbrackets 
