### PR TITLE
Small optimizations to software transform

### DIFF
--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -75,8 +75,18 @@ struct DecVtxFormat {
 // This struct too.
 struct TransformedVertex
 {
-	float x, y, z, fog;     // in case of morph, preblend during decode
-	float u; float v; float w;   // scaled by uscale, vscale, if there
+	union {
+		struct {
+			float x, y, z, fog;     // in case of morph, preblend during decode
+		};
+		float pos[4];
+	};
+	union {
+		struct {
+			float u; float v; float w;   // scaled by uscale, vscale, if there
+		};
+		float uv[3];
+	};
 	union {
 		u8 color0[4];   // prelit
 		u32 color0_32;

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -412,7 +412,7 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		// We only need one clear shader, so let's ignore the rest of the bits.
 		id0 = 1;
 	} else {
-		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 		bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !g_Config.bDisableAlphaTest;
 		bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
@@ -497,7 +497,7 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 void GenerateFragmentShaderDX9(char *buffer) {
 	char *p = buffer;
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
 	bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough() && !gstate.isModeClear();
 	bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !gstate.isModeClear() && !g_Config.bDisableAlphaTest;

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -133,7 +133,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 	char *p = buffer;
 	const u32 vertType = gstate.vertType;
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
 	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 	bool doShadeMapping = gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP;
@@ -256,7 +256,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "  float4 color0 : COLOR0;\n");
 		}
 		// only software transform supplies color1 as vertex data
-		if (lmode && !throughmode) {
+		if (lmode) {
 			WRITE(p, "  float4 color1 : COLOR1;\n");
 		}
 		WRITE(p, "};\n");
@@ -271,7 +271,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "  float2 v_texcoord: TEXCOORD0;\n");
 	}
 	WRITE(p, "  float4 v_color0    : COLOR0;\n");
-	if (lmode && !throughmode)
+	if (lmode)
 		WRITE(p, "  float3 v_color1    : COLOR1;\n");
 
 	if (enableFog) {
@@ -296,11 +296,11 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 		}
 		if (hasColor) {
 			WRITE(p, "  Out.v_color0 = In.color0;\n");
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  Out.v_color1 = In.color1.rgb;\n");
 		} else {
 			WRITE(p, "  Out.v_color0 = In.u_matambientalpha;\n");
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  Out.v_color1 = float3(0.0);\n");
 		}
 		if (enableFog) {
@@ -503,9 +503,9 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			if (lmode) {
 				WRITE(p, "  Out.v_color0 = clamp(lightSum0, 0.0, 1.0);\n");
 				// v_color1 only exists when lmode = 1.
-				if (specularIsZero && !throughmode) {
+				if (specularIsZero) {
 					WRITE(p, "  Out.v_color1 = float3(0, 0, 0);\n");
-				} else if (!throughmode) {
+				} else {
 					WRITE(p, "  Out.v_color1 = clamp(lightSum1, 0.0, 1.0);\n");
 				}
 			} else {
@@ -522,7 +522,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			} else {
 				WRITE(p, "  Out.v_color0 = u_matambientalpha;\n");
 			}
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  Out.v_color1 = float3(0, 0, 0);\n");
 		}
 

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -232,7 +232,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "%s", boneWeightAttrDecl[TranslateNumBones(vertTypeGetNumBoneWeights(vertType))]);
 		}
 		if (doTexture && hasTexcoord) {
-			if (doTextureProjection)
+			if (doTextureProjection && !throughmode)
 				WRITE(p, "  float3 texcoord : TEXCOORD0;\n");
 			else
 				WRITE(p, "  float2 texcoord : TEXCOORD0;\n");
@@ -265,7 +265,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "  float2 v_texcoord: TEXCOORD0;\n");
 	}
 	WRITE(p, "  float4 v_color0    : COLOR0;\n");
