### PR TITLE
Fix jump/call alignment, no-pos vertices

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -654,7 +654,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 
 			// After drawing, we advance the vertexAddr (when non indexed) or indexAddr (when indexed).
 			// Some games rely on this, they don't bother reloading VADDR and IADDR.
-			// Q: Are these changed reflected in the real registers? Needs testing.
+			// The VADDR/IADDR registers are NOT updated.
 			if (inds) {
 				int indexSize = 1;
 				if ((gstate.vertType & GE_VTYPE_IDX_MASK) == GE_VTYPE_IDX_16BIT)

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -752,7 +752,7 @@ void GLES_GPU::Execute_Prim(u32 op, u32 diff) {
 	}
 #endif
 
-	int bytesRead;
+	int bytesRead = 0;
 	transformDraw_.SubmitPrim(verts, inds, prim, count, gstate.vertType, &bytesRead);
 
 	int vertexCost = transformDraw_.EstimatePerVertexCost();
@@ -761,7 +761,7 @@ void GLES_GPU::Execute_Prim(u32 op, u32 diff) {
 
 	// After drawing, we advance the vertexAddr (when non indexed) or indexAddr (when indexed).
 	// Some games rely on this, they don't bother reloading VADDR and IADDR.
-	// Q: Are these changed reflected in the real registers? Needs testing.
+	// The VADDR/IADDR registers are NOT updated.
 	if (inds) {
 		int indexSize = 1;
 		if ((gstate.vertType & GE_VTYPE_IDX_MASK) == GE_VTYPE_IDX_16BIT)

--- a/GPU/GLES/VertexDecoder.cpp
+++ b/GPU/GLES/VertexDecoder.cpp
@@ -33,7 +33,7 @@
 static const u8 tcsize[4] = {0,2,4,8}, tcalign[4] = {0,1,2,4};
 static const u8 colsize[8] = {0,0,0,0,2,2,2,4}, colalign[8] = {0,0,0,0,2,2,2,4};
 static const u8 nrmsize[4] = {0,3,6,12}, nrmalign[4] = {0,1,2,4};
-static const u8 possize[4] = {0,3,6,12}, posalign[4] = {0,1,2,4};
+static const u8 possize[4] = {3,3,6,12}, posalign[4] = {1,1,2,4};
 static const u8 wtsize[4] = {0,1,2,4}, wtalign[4] = {0,1,2,4};
 
 // When software skinning. This array is only used when non-jitted - when jitted, the matrix
@@ -611,28 +611,28 @@ static const StepFunction nrmstep_morph[4] = {
 };
 
 static const StepFunction posstep[4] = {
-	0,
+	&VertexDecoder::Step_PosS8,
 	&VertexDecoder::Step_PosS8,
 	&VertexDecoder::Step_PosS16,
 	&VertexDecoder::Step_PosFloat,
 };
 
 static const StepFunction posstep_skin[4] = {
-	0,
+	&VertexDecoder::Step_PosS8Skin,
 	&VertexDecoder::Step_PosS8Skin,
 	&VertexDecoder::Step_PosS16Skin,
 	&VertexDecoder::Step_PosFloatSkin,
 };
 
 static const StepFunction posstep_morph[4] = {
-	0,
+	&VertexDecoder::Step_PosS8Morph,
 	&VertexDecoder::Step_PosS8Morph,
 	&VertexDecoder::Step_PosS16Morph,
 	&VertexDecoder::Step_PosFloatMorph,
 };
 
 static const StepFunction posstep_through[4] = {
-	0,
+	&VertexDecoder::Step_PosS8Through,
 	&VertexDecoder::Step_PosS8Through,
 	&VertexDecoder::Step_PosS16Through,
 	&VertexDecoder::Step_PosFloatThrough,
@@ -786,6 +786,10 @@ void VertexDecoder::SetVertexType(u32 fmt, VertexDecoderJitCache *jitCache) {
 		decOff += DecFmtSize(decFmt.nrmfmt);
 	}
 
+	if (!pos) {
+		ERROR_LOG_REPORT(G3D, "Vertices without position found");
+		pos = 1;
+	}
 	if (pos) { // there's always a position
 		size = align(size, posalign[pos]);
 		posoff = size;
@@ -818,8 +822,6 @@ void VertexDecoder::SetVertexType(u32 fmt, VertexDecoderJitCache *jitCache) {
 		}
 		decFmt.posoff = decOff;
 		decOff += DecFmtSize(decFmt.posfmt);
-	} else {
-		ERROR_LOG_REPORT(G3D, "Vertices without position found");
 	}
 
 	decFmt.stride = decOff;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -412,7 +412,7 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 
 			// After drawing, we advance the vertexAddr (when non indexed) or indexAddr (when indexed).
 			// Some games rely on this, they don't bother reloading VADDR and IADDR.
-			// Q: Are these changed reflected in the real registers? Needs testing.
+			// The VADDR/IADDR registers are NOT updated.
 			if (indices) {
 				int indexSize = 1;
 				if ((gstate.vertType & GE_VTYPE_IDX_MASK) == GE_VTYPE_IDX_16BIT)


### PR DESCRIPTION
http://forums.ppsspp.org/showthread.php?tid=1276&pid=82633#pid82633

According to my tests, CALL and JUMP simply ignore the bottom 2 bits, which isn't really that unusual.

I've also verified that PRIM does not modify VADDR/IADDR, although it does of course modify the context addr (from sceGeSaveContext.)

While testing that, I tested vertextype = 0.  This has a width of 3 bytes, and is afaict treated basically like s8 positions are.  I know there were some experiments with that in the past, but posalign/possize were always 0 then, and I think the steps were too.

-[Unknown]
