### PR TITLE
Add an option to prevent cpu stall on slow IO

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -337,6 +337,7 @@ static ConfigSetting cpuSettings[] = {
 	ConfigSetting("AtomicAudioLocks", &g_Config.bAtomicAudioLocks, false, true, true),
 
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
+	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -50,6 +50,13 @@ enum {
 	GPU_BACKEND_DIRECT3D9 = 1,
 };
 
+// For iIOTimingMethod.
+enum IOTimingMethods {
+	IOTIMING_FAST = 0,
+	IOTIMING_HOST = 1,
+	IOTIMING_REALISTIC = 2,
+};
+
 namespace http {
 	class Download;
 	class Downloader;
@@ -109,6 +116,7 @@ public:
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;
+	int iIOTimingMethod;
 	bool bSeparateIOThread;
 	bool bAtomicAudioLocks;
 	int iLockedCPUSpeed;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -600,6 +600,11 @@ int DirectoryFileSystem::DevType(u32 handle) {
 }
 
 size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
+	int ignored;
+	return ReadFile(handle, pointer, size, ignored);
+}
+
+size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
 	{
@@ -613,6 +618,11 @@ size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 }
 
 size_t DirectoryFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size) {
+	int ignored;
+	return WriteFile(handle, pointer, size, ignored);
+}
+
+size_t DirectoryFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
 	{
@@ -971,6 +981,11 @@ int VFSFileSystem::DevType(u32 handle) {
 }
 
 size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
+	int ignored;
+	return ReadFile(handle, pointer, size, ignored);
+}
+
+size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	DEBUG_LOG(FILESYS,"VFSFileSystem::ReadFile %08x %p %i", handle, pointer, (u32)size);
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
@@ -986,6 +1001,11 @@ size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 }
 
 size_t VFSFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size) {
+	int ignored;
+	return WriteFile(handle, pointer, size, ignored);
+}
+
+size_t VFSFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) {
 	// NOT SUPPORTED - READ ONLY
 	return 0;
 }

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -96,7 +96,9 @@ public:
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
 	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size) override;
+	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
@@ -139,7 +141,9 @@ public:
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
 	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size) override;
+	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -111,7 +111,9 @@ public:
 	virtual u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) = 0;
 	virtual void     CloseFile(u32 handle) = 0;
 	virtual size_t   ReadFile(u32 handle, u8 *pointer, s64 size) = 0;
+	virtual size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) = 0;
 	virtual size_t   WriteFile(u32 handle, const u8 *pointer, s64 size) = 0;
+	virtual size_t   WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) = 0;
 	virtual size_t   SeekFile(u32 handle, s32 position, FileMove type) = 0;
 	virtual PSPFileInfo GetFileInfo(std::string filename) = 0;
 	virtual bool     OwnsHandle(u32 handle) = 0;
@@ -135,7 +137,9 @@ public:
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) {return 0;}
 	void     CloseFile(u32 handle) {}
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) {return 0;}
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {return 0;}
 	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size) {return 0;}
+	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) {return 0;}
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) {return 0;}
 	PSPFileInfo GetFileInfo(std::string filename) {PSPFileInfo f; return f;}
 	bool     OwnsHandle(u32 handle) {return false;}

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -520,6 +520,12 @@ int ISOFileSystem::DevType(u32 handle)
 
 size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 {
+	int ignored;
+	return ReadFile(handle, pointer, size, ignored);
+}
+
+size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
+{
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
 	{
@@ -599,7 +605,13 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 	}
 }
 
-size_t ISOFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size) 
+size_t ISOFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size)
+{
+	ERROR_LOG(FILESYS, "Hey, what are you doing? You can't write to an ISO!");
+	return 0;
+}
+
+size_t ISOFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec)
 {
 	ERROR_LOG(FILESYS, "Hey, what are you doing? You can't write to an ISO!");
 	return 0;

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -86,6 +86,7 @@ private:
 	IHandleAllocator *hAlloc;
 	TreeEntry *treeroot;
 	BlockDevice *blockDevice;
+	u32 lastReadBlock_;
 
 	TreeEntry entireISO;
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -37,6 +37,7 @@ public:
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename = NULL) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
@@ -46,6 +47,8 @@ public:
 	u64      FreeSpace(const std::string &path) override { return 0; }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;
