### PR TITLE
Fix some minor issues in psmfplayer, schedule finish correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,6 +1016,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/HLE.h
 	Core/HLE/ReplaceTables.cpp
 	Core/HLE/ReplaceTables.h
+	Core/HLE/HLEHelperThread.cpp
+	Core/HLE/HLEHelperThread.h
 	Core/HLE/HLETables.cpp
 	Core/HLE/HLETables.h
 	Core/HLE/KernelWaitHelpers.h

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SRCS
   ELF/PrxDecrypter.cpp
   Font/PGF.cpp
   HLE/HLE.cpp
+  HLE/HLEHelperThread.cpp
   HLE/HLETables.cpp
   HLE/sceAtrac.cpp
   HLE/__sceAudio.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="Font\PGF.cpp" />
     <ClCompile Include="HDRemaster.cpp" />
     <ClCompile Include="HLE\HLE.cpp" />
+    <ClCompile Include="HLE\HLEHelperThread.cpp" />
     <ClCompile Include="HLE\HLETables.cpp" />
     <ClCompile Include="HLE\proAdhoc.cpp" />
     <ClCompile Include="HLE\ReplaceTables.cpp" />
@@ -472,6 +473,7 @@
     <ClInclude Include="HDRemaster.h" />
     <ClInclude Include="HLE\FunctionWrappers.h" />
     <ClInclude Include="HLE\HLE.h" />
+    <ClInclude Include="HLE\HLEHelperThread.h" />
     <ClInclude Include="HLE\HLETables.h" />
     <ClInclude Include="HLE\KernelWaitHelpers.h" />
     <ClInclude Include="HLE\proAdhoc.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -526,6 +526,9 @@
     <ClCompile Include="MIPS\x86\JitSafeMem.cpp">
       <Filter>MIPS\x86</Filter>
     </ClCompile>
+    <ClCompile Include="HLE\HLEHelperThread.cpp">
+      <Filter>HLE</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -971,6 +974,9 @@
     </ClInclude>
     <ClInclude Include="MIPS\x86\JitSafeMem.h">
       <Filter>MIPS\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="HLE\HLEHelperThread.h">
+      <Filter>HLE</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/HLE/HLEHelperThread.cpp
+++ b/Core/HLE/HLEHelperThread.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2014- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+#include "Common/ChunkFile.h"
+#include "Core/MemMap.h"
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/HLEHelperThread.h"
+#include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/sceKernelMemory.h"
+#include "Core/MIPS/MIPSCodeUtils.h"
+
+HLEHelperThread::HLEHelperThread() : id_(-1), entry_(0) {
+}
+
+HLEHelperThread::HLEHelperThread(const char *threadName, u32 instructions[], u32 instrCount, u32 prio, int stacksize) {
+	u32 bytes = instrCount * sizeof(u32);
+	u32 size = bytes + sizeof(u32) * 2;
+	AllocEntry(bytes);
+	Memory::Memcpy(entry_, instructions, bytes);
+
+	// Just to simplify things, we add the return here.
+	Memory::Write_U32(MIPS_MAKE_JR_RA(), entry_ + bytes + 0);
+	Memory::Write_U32(MIPS_MAKE_NOP(), entry_ + bytes + 4);
+
+	Create(threadName, prio, stacksize);
+}
+
+HLEHelperThread::HLEHelperThread(const char *threadName, const char *module, const char *func, u32 prio, int stacksize) {
+	const u32 bytes = sizeof(u32) * 2;
+	AllocEntry(bytes);
+	Memory::Write_U32(MIPS_MAKE_JR_RA(), entry_ + 0);
+	Memory::Write_U32(MIPS_MAKE_SYSCALL(module, func), entry_ + 4);
+
+	Create(threadName, prio, stacksize);
+}
+
+HLEHelperThread::~HLEHelperThread() {
+	__KernelDeleteThread(id_, SCE_KERNEL_ERROR_THREAD_TERMINATED, "helper deleted");
+	kernelMemory.Free(entry_);
+}
+
+void HLEHelperThread::AllocEntry(u32 size) {
+	entry_ = kernelMemory.Alloc(size);
+	currentMIPS->InvalidateICache(entry_, size);
+}
+
+void HLEHelperThread::Create(const char *threadName, u32 prio, int stacksize) {
+	id_ = __KernelCreateThreadInternal(threadName, __KernelGetCurThreadModuleId(), entry_, prio, stacksize, 0);
+}
+
+void HLEHelperThread::DoState(PointerWrap &p) {
+	auto s = p.Section("HLEHelperThread", 1);
+	if (!s) {
+		return;
+	}
+
+	p.Do(id_);
+	p.Do(entry_);
+}
+
+void HLEHelperThread::Start(u32 a0, u32 a1) {
+	__KernelStartThread(id_, a0, a1, true);
+}
+
+void HLEHelperThread::Terminate() {
+	__KernelStopThread(id_, SCE_KERNEL_ERROR_THREAD_TERMINATED, "helper terminated");
+}

