### PR TITLE
Clean up jit invalidation with replaced and continued blocks

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -94,6 +94,7 @@ void Jit::BranchRSRTComp(MIPSOpcode op, ArmGen::CCFlags cc, bool likely)
 
 		// Branch taken.  Always compile the delay slot, and then go to dest.
 		CompileDelaySlot(DELAYSLOT_NICE);
+		AddContinuedBlock(targetAddr);
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
 		// In case the delay slot was a break or something.
@@ -209,6 +210,7 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, ArmGen::CCFlags cc, bool andLink, bool
 		if (andLink)
 			gpr.SetImm(MIPS_REG_RA, js.compilerPC + 8);
 
+		AddContinuedBlock(targetAddr);
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
 		// In case the delay slot was a break or something.
@@ -461,6 +463,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 	case 2: //j
 		CompileDelaySlot(DELAYSLOT_NICE);
 		if (jo.continueJumps && js.numInstructions < jo.continueMaxInstructions) {
+			AddContinuedBlock(targetAddr);
 			// Account for the increment in the loop.
 			js.compilerPC = targetAddr - 4;
 			// In case the delay slot was a break or something.
@@ -478,6 +481,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 		gpr.SetImm(MIPS_REG_RA, js.compilerPC + 8);
 		CompileDelaySlot(DELAYSLOT_NICE);
 		if (jo.continueJumps && js.numInstructions < jo.continueMaxInstructions) {
+			AddContinuedBlock(targetAddr);
 			// Account for the increment in the loop.
 			js.compilerPC = targetAddr - 4;
 			// In case the delay slot was a break or something.
@@ -537,6 +541,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		}
 
 		if (jo.continueJumps && gpr.IsImm(rs) && js.numInstructions < jo.continueMaxInstructions) {
+			AddContinuedBlock(gpr.GetImm(rs));
 			// Account for the increment in the loop.
 			js.compilerPC = gpr.GetImm(rs) - 4;
 			// In case the delay slot was a break or something.

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1252,8 +1252,6 @@ namespace MIPSComp
 					gpr.MapReg(rt);
 					STR(gpr.R(rt), CTXREG, offsetof(MIPSState, vfpuCtrl) + 4 * (imm - 128));
 				}
-				//gpr.BindToRegister(rt, true, false);
-				//MOV(32, M(&currentMIPS->vfpuCtrl[imm - 128]), gpr.R(rt));
 
 				// TODO: Optimization if rt is Imm?
 				// Set these BEFORE disable!

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -21,6 +21,7 @@
 #include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/Debugger/SymbolMap.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -417,8 +418,7 @@ bool Jit::ReplaceJalTo(u32 dest) {
 	// No writing exits, keep going!
 
 	// Add a trigger so that if the inlined code changes, we invalidate this block.
-	// TODO: Correctly determine the size of this block.
-	blocks.ProxyBlock(js.blockStart, dest, 4, GetCodePtr());
+	blocks.ProxyBlock(js.blockStart, dest, symbolMap.GetFunctionSize(dest) / sizeof(u32), GetCodePtr());
 	return true;
 }
 

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -68,8 +68,6 @@ ArmJitOptions::ArmJitOptions() {
 	useBackJump = false;
 	useForwardJump = false;
 	cachePointers = true;
-	// WARNING: These options don't work properly with cache clearing or jit compare.
-	// Need to find a smart way to handle before enabling.
 	immBranches = false;
 	continueBranches = false;
 	continueJumps = false;
@@ -247,6 +245,8 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 {
 	js.cancel = false;
 	js.blockStart = js.compilerPC = mips_->pc;
+	js.lastContinuedPC = 0;
+	js.initialBlockSize = 0;
 	js.nextExit = 0;
 	js.downcountAmount = 0;
 	js.curBlock = b;
@@ -356,8 +356,25 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	// Don't forget to zap the newly written instructions in the instruction cache!
 	FlushIcache();
 
-	b->originalSize = js.numInstructions;
+	if (js.lastContinuedPC == 0)
+		b->originalSize = js.numInstructions;
+	else
+	{
+		// We continued at least once.  Add the last proxy and set the originalSize correctly.
+		blocks.ProxyBlock(js.blockStart, js.lastContinuedPC, (js.compilerPC - js.lastContinuedPC) / sizeof(u32), GetCodePtr());
+		b->originalSize = js.initialBlockSize;
+	}
 	return b->normalEntry;
+}
+
+void Jit::AddContinuedBlock(u32 dest)
+{
+	// The first block is the root block.  When we continue, we create proxy blocks after that.
+	if (js.lastContinuedPC == 0)
+		js.initialBlockSize = js.numInstructions;
+	else
+		blocks.ProxyBlock(js.blockStart, js.lastContinuedPC, (js.compilerPC - js.lastContinuedPC) / sizeof(u32), GetCodePtr());
+	js.lastContinuedPC = dest;
 }
 
 bool Jit::DescribeCodePtr(const u8 *ptr, std::string &name)

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -68,6 +68,8 @@ public:
 
 	void CompileDelaySlot(int flags);
 	void EatInstruction(MIPSOpcode op);
+	void AddContinuedBlock(u32 dest);
+
 	void Comp_RunBlock(MIPSOpcode op);
 	void Comp_ReplacementFunc(MIPSOpcode op);
 

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -119,11 +119,11 @@ void JitBlockCache::Shutdown() {
 // This clears the JIT cache. It's called from JitCache.cpp when the JIT cache
 // is full and when saving and loading states.
 void JitBlockCache::Clear() {
+	block_map_.clear();
+	proxyBlockMap_.clear();
 	for (int i = 0; i < num_blocks_; i++)
 		DestroyBlock(i, false);
 	links_to_.clear();
-	block_map_.clear();
-	proxyBlockMap_.clear();
 	num_blocks_ = 0;
 
 	blockMemRanges_[JITBLOCK_RANGE_SCRATCH] = std::make_pair(0xFFFFFFFF, 0x00000000);
@@ -216,7 +216,11 @@ void JitBlockCache::AddBlockMap(int block_num) {
 
 void JitBlockCache::RemoveBlockMap(int block_num) {
 	const JitBlock &b = blocks_[block_num];
-	u32 pAddr = b.originalAddress & 0x1FFFFFFF;
+	if (b.invalid) {
+		return;
+	}
+
+	const u32 pAddr = b.originalAddress & 0x1FFFFFFF;
 	auto it = block_map_.find(std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr));
 	if (it != block_map_.end() && it->second == block_num) {
 		block_map_.erase(it);

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -596,6 +596,9 @@ void JitBlockCache::InvalidateICache(u32 address, const u32 length) {
 				break;
 			}
 		}
+		if (next == last) {
+			break;
+		}
 	}
 }
 

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -217,7 +217,18 @@ void JitBlockCache::AddBlockMap(int block_num) {
 void JitBlockCache::RemoveBlockMap(int block_num) {
 	const JitBlock &b = blocks_[block_num];
 	u32 pAddr = b.originalAddress & 0x1FFFFFFF;
-	block_map_.erase(std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr));
+	auto it = block_map_.find(std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr));
+	if (it != block_map_.end() && it->second == block_num) {
+		block_map_.erase(it);
+	} else {
+		// It wasn't in there, or it has the wrong key.  Let's search...
+		for (auto it = block_map_.begin(); it != block_map_.end(); ++it) {
+			if (it->second == block_num) {
+				block_map_.erase(it);
+				break;
+			}
+		}
+	}
 }
 
 static void ExpandRange(std::pair<u32, u32> &range, u32 newStart, u32 newEnd) {

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -148,6 +148,9 @@ private:
 	void LinkBlock(int i);
 	void UnlinkBlock(int i);
 
+	void AddBlockMap(int block_num);
+	void RemoveBlockMap(int block_num);
+
 	MIPSOpcode GetEmuHackOpForBlock(int block_num) const;
 
 	MIPSState *mips_;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -156,7 +156,7 @@ private:
 	MIPSState *mips_;
 	CodeBlock *codeBlock_;
 	JitBlock *blocks_;
-	std::vector<int> proxyBlockIndices_;
+	std::multimap<u32, int> proxyBlockMap_;
 
 	int num_blocks_;
 	std::multimap<u32, int> links_to_;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -141,6 +141,8 @@ public:
 
 	int GetNumBlocks() const { return num_blocks_; }
 
+	static int GetBlockExitSize();
+
 private:
 	void LinkBlockExits(int i);
 	void LinkBlock(int i);

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -64,6 +64,8 @@ namespace MIPSComp {
 
 		u32 compilerPC;
 		u32 blockStart;
+		u32 lastContinuedPC;
+		u32 initialBlockSize;
 		int nextExit;
 		bool cancel;
 		bool inDelaySlot;

--- a/Core/MIPS/PPC/PpcCompVFPU.cpp
+++ b/Core/MIPS/PPC/PpcCompVFPU.cpp
@@ -671,7 +671,7 @@ namespace MIPSComp
 					// In case we have a saved prefix.
 					//FlushPrefixV();
 					//gpr.BindToRegister(rt, false, true);
-					//MOV(32, gpr.R(rt), M(&currentMIPS->vfpuCtrl[imm - 128]));
+					//MOV(32, gpr.R(rt), M(&mips_->vfpuCtrl[imm - 128]));
 				} else {
 					//ERROR - maybe need to make this value too an "interlock" value?
 					ERROR_LOG(CPU, "mfv - invalid register %i", imm);
@@ -688,7 +688,7 @@ namespace MIPSComp
 				gpr.MapReg(rt);
 				STW(gpr.R(rt), CTXREG, offsetof(MIPSState, vfpuCtrl) + 4 * (imm - 128));
 				//gpr.BindToRegister(rt, true, false);
-				//MOV(32, M(&currentMIPS->vfpuCtrl[imm - 128]), gpr.R(rt));
+				//MOV(32, M(&mips_->vfpuCtrl[imm - 128]), gpr.R(rt));
 
 				// TODO: Optimization if rt is Imm?
 				// Set these BEFORE disable!

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -215,6 +215,7 @@ void Jit::CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool del
 			if (likely)
 				CompileDelaySlot(DELAYSLOT_NICE);
 
+			AddContinuedBlock(targetAddr);
 			// Account for the increment in the loop.
 			js.compilerPC = targetAddr - 4;
 			// In case the delay slot was a break or something.
@@ -328,6 +329,7 @@ void Jit::BranchRSRTComp(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 
 		// Branch taken.  Always compile the delay slot, and then go to dest.
 		CompileDelaySlot(DELAYSLOT_NICE);
+		AddContinuedBlock(targetAddr);
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
 		// In case the delay slot was a break or something.
@@ -406,6 +408,7 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, Gen::CCFlags cc, bool andLink, bool li
 		if (andLink)
 			gpr.SetImm(MIPS_REG_RA, js.compilerPC + 8);
 
+		AddContinuedBlock(targetAddr);
 		// Account for the increment in the loop.
 		js.compilerPC = targetAddr - 4;
 		// In case the delay slot was a break or something.
@@ -585,6 +588,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 		CompileDelaySlot(DELAYSLOT_NICE);
 		if (jo.continueJumps && js.numInstructions < jo.continueMaxInstructions)
 		{
+			AddContinuedBlock(targetAddr);
 			// Account for the increment in the loop.
 			js.compilerPC = targetAddr - 4;
 			// In case the delay slot was a break or something.
@@ -609,6 +613,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 		CompileDelaySlot(DELAYSLOT_NICE);
 		if (jo.continueJumps && js.numInstructions < jo.continueMaxInstructions)
 		{
+			AddContinuedBlock(targetAddr);
 			// Account for the increment in the loop.
 			js.compilerPC = targetAddr - 4;
 			// In case the delay slot was a break or something.
@@ -679,6 +684,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 
 		if (jo.continueJumps && gpr.IsImm(rs) && js.numInstructions < jo.continueMaxInstructions)
 		{
+			AddContinuedBlock(gpr.GetImm(rs));
 			// Account for the increment in the loop.
 			js.compilerPC = gpr.GetImm(rs) - 4;
 			// In case the delay slot was a break or something.

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -224,7 +224,7 @@ void Jit::CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool del
 		{
 			// Take the branch
 			if (andLink)
-				MOV(32, M(&mips_->r[MIPS_REG_RA]), Imm32(js.compilerPC + 8));
+				MOV(32, gpr.GetDefaultLocation(MIPS_REG_RA), Imm32(js.compilerPC + 8));
 			CONDITIONAL_LOG_EXIT(targetAddr);
 			WriteExit(targetAddr, js.nextExit++);
 
@@ -259,7 +259,7 @@ void Jit::CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool del
 
 		// Take the branch
 		if (andLink)
-			MOV(32, M(&mips_->r[MIPS_REG_RA]), Imm32(js.compilerPC + 8));
+			MOV(32, gpr.GetDefaultLocation(MIPS_REG_RA), Imm32(js.compilerPC + 8));
 		CONDITIONAL_LOG_EXIT(targetAddr);
 		WriteExit(targetAddr, js.nextExit++);
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -650,7 +650,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 	{
 		// If this is a syscall, write the pc (for thread switching and other good reasons.)
 		gpr.MapReg(rs, true, false);
-		MOV(32, M(&currentMIPS->pc), gpr.R(rs));
+		MOV(32, M(&mips_->pc), gpr.R(rs));
 		if (andLink)
 			gpr.SetImm(rd, js.compilerPC + 8);
 		CompileDelaySlot(DELAYSLOT_FLUSH);

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1697,7 +1697,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 					// In case we have a saved prefix.
 					FlushPrefixV();
 					gpr.MapReg(rt, false, true);
-					MOV(32, gpr.R(rt), M(&currentMIPS->vfpuCtrl[imm - 128]));
+					MOV(32, gpr.R(rt), M(&mips_->vfpuCtrl[imm - 128]));
 				}
 			} else {
 				//ERROR - maybe need to make this value too an "interlock" value?
@@ -1724,7 +1724,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 				}
 			} else {
 				gpr.MapReg(rt, true, false);
-				MOV(32, M(&currentMIPS->vfpuCtrl[imm - 128]), gpr.R(rt));
+				MOV(32, M(&mips_->vfpuCtrl[imm - 128]), gpr.R(rt));
 			}
 
 			// TODO: Optimization if rt is Imm?
@@ -1756,7 +1756,7 @@ void Jit::Comp_Vmfvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, true, false);
 			MOVD_xmm(fpr.VX(vs), gpr.R(MIPS_REG_VFPUCC));
 		} else {
-			MOVSS(fpr.VX(vs), M(&currentMIPS->vfpuCtrl[imm - 128]));
+			MOVSS(fpr.VX(vs), M(&mips_->vfpuCtrl[imm - 128]));
 		}
 		fpr.ReleaseSpillLocks();
 	}
@@ -1772,7 +1772,7 @@ void Jit::Comp_Vmtvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, false, true);
 			MOVD_xmm(gpr.R(MIPS_REG_VFPUCC), fpr.VX(vs));
 		} else {
-			MOVSS(M(&currentMIPS->vfpuCtrl[imm - 128]), fpr.VX(vs));
+			MOVSS(M(&mips_->vfpuCtrl[imm - 128]), fpr.VX(vs));
 		}
 		fpr.ReleaseSpillLocks();
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -677,6 +677,14 @@ void Jit::WriteExit(u32 destination, int exit_num)
 		// No blocklinking.
 		MOV(32, M(&mips_->pc), Imm32(destination));
 		JMP(asm_.dispatcher, true);
+
+		// Normally, exits are 15 bytes (MOV + &pc + dest + JMP + dest) on 64 or 32 bit.
+		// But just in case we somehow optimized, pad.
+		ptrdiff_t actualSize = GetWritableCodePtr() - b->exitPtrs[exit_num];
+		int pad = JitBlockCache::GetBlockExitSize() - (int)actualSize;
+		for (int i = 0; i < pad; ++i) {
+			INT3();
+		}
 	}
 }
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -551,8 +551,7 @@ bool Jit::ReplaceJalTo(u32 dest) {
 	// No writing exits, keep going!
 
 	// Add a trigger so that if the inlined code changes, we invalidate this block.
-	// TODO: Correctly determine the size of this block.
-	blocks.ProxyBlock(js.blockStart, dest, 4, GetCodePtr());
+	blocks.ProxyBlock(js.blockStart, dest, symbolMap.GetFunctionSize(dest) / sizeof(u32), GetCodePtr());
 	return true;
 }
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -193,6 +193,7 @@ private:
 		CompileDelaySlot(flags, &state);
 	}
 	void EatInstruction(MIPSOpcode op);
