### PR TITLE
Fix deadlock when using cpu and ge debuggers at the same time

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -83,7 +83,7 @@ void MemCheck::JitCleanup()
 
 	// Here's the tricky part: would this have changed memory?
 	// Note that it did not actually get written.
-	bool changed = MIPSAnalyst::OpWouldChangeMemory(lastPC, lastAddr);
+	bool changed = MIPSAnalyst::OpWouldChangeMemory(lastPC, lastAddr, lastSize);
 	if (changed)
 	{
 		++numHits;

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -413,9 +413,9 @@ void CBreakPoints::Update(u32 addr)
 		
 		// In case this is a delay slot, clear the previous instruction too.
 		if (addr != 0)
-			MIPSComp::jit->ClearCacheAt(addr - 4, 8);
+			MIPSComp::jit->InvalidateCacheAt(addr - 4, 8);
 		else
-			MIPSComp::jit->ClearCache();
+			MIPSComp::jit->InvalidateCache();
 
 		if (resume)
 			Core_EnableStepping(false);

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -407,7 +407,7 @@ void CBreakPoints::Update(u32 addr)
 		if (Core_IsStepping() == false)
 		{
 			Core_EnableStepping(true);
-			Core_WaitInactive();
+			Core_WaitInactive(200);
 			resume = true;
 		}
 		

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -538,7 +538,7 @@ void CallSyscall(MIPSOpcode op)
 			CallSyscallWithoutFlags(info);
 	}
 	else
-		ERROR_LOG_REPORT(HLE, "Unimplemented HLE function %s", info->name ? info->name : "(???)");
+		ERROR_LOG_REPORT(HLE, "Unimplemented HLE function %s", info->name ? info->name : "(\?\?\?)");
 
 	if (g_Config.bShowDebugStats)
 	{

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -364,11 +364,8 @@ int sceKernelDcacheInvalidateRange(u32 addr, int size)
 }
 
 int sceKernelIcacheInvalidateRange(u32 addr, int size) {
-	DEBUG_LOG(CPU,"sceKernelIcacheInvalidateRange(%08x, %i)", addr, size);
-	// TODO: Make the JIT hash and compare the touched blocks.
-	if(MIPSComp::jit){
-		MIPSComp::jit->ClearCacheAt(addr, size);
-	}
+	DEBUG_LOG(CPU, "sceKernelIcacheInvalidateRange(%08x, %i)", addr, size);
+	currentMIPS->InvalidateICache(addr, size);
 	return 0;
 }
 

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -146,7 +146,12 @@ void Jit::ClearCache()
 	GenerateFixedCode();
 }
 
-void Jit::ClearCacheAt(u32 em_address, int length)
+void Jit::InvalidateCache()
+{
+	blocks.Clear();
+}
+
+void Jit::InvalidateCacheAt(u32 em_address, int length)
 {
 	blocks.InvalidateICache(em_address, length);
 }

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -178,7 +178,8 @@ public:
 	JitBlockCache *GetBlockCache() { return &blocks; }
 
 	void ClearCache();
