### PR TITLE
Support alpha and color test masks on desktop/gles3

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1048,7 +1048,7 @@ void DIRECTX9_GPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_COLORTEST:
 	case GE_CMD_COLORTESTMASK:
 		if (diff)
-			shaderManager_->DirtyUniform(DIRTY_COLORMASK);
+			shaderManager_->DirtyUniform(DIRTY_ALPHACOLORMASK);
 		break;
 
 	case GE_CMD_ALPHATEST:

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -157,7 +157,7 @@ void GenerateFragmentShaderDX9(char *buffer) {
 
 	if (enableAlphaTest || enableColorTest) {
 		WRITE(p, "float4 u_alphacolorref;\n");
-		WRITE(p, "float4 u_colormask;\n");
+		WRITE(p, "float4 u_alphacolormask;\n");
 	}
 	if (gstate.isTextureMapEnabled()) 
 		WRITE(p, "float3 u_texenv;\n");

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -117,7 +117,7 @@ LinkedShaderDX9::LinkedShaderDX9(VSShader *vs, PSShader *fs, u32 vertType, bool 
 	u_fogcolor = 		GetConstantByName("u_fogcolor");
 	u_fogcoef = 		GetConstantByName("u_fogcoef");
 	u_alphacolorref = 	GetConstantByName("u_alphacolorref");
-	u_colormask = 		GetConstantByName("u_colormask");
+	u_alphacolormask = 	GetConstantByName("u_alphacolormask");
 
 	// Transform
 	u_view = 	GetConstantByName("u_view");
@@ -345,8 +345,8 @@ void LinkedShaderDX9::updateUniforms() {
 	if (u_alphacolorref != 0 && (dirtyUniforms & DIRTY_ALPHACOLORREF)) {
 		SetColorUniform3Alpha255(u_alphacolorref, gstate.getColorTestRef(), gstate.getAlphaTestRef());
 	}
-	if (u_colormask != 0 && (dirtyUniforms & DIRTY_COLORMASK)) {
-		SetColorUniform3(u_colormask, gstate.colormask);
+	if (u_alphacolormask != 0 && (dirtyUniforms & DIRTY_ALPHACOLORMASK)) {
+		SetColorUniform3(u_alphacolormask, gstate.colortestmask);
 	}
 	if (u_fogcolor != 0 && (dirtyUniforms & DIRTY_FOGCOLOR)) {
 		SetColorUniform3(u_fogcolor, gstate.fogcolor);

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -84,7 +84,7 @@ public:
 	
 	// Fragment processing inputs
 	D3DXHANDLE u_alphacolorref;
-	D3DXHANDLE u_colormask;
+	D3DXHANDLE u_alphacolormask;
 	D3DXHANDLE u_fogcolor;
 	D3DXHANDLE u_fogcoef;
 
@@ -117,7 +117,7 @@ enum
 	DIRTY_TEXENV		 = (1 << 4),
 	DIRTY_ALPHACOLORREF	 = (1 << 5),
 	DIRTY_COLORREF	 = (1 << 6),
-	DIRTY_COLORMASK	 = (1 << 7),
+	DIRTY_ALPHACOLORMASK	 = (1 << 7),
 	DIRTY_LIGHT0 = (1 << 8),
 	DIRTY_LIGHT1 = (1 << 9),
 	DIRTY_LIGHT2 = (1 << 10),

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -730,7 +730,7 @@ void GenerateFragmentShader(char *buffer) {
 						WRITE(p, "  if (v.a > 0.002) discard;\n");
 					}
 				} else if (bitwiseOps) {
-					WRITE(p, "  if ((roundAndScaleTo255i(v.a) & u_alphacolormask.a) %s (int(u_alphacolorref.a) & u_alphacolormask.a)) discard;\n", alphaTestFuncs[alphaTestFunc]);
+					WRITE(p, "  if ((roundAndScaleTo255i(v.a) & u_alphacolormask.a) %s int(u_alphacolorref.a)) discard;\n", alphaTestFuncs[alphaTestFunc]);
 				} else if (gl_extensions.gpuVendor == GPU_VENDOR_POWERVR) {
 					// Work around bad PVR driver problem where equality check + discard just doesn't work.
 					if (alphaTestFunc != GE_COMP_NOTEQUAL)

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -1084,15 +1084,12 @@ void GLES_GPU::Execute_FogCoef(u32 op, u32 diff) {
 }
 
 void GLES_GPU::Execute_ColorTestMask(u32 op, u32 diff) {
-	shaderManager_->DirtyUniform(DIRTY_COLORMASK);
+	shaderManager_->DirtyUniform(DIRTY_ALPHACOLORMASK);
 }
 
 void GLES_GPU::Execute_AlphaTest(u32 op, u32 diff) {
-#ifndef MOBILE_DEVICE
-	if (((op >> 16) & 0xFF) != 0xFF && (op & 7) > 1)
-		WARN_LOG_REPORT_ONCE(alphatestmask, G3D, "Unsupported alphatest mask: %02x", (op >> 16) & 0xFF);
-#endif
 	shaderManager_->DirtyUniform(DIRTY_ALPHACOLORREF);
+	shaderManager_->DirtyUniform(DIRTY_ALPHACOLORMASK);
 }
 
 void GLES_GPU::Execute_StencilTest(u32 op, u32 diff) {

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -390,7 +390,7 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 		SetColorUniform3(u_texenv, gstate.texenvcolor);
 	}
 	if (dirty & DIRTY_ALPHACOLORREF) {
-		SetColorUniform3Alpha255(u_alphacolorref, gstate.getColorTestRef(), gstate.getAlphaTestRef());
+		SetColorUniform3Alpha255(u_alphacolorref, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
 	}
 	if (dirty & DIRTY_ALPHACOLORMASK) {
 		SetColorUniform3iAlpha(u_alphacolormask, gstate.colortestmask, gstate.getAlphaTestMask());

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -145,7 +145,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	u_fogcolor = glGetUniformLocation(program, "u_fogcolor");
 	u_fogcoef = glGetUniformLocation(program, "u_fogcoef");
 	u_alphacolorref = glGetUniformLocation(program, "u_alphacolorref");
-	u_colormask = glGetUniformLocation(program, "u_colormask");
+	u_alphacolormask = glGetUniformLocation(program, "u_alphacolormask");
 	u_stencilReplaceValue = glGetUniformLocation(program, "u_stencilReplaceValue");
 
 	u_fbotex = glGetUniformLocation(program, "fbotex");
@@ -216,7 +216,7 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	if (u_proj_through != -1) availableUniforms |= DIRTY_PROJTHROUGHMATRIX;
 	if (u_texenv != -1) availableUniforms |= DIRTY_TEXENV;
 	if (u_alphacolorref != -1) availableUniforms |= DIRTY_ALPHACOLORREF;
-	if (u_colormask != -1) availableUniforms |= DIRTY_COLORMASK;
+	if (u_alphacolormask != -1) availableUniforms |= DIRTY_ALPHACOLORMASK;
 	if (u_fogcolor != -1) availableUniforms |= DIRTY_FOGCOLOR;
 	if (u_fogcoef != -1) availableUniforms |= DIRTY_FOGCOEF;
 	if (u_texenv != -1) availableUniforms |= DIRTY_TEXENV;
@@ -284,7 +284,7 @@ static void SetColorUniform3Alpha(int uniform, u32 color, u8 alpha) {
 static void SetColorUniform3Alpha255(int uniform, u32 color, u8 alpha) {
 	if (gl_extensions.gpuVendor == GPU_VENDOR_POWERVR) {
 		const float col[4] = {
-			(float)((color & 0xFF)) * (1.0f / 255.0f),
+			(float)((color & 0xFF) >> 0) * (1.0f / 255.0f),
 			(float)((color & 0xFF00) >> 8) * (1.0f / 255.0f),
 			(float)((color & 0xFF0000) >> 16) * (1.0f / 255.0f),
 			(float)alpha * (1.0f / 255.0f)
@@ -292,13 +292,23 @@ static void SetColorUniform3Alpha255(int uniform, u32 color, u8 alpha) {
 		glUniform4fv(uniform, 1, col);
 	} else {
 		const float col[4] = {
-			(float)((color & 0xFF)) ,
-			(float)((color & 0xFF00) >> 8) ,
-			(float)((color & 0xFF0000) >> 16) ,
+			(float)((color & 0xFF) >> 0),
+			(float)((color & 0xFF00) >> 8),
+			(float)((color & 0xFF0000) >> 16),
 			(float)alpha 
 		};
 		glUniform4fv(uniform, 1, col);
 	}
+}
+
+static void SetColorUniform3iAlpha(int uniform, u32 color, u8 alpha) {
+	const int col[4] = {
+		(color & 0xFF) >> 0,
+		(color & 0xFF00) >> 8,
+		(color & 0xFF0000) >> 16,
+		alpha,
+	};
+	glUniform4iv(uniform, 1, col);
 }
 
 static void SetColorUniform3ExtraFloat(int uniform, u32 color, float extra) {
@@ -382,8 +392,8 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 	if (dirty & DIRTY_ALPHACOLORREF) {
 		SetColorUniform3Alpha255(u_alphacolorref, gstate.getColorTestRef(), gstate.getAlphaTestRef());
 	}
-	if (dirty & DIRTY_COLORMASK) {
-		SetColorUniform3(u_colormask, gstate.colormask);
+	if (dirty & DIRTY_ALPHACOLORMASK) {
+		SetColorUniform3iAlpha(u_alphacolormask, gstate.colortestmask, gstate.getAlphaTestMask());
 	}
 	if (dirty & DIRTY_FOGCOLOR) {
 		SetColorUniform3(u_fogcolor, gstate.fogcolor);

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -81,7 +81,7 @@ public:
 
 	// Fragment processing inputs
 	int u_alphacolorref;
-	int u_colormask;
+	int u_alphacolormask;
 	int u_fogcolor;
 	int u_fogcoef;
 
@@ -119,7 +119,7 @@ enum
 	// 1 << 6 is free! Wait, not anymore...
 	DIRTY_STENCILREPLACEVALUE = (1 << 6),
 
-	DIRTY_COLORMASK	 = (1 << 7),
+	DIRTY_ALPHACOLORMASK = (1 << 7),
 	DIRTY_LIGHT0 = (1 << 8),
 	DIRTY_LIGHT1 = (1 << 9),
 	DIRTY_LIGHT2 = (1 << 10),

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -183,7 +183,7 @@ struct GPUgstate
 				maxz,
 				colortest,
 				colorref,
-				colormask,
+				colortestmask,
 				alphatest,
 				stenciltest,
 				stencilop,
@@ -284,7 +284,7 @@ struct GPUgstate
 	bool isColorTestEnabled() const { return colorTestEnable & 1; }
 	GEComparison getColorTestFunction() { return static_cast<GEComparison>(colortest & 0x3); }
 	u32 getColorTestRef() const { return colorref & 0xFFFFFF; }
-	u32 getColorTestMask() const { return colormask & 0xFFFFFF; }
+	u32 getColorTestMask() const { return colortestmask & 0xFFFFFF; }
 
 	// Texturing
 	// TODO: Verify getTextureAddress() alignment?

--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -343,7 +343,7 @@ CtrlMatrixList::CtrlMatrixList(HWND hwnd)
 }
 
 void CtrlMatrixList::GetColumnText(wchar_t *dest, int row, int col) {
-	if (row < 0 || row >= MATRIXLIST_ROW_COUNT || col < 0 || col >= MATRIXLIST_COL_COUNT) {
+	if (!gpuDebug || row < 0 || row >= MATRIXLIST_ROW_COUNT || col < 0 || col >= MATRIXLIST_COL_COUNT) {
 		wcscpy(dest, L"Invalid");
 		return;
 	}


### PR DESCRIPTION
May help #3468 or possibly other issues.  Has a small performance impact but should only be for non-zero alphatests.

Some games possibly using it for alpha tests:
http://report.ppsspp.org/logs/kind/96?status=any

If I read correctly, GLSL 1.30 on desktop is where you can first use bitwise ops.

-[Unknown]
