### PR TITLE
Function replacement hooks and some GLES compat replacements

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -149,9 +149,7 @@ static int Replace_memcpy_swizzled() {
 	u32 pitch = PARAM(2);
 	u32 h = PARAM(4);
 	if (Memory::IsVRAMAddress(srcPtr)) {
-		// Cheat a bit to force a download of the framebuffer.
-		// VRAM + 0x00400000 is simply a VRAM mirror.
-		gpu->PerformMemoryCopy(srcPtr ^ 0x00400000, srcPtr, pitch * h);
+		gpu->PerformMemoryDownload(srcPtr, pitch * h);
 	}
 	u8 *dstp = Memory::GetPointerUnchecked(destPtr);
 	const u8 *srcp = Memory::GetPointerUnchecked(srcPtr);
@@ -465,9 +463,7 @@ static int Hook_godseaterburst_blit_texture() {
 	const u32 fb_info = Memory::Read_U32(fb_infoaddr);
 	const u32 fb_address = Memory::Read_U32(fb_info);
 	if (Memory::IsVRAMAddress(fb_address)) {
-		// Cheat a bit to force a download of the framebuffer.
-		// VRAM + 0x00400000 is simply a VRAM mirror.
-		gpu->PerformMemoryCopy(fb_address ^ 0x00400000, fb_address, 0x00048000);
+		gpu->PerformMemoryDownload(fb_address, 0x00048000);
 		CBreakPoints::ExecMemCheck(fb_address, true, 0x00048000, currentMIPS->pc);
 	}
 	return 0;
@@ -481,9 +477,7 @@ static int Hook_hexyzforce_monoclome_thread() {
 
 	const u32 fb_address = Memory::Read_U32(fb_info);
 	if (Memory::IsVRAMAddress(fb_address)) {
-		// Cheat a bit to force a download of the framebuffer.
-		// VRAM + 0x00400000 is simply a VRAM mirror.
-		gpu->PerformMemoryCopy(fb_address ^ 0x00400000, fb_address, 0x00088000);
+		gpu->PerformMemoryDownload(fb_address, 0x00088000);
 		CBreakPoints::ExecMemCheck(fb_address, true, 0x00088000, currentMIPS->pc);
 	}
 	return 0;

--- a/Core/HLE/ReplaceTables.h
+++ b/Core/HLE/ReplaceTables.h
@@ -40,6 +40,10 @@ typedef int (* ReplaceFunc)();
 
 enum {
 	REPFLAG_ALLOWINLINE = 1,
+	// Note that this will re-execute in a funciton that loops at start.
+	REPFLAG_HOOKENTER = 2,
+	// Only hooks jr ra, so only use on funcs that have that.
+	REPFLAG_HOOKEXIT = 4,
 };
 
 // Kind of similar to HLE functions but with different data.
@@ -57,7 +61,7 @@ int GetNumReplacementFuncs();
 int GetReplacementFuncIndex(u64 hash, int funcSize);
 const ReplacementTableEntry *GetReplacementFunc(int index);
 
-void WriteReplaceInstruction(u32 address, u64 hash, int size);
+void WriteReplaceInstructions(u32 address, u64 hash, int size);
 void RestoreReplacedInstruction(u32 address);
 void RestoreReplacedInstructions(u32 startAddr, u32 endAddr);
 bool GetReplacedOpAt(u32 address, u32 *op);

--- a/Core/HLE/ReplaceTables.h
+++ b/Core/HLE/ReplaceTables.h
@@ -52,6 +52,7 @@ struct ReplacementTableEntry {
 	ReplaceFunc replaceFunc;
 	MIPSComp::MIPSReplaceFunc jitReplaceFunc;
 	int flags;
+	s32 hookOffset;
 };
 
 void Replacement_Init();

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -416,6 +416,9 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op)
 		}
 	} else if (entry->replaceFunc) {
 		FlushAll();
+		gpr.SetRegImm(SCRATCHREG1, js.compilerPC);
+		MovToPC(SCRATCHREG1);
+
 		// Standard function call, nothing fancy.
 		// The function returns the number of cycles it took in EAX.
 		if (BLInRange((const void *)(entry->replaceFunc))) {

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -357,6 +357,11 @@ bool Jit::ReplaceJalTo(u32 dest) {
 		return false;
 	}
 
+	if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+		// If it's a hook, we can't replace the jal, we have to go inside the func.
+		return false;
+	}
+
 	// Warning - this might be bad if the code at the destination changes...
 	if (entry->flags & REPFLAG_ALLOWINLINE) {
 		// Jackpot! Just do it, no flushing. The code will be entirely inlined.
@@ -397,11 +402,18 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op)
 	if (entry->jitReplaceFunc) {
 		MIPSReplaceFunc repl = entry->jitReplaceFunc;
 		int cycles = (this->*repl)();
-		FlushAll();
-		// Flushed, so R1 is safe.
-		LDR(R1, CTXREG, MIPS_REG_RA * 4);
-		js.downcountAmount = cycles;
-		WriteExitDestInR(R1);
+
+		if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+			// Compile the original instruction at this address.  We ignore cycles for hooks.
+			MIPSCompileOp(Memory::Read_Instruction(js.compilerPC, true));
+		} else {
+			FlushAll();
+			// Flushed, so R1 is safe.
+			LDR(R1, CTXREG, MIPS_REG_RA * 4);
+			js.downcountAmount = cycles;
+			WriteExitDestInR(R1);
+			js.compiling = false;
+		}
 	} else if (entry->replaceFunc) {
 		FlushAll();
 		// Standard function call, nothing fancy.
@@ -412,21 +424,20 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op)
 			MOVI2R(R0, (u32)entry->replaceFunc);
 			BL(R0);
 		}
