### PR TITLE
Improve module loading and allocation

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -598,7 +598,7 @@ SectionID ElfReader::GetSectionByName(const char *name, int firstSection)
 u32 ElfReader::GetTotalTextSize() const {
 	u32 total = 0;
 	for (int i = 0; i < GetNumSections(); ++i) {
-		if (!(sections[i].sh_flags & SHF_WRITE) && (sections[i].sh_flags & SHF_ALLOC)) {
+		if (!(sections[i].sh_flags & SHF_WRITE) && (sections[i].sh_flags & SHF_ALLOC) && !(sections[i].sh_flags & SHF_STRINGS)) {
 			total += sections[i].sh_size;
 		}
 	}

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -392,6 +392,11 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 
 	bool kernelModule = modInfo ? (modInfo->moduleAttrs & 0x1000) != 0 : false;
 	BlockAllocator &memblock = kernelModule ? kernelMemory : userMemory;
+	std::string modName = "ELF";
+	if (modInfo) {
+		size_t n = strnlen(modInfo->name, 28);
+		modName = "ELF/" + std::string(modInfo->name, n);
+	}
 
 	entryPoint = header->e_entry;
 	u32 totalStart = 0xFFFFFFFF;
@@ -409,17 +414,17 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 	if (!bRelocate)
 	{
 		// Binary is prerelocated, load it where the first segment starts
-		vaddr = memblock.AllocAt(totalStart, totalSize, "ELF");
+		vaddr = memblock.AllocAt(totalStart, totalSize, modName.c_str());
 	}
 	else if (loadAddress)
 	{
 		// Binary needs to be relocated: add loadAddress to the binary start address
-		vaddr = memblock.AllocAt(loadAddress + totalStart, totalSize, "ELF");
+		vaddr = memblock.AllocAt(loadAddress + totalStart, totalSize, modName.c_str());
 	}
 	else
 	{
 		// Just put it where there is room
-		vaddr = memblock.Alloc(totalSize, fromTop, "ELF");
+		vaddr = memblock.Alloc(totalSize, fromTop, modName.c_str());
 	}
 
 	if (vaddr == (u32)-1) {

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -24,6 +24,9 @@
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceKernelModule.h"
 
+#ifdef BLACKBERRY
+using std::strnlen;
+#endif
 
 const char *ElfReader::GetSectionName(int section)
 {

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -28,8 +28,7 @@
 using std::strnlen;
 #endif
 
-const char *ElfReader::GetSectionName(int section)
-{
+const char *ElfReader::GetSectionName(int section) const {
 	if (sections[section].sh_type == SHT_NULL)
 		return 0;
 
@@ -609,6 +608,17 @@ u32 ElfReader::GetTotalDataSize() const {
 	u32 total = 0;
 	for (int i = 0; i < GetNumSections(); ++i) {
 		if ((sections[i].sh_flags & SHF_WRITE) && (sections[i].sh_flags & SHF_ALLOC) && !(sections[i].sh_flags & SHF_MASKPROC)) {
+			total += sections[i].sh_size;
+		}
+	}
+	return total;
+}
+
+u32 ElfReader::GetTotalSectionSizeByPrefix(const std::string &prefix) const {
+	u32 total = 0;
+	for (int i = 0; i < GetNumSections(); ++i) {
+		const char *secname = GetSectionName(i);
+		if (secname && !strncmp(secname, prefix.c_str(), prefix.length())) {
 			total += sections[i].sh_size;
 		}
 	}

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -348,7 +348,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 }
 
 
-int ElfReader::LoadInto(u32 loadAddress)
+int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 {
 	DEBUG_LOG(LOADER,"String section: %i", header->e_shstrndx);
 
@@ -402,7 +402,7 @@ int ElfReader::LoadInto(u32 loadAddress)
 	else
 	{
 		// Just put it where there is room
-		vaddr = userMemory.Alloc(totalSize, false, "ELF");
+		vaddr = userMemory.Alloc(totalSize, fromTop, "ELF");
 	}
 
 	if (vaddr == (u32)-1) {

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -79,7 +79,7 @@ public:
 
 	int GetNumSegments() const { return (int)(header->e_phnum); }
 	int GetNumSections() const { return (int)(header->e_shnum); }
-	const char *GetSectionName(int section);
+	const char *GetSectionName(int section) const;
 	u8 *GetPtr(u32 offset) const {
 		return (u8*)base + offset;
 	}
@@ -132,6 +132,7 @@ public:
 
 	u32 GetTotalTextSize() const;
 	u32 GetTotalDataSize() const;
+	u32 GetTotalSectionSizeByPrefix(const std::string &prefix) const;
 
 	// More indepth stuff:)
 	int LoadInto(u32 vaddr, bool fromTop);

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -134,7 +134,7 @@ public:
 	u32 GetTotalDataSize() const;
 
 	// More indepth stuff:)
-	int LoadInto(u32 vaddr);
+	int LoadInto(u32 vaddr, bool fromTop);
 	bool LoadSymbols();
 	bool LoadRelocations(Elf32_Rel *rels, int numRelocs);
 	void LoadRelocations2(int rel_seg);

--- a/Core/ELF/ElfTypes.h
+++ b/Core/ELF/ElfTypes.h
@@ -148,6 +148,8 @@ enum ElfSectionFlags
 	SHF_WRITE     =0x1,
 	SHF_ALLOC     =0x2,
 	SHF_EXECINSTR =0x4,
+	SHF_MERGE     =0x10,
+	SHF_STRINGS   =0x20,
 	SHF_MASKPROC  =0xF0000000,
 };
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -888,15 +888,6 @@ int sceKernelReferFplStatus(SceUID uid, u32 statusPtr)
 //////////////////////////////////////////////////////////////////////////
 //00:49:12 <TyRaNiD> ector, well the partitions are 1 = kernel, 2 = user, 3 = me, 4 = kernel mirror :)
 
-enum MemblockType
-{
-	PSP_SMEM_Low = 0,
-	PSP_SMEM_High = 1,
-	PSP_SMEM_Addr = 2,
-	PSP_SMEM_LowAligned = 3,
-	PSP_SMEM_HighAligned = 4,
-};
-
 class PartitionMemoryBlock : public KernelObject
 {
 public:

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -438,6 +438,11 @@ void __KernelMemoryInit()
 
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_VPL, __KernelVplBeginCallback, __KernelVplEndCallback);
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_FPL, __KernelFplBeginCallback, __KernelFplEndCallback);
+
+	// The kernel statically allocates this memory, which has some code in it.
+	// It appears this is used for some common funcs in Kernel_Library (memcpy, lwmutex, suspend intr, etc.)
+	// Allocating this block is necessary to have the same memory semantics as real firmware.
+	userMemory.AllocAt(PSP_GetUserMemoryBase(), 0x4000, "usersystemlib");
 }
 
 void __KernelMemoryDoState(PointerWrap &p)

--- a/Core/HLE/sceKernelMemory.h
+++ b/Core/HLE/sceKernelMemory.h
@@ -20,11 +20,14 @@
 #include "../Util/BlockAllocator.h"
 #include "sceKernel.h"
 
-
-//todo: "real" memory block allocator, 
-// have elf loader grab its memory block first to avoid overwriting,
-// etc
-
+enum MemblockType
+{
+	PSP_SMEM_Low = 0,
+	PSP_SMEM_High = 1,
+	PSP_SMEM_Addr = 2,
+	PSP_SMEM_LowAligned = 3,
+	PSP_SMEM_HighAligned = 4,
+};
 
 extern BlockAllocator userMemory;
 extern BlockAllocator kernelMemory;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -970,6 +970,8 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std
 			module->nm.segmentsize[i] = reader.GetSegmentMemSize(i);
 			if (module->nm.segmentsize[i] != 0) {
 				module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
+			} else {
+				module->nm.segmentaddr[i] = 0;
 			}
 		}
 		module->nm.data_size += reader.GetSegmentDataSize(i);
@@ -1667,15 +1669,15 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 	SceKernelLMOption *lmoption = 0;
 	if (optionAddr) {
 		lmoption = (SceKernelLMOption *)Memory::GetPointer(optionAddr);
-		if (lmoption->position < 0 || lmoption->position > 4) {
+		if (lmoption->position < PSP_SMEM_Low || lmoption->position > PSP_SMEM_HighAligned) {
 			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position", name, lmoption->position);
 			return SCE_KERNEL_ERROR_ILLEGAL_MEMBLOCKTYPE;
 		}
-		if (lmoption->position == 3 || lmoption->position == 4) {
+		if (lmoption->position == PSP_SMEM_LowAligned || lmoption->position == PSP_SMEM_HighAligned) {
 			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position (aligned)", name, lmoption->position);
 			return SCE_KERNEL_ERROR_ILLEGAL_ALIGNMENT_SIZE;
 		}
-		if (lmoption->position == 2) {
+		if (lmoption->position == PSP_SMEM_Addr) {
 			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position (fixed)", name, lmoption->position);
 			return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
 		}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -902,7 +902,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std
 			delete [] newptr;
 		module->Cleanup();
 		kernelObjects.Destroy<Module>(module->GetUID());
-		error = -1;
+		error = SCE_KERNEL_ERROR_UNSUPPORTED_PRX_TYPE;
 		return 0;
 	}
 	// Open ELF reader
@@ -1635,12 +1635,13 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 
 	if (!info.exists) {
 		ERROR_LOG(LOADER, "sceKernelLoadModule(%s, %08x): File does not exist", name, flags);
-		return SCE_KERNEL_ERROR_NOFILE;
+		// ERRNO_FILE_NOT_FOUND
+		return 0x80010002;
 	}
 
 	if (!size) {
 		ERROR_LOG(LOADER, "sceKernelLoadModule(%s, %08x): Module file is size 0", name, flags);
-		return SCE_KERNEL_ERROR_ILLEGAL_OBJECT;
+		return SCE_KERNEL_ERROR_FILEERR;
 	}
 
 	DEBUG_LOG(LOADER, "sceKernelLoadModule(%s, %08x)", name, flags);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -941,8 +941,10 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std
 	// TODO: Is summing them up correct?  Must not be since the numbers aren't exactly right.
 	for (int i = 0; i < reader.GetNumSegments(); ++i) {
 		if (i < (int)ARRAY_SIZE(module->nm.segmentaddr)) {
-			module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
 			module->nm.segmentsize[i] = reader.GetSegmentMemSize(i);
+			if (module->nm.segmentsize[i] != 0) {
+				module->nm.segmentaddr[i] = reader.GetSegmentVaddr(i);
+			}
 		}
 		module->nm.data_size += reader.GetSegmentDataSize(i);
 	}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -217,7 +217,8 @@ public:
 	Module() : textStart(0), textEnd(0), memoryBlockAddr(0), isFake(false) {}
 	~Module() {
 		if (memoryBlockAddr) {
-			if (memoryBlockAddr < PSP_GetUserMemoryBase()) {
+			// If it's either below user memory, or using a high kernel bit, it's in kernel.
+			if (memoryBlockAddr < PSP_GetUserMemoryBase() || memoryBlockAddr > PSP_GetUserMemoryEnd()) {
 				kernelMemory.Free(memoryBlockAddr);
 			} else {
 				userMemory.Free(memoryBlockAddr);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -994,12 +994,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std
 		module->nm.text_size = 0;
 	}
 
-	SectionID bssSection = reader.GetSectionByName(".bss");
-	if (bssSection != -1) {
-		module->nm.bss_size = reader.GetSectionSize(bssSection);
-	} else {
-		module->nm.bss_size = 0;
-	}
+	module->nm.bss_size = reader.GetTotalSectionSizeByPrefix(".bss");
 	module->nm.data_size = reader.GetTotalDataSize() - module->nm.bss_size;
 
 	INFO_LOG(LOADER, "Module %s: %08x %08x %08x", modinfo->name, modinfo->gp, modinfo->libent, modinfo->libstub);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2038,6 +2038,7 @@ void __KernelReturnFromModuleFunc()
 
 	if (module->nm.status == MODULE_STATUS_UNLOADING) {
 		// TODO: Delete the waiting thread?
+		module->Cleanup();
 		kernelObjects.Destroy<Module>(leftModuleID);
 	}
 }

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1702,7 +1702,7 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 
 		if (info.name == "BOOT.BIN")
 		{
-			NOTICE_LOG(LOADER, "Module %s is blacklisted or undecryptable - we try __KernelLoadExec", name);
+			NOTICE_LOG_REPORT(LOADER, "Module %s is blacklisted or undecryptable - we try __KernelLoadExec", name);
 			// Name might get deleted.
 			const std::string safeName = name;
 			return __KernelLoadExec(safeName.c_str(), 0, &error_string);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1651,6 +1651,18 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 	SceKernelLMOption *lmoption = 0;
 	if (optionAddr) {
 		lmoption = (SceKernelLMOption *)Memory::GetPointer(optionAddr);
+		if (lmoption->position < 0 || lmoption->position > 4) {
+			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position", name, lmoption->position);
+			return SCE_KERNEL_ERROR_ILLEGAL_MEMBLOCKTYPE;
+		}
+		if (lmoption->position == 3 || lmoption->position == 4) {
+			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position (aligned)", name, lmoption->position);
+			return SCE_KERNEL_ERROR_ILLEGAL_ALIGNMENT_SIZE;
+		}
+		if (lmoption->position == 2) {
+			ERROR_LOG_REPORT(LOADER, "sceKernelLoadModule(%s): invalid position (fixed)", name, lmoption->position);
+			return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
+		}
 		WARN_LOG_REPORT(LOADER, "sceKernelLoadModule: unsupported options size=%08x, flags=%08x, pos=%d, access=%d, data=%d, text=%d", lmoption->size, lmoption->flags, lmoption->position, lmoption->access, lmoption->mpiddata, lmoption->mpidtext);
 	}
 

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -20,6 +20,18 @@
 #include <string>
 #include "Core/HLE/sceKernel.h"
 
+struct PspModuleInfo {
+	u16_le moduleAttrs; //0x0000 User Mode, 0x1000 Kernel Mode
+	u16_le moduleVersion;
+	// 28 bytes of module name, packed with 0's.
+	char name[28];
+	u32_le gp;               // ptr to MIPS GOT data  (global offset table)
+	u32_le libent;           // ptr to .lib.ent section
+	u32_le libentend;        // ptr to end of .lib.ent section
+	u32_le libstub;          // ptr to .lib.stub section
+	u32_le libstubend;       // ptr to end of .lib.stub section
+};
+
 class PointerWrap;
 
 KernelObject *__KernelModuleObject();

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -452,7 +452,7 @@ inline u32 PSP_GetKernelMemoryEnd() { return 0x08400000;}
 
 inline u32 PSP_GetUserMemoryBase() { return 0x08800000;}
 
-inline u32 PSP_GetDefaultLoadAddress() { return 0x08804000;}
+inline u32 PSP_GetDefaultLoadAddress() { return 0;}
 //inline u32 PSP_GetDefaultLoadAddress() { return 0x0898dab0;}
 inline u32 PSP_GetVidMemBase() { return 0x04000000;}
 inline u32 PSP_GetVidMemEnd() { return 0x04800000;}


### PR DESCRIPTION
This is a bit of a large pull request.

Probably need to check these first:
- Metal Gear Solid Portable Ops (Chinese Patch)
- Kamen Rider Climax Heroes OOO

The overall goal is to make module allocation and memory management more correct.  This means:
- Allocate from top when specified.
- Use kernel memory for kernel modules, user memory for encrypted user modules.
- Eat 0x4000 at the bottom of RAM, normally used for Kernel_Library funcs in userspace.
- Correct more module info numbers.
- Leave holes in memory where allocations don't align (and also VPLs etc. I suppose.)
- Allocate for utility modules (based on 6.60.)
- Handle dependency requirements when loading utility modules.

This could break a bunch of things.  May want to merge after any dust settles and we're sure we're not doing a follow-up.

-[Unknown]
