### PR TITLE
x86jit: Micro optimize vs2i a bit

### DIFF
--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1291,7 +1291,7 @@ void Jit::Comp_Vx2i(MIPSOpcode op) {
 	}
 
 	// Unpack 16-bit words into 32-bit words, upper position, and we're done!
-	XORPS(XMM0, R(XMM0));
+	PXOR(XMM0, R(XMM0));
 	PUNPCKLWD(XMM0, R(XMM1));
 	
 	// Done! TODO: The rest of this should be possible to extract into a function.
@@ -1300,13 +1300,13 @@ void Jit::Comp_Vx2i(MIPSOpcode op) {
 	// TODO: Could apply D-prefix in parallel here...
 
 	MOVSS(fpr.V(dregs[0]), XMM0);
-	SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(3, 3, 2, 1));
+	PSRLDQ(XMM0, 4);
 	MOVSS(fpr.V(dregs[1]), XMM0);
 
 	if (sz != V_Single) {
-		SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(3, 3, 2, 1));
+		PSRLDQ(XMM0, 4);
 		MOVSS(fpr.V(dregs[2]), XMM0);
-		SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(3, 3, 2, 1));
+		PSRLDQ(XMM0, 4);
 		MOVSS(fpr.V(dregs[3]), XMM0);
 	}
 


### PR DESCRIPTION
You can see the latency/throughput of shufps vs psrldq here:
https://software.intel.com/sites/landingpage/IntrinsicsGuide/

I was wondering if this would actually help, so I hacked together something in UnitTest that will run arbitrary opcodes through the interp and then jit and give a speed ratio.  It's a big mess right now, but I'm thinking it's a good idea for jit performance testing (ought to work on ARM and x86 too.)  Right now I hacked Break into Core_Stop()'ing, and added tons of deps to UnitTest to make the linker happy (it's still complaining.)

Will probably have a chance to clean it up later, but if you have any suggestions let me know.  I guess a cleanish way could just be creating a temporary elf file, but I'm probably going to add some coreParameter to allow initialization without a valid file (I'm writing the ops directly to ram.)

Anyway, the goal would really be to test arbitrary sequences of opcodes, not always specific opcodes only.

Anyway this was tested with:

``` c++
    for (int i = 0; i < 100; ++i) {
        *p++ = 0xD03B0000 | (1 >> 7) | (7 << 8);
        *p++ = 0xD03B0000 | (1 >> 7);
        *p++ = 0xD03B0000 | (7 << 8);
        *p++ = 0xD03B0000 | (1 >> 7) | (7 << 8);
        *p++ = 0xD03B0000 | (1 >> 7) | (7 << 8);
        *p++ = 0xD03B0000 | (1 >> 7) | (7 << 8);
        *p++ = 0xD03B0000 | (1 >> 7) | (7 << 8);
    }
    *p++ = MIPS_MAKE_BREAK(1);
```

And then compared how many of those it could run full cycle in a loop within 0.5 seconds.

Previous version: 3571% speed of interpreter
This version: 4661% speed of interpreter

I'm not sure how well % of interpreter will scale across micro-architectures, maybe it's a bad way to measure.

-[Unknown]
