### PR TITLE
Add option to use the Android hardware scaler by setting a low resolution

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -368,7 +368,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("SoftwareSkinning", &g_Config.bSoftwareSkinning, true),
 	ReportedConfigSetting("TextureFiltering", &g_Config.iTexFiltering, 1),
 	ReportedConfigSetting("InternalResolution", &g_Config.iInternalResolution, &DefaultInternalResolution),
-	ReportedConfigSetting("AndroidHwScale", &g_Config.iAndroidHwScale, 0),
+	ReportedConfigSetting("AndroidHwScale", &g_Config.iAndroidHwScale, 1),
 	ReportedConfigSetting("FrameSkip", &g_Config.iFrameSkip, 0),
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false),
 	ReportedConfigSetting("FrameRate", &g_Config.iFpsLimit, 0),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -368,6 +368,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("SoftwareSkinning", &g_Config.bSoftwareSkinning, true),
 	ReportedConfigSetting("TextureFiltering", &g_Config.iTexFiltering, 1),
 	ReportedConfigSetting("InternalResolution", &g_Config.iInternalResolution, &DefaultInternalResolution),
+	ReportedConfigSetting("AndroidHwScale", &g_Config.iAndroidHwScale, 0),
 	ReportedConfigSetting("FrameSkip", &g_Config.iFrameSkip, 0),
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false),
 	ReportedConfigSetting("FrameRate", &g_Config.iFpsLimit, 0),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -258,6 +258,9 @@ public:
 	bool bDisableAlphaTest;  // Helps PowerVR immensely, breaks some graphics
 	// End GLES hacks.
 
+	// Use the hardware scaler to scale up the image to save fillrate. Similar to Windows' window size, really.
+	int iAndroidHwScale;  // 0 = device resolution. 1 = 480x272 (extended to correct aspect), 2 = 960x544 etc.
+
 	// Risky JIT optimizations
 	bool bDiscardRegsOnJRRA;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -142,8 +142,8 @@ void GameSettingsScreen::CreateViews() {
 	resolutionChoice_->SetEnabledPtr(&resolutionEnable_);
 
 #ifdef ANDROID
-	static const char *deviceResolutions[] = { "Native", "1x PSP", "2x PSP", "3x PSP", "4x PSP", "5x PSP" };
-	UI::PopupMultiChoice *hwscale = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAndroidHwScale, gs->T("Device Resolution (HW scaler)"), deviceResolutions, 0, ARRAY_SIZE(deviceResolutions), gs, screenManager()));
+	static const char *deviceResolutions[] = { "Native device resolution", "Auto (same as Rendering)", "1x PSP", "2x PSP", "3x PSP", "4x PSP", "5x PSP" };
+	UI::PopupMultiChoice *hwscale = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAndroidHwScale, gs->T("Display Resolution (HW scaler)"), deviceResolutions, 0, ARRAY_SIZE(deviceResolutions), gs, screenManager()));
 	hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode
 #endif
 
@@ -492,6 +492,9 @@ UI::EventReturn GameSettingsScreen::OnFullscreenChange(UI::EventParams &e) {
 UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 	if (gpu) {
 		gpu->Resized();
+	}
+	if (g_Config.iAndroidHwScale == 1) {
+		System_SendMessage("recreate", "");
 	}
 	Reporting::UpdateConfig();
 	return UI::EVENT_DONE;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -137,9 +137,15 @@ void GameSettingsScreen::CreateViews() {
 	static const char *internalResolutions[] = {"Auto (1:1)", "1x PSP", "2x PSP", "3x PSP", "4x PSP", "5x PSP" };
 #endif
 	resolutionChoice_ = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iInternalResolution, gs->T("Rendering Resolution"), internalResolutions, 0, ARRAY_SIZE(internalResolutions), gs, screenManager()));
-	resolutionChoice_->OnClick.Handle(this, &GameSettingsScreen::OnResolutionChange);
+	resolutionChoice_->OnChoice.Handle(this, &GameSettingsScreen::OnResolutionChange);
 	resolutionEnable_ = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	resolutionChoice_->SetEnabledPtr(&resolutionEnable_);
