### PR TITLE
Look at the right bytes for screenshot mode

### DIFF
--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -18,18 +18,22 @@
 #pragma once
 
 #include "Core/Dialog/PSPDialog.h"
+#include "Core/MemMap.h"
+
+struct SceUtilityScreenshotParams;
 
 class PSPScreenshotDialog : public PSPDialog {
 public:
 	PSPScreenshotDialog();
 	virtual ~PSPScreenshotDialog();
 
-	virtual int Init(int paramAddr);
+	virtual int Init(u32 paramAddr);
 	virtual int Update(int animSpeed);
 	virtual int ContStart();
 	virtual void DoState(PointerWrap &p);
 
 protected:
 	int mode;
+	PSPPointer<SceUtilityScreenshotParams> params_;
 };
 


### PR DESCRIPTION
Although, there's a bunch more needed to make this work properly.

It does happen that `100` = `0x64`, and `(0x64 & 7)` = `4`.  However, `4` does not have this behavior, neither does `0x80000064`.  Only `0x64` does.

Although actually, you have to change mode to 101 for it to quit.  102 makes it switch back to 2, but I don't know what to do then (probably wait and then issue another attempt?)

The above information required a ton of hard resets of my PSP, so I don't really want to mess with it much more atm... but this should be the right way to try to hack around the ContStart stuff.

-[Unknown]
