### PR TITLE
Add a non-functional stub for sceNetResolverInit.

### DIFF
--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -374,6 +374,12 @@ int sceNetApctlDisconnect() {
 	return 0;
 }
 
+int sceNetResolverInit()
+{
+	ERROR_LOG(SCENET, "UNIMPL %s()", __FUNCTION__);
+	return 0;
+}
+
 const HLEFunction sceNet[] = {
 	{0x39AF39A6, WrapU_UUUUU<sceNetInit>, "sceNetInit"},
 	{0x281928A9, WrapU_V<sceNetTerm>, "sceNetTerm"},
@@ -389,7 +395,7 @@ const HLEFunction sceNetResolver[] = {
 	{0x224c5f44, 0, "sceNetResolverStartNtoA"},
 	{0x244172af, 0, "sceNetResolverCreate"},
 	{0x94523e09, 0, "sceNetResolverDelete"},
-	{0xf3370e61, 0, "sceNetResolverInit"},
+	{0xf3370e61, WrapI_V<sceNetResolverInit>, "sceNetResolverInit"},
 	{0x808F6063, 0, "sceNetResolverStop"},
 	{0x6138194A, 0, "sceNetResolverTerm"},
 	{0x629e2fb7, 0, "sceNetResolverStartAtoN"},


### PR DESCRIPTION
Lets a Quake II homebrew port by CROW_BAR boot again.

Fixes https://github.com/hrydgard/ppsspp/issues/6819 (I didn't bother looking into the JIT crash, the internal error never happens with this stub being implemented).
