### PR TITLE
jit: MAP_NOINIT should always mean MAP_DIRTY

### DIFF
--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -309,7 +309,7 @@ namespace MIPSComp
 				if (!gpr.IsImm(rs) && rs != rt && (offset <= offsetRange) && offset >= -offsetRange) {
 					gpr.SpillLock(rs, rt);
 					gpr.MapRegAsPointer(rs);
-					gpr.MapReg(rt, load ? (MAP_NOINIT | MAP_DIRTY) : 0);
+					gpr.MapReg(rt, load ? MAP_NOINIT : 0);
 					switch (o) {
 					case 35: LDR  (gpr.R(rt), gpr.RPtr(rs), Operand2(offset, TYPE_IMM)); break;
 					case 37: LDRH (gpr.R(rt), gpr.RPtr(rs), Operand2(offset, TYPE_IMM)); break;
@@ -338,7 +338,7 @@ namespace MIPSComp
 					addrReg = gpr.R(rs);
 				} else {
 					// In this case, only map rt. rs+offset will be in R0.
-					gpr.MapReg(rt, load ? (MAP_NOINIT | MAP_DIRTY) : 0);
+					gpr.MapReg(rt, load ? MAP_NOINIT : 0);
 					gpr.SetRegImm(R0, addr);
 					addrReg = R0;
 				}

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -144,7 +144,7 @@ void ArmRegCache::SetRegImm(ARMReg reg, u32 imm) {
 
 void ArmRegCache::MapRegTo(ARMReg reg, MIPSGPReg mipsReg, int mapFlags) {
 	ar[reg].isDirty = (mapFlags & MAP_DIRTY) ? true : false;
-	if (!(mapFlags & MAP_NOINIT)) {
+	if ((mapFlags & MAP_NOINIT) != MAP_NOINIT) {
 		if (mipsReg == MIPS_REG_ZERO) {
 			// If we get a request to load the zero register, at least we won't spend
 			// time on a memory access...
@@ -243,7 +243,7 @@ ARMReg ArmRegCache::MapReg(MIPSGPReg mipsReg, int mapFlags) {
 		// add or subtract stuff to it. Later we could allow such things but for now
 		// let's just convert back to a register value by reloading from the backing storage.
 		ARMReg armReg = mr[mipsReg].reg;
-		if (!(mapFlags & MAP_NOINIT)) {
+		if ((mapFlags & MAP_NOINIT) != MAP_NOINIT) {
 			emit_->LDR(armReg, CTXREG, GetMipsRegOffset(mipsReg));
 		}
 		mr[mipsReg].loc = ML_ARMREG;
@@ -312,7 +312,7 @@ void ArmRegCache::MapInIn(MIPSGPReg rd, MIPSGPReg rs) {
 void ArmRegCache::MapDirtyIn(MIPSGPReg rd, MIPSGPReg rs, bool avoidLoad) {
 	SpillLock(rd, rs);
 	bool load = !avoidLoad || rd == rs;
-	MapReg(rd, MAP_DIRTY | (load ? 0 : MAP_NOINIT));
+	MapReg(rd, load ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rs);
 	ReleaseSpillLocks();
 }
@@ -320,7 +320,7 @@ void ArmRegCache::MapDirtyIn(MIPSGPReg rd, MIPSGPReg rs, bool avoidLoad) {
 void ArmRegCache::MapDirtyInIn(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, bool avoidLoad) {
 	SpillLock(rd, rs, rt);
 	bool load = !avoidLoad || (rd == rs || rd == rt);
-	MapReg(rd, MAP_DIRTY | (load ? 0 : MAP_NOINIT));
+	MapReg(rd, load ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rt);
 	MapReg(rs);
 	ReleaseSpillLocks();
@@ -330,8 +330,8 @@ void ArmRegCache::MapDirtyDirtyIn(MIPSGPReg rd1, MIPSGPReg rd2, MIPSGPReg rs, bo
 	SpillLock(rd1, rd2, rs);
 	bool load1 = !avoidLoad || rd1 == rs;
 	bool load2 = !avoidLoad || rd2 == rs;
-	MapReg(rd1, MAP_DIRTY | (load1 ? 0 : MAP_NOINIT));
-	MapReg(rd2, MAP_DIRTY | (load2 ? 0 : MAP_NOINIT));
+	MapReg(rd1, load1 ? MAP_DIRTY : MAP_NOINIT);
+	MapReg(rd2, load2 ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rs);
 	ReleaseSpillLocks();
 }
@@ -340,8 +340,8 @@ void ArmRegCache::MapDirtyDirtyInIn(MIPSGPReg rd1, MIPSGPReg rd2, MIPSGPReg rs, 
 	SpillLock(rd1, rd2, rs, rt);
 	bool load1 = !avoidLoad || (rd1 == rs || rd1 == rt);
 	bool load2 = !avoidLoad || (rd2 == rs || rd2 == rt);
-	MapReg(rd1, MAP_DIRTY | (load1 ? 0 : MAP_NOINIT));
-	MapReg(rd2, MAP_DIRTY | (load2 ? 0 : MAP_NOINIT));
+	MapReg(rd1, load1 ? MAP_DIRTY : MAP_NOINIT);
+	MapReg(rd2, load2 ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rt);
 	MapReg(rs);
 	ReleaseSpillLocks();

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -72,7 +72,7 @@ struct RegMIPS {
 // Initing is the default so the flag is reversed.
 enum {
 	MAP_DIRTY = 1,
-	MAP_NOINIT = 2,
+	MAP_NOINIT = 2 | MAP_DIRTY,
 };
 
 namespace MIPSComp {

--- a/Core/MIPS/ARM/ArmRegCacheFPU.cpp
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.cpp
@@ -125,7 +125,7 @@ allocate:
 		if (ar[reg].mipsReg == -1) {
 			// That means it's free. Grab it, and load the value into it (if requested).
 			ar[reg].isDirty = (mapFlags & MAP_DIRTY) ? true : false;
-			if (!(mapFlags & MAP_NOINIT)) {
+			if ((mapFlags & MAP_NOINIT) != MAP_NOINIT) {
 				if (mr[mipsReg].loc == ML_MEM && mipsReg < TEMP0) {
 					emit_->VLDR((ARMReg)(reg + S0), CTXREG, GetMipsRegOffset(mipsReg));
 				}
@@ -172,7 +172,7 @@ void ArmRegCacheFPU::MapInIn(MIPSReg rd, MIPSReg rs) {
 void ArmRegCacheFPU::MapDirtyIn(MIPSReg rd, MIPSReg rs, bool avoidLoad) {
 	SpillLock(rd, rs);
 	bool overlap = avoidLoad && rd == rs;
-	MapReg(rd, MAP_DIRTY | (overlap ? 0 : MAP_NOINIT));
+	MapReg(rd, overlap ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rs);
 	ReleaseSpillLock(rd);
 	ReleaseSpillLock(rs);
@@ -181,7 +181,7 @@ void ArmRegCacheFPU::MapDirtyIn(MIPSReg rd, MIPSReg rs, bool avoidLoad) {
 void ArmRegCacheFPU::MapDirtyInIn(MIPSReg rd, MIPSReg rs, MIPSReg rt, bool avoidLoad) {
 	SpillLock(rd, rs, rt);
 	bool overlap = avoidLoad && (rd == rs || rd == rt);
-	MapReg(rd, MAP_DIRTY | (overlap ? 0 : MAP_NOINIT));
+	MapReg(rd, overlap ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rt);
 	MapReg(rs);
 	ReleaseSpillLock(rd);
@@ -243,7 +243,7 @@ void ArmRegCacheFPU::MapDirtyInV(int vd, int vs, bool avoidLoad) {
 	bool overlap = avoidLoad && (vd == vs);
 	SpillLockV(vd);
 	SpillLockV(vs);
-	MapRegV(vd, MAP_DIRTY | (overlap ? 0 : MAP_NOINIT));
+	MapRegV(vd, overlap ? MAP_DIRTY : MAP_NOINIT);
 	MapRegV(vs);
 	ReleaseSpillLockV(vd);
 	ReleaseSpillLockV(vs);
@@ -254,7 +254,7 @@ void ArmRegCacheFPU::MapDirtyInInV(int vd, int vs, int vt, bool avoidLoad) {
 	SpillLockV(vd);
 	SpillLockV(vs);
 	SpillLockV(vt);
-	MapRegV(vd, MAP_DIRTY | (overlap ? 0 : MAP_NOINIT));
+	MapRegV(vd, overlap ? MAP_DIRTY : MAP_NOINIT);
 	MapRegV(vs);
 	MapRegV(vt);
 	ReleaseSpillLockV(vd);

--- a/Core/MIPS/PPC/PpcRegCache.cpp
+++ b/Core/MIPS/PPC/PpcRegCache.cpp
@@ -104,7 +104,7 @@ allocate:
 		if (ar[reg].mipsReg == -1) {
 			// That means it's free. Grab it, and load the value into it (if requested).
 			ar[reg].isDirty = (mapFlags & MAP_DIRTY) ? true : false;
-			if (!(mapFlags & MAP_NOINIT)) {
+			if ((mapFlags & MAP_NOINIT) != MAP_NOINIT) {
 				if (mr[mipsReg].loc == ML_MEM) {
 					if (mipsReg != 0) {
 						emit_->LWZ((PPCReg)reg, CTXREG, GetMipsRegOffset(mipsReg));
@@ -158,7 +158,7 @@ void PpcRegCache::MapInIn(MIPSReg rd, MIPSReg rs) {
 void PpcRegCache::MapDirtyIn(MIPSReg rd, MIPSReg rs, bool avoidLoad) {
 	SpillLock(rd, rs);
 	bool load = !avoidLoad || rd == rs;
-	MapReg(rd, MAP_DIRTY | (load ? 0 : MAP_NOINIT));
+	MapReg(rd, load ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rs);
 	ReleaseSpillLocks();
 }
@@ -166,7 +166,7 @@ void PpcRegCache::MapDirtyIn(MIPSReg rd, MIPSReg rs, bool avoidLoad) {
 void PpcRegCache::MapDirtyInIn(MIPSReg rd, MIPSReg rs, MIPSReg rt, bool avoidLoad) {
 	SpillLock(rd, rs, rt);
 	bool load = !avoidLoad || (rd == rs || rd == rt);
-	MapReg(rd, MAP_DIRTY | (load ? 0 : MAP_NOINIT));
+	MapReg(rd, load ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rt);
 	MapReg(rs);
 	ReleaseSpillLocks();
@@ -176,8 +176,8 @@ void PpcRegCache::MapDirtyDirtyInIn(MIPSReg rd1, MIPSReg rd2, MIPSReg rs, MIPSRe
 	SpillLock(rd1, rd2, rs, rt);
 	bool load1 = !avoidLoad || (rd1 == rs || rd1 == rt);
 	bool load2 = !avoidLoad || (rd2 == rs || rd2 == rt);
-	MapReg(rd1, MAP_DIRTY | (load1 ? 0 : MAP_NOINIT));
-	MapReg(rd2, MAP_DIRTY | (load2 ? 0 : MAP_NOINIT));
+	MapReg(rd1, load1 ? MAP_DIRTY : MAP_NOINIT);
+	MapReg(rd2, load2 ? MAP_DIRTY : MAP_NOINIT);
 	MapReg(rt);
 	MapReg(rs);
 	ReleaseSpillLocks();

--- a/Core/MIPS/PPC/PpcRegCache.h
+++ b/Core/MIPS/PPC/PpcRegCache.h
@@ -92,7 +92,7 @@ struct RegMIPS {
 // Initing is the default so the flag is reversed.
 enum {
 	MAP_DIRTY = 1,
-	MAP_NOINIT = 2,
+	MAP_NOINIT = 2 | MAP_DIRTY,
 };
 
 namespace MIPSComp {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1063,7 +1063,7 @@ void Jit::Comp_VecDo3(MIPSOpcode op) {
 		}
 		else
 		{
-			fpr.MapRegV(dregs[i], (dregs[i] == sregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(dregs[i], dregs[i] == sregs[i] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(dregs[i]);
 			tempxregs[i] = fpr.VX(dregs[i]);
 		}
@@ -1415,7 +1415,7 @@ void Jit::Comp_Vi2f(MIPSOpcode op) {
 	if (*mult != 1.0f)
 		MOVSS(XMM1, M(mult));
 	for (int i = 0; i < n; i++) {
-		fpr.MapRegV(tempregs[i], (sregs[i] == dregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+		fpr.MapRegV(tempregs[i], sregs[i] == dregs[i] ? MAP_DIRTY : MAP_NOINIT);
 		if (fpr.V(sregs[i]).IsSimpleReg()) {
 			CVTDQ2PS(fpr.VX(tempregs[i]), fpr.V(sregs[i]));
 		} else {
@@ -1834,7 +1834,7 @@ void Jit::Comp_Vsgn(MIPSOpcode op) {
 		}
 		else
 		{
-			fpr.MapRegV(dregs[i], (dregs[i] == sregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(dregs[i], dregs[i] == sregs[i] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(dregs[i]);
 			tempxregs[i] = fpr.VX(dregs[i]);
 		}
@@ -1892,7 +1892,7 @@ void Jit::Comp_Vocp(MIPSOpcode op) {
 		}
 		else
 		{
-			fpr.MapRegV(dregs[i], (dregs[i] == sregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(dregs[i], dregs[i] == sregs[i] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(dregs[i]);
 			tempxregs[i] = fpr.VX(dregs[i]);
 		}
@@ -2043,7 +2043,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 		}
 		else
 		{
-			fpr.MapRegV(dregs[i], (dregs[i] == sregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(dregs[i], dregs[i] == sregs[i] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(dregs[i]);
 			tempxregs[i] = fpr.VX(dregs[i]);
 		}
@@ -2427,7 +2427,7 @@ void Jit::Comp_VScl(MIPSOpcode op) {
 		}
 		else
 		{
-			fpr.MapRegV(dregs[i], (dregs[i] == sregs[i] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(dregs[i], dregs[i] == sregs[i] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(dregs[i]);
 			tempxregs[i] = fpr.VX(dregs[i]);
 		}
@@ -2691,14 +2691,14 @@ void Jit::Comp_Vi2x(MIPSOpcode op) {
 			// Will be discarded on release.
 			vreg = fpr.GetTempV();
 		}
-		fpr.MapRegV(vreg, (vreg == sregs[0] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+		fpr.MapRegV(vreg, vreg == sregs[0] ? MAP_DIRTY : MAP_NOINIT);
 		fpr.SpillLockV(vreg);
 		dst0 = fpr.VX(vreg);
 	} else {
 		// Pair, let's check if we should use dregs[0] directly.  No temp needed.
 		int vreg = dregs[0];
 		if (IsOverlapSafeAllowS(dregs[0], 0, 2, sregs)) {
-			fpr.MapRegV(vreg, (vreg == sregs[0] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+			fpr.MapRegV(vreg, vreg == sregs[0] ? MAP_DIRTY : MAP_NOINIT);
 			fpr.SpillLockV(vreg);
 			dst0 = fpr.VX(vreg);
 		}
@@ -2789,7 +2789,7 @@ void Jit::Comp_Vhoriz(MIPSOpcode op) {
 
 	X64Reg reg = XMM0;
 	if (IsOverlapSafeAllowS(dregs[0], 0, n, sregs)) {
-		fpr.MapRegV(dregs[0], (dregs[0] == sregs[0] ? 0 : MAP_NOINIT) | MAP_DIRTY);
+		fpr.MapRegV(dregs[0], dregs[0] == sregs[0] ? MAP_DIRTY : MAP_NOINIT);
 		fpr.SpillLockV(dregs[0]);
 		reg = fpr.VX(dregs[0]);
 	}

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -85,7 +85,7 @@ namespace MIPSComp {
 
 enum {
 	MAP_DIRTY = 1,
-	MAP_NOINIT = 2,
+	MAP_NOINIT = 2 | MAP_DIRTY,
 };
 
 // The PSP has 160 FP registers: 32 FPRs + 128 VFPU registers.


### PR DESCRIPTION
Avoided removing all MAP_DIRTY | MAP_NOINIT to avoid blamespam, but changed some that reduced parenthesis / complexity.

There were a couple lone MAP_NOINITs in armjit.

-[Unknown]
