### PR TITLE
Set depth update flag when depth write is enabled in non-clear mode only

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -401,7 +401,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(ztests[gstate.getDepthTestFunction()]);
 			glstate.depthWrite.set(gstate.isDepthWriteEnabled() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
-			framebufferManager_->SetDepthUpdated();
+			if (gstate.isDepthWriteEnabled() || alwaysDepthWrite) {
+				framebufferManager_->SetDepthUpdated();
+			}
 		} else {
 			glstate.depthTest.disable();
 		}


### PR DESCRIPTION
Try to set depth update flag only either depth write is enabled or the hack depth write enabled instead of only depth test enabled.

Probably less copy and better performance .

Fixes https://github.com/hrydgard/ppsspp/issues/5068
