### PR TITLE
Fix func replacements and delay slots on arm

### DIFF
--- a/Core/MIPS/ARM/ArmCompReplace.cpp
+++ b/Core/MIPS/ARM/ArmCompReplace.cpp
@@ -26,7 +26,7 @@ namespace MIPSComp {
 int Jit::Replace_fabsf() {
 	fpr.MapDirtyIn(0, 12);
 	VABS(fpr.R(0), fpr.R(12));
-	return 6;  // Number of instructions in the MIPS function
+	return 4;  // Number of instructions in the MIPS function
 }
 
 }


### PR DESCRIPTION
Fixes #6303.  Pretty sure it needs js.compilerPC += 4; to not execute the delay slot twice.

Also match the x86 jit in doing a call early too.

-[Unknown]
