### PR TITLE
Fix a heap overflow in block transfers, fix most save picture downloads, optimizations

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -104,7 +104,11 @@ static int Replace_memcpy() {
 	u32 destPtr = PARAM(0);
 	u32 srcPtr = PARAM(1);
 	u32 bytes = PARAM(2);
-	if (bytes != 0) {
+	bool skip = false;
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
+	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
 		u8 *src = Memory::GetPointerUnchecked(srcPtr);
 		memmove(dst, src, bytes);
@@ -114,9 +118,6 @@ static int Replace_memcpy() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
-	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		gpu->UpdateMemory(destPtr, srcPtr, bytes);
-	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -124,7 +125,11 @@ static int Replace_memcpy16() {
 	u32 destPtr = PARAM(0);
 	u32 srcPtr = PARAM(1);
 	u32 bytes = PARAM(2) * 16;
-	if (bytes != 0) {
+	bool skip = false;
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
+	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
 		u8 *src = Memory::GetPointerUnchecked(srcPtr);
 		memmove(dst, src, bytes);
@@ -134,9 +139,6 @@ static int Replace_memcpy16() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
-	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		gpu->UpdateMemory(destPtr, srcPtr, bytes);
-	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -144,7 +146,11 @@ static int Replace_memmove() {
 	u32 destPtr = PARAM(0);
 	u32 srcPtr = PARAM(1);
 	u32 bytes = PARAM(2);
-	if (bytes != 0) {
+	bool skip = false;
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
+		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+	}
+	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
 		u8 *src = Memory::GetPointerUnchecked(srcPtr);
 		memmove(dst, src, bytes);
@@ -154,9 +160,6 @@ static int Replace_memmove() {
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
-	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		gpu->UpdateMemory(destPtr, srcPtr, bytes);
-	}
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -165,14 +168,17 @@ static int Replace_memset() {
 	u8 *dst = Memory::GetPointerUnchecked(destPtr);
 	u8 value = PARAM(1);
 	u32 bytes = PARAM(2);
-	memset(dst, value, bytes);
+	bool skip = false;
+	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(destPtr)) {
+		skip = gpu->UpdateMemory(destPtr, destPtr, bytes);
+	}
+	if (!skip) {
+		memset(dst, value, bytes);
+	}
 	RETURN(destPtr);
 #ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
 #endif
-	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(destPtr)) {
-		gpu->UpdateMemory(destPtr, destPtr, bytes);
-	}
 	return 10 + bytes / 4;  // approximation
 }
 

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -43,16 +43,17 @@ void __DmacDoState(PointerWrap &p) {
 }
 
 int __DmacMemcpy(u32 dst, u32 src, u32 size) {
-	Memory::Memcpy(dst, Memory::GetPointer(src), size);
 #ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(src, false, size, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dst, true, size, currentMIPS->pc);
 #endif
 
-	src &= ~0x40000000;
-	dst &= ~0x40000000;
+	bool skip = false;
 	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
-		gpu->UpdateMemory(dst, src, size);
+		skip = gpu->UpdateMemory(dst, src, size);
+	}
+	if (!skip) {
+		Memory::Memcpy(dst, Memory::GetPointer(src), size);
 	}
 
 	// This number seems strangely reproducible.

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -559,11 +559,14 @@ u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
 u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
-	// Hm, sceDmacMemcpy seems to be the popular one for this. Ignoring for now.
-	// gpu->UpdateMemory(dst, src, size);
+
+	bool skip = false;
+	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
+		skip = gpu->UpdateMemory(dst, src, size);
+	}
 
 	// Technically should crash if these are invalid and size > 0...
-	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src) && Memory::IsValidAddress(dst + size - 1) && Memory::IsValidAddress(src + size - 1))
+	if (!skip && Memory::IsValidAddress(dst) && Memory::IsValidAddress(src) && Memory::IsValidAddress(dst + size - 1) && Memory::IsValidAddress(src + size - 1))
 	{
 		u8 *dstp = Memory::GetPointer(dst);
 		u8 *srcp = Memory::GetPointer(src);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1315,8 +1315,9 @@ void DIRECTX9_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationTy
 		framebufferManager_.UpdateFromMemory(addr, size);
 }
 
