### PR TITLE
Track sceDmac & block transfer for read framebuffer to memory

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -382,6 +382,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("TrueColor", &g_Config.bTrueColor, true),
 
 	ReportedConfigSetting("MipMap", &g_Config.bMipMap, true),
+	ReportedConfigSetting("BlockTransfer", &g_Config.bBlockTransfer, false),
 
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -128,6 +128,7 @@ public:
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	bool bTrueColor;
 	bool bMipMap;
+	bool bBlockTransfer;
 	int iTexScalingLevel; // 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -37,6 +37,7 @@ struct SymbolInfo {
 	SymbolType type;
 	u32 address;
 	u32 size;
+	u32 moduleAddress;
 };
 
 struct SymbolEntry {
@@ -93,6 +94,7 @@ public:
 	u32 GetFunctionStart(u32 address) const;
 	int GetFunctionNum(u32 address) const;
 	u32 GetFunctionSize(u32 startAddress) const;
+	u32 GetFunctionModuleAddress(u32 startAddress) const;
 	bool SetFunctionSize(u32 startAddress, u32 newSize);
 	bool RemoveFunction(u32 startAddress, bool removeName);
 	// Search for the first address their may be a function after address.
@@ -107,6 +109,7 @@ public:
 	void AddData(u32 address, u32 size, DataType type, int moduleIndex = -1);
 	u32 GetDataStart(u32 address) const;
 	u32 GetDataSize(u32 startAddress) const;
+	u32 GetDataModuleAddress(u32 startAddress) const;
 	DataType GetDataType(u32 startAddress) const;
 
 	static const u32 INVALID_ADDRESS = (u32)-1;

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -17,10 +17,11 @@
 
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
-#include "../MIPS/MIPSTables.h"
+#include "Core/MIPS/MIPSTables.h"
 #include "ElfReader.h"
-#include "../Debugger/SymbolMap.h"
-#include "../HLE/sceKernelMemory.h"
+#include "Core/Debugger/Breakpoints.h"
+#include "Core/Debugger/SymbolMap.h"
+#include "Core/HLE/sceKernelMemory.h"
 
 
 const char *ElfReader::GetSectionName(int section)
@@ -442,6 +443,7 @@ int ElfReader::LoadInto(u32 loadAddress)
 			}
 
 			memcpy(dst, src, srcSize);
