### PR TITLE
Enable LitPool for ARMv6.

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -534,9 +534,8 @@ void ARMXEmitter::MOVI2R(ARMReg reg, u32 val, bool optimize)
 				}
 			}
 			// Use literal pool for ARMv6.
-			// Disabled for now as it is crashing since Vertex Decoder JIT
-//			AddNewLit(val);
-//			LDR(reg, R_PC); // To be backpatched later
+			AddNewLit(val);
+			LDR(reg, R_PC); // To be backpatched later
 		}
 #endif
 	}


### PR DESCRIPTION
Was originally disabled because vertex JIT wasn't flushing but it now does.
