### PR TITLE
d3d: Centralize more framebuffer management

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -41,6 +41,29 @@ void FramebufferManagerCommon::SetDisplayFramebuffer(u32 framebuf, u32 stride, G
 	displayFormat_ = format;
 }
 
+VirtualFramebuffer *FramebufferManagerCommon::GetVFBAt(u32 addr) {
+	VirtualFramebuffer *match = NULL;
+	for (size_t i = 0; i < vfbs_.size(); ++i) {
+		VirtualFramebuffer *v = vfbs_[i];
+		if (MaskedEqual(v->fb_address, addr)) {
+			// Could check w too but whatever
+			if (match == NULL || match->last_frame_render < v->last_frame_render) {
+				match = v;
+			}
+		}
+	}
+	if (match != NULL) {
+		return match;
+	}
+
+	DEBUG_LOG(SCEGE, "Finding no FBO matching address %08x", addr);
+	return 0;
+}
+
+bool FramebufferManagerCommon::MaskedEqual(u32 addr1, u32 addr2) {
+	return (addr1 & 0x03FFFFFF) == (addr2 & 0x03FFFFFF);
+}
+
 // Heuristics to figure out the size of FBO to create.
 void FramebufferManagerCommon::EstimateDrawingSize(int &drawing_width, int &drawing_height) {
 	static const int MAX_FRAMEBUF_HEIGHT = 512;

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -25,11 +25,6 @@
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
-// Aggressively delete unused FBO:s to save gpu memory.
-enum {
-	FBO_OLD_AGE = 5,
-};
-
 FramebufferManagerCommon::FramebufferManagerCommon() :
 	displayFramebufPtr_(0),
 	displayStride_(0),

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -93,7 +93,12 @@ public:
 	FramebufferManagerCommon();
 	virtual ~FramebufferManagerCommon();
 
-	virtual void DoSetRenderFrameBuffer() = 0;
+	void BeginFrame();
+
+	virtual bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false) = 0;
+	virtual bool NotifyStencilUpload(u32 addr, int size, bool skipZero = false) = 0;
+
+	void DoSetRenderFrameBuffer();
 	void SetRenderFrameBuffer() {
 		// Inlining this part since it's so frequent.
 		if (!gstate_c.framebufChanged && currentRenderVfb_) {
@@ -155,7 +160,17 @@ public:
 
 protected:
 	void EstimateDrawingSize(int &drawing_width, int &drawing_height);
+	u32 FramebufferByteSize(const VirtualFramebuffer *vfb) const;
 	static bool MaskedEqual(u32 addr1, u32 addr2);
+
+	virtual void DecimateFBOs() = 0;
+	virtual void DestroyFramebuf(VirtualFramebuffer *vfb) = 0;
+	virtual void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false) = 0;
+	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) = 0;
+	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb) = 0;
+	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) = 0;
+
+	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer) {
 		dstBuffer->memoryUpdated = false;
@@ -185,5 +200,10 @@ protected:
 	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
 	u32 framebufRangeEnd_;
 
+	bool useBufferedRendering_;
+	bool updateVRAM_;
+
 	std::vector<VirtualFramebuffer *> vfbs_;
+
+	bool hackForce04154000Download_;
 };

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -206,4 +206,9 @@ protected:
 	std::vector<VirtualFramebuffer *> vfbs_;
 
 	bool hackForce04154000Download_;
+
+	// Aggressively delete unused FBOs to save gpu memory.
+	enum {
+		FBO_OLD_AGE = 5,
+	};
 };

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -138,6 +138,12 @@ public:
 		return true;
 	}
 
+	// TODO: Break out into some form of FBO manager
+	VirtualFramebuffer *GetVFBAt(u32 addr);
+	VirtualFramebuffer *GetDisplayVFB() {
+		return GetVFBAt(displayFramebufPtr_);
+	}
+
 	int GetRenderWidth() const { return currentRenderVfb_ ? currentRenderVfb_->renderWidth : 480; }
 	int GetRenderHeight() const { return currentRenderVfb_ ? currentRenderVfb_->renderHeight : 272; }
 	int GetTargetWidth() const { return currentRenderVfb_ ? currentRenderVfb_->width : 480; }
@@ -149,6 +155,7 @@ public:
 
 protected:
 	void EstimateDrawingSize(int &drawing_width, int &drawing_height);
+	static bool MaskedEqual(u32 addr1, u32 addr2);
 
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer) {
 		dstBuffer->memoryUpdated = false;

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -35,12 +35,6 @@
 #include <algorithm>
 
 namespace DX9 {
-
-	// Aggressively delete unused FBO:s to save gpu memory.
-	enum {
-		FBO_OLD_AGE = 5,
-	};
-
 	inline u16 RGBA8888toRGB565(u32 px) {
 		return ((px >> 3) & 0x001F) | ((px >> 5) & 0x07E0) | ((px >> 8) & 0xF800);
 	}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -41,10 +41,6 @@ namespace DX9 {
 		FBO_OLD_AGE = 5,
 	};
 
-	static bool MaskedEqual(u32 addr1, u32 addr2) {
-		return (addr1 & 0x03FFFFFF) == (addr2 & 0x03FFFFFF);
-	}
-
 	inline u16 RGBA8888toRGB565(u32 px) {
 		return ((px >> 3) & 0x001F) | ((px >> 5) & 0x07E0) | ((px >> 8) & 0xF800);
 	}
@@ -292,26 +288,6 @@ namespace DX9 {
 			pD3Ddevice->SetTexture(0, tex);
 		}
 		pD3Ddevice->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, coord, 5 * sizeof(float));
-	}
-
-
-	VirtualFramebuffer *FramebufferManagerDX9::GetVFBAt(u32 addr) {
-		VirtualFramebuffer *match = NULL;
-		for (size_t i = 0; i < vfbs_.size(); ++i) {
-			VirtualFramebuffer *v = vfbs_[i];
-			if (MaskedEqual(v->fb_address, addr) && v->format == displayFormat_ && v->width >= 480) {
-				// Could check w too but whatever
-				if (match == NULL || match->last_frame_render < v->last_frame_render) {
-					match = v;
-				}
-			}
-		}
-		if (match != NULL) {
-			return match;
-		}
-
-		DEBUG_LOG(SCEGE, "Finding no FBO matching address %08x", addr);
-		return 0;
 	}
 
 	void FramebufferManagerDX9::DestroyFramebuf(VirtualFramebuffer *v) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -126,7 +126,7 @@ namespace DX9 {
 			usage = D3DUSAGE_DYNAMIC;
 		}
 		HRESULT hr = pD3Ddevice->CreateTexture(512, 272, 1, usage, D3DFMT(D3DFMT_A8R8G8B8), pool, &drawPixelsTex_, NULL);
