### PR TITLE
Symbian: Over allocate VRAM (x4) in attempt to solve crash

### DIFF
--- a/Common/MemArena.cpp
+++ b/Common/MemArena.cpp
@@ -297,7 +297,11 @@ static bool Memory_TryBase(u8 *base, const MemoryView *views, int num_views, u32
 		} else {
 #ifdef __SYMBIAN32__
 			*(view.out_ptr_low) = (u8*)((int)arena->memmap->Base() + view.virtual_address);
-			arena->memmap->Commit(view.virtual_address & 0x3FFFFFFF, view.size);
+			// Over allocate VRAM to span the mirrors. Hopefully resolves crash.
+			if (i == 2)
+				arena->memmap->Commit(view.virtual_address & 0x3FFFFFFF, view.size * 4);
+			else
+				arena->memmap->Commit(view.virtual_address & 0x3FFFFFFF, view.size);
 		}
 		*(view.out_ptr) = (u8*)((int)arena->memmap->Base() + view.virtual_address & 0x3FFFFFFF);
 #elif defined(_XBOX)

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -108,7 +108,7 @@ void Write_Opcode_JIT(const u32 _Address, const Opcode _Value);
 Opcode Read_Instruction(const u32 _Address, bool resolveReplacements = false);
 Opcode ReadUnchecked_Instruction(const u32 _Address, bool resolveReplacements = false);
 
-u8	Read_U8(const u32 _Address);
+u8  Read_U8(const u32 _Address);
 u16 Read_U16(const u32 _Address);
 u32 Read_U32(const u32 _Address);
 u64 Read_U64(const u32 _Address);


### PR DESCRIPTION
Symbian: Over allocate VRAM (x4) in attempt to solve crash caused by 0.98-601. This brings allocation to the same as before the commit. See #6103
