### PR TITLE
Add a bit of a hack for smaller framebuf memcpys

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -486,6 +486,11 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 				srcBuffer = vfb;
 				srcY = yOffset;
 				srcH = size == vfb_byteWidth ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
+			} else if ((offset % vfb_byteStride) == 0 && size == vfb->fb_stride && yOffset < srcY) {
+				// Valkyrie Profile reads 512 bytes at a time, rather than 2048.  So, let's whitelist fb_stride also.
+				srcBuffer = vfb;
+				srcY = yOffset;
+				srcH = 1;
 			}
 		}
 	}


### PR DESCRIPTION
In Valkyrie Profile, some framebuf data is downloaded in chunks of 512 bytes.  We were rejecting this (misaligned copy, which might mean a copy of texture data outside the framebuf), so the effect was missing.

The effect is pretty common though, it's the blur that happens whenever you enter a battle.

Anyway, this causes a download when the first stride bytes of a line is read.  The other three reads of the line won't trigger a download, but we download full lines anyway.  I wish we knew the whole height ahead of time.

Hopefully this doesn't false-positive in any other games.  I'm a bit worried that it's more likely to affect texture data right after a framebuffer we've mis-detected the height of.  At first I added the same change for upload, but decided better of it for this reason (texture uploads.)

-[Unknown]
