### PR TITLE
Set NSPrincipalClass to get retina widget rendering on OS X

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -58,5 +58,7 @@
 		<integer>1</integer>
 		<integer>2</integer>
 	</array>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
There's really only the title bar where this applies, but it looks a lot better:

![](http://f.cl.ly/items/1A2i3s332H361i1g3n3b/Screen%20Shot%202014-09-04%20at%2012.00.02.png)
![](http://f.cl.ly/items/0j1t0g1D2D2I3M0t3m1f/Screen%20Shot%202014-09-04%20at%2012.06.24.png)

We should check if this doesn't break anything on iOS, since the Info.plist is used for both. Though it should be fine; iOS shouldn't care about NSPrincipalClass
