### PR TITLE
Add an option to disable clut/render-to-self/etc.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -397,7 +397,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("SmallDisplay", &g_Config.bSmallDisplay, false),
 	ConfigSetting("ImmersiveMode", &g_Config.bImmersiveMode, false),
 
-	ConfigSetting("TrueColor", &g_Config.bTrueColor, true),
+	ReportedConfigSetting("TrueColor", &g_Config.bTrueColor, true),
 
 	ReportedConfigSetting("MipMap", &g_Config.bMipMap, true),
 
@@ -415,6 +415,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("PostShader", &g_Config.sPostShaderName, "Off"),
 
 	ReportedConfigSetting("MemBlockTransferGPU", &g_Config.bBlockTransferGPU, true),
+	ReportedConfigSetting("DisableSlowFramebufEffects", &g_Config.bDisableSlowFramebufEffects, true),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -146,6 +146,7 @@ public:
 	bool bTimerHack;
 	bool bAlphaMaskHack;
 	bool bBlockTransferGPU;
+	bool bDisableSlowFramebufEffects;
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	std::string sPostShaderName;  // Off for off.
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -313,12 +313,12 @@ bool ShouldUseShaderBlending() {
 
 	switch (eq) {
 	case GE_BLENDMODE_ABSDIFF:
-		return true;
+		return !g_Config.bDisableSlowFramebufEffects;
 
 	case GE_BLENDMODE_MIN:
 	case GE_BLENDMODE_MAX:
 		// These don't use the factors.
-		return !gl_extensions.EXT_blend_minmax && !gl_extensions.GLES3;
+		return !gl_extensions.EXT_blend_minmax && !gl_extensions.GLES3 && !g_Config.bDisableSlowFramebufEffects;
 
 	default:
 		break;
@@ -334,7 +334,7 @@ bool ShouldUseShaderBlending() {
 	case GE_SRCBLEND_DOUBLEINVSRCALPHA:
 	case GE_SRCBLEND_DOUBLEDSTALPHA:
 	case GE_SRCBLEND_DOUBLEINVDSTALPHA:
-		return true;
+		return !g_Config.bDisableSlowFramebufEffects;
 
 	case GE_SRCBLEND_FIXA:
 		if (funcB == GE_DSTBLEND_FIXB) {
@@ -355,7 +355,7 @@ bool ShouldUseShaderBlending() {
 	case GE_DSTBLEND_DOUBLEINVSRCALPHA:
 	case GE_DSTBLEND_DOUBLEDSTALPHA:
 	case GE_DSTBLEND_DOUBLEINVDSTALPHA:
-		return true;
+		return !g_Config.bDisableSlowFramebufEffects;
 
 	default:
 		break;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1009,7 +1009,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	if (useBufferedRendering) {
 		GLuint program = 0;
-		if (entry->status & TexCacheEntry::STATUS_DEPALETTIZE) {
+		if ((entry->status & TexCacheEntry::STATUS_DEPALETTIZE) && !g_Config.bDisableSlowFramebufEffects) {
 			program = depalShaderCache_->GetDepalettizeShader(framebuffer->format);
 		}
 		if (program) {

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -332,8 +332,10 @@ void TransformDrawEngine::SubmitPrim(void *verts, void *inds, GEPrimitiveType pr
 	}
 
 	if (prim == GE_PRIM_RECTANGLES && (gstate.getTextureAddress(0) & 0x3FFFFFFF) == (gstate.getFrameBufAddress() & 0x3FFFFFFF)) {
-		gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
-		Flush();
+		if (!g_Config.bDisableSlowFramebufEffects) {
+			gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
+			Flush();
+		}
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -164,6 +164,9 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *texSecondary_ = graphicsSettings->Add(new CheckBox(&g_Config.bTextureSecondaryCache, gs->T("Retain changed textures", "Retain changed textures (speedup, mem hog)")));
 	texSecondary_->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
+	CheckBox *framebufferSlowEffects = graphicsSettings->Add(new CheckBox(&g_Config.bDisableSlowFramebufEffects, gs->T("Disable slower effects (speedup)")));
+	framebufferSlowEffects->SetDisabledPtr(&g_Config.bSoftwareRendering);
+
 	// Seems solid, so we hide the setting.
 	// CheckBox *vtxJit = graphicsSettings->Add(new CheckBox(&g_Config.bVertexDecoderJit, gs->T("Vertex Decoder JIT")));
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -86,26 +86,9 @@ private:
 	bool enableReports_;
 
 	// Cached booleans
-	bool hwTransformEnable;
-	bool vtxCacheEnable;
-	bool renderModeEnable;
-	bool blockTransferEnable;
-	bool swSkinningEnable;
-	bool texBackoffEnable;
-	bool mipmapEnable;
-	bool texScalingEnable;
-	bool texSecondaryEnable;
-	bool beziersEnable;
-	bool stencilTestEnable;
-	bool depthWriteEnable;
-	bool prescaleEnable;
-	bool texScalingTypeEnable;
-	bool desposterizeEnable;
-	bool anisotropicEnable;
-	bool texFilteringEnable;
-	bool postProcEnable;
-	bool resolutionEnable;
-	bool alphaHackEnable;
+	bool vtxCacheEnable_;
+	bool postProcEnable_;
+	bool resolutionEnable_;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {


### PR DESCRIPTION
Some people with slower devices would prefer the higher render resolution with major graphical glitches, it seems like.  This isn't a very difficult option to add, and in some games the improper effects are probably tolerable.

-[Unknown]
