### PR TITLE
Remove USE_FFMPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,6 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^armv7")
 	set(ARMV7 ON)
 endif()
 
-# Remove soon?
-set(USE_FFMPEG ON)
-
 if(ARM OR SIMULATOR)
 	set(USING_EGL ON)
 	set(MOBILE_DEVICE ON)
@@ -83,8 +80,6 @@ option(MOBILE_DEVICE "Set to ON when targetting a mobile device" ${MOBILE_DEVICE
 option(HEADLESS "Set to OFF to not generate the PPSSPPHeadless target" ${HEADLESS})
 option(UNITTEST "Set to ON to generate the unittest target" ${UNITTEST})
 option(SIMULATOR "Set to ON when targeting an x86 simulator of an ARM platform" ${SIMULATOR})
-# :: Options
-option(USE_FFMPEG "Build with FFMPEG support" ${USE_FFMPEG})
 
 if(ANDROID OR BLACKBERRY OR IOS)
 	if (NOT CMAKE_TOOLCHAIN_FILE)
@@ -375,7 +370,7 @@ add_library(stb_vorbis STATIC
 	native/ext/stb_vorbis/stb_vorbis.h)
 include_directories(native/ext/stb_vorbis)
 
-if(USE_FFMPEG AND NOT DEFINED FFMPEG_BUILDDIR)
+if(NOT DEFINED FFMPEG_BUILDDIR)
 	if(ANDROID)
 		if(ARMV7)
 			set(PLATFORM_ARCH "android/armv7")
@@ -433,50 +428,47 @@ if(USE_FFMPEG AND NOT DEFINED FFMPEG_BUILDDIR)
 			SET (FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} libswscale)
 		endif()
 	endif(DEFINED PLATFORM_ARCH)
-endif(USE_FFMPEG AND NOT DEFINED FFMPEG_BUILDDIR)
+endif(NOT DEFINED FFMPEG_BUILDDIR)
 
-if(USE_FFMPEG)
-	# Using shared libraries
-	if(DEFINED FFMPEG_BUILDDIR)
-		include_directories(ffmpeg ${FFMPEG_BUILDDIR})
+# Using shared libraries
+if(DEFINED FFMPEG_BUILDDIR)
+	include_directories(ffmpeg ${FFMPEG_BUILDDIR})
 
-		add_library(libavformat STATIC IMPORTED)
-		set_target_properties(libavformat PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavformat/libavformat.a)
-		add_library(libavcodec STATIC IMPORTED)
-		set_target_properties(libavcodec PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavcodec/libavcodec.a)
-		add_library(libavutil STATIC IMPORTED)
-		set_target_properties(libavutil PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavutil/libavutil.a)
-		add_library(libswresample STATIC IMPORTED)
-		set_target_properties(libswresample PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libswresample/libswresample.a)
-		add_library(libswscale STATIC IMPORTED)
-		set_target_properties(libswscale PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libswscale/libswscale.a)
+	add_library(libavformat STATIC IMPORTED)
+	set_target_properties(libavformat PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavformat/libavformat.a)
+	add_library(libavcodec STATIC IMPORTED)
+	set_target_properties(libavcodec PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavcodec/libavcodec.a)
+	add_library(libavutil STATIC IMPORTED)
+	set_target_properties(libavutil PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libavutil/libavutil.a)
+	add_library(libswresample STATIC IMPORTED)
+	set_target_properties(libswresample PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libswresample/libswresample.a)
+	add_library(libswscale STATIC IMPORTED)
+	set_target_properties(libswscale PROPERTIES IMPORTED_LOCATION ${FFMPEG_BUILDDIR}/libswscale/libswscale.a)
 
-		SET (FFMPEG_LIBRARIES
-			libavformat
-			libavcodec
-			libavutil
-			libswresample
-			libswscale
-		)
+	SET (FFMPEG_LIBRARIES
+		libavformat
+		libavcodec
+		libavutil
+		libswresample
+		libswscale
+	)
+endif()
+
+if(APPLE OR BLACKBERRY)
+	set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} iconv)
+endif()
+
+if(APPLE)
+	set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} bz2 "-framework CoreVideo")
+	if (NOT IOS)
+		set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} "-framework VideoDecodeAcceleration")
 	endif()
