### PR TITLE
Avoid using constant color when blending

### DIFF
--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -439,7 +439,7 @@ void TransformDrawEngine::ApplyBlendState() {
 			setBlendColorv(fixB);
 			glBlendFuncB = GL_CONSTANT_COLOR;
 		} else if (glBlendFuncA == GL_INVALID_ENUM && glBlendFuncB == GL_INVALID_ENUM) {
-			if (blendColorSimilar(fixA, Vec3f::AssignToAll(constantAlpha) - fixB)) {
+			if (blendColorSimilar(fixA, Vec3f::AssignToAll(1.0f) - fixB)) {
 				glBlendFuncA = GL_CONSTANT_COLOR;
 				glBlendFuncB = GL_ONE_MINUS_CONSTANT_COLOR;
 				setBlendColorv(fixA);


### PR DESCRIPTION
If it's just ONE/ZERO or etc., we can keep those constants (without setting one explicitly.)  May be faster, and apparently less buggy in some drivers.

-[Unknown]