-void DIRECTX9_GPU::UpdateMemory(u32 dest, u32 src, int size) {
+bool DIRECTX9_GPU::UpdateMemory(u32 dest, u32 src, int size) {
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
 }
 
 void DIRECTX9_GPU::ClearCacheNextFrame() {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -46,7 +46,7 @@ public:
 	virtual void BeginFrame();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual void UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1858,19 +1858,24 @@ u32 FramebufferManager::FramebufferByteSize(const VirtualFramebuffer *vfb) const
 }
 
 void FramebufferManager::FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int bpp) const {
+	int dstYOffset = 0;
+	int srcYOffset = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = vfbs_[i];
 		const u32 vfb_address = 0x04000000 | vfb->fb_address;
 		const u32 vfb_size = FramebufferByteSize(vfb);
 		if (vfb_address <= dstBasePtr && dstBasePtr < vfb_address + vfb_size) {
-			dstY += (dstBasePtr - vfb_address) / (dstStride * bpp);
+			dstYOffset = (dstBasePtr - vfb_address) / (dstStride * bpp);
 			dstBuffer = vfb;
 		}
 		if (vfb_address <= srcBasePtr && srcBasePtr < vfb_address + vfb_size) {
-			srcY += (srcBasePtr - vfb_address) / (srcStride * bpp);
+			srcYOffset = (srcBasePtr - vfb_address) / (srcStride * bpp);
 			srcBuffer = vfb;
 		}
 	}
+
+	dstY += dstYOffset;
+	srcY += srcYOffset;
 }
 
 bool FramebufferManager::NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int width, int height, int bpp) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1882,6 +1882,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 		if (g_Config.bBlockTransferGPU) {
 			const u8 *srcBase = Memory::GetPointerUnchecked(src);
 			fbo_bind_as_render_target(dstBuffer->fbo);
+			glViewport(0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight);
 			// TODO: Validate x/y/w/h based on size and offset?
 			DrawPixels(dstBuffer, 0, 0, srcBase, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height);
 			dstBuffer->dirtyAfterDisplay = true;
@@ -1892,6 +1893,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 			} else {
 				fbo_unbind();
 			}
+			glstate.viewport.restore();
 			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
 			// This is a memcpy, let's still copy just in case.
 			return false;
@@ -2015,6 +2017,7 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 				fbo_bind_as_render_target(dstBuffer->fbo);
 				int dstBpp = dstBuffer->format == GE_FORMAT_8888 ? 4 : 2;
 				float dstXFactor = (float)bpp / dstBpp;
+				glViewport(0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight);
 				DrawPixels(dstBuffer, dstX * dstXFactor, dstY, srcBase, dstBuffer->format, srcStride * dstXFactor, width * dstXFactor, height);
 				dstBuffer->dirtyAfterDisplay = true;
 				if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
@@ -2024,6 +2027,7 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 				} else {
 					fbo_unbind();
 				}
+				glstate.viewport.restore();
 				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
 			}
 		}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1231,7 +1231,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 		}
 
 		vfb->memoryUpdated = true;
-		BlitFramebuffer_(nvfb, x, y, vfb, x, y, w, h, 0);
+		BlitFramebuffer_(nvfb, x, y, vfb, x, y, w, h, 0, true);
 
 		// PackFramebufferSync_() - Synchronous pixel data transfer using glReadPixels
 		// PackFramebufferAsync_() - Asynchronous pixel data transfer using glReadPixels with PBOs
@@ -1254,7 +1254,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 }
 
 // TODO: If dimensions are the same, we can use glCopyImageSubData.
