### PR TITLE
Eat cycles during GE block transfers

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1478,6 +1478,9 @@ void DIRECTX9_GPU::DoBlockTransfer() {
 			dstStride == 512 && height == 272) {
 		framebufferManager_.DrawPixels(Memory::GetPointerUnchecked(dstBasePtr), GE_FORMAT_8888, 512);
 	}
+
+	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
+	cyclesExecuted += ((height * width * bpp) * 16) / 10;
 }
 
 void DIRECTX9_GPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -2000,6 +2000,9 @@ void GLES_GPU::DoBlockTransfer() {
 	CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
 #endif
+
+	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
+	cyclesExecuted += ((height * width * bpp) * 16) / 10;
 }
 
 void GLES_GPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {

--- a/GPU/GLES/SoftwareTransform.cpp
+++ b/GPU/GLES/SoftwareTransform.cpp
@@ -548,9 +548,9 @@ void TransformDrawEngine::SoftwareTransformAndDraw(
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glVertexAttribPointer(ATTR_POSITION, 4, GL_FLOAT, GL_FALSE, vertexSize, drawBuffer);
 	int attrMask = program->attrMask;
-	if (attrMask & (1 << ATTR_TEXCOORD)) glVertexAttribPointer(ATTR_TEXCOORD, doTextureProjection ? 3 : 2, GL_FLOAT, GL_FALSE, vertexSize, ((uint8_t*)drawBuffer) + 4 * 4);
-	if (attrMask & (1 << ATTR_COLOR0)) glVertexAttribPointer(ATTR_COLOR0, 4, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, ((uint8_t*)drawBuffer) + 7 * 4);
-	if (attrMask & (1 << ATTR_COLOR1)) glVertexAttribPointer(ATTR_COLOR1, 3, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, ((uint8_t*)drawBuffer) + 8 * 4);
+	if (attrMask & (1 << ATTR_TEXCOORD)) glVertexAttribPointer(ATTR_TEXCOORD, doTextureProjection ? 3 : 2, GL_FLOAT, GL_FALSE, vertexSize, ((uint8_t*)drawBuffer) + offsetof(TransformedVertex, u));
+	if (attrMask & (1 << ATTR_COLOR0)) glVertexAttribPointer(ATTR_COLOR0, 4, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, ((uint8_t*)drawBuffer) + offsetof(TransformedVertex, color0));
+	if (attrMask & (1 << ATTR_COLOR1)) glVertexAttribPointer(ATTR_COLOR1, 3, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, ((uint8_t*)drawBuffer) + offsetof(TransformedVertex, color1));
 	if (drawIndexed) {
 #if 1  // USING_GLES2
 		glDrawElements(glprim[prim], numTrans, GL_UNSIGNED_SHORT, inds);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -626,6 +626,9 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff)
 			CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
 #endif
 
+			// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
+			cyclesExecuted += ((height * width * bpp) * 16) / 10;
+
 			// Could theoretically dirty the framebuffer.
 			framebufferDirty_ = true;
 			break;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -609,7 +609,7 @@ again:
 void GameInfoCache::SetupTexture(GameInfo *info, std::string &textureData, Thin3DContext *thin3d, Thin3DTexture *&tex, double &loadTime) {
 	if (textureData.size()) {
 		if (!tex) {
-			tex = thin3d->CreateTextureFromFileData(textureData.data(), textureData.size(), T3DFileType::PNG);
+			tex = thin3d->CreateTextureFromFileData(textureData.data(), (int)textureData.size(), T3DFileType::PNG);
 			if (tex) {
 				loadTime = time_now_d();
 			} else {


### PR DESCRIPTION
Some adhoc tests showing the timing:
https://docs.google.com/spreadsheets/d/1nEo_mw7mcdqbdpsaZPdEHN_8ropzXayohoyRcQfishw/edit#gid=2054001637

This is enough to allow the gpu/commands/blocktransfer test to pass as current (before it didn't, even when run with non-null gpu, because it didn't reschedule on `sceGeDrawSync()`.)

-[Unknown]
