### PR TITLE
Small optimizations to fragtest cache and oom tweak for texcache

### DIFF
--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -107,6 +107,10 @@ bool IsAlphaTestAgainstZero() {
 	return gstate.getAlphaTestRef() == 0 && gstate.getAlphaTestMask() == 0xFF;
 }
 
+bool IsColorTestAgainstZero() {
+	return gstate.getColorTestRef() == 0 && gstate.getColorTestMask() == 0xFFFFFF;
+}
+
 const bool nonAlphaSrcFactors[16] = {
 	true,  // GE_SRCBLEND_DSTCOLOR,
 	true,  // GE_SRCBLEND_INVDSTCOLOR,
@@ -453,19 +457,20 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		}
 #endif
 		if (enableColorTest) {
-			// 3 bits total.
+			// 4 bits total.
 			id0 |= 1 << 17;
 			id0 |= gstate.getColorTestFunction() << 18;
+			id0 |= (IsColorTestAgainstZero() & 1) << 20;
 		}
-		id0 |= (enableFog & 1) << 20;
-		id0 |= (doTextureProjection & 1) << 21;
-		id0 |= (enableColorDoubling & 1) << 22;
+		id0 |= (enableFog & 1) << 21;
+		id0 |= (doTextureProjection & 1) << 22;
+		id0 |= (enableColorDoubling & 1) << 23;
 		// 2 bits
-		id0 |= (stencilToAlpha) << 23;
+		id0 |= (stencilToAlpha) << 24;
 
 		if (stencilToAlpha != REPLACE_ALPHA_NO) {
 			// 4 bits
-			id0 |= ReplaceAlphaWithStencilType() << 25;
+			id0 |= ReplaceAlphaWithStencilType() << 26;
 		}
 
 		if (enableAlphaTest)
@@ -473,7 +478,6 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		else
 			gpuStats.numNonAlphaTestedDraws++;
 
-		id0 |= (gstate_c.bgraTexture & 1) << 29;
 		// 2 bits.
 		id0 |= ReplaceLogicOpType() << 30;
 
@@ -485,6 +489,10 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 			id1 |= gstate.getBlendFuncA() << 6;
 			id1 |= gstate.getBlendFuncB() << 10;
 		}
+
+		// TODO: Flat shading?
+
+		id1 |= (gstate_c.bgraTexture & 1) << 15;
 	}
 
 	id->d[0] = id0;
@@ -502,6 +510,7 @@ void GenerateFragmentShaderDX9(char *buffer) {
 	bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !gstate.isModeClear() && !g_Config.bDisableAlphaTest;
 	bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
 	bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue() && !gstate.isModeClear();
+	bool colorTestAgainstZero = IsColorTestAgainstZero();
 	bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
 	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 	bool doTextureAlpha = gstate.isTextureAlphaUsed();
@@ -712,15 +721,31 @@ void GenerateFragmentShaderDX9(char *buffer) {
 		}
 #endif
 		if (enableColorTest) {
-			GEComparison colorTestFunc = gstate.getColorTestFunction();
-			const char *colorTestFuncs[] = { "#", "#", " != ", " == " };	// never/always don't make sense
-			u32 colorTestMask = gstate.getColorTestMask();
-			if (colorTestFuncs[colorTestFunc][0] != '#') {
-				const char * test = colorTestFuncs[colorTestFunc];
-				WRITE(p, "  float3 colortest = roundAndScaleTo255v(v.rgb);\n");
-				WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b ))  clip(-1);\n", test, test, test);
+			if (colorTestAgainstZero) {
+				GEComparison colorTestFunc = gstate.getColorTestFunction();
+				// When testing against 0 (common), we can avoid some math.
+				// 0.002 is approximately half of 1.0 / 255.0.
+				if (colorTestFunc == GE_COMP_NOTEQUAL) {
+					WRITE(p, "  if (v.r < 0.002 && v.g < 0.002 && v.b < 0.002) clip(-1);\n");
+				} else if (colorTestFunc != GE_COMP_NEVER) {
+					// Anything else is a test for == 0.
+					WRITE(p, "  if (v.r > 0.002 || v.g > 0.002 || v.b > 0.002) clip(-1);\n");
+				} else {
+					// NEVER has been logged as used by games, although it makes little sense - statically failing.
+					// Maybe we could discard the drawcall, but it's pretty rare.  Let's just statically discard here.
+					WRITE(p, "  clip(-1);\n");
+				}
 			} else {
-				WRITE(p, "  clip(-1);\n");
+				GEComparison colorTestFunc = gstate.getColorTestFunction();
+				const char *colorTestFuncs[] = { "#", "#", " != ", " == " };	// never/always don't make sense
+				u32 colorTestMask = gstate.getColorTestMask();
+				if (colorTestFuncs[colorTestFunc][0] != '#') {
+					const char * test = colorTestFuncs[colorTestFunc];
+					WRITE(p, "  float3 colortest = roundAndScaleTo255v(v.rgb);\n");
+					WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b )) clip(-1);\n", test, test, test);
+				} else {
+					WRITE(p, "  clip(-1);\n");
+				}
 			}
 		}
 

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -415,7 +415,6 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
 		bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !g_Config.bDisableAlphaTest;
