### PR TITLE
use libc++ for iOS to avoid additional directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,8 @@ if(NOT MSVC)
 
 	if(IOS)
 		add_definitions(-DGL_ETC1_RGB8_OES=0)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -U__STRICT_ANSI__")
+		set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 		# armv7s (without resorting to FastMemory) is still a work in progress
 		# comment out the next line to enable default/"standard" architectures (which is a fat armv7/armv7s binary)
 		set(CMAKE_OSX_ARCHITECTURES "armv7")

--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -28,19 +28,11 @@
 // - Serialization code for anything complex has to be manually written.
 
 #include <map>
-#ifdef IOS
-#include <tr1/unordered_map>
-namespace std {
-	using std::tr1::unordered_map;
-	using std::tr1::unordered_multimap;
-}
-#else
 #include <unordered_map>
-#endif
 #include <deque>
 #include <list>
 #include <set>
-#if defined(IOS) || defined(MACGNUSTD)
+#if defined(MACGNUSTD)
 #include <tr1/type_traits>
 #else
 #include <type_traits>
@@ -50,7 +42,7 @@ namespace std {
 #include "FileUtil.h"
 #include "../ext/snappy/snappy-c.h"
 
-#if defined(IOS) || defined(MACGNUSTD)
+#if defined(MACGNUSTD)
 namespace std {
 	using tr1::is_pointer;
 }

--- a/Common/StdMutex.h
+++ b/Common/StdMutex.h
@@ -8,7 +8,7 @@
 // Note: __MAC_10_7 is defined on 10.7+.
 #if (GCC_VERSION >= GCC_VER(4,4,0) && __GXX_EXPERIMENTAL_CXX0X__ || defined(__APPLE__)) \
 /* GCC 4.4 provides <mutex>, except on these platforms: */ \
-    && !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(IOS) && !defined(MACGNUSTD)
+    && !defined(ANDROID) && !defined(__SYMBIAN32__) && !defined(MACGNUSTD)
 #include <mutex>
 #else
 

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -17,15 +17,7 @@
 
 #include <algorithm>
 #include <map>
-#ifdef IOS
-#include <tr1/unordered_map>
-namespace std {
-	using std::tr1::unordered_map;
-	using std::tr1::unordered_multimap;
-}
-#else
 #include <unordered_map>
-#endif
 #include "Common/ChunkFile.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/HLE.h"

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -18,15 +18,7 @@
 #pragma once
 
 #include <map>
-#ifdef IOS
-#include <tr1/unordered_map>
-namespace std {
-	using std::tr1::unordered_map;
-	using std::tr1::unordered_multimap;
-}
-#else
 #include <unordered_map>
-#endif
 #include <vector>
 #include <string>
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -16,15 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <map>
-#ifdef IOS
-#include <tr1/unordered_map>
-namespace std {
-	using std::tr1::unordered_map;
-	using std::tr1::unordered_multimap;
-};
-#else
 #include <unordered_map>
-#endif
 #include <set>
 #include "base/mutex.h"
 #include "ext/cityhash/city.h"

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -17,15 +17,7 @@
 
 #pragma once
 
-#if defined(IOS)
-#include <tr1/unordered_map>
-namespace std {
-	using std::tr1::unordered_map;
-}
-#else
 #include <unordered_map>
-#endif
-
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Common/IndexGenerator.h"
 #include "GPU/Common/VertexDecoderCommon.h"

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -38,7 +38,7 @@
 #include "Core/Config.h"
 #include "UI/GameInfoCache.h"
 
-#if defined(__SYMBIAN32__) || defined(IOS)
+#ifdef __SYMBIAN32__
 #define unique_ptr auto_ptr
 #endif
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -96,7 +96,7 @@
 #include "Common/KeyMap.h"
 #endif
 
-#if defined(__SYMBIAN32__) || defined(IOS)
+#ifdef __SYMBIAN32__
 #define unique_ptr auto_ptr
 #endif
 


### PR DESCRIPTION
This includes the change proposed by @unknownbrackets in https://github.com/hrydgard/ppsspp/issues/6972 along with the resulting removal of all of the iOS directives added when using libstdc++
