### PR TITLE
x86jit: Fix more simd mapping

### DIFF
--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -611,9 +611,9 @@ void FPURegCache::StoreFromRegister(int i) {
 				if (mri[j] == -1) {
 					break;
 				}
-				if (mri[j] - 32 >= 128 && mri[j] == mri[j - 1] + 1) {
+				if (mri[j] - 32 >= 128 && mri[j - 1] - 32 >= 128 && mri[j] == mri[j - 1] + 1) {
 					seq++;
-				} else if (mri[j] - 32 < 128 && voffset[mri[j] - 32] == voffset[mri[j - 1] - 32] + 1) {
+				} else if (mri[j] - 32 < 128 && mri[j - 1] - 32 < 128 && voffset[mri[j] - 32] == voffset[mri[j - 1] - 32] + 1) {
 					seq++;
 				} else {
 					break;

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -439,7 +439,7 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 		} else if (n == 4) {
 			if (!vregs[v[2]].location.IsSimpleReg(xr2))
 				emit->MOVSS(xr2, vregs[v[2]].location);
-			if (!vregs[v[3]].location.IsSimpleReg(xr2))
+			if (!vregs[v[3]].location.IsSimpleReg(xr1))
 				emit->MOVSS(xr1, vregs[v[3]].location);
 			emit->UNPCKLPS(xr2, Gen::R(xr1));
 			emit->MOVSS(xr1, vregs[v[1]].location);


### PR DESCRIPTION
It seems like 9cfe801 is the cause of the Tekken issue (or at least the one we identified and created a test for.)  The issue is that `voffset[0xa0 - 32]` is outside the array, and happens to always be 0, so it thought it went after 1.

-[Unknown]
