### PR TITLE
Use pixelWidth/pixelHeight for Auto (1:1) res

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -113,8 +113,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 	const Bounds &bounds = screenManager()->getUIContext()->GetBounds();
 
 	if (g_Config.iInternalResolution == 0) {
-		coreParam.renderWidth = bounds.w;
-		coreParam.renderHeight = bounds.h;
+		coreParam.renderWidth = coreParam.pixelWidth;
+		coreParam.renderHeight = coreParam.pixelHeight;
 	} else {
 		if (g_Config.iInternalResolution < 0)
 			g_Config.iInternalResolution = 1;


### PR DESCRIPTION
By definition, it ought to be 1 PSP pixel for each host pixel.

The old way was accounting for dpi (thanks xperia64.)  Fixes #7764.

On my Nexus 5, I get `NativeApp.displayResize(1920 x 1080, dpi=480, refresh=60.00)` which is "correct" (the refresh rate is [not exactly right due to an Android bug](https://code.google.com/p/android/issues/detail?id=82922).)

But it thinks 1:1 is 960x540.  This is because dpi=480, and so g_dpi_scale=0.5.  Thus it's using "qHD" by halving each width and height.

Instead we just want 1:1 pixels.  That's what it says on the tin, after all.

-[Unknown]
