### PR TITLE
Apply unsupported blending modes in the shader

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -314,7 +314,7 @@ bool ShouldUseShaderBlending() {
 			u32 fixA = gstate.getFixA();
 			u32 fixB = gstate.getFixB();
 			// OpenGL only supports one constant color, so check if we could be more exact.
-			if (fixA != fixB && fixA != 0xFFFFFF - fixB) {
+			if (fixA != fixB && fixA != 0xFFFFFF - fixB && fixA != 0 && fixB != 0 && fixA != 0xFFFFFF && fixB != 0xFFFFFF) {
 				return true;
 			}
 		}

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -742,21 +742,12 @@ void GenerateFragmentShader(char *buffer) {
 				WRITE(p, "  v.rgb = destColor.rgb * %s - v.rgb * %s;\n", srcFactor, dstFactor);
 				break;
 			case GE_BLENDMODE_MIN:
-				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
-					WARN_LOG_REPORT(G3D, "Using MIN blend equation with odd factors: %d, %d", funcA, funcB);
-				}
 				WRITE(p, "  v.rgb = min(v.rgb, destColor.rgb);\n");
 				break;
 			case GE_BLENDMODE_MAX:
-				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
-					WARN_LOG_REPORT(G3D, "Using MAX blend equation with odd factors: %d, %d", funcA, funcB);
-				}
 				WRITE(p, "  v.rgb = max(v.rgb, destColor.rgb);\n");
 				break;
 			case GE_BLENDMODE_ABSDIFF:
-				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
-					WARN_LOG_REPORT(G3D, "Using ABSDIFF blend equation with odd factors: %d, %d", funcA, funcB);
-				}
 				WRITE(p, "  v.rgb = abs(v.rgb - destColor.rgb);\n");
 				break;
 			}

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -707,11 +707,11 @@ void GenerateFragmentShader(char *buffer) {
 			case GE_SRCBLEND_INVSRCALPHA:       srcFactor = "vec3(1.0 - v.a)"; break;
 			case GE_SRCBLEND_DSTALPHA:          srcFactor = "vec3(destColor.a)"; break;
 			case GE_SRCBLEND_INVDSTALPHA:       srcFactor = "vec3(1.0 - destColor.a)"; break;
-			case GE_SRCBLEND_DOUBLESRCALPHA:    srcFactor = "vec3(v.a + v.a)"; break;
+			case GE_SRCBLEND_DOUBLESRCALPHA:    srcFactor = "vec3(v.a * 2.0)"; break;
 			// TODO: Double inverse, or inverse double?  Following softgpu for now...
-			case GE_SRCBLEND_DOUBLEINVSRCALPHA: srcFactor = "vec3(1.0 - v.a - v.a)"; break;
-			case GE_SRCBLEND_DOUBLEDSTALPHA:    srcFactor = "vec3(destColor.a + destColor.a)"; break;
-			case GE_SRCBLEND_DOUBLEINVDSTALPHA: srcFactor = "vec3(1.0 - destColor.a - destColor.a)"; break;
+			case GE_SRCBLEND_DOUBLEINVSRCALPHA: srcFactor = "vec3(1.0 - v.a * 2.0)"; break;
+			case GE_SRCBLEND_DOUBLEDSTALPHA:    srcFactor = "vec3(destColor.a * 2.0)"; break;
+			case GE_SRCBLEND_DOUBLEINVDSTALPHA: srcFactor = "vec3(1.0 - destColor.a * 2.0)"; break;
 			case GE_SRCBLEND_FIXA:              srcFactor = "u_blendFixA"; break;
 			}
 			switch (funcB)
