### PR TITLE
Avoid emitting rounding mode code when not needed

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1148,10 +1148,8 @@ void __KernelThreadingInit()
 
 	// Yeah, this is straight out of JPCSP, I should be ashamed.
 	const static u32_le idleThreadCode[] = {
-		MIPS_MAKE_ADDIU(MIPS_REG_A0, MIPS_REG_ZERO, 0),
 		MIPS_MAKE_LUI(MIPS_REG_RA, 0x0800),
 		MIPS_MAKE_JR_RA(),
-		//MIPS_MAKE_SYSCALL("ThreadManForUser", "sceKernelDelayThread"),
 		MIPS_MAKE_SYSCALL("FakeSysCalls", "_sceKernelIdle"),
 		MIPS_MAKE_BREAK(0),
 	};

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -114,9 +114,9 @@ void Jit::GenerateFixedCode()
 	MovToPC(R0);
 	outerLoop = GetCodePtr();
 		SaveDowncount();
-		RestoreRoundingMode();
+		RestoreRoundingMode(true);
 		QuickCallFunction(R0, &CoreTiming::Advance);
-		ApplyRoundingMode();
+		ApplyRoundingMode(true);
 		RestoreDowncount();
 		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
 
@@ -175,9 +175,9 @@ void Jit::GenerateFixedCode()
 
 			// No block found, let's jit
 			SaveDowncount();
-			RestoreRoundingMode();
+			RestoreRoundingMode(true);
 			QuickCallFunction(R2, (void *)&JitAt);
-			ApplyRoundingMode();
+			ApplyRoundingMode(true);
 			RestoreDowncount();
 
 			B(dispatcherNoCheck); // no point in special casing this
@@ -199,7 +199,7 @@ void Jit::GenerateFixedCode()
 	}
 
 	SaveDowncount();
-	RestoreRoundingMode();
+	RestoreRoundingMode(true);
 
 	ADD(R_SP, R_SP, 4);
 

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -114,9 +114,9 @@ void Jit::GenerateFixedCode()
 	MovToPC(R0);
 	outerLoop = GetCodePtr();
 		SaveDowncount();
-		ClearRoundingMode();
+		RestoreRoundingMode();
 		QuickCallFunction(R0, &CoreTiming::Advance);
-		SetRoundingMode();
+		ApplyRoundingMode();
 		RestoreDowncount();
 		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
 
@@ -175,9 +175,9 @@ void Jit::GenerateFixedCode()
 
 			// No block found, let's jit
 			SaveDowncount();
-			ClearRoundingMode();
+			RestoreRoundingMode();
 			QuickCallFunction(R2, (void *)&JitAt);
-			SetRoundingMode();
+			ApplyRoundingMode();
 			RestoreDowncount();
 
 			B(dispatcherNoCheck); // no point in special casing this
@@ -199,7 +199,7 @@ void Jit::GenerateFixedCode()
 	}
 
 	SaveDowncount();
-	ClearRoundingMode();
+	RestoreRoundingMode();
 
 	ADD(R_SP, R_SP, 4);
 

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -538,7 +538,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	// If we're in a delay slot, this is off by one.
 	const int offset = js.inDelaySlot ? -1 : 0;
 	WriteDownCount(offset);
-	ClearRoundingMode();
+	RestoreRoundingMode();
 	js.downcountAmount = -offset;
 
 	// TODO: Maybe discard v0, v1, and some temps?  Definitely at?
@@ -558,7 +558,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 		gpr.SetRegImm(R0, op.encoding);
 		QuickCallFunction(R1, (void *)&CallSyscall);
 	}
-	SetRoundingMode();
+	ApplyRoundingMode();
 	RestoreDowncount();
 
 	WriteSyscallExit();

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -67,9 +67,10 @@ void Jit::BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	bool immBranch = false;
-	bool immBranchNotTaken = false;
+	bool immBranchTaken = false;
 	if (gpr.IsImm(rs) && gpr.IsImm(rt)) {
 		// The cc flags are opposites: when NOT to take the branch.
+		bool immBranchNotTaken;
 		s32 rsImm = (s32)gpr.GetImm(rs);
 		s32 rtImm = (s32)gpr.GetImm(rt);
 
@@ -80,10 +81,11 @@ void Jit::BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSRTComp().");
 		}
 		immBranch = true;
