### PR TITLE
Track block transfer for read framebuffer to memory.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -382,6 +382,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("TrueColor", &g_Config.bTrueColor, true),
 
 	ReportedConfigSetting("MipMap", &g_Config.bMipMap, true),
+	ReportedConfigSetting("BlockTransfer", &g_Config.bBlockTransfer, false),
 
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -128,6 +128,7 @@ public:
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	bool bTrueColor;
 	bool bMipMap;
+	bool bBlockTransfer;
 	int iTexScalingLevel; // 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -341,6 +341,7 @@ FramebufferManager::FramebufferManager() :
 	ClearBuffer();
 
 	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+	updateVRAM_ = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 
 	SetLineWidth();
 }
@@ -854,11 +855,19 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 
 	// We already have it!
 	} else if (vfb != currentRenderVfb_) {
-		bool updateVRAM = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 
-		if (updateVRAM && !vfb->memoryUpdated) {
+		if (updateVRAM_ && !vfb->memoryUpdated) {
 			ReadFramebufferToMemory(vfb, true);
 		}
+		if (!updateVRAM_ && g_Config.bBlockTransfer)  {
+			// Track block transfer
+			for (auto it = reportedBlits_.begin(), end = reportedBlits_.end(); it != end; ++it) {
+				if ((vfb->fb_address | 0x04000000) == it->second) {
+					ReadFramebufferToMemory(vfb);
+				}
+			}
+		}
+
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
@@ -1113,7 +1122,8 @@ void FramebufferManager::CopyDisplayToOutput() {
 void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync) {
 #ifndef USING_GLES2
 	if (sync) {
-		PackFramebufferAsync_(NULL); // flush async just in case when we go for synchronous update
+		// flush async just in case when we go for synchronous update
+		PackFramebufferAsync_(NULL);
 	}
 #endif
 
@@ -1208,13 +1218,16 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 		BlitFramebuffer_(vfb, nvfb, false);
 
 #ifdef USING_GLES2
-		PackFramebufferSync_(nvfb); // synchronous glReadPixels
+		// Always use synchronous glReadPixels on mobile platform
+		PackFramebufferSync_(nvfb);
 #else
 		if (gl_extensions.PBO_ARB && gl_extensions.OES_texture_npot) {
 			if (!sync) {
-				PackFramebufferAsync_(nvfb); // asynchronous glReadPixels using PBOs
+				// asynchronous glReadPixels using PBOs
+				PackFramebufferAsync_(nvfb);
 			} else {
-				PackFramebufferSync_(nvfb); // synchronous glReadPixels
+				// synchronous glReadPixels
+				PackFramebufferSync_(nvfb);
 			}
 		}
 #endif
@@ -1281,7 +1294,8 @@ void ConvertFromRGBA8888(u8 *dst, const u8 *src, u32 stride, u32 height, GEBuffe
 		} else { // Here lets assume they don't intersect
 			memcpy(dst, src, stride * height * 4);
 		}
-	} else { // But here it shouldn't matter if they do
+	} else { 
+		// But here it shouldn't matter if they do
 		int size = height * stride;
 		const u32 *src32 = (const u32 *)src;
 		u16 *dst16 = (u16 *)dst;
@@ -1516,7 +1530,8 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb) {
 	GLubyte *packed = 0;
 	if (vfb->format == GE_FORMAT_8888) {
 		packed = (GLubyte *)Memory::GetPointer(fb_address);
-	} else { // End result may be 16-bit but we are reading 32-bit, so there may not be enough space at fb_address
+	} else { 
+		// End result may be 16-bit but we are reading 32-bit, so there may not be enough space at fb_address
 		packed = (GLubyte *)malloc(bufSize * sizeof(GLubyte));
 	}
 
@@ -1549,7 +1564,8 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb) {
 				break;
 		}
 
-		if (vfb->format != GE_FORMAT_8888) { // If not RGBA 8888 we need to convert
+		if (vfb->format != GE_FORMAT_8888) { 
+			// If not RGBA 8888 we need to convert
 			ConvertFromRGBA8888(Memory::GetPointer(fb_address), packed, vfb->fb_stride, vfb->height, vfb->format);
 			free(packed);
 		}
@@ -1563,8 +1579,10 @@ void FramebufferManager::EndFrame() {
 		DestroyAllFBOs();
 		glstate.viewport.set(0, 0, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 		int zoom = g_Config.iInternalResolution;
-		if (zoom == 0) // auto mode
+		if (zoom == 0) {
+			// auto mode
 			zoom = (PSP_CoreParameter().pixelWidth + 479) / 480;
+		}
 
 		PSP_CoreParameter().renderWidth = 480 * zoom;
 		PSP_CoreParameter().renderHeight = 272 * zoom;
@@ -1614,6 +1632,7 @@ std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 	return list;
 }
 
+
 // MotoGP workaround
 void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dest, int size) {
 	for (size_t i = 0; i < vfbs_.size(); i++) {
@@ -1628,14 +1647,14 @@ void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dest, int size) {
 void FramebufferManager::DecimateFBOs() {
 	fbo_unbind();
 	currentRenderVfb_ = 0;
-	bool updateVram = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = vfbs_[i];
 		int age = frameLastFramebufUsed - std::max(vfb->last_frame_render, vfb->last_frame_used);
 
-		if (updateVram && age == 0 && !vfb->memoryUpdated) 
-				ReadFramebufferToMemory(vfb);
+		if (updateVRAM_ && age == 0 && !vfb->memoryUpdated) {
+			ReadFramebufferToMemory(vfb);
+		}
 
 		if (vfb == displayFramebuf_ || vfb == prevDisplayFramebuf_ || vfb == prevPrevDisplayFramebuf_) {
 			continue;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -251,7 +251,8 @@ private:
 
 	bool resized_;
 	bool useBufferedRendering_;
-
+	bool updateVRAM_;
+	
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<std::pair<int, int>, FBO *> renderCopies_;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -166,7 +166,8 @@ void GameSettingsScreen::CreateViews() {
 	}
 
 	graphicsSettings->Add(new CheckBox(&g_Config.bLowQualitySplineBezier, gs->T("LowCurves", "Low quality spline/bezier curves")));
-
+	graphicsSettings->Add(new CheckBox(&g_Config.bBlockTransfer, gs->T("Block Transfer")));
+	
 	// In case we're going to add few other antialiasing option like MSAA in the future.
 	// graphicsSettings->Add(new CheckBox(&g_Config.bFXAA, gs->T("FXAA")));
 	graphicsSettings->Add(new ItemHeader(gs->T("Texture Scaling")));


### PR DESCRIPTION
Link to #618 

This simply check the reportedBlits_ which stored the source address of downstream block transfer and use it check against with the current framebuffer address . When matched , trigger read framebuffer to memory mode only for that specific framebuffer , therefore it is extrememly fast .

This significanly improves Ys 7 with mini map support and other areas with special effects (FPS from 288% -> 1145%)

For example YS 7

Lava Scene
- Read to framebuffer memory mode , 87 FPS
  ![ulus10551_00013](https://cloud.githubusercontent.com/assets/3000282/2876350/e3ce14ba-d433-11e3-9700-ae5480f03809.jpg)
- Buffered rendering mode with block transfer option enabled , 343 FPS
  ![ulus10551_00014](https://cloud.githubusercontent.com/assets/3000282/2876351/e9c7e076-d433-11e3-8633-4ce192b6c1f3.jpg)

Port scene
- Read to framebuffer memory mode , 130 FPS
  ![ulus10551_00018](https://cloud.githubusercontent.com/assets/3000282/2876425/a30b3262-d435-11e3-9730-9f8b301fdae1.jpg)
- Buffered rendering mode with block transfer option enabled , 366 FPS
  ![ulus10551_00019](https://cloud.githubusercontent.com/assets/3000282/2876423/98e80d32-d435-11e3-88a8-65b977d5ced6.jpg)