@@ -722,10 +722,10 @@ void GenerateFragmentShader(char *buffer) {
 			case GE_DSTBLEND_INVSRCALPHA:       dstFactor = "vec3(1.0 - v.a)"; break;
 			case GE_DSTBLEND_DSTALPHA:          dstFactor = "vec3(destColor.a)"; break;
 			case GE_DSTBLEND_INVDSTALPHA:       dstFactor = "vec3(1.0 - destColor.a)"; break;
-			case GE_DSTBLEND_DOUBLESRCALPHA:    dstFactor = "vec3(v.a + v.a)"; break;
-			case GE_DSTBLEND_DOUBLEINVSRCALPHA: dstFactor = "vec3(1.0 - v.a - v.a)"; break;
-			case GE_DSTBLEND_DOUBLEDSTALPHA:    dstFactor = "vec3(destColor.a + destColor.a)"; break;
-			case GE_DSTBLEND_DOUBLEINVDSTALPHA: dstFactor = "vec3(1.0 - destColor.a - destColor.a)"; break;
+			case GE_DSTBLEND_DOUBLESRCALPHA:    dstFactor = "vec3(v.a * 2.0)"; break;
+			case GE_DSTBLEND_DOUBLEINVSRCALPHA: dstFactor = "vec3(1.0 - v.a * 2.0)"; break;
+			case GE_DSTBLEND_DOUBLEDSTALPHA:    dstFactor = "vec3(destColor.a * 2.0)"; break;
+			case GE_DSTBLEND_DOUBLEINVDSTALPHA: dstFactor = "vec3(1.0 - destColor.a * 2.0)"; break;
 			case GE_DSTBLEND_FIXB:              dstFactor = "u_blendFixB"; break;
 			}
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -399,10 +399,11 @@ void ComputeFragmentShaderID(FragmentShaderID *id) {
 			gpuStats.numNonAlphaTestedDraws++;
 
 		if (ShouldUseShaderBlending()) {
-			// 11 bits total.
-			id1 |= (gstate.getBlendEq() << 0);
-			id1 |= (gstate.getBlendFuncA() << 3);
-			id1 |= (gstate.getBlendFuncB() << 7);
+			// 12 bits total.
+			id1 |= 1;
+			id1 |= (gstate.getBlendEq() << 1);
+			id1 |= (gstate.getBlendFuncA() << 4);
+			id1 |= (gstate.getBlendFuncB() << 8);
 		}
 	}
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -744,19 +744,19 @@ void GenerateFragmentShader(char *buffer) {
 				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
 					WARN_LOG_REPORT(G3D, "Using MIN blend equation with odd factors: %d, %d", funcA, funcB);
 				}
-				WRITE(p, "  v.rgb = min(v.rgb, destColor.rgb);\n", srcFactor, dstFactor);
+				WRITE(p, "  v.rgb = min(v.rgb, destColor.rgb);\n");
 				break;
 			case GE_BLENDMODE_MAX:
 				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
 					WARN_LOG_REPORT(G3D, "Using MAX blend equation with odd factors: %d, %d", funcA, funcB);
 				}
-				WRITE(p, "  v.rgb = max(v.rgb, destColor.rgb);\n", srcFactor, dstFactor);
+				WRITE(p, "  v.rgb = max(v.rgb, destColor.rgb);\n");
 				break;
 			case GE_BLENDMODE_ABSDIFF:
 				if (funcA != GE_SRCBLEND_DSTCOLOR || funcB != GE_DSTBLEND_SRCCOLOR) {
 					WARN_LOG_REPORT(G3D, "Using ABSDIFF blend equation with odd factors: %d, %d", funcA, funcB);
 				}
-				WRITE(p, "  v.rgb = abs(v.rgb - destColor.rgb);\n", srcFactor, dstFactor);
+				WRITE(p, "  v.rgb = abs(v.rgb - destColor.rgb);\n");
 				break;
 			}
 		}