+	void AddContinuedBlock(u32 dest);
 
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInReg(X64Reg reg);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -260,12 +260,31 @@ private:
 	}
 
 	bool PredictTakeBranch(u32 targetAddr, bool likely);
-	bool CanContinueBranch() {
+	bool CanContinueBranch(u32 targetAddr) {
 		if (!jo.continueBranches || js.numInstructions >= jo.continueMaxInstructions) {
 			return false;
 		}
 		// Need at least 2 exits left over.
 		if (js.nextExit >= MAX_JIT_BLOCK_EXITS - 2) {
+			return false;
+		}
+		// Sometimes we predict wrong and get into impossible conditions where games have jumps to 0.
+		if (!targetAddr) {
+			return false;
+		}
+		return true;
+	}
+	bool CanContinueJump(u32 targetAddr) {
+		if (!jo.continueJumps || js.numInstructions >= jo.continueMaxInstructions) {
+			return false;
+		}
+		if (!targetAddr) {
+			return false;
+		}
+		return true;
+	}
+	bool CanContinueImmBranch(u32 targetAddr) {
+		if (!jo.immBranches || js.numInstructions >= jo.continueMaxInstructions) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Also, writes breakpoints when linking block exits so the jit compare isn't confusing.

Continuing helps in some cases and really cuts down on tiny blocks, but it also makes some things slower.  I think it just needs (much) better heuristics.

-[Unknown]
