### PR TITLE
Don't block duplicate enqueues when intr pending

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -214,7 +214,9 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		//stack = NULL;
 		for (int i = 0; i < DisplayListMaxCount; ++i) {
 			if (dls[i].state != PSP_GE_DL_STATE_NONE && dls[i].state != PSP_GE_DL_STATE_COMPLETED) {
-				if (dls[i].pc == listpc) {
+				// Logically, if the CPU has not interrupted yet, it hasn't seen the latest pc either.
+				// Exit enqueues right after an END, which fails without ignoring pendingInterrupt lists.
+				if (dls[i].pc == listpc && !dls[i].pendingInterrupt) {
 					ERROR_LOG(G3D, "sceGeListEnqueue: can't enqueue, list address %08X already used", listpc);
 					return 0x80000021;
 				}


### PR DESCRIPTION
What happens is the game has list data like this:

STUFF
FINISH
END
MORE STUFF
FINISH
END

After enqueuing the first END, it tries to enqueue MORE STUFF.  However, if the previous list already finished, but hasn't run the interrupt yet, its pc points to MORE STUFF (even though MORE STUFF will never be executed), so it bails.

The duplicate check is most likely only on the last known pc, so I suspect there's never a case on a real PSP where MORE STUFF can be seen as a duplicate address - it's either finished/dequeued, or still running, but either way never pointing to MORE STUFF.

-[Unknown]