+endif(APPLE)
 
-	if(APPLE OR BLACKBERRY)
-		set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} iconv)
-	endif()
-
-	if(APPLE)
-		set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} bz2 "-framework CoreVideo")
-		if (NOT IOS)
-			set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} "-framework VideoDecodeAcceleration")
-		endif()
-	endif(APPLE)
-
-	set(LinkCommon ${LinkCommon} ${FFMPEG_LIBRARIES})
-	add_definitions(-DUSE_FFMPEG)
-endif(USE_FFMPEG)
+set(LinkCommon ${LinkCommon} ${FFMPEG_LIBRARIES})
 
 # Modification to show where we are pulling the ffmpeg libraries from.
-if(USE_FFMPEG AND DEFINED FFMPEG_LIBRARIES)
+if(DEFINED FFMPEG_LIBRARIES)
 	target_link_libraries(Common ${FFMPEG_LIBRARIES})
 	message(STATUS "FFMPEG library locations:")
 	if(DEFINED PLATFORM_ARCH)
@@ -500,11 +492,6 @@ if(USE_FFMPEG AND DEFINED FFMPEG_LIBRARIES)
 	endif(DEFINED PLATFORM_ARCH)
 else()
 	message(STATUS "ERROR: No FFMPEG library locations")
-endif()
-
-if(USE_FFMPEG AND NOT DEFINED FFMPEG_LIBRARIES)
-	message(WARNING "FFMPEG_BUILDDIR variable or manual path definition is required to enable FFmpeg. Disabling it.")
-	unset(USE_FFMPEG)
 endif()
 
 find_package(ZLIB)

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -71,7 +71,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86\include;../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;USE_FFMPEG;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -91,7 +91,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86_64\include;../common;..;../native;../native/ext/glew;../ext/zlib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;USE_FFMPEG;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <OmitFramePointers>false</OmitFramePointers>
@@ -117,7 +117,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;USE_FFMPEG;WIN32;_LIB;NDEBUG;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_LIB;NDEBUG;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -151,7 +151,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;USE_FFMPEG;WIN32;_LIB;NDEBUG;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_LIB;NDEBUG;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -72,15 +72,11 @@ const u32 ATRAC3PLUS_MAX_SAMPLES = 0x800;
 
 static const int atracDecodeDelay = 2300;
 
-#ifdef USE_FFMPEG
-
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libswresample/swresample.h>
 #include <libavutil/samplefmt.h>
 }
