### PR TITLE
Rename some color conversion funcs

### DIFF
--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -382,7 +382,6 @@ void ConvertRGBA5551ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 	}
 }
 
-// TODO: This seems to be BGRA4444 -> RGBA888?
 void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) {
 #ifdef _M_SSE
 	const __m128i mask4 = _mm_set1_epi16(0x000f);
@@ -399,12 +398,12 @@ void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 		const __m128i c = _mm_load_si128(&srcp[i]);
 
 		// Let's just grab R000 R000, without swizzling yet.
-		__m128i r = _mm_and_si128(_mm_srli_epi16(c, 8), mask4);
+		__m128i r = _mm_and_si128(c, mask4);
 		// And then 00G0 00G0.
 		__m128i g = _mm_and_si128(_mm_srli_epi16(c, 4), mask4);
 		g = _mm_slli_epi16(g, 8);
 		// Now B000 B000.
-		__m128i b = _mm_and_si128(c, mask4);
+		__m128i b = _mm_and_si128(_mm_srli_epi16(c, 8), mask4);
 		// And lastly 00A0 00A0.  No mask needed, we have a wall.
 		__m128i a = _mm_srli_epi16(c, 12);
 		a = _mm_slli_epi16(g, 8);
@@ -427,9 +426,9 @@ void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 	u8 *dst = (u8 *)dst32;
 	for (u32 x = i; x < numPixels; x++) {
 		u16 col = src[x];
-		dst[x * 4] = Convert4To8((col >> 8) & 0xf);
+		dst[x * 4] = Convert4To8(col & 0xf);
 		dst[x * 4 + 1] = Convert4To8((col >> 4) & 0xf);
-		dst[x * 4 + 2] = Convert4To8(col & 0xf);
+		dst[x * 4 + 2] = Convert4To8((col >> 8) & 0xf);
 		dst[x * 4 + 3] = Convert4To8(col >> 12);
 	}
 }

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -433,37 +433,40 @@ void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 	}
 }
 
