### PR TITLE
Eat a few more cycles on END cmds

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -773,6 +773,9 @@ void GPUCommon::Execute_End(u32 op, u32 diff) {
 	easy_guard guard(listLock);
 	const u32 prev = Memory::ReadUnchecked_U32(currentList->pc - 4);
 	UpdatePC(currentList->pc);
+	// Count in a few extra cycles on END.
+	cyclesExecuted += 60;
+
 	switch (prev >> 24) {
 	case GE_CMD_SIGNAL:
 		{


### PR DESCRIPTION
Fixes #3049, which apparently expects an END/FINISH (which is all there is after a stall update) to not immediately trigger (it drawsyncs soon after, and completely expects that to reschedule.)

Either way, it seems plausible an END would take a few more cycles than most instructions, since it generates an interrupt.

-[Unknown]
