### PR TITLE
Replace frame download in suikoden1&2

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -652,6 +652,24 @@ static int Hook_sakurasou_download_frame() {
 	return 0;
 }
 
+static int Hook_suikoden1_and_2_download_frame_1() {
+	const u32 fb_address = currentMIPS->r[MIPS_REG_S4];
+	if (Memory::IsVRAMAddress(fb_address)) {
+		gpu->PerformMemoryDownload(fb_address, 0x00088000);
+		CBreakPoints::ExecMemCheck(fb_address, true, 0x00088000, currentMIPS->pc);
+	}
+	return 0;
+}
+
+static int Hook_suikoden1_and_2_download_frame_2() {
+	const u32 fb_address = currentMIPS->r[MIPS_REG_S2];
+	if (Memory::IsVRAMAddress(fb_address)) {
+		gpu->PerformMemoryDownload(fb_address, 0x00088000);
+		CBreakPoints::ExecMemCheck(fb_address, true, 0x00088000, currentMIPS->pc);
+	}
+	return 0;
+}
+
 // Can either replace with C functions or functions emitted in Asm/ArmAsm.
 static const ReplacementTableEntry entries[] = {
 	// TODO: I think some games can be helped quite a bit by implementing the
@@ -705,6 +723,8 @@ static const ReplacementTableEntry entries[] = {
 	{ "kirameki_school_life_download_frame", &Hook_kirameki_school_life_download_frame, 0, REPFLAG_HOOKENTER },
 	{ "orenoimouto_download_frame", &Hook_orenoimouto_download_frame, 0, REPFLAG_HOOKENTER },
 	{ "sakurasou_download_frame", &Hook_sakurasou_download_frame, 0, REPFLAG_HOOKENTER, 0xF8 },
+	{ "suikoden1_and_2_download_frame_1", &Hook_suikoden1_and_2_download_frame_1, 0, REPFLAG_HOOKENTER, 0x9C },
+	{ "suikoden1_and_2_download_frame_2", &Hook_suikoden1_and_2_download_frame_2, 0, REPFLAG_HOOKENTER, 0x48 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -123,6 +123,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x1bdf3600844373fd, 112, "strstr", },
 	{ 0x1c967be07917ddc9, 92, "strcat", },
 	{ 0x1d03fa48334ca966, 556, "_strtol_r", },
+	{ 0x1d1311966d2243e9, 428, "suikoden1_and_2_download_frame_1", }, // Gensou Suikoden 1&2
 	{ 0x1e1525e3bc2f6703, 676, "rint", },
 	{ 0x1ec055f28bb9f4d1, 88, "gu_update_stall", },
 	{ 0x1f53eac122f96b37, 224, "cosf", },
@@ -422,6 +423,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xfa156c48461eeeb9, 24, "vf2id_q", },
 	{ 0xfb4253a1d9d9df9f, 20, "isnanf", },
 	{ 0xfd34a9ad94fa6241, 76, "__extendsfdf2", },
+	{ 0xfe2566ad957054b7, 232, "suikoden1_and_2_download_frame_2", }, // Gensou Suikoden 1&2
 	{ 0xfe4f0280240008e9, 28, "vavg_q", },
 	{ 0xfe5dd338ab862291, 216, "memset", }, // Metal Gear Solid: Peace Walker demo
 	{ 0xffc8f5f8f946152c, 192, "dl_write_light_color", },


### PR DESCRIPTION
Hook_suikoden1_and_2_download_frame_1 is for the title background.https://gist.github.com/daniel229/a6071897b5fb6eb475c5
Hook_suikoden1_and_2_download_frame_2 is for the ingame background transition screen ETC.https://gist.github.com/daniel229/6c9d5e0c2ce518c0d2db

zz_sceGeEdramGetAddr renturn an v0  give it to s4(func1) and s2(func).
The hooking still out of the loop.

![01](https://cloud.githubusercontent.com/assets/3481559/4264549/f1420920-3c2b-11e4-8def-f67d1d0283bd.png)
![02](https://cloud.githubusercontent.com/assets/3481559/4264550/f1450972-3c2b-11e4-994e-ae59d1c72d52.png)

![03](https://cloud.githubusercontent.com/assets/3481559/4264548/f141aea8-3c2b-11e4-81df-d5cc0691a09b.png)
![04](https://cloud.githubusercontent.com/assets/3481559/4264551/f146d3d8-3c2b-11e4-9d35-444f0ab6cbe8.png)