+	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
+
 	bool GetHostPath(const std::string &inpath, std::string &outpath) {return false;}
 	bool MkDir(const std::string &dirname) override {return false;}
 	bool RmDir(const std::string &dirname) override { return false; }
@@ -116,6 +119,9 @@ public:
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override {
 		return isoFileSystem_->ReadFile(handle, pointer, size);
 	}
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override {
+		return isoFileSystem_->ReadFile(handle, pointer, size, usec);
+	}
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override {
 		return isoFileSystem_->SeekFile(handle, position, type);
 	}
@@ -136,6 +142,9 @@ public:
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override {
 		return isoFileSystem_->WriteFile(handle, pointer, size);
+	}
+	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override {
+		return isoFileSystem_->WriteFile(handle, pointer, size, usec);
 	}
 	bool GetHostPath(const std::string &inpath, std::string &outpath) { return false; }
 	bool MkDir(const std::string &dirname) override { return false; }

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -555,7 +555,7 @@ size_t MetaFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 	lock_guard guard(lock);
 	IFileSystem *sys = GetHandleOwner(handle);
 	if (sys)
-		return sys->ReadFile(handle,pointer,size);
+		return sys->ReadFile(handle, pointer, size);
 	else
 		return 0;
 }
@@ -565,7 +565,27 @@ size_t MetaFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size)
 	lock_guard guard(lock);
 	IFileSystem *sys = GetHandleOwner(handle);
 	if (sys)
-		return sys->WriteFile(handle,pointer,size);
+		return sys->WriteFile(handle, pointer, size);
+	else
+		return 0;
+}
+
+size_t MetaFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
+{
+	lock_guard guard(lock);
+	IFileSystem *sys = GetHandleOwner(handle);
+	if (sys)
+		return sys->ReadFile(handle, pointer, size, usec);
+	else
+		return 0;
+}
+
+size_t MetaFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec)
+{
+	lock_guard guard(lock);
+	IFileSystem *sys = GetHandleOwner(handle);
+	if (sys)
+		return sys->WriteFile(handle, pointer, size, usec);
 	else
 		return 0;
 }

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -96,7 +96,9 @@ public:
 	u32      OpenWithError(int &error, std::string filename, FileAccess access, const char *devicename = NULL);
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
 	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size) override;
+	size_t   WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override { return false; }

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -422,6 +422,11 @@ size_t VirtualDiscFileSystem::SeekFile(u32 handle, s32 position, FileMove type) 
 }
 
 size_t VirtualDiscFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
+	int ignored;
+	return ReadFile(handle, pointer, size, ignored);
+}
+
+size_t VirtualDiscFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
 	{
@@ -696,6 +701,12 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 }
 
 size_t VirtualDiscFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size)
+{
+	ERROR_LOG(FILESYS,"VirtualDiscFileSystem: Cannot write to file on virtual disc");
+	return 0;
+}
+
+size_t VirtualDiscFileSystem::WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec)
 {
 	ERROR_LOG(FILESYS,"VirtualDiscFileSystem: Cannot write to file on virtual disc");
 	return 0;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -33,6 +33,7 @@ public:
 	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
+	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
 	void     CloseFile(u32 handle) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
@@ -45,6 +46,7 @@ public:
 
 	// unsupported operations
 	size_t  WriteFile(u32 handle, const u8 *pointer, s64 size) override;
+	size_t  WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 	bool MkDir(const std::string &dirname) override;
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -180,6 +180,7 @@ private:
 
 	std::vector<FileListEntry> fileList;
 	u32 currentBlockIndex;
+	u32 lastReadBlock_;
 
 	std::map<std::string, Handler *> handlers;
 };

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1391,7 +1391,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			return ERROR_MEMSTICK_DEVCTL_BAD_PARAMS;
 		}
 		break;
-	// TODO: What does these do?  Seem to require a u32 in, no output.
+	// TODO: What do these do?  Seem to require a u32 in, no output.
 	case 0x01F100A6:
 	case 0x01F100A8:
 	case 0x01F100A9:

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -47,6 +47,11 @@ void AsyncIOManager::Shutdown() {
 	results_.clear();
 }
 
