### PR TITLE
Use NEON for GL texture color conversion

### DIFF
--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -559,7 +559,7 @@ void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixel
 	}
 }
 
-void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels) {
+void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, const u32 numPixels) {
 #ifdef _M_SSE
 	const __m128i maskG = _mm_set1_epi16(0x07E0);
 
@@ -602,12 +602,14 @@ void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels) {
 
 #ifndef ConvertRGBA5551ToABGR1555
 Convert16bppTo16bppFunc ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555Basic;
+Convert16bppTo16bppFunc ConvertRGB565ToBGR565 = &ConvertRGB565ToBGR565Basic;
 #endif
 
 void SetupColorConv() {
 #if defined(HAVE_ARMV7) && !defined(ARM64)
 	if (cpu_info.bNEON) {
 		ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555NEON;
+		ConvertRGB565ToBGR565 = &ConvertRGB565ToBGR565NEON;
 	}
 #endif
 }

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -469,10 +469,9 @@ void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels) {
 	}
 }
 
-void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels) {
+void ConvertRGBA4444ToABGR4444Basic(u16 *dst, const u16 *src, const u32 numPixels) {
 #ifdef _M_SSE
-	const __m128i maskB = _mm_set1_epi16(0x00F0);
-	const __m128i maskG = _mm_set1_epi16(0x0F00);
+	const __m128i mask0040 = _mm_set1_epi16(0x00F0);
 
 	const __m128i *srcp = (const __m128i *)src;
 	__m128i *dstp = (__m128i *)dst;
@@ -483,8 +482,8 @@ void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels) {
 	for (u32 i = 0; i < sseChunks; ++i) {
 		const __m128i c = _mm_load_si128(&srcp[i]);
 		__m128i v = _mm_srli_epi16(c, 12);
-		v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi16(c, 4), maskB));
-		v = _mm_or_si128(v, _mm_and_si128(_mm_slli_epi16(c, 4), maskG));
+		v = _mm_or_si128(v, _mm_and_si128(_mm_srli_epi16(c, 4), mask0040));
+		v = _mm_or_si128(v, _mm_slli_epi16(_mm_and_si128(c, mask0040), 4));
 		v = _mm_or_si128(v, _mm_slli_epi16(c, 12));
 		_mm_store_si128(&dstp[i], v);
 	}
@@ -600,7 +599,9 @@ void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, const u32 numPixels) {
 	}
 }
 
-#ifndef ConvertRGBA5551ToABGR1555
+// Reuse the logic from the header - if these aren't defined, we need externs.
+#ifndef ConvertRGBA4444ToABGR4444
+Convert16bppTo16bppFunc ConvertRGBA4444ToABGR4444 = &ConvertRGBA4444ToABGR4444Basic;
 Convert16bppTo16bppFunc ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555Basic;
 Convert16bppTo16bppFunc ConvertRGB565ToBGR565 = &ConvertRGB565ToBGR565Basic;
 #endif
@@ -608,6 +609,7 @@ Convert16bppTo16bppFunc ConvertRGB565ToBGR565 = &ConvertRGB565ToBGR565Basic;
 void SetupColorConv() {
 #if defined(HAVE_ARMV7) && !defined(ARM64)
 	if (cpu_info.bNEON) {
+		ConvertRGBA4444ToABGR4444 = &ConvertRGBA4444ToABGR4444NEON;
 		ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555NEON;
 		ConvertRGB565ToBGR565 = &ConvertRGB565ToBGR565NEON;
 	}

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -514,7 +514,7 @@ void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels) {
 	}
 }
 
-void ConvertRGBA5551ToABGR1555(u16 *dst, const u16 *src, const u32 numPixels) {
+void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixels) {
 #ifdef _M_SSE
 	const __m128i maskB = _mm_set1_epi16(0x003E);
 	const __m128i maskG = _mm_set1_epi16(0x07C0);
@@ -598,4 +598,16 @@ void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels) {
 		         ((c >> 0)  & 0x07E0) |
 		         ((c << 11) & 0xF800);
 	}
+}
+
+#ifndef ConvertRGBA5551ToABGR1555
+Convert16bppTo16bppFunc ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555Basic;
+#endif
+
+void SetupColorConv() {
+#if defined(HAVE_ARMV7) && !defined(ARM64)
+	if (cpu_info.bNEON) {
+		ConvertRGBA5551ToABGR1555 = &ConvertRGBA5551ToABGR1555NEON;
+	}
+#endif
 }

--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -130,9 +130,17 @@ void ConvertBGRA4444ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 void ConvertBGRA5551ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 
-void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGBA4444ToABGR4444Basic(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, const u32 numPixels);
+
+#if defined(ARM64)
+#define ConvertRGBA4444ToABGR4444 ConvertRGBA4444ToABGR4444NEON
+#elif !defined(ARM)
+#define ConvertRGBA4444ToABGR4444 ConvertRGBA4444ToABGR4444Basic
+#else
+extern Convert16bppTo16bppFunc ConvertRGBA4444ToABGR4444;
+#endif
 
 #if defined(ARM64)
 #define ConvertRGBA5551ToABGR1555 ConvertRGBA5551ToABGR1555NEON