+		immBranchTaken = !immBranchNotTaken;
 	}
 
 	if (jo.immBranches && immBranch && js.numInstructions < jo.continueMaxInstructions) {
-		if (immBranchNotTaken) {
+		if (!immBranchTaken) {
 			// Skip the delay slot if likely, otherwise it'll be the next instruction.
 			if (likely)
 				js.compilerPC += 4;
@@ -102,52 +104,64 @@ void Jit::BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC+4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rt, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
-	if (!likely && delaySlotIsNice)
-		CompileDelaySlot(DELAYSLOT_NICE);
 
-	// We might be able to flip the condition (EQ/NEQ are easy.)
-	const bool canFlip = cc == CC_EQ || cc == CC_NEQ;
-
-	Operand2 op2;
-	bool negated;
-	if (gpr.IsImm(rt) && TryMakeOperand2_AllowNegation(gpr.GetImm(rt), op2, &negated)) {
-		gpr.MapReg(rs);
-		if (!negated)
-			CMP(gpr.R(rs), op2);
-		else
-			CMN(gpr.R(rs), op2);
-	} else {
-		if (gpr.IsImm(rs) && TryMakeOperand2_AllowNegation(gpr.GetImm(rs), op2, &negated) && canFlip) {
-			gpr.MapReg(rt);
-			if (!negated)
-				CMP(gpr.R(rt), op2);
-			else
-				CMN(gpr.R(rt), op2);
-		} else {
-			gpr.MapInIn(rs, rt);
-			CMP(gpr.R(rs), gpr.R(rt));
-		}
-	}
-
-	ArmGen::FixupBranch ptr;
-	if (!likely) {
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+	if (immBranch) {
+		// Continuing is handled above, this is just static jumping.
+		if (immBranchTaken || !likely)
+			CompileDelaySlot(DELAYSLOT_FLUSH);
 		else
 			FlushAll();
-		ptr = B_CC(cc);
+
+		const u32 destAddr = immBranchTaken ? targetAddr : js.compilerPC + 8;
+		WriteExit(destAddr, js.nextExit++);
 	} else {
-		FlushAll();
-		ptr = B_CC(cc);
-		CompileDelaySlot(DELAYSLOT_FLUSH);
+		if (!likely && delaySlotIsNice)
+			CompileDelaySlot(DELAYSLOT_NICE);
+
+		// We might be able to flip the condition (EQ/NEQ are easy.)
+		const bool canFlip = cc == CC_EQ || cc == CC_NEQ;
+
+		Operand2 op2;
+		bool negated;
+		if (gpr.IsImm(rt) && TryMakeOperand2_AllowNegation(gpr.GetImm(rt), op2, &negated)) {
+			gpr.MapReg(rs);
+			if (!negated)
+				CMP(gpr.R(rs), op2);
+			else
+				CMN(gpr.R(rs), op2);
+		} else {
+			if (gpr.IsImm(rs) && TryMakeOperand2_AllowNegation(gpr.GetImm(rs), op2, &negated) && canFlip) {
+				gpr.MapReg(rt);
+				if (!negated)
+					CMP(gpr.R(rt), op2);
+				else
+					CMN(gpr.R(rt), op2);
+			} else {
+				gpr.MapInIn(rs, rt);
+				CMP(gpr.R(rs), gpr.R(rt));
+			}
+		}
+
+		ArmGen::FixupBranch ptr;
+		if (!likely) {
+			if (!delaySlotIsNice)
+				CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+			else
+				FlushAll();
+			ptr = B_CC(cc);
+		} else {
+			FlushAll();
+			ptr = B_CC(cc);
+			CompileDelaySlot(DELAYSLOT_FLUSH);
+		}
+
+		// Take the branch
+		WriteExit(targetAddr, js.nextExit++);
+
+		SetJumpTarget(ptr);
+		// Not taken
+		WriteExit(js.compilerPC + 8, js.nextExit++);
 	}
-
-	// Take the branch
-	WriteExit(targetAddr, js.nextExit++);
-
-	SetJumpTarget(ptr);
-	// Not taken
-	WriteExit(js.compilerPC+8, js.nextExit++);
 
 	js.compiling = false;
 }
@@ -164,9 +178,10 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, ArmGen::CCFlags cc, bool andLink, bool
 	u32 targetAddr = js.compilerPC + offset + 4;
 
 	bool immBranch = false;
-	bool immBranchNotTaken = false;
+	bool immBranchTaken = false;
 	if (gpr.IsImm(rs)) {
 		// The cc flags are opposites: when NOT to take the branch.
+		bool immBranchNotTaken;
 		s32 imm = (s32)gpr.GetImm(rs);
 
 		switch (cc)
@@ -178,10 +193,11 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, ArmGen::CCFlags cc, bool andLink, bool
 		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSZeroComp().");
 		}
 		immBranch = true;
+		immBranchTaken = !immBranchNotTaken;
 	}
 
 	if (jo.immBranches && immBranch && js.numInstructions < jo.continueMaxInstructions) {
-		if (immBranchNotTaken) {
+		if (!immBranchTaken) {
 			// Skip the delay slot if likely, otherwise it'll be the next instruction.
 			if (likely)
 				js.compilerPC += 4;
@@ -203,40 +219,54 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, ArmGen::CCFlags cc, bool andLink, bool
 	MIPSOpcode delaySlotOp = Memory::Read_Instruction(js.compilerPC + 4);
 	bool delaySlotIsNice = IsDelaySlotNiceReg(op, delaySlotOp, rs);
 	CONDITIONAL_NICE_DELAYSLOT;
-	if (!likely && delaySlotIsNice)
-		CompileDelaySlot(DELAYSLOT_NICE);
 
-	gpr.MapReg(rs);
-	CMP(gpr.R(rs), Operand2(0, TYPE_IMM));
-
-	ArmGen::FixupBranch ptr;
-	if (!likely)
-	{
-		if (!delaySlotIsNice)
-			CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+	if (immBranch) {
+		// Continuing is handled above, this is just static jumping.
+		if (immBranchTaken && andLink)
+			gpr.SetImm(MIPS_REG_RA, js.compilerPC + 8);
+		if (immBranchTaken || !likely)
+			CompileDelaySlot(DELAYSLOT_FLUSH);
 		else
 			FlushAll();
-		ptr = B_CC(cc);
-	}
-	else
-	{
-		FlushAll();
-		ptr = B_CC(cc);
-		CompileDelaySlot(DELAYSLOT_FLUSH);
-	}
 
-	// Take the branch
-	if (andLink)
-	{
-		gpr.SetRegImm(SCRATCHREG1, js.compilerPC + 8);
-		STR(SCRATCHREG1, CTXREG, MIPS_REG_RA * 4);
+		const u32 destAddr = immBranchTaken ? targetAddr : js.compilerPC + 8;
+		WriteExit(destAddr, js.nextExit++);
+	} else {
+		if (!likely && delaySlotIsNice)
+			CompileDelaySlot(DELAYSLOT_NICE);
+
+		gpr.MapReg(rs);
+		CMP(gpr.R(rs), Operand2(0, TYPE_IMM));
+
+		ArmGen::FixupBranch ptr;
+		if (!likely)
+		{
+			if (!delaySlotIsNice)
+				CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
+			else
+				FlushAll();
+			ptr = B_CC(cc);
+		}
+		else
+		{
+			FlushAll();
+			ptr = B_CC(cc);
+			CompileDelaySlot(DELAYSLOT_FLUSH);
+		}
+
+		// Take the branch
+		if (andLink)
+		{
+			gpr.SetRegImm(SCRATCHREG1, js.compilerPC + 8);
+			STR(SCRATCHREG1, CTXREG, MIPS_REG_RA * 4);
+		}
+
+		WriteExit(targetAddr, js.nextExit++);
+
+		SetJumpTarget(ptr);
+		// Not taken
+		WriteExit(js.compilerPC + 8, js.nextExit++);
 	}
-
-	WriteExit(targetAddr, js.nextExit++);
-
-	SetJumpTarget(ptr);
-	// Not taken
-	WriteExit(js.compilerPC + 8, js.nextExit++);
 	js.compiling = false;
 }
 

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -420,6 +420,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				AND(gpr.R(MIPS_REG_FPCOND), SCRATCHREG1, Operand2(1));
 #endif
 			}
+			UpdateRoundingMode();
 			ApplyRoundingMode();
 		} else {
 			Comp_Generic(op);

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -280,7 +280,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		VNEG(fpr.R(fd), fpr.R(fs));
 		break;
 	case 12: //FsI(fd) = (int)floorf(F(fs)+0.5f); break; //round.w.s
-		ClearRoundingMode();
+		RestoreRoundingMode();
 		fpr.MapDirtyIn(fd, fs);
 		VCVT(fpr.R(fd), fpr.R(fs), TO_INT | IS_SIGNED);
 		break;
@@ -295,7 +295,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		break;
 	case 14: //FsI(fd) = (int)ceilf (F(fs));      break; //ceil.w.s
 	{
-		ClearRoundingMode();
+		RestoreRoundingMode();
 		fpr.MapDirtyIn(fd, fs);
 		VMRS(SCRATCHREG2);
 		// Assume we're always in round-to-nearest mode.
@@ -313,7 +313,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	}
 	case 15: //FsI(fd) = (int)floorf(F(fs));      break; //floor.w.s
 	{
-		ClearRoundingMode();
+		RestoreRoundingMode();
 		fpr.MapDirtyIn(fd, fs);
 		VMRS(SCRATCHREG2);
 		// Assume we're always in round-to-nearest mode.
@@ -399,8 +399,8 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //ctc1
 		if (fs == 31) {
-			// Must clear before setting, since SetRoundingMode() assumes it was cleared.
-			ClearRoundingMode();
+			// Must clear before setting, since ApplyRoundingMode() assumes it was cleared.
+			RestoreRoundingMode();
 			bool wasImm = gpr.IsImm(rt);
 			if (wasImm) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
@@ -420,7 +420,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				AND(gpr.R(MIPS_REG_FPCOND), SCRATCHREG1, Operand2(1));
 #endif
 			}
-			SetRoundingMode();
+			ApplyRoundingMode();
 		} else {
 			Comp_Generic(op);
 		}

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -192,8 +192,8 @@ private:
 
 	void WriteDownCount(int offset = 0);
 	void WriteDownCountR(ARMReg reg);
-	void ClearRoundingMode();
-	void SetRoundingMode();
+	void RestoreRoundingMode();
+	void ApplyRoundingMode();
 	void MovFromPC(ARMReg r);
 	void MovToPC(ARMReg r);
 

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -192,8 +192,9 @@ private:
 
 	void WriteDownCount(int offset = 0);
 	void WriteDownCountR(ARMReg reg);
-	void RestoreRoundingMode();
-	void ApplyRoundingMode();
+	void RestoreRoundingMode(bool force = false);
+	void ApplyRoundingMode(bool force = false);
+	void UpdateRoundingMode();
 	void MovFromPC(ARMReg r);
 	void MovToPC(ARMReg r);
 

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -55,7 +55,9 @@ namespace MIPSComp {
 		};
 
 		JitState()
-			: startDefaultPrefix(true),
+			: hasSetRounding(0),
+			lastSetRounding(0),
+			startDefaultPrefix(true),
 			prefixSFlag(PREFIX_UNKNOWN),
 			prefixTFlag(PREFIX_UNKNOWN),
 			prefixDFlag(PREFIX_UNKNOWN) {}
@@ -71,6 +73,9 @@ namespace MIPSComp {
 		int numInstructions;
 		bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
 		JitBlock *curBlock;
+
+		u8 hasSetRounding;
+		u8 lastSetRounding;
 
 		// VFPU prefix magic
 		bool startDefaultPrefix;

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -77,9 +77,9 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 #endif
 
 	outerLoop = GetCodePtr();
-		jit->ClearRoundingMode(this);
+		jit->RestoreRoundingMode(this);
 		ABI_CallFunction(reinterpret_cast<void *>(&CoreTiming::Advance));
-		jit->SetRoundingMode(this);
+		jit->ApplyRoundingMode(this);
 		FixupBranch skipToRealDispatch = J(); //skip the sync and compare first time
 
 		dispatcherCheckCoreState = GetCodePtr();
@@ -134,9 +134,9 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			SetJumpTarget(notfound);
 
 			//Ok, no block, let's jit
-			jit->ClearRoundingMode(this);
+			jit->RestoreRoundingMode(this);
 			ABI_CallFunction(&Jit);
-			jit->SetRoundingMode(this);
+			jit->ApplyRoundingMode(this);
 			JMP(dispatcherNoCheck, true); // Let's just dispatch again, we'll enter the block since we know it's there.
 
 		SetJumpTarget(bail);
@@ -146,12 +146,12 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 		J_CC(CC_Z, outerLoop, true);
 
 	SetJumpTarget(badCoreState);
-	jit->ClearRoundingMode(this);
+	jit->RestoreRoundingMode(this);
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 
 	breakpointBailout = GetCodePtr();
-	jit->ClearRoundingMode(this);
+	jit->RestoreRoundingMode(this);
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 }

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -77,9 +77,9 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 #endif
 
 	outerLoop = GetCodePtr();
-		jit->RestoreRoundingMode(this);
+		jit->RestoreRoundingMode(true, this);
 		ABI_CallFunction(reinterpret_cast<void *>(&CoreTiming::Advance));
-		jit->ApplyRoundingMode(this);
+		jit->ApplyRoundingMode(true, this);
 		FixupBranch skipToRealDispatch = J(); //skip the sync and compare first time
 
 		dispatcherCheckCoreState = GetCodePtr();
@@ -134,9 +134,9 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			SetJumpTarget(notfound);
 
 			//Ok, no block, let's jit
-			jit->RestoreRoundingMode(this);
+			jit->RestoreRoundingMode(true, this);
 			ABI_CallFunction(&Jit);
-			jit->ApplyRoundingMode(this);
+			jit->ApplyRoundingMode(true, this);
 			JMP(dispatcherNoCheck, true); // Let's just dispatch again, we'll enter the block since we know it's there.
 
 		SetJumpTarget(bail);
@@ -146,12 +146,12 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 		J_CC(CC_Z, outerLoop, true);
 
 	SetJumpTarget(badCoreState);
-	jit->RestoreRoundingMode(this);
+	jit->RestoreRoundingMode(true, this);
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 
 	breakpointBailout = GetCodePtr();
-	jit->RestoreRoundingMode(this);
+	jit->RestoreRoundingMode(true, this);
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 }

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -189,7 +189,12 @@ void Jit::CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool del
 			if (predictTakeBranch)
 				GetStateAndFlushAll(state);
 			else
+			{
+				// We need to get the state BEFORE the delay slot is compiled.
+				gpr.GetState(state.gpr);
+				fpr.GetState(state.fpr);
 				CompileDelaySlot(DELAYSLOT_FLUSH);
+			}
 		}
 
 		if (predictTakeBranch)

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -681,7 +681,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	// If we're in a delay slot, this is off by one.
 	const int offset = js.inDelaySlot ? -1 : 0;
 	WriteDowncount(offset);
-	ClearRoundingMode();
+	RestoreRoundingMode();
 	js.downcountAmount = -offset;
 
 	// Skip the CallSyscall where possible.
@@ -691,7 +691,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	else
 		ABI_CallFunctionC(&CallSyscall, op.encoding);
 
-	SetRoundingMode();
+	ApplyRoundingMode();
 	WriteSyscallExit();
 	js.compiling = false;
 }

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -387,6 +387,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
 					// Default nearest / no-flush mode, just leave it cleared.
 				} else {
+					UpdateRoundingMode();
 					ApplyRoundingMode();
 				}
 			} else {
@@ -399,6 +400,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				MOV(32, M(&mips_->fcr31), gpr.R(rt));
 				AND(32, M(&mips_->fcr31), Imm32(0x0181FFFF));
 				gpr.UnlockAll();
+				UpdateRoundingMode();
 				ApplyRoundingMode();
 			}
 		} else {

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -379,15 +379,15 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1
 		if (fs == 31) {
-			// Must clear before setting, since SetRoundingMode() assumes it was cleared.
-			ClearRoundingMode();
+			// Must clear before setting, since ApplyRoundingMode() assumes it was cleared.
+			RestoreRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
 				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
 				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
 					// Default nearest / no-flush mode, just leave it cleared.
 				} else {
-					SetRoundingMode();
+					ApplyRoundingMode();
 				}
 			} else {
 				gpr.Lock(rt, MIPS_REG_FPCOND);
@@ -399,7 +399,7 @@ void Jit::Comp_mxc1(MIPSOpcode op)
 				MOV(32, M(&mips_->fcr31), gpr.R(rt));
 				AND(32, M(&mips_->fcr31), Imm32(0x0181FFFF));
 				gpr.UnlockAll();
-				SetRoundingMode();
+				ApplyRoundingMode();
 			}
 		} else {
 			Comp_Generic(op);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -248,7 +248,9 @@ void Jit::ApplyRoundingMode(bool force, XEmitter *emitter)
 		// If it's 0, we don't actually bother setting.  This is the most common.
 		// We always use nearest as the default rounding mode with
 		// flush-to-zero disabled.
-		FixupBranch skip = emitter->J_CC(CC_Z);
+		FixupBranch skip;
+		if (!g_Config.bForceFlushToZero)
+			skip = emitter->J_CC(CC_Z);
 
 		emitter->STMXCSR(M(&currentMIPS->temp));
 
@@ -273,7 +275,8 @@ void Jit::ApplyRoundingMode(bool force, XEmitter *emitter)
 
 		emitter->LDMXCSR(M(&currentMIPS->temp));
 
-		emitter->SetJumpTarget(skip);
+		if (!g_Config.bForceFlushToZero)
+			emitter->SetJumpTarget(skip);
 	}
 }
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -165,8 +165,8 @@ public:
 	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);
 	void EatPrefix() { js.EatPrefix(); }
 
