### PR TITLE
Update Direct3D 9 texture cache

### DIFF
--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -1106,8 +1106,8 @@ namespace DX9 {
 			hr = offscreen->LockRect(&locked, &rect, D3DLOCK_READONLY);
 			if (SUCCEEDED(hr)) {
 				// TODO: Handle the other formats?  We don't currently create them, I think.
-				buffer.Allocate(locked.Pitch / 4, vfb->renderHeight, GPU_DBG_FORMAT_8888_BGRA, false);
-				memcpy(buffer.GetData(), locked.pBits, locked.Pitch * vfb->renderHeight);
+				buffer.Allocate(locked.Pitch / 4, desc.Height, GPU_DBG_FORMAT_8888_BGRA, false);
+				memcpy(buffer.GetData(), locked.pBits, locked.Pitch * desc.Height);
 				offscreen->UnlockRect();
 				success = true;
 			}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -498,6 +498,8 @@ namespace DX9 {
 			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
 
 			vfb->last_frame_render = gpuStats.numFlips;
+			vfb->last_frame_used = 0;
+			vfb->last_frame_attached = 0;
 			frameLastFramebufUsed = gpuStats.numFlips;
 			vfbs_.push_back(vfb);
 			ClearBuffer();

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -51,6 +51,7 @@ enum {
 
 struct VirtualFramebufferDX9 {
 	int last_frame_used;
+	int last_frame_attached;
 	int last_frame_render;
 	bool memoryUpdated; 
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -388,6 +388,8 @@ DIRECTX9_GPU::DIRECTX9_GPU()
 	transformDraw_.SetFramebufferManager(&framebufferManager_);
 	framebufferManager_.SetTextureCache(&textureCache_);
 	framebufferManager_.SetShaderManager(shaderManager_);
+	textureCache_.SetFramebufferManager(&framebufferManager_);
+	textureCache_.SetShaderManager(shaderManager_);
 
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1584,6 +1584,7 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 
 	LPDIRECT3DBASETEXTURE9 baseTex;
 	LPDIRECT3DTEXTURE9 tex;
+	LPDIRECT3DSURFACE9 offscreen = nullptr;
 	HRESULT hr;
 
 	bool success;
@@ -1596,6 +1597,22 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 			tex->GetLevelDesc(level, &desc);
 			RECT rect = {0, 0, desc.Width, desc.Height};
 			hr = tex->LockRect(level, &locked, &rect, D3DLOCK_READONLY);
+
+			// If it fails, this means it's a render-to-texture, so we have to get creative.
+			if (FAILED(hr)) {
+				LPDIRECT3DSURFACE9 renderTarget;
+				hr = tex->GetSurfaceLevel(level, &renderTarget);
+				if (SUCCEEDED(hr)) {
+					hr = pD3Ddevice->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &offscreen, NULL);
+					if (SUCCEEDED(hr)) {
+						hr = pD3Ddevice->GetRenderTargetData(renderTarget, offscreen);
+						if (SUCCEEDED(hr)) {
+							hr = offscreen->LockRect(&locked, &rect, D3DLOCK_READONLY);
+						}
+					}
+				}
+			}
+
 			if (SUCCEEDED(hr)) {
 				GPUDebugBufferFormat fmt;
 				int pixelSize;
@@ -1628,7 +1645,12 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 				} else {
 					success = false;
 				}
-				tex->UnlockRect(level);
+				if (offscreen) {
+					offscreen->UnlockRect();
+					offscreen->Release();
+				} else {
+					tex->UnlockRect(level);
+				}
 			}
 			tex->Release();
 		}

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -24,15 +24,12 @@
 
 namespace DX9 {
 
-struct FragmentShaderIDDX9
-{
-	FragmentShaderIDDX9() {d[0] = 0xFFFFFFFF;}
-	void clear() {d[0] = 0xFFFFFFFF;}
-	u32 d[1];
-	bool operator < (const FragmentShaderIDDX9 &other) const
-	{
-		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++)
-		{
+struct FragmentShaderIDDX9 {
+	FragmentShaderIDDX9() {clear();}
+	void clear() {d[0] = 0xFFFFFFFF; d[1] = 0xFFFFFFFF;}
+	u32 d[2];
+	bool operator < (const FragmentShaderIDDX9 &other) const {
+		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
 			if (d[i] < other.d[i])
 				return true;
 			if (d[i] > other.d[i])
@@ -40,10 +37,8 @@ struct FragmentShaderIDDX9
 		}
 		return false;
 	}
-	bool operator == (const FragmentShaderIDDX9 &other) const
-	{
-		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++)
-		{
+	bool operator == (const FragmentShaderIDDX9 &other) const {
+		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
 			if (d[i] != other.d[i])
 				return false;
 		}
@@ -51,9 +46,11 @@ struct FragmentShaderIDDX9
 	}
 };
 
-
 void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id);
-
 void GenerateFragmentShaderDX9(char *buffer);
+
+bool IsAlphaTestAgainstZero();
+bool IsAlphaTestTriviallyTrue();
+bool IsColorTestTriviallyTrue();
 
 };

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -27,6 +27,8 @@
 namespace DX9 {
 
 struct VirtualFramebufferDX9;
+class FramebufferManagerDX9;
+class ShaderManagerDX9;
 
 enum TextureFiltering {
 	AUTO = 1,
@@ -41,13 +43,13 @@ enum FramebufferNotification {
 	NOTIFY_FB_DESTROYED,
 };
 
-class TextureCacheDX9 
-{
+class TextureCacheDX9 {
 public:
 	TextureCacheDX9();
 	~TextureCacheDX9();
 
-	void SetTexture(bool t = false);
+	void SetTexture(bool force = false);
+	bool SetOffsetTexture(u32 offset);
 
 	void Clear(bool delete_them);
 	void StartFrame();
@@ -60,6 +62,13 @@ public:
 	// are being rendered to. This is barebones so far.
 	void NotifyFramebuffer(u32 address, VirtualFramebufferDX9 *framebuffer, FramebufferNotification msg);
 
+	void SetFramebufferManager(FramebufferManagerDX9 *fbManager) {
+		framebufferManager_ = fbManager;
+	}
+	void SetShaderManager(ShaderManagerDX9 *sm) {
+		shaderManager_ = sm;
+	}
+
 	size_t NumLoadedTextures() const {
 		return cache.size();
 	}
@@ -67,7 +76,8 @@ public:
 	// Only used by Qt UI?
 	bool DecodeTexture(u8 *output, GPUgstate state);
 
-private:
+	void ForgetLastTexture();
+
 	// Wow this is starting to grow big. Soon need to start looking at resizing it.
 	// Must stay a POD.
 	struct TexCacheEntry {
@@ -76,14 +86,19 @@ private:
 
 		enum Status {
 			STATUS_HASHING = 0x00,
-			STATUS_RELIABLE = 0x01,  // cache, don't hash
-			STATUS_UNRELIABLE = 0x02,  // never cache
+			STATUS_RELIABLE = 0x01,        // Don't bother rehashing.
+			STATUS_UNRELIABLE = 0x02,      // Always recheck hash.
 			STATUS_MASK = 0x03,
 
 			STATUS_ALPHA_UNKNOWN = 0x04,
-			STATUS_ALPHA_FULL = 0x00,  // Has no alpha channel, or always full alpha.
-			STATUS_ALPHA_SIMPLE = 0x08,  // Like above, but also has 0 alpha (e.g. 5551.)
+			STATUS_ALPHA_FULL = 0x00,      // Has no alpha channel, or always full alpha.
+			STATUS_ALPHA_SIMPLE = 0x08,    // Like above, but also has 0 alpha (e.g. 5551.)
 			STATUS_ALPHA_MASK = 0x0c,
+
+			STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 15 frames in between.)
+			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
+			STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
+			STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
 		};
 
 		// Status, but int so we can zero initialize.
@@ -99,12 +114,33 @@ private:
 		u8 format;
 		u16 dim;
 		u16 bufw;
-		LPDIRECT3DTEXTURE9 texture;  //GLuint
+		LPDIRECT3DTEXTURE9 texture;
 		int invalidHint;
 		u32 fullhash;
 		u32 cluthash;
 		int maxLevel;
+		float lodBias;
 
+		Status GetHashStatus() {
+			return Status(status & STATUS_MASK);
+		}
+		void SetHashStatus(Status newStatus) {
+			status = (status & ~STATUS_MASK) | newStatus;
+		}
+		Status GetAlphaStatus() {
+			return Status(status & STATUS_ALPHA_MASK);
+		}
+		void SetAlphaStatus(Status newStatus) {
+			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
+		}
+		void SetAlphaStatus(Status newStatus, int level) {
+			// For non-level zero, only set more restrictive.
+			if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
+				SetAlphaStatus(newStatus);
+			} else if (newStatus == STATUS_ALPHA_SIMPLE && GetAlphaStatus() == STATUS_ALPHA_FULL) {
+				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
+			}
+		}
 		bool Matches(u16 dim2, u8 format2, int maxLevel2);
 		void ReleaseTexture() {
 			if (texture) {
@@ -113,27 +149,43 @@ private:
 		}
 	};
 
+	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
+
+private:
+	typedef std::map<u64, TexCacheEntry> TexCache;
+
 	void Decimate();  // Run this once per frame to get rid of old textures.
+	void DeleteTexture(TexCache::iterator it);
 	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 bytesPerPixel, u32 level);
 	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, u32 dstFmt, int bufw);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
-	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages);
+	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, int scaleFactor, u32 dstFmt);
+	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	void *DecodeTextureLevel(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &texByteAlign, u32 &dstFmt, int *bufw = 0);
 	TexCacheEntry::Status CheckAlpha(const u32 *pixelData, u32 dstFmt, int stride, int w, int h);
 	template <typename T>
 	const T *GetCurrentClut();
 	u32 GetCurrentClutHash();
 	void UpdateCurrentClut();
