### PR TITLE
Remove bgm and sfx volume settings

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -446,9 +446,7 @@ static ConfigSetting graphicsSettings[] = {
 
 static ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", &g_Config.bEnableSound, true),
-	ConfigSetting("VolumeBGM", &g_Config.iBGMVolume, 7),
-	ConfigSetting("VolumeSFX", &g_Config.iSFXVolume, 7),
-	ConfigSetting("AudioLatency", &g_Config.IaudioLatency, 1),
+	ConfigSetting("AudioLatency", &g_Config.iAudioLatency, 1),
 	ConfigSetting("SoundSpeedHack", &g_Config.bSoundSpeedHack, false),
 
 	ConfigSetting(false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -27,7 +27,6 @@
 extern const char *PPSSPP_GIT_VERSION;
 #endif
 
-const int MAX_CONFIG_VOLUME = 8;
 const int PSP_MODEL_FAT = 0;
 const int PSP_MODEL_SLIM = 1;
 const int PSP_DEFAULT_FIRMWARE = 150;
@@ -154,9 +153,7 @@ public:
 
 	// Sound
 	bool bEnableSound;
-	int IaudioLatency; // 0 = low , 1 = medium(default) , 2 = high
-	int iSFXVolume;
-	int iBGMVolume;
+	int iAudioLatency; // 0 = low , 1 = medium(default) , 2 = high
 
 	// Audio Hack
 	bool bSoundSpeedHack;

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -106,7 +106,7 @@ void __AudioCPUMHzChange() {
 void __AudioInit() {
 	mixFrequency = 44100;
 
-	switch (g_Config.IaudioLatency) {
+	switch (g_Config.iAudioLatency) {
 	case LOW_LATENCY:
 		chanQueueMaxSizeFactor = 1;
 		chanQueueMinSizeFactor = 1;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -654,7 +654,6 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 							if (avret < 0) {
 								ERROR_LOG(ME, "swr_convert: Error while converting %d", avret);
 							}
-							__AdjustBGMVolume((s16 *)out, numSamples * atrac->atracOutputChannels);
 						}
 					}
 					av_free_packet(&packet);
@@ -1868,7 +1867,6 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 					if (avret < 0) {
 						ERROR_LOG(ME, "swr_convert: Error while converting %d", avret);
 					}
-					__AdjustBGMVolume((s16 *)out, numSamples * atrac->atracOutputChannels);
 				}
 				av_free_packet(&packet);
 				if (got_frame)

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -115,17 +115,6 @@ static int getPixelFormatBytes(int pspFormat)
 	}
 }
 
-void __AdjustBGMVolume(s16 *samples, u32 count) {
-	if (g_Config.iBGMVolume < 0 || g_Config.iBGMVolume >= MAX_CONFIG_VOLUME) {
-		return;
-	}
-
-	int volumeShift = MAX_CONFIG_VOLUME - g_Config.iBGMVolume;
-	for (u32 i = 0; i < count; ++i) {
-		samples[i] >>= volumeShift;
-	}
-}
-
 MediaEngine::MediaEngine(): m_pdata(0) {
 #ifdef USE_FFMPEG
 	m_pFormatCtx = 0;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -50,8 +50,6 @@ inline s64 getMpegTimeStamp(const u8 *buf) {
 bool InitFFmpeg();
 #endif
 
-void __AdjustBGMVolume(s16 *samples, u32 count);
-
 class MediaEngine
 {
 public:

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -483,8 +483,6 @@ void SasInstance::MixVoice(SasVoice &voice) {
 
 		u32 sampleFrac = voice.sampleFrac;
 		// We need to shift by 12 anyway, so combine that with the volume shift.
-		int volumeShift = (12 + MAX_CONFIG_VOLUME - g_Config.iSFXVolume);
-		if (volumeShift < 0) volumeShift = 0;
 		for (int i = 0; i < grainSize; i++) {
 			// For now: nearest neighbour, not even using the resample history at all.
 			int sample = resampleBuffer[sampleFrac / PSP_SAS_PITCH_BASE + 2];
@@ -502,10 +500,10 @@ void SasInstance::MixVoice(SasVoice &voice) {
 			// We mix into this 32-bit temp buffer and clip in a second loop
 			// Ideally, the shift right should be there too but for now I'm concerned about
 			// not overflowing.
-			mixBuffer[i * 2] += (sample * voice.volumeLeft ) >> volumeShift; // Max = 16 and Min = 12(default)
-			mixBuffer[i * 2 + 1] += (sample * voice.volumeRight) >> volumeShift; // Max = 16 and Min = 12(default)
-			sendBuffer[i * 2] += sample * voice.effectLeft >> volumeShift;
-			sendBuffer[i * 2 + 1] += sample * voice.effectRight >> volumeShift;
+			mixBuffer[i * 2] += (sample * voice.volumeLeft ) >> 12;
+			mixBuffer[i * 2 + 1] += (sample * voice.volumeRight) >> 12;
+			sendBuffer[i * 2] += sample * voice.effectLeft >> 12;
+			sendBuffer[i * 2 + 1] += sample * voice.effectRight >> 12;
 			voice.envelope.Step();
 		}
 

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -243,8 +243,6 @@ bool SimpleAudio::Decode(void* inbuf, int inbytes, uint8_t *outbuf, int *outbyte
 
 		// each sample occupies 2 bytes
 		*outbytes = outSamples * 2;
-		// We always convert to stereo.
-		__AdjustBGMVolume((s16 *)outbuf, frame_->nb_samples * 2);
 
 		// Save outbuf into pcm audio, you can uncomment this line to save and check the decoded audio into pcm file.
 		// SaveAudio("dump.pcm", outbuf, *outbytes);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -292,14 +292,9 @@ void GameSettingsScreen::CreateViews() {
 
 	audioSettings->Add(new ItemHeader(ms->T("Audio")));
 
-	PopupSliderChoice *sfxVol = audioSettings->Add(new PopupSliderChoice(&g_Config.iSFXVolume, 0, MAX_CONFIG_VOLUME, a->T("SFX volume"), screenManager()));
-	sfxVol->SetEnabledPtr(&g_Config.bEnableSound);
-	PopupSliderChoice *bgmVol = audioSettings->Add(new PopupSliderChoice(&g_Config.iBGMVolume, 0, MAX_CONFIG_VOLUME, a->T("BGM volume"), screenManager()));
-	bgmVol->SetEnabledPtr(&g_Config.bEnableSound);
-
 	audioSettings->Add(new CheckBox(&g_Config.bEnableSound, a->T("Enable Sound")));
 	static const char *latency[] = { "Low", "Medium", "High" };
-	PopupMultiChoice *lowAudio = audioSettings->Add(new PopupMultiChoice(&g_Config.IaudioLatency, a->T("Audio Latency"), latency, 0, ARRAY_SIZE(latency), gs, screenManager()));
+	PopupMultiChoice *lowAudio = audioSettings->Add(new PopupMultiChoice(&g_Config.iAudioLatency, a->T("Audio Latency"), latency, 0, ARRAY_SIZE(latency), gs, screenManager()));
 	lowAudio->SetEnabledPtr(&g_Config.bEnableSound);
 
 	audioSettings->Add(new ItemHeader(a->T("Audio hacks")));

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -343,8 +343,6 @@ int main(int argc, const char* argv[])
 	g_Config.bFrameSkipUnthrottle = false;
 	g_Config.bEnableLogging = fullLog;
 	g_Config.iNumWorkerThreads = 1;
-	g_Config.iBGMVolume = MAX_CONFIG_VOLUME;
-	g_Config.iSFXVolume = MAX_CONFIG_VOLUME;
 	g_Config.bSoftwareSkinning = true;
 	g_Config.bVertexDecoderJit = true;
 	g_Config.bBlockTransferGPU = true;


### PR DESCRIPTION
They don't actually work in all games, and this only confuses users.

Also, the default 7 lowers the volume of audio detected as bgm or sfx, but not other volume.  This means that some audio may have played too loud in some games by default, which will be fixed by this change.

The poll on the forum did not get many responses.  The top response was "I don't care", and the second response was "remove the settings."  Fixes #2659.

I'm not aware of any devices without decent volume controls (except my phone, the volume buttons were missing when I got it, but I don't really care.)

-[Unknown]