-	void ClearRoundingMode(XEmitter *emitter = NULL);
-	void SetRoundingMode(XEmitter *emitter = NULL);
+	void RestoreRoundingMode(XEmitter *emitter = NULL);
+	void ApplyRoundingMode(XEmitter *emitter = NULL);
 
 	JitBlockCache *GetBlockCache() { return &blocks; }
 	AsmRoutineManager &Asm() { return asm_; }

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -228,6 +228,7 @@ private:
 	void CompITypeMemUnpairedLR(MIPSOpcode op, bool isStore);
 	void CompITypeMemUnpairedLRInner(MIPSOpcode op, X64Reg shiftReg);
 	void CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool delaySlotIsNice, bool likely, bool andLink);
+	void CompBranchExit(bool taken, u32 targetAddr, u32 notTakenAddr, bool delaySlotIsNice, bool likely, bool andLink);
 
 	void CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 	void CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN = false);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -165,8 +165,9 @@ public:
 	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);
 	void EatPrefix() { js.EatPrefix(); }
 
-	void RestoreRoundingMode(XEmitter *emitter = NULL);
-	void ApplyRoundingMode(XEmitter *emitter = NULL);
+	void RestoreRoundingMode(bool force = false, XEmitter *emitter = NULL);
+	void ApplyRoundingMode(bool force = false, XEmitter *emitter = NULL);
+	void UpdateRoundingMode(XEmitter *emitter = NULL);
 
 	JitBlockCache *GetBlockCache() { return &blocks; }
 	AsmRoutineManager &Asm() { return asm_; }


### PR DESCRIPTION
This uses a similar strategy to vfpu prefix handling - rebuild jit if the assumption changes.

Also, static jumps.  Blocks still won't continue, but it just skips the compare and conditionals jumps.  Less code, less branch prediction, but probably a small difference.

-[Unknown]
