### PR TITLE
Fixed PPSSPP crash on iOS 5. Fixes issue #5613.

### DIFF
--- a/Common/MemArena.cpp
+++ b/Common/MemArena.cpp
@@ -34,10 +34,6 @@
 #endif
 #endif
 
-#ifdef IOS
-void* globalbase=NULL;
-#endif
-
 #ifdef ANDROID
 
 // Hopefully this ABI will never change...
@@ -249,28 +245,13 @@ u8* MemArena::Find4GBBase()
 	}
 	return base;
 #else
-#ifdef IOS
-    void* base = NULL;
-    if (globalbase==NULL){
-        base = mmap(0, 0x08000000, PROT_READ | PROT_WRITE,
-                    MAP_ANON | MAP_SHARED, -1, 0);
-        if (base == MAP_FAILED) {
-            PanicAlert("Failed to map 128 MB of memory space: %s", strerror(errno));
-            return 0;
-        }
-        munmap(base, 0x08000000);
-        globalbase=base;
-    }
-    else{base=globalbase;}
-#else
-    void* base = mmap(0, 0x10000000, PROT_READ | PROT_WRITE,
-                      MAP_ANON | MAP_SHARED, -1, 0);
-    if (base == MAP_FAILED) {
-        PanicAlert("Failed to map 256 MB of memory space: %s", strerror(errno));
-        return 0;
-    }
-    munmap(base, 0x10000000);
-#endif
+	void* base = mmap(0, 0x10000000, PROT_READ | PROT_WRITE,
+		MAP_ANON | MAP_SHARED, -1, 0);
+	if (base == MAP_FAILED) {
+		PanicAlert("Failed to map 256 MB of memory space: %s", strerror(errno));
+		return 0;
+	}
+	munmap(base, 0x10000000);
 	return static_cast<u8*>(base);
 #endif
 #endif


### PR DESCRIPTION
This fixes the PPSSPP crash-on-launch bug that iOS 5 users have been experiencing for some time..

This also fixes issue #5613.

Tested to be working on multiple devices:
iOS: N90, N92, N81, N18, N41, N51, N42, N88
Android: X10, tate, mako, yuga
