### PR TITLE
x86jit: Micro optimize cvt.s.w a bit

### DIFF
--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -285,10 +285,14 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		break;
 
 	case 32: //F(fd)	= (float)FsI(fs);			break; //cvt.s.w
-		// Store to memory so we can read it as an integer value.
-		fpr.StoreFromRegister(fs);
-		CVTSI2SS(XMM0, fpr.R(fs));
-		MOVSS(fpr.R(fd), XMM0);
+		fpr.MapReg(fd, fs == fd, true);
+		if (fpr.R(fs).IsSimpleReg()) {
+			CVTDQ2PS(fpr.RX(fd), fpr.R(fs));
+		} else {
+			// If fs was fd, we'd be in the case above since we mapped fd.
+			MOVSS(fpr.RX(fd), fpr.R(fs));
+			CVTDQ2PS(fpr.RX(fd), fpr.R(fd));
+		}
 		break;
 
 	case 36: //FsI(fd) = (int)	F(fs);			 break; //cvt.w.s

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -18,6 +18,8 @@
 #include "base/timeutil.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/MIPS/MIPSAsm.h"
 #include "Core/MemMap.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"


### PR DESCRIPTION
This implementation is about 5x faster for micro benchmarks.  Little impact to overall perf in games I tested, though.

CVTDQ2PS has lower latency, and I suppose a game is likely to use the reg afterward, so might as well map fd.  Just a single op if fd == fs which I'm pretty sure is common, otherwise an unaligned load (maybe could map to a reg but unsure if losing a reg is worth it since they're likely done with that reg...)

-[Unknown]
