### PR TITLE
umd0 solution: Add "OnlyEntireISOFileSystem" to fix #6638

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -299,9 +299,8 @@ void ISOFileSystem::ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root,
 
 ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catchError)
 {
-	if (path.length() == 0)
-	{
-		//Ah, the device!	"umd0:"
+	if (path.length() == 0) {
+		// Ah, the device!	"umd0:"
 		return &entireISO;
 	}
 
@@ -310,9 +309,6 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 
 	if (path[0] == '/')
 		path.erase(0,1);
-
-	if (path == "umd0")
-		return &entireISO;
 
 	TreeEntry *e = treeroot;
 	if (path.length() == 0)
@@ -724,6 +720,12 @@ std::string ISOFileSystem::EntryFullPath(TreeEntry *e)
 	}
 
 	return path;
+}
+
+ISOFileSystem::TreeEntry::~TreeEntry() {
+	for (size_t i = 0; i < children.size(); ++i)
+		delete children[i];
+	children.clear();
 }
 
 void ISOFileSystem::DoState(PointerWrap &p)

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -96,11 +96,14 @@ private:
 // On the "umd0:" device, any file you open is the entire ISO.
 // Simply wrap around an ISOFileSystem which has all the necessary machinery, while changing
 // the filenames to "", to achieve this.
-class OnlyEntireISOFileSystem : public IFileSystem {
+class ISOBlockSystem : public IFileSystem {
 public:
-	OnlyEntireISOFileSystem(ISOFileSystem *isoFileSystem) : isoFileSystem_(isoFileSystem) {}
+	ISOBlockSystem(ISOFileSystem *isoFileSystem) : isoFileSystem_(isoFileSystem) {}
 
-	void DoState(PointerWrap &p) override {}
+	void DoState(PointerWrap &p) override {
+		// This is a bit iffy, as block device savestates already are iffy (loads/saves multiple times for multiple mounts..)
+		isoFileSystem_->DoState(p);
+	}
 
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override { return std::vector<PSPFileInfo>(); }
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename = NULL) override {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -60,6 +60,7 @@ void InitMemoryForGameISO(std::string fileToStart) {
 	FileInfo info;
 	if (!getFileInfo(fileToStart.c_str(), &info)) return;
 
+	bool actualIso = false;
 	if (info.isDirectory)
 	{
 		umd2 = new VirtualDiscFileSystem(&pspFileSystem, fileToStart);
@@ -71,15 +72,24 @@ void InitMemoryForGameISO(std::string fileToStart) {
 		if (!bd)
 			return;
 		umd2 = new ISOFileSystem(&pspFileSystem, bd);
+		actualIso = true;
 	}
 
 	// Parse PARAM.SFO
 
 	//pspFileSystem.Mount("host0:",umd2);
-	pspFileSystem.Mount("umd0:", umd2);
-	pspFileSystem.Mount("umd1:", umd2);
+
+	IFileSystem *entireIso = 0;
+	if (actualIso) {
+		entireIso = new OnlyEntireISOFileSystem(static_cast<ISOFileSystem *>(umd2));
+	} else {
+		entireIso = umd2;
+	}
+
+	pspFileSystem.Mount("umd0:", entireIso);
+	pspFileSystem.Mount("umd1:", entireIso);
 	pspFileSystem.Mount("disc0:", umd2);
-	pspFileSystem.Mount("umd:", umd2);
+	pspFileSystem.Mount("umd:", entireIso);
 
 	std::string gameID;
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -81,7 +81,7 @@ void InitMemoryForGameISO(std::string fileToStart) {
 
 	IFileSystem *entireIso = 0;
 	if (actualIso) {
-		entireIso = new OnlyEntireISOFileSystem(static_cast<ISOFileSystem *>(umd2));
+		entireIso = new ISOBlockSystem(static_cast<ISOFileSystem *>(umd2));
 	} else {
 		entireIso = umd2;
 	}


### PR DESCRIPTION
Wraps around an ISOFileSystem, redirecting all the filenames to "" to achieve the desired effect (should fix Bleach Soul Carnival 2 without resorting to CPkmn's hack from #6638)

This is for discussion to begin with, I'm not sure this is the best solution.

Probably breaks savestates as-is... I'm actually confused by our MetaFileSystem::DoState , seems like it may store a system multiple times if it's mounted on several points.

Also, a nicer name for the class would be good...
