### PR TITLE
Use glStencilMask() to partially simulate amask

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -176,6 +176,7 @@ void FramebufferManager::ClearBuffer() {
 	glstate.depthWrite.set(GL_TRUE);
 	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	glstate.stencilFunc.set(GL_ALWAYS, 0, 0);
+	glstate.stencilMask.set(0xFF);
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 	glClearStencil(0);
 #ifdef USING_GLES2
@@ -207,6 +208,7 @@ void FramebufferManager::DisableState() {
 	glstate.colorLogicOp.disable();
 #endif
 	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glstate.stencilMask.set(0xFF);
 }
 
 void FramebufferManager::SetNumExtraFBOs(int num) {

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -411,6 +411,7 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 
 		// Note that scissor may still apply while clearing.  Turn off other tests for the clear.
 		glstate.stencilTest.disable();
+		glstate.stencilMask.set(0xFF);
 		glstate.depthTest.disable();
 
 		GLbitfield target = 0;

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -455,6 +455,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			// We should set "ref" to that value instead of 0.
 			// In case of clear rectangles, we set it again once we know what the color is.
 			glstate.stencilFunc.set(GL_ALWAYS, 255, 0xFF);
+			glstate.stencilMask.set(0xFF);
 		} else {
 			glstate.stencilTest.disable();
 		}
@@ -505,6 +506,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			WARN_LOG_REPORT_ONCE(rgbmask, G3D, "Unsupported RGB mask: r=%02x g=%02x b=%02x", rbits, gbits, bbits);
 		}
 		if (abits != 0 && abits != 0xFF) {
+			// The stencil part of the mask is supported.
 			WARN_LOG_REPORT_ONCE(amask, G3D, "Unsupported alpha/stencil mask: %02x", abits);
 		}
 #endif
@@ -530,6 +532,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.stencilOp.set(stencilOps[gstate.getStencilOpSFail()],  // stencil fail
 				stencilOps[gstate.getStencilOpZFail()],  // depth fail
 				stencilOps[gstate.getStencilOpZPass()]); // depth pass
+			glstate.stencilMask.set(~abits);
 		} else {
 			glstate.stencilTest.disable();
 		}

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -210,18 +210,18 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size, bool skipZero) 
 		// DrawActiveTexture unbinds it, so rebind here before setting uniforms.
 		glsl_bind(stencilUploadProgram_);
 		if (dstBuffer->format == GE_FORMAT_4444) {
-			glStencilMask(Convert4To8(i));
+			glstate.stencilMask.set(Convert4To8(i));
 			glUniform1f(u_stencilValue, i * (16.0f / 255.0f));
 		} else if (dstBuffer->format == GE_FORMAT_5551) {
-			glStencilMask(0xFF);
+			glstate.stencilMask.set(0xFF);
 			glUniform1f(u_stencilValue, i * (128.0f / 255.0f));
 		} else {
-			glStencilMask(i);
+			glstate.stencilMask.set(i);
 			glUniform1f(u_stencilValue, i * (1.0f / 255.0f));
 		}
 		DrawActiveTexture(0, 0, 0, dstBuffer->width, dstBuffer->height, dstBuffer->bufferWidth, dstBuffer->bufferHeight, false, 0.0f, 0.0f, 1.0f, 1.0f, stencilUploadProgram_);
 	}
-	glStencilMask(0xFF);
+	glstate.stencilMask.set(0xFF);
 
 	if (useBlit) {
 		fbo_bind_as_render_target(dstBuffer->fbo);

--- a/UI/UIShader.cpp
+++ b/UI/UIShader.cpp
@@ -95,6 +95,7 @@ void UIShader_Prepare()
 	glstate.depthTest.disable();
 	glstate.scissorTest.disable();
 	glstate.stencilTest.disable();
+	glstate.stencilMask.set(0xFF);
 #if !defined(USING_GLES2)
   	glstate.colorLogicOp.disable();
 #endif 


### PR DESCRIPTION
Alpha won't be correct, though.  Not well tested.

This depends on part of hrydgard/native#226, ddf67c5f72d79a392eea1dbcbd76251352c7c671, but it will conflict with #6679.  All that needs to happen is native updated to tip if that is merged first, or I can just update the pull.

@daniel229 does this improve anything in Silent Hill?  I don't really know if it will or not.

-[Unknown]
