### PR TITLE
Win32: Add an UI option to change the GPU backend.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -407,6 +407,8 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("FrameRate", &g_Config.iFpsLimit, 0),
 #ifdef _WIN32
 	ConfigSetting("FrameSkipUnthrottle", &g_Config.bFrameSkipUnthrottle, false),
+	ConfigSetting("TemporaryGPUBackend", &g_Config.iTempGPUBackend, -1, false),
+	ConfigSetting("RestartRequired", &g_Config.bRestartRequired, false, false),
 #else
 	ConfigSetting("FrameSkipUnthrottle", &g_Config.bFrameSkipUnthrottle, true),
 #endif
@@ -828,6 +830,10 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 
 	CleanRecent();
+
+#ifdef _WIN32
+	iTempGPUBackend = iGPUBackend;
+#endif
 }
 
 void Config::Save() {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -82,6 +82,12 @@ public:
 	bool bTopMost;
 	std::string sFont;
 	bool bIgnoreWindowsKey;
+
+	// Used for switching the GPU backend in GameSettingsScreen.
+	// Without this, PPSSPP instantly crashes if we edit iGPUBackend directly...
+	int iTempGPUBackend;
+
+	bool bRestartRequired;
 #endif
 
 	bool bPauseWhenMinimized;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -117,7 +117,7 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gs->T("Rendering Mode")));
 #if defined(_WIN32)
-	static const char *renderingBackend[] = { "OpenGL", "DirectX" };
+	static const char *renderingBackend[] = { "OpenGL", "Direct3D9" };
 	PopupMultiChoice *renderingBackendChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTempGPUBackend, gs->T("Backend"), renderingBackend, GPU_BACKEND_OPENGL, ARRAY_SIZE(renderingBackend), gs, screenManager()));
 	renderingBackendChoice->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingBackend);
 #endif

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -35,7 +35,7 @@ protected:
 	virtual void CreateViews();
 	virtual void sendMessage(const char *message, const char *value);
 	void CallbackRestoreDefaults(bool yes);
-
+	void CallbackRenderingBackend(bool yes);
 	bool UseVerticalLayout() const;
 
 private:
@@ -75,6 +75,7 @@ private:
 	UI::EventReturn OnShaderChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 	UI::EventReturn OnRenderingMode(UI::EventParams &e);
+	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 	UI::EventReturn OnSoftwareRendering(UI::EventParams &e);
 	UI::EventReturn OnHardwareTransform(UI::EventParams &e);

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -465,11 +465,12 @@ namespace MainWindow
 		SUBMENU_CUSTOM_SHADERS = 10,
 		SUBMENU_RENDERING_RESOLUTION = 11,
 		SUBMENU_WINDOW_SIZE = 12,
-		SUBMENU_RENDERING_MODE = 13,
-		SUBMENU_FRAME_SKIPPING = 14,
-		SUBMENU_TEXTURE_FILTERING = 15,
-		SUBMENU_BUFFER_FILTER = 16,
-		SUBMENU_TEXTURE_SCALING = 17,
+		SUBMENU_RENDERING_BACKEND = 13,
+		SUBMENU_RENDERING_MODE = 14,
+		SUBMENU_FRAME_SKIPPING = 15,
+		SUBMENU_TEXTURE_FILTERING = 16,
+		SUBMENU_BUFFER_FILTER = 17,
+		SUBMENU_TEXTURE_SCALING = 18,
 	};
 
 	std::string GetMenuItemText(int menuID) {
@@ -649,6 +650,9 @@ namespace MainWindow
 		// Skip rendering resolution 2x-5x..
 		TranslateSubMenu("Window Size", MENU_OPTIONS, SUBMENU_WINDOW_SIZE);
 		// Skip window size 1x-4x..
+		TranslateSubMenu("Backend", MENU_OPTIONS, SUBMENU_RENDERING_BACKEND);
+		TranslateMenuItem(ID_OPTIONS_DIRECTX);
+		TranslateMenuItem(ID_OPTIONS_OPENGL);
 		TranslateSubMenu("Rendering Mode", MENU_OPTIONS, SUBMENU_RENDERING_MODE, L"\tF5");
 		TranslateMenuItem(ID_OPTIONS_NONBUFFEREDRENDERING);
 		TranslateMenuItem(ID_OPTIONS_BUFFEREDRENDERING);
@@ -1356,6 +1360,18 @@ namespace MainWindow
 					NativeMessageReceived("gpu clear cache", "");
 					break;
 
+				case ID_OPTIONS_DIRECTX:
+					g_Config.iTempGPUBackend = GPU_BACKEND_DIRECT3D9;
+					g_Config.bRestartRequired = true;
+					PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+					break;
+
+				case ID_OPTIONS_OPENGL:
+					g_Config.iTempGPUBackend = GPU_BACKEND_OPENGL;
+					g_Config.bRestartRequired = true;
+					PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+					break;
+
 				case ID_OPTIONS_NONBUFFEREDRENDERING:   setRenderingMode(FB_NON_BUFFERED_MODE); break;
 				case ID_OPTIONS_BUFFEREDRENDERING:      setRenderingMode(FB_BUFFERED_MODE); break;
 				case ID_OPTIONS_READFBOTOMEMORYCPU:     setRenderingMode(FB_READFBOMEMORY_CPU); break;
@@ -1924,6 +1940,17 @@ namespace MainWindow
 		for (int i = 0; i < ARRAY_SIZE(savestateSlot); i++) {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | (( i == g_Config.iCurrentStateSlot )? MF_CHECKED : MF_UNCHECKED));
 		}
