### PR TITLE
Core: Mark some module functions as static

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -106,14 +106,14 @@ inline void AdjustVolumeBlock(s16 *out, s16 *in, int size, int leftVol, int righ
 	}
 }
 
-void hleAudioUpdate(u64 userdata, int cyclesLate) {
+static void hleAudioUpdate(u64 userdata, int cyclesLate) {
 	// Schedule the next cycle first.  __AudioUpdate() may consume cycles.
 	CoreTiming::ScheduleEvent(audioIntervalCycles - cyclesLate, eventAudioUpdate, 0);
 
 	__AudioUpdate();
 }
 
-void hleHostAudioUpdate(u64 userdata, int cyclesLate) {
+static void hleHostAudioUpdate(u64 userdata, int cyclesLate) {
 	CoreTiming::ScheduleEvent(audioHostIntervalCycles - cyclesLate, eventHostAudioUpdate, 0);
 
 	// Not all hosts need this call to poke their audio system once in a while, but those that don't
@@ -121,7 +121,7 @@ void hleHostAudioUpdate(u64 userdata, int cyclesLate) {
 	host->UpdateSound();
 }
 
-void __AudioCPUMHzChange() {
+static void __AudioCPUMHzChange() {
 	audioIntervalCycles = (int)(usToCycles(1000000ULL) * hwBlockSize / hwSampleRate);
 	audioHostIntervalCycles = (int)(usToCycles(1000000ULL) * hostAttemptBlockSize / hwSampleRate);
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -444,14 +444,14 @@ void __AtracShutdown() {
 	}
 }
 
-Atrac *getAtrac(int atracID) {
+static Atrac *getAtrac(int atracID) {
 	if (atracID < 0 || atracID >= PSP_NUM_ATRAC_IDS) {
 		return NULL;
 	}
 	return atracIDs[atracID];
 }
 
-int createAtrac(Atrac *atrac, int codecType) {
+static int createAtrac(Atrac *atrac, int codecType) {
 	for (int i = 0; i < (int)ARRAY_SIZE(atracIDs); ++i) {
 		if (atracIDTypes[i] == codecType && atracIDs[i] == 0) {
 			atracIDs[i] = atrac;
@@ -463,7 +463,7 @@ int createAtrac(Atrac *atrac, int codecType) {
 	return ATRAC_ERROR_NO_ATRACID;
 }
 
-int deleteAtrac(int atracID) {
+static int deleteAtrac(int atracID) {
 	if (atracID >= 0 && atracID < PSP_NUM_ATRAC_IDS) {
 		if (atracIDs[atracID] != NULL) {
 			delete atracIDs[atracID];
@@ -476,7 +476,7 @@ int deleteAtrac(int atracID) {
 	return ATRAC_ERROR_BAD_ATRACID;
 }
 
-int getCodecType(u32 addr) {
+static int getCodecType(u32 addr) {
 	int at3magic = Memory::Read_U16(addr+20);
 	if (at3magic == AT3_MAGIC) {
 		return PSP_MODE_AT_3;
@@ -617,7 +617,7 @@ int Atrac::Analyze() {
 	return 0;
 }
 
-u32 sceAtracGetAtracID(int codecType) {
+static u32 sceAtracGetAtracID(int codecType) {
 	if (codecType != PSP_MODE_AT_3 && codecType != PSP_MODE_AT_3_PLUS) {
 		ERROR_LOG_REPORT(ME, "sceAtracGetAtracID(%i): invalid codecType", codecType);
 		return ATRAC_ERROR_INVALID_CODECTYPE;
@@ -661,7 +661,7 @@ u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 // (We always have "first.offset + first.writableBytes = atracBufSize").
 // We only reset the temp buf when games call sceAtracGetStreamDataInfo,
 // because that function would tell games how to add the left stream data.
-u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
+static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracAddStreamData(%i, %08x): bad atrac ID", atracID, bytesToAdd);
@@ -823,7 +823,7 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 	return ret;
 }
 
-u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr) {
+static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr) {
 	int ret = -1;
 
 	// Note that outAddr being null is completely valid here, used to skip data.
@@ -851,12 +851,12 @@ u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishF
 	return ret;
 }
 
-u32 sceAtracEndEntry() {
+static u32 sceAtracEndEntry() {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceAtracEndEntry()");
 	return 0;
 }
 
-u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAddr) {
+static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAddr) {
 	auto bufferInfo = PSPPointer<AtracResetBufferInfo>::Create(bufferInfoAddr);
 
 	Atrac *atrac = getAtrac(atracID);
@@ -909,7 +909,7 @@ u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAdd
 	}
 }
 
-u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
+static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetBitrate(%i, %08x): bad atrac ID", atracID, outBitrateAddr);
@@ -930,7 +930,7 @@ u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 	return 0;
 }
 
-u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
+static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetChannel(%i, %08x): bad atrac ID", atracID, channelAddr);
@@ -946,7 +946,7 @@ u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 	return 0;
 }
 
-u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
+static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetLoopStatus(%i, %08x, %08x): bad atrac ID", atracID, loopNumAddr, statusAddr);
@@ -969,7 +969,7 @@ u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 	return 0;
 }
 
-u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
+static u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetInternalErrorInfo(%i, %08x): bad atrac ID", atracID, errorAddr);
@@ -985,7 +985,7 @@ u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 	return 0;
 }
 
-u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
+static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetMaxSample(%i, %08x): bad atrac ID", atracID, maxSamplesAddr);
@@ -1003,7 +1003,7 @@ u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	return 0;
 }
 
-u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
+static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetNextDecodePosition(%i, %08x): bad atrac ID", atracID, outposAddr);
@@ -1025,7 +1025,7 @@ u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	return 0;
 }
 
-u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
+static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetNextSample(%i, %08x): bad atrac ID", atracID, outNAddr);
@@ -1065,7 +1065,7 @@ u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	return 0;
 }
 
-u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
+static u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetRemainFrame(%i, %08x): bad atrac ID", atracID, remainAddr);
@@ -1085,7 +1085,7 @@ u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	return 0;
 }
 
-u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr) {
+static u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetSecondBufferInfo(%i, %08x, %08x): bad atrac ID", atracID, outposAddr, outBytesAddr);
@@ -1104,7 +1104,7 @@ u32 sceAtracGetSecondBufferInfo(int atracID, u32 outposAddr, u32 outBytesAddr) {
 	return ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED;
 }
 
-u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {
+static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetSoundSample(%i, %08x, %08x, %08x): bad atrac ID", atracID, outEndSampleAddr, outLoopStartSampleAddr, outLoopEndSampleAddr);
@@ -1127,7 +1127,7 @@ u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSa
 // Games call this function to get some info for add more stream data,
 // such as where the data read from, where the data add to,
 // and how many bytes are allowed to add.
-u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr) {
+static u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr, u32 readOffsetAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetStreamDataInfo(%i, %08x, %08x, %08x): bad atrac ID", atracID, writeAddr, writableBytesAddr, readOffsetAddr);
@@ -1156,12 +1156,12 @@ u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableBytesAddr,
 	return 0;
 }
 
-u32 sceAtracReleaseAtracID(int atracID) {
+static u32 sceAtracReleaseAtracID(int atracID) {
 	INFO_LOG(ME, "sceAtracReleaseAtracID(%i)", atracID);
 	return deleteAtrac(atracID);
 }
 
-u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
+static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracResetPlayPosition(%i, %i, %i, %i): bad atrac ID", atracID, sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf);
@@ -1225,7 +1225,7 @@ static int64_t _AtracSeekbuffer(void *opaque, int64_t offset, int whence) {
 #endif // USE_FFMPEG
 
 #ifdef USE_FFMPEG
-int __AtracUpdateOutputMode(Atrac *atrac, int wanted_channels) {
+static int __AtracUpdateOutputMode(Atrac *atrac, int wanted_channels) {
 	if (atrac->pSwrCtx && atrac->atracOutputChannels == wanted_channels)
 		return 0;
 	atrac->atracOutputChannels = wanted_channels;
@@ -1320,7 +1320,7 @@ int __AtracSetContext(Atrac *atrac) {
 	return 0;
 }
 
-int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
+static int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
 	if (atrac->first.size > atrac->first.filesize)
 		atrac->first.size = atrac->first.filesize;
 	atrac->first.fileoffset = atrac->first.size;
@@ -1366,7 +1366,7 @@ int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
 	return 0;
 }
 
-int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracID = false) {
+static int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracID = false) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac)
 		return -1;
@@ -1377,7 +1377,7 @@ int _AtracSetData(int atracID, u32 buffer, u32 bufferSize, bool needReturnAtracI
 	return hleDelayResult(ret, "atrac set data", 100);
 }
 
-u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
+static u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetHalfwayBuffer(%i, %08x, %8x, %8x): bad atrac ID", atracID, halfBuffer, readSize, halfBufferSize);
@@ -1403,7 +1403,7 @@ u32 sceAtracSetHalfwayBuffer(int atracID, u32 halfBuffer, u32 readSize, u32 half
 	return ret;
 }
 
-u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
+static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetSecondBuffer(%i, %08x, %8x): bad atrac ID", atracID, secondBuffer, secondBufferSize);
@@ -1417,7 +1417,7 @@ u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize)
 	return 0;
 }
 
-u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
+static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (atrac != NULL) {
 		INFO_LOG(ME, "sceAtracSetData(%i, %08x, %08x)", atracID, buffer, bufferSize);
@@ -1440,7 +1440,7 @@ u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 	}
 }
 
-int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
+static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 	// A large value happens in Tales of VS, and isn't handled somewhere properly as a u32.
 	// It's impossible for it to be that big anyway, so cap it.
 	if (bufferSize < 0) {
@@ -1475,7 +1475,7 @@ int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 	return atracID;
 }
 
-int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
+static int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetHalfwayBufferAndGetID(%08x, %08x, %08x): incorrect read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
@@ -1508,12 +1508,12 @@ int sceAtracSetHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBuffe
 	return atracID;
 }
 
-u32 sceAtracStartEntry() {
+static u32 sceAtracStartEntry() {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceAtracStartEntry()");
 	return 0;
 }
 
-u32 sceAtracSetLoopNum(int atracID, int loopNum) {
+static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetLoopNum(%i, %i): bad atrac ID", atracID, loopNum);
@@ -1538,7 +1538,7 @@ u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 	return 0;
 }
 
-int sceAtracReinit(int at3Count, int at3plusCount) {
+static int sceAtracReinit(int at3Count, int at3plusCount) {
 	for (int i = 0; i < PSP_NUM_ATRAC_IDS; ++i) {
 		if (atracIDs[i] != NULL) {
 			ERROR_LOG_REPORT(ME, "sceAtracReinit(%d, %d): cannot reinit while IDs in use", at3Count, at3plusCount);
@@ -1585,7 +1585,7 @@ int sceAtracReinit(int at3Count, int at3plusCount) {
 	}
 }
 
-int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
+static int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracGetOutputChannel(%i, %08x): bad atrac ID", atracID, outputChanPtr);
@@ -1601,7 +1601,7 @@ int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 	return 0;
 }
 
-int sceAtracIsSecondBufferNeeded(int atracID) {
+static int sceAtracIsSecondBufferNeeded(int atracID) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracIsSecondBufferNeeded(%i): bad atrac ID", atracID);
@@ -1614,7 +1614,7 @@ int sceAtracIsSecondBufferNeeded(int atracID) {
 	return 0;
 }
 
-int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
+static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetMOutHalfwayBuffer(%i, %08x, %08x, %08x): bad atrac ID", atracID, buffer, readSize, bufferSize);
@@ -1649,7 +1649,7 @@ int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 buff
 	return ret;
 }
 
-u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
+static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracSetMOutData(%i, %08x, %08x): bad atrac ID", atracID, buffer, bufferSize);
@@ -1685,7 +1685,7 @@ u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	return ret;
 }
 
-int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
+static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 	int codecType = getCodecType(buffer);
 	if (codecType == 0) {
 		ERROR_LOG_REPORT(ME, "sceAtracSetMOutDataAndGetID(%08x, %08x): ATRAC UNKNOWN FORMAT", buffer, bufferSize);
@@ -1720,7 +1720,7 @@ int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 	return atracID;
 }
 
-int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
+static int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetMOutHalfwayBufferAndGetID(%08x, %08x, %08x): incorrect read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;
@@ -1758,7 +1758,7 @@ int sceAtracSetMOutHalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfB
 	return atracID;
 }
 
-int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr) {
+static int sceAtracSetAA3DataAndGetID(u32 buffer, int bufferSize, int fileSize, u32 metadataSizeAddr) {
 	int codecType = getCodecType(buffer);
 	if (codecType == 0) {
 		ERROR_LOG_REPORT(ME, "sceAtracSetAA3DataAndGetID(%08x, %i, %i, %08x): ATRAC UNKNOWN FORMAT", buffer, bufferSize, fileSize, metadataSizeAddr);
@@ -1829,7 +1829,7 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 	*(u32*)(buf + 0xfc) = atrac->atracID;
 }
 
-int _sceAtracGetContextAddress(int atracID) {
+static int _sceAtracGetContextAddress(int atracID) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "_sceAtracGetContextAddress(%i): bad atrac id", atracID);
@@ -1901,7 +1901,7 @@ static const u16 at3plusHeaderMap[][3] = {
 };
 static const int at3plusHeaderMapSize = sizeof(at3plusHeaderMap) / (sizeof(u16)* 3);
 
-bool initAT3Decoder(Atrac *atrac, u8 *at3Header, u32 dataSize = 0xffb4a8) {
+static bool initAT3Decoder(Atrac *atrac, u8 *at3Header, u32 dataSize = 0xffb4a8) {
 	for (int i = 0; i < at3HeaderMapSize; i ++) {
 		if (at3HeaderMap[i][0] == atrac->atracBytesPerFrame && at3HeaderMap[i][1] == atrac->atracChannels) {
 			*(u32*)(at3Header + 0x04) = dataSize + sizeof(at3HeaderTemplate) - 8;
@@ -1920,7 +1920,7 @@ bool initAT3Decoder(Atrac *atrac, u8 *at3Header, u32 dataSize = 0xffb4a8) {
 	return false;
 }
 
-bool initAT3plusDecoder(Atrac *atrac, u8 *at3plusHeader, u32 dataSize = 0xffb4a8) {
+static bool initAT3plusDecoder(Atrac *atrac, u8 *at3plusHeader, u32 dataSize = 0xffb4a8) {
 	for (int i = 0; i < at3plusHeaderMapSize; i += 2) {
 		if (at3plusHeaderMap[i][0] == atrac->atracBytesPerFrame && at3plusHeaderMap[i][1] == atrac->atracChannels) {
 			*(u32*)(at3plusHeader + 0x04) = dataSize + sizeof(at3plusHeaderTemplate) - 8;
@@ -1937,7 +1937,7 @@ bool initAT3plusDecoder(Atrac *atrac, u8 *at3plusHeader, u32 dataSize = 0xffb4a8
 	return false;
 }
 
-int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
+static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracLowLevelInitDecoder(%i, %08x): bad atrac ID", atracID, paramsAddr);
@@ -2009,7 +2009,7 @@ int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	return 0;
 }
 
-int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
+static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "sceAtracLowLevelDecode(%i, %08x, %08x, %08x, %08x): bad atrac ID", atracID, sourceAddr, sourceBytesConsumedAddr, samplesAddr, sampleBytesAddr);
@@ -2080,7 +2080,7 @@ int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedA
 	return 0;
 }
 
-int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
+static int sceAtracSetAA3HalfwayBufferAndGetID(u32 halfBuffer, u32 readSize, u32 halfBufferSize) {
 	if (readSize > halfBufferSize) {
 		ERROR_LOG(ME, "sceAtracSetAA3HalfwayBufferAndGetID(%08x, %08x, %08x): invalid read size", halfBuffer, readSize, halfBufferSize);
 		return ATRAC_ERROR_INCORRECT_READ_SIZE;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -83,7 +83,7 @@ AudioChannel chans[PSP_AUDIO_CHANNEL_MAX + 1];
 // Not sure about the range of volume, I often see 0x800 so that might be either
 // max or 50%?
 
-u32 sceAudioOutputBlocking(u32 chan, int vol, u32 samplePtr) {
+static u32 sceAudioOutputBlocking(u32 chan, int vol, u32 samplePtr) {
 	if (vol > 0xFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutputBlocking() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -104,7 +104,7 @@ u32 sceAudioOutputBlocking(u32 chan, int vol, u32 samplePtr) {
 	}
 }
 
-u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
+static u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
 	int result = 0;
 	// For some reason, this is the only one that checks for negative.
 	if (leftvol > 0xFFFF || rightvol > 0xFFFF || leftvol < 0 || rightvol < 0) {
@@ -132,7 +132,7 @@ u32 sceAudioOutputPannedBlocking(u32 chan, int leftvol, int rightvol, u32 sample
 
 }
 
-u32 sceAudioOutput(u32 chan, int vol, u32 samplePtr) {
+static u32 sceAudioOutput(u32 chan, int vol, u32 samplePtr) {
 	if (vol > 0xFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -153,7 +153,7 @@ u32 sceAudioOutput(u32 chan, int vol, u32 samplePtr) {
 	}
 }
 
-u32 sceAudioOutputPanned(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
+static u32 sceAudioOutputPanned(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
 	if (leftvol > 0xFFFF || rightvol > 0xFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutputPanned() - invalid volume");
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -176,7 +176,7 @@ u32 sceAudioOutputPanned(u32 chan, int leftvol, int rightvol, u32 samplePtr) {
 	}
 }
 
-int sceAudioGetChannelRestLen(u32 chan) {
+static int sceAudioGetChannelRestLen(u32 chan) {
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
 		ERROR_LOG(SCEAUDIO, "sceAudioGetChannelRestLen(%08x) - bad channel", chan);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
@@ -186,7 +186,7 @@ int sceAudioGetChannelRestLen(u32 chan) {
 	return remainingSamples;
 }
 
-int sceAudioGetChannelRestLength(u32 chan) {
+static int sceAudioGetChannelRestLength(u32 chan) {
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
 		ERROR_LOG(SCEAUDIO, "sceAudioGetChannelRestLength(%08x) - bad channel", chan);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
@@ -204,7 +204,7 @@ static u32 GetFreeChannel() {
 	return -1;
 }
 
-u32 sceAudioChReserve(int chan, u32 sampleCount, u32 format) {
+static u32 sceAudioChReserve(int chan, u32 sampleCount, u32 format) {
 	if (chan < 0) {
 		chan = GetFreeChannel();
 		if (chan < 0) {
@@ -238,7 +238,7 @@ u32 sceAudioChReserve(int chan, u32 sampleCount, u32 format) {
 	return chan;
 }
 
-u32 sceAudioChRelease(u32 chan) {
+static u32 sceAudioChRelease(u32 chan) {
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
 		ERROR_LOG(SCEAUDIO, "sceAudioChRelease(%i) - bad channel", chan);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
@@ -254,7 +254,7 @@ u32 sceAudioChRelease(u32 chan) {
 	return 1;
 }
 
-u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {
+static u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {
 	int result = 0;
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
 		ERROR_LOG(SCEAUDIO, "sceAudioSetChannelDataLen(%08x, %08x) - bad channel", chan, len);
@@ -272,7 +272,7 @@ u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {
 	return result;
 }
 
-u32 sceAudioChangeChannelConfig(u32 chan, u32 format) {
+static u32 sceAudioChangeChannelConfig(u32 chan, u32 format) {
 	if (chan >= PSP_AUDIO_CHANNEL_MAX) {
 		ERROR_LOG(SCEAUDIO, "sceAudioChangeChannelConfig(%08x, %08x) - invalid channel number", chan, format);
 		return SCE_ERROR_AUDIO_INVALID_CHANNEL;
@@ -286,7 +286,7 @@ u32 sceAudioChangeChannelConfig(u32 chan, u32 format) {
 	}
 }
 
-u32 sceAudioChangeChannelVolume(u32 chan, u32 leftvol, u32 rightvol) {
+static u32 sceAudioChangeChannelVolume(u32 chan, u32 leftvol, u32 rightvol) {
 	if (leftvol > 0xFFFF || rightvol > 0xFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioChangeChannelVolume(%08x, %08x, %08x) - invalid volume", chan, leftvol, rightvol);
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -304,19 +304,19 @@ u32 sceAudioChangeChannelVolume(u32 chan, u32 leftvol, u32 rightvol) {
 	}
 }
 
-u32 sceAudioInit(){
+static u32 sceAudioInit() {
 	DEBUG_LOG(SCEAUDIO, "sceAudioInit()");
 	// Don't need to do anything
 	return 0;
 }
 
-u32 sceAudioEnd(){
+static u32 sceAudioEnd() {
 	DEBUG_LOG(SCEAUDIO, "sceAudioEnd()");
 	// Don't need to do anything
 	return 0;
 }
 
-u32 sceAudioOutput2Reserve(u32 sampleCount) {
+static u32 sceAudioOutput2Reserve(u32 sampleCount) {
 	if (sampleCount < 17 || sampleCount > 4111) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput2Reserve(%08x) - invalid sample count", sampleCount);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
@@ -332,7 +332,7 @@ u32 sceAudioOutput2Reserve(u32 sampleCount) {
 	return 0;
 }
 
-u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr){
+static u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr) {
 	// Note: 0xFFFFF, not 0xFFFF!
 	if (vol > 0xFFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput2OutputBlocking(%08x, %08x) - invalid volume", vol, dataPtr);
@@ -345,7 +345,7 @@ u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr){
 	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_OUTPUT2], PSP_AUDIO_CHANNEL_OUTPUT2, true);
 }
 
-u32 sceAudioOutput2ChangeLength(u32 sampleCount){
+static u32 sceAudioOutput2ChangeLength(u32 sampleCount) {
 	if (!chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput2ChangeLength(%08x) - channel not reserved ", sampleCount);
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
@@ -355,7 +355,7 @@ u32 sceAudioOutput2ChangeLength(u32 sampleCount){
 	return 0;
 }
 
-u32 sceAudioOutput2GetRestSample(){
+static u32 sceAudioOutput2GetRestSample() {
 	if (!chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput2GetRestSample() - channel not reserved ");
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
@@ -364,14 +364,14 @@ u32 sceAudioOutput2GetRestSample(){
 	return (u32) chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleQueue.size() / 2;
 }
 
-u32 sceAudioOutput2Release(){
+static u32 sceAudioOutput2Release() {
 	DEBUG_LOG(SCEAUDIO, "sceAudioOutput2Release()");
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].reset();
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].reserved = false;
 	return 0;
 }
 
-u32 sceAudioSetFrequency(u32 freq) {
+static u32 sceAudioSetFrequency(u32 freq) {
 	if (freq == 44100 || freq == 48000) {
 		INFO_LOG(SCEAUDIO, "sceAudioSetFrequency(%08x)", freq);
 		__AudioSetOutputFrequency(freq);
@@ -382,12 +382,12 @@ u32 sceAudioSetFrequency(u32 freq) {
 	}
 }
 
-u32 sceAudioSetVolumeOffset() {
+static u32 sceAudioSetVolumeOffset() {
 	ERROR_LOG(SCEAUDIO, "UNIMPL sceAudioSetVolumeOffset()");
 	return 0;
 }
 
-u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
+static u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 	if (format == 4) {
 		ERROR_LOG(SCEAUDIO, "sceAudioSRCChReserve(%08x, %08x, %08x) - unexpected format", sampleCount, freq, format);
 		return PSP_AUDIO_ERROR_SRC_FORMAT_4;
@@ -410,7 +410,7 @@ u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 	return 0;
 }
 
-u32 sceAudioSRCChRelease() {
+static u32 sceAudioSRCChRelease() {
 	if (!chans[PSP_AUDIO_CHANNEL_SRC].reserved) {
 		ERROR_LOG(SCEAUDIO, "sceAudioSRCChRelease() - channel not reserved ");
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
@@ -421,7 +421,7 @@ u32 sceAudioSRCChRelease() {
 	return 0;
 }
 
-u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
+static u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
 	if (vol > 0xFFFFF) {
 		ERROR_LOG(SCEAUDIO, "sceAudioSRCOutputBlocking(%08x, %08x) - invalid volume", vol, buf);
 		return SCE_ERROR_AUDIO_INVALID_VOLUME;
@@ -433,26 +433,26 @@ u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
 	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_SRC], PSP_AUDIO_CHANNEL_SRC, true);
 }
 
-u32 sceAudioRoutingSetMode(u32 mode) {
+static u32 sceAudioRoutingSetMode(u32 mode) {
 	ERROR_LOG_REPORT(SCEAUDIO, "sceAudioRoutingSetMode(%08x)", mode);
 	int previousMode = defaultRoutingMode;
 	defaultRoutingMode = mode;
 	return previousMode;
 }
 
-u32 sceAudioRoutingGetMode() {
+static u32 sceAudioRoutingGetMode() {
 	ERROR_LOG_REPORT(SCEAUDIO, "sceAudioRoutingGetMode()");
 	return defaultRoutingMode;
 }
 
-u32 sceAudioRoutingSetVolumeMode(u32 mode) {
+static u32 sceAudioRoutingSetVolumeMode(u32 mode) {
 	ERROR_LOG_REPORT(SCEAUDIO, "sceAudioRoutingSetVolumeMode(%08x)", mode);
 	int previousMode = defaultRoutingVolMode;
 	defaultRoutingVolMode = mode;
 	return previousMode;
 }
 
-u32 sceAudioRoutingGetVolumeMode() {
+static u32 sceAudioRoutingGetVolumeMode() {
 	ERROR_LOG_REPORT(SCEAUDIO, "sceAudioRoutingGetVolumeMode()");
 	return defaultRoutingVolMode;
 }

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -75,7 +75,7 @@ void __AudioCodecShutdown() {
 	clearDecoders();
 }
 
-int sceAudiocodecInit(u32 ctxPtr, int codec) {
+static int sceAudiocodecInit(u32 ctxPtr, int codec) {
 	if (IsValidCodec(codec)) {
 		// Create audio decoder for given audio codec and push it into AudioList
 		if (removeDecoder(ctxPtr)) {
@@ -92,7 +92,7 @@ int sceAudiocodecInit(u32 ctxPtr, int codec) {
 	return 0;
 }
 
-int sceAudiocodecDecode(u32 ctxPtr, int codec) {
+static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 	if (!ctxPtr){
 		ERROR_LOG_REPORT(ME, "sceAudiocodecDecode(%08x, %i (%s)) got NULL pointer", ctxPtr, codec, GetCodecName(codec));
 		return -1;
@@ -124,22 +124,22 @@ int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 	return 0;
 }
 
-int sceAudiocodecGetInfo(u32 ctxPtr, int codec) {
+static int sceAudiocodecGetInfo(u32 ctxPtr, int codec) {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceAudiocodecGetInfo(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 	return 0;
 }
 
-int sceAudiocodecCheckNeedMem(u32 ctxPtr, int codec) {
+static int sceAudiocodecCheckNeedMem(u32 ctxPtr, int codec) {
 	WARN_LOG(ME, "UNIMPL sceAudiocodecCheckNeedMem(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 	return 0;
 }
 
-int sceAudiocodecGetEDRAM(u32 ctxPtr, int codec) {
+static int sceAudiocodecGetEDRAM(u32 ctxPtr, int codec) {
 	WARN_LOG(ME, "UNIMPL sceAudiocodecGetEDRAM(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 	return 0;
 }
 
-int sceAudiocodecReleaseEDRAM(u32 ctxPtr, int id) {
+static int sceAudiocodecReleaseEDRAM(u32 ctxPtr, int id) {
 	if (removeDecoder(ctxPtr)){
 		INFO_LOG(ME, "sceAudiocodecReleaseEDRAM(%08x, %i)", ctxPtr, id);
 		return 0;

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -24,6 +24,7 @@
 #include "Core/MemMap.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceCcc.h"
 #include "Core/Reporting.h"
 
 typedef PSPPointer<char> PSPCharPointer;
@@ -61,7 +62,7 @@ void __CccDoState(PointerWrap &p)
 	p.Do(jis2ucsTable);
 }
 
-u32 __CccUCStoJIS(u32 c, u32 alt)
+static u32 __CccUCStoJIS(u32 c, u32 alt)
 {
 	// JIS can only be 16-bit at most, UCS can be 32 (even if the table only supports UCS-2.)
 	alt &= 0xFFFF;
@@ -72,7 +73,7 @@ u32 __CccUCStoJIS(u32 c, u32 alt)
 	return ucs2jisTable[c];
 }
 
-u32 __CccJIStoUCS(u32 c, u32 alt)
+static u32 __CccJIStoUCS(u32 c, u32 alt)
 {
 	// JIS can only be 16-bit at most, UCS can be 32 (even if the table only supports UCS-2.)
 	c &= 0xFFFF;
@@ -81,7 +82,7 @@ u32 __CccJIStoUCS(u32 c, u32 alt)
 	return jis2ucsTable[c];
 }
 
-void sceCccSetTable(u32 jis2ucs, u32 ucs2jis)
+static void sceCccSetTable(u32 jis2ucs, u32 ucs2jis)
 {
 	// Both tables jis2ucs and ucs2jis have a size of 0x20000 bytes.
 	DEBUG_LOG(HLE, "sceCccSetTable(%08x, %08x)", jis2ucs, ucs2jis);
@@ -89,7 +90,7 @@ void sceCccSetTable(u32 jis2ucs, u32 ucs2jis)
 	jis2ucsTable = jis2ucs;
 }
 
-int sceCccUTF8toUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccUTF8toUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstCharPointer::Create(srcAddr);
 	auto dst = PSPWCharPointer::Create(dstAddr);
@@ -121,7 +122,7 @@ int sceCccUTF8toUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccUTF8toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccUTF8toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstCharPointer::Create(srcAddr);
 	auto dst = PSPCharPointer::Create(dstAddr);
@@ -157,7 +158,7 @@ int sceCccUTF8toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccUTF16toUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccUTF16toUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstWCharPointer::Create(srcAddr);
 	auto dst = PSPCharPointer::Create(dstAddr);
@@ -188,7 +189,7 @@ int sceCccUTF16toUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccUTF16toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccUTF16toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstWCharPointer::Create(srcAddr);
 	auto dst = PSPCharPointer::Create(dstAddr);
@@ -224,7 +225,7 @@ int sceCccUTF16toSJIS(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccSJIStoUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccSJIStoUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstCharPointer::Create(srcAddr);
 	auto dst = PSPCharPointer::Create(dstAddr);
@@ -260,7 +261,7 @@ int sceCccSJIStoUTF8(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccSJIStoUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
+static int sceCccSJIStoUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
 {
 	const auto src = PSPConstCharPointer::Create(srcAddr);
 	auto dst = PSPWCharPointer::Create(dstAddr);
@@ -296,7 +297,7 @@ int sceCccSJIStoUTF16(u32 dstAddr, u32 dstSize, u32 srcAddr)
 	return n;
 }
 
-int sceCccStrlenUTF8(u32 strAddr)
+static int sceCccStrlenUTF8(u32 strAddr)
 {
 	const auto str = PSPConstCharPointer::Create(strAddr);
 	if (!str.IsValid())
@@ -308,7 +309,7 @@ int sceCccStrlenUTF8(u32 strAddr)
 	return UTF8(str).length();
 }
 
-int sceCccStrlenUTF16(u32 strAddr)
+static int sceCccStrlenUTF16(u32 strAddr)
 {
 	const auto str = PSPConstWCharPointer::Create(strAddr);
 	if (!str.IsValid())
@@ -320,7 +321,7 @@ int sceCccStrlenUTF16(u32 strAddr)
 	return UTF16LE(str).length();
 }
 
-int sceCccStrlenSJIS(u32 strAddr)
+static int sceCccStrlenSJIS(u32 strAddr)
 {
 	const auto str = PSPCharPointer::Create(strAddr);
 	if (!str.IsValid())
@@ -332,7 +333,7 @@ int sceCccStrlenSJIS(u32 strAddr)
 	return ShiftJIS(str).length();
 }
 
-u32 sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
+static u32 sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
 {
 	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
@@ -346,7 +347,7 @@ u32 sceCccEncodeUTF8(u32 dstAddrAddr, u32 ucs)
 	return dstp->ptr;
 }
 
-void sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
+static void sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
 {
 	auto dstp = PSPPointer<PSPWCharPointer>::Create(dstAddrAddr);
 
@@ -362,7 +363,7 @@ void sceCccEncodeUTF16(u32 dstAddrAddr, u32 ucs)
 	*dstp += UTF16LE::encode(*dstp, ucs);
 }
 
-u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
+static u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 {
 	auto dstp = PSPPointer<PSPCharPointer>::Create(dstAddrAddr);
 
@@ -376,7 +377,7 @@ u32 sceCccEncodeSJIS(u32 dstAddrAddr, u32 jis)
 	return dstp->ptr;
 }
 
-u32 sceCccDecodeUTF8(u32 dstAddrAddr)
+static u32 sceCccDecodeUTF8(u32 dstAddrAddr)
 {
 	auto dstp = PSPPointer<PSPConstCharPointer>::Create(dstAddrAddr);
 
@@ -396,7 +397,7 @@ u32 sceCccDecodeUTF8(u32 dstAddrAddr)
 	return result;
 }
 
-u32 sceCccDecodeUTF16(u32 dstAddrAddr)
+static u32 sceCccDecodeUTF16(u32 dstAddrAddr)
 {
 	auto dstp = PSPPointer<PSPConstWCharPointer>::Create(dstAddrAddr);
 
@@ -417,7 +418,7 @@ u32 sceCccDecodeUTF16(u32 dstAddrAddr)
 	return result;
 }
 
-u32 sceCccDecodeSJIS(u32 dstAddrAddr)
+static u32 sceCccDecodeSJIS(u32 dstAddrAddr)
 {
 	auto dstp = PSPPointer<PSPConstCharPointer>::Create(dstAddrAddr);
 
@@ -437,49 +438,49 @@ u32 sceCccDecodeSJIS(u32 dstAddrAddr)
 	return result;
 }
 
-int sceCccIsValidUTF8(u32 c)
+static int sceCccIsValidUTF8(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidUTF8(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidUTF16(u32 c)
+static int sceCccIsValidUTF16(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidUTF16(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidSJIS(u32 c)
+static int sceCccIsValidSJIS(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidSJIS(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidUCS2(u32 c)
+static int sceCccIsValidUCS2(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidUCS2(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidUCS4(u32 c)
+static int sceCccIsValidUCS4(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidUCS4(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidJIS(u32 c)
+static int sceCccIsValidJIS(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidJIS(%08x)", c);
 	return c != 0;
 }
 
-int sceCccIsValidUnicode(u32 c)
+static int sceCccIsValidUnicode(u32 c)
 {
 	WARN_LOG(HLE, "UNIMPL sceCccIsValidUnicode(%08x)", c);
 	return c != 0;
 }
 
-u32 sceCccSetErrorCharUTF8(u32 c)
+static u32 sceCccSetErrorCharUTF8(u32 c)
 {
 	DEBUG_LOG(HLE, "sceCccSetErrorCharUTF8(%08x)", c);
 	int result = errorUTF8;
@@ -487,7 +488,7 @@ u32 sceCccSetErrorCharUTF8(u32 c)
 	return result;
 }
 
-u32 sceCccSetErrorCharUTF16(u32 c)
+static u32 sceCccSetErrorCharUTF16(u32 c)
 {
 	DEBUG_LOG(HLE, "sceCccSetErrorCharUTF16(%08x)", c);
 	int result = errorUTF16;
@@ -495,7 +496,7 @@ u32 sceCccSetErrorCharUTF16(u32 c)
 	return result;
 }
 
-u32 sceCccSetErrorCharSJIS(u32 c)
+static u32 sceCccSetErrorCharSJIS(u32 c)
 {
 	DEBUG_LOG(HLE, "sceCccSetErrorCharSJIS(%04x)", c);
 	int result = errorSJIS;
@@ -503,7 +504,7 @@ u32 sceCccSetErrorCharSJIS(u32 c)
 	return result;
 }
 
-u32 sceCccUCStoJIS(u32 c, u32 alt)
+static u32 sceCccUCStoJIS(u32 c, u32 alt)
 {
 	if (ucs2jisTable.IsValid())
 	{
@@ -517,7 +518,7 @@ u32 sceCccUCStoJIS(u32 c, u32 alt)
 	}
 }
 
-u32 sceCccJIStoUCS(u32 c, u32 alt)
+static u32 sceCccJIStoUCS(u32 c, u32 alt)
 {
 	if (jis2ucsTable.IsValid())
 	{

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -37,19 +37,19 @@ static const u8 key19DC[16]  = {0xEC, 0x6D, 0x29, 0x59, 0x26, 0x35, 0xA5, 0x7F, 
 static const u8 key199C[16]  = {0x36, 0xA5, 0x3E, 0xAC, 0xC5, 0x26, 0x9E, 0xA3, 0x83, 0xD9, 0xEC, 0x25, 0x6C, 0x48, 0x48, 0x72};
 static const u8 key19AC[16]  = {0xD8, 0xC0, 0xB0, 0xF3, 0x3E, 0x6B, 0x76, 0x85, 0xFD, 0xFB, 0x4D, 0x7D, 0x45, 0x1E, 0x92, 0x03};
 
-void *memxor(void * dest, const void * src, size_t n)
+static void *memxor(void * dest, const void * src, size_t n)
 {
-  char const *s = (char const*)src;
-  char *d = (char*)dest;
+	char const *s = (char const*)src;
+	char *d = (char*)dest;
 
-  for (; n > 0; n--)
-    *d++ ^= *s++;
+	for (; n > 0; n--)
+		*d++ ^= *s++;
 
-  return dest;
+	return dest;
 }
 
 // The reason for the values from *FromMode calculations are not known.
-int numFromMode(int mode)
+static int numFromMode(int mode)
 {
 	int num = 0;
 	switch(mode)
@@ -75,7 +75,7 @@ int numFromMode(int mode)
 	}
 	return num;
 }
-int numFromMode2(int mode)
+static int numFromMode2(int mode)
 {
 	int num = 18;
 	if (mode == 1)
@@ -85,13 +85,13 @@ int numFromMode2(int mode)
 	return num;
 }
 
-int typeFromMode(int mode)
+static int typeFromMode(int mode)
 {
 	return (mode == 1 || mode == 2) ? 83 :
 	      ((mode == 3 || mode == 4) ? 87 : 100);	
 }
 
-int kirkSendCmd(u8* data, int length, int num, bool encrypt)
+static int kirkSendCmd(u8* data, int length, int num, bool encrypt)
 {
 	*(int*)(data+0) = encrypt ? KIRK_MODE_ENCRYPT_CBC : KIRK_MODE_DECRYPT_CBC;
 	*(int*)(data+4) = 0;
@@ -105,7 +105,7 @@ int kirkSendCmd(u8* data, int length, int num, bool encrypt)
 	return 0;
 }
 
-int kirkSendFuseCmd(u8* data, int length, bool encrypt)
+static int kirkSendFuseCmd(u8* data, int length, bool encrypt)
 {
 	*(int*)(data+0) = encrypt ? KIRK_MODE_ENCRYPT_CBC : KIRK_MODE_DECRYPT_CBC;
 	*(int*)(data+4) = 0;
@@ -120,7 +120,7 @@ int kirkSendFuseCmd(u8* data, int length, bool encrypt)
 	return 0;
 }
 
-int sub_15B0(u8* data, int alignedLen, u8* buf, int val)
+static int sub_15B0(u8* data, int alignedLen, u8* buf, int val)
 {
 	u8 sp0[16];
 	memcpy(sp0, data+alignedLen+4, 16);
@@ -134,7 +134,7 @@ int sub_15B0(u8* data, int alignedLen, u8* buf, int val)
 	return 0;
 }
 
-int sub_0000(u8* data_out, u8* data, int alignedLen, u8* data2, int& data3, int mode)
+static int sub_0000(u8* data_out, u8* data, int alignedLen, u8* data2, int& data3, int mode)
 {
 	memcpy(data_out+20, data2, 16);
 	// Mode 1:2 is 83, 3:4 is 87, 5:6 is 100
@@ -195,7 +195,7 @@ int sub_0000(u8* data_out, u8* data, int alignedLen, u8* data2, int& data3, int 
 	return 0;
 }
 
-int sub_1510(u8* data, int size, u8* result , int num)
+static int sub_1510(u8* data, int size, u8* result , int num)
 {
 	memxor(data+20, result, 16);
 
@@ -207,14 +207,14 @@ int sub_1510(u8* data, int size, u8* result , int num)
 	return 0;
 }
 
-int sub_17A8(u8* data)
+static int sub_17A8(u8* data)
 {
 	if (sceUtilsBufferCopyWithRange(data, 20, 0, 0, 14) == 0)
 		return 0;
 	return -261;
 }
 
-int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey)
+static int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey)
 {
 	pspChnnlsvContext1 ctx;
 	Memory::ReadStruct(addressCtx, &ctx);
@@ -325,7 +325,7 @@ int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
 	return 0;
 }
 
-int sceSdSetIndex(u32 addressCtx, int value)
+static int sceSdSetIndex(u32 addressCtx, int value)
 {
 	pspChnnlsvContext1 ctx;
 	Memory::ReadStruct(addressCtx,&ctx);
@@ -344,7 +344,7 @@ int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
 }
 
 
-int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length)
+static int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length)
 {
 	pspChnnlsvContext1 ctx;
 	Memory::ReadStruct(addressCtx, &ctx);
@@ -396,7 +396,7 @@ int sceSdRemoveValue_(pspChnnlsvContext1& ctx, u8* data, int length)
 	return 0;
 }
 
-int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 cryptkeyAddr)
+static int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 cryptkeyAddr)
 {
 	pspChnnlsvContext2 ctx2;
 	Memory::ReadStruct(ctx2Addr, &ctx2);
@@ -464,7 +464,7 @@ int sceSdCreateList_(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, u8*
 	return 0;
 }
 
-int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen)
+static int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen)
 {
 	pspChnnlsvContext2 ctx;
 	Memory::ReadStruct(ctxAddr, &ctx);
@@ -511,7 +511,7 @@ int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
 	return res;
 }
 
-int sceChnnlsv_21BE78B4(u32 ctxAddr)
+static int sceChnnlsv_21BE78B4(u32 ctxAddr)
 {
 	pspChnnlsvContext2 ctx;
 	Memory::ReadStruct(ctxAddr, &ctx);

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -20,11 +20,12 @@
 #include "Common/CommonTypes.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceDeflt.h"
 #include "Core/MemMap.h"
 
 // All the decompress functions are identical with only differing window bits. Possibly should be one function
 
-int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
+static int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
 	DEBUG_LOG(HLE, "sceGzipDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
 	int err;
 	uLong crc;
@@ -70,7 +71,7 @@ int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 C
 }
 
 
-int sceGzipDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
+static int sceGzipDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
 	DEBUG_LOG(HLE, "sceGzipDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
 	int err;
 	uLong crc;
@@ -115,7 +116,7 @@ int sceGzipDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc3
 	return stream.total_out;
 }
 
-int sceZlibDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
+static int sceZlibDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
 	DEBUG_LOG(HLE, "sceZlibDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
 	int err;
 	uLong crc;

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -20,6 +20,7 @@
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Core/HLE/HLE.h"
+#include "Core/HLE/sceDmac.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/Debugger/Breakpoints.h"
@@ -42,7 +43,7 @@ void __DmacDoState(PointerWrap &p) {
 	p.Do(dmacMemcpyDeadline);
 }
 
-int __DmacMemcpy(u32 dst, u32 src, u32 size) {
+static int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 #ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(src, false, size, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dst, true, size, currentMIPS->pc);
@@ -66,7 +67,7 @@ int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 	return 0;
 }
 
-u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
+static u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
 	if (size == 0) {
 		// Some games seem to do this frequently.
 		DEBUG_LOG(HLE, "sceDmacMemcpy(dest=%08x, src=%08x, size=%i): invalid size", dst, src, size);
@@ -92,7 +93,7 @@ u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
 	return __DmacMemcpy(dst, src, size);
 }
 
-u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
+static u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
 	if (size == 0) {
 		ERROR_LOG(HLE, "sceDmacTryMemcpy(dest=%08x, src=%08x, size=%i): invalid size", dst, src, size);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;

--- a/Core/HLE/sceGameUpdate.cpp
+++ b/Core/HLE/sceGameUpdate.cpp
@@ -17,26 +17,27 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceGameUpdate.h"
 
-u32 sceGameUpdateInit()
+static u32 sceGameUpdateInit()
 {
 	ERROR_LOG(SCEUTILITY, "UNIMPL sceGameUpdateInit()");
 	return 0;
 }
 
-u32 sceGameUpdateTerm()
+static u32 sceGameUpdateTerm()
 {
 	ERROR_LOG(SCEUTILITY, "UNIMPL sceGameUpdateTerm()");
 	return 0;
 }
 
-u32 sceGameUpdateRun()
+static u32 sceGameUpdateRun()
 {
 	ERROR_LOG(SCEUTILITY, "UNIMPL sceGameUpdateRun()");
 	return 0;
 }
 
-u32 sceGameUpdateAbort()
+static u32 sceGameUpdateAbort()
 {
 	ERROR_LOG(SCEUTILITY, "UNIMPL sceGameUpdateAbort()");
 	return 0;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -248,7 +248,7 @@ public:
 	}
 };
 
-void __GeExecuteSync(u64 userdata, int cyclesLate)
+static void __GeExecuteSync(u64 userdata, int cyclesLate)
 {
 	int listid = userdata >> 32;
 	GPUSyncType type = (GPUSyncType) (userdata & 0xFFFFFFFF);
@@ -256,12 +256,12 @@ void __GeExecuteSync(u64 userdata, int cyclesLate)
 	gpu->SyncEnd(type, listid, wokeThreads);
 }
 
-void __GeExecuteInterrupt(u64 userdata, int cyclesLate)
+static void __GeExecuteInterrupt(u64 userdata, int cyclesLate)
 {
 	__TriggerInterrupt(PSP_INTR_IMMEDIATE, PSP_GE_INTR, PSP_INTR_SUB_NONE);
 }
 
-void __GeCheckCycles(u64 userdata, int cyclesLate)
+static void __GeCheckCycles(u64 userdata, int cyclesLate)
 {
 	u64 geTicks = gpu->GetTickEstimate();
 	if (geTicks != 0)
@@ -389,7 +389,7 @@ void __GeWaitCurrentThread(GPUSyncType type, SceUID waitId, const char *reason)
 	__KernelWaitCurThread(waitType, waitId, 0, 0, false, reason);
 }
 
-bool __GeTriggerWait(WaitType waitType, SceUID waitId, WaitingThreadList &waitingThreads)
+static bool __GeTriggerWait(WaitType waitType, SceUID waitId, WaitingThreadList &waitingThreads)
 {
 	// TODO: Do they ever get a result other than 0?
 	bool wokeThreads = false;
@@ -411,7 +411,7 @@ bool __GeTriggerWait(GPUSyncType type, SceUID waitId)
 	return false;
 }
 
-u32 sceGeEdramGetAddr()
+static u32 sceGeEdramGetAddr()
 {
 	u32 retVal = 0x04000000;
 	DEBUG_LOG(SCEGE, "%08x = sceGeEdramGetAddr", retVal);
@@ -419,14 +419,14 @@ u32 sceGeEdramGetAddr()
 	return retVal;
 }
 
-u32 sceGeEdramGetSize()
+static u32 sceGeEdramGetSize()
 {
 	u32 retVal = 0x00200000;
 	DEBUG_LOG(SCEGE, "%08x = sceGeEdramGetSize()", retVal);
 	return retVal;
 }
 
-int __GeSubIntrBase(int callbackId)
+static int __GeSubIntrBase(int callbackId)
 {
 	return callbackId * 2;
 }
@@ -467,7 +467,7 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId,
 	return listID;
 }
 
-int sceGeListDeQueue(u32 listID)
+static int sceGeListDeQueue(u32 listID)
 {
 	WARN_LOG(SCEGE, "sceGeListDeQueue(%08x)", listID);
 	int result = gpu->DequeueList(0x35000000 ^ listID);
@@ -475,7 +475,7 @@ int sceGeListDeQueue(u32 listID)
 	return result;
 }
 
-int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
+static int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress)
 {
 	// Advance() might cause an interrupt, so defer the Advance but do it ASAP.
 	// Final Fantasy Type-0 has a graphical artifact without this (timing issue.)
@@ -492,7 +492,7 @@ int sceGeListSync(u32 displayListID, u32 mode) //0 : wait for completion		1:chec
 	return gpu->ListSync(0x35000000 ^ displayListID, mode);
 }
 
-u32 sceGeDrawSync(u32 mode)
+static u32 sceGeDrawSync(u32 mode)
 {
 	//wait/check entire drawing state
 	DEBUG_LOG(SCEGE, "sceGeDrawSync(mode=%d)  (0=wait for completion, 1=peek)", mode);
@@ -508,7 +508,7 @@ int sceGeContinue()
 	return ret;
 }
 
-int sceGeBreak(u32 mode, u32 unknownPtr)
+static int sceGeBreak(u32 mode, u32 unknownPtr)
 {
 	if (mode > 1)
 	{
@@ -532,7 +532,7 @@ int sceGeBreak(u32 mode, u32 unknownPtr)
 	return result;
 }
 
-u32 sceGeSetCallback(u32 structAddr)
+static u32 sceGeSetCallback(u32 structAddr)
 {
 	DEBUG_LOG(SCEGE, "sceGeSetCallback(struct=%08x)", structAddr);
 
@@ -571,7 +571,7 @@ u32 sceGeSetCallback(u32 structAddr)
 	return cbID;
 }
 
-int sceGeUnsetCallback(u32 cbID)
+static int sceGeUnsetCallback(u32 cbID)
 {
 	DEBUG_LOG(SCEGE, "sceGeUnsetCallback(cbid=%08x)", cbID);
 
@@ -641,13 +641,13 @@ u32 sceGeRestoreContext(u32 ctxAddr)
 	return 0;
 }
 
-void __GeCopyMatrix(u32 matrixPtr, float *mtx, u32 size) {
+static void __GeCopyMatrix(u32 matrixPtr, float *mtx, u32 size) {
 	for (u32 i = 0; i < size / sizeof(float); ++i) {
 		Memory::Write_U32(toFloat24(mtx[i]), matrixPtr + i * sizeof(float));
 	}
 }
 
-int sceGeGetMtx(int type, u32 matrixPtr) {
+static int sceGeGetMtx(int type, u32 matrixPtr) {
 	if (!Memory::IsValidAddress(matrixPtr)) {
 		ERROR_LOG(SCEGE, "sceGeGetMtx(%d, %08x) - bad matrix ptr", type, matrixPtr);
 		return -1;
@@ -686,7 +686,7 @@ int sceGeGetMtx(int type, u32 matrixPtr) {
 	return 0;
 }
 
-u32 sceGeGetCmd(int cmd) {
+static u32 sceGeGetCmd(int cmd) {
 	INFO_LOG(SCEGE, "sceGeGetCmd(%i)", cmd);
 	if (cmd >= 0 && cmd < (int)ARRAY_SIZE(gstate.cmdmem)) {
 		return gstate.cmdmem[cmd];  // Does not mask away the high bits.
@@ -695,12 +695,12 @@ u32 sceGeGetCmd(int cmd) {
 	}
 }
 
-int sceGeGetStack(int index, u32 stackPtr) {
+static int sceGeGetStack(int index, u32 stackPtr) {
 	WARN_LOG_REPORT(SCEGE, "sceGeGetStack(%i, %08x)", index, stackPtr);
 	return gpu->GetStack(index, stackPtr);
 }
 
-u32 sceGeEdramSetAddrTranslation(int new_size) {
+static u32 sceGeEdramSetAddrTranslation(int new_size) {
 	bool outsideRange = new_size != 0 && (new_size < 0x200 || new_size > 0x1000);
 	bool notPowerOfTwo = (new_size & (new_size - 1)) != 0;
 	if (outsideRange || notPowerOfTwo) {

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -70,17 +70,17 @@ void __HeapInit() {
 	heapList.clear();
 }
 
-int sceHeapReallocHeapMemory(u32 heapAddr, u32 memPtr, int memSize) {
+static int sceHeapReallocHeapMemory(u32 heapAddr, u32 memPtr, int memSize) {
 	ERROR_LOG_REPORT(HLE,"UNIMPL sceHeapReallocHeapMemory(%08x, %08x, %08x)", heapAddr, memPtr, memSize);
 	return 0;
 }
 
-int sceHeapReallocHeapMemoryWithOption(u32 heapPtr, u32 memPtr, int memSize, u32 paramsPtr) {
+static int sceHeapReallocHeapMemoryWithOption(u32 heapPtr, u32 memPtr, int memSize, u32 paramsPtr) {
 	ERROR_LOG_REPORT(HLE,"UNIMPL sceHeapReallocHeapMemoryWithOption(%08x, %08x, %08x, %08x)", heapPtr, memPtr, memSize, paramsPtr);
 	return 0;
 }
 
-int sceHeapFreeHeapMemory(u32 heapAddr, u32 memAddr) {
+static int sceHeapFreeHeapMemory(u32 heapAddr, u32 memAddr) {
 	Heap *heap = getHeap(heapAddr);
 	if (!heap) {
 		ERROR_LOG(HLE, "sceHeapFreeHeapMemory(%08x, %08x): invalid heap", heapAddr, memAddr);
@@ -99,12 +99,12 @@ int sceHeapFreeHeapMemory(u32 heapAddr, u32 memAddr) {
 	return 0;
 }
 
-int sceHeapGetMallinfo(u32 heapAddr, u32 infoPtr) {
+static int sceHeapGetMallinfo(u32 heapAddr, u32 infoPtr) {
 	ERROR_LOG_REPORT(HLE,"UNIMPL sceHeapGetMallinfo(%08x, %08x)", heapAddr, infoPtr);
 	return 0;
 }
 
-u32 sceHeapAllocHeapMemoryWithOption(u32 heapAddr, u32 memSize, u32 paramsPtr) {
+static u32 sceHeapAllocHeapMemoryWithOption(u32 heapAddr, u32 memSize, u32 paramsPtr) {
 	Heap *heap = getHeap(heapAddr);
 	u32 grain = 4;
 	if (!heap) {
@@ -132,7 +132,7 @@ u32 sceHeapAllocHeapMemoryWithOption(u32 heapAddr, u32 memSize, u32 paramsPtr) {
 	return addr;
 }
 
-int sceHeapGetTotalFreeSize(u32 heapAddr) {
+static int sceHeapGetTotalFreeSize(u32 heapAddr) {
 	Heap *heap = getHeap(heapAddr);
 	if (!heap) {
 		ERROR_LOG(HLE, "sceHeapGetTotalFreeSize(%08x): invalid heap", heapAddr);
@@ -148,7 +148,7 @@ int sceHeapGetTotalFreeSize(u32 heapAddr) {
 	return free;
 }
 
-int sceHeapIsAllocatedHeapMemory(u32 heapPtr, u32 memPtr) {
+static int sceHeapIsAllocatedHeapMemory(u32 heapPtr, u32 memPtr) {
 	if (!Memory::IsValidAddress(memPtr)) {
 		ERROR_LOG(HLE, "sceHeapIsAllocatedHeapMemory(%08x, %08x): invalid address", heapPtr, memPtr);
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
@@ -164,7 +164,7 @@ int sceHeapIsAllocatedHeapMemory(u32 heapPtr, u32 memPtr) {
 	return 0;
 }
 
-int sceHeapDeleteHeap(u32 heapAddr) {
+static int sceHeapDeleteHeap(u32 heapAddr) {
 	Heap *heap = getHeap(heapAddr);
 	if (!heap) {
 		ERROR_LOG(HLE, "sceHeapDeleteHeap(%08x): invalid heap", heapAddr);
@@ -177,7 +177,7 @@ int sceHeapDeleteHeap(u32 heapAddr) {
 	return 0;
 }
 
-int sceHeapCreateHeap(const char* name, u32 heapSize, int attr, u32 paramsPtr) {
+static int sceHeapCreateHeap(const char* name, u32 heapSize, int attr, u32 paramsPtr) {
 	if (paramsPtr != 0) {
 		u32 size = Memory::Read_U32(paramsPtr);
 		WARN_LOG_REPORT(HLE, "sceHeapCreateHeap(): unsupported options parameter, size = %d", size);
@@ -206,7 +206,7 @@ int sceHeapCreateHeap(const char* name, u32 heapSize, int attr, u32 paramsPtr) {
 	return heap->address;
 }
 
-u32 sceHeapAllocHeapMemory(u32 heapAddr, u32 memSize) {
+static u32 sceHeapAllocHeapMemory(u32 heapAddr, u32 memSize) {
 	Heap *heap = getHeap(heapAddr);
 	if (!heap) {
 		ERROR_LOG(HLE, "sceHeapAllocHeapMemory(%08x, %08x): invalid heap", heapAddr, memSize);

--- a/Core/HLE/sceHprm.cpp
+++ b/Core/HLE/sceHprm.cpp
@@ -21,7 +21,7 @@
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
 
-u32 sceHprmPeekCurrentKey(u32 keyAddress) {
+static u32 sceHprmPeekCurrentKey(u32 keyAddress) {
 	DEBUG_LOG(HLE,"0=sceHprmPeekCurrentKey(ptr)");
 	Memory::Write_U32(0, keyAddress);
 	return 0;
@@ -29,27 +29,27 @@ u32 sceHprmPeekCurrentKey(u32 keyAddress) {
 
 // TODO: Might make sense to reflect the headphone status of the host here,
 // if the games adjust their sound.
-u32 sceHprmIsHeadphoneExist() {
+static u32 sceHprmIsHeadphoneExist() {
 	DEBUG_LOG(HLE, "sceHprmIsHeadphoneExist()");
 	return 0;
 }
 
-u32 sceHprmIsMicrophoneExist() {
+static u32 sceHprmIsMicrophoneExist() {
 	DEBUG_LOG(HLE, "sceHprmIsMicrophoneExist()");
 	return 0;
 }
 
-u32 sceHprmIsRemoteExist() {
+static u32 sceHprmIsRemoteExist() {
 	DEBUG_LOG(HLE, "sceHprmIsRemoteExist()");
 	return 0;
 }
 
-u32 sceHprmPeekLatch(u32 latchAddr) {
+static u32 sceHprmPeekLatch(u32 latchAddr) {
 	DEBUG_LOG(HLE,"sceHprmPeekLatch latchAddr %08x",latchAddr);
 	return 0;
 }
 
-u32 sceHprmReadLatch(u32 latchAddr) {
+static u32 sceHprmReadLatch(u32 latchAddr) {
 	DEBUG_LOG(HLE,"sceHprmReadLatch latchAddr %08x",latchAddr);
 	return 0;
 }

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -50,224 +50,224 @@ int sceHttpSetResolveRetry(int connectionID, int retryCount) {
 	return 0;
 }
 
-int sceHttpInit(int unknown) {
+static int sceHttpInit(int unknown) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpInit(%i)", unknown);
 	return 0;
 }
 
-int sceHttpEnd() {
+static int sceHttpEnd() {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnd()");
 	return 0;
 }
 
-int sceHttpInitCache(int size) {
+static int sceHttpInitCache(int size) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpInitCache(%d)", size);
 	return 0;
 }
 
-int sceHttpEndCache() {
+static int sceHttpEndCache() {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEndCache()");
 	return 0;
 }
 
-int sceHttpEnableCache(int id) {
+static int sceHttpEnableCache(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnableCache(%d)", id);
 	return 0;
 }
 
-int sceHttpDisableCache(int id) {
+static int sceHttpDisableCache(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableCache(%d)", id);
 	return 0;
 }
 
-u32 sceHttpGetProxy(u32 id, u32 activateFlagPtr, u32 modePtr, u32 proxyHostPtr, u32 len, u32 proxyPort) {
+static u32 sceHttpGetProxy(u32 id, u32 activateFlagPtr, u32 modePtr, u32 proxyHostPtr, u32 len, u32 proxyPort) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpGetProxy(%d, %x, %x, %x, %d, %x)", id, activateFlagPtr, modePtr, proxyHostPtr, len, proxyPort);
 	return 0;
 }
 
-int sceHttpGetStatusCode(int requestID, u32 statusCodePtr) {
+static int sceHttpGetStatusCode(int requestID, u32 statusCodePtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpGetStatusCode(%d, %x)", requestID, statusCodePtr);
 	return 0;
 }
 
-int sceHttpReadData(int requestID, u32 dataPtr, u32 dataSize) {
+static int sceHttpReadData(int requestID, u32 dataPtr, u32 dataSize) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpReadData(%d, %x, %x)", requestID, dataPtr, dataSize);
 	return 0;
 }
 
-int sceHttpSendRequest(int requestID, u32 dataPtr, u32 dataSize) {
+static int sceHttpSendRequest(int requestID, u32 dataPtr, u32 dataSize) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSendRequest(%d, %x, %x)", requestID, dataPtr, dataSize);
 	return 0;
 }
 
-int sceHttpDeleteRequest(int requestID) {
+static int sceHttpDeleteRequest(int requestID) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDeleteRequest(%d)", requestID);
 	return 0;
 }
 
-int sceHttpDeleteHeader(int id, const char *name) {
+static int sceHttpDeleteHeader(int id, const char *name) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDeleteHeader(%d, %s)", id, name);
 	return 0;
 }
 
-int sceHttpDeleteConnection(int connectionID) {
+static int sceHttpDeleteConnection(int connectionID) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableCache(%d)", connectionID);
 	return 0;
 }
 
-int sceHttpSetConnectTimeOut(int id, u32 timeout) {
+static int sceHttpSetConnectTimeOut(int id, u32 timeout) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetConnectTimeout(%d, %d)", id, timeout);
 	return 0;
 }
 
-int sceHttpSetSendTimeOut(int id, u32 timeout) {
+static int sceHttpSetSendTimeOut(int id, u32 timeout) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetSendTimeout(%d, %d)", id, timeout);
 	return 0;
 }
 
-u32 sceHttpSetProxy(u32 id, u32 activateFlagPtr, u32 mode, u32 newProxyHostPtr, u32 newProxyPort) {
+static u32 sceHttpSetProxy(u32 id, u32 activateFlagPtr, u32 mode, u32 newProxyHostPtr, u32 newProxyPort) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetProxy(%d, %x, %x, %x, %d)", id, activateFlagPtr, mode, newProxyHostPtr, newProxyPort);
 	return 0;
 }
 
-int sceHttpEnableCookie(int id) {
+static int sceHttpEnableCookie(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnableCookie(%d)", id);
 	return 0;
 }
 
-int sceHttpEnableKeepAlive(int id) {
+static int sceHttpEnableKeepAlive(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnableKeepAlive(%d)", id);
 	return 0;
 }
 
-int sceHttpDisableCookie(int id) {
+static int sceHttpDisableCookie(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableCookie(%d)", id);
 	return 0;
 }
 
-int sceHttpDisableKeepAlive(int id) {
+static int sceHttpDisableKeepAlive(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableKeepAlive(%d)", id);
 	return 0;
 }
 
-int sceHttpsInit(int unknown1, int unknown2, int unknown3, int unknown4) {
+static int sceHttpsInit(int unknown1, int unknown2, int unknown3, int unknown4) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpsInit(%d, %d, %d, %d)", unknown1, unknown2, unknown3, unknown4);
 	return 0;
 }
 
-int sceHttpsEnd() {
+static int sceHttpsEnd() {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpsEnd()");
 	return 0;
 }
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
-int sceHttpCreateRequest(int connectionID, int method, const char *path, u64 contentLength) {
+static int sceHttpCreateRequest(int connectionID, int method, const char *path, u64 contentLength) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpCreateRequest(%d, %d, %s, %llx)", connectionID, method, path, contentLength);
 	return 0;
 }
 
-int sceHttpCreateConnection(int templateID, const char *hostString, const char *unknown1, u32 port, int unknown2) {
+static int sceHttpCreateConnection(int templateID, const char *hostString, const char *unknown1, u32 port, int unknown2) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpCreateConnection(%d, %s, %s, %d, %d)", templateID, hostString, unknown1, port, unknown2);
 	return 0;
 }
 
-int sceHttpGetNetworkErrno(int request, u32 errNumPtr) {
+static int sceHttpGetNetworkErrno(int request, u32 errNumPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpGetNetworkErrno(%d, %x)", request, errNumPtr);
 	return 0;
 }
 
-int sceHttpAddExtraHeader(int id, const char *name, const char *value, int unknown) {
+static int sceHttpAddExtraHeader(int id, const char *name, const char *value, int unknown) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpAddExtraHeader(%d, %s, %s, %d)", id, name, value, unknown);
 	return 0;
 }
 
-int sceHttpAbortRequest(int requestID) {
+static int sceHttpAbortRequest(int requestID) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpAbortRequest(%d)", requestID);
 	return 0;
 }
 
-int sceHttpDeleteTemplate(int templateID) {
+static int sceHttpDeleteTemplate(int templateID) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDeleteTemplate(%d)", templateID);
 	return 0;
 }
 
-int sceHttpSetMallocFunction(u32 mallocFuncPtr, u32 freeFuncPtr, u32 reallocFuncPtr) {
+static int sceHttpSetMallocFunction(u32 mallocFuncPtr, u32 freeFuncPtr, u32 reallocFuncPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetMallocFunction(%x, %x, %x)", mallocFuncPtr, freeFuncPtr, reallocFuncPtr);
 	return 0;
 }
 
-int sceHttpSetResolveTimeOut(int id, u32 timeout) {
+static int sceHttpSetResolveTimeOut(int id, u32 timeout) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetResolveTimeOut(%d, %d)", id, timeout);
 	return 0;
 }
 
-int sceHttpSetAuthInfoCB(int id, u32 callbackFuncPtr) {
+static int sceHttpSetAuthInfoCB(int id, u32 callbackFuncPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetAuthInfoCB(%d, %x)", id, callbackFuncPtr);
 	return 0;
 }
 
-int sceHttpEnableRedirect(int id) {
+static int sceHttpEnableRedirect(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnableRedirect(%d)", id);
 	return 0;
 }
 
-int sceHttpEnableAuth(int id) {
+static int sceHttpEnableAuth(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpEnableAuth(%d)", id);
 	return 0;
 }
 
-int sceHttpDisableRedirect(int id) {
+static int sceHttpDisableRedirect(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableRedirect(%d)", id);
 	return 0;
 }
 
-int sceHttpDisableAuth(int id) {
+static int sceHttpDisableAuth(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpDisableAuth(%d)", id);
 	return 0;
 }
 
-int sceHttpSaveSystemCookie() {
+static int sceHttpSaveSystemCookie() {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSaveSystemCookie()");
 	return 0;
 }
 
-int sceHttpsLoadDefaultCert(int unknown1, int unknown2) {
+static int sceHttpsLoadDefaultCert(int unknown1, int unknown2) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpLoadDefaultCert(%d, %d)", unknown1, unknown2);
 	return 0;
 }
 
-int sceHttpLoadSystemCookie() {
+static int sceHttpLoadSystemCookie() {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpLoadSystemCookie()");
 	return 0;
 }
 
-int sceHttpCreateTemplate(const char *agent, int unknown1, int unknown2) {
+static int sceHttpCreateTemplate(const char *agent, int unknown1, int unknown2) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpCreateTemplate(%s, %d, %d)", agent, unknown1, unknown2);
 	return 0;
 }
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
-int sceHttpCreateRequestWithURL(int connectionID, int method, const char *url, u64 contentLength) {
+static int sceHttpCreateRequestWithURL(int connectionID, int method, const char *url, u64 contentLength) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpCreateRequestWithURL(%d, %d, %s, %llx)", connectionID, method, url, contentLength);
 	return 0;
 }
 
-int sceHttpCreateConnectionWithURL(int templateID, const char *url, int unknown1) {
+static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int unknown1) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpCreateConnectionWithURL(%d, %s, %d)", templateID, url, unknown1);
 	return 0;
 }
 
-int sceHttpSetRecvTimeOut(int id, u32 timeout) {
+static int sceHttpSetRecvTimeOut(int id, u32 timeout) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpSetRecvTimeOut(%d, %x)", id, timeout);
 	return 0;
 }
 
-int sceHttpGetAllHeader(int request, u32 headerPtrToPtr, u32 headerSize) {
+static int sceHttpGetAllHeader(int request, u32 headerPtrToPtr, u32 headerSize) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpGetAllHeader(%d, %x, %x)", request, headerPtrToPtr, headerSize);
 	return 0;
 }
 
-int sceHttpGetContentLength(int requestID, u64 contentLengthPtr) {
+static int sceHttpGetContentLength(int requestID, u64 contentLengthPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceHttpGetContentLength(%d, %llx)", requestID, contentLengthPtr);
 	return 0;
 }

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -17,11 +17,12 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceImpose.h"
+#include "Core/HLE/sceUtility.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Common/ChunkFile.h"
-#include "Core/HLE/sceUtility.h"
 
 const int PSP_UMD_POPUP_DISABLE = 0;
 const int PSP_UMD_POPUP_ENABLE = 1;
@@ -55,7 +56,7 @@ void __ImposeDoState(PointerWrap &p)
 	p.Do(backlightOffTime);
 }
 
-u32 sceImposeGetBatteryIconStatus(u32 chargingPtr, u32 iconStatusPtr)
+static u32 sceImposeGetBatteryIconStatus(u32 chargingPtr, u32 iconStatusPtr)
 {
 	DEBUG_LOG(SCEUTILITY, "sceImposeGetBatteryIconStatus(%08x, %08x)", chargingPtr, iconStatusPtr);
 	if (Memory::IsValidAddress(chargingPtr))
@@ -65,7 +66,7 @@ u32 sceImposeGetBatteryIconStatus(u32 chargingPtr, u32 iconStatusPtr)
 	return 0;
 }
 
-u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal)
+static u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal)
 {
 	DEBUG_LOG(SCEUTILITY, "sceImposeSetLanguageMode(%08x, %08x)", languageVal, buttonVal);
 	language = languageVal;
@@ -73,7 +74,7 @@ u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal)
 	return 0;
 }
 
-u32 sceImposeGetLanguageMode(u32 languagePtr, u32 btnPtr)
+static u32 sceImposeGetLanguageMode(u32 languagePtr, u32 btnPtr)
 {
 	DEBUG_LOG(SCEUTILITY, "sceImposeGetLanguageMode(%08x, %08x)", languagePtr, btnPtr);
 	if (Memory::IsValidAddress(languagePtr))
@@ -83,24 +84,24 @@ u32 sceImposeGetLanguageMode(u32 languagePtr, u32 btnPtr)
 	return 0;
 }
 
-u32 sceImposeSetUMDPopup(int mode) {
+static u32 sceImposeSetUMDPopup(int mode) {
 	DEBUG_LOG(SCEUTILITY, "sceImposeSetUMDPopup(%i)", mode);
 	umdPopup = mode;
 	return 0;
 }
 
-u32 sceImposeGetUMDPopup() {
+static u32 sceImposeGetUMDPopup() {
 	DEBUG_LOG(SCEUTILITY, "sceImposeGetUMDPopup()");
 	return umdPopup;
 }
 
-u32 sceImposeSetBacklightOffTime(int time) {
+static u32 sceImposeSetBacklightOffTime(int time) {
 	DEBUG_LOG(SCEUTILITY, "sceImposeSetBacklightOffTime(%i)", time);
 	backlightOffTime = time;
 	return 0;
 }
 
-u32 sceImposeGetBacklightOffTime() {
+static u32 sceImposeGetBacklightOffTime() {
 	DEBUG_LOG(SCEUTILITY, "sceImposeGetBacklightOffTime()");
 	return backlightOffTime;
 }

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -28,6 +28,8 @@ void __IoShutdown();
 
 struct ScePspDateTime;
 
+u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen);
+
 u32 __IoGetFileHandleFromId(u32 id, u32 &outError);
 void __IoCopyDate(ScePspDateTime& date_out, const tm& date_in);
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -640,7 +640,7 @@ struct SystemStatus {
 	SceUInt_le perfcounter3;
 };
 
-int sceKernelReferSystemStatus(u32 statusPtr) {
+static int sceKernelReferSystemStatus(u32 statusPtr) {
 	DEBUG_LOG(SCEKERNEL, "sceKernelReferSystemStatus(%08x)", statusPtr);
 	if (Memory::IsValidAddress(statusPtr)) {
 		SystemStatus status;
@@ -675,7 +675,7 @@ struct DebugProfilerRegs {
 	u32 local_bus;
 };
 
-u32 sceKernelReferThreadProfiler(u32 statusPtr) {
+static u32 sceKernelReferThreadProfiler(u32 statusPtr) {
 	ERROR_LOG(SCEKERNEL, "FAKE sceKernelReferThreadProfiler()");
 
 	// Can we confirm that the struct above is the right struct?
@@ -689,25 +689,25 @@ u32 sceKernelReferThreadProfiler(u32 statusPtr) {
 	return 0;
 }
 
-int sceKernelReferGlobalProfiler(u32 statusPtr) {
+static int sceKernelReferGlobalProfiler(u32 statusPtr) {
 	ERROR_LOG(SCEKERNEL, "UNIMPL sceKernelReferGlobalProfiler(%08x)", statusPtr);
 	// Ignore for now
 	return 0;
 }
 
-int ThreadManForKernel_446d8de6(const char *threadName, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr)
+static int ThreadManForKernel_446d8de6(const char *threadName, u32 entry, u32 prio, int stacksize, u32 attr, u32 optionAddr)
 {
 	WARN_LOG(SCEKERNEL,"ThreadManForKernel_446d8de6:Not support this patcher");
 	return sceKernelCreateThread(threadName, entry, prio, stacksize,  attr, optionAddr);
 }
 
-int ThreadManForKernel_f475845d(SceUID threadToStartID, int argSize, u32 argBlockPtr)
+static int ThreadManForKernel_f475845d(SceUID threadToStartID, int argSize, u32 argBlockPtr)
 {	
 	WARN_LOG(SCEKERNEL,"ThreadManForKernel_f475845d:Not support this patcher");
 	return sceKernelStartThread(threadToStartID,argSize,argBlockPtr);
 }
 
-int ThreadManForKernel_ceadeb47(u32 usec)
+static int ThreadManForKernel_ceadeb47(u32 usec)
 {	
 	WARN_LOG(SCEKERNEL,"ThreadManForKernel_ceadeb47:Not support this patcher");
 	return sceKernelDelayThread(usec);
@@ -924,7 +924,7 @@ void Register_LoadExecForUser()
 	RegisterModule("LoadExecForUser", ARRAY_SIZE(LoadExecForUser), LoadExecForUser);
 }
 
-int LoadExecForKernel_4AC57943(SceUID cbId) 
+static int LoadExecForKernel_4AC57943(SceUID cbId) 
 {
 	WARN_LOG(SCEKERNEL,"LoadExecForKernel_4AC57943:Not support this patcher");
 	return sceKernelRegisterExitCallback(cbId);//not sure right

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -113,7 +113,7 @@ public:
 
 static int alarmTimer = -1;
 
-void __KernelTriggerAlarm(u64 userdata, int cyclesLate)
+static void __KernelTriggerAlarm(u64 userdata, int cyclesLate)
 {
 	int uid = (int) userdata;
 
@@ -156,7 +156,7 @@ void __KernelScheduleAlarm(Alarm *alarm, u64 micro)
 	CoreTiming::ScheduleEvent(usToCycles(micro), alarmTimer, alarm->GetUID());
 }
 
-SceUID __KernelSetAlarm(u64 micro, u32 handlerPtr, u32 commonPtr)
+static SceUID __KernelSetAlarm(u64 micro, u32 handlerPtr, u32 commonPtr)
 {
 	if (!Memory::IsValidAddress(handlerPtr))
 		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -142,7 +142,7 @@ KernelObject *__KernelEventFlagObject()
 	return new EventFlag;
 }
 
-bool __KernelEventFlagMatches(u32_le *pattern, u32 bits, u8 wait, u32 outAddr)
+static bool __KernelEventFlagMatches(u32_le *pattern, u32 bits, u8 wait, u32 outAddr)
 {
 	if ((wait & PSP_EVENT_WAITOR)
 		? (bits & *pattern) /* one or more bits of the mask */
@@ -160,7 +160,7 @@ bool __KernelEventFlagMatches(u32_le *pattern, u32 bits, u8 wait, u32 outAddr)
 	return false;
 }
 
-bool __KernelUnlockEventFlagForThread(EventFlag *e, EventFlagTh &th, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockEventFlagForThread(EventFlag *e, EventFlagTh &th, u32 &error, int result, bool &wokeThreads)
 {
 	if (!HLEKernel::VerifyWait(th.threadID, WAITTYPE_EVENTFLAG, e->GetUID()))
 		return true;
@@ -191,7 +191,7 @@ bool __KernelUnlockEventFlagForThread(EventFlag *e, EventFlagTh &th, u32 &error,
 	return true;
 }
 
-bool __KernelClearEventFlagThreads(EventFlag *e, int reason)
+static bool __KernelClearEventFlagThreads(EventFlag *e, int reason)
 {
 	u32 error;
 	bool wokeThreads = false;
@@ -394,7 +394,7 @@ void __KernelEventFlagTimeout(u64 userdata, int cycleslate)
 	}
 }
 
-void __KernelSetEventFlagTimeout(EventFlag *e, u32 timeoutPtr)
+static void __KernelSetEventFlagTimeout(EventFlag *e, u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || eventFlagWaitTimer == -1)
 		return;

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -76,7 +76,7 @@ static bool inInterrupt;
 static SceUID threadBeforeInterrupt;
 
 
-void sceKernelCpuSuspendIntr()
+static void sceKernelCpuSuspendIntr()
 {
 	VERBOSE_LOG(SCEINTC, "sceKernelCpuSuspendIntr");
 	int returnValue;
@@ -93,7 +93,7 @@ void sceKernelCpuSuspendIntr()
 	RETURN(returnValue);
 }
 
-void sceKernelCpuResumeIntr(u32 enable)
+static void sceKernelCpuResumeIntr(u32 enable)
 {
 	VERBOSE_LOG(SCEINTC, "sceKernelCpuResumeIntr(%i)", enable);
 	if (enable)
@@ -109,21 +109,21 @@ void sceKernelCpuResumeIntr(u32 enable)
 	hleEatCycles(15);
 }
 
-void sceKernelIsCpuIntrEnable()
+static void sceKernelIsCpuIntrEnable()
 {
 	u32 retVal = __InterruptsEnabled(); 
 	DEBUG_LOG(SCEINTC, "%i=sceKernelIsCpuIntrEnable()", retVal);
 	RETURN(retVal);
 }
 
-int sceKernelIsCpuIntrSuspended(int flag)
+static int sceKernelIsCpuIntrSuspended(int flag)
 {
 	int retVal = flag == 0 ? 1 : 0;
 	DEBUG_LOG(SCEINTC, "%i=sceKernelIsCpuIntrSuspended(%d)", retVal, flag);
 	return retVal;
 }
 
-void sceKernelCpuResumeIntrWithSync(u32 enable)
+static void sceKernelCpuResumeIntrWithSync(u32 enable)
 {
 	sceKernelCpuResumeIntr(enable);
 }
@@ -302,7 +302,7 @@ bool __IsInInterrupt()
 	return inInterrupt;
 }
 
-bool __CanExecuteInterrupt()
+static bool __CanExecuteInterrupt()
 {
 	return !inInterrupt;
 }
@@ -374,7 +374,7 @@ retry:
 	}
 }
 
-void __TriggerRunInterrupts(int type)
+static void __TriggerRunInterrupts(int type)
 {
 	// If interrupts aren't enabled, we run them later.
 	if (interruptsEnabled && !inInterrupt)
@@ -558,7 +558,7 @@ u32 sceKernelEnableSubIntr(u32 intrNumber, u32 subIntrNumber) {
 	return 0;
 }
 
-u32 sceKernelDisableSubIntr(u32 intrNumber, u32 subIntrNumber) {
+static u32 sceKernelDisableSubIntr(u32 intrNumber, u32 subIntrNumber) {
 	if (intrNumber >= PSP_NUMBER_INTERRUPTS) {
 		ERROR_LOG_REPORT(SCEINTC, "sceKernelDisableSubIntr(%i, %i): invalid interrupt", intrNumber, subIntrNumber);
 		return SCE_KERNEL_ERROR_ILLEGAL_INTRCODE;
@@ -599,13 +599,13 @@ struct PspIntrHandlerOptionParam {
 	u32 max_clock_hi;      //+34
 };  //=38
 
-void QueryIntrHandlerInfo()
+static void QueryIntrHandlerInfo()
 {
 	ERROR_LOG_REPORT(SCEINTC, "QueryIntrHandlerInfo()");
 	RETURN(0);
 }
 
-u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
+static u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
 {
 	u8 c = fillc & 0xff;
 	DEBUG_LOG(SCEINTC, "sceKernelMemset(ptr = %08x, c = %02x, n = %08x)", addr, c, n);
@@ -621,7 +621,7 @@ u32 sceKernelMemset(u32 addr, u32 fillc, u32 n)
 	return addr;
 }
 
-u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
+static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
 
@@ -683,46 +683,46 @@ const HLEFunction Kernel_Library[] =
 	{0xfa835cde,WrapI_I<sceKernelGetTlsAddr>, "sceKernelGetTlsAddr"},
 };
 
-u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
+static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
 	memcpy(Memory::GetPointer(dst), Memory::GetPointer(src), size);
 	return dst;
 }
 
-u32 sysclib_strcat(u32 dst, u32 src) {
+static u32 sysclib_strcat(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcat(dest=%08x, src=%08x)", dst, src);
 	strcat((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
 	return dst;
 }
 
-int sysclib_strcmp(u32 dst, u32 src) {
+static int sysclib_strcmp(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcmp(dest=%08x, src=%08x)", dst, src);
 	return strcmp((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
 }
 
-u32 sysclib_strcpy(u32 dst, u32 src) {
+static u32 sysclib_strcpy(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcpy(dest=%08x, src=%08x)", dst, src);
 	strcpy((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
 	return dst;
 }
 
-u32 sysclib_strlen(u32 src) {
+static u32 sysclib_strlen(u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strlen(src=%08x)", src);
 	return (u32)strlen(Memory::GetCharPointer(src));
 }
 
-int sysclib_memcmp(u32 dst, u32 src, u32 size) {
+static int sysclib_memcmp(u32 dst, u32 src, u32 size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memcmp(dest=%08x, src=%08x, size=%i)", dst, src, size);
 	return memcmp(Memory::GetCharPointer(dst), Memory::GetCharPointer(src), size);
 }
 
-int sysclib_sprintf(u32 dst, u32 fmt) {
+static int sysclib_sprintf(u32 dst, u32 fmt) {
 	ERROR_LOG(SCEKERNEL, "Unimpl sysclib_sprintf(dest=%08x, src=%08x)", dst, fmt);
 	// TODO
 	return sprintf((char *)Memory::GetPointer(dst), "%s", Memory::GetCharPointer(fmt));
 }
 
-u32 sysclib_memset(u32 destAddr, int data, int size) {
+static u32 sysclib_memset(u32 destAddr, int data, int size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memset(dest=%08x, data=%d ,size=%d)", destAddr, data, size);
 	if (Memory::IsValidAddress(destAddr))
 		memset(Memory::GetPointer(destAddr), data, size);

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -202,7 +202,7 @@ KernelObject *__KernelMbxObject()
 	return new Mbx;
 }
 
-bool __KernelUnlockMbxForThread(Mbx *m, MbxWaitingThread &th, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockMbxForThread(Mbx *m, MbxWaitingThread &th, u32 &error, int result, bool &wokeThreads)
 {
 	if (!HLEKernel::VerifyWait(th.threadID, WAITTYPE_MBX, m->GetUID()))
 		return true;
@@ -220,7 +220,7 @@ bool __KernelUnlockMbxForThread(Mbx *m, MbxWaitingThread &th, u32 &error, int re
 	return true;
 }
 
-bool __KernelUnlockMbxForThreadCheck(Mbx *m, MbxWaitingThread &waitData, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockMbxForThreadCheck(Mbx *m, MbxWaitingThread &waitData, u32 &error, int result, bool &wokeThreads)
 {
 	if (m->nmb.numMessages > 0 && __KernelUnlockMbxForThread(m, waitData, error, 0, wokeThreads))
 	{
@@ -254,7 +254,7 @@ void __KernelMbxTimeout(u64 userdata, int cyclesLate)
 	HLEKernel::WaitExecTimeout<Mbx, WAITTYPE_MBX>(threadID);
 }
 
-void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
+static void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || mbxWaitTimer == -1)
 		return;
@@ -271,7 +271,7 @@ void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
 	CoreTiming::ScheduleEvent(usToCycles(micro), mbxWaitTimer, __KernelGetCurThread());
 }
 
-std::vector<MbxWaitingThread>::iterator __KernelMbxFindPriority(std::vector<MbxWaitingThread> &waiting)
+static std::vector<MbxWaitingThread>::iterator __KernelMbxFindPriority(std::vector<MbxWaitingThread> &waiting)
 {
 	_dbg_assert_msg_(SCEKERNEL, !waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -488,7 +488,7 @@ enum SceKernelFplAttr
 	PSP_FPL_ATTR_KNOWN    = PSP_FPL_ATTR_FIFO | PSP_FPL_ATTR_PRIORITY | PSP_FPL_ATTR_HIGHMEM,
 };
 
-bool __KernelUnlockFplForThread(FPL *fpl, FplWaitingThread &threadInfo, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockFplForThread(FPL *fpl, FplWaitingThread &threadInfo, u32 &error, int result, bool &wokeThreads)
 {
 	const SceUID threadID = threadInfo.threadID;
 	if (!HLEKernel::VerifyWait(threadID, WAITTYPE_FPL, fpl->GetUID()))
@@ -538,12 +538,12 @@ void __KernelFplEndCallback(SceUID threadID, SceUID prevCallbackId)
 		DEBUG_LOG(SCEKERNEL, "sceKernelReceiveMbxCB: Resuming mbx wait from callback");
 }
 
-bool __FplThreadSortPriority(FplWaitingThread thread1, FplWaitingThread thread2)
+static bool __FplThreadSortPriority(FplWaitingThread thread1, FplWaitingThread thread2)
 {
 	return __KernelThreadSortPriority(thread1.threadID, thread2.threadID);
 }
 
-bool __KernelClearFplThreads(FPL *fpl, int reason)
+static bool __KernelClearFplThreads(FPL *fpl, int reason)
 {
 	u32 error;
 	bool wokeThreads = false;
@@ -554,7 +554,7 @@ bool __KernelClearFplThreads(FPL *fpl, int reason)
 	return wokeThreads;
 }
 
-void __KernelSortFplThreads(FPL *fpl)
+static void __KernelSortFplThreads(FPL *fpl)
 {
 	// Remove any that are no longer waiting.
 	SceUID uid = fpl->GetUID();
@@ -682,7 +682,7 @@ void __KernelFplTimeout(u64 userdata, int cyclesLate)
 	HLEKernel::WaitExecTimeout<FPL, WAITTYPE_FPL>(threadID);
 }
 
-void __KernelSetFplTimeout(u32 timeoutPtr)
+static void __KernelSetFplTimeout(u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || fplWaitTimer == -1)
 		return;
@@ -953,21 +953,21 @@ public:
 };
 
 
-u32 sceKernelMaxFreeMemSize() 
+static u32 sceKernelMaxFreeMemSize()
 {
 	u32 retVal = userMemory.GetLargestFreeBlockSize();
 	DEBUG_LOG(SCEKERNEL, "%08x (dec %i)=sceKernelMaxFreeMemSize()", retVal, retVal);
 	return retVal;
 }
 
-u32 sceKernelTotalFreeMemSize()
+static u32 sceKernelTotalFreeMemSize()
 {
 	u32 retVal = userMemory.GetTotalFreeBytes();
 	DEBUG_LOG(SCEKERNEL, "%08x (dec %i)=sceKernelTotalFreeMemSize()", retVal, retVal);
 	return retVal;
 }
 
-int sceKernelAllocPartitionMemory(int partition, const char *name, int type, u32 size, u32 addr)
+static int sceKernelAllocPartitionMemory(int partition, const char *name, int type, u32 size, u32 addr)
 {
 	if (name == NULL)
 	{
@@ -1017,14 +1017,14 @@ int sceKernelAllocPartitionMemory(int partition, const char *name, int type, u32
 	return uid;
 }
 
-int sceKernelFreePartitionMemory(SceUID id)
+static int sceKernelFreePartitionMemory(SceUID id)
 {
 	DEBUG_LOG(SCEKERNEL,"sceKernelFreePartitionMemory(%d)",id);
 
 	return kernelObjects.Destroy<PartitionMemoryBlock>(id);
 }
 
-u32 sceKernelGetBlockHeadAddr(SceUID id)
+static u32 sceKernelGetBlockHeadAddr(SceUID id)
 {
 	u32 error;
 	PartitionMemoryBlock *block = kernelObjects.Get<PartitionMemoryBlock>(id, error);
@@ -1041,7 +1041,7 @@ u32 sceKernelGetBlockHeadAddr(SceUID id)
 }
 
 
-int sceKernelPrintf(const char *formatString)
+static int sceKernelPrintf(const char *formatString)
 {
 	if (formatString == NULL)
 		return -1;
@@ -1143,7 +1143,7 @@ int sceKernelPrintf(const char *formatString)
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	bool validSDK = false;
 	switch (sdkMainVersion) {
@@ -1177,7 +1177,7 @@ int sceKernelSetCompiledSdkVersion(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion370(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion370(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x03070000) {
 		WARN_LOG_REPORT(SCEKERNEL, "sceKernelSetCompiledSdkVersion370 unknown SDK: %x", sdkVersion);
@@ -1189,7 +1189,7 @@ int sceKernelSetCompiledSdkVersion370(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion380_390(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion380_390(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x03080000 && sdkMainVersion != 0x03090000) {
 		WARN_LOG_REPORT(SCEKERNEL, "sceKernelSetCompiledSdkVersion380_390 unknown SDK: %x", sdkVersion);
@@ -1203,7 +1203,7 @@ int sceKernelSetCompiledSdkVersion380_390(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion395(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion395(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFFFF00;
 	if (sdkMainVersion != 0x04000000
 			&& sdkMainVersion != 0x04000100
@@ -1219,7 +1219,7 @@ int sceKernelSetCompiledSdkVersion395(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion600_602(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion600_602(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x06010000
 			&& sdkMainVersion != 0x06000000
@@ -1233,7 +1233,7 @@ int sceKernelSetCompiledSdkVersion600_602(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion500_505(int sdkVersion)
+static int sceKernelSetCompiledSdkVersion500_505(int sdkVersion)
 {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x05000000
@@ -1247,7 +1247,7 @@ int sceKernelSetCompiledSdkVersion500_505(int sdkVersion)
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion401_402(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion401_402(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x04010000
 			&& sdkMainVersion != 0x04020000) {
@@ -1260,7 +1260,7 @@ int sceKernelSetCompiledSdkVersion401_402(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion507(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion507(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x05070000) {
 		WARN_LOG_REPORT(SCEKERNEL, "sceKernelSetCompiledSdkVersion507 unknown SDK: %x", sdkVersion);
@@ -1272,7 +1272,7 @@ int sceKernelSetCompiledSdkVersion507(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion603_605(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion603_605(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x06040000
 			&& sdkMainVersion != 0x06030000
@@ -1286,7 +1286,7 @@ int sceKernelSetCompiledSdkVersion603_605(int sdkVersion) {
 	return 0;
 }
 
-int sceKernelSetCompiledSdkVersion606(int sdkVersion) {
+static int sceKernelSetCompiledSdkVersion606(int sdkVersion) {
 	int sdkMainVersion = sdkVersion & 0xFFFF0000;
 	if (sdkMainVersion != 0x06060000) {
 		ERROR_LOG_REPORT(SCEKERNEL, "sceKernelSetCompiledSdkVersion606 unknown SDK: %x (would crash)", sdkVersion);
@@ -1304,7 +1304,7 @@ int sceKernelGetCompiledSdkVersion() {
 	return sdkVersion_;
 }
 
-int sceKernelSetCompilerVersion(int version) {
+static int sceKernelSetCompilerVersion(int version) {
 	DEBUG_LOG(SCEKERNEL, "sceKernelSetCompilerVersion(%08x)", version);
 	compilerVersion_ = version;
 	flags_ |= SCE_KERNEL_HASCOMPILERVERSION;
@@ -1340,7 +1340,7 @@ enum SceKernelVplAttr
 	PSP_VPL_ATTR_KNOWN      = PSP_VPL_ATTR_FIFO | PSP_VPL_ATTR_PRIORITY | PSP_VPL_ATTR_SMALLEST | PSP_VPL_ATTR_HIGHMEM,
 };
 
-bool __KernelUnlockVplForThread(VPL *vpl, VplWaitingThread &threadInfo, u32 &error, int result, bool &wokeThreads) {
+static bool __KernelUnlockVplForThread(VPL *vpl, VplWaitingThread &threadInfo, u32 &error, int result, bool &wokeThreads) {
 	const SceUID threadID = threadInfo.threadID;
 	if (!HLEKernel::VerifyWait(threadID, WAITTYPE_VPL, vpl->GetUID())) {
 		return true;
@@ -1396,12 +1396,12 @@ void __KernelVplEndCallback(SceUID threadID, SceUID prevCallbackId)
 		DEBUG_LOG(SCEKERNEL, "sceKernelReceiveMbxCB: Resuming mbx wait from callback");
 }
 
-bool __VplThreadSortPriority(VplWaitingThread thread1, VplWaitingThread thread2)
+static bool __VplThreadSortPriority(VplWaitingThread thread1, VplWaitingThread thread2)
 {
 	return __KernelThreadSortPriority(thread1.threadID, thread2.threadID);
 }
 
-bool __KernelClearVplThreads(VPL *vpl, int reason)
+static bool __KernelClearVplThreads(VPL *vpl, int reason)
 {
 	u32 error;
 	bool wokeThreads = false;
@@ -1412,7 +1412,7 @@ bool __KernelClearVplThreads(VPL *vpl, int reason)
 	return wokeThreads;
 }
 
-void __KernelSortVplThreads(VPL *vpl)
+static void __KernelSortVplThreads(VPL *vpl)
 {
 	// Remove any that are no longer waiting.
 	SceUID uid = vpl->GetUID();
@@ -1523,7 +1523,7 @@ int sceKernelDeleteVpl(SceUID uid)
 
 // Returns false for invalid parameters (e.g. don't check callbacks, etc.)
 // Successful allocation is indicated by error == 0.
-bool __KernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 &error, bool trying, const char *funcname) {
+static bool __KernelAllocateVpl(SceUID uid, u32 size, u32 addrPtr, u32 &error, bool trying, const char *funcname) {
 	VPL *vpl = kernelObjects.Get<VPL>(uid, error);
 	if (vpl) {
 		if (size == 0 || size > (u32) vpl->nv.poolSize) {
@@ -1588,7 +1588,7 @@ void __KernelVplTimeout(u64 userdata, int cyclesLate) {
 	}
 }
 
-void __KernelSetVplTimeout(u32 timeoutPtr)
+static void __KernelSetVplTimeout(u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || vplWaitTimer == -1)
 		return;
@@ -1767,7 +1767,7 @@ int sceKernelReferVplStatus(SceUID uid, u32 infoPtr) {
 	}
 }
 
-u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
+static u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
 	if (Memory::IsValidAddress(paramsAddr) && Memory::Read_U32(paramsAddr) != 4) {
 		ERROR_LOG_REPORT(SCEKERNEL, "AllocMemoryBlock(%s): unsupported params size %d", pname, Memory::Read_U32(paramsAddr));
 		return SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT;
@@ -1798,12 +1798,12 @@ u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
 	return uid;
 }
 
-u32 FreeMemoryBlock(u32 uid) {
+static u32 FreeMemoryBlock(u32 uid) {
 	INFO_LOG(SCEKERNEL, "FreeMemoryBlock(%08x)", uid);
 	return kernelObjects.Destroy<PartitionMemoryBlock>(uid);
 }
 
-u32 GetMemoryBlockPtr(u32 uid, u32 addr) {
+static u32 GetMemoryBlockPtr(u32 uid, u32 addr) {
 	u32 error;
 	PartitionMemoryBlock *block = kernelObjects.Get<PartitionMemoryBlock>(uid, error);
 	if (block)
@@ -1819,18 +1819,18 @@ u32 GetMemoryBlockPtr(u32 uid, u32 addr) {
 	}
 }
 
-u32 SysMemUserForUser_D8DE5C1E() {
+static u32 SysMemUserForUser_D8DE5C1E() {
 	// Called by Evangelion Jo and return 0 here to go in-game.
 	ERROR_LOG(SCEKERNEL,"UNIMPL SysMemUserForUser_D8DE5C1E()");
 	return 0; 
 }
 
-u32 SysMemUserForUser_ACBD88CA() {
+static u32 SysMemUserForUser_ACBD88CA() {
 	ERROR_LOG_REPORT_ONCE(SysMemUserForUser_ACBD88CA, SCEKERNEL, "UNIMPL SysMemUserForUser_ACBD88CA()");
 	return 0; 
 }
 
-u32 SysMemUserForUser_945E45DA() {
+static u32 SysMemUserForUser_945E45DA() {
 	// Called by Evangelion Jo and expected return 0 here.
 	ERROR_LOG_REPORT_ONCE(SysMemUserForUser945E45DA, SCEKERNEL, "UNIMPL SysMemUserForUser_945E45DA()");
 	return 0; 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -442,7 +442,7 @@ static std::set<SceUID> loadedModules;
 // STATE END
 //////////////////////////////////////////////////////////////////////////
 
-void __KernelModuleInit()
+static void __KernelModuleInit()
 {
 	actionAfterModule = __KernelRegisterActionType(AfterModuleEntryCall::Create);
 }
@@ -479,7 +479,7 @@ struct HI16RelocInfo
 	u32 addr;
 	u32 data;
 };
-void WriteVarSymbol(u32 exportAddress, u32 relocAddress, u8 type, bool reverse = false)
+static void WriteVarSymbol(u32 exportAddress, u32 relocAddress, u8 type, bool reverse = false)
 {
 	// We have to post-process the HI16 part, since it might be +1 or not depending on the LO16 value.
 	static u32 lastHI16ExportAddress = 0;
@@ -759,7 +759,7 @@ void Module::Cleanup() {
 	}
 }
 
-void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, const u32 length) {
+static void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, const u32 length) {
 	if (!decryptedEbootDataPtr) {
 		ERROR_LOG(SCEMODULE, "Error saving decrypted EBOOT.BIN: invalid pointer");
 		return;
@@ -838,7 +838,7 @@ static bool IsHLEVersionedModule(const char *name) {
 	return false;
 }
 
-Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std::string *error_string, u32 *magic, u32 &error) {
+static Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std::string *error_string, u32 *magic, u32 &error) {
 	Module *module = new Module;
 	kernelObjects.Create(module);
 	loadedModules.insert(module->GetUID());
@@ -1368,7 +1368,7 @@ Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromTop, std
 	return module;
 }
 
-bool __KernelLoadPBP(const char *filename, std::string *error_string)
+static bool __KernelLoadPBP(const char *filename, std::string *error_string)
 {
 	static const char *FileNames[] =
 	{
@@ -1397,7 +1397,7 @@ bool __KernelLoadPBP(const char *filename, std::string *error_string)
 	return true;
 }
 
-Module *__KernelLoadModule(u8 *fileptr, SceKernelLMOption *options, std::string *error_string)
+static Module *__KernelLoadModule(u8 *fileptr, SceKernelLMOption *options, std::string *error_string)
 {
 	Module *module = 0;
 	// Check for PBP
@@ -1443,7 +1443,7 @@ Module *__KernelLoadModule(u8 *fileptr, SceKernelLMOption *options, std::string 
 	return module;
 }
 
-void __KernelStartModule(Module *m, int args, const char *argp, SceKernelSMOption *options)
+static void __KernelStartModule(Module *m, int args, const char *argp, SceKernelSMOption *options)
 {
 	m->nm.status = MODULE_STATUS_STARTED;
 	if (m->nm.module_start_func != 0 && m->nm.module_start_func != (u32)-1)
@@ -1632,7 +1632,7 @@ int sceKernelLoadExec(const char *filename, u32 paramPtr)
 	return 0;
 }
 
-u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
+static u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 {
 	if (!name) {
 		ERROR_LOG(LOADER, "sceKernelLoadModule(NULL, %08x): Bad name", flags);
@@ -1739,14 +1739,14 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr)
 	return hleDelayResult(module->GetUID(), "module loaded", 500);
 }
 
-u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr)
+static u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr)
 {
 	DEBUG_LOG(LOADER, "sceKernelLoadModuleNpDrm(%s, %08x)", name, flags);
 
 	return sceKernelLoadModule(name, flags, optionAddr);
 }
 
-void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
+static void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
 {
 	u32 priority = 0x20;
 	u32 stacksize = 0x40000; 
@@ -1846,7 +1846,7 @@ void sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValu
 	RETURN(moduleId);
 }
 
-u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
+static u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
 {
 	u32 priority = 0x20;
 	u32 stacksize = 0x40000;
@@ -1924,7 +1924,7 @@ u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 returnValueA
 	return 0;
 }
 
-u32 sceKernelUnloadModule(u32 moduleId)
+static u32 sceKernelUnloadModule(u32 moduleId)
 {
 	INFO_LOG(SCEMODULE,"sceKernelUnloadModule(%i)", moduleId);
 	u32 error;
@@ -2019,12 +2019,12 @@ u32 hleKernelStopUnloadSelfModuleWithOrWithoutStatus(u32 exitCode, u32 argSize, 
 	return 0;
 }
 
-u32 sceKernelSelfStopUnloadModule(u32 exitCode, u32 argSize, u32 argp) {
+static u32 sceKernelSelfStopUnloadModule(u32 exitCode, u32 argSize, u32 argp) {
 	// Used in Tom Clancy's Splinter Cell Essentials,Ghost in the Shell Stand Alone Complex
 	return hleKernelStopUnloadSelfModuleWithOrWithoutStatus(exitCode, argSize, argp, 0, 0, false);
 }
 
-u32 sceKernelStopUnloadSelfModuleWithStatus(u32 exitCode, u32 argSize, u32 argp, u32 statusAddr, u32 optionAddr) {
+static u32 sceKernelStopUnloadSelfModuleWithStatus(u32 exitCode, u32 argSize, u32 argp, u32 statusAddr, u32 optionAddr) {
 	return hleKernelStopUnloadSelfModuleWithOrWithoutStatus(exitCode, argSize, argp, statusAddr, optionAddr, true);
 }
 
@@ -2083,7 +2083,7 @@ struct GetModuleIdByAddressArg
 	SceUID result;
 };
 
-bool __GetModuleIdByAddressIterator(Module *module, GetModuleIdByAddressArg *state)
+static bool __GetModuleIdByAddressIterator(Module *module, GetModuleIdByAddressArg *state)
 {
 	const u32 start = module->memoryBlockAddr, size = module->memoryBlockSize;
 	if (start != 0 && start <= state->addr && start + size > state->addr)
@@ -2094,7 +2094,7 @@ bool __GetModuleIdByAddressIterator(Module *module, GetModuleIdByAddressArg *sta
 	return true;
 }
 
-u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
+static u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
 {
 	GetModuleIdByAddressArg state;
 	state.addr = moduleAddr;
@@ -2108,7 +2108,7 @@ u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
 	return state.result;
 }
 
-u32 sceKernelGetModuleId()
+static u32 sceKernelGetModuleId()
 {
 	INFO_LOG(SCEMODULE,"sceKernelGetModuleId()");
 	return __KernelGetCurThreadModuleId();
@@ -2126,7 +2126,7 @@ u32 sceKernelFindModuleByName(const char *name)
 	return 1;
 }
 
-u32 sceKernelLoadModuleByID(u32 id, u32 flags, u32 lmoptionPtr)
+static u32 sceKernelLoadModuleByID(u32 id, u32 flags, u32 lmoptionPtr)
 {
 	u32 error;
 	u32 handle = __IoGetFileHandleFromId(id, error);
@@ -2186,13 +2186,13 @@ u32 sceKernelLoadModuleByID(u32 id, u32 flags, u32 lmoptionPtr)
 	return module->GetUID();
 }
 
-u32 sceKernelLoadModuleDNAS(const char *name, u32 flags)
+static u32 sceKernelLoadModuleDNAS(const char *name, u32 flags)
 {
 	ERROR_LOG_REPORT(SCEMODULE, "UNIMPL 0=sceKernelLoadModuleDNAS()");
 	return 0;
 }
 
-SceUID sceKernelLoadModuleBufferUsbWlan(u32 size, u32 bufPtr, u32 flags, u32 lmoptionPtr)
+static SceUID sceKernelLoadModuleBufferUsbWlan(u32 size, u32 bufPtr, u32 flags, u32 lmoptionPtr)
 {
 	if (flags != 0) {
 		WARN_LOG_REPORT(LOADER, "sceKernelLoadModuleBufferUsbWlan: unsupported flags: %08x", flags);
@@ -2241,7 +2241,7 @@ SceUID sceKernelLoadModuleBufferUsbWlan(u32 size, u32 bufPtr, u32 flags, u32 lmo
 	return module->GetUID();
 }
 
-u32 sceKernelQueryModuleInfo(u32 uid, u32 infoAddr)
+static u32 sceKernelQueryModuleInfo(u32 uid, u32 infoAddr)
 {
 	INFO_LOG(SCEMODULE, "sceKernelQueryModuleInfo(%i, %08x)", uid, infoAddr);
 	u32 error;
@@ -2277,7 +2277,7 @@ u32 sceKernelQueryModuleInfo(u32 uid, u32 infoAddr)
 	return 0;
 }
 
-u32 sceKernelGetModuleIdList(u32 resultBuffer, u32 resultBufferSize, u32 idCountAddr)
+static u32 sceKernelGetModuleIdList(u32 resultBuffer, u32 resultBufferSize, u32 idCountAddr)
 {
 	ERROR_LOG(SCEMODULE, "UNTESTED sceKernelGetModuleIdList(%08x, %i, %08x)", resultBuffer, resultBufferSize, idCountAddr);
 	
@@ -2301,20 +2301,20 @@ u32 sceKernelGetModuleIdList(u32 resultBuffer, u32 resultBufferSize, u32 idCount
 	return 0;
 }
 
-u32 ModuleMgrForKernel_977de386(const char *name, u32 flags, u32 optionAddr)
+static u32 ModuleMgrForKernel_977de386(const char *name, u32 flags, u32 optionAddr)
 {
 	WARN_LOG(SCEMODULE,"ModuleMgrForKernel_977de386:Not support this patcher");
 	return sceKernelLoadModule(name, flags, optionAddr);
 }
 
-void ModuleMgrForKernel_50f0c1ec(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
+static void ModuleMgrForKernel_50f0c1ec(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr)
 {
 	WARN_LOG(SCEMODULE,"ModuleMgrForKernel_50f0c1ec:Not support this patcher");
 	sceKernelStartModule(moduleId, argsize, argAddr, returnValueAddr, optionAddr);
 }
 
 //fix for tiger x dragon
-u32 ModuleMgrForKernel_a1a78c58(const char *name, u32 flags, u32 optionAddr)
+static u32 ModuleMgrForKernel_a1a78c58(const char *name, u32 flags, u32 optionAddr)
 {
 	WARN_LOG(SCEMODULE,"ModuleMgrForKernel_a1a78c58:Not support this patcher");
 	return sceKernelLoadModule(name, flags, optionAddr);

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -123,7 +123,7 @@ struct MsgPipeWaitingThread
 	}
 };
 
-bool __KernelMsgPipeThreadSortPriority(MsgPipeWaitingThread thread1, MsgPipeWaitingThread thread2)
+static bool __KernelMsgPipeThreadSortPriority(MsgPipeWaitingThread thread1, MsgPipeWaitingThread thread2)
 {
 	return __KernelThreadSortPriority(thread1.threadID, thread2.threadID);
 }
@@ -301,13 +301,13 @@ KernelObject *__KernelMsgPipeObject()
 	return new MsgPipe;
 }
 
-void __KernelMsgPipeTimeout(u64 userdata, int cyclesLate)
+static void __KernelMsgPipeTimeout(u64 userdata, int cyclesLate)
 {
 	SceUID threadID = (SceUID) userdata;
 	HLEKernel::WaitExecTimeout<MsgPipe, WAITTYPE_MSGPIPE>(threadID);
 }
 
-bool __KernelSetMsgPipeTimeout(u32 timeoutPtr)
+static bool __KernelSetMsgPipeTimeout(u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || waitTimer == -1)
 		return true;
@@ -325,7 +325,7 @@ bool __KernelSetMsgPipeTimeout(u32 timeoutPtr)
 	return true;
 }
 
-int __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll, bool &needsResched, bool &needsWait)
+static int __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll, bool &needsResched, bool &needsWait)
 {
 	u32 curSendAddr = sendBufAddr;
 	SceUID uid = m->GetUID();
@@ -423,7 +423,7 @@ int __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode,
 	return 0;
 }
 
-int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll, bool &needsResched, bool &needsWait)
+static int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll, bool &needsResched, bool &needsWait)
 {
 	u32 curReceiveAddr = receiveBufAddr;
 	SceUID uid = m->GetUID();
@@ -519,7 +519,7 @@ int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int 
 	return 0;
 }
 
-void __KernelMsgPipeBeginCallback(SceUID threadID, SceUID prevCallbackId)
+static void __KernelMsgPipeBeginCallback(SceUID threadID, SceUID prevCallbackId)
 {
 	u32 error;
 	u32 waitValue = __KernelGetWaitValue(threadID, error);
@@ -560,7 +560,7 @@ void __KernelMsgPipeBeginCallback(SceUID threadID, SceUID prevCallbackId)
 	}
 }
 
-bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
+static bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
 {
 	if (!waitInfo.IsStillWaiting(m->GetUID()))
 		return true;
@@ -582,7 +582,7 @@ bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &waitInfo, 
 	return true;
 }
 
-bool __KernelCheckResumeMsgPipeReceive(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
+static bool __KernelCheckResumeMsgPipeReceive(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
 {
 	if (!waitInfo.IsStillWaiting(m->GetUID()))
 		return true;
@@ -603,7 +603,7 @@ bool __KernelCheckResumeMsgPipeReceive(MsgPipe *m, MsgPipeWaitingThread &waitInf
 	return true;
 }
 
-void __KernelMsgPipeEndCallback(SceUID threadID, SceUID prevCallbackId) {
+static void __KernelMsgPipeEndCallback(SceUID threadID, SceUID prevCallbackId) {
 	u32 error;
 	u32 waitValue = __KernelGetWaitValue(threadID, error);
 	u32 timeoutPtr = __KernelGetWaitTimeoutPtr(threadID, error);
@@ -752,7 +752,7 @@ int sceKernelDeleteMsgPipe(SceUID uid)
 	return kernelObjects.Destroy<MsgPipe>(uid);
 }
 
-int __KernelValidateSendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, bool tryMode = false)
+static int __KernelValidateSendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, bool tryMode = false)
 {
 	if (sendSize & 0x80000000)
 	{
@@ -789,7 +789,7 @@ int __KernelValidateSendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, int w
 	return 0;
 }
 
-int __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll)
+static int __KernelSendMsgPipe(MsgPipe *m, u32 sendBufAddr, u32 sendSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll)
 {
 	hleEatCycles(2400);
 
@@ -861,7 +861,7 @@ int sceKernelTrySendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, u32 waitM
 	return __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, 0, false, true);
 }
 
-int __KernelValidateReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, bool tryMode = false)
+static int __KernelValidateReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, bool tryMode = false)
 {
 	if (receiveSize & 0x80000000)
 	{
@@ -898,7 +898,7 @@ int __KernelValidateReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSi
 	return 0;
 }
 
-int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll)
+static int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, u32 timeoutPtr, bool cbEnabled, bool poll)
 {
 	bool needsResched = false;
 	bool needsWait = false;

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -210,7 +210,7 @@ void __KernelMutexShutdown()
 	mutexHeldLocks.clear();
 }
 
-void __KernelMutexAcquireLock(Mutex *mutex, int count, SceUID thread)
+static void __KernelMutexAcquireLock(Mutex *mutex, int count, SceUID thread)
 {
 #if defined(_DEBUG)
 	auto locked = mutexHeldLocks.equal_range(thread);
@@ -224,12 +224,12 @@ void __KernelMutexAcquireLock(Mutex *mutex, int count, SceUID thread)
 	mutex->nm.lockThread = thread;
 }
 
-void __KernelMutexAcquireLock(Mutex *mutex, int count)
+static void __KernelMutexAcquireLock(Mutex *mutex, int count)
 {
 	__KernelMutexAcquireLock(mutex, count, __KernelGetCurThread());
 }
 
-void __KernelMutexEraseLock(Mutex *mutex)
+static void __KernelMutexEraseLock(Mutex *mutex)
 {
 	if (mutex->nm.lockThread != -1)
 	{
@@ -247,7 +247,7 @@ void __KernelMutexEraseLock(Mutex *mutex)
 	mutex->nm.lockThread = -1;
 }
 
-std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUID> &waiting)
+static std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUID> &waiting)
 {
 	_dbg_assert_msg_(SCEKERNEL, !waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
 
@@ -267,7 +267,7 @@ std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUID> &wai
 	return best;
 }
 
-bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int result)
+static bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int result)
 {
 	if (!HLEKernel::VerifyWait(threadID, WAITTYPE_MUTEX, mutex->GetUID()))
 		return false;
@@ -291,7 +291,7 @@ bool __KernelUnlockMutexForThread(Mutex *mutex, SceUID threadID, u32 &error, int
 	return true;
 }
 
-bool __KernelUnlockMutexForThreadCheck(Mutex *mutex, SceUID threadID, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockMutexForThreadCheck(Mutex *mutex, SceUID threadID, u32 &error, int result, bool &wokeThreads)
 {
 	if (mutex->nm.lockThread == -1 && __KernelUnlockMutexForThread(mutex, threadID, error, 0))
 		return true;
@@ -390,7 +390,7 @@ int sceKernelDeleteMutex(SceUID id)
 	}
 }
 
-bool __KernelLockMutexCheck(Mutex *mutex, int count, u32 &error)
+static bool __KernelLockMutexCheck(Mutex *mutex, int count, u32 &error)
 {
 	if (error)
 		return false;
@@ -419,7 +419,7 @@ bool __KernelLockMutexCheck(Mutex *mutex, int count, u32 &error)
 	return false;
 }
 
-bool __KernelLockMutex(Mutex *mutex, int count, u32 &error)
+static bool __KernelLockMutex(Mutex *mutex, int count, u32 &error)
 {
 	if (!__KernelLockMutexCheck(mutex, count, error))
 		return false;
@@ -441,7 +441,7 @@ bool __KernelLockMutex(Mutex *mutex, int count, u32 &error)
 	return false;
 }
 
-bool __KernelUnlockMutex(Mutex *mutex, u32 &error)
+static bool __KernelUnlockMutex(Mutex *mutex, u32 &error)
 {
 	__KernelMutexEraseLock(mutex);
 
@@ -499,7 +499,7 @@ void __KernelMutexThreadEnd(SceUID threadID)
 	}
 }
 
-void __KernelWaitMutex(Mutex *mutex, u32 timeoutPtr)
+static void __KernelWaitMutex(Mutex *mutex, u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || mutexWaitTimer == -1)
 		return;
@@ -810,7 +810,7 @@ int sceKernelDeleteLwMutex(u32 workareaPtr)
 		return error;
 }
 
-bool __KernelLockLwMutex(NativeLwMutexWorkarea *workarea, int count, u32 &error)
+static bool __KernelLockLwMutex(NativeLwMutexWorkarea *workarea, int count, u32 &error)
 {
 	if (!error)
 	{
@@ -896,7 +896,7 @@ void __KernelLwMutexTimeout(u64 userdata, int cyclesLate)
 	HLEKernel::WaitExecTimeout<LwMutex, WAITTYPE_LWMUTEX>(threadID);
 }
 
-void __KernelWaitLwMutex(LwMutex *mutex, u32 timeoutPtr)
+static void __KernelWaitLwMutex(LwMutex *mutex, u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || lwMutexWaitTimer == -1)
 		return;
@@ -913,7 +913,7 @@ void __KernelWaitLwMutex(LwMutex *mutex, u32 timeoutPtr)
 	CoreTiming::ScheduleEvent(usToCycles(micro), lwMutexWaitTimer, __KernelGetCurThread());
 }
 
-bool __KernelUnlockLwMutexForThreadCheck(LwMutex *mutex, SceUID threadID, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockLwMutexForThreadCheck(LwMutex *mutex, SceUID threadID, u32 &error, int result, bool &wokeThreads)
 {
 	if (mutex->nm.lockThread == -1 && __KernelUnlockLwMutexForThread(mutex, mutex->nm.workarea, threadID, error, 0))
 		return true;
@@ -1058,7 +1058,7 @@ int sceKernelUnlockLwMutex(u32 workareaPtr, int count)
 	return 0;
 }
 
-int __KernelReferLwMutexStatus(SceUID uid, u32 infoPtr)
+static int __KernelReferLwMutexStatus(SceUID uid, u32 infoPtr)
 {
 	u32 error;
 	LwMutex *m = kernelObjects.Get<LwMutex>(uid, error);

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -107,7 +107,7 @@ KernelObject *__KernelSemaphoreObject()
 }
 
 // Returns whether the thread should be removed.
-bool __KernelUnlockSemaForThread(Semaphore *s, SceUID threadID, u32 &error, int result, bool &wokeThreads)
+static bool __KernelUnlockSemaForThread(Semaphore *s, SceUID threadID, u32 &error, int result, bool &wokeThreads)
 {
 	if (!HLEKernel::VerifyWait(threadID, WAITTYPE_SEMA, s->GetUID()))
 		return true;
@@ -155,7 +155,7 @@ void __KernelSemaEndCallback(SceUID threadID, SceUID prevCallbackId)
 
 // Resume all waiting threads (for delete / cancel.)
 // Returns true if it woke any threads.
-bool __KernelClearSemaThreads(Semaphore *s, int reason)
+static bool __KernelClearSemaThreads(Semaphore *s, int reason)
 {
 	u32 error;
 	bool wokeThreads = false;
@@ -351,7 +351,7 @@ void __KernelSemaTimeout(u64 userdata, int cycleslate)
 	}
 }
 
-void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)
+static void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)
 {
 	if (timeoutPtr == 0 || semaWaitTimer == -1)
 		return;
@@ -368,7 +368,7 @@ void __KernelSetSemaTimeout(Semaphore *s, u32 timeoutPtr)
 	CoreTiming::ScheduleEvent(usToCycles(micro), semaWaitTimer, __KernelGetCurThread());
 }
 
-int __KernelWaitSema(SceUID id, int wantedCount, u32 timeoutPtr, bool processCallbacks)
+static int __KernelWaitSema(SceUID id, int wantedCount, u32 timeoutPtr, bool processCallbacks)
 {
 	hleEatCycles(900);
 

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -67,18 +67,18 @@ KernelObject *__KernelVTimerObject() {
 	return new VTimer;
 }
 
-u64 __getVTimerRunningTime(VTimer *vt) {
+static u64 __getVTimerRunningTime(VTimer *vt) {
 	if (vt->nvt.active == 0)
 		return 0;
 
 	return CoreTiming::GetGlobalTimeUs() - vt->nvt.base;
 }
 
-u64 __getVTimerCurrentTime(VTimer* vt) {
+static u64 __getVTimerCurrentTime(VTimer* vt) {
 	return vt->nvt.current + __getVTimerRunningTime(vt);
 }
 
-int __KernelCancelVTimer(SceUID id) {
+static int __KernelCancelVTimer(SceUID id) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(id, error);
 
@@ -90,7 +90,7 @@ int __KernelCancelVTimer(SceUID id) {
 	return 0;
 }
 
-void __KernelScheduleVTimer(VTimer *vt, u64 schedule) {
+static void __KernelScheduleVTimer(VTimer *vt, u64 schedule) {
 	CoreTiming::UnscheduleEvent(vtimerTimer, vt->GetUID());
 
 	vt->nvt.schedule = schedule;
@@ -114,7 +114,7 @@ void __KernelScheduleVTimer(VTimer *vt, u64 schedule) {
 	}
 }
 
-void __rescheduleVTimer(SceUID id, u32 delay) {
+static void __rescheduleVTimer(SceUID id, u32 delay) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(id, error);
 
@@ -175,7 +175,7 @@ public:
 	}
 };
 
-void __KernelTriggerVTimer(u64 userdata, int cyclesLate) {
+static void __KernelTriggerVTimer(u64 userdata, int cyclesLate) {
 	SceUID uid = (SceUID) userdata;
 
 	u32 error;
@@ -319,7 +319,7 @@ u64 sceKernelGetVTimerTimeWide(SceUID uid) {
 	return time;
 }
 
-u64 __KernelSetVTimer(VTimer *vt, u64 time) {
+static u64 __KernelSetVTimer(VTimer *vt, u64 time) {
 	u64 current = __getVTimerCurrentTime(vt);
 	vt->nvt.current = time - __getVTimerRunningTime(vt);
 
@@ -365,7 +365,7 @@ u64 sceKernelSetVTimerTimeWide(SceUID uid, u64 timeClock) {
 	return __KernelSetVTimer(vt, timeClock);
 }
 
-void __startVTimer(VTimer *vt) {
+static void __startVTimer(VTimer *vt) {
 	vt->nvt.active = 1;
 	vt->nvt.base = CoreTiming::GetGlobalTimeUs();
 
@@ -397,7 +397,7 @@ u32 sceKernelStartVTimer(SceUID uid) {
 	return error;
 }
 
-void __stopVTimer(VTimer *vt) {
+static void __stopVTimer(VTimer *vt) {
 	// This increases (__getVTimerCurrentTime includes nvt.current.)
 	vt->nvt.current = __getVTimerCurrentTime(vt);
 	vt->nvt.active = 0;

--- a/Core/HLE/sceMd5.cpp
+++ b/Core/HLE/sceMd5.cpp
@@ -17,6 +17,7 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceMd5.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Common/Crypto/md5.h"
@@ -46,7 +47,7 @@ u32 sceKernelUtilsMt19937UInt(u32 ctx) {
 
 static md5_context md5_ctx;
 
-int sceMd5Digest(u32 dataAddr, u32 len, u32 digestAddr) {
+static int sceMd5Digest(u32 dataAddr, u32 len, u32 digestAddr) {
 	DEBUG_LOG(HLE, "sceMd5Digest(%08x, %d, %08x)", dataAddr, len, digestAddr);
 
 	if (!Memory::IsValidAddress(dataAddr) || !Memory::IsValidAddress(digestAddr))
@@ -56,7 +57,7 @@ int sceMd5Digest(u32 dataAddr, u32 len, u32 digestAddr) {
 	return 0;
 }
 
-int sceMd5BlockInit(u32 ctxAddr) {
+static int sceMd5BlockInit(u32 ctxAddr) {
 	DEBUG_LOG(HLE, "sceMd5BlockInit(%08x)", ctxAddr);
 	if (!Memory::IsValidAddress(ctxAddr))
 		return -1;
@@ -68,7 +69,7 @@ int sceMd5BlockInit(u32 ctxAddr) {
 	return 0;
 }
 
-int sceMd5BlockUpdate(u32 ctxAddr, u32 dataPtr, u32 len) {
+static int sceMd5BlockUpdate(u32 ctxAddr, u32 dataPtr, u32 len) {
 	DEBUG_LOG(HLE, "sceMd5BlockUpdate(%08x, %08x, %d)", ctxAddr, dataPtr, len);
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(dataPtr))
 		return -1;
@@ -77,7 +78,7 @@ int sceMd5BlockUpdate(u32 ctxAddr, u32 dataPtr, u32 len) {
 	return 0;
 }
 
-int sceMd5BlockResult(u32 ctxAddr, u32 digestAddr) {
+static int sceMd5BlockResult(u32 ctxAddr, u32 digestAddr) {
 	DEBUG_LOG(HLE, "sceMd5BlockResult(%08x, %08x)", ctxAddr, digestAddr);
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -84,7 +84,7 @@ static std::map<u32, Mp3Context *> mp3Map_old;
 static std::map<u32, AuCtx *> mp3Map;
 static const int mp3DecodeDelay = 4000;
 
-AuCtx *getMp3Ctx(u32 mp3) {
+static AuCtx *getMp3Ctx(u32 mp3) {
 	if (mp3Map.find(mp3) == mp3Map.end())
 		return NULL;
 	return mp3Map[mp3];
@@ -137,7 +137,7 @@ void __Mp3DoState(PointerWrap &p) {
 	}
 }
 
-int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
+static int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	DEBUG_LOG(ME, "sceMp3Decode(%08x,%08x)", mp3, outPcmPtr);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -154,7 +154,7 @@ int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	return pcmBytes;
 }
 
-int sceMp3ResetPlayPosition(u32 mp3) {
+static int sceMp3ResetPlayPosition(u32 mp3) {
 	DEBUG_LOG(ME, "SceMp3ResetPlayPosition(%08x)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -166,7 +166,7 @@ int sceMp3ResetPlayPosition(u32 mp3) {
 	return ctx->AuResetPlayPosition();
 }
 
-int sceMp3CheckStreamDataNeeded(u32 mp3) {
+static int sceMp3CheckStreamDataNeeded(u32 mp3) {
 	DEBUG_LOG(ME, "sceMp3CheckStreamDataNeeded(%08x)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -178,7 +178,7 @@ int sceMp3CheckStreamDataNeeded(u32 mp3) {
 	return ctx->AuCheckStreamDataNeeded();
 }
 
-u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
+static u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
 	INFO_LOG(ME, "sceMp3ReserveMp3Handle(%08x)", mp3Addr);
 	if (!Memory::IsValidAddress(mp3Addr)){
 		ERROR_LOG(ME, "sceMp3ReserveMp3Handle(%08x) invalid address %08x", mp3Addr, mp3Addr);
@@ -218,19 +218,19 @@ u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
 	return mp3Addr;
 }
 
-int sceMp3InitResource() {
+static int sceMp3InitResource() {
 	WARN_LOG(ME, "UNIMPL: sceMp3InitResource");
 	// Do nothing here 
 	return 0;
 }
 
-int sceMp3TermResource() {
+static int sceMp3TermResource() {
 	WARN_LOG(ME, "UNIMPL: sceMp3TermResource");
 	// Do nothing here 
 	return 0;
 }
 
-int __CalculateMp3Channels(int bitval) {
+static int __CalculateMp3Channels(int bitval) {
 	if (bitval == 0 || bitval == 1 || bitval == 2) { // Stereo / Joint Stereo / Dual Channel.
 		return 2;
 	}
@@ -242,7 +242,7 @@ int __CalculateMp3Channels(int bitval) {
 	}
 }
 
-int __CalculateMp3SampleRates(int bitval, int mp3version) {
+static int __CalculateMp3SampleRates(int bitval, int mp3version) {
 	if (mp3version == 3) { // MPEG Version 1
 		int valuemapping[] = { 44100, 48000, 32000, -1 };
 		return valuemapping[bitval];
@@ -260,7 +260,7 @@ int __CalculateMp3SampleRates(int bitval, int mp3version) {
 	}
 }
 
-int __CalculateMp3Bitrates(int bitval, int mp3version, int mp3layer) {
+static int __CalculateMp3Bitrates(int bitval, int mp3version, int mp3layer) {
 	if (mp3version == 3) { // MPEG Version 1
 		if (mp3layer == 3) { // Layer I
 			int valuemapping[] = { 0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, -1 };
@@ -296,7 +296,7 @@ int __CalculateMp3Bitrates(int bitval, int mp3version, int mp3layer) {
 	}
 }
 
-int __ParseMp3Header(AuCtx *ctx, bool *isID3) {
+static int __ParseMp3Header(AuCtx *ctx, bool *isID3) {
 	int header = bswap32(Memory::Read_U32(ctx->AuBuf));
 	// ID3 tag , can be seen in Hanayaka Nari Wa ga Ichizoku.
 	static const int ID3 = 0x49443300;
@@ -310,7 +310,7 @@ int __ParseMp3Header(AuCtx *ctx, bool *isID3) {
 	return header;
 }
 
-int sceMp3Init(u32 mp3) {
+static int sceMp3Init(u32 mp3) {
 	INFO_LOG(ME, "sceMp3Init(%08x)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -350,7 +350,7 @@ int sceMp3Init(u32 mp3) {
 	return 0;
 }
 
-int sceMp3GetLoopNum(u32 mp3) {
+static int sceMp3GetLoopNum(u32 mp3) {
 	DEBUG_LOG(ME, "sceMp3GetLoopNum(%08x)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -362,7 +362,7 @@ int sceMp3GetLoopNum(u32 mp3) {
 	return ctx->AuGetLoopNum();
 }
 
-int sceMp3GetMaxOutputSample(u32 mp3) {
+static int sceMp3GetMaxOutputSample(u32 mp3) {
 	DEBUG_LOG(ME, "sceMp3GetMaxOutputSample(%08x)", mp3);
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
@@ -373,7 +373,7 @@ int sceMp3GetMaxOutputSample(u32 mp3) {
 	return ctx->AuGetMaxOutputSample();
 }
 
-int sceMp3GetSumDecodedSample(u32 mp3) {
+static int sceMp3GetSumDecodedSample(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetSumDecodedSample(%08X)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -385,7 +385,7 @@ int sceMp3GetSumDecodedSample(u32 mp3) {
 	return ctx->AuGetSumDecodedSample();
 }
 
-int sceMp3SetLoopNum(u32 mp3, int loop) {
+static int sceMp3SetLoopNum(u32 mp3, int loop) {
 	INFO_LOG(ME, "sceMp3SetLoopNum(%08X, %i)", mp3, loop);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -397,7 +397,7 @@ int sceMp3SetLoopNum(u32 mp3, int loop) {
 	return ctx->AuSetLoopNum(loop);
 }
 
-int sceMp3GetMp3ChannelNum(u32 mp3) {
+static int sceMp3GetMp3ChannelNum(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetMp3ChannelNum(%08X)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -409,7 +409,7 @@ int sceMp3GetMp3ChannelNum(u32 mp3) {
 	return ctx->AuGetChannelNum();
 }
 
-int sceMp3GetBitRate(u32 mp3) {
+static int sceMp3GetBitRate(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetBitRate(%08X)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -421,7 +421,7 @@ int sceMp3GetBitRate(u32 mp3) {
 	return ctx->AuGetBitRate();
 }
 
-int sceMp3GetSamplingRate(u32 mp3) {
+static int sceMp3GetSamplingRate(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetSamplingRate(%08X)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -433,7 +433,7 @@ int sceMp3GetSamplingRate(u32 mp3) {
 	return ctx->AuGetSamplingRate();
 }
 
-int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcposPtr) {
+static int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcposPtr) {
 	DEBUG_LOG(ME, "sceMp3GetInfoToAddStreamData(%08X, %08X, %08X, %08X)", mp3, dstPtr, towritePtr, srcposPtr);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -445,7 +445,7 @@ int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcpos
 	return ctx->AuGetInfoToAddStreamData(dstPtr, towritePtr, srcposPtr);
 }
 
-int sceMp3NotifyAddStreamData(u32 mp3, int size) {
+static int sceMp3NotifyAddStreamData(u32 mp3, int size) {
 	DEBUG_LOG(ME, "sceMp3NotifyAddStreamData(%08X, %i)", mp3, size);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -457,7 +457,7 @@ int sceMp3NotifyAddStreamData(u32 mp3, int size) {
 	return ctx->AuNotifyAddStreamData(size);
 }
 
-int sceMp3ReleaseMp3Handle(u32 mp3) {
+static int sceMp3ReleaseMp3Handle(u32 mp3) {
 	INFO_LOG(ME, "sceMp3ReleaseMp3Handle(%08X)", mp3);
 
 	AuCtx *ctx = getMp3Ctx(mp3);
@@ -472,17 +472,17 @@ int sceMp3ReleaseMp3Handle(u32 mp3) {
 	return 0;
 }
 
-u32 sceMp3EndEntry() {
+static u32 sceMp3EndEntry() {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceMp3EndEntry(...)");
 	return 0;
 }
 
-u32 sceMp3StartEntry() {
+static u32 sceMp3StartEntry() {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceMp3StartEntry(...)");
 	return 0;
 }
 
-u32 sceMp3GetFrameNum(u32 mp3) {
+static u32 sceMp3GetFrameNum(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetFrameNum(%08x)", mp3);
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
@@ -492,7 +492,7 @@ u32 sceMp3GetFrameNum(u32 mp3) {
 	return ctx->AuGetFrameNum();
 }
 
-u32 sceMp3GetMPEGVersion(u32 mp3) {
+static u32 sceMp3GetMPEGVersion(u32 mp3) {
 	INFO_LOG(ME, "sceMp3GetMPEGVersion(%08x)", mp3);
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
@@ -503,7 +503,7 @@ u32 sceMp3GetMPEGVersion(u32 mp3) {
 	return ctx->AuGetVersion();
 }
 
-u32 sceMp3ResetPlayPositionByFrame(u32 mp3, int position) {
+static u32 sceMp3ResetPlayPositionByFrame(u32 mp3, int position) {
 	DEBUG_LOG(ME, "sceMp3ResetPlayPositionByFrame(%08x, %i)", mp3, position);
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
@@ -514,7 +514,7 @@ u32 sceMp3ResetPlayPositionByFrame(u32 mp3, int position) {
 	return ctx->AuResetPlayPositionByFrame(position);
 }
 
-u32 sceMp3LowLevelInit(u32 mp3) {
+static u32 sceMp3LowLevelInit(u32 mp3) {
 	INFO_LOG(ME, "sceMp3LowLevelInit(%i)", mp3);
 	auto ctx = new AuCtx;
 
@@ -532,7 +532,7 @@ u32 sceMp3LowLevelInit(u32 mp3) {
 	return 0;
 }
 
-u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
+static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
 	// sourceAddr: input mp3 stream buffer
 	// sourceBytesConsumedAddr: consumed bytes decoded in source
 	// samplesAddr: output pcm buffer

--- a/Core/HLE/sceMp4.cpp
+++ b/Core/HLE/sceMp4.cpp
@@ -25,7 +25,7 @@
 
 static std::map<u32, AuCtx*> aacMap;
 
-AuCtx *getAacCtx(u32 id) {
+static AuCtx *getAacCtx(u32 id) {
 	if (aacMap.find(id) == aacMap.end())
 		return NULL;
 	return aacMap[id];
@@ -46,68 +46,68 @@ void __AACDoState(PointerWrap &p) {
 	p.Do(aacMap);
 }
 
-u32 sceMp4Init()
+static u32 sceMp4Init()
 {
 	INFO_LOG(ME, "sceMp4Init()");
 	return 0;
 }
 
-u32 sceMp4Finish()
+static u32 sceMp4Finish()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4Finish()");
 	return 0;
 }
 
-u32 sceMp4Create(u32 mp4, u32 unknown2, u32 readBufferAddr, u32 readBufferSize)
+static u32 sceMp4Create(u32 mp4, u32 unknown2, u32 readBufferAddr, u32 readBufferSize)
 {
 	ERROR_LOG_REPORT(ME, "UNIMPL sceMp4Create(mp4 %i,unknown2 %08x,readBufferAddr %08x,readBufferSize %i)", mp4, unknown2, readBufferAddr, readBufferSize);
 	return 0;
 }
 
-u32 sceMp4GetNumberOfSpecificTrack()
+static u32 sceMp4GetNumberOfSpecificTrack()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetNumberOfSpecificTrack()");
 	return 1;
 }
 
-u32 sceMp4GetMovieInfo(u32 mp4, u32 unknown2)
+static u32 sceMp4GetMovieInfo(u32 mp4, u32 unknown2)
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetMovieInfo(mp4 %i, unknown2 %08x)",mp4, unknown2);
 	return 0;
 }
 
-u32 sceMp4TrackSampleBufAvailableSize(u32 mp4, u32 unknown2)
+static u32 sceMp4TrackSampleBufAvailableSize(u32 mp4, u32 unknown2)
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4TrackSampleBufAvailableSize(mp4 %i, unknown2 %08x)", mp4, unknown2);
 	return 0;
 }
 
-u32 sceMp4CreatesceMp4GetNumberOfMetaData()
+static u32 sceMp4CreatesceMp4GetNumberOfMetaData()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetNumberOfMetaData()");
 	return 0;
 }
 
-u32 sceMp4Delete()
+static u32 sceMp4Delete()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4Delete()");
 	return 0;
 }
 
-u32 sceMp4AacDecodeInitResource(int unknown)
+static u32 sceMp4AacDecodeInitResource(int unknown)
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4AacDecodeInitResource(%i)",unknown);
 	return 0;
 }
 
-u32 sceMp4InitAu(u32 mp4, u32 unknown2, u32 auAddr)
+static u32 sceMp4InitAu(u32 mp4, u32 unknown2, u32 auAddr)
 {
 	// unknown2 = return value of sceMpegAvcResourceGetAvcEsBuf()
 	ERROR_LOG(ME, "UNIMPL sceMp4InitAu(mp4 %i,unknown2 %08x,auAddr %08x)", mp4, unknown2, auAddr);
 	return 0;
 }
 
-u32 sceMp4GetAvcAu(u32 mp4, u32 unknown2, u32 auAddr, u32 unknown4)
+static u32 sceMp4GetAvcAu(u32 mp4, u32 unknown2, u32 auAddr, u32 unknown4)
 {
 	// unknown2 = return value of sceMpegAvcResourceGetAvcEsBuf()
 	ERROR_LOG(ME, "UNIMPL sceMp4InitAu(mp4 %i,unknown2 %08x,auAddr %08x,unknown4 %08x)", mp4, unknown2, auAddr, unknown4);
@@ -115,27 +115,27 @@ u32 sceMp4GetAvcAu(u32 mp4, u32 unknown2, u32 auAddr, u32 unknown4)
 }
 
 
-u32 sceMp4GetAvcTrackInfoData()
+static u32 sceMp4GetAvcTrackInfoData()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetAvcTrackInfoData()");
 	return 0;
 }
 
-u32 sceMp4TrackSampleBufConstruct(u32 mp4, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5, u32 unknown6, u32 unknown7)
+static u32 sceMp4TrackSampleBufConstruct(u32 mp4, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5, u32 unknown6, u32 unknown7)
 {
 	// unknown4 == value returned by sceMp4_BCA9389C
 	ERROR_LOG(ME, "UNIMPL sceMp4TrackSampleBufConstruct(mp4 %i,unknown2 %08x,unknown3 %08x, unknown4 %08x, unknown5 %08x, unknown6 %08x, unknown7 %08x)", mp4, unknown2, unknown3, unknown4, unknown5, unknown6, unknown7);
 	return 0;
 }
 
-u32 sceMp4TrackSampleBufQueryMemSize(u32 unknown1, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5)
+static u32 sceMp4TrackSampleBufQueryMemSize(u32 unknown1, u32 unknown2, u32 unknown3, u32 unknown4, u32 unknown5)
 {
 	u32 value = std::max(unknown2 * unknown3, unknown4 << 1) + (unknown2 << 6) + unknown5 + 256;
 	ERROR_LOG(ME, "sceMp4TrackSampleBufQueryMemSize return %i",value);
 	return value;
 }
 
-u32 sceMp4AacDecode(u32 mp4, u32 auAddr, u32 bufferAddr, u32 init, u32 frequency)
+static u32 sceMp4AacDecode(u32 mp4, u32 auAddr, u32 bufferAddr, u32 init, u32 frequency)
 {
 	// Decode audio:
 	// - init: 1 at first call, 0 afterwards
@@ -146,56 +146,56 @@ u32 sceMp4AacDecode(u32 mp4, u32 auAddr, u32 bufferAddr, u32 init, u32 frequency
 	//return -1;
 }
 
-u32 sceMp4GetAacAu(u32 mp4, u32 unknown2, u32 auAddr, u32 unknown4)
+static u32 sceMp4GetAacAu(u32 mp4, u32 unknown2, u32 auAddr, u32 unknown4)
 {
 	// unknown4: pointer to a 40-bytes structure
 	ERROR_LOG(ME, "sceMp4GetAacAu(mp4 %i,unknown2 %08x,auAddr %08x,unknown4 %i ", mp4, unknown2, auAddr, unknown4);
 	return 0;
 }
 
-u32 sceMp4GetSampleInfo()
+static u32 sceMp4GetSampleInfo()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetSampleInfo()");
 	return 0;
 }
 
-u32 sceMp4GetSampleNumWithTimeStamp()
+static u32 sceMp4GetSampleNumWithTimeStamp()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetSampleNumWithTimeStamp()");
 	return 0;
 }
 
-u32 sceMp4TrackSampleBufFlush()
+static u32 sceMp4TrackSampleBufFlush()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4TrackSampleBufFlush()");
 	return 0;
 }
 
-u32 sceMp4AacDecodeInit(int unknown)
+static u32 sceMp4AacDecodeInit(int unknown)
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4AacDecodeInit(%i)",unknown);
 	return 0;
 }
 
-u32 sceMp4GetAacTrackInfoData()
+static u32 sceMp4GetAacTrackInfoData()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetAacTrackInfoData()");
 	return 0;
 }
 
-u32 sceMp4GetNumberOfMetaData()
+static u32 sceMp4GetNumberOfMetaData()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4GetNumberOfMetaData()");
 	return 0;
 }
 
-u32 sceMp4RegistTrack(u32 mp4, u32 unknown2, u32 unknown3, u32 callbacks, u32 unknown5)
+static u32 sceMp4RegistTrack(u32 mp4, u32 unknown2, u32 unknown3, u32 callbacks, u32 unknown5)
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4RegistTrack(mp4 %i,unknown2 %i,unknown3 %i,callbacks %i unknown5 %i)",mp4,unknown2,unknown3,callbacks,unknown5);
 	return 0;
 }
 
-u32 sceMp4SearchSyncSampleNum()
+static u32 sceMp4SearchSyncSampleNum()
 {
 	ERROR_LOG(ME, "UNIMPL sceMp4SearchSyncSampleNum()");
 	return 0;
@@ -204,7 +204,7 @@ u32 sceMp4SearchSyncSampleNum()
 
 // sceAac module starts from here
 
-u32 sceAacExit(u32 id)
+static u32 sceAacExit(u32 id)
 {
 	INFO_LOG(ME, "sceAacExit(id %i)", id);
 	if (aacMap.find(id) != aacMap.end()) {
@@ -218,7 +218,7 @@ u32 sceAacExit(u32 id)
 	return 0;
 }
 
-u32 sceAacInit(u32 id)
+static u32 sceAacInit(u32 id)
 {
 	INFO_LOG(ME, "UNIMPL sceAacInit(%08x)", id);
 	if (!Memory::IsValidAddress(id)){
@@ -276,20 +276,20 @@ u32 sceAacInit(u32 id)
 	return id;
 }
 
-u32 sceAacInitResource(u32 numberIds)
+static u32 sceAacInitResource(u32 numberIds)
 {
 	// Do nothing here
 	INFO_LOG_REPORT(ME, "sceAacInitResource(%i)", numberIds);
 	return 0;
 }
 
-u32 sceAacTermResource()
+static u32 sceAacTermResource()
 {
 	ERROR_LOG(ME, "UNIMPL sceAacTermResource()");
 	return 0;
 }
 
-u32 sceAacDecode(u32 id, u32 pcmAddr)
+static u32 sceAacDecode(u32 id, u32 pcmAddr)
 {
 	// return the size of output pcm, <0 error
 	DEBUG_LOG(ME, "sceAacDecode(id %i, bufferAddress %08x)", id, pcmAddr);
@@ -302,7 +302,7 @@ u32 sceAacDecode(u32 id, u32 pcmAddr)
 	return ctx->AuDecode(pcmAddr);
 }
 
-u32 sceAacGetLoopNum(u32 id)
+static u32 sceAacGetLoopNum(u32 id)
 {
 	INFO_LOG(ME, "sceAacGetLoopNum(id %i)", id);
 	auto ctx = getAacCtx(id);
@@ -313,7 +313,7 @@ u32 sceAacGetLoopNum(u32 id)
 	return ctx->AuGetLoopNum();
 }
 
-u32 sceAacSetLoopNum(u32 id, int loop)
+static u32 sceAacSetLoopNum(u32 id, int loop)
 {
 	INFO_LOG(ME, "sceAacSetLoopNum(id %i,loop %d)", id, loop);
 	auto ctx = getAacCtx(id);
@@ -325,7 +325,7 @@ u32 sceAacSetLoopNum(u32 id, int loop)
 	return ctx->AuSetLoopNum(loop);
 }
 
-int sceAacCheckStreamDataNeeded(u32 id)
+static int sceAacCheckStreamDataNeeded(u32 id)
 {
 	// return 1 to read more data stream, 0 don't read, <0 error
 	DEBUG_LOG(ME, "sceAacCheckStreamDataNeeded(%i)", id);
@@ -339,7 +339,7 @@ int sceAacCheckStreamDataNeeded(u32 id)
 	return ctx->AuCheckStreamDataNeeded();
 }
 
-u32 sceAacNotifyAddStreamData(u32 id, int size)
+static u32 sceAacNotifyAddStreamData(u32 id, int size)
 {
 	// check how many bytes we have read from source file
 	DEBUG_LOG(ME, "sceAacNotifyAddStreamData(%i, %08x)", id, size);
@@ -353,7 +353,7 @@ u32 sceAacNotifyAddStreamData(u32 id, int size)
 	return ctx->AuNotifyAddStreamData(size);
 }
 
-u32 sceAacGetInfoToAddStreamData(u32 id, u32 buff, u32 size, u32 srcPos)
+static u32 sceAacGetInfoToAddStreamData(u32 id, u32 buff, u32 size, u32 srcPos)
 {
 	// read from stream position srcPos of size bytes into buff
 	DEBUG_LOG(ME, "sceAacGetInfoToAddStreamData(%08X, %08X, %08X, %08X)", id, buff, size, srcPos);
@@ -367,7 +367,7 @@ u32 sceAacGetInfoToAddStreamData(u32 id, u32 buff, u32 size, u32 srcPos)
 	return ctx->AuGetInfoToAddStreamData(buff, size, srcPos);
 }
 
-u32 sceAacGetMaxOutputSample(u32 id)
+static u32 sceAacGetMaxOutputSample(u32 id)
 {
 	DEBUG_LOG(ME, "sceAacGetMaxOutputSample(id %i)", id);
 	auto ctx = getAacCtx(id);
@@ -379,7 +379,7 @@ u32 sceAacGetMaxOutputSample(u32 id)
 	return ctx->AuGetMaxOutputSample();
 }
 
-u32 sceAacGetSumDecodedSample(u32 id)
+static u32 sceAacGetSumDecodedSample(u32 id)
 {
 	DEBUG_LOG(ME, "sceAacGetSumDecodedSample(id %i)", id);
 	auto ctx = getAacCtx(id);
@@ -391,7 +391,7 @@ u32 sceAacGetSumDecodedSample(u32 id)
 	return ctx->AuGetSumDecodedSample();
 }
 
-u32 sceAacResetPlayPosition(u32 id)
+static u32 sceAacResetPlayPosition(u32 id)
 {
 	INFO_LOG(ME, "sceAacResetPlayPosition(id %i)", id);
 	auto ctx = getAacCtx(id);

--- a/Core/HLE/sceMt19937.cpp
+++ b/Core/HLE/sceMt19937.cpp
@@ -17,10 +17,11 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceMt19937.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 
-u32 sceMt19937Init(u32 mt19937Addr, u32 seed)
+static u32 sceMt19937Init(u32 mt19937Addr, u32 seed)
 {
 	WARN_LOG(HLE, "sceMt19937Init(%08x, %08x)", mt19937Addr, seed);
 	if (!Memory::IsValidAddress(mt19937Addr))
@@ -32,7 +33,7 @@ u32 sceMt19937Init(u32 mt19937Addr, u32 seed)
 	return 0;
 }
 
-u32 sceMt19937UInt(u32 mt19937Addr)
+static u32 sceMt19937UInt(u32 mt19937Addr)
 {
 	WARN_LOG(HLE, "sceMt19937UInt(%08x)", mt19937Addr);
 	if (!Memory::IsValidAddress(mt19937Addr))

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -23,6 +23,7 @@
 #include "Common/ChunkFile.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/sceNetAdhoc.h"
 #include "Core/HLE/proAdhoc.h"
 #include "Core/MemMap.h"
 
@@ -187,7 +188,7 @@ void __NetAdhocDoState(PointerWrap &p) {
 	p.Do(adhocctlHandlers);
 }
 
-void __UpdateAdhocctlHandlers(int flag, int error) {
+static void __UpdateAdhocctlHandlers(int flag, int error) {
 	u32 args[3] = { 0, 0, 0 };
 	args[0] = flag;
 	args[1] = error;
@@ -198,7 +199,7 @@ void __UpdateAdhocctlHandlers(int flag, int error) {
 	}
 }
 
-int getBlockingFlag(int id) {
+static int getBlockingFlag(int id) {
 #ifdef _MSC_VER
 	return 0;
 #else
@@ -207,13 +208,13 @@ int getBlockingFlag(int id) {
 #endif
 }
 
-void __handlerUpdateCallback(u64 userdata, int cycleslate) {
+static void __handlerUpdateCallback(u64 userdata, int cycleslate) {
 	int buff[2];
 	split64(userdata,buff);
 	__UpdateAdhocctlHandlers(buff[0], buff[1]);
 }
 
-u32 sceNetAdhocInit() {
+static u32 sceNetAdhocInit() {
 	// Library uninitialized
 	INFO_LOG(SCENET, "sceNetAdhocInit() at %08x", currentMIPS->pc);
 	if (!netAdhocInited) {
@@ -231,7 +232,7 @@ u32 sceNetAdhocInit() {
 	return ERROR_NET_ADHOC_ALREADY_INITIALIZED;
 }
 
-u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
+static u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	INFO_LOG(SCENET, "sceNetAdhocctlInit(%i, %i, %08x) at %08x", stackSize, prio, productAddr, currentMIPS->pc);
 	if (netAdhocctlInited) {
 		return ERROR_NET_ADHOCCTL_ALREADY_INITIALIZED;
@@ -255,7 +256,7 @@ u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	return 0;
 }
 
-int sceNetAdhocctlGetState(u32 ptrToStatus) {
+static int sceNetAdhocctlGetState(u32 ptrToStatus) {
 	// Library initialized
 	if (netAdhocctlInited) {
 		// Valid Arguments
@@ -283,7 +284,7 @@ int sceNetAdhocctlGetState(u32 ptrToStatus) {
  * @return Socket ID > 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_SOCKET_ID_NOT_AVAIL, ADHOC_INVALID_ADDR, ADHOC_PORT_NOT_AVAIL, ADHOC_INVALID_PORT, ADHOC_PORT_IN_USE, NET_NO_SPACE
  */
 // When choosing AdHoc menu in Wipeout Pulse sometimes it's saying that "WLAN is turned off" on game screen and getting "kUnityCommandCode_MediaDisconnected" error in the Log Console when calling sceNetAdhocPdpCreate, probably it needed to wait something from the thread before calling this (ie. need to receives 7 bytes from adhoc server 1st?)
-int sceNetAdhocPdpCreate(const char *mac, u32 port, int bufferSize, u32 unknown) {
+static int sceNetAdhocPdpCreate(const char *mac, u32 port, int bufferSize, u32 unknown) {
 	INFO_LOG(SCENET, "sceNetAdhocPdpCreate(%p, %u, %u, %u) at %08x", mac, port, bufferSize, unknown, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -401,7 +402,7 @@ int sceNetAdhocPdpCreate(const char *mac, u32 port, int bufferSize, u32 unknown)
  * @param parameter OUT: Adhoc Parameter
  * @return 0 on success or... ADHOCCTL_NOT_INITIALIZED, ADHOCCTL_INVALID_ARG
  */
-int sceNetAdhocctlGetParameter(u32 paramAddr) {
+static int sceNetAdhocctlGetParameter(u32 paramAddr) {
 	DEBUG_LOG(SCENET, "sceNetAdhocctlGetParameter(%u)",paramAddr);
 	if (!g_Config.bEnableWlan) {
 		return ERROR_NET_ADHOCCTL_DISCONNECTED;
@@ -436,7 +437,7 @@ int sceNetAdhocctlGetParameter(u32 paramAddr) {
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_INVALID_ARG, ADHOC_NOT_INITIALIZED, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_INVALID_ADDR, ADHOC_INVALID_PORT, ADHOC_INVALID_DATALEN, ADHOC_SOCKET_ALERTED, ADHOC_TIMEOUT, ADHOC_THREAD_ABORTED, ADHOC_WOULD_BLOCK, NET_NO_SPACE, NET_INTERNAL
  */
-int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, int timeout, int flag) {
+static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, int timeout, int flag) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPdpSend(%i, %p, %i, %p, %i, %i, %i)", id, mac, port, data, len, timeout, flag);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -602,7 +603,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_INVALID_ARG, ADHOC_NOT_INITIALIZED, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_SOCKET_ALERTED, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_NOT_ENOUGH_SPACE, ADHOC_THREAD_ABORTED, NET_INTERNAL
  */
-int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLength, u32 timeout, int flag) {
+static int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLength, u32 timeout, int flag) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPdpRecv(%i, %p, %p, %p, %p, %i, %i) at %08x", id, addr, port, buf, dataLength, timeout, flag, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -722,12 +723,12 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 }
 
 // Assuming < 0 for failure, homebrew SDK doesn't have much to say about this one..
-int sceNetAdhocSetSocketAlert(int id, int flag) {
- 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocSetSocketAlert(%d, %d)", id, flag);
+static int sceNetAdhocSetSocketAlert(int id, int flag) {
+	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocSetSocketAlert(%d, %d)", id, flag);
 	return -1;
 }
 
-int sceNetAdhocPollSocket(u32 socketStructAddr, int count, int timeout, int nonblock) {
+static int sceNetAdhocPollSocket(u32 socketStructAddr, int count, int timeout, int nonblock) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocPollSocket(%08x, %i, %i, %i)", socketStructAddr, count, timeout, nonblock);
 	return -1;
 }
@@ -738,7 +739,7 @@ int sceNetAdhocPollSocket(u32 socketStructAddr, int count, int timeout, int nonb
  * @param flag Bitflags (Unused)
  * @return 0 on success or... ADHOC_INVALID_ARG, ADHOC_NOT_INITIALIZED, ADHOC_INVALID_SOCKET_ID
  */
-int sceNetAdhocPdpDelete(int id, int unknown) {
+static int sceNetAdhocPdpDelete(int id, int unknown) {
 	// WLAN might be disabled in the middle of successfull multiplayer, but we still need to cleanup right?
 	INFO_LOG(SCENET, "sceNetAdhocPdpDelete(%d, %d) at %08x", id, unknown, currentMIPS->pc);
 	/*
@@ -784,12 +785,12 @@ int sceNetAdhocPdpDelete(int id, int unknown) {
 	return ERROR_NET_ADHOC_NOT_INITIALIZED;
 }
 
-int sceNetAdhocctlGetAdhocId(u32 productStructAddr) {
+static int sceNetAdhocctlGetAdhocId(u32 productStructAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlGetAdhocId(%x)", productStructAddr);
 	return 0;
 }
 
-int sceNetAdhocctlScan() {
+static int sceNetAdhocctlScan() {
 	INFO_LOG(SCENET, "sceNetAdhocctlScan() at %08x", currentMIPS->pc);
 
 	// Library initialized
@@ -840,7 +841,7 @@ int sceNetAdhocctlScan() {
 	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
 }
 
-int sceNetAdhocctlGetScanInfo(u32 size, u32 bufAddr) {
+static int sceNetAdhocctlGetScanInfo(u32 size, u32 bufAddr) {
 	INFO_LOG(SCENET, "sceNetAdhocctlGetScanInfo([%08x]=%i, %08x)", size, Memory::Read_U32(size), bufAddr);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -931,7 +932,7 @@ int sceNetAdhocctlGetScanInfo(u32 size, u32 bufAddr) {
 
 // TODO: How many handlers can the PSP actually have for Adhocctl?
 // TODO: Should we allow the same handler to be added more than once?
-u32 sceNetAdhocctlAddHandler(u32 handlerPtr, u32 handlerArg) {
+static u32 sceNetAdhocctlAddHandler(u32 handlerPtr, u32 handlerArg) {
 	bool foundHandler = false;
 	u32 retval = 0;
 	struct AdhocctlHandler handler;
@@ -970,7 +971,7 @@ u32 sceNetAdhocctlAddHandler(u32 handlerPtr, u32 handlerArg) {
 	return retval;
 }
 
-u32 sceNetAdhocctlDisconnect() {
+static u32 sceNetAdhocctlDisconnect() {
 	// WLAN might be disabled in the middle of successfull multiplayer, but we still need to cleanup right?
 	INFO_LOG(SCENET, "sceNetAdhocctlDisconnect() at %08x", currentMIPS->pc);
 	/*
@@ -1037,7 +1038,7 @@ u32 sceNetAdhocctlDisconnect() {
 	return 0; //ERROR_NET_ADHOC_NOT_INITIALIZED; // Wipeout Pulse will repeatedly calling this function if returned value is ERROR_NET_ADHOC_NOT_INITIALIZED
 }
 
-u32 sceNetAdhocctlDelHandler(u32 handlerID) {
+static u32 sceNetAdhocctlDelHandler(u32 handlerID) {
 	if (adhocctlHandlers.find(handlerID) != adhocctlHandlers.end()) {
 		adhocctlHandlers.erase(handlerID);
 		WARN_LOG(SCENET, "UNTESTED sceNetAdhocctlDelHandler(%d): deleted handler %d", handlerID, handlerID);
@@ -1077,12 +1078,12 @@ int sceNetAdhocctlTerm() {
 	return 0;
 }
 
-int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
+static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlGetNameByAddr(%s, %08x)", mac, nameAddr);
 	return -1;
 }
 
-int sceNetAdhocctlJoin(u32 scanInfoAddr) {
+static int sceNetAdhocctlJoin(u32 scanInfoAddr) {
 	WARN_LOG(SCENET, "UNTESTED sceNetAdhocctlJoin(%08x) at %08x", scanInfoAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -1145,7 +1146,7 @@ int sceNetAdhocctlJoin(u32 scanInfoAddr) {
 	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
 }
 
-int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
+static int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlGetPeerInfo(%s, %i, %08x)", mac, size, peerInfoAddr);
 	return -1;
 }
@@ -1224,7 +1225,7 @@ int sceNetAdhocctlCreate(const char *groupName) {
 	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
 }
 
-int sceNetAdhocctlConnect(u32 ptrToGroupName) {
+static int sceNetAdhocctlConnect(u32 ptrToGroupName) {
 	if (Memory::IsValidAddress(ptrToGroupName)) {
 		INFO_LOG(SCENET, "sceNetAdhocctlConnect(groupName=%s) at %08x", Memory::GetCharPointer(ptrToGroupName), currentMIPS->pc);
 		return sceNetAdhocctlCreate(Memory::GetCharPointer(ptrToGroupName));
@@ -1233,12 +1234,12 @@ int sceNetAdhocctlConnect(u32 ptrToGroupName) {
 	}
 }
 
-int sceNetAdhocctlCreateEnterGameMode(const char *groupName, int unknown, int playerNum, u32 macsAddr, int timeout, int unknown2) {
+static int sceNetAdhocctlCreateEnterGameMode(const char *groupName, int unknown, int playerNum, u32 macsAddr, int timeout, int unknown2) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlCreateEnterGameMode(%s, %i, %i, %08x, %i, %i) at %08x", groupName, unknown, playerNum, macsAddr, timeout, unknown2, currentMIPS->pc);
 	return -1;
 }
 
-int sceNetAdhocctlJoinEnterGameMode(const char *groupName, const char *macAddr, int timeout, int unknown2) {
+static int sceNetAdhocctlJoinEnterGameMode(const char *groupName, const char *macAddr, int timeout, int unknown2) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlJoinEnterGameMode(%s, %s, %i, %i) at %08x", groupName, macAddr, timeout, unknown2, currentMIPS->pc);
 	return -1;
 }
@@ -1278,7 +1279,7 @@ int sceNetAdhocTerm() {
 	}
 }
 
-int sceNetAdhocGetPdpStat(int structSize, u32 structAddr) {
+static int sceNetAdhocGetPdpStat(int structSize, u32 structAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGetPdpStat(%i, %08x)", structSize, structAddr);
 	return 0;
 }
@@ -1290,7 +1291,7 @@ int sceNetAdhocGetPdpStat(int structSize, u32 structAddr) {
  * @param buf PTP Socket List Buffer (can be NULL if you wish to receive Required Length)
  * @return 0 on success or... ADHOC_INVALID_ARG, ADHOC_NOT_INITIALIZED
  */
-int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
+static int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
 	// Spams a lot 
 	VERBOSE_LOG(SCENET,"sceNetAdhocGetPtpStat(%u,%u)",structSize,structAddr);
 
@@ -1373,7 +1374,7 @@ int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
  * @param flag Bitflags (Unused)
  * @return Socket ID > 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_ADDR, ADHOC_INVALID_PORT
  */
-int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac, int dport, int bufsize, int rexmt_int, int rexmt_cnt, int unknown) {
+static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac, int dport, int bufsize, int rexmt_int, int rexmt_cnt, int unknown) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPtpOpen(%s,%d,%s,%d,%d,%d,%d,%d)", srcmac, sport, dstmac,dport,bufsize, rexmt_int, rexmt_cnt, unknown);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -1491,7 +1492,7 @@ int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac, int dp
  * @param flag Nonblocking Flag
  * @return Socket ID >= 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_SOCKET_ALERTED, ADHOC_SOCKET_ID_NOT_AVAIL, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_NOT_LISTENED, ADHOC_THREAD_ABORTED, NET_INTERNAL
  */
-int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int timeout, int flag) {
+static int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int timeout, int flag) {
 
 	SceNetEtherAddr * addr = NULL;
 	if (Memory::IsValidAddress(peerMacAddrPtr)) {
@@ -1652,7 +1653,7 @@ int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int timeou
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_CONNECTION_REFUSED, ADHOC_SOCKET_ALERTED, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_NOT_OPENED, ADHOC_THREAD_ABORTED, NET_INTERNAL
  */
-int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
+static int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPtpConnect(%i, %i, %08x)", id, timeout, flag);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -1766,7 +1767,7 @@ int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
  * @param flag Bitflags (Unused)
  * @return 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED
  */
-int sceNetAdhocPtpClose(int id, int unknown) {
+static int sceNetAdhocPtpClose(int id, int unknown) {
 	DEBUG_LOG(SCENET,"sceNetAdhocPtpClose(%d,%d)",id,unknown);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -1814,7 +1815,7 @@ int sceNetAdhocPtpClose(int id, int unknown) {
  * @param flag Bitflags (Unused)
  * @return Socket ID > 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_ADDR, ADHOC_INVALID_PORT, ADHOC_SOCKET_ID_NOT_AVAIL, ADHOC_PORT_NOT_AVAIL, ADHOC_PORT_IN_USE, NET_NO_SPACE
  */
-int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int rexmt_int, int rexmt_cnt, int backlog, int unk) {
+static int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int rexmt_int, int rexmt_cnt, int backlog, int unk) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPtpListen(%p,%d,%d,%d,%d,%d,%d)",srcmac,sport,bufsize,rexmt_int,rexmt_cnt,backlog,unk);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -1933,7 +1934,7 @@ int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int rexmt_i
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_SOCKET_ALERTED, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_NOT_CONNECTED, ADHOC_THREAD_ABORTED, ADHOC_INVALID_DATALEN, ADHOC_DISCONNECTED, NET_INTERNAL, NET_NO_SPACE
  */
-int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int flag) {
+static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int flag) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPtpSend(%d,%08x,%08x,%d,%d)", id, dataAddr, dataSizeAddr, timeout, flag);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -2020,7 +2021,7 @@ int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int 
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_SOCKET_ALERTED, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_THREAD_ABORTED, ADHOC_DISCONNECTED, NET_INTERNAL
  */
-int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int flag) {
+static int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int flag) {
 	DEBUG_LOG(SCENET, "sceNetAdhocPtpRecv(%d,%08x,%08x,%d,%d)", id, dataAddr, dataSizeAddr, timeout, flag);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -2098,7 +2099,7 @@ int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeout, int 
  * @param flag Nonblocking Flag
  * @return 0 on success or... ADHOC_NOT_INITIALIZED, ADHOC_INVALID_ARG, ADHOC_INVALID_SOCKET_ID, ADHOC_SOCKET_DELETED, ADHOC_SOCKET_ALERTED, ADHOC_WOULD_BLOCK, ADHOC_TIMEOUT, ADHOC_THREAD_ABORTED, ADHOC_DISCONNECTED, ADHOC_NOT_CONNECTED, NET_INTERNAL
  */
-int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
+static int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
 	DEBUG_LOG(SCENET,"sceNetAdhocPtpFlush(%d,%d,%d)", id, timeout, nonblock);
 	if (!g_Config.bEnableWlan) {
 		return 0;
@@ -2119,42 +2120,42 @@ int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
 	return ERROR_NET_ADHOC_NOT_INITIALIZED;
 }
 
-int sceNetAdhocGameModeCreateMaster(u32 data, int size) {
+static int sceNetAdhocGameModeCreateMaster(u32 data, int size) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeCreateMaster(%08x, %i) at %08x", data, size, currentMIPS->pc);
 	return -1;
 }
 
-int sceNetAdhocGameModeCreateReplica(const char *mac, u32 data, int size) {
+static int sceNetAdhocGameModeCreateReplica(const char *mac, u32 data, int size) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeCreateReplica(%s, %08x, %i) at %08x", mac, data, size, currentMIPS->pc);
 	return -1;
 }
 
-int sceNetAdhocGameModeUpdateMaster() {
+static int sceNetAdhocGameModeUpdateMaster() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeUpdateMaster()");
 	return -1;
 }
 
-int sceNetAdhocGameModeDeleteMaster() {
+static int sceNetAdhocGameModeDeleteMaster() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeDeleteMaster()");
 	return -1;
 }
 
-int sceNetAdhocGameModeUpdateReplica(int id, u32 infoAddr) {
+static int sceNetAdhocGameModeUpdateReplica(int id, u32 infoAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeUpdateReplica(%i, %08x)", id, infoAddr);
 	return -1;
 }
 
-int sceNetAdhocGameModeDeleteReplica(int id) {
+static int sceNetAdhocGameModeDeleteReplica(int id) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGameModeDeleteReplica(%i)", id);
 	return -1;
 }
 
-int sceNetAdhocGetSocketAlert() {
+static int sceNetAdhocGetSocketAlert() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocGetSocketAlert()");
 	return 0;
 }
 
-int sceNetAdhocMatchingInit(u32 memsize) {
+static int sceNetAdhocMatchingInit(u32 memsize) {
 	INFO_LOG(SCENET, "sceNetAdhocMatchingInit(%d) at %08x", memsize, currentMIPS->pc);
 	// Uninitialized Library
 	if (!netAdhocMatchingInited) {
@@ -2188,7 +2189,7 @@ int sceNetAdhocMatchingTerm() {
 
 
 // Presumably returns a "matchingId".
-int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbuflen, int hello_int, int keepalive_int, int init_count, int rexmt_int, u32 callbackAddr) {
+static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbuflen, int hello_int, int keepalive_int, int init_count, int rexmt_int, u32 callbackAddr) {
 	INFO_LOG(SCENET, "sceNetAdhocMatchingCreate(mode=%i, maxnum=%i, port=%i, rxbuflen=%i, hello=%i, keepalive=%i, initcount=%i, rexmt=%i, callbackAddr=%08x) at %08x", mode, maxnum, port, rxbuflen, hello_int, keepalive_int, init_count, rexmt_int, callbackAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -2298,7 +2299,7 @@ int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbuflen, int 
 }
 
 // TODO: Should we execute the callback used to create the Matching Id if it's a valid address?
-int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, int inthPri, int inthStack, int optLen, u32 optDataAddr) {
+static int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, int inthPri, int inthStack, int optLen, u32 optDataAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingStart(%i, %i, %i, %i, %i, %i, %08x) at %08x", matchingId, evthPri, evthStack, inthPri, inthStack, optLen, optDataAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan)
 		return -1;
@@ -2330,7 +2331,7 @@ int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, int int
 	return 0;
 }
 
-int sceNetAdhocMatchingStop(int matchingId) {
+static int sceNetAdhocMatchingStop(int matchingId) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingStop(%i)", matchingId);
 	if (!g_Config.bEnableWlan)
 		return -1;
@@ -2349,7 +2350,7 @@ int sceNetAdhocMatchingStop(int matchingId) {
 	return 0;
 }
 
-int sceNetAdhocMatchingDelete(int matchingId) {
+static int sceNetAdhocMatchingDelete(int matchingId) {
 	// WLAN might be disabled in the middle of successfull multiplayer, but we still need to cleanup right?
 	/*
 	if (!g_Config.bEnableWlan)
@@ -2399,28 +2400,28 @@ int sceNetAdhocMatchingDelete(int matchingId) {
 	return 0;
 }
 
-int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
+static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingSelectTarget(%i, %s, %i, %08x)", matchingId, macAddress, optLen, optDataPtr);
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingCancelTargetWithOpt(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
+static int sceNetAdhocMatchingCancelTargetWithOpt(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingCancelTargetWithOpt(%i, %s, %i, %08x)", matchingId, macAddress, optLen, optDataPtr);
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingCancelTarget(int matchingId, const char *macAddress) {
+static int sceNetAdhocMatchingCancelTarget(int matchingId, const char *macAddress) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingCancelTarget(%i, %s)", matchingId, macAddress);
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAddr) {
+static int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingGetHelloOpt(%i, %08x, %08x)", matchingId, optLenAddr, optDataAddr);
 	if (!g_Config.bEnableWlan)
 		return -1;
@@ -2462,7 +2463,7 @@ int sceNetAdhocMatchingSetHelloOpt(int matchingId, int optLenAddr, u32 optDataAd
 	return 0;
 }
 
-int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) {
+static int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) {
 	DEBUG_LOG(SCENET, "UNTESTED sceNetAdhocMatchingGetMembers(%i, [%08x]=%i, %08x) at %08x", matchingId, sizeAddr, Memory::Read_U32(sizeAddr), buf, currentMIPS->pc);
 	if (!g_Config.bEnableWlan)
 		return -1;
@@ -2523,28 +2524,28 @@ int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) {
 	return 0;
 }
 
-int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u32 dataAddr) {
+static int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u32 dataAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingSendData(%i, %s, %i, %08x)", matchingId, mac, dataLen, dataAddr);
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
+static int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingAbortSendData(%i, %s)", matchingId, mac);
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingGetPoolMaxAlloc() {
+static int sceNetAdhocMatchingGetPoolMaxAlloc() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingGetPoolMaxAlloc()");
 	if (!g_Config.bEnableWlan)
 		return -1;
 	return 0;
 }
 
-int sceNetAdhocMatchingGetPoolStat() {
+static int sceNetAdhocMatchingGetPoolStat() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocMatchingGetPoolStat()");
 	if (!g_Config.bEnableWlan)
 		return -1;
@@ -2599,18 +2600,18 @@ const HLEFunction sceNetAdhocMatching[] = {
 	{0x9c5cfb7d, WrapI_V<sceNetAdhocMatchingGetPoolStat>, "sceNetAdhocMatchingGetPoolStat"},
 };
 
-int sceNetAdhocctlExitGameMode() {
+static int sceNetAdhocctlExitGameMode() {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlExitGameMode()");
 	return -1;
 }
 
-int sceNetAdhocctlGetGameModeInfo(u32 infoAddr) {
+static int sceNetAdhocctlGetGameModeInfo(u32 infoAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlGetGameModeInfo(%08x)", infoAddr);
 	return -1;
 }
 
 
-int sceNetAdhocctlGetPeerList(u32 sizeAddr, u32 bufAddr) {
+static int sceNetAdhocctlGetPeerList(u32 sizeAddr, u32 bufAddr) {
 	INFO_LOG(SCENET, "sceNetAdhocctlGetPeerList(%08x, %08x) at %08x", sizeAddr, bufAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return -1;
@@ -2690,7 +2691,7 @@ int sceNetAdhocctlGetPeerList(u32 sizeAddr, u32 bufAddr) {
 	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
 }
 
-int sceNetAdhocctlGetAddrByName(const char *nickName, u32 sizeAddr, u32 bufAddr) {
+static int sceNetAdhocctlGetAddrByName(const char *nickName, u32 sizeAddr, u32 bufAddr) {
 	ERROR_LOG(SCENET, "UNIMPL sceNetAdhocctlGetPeerList(%s, %08x, %08x)", nickName, sizeAddr, bufAddr);
 	return -1;
 }

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -23,14 +23,14 @@
 
 #include "Core/HLE/sceNp.h"
 
-int sceNp_857B47D3()
+static int sceNp_857B47D3()
 {
 	// No parameters
 	ERROR_LOG(HLE, "UNIMPL sceNp_857B47D3()");
 	return 0;
 }
 
-int sceNp_37E1E274()
+static int sceNp_37E1E274()
 {
 	// No parameters
 	ERROR_LOG(HLE, "UNIMPL sceNp_37E1E274()");
@@ -47,14 +47,14 @@ void Register_sceNp()
 	RegisterModule("sceNp", ARRAY_SIZE(sceNp), sceNp);
 }
 
-int sceNpAuth_4EC1F667() 
+static int sceNpAuth_4EC1F667()
 {
 	// No parameters
 	ERROR_LOG(HLE, "UNIMPL sceNpAuth_4EC1F667()");
 	return 0;
 }
 
-int sceNpAuth_A1DE86F8(u32 poolSize, u32 stackSize, u32 threadPrio) 
+static int sceNpAuth_A1DE86F8(u32 poolSize, u32 stackSize, u32 threadPrio)
 {
 	ERROR_LOG(HLE, "UNIMPL sceNpAuth_A1DE86F8(%08x, %08x, %08x)",poolSize, stackSize, threadPrio);
 	return 0;
@@ -70,14 +70,14 @@ void Register_sceNpAuth()
 	RegisterModule("sceNpAuth", ARRAY_SIZE(sceNpAuth), sceNpAuth);
 }
 
-int sceNpService_00ACFAC3() 
+static int sceNpService_00ACFAC3()
 {
 	// No parameters
 	ERROR_LOG(HLE, "UNIMPL sceNpService_00ACFAC3()");
 	return 0;
 }
 
-int sceNpService_0F8F5821(u32 poolSize, u32 stackSize, u32 threadPrio) 
+static int sceNpService_0F8F5821(u32 poolSize, u32 stackSize, u32 threadPrio)
 {
 	ERROR_LOG(HLE, "UNIMPL sceNpService_0F8F5821(%08x, %08x, %08x)",poolSize, stackSize, threadPrio);
 	return 0;

--- a/Core/HLE/sceOpenPSID.cpp
+++ b/Core/HLE/sceOpenPSID.cpp
@@ -20,7 +20,7 @@
 #include "Core/HLE/sceOpenPSID.h"
 #include "Core/MemMap.h"
 
-int sceOpenPSIDGetOpenPSID(u32 OpenPSIDPtr)
+static int sceOpenPSIDGetOpenPSID(u32 OpenPSIDPtr)
 {
 	ERROR_LOG(HLE, "UNTESTED sceOpenPSIDGetOpenPSID(%d)", OpenPSIDPtr);
 	u8 dummyOpenPSID[16] = {0x10, 0x02, 0xA3, 0x44, 0x13, 0xF5, 0x93, 0xB0, 0xCC, 0x6E, 0xD1, 0x32, 0x27, 0x85, 0x0F, 0x9D};

--- a/Core/HLE/sceP3da.cpp
+++ b/Core/HLE/sceP3da.cpp
@@ -17,17 +17,18 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceP3da.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 
 
-u32 sceP3daBridgeInit(u32 channelsNum, u32 samplesNum)
+static u32 sceP3daBridgeInit(u32 channelsNum, u32 samplesNum)
 {
 	ERROR_LOG_REPORT(SCEAUDIO, "UNIMPL sceP3daBridgeInit(%08x, %08x)", channelsNum, samplesNum);
 	return 0;
 }
 
-u32 sceP3daBridgeExit()
+static u32 sceP3daBridgeExit()
 {
 	ERROR_LOG_REPORT(SCEAUDIO, "UNIMPL sceP3daBridgeExit()");
 	return 0;
@@ -42,7 +43,7 @@ static inline int getScaleValue(u32 channelsNum) {
 	return val;
 }
 
-u32 sceP3daBridgeCore(u32 p3daCoreAddr, u32 channelsNum, u32 samplesNum, u32 inputAddr, u32 outputAddr)
+static u32 sceP3daBridgeCore(u32 p3daCoreAddr, u32 channelsNum, u32 samplesNum, u32 inputAddr, u32 outputAddr)
 {
 	DEBUG_LOG(SCEAUDIO, "sceP3daBridgeCore(%08x, %08x, %08x, %08x, %08x)", p3daCoreAddr, channelsNum, samplesNum, inputAddr, outputAddr);
 	if (Memory::IsValidAddress(inputAddr) && Memory::IsValidAddress(outputAddr)) {

--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -25,7 +25,7 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
 
-int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
+static int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
 	u8 *src, *key;
 	u32 crc;
@@ -73,7 +73,7 @@ int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea
 	return -1;
 }
 
-int scePauth_98B83B5D(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
+static int scePauth_98B83B5D(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
 	u8 *src, *key;
 	u32 crc;

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -85,49 +85,49 @@ void __PowerDoState(PointerWrap &p) {
 	p.Do(volatileWaitingThreads);
 }
 
-int scePowerGetBatteryLifePercent() {
+static int scePowerGetBatteryLifePercent() {
 	DEBUG_LOG(HLE, "100=scePowerGetBatteryLifePercent");
 	return 100;
 }
 
-int scePowerGetBatteryLifeTime() {
+static int scePowerGetBatteryLifeTime() {
 	DEBUG_LOG(HLE, "0=scePowerGetBatteryLifeTime()");
 	// 0 means we're on AC power.
 	return 0;
 }
 
-int scePowerGetBatteryTemp() {
+static int scePowerGetBatteryTemp() {
 	DEBUG_LOG(HLE, "0=scePowerGetBatteryTemp()");
 	// 0 means celsius temperature of the battery
 	return 0;
 }
 
-int scePowerIsPowerOnline() {
+static int scePowerIsPowerOnline() {
 	DEBUG_LOG(HLE, "1=scePowerIsPowerOnline");
 	return 1;
 }
 
-int scePowerIsBatteryExist() {
+static int scePowerIsBatteryExist() {
 	DEBUG_LOG(HLE, "1=scePowerIsBatteryExist");
 	return 1;
 }
 
-int scePowerIsBatteryCharging() {
+static int scePowerIsBatteryCharging() {
 	DEBUG_LOG(HLE, "0=scePowerIsBatteryCharging");
 	return 0;
 }
 
-int scePowerGetBatteryChargingStatus() {
+static int scePowerGetBatteryChargingStatus() {
 	DEBUG_LOG(HLE, "0=scePowerGetBatteryChargingStatus");
 	return 0;
 }
 
-int scePowerIsLowBattery() {
+static int scePowerIsLowBattery() {
 	DEBUG_LOG(HLE, "0=scePowerIsLowBattery");
 	return 0;
 }
 
-int scePowerRegisterCallback(int slot, int cbId) {
+static int scePowerRegisterCallback(int slot, int cbId) {
 	DEBUG_LOG(HLE, "0=scePowerRegisterCallback(%i, %i)", slot, cbId);
 
 	if (slot < -1 || slot >= numberOfCBPowerSlotsPrivate) {
@@ -168,7 +168,7 @@ int scePowerRegisterCallback(int slot, int cbId) {
 	return retval;
 }
 
-int scePowerUnregisterCallback(int slotId) {
+static int scePowerUnregisterCallback(int slotId) {
 	DEBUG_LOG(HLE, "0=scePowerUnregisterCallback(%i)", slotId);
 
 	if (slotId < 0 || slotId >= numberOfCBPowerSlotsPrivate) {
@@ -189,7 +189,7 @@ int scePowerUnregisterCallback(int slotId) {
 	return 0;
 }
 
-int sceKernelPowerLock(int lockType) {
+static int sceKernelPowerLock(int lockType) {
 	DEBUG_LOG(HLE, "0=sceKernelPowerLock(%i)", lockType);
 	if (lockType == 0) {
 		return 0;
@@ -198,7 +198,7 @@ int sceKernelPowerLock(int lockType) {
 	}
 }
 
-int sceKernelPowerUnlock(int lockType) {
+static int sceKernelPowerUnlock(int lockType) {
 	DEBUG_LOG(HLE, "0=sceKernelPowerUnlock(%i)", lockType);
 	if (lockType == 0) {
 		return 0;
@@ -207,12 +207,12 @@ int sceKernelPowerUnlock(int lockType) {
 	}
 }
 
-int sceKernelPowerTick(int flag) {
+static int sceKernelPowerTick(int flag) {
 	DEBUG_LOG(HLE, "UNIMPL 0=sceKernelPowerTick(%i)", flag);
 	return 0;
 }
 
-int __KernelVolatileMemLock(int type, u32 paddr, u32 psize) {
+static int __KernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 	if (type != 0) {
 		return SCE_KERNEL_ERROR_INVALID_MODE;
 	}
@@ -234,7 +234,7 @@ int __KernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 	return 0;
 }
 
-int sceKernelVolatileMemTryLock(int type, u32 paddr, u32 psize) {
+static int sceKernelVolatileMemTryLock(int type, u32 paddr, u32 psize) {
 	u32 error = __KernelVolatileMemLock(type, paddr, psize);
 
 	switch (error) {
@@ -259,7 +259,7 @@ int sceKernelVolatileMemTryLock(int type, u32 paddr, u32 psize) {
 	return error;
 }
 
-int sceKernelVolatileMemUnlock(int type) {
+static int sceKernelVolatileMemUnlock(int type) {
 	if (type != 0) {
 		ERROR_LOG_REPORT(HLE, "sceKernelVolatileMemUnlock(%i) - invalid mode", type);
 		return SCE_KERNEL_ERROR_INVALID_MODE;
@@ -296,7 +296,7 @@ int sceKernelVolatileMemUnlock(int type) {
 	return 0;
 }
 
-int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
+static int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 	u32 error = 0;
 
 	// If dispatch is disabled or in an interrupt, don't check, just return an error.
@@ -353,7 +353,7 @@ int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 }
 
 
-u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
+static u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 	if (g_Config.iLockedCPUSpeed > 0) {
 		INFO_LOG(HLE,"scePowerSetClockFrequency(%i,%i,%i): locked by user config at %i, %i, %i", pllfreq, cpufreq, busfreq, g_Config.iLockedCPUSpeed, g_Config.iLockedCPUSpeed, busFreq);
 	}
@@ -371,7 +371,7 @@ u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 	return 0;
 }
 
-u32 scePowerSetCpuClockFrequency(u32 cpufreq) {
+static u32 scePowerSetCpuClockFrequency(u32 cpufreq) {
 	if(g_Config.iLockedCPUSpeed > 0) {
 		DEBUG_LOG(HLE,"scePowerSetCpuClockFrequency(%i): locked by user config at %i", cpufreq, g_Config.iLockedCPUSpeed);
 	}
@@ -386,7 +386,7 @@ u32 scePowerSetCpuClockFrequency(u32 cpufreq) {
 	return 0;
 }
 
-u32 scePowerSetBusClockFrequency(u32 busfreq) {
+static u32 scePowerSetBusClockFrequency(u32 busfreq) {
 	if(g_Config.iLockedCPUSpeed > 0) {
 		DEBUG_LOG(HLE,"scePowerSetBusClockFrequency(%i): locked by user config at %i", busfreq, busFreq);
 	}
@@ -402,46 +402,46 @@ u32 scePowerSetBusClockFrequency(u32 busfreq) {
 	return 0;
 }
 
-u32 scePowerGetCpuClockFrequencyInt() {
+static u32 scePowerGetCpuClockFrequencyInt() {
 	int cpuFreq = CoreTiming::GetClockFrequencyMHz();
 	DEBUG_LOG(HLE,"%i=scePowerGetCpuClockFrequencyInt()", cpuFreq);
 	return cpuFreq;
 }
 
-u32 scePowerGetPllClockFrequencyInt() {
+static u32 scePowerGetPllClockFrequencyInt() {
 	INFO_LOG(HLE,"%i=scePowerGetPllClockFrequencyInt()", pllFreq);
 	return pllFreq;
 }
 
-u32 scePowerGetBusClockFrequencyInt() {
+static u32 scePowerGetBusClockFrequencyInt() {
 	INFO_LOG(HLE,"%i=scePowerGetBusClockFrequencyInt()", busFreq);
 	return busFreq;
 }
 
-float scePowerGetCpuClockFrequencyFloat() {
+static float scePowerGetCpuClockFrequencyFloat() {
 	int cpuFreq = CoreTiming::GetClockFrequencyMHz(); 
 	INFO_LOG(HLE, "%f=scePowerGetCpuClockFrequencyFloat()", (float)cpuFreq);
 	return (float) cpuFreq;
 }
 
-float scePowerGetPllClockFrequencyFloat() {
+static float scePowerGetPllClockFrequencyFloat() {
 	INFO_LOG(HLE, "%f=scePowerGetPllClockFrequencyFloat()", (float)pllFreq);
 	return (float) pllFreq;
 }
 
-float scePowerGetBusClockFrequencyFloat() {
+static float scePowerGetBusClockFrequencyFloat() {
 	INFO_LOG(HLE, "%f=scePowerGetBusClockFrequencyFloat()", (float)busFreq);
 	return (float) busFreq;
 }
 
-int scePowerTick() {
+static int scePowerTick() {
 	DEBUG_LOG(HLE, "scePowerTick()");
 	// Don't think we need to do anything.
 	return 0;
 }
 
 
-u32 IsPSPNonFat() {
+static u32 IsPSPNonFat() {
 	DEBUG_LOG(HLE, "%d=scePower_a85880d0_IsPSPNonFat()", g_Config.iPSPModel);
 
 	return g_Config.iPSPModel;  

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -140,10 +140,12 @@ struct PsmfEntry {
 	int EPPicOffset;
 };
 
-int getMaxAheadTimestamp(int packets) {return std::max(40000, packets * 700);}
+static int getMaxAheadTimestamp(int packets) {
+	return std::max(40000, packets * 700);
+}
 
 // Some of our platforms don't play too nice with direct unaligned access.
-u32 ReadUnalignedU32BE(const u8 *p) {
+static u32 ReadUnalignedU32BE(const u8 *p) {
 	return (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | (p[3] << 0);
 }
 
@@ -572,7 +574,7 @@ int Psmf::FindEPWithTimestamp(int pts) const {
 static std::map<u32, Psmf *> psmfMap;
 static std::map<u32, PsmfPlayer *> psmfPlayerMap;
 
-Psmf *getPsmf(u32 psmf)
+static Psmf *getPsmf(u32 psmf)
 {
 	auto psmfstruct = PSPPointer<PsmfData>::Create(psmf);
 	if (!psmfstruct.IsValid())
@@ -584,7 +586,7 @@ Psmf *getPsmf(u32 psmf)
 		return 0;
 }
 
-PsmfPlayer *getPsmfPlayer(u32 psmfplayer)
+static PsmfPlayer *getPsmfPlayer(u32 psmfplayer)
 {
 	auto iter = psmfPlayerMap.find(Memory::Read_U32(psmfplayer));
 	if (iter != psmfPlayerMap.end())
@@ -629,7 +631,7 @@ void __PsmfShutdown()
 	psmfPlayerMap.clear();
 }
 
-u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData)
+static u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData)
 {
 	if (!Memory::IsValidAddress(psmfData)) {
 		// TODO: Check error code.
@@ -655,7 +657,7 @@ u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData)
 	return 0;
 }
 
-u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
+static u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -666,7 +668,7 @@ u32 scePsmfGetNumberOfStreams(u32 psmfStruct)
 	return psmf->numStreams;
 }
 
-u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType)
+static u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -683,7 +685,7 @@ u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType)
 	return streamNum;
 }
 
-u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u32 channel)
+static u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u32 channel)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -697,7 +699,7 @@ u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u32 chann
 	return 0;
 }
 
-u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32 typeNum)
+static u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32 typeNum)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -712,7 +714,7 @@ u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32
 	return 0;
 }
 
-u32 scePsmfSpecifyStream(u32 psmfStruct, int streamNum) {
+static u32 scePsmfSpecifyStream(u32 psmfStruct, int streamNum) {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(ME, "scePsmfSpecifyStream(%08x, %i): invalid psmf", psmfStruct, streamNum);
@@ -723,7 +725,7 @@ u32 scePsmfSpecifyStream(u32 psmfStruct, int streamNum) {
 	return 0;
 }
 
-u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr) {
+static u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr) {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(ME, "scePsmfGetVideoInfo(%08x, %08x): invalid psmf", psmfStruct, videoInfoAddr);
@@ -737,7 +739,7 @@ u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr) {
 	return 0;
 }
 
-u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr) {
+static u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr) {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(ME, "scePsmfGetAudioInfo(%08x, %08x): invalid psmf", psmfStruct, audioInfoAddr);
@@ -751,7 +753,7 @@ u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr) {
 	return 0;
 }
 
-u32 scePsmfGetCurrentStreamType(u32 psmfStruct, u32 typeAddr, u32 channelAddr) {
+static u32 scePsmfGetCurrentStreamType(u32 psmfStruct, u32 typeAddr, u32 channelAddr) {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
 		ERROR_LOG(ME, "scePsmfGetCurrentStreamType(%08x, %08x, %08x): invalid psmf", psmfStruct, typeAddr, channelAddr);
@@ -770,7 +772,7 @@ u32 scePsmfGetCurrentStreamType(u32 psmfStruct, u32 typeAddr, u32 channelAddr) {
 	return 0;
 }
 
-u32 scePsmfGetStreamSize(u32 psmfStruct, u32 sizeAddr)
+static u32 scePsmfGetStreamSize(u32 psmfStruct, u32 sizeAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -784,7 +786,7 @@ u32 scePsmfGetStreamSize(u32 psmfStruct, u32 sizeAddr)
 	return 0;
 }
 
-u32 scePsmfQueryStreamOffset(u32 bufferAddr, u32 offsetAddr)
+static u32 scePsmfQueryStreamOffset(u32 bufferAddr, u32 offsetAddr)
 {
 	WARN_LOG(ME, "scePsmfQueryStreamOffset(%08x, %08x)", bufferAddr, offsetAddr);
 	if (Memory::IsValidAddress(offsetAddr)) {
@@ -793,7 +795,7 @@ u32 scePsmfQueryStreamOffset(u32 bufferAddr, u32 offsetAddr)
 	return 0;
 }
 
-u32 scePsmfQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
+static u32 scePsmfQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 {
 	WARN_LOG(ME, "scePsmfQueryStreamSize(%08x, %08x)", bufferAddr, sizeAddr);
 	if (Memory::IsValidAddress(sizeAddr)) {
@@ -802,7 +804,7 @@ u32 scePsmfQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 	return 0;
 }
 
-u32 scePsmfGetHeaderSize(u32 psmfStruct, u32 sizeAddr)
+static u32 scePsmfGetHeaderSize(u32 psmfStruct, u32 sizeAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -816,7 +818,7 @@ u32 scePsmfGetHeaderSize(u32 psmfStruct, u32 sizeAddr)
 	return 0;
 }
 
-u32 scePsmfGetPsmfVersion(u32 psmfStruct)
+static u32 scePsmfGetPsmfVersion(u32 psmfStruct)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -827,7 +829,7 @@ u32 scePsmfGetPsmfVersion(u32 psmfStruct)
 	return psmf->version;
 }
 
-u32 scePsmfVerifyPsmf(u32 psmfAddr)
+static u32 scePsmfVerifyPsmf(u32 psmfAddr)
 {
 	u32 magic = Memory::Read_U32(psmfAddr);
 	if (magic != PSMF_MAGIC) {
@@ -846,7 +848,7 @@ u32 scePsmfVerifyPsmf(u32 psmfAddr)
 	return 0;
 }
 
-u32 scePsmfGetNumberOfEPentries(u32 psmfStruct)
+static u32 scePsmfGetNumberOfEPentries(u32 psmfStruct)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -857,7 +859,7 @@ u32 scePsmfGetNumberOfEPentries(u32 psmfStruct)
 	return psmf->EPMapEntriesNum;
 }
 
-u32 scePsmfGetPresentationStartTime(u32 psmfStruct, u32 startTimeAddr)
+static u32 scePsmfGetPresentationStartTime(u32 psmfStruct, u32 startTimeAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -871,7 +873,7 @@ u32 scePsmfGetPresentationStartTime(u32 psmfStruct, u32 startTimeAddr)
 	return 0;
 }
 
-u32 scePsmfGetPresentationEndTime(u32 psmfStruct, u32 endTimeAddr)
+static u32 scePsmfGetPresentationEndTime(u32 psmfStruct, u32 endTimeAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -885,7 +887,7 @@ u32 scePsmfGetPresentationEndTime(u32 psmfStruct, u32 endTimeAddr)
 	return 0;
 }
 
-u32 scePsmfGetCurrentStreamNumber(u32 psmfStruct)
+static u32 scePsmfGetCurrentStreamNumber(u32 psmfStruct)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -897,7 +899,7 @@ u32 scePsmfGetCurrentStreamNumber(u32 psmfStruct)
 	return psmf->currentStreamNum;
 }
 
-u32 scePsmfCheckEPMap(u32 psmfStruct) 
+static u32 scePsmfCheckEPMap(u32 psmfStruct)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -909,7 +911,7 @@ u32 scePsmfCheckEPMap(u32 psmfStruct)
 	return psmf->EPMap.empty() ? ERROR_PSMF_NOT_FOUND : 0;
 }
 
-u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
+static u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -928,7 +930,7 @@ u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
 	return 0;
 }
 
-u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
+static u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -954,7 +956,7 @@ u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
 	return 0;
 }
 
-u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
+static u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
 {
 	Psmf *psmf = getPsmf(psmfStruct);
 	if (!psmf) {
@@ -982,7 +984,7 @@ u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
 	return epid;
 }
 
-int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
+static int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
 {
 	auto player = PSPPointer<u32>::Create(psmfPlayer);
 	const auto data = PSPPointer<const PsmfPlayerCreateData>::Create(dataPtr);
@@ -1036,7 +1038,7 @@ int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr)
 	return hleDelayResult(0, "player create", 20000);
 }
 
-int scePsmfPlayerStop(u32 psmfPlayer) {
+static int scePsmfPlayerStop(u32 psmfPlayer) {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG(ME, "scePsmfPlayerStop(%08x): invalid psmf player", psmfPlayer);
@@ -1053,7 +1055,7 @@ int scePsmfPlayerStop(u32 psmfPlayer) {
 	return hleDelayResult(0, "psmfplayer stop", 3000);
 }
 
-int scePsmfPlayerBreak(u32 psmfPlayer)
+static int scePsmfPlayerBreak(u32 psmfPlayer)
 {
 	WARN_LOG(ME, "scePsmfPlayerBreak(%08x)", psmfPlayer);
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
@@ -1067,7 +1069,7 @@ int scePsmfPlayerBreak(u32 psmfPlayer)
 	return 0;
 }
 
-int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
+static int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
 	if (!psmfplayer->filehandle)
 		return -1;
 	u8* buf = psmfplayer->tempbuf;
@@ -1100,7 +1102,7 @@ int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
 	return 0;
 }
 
-int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset, bool docallback) {
+static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset, bool docallback) {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer || psmfplayer->status != PSMF_PLAYER_STATUS_INIT) {
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
@@ -1175,7 +1177,7 @@ int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset, b
 	return hleDelayResult(0, "psmfplayer set", delayUs);
 }
 
-int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename) 
+static int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 {
 	u32 result = _PsmfPlayerSetPsmfOffset(psmfPlayer, filename, 0, false);
 	if (result == ERROR_PSMFPLAYER_INVALID_STATUS) {
@@ -1190,7 +1192,7 @@ int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename)
 	return result;
 }
 
-int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename) 
+static int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 {
 	// TODO: hleCheckCurrentCallbacks?
 	u32 result = _PsmfPlayerSetPsmfOffset(psmfPlayer, filename, 0, true);
@@ -1206,7 +1208,7 @@ int scePsmfPlayerSetPsmfCB(u32 psmfPlayer, const char *filename)
 	return result;
 }
 
-int scePsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset) 
+static int scePsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset)
 {
 	u32 result = _PsmfPlayerSetPsmfOffset(psmfPlayer, filename, offset, false);
 	if (result == ERROR_PSMFPLAYER_INVALID_STATUS) {
@@ -1221,7 +1223,7 @@ int scePsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int offset)
 	return result;
 }
 
-int scePsmfPlayerSetPsmfOffsetCB(u32 psmfPlayer, const char *filename, int offset) 
+static int scePsmfPlayerSetPsmfOffsetCB(u32 psmfPlayer, const char *filename, int offset)
 {
 	// TODO: hleCheckCurrentCallbacks?
 	u32 result = _PsmfPlayerSetPsmfOffset(psmfPlayer, filename, offset, true);
@@ -1237,7 +1239,7 @@ int scePsmfPlayerSetPsmfOffsetCB(u32 psmfPlayer, const char *filename, int offse
 	return result;
 }
 
-int scePsmfPlayerGetAudioOutSize(u32 psmfPlayer) 
+static int scePsmfPlayerGetAudioOutSize(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1248,7 +1250,7 @@ int scePsmfPlayerGetAudioOutSize(u32 psmfPlayer)
 	return audioSamplesBytes;
 }
 
-bool __PsmfPlayerContinueSeek(PsmfPlayer *psmfplayer, int tries = 50) {
+static bool __PsmfPlayerContinueSeek(PsmfPlayer *psmfplayer, int tries = 50) {
 	if (psmfplayer->seekDestTimeStamp <= 0) {
 		return true;
 	}
@@ -1268,7 +1270,7 @@ bool __PsmfPlayerContinueSeek(PsmfPlayer *psmfplayer, int tries = 50) {
 	return true;
 }
 
-int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
+static int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1394,7 +1396,7 @@ int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 	return delayUs == 0 ? 0 : hleDelayResult(0, "psmfplayer start", delayUs);
 }
 
-int scePsmfPlayerDelete(u32 psmfPlayer) 
+static int scePsmfPlayerDelete(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1410,7 +1412,7 @@ int scePsmfPlayerDelete(u32 psmfPlayer)
 	return hleDelayResult(0, "psmfplayer deleted", 20000);
 }
 
-int scePsmfPlayerUpdate(u32 psmfPlayer) 
+static int scePsmfPlayerUpdate(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1436,7 +1438,7 @@ int scePsmfPlayerUpdate(u32 psmfPlayer)
 	return 0;
 }
 
-int scePsmfPlayerReleasePsmf(u32 psmfPlayer) 
+static int scePsmfPlayerReleasePsmf(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1453,7 +1455,7 @@ int scePsmfPlayerReleasePsmf(u32 psmfPlayer)
 	return 0;
 }
 
-void __PsmfUpdatePts(PsmfPlayer *psmfplayer, PsmfVideoData *videoData) {
+static void __PsmfUpdatePts(PsmfPlayer *psmfplayer, PsmfVideoData *videoData) {
 	// getVideoTimestamp() includes the frame duration, remove it for this frame's pts.
 	psmfplayer->psmfPlayerAvcAu.pts = psmfplayer->mediaengine->getVideoTimeStamp() - VIDEO_FRAME_DURATION_TS;
 	if (videoData) {
@@ -1461,7 +1463,7 @@ void __PsmfUpdatePts(PsmfPlayer *psmfplayer, PsmfVideoData *videoData) {
 	}
 }
 
-int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
+static int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1554,7 +1556,7 @@ int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	return hleDelayResult(0, "psmfPlayer video decode", 3000);
 }
 
-int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
+static int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1601,7 +1603,7 @@ int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 	return ret;
 }
 
-int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer) 
+static int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1619,7 +1621,7 @@ int scePsmfPlayerGetCurrentStatus(u32 psmfPlayer)
 	return psmfplayer->status;
 }
 
-u32 scePsmfPlayerGetCurrentPts(u32 psmfPlayer, u32 currentPtsAddr) 
+static u32 scePsmfPlayerGetCurrentPts(u32 psmfPlayer, u32 currentPtsAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1642,7 +1644,7 @@ u32 scePsmfPlayerGetCurrentPts(u32 psmfPlayer, u32 currentPtsAddr)
 	return 0;
 }
 
-u32 scePsmfPlayerGetPsmfInfo(u32 psmfPlayer, u32 psmfInfoAddr) 
+static u32 scePsmfPlayerGetPsmfInfo(u32 psmfPlayer, u32 psmfInfoAddr)
 {
 	auto info = PSPPointer<PsmfInfo>::Create(psmfInfoAddr);
 	if (!Memory::IsValidAddress(psmfPlayer) || !info.IsValid()) {
@@ -1673,7 +1675,7 @@ u32 scePsmfPlayerGetPsmfInfo(u32 psmfPlayer, u32 psmfInfoAddr)
 	return 0;
 }
 
-u32 scePsmfPlayerGetCurrentPlayMode(u32 psmfPlayer, u32 playModeAddr, u32 playSpeedAddr) 
+static u32 scePsmfPlayerGetCurrentPlayMode(u32 psmfPlayer, u32 playModeAddr, u32 playSpeedAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1691,7 +1693,7 @@ u32 scePsmfPlayerGetCurrentPlayMode(u32 psmfPlayer, u32 playModeAddr, u32 playSp
 	return 0;
 }
 
-u32 scePsmfPlayerGetCurrentVideoStream(u32 psmfPlayer, u32 videoCodecAddr, u32 videoStreamNumAddr) 
+static u32 scePsmfPlayerGetCurrentVideoStream(u32 psmfPlayer, u32 videoCodecAddr, u32 videoStreamNumAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1713,7 +1715,7 @@ u32 scePsmfPlayerGetCurrentVideoStream(u32 psmfPlayer, u32 videoCodecAddr, u32 v
 	return 0;
 }
 
-u32 scePsmfPlayerGetCurrentAudioStream(u32 psmfPlayer, u32 audioCodecAddr, u32 audioStreamNumAddr) 
+static u32 scePsmfPlayerGetCurrentAudioStream(u32 psmfPlayer, u32 audioCodecAddr, u32 audioStreamNumAddr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1735,7 +1737,7 @@ u32 scePsmfPlayerGetCurrentAudioStream(u32 psmfPlayer, u32 audioCodecAddr, u32 a
 	return 0;
 }
 
-int scePsmfPlayerSetTempBuf(u32 psmfPlayer, u32 tempBufAddr, u32 tempBufSize) 
+static int scePsmfPlayerSetTempBuf(u32 psmfPlayer, u32 tempBufAddr, u32 tempBufSize)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1759,7 +1761,7 @@ int scePsmfPlayerSetTempBuf(u32 psmfPlayer, u32 tempBufAddr, u32 tempBufSize)
 	return 0;
 }
 
-u32 scePsmfPlayerChangePlayMode(u32 psmfPlayer, int playMode, int playSpeed) 
+static u32 scePsmfPlayerChangePlayMode(u32 psmfPlayer, int playMode, int playSpeed)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1807,7 +1809,7 @@ u32 scePsmfPlayerChangePlayMode(u32 psmfPlayer, int playMode, int playSpeed)
 	return 0;
 }
 
-u32 scePsmfPlayerSelectAudio(u32 psmfPlayer) 
+static u32 scePsmfPlayerSelectAudio(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1833,7 +1835,7 @@ u32 scePsmfPlayerSelectAudio(u32 psmfPlayer)
 	return 0;
 }
 
-u32 scePsmfPlayerSelectVideo(u32 psmfPlayer) 
+static u32 scePsmfPlayerSelectVideo(u32 psmfPlayer)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1859,7 +1861,7 @@ u32 scePsmfPlayerSelectVideo(u32 psmfPlayer)
 	return 0;
 }
 
-u32 scePsmfPlayerSelectSpecificVideo(u32 psmfPlayer, int videoCodec, int videoStreamNum) 
+static u32 scePsmfPlayerSelectSpecificVideo(u32 psmfPlayer, int videoCodec, int videoStreamNum)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1897,7 +1899,7 @@ u32 scePsmfPlayerSelectSpecificVideo(u32 psmfPlayer, int videoCodec, int videoSt
 }
 
 // WARNING: This function appears to be buggy in most libraries.
-u32 scePsmfPlayerSelectSpecificAudio(u32 psmfPlayer, int audioCodec, int audioStreamNum) 
+static u32 scePsmfPlayerSelectSpecificAudio(u32 psmfPlayer, int audioCodec, int audioStreamNum)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1934,7 +1936,7 @@ u32 scePsmfPlayerSelectSpecificAudio(u32 psmfPlayer, int audioCodec, int audioSt
 	return 0;
 }
 
-u32 scePsmfPlayerConfigPlayer(u32 psmfPlayer, int configMode, int configAttr) 
+static u32 scePsmfPlayerConfigPlayer(u32 psmfPlayer, int configMode, int configAttr)
 {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
@@ -1974,7 +1976,7 @@ u32 scePsmfPlayerConfigPlayer(u32 psmfPlayer, int configMode, int configAttr)
 	return 0;
 }
 
-int __PsmfPlayerFinish(u32 psmfPlayer) {
+static int __PsmfPlayerFinish(u32 psmfPlayer) {
 	PsmfPlayer *psmfplayer = getPsmfPlayer(psmfPlayer);
 	if (!psmfplayer) {
 		ERROR_LOG_REPORT(ME, "__PsmfPlayerFinish(%08x): invalid psmf player", psmfPlayer);

--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -2,28 +2,27 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceIo.h"
 
-u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen);
-
-int sceNpDrmSetLicenseeKey(u32 npDrmKeyAddr)
+static int sceNpDrmSetLicenseeKey(u32 npDrmKeyAddr)
 {
 	INFO_LOG(HLE, "call sceNpDrmSetLicenseeKey(%08x)", npDrmKeyAddr);
 	return 0;
 }
 
-int sceNpDrmClearLicenseeKey()
+static int sceNpDrmClearLicenseeKey()
 {
 	INFO_LOG(HLE, "call sceNpDrmClearLicenseeKey()");
 	return 0;
 }
 
-int sceNpDrmRenameCheck(const char *filename)
+static int sceNpDrmRenameCheck(const char *filename)
 {
 	INFO_LOG(HLE, "call sceNpDrmRenameCheck(%s)", filename);
 	return 0;
 }
 
-int sceNpDrmEdataSetupKey(u32 edataFd)
+static int sceNpDrmEdataSetupKey(u32 edataFd)
 {
 	INFO_LOG(HLE, "call sceNpDrmEdataSetupKey %x", edataFd);
 	/* set PGD offset */
@@ -32,13 +31,13 @@ int sceNpDrmEdataSetupKey(u32 edataFd)
 	return sceIoIoctl(edataFd, 0x04100001, 0, 0, 0, 0);
 }
 
-int sceNpDrmEdataGetDataSize(u32 edataFd)
+static int sceNpDrmEdataGetDataSize(u32 edataFd)
 {
 	INFO_LOG(HLE, "call sceNpDrmEdataGetDataSize %x", edataFd);
 	return sceIoIoctl(edataFd, 0x04100010, 0, 0, 0, 0);
 }
 
-int sceNpDrmOpen()
+static int sceNpDrmOpen()
 {
 	ERROR_LOG(HLE, "UNIMPL sceNpDrmOpen");
 	return 0;

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -70,7 +70,7 @@ const int PSP_TIME_INVALID_MINUTES = -5;
 const int PSP_TIME_INVALID_SECONDS = -6;
 const int PSP_TIME_INVALID_MICROSECONDS = -7;
 
-u64 __RtcGetCurrentTick()
+static u64 __RtcGetCurrentTick()
 {
 	// TODO: It's probably expecting ticks since January 1, 0001?
 	return CoreTiming::GetGlobalTimeUs() + rtcBaseTicks;
@@ -101,7 +101,7 @@ time_t rtc_timegm(struct tm *tm)
 #define rtc_timegm timegm
 #else
 
-time_t rtc_timegm(struct tm *tm)
+static time_t rtc_timegm(struct tm *tm)
 {
 	time_t ret;
 	char *tz;
@@ -157,7 +157,7 @@ void __RtcTimeOfDay(PSPTimeval *tv)
 	tv->tv_usec = adjustedUs % 1000000UL;
 }
 
-void __RtcTmToPspTime(ScePspDateTime &t, const tm *val)
+static void __RtcTmToPspTime(ScePspDateTime &t, const tm *val)
 {
 	t.year = val->tm_year + 1900;
 	t.month = val->tm_mon + 1;
@@ -168,7 +168,7 @@ void __RtcTmToPspTime(ScePspDateTime &t, const tm *val)
 	t.microsecond = 0;
 }
 
-void __RtcPspTimeToTm(tm &val, const ScePspDateTime &pt)
+static void __RtcPspTimeToTm(tm &val, const ScePspDateTime &pt)
 {
 	val.tm_year = pt.year - 1900;
 	val.tm_mon = pt.month - 1;
@@ -181,7 +181,7 @@ void __RtcPspTimeToTm(tm &val, const ScePspDateTime &pt)
 	val.tm_isdst = 0;
 }
 
-void __RtcTicksToPspTime(ScePspDateTime &t, u64 ticks)
+static void __RtcTicksToPspTime(ScePspDateTime &t, u64 ticks)
 {
 	int numYearAdd = 0;
 	if (ticks < 1000000ULL)
@@ -227,7 +227,7 @@ void __RtcTicksToPspTime(ScePspDateTime &t, u64 ticks)
 	t.second = local->tm_sec;
 }
 
-u64 __RtcPspTimeToTicks(const ScePspDateTime &pt)
+static u64 __RtcPspTimeToTicks(const ScePspDateTime &pt)
 {
 	tm local;
 	__RtcPspTimeToTm(local, pt);
@@ -250,18 +250,18 @@ u64 __RtcPspTimeToTicks(const ScePspDateTime &pt)
 	return result + tickOffset;
 }
 
-bool __RtcValidatePspTime(const ScePspDateTime &t)
+static bool __RtcValidatePspTime(const ScePspDateTime &t)
 {
 	return t.year > 0 && t.year <= 9999;
 }
 
-u32 sceRtcGetTickResolution()
+static u32 sceRtcGetTickResolution()
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetTickResolution()");
 	return 1000000;
 }
 
-u32 sceRtcGetCurrentTick(u32 tickPtr)
+static u32 sceRtcGetCurrentTick(u32 tickPtr)
 {
 	VERBOSE_LOG(SCERTC, "sceRtcGetCurrentTick(%08x)", tickPtr);
 
@@ -273,7 +273,7 @@ u32 sceRtcGetCurrentTick(u32 tickPtr)
 	return 0;
 }
 
-u64 sceRtcGetAccumulativeTime()
+static u64 sceRtcGetAccumulativeTime()
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetAccumulativeTime()");
 	hleEatCycles(300);
@@ -281,7 +281,7 @@ u64 sceRtcGetAccumulativeTime()
 	return __RtcGetCurrentTick();
 }
 
-u32 sceRtcGetCurrentClock(u32 pspTimePtr, int tz)
+static u32 sceRtcGetCurrentClock(u32 pspTimePtr, int tz)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetCurrentClock(%08x, %d)", pspTimePtr, tz);
 	PSPTimeval tv;
@@ -311,7 +311,7 @@ u32 sceRtcGetCurrentClock(u32 pspTimePtr, int tz)
 	return 0;
 }
 
-u32 sceRtcGetCurrentClockLocalTime(u32 pspTimePtr)
+static u32 sceRtcGetCurrentClockLocalTime(u32 pspTimePtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetCurrentClockLocalTime(%08x)", pspTimePtr);
 	PSPTimeval tv;
@@ -337,7 +337,7 @@ u32 sceRtcGetCurrentClockLocalTime(u32 pspTimePtr)
 	return 0;
 }
 
-u32 sceRtcSetTick(u32 pspTimePtr, u32 tickPtr)
+static u32 sceRtcSetTick(u32 pspTimePtr, u32 tickPtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcSetTick(%08x, %08x)", pspTimePtr, tickPtr);
 	if (Memory::IsValidAddress(pspTimePtr) && Memory::IsValidAddress(tickPtr))
@@ -351,7 +351,7 @@ u32 sceRtcSetTick(u32 pspTimePtr, u32 tickPtr)
 	return 0;
 }
 
-u32 sceRtcGetTick(u32 pspTimePtr, u32 tickPtr)
+static u32 sceRtcGetTick(u32 pspTimePtr, u32 tickPtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetTick(%08x, %08x)", pspTimePtr, tickPtr);
 	ScePspDateTime pt;
@@ -371,7 +371,7 @@ u32 sceRtcGetTick(u32 pspTimePtr, u32 tickPtr)
 	return 0;
 }
 
-u32 sceRtcGetDayOfWeek(u32 year, u32 month, u32 day)
+static u32 sceRtcGetDayOfWeek(u32 year, u32 month, u32 day)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetDayOfWeek(%d, %d, %d)", year, month, day);
 
@@ -411,12 +411,12 @@ u32 sceRtcGetDayOfWeek(u32 year, u32 month, u32 day)
 	return local.tm_wday;
 }
 
-bool __RtcIsLeapYear(u32 year)
+static bool __RtcIsLeapYear(u32 year)
 {
 	return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 }
 
-int __RtcDaysInMonth(u32 year, u32 month)
+static int __RtcDaysInMonth(u32 year, u32 month)
 {
 	switch (month)
 	{
@@ -436,7 +436,7 @@ int __RtcDaysInMonth(u32 year, u32 month)
 	}
 }
 
-u32 sceRtcGetDaysInMonth(u32 year, u32 month)
+static u32 sceRtcGetDaysInMonth(u32 year, u32 month)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetDaysInMonth(%d, %d)", year, month);
 
@@ -446,13 +446,13 @@ u32 sceRtcGetDaysInMonth(u32 year, u32 month)
 	return __RtcDaysInMonth(year, month);
 }
 
-u32 sceRtcIsLeapYear(u32 year)
+static u32 sceRtcIsLeapYear(u32 year)
 {
 	DEBUG_LOG(SCERTC, "sceRtcIsLeapYear(%d)", year);
 	return __RtcIsLeapYear(year) ? 1 : 0;
 }
 
-int sceRtcConvertLocalTimeToUTC(u32 tickLocalPtr,u32 tickUTCPtr)	
+static int sceRtcConvertLocalTimeToUTC(u32 tickLocalPtr,u32 tickUTCPtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcConvertLocalTimeToUTC(%d, %d)", tickLocalPtr, tickUTCPtr);
 	if (Memory::IsValidAddress(tickLocalPtr) && Memory::IsValidAddress(tickUTCPtr))
@@ -475,7 +475,7 @@ int sceRtcConvertLocalTimeToUTC(u32 tickLocalPtr,u32 tickUTCPtr)
 	return 0;
 }
 
-int sceRtcConvertUtcToLocalTime(u32 tickUTCPtr,u32 tickLocalPtr) 
+static int sceRtcConvertUtcToLocalTime(u32 tickUTCPtr,u32 tickLocalPtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcConvertLocalTimeToUTC(%d, %d)", tickLocalPtr, tickUTCPtr);
 	if (Memory::IsValidAddress(tickLocalPtr) && Memory::IsValidAddress(tickUTCPtr))
@@ -498,7 +498,7 @@ int sceRtcConvertUtcToLocalTime(u32 tickUTCPtr,u32 tickLocalPtr)
 	return 0;
 }
 
-int sceRtcCheckValid(u32 datePtr)
+static int sceRtcCheckValid(u32 datePtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcCheckValid(%d)", datePtr);
 
@@ -548,7 +548,7 @@ int sceRtcCheckValid(u32 datePtr)
 	}
 }
 
-int sceRtcSetTime_t(u32 datePtr, u32 time)
+static int sceRtcSetTime_t(u32 datePtr, u32 time)
 {
 	DEBUG_LOG(SCERTC, "sceRtcSetTime_t(%08x,%d)", datePtr, time);
 	if (Memory::IsValidAddress(datePtr))
@@ -564,7 +564,7 @@ int sceRtcSetTime_t(u32 datePtr, u32 time)
 	return 0;
 }
 
-int sceRtcSetTime64_t(u32 datePtr, u64 time)
+static int sceRtcSetTime64_t(u32 datePtr, u64 time)
 {
 	DEBUG_LOG(SCERTC, "sceRtcSetTime64_t(%08x,%lld)", datePtr, time);
 	if (Memory::IsValidAddress(datePtr))
@@ -580,7 +580,7 @@ int sceRtcSetTime64_t(u32 datePtr, u64 time)
 	return 0;
 }
 
-int sceRtcGetTime_t(u32 datePtr, u32 timePtr)
+static int sceRtcGetTime_t(u32 datePtr, u32 timePtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetTime_t(%08x,%08x)", datePtr, timePtr);
 	if (Memory::IsValidAddress(datePtr)&&Memory::IsValidAddress(timePtr))
@@ -597,7 +597,7 @@ int sceRtcGetTime_t(u32 datePtr, u32 timePtr)
 	return 0;
 }
 
-int sceRtcGetTime64_t(u32 datePtr, u32 timePtr)
+static int sceRtcGetTime64_t(u32 datePtr, u32 timePtr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcGetTime64_t(%08x,%08x)", datePtr, timePtr);
 	if (Memory::IsValidAddress(datePtr)&&Memory::IsValidAddress(timePtr))
@@ -614,7 +614,7 @@ int sceRtcGetTime64_t(u32 datePtr, u32 timePtr)
 	return 0;
 }
 
-int sceRtcSetDosTime(u32 datePtr, u32 dosTime)
+static int sceRtcSetDosTime(u32 datePtr, u32 dosTime)
 {
 	DEBUG_LOG(SCERTC, "sceRtcSetDosTime(%d,%d)", datePtr, dosTime);
 	if (Memory::IsValidAddress(datePtr))
@@ -641,7 +641,7 @@ int sceRtcSetDosTime(u32 datePtr, u32 dosTime)
 	return 0;
 }
 
-int sceRtcGetDosTime(u32 datePtr, u32 dosTime)
+static int sceRtcGetDosTime(u32 datePtr, u32 dosTime)
 {
 	int retValue = 0;
 	DEBUG_LOG(SCERTC, "sceRtcGetDosTime(%d,%d)", datePtr, dosTime);
@@ -684,7 +684,7 @@ int sceRtcGetDosTime(u32 datePtr, u32 dosTime)
 	return retValue;
 }
 
-int sceRtcSetWin32FileTime(u32 datePtr, u64 win32Time)
+static int sceRtcSetWin32FileTime(u32 datePtr, u64 win32Time)
 {
 	if (!Memory::IsValidAddress(datePtr))
 	{
@@ -700,7 +700,7 @@ int sceRtcSetWin32FileTime(u32 datePtr, u64 win32Time)
 	return 0;
 }
 
-int sceRtcGetWin32FileTime(u32 datePtr, u32 win32TimePtr)
+static int sceRtcGetWin32FileTime(u32 datePtr, u32 win32TimePtr)
 {
 	if (!Memory::IsValidAddress(datePtr))
 	{
@@ -725,7 +725,7 @@ int sceRtcGetWin32FileTime(u32 datePtr, u32 win32TimePtr)
 	return 0;
 }
 
-int sceRtcCompareTick(u32 tick1Ptr, u32 tick2Ptr)
+static int sceRtcCompareTick(u32 tick1Ptr, u32 tick2Ptr)
 {
 	DEBUG_LOG(SCERTC, "sceRtcCompareTick(%d,%d)", tick1Ptr, tick2Ptr);
 	if (Memory::IsValidAddress(tick1Ptr) && Memory::IsValidAddress(tick2Ptr))
@@ -740,7 +740,7 @@ int sceRtcCompareTick(u32 tick1Ptr, u32 tick2Ptr)
 	return 0;
 }
 
-int sceRtcTickAddTicks(u32 destTickPtr, u32 srcTickPtr, u64 numTicks)
+static int sceRtcTickAddTicks(u32 destTickPtr, u32 srcTickPtr, u64 numTicks)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -754,7 +754,7 @@ int sceRtcTickAddTicks(u32 destTickPtr, u32 srcTickPtr, u64 numTicks)
 	return 0;
 }
 
-int sceRtcTickAddMicroseconds(u32 destTickPtr,u32 srcTickPtr, u64 numMS)
+static int sceRtcTickAddMicroseconds(u32 destTickPtr,u32 srcTickPtr, u64 numMS)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -768,7 +768,7 @@ int sceRtcTickAddMicroseconds(u32 destTickPtr,u32 srcTickPtr, u64 numMS)
 	return 0;
 }
 
-int sceRtcTickAddSeconds(u32 destTickPtr, u32 srcTickPtr, u64 numSecs)
+static int sceRtcTickAddSeconds(u32 destTickPtr, u32 srcTickPtr, u64 numSecs)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -781,7 +781,7 @@ int sceRtcTickAddSeconds(u32 destTickPtr, u32 srcTickPtr, u64 numSecs)
 	return 0;
 }
 
-int sceRtcTickAddMinutes(u32 destTickPtr, u32 srcTickPtr, u64 numMins)
+static int sceRtcTickAddMinutes(u32 destTickPtr, u32 srcTickPtr, u64 numMins)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -794,7 +794,7 @@ int sceRtcTickAddMinutes(u32 destTickPtr, u32 srcTickPtr, u64 numMins)
 	return 0;
 }
 
-int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
+static int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -806,7 +806,7 @@ int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
 	return 0;
 }
 
-int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
+static int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -819,7 +819,7 @@ int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
 	return 0;
 }
 
-int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
+static int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
 {
 	if (Memory::IsValidAddress(destTickPtr) && Memory::IsValidAddress(srcTickPtr))
 	{
@@ -832,7 +832,7 @@ int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
 	return 0;
 }
 
-int sceRtcTickAddMonths(u32 destTickPtr, u32 srcTickPtr, int numMonths)
+static int sceRtcTickAddMonths(u32 destTickPtr, u32 srcTickPtr, int numMonths)
 {
 	if (!Memory::IsValidAddress(destTickPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
@@ -872,7 +872,7 @@ int sceRtcTickAddMonths(u32 destTickPtr, u32 srcTickPtr, int numMonths)
 	return 0;
 }
 
-int sceRtcTickAddYears(u32 destTickPtr, u32 srcTickPtr, int numYears)
+static int sceRtcTickAddYears(u32 destTickPtr, u32 srcTickPtr, int numYears)
 {
 	if (!Memory::IsValidAddress(destTickPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
@@ -900,13 +900,13 @@ int sceRtcTickAddYears(u32 destTickPtr, u32 srcTickPtr, int numYears)
 	return 0;
 }
 
-int sceRtcParseDateTime(u32 destTickPtr, u32 dateStringPtr)
+static int sceRtcParseDateTime(u32 destTickPtr, u32 dateStringPtr)
 {
 	ERROR_LOG_REPORT(SCERTC, "UNIMPL sceRtcParseDateTime(%d,%d)", destTickPtr, dateStringPtr);
 	return 0;
 }
 
-int sceRtcGetLastAdjustedTime(u32 tickPtr)
+static int sceRtcGetLastAdjustedTime(u32 tickPtr)
 {
 	if (Memory::IsValidAddress(tickPtr))
 		Memory::Write_U64(rtcLastAdjustedTicks, tickPtr);
@@ -914,7 +914,7 @@ int sceRtcGetLastAdjustedTime(u32 tickPtr)
 	return 0;
 }
 
-int sceRtcGetLastReincarnatedTime(u32 tickPtr)
+static int sceRtcGetLastReincarnatedTime(u32 tickPtr)
 {
 	if (Memory::IsValidAddress(tickPtr))
 		Memory::Write_U64(rtcLastReincarnatedTicks, tickPtr);
@@ -923,13 +923,13 @@ int sceRtcGetLastReincarnatedTime(u32 tickPtr)
 }
 
 //Returns 0 on success, according to Project Diva 2nd jpcsptrace log
-int sceRtcSetAlarmTick(u32 unknown1, u32 unknown2)
+static int sceRtcSetAlarmTick(u32 unknown1, u32 unknown2)
 {
 	ERROR_LOG_REPORT(SCERTC, "UNIMPL sceRtcSetAlarmTick(%x, %x)", unknown1, unknown2);
 	return 0; 
 }
 
-int __RtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
+static int __RtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
 {
 	u64 srcTick = Memory::Read_U64(srcTickPtr);
 
@@ -960,7 +960,7 @@ int __RtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
 	return 0;
 }
 
-int __RtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
+static int __RtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
 {
 	u64 srcTick = Memory::Read_U64(srcTickPtr);
 
@@ -992,7 +992,7 @@ int __RtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
 	return 0;
 }
 
-int sceRtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
+static int sceRtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
 {
 	if (!Memory::IsValidAddress(outPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
@@ -1005,7 +1005,7 @@ int sceRtcFormatRFC2822(u32 outPtr, u32 srcTickPtr, int tz)
 	return __RtcFormatRFC2822(outPtr, srcTickPtr, tz);
 }
 
-int sceRtcFormatRFC2822LocalTime(u32 outPtr, u32 srcTickPtr)
+static int sceRtcFormatRFC2822LocalTime(u32 outPtr, u32 srcTickPtr)
 {
 	if (!Memory::IsValidAddress(outPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
@@ -1027,7 +1027,7 @@ int sceRtcFormatRFC2822LocalTime(u32 outPtr, u32 srcTickPtr)
 	return __RtcFormatRFC2822(outPtr, srcTickPtr, tz_seconds / 60);
 }
 
-int sceRtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
+static int sceRtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
 {
 	if (!Memory::IsValidAddress(outPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
@@ -1040,7 +1040,7 @@ int sceRtcFormatRFC3339(u32 outPtr, u32 srcTickPtr, int tz)
 	return __RtcFormatRFC3339(outPtr, srcTickPtr, tz);
 }
 
-int sceRtcFormatRFC3339LocalTime(u32 outPtr, u32 srcTickPtr)
+static int sceRtcFormatRFC3339LocalTime(u32 outPtr, u32 srcTickPtr)
 {
 	if (!Memory::IsValidAddress(outPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -82,7 +82,7 @@ void __SasShutdown() {
 }
 
 
-u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampleRate) {
+static u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampleRate) {
 	if (!Memory::IsValidAddress(core) || (core & 0x3F) != 0) {
 		ERROR_LOG_REPORT(SCESAS, "sceSasInit(%08x, %i, %i, %i, %i): bad core address", core, grainSize, maxVoices, outputMode, sampleRate);
 		return ERROR_SAS_BAD_ADDRESS;
@@ -117,7 +117,7 @@ u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampl
 	return 0;
 }
 
-u32 sceSasGetEndFlag(u32 core) {
+static u32 sceSasGetEndFlag(u32 core) {
 	u32 endFlag = 0;
 	for (int i = 0; i < sas->maxVoices; i++) {
 		if (!sas->voices[i].playing)
@@ -129,7 +129,7 @@ u32 sceSasGetEndFlag(u32 core) {
 }
 
 // Runs the mixer
-u32 _sceSasCore(u32 core, u32 outAddr) {
+static u32 _sceSasCore(u32 core, u32 outAddr) {
 	if (!Memory::IsValidAddress(outAddr)) {
 		ERROR_LOG_REPORT(SCESAS, "sceSasCore(%08x, %08x): invalid address", core, outAddr);
 		return ERROR_SAS_INVALID_PARAMETER;
@@ -143,7 +143,7 @@ u32 _sceSasCore(u32 core, u32 outAddr) {
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
-u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume) {
+static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume) {
 	if (!Memory::IsValidAddress(inoutAddr)) {
 		ERROR_LOG_REPORT(SCESAS, "sceSasCoreWithMix(%08x, %08x, %i, %i): invalid address", core, inoutAddr, leftVolume, rightVolume);
 		return ERROR_SAS_INVALID_PARAMETER;
@@ -160,7 +160,7 @@ u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int rightVolume)
 	return hleDelayResult(0, "sas core", 240);
 }
 
-u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
+static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -207,7 +207,7 @@ u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
 	return 0;
 }
 
-u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loopPos)
+static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loopPos)
 {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
@@ -241,7 +241,7 @@ u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loopPos
 	return 0;
 }
 
-u32 sceSasGetPauseFlag(u32 core) {
+static u32 sceSasGetPauseFlag(u32 core) {
 	u32 pauseFlag = 0;
 	for (int i = 0; i < sas->maxVoices; i++) {
 		if (sas->voices[i].paused)
@@ -252,7 +252,7 @@ u32 sceSasGetPauseFlag(u32 core) {
 	return pauseFlag;
 }
 
-u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
+static u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
 	DEBUG_LOG(SCESAS, "sceSasSetPause(%08x, %08x, %i)", core, voicebit, pause);
 
 	for (int i = 0; voicebit != 0; i++, voicebit >>= 1) {
@@ -265,7 +265,7 @@ u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
 	return 0;
 }
 
-u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effectLeftVol, int effectRightVol) {
+static u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effectLeftVol, int effectRightVol) {
 	DEBUG_LOG(SCESAS, "sceSasSetVolume(%08x, %i, %i, %i, %i, %i)", core, voiceNum, leftVol, rightVol, effectLeftVol, effectRightVol);
 
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
@@ -285,7 +285,7 @@ u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effec
 	return 0;
 }
 
-u32 sceSasSetPitch(u32 core, int voiceNum, int pitch) {
+static u32 sceSasSetPitch(u32 core, int voiceNum, int pitch) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -302,7 +302,7 @@ u32 sceSasSetPitch(u32 core, int voiceNum, int pitch) {
 	return 0;
 }
 
-u32 sceSasSetKeyOn(u32 core, int voiceNum) {
+static u32 sceSasSetKeyOn(u32 core, int voiceNum) {
 	DEBUG_LOG(SCESAS, "sceSasSetKeyOn(%08x, %i)", core, voiceNum);
 
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
@@ -320,7 +320,7 @@ u32 sceSasSetKeyOn(u32 core, int voiceNum) {
 }
 
 // sceSasSetKeyOff can be used to start sounds, that just sound during the Release phase!
-u32 sceSasSetKeyOff(u32 core, int voiceNum) {
+static u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -337,7 +337,7 @@ u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 	}
 }
 
-u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
+static u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -356,7 +356,7 @@ u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
 	return 0;
 }
 
-u32 sceSasSetSL(u32 core, int voiceNum, int level) {
+static u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -368,7 +368,7 @@ u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 	return 0;
 }
 
-u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
+static u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -390,7 +390,7 @@ u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) 
 	return 0;
 }
 
-u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
+static u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -436,7 +436,7 @@ u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int
 }
 
 
-u32 sceSasSetSimpleADSR(u32 core, int voiceNum, u32 ADSREnv1, u32 ADSREnv2) {
+static u32 sceSasSetSimpleADSR(u32 core, int voiceNum, u32 ADSREnv1, u32 ADSREnv2) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		WARN_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -454,7 +454,7 @@ u32 sceSasSetSimpleADSR(u32 core, int voiceNum, u32 ADSREnv1, u32 ADSREnv2) {
 	return 0;
 }
 
-u32 sceSasGetEnvelopeHeight(u32 core, int voiceNum) {
+static u32 sceSasGetEnvelopeHeight(u32 core, int voiceNum) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
 		ERROR_LOG(SCESAS, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
 		return ERROR_SAS_INVALID_VOICE;
@@ -466,20 +466,20 @@ u32 sceSasGetEnvelopeHeight(u32 core, int voiceNum) {
 	return height;
 }
 
-u32 sceSasRevType(u32 core, int type) {
+static u32 sceSasRevType(u32 core, int type) {
 	DEBUG_LOG(SCESAS, "sceSasRevType(%08x, %i)", core, type);
 	sas->waveformEffect.type = type;
 	return 0;
 }
 
-u32 sceSasRevParam(u32 core, int delay, int feedback) {
+static u32 sceSasRevParam(u32 core, int delay, int feedback) {
 	DEBUG_LOG(SCESAS, "sceSasRevParam(%08x, %i, %i)", core, delay, feedback);
 	sas->waveformEffect.delay = delay;
 	sas->waveformEffect.feedback = feedback;
 	return 0;
 }
 
-u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
+static u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
 	if (lv > 0x1000 || rv > 0x1000) {
 		WARN_LOG_REPORT(SCESAS, "sceSasRevEVOL(%08x, %i, %i): invalid volume", core, lv, rv);
 		return ERROR_SAS_REV_INVALID_VOLUME;
@@ -490,30 +490,30 @@ u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
 	return 0;
 }
 
-u32 sceSasRevVON(u32 core, int dry, int wet) {
+static u32 sceSasRevVON(u32 core, int dry, int wet) {
 	DEBUG_LOG(SCESAS, "sceSasRevVON(%08x, %i, %i)", core, dry, wet);
 	sas->waveformEffect.isDryOn = dry != 0;
 	sas->waveformEffect.isWetOn = wet != 0;
 	return 0;
 }
 
-u32 sceSasGetGrain(u32 core) {
+static u32 sceSasGetGrain(u32 core) {
 	DEBUG_LOG(SCESAS, "sceSasGetGrain(%08x)", core);
 	return sas->GetGrainSize();
 }
 
-u32 sceSasSetGrain(u32 core, int grain) {
+static u32 sceSasSetGrain(u32 core, int grain) {
 	INFO_LOG(SCESAS, "sceSasSetGrain(%08x, %i)", core, grain);
 	sas->SetGrainSize(grain);
 	return 0;
 }
 
-u32 sceSasGetOutputMode(u32 core) {
+static u32 sceSasGetOutputMode(u32 core) {
 	DEBUG_LOG(SCESAS, "sceSasGetOutputMode(%08x)", core);
 	return sas->outputMode;
 }
 
-u32 sceSasSetOutputMode(u32 core, u32 outputMode) {
+static u32 sceSasSetOutputMode(u32 core, u32 outputMode) {
 	if (outputMode != 0 && outputMode != 1) {
 		ERROR_LOG_REPORT(SCESAS, "sceSasSetOutputMode(%08x, %i): bad output mode", core, outputMode);
 		return ERROR_SAS_INVALID_OUTPUT_MODE;
@@ -524,7 +524,7 @@ u32 sceSasSetOutputMode(u32 core, u32 outputMode) {
 	return 0;
 }
 
-u32 sceSasGetAllEnvelopeHeights(u32 core, u32 heightsAddr) {
+static u32 sceSasGetAllEnvelopeHeights(u32 core, u32 heightsAddr) {
 	DEBUG_LOG(SCESAS, "sceSasGetAllEnvelopeHeights(%08x, %i)", core, heightsAddr);
 
 	if (!Memory::IsValidAddress(heightsAddr)) {
@@ -539,17 +539,17 @@ u32 sceSasGetAllEnvelopeHeights(u32 core, u32 heightsAddr) {
 	return 0;
 }
 
-u32 sceSasSetTriangularWave(u32 sasCore, int voice, int unknown) {
+static u32 sceSasSetTriangularWave(u32 sasCore, int voice, int unknown) {
 	ERROR_LOG_REPORT(SCESAS, "UNIMPL sceSasSetTriangularWave(%08x, %i, %i)", sasCore, voice, unknown);
 	return 0;
 }
 
-u32 sceSasSetSteepWave(u32 sasCore, int voice, int unknown) {
+static u32 sceSasSetSteepWave(u32 sasCore, int voice, int unknown) {
 	ERROR_LOG_REPORT(SCESAS, "UNIMPL sceSasSetSteepWave(%08x, %i, %i)", sasCore, voice, unknown);
 	return 0;
 }
 
-u32 __sceSasSetVoiceATRAC3(u32 core, int voiceNum, u32 atrac3Context) {
+static u32 __sceSasSetVoiceATRAC3(u32 core, int voiceNum, u32 atrac3Context) {
 	DEBUG_LOG_REPORT(SCESAS, "__sceSasSetVoiceATRAC3(%08x, %i, %08x)", core, voiceNum, atrac3Context);
 	SasVoice &v = sas->voices[voiceNum];
 	v.type = VOICETYPE_ATRAC3;
@@ -560,7 +560,7 @@ u32 __sceSasSetVoiceATRAC3(u32 core, int voiceNum, u32 atrac3Context) {
 	return 0;
 }
 
-u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr, int atrac3DataLength) {
+static u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr, int atrac3DataLength) {
 	DEBUG_LOG_REPORT(SCESAS, "__sceSasConcatenateATRAC3(%08x, %i, %08x, %i)", core, voiceNum, atrac3DataAddr, atrac3DataLength);
 	SasVoice &v = sas->voices[voiceNum];
 	if (Memory::IsValidAddress(atrac3DataAddr))
@@ -568,7 +568,7 @@ u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr, int at
 	return 0;
 }
 
-u32 __sceSasUnsetATRAC3(u32 core, int voiceNum) {
+static u32 __sceSasUnsetATRAC3(u32 core, int voiceNum) {
 	DEBUG_LOG_REPORT(SCESAS, "__sceSasUnsetATRAC3(%08x, %i)", core, voiceNum);
 	Memory::Write_U32(0, core + 56 * voiceNum + 20);
 	return 0;

--- a/Core/HLE/sceSsl.cpp
+++ b/Core/HLE/sceSsl.cpp
@@ -49,7 +49,7 @@ void __SslDoState(PointerWrap &p)
 	p.Do(currentMemSize);
 }
 
-int sceSslInit(int heapSize)
+static int sceSslInit(int heapSize)
 {
 	DEBUG_LOG(HLE, "sceSslInit %d", heapSize);
 	if (isSslInit) 
@@ -67,7 +67,7 @@ int sceSslInit(int heapSize)
 	return 0;
 }
 
-int sceSslEnd() 
+static int sceSslEnd()
 {
 	DEBUG_LOG(HLE, "sceSslEnd");
 	if (!isSslInit) 
@@ -78,7 +78,7 @@ int sceSslEnd()
 	return 0;
 }
 
-int sceSslGetUsedMemoryMax(u32 maxMemPtr) 
+static int sceSslGetUsedMemoryMax(u32 maxMemPtr)
 {
 	DEBUG_LOG(HLE, "sceSslGetUsedMemoryMax %d", maxMemPtr);
 	if (!isSslInit) 
@@ -93,7 +93,7 @@ int sceSslGetUsedMemoryMax(u32 maxMemPtr)
 	return 0;
 }
 
-int sceSslGetUsedMemoryCurrent(u32 currentMemPtr) 
+static int sceSslGetUsedMemoryCurrent(u32 currentMemPtr)
 {
 	DEBUG_LOG(HLE, "sceSslGetUsedMemoryCurrent %d", currentMemPtr);
 	if (!isSslInit) 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -97,7 +97,7 @@ void __UmdDoState(PointerWrap &p)
 		p.Do(UMDReplacePermit);
 }
 
-u8 __KernelUmdGetState()
+static u8 __KernelUmdGetState()
 {
 	// Most games seem to expect the disc to be ready early on, active or not.
 	// It seems like the PSP sets this state when the disc is "ready".
@@ -133,7 +133,7 @@ void __UmdStatChange(u64 userdata, int cyclesLate)
 	}
 }
 
-void __KernelUmdActivate()
+static void __KernelUmdActivate()
 {
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE;
 	// PSP_UMD_READY will be returned when sceKernelGetCompiledSdkVersion() != 0
@@ -148,7 +148,7 @@ void __KernelUmdActivate()
 	CoreTiming::ScheduleEvent(usToCycles(MICRO_DELAY_ACTIVATE), umdStatChangeEvent, 1);
 }
 
-void __KernelUmdDeactivate()
+static void __KernelUmdDeactivate()
 {
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READY;
 	if (driveCBId != 0)
@@ -223,13 +223,13 @@ void __UmdEndCallback(SceUID threadID, SceUID prevCallbackId)
 	}
 }
 
-int sceUmdCheckMedium()
+static int sceUmdCheckMedium()
 {
 	DEBUG_LOG(SCEIO, "1=sceUmdCheckMedium()");
 	return 1; //non-zero: disc in drive
 }
 	
-u32 sceUmdGetDiscInfo(u32 infoAddr)
+static u32 sceUmdGetDiscInfo(u32 infoAddr)
 {
 	DEBUG_LOG(SCEIO, "sceUmdGetDiscInfo(%08x)", infoAddr);
 
@@ -244,7 +244,7 @@ u32 sceUmdGetDiscInfo(u32 infoAddr)
 		return PSP_ERROR_UMD_INVALID_PARAM;
 }
 
-int sceUmdActivate(u32 mode, const char *name)
+static int sceUmdActivate(u32 mode, const char *name)
 {
 	if (mode < 1 || mode > 2)
 		return PSP_ERROR_UMD_INVALID_PARAM;
@@ -260,7 +260,7 @@ int sceUmdActivate(u32 mode, const char *name)
 	return 0;
 }
 
-int sceUmdDeactivate(u32 mode, const char *name)
+static int sceUmdDeactivate(u32 mode, const char *name)
 {
 	// Why 18?  No idea.
 	if (mode > 18)
@@ -277,7 +277,7 @@ int sceUmdDeactivate(u32 mode, const char *name)
 	return 0;
 }
 
-u32 sceUmdRegisterUMDCallBack(u32 cbId)
+static u32 sceUmdRegisterUMDCallBack(u32 cbId)
 {
 	int retVal = 0;
 
@@ -292,7 +292,7 @@ u32 sceUmdRegisterUMDCallBack(u32 cbId)
 	return retVal;
 }
 
-int sceUmdUnRegisterUMDCallBack(int cbId)
+static int sceUmdUnRegisterUMDCallBack(int cbId)
 {
 	int retVal;
 
@@ -310,7 +310,7 @@ int sceUmdUnRegisterUMDCallBack(int cbId)
 	return retVal;
 }
 
-u32 sceUmdGetDriveStat()
+static u32 sceUmdGetDriveStat()
 {
 	//u32 retVal = PSP_UMD_INITED | PSP_UMD_READY | PSP_UMD_PRESENT;
 	u32 retVal = __KernelUmdGetState();
@@ -331,7 +331,7 @@ void __UmdStatTimeout(u64 userdata, int cyclesLate)
 	HLEKernel::RemoveWaitingThread(umdWaitingThreads, threadID);
 }
 
-void __UmdWaitStat(u32 timeout)
+static void __UmdWaitStat(u32 timeout)
 {
 	// This happens to be how the hardware seems to time things.
 	if (timeout <= 4)
@@ -349,7 +349,7 @@ void __UmdWaitStat(u32 timeout)
 * @return < 0 on error
 *
 */
-int sceUmdWaitDriveStat(u32 stat)
+static int sceUmdWaitDriveStat(u32 stat)
 {
 	if (stat == 0) {
 		DEBUG_LOG(SCEIO, "sceUmdWaitDriveStat(stat = %08x): bad status", stat);
@@ -376,7 +376,7 @@ int sceUmdWaitDriveStat(u32 stat)
 	return 0;
 }
 
-int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout)
+static int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout)
 {
 	if (stat == 0) {
 		DEBUG_LOG(SCEIO, "sceUmdWaitDriveStatWithTimer(stat = %08x, timeout = %d): bad status", stat, timeout);
@@ -406,7 +406,7 @@ int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout)
 	return 0;
 }
 
-int sceUmdWaitDriveStatCB(u32 stat, u32 timeout)
+static int sceUmdWaitDriveStatCB(u32 stat, u32 timeout)
 {
 	if (stat == 0) {
 		DEBUG_LOG(SCEIO, "sceUmdWaitDriveStatCB(stat = %08x, timeout = %d): bad status", stat, timeout);
@@ -440,7 +440,7 @@ int sceUmdWaitDriveStatCB(u32 stat, u32 timeout)
 	return 0;
 }
 
-u32 sceUmdCancelWaitDriveStat()
+static u32 sceUmdCancelWaitDriveStat()
 {
 	DEBUG_LOG(SCEIO, "0=sceUmdCancelWaitDriveStat()");
 
@@ -454,7 +454,7 @@ u32 sceUmdCancelWaitDriveStat()
 	return 0;
 }
 
-u32 sceUmdGetErrorStat()
+static u32 sceUmdGetErrorStat()
 {
 	DEBUG_LOG(SCEIO,"%i=sceUmdGetErrorStat()", umdErrorStat);
 	return umdErrorStat;
@@ -506,14 +506,14 @@ bool getUMDReplacePermit() {
 	return UMDReplacePermit;
 }
 
-u32 sceUmdReplaceProhibit()
+static u32 sceUmdReplaceProhibit()
 {
 	UMDReplacePermit = false;
 	DEBUG_LOG(SCEIO,"sceUmdReplaceProhibit()");
 	return 0;
 }
 
-u32 sceUmdReplacePermit()
+static u32 sceUmdReplacePermit()
 {
 	UMDReplacePermit = true;
 	DEBUG_LOG(SCEIO,"sceUmdReplacePermit()");

--- a/Core/HLE/sceUsb.cpp
+++ b/Core/HLE/sceUsb.cpp
@@ -61,19 +61,19 @@ void __UsbDoState(PointerWrap &p)
 	p.Do(usbActivated);
 }
 
-int sceUsbStart(const char* driverName, u32 argsSize, u32 argsPtr) {
+static int sceUsbStart(const char* driverName, u32 argsSize, u32 argsPtr) {
 	ERROR_LOG(HLE, "UNIMPL sceUsbStart(%s, %i, %08x)", driverName, argsSize, argsPtr);
 	usbStarted = true;
 	return 0;
 }
 
-int sceUsbStop(const char* driverName, u32 argsSize, u32 argsPtr) {
+static int sceUsbStop(const char* driverName, u32 argsSize, u32 argsPtr) {
 	ERROR_LOG(HLE, "UNIMPL sceUsbStop(%s, %i, %08x)", driverName, argsSize, argsPtr);
 	usbStarted = false;
 	return 0;
 }
 
-int sceUsbGetState() {
+static int sceUsbGetState() {
 	ERROR_LOG(HLE, "UNIMPL sceUsbGetState");
 	int state = (usbStarted ? USB_STATUS_STARTED : USB_STATUS_STOPPED)
 	    | (usbConnected ? USB_STATUS_CONNECTED : USB_STATUS_DISCONNECTED)
@@ -81,13 +81,13 @@ int sceUsbGetState() {
 	return state;
 }
 
-int sceUsbActivate(u32 pid) {
+static int sceUsbActivate(u32 pid) {
 	ERROR_LOG(HLE, "UNIMPL sceUsbActivate(%i)", pid);
 	usbActivated = true;
 	return 0;
 }
 
-int sceUsbDeactivate(u32 pid) {
+static int sceUsbDeactivate(u32 pid) {
 	ERROR_LOG(HLE, "UNIMPL sceUsbDeactivate(%i)", pid);
 	usbActivated = false;
 	return 0;

--- a/Core/HLE/sceUsbGps.cpp
+++ b/Core/HLE/sceUsbGps.cpp
@@ -26,12 +26,12 @@ enum UsbStatus {
 	GPS_STATE_ON = 3,
 };
 
-int sceUsbGpsGetState(u32 stateAddr) {
+static int sceUsbGpsGetState(u32 stateAddr) {
 	ERROR_LOG(HLE, "UNIMPL sceUsbGpsGetData(%08x)", stateAddr);
 	return 0;
 }
 
-int sceUsbGpsOpen() {
+static int sceUsbGpsOpen() {
 	ERROR_LOG(HLE, "UNIMPL sceUsbGpsOpen");
 	return 0;
 }

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -116,7 +116,7 @@ void __UtilityShutdown()
 	gamedataInstallDialog.Shutdown(true);
 }
 
-int __UtilityGetStatus()
+static int __UtilityGetStatus()
 {
 	if (currentDialogType == UTILITY_DIALOG_NONE) {
 		return 0;
@@ -126,7 +126,7 @@ int __UtilityGetStatus()
 	}
 }
 
-int sceUtilitySavedataInitStart(u32 paramAddr)
+static int sceUtilitySavedataInitStart(u32 paramAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
@@ -142,7 +142,7 @@ int sceUtilitySavedataInitStart(u32 paramAddr)
 	return ret;
 }
 
-int sceUtilitySavedataShutdownStart()
+static int sceUtilitySavedataShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
@@ -156,7 +156,7 @@ int sceUtilitySavedataShutdownStart()
 	return ret;
 }
 
-int sceUtilitySavedataGetStatus()
+static int sceUtilitySavedataGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
@@ -174,7 +174,7 @@ int sceUtilitySavedataGetStatus()
 	return status;
 }
 
-int sceUtilitySavedataUpdate(int animSpeed)
+static int sceUtilitySavedataUpdate(int animSpeed)
 {
 	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
@@ -189,7 +189,7 @@ int sceUtilitySavedataUpdate(int animSpeed)
 	return result;
 }
 
-u32 sceUtilityLoadAvModule(u32 module)
+static u32 sceUtilityLoadAvModule(u32 module)
 {
 	if (module > 7)
 	{
@@ -201,13 +201,13 @@ u32 sceUtilityLoadAvModule(u32 module)
 	return hleDelayResult(0, "utility av module loaded", 25000);
 }
 
-u32 sceUtilityUnloadAvModule(u32 module)
+static u32 sceUtilityUnloadAvModule(u32 module)
 {
 	INFO_LOG(SCEUTILITY,"0=sceUtilityUnloadAvModule(%i)", module);
 	return hleDelayResult(0, "utility av module unloaded", 800);
 }
 
-u32 sceUtilityLoadModule(u32 module)
+static u32 sceUtilityLoadModule(u32 module)
 {
 	// TODO: Not all modules between 0x100 and 0x601 are valid.
 	if (module < 0x100 || module > 0x601)
@@ -240,7 +240,7 @@ u32 sceUtilityLoadModule(u32 module)
 		return hleDelayResult(0, "utility module loaded", 25000);
 }
 
-u32 sceUtilityUnloadModule(u32 module)
+static u32 sceUtilityUnloadModule(u32 module)
 {
 	// TODO: Not all modules between 0x100 and 0x601 are valid.
 	if (module < 0x100 || module > 0x601)
@@ -265,7 +265,7 @@ u32 sceUtilityUnloadModule(u32 module)
 		return hleDelayResult(0, "utility module unloaded", 400);
 }
 
-int sceUtilityMsgDialogInitStart(u32 paramAddr)
+static int sceUtilityMsgDialogInitStart(u32 paramAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_MSG)
 	{
@@ -281,7 +281,7 @@ int sceUtilityMsgDialogInitStart(u32 paramAddr)
 	return ret;
 }
 
-int sceUtilityMsgDialogShutdownStart()
+static int sceUtilityMsgDialogShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_MSG)
 	{
@@ -295,7 +295,7 @@ int sceUtilityMsgDialogShutdownStart()
 	return ret;
 }
 
-int sceUtilityMsgDialogUpdate(int animSpeed)
+static int sceUtilityMsgDialogUpdate(int animSpeed)
 {
 	if (currentDialogType != UTILITY_DIALOG_MSG)
 	{
@@ -310,7 +310,7 @@ int sceUtilityMsgDialogUpdate(int animSpeed)
 	return ret;
 }
 
-int sceUtilityMsgDialogGetStatus()
+static int sceUtilityMsgDialogGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_MSG)
 	{
@@ -326,7 +326,7 @@ int sceUtilityMsgDialogGetStatus()
 	return status;
 }
 
-int sceUtilityMsgDialogAbort()
+static int sceUtilityMsgDialogAbort()
 {
 	if (currentDialogType != UTILITY_DIALOG_MSG)
 	{
@@ -341,7 +341,7 @@ int sceUtilityMsgDialogAbort()
 
 
 // On screen keyboard
-int sceUtilityOskInitStart(u32 oskPtr)
+static int sceUtilityOskInitStart(u32 oskPtr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_OSK)
 	{
@@ -357,7 +357,7 @@ int sceUtilityOskInitStart(u32 oskPtr)
 	return ret;
 }
 
-int sceUtilityOskShutdownStart()
+static int sceUtilityOskShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_OSK)
 	{
@@ -371,7 +371,7 @@ int sceUtilityOskShutdownStart()
 	return ret;
 }
 
-int sceUtilityOskUpdate(int animSpeed)
+static int sceUtilityOskUpdate(int animSpeed)
 {
 	if (currentDialogType != UTILITY_DIALOG_OSK)
 	{
@@ -384,7 +384,7 @@ int sceUtilityOskUpdate(int animSpeed)
 	return ret;
 }
 
-int sceUtilityOskGetStatus()
+static int sceUtilityOskGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_OSK)
 	{
@@ -401,7 +401,7 @@ int sceUtilityOskGetStatus()
 }
 
 
-int sceUtilityNetconfInitStart(u32 paramsAddr)
+static int sceUtilityNetconfInitStart(u32 paramsAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_NET) {
 		WARN_LOG(SCEUTILITY, "sceUtilityNetconfInitStart(%08x): wrong dialog type", paramsAddr);
@@ -416,7 +416,7 @@ int sceUtilityNetconfInitStart(u32 paramsAddr)
 	return ret;
 }
 
-int sceUtilityNetconfShutdownStart()
+static int sceUtilityNetconfShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_NET) {
 		WARN_LOG(SCEUTILITY, "sceUtilityNetconfShutdownStart(): wrong dialog type");
@@ -429,14 +429,14 @@ int sceUtilityNetconfShutdownStart()
 	return ret;
 }
 
-int sceUtilityNetconfUpdate(int animSpeed)
+static int sceUtilityNetconfUpdate(int animSpeed)
 {
 	int ret = netDialog.Update(animSpeed);
 	ERROR_LOG(SCEUTILITY, "UNIMPL %08x=sceUtilityNetconfUpdate(%i)", ret, animSpeed);
 	return ret;
 }
 
-int sceUtilityNetconfGetStatus()
+static int sceUtilityNetconfGetStatus()
 {
 	// Spam in Danball Senki BOOST
 	if (currentDialogType != UTILITY_DIALOG_NET) {
@@ -454,7 +454,7 @@ int sceUtilityNetconfGetStatus()
 
 //TODO: Implement all sceUtilityScreenshot* for real, it doesn't seem to be complex
 //but it requires more investigation
-int sceUtilityScreenshotInitStart(u32 paramAddr)
+static int sceUtilityScreenshotInitStart(u32 paramAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_SCREENSHOT)
 	{
@@ -470,7 +470,7 @@ int sceUtilityScreenshotInitStart(u32 paramAddr)
 	return retval;
 }
 
-int sceUtilityScreenshotShutdownStart()
+static int sceUtilityScreenshotShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_SCREENSHOT)
 	{
@@ -484,7 +484,7 @@ int sceUtilityScreenshotShutdownStart()
 	return ret;
 }
 
-int sceUtilityScreenshotUpdate(u32 animSpeed)
+static int sceUtilityScreenshotUpdate(u32 animSpeed)
 {
 	if (currentDialogType != UTILITY_DIALOG_SCREENSHOT)
 	{
@@ -497,7 +497,7 @@ int sceUtilityScreenshotUpdate(u32 animSpeed)
 	return ret;
 }
 
-int sceUtilityScreenshotGetStatus()
+static int sceUtilityScreenshotGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_SCREENSHOT)
 	{
@@ -513,7 +513,7 @@ int sceUtilityScreenshotGetStatus()
 	return status;
 }
 
-int sceUtilityScreenshotContStart(u32 paramAddr)
+static int sceUtilityScreenshotContStart(u32 paramAddr)
 {
 	if (currentDialogType != UTILITY_DIALOG_SCREENSHOT)
 	{
@@ -526,7 +526,7 @@ int sceUtilityScreenshotContStart(u32 paramAddr)
 	return ret;
 }
 
-int sceUtilityGamedataInstallInitStart(u32 paramsAddr)
+static int sceUtilityGamedataInstallInitStart(u32 paramsAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_GAMEDATAINSTALL)
 	{
@@ -541,7 +541,7 @@ int sceUtilityGamedataInstallInitStart(u32 paramsAddr)
 	return ret;
 }
 
-int sceUtilityGamedataInstallShutdownStart() {
+static int sceUtilityGamedataInstallShutdownStart() {
 	if (currentDialogType != UTILITY_DIALOG_GAMEDATAINSTALL)
 	{
 		WARN_LOG(SCEUTILITY, "sceUtilityGamedataInstallShutdownStart(): wrong dialog type");
@@ -553,7 +553,7 @@ int sceUtilityGamedataInstallShutdownStart() {
 	return gamedataInstallDialog.Shutdown();
 }
 
-int sceUtilityGamedataInstallUpdate(int animSpeed) {
+static int sceUtilityGamedataInstallUpdate(int animSpeed) {
 	if (currentDialogType != UTILITY_DIALOG_GAMEDATAINSTALL)
 	{
 		WARN_LOG(SCEUTILITY, "sceUtilityGamedataInstallUpdate(%i): wrong dialog type", animSpeed);
@@ -565,7 +565,7 @@ int sceUtilityGamedataInstallUpdate(int animSpeed) {
 	return ret;
 }
 
-int sceUtilityGamedataInstallGetStatus()
+static int sceUtilityGamedataInstallGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_GAMEDATAINSTALL)
 	{
@@ -579,7 +579,7 @@ int sceUtilityGamedataInstallGetStatus()
 	return status;
 }
 
-int sceUtilityGamedataInstallAbort()
+static int sceUtilityGamedataInstallAbort()
 {
 	if (currentDialogType != UTILITY_DIALOG_GAMEDATAINSTALL)
 	{
@@ -594,13 +594,13 @@ int sceUtilityGamedataInstallAbort()
 }
 
 //TODO: should save to config file
-u32 sceUtilitySetSystemParamString(u32 id, u32 strPtr)
+static u32 sceUtilitySetSystemParamString(u32 id, u32 strPtr)
 {
 	WARN_LOG_REPORT(SCEUTILITY, "sceUtilitySetSystemParamString(%i, %08x)", id, strPtr);
 	return 0;
 }
 
-u32 sceUtilityGetSystemParamString(u32 id, u32 destaddr, int destSize)
+static u32 sceUtilityGetSystemParamString(u32 id, u32 destaddr, int destSize)
 {
 	DEBUG_LOG(SCEUTILITY, "sceUtilityGetSystemParamString(%i, %08x, %i)", id, destaddr, destSize);
 	char *buf = (char *)Memory::GetPointer(destaddr);
@@ -619,7 +619,7 @@ u32 sceUtilityGetSystemParamString(u32 id, u32 destaddr, int destSize)
 	return 0;
 }
 
-u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr)
+static u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr)
 {
 	DEBUG_LOG(SCEUTILITY,"sceUtilityGetSystemParamInt(%i, %08x)", id,destaddr);
 	u32 param = 0;
@@ -660,48 +660,48 @@ u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr)
 	return 0;
 }
 
-u32 sceUtilityLoadNetModule(u32 module)
+static u32 sceUtilityLoadNetModule(u32 module)
 {
 	DEBUG_LOG(SCEUTILITY,"FAKE: sceUtilityLoadNetModule(%i)", module);
 	return 0;
 }
 
-u32 sceUtilityUnloadNetModule(u32 module)
+static u32 sceUtilityUnloadNetModule(u32 module)
 {
 	DEBUG_LOG(SCEUTILITY,"FAKE: sceUtilityUnloadNetModule(%i)", module);
 	return 0;
 }
 
-void sceUtilityInstallInitStart(u32 unknown)
+static void sceUtilityInstallInitStart(u32 unknown)
 {
 	WARN_LOG_REPORT(SCEUTILITY, "UNIMPL sceUtilityInstallInitStart()");
 }
 
-int sceUtilityStoreCheckoutShutdownStart()
+static int sceUtilityStoreCheckoutShutdownStart()
 {
 	ERROR_LOG(SCEUTILITY,"UNIMPL sceUtilityStoreCheckoutShutdownStart()");
 	return 0;
 }
 
-int sceUtilityStoreCheckoutInitStart(u32 paramsPtr)
+static int sceUtilityStoreCheckoutInitStart(u32 paramsPtr)
 {
 	ERROR_LOG_REPORT(SCEUTILITY,"UNIMPL sceUtilityStoreCheckoutInitStart(%d)", paramsPtr);
 	return 0;
 }
 
-int sceUtilityStoreCheckoutUpdate(int drawSpeed)
+static int sceUtilityStoreCheckoutUpdate(int drawSpeed)
 {
 	ERROR_LOG(SCEUTILITY,"UNIMPL sceUtilityStoreCheckoutUpdate(%d)", drawSpeed);
 	return 0;
 }
 
-int sceUtilityStoreCheckoutGetStatus()
+static int sceUtilityStoreCheckoutGetStatus()
 {
 	ERROR_LOG(SCEUTILITY,"UNIMPL sceUtilityStoreCheckoutGetStatus()");
 	return 0;
 }
 
-int sceUtilityGameSharingShutdownStart()
+static int sceUtilityGameSharingShutdownStart()
 {
 	if (currentDialogType != UTILITY_DIALOG_GAMESHARING)
 	{
@@ -714,7 +714,7 @@ int sceUtilityGameSharingShutdownStart()
 	return 0;
 }
 
-int sceUtilityGameSharingInitStart(u32 paramsPtr)
+static int sceUtilityGameSharingInitStart(u32 paramsPtr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_GAMESHARING)
 	{
@@ -728,7 +728,7 @@ int sceUtilityGameSharingInitStart(u32 paramsPtr)
 	return 0;
 }
 
-int sceUtilityGameSharingUpdate(int animSpeed)
+static int sceUtilityGameSharingUpdate(int animSpeed)
 {
 	if (currentDialogType != UTILITY_DIALOG_GAMESHARING)
 	{
@@ -740,7 +740,7 @@ int sceUtilityGameSharingUpdate(int animSpeed)
 	return 0;
 }
 
-int sceUtilityGameSharingGetStatus()
+static int sceUtilityGameSharingGetStatus()
 {
 	if (currentDialogType != UTILITY_DIALOG_GAMESHARING)
 	{

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -39,7 +39,7 @@ void __VaudioDoState(PointerWrap &p) {
 	p.Do(vaudioReserved);
 }
 
-u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
+static u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
 	if (vaudioReserved) {
 		ERROR_LOG(SCEAUDIO, "sceVaudioChReserve(%i, %i, %i) - already reserved", sampleCount, freq, format);
 		return SCE_KERNEL_ERROR_BUSY;
@@ -60,7 +60,7 @@ u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
 	return 0;
 }
 
-u32 sceVaudioChRelease() {
+static u32 sceVaudioChRelease() {
 	DEBUG_LOG(SCEAUDIO, "sceVaudioChRelease(...)");
 	if (!chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
@@ -72,7 +72,7 @@ u32 sceVaudioChRelease() {
 	}
 }
 
-u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
+static u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
 	DEBUG_LOG(SCEAUDIO, "sceVaudioOutputBlocking(%i, %08x)", vol, buffer);
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].leftVolume = vol;
 	chans[PSP_AUDIO_CHANNEL_OUTPUT2].rightVolume = vol;
@@ -81,12 +81,12 @@ u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
 	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, true);
 }
 
-u32 sceVaudioSetEffectType(int effectType, int vol) {
+static u32 sceVaudioSetEffectType(int effectType, int vol) {
 	ERROR_LOG_REPORT(SCEAUDIO, "UNIMPL sceVaudioSetEffectType(%i, %i)", effectType, vol);
 	return 0;
 }
 
-u32 sceVaudioSetAlcMode(int alcMode) {
+static u32 sceVaudioSetAlcMode(int alcMode) {
 	ERROR_LOG_REPORT(SCEAUDIO, "UNIMPL sceVaudioSetAlcMode(%i)", alcMode);
 	return 0;
 }


### PR DESCRIPTION
Silences a load of warnings if ever compiling with -Wall or prototype warnings. Also has the side benefit of making it more indicative of which functions are used externally.

Confirmed to compile fine on OSX.
