### PR TITLE
d3d9: Emulate some logic ops with blending

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -44,7 +44,7 @@
 //   * Smaller than the audio, sliding with a loop at the end (state STREAMED WITH LOOP AT END = 5)
 //   * Smaller with a second buffer to help with a loop in the middle (state STREAMED WITH SECOND BUF = 6)
 //   * Not managed, decoding using "low level" manual looping etc. (LOW LEVEL = 8)
-//   * Not managed, reseved externally - possibly by sceSas - through low level (RESERVED = 16)
+//   * Not managed, reserved externally - possibly by sceSas - through low level (RESERVED = 16)
 
 #define ATRAC_ERROR_API_FAIL                 0x80630002
 #define ATRAC_ERROR_NO_ATRACID               0x80630003

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -25,6 +25,7 @@
 #include "GPU/Common/IndexGenerator.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Directx9/PixelShaderGeneratorDX9.h"
 
 struct DecVtxFormat;
 
@@ -183,7 +184,7 @@ private:
 	void ApplyDrawState(int prim);
 	void ApplyDrawStateLate();
 	void ApplyBlendState();
-	void ApplyStencilReplaceOnly();
+	void ApplyStencilReplaceAndLogicOp(ReplaceAlphaType replaceAlphaWithStencil);
 	bool ApplyShaderBlending();
 	inline void ResetShaderBlending();
 

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -23,6 +23,7 @@
 #include "GPU/Common/IndexGenerator.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/GLES/FragmentShaderGenerator.h"
 #include "gfx/gl_common.h"
 #include "gfx/gl_lost_manager.h"
 
@@ -180,7 +181,7 @@ private:
 	void ApplyDrawState(int prim);
 	void ApplyDrawStateLate();
 	void ApplyBlendState();
-	void ApplyStencilReplaceOnly();
+	void ApplyStencilReplaceAndLogicOp(ReplaceAlphaType replaceAlphaWithStencil);
 	bool ApplyShaderBlending();
 	inline void ResetShaderBlending();
 	GLuint AllocateBuffer();


### PR DESCRIPTION
This makes Brave Story's intro visible.  Also add for GLES2/GLES3, but doesn't seem to work on GLES2 (at least on my phone, not sure why...)

Improves #6916 anyhow.  Will mostly fix it once depal is merged (didn't want to conflict that by modifying the texture cache fbo_bind_color_as_texture() part.)

Even with that, there are a couple weird artifacts still, not sure if it's position/texel alignment or something.

-[Unknown]
