### PR TITLE
Win32: Use wide strings to parse some command-line arguments, and convert them to proper UTF-8 for others.

### DIFF
--- a/Common/CommonWindows.h
+++ b/Common/CommonWindows.h
@@ -22,8 +22,6 @@ extern "C" void _ReadBarrier();
 
 #else
 #include <Windows.h>
-#include <vector>
-extern std::vector<std::wstring> GetWideCmdLine();
 #endif
 
 #undef min

--- a/Common/CommonWindows.h
+++ b/Common/CommonWindows.h
@@ -22,6 +22,8 @@ extern "C" void _ReadBarrier();
 
 #else
 #include <Windows.h>
+#include <vector>
+extern std::vector<std::wstring> GetWideCmdLine();
 #endif
 
 #undef min

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -694,8 +694,11 @@ std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
 }
 
 void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
-	iniFilename_ = FindConfigFile(iniFileName != NULL ? iniFileName : "ppsspp.ini");
-	controllerIniFilename_ = FindConfigFile(controllerIniFilename != NULL ? controllerIniFilename : "controls.ini");
+	const bool useIniFilename = (iniFileName != NULL) && (strlen(iniFileName) > 0);
+	iniFilename_ = FindConfigFile(useIniFilename ? iniFileName : "ppsspp.ini");
+
+	const bool useControllerIniFilename = (controllerIniFilename != NULL) && (strlen(controllerIniFilename) > 0);
+	controllerIniFilename_ = FindConfigFile(useControllerIniFilename ? controllerIniFilename : "controls.ini");
 
 	INFO_LOG(LOADER, "Loading config: %s", iniFilename_.c_str());
 	bSaveSettings = true;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -694,10 +694,10 @@ std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
 }
 
 void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
-	const bool useIniFilename = (iniFileName != NULL) && (strlen(iniFileName) > 0);
+	const bool useIniFilename = iniFileName != nullptr && strlen(iniFileName) > 0;
 	iniFilename_ = FindConfigFile(useIniFilename ? iniFileName : "ppsspp.ini");
 
-	const bool useControllerIniFilename = (controllerIniFilename != NULL) && (strlen(controllerIniFilename) > 0);
+	const bool useControllerIniFilename = controllerIniFilename != nullptr && strlen(controllerIniFilename) > 0;
 	controllerIniFilename_ = FindConfigFile(useControllerIniFilename ? controllerIniFilename : "controls.ini");
 
 	INFO_LOG(LOADER, "Loading config: %s", iniFilename_.c_str());

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -89,7 +89,27 @@ unsigned int WINAPI TheThread(void *)
 
 	Host *oldHost = host;
 
-	NativeInit(__argc, (const char **)__argv, "1234", "1234", "1234");
+	// Convert the command-line arguments to Unicode, then to proper UTF-8 
+	// (the benefit being that we don't have to pollute the UI project with win32 ifdefs and lots of Convert<whatever>To<whatever>).
+	// This avoids issues with PPSSPP inadvertently destroying paths with Unicode glyphs 
+	// (using the ANSI args resulted in Japanese/Chinese glyphs being turned into question marks, at least for me..).
+	// -TheDax
+	std::vector<std::wstring> wideArgs = GetWideCmdLine();
+	std::vector<std::string> argsUTF8;
+	for (auto& i : wideArgs)
+	{
+		argsUTF8.push_back(ConvertWStringToUTF8(i));
+	}
+
+	std::vector<const char *> args;
+
+	for (auto& string: argsUTF8)
+	{
+		args.push_back(string.c_str());
+	}
+
+	NativeInit(args.size(), &args[0], "1234", "1234", "1234");
+
 	Host *nativeHost = host;
 	host = oldHost;
 

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -27,6 +27,8 @@ static recursive_mutex emuThreadLock;
 static HANDLE emuThread;
 static volatile long emuThreadReady;
 
+extern std::vector<std::wstring> GetWideCmdLine();
+
 enum EmuThreadStatus : long
 {
 	THREAD_NONE = 0,
@@ -96,9 +98,9 @@ unsigned int WINAPI TheThread(void *)
 	// -TheDax
 	std::vector<std::wstring> wideArgs = GetWideCmdLine();
 	std::vector<std::string> argsUTF8;
-	for (auto& i : wideArgs)
+	for (auto& string : wideArgs)
 	{
-		argsUTF8.push_back(ConvertWStringToUTF8(i));
+		argsUTF8.push_back(ConvertWStringToUTF8(string));
 	}
 
 	std::vector<const char *> args;
@@ -108,7 +110,7 @@ unsigned int WINAPI TheThread(void *)
 		args.push_back(string.c_str());
 	}
 
-	NativeInit(args.size(), &args[0], "1234", "1234", "1234");
+	NativeInit(static_cast<int>(args.size()), &args[0], "1234", "1234", "1234");
 
 	Host *nativeHost = host;
 	host = oldHost;


### PR DESCRIPTION
It doesn't make much sense to parse some of them as ANSI/ASCII anymore, since we use Unicode now. In addition, it's currently not possible to load states, games, or configuration inis from paths with Unicode glyphs in them.
