### PR TITLE
copy the current config when creating a pre-game config

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -863,7 +863,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 void Config::Save() {
 	if (iniFilename_.size() && g_Config.bSaveSettings) {
 		
-		saveGameConfig();
+		saveGameConfig(gameId);
 
 		CleanRecent();
 		IniFile iniFile;
@@ -1092,6 +1092,8 @@ bool Config::createGameConfig(const std::string &pGameId)
 	}
 
 	File::CreateEmptyFile(fullIniFilePath);
+	g_Config.saveGameConfig(pGameId);
+
 	return true;
 }
 
@@ -1116,14 +1118,14 @@ std::string Config::getGameConfigFile(const std::string &pGameId)
 	return iniFileNameFull;
 }
 
-bool Config::saveGameConfig()
+bool Config::saveGameConfig(const std::string &pGameId)
 {
-	if (!bGameSpecific)
+	if (pGameId.empty())
 	{
 		return false;
 	}
 
-	std::string fullIniFilePath = getGameConfigFile(gameId);
+	std::string fullIniFilePath = getGameConfigFile(pGameId);
 
 	IniFile iniFile;
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1060,10 +1060,18 @@ const std::string Config::FindConfigFile(const std::string &baseFilename) {
 }
 
 void Config::RestoreDefaults() {
-	if(File::Exists(iniFilename_))
-		File::Delete(iniFilename_);
-	recentIsos.clear();
-	currentDirectory = "";
+	if (bGameSpecific)
+	{
+		deleteGameConfig(gameId);
+		createGameConfig(gameId);
+	}
+	else
+	{
+		if (File::Exists(iniFilename_))
+			File::Delete(iniFilename_);
+		recentIsos.clear();
+		currentDirectory = "";
+	}
 	Load();
 }
 
@@ -1092,7 +1100,6 @@ bool Config::createGameConfig(const std::string &pGameId)
 	}
 
 	File::CreateEmptyFile(fullIniFilePath);
-	g_Config.saveGameConfig(pGameId);
 
 	return true;
 }
@@ -1101,11 +1108,6 @@ bool Config::deleteGameConfig(const std::string& pGameId)
 {
 	std::string fullIniFilePath = getGameConfigFile(pGameId);
 
-	if (pGameId == gameId)
-	{
-		unloadGameConfig();
-		Load(iniFilename_.c_str(),controllerIniFilename_.c_str());
-	}
 	File::Delete(fullIniFilePath);
 	return true;
 }
@@ -1150,7 +1152,6 @@ bool Config::loadGameConfig(const std::string &pGameId)
 	if (!hasGameConfig(pGameId))
 	{
 		INFO_LOG(LOADER, "Failed to read %s. No game-specific settings found, using global defaults.", iniFileNameFull.c_str());
-		// NO game specific config file found
 		return false;
 	}
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -353,7 +353,7 @@ public:
 	bool createGameConfig(const std::string &game_id);
 	bool deleteGameConfig(const std::string& pGameId);
 	bool loadGameConfig(const std::string &game_id);
-	bool saveGameConfig();
+	bool saveGameConfig(const std::string &pGameId);
 	void unloadGameConfig();
 	std::string getGameConfigFile(const std::string &gameId);
 	bool hasGameConfig(const std::string &game_id);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -441,6 +441,7 @@ void PSP_Shutdown() {
 	pspIsInited = false;
 	pspIsIniting = false;
 	pspIsQuiting = false;
+	g_Config.unloadGameConfig();
 }
 
 void PSP_RunLoopUntil(u64 globalticks) {

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -116,6 +116,8 @@ UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)
 {
 	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_,0);
 	g_Config.createGameConfig(info->id);
+	g_Config.saveGameConfig(info->id);
+
 	screenManager()->topScreen()->RecreateViews();
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -933,9 +933,18 @@ void GameSettingsScreen::CallbackRestoreDefaults(bool yes) {
 UI::EventReturn GameSettingsScreen::OnRestoreDefaultSettings(UI::EventParams &e) {
 	I18NCategory *de = GetI18NCategory("Developer");
 	I18NCategory *d = GetI18NCategory("Dialog");
-	screenManager()->push(
-		new PromptScreen(de->T("RestoreDefaultSettings", "Are you sure you want to restore all settings(except control mapping)\nback to their defaults?\nYou can't undo this.\nPlease restart PPSSPP after restoring settings."), d->T("OK"), d->T("Cancel"),
-	std::bind(&GameSettingsScreen::CallbackRestoreDefaults, this, placeholder::_1)));
+	if (g_Config.bGameSpecific)
+	{
+		screenManager()->push(
+			new PromptScreen(de->T("RestoreGameDefaultSettings", "Are you sure you want to restore the game-specific settings back to their defaults?\n"), d->T("OK"), d->T("Cancel"),
+			std::bind(&GameSettingsScreen::CallbackRestoreDefaults, this, placeholder::_1)));
+	}
+	else
+	{
+		screenManager()->push(
+			new PromptScreen(de->T("RestoreDefaultSettings", "Are you sure you want to restore all settings(except control mapping)\nback to their defaults?\nYou can't undo this.\nPlease restart PPSSPP after restoring settings."), d->T("OK"), d->T("Cancel"),
+			std::bind(&GameSettingsScreen::CallbackRestoreDefaults, this, placeholder::_1)));
+	}
 
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -936,7 +936,7 @@ UI::EventReturn GameSettingsScreen::OnRestoreDefaultSettings(UI::EventParams &e)
 	if (g_Config.bGameSpecific)
 	{
 		screenManager()->push(
-			new PromptScreen(de->T("RestoreGameDefaultSettings", "Are you sure you want to restore the game-specific settings back to their defaults?\n"), d->T("OK"), d->T("Cancel"),
+			new PromptScreen(de->T("RestoreGameDefaultSettings", "Are you sure you want to restore the game-specific settings back to the ppsspp defaults?\n"), d->T("OK"), d->T("Cancel"),
 			std::bind(&GameSettingsScreen::CallbackRestoreDefaults, this, placeholder::_1)));
 	}
 	else

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1226,7 +1226,6 @@ void GamePauseScreen::onFinish(DialogResult result) {
 
 UI::EventReturn GamePauseScreen::OnExitToMenu(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
-	NativeMessageReceived("stop","");
 	return UI::EVENT_DONE;
 }
 
@@ -1272,6 +1271,7 @@ void GamePauseScreen::CallbackDeleteConfig(bool yes)
 	{
 		GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
 		g_Config.deleteGameConfig(info->id);
+		g_Config.unloadGameConfig();
 		screenManager()->RecreateAllViews();
 	}
 }
@@ -1281,6 +1281,8 @@ UI::EventReturn GamePauseScreen::OnCreateConfig(UI::EventParams &e)
 	std::string gameId = g_paramSFO.GetValueString("DISC_ID");
 	g_Config.createGameConfig(gameId);
 	g_Config.changeGameSpecific(gameId);
+	g_Config.saveGameConfig(gameId);
+
 	screenManager()->topScreen()->RecreateViews();
 	return UI::EVENT_DONE;
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -760,11 +760,6 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "inputDeviceConnected") {
 		KeyMap::NotifyPadConnected(value);
 	}
-	else if (msg == "stop")
-	{
-		g_Config.Save();
-		g_Config.unloadGameConfig();
-	}
 }
 
 void NativeUpdate(InputState &input) {


### PR DESCRIPTION
I don't care either way but I guess this makes it more practical, because you can reset to defaults but you can't copy any other way (except for copy/pasting the *.ini files).