-
-#endif // USE_FFMPEG
 
 struct InputBuffer {
 	u32 addr;
@@ -113,14 +109,12 @@ struct Atrac {
 		failedDecode(false), resetBuffer(false), codecType(0) {
 		memset(&first, 0, sizeof(first));
 		memset(&second, 0, sizeof(second));
-#ifdef USE_FFMPEG
 		pFormatCtx = 0;
 		pAVIOCtx = 0;
 		pCodecCtx = 0;
 		pSwrCtx = 0;
 		pFrame = 0;
 		audio_stream_index = 0;
-#endif // USE_FFMPEG
 		atracContext = 0;
 	}
 
@@ -129,9 +123,7 @@ struct Atrac {
 	}
 
 	void CleanStuff() {
-#ifdef USE_FFMPEG
 		ReleaseFFMPEGContext();
-#endif // USE_FFMPEG
 
 		if (data_buf)
 			delete [] data_buf;
@@ -249,7 +241,6 @@ struct Atrac {
 
 	PSPPointer<SceAtracId> atracContext;
 
-#ifdef USE_FFMPEG
 	AVFormatContext *pFormatCtx;
 	AVIOContext	    *pAVIOCtx;
 	AVCodecContext  *pCodecCtx;
@@ -281,7 +272,6 @@ struct Atrac {
 		s64 seek_pos = (s64)sample;
 		av_seek_frame(pFormatCtx, audio_stream_index, seek_pos, 0);
 	}
-#endif // USE_FFMPEG
 };
 
 struct AtracSingleResetBufferInfo {
@@ -313,10 +303,8 @@ void __AtracInit() {
 	atracIDTypes[4] = 0;
 	atracIDTypes[5] = 0;
 
-#ifdef USE_FFMPEG
 	avcodec_register_all();
 	av_register_all();
-#endif // USE_FFMPEG
 }
 
 void __AtracDoState(PointerWrap &p) {
@@ -603,7 +591,7 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 			// TODO: This isn't at all right, but at least it makes the music "last" some time.
 			u32 numSamples = 0;
 			u32 atracSamplesPerFrame = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
-#ifdef USE_FFMPEG
+
 			if (!atrac->failedDecode && (atrac->codecType == PSP_MODE_AT_3 || atrac->codecType == PSP_MODE_AT_3_PLUS) && atrac->pCodecCtx) {
 				int forceseekSample = atrac->currentSample * 2 > atrac->endSample ? 0 : atrac->endSample;
 				atrac->SeekToSample(forceseekSample);
@@ -663,7 +651,6 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 					}
 				}
 			}
-#endif // USE_FFMPEG
 
 			*SamplesNum = numSamples;
 			// update current sample and decodePos
@@ -1032,11 +1019,9 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 		if (bytesWrittenFirstBuf > 0)
 			sceAtracAddStreamData(atracID, bytesWrittenFirstBuf);
 		atrac->currentSample = sample;
-#ifdef USE_FFMPEG
 		if ((atrac->codecType == PSP_MODE_AT_3 || atrac->codecType == PSP_MODE_AT_3_PLUS) && atrac->pCodecCtx) {
 			atrac->SeekToSample(sample);
 		} else
-#endif // USE_FFMPEG
 		{
 			atrac->decodePos = atrac->getDecodePosBySample(sample);
 		}
@@ -1044,7 +1029,6 @@ u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf,
 	return 0;
 }
 
-#ifdef USE_FFMPEG
 static int _AtracReadbuffer(void *opaque, uint8_t *buf, int buf_size) {
 	Atrac *atrac = (Atrac *)opaque;
 	if (atrac->decodePos > atrac->first.filesize)
@@ -1072,17 +1056,12 @@ static int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence) {
 	case SEEK_END:
 		atrac->decodePos = atrac->first.filesize - (u32)offset;
 		break;
-#ifdef USE_FFMPEG
 	case AVSEEK_SIZE:
 		return atrac->first.filesize;
-#endif
 	}
 	return atrac->decodePos;
 }
 
-#endif // USE_FFMPEG
-
-#ifdef USE_FFMPEG
 int __AtracUpdateOutputMode(Atrac *atrac, int wanted_channels) {
 	if (atrac->pSwrCtx && atrac->atracOutputChannels == wanted_channels)
 		return 0;
@@ -1113,10 +1092,8 @@ int __AtracUpdateOutputMode(Atrac *atrac, int wanted_channels) {
 	}
 	return 0;
 }
-#endif // USE_FFMPEG
 
 int __AtracSetContext(Atrac *atrac) {
-#ifdef USE_FFMPEG
 	InitFFmpeg();
 
 	u8* tempbuf = (u8*)av_malloc(atrac->atracBufSize);
@@ -1168,7 +1145,6 @@ int __AtracSetContext(Atrac *atrac) {
 	atrac->pFrame = av_frame_alloc();
 	// reinit decodePos, because ffmpeg had changed it.
 	atrac->decodePos = 0;
-#endif
 
 	return 0;
 }
@@ -1194,11 +1170,9 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
 			WARN_LOG(ME, "This is an atrac3 stereo audio");
 		}
 
-#ifdef USE_FFMPEG
 		atrac->data_buf = new u8[atrac->first.filesize];
 		Memory::Memcpy(atrac->data_buf, buffer, std::min(bufferSize, atrac->first.filesize));
 		return __AtracSetContext(atrac);
-#endif // USE_FFMPEG
 
 	} else if (atrac->codecType == PSP_MODE_AT_3_PLUS) {
 		if (atrac->atracChannels == 1) {
@@ -1583,11 +1557,10 @@ int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 met
 
 int _AtracGetIDByContext(u32 contextAddr) {
 	int atracID = (int)Memory::Read_U32(contextAddr + 0xfc);
-#ifdef USE_FFMPEG
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac)
 		__AtracUpdateOutputMode(atrac, 1);
-#endif // USE_FFMPEG
+
 	return atracID;
 }
 
@@ -1756,7 +1729,6 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 		atrac->CleanStuff();
 		INFO_LOG(ME, "Channels: %i outputChannels: %i bytesperFrame: %x", 
 			atrac->atracChannels, atrac->atracOutputChannels, atrac->atracBytesPerFrame);
-#ifdef USE_FFMPEG
 		if (atrac->codecType == PSP_MODE_AT_3) {
 			if (atrac->atracChannels == 1) {
 				WARN_LOG(ME, "This is an atrac3 mono audio (low level)");
@@ -1804,7 +1776,6 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 			__AtracSetContext(atrac);
 			return 0;
 		}
-#endif // USE_FFMPEG
 	}
 	return 0;
 }
