### PR TITLE
Convert all CLUT entries ever loaded

### DIFF
--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -226,6 +226,7 @@ private:
 	u32 *clutBuf_;
 	u32 clutHash_;
 	u32 clutTotalBytes_;
+	u32 clutMaxBytes_;
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;


### PR DESCRIPTION
Some games reuse previously loaded bytes, like World Neverland.  We displayed bad colors in these cases when we don't convert all the entries.

Technically, this means we're hashing less than used in these cases, but if we hash more we will get lots of false cache misses.

-[Unknown]
