### PR TITLE
Allow GL_EXT_bgra to be used on Tegra Platform

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1262,11 +1262,8 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *src, VirtualFrameb
 }
 
 static inline bool UseBGRA8888() {
-	// TODO: Other platforms?  May depend on vendor which is faster?
-#ifdef _WIN32
+	// GL_EXT_bgra can be seen on Tegra Platform and on Desktop Platform 
 	return gl_extensions.EXT_bgra;
-#endif
-	return false;
 }
 
 // TODO: SSE/NEON

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -57,11 +57,8 @@
 extern int g_iNumVideos;
 
 static inline bool UseBGRA8888() {
-	// TODO: Other platforms?  May depend on vendor which is faster?
-#ifdef _WIN32
+	// GL_EXT_bgra can be seen on Tegra Platform and on Desktop Platform 
 	return gl_extensions.EXT_bgra;
-#endif
-	return false;
 }
 
 TextureCache::TextureCache() : clearCacheNextFrame_(false), lowMemoryMode_(false), clutBuf_(NULL) {


### PR DESCRIPTION
GL_EXT_bgra can been seen on Tegra Platform (but not on Mali , Adreno)
