### PR TITLE
Correctly flip textures in DrawActiveTexture()

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -511,7 +511,9 @@ void FramebufferManager::DrawPlainColor(u32 color) {
 // x, y, w, h are relative coordinates against destW/destH, which is not very intuitive.
 void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, float w, float h, float destW, float destH, bool flip, float u0, float v0, float u1, float v1, GLSLProgram *program) {
 	if (flip) {
-		std::swap(v0, v1);
+		// We're flipping, so 0 is downward.  Reverse everything from 1.0f.
+		v0 = 1.0f - v0;
+		v1 = 1.0f - v1;
 	}
 	const float texCoords[8] = {u0,v0, u1,v0, u1,v1, u0,v1};
 	static const GLushort indices[4] = {0,1,3,2};


### PR DESCRIPTION
We want to flip the origin of UV (top to bottom), not the pixels within the specified range.

The flip value isn't used by any of the new calls in #6049, so I don't think anything needs the "flip the specified area" behavior.

This fixes Wild Arms XF (which has 512x512 framebuffers and needs to render only the top half.)

-[Unknown]
