### PR TITLE
Track framebuffer memory dirty more carefully

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -206,6 +206,11 @@ public:
 			currentRenderVfb_->depthUpdated = true;
 		}
 	}
+	void SetColorUpdated() {
+		if (currentRenderVfb_) {
+			currentRenderVfb_->memoryUpdated = false;
+		}
+	}
 
 	bool MayIntersectFramebuffer(u32 start) {
 		// Clear the cache/kernel bits.

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -420,6 +420,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 		// Stencil takes alpha.
 		glClearStencil(clearColor >> 24);
 		glClear(target);
+		framebufferManager_->SetColorUpdated();
 		return;
 	}
 

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -146,5 +146,6 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 		fbo_unbind();
 	}
 	glstate.viewport.restore();
+	dstBuffer->memoryUpdated = false;
 	return true;
 }

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -760,6 +760,7 @@ rotateVBO:
 	dcid_ = 0;
 	prevPrim_ = GE_PRIM_INVALID;
 	gstate_c.vertexFullAlpha = true;
+	framebufferManager_->SetColorUpdated();
 
 #ifndef MOBILE_DEVICE
 	host->GPUNotifyDraw();


### PR DESCRIPTION
Fixes #6296, Grand Knights History slowdown during battle transition.  May also more correctly identify block transfer downloads.

Specifically the slowdown was because `srcBuffer == currentRenderVfb_`, and we had to assume it could've been updated since it was the current target.  Now, we dirty on flush, so we know if it's dirty regardless of whteher it's the current target or not.

-[Unknown]
