### PR TITLE
D3D shader cleanup - remove LinkedShaders and use fixed constant slots

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1413,7 +1413,7 @@ void DIRECTX9_GPU::ExecuteOpInternal(u32 op, u32 diff) {
 void DIRECTX9_GPU::UpdateStats() {
 	gpuStats.numVertexShaders = shaderManager_->NumVertexShaders();
 	gpuStats.numFragmentShaders = shaderManager_->NumFragmentShaders();
-	gpuStats.numShaders = shaderManager_->NumPrograms();
+	gpuStats.numShaders = -1;
 	gpuStats.numTextures = (int)textureCache_.NumLoadedTextures();
 	gpuStats.numFBOs = (int)framebufferManager_.NumVFBs();
 }

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -493,9 +493,6 @@ void DIRECTX9_GPU::BeginFrameInternal() {
 	}
 	shaderManager_->DirtyShader();
 
-	// Not sure if this is really needed.
-	shaderManager_->DirtyUniform(DIRTY_ALL);
-
 	framebufferManager_.BeginFrame();
 }
 

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -237,23 +237,23 @@ void GenerateFragmentShaderDX9(char *buffer) {
 		WRITE(p, "float3 roundAndScaleTo255v(float3 x) { return floor(x * 255.0f + 0.5f); }\n");
 	}
 
-	WRITE(p, " struct PS_IN {\n");
+	WRITE(p, "struct PS_IN {\n");
 	if (doTexture) {
 		if (doTextureProjection)
-			WRITE(p, "		float3 v_texcoord: TEXCOORD0;\n");
+			WRITE(p, "  float3 v_texcoord: TEXCOORD0;\n");
 		else
-			WRITE(p, "		float2 v_texcoord: TEXCOORD0;\n");
+			WRITE(p, "  float2 v_texcoord: TEXCOORD0;\n");
 	}
-	WRITE(p, "		float4 v_color0: COLOR0;\n");
+	WRITE(p, "  float4 v_color0: COLOR0;\n");
 	if (lmode) {
-		WRITE(p, "		float3 v_color1: COLOR1;\n");
+		WRITE(p, "  float3 v_color1: COLOR1;\n");
 	}
 	if (enableFog) {
-		WRITE(p, "float2 v_fogdepth: TEXCOORD1;\n");
+		WRITE(p, "  float2 v_fogdepth: TEXCOORD1;\n");
 	}
