### PR TITLE
Don't crash when framebuffer is a nullptr.

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1005,6 +1005,10 @@ bool SetDebugTexture() {
 #endif
 
 void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) {
+	if (framebuffer == nullptr) {
+		return;
+	}
+
 	framebuffer->usageFlags |= FB_USAGE_TEXTURE;
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	if (useBufferedRendering) {


### PR DESCRIPTION
nullptr keyword usage should be fine now, since we support C++11 everywhere.

Should fix https://github.com/hrydgard/ppsspp/issues/6529, but I'd imagine if the framebuffer is ending up as null somewhere in the middle of a game, we've got bigger issues.
