### PR TITLE
Correct a lot of inaccuracies in the tlspl functions

### DIFF
--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1957,7 +1957,7 @@ int __KernelFreeTls(TLSPL *tls, SceUID threadID)
 			// Otherwise, if there was a thread waiting, we were full, so this newly freed one is theirs.
 			// TODO: Is the block wiped or anything?
 			tls->usage[freeBlock] = waitingThreadID;
-			__KernelResumeThreadFromWait(waitingThreadID, freeBlock);
+			__KernelResumeThreadFromWait(waitingThreadID, freedAddress);
 
 			// Gotta watch the thread to quit as well, since they've allocated now.
 			tlsplThreadEndChecks.insert(std::make_pair(waitingThreadID, uid));

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -2205,7 +2205,7 @@ int sceKernelGetTlsAddr(SceUID uid)
 		{
 			tls->waitingThreads.push_back(threadID);
 			__KernelWaitCurThread(WAITTYPE_TLSPL, uid, 1, 0, false, "allocate tls");
-			return -1;
+			return 0;
 		}
 
 		u32 alignedSize = (tls->ntls.blockSize + tls->alignment - 1) & ~(tls->alignment - 1);
@@ -2218,7 +2218,7 @@ int sceKernelGetTlsAddr(SceUID uid)
 		return allocAddress;
 	}
 	else
-		return error;
+		return 0;
 }
 
 // Parameters are an educated guess.

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -2032,6 +2032,9 @@ SceUID sceKernelCreateTlspl(const char *name, u32 partition, u32 attr, u32 block
 		return SCE_KERNEL_ERROR_ILLEGAL_MEMSIZE;
 	}
 
+	// Upalign to a multiple of 4.  Strangely, the ReferTlsStatus value is the original.
+	u32 alignedSize = (blockSize + 3) & ~3;
+
 	int index = -1;
 	for (int i = 0; i < TLSPL_NUM_INDEXES; ++i)
 		if (tlsplUsedIndexes[i] == false)
@@ -2046,7 +2049,7 @@ SceUID sceKernelCreateTlspl(const char *name, u32 partition, u32 attr, u32 block
 		return PSP_ERROR_TOO_MANY_TLSPL;
 	}
 
-	u32 totalSize = blockSize * count;
+	u32 totalSize = alignedSize * count;
 	u32 blockPtr = userMemory.Alloc(totalSize, (attr & PSP_TLSPL_ATTR_HIGHMEM) != 0, name);
 #ifdef _DEBUG
 	userMemory.ListBlocks();
@@ -2152,7 +2155,8 @@ int sceKernelGetTlsAddr(SceUID uid)
 			return -1;
 		}
 
-		return tls->address + allocBlock * tls->ntls.blockSize;
+		u32 alignedSize = (tls->ntls.blockSize + 3) & ~3;
+		return tls->address + allocBlock * alignedSize;
 	}
 	else
 		return error;

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -2011,7 +2011,15 @@ void __KernelTlsplThreadEnd(SceUID threadID)
 		TLSPL *tls = kernelObjects.Get<TLSPL>(tlsID, error);
 
 		if (tls)
+		{
 			__KernelFreeTls(tls, threadID);
+
+			// Restart the loop, freeing mutated it.
+			locked = tlsplThreadEndChecks.equal_range(threadID);
+			iter = locked.first;
+			if (locked.first == locked.second)
+				break;
+		}
 	}
 	tlsplThreadEndChecks.erase(locked.first, locked.second);
 }

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -2196,7 +2196,6 @@ int sceKernelFreeTlspl(SceUID uid)
 		return error;
 }
 
-// Parameters are an educated guess.
 int sceKernelReferTlsplStatus(SceUID uid, u32 infoPtr)
 {
 	DEBUG_LOG(SCEKERNEL, "sceKernelReferTlsplStatus(%08x, %08x)", uid, infoPtr);
@@ -2204,8 +2203,8 @@ int sceKernelReferTlsplStatus(SceUID uid, u32 infoPtr)
 	TLSPL *tls = kernelObjects.Get<TLSPL>(uid, error);
 	if (tls)
 	{
-		// TODO: Check size.
-		Memory::WriteStruct(infoPtr, &tls->ntls);
+		if (Memory::Read_U32(infoPtr) != 0)
+			Memory::WriteStruct(infoPtr, &tls->ntls);
 		return 0;
 	}
 	else

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1971,9 +1971,9 @@ int __KernelFreeTls(TLSPL *tls, SceUID threadID)
 		++tls->ntls.freeBlocks;
 		return 0;
 	}
-	// TODO: Correct error code.
+	// We say "okay" even though nothing was freed.
 	else
-		return -1;
+		return 0;
 }
 
 void __KernelTlsplThreadEnd(SceUID threadID)


### PR DESCRIPTION
This mostly passes hrydgard/pspautotests#168, with the exception of:
- High mem allocation and max size allocation - this is actually an issue with our test framework (psplink automatically fudges things so you have one big block of ram, unlike in games.)
- It seems that you can refer to the 16 possible tlspls by the lower 8 bits or something, and the ids are always in the pattern 0x01, 0xd, 0x11, 0x1d, etc.  I kinda doubt any software depends on this, although it should probably eventually be fixed.

This could impact:
http://report.ppsspp.org/logs/kind/416
http://report.ppsspp.org/logs/kind/417

Both reported things are supported now.  But, it could really impact any game using tlspl functions.

-[Unknown]
