### PR TITLE
Avoid shrinking buffer w/h in throughmode

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -869,8 +869,14 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 			// Update fb stride in case it changed
 			vfb->fb_stride = fb_stride;
 			v->format = fmt;
-			v->width = drawing_width;
-			v->height = drawing_height;
+			// In throughmode, a higher height could be used.  Let's avoid shrinking the buffer.
+			if (gstate.isModeThrough() && (int)v->width < fb_stride) {
+				v->width = std::max((int)v->width, drawing_width);
+				v->height = std::max((int)v->height, drawing_height);
+			} else {
+				v->width = drawing_width;
+				v->height = drawing_height;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
Since they could overdraw and we already scissor.

Fixes #6312.  Since these are throughmode anyway, it shouldn't be risky, and it won't grow buffers every - only not shrink them.

For example, there is a 480x272 buffer that Dragon Ball Z reuses at 64x64 for shadows.  It only uses throughmode for the shadows, so while 64x64 is technically correct, they aren't actually clipped to that since it's only by region (viewport is not used in throughmode I think?) anyway.  With this change it treats them as 480x272, but this causes no glitches.

The important thing is that we shouldn't overestimate the size and blit wrong (unless we previously detected the height incorrectly.)

-[Unknown]
