### PR TITLE
GameSettingsScreen: Disable a bunch of options when software rendering is enabled.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -230,7 +230,9 @@ void GameSettingsScreen::CreateViews() {
 	graphicsSettings->Add(new ItemHeader(gs->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTimerHack, gs->T("Timer Hack")));
 	// Maybe hide this on non-PVR?
-	graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
+	CheckBox *alphaHack = graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
+	alphaHackEnable = !g_Config.bSoftwareRendering;
+	alphaHack->SetEnabledPtr(&alphaHackEnable);
 
 
 	CheckBox *depthWrite = graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
@@ -425,7 +427,6 @@ UI::EventReturn GameSettingsScreen::OnSoftwareRendering(UI::EventParams &e) {
 	swSkinningEnable = !PSP_IsInited() && !g_Config.bSoftwareRendering;
 	hwTransformEnable = !g_Config.bSoftwareRendering;
 	vtxCacheEnable = hwTransformEnable && g_Config.bHardwareTransform;
-
 	texBackoffEnable = !g_Config.bSoftwareRendering;
 	mipmapEnable = !g_Config.bSoftwareRendering;
 	texScalingEnable = !g_Config.bSoftwareRendering;
@@ -435,6 +436,7 @@ UI::EventReturn GameSettingsScreen::OnSoftwareRendering(UI::EventParams &e) {
 	texFilteringEnable = !g_Config.bSoftwareRendering;
 	blockTransferEnable = !g_Config.bSoftwareRendering;
 	renderModeEnable = !g_Config.bSoftwareRendering;
+	alphaHackEnable = !g_Config.bSoftwareRendering;
 	postProcEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	resolutionEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	return UI::EVENT_DONE;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -59,6 +59,7 @@ void GameSettingsScreen::CreateViews() {
 	cap60FPS_ = g_Config.iForceMaxEmulatedFPS == 60;
 
 	iAlternateSpeedPercent_ = (g_Config.iFpsLimit * 100) / 60;
+
 	// Information in the top left.
 	// Back button to the bottom left.
 	// Scrolling action menu to the right.
@@ -116,7 +117,8 @@ void GameSettingsScreen::CreateViews() {
 	graphicsSettings->Add(new ItemHeader(gs->T("Features")));
 	postProcChoice_ = graphicsSettings->Add(new Choice(gs->T("Postprocessing Shader")));
 	postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
-	postProcChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
+	postProcEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+	postProcChoice_->SetEnabledPtr(&postProcEnable);
 
 #if !defined(MOBILE_DEVICE)
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gs->T("FullScreen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
@@ -138,7 +140,9 @@ void GameSettingsScreen::CreateViews() {
 #endif
 	resolutionChoice_ = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iInternalResolution, gs->T("Rendering Resolution"), internalResolutions, 0, ARRAY_SIZE(internalResolutions), gs, screenManager()));
 	resolutionChoice_->OnClick.Handle(this, &GameSettingsScreen::OnResolutionChange);
-	resolutionChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
+	resolutionEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+	resolutionChoice_->SetEnabledPtr(&resolutionEnable);
+
 #ifdef _WIN32
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gs->T("VSync")));
 #endif
@@ -431,8 +435,8 @@ UI::EventReturn GameSettingsScreen::OnSoftwareRendering(UI::EventParams &e) {
 	texFilteringEnable = !g_Config.bSoftwareRendering;
 	blockTransferEnable = !g_Config.bSoftwareRendering;
 	renderModeEnable = !g_Config.bSoftwareRendering;
-	postProcChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
-	resolutionChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
+	postProcEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+	resolutionEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	return UI::EVENT_DONE;
 }
 
@@ -459,8 +463,8 @@ UI::EventReturn GameSettingsScreen::OnRenderingMode(UI::EventParams &e) {
 	enableReports_ = Reporting::IsEnabled();
 	enableReportsCheckbox_->SetEnabled(Reporting::IsSupported());
 
-	postProcChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
-	resolutionChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
+	postProcEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+	resolutionEnable = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -95,12 +95,14 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Rendering Mode")));
 	static const char *renderingMode[] = { "Non-Buffered Rendering", "Buffered Rendering", "Read Framebuffers To Memory (CPU)", "Read Framebuffers To Memory (GPU)"};
-	renderingModeChoice_ = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iRenderingMode, gs->T("Mode"), renderingMode, 0, ARRAY_SIZE(renderingMode), gs, screenManager()));
-	renderingModeChoice_->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingMode);
-	renderingModeChoice_->SetEnabled(!g_Config.bSoftwareRendering);
+	PopupMultiChoice *renderingModeChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iRenderingMode, gs->T("Mode"), renderingMode, 0, ARRAY_SIZE(renderingMode), gs, screenManager()));
+	renderingModeChoice->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingMode);
+	renderModeEnable = !g_Config.bSoftwareRendering;
+	renderingModeChoice->SetEnabledPtr(&renderModeEnable);
 
