### PR TITLE
d3d: Use INTZ depth textures where supported

### DIFF
--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -55,6 +55,8 @@ enum GPUDebugBufferFormat {
 	GPU_DBG_FORMAT_FLOAT = 0x10,
 	GPU_DBG_FORMAT_16BIT = 0x11,
 	GPU_DBG_FORMAT_8BIT = 0x12,
+	GPU_DBG_FORMAT_24BIT_8X = 0x13,
+	GPU_DBG_FORMAT_24X_8BIT = 0x14,
 };
 
 inline GPUDebugBufferFormat &operator |=(GPUDebugBufferFormat &lhs, const GPUDebugBufferFormat &rhs) {
@@ -137,11 +139,23 @@ struct GPUDebugBuffer {
 		fmt_ = fmt;
 		flipped_ = flipped;
 
-		u32 pixelSize = 2;
-		if (fmt == GPU_DBG_FORMAT_8888 || fmt == GPU_DBG_FORMAT_8888_BGRA || fmt == GPU_DBG_FORMAT_FLOAT) {
+		u32 pixelSize;
+		switch (fmt) {
+		case GPU_DBG_FORMAT_8888:
+		case GPU_DBG_FORMAT_8888_BGRA:
+		case GPU_DBG_FORMAT_FLOAT:
+		case GPU_DBG_FORMAT_24BIT_8X:
+		case GPU_DBG_FORMAT_24X_8BIT:
 			pixelSize = 4;
-		} else if (fmt == GPU_DBG_FORMAT_8BIT) {
+			break;
+
+		case GPU_DBG_FORMAT_8BIT:
 			pixelSize = 1;
+			break;
+
+		default:
+			pixelSize = 2;
+			break;
 		}
 
 		data_ = new u8[pixelSize * stride * height];
@@ -154,7 +168,11 @@ struct GPUDebugBuffer {
 		data_ = NULL;
 	}
 
-	u8 *GetData() const {
+	u8 *GetData() {
+		return data_;
+	}
+
+	const u8 *GetData() const {
 		return data_;
 	}
 

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -503,8 +503,7 @@ namespace DX9 {
 
 		// Copy depth pixel value from the read framebuffer to the draw framebuffer
 		if (prevVfb && !g_Config.bDisableSlowFramebufEffects) {
-			// TODO
-			//BlitFramebufferDepth(prevVfb, vfb);
+			BlitFramebufferDepth(prevVfb, vfb);
 		}
 		if (vfb->drawnFormat != vfb->format) {
 			// TODO: Might ultimately combine this with the resize step in DoSetRenderFrameBuffer().
@@ -538,6 +537,64 @@ namespace DX9 {
 		if (gstate_c.curRTRenderWidth != vfb->renderWidth || gstate_c.curRTRenderHeight != vfb->renderHeight) {
 			shaderManager_->DirtyUniform(DIRTY_PROJMATRIX);
 			shaderManager_->DirtyUniform(DIRTY_PROJTHROUGHMATRIX);
+		}
+	}
+
+	void FramebufferManagerDX9::BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst) {
+		if (!src->fbo || !dst->fbo || !useBufferedRendering_) {
+			return;
+		}
+
+		// If depth wasn't updated, then we're at least "two degrees" away from the data.
+		// This is an optimization: it probably doesn't need to be copied in this case.
+		if (!src->depthUpdated) {
+			return;
+		}
+
+		if (src->z_address == dst->z_address &&
+			src->z_stride != 0 && dst->z_stride != 0 &&
+			src->renderWidth == dst->renderWidth &&
+			src->renderHeight == dst->renderHeight) {
+
+			// Let's only do this if not clearing.
+			if (!gstate.isModeClear() || !gstate.isClearModeDepthMask()) {
+				// Doesn't work.  Use a shader maybe?
+				/*fbo_unbind();
+
+				LPDIRECT3DTEXTURE9 srcTex = fbo_get_depth_texture(src->fbo);
+				LPDIRECT3DTEXTURE9 dstTex = fbo_get_depth_texture(dst->fbo);
+
+				if (srcTex && dstTex) {
+					D3DSURFACE_DESC srcDesc;
+					srcTex->GetLevelDesc(0, &srcDesc);
+					D3DSURFACE_DESC dstDesc;
+					dstTex->GetLevelDesc(0, &dstDesc);
+
+					D3DLOCKED_RECT srcLock;
+					D3DLOCKED_RECT dstLock;
+					HRESULT srcLockRes = srcTex->LockRect(0, &srcLock, nullptr, D3DLOCK_READONLY);
+					HRESULT dstLockRes = dstTex->LockRect(0, &dstLock, nullptr, 0);
+					if (SUCCEEDED(srcLockRes) && SUCCEEDED(dstLockRes)) {
+						int pitch = std::min(srcLock.Pitch, dstLock.Pitch);
+						u32 h = std::min(srcDesc.Height, dstDesc.Height);
+						const u8 *srcp = (const u8 *)srcLock.pBits;
+						u8 *dstp = (u8 *)dstLock.pBits;
+						for (u32 y = 0; y < h; ++y) {
+							memcpy(dstp, srcp, pitch);
+							dstp += dstLock.Pitch;
+							srcp += srcLock.Pitch;
+						}
+					}
+					if (SUCCEEDED(srcLockRes)) {
+						srcTex->UnlockRect(0);
+					}
+					if (SUCCEEDED(dstLockRes)) {
+						dstTex->UnlockRect(0);
+					}
+				}
+
+				RebindFramebuffer();*/
+			}
 		}
 	}
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -71,6 +71,8 @@ public:
 	void DeviceLost();
 	void CopyDisplayToOutput();
 
+	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
+
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
 
 	std::vector<FramebufferInfo> GetFramebufferList();

--- a/GPU/Directx9/helper/fbo.h
+++ b/GPU/Directx9/helper/fbo.h
@@ -28,6 +28,7 @@ FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, F
 void fbo_bind_as_render_target(FBO *fbo);
 // color must be 0, for now.
 void fbo_bind_color_as_texture(FBO *fbo, int color);
+void fbo_bind_depth_as_texture(FBO *fbo);
 LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO *fbo);
 LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO *fbo);
 void fbo_unbind();
@@ -37,8 +38,7 @@ void fbo_resolve(FBO *fbo);
 HRESULT fbo_blit_color(FBO *src, const RECT *srcRect, FBO *dst, const RECT *dstRect, D3DTEXTUREFILTERTYPE filter);
 
 LPDIRECT3DTEXTURE9 fbo_get_color_texture(FBO *fbo);
-
-void * fbo_get_rtt(FBO *fbo);
+LPDIRECT3DTEXTURE9 fbo_get_depth_texture(FBO *fbo);
 
 // To get default depth and rt surface
 void fbo_init();

--- a/GPU/Directx9/helper/fbo.h
+++ b/GPU/Directx9/helper/fbo.h
@@ -41,7 +41,7 @@ LPDIRECT3DTEXTURE9 fbo_get_color_texture(FBO *fbo);
 LPDIRECT3DTEXTURE9 fbo_get_depth_texture(FBO *fbo);
 
 // To get default depth and rt surface
-void fbo_init();
+void fbo_init(LPDIRECT3D9 d3d);
 void fbo_shutdown();
 
 };

--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -210,7 +210,7 @@ void DirectxInit(HWND window) {
 
 	CompileShaders();
 
-	fbo_init();
+	fbo_init(pD3D);
 }
 
 };

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -91,7 +91,7 @@ public:
 	void SetLineWidth();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old);
 
