### PR TITLE
jit: Fix partial invalidation of larger blocks

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -317,7 +317,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 #endif
 
 		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
-		if (GetSpaceLeft() < 0x800)
+		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS)
 		{
 			FlushAll();
 			WriteExit(js.compilerPC, js.nextExit++);

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -600,7 +600,7 @@ void JitBlockCache::InvalidateICache(u32 address, const u32 length) {
 	do {
 	restart:
 		auto next = block_map_.lower_bound(std::make_pair(pAddr, 0));
-		auto last = block_map_.upper_bound(std::make_pair(pAddr + MAX_BLOCK_INSTRUCTIONS, 0));
+		auto last = block_map_.upper_bound(std::make_pair(pEnd + MAX_BLOCK_INSTRUCTIONS, 0));
 		// Note that if next is end(), last will be end() too (equal.)
 		for (; next != last; ++next) {
 			const u32 blockStart = next->first.second;

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -600,7 +600,7 @@ void JitBlockCache::InvalidateICache(u32 address, const u32 length) {
 	do {
 	restart:
 		auto next = block_map_.lower_bound(std::make_pair(pAddr, 0));
-		auto last = block_map_.upper_bound(std::make_pair(pEnd, 0));
+		auto last = block_map_.upper_bound(std::make_pair(pAddr + MAX_BLOCK_INSTRUCTIONS, 0));
 		// Note that if next is end(), last will be end() too (equal.)
 		for (; next != last; ++next) {
 			const u32 blockStart = next->first.second;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -143,6 +143,10 @@ public:
 
 	static int GetBlockExitSize();
 
+	enum {
+		MAX_BLOCK_INSTRUCTIONS = 0x4000,
+	};
+
 private:
 	void LinkBlockExits(int i);
 	void LinkBlock(int i);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -455,7 +455,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 		js.numInstructions++;
 
 		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
-		if (GetSpaceLeft() < 0x800)
+		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS)
 		{
 			FlushAll();
 			WriteExit(js.compilerPC, js.nextExit++);


### PR DESCRIPTION
Oops, of course the end can be after the other end.  Let's just cap the block size to give it a fixed search size.

-[Unknown]
