### PR TITLE
Fix the vrndi.s output range

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1995,6 +1995,7 @@ void ThreadContext::reset()
 	vfpuCtrl[VFPU_CTRL_DPREFIX] = 0x0;	// neutral
 	vfpuCtrl[VFPU_CTRL_CC] = 0x3f;
 	vfpuCtrl[VFPU_CTRL_INF4] = 0;
+	vfpuCtrl[VFPU_CTRL_REV] = 0x7772ceab;
 	vfpuCtrl[VFPU_CTRL_RCX0] = 0x3f800001;
 	vfpuCtrl[VFPU_CTRL_RCX1] = 0x3f800002;
 	vfpuCtrl[VFPU_CTRL_RCX2] = 0x3f800004;

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1277,6 +1277,25 @@ namespace MIPSComp
 		fpr.ReleaseSpillLocksAndDiscardTemps();
 	}
 
+	void Jit::Comp_Vmfvc(MIPSOpcode op) {
+		NEON_IF_AVAILABLE(CompNEON_Vmtvc);
+		CONDITIONAL_DISABLE;
+
+		int vs = _VS;
+		int imm = op & 0xFF;
+		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
+			fpr.MapRegV(vs);
+			if (imm - 128 == VFPU_CTRL_CC) {
+				gpr.MapReg(MIPS_REG_VFPUCC, 0);
+				VMOV(fpr.V(vs), gpr.R(MIPS_REG_VFPUCC));
+			} else {
+				ADDI2R(SCRATCHREG1, CTXREG, offsetof(MIPSState, vfpuCtrl[0]) + (imm - 128) * 4, SCRATCHREG2);
+				VLDR(fpr.V(vs), SCRATCHREG1, 0);
+			}
+			fpr.ReleaseSpillLocksAndDiscardTemps();
+		}
+	}
+
 	void Jit::Comp_Vmtvc(MIPSOpcode op) {
 		NEON_IF_AVAILABLE(CompNEON_Vmtvc);
 		CONDITIONAL_DISABLE;

--- a/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
@@ -73,6 +73,10 @@ void Jit::CompNEON_Mftv(MIPSOpcode op) {
 	DISABLE;
 }
 
+void Jit::CompNEON_Vmfvc(MIPSOpcode op) {
+	DISABLE;
+}
+
 void Jit::CompNEON_Vmtvc(MIPSOpcode op) {
 	DISABLE;
 }

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -110,6 +110,7 @@ public:
 	void Comp_VecDo3(MIPSOpcode op);
 	void Comp_VV2Op(MIPSOpcode op);
 	void Comp_Mftv(MIPSOpcode op);
+	void Comp_Vmfvc(MIPSOpcode op);
 	void Comp_Vmtvc(MIPSOpcode op);
 	void Comp_Vmmov(MIPSOpcode op);
 	void Comp_VScl(MIPSOpcode op);
@@ -147,6 +148,7 @@ public:
 	void CompNEON_VecDo3(MIPSOpcode op);
 	void CompNEON_VV2Op(MIPSOpcode op);
 	void CompNEON_Mftv(MIPSOpcode op);
+	void CompNEON_Vmfvc(MIPSOpcode op);
 	void CompNEON_Vmtvc(MIPSOpcode op);
 	void CompNEON_Vmmov(MIPSOpcode op);
 	void CompNEON_VScl(MIPSOpcode op);

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -191,6 +191,7 @@ void MIPSState::Init() {
 	vfpuCtrl[VFPU_CTRL_DPREFIX] = 0;
 	vfpuCtrl[VFPU_CTRL_CC] = 0x3f;
 	vfpuCtrl[VFPU_CTRL_INF4] = 0;
+	vfpuCtrl[VFPU_CTRL_REV] = 0x7772ceab;
 	vfpuCtrl[VFPU_CTRL_RCX0] = 0x3f800001;
 	vfpuCtrl[VFPU_CTRL_RCX1] = 0x3f800002;
 	vfpuCtrl[VFPU_CTRL_RCX2] = 0x3f800004;

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -763,9 +763,9 @@ const MIPSInstruction tableVFPU9[32] = // 110100 00010 xxxxx . ....... . .......
 
 	//16
 	// TODO: Flags may not be correct (prefixes, etc.)
-	INSTR("vmfvc", &Jit::Comp_Generic, Dis_Vmftvc, Int_Vmfvc, IN_OTHER|OUT_OTHER|IS_VFPU),
+	INSTR("vmfvc", &Jit::Comp_Vmfvc, Dis_Vmftvc, Int_Vmfvc, IN_OTHER|OUT_OTHER|IS_VFPU),
 	// TODO: Flags may not be correct (prefixes, etc.)
-	INSTR("vmtvc", &Jit::Comp_Generic, Dis_Vmftvc, Int_Vmtvc, IN_OTHER|OUT_OTHER|IS_VFPU),
+	INSTR("vmtvc", &Jit::Comp_Vmtvc, Dis_Vmftvc, Int_Vmtvc, IN_OTHER|OUT_OTHER|IS_VFPU),
 	INVALID,
 	INVALID,
 

--- a/Core/MIPS/PPC/PpcCompVFPU.cpp
+++ b/Core/MIPS/PPC/PpcCompVFPU.cpp
@@ -712,6 +712,19 @@ namespace MIPSComp
 		fpr.ReleaseSpillLocksAndDiscardTemps();
 	}
 
+	void Jit::Comp_Vmfvc(MIPSOpcode op) {
+		CONDITIONAL_DISABLE;
+
+		int vs = _VS;
+		int imm = op & 0xFF;
+		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
+			fpr.MapRegV(vs);
+			ADDI(SREG, CTXREG, offsetof(MIPSState, vfpuCtrl[0]) + (imm - 128) * 4);
+			LFS(fpr.V(vs), SREG, 0);
+			fpr.ReleaseSpillLocksAndDiscardTemps();
+		}
+	}
+
 	void Jit::Comp_Vmtvc(MIPSOpcode op) {
 		CONDITIONAL_DISABLE;
 

--- a/Core/MIPS/PPC/PpcJit.h
+++ b/Core/MIPS/PPC/PpcJit.h
@@ -215,6 +215,7 @@ namespace MIPSComp
 		void Comp_VecDo3(MIPSOpcode op);
 		void Comp_VV2Op(MIPSOpcode op);
 		void Comp_Mftv(MIPSOpcode op);
+		void Comp_Vmfvc(MIPSOpcode op);
 		void Comp_Vmtvc(MIPSOpcode op);
 		void Comp_Vmmov(MIPSOpcode op);
 		void Comp_VScl(MIPSOpcode op);

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1742,6 +1742,22 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 	}
 }
 
