### PR TITLE
Separate framebuffer sampling params from tex

### DIFF
--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -113,11 +113,8 @@ public:
 
 			STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 15 frames in between.)
 			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
-			STATUS_DEPALETTIZE = 0x40,
-			STATUS_DEPALETTIZE_DIRTY = 0x80,
-			STATUS_TEXPARAM_DIRTY = 0x100,
-
-			STATUS_TO_SCALE = 0x200,
+			STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
+			STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
 		};
 
 		// Status, but int so we can zero initialize.
@@ -170,6 +167,8 @@ public:
 		bool Matches(u16 dim2, u8 format2, int maxLevel2);
 	};
 
+	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
+
 private:
 	typedef std::map<u64, TexCacheEntry> TexCache;
 
@@ -177,6 +176,7 @@ private:
 	void DeleteTexture(TexCache::iterator it);
 	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPixel, u32 level);
 	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, GLuint dstFmt, int bufw);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, int scaleFactor, GLenum dstFmt);
 	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -174,6 +174,8 @@ private:
 	void DoFlush();
 	void SoftwareTransformAndDraw(int prim, u8 *decoded, LinkedShader *program, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex);
 	void ApplyDrawState(int prim);
+	bool ApplyShaderBlending();
+	void ResetShaderBlending();
 	bool IsReallyAClear(int numVerts) const;
 	GLuint AllocateBuffer();
 	void FreeBuffer(GLuint buf);


### PR DESCRIPTION
This way we don't need to reset params on the texture or worry about things like that.  We always force on the framebuffer anyway, so this is simpler.

Also don't enable mipmaps when using a framebuffer, since they don't make sense currently.  Was a bit worried there might be some negative interactions there.

-[Unknown]
