### PR TITLE
Don't set focus for Play choice

### DIFF
--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -113,8 +113,6 @@ void GameScreen::CreateViews() {
 #ifdef _WIN32
 	rightColumnItems->Add(new Choice(ga->T("Show In Folder")))->OnClick.Handle(this, &GameScreen::OnShowInFolder);
 #endif
-
-	UI::SetFocusedView(play);
 }
 
 UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)


### PR DESCRIPTION
See #7404. While it's just a workaround for that bug, we don't have any other choices explicitly focused anywhere. So perhaps we shouldn't do it here as well to keeps things consistent.
