### PR TITLE
Apply byte offset when using rendered textures

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -516,6 +516,7 @@ void GenerateFragmentShader(char *buffer) {
 	}
 	if (gstate_c.needShaderTexClamp) {
 		WRITE(p, "uniform vec4 u_texclamp;");
+		WRITE(p, "uniform vec2 u_texclampoff;");
 	}
 
 	if (enableAlphaTest || enableColorTest) {
@@ -604,6 +605,8 @@ void GenerateFragmentShader(char *buffer) {
 				} else {
 					vcoord = "mod(" + vcoord + ", u_texclamp.y)";
 				}
+				ucoord = "(" + ucoord + " + u_texclampoff.x)";
+				vcoord = "(" + vcoord + " + u_texclampoff.y)";
 
 				if (gstate_c.flipTexture) {
 					vcoord = "1.0 - " + vcoord;

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -371,33 +371,43 @@ void ComputeFragmentShaderID(FragmentShaderID *id) {
 			id0 |= gstate.getTextureFunction() << 2;
 			id0 |= (doTextureAlpha & 1) << 5; // rgb or rgba
 			id0 |= (gstate_c.flipTexture & 1) << 6;
+
+			if (gstate_c.needShaderTexClamp) {
+				// 3 bits total.
+				id0 |= 1 << 7;
+				id0 |= gstate.isTexCoordClampedS() << 8;
+				id0 |= gstate.isTexCoordClampedT() << 9;
+			}
 		}
 
-		id0 |= (lmode & 1) << 7;
+		id0 |= (lmode & 1) << 10;
 		if (enableAlphaTest) {
-			id0 |= 1 << 8;
-			id0 |= gstate.getAlphaTestFunction() << 9;
+			id0 |= 1 << 11;
+			id0 |= gstate.getAlphaTestFunction() << 12;
 		}
 		if (enableColorTest) {
-			id0 |= 1 << 12;
-			id0 |= gstate.getColorTestFunction() << 13;	 // color test func
+			id0 |= 1 << 15;
+			id0 |= gstate.getColorTestFunction() << 16;	 // color test func
 		}
-		id0 |= (enableFog & 1) << 15;
-		id0 |= (doTextureProjection & 1) << 16;
-		id0 |= (enableColorDoubling & 1) << 17;
-		id0 |= (enableAlphaDoubling & 1) << 18;
-		id0 |= (stencilToAlpha) << 19;
+		id0 |= (enableFog & 1) << 18;
+		id0 |= (doTextureProjection & 1) << 19;
+		id0 |= (enableColorDoubling & 1) << 20;
+		id0 |= (enableAlphaDoubling & 1) << 21;
+		// 2 bits
+		id0 |= (stencilToAlpha) << 22;
 	
 		if (stencilToAlpha != REPLACE_ALPHA_NO) {
 			// 3 bits
-			id0 |= ReplaceAlphaWithStencilType() << 21;
+			id0 |= ReplaceAlphaWithStencilType() << 24;
 		}
 
-		id0 |= (alphaTestAgainstZero & 1) << 24;
+		id0 |= (alphaTestAgainstZero & 1) << 27;
 		if (enableAlphaTest)
 			gpuStats.numAlphaTestedDraws++;
 		else
 			gpuStats.numNonAlphaTestedDraws++;
+
+		// 28 - 31 are free.
 
 		if (ShouldUseShaderBlending()) {
 			// 12 bits total.
@@ -405,13 +415,6 @@ void ComputeFragmentShaderID(FragmentShaderID *id) {
 			id1 |= gstate.getBlendEq() << 1;
 			id1 |= gstate.getBlendFuncA() << 4;
 			id1 |= gstate.getBlendFuncB() << 8;
-		}
-
-		if (gstate_c.needShaderTexClamp) {
-			// 3 bits total.
-			id1 |= 1 << 12;
-			id1 |= gstate.isTexCoordClampedS() << 13;
-			id1 |= gstate.isTexCoordClampedT() << 14;
 		}
 	}
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -504,7 +504,9 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 			gstate_c.curTextureYOffset * invH,
 		};
 		glUniform4fv(u_texclamp, 1, texclamp);
-		glUniform2fv(u_texclampoff, 1, texclampoff);
+		if (u_texclampoff != -1) {
+			glUniform2fv(u_texclampoff, 1, texclampoff);
+		}
 	}
 
 	// Transform

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -186,6 +186,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	u_matemissive = glGetUniformLocation(program, "u_matemissive");
 	u_uvscaleoffset = glGetUniformLocation(program, "u_uvscaleoffset");
 	u_texclamp = glGetUniformLocation(program, "u_texclamp");
