### PR TITLE
Transform rects using indices

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -38,5 +38,5 @@ struct SoftwareTransformResult {
 	u8 stencilValue;
 };
 
-void SoftwareTransform(int prim, u8 *decoded, int vertexCount, u32 vertexType, void *inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex, FramebufferManagerCommon *fbman, TextureCacheCommon *texCache, TransformedVertex *transformed, TransformedVertex *transformedExpanded, TransformedVertex *&drawBuffer, 
+void SoftwareTransform(int prim, u8 *decoded, int vertexCount, u32 vertexType, u16 *&inds, int indexType, const DecVtxFormat &decVtxFormat, int maxIndex, FramebufferManagerCommon *fbman, TextureCacheCommon *texCache, TransformedVertex *transformed, TransformedVertex *transformedExpanded, TransformedVertex *&drawBuffer,
 	int &numTrans, bool &drawIndexed, SoftwareTransformResult *result);

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -833,7 +833,7 @@ rotateVBO:
 
 		SoftwareTransform(
 			prim, decoded, indexGen.VertexCount(),
-			dec_->VertexType(), (void *)inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
+			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 			indexGen.MaxIndex(), framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -823,7 +823,7 @@ rotateVBO:
 
 		SoftwareTransform(
 			prim, decoded, indexGen.VertexCount(),
-			dec_->VertexType(), (void *)inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
+			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 			indexGen.MaxIndex(), framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {

--- a/Windows/DSoundStream.cpp
+++ b/Windows/DSoundStream.cpp
@@ -405,7 +405,7 @@ int WASAPIAudioBackend::RunThread() {
 					float *ptr = (float *)pData;
 					int chans = pDeviceFormat->Format.nChannels;
 					memset(ptr, 0, pNumAvFrames * chans * sizeof(float));
-					for (int i = 0; i < pNumAvFrames; i++) {
+					for (UINT32 i = 0; i < pNumAvFrames; i++) {
 						ptr[i * chans + 0] = (float)shortBuf[i * 2] * (1.0f / 32768.0f);
 						ptr[i * chans + 1] = (float)shortBuf[i * 2 + 1] * (1.0f / 32768.0f);
 					}


### PR DESCRIPTION
Because we can.  Well, it should mean less copying to the GPU in some cases but probably not anywhere hot.

Tried to simplify the logic a bit too.

AFIACT there should always be space at `inds + vertexCount` when doing rectangles, since they aren't otherwise expanded.... right?

-[Unknown]
