### PR TITLE
ARM64 jit: Statically allocate a few registers, including SP

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -46,12 +46,12 @@ bool IsPowerOfTwo(uint64_t x) {
 
 bool IsImmArithmetic(uint64_t input, u32 *val, bool *shift) {
 	if (input < 4096) {
-		*val = input;
-		*shift = false;
+		if (val) *val = input;
+		if (shift) *shift = false;
 		return true;
 	} else if ((input & 0xFFF000) == input) {
-		*val = input >> 12;
-		*shift = true;
+		if (val) *val = input >> 12;
+		if (shift) *shift = true;
 		return true;
 	}
 	return false;

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1207,6 +1207,8 @@ void RestoreReplacedInstruction(u32 address) {
 }
 
 void RestoreReplacedInstructions(u32 startAddr, u32 endAddr) {
+	if (endAddr == startAddr)
+		return;
 	// Need to be in order, or we'll hang.
 	if (endAddr < startAddr)
 		std::swap(endAddr, startAddr);

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -33,6 +33,7 @@ using namespace Arm64Gen;
 //static int temp32; // unused?
 
 static const bool enableDebug = false;
+static const bool enableDisasm = false;
 
 //static bool enableStatistics = false; //unused?
 
@@ -228,7 +229,7 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 	}
 
 	// Leave this at the end, add more stuff above.
-	if (false) {
+	if (enableDisasm) {
 		std::vector<std::string> lines = DisassembleArm64(start, GetCodePtr() - start);
 		for (auto s : lines) {
 			INFO_LOG(JIT, "%s", s.c_str());

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -71,10 +71,10 @@ static const bool enableDebug = false;
 
 extern volatile CoreState coreState;
 
-void ShowPC(u32 sp, void *membase, void *jitbase) {
+void ShowPC(u32 downcount, void *membase, void *jitbase) {
 	static int count = 0;
 	if (currentMIPS) {
-		ELOG("ShowPC : %08x  Downcount : %08x %d %p %p", currentMIPS->pc, sp, count);
+		ELOG("ShowPC : %08x  Downcount : %08x %d %p %p", currentMIPS->pc, downcount, count, membase, jitbase);
 	} else {
 		ELOG("Universe corrupt?");
 	}
@@ -93,7 +93,18 @@ namespace MIPSComp {
 
 using namespace Arm64JitConstants;
 
-void Arm64Jit::GenerateFixedCode() {
+void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
+	saveStaticRegisters = AlignCode16();
+	const u8 *start = saveStaticRegisters;
+	STR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
+	gpr.EmitSaveStaticAllocs();
+	RET();
+
+	loadStaticRegisters = AlignCode16();
+	gpr.EmitLoadStaticAllocs();
+	LDR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
+	RET();
+
 	enterCode = AlignCode16();
 
 	BitSet32 regs_to_save(Arm64Gen::ALL_CALLEE_SAVED);
@@ -106,16 +117,16 @@ void Arm64Jit::GenerateFixedCode() {
 	MOVP2R(CTXREG, mips_);
 	MOVP2R(JITBASEREG, GetBasePtr());
 
-	RestoreDowncount();
+	LoadStaticRegisters();
 	MovFromPC(SCRATCH1);
 	outerLoopPCInSCRATCH1 = GetCodePtr();
 	MovToPC(SCRATCH1);
 	outerLoop = GetCodePtr();
-		SaveDowncount();  // Advance can change the downcount, so must save/restore
+		SaveStaticRegisters();  // Advance can change the downcount, so must save/restore
 		RestoreRoundingMode(true);
 		QuickCallFunction(SCRATCH1_64, &CoreTiming::Advance);
 		ApplyRoundingMode(true);
-		RestoreDowncount();
+		LoadStaticRegisters();
 		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
 
 		dispatcherCheckCoreState = GetCodePtr();
@@ -165,11 +176,11 @@ void Arm64Jit::GenerateFixedCode() {
 			SetJumpTarget(skipJump);
 
 			// No block found, let's jit
-			SaveDowncount();
+			SaveStaticRegisters();
 			RestoreRoundingMode(true);
 			QuickCallFunction(SCRATCH1_64, (void *)&MIPSComp::JitAt);
 			ApplyRoundingMode(true);
-			RestoreDowncount();
+			LoadStaticRegisters();
 
 			B(dispatcherNoCheck); // no point in special casing this
 
@@ -184,20 +195,13 @@ void Arm64Jit::GenerateFixedCode() {
 	SetJumpTarget(badCoreState);
 	breakpointBailout = GetCodePtr();
 
-	SaveDowncount();
+	SaveStaticRegisters();
 	RestoreRoundingMode(true);
 
 	fp.ABI_PopRegisters(regs_to_save_fp);
 	ABI_PopRegisters(regs_to_save);
 
 	RET();
-	
-	if (false) {
-		std::vector<std::string> lines = DisassembleArm64(enterCode, GetCodePtr() - enterCode);
-		for (auto s : lines) {
-			INFO_LOG(JIT, "%s", s.c_str());
-		}
-	}
 
 	// Generate some integer conversion funcs.
 	static const RoundingMode roundModes[8] = {ROUND_N, ROUND_P, ROUND_M, ROUND_Z, ROUND_N, ROUND_P, ROUND_M, ROUND_Z,};
@@ -212,6 +216,14 @@ void Arm64Jit::GenerateFixedCode() {
 		SetJumpTarget(skip);
 
 		RET();
+	}
+
+	// Leave this at the end, add more stuff above.
+	if (true) {
+		std::vector<std::string> lines = DisassembleArm64(start, GetCodePtr() - start);
+		for (auto s : lines) {
+			INFO_LOG(JIT, "%s", s.c_str());
+		}
 	}
 
 	// Don't forget to zap the instruction cache! This must stay at the end of this function.

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -185,7 +185,7 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 				BR(SCRATCH1_64);
 			SetJumpTarget(skipJump);
 
-			// No block found, let's jit
+			// No block found, let's jit. I don't think we actually need to save static regs that are in callee-save regs here but whatever.
 			SaveStaticRegisters();
 			RestoreRoundingMode(true);
 			QuickCallFunction(SCRATCH1_64, (void *)&MIPSComp::JitAt);

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -82,10 +82,22 @@ void Arm64Jit::Comp_IType(MIPSOpcode op) {
 	switch (op >> 26) {
 	case 8:	// same as addiu?
 	case 9:	// R(rt) = R(rs) + simm; break;	//addiu
-		if (simm >= 0) {
-			CompImmLogic(rs, rt, simm, &ARM64XEmitter::ADD, &ARM64XEmitter::TryADDI2R, &EvalAdd);
-		} else if (simm < 0) {
-			CompImmLogic(rs, rt, -simm, &ARM64XEmitter::SUB, &ARM64XEmitter::TrySUBI2R, &EvalSub);
+		// Special-case for small adjustments of pointerified registers. Commonly for SP but happens for others.
+		if (rs == rt && gpr.IsMappedAsPointer(rs) && IsImmArithmetic(simm < 0 ? -simm : simm, nullptr, nullptr)) {
+			ARM64Reg r32 = gpr.R(rs);
+			gpr.MarkDirty(r32);
+			ARM64Reg r = EncodeRegTo64(r32);
+			if (simm > 0) {
+				ADDI2R(r, r, simm);
+			} else {
+				SUBI2R(r, r, -simm);
+			}
+		} else {
+			if (simm >= 0) {
+				CompImmLogic(rs, rt, simm, &ARM64XEmitter::ADD, &ARM64XEmitter::TryADDI2R, &EvalAdd);
+			} else if (simm < 0) {
+				CompImmLogic(rs, rt, -simm, &ARM64XEmitter::SUB, &ARM64XEmitter::TrySUBI2R, &EvalSub);
+			}
 		}
 		break;
 

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -389,7 +389,8 @@ void Arm64Jit::CompShiftVar(MIPSOpcode op, Arm64Gen::ShiftType shiftType) {
 		return;
 	}
 	gpr.MapDirtyInIn(rd, rs, rt);
-	ANDI2R(SCRATCH1, gpr.R(rs), 0x1F, INVALID_REG);  // Not sure if ARM64 wraps like this so let's do it for it.
+	// Not sure if ARM64 wraps like this so let's do it for it.  (TODO: According to the ARM ARM, it will indeed mask for us so this is not necessary)
+	ANDI2R(SCRATCH1, gpr.R(rs), 0x1F, INVALID_REG);
 	switch (shiftType) {
 	case ST_LSL: LSLV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;
 	case ST_LSR: LSRV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -591,7 +591,7 @@ void Arm64Jit::Comp_Syscall(MIPSOpcode op)
 
 	FlushAll();
 
-	SaveDowncount();
+	SaveStaticRegisters();
 #ifdef USE_PROFILER
 	// When profiling, we can't skip CallSyscall, since it times syscalls.
 	MOVI2R(W0, op.encoding);
@@ -608,8 +608,8 @@ void Arm64Jit::Comp_Syscall(MIPSOpcode op)
 		QuickCallFunction(X1, (void *)&CallSyscall);
 	}
 #endif
+	LoadStaticRegisters();
 	ApplyRoundingMode();
-	RestoreDowncount();
 
 	WriteSyscallExit();
 	js.compiling = false;

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1841,6 +1841,8 @@ namespace MIPSComp {
 		gpr.FlushBeforeCall();
 		fpr.FlushAll();
 
+		// Don't need to SaveStaticRegs here as long as they are all in callee-save regs - this callee won't read them.
+
 		bool negSin1 = (imm & 0x10) ? true : false;
 
 		fpr.MapRegV(sreg);

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -233,7 +233,8 @@ MIPSOpcode Arm64Jit::GetOffsetInstruction(int offset) {
 
 const u8 *Arm64Jit::DoJit(u32 em_address, JitBlock *b) {
 	js.cancel = false;
-	js.blockStart = js.compilerPC = mips_->pc;
+	js.blockStart = mips_->pc;
+	js.compilerPC = mips_->pc;
 	js.lastContinuedPC = 0;
 	js.initialBlockSize = 0;
 	js.nextExit = 0;

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -485,11 +485,20 @@ void Arm64Jit::MovToPC(ARM64Reg r) {
 
 // Should not really be necessary except when entering Advance
 void Arm64Jit::SaveStaticRegisters() {
-	QuickCallFunction(SCRATCH2_64, saveStaticRegisters);
+	if (jo.useStaticAlloc) {
+		QuickCallFunction(SCRATCH2_64, saveStaticRegisters);
+	} else {
+		// Inline the single operation
+		STR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
+	}
 }
 
 void Arm64Jit::LoadStaticRegisters() {
-	QuickCallFunction(SCRATCH2_64, loadStaticRegisters);
+	if (jo.useStaticAlloc) {
+		QuickCallFunction(SCRATCH2_64, loadStaticRegisters);
+	} else {
+		LDR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
+	}
 }
 
 void Arm64Jit::WriteDownCount(int offset) {

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -177,7 +177,7 @@ public:
 	void EatPrefix() { js.EatPrefix(); }
 
 private:
-	void GenerateFixedCode();
+	void GenerateFixedCode(const JitOptions &jo);
 	void FlushAll();
 	void FlushPrefixV();
 
@@ -197,8 +197,8 @@ private:
 
 	bool ReplaceJalTo(u32 dest);
 
-	void SaveDowncount();
-	void RestoreDowncount();
+	void SaveStaticRegisters();
+	void LoadStaticRegisters();
 
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInR(Arm64Gen::ARM64Reg Reg);
@@ -262,6 +262,9 @@ public:
 	const u8 *dispatcherNoCheck;
 
 	const u8 *breakpointBailout;
+
+	const u8 *saveStaticRegisters;
+	const u8 *loadStaticRegisters;
 
 	// Indexed by FPCR FZ:RN bits for convenience.  Uses SCRATCH2.
 	const u8 *convertS0ToSCRATCH1[8];

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -259,17 +259,20 @@ ARM64Reg Arm64RegCache::MapReg(MIPSGPReg mipsReg, int mapFlags) {
 
 	if (mr[mipsReg].isStatic) {
 		if (mr[mipsReg].loc == ML_IMM) {
-			if (!(mapFlags & MAP_NOINIT))
+			if ((mapFlags & MAP_NOINIT) == MAP_NOINIT) {
+				mr[mipsReg].loc = ML_ARMREG;
+			} else {
 				SetRegImm(armReg, mr[mipsReg].imm);
-			mr[mipsReg].loc = ML_ARMREG_IMM;
+				mr[mipsReg].loc = ML_ARMREG_IMM;
+			}
 		}
 		// Erasing the imm on dirty (necessary since otherwise we will still think it's ML_ARMREG_IMM and return
 		// true for IsImm and calculate crazily wrong things).  /unknown
 		if (mapFlags & MAP_DIRTY) {
 			mr[mipsReg].loc = ML_ARMREG;
+			ar[armReg].pointerified = false;
 			ar[armReg].isDirty = true;  // Not that it matters
 		}
-		ar[armReg].pointerified = false;
 		return mr[mipsReg].reg;
 	}
 

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -143,6 +143,10 @@ bool Arm64RegCache::IsMappedAsPointer(MIPSGPReg mipsReg) {
 	return false;
 }
 
+void Arm64RegCache::MarkDirty(ARM64Reg reg) {
+	ar[reg].isDirty = true;
+}
+
 void Arm64RegCache::SetRegImm(ARM64Reg reg, u64 imm) {
 	// On ARM64, at least Cortex A57, good old MOVT/MOVW  (MOVK in 64-bit) is really fast.
 	emit_->MOVI2R(reg, imm);

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -598,7 +598,7 @@ void Arm64RegCache::FlushAll() {
 		if (areg1 == INVALID_REG && IsPureImm(mreg1) && !mr[i].isStatic) {
 			areg1 = SCRATCH1;
 		}
-		if (areg2 == INVALID_REG && IsPureImm(mreg2) && !mr[i].isStatic) {
+		if (areg2 == INVALID_REG && IsPureImm(mreg2) && !mr[i + 1].isStatic) {
 			areg2 = SCRATCH2;
 		}
 
@@ -627,6 +627,7 @@ void Arm64RegCache::FlushAll() {
 		if (mr[i].isStatic) {
 			if (mr[i].loc == ML_IMM) {
 				SetRegImm(mr[i].reg, mr[i].imm);
+				mr[i].loc = ML_ARMREG_IMM;
 				ar[mr[mipsReg].reg].pointerified = false;
 			}
 			if (i != MIPS_REG_ZERO && mr[i].reg == INVALID_REG) {

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -645,6 +645,9 @@ void Arm64RegCache::FlushAll() {
 		if (allocs[i].pointerified && !ar[allocs[i].ar].pointerified) {
 			// Re-pointerify
 			emit_->MOVK(EncodeRegTo64(allocs[i].ar), ((uint64_t)Memory::base) >> 32, SHIFT_32);
+		} else {
+			// If this register got pointerified on the way, mark it as not, so that after save/reload (like in an interpreter fallback), it won't be regarded as such, as it simply won't be.
+			ar[allocs[i].ar].pointerified = false;
 		}
 	}
 	// Sanity check

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -139,6 +139,7 @@ private:
 	struct StaticAllocation {
 		MIPSGPReg mr;
 		Arm64Gen::ARM64Reg ar;
+		bool pointerified;
 	};
 	const StaticAllocation *GetStaticAllocations(int &count);
 	const Arm64Gen::ARM64Reg *GetMIPSAllocationOrder(int &count);

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -56,19 +56,11 @@ enum {
 	MAP_NOINIT = 2 | MAP_DIRTY,
 };
 
-}
-
-// R1 to R6: mapped MIPS regs
-// R8 = flags (maybe we could do better here?)
-// R9 = code pointers
-// R10 = MIPS context
-// R11 = base pointer
-// R14 = scratch (actually LR)
-
+}  // namespace
 
 typedef int MIPSReg;
 
-struct RegARM {
+struct RegARM64 {
 	MIPSGPReg mipsReg;  // if -1, no mipsreg attached.
 	bool isDirty;  // Should the register be written back?
 	bool pointerified;  // Has used movk to move the memory base into the top part of the reg. Note - still usable as 32-bit reg!
@@ -81,6 +73,7 @@ struct RegMIPS {
 	u64 imm;
 	Arm64Gen::ARM64Reg reg;  // reg index
 	bool spillLock;  // if true, this register cannot be spilled.
+	bool isStatic;  // if true, this register will not be written back to ram by the regcache
 	// If loc == ML_MEM, it's back in its location in the CPU context struct.
 };
 
@@ -123,7 +116,6 @@ public:
 	void MapDirtyDirtyIn(MIPSGPReg rd1, MIPSGPReg rd2, MIPSGPReg rs, bool avoidLoad = true);
 	void MapDirtyDirtyInIn(MIPSGPReg rd1, MIPSGPReg rd2, MIPSGPReg rs, MIPSGPReg rt, bool avoidLoad = true);
 	void FlushArmReg(Arm64Gen::ARM64Reg r);
-	void FlushR(MIPSGPReg r);
 	void FlushBeforeCall();
 	void FlushAll();
 	void DiscardR(MIPSGPReg r);
@@ -138,12 +130,22 @@ public:
 
 	int GetMipsRegOffset(MIPSGPReg r);
 
+	// Call these when leaving/entering the JIT
+	void EmitLoadStaticAllocs();
+	void EmitSaveStaticAllocs();
+
 private:
+	struct StaticAllocation {
+		MIPSGPReg mr;
+		Arm64Gen::ARM64Reg ar;
+	};
+	const StaticAllocation *GetStaticAllocations(int &count);
 	const Arm64Gen::ARM64Reg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(Arm64Gen::ARM64Reg reg, MIPSGPReg mipsReg, int mapFlags);
 	Arm64Gen::ARM64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	Arm64Gen::ARM64Reg ARM64RegForFlush(MIPSGPReg r);
-		
+	void FlushR(MIPSGPReg r);
+
 	MIPSState *mips_;
 	Arm64Gen::ARM64XEmitter *emit_;
 	MIPSComp::JitState *js_;
@@ -155,6 +157,6 @@ private:
 		NUM_MIPSREG = Arm64JitConstants::TOTAL_MAPPABLE_MIPSREGS,
 	};
 
-	RegARM ar[NUM_ARMREG];
+	RegARM64 ar[NUM_ARMREG];
 	RegMIPS mr[NUM_MIPSREG];
 };

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -118,6 +118,7 @@ public:
 	void FlushArmReg(Arm64Gen::ARM64Reg r);
 	void FlushBeforeCall();
 	void FlushAll();
+	void FlushR(MIPSGPReg r);
 	void DiscardR(MIPSGPReg r);
 
 	Arm64Gen::ARM64Reg R(MIPSGPReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
@@ -144,7 +145,6 @@ private:
 	void MapRegTo(Arm64Gen::ARM64Reg reg, MIPSGPReg mipsReg, int mapFlags);
 	Arm64Gen::ARM64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	Arm64Gen::ARM64Reg ARM64RegForFlush(MIPSGPReg r);
-	void FlushR(MIPSGPReg r);
 
 	MIPSState *mips_;
 	Arm64Gen::ARM64XEmitter *emit_;

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -109,6 +109,7 @@ public:
 	bool IsMapped(MIPSGPReg reg);
 	bool IsMappedAsPointer(MIPSGPReg reg);
 
+	void MarkDirty(Arm64Gen::ARM64Reg reg);
 	void MapIn(MIPSGPReg rs);
 	void MapInIn(MIPSGPReg rd, MIPSGPReg rs);
 	void MapDirtyIn(MIPSGPReg rd, MIPSGPReg rs, bool avoidLoad = true);

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -98,6 +98,7 @@ public:
 
 	void SetImm(MIPSGPReg reg, u64 immVal);
 	bool IsImm(MIPSGPReg reg) const;
+	bool IsPureImm(MIPSGPReg reg) const;
 	u64 GetImm(MIPSGPReg reg) const;
 	// Optimally set a register to an imm value (possibly using another register.)
 	void SetRegImm(Arm64Gen::ARM64Reg reg, u64 imm);

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -45,5 +45,10 @@ namespace MIPSComp {
 		continueBranches = false;
 		continueJumps = false;
 		continueMaxInstructions = 300;
+
+		useStaticAlloc = false;
+#ifdef ARM64
+		useStaticAlloc = true;
+#endif
 	}
 }

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -194,6 +194,7 @@ namespace MIPSComp {
 		bool downcountInRegister;
 		// ARM64 only
 		bool useASIMDVFPU;
+		bool useStaticAlloc;
 
 		// Common
 		bool enableBlocklink;


### PR DESCRIPTION
Haven't really benchmarked but the code looks a bit nicer and shorter quite often.

We probably want to statically allocate more registers as there's plenty of space, but it's best to allocate these in callee-save registers, and there's no more left. There are a couple we could free up though.

More testing is needed before merge.
