### PR TITLE
Upload stencil/color on FBO create, clear depth/stencil to 0, fix software transform

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -179,9 +179,9 @@ void FramebufferManager::ClearBuffer() {
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClearStencil(0xFF);
 #ifdef USING_GLES2
-	glClearDepthf(1.0f);
+	glClearDepthf(0.0f);
 #else
-	glClearDepth(1.0);
+	glClearDepth(0.0);
 #endif
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 }
@@ -190,9 +190,9 @@ void FramebufferManager::ClearDepthBuffer() {
 	glstate.scissorTest.disable();
 	glstate.depthWrite.set(GL_TRUE);
 #ifdef USING_GLES2
-	glClearDepthf(1.0f);
+	glClearDepthf(0.0f);
 #else
-	glClearDepth(1.0);
+	glClearDepth(0.0);
 #endif
 	glClear(GL_DEPTH_BUFFER_BIT);
 }

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -70,8 +70,7 @@ static const char tex_fs[] =
 	"uniform sampler2D sampler0;\n"
 	"varying vec2 v_texcoord0;\n"
 	"void main() {\n"
-	"  gl_FragColor.rgb = texture2D(sampler0, v_texcoord0).rgb;\n"
-	"  gl_FragColor.a = 1.0;\n"
+	"  gl_FragColor = texture2D(sampler0, v_texcoord0);\n"
 	"}\n";
 
 static const char basic_vs[] =

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -175,9 +175,9 @@ void FramebufferManager::ClearBuffer() {
 	glstate.scissorTest.disable();
 	glstate.depthWrite.set(GL_TRUE);
 	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glstate.stencilFunc.set(GL_ALWAYS, 0xFF, 0xFF);
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glClearStencil(0xFF);
+	glstate.stencilFunc.set(GL_ALWAYS, 0, 0);
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glClearStencil(0);
 #ifdef USING_GLES2
 	glClearDepthf(0.0f);
 #else

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -251,6 +251,7 @@ private:
 	void EstimateDrawingSize(int &drawing_width, int &drawing_height);
 	static void DisableState();
 	static void ClearBuffer();
+	static void ClearDepthBuffer();
 	static bool MaskedEqual(u32 addr1, u32 addr2);
 
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer) {

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -213,6 +213,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				Vec3ByMatrix43(out, pos, gstate.worldMatrix);
 				if (reader.hasNormal()) {
 					reader.ReadNrm(normal.AsArray());
+					if (gstate.areNormalsReversed()) {
+						normal = -normal;
+					}
 					Norm3ByMatrix43(worldnormal.AsArray(), normal.AsArray(), gstate.worldMatrix);
 					worldnormal = worldnormal.Normalized();
 				}
@@ -242,7 +245,10 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 				Vec3ByMatrix43(out, psum.AsArray(), gstate.worldMatrix);
 				if (reader.hasNormal()) {
 					normal = nsum;
-					Norm3ByMatrix43(worldnormal.AsArray(), nsum.AsArray(), gstate.worldMatrix);
+					if (gstate.areNormalsReversed()) {
+						normal = -normal;
+					}
+					Norm3ByMatrix43(worldnormal.AsArray(), normal.AsArray(), gstate.worldMatrix);
 					worldnormal = worldnormal.Normalized();
 				}
 			}

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -88,6 +88,7 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 
 	shaderManager_->DirtyLastShader();
 
+	// TODO: Check if it's all the same value, commonly 0?
 	MakePixelTexture(Memory::GetPointer(addr), dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight);
 	DisableState();
 	glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);


### PR DESCRIPTION
Forcing a to 1.0 in DrawPixels() was a problem with blending a long time ago.  It's better to upload the actual alpha, e.g. for block transfers.  Would actually like to upload stencil but I have a feeling performance will be horrible in some games.

Also fixes normal handling in software transform to match hardware transform better.

Then I went ahead and cleared the stencil and depth to 0, except on FBO creation where it uploads.  I'm hoping this doesn't cause any glitches... it may theoretically help "read framebuffers to memory" since it will destroy texture data a tiny bit less often.

Hexyz Force (#4719) still works already, no replacements needed, so something may already be catching it or the upload on create is.

-[Unknown]
