### PR TITLE
Win32: Add some MSBuild scripts to build from the command-line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Debug
 Release
 Windows/x64
 Windows/ipch
+Windows/bin-release
 ui_atlas.zim.png
 android/assets
 # For Mac

--- a/Windows/build-x64.cmd
+++ b/Windows/build-x64.cmd
@@ -39,7 +39,7 @@ if not exist %PPSSPP_ROOT%\%RELEASEX64% (
 )
 call msbuild PPSSPP.sln /t:Clean %DBG_PPSSPP% /m
 call msbuild PPSSPP.sln /t:Build %DBG_PPSSPP% /m
-if not exist %PPSSPP_ROOT%\%RELEASEX64% (
+if not exist %PPSSPP_ROOT%\%DEBUGX64% (
     echo Debug build failed.
     goto Quit
 )

--- a/Windows/build-x64.cmd
+++ b/Windows/build-x64.cmd
@@ -1,0 +1,68 @@
+@echo off
+rem // Copyright (c) 2012- PPSSPP Project.
+
+rem // This program is free software: you can redistribute it and/or modify
+rem // it under the terms of the GNU General Public License as published by
+rem // the Free Software Foundation, version 2.0 or later versions.
+
+rem // This program is distributed in the hope that it will be useful,
+rem // but WITHOUT ANY WARRANTY; without even the implied warranty of
+rem // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+rem // GNU General Public License 2.0 for more details.
+
+rem // A copy of the GPL 2.0 should have been included with the program.
+rem // If not, see http://www.gnu.org/licenses/
+
+rem // Official git repository and contact information can be found at
+rem // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+if not defined vs120comntools (
+  echo "Visual Studio 2013 doesn't appear to be installed properly. Quitting."
+  goto quit
+  ) else (
+    call "%vs120comntools%\vsvars32.bat" x86_amd64
+)
+
+set PPSSPP_ROOT=%CD%\..
+set RELEASE_DIR=%CD%\bin-release
+set RELEASE_X64=PPSSPPWindows64.exe
+set DEBUG_X64=PPSSPPDebug64.exe
+
+set RLS_PPSSPP = /p:Configuration=Release;Platform=x64 /m
+set DBG_PPSSPP = /p:Configuration=Debug;Platform=x64 /m
+
+call msbuild PPSSPP.sln /t:Clean %RLS_PPSSPP%
+call msbuild PPSSPP.sln /t:Build %RLS_PPSSPP%
+if not exist %PPSSPP_ROOT%\%RELEASEX64% (
+    echo Release build failed.
+    goto Quit
+)
+call msbuild PPSSPP.sln /t:Clean %DBG_PPSSPP% /m
+call msbuild PPSSPP.sln /t:Build %DBG_PPSSPP% /m
+if not exist %PPSSPP_ROOT%\%RELEASEX64% (
+    echo Debug build failed.
+    goto Quit
+)
+
+if not exist %RELEASE_DIR%\\. (
+  mkdir %RELEASE_DIR%
+) else (
+  rmdir /S /Q %RELEASE_DIR%
+  mkdir %RELEASE_DIR%
+)
+
+cd /d %RELEASE_DIR%
+
+xcopy "%PPSSPP_ROOT%\assets" ".\assets\*" /S
+xcopy "%PPSSPP_ROOT%\flash0" ".\flash0\*" /S
+xcopy "%PPSSPP_ROOT%\lang" ".\lang\*" /S
+
+copy %PPSSPP_ROOT%\LICENSE.txt /Y
+copy %PPSSPP_ROOT%\README.md /Y
+
+copy %PPSSPP_ROOT%\%DEBUG_X64% /Y
+
+copy %PPSSPP_ROOT%\%RELEASE_X64% /Y
+
+:Quit
+pause

