### PR TITLE
Fix video flicker, add memchecks and detect no audio better

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -740,7 +740,6 @@ bool InitPmp(MpegContext * ctx){
 	InitFFmpeg();
 	auto mediaengine = ctx->mediaengine;
 	mediaengine->m_isVideoEnd = false;
-	mediaengine->m_noAudioData = false;
 	mediaengine->m_firstTimeStamp = 0;
 	mediaengine->m_lastTimeStamp = 0;
 	ctx->mpegFirstTimestamp = 0;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -931,7 +931,7 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
 		*player = 0;
 		return SCE_KERNEL_ERROR_ILLEGAL_ADDRESS;
 	}
-	if (data->bufferSize < 0x00300000) {
+	if (data->bufferSize < 0x00285800) {
 		ERROR_LOG_REPORT(ME, "scePsmfPlayerCreate(%08x, %08x): buffer too small %08x", psmfPlayer, dataPtr, data->bufferSize);
 		*player = 0;
 		return ERROR_PSMFPLAYER_BUFFER_SIZE;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1318,7 +1318,9 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 			if (deltapts > 0) {
 				// Don't advance, just return the same frame again.
 				// TODO: This also seems somewhat based on Update() calls, but audio is involved too...
-				psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, videoData->frameWidth, videoPixelMode);
+				int displaybufSize = psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, videoData->frameWidth, videoPixelMode);
+				// Need to invalidate, even if it didn't change, to trigger upload to framebuffer.
+				gpu->InvalidateCache(videoData->displaybuf, displaybufSize, GPU_INVALIDATE_SAFE);
 				psmfplayer->psmfPlayerAvcAu.pts = psmfplayer->mediaengine->getVideoTimeStamp();
 				videoData->displaypts = (u32)psmfplayer->psmfPlayerAvcAu.pts;
 				return hleDelayResult(0, "psmfPlayer behind audio", 3000);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -761,6 +761,9 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 		if (!m_audioContext->Decode(audioFrame, frameSize, buffer, &outbytes)) {
 			ERROR_LOG(ME, "Audio (%s) decode failed during video playback", GetCodecName(m_audioType));
 		}
+#ifndef MOBILE_DEVICE
+		CBreakPoints::ExecMemCheck(bufferPtr, true, outbytes, currentMIPS->pc);
+#endif
 	}
 
 	if (headerCode1 == 0x24) {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -16,8 +16,10 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Core/Config.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/HW/MediaEngine.h"
 #include "Core/MemMap.h"
+#include "Core/MIPS/MIPS.h"
 #include "Core/Reporting.h"
 #include "GPU/GPUInterface.h"
 #include "Core/HW/SimpleAudioDec.h"
@@ -614,6 +616,10 @@ int MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMo
 		ERROR_LOG_REPORT(ME, "Unsupported video pixel format %d", videoPixelMode);
 		break;
 	}
+
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(bufferPtr, true, videoImageSize, currentMIPS->pc);
+#endif
 	return videoImageSize;
 #endif // USE_FFMPEG
 	return 0;
@@ -649,6 +655,9 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineRGBA(imgbuf, data, width);
 			data += m_desWidth * sizeof(u32);
 			imgbuf += frameWidth * sizeof(u32);
+#ifndef MOBILE_DEVICE
+			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u32), true, width * sizeof(u32), currentMIPS->pc);
+#endif
 		}
 		videoImageSize = frameWidth * sizeof(u32) * m_desHeight;
 		break;
@@ -659,6 +668,9 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR5650(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
+#ifndef MOBILE_DEVICE
+			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+#endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;
@@ -669,6 +681,9 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR5551(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
+#ifndef MOBILE_DEVICE
+			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+#endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;
@@ -679,6 +694,9 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR4444(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
+#ifndef MOBILE_DEVICE
+			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+#endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
 		break;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -788,7 +788,6 @@ bool MediaEngine::IsNoAudioData() {
 	// Let's double check.  Here should be a safe enough place to demux.
 	m_demux->demux(m_audioStream);
 	return !m_demux->hasNextAudioFrame(NULL, NULL, NULL, NULL);
-
 }
 
 s64 MediaEngine::getVideoTimeStamp() {

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -87,7 +87,7 @@ public:
 	s64 getLastTimeStamp();
 
 	bool IsVideoEnd() { return m_isVideoEnd; }
-	bool IsNoAudioData() { return m_noAudioData; }
+	bool IsNoAudioData();
 
 	void DoState(PointerWrap &p);
 
@@ -128,7 +128,6 @@ public:  // TODO: Very little of this below should be public.
 	s64 m_lastTimeStamp;
 
 	bool m_isVideoEnd;
-	bool m_noAudioData;
 
 	int m_ringbuffersize;
 	u8 m_mpegheader[0x10000];  // TODO: Allocate separately

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -14,11 +14,12 @@ public:
 	MpegDemux(int size, int offset);
 	~MpegDemux();
 
-	bool addStreamData(u8* buf, int addSize);
+	bool addStreamData(const u8 *buf, int addSize);
 	void demux(int audioChannel);
 
 	// return its framesize
-	int getNextaudioFrame(u8** buf, int *headerCode1, int *headerCode2);
+	int getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2);
+	bool hasNextAudioFrame(int *gotsizeOut, int *frameSizeOut, int *headerCode1, int *headerCode2);
 
 	inline int getRemainSize() {
 		return m_len - m_readSize;


### PR DESCRIPTION
This fixes cases where videos are misdetected as having audio when they don't (or possibly the reverse as well), and fixes the video flicker in Dead or Alive.

-[Unknown]
