### PR TITLE
Handle fpu rounding mode at least in jits

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -324,6 +324,7 @@ static ConfigSetting cpuSettings[] = {
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0),
+	ReportedConfigSetting("SetRoundingMode", &g_Config.bSetRoundingMode, true),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -86,6 +86,7 @@ public:
 	bool bCheckForNewVersion;
 	bool bForceLagSync;
 	bool bFuncReplacements;
+	bool bSetRoundingMode;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -114,7 +114,9 @@ void Jit::GenerateFixedCode()
 	MovToPC(R0);
 	outerLoop = GetCodePtr();
 		SaveDowncount();
+		ClearRoundingMode();
 		QuickCallFunction(R0, &CoreTiming::Advance);
+		SetRoundingMode();
 		RestoreDowncount();
 		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
 
@@ -173,7 +175,9 @@ void Jit::GenerateFixedCode()
 
 			// No block found, let's jit
 			SaveDowncount();
+			ClearRoundingMode();
 			QuickCallFunction(R2, (void *)&JitAt);
+			SetRoundingMode();
 			RestoreDowncount();
 
 			B(dispatcherNoCheck); // no point in special casing this
@@ -195,6 +199,7 @@ void Jit::GenerateFixedCode()
 	}
 
 	SaveDowncount();
+	ClearRoundingMode();
 
 	ADD(R_SP, R_SP, 4);
 

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -559,6 +559,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 		QuickCallFunction(R1, (void *)&CallSyscall);
 	}
 	RestoreDowncount();
+	SetRoundingMode();
 
 	WriteSyscallExit();
 	js.compiling = false;

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -538,6 +538,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	// If we're in a delay slot, this is off by one.
 	const int offset = js.inDelaySlot ? -1 : 0;
 	WriteDownCount(offset);
+	ClearRoundingMode();
 	js.downcountAmount = -offset;
 
 	// TODO: Maybe discard v0, v1, and some temps?  Definitely at?

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -190,6 +190,8 @@ private:
 
 	void WriteDownCount(int offset = 0);
 	void WriteDownCountR(ARMReg reg);