+	u_texclampoff = glGetUniformLocation(program, "u_texclampoff");
 
 	for (int i = 0; i < 4; i++) {
 		char temp[64];
@@ -498,7 +499,12 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 			invW * 0.5f,
 			invH * 0.5f,
 		};
+		const float texclampoff[2] = {
+			gstate_c.curTextureXOffset * invW,
+			gstate_c.curTextureYOffset * invH,
+		};
 		glUniform4fv(u_texclamp, 1, texclamp);
+		glUniform2fv(u_texclampoff, 1, texclampoff);
 	}
 
 	// Transform

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -87,6 +87,7 @@ public:
 	// Texturing
 	int u_uvscaleoffset;
 	int u_texclamp;
+	int u_texclampoff;
 
 	// Lighting
 	int u_ambient;

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -174,9 +174,6 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			// Most of the time non-framebuffer textures will be used which can be clamped themselves.
 			shaderManager_->DirtyUniform(DIRTY_TEXCLAMP);
 		}
-	} else {
-		// Let's not leave this set.
-		gstate_c.needShaderTexClamp = false;
 	}
 
 	// Set blend - unless we need to do it in the shader.

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1017,6 +1017,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 		if (framebuffer->fbo)
 			framebuffer->fbo = 0;
 		glBindTexture(GL_TEXTURE_2D, 0);
+		gstate_c.needShaderTexClamp = false;
 	}
 }
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -169,7 +169,10 @@ public:
 	};
 
 private:
+	typedef std::map<u64, TexCacheEntry> TexCache;
+
 	void Decimate();  // Run this once per frame to get rid of old textures.
+	void DeleteTexture(TexCache::iterator it);
 	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPixel, u32 level);
 	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, GLuint dstFmt, int bufw);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
@@ -187,11 +190,17 @@ private:
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
-	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
 	TexCache secondCache;
 	std::vector<VirtualFramebuffer *> fbCache_;
 	std::vector<u32> nameCache_;
+
+	// Separate to keep main texture cache size down.
+	struct AttachedFramebufferInfo {
+		u32 xOffset;
+		u32 yOffset;
+	};
+	std::map<u32, AttachedFramebufferInfo> fbTexInfo_;
 
 	bool clearCacheNextFrame_;
 	bool lowMemoryMode_;

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -328,6 +328,7 @@ void GPUStateCache::DoState(PointerWrap &p) {
 	p.Do(curTextureWidth);
 	p.Do(curTextureHeight);
 	p.Do(actualTextureHeight);
+	// curTextureXOffset and curTextureYOffset don't need to be saved.  Well, the above don't either...
 
 	p.Do(vpWidth);
 	p.Do(vpHeight);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -465,6 +465,9 @@ struct GPUStateCache
 	u32 curTextureWidth;
 	u32 curTextureHeight;
 	u32 actualTextureHeight;
+	// Only applied when needShaderTexClamp = true.
+	u32 curTextureXOffset;
+	u32 curTextureYOffset;
 
 	float vpWidth;
 	float vpHeight;


### PR DESCRIPTION
Fixes Valkyrie Profile intros now that wrapping is being done.  It uses a UV like 1.0, 2.0, 3.0 with a width of 64 on a texture that's much wider.  It worked before just because the UV was "correct" anyway when scaled.

Might help other games using offset framebuffer textures without unwrapped UVs.

I hope I'm not making the frag shader too slow...

-[Unknown]