-		// Alternatively, we could inline it here, instead of calling out, if it's a function
-		// we can emit.
 
-		LDR(R1, CTXREG, MIPS_REG_RA * 4);
-		WriteDownCountR(R0);
-		js.downcountAmount = 0;  // we just subtracted most of it
-		WriteExitDestInR(R1);
+		if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+			// Compile the original instruction at this address.  We ignore cycles for hooks.
+			MIPSCompileOp(Memory::Read_Instruction(js.compilerPC, true));
+		} else {
+			LDR(R1, CTXREG, MIPS_REG_RA * 4);
+			WriteDownCountR(R0);
+			js.downcountAmount = 0;  // we just subtracted most of it
+			WriteExitDestInR(R1);
+			js.compiling = false;
+		}
 	} else {
 		ERROR_LOG(HLE, "Replacement function %s has neither jit nor regular impl", entry->name);
 	}
-
-	js.compiling = false;
-
-	// We could even do this in the jal that is branching to the function
-	// but having the op is necessary for the interpreter anyway.
 }
 
 void Jit::Comp_Generic(MIPSOpcode op)

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -953,7 +953,7 @@ skip:
 		lock_guard guard(functions_lock);
 
 		for (size_t i = 0; i < functions.size(); i++) {
-			WriteReplaceInstruction(functions[i].start, functions[i].hash, functions[i].size);
+			WriteReplaceInstructions(functions[i].start, functions[i].hash, functions[i].size);
 		}
 	}
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -149,6 +149,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x317afeb882ff324a, 212, "memcpy", }, // Mimana
 	{ 0x31ea2e192f5095a1, 52, "vector_add_t", },
 	{ 0x31f523ef18898e0e, 420, "logf", },
+	{ 0x32215b1d2196377f, 844, "godseaterburst_blit_texture", },
 	{ 0x32806967fe81568b, 40, "vector_sub_t_2", },
 	{ 0x32ceb9a7f72b9385, 440, "_strtoul_r", },
 	{ 0x32e6bc7c151491ed, 68, "memchr", },
@@ -294,6 +295,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xa1ca0640f11182e7, 72, "strcspn", },
 	{ 0xa243486be51ce224, 272, "cosf", },
 	{ 0xa2bcef60a550a3ef, 92, "matrix_rot_z", },
