### PR TITLE
Make sure we don't try to download too-tall buffers

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1879,7 +1879,7 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb, int x, in
 	}
 
 	// Pixel size always 4 here because we always request RGBA8888
-	size_t bufSize = vfb->fb_stride * vfb->height * 4;
+	size_t bufSize = vfb->fb_stride * std::max(vfb->height, (u16)h) * 4;
 	u32 fb_address = (0x04000000) | vfb->fb_address;
 
 	GLubyte *packed = 0;
@@ -2354,7 +2354,7 @@ bool FramebufferManager::NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride
 			const int srcBpp = srcBuffer->format == GE_FORMAT_8888 ? 4 : 2;
 			const float srcXFactor = (float)bpp / srcBpp;
 			if (srcHeight <= 0 || srcY + srcHeight >= srcBuffer->bufferHeight) {
-				WARN_LOG_ONCE(btd, G3D, "Block transfer download %08x -> %08x skipped, %d+%d is taller than %d", srcBasePtr, dstBasePtr, srcY, srcHeight, srcBuffer->bufferHeight);
+				WARN_LOG_ONCE(btdheight, G3D, "Block transfer download %08x -> %08x skipped, %d+%d is taller than %d", srcBasePtr, dstBasePtr, srcY, srcHeight, srcBuffer->bufferHeight);
 			} else {
 				ReadFramebufferToMemory(srcBuffer, true, srcX * srcXFactor, srcY, srcWidth * srcXFactor, srcHeight);
 			}


### PR DESCRIPTION
This was causing crashes in some games from reports.  I couldn't reproduce the Tactics Ogre one, but I don't know why since it should've crashed me by all rights.  So I can't say for sure but mostly sure this will take care of #6442 and one of the crashes in #5918 (not clear on the other.)

-[Unknown]
