### PR TITLE
More x86jit micro optimizations for the FPU

### DIFF
--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -47,6 +47,14 @@ namespace MIPSComp {
 using namespace Gen;
 using namespace X64JitConstants;
 
+void Jit::CopyFPReg(X64Reg dst, OpArg src) {
+	if (src.IsSimpleReg()) {
+		MOVAPS(dst, src);
+	} else {
+		MOVSS(dst, src);
+	}
+}
+
 void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpArg), bool orderMatters) {
 	int ft = _FT;
 	int fs = _FS;
@@ -62,14 +70,14 @@ void Jit::CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(X64Reg reg, OpAr
 	} else if (ft != fd) {
 		// fs can't be fd (handled above.)
 		fpr.MapReg(fd, false, true);
-		MOVSS(fpr.RX(fd), fpr.R(fs));
+		CopyFPReg(fpr.RX(fd), fpr.R(fs));
 		(this->*arith)(fpr.RX(fd), fpr.R(ft));
 	} else {
-		// fd must be ft.
+		// fd must be ft, and order must matter.
 		fpr.MapReg(fd, true, true);
-		MOVSS(XMM0, fpr.R(fs));
+		CopyFPReg(XMM0, fpr.R(fs));
 		(this->*arith)(XMM0, fpr.R(ft));
-		MOVSS(fpr.RX(fd), R(XMM0));
+		MOVAPS(fpr.RX(fd), R(XMM0));
 	}
 	fpr.ReleaseSpillLocks();
 }
