### PR TITLE
Stringify the PSP dialogs.

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -192,13 +192,12 @@ bool PSPDialog::IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThr
 	return false;
 }
 
-void PSPDialog::DisplayButtons(int flags, const char *caption)
+void PSPDialog::DisplayButtons(int flags, const std::string &caption)
 {
 	bool useCaption = false;
-	char safeCaption[65] = {0};
-	if (caption != NULL && *caption != '\0') {
+
+	if (!caption.empty()) {
 		useCaption = true;
-		strncpy(safeCaption, caption, 64);
 	}
 
 	I18NCategory *d = GetI18NCategory("Dialog");
@@ -208,14 +207,14 @@ void PSPDialog::DisplayButtons(int flags, const char *caption)
 		x2 = 183.5f;
 	}
 	if (flags & DS_BUTTON_OK) {
-		const char *text = useCaption ? safeCaption : d->T("Enter");
+		std::string text = useCaption ? caption : d->T("Enter");
 		PPGeDrawImage(okButtonImg, x2, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));
 		PPGeDrawImage(okButtonImg, x2, 256, 11.5f, 11.5f, 0, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawText(text, x2 + 15.5f, 254, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(text, x2 + 14.5f, 252, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
 	}
 	if (flags & DS_BUTTON_CANCEL) {
-		const char *text = useCaption ? safeCaption : d->T("Back");
+		std::string text = useCaption ? caption : d->T("Back");
 		PPGeDrawText(text, x1 + 15.5f, 254, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
 		PPGeDrawText(text, x1 + 14.5f, 252, PPGE_ALIGN_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
 		PPGeDrawImage(cancelButtonImg, x1, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
@@ -82,7 +84,7 @@ protected:
 	bool IsButtonPressed(int checkButton);
 	bool IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold = 30, int framesHeldRepeatRate = 10);
 	// The caption override is assumed to have a size of 64 bytes.
-	void DisplayButtons(int flags, const char *caption = NULL);
+	void DisplayButtons(int flags, const std::string &caption = "");
 	void ChangeStatus(DialogStatus newStatus, int delayUs);
 	void ChangeStatusInit(int delayUs);
 	void ChangeStatusShutdown(int delayUs);

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -135,7 +135,7 @@ int PSPGamedataInstallDialog::Shutdown(bool force) {
 	return PSPDialog::Shutdown();
 }
 
-std::string PSPGamedataInstallDialog::GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, std::string filename){
+std::string PSPGamedataInstallDialog::GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, const std::string &filename) {
 	if (!param)
 		return "";
 	std::string GameDataInstallPath = saveBasePath + param->gameName + param->dataName + "/";

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -47,7 +47,7 @@ public:
 	virtual void DoState(PointerWrap &p);
 
 	int Abort();
-	std::string GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, std::string filename);
+	std::string GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, const std::string &filename);
 
 private:
 	SceUtilityGamedataInstallParam request;

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -140,7 +140,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr) {
 	return 0;
 }
 
-void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
+void PSPMsgDialog::DisplayMessage(const std::string &text, bool hasYesNo, bool hasOK)
 {
 	float WRAP_WIDTH = 300.0f;
 	if (UTF8StringNonASCIICount(text.c_str()) > 3)
@@ -248,10 +248,10 @@ int PSPMsgDialog::Update(int animSpeed) {
 			DisplayMessage(msgText, (flag & DS_YESNO) != 0, (flag & DS_OK) != 0);
 
 		if (flag & (DS_OK | DS_VALIDBUTTON)) 
-			DisplayButtons(DS_BUTTON_OK, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.okayButton : NULL);
+			DisplayButtons(DS_BUTTON_OK, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.okayButton : "");
 
 		if (flag & DS_CANCELBUTTON)
-			DisplayButtons(DS_BUTTON_CANCEL, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.cancelButton : NULL);
+			DisplayButtons(DS_BUTTON_CANCEL, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.cancelButton : "");
 
 		if (IsButtonPressed(cancelButtonFlag) && (flag & DS_CANCELBUTTON))
 		{

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -73,7 +73,7 @@ protected:
 	}
 
 private :
-	void DisplayMessage(std::string text, bool hasYesNo = false, bool hasOK = false);
+	void DisplayMessage(const std::string &text, bool hasYesNo = false, bool hasOK = false);
 
 	enum Flags
 	{

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -15,9 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <string>
+
 #include "i18n/i18n.h"
 
 #include "Common/ChunkFile.h"
+#include "Common/StringUtils.h"
 
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Util/PPGeDraw.h"
@@ -385,123 +388,122 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 		I18NCategory *d = GetI18NCategory("Dialog");
 		PPGeDrawText(d->T("NEW DATA"), 180, 136, PPGE_ALIGN_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
 	} else {
-		char title[512];
-		char time[512];
-		char saveTitle[512];
-		char saveDetail[512];
+		std::string title;
+		std::string time;
+		std::string saveTitle;
+		std::string saveDetail;
 
-		char am_pm[] = "AM";
-		char hour_time[10] ;
+		std::string am_pm = "AM";
+		std::string hour_time;
 		int hour = param.GetFileInfo(currentSelectedSave).modif_time.tm_hour;
 		int min  = param.GetFileInfo(currentSelectedSave).modif_time.tm_min;
+
 		switch (g_Config.iTimeFormat) {
 		case 1:
 			if (hour > 12) {
-				strcpy(am_pm, "PM");
+				am_pm = "PM";
 				hour -= 12;
 			}
-			snprintf(hour_time,10,"%02d:%02d %s", hour, min, am_pm);
+			hour_time = StringFromFormat("%02d:%02d %s", hour, min, am_pm.c_str());
 			break;
 		case 2:
-			snprintf(hour_time,10,"%02d:%02d", hour, min); 
+			hour_time = StringFromFormat("%02d:%02d", hour, min); 
 			break;
 		default:
 			if (hour > 12) {
-				strcpy(am_pm, "PM");
+				am_pm = "PM";
 				hour -= 12;
 			}
-			snprintf(hour_time,10,"%02d:%02d %s", hour, min, am_pm);
+			hour_time = StringFromFormat("%02d:%02d %s", hour, min, am_pm.c_str());
 		}
 
-		snprintf(title, 512, "%s", param.GetFileInfo(currentSelectedSave).title);
+		title = param.GetFileInfo(currentSelectedSave).title;
 		int day   = param.GetFileInfo(currentSelectedSave).modif_time.tm_mday;
 		int month = param.GetFileInfo(currentSelectedSave).modif_time.tm_mon + 1;
 		int year  = param.GetFileInfo(currentSelectedSave).modif_time.tm_year + 1900;
 		s64 sizeK = param.GetFileInfo(currentSelectedSave).size / 1024;
+
 		switch (g_Config.iDateFormat) {
 		case 1:
-			snprintf(time, 512, "%d/%02d/%02d   %s  %lld KB", year, month, day, hour_time, sizeK);
+			time = StringFromFormat("%d/%02d/%02d   %s  %lld KB", year, month, day, hour_time, sizeK);
 			break;
 		case 2:
-			snprintf(time, 512, "%02d/%02d/%d   %s  %lld KB", month, day, year, hour_time, sizeK);
+			time = StringFromFormat("%02d/%02d/%d   %s  %lld KB", month, day, year, hour_time, sizeK);
 			break;
 		case 3:
-			snprintf(time, 512, "%02d/%02d/%d   %s  %lld KB", day, month, year, hour_time, sizeK);
+			time = StringFromFormat("%02d/%02d/%d   %s  %lld KB", day, month, year, hour_time, sizeK);
 			break;
 		default:
-			snprintf(time, 512, "%d/%02d/%02d   %s  %lld KB", year, month, day, hour_time, sizeK);
+			time = StringFromFormat("%d/%02d/%02d   %s  %lld KB", year, month, day, hour_time, sizeK);
 		}
-		snprintf(saveTitle, 512, "%s", param.GetFileInfo(currentSelectedSave).saveTitle);
-		snprintf(saveDetail, 512, "%s", param.GetFileInfo(currentSelectedSave).saveDetail);
+
+		saveTitle = param.GetFileInfo(currentSelectedSave).saveTitle;
+		saveDetail = param.GetFileInfo(currentSelectedSave).saveDetail;
 		
 		PPGeDrawRect(180, 136, 480, 137, CalcFadedColor(0xFFFFFFFF));
-		std::string titleTxt = title;
-		std::string timeTxt = time;
-		std::string saveTitleTxt = saveTitle;
-		std::string saveDetailTxt = saveDetail;
 
-		PPGeDrawText(titleTxt.c_str(), 181, 138, PPGE_ALIGN_BOTTOM, 0.6f, CalcFadedColor(0x80000000));
-		PPGeDrawText(titleTxt.c_str(), 180, 136, PPGE_ALIGN_BOTTOM, 0.6f, CalcFadedColor(0xFFC0C0C0));
-		PPGeDrawText(timeTxt.c_str(), 181, 139, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
-		PPGeDrawText(timeTxt.c_str(), 180, 137, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(saveTitleTxt.c_str(), 176, 162, PPGE_ALIGN_LEFT, 0.55f, CalcFadedColor(0x80000000));
-		PPGeDrawText(saveTitleTxt.c_str(), 175, 159, PPGE_ALIGN_LEFT, 0.55f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(saveDetailTxt.c_str(), 176, 183, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
-		PPGeDrawText(saveDetailTxt.c_str(), 175, 181, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(title, 181, 138, PPGE_ALIGN_BOTTOM, 0.6f, CalcFadedColor(0x80000000));
+		PPGeDrawText(title, 180, 136, PPGE_ALIGN_BOTTOM, 0.6f, CalcFadedColor(0xFFC0C0C0));
+		PPGeDrawText(time, 181, 139, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
+		PPGeDrawText(time, 180, 137, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(saveTitle, 176, 162, PPGE_ALIGN_LEFT, 0.55f, CalcFadedColor(0x80000000));
+		PPGeDrawText(saveTitle, 175, 159, PPGE_ALIGN_LEFT, 0.55f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(saveDetail, 176, 183, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
+		PPGeDrawText(saveDetail, 175, 181, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 	}
 }
 
 void PSPSaveDialog::DisplaySaveDataInfo2()
 {
-	if (param.GetFileInfo(currentSelectedSave).size == 0) {		
-	} else {
-		char txt[1024];
-		char date[256];
-		char am_pm[] = "AM";
-		char hour_time[10] ;
+	if (param.GetFileInfo(currentSelectedSave).size != 0) {
+		std::string saveinfo;
+		std::string date;
+		std::string am_pm = "AM";
+		std::string hour_time;
 		int hour = param.GetFileInfo(currentSelectedSave).modif_time.tm_hour;
 		int min  = param.GetFileInfo(currentSelectedSave).modif_time.tm_min;
+
 		switch (g_Config.iTimeFormat) {
 		case 1:
 			if (hour > 12) {
-				strcpy(am_pm, "PM");
+				am_pm = "PM";
 				hour -= 12;
 			}
-			snprintf(hour_time,10,"%02d:%02d %s", hour, min, am_pm);
+			hour_time = StringFromFormat("%02d:%02d %s", hour, min, am_pm.c_str());
 			break;
 		case 2:
-			snprintf(hour_time,10,"%02d:%02d", hour, min); 
+			hour_time = StringFromFormat("%02d:%02d", hour, min); 
 			break;
 		default:
 			if (hour > 12) {
-				strcpy(am_pm, "PM");
+				am_pm = "PM";
 				hour -= 12;
 			}
-			snprintf(hour_time,10,"%02d:%02d %s", hour, min, am_pm);
+			hour_time = StringFromFormat("%02d:%02d %s", hour, min, am_pm.c_str());
 		}
 
-		const char *saveTitle = param.GetFileInfo(currentSelectedSave).saveTitle;
+		std::string saveTitle = param.GetFileInfo(currentSelectedSave).saveTitle;
 		int day   = param.GetFileInfo(currentSelectedSave).modif_time.tm_mday;
 		int month = param.GetFileInfo(currentSelectedSave).modif_time.tm_mon + 1;
 		int year  = param.GetFileInfo(currentSelectedSave).modif_time.tm_year + 1900;
 		s64 sizeK = param.GetFileInfo(currentSelectedSave).size / 1024;
 		switch (g_Config.iDateFormat) {
 		case 1:
-			snprintf(date, 256, "%d/%02d/%02d", year, month, day);
+			date = StringFromFormat("%d/%02d/%02d", year, month, day);
 			break;
 		case 2:
-			snprintf(date, 256, "%02d/%02d/%d", month, day, year);
+			date = StringFromFormat("%02d/%02d/%d", month, day, year);
 			break;
 		case 3:
-			snprintf(date, 256, "%02d/%02d/%d", day, month, year);
+			date = StringFromFormat("%02d/%02d/%d", day, month, year);
 			break;
 		default:
-			snprintf(date, 256, "%d/%02d/%02d", year, month, day);
+			date = StringFromFormat("%d/%02d/%02d", year, month, day);
 		}
-		snprintf(txt, 1024, "%s\n%s  %s\n%lld KB", saveTitle, date, hour_time, sizeK);
-		std::string saveinfoTxt = txt;
-		PPGeDrawText(saveinfoTxt.c_str(), 9, 202, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
-		PPGeDrawText(saveinfoTxt.c_str(), 8, 200, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		saveinfo = StringFromFormat("%s\n%s  %s\n%lld KB", saveTitle.c_str(), date, hour_time, sizeK);
+
+		PPGeDrawText(saveinfo, 9, 202, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0x80000000));
+		PPGeDrawText(saveinfo, 8, 200, PPGE_ALIGN_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
 	}
 }
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <algorithm>
+#include <string>
 
 #include "image/zim_load.h"
 #include "image/png_load.h"
@@ -356,7 +357,7 @@ static const AtlasChar *PPGeGetChar(const AtlasFont &atlasfont, unsigned int cva
 }
 
 // Break a single text string into mutiple lines.
-static AtlasTextMetrics BreakLines(const char *text, const AtlasFont &atlasfont, float x, float y, 
+static AtlasTextMetrics BreakLines(const std::string& text, const AtlasFont &atlasfont, float x, float y, 
 									int align, float scale, int wrapType, float wrapWidth, bool dryRun)
 {
 	y += atlasfont.ascend * scale;
@@ -380,7 +381,7 @@ static AtlasTextMetrics BreakLines(const char *text, const AtlasFont &atlasfont,
 	int numLines = 1;
 	float maxw = 0;
 	float lineHeight = atlasfont.height * scale;
-	for (UTF8 utf(text); !utf.end(); )
+	for (UTF8 utf(text.c_str()); !utf.end(); )
 	{
 		float lineWidth = 0;
 		bool skipRest = false;
@@ -594,7 +595,7 @@ static AtlasTextMetrics BreakLines(const char *text, const AtlasFont &atlasfont,
 }
 
 void PPGeMeasureText(float *w, float *h, int *n, 
-					const char *text, float scale, int WrapType, int wrapWidth)
+					const std::string &text, float scale, int WrapType, int wrapWidth)
 {
 	const AtlasFont &atlasfont = *ppge_atlas.fonts[0];
 	AtlasTextMetrics metrics = BreakLines(text, atlasfont, 0, 0, 0, scale, WrapType, wrapWidth, true);
@@ -603,7 +604,7 @@ void PPGeMeasureText(float *w, float *h, int *n,
 	if (n) *n = metrics.numLines;
 }
 
-void PPGePrepareText(const char *text, float x, float y, int align, float scale, int WrapType, int wrapWidth)
+void PPGePrepareText(const std::string &text, float x, float y, int align, float scale, int WrapType, int wrapWidth)
 {
 	const AtlasFont &atlasfont = *ppge_atlas.fonts[0];
 	char_lines_metrics = BreakLines(text, atlasfont, x, y, align, scale, WrapType, wrapWidth, false);
@@ -647,13 +648,13 @@ void PPGeDrawCurrentText(u32 color)
 	char_lines_metrics = zeroBox;
 }
 
-void PPGeDrawText(const char *text, float x, float y, int align, float scale, u32 color)
+void PPGeDrawText(const std::string &text, float x, float y, int align, float scale, u32 color)
 {
 	PPGePrepareText(text, x, y, align, scale, PPGE_LINE_USE_ELLIPSIS);
 	PPGeDrawCurrentText(color);
 }
 
-void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, int align, float scale, u32 color)
+void PPGeDrawTextWrapped(const std::string &text, float x, float y, float wrapWidth, int align, float scale, u32 color)
 {
 	PPGePrepareText(text, x, y, align, scale, PPGE_LINE_USE_ELLIPSIS | PPGE_LINE_WRAP_WORD, wrapWidth);
 	PPGeDrawCurrentText(color);

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -77,10 +77,10 @@ enum {
 
 // Get the metrics of the bounding box of the text without changing the buffer or state.
 void PPGeMeasureText(float *w, float *h, int *n, 
-					const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
+					const std::string &text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
 // Overwrite the current text lines buffer so it can be drawn later.
-void PPGePrepareText(const char *text, float x, float y, int align, float scale, 
+void PPGePrepareText(const std::string &text, float x, float y, int align, float scale, 
 					int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
 // Get the metrics of the bounding box of the currently stated text.
@@ -94,8 +94,8 @@ void PPGeDrawCurrentText(u32 color = 0xFFFFFFFF);
 
 // Draws some text using the one font we have.
 // Clears the text buffer when done.
-void PPGeDrawText(const char *text, float x, float y, int align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
-void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, int align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
+void PPGeDrawText(const std::string &text, float x, float y, int align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
+void PPGeDrawTextWrapped(const std::string &text, float x, float y, float wrapWidth, int align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
 
 // Draws a "4-patch" for button-like things that can be resized.
 void PPGeDraw4Patch(int atlasImage, float x, float y, float w, float h, u32 color = 0xFFFFFFFF);


### PR DESCRIPTION
Gets rid of some verbose-ish C-string handling. Cleans up the const char\* -> std::string assignment done as well.

Also allows for passing strings directly to the draw calls so .c_str() isn't required anymore all the time. Just some tiny cleanup.
