### PR TITLE
Count more in frame profiler, tweaks

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 
 #include "base/logging.h"
+#include "profiler/profiler.h"
 
 #include "Common/MsgHandler.h"
 #include "Common/StdMutex.h"
@@ -583,6 +584,7 @@ void ForceCheck()
 
 void Advance()
 {
+	PROFILE_THIS_SCOPE("advance");
 	int cyclesExecuted = slicelength - currentMIPS->downcount;
 	globalTimer += cyclesExecuted;
 	currentMIPS->downcount = slicelength;

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -22,6 +22,7 @@
 
 #include "base/logging.h"
 #include "base/timeutil.h"
+#include "profiler/profiler.h"
 
 #include "Core/Config.h"
 #include "Core/CoreTiming.h"
@@ -521,6 +522,7 @@ void hleSetSteppingTime(double t)
 
 void CallSyscall(MIPSOpcode op)
 {
+	PROFILE_THIS_SCOPE("syscall");
 	double start = 0.0;  // need to initialize to fix the race condition where g_Config.bShowDebugStats is enabled in the middle of this func.
 	if (g_Config.bShowDebugStats)
 	{

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -31,6 +31,7 @@
 // and move everything into native...
 #include "base/logging.h"
 #include "base/timeutil.h"
+#include "profiler/profiler.h"
 
 #ifndef _XBOX
 #include "gfx_es2/gl_state.h"
@@ -489,6 +490,7 @@ static bool FrameTimingThrottled() {
 
 // Let's collect all the throttling and frameskipping logic here.
 static void DoFrameTiming(bool &throttle, bool &skipFrame, float timestep) {
+	PROFILE_THIS_SCOPE("timing");
 	int fpsLimiter = PSP_CoreParameter().fpsLimit;
 	throttle = FrameTimingThrottled();
 	skipFrame = false;
@@ -568,6 +570,7 @@ static void DoFrameTiming(bool &throttle, bool &skipFrame, float timestep) {
 }
 
 static void DoFrameIdleTiming() {
+	PROFILE_THIS_SCOPE("timing");
 	if (!FrameTimingThrottled() || !g_Config.bEnableSound || wasPaused) {
 		return;
 	}
@@ -727,6 +730,7 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 	// The goal here is to prevent network, audio, and input lag from the real world.
 	// Our normal timing is very "stop and go".  This is efficient, but causes real world lag.
 	// This event (optionally) runs every 1ms to sync with the real world.
+	PROFILE_THIS_SCOPE("timing");
 
 	if (!FrameTimingThrottled()) {
 		lagSyncScheduled = false;

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "profiler/profiler.h"
+
 #include "Core/Reporting.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
@@ -607,6 +609,11 @@ void ArmJit::Comp_Syscall(MIPSOpcode op)
 	FlushAll();
 
 	SaveDowncount();
+#ifdef USE_PROFILER
+	// When profiling, we can't skip CallSyscall, since it times syscalls.
+	gpr.SetRegImm(R0, op.encoding);
+	QuickCallFunction(R1, (void *)&CallSyscall);
+#else
 	// Skip the CallSyscall where possible.
 	void *quickFunc = GetQuickSyscallFunc(op);
 	if (quickFunc)
@@ -620,6 +627,7 @@ void ArmJit::Comp_Syscall(MIPSOpcode op)
 		gpr.SetRegImm(R0, op.encoding);
 		QuickCallFunction(R1, (void *)&CallSyscall);
 	}
+#endif
 	ApplyRoundingMode();
 	RestoreDowncount();
 

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "base/logging.h"
+#include "profiler/profiler.h"
 #include "Common/ChunkFile.h"
 
 #include "Core/Reporting.h"
@@ -195,6 +196,7 @@ void ArmJit::CompileDelaySlot(int flags)
 
 
 void ArmJit::Compile(u32 em_address) {
+	PROFILE_THIS_SCOPE("jitc");
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
 		ClearCache();
 	}
@@ -230,8 +232,8 @@ void ArmJit::Compile(u32 em_address) {
 	}
 }
 
-void ArmJit::RunLoopUntil(u64 globalticks)
-{
+void ArmJit::RunLoopUntil(u64 globalticks) {
+	PROFILE_THIS_SCOPE("jit");
 	((void (*)())enterCode)();
 }
 

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "profiler/profiler.h"
+
 #include "Core/Reporting.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
@@ -590,6 +592,11 @@ void Arm64Jit::Comp_Syscall(MIPSOpcode op)
 	FlushAll();
 
 	SaveDowncount();
+#ifdef USE_PROFILER
+	// When profiling, we can't skip CallSyscall, since it times syscalls.
+	MOVI2R(W0, op.encoding);
+	QuickCallFunction(X1, (void *)&CallSyscall);
+#else
 	// Skip the CallSyscall where possible.
 	void *quickFunc = GetQuickSyscallFunc(op);
 	if (quickFunc) {
@@ -600,6 +607,7 @@ void Arm64Jit::Comp_Syscall(MIPSOpcode op)
 		MOVI2R(W0, op.encoding);
 		QuickCallFunction(X1, (void *)&CallSyscall);
 	}
+#endif
 	ApplyRoundingMode();
 	RestoreDowncount();
 

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "base/logging.h"
+#include "profiler/profiler.h"
 #include "Common/ChunkFile.h"
 #include "Common/CPUDetect.h"
 
@@ -179,6 +180,7 @@ void Arm64Jit::CompileDelaySlot(int flags) {
 
 
 void Arm64Jit::Compile(u32 em_address) {
+	PROFILE_THIS_SCOPE("jitc");
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
 		INFO_LOG(JIT, "Space left: %i", GetSpaceLeft());
 		ClearCache();
@@ -217,6 +219,7 @@ void Arm64Jit::Compile(u32 em_address) {
 }
 
 void Arm64Jit::RunLoopUntil(u64 globalticks) {
+	PROFILE_THIS_SCOPE("jit");
 	((void (*)())enterCode)();
 }
 

--- a/Core/MIPS/MIPS/MipsJit.cpp
+++ b/Core/MIPS/MIPS/MipsJit.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "base/logging.h"
+#include "profiler/profiler.h"
 #include "Common/ChunkFile.h"
 #include "Core/Reporting.h"
 #include "Core/Config.h"
@@ -137,6 +138,7 @@ void MipsJit::CompileDelaySlot(int flags)
 
 
 void MipsJit::Compile(u32 em_address) {
+	PROFILE_THIS_SCOPE("jitc");
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
 		ClearCache();
 	}
@@ -163,6 +165,7 @@ void MipsJit::Compile(u32 em_address) {
 
 void MipsJit::RunLoopUntil(u64 globalticks)
 {
+	PROFILE_THIS_SCOPE("jit");
 	((void (*)())enterCode)();
 }
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -19,6 +19,7 @@
 #include <iterator>
 
 #include "math/math_util.h"
+#include "profiler/profiler.h"
 
 #include "Common/ChunkFile.h"
 #include "Core/Core.h"
@@ -347,6 +348,7 @@ void Jit::EatInstruction(MIPSOpcode op)
 
 void Jit::Compile(u32 em_address)
 {
+	PROFILE_THIS_SCOPE("jitc");
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull())
 	{
 		ClearCache();
@@ -385,6 +387,7 @@ void Jit::Compile(u32 em_address)
 
 void Jit::RunLoopUntil(u64 globalticks)
 {
+	PROFILE_THIS_SCOPE("jit");
 	((void (*)())asm_.enterCode)();
 }
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -804,7 +804,7 @@ void GLES_GPU::Execute_Prim(u32 op, u32 diff) {
 			return;
 	}
 
-	// This also make skipping drawing very effective.
+	// This also makes skipping drawing very effective.
 	framebufferManager_.SetRenderFrameBuffer();
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
 		transformDraw_.SetupVertexDecoder(gstate.vertType);

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -578,6 +578,7 @@ void TransformDrawEngine::FreeBuffer(GLuint buf) {
 }
 
 void TransformDrawEngine::DoFlush() {
+	PROFILE_THIS_SCOPE("flush");
 	gpuStats.numFlushes++;
 	gpuStats.numTrackedVertexArrays = (int)vai_.size();
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -810,6 +810,8 @@ void DrawProfile(UIContext &ui) {
 	int numCategories = Profiler_GetNumCategories();
 	int historyLength = Profiler_GetHistoryLength();
 
+	ui.SetFontStyle(ui.theme->uiFont);
+
 	float legendWidth = 80.0f;
 	for (int i = 0; i < numCategories; i++) {
 		const char *name = Profiler_GetCategoryName(i);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -815,6 +815,10 @@ void DrawProfile(UIContext &ui) {
 	float legendWidth = 80.0f;
 	for (int i = 0; i < numCategories; i++) {
 		const char *name = Profiler_GetCategoryName(i);
+		if (!strcmp(name, "timing")) {
+			continue;
+		}
+
 		float w = 0.0f, h = 0.0f;
 		ui.MeasureText(ui.GetFontStyle(), name, &w, &h);
 		if (w > legendWidth) {
@@ -832,6 +836,9 @@ void DrawProfile(UIContext &ui) {
 
 	for (int i = 0; i < numCategories; i++) {
 		const char *name = Profiler_GetCategoryName(i);
+		if (!strcmp(name, "timing")) {
+			continue;
+		}
 		uint32_t color = nice_colors[i % ARRAY_SIZE(nice_colors)];
 
 		float y = legendStartY + i * rowH;
@@ -877,6 +884,10 @@ void DrawProfile(UIContext &ui) {
 	maxVal = 0.0f;
 	float maxTotal = 0.0f;
 	for (int i = 0; i < numCategories; i++) {
+		const char *name = Profiler_GetCategoryName(i);
+		if (!strcmp(name, "timing")) {
+			continue;
+		}
 		Profiler_GetHistory(i, &history[0], historyLength);
 
 		float x = 10;


### PR DESCRIPTION
This makes it so we count jit, compiling, flushing, and some other things in the frame profiler.

Gives a much more accurate picture of time and lags.  You can also see when jit or even jitc causes a frame to lag.  And the cost of mpeg/atrac/other currently uninstrumented syscalls high level.

Obviously this relies upon the nesting feature of the profiler heavily.

-[Unknown]