-	void BlitFramebufferDepth(VirtualFramebuffer *sourceframebuffer, VirtualFramebuffer *targetframebuffer);
+	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
 	// For use when texturing from a framebuffer.  May create a duplicate if target.
 	void BindFramebufferColor(VirtualFramebuffer *framebuffer, bool skipCopy = false);

--- a/Windows/D3D9Base.cpp
+++ b/Windows/D3D9Base.cpp
@@ -159,7 +159,7 @@ bool D3D9_Init(HWND hWnd, bool windowed, std::string *error_message) {
 	LoadD3DX9Dynamic();
 
 	DX9::CompileShaders();
-	DX9::fbo_init();
+	DX9::fbo_init(d3d);
 
 	if (deviceEx && IsWin7OrLater()) {
 		deviceEx->SetMaximumFrameLatency(1);

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -67,19 +67,20 @@ static const char basic_vs[] =
 	"}\n";
 
 SimpleGLWindow::SimpleGLWindow(HWND wnd)
-	: hWnd_(wnd), valid_(false), drawProgram_(NULL), tex_(0), flags_(0), zoom_(false),
-	  dragging_(false), offsetX_(0), offsetY_(0) {
+	: hWnd_(wnd), valid_(false), drawProgram_(nullptr), tex_(0), flags_(0), zoom_(false),
+	  dragging_(false), offsetX_(0), offsetY_(0), reformatBuf_(nullptr) {
 	SetWindowLongPtr(wnd, GWLP_USERDATA, (LONG) this);
 }
 
 SimpleGLWindow::~SimpleGLWindow() {
-	if (drawProgram_ != NULL) {
+	if (drawProgram_ != nullptr) {
 		glsl_destroy(drawProgram_);
 	}
 	if (tex_) {
 		glDeleteTextures(1, &tex_);
 		glDeleteTextures(1, &checker_);
 	}
+	delete [] reformatBuf_;
 };
 
 void SimpleGLWindow::Initialize(u32 flags) {
@@ -204,12 +205,13 @@ void SimpleGLWindow::DrawChecker() {
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, indices);
 }
 
-void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
+void SimpleGLWindow::Draw(const u8 *data, int w, int h, bool flipped, Format fmt) {
 	wglMakeCurrent(hDC_, hGLRC_);
 
 	GLint components = GL_RGBA;
 	GLint memComponents = 0;
 	GLenum glfmt;
+	const u8 *finalData = data;
 	if (fmt == FORMAT_8888) {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		glfmt = GL_UNSIGNED_BYTE;
@@ -220,6 +222,15 @@ void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
 	} else if (fmt == FORMAT_FLOAT) {
 		glfmt = GL_FLOAT;
 		components = GL_RED;
+	} else if (fmt == FORMAT_24BIT_8X) {
+		glfmt = GL_UNSIGNED_INT;
+		components = GL_RED;
+		finalData = Reformat(data, fmt, w * h);
+	} else if (fmt == FORMAT_24X_8BIT) {
+		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+		glfmt = GL_UNSIGNED_BYTE;
+		components = GL_RED;
+		finalData = Reformat(data, fmt, w * h);
 	} else {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
 		if (fmt == FORMAT_4444) {
@@ -259,7 +270,7 @@ void SimpleGLWindow::Draw(u8 *data, int w, int h, bool flipped, Format fmt) {
 	}
 
 	glBindTexture(GL_TEXTURE_2D, tex_);
-	glTexImage2D(GL_TEXTURE_2D, 0, components, w, h, 0, memComponents, glfmt, data);
+	glTexImage2D(GL_TEXTURE_2D, 0, components, w, h, 0, memComponents, glfmt, finalData);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -421,6 +432,28 @@ bool SimpleGLWindow::ToggleZoom() {
 	Redraw();
 
 	return true;
+}
+
+const u8 *SimpleGLWindow::Reformat(const u8 *data, Format fmt, u32 numPixels) {
+	if (!reformatBuf_ || reformatBufSize_ < numPixels) {
+		delete [] reformatBuf_;
+		reformatBuf_ = new u32[numPixels];
+		reformatBufSize_ = numPixels;
+	}
+
+	const u32 *data32 = (const u32 *)data;
+	if (fmt == FORMAT_24BIT_8X) {
+		for (u32 i = 0; i < numPixels; ++i) {
+			reformatBuf_[i] = (data32[i] << 8) | ((data32[i] >> 16) & 0xFF);
+		}
+	} else if (fmt == FORMAT_24X_8BIT) {
+		u8 *buf8 = (u8 *)reformatBuf_;
+		for (u32 i = 0; i < numPixels; ++i) {
+			u32 v = (data32[i] >> 24) & 0xFF;
+			buf8[i] = v;
+		}
+	}
+	return (const u8 *)reformatBuf_;
 }
 
 SimpleGLWindow *SimpleGLWindow::GetFrom(HWND hwnd) {

--- a/Windows/GEDebugger/SimpleGLWindow.h
+++ b/Windows/GEDebugger/SimpleGLWindow.h
@@ -39,6 +39,8 @@ struct SimpleGLWindow {
 		FORMAT_FLOAT = 0x10,
 		FORMAT_16BIT = 0x11,
 		FORMAT_8BIT = 0x12,
+		FORMAT_24BIT_8X = 0x13,
+		FORMAT_24X_8BIT = 0x14,
 	};
 
 	enum Flags {
@@ -54,7 +56,7 @@ struct SimpleGLWindow {
 	~SimpleGLWindow();
 
 	void Clear();
-	void Draw(u8 *data, int w, int h, bool flipped = false, Format = FORMAT_8888);
+	void Draw(const u8 *data, int w, int h, bool flipped = false, Format = FORMAT_8888);
 	void Redraw(bool andSwap = true);
 	void Initialize(u32 flags);
 	static SimpleGLWindow *GetFrom(HWND hwnd);
@@ -101,6 +103,7 @@ protected:
 	bool DragContinue(int mouseX, int mouseY);
 	bool DragEnd(int mouseX, int mouseY);
 	bool ToggleZoom();
+	const u8 *Reformat(const u8 *data, Format fmt, u32 numPixels);
 
 	HWND hWnd_;
 	HDC hDC_;
@@ -127,4 +130,6 @@ protected:
 	// Offset to position the texture is drawn at.
 	int offsetX_;
 	int offsetY_;
+	u32 *reformatBuf_;
+	u32 reformatBufSize_;
 };


### PR DESCRIPTION
For me, no performance loss.  Allows the debugger to view it just fine, might allow blitting.

-[Unknown]
