### PR TITLE
Add an option to ignore gamepads when not focused

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -540,6 +540,7 @@ static ConfigSetting controlSettings[] = {
 #endif
 
 	ConfigSetting("DisableDpadDiagonals", &g_Config.bDisableDpadDiagonals, false, true, true),
+	ConfigSetting("GamepadOnlyFocused", &g_Config.bGamepadOnlyFocused, false, true, true),
 	ConfigSetting("TouchButtonStyle", &g_Config.iTouchButtonStyle, 1, true, true),
 	ConfigSetting("TouchButtonOpacity", &g_Config.iTouchButtonOpacity, 65, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -234,6 +234,7 @@ public:
 
 	// Disable diagonals
 	bool bDisableDpadDiagonals;
+	bool bGamepadOnlyFocused;
 	// Control Style
 	int iTouchButtonStyle;
 	// Control Positions

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -369,6 +369,10 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new ItemHeader(ms->T("Controls")));
 	controlsSettings->Add(new Choice(c->T("Control Mapping")))->OnClick.Handle(this, &GameSettingsScreen::OnControlMapping);
 
+#if defined(USING_WIN_UI)
+	controlsSettings->Add(new CheckBox(&g_Config.bGamepadOnlyFocused, c->T("Ignore gamepads when not focused")));
+#endif
+
 #if defined(MOBILE_DEVICE)
 	controlsSettings->Add(new CheckBox(&g_Config.bHapticFeedback, c->T("HapticFeedback", "Haptic Feedback (vibration)")));
 	static const char *tiltTypes[] = { "None (Disabled)", "Analog Stick", "D-PAD", "PSP Action Buttons"};

--- a/Windows/InputDevice.cpp
+++ b/Windows/InputDevice.cpp
@@ -21,6 +21,7 @@
 #include "input/input_state.h"
 #include "thread/thread.h"
 #include "thread/threadutil.h"
+#include "Core/Config.h"
 #include "Core/Host.h"
 #include "Windows/InputDevice.h"
 #include "Windows/XinputDevice.h"
@@ -33,6 +34,7 @@ static volatile bool inputThreadEnabled = false;
 static std::thread *inputThread = NULL;
 static recursive_mutex inputMutex;
 static condition_variable inputEndCond;
+static bool focused = true;
 
 extern InputState input_state;
 
@@ -46,7 +48,7 @@ inline static void ExecuteInputPoll() {
 	input_state.pad_lstick_y = 0;
 	input_state.pad_rstick_x = 0;
 	input_state.pad_rstick_y = 0;
-	if (host) {
+	if (host && (focused || !g_Config.bGamepadOnlyFocused)) {
 		host->PollControllers(input_state);
 	}
 	UpdateInputState(&input_state);
@@ -86,4 +88,12 @@ void InputDevice::StopPolling() {
 	}
 	delete inputThread;
 	inputThread = NULL;
+}
+
+void InputDevice::GainFocus() {
+	focused = true;
+}
+
+void InputDevice::LoseFocus() {
+	focused = false;
 }

--- a/Windows/InputDevice.h
+++ b/Windows/InputDevice.h
@@ -32,4 +32,7 @@ public:
 
 	static void BeginPolling();
 	static void StopPolling();
+
+	static void GainFocus();
+	static void LoseFocus();
 };

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -58,6 +58,8 @@ namespace WindowsRawInput {
 	static void *rawInputBuffer;
 	static size_t rawInputBufferSize;
 	static bool menuActive;
+	static bool focused = true;
+	static bool mouseRightDown = false;
 
 	void Init() {
 		RAWINPUTDEVICE dev[3];
@@ -171,7 +173,18 @@ namespace WindowsRawInput {
 		return 0;
 	}
 
-	void ProcessMouse(RAWINPUT *raw, bool foreground) {
+	static bool MouseInWindow(HWND hWnd) {
+		POINT pt;
+		if (GetCursorPos(&pt) != 0) {
+			RECT rt;
+			if (GetWindowRect(hWnd, &rt) != 0) {
+				return PtInRect(&rt, pt) != 0;
+			}
+		}
+		return true;
+	}
+
+	void ProcessMouse(HWND hWnd, RAWINPUT *raw, bool foreground) {
 		if (menuActive && UpdateMenuActive()) {
 			// Ignore mouse input while a menu is active, it's probably interacting with the menu.
 			return;
@@ -193,12 +206,27 @@ namespace WindowsRawInput {
 			key.flags = KEY_DOWN;
 			key.keyCode = windowsTransTable[VK_RBUTTON];
 			NativeTouch(touch);
-			NativeKey(key);
+			if (MouseInWindow(hWnd)) {
+				NativeKey(key);
+			}
+			mouseRightDown = true;
 		} else if (raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP) {
 			key.flags = KEY_UP;
 			key.keyCode = windowsTransTable[VK_RBUTTON];
 			NativeTouch(touch);
-			NativeKey(key);
+			if (MouseInWindow(hWnd)) {
+				if (!mouseRightDown) {
+					// This means they were focused outside, and right clicked inside.
+					// Seems intentional, so send a down first.
+					key.flags = KEY_DOWN;
+					NativeKey(key);
+					key.flags = KEY_UP;
+					NativeKey(key);
+				} else {
+					NativeKey(key);
+				}
+			}
+			mouseRightDown = false;
 		}
 
 		// TODO : Smooth and translate to an axis every frame.
@@ -229,7 +257,7 @@ namespace WindowsRawInput {
 			break;
 
 		case RIM_TYPEMOUSE:
-			ProcessMouse(raw, foreground);
+			ProcessMouse(hWnd, raw, foreground);
 			break;
 
 		case RIM_TYPEHID:
@@ -241,6 +269,10 @@ namespace WindowsRawInput {
 		return DefWindowProc(hWnd, WM_INPUT, wParam, lParam);
 	}
 
+	void GainFocus() {
+		focused = true;
+	}
+
 	void LoseFocus() {
 		// Force-release all held keys on the keyboard to prevent annoying stray inputs.
 		KeyInput key;
@@ -250,6 +282,7 @@ namespace WindowsRawInput {
 			key.keyCode = *i;
 			NativeKey(key);
 		}
+		focused = false;
 	}
 
 	void NotifyMenu() {

--- a/Windows/RawInput.h
+++ b/Windows/RawInput.h
@@ -22,6 +22,7 @@ namespace WindowsRawInput {
 	LRESULT Process(HWND hWnd, WPARAM wParam, LPARAM lParam);
 	// Not actually RawInput but it kinda belongs here anyway.
 	LRESULT ProcessChar(HWND hWnd, WPARAM wParam, LPARAM lParam);
+	void GainFocus();
 	void LoseFocus();
 	void NotifyMenu();
 	void Shutdown();

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1083,6 +1083,7 @@ namespace MainWindow
 			{
 				bool pause = true;
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
+					InputDevice::GainFocus();
 					g_activeWindow = WINDOW_MAINWINDOW;
 					pause = false;
 				}
@@ -1097,6 +1098,7 @@ namespace MainWindow
 
 				if (wParam == WA_INACTIVE) {
 					WindowsRawInput::LoseFocus();
+					InputDevice::LoseFocus();
 				}
 			}
 			break;

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1083,6 +1083,7 @@ namespace MainWindow
 			{
 				bool pause = true;
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
+					WindowsRawInput::GainFocus();
 					InputDevice::GainFocus();
 					g_activeWindow = WINDOW_MAINWINDOW;
 					pause = false;


### PR DESCRIPTION
Personally, I greatly prefer it allowing it while not focused, but this way people can pick.

Not sure if "Ignore gamepads when not focused" is the best or clearest wording...

Windows only for now since I don't want to mess with Qt/etc.

-[Unknown]
