### PR TITLE
Correct framebuf clamping, tex projection from framebuf

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -516,7 +516,7 @@ void GenerateFragmentShader(char *buffer) {
 		}
 	}
 	if (gstate_c.needShaderTexClamp) {
-		WRITE(p, "uniform vec2 u_texclamp;");
+		WRITE(p, "uniform vec4 u_texclamp;");
 	}
 
 	if (enableAlphaTest || enableColorTest) {
@@ -592,13 +592,13 @@ void GenerateFragmentShader(char *buffer) {
 				}
 
 				if (gstate.isTexCoordClampedS()) {
-					ucoord = "clamp(" + ucoord + ", 0.0, u_texclamp.x)";
+					ucoord = "clamp(" + ucoord + ", u_texclamp.z, u_texclamp.x - u_texclamp.z)";
 				} else {
 					ucoord = "mod(" + ucoord + ", u_texclamp.x)";
 				}
 				// The v coordinate is more tricky, since it's flipped.
 				if (gstate.isTexCoordClampedT()) {
-					vcoord = "clamp(" + vcoord + ", 0.0, u_texclamp.y)";
+					vcoord = "clamp(" + vcoord + ", u_texclamp.w, u_texclamp.y - u_texclamp.w)";
 				} else {
 					vcoord = "mod(" + vcoord + ", u_texclamp.y)";
 				}

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -487,11 +487,14 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 		const float widthFactor = (float)w * invW;
 		const float heightFactor = (float)h * invH;
 
-		const float texclamp[2] = {
+		// First wrap xy, then half texel xy (for clamp.)
+		const float texclamp[4] = {
 			widthFactor,
 			heightFactor,
+			invW * 0.5f,
+			invH * 0.5f,
 		};
-		glUniform2fv(u_texclamp, 1, texclamp);
+		glUniform4fv(u_texclamp, 1, texclamp);
 	}
 
 	// Transform

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -172,6 +172,8 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 	}
 
 	VertexReader reader(decoded, decVtxFormat, vertType);
+	// We flip in the fragment shader for GE_TEXMAP_TEXTURE_MATRIX.
+	const bool flipV = gstate_c.flipTexture && gstate.getUVGenMode() != GE_TEXMAP_TEXTURE_MATRIX;
 	for (int index = 0; index < maxIndex; index++) {
 		reader.Goto(index);
 
@@ -371,7 +373,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		memcpy(&transformed[index].x, v, 3 * sizeof(float));
 		transformed[index].fog = fogCoef;
 		memcpy(&transformed[index].u, uv, 3 * sizeof(float));
-		if (gstate_c.flipTexture) {
+		if (flipV) {
 			transformed[index].v = 1.0f - transformed[index].v;
 		}
 		transformed[index].color0_32 = c0.ToRGBA();

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -661,7 +661,8 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 				break;
 			}
 
-			if (flipV)
+			// Will flip in the fragment for GE_TEXMAP_TEXTURE_MATRIX.
+			if (flipV && gstate.getUVGenMode() != GE_TEXMAP_TEXTURE_MATRIX)
 				WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y;\n");
 		}
 


### PR DESCRIPTION
Probably flipping the drawing will be better (less work in frag shader), although it means fixing a lot of places - scissor, throughmode, blitting, readpixels, ge debugger, etc.

Anyway, for now, this defers flipping when projecting to the frag shader.  That seems to really help the case of #4421 I know about (at least for me.)

Another issue was the clamping: it was clamping to the edge.  In Kingdom Hearts, for example, the framebuffer is necessarily 128x64, but the part textured from is only 64x64.  Clamping was clamping to texel 64, rather than texel 63, sometimes showing artifacts from the other region of the framebuffer.  Clamping to a half pixel fixes that (hopefully precision will be okay on mobile...)

While testing this, I found that Dragon Ball Z uses individual bits of the writemask, unfortunately.  We could at least try using glStencilMask, but it won't work well.  I wonder if it's worth reporting.  If games use it super conservatively, we could potentially do it in the shader like blending on GLES 3.

-[Unknown]
