### PR TITLE
Joystick hot-plugging for SDL.

### DIFF
--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -147,7 +147,7 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	case SDL_JOYDEVICEREMOVED:
 		{
 			int deviceIndex = getDeviceIndex(event.jdevice.which);
-			if (deviceIndex >= 0){
+			if (deviceIndex >= 0) {
 				SDL_JoystickClose(joys[deviceIndex]);
 				joys[deviceIndex] = 0;
 			}
@@ -156,10 +156,10 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	}
 }
 
-int SDLJoystick::getDeviceIndex(int instanceId){
-	for (int i = 0; i < joys.size(); i++){
+int SDLJoystick::getDeviceIndex(int instanceId) {
+	for (int i = 0; i < joys.size(); i++) {
 		SDL_Joystick *joy = joys[i];
-		if (SDL_JoystickInstanceID(joy) == instanceId){
+		if (SDL_JoystickInstanceID(joy) == instanceId) {
 			return i;
 		}
 	}

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -49,14 +49,15 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	case SDL_JOYAXISMOTION:
 		{
 			std::map<int, int>::const_iterator i = SDLJoyAxisMap.find(event.jaxis.axis);
-			if (i != SDLJoyAxisMap.end()) {
+			int deviceIndex = getDeviceIndex(event.jaxis.which);
+			if (i != SDLJoyAxisMap.end() && deviceIndex >= 0) {
 				AxisInput axis;
 				axis.axisId = i->second;
 				// 1.2 to try to approximate the PSP's clamped rectangular range.
 				axis.value = 1.2 * event.jaxis.value / 32767.0f;
 				if (axis.value > 1.0f) axis.value = 1.0f;
 				if (axis.value < -1.0f) axis.value = -1.0f;
-				axis.deviceId = DEVICE_ID_PAD_0 + event.jaxis.which;
+				axis.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
 				axis.flags = 0;
 				NativeAxis(axis);
 			}
@@ -66,11 +67,12 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	case SDL_JOYBUTTONDOWN:
 		{
 			std::map<int, int>::const_iterator i = SDLJoyButtonMap.find(event.jbutton.button);
-			if (i != SDLJoyButtonMap.end()) {
+			int deviceIndex = getDeviceIndex(event.jbutton.which);
+			if (i != SDLJoyButtonMap.end() && deviceIndex >= 0) {
 				KeyInput key;
 				key.flags = KEY_DOWN;
 				key.keyCode = i->second;
-				key.deviceId = DEVICE_ID_PAD_0 + event.jbutton.which;
+				key.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
 				NativeKey(key);
 			}
 			break;
@@ -79,11 +81,12 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	case SDL_JOYBUTTONUP:
 		{
 			std::map<int, int>::const_iterator i = SDLJoyButtonMap.find(event.jbutton.button);
-			if (i != SDLJoyButtonMap.end()) {
+			int deviceIndex = getDeviceIndex(event.jbutton.which);
+			if (i != SDLJoyButtonMap.end() && deviceIndex >= 0) {
 				KeyInput key;
 				key.flags = KEY_UP;
 				key.keyCode = i->second;
-				key.deviceId = DEVICE_ID_PAD_0 + event.jbutton.which;
+				key.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
 				NativeKey(key);
 			}
 			break;
@@ -91,9 +94,13 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 
 	case SDL_JOYHATMOTION:
 		{
+			int deviceIndex = getDeviceIndex(event.jhat.which);
+			if (deviceIndex < 0) {
+				break;
+			}
 #ifdef _WIN32
 			KeyInput key;
-			key.deviceId = DEVICE_ID_PAD_0 + event.jhat.which;
+			key.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
 
 			key.flags = (event.jhat.value & SDL_HAT_UP)?KEY_DOWN:KEY_UP;
 			key.keyCode = NKCODE_DPAD_UP;
@@ -112,8 +119,8 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 			AxisInput axisY;
 			axisX.axisId = JOYSTICK_AXIS_HAT_X;
 			axisY.axisId = JOYSTICK_AXIS_HAT_Y;
-			axisX.deviceId = DEVICE_ID_PAD_0 + event.jhat.which;
-			axisY.deviceId = DEVICE_ID_PAD_0 + event.jhat.which;
+			axisX.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
+			axisY.deviceId = DEVICE_ID_PAD_0 + deviceIndex;
 			axisX.value = 0.0f;
 			axisY.value = 0.0f;
 			if (event.jhat.value & SDL_HAT_LEFT) axisX.value = -1.0f;
@@ -125,7 +132,38 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 #endif
 			break;
 		}
+
+	case SDL_JOYDEVICEADDED:
+		{
+			int deviceIndex = event.jdevice.which;
+			if (deviceIndex >= joys.size()) {
+				joys.resize(deviceIndex+1);
+			}
+			joys[deviceIndex] = SDL_JoystickOpen(deviceIndex);
+			SDL_JoystickEventState(SDL_ENABLE);
+			break;
+		}
+
+	case SDL_JOYDEVICEREMOVED:
+		{
+			int deviceIndex = getDeviceIndex(event.jdevice.which);
+			if (deviceIndex >= 0){
+				SDL_JoystickClose(joys[deviceIndex]);
+				joys[deviceIndex] = 0;
+			}
+			break;
+		}
 	}
+}
+
+int SDLJoystick::getDeviceIndex(int instanceId){
+	for (int i = 0; i < joys.size(); i++){
+		SDL_Joystick *joy = joys[i];
+		if (SDL_JoystickInstanceID(joy) == instanceId){
+			return i;
+		}
+	}
+	return -1;
 }
 
 void SDLJoystick::runLoop(){

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -94,4 +94,5 @@ private:
 	SDL_Thread *thread ;
 	bool running ;
 
+	int getDeviceIndex(int instanceId);
 };


### PR DESCRIPTION
In SDL environment, joysticks will only opened at startup. but I want to sometimes plug joysticks after startup. this patch treats SDL_JOYDEVICEADDED / SDL_JOYDEVICEREMOVED events for hot plugging. Could you please merge this?
