### PR TITLE
Handle a case of 480x360 framebuffers

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -122,7 +122,9 @@ void FramebufferManagerCommon::EstimateDrawingSize(int &drawing_width, int &draw
 			drawing_height = 272;
 		}
 		// Sometimes region is set larger than the VRAM for the framebuffer.
-		if (region_width <= fb_stride && region_width > drawing_width && region_height <= MAX_FRAMEBUF_HEIGHT) {
+		// However, in one game it's correctly set as a larger height (see #7277) with the same width.
+		// A bit of a hack, but we try to handle that unusual case here.
+		if (region_width <= fb_stride && (region_width > drawing_width || (region_width == drawing_width && region_height > drawing_height)) && region_height <= MAX_FRAMEBUF_HEIGHT) {
 			drawing_width = region_width;
 			drawing_height = std::max(drawing_height, region_height);
 		}

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -145,8 +145,8 @@ void SoftwareTransform(
 
 	bool skinningEnabled = vertTypeIsSkinningEnabled(vertType);
 
-	int w = gstate.getTextureWidth(0);
-	int h = gstate.getTextureHeight(0);
+	const int w = gstate.getTextureWidth(0);
+	const int h = gstate.getTextureHeight(0);
 	float widthFactor = (float) w / (float) gstate_c.curTextureWidth;
 	float heightFactor = (float) h / (float) gstate_c.curTextureHeight;
 
@@ -396,7 +396,7 @@ void SoftwareTransform(
 	}
 
 	// This means we're using a framebuffer (and one that isn't big enough.)
-	if (gstate_c.curTextureHeight < (u32)gstate.getTextureHeight(0) && maxIndex >= 2) {
+	if (gstate_c.curTextureHeight < (u32)h && maxIndex >= 2) {
 		// Even if not rectangles, this will detect if either of the first two are outside the framebuffer.
 		// HACK: Adding one pixel margin to this detection fixes issues in Assassin's Creed : Bloodlines,
 		// while still keeping BOF working (see below).


### PR DESCRIPTION
Region and scissor are 480x360, but viewport is just default (also, throughmode is on.)  We could add more checks, but just the height being a bit higher is already unusual, so should be relatively safe.

Fixes #7277.

These heuristics aren't beautiful but they generally work...

-[Unknown]