-	void AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer, bool exactMatch);
+	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer, u32 texaddrOffset = 0);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebufferDX9 *framebuffer);
-	void SetTextureFramebuffer(TexCacheEntry *entry);
+	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebufferDX9 *framebuffer);
 
 	TexCacheEntry *GetEntryAt(u32 texaddr);
 
-	typedef std::map<u64, TexCacheEntry> TexCache;
 	TexCache cache;
 	TexCache secondCache;
 	std::vector<VirtualFramebufferDX9 *> fbCache_;
+
+	// Separate to keep main texture cache size down.
+	struct AttachedFramebufferInfo {
+		u32 xOffset;
+		u32 yOffset;
+	};
+	std::map<u32, AttachedFramebufferInfo> fbTexInfo_;
+	void AttachFramebufferValid(TexCacheEntry *entry, VirtualFramebufferDX9 *framebuffer, const AttachedFramebufferInfo &fbInfo);
+	void AttachFramebufferInvalid(TexCacheEntry *entry, VirtualFramebufferDX9 *framebuffer, const AttachedFramebufferInfo &fbInfo);
 
 	bool clearCacheNextFrame_;
 	bool lowMemoryMode_;
@@ -150,6 +202,7 @@ private:
 	u32 *clutBuf_;
 	u32 clutHash_;
 	u32 clutTotalBytes_;
