### PR TITLE
Use SSE in CheckAlpha scanning

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -330,3 +330,339 @@ void DecodeDXT5Block(u32 *dst, const DXT5Block *src, int pitch) {
 		dst += pitch;
 	}
 }
+
+#ifdef _M_SSE
+static inline u32 CombineSSEBits(const __m128i &v) {
+	__m128i temp;
+	temp = _mm_or_si128(v, _mm_srli_si128(v, 8));
+	temp = _mm_or_si128(temp, _mm_srli_si128(temp, 4));
+	return _mm_cvtsi128_si32(temp);
+}
+
+CheckAlphaResult CheckAlphaRGBA8888SSE2(const u32 *pixelData, int stride, int w, int h) {
+	const __m128i zero = _mm_setzero_si128();
+	const __m128i full = _mm_set1_epi32(0xFF);
+
+	const __m128i *p = (const __m128i *)pixelData;
+	const int w4 = w / 4;
+	const int stride4 = stride / 4;
+
+	__m128i hasZeroCursor = _mm_setzero_si128();
+	for (int y = 0; y < h; ++y) {
+		__m128i hasAnyCursor = _mm_setzero_si128();
+
+		for (int i = 0; i < w4; ++i) {
+			const __m128i a = _mm_srli_epi32(_mm_load_si128(&p[i]), 24);
+
+			const __m128i isZero = _mm_cmpeq_epi32(a, zero);
+			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
+
+			// If a = FF, isNotFull will be 0 -> hasAny will be 0.
+			// If a = 00, a & isNotFull will be 0 -> hasAny will be 0.
+			// In any other case, hasAny will have some bits set.
+			const __m128i isNotFull = _mm_cmplt_epi32(a, full);
+			hasAnyCursor = _mm_or_si128(hasAnyCursor, _mm_and_si128(a, isNotFull));
+		}
+		p += stride4;
+
+		// We check any early, in case we can skip the rest of the rows.
+		if (CombineSSEBits(hasAnyCursor) != 0) {
+			return CHECKALPHA_ANY;
+		}
+	}
+
+	// Now let's sum up the bits.
+	if (CombineSSEBits(hasZeroCursor) != 0) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaABGR4444SSE2(const u32 *pixelData, int stride, int w, int h) {
+	const __m128i zero = _mm_setzero_si128();
+	const __m128i full = _mm_set1_epi16(0x000F);
+
+	const __m128i *p = (const __m128i *)pixelData;
+	const int w8 = w / 8;
+	const int stride8 = stride / 8;
+
+	__m128i hasZeroCursor = _mm_setzero_si128();
+	for (int y = 0; y < h; ++y) {
+		__m128i hasAnyCursor = _mm_setzero_si128();
+
+		for (int i = 0; i < w8; ++i) {
+			const __m128i a = _mm_and_si128(_mm_load_si128(&p[i]), full);
+
+			const __m128i isZero = _mm_cmpeq_epi16(a, zero);
+			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
+
+			// If a = F, isNotFull will be 0 -> hasAny will be 0.
+			// If a = 0, a & isNotFull will be 0 -> hasAny will be 0.
+			// In any other case, hasAny will have some bits set.
+			const __m128i isNotFull = _mm_cmplt_epi32(a, full);
+			hasAnyCursor = _mm_or_si128(hasAnyCursor, _mm_and_si128(a, isNotFull));
+		}
+		p += stride8;
+
+		// We check any early, in case we can skip the rest of the rows.
+		if (CombineSSEBits(hasAnyCursor) != 0) {
+			return CHECKALPHA_ANY;
+		}
+	}
+
+	// Now let's sum up the bits.
+	if (CombineSSEBits(hasZeroCursor) != 0) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaABGR1555SSE2(const u32 *pixelData, int stride, int w, int h) {
+	const __m128i zero = _mm_setzero_si128();
+
+	const __m128i *p = (const __m128i *)pixelData;
+	const int w8 = w / 8;
+	const int stride8 = stride / 8;
+
+	__m128i hasZeroCursor = _mm_setzero_si128();
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w8; ++i) {
+			const __m128i a = _mm_slli_epi16(_mm_load_si128(&p[i]), 15);
+
+			const __m128i isZero = _mm_cmpeq_epi16(a, zero);
+			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
+		}
+		p += stride8;
+	}
+
+	// Now let's sum up the bits.
+	if (CombineSSEBits(hasZeroCursor) != 0) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaRGBA4444SSE2(const u32 *pixelData, int stride, int w, int h) {
+	const __m128i zero = _mm_setzero_si128();
+	const __m128i full = _mm_set1_epi16(0x000F);
+
+	const __m128i *p = (const __m128i *)pixelData;
+	const int w8 = w / 8;
+	const int stride8 = stride / 8;
+
+	__m128i hasZeroCursor = _mm_setzero_si128();
+	for (int y = 0; y < h; ++y) {
+		__m128i hasAnyCursor = _mm_setzero_si128();
+
+		for (int i = 0; i < w8; ++i) {
+			const __m128i a = _mm_srli_epi16(_mm_load_si128(&p[i]), 12);
+
+			const __m128i isZero = _mm_cmpeq_epi16(a, zero);
+			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
+
+			// If a = F, isNotFull will be 0 -> hasAny will be 0.
+			// If a = 0, a & isNotFull will be 0 -> hasAny will be 0.
+			// In any other case, hasAny will have some bits set.
+			const __m128i isNotFull = _mm_cmplt_epi32(a, full);
+			hasAnyCursor = _mm_or_si128(hasAnyCursor, _mm_and_si128(a, isNotFull));
+		}
+		p += stride8;
+
+		// We check any early, in case we can skip the rest of the rows.
+		if (CombineSSEBits(hasAnyCursor) != 0) {
+			return CHECKALPHA_ANY;
+		}
+	}
+
+	// Now let's sum up the bits.
+	if (CombineSSEBits(hasZeroCursor) != 0) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaRGBA5551SSE2(const u32 *pixelData, int stride, int w, int h) {
+	const __m128i zero = _mm_setzero_si128();
+	const __m128i full = _mm_set1_epi16(0x0001);
+
+	const __m128i *p = (const __m128i *)pixelData;
+	const int w8 = w / 8;
+	const int stride8 = stride / 8;
+
+	__m128i hasZeroCursor = _mm_setzero_si128();
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w8; ++i) {
+			const __m128i a = _mm_srli_epi16(_mm_load_si128(&p[i]), 15);
+
+			const __m128i isZero = _mm_cmpeq_epi16(a, zero);
+			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
+		}
+		p += stride8;
+	}
+
+	// Now let's sum up the bits.
+	if (CombineSSEBits(hasZeroCursor) != 0) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+#endif
+
+CheckAlphaResult CheckAlphaRGBA8888Basic(const u32 *pixelData, int stride, int w, int h) {
+#ifdef _M_SSE
+	// Use SSE if aligned to 16 bytes / 4 pixels (almost always the case.)
+	if ((w & 3) == 0 && (stride & 3) == 0) {
+		return CheckAlphaRGBA8888SSE2(pixelData, stride, w, h);
+	}
+#endif
+
+	u32 hitZeroAlpha = 0;
+
+	const u32 *p = pixelData;
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w; ++i) {
+			u32 a = p[i] & 0xFF000000;
+			hitZeroAlpha |= a ^ 0xFF000000;
+			if (a != 0xFF000000 && a != 0) {
+				// We're done, we hit non-zero, non-full alpha.
+				return CHECKALPHA_ANY;
+			}
+		}
+		p += stride;
+	}
+
+	if (hitZeroAlpha) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaABGR4444Basic(const u32 *pixelData, int stride, int w, int h) {
+#ifdef _M_SSE
+	// Use SSE if aligned to 16 bytes / 8 pixels (usually the case.)
+	if ((w & 7) == 0 && (stride & 7) == 0) {
+		return CheckAlphaABGR4444SSE2(pixelData, stride, w, h);
+	}
+#endif
+
+	u32 hitZeroAlpha = 0;
+
+	const u32 *p = pixelData;
+	const int w2 = (w + 1) / 2;
+	const int stride2 = (stride + 1) / 2;
+
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w2; ++i) {
+			u32 a = p[i] & 0x000F000F;
+			hitZeroAlpha |= a ^ 0x000F000F;
+			if (a != 0x000F000F && a != 0x0000000F && a != 0x000F0000 && a != 0) {
+				// We're done, we hit non-zero, non-full alpha.
+				return CHECKALPHA_ANY;
+			}
+		}
+		p += stride;
+	}
+
+	if (hitZeroAlpha) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaABGR1555Basic(const u32 *pixelData, int stride, int w, int h) {
+#ifdef _M_SSE
+	// Use SSE if aligned to 16 bytes / 8 pixels (usually the case.)
+	if ((w & 7) == 0 && (stride & 7) == 0) {
+		return CheckAlphaABGR1555SSE2(pixelData, stride, w, h);
+	}
+#endif
+
+	u32 hitZeroAlpha = 0;
+
+	const u32 *p = pixelData;
+	const int w2 = (w + 1) / 2;
+	const int stride2 = (stride + 1) / 2;
+
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w2; ++i) {
+			u32 a = p[i] & 0x00010001;
+			hitZeroAlpha |= a ^ 0x00010001;
+		}
+		p += stride;
+	}
+
+	if (hitZeroAlpha) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaRGBA4444Basic(const u32 *pixelData, int stride, int w, int h) {
+#ifdef _M_SSE
+	// Use SSE if aligned to 16 bytes / 8 pixels (usually the case.)
+	if ((w & 7) == 0 && (stride & 7) == 0) {
+		return CheckAlphaRGBA4444SSE2(pixelData, stride, w, h);
+	}
+#endif
+
+	u32 hitZeroAlpha = 0;
+
+	const u32 *p = pixelData;
+	const int w2 = (w + 1) / 2;
+	const int stride2 = (stride + 1) / 2;
+
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w2; ++i) {
+			u32 a = p[i] & 0xF000F000;
+			hitZeroAlpha |= a ^ 0xF000F000;
+			if (a != 0xF000F000 && a != 0xF0000000 && a != 0x0000F000 && a != 0) {
+				// We're done, we hit non-zero, non-full alpha.
+				return CHECKALPHA_ANY;
+			}
+		}
+		p += stride;
+	}
+
+	if (hitZeroAlpha) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}
+
+CheckAlphaResult CheckAlphaRGBA5551Basic(const u32 *pixelData, int stride, int w, int h) {
+#ifdef _M_SSE
+	// Use SSE if aligned to 16 bytes / 8 pixels (usually the case.)
+	if ((w & 7) == 0 && (stride & 7) == 0) {
+		return CheckAlphaRGBA5551SSE2(pixelData, stride, w, h);
+	}
+#endif
+
+	u32 hitZeroAlpha = 0;
+
+	const u32 *p = pixelData;
+	const int w2 = (w + 1) / 2;
+	const int stride2 = (stride + 1) / 2;
+
+	for (int y = 0; y < h; ++y) {
+		for (int i = 0; i < w2; ++i) {
+			u32 a = p[i] & 0x80008000;
+			hitZeroAlpha |= a ^ 0x80008000;
+		}
+		p += stride;
+	}
+
+	if (hitZeroAlpha) {
+		return CHECKALPHA_ZERO;
+	} else {
+		return CHECKALPHA_FULL;
+	}
+}

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -332,7 +332,7 @@ void DecodeDXT5Block(u32 *dst, const DXT5Block *src, int pitch) {
 }
 
 #ifdef _M_SSE
