### PR TITLE
Reduce some texture scaling limits to rely on texels instead

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1424,7 +1424,7 @@ void TextureCache::SetTexture(bool force) {
 	if (entry->addr > 0x05000000 && entry->addr < 0x08800000)
 		scaleFactor = 1;
 
-	if (scaleFactor != 1) {
+	if (scaleFactor != 1 && (entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
 		if (texelsScaledThisFrame_ >= TEXCACHE_MAX_TEXELS_SCALED) {
 			entry->status |= TexCacheEntry::STATUS_TO_SCALE;
 			scaleFactor = 1;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1209,6 +1209,7 @@ void TextureCache::SetTexture(bool force) {
 					if (g_Config.bTextureBackoffCache) {
 						entry->SetHashStatus(TexCacheEntry::STATUS_HASHING);
 					}
+					entry->status &= ~TexCacheEntry::STATUS_CHANGE_FREQUENT;
 				}
 			}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -51,7 +51,7 @@
 #define TEXCACHE_DECIMATION_INTERVAL 13
 
 // Changes more frequent than this will be considered "frequent" and prevent texture scaling.
-#define TEXCACHE_FRAME_CHANGE_FREQUENT 15
+#define TEXCACHE_FRAME_CHANGE_FREQUENT 6
 
 #define TEXCACHE_NAME_CACHE_SIZE 16
 


### PR DESCRIPTION
This regains trust on textures and reduces the "frequent" limit so that textures can be scaled more often.  Doing it based on total texels seems more bullet proof, anyway.

Also fixes textures that were frequently changing still being counted against scaled texels.

Might be good to verify Type-0's performance with this...

-[Unknown]
