### PR TITLE
Pass PSMF video framewidth to be used as width of the framebuffer

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -25,6 +25,7 @@
 #include "Core/HLE/scePsmf.h"
 #include "Core/HLE/sceMpeg.h"
 #include "Core/HW/MediaEngine.h"
+#include "GPU/GLES/Framebuffer.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
@@ -234,6 +235,7 @@ public:
 	PsmfPlayerStatus status;
 
 	MediaEngine* mediaengine;
+	FramebufferManager framebuffer;
 };
 
 class PsmfStream {
@@ -1329,9 +1331,9 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	}
 	// In case we change warm up later, save a high value in savestates - video started.
 	psmfplayer->warmUp = 10000;
-
 	auto videoData = PSPPointer<PsmfVideoData>::Create(videoDataAddr);
 	if (videoData.IsValid()) {
+		psmfplayer->framebuffer.SetPsmfWidth(videoData->frameWidth);
 		if (!psmfplayer->mediaengine->IsNoAudioData()) {
 			const s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 			if (deltapts > 0) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -59,6 +59,9 @@
 
 extern int g_iNumVideos;
 
+bool psmfVideo = false;
+int psmfWidth = 0;
+
 static const char tex_fs[] =
 #ifdef USING_GLES2
 	"precision mediump float;\n"
@@ -931,6 +934,11 @@ void FramebufferManager::SetLineWidth() {
 #endif
 }
 
+void FramebufferManager::SetPsmfWidth(int width) {
+	psmfVideo = true;
+	psmfWidth = width;
+}
+
 void FramebufferManager::BindFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer) {
 	if (!sourceframebuffer || !targetframebuffer->fbo || !useBufferedRendering_) {
 		return;
@@ -1687,7 +1695,7 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 					h = (h * vfb->renderHeight) / vfb->bufferHeight;
 					glstate.viewport.set(0, vfb->renderHeight - h, w, h);
 					needUnbind = true;
-					DrawPixels(Memory::GetPointer(addr | 0x04000000), vfb->format, vfb->fb_stride);
+					DrawPixels(Memory::GetPointer(addr | 0x04000000), vfb->format, psmfVideo ? psmfWidth : vfb->fb_stride);
 				} else {
 					INFO_LOG(SCEGE, "Invalidating FBO for %08x (%i x %i x %i)", vfb->fb_address, vfb->width, vfb->height, vfb->format)
 					DestroyFramebuf(vfb);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -204,6 +204,8 @@ public:
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 
+	void SetPsmfWidth(int width);
+
 private:
 	void CompileDraw2DProgram();
 	void DestroyDraw2DProgram();


### PR DESCRIPTION
Attempt the fix the video distortion in https://github.com/hrydgard/ppsspp/issues/5068 , trying to pass the psmf video framewidth to be used as width of the framebuffer .
