### PR TITLE
x86 JIT: Sacrifice a register for a pointer to the MIPS context. Shrinks emitted x86 code considerably.

### DIFF
--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -26,6 +26,12 @@
 #error "Don't build this on arm."
 #endif
 
+#ifdef _M_X64
+#define PTRBITS 64
+#else
+#define PTRBITS 32
+#endif
+
 namespace Gen
 {
 

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -103,6 +103,14 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 
 			dispatcherNoCheck = GetCodePtr();
 
+			// TODO: Find a less costly place to put this (or multiple..)
+#ifdef _M_X64
+			// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but no VFPUR)
+			MOV(64, R(CTXREG), ImmPtr(&mips->f[0]));
+#else
+			MOV(32, R(CTXREG), ImmPtr(&mips->f[0]));
+#endif
+
 			MOV(32, R(EAX), M(&mips->pc));
 #ifdef _M_IX86
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -103,13 +103,9 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 
 			dispatcherNoCheck = GetCodePtr();
 
-			// TODO: Find a less costly place to put this (or multiple..)
-#ifdef _M_X64
+			// TODO: Find a less costly place to put this (or multiple..)?
 			// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but no VFPUR)
-			MOV(64, R(CTXREG), ImmPtr(&mips->f[0]));
-#else
-			MOV(32, R(CTXREG), ImmPtr(&mips->f[0]));
-#endif
+			MOV(PTRBITS, R(CTXREG), ImmPtr(&mips->f[0]));
 
 			MOV(32, R(EAX), M(&mips->pc));
 #ifdef _M_IX86

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -33,12 +33,12 @@ static const int allocationOrder[] =
 	// On x64, RCX and RDX are the first args.  CallProtectedFunction() assumes they're not regcached.
 #ifdef _M_X64
 #ifdef _WIN32
-	RSI, RDI, R13, R14, R8, R9, R10, R11, R12,
+	RSI, RDI, R13, R8, R9, R10, R11, R12,
 #else
-	RBP, R13, R14, R8, R9, R10, R11, R12,
+	RBP, R13, R8, R9, R10, R11, R12,
 #endif
 #elif _M_IX86
-	ESI, EDI, EBP, EDX, ECX,  // Let's try to free up EBX as well.
+	ESI, EDI, EDX, ECX,  // Let's try to free up EBX as well.
 #endif
 };
 
@@ -218,8 +218,9 @@ const int *GPRRegCache::GetAllocationOrder(int &count) {
 
 
 OpArg GPRRegCache::GetDefaultLocation(MIPSGPReg reg) const {
-	if (reg < 32)
-		return M(&mips->r[reg]);
+	if (reg < 32) {
+		return MDisp(CTXREG, -128 + reg * 4);
+	}
 	switch (reg) {
 	case MIPS_REG_HI:
 		return M(&mips->hi);

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -31,6 +31,12 @@ using namespace Gen;
 
 #define NUM_MIPS_GPRS 36
 
+#ifdef _M_X64
+#define CTXREG R14
+#else
+#define CTXREG EBP
+#endif
+
 struct MIPSCachedReg {
 	OpArg location;
 	bool away;  // value not in source register

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -20,6 +20,7 @@
 #include "Common/Log.h"
 #include "Common/x64Emitter.h"
 #include "Core/MIPS/MIPSAnalyst.h"
+#include "Core/MIPS/x86/RegCache.h"
 #include "Core/MIPS/x86/RegCacheFPU.h"
 
 u32 FPURegCache::tempValues[NUM_TEMPS];
@@ -215,7 +216,7 @@ void FPURegCache::Flush() {
 
 OpArg FPURegCache::GetDefaultLocation(int reg) const {
 	if (reg < 32) {
-		return M(&mips->f[reg]);
+		return MDisp(CTXREG, reg * 4);
 	} else if (reg < 32 + 128) {
 		return M(&mips->v[voffset[reg - 32]]);
 	} else {

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -150,13 +150,6 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_Color5551Morph, &VertexDecoderJitCache::Jit_Color5551Morph},
 };
 
-// TODO: This should probably be global...
-#ifdef _M_X64
-#define PTRBITS 64
-#else
-#define PTRBITS 32
-#endif
-
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 	dec_ = &dec;
 	const u8 *start = this->GetCodePtr();


### PR DESCRIPTION
Nice in 64-bit, but might be a bit too much in 32-bit though... Needs testing and benching.
