### PR TITLE
Detect Peace Walker's anti-cheat hash func

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -299,6 +299,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xa2bcef60a550a3ef, 92, "matrix_rot_z", },
 	{ 0xa373f55c65cd757a, 312, "memcpy_swizzled" }, // God Eater Burst Demo
 	{ 0xa41989db0f9bf97e, 1304, "pow", },
+	{ 0xa4984da0a704cd67, 72, "peacewalker_codehash" }, // Metal Gear Solid: Peace Walker demo
 	{ 0xa46cc6ea720d5775, 44, "dl_write_cull", },
 	{ 0xa54967288afe8f26, 600, "ceil", },
 	{ 0xa5ddbbc688e89a4d, 56, "isinf", },

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -201,7 +201,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x52d5141545a75eda, 60, "dl_write_clutformat", },
 	{ 0x530cbe1ce9b45d58, 108, "dl_write_light_vector", },
 	{ 0x53c9aa23504a630f, 96, "vmmul_q_5", },
-	{ 0x54015ccbcbc75374, 24, "strlen", },
+	{ 0x54015ccbcbc75374, 24, "strlen", }, // Metal Gear Solid: Peace Walker demo
 	{ 0x5550d87a851c218c, 168, "dl_write_viewport", },
 	{ 0x55c1294280bfade0, 88, "dl_write_blend_fixed", },
 	{ 0x56c9929e8c8c5768, 24, "fabsf", },
@@ -413,7 +413,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xfb4253a1d9d9df9f, 20, "isnanf", },
 	{ 0xfd34a9ad94fa6241, 76, "__extendsfdf2", },
 	{ 0xfe4f0280240008e9, 28, "vavg_q", },
-	{ 0xfe5dd338ab862291, 216, "memset", },
+	{ 0xfe5dd338ab862291, 216, "memset", }, // Metal Gear Solid: Peace Walker demo
 	{ 0xffc8f5f8f946152c, 192, "dl_write_light_color", },
 };
 
@@ -755,6 +755,9 @@ skip:
 					closestJumpbackTarget = target;
 				}
 			}
+			if (aheadOp == MIPS_MAKE_JR_RA()) {
+				break;
+			}
 		}
 
 		if (closestJumpbackAddr != INVALIDTARGET && furthestJumpbackAddr == INVALIDTARGET) {
@@ -846,7 +849,8 @@ skip:
 					}
 
 					// A jump later.  Probably tail, but let's check if it jumps back.
-					u32 knownEnd = furthestBranch == 0 ? addr : furthestBranch;
+					// We use + 8 here in case it jumps right back to the delay slot.  We'll consider that inside the func.
+					u32 knownEnd = furthestBranch == 0 ? addr + 8 : furthestBranch;
 					u32 jumpback = ScanAheadForJumpback(sureTarget, currentFunction.start, knownEnd);
 					if (jumpback != INVALIDTARGET && jumpback > addr && jumpback > knownEnd) {
 						furthestBranch = jumpback;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -315,9 +315,10 @@ void System_Wake() {
 
 static bool pspIsInited = false;
 static bool pspIsIniting = false;
+static bool pspIsQuiting = false;
 
 bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
-	if (pspIsIniting) {
+	if (pspIsIniting || pspIsQuiting) {
 		return false;
 	}
 
@@ -394,12 +395,12 @@ bool PSP_IsIniting() {
 }
 
 bool PSP_IsInited() {
-	return pspIsInited;
+	return pspIsInited && !pspIsQuiting;
 }
 
 void PSP_Shutdown() {
 	// Do nothing if we never inited.
-	if (!pspIsInited && !pspIsIniting) {
+	if (!pspIsInited && !pspIsIniting && !pspIsQuiting) {
 		return;
 	}
 
@@ -409,6 +410,8 @@ void PSP_Shutdown() {
 	}
 #endif
 
+	// Make sure things know right away that PSP memory, etc. is going away.
+	pspIsQuiting = true;
 	if (coreState == CORE_RUNNING)
 		Core_UpdateState(CORE_ERROR);
 	Core_NotifyShutdown();
@@ -426,6 +429,7 @@ void PSP_Shutdown() {
 	currentMIPS = 0;
 	pspIsInited = false;
 	pspIsIniting = false;
+	pspIsQuiting = false;
 }
 
 void PSP_RunLoopUntil(u64 globalticks) {


### PR DESCRIPTION
This replaces the func with one that ignores emuhacks.  The demo calls this func often.

This makes the demo work, despite #3365.  Not sure if we should consider it fixed?  Anyway, it seems like I could make this func return whatever I want, and it'd be fine; the important thing is it doesn't ever change for the same code.

I know that #2845 doesn't seem to be caused by jit, but I don't know if the full game employs any of this anti-cheat stuff.  Not sure if the func exists there or has the same signature.  I'm assuming it does.

-[Unknown]
