### PR TITLE
Win32: Go fullscreen before showing the window to avoid an ugly artifact.

### DIFF
--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -827,6 +827,9 @@ namespace MainWindow
 
 		hideCursor = true;
 		SetTimer(hwndMain, TIMER_CURSORUPDATE, CURSORUPDATE_INTERVAL_MS, 0);
+
+		if (g_Config.bFullScreen)
+			SwitchToFullscreen(hwndMain);
 		
 		ShowWindow(hwndMain, nCmdShow);
 
@@ -837,9 +840,6 @@ namespace MainWindow
 		WindowsRawInput::Init();
 
 		SetFocus(hwndMain);
-
-		if (g_Config.bFullScreen)
-			SwitchToFullscreen(hwndMain);
 
 		return TRUE;
 	}


### PR DESCRIPTION
Shouldn't break anything, since we seemed to figure out what broke vsync for NVidia (it was to do with postprocessing shaders, wasn't it?)..
