### PR TITLE
Add option for less timing lag (spin on Windows)

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -265,6 +265,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("HomebrewStore", &g_Config.bHomebrewStore, false, false),
 	ConfigSetting("CheckForNewVersion", &g_Config.bCheckForNewVersion, true),
 	ConfigSetting("Language", &g_Config.sLanguageIni, &DefaultLangRegion),
+	ConfigSetting("ForceLagSync", &g_Config.bForceLagSync, false),
 
 	ReportedConfigSetting("NumWorkerThreads", &g_Config.iNumWorkerThreads, &DefaultNumWorkers),
 	ConfigSetting("EnableAutoLoad", &g_Config.bEnableAutoLoad, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -83,6 +83,7 @@ public:
 	bool bFastMemory;
 	bool bJit;
 	bool bCheckForNewVersion;
+	bool bForceLagSync;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -24,16 +24,6 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/time.h>
-#else
-#define NOMINMAX
-#include <winsock2.h>
-
-static inline int usleep(long us) {
-	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = us;
-	return select(0, NULL, NULL, NULL, &tv);
-}
 #endif
 
 // TODO: Move the relevant parts into common. Don't want the core
@@ -706,7 +696,9 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 	time_update();
 	while (time_now_d() < goal) {
 		const double left = goal - time_now_d();
+#ifndef _WIN32
 		usleep((long)(left * 1000000));
+#endif
 		time_update();
 	}
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -20,6 +20,22 @@
 #include <cmath>
 #include <algorithm>
 
+// TODO: Move this somewhere else, cleanup.
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/time.h>
+#else
+#define NOMINMAX
+#include <winsock2.h>
+
+static inline int usleep(long us) {
+	struct timeval tv;
+	tv.tv_sec = 0;
+	tv.tv_usec = us;
+	return select(0, NULL, NULL, NULL, &tv);
+}
+#endif
+
 // TODO: Move the relevant parts into common. Don't want the core
 // to be dependent on "native", I think. Or maybe should get rid of common
 // and move everything into native...
@@ -79,6 +95,10 @@ static bool framebufIsLatched;
 static int enterVblankEvent = -1;
 static int leaveVblankEvent = -1;
 static int afterFlipEvent = -1;
+static int lagSyncEvent = -1;
+
+static double lastLagSync = 0.0;
+static bool lagSyncScheduled = false;
 
 // hCount is computed now.
 static int vCount;
@@ -140,11 +160,20 @@ static int lastFlipsTooFrequent = 0;
 void hleEnterVblank(u64 userdata, int cyclesLate);
 void hleLeaveVblank(u64 userdata, int cyclesLate);
 void hleAfterFlip(u64 userdata, int cyclesLate);
+void hleLagSync(u64 userdata, int cyclesLate);
 
 void __DisplayVblankBeginCallback(SceUID threadID, SceUID prevCallbackId);
 void __DisplayVblankEndCallback(SceUID threadID, SceUID prevCallbackId);
 int __DisplayGetFlipCount() { return actualFlips; }
 int __DisplayGetVCount() { return vCount; }
+
+static void ScheduleLagSync() {
+	lagSyncScheduled = g_Config.bForceLagSync;
+	if (lagSyncScheduled) {
+		CoreTiming::ScheduleEvent(msToCycles(1), lagSyncEvent, 0);
+		lastLagSync = real_time_now();
+	}
+}
 
 void __DisplayInit() {
 	gpuStats.Reset();
@@ -168,6 +197,9 @@ void __DisplayInit() {
 	leaveVblankEvent = CoreTiming::RegisterEvent("LeaveVBlank", &hleLeaveVblank);
 	afterFlipEvent = CoreTiming::RegisterEvent("AfterFlip", &hleAfterFlip);
 
+	lagSyncEvent = CoreTiming::RegisterEvent("LagSync", &hleLagSync);
+	ScheduleLagSync();
+
 	CoreTiming::ScheduleEvent(msToCycles(frameMs - vblankMs), enterVblankEvent, 0);
 	isVblank = 0;
 	vCount = 0;
@@ -189,7 +221,7 @@ void __DisplayInit() {
 }
 
 void __DisplayDoState(PointerWrap &p) {
-	auto s = p.Section("sceDisplay", 1, 4);
+	auto s = p.Section("sceDisplay", 1, 5);
 	if (!s)
 		return;
 
@@ -225,6 +257,19 @@ void __DisplayDoState(PointerWrap &p) {
 	CoreTiming::RestoreRegisterEvent(leaveVblankEvent, "LeaveVBlank", &hleLeaveVblank);
 	p.Do(afterFlipEvent);
 	CoreTiming::RestoreRegisterEvent(afterFlipEvent, "AfterFlip", &hleAfterFlip);
+
+	if (s >= 5) {
+		p.Do(lagSyncEvent);
+		p.Do(lagSyncScheduled);
+		CoreTiming::RestoreRegisterEvent(lagSyncEvent, "LagSync", &hleLagSync);
+		lastLagSync = real_time_now();
+		if (lagSyncScheduled != g_Config.bForceLagSync) {
+			ScheduleLagSync();
+		}
+	} else {
+		lagSyncEvent = CoreTiming::RegisterEvent("LagSync", &hleLagSync);
+		ScheduleLagSync();
+	}
 
 	p.Do(gstate);
 	gstate_c.DoState(p);
@@ -621,6 +666,11 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 void hleAfterFlip(u64 userdata, int cyclesLate)
 {
 	gpu->BeginFrame();  // doesn't really matter if begin or end of frame.
+
+	// This seems like as good a time as any to check if the config changed.
+	if (lagSyncScheduled != g_Config.bForceLagSync) {
+		ScheduleLagSync();
+	}
 }
 
 void hleLeaveVblank(u64 userdata, int cyclesLate) {
@@ -630,6 +680,38 @@ void hleLeaveVblank(u64 userdata, int cyclesLate) {
 
 	// Fire the vblank listeners after the vblank completes.
 	__DisplayFireVblank();
+}
+
+void hleLagSync(u64 userdata, int cyclesLate) {
+	// The goal here is to prevent network, audio, and input lag from the real world.
+	// Our normal timing is very "stop and go".  This is efficient, but causes real world lag.
+	// This event (optionally) runs every 1ms to sync with the real world.
+
+	if (PSP_CoreParameter().unthrottle) {
+		lagSyncScheduled = false;
+		return;
+	}
+
+	float scale = 1.0f;
+	if (PSP_CoreParameter().fpsLimit == FPS_LIMIT_CUSTOM) {
+		if (g_Config.iFpsLimit == 0) {
+			lagSyncScheduled = false;
+			return;
+		}
+
+		scale = g_Config.iFpsLimit / 60.0f;
+	}
+
+	// TODO: Smarter, adaptive?  Account for cyclesLate?  Let's just try this for now.
+	const double goal = lastLagSync + (scale / 1000.0f);
+	time_update();
+	while (time_now_d() < goal) {
+		const double left = goal - time_now_d();
+		usleep((long)(left * 1000000));
+		time_update();
+	}
+
+	ScheduleLagSync();
 }
 
 u32 sceDisplayIsVblank() {

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -699,7 +699,7 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 			return;
 		}
 
-		scale = g_Config.iFpsLimit / 60.0f;
+		scale = 60.0f / g_Config.iFpsLimit;
 	}
 
 	const double goal = lastLagSync + (scale / 1000.0f);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -304,6 +304,7 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateCPUThread, s->T("Multithreaded (experimental)")))->SetEnabled(!PSP_IsInited());
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateIOThread, s->T("I/O on thread (experimental)")))->SetEnabled(!PSP_IsInited());
+	systemSettings->Add(new CheckBox(&g_Config.bForceLagSync, s->T("Force real clock sync (slower, less lag)")));
 	systemSettings->Add(new PopupSliderChoice(&g_Config.iLockedCPUSpeed, 0, 1000, s->T("Change CPU Clock", "Change CPU Clock (0 = default) (unstable)"), screenManager()));
 #ifndef MOBILE_DEVICE
 	systemSettings->Add(new PopupSliderChoice(&g_Config.iRewindFlipFrequency, 0, 1800, s->T("Rewind Snapshot Frequency", "Rewind Snapshot Frequency (0 = off, mem hog)"), screenManager()));


### PR DESCRIPTION
This adds an option to use alternate timing, which syncs up the game clock every 1ms when not fast forwarding.  This reduces potential input, network, and audio lag when the cpu is able to complete faster than realtime (common especially on PCs.)

However, it's slower, especially with multithreading off.  Which is why I'm leaving it as an option.  I haven't really tested it on Android.

Adds the following string (not sure if this is the best description...):
Force real clock sync (slower, less lag)

A more thorough description here:
https://github.com/hrydgard/ppsspp/issues/4020#issuecomment-44773145

At least in one game, there's been confirmation this improves input lag.

Outside this feature, this also makes non-Windows platforms use slightly more accurate frame timing (sub millisecond) where possible.

-[Unknown]