-		bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
 		bool enableColorDoubling = gstate.isColorDoublingEnabled();
 		bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
@@ -447,28 +446,28 @@ void ComputeFragmentShaderIDDX9(FragmentShaderIDDX9 *id) {
 		id0 |= (lmode & 1) << 11;
 #if !defined(DX9_USE_HW_ALPHA_TEST)
 		if (enableAlphaTest) {
-			// 4 bits total.
+			// 5 bits total.
 			id0 |= 1 << 12;
 			id0 |= gstate.getAlphaTestFunction() << 13;
+			id0 |= (IsAlphaTestAgainstZero() & 1) << 16;
 		}
 #endif
 		if (enableColorTest) {
 			// 3 bits total.
-			id0 |= 1 << 16;
-			id0 |= gstate.getColorTestFunction() << 17;
+			id0 |= 1 << 17;
+			id0 |= gstate.getColorTestFunction() << 18;
 		}
-		id0 |= (enableFog & 1) << 19;
-		id0 |= (doTextureProjection & 1) << 20;
-		id0 |= (enableColorDoubling & 1) << 21;
+		id0 |= (enableFog & 1) << 20;
+		id0 |= (doTextureProjection & 1) << 21;
+		id0 |= (enableColorDoubling & 1) << 22;
 		// 2 bits
-		id0 |= (stencilToAlpha) << 22;
+		id0 |= (stencilToAlpha) << 23;
 
 		if (stencilToAlpha != REPLACE_ALPHA_NO) {
 			// 4 bits
-			id0 |= ReplaceAlphaWithStencilType() << 24;
+			id0 |= ReplaceAlphaWithStencilType() << 25;
 		}
 
-		id0 |= (alphaTestAgainstZero & 1) << 28;
 		if (enableAlphaTest)
 			gpuStats.numAlphaTestedDraws++;
 		else

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -79,6 +79,7 @@ enum ReplaceBlendType {
 
 bool IsAlphaTestAgainstZero();
 bool IsAlphaTestTriviallyTrue();
+bool IsColorTestAgainstZero();
 bool IsColorTestTriviallyTrue();
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend);

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -397,7 +397,6 @@ void ComputeFragmentShaderID(ShaderID *id) {
 		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
 		bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !g_Config.bDisableAlphaTest;
-		bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
 		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
 		bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
@@ -430,28 +429,28 @@ void ComputeFragmentShaderID(ShaderID *id) {
 		id0 |= (lmode & 1) << 11;
 #if !defined(DX9_USE_HW_ALPHA_TEST)
 		if (enableAlphaTest) {
-			// 4 bits total.
+			// 5 bits total.
 			id0 |= 1 << 12;
 			id0 |= gstate.getAlphaTestFunction() << 13;
+			id0 |= (IsAlphaTestAgainstZero() & 1) << 16;
 		}
 #endif
 		if (enableColorTest) {
 			// 3 bits total.
-			id0 |= 1 << 16;
-			id0 |= gstate.getColorTestFunction() << 17;
+			id0 |= 1 << 17;
+			id0 |= gstate.getColorTestFunction() << 18;
 		}
-		id0 |= (enableFog & 1) << 19;
-		id0 |= (doTextureProjection & 1) << 20;
-		id0 |= (enableColorDoubling & 1) << 21;
+		id0 |= (enableFog & 1) << 20;
+		id0 |= (doTextureProjection & 1) << 21;
+		id0 |= (enableColorDoubling & 1) << 22;
 		// 2 bits
-		id0 |= (stencilToAlpha) << 22;
+		id0 |= (stencilToAlpha) << 23;
 	
 		if (stencilToAlpha != REPLACE_ALPHA_NO) {
 			// 4 bits
-			id0 |= ReplaceAlphaWithStencilType() << 24;
+			id0 |= ReplaceAlphaWithStencilType() << 25;
 		}
 
-		id0 |= (alphaTestAgainstZero & 1) << 28;
 		if (enableAlphaTest)
 			gpuStats.numAlphaTestedDraws++;
 		else

--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -54,6 +54,7 @@ enum ReplaceBlendType {
 
 bool IsAlphaTestAgainstZero();
 bool IsAlphaTestTriviallyTrue();
+bool IsColorTestAgainstZero();
 bool IsColorTestTriviallyTrue();
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend);

--- a/GPU/GLES/FragmentTestCache.cpp
+++ b/GPU/GLES/FragmentTestCache.cpp
@@ -22,6 +22,7 @@
 
 // These are small, let's give them plenty of frames.
 static const int FRAGTEST_TEXTURE_OLD_AGE = 307;
+static const int FRAGTEST_DECIMATION_INTERVAL = 113;
 
 FragmentTestCache::FragmentTestCache() : textureCache_(NULL), lastTexture_(0) {
 	scratchpad_ = new u8[256 * 4];
@@ -161,13 +162,18 @@ void FragmentTestCache::Clear(bool deleteThem) {
 }
 
 void FragmentTestCache::Decimate() {
-	for (auto tex = cache_.begin(); tex != cache_.end(); ) {
-		if (tex->second.lastFrame + FRAGTEST_TEXTURE_OLD_AGE < gpuStats.numFlips) {
-			glDeleteTextures(1, &tex->second.texture);
-			cache_.erase(tex++);
-		} else {
-			++tex;
+	if (--decimationCounter_ <= 0) {
+		for (auto tex = cache_.begin(); tex != cache_.end(); ) {
+			if (tex->second.lastFrame + FRAGTEST_TEXTURE_OLD_AGE < gpuStats.numFlips) {
+				glDeleteTextures(1, &tex->second.texture);
+				cache_.erase(tex++);
+			} else {
+				++tex;
+			}
 		}
+
+		decimationCounter_ = FRAGTEST_DECIMATION_INTERVAL;
 	}
+
 	lastTexture_ = 0;
 }

--- a/GPU/GLES/FragmentTestCache.h
+++ b/GPU/GLES/FragmentTestCache.h
@@ -80,4 +80,5 @@ private:
 	std::map<FragmentTestID, FragmentTestTexture> cache_;
 	u8 *scratchpad_;
 	GLuint lastTexture_;
+	int decimationCounter_;
 };

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -2023,12 +2023,16 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level, bool replac
 		glTexSubImage2D(GL_TEXTURE_2D, level, 0, 0, w, h, components2, dstFmt, pixelData);
 	} else {
 		glTexImage2D(GL_TEXTURE_2D, level, components, w, h, 0, components2, dstFmt, pixelData);
-		GLenum err = glGetError();
-		if (err == GL_OUT_OF_MEMORY) {
-			lowMemoryMode_ = true;
-			Decimate();
-			// Try again.
-			glTexImage2D(GL_TEXTURE_2D, level, components, w, h, 0, components2, dstFmt, pixelData);
+		if (!lowMemoryMode_) {
+			GLenum err = glGetError();
+			if (err == GL_OUT_OF_MEMORY) {
+				WARN_LOG_REPORT(G3D, "Texture cache ran out of GPU memory; switching to low memory mode");
+				lowMemoryMode_ = true;
+				decimationCounter_ = 0;
+				Decimate();
+				// Try again, now that we've cleared out textures in lowMemoryMode_.
+				glTexImage2D(GL_TEXTURE_2D, level, components, w, h, 0, components2, dstFmt, pixelData);
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds a colorTestAgainstZero, similar to alphaTesAgainstZero.  This is a bit faster and should still be accurate on mobile and desktop.  Apparently Castlevania and a few other games use tests against zero, not just Tales of Phantasia X.

This also decimates less often (a very tiny optimization, but it's more consistent too.)

Lastly, I fixed an issue related to decimation intervals that could've caused the texture cache not to flush properly on oom (although it probably would have later.)  I also made it report, since I want to know if this is actually happening and with what frequency on what devices.

-[Unknown]
