### PR TITLE
dx9: Compensate for viewport w/h adjustments

### DIFF
--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -853,7 +853,7 @@ namespace DX9 {
 			// We maintain a separate vector of framebuffer objects for blitting.
 			for (size_t i = 0; i < bvfbs_.size(); ++i) {
 				VirtualFramebuffer *v = bvfbs_[i];
-				if (MaskedEqual(v->fb_address, vfb->fb_address) && v->format == vfb->format) {
+				if (v->fb_address == vfb->fb_address && v->format == vfb->format) {
 					if (v->bufferWidth == vfb->bufferWidth && v->bufferHeight == vfb->bufferHeight) {
 						nvfb = v;
 						v->fb_stride = vfb->fb_stride;
@@ -874,8 +874,8 @@ namespace DX9 {
 				nvfb->z_stride = vfb->z_stride;
 				nvfb->width = vfb->width;
 				nvfb->height = vfb->height;
-				nvfb->renderWidth = vfb->width;
-				nvfb->renderHeight = vfb->height;
+				nvfb->renderWidth = vfb->bufferWidth;
+				nvfb->renderHeight = vfb->bufferHeight;
 				nvfb->bufferWidth = vfb->bufferWidth;
 				nvfb->bufferHeight = vfb->bufferHeight;
 				nvfb->format = vfb->format;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -1652,7 +1652,7 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, int level, int maxL
 		entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
 	}
 
-	if (level == 0 && !replaceImages) {
+	if (level == 0 && (!replaceImages || entry.texture == nullptr)) {
 		// Create texture
 		D3DPOOL pool = D3DPOOL_MANAGED;
 		int usage = 0;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -476,6 +476,11 @@ struct GPUStateCache
 	float vpWidth;
 	float vpHeight;
 	float vpDepth;
+	// Only used by Direct3D, not saved.
+	float vpXOffset;
+	float vpYOffset;
+	float vpWidthScale;
+	float vpHeightScale;
 
 	u32 curRTWidth;
 	u32 curRTHeight;


### PR DESCRIPTION
Fixes text in Final Fantasy 4, world map in Star Ocean, etc.

This was a pain.  I don't think I did it in the most optimal way...

I guess we should do something similar for depth?  Well, that possibly in GLES too.

-[Unknown]
