### PR TITLE
mips: Minor tweaks to the mips emitter

### DIFF
--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -268,6 +268,12 @@ void MIPSEmitter::LB(MIPSReg value, MIPSReg base, s16 offset) {
 	Write32Fields(26, 0x20, 21, base, 16, value, 0, (u16)offset);
 }
 
+void MIPSEmitter::LH(MIPSReg value, MIPSReg base, s16 offset) {
+	// 100001 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
+	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	Write32Fields(26, 0x21, 21, base, 16, value, 0, (u16)offset);
+}
+
 void MIPSEmitter::LW(MIPSReg value, MIPSReg base, s16 offset) {
 	// 100011 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
 	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
@@ -278,6 +284,12 @@ void MIPSEmitter::SB(MIPSReg value, MIPSReg base, s16 offset) {
 	// 101000 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
 	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x28, 21, base, 16, value, 0, (u16)offset);
+}
+
+void MIPSEmitter::SH(MIPSReg value, MIPSReg base, s16 offset) {
+	// 101001 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
+	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	Write32Fields(26, 0x29, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::SW(MIPSReg value, MIPSReg base, s16 offset) {

--- a/Common/MipsEmitter.h
+++ b/Common/MipsEmitter.h
@@ -168,9 +168,19 @@ public:
 	}
 
 	void LB(MIPSReg dest, MIPSReg base, s16 offset);
+	void LH(MIPSReg dest, MIPSReg base, s16 offset);
 	void LW(MIPSReg dest, MIPSReg base, s16 offset);
 	void SB(MIPSReg value, MIPSReg base, s16 offset);
+	void SH(MIPSReg dest, MIPSReg base, s16 offset);
 	void SW(MIPSReg value, MIPSReg base, s16 offset);
+
+	// These exist for the sole purpose of making compilation fail if you try to load/store from R+R.
+	void LB(MIPSReg dest, MIPSReg base, MIPSReg invalid);
+	void LH(MIPSReg dest, MIPSReg base, MIPSReg invalid);
+	void LW(MIPSReg dest, MIPSReg base, MIPSReg invalid);
+	void SB(MIPSReg value, MIPSReg base, MIPSReg invalid);
+	void SH(MIPSReg dest, MIPSReg base, MIPSReg invalid);
+	void SW(MIPSReg value, MIPSReg base, MIPSReg invalid);
 
 	void SLL(MIPSReg rd, MIPSReg rt, u8 sa);
 	void SRL(MIPSReg rd, MIPSReg rt, u8 sa);

--- a/Common/MipsEmitter.h
+++ b/Common/MipsEmitter.h
@@ -228,7 +228,11 @@ public:
 		MOVI2R(reg, (u32)val);
 	}
 	template <class T> void MOVP2R(MIPSReg reg, T *val) {
-		MOVI2R(reg, (intptr_t)(const void *)val);
+		if (sizeof(uintptr_t) > sizeof(u32)) {
+			MOVI2R(reg, (u64)(intptr_t)(const void *)val);
+		} else {
+			MOVI2R(reg, (u32)(intptr_t)(const void *)val);
+		}
 	}
 
 protected:


### PR DESCRIPTION
I think someone said there was a compilation problem in some version of gcc or something when the cast couldn't be resolved properly.

-[Unknown]