-static inline u32 CombineSSEBits(const __m128i &v) {
+static inline u32 CombineSSEBitsToDWORD(const __m128i &v) {
 	__m128i temp;
 	temp = _mm_or_si128(v, _mm_srli_si128(v, 8));
 	temp = _mm_or_si128(temp, _mm_srli_si128(temp, 4));
@@ -366,13 +366,13 @@ CheckAlphaResult CheckAlphaRGBA8888SSE2(const u32 *pixelData, int stride, int w,
 		p += stride4;
 
 		// We check any early, in case we can skip the rest of the rows.
-		if (CombineSSEBits(hasAnyCursor) != 0) {
+		if (CombineSSEBitsToDWORD(hasAnyCursor) != 0) {
 			return CHECKALPHA_ANY;
 		}
 	}
 
 	// Now let's sum up the bits.
-	if (CombineSSEBits(hasZeroCursor) != 0) {
+	if (CombineSSEBitsToDWORD(hasZeroCursor) != 0) {
 		return CHECKALPHA_ZERO;
 	} else {
 		return CHECKALPHA_FULL;
@@ -381,7 +381,7 @@ CheckAlphaResult CheckAlphaRGBA8888SSE2(const u32 *pixelData, int stride, int w,
 
 CheckAlphaResult CheckAlphaABGR4444SSE2(const u32 *pixelData, int stride, int w, int h) {
 	const __m128i zero = _mm_setzero_si128();
-	const __m128i full = _mm_set1_epi16(0x000F);
+	const __m128i full = _mm_set1_epi16(0xF000);
 
 	const __m128i *p = (const __m128i *)pixelData;
 	const int w8 = w / 8;
@@ -392,7 +392,7 @@ CheckAlphaResult CheckAlphaABGR4444SSE2(const u32 *pixelData, int stride, int w,
 		__m128i hasAnyCursor = _mm_setzero_si128();
 
 		for (int i = 0; i < w8; ++i) {
-			const __m128i a = _mm_and_si128(_mm_load_si128(&p[i]), full);
+			const __m128i a = _mm_slli_epi16(_mm_load_si128(&p[i]), 12);
 
 			const __m128i isZero = _mm_cmpeq_epi16(a, zero);
 			hasZeroCursor = _mm_or_si128(hasZeroCursor, isZero);
@@ -406,13 +406,13 @@ CheckAlphaResult CheckAlphaABGR4444SSE2(const u32 *pixelData, int stride, int w,
 		p += stride8;
 
 		// We check any early, in case we can skip the rest of the rows.
-		if (CombineSSEBits(hasAnyCursor) != 0) {
+		if (CombineSSEBitsToDWORD(hasAnyCursor) != 0) {
 			return CHECKALPHA_ANY;
 		}
 	}
 
 	// Now let's sum up the bits.
-	if (CombineSSEBits(hasZeroCursor) != 0) {
+	if (CombineSSEBitsToDWORD(hasZeroCursor) != 0) {
 		return CHECKALPHA_ZERO;
 	} else {
 		return CHECKALPHA_FULL;
@@ -438,7 +438,7 @@ CheckAlphaResult CheckAlphaABGR1555SSE2(const u32 *pixelData, int stride, int w,
 	}
 
 	// Now let's sum up the bits.
-	if (CombineSSEBits(hasZeroCursor) != 0) {
+	if (CombineSSEBitsToDWORD(hasZeroCursor) != 0) {
 		return CHECKALPHA_ZERO;
 	} else {
 		return CHECKALPHA_FULL;
@@ -472,13 +472,13 @@ CheckAlphaResult CheckAlphaRGBA4444SSE2(const u32 *pixelData, int stride, int w,
 		p += stride8;
 
 		// We check any early, in case we can skip the rest of the rows.
-		if (CombineSSEBits(hasAnyCursor) != 0) {
+		if (CombineSSEBitsToDWORD(hasAnyCursor) != 0) {
 			return CHECKALPHA_ANY;
 		}
 	}
 
 	// Now let's sum up the bits.
-	if (CombineSSEBits(hasZeroCursor) != 0) {
+	if (CombineSSEBitsToDWORD(hasZeroCursor) != 0) {
 		return CHECKALPHA_ZERO;
 	} else {
 		return CHECKALPHA_FULL;
@@ -487,7 +487,6 @@ CheckAlphaResult CheckAlphaRGBA4444SSE2(const u32 *pixelData, int stride, int w,
 
 CheckAlphaResult CheckAlphaRGBA5551SSE2(const u32 *pixelData, int stride, int w, int h) {
 	const __m128i zero = _mm_setzero_si128();
-	const __m128i full = _mm_set1_epi16(0x0001);
 
 	const __m128i *p = (const __m128i *)pixelData;
 	const int w8 = w / 8;
@@ -505,7 +504,7 @@ CheckAlphaResult CheckAlphaRGBA5551SSE2(const u32 *pixelData, int stride, int w,
 	}
 
 	// Now let's sum up the bits.
-	if (CombineSSEBits(hasZeroCursor) != 0) {
+	if (CombineSSEBitsToDWORD(hasZeroCursor) != 0) {
 		return CHECKALPHA_ZERO;
 	} else {
 		return CHECKALPHA_FULL;

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -75,6 +75,19 @@ extern ReliableHash64Func DoReliableHash64;
 typedef u32 ReliableHashType;
 #endif
 
+enum CheckAlphaResult {
+	// These are intended to line up with TexCacheEntry::STATUS_ALPHA_UNKNOWN, etc.
+	CHECKALPHA_FULL = 0,
+	CHECKALPHA_ANY = 4,
+	CHECKALPHA_ZERO = 8,
+};
+
+CheckAlphaResult CheckAlphaRGBA8888Basic(const u32 *pixelData, int stride, int w, int h);
+CheckAlphaResult CheckAlphaABGR4444Basic(const u32 *pixelData, int stride, int w, int h);
+CheckAlphaResult CheckAlphaRGBA4444Basic(const u32 *pixelData, int stride, int w, int h);
+CheckAlphaResult CheckAlphaABGR1555Basic(const u32 *pixelData, int stride, int w, int h);
+CheckAlphaResult CheckAlphaRGBA5551Basic(const u32 *pixelData, int stride, int w, int h);
+
 // All these DXT structs are in the reverse order, as compared to PC.
 // On PC, alpha comes before color, and interpolants are before the tile data.
 


### PR DESCRIPTION
My usual strategy of testing on SSE first.  Simple measurements seem to clock these in at taking around 35% as long as the originals.  Once broken out and NEON-ized, can look at integrating (since hopefully we'll have found any issues first.)

Probably makes a lot more sense to do it simultaneously with the format conversion, but palette gets a bit tricky.  Ultimately, it will still need to be checked on the result or via a palette entry index or something, if we keep it.

As a reminder, the reason for the alpha check is:
- It allows us to skip some alpha testing cases (most primarily, > X when vertex and texture use full alpha.)
- It allows skipping a very tiny amount of logic in the frag shader sometimes.

I've always felt like it could be used more effectively, but I guess in practice it hasn't so far.  It seems to cost surprisingly much (to me) on ARM, so maybe it's doing more harm than good sometimes.

Also, it calculates two results.  Similarly, knowing a texture contains 1/0 alpha seems inherently useful, but we're not using that at all currently.  Might definitely be doing more harm than good...

Lastly, I've named these based on going from the least bit, but I'm not sure.  Maybe I should just name the 8888 one ABGR?  We're very inconsistent here, I think we should pick a rule.

-[Unknown]
