### PR TITLE
Support memset and swizzling memcpy on framebuffers

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -168,12 +168,9 @@ static int Replace_memset() {
 	u8 *dst = Memory::GetPointerUnchecked(destPtr);
 	u8 value = PARAM(1);
 	u32 bytes = PARAM(2);
-	bool skip = false;
-	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(destPtr)) {
-		skip = gpu->UpdateMemory(destPtr, destPtr, bytes);
-	}
-	if (!skip) {
-		memset(dst, value, bytes);
+	memset(dst, value, bytes);
+	if (Memory::IsVRAMAddress(destPtr)) {
+		gpu->UpdateMemory(destPtr, destPtr, bytes);
 	}
 	RETURN(destPtr);
 #ifndef MOBILE_DEVICE

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -106,7 +106,7 @@ static int Replace_memcpy() {
 	u32 bytes = PARAM(2);
 	bool skip = false;
 	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+		skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 	}
 	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
@@ -127,7 +127,7 @@ static int Replace_memcpy16() {
 	u32 bytes = PARAM(2) * 16;
 	bool skip = false;
 	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+		skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 	}
 	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
@@ -150,7 +150,7 @@ static int Replace_memcpy_swizzled() {
 	if (Memory::IsVRAMAddress(srcPtr)) {
 		// Cheat a bit to force a download of the framebuffer.
 		// VRAM + 0x00400000 is simply a VRAM mirror.
-		gpu->UpdateMemory(srcPtr ^ 0x00400000, srcPtr, pitch * h);
+		gpu->PerformMemoryCopy(srcPtr ^ 0x00400000, srcPtr, pitch * h);
 	}
 	u8 *dstp = Memory::GetPointerUnchecked(destPtr);
 	const u8 *srcp = Memory::GetPointerUnchecked(srcPtr);
@@ -184,7 +184,7 @@ static int Replace_memmove() {
 	u32 bytes = PARAM(2);
 	bool skip = false;
 	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
-		skip = gpu->UpdateMemory(destPtr, srcPtr, bytes);
+		skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 	}
 	if (!skip && bytes != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
@@ -204,9 +204,12 @@ static int Replace_memset() {
 	u8 *dst = Memory::GetPointerUnchecked(destPtr);
 	u8 value = PARAM(1);
 	u32 bytes = PARAM(2);
-	memset(dst, value, bytes);
+	bool skip = false;
 	if (Memory::IsVRAMAddress(destPtr)) {
-		gpu->UpdateMemory(destPtr, destPtr, bytes);
+		skip = gpu->PerformMemorySet(destPtr, value, bytes);
+	}
+	if (!skip) {
+		memset(dst, value, bytes);
 	}
 	RETURN(destPtr);
 #ifndef MOBILE_DEVICE

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -560,6 +560,27 @@ void RestoreReplacedInstructions(u32 startAddr, u32 endAddr) {
 	replacedInstructions.erase(start, end);
 }
 
+std::map<u32, u32> SaveAndClearReplacements() {
+	std::map<u32, u32> saved;
+	for (auto it = replacedInstructions.begin(), end = replacedInstructions.end(); it != end; ++it) {
+		const u32 addr = it->first;
+		const u32 curInstr = Memory::Read_U32(addr);
+		if (MIPS_IS_REPLACEMENT(curInstr)) {
+			saved[addr] = curInstr;
+			Memory::Write_U32(it->second, addr);
+		}
+	}
+	return saved;
+}
+
+void RestoreSavedReplacements(const std::map<u32, u32> &saved) {
+	for (auto it = saved.begin(), end = saved.end(); it != end; ++it) {
+		const u32 addr = it->first;
+		// Just put the replacements back.
+		Memory::Write_U32(it->second, addr);
+	}
+}
+
 bool GetReplacedOpAt(u32 address, u32 *op) {
 	u32 instr = Memory::Read_Opcode_JIT(address).encoding;
 	if (MIPS_IS_REPLACEMENT(instr)) {

--- a/Core/HLE/ReplaceTables.h
+++ b/Core/HLE/ReplaceTables.h
@@ -61,3 +61,7 @@ void WriteReplaceInstruction(u32 address, u64 hash, int size);
 void RestoreReplacedInstruction(u32 address);
 void RestoreReplacedInstructions(u32 startAddr, u32 endAddr);
 bool GetReplacedOpAt(u32 address, u32 *op);
+
+// For savestates.  If you call SaveAndClearReplacements(), you must call RestoreSavedReplacements().
+std::map<u32, u32> SaveAndClearReplacements();
+void RestoreSavedReplacements(const std::map<u32, u32> &saved);

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -50,7 +50,7 @@ int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 
 	bool skip = false;
 	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
-		skip = gpu->UpdateMemory(dst, src, size);
+		skip = gpu->PerformMemoryCopy(dst, src, size);
 	}
 	if (!skip) {
 		Memory::Memcpy(dst, Memory::GetPointer(src), size);

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -552,9 +552,12 @@ u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
 {
 	u8 c = fillc & 0xff;
 	DEBUG_LOG(SCEINTC, "sceKernelMemset(ptr = %08x, c = %02x, n = %08x)", addr, c, n);
-	Memory::Memset(addr, c, n);
+	bool skip = false;
 	if (Memory::IsVRAMAddress(addr)) {
-		gpu->UpdateMemory(addr, addr, n);
+		skip = gpu->PerformMemorySet(addr, fillc, n);
+	}
+	if (!skip) {
+		Memory::Memset(addr, c, n);
 	}
 	return addr;
 }
@@ -565,7 +568,7 @@ u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 
 	bool skip = false;
 	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
-		skip = gpu->UpdateMemory(dst, src, size);
+		skip = gpu->PerformMemoryCopy(dst, src, size);
 	}
 
 	// Technically should crash if these are invalid and size > 0...

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -553,6 +553,9 @@ u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
 	u8 c = fillc & 0xff;
 	DEBUG_LOG(SCEINTC, "sceKernelMemset(ptr = %08x, c = %02x, n = %08x)", addr, c, n);
 	Memory::Memset(addr, c, n);
+	if (Memory::IsVRAMAddress(addr)) {
+		gpu->UpdateMemory(addr, addr, n);
+	}
 	return addr;
 }
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -33,6 +33,7 @@
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Core/HLE/HLE.h"
+#include "Core/HLE/ReplaceTables.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
@@ -226,10 +227,12 @@ namespace SaveState
 		// Memory is a bit tricky when jit is enabled, since there's emuhacks in it.
 		if (MIPSComp::jit && p.mode == p.MODE_WRITE)
 		{
-			auto blocks = MIPSComp::jit->GetBlockCache();
-			auto saved = blocks->SaveAndClearEmuHackOps();
+			auto blockCache = MIPSComp::jit->GetBlockCache();
+			auto savedReplacements = SaveAndClearReplacements();
+			auto savedBlocks = blockCache->SaveAndClearEmuHackOps();
 			Memory::DoState(p);
-			blocks->RestoreSavedEmuHackOps(saved);
+			blockCache->RestoreSavedEmuHackOps(savedBlocks);
+			RestoreSavedReplacements(savedReplacements);
 		}
 		else
 			Memory::DoState(p);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1315,7 +1315,12 @@ void DIRECTX9_GPU::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationTy
 		framebufferManager_.UpdateFromMemory(addr, size);
 }
 
-bool DIRECTX9_GPU::UpdateMemory(u32 dest, u32 src, int size) {
+bool DIRECTX9_GPU::PerformMemoryCopy(u32 dest, u32 src, int size) {
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
+bool DIRECTX9_GPU::PerformMemorySet(u32 dest, u8 v, int size) {
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	return false;
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -46,7 +46,8 @@ public:
 	virtual void BeginFrame();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual bool UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
+	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012- PPSSPP Project.
+﻿// Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -1851,7 +1851,7 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 	}
 }
 
-bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
+bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool isMemset) {
 	if (!useBufferedRendering_ || updateVRAM_) {
 		return false;
 	}
@@ -1880,11 +1880,9 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 		}
 	}
 
-	bool actuallyMemset = src == dst;
-
 	// TODO: Do ReadFramebufferToMemory etc where applicable.
 	// This will slow down MotoGP but make the hack above unnecessary.
-	if (dstBuffer && srcBuffer && !actuallyMemset) {
+	if (dstBuffer && srcBuffer && !isMemset) {
 		if (srcBuffer == dstBuffer) {
 			WARN_LOG_REPORT_ONCE(dstsrccpy, G3D, "Intra-buffer memcpy (not supported) %08x -> %08x", src, dst);
 		} else {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1880,9 +1880,11 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size) {
 		}
 	}
 
+	bool actuallyMemset = src == dst;
+
 	// TODO: Do ReadFramebufferToMemory etc where applicable.
 	// This will slow down MotoGP but make the hack above unnecessary.
-	if (dstBuffer && srcBuffer) {
+	if (dstBuffer && srcBuffer && !actuallyMemset) {
 		if (srcBuffer == dstBuffer) {
 			WARN_LOG_REPORT_ONCE(dstsrccpy, G3D, "Intra-buffer memcpy (not supported) %08x -> %08x", src, dst);
 		} else {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -211,7 +211,7 @@ public:
 	}
 	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 
-	bool NotifyFramebufferCopy(u32 src, u32 dest, int size);
+	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false);
 
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
 

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -44,7 +44,8 @@ public:
 	virtual void BeginFrame();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual bool UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
+	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 
@@ -151,7 +152,8 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void UpdateMemoryInternal(u32 dest, u32 src, int size);
+	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
+	void PerformMemorySetInternal(u32 dest, u8 v, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
 	static CommandInfo cmdInfo_[256];

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -164,6 +164,7 @@ enum GPUEventType {
 	GPU_EVENT_FINISH_EVENT_LOOP,
 	GPU_EVENT_SYNC_THREAD,
 	GPU_EVENT_FB_MEMCPY,
+	GPU_EVENT_FB_MEMSET,
 };
 
 struct GPUEvent {
@@ -182,6 +183,12 @@ struct GPUEvent {
 			u32 src;
 			int size;
 		} fb_memcpy;
+		// GPU_EVENT_FB_MEMSET
+		struct {
+			u32 dst;
+			u8 v;
+			int size;
+		} fb_memset;
 	};
 
 	operator GPUEventType() const {
@@ -234,7 +241,8 @@ public:
 	// If size = -1, invalidate everything.
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type) = 0;
 	// Update either RAM from VRAM, or VRAM from RAM... or even VRAM from VRAM.
-	virtual bool UpdateMemory(u32 dest, u32 src, int size) = 0;
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size) = 0;
+	virtual bool PerformMemorySet(u32 dest, u8 v, int size) = 0;
 
 	// Will cause the texture cache to be cleared at the start of the next frame.
 	virtual void ClearCacheNextFrame() = 0;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -657,7 +657,13 @@ void NullGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 	// Nothing to invalidate.
 }
 
-bool NullGPU::UpdateMemory(u32 dest, u32 src, int size) {
+bool NullGPU::PerformMemoryCopy(u32 dest, u32 src, int size) {
+	// Nothing to update.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
+bool NullGPU::PerformMemorySet(u32 dest, u8 v, int size) {
 	// Nothing to update.
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	return false;

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -34,7 +34,8 @@ public:
 	virtual void CopyDisplayToOutput() {}
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual bool UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
+	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -851,7 +851,16 @@ void SoftGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type)
 	// Nothing to invalidate.
 }
 
-bool SoftGPU::UpdateMemory(u32 dest, u32 src, int size)
+bool SoftGPU::PerformMemoryCopy(u32 dest, u32 src, int size)
+{
+	// Nothing to update.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	// Let's just be safe.
+	framebufferDirty_ = true;
+	return false;
+}
+
+bool SoftGPU::PerformMemorySet(u32 dest, u8 v, int size)
 {
 	// Nothing to update.
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -59,7 +59,8 @@ public:
 	virtual void CopyDisplayToOutput();
 	virtual void UpdateStats();
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
-	virtual bool UpdateMemory(u32 dest, u32 src, int size);
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
+	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}

--- a/assets/knownfuncs.ini
+++ b/assets/knownfuncs.ini
@@ -140,6 +140,7 @@
 6301fa5149bd973a:120 = wcscat
 658b07240a690dbd:36 = strlen
 66122f0ab50b2ef9:296 = dl_write_dither_matrix_5
+66f7f1beccbc104a:256 = memcpy_swizzled
 679e647e34ecf7f1:132 = roundf
 67afe74d9ec72f52:4380 = _strtod_r
 68b22c2aa4b8b915:400 = sqrt


### PR DESCRIPTION
The memset fixes some minor artifacts in Narikiri Dungeon, and the swizzling is used by God Eater 2 when loading saves (it then textures it swizzled.)

I can imagine more games might use a swizzling memcpy like this, not sure if the params will be the same...

-[Unknown]
