### PR TITLE
Flush before blitting, skip unlikely depthcopy case

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1441,8 +1441,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 		}
 #endif
 
-		// Null out currentRenderVfb_ so it gets set again properly.
-		currentRenderVfb_ = NULL;
+		RebindFramebuffer();
 	}
 }
 
@@ -1968,7 +1967,6 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 			if (MaskedEqual(vfb->fb_address, addr)) {
 				FlushBeforeCopy();
 				fbo_unbind();
-				currentRenderVfb_ = 0;
 
 				vfb->dirtyAfterDisplay = true;
 				vfb->reallyDirtyAfterDisplay = true;
@@ -1993,8 +1991,10 @@ void FramebufferManager::UpdateFromMemory(u32 addr, int size, bool safe) {
 			}
 		}
 
-		if (needUnbind)
+		if (needUnbind) {
 			fbo_unbind();
+		}
+		RebindFramebuffer();
 	}
 }
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -161,7 +161,7 @@ public:
 	void UpdateFromMemory(u32 addr, int size, bool safe);
 	void SetLineWidth();
 
-	void BindFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer);
+	void BlitFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer);
 
 	// For use when texturing from a framebuffer.  May create a duplicate if target.
 	void BindFramebufferColor(VirtualFramebuffer *framebuffer, bool skipCopy = false);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -33,6 +33,8 @@
 
 struct GLSLProgram;
 class TextureCache;
+class TransformDrawEngine;
+class ShaderManager;
 
 enum {
 	FB_USAGE_DISPLAYED_FRAMEBUFFER = 1,
@@ -110,8 +112,6 @@ struct AsyncPBO {
 
 #endif
 
-class ShaderManager;
-
 class FramebufferManager {
 public:
 	FramebufferManager();
@@ -122,6 +122,9 @@ public:
 	}
 	void SetShaderManager(ShaderManager *sm) {
 		shaderManager_ = sm;
+	}
+	void SetTransformDrawEngine(TransformDrawEngine *td) {
+		transformDraw_ = td;
 	}
 
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
@@ -232,6 +235,7 @@ public:
 private:
 	void CompileDraw2DProgram();
 	void DestroyDraw2DProgram();
+	void FlushBeforeCopy();
 
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const;
 	u32 FramebufferByteSize(const VirtualFramebuffer *vfb) const;
@@ -280,6 +284,7 @@ private:
 
 	TextureCache *textureCache_;
 	ShaderManager *shaderManager_;
+	TransformDrawEngine *transformDraw_;
 	bool usePostShader_;
 	bool postShaderAtOutputResolution_;
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -409,6 +409,7 @@ GLES_GPU::GLES_GPU()
 	transformDraw_.SetFramebufferManager(&framebufferManager_);
 	framebufferManager_.SetTextureCache(&textureCache_);
 	framebufferManager_.SetShaderManager(shaderManager_);
+	framebufferManager_.SetTransformDrawEngine(&transformDraw_);
 	textureCache_.SetFramebufferManager(&framebufferManager_);
 	textureCache_.SetDepalShaderCache(&depalShaderCache_);
 	textureCache_.SetShaderManager(shaderManager_);
@@ -603,10 +604,12 @@ void GLES_GPU::CopyDisplayToOutput() {
 }
 
 void GLES_GPU::CopyDisplayToOutputInternal() {
+	// Flush anything left over.
+	framebufferManager_.SetRenderFrameBuffer();
+	transformDraw_.Flush();
+
 	glstate.depthWrite.set(GL_TRUE);
 	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-
-	transformDraw_.Flush();
 
 	framebufferManager_.CopyDisplayToOutput();
 	framebufferManager_.EndFrame();

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -605,7 +605,7 @@ void GLES_GPU::CopyDisplayToOutput() {
 
 void GLES_GPU::CopyDisplayToOutputInternal() {
 	// Flush anything left over.
-	framebufferManager_.SetRenderFrameBuffer();
+	framebufferManager_.RebindFramebuffer();
 	transformDraw_.Flush();
 
 	glstate.depthWrite.set(GL_TRUE);


### PR DESCRIPTION
If we stalled a list, we could end up with a memcpy() during the stall, which would not work properly.  This flushes before performing any blit/upload/download operations so that they are properly consistent.

Additionally, I realized that depth has a stride that is generally 0 when not in use.  This makes it report less spurious warnings about depth overlap, and might skip rare cases of depthcopy (when moving from a depth buffer at 0 with stride, to a framebuffer with no depth buffer.)

-[Unknown]
