### PR TITLE
RFC: Process sceSas in blocks of 32 samples

### DIFF
--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -143,6 +143,7 @@ public:
 	void SetSimpleEnvelope(u32 ADSREnv1, u32 ADSREnv2);
 
 	void WalkCurve(int type, int rate);
+	void GetTypeAndRate(int &type, int &rate);
 
 	void KeyOn();
 	void KeyOff();
@@ -175,9 +176,6 @@ public:
 private:
 	// Actual PSP values.
 	enum ADSRState {
-		// Okay, this one isn't a real value but it might be.
-		STATE_KEYON_STEP = -42,
-
 		STATE_KEYON = -2,
 		STATE_OFF = -1,
 		STATE_ATTACK = 0,


### PR DESCRIPTION
As we talked about, reduces the amount of CPU work in audio ADSR curve walking. Probably a very slight speedup.

However, the adsrcurve test is very slightly off... so probably shouldn't merge this as is.