--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -15,10 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-
 #pragma once
 
 #include "CommonTypes.h"
+#include "ColorConvNEON.h"
+
+void SetupColorConv();
 
 inline u8 Convert4To8(u8 v) {
 	// Swizzle bits: 00001234 -> 12341234
@@ -104,6 +106,11 @@ void convert5551_dx9(u16* data, u32* out, int width, int l, int u);
 
 // "Complete" set of color conversion functions between the usual formats.
 
+typedef void (*Convert16bppTo16bppFunc)(u16 *dst, const u16 *src, const u32 numPixels);
+typedef void (*Convert16bppTo32bppFunc)(u32 *dst, const u16 *src, const u32 numPixels);
+typedef void (*Convert32bppTo16bppFunc)(u16 *dst, const u32 *src, const u32 numPixels);
+typedef void (*Convert32bppTo32bppFunc)(u32 *dst, const u32 *src, const u32 numPixels);
+
 void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, const u32 numPixels);
 #define ConvertRGBA8888ToBGRA8888 ConvertBGRA8888ToRGBA8888
 
@@ -124,5 +131,13 @@ void ConvertBGRA5551ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 
 void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels);
-void ConvertRGBA5551ToABGR1555(u16 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels);
+
+#if defined(ARM64)
+#define ConvertRGBA5551ToABGR1555 ConvertRGBA5551ToABGR1555NEON
+#elif !defined(ARM)
+#define ConvertRGBA5551ToABGR1555 ConvertRGBA5551ToABGR1555Basic
+#else
+extern Convert16bppTo16bppFunc ConvertRGBA5551ToABGR1555;
+#endif

--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -132,7 +132,7 @@ void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 
 void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixels);
-void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, const u32 numPixels);
 
 #if defined(ARM64)
 #define ConvertRGBA5551ToABGR1555 ConvertRGBA5551ToABGR1555NEON
@@ -140,4 +140,12 @@ void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, const u32 numPixels);
 #define ConvertRGBA5551ToABGR1555 ConvertRGBA5551ToABGR1555Basic
 #else
 extern Convert16bppTo16bppFunc ConvertRGBA5551ToABGR1555;
+#endif
+
+#if defined(ARM64)
+#define ConvertRGB565ToBGR565 ConvertRGB565ToBGR565NEON
+#elif !defined(ARM)
+#define ConvertRGB565ToBGR565 ConvertRGB565ToBGR565Basic
+#else
+extern Convert16bppTo16bppFunc ConvertRGB565ToBGR565;
 #endif

--- a/Common/ColorConvNEON.cpp
+++ b/Common/ColorConvNEON.cpp
@@ -20,4 +20,37 @@
 #include "Common.h"
 #include "CPUDetect.h"
 
-// TODO: NEON color conversion funcs.
+#if !defined(ARM) && !defined(ARM64)
+#error Should not be compiled on non-ARM.
+#endif
+
+// TODO: More NEON color conversion funcs.
+
+void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, const u32 numPixels) {
+	const uint16x8_t maskB = vdupq_n_u16(0x003E);
+	const uint16x8_t maskG = vdupq_n_u16(0x07C0);
+
+	u32 simdable = (numPixels / 8) * 8;
+	const u16 *srcp = src;
+	u16 *dstp = dst;
+	for (u32 i = 0; i < simdable; i += 8) {
+		uint16x8_t c = vld1q_u16(srcp);
+
+		const uint16x8_t a = vshrq_n_u16(c, 15);
+		const uint16x8_t b = vandq_u16(vshrq_n_u16(c, 9), maskB);
+		const uint16x8_t g = vandq_u16(vshlq_n_u16(c, 1), maskG);
+		const uint16x8_t r = vshlq_n_u16(c, 11);
+
+		uint16x8_t res = vorrq_u16(vorrq_u16(r, g), vorrq_u16(b, a));
+		vst1q_u16(dstp, res);
+
+		srcp += 8;
+		dstp += 8;
+	}
+
+	// Finish off the rest, if there were any outside the simdable range.
+	if (numPixels > simdable) {
+		// Note that we've already moved srcp/dstp forward.
+		ConvertRGBA5551ToABGR1555Basic(dst, src, numPixels - simdable);
+	}
+}

--- a/Common/ColorConvNEON.cpp
+++ b/Common/ColorConvNEON.cpp
@@ -54,3 +54,30 @@ void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, const u32 numPixels
 		ConvertRGBA5551ToABGR1555Basic(dst, src, numPixels - simdable);
 	}
 }
