### PR TITLE
Apply a very specific hack for Danganronpa

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -209,6 +209,7 @@ public:
 		}
 		return true;
 	}
+	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 
 	bool NotifyFramebufferCopy(u32 src, u32 dest, int size);
 
@@ -273,6 +274,8 @@ private:
 	bool useBufferedRendering_;
 	bool updateVRAM_;
 	bool gameUsesSequentialCopies_;
+
+	bool hackForce04154000Download_;
 
 	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
 	u32 framebufRangeEnd_;


### PR DESCRIPTION
This should allow playing at non-1x resolutions, and without slowing down the entire game just for one small framebuffer.

Generally, hacks are a bad thing.  But even with memcpy and block transfer stuff, we'll never be able to solve this game without some sort of hack.  Detecting memory reads will complicate cross-platform compat or slow things down.

I'm the last person who advocates hacks, but I also like things to just work out of the box and be fast.  I'm not wanting to "open pandora's box" here, but it doesn't seem like there's any better way for this game.

-[Unknown]
