### PR TITLE
x86jit: Minor tweaks to asm dispatcher

### DIFF
--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -95,9 +95,10 @@ void ArmJit::GenerateFixedCode()
 	//   * r2-r4
 	// Really starting to run low on registers already though...
 
-	MOVP2R(R11, Memory::base);
-	MOVP2R(R10, mips_);
-	MOVP2R(R9, GetBasePtr());
+	// R11, R10, R9
+	MOVP2R(MEMBASEREG, Memory::base);
+	MOVP2R(CTXREG, mips_);
+	MOVP2R(JITBASEREG, GetBasePtr());
 
 	// Doing this down here for better pipelining, just in case.
 	if (cpu_info.bNEON) {
@@ -162,10 +163,10 @@ void ArmJit::GenerateFixedCode()
 				// Another idea: Shift the bloc number left by two in the op, this would let us do
 				// LDR(R0, R9, R0); here, replacing the next instructions.
 #ifdef IOS
-				// TODO: Fix me, I'm ugly.
-				MOVI2R(R9, (u32)GetBasePtr());
+				// On iOS, R9 (JITBASEREG) is volatile.  We have to reload it.
+				MOVI2R(JITBASEREG, (u32)GetBasePtr());
 #endif
-				ADD(R0, R0, R9);
+				ADD(R0, R0, JITBASEREG);
 				B(R0);
 			SetCC(CC_AL);
 

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -23,6 +23,7 @@
 
 namespace ArmJitConstants {
 
+const ArmGen::ARMReg JITBASEREG = ArmGen::R9;
 const ArmGen::ARMReg CTXREG = ArmGen::R10;
 const ArmGen::ARMReg MEMBASEREG = ArmGen::R11;
 const ArmGen::ARMReg SCRATCHREG1 = ArmGen::R0;

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -45,17 +45,15 @@ static bool enableDebug = false;
 
 //GLOBAL STATIC ALLOCATIONS x86
 //EAX - ubiquitous scratch register - EVERYBODY scratches this
+//EBP - Pointer to fpr/gpr regs
 
 //GLOBAL STATIC ALLOCATIONS x64
 //EAX - ubiquitous scratch register - EVERYBODY scratches this
 //RBX - Base pointer of memory
-//R15 - Pointer to array of block pointers 
+//R14 - Pointer to fpr/gpr regs
+//R15 - Pointer to array of block pointers
 
 extern volatile CoreState coreState;
-
-// IDEA, NOT IMPLEMENTED: no more block numbers - hack opcodes just contain offset within
-// dynarec buffer, gets rid of lookup into block buffer
-// At this offset - 4, there is an int specifying the block number if needed.
 
 void ImHere()
 {
@@ -68,8 +66,8 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 	ABI_PushAllCalleeSavedRegsAndAdjustStack();
 #ifdef _M_X64
 	// Two statically allocated registers.
-	MOV(64, R(RBX), ImmPtr(Memory::base));
-	MOV(64, R(R15), ImmPtr(jit->GetBasePtr())); //It's below 2GB so 32 bits are good enough
+	MOV(64, R(MEMBASEREG), ImmPtr(Memory::base));
+	MOV(64, R(JITBASEREG), ImmPtr(jit->GetBasePtr())); //It's below 2GB so 32 bits are good enough
 #endif
 	// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but no VFPUR)
 	MOV(PTRBITS, R(CTXREG), ImmPtr(&mips->f[0]));
@@ -108,7 +106,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			_assert_msg_(CPU, Memory::base != 0, "Memory base bogus");
 			MOV(32, R(EAX), MDisp(EAX, (u32)Memory::base));
 #elif _M_X64
-			MOV(32, R(EAX), MComplex(RBX, RAX, SCALE_1, 0));
+			MOV(32, R(EAX), MComplex(MEMBASEREG, RAX, SCALE_1, 0));
 #endif
 			MOV(32, R(EDX), R(EAX));
 			AND(32, R(EDX), Imm32(MIPS_JITBLOCK_MASK));
@@ -123,7 +121,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 #ifdef _M_IX86
 				ADD(32, R(EAX), ImmPtr(jit->GetBasePtr()));
 #elif _M_X64
-				ADD(64, R(RAX), R(R15));
+				ADD(64, R(RAX), R(JITBASEREG));
 #endif
 				JMPptr(R(EAX));
 			SetJumpTarget(notfound);

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -71,6 +71,8 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 	MOV(64, R(RBX), ImmPtr(Memory::base));
 	MOV(64, R(R15), ImmPtr(jit->GetBasePtr())); //It's below 2GB so 32 bits are good enough
 #endif
+	// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but no VFPUR)
+	MOV(PTRBITS, R(CTXREG), ImmPtr(&mips->f[0]));
 
 	outerLoop = GetCodePtr();
 		jit->RestoreRoundingMode(true, this);
@@ -99,11 +101,8 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 
 			dispatcherNoCheck = GetCodePtr();
 
-			// TODO: Find a less costly place to put this (or multiple..)?
-			// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but no VFPUR)
-			MOV(PTRBITS, R(CTXREG), ImmPtr(&mips->f[0]));
-
 			MOV(32, R(EAX), M(&mips->pc));
+
 #ifdef _M_IX86
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
 			_assert_msg_(CPU, Memory::base != 0, "Memory base bogus");

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -100,6 +100,7 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit)
 			dispatcherNoCheck = GetCodePtr();
 
 			MOV(32, R(EAX), M(&mips->pc));
+			dispatcherInEAXNoCheck = GetCodePtr();
 
 #ifdef _M_IX86
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));