-	void ClearCacheAt(u32 em_address, int length = 4);
+	void InvalidateCache();
+	void InvalidateCacheAt(u32 em_address, int length = 4);
 
 	void EatPrefix() { js.EatPrefix(); }
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -328,5 +328,5 @@ u32 MIPSState::ReadFCR(int reg) {
 void MIPSState::InvalidateICache(u32 address, int length) {
 	// Only really applies to jit.
 	if (MIPSComp::jit)
-		MIPSComp::jit->ClearCacheAt(address, length);
+		MIPSComp::jit->InvalidateCacheAt(address, length);
 }

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -127,7 +127,7 @@ namespace MIPSAnalyst
 	bool IsDelaySlotNiceFPU(MIPSOpcode branchOp, MIPSOpcode op);
 	bool IsSyscall(MIPSOpcode op);
 
-	bool OpWouldChangeMemory(u32 pc, u32 addr);
+	bool OpWouldChangeMemory(u32 pc, u32 addr, u32 size);
 
 	void Shutdown();
 	

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -133,7 +133,7 @@ namespace MIPSInt
 		case 8:
 			// Invalidate the instruction cache at this address
 			if (MIPSComp::jit) {
-				MIPSComp::jit->ClearCacheAt(addr, 0x40);
+				MIPSComp::jit->InvalidateCacheAt(addr, 0x40);
 			}
 			break;
 

--- a/Core/MIPS/PPC/PpcJit.cpp
+++ b/Core/MIPS/PPC/PpcJit.cpp
@@ -217,7 +217,11 @@ void Jit::ClearCache() {
 	GenerateFixedCode();
 }
 
-void Jit::ClearCacheAt(u32 em_address, int length) {
+void Jit::InvalidateCache() {
+	blocks.Clear();
+}
+
+void Jit::InvalidateCacheAt(u32 em_address, int length) {
 	blocks.InvalidateICache(em_address, length);
 }
 

--- a/Core/MIPS/PPC/PpcJit.h
+++ b/Core/MIPS/PPC/PpcJit.h
@@ -286,7 +286,8 @@ namespace MIPSComp
 		void WriteSyscallExit();
 
 		void ClearCache();
-		void ClearCacheAt(u32 em_address, int length = 4);
+		void InvalidateCache();
+		void InvalidateCacheAt(u32 em_address, int length = 4);
 
 		void RunLoopUntil(u64 globalticks);
 		void GenerateFixedCode();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -218,7 +218,12 @@ void Jit::ClearCache()
 	ClearCodeSpace();
 }
 
-void Jit::ClearCacheAt(u32 em_address, int length)
+void Jit::InvalidateCache()
+{
+	blocks.Clear();
+}
+
+void Jit::InvalidateCacheAt(u32 em_address, int length)
 {
 	blocks.InvalidateICache(em_address, length);
 }

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -168,7 +168,8 @@ public:
 	AsmRoutineManager &Asm() { return asm_; }
 
 	void ClearCache();
-	void ClearCacheAt(u32 em_address, int length = 4);
+	void InvalidateCache();
+	void InvalidateCacheAt(u32 em_address, int length = 4);
 
 private:
 	void GetStateAndFlushAll(RegCacheState &state);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2094,7 +2094,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 		const u32 vfb_size = FramebufferByteSize(vfb);
 		const u32 vfb_bpp = vfb->format == GE_FORMAT_8888 ? 4 : 2;
 		const u32 vfb_byteStride = vfb->fb_stride * vfb_bpp;
-		const u32 vfb_byteWidth = vfb->width * vfb_bpp;
+		const int vfb_byteWidth = vfb->width * vfb_bpp;
 
 		if (dst >= vfb_address && (dst + size <= vfb_address + vfb_size || dst == vfb_address)) {
 			const u32 offset = dst - vfb_address;

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -50,10 +50,6 @@ static const char *stencil_vs =
 "  gl_Position = a_position;\n"
 "}\n";
 
-static bool MaskedEqual(u32 addr1, u32 addr2) {
-	return (addr1 & 0x03FFFFFF) == (addr2 & 0x03FFFFFF);
-}
-
 bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 	if (!MayIntersectFramebuffer(addr)) {
 		return false;
@@ -110,6 +106,9 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 		break;
 	case GE_FORMAT_8888:
 		values = 256;
+		break;
+	case GE_FORMAT_INVALID:
+		// Impossible.
 		break;
 	}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1083,7 +1083,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 		gstate_c.flipTexture = true;
 		gstate_c.curTextureXOffset = fbTexInfo_[entry->addr].xOffset;
 		gstate_c.curTextureYOffset = fbTexInfo_[entry->addr].yOffset;
-		gstate_c.needShaderTexClamp = gstate_c.curTextureWidth != gstate.getTextureWidth(0) || gstate_c.curTextureHeight != gstate.getTextureHeight(0);
+		gstate_c.needShaderTexClamp = gstate_c.curTextureWidth != (u32)gstate.getTextureWidth(0) || gstate_c.curTextureHeight != (u32)gstate.getTextureHeight(0);
 		if (gstate_c.curTextureXOffset != 0 || gstate_c.curTextureYOffset != 0) {
 			gstate_c.needShaderTexClamp = true;
 		}

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -298,7 +298,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 		Memory::Write_U32(encoded, address);
 		// In case this is a delay slot or combined instruction, clear cache above it too.
 		if (MIPSComp::jit)
-			MIPSComp::jit->ClearCacheAt(address - 4, 8);
+			MIPSComp::jit->InvalidateCacheAt(address - 4, 8);
 		scanFunctions();
 
 		if (address == curAddress)


### PR DESCRIPTION
I think invalidate is safe to call whenever.  Could check if GE is paused rather than using a timeout, I suppose, but if the cpu has hung probably better to eventually resume anyway.

-[Unknown]
