### PR TITLE
Let desktop SDL builds see the fullscreen option in the GameSettingsScreen, too.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -125,7 +125,7 @@ void GameSettingsScreen::CreateViews() {
 	postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
 	postProcChoice_->SetEnabled(g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 
-#if defined(_WIN32) || defined(USING_QT_UI)
+#if !defined(MOBILE_DEVICE)
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gs->T("FullScreen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
 #endif
 	graphicsSettings->Add(new CheckBox(&g_Config.bStretchToDisplay, gs->T("Stretch to Display")));
@@ -410,7 +410,12 @@ UI::EventReturn GameSettingsScreen::OnReloadCheats(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnFullscreenChange(UI::EventParams &e) {
+#if defined(USING_WIN_UI) || defined(USING_QT_UI)
 	host->GoFullscreen(g_Config.bFullScreen);
+#else
+	// SDL, basically.
+	System_SendMessage("toggle_fullscreen", "");
+#endif
 	return UI::EVENT_DONE;
 }
 


### PR DESCRIPTION
There doesn't seem to be any reason why they can't, especially when there's a message that can be sent to toggle it in the first place.

I'm not sure what the issue creator in https://github.com/hrydgard/ppsspp/issues/5953 meant by "fullscreen button is missing", but this should resolve the obvious lack of fullscreen-ness.