+	{ 0xa373f55c65cd757a, 312, "memcpy_swizzled" }, // God Eater Burst Demo
 	{ 0xa41989db0f9bf97e, 1304, "pow", },
 	{ 0xa46cc6ea720d5775, 44, "dl_write_cull", },
 	{ 0xa54967288afe8f26, 600, "ceil", },

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -87,6 +87,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x0654fc8adbe16ef7, 28, "vmul_q", },
 	{ 0x06b243c926fa6ab5, 24, "vf2in_q", },
 	{ 0x06e2826e02056114, 56, "wcslen", },
+	{ 0x073cf0b61d3b875a, 416, "hexyzforce_monoclome_thread", }, // Hexyz Force
 	{ 0x075fa9b234b41e9b, 32, "fmodf", },
 	{ 0x0a051019bdd786c3, 184, "strcasecmp", },
 	{ 0x0a46dc426054bb9d, 24, "vector_add_t", },
@@ -149,7 +150,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x317afeb882ff324a, 212, "memcpy", }, // Mimana
 	{ 0x31ea2e192f5095a1, 52, "vector_add_t", },
 	{ 0x31f523ef18898e0e, 420, "logf", },
-	{ 0x32215b1d2196377f, 844, "godseaterburst_blit_texture", },
+	{ 0x32215b1d2196377f, 844, "godseaterburst_blit_texture", }, // Gods Eater Burst
 	{ 0x32806967fe81568b, 40, "vector_sub_t_2", },
 	{ 0x32ceb9a7f72b9385, 440, "_strtoul_r", },
 	{ 0x32e6bc7c151491ed, 68, "memchr", },

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -978,11 +978,11 @@ skip:
 		}
 	}
 
-	const char *LookupHash(u64 hash, int funcsize) {
-		for (auto it = hashMap.begin(), end = hashMap.end(); it != end; ++it) {
-			if (it->hash == hash && (int)it->size == funcsize) {
-				return it->name;
-			}
+	const char *LookupHash(u64 hash, u32 funcsize) {
+		const HashMapFunc f = { "", hash, funcsize };
+		auto it = hashMap.find(f);
+		if (it != hashMap.end()) {
+			return it->name;
 		}
 		return 0;
 	}

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -110,7 +110,7 @@ namespace MIPSAnalyst
 	void LoadHashMap(std::string filename);
 	void StoreHashMap(std::string filename = "");
 
-	const char *LookupHash(u64 hash, int funcSize);
+	const char *LookupHash(u64 hash, u32 funcSize);
 	void ReplaceFunctions();
 
 	void UpdateHashMap();

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -30,6 +30,7 @@
 
 #define MIPS_MAKE_ADDIU(dreg, sreg, immval) ((9 << 26) | ((dreg) << 16) | ((sreg) << 21) | (immval))
 #define MIPS_MAKE_LUI(reg, immval) (0x3c000000 | ((reg) << 16) | (immval))
+#define MIPS_MAKE_LW(rt, rs, immval) (0x8c000000 | ((rs) << 21) | ((rt) << 16) | (immval))
 #define MIPS_MAKE_SYSCALL(module, function) GetSyscallOp(module, GetNibByName(module, function))
 #define MIPS_MAKE_BREAK() (13)  // ! :)
 

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -1022,11 +1022,16 @@ namespace MIPSInt
 		const ReplacementTableEntry *entry = GetReplacementFunc(index);
 		if (entry && entry->replaceFunc) {
 			entry->replaceFunc();
+
+			if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+				// Interpret the original instruction under the hook.
+				MIPSInterpret(Memory::Read_Instruction(PC, true));
+			} else {
+				PC = currentMIPS->r[MIPS_REG_RA];
+			}
 		} else {
 			ERROR_LOG(CPU, "Bad replacement function index %i", index);
-		}	
-
-		PC = currentMIPS->r[MIPS_REG_RA];
+		}
 	}
 
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -423,6 +423,11 @@ bool Jit::ReplaceJalTo(u32 dest) {
 		return false;
 	}
 
