### PR TITLE
Fix resize the window correctly on dx9 backend

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -130,6 +130,7 @@ bool iosCanUseJit;
 // Really need to clean this mess of globals up... but instead I add more :P
 bool g_TakeScreenshot;
 static bool isOuya;
+static bool resized = false;
 
 struct PendingMessage {
 	std::string msg;
@@ -711,6 +712,11 @@ void NativeRender() {
 	if (g_TakeScreenshot) {
 		TakeScreenshot();
 	}
+
+	if (resized) {
+		resized = false;
+		D3D9_Resize(0);
+	}
 }
 
 void HandleGlobalMessage(const std::string &msg, const std::string &value) {
@@ -884,6 +890,8 @@ void NativeMessageReceived(const char *message, const char *value) {
 }
 
 void NativeResized() {
+	resized = true;
+
 	if (uiContext) {
 		// Modifying the bounds here can be used to "inset" the whole image to gain borders for TV overscan etc.
 		// The UI now supports any offset but not the EmuScreen yet.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -713,9 +713,13 @@ void NativeRender() {
 		TakeScreenshot();
 	}
 
-	if (resized) {
-		resized = false;
-		D3D9_Resize(0);
+	if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
+		if (resized) {
+			resized = false;
+#ifdef _WIN32
+			D3D9_Resize(0);
+#endif
+		}
 	}
 }
 

--- a/Windows/D3D9Base.cpp
+++ b/Windows/D3D9Base.cpp
@@ -22,6 +22,7 @@ static LPDIRECT3DDEVICE9EX deviceEx;
 static HDC hDC;     // Private GDI Device Context
 static HGLRC hRC;   // Permanent Rendering Context
 static HWND hWnd;   // Holds Our Window Handle
+static D3DPRESENT_PARAMETERS pp;
 
 static int xres, yres;
 
@@ -125,10 +126,9 @@ bool D3D9_Init(HWND hWnd, bool windowed, std::string *error_message) {
 	int xres = rc.right - rc.left;
 	int yres = rc.bottom - rc.top;
 
-	D3DPRESENT_PARAMETERS pp;
 	memset(&pp, 0, sizeof(pp));
-	pp.BackBufferWidth = xres;
-	pp.BackBufferHeight = yres;
+	pp.BackBufferWidth = 0;
+	pp.BackBufferHeight = 0;
 	pp.BackBufferFormat = d3ddm.Format;
 	pp.MultiSampleType = D3DMULTISAMPLE_NONE;
 	pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
@@ -186,7 +186,16 @@ bool D3D9_Init(HWND hWnd, bool windowed, std::string *error_message) {
 }
 
 void D3D9_Resize(HWND window) {
-	// TODO!
+	// Allow call from only EMU thread.
+	if (device) {
+		DX9::fbo_shutdown();
+		pp.BackBufferWidth = 0;
+		pp.BackBufferHeight = 0;
+		HRESULT hr = device->Reset(&pp);
+		if (FAILED(hr)){
+		}
+		DX9::fbo_init(d3d);
+	}
 }
 
 void D3D9_Shutdown() {


### PR DESCRIPTION
Maybe, we need to release some more resources when reset the device.
