### PR TITLE
Properly handle atrac packets with multiple frames

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1255,6 +1255,7 @@ int __AtracSetContext(Atrac *atrac) {
 		atrac->pCodecCtx->channel_layout = AV_CH_LAYOUT_MONO;
 
 	// open codec
+	atrac->pCodecCtx->request_sample_fmt = AV_SAMPLE_FMT_S16;
 	if ((ret = avcodec_open2(atrac->pCodecCtx, pCodec, NULL)) < 0) {
 		ERROR_LOG(ME, "avcodec_open2: Cannot open audio decoder %d", ret);
 		return -1;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -360,7 +360,9 @@ struct Atrac {
 		if (bytes_read == AVERROR_PATCHWELCOME) {
 			ERROR_LOG(ME, "Unsupported feature in ATRAC audio.");
 			// Let's try the next packet.
-			packet->size = 0;
+			if (packet == decodePacket) {
+				packet->size = 0;
+			}
 			// TODO: Or actually, should we return a blank frame and pretend it worked?
 			return ATDECODE_FEEDME;
 		} else if (bytes_read < 0) {
@@ -369,8 +371,10 @@ struct Atrac {
 			return ATDECODE_FAILED;
 		}
 
-		packet->size -= bytes_read;
-		packet->data += bytes_read;
+		if (packet == decodePacket) {
+			packet->size -= bytes_read;
+			packet->data += bytes_read;
+		}
 		return got_frame ? ATDECODE_GOTFRAME : ATDECODE_FEEDME;
 	}
 #endif // USE_FFMPEG

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -335,7 +335,7 @@ struct Atrac {
 		if (packet->size < (int)atracBytesPerFrame) {
 			// Whoops, we have a packet that is smaller than a frame.  Let's meld a new one.
 			u32 initialSize = packet->size;
-			u32 needed = atracBytesPerFrame - initialSize;
+			int needed = atracBytesPerFrame - initialSize;
 			av_init_packet(&tempPacket);
 			av_copy_packet(&tempPacket, packet);
 			av_grow_packet(&tempPacket, needed);
@@ -350,6 +350,7 @@ struct Atrac {
 					packet->data += needed;
 				}
 			}
+			decodePacket = &tempPacket;
 		}
 
 		int got_frame = 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -311,6 +311,8 @@ struct Atrac {
 	void SeekToSample(int sample) {
 		s64 seek_pos = (s64)sample;
 		av_seek_frame(pFormatCtx, audio_stream_index, seek_pos, 0);
+		// Discard any pending packet data.
+		packet->size = 0;
 	}
 
 	bool FillPacket() {


### PR DESCRIPTION
I thought I'd tried this before and it didn't work, but I think I missed a free packet.  This clears it up, just makes the packet long lived.

Now the first few frames of data from atrac decode actually mostly match the correct data, which may get rid of garbage in the start of music and effects (I think there was some game where it affected voices?)

-[Unknown]
