### PR TITLE
Fix Replace_memcpy crash

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -110,7 +110,7 @@ static int Replace_memcpy() {
 	if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
 		skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 	}
-	if (!skip && bytes != 0) {
+	if (!skip && bytes != 0 && destPtr != 0) {
 		u8 *dst = Memory::GetPointerUnchecked(destPtr);
 		const u8 *src = Memory::GetPointerUnchecked(srcPtr);
 


### PR DESCRIPTION
Fix Replace_memcpy crash in #5496
if do not use Replace_memcpy,the game still have problem
![1](https://cloud.githubusercontent.com/assets/2177532/3209287/87485fba-ee65-11e3-9762-a1249d60e864.png)
