### PR TITLE
Only loop psmf players at video end

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -193,7 +193,7 @@ void MediaEngine::DoState(PointerWrap &p){
 	u32 hasloadStream = m_pdata != NULL;
 	p.Do(hasloadStream);
 	if (hasloadStream && p.mode == p.MODE_READ)
-		loadStream(m_mpegheader, 2048, m_ringbuffersize);
+		reloadStream();
 #ifdef USE_FFMPEG
 	u32 hasopencontext = m_pFormatCtx != NULL;
 #else
@@ -338,6 +338,11 @@ bool MediaEngine::loadStream(const u8 *buffer, int readSize, int RingbufferSize)
 	m_demux = new MpegDemux(RingbufferSize + 2048, mpegoffset);
 	m_demux->addStreamData(buffer, readSize);
 	return true;
+}
+
+bool MediaEngine::reloadStream()
+{
+	return loadStream(m_mpegheader, 2048, m_ringbuffersize);
 }
 
 int MediaEngine::addStreamData(const u8 *buffer, int addSize) {

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -60,6 +60,7 @@ public:
 
 	void closeMedia();
 	bool loadStream(const u8 *buffer, int readSize, int RingbufferSize);
+	bool reloadStream();
 	// open the mpeg context
 	bool openContext();
 	void closeContext();


### PR DESCRIPTION
Otherwise we might reload the stream right away after reading in a short video.  May help #6734.

-[Unknown]
