### PR TITLE
Frame profiler overlay

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -761,6 +761,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	INFO_LOG(LOADER, "Loading config: %s", iniFilename_.c_str());
 	bSaveSettings = true;
 
+	bShowFrameProfiler = true;
 
 	IniFile iniFile;
 	if (!iniFile.Load(iniFilename_)) {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -374,6 +374,9 @@ public:
 	bool bSkipDeadbeefFilling;
 	bool bFuncHashMap;
 
+	// Volatile development settings
+	bool bShowFrameProfiler;
+
 	std::string currentDirectory;
 	std::string externalDirectory; 
 	std::string memStickDirectory;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -180,7 +180,6 @@ void GPU_SwapBuffers() {
 		D3D9_SwapBuffers();
 		break;
 	}
-	PROFILE_END_FRAME();
 }
 
 #endif

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -22,6 +22,7 @@
 #include "base/mutex.h"
 #include "base/timeutil.h"
 #include "input/input_state.h"
+#include "profiler/profiler.h"
 
 #include "Core/Core.h"
 #include "Core/Config.h"
@@ -179,6 +180,7 @@ void GPU_SwapBuffers() {
 		D3D9_SwapBuffers();
 		break;
 	}
+	PROFILE_END_FRAME();
 }
 
 #endif

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -20,6 +20,8 @@
 
 #include "native/thread/thread.h"
 #include "native/thread/threadutil.h"
+#include "profiler/profiler.h"
+
 #include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/Debugger/Breakpoints.h"
