### PR TITLE
Avoid a texture offset if framebuf attach fails

### DIFF
--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1005,9 +1005,7 @@ bool SetDebugTexture() {
 #endif
 
 void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) {
-	if (framebuffer == nullptr) {
-		return;
-	}
+	_dbg_assert_msg_(G3D, framebuffer != nullptr, "Framebuffer must not be null.");
 
 	framebuffer->usageFlags |= FB_USAGE_TEXTURE;
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
@@ -1137,13 +1135,14 @@ bool TextureCache::SetOffsetTexture(u32 offset) {
 		}
 	}
 
-	if (success) {
+	if (success && entry->framebuffer) {
 		SetTextureFramebuffer(entry, entry->framebuffer);
 		lastBoundTexture = -1;
 		entry->lastFrame = gpuStats.numFlips;
+		return true;
 	}
 
-	return success;
+	return false;
 }
 
 void TextureCache::SetTexture(bool force) {


### PR DESCRIPTION
But, I'm not sure in what case this could happen, since `success` should only be true if it attached one (unless something is in `fbCache_` twice?)

Anyway, if there is a case where it's not attached, we should not return true in SetOffsetTexture(), since that will adjust the texturing to account for a framebuffer that is not there.  Although, I'm not sure we're handling that case exactly right still...

@thedax, does #6529 still work with this change?

-[Unknown]
