### PR TITLE
Use OpenCPPFile for iostream open

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -97,6 +97,17 @@ FILE *OpenCFile(const std::string &filename, const char *mode)
 #endif
 }
 
+bool OpenCPPFile(std::fstream & stream, const std::string &filename, std::ios::openmode mode)
+{
+#if defined(_WIN32) && defined(UNICODE)
+	stream.open(ConvertUTF8ToWString(filename), mode);
+#else
+	stream.open(filename.c_str(), mode);
+#endif
+	return stream.is_open();
+}
+
+
 // Remove any ending forward slashes from directory paths
 // Modifies argument.
 static void StripTailDirSlashes(std::string &fname)

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -49,6 +49,7 @@ struct FSTEntry
 
 // Mostly to handle utf-8 filenames better on Windows.
 FILE *OpenCFile(const std::string &filename, const char *mode);
+bool OpenCPPFile(std::fstream & stream, const std::string &filename, std::ios::openmode mode);
 
 // Returns true if file filename exists
 bool Exists(const std::string &filename);

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -15,9 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <string>
 #include <deque>
-#include <fstream>
+#include "Common/FileUtil.h"
 
 #include "base/functional.h"
 #include "ui/view.h"
@@ -35,8 +34,6 @@ class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
 	CwCheatScreen() {}
 	void CreateCodeList();
-	std::ifstream is;
-	std::ofstream os;
 	void processFileOn(std::string activatedCheat);
 	void processFileOff(std::string deactivatedCheat);
 	const char * name;


### PR DESCRIPTION
Keeps the code consistent with OpenCFile and allows us to avoid the #ifdef mess. Also pick up on some areas it was missing from CwCheatScreen.
