### PR TITLE
Win32: Add a "Driver Version" line in the System Information dev tool screen.

### DIFF
--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -233,6 +233,9 @@ void SystemInfoScreen::CreateViews() {
 	deviceSpecs->Add(new ItemHeader("GPU Information"));
 	deviceSpecs->Add(new InfoItem("Vendor", (char *)glGetString(GL_VENDOR)));
 	deviceSpecs->Add(new InfoItem("Model", (char *)glGetString(GL_RENDERER)));
+#ifdef _WIN32
+	deviceSpecs->Add(new InfoItem("Driver Version", System_GetProperty(SYSPROP_GPUDRIVER_VERSION)));
+#endif
 	deviceSpecs->Add(new ItemHeader("OpenGL Version Information"));
 	std::string openGL = (char *)glGetString(GL_VERSION);
 	openGL.resize(30);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -17,6 +17,7 @@
 
 #include <WinNls.h>
 #include <math.h>
+#include <Wbemidl.h>
 
 #include "Common/CommonWindows.h"
 
@@ -67,6 +68,7 @@ CMemoryDlg *memoryWindow[MAX_CPUCOUNT] = {0};
 
 static std::string langRegion;
 static std::string osName;
+static std::string gpuDriverVersion;
 
 typedef BOOL(WINAPI *isProcessDPIAwareProc)();
 typedef BOOL(WINAPI *setProcessDPIAwareProc)();
@@ -158,6 +160,55 @@ std::string GetWindowsSystemArchitecture() {
 		return "(Unknown)";
 }
 
+// Adapted mostly as-is from http://www.gamedev.net/topic/495075-how-to-retrieve-info-about-videocard/?view=findpost&p=4229170
+// so credit goes to that post's author, and in turn, the author of the site mentioned in that post (which seems to be down?).
+std::string GetVideoCardDriverVersion()
+{
+	std::string retvalue = "";
+
+	HRESULT hr;
+	hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+
+	IWbemLocator *pIWbemLocator = NULL;
+	hr = CoCreateInstance(__uuidof(WbemLocator), NULL, CLSCTX_INPROC_SERVER, 
+		__uuidof(IWbemLocator), (LPVOID *)&pIWbemLocator);
+
+	BSTR bstrServer = SysAllocString(L"\\\\.\\root\\cimv2");
+	IWbemServices *pIWbemServices;
+	hr = pIWbemLocator->ConnectServer(bstrServer, NULL, NULL, 0L, 0L, NULL,	NULL, &pIWbemServices);
+
+	hr = CoSetProxyBlanket(pIWbemServices, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, 
+		NULL, RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, NULL,EOAC_DEFAULT);
+
+	BSTR bstrWQL = SysAllocString(L"WQL");
+	BSTR bstrPath = SysAllocString(L"select * from Win32_VideoController");
+	IEnumWbemClassObject* pEnum;
+	hr = pIWbemServices->ExecQuery(bstrWQL, bstrPath, WBEM_FLAG_FORWARD_ONLY, NULL, &pEnum);
+
+	IWbemClassObject* pObj = NULL;
+	ULONG uReturned;
+	VARIANT var;
+	hr = pEnum->Next(WBEM_INFINITE, 1, &pObj, &uReturned);
+
+	if (uReturned) {
+		hr = pObj->Get(L"DriverVersion", 0, &var, NULL, NULL);
+		if (SUCCEEDED(hr)) {
+			char str[MAX_PATH];
+			WideCharToMultiByte(CP_ACP, 0, var.bstrVal, -1, str, sizeof(str), NULL, NULL);
+			retvalue = str;
+		}
+	}
+
+	pEnum->Release();
+	SysFreeString(bstrPath);
+	SysFreeString(bstrWQL);
+	pIWbemServices->Release();
+	SysFreeString(bstrServer);
+	CoUninitialize();
+
+	return retvalue;
+}
+
 std::string System_GetProperty(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_NAME:
@@ -179,6 +230,8 @@ std::string System_GetProperty(SystemProperty prop) {
 			}
 			return retval;
 		}
+	case SYSPROP_GPUDRIVER_VERSION:
+		return gpuDriverVersion;
 	default:
 		return "";
 	}
@@ -313,6 +366,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	}
 
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();
+	gpuDriverVersion = GetVideoCardDriverVersion();
 
 	const char *configFilename = NULL;
 	const char *configOption = "--config=";

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -162,8 +162,7 @@ std::string GetWindowsSystemArchitecture() {
 
 // Adapted mostly as-is from http://www.gamedev.net/topic/495075-how-to-retrieve-info-about-videocard/?view=findpost&p=4229170
 // so credit goes to that post's author, and in turn, the author of the site mentioned in that post (which seems to be down?).
-std::string GetVideoCardDriverVersion()
-{
+std::string GetVideoCardDriverVersion() {
 	std::string retvalue = "";
 
 	HRESULT hr;


### PR DESCRIPTION
Requires https://github.com/hrydgard/native/pull/225 ~~(hence why Travis is failing)~~. Other platforms can feel free to add their platform-specific code as needed.

As stated in the comment, I mostly adapted (e.g. changed the styling slightly) it as is from http://www.gamedev.net/topic/495075-how-to-retrieve-info-about-videocard/?view=findpost&p=4229170. There probably aren't too many unique ways of querying WMI for this stuff..

![menu_00006](https://cloud.githubusercontent.com/assets/4482745/3760242/54674830-1873-11e4-8f3e-d7e6e89e4a00.jpg)
