### PR TITLE
Avoid debug log spam in menu

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -676,7 +676,7 @@ static ConfigSectionSettings sections[] = {
 	{"Upgrade", upgradeSettings},
 };
 
-Config::Config() : bGameSpecific(false){ }
+Config::Config() : bGameSpecific(false) { }
 Config::~Config() { }
 
 std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
@@ -847,7 +847,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	//but these configs shouldn't contain older versions anyhow
 	if (bGameSpecific)
 	{
-		loadGameConfig(gameId);
+		loadGameConfig(gameId_);
 	}
 
 	CleanRecent();
@@ -864,7 +864,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 void Config::Save() {
 	if (iniFilename_.size() && g_Config.bSaveSettings) {
 		
-		saveGameConfig(gameId);
+		saveGameConfig(gameId_);
 
 		CleanRecent();
 		IniFile iniFile;
@@ -1055,7 +1055,10 @@ const std::string Config::FindConfigFile(const std::string &baseFilename) {
 	if (!File::Exists(filename)) {
 		std::string path;
 		SplitPath(filename, &path, NULL, NULL);
-		File::CreateFullPath(path);
+		if (createdPath_ != path) {
+			File::CreateFullPath(path);
+			createdPath_ = path;
+		}
 	}
 	return filename;
 }
@@ -1063,8 +1066,8 @@ const std::string Config::FindConfigFile(const std::string &baseFilename) {
 void Config::RestoreDefaults() {
 	if (bGameSpecific)
 	{
-		deleteGameConfig(gameId);
-		createGameConfig(gameId);
+		deleteGameConfig(gameId_);
+		createGameConfig(gameId_);
 	}
 	else
 	{
@@ -1087,7 +1090,7 @@ bool Config::hasGameConfig(const std::string &pGameId)
 
 void Config::changeGameSpecific(const std::string &pGameId)
 {
-	gameId = pGameId;
+	gameId_ = pGameId;
 	bGameSpecific = !pGameId.empty();
 }
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -385,11 +385,12 @@ public:
 	
 	
 private:
-	std::string gameId;
+	std::string gameId_;
 	std::string iniFilename_;
 	std::string controllerIniFilename_;
 	std::vector<std::string> searchPath_;
 	std::string defaultPath_;
+	std::string createdPath_;
 };
 
 std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();


### PR DESCRIPTION
It keeps trying to create the same path over and over every time it draws any button.  This at least cuts that out.

-[Unknown]