+
+#ifdef ANDROID
+	static const char *deviceResolutions[] = { "Native", "1x PSP", "2x PSP", "3x PSP", "4x PSP", "5x PSP" };
+	UI::PopupMultiChoice *hwscale = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAndroidHwScale, gs->T("Device Resolution (HW scaler)"), deviceResolutions, 0, ARRAY_SIZE(deviceResolutions), gs, screenManager()));
+	hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode
+#endif
 
 #ifdef _WIN32
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gs->T("VSync")));
@@ -488,6 +494,11 @@ UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 		gpu->Resized();
 	}
 	Reporting::UpdateConfig();
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnHwScaleChange(UI::EventParams &e) {
+	System_SendMessage("recreate", "");
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -69,6 +69,7 @@ private:
 	UI::EventReturn OnClearRecents(UI::EventParams &e);
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
+	UI::EventReturn OnHwScaleChange(UI::EventParams &e);
 	UI::EventReturn OnFrameSkipChange(UI::EventParams &e);
 	UI::EventReturn OnShaderChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -200,7 +200,15 @@ std::string NativeQueryConfig(std::string query) {
 	} else if (query == "immersiveMode") {
 		return std::string(g_Config.bImmersiveMode ? "1" : "0");
 	} else if (query == "hwScale") {
-		sprintf(temp, "%i", g_Config.iAndroidHwScale);
+		int scale = g_Config.iAndroidHwScale;
+		if (scale == 1) {
+			// If g_Config.iInternalResolution is also set to Auto (1), we fall back to "Device resolution" (0). It works out.
+			scale = g_Config.iInternalResolution;
+		} else if (scale >= 2) {
+			scale -= 1;
+		}
+
+		sprintf(temp, "%i", scale);
 		return std::string(temp);
 	} else {
 		return std::string("");

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -193,14 +193,17 @@ void QtHost::ShutdownSound() { g_mixer = 0; }
 #endif
 
 std::string NativeQueryConfig(std::string query) {
+	char temp[128];
 	if (query == "screenRotation") {
-		char temp[128];
 		sprintf(temp, "%i", g_Config.iScreenRotation);
-		return temp;
+		return std::string(temp);
 	} else if (query == "immersiveMode") {
-		return g_Config.bImmersiveMode ? "1" : "0";
+		return std::string(g_Config.bImmersiveMode ? "1" : "0");
+	} else if (query == "hwScale") {
+		sprintf(temp, "%i", g_Config.iAndroidHwScale);
+		return std::string(temp);
 	} else {
-		return "";
+		return std::string("");
 	}
 }
 
@@ -540,8 +543,6 @@ void NativeInitGraphics() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-
-	glstate.viewport.set(0, 0, pixel_xres, pixel_yres);
 
 #ifdef _WIN32
 	DSound::DSound_StartSound(MainWindow::GetHWND(), &Win32Mix);

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1,8 +1,11 @@
 package org.ppsspp.ppsspp;
 
+import android.graphics.Point;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.henrikrydgard.libnative.NativeActivity;
+import com.henrikrydgard.libnative.NativeApp;
 import com.google.analytics.tracking.android.EasyTracker;
 
 public class PpssppActivity extends NativeActivity {
@@ -12,7 +15,9 @@ public class PpssppActivity extends NativeActivity {
 
 	// Key used by shortcut.
 	public static final String SHORTCUT_EXTRA_KEY = "org.ppsspp.ppsspp.Shortcuts";
-
+	
+	public static final String TAG = "PpssppActivity";
+	
 	public PpssppActivity() {
 		super();
 	}
@@ -37,5 +42,46 @@ public class PpssppActivity extends NativeActivity {
 	public void onStop() {
 		super.onStop();
 		EasyTracker.getInstance(this).activityStop(this);
+	}
+	
+	@Override
+	public void getDesiredBackbufferSize(Point sz) {
+		GetScreenSize(sz);
+		String config = NativeApp.queryConfig("hwScale");
+		int scale;
+		try {
+			scale = Integer.parseInt(config);
+			if (scale == 0) {
+				sz.x = 0;
+				sz.y = 0;
+				return;
+			}
+		}
+		catch (NumberFormatException e) {
+			sz.x = 0;
+			sz.y = 0;
+			return;
+		}
+		
+		float ratio = (float)sz.x / (float)sz.y;
+		//Log.i(TAG, "GetScreenSize returned: " + sz.x + "x" + sz.y + "=" + ratio);
+		float targetRatio;
+		if (sz.x > sz.y) {
+			targetRatio = 480.0f / 272.0f;
+			sz.x = 480 * scale;
+			sz.y = 272 * scale;
+		} else {
+			targetRatio = 272.0f / 480.0f;
+			sz.x = 272 * scale;
+			sz.y = 480 * scale;
+		}
+		//Log.i(TAG, "Target ratio: " + targetRatio + " ratio: " + ratio);
+		float correction = targetRatio / ratio;
+		if (ratio < targetRatio) {
+			sz.y *= correction;
+		} else {
+			sz.x *= correction;
+		}
+		//Log.i(TAG, "Corrected ratio: " + sz.x + " x " + sz.y);
 	}
 }


### PR DESCRIPTION
http://android-developers.blogspot.se/2013/09/using-hardware-scaler-for-performance.html

Uses this feature I added to native: https://github.com/hrydgard/native/commit/1012f46dee3473376eff2a549c64a7f2356461b0

This should help high-resolution devices a bit, like those zany 2560x1440 phones.

I can't figure out a good way to describe the option in the UI though...
