### PR TITLE
d3d: Fix CheckAlpha() for 16-bit formats

### DIFF
--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -951,7 +951,7 @@ namespace DX9 {
 			return true;
 		}
 
-		LPDIRECT3DSURFACE9 renderTarget;
+		LPDIRECT3DSURFACE9 renderTarget = nullptr;
 		HRESULT hr;
 		hr = pD3Ddevice->GetRenderTarget(0, &renderTarget);
 		if (!renderTarget || !SUCCEEDED(hr))
@@ -960,10 +960,12 @@ namespace DX9 {
 		D3DSURFACE_DESC desc;
 		renderTarget->GetDesc(&desc);
 
-		LPDIRECT3DSURFACE9 offscreen;
+		LPDIRECT3DSURFACE9 offscreen = nullptr;
 		hr = pD3Ddevice->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &offscreen, NULL);
-		if (!SUCCEEDED(hr))
+		if (!offscreen || !SUCCEEDED(hr)) {
+			renderTarget->Release();
 			return false;
+		}
 
 		bool success = false;
 		hr = pD3Ddevice->GetRenderTargetData(renderTarget, offscreen);
@@ -981,6 +983,7 @@ namespace DX9 {
 		}
 
 		offscreen->Release();
+		renderTarget->Release();
 
 		return success;
 	}

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -1598,9 +1598,9 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 
 			// If it fails, this means it's a render-to-texture, so we have to get creative.
 			if (FAILED(hr)) {
-				LPDIRECT3DSURFACE9 renderTarget;
+				LPDIRECT3DSURFACE9 renderTarget = nullptr;
 				hr = tex->GetSurfaceLevel(level, &renderTarget);
-				if (SUCCEEDED(hr)) {
+				if (renderTarget && SUCCEEDED(hr)) {
 					hr = pD3Ddevice->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &offscreen, NULL);
 					if (SUCCEEDED(hr)) {
 						hr = pD3Ddevice->GetRenderTargetData(renderTarget, offscreen);
@@ -1608,6 +1608,7 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 							hr = offscreen->LockRect(&locked, &rect, D3DLOCK_READONLY);
 						}
 					}
+					renderTarget->Release();
 				}
 			}
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -1510,9 +1510,9 @@ TextureCacheDX9::TexCacheEntry::Status TextureCacheDX9::CheckAlpha(const u32 *pi
 			const u32 *p = pixelData;
 			for (int y = 0; y < h && hitSomeAlpha == 0; ++y) {
 				for (int i = 0; i < (w + 1) / 2; ++i) {
-					u32 a = p[i] & 0x000F000F;
-					hitZeroAlpha |= a ^ 0x000F000F;
-					if (a != 0x000F000F && a != 0x0000000F && a != 0x000F0000 && a != 0) {
+					u32 a = p[i] & 0xF000F000;
+					hitZeroAlpha |= a ^ 0xF000F000;
+					if (a != 0xF000F000 && a != 0xF0000000 && a != 0x0000F000 && a != 0) {
 						hitSomeAlpha = 1;
 						break;
 					}
@@ -1526,8 +1526,8 @@ TextureCacheDX9::TexCacheEntry::Status TextureCacheDX9::CheckAlpha(const u32 *pi
 			const u32 *p = pixelData;
 			for (int y = 0; y < h; ++y) {
 				for (int i = 0; i < (w + 1) / 2; ++i) {
-					u32 a = p[i] & 0x00010001;
-					hitZeroAlpha |= a ^ 0x00010001;
+					u32 a = p[i] & 0x10001000;
+					hitZeroAlpha |= a ^ 0x10001000;
 				}
 				p += stride/2;
 			}


### PR DESCRIPTION
Not reversed in d3d, unlike gles.  Fixes #6883 (pretty sure.)

-[Unknown]
