### PR TITLE
Support gpu memcpy/memset line-by line

### DIFF
--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -135,6 +135,10 @@ bool EnterStepping(std::function<void()> callback) {
 	return true;
 }
 
+bool IsStepping() {
+	return isStepping;
+}
+
 static bool GetBuffer(const GPUDebugBuffer *&buffer, PauseAction type, const GPUDebugBuffer &resultBuffer) {
 	if (!isStepping) {
 		return false;

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -26,6 +26,7 @@ namespace GPUStepping {
 	// Begins stepping and calls callback while inside a lock preparing stepping.
 	// This would be a good place to deliver a message to code that stepping is ready.
 	bool EnterStepping(std::function<void()> callback);
+	bool IsStepping();
 
 	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer);
 	bool GPU_GetCurrentDepthbuffer(const GPUDebugBuffer *&buffer);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2036,21 +2036,21 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 		const u32 vfb_byteStride = vfb->fb_stride * vfb_bpp;
 		const u32 vfb_byteWidth = vfb->width * vfb_bpp;
 
-		if (dst >= vfb_address && dst + size <= vfb_address + vfb_size) {
+		if (dst >= vfb_address && (dst + size <= vfb_address + vfb_size || dst == vfb_address)) {
 			const u32 offset = dst - vfb_address;
 			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0)) {
 				dstBuffer = vfb;
 				dstY = offset / vfb_byteStride;
-				dstH = size == vfb_byteWidth ? 1 : size / vfb_byteStride;
+				dstH = size == vfb_byteWidth ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
 			}
 		}
 
-		if (src >= vfb_address && src + size <= vfb_address + vfb_size) {
+		if (src >= vfb_address && (src + size <= vfb_address + vfb_size || src == vfb_address)) {
 			const u32 offset = src - vfb_address;
 			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0)) {
 				srcBuffer = vfb;
 				srcY = offset / vfb_byteStride;
-				srcH = size == vfb_byteWidth ? 1 : size / vfb_byteStride;
+				srcH = size == vfb_byteWidth ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
 			}
 		}
 	}

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -37,6 +37,7 @@
 
 #include "GPU/Common/PostShader.h"
 #include "GPU/Common/TextureDecoder.h"
+#include "GPU/Debugger/Stepping.h"
 #include "GPU/GLES/Framebuffer.h"
 #include "GPU/GLES/TextureCache.h"
 #include "GPU/GLES/TransformPipeline.h"
@@ -1139,6 +1140,9 @@ void FramebufferManager::BindFramebufferColor(VirtualFramebuffer *framebuffer, b
 
 	// currentRenderVfb_ will always be set when this is called, except from the GE debugger.
 	// Let's just not bother with the copy in that case.
+	if (GPUStepping::IsStepping()) {
+		skipCopy = true;
+	}
 	if (!skipCopy && currentRenderVfb_ && MaskedEqual(framebuffer->fb_address, gstate.getFrameBufRawAddress())) {
 		// TODO: Maybe merge with bvfbs_?  Not sure if those could be packing, and they're created at a different size.
 		FBO *renderCopy = GetTempFBO(framebuffer->renderWidth, framebuffer->renderHeight, framebuffer->colorDepth);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2024,9 +2024,9 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 
 	VirtualFramebuffer *dstBuffer = 0;
 	VirtualFramebuffer *srcBuffer = 0;
-	u32 dstY = 0;
+	u32 dstY = (u32)-1;
 	u32 dstH = 0;
-	u32 srcY = 0;
+	u32 srcY = (u32)-1;
 	u32 srcH = 0;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = vfbs_[i];
@@ -2038,18 +2038,20 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 
 		if (dst >= vfb_address && (dst + size <= vfb_address + vfb_size || dst == vfb_address)) {
 			const u32 offset = dst - vfb_address;
-			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0)) {
+			const u32 yOffset = offset / vfb_byteStride;
+			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0) && yOffset < dstY) {
 				dstBuffer = vfb;
-				dstY = offset / vfb_byteStride;
+				dstY = yOffset;
 				dstH = size == vfb_byteWidth ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
 			}
 		}
 
 		if (src >= vfb_address && (src + size <= vfb_address + vfb_size || src == vfb_address)) {
 			const u32 offset = src - vfb_address;
-			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0)) {
+			const u32 yOffset = offset / vfb_byteStride;
+			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0) && yOffset < srcY) {
 				srcBuffer = vfb;
-				srcY = offset / vfb_byteStride;
+				srcY = yOffset;
 				srcH = size == vfb_byteWidth ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
 			}
 		}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -321,6 +321,13 @@ void TextureCache::NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffe
 	if (addr >= 0x04000000 && addr < 0x04110000) {
 		// This range usually is dominated by framebuffers.  Assume the entire height is up for grabs.
 		cacheKeyEnd = cacheKey + ((u64)(framebuffer->fb_stride * framebuffer->height * bpp) << 32);
+	} else {
+		const u64 cacheKeyRealEnd = cacheKey + ((u64)(framebuffer->fb_stride * framebuffer->height * bpp) << 32);
+		for (auto it = cache.lower_bound(cacheKeyEnd), end = cache.upper_bound(cacheKeyRealEnd); it != end; ++it) {
+			if (it->second.bufw == framebuffer->fb_stride) {
+				WARN_LOG_REPORT_ONCE(subareaIgnored, G3D, "Ignoring possible texture at offset %08x from %08x", it->second.addr, framebuffer->fb_address);
+			}
+		}
 	}
 
 	switch (msg) {

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -61,6 +61,7 @@ SOURCES += $$P/Core/*.cpp \ # Core
 	$$P/GPU/GLES/VertexDecoder.cpp \
 	$$P/GPU/GLES/VertexShaderGenerator.cpp \
 	$$P/GPU/Software/*.cpp \
+	$$P/GPU/Debugger/*.cpp \
 	$$P/GPU/Common/IndexGenerator.cpp \
 	$$P/GPU/Common/TextureDecoder.cpp \
 	$$P/GPU/Common/VertexDecoderCommon.cpp \
@@ -88,6 +89,7 @@ HEADERS += $$P/Core/*.h \
 	$$P/Core/Util/*.h \
 	$$P/GPU/GLES/*.h \
 	$$P/GPU/Software/*.h \
+	$$P/GPU/Debugger/*.h \
 	$$P/GPU/Common/*.h \
 	$$P/GPU/*.h \
 	$$P/ext/libkirk/*.h \


### PR DESCRIPTION
Used in for example Final Fantasy Tactics.  Fixes glitch when entering save screen, probably others.

Trying to keep it relatively safe still.

-[Unknown]
