### PR TITLE
Reduce timing inaccuracy from 44.1kHz

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -87,6 +87,7 @@ static std::recursive_mutex externalEventSection;
 
 // Warning: not included in save state.
 void (*advanceCallback)(int cyclesExecuted) = NULL;
+std::vector<MHzChangeCallback> mhzChangeCallbacks;
 
 void SetClockFrequencyMHz(int cpuMhz)
 {
@@ -97,6 +98,11 @@ void SetClockFrequencyMHz(int cpuMhz)
 
 	CPU_HZ = cpuMhz * 1000000;
 	// TODO: Rescale times of scheduled events?
+
+	for (auto it = mhzChangeCallbacks.begin(), end = mhzChangeCallbacks.end(); it != end; ++it) {
+		MHzChangeCallback cb = *it;
+		cb();
+	}
 }
 
 int GetClockFrequencyMHz()
@@ -198,6 +204,7 @@ void Init()
 	lastGlobalTimeTicks = 0;
 	lastGlobalTimeUs = 0;
 	hasTsEvents = 0;
+	mhzChangeCallbacks.clear();
 }
 
 void Shutdown()
@@ -405,6 +412,10 @@ s64 UnscheduleThreadsafeEvent(int event_type, u64 userdata)
 void RegisterAdvanceCallback(void (*callback)(int cyclesExecuted))
 {
 	advanceCallback = callback;
+}
+
+void RegisterMHzChangeCallback(MHzChangeCallback callback) {
+	mhzChangeCallbacks.push_back(callback);
 }
 
 bool IsScheduled(int event_type) 

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -76,6 +76,7 @@ namespace CoreTiming
 	void Init();
 	void Shutdown();
 
+	typedef void (*MHzChangeCallback)();
 	typedef void (*TimedCallback)(u64 userdata, int cyclesLate);
 
 	u64 GetTicks();
@@ -116,6 +117,7 @@ namespace CoreTiming
 
 	// Warning: not included in save states.
 	void RegisterAdvanceCallback(void (*callback)(int cyclesExecuted));
+	void RegisterMHzChangeCallback(MHzChangeCallback callback);
 
 	std::string GetScheduledEventsSummary();
 


### PR DESCRIPTION
1,000,000 \* 64 / 44,100 is not an integer, so it introduces a drift from true 44.1kHz.  Apparently, some games seem to time based on this (such as Project Diva games, it seems.)

We could track the error and etc., although it's not clear how exactly accurate the PSP itself is.

Anyway, this uses cycles instead of microseconds for the interval, reducing the error significantly.  It will still run slightly too often, but during an hour of gameplay this error should be less than 12ms.  Before, an hour of gameplay was enough for it to be off around 890ms.

-[Unknown]