--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -20,9 +20,9 @@
 #include "Globals.h"
 
 struct FragmentShaderID {
-	FragmentShaderID() {d[0] = 0xFFFFFFFF;}
-	void clear() {d[0] = 0xFFFFFFFF;}
-	u32 d[1];
+	FragmentShaderID() {clear();}
+	void clear() {d[0] = 0xFFFFFFFF; d[1] = 0xFFFFFFFF;}
+	u32 d[2];
 	bool operator < (const FragmentShaderID &other) const {
 		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
 			if (d[i] < other.d[i])
@@ -62,4 +62,4 @@ bool IsAlphaTestTriviallyTrue();
 bool IsColorTestTriviallyTrue();
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil();
-
+bool ShouldUseShaderBlending();

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1007,6 +1007,10 @@ void FramebufferManager::BindFramebufferDepth(VirtualFramebuffer *sourceframebuf
 }
 
 void FramebufferManager::BindFramebufferColor(VirtualFramebuffer *framebuffer) {
+	if (framebuffer == NULL) {
+		framebuffer = currentRenderVfb_;
+	}
+
 	if (!framebuffer->fbo || !useBufferedRendering_) {
 		glBindTexture(GL_TEXTURE_2D, 0);
 		gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -784,7 +784,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 
 	// None found? Create one.
 	if (!vfb) {
-		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+		textureCache_->ForgetLastTexture();
 		vfb = new VirtualFramebuffer();
 		vfb->fbo = 0;
 		vfb->fb_address = fb_address;
@@ -891,7 +891,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		// Use it as a render target.
 		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+		textureCache_->ForgetLastTexture();
 		vfb->last_frame_render = gpuStats.numFlips;
 		frameLastFramebufUsed = gpuStats.numFlips;
 		vfb->dirtyAfterDisplay = true;
@@ -1248,7 +1248,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 			glEnable(GL_DITHER);
 		} else {
 			nvfb->usageFlags |= FB_USAGE_RENDERTARGET;
-			gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+			textureCache_->ForgetLastTexture();
 			nvfb->last_frame_render = gpuStats.numFlips;
 			nvfb->dirtyAfterDisplay = true;
 
@@ -1392,6 +1392,7 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 		float srcH = src->height;
 		DrawActiveTexture(0, dstX, dstY, w, h, dst->width, dst->height, false, srcX / srcW, srcY / srcH, (srcX + w) / srcW, (srcY + h) / srcH, draw2dprogram_);
 		glBindTexture(GL_TEXTURE_2D, 0);
+		textureCache_->ForgetLastTexture();
 	}
 
 	glstate.scissorTest.restore();
@@ -1923,7 +1924,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 				fbo_unbind();
 			}
 			glstate.viewport.restore();
-			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+			textureCache_->ForgetLastTexture();
 			// This is a memcpy, let's still copy just in case.
 			return false;
 		}
@@ -2057,7 +2058,7 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 					fbo_unbind();
 				}
 				glstate.viewport.restore();
-				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
+				textureCache_->ForgetLastTexture();
 			}
 		}
 	}

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -162,8 +162,8 @@ static const CommandTableEntry commandTable[] = {
 	{GE_CMD_STENCILTESTENABLE, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_ALPHABLENDENABLE, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_BLENDMODE, FLAG_FLUSHBEFOREONCHANGE},
-	{GE_CMD_BLENDFIXEDA, FLAG_FLUSHBEFOREONCHANGE},
-	{GE_CMD_BLENDFIXEDB, FLAG_FLUSHBEFOREONCHANGE},
+	{GE_CMD_BLENDFIXEDA, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTEONCHANGE, &GLES_GPU::Execute_BlendFixA},
+	{GE_CMD_BLENDFIXEDB, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTEONCHANGE, &GLES_GPU::Execute_BlendFixB},
 	{GE_CMD_MASKRGB, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_MASKALPHA, FLAG_FLUSHBEFOREONCHANGE},
 	{GE_CMD_ZTEST, FLAG_FLUSHBEFOREONCHANGE},
@@ -1080,6 +1080,14 @@ void GLES_GPU::Execute_ColorRef(u32 op, u32 diff) {
 	shaderManager_->DirtyUniform(DIRTY_ALPHACOLORREF);
 }
 
+void GLES_GPU::Execute_BlendFixA(u32 op, u32 diff) {
+	shaderManager_->DirtyUniform(DIRTY_BLENDFIX);
+}
+
+void GLES_GPU::Execute_BlendFixB(u32 op, u32 diff) {
+	shaderManager_->DirtyUniform(DIRTY_BLENDFIX);
+}
+
 void GLES_GPU::Execute_WorldMtxNum(u32 op, u32 diff) {
 	// This is almost always followed by GE_CMD_WORLDMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointer(currentList->pc + 4);
@@ -1607,8 +1615,14 @@ void GLES_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 	//////////////////////////////////////////////////////////////////
 	case GE_CMD_ALPHABLENDENABLE:
 	case GE_CMD_BLENDMODE:
+		break;
+
 	case GE_CMD_BLENDFIXEDA:
+		Execute_BlendFixA(op, diff);
+		break;
+
 	case GE_CMD_BLENDFIXEDB:
+		Execute_BlendFixB(op, diff);
 		break;
 
 	case GE_CMD_ALPHATESTENABLE:

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -123,6 +123,8 @@ public:
 	void Execute_AlphaTest(u32 op, u32 diff);
 	void Execute_StencilTest(u32 op, u32 diff);
 	void Execute_ColorRef(u32 op, u32 diff);
+	void Execute_BlendFixA(u32 op, u32 diff);
+	void Execute_BlendFixB(u32 op, u32 diff);
 	void Execute_WorldMtxNum(u32 op, u32 diff);
 	void Execute_WorldMtxData(u32 op, u32 diff);
 	void Execute_ViewMtxNum(u32 op, u32 diff);

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -155,6 +155,10 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	u_colormask = glGetUniformLocation(program, "u_colormask");
 	u_stencilReplaceValue = glGetUniformLocation(program, "u_stencilReplaceValue");
 
+	u_fbotex = glGetUniformLocation(program, "fbotex");
+	u_blendFixA = glGetUniformLocation(program, "u_blendFixA");
+	u_blendFixB = glGetUniformLocation(program, "u_blendFixB");
+
 	// Transform
 	u_view = glGetUniformLocation(program, "u_view");
 	u_world = glGetUniformLocation(program, "u_world");
@@ -225,6 +229,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	if (u_view != -1) availableUniforms |= DIRTY_VIEWMATRIX;
 	if (u_texmtx != -1) availableUniforms |= DIRTY_TEXMATRIX;
 	if (u_stencilReplaceValue != -1) availableUniforms |= DIRTY_STENCILREPLACEVALUE;
+	if (u_blendFixA != -1 || u_blendFixB != -1) availableUniforms |= DIRTY_BLENDFIX;
 
 	// Looping up to numBones lets us avoid checking u_bone[i]
 	for (int i = 0; i < numBones; i++) {
@@ -247,6 +252,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 
 	// Default uniform values
 	glUniform1i(u_tex, 0);
+	glUniform1i(u_fbotex, 1);
 	// The rest, use the "dirty" mechanism.
 	dirtyUniforms = DIRTY_ALL;
 	use(vertType, previous);
@@ -519,6 +525,11 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 		}
 	}
 #endif
+
+	if (dirty & DIRTY_BLENDFIX) {
+		SetColorUniform3(u_blendFixA, gstate.getFixA());
+		SetColorUniform3(u_blendFixB, gstate.getFixB());
+	}
 
 	// Lighting
 	if (dirty & DIRTY_AMBIENT) {

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -73,6 +73,11 @@ public:
 #endif
 	int numBones;
 
+	// Shader blending.
+	int u_fbotex;
+	int u_blendFixA;
+	int u_blendFixB;
+
 	// Fragment processing inputs
 	int u_alphacolorref;
 	int u_colormask;
@@ -123,7 +128,7 @@ enum
 	DIRTY_AMBIENT = (1 << 15),
 	DIRTY_MATAMBIENTALPHA = (1 << 16),
 
-	// 1 << 17 is free!
+	DIRTY_BLENDFIX = (1 << 17),  // (either one.)
 
 	DIRTY_UVSCALEOFFSET = (1 << 18),  // this will be dirtied ALL THE TIME... maybe we'll need to do "last value with this shader compares"
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -178,6 +178,19 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 	bool wantBlend = !gstate.isModeClear() && gstate.isAlphaBlendEnabled();
 	if (wantBlend && ShouldUseShaderBlending()) {
 		if (!gl_extensions.NV_shader_framebuffer_fetch) {
+			static const int MAX_REASONABLE_BLITS_PER_FRAME = 24;
+
+			static int lastFrameBlit = -1;
+			static int blitsThisFrame = 0;
+			if (lastFrameBlit != gpuStats.numFlips) {
+				if (blitsThisFrame > MAX_REASONABLE_BLITS_PER_FRAME) {
+					WARN_LOG_REPORT_ONCE(blendingBlit, G3D, "Lots of blits needed for obscure blending: %d per frame, blend %d/%d/%d", blitsThisFrame, gstate.getBlendFuncA(), gstate.getBlendFuncB(), gstate.getBlendEq());
+				}
+				blitsThisFrame = 0;
+				lastFrameBlit = gpuStats.numFlips;
+			}
+			++blitsThisFrame;
+
 			glActiveTexture(GL_TEXTURE1);
 			framebufferManager_->BindFramebufferColor(NULL);
 			glActiveTexture(GL_TEXTURE0);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -171,9 +171,6 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
 	}
 
-	// TODO: The top bit of the alpha channel should be written to the stencil bit somehow. This appears to require very expensive multipass rendering :( Alternatively, one could do a
-	// single fullscreen pass that converts alpha to stencil (or 2 passes, to set both the 0 and 1 values) very easily.
-
 	// Set blend
 	bool wantBlend = !gstate.isModeClear() && gstate.isAlphaBlendEnabled();
 	if (wantBlend && ShouldUseShaderBlending()) {

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -171,7 +171,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
 	}
 
-	// Set blend
+	// Set blend - unless we need to do it in the shader.
 	bool wantBlend = !gstate.isModeClear() && gstate.isAlphaBlendEnabled();
 	if (wantBlend && ShouldUseShaderBlending()) {
 		if (!gl_extensions.NV_shader_framebuffer_fetch) {
@@ -191,10 +191,16 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glActiveTexture(GL_TEXTURE1);
 			framebufferManager_->BindFramebufferColor(NULL);
 			glActiveTexture(GL_TEXTURE0);
+			fboTexBound_ = true;
 		}
 		// None of the below logic is interesting, we're gonna do it entirely in the shader.
 		wantBlend = false;
+	} else if (fboTexBound_) {
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		glActiveTexture(GL_TEXTURE0);
 	}
+
 	glstate.blend.set(wantBlend);
 	if (wantBlend) {
 		// This can't be done exactly as there are several PSP blend modes that are impossible to do on OpenGL ES 2.0, and some even on regular OpenGL for desktop.

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -65,6 +65,11 @@ public:
 		return cache.size();
 	}
 
+	void ForgetLastTexture() {
+		lastBoundTexture = -1;
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+	}
+
 	// Only used by Qt UI?
 	bool DecodeTexture(u8 *output, GPUgstate state);
 

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -126,7 +126,8 @@ TransformDrawEngine::TransformDrawEngine()
 		numDrawCalls(0),
 		vertexCountInDrawCalls(0),
 		decodeCounter_(0),
-		uvScale(0) {
+		uvScale(0),
+		fboTexBound_(false) {
 	decimationCounter_ = VERTEXCACHE_DECIMATION_INTERVAL;
 	// Allocate nicely aligned memory. Maybe graphics drivers will
 	// appreciate it.

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -243,4 +243,6 @@ private:
 	u32 dcid_;
 
 	UVScale *uvScale;
+
+	bool fboTexBound_;
 };


### PR DESCRIPTION
This handles unsupported fixed color combinations, alpha doubling, etc.

Where possible, tries to avoid it - it means using a blit (without the framebuffer fetch extension), which can slow things down a lot with tons of drawcalls.

This fixes some effects in games which use doubling blend modes, but I haven't tested all the cases (especially since I don't have all the games.)  It also does absdiff blending and mismatched fixed color blending.  It will not help GLES2, and requires GLES3+ or OpenGL 3.0+.

I'm worried this might need a setting.  Before I made `AlphaToColorDoubling() || CanDoubleSrcBlendMode()` bail, it made Popolocrois severely slower.  However, it does allow more accuracy.

-[Unknown]
