### PR TITLE
PostShaders translation

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -255,9 +255,9 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 	std::vector<std::string> items;
 	int selected = -1;
 	for (int i = 0; i < (int)shaders_.size(); i++) {
-		if (shaders_[i].name == g_Config.sPostShaderName)
+		if (shaders_[i].section == g_Config.sPostShaderName)
 			selected = i;
-		items.push_back(ps->T(shaders_[i].name.c_str()));
+		items.push_back(ps->T(shaders_[i].section.c_str()));
 	}
 	adaptor_ = UI::StringVectorListAdaptor(items, selected);
 }
@@ -265,7 +265,7 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 void PostProcScreen::OnCompleted(DialogResult result) {
 	if (result != DR_OK)
 		return;
-	g_Config.sPostShaderName = shaders_[listView_->GetSelected()].name;
+	g_Config.sPostShaderName = shaders_[listView_->GetSelected()].section;
 }
 
 NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen(title) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -255,7 +255,7 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 	std::vector<std::string> items;
 	int selected = -1;
 	for (int i = 0; i < (int)shaders_.size(); i++) {
-		if (shaders_[i].section == g_Config.sPostShaderName)
+		if (shaders_[i].name == g_Config.sPostShaderName)
 			selected = i;
 		items.push_back(ps->T(shaders_[i].name.c_str()));
 	}
@@ -265,7 +265,7 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 void PostProcScreen::OnCompleted(DialogResult result) {
 	if (result != DR_OK)
 		return;
-	g_Config.sPostShaderName = shaders_[listView_->GetSelected()].section;
+	g_Config.sPostShaderName = shaders_[listView_->GetSelected()].name;
 }
 
 NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen(title) {

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -552,12 +552,12 @@ namespace MainWindow
 
 		for (auto i = info.begin(); i != info.end(); ++i) {
 			checkedStatus = MF_UNCHECKED;
-			availableShaders.push_back(i->section);
-			if (g_Config.sPostShaderName == i->section) {
+			availableShaders.push_back(i->name);
+			if (g_Config.sPostShaderName == i->name) {
 				checkedStatus = MF_CHECKED;
 			}
 
-			translatedShaderName = ps->T(i->section.c_str());
+			translatedShaderName = ps->T(i->name.c_str());
 
 			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		}

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -552,12 +552,12 @@ namespace MainWindow
 
 		for (auto i = info.begin(); i != info.end(); ++i) {
 			checkedStatus = MF_UNCHECKED;
-			availableShaders.push_back(i->name);
-			if (g_Config.sPostShaderName == i->name) {
+			availableShaders.push_back(i->section);
+			if (g_Config.sPostShaderName == i->section) {
 				checkedStatus = MF_CHECKED;
 			}
 
-			translatedShaderName = ps->T(i->name.c_str());
+			translatedShaderName = ps->T(i->section.c_str());
 
 			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		}


### PR DESCRIPTION
To translate shaders we get strings from https://github.com/hrydgard/ppsspp/blob/master/assets/shaders/defaultshaders.ini.
The problem is that we use the string between square brackets to display the shader name when it's in the main screen, and we use the string at the "Name=" line to display the shader name when it's in the corresponding popup.
Therefore, each of these strings requires its proper translation.
But it's useless to have 2 different strings for 1 shader name, we should always use the string at the "Name=" line.

This is what I have done in this pull request.
It seems to work well... But I'm not sure, should we change more things in the code ?
