### PR TITLE
Cleanup psmfplayer pts/frame/audio sync, handle start parameters

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1232,6 +1232,13 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 	psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING;
 
 	psmfplayer->mediaengine->openContext();
+	// TODO: It would be better to spread this out into the Update() calls.
+	while (!psmfplayer->mediaengine->seekTo(initPts, videoPixelMode)) {
+		_PsmfPlayerFillRingbuffer(psmfplayer);
+		if (psmfplayer->mediaengine->IsVideoEnd()) {
+			break;
+		}
+	}
 	return 0;
 }
 
@@ -1555,7 +1562,7 @@ u32 scePsmfPlayerGetCurrentAudioStream(u32 psmfPlayer, u32 audioCodecAddr, u32 a
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerGetCurrentAudioStream(%08x, %08x, %08x): invalid psmf player", psmfPlayer, audioCodecAddr, audioStreamNumAddr);
-		return ERROR_PSMF_NOT_FOUND;
+		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 	if (psmfplayer->status == PSMF_PLAYER_STATUS_INIT) {
 		ERROR_LOG(ME, "scePsmfPlayerGetCurrentVideoStream(%08x): psmf not yet set", psmfPlayer);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1213,11 +1213,32 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 		return ERROR_PSMFPLAYER_INVALID_PARAM;
 	}
 
+	if (psmfplayer->totalAudioStreams > 0) {
+		if (playerData->audioCodec != 0x0F && playerData->audioCodec != 0x01) {
+			ERROR_LOG_REPORT(ME, "scePsmfPlayerStart(%08x, %08x, %d): invalid audio codec %02x", psmfPlayer, psmfPlayerData, initPts, playerData->audioCodec);
+			return ERROR_PSMFPLAYER_INVALID_STREAM;
+		}
+		if (playerData->audioStreamNum >= psmfplayer->totalAudioStreams) {
+			ERROR_LOG_REPORT(ME, "scePsmfPlayerStart(%08x, %08x, %d): unable to change audio stream to %d", psmfPlayer, psmfPlayerData, initPts, playerData->audioStreamNum);
+			return ERROR_PSMFPLAYER_INVALID_CONFIG;
+		}
+	}
+	if (playerData->videoCodec != 0x0E && playerData->videoCodec != 0x00) {
+		ERROR_LOG_REPORT(ME, "scePsmfPlayerStart(%08x, %08x, %d): invalid video codec %02x", psmfPlayer, psmfPlayerData, initPts, playerData->videoCodec);
+		return ERROR_PSMFPLAYER_INVALID_STREAM;
+	}
+	if (playerData->videoStreamNum < 0 || playerData->videoStreamNum >= psmfplayer->totalVideoStreams) {
+		ERROR_LOG_REPORT(ME, "scePsmfPlayerStart(%08x, %08x, %d): unable to change video stream to %d", psmfPlayer, psmfPlayerData, initPts, playerData->videoStreamNum);
+		return ERROR_PSMFPLAYER_INVALID_CONFIG;
+	}
+
 	WARN_LOG(ME, "scePsmfPlayerStart(%08x, %08x, %d)", psmfPlayer, psmfPlayerData, initPts);
 
+	psmfplayer->mediaengine->setVideoStream(playerData->videoStreamNum);
 	psmfplayer->videoCodec = playerData->videoCodec;
 	psmfplayer->videoStreamNum = playerData->videoStreamNum;
 	if (!psmfplayer->mediaengine->IsNoAudioData()) {
+		psmfplayer->mediaengine->setAudioStream(playerData->audioStreamNum);
 		psmfplayer->audioCodec = playerData->audioCodec;
 		psmfplayer->audioStreamNum = playerData->audioStreamNum;
 	}

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -678,7 +678,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			data += m_desWidth * sizeof(u32);
 			imgbuf += frameWidth * sizeof(u32);
 #ifndef MOBILE_DEVICE
-			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u32), true, width * sizeof(u32), currentMIPS->pc);
+			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u32), true, width * sizeof(u32), currentMIPS->pc);
 #endif
 		}
 		videoImageSize = frameWidth * sizeof(u32) * m_desHeight;
@@ -691,7 +691,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
 #ifndef MOBILE_DEVICE
