### PR TITLE
armjit: Fix rounding mode, allow non flush-to-zero

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -313,6 +313,14 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting(false),
 };
 
+static bool DefaultForceFlushToZero() {
+#ifdef ARM
+	return true;
+#else
+	return false;
+#endif
+}
+
 static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("Jit", &g_Config.bJit, &DefaultJit),
 	ReportedConfigSetting("SeparateCPUThread", &g_Config.bSeparateCPUThread, false),
@@ -323,6 +331,7 @@ static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0),
 	ReportedConfigSetting("SetRoundingMode", &g_Config.bSetRoundingMode, true),
+	ReportedConfigSetting("ForceFlushToZero", &g_Config.bForceFlushToZero, &DefaultForceFlushToZero),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -98,6 +98,7 @@ public:
 	bool bForceLagSync;
 	bool bFuncReplacements;
 	bool bSetRoundingMode;
+	bool bForceFlushToZero;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -399,6 +399,8 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //ctc1
 		if (fs == 31) {
+			// Must clear before setting, since SetRoundingMode() assumes it was cleared.
+			ClearRoundingMode();
 			bool wasImm = gpr.IsImm(rt);
 			if (wasImm) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
@@ -417,15 +419,8 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				MOV(SCRATCHREG1, Operand2(gpr.R(rt), ST_LSR, 23));
 				AND(gpr.R(MIPS_REG_FPCOND), SCRATCHREG1, Operand2(1));
 #endif
-				SetRoundingMode();
-			} else {
-				if ((gpr.GetImm(rt) & 3) == 0) {
-					// Default nearest mode, let's do this the fast way.
-					ClearRoundingMode();
-				} else {
-					SetRoundingMode();
-				}
 			}
+			SetRoundingMode();
 		} else {
 			Comp_Generic(op);
 		}

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -379,6 +379,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1
 		if (fs == 31) {
+			// Must clear before setting, since SetRoundingMode() assumes it was cleared.
 			ClearRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -250,10 +250,14 @@ void Jit::SetRoundingMode(XEmitter *emitter)
 		emitter->SHL(32, R(EAX), Imm8(13));
 		emitter->OR(32, M(&currentMIPS->temp), R(EAX));
 
-		emitter->TEST(32, M(&mips_->fcr31), Imm32(1 << 24));
-		FixupBranch skip3 = emitter->J_CC(CC_Z);
-		emitter->OR(32, M(&currentMIPS->temp), Imm32(1 << 15));
-		emitter->SetJumpTarget(skip3);
+		if (g_Config.bForceFlushToZero) {
+			emitter->OR(32, M(&currentMIPS->temp), Imm32(1 << 15));
+		} else {
+			emitter->TEST(32, M(&mips_->fcr31), Imm32(1 << 24));
+			FixupBranch skip3 = emitter->J_CC(CC_Z);
+			emitter->OR(32, M(&currentMIPS->temp), Imm32(1 << 15));
+			emitter->SetJumpTarget(skip3);
+		}
 
 		emitter->LDMXCSR(M(&currentMIPS->temp));
 


### PR DESCRIPTION
Default: force flush to zero (for RunFast mode.)  But now it's an ini option so we can more easily compare armjit differences.

Basically just ports #6828 to armjit and wraps it in an option.

-[Unknown]
