### PR TITLE
unittest: avoid build error on case-sensitive filesystems

### DIFF
--- a/unittest/TestArm64Emitter.cpp
+++ b/unittest/TestArm64Emitter.cpp
@@ -1,4 +1,4 @@
-#include "Common/ARM64Emitter.h"
+#include "Common/Arm64Emitter.h"
 #include "Core/MIPS/JitCommon/JitState.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"

--- a/unittest/TestX64Emitter.cpp
+++ b/unittest/TestX64Emitter.cpp
@@ -1,4 +1,4 @@
-#include "Common/X64Emitter.h"
+#include "Common/x64Emitter.h"
 #include "Core/MIPS/x86/RegCacheFPU.h"
 #include "Core/MIPS/x86/Jit.h"
 #include "Core/MIPS/JitCommon/JitState.h"


### PR DESCRIPTION
unittest/TestArm64Emitter.cpp:1:10: fatal error: 'Common/ARM64Emitter.h' file not found
unittest/TestX64Emitter.cpp:1:10: fatal error: 'Common/X64Emitter.h' file not found
