### PR TITLE
Allow headless to compare Direct3D 9

### DIFF
--- a/headless/Compare.h
+++ b/headless/Compare.h
@@ -16,8 +16,11 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <string>
+#include <vector>
 
 #include "Globals.h"
+
+struct GPUDebugBuffer;
 
 extern bool teamCityMode;
 extern std::string teamCityName;
@@ -28,4 +31,5 @@ std::string ExpectedScreenshotFromFilename(const std::string &bootFilename);
 std::string GetTestName(const std::string &bootFilename);
 
 bool CompareOutput(const std::string &bootFilename, const std::string &output, bool verbose);
-double CompareScreenshot(const u8 *pixels, int w, int h, int stride, const std::string screenshotFilename, std::string &error);
+std::vector<u32> TranslateDebugBufferToCompare(const GPUDebugBuffer *buffer, u32 stride, u32 h);
+double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 h, const std::string screenshotFilename, std::string &error);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -94,7 +94,7 @@ int printUsage(const char *progname, const char *reason)
 	fprintf(stderr, "  -r, --root some/path  mount path on host0: (elfs must be in here)\n");
 	fprintf(stderr, "  -l, --log             full log output, not just emulated printfs\n");
 
-#if HEADLESSHOST_CLASS != HeadlessHost
+#if defined(HEADLESSHOST_CLASS)
 	{
 		fprintf(stderr, "  --graphics=BACKEND    use the full gpu backend (slower)\n");
 		fprintf(stderr, "                        options: gles, software, directx9\n");
@@ -112,16 +112,21 @@ int printUsage(const char *progname, const char *reason)
 	return 1;
 }
 
-static HeadlessHost * getHost(GPUCore gpuCore) {
-	switch(gpuCore) {
+static HeadlessHost *getHost(GPUCore gpuCore) {
+	switch (gpuCore) {
 	case GPU_NULL:
 		return new HeadlessHost();
 #ifdef _WIN32
 	case GPU_DIRECTX9:
 		return new WindowsHeadlessHostDx9();
 #endif
+#ifdef HEADLESSHOST_CLASS
 	default:
 		return new HEADLESSHOST_CLASS();
+#else
+	default:
+		return new HeadlessHost();
+#endif
 	}
 }
 

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -20,8 +20,6 @@
 #include "Core/Host.h"
 #include "Core/Debugger/SymbolMap.h"
 
-#define HEADLESSHOST_CLASS HeadlessHost
-
 // TODO: Get rid of this junk
 class HeadlessHost : public Host
 {

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -24,6 +24,7 @@
 
 #include "Core/CoreParameter.h"
 #include "Core/System.h"
+#include "GPU/Common/GPUDebugInterface.h"
 
 #include "base/logging.h"
 #include "gfx_es2/gl_state.h"
@@ -108,16 +109,16 @@ void WindowsHeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
 	}
 
 	// We ignore the current framebuffer parameters and just grab the full screen.
-	const static int FRAME_WIDTH = 512;
-	const static int FRAME_HEIGHT = 272;
-	u8 *pixels = new u8[FRAME_WIDTH * FRAME_HEIGHT * 4];
+	const static u32 FRAME_STRIDE = 512;
+	const static u32 FRAME_WIDTH = 480;
+	const static u32 FRAME_HEIGHT = 272;
 
-	// TODO: Maybe this code should be moved into GLES_GPU to support DirectX/etc.
-	glReadBuffer(GL_FRONT);
-	glReadPixels(0, 0, FRAME_WIDTH, FRAME_HEIGHT, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
+	GPUDebugBuffer buffer;
+	gpuDebug->GetCurrentFramebuffer(buffer);
+	const std::vector<u32> pixels = TranslateDebugBufferToCompare(&buffer, 512, 272);
 
 	std::string error;
-	double errors = CompareScreenshot(pixels, FRAME_WIDTH, FRAME_HEIGHT, FRAME_WIDTH, comparisonScreenshot, error);
+	double errors = CompareScreenshot(pixels, FRAME_STRIDE, FRAME_WIDTH, FRAME_HEIGHT, comparisonScreenshot, error);
 	if (errors < 0)
 		SendOrCollectDebugOutput(error);
 
@@ -143,14 +144,12 @@ void WindowsHeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
 		if (saved)
 		{
 			fwrite(&header, sizeof(header), 1, saved);
-			fwrite(pixels, sizeof(u32), FRAME_WIDTH * FRAME_HEIGHT, saved);
+			fwrite(pixels.data(), sizeof(u32), FRAME_STRIDE * FRAME_HEIGHT, saved);
 			fclose(saved);
 
 			SendOrCollectDebugOutput("Actual output written to: __testfailure.bmp\n");
 		}
 	}
-
-	delete [] pixels;
 }
 
 void WindowsHeadlessHost::SetComparisonScreenshot(const std::string &filename)

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -29,7 +29,6 @@
 #include "base/logging.h"
 #include "gfx_es2/gl_state.h"
 #include "gfx/gl_common.h"
-#include "gfx/gl_lost_manager.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
 
@@ -81,8 +80,6 @@ void WindowsHeadlessHost::LoadNativeAssets()
 	VFSRegister("", new DirectoryAssetReader("../"));
 	VFSRegister("", new DirectoryAssetReader("../Windows/assets/"));
 	VFSRegister("", new DirectoryAssetReader("../Windows/"));
-
-	gl_lost_manager_init();
 }
 
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -37,7 +37,7 @@ public:
 	virtual void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h);
 	virtual void SetComparisonScreenshot(const std::string &filename);
 
