### PR TITLE
Minor snprintf() and perf changes

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -608,22 +608,20 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 
 	for (int i = 0; i < 4; i++) {
 		if (dirty & (DIRTY_LIGHT0 << i)) {
-			if (u_lightpos[i] != -1) {
-				if (gstate.isDirectionalLight(i)) {
-					// Prenormalize
-					float x = getFloat24(gstate.lpos[i * 3 + 0]);
-					float y = getFloat24(gstate.lpos[i * 3 + 1]);
-					float z = getFloat24(gstate.lpos[i * 3 + 2]);
-					float len = sqrtf(x*x + y*y + z*z);
-					if (len == 0.0f)
-						len = 1.0f;
-					else
-						len = 1.0f / len;
-					float vec[3] = { x * len, y * len, z * len };
-					glUniform3fv(u_lightpos[i], 1, vec);
-				} else {
-					SetFloat24Uniform3(u_lightpos[i], &gstate.lpos[i * 3]);
-				}
+			if (gstate.isDirectionalLight(i)) {
+				// Prenormalize
+				float x = getFloat24(gstate.lpos[i * 3 + 0]);
+				float y = getFloat24(gstate.lpos[i * 3 + 1]);
+				float z = getFloat24(gstate.lpos[i * 3 + 2]);
+				float len = sqrtf(x*x + y*y + z*z);
+				if (len == 0.0f)
+					len = 1.0f;
+				else
+					len = 1.0f / len;
+				float vec[3] = { x * len, y * len, z * len };
+				glUniform3fv(u_lightpos[i], 1, vec);
+			} else {
+				SetFloat24Uniform3(u_lightpos[i], &gstate.lpos[i * 3]);
 			}
 			if (u_lightdir[i] != -1) SetFloat24Uniform3(u_lightdir[i], &gstate.ldir[i * 3]);
 			if (u_lightatt[i] != -1) SetFloat24Uniform3(u_lightatt[i], &gstate.latt[i * 3]);

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -57,27 +57,27 @@ void GeDescribeVertexType(u32 op, char *buffer, int len) {
 	char *w = buffer, *end = buffer + len;
 	if (through)
 		w += snprintf(w, end - w, "through, ");
-	if (typeNames[tc])
+	if (typeNames[tc] && w < end)
 		w += snprintf(w, end - w, "%s texcoords, ", typeNames[tc]);
-	if (colorNames[col])
+	if (colorNames[col] && w < end)
 		w += snprintf(w, end - w, "%s colors, ", colorNames[col]);
-	if (typeNames[nrm])
+	if (typeNames[nrm] && w < end)
 		w += snprintf(w, end - w, "%s normals, ", typeNamesS[nrm]);
-	if (typeNames[pos])
+	if (typeNames[pos] && w < end)
 		w += snprintf(w, end - w, "%s positions, ", typeNamesS[pos]);
-	if (typeNames[weight])
+	if (typeNames[weight] && w < end)
 		w += snprintf(w, end - w, "%s weights (%d), ", typeNames[weight], weightCount);
-	else if (weightCount > 0)
+	else if (weightCount > 0 && w < end)
 		w += snprintf(w, end - w, "unknown weights (%d), ", weightCount);
-	if (morphCount > 0)
+	if (morphCount > 0 && w < end)
 		w += snprintf(w, end - w, "%d morphs, ", morphCount);
-	if (typeNames[idx])
+	if (typeNames[idx] && w < end)
 		w += snprintf(w, end - w, "%s indexes, ", typeNames[idx]);
 
 	if (w < buffer + 2)
 		snprintf(buffer, len, "none");
 	// Otherwise, get rid of the pesky trailing comma.
-	else
+	else if (w < end)
 		w[-2] = '\0';
 }
 

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -905,12 +905,12 @@ void CtrlDisAsmView::copyInstructions(u32 startAddr, u32 endAddr, bool withDisas
 		char *temp = new char[space];
 
 		char *p = temp, *end = temp + space;
-		for (u32 pos = startAddr; pos < endAddr; pos += instructionSize)
+		for (u32 pos = startAddr; pos < endAddr && p < end; pos += instructionSize)
 		{
 			p += snprintf(p, end - p, "%08X", debugger->readMemory(pos));
 
 			// Don't leave a trailing newline.
-			if (pos + instructionSize < endAddr)
+			if (pos + instructionSize < endAddr && p < end)
 				p += snprintf(p, end - p, "\r\n");
 		}
 		W32Util::CopyTextToClipboard(wnd, temp);

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -314,7 +314,7 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				char *temp = new char[space];
 
 				char *p = temp, *end = temp + space;
-				for (u32 pos = selectRangeStart; pos < selectRangeEnd; pos += instructionSize)
+				for (u32 pos = selectRangeStart; pos < selectRangeEnd && p < end; pos += instructionSize)
 				{
 					GPUDebugOp op = gpuDebug->DissassembleOp(pos);
 					p += snprintf(p, end - p, "%s\r\n", op.desc.c_str());
@@ -351,7 +351,7 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				char *temp = new char[space];
 
 				char *p = temp, *end = temp + space;
-				for (u32 pos = selectRangeStart; pos < selectRangeEnd; pos += instructionSize)
+				for (u32 pos = selectRangeStart; pos < selectRangeEnd && p < end; pos += instructionSize)
 					p += snprintf(p, end - p, "%08X\r\n", Memory::ReadUnchecked_U32(pos));
 
 				W32Util::CopyTextToClipboard(wnd, temp);


### PR DESCRIPTION
No major impact.  Avoids a crash on a large copy of instructions, and kills a compare that's not needed.

-[Unknown]
