### PR TITLE
Fix to VFPU register allocation. Fixes #7174

### DIFF
--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -121,7 +121,7 @@ JitOptions::JitOptions()
 	continueBranches = false;
 	continueJumps = false;
 	continueMaxInstructions = 300;
-	enableVFPUSIMD = false;
+	enableVFPUSIMD = true;
 	// Set by Asm if needed.
 	reserveR15ForAsm = false;
 }

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -354,6 +354,9 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 		for (int i = 0; i < 4; ++i) {
 			xrsLoaded[i] = false;
 		}
+		for (int i = 2; i < n; ++i){
+			xrs[i] = INVALID_REG;
+		}
 		regsLoaded = 0;
 	}
 


### PR DESCRIPTION
GetFreeXRegs(_,_,true) invalidates registers it can see on spill,
but it can't see all the registers in the array due to how we call it
so we have to invalidate the rest ourselves.  Not doing so can get it
to use the same register twice.

I also have a relevant auto-test if there's any interest.  It is transcribed directly from a game though.
