### PR TITLE
Adjust some timeouts and the thread switch penalty

### DIFF
--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -403,7 +403,7 @@ void __KernelSetEventFlagTimeout(EventFlag *e, u32 timeoutPtr)
 
 	// This seems like the actual timing of timeouts on hardware.
 	if (micro <= 1)
-		micro = 5;
+		micro = 25;
 	else if (micro <= 209)
 		micro = 240;
 

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -263,7 +263,7 @@ void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
 
 	// This seems to match the actual timing.
 	if (micro <= 2)
-		micro = 10;
+		micro = 20;
 	else if (micro <= 209)
 		micro = 250;
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -684,10 +684,10 @@ void __KernelSetFplTimeout(u32 timeoutPtr)
 	// TODO: test for fpls.
 	// This happens to be how the hardware seems to time things.
 	if (micro <= 5)
-		micro = 10;
+		micro = 20;
 	// Yes, this 7 is reproducible.  6 is (a lot) longer than 7.
 	else if (micro == 7)
-		micro = 15;
+		micro = 25;
 	else if (micro <= 215)
 		micro = 250;
 
@@ -1596,10 +1596,10 @@ void __KernelSetVplTimeout(u32 timeoutPtr)
 
 	// This happens to be how the hardware seems to time things.
 	if (micro <= 5)
-		micro = 10;
+		micro = 20;
 	// Yes, this 7 is reproducible.  6 is (a lot) longer than 7.
 	else if (micro == 7)
-		micro = 15;
+		micro = 25;
 	else if (micro <= 215)
 		micro = 250;
 

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -499,7 +499,7 @@ void __KernelWaitMutex(Mutex *mutex, u32 timeoutPtr)
 
 	// This happens to be how the hardware seems to time things.
 	if (micro <= 3)
-		micro = 15;
+		micro = 25;
 	else if (micro <= 249)
 		micro = 250;
 
@@ -896,7 +896,7 @@ void __KernelWaitLwMutex(LwMutex *mutex, u32 timeoutPtr)
 
 	// This happens to be how the hardware seems to time things.
 	if (micro <= 3)
-		micro = 15;
+		micro = 25;
 	else if (micro <= 249)
 		micro = 250;
 

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -359,7 +359,7 @@ void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)
 
 	// This happens to be how the hardware seems to time things.
 	if (micro <= 3)
-		micro = 15;
+		micro = 25;
 	else if (micro <= 249)
 		micro = 250;
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -3241,9 +3241,9 @@ void __KernelSwitchContext(Thread *target, const char *reason)
 	if (fromIdle && toIdle) {
 		// Don't eat any cycles going between idle.
 	} else if (fromIdle || toIdle) {
-		currentMIPS->downcount -= 1500;
+		currentMIPS->downcount -= 1200;
 	} else {
-		currentMIPS->downcount -= 3000;
+		currentMIPS->downcount -= 2700;
 	}
 
 	if (target)

--- a/test.py
+++ b/test.py
@@ -413,6 +413,8 @@ def main():
       tests = tests_good
     else:
       tests = tests_next + tests_good
+  elif '-m' in args and '-g' in args:
+    tests = [i for i in tests_good if i.startswith(tests[0])]
   elif '-m' in args:
     tests = [i for i in tests_next + tests_good if i.startswith(tests[0])]
 


### PR DESCRIPTION
This unbreaks a bunch of tests, a couple of which were hanging (since the immediate-wakeup change.)

-[Unknown]
