### PR TITLE
Another attempt at framebuffer size estimate changes

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -652,18 +652,18 @@ void FramebufferManager::EstimateDrawingSize(int &drawing_width, int &drawing_he
 	// In this case, viewport=64x64, region=1024x1024, scissor varies (480x272 sometimes), stride=1024
 
 	// Games don't always set any of these.  Take the greatest parameter that looks valid based on stride.
-	if (viewport_width <= fb_stride) {
+	if (viewport_width > 4 && viewport_width <= fb_stride) {
 		drawing_width = viewport_width;
 		drawing_height = viewport_height;
 		// Sometimes region is set larger than the VRAM for the framebuffer.
 		if (region_width <= fb_stride && region_width > drawing_width) {
 			drawing_width = region_width;
-			drawing_height = region_height;
+			drawing_height = std::max(drawing_height, region_height);
 		}
 		// Scissor is often set to a subsection of the framebuffer, so we pay the least attention to it.
 		if (scissor_width <= fb_stride && scissor_width > drawing_width) {
 			drawing_width = scissor_width;
-			drawing_height = scissor_height;
+			drawing_height = std::max(drawing_height, scissor_height);
 		}
 	} else {
 		// If viewport wasn't valid, let's just take the greatest anything regardless of stride.

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -621,7 +621,7 @@ VirtualFramebuffer *FramebufferManager::GetVFBAt(u32 addr) {
 	VirtualFramebuffer *match = NULL;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, addr) && v->format == displayFormat_ && v->width >= 480) {
+		if (MaskedEqual(v->fb_address, addr)) {
 			// Could check w too but whatever
 			if (match == NULL || match->last_frame_render < v->last_frame_render) {
 				match = v;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -638,15 +638,13 @@ VirtualFramebuffer *FramebufferManager::GetVFBAt(u32 addr) {
 
 // Heuristics to figure out the size of FBO to create.
 void FramebufferManager::EstimateDrawingSize(int &drawing_width, int &drawing_height) {
-	const int default_width = 480;
-	const int default_height = 272;
 	const int viewport_width = (int) gstate.getViewportX1();
 	const int viewport_height = (int) gstate.getViewportY1();
 	const int region_width = gstate.getRegionX2() + 1;
 	const int region_height = gstate.getRegionY2() + 1;
 	const int scissor_width = gstate.getScissorX2() + 1;
 	const int scissor_height = gstate.getScissorY2() + 1;
-	const int fb_stride = gstate.FrameBufStride();
+	const int fb_stride = std::max(gstate.FrameBufStride(), 4);
 
 	DEBUG_LOG(SCEGE,"viewport : %ix%i, region : %ix%i , scissor: %ix%i, stride: %i, %i", viewport_width,viewport_height, region_width, region_height, scissor_width, scissor_height, fb_stride, gstate.isModeThrough());
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -677,7 +677,13 @@ void FramebufferManager::EstimateDrawingSize(int &drawing_width, int &drawing_he
 	}
 
 	// Assume no buffer is > 512 tall, it couldn't be textured or displayed fully if so.
-	drawing_height = std::min(drawing_height, 512);
+	if (drawing_height > 512) {
+		if (region_height < 512) {
+			drawing_height = region_height;
+		} else if (scissor_height < 512) {
+			drawing_height = scissor_height;
+		}
+	}
 
 	if (viewport_width != region_width) {
 		// The majority of the time, these are equal.  If not, let's check what we know.

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -879,6 +879,12 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 			vfb->fbo = fbo_create(vfb->renderWidth, vfb->renderHeight, 1, true, vfb->colorDepth);
 			if (vfb->fbo) {
 				fbo_bind_as_render_target(vfb->fbo);
+
+				if (destroyVfb) {
+					// Copy over the contents of the framebuffer we're replacing.
+					BlitFramebuffer_(vfb, 0, 0, destroyVfb, 0, 0, vfb->width, vfb->height, 0);
+					fbo_bind_as_render_target(vfb->fbo);
+				}
 			} else {
 				ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", vfb->renderWidth, vfb->renderHeight);
 			}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -655,6 +655,11 @@ void FramebufferManager::EstimateDrawingSize(int &drawing_width, int &drawing_he
 	if (viewport_width > 4 && viewport_width <= fb_stride) {
 		drawing_width = viewport_width;
 		drawing_height = viewport_height;
+		// Some games specify a viewport with 0.5, but don't have VRAM for 273.  480x272 is the buffer size.
+		if (viewport_width == 481 && region_width == 480 && viewport_height == 273 && region_height == 272) {
+			drawing_width = 480;
+			drawing_height = 272;
+		}
 		// Sometimes region is set larger than the VRAM for the framebuffer.
 		if (region_width <= fb_stride && region_width > drawing_width) {
 			drawing_width = region_width;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -752,15 +752,11 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 	gstate_c.framebufChanged = false;
 
 	// Get parameters
-	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.FrameBufStride();
+	const u32 fb_address = gstate.getFrameBufRawAddress();
+	const int fb_stride = gstate.FrameBufStride();
 
-	u32 z_address = gstate.getDepthBufRawAddress();
-	int z_stride = gstate.DepthBufStride();
-
-	// Yeah this is not completely right. but it'll do for now.
-	//int drawing_width = ((gstate.region2) & 0x3FF) + 1;
-	//int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
+	const u32 z_address = gstate.getDepthBufRawAddress();
+	const int z_stride = gstate.DepthBufStride();
 
 	GEBufferFormat fmt = gstate.FrameBufFormat();
 
@@ -768,9 +764,6 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 	// we need to infer the size of the current framebuffer somehow.
 	int drawing_width, drawing_height;
 	EstimateDrawingSize(drawing_width, drawing_height);
-
-	int buffer_width = drawing_width;
-	int buffer_height = drawing_height;
 
 	// Find a matching framebuffer
 	VirtualFramebuffer *vfb = 0;
@@ -845,8 +838,8 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		vfb->lastFrameNewSize = gpuStats.numFlips;
 		vfb->renderWidth = (u16)(drawing_width * renderWidthFactor);
 		vfb->renderHeight = (u16)(drawing_height * renderHeightFactor);
-		vfb->bufferWidth = buffer_width;
-		vfb->bufferHeight = buffer_height;
+		vfb->bufferWidth = drawing_width;
+		vfb->bufferHeight = drawing_height;
 		vfb->format = fmt;
 		vfb->usageFlags = FB_USAGE_RENDERTARGET;
 		vfb->dirtyAfterDisplay = true;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -186,6 +186,8 @@ public:
 	int GetRenderHeight() const { return currentRenderVfb_ ? currentRenderVfb_->renderHeight : 272; }
 	int GetTargetWidth() const { return currentRenderVfb_ ? currentRenderVfb_->width : 480; }
 	int GetTargetHeight() const { return currentRenderVfb_ ? currentRenderVfb_->height : 272; }
+	int GetTargetBufferWidth() const { return currentRenderVfb_ ? currentRenderVfb_->bufferWidth : 480; }
+	int GetTargetBufferHeight() const { return currentRenderVfb_ ? currentRenderVfb_->bufferHeight : 272; }
 
 	u32 PrevDisplayFramebufAddr() {
 		return prevDisplayFramebuf_ ? (0x04000000 | prevDisplayFramebuf_->fb_address) : 0;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -233,6 +233,7 @@ private:
 
 	void SetNumExtraFBOs(int num);
 
+	void EstimateDrawingSize(int &drawing_width, int &drawing_height);
 	static void DisableState();
 	static void ClearBuffer();
 	static bool MaskedEqual(u32 addr1, u32 addr2);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -461,6 +461,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		}
 	}
 
+	bool throughmode = gstate.isModeThrough();
+
 	float renderWidthFactor, renderHeightFactor;
 	float renderWidth, renderHeight;
 	float renderX, renderY;
@@ -470,8 +472,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		renderY = 0.0f;
 		renderWidth = framebufferManager_->GetRenderWidth();
 		renderHeight = framebufferManager_->GetRenderHeight();
-		renderWidthFactor = (float)renderWidth / framebufferManager_->GetTargetWidth();
-		renderHeightFactor = (float)renderHeight / framebufferManager_->GetTargetHeight();
+		renderWidthFactor = (float)renderWidth / framebufferManager_->GetTargetBufferWidth();
+		renderHeightFactor = (float)renderHeight / framebufferManager_->GetTargetBufferHeight();
 	} else {
 		// TODO: Aspect-ratio aware and centered
 		float pixelW = PSP_CoreParameter().pixelWidth;
@@ -480,8 +482,6 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		renderWidthFactor = renderWidth / 480.0f;
 		renderHeightFactor = renderHeight / 272.0f;
 	}
-
-	bool throughmode = gstate.isModeThrough();
 
 	// Scissor
 	int scissorX1 = gstate.getScissorX1();
@@ -518,6 +518,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 	float offsetY = gstate.getOffsetY();
 
 	if (throughmode) {
+		// If the buffer is too large, offset the viewport to the top.
+		renderY += renderHeight - framebufferManager_->GetTargetHeight() * renderHeightFactor;
+
 		// No viewport transform here. Let's experiment with using region.
 		glstate.viewport.set(
 			renderX + (0 + regionX1) * renderWidthFactor, 

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -88,7 +88,7 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 
 	shaderManager_->DirtyLastShader();
 
-	MakePixelTexture(Memory::GetPointer(addr), dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height);
+	MakePixelTexture(Memory::GetPointer(addr), dstBuffer->format, dstBuffer->fb_stride, dstBuffer->renderWidth, dstBuffer->renderHeight);
 	DisableState();
 	glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
 	glstate.stencilTest.enable();
@@ -136,7 +136,7 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 			glStencilMask(i);
 			glUniform1f(u_stencilValue, i * (1.0f / 255.0f));
 		}
-		DrawActiveTexture(0, 0, 0, dstBuffer->width, dstBuffer->height, dstBuffer->width, dstBuffer->height, false, 0.0f, 0.0f, 1.0f, 1.0f, stencilUploadProgram_);
+		DrawActiveTexture(0, 0, 0, dstBuffer->width, dstBuffer->height, dstBuffer->bufferWidth, dstBuffer->bufferHeight, false, 0.0f, 0.0f, 1.0f, 1.0f, stencilUploadProgram_);
 	}
 	glStencilMask(0xFF);
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -959,8 +959,8 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 		entry->framebuffer->last_frame_used = gpuStats.numFlips;
 
 		// We need to force it, since we may have set it on a texture before attaching.
-		gstate_c.curTextureWidth = entry->framebuffer->width;
-		gstate_c.curTextureHeight = entry->framebuffer->height;
+		gstate_c.curTextureWidth = entry->framebuffer->bufferWidth;
+		gstate_c.curTextureHeight = entry->framebuffer->bufferHeight;
 		gstate_c.flipTexture = true;
 		gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
 		gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;


### PR DESCRIPTION
This needs testing, and probably there are things that don't work.  I tried to expand the logic that guesses at the size of a framebuffer to cover the cases I could see.

This fixes the broken games in #6093 for me.  It does make the Valkyrie Profile video correct as well, but I'm not sure if there's still an issue there since videos maybe ought to "prompt" the resizing code... this can mean framebuffers remain a bit larger, though, hmm.

@solarmystic, if you could test some games with this it'd be a real help.

-[Unknown]
