### PR TITLE
Report any attempt to read a negative size

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -25,6 +25,7 @@
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HW/MemoryStick.h"
+#include "Core/Reporting.h"
 #include "UI/OnScreenDisplay.h"
 
 #ifdef _WIN32
@@ -606,8 +607,12 @@ size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 
 size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
-	if (iter != entries.end())
-	{
+	if (iter != entries.end()) {
+		if (size < 0) {
+			ERROR_LOG_REPORT(FILESYS, "Invalid read for %lld bytes from disk %s", size, iter->second.guestFilename.c_str());
+			return 0;
+		}
+
 		size_t bytesRead = iter->second.hFile.Read(pointer,size);
 		return bytesRead;
 	} else {

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -554,8 +554,7 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
 		{
 			positionOnIso = e.sectorStart * 2048 + e.seekPos;
 			
-			if (e.seekPos + size > e.openSize)
-			{
+			if ((s64)e.seekPos + size > (s64)e.openSize) {
 				size = e.openSize - e.seekPos;
 			}
 		}
@@ -564,8 +563,7 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
 			_dbg_assert_msg_(FILESYS, e.file != 0, "Expecting non-raw fd to have a tree entry.");
 
 			//clamp read length
-			if ((s64)e.seekPos > e.file->size - (s64)size)
-			{
+			if ((s64)e.seekPos + size > e.file->size) {
 				size = e.file->size - (s64)e.seekPos;
 			}
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -528,9 +528,13 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
 {
 	EntryMap::iterator iter = entries.find(handle);
-	if (iter != entries.end())
-	{
+	if (iter != entries.end()) {
 		OpenFileEntry &e = iter->second;
+
+		if (size < 0) {
+			ERROR_LOG_REPORT(FILESYS, "Invalid read for %lld bytes from umd %s", size, e.file ? e.file->name.c_str() : "device");
+			return 0;
+		}
 		
 		if (e.isBlockSectorMode)
 		{

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -21,6 +21,7 @@
 #include "Core/FileSystems/VirtualDiscFileSystem.h"
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/HLE/sceKernel.h"
+#include "Core/Reporting.h"
 #include "file/zip_read.h"
 #include "util/text/utf8.h"
 
@@ -434,8 +435,12 @@ size_t VirtualDiscFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
 
 size_t VirtualDiscFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
-	if (iter != entries.end())
-	{
+	if (iter != entries.end()) {
+		if (size < 0) {
+			ERROR_LOG_REPORT(FILESYS, "Invalid read for %lld bytes from virtual umd", size);
+			return 0;
+		}
+
 		// it's the whole iso... it could reference any of the files on the disc.
 		// For now let's just open and close the files on demand. Can certainly be done
 		// better though


### PR DESCRIPTION
If this should return an error, that should be handled in sceIo.  But by the time it gets here, I'm sure it should refuse to read a negative s64 of bytes.

This is apparently causing glitches in #6374.

-[Unknown]