-void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) {
+void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, bool flip) {
 	if (!dst->fbo) {
 		ERROR_LOG_REPORT_ONCE(dstfbozero, SCEGE, "BlitFramebuffer_: dst->fbo == 0");
 		fbo_unbind();
@@ -1299,6 +1299,10 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 		int dstX2 = (dstX + w) * dstXFactor;
 		int dstY2 = dst->renderHeight - (h + dstY) * dstYFactor;
 		int dstY1 = dstY2 + h * dstYFactor;
+
+		if (flip) {
+			std::swap(dstY1, dstY2);
+		}
 
 #ifdef MAY_HAVE_GLES3
 		fbo_bind_for_read(src->fbo);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1834,9 +1834,8 @@ void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 		if (srcBuffer == dstBuffer) {
 			WARN_LOG_REPORT_ONCE(dstsrccpy, G3D, "Intra-buffer memcpy (not supported) %08x -> %08x", src, dst);
 		} else {
-			WARN_LOG_ONCE(dstnotsrccpy, G3D, "Inter-buffer memcpy %08x -> %08x", src, dst);
+			WARN_LOG_REPORT_ONCE(dstnotsrccpy, G3D, "Inter-buffer memcpy (not supported) %08x -> %08x", src, dst);
 			// Just do the blit!
-			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
 			// if (g_Config.bBlockTransferGPU) {
 			//   BlitFramebuffer_(dstBuffer, 0, 0, srcBuffer, 0, 0, srcBuffer->width, srcBuffer->height, 0);
 			// }
@@ -1847,7 +1846,7 @@ void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 		// if (g_Config.bBlockTransferGPU) {
 		// }
 	} else if (srcBuffer && g_Config.iRenderingMode == FB_BUFFERED_MODE) {
-		WARN_LOG_ONCE(btdcpy, G3D, "Memcpy fbo download %08x -> %08x", src, dst);
+		WARN_LOG_REPORT_ONCE(btdcpy, G3D, "Memcpy fbo download (not supported) %08x -> %08x", src, dst);
 		// if (g_Config.bBlockTransferGPU) {
 		//   ReadFramebufferToMemory(srcBuffer, true, 0, 0, srcBuffer->width, srcBuffer->height);
 		// }
@@ -1890,7 +1889,6 @@ bool FramebufferManager::NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride
 		} else {
 			WARN_LOG_ONCE(dstnotsrc, G3D, "Inter-buffer block transfer %08x -> %08x", srcBasePtr, dstBasePtr);
 			// Just do the blit!
-			// TODO: Possibly take bpp into account somehow if games are doing really crazy things?
 			if (g_Config.bBlockTransferGPU) {
 				BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, width, height, bpp);
 				return true;  // No need to actually do the memory copy behind, probably.
@@ -1945,7 +1943,7 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 		FindTransferFramebuffers(dstBuffer, srcBuffer, dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, bpp);
 
 		if (dstBuffer && !srcBuffer) {
-			WARN_LOG_REPORT_ONCE(btu, G3D, "Block transfer upload (not supported) %08x -> %08x", srcBasePtr, dstBasePtr);
+			WARN_LOG_REPORT_ONCE(btu, G3D, "Block transfer upload %08x -> %08x", srcBasePtr, dstBasePtr);
 			if (g_Config.bBlockTransferGPU) {
 				u8 *srcBase = Memory::GetPointerUnchecked(srcBasePtr) + (srcX + srcY * srcStride) * bpp;
 				DrawPixels(dstBuffer, dstX, dstY, srcBase, dstBuffer->format, srcStride * bpp, width, height);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -838,8 +838,9 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		currentRenderVfb_ = vfb;
 
 		u32 byteSize = FramebufferByteSize(vfb);
-		if (fb_address + byteSize > framebufRangeEnd_) {
-			framebufRangeEnd_ = ((fb_address + byteSize) & 0x3FFFFFFF) | 0x04000000;
+		u32 fb_address_mem = (fb_address & 0x3FFFFFFF) | 0x04000000;
+		if (fb_address_mem + byteSize > framebufRangeEnd_) {
+			framebufRangeEnd_ = fb_address_mem + byteSize;
 		}
 
 		INFO_LOG(SCEGE, "Creating FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1310,7 +1310,8 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 		int dstY1 = dstY2 + h * dstYFactor;
 
 		if (flip) {
-			std::swap(dstY1, dstY2);
+			dstY1 = dst->renderHeight - dstY1;
+			dstY2 = dst->renderHeight - dstY2;
 		}
 
 #ifdef MAY_HAVE_GLES3

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2013,7 +2013,9 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 			if (g_Config.bBlockTransferGPU) {
 				const u8 *srcBase = Memory::GetPointerUnchecked(srcBasePtr) + (srcX + srcY * srcStride) * bpp;
 				fbo_bind_as_render_target(dstBuffer->fbo);
-				DrawPixels(dstBuffer, dstX, dstY, srcBase, dstBuffer->format, srcStride, width, height);
+				int dstBpp = dstBuffer->format == GE_FORMAT_8888 ? 4 : 2;
+				float dstXFactor = (float)bpp / dstBpp;
+				DrawPixels(dstBuffer, dstX * dstXFactor, dstY, srcBase, dstBuffer->format, srcStride * dstXFactor, width * dstXFactor, height);
 				dstBuffer->dirtyAfterDisplay = true;
 				if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
 					dstBuffer->reallyDirtyAfterDisplay = true;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1892,6 +1892,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 			} else {
 				fbo_unbind();
 			}
+			gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
 			// This is a memcpy, let's still copy just in case.
 			return false;
 		}
@@ -2011,6 +2012,7 @@ void FramebufferManager::NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride,
 				} else {
 					fbo_unbind();
 				}
+				gstate_c.textureChanged = TEXCHANGE_PARAMSONLY;
 			}
 		}
 	}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1804,18 +1804,15 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 }
 
 void FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
-	if (!MayIntersectFramebuffer(src) && !MayIntersectFramebuffer(dst)) {
-		// Don't waste time looking if neither can be a framebuffer.
-		return;
-	}
-
 	// MotoGP workaround
-	for (size_t i = 0; i < vfbs_.size(); i++) {
-		int bpp = vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2;
-		int fsize = vfbs_[i]->fb_stride * vfbs_[i]->height * (vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2);
-		if ((vfbs_[i]->fb_address | 0x04000000) == src && size == fsize) {
-			// A framebuffer matched!
-			knownFramebufferRAMCopies_.insert(std::pair<u32, u32>(src, dst));
+	if (Memory::IsVRAMAddress(src) && Memory::IsRAMAddress(dst)) {
+		for (size_t i = 0; i < vfbs_.size(); i++) {
+			int bpp = vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2;
+			int fsize = vfbs_[i]->fb_stride * vfbs_[i]->height * (vfbs_[i]->format == GE_FORMAT_8888 ? 4 : 2);
+			if (MaskedEqual(vfbs_[i]->fb_address, src) && size == fsize) {
+				// A framebuffer matched!
+				knownFramebufferRAMCopies_.insert(std::pair<u32, u32>(src, dst));
+			}
 		}
 	}
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1904,7 +1904,7 @@ bool FramebufferManager::NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride
 		return false;
 	} else if (srcBuffer) {
 		WARN_LOG_ONCE(btd, G3D, "Block transfer download %08x -> %08x", srcBasePtr, dstBasePtr);
-		if (g_Config.bBlockTransferGPU) {
+		if (g_Config.bBlockTransferGPU && (srcBuffer == currentRenderVfb_ || !srcBuffer->memoryUpdated)) {
 			ReadFramebufferToMemory(srcBuffer, true, srcX, srcY, width, height);
 		}
 		return false;  // Let the bit copy happen

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -227,7 +227,7 @@ private:
 	VirtualFramebuffer *currentRenderVfb_;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
-	void BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp);
+	void BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, bool flip = false);
 #ifndef USING_GLES2
 	void PackFramebufferAsync_(VirtualFramebuffer *vfb);
 #endif

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -210,7 +210,7 @@ public:
 		return true;
 	}
 
-	void NotifyFramebufferCopy(u32 src, u32 dest, int size);
+	bool NotifyFramebufferCopy(u32 src, u32 dest, int size);
 
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -166,7 +166,8 @@ public:
 	// Returns true if it's sure this is a direct FBO->FBO transfer and it has already handle it.
 	// In that case we hardly need to actually copy the bytes in VRAM, they will be wrong anyway (unless
 	// read framebuffers is on, in which case this should always return false).
-	bool NotifyBlockTransfer(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp);
+	bool NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp);
+	void NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp);
 
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h);
@@ -210,6 +211,8 @@ public:
 private:
 	void CompileDraw2DProgram();
 	void DestroyDraw2DProgram();
