### PR TITLE
Try to workaround Breath of Fire 3's render-to-tex

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -188,6 +188,8 @@ public:
 	int GetTargetHeight() const { return currentRenderVfb_ ? currentRenderVfb_->height : 272; }
 	int GetTargetBufferWidth() const { return currentRenderVfb_ ? currentRenderVfb_->bufferWidth : 480; }
 	int GetTargetBufferHeight() const { return currentRenderVfb_ ? currentRenderVfb_->bufferHeight : 272; }
+	int GetTargetStride() const { return currentRenderVfb_ ? currentRenderVfb_->fb_stride : 512; }
+	GEBufferFormat GetTargetFormat() const { return currentRenderVfb_ ? currentRenderVfb_->format : displayFormat_; }
 
 	u32 PrevDisplayFramebufAddr() {
 		return prevDisplayFramebuf_ ? (0x04000000 | prevDisplayFramebuf_->fb_address) : 0;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -57,6 +57,7 @@ public:
 	~TextureCache();
 
 	void SetTexture(bool force = false);
+	bool SetOffsetTexture(u32 offset);
 
 	void Clear(bool delete_them);
 	void StartFrame();
@@ -180,7 +181,7 @@ private:
 	void UpdateCurrentClut();
 	void AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, bool exactMatch);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
-	void SetTextureFramebuffer(TexCacheEntry *entry);
+	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 


### PR DESCRIPTION
It renders to two areas but textures with a high V to reach the second texture/render surface.  We've been wrapping the V around but this shows the right buffer.

Fixes #2759.

-[Unknown]
