### PR TITLE
Keep separate track of ffmpeg pos and decode pos

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -2185,8 +2185,8 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 		if (sourcebytes > 0) {
 			Memory::Memcpy(atrac->data_buf + atrac->first.size, sourceAddr, sourcebytes);
 			CBreakPoints::ExecMemCheck(sourceAddr, false, sourcebytes, currentMIPS->pc);
-			if (atrac->decodePos >= atrac->first.size) {
-				atrac->decodePos = atrac->first.size;
+			if (atrac->bufferPos >= atrac->first.size) {
+				atrac->bufferPos = atrac->first.size;
 			}
 			atrac->first.size += sourcebytes;
 		}
@@ -2222,7 +2222,7 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 		numSamples = (atrac->codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
 		Memory::Write_U32(numSamples * sizeof(s16) * atrac->atracOutputChannels, sampleBytesAddr);
 
-		if (atrac->decodePos >= atrac->first.size) {
+		if (atrac->bufferPos >= atrac->first.size) {
 			atrac->first.writableBytes = atrac->atracBytesPerFrame;
 			atrac->first.size = atrac->firstSampleoffset;
 			atrac->ForceSeekToSample(0);


### PR DESCRIPTION
FFmpeg buffers, so forcing the pos only makes FFmpeg read in garbage because it doesn't know that you seeked in the bytestream on it.

The code before was basically overwriting the seek pos after FFmpeg read it, and so when FFmpeg tried to continue reading, it ended up reading in a different place than it was aware of.  The old method of force seeking all the time (which causes early packets to get scrambled or something, so isn't good) "worked around" this problem because it made FFmpeg resend the seek position each time.

This might fix problems of bad data that existed before, when FFmpeg didn't decide to send the seek pos or otherwise got confused by its seek position getting mistreated.

Fixes #7633 and Grand Theft Auto.

-[Unknown]