+
+	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int bpp) const;
 
 	void SetNumExtraFBOs(int num);
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -223,6 +223,7 @@ private:
 	void DestroyDraw2DProgram();
 
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int bpp) const;
+	u32 FramebufferByteSize(const VirtualFramebuffer *vfb) const;
 
 	void SetNumExtraFBOs(int num);
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -245,7 +245,7 @@ private:
 #ifndef USING_GLES2
 	void PackFramebufferAsync_(VirtualFramebuffer *vfb);
 #endif
-	void PackFramebufferSync_(VirtualFramebuffer *vfb);
+	void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 
 	// Used by DrawPixels
 	unsigned int drawPixelsTex_;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -200,6 +200,16 @@ public:
 		}
 	}
 
+	bool MayIntersectFramebuffer(u32 start) {
+		// Clear the cache/kernel bits.
+		start = start & 0x3FFFFFFF;
+		// Most games only have two framebuffers at the start.
+		if (start >= framebufRangeEnd_ || start < PSP_GetVidMemBase()) {
+			return false;
+		}
+		return true;
+	}
+
 	void NotifyFramebufferCopy(u32 src, u32 dest, int size);
 
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
@@ -261,7 +271,10 @@ private:
 	bool resized_;
 	bool useBufferedRendering_;
 	bool updateVRAM_;