+
+void ConvertRGB565ToBGR565NEON(u16 *dst, const u16 *src, const u32 numPixels) {
+	const uint16x8_t maskG = vdupq_n_u16(0x07E0);
+
+	u32 simdable = (numPixels / 8) * 8;
+	const u16 *srcp = src;
+	u16 *dstp = dst;
+	for (u32 i = 0; i < simdable; i += 8) {
+		uint16x8_t c = vld1q_u16(srcp);
+
+		const uint16x8_t b = vshrq_n_u16(c, 11);
+		const uint16x8_t g = vandq_u16(c, maskG);
+		const uint16x8_t r = vshlq_n_u16(c, 11);
+
+		uint16x8_t res = vorrq_u16(vorrq_u16(r, g), b);
+		vst1q_u16(dstp, res);
+
+		srcp += 8;
+		dstp += 8;
+	}
+
+	// Finish off the rest, if there were any outside the simdable range.
+	if (numPixels > simdable) {
+		// Note that we've already moved srcp/dstp forward.
+		ConvertRGB565ToBGR565Basic(dst, src, numPixels - simdable);
+	}
+}

--- a/Common/ColorConvNEON.h
+++ b/Common/ColorConvNEON.h
@@ -19,5 +19,6 @@
 
 #include "ColorConv.h"
 
+void ConvertRGBA4444ToABGR4444NEON(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGB565ToBGR565NEON(u16 *dst, const u16 *src, const u32 numPixels);

--- a/Common/ColorConvNEON.h
+++ b/Common/ColorConvNEON.h
@@ -18,3 +18,5 @@
 #pragma once
 
 #include "ColorConv.h"
+
+void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, const u32 numPixels);

--- a/Common/ColorConvNEON.h
+++ b/Common/ColorConvNEON.h
@@ -20,3 +20,4 @@
 #include "ColorConv.h"
 
 void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGB565ToBGR565NEON(u16 *dst, const u16 *src, const u32 numPixels);

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -207,9 +207,11 @@ void DoUnswizzleTex16Basic(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 
 }
 
 #ifndef _M_SSE
+#ifndef ARM64
 QuickTexHashFunc DoQuickTexHash = &QuickTexHashBasic;
 UnswizzleTex16Func DoUnswizzleTex16 = &DoUnswizzleTex16Basic;
 ReliableHash32Func DoReliableHash32 = &XXH32;
+#endif
 ReliableHash64Func DoReliableHash64 = &XXH64;
 #endif
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1,9 +1,10 @@
 #include <algorithm>
 #include "native/base/mutex.h"
 #include "native/base/timeutil.h"
-#include "GeDisasm.h"
-#include "GPUCommon.h"
-#include "GPUState.h"
+#include "Common/ColorConv.h"
+#include "GPU/GeDisasm.h"
+#include "GPU/GPUCommon.h"
+#include "GPU/GPUState.h"
 #include "ChunkFile.h"
 #include "Core/Config.h"
 #include "Core/CoreTiming.h"
@@ -21,6 +22,7 @@ GPUCommon::GPUCommon() :
 	dumpThisFrame_(false)
 {
 	Reinitialize();
+	SetupColorConv();
 	SetThreadEnabled(g_Config.bSeparateCPUThread);
 }
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -82,6 +82,7 @@ ARCH_FILES := \
   $(SRC)/Core/Util/AudioFormatNEON.cpp \
   $(SRC)/Common/Arm64Emitter.cpp \
   $(SRC)/Common/ArmCPUDetect.cpp \
+  $(SRC)/Common/ColorConvNEON.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompALU.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompBranch.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompFPU.cpp \


### PR DESCRIPTION
This will mainly be used for palette loads and non-indexed textures.  Won't affect gameplay much in the general case (unless textures are being reloaded frequently), but may improve load times a bit.

I've also made armv8 (64) use the NEON versions statically.  I have not tested this at all.  I changed this also for texture hashing / etc.

Each NEON func takes about 50% as long as the non-NEON version on my Nexus 5.  Tried prefetching as well as using walls instead of masks, neither of which seemed to help.

FWIW, I tested this only synthetically via:

``` c++
        double st, et;
        printf("ColorConv TEST:\n");

        u16 *buf1 = (u16 *)malloc(1024 * 1024);
        for (int i = 0; i < 1024 * 1024 / 2; i++) {
            buf1[i] = (u16)i;
        }
        u16 *buf2 = (u16 *)malloc(1024 * 1024);

        // Try to read into cache.
        memcpy(buf2, buf1, 1024 * 1024);
        memset(buf2, 0xCC, 1024 * 1024);

        st = real_time_now();
        for (int i = 0; i < 20; i++) {
            memset(buf2, 0xCC, 1024 * 1024);
            ConvertRGB565ToBGR565(buf2, buf1, 1024 * 1024 / 2);
        }
        et = real_time_now();

        printf("N Result: %f ms / %08x\n", (et - st) * 1000.0, hash::Adler32((const uint8 *)buf2, 1024 * 1024));

        memcpy(buf2, buf1, 1024 * 1024);
        memset(buf2, 0xCC, 1024 * 1024);

        st = real_time_now();
        for (int i = 0; i < 20; i++) {
            memset(buf2, 0xCC, 1024 * 1024);
            ConvertRGB565ToBGR565Basic(buf2, buf1, 1024 * 1024 / 2);
        }
        et = real_time_now();

        printf("B Result: %f ms / %08x\n", (et - st) * 1000.0, hash::Adler32((const uint8 *)buf2, 1024 * 1024));

        free(buf1);
        free(buf2);
```

-[Unknown]
