### PR TITLE
Reschedule immediately in many cases

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -78,7 +78,10 @@ void hleDelayResultFinish(u64 userdata, int cycleslate)
 	u64 result = (userdata & 0xFFFFFFFF00000000ULL) | __KernelGetWaitValue(threadID, error);
 
 	if (error == 0 && verify == 1)
+	{
 		__KernelResumeThreadFromWait(threadID, result);
+		__KernelReSchedule("woke from hle delay");
+	}
 	else
 		WARN_LOG(HLE, "Someone else woke up HLE-blocked thread?");
 }

--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -42,6 +42,7 @@ inline void WaitExecTimeout(SceUID threadID) {
 		// actually running, it will get a DELETE result instead of a TIMEOUT.
 		// So, we need to remember it or we won't be able to mark it DELETE instead later.
 		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
+		__KernelReSchedule("wait timed out");
 	}
 }
 

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -293,6 +293,7 @@ inline void __AudioWakeThreads(AudioChannel &chan, int result, int step) {
 			// DEBUG_LOG(SCEAUDIO, "Woke thread %i for some buffer filling", waitingThread);
 			u32 ret = result == 0 ? __KernelGetWaitValue(waitInfo.threadID, error) : SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 			__KernelResumeThreadFromWait(waitInfo.threadID, ret);
+			__KernelReSchedule("audio drain");
 
 			chan.waitingThreads.erase(chan.waitingThreads.begin() + w--);
 		}

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -271,6 +271,7 @@ retry:
 		ctrlDataPtr = __KernelGetWaitValue(threadID, error);
 		int retVal = __CtrlReadSingleBuffer(ctrlDataPtr, wVal == CTRL_WAIT_NEGATIVE);
 		__KernelResumeThreadFromWait(threadID, retVal);
+		__KernelReSchedule("ctrl buffers updated");
 	}
 }
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -324,6 +324,7 @@ void __IoAsyncNotify(u64 userdata, int cyclesLate) {
 	u32 address = __KernelGetWaitValue(threadID, error);
 	if (HLEKernel::VerifyWait(threadID, WAITTYPE_ASYNCIO, f->GetUID())) {
 		HLEKernel::ResumeFromWait(threadID, WAITTYPE_ASYNCIO, f->GetUID(), 0);
+		__KernelReSchedule("async io completed");
 		// Someone woke up, so it's no longer got one.
 		f->hasAsyncResult = false;
 
@@ -360,7 +361,9 @@ void __IoSyncNotify(u64 userdata, int cyclesLate) {
 		ERROR_LOG(SCEIO, "Unable to complete IO operation on %s", f->GetName());
 	}
 
-	HLEKernel::ResumeFromWait(threadID, WAITTYPE_IO, fd, result);
+	if (HLEKernel::ResumeFromWait(threadID, WAITTYPE_IO, fd, result)) {
+		__KernelReSchedule("io completed");
+	}
 }
 
 void __IoAsyncBeginCallback(SceUID threadID, SceUID prevCallbackId) {

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1760,7 +1760,10 @@ void hleScheduledWakeup(u64 userdata, int cyclesLate)
 	SceUID threadID = (SceUID)userdata;
 	u32 error;
 	if (__KernelGetWaitID(threadID, WAITTYPE_DELAY, error) == threadID)
+	{
 		__KernelResumeThreadFromWait(threadID, 0);
+		__KernelReSchedule("thread delay finished");
+	}
 }
 
 void __KernelScheduleWakeup(SceUID threadID, s64 usFromNow)


### PR DESCRIPTION
I have not carefully tested each of these, but they are generally in line with my previous testing.  I may go ahead and test many of them with better-priority threads, but feedback from testing to see if it breaks games would be appreciated.

I'm pretty sure this will fix #2188 and help #5947.  I will be very surprised if it doesn't cause problems in at least a few games though...

I'm pretty sure that thread end waits, at least, do not wake up immediately regardless of priority, but definitely need to test that more.

-[Unknown]
