### PR TITLE
Implement GPU block copies between buffers and from buffer to RAM.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -396,6 +396,8 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("SplineBezierQuality", &g_Config.iSplineBezierQuality, 2),
 	ReportedConfigSetting("PostShader", &g_Config.sPostShaderName, "Off"),
 
+	ReportedConfigSetting("BlockTransferGPU", &g_Config.bBlockTransferGPU, false),
+
 	ConfigSetting(false),
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -143,6 +143,7 @@ public:
 	bool bAlwaysDepthWrite;
 	bool bTimerHack;
 	bool bAlphaMaskHack;
+	bool bBlockTransferGPU;
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	std::string sPostShaderName;  // Off for off.
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1033,7 +1033,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 			// The game is displaying something directly from RAM. In GTA, it's decoded video.
 
 			// First check that it's not a known RAM copy of a VRAM framebuffer though, as in MotoGP
-			for (auto iter = knownFramebufferCopies_.begin(); iter != knownFramebufferCopies_.end(); ++iter) {
+			for (auto iter = knownFramebufferRAMCopies_.begin(); iter != knownFramebufferRAMCopies_.end(); ++iter) {
 				if (iter->second == displayFramebufPtr_) {
 					vfb = GetVFBAt(iter->first);
 				}
@@ -1646,16 +1646,6 @@ std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 	return list;
 }
 
-void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dest, int size) {
-	for (size_t i = 0; i < vfbs_.size(); i++) {
-		int fsize = vfbs_[i]->fb_stride * vfbs_[i]->height * (vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2);
-		if ((vfbs_[i]->fb_address | 0x04000000) == src && size == fsize ) {
-			// A framebuffer matched!
-			knownFramebufferCopies_.insert(std::pair<u32, u32>(src, dest));
-		}
-	}
-}
-
 void FramebufferManager::DecimateFBOs() {
 	fbo_unbind();
 	currentRenderVfb_ = 0;
@@ -1759,6 +1749,49 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 
 		if (needUnbind)
 			fbo_unbind();
+	}
+}
+
+void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
+	// MotoGP workaround
+	for (size_t i = 0; i < vfbs_.size(); i++) {
+		int bpp = vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2;
+		int fsize = vfbs_[i]->fb_stride * vfbs_[i]->height * (vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2);
+		if ((vfbs_[i]->fb_address | 0x04000000) == src && size == fsize) {
+			// A framebuffer matched!
+			knownFramebufferRAMCopies_.insert(std::pair<u32, u32>(src, dst));
+		}
+	}
+
+	VirtualFramebuffer *dstBuffer = 0;
+	VirtualFramebuffer *srcBuffer = 0;
+	for (size_t i = 0; i < vfbs_.size(); ++i) {
+		VirtualFramebuffer *vfb = vfbs_[i];
+		if (MaskedEqual(vfb->fb_address, dst)) {
+			dstBuffer = vfb;
+		}
+		if (MaskedEqual(vfb->fb_address, src)) {
+			srcBuffer = vfb;
+		}
+	}
+
+	// TODO: Do ReadFramebufferToMemory etc where applicable.
+	// This will slow down MotoGP but make the hack above unnecessary.
+	if (dstBuffer && srcBuffer) {
+		if (srcBuffer == dstBuffer) {
+			WARN_LOG_REPORT_ONCE(dstsrccpy, G3D, "Intra-buffer memcpy (not supported) %08x -> %08x", src, dst);
+		} else {
+			WARN_LOG_ONCE(dstnotsrccpy, G3D, "Inter-buffer memcpy %08x -> %08x", src, dst);
+			// Just do the blit!
+			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
+			// BlitFramebuffer_(dstBuffer, 0, 0, srcBuffer, 0, 0, srcBuffer->width, srcBuffer->height);
+		}
+	} else if (dstBuffer) {
+		WARN_LOG_REPORT_ONCE(btucpy, G3D, "Memcpy fbo upload (not supported) %08x -> %08x", src, dst);
+		// Here we should just draw the pixels into the buffer.
+	} else if (srcBuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE) {
+		WARN_LOG_ONCE(btdcpy, G3D, "Memcpy fbo download %08x -> %08x", src, dst);
+		// ReadFramebufferToMemory(srcBuffer, true, 0, 0, srcBuffer->width, srcBuffer->height);
 	}
 }
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -851,7 +851,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 	} else if (vfb != currentRenderVfb_) {
 	
 		if (updateVRAM_ && !vfb->memoryUpdated) {
-			ReadFramebufferToMemory(vfb, true, 0, 0, 480, 272);
+			ReadFramebufferToMemory(vfb, true, 0, 0, vfb->width, vfb->height);
 		}
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
@@ -1119,6 +1119,10 @@ void FramebufferManager::CopyDisplayToOutput() {
 }
 
 void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) {
+	
+	// Null out currentRenderVfb_
+	currentRenderVfb_ = NULL;
+	
 #ifndef USING_GLES2
 	if (sync) {
 		PackFramebufferAsync_(NULL); // flush async just in case when we go for synchronous update

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1271,7 +1271,7 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 	// Should maybe revamp that interface.
 	float srcW = src->width;
 	float srcH = src->height;
-	DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcX / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
+	DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcY / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	fbo_unbind();

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -364,14 +364,16 @@ FramebufferManager::~FramebufferManager() {
 	delete [] convBuf;
 }
 
-void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelFormat, int linesize, bool applyPostShader) {
-	if (drawPixelsTex_ && drawPixelsTexFormat_ != pixelFormat) {
+void FramebufferManager::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) {
+	if (drawPixelsTex_ && (drawPixelsTexFormat_ != srcPixelFormat || drawPixelsTexW_ != width || drawPixelsTexH_ != height)) {
 		glDeleteTextures(1, &drawPixelsTex_);
 		drawPixelsTex_ = 0;
 	}
 
 	if (!drawPixelsTex_) {
 		glGenTextures(1, &drawPixelsTex_);
+		drawPixelsTexW_ = width;
+		drawPixelsTexH_ = height;
 
 		// Initialize backbuffer texture for DrawPixels
 		glBindTexture(GL_TEXTURE_2D, drawPixelsTex_);
@@ -383,21 +385,21 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 512, 272, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
 		glBindTexture(GL_TEXTURE_2D, 0);
-		drawPixelsTexFormat_ = pixelFormat;
+		drawPixelsTexFormat_ = srcPixelFormat;
 	}
 
 	// TODO: We can just change the texture format and flip some bits around instead of this.
 	bool useConvBuf = false;
-	if (pixelFormat != GE_FORMAT_8888 || linesize != 512) {
+	if (srcPixelFormat != GE_FORMAT_8888 || srcStride != 512) {
 		useConvBuf = true;
 		if (!convBuf) {
 			convBuf = new u8[512 * 272 * 4];
 		}
 		for (int y = 0; y < 272; y++) {
-			switch (pixelFormat) {
+			switch (srcPixelFormat) {
 			case GE_FORMAT_565:
 				{
-					const u16 *src = (const u16 *)framebuf + linesize * y;
+					const u16 *src = (const u16 *)srcPixels + srcStride * y;
 					u8 *dst = convBuf + 4 * 512 * y;
 					for (int x = 0; x < 480; x++)
 					{
@@ -412,7 +414,7 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 
 			case GE_FORMAT_5551:
 				{
-					const u16 *src = (const u16 *)framebuf + linesize * y;
+					const u16 *src = (const u16 *)srcPixels + srcStride * y;
 					u8 *dst = convBuf + 4 * 512 * y;
 					for (int x = 0; x < 480; x++)
 					{
@@ -427,7 +429,7 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 
 			case GE_FORMAT_4444:
 				{
-					const u16 *src = (const u16 *)framebuf + linesize * y;
+					const u16 *src = (const u16 *)srcPixels + srcStride * y;
 					u8 *dst = convBuf + 4 * 512 * y;
 					for (int x = 0; x < 480; x++)
 					{
@@ -442,7 +444,7 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 
 			case GE_FORMAT_8888:
 				{
-					const u8 *src = framebuf + linesize * 4 * y;
+					const u8 *src = srcPixels + srcStride * 4 * y;
 					u8 *dst = convBuf + 4 * 512 * y;
 					memcpy(dst, src, 4 * 480);
 				}
@@ -454,14 +456,23 @@ void FramebufferManager::DrawPixels(const u8 *framebuf, GEBufferFormat pixelForm
 			}
 		}
 	}
-
-	float x, y, w, h;
-	CenterRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight);
 	glBindTexture(GL_TEXTURE_2D, drawPixelsTex_);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 512, 272, GL_RGBA, GL_UNSIGNED_BYTE, useConvBuf ? convBuf : framebuf);
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 512, 272, GL_RGBA, GL_UNSIGNED_BYTE, useConvBuf ? convBuf : srcPixels);
+}
+
+void FramebufferManager::DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) {
+	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height);
+	DrawActiveTexture(0, dstX, dstY, width, height, vfb->width, vfb->height, false, 0.0f, 0.0f, 1.0f, 1.0f);
+}
+
+void FramebufferManager::DrawFramebuffer(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader) {
+	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, 512, 272);
 
 	DisableState();
+	// This CenterRect is for when we're drawing directly to the backbuffer... Ugh. Should we really do that here?
+	float x, y, w, h;
+	CenterRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight);
 
 	// This might draw directly at the backbuffer (if so, applyPostShader is set) so if there's a post shader, we need to apply it here.
 	// Should try to unify this path with the regular path somehow, but this simple solution works for most of the post shaders 
@@ -1041,7 +1052,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 
 			if (!vfb) {
 				// Just a pointer to plain memory to draw. We should create a framebuffer, then draw to it.
-				DrawPixels(Memory::GetPointer(displayFramebufPtr_), displayFormat_, displayStride_, true);
+				DrawFramebuffer(Memory::GetPointer(displayFramebufPtr_), displayFormat_, displayStride_, true);
 				return;
 			}
 		} else {
@@ -1738,7 +1749,7 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 					h = (h * vfb->renderHeight) / vfb->bufferHeight;
 					glstate.viewport.set(0, vfb->renderHeight - h, w, h);
 					needUnbind = true;
-					DrawPixels(Memory::GetPointer(addr | 0x04000000), vfb->format, vfb->fb_stride);
+					DrawPixels(vfb, 0, 0, Memory::GetPointer(addr | 0x04000000), vfb->format, vfb->fb_stride, vfb->width, vfb->height);
 				} else {
 					INFO_LOG(SCEGE, "Invalidating FBO for %08x (%i x %i x %i)", vfb->fb_address, vfb->width, vfb->height, vfb->format)
 					DestroyFramebuf(vfb);
@@ -1817,7 +1828,7 @@ bool FramebufferManager::NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int 
 	if (((backBuffer != 0 && dstBasePtr == backBuffer) ||
 		(displayBuffer != 0 && dstBasePtr == displayBuffer)) &&
 		dstStride == 512 && height == 272) {
-		DrawPixels(Memory::GetPointerUnchecked(dstBasePtr), GE_FORMAT_8888, 512);
+		DrawFramebuffer(Memory::GetPointerUnchecked(dstBasePtr), GE_FORMAT_8888, 512, false);
 	}
 
 	VirtualFramebuffer *dstBuffer = 0;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1762,34 +1762,39 @@ bool FramebufferManager::NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int 
 		DrawPixels(Memory::GetPointerUnchecked(dstBasePtr), GE_FORMAT_8888, 512);
 	}
 
-	// The stuff in the #ifdef is JUST for reporting, not used for anything else. 
-#ifndef MOBILE_DEVICE
-	if (reportedBlits_.insert(std::make_pair(dstBasePtr, srcBasePtr)).second) {
-		// Already reported/checked.
-		bool dstBuffer = false;
-		bool srcBuffer = false;
-		for (size_t i = 0; i < vfbs_.size(); ++i) {
-			VirtualFramebuffer *vfb = vfbs_[i];
-			if (MaskedEqual(vfb->fb_address, dstBasePtr)) {
-				dstBuffer = true;
-			}
-			if (MaskedEqual(vfb->fb_address, srcBasePtr)) {
-				srcBuffer = true;
-			}
+	VirtualFramebuffer *dstBuffer = 0;
+	VirtualFramebuffer *srcBuffer = 0;
+	for (size_t i = 0; i < vfbs_.size(); ++i) {
+		VirtualFramebuffer *vfb = vfbs_[i];
+		if (MaskedEqual(vfb->fb_address, dstBasePtr)) {
+			dstBuffer = vfb;
 		}
-
-		if (dstBuffer && srcBuffer) {
-			WARN_LOG_REPORT(G3D, "Intra buffer block transfer (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
-		} else if (dstBuffer) {
-			WARN_LOG_REPORT(G3D, "Block transfer upload (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
-		} else if (srcBuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE) {
-			WARN_LOG_REPORT(G3D, "Block transfer download (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
+		if (MaskedEqual(vfb->fb_address, srcBasePtr)) {
+			srcBuffer = vfb;
 		}
 	}
 
-#endif
-
-	return false;
+	if (dstBuffer && srcBuffer) {
+		if (srcBuffer == dstBuffer) {
+			WARN_LOG_REPORT_ONCE(dstsrc, G3D, "Intra-buffer block transfer (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
+		} else {
+			WARN_LOG_ONCE(dstnotsrc, G3D, "Inter-buffer block transfer %08x -> %08x", srcBasePtr, dstBasePtr);
+			// Just do the blit!
+			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
+			BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, width, height);
+		}
+		return true;  // No need to actually do the memory copy behind, probably.
+	} else if (dstBuffer) {
+		WARN_LOG_REPORT_ONCE(btu, G3D, "Block transfer upload (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
+		// Here we should just draw the pixels into the buffer.
+		return false;
+	} else if (srcBuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE) {
+		WARN_LOG_ONCE(btd, G3D, "Block transfer download %08x -> %08x", srcBasePtr, dstBasePtr);
+		ReadFramebufferToMemory(srcBuffer, true, srcX, srcY, width, height);
+		return false;  // Let the bit copy happen
+	} else {
+		return false;
+	}
 }
 
 void FramebufferManager::Resized() {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1781,7 +1781,9 @@ bool FramebufferManager::NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int 
 			WARN_LOG_ONCE(dstnotsrc, G3D, "Inter-buffer block transfer %08x -> %08x", srcBasePtr, dstBasePtr);
 			// Just do the blit!
 			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
-			BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, width, height);
+			if (g_Config.iRenderingMode == FB_BUFFERED_MODE) {
+				BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, width, height);
+			}
 		}
 		return true;  // No need to actually do the memory copy behind, probably.
 	} else if (dstBuffer) {
@@ -1790,7 +1792,9 @@ bool FramebufferManager::NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int 
 		return false;
 	} else if (srcBuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE) {
 		WARN_LOG_ONCE(btd, G3D, "Block transfer download %08x -> %08x", srcBasePtr, dstBasePtr);
-		ReadFramebufferToMemory(srcBuffer, true, srcX, srcY, width, height);
+		if (g_Config.iRenderingMode == FB_BUFFERED_MODE) {
+			ReadFramebufferToMemory(srcBuffer, true, srcX, srcY, width, height);
+		}
 		return false;  // Let the bit copy happen
 	} else {
 		return false;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1236,8 +1236,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 	}
 }
 
-// TODO: If glBlitFramebuffer is available, we can take a shortcut. If, in addition, the dimensions
-// are the same, we can use glCopyImageSubData.
+// TODO: If dimensions are the same, we can use glCopyImageSubData.
 void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h) {
 	if (!dst->fbo) {
 		ERROR_LOG_REPORT_ONCE(dstfbozero, SCEGE, "BlitFramebuffer_: dst->fbo == 0");
@@ -1252,32 +1251,43 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 	}
 
 	fbo_bind_as_render_target(dst->fbo);
-	fbo_bind_color_as_texture(src->fbo, 0);
 
-	// glCheckFramebufferStatus should only be called at creation time. Here it's just silly - we just bound a draw buffer above.
-#if 0
-	if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-		ERROR_LOG(SCEGE, "Incomplete target framebuffer, aborting blit");
-		fbo_unbind();
-		if (gl_extensions.FBO_ARB) {
-			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		}
-		return;
-	}
+
+#ifndef USING_GLES2
+	if (gl_extensions.FBO_ARB) {
+#else
+	if (gl_extensions.GLES3 || gl_extensions.NV_framebuffer_blit) {
 #endif
-	// Make sure our 2D drawing program is ready. Compiles only if not already compiled.
-	CompileDraw2DProgram();
 
-	glstate.viewport.set(0, 0, dst->width, dst->height);
-	DisableState();
+#ifdef MAY_HAVE_GLES3
+			fbo_bind_for_read(src->fbo);
+			if (gl_extensions.GLES3) {
+				glBlitFramebuffer(0, src->renderHeight, src->renderWidth, 0, 0, 0, dst->width, dst->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+			}
+#if defined(ANDROID)  // We only support this extension on Android, it's not even available on PC.
+			else if (gl_extensions.NV_framebuffer_blit) {
+				glBlitFramebufferNV(0, src->renderHeight, src->renderWidth, 0, 0, 0, dst->width, dst->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+			}
+#endif // defined(ANDROID)
 
-	// The first four coordinates are relative to the 6th and 7th arguments of DrawActiveTexture.
-	// Should maybe revamp that interface.
-	float srcW = src->width;
-	float srcH = src->height;
-	DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcY / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
+	} else {
+		fbo_bind_color_as_texture(src->fbo, 0);
 
-	glBindTexture(GL_TEXTURE_2D, 0);
+		// Make sure our 2D drawing program is ready. Compiles only if not already compiled.
+		CompileDraw2DProgram();
+
+		glstate.viewport.set(0, 0, dst->width, dst->height);
+		DisableState();
+
+		// The first four coordinates are relative to the 6th and 7th arguments of DrawActiveTexture.
+		// Should maybe revamp that interface.
+		float srcW = src->width;
+		float srcH = src->height;
+		DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcY / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
+		glBindTexture(GL_TEXTURE_2D, 0);
+	}
+#endif // MAY_HAVE_GLES3
+
 	fbo_unbind();
 }
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1859,9 +1859,10 @@ bool FramebufferManager::NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int 
 			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
 			if (g_Config.bBlockTransferGPU) {
 				BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, width, height);
+				return true;  // No need to actually do the memory copy behind, probably.
 			}
 		}
-		return true;  // No need to actually do the memory copy behind, probably.
+		return false;
 	} else if (dstBuffer) {
 		WARN_LOG_REPORT_ONCE(btu, G3D, "Block transfer upload (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
 		if (g_Config.bBlockTransferGPU) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1262,10 +1262,12 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 #ifdef MAY_HAVE_GLES3
 			fbo_bind_for_read(src->fbo);
 			if (gl_extensions.GLES3) {
+				// Render buffer is upside down , swap srcY0 with srcY1 to flip it correct
 				glBlitFramebuffer(0, src->renderHeight, src->renderWidth, 0, 0, 0, dst->width, dst->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 			}
 #if defined(ANDROID)  // We only support this extension on Android, it's not even available on PC.
 			else if (gl_extensions.NV_framebuffer_blit) {
+				// Render buffer is upside down , swap srcY0 with srcY1 to flip it correct
 				glBlitFramebufferNV(0, src->renderHeight, src->renderWidth, 0, 0, 0, dst->width, dst->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 			}
 #endif // defined(ANDROID)

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1559,7 +1559,7 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb) {
 
 	bool convert = vfb->format != GE_FORMAT_8888 || UseBGRA8888();
 
-	if (convert) {
+	if (!convert) {
 		packed = (GLubyte *)Memory::GetPointer(fb_address);
 	} else { // End result may be 16-bit but we are reading 32-bit, so there may not be enough space at fb_address
 		packed = (GLubyte *)malloc(bufSize * sizeof(GLubyte));

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1119,10 +1119,7 @@ void FramebufferManager::CopyDisplayToOutput() {
 }
 
 void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) {
-	
-	// Null out currentRenderVfb_
-	currentRenderVfb_ = NULL;
-	
+
 #ifndef USING_GLES2
 	if (sync) {
 		PackFramebufferAsync_(NULL); // flush async just in case when we go for synchronous update
@@ -1130,6 +1127,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 #endif
 
 	if (vfb) {
+
 		// We'll pseudo-blit framebuffers here to get a resized and flipped version of vfb.
 		// For now we'll keep these on the same struct as the ones that can get displayed
 		// (and blatantly copy work already done above while at it).
@@ -1233,6 +1231,9 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 			}
 		}
 #endif
+
+		// Null out currentRenderVfb_ so it gets set again properly.
+		currentRenderVfb_ = NULL;
 	}
 }
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1272,6 +1272,8 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 			}
 #endif // defined(ANDROID)
 
+#endif // MAY_HAVE_GLES3
+
 	} else {
 		fbo_bind_color_as_texture(src->fbo, 0);
 
@@ -1288,7 +1290,6 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 		DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcY / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
-#endif // MAY_HAVE_GLES3
 
 	fbo_unbind();
 }

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -261,8 +261,4 @@ private:
 	AsyncPBO *pixelBufObj_; //this isn't that large
 	u8 currentPBO_;
 #endif
-
-	// This is to be used only for reporting of strange blits. Don't control behaviour as
-	// this is "permanent" while framebuffers aren't.
-	std::set<std::pair<u32, u32>> reportedBlits_;
 };

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -124,7 +124,10 @@ public:
 		shaderManager_ = sm;
 	}
 
-	void DrawPixels(const u8 *framebuf, GEBufferFormat pixelFormat, int linesize, bool applyPostShader = false);
+	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
+
+	void DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
+	void DrawFramebuffer(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader);
 
 	// If texture != 0, will bind it.
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
@@ -233,6 +236,8 @@ private:
 	// Used by DrawPixels
 	unsigned int drawPixelsTex_;
 	GEBufferFormat drawPixelsTexFormat_;
+	int drawPixelsTexW_;
+	int drawPixelsTexH_;
 
 	u8 *convBuf;
 	GLSLProgram *draw2dprogram_;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -256,7 +256,7 @@ private:
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<std::pair<int, int>, FBO *> renderCopies_;
 
-	std::set<std::pair<u32, u32>> knownFramebufferCopies_;
+	std::set<std::pair<u32, u32>> knownFramebufferRAMCopies_;
 
 #ifndef USING_GLES2
 	AsyncPBO *pixelBufObj_; //this isn't that large

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -251,7 +251,8 @@ private:
 
 	bool resized_;
 	bool useBufferedRendering_;
-
+	bool updateVRAM_;
+	
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<std::pair<int, int>, FBO *> renderCopies_;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -99,7 +99,7 @@ void GameSettingsScreen::CreateViews() {
 	static const char *renderingMode[] = { "Non-Buffered Rendering", "Buffered Rendering", "Read Framebuffers To Memory (CPU)", "Read Framebuffers To Memory (GPU)"};
 	PopupMultiChoice *rm = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iRenderingMode, gs->T("Mode"), renderingMode, 0, ARRAY_SIZE(renderingMode), gs, screenManager()));
 	rm->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingMode);
-
+	graphicsSettings->Add(new CheckBox(&g_Config.bBlockTransferGPU, gs->T("Simulate Block Transfer", "Simulate Block Transfer (unfinished)")));
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Frame Rate Control")));
 	static const char *frameSkip[] = {"Off", "1", "2", "3", "4", "5", "6", "7", "8"};


### PR DESCRIPTION
(first one not very well tested, second one improves Burnout Legends sun a lot).

Implements parts of #3515 and #618.

Also hopes to be an alternative to #6030.

Intended for Buffered Rendering, not the Read Framebuffer modes.

I hope that with this we can minimize the use of the Read Framebuffer modes (they will still be required in Dangan Ronpa).
