### PR TITLE
Use CPU pixel format conversion for AMD/ATI platform only

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1330,7 +1330,7 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 	GLubyte *packed = 0;
 	bool unbind = false;
 	u8 nextPBO = (currentPBO_ + 1) % MAX_PBO;
-	bool useCPU = g_Config.iRenderingMode == FB_READFBOMEMORY_CPU;
+	bool useCPU = gl_extensions.gpuVendor == GPU_VENDOR_AMD;
 
 	// We'll prepare two PBOs to switch between readying and reading
 	if (!pixelBufObj_) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1110,6 +1110,29 @@ void FramebufferManager::CopyDisplayToOutput() {
 	}
 }
 
+void ReportGLErrors() {
+	GLenum error = glGetError();
+	switch (error) {
+	case GL_NO_ERROR:
+		break;
+	case GL_INVALID_ENUM:
+		ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_ENUM");
+		break;
+	case GL_INVALID_VALUE:
+		ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_VALUE");
+		break;
+	case GL_INVALID_OPERATION:
+		ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_OPERATION");
+		break;
+	case GL_INVALID_FRAMEBUFFER_OPERATION:
+		ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_FRAMEBUFFER_OPERATION");
+		break;
+	case GL_OUT_OF_MEMORY:
+		ERROR_LOG(SCEGE, "glReadPixels: GL_OUT_OF_MEMORY");
+		break;
+	}
+}
+
 void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync) {
 #ifndef USING_GLES2
 	if (sync) {
@@ -1447,31 +1470,9 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 			glPixelStorei(GL_PACK_ALIGNMENT, align);
 			glReadPixels(0, 0, vfb->fb_stride, vfb->height, pixelFormat, pixelType, 0);
 		}
-
-		GLenum error = glGetError();
-		switch(error) {
-			case 0:
-				break;
-			case GL_INVALID_ENUM:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_ENUM");
-				break;
-			case GL_INVALID_VALUE:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_VALUE");
-				break;
-			case GL_INVALID_OPERATION:
-				// GL_INVALID_OPERATION will happen sometimes midframe but everything
-				// seems to work out when actually mapping buffers?
-				// GL_SAMPLE_BUFFERS, GL_READ_BUFFER, GL_BUFFER_SIZE/MAPPED,
-				// GL_PIXEL_PACK_BUFFER_BINDING, all have the expected values.
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_OPERATION");
-				break;
-			case GL_INVALID_FRAMEBUFFER_OPERATION:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_FRAMEBUFFER_OPERATION");
-				break;
-			default:
-				ERROR_LOG(SCEGE, "glReadPixels: UNKNOWN OPENGL ERROR %u", error);
-				break;
-		}
+		
+		// Report GL error return by glReadPixels
+		ReportGLErrors();
 
 		fbo_unbind();
 		if (gl_extensions.FBO_ARB) {
@@ -1531,28 +1532,8 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb) {
 			glfmt = GL_BGRA_EXT;
 #endif
 		glReadPixels(0, 0, vfb->fb_stride, vfb->height, glfmt, GL_UNSIGNED_BYTE, packed);
-		GLenum error = glGetError();
-		switch(error) {
-			case 0:
-				break;
-			case GL_INVALID_ENUM:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_ENUM");
-				break;
-			case GL_INVALID_VALUE:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_VALUE");
-				break;
-			case GL_INVALID_OPERATION:
-				// GL_INVALID_OPERATION will happen sometimes midframe but everything
-				// seems to work out when actually reading?
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_OPERATION");
-				break;
-			case GL_INVALID_FRAMEBUFFER_OPERATION:
-				ERROR_LOG(SCEGE, "glReadPixels: GL_INVALID_FRAMEBUFFER_OPERATION");
-				break;
-			default:
-				ERROR_LOG(SCEGE, "glReadPixels: UNKNOWN OPENGL ERROR %u", error);
-				break;
-		}
+		// Report GL error return by glReadPixels
+		ReportGLErrors();
 
 		if (vfb->format != GE_FORMAT_8888) { // If not RGBA 8888 we need to convert
 			ConvertFromRGBA8888(Memory::GetPointer(fb_address), packed, vfb->fb_stride, vfb->height, vfb->format);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -97,7 +97,7 @@ void GameSettingsScreen::CreateViews() {
 	tabHolder->AddTab(ms->T("Graphics"), graphicsSettingsScroll);
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Rendering Mode")));
-	static const char *renderingMode[] = { "Non-Buffered Rendering", "Buffered Rendering", "Read Framebuffers To Memory (CPU)", "Read Framebuffers To Memory (GPU)"};
+	static const char *renderingMode[] = { "Non-Buffered Rendering", "Buffered Rendering", "Read Framebuffers To Memory"};
 	PopupMultiChoice *rm = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iRenderingMode, gs->T("Mode"), renderingMode, 0, ARRAY_SIZE(renderingMode), gs, screenManager()));
 	rm->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingMode);
 


### PR DESCRIPTION
Nvidia platform shouldn't need it and will bit slow down a bit.

I remember this has been suggested previously here https://github.com/hrydgard/ppsspp/issues/1686 to detect and set it simply using vendor .

(There are some underlying codes need to be removed but will clean up later)
