### PR TITLE
Add a way to connect 2 clients on one PC

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -571,6 +571,7 @@ static ConfigSetting controlSettings[] = {
 
 static ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", &g_Config.bEnableWlan, false, true, true),
+	ConfigSetting("SetBindAddress", &g_Config.bBindLocal, false, true, true),
 	ConfigSetting("EnableAdhocServer", &g_Config.bEnableAdhocServer, false, true, true),
 	ConfigSetting(false),
 };
@@ -601,6 +602,7 @@ static ConfigSetting systemParamSettings[] = {
 	ReportedConfigSetting("PSPFirmwareVersion", &g_Config.iFirmwareVersion, PSP_DEFAULT_FIRMWARE, true, true),
 	ConfigSetting("NickName", &g_Config.sNickName, "PPSSPP", true, true),
 	ConfigSetting("proAdhocServer", &g_Config.proAdhocServer, "localhost", true, true),
+	ConfigSetting("localBindAddress", &g_Config.localBindAddress, "localhost", true, true),
 	ConfigSetting("MacAddress", &g_Config.sMACAddress, &CreateRandMAC, true, true),
 	ReportedConfigSetting("Language", &g_Config.iLanguage, &DefaultSystemParamLanguage, true, true),
 	ConfigSetting("TimeFormat", &g_Config.iTimeFormat, PSP_SYSTEMPARAM_TIME_FORMAT_24HR, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -299,6 +299,7 @@ public:
 	// SystemParam
 	std::string sNickName;
 	std::string proAdhocServer;
+	std::string localBindAddress;
 	std::string sMACAddress;
 	int iLanguage;
 	int iTimeFormat;
@@ -314,6 +315,7 @@ public:
 	bool bEnableAdhocServer;
 	int iWlanAdhocChannel;
 	bool bWlanPowerSave;
+	bool bBindLocal;
 
 	int iPSPModel;
 	int iFirmwareVersion;

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -30,6 +30,7 @@
 #include "UI/OnScreenDisplay.h"
 #include "proAdhoc.h" 
 
+sockaddr localIP;
 uint32_t fakePoolSize                 = 0;
 SceNetAdhocMatchingContext * contexts = NULL;
 int one                               = 1;
@@ -1396,6 +1397,7 @@ int getPTPSocketCount(void) {
 }
 
 int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
+	//TODO: this is all IPv4 only
 	int iResult = 0;
 	metasocket = (int)INVALID_SOCKET;
 	metasocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -1415,7 +1417,7 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 
 	iResult = getaddrinfo(g_Config.proAdhocServer.c_str(),0,NULL,&resultAddr);
 	if (iResult != 0) {
-		ERROR_LOG(SCENET, "DNS Error (%s)\n", g_Config.proAdhocServer.c_str());
+		ERROR_LOG(SCENET, "DNS Error (%s) result: %d\n", g_Config.proAdhocServer.c_str(), iResult);
 		osm.Show("DNS Error connecting to " + g_Config.proAdhocServer, 8.0f);
 		return iResult;
 	}
@@ -1426,14 +1428,44 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 			break;
 		}
 	}
-	
+	freeaddrinfo(resultAddr);
+
+	// Resolve dns for client
+	if (g_Config.bBindLocal)
+	{
+
+		addrinfo *localAddr;
+
+		iResult = getaddrinfo(g_Config.localBindAddress.c_str(), 0, NULL, &localAddr);
+		if (iResult != 0) {
+			ERROR_LOG(SCENET, "DNS Error (%s) result: %d\n", g_Config.localBindAddress.c_str(), iResult);
+			osm.Show("DNS Error, can't resolve client bind " + g_Config.localBindAddress, 8.0f);
+			return iResult;
+		}
+		for (ptr = localAddr; ptr != NULL; ptr = ptr->ai_next) {
+			switch (ptr->ai_family) {
+			case AF_INET:
+				memcpy(&localIP, ptr->ai_addr, sizeof(sockaddr));
+				break;
+			}
+		}
+		((sockaddr_in *) &localIP)->sin_port = SERVER_PORT; //NOTE: maybe use SERVER_PORT or 0 here
+		int iResult = bind(metasocket, &localIP, sizeof(sockaddr_in));
+		if (iResult != 0) {
+			ERROR_LOG(SCENET, "Bind Error, bind to (%s) returned %d \n", g_Config.localBindAddress.c_str(),iResult);
+			osm.Show("Bind Error, can't bind to \"" + g_Config.localBindAddress + "\" error code: " + std::to_string(iResult), 8.0f);
+			return iResult;
+		}
+		freeaddrinfo(localAddr);
+	}
+
 	memset(&parameter, 0, sizeof(parameter));
 	strcpy((char *)&parameter.nickname.data, g_Config.sNickName.c_str());
 	parameter.channel = 1; // Fake Channel 1
 	getLocalMac(&parameter.bssid.mac_addr);
 
 	server_addr.sin_addr = serverIp;