-			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
 #endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
@@ -704,7 +704,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
 #ifndef MOBILE_DEVICE
-			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
 #endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;
@@ -717,7 +717,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			data += m_desWidth * sizeof(u16);
 			imgbuf += frameWidth * sizeof(u16);
 #ifndef MOBILE_DEVICE
-			CBreakPoints::ExecMemCheck(bufferPtr + frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
+			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
 #endif
 		}
 		videoImageSize = frameWidth * sizeof(u16) * m_desHeight;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -359,6 +359,28 @@ int MediaEngine::addStreamData(u8* buffer, int addSize) {
 	return size;
 }
 
+bool MediaEngine::seekTo(s64 timestamp, int videoPixelMode) {
+	if (timestamp <= 0) {
+		return true;
+	}
+
+	// Just doing it the not so great way to be sure audio is in sync.
+	int timeout = 1000;
+	while (getVideoTimeStamp() < timestamp - 3003) {
+		if (getAudioTimeStamp() < getVideoTimeStamp()) {
+			getNextAudioFrame(NULL, NULL, NULL);
+		}
+		if (!stepVideo(videoPixelMode)) {
+			return false;
+		}
+		if (--timeout <= 0) {
+			return true;
+		}
+	}
+
+	return true;
+}
+
 bool MediaEngine::setVideoStream(int streamNum, bool force) {
 	if (m_videoStream == streamNum && !force) {
 		// Yay, nothing to do.
@@ -733,6 +755,16 @@ int MediaEngine::getAudioRemainSize() {
 	return m_demux->getRemainSize();
 }
 
+int MediaEngine::getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2) {
+	// When getting a frame, increment pts
+	m_audiopts += 4180;
+
+	// Demux now (rather than on add data) so that we select the right stream.
+	m_demux->demux(m_audioStream);
+
+	return m_demux->getNextAudioFrame(buf, headerCode1, headerCode2);
+}
+
 int MediaEngine::getAudioSamples(u32 bufferPtr) {
 	if (!Memory::IsValidAddress(bufferPtr)) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);
@@ -743,15 +775,9 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 		return 0;
 	}
 
-	// When getting a frame, increment pts
-	m_audiopts += 4180;
-	
-	// Demux now (rather than on add data) so that we select the right stream.
-	m_demux->demux(m_audioStream);
-
 	u8 *audioFrame = 0;
 	int headerCode1, headerCode2;
-	int frameSize = m_demux->getNextAudioFrame(&audioFrame, &headerCode1, &headerCode2);
+	int frameSize = getNextAudioFrame(&audioFrame, &headerCode1, &headerCode2);
 	if (frameSize == 0) {
 		return 0;
 	}

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -66,6 +66,7 @@ public:
 
 	// Returns number of packets actually added. I guess the buffer might be full.
 	int addStreamData(u8* buffer, int addSize);
+	bool seekTo(s64 timestamp, int videoPixelMode);
 
 	bool setVideoStream(int streamNum, bool force = false);
 	// TODO: Return false if the stream doesn't exist.
@@ -93,6 +94,7 @@ public:
 
 private:
 	void updateSwsFormat(int videoPixelMode);
+	int getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2);
 
 public:  // TODO: Very little of this below should be public.
 

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -248,7 +248,9 @@ int MpegDemux::getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2)
 		audioPos = gotsize;
 	}
 	m_audioStream.pop_front(0, audioPos);
-	*buf = m_audioFrame + 8;
+	if (buf) {
+		*buf = m_audioFrame + 8;
+	}
 	return frameSize - 8;
 }
 


### PR DESCRIPTION
This does several things:
- Fixes error codes in scePsmfPlayerStart() and scePsmfPlayerGetCurrentPts().
- Allows scePsmfPlayerStart() to select an initial pts or rewind (with warmup, as the official lib also has.)
- Selects the correct streams when starting a video, for multistream videos.  Practically, may help EUR games that have multiple audio tracks or something.
- Skip video frames if audio is far ahead of the video (as the official psmfplayer lib also does.)

With this, the frame and audio data generally matches (with small variations, I get +0x00020202 brighter on my PSP in videos, and a few bits different in the audio stream) what comes out of the PSP when decoding.

-[Unknown]