-		if (!hr) {
+		if (FAILED(hr)) {
 			drawPixelsTex_ = nullptr;
 			ERROR_LOG(G3D, "Failed to create drawpixels texture");
 		}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -136,7 +136,7 @@ namespace DX9 {
 			drawPixelsTex_ = nullptr;
 			ERROR_LOG(G3D, "Failed to create drawpixels texture");
 		}
-		useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+		BeginFrame();
 	}
 
 	FramebufferManagerDX9::~FramebufferManagerDX9() {
@@ -310,221 +310,171 @@ namespace DX9 {
 		delete v;
 	}
 
-	void FramebufferManagerDX9::DoSetRenderFrameBuffer() {
-#if 0
-		if (g_Config.iRenderingMode != 0 && g_Config.bWipeFramebufferAlpha && currentRenderVfb_) {
-			// Hack is enabled, and there was a previous framebuffer.
-			// Before we switch, let's do a series of trickery to copy one bit of stencil to
-			// destination alpha. Or actually, this is just a bunch of hackery attempts on Wipeout.
-			// Ignore for now.
-			/*
-			glstate.depthTest.disable();
-			glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-			glstate.stencilTest.enable();
-			glstate.stencilOp.set(GL_KEEP, GL_KEEP, GL_KEEP);  // don't modify stencil?
-			glstate.stencilFunc.set(GL_GEQUAL, 0xFE, 0xFF);
-			DrawPlainColor(0x00000000);
-			//glstate.stencilFunc.set(GL_LESS, 0x80, 0xFF);
-			//DrawPlainColor(0xFF000000);
-			glstate.stencilTest.disable();
-			glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-			*/
+	void FramebufferManagerDX9::ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force) {
+		float renderWidthFactor = (float)vfb->renderWidth / (float)vfb->bufferWidth;
+		float renderHeightFactor = (float)vfb->renderHeight / (float)vfb->bufferHeight;
+		VirtualFramebuffer old = *vfb;
 
-			glstate.depthTest.disable();
-			glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-			DrawPlainColor(0x00000000);
-			shaderManager_->DirtyLastShader();  // dirty lastShader_
-		}
-#endif
-		gstate_c.framebufChanged = false;
-
-		// Get parameters
-		u32 fb_address = gstate.getFrameBufRawAddress();
-		int fb_stride = gstate.fbwidth & 0x3C0;
-
-		u32 z_address = gstate.getDepthBufRawAddress();
-		int z_stride = gstate.zbwidth & 0x3C0;
-
-		// Yeah this is not completely right. but it'll do for now.
-		//int drawing_width = ((gstate.region2) & 0x3FF) + 1;
-		//int drawing_height = ((gstate.region2 >> 10) & 0x3FF) + 1;
-
-		GEBufferFormat fmt = gstate.FrameBufFormat();
-
-		// As there are no clear "framebuffer width" and "framebuffer height" registers,
-		// we need to infer the size of the current framebuffer somehow.
-		int drawing_width, drawing_height;
-		EstimateDrawingSize(drawing_width, drawing_height);
-
-		int buffer_width = drawing_width;
-		int buffer_height = drawing_height;
-
-		// Find a matching framebuffer
-		VirtualFramebuffer *vfb = 0;
-		for (size_t i = 0; i < vfbs_.size(); ++i) {
-			VirtualFramebuffer *v = vfbs_[i];
-			if (MaskedEqual(v->fb_address, fb_address) && v->width >= drawing_width && v->height >= drawing_height) {
-				// Let's not be so picky for now. Let's say this is the one.
-				vfb = v;
-				// Update fb stride in case it changed
-				vfb->fb_stride = fb_stride;
-				v->format = fmt;
-				break; 
+		if (force) {
+			vfb->bufferWidth = w;
+			vfb->bufferHeight = h;
+		} else {
+			if (vfb->bufferWidth >= w && vfb->bufferHeight >= h) {
+				return;
 			}
+
+			// In case it gets thin and wide, don't resize down either side.
+			vfb->bufferWidth = std::max(vfb->bufferWidth, w);
+			vfb->bufferHeight = std::max(vfb->bufferHeight, h);
 		}
 
-		float renderWidthFactor = (float)PSP_CoreParameter().renderWidth / 480.0f;
-		float renderHeightFactor = (float)PSP_CoreParameter().renderHeight / 272.0f;
+		vfb->renderWidth = vfb->bufferWidth * renderWidthFactor;
+		vfb->renderHeight = vfb->bufferHeight * renderHeightFactor;
 
-		// None found? Create one.
-		if (!vfb) {
-			gstate_c.textureChanged = true;
-			vfb = new VirtualFramebuffer();
-			vfb->fbo = 0;
-			vfb->fb_address = fb_address;
-			vfb->fb_stride = fb_stride;
-			vfb->z_address = z_address;
-			vfb->z_stride = z_stride;
-			vfb->width = drawing_width;
-			vfb->height = drawing_height;
-			vfb->renderWidth = (u16)(drawing_width * renderWidthFactor);
-			vfb->renderHeight = (u16)(drawing_height * renderHeightFactor);
-			vfb->bufferWidth = buffer_width;
-			vfb->bufferHeight = buffer_height;
-			vfb->format = fmt;
-			vfb->usageFlags = FB_USAGE_RENDERTARGET;
-			vfb->dirtyAfterDisplay = true;
-			if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
-				vfb->reallyDirtyAfterDisplay = true;
-			vfb->memoryUpdated = false; 
+		bool trueColor = g_Config.bTrueColor;
+		if (hackForce04154000Download_ && vfb->fb_address == 0x00154000) {
+			trueColor = true;
+		}
 
-			if (g_Config.bTrueColor) {
+		if (trueColor) {
+			vfb->colorDepth = FBO_8888;
+		} else {
+			switch (vfb->format) {
+			case GE_FORMAT_4444:
+				vfb->colorDepth = FBO_4444;
+				break;
+			case GE_FORMAT_5551:
+				vfb->colorDepth = FBO_5551;
+				break;
+			case GE_FORMAT_565:
+				vfb->colorDepth = FBO_565;
+				break;
+			case GE_FORMAT_8888:
+			default:
 				vfb->colorDepth = FBO_8888;
-			} else { 
-				switch (fmt) {
-				case GE_FORMAT_4444: 
-					vfb->colorDepth = FBO_4444; 
-					break;
-				case GE_FORMAT_5551: 
-					vfb->colorDepth = FBO_5551; 
-					break;
-				case GE_FORMAT_565: 
-					vfb->colorDepth = FBO_565; 
-					break;
-				case GE_FORMAT_8888: 
-					vfb->colorDepth = FBO_8888; 
-					break;
-				default: 
-					vfb->colorDepth = FBO_8888; 
-					break;
+				break;
+			}
+		}
+
+		textureCache_->ForgetLastTexture();
+		fbo_unbind();
+
+		if (!useBufferedRendering_) {
+			if (vfb->fbo) {
+				fbo_destroy(vfb->fbo);
+				vfb->fbo = 0;
+			}
+			return;
+		}
+
+		vfb->fbo = fbo_create(vfb->renderWidth, vfb->renderHeight, 1, true, (FBOColorDepth)vfb->colorDepth);
+		if (old.fbo) {
+			INFO_LOG(SCEGE, "Resizing FBO for %08x : %i x %i x %i", vfb->fb_address, w, h, vfb->format);
+			if (vfb->fbo) {
+				ClearBuffer();
+				if (!g_Config.bDisableSlowFramebufEffects) {
+					// TODO
+					//BlitFramebuffer_(vfb, 0, 0, &old, 0, 0, std::min(vfb->bufferWidth, vfb->width), std::min(vfb->height, vfb->bufferHeight), 0);
 				}
 			}
+			fbo_destroy(old.fbo);
+			if (vfb->fbo) {
+				fbo_bind_as_render_target(vfb->fbo);
+			}
+		}
 
-			if (useBufferedRendering_) {
-				vfb->fbo = fbo_create(vfb->renderWidth, vfb->renderHeight, 1, true, (FBOColorDepth)vfb->colorDepth);
-				if (vfb->fbo) {
-					fbo_bind_as_render_target(vfb->fbo);
-				} else {
-					ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", vfb->renderWidth, vfb->renderHeight);
-				}
+		if (!vfb->fbo) {
+			ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", vfb->renderWidth, vfb->renderHeight);
+		}
+	}
+
+	void FramebufferManagerDX9::NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) {
+		if (!useBufferedRendering_) {
+			fbo_unbind();
+			// Let's ignore rendering to targets that have not (yet) been displayed.
+			gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
+		}
+
+		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
+
+		ClearBuffer();
+
+		// TODO (in Common)
+		//if (useBufferedRendering_ && !updateVRAM_ && !g_Config.bDisableSlowFramebufEffects) {
+		//	u32 byteSize = FramebufferByteSize(vfb);
+		//	u32 fb_address_mem = (vfb->fb_address & 0x3FFFFFFF) | 0x04000000;
+		//	gpu->PerformMemoryUpload(fb_address_mem, byteSize);
+		//	NotifyStencilUpload(fb_address_mem, byteSize, true);
+		//	// TODO: Is it worth trying to upload the depth buffer?
+		//}
+
+		// ugly...
+		if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
+			shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
+		}
+	}
+
+	void FramebufferManagerDX9::NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb) {
+		if (ShouldDownloadFramebuffer(vfb) && !vfb->memoryUpdated) {
+			// TODO
+			//ReadFramebufferToMemory(vfb, true, 0, 0, vfb->width, vfb->height);
+		}
+		textureCache_->ForgetLastTexture();
+
+		if (useBufferedRendering_) {
+			if (vfb->fbo) {
+				fbo_bind_as_render_target(vfb->fbo);
 			} else {
+				// wtf? This should only happen very briefly when toggling bBufferedRendering
 				fbo_unbind();
-				// Let's ignore rendering to targets that have not (yet) been displayed.
+			}
+		} else {
+			if (vfb->fbo) {
+				// wtf? This should only happen very briefly when toggling bBufferedRendering
+				textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED);
+				fbo_destroy(vfb->fbo);
+				vfb->fbo = 0;
+			}
+			fbo_unbind();
+
+			// Let's ignore rendering to targets that have not (yet) been displayed.
+			if (vfb->usageFlags & FB_USAGE_DISPLAYED_FRAMEBUFFER) {
+				gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
+			} else {
 				gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
 			}
+		}
+		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
 
-			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
-
-			vfb->last_frame_render = gpuStats.numFlips;
-			vfb->last_frame_used = 0;
-			vfb->last_frame_attached = 0;
-			frameLastFramebufUsed_ = gpuStats.numFlips;
-			vfbs_.push_back(vfb);
-			ClearBuffer();
-
-			currentRenderVfb_ = vfb;
-
-			INFO_LOG(SCEGE, "Creating FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-
-			// Let's check for depth buffer overlap.  Might be interesting.
-			bool sharingReported = false;
-			for (size_t i = 0, end = vfbs_.size(); i < end; ++i) {
-				if (MaskedEqual(fb_address, vfbs_[i]->z_address)) {
-					WARN_LOG_REPORT(SCEGE, "FBO created from existing depthbuffer (unsupported), %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-				} else if (MaskedEqual(z_address, vfbs_[i]->fb_address)) {
-					WARN_LOG_REPORT(SCEGE, "FBO using other buffer as depthbuffer (unsupported), %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-				} else if (MaskedEqual(z_address, vfbs_[i]->z_address) && fb_address != vfbs_[i]->fb_address && !sharingReported) {
-					WARN_LOG_REPORT(SCEGE, "FBO sharing existing depthbuffer (unsupported), %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-					sharingReported = true;
-				}
-			}
-
-			// We already have it!
-		} else if (vfb != currentRenderVfb_) {
-			bool updateVRAM = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
-
-			if (updateVRAM && !vfb->memoryUpdated) {
-				ReadFramebufferToMemory(vfb, true);
-			} 
-			// Use it as a render target.
-			DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-			vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-			gstate_c.textureChanged = true;
-			vfb->last_frame_render = gpuStats.numFlips;
-			frameLastFramebufUsed_ = gpuStats.numFlips;
-			vfb->dirtyAfterDisplay = true;
-			if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
-				vfb->reallyDirtyAfterDisplay = true;
-			vfb->memoryUpdated = false;
-
-			if (useBufferedRendering_) {
-				if (vfb->fbo) {
-					fbo_bind_as_render_target(vfb->fbo);
-				} else {
-					// wtf? This should only happen very briefly when toggling bBufferedRendering
-					fbo_unbind();
-				}
-			} else {
-				if (vfb->fbo) {
-					// wtf? This should only happen very briefly when toggling bBufferedRendering
-					textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED);
-					fbo_destroy(vfb->fbo);
-					vfb->fbo = 0;
-				}
-				fbo_unbind();
-
-				// Let's ignore rendering to targets that have not (yet) been displayed.
-				if (vfb->usageFlags & FB_USAGE_DISPLAYED_FRAMEBUFFER) {
-					gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
-				} else {
-					gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
-				}
-			}
-			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
-
-#if 0
-			// Some tiled mobile GPUs benefit IMMENSELY from clearing an FBO before rendering
-			// to it. This broke stuff before, so now it only clears on the first use of an
-			// FBO in a frame. This means that some games won't be able to avoid the on-some-GPUs
-			// performance-crushing framebuffer reloads from RAM, but we'll have to live with that.
-			if (vfb->last_frame_render != gpuStats.numFlips)	{
-				ClearBuffer();
-			}
-#endif
-			currentRenderVfb_ = vfb;
-		} else {
-			vfb->last_frame_render = gpuStats.numFlips;
-			frameLastFramebufUsed_ = gpuStats.numFlips;
-			vfb->dirtyAfterDisplay = true;
-			if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
-				vfb->reallyDirtyAfterDisplay = true;
+		// Copy depth pixel value from the read framebuffer to the draw framebuffer
+		if (prevVfb && !g_Config.bDisableSlowFramebufEffects) {
+			// TODO
+			//BlitFramebufferDepth(prevVfb, vfb);
+		}
+		if (vfb->drawnFormat != vfb->format) {
+			// TODO: Might ultimately combine this with the resize step in DoSetRenderFrameBuffer().
+			// TODO
+			//ReformatFramebufferFrom(vfb, vfb->drawnFormat);
 		}
 
 		// ugly...
 		if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
 			shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
-			gstate_c.curRTWidth = vfb->width;
-			gstate_c.curRTHeight = vfb->height;
+		}
+	}
+
+	void FramebufferManagerDX9::NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) {
+		if (vfbFormatChanged) {
+			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
+			if (vfb->drawnFormat != vfb->format) {
+				// TODO
+				//ReformatFramebufferFrom(vfb, vfb->drawnFormat);
+			}
+		}
+
+		// ugly...
+		if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
+			shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
 		}
 	}
 
@@ -872,12 +822,6 @@ namespace DX9 {
 		resized_ = false;
 	}
 
-	void FramebufferManagerDX9::BeginFrame() {
-		DecimateFBOs();
-		currentRenderVfb_ = 0;
-		useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-	}
-
 	std::vector<FramebufferInfo> FramebufferManagerDX9::GetFramebufferList() {
 		std::vector<FramebufferInfo> list;
 
@@ -898,7 +842,7 @@ namespace DX9 {
 	}
 
 	// MotoGP workaround
-	void FramebufferManagerDX9::NotifyFramebufferCopy(u32 src, u32 dest, int size) {
+	bool FramebufferManagerDX9::NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset) {
 		for (size_t i = 0; i < vfbs_.size(); i++) {
 			// This size fits for MotoGP. Might want to make this more flexible for other games if they do the same.
 			if ((vfbs_[i]->fb_address | 0x04000000) == src && size == 512 * 272 * 2) {
@@ -906,6 +850,13 @@ namespace DX9 {
 				knownFramebufferCopies_.insert(std::pair<u32, u32>(src, dest));
 			}
 		}
+		// TODO
+		return false;
+	}
+
+	bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, bool skipZero) {
+		// TODO
+		return false;
 	}
 
 	void FramebufferManagerDX9::DecimateFBOs() {

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -60,23 +60,22 @@ public:
 	void DrawActiveTexture(LPDIRECT3DTEXTURE9 tex, float x, float y, float w, float h, float destW, float destH, bool flip = false, float uscale = 1.0f, float vscale = 1.0f);
 
 	void DestroyAllFBOs();
-	void DecimateFBOs();
 
-	void BeginFrame();
 	void EndFrame();
 	void Resized();
 	void DeviceLost();
 	void CopyDisplayToOutput();
-	virtual void DoSetRenderFrameBuffer() override;  // Uses parameters computed from gstate
 	void UpdateFromMemory(u32 addr, int size, bool safe);
 
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync = true);
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 
-	void NotifyFramebufferCopy(u32 src, u32 dest, int size);
+	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false);
+	bool NotifyStencilUpload(u32 addr, int size, bool skipZero = false);
 
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
+	void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false);
 
 	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
@@ -86,6 +85,12 @@ protected:
 	virtual void DisableState() override;
 	virtual void ClearBuffer() override;
 	virtual void ClearDepthBuffer() override;
+
+	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
+	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb) override;
+	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+
+	virtual void DecimateFBOs() override;
 
 private:
 	void CompileDraw2DProgram();
@@ -114,7 +119,6 @@ private:
 	std::vector<FBO *> extraFBOs_;
 
 	bool resized_;
-	bool useBufferedRendering_;
 
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -72,12 +72,6 @@ public:
 
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync = true);
 
