### PR TITLE
Fix callback status forgotten by sceKernelSleepThreadCB() and others

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -48,8 +48,6 @@ enum
 	HLE_AFTER_RESCHED           = 0x01,
 	// Call current thread's callbacks after the syscall.
 	HLE_AFTER_CURRENT_CALLBACKS = 0x02,
-	// Check all threads' callbacks after the syscall.
-	HLE_AFTER_ALL_CALLBACKS     = 0x04,
 	// Reschedule and process current thread's callbacks after the syscall.
 	HLE_AFTER_RESCHED_CALLBACKS = 0x08,
 	// Run interrupts (and probably reschedule) after the syscall.
@@ -256,11 +254,6 @@ const char *GetFuncName(int moduleIndex, int func)
 	return "[unknown]";
 }
 
-void hleCheckAllCallbacks()
-{
-	hleAfterSyscall |= HLE_AFTER_ALL_CALLBACKS;
-}
-
 void hleCheckCurrentCallbacks()
 {
 	hleAfterSyscall |= HLE_AFTER_CURRENT_CALLBACKS;
@@ -384,13 +377,10 @@ inline void hleFinishSyscall(const HLEFunction &info)
 	if ((hleAfterSyscall & HLE_AFTER_RUN_INTERRUPTS) != 0)
 		__RunOnePendingInterrupt();
 
-	// Rescheduling will also do HLE_AFTER_ALL_CALLBACKS.
 	if ((hleAfterSyscall & HLE_AFTER_RESCHED_CALLBACKS) != 0)
 		__KernelReSchedule(true, hleAfterSyscallReschedReason);
 	else if ((hleAfterSyscall & HLE_AFTER_RESCHED) != 0)
 		__KernelReSchedule(hleAfterSyscallReschedReason);
-	else if ((hleAfterSyscall & HLE_AFTER_ALL_CALLBACKS) != 0)
-		__KernelCheckCallbacks();
 
 	if ((hleAfterSyscall & HLE_AFTER_DEBUG_BREAK) != 0)
 	{

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -378,7 +378,7 @@ inline void hleFinishSyscall(const HLEFunction &info)
 	if ((hleAfterSyscall & HLE_AFTER_SKIP_DEADBEEF) == 0)
 		SetDeadbeefRegs();
 
-	if ((hleAfterSyscall & HLE_AFTER_CURRENT_CALLBACKS) != 0)
+	if ((hleAfterSyscall & HLE_AFTER_CURRENT_CALLBACKS) != 0 && (hleAfterSyscall & HLE_AFTER_RESCHED_CALLBACKS) == 0)
 		__KernelForceCallbacks();
 
 	if ((hleAfterSyscall & HLE_AFTER_RUN_INTERRUPTS) != 0)

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -79,8 +79,6 @@ void RegisterModule(const char *name, int numFunctions, const HLEFunction *funcT
 
 // Run the current thread's callbacks after the syscall finishes.
 void hleCheckCurrentCallbacks();
-// Check and potentially run all thread's callbacks after the syscall finishes.
-void hleCheckAllCallbacks();
 // Reschedule after the syscall finishes.
 void hleReSchedule(const char *reason);
 // Reschedule and go into a callback processing state after the syscall finishes.

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2758,7 +2758,6 @@ int sceKernelSleepThread()
 int sceKernelSleepThreadCB()
 {
 	VERBOSE_LOG(SCEKERNEL, "sceKernelSleepThreadCB()");
-	hleCheckCurrentCallbacks();
 	return __KernelSleepThread(true);
 }
 
@@ -2810,7 +2809,6 @@ int sceKernelWaitThreadEndCB(SceUID threadID, u32 timeoutPtr)
 	Thread *t = kernelObjects.Get<Thread>(threadID, error);
 	if (t)
 	{
-		hleCheckCurrentCallbacks();
 		if (t->nt.status != THREADSTATUS_DORMANT)
 		{
 			if (Memory::IsValidAddress(timeoutPtr))
@@ -2819,6 +2817,8 @@ int sceKernelWaitThreadEndCB(SceUID threadID, u32 timeoutPtr)
 				t->waitingThreads.push_back(currentThread);
 			__KernelWaitCurThread(WAITTYPE_THREADEND, threadID, 0, timeoutPtr, true, "thread wait end");
 		}
+		else
+			hleCheckCurrentCallbacks();
 
 		return t->nt.exitStatus;
 	}


### PR DESCRIPTION
Ultimately, @sum2012's change in #5607 was basically right (although not a full fix.)  Sorry @sum2012.

The basic problem is described in 10096b9.

Will probably take care of #5855.

-[Unknown]
