### PR TITLE
DInput/XInput: Configurable deadzone + inverter

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -562,6 +562,16 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogStickX", &g_Config.fAnalogStickX, -1.0f, true, true),
 	ConfigSetting("AnalogStickY", &g_Config.fAnalogStickY, -1.0f, true, true),
 	ConfigSetting("AnalogStickScale", &g_Config.fAnalogStickScale, defaultControlScale, true, true),
+#ifdef _WIN32
+	ConfigSetting("DInputAnalogDeadzone", &g_Config.fDInputAnalogDeadzone, 0.1f, true, true),
+	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("XInputLeftAnalogDeadzone", &g_Config.fXInputLeftAnalogDeadzone, 0.24f, true, true),
+	ConfigSetting("XInputLeftAnalogInverseDeadzoneX", &g_Config.fXInputLeftAnalogInverseDeadzoneX, 0.0f, true, true),
+	ConfigSetting("XInputLeftAnalogInverseDeadzoneY", &g_Config.fXInputLeftAnalogInverseDeadzoneY, 0.0f, true, true),
+	ConfigSetting("XInputRightAnalogDeadzone", &g_Config.fXInputRightAnalogDeadzone, 0.27f, true, true),
+	ConfigSetting("XInputRightAnalogInverseDeadzoneX", &g_Config.fXInputRightAnalogInverseDeadzoneX, 0.0f, true, true),
+	ConfigSetting("XInputRightAnalogInverseDeadzoneY", &g_Config.fXInputRightAnalogInverseDeadzoneY, 0.0f, true, true),
+#endif
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 
 	ConfigSetting(false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -276,6 +276,17 @@ public:
 
 	bool bHapticFeedback;
 
+	float fDInputAnalogDeadzone;
+	float fDInputAnalogInverseDeadzone;
+
+	float fXInputLeftAnalogDeadzone;
+	float fXInputLeftAnalogInverseDeadzoneX;
+	float fXInputLeftAnalogInverseDeadzoneY;
+
+	float fXInputRightAnalogDeadzone;
+	float fXInputRightAnalogInverseDeadzoneX;
+	float fXInputRightAnalogInverseDeadzoneY;
+
 	float fAnalogLimiterDeadzone;
 	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into
 	// proper options when good enough.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -372,6 +372,18 @@ void GameSettingsScreen::CreateViews() {
 	View *style = controlsSettings->Add(new PopupMultiChoice(&g_Config.iTouchButtonStyle, c->T("Button style"), touchControlStyles, 0, ARRAY_SIZE(touchControlStyles), c, screenManager()));
 	style->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+	controlsSettings->Add(new ItemHeader(c->T("DInput Analog Settings", "DInput Analog Settings")));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone"), screenManager()));
+
+	controlsSettings->Add(new ItemHeader(c->T("XInput Analog Settings", "XInput Analog Stick Settings")));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Left Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogInverseDeadzoneX, 0.0f, 1.0f, c->T("Inverse Dead Zone X (Left Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogInverseDeadzoneY, 0.0f, 1.0f, c->T("Inverse Dead Zone Y (Left Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Right Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogInverseDeadzoneX, 0.0f, 1.0f, c->T("Inverse Dead Zone X (Right Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogInverseDeadzoneY, 0.0f, 1.0f, c->T("Inverse Dead Zone Y (Right Stick)"), screenManager()));
+
 	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 #if defined(USING_WIN_UI)
 	controlsSettings->Add(new CheckBox(&g_Config.bIgnoreWindowsKey, c->T("Ignore Windows Key")));


### PR DESCRIPTION
I've added configurable deadzone settings for both DInput and XInput devices. Keeping with the existing setup, the DInput setting applies to all axes, whereas the XInput setting applies separate values for the left and right sticks. The triggers have been left as-is for now, and the affected default values have been converted into float (and back where appropriate) for the sake of user interface.

Along with that I've added a configurable deadzone inverter, which was my original goal. As the PSP's analog nub isn't very precise, a lot of games have a generous deadzone hard-coded into them. The inverter is able to circumvent this by mapping a hardware input axis' 0.0-1.0 values to an arbitrary x.x-1.0 range (prior to circle-square mapping). Like the deadzone settings, these apply universally to DInput axes and separately for the left and right analogs via XInput.

For a practical example of why this is useful, consider the situation of playing WipEout Pulse with a DualShock 3 spoofed as an XInput device. Under the existing setup (24% hard-coded PPSSPP deadzone, no inverter) there's a sizable (~30%) deadzone present, which makes it difficult to make minor course corrections and results in a lot of oversteer. With the PPSSPP deadzone reduced to 10% and the inverter set to 30%, the game's built-in deadzone is eliminated and control is considerably more precise whilst retaining a PPSSPP-mandated 10% deadzone to prevent stick drift.

This can be applied to a wide range of other games to make them more playable on full-size controllers.
