### PR TITLE
Apply tex wrap/clamp in shader for render-to-tex

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -185,6 +185,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	u_matspecular = glGetUniformLocation(program, "u_matspecular");
 	u_matemissive = glGetUniformLocation(program, "u_matemissive");
 	u_uvscaleoffset = glGetUniformLocation(program, "u_uvscaleoffset");
+	u_texclamp = glGetUniformLocation(program, "u_texclamp");
 
 	for (int i = 0; i < 4; i++) {
 		char temp[64];
@@ -225,6 +226,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	if (u_fogcoef != -1) availableUniforms |= DIRTY_FOGCOEF;
 	if (u_texenv != -1) availableUniforms |= DIRTY_TEXENV;
 	if (u_uvscaleoffset != -1) availableUniforms |= DIRTY_UVSCALEOFFSET;
+	if (u_texclamp != -1) availableUniforms |= DIRTY_TEXCLAMP;
 	if (u_world != -1) availableUniforms |= DIRTY_WORLDMATRIX;
 	if (u_view != -1) availableUniforms |= DIRTY_VIEWMATRIX;
 	if (u_texmtx != -1) availableUniforms |= DIRTY_TEXMATRIX;
@@ -475,6 +477,21 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 			ERROR_LOG_REPORT(G3D, "Unexpected UV gen mode: %d", gstate.getUVGenMode());
 		}
 		glUniform4fv(u_uvscaleoffset, 1, uvscaleoff);
+	}
+
+	if (dirty & DIRTY_TEXCLAMP) {
+		const float invW = 1.0f / (float)gstate_c.curTextureWidth;
+		const float invH = 1.0f / (float)gstate_c.curTextureHeight;
+		const int w = gstate.getTextureWidth(0);
+		const int h = gstate.getTextureHeight(0);
+		const float widthFactor = (float)w * invW;
+		const float heightFactor = (float)h * invH;
+
+		const float texclamp[2] = {
+			widthFactor,
+			heightFactor,
+		};
+		glUniform2fv(u_texclamp, 1, texclamp);
 	}
 
 	// Transform

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -86,6 +86,7 @@ public:
 
 	// Texturing
 	int u_uvscaleoffset;
+	int u_texclamp;
 
 	// Lighting
 	int u_ambient;
@@ -131,6 +132,7 @@ enum
 	DIRTY_BLENDFIX = (1 << 17),  // (either one.)
 
 	DIRTY_UVSCALEOFFSET = (1 << 18),  // this will be dirtied ALL THE TIME... maybe we'll need to do "last value with this shader compares"
+	DIRTY_TEXCLAMP = (1 << 19),
 
 	DIRTY_WORLDMATRIX = (1 << 21),
 	DIRTY_VIEWMATRIX = (1 << 22),  // Maybe we'll fold this into projmatrix eventually

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -169,6 +169,14 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
 		textureCache_->SetTexture();
 		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
+		if (gstate_c.needShaderTexClamp) {
+			// We will rarely need to set this, so let's do it every time on use rather than in runloop.
+			// Most of the time non-framebuffer textures will be used which can be clamped themselves.
+			shaderManager_->DirtyUniform(DIRTY_TEXCLAMP);
+		}
+	} else {
+		// Let's not leave this set.
+		gstate_c.needShaderTexClamp = false;
 	}
 
 	// Set blend - unless we need to do it in the shader.

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -302,6 +302,8 @@ void GPUStateCache::DoState(PointerWrap &p) {
 		p.Do(flipTexture);
 	}
 
+	// needShaderTexClamp doesn't need to be saved.
+
 	if (s >= 3) {
 		p.Do(textureSimpleAlpha);
 	} else {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -458,6 +458,7 @@ struct GPUStateCache
 
 	UVScale uv;
 	bool flipTexture;
+	bool needShaderTexClamp;
 
 	float morphWeights[8];
 


### PR DESCRIPTION
Fixes graphical artifacts in Wild Arms XF (which depends on how you get there, because it's based on the size of the framebuffer.)

I'm not really sure how to do projection... but I wonder if it's related to some of our shadow bugs.  Is it x/z, y/z?  That seems to help some artifacts but of course doesn't fix the offsetting.

-[Unknown]
