### PR TITLE
Act as if unreadable files don't exist

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -237,8 +237,12 @@ LocalFileLoader::~LocalFileLoader() {
 }
 
 bool LocalFileLoader::Exists() {
-	FileInfo info;
-	return getFileInfo(filename_.c_str(), &info);
+	// If we couldn't open it for reading, we say it does not exist.
+	if (f_) {
+		FileInfo info;
+		return getFileInfo(filename_.c_str(), &info);
+	}
+	return false;
 }
 
 bool LocalFileLoader::IsDirectory() {


### PR DESCRIPTION
This mainly affects Linux.  If a file cannot be opened for reading, we should just return false for Exists(), since that will prevent us from trying to read from the file later.

(a user reported a crash on Linux when running as non-root and the stack trace pointed here.)

-[Unknown]
