### PR TITLE
Check memory stick free space and tell the game about it

### DIFF
--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -323,7 +323,7 @@ public:
 	std::string GetKey(const SceUtilitySavedataParam *param) const;
 	bool HasKey(const SceUtilitySavedataParam *param) const;
 
-	static std::string GetSpaceText(int size);
+	static std::string GetSpaceText(u64 size);
 
 	int SetPspParam(SceUtilitySavedataParam* param);
 	SceUtilitySavedataParam *GetPspParam();

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -293,7 +293,7 @@ bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 		}
 		if (z.total_out != frameSize)
 		{
-			ERROR_LOG(LOADER, "block %d: block size error %d != %d\n", blockNumber, z.total_out, frameSize);
+			ERROR_LOG(LOADER, "block %d: block size error %d != %d\n", blockNumber, (u32)z.total_out, frameSize);
 			inflateEnd(&z);
 			memset(outPtr, 0, GetBlockSize());
 			return false;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <limits>
 #include "ChunkFile.h"
 #include "FileUtil.h"
 #include "DirectoryFileSystem.h"
@@ -719,6 +720,20 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 	closedir(dp);
 #endif
 	return myVector;
+}
+
+u64 DirectoryFileSystem::FreeSpace(const std::string &path) {
+#ifdef _WIN32
+	const std::wstring w32path = ConvertUTF8ToWString(GetLocalPath(path));
+	ULARGE_INTEGER free;
+	if (GetDiskFreeSpaceExW(w32path.c_str(), &free, nullptr, nullptr))
+		return free.QuadPart;
+#else
+	// TODO: Implement.
+#endif
+
+	// Just assume they're swimming in free disk space if we don't know otherwise.
+	return std::numeric_limits<u64>::max();
 }
 
 void DirectoryFileSystem::DoState(PointerWrap &p) {

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -109,6 +109,7 @@ public:
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	int Flags() { return flags; }
+	u64 FreeSpace(const std::string &path) override;
 
 private:
 	struct OpenFileEntry {
@@ -151,6 +152,7 @@ public:
 	bool RemoveFile(const std::string &filename);
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	int Flags() { return 0; }
+	u64 FreeSpace(const std::string &path) override { return 0; }
 
 private:
 	struct OpenFileEntry {

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -117,6 +117,7 @@ public:
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 	virtual int      DevType(u32 handle) = 0;
 	virtual int      Flags() = 0;
+	virtual u64      FreeSpace(const std::string &path) = 0;
 };
 
 
@@ -140,6 +141,7 @@ public:
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
 	virtual int DevType(u32 handle) { return 0; }
 	virtual int Flags() { return 0; }
+	virtual u64 FreeSpace(const std::string &path) override { return 0; }
 };
 
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -43,6 +43,7 @@ public:
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int      DevType(u32 handle) override;
 	int      Flags() override { return 0; }
+	u64      FreeSpace(const std::string &path) override { return 0; }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
@@ -131,6 +132,7 @@ public:
 		return isoFileSystem_->DevType(handle);
 	}
 	int      Flags() override { return isoFileSystem_->Flags(); }
+	u64      FreeSpace(const std::string &path) override { return isoFileSystem_->FreeSpace(path); }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override {
 		return isoFileSystem_->WriteFile(handle, pointer, size);

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -591,6 +591,17 @@ int MetaFileSystem::ReadEntireFile(const std::string &filename, std::vector<u8> 
 	return 0;
 }
 
+u64 MetaFileSystem::FreeSpace(const std::string &path)
+{
+	lock_guard guard(lock);
+	std::string of;
+	IFileSystem *system;
+	if (MapFilePath(path, of, &system))
+		return system->FreeSpace(of);
+	else
+		return 0;
+}
+
 void MetaFileSystem::DoState(PointerWrap &p)
 {
 	lock_guard guard(lock);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -108,6 +108,7 @@ public:
 	virtual int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 	virtual int  DevType(u32 handle);
 	virtual int  Flags() { return 0; }
+	virtual u64  FreeSpace(const std::string &path) override;
 
 	// Convenience helper - returns < 0 on failure.
 	int ReadEntireFile(const std::string &filename, std::vector<u8> &data);

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -41,6 +41,7 @@ public:
 	bool GetHostPath(const std::string &inpath, std::string &outpath);
 	std::vector<PSPFileInfo> GetDirListing(std::string path);
 	int  Flags() { return 0; }
+	u64  FreeSpace(const std::string &path) override { return 0; }
 
 	// unsupported operations
 	size_t  WriteFile(u32 handle, const u8 *pointer, s64 size);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -438,7 +438,7 @@ void __IoWakeManager() {
 }
 
 void __IoInit() {
-	MemoryStick_SetFatState(PSP_FAT_MEMORYSTICK_STATE_ASSIGNED);
+	MemoryStick_Init();
 
 	asyncNotifyEvent = CoreTiming::RegisterEvent("IoAsyncNotify", __IoAsyncNotify);
 	syncNotifyEvent = CoreTiming::RegisterEvent("IoSyncNotify", __IoSyncNotify);

--- a/Core/HW/MemoryStick.h
+++ b/Core/HW/MemoryStick.h
@@ -18,6 +18,7 @@ enum MemStickFatState {
 	PSP_FAT_MEMORYSTICK_STATE_ASSIGNED   = 1,
 };
 
+void MemoryStick_Init();
 void MemoryStick_DoState(PointerWrap &p);
 MemStickState MemoryStick_State();
 MemStickFatState MemoryStick_FatState();


### PR DESCRIPTION
This isn't necessarily super well tested, in that I did not fill up my disk and see if it made any games freak out in incorrect/correct ways.  However, I did verify that this doesn't make games freak out (at least the ones I tested) when you _do_ have free space.

This also changes the memory stick (except in old savestates) to be 8GB.  Sony did sell an 8GB stick, so that shouldn't be an unusual size for games to see.  If you have more than 8GB free, it always just says 8GB.  In practice, I suspect 32GB or higher might work fine (as I have 32GB on my PSP, actually, and have never had a problem.)

Incidentally, I've never run out of space on my PSP, so I don't really know how well games react to out of space problems (although I did on my Android device which actually had less space.)

This change may affect behavior of some games.  For example, Dissidia refused to export highest quality avis with the previous setting iirc.  It's possible it may trigger bugs or forced installations that didn't happen before, in the worst case.

On Symbian, it always lies and says there are 8GB free, since I don't know how to detect disk space on that platform.

This improves #6593.  However, surely there are still error codes and such we ought to be providing in that situation, which is probably what most games react to if anything.

-[Unknown]
