### PR TITLE
Use Dolphin's audio resampler to lower latency on Android and prevent drift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1276,6 +1276,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HW/MemoryStick.h
 	Core/HW/SasAudio.cpp
 	Core/HW/SasAudio.h
+	Core/HW/StereoResampler.cpp
+	Core/HW/StereoResampler.h
 	Core/Host.cpp
 	Core/Host.h
 	Core/Loaders.cpp

--- a/Common/Atomic_GCC.h
+++ b/Common/Atomic_GCC.h
@@ -1,29 +1,12 @@
-// Copyright (C) 2003 Dolphin Project.
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
 
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, version 2.0 or later versions.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License 2.0 for more details.
-
-// A copy of the GPL 2.0 should have been included with the program.
-// If not, see http://www.gnu.org/licenses/
-
-// Official SVN repository and contact information can be found at
-// http://code.google.com/p/dolphin-emu/
+// IWYU pragma: private, include "Common/Atomic.h"
 
 #pragma once
 
-#ifdef BLACKBERRY
-#include <atomic.h>
-#elif defined(__SYMBIAN32__)
-#include <e32atomics.h>
-#endif
-
-#include "Common.h"
+#include "Common/Common.h"
 
 // Atomic operations are performed in a single step by the CPU. It is
 // impossible for other threads to see the operation "half-done."
