### PR TITLE
Use a minihash in the vertex cache, treat unreliable arrays more carefully

### DIFF
--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -661,8 +661,13 @@ void TransformDrawEngine::DoFlush() {
 						vai->numFrames++;
 					}
 					if (vai->drawsUntilNextFullHash == 0) {
-						u32 newHash = ComputeHash();
-						if (newHash != vai->hash) {
+						// Let's try to skip a full hash if mini would fail.
+						const u32 newMiniHash = ComputeMiniHash();
+						u32 newHash = vai->hash;
+						if (newMiniHash == vai->minihash) {
+							newHash = ComputeHash();
+						}
+						if (newMiniHash != vai->minihash || newHash != vai->hash) {
 							MarkUnreliable(vai);
 							DecodeVerts();
 							goto rotateVBO;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -672,9 +672,9 @@ void TransformDrawEngine::DoFlush() {
 							DecodeVerts();
 							goto rotateVBO;
 						}
-						if (vai->numVerts > 100) {
-							// exponential backoff up to 16 draws, then every 24
-							vai->drawsUntilNextFullHash = std::min(24, vai->numFrames);
+						if (vai->numVerts > 64) {
+							// exponential backoff up to 16 draws, then every 32
+							vai->drawsUntilNextFullHash = std::min(32, vai->numFrames);
 						} else {
 							// Lower numbers seem much more likely to change.
 							vai->drawsUntilNextFullHash = 0;

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -193,6 +193,7 @@ private:
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);
 
 	u32 ComputeHash();  // Reads deferred vertex data.
+	void MarkUnreliable(VertexArrayInfo *vai);
 
 	VertexDecoder *GetVertexDecoder(u32 vtype);
 

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -78,6 +78,7 @@ public:
 	};
 
 	u32 hash;
+	u32 minihash;
 
 	Status status;
 
@@ -192,6 +193,7 @@ private:
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);
 
+	u32 ComputeMiniHash();
 	u32 ComputeHash();  // Reads deferred vertex data.
 	void MarkUnreliable(VertexArrayInfo *vai);
 


### PR DESCRIPTION
The minihash should be fairly fast (unless many small flushes are pushed, but we're already in trouble there.)  It seems to catch many cases for me, although not all.  I've only benchmarked it on Windows, but it checks a small subset of the data.

Unreliable arrays were "expiring" 120 flips after they became unreliable.  If a bunch were on the same frame, this would be a hit every 120 flips potentially all at once.  So this also prevents expiring too many in the same flip, and extends the unreliable length.

For me this improves both the performance (slightly) and accuracy of the vertex cache.

-[Unknown]
