### PR TITLE
JIT IR: Fix typo breaking reordering

### DIFF
--- a/Core/MIPS/IR.cpp
+++ b/Core/MIPS/IR.cpp
@@ -184,7 +184,7 @@ static bool Reorder(IRBlock *block) {
 			// Compare register numbers and swap if possible.
 			if (MIPS_GET_RT(e1.op) > MIPS_GET_RT(e2.op) &&
 				  (MIPS_GET_IMM16(e1.op) != MIPS_GET_IMM16(e2.op) ||
-					 MIPS_GET_RT(e1.op) != MIPS_GET_RT(e2.op))) {
+					 MIPS_GET_RS(e1.op) != MIPS_GET_RS(e2.op))) {
 				std::swap(e1, e2);
 #if 0
 				const char *type = "SW";


### PR DESCRIPTION
This was it, just a typo.  Darn, wish I'd just noticed it with my eyes rather than debugging.

Actually, there are dead stores in some games, for example Star Ocean, which I didn't even see any branches to.  We could probably eliminate them branch or no branch in IR as well.  Not sure how common, though...

Note: pull to jit-ir.

-[Unknown]
