### PR TITLE
Fix gpu/ge/queue test, GE debugger breaking when not active

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -490,7 +490,10 @@ u32 sceGeDrawSync(u32 mode)
 int sceGeContinue()
 {
 	DEBUG_LOG(SCEGE, "sceGeContinue");
-	return gpu->Continue();
+	int ret = gpu->Continue();
+	hleEatCycles(220);
+	hleReSchedule("ge continue");
+	return ret;
 }
 
 int sceGeBreak(u32 mode, u32 unknownPtr)

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -31,7 +31,7 @@ enum PauseAction {
 	PAUSE_GETTEX,
 	PAUSE_SETCMDVALUE,
 };
-	
+
 static bool isStepping;
 
 static recursive_mutex pauseLock;
@@ -40,7 +40,7 @@ static PauseAction pauseAction = PAUSE_CONTINUE;
 static recursive_mutex actionLock;
 static condition_variable actionWait;
 // In case of accidental wakeup.
-static bool actionComplete;
+static volatile bool actionComplete;
 
 // Many things need to run on the GPU thread.  For example, reading the framebuffer.
 // A message system is used to achieve this (temporarily "unpausing" the thread.)

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -271,8 +271,8 @@ void CGEDebugger::SetBreakNext(BreakNextType type) {
 	attached = true;
 	SetupPreviews();
 
-	ResumeFromStepping();
 	breakNext = type;
+	ResumeFromStepping();
 }
 
 BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
@@ -455,7 +455,9 @@ static void DeliverMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
 }
 
 static void PauseWithMessage(UINT msg, WPARAM wParam = NULL, LPARAM lParam = NULL) {
-	EnterStepping(std::bind(&DeliverMessage, msg, wParam, lParam));
+	if (attached) {
+		EnterStepping(std::bind(&DeliverMessage, msg, wParam, lParam));
+	}
 }
 
 void WindowsHost::GPUNotifyCommand(u32 pc) {


### PR DESCRIPTION
Also, I think I hit some sort of race condition in the GE debugger in Trails in the Sky.  When hitting "step tex", it would sometimes just skip over a bunch of textures.  I'm not sure what's causing it, tried marking `actionComplete` volatile.

-[Unknown]
