### PR TITLE
d3d: Set texture only when enabled

### DIFF
--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -118,11 +118,14 @@ static bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margin = 0.1
 void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
-	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED) {
-		if (gstate.isTextureMapEnabled()) {
-			textureCache_->SetTexture();
-		}
+	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
+		textureCache_->SetTexture();
 		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
+		if (gstate_c.needShaderTexClamp) {
+			// We will rarely need to set this, so let's do it every time on use rather than in runloop.
+			// Most of the time non-framebuffer textures will be used which can be clamped themselves.
+			shaderManager_->DirtyUniform(DIRTY_TEXCLAMP);
+		}
 	}
 
 	// TODO: The top bit of the alpha channel should be written to the stencil bit somehow. This appears to require very expensive multipass rendering :( Alternatively, one could do a


### PR DESCRIPTION
This allows optimizations that were applied to the cmd flags.

Also, drop the clamp stuff in, even if not used yet... I suppose we will use it, and it doesn't hurt anything.

-[Unknown]
