### PR TITLE
Ignore manifest files generated by MVSC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ ui_atlas_high.zim.png
 android/assets
 ext/_Output
 android/lint.xml
+PPSSPPWindows64.exe.manifest
+PPSSPPWindows.exe.manifest
+
 # For Mac
 .DS_Store
 


### PR DESCRIPTION
They are generated since PPSSPPP switch to static linking.