+	if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+		// If it's a hook, we can't replace the jal, we have to go inside the func.
+		return false;
+	}
+
 	// Warning - this might be bad if the code at the destination changes...
 	if (entry->flags & REPFLAG_ALLOWINLINE) {
 		// Jackpot! Just do it, no flushing. The code will be entirely inlined.
@@ -470,26 +475,34 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op)
 	if (entry->jitReplaceFunc) {
 		MIPSReplaceFunc repl = entry->jitReplaceFunc;
 		int cycles = (this->*repl)();
-		FlushAll();
-		MOV(32, R(ECX), M(&currentMIPS->r[MIPS_REG_RA]));
-		js.downcountAmount = cycles;
-		WriteExitDestInReg(ECX);
-		js.compiling = false;
+
+		if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+			// Compile the original instruction at this address.  We ignore cycles for hooks.
+			MIPSCompileOp(Memory::Read_Instruction(js.compilerPC, true));
+		} else {
+			FlushAll();
+			MOV(32, R(ECX), M(&currentMIPS->r[MIPS_REG_RA]));
+			js.downcountAmount = cycles;
+			WriteExitDestInReg(ECX);
+			js.compiling = false;
+		}
 	} else if (entry->replaceFunc) {
 		FlushAll();
 
 		// Standard function call, nothing fancy.
 		// The function returns the number of cycles it took in EAX.
 		ABI_CallFunction(entry->replaceFunc);
-		// Alternatively, we could inline it here, instead of calling out, if it's a function
-		// we can emit.
 
-		MOV(32, R(ECX), M(&currentMIPS->r[MIPS_REG_RA]));
-		SUB(32, M(&currentMIPS->downcount), R(EAX));
-		js.downcountAmount = 0;  // we just subtracted most of it
-		WriteExitDestInReg(ECX);
-
-		js.compiling = false;
+		if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {
+			// Compile the original instruction at this address.  We ignore cycles for hooks.
+			MIPSCompileOp(Memory::Read_Instruction(js.compilerPC, true));
+		} else {
+			MOV(32, R(ECX), M(&currentMIPS->r[MIPS_REG_RA]));
+			SUB(32, M(&currentMIPS->downcount), R(EAX));
+			js.downcountAmount = 0;  // we just subtracted most of it
+			WriteExitDestInReg(ECX);
+			js.compiling = false;
+		}
 	} else {
 		ERROR_LOG(HLE, "Replacement function %s has neither jit nor regular impl", entry->name);
 	}

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -442,6 +442,7 @@ bool Jit::ReplaceJalTo(u32 dest) {
 		gpr.SetImm(MIPS_REG_RA, js.compilerPC + 8);
 		CompileDelaySlot(DELAYSLOT_NICE);
 		FlushAll();
+		MOV(32, M(&mips_->pc), Imm32(js.compilerPC));
 		ABI_CallFunction(entry->replaceFunc);
 		SUB(32, M(&currentMIPS->downcount), R(EAX));
 		js.downcountAmount = 0;  // we just subtracted most of it
@@ -491,6 +492,7 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op)
 
 		// Standard function call, nothing fancy.
 		// The function returns the number of cycles it took in EAX.
