### PR TITLE
Flush using STP where possible in ARM64

### DIFF
--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -62,7 +62,8 @@ static const bool enableDebug = false;
 // saving them when we call out of the JIT. We will perform regular dynamic register allocation in the rest (x0-x15)
 
 // STATIC ALLOCATION ARM64 (these are all callee-save registers):
-// x24 : Down counter
+// x23 : Down counter
+// x24 : PC save on JR with non-nice delay slot (to be eliminated later?)
 // x25 : MSR/MRS temporary (to be eliminated later)
 // x26 : JIT base reg
 // x27 : MIPS state (Could eliminate by placing the MIPS state right at the memory base)

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -61,8 +61,11 @@ const ARM64Reg *Arm64RegCache::GetMIPSAllocationOrder(int &count) {
 }
 
 void Arm64RegCache::FlushBeforeCall() {
-	// TODO: More optimal
-	FlushAll();
+	// These registers are not preserved by function calls.
+	for (int i = 0; i < 19; ++i) {
+		FlushArmReg(ARM64Reg(W0 + i));
+	}
+	FlushArmReg(W30);
 }
 
 bool Arm64RegCache::IsMapped(MIPSGPReg mipsReg) {

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -142,6 +142,7 @@ private:
 	const Arm64Gen::ARM64Reg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(Arm64Gen::ARM64Reg reg, MIPSGPReg mipsReg, int mapFlags);
 	Arm64Gen::ARM64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
+	Arm64Gen::ARM64Reg ARM64RegForFlush(MIPSGPReg r);
 		
 	MIPSState *mips_;
 	Arm64Gen::ARM64XEmitter *emit_;


### PR DESCRIPTION
In microbenching, got a nice boost from this.  Testing games with fast forward improved too.

This also tries to store an already imm-loaded reg in place of a matching imm.  I didn't check how often that happens.

-[Unknown]
