### PR TITLE
Keep Windows devices from sleeping while playing

### DIFF
--- a/Core/Core.h
+++ b/Core/Core.h
@@ -46,4 +46,4 @@ bool UpdateScreenScale(int width, int height);
 
 // Don't run the core when minimized etc.
 void Core_NotifyWindowHidden(bool hidden);
-
+void Core_NotifyActivity();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -285,6 +285,8 @@ inline float clamp1(float x) {
 }
 
 bool EmuScreen::touch(const TouchInput &touch) {
+	Core_NotifyActivity();
+
 	if (root_) {
 		root_->Touch(touch);
 		return true;
@@ -427,6 +429,8 @@ inline void EmuScreen::setVKeyAnalogY(int stick, int virtualKeyMin, int virtualK
 }
 
 bool EmuScreen::key(const KeyInput &key) {
+	Core_NotifyActivity();
+
 	std::vector<int> pspKeys;
 	KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys);
 
@@ -470,6 +474,8 @@ void EmuScreen::pspKey(int pspKeyCode, int flags) {
 }
 
 bool EmuScreen::axis(const AxisInput &axis) {
+	Core_NotifyActivity();
+
 	if (axis.value > 0) {
 		processAxis(axis, 1);
 		return true;


### PR DESCRIPTION
See #6340.

This takes a slightly more conservative approach than disabling it entirely: if there's been no input for 2 hours, stop telling Windows it can't go to sleep.  Intentionally, doesn't do it from the pause screen.

This obviously duplicates the existing Windows setting, but I think 2 hours is a reasonable default that might save a couple laptops from dying here and there, by mistake.  Also, I swear I've seen before in XP (might be fixed in Windows 7 or something) that gamepad button presses don't keep Windows awake.

Not sure if other platforms need to do anything.

-[Unknown]