--- a/Core/HLE/HLEHelperThread.h
+++ b/Core/HLE/HLEHelperThread.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2014- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+#include "Core/HLE/sceKernel.h"
+
+class PointerWrap;
+
+class HLEHelperThread {
+public:
+	// For savestates.
+	HLEHelperThread();
+	HLEHelperThread(const char *threadName, u32 instructions[], u32 instrCount, u32 prio, int stacksize);
+	HLEHelperThread(const char *threadName, const char *module, const char *func, u32 prio, int stacksize);
+	~HLEHelperThread();
+	void DoState(PointerWrap &p);
+
+	void Start(u32 a0, u32 a1);
+	void Terminate();
+
+private:
+	void AllocEntry(u32 size);
+	void Create(const char *threadName, u32 prio, int stacksize);
+
+	SceUID id_;
+	u32 entry_;
+};

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -27,18 +27,22 @@
 // http://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/ThreadManForUser.java
 
 int sceKernelChangeThreadPriority(SceUID threadID, int priority);
+SceUID __KernelCreateThreadInternal(const char *threadName, SceUID moduleID, u32 entry, u32 prio, int stacksize, u32 attr);
 int __KernelCreateThread(const char *threadName, SceUID moduleID, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
 int sceKernelCreateThread(const char *threadName, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr);
 int sceKernelDelayThread(u32 usec);
 int sceKernelDelayThreadCB(u32 usec);
 int sceKernelDelaySysClockThread(u32 sysclockAddr);
 int sceKernelDelaySysClockThreadCB(u32 sysclockAddr);
+void __KernelStopThread(SceUID threadID, int exitStatus, const char *reason);
+u32 __KernelDeleteThread(SceUID threadID, int exitStatus, const char *reason);
 int sceKernelDeleteThread(int threadHandle);
 void sceKernelExitDeleteThread(int exitStatus);
 void sceKernelExitThread(int exitStatus);
 void _sceKernelExitThread(int exitStatus);
 SceUID sceKernelGetThreadId();
 void sceKernelGetThreadCurrentPriority();
+int __KernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr, bool forceArgs = false);
 int sceKernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr);
 u32 sceKernelSuspendDispatchThread();
 u32 sceKernelResumeDispatchThread(u32 suspended);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1438,19 +1438,11 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerGetVideoData(%08x, %08x): invalid psmf player", psmfPlayer, videoDataAddr);
-		return ERROR_PSMF_NOT_FOUND;
-	}
-
-	bool isInitialized = isInitializedStatus(psmfplayer->status);
-	if (!isInitialized) {
-		ERROR_LOG(ME, "scePsmfPlayerGetVideoData(%08x): not initialized", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
-
-	bool psmfplayerstatus = isPlayingStatus(psmfplayer->status);
-	if (!psmfplayerstatus) {
+	if (psmfplayer->status < PSMF_PLAYER_STATUS_PLAYING) {
 		ERROR_LOG(ME, "scePsmfPlayerGetVideoData(%08x): psmf not playing", psmfPlayer);
-		return ERROR_PSMF_NOT_INITIALIZED;
+		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 
 	if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1493,22 +1493,20 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 			}
 		}
 
-		if (!doVideoStep || psmfplayer->mediaengine->stepVideo(videoPixelMode)) {
-			int displaybufSize = psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, videoData->frameWidth, videoPixelMode);
-			gpu->InvalidateCache(videoData->displaybuf, displaybufSize, GPU_INVALIDATE_SAFE);
+		if (doVideoStep) {
+			psmfplayer->mediaengine->stepVideo(videoPixelMode);
 		}
+
+		// Always write the video frame, even after the video has ended.
+		int displaybufSize = psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, videoData->frameWidth, videoPixelMode);
+		gpu->InvalidateCache(videoData->displaybuf, displaybufSize, GPU_INVALIDATE_SAFE);
 		__PsmfUpdatePts(psmfplayer, videoData);
 	}
 
 	_PsmfPlayerFillRingbuffer(psmfplayer);
-	int ret = psmfplayer->mediaengine->IsVideoEnd() ? (int)ERROR_PSMFPLAYER_NO_MORE_DATA : 0;
 
-	DEBUG_LOG(ME, "%08x=scePsmfPlayerGetVideoData(%08x, %08x)", ret, psmfPlayer, videoDataAddr);
-	if (ret != 0) {
-		return ret;
-	}
-
-	return hleDelayResult(ret, "psmfPlayer video decode", 3000);
+	DEBUG_LOG(ME, "%08x=scePsmfPlayerGetVideoData(%08x, %08x)", 0, psmfPlayer, videoDataAddr);
+	return hleDelayResult(0, "psmfPlayer video decode", 3000);
 }
 
 int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1026,12 +1026,11 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
 	return hleDelayResult(0, "player create", 20000);
 }
 
