### PR TITLE
Try to use bitwise / texelFetch in glsl based on EXT_gpu_shader4

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -367,7 +367,7 @@ namespace Reporting
 		if (!IsEnabled() || CheckSpamLimited())
 			return;
 
-		const int MESSAGE_BUFFER_SIZE = 32768;
+		const int MESSAGE_BUFFER_SIZE = 65536;
 		char temp[MESSAGE_BUFFER_SIZE];
 
 		va_list args;


### PR DESCRIPTION
Requires hrydgard/native#235.

We had a shader link error reported from GL 3.0 / GLSL 1.3 that said "#extension GL_EXT_gpu_shader4 : enable" was required to use logical ands.  This isn't true, GLSL 1.3 mandated it as a core feature afaiu.  That being said, it seems like emitting that won't hurt anything where the extension is supported, and we might be able to use the feature on older cards.

It is possible this could impact performance slightly for pre GL 3.0 cards (because they will more accurately be testing &.)  Of course, still need to figure out if the texture-lookup method might actually be better.

-[Unknown]
