### PR TITLE
x86jit: Use ANDPS for abs.s

### DIFF
--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -271,7 +271,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		if (fd != fs) {
 			MOVSS(fpr.RX(fd), fpr.R(fs));
 		}
-		PAND(fpr.RX(fd), M(ssNoSignMask));
+		ANDPS(fpr.RX(fd), M(ssNoSignMask));
 		break;
 
 	case 6:	//F(fd)	= F(fs);				break; //mov


### PR DESCRIPTION
Should be faster considering they're likely to use other floating point math on it.  As long as that's the case, this is faster than PAND.

Micro optimization, of course.  67x vs 87x or so with add.s, abs.s, add.s, abs.s.

-[Unknown]
