### PR TITLE
If audio is disabled, don't play background audio.

### DIFF
--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -9,6 +9,7 @@
 #include "Core/HLE/__sceAudio.h"
 #include "Common/FixedSizeQueue.h"
 #include "GameInfoCache.h"
+#include "Core/Config.h"
 
 // Really simple looping in-memory AT3 player that also takes care of reading the file format.
 // Turns out that AT3 files used for this are modified WAVE files so fairly easy to parse.
@@ -173,6 +174,10 @@ void SetBackgroundAudioGame(const std::string &path) {
 	lock_guard lock(bgMutex);
 	if (path == bgGamePath) {
 		// Do nothing
+		return;
+	}
+
+	if (!g_Config.bEnableSound) {
 		return;
 	}
 


### PR DESCRIPTION
It seems odd to me to play background music when right-clicking a game (or moving the dpad cursor over a game) if we have audio disabled in the settings, especially if we're not calling the option "Enable Audio in-game" or something. Not a huge deal, but it's just something I noticed a bit ago.