+
+		if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
+			EnableMenuItem(menu, ID_OPTIONS_DIRECTX, MF_GRAYED);
+			CheckMenuItem(menu, ID_OPTIONS_DIRECTX, MF_CHECKED);
+			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_ENABLED);
+		} else {
+			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_GRAYED);
+			CheckMenuItem(menu, ID_OPTIONS_OPENGL, MF_CHECKED);
+			EnableMenuItem(menu, ID_OPTIONS_DIRECTX, MF_ENABLED);
+		}
+
 
 		UpdateDynamicMenuCheckmarks();
 		UpdateCommands();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -588,7 +588,20 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	DialogManager::DestroyAll();
 	timeEndPeriod(1);
 	delete host;
+
+	// Is there a safer place to do this?
+	// Doing this in Config::Save requires knowing if the UI state is UISTATE_EXIT,
+	// but that causes UnitTest to fail linking with 400 errors if System.h is included..
+	if (g_Config.iTempGPUBackend != g_Config.iGPUBackend)
+		g_Config.iGPUBackend = g_Config.iTempGPUBackend;
+
 	g_Config.Save();
 	LogManager::Shutdown();
+
+	if (g_Config.bRestartRequired) {
+		wchar_t moduleFilename[MAX_PATH];
+		GetModuleFileName(GetModuleHandle(NULL), moduleFilename, MAX_PATH);
+		ShellExecute(NULL, NULL, moduleFilename, NULL, NULL, SW_SHOW);
+	}
 	return 0;
 }

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -592,8 +592,12 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	// Is there a safer place to do this?
 	// Doing this in Config::Save requires knowing if the UI state is UISTATE_EXIT,
 	// but that causes UnitTest to fail linking with 400 errors if System.h is included..
-	if (g_Config.iTempGPUBackend != g_Config.iGPUBackend)
+	if (g_Config.iTempGPUBackend != g_Config.iGPUBackend) {
 		g_Config.iGPUBackend = g_Config.iTempGPUBackend;
+
+		// For now, turn off software rendering too, similar to the command-line.
+		g_Config.bSoftwareRendering = false;
+	}
 
 	g_Config.Save();
 	LogManager::Shutdown();

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -469,39 +469,47 @@ BEGIN
             MENUITEM "&3x",                                 ID_OPTIONS_WINDOW3X
             MENUITEM "&4x",                                 ID_OPTIONS_WINDOW4X
         END