+		MOV(32, M(&mips_->pc), Imm32(js.compilerPC));
 		ABI_CallFunction(entry->replaceFunc);
 
 		if (entry->flags & (REPFLAG_HOOKENTER | REPFLAG_HOOKEXIT)) {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -225,17 +225,17 @@ namespace SaveState
 		CoreTiming::DoState(p);
 
 		// Memory is a bit tricky when jit is enabled, since there's emuhacks in it.
+		auto savedReplacements = SaveAndClearReplacements();
 		if (MIPSComp::jit && p.mode == p.MODE_WRITE)
 		{
 			auto blockCache = MIPSComp::jit->GetBlockCache();
-			auto savedReplacements = SaveAndClearReplacements();
 			auto savedBlocks = blockCache->SaveAndClearEmuHackOps();
 			Memory::DoState(p);
 			blockCache->RestoreSavedEmuHackOps(savedBlocks);
-			RestoreSavedReplacements(savedReplacements);
 		}
 		else
 			Memory::DoState(p);
+		RestoreSavedReplacements(savedReplacements);
 
 		MemoryStick_DoState(p);
 		currentMIPS->DoState(p);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1325,6 +1325,11 @@ bool DIRECTX9_GPU::PerformMemorySet(u32 dest, u8 v, int size) {
 	return false;
 }
 
+bool DIRECTX9_GPU::PerformMemoryDownload(u32 dest, int size) {
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
 void DIRECTX9_GPU::ClearCacheNextFrame() {
 	textureCache_.ClearNextFrame();
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -48,6 +48,7 @@ public:
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
 	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
+	virtual bool PerformMemoryDownload(u32 dest, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -2048,6 +2048,12 @@ bool GLES_GPU::PerformMemorySet(u32 dest, u8 v, int size) {
 	return false;
 }
 
+bool GLES_GPU::PerformMemoryDownload(u32 dest, int size) {
+	// Cheat a bit to force a download of the framebuffer.
+	// VRAM + 0x00400000 is simply a VRAM mirror.
+	return gpu->PerformMemoryCopy(dest ^ 0x00400000, dest, size);
+}
+
 void GLES_GPU::ClearCacheNextFrame() {
 	textureCache_.ClearNextFrame();
 }

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -47,6 +47,7 @@ public:
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
 	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
+	virtual bool PerformMemoryDownload(u32 dest, int size);
 	virtual void ClearCacheNextFrame();
 	virtual void DeviceLost();  // Only happens on Android. Drop all textures and shaders.
 

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -243,6 +243,7 @@ public:
 	// Update either RAM from VRAM, or VRAM from RAM... or even VRAM from VRAM.
 	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size) = 0;
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size) = 0;
+	virtual bool PerformMemoryDownload(u32 dest, int size) = 0;
 
 	// Will cause the texture cache to be cleared at the start of the next frame.
 	virtual void ClearCacheNextFrame() = 0;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -668,3 +668,9 @@ bool NullGPU::PerformMemorySet(u32 dest, u8 v, int size) {
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	return false;
 }
+
+bool NullGPU::PerformMemoryDownload(u32 dest, int size) {
+	// Nothing to update.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -36,6 +36,7 @@ public:
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
 	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
+	virtual bool PerformMemoryDownload(u32 dest, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -869,6 +869,13 @@ bool SoftGPU::PerformMemorySet(u32 dest, u8 v, int size)
 	return false;
 }
 
+bool SoftGPU::PerformMemoryDownload(u32 dest, int size)
+{
+	// Nothing to update.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
 bool SoftGPU::FramebufferDirty() {
 	if (g_Config.bSeparateCPUThread) {
 		// Allow it to process fully before deciding if it's dirty.

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -61,6 +61,7 @@ public:
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type);
 	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size);
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size);
+	virtual bool PerformMemoryDownload(u32 dest, int size);
 	virtual void ClearCacheNextFrame() {};
 
 	virtual void DeviceLost() {}

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -455,6 +455,9 @@ int CtrlBreakpointList::getBreakpointIndex(int itemIndex, bool& isMemory)
 
 void CtrlBreakpointList::GetColumnText(wchar_t* dest, int row, int col)
 {
+	if (!PSP_IsInited()) {
+		return;
+	}
 	bool isMemory;
 	int index = getBreakpointIndex(row,isMemory);
 	if (index == -1) return;


### PR DESCRIPTION
This makes the debug build a lot faster, and adds hooking (rather than complete replacing) support for function replacements.

Hooks can be on call, on exit, or at an arbitrary offset into the function.  This is super useful also for debugging games, sometimes.  For example, I have one game where I hooked the function it used to render a string, so that I could log (and screenshot) whenever it used untranslated text.  I had hardcoded this, but doing it via a replacement is cleaner.

Also fixes the inlined swizzled memcpy in Gods Eater Burst, and an alternate signature of the func in a demo.  I don't have any other versions of the game, doesn't seem to use it in God Eater.

This also fixes #3973.  The performance doesn't seem too bad, actually.

Star Ocean (#1392) up next, although I haven't decided what the best way to do it is.  I'm thinking a hook (the func is doing other stuff) and I guess there's no option but multiple passes.  Will probably have to add a PerformStencilUpload() or something to gpu...

-[Unknown]
