### PR TITLE
Fix some problems in d3d depal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1302,9 +1302,8 @@ if(ARMV7)
 	set(GPU_NEON GPU/Common/TextureDecoderNEON.cpp)
 endif()
 add_library(GPU OBJECT
-	GPU/Common/DepalettizeShaderCommon.h
 	GPU/Common/DepalettizeShaderCommon.cpp
-	GPU/Common/FramebufferCommon.h
+	GPU/Common/DepalettizeShaderCommon.h
 	GPU/Common/FramebufferCommon.cpp
 	GPU/Common/FramebufferCommon.h
 	GPU/Common/GPUDebugInterface.h

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -15,8 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#pragma once
-
 #include <stdio.h>
 
 #include "Common/Log.h"

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -73,7 +73,7 @@ public:
 
 	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
-	void BindFramebufferColor(VirtualFramebuffer *framebuffer, bool skipCopy);
+	void BindFramebufferColor(VirtualFramebuffer *framebuffer, bool skipCopy = false);
 
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -859,9 +859,9 @@ void TextureCacheDX9::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebu
 			vp.Height = framebuffer->renderHeight;
 			pD3Ddevice->SetViewport(&vp);
 
-			fbo_bind_color_as_texture(depalFBO, 0);
-
 			pD3Ddevice->DrawIndexedPrimitiveUP(D3DPT_TRIANGLEFAN, 0, 4, 2, indices, D3DFMT_INDEX16, pos, (3 + 2) * sizeof(float));
+
+			fbo_bind_color_as_texture(depalFBO, 0);
 
 			dxstate.Restore();
 			framebufferManager_->RebindFramebuffer();

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -829,10 +829,10 @@ void TextureCacheDX9::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebu
 			fbo_bind_as_render_target(depalFBO);
 
 			static const float pos[12 + 8] = {
-				-1, -1, -1,  0, 0,
-				1, -1, -1,	   1, 0,
-				1, 1, -1,		 1, 1,
-				-1, 1, -1,		 0, 1,
+				-1, -1, -1,   0, 0,
+				1, -1, -1,    1, 0,
+				1, 1, -1,     1, 1,
+				-1, 1, -1,    0, 1,
 			};
 			static const u16 indices[4] = { 0, 1, 3, 2 };
 
@@ -874,24 +874,11 @@ void TextureCacheDX9::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebu
 			TexCacheEntry::Status alphaStatus = CheckAlpha(clutBuf_, getClutDestFormat(gstate.getClutPaletteFormat()), clutExtendedColors, clutExtendedColors, 1);
 			gstate_c.textureFullAlpha = alphaStatus == TexCacheEntry::STATUS_ALPHA_FULL;
 			gstate_c.textureSimpleAlpha = alphaStatus == TexCacheEntry::STATUS_ALPHA_SIMPLE;
-
 		} else {
 			entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
-			fbo_bind_color_as_texture(entry->framebuffer->fbo, 0);
+			framebufferManager_->BindFramebufferColor(framebuffer);
 
-			// For now, let's not bind FBOs that we know are off (invalidHint will be -1.)
-			// But let's still not use random memory.
-			if (entry->framebuffer->fbo) {
-				fbo_bind_color_as_texture(entry->framebuffer->fbo, 0);
-				// Keep the framebuffer alive.
-				// TODO: Dangerous if it sets a new one?
-				entry->framebuffer->last_frame_used = gpuStats.numFlips;
-			} else {
-				pD3Ddevice->SetTexture(0, NULL);
-				gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
-			}
-
-			gstate_c.textureFullAlpha = framebuffer->format == GE_FORMAT_565;
+			gstate_c.textureFullAlpha = framebuffer->drawnFormat == GE_FORMAT_565;
 			gstate_c.textureSimpleAlpha = gstate_c.textureFullAlpha;
 		}
 


### PR DESCRIPTION
Still doesn't work.  I'm not sure why.  Both commits I thought, "aha, I've got it."

I made the shader statically output red, and it doesn't render red, so it's not even drawing.  Debug says the vertex decl is wrong, but replacing SetFVF with `pD3Ddevice->SetVertexDeclaration(pFramebufferVertexDecl);` fixes that without fixing the rendering (still not drawing red.)

`DrawActiveTexture()` uses `DrawPrimitiveUP()`, so I tried that, no difference either.  The result seems to always be black.

-[Unknown]
