### PR TITLE
jit: Prioritize clobbered regs and discard them on spill

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -63,7 +63,7 @@ namespace MIPSComp
 {
 	using namespace ArmGen;
 
-ArmJit::ArmJit(MIPSState *mips) : blocks(mips, this), gpr(mips, &jo), fpr(mips, &js, &jo), mips_(mips)
+ArmJit::ArmJit(MIPSState *mips) : blocks(mips, this), gpr(mips, &js, &jo), fpr(mips, &js, &jo), mips_(mips)
 { 
 	logBlocks = 0;
 	dontLogBlocks = 0;

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -28,7 +28,7 @@
 
 using namespace ArmGen;
 
-ArmRegCache::ArmRegCache(MIPSState *mips, MIPSComp::ArmJitOptions *options) : mips_(mips), options_(options) {
+ArmRegCache::ArmRegCache(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::ArmJitOptions *jo) : mips_(mips), js_(js), jo_(jo) {
 }
 
 void ArmRegCache::Init(ARMXEmitter *emitter) {
@@ -55,7 +55,7 @@ const ARMReg *ArmRegCache::GetMIPSAllocationOrder(int &count) {
 	// R8 is used to preserve flags in nasty branches.
 	// R9 and upwards are reserved for jit basics.
 	// R14 (LR) is used as a scratch reg (overwritten on calls/return.)
-	if (options_->downcountInRegister) {
+	if (jo_->downcountInRegister) {
 		static const ARMReg allocationOrder[] = {
 			R1, R2, R3, R4, R5, R6, R12,
 		};

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -75,11 +75,12 @@ enum {
 
 namespace MIPSComp {
 	struct ArmJitOptions;
+	struct JitState;
 }
 
 class ArmRegCache {
 public:
-	ArmRegCache(MIPSState *mips, MIPSComp::ArmJitOptions *options);
+	ArmRegCache(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::ArmJitOptions *jo);
 	~ArmRegCache() {}
 
 	void Init(ArmGen::ARMXEmitter *emitter);
@@ -132,8 +133,9 @@ private:
 	ArmGen::ARMReg FindBestToSpill(bool unusedOnly);
 		
 	MIPSState *mips_;
-	MIPSComp::ArmJitOptions *options_;
 	ArmGen::ARMXEmitter *emit_;
+	MIPSComp::JitState *js_;
+	MIPSComp::ArmJitOptions *jo_;
 	u32 compilerPC_;
 
 	enum {

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -130,7 +130,7 @@ private:
 	const ArmGen::ARMReg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(ArmGen::ARMReg reg, MIPSGPReg mipsReg, int mapFlags);
 	int FlushGetSequential(MIPSGPReg startMipsReg, bool allowFlushImm);
-	ArmGen::ARMReg FindBestToSpill(bool unusedOnly);
+	ArmGen::ARMReg FindBestToSpill(bool unusedOnly, bool *clobbered);
 		
 	MIPSState *mips_;
 	ArmGen::ARMXEmitter *emit_;

--- a/Core/MIPS/ARM/ArmRegCacheFPU.h
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.h
@@ -60,7 +60,7 @@ struct FPURegMIPS {
 	// Where is this MIPS register?
 	RegMIPSLoc loc;
 	// Data (only one of these is used, depending on loc. Could make a union).
-	int reg;
+	u32 reg;
 	int lane;
 
 	bool spillLock;  // if true, this register cannot be spilled.

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -79,6 +79,8 @@ namespace MIPSAnalyst
 
 	// This tells us if the reg is used within intrs of addr (also includes likely delay slots.)
 	bool IsRegisterUsed(MIPSGPReg reg, u32 addr, int instrs);
+	// This tells us if the reg is clobbered within intrs of addr (e.g. it is surely not used.)
+	bool IsRegisterClobbered(MIPSGPReg reg, u32 addr, int instrs);
 
 	struct AnalyzedFunction {
 		u32 start;

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -133,7 +133,6 @@ Jit::Jit(MIPSState *mips) : blocks(mips, this), mips_(mips)
 	blocks.Init();
 	gpr.SetEmitter(this);
 	fpr.SetEmitter(this);
-	fpr.SetOptions(&jo);
 	AllocCodeSpace(1024 * 1024 * 16);
 	asm_.Init(mips, this);
 	safeMemFuncs.Init(&thunks);
@@ -419,8 +418,8 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 
 	MIPSAnalyst::AnalysisResults analysis = MIPSAnalyst::Analyze(em_address);
 
-	gpr.Start(mips_, analysis);
-	fpr.Start(mips_, analysis);
+	gpr.Start(mips_, &js, &jo, analysis);
+	fpr.Start(mips_, &js, &jo, analysis);
 
 	js.numInstructions = 0;
 	while (js.compiling) {

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -52,7 +52,7 @@ GPRRegCache::GPRRegCache() : mips(0), emit(0) {
 	memset(xregs, 0, sizeof(xregs));
 }
 
-void GPRRegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
+void GPRRegCache::Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats) {
 	this->mips = mips;
 	for (int i = 0; i < NUM_X_REGS; i++) {
 		xregs[i].free = true;
@@ -85,6 +85,9 @@ void GPRRegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
 	}*/
 	//Find top regs - preload them (load bursts ain't bad)
 	//But only preload IF written OR reads >= 3
+
+	js_ = js;
+	jo_ = jo;
 }
 
 

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -56,12 +56,17 @@ struct GPRRegCacheState {
 	X64CachedReg xregs[NUM_X_REGS];
 };
 
+namespace MIPSComp {
+	struct JitOptions;
+	struct JitState;
+}
+
 class GPRRegCache
 {
 public:
 	GPRRegCache();
 	~GPRRegCache() {}
-	void Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats);
+	void Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats);
 
 	void DiscardRegContentsIfCached(MIPSGPReg preg);
 	void SetEmitter(Gen::XEmitter *emitter) {emit = emitter;}
@@ -116,4 +121,6 @@ private:
 	X64CachedReg xregs[NUM_X_REGS];
 
 	Gen::XEmitter *emit;
+	MIPSComp::JitState *js_;
+	MIPSComp::JitOptions *jo_;
 };

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -115,6 +115,7 @@ public:
 
 private:
 	Gen::X64Reg GetFreeXReg();
+	Gen::X64Reg FindBestToSpill(bool unusedOnly);
 	const int *GetAllocationOrder(int &count);
 
 	MIPSCachedReg regs[NUM_MIPS_GPRS];

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -115,7 +115,7 @@ public:
 
 private:
 	Gen::X64Reg GetFreeXReg();
-	Gen::X64Reg FindBestToSpill(bool unusedOnly);
+	Gen::X64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	const int *GetAllocationOrder(int &count);
 
 	MIPSCachedReg regs[NUM_MIPS_GPRS];

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -35,7 +35,7 @@ FPURegCache::FPURegCache() : mips(0), initialReady(false), emit(0) {
 	vregs = regs + 32;
 }
 
-void FPURegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
+void FPURegCache::Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats) {
 	this->mips = mips;
 
 	if (!initialReady) {
@@ -46,6 +46,9 @@ void FPURegCache::Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats) {
 	memcpy(xregs, xregsInitial, sizeof(xregs));
 	memcpy(regs, regsInitial, sizeof(regs));
 	pendingFlush = false;
+
+	js_ = js;
+	jo_ = jo;
 }
 
 void FPURegCache::SetupInitialRegs() {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -79,6 +79,7 @@ struct FPURegCacheState {
 
 namespace MIPSComp {
 	struct JitOptions;
+	struct JitState;
 }
 
 enum {
@@ -97,7 +98,7 @@ public:
 	FPURegCache();
 	~FPURegCache() {}
 
-	void Start(MIPSState *mips, MIPSAnalyst::AnalysisResults &stats);
+	void Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats);
 	void MapReg(int preg, bool doLoad = true, bool makeDirty = true);
 	void StoreFromRegister(int preg);
 	void StoreFromRegisterV(int preg) {
@@ -117,7 +118,6 @@ public:
 	int GetTempVS(u8 *v, VectorSize vsz);
 
 	void SetEmitter(Gen::XEmitter *emitter) {emit = emitter;}
-	void SetOptions(MIPSComp::JitOptions *jo) {jo_ = jo;}
 
 	void Flush();
 	int SanityCheck() const;
@@ -242,5 +242,6 @@ private:
 	static float tempValues[NUM_TEMPS];
 
 	Gen::XEmitter *emit;
+	MIPSComp::JitState *js_;
 	MIPSComp::JitOptions *jo_;
 };

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -351,7 +351,9 @@ TestItem availableTests[] = {
 	TEST_ITEM(Asin),
 	TEST_ITEM(SinCos),
 	TEST_ITEM(ArmEmitter),
+#ifndef ARM
 	TEST_ITEM(X64Emitter),
+#endif
 	TEST_ITEM(VFPUSinCos),
 	TEST_ITEM(MathUtil),
 	TEST_ITEM(Parsers),


### PR DESCRIPTION
When we're spilling a register, try to find a register that will be clobbered so we can discard it rather than storing.

This does sometimes happen when the reg is dirty, but it's not super common.  Anyway, it may still help us choose better registers even if it isn't dirty.

Also there is a small edge case: we can't allow a branch to discard a reg that its delay slot clobbers, because we map the branch's regs _after_ executing the delay slot.

Anyway, it also brings the spill logic from arm to x86 so they are more consistent.

Unfortunately, I didn't observe any real performance improvement from this in the games I tested.

-[Unknown]
