### PR TITLE
Workaround for graphics glitch in Phantasy Star Portable 2

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -444,6 +444,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("VSyncInterval", &g_Config.bVSync, false),
 	ReportedConfigSetting("DisableStencilTest", &g_Config.bDisableStencilTest, false),
 	ReportedConfigSetting("AlwaysDepthWrite", &g_Config.bAlwaysDepthWrite, false),
+	ReportedConfigSetting("DepthRangeHack", &g_Config.bDepthRangeHack, false),
 
 	// Not really a graphics setting...
 	ReportedConfigSetting("TimerHack", &g_Config.bTimerHack, &DefaultTimerHack),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -165,6 +165,7 @@ public:
 	bool bReloadCheats;
 	bool bDisableStencilTest;
 	bool bAlwaysDepthWrite;
+	bool bDepthRangeHack;
 	bool bTimerHack;
 	bool bAlphaMaskHack;
 	bool bBlockTransferGPU;

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -305,7 +305,7 @@ static void SetColorUniform3Alpha255(int uniform, u32 color, u8 alpha) {
 			(float)((color & 0xFF) >> 0),
 			(float)((color & 0xFF00) >> 8),
 			(float)((color & 0xFF0000) >> 16),
-			(float)alpha
+			(float)alpha 
 		};
 		glUniform4fv(uniform, 1, col);
 	}
@@ -413,8 +413,10 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 					a = (n + f) / (n - f);
 					b = (2.0f * n * f) / (n - f);
 
-					flippedMatrix[10] = a;
-					flippedMatrix[14] = b;
+					if (!my_isnan(a) && !my_isnan(b)) {
+						flippedMatrix[10] = a;
+						flippedMatrix[14] = b;
+					}
 				}
 			}
 		}

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -93,7 +93,7 @@ static const GLushort cullingMode[] = {
 };
 
 static const GLushort ztests[] = {
-	GL_NEVER, GL_ALWAYS, GL_EQUAL, GL_NOTEQUAL,
+	GL_NEVER, GL_ALWAYS, GL_EQUAL, GL_NOTEQUAL, 
 	GL_LESS, GL_LEQUAL, GL_GREATER, GL_GEQUAL,
 };
 
@@ -732,7 +732,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 	int scissorY2 = gstate.getScissorY2() + 1;
 
 	// This is a bit of a hack as the render buffer isn't always that size
-	if (scissorX1 == 0 && scissorY1 == 0
+	if (scissorX1 == 0 && scissorY1 == 0 
 		&& scissorX2 >= (int) gstate_c.curRTWidth
 		&& scissorY2 >= (int) gstate_c.curRTHeight) {
 		glstate.scissorTest.disable();
@@ -765,7 +765,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 		// No viewport transform here. Let's experiment with using region.
 		glstate.viewport.set(
-			renderX + (0 + regionX1) * renderWidthFactor,
+			renderX + (0 + regionX1) * renderWidthFactor, 
 			renderY + (0 - regionY1) * renderHeightFactor,
 			(regionX2 - regionX1) * renderWidthFactor,
 			(regionY2 - regionY1) * renderHeightFactor);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -805,9 +805,46 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 		float zScale = getFloat24(gstate.viewportz1) / 65535.0f;
 		float zOff = getFloat24(gstate.viewportz2) / 65535.0f;
-		float depthRangeMin = zOff - zScale;
-		float depthRangeMax = zOff + zScale;
-		glstate.depthRange.set(depthRangeMin, depthRangeMax);
+
+		// In Phantasy Star Portable 2, depth range sometimes goes negative and is clamped by glDepthRange to 0,
+		// causing graphics clipping glitch (issue #1788). This hack modifies the projection matrix to work around it.
+		if (g_Config.bDepthRangeHack) {
+			// if far depth range < 0
+			if (zOff + zScale < 0.0f) {
+				// if perspective projection
+				if (gstate.projMatrix[11] < 0.0f) {
+					float depthMax = gstate.getDepthRangeMax() / 65535.0f;
+					float depthMin = gstate.getDepthRangeMin() / 65535.0f;
+
+					float a = gstate.projMatrix[10];
+					float b = gstate.projMatrix[14];
+
+					float n = b / (a - 1.0f);
+					float f = b / (a + 1.0f);
+
+					f = (n * f) / (n + ((zOff + zScale) * (n - f) / (depthMax - depthMin)));
+
+					a = (n + f) / (n - f);
+					b = (2.0f * n * f) / (n - f);
+
+					gstate.projMatrix[10] = a;
+					gstate.projMatrix[14] = b;
+
+					shaderManager_->DirtyUniform(DIRTY_PROJMATRIX);
+
+					zOff = (zOff - zScale) / 2.0f;
+					zScale = -zOff;
+
+					gstate.viewportz2 &= 0xFF000000;
+					gstate.viewportz2 |= toFloat24(zOff * 65535.0f);
+
+					gstate.viewportz1 &= 0xFF000000;
+					gstate.viewportz1 |= toFloat24(zScale * 65535.0f);
+				}
+			}
+		}
+
+		glstate.depthRange.set(zOff - zScale, zOff + zScale);
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -278,6 +278,9 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *prescale = graphicsSettings->Add(new CheckBox(&g_Config.bPrescaleUV, gs->T("Texture Coord Speedhack")));
 	prescale->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
+	CheckBox *depthRange = graphicsSettings->Add(new CheckBox(&g_Config.bDepthRangeHack, gs->T("Depth Range Hack (Phantasy Star Portable 2)")));
+	depthRange->SetDisabledPtr(&g_Config.bSoftwareRendering);
+
 	graphicsSettings->Add(new ItemHeader(gs->T("Overlay Information")));
 	static const char *fpsChoices[] = {
 		"None", "Speed", "FPS", "Both"


### PR DESCRIPTION
In Phantasy Star Portable 2, depth range sometimes goes negative and is clamped by `glDepthRange` to 0, causing graphics clipping glitch (issue #1788). This hack modifies the projection matrix to work around it.

A checkbox is added under Hack setting to toggle this.

Hack off
![a0](https://cloud.githubusercontent.com/assets/9575661/4964325/afe64a3a-6792-11e4-9ee0-89358f0851d6.png)

Hack on
![a1](https://cloud.githubusercontent.com/assets/9575661/4964330/c37a5b0e-6792-11e4-9963-bcbe43fc2a50.png)
