### PR TITLE
DInput/XInput: Configurable deadzone + inverter

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -562,6 +562,19 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogStickX", &g_Config.fAnalogStickX, -1.0f, true, true),
 	ConfigSetting("AnalogStickY", &g_Config.fAnalogStickY, -1.0f, true, true),
 	ConfigSetting("AnalogStickScale", &g_Config.fAnalogStickScale, defaultControlScale, true, true),
+#ifdef _WIN32
+	ConfigSetting("DInputAnalogDeadzone", &g_Config.fDInputAnalogDeadzone, 0.1f, true, true),
+	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
+
+	ConfigSetting("XInputLeftAnalogDeadzone", &g_Config.fXInputLeftAnalogDeadzone, 0.24f, true, true),
+	ConfigSetting("XInputRightAnalogDeadzone", &g_Config.fXInputRightAnalogDeadzone, 0.27f, true, true),
+
+	ConfigSetting("XInputLeftAnalogInverseMode", &g_Config.iXInputLeftAnalogInverseMode, 0, true, true),
+	ConfigSetting("XInputLeftAnalogInverseDeadzone", &g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, true, true),
+
+	ConfigSetting("XInputRightAnalogInverseMode", &g_Config.iXInputRightAnalogInverseMode, 0, true, true),
+	ConfigSetting("XInputRightAnalogInverseDeadzone", &g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, true, true),
+#endif
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 
 	ConfigSetting(false),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -564,22 +564,14 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogStickScale", &g_Config.fAnalogStickScale, defaultControlScale, true, true),
 #ifdef _WIN32
 	ConfigSetting("DInputAnalogDeadzone", &g_Config.fDInputAnalogDeadzone, 0.1f, true, true),
+	ConfigSetting("DInputAnalogInverseMode", &g_Config.iDInputAnalogInverseMode, 0, true, true),
 	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
 	ConfigSetting("DInputAnalogSensitivity", &g_Config.fDInputAnalogSensitivity, 1.0f, true, true),
 