-	iResult = connect(metasocket,(sockaddr *)&server_addr,sizeof(server_addr));
+	iResult = connect(metasocket, (sockaddr *) &server_addr, sizeof(server_addr));
 	if (iResult == SOCKET_ERROR) {
 		uint8_t * sip = (uint8_t *)&server_addr.sin_addr.s_addr;
 		char buffer[512];

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -170,6 +170,8 @@ inline bool connectInProgress(int errcode){ return (errcode == EINPROGRESS); }
 #define PSP_ADHOCCTL_RECV_TIMEOUT	100000
 #define PSP_ADHOCCTL_PING_TIMEOUT	2000000
 
+extern sockaddr localIP;
+
 #ifdef _MSC_VER 
 #pragma pack(push, 1)
 #endif

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -259,8 +259,14 @@ static int sceNetAdhocPdpCreate(const char *mac, u32 port, int bufferSize, u32 u
 					// Binding Information for local Port
 					sockaddr_in addr;
 					addr.sin_family = AF_INET;
-					addr.sin_addr.s_addr = INADDR_ANY;
-
+					if (g_Config.bBindLocal)
+					{
+						addr.sin_addr = ((sockaddr_in *) &localIP)->sin_addr;
+					}
+					else
+					{
+						addr.sin_addr.s_addr = INADDR_ANY;
+					}
 					//if (port < 7) addr.sin_port = htons(port + 1341); else // <= 443
 					addr.sin_port = htons(port); // This not safe in any way...
 					// The port might be under 1024 (ie. GTA:VCS use port 1, Ford Street Racing use port 0 (UNUSED_PORT), etc) and already used by other application/host OS, should we add 1024 to the port whenever it tried to use an already used port?

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -386,10 +386,13 @@ void GameSettingsScreen::CreateViews() {
 
 	networkingSettings->Add(new ItemHeader(n->T("Networking")));
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
+	networkingSettings->Add(new CheckBox(&g_Config.bBindLocal, n->T("Enable bind", "Specify client address")));
 
 #ifdef _WIN32
+	networkingSettings->Add(new PopupTextInputChoice(&g_Config.localBindAddress, n->T("Change bind address"), "", 255, screenManager()));
 	networkingSettings->Add(new PopupTextInputChoice(&g_Config.proAdhocServer, n->T("Change proAdhocServer Address"), "", 255, screenManager()));
 #else
+	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.localBindAddress, n->T("Change bind address"), nullptr))->OnClick.Handle(this, 255, &GameSettingsScreen::OnChangeBindAddress);
 	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.proAdhocServer, n->T("Change proAdhocServer Address"), nullptr))->OnClick.Handle(this, &GameSettingsScreen::OnChangeproAdhocServerAddress);
 #endif
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableAdhocServer, n->T("Enable built-in PRO Adhoc Server", "Enable built-in PRO Adhoc Server")));
@@ -808,11 +811,33 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 		}
 	}
 	else
-		screenManager()->push(new ProAdhocServerScreen);
+		screenManager()->push(new HostnameSelectScreen(g_Config.proAdhocServer));
 #else
-	screenManager()->push(new ProAdhocServerScreen);
+	screenManager()->push(new HostnameSelectScreen(g_Config.proAdhocServer));
 #endif
 	
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnChangeBindAddress(UI::EventParams &e)
+{
+#if defined(_WIN32) || defined(USING_QT_UI)	
+	if (!g_Config.bFullScreen) {
+		const size_t name_len = 256;
+
+		char name[name_len];
+		memset(name, 0, sizeof(name));
+
+		if (System_InputBoxGetString("Enter an IP address", g_Config.localBindAddress.c_str(), name, name_len)) {
+			g_Config.localBindAddress = name;
+		}
+	}
+	else
+		screenManager()->push(new HostnameSelectScreen(g_Config.localBindAddress));
+#else
+	screenManager()->push(new HostnameSelectScreen(g_Config.localBindAddress));
+#endif
+
 	return UI::EVENT_DONE;
 }
 