-	WRITE(p, " };\n\n");
-	WRITE(p, " float4 main( PS_IN In ) : COLOR\n");
-	WRITE(p, " {\n");
+	WRITE(p, "};\n");
+	WRITE(p, "float4 main( PS_IN In ) : COLOR\n");
+	WRITE(p, "{\n");
 
 	if (gstate.isModeClear()) {
 		// Clear mode does not allow any fancy shading.

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -219,15 +219,16 @@ void GenerateFragmentShaderDX9(char *buffer) {
 		WRITE(p, "sampler tex: register(s0);\n");
 
 	if (enableAlphaTest || enableColorTest) {
-		WRITE(p, "float4 u_alphacolorref;\n");
-		WRITE(p, "float4 u_alphacolormask;\n");
+		WRITE(p, "float4 u_alphacolorref : register(c%i);\n", CONST_PS_ALPHACOLORREF);
+		WRITE(p, "float4 u_alphacolormask : register(c%i);\n", CONST_PS_ALPHACOLORMASK);
 	}
-	if (gstate.isTextureMapEnabled() && gstate.getTextureFunction() == GE_TEXFUNC_BLEND) 
-		WRITE(p, "float3 u_texenv;\n");
+
+	if (gstate.isTextureMapEnabled() && gstate.getTextureFunction() == GE_TEXFUNC_BLEND) {
+		WRITE(p, "float3 u_texenv : register(c%i);\n", CONST_PS_TEXENV);
+	}
 	if (enableFog) {
-		WRITE(p, "float3 u_fogcolor;\n");
+		WRITE(p, "float3 u_fogcolor : register(c%i);\n", CONST_PS_FOGCOLOR);
 	}
-	
 
 	if (enableAlphaTest) {
 		WRITE(p, "float roundAndScaleTo255f(float x) { return floor(x * 255.0f + 0.5f); }\n");
@@ -236,26 +237,23 @@ void GenerateFragmentShaderDX9(char *buffer) {
 		WRITE(p, "float3 roundAndScaleTo255v(float3 x) { return floor(x * 255.0f + 0.5f); }\n");
 	}
 
-	WRITE(p, " struct PS_IN                               \n");
-	WRITE(p, " {                                          \n");
-	if (doTexture)
-	{
+	WRITE(p, " struct PS_IN {\n");
+	if (doTexture) {
 		if (doTextureProjection)
-			WRITE(p, "		float3 v_texcoord: TEXCOORD0;         \n");
+			WRITE(p, "		float3 v_texcoord: TEXCOORD0;\n");
 		else
-			WRITE(p, "		float2 v_texcoord: TEXCOORD0;         \n");
+			WRITE(p, "		float2 v_texcoord: TEXCOORD0;\n");
 	}
-	WRITE(p, "		float4 v_color0: COLOR0;              \n"); 
+	WRITE(p, "		float4 v_color0: COLOR0;\n");
 	if (lmode) {
-		WRITE(p, "		float3 v_color1: COLOR1;              \n");    
+		WRITE(p, "		float3 v_color1: COLOR1;\n");
 	}
 	if (enableFog) {
 		WRITE(p, "float2 v_fogdepth: TEXCOORD1;\n");
 	}
-	WRITE(p, " };                                         \n"); 
-	WRITE(p, "                                            \n");
-	WRITE(p, " float4 main( PS_IN In ) : COLOR            \n");
-	WRITE(p, " {									      \n");
+	WRITE(p, " };\n\n");
+	WRITE(p, " float4 main( PS_IN In ) : COLOR\n");
+	WRITE(p, " {\n");
 
 	if (gstate.isModeClear()) {
 		// Clear mode does not allow any fancy shading.

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -53,4 +53,9 @@ bool IsAlphaTestAgainstZero();
 bool IsAlphaTestTriviallyTrue();
 bool IsColorTestTriviallyTrue();
 
+#define CONST_PS_TEXENV 0
+#define CONST_PS_ALPHACOLORREF 1
+#define CONST_PS_ALPHACOLORMASK 2
+#define CONST_PS_FOGCOLOR 3
+
 };

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -209,7 +209,7 @@ LinkedShaderDX9::~LinkedShaderDX9() {
 //	glDeleteProgram(program);
 }
 
-void PSShader::SetColorUniform3(int creg, u32 color) {
+void PSShader::PSSetColorUniform3(int creg, u32 color) {
 	const float col[4] = {
 		((color & 0xFF)) / 255.0f,
 		((color & 0xFF00) >> 8) / 255.0f,
@@ -219,7 +219,7 @@ void PSShader::SetColorUniform3(int creg, u32 color) {
 	pD3Ddevice->SetPixelShaderConstantF(creg, col, 1);
 }
 
-void PSShader::SetColorUniform3Alpha255(int creg, u32 color, u8 alpha) {
+void PSShader::PSSetColorUniform3Alpha255(int creg, u32 color, u8 alpha) {
 	const float col[4] = {
 		(float)((color & 0xFF)),
 		(float)((color & 0xFF00) >> 8),
@@ -229,12 +229,12 @@ void PSShader::SetColorUniform3Alpha255(int creg, u32 color, u8 alpha) {
 	pD3Ddevice->SetPixelShaderConstantF(creg, col, 1);
 }
 
-void VSShader::SetFloat(int creg, float value) {
+void VSShader::VSSetFloat(int creg, float value) {
 	const float f[4] = { value, 0.0f, 0.0f, 0.0f };
 	pD3Ddevice->SetVertexShaderConstantF(creg, f, 1);
 }
 
-void VSShader::SetFloatArray(int creg, const float *value, int count) {
+void VSShader::VSSetFloatArray(int creg, const float *value, int count) {
 	float f[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	for (int i = 0; i < count; i++) {
 		f[i] = value[i];
@@ -243,7 +243,7 @@ void VSShader::SetFloatArray(int creg, const float *value, int count) {
 }
 
 // Utility
-void VSShader::SetColorUniform3(int creg, u32 color) {
+void VSShader::VSSetColorUniform3(int creg, u32 color) {
 	const float col[4] = {
 		((color & 0xFF)) / 255.0f,
 		((color & 0xFF00) >> 8) / 255.0f,
@@ -253,14 +253,14 @@ void VSShader::SetColorUniform3(int creg, u32 color) {
 	pD3Ddevice->SetVertexShaderConstantF(creg, col, 1);
 }
 
-void VSShader::SetFloat24Uniform3(int creg, const u32 data[3]) {
+void VSShader::VSSetFloat24Uniform3(int creg, const u32 data[3]) {
 	const u32 col[4] = {
 		data[0] >> 8, data[1] >> 8, data[2] >> 8, 0
 	};
 	pD3Ddevice->SetVertexShaderConstantF(creg, (const float *)&col[0], 1);
 }
 
-void VSShader::SetColorUniform3Alpha(int creg, u32 color, u8 alpha) {
+void VSShader::VSSetColorUniform3Alpha(int creg, u32 color, u8 alpha) {
 	const float col[4] = {
 		((color & 0xFF)) / 255.0f,
 		((color & 0xFF00) >> 8) / 255.0f,
@@ -270,7 +270,7 @@ void VSShader::SetColorUniform3Alpha(int creg, u32 color, u8 alpha) {
 	pD3Ddevice->SetVertexShaderConstantF(creg, col, 1);
 }
 
-void VSShader::SetColorUniform3ExtraFloat(int creg, u32 color, float extra) {
+void VSShader::VSSetColorUniform3ExtraFloat(int creg, u32 color, float extra) {
 	const float col[4] = {
 		((color & 0xFF)) / 255.0f,
 		((color & 0xFF00) >> 8) / 255.0f,
@@ -281,13 +281,13 @@ void VSShader::SetColorUniform3ExtraFloat(int creg, u32 color, float extra) {
 }
 
 // Utility
-void VSShader::SetMatrix4x3(int creg, const float *m4x3) {
+void VSShader::VSSetMatrix4x3(int creg, const float *m4x3) {
 	float m4x4[16];
 	ConvertMatrix4x3To4x4Transposed(m4x4, m4x3);
 	pD3Ddevice->SetVertexShaderConstantF(creg, m4x4, 4);
 }
 
-void VSShader::SetMatrix(int creg, const float* pMatrix) {
+void VSShader::VSSetMatrix(int creg, const float* pMatrix) {
 	float transp[16];
 	Transpose4x4(transp, pMatrix);
 	pD3Ddevice->SetVertexShaderConstantF(creg, transp, 4);
@@ -304,8 +304,8 @@ void ConvertProjMatrixToD3D(Matrix4x4 & in, bool invert) {
 
 void LinkedShaderDX9::updateUniforms() {
 	if (dirtyUniforms) {
-		m_fs->updateUniforms(dirtyUniforms);
-		m_vs->updateUniforms(dirtyUniforms);
+		m_fs->PSUpdateUniforms(dirtyUniforms);
+		m_vs->VSUpdateUniforms(dirtyUniforms);
 		dirtyUniforms = 0;
 	}
 }
@@ -317,22 +317,22 @@ void LinkedShaderDX9::use() {
 	pD3Ddevice->SetVertexShader(m_vs->shader);
 }
 
-void PSShader::updateUniforms(int dirtyUniforms) {
+void PSShader::PSUpdateUniforms(int dirtyUniforms) {
 	if (u_texenv != 0 && (dirtyUniforms & DIRTY_TEXENV)) {
-		SetColorUniform3(CONST_PS_TEXENV, gstate.texenvcolor);
+		PSSetColorUniform3(CONST_PS_TEXENV, gstate.texenvcolor);
 	}
 	if (u_alphacolorref != 0 && (dirtyUniforms & DIRTY_ALPHACOLORREF)) {
-		SetColorUniform3Alpha255(CONST_PS_ALPHACOLORREF, gstate.getColorTestRef(), gstate.getAlphaTestRef());
+		PSSetColorUniform3Alpha255(CONST_PS_ALPHACOLORREF, gstate.getColorTestRef(), gstate.getAlphaTestRef());
 	}
 	if (u_alphacolormask != 0 && (dirtyUniforms & DIRTY_ALPHACOLORMASK)) {
-		SetColorUniform3(CONST_PS_ALPHACOLORMASK, gstate.colortestmask);
+		PSSetColorUniform3(CONST_PS_ALPHACOLORMASK, gstate.colortestmask);
 	}
 	if (u_fogcolor != 0 && (dirtyUniforms & DIRTY_FOGCOLOR)) {
-		SetColorUniform3(CONST_PS_FOGCOLOR, gstate.fogcolor);
+		PSSetColorUniform3(CONST_PS_FOGCOLOR, gstate.fogcolor);
 	}
 }
 
-void VSShader::updateUniforms(int dirtyUniforms) {
+void VSShader::VSUpdateUniforms(int dirtyUniforms) {
 	// Update any dirty uniforms before we draw
 	if (u_proj != 0 && (dirtyUniforms & DIRTY_PROJMATRIX)) {
 		Matrix4x4 flippedMatrix;
@@ -349,7 +349,7 @@ void VSShader::updateUniforms(int dirtyUniforms) {
 		bool invert = gstate_c.vpDepth < 0;
 		ConvertProjMatrixToD3D(flippedMatrix, invert);
 
-		SetMatrix(CONST_VS_PROJ, flippedMatrix.getReadPtr());
+		VSSetMatrix(CONST_VS_PROJ, flippedMatrix.getReadPtr());
 	}
 	if (u_proj_through != 0 && (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX)) {
 		Matrix4x4 proj_through;
@@ -357,24 +357,24 @@ void VSShader::updateUniforms(int dirtyUniforms) {
 
 		ConvertProjMatrixToD3D(proj_through, false);
 
-		SetMatrix(CONST_VS_PROJ_THROUGH, proj_through.getReadPtr());
+		VSSetMatrix(CONST_VS_PROJ_THROUGH, proj_through.getReadPtr());
 	}
 	// Transform
 	if (u_world != 0 && (dirtyUniforms & DIRTY_WORLDMATRIX)) {
-		SetMatrix4x3(CONST_VS_WORLD, gstate.worldMatrix);
+		VSSetMatrix4x3(CONST_VS_WORLD, gstate.worldMatrix);
 	}
 	if (u_view != 0 && (dirtyUniforms & DIRTY_VIEWMATRIX)) {
-		SetMatrix4x3(CONST_VS_VIEW, gstate.viewMatrix);
+		VSSetMatrix4x3(CONST_VS_VIEW, gstate.viewMatrix);
 	}
 	if (u_texmtx != 0 && (dirtyUniforms & DIRTY_TEXMATRIX)) {
-		SetMatrix4x3(CONST_VS_TEXMTX, gstate.tgenMatrix);
+		VSSetMatrix4x3(CONST_VS_TEXMTX, gstate.tgenMatrix);
 	}
 	if (u_fogcoef != 0 && (dirtyUniforms & DIRTY_FOGCOEF)) {
 		const float fogcoef[2] = {
 			getFloat24(gstate.fog1),
 			getFloat24(gstate.fog2),
 		};
-		SetFloatArray(CONST_VS_FOGCOEF, fogcoef, 2);
+		VSSetFloatArray(CONST_VS_FOGCOEF, fogcoef, 2);
 	}
 	// TODO: Could even set all bones in one go if they're all dirty.
 #ifdef USE_BONE_ARRAY
@@ -407,7 +407,7 @@ void VSShader::updateUniforms(int dirtyUniforms) {
 		if (dirtyUniforms & (DIRTY_BONEMATRIX0 << i)) {
 			ConvertMatrix4x3To4x4(bonetemp, gstate.boneMatrix + 12 * i);
 			if (u_bone[i] != 0)
-				SetMatrix(CONST_VS_BONE0 + 4 * i, bonetemp);
+				VSSetMatrix(CONST_VS_BONE0 + 4 * i, bonetemp);
 		}
 	}
 #endif
@@ -440,24 +440,24 @@ void VSShader::updateUniforms(int dirtyUniforms) {
 				uvscaleoff[3] = 0.0f;
 			}
 		}
-		SetFloatArray(CONST_VS_UVSCALEOFFSET, uvscaleoff, 4);
+		VSSetFloatArray(CONST_VS_UVSCALEOFFSET, uvscaleoff, 4);
 	}
 
 	// Lighting
 	if (u_ambient != 0 && (dirtyUniforms & DIRTY_AMBIENT)) {
-		SetColorUniform3Alpha(CONST_VS_AMBIENT, gstate.ambientcolor, gstate.getAmbientA());
+		VSSetColorUniform3Alpha(CONST_VS_AMBIENT, gstate.ambientcolor, gstate.getAmbientA());
 	}
 	if (u_matambientalpha != 0 && (dirtyUniforms & DIRTY_MATAMBIENTALPHA)) {
-		SetColorUniform3Alpha(CONST_VS_MATAMBIENTALPHA, gstate.materialambient, gstate.getMaterialAmbientA());
+		VSSetColorUniform3Alpha(CONST_VS_MATAMBIENTALPHA, gstate.materialambient, gstate.getMaterialAmbientA());
 	}
 	if (u_matdiffuse != 0 && (dirtyUniforms & DIRTY_MATDIFFUSE)) {
-		SetColorUniform3(CONST_VS_MATDIFFUSE, gstate.materialdiffuse);
+		VSSetColorUniform3(CONST_VS_MATDIFFUSE, gstate.materialdiffuse);
 	}
 	if (u_matemissive != 0 && (dirtyUniforms & DIRTY_MATEMISSIVE)) {
-		SetColorUniform3(CONST_VS_MATEMISSIVE, gstate.materialemissive);
+		VSSetColorUniform3(CONST_VS_MATEMISSIVE, gstate.materialemissive);
 	}
 	if (u_matspecular != 0 && (dirtyUniforms & DIRTY_MATSPECULAR)) {
-		SetColorUniform3ExtraFloat(CONST_VS_MATSPECULAR, gstate.materialspecular, getFloat24(gstate.materialspecularcoef));
+		VSSetColorUniform3ExtraFloat(CONST_VS_MATSPECULAR, gstate.materialspecular, getFloat24(gstate.materialspecularcoef));
 	}
 	for (int i = 0; i < 4; i++) {
 		if (dirtyUniforms & (DIRTY_LIGHT0 << i)) {
@@ -473,18 +473,18 @@ void VSShader::updateUniforms(int dirtyUniforms) {
 					else
 						len = 1.0f / len;
 					float vec[3] = { x * len, y * len, z * len };
-					SetFloatArray(CONST_VS_LIGHTPOS + i, vec, 3);
+					VSSetFloatArray(CONST_VS_LIGHTPOS + i, vec, 3);
 				} else {
-					SetFloat24Uniform3(CONST_VS_LIGHTPOS + i, &gstate.lpos[i * 3]);
+					VSSetFloat24Uniform3(CONST_VS_LIGHTPOS + i, &gstate.lpos[i * 3]);
 				}
 			}
-			if (u_lightdir[i] != 0) SetFloat24Uniform3(CONST_VS_LIGHTDIR + i, &gstate.ldir[i * 3]);
-			if (u_lightatt[i] != 0) SetFloat24Uniform3(CONST_VS_LIGHTATT + i, &gstate.latt[i * 3]);
-			if (u_lightangle[i] != 0) SetFloat(CONST_VS_LIGHTANGLE + i, getFloat24(gstate.lcutoff[i]));
-			if (u_lightspotCoef[i] != 0) SetFloat(CONST_VS_LIGHTSPOTCOEF + i, getFloat24(gstate.lconv[i]));
-			if (u_lightambient[i] != 0) SetColorUniform3(CONST_VS_LIGHTAMBIENT + i, gstate.lcolor[i * 3]);
-			if (u_lightdiffuse[i] != 0) SetColorUniform3(CONST_VS_LIGHTDIFFUSE + i, gstate.lcolor[i * 3 + 1]);
-			if (u_lightspecular[i] != 0) SetColorUniform3(CONST_VS_LIGHTSPECULAR + i, gstate.lcolor[i * 3 + 2]);
+			if (u_lightdir[i] != 0) VSSetFloat24Uniform3(CONST_VS_LIGHTDIR + i, &gstate.ldir[i * 3]);
+			if (u_lightatt[i] != 0) VSSetFloat24Uniform3(CONST_VS_LIGHTATT + i, &gstate.latt[i * 3]);
+			if (u_lightangle[i] != 0) VSSetFloat(CONST_VS_LIGHTANGLE + i, getFloat24(gstate.lcutoff[i]));
+			if (u_lightspotCoef[i] != 0) VSSetFloat(CONST_VS_LIGHTSPOTCOEF + i, getFloat24(gstate.lconv[i]));
+			if (u_lightambient[i] != 0) VSSetColorUniform3(CONST_VS_LIGHTAMBIENT + i, gstate.lcolor[i * 3]);
+			if (u_lightdiffuse[i] != 0) VSSetColorUniform3(CONST_VS_LIGHTDIFFUSE + i, gstate.lcolor[i * 3 + 1]);
+			if (u_lightspecular[i] != 0) VSSetColorUniform3(CONST_VS_LIGHTSPECULAR + i, gstate.lcolor[i * 3 + 2]);
 		}
 	}
 }

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -120,10 +120,10 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
-	void updateUniforms(int dirtyUniforms);
+	void PSUpdateUniforms(int dirtyUniforms);
 
-	void SetColorUniform3Alpha255(int creg, u32 color, u8 alpha);
-	void SetColorUniform3(int creg, u32 color);
+	void PSSetColorUniform3Alpha255(int creg, u32 color, u8 alpha);
+	void PSSetColorUniform3(int creg, u32 color);
 
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
@@ -152,16 +152,16 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
-	void updateUniforms(int dirtyUniforms);
+	void VSUpdateUniforms(int dirtyUniforms);
 
-	void SetMatrix4x3(int creg, const float *m4x3);
-	void SetColorUniform3(int creg, u32 color);
-	void SetColorUniform3ExtraFloat(int creg, u32 color, float extra);
-	void SetColorUniform3Alpha(int creg, u32 color, u8 alpha);
-	void SetMatrix(int creg, const float* pMatrix);
-	void SetFloat(int creg, float value);
-	void SetFloatArray(int creg, const float *value, int count);
-	void SetFloat24Uniform3(int creg, const u32 data[3]);
+	void VSSetMatrix4x3(int creg, const float *m4x3);
+	void VSSetColorUniform3(int creg, u32 color);
+	void VSSetColorUniform3ExtraFloat(int creg, u32 color, float extra);
+	void VSSetColorUniform3Alpha(int creg, u32 color, u8 alpha);
+	void VSSetMatrix(int creg, const float* pMatrix);
+	void VSSetFloat(int creg, float value);
+	void VSSetFloatArray(int creg, const float *value, int count);
+	void VSSetFloat24Uniform3(int creg, const u32 data[3]);
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
 	LPDIRECT3DVERTEXSHADER9 shader;

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -44,13 +44,11 @@ enum {
 	ATTR_COUNT,
 };
 
-class LinkedShaderDX9
-{
+class LinkedShaderDX9 {
 public:
 	LinkedShaderDX9(VSShader *vs, PSShader *fs, u32 vertType, bool useHWTransform);
 	~LinkedShaderDX9();
 
-	void updateUniforms();
 	void use();
 
 	// Set to false if the VS failed, happens on Mali-400 a lot for complex shaders.
@@ -58,8 +56,6 @@ public:
 
 	VSShader *m_vs;
 	PSShader *m_fs;
-
-	u32 dirtyUniforms;
 };
 
 // Will reach 32 bits soon :P
@@ -120,11 +116,6 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
-	void PSUpdateUniforms(int dirtyUniforms);
-
-	void PSSetColorUniform3Alpha255(int creg, u32 color, u8 alpha);
-	void PSSetColorUniform3(int creg, u32 color);
-
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
 	LPDIRECT3DPIXELSHADER9 shader;
@@ -134,12 +125,6 @@ protected:
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
-
-	// Fragment processing inputs
-	D3DXHANDLE u_texenv;
-	D3DXHANDLE u_alphacolorref;
-	D3DXHANDLE u_alphacolormask;
-	D3DXHANDLE u_fogcolor;
 };
 
 class VSShader {
@@ -152,57 +137,15 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
-	void VSUpdateUniforms(int dirtyUniforms);
-
-	void VSSetMatrix4x3(int creg, const float *m4x3);
-	void VSSetColorUniform3(int creg, u32 color);
-	void VSSetColorUniform3ExtraFloat(int creg, u32 color, float extra);
-	void VSSetColorUniform3Alpha(int creg, u32 color, u8 alpha);
-	void VSSetMatrix(int creg, const float* pMatrix);
-	void VSSetFloat(int creg, float value);
-	void VSSetFloatArray(int creg, const float *value, int count);
-	void VSSetFloat24Uniform3(int creg, const u32 data[3]);
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
 	LPDIRECT3DVERTEXSHADER9 shader;
 	LPD3DXCONSTANTTABLE constant;
+
 protected:	
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
-
-	// Transform
-	D3DXHANDLE u_view;
-	D3DXHANDLE u_texmtx;
-	D3DXHANDLE u_world;
-	D3DXHANDLE u_proj;
-	D3DXHANDLE u_proj_through;
-#ifdef USE_BONE_ARRAY
-	D3DXHANDLE u_bone;  // array, size is numBones
-#else
-	D3DXHANDLE u_bone[8];
-#endif
-	int numBones;
-
-	D3DXHANDLE u_fogcoef;
-
-	// Texturing
-	D3DXHANDLE u_uvscaleoffset;
-
-	// Lighting
-	D3DXHANDLE u_ambient;
-	D3DXHANDLE u_matambientalpha;
-	D3DXHANDLE u_matdiffuse;
-	D3DXHANDLE u_matspecular;
-	D3DXHANDLE u_matemissive;
-	D3DXHANDLE u_lightpos[4];
-	D3DXHANDLE u_lightdir[4];
-	D3DXHANDLE u_lightatt[4];  // attenuation
-	D3DXHANDLE u_lightangle[4]; // spotlight cone angle (cosine)
-	D3DXHANDLE u_lightspotCoef[4]; // spotlight dropoff
-	D3DXHANDLE u_lightdiffuse[4];  // each light consist of vec4[3]
-	D3DXHANDLE u_lightspecular[4];  // attenuation
-	D3DXHANDLE u_lightambient[4];  // attenuation
 };
 
 class ShaderManagerDX9
@@ -224,6 +167,20 @@ public:
 	int NumPrograms() const { return (int)linkedShaderCache_.size(); }
 
 private:
+	void PSUpdateUniforms(int dirtyUniforms);
+	void VSUpdateUniforms(int dirtyUniforms);
+	void PSSetColorUniform3Alpha255(int creg, u32 color, u8 alpha);
+	void PSSetColorUniform3(int creg, u32 color);
+
+	void VSSetMatrix4x3(int creg, const float *m4x3);
+	void VSSetColorUniform3(int creg, u32 color);
+	void VSSetColorUniform3ExtraFloat(int creg, u32 color, float extra);
+	void VSSetColorUniform3Alpha(int creg, u32 color, u8 alpha);
+	void VSSetMatrix(int creg, const float* pMatrix);
+	void VSSetFloat(int creg, float value);
+	void VSSetFloatArray(int creg, const float *value, int count);
+	void VSSetFloat24Uniform3(int creg, const u32 data[3]);
+
 	void Clear();
 
 	struct LinkedShaderCacheEntry {
@@ -243,7 +200,6 @@ private:
 
 	LinkedShaderDX9 *lastShader_;
 	u32 globalDirty_;
-	u32 shaderSwitchDirty_;
 	char *codeBuffer_;
 
 	typedef std::map<FragmentShaderIDDX9, PSShader *> FSCache;
@@ -251,7 +207,6 @@ private:
 
 	typedef std::map<VertexShaderIDDX9, VSShader *> VSCache;
 	VSCache vsCache_;
-
 };
 
 };

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -60,18 +60,6 @@ public:
 	PSShader *m_fs;
 
 	u32 dirtyUniforms;
-
-	// Present attributes in the shader.
-	int attrMask;  // 1 << ATTR_ ... or-ed together.
-
-	// Pre-fetched attrs and uniforms
-	D3DXHANDLE a_position;
-	D3DXHANDLE a_color0;
-	D3DXHANDLE a_color1;
-	D3DXHANDLE a_texcoord;
-	D3DXHANDLE a_normal;
-	D3DXHANDLE a_weight0123;
-	D3DXHANDLE a_weight4567;
 };
 
 // Will reach 32 bits soon :P
@@ -79,12 +67,12 @@ enum
 {
 	DIRTY_PROJMATRIX = (1 << 0),
 	DIRTY_PROJTHROUGHMATRIX = (1 << 1),
-	DIRTY_FOGCOLOR	 = (1 << 2),
-	DIRTY_FOGCOEF    = (1 << 3),
-	DIRTY_TEXENV		 = (1 << 4),
-	DIRTY_ALPHACOLORREF	 = (1 << 5),
-	DIRTY_COLORREF	 = (1 << 6),
-	DIRTY_ALPHACOLORMASK	 = (1 << 7),
+	DIRTY_FOGCOLOR = (1 << 2),
+	DIRTY_FOGCOEF = (1 << 3),
+	DIRTY_TEXENV = (1 << 4),
+	DIRTY_ALPHACOLORREF = (1 << 5),
+	DIRTY_COLORREF = (1 << 6),
+	DIRTY_ALPHACOLORMASK = (1 << 7),
 	DIRTY_LIGHT0 = (1 << 8),
 	DIRTY_LIGHT1 = (1 << 9),
 	DIRTY_LIGHT2 = (1 << 10),
@@ -110,6 +98,13 @@ enum
 	DIRTY_BONEMATRIX6 = (1 << 30),
 	DIRTY_BONEMATRIX7 = (1 << 31),
 
+	DIRTY_VSHADER_UNIFORMS = DIRTY_PROJMATRIX | DIRTY_PROJTHROUGHMATRIX | DIRTY_FOGCOEF | DIRTY_LIGHT0 | DIRTY_LIGHT1 | DIRTY_LIGHT2 | DIRTY_LIGHT3 |
+	DIRTY_MATDIFFUSE | DIRTY_MATSPECULAR | DIRTY_MATEMISSIVE | DIRTY_AMBIENT | DIRTY_MATAMBIENTALPHA | DIRTY_MATERIAL | DIRTY_UVSCALEOFFSET |
+	DIRTY_WORLDMATRIX | DIRTY_VIEWMATRIX | DIRTY_TEXMATRIX |
+	DIRTY_BONEMATRIX0 | DIRTY_BONEMATRIX1 | DIRTY_BONEMATRIX2 | DIRTY_BONEMATRIX3 | DIRTY_BONEMATRIX4 | DIRTY_BONEMATRIX5 | DIRTY_BONEMATRIX6 | DIRTY_BONEMATRIX7,
+
+	DIRTY_PSHADER_UNIFORMS = DIRTY_FOGCOLOR | DIRTY_TEXENV | DIRTY_ALPHACOLORREF | DIRTY_ALPHACOLORMASK,
+
 	DIRTY_ALL = 0xFFFFFFFF
 };
 
@@ -127,23 +122,21 @@ public:
 	
 	void updateUniforms(int dirtyUniforms);
 
-	void SetFloatArray(D3DXHANDLE uniform, const float* pArray, int len);
-	void SetColorUniform3Alpha255(D3DXHANDLE uniform, u32 color, u8 alpha);
-	void SetColorUniform3(D3DXHANDLE uniform, u32 color);
+	void SetColorUniform3Alpha255(int creg, u32 color, u8 alpha);
+	void SetColorUniform3(int creg, u32 color);
 
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
 	LPDIRECT3DPIXELSHADER9 shader;
 	LPD3DXCONSTANTTABLE constant;
+
 protected:	
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
 
-	D3DXHANDLE u_tex;
-	D3DXHANDLE u_texenv;
-
 	// Fragment processing inputs
+	D3DXHANDLE u_texenv;
 	D3DXHANDLE u_alphacolorref;
 	D3DXHANDLE u_alphacolormask;
 	D3DXHANDLE u_fogcolor;

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -120,7 +120,7 @@ public:
 	void DirtyUniform(u32 what) {
 		globalDirty_ |= what;
 	}
-	void DirtyLastShader();  // disables vertex arrays
+	void DirtyLastShader();
 
 	int NumVertexShaders() const { return (int)vsCache_.size(); }
 	int NumFragmentShaders() const { return (int)fsCache_.size(); }

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -154,14 +154,14 @@ public:
 	
 	void updateUniforms(int dirtyUniforms);
 
-	void SetMatrix4x3(D3DXHANDLE uniform, const float *m4x3);
-	void SetColorUniform3(D3DXHANDLE uniform, u32 color);
-	void SetColorUniform3ExtraFloat(D3DXHANDLE uniform, u32 color, float extra);
-	void SetColorUniform3Alpha(D3DXHANDLE uniform, u32 color, u8 alpha);
-	void SetMatrix(D3DXHANDLE uniform, const float* pMatrix);
-	void SetFloatArray(D3DXHANDLE uniform, const float* pArray, int len);
-	void SetFloat(D3DXHANDLE uniform, float value);
-	void SetFloat24Uniform3(D3DXHANDLE uniform, const u32 data[3]);
+	void SetMatrix4x3(int creg, const float *m4x3);
+	void SetColorUniform3(int creg, u32 color);
+	void SetColorUniform3ExtraFloat(int creg, u32 color, float extra);
+	void SetColorUniform3Alpha(int creg, u32 color, u8 alpha);
+	void SetMatrix(int creg, const float* pMatrix);
+	void SetFloat(int creg, float value);
+	void SetFloatArray(int creg, const float *value, int count);
+	void SetFloat24Uniform3(int creg, const u32 data[3]);
 	D3DXHANDLE GetConstantByName(LPCSTR pName);
 
 	LPDIRECT3DVERTEXSHADER9 shader;

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -46,26 +46,12 @@ enum {
 
 class LinkedShaderDX9
 {
-protected:		
-	// Helper
-	D3DXHANDLE GetConstantByName(LPCSTR pName);
-	void SetMatrix4x3(D3DXHANDLE uniform, const float *m4x3);
-	void SetColorUniform3(D3DXHANDLE uniform, u32 color);
-	void SetColorUniform3ExtraFloat(D3DXHANDLE uniform, u32 color, float extra);
-	void SetColorUniform3Alpha(D3DXHANDLE uniform, u32 color, u8 alpha);
-	void SetColorUniform3Alpha255(D3DXHANDLE uniform, u32 color, u8 alpha);
-	void SetMatrix(D3DXHANDLE uniform, const float* pMatrix);
-	void SetFloatArray(D3DXHANDLE uniform, const float* pArray, int len);
-	void SetFloat(D3DXHANDLE uniform, float value);
-	void SetFloat24Uniform3(D3DXHANDLE uniform, const u32 data[3]);
-
 public:
 	LinkedShaderDX9(VSShader *vs, PSShader *fs, u32 vertType, bool useHWTransform);
 	~LinkedShaderDX9();
 
-	void use();
-	void stop();
 	void updateUniforms();
+	void use();
 
 	// Set to false if the VS failed, happens on Mali-400 a lot for complex shaders.
 	bool useHWTransform_;
@@ -86,44 +72,6 @@ public:
 	D3DXHANDLE a_normal;
 	D3DXHANDLE a_weight0123;
 	D3DXHANDLE a_weight4567;
-
-	D3DXHANDLE u_tex;
-	D3DXHANDLE u_proj;
-	D3DXHANDLE u_proj_through;
-	D3DXHANDLE u_texenv;
-	D3DXHANDLE u_view;
-	D3DXHANDLE u_texmtx;
-	D3DXHANDLE u_world;
-#ifdef USE_BONE_ARRAY
-	D3DXHANDLE u_bone;  // array, size is numBones
-#else
-	D3DXHANDLE u_bone[8];
-#endif
-	int numBones;
-	
-	// Fragment processing inputs
-	D3DXHANDLE u_alphacolorref;
-	D3DXHANDLE u_alphacolormask;
-	D3DXHANDLE u_fogcolor;
-	D3DXHANDLE u_fogcoef;
-
-	// Texturing
-	D3DXHANDLE u_uvscaleoffset;
-
-	// Lighting
-	D3DXHANDLE u_ambient;
-	D3DXHANDLE u_matambientalpha;
-	D3DXHANDLE u_matdiffuse;
-	D3DXHANDLE u_matspecular;
-	D3DXHANDLE u_matemissive;
-	D3DXHANDLE u_lightpos[4];
-	D3DXHANDLE u_lightdir[4];
-	D3DXHANDLE u_lightatt[4];  // attenuation
-	D3DXHANDLE u_lightangle[4]; // spotlight cone angle (cosine)
-	D3DXHANDLE u_lightspotCoef[4]; // spotlight dropoff
-	D3DXHANDLE u_lightdiffuse[4];  // each light consist of vec4[3]
-	D3DXHANDLE u_lightspecular[4];  // attenuation
-	D3DXHANDLE u_lightambient[4];  // attenuation
 };
 
 // Will reach 32 bits soon :P
@@ -177,17 +125,33 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
+	void updateUniforms(int dirtyUniforms);
+
+	void SetFloatArray(D3DXHANDLE uniform, const float* pArray, int len);
+	void SetColorUniform3Alpha255(D3DXHANDLE uniform, u32 color, u8 alpha);
+	void SetColorUniform3(D3DXHANDLE uniform, u32 color);
+
+	D3DXHANDLE GetConstantByName(LPCSTR pName);
+
 	LPDIRECT3DPIXELSHADER9 shader;
 	LPD3DXCONSTANTTABLE constant;
 protected:	
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
+
+	D3DXHANDLE u_tex;
+	D3DXHANDLE u_texenv;
+
+	// Fragment processing inputs
+	D3DXHANDLE u_alphacolorref;
+	D3DXHANDLE u_alphacolormask;
+	D3DXHANDLE u_fogcolor;
 };
 
 class VSShader {
 public:
-	VSShader(const char *code, bool useHWTransform);
+	VSShader(const char *code, int vertType, bool useHWTransform);
 	~VSShader();
 
 	const std::string &source() const { return source_; }
@@ -195,12 +159,57 @@ public:
 	bool Failed() const { return failed_; }
 	bool UseHWTransform() const { return useHWTransform_; }
 	
+	void updateUniforms(int dirtyUniforms);
+
+	void SetMatrix4x3(D3DXHANDLE uniform, const float *m4x3);
+	void SetColorUniform3(D3DXHANDLE uniform, u32 color);
+	void SetColorUniform3ExtraFloat(D3DXHANDLE uniform, u32 color, float extra);
+	void SetColorUniform3Alpha(D3DXHANDLE uniform, u32 color, u8 alpha);
+	void SetMatrix(D3DXHANDLE uniform, const float* pMatrix);
+	void SetFloatArray(D3DXHANDLE uniform, const float* pArray, int len);
+	void SetFloat(D3DXHANDLE uniform, float value);
+	void SetFloat24Uniform3(D3DXHANDLE uniform, const u32 data[3]);
+	D3DXHANDLE GetConstantByName(LPCSTR pName);
+
 	LPDIRECT3DVERTEXSHADER9 shader;
 	LPD3DXCONSTANTTABLE constant;
 protected:	
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
+
+	// Transform
+	D3DXHANDLE u_view;
+	D3DXHANDLE u_texmtx;
+	D3DXHANDLE u_world;
+	D3DXHANDLE u_proj;
+	D3DXHANDLE u_proj_through;
+#ifdef USE_BONE_ARRAY
+	D3DXHANDLE u_bone;  // array, size is numBones
+#else
+	D3DXHANDLE u_bone[8];
+#endif
+	int numBones;
+
+	D3DXHANDLE u_fogcoef;
+
+	// Texturing
+	D3DXHANDLE u_uvscaleoffset;
+
+	// Lighting
+	D3DXHANDLE u_ambient;
+	D3DXHANDLE u_matambientalpha;
+	D3DXHANDLE u_matdiffuse;
+	D3DXHANDLE u_matspecular;
+	D3DXHANDLE u_matemissive;
+	D3DXHANDLE u_lightpos[4];
+	D3DXHANDLE u_lightdir[4];
+	D3DXHANDLE u_lightatt[4];  // attenuation
+	D3DXHANDLE u_lightangle[4]; // spotlight cone angle (cosine)
+	D3DXHANDLE u_lightspotCoef[4]; // spotlight dropoff
+	D3DXHANDLE u_lightdiffuse[4];  // each light consist of vec4[3]
+	D3DXHANDLE u_lightspecular[4];  // attenuation
+	D3DXHANDLE u_lightambient[4];  // attenuation
 };
 
 class ShaderManagerDX9

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -281,12 +281,12 @@ IDirect3DVertexDeclaration9 *TransformDrawEngineDX9::SetupDecFmtForDraw(VSShader
 		// Vertices Elements orders
 		// WEIGHT
 		if (decFmt.w0fmt != 0) {
-			VertexAttribSetup(VertexElement, decFmt.w0fmt, decFmt.w0off, D3DDECLUSAGE_BLENDWEIGHT, 0);
+			VertexAttribSetup(VertexElement, decFmt.w0fmt, decFmt.w0off, D3DDECLUSAGE_TEXCOORD, 1);
 			VertexElement++;
 		}
 
 		if (decFmt.w1fmt != 0) {
-			VertexAttribSetup(VertexElement, decFmt.w1fmt, decFmt.w1off, D3DDECLUSAGE_BLENDWEIGHT, 1);
+			VertexAttribSetup(VertexElement, decFmt.w1fmt, decFmt.w1off, D3DDECLUSAGE_TEXCOORD, 2);
 			VertexElement++;
 		}
 

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -271,7 +271,7 @@ static void LogDecFmtForDraw(const DecVtxFormat &decFmt) {
 	//pD3Ddevice->SetRenderState(D3DRS_FILLMODE, D3DFILL_WIREFRAME);
 }
 
-IDirect3DVertexDeclaration9 *TransformDrawEngineDX9::SetupDecFmtForDraw(LinkedShaderDX9 *program, const DecVtxFormat &decFmt, u32 pspFmt) {
+IDirect3DVertexDeclaration9 *TransformDrawEngineDX9::SetupDecFmtForDraw(VSShader *vshader, const DecVtxFormat &decFmt, u32 pspFmt) {
 	auto vertexDeclCached = vertexDeclMap_.find(pspFmt);
 
 	if (vertexDeclCached == vertexDeclMap_.end()) {
@@ -437,7 +437,7 @@ bool TransformDrawEngineDX9::IsReallyAClear(int numVerts) const {
 // Actually again, single quads could be drawn more efficiently using GL_TRIANGLE_STRIP, no need to duplicate verts as for
 // GL_TRIANGLES. Still need to sw transform to compute the extra two corners though.
 void TransformDrawEngineDX9::SoftwareTransformAndDraw(
-	int prim, u8 *decoded, LinkedShaderDX9 *program, int vertexCount, u32 vertType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex) {
+	int prim, u8 *decoded, int vertexCount, u32 vertType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex) {
 		
 		bool throughmode = (vertType & GE_VTYPE_THROUGH_MASK) != 0;
 		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
@@ -1057,9 +1057,9 @@ void TransformDrawEngineDX9::DoFlush() {
 	GEPrimitiveType prim = prevPrim_;
 	ApplyDrawState(prim);
 
-	LinkedShaderDX9 *program = shaderManager_->ApplyShader(prim, lastVType_);
+	VSShader *vshader = shaderManager_->ApplyShader(prim, lastVType_);
 
-		if (program->useHWTransform_) {
+	if (vshader->UseHWTransform()) {
 			LPDIRECT3DVERTEXBUFFER9 vb_ = NULL;
 			LPDIRECT3DINDEXBUFFER9 ib_ = NULL;
 
@@ -1233,7 +1233,7 @@ rotateVBO:
 				gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 			}
 
-			IDirect3DVertexDeclaration9 *pHardwareVertexDecl = SetupDecFmtForDraw(program, dec_->GetDecVtxFmt(), dec_->VertexType());
+			IDirect3DVertexDeclaration9 *pHardwareVertexDecl = SetupDecFmtForDraw(vshader, dec_->GetDecVtxFmt(), dec_->VertexType());
 
 			if (pHardwareVertexDecl) {
 				pD3Ddevice->SetVertexDeclaration(pHardwareVertexDecl);
@@ -1272,7 +1272,7 @@ rotateVBO:
 			DEBUG_LOG(G3D, "Flush prim %i SW! %i verts in one go", prim, indexGen.VertexCount());
 
 			SoftwareTransformAndDraw(
-				prim, decoded, program, indexGen.VertexCount(), 
+				prim, decoded, indexGen.VertexCount(), 
 				dec_->VertexType(), (void *)decIndex, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 				indexGen.MaxIndex());
 		}

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -28,7 +28,7 @@ struct DecVtxFormat;
 
 namespace DX9 {
 
-class LinkedShaderDX9;
+class VSShader;
 class ShaderManagerDX9;
 class TextureCacheDX9;
 class FramebufferManagerDX9;
@@ -144,10 +144,10 @@ public:
 
 private:
 	void DoFlush();
-	void SoftwareTransformAndDraw(int prim, u8 *decoded, LinkedShaderDX9 *program, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex);
+	void SoftwareTransformAndDraw(int prim, u8 *decoded, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex);
 	void ApplyDrawState(int prim);
 	bool IsReallyAClear(int numVerts) const;
-	IDirect3DVertexDeclaration9 *SetupDecFmtForDraw(LinkedShaderDX9 *program, const DecVtxFormat &decFmt, u32 pspFmt);
+	IDirect3DVertexDeclaration9 *SetupDecFmtForDraw(VSShader *vshader, const DecVtxFormat &decFmt, u32 pspFmt);
 
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, VertexDecoderDX9 *dec, int lowerBound, int upperBound, u32 vertType);

--- a/GPU/Directx9/VertexShaderGeneratorDX9.h
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.h
@@ -58,4 +58,34 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform);
 // Collapse to less skinning shaders to reduce shader switching, which is expensive.
 int TranslateNumBonesDX9(int bones);
 
+#define CONST_VS_PROJ 0
+#define CONST_VS_PROJ_THROUGH 4
+#define CONST_VS_VIEW 8
+#define CONST_VS_WORLD 12
+#define CONST_VS_TEXMTX 16
+#define CONST_VS_BONE0 20
+#define CONST_VS_BONE1 24
+#define CONST_VS_BONE2 28
+#define CONST_VS_BONE3 32
+#define CONST_VS_BONE4 36
+#define CONST_VS_BONE5 40
+#define CONST_VS_BONE6 44
+#define CONST_VS_BONE7 48
+#define CONST_VS_BONE8 52
+#define CONST_VS_FOGCOEF 56
+#define CONST_VS_UVSCALEOFFSET 57
+#define CONST_VS_AMBIENT 58
+#define CONST_VS_MATAMBIENTALPHA 59
+#define CONST_VS_MATDIFFUSE 60
+#define CONST_VS_MATSPECULAR 61
+#define CONST_VS_MATEMISSIVE 62
+#define CONST_VS_LIGHTPOS 64
+#define CONST_VS_LIGHTDIR 68
+#define CONST_VS_LIGHTATT 72
+#define CONST_VS_LIGHTANGLE 76
+#define CONST_VS_LIGHTSPOTCOEF 80
+#define CONST_VS_LIGHTDIFFUSE 84
+#define CONST_VS_LIGHTSPECULAR 88
+#define CONST_VS_LIGHTAMBIENT 92
+
 };

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -9,44 +9,38 @@ LPDIRECT3DDEVICE9EX pD3DdeviceEx = NULL;
 LPDIRECT3D9 pD3D = NULL;
 
 static const char * vscode =
-  " float4x4 matWVP : register(c0);              "
-  "                                              "
-	" struct VS_IN {                               "
-  "		float4 ObjPos   : POSITION;              "                 
-	"		float2 Uv    : TEXCOORD0;                 "  // Vertex color
-  " };                                           "
-  "                                              "
-	" struct VS_OUT {                              "
-  "		float4 ProjPos  : POSITION;              " 
-	"		float2 Uv    : TEXCOORD0;                 "  // Vertex color
-  " };                                           "
-  "                                              "
-	" VS_OUT main( VS_IN In ) {                    "
-  "		VS_OUT Out;                              "
-	"		Out.ProjPos = In.ObjPos;  "  // Transform vertex into
-	"		Out.Uv = In.Uv;			"
-  "		return Out;                              "  // Transfer color
-  " }                                            ";
+  "struct VS_IN {\n"
+  "  float4 ObjPos   : POSITION;\n"
+  "  float2 Uv    : TEXCOORD0;\n"
+  "};"
+  "struct VS_OUT {\n"
+  "  float4 ProjPos  : POSITION;\n"
+  "  float2 Uv    : TEXCOORD0;\n"
+  "};\n"
+  "VS_OUT main( VS_IN In ) {\n"
+  "  VS_OUT Out;\n"
+  "  Out.ProjPos = In.ObjPos;\n"
+  "  Out.Uv = In.Uv;\n"
+  "  return Out;\n"
+  "}\n";
 
 //--------------------------------------------------------------------------------------
 // Pixel shader
 //--------------------------------------------------------------------------------------
 static const char * pscode =
-	" sampler s: register(s0);					   "
-	" struct PS_IN {                                "
-	"     float2 Uv : TEXCOORD0;                   "
-	" };                                           "
-	"                                              "
-	" float4 main( PS_IN In ) : COLOR {            "
-	"   float4 c =  tex2D(s, In.Uv)  ;           "
-	"   c.a = 1.0f;"
-	"   return c;								   "
-	" }                                            ";
+  "sampler s: register(s0);\n"
+  "struct PS_IN {\n"
+  "  float2 Uv : TEXCOORD0;\n"
+  "};\n"
+  "float4 main( PS_IN In ) : COLOR {\n"
+  "  float4 c =  tex2D(s, In.Uv);\n"
+  "  c.a = 1.0f;\n"
+  "  return c;\n"
+  "}\n";
 
 IDirect3DVertexDeclaration9* pFramebufferVertexDecl = NULL;
 
-static const D3DVERTEXELEMENT9  VertexElements[] =
-{
+static const D3DVERTEXELEMENT9 VertexElements[] = {
 	{ 0, 0, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
 	{ 0, 12, D3DDECLTYPE_FLOAT2, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
 	D3DDECL_END()
@@ -54,8 +48,7 @@ static const D3DVERTEXELEMENT9  VertexElements[] =
 
 IDirect3DVertexDeclaration9* pSoftVertexDecl = NULL;
 
-static const D3DVERTEXELEMENT9  SoftTransVertexElements[] =
-{
+static const D3DVERTEXELEMENT9 SoftTransVertexElements[] = {
 	{ 0, 0, D3DDECLTYPE_FLOAT4, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
 	{ 0, 16, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
 	{ 0, 28, D3DDECLTYPE_UBYTE4N, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0 },
@@ -263,7 +256,6 @@ void DirectxInit(HWND window) {
 		// TODO
 	}
 
-	
 #ifdef _XBOX
 	pD3Ddevice->SetRingBufferParameters( &d3dr );
 #endif

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -852,6 +852,32 @@ inline void ConvertMatrix4x3To4x4(float *m4x4, const float *m4x3) {
 	m4x4[15] = 1.0f;
 }
 
+inline void ConvertMatrix4x3To4x4Transposed(float *m4x4, const float *m4x3) {
+	m4x4[0] = m4x3[0];
+	m4x4[1] = m4x3[3];
+	m4x4[2] = m4x3[6];
+	m4x4[3] = m4x3[9];
+	m4x4[4] = m4x3[1];
+	m4x4[5] = m4x3[4];
+	m4x4[6] = m4x3[7];
+	m4x4[7] = m4x3[10];
+	m4x4[8] = m4x3[2];
+	m4x4[9] = m4x3[5];
+	m4x4[10] = m4x3[8];
+	m4x4[11] = m4x3[11];
+	m4x4[12] = 0.0f;
+	m4x4[13] = 0.0f;
+	m4x4[14] = 0.0f;
+	m4x4[15] = 1.0f;
+}
+
+inline void Transpose4x4(float out[16], const float in[16]) {
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			out[i * 4 + j] = in[j * 4 + i];
+		}
+	}
+}
 
 inline float Vec3Dot(const float v1[3], const float v2[3])
 {


### PR DESCRIPTION
In DX9, constants are in a shared space so they don't need to be reset per shader, and you don't need to explicitly link vertex and pixel shaders with each other, that's done by the runtime.

Should be a noticable speed boost.