-	ConfigSetting("DInputAnalogInverseMode", &g_Config.iDInputAnalogInverseMode, 0, true, true),
-	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
-
-	ConfigSetting("XInputLeftAnalogDeadzone", &g_Config.fXInputLeftAnalogDeadzone, 0.24f, true, true),
-	ConfigSetting("XInputRightAnalogDeadzone", &g_Config.fXInputRightAnalogDeadzone, 0.27f, true, true),
-
-	ConfigSetting("XInputLeftAnalogInverseMode", &g_Config.iXInputLeftAnalogInverseMode, 0, true, true),
-	ConfigSetting("XInputLeftAnalogInverseDeadzone", &g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, true, true),
-	ConfigSetting("XInputLeftAnalogSensitivity", &g_Config.fXInputLeftAnalogSensitivity, 1.0f, true, true),
-
-	ConfigSetting("XInputRightAnalogInverseMode", &g_Config.iXInputRightAnalogInverseMode, 0, true, true),
-	ConfigSetting("XInputRightAnalogInverseDeadzone", &g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, true, true),
-	ConfigSetting("XInputRightAnalogSensitivity", &g_Config.fXInputRightAnalogSensitivity, 1.0f, true, true),
+	ConfigSetting("XInputAnalogDeadzone", &g_Config.fXInputAnalogDeadzone, 0.24f, true, true),
+	ConfigSetting("XInputAnalogInverseMode", &g_Config.iXInputAnalogInverseMode, 0, true, true),
+	ConfigSetting("XInputAnalogInverseDeadzone", &g_Config.fXInputAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("XInputAnalogSensitivity", &g_Config.fXInputAnalogSensitivity, 1.0f, true, true),
 #endif
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -565,15 +565,21 @@ static ConfigSetting controlSettings[] = {
 #ifdef _WIN32
 	ConfigSetting("DInputAnalogDeadzone", &g_Config.fDInputAnalogDeadzone, 0.1f, true, true),
 	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("DInputAnalogSensitivity", &g_Config.fDInputAnalogSensitivity, 1.0f, true, true),
+
+	ConfigSetting("DInputAnalogInverseMode", &g_Config.iDInputAnalogInverseMode, 0, true, true),
+	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
 
 	ConfigSetting("XInputLeftAnalogDeadzone", &g_Config.fXInputLeftAnalogDeadzone, 0.24f, true, true),
 	ConfigSetting("XInputRightAnalogDeadzone", &g_Config.fXInputRightAnalogDeadzone, 0.27f, true, true),
 
 	ConfigSetting("XInputLeftAnalogInverseMode", &g_Config.iXInputLeftAnalogInverseMode, 0, true, true),
 	ConfigSetting("XInputLeftAnalogInverseDeadzone", &g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("XInputLeftAnalogSensitivity", &g_Config.fXInputLeftAnalogSensitivity, 1.0f, true, true),
 
 	ConfigSetting("XInputRightAnalogInverseMode", &g_Config.iXInputRightAnalogInverseMode, 0, true, true),
 	ConfigSetting("XInputRightAnalogInverseDeadzone", &g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("XInputRightAnalogSensitivity", &g_Config.fXInputRightAnalogSensitivity, 1.0f, true, true),
 #endif
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -276,6 +276,19 @@ public:
 
 	bool bHapticFeedback;
 
+	float fDInputAnalogDeadzone;
+	int iDInputAnalogInverseMode;
+	float fDInputAnalogInverseDeadzone;
+
+	float fXInputLeftAnalogDeadzone;
+	float fXInputRightAnalogDeadzone;
+
+	int iXInputLeftAnalogInverseMode;
+	float fXInputLeftAnalogInverseDeadzone;
+
+	int iXInputRightAnalogInverseMode;
+	float fXInputRightAnalogInverseDeadzone;
+
 	float fAnalogLimiterDeadzone;
 	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into
 	// proper options when good enough.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -279,15 +279,18 @@ public:
 	float fDInputAnalogDeadzone;
 	int iDInputAnalogInverseMode;
 	float fDInputAnalogInverseDeadzone;
+	float fDInputAnalogSensitivity;
 
 	float fXInputLeftAnalogDeadzone;
 	float fXInputRightAnalogDeadzone;
 
 	int iXInputLeftAnalogInverseMode;
 	float fXInputLeftAnalogInverseDeadzone;
+	float fXInputLeftAnalogSensitivity;
 
 	int iXInputRightAnalogInverseMode;
 	float fXInputRightAnalogInverseDeadzone;
+	float fXInputRightAnalogSensitivity;
 
 	float fAnalogLimiterDeadzone;
 	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -281,16 +281,10 @@ public:
 	float fDInputAnalogInverseDeadzone;
 	float fDInputAnalogSensitivity;
 
-	float fXInputLeftAnalogDeadzone;
-	float fXInputRightAnalogDeadzone;
-
-	int iXInputLeftAnalogInverseMode;
-	float fXInputLeftAnalogInverseDeadzone;
-	float fXInputLeftAnalogSensitivity;
-
-	int iXInputRightAnalogInverseMode;
-	float fXInputRightAnalogInverseDeadzone;
-	float fXInputRightAnalogSensitivity;
+	float fXInputAnalogDeadzone;
+	int iXInputAnalogInverseMode;
+	float fXInputAnalogInverseDeadzone;
+	float fXInputAnalogSensitivity;
 
 	float fAnalogLimiterDeadzone;
 	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -376,15 +376,15 @@ void GameSettingsScreen::CreateViews() {
 
 	controlsSettings->Add(new ItemHeader(c->T("DInput Analog Settings", "DInput Analog Settings")));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iDInputAnalogInverseMode, c->T("Inverse Dead Zone Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size"), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity"), screenManager()));
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iDInputAnalogInverseMode, c->T("Analog Mapper Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Analog Mapper Low End (Inverse Deadzone)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogSensitivity, 0.0f, 10.0f, c->T("Analog Mapper High End (Axis Sensitivity)"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("XInput Analog Settings", "XInput Analog Settings")));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputAnalogInverseMode, c->T("Inverse Dead Zone Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size"), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity"), screenManager()));
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputAnalogInverseMode, c->T("Analog Mapper Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Analog Mapper Low End (Inverse Deadzone)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, c->T("Analog Mapper High End (Axis Sensitivity)"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 #if defined(USING_WIN_UI)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -381,16 +381,10 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("XInput Analog Settings", "XInput Analog Settings")));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Left Stick)"), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Right Stick)"), screenManager()));
-
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputLeftAnalogInverseMode, c->T("Inverse Dead Zone Mode (Left Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Left Stick)"), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity (Left Stick)"), screenManager()));
-
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputRightAnalogInverseMode, c->T("Inverse Dead Zone Mode (Right Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Right Stick)"), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity (Right Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputAnalogInverseMode, c->T("Inverse Dead Zone Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 #if defined(USING_WIN_UI)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -378,6 +378,7 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
 	controlsSettings->Add(new PopupMultiChoice(&g_Config.iDInputAnalogInverseMode, c->T("Inverse Dead Zone Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("XInput Analog Settings", "XInput Analog Settings")));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Left Stick)"), screenManager()));
@@ -385,9 +386,11 @@ void GameSettingsScreen::CreateViews() {
 
 	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputLeftAnalogInverseMode, c->T("Inverse Dead Zone Mode (Left Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Left Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity (Left Stick)"), screenManager()));
 
 	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputRightAnalogInverseMode, c->T("Inverse Dead Zone Mode (Right Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Right Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogSensitivity, 0.0f, 10.0f, c->T("Sensitivity (Right Stick)"), screenManager()));
 
 	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 #if defined(USING_WIN_UI)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -372,6 +372,23 @@ void GameSettingsScreen::CreateViews() {
 	View *style = controlsSettings->Add(new PopupMultiChoice(&g_Config.iTouchButtonStyle, c->T("Button style"), touchControlStyles, 0, ARRAY_SIZE(touchControlStyles), c, screenManager()));
 	style->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+	static const char *inverseDeadzoneModes[] = { "Off", "X", "Y", "X + Y" };
+
+	controlsSettings->Add(new ItemHeader(c->T("DInput Analog Settings", "DInput Analog Settings")));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone"), screenManager()));
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iDInputAnalogInverseMode, c->T("Inverse Dead Zone Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size"), screenManager()));
+
+	controlsSettings->Add(new ItemHeader(c->T("XInput Analog Settings", "XInput Analog Settings")));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Left Stick)"), screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogDeadzone, 0.0f, 1.0f, c->T("Dead Zone (Right Stick)"), screenManager()));
+
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputLeftAnalogInverseMode, c->T("Inverse Dead Zone Mode (Left Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputLeftAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Left Stick)"), screenManager()));
+
+	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputRightAnalogInverseMode, c->T("Inverse Dead Zone Mode (Right Stick)"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), c, screenManager()));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputRightAnalogInverseDeadzone, 0.0f, 1.0f, c->T("Inverse Dead Zone Size (Right Stick)"), screenManager()));
+
 	controlsSettings->Add(new ItemHeader(c->T("Keyboard", "Keyboard Control Settings")));
 #if defined(USING_WIN_UI)
 	controlsSettings->Add(new CheckBox(&g_Config.bIgnoreWindowsKey, c->T("Ignore Windows Key")));

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -261,21 +261,21 @@ int DinputDevice::UpdateState(InputState &input_state) {
 			{
 				short xSign = Signs(js.lX);
 				if (xSign != 0.0f) {
-					js.lX = LinearMaps(js.lX, xSign * (short)(dz * 10000), xSign * 10000, xSign * (short)(md * 10000), (xSign * 10000 * st) - (short)(md * 10000) );
+					js.lX = LinearMaps(js.lX, xSign * (short)(dz * 10000), xSign * 10000, xSign * (short)(md * 10000), xSign * 10000 * st);
 				}
 			}
 			else if (idzm == 2)
 			{
 				short ySign = Signs(js.lY);
 				if (ySign != 0.0f) {
-					js.lY = LinearMaps(js.lY, ySign * (short)(dz * 10000.0f), ySign * 10000, ySign * (short)(md * 10000.0f), (ySign * 10000 * st) - (short)(md * 10000));
+					js.lY = LinearMaps(js.lY, ySign * (short)(dz * 10000.0f), ySign * 10000, ySign * (short)(md * 10000.0f), ySign * 10000 * st);
 				}
 			}
 			else if (idzm == 3)
 			{
 				float xNorm = (float)js.lX / magnitude;
 				float yNorm = (float)js.lY / magnitude;
-				float mapMag = LinearMaps(magnitude, dz * 10000.0f, 10000.0f, md * 10000.0f, (10000.0f * st) - (short)(md * 10000));
+				float mapMag = LinearMaps(magnitude, dz * 10000.0f, 10000.0f, md * 10000.0f, 10000.0f * st);
 				js.lX = (short)(xNorm * mapMag);
 				js.lY = (short)(yNorm * mapMag);
 			}

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -156,21 +156,21 @@ static Stick NormalizedDeadzoneFilter(short x, short y, float dz, int idzm, floa
 		{
 			float xSign = Signf(s.x);
 			if (xSign != 0.0f) {
-				s.x = LinearMapf(s.x, xSign * dz, xSign, xSign * md, (xSign * st) - md);
+				s.x = LinearMapf(s.x, xSign * dz, xSign, xSign * md, xSign * st);
 			}
 		}
 		else if (idzm == 2)
 		{
 			float ySign = Signf(s.y);
 			if (ySign != 0.0f) {
-				s.y = LinearMapf(s.y, ySign * dz, ySign, ySign * md, (ySign * st) - md);
+				s.y = LinearMapf(s.y, ySign * dz, ySign, ySign * md, ySign * st);
 			}
 		}
 		else if (idzm == 3)
 		{
 			float xNorm = s.x / magnitude;
 			float yNorm = s.y / magnitude;
-			float mapMag = LinearMapf(magnitude, dz, 1.0f, md, (1.0f * st) - md);
+			float mapMag = LinearMapf(magnitude, dz, 1.0f, md, st);
 			s.x = xNorm * mapMag;
 			s.y = yNorm * mapMag;
 		}

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -128,7 +128,7 @@ inline float LinearMapf(float val, float a0, float a1, float b0, float b1) {
 	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
 }
 
-static Stick NormalizedDeadzoneFilter(short x, short y, float dz, int idzm, float idz) {
+static Stick NormalizedDeadzoneFilter(short x, short y, float dz, int idzm, float idz, float st) {
 	Stick s(x, y, 1.0 / 32767.0f);
 
 	float magnitude = sqrtf(s.x * s.x + s.y * s.y);
@@ -156,21 +156,21 @@ static Stick NormalizedDeadzoneFilter(short x, short y, float dz, int idzm, floa
 		{
 			float xSign = Signf(s.x);
 			if (xSign != 0.0f) {
-				s.x = LinearMapf(s.x, xSign * dz, xSign, xSign * md, xSign);
+				s.x = LinearMapf(s.x, xSign * dz, xSign, xSign * md, (xSign * st) - md);
 			}
 		}
 		else if (idzm == 2)
 		{
 			float ySign = Signf(s.y);
 			if (ySign != 0.0f) {
-				s.y = LinearMapf(s.y, ySign * dz, ySign, ySign * md, ySign);
+				s.y = LinearMapf(s.y, ySign * dz, ySign, ySign * md, (ySign * st) - md);
 			}
 		}
 		else if (idzm == 3)
 		{
 			float xNorm = s.x / magnitude;
 			float yNorm = s.y / magnitude;
-			float mapMag = LinearMapf(magnitude, dz, 1.0, md, 1.0);
+			float mapMag = LinearMapf(magnitude, dz, 1.0f, md, (1.0f * st) - md);
 			s.x = xNorm * mapMag;
 			s.y = yNorm * mapMag;
 		}
@@ -238,9 +238,10 @@ int XinputDevice::UpdateState(InputState &input_state) {
 		const float LEFT_STICK_DEADZONE = g_Config.fXInputLeftAnalogDeadzone;
 		const int LEFT_STICK_INV_MODE = g_Config.iXInputLeftAnalogInverseMode;
 		const float LEFT_STICK_INV_DEADZONE = g_Config.fXInputLeftAnalogInverseDeadzone;
+		const float LEFT_STICK_SENSITIVITY = g_Config.fXInputLeftAnalogSensitivity;
 
 		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbLX, prevState.Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE)) {
-			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE, LEFT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE);
+			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE, LEFT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE, LEFT_STICK_SENSITIVITY);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;
@@ -259,9 +260,10 @@ int XinputDevice::UpdateState(InputState &input_state) {
 		const float RIGHT_STICK_DEADZONE = g_Config.fXInputRightAnalogDeadzone;
 		const int RIGHT_STICK_INV_MODE = g_Config.iXInputRightAnalogInverseMode;
 		const float RIGHT_STICK_INV_DEADZONE = g_Config.fXInputRightAnalogInverseDeadzone;
+		const float RIGHT_STICK_SENSITIVITY = g_Config.fXInputRightAnalogSensitivity;
 
 		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbRX, prevState.Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE)) {
-			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE, RIGHT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE);
+			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE, RIGHT_STICK_INV_MODE, RIGHT_STICK_INV_DEADZONE, RIGHT_STICK_SENSITIVITY);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -235,13 +235,13 @@ int XinputDevice::UpdateState(InputState &input_state) {
 		}
 		ApplyButtons(state, input_state);
 
-		const float LEFT_STICK_DEADZONE = g_Config.fXInputLeftAnalogDeadzone;
-		const int LEFT_STICK_INV_MODE = g_Config.iXInputLeftAnalogInverseMode;
-		const float LEFT_STICK_INV_DEADZONE = g_Config.fXInputLeftAnalogInverseDeadzone;
-		const float LEFT_STICK_SENSITIVITY = g_Config.fXInputLeftAnalogSensitivity;
+		const float STICK_DEADZONE = g_Config.fXInputAnalogDeadzone;
+		const int STICK_INV_MODE = g_Config.iXInputAnalogInverseMode;
+		const float STICK_INV_DEADZONE = g_Config.fXInputAnalogInverseDeadzone;
+		const float STICK_SENSITIVITY = g_Config.fXInputAnalogSensitivity;
 
-		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbLX, prevState.Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE)) {
-			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE, LEFT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE, LEFT_STICK_SENSITIVITY);
+		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbLX, prevState.Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, STICK_DEADZONE)) {
+			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, STICK_DEADZONE, STICK_INV_MODE, STICK_INV_DEADZONE, STICK_SENSITIVITY);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;
@@ -257,13 +257,8 @@ int XinputDevice::UpdateState(InputState &input_state) {
 			}
 		}
 