@@ -994,12 +1019,12 @@ UI::EventReturn DeveloperToolsScreen::OnJitAffectingSetting(UI::EventParams &e) 
 	return UI::EVENT_DONE;
 }
 
-void ProAdhocServerScreen::CreateViews() {
+void HostnameSelectScreen::CreateViews() {
 	using namespace UI;	
 	I18NCategory *s = GetI18NCategory("System");
 	I18NCategory *d = GetI18NCategory("Dialog");
 	
-	tempProAdhocServer = g_Config.proAdhocServer;
+	tempProAdhocServer = targetConfig;
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 	LinearLayout *leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	
@@ -1007,115 +1032,115 @@ void ProAdhocServerScreen::CreateViews() {
 	addrView_ = new TextView(tempProAdhocServer, ALIGN_LEFT, false);
 	leftColumn->Add(addrView_);
 	LinearLayout *rightColumn = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(0, 120, 10, NONE, NONE,10));
-	rightColumn->Add(new Button("0"))->OnClick.Handle(this, &ProAdhocServerScreen::On0Click);
-	rightColumn->Add(new Button("1"))->OnClick.Handle(this, &ProAdhocServerScreen::On1Click);
-	rightColumn->Add(new Button("2"))->OnClick.Handle(this, &ProAdhocServerScreen::On2Click);
-	rightColumn->Add(new Button("3"))->OnClick.Handle(this, &ProAdhocServerScreen::On3Click);
-	rightColumn->Add(new Button("4"))->OnClick.Handle(this, &ProAdhocServerScreen::On4Click);
-	rightColumn->Add(new Button("5"))->OnClick.Handle(this, &ProAdhocServerScreen::On5Click);
-	rightColumn->Add(new Button("6"))->OnClick.Handle(this, &ProAdhocServerScreen::On6Click);
-	rightColumn->Add(new Button("7"))->OnClick.Handle(this, &ProAdhocServerScreen::On7Click);
-	rightColumn->Add(new Button("8"))->OnClick.Handle(this, &ProAdhocServerScreen::On8Click);
-	rightColumn->Add(new Button("9"))->OnClick.Handle(this, &ProAdhocServerScreen::On9Click);
-	rightColumn->Add(new Button("."))->OnClick.Handle(this, &ProAdhocServerScreen::OnPointClick);
-	rightColumn->Add(new Button(d->T("Delete")))->OnClick.Handle(this, &ProAdhocServerScreen::OnDeleteClick);
-	rightColumn->Add(new Button(d->T("Delete all")))->OnClick.Handle(this, &ProAdhocServerScreen::OnDeleteAllClick);
-	rightColumn->Add(new Button(d->T("OK")))->OnClick.Handle(this, &ProAdhocServerScreen::OnOKClick);
-	rightColumn->Add(new Button(d->T("Cancel")))->OnClick.Handle(this, &ProAdhocServerScreen::OnCancelClick);
+	rightColumn->Add(new Button("0"))->OnClick.Handle(this, &HostnameSelectScreen::On0Click);
+	rightColumn->Add(new Button("1"))->OnClick.Handle(this, &HostnameSelectScreen::On1Click);
+	rightColumn->Add(new Button("2"))->OnClick.Handle(this, &HostnameSelectScreen::On2Click);
+	rightColumn->Add(new Button("3"))->OnClick.Handle(this, &HostnameSelectScreen::On3Click);
+	rightColumn->Add(new Button("4"))->OnClick.Handle(this, &HostnameSelectScreen::On4Click);
+	rightColumn->Add(new Button("5"))->OnClick.Handle(this, &HostnameSelectScreen::On5Click);
+	rightColumn->Add(new Button("6"))->OnClick.Handle(this, &HostnameSelectScreen::On6Click);
+	rightColumn->Add(new Button("7"))->OnClick.Handle(this, &HostnameSelectScreen::On7Click);
+	rightColumn->Add(new Button("8"))->OnClick.Handle(this, &HostnameSelectScreen::On8Click);
+	rightColumn->Add(new Button("9"))->OnClick.Handle(this, &HostnameSelectScreen::On9Click);
+	rightColumn->Add(new Button("."))->OnClick.Handle(this, &HostnameSelectScreen::OnPointClick);
+	rightColumn->Add(new Button(d->T("Delete")))->OnClick.Handle(this, &HostnameSelectScreen::OnDeleteClick);
+	rightColumn->Add(new Button(d->T("Delete all")))->OnClick.Handle(this, &HostnameSelectScreen::OnDeleteAllClick);
+	rightColumn->Add(new Button(d->T("OK")))->OnClick.Handle(this, &HostnameSelectScreen::OnOKClick);
+	rightColumn->Add(new Button(d->T("Cancel")))->OnClick.Handle(this, &HostnameSelectScreen::OnCancelClick);
 	root_->Add(leftColumn);
 	root_->Add(rightColumn);
 }
 
-UI::EventReturn ProAdhocServerScreen::On0Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On0Click(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0)
 		tempProAdhocServer.append("0");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On1Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On1Click(UI::EventParams &e) {
 	tempProAdhocServer.append("1");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On2Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On2Click(UI::EventParams &e) {
 	tempProAdhocServer.append("2");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On3Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On3Click(UI::EventParams &e) {
 	tempProAdhocServer.append("3");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On4Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On4Click(UI::EventParams &e) {
 	tempProAdhocServer.append("4");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On5Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On5Click(UI::EventParams &e) {
 	tempProAdhocServer.append("5");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On6Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On6Click(UI::EventParams &e) {
 	tempProAdhocServer.append("6");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On7Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On7Click(UI::EventParams &e) {
 	tempProAdhocServer.append("7");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On8Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On8Click(UI::EventParams &e) {
 	tempProAdhocServer.append("8");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On9Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On9Click(UI::EventParams &e) {
 	tempProAdhocServer.append("9");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
 
-UI::EventReturn ProAdhocServerScreen::OnPointClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0 && tempProAdhocServer.at(tempProAdhocServer.length() - 1) != '.')
 		tempProAdhocServer.append(".");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnDeleteClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0)
 		tempProAdhocServer.erase(tempProAdhocServer.length() -1, 1);
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnDeleteAllClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnDeleteAllClick(UI::EventParams &e) {
 	tempProAdhocServer = "";
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnOKClick(UI::EventParams &e) {
-	g_Config.proAdhocServer = tempProAdhocServer;
+UI::EventReturn HostnameSelectScreen::OnOKClick(UI::EventParams &e) {
+	targetConfig = tempProAdhocServer;
 	UIScreen::OnBack(e);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnCancelClick(UI::EventParams &e) {
-	tempProAdhocServer = g_Config.proAdhocServer;
+UI::EventReturn HostnameSelectScreen::OnCancelClick(UI::EventParams &e) {
+	tempProAdhocServer = targetConfig;
 	UIScreen::OnBack(e);
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -76,6 +76,7 @@ private:
 	UI::EventReturn OnDeveloperTools(UI::EventParams &e);
 	UI::EventReturn OnChangeNickname(UI::EventParams &e);
 	UI::EventReturn OnChangeproAdhocServerAddress(UI::EventParams &e);
+	UI::EventReturn OnChangeBindAddress(UI::EventParams &e);
 	UI::EventReturn OnChangeMacAddress(UI::EventParams &e);
 	UI::EventReturn OnClearRecents(UI::EventParams &e);
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
@@ -126,15 +127,16 @@ private:
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 };
 
-class ProAdhocServerScreen : public UIDialogScreenWithBackground {
+class HostnameSelectScreen : public UIDialogScreenWithBackground {
 public:
-	ProAdhocServerScreen() {}	
+	HostnameSelectScreen(std::string &target) : targetConfig(target){}	
 
 protected:
 	virtual void CreateViews();
 
 private:	
 	std::string tempProAdhocServer;
+	std::string &targetConfig;
 	UI::TextView *addrView_;
 	UI::EventReturn OnBack(UI::EventParams &e);
 	UI::EventReturn On0Click(UI::EventParams &e);


### PR DESCRIPTION
THIS IS NOT FOR MERGING

this is obviously just a hack for now to be able to test networking without needing two PCs or a VM, especially because of the inelegantly hackish global `localIP` value.

I also need to look at all the `xyz_localIP()` functions and how they would interact with this, but it seems to work for now

![](http://i.imgur.com/vFVdooP.jpg)

And it is useful for testing purposes which is why I made this pull-request as a place to discuss how to deal with this use-case as a whole.

Whether we should just add an option to add a header with port information and tunnel everything through one port or we should just port-shift everything uniformly like jpcsp does
