### PR TITLE
Implement a few more x86jit ops

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1812,8 +1812,8 @@ void XEmitter::PCMPGTB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x64, dest, ar
 void XEmitter::PCMPGTW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x65, dest, arg);}
 void XEmitter::PCMPGTD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x66, dest, arg);}
 
-void XEmitter::PEXTRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC5, dest, arg); Write8(subreg);}
-void XEmitter::PINSRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC4, dest, arg); Write8(subreg);}
+void XEmitter::PEXTRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC5, dest, arg, 1); Write8(subreg);}
+void XEmitter::PINSRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC4, dest, arg, 1); Write8(subreg);}
 
 void XEmitter::PMADDWD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
 void XEmitter::PSADBW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1771,6 +1771,11 @@ void XEmitter::PBLENDVB(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3810, dest
 void XEmitter::BLENDVPS(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3814, dest, arg);}
 void XEmitter::BLENDVPD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3815, dest, arg);}
 
+void XEmitter::ROUNDSS(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A0A, dest, arg, 1); Write8(mode);}
+void XEmitter::ROUNDSD(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A0B, dest, arg, 1); Write8(mode);}
+void XEmitter::ROUNDPS(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A08, dest, arg, 1); Write8(mode);}
+void XEmitter::ROUNDPD(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A09, dest, arg, 1); Write8(mode);}
+
 void XEmitter::PAND(X64Reg dest, OpArg arg)     {WriteSSEOp(0x66, 0xDB, dest, arg);}
 void XEmitter::PANDN(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xDF, dest, arg);}
 void XEmitter::PXOR(X64Reg dest, OpArg arg)     {WriteSSEOp(0x66, 0xEF, dest, arg);}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -141,6 +141,17 @@ enum FloatOp {
 	floatINVALID = -1,
 };
 
+enum FloatRound {
+	FROUND_NEAREST = 0,
+	FROUND_FLOOR = 1,
+	FROUND_CEIL = 2,
+	FROUND_ZERO = 3,
+	FROUND_MXCSR = 4,
+
+	FROUND_RAISE_PRECISION = 0,
+	FROUND_IGNORE_PRECISION = 8,
+};
+
 class XEmitter;
 
 // RIP addressing does not benefit from micro op fusion on Core arch
@@ -792,6 +803,32 @@ public:
 	void PBLENDVB(X64Reg dest, OpArg arg);
 	void BLENDVPS(X64Reg dest, OpArg arg);
 	void BLENDVPD(X64Reg dest, OpArg arg);
