### PR TITLE
Compatibility ndk r9d armeabi-v7a-hard APP_ABI building.

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -51,7 +51,8 @@ ARCH_FILES := \
   $(SRC)/GPU/Common/VertexDecoderX86.cpp
 endif
 
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+# ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
 ARCH_FILES := \
   $(SRC)/GPU/Common/TextureDecoderNEON.cpp.neon \
   $(SRC)/Common/ArmEmitter.cpp \

--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -17,7 +17,8 @@ LOCAL_C_INCLUDES := \
 LOCAL_STATIC_LIBRARIES := native libzip
 LOCAL_LDLIBS := -lz -lGLESv2 -lEGL -ldl -llog
 
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+# ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavformat.a
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavcodec.a
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libswresample.a


### PR DESCRIPTION
Fix APP_ABI=armeabi-v7a-hard ndk building problem.

I also create a pull request for native rep.

Just change ab.sh to test it:
-- NDK_MODULE_PATH=..:../native/ext $NDK/ndk-build -j3 $*
++ NDK_MODULE_PATH=..:../native/ext $NDK/ndk-build APP_ABI=armeabi-v7a-hard -j3 $*