@@ -1817,7 +1788,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 	}
 
 	DEBUG_LOG(ME, "UNIMPL sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x)", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
-#ifdef USE_FFMPEG
+
 	if (atrac && atrac->pCodecCtx && Memory::IsValidAddress(sourceAddr) && Memory::IsValidAddress(sourceBytesConsumedAddr) &&
   		Memory::IsValidAddress(samplesAddr) && Memory::IsValidAddress(sampleBytesAddr)) {
 		u32 sourcebytes = atrac->first.writableBytes;
@@ -1889,7 +1860,6 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 		Memory::Write_U32(atrac->first.writableBytes, sourceBytesConsumedAddr);
 		return hleDelayResult(0, "low level atrac decode data", atracDecodeDelay);
 	}
-#endif // USE_FFMPEG
 
 	return 0;
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -92,15 +92,11 @@ static std::list<AVFrame*> pmp_queue; //list of pmp video frames have been decod
 static std::list<u32> pmp_ContextList; //list of pmp media contexts
 static bool pmp_oldStateLoaded = false; // for dostate
 
-#ifdef USE_FFMPEG 
-
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
 }
 static AVPixelFormat pmp_want_pix_fmt;
-
-#endif
 
 struct SceMpegLLI
 {
@@ -361,10 +357,8 @@ void __MpegInit() {
 	streamIdGen = 1;
 	actionPostPut = __KernelRegisterActionType(PostPutAction::Create);
 
-#ifdef USE_FFMPEG
 	avcodec_register_all();
 	av_register_all();
-#endif
 }
 
 void __MpegDoState(PointerWrap &p) {
@@ -741,7 +735,6 @@ bool isContextExist(u32 ctxAddr){
 
 // Initialize Pmp video parameters and decoder.
 bool InitPmp(MpegContext * ctx){
-#ifdef USE_FFMPEG
 	InitFFmpeg();
 	auto mediaengine = ctx->mediaengine;
 	mediaengine->m_isVideoEnd = false;
@@ -801,10 +794,6 @@ bool InitPmp(MpegContext * ctx){
 	mediaengine->m_buffer = (u8*)av_malloc(mediaengine->m_bufSize);
 
 	return true;
-#else
-	// we can not play pmp video without ffmpeg
-	return false;
-#endif
 }
 
 // This class H264Frames is used for collecting small pieces of frames into larger frames for ffmpeg to decode
@@ -875,9 +864,7 @@ public:
 			stream = str;
 		}
 	};
-#ifndef USE_FFMPEG
 #define FF_INPUT_BUFFER_PADDING_SIZE 16
-#endif
 	void addpadding(){
 		u8* str = new u8[size + FF_INPUT_BUFFER_PADDING_SIZE];
 		memcpy(str, stream, size);
@@ -1006,7 +993,6 @@ void __VideoPmpInit() {
 }
 
 void __VideoPmpShutdown() {
-#ifdef USE_FFMPEG
 	// We need to empty pmp_queue to not leak memory.
 	for (std::list<AVFrame *>::iterator it = pmp_queue.begin(); it != pmp_queue.end(); it++){
 		av_free(*it);
@@ -1015,7 +1001,6 @@ void __VideoPmpShutdown() {
 	pmp_ContextList.clear();
 	delete pmpframes;
 	pmpframes = NULL;
-#endif
 }
 
 void __VideoPmpDoState(PointerWrap &p){

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -33,22 +33,18 @@
 class PointerWrap;
 class SimpleAudio;
 
-#ifdef USE_FFMPEG
 struct SwsContext;
 struct AVFrame;
 struct AVIOContext;
 struct AVFormatContext;
 struct AVCodecContext;
-#endif
 
 inline s64 getMpegTimeStamp(const u8 *buf) {
 	return (s64)buf[5] | ((s64)buf[4] << 8) | ((s64)buf[3] << 16) | ((s64)buf[2] << 24) 
 		| ((s64)buf[1] << 32) | ((s64)buf[0] << 36);
 }
 
-#ifdef USE_FFMPEG
 bool InitFFmpeg();
-#endif
 
 class MediaEngine
 {
@@ -100,14 +96,12 @@ private:
 public:  // TODO: Very little of this below should be public.
 
 	// Video ffmpeg context - not used for audio
-#ifdef USE_FFMPEG
 	AVFormatContext *m_pFormatCtx;
 	std::map<int, AVCodecContext *> m_pCodecCtxs;
 	AVFrame *m_pFrame;
 	AVFrame *m_pFrameRGB;
 	AVIOContext *m_pIOContext;
 	SwsContext *m_sws_ctx;
-#endif
 
 	int m_sws_fmt;
 	u8 *m_buffer;

--- a/Qt/Settings.pri
+++ b/Qt/Settings.pri
@@ -1,5 +1,5 @@
 VERSION = 0.9.9.1
-DEFINES += USING_QT_UI USE_FFMPEG
+DEFINES += USING_QT_UI
 
 # Global specific
 win32:CONFIG(release, debug|release): CONFIG_DIR = $$join(OUT_PWD,,,/release)
@@ -24,7 +24,7 @@ include(Platform/OSDetection.pri)
 !contains(CONFIG, staticlib) {
 	QMAKE_LIBDIR += $$CONFIG_DIR
 	!system_ffmpeg: QMAKE_LIBDIR += $$P/ffmpeg/$${PLATFORM_NAME}/$${PLATFORM_ARCH}/lib/
-	contains(DEFINES, USE_FFMPEG): LIBS+=  -lavformat -lavcodec -lavutil -lswresample -lswscale
+	LIBS+=  -lavformat -lavcodec -lavutil -lswresample -lswscale
 	equals(PLATFORM_NAME, "linux"):arm|android: LIBS += -lEGL
 }
 


### PR DESCRIPTION
Just leaving this here in case it is decided to remove it.

Reasons for keeping USE_FFMPEG:
- Debugging
- Packaging for Linux distros that don't allow ffmpeg for legal reasons
