### PR TITLE
Handle negative read sizes more correctly

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -566,28 +566,30 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 
 		_dbg_assert_msg_(FILESYS, (middleSize & 2047) == 0, "Remaining size should be aligned");
 
-		if (firstBlockSize != 0)
+		const u8 *const start = pointer;
+		if (firstBlockSize > 0)
 		{
 			blockDevice->ReadBlock(secNum++, theSector);
 			memcpy(pointer, theSector + firstBlockOffset, firstBlockSize);
 			pointer += firstBlockSize;
 		}
-		if (middleSize != 0)
+		if (middleSize > 0)
 		{
 			const u32 sectors = (u32)(middleSize / 2048);
 			blockDevice->ReadBlocks(secNum, sectors, pointer);
 			secNum += sectors;
 			pointer += middleSize;
 		}
-		if (lastBlockSize != 0)
+		if (lastBlockSize > 0)
 		{
 			blockDevice->ReadBlock(secNum++, theSector);
 			memcpy(pointer, theSector, lastBlockSize);
 			pointer += lastBlockSize;
 		}
 
-		e.seekPos += (unsigned int)size;
-		return (size_t)size;
+		size_t totalBytes = pointer - start;
+		e.seekPos += (unsigned int)totalBytes;
+		return (size_t)totalBytes;
 	}
 	else
 	{

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -726,6 +726,9 @@ bool __IoRead(int &result, int id, u32 data_addr, int size) {
 		if (!(f->openMode & FILEACCESS_READ)) {
 			result = ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
 			return true;
+		} else if (size < 0) {
+			result = SCE_KERNEL_ERROR_ILLEGAL_ADDR;
+			return true;
 		} else if (Memory::IsValidAddress(data_addr)) {
 			CBreakPoints::ExecMemCheck(data_addr, true, size, currentMIPS->pc);
 			u8 *data = (u8*) Memory::GetPointer(data_addr);
@@ -855,6 +858,10 @@ bool __IoWrite(int &result, int id, u32 data_addr, int size) {
 		}
 		if (!(f->openMode & FILEACCESS_WRITE)) {
 			result = ERROR_KERNEL_BAD_FILE_DESCRIPTOR;
+			return true;
+		}
+		if (size < 0) {
+			result = SCE_KERNEL_ERROR_ILLEGAL_ADDR;
 			return true;
 		}
 


### PR DESCRIPTION
A negative read or write size always returns (afaict) `SCE_KERNEL_ERROR_ILLEGAL_ADDR`, at least in user mode for valid addresses.

-[Unknown]
