### PR TITLE
sceDisplayGetVcount should apparently reschedule. Fixes #3234.

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -905,6 +905,7 @@ u32 sceDisplayGetVcount() {
 	VERBOSE_LOG(SCEDISPLAY,"%i=sceDisplayGetVcount()", vCount);
 
 	hleEatCycles(150);
+	hleReSchedule("get vcount");
 	return vCount;
 }
 


### PR DESCRIPTION
We might want to test a bit before doing this, but it fixes https://github.com/hrydgard/ppsspp/issues/3234, at least for me. @unknownbrackets: Is there any way to get JPCSPTrace to tell us if a function reschedules or not?
