### PR TITLE
Eat cycles when context switching and delaying

### DIFF
--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -45,7 +45,7 @@ inline void WaitExecTimeout(SceUID threadID) {
 	}
 }
 
-// Move a thead from the waiting thread list to the paused thread list.
+// Move a thread from the waiting thread list to the paused thread list.
 // This version is for vectors which contain structs, which must have SceUID threadID and u64 pausedTimeout.
 // Should not be called directly.
 template <typename WaitInfoType, typename PauseType>

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1059,7 +1059,7 @@ void __KernelSleepEndCallback(SceUID threadID, SceUID prevCallbackId) {
 		DEBUG_LOG(SCEKERNEL, "sceKernelSleepThreadCB: resume from callback, wakeupCount decremented to %i", thread->nt.wakeupCount);
 		__KernelResumeThreadFromWait(threadID, 0);
 	} else {
-		DEBUG_LOG(SCEKERNEL, "sceKernelDelayThreadCB: Resuming sleep after callback");
+		DEBUG_LOG(SCEKERNEL, "sceKernelSleepThreadCB: Resuming sleep after callback");
 	}
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -3234,6 +3234,9 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 	}
 #endif
 
+	// Switching threads eats some cycles.  This is a low approximation.
+	currentMIPS->downcount -= 3000;
+
 	if (target)
 	{
 		// No longer waiting.

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -251,7 +251,6 @@ struct MipsCall {
 	u32 args[6];
 	int numArgs;
 	Action *doAfter;
-	u32 savedIdRegister;
 	u32 savedRa;
 	u32 savedPc;
 	u32 savedV0;

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -63,8 +63,6 @@ enum MIPSGPReg
 	MIPS_REG_FP=30,
 	MIPS_REG_RA=31,
 
-	// ID for mipscall "callback" is stored here - from JPCSP
-	MIPS_REG_CALL_ID=MIPS_REG_S0,
 	MIPS_REG_INVALID=-1,
 
 	// Not real regs, just for convenience/jit mapping.

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -897,8 +897,8 @@ namespace MIPSInt
 				if (F(fs) >= 0.0f) {
 					FsI(fd) = (int)floorf(F(fs));
 					// Overflow, but it was positive.
-					if (FsI(fd) == -2147483648) {
-						FsI(fd) = 2147483647;
+					if (FsI(fd) == -2147483648LL) {
+						FsI(fd) = 2147483647LL;
 					}
 				} else {
 					// Overflow happens to be the right value anyway.


### PR DESCRIPTION
Testing it carefully on a PSP, I found that I could not get any scheduling to happen in the <= 1us PPSSPP gave.  These changes make it take time, which fixes some issues I hit trying to improve callbacks.

This could affect timing and speed in some games, so it's probably good to test.  I want to do this before the other callback changes to be safe.

-[Unknown]