+	u32 clutMaxBytes_;
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
@@ -158,6 +211,13 @@ private:
 	float maxAnisotropyLevel;
 
 	int decimationCounter_;
+	int texelsScaledThisFrame_;
+	int timesInvalidatedAllThisFrame_;
+
+	FramebufferManagerDX9 *framebufferManager_;
+	ShaderManagerDX9 *shaderManager_;
 };
+
+D3DFORMAT getClutDestFormat(GEPaletteFormat format);
 
 };

--- a/GPU/Directx9/TextureScalerDX9.cpp
+++ b/GPU/Directx9/TextureScalerDX9.cpp
@@ -61,10 +61,10 @@ namespace {
 		for(int y = l; y < u; ++y) {
 			for(int x = 0; x < width; ++x) {
 				u32 val = data[y*width + x];
-				u32 r = ((val>>12) & 0xF) * 17;
-				u32 g = ((val>> 8) & 0xF) * 17;
-				u32 b = ((val>> 4) & 0xF) * 17;
-				u32 a = ((val>> 0) & 0xF) * 17;
+				u32 r = ((val>> 0) & 0xF) * 17;
+				u32 g = ((val>> 4) & 0xF) * 17;
+				u32 b = ((val>> 8) & 0xF) * 17;
+				u32 a = ((val>>12) & 0xF) * 17;
 				out[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
 			}
 		}
@@ -75,9 +75,9 @@ namespace {
 		for(int y = l; y < u; ++y) {
 			for(int x = 0; x < width; ++x) {
 				u32 val = data[y*width + x];
-				u32 r = Convert5To8((val>>11) & 0x1F);
+				u32 r = Convert5To8((val    ) & 0x1F);
 				u32 g = Convert6To8((val>> 5) & 0x3F);
-				u32 b = Convert5To8((val    ) & 0x1F);
+				u32 b = Convert5To8((val>>11) & 0x1F);
 				out[y*width + x] = (0xFF << 24) | (b << 16) | (g << 8) | r;
 			}
 		}
@@ -88,10 +88,10 @@ namespace {
 		for(int y = l; y < u; ++y) {
 			for(int x = 0; x < width; ++x) {
 				u32 val = data[y*width + x];
-				u32 r = Convert5To8((val>>11) & 0x1F);
-				u32 g = Convert5To8((val>> 6) & 0x1F);
-				u32 b = Convert5To8((val>> 1) & 0x1F);
-				u32 a = (val & 0x1) * 255;
+				u32 r = Convert5To8((val>> 0) & 0x1F);
+				u32 g = Convert5To8((val>> 5) & 0x1F);
+				u32 b = Convert5To8((val>>10) & 0x1F);
+				u32 a = ((val >> 15) & 0x1) * 255;
 				out[y*width + x] = (a << 24) | (b << 16) | (g << 8) | r;
 			}
 		}

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -44,6 +44,10 @@ class FramebufferManagerDX9;
 // DRAWN_ONCE -> death
 // DRAWN_RELIABLE -> death
 
+enum {
+	VAI_FLAG_VERTEXFULLALPHA = 1,
+};
+
 
 // Don't bother storing information about draws smaller than this.
 enum {
@@ -64,8 +68,10 @@ public:
 		lastFrame = gpuStats.numFlips;
 		numVerts = 0;
 		drawsUntilNextFullHash = 0;
+		flags = 0;
 	}
 	~VertexArrayInfoDX9();
+
 	enum Status {
 		VAI_NEW,
 		VAI_HASHING,
@@ -80,7 +86,6 @@ public:
 	LPDIRECT3DVERTEXBUFFER9 vbo;
 	LPDIRECT3DINDEXBUFFER9 ebo;
 
-	
 	// Precalculated parameter for drawRangeElements
 	u16 numVerts;
 	u16 maxIndex;
@@ -92,8 +97,8 @@ public:
 	int numFrames;
 	int lastFrame;  // So that we can forget.
 	u16 drawsUntilNextFullHash;
+	u8 flags;
 };
-
 
 // Handles transform, lighting and drawing.
 class TransformDrawEngineDX9 {

--- a/GPU/Directx9/VertexDecoderDX9.cpp
+++ b/GPU/Directx9/VertexDecoderDX9.cpp
@@ -231,6 +231,7 @@ void VertexDecoderDX9::Step_Color565() const
 	c[1] = Convert6To8((cdata>>5) & 0x3f);
 	c[2] = Convert5To8((cdata>>11) & 0x1f);
 	c[3] = 255;
+	// Always full alpha.
 }
 
 void VertexDecoderDX9::Step_Color5551() const
@@ -241,6 +242,7 @@ void VertexDecoderDX9::Step_Color5551() const
 	c[1] = Convert5To8((cdata>>5) & 0x1f);
 	c[2] = Convert5To8((cdata>>10) & 0x1f);
 	c[3] = (cdata >> 15) ? 255 : 0;
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] != 0;
 }
 
 void VertexDecoderDX9::Step_Color4444() const
@@ -251,6 +253,7 @@ void VertexDecoderDX9::Step_Color4444() const
 	c[1] =  Convert4To8((cdata >> (4)) & 0xF);
 	c[2] =  Convert4To8((cdata >> (8)) & 0xF);
 	c[3] =  Convert4To8((cdata >> (12)) & 0xF);
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
 
 void VertexDecoderDX9::Step_Color8888() const
@@ -261,6 +264,7 @@ void VertexDecoderDX9::Step_Color8888() const
 	c[1] = cdata[1];
 	c[2] = cdata[2];
 	c[3] = cdata[3];
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
 
 void VertexDecoderDX9::Step_Color565Morph() const
@@ -270,16 +274,16 @@ void VertexDecoderDX9::Step_Color565Morph() const
 	{
 		float w = gstate_c.morphWeights[n];		
 		u16 cdata = (u16)(*(u16_le*)(ptr_ + onesize_*n + coloff));
-
 		col[0] += w * (cdata & 0x1f) * (255.0f / 31.0f);
 		col[1] += w * ((cdata>>5) & 0x3f) * (255.0f / 63.0f);
 		col[2] += w * ((cdata>>11) & 0x1f) * (255.0f / 31.0f);
 	}
 	u8 *c = decoded_ + decFmt.c0off;
-	c[0] = (u8)col[0];
-	c[1] = (u8)col[1];
-	c[2] = (u8)col[2];
+	for (int i = 0; i < 3; i++) {
+		c[i] = clamp_u8((int)col[i]);
+	}
 	c[3] = 255;
+	// Always full alpha.
 }
 
 void VertexDecoderDX9::Step_Color5551Morph() const
@@ -295,10 +299,10 @@ void VertexDecoderDX9::Step_Color5551Morph() const
 		col[3] += w * ((cdata>>15) ? 255.0f : 0.0f);
 	}
 	u8 *c = decoded_ + decFmt.c0off;
