### PR TITLE
control filename trimmed to the wrong size in line 417

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -414,7 +414,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			}
 
 			if (wideArgs[i].find(controlsOption) != std::wstring::npos && wideArgs[i].size() > controlsOption.size()) {
-				const std::wstring tempWide = wideArgs[i].substr(configOption.size());
+				const std::wstring tempWide = wideArgs[i].substr(controlsOption.size());
 				const std::string tempStr = ConvertWStringToUTF8(tempWide);
 				std::strncpy(controlsConfigFilename, tempStr.c_str(), MAX_PATH);
 			}


### PR DESCRIPTION
trimmed controller filename to the size of settings filename, resulting in controller file having "config=" attached to it.

(
16:19:570 Config.cpp:891 E[LOAD]: Error saving config - can't read ini C:\Games\ppsspp\memstick/PSP/SYSTEM/config=c:\temp\tcon.ini
16:19:570 Config.cpp:895 E[LOAD]: Error saving config - can't write ini C:\Games\ppsspp\memstick/PSP/SYSTEM/config=c:\temp\tcon.ini)