-	if (lmode) 
+	if (lmode && !throughmode)
 		WRITE(p, "  float3 v_color1    : COLOR1;\n");
 
 	if (enableFog) {
@@ -279,18 +279,22 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 		// Simple pass-through of vertex data to fragment shader
 		if (doTexture) {
 			if (doTextureProjection) {
-				WRITE(p, "  Out.v_texcoord = In.texcoord;\n");
+				if (throughmode) {
+					WRITE(p, "  Out.v_texcoord = float3(In.texcoord.x, In.texcoord.y, 1.0);\n");
+				} else {
+					WRITE(p, "  Out.v_texcoord = In.texcoord;\n");
+				}
 			} else {
 				WRITE(p, "  Out.v_texcoord = In.texcoord.xy;\n");
 			}
 		}
 		if (hasColor) {
 			WRITE(p, "  Out.v_color0 = In.color0;\n");
-			if (lmode)
+			if (lmode && !throughmode)
 				WRITE(p, "  Out.v_color1 = In.color1.rgb;\n");
 		} else {
 			WRITE(p, "  Out.v_color0 = In.u_matambientalpha;\n");
-			if (lmode)
+			if (lmode && !throughmode)
 				WRITE(p, "  Out.v_color1 = float3(0.0);\n");
 		}
 		if (enableFog) {
@@ -493,9 +497,9 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			if (lmode) {
 				WRITE(p, "  Out.v_color0 = clamp(lightSum0, 0.0, 1.0);\n");
 				// v_color1 only exists when lmode = 1.
-				if (specularIsZero) {
+				if (specularIsZero && !throughmode) {
 					WRITE(p, "  Out.v_color1 = float3(0, 0, 0);\n");
-				} else {
+				} else if (!throughmode) {
 					WRITE(p, "  Out.v_color1 = clamp(lightSum1, 0.0, 1.0);\n");
 				}
 			} else {
@@ -512,7 +516,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			} else {
 				WRITE(p, "  Out.v_color0 = u_matambientalpha;\n");
 			}
-			if (lmode)
+			if (lmode && !throughmode)
 				WRITE(p, "  Out.v_color1 = float3(0, 0, 0);\n");
 		}
 

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -232,7 +232,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "%s", boneWeightAttrDecl[TranslateNumBones(vertTypeGetNumBoneWeights(vertType))]);
 		}
 		if (doTexture && hasTexcoord) {
-			if (doTextureProjection && !throughmode)
+			if (doTextureProjection)
 				WRITE(p, "  float3 texcoord : TEXCOORD0;\n");
 			else
 				WRITE(p, "  float2 texcoord : TEXCOORD0;\n");

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -232,10 +232,7 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 			WRITE(p, "%s", boneWeightAttrDecl[TranslateNumBones(vertTypeGetNumBoneWeights(vertType))]);
 		}
 		if (doTexture && hasTexcoord) {
-			if (doTextureProjection)
-				WRITE(p, "  float3 texcoord : TEXCOORD0;\n");
-			else
-				WRITE(p, "  float2 texcoord : TEXCOORD0;\n");
+			WRITE(p, "  float2 texcoord : TEXCOORD0;\n");
 		}
 		if (hasColor)  {
 			WRITE(p, "  float4 color0 : COLOR0;\n");
@@ -249,10 +246,19 @@ void GenerateVertexShaderDX9(int prim, char *buffer, bool useHWTransform) {
 	} else {
 		WRITE(p, "struct VS_IN {\n");
 		WRITE(p, "  float4 position : POSITION;\n");
-		WRITE(p, "  float3 texcoord : TEXCOORD0;\n");
-		WRITE(p, "  float4 color0 : COLOR0;\n");
+		if (doTexture && hasTexcoord) {
+			if (doTextureProjection && !throughmode)
+				WRITE(p, "  float3 texcoord : TEXCOORD0;\n");
+			else
+				WRITE(p, "  float2 texcoord : TEXCOORD0;\n");
+		}
+		if (hasColor) {
+			WRITE(p, "  float4 color0 : COLOR0;\n");
+		}
 		// only software transform supplies color1 as vertex data
-		WRITE(p, "  float4 color1 : COLOR1;\n");
+		if (lmode && !throughmode) {
+			WRITE(p, "  float4 color1 : COLOR1;\n");
+		}
 		WRITE(p, "};\n");
 	}
 

--- a/GPU/GLES/DepalettizeShader.cpp
+++ b/GPU/GLES/DepalettizeShader.cpp
@@ -209,7 +209,7 @@ GLuint DepalShaderCache::GetDepalettizeShader(GEBufferFormat pixelFormat) {
 	GLint u_pal = glGetUniformLocation(program, "pal");
 
 	glUniform1i(u_tex, 0);
-	glUniform1i(u_pal, 1);
+	glUniform1i(u_pal, 3);
 
 	GLint linkStatus = GL_FALSE;
 	glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -394,7 +394,7 @@ void ComputeFragmentShaderID(ShaderID *id) {
 		// We only need one clear shader, so let's ignore the rest of the bits.
 		id0 = 1;
 	} else {
-		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 		bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !g_Config.bDisableAlphaTest;
 		bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
@@ -568,7 +568,7 @@ void GenerateFragmentShader(char *buffer) {
 		varying = "in";
 	}
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
 	bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough() && !gstate.isModeClear();
 	bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !gstate.isModeClear() && !g_Config.bDisableAlphaTest;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -979,7 +979,7 @@ void FramebufferManager::BindFramebufferColor(int stage, VirtualFramebuffer *fra
 		fbo_bind_color_as_texture(framebuffer->fbo, 0);
 	}
 
-	if (stage != GL_TEXTURE1) {
+	if (stage != GL_TEXTURE0) {
 		glActiveTexture(stage);
 	}
 }

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1109,7 +1109,7 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 			glEnableVertexAttribArray(a_position);
 			glEnableVertexAttribArray(a_texcoord0);
 
-			glActiveTexture(GL_TEXTURE1);
+			glActiveTexture(GL_TEXTURE3);
 			glBindTexture(GL_TEXTURE_2D, clutTexture);
 			glActiveTexture(GL_TEXTURE0);
 

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -214,7 +214,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		boneWeightDecl = boneWeightInDecl;
 	}
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
 	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 	bool doShadeMapping = gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP;
@@ -264,7 +264,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 	}
 	if (hasColor) {
 		WRITE(p, "%s lowp vec4 color0;\n", attribute);
-		if (lmode && !useHWTransform && !throughmode)  // only software transform supplies color1 as vertex data
+		if (lmode && !useHWTransform)  // only software transform supplies color1 as vertex data
 			WRITE(p, "%s lowp vec3 color1;\n", attribute);
 	}
 
@@ -337,7 +337,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 	}
 
 	WRITE(p, "%s %s lowp vec4 v_color0;\n", shading, varying);
