### PR TITLE
jit: Discard unused regs before a syscall

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -358,9 +358,8 @@ inline static void SetDeadbeefRegs()
 	currentMIPS->r[MIPS_REG_COMPILER_SCRATCH] = 0xDEADBEEF;
 	// Set all the arguments and temp regs.
 	memcpy(&currentMIPS->r[MIPS_REG_A0], deadbeefRegs, sizeof(deadbeefRegs));
-	// Using a magic number since there's confusion/disagreement on reg names.
-	currentMIPS->r[24] = 0xDEADBEEF;
-	currentMIPS->r[25] = 0xDEADBEEF;
+	currentMIPS->r[MIPS_REG_T8] = 0xDEADBEEF;
+	currentMIPS->r[MIPS_REG_T9] = 0xDEADBEEF;
 
 	currentMIPS->lo = 0xDEADBEEF;
 	currentMIPS->hi = 0xDEADBEEF;

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -582,6 +582,22 @@ void ArmJit::Comp_JumpReg(MIPSOpcode op)
 	
 void ArmJit::Comp_Syscall(MIPSOpcode op)
 {
+	if (!g_Config.bSkipDeadbeefFilling)
+	{
+		// All of these will be overwritten with DEADBEEF anyway.
+		gpr.DiscardR(MIPS_REG_COMPILER_SCRATCH);
+		// We need to keep A0 - T3, which are used for args.
+		gpr.DiscardR(MIPS_REG_T4);
+		gpr.DiscardR(MIPS_REG_T5);
+		gpr.DiscardR(MIPS_REG_T6);
+		gpr.DiscardR(MIPS_REG_T7);
+		gpr.DiscardR(MIPS_REG_T8);
+		gpr.DiscardR(MIPS_REG_T9);
+
+		gpr.DiscardR(MIPS_REG_HI);
+		gpr.DiscardR(MIPS_REG_LO);
+	}
+
 	// If we're in a delay slot, this is off by one.
 	const int offset = js.inDelaySlot ? -1 : 0;
 	WriteDownCount(offset);

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -752,7 +752,21 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 
 void Jit::Comp_Syscall(MIPSOpcode op)
 {
-	// TODO: Maybe discard v0, v1, and some temps?  Definitely at?
+	if (!g_Config.bSkipDeadbeefFilling)
+	{
+		// All of these will be overwritten with DEADBEEF anyway.
+		gpr.DiscardR(MIPS_REG_COMPILER_SCRATCH);
+		// We need to keep A0 - T3, which are used for args.
+		gpr.DiscardR(MIPS_REG_T4);
+		gpr.DiscardR(MIPS_REG_T5);
+		gpr.DiscardR(MIPS_REG_T6);
+		gpr.DiscardR(MIPS_REG_T7);
+		gpr.DiscardR(MIPS_REG_T8);
+		gpr.DiscardR(MIPS_REG_T9);
+
+		gpr.DiscardR(MIPS_REG_HI);
+		gpr.DiscardR(MIPS_REG_LO);
+	}
 	FlushAll();
 
 	// If we're in a delay slot, this is off by one.

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -241,6 +241,21 @@ void GPRRegCache::DiscardRegContentsIfCached(MIPSGPReg preg) {
 	}
 }
 
+void GPRRegCache::DiscardR(MIPSGPReg preg) {
+	if (regs[preg].away) {
+		if (regs[preg].location.IsSimpleReg()) {
+			DiscardRegContentsIfCached(preg);
+		} else {
+			regs[preg].away = false;
+			if (preg == MIPS_REG_ZERO) {
+				regs[preg].location = Imm32(0);
+			} else {
+				regs[preg].location = GetDefaultLocation(preg);
+			}
+		}
+	}
+}
+
 
 void GPRRegCache::SetImm(MIPSGPReg preg, u32 immValue) {
 	// ZERO is always zero.  Let's just make sure.

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -72,6 +72,7 @@ public:
 	void Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats);
 
 	void DiscardRegContentsIfCached(MIPSGPReg preg);
+	void DiscardR(MIPSGPReg preg);
 	void SetEmitter(Gen::XEmitter *emitter) {emit = emitter;}
 
 	void FlushR(Gen::X64Reg reg); 


### PR DESCRIPTION
This is a pretty minor optimization, though.

-[Unknown]
