### PR TITLE
Win32: Fix a bug in fullscreen, and consolidate the fullscreen code into one function.

### DIFF
--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -336,10 +336,7 @@ bool WindowsHost::CreateDesktopShortcut(std::string argumentPath, std::string ga
 }
 
 void WindowsHost::GoFullscreen(bool viewFullscreen) {
-	if (viewFullscreen)
-		MainWindow::SwitchToFullscreen(mainWindow_);
-	else
-		MainWindow::SwitchToWindowed(mainWindow_);
+	MainWindow::ToggleFullscreen(mainWindow_, viewFullscreen);
 }
 
 void WindowsHost::ToggleDebugConsoleVisibility() {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -338,7 +338,7 @@ namespace MainWindow
 		// Remove the menu bar.
 		::SetMenu(hWnd, goingFullscreen ? NULL : menu);
 
-		// Resize to normal view.
+		// Resize to the appropriate view.
 		ShowWindow(hwndMain, goingFullscreen ? SW_MAXIMIZE : SW_RESTORE);
 
 		g_Config.bFullScreen = goingFullscreen;
@@ -757,7 +757,7 @@ namespace MainWindow
 		windowTitle = title;
 	}
 
-	BOOL Show(HINSTANCE hInstance, int nCmdShow) {
+	BOOL Show(HINSTANCE hInstance) {
 		hInst = hInstance; // Store instance handle in our global variable.
 		RECT rc = DetermineWindowRectangle();
 

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -336,10 +336,10 @@ namespace MainWindow
 		::SetWindowLong(hWnd, GWL_STYLE, dwNewStyle);
 
 		// Remove the menu bar.
-		::SetMenu(hWnd, g_Config.bFullScreen ? NULL : menu);
+		::SetMenu(hWnd, goingFullscreen ? NULL : menu);
 
 		// Resize to normal view.
-		ShowWindow(hwndMain, g_Config.bFullScreen ? SW_MAXIMIZE : SW_RESTORE);
+		ShowWindow(hwndMain, goingFullscreen ? SW_MAXIMIZE : SW_RESTORE);
 
 		g_Config.bFullScreen = goingFullscreen;
 		CorrectCursor();
@@ -349,7 +349,7 @@ namespace MainWindow
 		if (showOSM) {
 			ShowScreenResolution();
 		}
-		ShowOwnedPopups(hwndMain, TRUE);
+		ShowOwnedPopups(hwndMain, goingFullscreen ? FALSE : TRUE);
 		W32Util::MakeTopMost(hwndMain, g_Config.bTopMost);
 
 		g_inModeSwitch = false;

--- a/Windows/WndMainWindow.h
+++ b/Windows/WndMainWindow.h
@@ -49,7 +49,7 @@ namespace MainWindow
 	};
 
 	void Init(HINSTANCE hInstance);
-	BOOL Show(HINSTANCE hInstance, int nCmdShow);
+	BOOL Show(HINSTANCE hInstance);
 	void CreateDebugWindows();
 	void DestroyDebugWindows();
 	void Close();

--- a/Windows/WndMainWindow.h
+++ b/Windows/WndMainWindow.h
@@ -63,8 +63,7 @@ namespace MainWindow
 	HWND GetDisplayHWND();
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory = false);
 	void SaveStateActionFinished(bool result, void *userdata);
-	void SwitchToFullscreen(HWND hWnd);
-	void SwitchToWindowed(HWND hWnd);
+	void ToggleFullscreen(HWND hWnd, bool goingFullscreen);
 	void ToggleDebugConsoleVisibility();
 	void TranslateMenus();
 	void setTexScalingMultiplier(int level);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -374,7 +374,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	g_hPopupMenus = LoadMenu(_hInstance, (LPCWSTR)IDR_POPUPMENUS);
 
-	MainWindow::Show(_hInstance, iCmdShow);
+	MainWindow::Show(_hInstance);
 
 	HWND hwndMain = MainWindow::GetHWND();
 	HWND hwndDisplay = MainWindow::GetDisplayHWND();


### PR DESCRIPTION
99% of the code is the same anyway.

The bug was created (more like exposed by, but whatever) in https://github.com/hrydgard/ppsspp/commit/cf00fd1ac883cfe101607e73e68fd7a4ee30b394 by @vnctdj. Basically, if we start in fullscreen, we start with a borderless window with no menu bar, set to the size of the last windowed mode used (which is of course, not desirable. If I exit in fullscreen, I certainly expect it to begin in fullscreen again).
