### PR TITLE
End the video when we run out of packets

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1395,7 +1395,8 @@ int scePsmfPlayerUpdate(u32 psmfPlayer)
 	}
 
 	DEBUG_LOG(ME, "scePsmfPlayerUpdate(%08x)", psmfPlayer);
-	if ((s64)psmfplayer->psmfPlayerAvcAu.pts >= (s64)psmfplayer->totalDurationTimestamp - VIDEO_FRAME_DURATION_TS) {
+	bool videoPtsEnd = (s64)psmfplayer->psmfPlayerAvcAu.pts >= (s64)psmfplayer->totalDurationTimestamp - VIDEO_FRAME_DURATION_TS;
+	if (videoPtsEnd || (psmfplayer->mediaengine->IsVideoEnd() && psmfplayer->mediaengine->IsNoAudioData())) {
 		if (videoLoopStatus == PSMF_PLAYER_CONFIG_NO_LOOP && psmfplayer->videoStep >= 1) {
 			if (psmfplayer->status != PSMF_PLAYER_STATUS_PLAYING_FINISHED) {
 				psmfplayer->ScheduleFinish(psmfPlayer);


### PR DESCRIPTION
If there are no audio or video packets left, even if we haven't hit the pts, the video is over.

Fixes #6135, hanging in Chinese translation of Clannad.

The problem before was that it was ending too late, so this should be safe, and probably is correct (I did notice if there weren't any audio frames with the specified stream, it seemed to end immediately too.)

-[Unknown]
