### PR TITLE
Trigger memchecks in replaced funcs, call gpu->UpdateMemory()

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -20,6 +20,7 @@
 
 #include "base/basictypes.h"
 #include "base/logging.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/MIPSAnalyst.h"
@@ -108,6 +109,10 @@ static int Replace_memcpy() {
 		memmove(dst, src, bytes);
 	}
 	RETURN(destPtr);
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
+#endif
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -121,6 +126,10 @@ static int Replace_memcpy16() {
 		memmove(dst, src, bytes);
 	}
 	RETURN(destPtr);
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
+#endif
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -134,6 +143,10 @@ static int Replace_memmove() {
 		memmove(dst, src, bytes);
 	}
 	RETURN(destPtr);
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
+#endif
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -144,6 +157,9 @@ static int Replace_memset() {
 	u32 bytes = PARAM(2);
 	memset(dst, value, bytes);
 	RETURN(destPtr);
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
+#endif
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -354,6 +370,12 @@ static int Replace_dl_write_matrix() {
 		dest[11] = matrix | (src[14] >> 8);
 #endif
 	}
+
+#ifndef MOBILE_DEVICE
+	CBreakPoints::ExecMemCheck(PARAM(2), false, count * sizeof(float), currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(PARAM(0) + 2 * sizeof(u32), true, sizeof(u32), currentMIPS->pc);
+	CBreakPoints::ExecMemCheck(dlStruct[2], true, (count + 1) * sizeof(u32), currentMIPS->pc);
+#endif
 
 	dlStruct[2] += (1 + count) * 4;
 	RETURN(dlStruct[2]);

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -28,6 +28,7 @@
 #include "Core/HLE/FunctionWrappers.h"
 
 #include "GPU/Math3D.h"
+#include "GPU/GPUInterface.h"
 
 #if defined(_M_IX86) || defined(_M_X64)
 #include <emmintrin.h>
@@ -113,6 +114,9 @@ static int Replace_memcpy() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -130,6 +134,9 @@ static int Replace_memcpy16() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -147,6 +154,9 @@ static int Replace_memmove() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -160,6 +170,9 @@ static int Replace_memset() {
 #ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(destPtr)) {
+		gpu->UpdateMemory(destPtr, destPtr, bytes);
+	}
 	return 10 + bytes / 4;  // approximation
 }
 


### PR DESCRIPTION
Will interact with #6049.

I forgot the memchecks weren't there, made #6109 a lot harder to find... this doesn't yet fix that issue though, since UpdateMemory() does not currently download.

-[Unknown]
