### PR TITLE
Update GE_TEXMAP_ENVIRONMENT_MAP in Direct3D9 so it matches OpenGL's behaviour

### DIFF
--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -571,7 +571,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 				break;
 
 			case GE_TEXMAP_ENVIRONMENT_MAP:  // Shade mapping - use dots from light sources.
-				WRITE(p, "  Out.v_texcoord.xy = u_uvscaleoffset.xy * float2(1.0 + dot(normalize(u_lightpos%i), worldnormal), 1.0 - dot(normalize(u_lightpos%i), worldnormal)) * 0.5;\n", gstate.getUVLS0(), gstate.getUVLS1());
+				WRITE(p, "  Out.v_texcoord.xy = u_uvscaleoffset.xy * float2(1.0 + dot(normalize(u_lightpos%i), worldnormal), 1.0 + dot(normalize(u_lightpos%i), worldnormal)) * 0.5;\n", gstate.getUVLS0(), gstate.getUVLS1());
 				break;
 
 			default:


### PR DESCRIPTION
Improves the car colours in Outrun 2006, but like OpenGL, it's still got some areas with the wrong blue hue.

Basically the same as the old https://github.com/hrydgard/ppsspp/pull/5612, but for Direct3D9. Also yay for typo in the branch name.
