### PR TITLE
Read pending vertex data before exiting gpu loop

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -621,6 +621,11 @@ void DIRECTX9_GPU::FastRunLoop(DisplayList &list) {
 	}
 }
 
+void DIRECTX9_GPU::FinishDeferred() {
+	// This finishes reading any vertex data that is pending.
+	transformDraw_.FinishDeferred();
+}
+
 void DIRECTX9_GPU::ProcessEvent(GPUEvent ev) {
 	switch (ev.type) {
 	case GPU_EVENT_INIT_CLEAR:

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -144,9 +144,10 @@ public:
 	void Execute_BoneMtxData(u32 op, u32 diff);
 
 protected:
-	virtual void FastRunLoop(DisplayList &list);
-	virtual void ProcessEvent(GPUEvent ev);
-	virtual void FastLoadBoneMatrix(u32 target);
+	void FastRunLoop(DisplayList &list) override;
+	void ProcessEvent(GPUEvent ev) override;
+	void FastLoadBoneMatrix(u32 target) override;
+	void FinishDeferred() override;
 
 private:
 	void UpdateCmdInfo();

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -171,6 +171,12 @@ public:
 		DoFlush();
 	}
 
+	void FinishDeferred() {
+		if (!numDrawCalls)
+			return;
+		DecodeVerts();
+	}
+
 	bool IsCodePtrVertexDecoder(const u8 *ptr) const;
 
 protected:

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -705,6 +705,10 @@ void GLES_GPU::FastRunLoop(DisplayList &list) {
 	downcount = 0;
 }
 
+void GLES_GPU::FinishDeferred() {
+	// This finishes reading any vertex data that is pending.
+	transformDraw_.FinishDeferred();
+}
 
 void GLES_GPU::ProcessEvent(GPUEvent ev) {
 	switch (ev.type) {

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -146,9 +146,10 @@ public:
 	void Execute_BlockTransferStart(u32 op, u32 diff);
 
 protected:
-	virtual void FastRunLoop(DisplayList &list);
-	virtual void ProcessEvent(GPUEvent ev);
-	virtual void FastLoadBoneMatrix(u32 target);
+	void FastRunLoop(DisplayList &list) override;
+	void ProcessEvent(GPUEvent ev) override;
+	void FastLoadBoneMatrix(u32 target) override;
+	void FinishDeferred() override;
 
 private:
 	void Flush() {

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -174,6 +174,12 @@ public:
 		DoFlush();
 	}
 
+	void FinishDeferred() {
+		if (!numDrawCalls)
+			return;
+		DecodeVerts();
+	}
+
 	bool IsCodePtrVertexDecoder(const u8 *ptr) const;
 
 protected:

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -533,6 +533,8 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 		}
 	}
 
+	FinishDeferred();
+
 	// We haven't run the op at list.pc, so it shouldn't count.
 	if (cycleLastPC != list.pc) {
 		UpdatePC(list.pc - 4, list.pc);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -139,6 +139,8 @@ protected:
 	virtual bool ShouldExitEventLoop() {
 		return coreState != CORE_RUNNING;
 	}
+	virtual void FinishDeferred() {
+	}
 
 	// Allows early unlocking with a guard.  Do not double unlock.
 	class easy_guard {


### PR DESCRIPTION
Fixes save pictures in Crimson Gem Saga.

At a very basic level, the game is doing something along the lines of this:

``` c++
u16 vertices[(3 + 2) * 2];

vertices = pos_icon_1;
drawIconThenStall(tex_icon_1);

vertices = pos_icon_2;
drawIconThenStall(tex_icon_2);

vertices = pos_icon_3;
drawIconThenStall(tex_icon_3);
```

The issue is, there's nothing that causes us to flush before the stall.  By the time we realize it's time to flush (texture changes after the unstall), the game has already modified the vertex data.

This simply decodes the vertex data before returning from the stall.  I didn't want to do a full flush, since we might still be able to combine more verts after an unstall - I'm sure some game does this and would get terrible performance with a full flush.  However, just decoding verts should not be that expensive, and it effectively buffers them.

The game may actually be unstalling from an interrupt handler or something, because this even fixes it with multithreaded enabled.  I think the game is "behaving correctly" and not even sloppy here, though surely a few more bytes to just draw all the icons in one go wouldn't have broken the bank...

Fixes #7255.

-[Unknown]