-		const float RIGHT_STICK_DEADZONE = g_Config.fXInputRightAnalogDeadzone;
-		const int RIGHT_STICK_INV_MODE = g_Config.iXInputRightAnalogInverseMode;
-		const float RIGHT_STICK_INV_DEADZONE = g_Config.fXInputRightAnalogInverseDeadzone;
-		const float RIGHT_STICK_SENSITIVITY = g_Config.fXInputRightAnalogSensitivity;
-
-		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbRX, prevState.Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE)) {
-			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE, RIGHT_STICK_INV_MODE, RIGHT_STICK_INV_DEADZONE, RIGHT_STICK_SENSITIVITY);
+		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbRX, prevState.Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, STICK_DEADZONE)) {
+			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, STICK_DEADZONE, STICK_INV_MODE, STICK_INV_DEADZONE, STICK_SENSITIVITY);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -120,12 +120,20 @@ inline float Clampf(float val, float min, float max) {
 	return val;
 }
 
-static Stick NormalizedDeadzoneFilter(short x, short y, short thresh) {
-	static const float DEADZONE = (float)thresh / 32767.0f;
+inline float Signf(float val) {
+	return (0.0f < val) - (val < 0.0f);
+}
+
+inline float LinearMapf(float val, float a0, float a1, float b0, float b1) {
+	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
+}
+
+static Stick NormalizedDeadzoneFilter(short x, short y, float dz, int idzm, float idz) {
 	Stick s(x, y, 1.0 / 32767.0f);
 
 	float magnitude = sqrtf(s.x * s.x + s.y * s.y);
-	if (magnitude > DEADZONE) {
+	if (magnitude > dz) {
+
 		// Circle to square mapping (the PSP stick outputs the full -1..1 square of values)
 #if 1
 		// Looks way better than the old one, below, in the axis tester.
@@ -140,6 +148,33 @@ static Stick NormalizedDeadzoneFilter(short x, short y, short thresh) {
 			s.y *= 1.41421f;
 		}
 #endif
+
+		// Linear range mapping (used to invert deadzones)
+		float md = std::max(dz, idz);
+
+		if (idzm == 1)
+		{
+			float xSign = Signf(s.x);
+			if (xSign != 0.0f) {
+				s.x = LinearMapf(s.x, xSign * dz, xSign, xSign * md, xSign);
+			}
+		}
+		else if (idzm == 2)
+		{
+			float ySign = Signf(s.y);
+			if (ySign != 0.0f) {
+				s.y = LinearMapf(s.y, ySign * dz, ySign, ySign * md, ySign);
+			}
+		}
+		else if (idzm == 3)
+		{
+			float xNorm = s.x / magnitude;
+			float yNorm = s.y / magnitude;
+			float mapMag = LinearMapf(magnitude, dz, 1.0, md, 1.0);
+			s.x = xNorm * mapMag;
+			s.y = yNorm * mapMag;
+		}
+
 		s.x = Clampf(s.x, -1.0f, 1.0f);
 		s.y = Clampf(s.y, -1.0f, 1.0f);
 	} else {
@@ -149,14 +184,13 @@ static Stick NormalizedDeadzoneFilter(short x, short y, short thresh) {
 	return s;
 }
 
-bool NormalizedDeadzoneDiffers(short x1, short y1, short x2, short y2, const short thresh) {
-	static const float DEADZONE = (float)thresh / 32767.0f;
+bool NormalizedDeadzoneDiffers(short x1, short y1, short x2, short y2, const float dz) {
 	Stick s1(x1, y1, 1.0 / 32767.0f);
 	Stick s2(x2, y2, 1.0 / 32767.0f);
 
 	float magnitude1 = sqrtf(s1.x * s1.x + s1.y * s1.y);
 	float magnitude2 = sqrtf(s2.x * s2.x + s2.y * s2.y);
-	if (magnitude1 > DEADZONE || magnitude2 > DEADZONE) {
+	if (magnitude1 > dz || magnitude2 > dz) {
 		return x1 != x2 || y1 != y2;
 	}
 	return false;
@@ -201,8 +235,12 @@ int XinputDevice::UpdateState(InputState &input_state) {
 		}
 		ApplyButtons(state, input_state);
 
-		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbLX, prevState.Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE)) {
-			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE);
+		const float LEFT_STICK_DEADZONE = g_Config.fXInputLeftAnalogDeadzone;
+		const int LEFT_STICK_INV_MODE = g_Config.iXInputLeftAnalogInverseMode;
+		const float LEFT_STICK_INV_DEADZONE = g_Config.fXInputLeftAnalogInverseDeadzone;
+
+		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbLX, prevState.Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE)) {
+			Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, LEFT_STICK_DEADZONE, LEFT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;
@@ -218,8 +256,12 @@ int XinputDevice::UpdateState(InputState &input_state) {
 			}
 		}
 
-		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbRX, prevState.Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)) {
-			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+		const float RIGHT_STICK_DEADZONE = g_Config.fXInputRightAnalogDeadzone;
+		const int RIGHT_STICK_INV_MODE = g_Config.iXInputRightAnalogInverseMode;
+		const float RIGHT_STICK_INV_DEADZONE = g_Config.fXInputRightAnalogInverseDeadzone;
+
+		if (NormalizedDeadzoneDiffers(prevState.Gamepad.sThumbRX, prevState.Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE)) {
+			Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, RIGHT_STICK_DEADZONE, RIGHT_STICK_INV_MODE, LEFT_STICK_INV_DEADZONE);
 
 			AxisInput axis;
 			axis.deviceId = DEVICE_ID_X360_0;


### PR DESCRIPTION
(Revised version of a previous Pull Request)

I've added configurable deadzone settings for both DInput and XInput devices. Keeping with the existing setup, the DInput setting applies to all axes, whereas the XInput setting applies separate values for the left and right sticks. The triggers have been left as-is for now, and the affected default values have been converted into float for the sake of user interface.

Along with that I've added a configurable deadzone inverter, which was my original goal. As the PSP's analog nub isn't very precise, a lot of games have a generous deadzone hard-coded into them. The inverter is able to circumvent this by mapping a hardware input axis' 0.0-1.0 values to an arbitrary x.x-1.0 range. Unlike the deadzone setting, this applies to DInput's X/Y axes and separately for XInput's left and right analogs.

For a practical example of why this is useful, consider the situation of playing WipEout Pulse with a DualShock 3 spoofed as an XInput device. Under the existing setup (24% hard-coded PPSSPP deadzone, no inverter) there's a sizable (~30%) in-game deadzone present, which makes it difficult to make minor course corrections and results in a lot of oversteer. With the PPSSPP deadzone reduced to 10% and the inverter set to 30% in X axis mode, the game's built-in deadzone is removed and control is considerably more precise whilst retaining the 10% PPSSPP deadzone to prevent stick drift.

This can be applied to a wide range of other games to make them more playable on full-size controllers.
