### PR TITLE
Move GL lost manager to NativeInit/NativeShutdown

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -442,13 +442,16 @@ void NativeInit(int argc, const char *argv[],
 	mainWindow->show();
 	host = new QtHost(mainWindow);
 #endif
+
+	// We do this here, instead of in NativeInitGraphics, because the display may be reset.
+	// When it's reset we don't want to forget all our managed things.
+	gl_lost_manager_init();
 }
 
 void NativeInitGraphics() {
 	FPU_SetFastMode();
 
 	CheckGLExtensions();
-	gl_lost_manager_init();
 	ui_draw2d.SetAtlas(&ui_atlas);
 	ui_draw2d_front.SetAtlas(&ui_atlas);
 
@@ -564,8 +567,6 @@ void NativeShutdownGraphics() {
 	ui_draw2d_front.Shutdown();
 
 	UIShader_Shutdown();
-
-	gl_lost_manager_shutdown();
 }
 
 void TakeScreenshot() {
@@ -866,6 +867,8 @@ void NativeResized() {
 }
 
 void NativeShutdown() {
+	gl_lost_manager_shutdown();
+
 	screenManager->shutdown();
 	delete screenManager;
 	screenManager = 0;


### PR DESCRIPTION
Otherwise, we clear the registered holders when the display turns off, and never remember them.  This causes the vertex cache to stop working, for example.

It was also somehow affecting the gameinfo cache for me, which I didn't debug much and doesn't make sense from the code, but it doesn't happen anymore with this change.  It did happen after several cycles of locking the screen, so maybe it was just errors from the vertex cache breaking things somehow causing it.

This fixes #5636.

-[Unknown]
