### PR TITLE
MIPSAnalyst: Pass strings by const reference.

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1108,7 +1108,7 @@ skip:
 		return 0;
 	}
 
-	void SetHashMapFilename(std::string filename) {
+	void SetHashMapFilename(const std::string& filename) {
 		if (filename.empty())
 			hashmapFileName = GetSysDirectory(DIRECTORY_SYSTEM) + "knownfuncs.ini";
 		else
@@ -1180,7 +1180,7 @@ skip:
 		}
 	}
 
-	void LoadHashMap(std::string filename) {
+	void LoadHashMap(const std::string& filename) {
 		FILE *file = File::OpenCFile(filename, "rt");
 		if (!file) {
 			WARN_LOG(LOADER, "Could not load hash map: %s", filename.c_str());

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -107,9 +107,9 @@ namespace MIPSAnalyst
 	void ForgetFunctions(u32 startAddr, u32 endAddr);
 	void CompileLeafs();
 
-	void SetHashMapFilename(std::string filename = "");
+	void SetHashMapFilename(const std::string& filename = "");
 	void LoadBuiltinHashMap();
-	void LoadHashMap(std::string filename);
+	void LoadHashMap(const std::string& filename);
 	void StoreHashMap(std::string filename = "");
 
 	const char *LookupHash(u64 hash, u32 funcSize);


### PR DESCRIPTION
StoreHashMap is left alone as it modifies the parameter based on a conditional.
