### PR TITLE
Fix discarding imms and flushing zero in arm64

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -209,6 +209,7 @@ namespace MIPSComp
 				return;
 			}
 			// If rd is rhs, we may have lost it in the MapDirtyIn().  lhs was kept.
+			// This means the rhsImm value was never flushed to rhs, and would be garbage.
 			if (rd == rhs) {
 				// Luckily, it was just an imm.
 				gpr.SetImm(rhs, rhsImm);

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -389,6 +389,10 @@ void ArmRegCache::DiscardR(MIPSGPReg mipsReg) {
 		}
 		mr[mipsReg].imm = 0;
 	}
+	if (prevLoc == ML_IMM && mipsReg != MIPS_REG_ZERO) {
+		mr[mipsReg].loc = ML_MEM;
+		mr[mipsReg].imm = 0;
+	}
 }
 
 void ArmRegCache::FlushR(MIPSGPReg r) {

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -357,9 +357,9 @@ void ArmRegCache::FlushArmReg(ARMReg r) {
 		}
 		return;
 	}
-	if (ar[r].mipsReg != MIPS_REG_INVALID && ar[r].mipsReg != MIPS_REG_ZERO) {
+	if (ar[r].mipsReg != MIPS_REG_INVALID) {
 		auto &mreg = mr[ar[r].mipsReg];
-		if (mreg.loc == ML_ARMREG_IMM) {
+		if (mreg.loc == ML_ARMREG_IMM || ar[r].mipsReg == MIPS_REG_ZERO) {
 			// We know its immedate value, no need to STR now.
 			mreg.loc = ML_IMM;
 			mreg.reg = INVALID_REG;

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -208,6 +208,7 @@ void Arm64Jit::CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARM64XE
 			return;
 		}
 		// If rd is rhs, we may have lost it in the MapDirtyIn().  lhs was kept.
+		// This means the rhsImm value was never flushed to rhs, and would be garbage.
 		if (rd == rhs) {
 			// Luckily, it was just an imm.
 			gpr.SetImm(rhs, rhsImm);

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -306,9 +306,9 @@ void Arm64RegCache::FlushArmReg(ARM64Reg r) {
 		}
 		return;
 	}
-	if (ar[r].mipsReg != MIPS_REG_INVALID && ar[r].mipsReg != MIPS_REG_ZERO) {
+	if (ar[r].mipsReg != MIPS_REG_INVALID) {
 		auto &mreg = mr[ar[r].mipsReg];
-		if (mreg.loc == ML_ARMREG_IMM) {
+		if (mreg.loc == ML_ARMREG_IMM || ar[r].mipsReg == MIPS_REG_ZERO) {
 			// We know its immedate value, no need to STR now.
 			mreg.loc = ML_IMM;
 			mreg.reg = INVALID_REG;
@@ -351,6 +351,9 @@ void Arm64RegCache::DiscardR(MIPSGPReg mipsReg) {
 ARM64Reg Arm64RegCache::ARM64RegForFlush(MIPSGPReg r) {
 	switch (mr[r].loc) {
 	case ML_IMM:
+		if (r == MIPS_REG_ZERO) {
+			return INVALID_REG;
+		}
 		// Zero is super easy.
 		if (mr[r].imm == 0) {
 			return WZR;

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -342,6 +342,10 @@ void Arm64RegCache::DiscardR(MIPSGPReg mipsReg) {
 		}
 		mr[mipsReg].imm = 0;
 	}
+	if (prevLoc == ML_IMM && mipsReg != MIPS_REG_ZERO) {
+		mr[mipsReg].loc = ML_MEM;
+		mr[mipsReg].imm = 0;
+	}
 }
 
 ARM64Reg Arm64RegCache::ARM64RegForFlush(MIPSGPReg r) {


### PR DESCRIPTION
Before it would simply not discard.  Also, zero was not flushed properly and this may have affected arm too (my recent change, sorry.)

There's also an optimization for e.g. `subu v0, $0, v0` and similar instructions, by using WZR directly rather than a temp reg.  This makes the special cases in `or` entirely unnecessary, since MOV is just an ORR with WZR anyway.

-[Unknown]
