### PR TITLE
sceIo: Remove always false condition

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1071,9 +1071,8 @@ static u32 npdrmLseek(FileNode *f, s32 where, FileMove whence)
 		newPos = f->pgdInfo->data_size+where;
 	}
 
-	if(newPos<0 || newPos>f->pgdInfo->data_size){
+	if (newPos > f->pgdInfo->data_size)
 		return -EINVAL;
-	}
 
 	f->pgdInfo->file_offset = newPos;
 	blockPos = newPos&~(f->pgdInfo->block_size-1);


### PR DESCRIPTION
newPos is unsigned, so a check against less than zero would never evaluate true.
