### PR TITLE
Add options to import/export .sym files from the menu

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -274,6 +274,27 @@ bool SymbolMap::LoadNocashSym(const char *filename) {
 	return true;
 }
 
+void SymbolMap::SaveNocashSym(const char *filename) const {
+	lock_guard guard(lock_);
+
+	// Don't bother writing a blank file.
+	if (!File::Exists(filename) && functions.empty() && data.empty()) {
+		return;
+	}
+
+	FILE* f = fopen(filename, "w");
+	if (f == NULL)
+		return;
+
+	// only write functions, the rest isn't really interesting
+	for (auto it = functions.begin(), end = functions.end(); it != end; ++it) {
+		const FunctionEntry& e = it->second;
+		fprintf(f, "%08X %s,%04X\n", GetModuleAbsoluteAddr(e.start,e.module),GetLabelNameRel(e.start, e.module), e.size);
+	}
+	
+	fclose(f);
+}
+
 SymbolType SymbolMap::GetSymbolType(u32 address) const {
 	lock_guard guard(lock_);
 	if (activeFunctions.find(address) != activeFunctions.end())

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -71,6 +71,7 @@ public:
 	bool LoadSymbolMap(const char *filename);
 	void SaveSymbolMap(const char *filename) const;
 	bool LoadNocashSym(const char *ilename);
+	void SaveNocashSym(const char *filename) const;
 
 	SymbolType GetSymbolType(u32 address) const;
 	bool GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask = ST_FUNCTION) const;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -451,6 +451,8 @@ namespace MainWindow
 		EnableMenuItem(menu, ID_EMULATION_SWITCH_UMD, umdSwitchEnable);
 		EnableMenuItem(menu, ID_DEBUG_LOADMAPFILE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_SAVEMAPFILE, menuEnable);
+		EnableMenuItem(menu, ID_DEBUG_LOADSYMFILE, menuEnable);
+		EnableMenuItem(menu, ID_DEBUG_SAVESYMFILE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_RESETSYMBOLTABLE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_EXTRACTFILE, menuEnable);
 	}
@@ -630,6 +632,8 @@ namespace MainWindow
 		// Debug menu
 		TranslateMenuItem(ID_DEBUG_LOADMAPFILE);
 		TranslateMenuItem(ID_DEBUG_SAVEMAPFILE);
+		TranslateMenuItem(ID_DEBUG_LOADSYMFILE);
+		TranslateMenuItem(ID_DEBUG_SAVESYMFILE);
 		TranslateMenuItem(ID_DEBUG_RESETSYMBOLTABLE);
 		TranslateMenuItem(ID_DEBUG_DUMPNEXTFRAME);
 		TranslateMenuItem(ID_DEBUG_TAKESCREENSHOT,  L"\tF12");
@@ -1426,6 +1430,23 @@ namespace MainWindow
 				case ID_DEBUG_SAVEMAPFILE:
 					if (W32Util::BrowseForFileName(false, hWnd, L"Save .ppmap",0,L"Maps\0*.ppmap\0All files\0*.*\0\0",L"ppmap",fn))
 						symbolMap.SaveSymbolMap(fn.c_str());
+					break;
+					
+				case ID_DEBUG_LOADSYMFILE:
+					if (W32Util::BrowseForFileName(true, hWnd, L"Load .sym",0,L"Symbols\0*.sym\0All files\0*.*\0\0",L"sym",fn)) {
+						symbolMap.LoadNocashSym(fn.c_str());
+
+						if (disasmWindow[0])
+							disasmWindow[0]->NotifyMapLoaded();
+
+						if (memoryWindow[0])
+							memoryWindow[0]->NotifyMapLoaded();
+					}
+					break;
+
+				case ID_DEBUG_SAVESYMFILE:
+					if (W32Util::BrowseForFileName(false, hWnd, L"Save .sym",0,L"Symbols\0*.sym\0All files\0*.*\0\0",L"sym",fn))
+						symbolMap.SaveNocashSym(fn.c_str());
 					break;
 
 				case ID_DEBUG_RESETSYMBOLTABLE:

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -417,6 +417,8 @@ BEGIN
     BEGIN
         MENUITEM "Load Map File...",                        ID_DEBUG_LOADMAPFILE
         MENUITEM "Save Map File...",                        ID_DEBUG_SAVEMAPFILE
+        MENUITEM "Load .sym File...",                       ID_DEBUG_LOADSYMFILE
+        MENUITEM "Save .sym File...",                       ID_DEBUG_SAVESYMFILE
         MENUITEM "Reset Symbol Table",                      ID_DEBUG_RESETSYMBOLTABLE
         MENUITEM SEPARATOR
         MENUITEM "Dump Next Frame to Log",                  ID_DEBUG_DUMPNEXTFRAME

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -311,6 +311,8 @@
 #define IDC_MODULELIST                   40147
 #define IDC_GEDBG_TEXLEVELDOWN           40148
 #define IDC_GEDBG_TEXLEVELUP             40149
+#define ID_DEBUG_LOADSYMFILE             40150
+#define ID_DEBUG_SAVESYMFILE             40151
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500
@@ -323,7 +325,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40150
+#define _APS_NEXT_COMMAND_VALUE         40152
 #define _APS_NEXT_CONTROL_VALUE         1197
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
It's automatically loaded like the other one if present in the disc directory, so it makes sense to offer the option to do it manually too.
