### PR TITLE
x86jit: Fix another sequential detect problem

### DIFF
--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -121,8 +121,7 @@ JitOptions::JitOptions()
 	continueBranches = false;
 	continueJumps = false;
 	continueMaxInstructions = 300;
-	// TODO: breaks something in Monhun Nikki Poka Poka Ailu Mura G (see #7245.)
-	enableVFPUSIMD = false;
+	enableVFPUSIMD = true;
 	// Set by Asm if needed.
 	reserveR15ForAsm = false;
 }

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -332,14 +332,17 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 	// Let's also check if the memory addresses are sequential.
 	int sequential = 1;
 	for (int i = 1; i < n; ++i) {
-		if (v[i] < 128) {
+		if (v[i] < 128 && v[i - 1] < 128) {
 			if (voffset[v[i]] != voffset[v[i - 1]] + 1) {
 				break;
 			}
-		} else {
+		} else if (v[i] >= 128 && v[i - 1] >= 128) {
 			if (v[i] != v[i - 1] + 1) {
 				break;
 			}
+		} else {
+			// Temps can't be sequential with non-temps.
+			break;
 		}
 		++sequential;
 	}


### PR DESCRIPTION
Arg.  Maybe should use voffset after all, but it won't fit in a u8 anyway...

Fixes #7245.

-[Unknown]
