### PR TITLE
Don't set pending boot flag on "stop"

### DIFF
--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -59,7 +59,7 @@ private:
 
 	void autoLoad();
 
-	bool booted_;
+	bool bootPending_;
 	std::string gamePath_;
 
 	// Something invalid was loaded, don't try to emulate


### PR DESCRIPTION
And rename to boot pending, not "boot successful", reversing all the cases (except "stop".)

I can't reproduce #6086, but this is my best guess.

-[Unknown]
