### PR TITLE
Reverse packetsFree to packetsAvail

### DIFF
--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -58,7 +58,7 @@ struct SceMpegRingBuffer {
 	s32_le packets;
 	s32_le packetsRead;
 	s32_le packetsWritten;
-	s32_le packetsFree; // pspsdk: unk2, noxa: iUnk0
+	s32_le packetsAvail; // pspsdk: unk2, noxa: iUnk0
 	s32_le packetSize; // 2048
 	u32_le data; // address, ring buffer
 	u32_le callback_addr; // see sceMpegRingbufferPut


### PR DESCRIPTION
This is the actual value stored in memory, which games may be accessing or even writing to.  There are a few games still dying on videos and I'm wondering if it's related.

Just reversed the value everywhere, hoping that's safest.

Makes the video/mpeg/ringbuffer/avail test pass.

-[Unknown]
