### PR TITLE
Restart to d3d9/gles preserving arguments

### DIFF
--- a/Windows/OpenGLBase.cpp
+++ b/Windows/OpenGLBase.cpp
@@ -7,6 +7,7 @@
 #include "util/text/utf8.h"
 #include "i18n/i18n.h"
 
+#include "Windows/W32Util/Misc.h"
 #include "Windows/OpenGLBase.h"
 
 static HDC hDC;     // Private GDI Device Context
@@ -157,11 +158,7 @@ bool GL_Init(HWND window, std::string *error_message) {
 			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
 			g_Config.Save();
 
-			wchar_t moduleFilename[MAX_PATH];
-			GetModuleFileName(GetModuleHandle(NULL), moduleFilename, MAX_PATH);
-			ShellExecute(NULL, NULL, moduleFilename, NULL, NULL, SW_SHOW);
-
-			ExitProcess(0);
+			W32Util::ExitAndRestart();
 		}
 
 		// Avoid further error messages. Let's just bail, it's safe, and we can't continue.

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include <WinUser.h>
+#include <shellapi.h>
 #include "Misc.h"
 #include "util/text/utf8.h"
 #include <commctrl.h>
@@ -90,6 +91,24 @@ namespace W32Util
 		SetWindowPos(hwnd, style, 0,0,0,0, SWP_NOMOVE | SWP_NOSIZE);
 	}
 
+	void ExitAndRestart() {
+		// This preserves arguments (for example, config file) and working directory.
+
+		wchar_t moduleFilename[MAX_PATH];
+		wchar_t workingDirectory[MAX_PATH];
+		GetCurrentDirectoryW(MAX_PATH, workingDirectory);
+		wchar_t *cmdline = GetCommandLineW();
+		if (cmdline) {
+			cmdline = wcschr(cmdline, ' ');
+			if (cmdline) {
+				++cmdline;
+			}
+		}
+		GetModuleFileName(GetModuleHandle(NULL), moduleFilename, MAX_PATH);
+		ShellExecute(NULL, NULL, moduleFilename, cmdline, workingDirectory, SW_SHOW);
+
+		ExitProcess(0);
+	}
 }
 
 

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -10,6 +10,7 @@ namespace W32Util
 	BOOL CopyTextToClipboard(HWND hwnd, const char *text);
 	BOOL CopyTextToClipboard(HWND hwnd, const std::wstring &wtext);
 	void MakeTopMost(HWND hwnd, bool topMost);
+	void ExitAndRestart();
 }
 
 struct GenericListViewColumn

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -603,9 +603,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	LogManager::Shutdown();
 
 	if (g_Config.bRestartRequired) {
-		wchar_t moduleFilename[MAX_PATH];
-		GetModuleFileName(GetModuleHandle(NULL), moduleFilename, MAX_PATH);
-		ShellExecute(NULL, NULL, moduleFilename, NULL, NULL, SW_SHOW);
+		W32Util::ExitAndRestart();
 	}
 	return 0;
 }


### PR DESCRIPTION
I use a `-l` and would prefer it to restart with the param still set.  I think people who use `--config` or `--log` would also want this.

-[Unknown]
