### PR TITLE
Fix function replacement hooks on arm

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -93,7 +93,7 @@ bool ElfReader::LoadRelocations(Elf32_Rel *rels, int numRelocs)
 			continue;
 		}
 
-		u32 op = Memory::Read_Instruction(addr).encoding;
+		u32 op = Memory::Read_Instruction(addr, true).encoding;
 
 		const bool log = false;
 		//log=true;
@@ -306,7 +306,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 				ERROR_LOG_REPORT(LOADER, "Rel2: invalid lo16 type! %x", flag);
 			}
 
-			op = Memory::Read_Instruction(rel_offset).encoding;
+			op = Memory::Read_Instruction(rel_offset, true).encoding;
 			DEBUG_LOG(LOADER, "Rel2: %5d: CMD=0x%04X flag=%x type=%d off_seg=%d offset=%08x addr_seg=%d op=%08x\n", rcount, cmd, flag, type, off_seg, rel_base, addr_seg, op);
 
 			switch(type){

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -473,7 +473,7 @@ void WriteVarSymbol(u32 exportAddress, u32 relocAddress, u8 type, bool reverse =
 	static std::vector<HI16RelocInfo> lastHI16Relocs;
 	static bool lastHI16Processed = true;
 
-	u32 relocData = Memory::Read_Instruction(relocAddress).encoding;
+	u32 relocData = Memory::Read_Instruction(relocAddress, true).encoding;
 
 	switch (type)
 	{
@@ -518,7 +518,7 @@ void WriteVarSymbol(u32 exportAddress, u32 relocAddress, u8 type, bool reverse =
 		// The R_MIPS_LO16 and R_MIPS_HI16 will often be *different* relocAddress values.
 		HI16RelocInfo reloc;
 		reloc.addr = relocAddress;
-		reloc.data = Memory::Read_Instruction(relocAddress).encoding;
+		reloc.data = Memory::Read_Instruction(relocAddress, true).encoding;
 		lastHI16Relocs.push_back(reloc);
 		lastHI16Processed = false;
 		break;

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -179,7 +179,7 @@ void Jit::CompileDelaySlot(int flags)
 		MRS(R8);  // Save flags register. R8 is preserved through function calls and is not allocated.
 
 	js.inDelaySlot = true;
-	MIPSOpcode op = Memory::Read_Instruction(js.compilerPC + 4);
+	MIPSOpcode op = Memory::Read_Opcode_JIT(js.compilerPC + 4);
 	MIPSCompileOp(op);
 	js.inDelaySlot = false;
 
@@ -275,7 +275,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	{
 		gpr.SetCompilerPC(js.compilerPC);  // Let it know for log messages
 		fpr.SetCompilerPC(js.compilerPC);
-		MIPSOpcode inst = Memory::Read_Instruction(js.compilerPC);
+		MIPSOpcode inst = Memory::Read_Opcode_JIT(js.compilerPC);
 		js.downcountAmount += MIPSGetInstructionCycleEstimate(inst);
 
 		MIPSCompileOp(inst);
@@ -315,7 +315,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		INFO_LOG(JIT, "=============== mips ===============");
 		for (u32 cpc = em_address; cpc != js.compilerPC + 4; cpc += 4) {
-			MIPSDisAsm(Memory::Read_Instruction(cpc), cpc, temp, true);
+			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp, true);
 			INFO_LOG(JIT, "M: %08x   %s", cpc, temp);
 		}
 	}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -506,7 +506,7 @@ namespace MIPSAnalyst {
 	}
 
 	bool OpWouldChangeMemory(u32 pc, u32 addr, u32 size) {
-		const auto op = Memory::Read_Instruction(pc);
+		const auto op = Memory::Read_Instruction(pc, true);
 
 		// TODO: Trap sc/ll, svl.q, svr.q?
 
@@ -574,7 +574,7 @@ namespace MIPSAnalyst {
 		}
 
 		for (u32 addr = address, endAddr = address + MAX_ANALYZE; addr <= endAddr; addr += 4) {
-			MIPSOpcode op = Memory::Read_Instruction(addr);
+			MIPSOpcode op = Memory::Read_Instruction(addr, true);
 			MIPSInfo info = MIPSGetInfo(op);
 
 			MIPSGPReg rs = MIPS_GET_RS(op);
@@ -639,7 +639,7 @@ namespace MIPSAnalyst {
 	// Don't think we use this yet.
 	bool IsRegisterUsed(MIPSGPReg reg, u32 addr) {
 		while (true) {
-			MIPSOpcode op = Memory::Read_Instruction(addr);
+			MIPSOpcode op = Memory::Read_Instruction(addr, true);
 			MIPSInfo info = MIPSGetInfo(op);
 			if ((info & IN_RS) && (MIPS_GET_RS(op) == reg))
 				return true;
@@ -736,7 +736,7 @@ skip:
 		u32 furthestJumpbackAddr = INVALIDTARGET;
 
 		for (u32 ahead = fromAddr; ahead < fromAddr + MAX_AHEAD_SCAN; ahead += 4) {
-			MIPSOpcode aheadOp = Memory::Read_Instruction(ahead);
+			MIPSOpcode aheadOp = Memory::Read_Instruction(ahead, true);
 			u32 target = GetBranchTargetNoRA(ahead, aheadOp);
 			if (target == INVALIDTARGET && ((aheadOp & 0xFC000000) == 0x08000000)) {
 				target = GetJumpTarget(ahead);
@@ -757,7 +757,7 @@ skip:
 
 		if (closestJumpbackAddr != INVALIDTARGET && furthestJumpbackAddr == INVALIDTARGET) {
 			for (u32 behind = closestJumpbackTarget; behind < fromAddr; behind += 4) {
-				MIPSOpcode behindOp = Memory::Read_Instruction(behind);
+				MIPSOpcode behindOp = Memory::Read_Instruction(behind, true);
 				u32 target = GetBranchTargetNoRA(behind, behindOp);
 				if (target == INVALIDTARGET && ((behindOp & 0xFC000000) == 0x08000000)) {
 					target = GetJumpTarget(behind);
@@ -812,7 +812,7 @@ skip:
 				continue;
 			}
 
-			MIPSOpcode op = Memory::Read_Instruction(addr);
+			MIPSOpcode op = Memory::Read_Instruction(addr, true);
 			u32 target = GetBranchTargetNoRA(addr, op);
 			if (target != INVALIDTARGET) {
 				isStraightLeaf = false;
@@ -835,7 +835,7 @@ skip:
 					// If it's a nearby forward jump, and not a stackless leaf, assume not a tail call.
 					if (sureTarget <= addr + MAX_JUMP_FORWARD && decreasedSp) {
 						// But let's check the delay slot.
-						MIPSOpcode op = Memory::Read_Instruction(addr + 4);
+						MIPSOpcode op = Memory::Read_Instruction(addr + 4, true);
 						// addiu sp, sp, +X
 						if ((op & 0xFFFF8000) != 0x27BD0000) {
 							furthestBranch = sureTarget;

--- a/Core/MIPS/MIPSCodeUtils.cpp
+++ b/Core/MIPS/MIPSCodeUtils.cpp
@@ -32,7 +32,7 @@ namespace MIPSCodeUtils
 
 	u32 GetJumpTarget(u32 addr)
 	{
-		MIPSOpcode op = Memory::Read_Instruction(addr);
+		MIPSOpcode op = Memory::Read_Instruction(addr, true);
 		if (op != 0)
 		{
 			MIPSInfo info = MIPSGetInfo(op);
@@ -50,7 +50,7 @@ namespace MIPSCodeUtils
 
 	u32 GetBranchTarget(u32 addr)
 	{
-		MIPSOpcode op = Memory::Read_Instruction(addr);
+		MIPSOpcode op = Memory::Read_Instruction(addr, true);
 		if (op != 0)
 		{
 			MIPSInfo info = MIPSGetInfo(op);
@@ -67,7 +67,7 @@ namespace MIPSCodeUtils
 
 	u32 GetBranchTargetNoRA(u32 addr)
 	{
-		MIPSOpcode op = Memory::Read_Instruction(addr);
+		MIPSOpcode op = Memory::Read_Instruction(addr, true);
 		return GetBranchTargetNoRA(addr, op);
 	}
 
@@ -89,7 +89,7 @@ namespace MIPSCodeUtils
 
 	u32 GetSureBranchTarget(u32 addr)
 	{
-		MIPSOpcode op = Memory::Read_Instruction(addr);
+		MIPSOpcode op = Memory::Read_Instruction(addr, true);
 		if (op != 0)
 		{
 			MIPSInfo info = MIPSGetInfo(op);

--- a/Core/MIPS/MIPSStackWalk.cpp
+++ b/Core/MIPS/MIPSStackWalk.cpp
@@ -67,7 +67,7 @@ namespace MIPSStackWalk {
 		// It ought to be pretty close.
 		u32 stop = pc - 32 * 4;
 		for (; Memory::IsValidAddress(pc) && pc >= stop; pc -= 4) {
-			MIPSOpcode op = Memory::Read_Instruction(pc);
+			MIPSOpcode op = Memory::Read_Instruction(pc, true);
 
 			// We're looking for a "mov fp, sp" close by a "addiu sp, sp, -N".
 			if (IsMovRegsInstr(op) && _RD == MIPS_REG_FP && (_RS == MIPS_REG_SP || _RT == MIPS_REG_SP)) {
@@ -83,7 +83,7 @@ namespace MIPSStackWalk {
 		int ra_offset = -1;
 		u32 stop = entry == INVALIDTARGET ? 0 : entry;
 		for (u32 pc = frame.pc; Memory::IsValidAddress(pc) && pc >= stop; pc -= 4) {
-			MIPSOpcode op = Memory::Read_Instruction(pc);
+			MIPSOpcode op = Memory::Read_Instruction(pc, true);
 
 			// Here's where they store the ra address.
 			if (IsSWInstr(op) && _RT == MIPS_REG_RA && _RS == MIPS_REG_SP) {

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -416,7 +416,7 @@ static Opcode Read_Instruction(u32 address, bool resolveReplacements, Opcode ins
 		} else {
 			return inst;
 		}
-	} else if (MIPS_IS_REPLACEMENT(inst.encoding)) {
+	} else if (resolveReplacements && MIPS_IS_REPLACEMENT(inst.encoding)) {
 		u32 op;
 		if (GetReplacedOpAt(address, &op)) {
 			if (MIPS_IS_EMUHACK(op)) {

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -146,6 +146,5 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size) {
 		fbo_unbind();
 	}
 	glstate.viewport.restore();
-	dstBuffer->memoryUpdated = false;
 	return true;
 }


### PR DESCRIPTION
They were only getting replaced in ReplaceJalTo(), because otherwise the replacement was resolved by the time armjit saw it.

Fixes Star Ocean on Android.

-[Unknown]
