### PR TITLE
sceMpeg: Remove an unnecessary if statement

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -846,8 +846,7 @@ public:
 		memcpy(newstream, stream, size);
 		memcpy(newstream + size, str, sz);
 		// delete old stream
-		if (stream)
-			delete[] stream;
+		delete[] stream;
 		// replace with new stream
 		stream = newstream;
 		size = newsize;


### PR DESCRIPTION
stream is previously used in the above memcpy, so this check is not necessary.
