### PR TITLE
Use framebuffer fetch more and on more devices

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -281,6 +281,8 @@ ReplaceBlendType ReplaceBlendWithShader() {
 		case GE_DSTBLEND_DOUBLEINVSRCALPHA:
 			// We can't technically do this correctly (due to clamping) without reading the dst color.
 			// Using a copy isn't accurate either, though, when there's overlap.
+			if (gl_extensions.EXT_shader_framebuffer_fetch || gl_extensions.NV_shader_framebuffer_fetch)
+				return !gstate_c.allowShaderBlend ? REPLACE_BLEND_PRE_SRC_2X_ALPHA : REPLACE_BLEND_COPY_FBO;
 			return REPLACE_BLEND_PRE_SRC_2X_ALPHA;
 
 		default:
@@ -338,11 +340,15 @@ ReplaceBlendType ReplaceBlendWithShader() {
 		case GE_DSTBLEND_DOUBLEINVSRCALPHA:
 			if (funcA == GE_SRCBLEND_SRCALPHA || funcA == GE_SRCBLEND_INVSRCALPHA) {
 				// Can't safely double alpha, will clamp.  However, a copy may easily be worse due to overlap.
+				if (gl_extensions.EXT_shader_framebuffer_fetch || gl_extensions.NV_shader_framebuffer_fetch)
+					return !gstate_c.allowShaderBlend ? REPLACE_BLEND_PRE_SRC_2X_ALPHA : REPLACE_BLEND_COPY_FBO;
 				return REPLACE_BLEND_PRE_SRC_2X_ALPHA;
 			} else {
 				// This means dst alpha/color is used in the src factor.
 				// Unfortunately, copying here causes overlap problems in Silent Hill games (it seems?)
 				// We will just hope that doubling alpha for the dst factor will not clamp too badly.
+				if (gl_extensions.EXT_shader_framebuffer_fetch || gl_extensions.NV_shader_framebuffer_fetch)
+					return !gstate_c.allowShaderBlend ? REPLACE_BLEND_2X_ALPHA : REPLACE_BLEND_COPY_FBO;
 				return REPLACE_BLEND_2X_ALPHA;
 			}
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -521,14 +521,12 @@ void GenerateFragmentShader(char *buffer) {
 	highpFog = (gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_BAD) ? true : false;
 	highpTexcoord = highpFog;
 
-	// GL_NV_shader_framebuffer_fetch available on mobile platform and ES 2.0 only but not desktop
-	if (gl_extensions.NV_shader_framebuffer_fetch) {
-		WRITE(p, "#extension GL_NV_shader_framebuffer_fetch : require\n");
-	}
 	if (gl_extensions.EXT_shader_framebuffer_fetch) {
 		WRITE(p, "#extension GL_EXT_shader_framebuffer_fetch : require\n");
-	}
-	if (gl_extensions.ARM_shader_framebuffer_fetch) {
+	} else if (gl_extensions.NV_shader_framebuffer_fetch) {
+		// GL_NV_shader_framebuffer_fetch is available on mobile platform and ES 2.0 only but not on desktop.
+		WRITE(p, "#extension GL_NV_shader_framebuffer_fetch : require\n");
+	} else if (gl_extensions.ARM_shader_framebuffer_fetch) {
 		WRITE(p, "#extension GL_ARM_shader_framebuffer_fetch : require\n");
 	}
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -167,7 +167,7 @@ static inline bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margi
 }
 
 bool TransformDrawEngine::ApplyShaderBlending() {
-	if (gl_extensions.NV_shader_framebuffer_fetch || gl_extensions.EXT_shader_framebuffer_fetch) {
+	if (gl_extensions.ANY_shader_framebuffer_fetch) {
 		return true;
 	}
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -167,7 +167,7 @@ static inline bool blendColorSimilar(const Vec3f &a, const Vec3f &b, float margi
 }
 
 bool TransformDrawEngine::ApplyShaderBlending() {
-	if (gl_extensions.NV_shader_framebuffer_fetch) {
+	if (gl_extensions.NV_shader_framebuffer_fetch || gl_extensions.EXT_shader_framebuffer_fetch) {
 		return true;
 	}
 


### PR DESCRIPTION
This adds support for EXT_shader_framebuffer_fetch, which is available on PowerVR devices, specifically Apple A7 (comes up as a GPU?), PowerVR Rogue, and PowerVR SGX 535+.

Additionally, we currently avoid copying FBOs for some blending modes where overlap is more of an issue, and it's a bit hacky.  But framebuffer fetch should be ordered, and therefore safe to use in these situations for more accurate blending.

These two changes may solve issues like the one noted in #1313.

I don't have any working devices with support, so this is basically untested.  So, it may also break things horribly...

-[Unknown]
