### PR TITLE
Use more correct rounding in armjit, update x86jit and minor

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -88,7 +88,7 @@ Jit::Jit(MIPSState *mips) : blocks(mips, this), gpr(mips, &jo), fpr(mips), mips_
 	AllocCodeSpace(1024 * 1024 * 16);  // 32MB is the absolute max because that's what an ARM branch instruction can reach, backwards and forwards.
 	GenerateFixedCode();
 
-	js.startDefaultPrefix = true;
+	js.startDefaultPrefix = mips_->HasDefaultPrefix();
 }
 
 void Jit::DoState(PointerWrap &p)

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -218,6 +218,10 @@ void MIPSState::Init() {
 	rng.Init(0x1337);
 }
 
+bool MIPSState::HasDefaultPrefix() const {
+	return vfpuCtrl[VFPU_CTRL_SPREFIX] == 0xe4 && vfpuCtrl[VFPU_CTRL_TPREFIX] == 0xe4 && vfpuCtrl[VFPU_CTRL_DPREFIX] == 0;
+}
+
 void MIPSState::UpdateCore(CPUCore desired) {
 	if (PSP_CoreParameter().cpuCore == desired) {
 		return;

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -186,6 +186,8 @@ public:
 		return (vfpuCtrl[VFPU_CTRL_DPREFIX] >> (8 + i)) & 1;
 	}
 
+	bool HasDefaultPrefix() const;
+
 	void SingleStep();
 	int RunLoopUntil(u64 globalTicks);
 	// To clear jit caches, etc.

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -494,7 +494,8 @@ void Jit::BranchVFPUFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 	// THE CONDITION
 	int imm3 = (op >> 18) & 7;
 
-	TEST(32, M(&(mips_->vfpuCtrl[VFPU_CTRL_CC])), Imm32(1 << imm3));
+	gpr.KillImmediate(MIPS_REG_VFPUCC, true, false);
+	TEST(32, gpr.R(MIPS_REG_VFPUCC), Imm32(1 << imm3));
 
 	u32 notTakenTarget = js.compilerPC + (delaySlotIsBranch ? 4 : 8);
 	CompBranchExits(cc, targetAddr, notTakenTarget, delaySlotIsNice, likely, false);

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -446,7 +446,8 @@ void Jit::BranchFPFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
-	TEST(32, M(&(mips_->fpcond)), Imm32(1));
+	gpr.KillImmediate(MIPS_REG_FPCOND, true, false);
+	TEST(32, gpr.R(MIPS_REG_FPCOND), Imm32(1));
 
 	CompBranchExits(cc, targetAddr, js.compilerPC + 8, delaySlotIsNice, likely, false);
 }

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -135,10 +135,9 @@ Jit::Jit(MIPSState *mips) : blocks(mips, this), mips_(mips)
 	fpr.SetEmitter(this);
 	AllocCodeSpace(1024 * 1024 * 16);
 	asm_.Init(mips, this);
-	// TODO: If it becomes possible to switch from the interpreter, this should be set right.
-	js.startDefaultPrefix = true;
-
 	safeMemFuncs.Init(&thunks);
+
+	js.startDefaultPrefix = mips_->HasDefaultPrefix();
 }
 
 Jit::~Jit() {

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -29,7 +29,6 @@ using namespace Gen;
 #define NUM_X_REGS 8
 #endif
 
-// TODO: Add more cachable regs, like HI, LO
 #define NUM_MIPS_GPRS 36
 
 struct MIPSCachedReg {

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -30,7 +30,7 @@ using namespace Gen;
 #endif
 
 // TODO: Add more cachable regs, like HI, LO
-#define NUM_MIPS_GPRS 32
+#define NUM_MIPS_GPRS 36
 
 struct MIPSCachedReg {
 	OpArg location;

--- a/GPU/GLES/VertexDecoderArm.cpp
+++ b/GPU/GLES/VertexDecoderArm.cpp
@@ -1090,10 +1090,10 @@ void VertexDecoderJitCache::Jit_WriteMorphColor(int outOff, bool checkAlpha) {
 			VMOV_neon(I_32, scratchReg, D4, 0);
 		}
 	} else {
-		VCVT(S8, S8, TO_INT);
-		VCVT(S9, S9, TO_INT);
-		VCVT(S10, S10, TO_INT);
-		VCVT(S11, S11, TO_INT);
+		VCVT(S8, S8, TO_INT | ROUND_TO_ZERO);
+		VCVT(S9, S9, TO_INT | ROUND_TO_ZERO);
+		VCVT(S10, S10, TO_INT | ROUND_TO_ZERO);
+		VCVT(S11, S11, TO_INT | ROUND_TO_ZERO);
 		VMOV(scratchReg, S8);
 		VMOV(scratchReg2, S9);
 		VMOV(scratchReg3, S10);


### PR DESCRIPTION
So, it sounds like this will fix #2278.  Specifically the old method of rounding was simply not accurate enough.

This makes cvt.w.s quite complex.  But, from testing a number of games it seems like 0/1 are the vastly most common rounding modes, which makes sense.  Most games use the specific instructions instead.  It seems like trunc.w.s is the most common, which makes sense.

Also had to take extra care of the fd == fs case, and used a jump because it seems like a jump is faster than 3+ instructions at least on armv7.

This also updates the x86jit to keep track of HI/LO/FPCOND/VFPUCC like armjit.  Just for consistency really.

Not sure if we could try to use/cache the hardware rounding mode instead, or if that would even buy us anything.  I assume we'd want to set it back at the end of the jit block, so it'd only help if they come in a row.

Mostly thanks to @xsacha for finding it.

-[Unknown]
