### PR TITLE
Ignore the filename in "umd0:xxx"

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -311,7 +311,10 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 	if (path[0] == '/')
 		path.erase(0,1);
 
-	if (path == "umd0")
+	// Ignore the filename in "umd0:xxx".
+	// Using umd0: is always opening the whole UMD in sector block mode,
+	// ignoring the file name specified after the colon.
+	if (path.substr(0, 3) == "umd")
 		return &entireISO;
 
 	TreeEntry *e = treeroot;


### PR DESCRIPTION
Based on http://code.google.com/p/jpcsp/source/detail?r=2215
The change fix Bleach Soul Carnival 2 in jpcsp emulator
But there is another problem in PPSSPP
![1](https://cloud.githubusercontent.com/assets/2177532/3712526/49a1585c-151a-11e4-8b83-cbbb7dc262e3.jpg)
mark #875