-	if (lmode && !throughmode) {
+	if (lmode) {
 		WRITE(p, "%s %s lowp vec3 v_color1;\n", shading, varying);
 	}
 	if (doTexture) {
@@ -370,11 +370,11 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		}
 		if (hasColor) {
 			WRITE(p, "  v_color0 = color0;\n");
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  v_color1 = color1;\n");
 		} else {
 			WRITE(p, "  v_color0 = u_matambientalpha;\n");
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  v_color1 = vec3(0.0);\n");
 		}
 		if (enableFog) {
@@ -584,9 +584,9 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			if (lmode) {
 				WRITE(p, "  v_color0 = clamp(lightSum0, 0.0, 1.0);\n");
 				// v_color1 only exists when lmode = 1.
-				if (specularIsZero && !throughmode) {
+				if (specularIsZero) {
 					WRITE(p, "  v_color1 = vec3(0.0);\n");
-				} else if (!throughmode) {
+				} else {
 					WRITE(p, "  v_color1 = clamp(lightSum1, 0.0, 1.0);\n");
 				}
 			} else {
@@ -603,7 +603,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			} else {
 				WRITE(p, "  v_color0 = u_matambientalpha;\n");
 			}
-			if (lmode && !throughmode)
+			if (lmode)
 				WRITE(p, "  v_color1 = vec3(0.0);\n");
 		}
 


### PR DESCRIPTION
This cuts down on work done in throughmode software transform, e.g. 2D rectangle drawing.  It should simplify the fragment shader and also the cpu side of the transform.

It gives a 1% performance improvement in Tales of Phantasia X on my desktop.

Swapping the if in software transform should even very slightly benefit non-through.

Also, I moved the palette for depal to stage 3.  8 stages should always be available, and I think it's better to dedicate a stage to each thing to ensure there's no overlap.  Also, using a separate stage from shader blending makes it more possibly to do depal in the normal render, if we choose to try that.

-[Unknown]
