### PR TITLE
Win32 buildfix. Remove the new MAC address editing prompt, too.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -380,11 +380,11 @@ void GameSettingsScreen::CreateViews() {
 
 #ifdef _WIN32
 	systemSettings->Add(new PopupTextInputChoice(&g_Config.proAdhocServer, s->T("Change proAdhocServer Address"), "", screenManager()));
-	systemSettings->Add(new PopupTextInputChoice(&g_Config.localMacAddress, s->T("Change Mac Address"), "", screenManager()));
 #else
 	systemSettings->Add(new Choice(s->T("Change proAdhocServer Address")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeproAdhocServerAddress);
-	systemSettings->Add(new Choice(s->T("Change Mac Address")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeMacAddress);
 #endif
+
+	systemSettings->Add(new Choice(s->T("Change Mac Address")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeMacAddress);
 
 //#ifndef ANDROID
 	systemSettings->Add(new ItemHeader(s->T("Cheats", "Cheats (experimental, see forums)")));


### PR DESCRIPTION
Self-explanatory.
