### PR TITLE
Report shader errors in Direct3D 9, plug some leaks

### DIFF
--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -21,6 +21,7 @@
 
 #include <map>
 #include "helper/global.h"
+#include "base/logging.h"
 #include "math/lin/matrix4x4.h"
 #include "util/text/utf8.h"
 
@@ -42,8 +43,22 @@ PSShader::PSShader(const char *code, bool useHWTransform) : failed_(false), useH
 	OutputDebugString(ConvertUTF8ToWString(code).c_str());
 #endif
 	bool success;
+	std::string errorMessage;
 
-	success = CompilePixelShader(code, &shader, &constant);
+	success = CompilePixelShader(code, &shader, &constant, errorMessage);
+
+	if (!errorMessage.empty()) {
+		if (success) {
+			ERROR_LOG(G3D, "Warnings in shader compilation!");
+		} else {
+			ERROR_LOG(G3D, "Error in shader compilation!");
+		}
+		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
+		ERROR_LOG(G3D, "Shader source:\n%s", code);
+		OutputDebugStringUTF8("Messages:\n");
+		OutputDebugStringUTF8(errorMessage.c_str());
+		Reporting::ReportMessage("D3D error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
+	}
 
 	if (!success) {
 		failed_ = true;
@@ -69,8 +84,22 @@ VSShader::VSShader(const char *code, bool useHWTransform) : failed_(false), useH
 	OutputDebugString(ConvertUTF8ToWString(code).c_str());
 #endif
 	bool success;
+	std::string errorMessage;
 
-	success = CompileVertexShader(code, &shader, &constant);
+	success = CompileVertexShader(code, &shader, &constant, errorMessage);
+
+	if (!errorMessage.empty()) {
+		if (success) {
+			ERROR_LOG(G3D, "Warnings in shader compilation!");
+		} else {
+			ERROR_LOG(G3D, "Error in shader compilation!");
+		}
+		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
+		ERROR_LOG(G3D, "Shader source:\n%s", code);
+		OutputDebugStringUTF8("Messages:\n");
+		OutputDebugStringUTF8(errorMessage.c_str());
+		Reporting::ReportMessage("D3D error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
+	}
 
 	if (!success) {
 		failed_ = true;

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -47,6 +47,8 @@ PSShader::PSShader(const char *code, bool useHWTransform) : failed_(false), useH
 
 	if (!success) {
 		failed_ = true;
+		if (shader)
+			shader->Release();
 		shader = NULL;
 	} else {
 		DEBUG_LOG(G3D, "Compiled shader:\n%s\n", (const char *)code);
@@ -55,6 +57,8 @@ PSShader::PSShader(const char *code, bool useHWTransform) : failed_(false), useH
 
 PSShader::~PSShader() {
 	pD3Ddevice->SetPixelShader(NULL);
+	if (constant)
+		constant->Release();
 	if (shader)
 		shader->Release();
 }
@@ -70,6 +74,8 @@ VSShader::VSShader(const char *code, bool useHWTransform) : failed_(false), useH
 
 	if (!success) {
 		failed_ = true;
+		if (shader)
+			shader->Release();
 		shader = NULL;
 	} else {
 		DEBUG_LOG(G3D, "Compiled shader:\n%s\n", (const char *)code);
@@ -78,6 +84,8 @@ VSShader::VSShader(const char *code, bool useHWTransform) : failed_(false), useH
 
 VSShader::~VSShader() {
 	pD3Ddevice->SetVertexShader(NULL);
+	if (constant)
+		constant->Release();
 	if (shader)
 		shader->Release();
 }

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -142,6 +142,7 @@ private:
 	void SoftwareTransformAndDraw(int prim, u8 *decoded, LinkedShaderDX9 *program, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex);
 	void ApplyDrawState(int prim);
 	bool IsReallyAClear(int numVerts) const;
+	IDirect3DVertexDeclaration9 *SetupDecFmtForDraw(LinkedShaderDX9 *program, const DecVtxFormat &decFmt, u32 pspFmt);
 
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, VertexDecoderDX9 *dec, int lowerBound, int upperBound, u32 vertType);
@@ -184,6 +185,7 @@ private:
 	TransformedVertex *transformedExpanded;
 
 	std::map<u32, VertexArrayInfoDX9 *> vai_;
+	std::map<u32, IDirect3DVertexDeclaration9 *> vertexDeclMap_;
 
 	// Fixed index buffer for easy quad generation from spline/bezier
 	u16 *quadIndices_;

--- a/GPU/Directx9/helper/fbo.h
+++ b/GPU/Directx9/helper/fbo.h
@@ -41,5 +41,6 @@ void * fbo_get_rtt(FBO *fbo);
 
 // To get default depth and rt surface
 void fbo_init();
+void fbo_shutdown();
 
 };

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -214,6 +214,20 @@ void CompileShaders() {
 	pD3Ddevice->CreateVertexDeclaration( SoftTransVertexElements, &pSoftVertexDecl );
 }
 
+void DestroyShaders() {
+	if (pFramebufferVertexShader) {
+		pFramebufferVertexShader->Release();
+	}
+	if (pFramebufferPixelShader) {
+		pFramebufferPixelShader->Release();
+	}
+	if (pFramebufferVertexDecl) {
+		pFramebufferVertexDecl->Release();
+	}
+	if (pSoftVertexDecl) {
+		pSoftVertexDecl->Release();
+	}
+}
 
 bool useVsync = false;
 

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -66,8 +66,6 @@ LPDIRECT3DVERTEXSHADER9      pFramebufferVertexShader = NULL; // Vertex Shader
 LPDIRECT3DPIXELSHADER9       pFramebufferPixelShader = NULL;  // Pixel Shader
 
 bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
-	LPD3DXCONSTANTTABLE shaderTable = *pShaderTable;
-
 	ID3DXBuffer* pShaderCode = NULL;
 	ID3DXBuffer* pErrorMsg = NULL;
 
@@ -85,9 +83,12 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 		&pErrorMsg,
 		pShaderTable);
 
-	if( FAILED(hr) )
-	{
+	if (pErrorMsg) {
 		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		pErrorMsg->Release();
+	}
+
+	if (FAILED(hr)) {
 		DebugBreak();
 		return false;
 	}
@@ -102,8 +103,6 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 }
 
 bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
-	LPD3DXCONSTANTTABLE shaderTable = *pShaderTable;
-
 	ID3DXBuffer* pShaderCode = NULL;
 	ID3DXBuffer* pErrorMsg = NULL;
 
@@ -121,9 +120,12 @@ bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, L
 		&pErrorMsg,
 		pShaderTable);
 
-	if( FAILED(hr) )
-	{
+	if (pErrorMsg) {
 		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		pErrorMsg->Release();
+	}
+
+	if (FAILED(hr)) {
 		DebugBreak();
 		return false;
 	}
@@ -154,9 +156,12 @@ void CompileShaders() {
 		&pErrorMsg,
 		NULL);
 
-	if( FAILED(hr) )
-	{
+	if (pErrorMsg) {
 		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		pErrorMsg->Release();
+	}
+
+	if (FAILED(hr)) {
 		DebugBreak();
 	}
 
@@ -165,6 +170,10 @@ void CompileShaders() {
 		&pFramebufferVertexShader );
 
 	pShaderCode->Release();
+	if (pErrorMsg) {
+		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		pErrorMsg->Release();
+	}
 
 	// Compile pixel shader.
 	hr = dyn_D3DXCompileShader(pscode,
@@ -178,9 +187,12 @@ void CompileShaders() {
 		&pErrorMsg,
 		NULL);
 
-	if( FAILED(hr) )
-	{
+	if (pErrorMsg) {
 		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		pErrorMsg->Release();
+	}
+
+	if (FAILED(hr)) {
 		DebugBreak();
 	}
 

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -65,7 +65,7 @@ static const D3DVERTEXELEMENT9  SoftTransVertexElements[] =
 LPDIRECT3DVERTEXSHADER9      pFramebufferVertexShader = NULL; // Vertex Shader
 LPDIRECT3DPIXELSHADER9       pFramebufferPixelShader = NULL;  // Pixel Shader
 
-bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
+bool CompilePixelShader(const char *code, LPDIRECT3DPIXELSHADER9 *pShader, LPD3DXCONSTANTTABLE *pShaderTable, std::string &errorMessage) {
 	ID3DXBuffer* pShaderCode = NULL;
 	ID3DXBuffer* pErrorMsg = NULL;
 
@@ -84,12 +84,15 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 		pShaderTable);
 
 	if (pErrorMsg) {
-		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		errorMessage = (CHAR *)pErrorMsg->GetBufferPointer();
 		pErrorMsg->Release();
+	} else {
+		errorMessage = "";
 	}
 
 	if (FAILED(hr)) {
-		DebugBreak();
+		if (pShaderCode)
+			pShaderCode->Release();
 		return false;
 	}
 
@@ -102,7 +105,7 @@ bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, LPD
 	return true;
 }
 
-bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, LPD3DXCONSTANTTABLE * pShaderTable) {
+bool CompileVertexShader(const char *code, LPDIRECT3DVERTEXSHADER9 *pShader, LPD3DXCONSTANTTABLE *pShaderTable, std::string &errorMessage) {
 	ID3DXBuffer* pShaderCode = NULL;
 	ID3DXBuffer* pErrorMsg = NULL;
 
@@ -121,12 +124,15 @@ bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, L
 		pShaderTable);
 
 	if (pErrorMsg) {
-		OutputDebugStringA((CHAR*)pErrorMsg->GetBufferPointer());
+		errorMessage = (CHAR *)pErrorMsg->GetBufferPointer();
 		pErrorMsg->Release();
+	} else {
+		errorMessage = "";
 	}
 
 	if (FAILED(hr)) {
-		DebugBreak();
+		if (pShaderCode)
+			pShaderCode->Release();
 		return false;
 	}
 

--- a/GPU/Directx9/helper/global.h
+++ b/GPU/Directx9/helper/global.h
@@ -27,6 +27,7 @@ extern IDirect3DVertexDeclaration9* pSoftVertexDecl;
 void CompileShaders();
 bool CompilePixelShader(const char *code, LPDIRECT3DPIXELSHADER9 *pShader, ID3DXConstantTable **pShaderTable, std::string &errorMessage);
 bool CompileVertexShader(const char *code, LPDIRECT3DVERTEXSHADER9 *pShader, ID3DXConstantTable **pShaderTable, std::string &errorMessage);
+void DestroyShaders();
 void DirectxInit(HWND window);
 
 #define D3DBLEND_UNK	D3DSTENCILOP_FORCE_DWORD

--- a/GPU/Directx9/helper/global.h
+++ b/GPU/Directx9/helper/global.h
@@ -9,6 +9,7 @@
 #define D3DFMT(x) x
 #endif
 
+#include <string>
 #include <d3d9.h>
 
 struct ID3DXConstantTable;
@@ -24,8 +25,8 @@ extern IDirect3DVertexDeclaration9* pFramebufferVertexDecl;
 extern IDirect3DVertexDeclaration9* pSoftVertexDecl;
 
 void CompileShaders();
-bool CompilePixelShader(const char * code, LPDIRECT3DPIXELSHADER9 * pShader, ID3DXConstantTable **pShaderTable);
-bool CompileVertexShader(const char * code, LPDIRECT3DVERTEXSHADER9 * pShader, ID3DXConstantTable **pShaderTable);
+bool CompilePixelShader(const char *code, LPDIRECT3DPIXELSHADER9 *pShader, ID3DXConstantTable **pShaderTable, std::string &errorMessage);
+bool CompileVertexShader(const char *code, LPDIRECT3DVERTEXSHADER9 *pShader, ID3DXConstantTable **pShaderTable, std::string &errorMessage);
 void DirectxInit(HWND window);
 
 #define D3DBLEND_UNK	D3DSTENCILOP_FORCE_DWORD

--- a/Windows/D3D9Base.cpp
+++ b/Windows/D3D9Base.cpp
@@ -121,5 +121,7 @@ void D3D9_Shutdown() {
 	device->EndScene();
 	device->Release();
 	d3d->Release();
+	DX9::pD3Ddevice = NULL;
+	DX9::pD3Ddevice = NULL;
 	hWnd = NULL;
 }

--- a/Windows/D3D9Base.cpp
+++ b/Windows/D3D9Base.cpp
@@ -116,6 +116,8 @@ void D3D9_Resize(HWND window) {
 }
 
 void D3D9_Shutdown() { 
+	DX9::DestroyShaders();
+	DX9::fbo_shutdown();
 	device->EndScene();
 	device->Release();
 	d3d->Release();

--- a/headless/WindowsHeadlessHostDx9.cpp
+++ b/headless/WindowsHeadlessHostDx9.cpp
@@ -25,6 +25,7 @@
 #include "base/logging.h"
 #include "thin3d/d3dx9_loader.h"
 #include "GPU/Directx9/helper/global.h"
+#include "GPU/Directx9/helper/fbo.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
 
@@ -80,6 +81,12 @@ bool WindowsHeadlessHostDx9::InitGL(std::string *error_message)
 
 void WindowsHeadlessHostDx9::ShutdownGL()
 {
+	DX9::DestroyShaders();
+	DX9::fbo_shutdown();
+	DX9::pD3Ddevice->EndScene();
+	DX9::pD3Ddevice->Release();
+	DX9::pD3Ddevice = NULL;
+	hWnd = NULL;
 }
 
 bool WindowsHeadlessHostDx9::ResizeGL()


### PR DESCRIPTION
This reports and logs errors from shaders better, and frees the warnings generated on most shader compiles.

Also frees better on shutdown, but not major.  There are still leaks left, unfortunately...

-[Unknown]