-	c[0] = (u8)col[0];
-	c[1] = (u8)col[1];
-	c[2] = (u8)col[2];
-	c[3] = (u8)col[3];
+	for (int i = 0; i < 4; i++) {
+		c[i] = clamp_u8((int)col[i]);
+	}
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
 
 void VertexDecoderDX9::Step_Color4444Morph() const
@@ -312,10 +316,10 @@ void VertexDecoderDX9::Step_Color4444Morph() const
 			col[j] += w * ((cdata >> (j * 4)) & 0xF) * (255.0f / 15.0f);
 	}
 	u8 *c = decoded_ + decFmt.c0off;
-	c[0] = (u8)col[0];
-	c[1] = (u8)col[1];
-	c[2] = (u8)col[2];
-	c[3] = (u8)col[3];
+	for (int i = 0; i < 4; i++) {
+		c[i] = clamp_u8((int)col[i]);
+	}
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
 
 void VertexDecoderDX9::Step_Color8888Morph() const
@@ -329,10 +333,10 @@ void VertexDecoderDX9::Step_Color8888Morph() const
 			col[j] += w * cdata[j];
 	}
 	u8 *c = decoded_ + decFmt.c0off;
-	c[0] = (u8)col[0];
-	c[1] = (u8)col[1];
-	c[2] = (u8)col[2];
-	c[3] = (u8)col[3];
+	for (int i = 0; i < 4; i++) {
+		c[i] = clamp_u8((int)col[i]);
+	}
+	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && c[3] == 255;
 }
 
 void VertexDecoderDX9::Step_NormalS8() const

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -90,10 +90,10 @@ bool IsAlphaTestTriviallyTrue() {
 #endif
 			return (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed())) || (
 					(!gstate.isStencilTestEnabled() &&
-				  !gstate.isDepthTestEnabled() && 
+					!gstate.isDepthTestEnabled() &&
 					gstate.getAlphaTestRef() == 0 &&
 					gstate.isAlphaBlendEnabled() &&
-					gstate.getBlendFuncA() == GE_SRCBLEND_SRCALPHA && 
+					gstate.getBlendFuncA() == GE_SRCBLEND_SRCALPHA &&
 					safeDestFactors[(int)gstate.getBlendFuncB()]));
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -112,6 +112,7 @@ void TextureCache::Clear(bool delete_them) {
 		cache.clear();
 		secondCache.clear();
 	}