+	void ClearRoundingMode();
+	void SetRoundingMode();
 	void MovFromPC(ARMReg r);
 	void MovToPC(ARMReg r);
 

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -58,7 +58,8 @@ namespace MIPSComp {
 			: startDefaultPrefix(true),
 			prefixSFlag(PREFIX_UNKNOWN),
 			prefixTFlag(PREFIX_UNKNOWN),
-			prefixDFlag(PREFIX_UNKNOWN) {}
+			prefixDFlag(PREFIX_UNKNOWN),
+			roundingModeSet(false) {}
 
 		u32 compilerPC;
 		u32 blockStart;
@@ -80,6 +81,8 @@ namespace MIPSComp {
 		PrefixState prefixSFlag;
 		PrefixState prefixTFlag;
 		PrefixState prefixDFlag;
+
+		bool roundingModeSet;
 
 		void PrefixStart() {
 			if (startDefaultPrefix) {

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -58,8 +58,7 @@ namespace MIPSComp {
 			: startDefaultPrefix(true),
 			prefixSFlag(PREFIX_UNKNOWN),
 			prefixTFlag(PREFIX_UNKNOWN),
-			prefixDFlag(PREFIX_UNKNOWN),
-			roundingModeSet(false) {}
+			prefixDFlag(PREFIX_UNKNOWN) {}
 
 		u32 compilerPC;
 		u32 blockStart;
@@ -81,8 +80,6 @@ namespace MIPSComp {
 		PrefixState prefixSFlag;
 		PrefixState prefixTFlag;
 		PrefixState prefixDFlag;
-
-		bool roundingModeSet;
 
 		void PrefixStart() {
 			if (startDefaultPrefix) {

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -691,6 +691,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	else
 		ABI_CallFunctionC(&CallSyscall, op.encoding);
 
+	SetRoundingMode();
 	WriteSyscallExit();
 	js.compiling = false;
 }

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -681,6 +681,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	// If we're in a delay slot, this is off by one.
 	const int offset = js.inDelaySlot ? -1 : 0;
 	WriteDowncount(offset);
+	ClearRoundingMode();
 	js.downcountAmount = -offset;
 
 	// Skip the CallSyscall where possible.

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -79,7 +79,6 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 void Jit::Comp_FPU3op(MIPSOpcode op)
 { 
 	CONDITIONAL_DISABLE;
-	SetRoundingMode();
 	switch (op & 0x3f) 
 	{
 	case 0: CompFPTriArith(op, &XEmitter::ADDSS, false); break; //F(fd) = F(fs) + F(ft); //add
@@ -174,8 +173,6 @@ void Jit::CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN)
 void Jit::Comp_FPUComp(MIPSOpcode op)
 {
 	CONDITIONAL_DISABLE;
-	// TODO: Does this matter here?
-	SetRoundingMode();
 
 	int fs = _FS;
 	int ft = _FT;
@@ -296,7 +293,6 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 
 	case 36: //FsI(fd) = (int)	F(fs);			 break; //cvt.w.s
 		{
-			SetRoundingMode();
 			fpr.SpillLock(fs, fd);
 			fpr.StoreFromRegister(fd);
 			CVTSS2SI(EAX, fpr.R(fs));

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -79,6 +79,7 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 void Jit::Comp_FPU3op(MIPSOpcode op)
 { 
 	CONDITIONAL_DISABLE;
+	SetRoundingMode();
 	switch (op & 0x3f) 
 	{
 	case 0: CompFPTriArith(op, &XEmitter::ADDSS, false); break; //F(fd) = F(fs) + F(ft); //add
@@ -173,6 +174,8 @@ void Jit::CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN)
 void Jit::Comp_FPUComp(MIPSOpcode op)
 {
 	CONDITIONAL_DISABLE;
+	// TODO: Does this matter here?
+	SetRoundingMode();
 
 	int fs = _FS;
 	int ft = _FT;
@@ -357,6 +360,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1
 		if (fs == 31) {
+			ClearRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
 				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -181,6 +181,8 @@ private:
 	void FlushAll();
 	void FlushPrefixV();
 	void WriteDowncount(int offset = 0);
+	void ClearRoundingMode();
+	void SetRoundingMode();
 	bool ReplaceJalTo(u32 dest);
 	// See CompileDelaySlotFlags for flags.
 	void CompileDelaySlot(int flags, RegCacheState *state = NULL);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -164,6 +164,9 @@ public:
 	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);
 	void EatPrefix() { js.EatPrefix(); }
 
+	void ClearRoundingMode(XEmitter *emitter = NULL);
+	void SetRoundingMode(XEmitter *emitter = NULL);
+
 	JitBlockCache *GetBlockCache() { return &blocks; }
 	AsmRoutineManager &Asm() { return asm_; }
 
@@ -181,8 +184,6 @@ private:
 	void FlushAll();
 	void FlushPrefixV();
 	void WriteDowncount(int offset = 0);
-	void ClearRoundingMode();
-	void SetRoundingMode();
 	bool ReplaceJalTo(u32 dest);
 	// See CompileDelaySlotFlags for flags.
 	void CompileDelaySlot(int flags, RegCacheState *state = NULL);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -375,6 +375,7 @@ void GameSettingsScreen::CreateViews() {
 #ifndef MOBILE_DEVICE
 	systemSettings->Add(new PopupSliderChoice(&g_Config.iRewindFlipFrequency, 0, 1800, s->T("Rewind Snapshot Frequency", "Rewind Snapshot Frequency (0 = off, mem hog)"), screenManager()));
 #endif
+	systemSettings->Add(new CheckBox(&g_Config.bSetRoundingMode, s->T("Respect FPU rounding (disable for old GEB saves)")))->OnClick.Handle(this, &GameSettingsScreen::OnJitAffectingSetting);
 
 	systemSettings->Add(new CheckBox(&g_Config.bAtomicAudioLocks, s->T("Atomic Audio locks (experimental)")))->SetEnabled(!PSP_IsInited());
 #if defined(USING_WIN_UI)

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -346,6 +346,7 @@ int main(int argc, const char* argv[])
 	g_Config.bSoftwareSkinning = true;
 	g_Config.bVertexDecoderJit = true;
 	g_Config.bBlockTransferGPU = true;
+	g_Config.bSetRoundingMode = true;
 
 #ifdef _WIN32
 	InitSysDirectories();


### PR DESCRIPTION
This notably doesn't handle it in the interpreter, and out of free time to try to make that happen.

Have some test mul.s ops which I plan to add to the cpu/fpu/fpu test.

I did not notice any obvious performance impact on Android but I did not test thoroughly.  If performance does take a hit, could maybe only start setting the mode if the game ever sets the FCSR, since it's uncommon but usually done in game init if it is done.

Fixes #3988 (well, except in interp.)  ~~@thedax I am probably crazy to hope, but would love to know if Peace Walker is affected by this.~~  VICTORY, fixes #2845.

-[Unknown]
