### PR TITLE
Improve spline performance

### DIFF
--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -46,6 +46,9 @@ inline __m128 SSENormalizeMultiplierSSE2(__m128 v)
 	return _mm_shuffle_ps(rt, rt, _MM_SHUFFLE(0, 0, 0, 0));
 }
 
+#if _M_SSE >= 0x401
+#include <smmintrin.h>
+
 inline __m128 SSENormalizeMultiplierSSE4(__m128 v)
 {
 	return _mm_rsqrt_ps(_mm_dp_ps(v, v, 0xFF));
@@ -57,6 +60,13 @@ inline __m128 SSENormalizeMultiplier(bool useSSE4, __m128 v)
 		return SSENormalizeMultiplierSSE4(v);
 	return SSENormalizeMultiplierSSE2(v);
 }
+#else
+inline __m128 SSENormalizeMultiplier(bool useSSE4, __m128 v)
+{
+	return SSENormalizeMultiplierSSE2(v);
+}
+#endif
+
 #endif
 
 

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -209,7 +209,7 @@ public:
 	Vec3(const __m128 &_vec) : vec(_vec) {}
 	Vec3(const __m128i &_ivec) : ivec(_ivec) {}
 	Vec3(const Vec3Packed<T> &_xyz) {
-		ivec = _mm_loadu_ps(_xyz.AsArray());
+		vec = _mm_loadu_ps(_xyz.AsArray());
 	}
 #else
 	Vec3(const Vec3Packed<T> &_xyz) : x(_xyz.x), y(_xyz.y), z(_xyz.z) {}
@@ -377,7 +377,9 @@ public:
 	Vec3Packed(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3Packed(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3Packed(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
-	Vec3Packed(const Vec3<T>& _xyz) : x(_xyz.x), y(_xyz.y), z(_xyz.z) {}
+	Vec3Packed(const Vec3<T>& _xyz) {
+		memcpy(&x, _xyz.AsArray(), sizeof(float) * 3);
+	}
 
 	template<typename T2>
 	Vec3Packed<T2> Cast() const

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -180,6 +180,9 @@ public:
 typedef Vec2<float> Vec2f;
 
 template<typename T>
+class Vec3Packed;
+
+template<typename T>
 class Vec3
 {
 public:
@@ -205,6 +208,11 @@ public:
 #if defined(_M_SSE)
 	Vec3(const __m128 &_vec) : vec(_vec) {}
 	Vec3(const __m128i &_ivec) : ivec(_ivec) {}
+	Vec3(const Vec3Packed<T> &_xyz) {
+		ivec = _mm_loadu_ps(_xyz.AsArray());
+	}
+#else
+	Vec3(const Vec3Packed<T> &_xyz) : x(_xyz.x), y(_xyz.y), z(_xyz.z) {}
 #endif
 
 	template<typename T2>
@@ -369,6 +377,7 @@ public:
 	Vec3Packed(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3Packed(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3Packed(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
+	Vec3Packed(const Vec3<T>& _xyz) : x(_xyz.x), y(_xyz.y), z(_xyz.z) {}
 
 	template<typename T2>
 	Vec3Packed<T2> Cast() const


### PR DESCRIPTION
This cuts down on some overhead and makes sure SSE is used for more of it.

With this, the Thundaga spell as mentioned in #7111 at least is able to run on my i7 at full speed.  Before, I started dropping frames during it at high quality.

-[Unknown]