+	fbTexInfo_.clear();
 }
 
 void TextureCache::DeleteTexture(TexCache::iterator it) {
@@ -890,7 +891,7 @@ void TextureCache::LoadClut() {
 	u32 clutAddr = gstate.getClutAddress();
 	if (Memory::IsValidAddress(clutAddr)) {
 #ifdef _M_SSE
-		int numBlocks = gstate.getClutLoadBlocks(); 
+		int numBlocks = gstate.getClutLoadBlocks();
 		clutTotalBytes_ = numBlocks * 32;
 		const __m128i *source = (const __m128i *)Memory::GetPointerUnchecked(clutAddr);
 		__m128i *dest = (__m128i *)clutBufRaw_;
@@ -936,7 +937,7 @@ void TextureCache::UpdateCurrentClut() {
 	clutAlphaLinear_ = false;
 	clutAlphaLinearColor_ = 0;
 	if (gstate.getClutPaletteFormat() == GE_CMODE_16BIT_ABGR4444 && gstate.isClutIndexSimple()) {
-		const u16 *clut = GetCurrentClut<u16>();
+		const u16_le *clut = GetCurrentClut<u16_le>();
 		clutAlphaLinear_ = true;
 		clutAlphaLinearColor_ = clut[15] & 0xFFF0;
 		for (int i = 0; i < 16; ++i) {
@@ -1725,8 +1726,7 @@ void *TextureCache::DecodeTextureLevel(GETextureFormat format, GEPaletteFormat c
 				finalBuf = tmpTexBuf32.data();
 				ConvertColors(finalBuf, texptr, dstFmt, bufw * h);
 			}
-		}
-		else {
+		} else {
 			tmpTexBuf32.resize(std::max(bufw, w) * h);
 			finalBuf = UnswizzleFromMem(texptr, bufw, 4, level);
 			ConvertColors(finalBuf, finalBuf, dstFmt, bufw * h);


### PR DESCRIPTION
Next step is to make them reuse more stuff, I think.

Also, I suppose Direct3D should ideally lock and then write directly to the texture, rather than so many temporaries.

-[Unknown]