-private:
+protected:
 	bool ResizeGL();
 	void LoadNativeAssets();
 	void SendOrCollectDebugOutput(const std::string &output);

--- a/headless/WindowsHeadlessHostDx9.cpp
+++ b/headless/WindowsHeadlessHostDx9.cpp
@@ -23,6 +23,7 @@
 #include <io.h>
 
 #include "base/logging.h"
+#include "thin3d/d3dx9_loader.h"
 #include "GPU/Directx9/helper/global.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
@@ -52,47 +53,20 @@ HWND DxCreateWindow()
 	RECT wr = {0, 0, WINDOW_WIDTH, WINDOW_HEIGHT};    // set the size, but not the position
 	AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);    // adjust the size
 
-	DWORD style = WS_OVERLAPPEDWINDOW | WS_VISIBLE;
+	DWORD style = WS_OVERLAPPEDWINDOW | (WINDOW_VISIBLE ? WS_VISIBLE : 0);
 	return CreateWindowEx(0, _T("PPSSPPHeadless"), _T("PPSSPPHeadless"), style, CW_USEDEFAULT, CW_USEDEFAULT, wr.right - wr.left, wr.bottom - wr.top, NULL, NULL, NULL, NULL);
-}
-
-void WindowsHeadlessHostDx9::LoadNativeAssets()
-{
-	// Native is kinda talkative, but that's annoying in our case.
-	out = _fdopen(_dup(_fileno(stdout)), "wt");
-	freopen("NUL", "wt", stdout);
-
-	VFSRegister("", new DirectoryAssetReader("assets/"));
-	VFSRegister("", new DirectoryAssetReader(""));
-	VFSRegister("", new DirectoryAssetReader("../"));
-	VFSRegister("", new DirectoryAssetReader("../Windows/assets/"));
-	VFSRegister("", new DirectoryAssetReader("../Windows/"));
-
-	// See SendDebugOutput() for how things get back on track.
-}
-
-void WindowsHeadlessHostDx9::SendDebugOutput(const std::string &output)
-{
-	fwrite(output.data(), sizeof(char), output.length(), out);
-	OutputDebugStringUTF8(output.c_str());
-}
-
-void WindowsHeadlessHostDx9::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
-{
-	
-}
-
-void WindowsHeadlessHostDx9::SetComparisonScreenshot(const std::string &filename)
-{
-	comparisonScreenshot = filename;
 }
 
 bool WindowsHeadlessHostDx9::InitGL(std::string *error_message)
 {
+	LoadD3DX9Dynamic();
 	hWnd = DxCreateWindow();
 
-	ShowWindow(hWnd, TRUE);
-	SetFocus(hWnd);
+	if (WINDOW_VISIBLE)
+	{
+		ShowWindow(hWnd, TRUE);
+		SetFocus(hWnd);
+	}
 
 	DX9::DirectxInit(hWnd);
 

--- a/headless/WindowsHeadlessHostDx9.h
+++ b/headless/WindowsHeadlessHostDx9.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "StubHost.h"
+#include "WindowsHeadlessHost.h"
 
 #undef HEADLESSHOST_CLASS
 #define HEADLESSHOST_CLASS WindowsHeadlessHost
@@ -25,7 +26,7 @@
 #include "Common/CommonWindows.h"
 
 // TODO: Get rid of this junk
-class WindowsHeadlessHostDx9 : public HeadlessHost
+class WindowsHeadlessHostDx9 : public WindowsHeadlessHost
 {
 public:
 	virtual bool InitGL(std::string *error_message);
@@ -33,19 +34,6 @@ public:
 
 	virtual void SwapBuffers();
 
-	virtual void SendDebugOutput(const std::string &output);
-	virtual void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h);
-	virtual void SetComparisonScreenshot(const std::string &filename);
-
-	virtual bool ShouldSkipUI() { return false; }
-
 private:
 	bool ResizeGL();
-	void LoadNativeAssets();
-
-	HWND hWnd;
-	HDC hDC;
-	HGLRC hRC;
-	FILE *out;
-	std::string comparisonScreenshot;
 };


### PR DESCRIPTION
We already have a debug interface that works, let's use it.

This also fixes the gpu/commands/basic test (which turns out to be 1px off in software and directx9, but not gles, btw.)  I guess the issue was simply with using GL_FRONT.

-[Unknown]
