### PR TITLE
Add Buffer Scalling Filter option

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -390,6 +390,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true),
 	ReportedConfigSetting("SoftwareSkinning", &g_Config.bSoftwareSkinning, true),
 	ReportedConfigSetting("TextureFiltering", &g_Config.iTexFiltering, 1),
+	ReportedConfigSetting("BufferFiltering", &g_Config.iBufFilter, 1),
 	ReportedConfigSetting("InternalResolution", &g_Config.iInternalResolution, &DefaultInternalResolution),
 	ReportedConfigSetting("AndroidHwScale", &g_Config.iAndroidHwScale, &DefaultAndroidHwScale),
 	ReportedConfigSetting("FrameSkip", &g_Config.iFrameSkip, 0),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -109,6 +109,7 @@ public:
 
 	int iRenderingMode; // 0 = non-buffered rendering 1 = buffered rendering 2 = Read Framebuffer to memory (CPU) 3 = Read Framebuffer to memory (GPU)
 	int iTexFiltering; // 1 = off , 2 = nearest , 3 = linear , 4 = linear(CG)
+	int iBufFilter; // 1 = linear, 2 = nearest
 	bool bPartialStretch;
 	bool bStretchToDisplay;
 	bool bSmallDisplay;  // Useful on large tablets with touch controls to not overlap the image. Temporary setting - will be replaced by more comprehensive display size settings.

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -620,10 +620,8 @@ void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, flo
 		program = draw2dprogram_;
 	}
 
-	// Always use linear filtering when stretching a buffer to the screen. Might want to make this
-	// an option in the future.
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, g_Config.iBufFilter == SCALE_NEAREST ? GL_NEAREST : GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_Config.iBufFilter == SCALE_NEAREST ? GL_NEAREST : GL_LINEAR);
 
 	shaderManager_->DirtyLastShader();  // dirty lastShader_
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -37,6 +37,11 @@ enum TextureFiltering {
 	LINEARFMV = 4,
 };
 
+enum BufferFilter {
+	SCALE_LINEAR = 1,
+	SCALE_NEAREST = 2,
+};
+
 enum FramebufferNotification {
 	NOTIFY_FB_CREATED,
 	NOTIFY_FB_UPDATED,

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -245,6 +245,10 @@ void GameSettingsScreen::CreateViews() {
 	PopupMultiChoice *texFilter = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexFiltering, gs->T("Texture Filter"), texFilters, 1, ARRAY_SIZE(texFilters), gs, screenManager()));
 	texFilter->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
+	static const char *bufFilters[] = { "Linear", "Nearest", };
+	PopupMultiChoice *bufFilter = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iBufFilter, gs->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gs, screenManager()));
+	bufFilter->SetDisabledPtr(&g_Config.bSoftwareRendering);
+
 	graphicsSettings->Add(new ItemHeader(gs->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 	graphicsSettings->Add(new CheckBox(&g_Config.bTimerHack, gs->T("Timer Hack")));
 	CheckBox *alphaHack = graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gs->T("Disable Alpha Test (PowerVR speedup)")));

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -468,7 +468,8 @@ namespace MainWindow
 		SUBMENU_RENDERING_MODE = 13,
 		SUBMENU_FRAME_SKIPPING = 14,
 		SUBMENU_TEXTURE_FILTERING = 15,
