### PR TITLE
Optimize stencil uploading

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1005,7 +1005,7 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		ClearBuffer();
 		if (useBufferedRendering_ && !updateVRAM_) {
 			gpu->PerformMemoryUpload(fb_address_mem, byteSize);
-			gpu->PerformStencilUpload(fb_address_mem, byteSize);
+			NotifyStencilUpload(fb_address_mem, byteSize, true);
 			// TODO: Is it worth trying to upload the depth buffer?
 		}
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -226,7 +226,7 @@ public:
 	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 
 	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false);
-	bool NotifyStencilUpload(u32 addr, int size);
+	bool NotifyStencilUpload(u32 addr, int size, bool skipZero = false);
 
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false);

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -51,10 +51,10 @@ static const char *stencil_vs =
 "}\n";
 
 static u8 StencilBits5551(const u8 *ptr8, u32 numPixels) {
-	const u16 *ptr = (const u16 *)ptr8;
+	const u32 *ptr = (const u32 *)ptr8;
 
-	for (u32 i = 0; i < numPixels; ++i) {
-		if (ptr[i] & 0x8000) {
+	for (u32 i = 0; i < numPixels / 2; ++i) {
+		if (ptr[i] & 0x80008000) {
 			return 1;
 		}
 	}
@@ -63,25 +63,25 @@ static u8 StencilBits5551(const u8 *ptr8, u32 numPixels) {
 }
 
 static u8 StencilBits4444(const u8 *ptr8, u32 numPixels) {
-	const u16 *ptr = (const u16 *)ptr8;
-	u8 bits = 0;
+	const u32 *ptr = (const u32 *)ptr8;
+	u32 bits = 0;
 
-	for (u32 i = 0; i < numPixels; ++i) {
-		bits |= ptr[i] >> 12;
+	for (u32 i = 0; i < numPixels / 2; ++i) {
+		bits |= ptr[i];
 	}
 
-	return bits;
+	return ((bits >> 12) & 0xF) | (bits >> 28);
 }
 
 static u8 StencilBits8888(const u8 *ptr8, u32 numPixels) {
 	const u32 *ptr = (const u32 *)ptr8;
-	u8 bits = 0;
+	u32 bits = 0;
 
 	for (u32 i = 0; i < numPixels; ++i) {
-		bits |= ptr[i] >> 24;
+		bits |= ptr[i];
 	}
 
-	return bits;
+	return bits >> 24;
 }
 
 bool FramebufferManager::NotifyStencilUpload(u32 addr, int size, bool skipZero) {


### PR DESCRIPTION
This tries to avoid it in the normal case (e.g. when the memory is all zeroes.)  It also scans to determine which bits are set, so as to avoid the expensive fills (some areas, not many, in Star Ocean have not all the bits set, for example.)

Also, it's quite clear that 1x is way faster than 2x (possibly because of the fragment shader, the mask, the discard, or all of the above.)  Where glBlitFramebuffer is available, this makes it upload the stencil at 1x and then blit the stencil across.  This takes Star Ocean (while panning) from 600% to 1000% at 5x on my desktop.  It may also help Tegra and GLES3 devices, but performance there is untested.

-[Unknown]