-// TODO: This seems to be ABGR4444 -> RGBA888?
-void ConvertBGRA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) {
+void ConvertRGBA4444ToBGRA8888(u32 *dst32, const u16 *src, const u32 numPixels) {
 	u8 *dst = (u8 *)dst32;
 	for (u32 x = 0; x < numPixels; x++) {
-		u16 col = src[x];
-		dst[x * 4 + 0] = (col >> 12) << 4;
-		dst[x * 4 + 1] = ((col >> 8) & 0xf) << 4;
-		dst[x * 4 + 2] = ((col >> 4) & 0xf) << 4;
-		dst[x * 4 + 3] = (col & 0xf) << 4;
+		u16 c = src[x];
+		u32 r = c & 0x000f;
+		u32 g = (c >> 4) & 0x000f;
+		u32 b = (c >> 8) & 0x000f;
+		u32 a = (c >> 12) & 0x000f;
+
+		dst[x] = (r << (16 + 4)) | (g << (8 + 4)) | (b << 4) | (a << (24 + 4));
 	}
 }
 
-inline void ARGB8From565(u16 c, u32 * dst) {
-	*dst = ((c & 0x001f) << 19) | (((c >> 5) & 0x003f) << 11) | ((((c >> 10) & 0x001f) << 3)) | 0xFF000000;
-}
-
-inline void ARGB8From5551(u16 c, u32 * dst) {
-	*dst = ((c & 0x001f) << 19) | (((c >> 5) & 0x001f) << 11) | ((((c >> 10) & 0x001f) << 3)) | 0xFF000000;
-}
-
-void ConvertBGRA5551ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels) {
+void ConvertRGBA5551ToBGRA8888(u32 *dst, const u16 *src, const u32 numPixels) {
 	for (u32 x = 0; x < numPixels; x++) {
-		u16 col0 = src[x];
-		ARGB8From5551(col0, &dst[x]);
+		u16 c = src[x];
+		u32 r = c & 0x001f;
+		u32 g = (c >> 5) & 0x001f;
+		u32 b = (c >> 10) & 0x001f;
+		// We force an arithmetic shift to get the sign bits/
+		u32 a = ((s32)(s16)c) & 0xff000000;
+
+		dst[x] = (r << (16 + 3)) | (g << (8 + 3)) | (b << 3) | a;
 	}
 }
 
-void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels) {
+void ConvertRGB565ToBGRA8888(u32 *dst, const u16 *src, const u32 numPixels) {
 	for (u32 x = 0; x < numPixels; x++) {
-		u16 col0 = src[x];
-		ARGB8From565(col0, &dst[x]);
+		u16 c = src[x];
+		u32 r = c & 0x001f;
+		u32 g = (c >> 5) & 0x003f;
+		u32 b = (c >> 11) & 0x001f;
+
+		dst[x] = (r << (16 + 3)) | (g << (8 + 2)) | (b << 3) | 0xFF000000;
 	}
 }
 

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -332,7 +332,6 @@ void ConvertRGBA5551ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 #ifdef _M_SSE
 	const __m128i mask5 = _mm_set1_epi16(0x001f);
 	const __m128i mask8 = _mm_set1_epi16(0x00ff);
-	const __m128i one = _mm_set1_epi16(0x0001);
 
 	const __m128i *srcp = (const __m128i *)src;
 	__m128i *dstp = (__m128i *)dst32;
@@ -359,8 +358,8 @@ void ConvertRGBA5551ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 		b = _mm_and_si128(b, mask8);
 
 		// 1 bit A to 00AA 00AA.
-		__m128i a = _mm_srli_epi16(c, 15);
-		a = _mm_slli_epi16(_mm_cmpeq_epi16(a, one), 8);
+		__m128i a = _mm_srai_epi16(c, 15);
+		a = _mm_slli_epi16(a, 8);
 
 		// Now combine them, RRGG RRGG and BBAA BBAA, and then interleave.
 		const __m128i rg = _mm_or_si128(r, g);

--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -126,9 +126,9 @@ void ConvertRGBA565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA5551ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA4444ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
 
-void ConvertBGRA4444ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
-void ConvertBGRA5551ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
-void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGBA4444ToBGRA8888(u32 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGBA5551ToBGRA8888(u32 *dst, const u16 *src, const u32 numPixels);
+void ConvertRGB565ToBGRA8888(u32 *dst, const u16 *src, const u32 numPixels);
 
 void ConvertRGBA4444ToABGR4444Basic(u16 *dst, const u16 *src, const u32 numPixels);
 void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, const u32 numPixels);

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -140,7 +140,7 @@ namespace DX9 {
 					{
 						const u16_le *src = (const u16_le *)srcPixels + srcStride * y;
 						u32 *dst = (u32 *)(convBuf + rect.Pitch * y);
-						ConvertBGR565ToRGBA8888(dst, src, width);
+						ConvertRGB565ToBGRA8888(dst, src, width);
 					}
 					break;
 					// faster
@@ -148,14 +148,14 @@ namespace DX9 {
 					{
 						const u16_le *src = (const u16_le *)srcPixels + srcStride * y;
 						u32 *dst = (u32 *)(convBuf + rect.Pitch * y);
-						ConvertBGRA5551ToRGBA8888(dst, src, width);
+						ConvertRGBA5551ToBGRA8888(dst, src, width);
 					}
 					break;
 				case GE_FORMAT_4444:
 					{
 						const u16_le *src = (const u16_le *)srcPixels + srcStride * y;
 						u8 *dst = (u8 *)(convBuf + rect.Pitch * y);
-						ConvertBGRA4444ToRGBA8888((u32 *)dst, src, width);
+						ConvertRGBA4444ToBGRA8888((u32 *)dst, src, width);
 					}
 					break;
 
@@ -163,7 +163,7 @@ namespace DX9 {
 					{
 						const u32_le *src = (const u32_le *)srcPixels + srcStride * y;
 						u32 *dst = (u32 *)(convBuf + rect.Pitch * y);
-						ConvertBGRA8888ToRGBA8888(dst, src, width);
+						ConvertRGBA8888ToBGRA8888(dst, src, width);
 					}
 					break;
 				}
@@ -172,7 +172,7 @@ namespace DX9 {
 			for (int y = 0; y < height; y++) {
 				const u32_le *src = (const u32_le *)srcPixels + srcStride * y;
 				u32 *dst = (u32 *)(convBuf + rect.Pitch * y);
-				ConvertBGRA8888ToRGBA8888(dst, src, width);
+				ConvertRGBA8888ToBGRA8888(dst, src, width);
 			}
 		}
 


### PR DESCRIPTION
This uses the least->most convention.

Also, this fixes a few types, specifically GL 4444->8888 and all 16 bit Direct3D 9 types, which were converting components incorrectly.

-[Unknown]
