### PR TITLE
MSBuild scripts: Enable parallel build and in effect, fix x64.

### DIFF
--- a/Windows/build-x64.cmd
+++ b/Windows/build-x64.cmd
@@ -28,8 +28,8 @@ set RELEASE_DIR=%CD%\bin-release
 set RELEASE_X64=PPSSPPWindows64.exe
 set DEBUG_X64=PPSSPPDebug64.exe
 
-set RLS_PPSSPP = /p:Configuration=Release;Platform=x64 /m
-set DBG_PPSSPP = /p:Configuration=Debug;Platform=x64 /m
+set RLS_PPSSPP=/m /p:Configuration=Release;Platform=x64
+set DBG_PPSSPP=/m /p:Configuration=Debug;Platform=x64
 
 call msbuild PPSSPP.sln /t:Clean %RLS_PPSSPP%
 call msbuild PPSSPP.sln /t:Build %RLS_PPSSPP%

--- a/Windows/build-x86.cmd
+++ b/Windows/build-x86.cmd
@@ -28,8 +28,8 @@ set RELEASE_DIR=%CD%\bin-release
 set RELEASE_X86=PPSSPPWindows.exe
 set DEBUG_X86=PPSSPPDebug.exe
 
-set RLS_PPSSPP = /p:Configuration=Release;Platform=win32 /m
-set DBG_PPSSPP = /p:Configuration=Debug;Platform=win32 /m
+set RLS_PPSSPP=/m /p:Configuration=Release;Platform=win32
+set DBG_PPSSPP=/m /p:Configuration=Debug;Platform=win32
 
 call msbuild PPSSPP.sln /t:Clean %RLS_PPSSPP%
 call msbuild PPSSPP.sln /t:Build %RLS_PPSSPP%


### PR DESCRIPTION
For some reason it was complaining about the platform being invalid with the /m switch at the end. Hopefully, this is the last tweak they need..
