### PR TITLE
Fix nonblocking ptpConnect on Windows

### DIFF
--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -40,11 +40,13 @@ typedef int socklen_t;
 #define EAGAIN WSAEWOULDBLOCK
 #define EINPROGRESS WSAEWOULDBLOCK
 #define EISCONN WSAEISCONN
+inline bool connectInProgress(int errcode){ return (errcode == WSAEWOULDBLOCK || errcode == WSAEINVAL || errcode == WSAEALREADY); }
 #else
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1
 #define closesocket close
 #define PACK __attribute__((packed))
+inline bool connectInProgress(int errcode){ return (errcode == EINPROGRESS); }
 #endif
 
 // psp strutcs and definitions

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1474,7 +1474,7 @@ int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
 					}
 					
 					// Connection in Progress
-					else if (connectresult == -1 && errorcode == EINPROGRESS) {
+					else if (connectresult == -1 && connectInProgress(errorcode)) {
 						// Nonblocking Mode
 						if (flag) return ERROR_NET_ADHOC_WOULD_BLOCK;
 						


### PR DESCRIPTION
According to
http://msdn.microsoft.com/en-us/library/windows/desktop/ms737625%28v=vs.85%29.aspx
"[...] it is not recommended that applications use multiple calls to
connect to detect connection completion.  If they do, they must be
prepared to handle WSAEINVAL and WSAEWOULDBLOCK error values the same
way that they handle WSAEALREADY, to assure robust operation."

Ideally socket->state should be set to a different state and select()
used to poll sockets until state can be switched to closed or
established.  Changes to socket->state are visible to games as so
probably should not be done without testing.
