### PR TITLE
x86jit: Preload sp and similar regs used often

### DIFF
--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -77,7 +77,8 @@ namespace MIPSAnalyst
 
 	AnalysisResults Analyze(u32 address);
 
-	bool IsRegisterUsed(MIPSGPReg reg, u32 addr);
+	// This tells us if the reg is used within intrs of addr (also includes likely delay slots.)
+	bool IsRegisterUsed(MIPSGPReg reg, u32 addr, int instrs);
 
 	struct AnalyzedFunction {
 		u32 start;

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -121,7 +121,7 @@ namespace MIPSComp
 		shiftReg = R9;
 #endif
 
-		gpr.Lock(rt);
+		gpr.Lock(rt, rs);
 		gpr.MapReg(rt, true, !isStore);
 
 		// Grab the offset from alignment for shifting (<< 3 for bytes -> bits.)

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -233,6 +233,7 @@ void Jit::Comp_SV(MIPSOpcode op) {
 	{
 	case 50: //lv.s  // VI(vt) = Memory::Read_U32(addr);
 		{
+			gpr.Lock(rs);
 			gpr.MapReg(rs, true, false);
 			fpr.MapRegV(vt, MAP_NOINIT);
 
@@ -256,7 +257,8 @@ void Jit::Comp_SV(MIPSOpcode op) {
 
 	case 58: //sv.s   // Memory::Write_U32(VI(vt), addr);
 		{
-			gpr.MapReg(rs, true, true);
+			gpr.Lock(rs);
+			gpr.MapReg(rs, true, false);
 
 			// Even if we don't use real SIMD there's still 8 or 16 scalar float registers.
 			fpr.MapRegV(vt, 0);
@@ -302,7 +304,7 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			}
 			DISABLE;
 
-			gpr.MapReg(rs, true, true);
+			gpr.MapReg(rs, true, false);
 			gpr.FlushLockX(ECX);
 			u8 vregs[4];
 			GetVectorRegs(vregs, V_Quad, vt);
@@ -364,7 +366,8 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 
 	case 54: //lv.q
 		{
-			gpr.MapReg(rs, true, true);
+			gpr.Lock(rs);
+			gpr.MapReg(rs, true, false);
 	
 			u8 vregs[4];
 			GetVectorRegs(vregs, V_Quad, vt);
@@ -396,7 +399,8 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 
 	case 62: //sv.q
 		{
-			gpr.MapReg(rs, true, true);
+			gpr.Lock(rs);
+			gpr.MapReg(rs, true, false);
 
 			u8 vregs[4];
 			GetVectorRegs(vregs, V_Quad, vt);

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -55,6 +55,12 @@ JitSafeMem::JitSafeMem(Jit *jit, MIPSGPReg raddr, s32 offset, u32 alignMask)
 		iaddr_ = (u32) -1;
 
 	fast_ = g_Config.bFastMemory || raddr == MIPS_REG_SP;
+
+	// If raddr_ is going to get loaded soon, load it now for more optimal code.
+	// We assume that it was already locked.
+	const int LOOKAHEAD_OPS = 3;
+	if (!jit_->gpr.R(raddr_).IsImm() && MIPSAnalyst::IsRegisterUsed(raddr_, jit_->js.compilerPC + 4, LOOKAHEAD_OPS))
+		jit_->gpr.MapReg(raddr_, true, false);
 }
 
 void JitSafeMem::SetFar()


### PR DESCRIPTION
This can help us avoid using a temporary.

Very tiny performance improvement.

-[Unknown]