+			CBreakPoints::ExecMemCheck(writeAddr, true, dstSize, currentMIPS->pc);
 			DEBUG_LOG(LOADER,"Loadable Segment Copied to %08x, size %08x", writeAddr, (u32)p->p_memsz);
 		}
 	}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -447,7 +447,10 @@ void JitBlockCache::DestroyBlock(int block_num, bool invalidate) {
 	if (b->proxyFor) {
 		for (size_t i = 0; i < b->proxyFor->size(); i++) {
 			int proxied_blocknum = GetBlockNumberFromStartAddress((*b->proxyFor)[i], false);
-			DestroyBlock(proxied_blocknum, invalidate);
+			// If it was already cleared, we don't know which to destroy.
+			if (proxied_blocknum != -1) {
+				DestroyBlock(proxied_blocknum, invalidate);
+			}
 		}
 		b->proxyFor->clear();
 		delete b->proxyFor;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -751,7 +751,8 @@ skip:
 				// We still need to insert the func for hashing purposes.
 				currentFunction.start = syminfo.address;
 				currentFunction.end = syminfo.address + syminfo.size - 4;
-				currentFunction.foundInSymbolMap = true;
+				// Re-add it to the map if the module address is not known yet (only happens from loaded maps.)
+				currentFunction.foundInSymbolMap = syminfo.moduleAddress != 0;
 				functions.push_back(currentFunction);
 				currentFunction.foundInSymbolMap = false;
 				currentFunction.start = addr + 4;

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -25,6 +25,9 @@
 
 #ifdef _M_SSE
 #include <xmmintrin.h>
+#if _M_SSE >= 0x401
+#include <smmintrin.h>
+#endif
 
 u32 QuickTexHashSSE2(const void *checkp, u32 size) {
 	u32 check = 0;
@@ -270,5 +273,130 @@ void DecodeDXT5Block(u32 *dst, const DXT5Block *src, int pitch) {
 			data >>= 3;
 		}
 		dst += pitch;
+	}
+}
+
+void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, const u32 numPixels) {
+#ifdef _M_SSE
+	const __m128i maskGA = _mm_set1_epi32(0xFF00FF00);
+
+	const __m128i *srcp = (const __m128i *)src;
+	__m128i *dstp = (__m128i *)dst;
+	u32 sseChunks = numPixels / 4;
+	if (((intptr_t)src & 0xF) || ((intptr_t)dst & 0xF)) {
+		sseChunks = 0;
+	}
+	for (u32 i = 0; i < sseChunks; ++i) {
+		__m128i c = _mm_load_si128(&srcp[i]);
+		__m128i rb = _mm_andnot_si128(maskGA, c);
+		c = _mm_and_si128(c, maskGA);
+
+		__m128i b = _mm_srli_epi32(rb, 16);
+		__m128i r = _mm_slli_epi32(rb, 16);
+		c = _mm_or_si128(_mm_or_si128(c, r), b);
+		_mm_store_si128(&dstp[i], c);
+	}
+	// The remainder starts right after those done via SSE.
+	u32 i = sseChunks * 4;
+#else
+	u32 i = 0;
+#endif
+	for (; i < numPixels; i++) {
+		const u32 c = src[i];
+		dst[i] = ((c >> 16) & 0x000000FF) |
+		         ((c >> 0)  & 0xFF00FF00) |
+		         ((c << 16) & 0x00FF0000);
+	}
+}
+
+inline u16 RGBA8888toRGBA5551(u32 px) {
+	return ((px >> 3) & 0x001F) | ((px >> 6) & 0x03E0) | ((px >> 9) & 0x7C00) | ((px >> 16) & 0x8000);
+}
+
+void ConvertRGBA8888ToRGBA5551(u16 *dst, const u32 *src, const u32 numPixels) {
+#if _M_SSE >= 0x401
+	const __m128i maskAG = _mm_set1_epi32(0x8000F800);
+	const __m128i maskRB = _mm_set1_epi32(0x00F800F8);
+	const __m128i mask = _mm_set1_epi32(0x0000FFFF);
+
+	const __m128i *srcp = (const __m128i *)src;
+	__m128i *dstp = (__m128i *)dst;
+	u32 sseChunks = (numPixels / 4) & ~1;
+	// SSE 4.1 required for _mm_packus_epi32.
+	if (((intptr_t)src & 0xF) || ((intptr_t)dst & 0xF) || !cpu_info.bSSE4_1) {
+		sseChunks = 0;
+	}
+	for (u32 i = 0; i < sseChunks; i += 2) {
+		__m128i c1 = _mm_load_si128(&srcp[i + 0]);
+		__m128i c2 = _mm_load_si128(&srcp[i + 1]);
+		__m128i ag, rb;
+
+		ag = _mm_and_si128(c1, maskAG);
+		ag = _mm_or_si128(_mm_srli_epi32(ag, 16), _mm_srli_epi32(ag, 6));
+		rb = _mm_and_si128(c1, maskRB);
+		rb = _mm_or_si128(_mm_srli_epi32(rb, 3), _mm_srli_epi32(rb, 9));
+		c1 = _mm_and_si128(_mm_or_si128(ag, rb), mask);
+
+		ag = _mm_and_si128(c2, maskAG);
+		ag = _mm_or_si128(_mm_srli_epi32(ag, 16), _mm_srli_epi32(ag, 6));
+		rb = _mm_and_si128(c2, maskRB);
+		rb = _mm_or_si128(_mm_srli_epi32(rb, 3), _mm_srli_epi32(rb, 9));
+		c2 = _mm_and_si128(_mm_or_si128(ag, rb), mask);
+
+		_mm_store_si128(&dstp[i / 2], _mm_packus_epi32(c1, c2));
+	}
+	// The remainder starts right after those done via SSE.
+	u32 i = sseChunks * 4;
+#else
+	u32 i = 0;
+#endif
+	for (; i < numPixels; i++) {
+		dst[i] = RGBA8888toRGBA5551(src[i]);
+	}
+}
+
+inline u16 BGRA8888toRGBA5551(u32 px) {
+	return ((px >> 19) & 0x001F) | ((px >> 6) & 0x03E0) | ((px << 7) & 0x7C00) | ((px >> 16) & 0x8000);
+}
+
+void ConvertBGRA8888ToRGBA5551(u16 *dst, const u32 *src, const u32 numPixels) {
+#if _M_SSE >= 0x401
+	const __m128i maskAG = _mm_set1_epi32(0x8000F800);
+	const __m128i maskRB = _mm_set1_epi32(0x00F800F8);
+	const __m128i mask = _mm_set1_epi32(0x0000FFFF);
+
+	const __m128i *srcp = (const __m128i *)src;
+	__m128i *dstp = (__m128i *)dst;
+	u32 sseChunks = (numPixels / 4) & ~1;
+	// SSE 4.1 required for _mm_packus_epi32.
+	if (((intptr_t)src & 0xF) || ((intptr_t)dst & 0xF) || !cpu_info.bSSE4_1) {
+		sseChunks = 0;
+	}
+	for (u32 i = 0; i < sseChunks; i += 2) {
+		__m128i c1 = _mm_load_si128(&srcp[i + 0]);
+		__m128i c2 = _mm_load_si128(&srcp[i + 1]);
+		__m128i ag, rb;
+
+		ag = _mm_and_si128(c1, maskAG);
+		ag = _mm_or_si128(_mm_srli_epi32(ag, 16), _mm_srli_epi32(ag, 6));
+		rb = _mm_and_si128(c1, maskRB);
+		rb = _mm_or_si128(_mm_srli_epi32(rb, 19), _mm_slli_epi32(rb, 7));
+		c1 = _mm_and_si128(_mm_or_si128(ag, rb), mask);
+
+		ag = _mm_and_si128(c2, maskAG);
+		ag = _mm_or_si128(_mm_srli_epi32(ag, 16), _mm_srli_epi32(ag, 6));
+		rb = _mm_and_si128(c2, maskRB);
+		rb = _mm_or_si128(_mm_srli_epi32(rb, 19), _mm_slli_epi32(rb, 7));
+		c2 = _mm_and_si128(_mm_or_si128(ag, rb), mask);
+
+		_mm_store_si128(&dstp[i / 2], _mm_packus_epi32(c1, c2));
+	}
+	// The remainder starts right after those done via SSE.
+	u32 i = sseChunks * 4;
+#else
+	u32 i = 0;
+#endif
+	for (; i < numPixels; i++) {
+		dst[i] = BGRA8888toRGBA5551(src[i]);
 	}
 }

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -201,3 +201,7 @@ inline void DeIndexTexture4Optimal(ClutT *dest, const u32 texaddr, int length, C
 	const u8 *indexed = (const u8 *) Memory::GetPointer(texaddr);
 	DeIndexTexture4Optimal(dest, indexed, length, color);
 }
