### PR TITLE
Correct clut caching (just in case) and clut shader generation timing

### DIFF
--- a/GPU/GLES/DepalettizeShader.cpp
+++ b/GPU/GLES/DepalettizeShader.cpp
@@ -158,7 +158,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat) {
 		if (shiftedMask & 0x3E0) WRITE(p, "  int g = int(index.g * 31.99);\n"); else WRITE(p, "  int g = 0;\n");
 		if (shiftedMask & 0x7C00) WRITE(p, "  int b = int(index.b * 31.99);\n"); else WRITE(p, "  int b = 0;\n");
 		if (shiftedMask & 0x8000) WRITE(p, "  int a = int(index.a);\n"); else WRITE(p, "  int a = 0;\n");
-		WRITE(p, "int color = (a << 15) | (b << 10) | (g << 5) | (r);");
+		WRITE(p, "  int color = (a << 15) | (b << 10) | (g << 5) | (r);");
 		break;
 	}
 	float texturePixels = 256;
@@ -166,7 +166,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat) {
 		texturePixels = 512;
 
 	WRITE(p, "  color = ((color >> %i) & 0x%02x) | %i;\n", shift, mask, offset);  // '|' matches what we have in gstate.h
-	WRITE(p, "  fragColor0 = texture2D(pal, vec2((floor(float(color)) - 0.5) * (1.0 / %f), 0.0));\n", texturePixels);
+	WRITE(p, "  fragColor0 = texture2D(pal, vec2((floor(float(color)) + 0.5) * (1.0 / %f), 0.0));\n", texturePixels);
 	WRITE(p, "}\n");
 }
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -511,7 +511,9 @@ void FramebufferManager::DrawPlainColor(u32 color) {
 // x, y, w, h are relative coordinates against destW/destH, which is not very intuitive.
 void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, float w, float h, float destW, float destH, bool flip, float u0, float v0, float u1, float v1, GLSLProgram *program) {
 	if (flip) {
-		std::swap(v0, v1);
+		// We're flipping, so 0 is downward.  Reverse everything from 1.0f.
+		v0 = 1.0f - v0;
+		v1 = 1.0f - v1;
 	}
 	const float texCoords[8] = {u0,v0, u1,v0, u1,v1, u0,v1};
 	static const GLushort indices[4] = {0,1,3,2};

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -230,17 +230,6 @@ inline void AttachFramebufferInvalid(T &entry, VirtualFramebuffer *framebuffer) 
 	}
 }
 
-bool TextureCache::AttachFramebufferCLUT(TextureCache::TexCacheEntry *entry, VirtualFramebuffer *framebuffer, u32 address) {
-	GLuint program = depalShaderCache_->GetDepalettizeShader(framebuffer->format);
-	if (program) {
-		entry->framebuffer = framebuffer;
-		entry->invalidHint = -1;
-		entry->status |= TexCacheEntry::STATUS_DEPALETTIZE;
-		return true;
-	}
-	return false;
-}
-
 void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch) {
 	// If they match exactly, it's non-CLUT and from the top left.
 	if (exactMatch) {
@@ -269,7 +258,10 @@ void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualF
 		bool clutSuccess = false;
 		if (((framebuffer->format == GE_FORMAT_8888 && entry->format == GE_TFMT_CLUT32) ||
 			   (framebuffer->format != GE_FORMAT_8888 && entry->format == GE_TFMT_CLUT16))) {
-			clutSuccess = AttachFramebufferCLUT(entry, framebuffer, address);
+			AttachFramebufferValid(entry, framebuffer);
+			entry->status |= TexCacheEntry::STATUS_DEPALETTIZE;
+			// We'll validate it later.
+			clutSuccess = true;
 		} else if (entry->format == GE_TFMT_CLUT8 || entry->format == GE_TFMT_CLUT4) {
 			ERROR_LOG_REPORT_ONCE(fourEightBit, G3D, "4 and 8-bit CLUT format not supported for framebuffers");
 		}
@@ -893,7 +885,11 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 	entry->framebuffer->usageFlags |= FB_USAGE_TEXTURE;
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	if (useBufferedRendering) {
+		GLuint program = 0;
 		if (entry->status & TexCacheEntry::STATUS_DEPALETTIZE) {
+			program = depalShaderCache_->GetDepalettizeShader(entry->framebuffer->format);
+		}
+		if (program) {
 			GLuint clutTexture = depalShaderCache_->GetClutTexture(clutHash_, clutBuf_);
 			if (!entry->depalFBO) {
 				entry->depalFBO = fbo_create(entry->framebuffer->renderWidth, entry->framebuffer->renderHeight, 1, false, FBO_8888);
@@ -913,7 +909,6 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 			};
 			static const GLubyte indices[4] = { 0, 1, 3, 2 };
 
-			GLuint program = depalShaderCache_->GetDepalettizeShader(entry->framebuffer->format);
 			glUseProgram(program);
 
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -953,6 +948,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 			glstate.Restore();
 			framebufferManager_->RebindFramebuffer();
 		} else {
+			entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
 			framebufferManager_->BindFramebufferColor(entry->framebuffer);
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -936,6 +936,9 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 			glDisable(GL_CULL_FACE);
 			glDisable(GL_DEPTH_TEST);
 			glDisable(GL_STENCIL_TEST);
+#if !defined(USING_GLES2)
+			glDisable(GL_LOGIC_OP);
+#endif
 			glViewport(0, 0, entry->framebuffer->renderWidth, entry->framebuffer->renderHeight);
 
 			glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 12, pos);

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -153,7 +153,6 @@ private:
 	u32 GetCurrentClutHash();
 	void UpdateCurrentClut();
 	void AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch);
-	bool AttachFramebufferCLUT(TextureCache::TexCacheEntry *entry, VirtualFramebuffer *framebuffer, u32 address);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry);
 


### PR DESCRIPTION
I figure it's fine to only bother to generate a clut shader when we're about to use it, since any other time won't actually tell us if it's successful.  It does mean slightly different logic than before if not successful, though (with the invalid attachment thing.)

-[Unknown]
