### PR TITLE
Decimate in clut stuff, adjustments to IsReallyAClear()

### DIFF
--- a/GPU/GLES/DepalettizeShader.h
+++ b/GPU/GLES/DepalettizeShader.h
@@ -30,6 +30,7 @@ public:
 class DepalTexture {
 public:
 	GLuint texture;
+	int lastFrame;
 };
 
 // Caches both shaders and palette textures.

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -202,7 +202,6 @@ StencilValueType ReplaceAlphaWithStencilType() {
 				return STENCIL_VALUE_KEEP;
 			}
 
-		// Decrementing always zeros, since there's only one bit.
 		case GE_STENCILOP_DECR:
 		case GE_STENCILOP_INCR:
 		case GE_STENCILOP_INVERT:

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -528,6 +528,7 @@ void FramebufferManager::DrawPlainColor(u32 color) {
 	glEnableVertexAttribArray(program->a_position);
 	glVertexAttribPointer(program->a_position, 3, GL_FLOAT, GL_FALSE, 12, pos);
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, indices);
+	// TODO: Really disable this?
 	glDisableVertexAttribArray(program->a_position);
 
 	glsl_unbind();
@@ -602,6 +603,7 @@ void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, flo
 	glVertexAttribPointer(program->a_position, 3, GL_FLOAT, GL_FALSE, 12, pos);
 	glVertexAttribPointer(program->a_texcoord0, 2, GL_FLOAT, GL_FALSE, 8, texCoords);
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_SHORT, indices);
+	// TODO: Really disable these?
 	glDisableVertexAttribArray(program->a_position);
 	glDisableVertexAttribArray(program->a_texcoord0);
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -521,6 +521,8 @@ void FramebufferManager::DrawPlainColor(u32 color) {
 		((color & 0xFF000000) >> 24) / 255.0f,
 	};
 
+	shaderManager_->DirtyLastShader();
+
 	glsl_bind(program);
 	glUniform4fv(plainColorLoc_, 1, col);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -528,7 +530,6 @@ void FramebufferManager::DrawPlainColor(u32 color) {
 	glEnableVertexAttribArray(program->a_position);
 	glVertexAttribPointer(program->a_position, 3, GL_FLOAT, GL_FALSE, 12, pos);
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, indices);
-	// TODO: Really disable this?
 	glDisableVertexAttribArray(program->a_position);
 
 	glsl_unbind();
@@ -589,6 +590,8 @@ void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, flo
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
+	shaderManager_->DirtyLastShader();  // dirty lastShader_
+
 	glsl_bind(program);
 	if (program == postShaderProgram_ && timeLoc_ != -1) {
 		int flipCount = __DisplayGetFlipCount();
@@ -603,13 +606,10 @@ void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, flo
 	glVertexAttribPointer(program->a_position, 3, GL_FLOAT, GL_FALSE, 12, pos);
 	glVertexAttribPointer(program->a_texcoord0, 2, GL_FLOAT, GL_FALSE, 8, texCoords);
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_SHORT, indices);
-	// TODO: Really disable these?
 	glDisableVertexAttribArray(program->a_position);
 	glDisableVertexAttribArray(program->a_texcoord0);
 
 	glsl_unbind();
-
-	shaderManager_->DirtyLastShader();  // dirty lastShader_
 }
 
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -411,6 +411,7 @@ GLES_GPU::GLES_GPU()
 	framebufferManager_.SetShaderManager(shaderManager_);
 	textureCache_.SetFramebufferManager(&framebufferManager_);
 	textureCache_.SetDepalShaderCache(&depalShaderCache_);
+	textureCache_.SetShaderManager(shaderManager_);
 
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -545,6 +545,7 @@ void GLES_GPU::BeginFrameInternal() {
 
 	textureCache_.StartFrame();
 	transformDraw_.DecimateTrackedVertexArrays();
+	depalShaderCache_.Decimate();
 
 	if (dumpNextFrame_) {
 		NOTICE_LOG(G3D, "DUMPING THIS FRAME");

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -684,11 +684,10 @@ Shader *ShaderManager::ApplyVertexShader(int prim, u32 vertType) {
 LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertType) {
 	FragmentShaderID FSID;
 	ComputeFragmentShaderID(&FSID);
-	if (lastVShaderSame_ && FSID == lastFSID_ && !gstate_c.shaderChanged) {
+	if (lastVShaderSame_ && FSID == lastFSID_) {
 		lastShader_->UpdateUniforms(vertType);
 		return lastShader_;
 	}
-	gstate_c.shaderChanged = false;
 
 	lastFSID_ = FSID;
 

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -417,13 +417,6 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		// Stencil takes alpha.
 		glClearStencil(clearColor >> 24);
 		glClear(target);
-
-		// TODO: Now we may have enabled vertex arrays with no data.
-		// This will crash later in DrawActiveTexture().  So we just give it dummy values.
-		if (program->attrMask & (1 << ATTR_COLOR0)) {
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
-			glVertexAttribPointer(ATTR_COLOR0, 4, GL_UNSIGNED_BYTE, GL_TRUE, 4, transformed);
-		}
 		return;
 	}
 

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -383,7 +383,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 	//
 	// An alternative option is to simply ditch all the verts except the first and last to create a single
 	// rectangle out of many. Quite a small optimization though.
-	if (false && maxIndex > 1 && gstate.isModeClear() && prim == GE_PRIM_RECTANGLES && IsReallyAClear(maxIndex)) {
+	if (maxIndex > 1 && gstate.isModeClear() && prim == GE_PRIM_RECTANGLES && IsReallyAClear(maxIndex)) {
 		u32 clearColor = transformed[0].color0_32;
 		float clearDepth = transformed[0].z;
 		const float col[4] = {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -28,6 +28,7 @@
 struct VirtualFramebuffer;
 class FramebufferManager;
 class DepalShaderCache;
+class ShaderManager;
 
 enum TextureFiltering {
 	AUTO = 1,
@@ -73,6 +74,9 @@ public:
 	}
 	void SetDepalShaderCache(DepalShaderCache *dpCache) {
 		depalShaderCache_ = dpCache;
+	}
+	void SetShaderManager(ShaderManager *sm) {
+		shaderManager_ = sm;
 	}
 
 	size_t NumLoadedTextures() const {
@@ -203,6 +207,7 @@ private:
 	int decimationCounter_;
 	FramebufferManager *framebufferManager_;
 	DepalShaderCache *depalShaderCache_;
+	ShaderManager *shaderManager_;
 };
 
 GLenum getClutDestFormat(GEPaletteFormat format);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -453,8 +453,6 @@ struct GPUStateCache
 	bool textureSimpleAlpha;
 	bool vertexFullAlpha;
 	bool framebufChanged;
-	// Doesn't need savestating.
-	bool shaderChanged;
 
 	int skipDrawReason;
 


### PR DESCRIPTION
Even on desktop, the clear stuff provides a small performance increase in for example Gods Eater Burst.  There's a comment that the depth is wrong... but I'm not sure I see why it would be?

I noticed that we leave vertex arrays enabled even when calling DrawActiveTexture, etc.  I guess this is probably okay, but is it a problem we disable them in those funcs?

-[Unknown]
