### PR TITLE
Limit the amount of texture scaling done per frame to reduce stutters

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1241,7 +1241,6 @@ void TextureCache::SetTexture(bool force) {
 
 		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && g_Config.iTexScalingLevel != 1 && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
 			// INFO_LOG(G3D, "Reloading texture to do the scaling we skipped..");
-			entry->status &= ~TexCacheEntry::STATUS_TO_SCALE;
 			match = false;
 		}
 
@@ -1424,6 +1423,7 @@ void TextureCache::SetTexture(bool force) {
 			scaleFactor = 1;
 			// INFO_LOG(G3D, "Skipped scaling for now..");
 		} else {
+			entry->status &= ~TexCacheEntry::STATUS_TO_SCALE;
 			texelsScaledThisFrame_ += w * h;
 		}
 	}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -773,8 +773,9 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int n
 void TextureCache::StartFrame() {
 	lastBoundTexture = -1;
 
-	if (texelsScaledThisFrame_)
-		INFO_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
+	if (texelsScaledThisFrame_) {
+		// INFO_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
+	}
 	texelsScaledThisFrame_ = 0;
 	if (clearCacheNextFrame_) {
 		Clear(true);
@@ -1239,7 +1240,7 @@ void TextureCache::SetTexture(bool force) {
 		}
 
 		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && g_Config.iTexScalingLevel != 1 && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
-			INFO_LOG(G3D, "Reloading texture to do the scaling we skipped..");
+			// INFO_LOG(G3D, "Reloading texture to do the scaling we skipped..");
 			entry->status &= ~TexCacheEntry::STATUS_TO_SCALE;
 			match = false;
 		}
@@ -1421,7 +1422,7 @@ void TextureCache::SetTexture(bool force) {
 		if (texelsScaledThisFrame_ >= TEXCACHE_MAX_TEXELS_SCALED) {
 			entry->status |= TexCacheEntry::STATUS_TO_SCALE;
 			scaleFactor = 1;
-			INFO_LOG(G3D, "Skipped scaling for now..");
+			// INFO_LOG(G3D, "Skipped scaling for now..");
 		} else {
 			texelsScaledThisFrame_ += w * h;
 		}

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -115,7 +115,9 @@ public:
 			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
 			STATUS_DEPALETTIZE = 0x40,
 			STATUS_DEPALETTIZE_DIRTY = 0x80,
-			STATUS_TEXPARAM_DIRTY = 0x100
+			STATUS_TEXPARAM_DIRTY = 0x100,
+
+			STATUS_TO_SCALE = 0x200,
 		};
 
 		// Status, but int so we can zero initialize.
@@ -227,6 +229,8 @@ private:
 	float maxAnisotropyLevel;
 
 	int decimationCounter_;
+	int texelsScaledThisFrame_;
+
 	FramebufferManager *framebufferManager_;
 	DepalShaderCache *depalShaderCache_;
 	ShaderManager *shaderManager_;


### PR DESCRIPTION
Scaling causes really bad stutters in some games on some hardware.

This should also reduce the impact of pathological cases like the first boss of FF Type-0 to be more bearable.

Causes some extra work but the heavy work gets spread over more frames. This probably will need some testing tuning before merge.

It should do nothing to speed if scaling is not enabled.