-	// TODO: Break out into some form of FBO manager
-	VirtualFramebuffer *GetVFBAt(u32 addr);
-	VirtualFramebuffer *GetDisplayVFB() {
-		return GetVFBAt(displayFramebufPtr_);
-	}
-
 	std::vector<FramebufferInfo> GetFramebufferList();
 
 	void NotifyFramebufferCopy(u32 src, u32 dest, int size);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -741,300 +741,93 @@ void FramebufferManager::ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h
 	}
 }
 
-void FramebufferManager::DoSetRenderFrameBuffer() {
-	/*
-	if (useBufferedRendering_ && currentRenderVfb_) {
-		// Hack is enabled, and there was a previous framebuffer.
-		// Before we switch, let's do a series of trickery to copy one bit of stencil to
-		// destination alpha. Or actually, this is just a bunch of hackery attempts on Wipeout.
-		// Ignore for now.
-		glstate.depthTest.disable();
-		glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-		glstate.stencilTest.enable();
-		glstate.stencilOp.set(GL_KEEP, GL_KEEP, GL_KEEP);  // don't modify stencil§
-		glstate.stencilFunc.set(GL_GEQUAL, 0xFE, 0xFF);
-		DrawPlainColor(0x00000000);
-		//glstate.stencilFunc.set(GL_LESS, 0x80, 0xFF);
-		//DrawPlainColor(0xFF000000);
-		glstate.stencilTest.disable();
-		glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-
-		glstate.depthTest.disable();
-		glstate.colorMask.set(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-		DrawPlainColor(0x00000000);
-		shaderManager_->DirtyLastShader();  // dirty lastShader_
-	}
-	*/
-
-
-	gstate_c.framebufChanged = false;
-
-	// Get parameters
-	const u32 fb_address = gstate.getFrameBufRawAddress();
-	const int fb_stride = gstate.FrameBufStride();
-
-	const u32 z_address = gstate.getDepthBufRawAddress();
-	const int z_stride = gstate.DepthBufStride();
-
-	GEBufferFormat fmt = gstate.FrameBufFormat();
-
-	// As there are no clear "framebuffer width" and "framebuffer height" registers,
-	// we need to infer the size of the current framebuffer somehow.
-	int drawing_width, drawing_height;
-	EstimateDrawingSize(drawing_width, drawing_height);
-
-	gstate_c.cutRTOffsetX = 0;
-	bool vfbFormatChanged = false;
-	GEBufferFormat vfbOldFormat = GE_FORMAT_INVALID;
-
-	// Find a matching framebuffer
-	VirtualFramebuffer *vfb = 0;
-	size_t i;
-	for (i = 0; i < vfbs_.size(); ++i) {
-		VirtualFramebuffer *v = vfbs_[i];
-		if (v->fb_address == fb_address) {
-			vfb = v;
-			// Update fb stride in case it changed
-			if (vfb->fb_stride != fb_stride || vfb->format != fmt) {
-				vfbOldFormat = vfb->format;
-				vfbFormatChanged = true;
-				vfb->fb_stride = fb_stride;
-				vfb->format = fmt;
-			}
-			// In throughmode, a higher height could be used.  Let's avoid shrinking the buffer.
-			if (gstate.isModeThrough() && (int)vfb->width < fb_stride) {
-				vfb->width = std::max((int)vfb->width, drawing_width);
-				vfb->height = std::max((int)vfb->height, drawing_height);
-			} else {
-				vfb->width = drawing_width;
-				vfb->height = drawing_height;
-			}
-			break;
-		} else if (v->fb_address < fb_address && v->fb_address + v->fb_stride * 4 > fb_address) {
-			// Possibly a render-to-offset.
-			const u32 bpp = v->format == GE_FORMAT_8888 ? 4 : 2;
-			const int x_offset = (fb_address - v->fb_address) / bpp;
-			if (v->format == fmt && v->fb_stride == fb_stride && x_offset < fb_stride && v->height >= drawing_height) {
-				WARN_LOG_REPORT_ONCE(renderoffset, HLE, "Rendering to framebuffer offset: %08x +%dx%d", v->fb_address, x_offset, 0);
-				vfb = v;
-				gstate_c.cutRTOffsetX = x_offset;
-				vfb->width = std::max((int)vfb->width, x_offset + drawing_width);
-				// To prevent the newSize code from being confused.
-				drawing_width += x_offset;
-				break;
-			}
-		}
+void FramebufferManager::NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) {
+	if (!useBufferedRendering_) {
+		fbo_unbind();
+		// Let's ignore rendering to targets that have not (yet) been displayed.
+		gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
 	}
 
-	if (vfb) {
-		if ((drawing_width != vfb->bufferWidth || drawing_height != vfb->bufferHeight)) {
-			// Even if it's not newly wrong, if this is larger we need to resize up.
-			if (vfb->width > vfb->bufferWidth || vfb->height > vfb->bufferHeight) {
-				ResizeFramebufFBO(vfb, vfb->width, vfb->height);
-			} else if (vfb->newWidth != drawing_width || vfb->newHeight != drawing_height) {
-				// If it's newly wrong, or changing every frame, just keep track.
-				vfb->newWidth = drawing_width;
-				vfb->newHeight = drawing_height;
-				vfb->lastFrameNewSize = gpuStats.numFlips;
-			} else if (vfb->lastFrameNewSize + FBO_OLD_AGE < gpuStats.numFlips) {
-				// Okay, it's changed for a while (and stayed that way.)  Let's start over.
-				// But only if we really need to, to avoid blinking.
-				bool needsRecreate = vfb->bufferWidth > fb_stride;
-				needsRecreate = needsRecreate || vfb->newWidth > vfb->bufferWidth || vfb->newWidth * 2 < vfb->bufferWidth;
-				needsRecreate = needsRecreate || vfb->newHeight > vfb->newHeight || vfb->newHeight * 2 < vfb->newHeight;
-				if (needsRecreate) {
-					ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);
-				}
-			}
+	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
+
+	// Some AMD drivers crash if we don't clear the buffer first?
+	glDisable(GL_DITHER);  // why?
+	ClearBuffer();
+
+	// ugly...
+	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
+		shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
+	}
+}
+
+void FramebufferManager::NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb) {
+	if (ShouldDownloadFramebuffer(vfb) && !vfb->memoryUpdated) {
+		ReadFramebufferToMemory(vfb, true, 0, 0, vfb->width, vfb->height);
+	}
+	textureCache_->ForgetLastTexture();
+
+	if (useBufferedRendering_) {
+		if (vfb->fbo) {
+			fbo_bind_as_render_target(vfb->fbo);
 		} else {
-			// It's not different, let's keep track of that too.
-			vfb->lastFrameNewSize = gpuStats.numFlips;
-		}
-	}
-
-	float renderWidthFactor = (float)PSP_CoreParameter().renderWidth / 480.0f;
-	float renderHeightFactor = (float)PSP_CoreParameter().renderHeight / 272.0f;
-
-	if (hackForce04154000Download_ && fb_address == 0x00154000) {
-		renderWidthFactor = 1.0;
-		renderHeightFactor = 1.0;
-	}
-
-	// None found? Create one.
-	if (!vfb) {
-		vfb = new VirtualFramebuffer();
-		vfb->fbo = 0;
-		vfb->fb_address = fb_address;
-		vfb->fb_stride = fb_stride;
-		vfb->z_address = z_address;
-		vfb->z_stride = z_stride;
-		vfb->width = drawing_width;
-		vfb->height = drawing_height;
-		vfb->newWidth = drawing_width;
-		vfb->newHeight = drawing_height;
-		vfb->lastFrameNewSize = gpuStats.numFlips;
-		vfb->renderWidth = (u16)(drawing_width * renderWidthFactor);
-		vfb->renderHeight = (u16)(drawing_height * renderHeightFactor);
-		vfb->bufferWidth = drawing_width;
-		vfb->bufferHeight = drawing_height;
-		vfb->format = fmt;
-		vfb->drawnWidth = 0;
-		vfb->drawnHeight = 0;
-		vfb->drawnFormat = fmt;
-		vfb->usageFlags = FB_USAGE_RENDERTARGET;
-		SetColorUpdated(vfb);
-		vfb->depthUpdated = false;
-
-		ResizeFramebufFBO(vfb, drawing_width, drawing_height, true);
-
-		if (!useBufferedRendering_) {
+			// wtf? This should only happen very briefly when toggling bBufferedRendering
 			fbo_unbind();
-			// Let's ignore rendering to targets that have not (yet) been displayed.
-			gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
-		}
-
-		INFO_LOG(SCEGE, "Creating FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-
-		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
-
-		vfb->last_frame_render = gpuStats.numFlips;
-		vfb->last_frame_used = 0;
-		vfb->last_frame_attached = 0;
-		frameLastFramebufUsed_ = gpuStats.numFlips;
-		vfbs_.push_back(vfb);
-		glDisable(GL_DITHER);  // why?
-		currentRenderVfb_ = vfb;
-
-		u32 byteSize = FramebufferByteSize(vfb);
-		u32 fb_address_mem = (fb_address & 0x3FFFFFFF) | 0x04000000;
-		if (Memory::IsVRAMAddress(fb_address_mem) && fb_address_mem + byteSize > framebufRangeEnd_) {
-			framebufRangeEnd_ = fb_address_mem + byteSize;
-		}
-
-		// Some AMD drivers crash if we don't clear the buffer first?
-		ClearBuffer();
-		if (useBufferedRendering_ && !updateVRAM_ && !g_Config.bDisableSlowFramebufEffects) {
-			gpu->PerformMemoryUpload(fb_address_mem, byteSize);
-			NotifyStencilUpload(fb_address_mem, byteSize, true);
-			// TODO: Is it worth trying to upload the depth buffer?
-		}
-
-		// Let's check for depth buffer overlap.  Might be interesting.
-		bool sharingReported = false;
-		bool writingDepth = true;
-		// Technically, it may write depth later, but we're trying to detect it only when it's really true.
-		if (gstate.isModeClear()) {
-			writingDepth = !gstate.isClearModeDepthMask() && gstate.isDepthWriteEnabled();
-		} else {
-			writingDepth = gstate.isDepthWriteEnabled();
-		}
-		for (size_t i = 0, end = vfbs_.size(); i < end; ++i) {
-			if (vfbs_[i]->z_stride != 0 && fb_address == vfbs_[i]->z_address) {
-				// If it's clearing it, most likely it just needs more video memory.
-				// Technically it could write something interesting and the other might not clear, but that's not likely.
-				if (!gstate.isModeClear() || !gstate.isClearModeColorMask() || !gstate.isClearModeAlphaMask()) {
-					if (fb_address != z_address && vfbs_[i]->fb_address != vfbs_[i]->z_address) {
-						WARN_LOG_REPORT(SCEGE, "FBO created from existing depthbuffer as color, %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-					}
-				}
-			} else if (z_stride != 0 && z_address == vfbs_[i]->fb_address) {
-				// If it's clearing it, then it's probably just the reverse of the above case.
-				if (writingDepth) {
-					WARN_LOG_REPORT(SCEGE, "FBO using existing buffer as depthbuffer, %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-				}
-			} else if (vfbs_[i]->z_stride != 0 && z_address == vfbs_[i]->z_address && fb_address != vfbs_[i]->fb_address && !sharingReported) {
-				// This happens a lot, but virtually always it's cleared.
-				// It's possible the other might not clear, but when every game is reported it's not useful.
-				if (writingDepth) {
-					WARN_LOG_REPORT(SCEGE, "FBO reusing depthbuffer, %08x/%08x and %08x/%08x", fb_address, z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
-					sharingReported = true;
-				}
-			}
-		}
-
-	// We already have it!
-	} else if (vfb != currentRenderVfb_) {
-	
-		if (ShouldDownloadFramebuffer(vfb) && !vfb->memoryUpdated) {
-			ReadFramebufferToMemory(vfb, true, 0, 0, vfb->width, vfb->height);
-		}
-		// Use it as a render target.
-		DEBUG_LOG(SCEGE, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
-		textureCache_->ForgetLastTexture();
-		vfb->last_frame_render = gpuStats.numFlips;
-		frameLastFramebufUsed_ = gpuStats.numFlips;
-		vfb->dirtyAfterDisplay = true;
-		if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
-			vfb->reallyDirtyAfterDisplay = true;
-
-		if (useBufferedRendering_) {
-			if (vfb->fbo) {
-				fbo_bind_as_render_target(vfb->fbo);
-			} else {
-				// wtf? This should only happen very briefly when toggling bBufferedRendering
-				fbo_unbind();
-			}
-		} else {
-			if (vfb->fbo) {
-				// wtf? This should only happen very briefly when toggling bBufferedRendering
-				textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED);
-				fbo_destroy(vfb->fbo);
-				vfb->fbo = 0;
-			}
-			fbo_unbind();
-
-			// Let's ignore rendering to targets that have not (yet) been displayed.
-			if (vfb->usageFlags & FB_USAGE_DISPLAYED_FRAMEBUFFER) {
-				gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
-			} else {
-				gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
-			}
-		}
-		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
-
-#ifdef USING_GLES2
-		// Some tiled mobile GPUs benefit IMMENSELY from clearing an FBO before rendering
-		// to it. This broke stuff before, so now it only clears on the first use of an
-		// FBO in a frame. This means that some games won't be able to avoid the on-some-GPUs
-		// performance-crushing framebuffer reloads from RAM, but we'll have to live with that.
-		if (vfb->last_frame_render != gpuStats.numFlips) {
-			ClearBuffer();
-		}
-#endif
-
-		// Copy depth pixel value from the read framebuffer to the draw framebuffer
-		if (currentRenderVfb_ && !g_Config.bDisableSlowFramebufEffects) {
-			BlitFramebufferDepth(currentRenderVfb_, vfb);
-		}
-		currentRenderVfb_ = vfb;
-		if (vfbFormatChanged && vfbOldFormat != vfb->format) {
-			// TODO: Might ultimately combine this with the resize step above.
-			ReformatFramebufferFrom(vfb, vfbOldFormat);
 		}
 	} else {
-		if (vfbFormatChanged) {
-			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
-			if (vfbOldFormat != vfb->format) {
-				ReformatFramebufferFrom(vfb, vfbOldFormat);
-			}
+		if (vfb->fbo) {
+			// wtf? This should only happen very briefly when toggling bBufferedRendering
+			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED);
+			fbo_destroy(vfb->fbo);
+			vfb->fbo = 0;
 		}
+		fbo_unbind();
 
-		vfb->last_frame_render = gpuStats.numFlips;
-		frameLastFramebufUsed_ = gpuStats.numFlips;
-		vfb->dirtyAfterDisplay = true;
-		if ((gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
-			vfb->reallyDirtyAfterDisplay = true;
+		// Let's ignore rendering to targets that have not (yet) been displayed.
+		if (vfb->usageFlags & FB_USAGE_DISPLAYED_FRAMEBUFFER) {
+			gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
+		} else {
+			gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
+		}
+	}
+	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
+
+#ifdef USING_GLES2
+	// Some tiled mobile GPUs benefit IMMENSELY from clearing an FBO before rendering
+	// to it. This broke stuff before, so now it only clears on the first use of an
+	// FBO in a frame. This means that some games won't be able to avoid the on-some-GPUs
+	// performance-crushing framebuffer reloads from RAM, but we'll have to live with that.
+	if (vfb->last_frame_render != gpuStats.numFlips) {
+		ClearBuffer();
+	}
+#endif
+
+	// Copy depth pixel value from the read framebuffer to the draw framebuffer
+	if (prevVfb && !g_Config.bDisableSlowFramebufEffects) {
+		BlitFramebufferDepth(prevVfb, vfb);
+	}
+	if (vfb->drawnFormat != vfb->format) {
+		// TODO: Might ultimately combine this with the resize step in DoSetRenderFrameBuffer().
+		ReformatFramebufferFrom(vfb, vfb->drawnFormat);
 	}
 
 	// ugly...
 	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
 		shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
-		gstate_c.curRTWidth = vfb->width;
-		gstate_c.curRTHeight = vfb->height;
 	}
-	gstate_c.curRTRenderWidth = vfb->renderWidth;
-	gstate_c.curRTRenderHeight = vfb->renderHeight;
+}
+
+void FramebufferManager::NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) {
+	if (vfbFormatChanged) {
+		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED);
+		if (vfb->drawnFormat != vfb->format) {
+			ReformatFramebufferFrom(vfb, vfb->drawnFormat);
+		}
+	}
+
+	// ugly...
+	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
+		shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
+	}
 }
 
 void FramebufferManager::SetLineWidth() {
@@ -1316,10 +1109,6 @@ void FramebufferManager::CopyDisplayToOutput() {
 
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
-}
-
-inline bool FramebufferManager::ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const {
-	return updateVRAM_ || (hackForce04154000Download_ && vfb->fb_address == 0x00154000);
 }
 
 inline bool FramebufferManager::ShouldDownloadUsingCPU(const VirtualFramebuffer *vfb) const {
@@ -1921,13 +1710,6 @@ void FramebufferManager::DeviceLost() {
 	resized_ = false;
 }
 
-void FramebufferManager::BeginFrame() {
-	DecimateFBOs();
-	currentRenderVfb_ = 0;
-	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-	updateVRAM_ = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
-}
-
 std::vector<FramebufferInfo> FramebufferManager::GetFramebufferList() {
 	std::vector<FramebufferInfo> list;
 
@@ -2159,10 +1941,6 @@ bool FramebufferManager::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool 
 	} else {
 		return false;
 	}
-}
-
-u32 FramebufferManager::FramebufferByteSize(const VirtualFramebuffer *vfb) const {
-	return vfb->fb_stride * vfb->height * (vfb->format == GE_FORMAT_8888 ? 4 : 2);
 }
 
 void FramebufferManager::FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -102,10 +102,6 @@ enum {
 	FBO_OLD_AGE = 5,
 };
 
-bool FramebufferManager::MaskedEqual(u32 addr1, u32 addr2) {
-	return (addr1 & 0x03FFFFFF) == (addr2 & 0x03FFFFFF);
-}
-
 inline u16 RGBA8888toRGB565(u32 px) {
 	return ((px >> 3) & 0x001F) | ((px >> 5) & 0x07E0) | ((px >> 8) & 0xF800);
 }
@@ -638,26 +634,6 @@ void FramebufferManager::DrawActiveTexture(GLuint texture, float x, float y, flo
 	glDisableVertexAttribArray(program->a_texcoord0);
 
 	glsl_unbind();
-}
-
-
-VirtualFramebuffer *FramebufferManager::GetVFBAt(u32 addr) {
-	VirtualFramebuffer *match = NULL;
-	for (size_t i = 0; i < vfbs_.size(); ++i) {
-		VirtualFramebuffer *v = vfbs_[i];
-		if (MaskedEqual(v->fb_address, addr)) {
-			// Could check w too but whatever
-			if (match == NULL || match->last_frame_render < v->last_frame_render) {
-				match = v;
-			}
-		}
-	}
-	if (match != NULL) {
-		return match;
-	}
-
-	DEBUG_LOG(SCEGE, "Finding no FBO matching address %08x", addr);
-	return 0;
 }
 
 void FramebufferManager::DestroyFramebuf(VirtualFramebuffer *v) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -97,11 +97,6 @@ static const char color_vs[] =
 	"  gl_Position = a_position;\n"
 	"}\n";
 
-// Aggressively delete unused FBO:s to save gpu memory.
-enum {
-	FBO_OLD_AGE = 5,
-};
-
 inline u16 RGBA8888toRGB565(u32 px) {
 	return ((px >> 3) & 0x001F) | ((px >> 5) & 0x07E0) | ((px >> 8) & 0xF800);
 }

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -83,15 +83,12 @@ public:
 	void DrawPlainColor(u32 color);
 
 	void DestroyAllFBOs();
-	void DecimateFBOs();
 
 	void Init();
-	void BeginFrame();
 	void EndFrame();
 	void Resized();
 	void DeviceLost();
 	void CopyDisplayToOutput();
-	virtual void DoSetRenderFrameBuffer() override;  // Uses parameters computed from gstate
 	void UpdateFromMemory(u32 addr, int size, bool safe);
 	void SetLineWidth();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old);
@@ -131,17 +128,21 @@ protected:
 	virtual void ClearBuffer() override;
 	virtual void ClearDepthBuffer() override;
 
+	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
+	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb) override;
+	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+
+	virtual void DecimateFBOs() override;
+
 private:
 	void CompileDraw2DProgram();
 	void DestroyDraw2DProgram();
 	void FlushBeforeCopy();
 
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const;
-	u32 FramebufferByteSize(const VirtualFramebuffer *vfb) const;
 
 	void SetNumExtraFBOs(int num);
 
-	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	inline bool ShouldDownloadUsingCPU(const VirtualFramebuffer *vfb) const;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
@@ -176,11 +177,7 @@ private:
 	std::vector<FBO *> extraFBOs_;
 
 	bool resized_;
-	bool useBufferedRendering_;
-	bool updateVRAM_;
 	bool gameUsesSequentialCopies_;
-
-	bool hackForce04154000Download_;
 
 	struct TempFBO {
 		FBO *fbo;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -110,12 +110,6 @@ public:
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h);
 
-	// TODO: Break out into some form of FBO manager
-	VirtualFramebuffer *GetVFBAt(u32 addr);
-	VirtualFramebuffer *GetDisplayVFB() {
-		return GetVFBAt(displayFramebufPtr_);
-	}
-
 	std::vector<FramebufferInfo> GetFramebufferList();
 
 	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset = false);
@@ -146,8 +140,6 @@ private:
 	u32 FramebufferByteSize(const VirtualFramebuffer *vfb) const;
 
 	void SetNumExtraFBOs(int num);
-
-	static bool MaskedEqual(u32 addr1, u32 addr2);
 
 	inline bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	inline bool ShouldDownloadUsingCPU(const VirtualFramebuffer *vfb) const;

--- a/Windows/D3D9Base.cpp
+++ b/Windows/D3D9Base.cpp
@@ -60,13 +60,12 @@ bool D3D9_Init(HWND hWnd, bool windowed, std::string *error_message) {
 	HMODULE hD3D9 = LoadLibrary(TEXT("d3d9.dll"));
 	g_pfnCreate9ex = (DIRECT3DCREATE9EX)GetProcAddress(hD3D9, "Direct3DCreate9Ex");
 	has9Ex = (g_pfnCreate9ex != NULL);
-	FreeLibrary(hD3D9);
 
 	// For some reason, can't quite get Ex to work right..
 	// has9Ex = false;
 
 	if (has9Ex) {
-		HRESULT result = Direct3DCreate9Ex(D3D_SDK_VERSION, &d3dEx);
+		HRESULT result = g_pfnCreate9ex(D3D_SDK_VERSION, &d3dEx);
 		d3d = d3dEx;
 		if (FAILED(result)) {
 			ELOG("Failed to create D3D9Ex context");
@@ -79,6 +78,7 @@ bool D3D9_Init(HWND hWnd, bool windowed, std::string *error_message) {
 			return false;
 		}
 	}
+	FreeLibrary(hD3D9);
 
 	D3DCAPS9 d3dCaps;
 


### PR DESCRIPTION
This centralizes all the sizing, creation, offsetting, etc. logic - not all of which is supported by Direct3D yet.

-[Unknown]
