### PR TITLE
Discuss __KernelChangeThreadState

### DIFF
--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -293,7 +293,7 @@ enum ThreadStatus
 	THREADSTATUS_WAITSUSPEND = THREADSTATUS_WAIT | THREADSTATUS_SUSPEND
 };
 
-void __KernelChangeThreadState(Thread *thread, ThreadStatus newStatus);
+bool __KernelChangeThreadState(Thread *thread, ThreadStatus newStatus);
 
 typedef void (*ThreadCallback)(SceUID threadID);
 void __KernelListenThreadEnd(ThreadCallback callback);


### PR DESCRIPTION
Related #6557
JPCSP emulator has this log but PPSSPP doesn't
94779 [user_main] INFO  hle.ThreadManForUser - DispatchThread disabled, not context switching to CsdThread(uid=0x55, Status=PSP_THREAD_READY, Priority=0x11, Wait=None, doCallbacks=false)

this commit base on  http://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/ThreadManForUser.java#628
This commit do not fix the game
