### PR TITLE
Support cso files with larger block sizes

### DIFF
--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -47,9 +47,14 @@ public:
 private:
 	FILE *f;
 	u32 *index;
-	int indexShift;
-	u32 blockSize;
+	u8 *readBuffer;
+	u8 *zlibBuffer;
+	u32 zlibBufferFrame;
+	u8 indexShift;
+	u8 blockShift;
+	u32 frameSize;
 	u32 numBlocks;
+	u32 numFrames;
 };
 
 


### PR DESCRIPTION
Calling them "frames" just to quell the confusion level in the code.

No tools I know of generate cso files with larger block sizes by default, but all seem to correctly fill the field.  Larger block sizes could lead to better compression, though.

Apparently there's an effort to create a new format ("ZSO") that uses lz4 instead of deflate.  lz4 of course decompresses much faster, and apparently this improves loading times at least on real PSPs.  It's basically the same except with different magic bytes (I'd use `version`, but doesn't really matter...)

Tested by manually creating a cso with a larger block size (created a [cso compressor](https://github.com/unknownbrackets/maxcso) to experiment with c++11 features that Symbian denies me... can just change the SECTOR_SIZE constant there and then compress a regular ISO.)

-[Unknown]
