### PR TITLE
Allow jit and fast memory to be reconfigured at runtime

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -215,6 +215,26 @@ void MIPSState::Init() {
 	rng.Init(0x1337);
 }
 
+void MIPSState::UpdateCore(CPUCore desired) {
+	if (PSP_CoreParameter().cpuCore == desired) {
+		return;
+	}
+
+	PSP_CoreParameter().cpuCore = desired;
+	switch (PSP_CoreParameter().cpuCore) {
+	case CPU_JIT:
+		if (!MIPSComp::jit) {
+			MIPSComp::jit = new MIPSComp::Jit(this);
+		}
+		break;
+
+	case CPU_INTERPRETER:
+		delete MIPSComp::jit;
+		MIPSComp::jit = 0;
+		break;
+	}
+}
+
 void MIPSState::DoState(PointerWrap &p) {
 	auto s = p.Section("MIPSState", 1, 3);
 	if (!s)

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -19,6 +19,7 @@
 
 #include "util/random/rng.h"
 #include "Common/CommonTypes.h"
+#include "Core/CoreParameter.h"
 #include "Core/Opcode.h"
 
 class PointerWrap;
@@ -131,6 +132,7 @@ public:
 	void Init();
 	void Shutdown();
 	void Reset();
+	void UpdateCore(CPUCore desired);
 
 	void DoState(PointerWrap &p);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -215,6 +215,7 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		if (MIPSComp::jit) {
 			MIPSComp::jit->ClearCache();
 		}
+		currentMIPS->UpdateCore(g_Config.bJit ? CPU_JIT : CPU_INTERPRETER);
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -57,7 +57,6 @@ void GameSettingsScreen::CreateViews() {
 	GameInfo *info = g_gameInfoCache.GetInfo(gamePath_, true);
 
 	cap60FPS_ = g_Config.iForceMaxEmulatedFPS == 60;
-	showDebugStats_ = g_Config.bShowDebugStats;
 
 	iAlternateSpeedPercent_ = (g_Config.iFpsLimit * 100) / 60;
 
@@ -205,7 +204,7 @@ void GameSettingsScreen::CreateViews() {
 #endif
 	};
 	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iShowFPSCounter, gs->T("Show FPS Counter"), fpsChoices, 0, ARRAY_SIZE(fpsChoices), gs, screenManager()));
-	graphicsSettings->Add(new CheckBox(&showDebugStats_, gs->T("Show Debug Statistics")));
+	graphicsSettings->Add(new CheckBox(&g_Config.bShowDebugStats, gs->T("Show Debug Statistics")))->OnClick.Handle(this, &GameSettingsScreen::OnJitAffectingSetting);
 
 	// Developer tools are not accessible ingame, so it goes here.
 	graphicsSettings->Add(new ItemHeader(gs->T("Debugging")));
@@ -302,7 +301,7 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new Choice(dev->T("Language", "Language")))->OnClick.Handle(this, &GameSettingsScreen::OnLanguage);
 
 	systemSettings->Add(new ItemHeader(s->T("Emulation")));
