### PR TITLE
comment out display list debug window

### DIFF
--- a/Qt/Debugger/debugger_displaylist.cpp
+++ b/Qt/Debugger/debugger_displaylist.cpp
@@ -11,7 +11,8 @@
 #include "base/display.h"
 #include "mainwindow.h"
 #include "UI/HostTypes.h"
-#include "GPU/GLES/VertexDecoder.h"
+//commented out until someone bothers to maintain it
+//#include "GPU/GLES/VertexDecoder.h"
 
 Debugger_DisplayList::Debugger_DisplayList(DebugInterface *_cpu, MainWindow* mainWindow_, QWidget *parent) :
 	QDialog(parent),
@@ -1622,6 +1623,8 @@ void Debugger_DisplayList::on_zoompBtn_clicked()
 
 void Debugger_DisplayList::UpdateVertexInfo()
 {
+	//commented out until someone bothers to maintain it
+#if 0
 	ui->vertexData->clear();
 
 	QTreeWidgetItem* item = ui->vertexList->currentItem();
@@ -1691,6 +1694,7 @@ void Debugger_DisplayList::UpdateVertexInfo()
 	{
 		ui->vertexData->resizeColumnToContents(i);
 	}
+#endif
 }
 
 void Debugger_DisplayList::on_vertexList_itemClicked(QTreeWidgetItem *item, int column)

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -474,8 +474,9 @@ void MainWindow::createMenus()
 	debugMenu->addSeparator();
 	debugMenu->add(new MenuAction(this, SLOT(disasmAct()),    QT_TR_NOOP("Disassembly"), Qt::CTRL + Qt::Key_D))
 		->addDisableState(UISTATE_MENU);
-	debugMenu->add(new MenuAction(this, SLOT(dpyListAct()),   QT_TR_NOOP("Display List...")))
-		->addDisableState(UISTATE_MENU);
+	//commented out until someone bothers to maintain it
+	//debugMenu->add(new MenuAction(this, SLOT(dpyListAct()),   QT_TR_NOOP("Display List...")))
+	//	->addDisableState(UISTATE_MENU);
 	debugMenu->add(new MenuAction(this, SLOT(consoleAct()),   QT_TR_NOOP("Log Console")))
 		->addDisableState(UISTATE_MENU);
 	debugMenu->add(new MenuAction(this, SLOT(memviewAct()),   QT_TR_NOOP("Memory View")))


### PR DESCRIPTION
comment out the display list debug window in the QT version
because it's not maintained and currently causes compilation
errors because it was not updated to deal with the new GPU
backend

" fixes #6926 " for very liberal definitions of "fix"
