### PR TITLE
Revert "Apply hleDelayResult to sceMpegAvcCsc"

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1799,7 +1799,10 @@ u32 sceMpegAvcCsc(u32 mpeg, u32 sourceAddr, u32 rangeAddr, int frameWidth, u32 d
 	int destSize = ctx->mediaengine->writeVideoImageWithRange(destAddr, frameWidth, ctx->videoPixelMode, x, y, width, height);
 
 	gpu->InvalidateCache(destAddr, destSize, GPU_INVALIDATE_SAFE);
-	return hleDelayResult(0, "mpeg avc csc", avcDecodeDelayMs);
+	// Do not hleDelayResult
+	// Will cause video 's screen dislocation in Bleach heat of soul 6
+	// https://github.com/hrydgard/ppsspp/issues/5535
+	return 0;
 }
 
 u32 sceMpegRingbufferDestruct(u32 ringbufferAddr)


### PR DESCRIPTION
This revert https://github.com/hrydgard/ppsspp/commit/54d97824e0ca396a9f162ec13bf06e7b8c176b9e

Fix video 's screen dislocation in Bleach heat of soul 6
Fix #5535

Before
![3](https://cloud.githubusercontent.com/assets/2177532/3006734/afc70706-de44-11e3-92f5-7a6078327471.png)

Changed
![2](https://cloud.githubusercontent.com/assets/2177532/3006736/b6fdd28e-de44-11e3-954b-2cbc5901476a.png)
