### PR TITLE
Fix #6353

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -408,6 +408,7 @@ static ConfigSetting soundSettings[] = {
 	ConfigSetting("VolumeBGM", &g_Config.iBGMVolume, 7),
 	ConfigSetting("VolumeSFX", &g_Config.iSFXVolume, 7),
 	ConfigSetting("AudioLatency", &g_Config.IaudioLatency, 1),
+	ConfigSetting("SoundSpeedHack", &g_Config.bSoundSpeedHack, false),
 
 	ConfigSetting(false),
 };


### PR DESCRIPTION
This fixes #6353 (Sound Speed Hack setting is not saved after exiting PPSSPP).

This also my first ever pull request on Github for PPSSPP, so do advise if something is not done correctly, @hrydgard 
