### PR TITLE
Support more screenshot framebuffer formats

### DIFF
--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -47,6 +47,7 @@ enum GPUDebugBufferFormat {
 
 	// 565 is just reversed, the others have B and R swapped.
 	GPU_DBG_FORMAT_565_BGRA = 0x04,
+	GPU_DBG_FORMAT_BRSWAP_FLAG = 0x08,
 	GPU_DBG_FORMAT_5551_BGRA = 0x09,
 	GPU_DBG_FORMAT_4444_BGRA = 0x0A,
 	GPU_DBG_FORMAT_8888_BGRA = 0x0B,


### PR DESCRIPTION
So, the good news is this will support screenshots in more cases, maybe in software renderer, TrueColor off, etc.  It's not super fast or super hot.

The bad news is that the black screenshot thing still happens, and the cause is that the frame hasn't been rendered yet.  Example case:
1. You go to the menu and then exit.
2. PPSSPP destroys all framebuffers to recreate them.
3. You re-enter the menu before the display buffer has been created / rendered to.
4. Screenshot either takes an empty buffer or else memory, but either way gets outdated / black / etc.

Before, in some cases, it would just fail.  Now it will succeed, but usually with black.  Not sure which is better.  The best "solution" to this would be to allow the game to run for another frame, but it's not entirely 100% detectable...

-[Unknown]
