### PR TITLE
Attempt to make the texture hash match(able) - needs testing

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -39,7 +39,7 @@ u32 QuickTexHashSSE2(const void *checkp, u32 size) {
 		const __m128i *p = (const __m128i *)checkp;
 		for (u32 i = 0; i < size / 16; i += 4) {
 			__m128i chunk = _mm_mullo_epi16(_mm_load_si128(&p[i]), cursor2);
-			cursor = _mm_add_epi32(cursor, chunk);
+			cursor = _mm_add_epi16(cursor, chunk);
 			cursor = _mm_xor_si128(cursor, _mm_load_si128(&p[i + 1]));
 			cursor = _mm_add_epi32(cursor, _mm_load_si128(&p[i + 2]));
 			chunk = _mm_mullo_epi16(_mm_load_si128(&p[i + 3]), cursor2);
@@ -62,6 +62,57 @@ u32 QuickTexHashSSE2(const void *checkp, u32 size) {
 	return check;
 }
 #endif
+
+u32 QuickTexHashNonSSE(const void *checkp, u32 size) {
+	u32 check = 0;
+
+	if (((intptr_t)checkp & 0xf) == 0 && (size & 0x3f) == 0) {
+		static const u16 cursor2_initial[8] = {0xc00bU, 0x9bd9U, 0x4b73U, 0xb651U, 0x4d9bU, 0x4309U, 0x0083U, 0x0001U};
+		union u32x4_u16x8 {
+			u32 x32[4];
+			u16 x16[8];
+		};
+		u32x4_u16x8 cursor = {0, 0, 0, 0};
+		u32x4_u16x8 cursor2;
+		static const u16 update[8] = {0x2455U, 0x2455U, 0x2455U, 0x2455U, 0x2455U, 0x2455U, 0x2455U, 0x2455U};
+
+		for (u32 j = 0; j < 8; ++j) {
+			cursor2.x16[j] = cursor2_initial[j];
+		}
+
+		const u32x4_u16x8 *p = (const u32x4_u16x8 *)checkp;
+		for (u32 i = 0; i < size / 16; i += 4) {
+			for (u32 j = 0; j < 8; ++j) {
+				const u16 temp = p[i + 0].x16[j] * cursor2.x16[j];
+				cursor.x16[j] += temp;
+			}
+			for (u32 j = 0; j < 4; ++j) {
+				cursor.x32[j] ^= p[i + 1].x32[j];
+				cursor.x32[j] += p[i + 2].x32[j];
+			}
+			for (u32 j = 0; j < 8; ++j) {
+				const u16 temp = p[i + 3].x16[j] * cursor2.x16[j];
+				cursor.x16[j] ^= temp;
+			}
+			for (u32 j = 0; j < 8; ++j) {
+				cursor2.x16[j] += update[j];
+			}
+		}
+
+		for (u32 j = 0; j < 4; ++j) {
+			cursor.x32[j] += cursor2.x32[j];
+		}
+		check = cursor.x32[0] + cursor.x32[1] + cursor.x32[2] + cursor.x32[3];
+	} else {
+		const u32 *p = (const u32 *)checkp;
+		for (u32 i = 0; i < size / 8; ++i) {
+			check += *p++;
+			check ^= *p++;
+		}
+	}
+
+	return check;
+}
 
 static u32 QuickTexHashBasic(const void *checkp, u32 size) {
 #if defined(ARM) && defined(__GNUC__)

--- a/GPU/Common/TextureDecoderNEON.cpp
+++ b/GPU/Common/TextureDecoderNEON.cpp
@@ -22,7 +22,7 @@
 #error Should not be compiled on non-ARM.
 #endif
 
-static const u16 MEMORY_ALIGNED16(QuickTexHashInitial[8]) = {0x0001U, 0x0083U, 0x4309U, 0x4d9bU, 0xb651U, 0x4b73U, 0x9bd9U, 0xc00bU};
+static const u16 MEMORY_ALIGNED16(QuickTexHashInitial[8]) = {0xc00bU, 0x9bd9U, 0x4b73U, 0xb651U, 0x4d9bU, 0x4309U, 0x0083U, 0x0001U};
 
 u32 QuickTexHashNEON(const void *checkp, u32 size) {
 	u32 check = 0;

--- a/GPU/Common/TextureDecoderNEON.cpp
+++ b/GPU/Common/TextureDecoderNEON.cpp
@@ -60,15 +60,15 @@ u32 QuickTexHashNEON(const void *checkp, u32 size) {
 			"vmov.i32 q0, #0\n"
 
 			// Initialize cursor2.
-			"movw r0, 0x0001\n"
-			"movt r0, 0x0083\n"
-			"movw r1, 0x4309\n"
-			"movt r1, 0x4d9b\n"
+			"movw r0, 0xc00b\n"
+			"movt r0, 0x9bd9\n"
+			"movw r1, 0x4b73\n"
+			"movt r1, 0xb651\n"
 			"vmov d2, r0, r1\n"
-			"movw r0, 0xb651\n"
-			"movt r0, 0x4b73\n"
-			"movw r1, 0x9bd9\n"
-			"movt r1, 0xc00b\n"
+			"movw r0, 0x4d9b\n"
+			"movt r0, 0x4309\n"
+			"movw r1, 0x0083\n"
+			"movt r1, 0x0001\n"
 			"vmov d3, r0, r1\n"
 
 			// Initialize update.


### PR DESCRIPTION
Unfortunately, I _do not currently have an Android device_, so the ARM changes are _completely untested_.  They do compile.

The non-SSE version matches the SSE2 version for all the textures I tested.  Before you ask, no, MSVC is not able to vectorize it (I even tried making it easier in different ways.)  Didn't check gcc.  In MSVC is takes about 10 times as long as the SSE2 version (which puts it about in the same speed range as XXH32.)

The alteration to the SSE2 version has no speed impact.

The alterations to the NEON version **may** result in the same hash values, but are untested.  They may or may not have a performance impact, which is also untested.  Could really use someone's testing here.

The goal is that they would match and we could potentially use them for texture replacements or what have you.

To test the NEON version's performance, you would do the following:
1. Change headless/Headless.cpp as follows:
   
   1.1. Add `#include "GPU/Common/TextureDecoder.h"` near the top.
   1.2. Find:
   
   ``` c++
   int main(int argc, const char* argv[])
   {
   ```
   
   Replace:
   
   ``` c++
   volatile u32 noOptimPlease;
   int main(int argc, const char* argv[])
   {
      const static char ref[16384] = {1, 2, 3, 4, 5, -1, -1, -1, -1, -1};
      double st1 = real_time_now();
      for (int i = 0; i < 10000; ++i) {
          noOptimPlease |= DoQuickTexHash(ref, 16384);
      }
      double et1 = real_time_now();
      printf("Time taken: %f, result = %08x\n", et1 - st1, DoQuickTexHash(ref, 16384));
      return 0;
   ```
2. Compile _without_ the patch merged, using a command line like `ab HEADLESS=1`.
3. Push the binary to your device (not using Eclipse) via `adb push ppsspp/android/libs/armeabi-v7a/ppsspp_headless //data/local/tmp/`, and then `adb shell chmod 0777 //data/local/tmp/ppsspp_headless` (both commands are necessary, device need not be rooted or anything.)
4. Execute the test: `adb shell "cd /data/local/tmp/ && ./ppsspp_headless`, ideally a few times and record the numbers.
5. Recompile with my patch and the change to headless (again, `ab HEADLESS=1`.)
6. Re push the binary as in step 3.  Yes, the chmod part is needed again as well.
7. Execute the test again and record the numbers.

Ideally, they will mostly match.  I expect that they will.

The next interesting thing would be to compare the hash result.  The results from the two versions **should** be different, or you did something wrong.  What I want it to match is the PC version.  If the result is `6a713c4b` in the new version, it's most likely a winner.

-[Unknown]