--- a/Windows/build-x86.cmd
+++ b/Windows/build-x86.cmd
@@ -39,7 +39,7 @@ if not exist %PPSSPP_ROOT%\%RELEASEX86% (
 )
 call msbuild PPSSPP.sln /t:Clean %DBG_PPSSPP% /m
 call msbuild PPSSPP.sln /t:Build %DBG_PPSSPP% /m
-if not exist %PPSSPP_ROOT%\%RELEASEX86% (
+if not exist %PPSSPP_ROOT%\%DEBUGX86% (
     echo Debug build failed.
     goto Quit
 )

--- a/Windows/build-x86.cmd
+++ b/Windows/build-x86.cmd
@@ -1,0 +1,68 @@
+@echo off
+rem // Copyright (c) 2012- PPSSPP Project.
+
+rem // This program is free software: you can redistribute it and/or modify
+rem // it under the terms of the GNU General Public License as published by
+rem // the Free Software Foundation, version 2.0 or later versions.
+
+rem // This program is distributed in the hope that it will be useful,
+rem // but WITHOUT ANY WARRANTY; without even the implied warranty of
+rem // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+rem // GNU General Public License 2.0 for more details.
+
+rem // A copy of the GPL 2.0 should have been included with the program.
+rem // If not, see http://www.gnu.org/licenses/
+
+rem // Official git repository and contact information can be found at
+rem // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+if not defined vs120comntools (
+  echo "Visual Studio 2013 doesn't appear to be installed properly. Quitting."
+  goto quit
+  ) else (
+    call "%vs120comntools%\vsvars32.bat" x86_amd64
+)
+
+set PPSSPP_ROOT=%CD%\..
+set RELEASE_DIR=%CD%\bin-release
+set RELEASE_X86=PPSSPPWindows.exe
+set DEBUG_X86=PPSSPPDebug.exe
+
+set RLS_PPSSPP = /p:Configuration=Release;Platform=win32 /m
+set DBG_PPSSPP = /p:Configuration=Debug;Platform=win32 /m
+
+call msbuild PPSSPP.sln /t:Clean %RLS_PPSSPP%
+call msbuild PPSSPP.sln /t:Build %RLS_PPSSPP%
+if not exist %PPSSPP_ROOT%\%RELEASEX86% (
+    echo Release build failed.
+    goto Quit
+)
+call msbuild PPSSPP.sln /t:Clean %DBG_PPSSPP% /m
+call msbuild PPSSPP.sln /t:Build %DBG_PPSSPP% /m
+if not exist %PPSSPP_ROOT%\%RELEASEX86% (
+    echo Debug build failed.
+    goto Quit
+)
+
+if not exist %RELEASE_DIR%\\. (
+  mkdir %RELEASE_DIR%
+) else (
+  rmdir /S /Q %RELEASE_DIR%
+  mkdir %RELEASE_DIR%
+)
+
+cd /d %RELEASE_DIR%
+
+xcopy "%PPSSPP_ROOT%\assets" ".\assets\*" /S
+xcopy "%PPSSPP_ROOT%\flash0" ".\flash0\*" /S
+xcopy "%PPSSPP_ROOT%\lang" ".\lang\*" /S
+
+copy %PPSSPP_ROOT%\LICENSE.txt /Y
+copy %PPSSPP_ROOT%\README.md /Y
+
+copy %PPSSPP_ROOT%\%DEBUG_X86% /Y
+
+copy %PPSSPP_ROOT%\%RELEASE_X86% /Y
+
+:Quit
+pause


### PR DESCRIPTION
Might be handy for building PPSSPP quicker without having to open Visual Studio. These could easily be combined to build all 4 "platforms" at once (release/debug x86 & release/debug x64), but I figure it's more convenient to have them separate.

These will compile PPSSPP from the command-prompt, and package up the release and debug binaries up nicely in a new folder called bin-release, under the Windows directory in the source code tree. They also have primitive error checking: If either debug or release of whichever platform fails to build, it won't attempt to package up everything after that.
