### PR TITLE
Allow uploads to framebuffers in non-buffered, disable shader blending

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -288,6 +288,9 @@ bool ShouldUseShaderBlending() {
 	if (!gl_extensions.VersionGEThan(3, 0, 0) && !gl_extensions.GLES3) {
 		return false;
 	}
+	if (g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+		return false;
+	}
 
 	GEBlendSrcFactor funcA = gstate.getBlendFuncA();
 	GEBlendDstFactor funcB = gstate.getBlendFuncB();


### PR DESCRIPTION
This also allows the render-to-texture copies on GLES2 and pre GL3 devices.

-[Unknown]