-		SUBMENU_TEXTURE_SCALING = 16,
+		SUBMENU_BUFFER_FILTER = 16,
+		SUBMENU_TEXTURE_SCALING = 17,
 	};
 
 	std::string GetMenuItemText(int menuID) {
@@ -666,6 +667,9 @@ namespace MainWindow
 		TranslateMenuItem(ID_OPTIONS_NEARESTFILTERING);
 		TranslateMenuItem(ID_OPTIONS_LINEARFILTERING);
 		TranslateMenuItem(ID_OPTIONS_LINEARFILTERING_CG);
+		TranslateSubMenu("Screen Scaling Filter", MENU_OPTIONS, SUBMENU_BUFFER_FILTER);
+		TranslateMenuItem(ID_OPTIONS_BUFLINEARFILTER);
+		TranslateMenuItem(ID_OPTIONS_BUFNEARESTFILTER);
 		TranslateSubMenu("Texture Scaling", MENU_OPTIONS, SUBMENU_TEXTURE_SCALING);
 		TranslateMenuItem(ID_TEXTURESCALING_OFF);
 		// Skip texture scaling 2x-5x...
@@ -698,6 +702,10 @@ namespace MainWindow
 
 	void setTexFiltering(int type) {
 		g_Config.iTexFiltering = type;
+	}
+
+	void setBufFilter(int type) {
+		g_Config.iBufFilter = type;
 	}
 
 	void setTexScalingType(int type) {
@@ -1524,6 +1532,9 @@ namespace MainWindow
 				case ID_OPTIONS_LINEARFILTERING:       setTexFiltering(LINEAR); break;
 				case ID_OPTIONS_LINEARFILTERING_CG:    setTexFiltering(LINEARFMV); break;
 
+				case ID_OPTIONS_BUFLINEARFILTER:       setBufFilter(SCALE_LINEAR); break;
+				case ID_OPTIONS_BUFNEARESTFILTER:      setBufFilter(SCALE_NEAREST); break;
+
 				case ID_OPTIONS_TOPMOST:
 					g_Config.bTopMost = !g_Config.bTopMost;
 					W32Util::MakeTopMost(hWnd, g_Config.bTopMost);
@@ -1851,6 +1862,20 @@ namespace MainWindow
 
 		for (int i = 0; i < ARRAY_SIZE(texfilteringitems); i++) {
 			CheckMenuItem(menu, texfilteringitems[i], MF_BYCOMMAND | ((i + 1) == g_Config.iTexFiltering ? MF_CHECKED : MF_UNCHECKED));
+		}
+
+		static const int bufferfilteritems[] = {
+			ID_OPTIONS_BUFLINEARFILTER,
+			ID_OPTIONS_BUFNEARESTFILTER,
+		};
+		if (g_Config.iBufFilter < SCALE_LINEAR)
+			g_Config.iBufFilter = SCALE_LINEAR;
+
+		else if (g_Config.iBufFilter > SCALE_NEAREST)
+			g_Config.iBufFilter = SCALE_NEAREST;
+
+		for (int i = 0; i < ARRAY_SIZE(bufferfilteritems); i++) {
+			CheckMenuItem(menu, bufferfilteritems[i], MF_BYCOMMAND | ((i + 1) == g_Config.iBufFilter ? MF_CHECKED : MF_UNCHECKED));
 		}
 
 		static const int renderingmode[] = {

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -497,6 +497,11 @@ BEGIN
 								MENUITEM "Linear",                              ID_OPTIONS_LINEARFILTERING
 								MENUITEM "Linear on FMV",                       ID_OPTIONS_LINEARFILTERING_CG
 				END
+				POPUP "Screen Scaling Filter"
+						BEGIN
+								MENUITEM "Linear",                              ID_OPTIONS_BUFLINEARFILTER
+								MENUITEM "Nearest",                             ID_OPTIONS_BUFNEARESTFILTER
+				END
         POPUP "Texture Scaling"
         BEGIN
             MENUITEM "Off",                             ID_TEXTURESCALING_OFF

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -313,6 +313,8 @@
 #define IDC_GEDBG_TEXLEVELUP             40149
 #define ID_DEBUG_LOADSYMFILE             40150
 #define ID_DEBUG_SAVESYMFILE             40151
+#define ID_OPTIONS_BUFLINEARFILTER       40152
+#define ID_OPTIONS_BUFNEARESTFILTER      40153
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
 Not sure if we want another option in the graphic settings:|. This add's an option to change filter used while scalling buffers

 Current behaviour is always linear, which looks very blurry if you stretch low res like x1 to high res window/fullscreen. This can decrease quality of some shader effects and is also probably hated by many "sharpness" fanatics out there that has to(~ upscalling glitches / weak hardware) use low res.

 Defaults to linear, so no change for those that will not use it.
