### PR TITLE
Save after changing recent list

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -230,6 +230,7 @@ void CPU_Init() {
 
 	if (coreParameter.updateRecent) {
 		g_Config.AddRecent(filename);
+		g_Config.Save();
 	}
 
 	coreState = coreParameter.startPaused ? CORE_STEPPING : CORE_RUNNING;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -59,6 +59,7 @@ bool GameInfo::DeleteGame() {
 			auto i = std::find(g_Config.recentIsos.begin(), g_Config.recentIsos.end(), fileToRemove);
 			if (i != g_Config.recentIsos.end()) {
 				g_Config.recentIsos.erase(i);
+				g_Config.Save();
 			}
 			return true;
 		}

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -301,6 +301,7 @@ UI::EventReturn GameScreen::OnRemoveFromRecent(UI::EventParams &e) {
 		if (!strcmp((*it).c_str(), gamePath_.c_str())) {
 #endif
 			g_Config.recentIsos.erase(it);
+			g_Config.Save();
 			screenManager()->switchScreen(new MainScreen());
 			return UI::EVENT_DONE;
 		}


### PR DESCRIPTION
regarding #7472 . If this is not done then the config file (the main config,
the per-game config files do not have recent entries) is loaded when a game
with game-specific settings is touched.

No clue what else to do.
