### PR TITLE
For 5551 buffers, force stencil mask to 1/0

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -693,7 +693,12 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			glstate.stencilOp.set(stencilOps[gstate.getStencilOpSFail()],  // stencil fail
 				stencilOps[gstate.getStencilOpZFail()],  // depth fail
 				stencilOps[gstate.getStencilOpZPass()]); // depth pass
-			glstate.stencilMask.set(~abits);
+
+			if (gstate.FrameBufFormat() == GE_FORMAT_5551) {
+				glstate.stencilMask.set(abits <= 0x7f ? 0xff : 0x00);
+			} else {
+				glstate.stencilMask.set(~abits);
+			}
 		} else {
 			glstate.stencilTest.disable();
 		}


### PR DESCRIPTION
For 4444, it would also be ideal to spread the bits, but that gets a bit complicated.  5650 probably doesn't matter.

Fixes #6778.

This is based on testing on a psp, although it makes sense of course that the bits would apply just like the stencil test mask.

-[Unknown]
