### PR TITLE
Disable software rendering UI when Direct3D is used

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -298,7 +298,7 @@ void GameSettingsScreen::CreateViews() {
 	// We normally use software rendering to debug so put it in debugging.
 	CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gs->T("Software Rendering", "Software Rendering (experimental)")));
 	softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);
-	if (PSP_IsInited())
+	if (PSP_IsInited() || g_Config.iGPUBackend != GPU_BACKEND_OPENGL)
 		softwareGPU->SetEnabled(false);
 
 	// Audio


### PR DESCRIPTION
Don't let people enable the software rendering checkbox if the backend is not OpenGL, since the software mode depends on OpenGL.

It's already being disabled when switching backends.
