### PR TITLE
x86jit: A few more minor optimizations, zero bugfix

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -470,9 +470,6 @@ namespace MIPSComp
 				MIPSGPReg rhs = rt;
 				CCFlags cc = CC_L;
 				if (gpr.IsImm(lhs)) {
-					// Hmm.  This is a bit confusing.  lhs may be ZERO, but its location may be memory.
-					// TODO: That's probably not a good thing, but changing it breaks more...
-					gpr.SetImm(lhs, gpr.GetImm(lhs));
 					// rhs is guaranteed not to be an imm (handled above.)
 					std::swap(lhs, rhs);
 					cc = SwapCCFlag(cc);
@@ -513,9 +510,6 @@ namespace MIPSComp
 				MIPSGPReg rhs = rt;
 				CCFlags cc = CC_B;
 				if (gpr.IsImm(lhs)) {
-					// Hmm.  This is a bit confusing.  lhs may be ZERO, but its location may be memory.
-					// TODO: That's probably not a good thing, but changing it breaks more...
-					gpr.SetImm(lhs, gpr.GetImm(lhs));
 					// rhs is guaranteed not to be an imm (handled above.)
 					std::swap(lhs, rhs);
 					cc = SwapCCFlag(cc);

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -130,7 +130,7 @@ void Jit::BranchLogExit(MIPSOpcode op, u32 dest, bool useEAX)
 	SetJumpTarget(skip);
 }
 
-static CCFlags FlipCCFlag(CCFlags flag)
+CCFlags Jit::FlipCCFlag(CCFlags flag)
 {
 	switch (flag)
 	{
@@ -152,6 +152,32 @@ static CCFlags FlipCCFlag(CCFlags flag)
 	case CC_NLE: return CC_LE;
 	}
 	ERROR_LOG_REPORT(JIT, "FlipCCFlag: Unexpected CC flag: %d", flag);
+	return CC_O;
+}
+
+CCFlags Jit::SwapCCFlag(CCFlags flag)
+{
+	// This swaps the comparison for an lhs/rhs swap, but doesn't flip/invert the logic.
+	switch (flag)
+	{
+	case CC_O: return CC_O;
+	case CC_NO: return CC_NO;
+	case CC_B: return CC_A;
+	case CC_NB: return CC_NA;
+	case CC_Z: return CC_Z;
+	case CC_NZ: return CC_NZ;
+	case CC_BE: return CC_AE;
+	case CC_NBE: return CC_NAE;
+	case CC_S: return CC_S;
+	case CC_NS: return CC_NS;
+	case CC_P: return CC_P;
+	case CC_NP: return CC_NP;
+	case CC_L: return CC_G;
+	case CC_NL: return CC_NG;
+	case CC_LE: return CC_GE;
+	case CC_NLE: return CC_NGE;
+	}
+	ERROR_LOG_REPORT(JIT, "SwapCCFlag: Unexpected CC flag: %d", flag);
 	return CC_O;
 }
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -73,8 +73,7 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 
 void Jit::Comp_FPU3op(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
-	switch (op & 0x3f) 
-	{
+	switch (op & 0x3f) {
 	case 0: CompFPTriArith(op, &XEmitter::ADDSS, false); break; //F(fd) = F(fs) + F(ft); //add
 	case 1: CompFPTriArith(op, &XEmitter::SUBSS, true); break;  //F(fd) = F(fs) - F(ft); //sub
 	case 2: CompFPTriArith(op, &XEmitter::MULSS, false); break; //F(fd) = F(fs) * F(ft); //mul

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -230,6 +230,8 @@ private:
 	void CompITypeMemUnpairedLRInner(MIPSOpcode op, X64Reg shiftReg);
 	void CompBranchExits(CCFlags cc, u32 targetAddr, u32 notTakenAddr, bool delaySlotIsNice, bool likely, bool andLink);
 	void CompBranchExit(bool taken, u32 targetAddr, u32 notTakenAddr, bool delaySlotIsNice, bool likely, bool andLink);
+	static CCFlags FlipCCFlag(CCFlags flag);
+	static CCFlags SwapCCFlag(CCFlags flag);
 
 	void CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters);
 	void CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN = false);


### PR DESCRIPTION
Re-enabled with slt thing with the typo fixed, and allowed it to flip the cc to avoid loading regs unnecessarily.

While testing that, found an issue where sometimes we'd use $zero as an imm, but it wouldn't actually be an imm.  So I changed the special handling of that reg to be safer.

-[Unknown]
