### PR TITLE
Cleanup errors and pausing in psmfplayer

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1025,10 +1025,8 @@ int scePsmfPlayerStop(u32 psmfPlayer) {
 		ERROR_LOG(ME, "scePsmfPlayerStop(%08x): invalid psmf player", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
-
-	bool isInitialized = isInitializedStatus(psmfplayer->status);
-	if (!isInitialized) {
-		ERROR_LOG(ME, "scePsmfPlayerStop(%08x): not initialized", psmfPlayer);
+	if (psmfplayer->status < PSMF_PLAYER_STATUS_PLAYING) {
+		ERROR_LOG(ME, "scePsmfPlayerStop(%08x): not yet playing", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 	psmfplayer->AbortFinish();

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1044,18 +1044,11 @@ int scePsmfPlayerBreak(u32 psmfPlayer)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerBreak(%08x): invalid psmf player", psmfPlayer);
-		return ERROR_PSMF_NOT_FOUND;
-	}
-
-	bool isInitialized = isInitializedStatus(psmfplayer->status);
-	if (!isInitialized) {
-		ERROR_LOG(ME, "scePsmfPlayerBreak(%08x): not initialized", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
+
 	psmfplayer->AbortFinish();
 
-	// Fix everybody stress buster
-	psmfplayer->status = PSMF_PLAYER_STATUS_INIT;
 	return 0;
 }
 
@@ -1566,7 +1559,7 @@ int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 
 	int ret = 0;
 	if (psmfplayer->mediaengine->getAudioSamples(audioDataAddr) == 0) {
-		if (psmfplayer->totalAudioStreams > 0 && psmfplayer->psmfPlayerAvcAu.pts < psmfplayer->totalDurationTimestamp - VIDEO_FRAME_DURATION_TS) {
+		if (psmfplayer->totalAudioStreams > 0 && (s64)psmfplayer->psmfPlayerAvcAu.pts < (s64)psmfplayer->totalDurationTimestamp - VIDEO_FRAME_DURATION_TS) {
 			// Write zeros for any missing trailing frames so it syncs with the video.
 			Memory::Memset(audioDataAddr, 0, audioSamplesBytes);
 		} else {

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1532,8 +1532,10 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 			psmfplayer->mediaengine->stepVideo(videoPixelMode);
 		}
 
+		// It seems the frameWidth is rounded down to even values, and defaults to 512.
+		int bufw = videoData->frameWidth == 0 ? 512 : videoData->frameWidth & ~1;
 		// Always write the video frame, even after the video has ended.
-		int displaybufSize = psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, videoData->frameWidth, videoPixelMode);
+		int displaybufSize = psmfplayer->mediaengine->writeVideoImage(videoData->displaybuf, bufw, videoPixelMode);
 		gpu->InvalidateCache(videoData->displaybuf, displaybufSize, GPU_INVALIDATE_SAFE);
 		__PsmfUpdatePts(psmfplayer, videoData);
 	}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1484,11 +1484,6 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 		return SCE_KERNEL_ERROR_INVALID_VALUE;
 	}
 
-	if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {
-		INFO_LOG(HLE, "scePsmfPlayerGetVideoData(%08x): paused mode", psmfPlayer);
-		return 0;
-	}
-
 	hleEatCycles(20000);
 
 	if (!__PsmfPlayerContinueSeek(psmfplayer)) {
@@ -1509,7 +1504,9 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 
 	if (videoData.IsValid()) {
 		bool doVideoStep = true;
-		if (!psmfplayer->mediaengine->IsNoAudioData()) {
+		if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {
+			doVideoStep = false;
+		} else if (!psmfplayer->mediaengine->IsNoAudioData()) {
 			s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 			if (deltapts > 0) {
 				// Don't advance, just return the same frame again.

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1373,20 +1373,15 @@ int scePsmfPlayerDelete(u32 psmfPlayer)
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerDelete(%08x): invalid psmf player", psmfPlayer);
-		return ERROR_PSMF_NOT_FOUND;
-	}
-
-	bool isInitialized = isInitializedStatus(psmfplayer->status);
-	if (!isInitialized) {
-		ERROR_LOG(ME, "scePsmfPlayerDelete(%08x): not initialized", psmfPlayer);
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 
 	INFO_LOG(ME, "scePsmfPlayerDelete(%08x)", psmfPlayer);
 	delete psmfplayer;
-	psmfPlayerMap.erase(psmfPlayer);
+	psmfPlayerMap.erase(Memory::Read_U32(psmfPlayer));
+	Memory::Write_U32(0, psmfPlayer);
 
-	return 0;
+	return hleDelayResult(0, "psmfplayer deleted", 20000);
 }
 
 int scePsmfPlayerUpdate(u32 psmfPlayer) 

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -89,6 +89,8 @@ public:
 
 	bool IsVideoEnd() { return m_isVideoEnd; }
 	bool IsNoAudioData();
+	int VideoWidth() { return m_desWidth; }
+	int VideoHeight() { return m_desHeight; }
 
 	void DoState(PointerWrap &p);
 


### PR DESCRIPTION
So, I think this is pretty much it now.

The most major changes are:
- scePsmfPlayerGetAudioData() can return trailing zero packets to sync with video.
- scePsmfPlayerGetVideoData() seems to treat bufw=0 as 512 (even for videos with odd sizes.)
- While paused, scePsmfPlayerGetVideoData() still writes the frame.  Basically it always tries to write the frame.
- While paused, scePsmfPlayerGetAudioData() does NOT write the frame.
- scePsmfPlayerBreak() isn't supposed to change status at all (I'm not 100% sure what it does, but with recent fixes, almost none of my games call it anymore, and when they do, it seems like a safety to reset any errors.)
- scePsmfPlayerDelete() writes a 0 to the pointer (previously written in create.)

-[Unknown]