-	
+
+	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
+	u32 framebufRangeEnd_;
+
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<std::pair<int, int>, FBO *> renderCopies_;
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -239,7 +239,8 @@ private:
 	int drawPixelsTexW_;
 	int drawPixelsTexH_;
 
-	u8 *convBuf;
+	u8 *convBuf_;
+	u32 convBufSize_;
 	GLSLProgram *draw2dprogram_;
 	GLSLProgram *plainColorProgram_;
 	GLSLProgram *postShaderProgram_;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -272,6 +272,7 @@ private:
 	bool resized_;
 	bool useBufferedRendering_;
 	bool updateVRAM_;
+	bool gameUsesSequentialCopies_;
 
 	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
 	u32 framebufRangeEnd_;

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1964,7 +1964,7 @@ void GLES_GPU::UpdateMemory(u32 dest, u32 src, int size) {
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 
 	// Track stray copies of a framebuffer in RAM. MotoGP does this.
-	if (Memory::IsVRAMAddress(src) && Memory::IsRAMAddress(dest)) {
+	if (framebufferManager_.MayIntersectFramebuffer(src) || framebufferManager_.MayIntersectFramebuffer(dest)) {
 		framebufferManager_.NotifyFramebufferCopy(src, dest, size);
 	}
 }

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1963,10 +1963,12 @@ void GLES_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType t
 bool GLES_GPU::UpdateMemory(u32 dest, u32 src, int size) {
 	// Track stray copies of a framebuffer in RAM. MotoGP does this.
 	if (framebufferManager_.MayIntersectFramebuffer(src) || framebufferManager_.MayIntersectFramebuffer(dest)) {
-		// TODO: Copy in the right order.
-		Memory::Memcpy(dest, Memory::GetPointer(src), size);
-		framebufferManager_.NotifyFramebufferCopy(src, dest, size);
-		InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+		if (!framebufferManager_.NotifyFramebufferCopy(src, dest, size)) {
+			Memory::Memcpy(dest, Memory::GetPointer(src), size);
+			InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+		} else {
+			InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+		}
 		return true;
 	}
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1955,8 +1955,9 @@ void GLES_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType t
 	else
 		textureCache_.InvalidateAll(type);
 
-	if (type != GPU_INVALIDATE_ALL)
+	if (type != GPU_INVALIDATE_ALL && framebufferManager_.MayIntersectFramebuffer(addr)) {
 		framebufferManager_.UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
+	}
 }
 
 void GLES_GPU::UpdateMemory(u32 dest, u32 src, int size) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1956,7 +1956,11 @@ void GLES_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType t
 		textureCache_.InvalidateAll(type);
 
 	if (type != GPU_INVALIDATE_ALL && framebufferManager_.MayIntersectFramebuffer(addr)) {
-		framebufferManager_.UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
+		// If we're doing block transfers, we shouldn't need this, and it'll only confuse us.
+		// Vempire invalidates (with writeback) after drawing, but before blitting.
+		if (!g_Config.bBlockTransferGPU || type == GPU_INVALIDATE_SAFE) {
+			framebufferManager_.UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
+		}
 	}
 }
 

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -44,7 +44,7 @@ public:
 	virtual void BeginFrame();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual void UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -151,6 +151,7 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