+void Jit::Comp_Vmfvc(MIPSOpcode op) {
+	CONDITIONAL_DISABLE;
+	int vs = _VS;
+	int imm = op & 0xFF;
+	if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
+		fpr.MapRegV(vs, 0);
+		if (imm - 128 == VFPU_CTRL_CC) {
+			gpr.MapReg(MIPS_REG_VFPUCC, true, false);
+			MOVD_xmm(fpr.VX(vs), gpr.R(MIPS_REG_VFPUCC));
+		} else {
+			MOVSS(fpr.VX(vs), M(&currentMIPS->vfpuCtrl[imm - 128]));
+		}
+		fpr.ReleaseSpillLocks();
+	}
+}
+
 void Jit::Comp_Vmtvc(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	int vs = _VS;

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -118,6 +118,7 @@ public:
 	void Comp_VecDo3(MIPSOpcode op);
 	void Comp_VV2Op(MIPSOpcode op);
 	void Comp_Mftv(MIPSOpcode op);
+	void Comp_Vmfvc(MIPSOpcode op);
 	void Comp_Vmtvc(MIPSOpcode op);
 	void Comp_Vmmov(MIPSOpcode op);
 	void Comp_VScl(MIPSOpcode op);


### PR DESCRIPTION
Was previously outputting only valid positive float values, but should use a much wider range of a u32.

Might've affected randomness in some games.

-[Unknown]
