### PR TITLE
Clear stencil/alpha when switching from 565, minor frag shader simplication

### DIFF
--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -162,6 +162,7 @@ public:
 	}
 	void UpdateFromMemory(u32 addr, int size, bool safe);
 	void SetLineWidth();
+	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old);
 
 	void BlitFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer);
 


### PR DESCRIPTION
I became worried that shader compilers, in their great wisdom, might not optimally reduce:

fragColor0 = vec4(v.rgb, 0.0);
fragColor0.a = 1.0;

Anyway, not overwriting the 0.0 afterward is probably clearer, in case someone wonders, "why zero?"

-[Unknown]
