### PR TITLE
Try to allocate executable memory close to PPSSPP memory if not below 4GB

### DIFF
--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -170,10 +170,12 @@ void* AllocateExecutableMemory(size_t size, bool exec)
 #endif
 		PanicAlert("Failed to allocate executable memory");
 	}
+#if defined(_M_X64) && !defined(_WIN32)
 	else if (exec && (uintptr_t) map_hint <= 0xFFFFFFFF)
 	{
 		map_hint += round_page(size); /* round up if we're below 32-bit mark, probably allocating sequentially */
 	}
+#endif
 
 	return ptr;
 }

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -76,7 +76,7 @@ static void *SearchForFreeMem(size_t size)
 	while (VirtualQuery((void *)last_addr, &info, sizeof(info)) == sizeof(info))
 	{
 		// went too far, unusable for executable memory
-		if (last_addr + 0x80000000 < (uintptr_t) &hint_loction)
+		if (last_addr + 0x80000000 < (uintptr_t) &hint_location)
 			return NULL;
 
 		uintptr_t end = last_addr + size;

--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -27,7 +27,7 @@
 using std::size_t;
 #endif
 
-void* AllocateExecutableMemory(size_t size, bool low = true);
+void* AllocateExecutableMemory(size_t size, bool exec = true);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size,size_t alignment);


### PR DESCRIPTION
This tries to work around #1106 without having to remove RIP-relative addressing from the X64 emitter.

Both Windows and *nix follow a similar strategy: find the location of PPSSPP global variables in memory and try to find free memory areas below it. We don't search up because we could be at the upper-limit on usable memory in the process. On Windows we specifically query each memory region until we find one that is free. On *nix, we jump down 0.5GB in virtual memory and try allocating there, relying on the fact that mmap can search around if it can't use the exact address passed in. These new routines only happen if PPSSPP is in high memory (>0xFFFFFFFF) and if it's in low memory it falls back to the existing behavior for that.
