### PR TITLE
don't try to access past the number of vertices when drawing rectangles

### DIFF
--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -174,7 +174,7 @@ void IndexGenerator::AddLineStrip(int numVerts) {
 void IndexGenerator::AddRectangles(int numVerts) {
 	u16 *outInds = inds_;
 	const int startIndex = index_;
-	for (int i = 0; i < numVerts; i += 2) {
+	for (int i = 0; i +1 < numVerts; i += 2) {
 		*outInds++ = startIndex + i;
 		*outInds++ = startIndex + i + 1;
 	}
@@ -387,7 +387,7 @@ void IndexGenerator::TranslateLineStrip(int numInds, const u16 *_inds, int index
 void IndexGenerator::TranslateRectangles(int numInds, const u8 *inds, int indexOffset) {
 	indexOffset = index_ - indexOffset;
 	u16 *outInds = inds_;
-	for (int i = 0; i < numInds; i += 2) {
+	for (int i = 0; i + 1 < numInds; i += 2) {
 		*outInds++ = indexOffset + inds[i];
 		*outInds++ = indexOffset + inds[i+1];
 	}

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -174,7 +174,9 @@ void IndexGenerator::AddLineStrip(int numVerts) {
 void IndexGenerator::AddRectangles(int numVerts) {
 	u16 *outInds = inds_;
 	const int startIndex = index_;
-	for (int i = 0; i +1 < numVerts; i += 2) {
+	//rectangles always need 2 vertices, disregard the last one if there's an odd number
+	numVerts = numVerts & ~1;
+	for (int i = 0; i < numVerts; i += 2) {
 		*outInds++ = startIndex + i;
 		*outInds++ = startIndex + i + 1;
 	}
@@ -387,7 +389,9 @@ void IndexGenerator::TranslateLineStrip(int numInds, const u16 *_inds, int index
 void IndexGenerator::TranslateRectangles(int numInds, const u8 *inds, int indexOffset) {
 	indexOffset = index_ - indexOffset;
 	u16 *outInds = inds_;
-	for (int i = 0; i + 1 < numInds; i += 2) {
+	//rectangles always need 2 vertices, disregard the last one if there's an odd number
+	numInds = numInds & ~1; 
+	for (int i = 0; i < numInds; i += 2) {
 		*outInds++ = indexOffset + inds[i];
 		*outInds++ = indexOffset + inds[i+1];
 	}
@@ -401,6 +405,8 @@ void IndexGenerator::TranslateRectangles(int numInds, const u16 *_inds, int inde
 	indexOffset = index_ - indexOffset;
 	const u16_le *inds = (u16_le*)_inds;
 	u16 *outInds = inds_;
+	//rectangles always need 2 vertices, disregard the last one if there's an odd number
+	numInds = numInds & ~1;
 	for (int i = 0; i < numInds; i += 2) {
 		*outInds++ = indexOffset + inds[i];
 		*outInds++ = indexOffset + inds[i+1];

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -460,6 +460,8 @@ void SoftwareTransform(
 		numTrans = vertexCount;
 		drawIndexed = true;
 	} else {
+		//rectangles always need 2 vertices, disregard the last one if there's an odd number
+		vertexCount = vertexCount & ~1;
 		numTrans = 0;
 		drawBuffer = transformedExpanded;
 		TransformedVertex *trans = &transformedExpanded[0];
@@ -467,7 +469,7 @@ void SoftwareTransform(
 		u16 *newInds = inds + vertexCount;
 		u16 *indsOut = newInds;
 		maxIndex = 4 * vertexCount;
-		for (int i = 0; i + 1 < vertexCount; i += 2) {
+		for (int i = 0; i < vertexCount; i += 2) {
 			const TransformedVertex &transVtxTL = transformed[indsIn[i + 0]];
 			const TransformedVertex &transVtxBR = transformed[indsIn[i + 1]];
 

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -467,7 +467,7 @@ void SoftwareTransform(
 		u16 *newInds = inds + vertexCount;
 		u16 *indsOut = newInds;
 		maxIndex = 4 * vertexCount;
-		for (int i = 0; i < vertexCount; i += 2) {
+		for (int i = 0; i + 1 < vertexCount; i += 2) {
 			const TransformedVertex &transVtxTL = transformed[indsIn[i + 0]];
 			const TransformedVertex &transVtxBR = transformed[indsIn[i + 1]];
 

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -95,6 +95,9 @@ static void ExpandRectangles(std::vector<GPUDebugVertex> &vertices, std::vector<
 		numInds = count;
 	}
 
+	//rectangles always need 2 vertices, disregard the last one if there's an odd number
+	numInds = numInds & ~1;
+
 	// Will need 4 coords and 6 points per rectangle (currently 2 each.)
 	newVerts.resize(numInds * 2);
 	newInds.resize(numInds * 3);
@@ -102,7 +105,7 @@ static void ExpandRectangles(std::vector<GPUDebugVertex> &vertices, std::vector<
 	u16 v = 0;
 	GPUDebugVertex *vert = &newVerts[0];
 	u16 *ind = &newInds[0];
-	for (size_t i = 0, end = numInds; i+1 < end; i += 2) {
+	for (size_t i = 0, end = numInds; i < end; i += 2) {
 		const auto &orig_tl = useInds ? vertices[indices[i]] : vertices[i];
 		const auto &orig_br = useInds ? vertices[indices[i + 1]] : vertices[i + 1];
 

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -102,7 +102,7 @@ static void ExpandRectangles(std::vector<GPUDebugVertex> &vertices, std::vector<
 	u16 v = 0;
 	GPUDebugVertex *vert = &newVerts[0];
 	u16 *ind = &newInds[0];
-	for (size_t i = 0, end = numInds; i < end; i += 2) {
+	for (size_t i = 0, end = numInds; i+1 < end; i += 2) {
 		const auto &orig_tl = useInds ? vertices[indices[i]] : vertices[i];
 		const auto &orig_br = useInds ? vertices[indices[i + 1]] : vertices[i + 1];
 


### PR DESCRIPTION
somehow fixes http://forums.ppsspp.org/showthread.php?tid=1436 , ~~still got some weird flickering of the healthbar and radar but no half-screen obstructing anymore~~ (nvm., flickering had to do with vertex cache)