+bool AsyncIOManager::HasResult(u32 handle) {
+	lock_guard guard(resultsLock_);
+	return results_.find(handle) != results_.end();
+}
+
 bool AsyncIOManager::PopResult(u32 handle, AsyncIOResult &result) {
 	lock_guard guard(resultsLock_);
 	if (results_.find(handle) != results_.end()) {

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -64,6 +64,16 @@ bool AsyncIOManager::PopResult(u32 handle, AsyncIOResult &result) {
 	}
 }
 
+bool AsyncIOManager::ReadResult(u32 handle, AsyncIOResult &result) {
+	lock_guard guard(resultsLock_);
+	if (results_.find(handle) != results_.end()) {
+		result = results_[handle];
+		return true;
+	} else {
+		return false;
+	}
+}
+
 bool AsyncIOManager::WaitResult(u32 handle, AsyncIOResult &result) {
 	lock_guard guard(resultsLock_);
 	ScheduleEvent(IO_EVENT_SYNC);
@@ -78,6 +88,24 @@ bool AsyncIOManager::WaitResult(u32 handle, AsyncIOResult &result) {
 	}
 
 	return false;
+}
+
+u64 AsyncIOManager::ResultFinishTicks(u32 handle) {
+	AsyncIOResult result;
+
+	lock_guard guard(resultsLock_);
+	ScheduleEvent(IO_EVENT_SYNC);
+	while (HasEvents() && ThreadEnabled() && resultsPending_.find(handle) != resultsPending_.end()) {
+		if (ReadResult(handle, result)) {
+			return result.finishTicks;
+		}
+		resultsWait_.wait_for(resultsLock_, 16);
+	}
+	if (ReadResult(handle, result)) {
+		return result.finishTicks;
+	}
+
+	return 0;
 }
 
 void AsyncIOManager::ProcessEvent(AsyncIOEvent ev) {
@@ -96,14 +124,15 @@ void AsyncIOManager::ProcessEvent(AsyncIOEvent ev) {
 }
 
 void AsyncIOManager::Read(u32 handle, u8 *buf, size_t bytes) {
-	size_t result = pspFileSystem.ReadFile(handle, buf, bytes);
-	EventResult(handle, result);
+	int usec = 0;
+	s64 result = pspFileSystem.ReadFile(handle, buf, bytes, usec);
+	EventResult(handle, AsyncIOResult(result, usec));
 }
 
 void AsyncIOManager::Write(u32 handle, u8 *buf, size_t bytes) {
-	// We want to sign extend this on 32-bit.
-	AsyncIOResult result = (ssize_t)pspFileSystem.WriteFile(handle, buf, bytes);
-	EventResult(handle, result);
+	int usec = 0;
+	s64 result = pspFileSystem.WriteFile(handle, buf, bytes, usec);
+	EventResult(handle, AsyncIOResult(result, usec));
 }
 
 void AsyncIOManager::EventResult(u32 handle, AsyncIOResult result) {
@@ -116,12 +145,20 @@ void AsyncIOManager::EventResult(u32 handle, AsyncIOResult result) {
 }
 
 void AsyncIOManager::DoState(PointerWrap &p) {
-	auto s = p.Section("AsyncIoManager", 1);
+	auto s = p.Section("AsyncIoManager", 1, 2);
 	if (!s)
 		return;
 
 	SyncThread();
 	lock_guard guard(resultsLock_);
 	p.Do(resultsPending_);
-	p.Do(results_);
+	if (s >= 2) {
+		p.Do(results_);
+	} else {
+		std::map<u32, size_t> oldResults;
+		p.Do(oldResults);
+		for (auto it = oldResults.begin(), end = oldResults.end(); it != end; ++it) {
+			results_[it->first] = AsyncIOResult(it->second);
+		}
+	}
 }

--- a/Core/HW/AsyncIOManager.h
+++ b/Core/HW/AsyncIOManager.h
@@ -55,6 +55,7 @@ public:
 	void ScheduleOperation(AsyncIOEvent ev);
 	void Shutdown();
 
+	bool HasResult(u32 handle);
 	bool PopResult(u32 handle, AsyncIOResult &result);
 	bool WaitResult(u32 handle, AsyncIOResult &result);
 

--- a/Core/HW/AsyncIOManager.h
+++ b/Core/HW/AsyncIOManager.h
@@ -43,8 +43,29 @@ struct AsyncIOEvent {
 	}
 };
 
-// TODO: Something better.
-typedef s64 AsyncIOResult;
+struct AsyncIOResult {
+	AsyncIOResult() : result(0), finishTicks(0) {
+	}
+
+	explicit AsyncIOResult(s64 r) : result(r), finishTicks(0) {
+	}
+
+	AsyncIOResult(s64 r, int usec) : result(r) {
+		finishTicks = CoreTiming::GetTicks() + usToCycles(usec);
+	}
+
+	void DoState(PointerWrap &p) {
+		auto s = p.Section("AsyncIOResult", 1);
+		if (!s)
+			return;
+
+		p.Do(result);
+		p.Do(finishTicks);
+	}
+
+	s64 result;
+	u64 finishTicks;
+};
 
 typedef ThreadEventQueue<NoBase, AsyncIOEvent, AsyncIOEventType, IO_EVENT_INVALID, IO_EVENT_SYNC, IO_EVENT_FINISH> IOThreadEventQueue;
 class AsyncIOManager : public IOThreadEventQueue {
@@ -57,7 +78,9 @@ public:
 
 	bool HasResult(u32 handle);
 	bool PopResult(u32 handle, AsyncIOResult &result);
+	bool ReadResult(u32 handle, AsyncIOResult &result);
 	bool WaitResult(u32 handle, AsyncIOResult &result);
+	u64 ResultFinishTicks(u32 handle);
 
 protected:
 	virtual void ProcessEvent(AsyncIOEvent ref);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -392,7 +392,7 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateCPUThread, s->T("Multithreaded (experimental)")));
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateIOThread, s->T("I/O on thread (experimental)")))->SetEnabled(!PSP_IsInited());
-	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)" };
+	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)", "Simulate UMD delays" };
 	View *ioTimingMethod = systemSettings->Add(new PopupMultiChoice(&g_Config.iIOTimingMethod, s->T("IO timing method"), ioTimingMethods, 0, ARRAY_SIZE(ioTimingMethods), s, screenManager()));
 	ioTimingMethod->SetEnabledPtr(&g_Config.bSeparateIOThread);
 	systemSettings->Add(new CheckBox(&g_Config.bForceLagSync, s->T("Force real clock sync (slower, less lag)")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -392,6 +392,9 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateCPUThread, s->T("Multithreaded (experimental)")));
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateIOThread, s->T("I/O on thread (experimental)")))->SetEnabled(!PSP_IsInited());
+	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)" };
+	View *ioTimingMethod = systemSettings->Add(new PopupMultiChoice(&g_Config.iIOTimingMethod, s->T("IO timing method"), ioTimingMethods, 0, ARRAY_SIZE(ioTimingMethods), s, screenManager()));
+	ioTimingMethod->SetEnabledPtr(&g_Config.bSeparateIOThread);
 	systemSettings->Add(new CheckBox(&g_Config.bForceLagSync, s->T("Force real clock sync (slower, less lag)")));
 	systemSettings->Add(new PopupSliderChoice(&g_Config.iLockedCPUSpeed, 0, 1000, s->T("Change CPU Clock", "Change CPU Clock (0 = default) (unstable)"), screenManager()));
 #ifndef MOBILE_DEVICE


### PR DESCRIPTION
This is good for any slow storage, including:
- Hard disk spinning up.
- Generally slow (cheap) SD cards.
- HTTP or Samba streaming.

May possibly cause bugs in some cases where timing is unrealistic.  That being said, as long as the game is a UMD game, and there's caching (could enable memory caching for storage), it should not be a problem usually.

This _significantly_ improves the gameplay experience when streaming games from HTTP, because you get natural loading screens or short stalls with backgroud music playing (as would happen on a PSP) rather than lag.

I'm also thinking to pull in my io-minor2 changes (potentially making it more accurate now/future) as a "realistic" timing option.

Since fast is probably the best compromise between safe and not having annoying loading screens, I'm not sure there's any good way to avoid an option.  Would appreciate any suggestions on better phrasing.

-[Unknown]
