### PR TITLE
Fix another race in multithread, and ge sync

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -71,7 +71,7 @@ Event *eventPool = 0;
 Event *eventTsPool = 0;
 int allocatedTsEvents = 0;
 // Optimization to skip MoveEvents when possible.
-volatile u32 hasTsEvents = false;
+volatile u32 hasTsEvents = 0;
 
 // Downcount has been moved to currentMIPS, to save a couple of clocks in every ARM JIT block
 // as we can already reach that structure through a register.

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -32,9 +32,11 @@ bool AsyncIOManager::HasOperation(u32 handle) {
 }
 
 void AsyncIOManager::ScheduleOperation(AsyncIOEvent ev) {
-	lock_guard guard(resultsLock_);
-	if (!resultsPending_.insert(ev.handle).second) {
-		ERROR_LOG_REPORT(SCEIO, "Scheduling operation for file %d while one is pending (type %d)", ev.handle, ev.type);
+	{
+		lock_guard guard(resultsLock_);
+		if (!resultsPending_.insert(ev.handle).second) {
+			ERROR_LOG_REPORT(SCEIO, "Scheduling operation for file %d while one is pending (type %d)", ev.handle, ev.type);
+		}
 	}
 	ScheduleEvent(ev);
 }

--- a/Core/ThreadEventQueue.h
+++ b/Core/ThreadEventQueue.h
@@ -112,6 +112,22 @@ struct ThreadEventQueue : public B {
 		eventsHaveRun_ = false;
 	}
 
+	inline bool ShouldSyncThread(bool force) {
+		if (!HasEvents())
+			return false;
+		if (coreState != CORE_RUNNING && !force)
+			return false;
+
+		// Don't run if it's not running, but wait for startup.
+		if (!eventsRunning_) {
+			if (eventsHaveRun_ || coreState == CORE_ERROR || coreState == CORE_POWERDOWN) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	// Force ignores coreState.
 	void SyncThread(bool force = false) {
 		if (!threadEnabled_) {
@@ -122,7 +138,7 @@ struct ThreadEventQueue : public B {
 		// While processing the last event, HasEvents() will be false even while not done.
 		// So we schedule a nothing event and wait for that to finish.
 		ScheduleEvent(EVENT_SYNC);
-		while (HasEvents() && (eventsRunning_ || !eventsHaveRun_) && (force || coreState == CORE_RUNNING)) {
+		while (ShouldSyncThread(force)) {
 			eventsDrain_.wait(eventsLock_);
 		}
 	}


### PR DESCRIPTION
If EVENT_FINISH is received, but coreState is still CORE_RUNNING and the thread is still enabled, it would hang.  Makes more sense to wait for events before processing them anyhow...

Also ge sync was never running because detach wiped the id, of course...

-[Unknown]
