### PR TITLE
Limit time GameInfo file loaders are kept open

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -166,11 +166,14 @@ u64 GameInfo::GetInstallDataSizeInBytes() {
 }
 
 bool GameInfo::LoadFromPath(const std::string &gamePath) {
-	delete fileLoader;
-	fileLoader = ConstructFileLoader(gamePath);
-	filePath_ = gamePath;
+	// No need to rebuild if we already have it loaded.
+	if (filePath_ != gamePath) {
+		delete fileLoader;
+		fileLoader = ConstructFileLoader(gamePath);
+		filePath_ = gamePath;
+	}
 
-	return fileLoader->Exists();
+	return GetFileLoader()->Exists();
 }
 
 FileLoader *GameInfo::GetFileLoader() {

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -101,6 +101,9 @@ public:
 
 	bool DeleteGame();  // Better be sure what you're doing when calling this.
 	bool DeleteAllSaveData();
+	bool LoadFromPath(const std::string &gamePath);
+	FileLoader *GetFileLoader();
+	void DisposeFileLoader();
 
 	u64 GetGameSizeInBytes();
 	u64 GetSaveDataSizeInBytes();
@@ -157,7 +160,9 @@ public:
 	u64 saveDataSize;
 	u64 installDataSize;
 
+protected:
 	FileLoader *fileLoader;
+	std::string filePath_;
 };
 
 class GameInfoCache {


### PR DESCRIPTION
This closes the file loaders after using them, which ought to limit active file descriptors.

It does mean that there is a tiny bit more overhead when viewing the detail of a game.  Could switch to decimation (since this overhead will be greater over HTTP, etc.) but it's not a big deal anyway.

-[Unknown]
