### PR TITLE
Add a hotkey to swap D-pad and left analog stick keys

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -939,10 +939,10 @@ void SwapKeys(int btn1, int btn2) {
 
 // Swap direction buttons and left analog axis
 void SwapAxis() {
-	SwapKeys(0, 12);
-	SwapKeys(1, 13);
-	SwapKeys(2, 14);
-	SwapKeys(3, 15);
+	SwapKeys(CTRL_UP, VIRTKEY_AXIS_Y_MAX);
+	SwapKeys(CTRL_DOWN, VIRTKEY_AXIS_Y_MIN);
+	SwapKeys(CTRL_LEFT, VIRTKEY_AXIS_X_MIN);
+	SwapKeys(CTRL_RIGHT, VIRTKEY_AXIS_X_MAX);
 }
 
 }  // KeyMap

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -650,6 +650,8 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{VIRTKEY_AXIS_RIGHT_Y_MIN, "RightAn.Down"},
 	{VIRTKEY_AXIS_RIGHT_X_MIN, "RightAn.Left"},
 	{VIRTKEY_AXIS_RIGHT_X_MAX, "RightAn.Right"},
+
+	{VIRTKEY_AXIS_SWAP, "AxisSwap"},
 };
 
 const int AXIS_BIND_NKCODE_START = 4000;
@@ -919,5 +921,28 @@ const std::set<std::string> &GetSeenPads() {
 	return g_seenPads;
 }
 
+
+void SwapKeys(int btn1, int btn2) {
+	std::vector<KeyDef> keys1;
+	std::vector<KeyDef> keys2;
+	KeyFromPspButton(psp_button_names[btn1].key, &keys1);
+	KeyFromPspButton(psp_button_names[btn2].key, &keys2);
+	RemoveButtonMapping(psp_button_names[btn1].key);
+	RemoveButtonMapping(psp_button_names[btn2].key);
+	for (size_t j = 0; j < keys1.size(); j++) {
+		SetKeyMapping(psp_button_names[btn2].key, KeyDef(keys1[j].deviceId, keys1[j].keyCode), false);
+	}
+	for (size_t j = 0; j < keys2.size(); j++) {
+		SetKeyMapping(psp_button_names[btn1].key, KeyDef(keys2[j].deviceId, keys2[j].keyCode), false);
+	}
+}
+
+// Swap direction buttons and left analog axis
+void SwapAxis() {
+	SwapKeys(0, 12);
+	SwapKeys(1, 13);
+	SwapKeys(2, 14);
+	SwapKeys(3, 15);
+}
 
 }  // KeyMap

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -949,10 +949,7 @@ const std::set<std::string> &GetSeenPads() {
 
 // Swap direction buttons and left analog axis
 void SwapAxis() {
-	if (g_swapped_keys)
-		g_swapped_keys = false;
-	else
-		g_swapped_keys = true;
+	g_swapped_keys = !g_swapped_keys;
 }
 
 }  // KeyMap

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -719,7 +719,7 @@ KeyDef AxisDef(int deviceId, int axisId, int direction) {
 	return KeyDef(deviceId, TranslateKeyCodeFromAxis(axisId, direction));
 }
 
-int SwappedKey(int btn) {
+int CheckAxisSwap(int btn) {
 	if (g_swapped_keys) {
 		switch (btn) {
 			case CTRL_UP: btn = VIRTKEY_AXIS_Y_MAX;
@@ -748,7 +748,7 @@ static bool FindKeyMapping(int deviceId, int key, std::vector<int> *psp_button) 
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter) {
 		for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
 			if (*iter2 == KeyDef(deviceId, key)) {
-				psp_button->push_back(SwappedKey(iter->first));
+				psp_button->push_back(CheckAxisSwap(iter->first));
 			}
 		}
 	}

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -47,6 +47,7 @@ enum {
 	VIRTKEY_NEXT_SLOT  = 0x1000f,
 	VIRTKEY_TOGGLE_FULLSCREEN = 0x10010,
 	VIRTKEY_ANALOG_LIGHTLY = 0x10011,
+	VIRTKEY_AXIS_SWAP = 0x10012,
 	VIRTKEY_LAST,
 	VIRTKEY_COUNT = VIRTKEY_LAST - VIRTKEY_FIRST
 };
@@ -156,6 +157,7 @@ namespace KeyMap {
 
 	void RestoreDefault();
 
+	void SwapAxis();
 	void UpdateConfirmCancelKeys();
 
 	void NotifyPadConnected(const std::string &name);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -290,6 +290,10 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		pauseTrigger_ = true;
 		break;
 
+	case VIRTKEY_AXIS_SWAP:
+		KeyMap::SwapAxis();
+		break;
+
 	case VIRTKEY_AXIS_X_MIN:
 	case VIRTKEY_AXIS_X_MAX:
 		setVKeyAnalogX(CTRL_STICK_LEFT, VIRTKEY_AXIS_X_MIN, VIRTKEY_AXIS_X_MAX);


### PR DESCRIPTION
Some games use D-pad for in-game movement & menu selections while others use left analog stick for that (leaving D-pad for items usage, map etc routines). Instead of re-defining keys for every game it's better to have a "swap" hotkey to switch between D-pad and left analog stick keys.

This patch is used in ROSA & OpenMandriva linux but likely it's worth of merging upstream.
