### PR TITLE
x86jit: Free up a reg and cut some bytes from asm

### DIFF
--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -115,9 +115,10 @@ void AsmRoutineManager::Generate(MIPSState *mips, MIPSComp::Jit *jit, MIPSComp::
 			MOV(32, R(EAX), MComplex(MEMBASEREG, RAX, SCALE_1, 0));
 #endif
 			MOV(32, R(EDX), R(EAX));
-			AND(32, R(EDX), Imm32(MIPS_JITBLOCK_MASK));
-			CMP(32, R(EDX), Imm32(MIPS_EMUHACK_OPCODE));
-			FixupBranch notfound = J_CC(CC_NZ);
+			_assert_msg_(JIT, MIPS_JITBLOCK_MASK == 0xFF000000, "Hardcoded assumption of emuhack mask");
+			SHR(32, R(EDX), Imm8(24));
+			CMP(32, R(EDX), Imm8(MIPS_EMUHACK_OPCODE >> 24));
+			FixupBranch notfound = J_CC(CC_NE);
 				if (enableDebug)
 				{
 					ADD(32, M(&mips->debugCount), Imm8(1));

--- a/Core/MIPS/x86/Asm.h
+++ b/Core/MIPS/x86/Asm.h
@@ -18,35 +18,31 @@
 #ifndef _JIT64ASM_H
 #define _JIT64ASM_H
 
-#include "x64Emitter.h"
-#include "../MIPS.h"
+#include "Common/x64Emitter.h"
+#include "Core/MIPS/MIPS.h"
 
 // Runtime generated assembly routines, like the Dispatcher.
 
-namespace MIPSComp
-{
+namespace MIPSComp {
 	class Jit;
+	struct JitOptions;
 }
 
-class AsmRoutineManager : public Gen::XCodeBlock
-{
+class AsmRoutineManager : public Gen::XCodeBlock {
 private:
-	void Generate(MIPSState *mips, MIPSComp::Jit *jit);
+	void Generate(MIPSState *mips, MIPSComp::Jit *jit, MIPSComp::JitOptions *jo);
 	void GenerateCommon();
 
 public:
-	AsmRoutineManager()
-	{
+	AsmRoutineManager() {
 	}
-	~AsmRoutineManager()
-	{
+	~AsmRoutineManager() {
 		FreeCodeSpace();
 	}
 
-	void Init(MIPSState *mips, MIPSComp::Jit *jit)
-	{
+	void Init(MIPSState *mips, MIPSComp::Jit *jit, MIPSComp::JitOptions *jo) {
 		AllocCodeSpace(8192);
-		Generate(mips, jit);
+		Generate(mips, jit, jo);
 		WriteProtect();
 	}
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -325,10 +325,18 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			CMP(32, R(EAX), Imm32(0));
 			FixupBranch next = J_CC(CC_NE);
 
+			auto PSPMemAddr = [](X64Reg scaled, int offset) {
+#ifdef _M_IX86
+				return MDisp(scaled, (u32)Memory::base + offset);
+#else
+				return MComplex(MEMBASEREG, scaled, 1, offset);
+#endif
+			};
+
 			fpr.MapRegsV(vregs, V_Quad, MAP_DIRTY);
 
 			// Offset = 0
-			MOVSS(fpr.RX(vregs[3]), MRegSum(MEMBASEREG, RAX));
+			MOVSS(fpr.RX(vregs[3]), PSPMemAddr(EAX, 0));
 
 			FixupBranch skip0 = J();
 			SetJumpTarget(next);
@@ -336,8 +344,8 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 1
-			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), PSPMemAddr(EAX, 4));
+			MOVSS(fpr.RX(vregs[2]), PSPMemAddr(EAX, 0));
 
 			FixupBranch skip1 = J();
 			SetJumpTarget(next);
@@ -345,9 +353,9 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 2
-			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 8));
-			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[1]), MComplex(MEMBASEREG, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), PSPMemAddr(EAX, 8));
+			MOVSS(fpr.RX(vregs[2]), PSPMemAddr(EAX, 4));
+			MOVSS(fpr.RX(vregs[1]), PSPMemAddr(EAX, 0));
 
 			FixupBranch skip2 = J();
 			SetJumpTarget(next);
@@ -355,10 +363,10 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 			next = J_CC(CC_NE);
 
 			// Offset = 3
-			MOVSS(fpr.RX(vregs[3]), MComplex(MEMBASEREG, RAX, 1, 12));
-			MOVSS(fpr.RX(vregs[2]), MComplex(MEMBASEREG, RAX, 1, 8));
-			MOVSS(fpr.RX(vregs[1]), MComplex(MEMBASEREG, RAX, 1, 4));
-			MOVSS(fpr.RX(vregs[0]), MComplex(MEMBASEREG, RAX, 1, 0));
+			MOVSS(fpr.RX(vregs[3]), PSPMemAddr(EAX, 12));
+			MOVSS(fpr.RX(vregs[2]), PSPMemAddr(EAX, 8));
+			MOVSS(fpr.RX(vregs[1]), PSPMemAddr(EAX, 4));
+			MOVSS(fpr.RX(vregs[0]), PSPMemAddr(EAX, 0));
 
 			SetJumpTarget(next);
 			SetJumpTarget(skip0);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -122,6 +122,8 @@ JitOptions::JitOptions()
 	continueJumps = false;
 	continueMaxInstructions = 300;
 	enableVFPUSIMD = false;
+	// Set by Asm if needed.
+	reserveR15ForAsm = false;
 }
 
 #ifdef _MSC_VER
@@ -134,7 +136,7 @@ Jit::Jit(MIPSState *mips) : blocks(mips, this), mips_(mips)
 	gpr.SetEmitter(this);
 	fpr.SetEmitter(this);
 	AllocCodeSpace(1024 * 1024 * 16);
-	asm_.Init(mips, this);
+	asm_.Init(mips, this, &jo);
 	safeMemFuncs.Init(&thunks);
 
 	js.startDefaultPrefix = mips_->HasDefaultPrefix();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -740,14 +740,14 @@ void Jit::WriteExitDestInReg(X64Reg reg)
 		SetJumpTarget(tooLow);
 		SetJumpTarget(tooHigh);
 
-		ABI_CallFunctionA(Memory::GetPointer, R(reg));
+		ABI_CallFunctionA((const void *)&Memory::GetPointer, R(reg));
 
 		// If we're ignoring, coreState didn't trip - so trip it now.
 		if (g_Config.bIgnoreBadMemAccess)
 		{
 			CMP(32, R(EAX), Imm32(0));
 			FixupBranch skip = J_CC(CC_NE);
-			ABI_CallFunctionA(&Core_UpdateState, Imm32(CORE_ERROR));
+			ABI_CallFunctionA((const void *)&Core_UpdateState, Imm32(CORE_ERROR));
 			SetJumpTarget(skip);
 		}
 

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -51,6 +51,7 @@ struct JitOptions
 	bool continueJumps;
 	int continueMaxInstructions;
 	bool enableVFPUSIMD;
+	bool reserveR15ForAsm;
 };
 
 // TODO: Hmm, humongous.

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -119,7 +119,7 @@ public:
 private:
 	Gen::X64Reg GetFreeXReg();
 	Gen::X64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
-	const int *GetAllocationOrder(int &count);
+	const Gen::X64Reg *GetAllocationOrder(int &count);
 
 	MIPSCachedReg regs[X64JitConstants::NUM_MIPS_GPRS];
 	X64CachedReg xregs[X64JitConstants::NUM_X_REGS];


### PR DESCRIPTION
This is an even easier way to free up a reg: normally we don't need a full 64-bit offset for the jit base.

Of course, in 32-bit, we can't free up a reg for CTXREG anyway, since there's no MEMBASEREG there.

That adds a byte to the main asm loop, but cutting the constants takes 6, so it's still a 5 byte savings.  Probably makes no real difference, though.

-[Unknown]
