### PR TITLE
Win32: Use CALLBACK (__stdcall) for DinputDevice::DevicesCallback.

### DIFF
--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -97,7 +97,7 @@ LPDIRECTINPUT8 DinputDevice::getPDI()
 	return pDI;
 }
 
-BOOL DinputDevice::DevicesCallback(
+BOOL CALLBACK DinputDevice::DevicesCallback(
 	LPCDIDEVICEINSTANCE lpddi,
 	LPVOID pvRef
 	)

--- a/Windows/DinputDevice.h
+++ b/Windows/DinputDevice.h
@@ -43,7 +43,7 @@ private:
 	//also, it excludes the devices that are compatible with XInput
 	static void getDevices();
 	//callback for the WinAPI to call
-	static BOOL DevicesCallback(
+	static BOOL CALLBACK DevicesCallback(
 	                LPCDIDEVICEINSTANCE lpddi,
 	                LPVOID pvRef
 	            );


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/6216.