-	systemSettings->Add(new CheckBox(&g_Config.bFastMemory, s->T("Fast Memory", "Fast Memory (Unstable)")));
+	systemSettings->Add(new CheckBox(&g_Config.bFastMemory, s->T("Fast Memory", "Fast Memory (Unstable)")))->OnClick.Handle(this, &GameSettingsScreen::OnJitAffectingSetting);
 
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateCPUThread, s->T("Multithreaded (experimental)")))->SetEnabled(!PSP_IsInited());
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateIOThread, s->T("I/O on thread (experimental)")))->SetEnabled(!PSP_IsInited());
@@ -406,6 +405,11 @@ UI::EventReturn GameSettingsScreen::OnRenderingMode(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
+UI::EventReturn GameSettingsScreen::OnJitAffectingSetting(UI::EventParams &e) {
+	NativeMessageReceived("clear jit", "");
+	return UI::EVENT_DONE;
+}
+
 UI::EventReturn GameSettingsScreen::OnFrameSkipChange(UI::EventParams &e) {
 	frameSkipAuto_->SetEnabled(g_Config.iFrameSkip != 0);
 
@@ -461,12 +465,6 @@ void GameSettingsScreen::update(InputState &input) {
 	g_Config.iForceMaxEmulatedFPS = cap60FPS_ ? 60 : 0;
 
 	g_Config.iFpsLimit = (iAlternateSpeedPercent_ * 60) / 100;
-
-	if (g_Config.bShowDebugStats != showDebugStats_) {
-		// This affects the jit.
-		NativeMessageReceived("clear jit", "");
-		g_Config.bShowDebugStats = showDebugStats_;
-	}
 }
 
 void GameSettingsScreen::sendMessage(const char *message, const char *value) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -615,18 +615,14 @@ void DeveloperToolsScreen::CreateViews() {
 	list->SetSpacing(0);
 	list->Add(new ItemHeader(s->T("General")));
 
+	bool canUseJit = true;
 #ifdef IOS
 	if (!iosCanUseJit) {
+		canUseJit = false;
 		list->Add(new TextView(s->T("DynarecisJailed", "Dynarec (JIT) - (Not jailbroken - JIT not available)")));
-	} else {
-		auto jitCheckbox = new CheckBox(&g_Config.bJit, s->T("Dynarec", "Dynarec (JIT)"));
-		jitCheckbox->SetEnabled(!PSP_IsInited());
-		list->Add(jitCheckbox);
 	}
 #else
-	auto jitCheckbox = new CheckBox(&g_Config.bJit, s->T("Dynarec", "Dynarec (JIT)"));
-	jitCheckbox->SetEnabled(!PSP_IsInited());
-	list->Add(jitCheckbox);
+	list->Add(new CheckBox(&g_Config.bJit, s->T("Dynarec", "Dynarec (JIT)")))->OnClick.Handle(this, &DeveloperToolsScreen::OnJitAffectingSetting);
 #endif
 
 	list->Add(new Choice(de->T("System Information")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSysInfo);
@@ -700,5 +696,10 @@ UI::EventReturn DeveloperToolsScreen::OnLoadLanguageIni(UI::EventParams &e) {
 
 UI::EventReturn DeveloperToolsScreen::OnLogConfig(UI::EventParams &e) {
 	screenManager()->push(new LogConfigScreen());
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn DeveloperToolsScreen::OnJitAffectingSetting(UI::EventParams &e) {
+	NativeMessageReceived("clear jit", "");
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -73,6 +73,7 @@ private:
 	UI::EventReturn OnShaderChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 	UI::EventReturn OnRenderingMode(UI::EventParams &e);
+	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 
 	UI::EventReturn OnScreenRotation(UI::EventParams &e);
 	UI::EventReturn OnImmersiveModeChange(UI::EventParams &e);
@@ -81,7 +82,6 @@ private:
 	bool cap60FPS_;
 	int iAlternateSpeedPercent_;
 	bool enableReports_;
-	bool showDebugStats_;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -100,4 +100,5 @@ private:
 	UI::EventReturn OnLoadLanguageIni(UI::EventParams &e);
 	UI::EventReturn OnSaveLanguageIni(UI::EventParams &e);
 	UI::EventReturn OnLogConfig(UI::EventParams &e);
+	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 };

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -135,6 +135,7 @@ void HandleCommonMessages(const char *message, const char *value, ScreenManager 
 		if (MIPSComp::jit && PSP_IsInited()) {
 			MIPSComp::jit->ClearCache();
 		}
+		currentMIPS->UpdateCore(g_Config.bJit ? CPU_JIT : CPU_INTERPRETER);
 	}
 }
 


### PR DESCRIPTION
Just need to clear the cache and reset MIPSComp::jit.

-[Unknown]
