### PR TITLE
Invalidate icache before letting the CWCheat engine change memory. Might fix JIT-related cheat crashes.

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -284,7 +284,7 @@ std::vector<std::string> CWCheatEngine::GetCodesList() { //Reads the entire chea
 
 void CWCheatEngine::InvalidateICache(u32 addr, int size) {
 	if (MIPSComp::jit) {
-		MIPSComp::jit->GetBlockCache()->InvalidateICache(addr & ~3, 4);
+		MIPSComp::jit->GetBlockCache()->InvalidateICache(addr & ~3, size);
 	}
 }
 

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -29,6 +29,7 @@ public:
 	bool HasCheats();
 
 private:
+	void InvalidateICache(u32 addr, int size);
 	void SkipCodes(int count);
 	void SkipAllCodes();
 	bool cheatsOn, exit2, cheatEnabled;


### PR DESCRIPTION
Please test if you use CWCheat and experience related crashes (I don't really :)
