### PR TITLE
Update vsync on resize, and before first FBO

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -350,14 +350,10 @@ FramebufferManager::FramebufferManager() :
 	currentPBO_(0)
 #endif
 {
+}
+
+void FramebufferManager::Init() {
 	CompileDraw2DProgram();
-
-	// And an initial clear. We don't clear per frame as the games are supposed to handle that
-	// by themselves.
-	ClearBuffer();
-
-	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-	updateVRAM_ = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 
 	const std::string gameId = g_paramSFO.GetValueString("DISC_ID");
 	// This applies a hack to Dangan Ronpa, its demo, and its sequel.
@@ -365,7 +361,12 @@ FramebufferManager::FramebufferManager() :
 	// We force this framebuffer to 1x and force download it automatically.
 	hackForce04154000Download_ = gameId == "NPJH50631" || gameId == "NPJH50372" || gameId == "NPJH90164" || gameId == "NPJH50515";
 
+	// And an initial clear. We don't clear per frame as the games are supposed to handle that
+	// by themselves.
+	ClearBuffer();
+
 	SetLineWidth();
+	BeginFrame();
 }
 
 FramebufferManager::~FramebufferManager() {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -141,6 +141,7 @@ public:
 	void DestroyAllFBOs();
 	void DecimateFBOs();
 
+	void Init();
 	void BeginFrame();
 	void EndFrame();
 	void Resized();

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -160,6 +160,7 @@ private:
 	void PerformMemorySetInternal(u32 dest, u8 v, int size);
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
+	inline void UpdateVsyncInterval(bool force);
 
 	static CommandInfo cmdInfo_[256];
 


### PR DESCRIPTION
May take care of #4440.  Per #6182, vsync is only broken when the post shader was previously enabled, but not if it is enabled while in game.  This implies it has to do with the order of operations.

The only logical thing is that we are creating an FBO before setting it, and this matters somehow.  These changes set vsync slightly more liberally in attempt to kill the problem.

I have not noticed the problem myself, so I can't test.

-[Unknown]
