### PR TITLE
Use texelFetch to handle ABSDIFF mode

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -367,12 +367,7 @@ void GenerateFragmentShader(char *buffer) {
 	// PowerVR needs highp to do the fog in MHU correctly.
 	// Others don't, and some can't handle highp in the fragment shader.
 	highpFog = gl_extensions.gpuVendor == GPU_VENDOR_POWERVR;
-	
-	// GL_NV_shader_framebuffer_fetch available on mobile platform and ES 2.0 only but not desktop
-	if (gl_extensions.NV_shader_framebuffer_fetch) {
-		WRITE(p, "  #extension GL_NV_shader_framebuffer_fetch : require\n");
-	}
-	
+		
 #elif !defined(FORCE_OPENGL_2_0)
 	if (gl_extensions.VersionGEThan(3, 3, 0)) {
 		fragColor0 = "fragColor0";
@@ -422,8 +417,9 @@ void GenerateFragmentShader(char *buffer) {
 	if (gstate_c.textureFullAlpha && gstate.getTextureFunction() != GE_TEXFUNC_REPLACE)
 		doTextureAlpha = false;
 
-	if (doTexture)
+	if (doTexture) {
 		WRITE(p, "uniform sampler2D tex;\n");
+	}
 
 	if (enableAlphaTest || enableColorTest) {
 		WRITE(p, "uniform vec4 u_alphacolorref;\n");
@@ -602,10 +598,10 @@ void GenerateFragmentShader(char *buffer) {
 		}
 	}
 
-	// Handle ABSDIFF blending mode using NV_shader_framebuffer_fetch
-	if (computeAbsdiff && gl_extensions.NV_shader_framebuffer_fetch) {
-		WRITE(p, "  lowp vec4 destColor = gl_LastFragData[0];\n");
-		WRITE(p, "  gl_FragColor = abs(destColor - v);\n");
+	// Handle ABSDIFF blending mode 
+	if (computeAbsdiff) {
+		WRITE(p, "  lowp vec4 destColor = texelFetch(tex, ivec2(gl_FragCoord.xy), 0);\n");
+		WRITE(p, "  v = abs(destColor - v);\n");
 	}
 
 	switch (stencilToAlpha) {

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -318,14 +318,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.blendFuncSeparate.set(glBlendFuncA, glBlendFuncB, GL_ZERO, GL_ONE);
 		}
 
-		if (blendFuncEq == GE_BLENDMODE_ABSDIFF) {
-			WARN_LOG_REPORT_ONCE(blendAbsdiff, G3D, "Unsupported absdiff blend mode");
-		}
-
 		if (((blendFuncEq >= GE_BLENDMODE_MIN) && gl_extensions.EXT_blend_minmax) || gl_extensions.GLES3) {
-			if (blendFuncEq == GE_BLENDMODE_ABSDIFF && gl_extensions.NV_shader_framebuffer_fetch) {
-				// Handle GE_BLENDMODE_ABSDIFF in fragment shader and turn off regular alpha blending here.
-				glstate.blend.set(false);
+			if (blendFuncEq == GE_BLENDMODE_ABSDIFF) {
+				// Handle GE_BLENDMODE_ABSDIFF in fragment shader.
 			} else {
 				glstate.blendEquation.set(eqLookup[blendFuncEq]);
 			}


### PR DESCRIPTION
Meanwhile , getting rid of usage of NV_shader_framebuffer_fetch .Tested on Nvidia only with OpengGL 4.4

Courtesy of @unknownbrackets to get this fixed.

Fixes https://github.com/hrydgard/ppsspp/issues/3001
