### PR TITLE
x86jit: Add basic support for mapping SIMD

### DIFF
--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -114,6 +114,7 @@ void Jit::ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz) {
 
 		// This puts the value into a temp reg, so we won't write the modified value back.
 		vregs[i] = fpr.GetTempV();
+		fpr.SimpleRegV(origV[regnum], 0);
 		fpr.MapRegV(vregs[i], MAP_NOINIT | MAP_DIRTY);
 
 		if (!constants) {
@@ -522,9 +523,12 @@ void Jit::Comp_VDot(MIPSOpcode op) {
 	GetVectorRegsPrefixT(tregs, sz, _VT);
 	GetVectorRegsPrefixD(dregs, V_Single, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
+
 	X64Reg tempxreg = XMM0;
-	if (IsOverlapSafe(dregs[0], 0, n, sregs, n, tregs))
-	{
+	if (IsOverlapSafe(dregs[0], 0, n, sregs, n, tregs)) {
 		fpr.MapRegsV(dregs, V_Single, MAP_NOINIT);
 		tempxreg = fpr.VX(dregs[0]);
 	}
@@ -564,6 +568,10 @@ void Jit::Comp_VHdp(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixT(tregs, sz, _VT);
 	GetVectorRegsPrefixD(dregs, V_Single, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
 
 	X64Reg tempxreg = XMM0;
 	if (IsOverlapSafe(dregs[0], 0, n, sregs, n, tregs))
@@ -610,6 +618,11 @@ void Jit::Comp_VCrossQuat(MIPSOpcode op) {
 	GetVectorRegs(sregs, sz, _VS);
 	GetVectorRegs(tregs, sz, _VT);
 	GetVectorRegs(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	if (sz == V_Triple) {
 		// Cross product vcrsp.t
@@ -722,6 +735,9 @@ void Jit::Comp_Vcmov(MIPSOpcode op) {
 	int tf = (op >> 19) & 1;
 	int imm3 = (op >> 16) & 7;
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+
 	for (int i = 0; i < n; ++i) {
 		// Simplification: Disable if overlap unsafe
 		if (!IsOverlapSafeAllowS(dregs[i], i, n, sregs)) {
@@ -806,6 +822,11 @@ void Jit::Comp_VecDo3(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixT(tregs, sz, _VT);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	X64Reg tempxregs[4];
 	for (int i = 0; i < n; ++i)
@@ -968,8 +989,10 @@ void Jit::Comp_Vcmp(MIPSOpcode op) {
 
 	if (cond == VC_GE || cond == VC_GT) {
 		// We flip, and we need them in regs so we don't clear the high lanes.
+		fpr.SimpleRegsV(sregs, sz, 0);
 		fpr.MapRegsV(tregs, sz, 0);
 	} else {
+		fpr.SimpleRegsV(tregs, sz, 0);
 		fpr.MapRegsV(sregs, sz, 0);
 	}
 
@@ -1159,6 +1182,10 @@ void Jit::Comp_Vi2f(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
+
 	int tempregs[4];
 	for (int i = 0; i < n; ++i) {
 		if (!IsOverlapSafe(dregs[i], i, n, sregs)) {
@@ -1250,6 +1277,9 @@ void Jit::Comp_Vh2f(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, outsize, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+
 	// Force ourselves an extra xreg as temp space.
 	X64Reg tempR = fpr.GetFreeXReg();
 	
@@ -1336,6 +1366,9 @@ void Jit::Comp_Vx2i(MIPSOpcode op) {
 	u8 sregs[4], dregs[4];
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, outsize, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
 
 	if (bits == 16) {
 		MOVSS(XMM1, fpr.V(sregs[0]));
@@ -1467,6 +1500,9 @@ void Jit::Comp_Vf2i(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+
 	u8 tempregs[4];
 	for (int i = 0; i < n; ++i) {
 		if (!IsOverlapSafe(dregs[i], i, n, sregs)) {
@@ -1552,6 +1588,10 @@ void Jit::Comp_Vsgn(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
+
 	X64Reg tempxregs[4];
 	for (int i = 0; i < n; ++i)
 	{
@@ -1605,6 +1645,10 @@ void Jit::Comp_Vocp(MIPSOpcode op) {
 	u8 sregs[4], dregs[4];
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	X64Reg tempxregs[4];
 	for (int i = 0; i < n; ++i)
@@ -1721,6 +1765,10 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 	u8 sregs[4], dregs[4];
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	X64Reg tempxregs[4];
 	for (int i = 0; i < n; ++i)
@@ -1860,6 +1908,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 		// rt = 0, imm = 255 appears to be used as a CPU interlock by some games.
 		if (rt != MIPS_REG_ZERO) {
 			if (imm < 128) {  //R(rt) = VI(imm);
+				fpr.SimpleRegV(imm, 0);
 				if (fpr.V(imm).IsSimpleReg()) {
 					fpr.MapRegV(imm, 0);
 					gpr.MapReg(rt, false, true);
@@ -1990,6 +2039,9 @@ void Jit::Comp_VMatrixInit(MIPSOpcode op) {
 	u8 dregs[16];
 	GetMatrixRegs(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
+
 	switch ((op >> 16) & 0xF) {
 	case 3: // vmidt
 		MOVSS(XMM0, M(&zero));
@@ -2035,6 +2087,10 @@ void Jit::Comp_Vmmov(MIPSOpcode op) {
 	GetMatrixRegs(sregs, sz, _VS);
 	GetMatrixRegs(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
+
 	// TODO: gas doesn't allow overlap, what does the PSP do?
 	// Potentially detect overlap or the safe direction to move in, or just DISABLE?
 	// This is very not optimal, blows the regcache everytime.
@@ -2077,6 +2133,11 @@ void Jit::Comp_VScl(MIPSOpcode op) {
 	// TODO: Prefixes seem strange...
 	GetVectorRegsPrefixT(&scale, V_Single, _VT);
 	GetVectorRegsPrefixD(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(&scale, V_Single, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	// Move to XMM0 early, so we don't have to worry about overlap with scale.
 	MOVSS(XMM0, fpr.V(scale));
@@ -2128,6 +2189,11 @@ void Jit::Comp_Vmmul(MIPSOpcode op) {
 	GetMatrixRegs(sregs, sz, _VS);
 	GetMatrixRegs(tregs, sz, _VT);
 	GetMatrixRegs(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	// Rough overlap check.
 	bool overlap = false;
@@ -2193,6 +2259,11 @@ void Jit::Comp_Vmscl(MIPSOpcode op) {
 	GetVectorRegs(&scale, V_Single, _VT);
 	GetMatrixRegs(dregs, sz, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(&scale, V_Single, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
+
 	// Move to XMM0 early, so we don't have to worry about overlap with scale.
 	MOVSS(XMM0, fpr.V(scale));
 
@@ -2251,6 +2322,11 @@ void Jit::Comp_Vtfm(MIPSOpcode op) {
 	GetMatrixRegs(sregs, msz, _VS);
 	GetVectorRegs(tregs, sz, _VT);
 	GetVectorRegs(dregs, sz, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, msz, 0);
+	fpr.SimpleRegsV(tregs, sz, 0);
+	fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);
 
 	// TODO: test overlap, optimize.
 	u8 tempregs[4];
@@ -2328,6 +2404,10 @@ void Jit::Comp_Vi2x(MIPSOpcode op) {
 	u8 sregs[4], dregs[4];
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, outsize, _VD);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, outsize, MAP_NOINIT | MAP_DIRTY);
 
 	// First, let's assemble the sregs into lanes of a single xmm reg.
 	// For quad inputs, we need somewhere for the bottom regs.  Ideally dregs[0].
@@ -2430,6 +2510,10 @@ void Jit::Comp_Vhoriz(MIPSOpcode op) {
 	GetVectorRegsPrefixS(sregs, sz, _VS);
 	GetVectorRegsPrefixD(dregs, V_Single, _VD);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(sregs, sz, 0);
+	fpr.SimpleRegsV(dregs, V_Single, MAP_NOINIT | MAP_DIRTY);
+
 	X64Reg reg = XMM0;
 	if (IsOverlapSafeAllowS(dregs[0], 0, n, sregs)) {
 		fpr.MapRegV(dregs[0], (dregs[0] == sregs[0] ? 0 : MAP_NOINIT) | MAP_DIRTY);
@@ -2470,6 +2554,9 @@ void Jit::Comp_Viim(MIPSOpcode op) {
 	u8 dreg;
 	GetVectorRegs(&dreg, V_Single, _VT);
 
+	// Flush SIMD.
+	fpr.SimpleRegsV(&dreg, V_Single, MAP_NOINIT | MAP_DIRTY);
+
 	s32 imm = (s32)(s16)(u16)(op & 0xFFFF);
 	FP32 fp;
 	fp.f = (float)imm;
@@ -2489,6 +2576,9 @@ void Jit::Comp_Vfim(MIPSOpcode op) {
 
 	u8 dreg;
 	GetVectorRegs(&dreg, V_Single, _VT);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(&dreg, V_Single, MAP_NOINIT | MAP_DIRTY);
 
 	FP16 half;
 	half.u = op & 0xFFFF;
@@ -2515,6 +2605,9 @@ void Jit::Comp_VRot(MIPSOpcode op) {
 	u8 sreg;
 	GetVectorRegs(dregs, sz, vd);
 	GetVectorRegs(&sreg, V_Single, vs);
+
+	// Flush SIMD.
+	fpr.SimpleRegsV(&sreg, V_Single, 0);
 
 	int imm = (op >> 16) & 0x1f;
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -120,6 +120,7 @@ JitOptions::JitOptions()
 	continueBranches = false;
 	continueJumps = false;
 	continueMaxInstructions = 300;
+	enableVFPUSIMD = true;
 }
 
 #ifdef _MSC_VER
@@ -131,6 +132,7 @@ Jit::Jit(MIPSState *mips) : blocks(mips, this), mips_(mips)
 	blocks.Init();
 	gpr.SetEmitter(this);
 	fpr.SetEmitter(this);
+	fpr.SetOptions(&jo);
 	AllocCodeSpace(1024 * 1024 * 16);
 	asm_.Init(mips, this);
 	safeMemFuncs.Init(&thunks);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -49,6 +49,7 @@ struct JitOptions
 	bool continueBranches;
 	bool continueJumps;
 	int continueMaxInstructions;
+	bool enableVFPUSIMD;
 };
 
 // TODO: Hmm, humongous.

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -246,6 +246,8 @@ bool FPURegCache::TryMapRegsVS(const u8 *v, VectorSize vsz, int flags) {
 }
 
 bool FPURegCache::TryMapDirtyInInVS(const u8 *vd, VectorSize vdsz, const u8 *vs, VectorSize vssz, const u8 *vt, VectorSize vtsz, bool avoidLoad) {
+	// TODO: Ideally, don't map any unless they're all mappable.
+	// Need to simplify this stuff.
 	bool success = TryMapRegsVS(vs, vssz, 0);
 	if (success) {
 		SpillLockV(vs, vssz);

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -21,6 +21,7 @@
 #include "Common/Log.h"
 #include "Common/x64Emitter.h"
 #include "Core/MIPS/MIPSAnalyst.h"
+#include "Core/MIPS/x86/Jit.h"
 #include "Core/MIPS/x86/RegCache.h"
 #include "Core/MIPS/x86/RegCacheFPU.h"
 
@@ -139,6 +140,9 @@ bool FPURegCache::IsMappedVS(const u8 *v, VectorSize vsz) {
 
 void FPURegCache::MapRegsVS(const u8 *r, VectorSize vsz, int flags) {
 	const int n = GetNumVectorElements(vsz);
+
+	_dbg_assert_msg_(JIT, jo_->enableVFPUSIMD, "Should not map simd regs when option is off.");
+
 	if (!TryMapRegsVS(r, vsz, flags)) {
 		// TODO: Could be more optimal.
 		for (int i = 0; i < n; ++i) {
@@ -152,6 +156,10 @@ void FPURegCache::MapRegsVS(const u8 *r, VectorSize vsz, int flags) {
 
 bool FPURegCache::CanMapVS(const u8 *v, VectorSize vsz) {
 	const int n = GetNumVectorElements(vsz);
+
+	if (!jo_->enableVFPUSIMD) {
+		return false;
+	}
 
 	if (IsMappedVS(v, vsz)) {
 		return true;

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -198,6 +198,7 @@ void FPURegCache::MapReg(const int i, bool doLoad, bool makeDirty) {
 		regs[i].lane = 0;
 		regs[i].away = true;
 	} else {
+		// TODO: If it's in a lane, need to pull it out.
 		// There are no immediates in the FPR reg file, so we already had this in a register. Make dirty as necessary.
 		xregs[RX(i)].dirty |= makeDirty;
 		_assert_msg_(JIT, regs[i].location.IsSimpleReg(), "not loaded and not simple.");

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -111,6 +111,18 @@ void FPURegCache::MapRegsV(const u8 *r, VectorSize sz, int flags) {
 	}
 }
 
+bool FPURegCache::IsMappedVS(u8 *r, VectorSize vsz) {
+	const int n = GetNumVectorElements(vsz);
+	if (!IsMappedVS(r[0]))
+		return false;
+	X64Reg xr = VSX(r[0]);
+	for (int i = 0; i < n; ++i) {
+		if (!IsMappedVS(r[i]) || VSX(r[i]) != xr)
+			return false;
+	}
+	return true;
+}
+
 void FPURegCache::MapRegsVS(const u8 *r, VectorSize vsz, int flags) {
 	const int n = GetNumVectorElements(vsz);
 	if (!TryMapRegsVS(r, vsz, flags)) {

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -307,8 +307,10 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 		for (int i = 0; i < n; ++i) {
 			StoreFromRegisterV(v[i]);
 		}
-		float *f = &mips->v[voffset[v[0]]];
-		if (((intptr_t)f & 0xf) == 0) {
+		const float *f = &mips->v[voffset[v[0]]];
+		if (((intptr_t)f & 0x7) == 0 && n == 2) {
+			emit->MOVQ_xmm(xrs[0], vregs[v[0]].location);
+		} else if (((intptr_t)f & 0xf) == 0) {
 			// On modern processors, MOVUPS on aligned is fast, but maybe not on older ones.
 			emit->MOVAPS(xrs[0], vregs[v[0]].location);
 		} else {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -162,6 +162,17 @@ public:
 	void ReleaseSpillLock(int mipsrega);
 	void ReleaseSpillLocks();
 
+	bool IsMapped(int r) {
+		return R(r).IsSimpleReg();
+	}
+	bool IsMappedV(int v) {
+		return vregs[v].lane == 0 && V(v).IsSimpleReg();
+	}
+	bool IsMappedVS(int v) {
+		return vregs[v].lane != 0 && VS(v).IsSimpleReg();
+	}
+	bool IsMappedVS(u8 *r, VectorSize vsz);
+
 	void MapRegV(int vreg, int flags);
 	void MapRegsV(int vec, VectorSize vsz, int flags);
 	void MapRegsV(const u8 *v, VectorSize vsz, int flags);

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -79,6 +79,10 @@ struct FPURegCacheState {
 	X64CachedFPReg xregs[NUM_X_FPREGS];
 };
 
+namespace MIPSComp {
+	struct JitOptions;
+}
+
 enum {
 	MAP_DIRTY = 1,
 	MAP_NOINIT = 2,
@@ -113,6 +117,7 @@ public:
 	// TODO: GetTempVS?
 
 	void SetEmitter(XEmitter *emitter) {emit = emitter;}
+	void SetOptions(MIPSComp::JitOptions *jo) {jo_ = jo;}
 
 	void Flush();
 	int SanityCheck() const;
@@ -229,4 +234,5 @@ private:
 	static u32 tempValues[NUM_TEMPS];
 
 	XEmitter *emit;
+	MIPSComp::JitOptions *jo_;
 };

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -202,6 +202,8 @@ private:
 	const int *GetAllocationOrder(int &count);
 	void SetupInitialRegs();
 
+	X64Reg LoadRegsVS(const u8 *v, int n);
+
 	MIPSCachedFPReg regs[NUM_MIPS_FPRS];
 	X64CachedFPReg xregs[NUM_X_FPREGS];
 	MIPSCachedFPReg *vregs;

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -194,6 +194,8 @@ public:
 	X64Reg GetFreeXReg();
 	int GetFreeXRegs(X64Reg *regs, int n, bool spill = true);
 
+	void Invariant() const;
+
 private:
 	const int *GetAllocationOrder(int &count);
 	void SetupInitialRegs();

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -173,10 +173,12 @@ public:
 	void ReleaseSpillLockV(int vreg) {
 		ReleaseSpillLock(vreg + 32);
 	}
+	void ReleaseSpillLockV(const u8 *vec, VectorSize sz);
 
 	// TODO: This may trash XMM0/XMM1 some day.
 	void MapRegsVS(const u8 *v, VectorSize vsz, int flags);
 	bool TryMapRegsVS(const u8 *v, VectorSize vsz, int flags);
+	bool TryMapDirtyInInVS(const u8 *vd, VectorSize vdsz, const u8 *vs, VectorSize vssz, const u8 *vt, VectorSize vtsz, bool avoidLoad = true);
 	// TODO: If s/t overlap differently, need read-only copies?  Maybe finalize d?  Major design flaw...
 	// TODO: Matrix versions?  Cols/Rows?
 	// No MapRegVS, that'd be silly.

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -171,10 +171,10 @@ public:
 		ReleaseSpillLock(vreg + 32);
 	}
 
-	// Warning: may trash XMM0/XMM1.
+	// TODO: This may trash XMM0/XMM1 some day.
 	void MapRegsVS(const u8 *v, VectorSize vsz, int flags);
-	// This won't trash them though.
 	bool TryMapRegsVS(const u8 *v, VectorSize vsz, int flags);
+	// TODO: If s/t overlap differently, need read-only copies?  Maybe finalize d?  Major design flaw...
 	// TODO: Matrix versions?  Cols/Rows?
 	// No MapRegVS, that'd be silly.
 
@@ -189,11 +189,11 @@ public:
 
 	void FlushX(X64Reg reg);
 	X64Reg GetFreeXReg();
+	int GetFreeXRegs(X64Reg *regs, int n, bool spill = true);
 
 private:
 	const int *GetAllocationOrder(int &count);
 	void SetupInitialRegs();
-	X64Reg GetFreeXRegNoSpill();
 
 	MIPSCachedFPReg regs[NUM_MIPS_FPRS];
 	X64CachedFPReg xregs[NUM_X_FPREGS];

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -154,6 +154,9 @@ public:
 		return (X64Reg)-1;
 	}
 
+	// Just to avoid coding mistakes, defined here to prevent compilation.
+	void R(X64Reg r);
+
 	// Register locking. Prevents them from being spilled.
 	void SpillLock(int p1, int p2=0xff, int p3=0xff, int p4=0xff);
 	void ReleaseSpillLock(int mipsrega);

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -171,7 +171,8 @@ public:
 	bool IsMappedVS(int v) {
 		return vregs[v].lane != 0 && VS(v).IsSimpleReg();
 	}
-	bool IsMappedVS(u8 *r, VectorSize vsz);
+	bool IsMappedVS(const u8 *v, VectorSize vsz);
+	bool CanMapVS(const u8 *v, VectorSize vsz);
 
 	void MapRegV(int vreg, int flags);
 	void MapRegsV(int vec, VectorSize vsz, int flags);

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -104,6 +104,7 @@ public:
 	void DiscardV(int vreg) {
 		DiscardR(vreg + 32);
 	}
+	void DiscardVS(int vreg);
 	bool IsTempX(X64Reg xreg);
 	int GetTempR();
 	int GetTempV() {


### PR DESCRIPTION
This implements only the VecDo3 ops using SIMD.  It seems to work from the games I've tested.

I'd like to simplify though.  I'm thinking it'd be better to change this pattern:

``` c++
    VectorSize sz = GetVecSize(op);
    int n = GetNumVectorElements(sz);

    u8 sregs[4], tregs[4], dregs[4];
    GetVectorRegsPrefixS(sregs, sz, _VS);
    GetVectorRegsPrefixT(tregs, sz, _VT);
    GetVectorRegsPrefixD(dregs, sz, _VD);

    if (fpr.TryMapDirtyInInVS(dregs, sz, sregs, sz, tregs, sz)) {
        ...

        ApplyPrefixD(dregs, sz);
        fpr.ReleaseSpillLocks();
        return;
    }

    // Flush SIMD.
    fpr.SimpleRegsV(sregs, sz, 0);
    fpr.SimpleRegsV(tregs, sz, 0);
    fpr.SimpleRegsV(dregs, sz, MAP_NOINIT | MAP_DIRTY);

    ...

    ApplyPrefixD(dregs, sz);

    fpr.ReleaseSpillLocks();
```

To something more like:

``` c++
    // Things like: VECREGS_D_LOAD, VECREGS_DSZ_HALF, VECREGS_NO_PREFIX, etc...
    VecOpRegs regs = GetVectorRegs(op, VECREGS_DST);

    if (fpr.TryMapVS(regs)) {
        ...

        // Or maybe done automatically if mapped?  Just worried about DISABLE.
        regs.FinalizeD();
        return;
    }

    fpr.SimpleRegsV(regs);

    ...

    regs.FinalizeD();
```

And also matrices... those are complicated...

-[Unknown]
