### PR TITLE
Work around windows 's fullscreen OSK pop up issue

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -30,6 +30,7 @@
 
 #if defined(USING_WIN_UI)
 #include "base/NativeApp.h"
+#include "Core/host.h"
 #endif
 
 #ifndef _WIN32
@@ -862,8 +863,18 @@ int PSPOskDialog::Update(int animSpeed) {
 #if defined(USING_WIN_UI)
 	// Windows: Fall back to the OSK/continue normally if we're in fullscreen.
 	// The dialog box doesn't work right if in fullscreen.
-	if(g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen)
-		return NativeKeyboard();
+	// Work arround by temp disable fullscreen
+
+	if (g_Config.bBypassOSKWithKeyboard) {
+		bool tFullScreen = g_Config.bFullScreen;
+		if (tFullScreen)
+			host->GoFullscreen(false);
+		int ret = NativeKeyboard();
+		if (tFullScreen)
+			host->GoFullscreen(true);
+		return ret;
+	}
+
 #endif
 
 	UpdateFade(animSpeed);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -512,9 +512,9 @@ UI::EventReturn GameSettingsScreen::OnChangeNickname(UI::EventParams &e) {
 		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a new PSP nickname", g_Config.sNickName.c_str(), name, name_len)) {
 		g_Config.sNickName = name;
+	}
 	if (tFullScreen)
 		host->GoFullscreen(true);
-	}
 #endif
 	return UI::EVENT_DONE;
 }
@@ -531,9 +531,10 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a IP address", g_Config.proAdhocServer.c_str(), name, name_len)) {
 		g_Config.proAdhocServer = name;
-	if (tFullScreen)
-		host->GoFullscreen(true);
 	}
+	if (tFullScreen)
+		host->GoFullscreen(true);	
+
 #endif
 	return UI::EVENT_DONE;
 }
@@ -550,9 +551,10 @@ UI::EventReturn GameSettingsScreen::OnChangeMacAddress(UI::EventParams &e) {
 		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a Mac address", g_Config.localMacAddress.c_str(), name, name_len)) {
 		g_Config.localMacAddress = name;
+	}
 	if (tFullScreen)
 		host->GoFullscreen(true);
-	}
+
 #endif
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -507,8 +507,13 @@ UI::EventReturn GameSettingsScreen::OnChangeNickname(UI::EventParams &e) {
 	char name[name_len];
 	memset(name, 0, sizeof(name));
 
+	bool tFullScreen = g_Config.bFullScreen;
+	if (tFullScreen)
+		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a new PSP nickname", g_Config.sNickName.c_str(), name, name_len)) {
 		g_Config.sNickName = name;
+	if (tFullScreen)
+		host->GoFullscreen(true);
 	}
 #endif
 	return UI::EVENT_DONE;
@@ -521,8 +526,13 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 	char name[name_len];
 	memset(name, 0, sizeof(name));
 
+	bool tFullScreen = g_Config.bFullScreen;
+	if (tFullScreen)
+		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a IP address", g_Config.proAdhocServer.c_str(), name, name_len)) {
 		g_Config.proAdhocServer = name;
+	if (tFullScreen)
+		host->GoFullscreen(true);
 	}
 #endif
 	return UI::EVENT_DONE;
@@ -535,8 +545,13 @@ UI::EventReturn GameSettingsScreen::OnChangeMacAddress(UI::EventParams &e) {
 	char name[name_len];
 	memset(name, 0, sizeof(name));
 
+	bool tFullScreen = g_Config.bFullScreen;
+	if (tFullScreen)
+		host->GoFullscreen(false);
 	if (System_InputBoxGetString("Enter a Mac address", g_Config.localMacAddress.c_str(), name, name_len)) {
 		g_Config.localMacAddress = name;
+	if (tFullScreen)
+		host->GoFullscreen(true);
 	}
 #endif
 	return UI::EVENT_DONE;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -339,6 +339,9 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new ItemHeader(s->T("Networking")));
 	systemSettings->Add(new CheckBox(&g_Config.bEnableWlan, s->T("Enable networking", "Enable networking/wlan (beta)")));
 #if defined(_WIN32) || defined(USING_QT_UI)
+	// TODO: Come up with a way to display a keyboard for mobile users,
+	// so until then, this is Windows/Desktop only.
+	systemSettings->Add(new Choice(s->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 	systemSettings->Add(new Choice(s->T("Change proAdhocServer Address")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeproAdhocServerAddress);
 	systemSettings->Add(new Choice(s->T("Change Mac Address")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeMacAddress);
 #else
@@ -365,11 +368,6 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new ItemHeader(s->T("PSP Settings")));
 	static const char *models[] = {"PSP-1000" , "PSP-2000/3000"};
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, s->T("PSP Model"), models, 0, ARRAY_SIZE(models), s, screenManager()));
-	// TODO: Come up with a way to display a keyboard for mobile users,
-	// so until then, this is Windows/Desktop only.
-#if defined(_WIN32) || defined(USING_QT_UI)
-	systemSettings->Add(new Choice(s->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
-#endif
 #if defined(_WIN32) || (defined(USING_QT_UI) && !defined(MOBILE_DEVICE))
 	// Screenshot functionality is not yet available on non-Windows/non-Qt
 	systemSettings->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, s->T("Screenshots as PNG")));


### PR DESCRIPTION
By temp turn of fullscreen.
#6156

I also enable this trick in sceUtilityOsk
The bad thing is that the background is dark when input.
![1](https://cloud.githubusercontent.com/assets/2177532/3091256/57152c48-e59a-11e3-9934-ad2c0de650ec.jpg)
