### PR TITLE
Use 8888, always, for Danganronpa's FBOs

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -223,7 +223,6 @@ public:
 		}
 		return true;
 	}
-	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 
 	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false);
 	bool NotifyStencilUpload(u32 addr, int size, bool skipZero = false);
@@ -254,6 +253,9 @@ private:
 	static void ClearBuffer();
 	static void ClearDepthBuffer();
 	static bool MaskedEqual(u32 addr1, u32 addr2);
+
+	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
+	inline bool ShouldDownloadUsingCPU(const VirtualFramebuffer *vfb) const;
 
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer) {
 		dstBuffer->memoryUpdated = false;


### PR DESCRIPTION
This should fix dithering on draw (guessing) causing problems for Adreno 3xx devices.  At least someone tested, and a test that basically did this seemed to fix it.

To summarize, from my memory at least:
- On some cards, blitting from 8888 -> 565 can cause dithering.
- On some cards, downloading from 565 in format 8888 can cause dithering.
- On some cards, drawing to 565 can cause dithering.

All of these presumably without dithering enabled (Danganronpa never enables dithering that I've seen.)

This also reverts #1081 because I couldn't figure out why we needed to set it twice and it just looked confusing (enable == set(true)).

@solarmystic if you could test it and let me know if it still works for you (lint roller, etc.), I'd appreciate it.

-[Unknown]
