### PR TITLE
x86jit/ppcjit: Correct some bad sltiu compares

### DIFF
--- a/Core/MIPS/PPC/PpcCompAlu.cpp
+++ b/Core/MIPS/PPC/PpcCompAlu.cpp
@@ -146,7 +146,7 @@ namespace MIPSComp
 		case 11: //sltiu
 			if (gpr.IsImm(rs))
 			{
-				gpr.SetImm(rt, gpr.GetImm(rs) < uimm);
+				gpr.SetImm(rt, gpr.GetImm(rs) < suimm);
 				break;
 			} else {
 				//DISABLE;
@@ -154,7 +154,7 @@ namespace MIPSComp
 
 				PPCReg ppc_rt = gpr.R(rt);
 
-				ADDI(SREG, R0, uimm);
+				ADDI(SREG, R0, suimm);
 				SUBFC(ppc_rt, SREG, gpr.R(rs));
 				SUBFE(ppc_rt, ppc_rt, ppc_rt);
 				NEG(ppc_rt, ppc_rt);

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -88,8 +88,8 @@ namespace MIPSComp
 				else
 				{
 					MOV(32, gpr.R(rt), gpr.R(rs));
-					if (simm != 0)
-						ADD(32, gpr.R(rt), Imm32((u32)(s32)simm));
+					if (suimm != 0)
+						ADD(32, gpr.R(rt), Imm32(suimm));
 				}
 				gpr.UnlockAll();
 			}
@@ -116,7 +116,7 @@ namespace MIPSComp
 		case 11: // R(rt) = R(rs) < uimm; break; //sltiu
 			if (gpr.IsImm(rs))
 			{
-				gpr.SetImm(rt, gpr.GetImm(rs) < uimm);
+				gpr.SetImm(rt, gpr.GetImm(rs) < suimm);
 				break;
 			}
 
@@ -124,7 +124,7 @@ namespace MIPSComp
 			gpr.MapReg(rs, true, false);
 			gpr.MapReg(rt, rt == rs, true);
 			XOR(32, R(EAX), R(EAX));
-			CMP(32, gpr.R(rs), Imm32((u32)simm));
+			CMP(32, gpr.R(rs), Imm32(suimm));
 			SETcc(CC_B, R(EAX));
 			MOV(32, gpr.R(rt), R(EAX));
 			gpr.UnlockAll();


### PR DESCRIPTION
The one in x86jit is a bit nasty in the cases where it might get hit.  Well, the ppc one is even more dangerous but not really active atm.

In the vast majority of cases, theoretically, it would be a loop counting from 0, and so it'd be fine.  But there has to be somewhere it's a nasty bug (and I'm always saying how surprised I am that these sort of known-result instructions occur even outside of loops...)

-[Unknown]
