### PR TITLE
Handle the FS (flush-to-zero) bit in FCR31 for x86 JIT.

### DIFF
--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -134,7 +134,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			jit->ClearRoundingMode(this);
 			ABI_CallFunction(&Jit);
 			jit->SetRoundingMode(this);
-			JMP(dispatcherNoCheck); // Let's just dispatch again, we'll enter the block since we know it's there.
+			JMP(dispatcherNoCheck, true); // Let's just dispatch again, we'll enter the block since we know it's there.
 
 		SetJumpTarget(bail);
 		SetJumpTarget(bailCoreState);

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -383,9 +383,8 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
 				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
-				if ((gpr.GetImm(rt) & 3) == 0) {
-					// Default nearest mode, let's do this the fast way.
-					ClearRoundingMode();
+				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
+					// Default nearest / no-flush mode, just leave it cleared.
 				} else {
 					SetRoundingMode();
 				}

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -379,12 +379,12 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1
 		if (fs == 31) {
+			ClearRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
 				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
 				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
-					// Default nearest / no-flush mode, let's do this the fast way.
-					ClearRoundingMode();
+					// Default nearest / no-flush mode, just leave it cleared.
 				} else {
 					SetRoundingMode();
 				}

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -379,12 +379,12 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1
 		if (fs == 31) {
-			ClearRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
 				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
 				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
-					// Default nearest / no-flush mode, just leave it cleared.
+					// Default nearest / no-flush mode, let's do this the fast way.
+					ClearRoundingMode();
 				} else {
 					SetRoundingMode();
 				}

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -233,25 +233,31 @@ void Jit::SetRoundingMode(XEmitter *emitter)
 		emitter->MOV(32, R(EAX), M(&mips_->fcr31));
 		emitter->AND(32, R(EAX), Imm32(0x1000003));
 
+		// If it's 0, we don't actually bother setting.  This is the most common.
+		// We always use nearest as the default rounding mode with
+		// flush-to-zero disabled.
+		FixupBranch skip = emitter->J_CC(CC_Z);
+
 		emitter->STMXCSR(M(&currentMIPS->temp));
-		emitter->AND(32, M(&currentMIPS->temp), Imm32(~(7 << 13)));
 
 		// The MIPS bits don't correspond exactly, so we have to adjust.
-		// 0 -> 0 (skip), 1 -> 3, 2 -> 2 (skip), 3 -> 1
+		// 0 -> 0 (skip2), 1 -> 3, 2 -> 2 (skip2), 3 -> 1
 		emitter->TEST(8, R(AL), Imm8(1));
-		FixupBranch skip = emitter->J_CC(CC_Z);
+		FixupBranch skip2 = emitter->J_CC(CC_Z);
 		emitter->XOR(32, R(EAX), Imm8(2));
-		emitter->SetJumpTarget(skip);
+		emitter->SetJumpTarget(skip2);
 
 		emitter->SHL(32, R(EAX), Imm8(13));
 		emitter->OR(32, M(&currentMIPS->temp), R(EAX));
 
 		emitter->TEST(32, M(&mips_->fcr31), Imm32(1 << 24));
-		FixupBranch skip2 = emitter->J_CC(CC_Z);
+		FixupBranch skip3 = emitter->J_CC(CC_Z);
 		emitter->OR(32, M(&currentMIPS->temp), Imm32(1 << 15));
-		emitter->SetJumpTarget(skip2);
+		emitter->SetJumpTarget(skip3);
 
 		emitter->LDMXCSR(M(&currentMIPS->temp));
+
+		emitter->SetJumpTarget(skip);
 	}
 }
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -233,31 +233,25 @@ void Jit::SetRoundingMode(XEmitter *emitter)
 		emitter->MOV(32, R(EAX), M(&mips_->fcr31));
 		emitter->AND(32, R(EAX), Imm32(0x1000003));
 
-		// If it's 0, we don't actually bother setting.  This is the most common.
-		// We always use nearest as the default rounding mode with
-		// flush-to-zero disabled.
-		FixupBranch skip = emitter->J_CC(CC_Z);
-
 		emitter->STMXCSR(M(&currentMIPS->temp));
+		emitter->AND(32, M(&currentMIPS->temp), Imm32(~(7 << 13)));
 
 		// The MIPS bits don't correspond exactly, so we have to adjust.
-		// 0 -> 0 (skip2), 1 -> 3, 2 -> 2 (skip2), 3 -> 1
+		// 0 -> 0 (skip), 1 -> 3, 2 -> 2 (skip), 3 -> 1
 		emitter->TEST(8, R(AL), Imm8(1));
-		FixupBranch skip2 = emitter->J_CC(CC_Z);
+		FixupBranch skip = emitter->J_CC(CC_Z);
 		emitter->XOR(32, R(EAX), Imm8(2));
-		emitter->SetJumpTarget(skip2);
+		emitter->SetJumpTarget(skip);
 
 		emitter->SHL(32, R(EAX), Imm8(13));
 		emitter->OR(32, M(&currentMIPS->temp), R(EAX));
 
 		emitter->TEST(32, M(&mips_->fcr31), Imm32(1 << 24));
-		FixupBranch skip3 = emitter->J_CC(CC_Z);
+		FixupBranch skip2 = emitter->J_CC(CC_Z);
 		emitter->OR(32, M(&currentMIPS->temp), Imm32(1 << 15));
-		emitter->SetJumpTarget(skip3);
+		emitter->SetJumpTarget(skip2);
 
 		emitter->LDMXCSR(M(&currentMIPS->temp));
-
-		emitter->SetJumpTarget(skip);
 	}
 }
 


### PR DESCRIPTION
I don't know if any commercial games need this, but I did use it to work around a bit of numerical instability in my Aquaria port.
