### PR TITLE
Fix a couple buggy ARM VFPU flags.

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1611,14 +1611,14 @@ namespace MIPSComp
 				fpr.MapInInV(sregs[i], tregs[i]);
 				VCMP(fpr.V(sregs[i]), fpr.V(tregs[i]));
 				VMRS_APSR();
-				flag = CC_LT;
+				flag = CC_LO;
 				break;
 
 			case VC_LE: // c = s[i] <= t[i]; 
 				fpr.MapInInV(sregs[i], tregs[i]);
 				VCMP(fpr.V(sregs[i]), fpr.V(tregs[i]));
 				VMRS_APSR();
-				flag = CC_LE;
+				flag = CC_LS;
 				break;
 
 			case VC_NE: // c = s[i] != t[i]


### PR DESCRIPTION
Unknown's explanation (huge thanks to him for the help):
LO means Lower (unsigned), but for floats, it means "Less than".
LT means Lower (signed), but for floats it means "Less than OR unordered".

ARM docs at http://infocenter.arm.com/help/topic/com.arm.doc.dui0068b/Chdhcfbc.html explain the following (assuming I understood them correctly):
LE means Signed less than or equal, and for floats it means "Less than or equal, or unordered".
LS means Unsigned lower or same, but for floats, it means "Less than or equal".

Fixes https://github.com/hrydgard/ppsspp/issues/1547, and who knows what else (is that One Piece game affected?). Flags are tricky beasts, indeed.
