### PR TITLE
d3d: Fix switching between rendering modes

### DIFF
--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -1301,6 +1301,12 @@ rotateVBO:
 
 void TransformDrawEngineDX9::Resized() {
 	decJitCache_->Clear();
+	lastVType_ = -1;
+	dec_ = NULL;
+	for (auto iter = decoderMap_.begin(); iter != decoderMap_.end(); iter++) {
+		delete iter->second;
+	}
+	decoderMap_.clear();
 
 	// ...
 }

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -838,7 +838,7 @@ void FramebufferManager::SetLineWidth() {
 }
 
 void FramebufferManager::ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old) {
-	if (!useBufferedRendering_) {
+	if (!useBufferedRendering_ || !vfb->fbo) {
 		return;
 	}
 


### PR DESCRIPTION
Need to clear the cache or we just get stuck in a breakpoint.

-[Unknown]