-int scePsmfPlayerStop(u32 psmfPlayer)
-{
+int scePsmfPlayerStop(u32 psmfPlayer) {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerStop(%08x): invalid psmf player", psmfPlayer);
-		return ERROR_PSMF_NOT_FOUND;
+		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 
 	bool isInitialized = isInitializedStatus(psmfplayer->status);
@@ -1043,7 +1042,7 @@ int scePsmfPlayerStop(u32 psmfPlayer)
 
 	INFO_LOG(ME, "scePsmfPlayerStop(%08x)", psmfPlayer);
 	psmfplayer->status = PSMF_PLAYER_STATUS_STANDBY;
-	return 0;
+	return hleDelayResult(0, "psmfplayer stop", 3000);
 }
 
 int scePsmfPlayerBreak(u32 psmfPlayer)

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1344,13 +1344,13 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 
 		int lastOffset = 0;
 		for (auto it = psmf.EPMap.begin(), end = psmf.EPMap.end(); it != end; ++it) {
-			if (initPts <= it->EPPts) {
+			if (initPts <= it->EPPts - (int)psmf.presentationStartTime) {
 				break;
 			}
 			lastOffset = it->EPOffset;
 		}
 
-		psmfplayer->readSize += lastOffset * 2048;
+		psmfplayer->readSize = lastOffset * 2048;
 		pspFileSystem.SeekFile(psmfplayer->filehandle, psmfplayer->fileoffset + psmfplayer->readSize, FILEMOVE_BEGIN);
 
 		_PsmfPlayerFillRingbuffer(psmfplayer);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1387,24 +1387,16 @@ int scePsmfPlayerUpdate(u32 psmfPlayer)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerUpdate(%08x): invalid psmf player", psmfPlayer);
-		return ERROR_PSMF_NOT_FOUND;
+		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
-
-	bool isInitialized = isInitializedStatus(psmfplayer->status);
-	if (!isInitialized) {
-		ERROR_LOG(ME, "scePsmfPlayerUpdate(%08x): not initialized", psmfPlayer);
+	if (psmfplayer->status < PSMF_PLAYER_STATUS_PLAYING) {
+		ERROR_LOG(ME, "scePsmfPlayerUpdate(%08x): not playing yet", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 
-	bool psmfplayerstatus = isPlayingStatus(psmfplayer->status);
-	if (!psmfplayerstatus) {
-		ERROR_LOG(ME, "scePsmfPlayerUpdate(%08x): psmf not playing", psmfPlayer);
-		return ERROR_PSMF_NOT_INITIALIZED;
-	}
-
 	DEBUG_LOG(ME, "scePsmfPlayerUpdate(%08x)", psmfPlayer);
-	if (psmfplayer->psmfPlayerAvcAu.pts > 0) {
-		if (psmfplayer->mediaengine->IsVideoEnd()) {
+	if ((s64)psmfplayer->psmfPlayerAvcAu.pts >= (s64)psmfplayer->totalDurationTimestamp - VIDEO_FRAME_DURATION_TS) {
+		if (videoLoopStatus == PSMF_PLAYER_CONFIG_NO_LOOP && psmfplayer->videoStep >= 1) {
 			INFO_LOG(ME, "video end reached");
 			psmfplayer->status = PSMF_PLAYER_STATUS_PLAYING_FINISHED;
 		}

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -197,6 +197,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Dialog/PSPSaveDialog.cpp \
   $(SRC)/Core/Dialog/SavedataParam.cpp \
   $(SRC)/Core/Font/PGF.cpp \
+  $(SRC)/Core/HLE/HLEHelperThread.cpp \
   $(SRC)/Core/HLE/HLETables.cpp \
   $(SRC)/Core/HLE/ReplaceTables.cpp \
   $(SRC)/Core/HLE/HLE.cpp \


### PR DESCRIPTION
FF2 was locking up because the finish status was set too early.  It should be set on the psmfplayer thread, at whatever priority the game set.  For example, after the audio thread has woken up in FF2's case.

This adds a helper to do that with normal thread scheduling.  It could theoretically do more (like audio sync and warmup probably are affected by thread priority), but I don't know of any observable differences that matter for that right now and it's a pain, heh.

Other changes:
- Trigger finish after the second update on the last presentable frame, matching tests.
- Correct seeking to specific pts (had some drift.)
- Minor error codes/scheduling in a few places.
- Don't stop writing frames from scePsmfPlayerGetVideoData(), even after video end.

Just a few more tests and I'll have psmfplayer mostly all figured out.  Just a few funcs left.

-[Unknown]