+
+void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, const u32 numPixels);
+void ConvertRGBA8888ToRGBA5551(u16 *dst, const u32 *src, const u32 numPixels);
+void ConvertBGRA8888ToRGBA5551(u16 *dst, const u32 *src, const u32 numPixels);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -62,6 +62,7 @@ struct VirtualFramebuffer {
 
 	u32 fb_address;
 	u32 z_address;
+	u32 block_address;
 	int fb_stride;
 	int z_stride;
 
@@ -162,6 +163,9 @@ public:
 	// Just for logging right now.  Might remove/change.
 	void NotifyBlockTransfer(u32 dst, u32 src);
 
+	// Handle Block Transfer (Download)
+	void BlockTransferDownload(u32 src);
+
 #ifdef USING_GLES2
   void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync = true);
 #else
@@ -251,6 +255,8 @@ private:
 
 	bool resized_;
 	bool useBufferedRendering_;
+	bool updateVRAM_;
+	bool skipFrame_;
 
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<std::pair<int, int>, FBO *> renderCopies_;

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1932,6 +1932,9 @@ void GLES_GPU::DoBlockTransfer() {
 	// TODO: Notify all overlapping FBOs that they need to reload.
 	framebufferManager_.NotifyBlockTransfer(dstBasePtr, srcBasePtr);
 
+	// Notify FBO with source address 
+	framebufferManager_.BlockTransferDownload(srcBasePtr);
+
 	textureCache_.Invalidate(dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, GPU_INVALIDATE_HINT);
 	if (Memory::IsRAMAddress(srcBasePtr) && Memory::IsVRAMAddress(dstBasePtr)) {
 		// TODO: This causes glitches in Tactics Ogre if we don't implement both ways (which will probably be slow...)

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -663,8 +663,12 @@ void GPUCommon::ProcessDLQueueInternal() {
 			return;
 		} else {
 			easy_guard guard(listLock);
-			// At the end, we can remove it from the queue and continue.
-			dlQueue.erase(std::remove(dlQueue.begin(), dlQueue.end(), listIndex), dlQueue.end());
+
+			// Some other list could've taken the spot while we dilly-dallied around.
+			if (l.state != PSP_GE_DL_STATE_QUEUED) {
+				// At the end, we can remove it from the queue and continue.
+				dlQueue.erase(std::remove(dlQueue.begin(), dlQueue.end(), listIndex), dlQueue.end());
+			}
 			UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
 		}
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -166,6 +166,7 @@ void GameSettingsScreen::CreateViews() {
 	}
 
 	graphicsSettings->Add(new CheckBox(&g_Config.bLowQualitySplineBezier, gs->T("LowCurves", "Low quality spline/bezier curves")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bBlockTransfer, gs->T("Block Transfer")));
 
 	// In case we're going to add few other antialiasing option like MSAA in the future.
 	// graphicsSettings->Add(new CheckBox(&g_Config.bFXAA, gs->T("FXAA")));


### PR DESCRIPTION
It is bit urgy but being a faster alternative as read to framebuffer memory but not used to be replacing it.It helps those games which require block transfer download.

For example
- Ys Seven Mini map (Read to framebuffer memory mode , 113 FPS)
  ![ulus10551_00001](https://cloud.githubusercontent.com/assets/3000282/2869876/7e7c6b5c-d299-11e3-8707-3008bfc8290e.jpg)
- Ys Seven Mini map (Buffered rendering mode with block transfer enabled , 240 FPS)
  ![ulus10551_00000](https://cloud.githubusercontent.com/assets/3000282/2869877/847e7d7e-d299-11e3-8668-b1ca2d5ab61f.jpg)
