### PR TITLE
Correct some module func return values, info values, and clear on unload

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -570,6 +570,26 @@ SectionID ElfReader::GetSectionByName(const char *name, int firstSection)
 	return -1;
 }
 
+u32 ElfReader::GetTotalTextSize() const {
+	u32 total = 0;
+	for (int i = 0; i < GetNumSections(); ++i) {
+		if (!(sections[i].sh_flags & SHF_WRITE) && (sections[i].sh_flags & SHF_ALLOC)) {
+			total += sections[i].sh_size;
+		}
+	}
+	return total;
+}
+
+u32 ElfReader::GetTotalDataSize() const {
+	u32 total = 0;
+	for (int i = 0; i < GetNumSections(); ++i) {
+		if ((sections[i].sh_flags & SHF_WRITE) && (sections[i].sh_flags & SHF_ALLOC) && !(sections[i].sh_flags & SHF_MASKPROC)) {
+			total += sections[i].sh_size;
+		}
+	}
+	return total;
+}
+
 bool ElfReader::LoadSymbols()
 {
 	bool hasSymbols = false;

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -77,8 +77,8 @@ public:
 	u32 GetEntryPoint() { return entryPoint; }
 	u32 GetFlags() { return (u32)(header->e_flags); }
 
-	int GetNumSegments() { return (int)(header->e_phnum); }
-	int GetNumSections() { return (int)(header->e_shnum); }
+	int GetNumSegments() const { return (int)(header->e_phnum); }
+	int GetNumSections() const { return (int)(header->e_shnum); }
 	const char *GetSectionName(int section);
 	u8 *GetPtr(u32 offset) const {
 		return (u8*)base + offset;
@@ -129,6 +129,9 @@ public:
 	u32 GetTotalSize() const {
 		return totalSize;
 	}
+
+	u32 GetTotalTextSize() const;
+	u32 GetTotalDataSize() const;
 
 	// More indepth stuff:)
 	int LoadInto(u32 vaddr);

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -80,12 +80,10 @@ public:
 	int GetNumSegments() { return (int)(header->e_phnum); }
 	int GetNumSections() { return (int)(header->e_shnum); }
 	const char *GetSectionName(int section);
-	u8 *GetPtr(u32 offset)
-	{
+	u8 *GetPtr(u32 offset) const {
 		return (u8*)base + offset;
 	}
-	u8 *GetSectionDataPtr(int section)
-	{
+	u8 *GetSectionDataPtr(int section) const {
 		if (section < 0 || section >= header->e_shnum)
 			return 0;
 		if (sections[section].sh_type != SHT_NOBITS)
@@ -93,45 +91,42 @@ public:
 		else
 			return 0;
 	}
-	u8 *GetSegmentPtr(int segment)
-	{
+	u8 *GetSegmentPtr(int segment) const {
 		return GetPtr(segments[segment].p_offset);
 	}
-	u32 GetSectionAddr(SectionID section) {return sectionAddrs[section];}
-	int GetSectionSize(SectionID section)
-	{
+	u32 GetSectionAddr(SectionID section) const {
+		return sectionAddrs[section];
+	}
+	int GetSectionSize(SectionID section) const {
 		return sections[section].sh_size;
 	}
 	SectionID GetSectionByName(const char *name, int firstSection=0); //-1 for not found
 
-	u32 GetSegmentPaddr(int segment)
-	{
+	u32 GetSegmentPaddr(int segment) const {
 	    return segments[segment].p_paddr;
 	}
-	u32 GetSegmentOffset(int segment)
-	{
+	u32 GetSegmentOffset(int segment) const {
 	    return segments[segment].p_offset;
 	}
-	u32 GetSegmentVaddr(int segment)
-	{
+	u32 GetSegmentVaddr(int segment) const {
 		return segmentVAddr[segment];
 	}
-	u32 GetSegmentDataSize(int segment)
-	{
+	u32 GetSegmentDataSize(int segment) const {
 		return segments[segment].p_filesz;
 	}
+	u32 GetSegmentMemSize(int segment) const {
+		return segments[segment].p_memsz;
+	}
 
-	bool DidRelocate() {
+	bool DidRelocate() const {
 		return bRelocate;
 	}
 
-	u32 GetVaddr()
-	{
+	u32 GetVaddr() const {
 		return vaddr;
 	}
 
-	u32 GetTotalSize()
-	{
+	u32 GetTotalSize() const {
 		return totalSize;
 	}
 

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -518,8 +518,10 @@ void CallSyscall(MIPSOpcode op)
 		start = time_now_d();
 	}
 	const HLEFunction *info = GetSyscallInfo(op);
-	if (!info)
+	if (!info) {
+		RETURN(SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED);
 		return;
+	}
 
 	if (info->func)
 	{
@@ -530,8 +532,10 @@ void CallSyscall(MIPSOpcode op)
 		else
 			CallSyscallWithoutFlags(info);
 	}
-	else
+	else {
+		RETURN(SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED);
 		ERROR_LOG_REPORT(HLE, "Unimplemented HLE function %s", info->name ? info->name : "(\?\?\?)");
+	}
 
 	if (g_Config.bShowDebugStats)
 	{

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -934,6 +934,8 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 	module->nm.data_size = 0;
 	// TODO: Is summing them up correct?  Must not be since the numbers aren't exactly right.
 	for (int i = 0; i < reader.GetNumSegments(); ++i) {
+		module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
+		module->nm.segmentsize[i] = reader.GetSegmentMemSize(i);
 		module->nm.data_size += reader.GetSegmentDataSize(i);
 	}
 	module->nm.gp_value = modinfo->gp;
@@ -1668,6 +1670,7 @@ void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValu
 	u32 error;
 	Module *module = kernelObjects.Get<Module>(moduleId, error);
 	if (!module) {
+		INFO_LOG(SCEMODULE, "sceKernelStartModule(%d,asize=%08x,aptr=%08x,retptr=%08x,%08x): error %08x", moduleId, argsize, argAddr, returnValueAddr, optionAddr, error);
 		RETURN(error);
 		return;
 	} else if (module->isFake) {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -948,8 +948,10 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 	module->nm.data_size = 0;
 	// TODO: Is summing them up correct?  Must not be since the numbers aren't exactly right.
 	for (int i = 0; i < reader.GetNumSegments(); ++i) {
-		module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
-		module->nm.segmentsize[i] = reader.GetSegmentMemSize(i);
+		if (i < (int)ARRAY_SIZE(module->nm.segmentaddr)) {
+			module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
+			module->nm.segmentsize[i] = reader.GetSegmentMemSize(i);
+		}
 		module->nm.data_size += reader.GetSegmentDataSize(i);
 	}
 	module->nm.gp_value = modinfo->gp;
@@ -968,7 +970,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 		}
 	}
 
-	if (!module->isFake &&  module->memoryBlockAddr != 0) {
+	if (!module->isFake && module->memoryBlockAddr != 0) {
 		symbolMap.AddModule(moduleName, module->memoryBlockAddr, module->memoryBlockSize);
 	}
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -966,10 +966,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 		module->textEnd = module->textStart + textSize;
 
 		module->nm.text_addr = module->textStart;
-		// TODO: This value appears to be wrong.  In one example, the PSP has a value > 0x1000 bigger.
-		module->nm.text_size = textSize;
-		// TODO: It seems like the data size excludes the text size, which kinda makes sense?
-		module->nm.data_size -= textSize;
+		module->nm.text_size = reader.GetTotalTextSize();
 
 		if (!module->isFake) {
 #if !defined(MOBILE_DEVICE)
@@ -982,6 +979,14 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			}
 #endif
 		}
+	}
+
+	SectionID bssSection = reader.GetSectionByName(".bss");
+	if (bssSection != -1) {
+		module->nm.bss_size = reader.GetSectionSize(bssSection);
+		module->nm.data_size = reader.GetTotalDataSize() - module->nm.bss_size;
+	} else {
+		module->nm.data_size = reader.GetTotalDataSize();
 	}
 
 	INFO_LOG(LOADER, "Module %s: %08x %08x %08x", modinfo->name, modinfo->gp, modinfo->libent, modinfo->libstub);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1247,6 +1247,9 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			default:
 				func.nid = nid;
 				func.symAddr = exportAddr;
+				if (ent->name == NULL) {
+					WARN_LOG_REPORT(HLE, "Exporting func from syslib export: %08x", nid);
+				}
 				module->ExportFunc(func);
 			}
 		}
@@ -1301,6 +1304,9 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 			default:
 				var.nid = nid;
 				var.symAddr = exportAddr;
+				if (ent->name == NULL) {
+					WARN_LOG_REPORT(HLE, "Exporting var from syslib export: %08x", nid);
+				}
 				module->ExportVar(var);
 				break;
 			}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1972,7 +1972,7 @@ void __KernelReturnFromModuleFunc()
 			} else {
 				if (it->statusPtr != 0)
 					Memory::Write_U32(exitStatus, it->statusPtr);
-				__KernelResumeThreadFromWait(it->threadID, 0);
+				__KernelResumeThreadFromWait(it->threadID, module->nm.status == MODULE_STATUS_STARTED ? leftModuleID : 0);
 			}
 		}
 	}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -275,7 +275,9 @@ public:
 		if (p.mode == p.MODE_READ) {
 			char moduleName[29] = {0};
 			strncpy(moduleName, nm.name, ARRAY_SIZE(nm.name));
-			symbolMap.AddModule(moduleName, memoryBlockAddr, memoryBlockSize);
+			if (memoryBlockAddr != 0) {
+				symbolMap.AddModule(moduleName, memoryBlockAddr, memoryBlockSize);
+			}
 		}
 	}
 
@@ -954,7 +956,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, std::string *erro
 		}
 	}
 
-	if (!module->isFake) {
+	if (!module->isFake &&  module->memoryBlockAddr != 0) {
 		symbolMap.AddModule(moduleName, module->memoryBlockAddr, module->memoryBlockSize);
 	}
 
@@ -2001,7 +2003,7 @@ struct GetModuleIdByAddressArg
 bool __GetModuleIdByAddressIterator(Module *module, GetModuleIdByAddressArg *state)
 {
 	const u32 start = module->memoryBlockAddr, size = module->memoryBlockSize;
-	if (start <= state->addr && start + size > state->addr)
+	if (start != 0 && start <= state->addr && start + size > state->addr)
 	{
 		state->result = module->GetUID();
 		return false;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1153,7 +1153,7 @@ void __KernelThreadingInit()
 		MIPS_MAKE_JR_RA(),
 		//MIPS_MAKE_SYSCALL("ThreadManForUser", "sceKernelDelayThread"),
 		MIPS_MAKE_SYSCALL("FakeSysCalls", "_sceKernelIdle"),
-		MIPS_MAKE_BREAK(),
+		MIPS_MAKE_BREAK(0),
 	};
 
 	// If you add another func here, don't forget __KernelThreadingDoState() below.

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -32,7 +32,7 @@
 #define MIPS_MAKE_LUI(reg, immval) (0x3c000000 | ((reg) << 16) | (immval))
 #define MIPS_MAKE_LW(rt, rs, immval) (0x8c000000 | ((rs) << 21) | ((rt) << 16) | (immval))
 #define MIPS_MAKE_SYSCALL(module, function) GetSyscallOp(module, GetNibByName(module, function))
-#define MIPS_MAKE_BREAK() (13)  // ! :)
+#define MIPS_MAKE_BREAK(n) (((n) << 6) | 13)  // ! :)
 
 #define MIPS_GET_OP(op)   ((op>>26) & 0x3F)
 #define MIPS_GET_FUNC(op) (op & 0x3F)


### PR DESCRIPTION
This makes several changes:
- Returns correct values / error codes in sceKernelModuleStart() and sceKernelLoadModule().
- Calculates bss/text/data size correctly as far as I can tell from a few different modules.
- Cleans up modules on unload by writing out breaks for their text section and -1 for their data (as the PSP seems to; but maybe there are flags?)
- Returns NOT_YET_LINKED on unresolved function imports, rather than leaving v0 as it was before.

Notably, text size may not be a multiple of 4, which results in a partially-overwritten break instruction.  I've tried to replicate the behavior exactly.

-[Unknown]
