### PR TITLE
Fix copy paste error with that breaks controlconfig passing via cmdline

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -416,7 +416,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			if (wideArgs[i].find(controlsOption) != std::wstring::npos && wideArgs[i].size() > controlsOption.size()) {
 				const std::wstring tempWide = wideArgs[i].substr(configOption.size());
 				const std::string tempStr = ConvertWStringToUTF8(tempWide);
-				std::strncpy(configFilename, tempStr.c_str(), MAX_PATH);
+				std::strncpy(controlsConfigFilename, tempStr.c_str(), MAX_PATH);
 			}
 		}
 	}


### PR DESCRIPTION
This was discovered by fgeds here: http://forums.ppsspp.org/showthread.php?tid=13655
so all props go to him.

I did not do any testing beyond making sure it compiles on Windows. But this seems to be an obvious copypaste error introduced in https://github.com/hrydgard/ppsspp/commit/3590352429042b16155c5f7f910efcfc33cf4881#diff-cf7f0200393625a9de07886fc6feb85fL404
