### PR TITLE
Use UIContext::DrawTextShadow instead of DrawBuffer::DrawTextShadow

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -428,13 +428,13 @@ void LogoScreen::render() {
 #endif
 	dc.Draw()->DrawImage(I_LOGO, bounds.centerX() + 40, bounds.centerY() - 30, 1.5f, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
 	//dc.Draw()->DrawTextShadow(UBUNTU48, "PPSSPP", xres / 2, yres / 2 - 30, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
-	dc.Draw()->SetFontScale(1.0f, 1.0f);
+	dc.SetFontScale(1.0f, 1.0f);
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawText(temp, bounds.centerX(), bounds.centerY() + 40, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
 	dc.DrawText(c->T("license", "Free Software under GPL 2.0"), bounds.centerX(), bounds.centerY() + 70, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
 	dc.DrawText("www.ppsspp.org", bounds.centerX(), yres / 2 + 130, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
 	if (boot_filename.size()) {
-		ui_draw2d.DrawTextShadow(UBUNTU24, boot_filename.c_str(), bounds.centerX(), bounds.centerY() + 180, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
+		dc.DrawTextShadow(boot_filename.c_str(), bounds.centerX(), bounds.centerY() + 180, colorAlpha(0xFFFFFFFF, alphaText), ALIGN_CENTER);
 	}
 
 #ifdef _WIN32

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -16,7 +16,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 
 	// Get height
 	float w, h;
-	dc.Draw()->MeasureText(UBUNTU24, "Wg", &w, &h);
+	dc.MeasureText(dc.theme->uiFont, "Wg", &w, &h);
 
 	float y = 10.0f;
 	// Then draw them all. 
@@ -27,14 +27,15 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 		if (alpha < 0.0) alpha = 0.0f;
 		// Messages that are wider than the screen are left-aligned instead of centered.
 		float tw, th;
-		dc.Draw()->MeasureText(UBUNTU24, iter->text.c_str(), &tw, &th);
+		dc.MeasureText(dc.theme->uiFont, iter->text.c_str(), &tw, &th);
 		float x = bounds_.centerX();
 		int align = ALIGN_TOP | ALIGN_HCENTER;
 		if (tw > bounds_.w) {
 			align = ALIGN_TOP | ALIGN_LEFT;
 			x = 2;
 		}
-		dc.Draw()->DrawTextShadow(UBUNTU24, iter->text.c_str(), x, y, colorAlpha(iter->color, alpha), align);
+		dc.SetFontStyle(dc.theme->uiFont);
+		dc.DrawTextShadow(iter->text.c_str(), x, y, colorAlpha(iter->color, alpha), align);
 		y += h;
 	}
 


### PR DESCRIPTION
In Qt, DrawBuffer::DrawTextShadow and DrawBuffer::DrawText draws '?' instead of requested character if the character is not in ascii.
The DrawBuffer::DrawText has already been replaced by UIContext::DrawText, but the UIContext::DrawTextShadow is missing. This results OSM to display '?????' instead of the correct string.

Depends on hrydgard/native#269