-	blockTransfer_ = graphicsSettings->Add(new CheckBox(&g_Config.bBlockTransferGPU, gs->T("Simulate Block Transfer", "Simulate Block Transfer (unfinished)")));
-	blockTransfer_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *blockTransfer = graphicsSettings->Add(new CheckBox(&g_Config.bBlockTransferGPU, gs->T("Simulate Block Transfer", "Simulate Block Transfer (unfinished)")));
+	blockTransferEnable = !g_Config.bSoftwareRendering;
+	blockTransfer->SetEnabledPtr(&blockTransferEnable);
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Frame Rate Control")));
 	static const char *frameSkip[] = {"Off", "1", "2", "3", "4", "5", "6", "7", "8"};
@@ -140,24 +142,30 @@ void GameSettingsScreen::CreateViews() {
 #ifdef _WIN32
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gs->T("VSync")));
 #endif
-	mipmapping_ = graphicsSettings->Add(new CheckBox(&g_Config.bMipMap, gs->T("Mipmapping")));
-	mipmapping_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *mipmapping = graphicsSettings->Add(new CheckBox(&g_Config.bMipMap, gs->T("Mipmapping")));
+	mipmapEnable = !g_Config.bSoftwareRendering;
+	mipmapping->SetEnabledPtr(&mipmapEnable);
 
-	hwTransform_ = graphicsSettings->Add(new CheckBox(&g_Config.bHardwareTransform, gs->T("Hardware Transform")));
-	hwTransform_->OnClick.Handle(this, &GameSettingsScreen::OnHardwareTransform);
-	hwTransform_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *hwTransform = graphicsSettings->Add(new CheckBox(&g_Config.bHardwareTransform, gs->T("Hardware Transform")));
+	hwTransform->OnClick.Handle(this, &GameSettingsScreen::OnHardwareTransform);
+	hwTransformEnable = !g_Config.bSoftwareRendering;
+	hwTransform->SetEnabledPtr(&hwTransformEnable);
 
-	swSkin_ = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareSkinning, gs->T("Software Skinning")));
-	swSkin_->SetEnabled(!PSP_IsInited() && !g_Config.bSoftwareRendering);
+	CheckBox *swSkin = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareSkinning, gs->T("Software Skinning")));
+	swSkinningEnable = !PSP_IsInited() && !g_Config.bSoftwareRendering;
+	swSkin->SetEnabledPtr(&swSkinningEnable);
 
-	vtxCache_ = graphicsSettings->Add(new CheckBox(&g_Config.bVertexCache, gs->T("Vertex Cache")));
-	vtxCache_->SetEnabled(!g_Config.bSoftwareRendering && g_Config.bHardwareTransform);
+	CheckBox *vtxCache = graphicsSettings->Add(new CheckBox(&g_Config.bVertexCache, gs->T("Vertex Cache")));
+	vtxCacheEnable = !g_Config.bSoftwareRendering && g_Config.bHardwareTransform;
+	vtxCache->SetEnabledPtr(&vtxCacheEnable);
 
-	texBackoff_ = graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gs->T("Lazy texture caching", "Lazy texture caching (speedup)")));
-	texBackoff_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *texBackoff = graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gs->T("Lazy texture caching", "Lazy texture caching (speedup)")));
+	texBackoffEnable = !g_Config.bSoftwareRendering;
+	texBackoff->SetEnabledPtr(&texBackoffEnable);
 
