### PR TITLE
Allow rescheduling within a callback

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1394,25 +1394,6 @@ void __KernelIdle()
 	// that was triggered at the end of the Idle period must get a chance to be scheduled.
 	CoreTiming::Advance();
 
-	// We must've exited a callback?
-	if (__KernelInCallback())
-	{
-		u32 error;
-		Thread *t = kernelObjects.Get<Thread>(currentCallbackThreadID, error);
-		if (t)
-		{
-			__KernelChangeReadyState(t, currentCallbackThreadID, false);
-			t->nt.status = (t->nt.status | THREADSTATUS_RUNNING) & ~THREADSTATUS_READY;
-			__KernelSwitchContext(t, "idle");
-		}
-		else
-		{
-			WARN_LOG_REPORT(SCEKERNEL, "UNTESTED - Callback thread deleted during interrupt?");
-			g_inCbCount = 0;
-			currentCallbackThreadID = 0;
-		}
-	}
-
 	// In Advance, we might trigger an interrupt such as vblank.
 	// If we end up in an interrupt, we don't want to reschedule.
 	// However, we have to reschedule... damn.
@@ -1712,10 +1693,6 @@ void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 time
 		return;
 	}
 
-	// TODO: Need to defer if in callback?
-	if (g_inCbCount > 0)
-		WARN_LOG_REPORT(SCEKERNEL, "UNTESTED - waiting within a callback, probably bad mojo.");
-
 	Thread *thread = __GetCurrentThread();
 	thread->nt.waitID = waitID;
 	thread->nt.waitType = type;
@@ -1891,14 +1868,14 @@ Thread *__KernelNextThread() {
 void __KernelReSchedule(const char *reason)
 {
 	// cancel rescheduling when in interrupt or callback, otherwise everything will be fucked up
-	if (__IsInInterrupt() || __KernelInCallback() || !__KernelIsDispatchEnabled())
+	if (__IsInInterrupt() || !__KernelIsDispatchEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;
 	}
 
 	// This may get us running a callback, don't reschedule out of it.
-	if (__KernelCheckCallbacks())
+	if (!__KernelInCallback() && __KernelCheckCallbacks())
 	{
 		reason = "Began interrupt or callback.";
 		return;
@@ -1906,7 +1883,7 @@ void __KernelReSchedule(const char *reason)
 
 	// Execute any pending events while we're doing scheduling.
 	CoreTiming::Advance();
-	if (__IsInInterrupt() || __KernelInCallback() || !__KernelIsDispatchEnabled())
+	if (__IsInInterrupt() || !__KernelIsDispatchEnabled())
 	{
 		reason = "In Interrupt Or Callback";
 		return;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1390,13 +1390,8 @@ void __KernelIdle()
 	// That means the hle flag would stick around until the next call.
 
 	CoreTiming::Idle();
-	// Advance must happen between Idle and Reschedule, so that threads that were waiting for something
-	// that was triggered at the end of the Idle period must get a chance to be scheduled.
-	CoreTiming::Advance();
-
-	// In Advance, we might trigger an interrupt such as vblank.
-	// If we end up in an interrupt, we don't want to reschedule.
-	// However, we have to reschedule... damn.
+	// We Advance within __KernelReSchedule(), so anything that has now happened after idle
+	// will be triggered properly upon reschedule.
 	__KernelReSchedule("idle");
 }
 

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1180,7 +1180,7 @@ namespace MIPSComp
 		for (int i = 0; i < n; i++) {
 			fpr.MapDirtyInV(tempregs[i], sregs[i]);
 			switch ((op >> 21) & 0x1f) {
-			case 16: /* TODO */ break; //n  (round_vfpu_n causes issue #3011 but seems right according to tests...)
+			case 16: /* TODO */ break; //n
 			case 17:
 				if (mult != 1.0f) {
 					VMUL(S0, fpr.V(sregs[i]), S1);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -636,7 +636,7 @@ namespace MIPSInt
 			} else {
 				switch ((op >> 21) & 0x1f)
 				{
-				case 16: d[i] = (int)round_vfpu_n(sv); break; //(floor(sv + 0.5f)); break; //n  (round_vfpu_n causes issue #3011 but seems right according to tests...)
+				case 16: d[i] = (int)round_vfpu_n(sv); break; //(floor(sv + 0.5f)); break; //n
 				case 17: d[i] = s[i]>=0 ? (int)floor(sv) : (int)ceil(sv); break; //z
 				case 18: d[i] = (int)ceil(sv); break; //u
 				case 19: d[i] = (int)floor(sv); break; //d

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1377,7 +1377,7 @@ void Jit::Comp_Vf2i(MIPSOpcode op) {
 		MINSD(XMM0, M(&maxIntAsDouble));
 		MAXSD(XMM0, M(&minIntAsDouble));
 		switch ((op >> 21) & 0x1f) {
-		case 16: /* TODO */ break; //n  (round_vfpu_n causes issue #3011 but seems right according to tests...)
+		case 16: /* TODO */ break; //n
 		case 17: CVTTSD2SI(EAX, R(XMM0)); break; //z - truncate
 		case 18: /* TODO */ break; //u
 		case 19: /* TODO */ break; //d


### PR DESCRIPTION
This may break, fix, or otherwise change things.  I tested several games and have not found any problems now (with the rest of the fixes so far out of the way.)  However, there are a few games I'm highly suspicious may be affected by waits not "applying" properly within a callback.

I think we can say this fixes #1082.  Callbacks are still not correct in every way, but they are not "not at all correct" anymore.

-[Unknown]
