### PR TITLE
Change vpfxs/r/t disassembly syntax

### DIFF
--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -150,7 +150,7 @@ namespace MIPSDis
 	{
 		int data = op & 0xFFFFF;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t",name);
+		sprintf(out, "%s\t[",name);
 		static const char *regnam[4] = {"X","Y","Z","W"};
 		static const char *constan[8] = {"0","1","2","1/2","3","1/3","1/4","1/6"};
 		for (int i=0; i<4; i++)
@@ -175,16 +175,19 @@ namespace MIPSDis
 			}
 			if (abs && !constants)
 				strcat(out, "|");
-			strcat(out, " ");
+			if (i != 3)
+				strcat(out, ",");
 		}
+
+		strcat(out, "]");
 	}
 
 	void Dis_VPFXD(MIPSOpcode op, char *out)
 	{
 		int data = op & 0xFFFFF;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t", name);
-		static const char *satNames[4] = {"", "0-1", "X", "-1-1"};
+		sprintf(out, "%s\t[", name);
+		static const char *satNames[4] = {"", "0:1", "X", "-1:1"};
 		for (int i=0; i<4; i++)
 		{
 			int sat = (data>>i*2)&3;
@@ -194,8 +197,10 @@ namespace MIPSDis
 			if (mask)
 				strcat(out, "M");
 			if (i < 4 - 1)
-				strcat(out, ", ");
+				strcat(out, ",");
 		}
+
+		strcat(out, "]");
 	}
 
 


### PR DESCRIPTION
This writes them in square brackets and comma seperated. Previously vpfxd was comma seperated, and vpfxs/t were only seperated by spaces. The debugger omits spaces, so everything was mashed together into one unreadable mess.
