### PR TITLE
Support render-to-offset within a framebuffer

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -507,6 +507,8 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 		renderHeightFactor = renderHeight / 272.0f;
 	}
 
+	renderX += gstate_c.cutRTOffsetX * renderWidthFactor;
+
 	// Scissor
 	int scissorX1 = gstate.getScissorX1();
 	int scissorY1 = gstate.getScissorY1();

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -336,5 +336,5 @@ void GPUStateCache::DoState(PointerWrap &p) {
 	p.Do(curRTWidth);
 	p.Do(curRTHeight);
 
-	// curRTBufferWidth and curRTBufferHeight don't need to be saved.
+	// curRTBufferWidth, curRTBufferHeight, and cutRTOffsetX don't need to be saved.
 }

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -474,9 +474,9 @@ struct GPUStateCache
 
 	u32 curRTWidth;
 	u32 curRTHeight;
-
 	u32 curRTRenderWidth;
 	u32 curRTRenderHeight;
+	u32 cutRTOffsetX;
 
 	u32 getRelativeAddress(u32 data) const;
 	void DoState(PointerWrap &p);

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -189,7 +189,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op) {
 	};
 
 	Matrix4x4 ortho;
-	ortho.setOrtho(0, frameWindow->TexWidth() * scale[0], frameWindow->TexHeight() * scale[1], 0, -1, 1);
+	ortho.setOrtho(-(int)gstate_c.cutRTOffsetX, (frameWindow->TexWidth() - (int)gstate_c.cutRTOffsetX) * scale[0], frameWindow->TexHeight() * scale[1], 0, -1, 1);
 	glUniformMatrix4fv(previewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 	glEnableVertexAttribArray(previewProgram->a_position);
 	glVertexAttribPointer(previewProgram->a_position, 3, GL_FLOAT, GL_FALSE, sizeof(GPUDebugVertex), (float *)vertices.data() + 2);


### PR DESCRIPTION
Fixes #6324.

I don't actually understand why subtracting the offset in setOrtho works for the preview...

-[Unknown]
