### PR TITLE
VFPU: Ensure that sin(4*x) returns 0.0 (and cos 1) for all x. Fixes #2921

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1832,24 +1832,18 @@ namespace MIPSComp
 		fpr.ReleaseSpillLocksAndDiscardTemps();
 	}
 
-#ifndef M_PI_2
-#define M_PI_2     1.57079632679489661923
-#endif
 	// sincosf is unavailable in the Android NDK:
 	// https://code.google.com/p/android/issues/detail?id=38423
 	double SinCos(float angle) {
 		union { struct { float sin; float cos; }; double out; } sincos;
-		angle *= (float)M_PI_2;
-		sincos.sin = sinf(angle);
-		sincos.cos = cosf(angle);
+		vfpu_sincos(angle, sincos.sin, sincos.cos);
 		return sincos.out;
 	}
 
 	double SinCosNegSin(float angle) {
 		union { struct { float sin; float cos; }; double out; } sincos;
-		angle *= (float)M_PI_2;
-		sincos.sin = -sinf(angle);
-		sincos.cos = cosf(angle);
+		vfpu_sincos(angle, sincos.sin, sincos.cos);
+		sincos.sin = -sincos.sin;
 		return sincos.out;
 	}
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -59,7 +59,10 @@ u8 fromvoffset[128];
 #define M_LN10     2.30258509299404568402f
 #undef M_PI
 #define M_PI       3.14159265358979323846f
+
+#ifndef M_PI_2
 #define M_PI_2     1.57079632679489661923f
+#endif
 #define M_PI_4     0.785398163397448309616f
 #define M_1_PI     0.318309886183790671538f
 #define M_2_PI     0.636619772367581343076f

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -19,6 +19,8 @@
 
 #include <cmath>
 
+#include "Core/MIPS/MIPS.h"
+
 #define _VD (op & 0x7F)
 #define _VS ((op>>8) & 0x7F)
 #define _VT ((op>>16) & 0x7F)