-				POPUP "Rendering Mode"
-				BEGIN
-					MENUITEM "Non-Buffered Rendering",				ID_OPTIONS_NONBUFFEREDRENDERING
-					MENUITEM "Buffered Rendering",					ID_OPTIONS_BUFFEREDRENDERING
-					MENUITEM "Read Framebuffers To Memory (CPU)",	ID_OPTIONS_READFBOTOMEMORYCPU
-					MENUITEM "Read Framebuffers To Memory (GPU)",	ID_OPTIONS_READFBOTOMEMORYGPU
-				END
-				POPUP "Frame Skipping"
-				BEGIN
-					MENUITEM "Auto",						        ID_OPTIONS_FRAMESKIP_AUTO
-					MENUITEM SEPARATOR
-					MENUITEM "Off",								    ID_OPTIONS_FRAMESKIP_0
-					MENUITEM "&1",							        ID_OPTIONS_FRAMESKIP_1
-					MENUITEM "&2",									ID_OPTIONS_FRAMESKIP_2
-					MENUITEM "&3",									ID_OPTIONS_FRAMESKIP_3
-					MENUITEM "&4",									ID_OPTIONS_FRAMESKIP_4
-					MENUITEM "&5",									ID_OPTIONS_FRAMESKIP_5
-					MENUITEM "&6",									ID_OPTIONS_FRAMESKIP_6
-					MENUITEM "&7",									ID_OPTIONS_FRAMESKIP_7
-					MENUITEM "&8",									ID_OPTIONS_FRAMESKIP_8
-				END
-				POPUP "Texture Filtering"
-						BEGIN
-								MENUITEM "Auto",                                ID_OPTIONS_TEXTUREFILTERING_AUTO
-								MENUITEM "Nearest",                             ID_OPTIONS_NEARESTFILTERING
-								MENUITEM "Linear",                              ID_OPTIONS_LINEARFILTERING
-								MENUITEM "Linear on FMV",                       ID_OPTIONS_LINEARFILTERING_CG
-				END
-				POPUP "Screen Scaling Filter"
-						BEGIN
-								MENUITEM "Linear",                              ID_OPTIONS_BUFLINEARFILTER
-								MENUITEM "Nearest",                             ID_OPTIONS_BUFNEARESTFILTER
-				END
+
+		POPUP "Backend"
+		BEGIN
+			MENUITEM "Direct3D9" ID_OPTIONS_DIRECTX
+			MENUITEM "OpenGL" ID_OPTIONS_OPENGL
+		END
+
+		POPUP "Rendering Mode"
+		BEGIN
+			MENUITEM "Non-Buffered Rendering",				ID_OPTIONS_NONBUFFEREDRENDERING
+			MENUITEM "Buffered Rendering",					ID_OPTIONS_BUFFEREDRENDERING
+			MENUITEM "Read Framebuffers To Memory (CPU)",	ID_OPTIONS_READFBOTOMEMORYCPU
+			MENUITEM "Read Framebuffers To Memory (GPU)",	ID_OPTIONS_READFBOTOMEMORYGPU
+		END
+		POPUP "Frame Skipping"
+		BEGIN
+			MENUITEM "Auto",						        ID_OPTIONS_FRAMESKIP_AUTO
+			MENUITEM SEPARATOR
+			MENUITEM "Off",								    ID_OPTIONS_FRAMESKIP_0
+			MENUITEM "&1",							        ID_OPTIONS_FRAMESKIP_1
+			MENUITEM "&2",									ID_OPTIONS_FRAMESKIP_2
+			MENUITEM "&3",									ID_OPTIONS_FRAMESKIP_3
+			MENUITEM "&4",									ID_OPTIONS_FRAMESKIP_4
+			MENUITEM "&5",									ID_OPTIONS_FRAMESKIP_5
+			MENUITEM "&6",									ID_OPTIONS_FRAMESKIP_6
+			MENUITEM "&7",									ID_OPTIONS_FRAMESKIP_7
+			MENUITEM "&8",									ID_OPTIONS_FRAMESKIP_8
+		END
+		POPUP "Texture Filtering"
+		BEGIN
+			MENUITEM "Auto",                                ID_OPTIONS_TEXTUREFILTERING_AUTO
+			MENUITEM "Nearest",                             ID_OPTIONS_NEARESTFILTERING
+			MENUITEM "Linear",                              ID_OPTIONS_LINEARFILTERING
+			MENUITEM "Linear on FMV",                       ID_OPTIONS_LINEARFILTERING_CG
+		END
+		POPUP "Screen Scaling Filter"
+		BEGIN
+			MENUITEM "Linear",                              ID_OPTIONS_BUFLINEARFILTER
+			MENUITEM "Nearest",                             ID_OPTIONS_BUFNEARESTFILTER
+		END
+
         POPUP "Texture Scaling"
         BEGIN
             MENUITEM "Off",                             ID_TEXTURESCALING_OFF

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -315,6 +315,8 @@
 #define ID_DEBUG_SAVESYMFILE             40151
 #define ID_OPTIONS_BUFLINEARFILTER       40152
 #define ID_OPTIONS_BUFNEARESTFILTER      40153
+#define ID_OPTIONS_DIRECTX               40154
+#define ID_OPTIONS_OPENGL                40155	
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
I think we're all sick of changing the INI file or using the command-line at this point.

It requires an application restart, hence the prompt screen. If chosen from the menu bar, it _restarts without warning (In the translation file I have prepared, it changed "Backend" to "Rendering Backend (Restarts PPSSPP)", but there is no other warning than that)._ It could, however, popup a message box instead, I guess.

Changing backends also disables software rendering.
