### PR TITLE
Fix spline tex coords perfectly correct.

### DIFF
--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -184,6 +184,8 @@ void  _SplinePatchFullQuality(u8 *&dest, int &count, const SplinePatchLocal &spa
 	// JPCSP is wrong at least because their method results in square loco roco.
 	int patch_div_s = (spatch.count_u - 3) * gstate.getPatchDivisionU();
 	int patch_div_t = (spatch.count_v - 3) * gstate.getPatchDivisionV();
+	if (patch_div_s >= 4) patch_div_s /= quality;
+	if (patch_div_t >= 4) patch_div_t /= quality;
 
 	if (patch_div_s <= 0) patch_div_s = 1;
 	if (patch_div_t <= 0) patch_div_t = 1;


### PR DESCRIPTION
Testing in FF4CC

Firaga
Surface patterns match perfectly.

PPSSPP
![ules01521_00005](https://cloud.githubusercontent.com/assets/1607422/5267092/c931f482-7a91-11e4-995f-87b57c98725b.jpg)
PSP
![final fantasy iv psp - elemental archfiends _four emperors_ 720p mp4_snapshot_01 10_ 2014 12 01_14 13 12](https://cloud.githubusercontent.com/assets/1607422/5267083/bc320236-7a91-11e4-88bb-027db9c9d5c7.jpg)

PPSSPP
![ules01521_00011](https://cloud.githubusercontent.com/assets/1607422/5267218/d0df3234-7a92-11e4-863f-68357f11a6bc.jpg)
PSP
![final fantasy iv psp - elemental archfiends _four emperors_ 720p mp4_snapshot_01 11_ 2014 12 01_14 09 39](https://cloud.githubusercontent.com/assets/1607422/5267222/d6f2e3b4-7a92-11e4-8179-c14cad63ef8f.jpg)

Thundaga
Before: a bit smooth
![ules01521_00013](https://cloud.githubusercontent.com/assets/1607422/5267582/7f830c14-7a95-11e4-9b28-05e52aeebf32.jpg)
After:
![ules01521_00007](https://cloud.githubusercontent.com/assets/1607422/5267363/e57add78-7a93-11e4-969d-f65bfa96a6ca.jpg)
PSP
![final fantasy iv complete collection - ff4 zeromus final battle ending part 1 of 3 720p mp4_snapshot_00 42_ 2014 12 01_14 18 47](https://cloud.githubusercontent.com/assets/1607422/5267369/f12a38bc-7a93-11e4-9a20-71cb841ca411.jpg)

Meteor
Before: Texture joints seamed
![ules01521_00001](https://cloud.githubusercontent.com/assets/1607422/5267514/f23b3e6c-7a94-11e4-8ae0-843af4b34aa6.jpg)
After: Seamless
![ules01521_00010](https://cloud.githubusercontent.com/assets/1607422/5267522/06b5c74a-7a95-11e4-830e-a2f624a6f18d.jpg)
