### PR TITLE
Improve load and shutdown performance a bit

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -305,7 +305,7 @@ public:
 					Do(first);
 					typename M::mapped_type second = default_val;
 					Do(second);
-					x.emplace(first, second);
+					x.insert(std::make_pair(first, second));
 					--number;
 				}
 			}

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -309,7 +309,7 @@ bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 			return false;
 		}
 		z.avail_in = readSize;
-		z.next_out = frameSize == GetBlockSize() ? outPtr : zlibBuffer;
+		z.next_out = frameSize == (u32)GetBlockSize() ? outPtr : zlibBuffer;
 		z.avail_out = frameSize;
 		z.next_in = readBuffer;
 
@@ -330,7 +330,7 @@ bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 		}
 		inflateEnd(&z);
 
-		if (frameSize != GetBlockSize())
+		if (frameSize != (u32)GetBlockSize())
 		{
 			zlibBufferFrame = frameNumber;
 			memcpy(outPtr, zlibBuffer + compressedOffset, GetBlockSize());

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -31,6 +31,15 @@ class BlockDevice
 public:
 	virtual ~BlockDevice() {}
 	virtual bool ReadBlock(int blockNumber, u8 *outPtr) = 0;
+	virtual bool ReadBlocks(int minBlock, int count, u8 *outPtr) {
+		for (int b = 0; b < count; ++b) {
+			if (!ReadBlock(minBlock + b, outPtr)) {
+				return false;
+			}
+			outPtr += GetBlockSize();
+		}
+		return true;
+	}
 	int GetBlockSize() const { return 2048;}  // forced, it cannot be changed by subclasses
 	virtual u32 GetNumBlocks() = 0;
 };

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -31,7 +31,7 @@ class BlockDevice
 public:
 	virtual ~BlockDevice() {}
 	virtual bool ReadBlock(int blockNumber, u8 *outPtr) = 0;
