### PR TITLE
Correct vertex preview of throughmode rects

### DIFF
--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -106,8 +106,8 @@ static void ExpandRectangles(std::vector<GPUDebugVertex> &vertices, std::vector<
 	u16 v = 0;
 	GPUDebugVertex *vert = &newVerts[0];
 	u16 *ind = &newInds[0];
-	for (size_t i = 0, end = numInds; i < end; i += 2) {
-		const auto &orig_tl = useInds ? vertices[indices[i]] : vertices[i];
+	for (size_t i = 0; i < numInds; i += 2) {
+		const auto &orig_tl = useInds ? vertices[indices[i + 0]] : vertices[i + 0];
 		const auto &orig_br = useInds ? vertices[indices[i + 1]] : vertices[i + 1];
 
 		vert[0] = orig_br;
@@ -219,7 +219,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op) {
 
 	// TODO: Probably there's a better way and place to do this.
 	u16 minIndex = 0;
-	u16 maxIndex = count;
+	u16 maxIndex = count - 1;
 	if (!indices.empty()) {
 		minIndex = 0xFFFF;
 		maxIndex = 0;
@@ -235,7 +235,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op) {
 
 	const float invTexWidth = 1.0f / gstate_c.curTextureWidth;
 	const float invTexHeight = 1.0f / gstate_c.curTextureHeight;
-	for (u16 i = minIndex; i < maxIndex; ++i) {
+	for (u16 i = minIndex; i <= maxIndex; ++i) {
 		vertices[i].u *= invTexWidth;
 		vertices[i].v *= invTexHeight;
 		if (vertices[i].u > 1.0f || vertices[i].u < 0.0f)


### PR DESCRIPTION
The texture was not highlighted correctly, since we didn't normalize all coords.

-[Unknown]
