### PR TITLE
Ridge Racer hack: Flush after every prim if fb addr == tex addr.

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -331,6 +331,11 @@ void TransformDrawEngine::SubmitPrim(void *verts, void *inds, GEPrimitiveType pr
 		DecodeVertsStep();
 		decodeCounter_++;
 	}
+
+	if (prim == GE_PRIM_RECTANGLES && (gstate.getTextureAddress(0) & 0x3FFFFFFF) == (gstate.getFrameBufAddress() & 0x3FFFFFFF)) {
+		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+		Flush();
+	}
 }
 
 void TransformDrawEngine::DecodeVerts() {


### PR DESCRIPTION
Fixes the bloom errors. @unknownbrackets discovered this method.

Not sure if I want to merge this.. It does add yet another check to a critical path.

@solarmystic, could you check the usual games? :)

Fixes #2919 .
