### PR TITLE
Oops, restore the deleted stencil test option since we haven't decided its fate yet.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -234,6 +234,9 @@ void GameSettingsScreen::CreateViews() {
 	alphaHackEnable = !g_Config.bSoftwareRendering;
 	alphaHack->SetEnabledPtr(&alphaHackEnable);
 
+	CheckBox *stencilTest = graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gs->T("Disable Stencil Test")));
+	stencilTestEnable = !g_Config.bSoftwareRendering;
+	stencilTest->SetEnabledPtr(&stencilTestEnable);
 
 	CheckBox *depthWrite = graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gs->T("Always Depth Write")));
 	depthWriteEnable = !g_Config.bSoftwareRendering;


### PR DESCRIPTION
Removal of this was an accident.
