### PR TITLE
Allow running JitHarness (and other unittests) on Android

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -942,9 +942,7 @@ DataType SymbolMap::GetDataType(u32 startAddress) const {
 	return it->second.type;
 }
 
-#if defined(_WIN32)
-
-void SymbolMap::getLabels(std::vector<LabelDefinition>& dest) const
+void SymbolMap::GetLabels(std::vector<LabelDefinition> &dest) const
 {
 	lock_guard guard(lock_);
 	for (auto it = activeLabels.begin(); it != activeLabels.end(); it++) {
@@ -954,6 +952,8 @@ void SymbolMap::getLabels(std::vector<LabelDefinition>& dest) const
 		dest.push_back(entry);
 	}
 }
+
+#if defined(_WIN32)
 
 struct DefaultSymbol {
 	u32 address;

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -26,9 +26,7 @@
 
 #include "Common/CommonTypes.h"
 
-#ifdef _WIN32
 #include "ext/armips/Core/Assembler.h"
-#endif
 
 enum SymbolType {
 	ST_NONE     = 0,
@@ -85,8 +83,8 @@ public:
 
 #ifdef _WIN32
 	void FillSymbolListBox(HWND listbox, SymbolType symType) const;
-	void getLabels(std::vector<LabelDefinition>& dest) const;
 #endif
+	void GetLabels(std::vector<LabelDefinition> &dest) const;
 
 	void AddModule(const char *name, u32 address, u32 size);
 	void UnloadModule(u32 address, u32 size);

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -9,20 +9,20 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/Debugger/SymbolMap.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ANDROID)
 #include "ext/armips/Core/Assembler.h"
 #endif
 
 namespace MIPSAsm
 {	
-	std::wstring errorText;
+	static std::wstring errorText;
 
 std::wstring GetAssembleError()
 {
 	return errorText;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ANDROID)
 class PspAssemblerFile: public AssemblerFile
 {
 public:
@@ -65,7 +65,7 @@ private:
 
 bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ANDROID)
 	PspAssemblerFile file;
 	StringList errors;
 
@@ -79,7 +79,7 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 	args.memoryFile = &file;
 	args.errorsResult = &errors;
 	
-	symbolMap.getLabels(args.labels);
+	symbolMap.GetLabels(args.labels);
 
 	errorText = L"";
 	if (!runArmips(args))
@@ -96,6 +96,7 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 
 	return true;
 #else
+	errorText = L"Unsupported platform";
 	return false;
 #endif
 }

--- a/GPU/GLES/FragmentTestCache.cpp
+++ b/GPU/GLES/FragmentTestCache.cpp
@@ -105,7 +105,7 @@ GLuint FragmentTestCache::CreateTestTexture(const GEComparison funcs[4], const u
 	// Build the logic map.
 	for (int color = 0; color < 256; ++color) {
 		for (int i = 0; i < 4; ++i) {
-			bool res;
+			bool res = true;
 			if (valid[i]) {
 				switch (funcs[i]) {
 				case GE_COMP_NEVER:
@@ -133,8 +133,6 @@ GLuint FragmentTestCache::CreateTestTexture(const GEComparison funcs[4], const u
 					res = (color & masks[i]) >= (refs[i] & masks[i]);
 					break;
 				}
-			} else {
-				res = true;
 			}
 			scratchpad_[color * 4 + i] = res ? 0xFF : 0;
 		}

--- a/android/ab.cmd
+++ b/android/ab.cmd
@@ -5,4 +5,4 @@ copy ..\assets\langregion.ini assets\langregion.ini
 copy ..\assets\*.png assets
 SET NDK=C:\AndroidNDK
 SET NDK_MODULE_PATH=..;..\native\ext
-%NDK%/ndk-build -j9 %1
+%NDK%/ndk-build -j9 %*

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -333,6 +333,75 @@ ifeq ($(HEADLESS),1)
   include $(BUILD_EXECUTABLE)
 endif
 
+ifeq ($(UNITTEST),1)
+  include $(CLEAR_VARS)
+  include $(LOCAL_PATH)/Locals.mk
+
+  # Android 5.0 requires PIE for executables.  Only supported on 4.1+, but this is testing anyway.
+  LOCAL_CFLAGS += -fPIE
+  LOCAL_LDFLAGS += -fPIE -pie
+
+  LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SRC)/ext/armips $(LOCAL_C_INCLUDES)
+
+  LIBARMIPS_FILES := \
+	$(SRC)/ext/armips/Archs/ARM/Arm.cpp \
+	$(SRC)/ext/armips/Archs/ARM/ArmOpcodes.cpp \
+	$(SRC)/ext/armips/Archs/ARM/ArmRelocator.cpp \
+	$(SRC)/ext/armips/Archs/ARM/CArmInstruction.cpp \
+	$(SRC)/ext/armips/Archs/ARM/CThumbInstruction.cpp \
+	$(SRC)/ext/armips/Archs/ARM/Pool.cpp \
+	$(SRC)/ext/armips/Archs/ARM/ThumbOpcodes.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/CMipsInstruction.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/CMipsMacro.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/Mips.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/MipsElfFile.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/MipsMacros.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/MipsOpcodes.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/MipsPSP.cpp \
+	$(SRC)/ext/armips/Archs/MIPS/PsxRelocator.cpp \
+	$(SRC)/ext/armips/Archs/Z80/CZ80Instruction.cpp \
+	$(SRC)/ext/armips/Archs/Z80/z80.cpp \
+	$(SRC)/ext/armips/Archs/Z80/z80Opcodes.cpp \
+	$(SRC)/ext/armips/Archs/Architecture.cpp \
+	$(SRC)/ext/armips/Commands/CAssemblerCommand.cpp \
+	$(SRC)/ext/armips/Commands/CAssemblerLabel.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveArea.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveConditional.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveData.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveFile.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveFill.cpp \
+	$(SRC)/ext/armips/Commands/CDirectiveMessage.cpp \
+	$(SRC)/ext/armips/Core/ELF/ElfFile.cpp \
+	$(SRC)/ext/armips/Core/ELF/ElfRelocator.cpp \
+	$(SRC)/ext/armips/Core/Assembler.cpp \
+	$(SRC)/ext/armips/Core/CMacro.cpp \
+	$(SRC)/ext/armips/Core/Common.cpp \
+	$(SRC)/ext/armips/Core/Directives.cpp \
+	$(SRC)/ext/armips/Core/FileManager.cpp \
+	$(SRC)/ext/armips/Core/MathParser.cpp \
+	$(SRC)/ext/armips/Core/Misc.cpp \
+	$(SRC)/ext/armips/Core/SymbolData.cpp \
+	$(SRC)/ext/armips/Core/SymbolTable.cpp \
+	$(SRC)/ext/armips/Util/ByteArray.cpp \
+	$(SRC)/ext/armips/Util/CommonClasses.cpp \
+	$(SRC)/ext/armips/Util/CRC.cpp \
+	$(SRC)/ext/armips/Util/EncodingTable.cpp \
+	$(SRC)/ext/armips/Util/FileClasses.cpp \
+	$(SRC)/ext/armips/Util/StringFormat.cpp \
+	$(SRC)/ext/armips/Util/Util.cpp
+
+  LOCAL_MODULE := ppsspp_unittest
+  LOCAL_SRC_FILES := \
+	$(LIBARMIPS_FILES) \
+    $(EXEC_AND_LIB_FILES) \
+	$(SRC)/Core/MIPS/MIPSAsm.cpp \
+    $(SRC)/UnitTest/JitHarness.cpp \
+    $(SRC)/UnitTest/TestArmEmitter.cpp \
+    $(SRC)/UnitTest/UnitTest.cpp
+
+  include $(BUILD_EXECUTABLE)
+endif
+
 $(call import-module,libzip)
 $(call import-module,native)
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -320,6 +320,10 @@ ifeq ($(HEADLESS),1)
   include $(CLEAR_VARS)
   include $(LOCAL_PATH)/Locals.mk
 
+  # Android 5.0 requires PIE for executables.  Only supported on 4.1+, but this is testing anyway.
+  LOCAL_CFLAGS += -fPIE
+  LOCAL_LDFLAGS += -fPIE -pie
+
   LOCAL_MODULE := ppsspp_headless
   LOCAL_SRC_FILES := \
     $(EXEC_AND_LIB_FILES) \

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 #include "base/timeutil.h"
+#include "input/input_state.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
@@ -144,7 +145,7 @@ bool TestJit() {
 		for (size_t j = 0; j < ARRAY_SIZE(lines); ++j) {
 			p++;
 			if (!MIPSAsm::MipsAssembleOpcode(lines[j], currentDebugMIPS, addr)) {
-				printf("ERROR: %S\n", MIPSAsm::GetAssembleError().c_str());
+				printf("ERROR: %ls\n", MIPSAsm::GetAssembleError().c_str());
 				compileSuccess = false;
 			}
 			addr += 4;
@@ -165,7 +166,7 @@ bool TestJit() {
 
 	printf("\n");
 
-	double jit_speed, interp_speed;
+	double jit_speed = 0.0, interp_speed = 0.0;
 	if (compileSuccess) {
 		interp_speed = ExecCPUTest();
 		mipsr4k.UpdateCore(CPU_JIT);


### PR DESCRIPTION
Steps:
1. `cd android`
2. `ab -DUNITTEST=1 APP_ABI=armeabi-v7a` (APP_ABI is just to build faster... can also add `NDK_DEBUG=1` for gdb/ds-5 and `HEADLESS=1`)
3. `adb push libs/armeabi-v7a/ppsspp_unittest //data/local/tmp/`
4. `adb shell "chmod 0777 /data/local/tmp/ppsspp_unittest"`
5. `adb shell /data/local/tmp/ppsspp_unittest Jit"`

-[Unknown]
