### PR TITLE
Do not let Direct3D override Software rendering

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -85,9 +85,17 @@ void EmuScreen::bootGame(const std::string &filename) {
 
 	CoreParameter coreParam;
 	coreParam.cpuCore = g_Config.bJit ? CPU_JIT : CPU_INTERPRETER;
-	coreParam.gpuCore = g_Config.bSoftwareRendering ? GPU_SOFTWARE : GPU_GLES;
-	if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
+	if (g_Config.bSoftwareRendering)
+	{
+		coreParam.gpuCore = GPU_SOFTWARE;
+	}
+	else if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9)
+	{
 		coreParam.gpuCore = GPU_DIRECTX9;
+	}
+	else
+	{
+		coreParam.gpuCore = GPU_GLES;;
 	}
 	coreParam.enableSound = g_Config.bEnableSound;
 	coreParam.fileToStart = filename;


### PR DESCRIPTION
This could be done more compact with a nested ?: , but I think this makes a lot clearer what's going on

It's either 
- this 
- disable the software rendering option in Direct3D,
- add the Software renderer as a seperate backend

I would actually like option #3 the most (although it does mix quite different semantics, one requires restart, the other can't be enabled when a game is loaded), but this was the first thing that came to mind
