### PR TITLE
d3d: Avoid rewriting textures to BGRA from RGBA, just swizzle

### DIFF
--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -167,6 +167,7 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		id->d[0] |= (doTextureProjection & 1) << 16;
 		id->d[0] |= (enableColorDoubling & 1) << 17;
 		id->d[0] |= (enableAlphaDoubling & 1) << 18;
+		id->d[0] |= (gstate_c.bgraTexture & 1) << 19;
 
 		if (enableAlphaTest)
 			gpuStats.numAlphaTestedDraws++;
@@ -253,9 +254,9 @@ void GenerateFragmentShaderDX9(char *buffer) {
 
 		if (gstate.isTextureMapEnabled()) {
 			if (doTextureProjection) {
-				WRITE(p, "  float4 t = tex2Dproj(tex, float4(In.v_texcoord.x, In.v_texcoord.y, 0, In.v_texcoord.z));\n");
+				WRITE(p, "  float4 t = tex2Dproj(tex, float4(In.v_texcoord.x, In.v_texcoord.y, 0, In.v_texcoord.z))%s;\n", gstate_c.bgraTexture ? ".bgra" : "");
 			} else {
-				WRITE(p, "  float4 t = tex2D(tex, In.v_texcoord.xy);\n");
+				WRITE(p, "  float4 t = tex2D(tex, In.v_texcoord.xy)%s;\n", gstate_c.bgraTexture ? ".bgra" : "");
 			}
 			WRITE(p, "  float4 p = In.v_color0;\n");
 

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -231,7 +231,7 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 			dxstate.stencilOp.set(D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE);
 			dxstate.stencilFunc.set(D3DCMP_ALWAYS, 0, 0xFF);
 		} else {
-			dxstate.depthTest.disable();
+			dxstate.stencilTest.disable();
 		}
 
 	} else {
@@ -244,8 +244,9 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 			dxstate.depthTest.enable();
 			dxstate.depthFunc.set(ztests[gstate.getDepthTestFunction()]);
 			dxstate.depthWrite.set(gstate.isDepthWriteEnabled());
-		} else 
+		} else {
 			dxstate.depthTest.disable();
+		}
 
 		// PSP color/alpha mask is per bit but we can only support per byte.
 		// But let's do that, at least. And let's try a threshold.

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -298,7 +298,7 @@ void GPUStateCache::DoState(PointerWrap &p) {
 		p.Do(flipTexture);
 	}
 
-	// needShaderTexClamp doesn't need to be saved.
+	// needShaderTexClamp and bgraTexture don't need to be saved.
 
 	if (s >= 3) {
 		p.Do(textureSimpleAlpha);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -460,6 +460,7 @@ struct GPUStateCache
 
 	UVScale uv;
 	bool flipTexture;
+	bool bgraTexture;
 	bool needShaderTexClamp;
 	bool allowShaderBlend;
 


### PR DESCRIPTION
In Direct3D, the order is already the same.  We don't need to redo the clut or textures or anything, so we can save a bit of copying and cut down on some code.

I was hoping for better, but it only gave a 1-2% improvement in FF2, so probably way less in most games.

-[Unknown]