@@ -760,6 +762,7 @@ static u32 npdrmRead(FileNode *f, u8 *data, int size) {
 }
 
 static bool __IoRead(int &result, int id, u32 data_addr, int size, int &us) {
+	PROFILE_THIS_SCOPE("ioread");
 	// Low estimate, may be improved later from the ReadFile result.
 	us = size / 100;
 	if (us < 100) {

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -16,6 +16,8 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "base/basictypes.h"
+#include "profiler/profiler.h"
+
 #include "Globals.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/HLE/sceAtrac.h"
@@ -525,6 +527,8 @@ void SasInstance::MixVoice(SasVoice &voice) {
 }
 
 void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
+	PROFILE_THIS_SCOPE("mixer");
+
 	int voicesPlayingCount = 0;
 
 	for (int v = 0; v < PSP_SAS_VOICES_MAX; v++) {

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -134,7 +134,6 @@ VirtualFramebuffer *FramebufferManagerCommon::GetVFBAt(u32 addr) {
 		return match;
 	}
 
-	DEBUG_LOG(SCEGE, "Finding no FBO matching address %08x", addr);
 	return 0;
 }
 

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <algorithm>
 
+#include "profiler/profiler.h"
+
 #include "Common/CPUDetect.h"
 #include "Core/Config.h"
 
@@ -752,6 +754,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 const GEPrimitiveType primType[] = { GE_PRIM_TRIANGLES, GE_PRIM_LINES, GE_PRIM_POINTS };
 
 void DrawEngineCommon::SubmitSpline(const void *control_points, const void *indices, int count_u, int count_v, int type_u, int type_v, GEPatchPrimType prim_type, u32 vertType) {
+	PROFILE_THIS_SCOPE("spline");
 	DispatchFlush();
 
 	// TODO: Verify correct functionality with < 4.
@@ -830,6 +833,8 @@ void DrawEngineCommon::SubmitSpline(const void *control_points, const void *indi
 }
 
 void DrawEngineCommon::SubmitBezier(const void *control_points, const void *indices, int count_u, int count_v, GEPatchPrimType prim_type, u32 vertType) {
+	PROFILE_THIS_SCOPE("bezier");
+
 	DispatchFlush();
 
 	// TODO: Verify correct functionality with < 4.

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -19,6 +19,7 @@
 
 #include "Common/ChunkFile.h"
 #include "base/logging.h"
+#include "profiler/profiler.h"
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/MIPS/MIPS.h"
@@ -601,6 +602,7 @@ void DIRECTX9_GPU::CopyDisplayToOutputInternal() {
 
 // Maybe should write this in ASM...
 void DIRECTX9_GPU::FastRunLoop(DisplayList &list) {
+	PROFILE_THIS_SCOPE("gpuloop");
 	const CommandInfo *cmdInfo = cmdInfo_;
 	for (; downcount > 0; --downcount) {
 		// We know that display list PCs have the upper nibble == 0 - no need to mask the pointer

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -682,6 +682,7 @@ void GLES_GPU::CopyDisplayToOutputInternal() {
 
 // Maybe should write this in ASM...
 void GLES_GPU::FastRunLoop(DisplayList &list) {
+	PROFILE_THIS_SCOPE("gpuloop");
 	const CommandInfo *cmdInfo = cmdInfo_;
 	int dc = downcount;
 	for (; dc > 0; --dc) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -17,6 +17,7 @@
 
 #include "base/logging.h"
 #include "gfx_es2/gl_state.h"
+#include "profiler/profiler.h"
 
 #include "Common/ChunkFile.h"
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -29,6 +29,7 @@
 #include "math/math_util.h"
 #include "gfx_es2/gl_state.h"
 #include "math/lin/matrix4x4.h"
+#include "profiler/profiler.h"
 
 #include "Core/Config.h"
 #include "Core/Reporting.h"
@@ -42,6 +43,7 @@
 #include "i18n/i18n.h"
 
 Shader::Shader(const char *code, uint32_t shaderType, bool useHWTransform, const ShaderID &shaderID) : failed_(false), useHWTransform_(useHWTransform), id_(shaderID) {
+	PROFILE_THIS_SCOPE("shadercomp");
 	source_ = code;
 #ifdef SHADERLOG
 	OutputDebugStringUTF8(code);
@@ -82,6 +84,8 @@ Shader::~Shader() {
 
 LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTransform, LinkedShader *previous)
 		: useHWTransform_(useHWTransform), program(0), dirtyUniforms(0) {
+	PROFILE_THIS_SCOPE("shaderlink");
+
 	program = glCreateProgram();
 	vs_ = vs;
 	glAttachShader(program, vs->shader);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -569,7 +569,6 @@ void TransformDrawEngine::ApplyBlendState() {
 }
 
 void TransformDrawEngine::ApplyDrawState(int prim) {
-	PROFILE_THIS_SCOPE("applydrawstate");
 
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
@@ -582,6 +581,9 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			shaderManager_->DirtyUniform(DIRTY_TEXCLAMP);
 		}
 	}
+
+	// Start profiling here to skip SetTexture which is already accounted for
+	PROFILE_THIS_SCOPE("applydrawstate");
 
 	// Set blend - unless we need to do it in the shader.
 	ApplyBlendState();

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -21,7 +21,8 @@
 
 
 #include "StateMapping.h"
-#include "native/gfx_es2/gl_state.h"
+#include "gfx_es2/gl_state.h"
+#include "profiler/profiler.h"
 
 #include "GPU/Math3D.h"
 #include "GPU/GPUState.h"
@@ -568,6 +569,8 @@ void TransformDrawEngine::ApplyBlendState() {
 }
 
 void TransformDrawEngine::ApplyDrawState(int prim) {
+	PROFILE_THIS_SCOPE("applydrawstate");
+
 	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
 
 	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <cstring>
 
+#include "profiler/profiler.h"
+
 #include "Common/ColorConv.h"
 #include "Core/Host.h"
 #include "Core/MemMap.h"
@@ -1116,6 +1118,7 @@ bool TextureCache::SetOffsetTexture(u32 offset) {
 }
 
 void TextureCache::SetTexture(bool force) {
+	PROFILE_THIS_SCOPE("settexture");
 #ifdef DEBUG_TEXTURES
 	if (SetDebugTexture()) {
 		// A different texture was bound, let's rebind next time.

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1118,7 +1118,6 @@ bool TextureCache::SetOffsetTexture(u32 offset) {
 }
 
 void TextureCache::SetTexture(bool force) {
-	PROFILE_THIS_SCOPE("settexture");
 #ifdef DEBUG_TEXTURES
 	if (SetDebugTexture()) {
 		// A different texture was bound, let's rebind next time.
@@ -1894,6 +1893,8 @@ TextureCache::TexCacheEntry::Status TextureCache::CheckAlpha(const u32 *pixelDat
 }
 
 void TextureCache::LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, int scaleFactor, GLenum dstFmt) {
+	PROFILE_THIS_SCOPE("loadtex");
+
 	// TODO: only do this once
 	u32 texByteAlign = 1;
 

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -72,7 +72,8 @@
 #include "Core/Config.h"
 #include "Core/CoreTiming.h"
 
-#include "native/gfx_es2/gl_state.h"
+#include "gfx_es2/gl_state.h"
+#include "profiler/profiler.h"
 
 #include "GPU/Math3D.h"
 #include "GPU/GPUState.h"
@@ -334,6 +335,8 @@ void TransformDrawEngine::DecodeVerts() {
 }
 
 void TransformDrawEngine::DecodeVertsStep() {
+	PROFILE_THIS_SCOPE("vertdec");
+
 	const int i = decodeCounter_;
 
 	const DeferredDrawCall &dc = drawCalls[i];

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -691,7 +691,7 @@ void GPUCommon::ProcessDLQueueInternal() {
 
 	for (int listIndex = GetNextListIndex(); listIndex != -1; listIndex = GetNextListIndex()) {
 		DisplayList &l = dls[listIndex];
-		DEBUG_LOG(G3D, "Okay, starting DL execution at %08x - stall = %08x", l.pc, l.stall);
+		DEBUG_LOG(G3D, "Starting DL execution at %08x - stall = %08x", l.pc, l.stall);
 		if (!InterpretList(l)) {
 			return;
 		} else {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -781,6 +781,17 @@ UI::EventReturn JitCompareScreen::OnCurrentBlock(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
+static const uint32_t nice_colors[8] = {
+	0xFF8040,
+	0x80FF40,
+	0x8040FF,
+	0xFFFF40,
+	0x40FFFF,
+	0xFF40FF,
+	0xc0c0c0,
+	0x8040c0,
+};
+
 void DrawProfile(UIContext &ui) {
 #ifdef USE_PROFILER
 	int numCategories = Profiler_GetNumCategories();
@@ -790,13 +801,14 @@ void DrawProfile(UIContext &ui) {
 	float legendStartX = ui.GetBounds().x2() - 100;
 
 	float rowH = 30;
+	const uint32_t opacity = 140 << 24;
 
 	for (int i = 0; i < numCategories; i++) {
 		const char *name = Profiler_GetCategoryName(i);
-		uint32_t color = Profiler_GetCategoryColor(i);
+		uint32_t color = nice_colors[i % ARRAY_SIZE(nice_colors)];
 
 		float y = legendStartY + i * rowH;
-		ui.FillRect(UI::Drawable(color), Bounds(legendStartX, y, rowH - 2, rowH - 2));
+		ui.FillRect(UI::Drawable(opacity | color), Bounds(legendStartX, y, rowH - 2, rowH - 2));
 		ui.DrawTextShadow(name, legendStartX + rowH + 2, y, 0xFFFFFFFF, ALIGN_VBASELINE);
 	}
 
@@ -840,9 +852,9 @@ void DrawProfile(UIContext &ui) {
 		Profiler_GetHistory(i, &history[0], historyLength);
 
 		float x = 10;
-		uint32_t col = Profiler_GetCategoryColor(i);
+		uint32_t col = nice_colors[i % ARRAY_SIZE(nice_colors)];
 		if (area)
-			col &= 0x7FFFFFFF;
+			col = opacity | (col & 0xFFFFFF);
 		UI::Drawable color(col);
 
 		if (area) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -797,8 +797,18 @@ void DrawProfile(UIContext &ui) {
 	int numCategories = Profiler_GetNumCategories();
 	int historyLength = Profiler_GetHistoryLength();
 
+	float legendWidth = 100.0f;
+	for (int i = 0; i < numCategories; i++) {
+		const char *name = Profiler_GetCategoryName(i);
+		float w = 0.0f, h = 0.0f;
+		ui.MeasureText(ui.GetFontStyle(), name, &w, &h);
+		if (w > legendWidth) {
+			legendWidth = w;
+		}
+	}
+
 	float legendStartY = ui.GetBounds().centerY();
-	float legendStartX = ui.GetBounds().x2() - 100;
+	float legendStartX = ui.GetBounds().x2() - std::min(legendWidth, 200.0f);
 
 	float rowH = 30;
 	const uint32_t opacity = 140 << 24;

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -141,3 +141,6 @@ private:
 	UI::LinearLayout *leftDisasm_;	
 	UI::LinearLayout *rightDisasm_;	
 };
+
+
+void DrawProfile(UIContext &ui);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -21,6 +21,7 @@
 #include "base/display.h"
 #include "base/logging.h"
 #include "base/timeutil.h"
+#include "profiler/profiler.h"
 
 #include "gfx_es2/glsl_program.h"
 #include "gfx_es2/gl_state.h"
@@ -908,9 +909,11 @@ void EmuScreen::render() {
 			DrawFPS(draw2d, screenManager()->getUIContext()->GetBounds());
 		}
 
+#ifdef USE_PROFILER
 		if (g_Config.bShowFrameProfiler) {
-			// DrawProfile(*screenManager()->getUIContext());
+			DrawProfile(*screenManager()->getUIContext());
 		}
+#endif
 
 		screenManager()->getUIContext()->End();
 	}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -874,7 +874,7 @@ void EmuScreen::render() {
 	if (useBufferedRendering && g_Config.iGPUBackend == GPU_BACKEND_OPENGL)
 		fbo_unbind();
 
-	if (!osm.IsEmpty() || g_Config.bShowDebugStats || g_Config.iShowFPSCounter || g_Config.bShowTouchControls || g_Config.bShowDeveloperMenu || g_Config.bShowAudioDebug || saveStatePreview_->GetVisibility() != UI::V_GONE) {
+	if (!osm.IsEmpty() || g_Config.bShowDebugStats || g_Config.iShowFPSCounter || g_Config.bShowTouchControls || g_Config.bShowDeveloperMenu || g_Config.bShowAudioDebug || saveStatePreview_->GetVisibility() != UI::V_GONE || g_Config.bShowFrameProfiler) {
 		Thin3DContext *thin3d = screenManager()->getThin3DContext();
 
 		// This sets up some important states but not the viewport.
@@ -906,6 +906,10 @@ void EmuScreen::render() {
 
 		if (g_Config.iShowFPSCounter) {
 			DrawFPS(draw2d, screenManager()->getUIContext()->GetBounds());
+		}
+
+		if (g_Config.bShowFrameProfiler) {
+			// DrawProfile(*screenManager()->getUIContext());
 		}
 
 		screenManager()->getUIContext()->End();

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -397,9 +397,12 @@ void InitPadLayout(float xres, float yres, float globalScale) {
 		g_Config.fUnthrottleKeyScale = scale;
 	}
 
-	//L and R------------------------------------------------------------
-	int l_key_X = 70 * scale;
-	int l_key_Y = 40 * scale;
+	// L and R------------------------------------------------------------
+	// Put them above the analog stick / above the buttons to the right.
+	// The corners were very hard to reach..
+
+	int l_key_X = 60 * scale;
+	int l_key_Y = yres - 110 * scale;
 
 	if (g_Config.fLKeyX == -1.0 || g_Config.fLKeyY == -1.0 ) {
 		g_Config.fLKeyX = (float)l_key_X / xres;
@@ -408,7 +411,7 @@ void InitPadLayout(float xres, float yres, float globalScale) {
 	}
 
 	int r_key_X = xres - 60 * scale;
-	int r_key_Y = 40 * scale;
+	int r_key_Y = yres - 110 * scale;
 
 	if (g_Config.fRKeyX == -1.0 || g_Config.fRKeyY == -1.0 ) {
 		g_Config.fRKeyX = (float)r_key_X / xres;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -48,7 +48,6 @@
 #include "file/zip_read.h"
 #include "thread/thread.h"
 #include "net/http_client.h"
-#include "gfx_es2/gl_state.h"  // should've been only for screenshot - but actually not, cleanup?
 #include "gfx_es2/draw_text.h"
 #include "gfx/gl_lost_manager.h"
 #include "gfx/texture.h"
@@ -57,6 +56,7 @@
 #include "math/fast/fast_math.h"
 #include "math/math_util.h"
 #include "math/lin/matrix4x4.h"
+#include "profiler/profiler.h"
 #include "thin3d/thin3d.h"
 #include "ui/ui.h"
 #include "ui/screen.h"
@@ -762,6 +762,8 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 }
 
 void NativeUpdate(InputState &input) {
+	PROFILE_END_FRAME();
+
 	{
 		lock_guard lock(pendingMutex);
 		for (size_t i = 0; i < pendingMessages.size(); i++) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -48,6 +48,7 @@
 #include "file/zip_read.h"
 #include "thread/thread.h"
 #include "net/http_client.h"
+#include "gfx_es2/gl_state.h"  // TODO: Get rid of this from here
 #include "gfx_es2/draw_text.h"
 #include "gfx/gl_lost_manager.h"
 #include "gfx/texture.h"

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -24,6 +24,7 @@
 #include "file/vfs.h"
 #include "file/zip_read.h"
 #include "base/NativeApp.h"
+#include "profiler/profiler.h"
 #include "thread/threadutil.h"
 #include "util/text/utf8.h"
 
@@ -342,6 +343,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	CoInitializeEx(NULL, COINIT_MULTITHREADED);
 
+	PROFILE_INIT();
 
 	// FMA3 support in the 2013 CRT is broken on Vista and Windows 7 RTM (fixed in SP1). Just disable it.
 #ifdef _M_X64


### PR DESCRIPTION
Initial work on a simple frame profiler overlay.

![overlay](https://cloud.githubusercontent.com/assets/130929/7621331/4de0ed60-f9c6-11e4-8589-e4972c3e4abc.jpg)

Biggest finding so far is just how slow texture decoding/loading is. It's really, really spiky in these charts, although not very visible in the screenshot above.

Turn it on by setting USE_PROFILER in profiler/profiler.h in native.
