### PR TITLE
Unpause lists after wait signals with no handler

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -193,6 +193,14 @@ public:
 			return true;
 		}
 
+		if (dl->signal == PSP_GE_SIGNAL_HANDLER_SUSPEND) {
+			if (sceKernelGetCompiledSdkVersion() <= 0x02000010) {
+				if (dl->state != PSP_GE_DL_STATE_NONE && dl->state != PSP_GE_DL_STATE_COMPLETED) {
+					dl->state = PSP_GE_DL_STATE_QUEUED;
+				}
+			}
+		}
+
 		ge_pending_cb.pop_front();
 		gpu->InterruptEnd(intrdata.listid);
 


### PR DESCRIPTION
This really should be correct behavior, and it fixes a hang in the gpu/displaylist/state test.

@xsacha there was some game you were showing me doing weird things with enqueuing lists... I wonder if this could help it?

-[Unknown]
