### PR TITLE
Added basic haptic feedback support for iOS platforms, made iOS bundle ID consistent with other platforms.

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>PPSSPP</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.rock88dev.PPSSPP</string>
+	<string>org.ppsspp.ppsspp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -4,6 +4,7 @@
 #import <string>
 #import <stdio.h>
 #import <stdlib.h>
+#import <AudioToolbox/AudioToolbox.h>
 
 #import "AppDelegate.h"
 
@@ -27,7 +28,8 @@ void System_SendMessage(const char *command, const char *parameter) {
 }
 
 void Vibrate(int length_ms) {
-	// TODO: Haptic feedback?
+	AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
+	// TODO: Actually make use of length_ms?
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
I added basic haptic feedback support for iOS platforms via AudioServicesPlaySystemSound(kSystemSoundID_Vibrate).

It does not make use of length_ms… yet. Fixes issue #5614.

Also, made the iOS bundle ID consistent with other platforms (`org.ppsspp.ppsspp`).
