### PR TITLE
Vsync control support for non-win32 platform

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -171,7 +171,7 @@ void UpdateRunLoop() {
 		NativeRender();
 	}
 
-	if (GetUIState() != UISTATE_INGAME) {
+	if (GetUIState() != UISTATE_INGAME || !PSP_IsInited()) {
 		// Simple throttling to not burn the GPU in the menu.
 		time_update();
 		double diffTime = time_now_d() - startTime;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -153,6 +153,9 @@ bool UpdateScreenScale(int width, int height, bool smallWindow) {
 }
 
 void UpdateRunLoop() {
+	time_update();
+	double startTime = time_now_d();
+
 	if (windowHidden && g_Config.bPauseWhenMinimized) {
 		sleep_ms(16);
 		return;
@@ -166,6 +169,16 @@ void UpdateRunLoop() {
 
 	if (GetUIState() != UISTATE_EXIT) {
 		NativeRender();
+	}
+
+	if (GetUIState() != UISTATE_INGAME) {
+		// Simple throttling to not burn the GPU in the menu.
+		time_update();
+		double diffTime = time_now_d() - startTime;
+		int sleepTime = (int)(1000.0 / 60.0) - (int)(diffTime * 1000.0);
+
+		if (sleepTime > 0)
+			sleep_ms(sleepTime);
 	}
 }
 
@@ -186,27 +199,15 @@ void GPU_SwapBuffers() {
 
 void Core_RunLoop() {
 	while ((GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT) {
-		time_update();
-#if defined(USING_WIN_UI)
-		double startTime = time_now_d();
 		UpdateRunLoop();
-
-		// Simple throttling to not burn the GPU in the menu.
-		time_update();
-		double diffTime = time_now_d() - startTime;
-		int sleepTime = (int)(1000.0 / 60.0) - (int)(diffTime * 1000.0);
-		if (sleepTime > 0)
-			Sleep(sleepTime);
+#if defined(USING_WIN_UI)
 		if (!windowHidden) {
 			GPU_SwapBuffers();
 		}
-#else
-		UpdateRunLoop();
 #endif
 	}
 
 	while (!coreState && GetUIState() == UISTATE_INGAME) {
-		time_update();
 		UpdateRunLoop();
 #if defined(USING_WIN_UI)
 		if (!windowHidden && !Core_IsStepping()) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -539,7 +539,7 @@ void GLES_GPU::BeginFrame() {
 }
 
 inline void GLES_GPU::UpdateVsyncInterval(bool force) {
-#ifdef _WIN32
+#ifndef USING_GLES2
 	int desiredVSyncInterval = g_Config.bVSync ? 1 : 0;
 	if (PSP_CoreParameter().unthrottle) {
 		desiredVSyncInterval = 0;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -197,7 +197,7 @@ void GameSettingsScreen::CreateViews() {
 	hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode
 #endif
 
-#ifdef _WIN32
+#ifndef USING_GLES2
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gs->T("VSync")));
 #endif
 	CheckBox *mipmapping = graphicsSettings->Add(new CheckBox(&g_Config.bMipMap, gs->T("Mipmapping")));


### PR DESCRIPTION
Make changes in native module take effect.
Add a way to turn off vsync in non-win32 platform.

See hrydgard/native#277
