### PR TITLE
Fix a scale for iPhone 6 Plus

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -21,6 +21,8 @@
 #include "gfx_es2/fbo.h"
 
 #define IS_IPAD() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
+#define IS_IPHONE() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone)
+#define IS_IPHONE_6P() (IS_IPHONE() && [[UIScreen mainScreen] bounds].size.height == 736.0)
 
 float dp_xscale = 1.0f;
 float dp_yscale = 1.0f;
@@ -130,7 +132,7 @@ ViewController* sharedViewController;
 	[EAGLContext setCurrentContext:self.context];
 	self.preferredFramesPerSecond = 60;
 
-	float scale = [UIScreen mainScreen].scale;
+	float scale = (IS_IPHONE_6P() ? 3.0f : [UIScreen mainScreen].scale);
 	CGSize size = [[UIApplication sharedApplication].delegate window].frame.size;
 
 	if (size.height > size.width)
@@ -227,7 +229,7 @@ ViewController* sharedViewController;
 {
 	lock_guard guard(input_state.lock);
 
-	float scale = [UIScreen mainScreen].scale;
+	float scale = (IS_IPHONE_6P() ? 3.0f : [UIScreen mainScreen].scale);
 
 	float scaledX = (int)(x * dp_xscale) * scale;
 	float scaledY = (int)(y * dp_yscale) * scale;


### PR DESCRIPTION
Fix scale for iPhone 6 Plus
1. add the definition for check the device is iPhone 6 Plus
2. If the device is iPhone 6 plus, fix a scale 3.0f
