### PR TITLE
Win32: Add a command-line argument to pick the GPU backend.

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -403,8 +403,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	std::vector<std::wstring> wideArgs = GetWideCmdLine();
 
-	for (size_t i = 1; i < wideArgs.size(); ++i)
-	{
+	for (size_t i = 1; i < wideArgs.size(); ++i) {
 		if (wideArgs[i][0] == L'\0')
 			continue;
 		if (wideArgs[i][0] == L'-') {
@@ -438,8 +437,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	const std::wstring gpuBackend = L"--gfx=";
 
 	// The rest is handled in NativeInit().
-	for (size_t i = 1; i < wideArgs.size(); ++i)
-	{
+	for (size_t i = 1; i < wideArgs.size(); ++i) {
 		if (wideArgs[i][0] == L'\0')
 			continue;
 
@@ -464,8 +462,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			if (wideArgs[i] == L"--windowed")
 				g_Config.bFullScreen = false;
 
-			if (wideArgs[i].find(gpuBackend) != std::wstring::npos && wideArgs[i].size() > gpuBackend.size())
-			{
+			if (wideArgs[i].find(gpuBackend) != std::wstring::npos && wideArgs[i].size() > gpuBackend.size()) {
 				const std::wstring restOfOption = wideArgs[i].substr(gpuBackend.size());
 
 				if (restOfOption == L"d3d")

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -435,6 +435,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	bool debugLogLevel = false;
 
+	const std::wstring gpuBackend = L"--gfx=";
+
 	// The rest is handled in NativeInit().
 	for (size_t i = 1; i < wideArgs.size(); ++i)
 	{
@@ -461,6 +463,16 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 			if (wideArgs[i] == L"--windowed")
 				g_Config.bFullScreen = false;
+
+			if (wideArgs[i].find(gpuBackend) != std::wstring::npos && wideArgs[i].size() > gpuBackend.size())
+			{
+				const std::wstring restOfOption = wideArgs[i].substr(gpuBackend.size());
+
+				if (restOfOption == L"d3d")
+					g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
+				else if (restOfOption == L"ogl")
+					g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
+			}
 		}
 	}
 #ifdef _DEBUG


### PR DESCRIPTION
It makes sense to add it since some users can't even open PPSSPP in OpenGL mode, so they can't get an initial ini file with which to enable Direct3D, meaning they need to copy and paste a fresh ini file into a blank ppsspp.ini, which is extremely unintuitive, so let this serve as a workaround for it until we add backend fallbacks. After that, it could be useful for debugging or something, perhaps..

Example syntax:
ppssppwindows.exe --gfx=ogl
ppssppwindows.exe --gfx=d3d

The former will launch PPSSPP with the OpenGL backend, whilst the latter will launch it with the Direct3D backend.