--- a/Core/MIPS/x86/Asm.h
+++ b/Core/MIPS/x86/Asm.h
@@ -56,6 +56,7 @@ public:
 	const u8 *dispatcher;
 	const u8 *dispatcherCheckCoreState;
 	const u8 *dispatcherNoCheck;
+	const u8 *dispatcherInEAXNoCheck;
 
 	const u8 *breakpointBailout;
 };

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -328,7 +328,7 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			fpr.MapRegsV(vregs, V_Quad, MAP_DIRTY);
 
 			// Offset = 0
-			MOVSS(fpr.RX(vregs[3]), MRegSum(RBX, RAX));
+			MOVSS(fpr.RX(vregs[3]), MRegSum(MEMBASEREG, RAX));
 
 			FixupBranch skip0 = J();
 			SetJumpTarget(next);
@@ -336,8 +336,8 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 1
-			MOVSS(fpr.RX(vregs[3]), MComplex(RBX, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[2]), MComplex(RBX, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 4));
+			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 0));
 
 			FixupBranch skip1 = J();
 			SetJumpTarget(next);
@@ -345,9 +345,9 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 2
-			MOVSS(fpr.RX(vregs[3]), MComplex(RBX, RAX, 1, 8));
-			MOVSS(fpr.RX(vregs[2]), MComplex(RBX, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[1]), MComplex(RBX, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 8));
+			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 4));
+			MOVSS(fpr.RX(vregs[1]), MComplex(MEMBASEREG, RAX, 1, 0));
 
 			FixupBranch skip2 = J();
 			SetJumpTarget(next);
