### PR TITLE
Optimize framebuffer binding and blits

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1191,6 +1191,7 @@ FBO *FramebufferManager::GetTempFBO(u16 w, u16 h, FBOColorDepth depth) {
 		return it->second.fbo;
 	}
 
+	textureCache_->ForgetLastTexture();
 	FBO *fbo = fbo_create(w, h, 1, false, depth);
 	if (!fbo)
 		return fbo;
@@ -1445,6 +1446,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 					break;
 			}
 
+			textureCache_->ForgetLastTexture();
 			nvfb->fbo = fbo_create(nvfb->width, nvfb->height, 1, false, nvfb->colorDepth);
 			if (!(nvfb->fbo)) {
 				ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1585,6 +1585,7 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 #endif // defined(USING_GLES2) && defined(ANDROID)
 		}
 
+		fbo_unbind_read();
 	} else {
 		fbo_bind_color_as_texture(src->fbo, 0);
 
@@ -1601,11 +1602,10 @@ void FramebufferManager::BlitFramebuffer_(VirtualFramebuffer *dst, int dstX, int
 		DrawActiveTexture(0, dstX1, dstY, w * dstXFactor, h, dst->bufferWidth, dst->bufferHeight, !flip, srcX1 / srcW, srcY / srcH, srcX2 / srcW, (srcY + h) / srcH, draw2dprogram_);
 		glBindTexture(GL_TEXTURE_2D, 0);
 		textureCache_->ForgetLastTexture();
+		glstate.viewport.restore();
 	}
 
 	glstate.scissorTest.restore();
-	glstate.viewport.restore();
-	fbo_unbind();
 }
 
 // TODO: SSE/NEON
@@ -1825,10 +1825,7 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 			fbo_bind_for_read(vfb->fbo);
 		} else {
 			ERROR_LOG_REPORT_ONCE(vfbfbozero, SCEGE, "PackFramebufferAsync_: vfb->fbo == 0");
-			fbo_unbind();
-			if (gl_extensions.FBO_ARB) {
-				glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-			}
+			fbo_unbind_read();
 			return;
 		}
 
@@ -1845,10 +1842,7 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 
 		if (fbStatus != GL_FRAMEBUFFER_COMPLETE) {
 			ERROR_LOG(SCEGE, "Incomplete source framebuffer, aborting read");
-			fbo_unbind();
-			if (gl_extensions.FBO_ARB) {
-				glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-			}
+			fbo_unbind_read();
 			return;
 		}
 
@@ -1872,11 +1866,7 @@ void FramebufferManager::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 
 		// LogReadPixelsError(glGetError());
 
-		fbo_unbind();
-		if (gl_extensions.FBO_ARB) {
-			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		}
-
+		fbo_unbind_read();
 		unbind = true;
 
 		pixelBufObj_[currentPBO_].fb_address = fb_address;
@@ -1901,10 +1891,7 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb, int x, in
 		fbo_bind_for_read(vfb->fbo);
 	} else {
 		ERROR_LOG_REPORT_ONCE(vfbfbozero, SCEGE, "PackFramebufferSync_: vfb->fbo == 0");
-		fbo_unbind();
-		if (gl_extensions.FBO_ARB) {
-			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		}
+		fbo_unbind_read();
 		return;
 	}
 
@@ -1949,7 +1936,7 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb, int x, in
 		}
 	}
 
-	fbo_unbind();
+	fbo_unbind_read();
 }
 
 void FramebufferManager::EndFrame() {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2338,11 +2338,7 @@ bool FramebufferManager::NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride
 				WARN_LOG_ONCE(dstsrc, G3D, "Intra-buffer block transfer %08x -> %08x", srcBasePtr, dstBasePtr);
 				if (g_Config.bBlockTransferGPU) {
 					FlushBeforeCopy();
-					FBO *tempFBO = GetTempFBO(dstBuffer->renderWidth, dstBuffer->renderHeight, dstBuffer->colorDepth);
-					VirtualFramebuffer tempBuffer = *dstBuffer;
-					tempBuffer.fbo = tempFBO;
-					BlitFramebuffer_(&tempBuffer, srcX, srcY, dstBuffer, srcX, srcY, dstWidth, dstHeight, bpp);
-					BlitFramebuffer_(dstBuffer, dstX, dstY, &tempBuffer, srcX, srcY, dstWidth, dstHeight, bpp);
+					BlitFramebuffer_(dstBuffer, dstX, dstY, srcBuffer, srcX, srcY, dstWidth, dstHeight, bpp);
 					RebindFramebuffer();
 					SetColorUpdated(dstBuffer);
 					return true;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2185,6 +2185,7 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 			if (g_Config.bBlockTransferGPU) {
 				BlitFramebuffer_(dstBuffer, 0, dstY, srcBuffer, 0, srcY, srcBuffer->width, srcH, 0);
 				SetColorUpdated(dstBuffer);
+				RebindFramebuffer();
 			}
 		}
 		return false;

--- a/GPU/GLES/StencilBuffer.cpp
+++ b/GPU/GLES/StencilBuffer.cpp
@@ -235,8 +235,6 @@ bool FramebufferManager::NotifyStencilUpload(u32 addr, int size, bool skipZero) 
 		}
 	}
 
-	fbo_unbind();
 	RebindFramebuffer();
-	glstate.viewport.restore();
 	return true;
 }


### PR DESCRIPTION
In one area of Tales of Phantasia X, there is a hot town where there are a ton of intra-buffer blits done in a row each frame.  This town only ran at 95% for me at best on desktop.

Avoiding the temporary fbo in an intra-buffer blit helped a lot, bringing it up to 150%.  With the other optimizations (avoiding unbinding and fbo caching), it's now up to 190%.

This is of course an extreme case.  Another example, Trails in the Sky, seemed to benefit only about 1% from these changes in certain cases, and probably less most of the time.

Requires hrydgard/native#234.

-[Unknown]
