### PR TITLE
Use an interface to read iso files, not raw file reading

### DIFF
--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -31,9 +31,11 @@ enum GPUCore {
 	GPU_DIRECTX9,
 };
 
+class FileLoader;
+
 // PSP_CoreParameter()
 struct CoreParameter {
-	CoreParameter() : collectEmuLog(0), unthrottle(false), fpsLimit(0), updateRecent(true), freezeNext(false), frozen(false) {}
+	CoreParameter() : collectEmuLog(0), unthrottle(false), fpsLimit(0), updateRecent(true), freezeNext(false), frozen(false), mountIsoLoader(nullptr) {}
 	CPUCore cpuCore;
 	GPUCore gpuCore;
 	bool enableSound;  // there aren't multiple sound cores.
@@ -65,4 +67,6 @@ struct CoreParameter {
 	// Freeze-frame. For nvidia perfhud profiling. Developers only.
 	bool freezeNext;
 	bool frozen;
+
+	FileLoader *mountIsoLoader;
 };

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -26,6 +26,8 @@
 #include "Common/CommonTypes.h"
 #include "Core/ELF/PBPReader.h"
 
+class FileLoader;
+
 class BlockDevice
 {
 public:
@@ -48,14 +50,14 @@ public:
 class CISOFileBlockDevice : public BlockDevice
 {
 public:
-	CISOFileBlockDevice(FILE *file);
+	CISOFileBlockDevice(FileLoader *fileLoader);
 	~CISOFileBlockDevice();
 	bool ReadBlock(int blockNumber, u8 *outPtr) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() { return numBlocks;}
 
 private:
-	FILE *f;
+	FileLoader *fileLoader_;
 	u32 *index;
 	u8 *readBuffer;
 	u8 *zlibBuffer;
@@ -71,18 +73,15 @@ private:
 class FileBlockDevice : public BlockDevice
 {
 public:
-	FileBlockDevice(FILE *file);
+	FileBlockDevice(FileLoader *fileLoader);
 	~FileBlockDevice();
 	bool ReadBlock(int blockNumber, u8 *outPtr) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
-	u32 GetNumBlocks() override {return (u32)(filesize / GetBlockSize());}
+	u32 GetNumBlocks() override {return (u32)(filesize_ / GetBlockSize());}
 
 private:
-#ifdef ANDROID
-	int fd;
-#endif
-	FILE *f;
-	u64 filesize;
+	FileLoader *fileLoader_;
+	u64 filesize_;
 };
 
 
@@ -99,14 +98,14 @@ struct table_info {
 class NPDRMDemoBlockDevice : public BlockDevice
 {
 public:
-	NPDRMDemoBlockDevice(FILE *file);
+	NPDRMDemoBlockDevice(FileLoader *fileLoader);
 	~NPDRMDemoBlockDevice();
 
 	bool ReadBlock(int blockNumber, u8 *outPtr) override;
 	u32 GetNumBlocks() override {return (u32)lbaSize;}
 
 private:
-	FILE *f;
+	FileLoader *fileLoader_;
 	u32 lbaSize;
 
 	u32 psarOffset;
@@ -140,4 +139,4 @@ private:
 };
 
 
-BlockDevice *constructBlockDevice(const char *filename);
+BlockDevice *constructBlockDevice(FileLoader *fileLoader);

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -469,7 +469,7 @@ void __UmdReplace(std::string filepath) {
 	if (!currentUMD)
 		return;
 
-	FileLoader *loadedFile = new LocalFileLoader(filepath);
+	FileLoader *loadedFile = ConstructFileLoader(filepath);
 
 	IFileSystem* umd2;
 	FileInfo info;

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -538,11 +538,12 @@ bool CachingFileLoader::MakeCacheSpaceFor(size_t blocks, bool readingAhead) {
 		for (auto it = blocks_.begin(); it != blocks_.end(); ) {
 			// Check for the minimum seen generation.
 			// TODO: Do this smarter?
-			if (it->second.generation < minGeneration) {
+			if (it->second.generation != 0 && it->second.generation < minGeneration) {
 				minGeneration = it->second.generation;
 			}
 
-			if (it->second.generation == oldestGeneration_) {
+			// 0 means it was never used yet or was the first read (e.g. block descriptor.)
+			if (it->second.generation == oldestGeneration_ || it->second.generation == 0) {
 				s64 pos = it->first;
 				delete it->second.ptr;
 				blocks_.erase(it);

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -15,7 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "thread/thread.h"
+#include "base/mutex.h"
 #include "base/stringutil.h"
+#include "base/timeutil.h"
 #include "file/file_util.h"
 #include "net/http_client.h"
 #include "net/resolve.h"
@@ -115,14 +118,16 @@ private:
 	void ShutdownCache();
 	size_t ReadFromCache(s64 pos, size_t bytes, void *data);
 	// Guaranteed to read at least one block into the cache.
-	void SaveIntoCache(s64 pos, size_t bytes);
-	void MakeCacheSpaceFor(size_t blocks);
+	void SaveIntoCache(s64 pos, size_t bytes, bool readingAhead = false);
+	bool MakeCacheSpaceFor(size_t blocks, bool readingAhead);
+	void StartReadAhead(s64 pos);
 
 	enum {
 		BLOCK_SIZE = 65536,
 		BLOCK_SHIFT = 16,
 		MAX_BLOCKS_PER_READ = 16,
 		MAX_BLOCKS_CACHED = 4096, // 256 MB
+		BLOCK_READAHEAD = 4,
 	};
 
 	s64 filesize_;
@@ -145,6 +150,9 @@ private:
 	};
 
 	std::map<s64, BlockInfo> blocks_;
+	recursive_mutex blocksMutex_;
+	mutable recursive_mutex backendMutex_;
+	bool aheadThread_;
 };
 
 FileLoader *ConstructFileLoader(const std::string &filename) {
@@ -347,7 +355,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 
 // Takes ownership of backend.
 CachingFileLoader::CachingFileLoader(FileLoader *backend)
-	: filesize_(0), filepos_(0), backend_(backend), exists_(-1), isDirectory_(-1) {
+	: filesize_(0), filepos_(0), backend_(backend), exists_(-1), isDirectory_(-1), aheadThread_(false) {
 	filesize_ = backend->FileSize();
 	if (filesize_ > 0) {
 		InitCache();
@@ -364,6 +372,7 @@ CachingFileLoader::~CachingFileLoader() {
 
 bool CachingFileLoader::Exists() {
 	if (exists_ == -1) {
+		lock_guard guard(backendMutex_);
 		exists_ = backend_->Exists() ? 1 : 0;
 	}
 	return exists_ == 1;
@@ -371,6 +380,7 @@ bool CachingFileLoader::Exists() {
 
 bool CachingFileLoader::IsDirectory() {
 	if (isDirectory_ == -1) {
+		lock_guard guard(backendMutex_);
 		isDirectory_ = backend_->IsDirectory() ? 1 : 0;
 	}
 	return isDirectory_ == 1;
@@ -381,6 +391,7 @@ s64 CachingFileLoader::FileSize() {
 }
 
 std::string CachingFileLoader::Path() const {
+	lock_guard guard(backendMutex_);
 	return backend_->Path();
 }
 
@@ -396,6 +407,8 @@ size_t CachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 		readSize += ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
 	}
 
+	StartReadAhead(absolutePos + readSize);
+
 	filepos_ = absolutePos + readSize;
 	return readSize;
 }
@@ -407,6 +420,14 @@ void CachingFileLoader::InitCache() {
 }
 
 void CachingFileLoader::ShutdownCache() {
+	// TODO: Maybe add some hint that deletion is coming soon?
+	// We can't delete while the thread is running, so have to wait.
+	// This should only happen from the menu.
+	while (aheadThread_) {
+		sleep_ms(1);
+	}
+
+	lock_guard guard(blocksMutex_);
 	for (auto block : blocks_) {
 		delete [] block.second.ptr;
 	}
@@ -421,6 +442,8 @@ size_t CachingFileLoader::ReadFromCache(s64 pos, size_t bytes, void *data) {
 	size_t readSize = 0;
 	size_t offset = (size_t)(pos - (cacheStartPos << BLOCK_SHIFT));
 	u8 *p = (u8 *)data;
+
+	lock_guard guard(blocksMutex_);
 	for (s64 i = cacheStartPos; i <= cacheEndPos; ++i) {
 		auto block = blocks_.find(i);
 		if (block == blocks_.end()) {
@@ -438,10 +461,11 @@ size_t CachingFileLoader::ReadFromCache(s64 pos, size_t bytes, void *data) {
 	return readSize;
 }
 
-void CachingFileLoader::SaveIntoCache(s64 pos, size_t bytes) {
+void CachingFileLoader::SaveIntoCache(s64 pos, size_t bytes, bool readingAhead) {
 	s64 cacheStartPos = pos >> BLOCK_SHIFT;
 	s64 cacheEndPos = (pos + bytes - 1) >> BLOCK_SHIFT;
 
+	lock_guard guard(blocksMutex_);
 	size_t blocksToRead = 0;
 	for (s64 i = cacheStartPos; i <= cacheEndPos; ++i) {
 		auto block = blocks_.find(i);
@@ -454,17 +478,29 @@ void CachingFileLoader::SaveIntoCache(s64 pos, size_t bytes) {
 		}
 	}
 
-	MakeCacheSpaceFor(blocksToRead);
+	if (!MakeCacheSpaceFor(blocksToRead, readingAhead) || blocksToRead == 0) {
+		return;
+	}
 
-	if (blocksToRead == 0) {
-		ERROR_LOG(LOADER, "No blocks to read into cache?");
-	} else if (blocksToRead == 1) {
+	if (blocksToRead == 1) {
+		blocksMutex_.unlock();
+
 		u8 *buf = new u8[BLOCK_SIZE];
+		backendMutex_.lock();
 		backend_->ReadAt(cacheStartPos << BLOCK_SHIFT, BLOCK_SIZE, buf);
+		backendMutex_.unlock();
+
+		blocksMutex_.lock();
 		blocks_[cacheStartPos] = BlockInfo(buf);
 	} else {
+		blocksMutex_.unlock();
+
 		u8 *wholeRead = new u8[blocksToRead << BLOCK_SHIFT];
+		backendMutex_.lock();
 		backend_->ReadAt(cacheStartPos << BLOCK_SHIFT, blocksToRead << BLOCK_SHIFT, wholeRead);
+		backendMutex_.unlock();
+
+		blocksMutex_.lock();
 		for (size_t i = 0; i < blocksToRead; ++i) {
 			u8 *buf = new u8[BLOCK_SIZE];
 			memcpy(buf, wholeRead + (i << BLOCK_SHIFT), BLOCK_SIZE);
@@ -477,9 +513,14 @@ void CachingFileLoader::SaveIntoCache(s64 pos, size_t bytes) {
 	++generation_;
 }
 
-void CachingFileLoader::MakeCacheSpaceFor(size_t blocks) {
+bool CachingFileLoader::MakeCacheSpaceFor(size_t blocks, bool readingAhead) {
 	size_t goal = MAX_BLOCKS_CACHED - blocks;
 
+	if (readingAhead && cacheSize_ > goal) {
+		return false;
+	}
+
+	lock_guard guard(blocksMutex_);
 	while (cacheSize_ > goal) {
 		u64 minGeneration = generation_;
 
@@ -512,6 +553,39 @@ void CachingFileLoader::MakeCacheSpaceFor(size_t blocks) {
 		// If we didn't find any, update to the lowest we did find.
 		oldestGeneration_ = minGeneration;
 	}
+
+	return true;
+}
+
+void CachingFileLoader::StartReadAhead(s64 pos) {
+	lock_guard guard(blocksMutex_);
+	if (aheadThread_) {
+		// Already going.
+		return;
+	}
+	if (cacheSize_ + BLOCK_READAHEAD > MAX_BLOCKS_CACHED) {
+		// Not enough space to readahead.
+		return;
+	}
+
+	aheadThread_ = true;
+	std::thread th([this, pos] {
+		lock_guard guard(blocksMutex_);
+		s64 cacheStartPos = pos >> BLOCK_SHIFT;
+		s64 cacheEndPos = cacheStartPos + BLOCK_READAHEAD - 1;
+
+		for (s64 i = cacheStartPos; i <= cacheEndPos; ++i) {
+			auto block = blocks_.find(i);
+			if (block == blocks_.end()) {
+				blocksMutex_.unlock();
+				SaveIntoCache(i << BLOCK_SHIFT, BLOCK_SIZE * BLOCK_READAHEAD, true);
+				break;
+			}
+		}
+
+		aheadThread_ = false;
+	});
+	th.detach();
 }
 
 // TODO : improve, look in the file more

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -31,6 +31,34 @@
 #include "Core/ELF/PBPReader.h"
 #include "Core/ELF/ParamSFO.h"
 
+class LocalFileLoader : public FileLoader {
+public:
+	LocalFileLoader(const std::string &filename);
+	virtual ~LocalFileLoader();
+
+	virtual bool Reopen(const std::string &filename);
+
+	virtual bool Exists() override;
+	virtual bool IsDirectory() override;
+	virtual s64 FileSize() override;
+	virtual std::string Path() const override;
+
+	virtual void Seek(s64 absolutePos) override;
+	virtual size_t Read(size_t bytes, size_t count, void *data) override;
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override;
+
+private:
+	// First only used by Android, but we can keep it here for everyone.
+	int fd_;
+	FILE *f_;
+	u64 filesize_;
+	std::string filename_;
+};
+
+FileLoader *ConstructFileLoader(const std::string &filename) {
+	return new LocalFileLoader(filename);
+}
+
 LocalFileLoader::LocalFileLoader(const std::string &filename) {
 	Reopen(filename);
 }

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -252,7 +252,7 @@ HTTPFileLoader::HTTPFileLoader(const std::string &filename)
 
 	// TODO: Expire cache via ETag, etc.
 	for (std::string header : responseHeaders) {
-		if (startsWith(header, "Content-Length:")) {
+		if (startsWithNoCase(header, "Content-Length:")) {
 			size_t size_pos = header.find_first_of(' ');
 			if (size_pos != header.npos) {
 				size_pos = header.find_first_not_of(' ', size_pos);
@@ -321,10 +321,12 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 	// We don't support multipart/byteranges responses.
 	bool supportedResponse = false;
 	for (std::string header : responseHeaders) {
-		if (startsWith(header, "Content-Range:")) {
+		if (startsWithNoCase(header, "Content-Range:")) {
 			// TODO: More correctness.  Whitespace can be missing or different.
 			s64 first = -1, last = -1, total = -1;
-			if (sscanf(header.c_str(), "Content-Range: bytes %lld-%lld/%lld", &first, &last, &total) >= 2) {
+			std::string lowerHeader = header;
+			std::transform(lowerHeader.begin(), lowerHeader.end(), lowerHeader.begin(), tolower);
+			if (sscanf(lowerHeader.c_str(), "content-range: bytes %lld-%lld/%lld", &first, &last, &total) >= 2) {
 				if (first == absolutePos && last == absoluteEnd - 1) {
 					supportedResponse = true;
 				} else {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -342,12 +342,12 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 	Buffer output;
 	client_.ReadResponseEntity(&readbuf, responseHeaders, &output);
 
+	client_.Disconnect();
+
 	if (!supportedResponse) {
 		ERROR_LOG(LOADER, "HTTP server did not respond with the range we wanted.");
 		return 0;
 	}
-
-	client_.Disconnect();
 
 	size_t readBytes = output.size();
 	output.Take(readBytes, (char *)data);

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -312,6 +312,10 @@ void HTTPFileLoader::Seek(s64 absolutePos) {
 
 size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 	s64 absoluteEnd = std::min(absolutePos + (s64)bytes, filesize_);
+	if (absolutePos >= filesize_ || bytes == 0) {
+		// Read outside of the file or no read at all, just fail immediately.
+		return 0;
+	}
 
 	// TODO: Keepalive, etc.
 	client_.Connect();

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -78,29 +78,7 @@ public:
 	}
 };
 
-class LocalFileLoader : public FileLoader {
-public:
-	LocalFileLoader(const std::string &filename);
-	virtual ~LocalFileLoader();
-
-	virtual bool Reopen(const std::string &filename);
-
-	virtual bool Exists() override;
-	virtual bool IsDirectory() override;
-	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
-
-	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override;
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override;
-
-private:
-	// First only used by Android, but we can keep it here for everyone.
-	int fd_;
-	FILE *f_;
-	u64 filesize_;
-	std::string filename_;
-};
+FileLoader *ConstructFileLoader(const std::string &filename);
 
 // This can modify the string, for example for stripping off the "/EBOOT.PBP"
 // for a FILETYPE_PSP_PBP_DIRECTORY.

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -50,9 +50,6 @@ class FileLoader {
 public:
 	virtual ~FileLoader() {}
 
-	// Needed when we switch from a directory to a PBP, etc.
-	virtual bool Reopen(const std::string &filename) = 0;
-
 	virtual bool Exists() = 0;
 	virtual bool IsDirectory() = 0;
 	virtual s64 FileSize() = 0;
@@ -85,4 +82,4 @@ FileLoader *ConstructFileLoader(const std::string &filename);
 IdentifiedFileType Identify_File(FileLoader *fileLoader);
 
 // Can modify the string filename, as it calls IdentifyFile above.
-bool LoadFile(FileLoader *fileLoader, std::string *error_string);
+bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -32,6 +32,7 @@
 #include "FileSystems/MetaFileSystem.h"
 #include "FileSystems/VirtualDiscFileSystem.h"
 
+#include "Core/Loaders.h"
 #include "Core/MemMap.h"
 #include "Core/HDRemaster.h"
 
@@ -53,21 +54,21 @@
 // We gather the game info before actually loading/booting the ISO
 // to determine if the emulator should enable extra memory and
 // double-sized texture coordinates.
-void InitMemoryForGameISO(std::string fileToStart) {
+void InitMemoryForGameISO(FileLoader *fileLoader) {
 	IFileSystem* umd2;
 
-	// check if it's a disc directory
-	FileInfo info;
-	if (!getFileInfo(fileToStart.c_str(), &info)) return;
+	if (!fileLoader->Exists()) {
+		return;
+	}
 
 	bool actualIso = false;
-	if (info.isDirectory)
+	if (fileLoader->IsDirectory())
 	{
-		umd2 = new VirtualDiscFileSystem(&pspFileSystem, fileToStart);
+		umd2 = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
 	}
 	else 
 	{
-		auto bd = constructBlockDevice(fileToStart.c_str());
+		auto bd = constructBlockDevice(fileLoader->Path().c_str());
 		// Can't init anything without a block device...
 		if (!bd)
 			return;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -68,7 +68,7 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 	}
 	else 
 	{
-		auto bd = constructBlockDevice(fileLoader->Path().c_str());
+		auto bd = constructBlockDevice(fileLoader);
 		// Can't init anything without a block device...
 		if (!bd)
 			return;
@@ -151,7 +151,7 @@ static const char *altBootNames[] = {
 	"disc0:/PSP_GAME/SYSDIR/ss.RAW",
 };
 
-bool Load_PSP_ISO(const char *filename, std::string *error_string)
+bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string)
 {
 	// Mounting stuff relocated to InitMemoryForGameISO due to HD Remaster restructuring of code.
 
@@ -224,12 +224,12 @@ static std::string NormalizePath(const std::string &path)
 	return buf;
 }
 
-bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string)
+bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string)
 {
 	// This is really just for headless, might need tweaking later.
-	if (!PSP_CoreParameter().mountIso.empty())
+	if (PSP_CoreParameter().mountIsoLoader != nullptr)
 	{
-		auto bd = constructBlockDevice(PSP_CoreParameter().mountIso.c_str());
+		auto bd = constructBlockDevice(PSP_CoreParameter().mountIsoLoader);
 		if (bd != NULL) {
 			ISOFileSystem *umd2 = new ISOFileSystem(&pspFileSystem, bd);
 
@@ -239,7 +239,7 @@ bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string)
 		}
 	}
 
-	std::string full_path = filename;
+	std::string full_path = fileLoader->Path();
 	std::string path, file, extension;
 	SplitPath(ReplaceAll(full_path, "\\", "/"), &path, &file, &extension);
 #ifdef _WIN32

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -21,6 +21,6 @@
 
 class FileLoader;
 
-bool Load_PSP_ISO(const char *filename, std::string *error_string);
-bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string);
+bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string);
+bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 void InitMemoryForGameISO(FileLoader *fileLoader);

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -19,6 +19,8 @@
 
 #include <string>
 
+class FileLoader;
+
 bool Load_PSP_ISO(const char *filename, std::string *error_string);
 bool Load_PSP_ELF_PBP(const char *filename, std::string *error_string);
-void InitMemoryForGameISO(std::string fileToStart);
+void InitMemoryForGameISO(FileLoader *fileLoader);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -182,12 +182,12 @@ void CPU_Init() {
 	Memory::g_PSPModel = g_Config.iPSPModel;
 
 	std::string filename = coreParameter.fileToStart;
-	loadedFile = new LocalFileLoader(filename);
+	loadedFile = ConstructFileLoader(filename);
 	IdentifiedFileType type = Identify_File(loadedFile);
 
 	// TODO: Put this somewhere better?
 	if (coreParameter.mountIso != "") {
-		coreParameter.mountIsoLoader = new LocalFileLoader(coreParameter.mountIso);
+		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso);
 	}
 
 	MIPSAnalyst::Reset();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -185,6 +185,11 @@ void CPU_Init() {
 	loadedFile = new LocalFileLoader(filename);
 	IdentifiedFileType type = Identify_File(loadedFile);
 
+	// TODO: Put this somewhere better?
+	if (coreParameter.mountIso != "") {
+		coreParameter.mountIsoLoader = new LocalFileLoader(coreParameter.mountIso);
+	}
+
 	MIPSAnalyst::Reset();
 	Replacement_Init();
 
@@ -249,7 +254,16 @@ void CPU_Shutdown() {
 	Memory::Shutdown();
 
 	delete loadedFile;
-	loadedFile = 0;
+	loadedFile = nullptr;
+
+	delete coreParameter.mountIsoLoader;
+	coreParameter.mountIsoLoader = nullptr;
+}
+
+// TODO: Maybe loadedFile doesn't even belong here...
+void UpdateLoadedFile(FileLoader *fileLoader) {
+	delete loadedFile;
+	loadedFile = fileLoader;
 }
 
 void CPU_RunLoop() {

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -220,7 +220,7 @@ void CPU_Init() {
 	// TODO: Check Game INI here for settings, patches and cheats, and modify coreParameter accordingly
 
 	// Why did we check for CORE_POWERDOWN here?
-	if (!LoadFile(loadedFile, &coreParameter.errorString)) {
+	if (!LoadFile(&loadedFile, &coreParameter.errorString)) {
 		CPU_Shutdown();
 		coreParameter.fileToStart = "";
 		CPU_SetState(CPU_THREAD_NOT_RUNNING);

--- a/Core/System.h
+++ b/Core/System.h
@@ -63,6 +63,8 @@ void Audio_Init();
 bool IsOnSeparateCPUThread();
 bool IsAudioInitialised();
 
+void UpdateLoadedFile(FileLoader *fileLoader);
+
 std::string GetSysDirectory(PSPDirectories directoryType);
 #ifdef _WIN32
 void InitSysDirectories();

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -247,7 +247,7 @@ public:
 			return;
 
 		std::string filename = gamePath_;
-		std::unique_ptr<FileLoader> fileLoader(new LocalFileLoader(filename));
+		std::unique_ptr<FileLoader> fileLoader(ConstructFileLoader(filename));
 		info_->path = gamePath_;
 		info_->fileType = Identify_File(fileLoader.get());
 		// Fallback title

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 #include <algorithm>
 
 #include "base/logging.h"
@@ -246,8 +247,9 @@ public:
 			return;
 
 		std::string filename = gamePath_;
+		std::unique_ptr<FileLoader> fileLoader(new LocalFileLoader(filename));
 		info_->path = gamePath_;
-		info_->fileType = Identify_File(filename);
+		info_->fileType = Identify_File(fileLoader.get());
 		// Fallback title
 		info_->title = getFilename(info_->path);
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -378,7 +378,7 @@ handleELF:
 				// Let's assume it's an ISO.
 				// TODO: This will currently read in the whole directory tree. Not really necessary for just a
 				// few files.
-				BlockDevice *bd = constructBlockDevice(gamePath_.c_str());
+				BlockDevice *bd = constructBlockDevice(fileLoader.get());
 				if (!bd)
 					return;  // nothing to do here..
 				ISOFileSystem umd(&handles, bd, "/PSP_GAME");


### PR DESCRIPTION
This moves it all into a FileLoader interface, and creates a LocalFileLoader and HTTPFileLoader class.  We could also add a SambaFileLoader or FTPFileLoader (would have horrible latency.)

Currently, there's no caching, which would make sense before exposing this functionality.  I'm thinking of a fixed-size ram cache (and larger reads.)  We could expose this as a CachedFileLoader class that takes HTTP/Samba as input.  Might do disk caching too but that starts to get complicated (definitely need to do ETag checks and Last-Modified etc.)

Motivation: I don't want to wait while I copy games to my Android just to test them.  I have limited storage space anyway, so to test a decent range of games I would have to wait while they upload, test, plug it back in, delete, upload more, etc.  HTTP makes more sense to me.

Latency on an 802.11n connection is not too bad even without proper caching.  There are fps dips but it's already acceptable I think.  Most likely users with tablets and the like might use this functionality (e.g. when only playing while on local wifi anyway.)

Requires hrydgard/native#242.

-[Unknown]
