### PR TITLE
Allocate tex and buffer names in chunks

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -384,7 +384,7 @@ void FramebufferManager::MakePixelTexture(const u8 *srcPixels, GEBufferFormat sr
 	}
 
 	if (!drawPixelsTex_) {
-		glGenTextures(1, &drawPixelsTex_);
+		drawPixelsTex_ = textureCache_->AllocTextureName();
 		drawPixelsTexW_ = width;
 		drawPixelsTexH_ = height;
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -89,6 +89,8 @@ public:
 		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
 	}
 
+	u32 AllocTextureName();
+
 	// Only used by Qt UI?
 	bool DecodeTexture(u8 *output, GPUgstate state);
 
@@ -189,6 +191,7 @@ private:
 	TexCache cache;
 	TexCache secondCache;
 	std::vector<VirtualFramebuffer *> fbCache_;
+	std::vector<u32> nameCache_;
 
 	bool clearCacheNextFrame_;
 	bool lowMemoryMode_;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -111,6 +111,7 @@ enum {
 
 #define VERTEXCACHE_DECIMATION_INTERVAL 17
 #define VERTEXCACHE_NAME_CACHE_SIZE 64
+#define VERTEXCACHE_NAME_CACHE_FULL_SIZE 80
 
 enum { VAI_KILL_AGE = 120 };
 
@@ -509,6 +510,13 @@ GLuint TransformDrawEngine::AllocateBuffer() {
 void TransformDrawEngine::FreeBuffer(GLuint buf) {
 	// We can reuse buffers by setting new data on them.
 	bufferNameCache_.push_back(buf);
+
+	// But let's not keep too many around, will eat up memory.
+	if (bufferNameCache_.size() >= VERTEXCACHE_NAME_CACHE_FULL_SIZE) {
+		GLsizei extra = (GLsizei)bufferNameCache_.size() - VERTEXCACHE_NAME_CACHE_SIZE;
+		glDeleteBuffers(extra, &bufferNameCache_[VERTEXCACHE_NAME_CACHE_SIZE]);
+		bufferNameCache_.resize(VERTEXCACHE_NAME_CACHE_SIZE);
+	}
 }
 
 void TransformDrawEngine::DoFlush() {

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -506,6 +506,11 @@ GLuint TransformDrawEngine::AllocateBuffer() {
 	return buf;
 }
 
+void TransformDrawEngine::FreeBuffer(GLuint buf) {
+	// We can reuse buffers by setting new data on them.
+	bufferNameCache_.push_back(buf);
+}
+
 void TransformDrawEngine::DoFlush() {
 	gpuStats.numFlushes++;
 	gpuStats.numTrackedVertexArrays = (int)vai_.size();
@@ -574,11 +579,11 @@ void TransformDrawEngine::DoFlush() {
 						if (newHash != vai->hash) {
 							vai->status = VertexArrayInfo::VAI_UNRELIABLE;
 							if (vai->vbo) {
-								glDeleteBuffers(1, &vai->vbo);
+								FreeBuffer(vai->vbo);
 								vai->vbo = 0;
 							}
 							if (vai->ebo) {
-								glDeleteBuffers(1, &vai->ebo);
+								FreeBuffer(vai->ebo);
 								vai->ebo = 0;
 							}
 							DecodeVerts();

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -176,6 +176,7 @@ private:
 	void ApplyDrawState(int prim);
 	bool IsReallyAClear(int numVerts) const;
 	GLuint AllocateBuffer();
+	void FreeBuffer(GLuint buf);
 
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -175,6 +175,7 @@ private:
 	void SoftwareTransformAndDraw(int prim, u8 *decoded, LinkedShader *program, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex);
 	void ApplyDrawState(int prim);
 	bool IsReallyAClear(int numVerts) const;
+	GLuint AllocateBuffer();
 
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);
@@ -223,10 +224,7 @@ private:
 
 	// Vertex buffer objects
 	// Element buffer objects
-	enum { NUM_VBOS = 128 };
-	GLuint vbo_[NUM_VBOS];
-	GLuint ebo_[NUM_VBOS];
-	int curVbo_;
+	std::vector<GLuint> bufferNameCache_;
 
 	// Other
 	ShaderManager *shaderManager_;


### PR DESCRIPTION
May improve performance on some mobile devices.  Also reuses buffer names to gen less as well.

Doesn't seem to have much impact on desktop, but it does seem to average slightly higher.

-[Unknown]
