### PR TITLE
When rendering a framebuffer using clut, check alpha

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -950,9 +950,15 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 			fbo_bind_color_as_texture(depalFBO, 0);
 			glstate.Restore();
 			framebufferManager_->RebindFramebuffer();
+
+			gstate_c.textureFullAlpha = false;
+			gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
 		} else {
 			entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
 			framebufferManager_->BindFramebufferColor(entry->framebuffer);
+
+			gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
+			gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
 		}
 
 		// Keep the framebuffer alive.
@@ -962,8 +968,6 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 		gstate_c.curTextureWidth = entry->framebuffer->width;
 		gstate_c.curTextureHeight = entry->framebuffer->height;
 		gstate_c.flipTexture = true;
-		gstate_c.textureFullAlpha = entry->framebuffer->format == GE_FORMAT_565;
-		gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
 		UpdateSamplingParams(*entry, true);
 	} else {
 		if (entry->framebuffer->fbo)

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -951,8 +951,14 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry) {
 			glstate.Restore();
 			framebufferManager_->RebindFramebuffer();
 
-			gstate_c.textureFullAlpha = false;
-			gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
+			const GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
+			const u32 clutBase = gstate.getClutIndexStartPos();
+			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
+			const u32 clutExtendedColors = (clutTotalBytes_ / bytesPerColor) + clutBase;
+
+			TexCacheEntry::Status alphaStatus = CheckAlpha(clutBuf_, getClutDestFormat(gstate.getClutPaletteFormat()), clutExtendedColors, clutExtendedColors, 1);
+			gstate_c.textureFullAlpha = alphaStatus == TexCacheEntry::STATUS_ALPHA_FULL;
+			gstate_c.textureSimpleAlpha = alphaStatus == TexCacheEntry::STATUS_ALPHA_SIMPLE;
 		} else {
 			entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
 			framebufferManager_->BindFramebufferColor(entry->framebuffer);

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -154,6 +154,14 @@ public:
 		void SetAlphaStatus(Status newStatus) {
 			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
 		}
+		void SetAlphaStatus(Status newStatus, int level) {
+			// For non-level zero, only set more restrictive.
+			if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
+				SetAlphaStatus(newStatus);
+			} else if (newStatus == STATUS_ALPHA_SIMPLE && GetAlphaStatus() == STATUS_ALPHA_FULL) {
+				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
+			}
+		}
 		bool Matches(u16 dim2, u8 format2, int maxLevel2);
 	};
 
@@ -165,7 +173,7 @@ private:
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, int scaleFactor, GLenum dstFmt);
 	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, GLenum dstFmt, int *bufw = 0);
-	void CheckAlpha(TexCacheEntry &entry, u32 *pixelData, GLenum dstFmt, int stride, int w, int h, bool isPrimary);
+	TexCacheEntry::Status CheckAlpha(u32 *pixelData, GLenum dstFmt, int stride, int w, int h);
 	template <typename T>
 	const T *GetCurrentClut();
 	u32 GetCurrentClutHash();


### PR DESCRIPTION
This wouldn't incorrectly skipped alpha if it was a 5650 framebuffer but the clut was not 5650.  Still not the fix for #6162...

-[Unknown]
