### PR TITLE
Try to handle more block transfer / tex render cases

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -22,6 +22,7 @@
 #include "native/thread/threadutil.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMap.h"
 #include "Core/System.h"
 #include "Core/Host.h"
@@ -725,6 +726,7 @@ bool __IoRead(int &result, int id, u32 data_addr, int size) {
 			result = ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
 			return true;
 		} else if (Memory::IsValidAddress(data_addr)) {
+			CBreakPoints::ExecMemCheck(data_addr, true, size, currentMIPS->pc);
 			u8 *data = (u8*) Memory::GetPointer(data_addr);
 			if (f->npdrm) {
 				result = npdrmRead(f, data, size);
@@ -854,6 +856,8 @@ bool __IoWrite(int &result, int id, u32 data_addr, int size) {
 			result = ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
 			return true;
 		}
+
+		CBreakPoints::ExecMemCheck(data_addr, false, size, currentMIPS->pc);
 
 		bool useThread = __KernelIsDispatchEnabled() && ioManagerThreadEnabled && size > IO_THREAD_MIN_DATA_SIZE;
 		if (useThread) {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -53,9 +53,6 @@
 // Changes more frequent than this will be considered "frequent" and prevent texture scaling.
 #define TEXCACHE_FRAME_CHANGE_FREQUENT 15
 
-// Assume a framebuffer format is garbage after this many flips.
-#define TEXCACHE_RENDERTEX_OLD_AGE 6
-
 #define TEXCACHE_NAME_CACHE_SIZE 16
 
 #ifndef GL_UNPACK_ROW_LENGTH
@@ -247,14 +244,9 @@ void TextureCache::AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualF
 		DEBUG_LOG(G3D, "Render to texture detected at %08x!", address);
 		if (!entry->framebuffer || entry->invalidHint == -1) {
 			if (entry->format != framebuffer->format) {
-				if (framebuffer->last_frame_render + TEXCACHE_RENDERTEX_OLD_AGE < gpuStats.numFlips) {
-					WARN_LOG_REPORT_ONCE(diffFormat3, G3D, "Render to texture with different formats %d != %d, no recent render", entry->format, framebuffer->format);
-					DetachFramebuffer(entry, address, framebuffer);
-				} else {
-					WARN_LOG_REPORT_ONCE(diffFormat1, G3D, "Render to texture with different formats %d != %d", entry->format, framebuffer->format);
-					// If it already has one, let's hope that one is correct.
-					AttachFramebufferInvalid(entry, framebuffer, fbInfo);
-				}
+				WARN_LOG_REPORT_ONCE(diffFormat1, G3D, "Render to texture with different formats %d != %d", entry->format, framebuffer->format);
+				// Let's avoid rendering when we know the format is wrong.  May be a video/etc. updating memory.
+				DetachFramebuffer(entry, address, framebuffer);
 			} else {
 				AttachFramebufferValid(entry, framebuffer, fbInfo);
 			}


### PR DESCRIPTION
Maybe one of these will help that Sakura game's video.  @daniel229, any good?

I think detaching makes sense if there's no rendering one way or another.  I also think there might be cases of deep offsets into a tall texture, hoping to catch them with the ugly 0x04110000 heuristic.  Could break something worst case...

-[Unknown]
