### PR TITLE
change manifest namespace to asm.v1

### DIFF
--- a/Windows/PPSSPP.manifest
+++ b/Windows/PPSSPP.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <assembly
-   xmlns="urn:schemas-microsoft-com:asm.v3"
+   xmlns="urn:schemas-microsoft-com:asm.v1"
    manifestVersion="1.0">
   <assemblyIdentity
      processorArchitecture="*"


### PR DESCRIPTION
I really just changed it v3 to test it being the same as the second that
Visual Studio auto-generated but that seems to not have been a good idea
I pretty much just accidentally commited it anyway.

Fixes #7562
