### PR TITLE
dx9: Don't force alpha to 1

### DIFF
--- a/GPU/Directx9/helper/global.cpp
+++ b/GPU/Directx9/helper/global.cpp
@@ -35,7 +35,6 @@ static const char * pscode =
   "};\n"
   "float4 main( PS_IN In ) : COLOR {\n"
   "  float4 c =  tex2D(s, In.Uv);\n"
-  "  c.a = 1.0f;\n"
   "  return c;\n"
   "}\n";
 


### PR DESCRIPTION
This was removed from GLES also.  Depal ends up using this shader for flipped blits, and it screws up alpha.

I fell into a trap trying to fix the off by one/half/all kinds of issues to get the test to pass.  Is there a better way to debug this?  I keep just tweaking different numbers... all still wrong, just in different ways, ugh.

Anyway, this makes naive depal tests pass.  3rd Birthday and Dragon Ball Z both don't look right still.

Note: pull to dx9-depal.  Well, I could probably just push it, but fyi.

-[Unknown]
