### PR TITLE
Replace frame download in Photo Kano.

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -913,6 +913,15 @@ static int Hook_utawarerumono_download_frame() {
 	return 0;
 }
 
+static int Hook_photokano_download_frame() {
+	const u32 fb_address = currentMIPS->r[MIPS_REG_A1];
+	if (Memory::IsVRAMAddress(fb_address)) {
+		gpu->PerformMemoryDownload(fb_address, 0x00088000);
+		CBreakPoints::ExecMemCheck(fb_address, true, 0x00088000, currentMIPS->pc);
+	}
+	return 0;
+}
+
 #ifdef ARM
 #define JITFUNC(f) (&MIPSComp::ArmJit::f)
 #elif defined(_M_X64) || defined(_M_IX86)
@@ -998,6 +1007,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "flowers_download_frame", &Hook_flowers_download_frame, 0, REPFLAG_HOOKENTER, 0x44 },
 	{ "motorstorm_download_frame", &Hook_motorstorm_download_frame, 0, REPFLAG_HOOKENTER, },
 	{ "utawarerumono_download_frame", &Hook_utawarerumono_download_frame, 0, REPFLAG_HOOKENTER, },
+	{ "photokano_download_frame", &Hook_photokano_download_frame, 0, REPFLAG_HOOKENTER, 0x2C },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -395,6 +395,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xc6b29de7d3245198, 656, "starocean_write_stencil" }, // Star Ocean 1 (US)
 	{ 0xc96e3a087ebf49a9, 100, "dl_write_light_color", },
 	{ 0xca7cb2c0b9410618, 680, "kudwafter_download_frame", }, // Kud Wafter
+	{ 0xcb22120018386319, 692, "photokano_download_frame", }, // Photo Kano
 	{ 0xcb7a2edd603ecfef, 48, "vtfm_p", },
 	{ 0xcdf64d21418b2667, 24, "vzero_q", },
 	{ 0xce1c95ee25b8e2ea, 448, "fmod", },


### PR DESCRIPTION
Fixes black photo and saveicon in Photo Kano,see https://github.com/hrydgard/ppsspp/issues/7457

Here is the function.
https://cloud.githubusercontent.com/assets/3481559/6101807/a159fd9c-b065-11e4-8fd4-17586e4c37f0.png

![03](https://cloud.githubusercontent.com/assets/3481559/6101809/b91bc3ac-b065-11e4-9a38-44b1761e306d.png)
