### PR TITLE
Keep track of size and format as of last draw per framebuf

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -986,6 +986,9 @@ void FramebufferManager::DoSetRenderFrameBuffer() {
 		vfb->bufferWidth = drawing_width;
 		vfb->bufferHeight = drawing_height;
 		vfb->format = fmt;
+		vfb->drawnWidth = 0;
+		vfb->drawnHeight = 0;
+		vfb->drawnFormat = fmt;
 		vfb->usageFlags = FB_USAGE_RENDERTARGET;
 		SetColorUpdated(vfb);
 		vfb->depthUpdated = false;
@@ -1268,7 +1271,7 @@ void FramebufferManager::BindFramebufferColor(VirtualFramebuffer *framebuffer, b
 		if (renderCopy) {
 			VirtualFramebuffer copyInfo = *framebuffer;
 			copyInfo.fbo = renderCopy;
-			BlitFramebuffer_(&copyInfo, 0, 0, framebuffer, 0, 0, framebuffer->width, framebuffer->height, 0, false);
+			BlitFramebuffer_(&copyInfo, 0, 0, framebuffer, 0, 0, framebuffer->drawnWidth, framebuffer->drawnHeight, 0, false);
 
 			RebindFramebuffer();
 			fbo_bind_color_as_texture(renderCopy, 0);
@@ -1487,6 +1490,9 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 			nvfb->bufferWidth = vfb->bufferWidth;
 			nvfb->bufferHeight = vfb->bufferHeight;
 			nvfb->format = vfb->format;
+			nvfb->drawnWidth = vfb->drawnWidth;
+			nvfb->drawnHeight = vfb->drawnHeight;
+			nvfb->drawnFormat = vfb->format;
 			nvfb->usageFlags = FB_USAGE_RENDERTARGET;
 			nvfb->dirtyAfterDisplay = true;
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -90,6 +90,10 @@ struct VirtualFramebuffer {
 	FBOColorDepth colorDepth;
 	FBO *fbo;
 
+	u16 drawnWidth;
+	u16 drawnHeight;
+	GEBufferFormat drawnFormat;
+
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
 };
@@ -261,6 +265,9 @@ private:
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer) {
 		dstBuffer->memoryUpdated = false;
 		dstBuffer->dirtyAfterDisplay = true;
+		dstBuffer->drawnWidth = dstBuffer->width;
+		dstBuffer->drawnHeight = dstBuffer->height;
+		dstBuffer->drawnFormat = dstBuffer->format;
 		if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
 			dstBuffer->reallyDirtyAfterDisplay = true;
 	}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1015,7 +1015,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 	if (useBufferedRendering) {
 		GLuint program = 0;
 		if ((entry->status & TexCacheEntry::STATUS_DEPALETTIZE) && !g_Config.bDisableSlowFramebufEffects) {
-			program = depalShaderCache_->GetDepalettizeShader(framebuffer->format);
+			program = depalShaderCache_->GetDepalettizeShader(framebuffer->drawnFormat);
 		}
 		if (program) {
 			GLuint clutTexture = depalShaderCache_->GetClutTexture(clutHash_, clutBuf_);
@@ -1088,7 +1088,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 			entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
 			framebufferManager_->BindFramebufferColor(framebuffer);
 
-			gstate_c.textureFullAlpha = framebuffer->format == GE_FORMAT_565;
+			gstate_c.textureFullAlpha = framebuffer->drawnFormat == GE_FORMAT_565;
 			gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1107,8 +1107,10 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 		}
 		SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight);
 	} else {
-		if (framebuffer->fbo)
+		if (framebuffer->fbo) {
+			fbo_destroy(framebuffer->fbo);
 			framebuffer->fbo = 0;
+		}
 		glBindTexture(GL_TEXTURE_2D, 0);
 		gstate_c.needShaderTexClamp = false;
 	}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -612,9 +612,6 @@ void GameInfoCache::SetupTexture(GameInfo *info, std::string &textureData, Thin3
 			tex = thin3d->CreateTextureFromFileData((const uint8_t *)textureData.data(), (int)textureData.size(), T3DImageType::PNG);
 			if (tex) {
 				loadTime = time_now_d();
-			} else {
-				tex->Release();
-				tex = 0;
 			}
 		}
 		textureData.clear();


### PR DESCRIPTION
This way if it renders to itself, we will have the right size and format.  Hopefully no major speed impact.  May help #6689.

Also, a small crashfix.  Can merge separately.

-[Unknown]
