### PR TITLE
Fix some issues in sceNetAdhoc with old savestates

### DIFF
--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -330,6 +330,11 @@ void BlockAllocator::CheckBlocks() const
 	}
 }
 
+const char *BlockAllocator::GetBlockTag(u32 addr) const {
+	const Block *b = GetBlockFromAddress(addr);
+	return b->tag;
+}
+
 inline BlockAllocator::Block *BlockAllocator::GetBlockFromAddress(u32 addr)
 {
 	for (Block *bp = bottom_; bp != NULL; bp = bp->next)

--- a/Core/Util/BlockAllocator.h
+++ b/Core/Util/BlockAllocator.h
@@ -54,6 +54,8 @@ public:
 	u32 GetLargestFreeBlockSize() const;
 	u32 GetTotalFreeBytes() const;
 
+	const char *GetBlockTag(u32 addr) const;
+
 	void DoState(PointerWrap &p);
 
 private:


### PR DESCRIPTION
This was causing the PPGe dlist to be shared with the thread, causing weirdness and a double-free on exit.

-[Unknown]