@@ -42,53 +25,78 @@
 namespace Common
 {
 
-inline void AtomicAdd(volatile u32& target, u32 value) {
+inline void AtomicAdd(volatile u32& target, u32 value)
+{
 	__sync_add_and_fetch(&target, value);
 }
 
-inline void AtomicAnd(volatile u32& target, u32 value) {
+inline void AtomicAnd(volatile u32& target, u32 value)
+{
 	__sync_and_and_fetch(&target, value);
 }
 
-inline void AtomicDecrement(volatile u32& target) {
+inline void AtomicDecrement(volatile u32& target)
+{
 	__sync_add_and_fetch(&target, -1);
 }
 
-inline void AtomicIncrement(volatile u32& target) {
+inline void AtomicIncrement(volatile u32& target)
+{
 	__sync_add_and_fetch(&target, 1);
 }
 
-inline u32 AtomicLoad(volatile u32& src) {
-	return src; // 32-bit reads are always atomic.
-}
-inline u32 AtomicLoadAcquire(volatile u32& src) {
-#ifdef __SYMBIAN32__
-	return __e32_atomic_load_acq32(&src);
-#else
-	//keep the compiler from caching any memory references
-	u32 result = src; // 32-bit reads are always atomic.
-	//__sync_synchronize(); // TODO: May not be necessary.
-	// Compiler instruction only. x86 loads always have acquire semantics.
-	__asm__ __volatile__ ( "":::"memory" );
-	return result;
-#endif
-}
-
-inline void AtomicOr(volatile u32& target, u32 value) {
+inline void AtomicOr(volatile u32& target, u32 value)
+{
 	__sync_or_and_fetch(&target, value);
 }
 
-inline void AtomicStore(volatile u32& dest, u32 value) {
-	dest = value; // 32-bit writes are always atomic.
+// Support clang versions older than 3.4.
+#if __clang__ 
+#if !__has_feature(cxx_atomic)
+template <typename T>
+_Atomic(T)* ToC11Atomic(volatile T* loc)
+{
+	return (_Atomic(T)*) loc;
 }
-inline void AtomicStoreRelease(volatile u32& dest, u32 value) {
-#ifdef BLACKBERRY
-	atomic_set(&dest, value);
-#elif defined(__SYMBIAN32__)
-	__e32_atomic_store_rel32(&dest, value);
-#else
-	__sync_lock_test_and_set(&dest, value); // TODO: Wrong! This function has acquire semantics.
+
+#define __atomic_load_n(p, m) __c11_atomic_load(ToC11Atomic(p), m)
+#define __atomic_store_n(p, v, m) __c11_atomic_store(ToC11Atomic(p), v, m)
+#define __atomic_exchange_n(p, v, m) __c11_atomic_exchange(ToC11Atomic(p), v, m)
 #endif
+#endif
+
+#ifndef __ATOMIC_RELAXED
+#error __ATOMIC_RELAXED not defined; your compiler version is too old.
+#endif
+
+template <typename T>
+inline T AtomicLoad(volatile T& src)
+{
+	return __atomic_load_n(&src, __ATOMIC_RELAXED);
+}
+
+template <typename T>
+inline T AtomicLoadAcquire(volatile T& src)
+{
+	return __atomic_load_n(&src, __ATOMIC_ACQUIRE);
+}
+
+template <typename T, typename U>
+inline void AtomicStore(volatile T& dest, U value)
+{
+	__atomic_store_n(&dest, value, __ATOMIC_RELAXED);
+}
+
+template <typename T, typename U>
+inline void AtomicStoreRelease(volatile T& dest, U value)
+{
+	__atomic_store_n(&dest, value, __ATOMIC_RELEASE);
+}
+
+template <typename T, typename U>
+inline T* AtomicExchangeAcquire(T* volatile& loc, U newval)
+{
+	return __atomic_exchange_n(&loc, newval, __ATOMIC_ACQ_REL);
 }
 
 }

--- a/Common/Atomic_GCC.h
+++ b/Common/Atomic_GCC.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "CommonTypes.h"
 
 // Atomic operations are performed in a single step by the CPU. It is
 // impossible for other threads to see the operation "half-done."

--- a/Common/Atomic_Win32.h
+++ b/Common/Atomic_Win32.h
@@ -57,12 +57,14 @@ inline void AtomicOr(volatile u32& target, u32 value)
 	_InterlockedOr((volatile LONG*)&target, (LONG)value);
 }
 
+// For the comment below to hold, better only use this with 32-bit types..
 template <typename T>
 inline T AtomicLoad(volatile T& src)
 {
 	return src; // 32-bit reads are always atomic.
 }
 
+// For the comment below to hold, better only use this with 32-bit types..
 template <typename T>
 inline T AtomicLoadAcquire(volatile T& src)
 {
@@ -71,17 +73,19 @@ inline T AtomicLoadAcquire(volatile T& src)
 	return result;
 }
 
+// For the comment below to hold, better only use this with 32-bit types..
 template <typename T, typename U>
 inline void AtomicStore(volatile T& dest, U value)
 {
 	dest = (T)value; // 32-bit writes are always atomic.
 }
 
+// For the comment below to hold, better only use this with 32-bit types..
 template <typename T, typename U>
 inline void AtomicStoreRelease(volatile T& dest, U value)
 {
 	_WriteBarrier(); // Compiler instruction only. x86 stores always have release semantics.
-	dest = (T)value; // 32-bit writes are always atomic.
+	dest = (T)value; // 32-bit writes are always atomic
 }
 
 template <typename T, typename U>

--- a/Common/Atomic_Win32.h
+++ b/Common/Atomic_Win32.h
@@ -1,29 +1,15 @@
-// Copyright (C) 2003 Dolphin Project.
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
 
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, version 2.0 or later versions.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License 2.0 for more details.
-
-// A copy of the GPL 2.0 should have been included with the program.
-// If not, see http://www.gnu.org/licenses/
-
-// Official SVN repository and contact information can be found at
-// http://code.google.com/p/dolphin-emu/
+// IWYU pragma: private, include "Common/Atomic.h"
 
 #pragma once
 
-#include "Common.h"
-#ifndef _XBOX
 #include <intrin.h>
-#else
-#include <ppcintrinsics.h>
-#endif
-#include "CommonWindows.h"
+#include <Windows.h>
+
+#include "CommonTypes.h"
 
 // Atomic operations are performed in a single step by the CPU. It is
 // impossible for other threads to see the operation "half-done."
@@ -46,41 +32,62 @@
 namespace Common
 {
 
-inline void AtomicAdd(volatile u32& target, u32 value) {
-	InterlockedExchangeAdd((volatile LONG*)&target, (LONG)value);
+inline void AtomicAdd(volatile u32& target, u32 value)
+{
+	_InterlockedExchangeAdd((volatile LONG*)&target, (LONG)value);
 }
 
-inline void AtomicAnd(volatile u32& target, u32 value) {
+inline void AtomicAnd(volatile u32& target, u32 value)
+{
 	_InterlockedAnd((volatile LONG*)&target, (LONG)value);
 }
 
-inline void AtomicIncrement(volatile u32& target) {
-	InterlockedIncrement((volatile LONG*)&target);
+inline void AtomicIncrement(volatile u32& target)
+{
+	_InterlockedIncrement((volatile LONG*)&target);
 }
 
-inline void AtomicDecrement(volatile u32& target) {
-	InterlockedDecrement((volatile LONG*)&target);
+inline void AtomicDecrement(volatile u32& target)
+{
+	_InterlockedDecrement((volatile LONG*)&target);
 }
 
-inline u32 AtomicLoad(volatile u32& src) {
+inline void AtomicOr(volatile u32& target, u32 value)
+{
+	_InterlockedOr((volatile LONG*)&target, (LONG)value);
+}
+
+template <typename T>
+inline T AtomicLoad(volatile T& src)
+{
 	return src; // 32-bit reads are always atomic.
 }
-inline u32 AtomicLoadAcquire(volatile u32& src) {
-	u32 result = src; // 32-bit reads are always atomic.
+
+template <typename T>
+inline T AtomicLoadAcquire(volatile T& src)
+{
+	T result = src; // 32-bit reads are always atomic.
 	_ReadBarrier(); // Compiler instruction only. x86 loads always have acquire semantics.
 	return result;
 }
 
-inline void AtomicOr(volatile u32& target, u32 value) {
-	_InterlockedOr((volatile LONG*)&target, (LONG)value);
+template <typename T, typename U>
+inline void AtomicStore(volatile T& dest, U value)
+{
+	dest = (T)value; // 32-bit writes are always atomic.
 }
 
-inline void AtomicStore(volatile u32& dest, u32 value) {
-	dest = value; // 32-bit writes are always atomic.
-}
-inline void AtomicStoreRelease(volatile u32& dest, u32 value) {
+template <typename T, typename U>
+inline void AtomicStoreRelease(volatile T& dest, U value)
+{
 	_WriteBarrier(); // Compiler instruction only. x86 stores always have release semantics.
-	dest = value; // 32-bit writes are always atomic.
+	dest = (T)value; // 32-bit writes are always atomic.
+}
+
+template <typename T, typename U>
+inline T* AtomicExchangeAcquire(T* volatile& loc, U newval)
+{
+	return (T*)_InterlockedExchangePointer_acq((void* volatile*)&loc, (void*)newval);
 }
 
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -334,8 +334,6 @@ static bool DefaultForceFlushToZero() {
 static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("Jit", &g_Config.bJit, &DefaultJit, true, true),
 	ReportedConfigSetting("SeparateCPUThread", &g_Config.bSeparateCPUThread, false, true, true),
-	ConfigSetting("AtomicAudioLocks", &g_Config.bAtomicAudioLocks, false, true, true),
-
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -118,7 +118,6 @@ public:
 	bool bSeparateCPUThread;
 	int iIOTimingMethod;
 	bool bSeparateIOThread;
-	bool bAtomicAudioLocks;
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;
 	bool bCacheFullIsoInRam;

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -274,6 +274,7 @@
     <ClCompile Include="HW\SasAudio.cpp" />
     <ClCompile Include="HW\AsyncIOManager.cpp" />
     <ClCompile Include="HW\SimpleAudioDec.cpp" />
+    <ClCompile Include="HW\StereoResampler.cpp" />
     <ClCompile Include="Loaders.cpp" />
     <ClCompile Include="MemMap.cpp" />
     <ClCompile Include="MemmapFunctions.cpp" />
@@ -512,6 +513,7 @@
     <ClInclude Include="HW\MemoryStick.h" />
     <ClInclude Include="HW\AsyncIOManager.h" />
     <ClInclude Include="HW\SimpleAudioDec.h" />
+    <ClInclude Include="HW\StereoResampler.h" />
     <ClInclude Include="Loaders.h" />
     <ClInclude Include="MemMap.h" />
     <ClInclude Include="MIPS\ARM\ArmAsm.h">

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -300,6 +300,9 @@
     <ClCompile Include="HW\MediaEngine.cpp">
       <Filter>HW</Filter>
     </ClCompile>
+    <ClCompile Include="HW\StereoResampler.cpp">
+      <Filter>HW</Filter>
+    </ClCompile>
     <ClCompile Include="Util\PPGeDraw.cpp">
       <Filter>Util</Filter>
     </ClCompile>
@@ -773,6 +776,9 @@
       <Filter>HLE\Libraries</Filter>
     </ClInclude>
     <ClInclude Include="HW\MediaEngine.h">
+      <Filter>HW</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\StereoResampler.h">
       <Filter>HW</Filter>
     </ClInclude>
     <ClInclude Include="Util\PPGeDraw.h">

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -410,42 +410,4 @@ void __AudioUpdate() {
 int __AudioMix(short *outstereo, int numFrames, int sampleRate) {
 	resampler.Mix(outstereo, numFrames, false, sampleRate);
 	return numFrames;
-
-	/*
-	// TODO: if mixFrequency != the actual output frequency, resample!
-	int underrun = -1;
-	s16 sampleL = 0;
-	s16 sampleR = 0;
-
-	const s16 *buf1 = 0, *buf2 = 0;
-	size_t sz1, sz2;
-	{
-		//TODO: do rigorous testing to see whether just blind locking will improve speed.
-		if (!__gainAudioQueueLock()){
-			 memset(outstereo, 0, numFrames * 2 * sizeof(short)); 
-			 return 0;
-		}
-		
-		resampler.Mix(outstereo, numFrames);
-		outAudioQueue.popPointers(numFrames * 2, &buf1, &sz1, &buf2, &sz2);
-
-		memcpy(outstereo, buf1, sz1 * sizeof(s16));
-		if (buf2) {
-			memcpy(outstereo + sz1, buf2, sz2 * sizeof(s16));
-		}
-
-		//release the atomic lock
-		__releaseAcquiredLock();
-	}
-
-	int remains = (int)(numFrames * 2 - sz1 - sz2);
-	if (remains > 0)
-		memset(outstereo + numFrames * 2 - remains, 0, remains*sizeof(s16));
-
-	if (sz1 + sz2 < (size_t)numFrames) {
-		underrun = (int)(sz1 + sz2) / 2;
-		VERBOSE_LOG(SCEAUDIO, "Audio out buffer UNDERRUN at %i of %i", underrun, numFrames);
-	}
-	return underrun >= 0 ? underrun : numFrames;
-	*/
 }

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -32,4 +32,4 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);
 void __AudioWakeThreads(AudioChannel &chan, int result, int step);
 void __AudioWakeThreads(AudioChannel &chan, int result);
 
-int __AudioMix(short *outstereo, int numSamples);
+int __AudioMix(short *outstereo, int numSamples, int sampleRate);

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -54,7 +54,6 @@ inline void ClampBufferToS16(s16 *out, const s32 *in, size_t size) {
 
 void StereoResampler::MixerFifo::Clear() {
 	memset(m_buffer, 0, sizeof(m_buffer));
-	// TODO
 }
 
 // Executed from sound stream thread
@@ -156,16 +155,10 @@ void StereoResampler::MixerFifo::PushSamples(const s32 *samples, unsigned int nu
 	}
 
 	Common::AtomicAdd(m_indexW, num_samples * 2);
-
-	return;
 }
 
 void StereoResampler::PushSamples(const int *samples, unsigned int num_samples) {
 	m_dma_mixer.PushSamples(samples, num_samples);
-}
-
-void StereoResampler::SetDMAInputSampleRate(unsigned int rate) {
-	m_dma_mixer.SetInputSampleRate(rate);
 }
 
 void StereoResampler::MixerFifo::SetInputSampleRate(unsigned int rate) {

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2015- PPSSPP Project and Dolphin Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+// Adapted from Dolphin.
+
+#include <string.h>
+
+#include "base/logging.h"
+#include "Common/ChunkFile.h"
+#include "Common/MathUtil.h"
+#include "Common/Atomics.h"
+#include "Core/HW/StereoResampler.h"
+#include "Globals.h"
+
+#ifdef _M_SSE
+#include <emmintrin.h>
+#endif
+
+inline void ClampBufferToS16(s16 *out, const s32 *in, size_t size) {
+#ifdef _M_SSE
+	// Size will always be 16-byte aligned as the hwBlockSize is.
+	while (size >= 8) {
+		__m128i in1 = _mm_loadu_si128((__m128i *)in);
+		__m128i in2 = _mm_loadu_si128((__m128i *)(in + 4));
+		__m128i packed = _mm_packs_epi32(in1, in2);
+		_mm_storeu_si128((__m128i *)out, packed);
+		out += 8;
+		in += 8;
+		size -= 8;
+	}
+	for (size_t i = 0; i < size; i++) {
+		out[i] = clamp_s16(in[i]);
+	}
+#else
+	for (size_t i = 0; i < size; i++) {
+		out[i] = clamp_s16(in[i]);
+	}
+#endif
+}
+
+void StereoResampler::MixerFifo::Clear() {
+	// TODO
+}
+
+// Executed from sound stream thread
+unsigned int StereoResampler::MixerFifo::Mix(short* samples, unsigned int numSamples, bool consider_framelimit, int sample_rate) {
+	unsigned int currentSample = 0;
+
+	// Cache access in non-volatile variable
+	// This is the only function changing the read value, so it's safe to
+	// cache it locally although it's written here.
+	// The writing pointer will be modified outside, but it will only increase,
+	// so we will just ignore new written data while interpolating.
+	// Without this cache, the compiler wouldn't be allowed to optimize the
+	// interpolation loop.
+	u32 indexR = Common::AtomicLoad(m_indexR);
+	u32 indexW = Common::AtomicLoad(m_indexW);
+
+	float numLeft = (float)(((indexW - indexR) & INDEX_MASK) / 2);
+	m_numLeftI = (numLeft + m_numLeftI*(CONTROL_AVG - 1)) / CONTROL_AVG;
+	float offset = (m_numLeftI - LOW_WATERMARK) * CONTROL_FACTOR;
+	if (offset > MAX_FREQ_SHIFT) offset = MAX_FREQ_SHIFT;
+	if (offset < -MAX_FREQ_SHIFT) offset = -MAX_FREQ_SHIFT;
+
+	// render numleft sample pairs to samples[]
+	// advance indexR with sample position
+	// remember fractional offset
+
+
+	float aid_sample_rate = m_input_sample_rate + offset;
+	
+	/*
+	u32 framelimit = SConfig::GetInstance().m_Framelimit;
+	if (consider_framelimit && framelimit > 1) {
+		aid_sample_rate = aid_sample_rate * (framelimit - 1) * 5 / 59.994;
+	}*/
+
+	const u32 ratio = (u32)(65536.0f * aid_sample_rate / (float)sample_rate);
+
+	s32 lvolume = m_LVolume;
+	s32 rvolume = m_RVolume;
+
+	// TODO: consider a higher-quality resampling algorithm.
+	// TODO: Add a fast path for 1:1.
+	for (; currentSample < numSamples * 2 && ((indexW - indexR) & INDEX_MASK) > 2; currentSample += 2) {
+		u32 indexR2 = indexR + 2; //next sample
+
+		s16 l1 = m_buffer[indexR & INDEX_MASK]; //current
+		s16 l2 = m_buffer[indexR2 & INDEX_MASK]; //next
+		int sampleL = ((l1 << 16) + (l2 - l1) * (u16)m_frac) >> 16;
+		sampleL = (sampleL * lvolume) >> 8;
+		sampleL += samples[currentSample + 1];
+		MathUtil::Clamp(&sampleL, -32767, 32767);
+		samples[currentSample + 1] = sampleL;
+
+		s16 r1 = m_buffer[(indexR + 1) & INDEX_MASK]; //current
+		s16 r2 = m_buffer[(indexR2 + 1) & INDEX_MASK]; //next
+		int sampleR = ((r1 << 16) + (r2 - r1) * (u16)m_frac) >> 16;
+		sampleR = (sampleR * rvolume) >> 8;
+		sampleR += samples[currentSample];
+		MathUtil::Clamp(&sampleR, -32767, 32767);
+		samples[currentSample] = sampleR;
+
+		m_frac += ratio;
+		indexR += 2 * (u16)(m_frac >> 16);
+		m_frac &= 0xffff;
+	}
+
+	// Padding with the last value to reduce clicking
+	short s[2];
+	s[0] = m_buffer[(indexR - 1) & INDEX_MASK];
+	s[1] = m_buffer[(indexR - 2) & INDEX_MASK];
+	s[0] = (s[0] * rvolume) >> 8;
+	s[1] = (s[1] * lvolume) >> 8;
+	for (; currentSample < numSamples * 2; currentSample += 2) {
+		int sampleR = s[0] + samples[currentSample];
+		MathUtil::Clamp(&sampleR, -32767, 32767);
+		samples[currentSample] = sampleR;
+		int sampleL = s[1] + samples[currentSample + 1];
+		MathUtil::Clamp(&sampleL, -32767, 32767);
+		samples[currentSample + 1] = sampleL;
+	}
+
+	// Flush cached variable
+	Common::AtomicStore(m_indexR, indexR);
+
+	return numSamples;
+}
+
+unsigned int StereoResampler::Mix(short* samples, unsigned int num_samples, bool consider_framelimit, int sample_rate) {
+	if (!samples)
+		return 0;
+
+	lock_guard lk(m_csMixing);
+	memset(samples, 0, num_samples * 2 * sizeof(short));
+	return m_dma_mixer.Mix(samples, num_samples, consider_framelimit, sample_rate);
+}
+
+void StereoResampler::MixerFifo::PushSamples(const s32 *samples, unsigned int num_samples) {
+	// Cache access in non-volatile variable
+	// indexR isn't allowed to cache in the audio throttling loop as it
+	// needs to get updates to not deadlock.
+	u32 indexW = Common::AtomicLoad(m_indexW);
+
+	// Check if we have enough free space
+	// indexW == m_indexR results in empty buffer, so indexR must always be smaller than indexW
+	if (num_samples * 2 + ((indexW - Common::AtomicLoad(m_indexR)) & INDEX_MASK) >= MAX_SAMPLES * 2)
+		return;
+
+	// AyuanX: Actual re-sampling work has been moved to sound thread
+	// to alleviate the workload on main thread
+	// and we simply store raw data here to make fast mem copy
+	int over_bytes = num_samples * 4 - (MAX_SAMPLES * 2 - (indexW & INDEX_MASK)) * sizeof(short);
+	if (over_bytes > 0) {
+		ClampBufferToS16(&m_buffer[indexW & INDEX_MASK], samples, (num_samples * 4 - over_bytes) / 2);
+		ClampBufferToS16(&m_buffer[0], samples + (num_samples * 4 - over_bytes) / sizeof(short), over_bytes / 2);
+	} else {
+		ClampBufferToS16(&m_buffer[indexW & INDEX_MASK], samples, num_samples * 2);
+	}
+
+	Common::AtomicAdd(m_indexW, num_samples * 2);
+
+	return;
+}
+
+void StereoResampler::PushSamples(const int *samples, unsigned int num_samples) {
+	m_dma_mixer.PushSamples(samples, num_samples);
+}
+
+void StereoResampler::SetDMAInputSampleRate(unsigned int rate) {
+	m_dma_mixer.SetInputSampleRate(rate);
+}
+
+void StereoResampler::MixerFifo::SetInputSampleRate(unsigned int rate) {
+	m_input_sample_rate = rate;
+}
+
+void StereoResampler::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)
+{
+	m_LVolume = lvolume + (lvolume >> 7);
+	m_RVolume = rvolume + (rvolume >> 7);
+}
+
+void StereoResampler::DoState(PointerWrap &p) {
+	auto s = p.Section("resampler", 1);
+	if (!s)
+		return;
+}

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -116,6 +116,8 @@ unsigned int StereoResampler::MixerFifo::Mix(short* samples, unsigned int numSam
 		m_frac &= 0xffff;
 	}
 
+	int realSamples = currentSample;
+
 	// Padding with the last value to reduce clicking
 	short s[2];
 	s[0] = m_buffer[(indexR - 1) & INDEX_MASK];
@@ -132,7 +134,11 @@ unsigned int StereoResampler::MixerFifo::Mix(short* samples, unsigned int numSam
 	// Flush cached variable
 	Common::AtomicStore(m_indexR, indexR);
 
-	return numSamples;
+	if (realSamples != numSamples * 2) {
+		ILOG("Underrun! %i / %i", realSamples / 2, numSamples);
+	}
+
+	return realSamples / 2;
 }
 
 unsigned int StereoResampler::Mix(short* samples, unsigned int num_samples, bool consider_framelimit, int sample_rate) {

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -27,7 +27,8 @@
 #include "Common/CommonTypes.h"
 
 // 16 bit Stereo
-#define MAX_SAMPLES     (1024 * 2) // 64ms
+
+#define MAX_SAMPLES     (2*(1024 * 2)) // 2*64ms - had to double it for nVidia Shield which has huge buffers
 #define INDEX_MASK      (MAX_SAMPLES * 2 - 1)
 
 #define LOW_WATERMARK   1280 // 40 ms

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -57,8 +57,6 @@ public:
 
 	void SetDMAInputSampleRate(unsigned int rate);
 
-	recursive_mutex& MixerCritical() { return m_csMixing; }
-
 	float GetCurrentSpeed() const { return m_speed; }
 	void UpdateSpeed(volatile float val) { m_speed = val; }
 
@@ -98,8 +96,6 @@ protected:
 
 	MixerFifo m_dma_mixer;
 	unsigned int m_sampleRate;
-
-	recursive_mutex m_csMixing;
 
 	volatile float m_speed; // Current rate of the emulation (1.0 = 100% speed)
 };

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -41,7 +41,6 @@ class StereoResampler {
 public:
 	StereoResampler()
 		: m_dma_mixer(this, 44100)
-		, m_speed(1.0)
 	{
 	}
 
@@ -53,12 +52,6 @@ public:
 	// Called from main thread
 	// This clamps the samples to 16-bit before starting to work on them.
 	virtual void PushSamples(const s32* samples, unsigned int num_samples);
-	unsigned int GetSampleRate() const { return m_sampleRate; }
-
-	void SetDMAInputSampleRate(unsigned int rate);
-
-	float GetCurrentSpeed() const { return m_speed; }
-	void UpdateSpeed(volatile float val) { m_speed = val; }
 
 	void Clear() {
 		m_dma_mixer.Clear();
@@ -95,7 +88,4 @@ protected:
 	};
 
 	MixerFifo m_dma_mixer;
-	unsigned int m_sampleRate;
-
-	volatile float m_speed; // Current rate of the emulation (1.0 = 100% speed)
 };

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -75,8 +75,6 @@ protected:
 			, m_input_sample_rate(sample_rate)
 			, m_indexW(0)
 			, m_indexR(0)
-			, m_LVolume(256)
-			, m_RVolume(256)
 			, m_numLeftI(0.0f)
 			, m_frac(0)
 		{
@@ -85,7 +83,6 @@ protected:
 		void PushSamples(const s32* samples, unsigned int num_samples);
 		unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit, int sample_rate);
 		void SetInputSampleRate(unsigned int rate);
-		void SetVolume(unsigned int lvolume, unsigned int rvolume);
 		void Clear();
 
 	private:
@@ -94,9 +91,6 @@ protected:
 		short m_buffer[MAX_SAMPLES * 2];
 		volatile u32 m_indexW;
 		volatile u32 m_indexR;
-		// Volume ranges from 0-256
-		volatile s32 m_LVolume;
-		volatile s32 m_RVolume;
 		float m_numLeftI;
 		u32 m_frac;
 	};

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2015- PPSSPP Project and Dolphin Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+// Adapted from Dolphin.
+
+#pragma once
+
+#include <string>
+
+#include "base/mutex.h"
+
+#include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
+
+// 16 bit Stereo
+#define MAX_SAMPLES     (1024 * 2) // 64ms
+#define INDEX_MASK      (MAX_SAMPLES * 2 - 1)
+
+#define LOW_WATERMARK   1280 // 40 ms
+#define MAX_FREQ_SHIFT  200  // per 32000 Hz
+#define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
+#define CONTROL_AVG     32
+
+class StereoResampler {
+
+public:
+	StereoResampler()
+		: m_dma_mixer(this, 44100)
+		, m_speed(1.0)
+	{
+	}
+
+	virtual ~StereoResampler() {}
+
+	// Called from audio threads
+	virtual unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit, int sampleRate);
+
+	// Called from main thread
+	// This clamps the samples to 16-bit before starting to work on them.
+	virtual void PushSamples(const s32* samples, unsigned int num_samples);
+	unsigned int GetSampleRate() const { return m_sampleRate; }
+
+	void SetDMAInputSampleRate(unsigned int rate);
+
+	recursive_mutex& MixerCritical() { return m_csMixing; }
+
+	float GetCurrentSpeed() const { return m_speed; }
+	void UpdateSpeed(volatile float val) { m_speed = val; }
+
+	void Clear() {
+		m_dma_mixer.Clear();
+	}
+
+	void DoState(PointerWrap &p);
+
+protected:
+	class MixerFifo {
+	public:
+		MixerFifo(StereoResampler *mixer, unsigned sample_rate)
+			: m_mixer(mixer)
+			, m_input_sample_rate(sample_rate)
+			, m_indexW(0)
+			, m_indexR(0)
+			, m_LVolume(256)
+			, m_RVolume(256)
+			, m_numLeftI(0.0f)
+			, m_frac(0)
+		{
+			memset(m_buffer, 0, sizeof(m_buffer));
+		}
+		void PushSamples(const s32* samples, unsigned int num_samples);
+		unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit, int sample_rate);
+		void SetInputSampleRate(unsigned int rate);
+		void SetVolume(unsigned int lvolume, unsigned int rvolume);
+		void Clear();
+
+	private:
+		StereoResampler *m_mixer;
+		unsigned m_input_sample_rate;
+		short m_buffer[MAX_SAMPLES * 2];
+		volatile u32 m_indexW;
+		volatile u32 m_indexR;
+		// Volume ranges from 0-256
+		volatile s32 m_LVolume;
+		volatile s32 m_RVolume;
+		float m_numLeftI;
+		u32 m_frac;
+	};
+
+	MixerFifo m_dma_mixer;
+	unsigned int m_sampleRate;
+
+	recursive_mutex m_csMixing;
+
+	volatile float m_speed; // Current rate of the emulation (1.0 = 100% speed)
+};

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -428,8 +428,6 @@ void GameSettingsScreen::CreateViews() {
 #endif
 	systemSettings->Add(new CheckBox(&g_Config.bSetRoundingMode, s->T("Respect FPU rounding (disable for old GEB saves)")))->OnClick.Handle(this, &GameSettingsScreen::OnJitAffectingSetting);
 
-	systemSettings->Add(new CheckBox(&g_Config.bAtomicAudioLocks, s->T("Atomic Audio locks (experimental)")))->SetEnabled(!PSP_IsInited());
-
 	systemSettings->Add(new ItemHeader(s->T("Developer Tools")));
 	systemSettings->Add(new Choice(s->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -142,6 +142,10 @@ static std::vector<PendingMessage> pendingMessages;
 static Thin3DContext *thin3d;
 static UIContext *uiContext;
 
+#ifdef _WIN32
+WindowsAudioBackend *winAudioBackend;
+#endif
+
 Thin3DContext *GetThin3D() {
 	return thin3d;
 }
@@ -235,7 +239,7 @@ int NativeMix(short *audio, int num_samples) {
 	}
 
 #ifdef _WIN32
-	DSound_UpdateSound();
+	winAudioBackend->Update();
 #endif
 
 	return num_samples;
@@ -571,13 +575,15 @@ void NativeInitGraphics() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
 #ifdef _WIN32
-	DSound_StartSound(MainWindow::GetHWND(), &Win32Mix, 44100);
+	winAudioBackend = CreateAudioBackend(AUDIO_BACKEND_AUTO);
+	winAudioBackend->Init(MainWindow::GetHWND(), &Win32Mix, 44100);
 #endif
 }
 
 void NativeShutdownGraphics() {
 #ifdef _WIN32
-	DSound_StopSound();
+	delete winAudioBackend;
+	winAudioBackend = NULL;
 #endif
 
 	screenManager->deviceLost();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -219,8 +219,10 @@ std::string NativeQueryConfig(std::string query) {
 
 		sprintf(temp, "%i", scale);
 		return std::string(temp);
+	} else if (query == "force44khz") {
+		return std::string("0");
 	} else {
-		return std::string("");
+		return "";
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -569,7 +569,7 @@ void NativeInitGraphics() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
 #ifdef _WIN32
-	DSound_StartSound(MainWindow::GetHWND(), &Win32Mix, 48000);
+	DSound_StartSound(MainWindow::GetHWND(), &Win32Mix, 44100);
 #endif
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -226,7 +226,8 @@ std::string NativeQueryConfig(std::string query) {
 
 int NativeMix(short *audio, int num_samples) {
 	if (GetUIState() == UISTATE_INGAME) {
-		num_samples = __AudioMix(audio, num_samples);
+		int sample_rate = System_GetPropertyInt(SYSPROP_AUDIO_SAMPLE_RATE);
+		num_samples = __AudioMix(audio, num_samples, sample_rate > 0 ? sample_rate : 44100);
 	}	else {
 		MixBackgroundAudio(audio, num_samples);
 	}
@@ -568,7 +569,7 @@ void NativeInitGraphics() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
 #ifdef _WIN32
-	DSound_StartSound(MainWindow::GetHWND(), &Win32Mix, 44100);
+	DSound_StartSound(MainWindow::GetHWND(), &Win32Mix, 48000);
 #endif
 }
 

--- a/Windows/DSoundStream.h
+++ b/Windows/DSoundStream.h
@@ -1,14 +1,23 @@
-#ifndef __SOUNDSTREAM_H__
-#define __SOUNDSTREAM_H__
+#pragma once
 
 #include "Common/CommonWindows.h"
 
 typedef int (*StreamCallback)(short *buffer, int numSamples, int bits, int rate, int channels);
 
-bool DSound_StartSound(HWND window, StreamCallback _callback, int sampleRate);
-void DSound_UpdateSound();
-void DSound_StopSound();
+class WindowsAudioBackend {
+public:
+	WindowsAudioBackend() {}
+	virtual ~WindowsAudioBackend() {}
+	virtual bool Init(HWND window, StreamCallback _callback, int sampleRate) = 0;
+	virtual void Update() {}  // Doesn't have to do anything
+	virtual int GetSampleRate() = 0;
+};
 
-int DSound_GetSampleRate();
- 
-#endif //__SOUNDSTREAM_H__
+enum AudioBackendType {
+	AUDIO_BACKEND_DSOUND,
+	// AUDIO_BACKEND_WASAPI,   // TODO
+	AUDIO_BACKEND_AUTO
+};
+
+// Factory
+WindowsAudioBackend *CreateAudioBackend(AudioBackendType type);

--- a/Windows/DSoundStream.h
+++ b/Windows/DSoundStream.h
@@ -9,8 +9,6 @@ bool DSound_StartSound(HWND window, StreamCallback _callback, int sampleRate);
 void DSound_UpdateSound();
 void DSound_StopSound();
 
-float DSound_GetTimer();
-int DSound_GetCurSample();
 int DSound_GetSampleRate();
  
 #endif //__SOUNDSTREAM_H__

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -126,9 +126,13 @@ void WindowsHost::InitSound()
 {
 }
 
+// UGLY!
+extern WindowsAudioBackend *winAudioBackend;
+
 void WindowsHost::UpdateSound()
 {
-	DSound_UpdateSound();
+	if (winAudioBackend)
+		winAudioBackend->Update();
 }
 
 void WindowsHost::ShutdownSound()

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -256,10 +256,13 @@ std::string System_GetProperty(SystemProperty prop) {
 	}
 }
 
+// Ugly!
+extern WindowsAudioBackend *winAudioBackend;
+
 int System_GetPropertyInt(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_AUDIO_SAMPLE_RATE:
-		return DSound_GetSampleRate();
+		return winAudioBackend ? winAudioBackend->GetSampleRate() : -1;
 	default:
 		return -1;
 	}

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -187,6 +187,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/HW/MpegDemux.cpp.arm \
   $(SRC)/Core/HW/MediaEngine.cpp.arm \
   $(SRC)/Core/HW/SasAudio.cpp.arm \
+  $(SRC)/Core/HW/StereoResampler.cpp.arm \
   $(SRC)/Core/Core.cpp \
   $(SRC)/Core/Config.cpp \
   $(SRC)/Core/CoreTiming.cpp \

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -22,7 +22,14 @@ std::string System_GetProperty(SystemProperty prop) {
 	}
 }
 
-int System_GetPropertyInt(SystemProperty prop) { return -1; }
+int System_GetPropertyInt(SystemProperty prop) {
+  switch (prop) {
+  case SYSPROP_AUDIO_SAMPLE_RATE:
+    return 44100;
+  default:
+    return -1;
+  }
+}
 
 void System_SendMessage(const char *command, const char *parameter) {
 	if (!strcmp(command, "finish")) {


### PR DESCRIPTION
By using the preferred sample rate of Android devices, we can hit the low-latency fast-path in more cases. For example, the Nexus 4, Nexus 5 and Nexus 9 have low-latency fast paths at 48 khz (while Galaxy Nexus has it at 44khz).

To do this we need to resample our audio output. Dolphin does this well (I think I originally wrote that code) and others have added a drift prevention mechanism, that will reduce glitches over time by slightly changing the sample rate to keep audio and video synchronized. So we just use Dolphin's mechanism, somewhat simplified as there's only one audio source to resample.

The improvement is very noticable on Nexus 4 and 9 but not at all really on Zenfone or nVidia Shield, unfortunately, as they don't seem to have tuned audio fast paths.

Fixes #6472 .
