### PR TITLE
x86jit: More fpu optimizations

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -45,8 +45,8 @@ namespace MIPSComp
 {
 	static bool NeedsTempForSETcc(X64Reg reg) {
 #ifndef _M_X64
-		// Can't use ESI or EDI, no 8-bit version.
-		if (reg != EDX && reg != ECX) {
+		// Can't use ESI or EDI (which we use), no 8-bit versions.  Only these.
+		if (reg != EAX && reg != EBX && reg != ECX && reg != EDX) {
 			return true;
 		}
 #endif

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -43,6 +43,16 @@ using namespace MIPSAnalyst;
 
 namespace MIPSComp
 {
+	static bool NeedsTempForSETcc(X64Reg reg) {
+#ifndef _M_X64
+		// Can't use ESI or EDI, no 8-bit version.
+		if (reg != EDX && reg != ECX) {
+			return true;
+		}
+#endif
+		return false;
+	}
+
 	void Jit::CompImmLogic(MIPSOpcode op, void (XEmitter::*arith)(int, const OpArg &, const OpArg &))
 	{
 		u32 uimm = (u16)(op & 0xFFFF);
@@ -103,37 +113,47 @@ namespace MIPSComp
 			break;
 
 		case 10: // R(rt) = (s32)R(rs) < simm; break; //slti
-			if (gpr.IsImm(rs))
-			{
+			if (gpr.IsImm(rs)) {
 				gpr.SetImm(rt, (s32)gpr.GetImm(rs) < simm);
-				break;
-			}
+			} else {
+				gpr.Lock(rt, rs);
+				// This is often used before a branch.  If rs is not already mapped, let's leave it.
+				gpr.MapReg(rt, rt == rs, true);
 
-			gpr.Lock(rt, rs);
-			gpr.MapReg(rs, true, false);
-			gpr.MapReg(rt, rt == rs, true);
-			XOR(32, R(EAX), R(EAX));
-			CMP(32, gpr.R(rs), Imm32(simm));
-			SETcc(CC_L, R(EAX));
-			MOV(32, gpr.R(rt), R(EAX));
-			gpr.UnlockAll();
+				bool needsTemp = NeedsTempForSETcc(gpr.RX(rt)) || rt == rs;
+				if (needsTemp) {
+					CMP(32, gpr.R(rs), Imm32(suimm));
+					SETcc(CC_L, R(EAX));
+					MOVZX(32, 8, gpr.RX(rt), R(EAX));
+				} else {
+					XOR(32, gpr.R(rt), gpr.R(rt));
+					CMP(32, gpr.R(rs), Imm32(suimm));
+					SETcc(CC_L, gpr.R(rt));
+				}
+				gpr.UnlockAll();
+			}
 			break;
 
 		case 11: // R(rt) = R(rs) < uimm; break; //sltiu
-			if (gpr.IsImm(rs))
-			{
+			if (gpr.IsImm(rs)) {
 				gpr.SetImm(rt, gpr.GetImm(rs) < suimm);
-				break;
-			}
+			} else {
+				gpr.Lock(rt, rs);
+				// This is often used before a branch.  If rs is not already mapped, let's leave it.
+				gpr.MapReg(rt, rt == rs, true);
 
-			gpr.Lock(rt, rs);
-			gpr.MapReg(rs, true, false);
-			gpr.MapReg(rt, rt == rs, true);
-			XOR(32, R(EAX), R(EAX));
-			CMP(32, gpr.R(rs), Imm32(suimm));
-			SETcc(CC_B, R(EAX));
-			MOV(32, gpr.R(rt), R(EAX));
-			gpr.UnlockAll();
+				bool needsTemp = NeedsTempForSETcc(gpr.RX(rt)) || rt == rs;
+				if (needsTemp) {
+					CMP(32, gpr.R(rs), Imm32(suimm));
+					SETcc(CC_B, R(EAX));
+					MOVZX(32, 8, gpr.RX(rt), R(EAX));
+				} else {
+					XOR(32, gpr.R(rt), gpr.R(rt));
+					CMP(32, gpr.R(rs), Imm32(suimm));
+					SETcc(CC_B, gpr.R(rt));
+				}
+				gpr.UnlockAll();
+			}
 			break;
 
 		case 12: // R(rt) = R(rs) & uimm; break; //andi
@@ -437,33 +457,49 @@ namespace MIPSComp
 			break;
 
 		case 42: //R(rd) = (int)R(rs) < (int)R(rt); break; //slt
-			if (gpr.IsImm(rs) && gpr.IsImm(rt))
+			if (gpr.IsImm(rs) && gpr.IsImm(rt)) {
 				gpr.SetImm(rd, (s32)gpr.GetImm(rs) < (s32)gpr.GetImm(rt));
-			else
-			{
-				gpr.Lock(rt, rs, rd);
+			} else if (rs == rt) {
+				gpr.SetImm(rd, 0);
+			} else {
+				gpr.Lock(rd, rs, rt);
 				gpr.MapReg(rs, true, false);
-				gpr.MapReg(rd, rd == rt, true);
-				XOR(32, R(EAX), R(EAX));
-				CMP(32, gpr.R(rs), gpr.R(rt));
-				SETcc(CC_L, R(EAX));
-				MOV(32, gpr.R(rd), R(EAX));
+				gpr.MapReg(rd, rd == rt || rd == rs, true);
+
+				bool needsTemp = NeedsTempForSETcc(gpr.RX(rd)) || rd == rt || rd == rs;
+				if (needsTemp) {
+					CMP(32, gpr.R(rs), gpr.R(rt));
+					SETcc(CC_L, R(EAX));
+					MOVZX(32, 8, gpr.RX(rd), R(EAX));
+				} else {
+					XOR(32, gpr.R(rd), gpr.R(rd));
+					CMP(32, gpr.R(rs), gpr.R(rt));
+					SETcc(CC_L, gpr.R(rd));
+				}
 				gpr.UnlockAll();
 			}
 			break;
 
 		case 43: //R(rd) = R(rs) < R(rt);		break; //sltu
-			if (gpr.IsImm(rs) && gpr.IsImm(rt))
+			if (gpr.IsImm(rs) && gpr.IsImm(rt)) {
 				gpr.SetImm(rd, gpr.GetImm(rs) < gpr.GetImm(rt));
-			else
-			{
+			} else if (rs == rt) {
+				gpr.SetImm(rd, 0);
+			} else {
 				gpr.Lock(rd, rs, rt);
 				gpr.MapReg(rs, true, false);
-				gpr.MapReg(rd, rd == rt, true);
-				XOR(32, R(EAX), R(EAX));
-				CMP(32, gpr.R(rs), gpr.R(rt));
-				SETcc(CC_B, R(EAX));
-				MOV(32, gpr.R(rd), R(EAX));
+				gpr.MapReg(rd, rd == rt || rd == rs, true);
+
+				bool needsTemp = NeedsTempForSETcc(gpr.RX(rd)) || rd == rt || rd == rs;
+				if (needsTemp) {
+					CMP(32, gpr.R(rs), gpr.R(rt));
+					SETcc(CC_L, R(EAX));
+					MOVZX(32, 8, gpr.RX(rd), R(EAX));
+				} else {
+					XOR(32, gpr.R(rd), gpr.R(rd));
+					CMP(32, gpr.R(rs), gpr.R(rt));
+					SETcc(CC_L, gpr.R(rd));
+				}
 				gpr.UnlockAll();
 			}
 			break;

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -42,32 +42,27 @@
 #define CONDITIONAL_DISABLE ;
 #define DISABLE { Comp_Generic(op); return; }
 
-namespace MIPSComp
-{
+namespace MIPSComp {
 
-void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters)
-{
+void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters) {
 	int ft = _FT;
 	int fs = _FS;
 	int fd = _FD;
 	fpr.SpillLock(fd, fs, ft);
 
-	if (fs == fd)
-	{
+	if (fs == fd) {
 		fpr.MapReg(fd, true, true);
 		(this->*arith)(fpr.RX(fd), fpr.R(ft));
-	}
-	else if (ft == fd && !orderMatters)
-	{
+	} else if (ft == fd && !orderMatters) {
 		fpr.MapReg(fd, true, true);
 		(this->*arith)(fpr.RX(fd), fpr.R(fs));
-	}
-	else if (ft != fd && fs != fd && ft != fs) {
+	} else if (ft != fd) {
+		// fs can't be fd (handled above.)
 		fpr.MapReg(fd, false, true);
 		MOVSS(fpr.RX(fd), fpr.R(fs));
 		(this->*arith)(fpr.RX(fd), fpr.R(ft));
-	}
-	else {
+	} else {
+		// fd must be ft.
 		fpr.MapReg(fd, true, true);
 		MOVSS(XMM0, fpr.R(fs));
 		(this->*arith)(XMM0, fpr.R(ft));
@@ -76,8 +71,7 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 	fpr.ReleaseSpillLocks();
 }
 
-void Jit::Comp_FPU3op(MIPSOpcode op)
-{ 
+void Jit::Comp_FPU3op(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	switch (op & 0x3f) 
 	{
@@ -93,15 +87,13 @@ void Jit::Comp_FPU3op(MIPSOpcode op)
 
 static u32 MEMORY_ALIGNED16(ssLoadStoreTemp);
 
-void Jit::Comp_FPULS(MIPSOpcode op)
-{
+void Jit::Comp_FPULS(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	s32 offset = _IMM16;
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 
-	switch(op >> 26)
-	{
+	switch (op >> 26) {
 	case 49: //FI(ft) = Memory::Read_U32(addr); break; //lwc1
 		{
 			gpr.Lock(rs);
@@ -177,8 +169,7 @@ void Jit::Comp_FPUComp(MIPSOpcode op) {
 	int fs = _FS;
 	int ft = _FT;
 
-	switch (op & 0xf)
-	{
+	switch (op & 0xf) {
 	case 0: //f
 	case 8: //sf
 		gpr.SetImm(MIPS_REG_FPCOND, 0);
@@ -230,8 +221,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	int fs = _FS;
 	int fd = _FD;
 
-	switch (op & 0x3f) 
-	{
+	switch (op & 0x3f) {
 	case 5:	//F(fd)	= fabsf(F(fs)); break; //abs
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -73,8 +73,7 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 
 void Jit::Comp_FPU3op(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
-	switch (op & 0x3f) 
-	{
+	switch (op & 0x3f) {
 	case 0: CompFPTriArith(op, &XEmitter::ADDSS, false); break; //F(fd) = F(fs) + F(ft); //add
 	case 1: CompFPTriArith(op, &XEmitter::SUBSS, true); break;  //F(fd) = F(fs) - F(ft); //sub
 	case 2: CompFPTriArith(op, &XEmitter::MULSS, false); break; //F(fd) = F(fs) * F(ft); //mul

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -384,9 +384,13 @@ void Jit::Comp_mxc1(MIPSOpcode op) {
 		return;
 
 	case 4: //FI(fs) = R(rt);	break; //mtc1
-		gpr.KillImmediate(rt, true, false);
 		fpr.MapReg(fs, false, true);
-		MOVD_xmm(fpr.RX(fs), gpr.R(rt));
+		if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0) {
+			XORPS(fpr.RX(fs), fpr.R(fs));
+		} else {
+			gpr.KillImmediate(rt, true, false);
+			MOVD_xmm(fpr.RX(fs), gpr.R(rt));
+		}
 		return;
 
 	case 6: //currentMIPS->WriteFCR(fs, R(rt)); break; //ctc1

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -235,7 +235,9 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 5:	//F(fd)	= fabsf(F(fs)); break; //abs
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
-		MOVSS(fpr.RX(fd), fpr.R(fs));
+		if (fd != fs) {
+			MOVSS(fpr.RX(fd), fpr.R(fs));
+		}
 		PAND(fpr.RX(fd), M(ssNoSignMask));
 		break;
 
@@ -250,7 +252,9 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 7:	//F(fd)	= -F(fs);			 break; //neg
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
-		MOVSS(fpr.RX(fd), fpr.R(fs));
+		if (fd != fs) {
+			MOVSS(fpr.RX(fd), fpr.R(fs));
+		}
 		PXOR(fpr.RX(fd), M(ssSignBits2));
 		break;
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -152,26 +152,26 @@ static const u64 MEMORY_ALIGNED16(ssOneBits[2])	= {0x0000000100000001ULL, 0x0000
 static const u64 MEMORY_ALIGNED16(ssSignBits2[2])	= {0x8000000080000000ULL, 0x8000000080000000ULL};
 static const u64 MEMORY_ALIGNED16(ssNoSignMask[2]) = {0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL};
 
-void Jit::CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN)
-{
+void Jit::CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN) {
 	gpr.MapReg(MIPS_REG_FPCOND, false, true);
-	MOVSS(XMM0, fpr.R(lhs));
-	CMPSS(XMM0, fpr.R(rhs), compare);
-	MOVD_xmm(gpr.R(MIPS_REG_FPCOND), XMM0);
 
 	// This means that NaN also means true, e.g. !<> or !>, etc.
-	if (allowNaN)
-	{
+	if (allowNaN) {
 		MOVSS(XMM0, fpr.R(lhs));
-		CMPUNORDSS(XMM0, fpr.R(rhs));
+		MOVSS(XMM1, fpr.R(lhs));
+		CMPSS(XMM0, fpr.R(rhs), compare);
+		CMPUNORDSS(XMM1, fpr.R(rhs));
 
-		MOVD_xmm(R(EAX), XMM0);
-		OR(32, gpr.R(MIPS_REG_FPCOND), R(EAX));
+		POR(XMM0, R(XMM1));
+	} else {
+		MOVSS(XMM0, fpr.R(lhs));
+		CMPSS(XMM0, fpr.R(rhs), compare);
 	}
+
+	MOVD_xmm(gpr.R(MIPS_REG_FPCOND), XMM0);
 }
 
-void Jit::Comp_FPUComp(MIPSOpcode op)
-{
+void Jit::Comp_FPUComp(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 
 	int fs = _FS;

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -264,7 +264,6 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 13: //FsI(fd) = F(fs)>=0 ? (int)floorf(F(fs)) : (int)ceilf(F(fs)); break;//trunc.w.s
 		{
 			fpr.SpillLock(fs, fd);
-			fpr.StoreFromRegister(fd);
 			CVTTSS2SI(EAX, fpr.R(fs));
 
 			// Did we get an indefinite integer value?
@@ -280,11 +279,13 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 			XOR(32, R(EAX), Imm32(0x7fffffff));
 
 			SetJumpTarget(skip);
+			fpr.DiscardR(fd);
 			MOV(32, fpr.R(fd), R(EAX));
 		}
 		break;
 
 	case 32: //F(fd)	= (float)FsI(fs);			break; //cvt.s.w
+		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fs == fd, true);
 		if (fpr.R(fs).IsSimpleReg()) {
 			CVTDQ2PS(fpr.RX(fd), fpr.R(fs));
@@ -297,8 +298,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 
 	case 36: //FsI(fd) = (int)	F(fs);			 break; //cvt.w.s
 		{
-			fpr.SpillLock(fs, fd);
-			fpr.StoreFromRegister(fd);
+			fpr.SpillLock(fs);
 			CVTSS2SI(EAX, fpr.R(fs));
 
 			// Did we get an indefinite integer value?
@@ -314,6 +314,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 			XOR(32, R(EAX), Imm32(0x7fffffff));
 
 			SetJumpTarget(skip);
+			fpr.DiscardR(fd);
 			MOV(32, fpr.R(fd), R(EAX));
 		}
 		break;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1848,8 +1848,12 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 		if (imm < 128) { // VI(imm) = R(rt);
 			fpr.MapRegV(imm, MAP_DIRTY | MAP_NOINIT);
 			// Let's not bother mapping rt if we don't have to.
-			gpr.KillImmediate(rt, true, false);
-			MOVD_xmm(fpr.VX(imm), gpr.R(rt));
+			if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0) {
+				XORPS(fpr.VX(imm), fpr.V(imm));
+			} else {
+				gpr.KillImmediate(rt, true, false);
+				MOVD_xmm(fpr.VX(imm), gpr.R(rt));
+			}
 		} else if (imm < 128 + VFPU_CTRL_MAX) { //mtvc //currentMIPS->vfpuCtrl[imm - 128] = R(rt);
 			if (imm - 128 == VFPU_CTRL_CC) {
 				if (gpr.IsImm(rt)) {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1398,12 +1398,18 @@ void Jit::Comp_Vf2i(MIPSOpcode op) {
 		break;
 	}
 
+	// Small optimization: 0 is our default mode anyway.
+	if (setMXCSR == 0 && !js.hasSetRounding) {
+		setMXCSR = -1;
+	}
 	// Except for truncate, we need to update MXCSR to our preferred rounding mode.
 	if (setMXCSR != -1) {
 		STMXCSR(M(&mxcsrTemp));
 		MOV(32, R(EAX), M(&mxcsrTemp));
 		AND(32, R(EAX), Imm32(~(3 << 13)));
-		OR(32, R(EAX), Imm32(setMXCSR << 13));
+		if (setMXCSR != 0) {
+			OR(32, R(EAX), Imm32(setMXCSR << 13));
+		}
 		MOV(32, M(&mips_->temp), R(EAX));
 		LDMXCSR(M(&mips_->temp));
 	}


### PR DESCRIPTION
These gain 10-15 points in a few games I tested, which is only around 1%, but might be better on some architectures or games.

Specifically:
- Implements fpu rounding conversions in jit other than cvt.w.s (used by some games, e.g. Kingdom Hearts.)
- Fixes a few places where regs were stored to mem and then overwritten anyway, or otherwise unnecessarily.
- Optimizes the case of loading a known immediate 0 into an fpu reg.
- Small improvement to 3-ops of the form "add.s x, y, y" / "mul.s x, y, y".
- Kills a couple minor MOVSS to self.  Maybe the emitter should nix that, even...

-[Unknown]
