### PR TITLE
x86jit: Implement other forms of vx2i

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -760,6 +760,8 @@ namespace MIPSInt
 			// Quad is the only option.
 			// This operation is weird. This particular way of working matches hw but does not 
 			// seem quite sane.
+			// I guess it's used for fixed-point math, and fills more bits to facilitate
+			// conversion between 8-bit and 16-bit values.  But then why not do it in vc2i?
 			{
 				u32 value = s[0];
 				u32 value2 = value / 2;


### PR DESCRIPTION
Gains 3.2% fps in Grand Knights History.  And I should note, that's with it spending > 50% of its time dealing with graphics, single threaded (30% overall hashing textures, in fact.)  With the other changes, up to 1020% now.

This also marks the first usage of > SSE2 in the jit.  It's only really faster using SSSE3 (on my desktop) for vc2i.  vuc2i is a wash, but at least it should be less bytes of code.  It was slower for vs2i/vus2i (which makes sense, those are awfully simple.)

-[Unknown]
