### PR TITLE
More ARM64 jit optimizations

### DIFF
--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -592,6 +592,10 @@ public:
 	void SBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);
 	void UBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);
 
+	void BFI(ARM64Reg Rd, ARM64Reg Rn, int lsb, int width) {
+		BFM(Rd, Rn, (64 - lsb) % (Is64Bit(Rd) ? 64 : 32), width - 1);
+	}
+
 	// Extract register (ROR with two inputs, if same then faster on A67)
 	void EXTR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u32 shift);
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -523,7 +523,7 @@ public:
 
 	void DoState(PointerWrap &p) override
 	{
-		auto s = p.Section("Thread", 1, 4);
+		auto s = p.Section("Thread", 1, 5);
 		if (!s)
 			return;
 
@@ -553,6 +553,8 @@ public:
 			context.other[4] = context.other[5];
 			context.other[3] = context.other[4];
 		}
+		if (s <= 4)
+			std::swap(context.hi, context.lo);
 
 		p.Do(callbacks);
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -138,8 +138,8 @@ struct ThreadContext
 		struct {
 			u32 pc;
 
-			u32 hi;
 			u32 lo;
+			u32 hi;
 
 			u32 fcr31;
 			u32 fpcond;

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -573,7 +573,7 @@ namespace MIPSComp
 				} else {
 					gpr.MapDirtyIn(rt, rs, false);
 #ifdef HAVE_ARMV7
-					BFI(gpr.R(rt), gpr.R(rs), pos, size-pos);
+					BFI(gpr.R(rt), gpr.R(rs), pos, size - pos);
 #else
 					ANDI2R(SCRATCHREG1, gpr.R(rs), sourcemask, SCRATCHREG2);
 					ANDI2R(gpr.R(rt), gpr.R(rt), destmask, SCRATCHREG2);

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -604,7 +604,6 @@ void ArmJit::Comp_Syscall(MIPSOpcode op)
 	RestoreRoundingMode();
 	js.downcountAmount = -offset;
 
-	// TODO: Maybe discard v0, v1, and some temps?  Definitely at?
 	FlushAll();
 
 	SaveDowncount();

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -540,8 +540,6 @@ void Arm64Jit::Comp_Allegrex2(MIPSOpcode op) {
 
 void Arm64Jit::Comp_MulDivType(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
-
-
 	MIPSGPReg rt = _RT;
 	MIPSGPReg rs = _RS;
 	MIPSGPReg rd = _RD;
@@ -613,8 +611,7 @@ void Arm64Jit::Comp_MulDivType(MIPSOpcode op) {
 		// TODO: Does this handle INT_MAX, 0, etc. correctly?
 		gpr.MapDirtyDirtyInIn(MIPS_REG_LO, MIPS_REG_HI, rs, rt);
 		SDIV(gpr.R(MIPS_REG_LO), gpr.R(rs), gpr.R(rt));
-		MUL(SCRATCH1, gpr.R(rt), gpr.R(MIPS_REG_LO));
-		SUB(gpr.R(MIPS_REG_HI), gpr.R(rs), SCRATCH1);
+		MSUB(gpr.R(MIPS_REG_HI), gpr.R(rs), gpr.R(rt), gpr.R(MIPS_REG_LO));
 		break;
 
 	case 27: //divu
@@ -645,8 +642,7 @@ void Arm64Jit::Comp_MulDivType(MIPSOpcode op) {
 			// TODO: Does this handle INT_MAX, 0, etc. correctly?
 			gpr.MapDirtyDirtyInIn(MIPS_REG_LO, MIPS_REG_HI, rs, rt);
 			UDIV(gpr.R(MIPS_REG_LO), gpr.R(rs), gpr.R(rt));
-			MUL(SCRATCH1, gpr.R(rt), gpr.R(MIPS_REG_LO));
-			SUB(gpr.R(MIPS_REG_HI), gpr.R(rs), SCRATCH1);
+			MSUB(gpr.R(MIPS_REG_HI), gpr.R(rs), gpr.R(rt), gpr.R(MIPS_REG_LO));
 		}
 		break;
 

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -227,6 +227,7 @@ void Arm64Jit::BranchRSZeroComp(MIPSOpcode op, CCFlags cc, bool andLink, bool li
 		if (!likely && delaySlotIsNice)
 			CompileDelaySlot(DELAYSLOT_NICE);
 
+		// TODO: Maybe we could use BZ here?
 		gpr.MapReg(rs);
 		CMP(gpr.R(rs), 0);
 
@@ -319,8 +320,9 @@ void Arm64Jit::BranchFPFlag(MIPSOpcode op, CCFlags cc, bool likely) {
 	if (!likely && delaySlotIsNice)
 		CompileDelaySlot(DELAYSLOT_NICE);
 
+	// TODO: Maybe we could use TBZ here?
 	gpr.MapReg(MIPS_REG_FPCOND);
-	TSTI2R(gpr.R(MIPS_REG_FPCOND), 1, W0);
+	TSTI2R(gpr.R(MIPS_REG_FPCOND), 1, SCRATCH1);
 	Arm64Gen::FixupBranch ptr;
 	if (!likely) {
 		if (!delaySlotIsNice)
@@ -379,8 +381,9 @@ void Arm64Jit::BranchVFPUFlag(MIPSOpcode op, CCFlags cc, bool likely) {
 
 	int imm3 = (op >> 18) & 7;
 
+	// TODO: Maybe could use TBZ?
 	gpr.MapReg(MIPS_REG_VFPUCC);
-	TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1 << imm3, W0);
+	TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1 << imm3, SCRATCH1);
 
 	Arm64Gen::FixupBranch ptr;
 	js.inDelaySlot = true;
@@ -584,7 +587,6 @@ void Arm64Jit::Comp_Syscall(MIPSOpcode op)
 	RestoreRoundingMode();
 	js.downcountAmount = -offset;
 
-	// TODO: Maybe discard v0, v1, and some temps?  Definitely at?
 	FlushAll();
 
 	SaveDowncount();

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -175,8 +175,8 @@ void Arm64Jit::Comp_FPUComp(MIPSOpcode op) {
 		break;
 	case 3:      // ueq, ngl (equal, unordered)
 		CSET(gpr.R(MIPS_REG_FPCOND), CC_EQ);
-		CSET(SCRATCH1, CC_VS);
-		ORR(gpr.R(MIPS_REG_FPCOND), gpr.R(MIPS_REG_FPCOND), SCRATCH1);
+		// If ordered, use the above result.  If unordered, use ZR+1 (being 1.)
+		CSINC(gpr.R(MIPS_REG_FPCOND), gpr.R(MIPS_REG_FPCOND), WZR, CC_VC);
 		return;
 	case 4:      // olt, lt (less than, ordered)
 		CSET(gpr.R(MIPS_REG_FPCOND), CC_LO);

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -274,35 +274,15 @@ void Arm64Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 36: //FsI(fd) = (int)  F(fs);            break; //cvt.w.s
 		fpr.MapDirtyIn(fd, fs);
 		if (js.hasSetRounding) {
-			// Urgh, this looks awfully expensive and bloated.. Perhaps we should have a global function pointer to the right FCVTS to use,
-			// and update it when the rounding mode is switched.
-			fp.FCMP(fpr.R(fs), fpr.R(fs));
-			FixupBranch skip_nan = B(CC_VC);
-			MOVI2R(SCRATCH1, 0x7FFFFFFF);
-			fp.FMOV(fpr.R(fd), SCRATCH1);
-			FixupBranch skip_rest = B();
-			// MIPS Rounding Mode:
-			//   0: Round nearest
-			//   1: Round to zero
-			//   2: Round up (ceil)
-			//   3: Round down (floor)
-			SetJumpTarget(skip_nan);
-			LDR(INDEX_UNSIGNED, SCRATCH1, CTXREG, offsetof(MIPSState, fcr31));
-			ANDI2R(SCRATCH1, SCRATCH1, 3);
-			ADR(SCRATCH2_64, 12);  // PC + 12 = address of first FCVTS below
-			ADD(SCRATCH2_64, SCRATCH2_64, EncodeRegTo64(SCRATCH1), ArithOption(SCRATCH2_64, ST_LSL, 3));
-			BR(SCRATCH2_64);  // choose from the four variants below!
-			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_N);
-			FixupBranch skip1 = B();
-			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_Z);
-			FixupBranch skip2 = B();
-			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_P);
-			FixupBranch skip3 = B();
-			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_M);
-			SetJumpTarget(skip1);
-			SetJumpTarget(skip2);
-			SetJumpTarget(skip3);
-			SetJumpTarget(skip_rest);
+			// We're just going to defer to our cached func.  Here's the arg.
+			fp.FMOV(S0, fpr.R(fs));
+
+			MOVP2R(SCRATCH1_64, &js.currentRoundingFunc);
+			LDR(INDEX_UNSIGNED, SCRATCH1_64, SCRATCH1_64, 0);
+
+			BLR(SCRATCH1_64);
+
+			fp.FMOV(fpr.R(fd), S0);
 		} else {
 			fp.FCMP(fpr.R(fs), fpr.R(fs));
 			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_Z);

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -110,7 +110,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 			}
 			MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
 		}
-		LDR(INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
+		fp.LDR(32, INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
 		for (auto skip : skips) {
 			SetJumpTarget(skip);
 		}
@@ -138,7 +138,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 			}
 			MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
 		}
-		STR(INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
+		fp.STR(32, INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
 		for (auto skip : skips) {
 			SetJumpTarget(skip);
 		}

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -362,7 +362,6 @@ bool Arm64Jit::ReplaceJalTo(u32 dest) {
 	if (!CanReplaceJalTo(dest, &entry, &funcSize)) {
 		return false;
 	}
-	INFO_LOG(HLE, "ReplaceJalTo to %s", entry->name);
 
 	// Warning - this might be bad if the code at the destination changes...
 	if (entry->flags & REPFLAG_ALLOWINLINE) {
@@ -410,7 +409,6 @@ void Arm64Jit::Comp_ReplacementFunc(MIPSOpcode op)
 	if (entry->flags & REPFLAG_DISABLED) {
 		MIPSCompileOp(Memory::Read_Instruction(GetCompilerPC(), true));
 	} else if (entry->jitReplaceFunc) {
-		INFO_LOG(HLE, "JitReplaceFunc to %s", entry->name);
 		MIPSReplaceFunc repl = entry->jitReplaceFunc;
 		int cycles = (this->*repl)();
 
@@ -426,7 +424,6 @@ void Arm64Jit::Comp_ReplacementFunc(MIPSOpcode op)
 			js.compiling = false;
 		}
 	} else if (entry->replaceFunc) {
-		INFO_LOG(HLE, "ReplaceFunc to %s", entry->name);
 		FlushAll();
 		RestoreRoundingMode();
 		gpr.SetRegImm(SCRATCH1, GetCompilerPC());

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -560,6 +560,13 @@ void Arm64Jit::ApplyRoundingMode(bool force) {
 		ORR(SCRATCH1, SCRATCH1, SCRATCH2, ArithOption(SCRATCH2, ST_LSL, 22));
 		_MSR(FIELD_FPCR, SCRATCH1_64);
 
+		// Let's update js.currentRoundingFunc with the right convertS0ToSCRATCH1 func.
+		MOVP2R(SCRATCH1_64, convertS0ToSCRATCH1);
+		// We already index this array including the FZ bit.  Easy.
+		LDR(SCRATCH2_64, SCRATCH1_64, SCRATCH2);
+		MOVP2R(SCRATCH1_64, &js.currentRoundingFunc);
+		STR(INDEX_UNSIGNED, SCRATCH2_64, SCRATCH1_64, 0);
+
 		POP(SCRATCH1);
 		SetJumpTarget(skip);
 	}

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -262,6 +262,9 @@ public:
 	const u8 *dispatcherNoCheck;
 
 	const u8 *breakpointBailout;
+
+	// Indexed by FPCR FZ:RN bits for convenience.  Uses SCRATCH2.
+	const u8 *convertS0ToSCRATCH1[8];
 };
 
 }	// namespace MIPSComp

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -78,6 +78,7 @@ namespace MIPSComp {
 
 		u8 hasSetRounding;
 		u8 lastSetRounding;
+		const u8 *currentRoundingFunc;
 
 		// VFPU prefix magic
 		bool startDefaultPrefix;

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -289,6 +289,7 @@ void MIPSState::DoState(PointerWrap &p) {
 	p.Do(pc);
 	p.Do(nextPC);
 	p.Do(downcount);
+	// Reversed, but we can just leave it that way.
 	p.Do(hi);
 	p.Do(lo);
 	p.Do(fpcond);

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -174,8 +174,8 @@ public:
 		struct {
 			u32 pc;
 
-			u32 hi;
 			u32 lo;
+			u32 hi;
 
 			u32 fcr31; //fpu control register
 			u32 fpcond;  // cache the cond flag of fcr31  (& 1 << 23)


### PR DESCRIPTION
This:
- Switches hi/lo but doesn't use them more efficiently yet.
- Implements ext/ins.
- Fixes float load/store in some cases (offsets, slowmem I think?)
- Removes some outdated logging/comments.
- Uses a function pointer for cvt.w.s.

Maybe there's a better place than `js` to put the current convert func pointer.  As is, that particular op is now about twice as fast or so.

I haven't heavily tested these changes, but I ran through a few games and everything was working fine.  Tests looked good too (although headless is currently crashing for me and I'm not sure why...)

-[Unknown]