+	void UpdateMemoryInternal(u32 dest, u32 src, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
 	static CommandInfo cmdInfo_[256];

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -163,6 +163,7 @@ enum GPUEventType {
 	GPU_EVENT_INVALIDATE_CACHE,
 	GPU_EVENT_FINISH_EVENT_LOOP,
 	GPU_EVENT_SYNC_THREAD,
+	GPU_EVENT_FB_MEMCPY,
 };
 
 struct GPUEvent {
@@ -175,6 +176,12 @@ struct GPUEvent {
 			int size;
 			GPUInvalidationType type;
 		} invalidate_cache;
+		// GPU_EVENT_FB_MEMCPY
+		struct {
+			u32 dst;
+			u32 src;
+			int size;
+		} fb_memcpy;
 	};
 
 	operator GPUEventType() const {

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -227,7 +227,7 @@ public:
 	// If size = -1, invalidate everything.
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type) = 0;
 	// Update either RAM from VRAM, or VRAM from RAM... or even VRAM from VRAM.
-	virtual void UpdateMemory(u32 dest, u32 src, int size) = 0;
+	virtual bool UpdateMemory(u32 dest, u32 src, int size) = 0;
 
 	// Will cause the texture cache to be cleared at the start of the next frame.
 	virtual void ClearCacheNextFrame() = 0;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -657,7 +657,8 @@ void NullGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 	// Nothing to invalidate.
 }
 
-void NullGPU::UpdateMemory(u32 dest, u32 src, int size) {
+bool NullGPU::UpdateMemory(u32 dest, u32 src, int size) {
 	// Nothing to update.
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
 }

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -34,7 +34,7 @@ public:
 	virtual void CopyDisplayToOutput() {}
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual void UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -851,12 +851,13 @@ void SoftGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type)
 	// Nothing to invalidate.
 }
 
-void SoftGPU::UpdateMemory(u32 dest, u32 src, int size)
+bool SoftGPU::UpdateMemory(u32 dest, u32 src, int size)
 {
 	// Nothing to update.
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	// Let's just be safe.
 	framebufferDirty_ = true;
+	return false;
 }
 
 bool SoftGPU::FramebufferDirty() {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -59,7 +59,7 @@ public:
 	virtual void CopyDisplayToOutput();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual void UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool UpdateMemory(u32 dest, u32 src, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}


### PR DESCRIPTION
The heap overflow was responsible the crashes I reported before, afaict.

This orders the copy properly such that save pictures generally work.  I've also added some optimizations so we can skip checking framebuffers for most memcpy operations (e.g. textures.)

This also flips the y when blitting for downloading framebuffers, which should not be done generally when blitting framebuffers (e.g. between each other.)

-[Unknown]