@@ -355,10 +355,10 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 3
-			MOVSS(fpr.RX(vregs[3]), MComplex(RBX, RAX, 1, 12));
-			MOVSS(fpr.RX(vregs[2]), MComplex(RBX, RAX, 1, 8));
-			MOVSS(fpr.RX(vregs[1]), MComplex(RBX, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[0]), MComplex(RBX, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 12));
+			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 8));
+			MOVSS(fpr.RX(vregs[1]), MComplex(MEMBASEREG, RAX, 1, 4));
+			MOVSS(fpr.RX(vregs[0]), MComplex(MEMBASEREG, RAX, 1, 0));
 
 			SetJumpTarget(next);
 			SetJumpTarget(skip0);

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -26,6 +26,7 @@
 namespace MIPSComp
 {
 using namespace Gen;
+using namespace X64JitConstants;
 
 void JitMemCheck(u32 addr, int size, int isWrite)
 {
@@ -83,7 +84,7 @@ bool JitSafeMem::PrepareWrite(OpArg &dest, int size)
 #ifdef _M_IX86
 			dest = M(Memory::base + (iaddr_ & Memory::MEMVIEW32_MASK & alignMask_));
 #else
-			dest = MDisp(RBX, iaddr_ & alignMask_);
+			dest = MDisp(MEMBASEREG, iaddr_ & alignMask_);
 #endif
 			return true;
 		}
@@ -108,7 +109,7 @@ bool JitSafeMem::PrepareRead(OpArg &src, int size)
 #ifdef _M_IX86
 			src = M(Memory::base + (iaddr_ & Memory::MEMVIEW32_MASK & alignMask_));
 #else
-			src = MDisp(RBX, iaddr_ & alignMask_);
+			src = MDisp(MEMBASEREG, iaddr_ & alignMask_);
 #endif
 			return true;
 		}
@@ -129,7 +130,7 @@ OpArg JitSafeMem::NextFastAddress(int suboffset)
 #ifdef _M_IX86
 		return M(Memory::base + (addr & Memory::MEMVIEW32_MASK));
 #else
-		return MDisp(RBX, addr);
+		return MDisp(MEMBASEREG, addr);
 #endif
 	}
 
@@ -138,7 +139,7 @@ OpArg JitSafeMem::NextFastAddress(int suboffset)
 #ifdef _M_IX86
 	return MDisp(xaddr_, (u32) Memory::base + offset_ + suboffset);
 #else
-	return MComplex(RBX, xaddr_, SCALE_1, offset_ + suboffset);
+	return MComplex(MEMBASEREG, xaddr_, SCALE_1, offset_ + suboffset);
 #endif
 }
 
@@ -198,7 +199,7 @@ OpArg JitSafeMem::PrepareMemoryOpArg(MemoryOpType type)
 #ifdef _M_IX86
 	return MDisp(xaddr_, (u32) Memory::base + offset_);
 #else
-	return MComplex(RBX, xaddr_, SCALE_1, offset_);
+	return MComplex(MEMBASEREG, xaddr_, SCALE_1, offset_);
 #endif
 }
 
@@ -461,7 +462,7 @@ void JitSafeMemFuncs::CreateReadFunc(int bits, const void *fallbackFunc) {
 #ifdef _M_IX86
 	MOVZX(32, bits, EAX, MDisp(EAX, (u32)Memory::base));
 #else
-	MOVZX(32, bits, EAX, MRegSum(RBX, EAX));
+	MOVZX(32, bits, EAX, MRegSum(MEMBASEREG, EAX));
 #endif
 
 	RET();
@@ -489,7 +490,7 @@ void JitSafeMemFuncs::CreateWriteFunc(int bits, const void *fallbackFunc) {
 #ifdef _M_IX86
 	MOV(bits, MDisp(EAX, (u32)Memory::base), R(EDX));
 #else
-	MOV(bits, MRegSum(RBX, EAX), R(EDX));
+	MOV(bits, MRegSum(MEMBASEREG, EAX), R(EDX));
 #endif
 
 	RET();

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -23,7 +23,9 @@
 
 namespace X64JitConstants {
 #ifdef _M_X64
+	const Gen::X64Reg MEMBASEREG = Gen::RBX;
 	const Gen::X64Reg CTXREG = Gen::R14;
+	const Gen::X64Reg JITBASEREG = Gen::R15;
 #else
 	const Gen::X64Reg CTXREG = Gen::EBP;
 #endif


### PR DESCRIPTION
Shouldn't need protected funcs in the safemem jumps, and can skip right to EAX pretty easily, but with a couple more bytes.  Also shave off the reload of the context pointer each dispatch.

Minimal if any measurable gains, though.

But, I think it's cleaner, and somehow I don't think this line was ever right: `J_CC(CC_NE, asm_.dispatcher, true);`

-[Unknown]
