### PR TITLE
Correct some minor issues with atrac looping

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -440,6 +440,7 @@ int Atrac::Analyze() {
 	first.filesize = Memory::Read_U32(first.addr + 4) + 8;
 
 	u32 offset = 12;
+	int loopFirstSampleOffset = 0;
 	firstSampleoffset = 0;
 
 	this->decodeEnd = first.filesize;
@@ -471,9 +472,13 @@ int Atrac::Analyze() {
 			break;
 		case FACT_CHUNK_MAGIC:
 			{
-				if (chunkSize >= 8) {
-					endSample = Memory::Read_U32(first.addr + offset);
-					firstSampleoffset = Memory::Read_U32(first.addr + offset + 4);
+				endSample = Memory::Read_U32(first.addr + offset);
+				firstSampleoffset = Memory::Read_U32(first.addr + offset + 4);
+				if (chunkSize >= 12) {
+					// Seems like this indicates it's got a separate offset for loops.
+					loopFirstSampleOffset = Memory::Read_U32(first.addr + offset + 8);
+				} else if (chunkSize >= 8) {
+					loopFirstSampleOffset = firstSampleoffset;
 				}
 			}
 			break;
@@ -489,8 +494,8 @@ int Atrac::Analyze() {
 					for (int i = 0; i < loopinfoNum; i++, loopinfoAddr += 24) {
 						loopinfo[i].cuePointID = Memory::Read_U32(loopinfoAddr);
 						loopinfo[i].type = Memory::Read_U32(loopinfoAddr + 4);
-						loopinfo[i].startSample = Memory::Read_U32(loopinfoAddr + 8) - firstSampleoffset;
-						loopinfo[i].endSample = Memory::Read_U32(loopinfoAddr + 12) - firstSampleoffset;
+						loopinfo[i].startSample = Memory::Read_U32(loopinfoAddr + 8) - loopFirstSampleOffset;
+						loopinfo[i].endSample = Memory::Read_U32(loopinfoAddr + 12) - loopFirstSampleOffset;
 						loopinfo[i].fraction = Memory::Read_U32(loopinfoAddr + 16);
 						loopinfo[i].playCount = Memory::Read_U32(loopinfoAddr + 20);
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -737,7 +737,7 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 			atrac->decodePos = atrac->getDecodePosBySample(atrac->currentSample);
 
 			int finishFlag = 0;
-			if (atrac->loopNum != 0 && (atrac->currentSample + (int)atracSamplesPerFrame > atrac->loopEndSample ||
+			if (atrac->loopNum != 0 && (atrac->currentSample > atrac->loopEndSample ||
 				(numSamples == 0 && atrac->first.size >= atrac->first.filesize))) {
 				atrac->currentSample = atrac->loopStartSample;
 				if (atrac->loopNum > 0)


### PR DESCRIPTION
We were looping a frame too early, and there are some files with different looping information it seems.

Also, the MOut functions refuse to function on stereo atrac files, and return a special error for that case.

Fixes #6953.

-[Unknown]
