### PR TITLE
Check all jit blocks in sceKernelIcacheInvalidateAll()

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -284,9 +284,7 @@ std::vector<std::string> CWCheatEngine::GetCodesList() { //Reads the entire chea
 }
 
 void CWCheatEngine::InvalidateICache(u32 addr, int size) {
-	if (MIPSComp::jit) {
-		MIPSComp::jit->GetBlockCache()->InvalidateICache(addr & ~3, size);
-	}
+	currentMIPS->InvalidateICache(addr & ~3, size);
 }
 
 void CWCheatEngine::Run() {

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -425,6 +425,8 @@ u32 sceKernelIcacheInvalidateAll()
 #ifdef LOG_CACHE
 	NOTICE_LOG(CPU, "Icache invalidated - should clear JIT someday");
 #endif
+	// Note that this doesn't actually fully invalidate all with such a large range.
+	currentMIPS->InvalidateICache(0, 0x3FFFFFFF);
 	return 0;
 }
 
@@ -435,6 +437,8 @@ u32 sceKernelIcacheClearAll()
 	NOTICE_LOG(CPU, "Icache cleared - should clear JIT someday");
 #endif
 	DEBUG_LOG(CPU, "Icache cleared - should clear JIT someday");
+	// Note that this doesn't actually fully invalidate all with such a large range.
+	currentMIPS->InvalidateICache(0, 0x3FFFFFFF);
 	return 0;
 }
 

--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -533,7 +533,7 @@ namespace MIPSComp
 
 		int pos = _POS;
 		int size = _SIZE + 1;
-		u32 mask = (1 << size) - 1;
+		u32 mask = 0xFFFFFFFFUL >> (32 - size);
 
 		// Don't change $zr.
 		if (rt == 0)

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -431,8 +431,7 @@ void Arm64Jit::Comp_Special3(MIPSOpcode op) {
 
 	int pos = _POS;
 	int size = _SIZE + 1;
-	// Workaround for a compiler bug.
-	u32 mask = size == 32 ? 0xFFFFFFFF : (1 << size) - 1;
+	u32 mask = 0xFFFFFFFFUL >> (32 - size);
 
 	// Don't change $zr.
 	if (rt == 0)

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -147,6 +147,7 @@ public:
 
 	// DOES NOT WORK CORRECTLY WITH JIT INLINING
 	void InvalidateICache(u32 address, const u32 length);
+	void InvalidateChangedBlocks();
 	void DestroyBlock(int block_num, bool invalidate);
 
 	// No jit operations may be run between these calls.

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -866,14 +866,15 @@ namespace MIPSInt
 		case 0x0: //ext
 			{
 				int size = _SIZE + 1;
-				R(rt) = (R(rs) >> pos) & ((1<<size) - 1);
+				u32 sourcemask = 0xFFFFFFFFUL >> (32 - size);
+				R(rt) = (R(rs) >> pos) & sourcemask;
 			}
 			break;
 		case 0x4: //ins
 			{
 				int size = (_SIZE + 1) - pos;
-				int sourcemask = (1 << size) - 1;
-				int destmask = sourcemask << pos;
+				u32 sourcemask = 0xFFFFFFFFUL >> (32 - size);
+				u32 destmask = sourcemask << pos;
 				R(rt) = (R(rt) & ~destmask) | ((R(rs)&sourcemask) << pos);
 			}
 			break;


### PR DESCRIPTION
This makes it invalidate all jit blocks that have definitely changed, which also invalidates any block linking to them.

Fixes #7868.

-[Unknown]
