### PR TITLE
Move the viewport transform to the proj matrix

### DIFF
--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -345,6 +345,12 @@ static void SetMatrix4x3(int uniform, const float *m4x3) {
 	glUniformMatrix4fv(uniform, 1, GL_FALSE, m4x4);
 }
 
+static inline void ScaleProjMatrix(Matrix4x4 &in) {
+	const Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, 0.0f);
+	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, 1.0);
+	in.translateAndScale(trans, scale);
+}
+
 void LinkedShader::use(u32 vertType, LinkedShader *previous) {
 	glUseProgram(program);
 	UpdateUniforms(vertType);
@@ -379,13 +385,16 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 
 	// Update any dirty uniforms before we draw
 	if (dirty & DIRTY_PROJMATRIX) {
-		float flippedMatrix[16];
-		memcpy(flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
-		if (gstate_c.vpHeight < 0) {
+		Matrix4x4 flippedMatrix;
+		memcpy(&flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
+
+		const bool invertedY = gstate_c.vpHeight < 0;
+		if (invertedY) {
 			flippedMatrix[5] = -flippedMatrix[5];
 			flippedMatrix[13] = -flippedMatrix[13];
 		}
-		if (gstate_c.vpWidth < 0) {
+		const bool invertedX = gstate_c.vpWidth < 0;
+		if (invertedX) {
 			flippedMatrix[0] = -flippedMatrix[0];
 			flippedMatrix[12] = -flippedMatrix[12];
 		}
@@ -422,7 +431,9 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 			}
 		}
 
-		glUniformMatrix4fv(u_proj, 1, GL_FALSE, flippedMatrix);
+		ScaleProjMatrix(flippedMatrix);
+
+		glUniformMatrix4fv(u_proj, 1, GL_FALSE, flippedMatrix.m);
 	}
 	if (dirty & DIRTY_PROJTHROUGHMATRIX)
 	{


### PR DESCRIPTION
The viewport has an implementation defined maximum size.  On some devices, it's as low as 2048 or 4096.  See here:
http://feedback.wildfiregames.com/report/opengl/feature/GL_MAX_VIEWPORT_DIMS%5B0%5D

Also, here for a few mobile devices (just from quick googling):
http://delphigl.de/glcapsviewer/gles_generatereport.php?reportID=152 (Adreno 330 - 4096)
http://feedback.wildfiregames.com/report/opengl/device/Mali-400%20MP (Mali-500 - 4096)
http://opengl.delphigl.de/gl_generatereport.php?reportID=233 (PowerVR 545 - 2048)

Tales of Destiny 2, for example, uses a large viewport, which may be outside this range at 1x or 2x on such devices.  This makes it work much better.  It may also have better subpixel precision.

This quite possibly may be responsible for #5726 and #6232 (very likely.)  It could even fix PowerVR issues, if they were caused by the 2048 limit.

I didn't notice any performance impact, but I have not tested a ton of games yet, just a few that like to play games with viewports.

-[Unknown]