+
+	// SSE4: rounding (see FloatRound for mode or use ROUNDNEARSS, etc. helpers.)
+	void ROUNDSS(X64Reg dest, OpArg arg, u8 mode);
+	void ROUNDSD(X64Reg dest, OpArg arg, u8 mode);
+	void ROUNDPS(X64Reg dest, OpArg arg, u8 mode);
+	void ROUNDPD(X64Reg dest, OpArg arg, u8 mode);
+
+	inline void ROUNDNEARSS(X64Reg dest, OpArg arg) { ROUNDSS(dest, arg, FROUND_NEAREST); }
+	inline void ROUNDFLOORSS(X64Reg dest, OpArg arg) { ROUNDSS(dest, arg, FROUND_FLOOR); }
+	inline void ROUNDCEILSS(X64Reg dest, OpArg arg) { ROUNDSS(dest, arg, FROUND_CEIL); }
+	inline void ROUNDZEROSS(X64Reg dest, OpArg arg) { ROUNDSS(dest, arg, FROUND_ZERO); }
+
+	inline void ROUNDNEARSD(X64Reg dest, OpArg arg) { ROUNDSD(dest, arg, FROUND_NEAREST); }
+	inline void ROUNDFLOORSD(X64Reg dest, OpArg arg) { ROUNDSD(dest, arg, FROUND_FLOOR); }
+	inline void ROUNDCEILSD(X64Reg dest, OpArg arg) { ROUNDSD(dest, arg, FROUND_CEIL); }
+	inline void ROUNDZEROSD(X64Reg dest, OpArg arg) { ROUNDSD(dest, arg, FROUND_ZERO); }
+
+	inline void ROUNDNEARPS(X64Reg dest, OpArg arg) { ROUNDPS(dest, arg, FROUND_NEAREST); }
+	inline void ROUNDFLOORPS(X64Reg dest, OpArg arg) { ROUNDPS(dest, arg, FROUND_FLOOR); }
+	inline void ROUNDCEILPS(X64Reg dest, OpArg arg) { ROUNDPS(dest, arg, FROUND_CEIL); }
+	inline void ROUNDZEROPS(X64Reg dest, OpArg arg) { ROUNDPS(dest, arg, FROUND_ZERO); }
+
+	inline void ROUNDNEARPD(X64Reg dest, OpArg arg) { ROUNDPD(dest, arg, FROUND_NEAREST); }
+	inline void ROUNDFLOORPD(X64Reg dest, OpArg arg) { ROUNDPD(dest, arg, FROUND_FLOOR); }
+	inline void ROUNDCEILPD(X64Reg dest, OpArg arg) { ROUNDPD(dest, arg, FROUND_CEIL); }
+	inline void ROUNDZEROPD(X64Reg dest, OpArg arg) { ROUNDPD(dest, arg, FROUND_ZERO); }
 
 	// AVX
 	void VADDSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -384,8 +384,8 @@ bool CISOFileBlockDevice::ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
 		const u32 frameBlocks = std::min(lastBlock - block + 1, blocksPerFrame) - frameBlockOffset;
 
 		if (frameReadEnd > readBufferEnd) {
-			const size_t maxNeeded = totalReadEnd - frameReadPos;
-			const size_t chunkSize = std::min(maxNeeded, (size_t)std::max(frameReadSize, CSO_READ_BUFFER_SIZE));
+			const s64 maxNeeded = totalReadEnd - frameReadPos;
+			const size_t chunkSize = (size_t)std::min(maxNeeded, (s64)std::max(frameReadSize, CSO_READ_BUFFER_SIZE));
 
 			fseeko(f, frameReadPos, SEEK_SET);
 			const u32 readSize = (u32)fread(readBuffer, 1, chunkSize, f);

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1040,6 +1040,7 @@ skip:
 
 		// Most of the time, functions from the same module will be contiguous in functions.
 		FunctionsVector::iterator prevMatch = functions.end();
+		size_t originalSize = functions.size();
 		for (auto iter = functions.begin(); iter != functions.end(); ++iter) {
 			const bool hadPrevMatch = prevMatch != functions.end();
 			const bool match = iter->start >= startAddr && iter->start <= endAddr;
@@ -1060,8 +1061,11 @@ skip:
 
 		RestoreReplacedInstructions(startAddr, endAddr);
 
-		// TODO: Also wipe them from hash->function map.
-		// It should be fine not to though, since a collision is not likely.
+		if (functions.empty()) {
+			hashToFunction.clear();
+		} else if (originalSize != functions.size()) {
+			UpdateHashToFunctionMap();
+		}
 	}
 
 	void ReplaceFunctions() {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1700,8 +1700,12 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ABI_CallFunction(thunks.ProtectFunction((const void *)&SinOnly, 0));
 #else
 			// Sigh, passing floats with cdecl isn't pretty, ends up on the stack.
-			MOVD_xmm(EAX, fpr.V(sregs[i]));
-			ABI_CallFunctionA(thunks.ProtectFunction((const void *)&SinOnly, 1), R(EAX));
+			if (fpr.V(sregs[i]).IsSimpleReg()) {
+				MOVD_xmm(R(EAX), fpr.VX(sregs[i]));
+			} else {
+				MOV(32, R(EAX), fpr.V(sregs[i]));
+			}
+			CallProtectedFunction((const void *)&SinOnly, R(EAX));
 #endif
 
 			MOVSS(tempxregs[i], M(&sincostemp[0]));
@@ -1712,8 +1716,12 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ABI_CallFunction(thunks.ProtectFunction((const void *)&CosOnly, 0));
 #else
 			// Sigh, passing floats with cdecl isn't pretty, ends up on the stack.
-			MOVD_xmm(EAX, fpr.V(sregs[i]));
-			ABI_CallFunctionA(thunks.ProtectFunction((const void *)&CosOnly, 1), R(EAX));
+			if (fpr.V(sregs[i]).IsSimpleReg()) {
+				MOVD_xmm(R(EAX), fpr.VX(sregs[i]));
+			} else {
+				MOV(32, R(EAX), fpr.V(sregs[i]));
+			}
+			CallProtectedFunction((const void *)&CosOnly, R(EAX));
 #endif
 
 			MOVSS(tempxregs[i], M(&sincostemp[1]));
@@ -1734,8 +1742,12 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ABI_CallFunction(thunks.ProtectFunction((const void *)&ASinScaled, 0));
 #else
 			// Sigh, passing floats with cdecl isn't pretty, ends up on the stack.
-			MOVD_xmm(EAX, fpr.V(sregs[i]));
-			ABI_CallFunctionA(thunks.ProtectFunction((const void *)&ASinScaled, 1), R(EAX));
+			if (fpr.V(sregs[i]).IsSimpleReg()) {
+				MOVD_xmm(R(EAX), fpr.VX(sregs[i]));
+			} else {
+				MOV(32, R(EAX), fpr.V(sregs[i]));
+			}
+			CallProtectedFunction((const void *)&ASinScaled, R(EAX));
 #endif
 
 			MOVSS(tempxregs[i], M(&sincostemp[0]));
@@ -1751,8 +1763,12 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ABI_CallFunction(thunks.ProtectFunction((const void *)&NegSinOnly, 0));
 #else
 			// Sigh, passing floats with cdecl isn't pretty, ends up on the stack.
-			MOVD_xmm(EAX, fpr.V(sregs[i]));
-			ABI_CallFunctionA(thunks.ProtectFunction((const void *)&NegSinOnly, 1), R(EAX));
+			if (fpr.V(sregs[i]).IsSimpleReg()) {
+				MOVD_xmm(R(EAX), fpr.VX(sregs[i]));
+			} else {
+				MOV(32, R(EAX), fpr.V(sregs[i]));
+			}
+			CallProtectedFunction((const void *)&NegSinOnly, R(EAX));
 #endif
 
 			MOVSS(tempxregs[i], M(&sincostemp[0]));


### PR DESCRIPTION
I'm not 100% sure about d7bdded6f89c71e1f7b414e68f860edb5298ce63.  If there's a special reason it wasn't using `extrabytes` it probably needs a comment.

I initially added ROUNDSD etc. but then realized of course I need vf2i to result in an _integer_, heh.  So I never used them.  I think they work but I only really tested ROUNDSD and not heavily at all.

-[Unknown]