-	texSecondary_ = graphicsSettings->Add(new CheckBox(&g_Config.bTextureSecondaryCache, gs->T("Retain changed textures", "Retain changed textures (speedup, mem hog)")));
-	texSecondary_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *texSecondary_ = graphicsSettings->Add(new CheckBox(&g_Config.bTextureSecondaryCache, gs->T("Retain changed textures", "Retain changed textures (speedup, mem hog)")));
+	texSecondaryEnable = !g_Config.bSoftwareRendering;
+	texSecondary_->SetEnabledPtr(&texSecondaryEnable);
 
 	// Seems solid, so we hide the setting.
 	// CheckBox *vtxJit = graphicsSettings->Add(new CheckBox(&g_Config.bVertexDecoderJit, gs->T("Vertex Decoder JIT")));
@@ -167,8 +175,9 @@ void GameSettingsScreen::CreateViews() {
 	// }
 
 	static const char *quality[] = { "Low", "Medium", "High"};
-	beziersChoice_ = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iSplineBezierQuality, gs->T("LowCurves", "Spline/Bezier curves quality"), quality, 0, ARRAY_SIZE(quality), gs, screenManager()));
-	beziersChoice_->SetEnabled(!g_Config.bSoftwareRendering);
+	PopupMultiChoice *beziersChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iSplineBezierQuality, gs->T("LowCurves", "Spline/Bezier curves quality"), quality, 0, ARRAY_SIZE(quality), gs, screenManager()));
+	beziersEnable = !g_Config.bSoftwareRendering;
+	beziersChoice->SetEnabledPtr(&beziersEnable);
 	
 	// In case we're going to add few other antialiasing option like MSAA in the future.
 	// graphicsSettings->Add(new CheckBox(&g_Config.bFXAA, gs->T("FXAA")));
@@ -190,17 +199,29 @@ void GameSettingsScreen::CreateViews() {
 		texScaleLevels = texScaleLevelsPOT;
 		numTexScaleLevels = ARRAY_SIZE(texScaleLevelsPOT);
 	}
-	texScalingChoice_ = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingLevel, gs->T("Upscale Level"), texScaleLevels, 0, numTexScaleLevels, gs, screenManager()));
-	texScalingChoice_->SetEnabled(!g_Config.bSoftwareRendering);
+	PopupMultiChoice *texScalingChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingLevel, gs->T("Upscale Level"), texScaleLevels, 0, numTexScaleLevels, gs, screenManager()));
+	texScalingEnable = !g_Config.bSoftwareRendering;
+	texScalingChoice->SetEnabledPtr(&texScalingEnable);
 
 	static const char *texScaleAlgos[] = { "xBRZ", "Hybrid", "Bicubic", "Hybrid + Bicubic", };
-	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingType, gs->T("Upscale Type"), texScaleAlgos, 0, ARRAY_SIZE(texScaleAlgos), gs, screenManager()));
-	graphicsSettings->Add(new CheckBox(&g_Config.bTexDeposterize, gs->T("Deposterize")));
+	PopupMultiChoice *texScalingType = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingType, gs->T("Upscale Type"), texScaleAlgos, 0, ARRAY_SIZE(texScaleAlgos), gs, screenManager()));
+	texScalingEnable = !g_Config.bSoftwareRendering;
+	texScalingType->SetEnabledPtr(&texScalingEnable);
+
+	CheckBox *deposterize = graphicsSettings->Add(new CheckBox(&g_Config.bTexDeposterize, gs->T("Deposterize")));
+	desposterizeEnable = !g_Config.bSoftwareRendering;
+	deposterize->SetEnabledPtr(&desposterizeEnable);
+
 	graphicsSettings->Add(new ItemHeader(gs->T("Texture Filtering")));
 	static const char *anisoLevels[] = { "Off", "2x", "4x", "8x", "16x" };
-	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAnisotropyLevel, gs->T("Anisotropic Filtering"), anisoLevels, 0, ARRAY_SIZE(anisoLevels), gs, screenManager()));
+	PopupMultiChoice *anisoFiltering = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAnisotropyLevel, gs->T("Anisotropic Filtering"), anisoLevels, 0, ARRAY_SIZE(anisoLevels), gs, screenManager()));
+	anisotropicEnable = !g_Config.bSoftwareRendering;
+	anisoFiltering->SetEnabledPtr(&anisotropicEnable);
+
 	static const char *texFilters[] = { "Auto", "Nearest", "Linear", "Linear on FMV", };
