### PR TITLE
Replace framebuffer download in Youkoso Hitsuji-Mura Portable

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1014,6 +1014,15 @@ static int Hook_gakuenheaven_download_frame() {
 	return 0;
 }
 
+static int Hook_youkosohitsujimura_download_frame() {
+	const u32 fb_address = currentMIPS->r[MIPS_REG_V0];
+	if (Memory::IsVRAMAddress(fb_address)) {
+		gpu->PerformMemoryDownload(fb_address, 0x00088000);
+		CBreakPoints::ExecMemCheck(fb_address, true, 0x00088000, currentMIPS->pc);
+}
+	return 0;
+}
+
 #ifdef ARM
 #define JITFUNC(f) (&MIPSComp::ArmJit::f)
 #elif defined(ARM64)
@@ -1106,6 +1115,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "photokano_download_frame", &Hook_photokano_download_frame, 0, REPFLAG_HOOKENTER, 0x2C },
 	{ "photokano_download_frame_2", &Hook_photokano_download_frame_2, 0, REPFLAG_HOOKENTER, },
 	{ "gakuenheaven_download_frame", &Hook_gakuenheaven_download_frame, 0, REPFLAG_HOOKENTER, },
+	{ "youkosohitsujimura_download_frame", &Hook_youkosohitsujimura_download_frame, 0, REPFLAG_HOOKENTER, 0x94 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -96,6 +96,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x073cf0b61d3b875a, 416, "hexyzforce_monoclome_thread", }, // Hexyz Force (US)
 	{ 0x075fa9b234b41e9b, 32, "fmodf", },
 	{ 0x0a051019bdd786c3, 184, "strcasecmp", },
+	{ 0x0a1bed70958935d2, 644, "youkosohitsujimura_download_frame", }, // Youkoso Hitsuji-Mura Portable
 	{ 0x0a46dc426054bb9d, 24, "vector_add_t", },
 	{ 0x0c0173ed70f84f66, 48, "vnormalize_t", },
 	{ 0x0c65188f5bfb3915, 24, "vsgn_q", },


### PR DESCRIPTION
Fixes transition screen in Youkoso Hitsuji-Mura Portable.

The replaced function
https://cloud.githubusercontent.com/assets/3481559/7226458/7d436c34-e77b-11e4-848a-934726dff03a.png