@@ -32,19 +34,19 @@ inline int Xpose(int v) {
 #endif
 
 inline float vfpu_sin(float angle) {
-	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle -= floorf(angle * 0.25f) * 4.f;
 	angle *= (float)M_PI_2;
 	return sinf(angle);
 }
 
 inline float vfpu_cos(float angle) {
-	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle -= floorf(angle * 0.25f) * 4.f;
 	angle *= (float)M_PI_2;
 	return cosf(angle);
 }
 
 inline void vfpu_sincos(float angle, float &sine, float &cosine) {
-	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle -= floorf(angle * 0.25f) * 4.f;
 	angle *= (float)M_PI_2;
 	sine = sinf(angle);
 	cosine = cosf(angle);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -17,15 +17,37 @@
 
 #pragma once
 
-
+#include <cmath>
 
 #define _VD (op & 0x7F)
 #define _VS ((op>>8) & 0x7F)
 #define _VT ((op>>16) & 0x7F)
 
-inline int Xpose(int v)
-{
+inline int Xpose(int v) {
 	return v^0x20;
+}
+
+#ifndef M_PI_2
+#define M_PI_2     1.57079632679489661923
+#endif
+
+inline float vfpu_sin(float angle) {
+	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle *= (float)M_PI_2;
+	return sinf(angle);
+}
+
+inline float vfpu_cos(float angle) {
+	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle *= (float)M_PI_2;
+	return cosf(angle);
+}
+
+inline void vfpu_sincos(float angle, float &sine, float &cosine) {
+	angle -= floorf(angle * 4.0f) * 0.25f;
+	angle *= (float)M_PI_2;
+	sine = sinf(angle);
+	cosine = cosf(angle);
 }
 
 #define VFPU_FLOAT16_EXP_MAX    0x1f

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2125,15 +2125,12 @@ typedef u32float SinCosArg;
 #endif
 
 void SinCos(SinCosArg angle) {
-	angle *= (float)1.57079632679489661923;  // pi / 2
-	sincostemp[0] = sinf(angle);
-	sincostemp[1] = cosf(angle);
+	vfpu_sincos(angle, sincostemp[0], sincostemp[1]);
 }
 
 void SinCosNegSin(SinCosArg angle) {
-	angle *= (float)1.57079632679489661923;  // pi / 2
-	sincostemp[0] = -sinf(angle);
-	sincostemp[1] = cosf(angle);
+	vfpu_sincos(angle, sincostemp[0], sincostemp[1]);
+	sincostemp[0] = -sincostemp[0];
 }
 
 // Very heavily used by FF:CC

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -37,10 +37,12 @@
 #include "math/math_util.h"
 #include "util/text/parsers.h"
 #include "Core/Config.h"
+#include "Core/MIPS/MIPSVFPUUtils.h"
 
 #define EXPECT_TRUE(a) if (!(a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
 #define EXPECT_FALSE(a) if ((a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
-#define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:" __LINE__ ": Test Fail\n%f\nvs\n%f\n", __FUNCTION__, a, b); return false; }
+#define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); return false; }
+#define EXPECT_APPROX_EQ_FLOAT(a, b) if (fabsf((a)-(b))>0.00001f) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
 #define EXPECT_EQ_STR(a, b) if (a != b) { printf("%s: Test Fail\n%s\nvs\n%s\n", __FUNCTION__, a.c_str(), b.c_str()); return false; }
 
 #define RET(a) if (!(a)) { return false; }
@@ -385,6 +387,35 @@ bool TestParsers() {
 	return true;
 }
 
+bool TestVFPUSinCos() {
+	float sine, cosine;
+	vfpu_sincos(0.0f, sine, cosine);
+	EXPECT_EQ_FLOAT(sine, 0.0f);
+	EXPECT_EQ_FLOAT(cosine, 1.0f);
+	vfpu_sincos(1.0f, sine, cosine);
+	EXPECT_APPROX_EQ_FLOAT(sine, 1.0f);
+	EXPECT_APPROX_EQ_FLOAT(cosine, 0.0f);
+	vfpu_sincos(2.0f, sine, cosine);
+	EXPECT_APPROX_EQ_FLOAT(sine, 0.0f);
+	EXPECT_APPROX_EQ_FLOAT(cosine, -1.0f);
+	vfpu_sincos(3.0f, sine, cosine);
+	EXPECT_APPROX_EQ_FLOAT(sine, -1.0f);
+	EXPECT_APPROX_EQ_FLOAT(cosine, 0.0f);
+	vfpu_sincos(4.0f, sine, cosine);
+	EXPECT_EQ_FLOAT(sine, 0.0f);
+	EXPECT_EQ_FLOAT(cosine, 1.0f);
+	vfpu_sincos(5.0f, sine, cosine);
+	EXPECT_APPROX_EQ_FLOAT(sine, 1.0f);
+	EXPECT_APPROX_EQ_FLOAT(cosine, 0.0f);
+
+	for (float angle = -10.0f; angle < 10.0f; angle++) {
+		vfpu_sincos(angle, sine, cosine);
+		EXPECT_APPROX_EQ_FLOAT(sine, sinf(angle * M_PI_2));
+		EXPECT_APPROX_EQ_FLOAT(cosine, cosf(angle * M_PI_2));
+	}
+	return true;
+}
+
 int main(int argc, const char *argv[]) {
 	cpu_info.bNEON = true;
 	cpu_info.bVFP = true;
@@ -393,7 +424,8 @@ int main(int argc, const char *argv[]) {
 	g_Config.bEnableLogging = true;
 	//TestAsin();
 	//TestSinCos();
-	TestArmEmitter();
+	//TestArmEmitter();
+	TestVFPUSinCos();
 	//TestMathUtil();
 	//TestParsers();
 	return 0;


### PR DESCRIPTION
This also makes it easier to replace our VFPU sin/cos implementations with some approximation later.

Note that our sinf/cosf function replacements should not call these, they are expected to behave like libc sinf/cosf, I would think.

Fixes #2921