-	virtual bool ReadBlocks(int minBlock, int count, u8 *outPtr) {
+	virtual bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
 		for (int b = 0; b < count; ++b) {
 			if (!ReadBlock(minBlock + b, outPtr)) {
 				return false;
@@ -50,7 +50,8 @@ class CISOFileBlockDevice : public BlockDevice
 public:
 	CISOFileBlockDevice(FILE *file);
 	~CISOFileBlockDevice();
-	bool ReadBlock(int blockNumber, u8 *outPtr);
+	bool ReadBlock(int blockNumber, u8 *outPtr) override;
+	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() { return numBlocks;}
 
 private:
@@ -73,6 +74,7 @@ public:
 	FileBlockDevice(FILE *file);
 	~FileBlockDevice();
 	bool ReadBlock(int blockNumber, u8 *outPtr) override;
+	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() override {return (u32)(filesize / GetBlockSize());}
 
 private:

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -58,9 +58,6 @@ enum
 	HLE_AFTER_SKIP_DEADBEEF     = 0x40,
 };
 
-typedef std::vector<Syscall> SyscallVector;
-typedef std::map<std::string, SyscallVector> SyscallVectorByModule;
-
 static std::vector<HLEModule> moduleDB;
 static int delayedResultEvent = -1;
 static int hleAfterSyscall = HLE_AFTER_NOTHING;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -114,7 +114,7 @@ struct VarSymbolImport {
 
 struct VarSymbolExport {
 	bool Matches(const VarSymbolImport &other) const {
-		return !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH) && nid == other.nid;
+		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
 	}
 
 	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
@@ -130,7 +130,7 @@ struct FuncSymbolImport {
 
 struct FuncSymbolExport {
 	bool Matches(const FuncSymbolImport &other) const {
-		return !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH) && nid == other.nid;
+		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
 	}
 
 	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -17,6 +17,15 @@
 
 #include <algorithm>
 #include <map>
+#ifdef IOS
+#include <tr1/unordered_map>
+namespace std {
+	using std::tr1::unordered_map;
+	using std::tr1::unordered_multimap;
+}
+#else
+#include <unordered_map>
+#endif
 #include "Common/ChunkFile.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/HLE.h"
@@ -155,7 +164,7 @@ struct LwMutex : public KernelObject
 static int mutexWaitTimer = -1;
 static int lwMutexWaitTimer = -1;
 // Thread -> Mutex locks for thread end.
-typedef std::multimap<SceUID, SceUID> MutexMap;
+typedef std::unordered_multimap<SceUID, SceUID> MutexMap;
 static MutexMap mutexHeldLocks;
 
 void __KernelMutexBeginCallback(SceUID threadID, SceUID prevCallbackId);
@@ -204,7 +213,7 @@ void __KernelMutexShutdown()
 void __KernelMutexAcquireLock(Mutex *mutex, int count, SceUID thread)
 {
 #if defined(_DEBUG)
-	std::pair<MutexMap::iterator, MutexMap::iterator> locked = mutexHeldLocks.equal_range(thread);
+	auto locked = mutexHeldLocks.equal_range(thread);
 	for (MutexMap::iterator iter = locked.first; iter != locked.second; ++iter)
 		_dbg_assert_msg_(SCEKERNEL, (*iter).second != mutex->GetUID(), "Thread %d / mutex %d wasn't removed from mutexHeldLocks properly.", thread, mutex->GetUID());
 #endif

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -222,12 +222,12 @@ void JitBlockCache::RemoveBlockMap(int block_num) {
 
 	const u32 pAddr = b.originalAddress & 0x1FFFFFFF;
 	auto it = block_map_.find(std::make_pair(pAddr + 4 * b.originalSize, pAddr));
-	if (it != block_map_.end() && it->second == block_num) {
+	if (it != block_map_.end() && it->second == (u32)block_num) {
 		block_map_.erase(it);
 	} else {
 		// It wasn't in there, or it has the wrong key.  Let's search...
 		for (auto it = block_map_.begin(); it != block_map_.end(); ++it) {
-			if (it->second == block_num) {
+			if (it->second == (u32)block_num) {
 				block_map_.erase(it);
 				break;
 			}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -200,7 +200,7 @@ void JitBlockCache::ProxyBlock(u32 rootAddress, u32 startAddress, u32 size, cons
 	// Make binary searches and stuff work ok
 	b.normalEntry = codePtr;
 	b.checkedEntry = codePtr;
-	proxyBlockMap_.emplace(startAddress, num_blocks_);
+	proxyBlockMap_.insert(std::make_pair(startAddress, num_blocks_));
 	AddBlockMap(num_blocks_);
 
 	num_blocks_++; //commit the current block
@@ -253,7 +253,7 @@ void JitBlockCache::FinalizeBlock(int block_num, bool block_link) {
 	if (block_link) {
 		for (int i = 0; i < MAX_JIT_BLOCK_EXITS; i++) {
 			if (b.exitAddress[i] != INVALID_EXIT) {
-				links_to_.emplace(b.exitAddress[i], block_num);
+				links_to_.insert(std::make_pair(b.exitAddress[i], block_num));
 				latestExit = std::max(latestExit, b.exitAddress[i]);
 			}
 		}

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -18,6 +18,15 @@
 #pragma once
 
 #include <map>
+#ifdef IOS
+#include <tr1/unordered_map>
+namespace std {
+	using std::tr1::unordered_map;
+	using std::tr1::unordered_multimap;
+}
+#else
+#include <unordered_map>
+#endif
 #include <vector>
 #include <string>
 
@@ -160,10 +169,10 @@ private:
 	MIPSState *mips_;
 	CodeBlock *codeBlock_;
 	JitBlock *blocks_;
-	std::multimap<u32, int> proxyBlockMap_;
+	std::unordered_multimap<u32, int> proxyBlockMap_;
 
 	int num_blocks_;
-	std::multimap<u32, int> links_to_;
+	std::unordered_multimap<u32, int> links_to_;
 	std::map<std::pair<u32,u32>, u32> block_map_; // (end_addr, start_addr) -> number
 
 	enum {

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -406,7 +406,7 @@ MemoryInitedLock Lock()
 	return MemoryInitedLock();
 }
 
-static Opcode Read_Instruction(u32 address, bool resolveReplacements, Opcode inst)
+__forceinline static Opcode Read_Instruction(u32 address, bool resolveReplacements, Opcode inst)
 {
 	if (!MIPS_IS_EMUHACK(inst.encoding)) {
 		return inst;

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -189,15 +189,16 @@ void __PPGeInit()
 		palette[i] = (val << 12) | 0xFFF;
 	}
 
-	u16_le *imagePtr = (u16_le *)imageData;
+	const u32_le *imagePtr = (u32_le *)imageData;
 	u8 *ramPtr = (u8 *)Memory::GetPointer(atlasPtr);
 
 	// Palettize to 4-bit, the easy way.
 	for (int i = 0; i < width * height / 2; i++) {
-		u16 c1 = imagePtr[i*2];
-		u16 c2 = imagePtr[i*2+1];
-		int a1 = c1 & 0xF;
-		int a2 = c2 & 0xF;
+		// Each pixel is 16 bits, so this loads two bits.
+		u32 c = imagePtr[i];
+		// It's white anyway, so we only look at one channel of each pixel.
+		int a1 = (c & 0x0000000F) >> 0;
+		int a2 = (c & 0x000F0000) >> 16;
 		u8 cval = (a2 << 4) | a1;
 		ramPtr[i] = cval;
 	}

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -194,7 +194,7 @@ void __PPGeInit()
 
 	// Palettize to 4-bit, the easy way.
 	for (int i = 0; i < width * height / 2; i++) {
-		// Each pixel is 16 bits, so this loads two bits.
+		// Each pixel is 16 bits, so this loads two pixels.
 		u32 c = imagePtr[i];
 		// It's white anyway, so we only look at one channel of each pixel.
 		int a1 = (c & 0x0000000F) >> 0;


### PR DESCRIPTION
When run in a loop, this makes games load a decent bit faster.  Although, initial load is still not a huge amount of time, I remember it being noticeable on my Android and this may help some.

On my desktop, in said loop with these changes, the biggest players are now:
- 34% Decoding PRX
- 33% __PPGeInit (98% of that is loading the zim)
- 10% ScanForFunctions

-[Unknown]
