### PR TITLE
Add a missing module sceSha256 found in Tantei Jinguji Saburo no functional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1236,6 +1236,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/sceRtc.h
 	Core/HLE/sceSas.cpp
 	Core/HLE/sceSas.h
+	Core/HLE/sceSha256.cpp
+	Core/HLE/sceSha256.h
 	Core/HLE/sceSsl.cpp
 	Core/HLE/sceSsl.h
 	Core/HLE/sceUmd.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -258,6 +258,7 @@
     <ClCompile Include="HLE\sceGameUpdate.cpp" />
     <ClCompile Include="HLE\sceRtc.cpp" />
     <ClCompile Include="HLE\sceSas.cpp" />
+    <ClCompile Include="HLE\sceSha256.cpp" />
     <ClCompile Include="HLE\sceSsl.cpp" />
     <ClCompile Include="HLE\sceUmd.cpp" />
     <ClCompile Include="HLE\sceUsb.cpp" />
@@ -539,6 +540,7 @@
     <ClInclude Include="HLE\sceGameUpdate.h" />
     <ClInclude Include="HLE\sceRtc.h" />
     <ClInclude Include="HLE\sceSas.h" />
+    <ClInclude Include="HLE\sceSha256.h" />
     <ClInclude Include="HLE\sceSsl.h" />
     <ClInclude Include="HLE\sceUmd.h" />
     <ClInclude Include="HLE\sceUsb.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -550,6 +550,9 @@
     <ClCompile Include="..\ext\udis86\decode.c">
       <Filter>Ext\udis86</Filter>
     </ClCompile>
+    <ClCompile Include="HLE\sceSha256.cpp">
+      <Filter>HLE\Libraries</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1019,6 +1022,9 @@
     </ClInclude>
     <ClInclude Include="..\ext\udis86\udis86.h">
       <Filter>Ext\udis86</Filter>
+    </ClInclude>
+    <ClInclude Include="HLE\sceSha256.h">
+      <Filter>HLE\Libraries</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -69,6 +69,7 @@
 #include "sceVaudio.h"
 #include "sceMt19937.h"
 #include "sceUsbGps.h"
+#include "sceSha256.h"
 
 #define N(s) s
 
@@ -330,5 +331,6 @@ void RegisterAllModules() {
 	Register_sceMpegbase();
 	Register_sceUsbGps();
 	Register_sceLibFttt();
+	Register_sceSha256();
 }
 

--- a/Core/HLE/sceSha256.cpp
+++ b/Core/HLE/sceSha256.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceSha256.h"
+
+int sceSha256_unknow(u32 unknow1, int unknow2, u32 unknow3) {
+	ERROR_LOG(HLE, "UNIMPL sceSha256_unknow (%08x,%08x,%08x)", unknow1, unknow2, unknow3);
+	return 0;
+}
+
+const HLEFunction sceSha256[] =
+{
+	{ 0x318A350C, WrapI_UIU<sceSha256_unknow>, "sceSha256_unknow" },
+};
+
+void Register_sceSha256()
+{
+	RegisterModule("sceSha256", ARRAY_SIZE(sceSha256), sceSha256);
+}

--- a/Core/HLE/sceSha256.h
+++ b/Core/HLE/sceSha256.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+void Register_sceSha256();

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -261,6 +261,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/HLE/sceRtc.cpp \
   $(SRC)/Core/HLE/scePsmf.cpp \
   $(SRC)/Core/HLE/sceSas.cpp \
+  $(SRC)/Core/HLE/sceSha256.cpp \
   $(SRC)/Core/HLE/sceSsl.cpp \
   $(SRC)/Core/HLE/sceUmd.cpp \
   $(SRC)/Core/HLE/sceUsb.cpp \


### PR DESCRIPTION
```
30:34:745 HLE\sceKernelModule.cpp:1078 D[LOAD]: Importing Module sceSha256, stubs at 0887527c
30:34:745 HLE\sceKernelModule.cpp:303 D[LOAD]: Importing [UNK: 0x318a350c] : 0887527c
30:34:745 HLE\sceKernelModule.cpp:680 I[LOAD]: Function (sceSha256,318a350c) unresolved, storing for later resolving
```

Fixed saving problem in Tantei Jinguji Saburo.

Before was not able to creat a savefile and even put the savefile to save folder,it hanged on loading.
![01](https://cloud.githubusercontent.com/assets/3481559/5300088/ee4d1ebe-7c07-11e4-8fb6-21aab433c64d.png)