@@ -151,14 +159,14 @@ void Jit::CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN) {
 
 	// This means that NaN also means true, e.g. !<> or !>, etc.
 	if (allowNaN) {
-		MOVSS(XMM0, fpr.R(lhs));
-		MOVSS(XMM1, fpr.R(lhs));
+		CopyFPReg(XMM0, fpr.R(lhs));
+		CopyFPReg(XMM1, fpr.R(lhs));
 		CMPSS(XMM0, fpr.R(rhs), compare);
 		CMPUNORDSS(XMM1, fpr.R(rhs));
 
 		POR(XMM0, R(XMM1));
 	} else {
-		MOVSS(XMM0, fpr.R(lhs));
+		CopyFPReg(XMM0, fpr.R(lhs));
 		CMPSS(XMM0, fpr.R(rhs), compare);
 	}
 
@@ -226,7 +234,8 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	int fd = _FD;
 
 	auto execRounding = [&](void (XEmitter::*conv)(X64Reg, OpArg), int setMXCSR) {
-		fpr.SpillLock(fs);
+		fpr.SpillLock(fd, fs);
+		fpr.MapReg(fd, fs == fd, true);
 
 		// Small optimization: 0 is our default mode anyway.
 		if (setMXCSR == 0 && !js.hasSetRounding) {
@@ -268,32 +277,42 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 5:	//F(fd)	= fabsf(F(fs)); break; //abs
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
-		if (fd != fs) {
-			MOVSS(fpr.RX(fd), fpr.R(fs));
+		if (fd != fs && fpr.IsMapped(fs)) {
+			MOVAPS(fpr.RX(fd), M(ssNoSignMask));
+			ANDPS(fpr.RX(fd), fpr.R(fs));
+		} else {
+			if (fd != fs) {
+				MOVSS(fpr.RX(fd), fpr.R(fs));
+			}
+			ANDPS(fpr.RX(fd), M(ssNoSignMask));
 		}
-		ANDPS(fpr.RX(fd), M(ssNoSignMask));
 		break;
 
 	case 6:	//F(fd)	= F(fs);				break; //mov
 		if (fd != fs) {
 			fpr.SpillLock(fd, fs);
 			fpr.MapReg(fd, fd == fs, true);
-			MOVSS(fpr.RX(fd), fpr.R(fs));
+			CopyFPReg(fpr.RX(fd), fpr.R(fs));
 		}
 		break;
 
 	case 7:	//F(fd)	= -F(fs);			 break; //neg
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
-		if (fd != fs) {
-			MOVSS(fpr.RX(fd), fpr.R(fs));
+		if (fd != fs && fpr.IsMapped(fs)) {
+			MOVAPS(fpr.RX(fd), M(ssSignBits2));
+			XORPS(fpr.RX(fd), fpr.R(fs));
+		} else {
+			if (fd != fs) {
+				MOVSS(fpr.RX(fd), fpr.R(fs));
+			}
+			XORPS(fpr.RX(fd), M(ssSignBits2));
 		}
-		XORPS(fpr.RX(fd), M(ssSignBits2));
 		break;
 
 
 	case 4:	//F(fd)	= sqrtf(F(fs)); break; //sqrt
-		fpr.SpillLock(fd, fs); // this probably works, just badly tested
+		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
 		SQRTSS(fpr.RX(fd), fpr.R(fs));
 		break;
@@ -305,7 +324,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 32: //F(fd)	= (float)FsI(fs);			break; //cvt.s.w
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fs == fd, true);
-		if (fpr.R(fs).IsSimpleReg()) {
+		if (fpr.IsMapped(fs)) {
 			CVTDQ2PS(fpr.RX(fd), fpr.R(fs));
 		} else {
 			// If fs was fd, we'd be in the case above since we mapped fd.

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -239,7 +239,6 @@ void Jit::Comp_SV(MIPSOpcode op) {
 	case 50: //lv.s  // VI(vt) = Memory::Read_U32(addr);
 		{
 			gpr.Lock(rs);
-			gpr.MapReg(rs, true, false);
 			fpr.MapRegV(vt, MAP_DIRTY | MAP_NOINIT);
 
 			JitSafeMem safe(this, rs, imm);
@@ -263,9 +262,7 @@ void Jit::Comp_SV(MIPSOpcode op) {
 	case 58: //sv.s   // Memory::Write_U32(VI(vt), addr);
 		{
 			gpr.Lock(rs);
-			gpr.MapReg(rs, true, false);
 
-			// Even if we don't use real SIMD there's still 8 or 16 scalar float registers.
 			fpr.MapRegV(vt, 0);
 
 			JitSafeMem safe(this, rs, imm);
@@ -380,7 +377,6 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 	case 54: //lv.q
 		{
 			gpr.Lock(rs);
-			gpr.MapReg(rs, true, false);
 	
 			u8 vregs[4];
 			GetVectorRegs(vregs, V_Quad, vt);
@@ -429,7 +425,6 @@ void Jit::Comp_SVQ(MIPSOpcode op)
 	case 62: //sv.q
 		{
 			gpr.Lock(rs);
-			gpr.MapReg(rs, true, false);
 
 			u8 vregs[4];
 			GetVectorRegs(vregs, V_Quad, vt);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -238,6 +238,7 @@ private:
 	static Gen::CCFlags FlipCCFlag(Gen::CCFlags flag);
 	static Gen::CCFlags SwapCCFlag(Gen::CCFlags flag);
 
+	void CopyFPReg(Gen::X64Reg dst, Gen::OpArg src);
 	void CompFPTriArith(MIPSOpcode op, void (XEmitter::*arith)(Gen::X64Reg reg, Gen::OpArg), bool orderMatters);
 	void CompFPComp(int lhs, int rhs, u8 compare, bool allowNaN = false);
 	void CompVrotShuffle(u8 *dregs, int imm, int n, bool negSin);


### PR DESCRIPTION
Tested on an Ivy, it makes sense that MOVAPS reg, reg would be faster though.

Also, fixed a performance issue with lv.q/sv.q on immediate known addresses when in safe mode (3x interp -> 35x interp.)  Not sure these are super common, but it still makes sense to use the same path as the other load/stores.

Also enabled SIMD with fast off.

-[Unknown]
