### PR TITLE
Don't wake a killed list in ge callback end.

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -227,7 +227,9 @@ public:
 				if (newState != PSP_GE_DL_STATE_RUNNING)
 					DEBUG_LOG_REPORT(SCEGE, "GE Interrupt: newState might be %d", newState);
 
-				dl->state = PSP_GE_DL_STATE_RUNNING;
+				if (dl->state != PSP_GE_DL_STATE_NONE && dl->state != PSP_GE_DL_STATE_COMPLETED) {
+					dl->state = PSP_GE_DL_STATE_QUEUED;
+				}
 			}
 			break;
 		default:


### PR DESCRIPTION
Fixes #3198, some homebrew demos locking up.

I didn't find any games that hit this but I didn't test a ton.  I'm not sure if it might've been making something work before...

Could possibly help any of these:
http://report.ppsspp.org/logs/kind/63

-[Unknown]
