### PR TITLE
Optimize double alpha blending for 1/0 textures

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -238,7 +238,14 @@ static bool AlphaToColorDoubling() {
 	// 2x alpha in the source function and full alpha = source color doubling.
 	// If we see this, we don't really need to care about the dest alpha function - sure we can't handle
 	// the doubling dest ones, but there's nothing we can do about that.
-	return (gstate.getBlendFuncA() == GE_SRCBLEND_DOUBLESRCALPHA) && (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed()));
+	if (gstate.getBlendFuncA() != GE_SRCBLEND_DOUBLESRCALPHA) {
+		return false;
+	}
+	if (gstate.getBlendFuncB() == GE_DSTBLEND_INVSRCALPHA) {
+		// If it's 1.0 or 0.0, then we can still color double (since 0.0 will blend out anyway.)
+		return (gstate_c.vertexFullAlpha && (gstate_c.textureSimpleAlpha || !gstate.isTextureAlphaUsed()));
+	}
+	return (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed()));
 }
 
 static bool CanDoubleSrcBlendMode() {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -883,6 +883,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 		gstate_c.curTextureHeight = entry->framebuffer->height;
 		gstate_c.flipTexture = true;
 		gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
+		gstate_c.textureSimpleAlpha = false;
 	} else {
 		if (entry->framebuffer->fbo)
 			entry->framebuffer->fbo = 0;
@@ -1071,6 +1072,7 @@ void TextureCache::SetTexture(bool force) {
 				glBindTexture(GL_TEXTURE_2D, entry->texture);
 				lastBoundTexture = entry->texture;
 				gstate_c.textureFullAlpha = entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL;
+				gstate_c.textureSimpleAlpha = entry->GetAlphaStatus() != TexCacheEntry::STATUS_ALPHA_UNKNOWN;
 			}
 			UpdateSamplingParams(*entry, false);
 			VERBOSE_LOG(G3D, "Texture at %08x Found in Cache, applying", texaddr);
@@ -1303,6 +1305,7 @@ void TextureCache::SetTexture(bool force) {
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
 	gstate_c.textureFullAlpha = entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL;
+	gstate_c.textureSimpleAlpha = entry->GetAlphaStatus() != TexCacheEntry::STATUS_ALPHA_UNKNOWN;
 }
 
 GLenum TextureCache::GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const {

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -270,7 +270,7 @@ struct GPUStateCache_v0
 };
 
 void GPUStateCache::DoState(PointerWrap &p) {
-	auto s = p.Section("GPUStateCache", 0, 2);
+	auto s = p.Section("GPUStateCache", 0, 3);
 	if (!s) {
 		// Old state, this was not versioned.
 		GPUStateCache_v0 old;
@@ -300,6 +300,12 @@ void GPUStateCache::DoState(PointerWrap &p) {
 
 		p.Do(uv);
 		p.Do(flipTexture);
+	}
+
+	if (s >= 3) {
+		p.Do(textureSimpleAlpha);
+	} else {
+		textureSimpleAlpha = false;
 	}
 
 	if (s < 2) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -450,6 +450,7 @@ struct GPUStateCache
 
 	u8 textureChanged;
 	bool textureFullAlpha;
+	bool textureSimpleAlpha;
 	bool vertexFullAlpha;
 	bool framebufChanged;
 


### PR DESCRIPTION
If the blend is 2*a / 1-a, and the alpha is either 1 or 0, we can still use color doubling instead.  Fixes #3379 (Persona 2.)

Without the performance hit of #6070.

-[Unknown]
