### PR TITLE
Revert "Set NSPrincipalClass to get retina widget rendering on OS X"

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -58,7 +58,5 @@
 		<integer>1</integer>
 		<integer>2</integer>
 	</array>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
Reverts hrydgard/ppsspp#6835

Let's see if this fixes the iOS "crash" as reported
