### PR TITLE
x86 jit: Allow storing all imms directly without bouncing to a register, not just zero

### DIFF
--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -209,6 +209,16 @@ struct OpArg
 		}
 	}
 
+	void SetImmBits(int bits) {
+		switch (bits)
+		{
+			case 8: scale = SCALE_IMM8; break;
+			case 16: scale = SCALE_IMM16; break;
+			case 32: scale = SCALE_IMM32; break;
+			case 64: scale = SCALE_IMM64; break;
+		}
+	}
+
 	X64Reg GetSimpleReg() const
 	{
 		if (scale == SCALE_NONE)

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -66,6 +66,16 @@ namespace MIPSComp {
 		gpr.UnlockAll();
 	}
 
+	static OpArg DowncastImm(OpArg in, int bits) {
+		if (!in.IsImm())
+			return in;
+		if (in.GetImmBits() > bits) {
+			in.SetImmBits(bits);
+			return in;
+		}
+		return in;
+	}
+
 	void Jit::CompITypeMemWrite(MIPSOpcode op, u32 bits, const void *safeFunc)
 	{
 		CONDITIONAL_DISABLE;
@@ -74,8 +84,12 @@ namespace MIPSComp {
 		MIPSGPReg rs = _RS;
 
 		gpr.Lock(rt, rs);
-		if (rt != MIPS_REG_ZERO)
+		
+		if (rt == MIPS_REG_ZERO || gpr.R(rt).IsImm()) {
+			// NOTICE_LOG(JIT, "%d-bit Imm at %08x : %08x", bits, js.blockStart, (u32)gpr.R(rt).GetImmValue());
+		} else {
 			gpr.MapReg(rt, true, false);
+		}
 
 #ifdef _M_IX86
 		// We use EDX so we can have DL for 8-bit ops.
@@ -103,7 +117,9 @@ namespace MIPSComp {
 					case 32: MOV(32, dest, Imm32(0)); break;
 					}
 				} else {
-					MOV(bits, dest, gpr.R(rt));
+					// The downcast is needed so we don't try to generate a 8-bit write with a 32-bit imm
+					// (that might have been generated from an li instruction) which is illegal.
+					MOV(bits, dest, DowncastImm(gpr.R(rt), bits));
 				}
 			}
 		}


### PR DESCRIPTION
This just jumped out at me while reading x86 disassembly from the jit. I don't think it makes a big difference but might reduce register pressure a little. This kind of thing is common in various display list writing functions in games.
