### PR TITLE
Try to match the initial atrac decode size

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1039,7 +1039,7 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 	} else {
 		DEBUG_LOG(ME, "sceAtracGetSoundSample(%i, %08x, %08x, %08x)", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
 		if (Memory::IsValidAddress(outEndSampleAddr))
-			Memory::Write_U32(atrac->endSample, outEndSampleAddr);
+			Memory::Write_U32(atrac->endSample - 1, outEndSampleAddr);
 		if (Memory::IsValidAddress(outLoopStartSampleAddr))
 			Memory::Write_U32(atrac->loopStartSample, outLoopStartSampleAddr);
 		if (Memory::IsValidAddress(outLoopEndSampleAddr))

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -676,6 +676,9 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 						skipSamples -= skipped;
 						numSamples = atrac->pFrame->nb_samples - skipped;
 
+						// If we're at the end, clamp to samples we want.  It always returns a full chunk.
+						numSamples = std::min((u32)atrac->endSample - (u32)atrac->currentSample, numSamples);
+
 						if (skipped > 0 && numSamples == 0) {
 							// Wait for the next one.
 							got_frame = 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -695,10 +695,8 @@ u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int 
 
 u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr) {
 	int ret = -1;
-	if (!Memory::IsValidAddress(outAddr)) {
-		ERROR_LOG(ME, "%08x=sceAtracDecodeData(%i, %08x, ...): Bad out addr, skipping", ret, atracID, outAddr);
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
-	}
+
+	// Note that outAddr being null is completely valid here, used to skip data.
 
 	u32 numSamples = 0;
 	u32 finish = 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -956,10 +956,18 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 		if (atrac->currentSample >= atrac->endSample) {
 			if (Memory::IsValidAddress(outNAddr))
 				Memory::Write_U32(0, outNAddr);
-			return ATRAC_ERROR_ALL_DATA_DECODED;
+			return 0;
 		} else {
-			u32 numSamples = atrac->endSample - atrac->currentSample;
 			u32 atracSamplesPerFrame = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
+			// Some kind of header size?
+			u32 firstOffsetExtra = atrac->codecType == PSP_CODEC_AT3PLUS ? 368 : 69;
+			// It seems like the PSP aligns the sample position to 0x800...?
+			u32 skipSamples = atrac->firstSampleoffset + firstOffsetExtra;
+			u32 firstSamples = (atracSamplesPerFrame - skipSamples) % atracSamplesPerFrame;
+			u32 numSamples = atrac->endSample - atrac->currentSample;
+			if (atrac->currentSample == 0) {
+				numSamples = firstSamples;
+			}
 			if (numSamples > atracSamplesPerFrame)
 				numSamples = atracSamplesPerFrame;
 			if (Memory::IsValidAddress(outNAddr))

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1663,7 +1663,7 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 	context->info.samplesPerChan = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
 	context->info.sampleSize = atrac->atracBytesPerFrame;
 	context->info.numChan = atrac->atracChannels;
-	context->info.dataOff = atrac->firstSampleoffset;
+	context->info.dataOff = atrac->dataOff;
 	context->info.endSample = atrac->endSample;
 	context->info.dataEnd = atrac->first.filesize;
 	context->info.curOff = atrac->first.size;
@@ -1815,6 +1815,7 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 			}
 
 			atrac->firstSampleoffset = headersize;
+			atrac->dataOff = headersize;
 			atrac->first.size = headersize;
 			atrac->first.filesize = headersize + atrac->atracBytesPerFrame;
 			atrac->data_buf = new u8[atrac->first.filesize];
@@ -1839,6 +1840,7 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 			}
 
 			atrac->firstSampleoffset = headersize;
+			atrac->dataOff = headersize;
 			atrac->first.size = headersize;
 			atrac->first.filesize = headersize + atrac->atracBytesPerFrame;
 			atrac->data_buf = new u8[atrac->first.filesize];

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -66,6 +66,6 @@ typedef struct
 
 // provide some decoder interface
 
-u32 _AtracAddStreamData(int atracID, u8 *buf, u32 bytesToAdd);
-u32 _AtracDecodeData(int atracID, u8* outbuf, u32 *SamplesNum, u32* finish, int *remains);
+u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
+u32 _AtracDecodeData(int atracID, u8* outbuf, u32 outbufPtr, u32 *SamplesNum, u32* finish, int *remains);
 int _AtracGetIDByContext(u32 contextAddr);

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -564,7 +564,7 @@ u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr, int at
 	DEBUG_LOG_REPORT(SCESAS, "__sceSasConcatenateATRAC3(%08x, %i, %08x, %i)", core, voiceNum, atrac3DataAddr, atrac3DataLength);
 	SasVoice &v = sas->voices[voiceNum];
 	if (Memory::IsValidAddress(atrac3DataAddr))
-		v.atrac3.addStreamData(Memory::GetPointer(atrac3DataAddr), atrac3DataLength);
+		v.atrac3.addStreamData(atrac3DataAddr, atrac3DataLength);
 	return 0;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -188,7 +188,7 @@ int SasAtrac3::getNextSamples(s16* outbuf, int wantedSamples) {
 		u32 numSamples = 0;
 		int remains = 0;
 		static s16 buf[0x800];
-		_AtracDecodeData(atracID, (u8*)buf, &numSamples, &finish, &remains);
+		_AtracDecodeData(atracID, (u8*)buf, 0, &numSamples, &finish, &remains);
 		if (numSamples > 0)
 			sampleQueue->push((u8*)buf, numSamples * sizeof(s16));
 		else
@@ -198,9 +198,9 @@ int SasAtrac3::getNextSamples(s16* outbuf, int wantedSamples) {
 	return finish;
 }
 
-int SasAtrac3::addStreamData(u8* buf, u32 addbytes) {
+int SasAtrac3::addStreamData(u32 bufPtr, u32 addbytes) {
 	if (atracID > 0) {
-		_AtracAddStreamData(atracID, buf, addbytes);
+		_AtracAddStreamData(atracID, bufPtr, addbytes);
 	}
 	return 0;
 }

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -126,7 +126,7 @@ public:
 	~SasAtrac3() { if (sampleQueue) delete sampleQueue; }
 	int setContext(u32 context);
 	int getNextSamples(s16* outbuf, int wantedSamples);
-	int addStreamData(u8* buf, u32 addbytes);
+	int addStreamData(u32 bufPtr, u32 addbytes);
 	void DoState(PointerWrap &p);
 
 private:


### PR DESCRIPTION
This ~~uses a buffer~~ skips samples to align the output the same way the PSP aligns its output.  Causes the audio/atrac/decode test to pass (though it needs to test more things.)

This may improve any game that accidentally relies on the first decode pass writing less data, and should improve how well the number of frames from decode match.  I think there was a game JPCSP recently fixed that we suspected this was the case for?

-[Unknown]