-	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexFiltering, gs->T("Texture Filter"), texFilters, 1, ARRAY_SIZE(texFilters), gs, screenManager()));
+	PopupMultiChoice *texFilter = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexFiltering, gs->T("Texture Filter"), texFilters, 1, ARRAY_SIZE(texFilters), gs, screenManager()));
+	texFilteringEnable = !g_Config.bSoftwareRendering;
+	texFilter->SetEnabledPtr(&texFilteringEnable);
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTimerHack, gs->T("Timer Hack")));
@@ -208,12 +229,13 @@ void GameSettingsScreen::CreateViews() {
 	graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
 
 
-	depthWrite_ = graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
-	depthWrite_->SetEnabled(!g_Config.bSoftwareRendering);
+	CheckBox *depthWrite = graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
+	depthWriteEnable = !g_Config.bSoftwareRendering;
+	depthWrite->SetEnabledPtr(&depthWriteEnable);
 
-	prescale_ = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Speedhack")));
-	if (PSP_IsInited() || g_Config.bSoftwareRendering)
-		prescale_->SetEnabled(false);
+	CheckBox *prescale = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Speedhack")));
+	prescaleEnable = !PSP_IsInited() && !g_Config.bSoftwareRendering;
+	prescale->SetEnabledPtr(&prescaleEnable);
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Overlay Information")));
 	static const char *fpsChoices[] = {
@@ -391,26 +413,32 @@ void GameSettingsScreen::CreateViews() {
 }
 
 UI::EventReturn GameSettingsScreen::OnSoftwareRendering(UI::EventParams &e) {
-	prescale_->SetEnabled(!PSP_IsInited() && !g_Config.bSoftwareRendering);
-	depthWrite_->SetEnabled(!g_Config.bSoftwareRendering);
-	stencilTest_->SetEnabled(!g_Config.bSoftwareRendering);
-	beziersChoice_->SetEnabled(!g_Config.bSoftwareRendering);
-	texSecondary_->SetEnabled(!g_Config.bSoftwareRendering);
-	swSkin_->SetEnabled(!PSP_IsInited() && !g_Config.bSoftwareRendering);
-	hwTransform_->SetEnabled(!g_Config.bSoftwareRendering);
-	vtxCache_->SetEnabled(!g_Config.bSoftwareRendering && g_Config.bHardwareTransform);
-	texBackoff_->SetEnabled(!g_Config.bSoftwareRendering);
-	mipmapping_->SetEnabled(!g_Config.bSoftwareRendering);
-	texScalingChoice_->SetEnabled(!g_Config.bSoftwareRendering);
-	blockTransfer_->SetEnabled(!g_Config.bSoftwareRendering);
-	renderingModeChoice_->SetEnabled(!g_Config.bSoftwareRendering);
+	prescaleEnable = !PSP_IsInited() && !g_Config.bSoftwareRendering;
+	depthWriteEnable = !g_Config.bSoftwareRendering;
+	stencilTestEnable = !g_Config.bSoftwareRendering;
+	beziersEnable = !g_Config.bSoftwareRendering;
+	texSecondaryEnable = !g_Config.bSoftwareRendering;
+	swSkinningEnable = !PSP_IsInited() && !g_Config.bSoftwareRendering;
+	hwTransformEnable = !g_Config.bSoftwareRendering;
+	vtxCacheEnable = hwTransformEnable && g_Config.bHardwareTransform;
+
+	texBackoffEnable = !g_Config.bSoftwareRendering;
+	mipmapEnable = !g_Config.bSoftwareRendering;
+	texScalingEnable = !g_Config.bSoftwareRendering;
+	texScalingTypeEnable = !g_Config.bSoftwareRendering;
+	desposterizeEnable = !g_Config.bSoftwareRendering;
+	anisotropicEnable = !g_Config.bSoftwareRendering;
+	texFilteringEnable = !g_Config.bSoftwareRendering;
+	blockTransferEnable = !g_Config.bSoftwareRendering;
+	renderModeEnable = !g_Config.bSoftwareRendering;
 	postProcChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
 	resolutionChoice_->SetEnabled(!g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE));
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnHardwareTransform(UI::EventParams &e) {
-	vtxCache_->SetEnabled(!g_Config.bSoftwareRendering && g_Config.bHardwareTransform);
+	hwTransformEnable = !g_Config.bSoftwareRendering;
+	vtxCacheEnable = hwTransformEnable && g_Config.bHardwareTransform;
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -229,8 +229,8 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTimerHack, gs->T("Timer Hack")));
-	// Maybe hide this on non-PVR?
-	CheckBox *alphaHack = graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")))->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
+	CheckBox *alphaHack = graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")));
+	alphaHack->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
 	alphaHackEnable = !g_Config.bSoftwareRendering;
 	alphaHack->SetEnabledPtr(&alphaHackEnable);
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -103,6 +103,8 @@ private:
 	bool desposterizeEnable;
 	bool anisotropicEnable;
 	bool texFilteringEnable;
+	bool postProcEnable;
+	bool resolutionEnable;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -105,6 +105,7 @@ private:
 	bool texFilteringEnable;
 	bool postProcEnable;
 	bool resolutionEnable;
+	bool alphaHackEnable;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -46,8 +46,21 @@ private:
 	UI::CheckBox *enableReportsCheckbox_;
 	UI::Choice *layoutEditorChoice_;
 	UI::Choice *postProcChoice_;
+	UI::PopupMultiChoice *renderingModeChoice_;
 	UI::PopupMultiChoice *resolutionChoice_;
 	UI::CheckBox *frameSkipAuto_;
+	UI::CheckBox *blockTransfer_;
+	UI::PopupMultiChoice *texScalingChoice_;
+	UI::CheckBox *mipmapping_;
+	UI::CheckBox *hwTransform_;
+	UI::CheckBox *swSkin_;
+	UI::CheckBox *vtxCache_;
+	UI::CheckBox *texBackoff_;
+	UI::CheckBox *texSecondary_;
+	UI::PopupMultiChoice *beziersChoice_;
+	UI::CheckBox *stencilTest_;
+	UI::CheckBox *depthWrite_;
+	UI::CheckBox *prescale_;
 
 	// Event handlers
 	UI::EventReturn OnControlMapping(UI::EventParams &e);
@@ -74,6 +87,8 @@ private:
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 	UI::EventReturn OnRenderingMode(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
+	UI::EventReturn OnSoftwareRendering(UI::EventParams &e);
+	UI::EventReturn OnHardwareTransform(UI::EventParams &e);
 
 	UI::EventReturn OnScreenRotation(UI::EventParams &e);
 	UI::EventReturn OnImmersiveModeChange(UI::EventParams &e);

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -46,21 +46,8 @@ private:
 	UI::CheckBox *enableReportsCheckbox_;
 	UI::Choice *layoutEditorChoice_;
 	UI::Choice *postProcChoice_;
-	UI::PopupMultiChoice *renderingModeChoice_;
 	UI::PopupMultiChoice *resolutionChoice_;
 	UI::CheckBox *frameSkipAuto_;
-	UI::CheckBox *blockTransfer_;
-	UI::PopupMultiChoice *texScalingChoice_;
-	UI::CheckBox *mipmapping_;
-	UI::CheckBox *hwTransform_;
-	UI::CheckBox *swSkin_;
-	UI::CheckBox *vtxCache_;
-	UI::CheckBox *texBackoff_;
-	UI::CheckBox *texSecondary_;
-	UI::PopupMultiChoice *beziersChoice_;
-	UI::CheckBox *stencilTest_;
-	UI::CheckBox *depthWrite_;
-	UI::CheckBox *prescale_;
 
 	// Event handlers
 	UI::EventReturn OnControlMapping(UI::EventParams &e);
@@ -97,6 +84,25 @@ private:
 	bool cap60FPS_;
 	int iAlternateSpeedPercent_;
 	bool enableReports_;
+
+	// Cached booleans
+	bool hwTransformEnable;
+	bool vtxCacheEnable;
+	bool renderModeEnable;
+	bool blockTransferEnable;
+	bool swSkinningEnable;
+	bool texBackoffEnable;
+	bool mipmapEnable;
+	bool texScalingEnable;
+	bool texSecondaryEnable;
+	bool beziersEnable;
+	bool stencilTestEnable;
+	bool depthWriteEnable;
+	bool prescaleEnable;
+	bool texScalingTypeEnable;
+	bool desposterizeEnable;
+	bool anisotropicEnable;
+	bool texFilteringEnable;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {


### PR DESCRIPTION
They don't do anything when software rendering is enabled, so there's bound to be confusion caused by these options continuing to be enabled, and thus it makes sense to disable them when SW rendering is on.

Since a large number of options are being fiddled with here, it's probably best to do a bit of rudimentary testing to make sure I didn't screw anything up. I don't think I did, but you never know if I missed one or two things.
