### PR TITLE
Add x86 weight ToFloat handling for d3d9

### DIFF
--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -673,6 +673,8 @@ private:
 	void Jit_WriteMorphColor(int outOff, bool checkAlpha = true);
 	void Jit_AnyS8ToFloat(int srcoff);
 	void Jit_AnyS16ToFloat(int srcoff);
+	void Jit_AnyU8ToFloat(int srcoff);
+	void Jit_AnyU16ToFloat(int srcoff);
 	void Jit_AnyS8Morph(int srcoff, int dstoff);
 	void Jit_AnyS16Morph(int srcoff, int dstoff);
 	void Jit_AnyFloatMorph(int srcoff, int dstoff);

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -673,8 +673,8 @@ private:
 	void Jit_WriteMorphColor(int outOff, bool checkAlpha = true);
 	void Jit_AnyS8ToFloat(int srcoff);
 	void Jit_AnyS16ToFloat(int srcoff);
-	void Jit_AnyU8ToFloat(int srcoff);
-	void Jit_AnyU16ToFloat(int srcoff);
+	void Jit_AnyU8ToFloat(int srcoff, u32 bits = 32);
+	void Jit_AnyU16ToFloat(int srcoff, u32 bits = 64);
 	void Jit_AnyS8Morph(int srcoff, int dstoff);
 	void Jit_AnyS16Morph(int srcoff, int dstoff);
 	void Jit_AnyFloatMorph(int srcoff, int dstoff);

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -603,6 +603,8 @@ public:
 
 	void Jit_WeightsU8();
 	void Jit_WeightsU16();
+	void Jit_WeightsU8ToFloat();
+	void Jit_WeightsU16ToFloat();
 	void Jit_WeightsFloat();
 
 	void Jit_WeightsU8Skin();

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -365,10 +365,11 @@ void VertexDecoderJitCache::Jit_WeightsU8ToFloat() {
 	for (j = 0; j < dec_->nweights; j++) {
 		MOVZX(32, 8, tempReg1, MDisp(srcReg, dec_->weightoff + j));
 		CVTSI2SS(fpScratchReg, R(tempReg1));
+		MULSS(fpScratchReg, M(&by128));
 		MOVSS(MDisp(dstReg, dec_->decFmt.w0off + j * 4), fpScratchReg);
 	}
 	while (j & 3) {
-		MOV(32, MDisp(dstReg, dec_->decFmt.w0off + j * 4), Imm8(0));
+		MOV(32, MDisp(dstReg, dec_->decFmt.w0off + j * 4), Imm32(0));
 		j++;
 	}
 }
@@ -379,10 +380,11 @@ void VertexDecoderJitCache::Jit_WeightsU16ToFloat() {
 	for (j = 0; j < dec_->nweights; j++) {
 		MOVZX(32, 16, tempReg1, MDisp(srcReg, dec_->weightoff + j * 2));
 		CVTSI2SS(fpScratchReg, R(tempReg1));
+		MULSS(fpScratchReg, M(&by32768));
 		MOVSS(MDisp(dstReg, dec_->decFmt.w0off + j * 4), fpScratchReg);
 	}
 	while (j & 3) {
-		MOV(32, MDisp(dstReg, dec_->decFmt.w0off + j * 4), Imm8(0));
+		MOV(32, MDisp(dstReg, dec_->decFmt.w0off + j * 4), Imm32(0));
 		j++;
 	}
 }

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -511,23 +511,13 @@ void VertexDecoderJitCache::Jit_TcU16() {
 }
 
 void VertexDecoderJitCache::Jit_TcU8ToFloat() {
-	// TODO: The first five instructions could be done in 1 or 2 in SSE4
-	MOVZX(32, 8, tempReg1, MDisp(srcReg, dec_->tcoff));
-	MOVZX(32, 8, tempReg2, MDisp(srcReg, dec_->tcoff + 1));
-	CVTSI2SS(fpScratchReg, R(tempReg1));
-	CVTSI2SS(fpScratchReg2, R(tempReg2));
-	UNPCKLPS(fpScratchReg, R(fpScratchReg2));
-	MULPS(fpScratchReg, M(&by128));
-	MOVQ_xmm(MDisp(dstReg, dec_->decFmt.uvoff), fpScratchReg);
+	Jit_AnyU8ToFloat(dec_->tcoff, 16);
+	MOVQ_xmm(MDisp(dstReg, dec_->decFmt.uvoff), XMM3);
 }
 
 void VertexDecoderJitCache::Jit_TcU16ToFloat() {
-	PXOR(fpScratchReg2, R(fpScratchReg2));
-	MOVD_xmm(fpScratchReg, MDisp(srcReg, dec_->tcoff));
-	PUNPCKLWD(fpScratchReg, R(fpScratchReg2));
-	CVTDQ2PS(fpScratchReg, R(fpScratchReg));
-	MULPS(fpScratchReg, M(&by32768));
-	MOVQ_xmm(MDisp(dstReg, dec_->decFmt.uvoff), fpScratchReg);
+	Jit_AnyU16ToFloat(dec_->tcoff, 32);
+	MOVQ_xmm(MDisp(dstReg, dec_->decFmt.uvoff), XMM3);
 }
 
 void VertexDecoderJitCache::Jit_TcU16Double() {


### PR DESCRIPTION
Only x86, don't need it for 32-bit.  Also some tiny optimization of the standard method for > 4 weights, although it seems rare.

Should improve perf in Direct3D 9 for games using weights.

-[Unknown]
