### PR TITLE
Enable function replacements by default

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -305,6 +305,7 @@ static ConfigSetting cpuSettings[] = {
 
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true),
+	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0),
 
 	ConfigSetting(false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -84,6 +84,7 @@ public:
 	bool bJit;
 	bool bCheckForNewVersion;
 	bool bForceLagSync;
+	bool bFuncReplacements;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -447,7 +447,7 @@ void __KernelModuleDoState(PointerWrap &p)
 		p.Do(loadedModules);
 	}
 
-	if (g_Config.bFuncHashMap) {
+	if (g_Config.bFuncReplacements) {
 		MIPSAnalyst::ReplaceFunctions();
 	}
 }
@@ -973,7 +973,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			bool gotSymbols = reader.LoadSymbols();
 			MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 #else
-			if (g_Config.bFuncHashMap) {
+			if (g_Config.bFuncReplacements) {
 				bool gotSymbols = reader.LoadSymbols();
 				MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 			}
@@ -1137,7 +1137,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			bool gotSymbols = reader.LoadSymbols();
 			MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 #else
-			if (g_Config.bFuncHashMap) {
+			if (g_Config.bFuncReplacements) {
 				bool gotSymbols = reader.LoadSymbols();
 				MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
 			}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -886,13 +886,16 @@ skip:
 		HashFunctions();
 
 		std::string hashMapFilename = GetSysDirectory(DIRECTORY_SYSTEM) + "knownfuncs.ini";
-		if (g_Config.bFuncHashMap) {
-			LoadHashMap(hashMapFilename);
-			StoreHashMap(hashMapFilename);
+		if (g_Config.bFuncHashMap || g_Config.bFuncReplacements) {
+			LoadBuiltinHashMap();
+			if (g_Config.bFuncHashMap) {
+				LoadHashMap(hashMapFilename);
+				StoreHashMap(hashMapFilename);
+			}
 			if (insertSymbols) {
 				ApplyHashMap();
 			}
-			if (g_Config.bFuncHashMap) {
+			if (g_Config.bFuncReplacements) {
 				ReplaceFunctions();
 			}
 		}
@@ -1052,8 +1055,7 @@ skip:
 		}
 	}
 
-	void LoadHashMap(std::string filename) {
-		// First insert the hardcoded entries.
+	void LoadBuiltinHashMap() {
 		HashMapFunc mf;
 		for (size_t i = 0; i < ARRAY_SIZE(hardcodedHashes); i++) {
 			mf.hash = hardcodedHashes[i].hash;
@@ -1063,7 +1065,9 @@ skip:
 			mf.hardcoded = true;
 			hashMap.insert(mf);
 		}
+	}
 
+	void LoadHashMap(std::string filename) {
 		FILE *file = File::OpenCFile(filename, "rt");
 		if (!file) {
 			WARN_LOG(LOADER, "Could not load hash map: %s", filename.c_str());

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -107,6 +107,7 @@ namespace MIPSAnalyst
 	void CompileLeafs();
 
 	void SetHashMapFilename(std::string filename = "");
+	void LoadBuiltinHashMap();
 	void LoadHashMap(std::string filename);
 	void StoreHashMap(std::string filename = "");
 

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -88,7 +88,7 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 
 	shaderManager_->DirtyLastShader();
 
-	MakePixelTexture(Memory::GetPointer(addr), dstBuffer->format, dstBuffer->fb_stride, dstBuffer->renderWidth, dstBuffer->renderHeight);
+	MakePixelTexture(Memory::GetPointer(addr), dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight);
 	DisableState();
 	glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
 	glstate.stencilTest.enable();


### PR DESCRIPTION
For some reason, I thought they were already enabled by default.

This makes it so people actually get some of the fixes and improvements from "simulate block transfers", small speedups, etc.  It may make mobile startup a bit slower.

Left it as an option in case there are bugs.

-[Unknown]
