### PR TITLE
Split texture application into two phases

### DIFF
--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -115,6 +115,12 @@ extern GPUgstate gstate;
 
 void GetFramebufferHeuristicInputs(FramebufferHeuristicParams *params, const GPUgstate &gstate);
 
+enum BindFramebufferColorFlags {
+	BINDFBCOLOR_SKIP_COPY = 0,
+	BINDFBCOLOR_MAY_COPY = 1,
+	BINDFBCOLOR_MAY_COPY_WITH_UV = 3,
+};
+
 class FramebufferManagerCommon {
 public:
 	FramebufferManagerCommon();

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -119,6 +119,7 @@ enum BindFramebufferColorFlags {
 	BINDFBCOLOR_SKIP_COPY = 0,
 	BINDFBCOLOR_MAY_COPY = 1,
 	BINDFBCOLOR_MAY_COPY_WITH_UV = 3,
+	BINDFBCOLOR_APPLY_TEX_OFFSET = 4,
 };
 
 class FramebufferManagerCommon {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -51,7 +51,6 @@ void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sCl
 		minFilt |= 1;
 	}
 	if (g_Config.iTexFiltering == TEX_FILTER_LINEAR && (!gstate.isColorTestEnabled() || IsColorTestTriviallyTrue())) {
-		// TODO: IsAlphaTestTriviallyTrue() is unsafe here.  vertexFullAlpha is not calculated yet.
 		if (!gstate.isAlphaTestEnabled() || IsAlphaTestTriviallyTrue()) {
 			magFilt |= 1;
 			minFilt |= 1;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -79,6 +79,7 @@ public:
 		u32 fullhash;
 		u32 cluthash;
 		float lodBias;
+		u16 maxSeenV;
 
 		// Cache the current filter settings so we can avoid setting it again.
 		// (OpenGL madness where filter settings are attached to each texture).

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -15,6 +15,11 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// This allows highlighting to work.  Yay.
+#ifdef __INTELLISENSE__
+#define ARM
+#endif
+
 #include "base/logging.h"
 #include "Common/CPUDetect.h"
 #include "Core/Config.h"

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -572,7 +572,7 @@ void VertexDecoderJitCache::Jit_TcU16Through() {
 	LDRH(tempReg2, srcReg, dec_->tcoff + 2);
 
 	// TODO: Cleanup.
-	MOVP2R(scratchReg, &gstate_c.vertMinU);
+	MOVP2R(scratchReg, &gstate_c.vertBounds.minU);
 
 	auto updateSide = [&](ARMReg r, CCFlags cc, u32 off) {
 		LDRH(tempReg3, scratchReg, off);
@@ -583,10 +583,10 @@ void VertexDecoderJitCache::Jit_TcU16Through() {
 	};
 
 	// TODO: Can this actually be fast?  Hmm, floats aren't better.
-	updateSide(tempReg1, CC_LT, 0);
-	updateSide(tempReg1, CC_GT, 2);
-	updateSide(tempReg2, CC_LT, 4);
-	updateSide(tempReg2, CC_GT, 6);
+	updateSide(tempReg1, CC_LT, offsetof(KnownVertexBounds, minU));
+	updateSide(tempReg1, CC_GT, offsetof(KnownVertexBounds, maxU));
+	updateSide(tempReg2, CC_LT, offsetof(KnownVertexBounds, minV));
+	updateSide(tempReg2, CC_GT, offsetof(KnownVertexBounds, maxV));
 
 	ORR(tempReg1, tempReg1, Operand2(tempReg2, ST_LSL, 16));
 	STR(tempReg1, dstReg, dec_->decFmt.uvoff);

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -565,6 +565,24 @@ void VertexDecoderJitCache::Jit_TcFloat() {
 void VertexDecoderJitCache::Jit_TcU16Through() {
 	LDRH(tempReg1, srcReg, dec_->tcoff);
 	LDRH(tempReg2, srcReg, dec_->tcoff + 2);
+
+	// TODO: Cleanup.
+	MOVP2R(scratchReg, &gstate_c.vertMinU);
+
+	auto updateSide = [&](ARMReg r, CCFlags cc, u32 off) {
+		LDRH(tempReg3, scratchReg, off);
+		CMP(r, tempReg3);
+		SetCC(cc);
+		STRH(r, scratchReg, off);
+		SetCC(CC_AL);
+	};
+
+	// TODO: Can this actually be fast?  Hmm, floats aren't better.
+	updateSide(tempReg1, CC_LT, 0);
+	updateSide(tempReg1, CC_GT, 2);
+	updateSide(tempReg2, CC_LT, 4);
+	updateSide(tempReg2, CC_GT, 6);
+
 	ORR(tempReg1, tempReg1, Operand2(tempReg2, ST_LSL, 16));
 	STR(tempReg1, dstReg, dec_->decFmt.uvoff);
 }

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -563,7 +563,7 @@ void VertexDecoderJitCache::Jit_TcU16Through() {
 	LDRH(INDEX_UNSIGNED, tempReg2, srcReg, dec_->tcoff + 2);
 
 	// TODO: Cleanup.
-	MOVP2R(scratchReg64, &gstate_c.vertMinU);
+	MOVP2R(scratchReg64, &gstate_c.vertBounds.minU);
 
 	auto updateSide = [&](ARM64Reg r, CCFlags cc, u32 off) {
 		LDRH(INDEX_UNSIGNED, tempReg3, scratchReg64, off);
@@ -574,10 +574,10 @@ void VertexDecoderJitCache::Jit_TcU16Through() {
 	};
 
 	// TODO: Can this actually be fast?  Hmm, floats aren't better.
-	updateSide(tempReg1, CC_LT, 0);
-	updateSide(tempReg1, CC_GT, 2);
-	updateSide(tempReg2, CC_LT, 4);
-	updateSide(tempReg2, CC_GT, 6);
+	updateSide(tempReg1, CC_LT, offsetof(KnownVertexBounds, minU));
+	updateSide(tempReg1, CC_GT, offsetof(KnownVertexBounds, maxU));
+	updateSide(tempReg2, CC_LT, offsetof(KnownVertexBounds, minV));
+	updateSide(tempReg2, CC_GT, offsetof(KnownVertexBounds, maxV));
 
 	ORR(tempReg1, tempReg1, tempReg2, ArithOption(tempReg2, ST_LSL, 16));
 	STR(INDEX_UNSIGNED, tempReg1, dstReg, dec_->decFmt.uvoff);

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -15,6 +15,11 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// This allows highlighting to work.  Yay.
+#ifdef __INTELLISENSE__
+#define ARM64
+#endif
+
 #include "base/logging.h"
 #include "Common/CPUDetect.h"
 #include "Core/Config.h"

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <stdio.h>
 
 #include "base/basictypes.h"
@@ -294,6 +295,11 @@ void VertexDecoder::Step_TcU16Through() const
 	const u16 *uvdata = (const u16_le*)(ptr_ + tcoff);
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
+
+	gstate_c.vertMinU = std::min(gstate_c.vertMinU, uvdata[0]);
+	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, uvdata[0]);
+	gstate_c.vertMinV = std::min(gstate_c.vertMinV, uvdata[1]);
+	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU16ThroughDouble() const
@@ -318,6 +324,11 @@ void VertexDecoder::Step_TcU16ThroughToFloat() const
 	const u16 *uvdata = (const u16_le*)(ptr_ + tcoff);
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
+
+	gstate_c.vertMinU = std::min(gstate_c.vertMinU, uvdata[0]);
+	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, uvdata[0]);
+	gstate_c.vertMinV = std::min(gstate_c.vertMinV, uvdata[1]);
+	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU16ThroughDoubleToFloat() const
@@ -342,6 +353,11 @@ void VertexDecoder::Step_TcFloatThrough() const
 	const float *uvdata = (const float*)(ptr_ + tcoff);
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
+
+	gstate_c.vertMinU = std::min(gstate_c.vertMinU, (u16)uvdata[0]);
+	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, (u16)uvdata[0]);
+	gstate_c.vertMinV = std::min(gstate_c.vertMinV, (u16)uvdata[1]);
+	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, (u16)uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU8Prescale() const {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -296,10 +296,10 @@ void VertexDecoder::Step_TcU16Through() const
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
 
-	gstate_c.vertMinU = std::min(gstate_c.vertMinU, uvdata[0]);
-	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, uvdata[0]);
-	gstate_c.vertMinV = std::min(gstate_c.vertMinV, uvdata[1]);
-	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, uvdata[1]);
+	gstate_c.vertBounds.minU = std::min(gstate_c.vertBounds.minU, uvdata[0]);
+	gstate_c.vertBounds.maxU = std::max(gstate_c.vertBounds.maxU, uvdata[0]);
+	gstate_c.vertBounds.minV = std::min(gstate_c.vertBounds.minV, uvdata[1]);
+	gstate_c.vertBounds.maxV = std::max(gstate_c.vertBounds.maxV, uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU16ThroughDouble() const
@@ -325,10 +325,10 @@ void VertexDecoder::Step_TcU16ThroughToFloat() const
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
 
-	gstate_c.vertMinU = std::min(gstate_c.vertMinU, uvdata[0]);
-	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, uvdata[0]);
-	gstate_c.vertMinV = std::min(gstate_c.vertMinV, uvdata[1]);
-	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, uvdata[1]);
+	gstate_c.vertBounds.minU = std::min(gstate_c.vertBounds.minU, uvdata[0]);
+	gstate_c.vertBounds.maxU = std::max(gstate_c.vertBounds.maxU, uvdata[0]);
+	gstate_c.vertBounds.minV = std::min(gstate_c.vertBounds.minV, uvdata[1]);
+	gstate_c.vertBounds.maxV = std::max(gstate_c.vertBounds.maxV, uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU16ThroughDoubleToFloat() const
@@ -354,10 +354,10 @@ void VertexDecoder::Step_TcFloatThrough() const
 	uv[0] = uvdata[0];
 	uv[1] = uvdata[1];
 
-	gstate_c.vertMinU = std::min(gstate_c.vertMinU, (u16)uvdata[0]);
-	gstate_c.vertMaxU = std::max(gstate_c.vertMaxU, (u16)uvdata[0]);
-	gstate_c.vertMinV = std::min(gstate_c.vertMinV, (u16)uvdata[1]);
-	gstate_c.vertMaxV = std::max(gstate_c.vertMaxV, (u16)uvdata[1]);
+	gstate_c.vertBounds.minU = std::min(gstate_c.vertBounds.minU, (u16)uvdata[0]);
+	gstate_c.vertBounds.maxU = std::max(gstate_c.vertBounds.maxU, (u16)uvdata[0]);
+	gstate_c.vertBounds.minV = std::min(gstate_c.vertBounds.minV, (u16)uvdata[1]);
+	gstate_c.vertBounds.maxV = std::max(gstate_c.vertBounds.maxV, (u16)uvdata[1]);
 }
 
 void VertexDecoder::Step_TcU8Prescale() const {

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -721,10 +721,10 @@ void VertexDecoderJitCache::Jit_TcU16Through() {
 	};
 
 	// TODO: Can this actually be fast?  Hmm, floats aren't better.
-	updateSide(tempReg1, CC_GE, &gstate_c.vertMinU);
-	updateSide(tempReg1, CC_LE, &gstate_c.vertMaxU);
-	updateSide(tempReg2, CC_GE, &gstate_c.vertMinV);
-	updateSide(tempReg2, CC_LE, &gstate_c.vertMaxV);
+	updateSide(tempReg1, CC_GE, &gstate_c.vertBounds.minU);
+	updateSide(tempReg1, CC_LE, &gstate_c.vertBounds.maxU);
+	updateSide(tempReg2, CC_GE, &gstate_c.vertBounds.minV);
+	updateSide(tempReg2, CC_LE, &gstate_c.vertBounds.maxV);
 }
 
 void VertexDecoderJitCache::Jit_TcU16ThroughToFloat() {

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -709,6 +709,22 @@ void VertexDecoderJitCache::Jit_TcFloatPrescale() {
 void VertexDecoderJitCache::Jit_TcU16Through() {
 	MOV(32, R(tempReg1), MDisp(srcReg, dec_->tcoff));
 	MOV(32, MDisp(dstReg, dec_->decFmt.uvoff), R(tempReg1));
+
+	MOV(32, R(tempReg2), R(tempReg1));
+	SHR(32, R(tempReg2), Imm8(16));
+
+	auto updateSide = [&](X64Reg r, CCFlags skipCC, u16 *value) {
+		CMP(16, R(r), M(value));
+		FixupBranch skip = J_CC(skipCC);
+		MOV(16, M(value), R(r));
+		SetJumpTarget(skip);
+	};
+
+	// TODO: Can this actually be fast?  Hmm, floats aren't better.
+	updateSide(tempReg1, CC_GE, &gstate_c.vertMinU);
+	updateSide(tempReg1, CC_LE, &gstate_c.vertMaxU);
+	updateSide(tempReg2, CC_GE, &gstate_c.vertMinV);
+	updateSide(tempReg2, CC_LE, &gstate_c.vertMaxV);
 }
 
 void VertexDecoderJitCache::Jit_TcU16ThroughToFloat() {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -644,6 +644,12 @@ namespace DX9 {
 					y = gstate_c.vertMinV;
 					w = gstate_c.vertMaxU - x;
 					h = gstate_c.vertMaxV - y;
+
+					// If we bound a framebuffer, apply the byte offset as pixels to the copy too.
+					if (flags & BINDFBCOLOR_APPLY_TEX_OFFSET) {
+						x += gstate_c.curTextureXOffset;
+						y += gstate_c.curTextureYOffset;
+					}
 				}
 
 				BlitFramebuffer(&copyInfo, x, y, framebuffer, x, y, w, h, 0, false);

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -639,11 +639,11 @@ namespace DX9 {
 
 				// If max is not > min, we probably could not detect it.  Skip.
 				// See the vertex decoder, where this is updated.
-				if ((flags & BINDFBCOLOR_MAY_COPY_WITH_UV) != 0 && gstate_c.vertMaxU > gstate_c.vertMinU) {
-					x = gstate_c.vertMinU;
-					y = gstate_c.vertMinV;
-					w = gstate_c.vertMaxU - x;
-					h = gstate_c.vertMaxV - y;
+				if ((flags & BINDFBCOLOR_MAY_COPY_WITH_UV) != 0 && gstate_c.vertBounds.maxU > gstate_c.vertBounds.minU) {
+					x = gstate_c.vertBounds.minU;
+					y = gstate_c.vertBounds.minV;
+					w = gstate_c.vertBounds.maxU - x;
+					h = gstate_c.vertBounds.maxV - y;
 
 					// If we bound a framebuffer, apply the byte offset as pixels to the copy too.
 					if (flags & BINDFBCOLOR_APPLY_TEX_OFFSET) {

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -71,7 +71,7 @@ public:
 
 	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
-	void BindFramebufferColor(int stage, VirtualFramebuffer *framebuffer, bool skipCopy = false);
+	void BindFramebufferColor(int stage, VirtualFramebuffer *framebuffer, int flags);
 
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
 

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -812,6 +812,8 @@ void TransformDrawEngineDX9::ApplyDrawStateLate() {
 	if (!gstate.isModeClear()) {
 		// TODO: Test texture?
 
+		textureCache_->ApplyTexture();
+
 		if (fboTexNeedBind_) {
 			framebufferManager_->BindFramebufferColor(1, nullptr, false);
 			// If we are rendering at a higher resolution, linear is probably best for the dest color.

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -815,7 +815,7 @@ void TransformDrawEngineDX9::ApplyDrawStateLate() {
 		textureCache_->ApplyTexture();
 
 		if (fboTexNeedBind_) {
-			framebufferManager_->BindFramebufferColor(1, nullptr, false);
+			framebufferManager_->BindFramebufferColor(1, nullptr, BINDFBCOLOR_MAY_COPY_WITH_UV);
 			// If we are rendering at a higher resolution, linear is probably best for the dest color.
 			pD3Ddevice->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
 			pD3Ddevice->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -926,7 +926,7 @@ void TextureCacheDX9::ApplyTexture() {
 			// Texture scale/offset and gen modes don't apply in through.
 			// So we can optimize how much of the texture we look at.
 			if (gstate.isModeThrough()) {
-				nextTexture_->maxSeenV = std::max(nextTexture_->maxSeenV, gstate_c.vertMaxV);
+				nextTexture_->maxSeenV = std::max(nextTexture_->maxSeenV, gstate_c.vertBounds.maxV);
 			} else {
 				// Otherwise, we need to reset to ensure we use the whole thing.
 				// Can't tell how much is used.
@@ -987,17 +987,17 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 		};
 
 		// If min is not < max, then we don't have values (wasn't set during decode.)
-		if (gstate_c.vertMinV < gstate_c.vertMaxV) {
+		if (gstate_c.vertBounds.minV < gstate_c.vertBounds.maxV) {
 			const float invWidth = 1.0f / (float)framebuffer->bufferWidth;
 			const float invHeight = 1.0f / (float)framebuffer->bufferHeight;
 			// Inverse of half = double.
 			const float invHalfWidth = invWidth * 2.0f;
 			const float invHalfHeight = invHeight * 2.0f;
 
-			const int u1 = gstate_c.vertMinU + gstate_c.curTextureXOffset;
-			const int v1 = gstate_c.vertMinV + gstate_c.curTextureYOffset;
-			const int u2 = gstate_c.vertMaxU + gstate_c.curTextureXOffset;
-			const int v2 = gstate_c.vertMaxV + gstate_c.curTextureYOffset;
+			const int u1 = gstate_c.vertBounds.minU + gstate_c.curTextureXOffset;
+			const int v1 = gstate_c.vertBounds.minV + gstate_c.curTextureYOffset;
+			const int u2 = gstate_c.vertBounds.maxU + gstate_c.curTextureXOffset;
+			const int v2 = gstate_c.vertBounds.maxV + gstate_c.curTextureYOffset;
 
 			const float left = u1 * invHalfWidth - 1.0f + xoff;
 			const float right = u2 * invHalfWidth - 1.0f + xoff;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -994,10 +994,15 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 			const float invHalfWidth = invWidth * 2.0f;
 			const float invHalfHeight = invHeight * 2.0f;
 
-			const float left = gstate_c.vertMinU * invHalfWidth - 1.0f + xoff;
-			const float right = gstate_c.vertMaxU * invHalfWidth - 1.0f + xoff;
-			const float top = gstate_c.vertMinV * invHalfHeight - 1.0f + yoff;
-			const float bottom = gstate_c.vertMaxV * invHalfHeight - 1.0f + yoff;
+			const int u1 = gstate_c.vertMinU + gstate_c.curTextureXOffset;
+			const int v1 = gstate_c.vertMinV + gstate_c.curTextureYOffset;
+			const int u2 = gstate_c.vertMaxU + gstate_c.curTextureXOffset;
+			const int v2 = gstate_c.vertMaxV + gstate_c.curTextureYOffset;
+
+			const float left = u1 * invHalfWidth - 1.0f + xoff;
+			const float right = u2 * invHalfWidth - 1.0f + xoff;
+			const float top = v1 * invHalfHeight - 1.0f + yoff;
+			const float bottom = v2 * invHalfHeight - 1.0f + yoff;
 			// Points are: BL, BR, TR, TL.
 			verts[0].pos = Pos(left, bottom, -1.0f);
 			verts[1].pos = Pos(right, bottom, -1.0f);
@@ -1005,10 +1010,10 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 			verts[3].pos = Pos(left, top, -1.0f);
 
 			// And also the UVs, same order.
-			const float uvleft = gstate_c.vertMinU * invWidth;
-			const float uvright = gstate_c.vertMaxU * invWidth;
-			const float uvtop = 1.0f - gstate_c.vertMinV * invHeight;
-			const float uvbottom = 1.0f - gstate_c.vertMaxV * invHeight;
+			const float uvleft = u1 * invWidth;
+			const float uvright = u2 * invWidth;
+			const float uvtop = 1.0f - v1 * invHeight;
+			const float uvbottom = 1.0f - v2 * invHeight;
 			verts[0].uv = UV(uvleft, uvbottom);
 			verts[1].uv = UV(uvright, uvbottom);
 			verts[2].uv = UV(uvright, uvtop);
@@ -1059,7 +1064,7 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 
 		framebufferManager_->RebindFramebuffer();
 	} else {
-		framebufferManager_->BindFramebufferColor(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV);
+		framebufferManager_->BindFramebufferColor(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 	}
 
 	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -766,7 +766,12 @@ static inline u32 MiniHash(const u32 *ptr) {
 	return ptr[0];
 }
 
-static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, GETextureFormat format) {
+static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, GETextureFormat format, TextureCacheDX9::TexCacheEntry *entry) {
+	if (h == 512 && entry->maxSeenV < 512 && entry->maxSeenV != 0) {
+		// Let's not hash less than 272, we might use more later and have to rehash.  272 is very common.
+		h = std::max(272, (int)entry->maxSeenV);
+	}
+
 	const u32 sizeInRAM = (textureBitsPerPixel[format] * bufw * h) / 8;
 	const u32 *checkp = (const u32 *) Memory::GetPointer(addr);
 
@@ -916,6 +921,20 @@ void TextureCacheDX9::ApplyTexture() {
 	if (nextTexture_->framebuffer) {
 		ApplyTextureFramebuffer(nextTexture_, nextTexture_->framebuffer);
 	} else {
+		// If the texture is >= 512 pixels tall...
+		if (nextTexture_->dim >= 0x900) {
+			// Texture scale/offset and gen modes don't apply in through.
+			// So we can optimize how much of the texture we look at.
+			if (gstate.isModeThrough()) {
+				nextTexture_->maxSeenV = std::max(nextTexture_->maxSeenV, gstate_c.vertMaxV);
+			} else {
+				// Otherwise, we need to reset to ensure we use the whole thing.
+				// Can't tell how much is used.
+				// TODO: We could tell for texcoord UV gen, and apply scale to max?
+				nextTexture_->maxSeenV = 512;
+			}
+		}
+
 		LPDIRECT3DTEXTURE9 texture = DxTex(nextTexture_);
 		pD3Ddevice->SetTexture(0, texture);
 		lastBoundTexture = texture;
@@ -1156,13 +1175,13 @@ void TextureCacheDX9::SetTexture(bool force) {
 
 			bool hashFail = false;
 			if (texhash != entry->hash) {
-				fullhash = QuickTexHash(texaddr, bufw, w, h, format);
+				fullhash = QuickTexHash(texaddr, bufw, w, h, format, entry);
 				hashFail = true;
 				rehash = false;
 			}
 
 			if (rehash && entry->GetHashStatus() != TexCacheEntry::STATUS_RELIABLE) {
-				fullhash = QuickTexHash(texaddr, bufw, w, h, format);
+				fullhash = QuickTexHash(texaddr, bufw, w, h, format, entry);
 				if (fullhash != entry->fullhash) {
 					hashFail = true;
 				} else if (entry->GetHashStatus() != TexCacheEntry::STATUS_HASHING && entry->numFrames > TexCacheEntry::FRAMES_REGAIN_TRUST) {
@@ -1297,7 +1316,7 @@ void TextureCacheDX9::SetTexture(bool force) {
 	// to avoid excessive clearing caused by cache invalidations.
 	entry->sizeInRAM = (textureBitsPerPixel[format] * bufw * h / 2) / 8;
 
-	entry->fullhash = fullhash == 0 ? QuickTexHash(texaddr, bufw, w, h, format) : fullhash;
+	entry->fullhash = fullhash == 0 ? QuickTexHash(texaddr, bufw, w, h, format, entry) : fullhash;
 	entry->cluthash = cluthash;
 
 	entry->status &= ~TexCacheEntry::STATUS_ALPHA_MASK;

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -81,6 +81,8 @@ public:
 
 	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 
+	void ApplyTexture();
+
 private:
 	// Can't be unordered_map, we use lower_bound ... although for some reason that compiles on MSVC.
 	typedef std::map<u64, TexCacheEntry> TexCache;
@@ -101,6 +103,7 @@ private:
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
+	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
 
 	LPDIRECT3DTEXTURE9 &DxTex(TexCacheEntry *entry) {
 		return *(LPDIRECT3DTEXTURE9 *)&entry->texturePtr;
@@ -147,6 +150,8 @@ private:
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
+
+	TexCacheEntry *nextTexture_;
 
 	LPDIRECT3DTEXTURE9 lastBoundTexture;
 	float maxAnisotropyLevel;

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -884,6 +884,12 @@ rotateVBO:
 	gstate_c.vertexFullAlpha = true;
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
+	// Now seems as good a time as any to reset the min/max coords, which we may examine later.
+	gstate_c.vertMinU = 512;
+	gstate_c.vertMinV = 512;
+	gstate_c.vertMaxU = 0;
+	gstate_c.vertMaxV = 0;
+
 	host->GPUNotifyDraw();
 }
 

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -695,7 +695,7 @@ void TransformDrawEngineDX9::DoFlush() {
 							vai->numVerts = indexGen.PureCount();
 						}
 
-						_dbg_assert_msg_(G3D, gstate_c.vertMinV >= gstate_c.vertMaxV, "Should not have checked UVs when caching.");
+						_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 
 						void * pVb;
 						u32 size = dec_->GetDecVtxFmt().stride * indexGen.MaxIndex();
@@ -888,10 +888,10 @@ rotateVBO:
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
 	// Now seems as good a time as any to reset the min/max coords, which we may examine later.
-	gstate_c.vertMinU = 512;
-	gstate_c.vertMinV = 512;
-	gstate_c.vertMaxU = 0;
-	gstate_c.vertMaxV = 0;
+	gstate_c.vertBounds.minU = 512;
+	gstate_c.vertBounds.minV = 512;
+	gstate_c.vertBounds.maxU = 0;
+	gstate_c.vertBounds.maxV = 0;
 
 	host->GPUNotifyDraw();
 }

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -694,6 +694,9 @@ void TransformDrawEngineDX9::DoFlush() {
 						if (!useElements && indexGen.PureCount()) {
 							vai->numVerts = indexGen.PureCount();
 						}
+
+						_dbg_assert_msg_(G3D, gstate_c.vertMinV >= gstate_c.vertMaxV, "Should not have checked UVs when caching.");
+
 						void * pVb;
 						u32 size = dec_->GetDecVtxFmt().stride * indexGen.MaxIndex();
 						pD3Ddevice->CreateVertexBuffer(size, D3DUSAGE_WRITEONLY, 0, D3DPOOL_DEFAULT, &vai->vbo, NULL);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -874,11 +874,11 @@ void FramebufferManager::BindFramebufferColor(int stage, u32 fbRawAddress, Virtu
 
 			// If max is not > min, we probably could not detect it.  Skip.
 			// See the vertex decoder, where this is updated.
-			if ((flags & BINDFBCOLOR_MAY_COPY_WITH_UV) != 0 && gstate_c.vertMaxU > gstate_c.vertMinU) {
-				x = gstate_c.vertMinU;
-				y = gstate_c.vertMinV;
-				w = gstate_c.vertMaxU - x;
-				h = gstate_c.vertMaxV - y;
+			if ((flags & BINDFBCOLOR_MAY_COPY_WITH_UV) != 0 && gstate_c.vertBounds.maxU > gstate_c.vertBounds.minU) {
+				x = gstate_c.vertBounds.minU;
+				y = gstate_c.vertBounds.minV;
+				w = gstate_c.vertBounds.maxU - x;
+				h = gstate_c.vertBounds.maxV - y;
 
 				// If we bound a framebuffer, apply the byte offset as pixels to the copy too.
 				if (flags & BINDFBCOLOR_APPLY_TEX_OFFSET) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -879,6 +879,12 @@ void FramebufferManager::BindFramebufferColor(int stage, u32 fbRawAddress, Virtu
 				y = gstate_c.vertMinV;
 				w = gstate_c.vertMaxU - x;
 				h = gstate_c.vertMaxV - y;
+
+				// If we bound a framebuffer, apply the byte offset as pixels to the copy too.
+				if (flags & BINDFBCOLOR_APPLY_TEX_OFFSET) {
+					x += gstate_c.curTextureXOffset;
+					y += gstate_c.curTextureYOffset;
+				}
 			}
 
 			BlitFramebuffer(&copyInfo, x, y, framebuffer, x, y, w, h, 0, false);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -98,7 +98,7 @@ public:
 	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
 	// For use when texturing from a framebuffer.  May create a duplicate if target.
-	void BindFramebufferColor(int stage, u32 fbRawAddress, VirtualFramebuffer *framebuffer, bool skipCopy = false);
+	void BindFramebufferColor(int stage, u32 fbRawAddress, VirtualFramebuffer *framebuffer, int flags);
 
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -747,6 +747,7 @@ void ShaderManager::DirtyLastShader() { // disables vertex arrays
 	if (lastShader_)
 		lastShader_->stop();
 	lastShader_ = 0;
+	lastVShaderSame_ = false;
 }
 
 // This is to be used when debugging why incompatible shaders are being linked, like is

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -904,7 +904,9 @@ void TransformDrawEngine::ApplyDrawStateLate() {
 		textureCache_->ApplyTexture();
 
 		if (fboTexNeedBind_) {
-			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr);
+			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr, BINDFBCOLOR_MAY_COPY_WITH_UV);
+			framebufferManager_->RebindFramebuffer();
+
 			glActiveTexture(GL_TEXTURE1);
 			// If we are rendering at a higher resolution, linear is probably best for the dest color.
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -901,6 +901,8 @@ void TransformDrawEngine::ApplyDrawStateLate() {
 			fragmentTestCache_->BindTestTexture(GL_TEXTURE2);
 		}
 
+		textureCache_->ApplyTexture();
+
 		if (fboTexNeedBind_) {
 			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr);
 			glActiveTexture(GL_TEXTURE1);

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -996,7 +996,7 @@ void TextureCache::ApplyTexture() {
 			// Texture scale/offset and gen modes don't apply in through.
 			// So we can optimize how much of the texture we look at.
 			if (gstate.isModeThrough()) {
-				nextTexture_->maxSeenV = std::max(nextTexture_->maxSeenV, gstate_c.vertMaxV);
+				nextTexture_->maxSeenV = std::max(nextTexture_->maxSeenV, gstate_c.vertBounds.maxV);
 			} else {
 				// Otherwise, we need to reset to ensure we use the whole thing.
 				// Can't tell how much is used.
@@ -1053,17 +1053,17 @@ void TextureCache::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuf
 		static const GLubyte indices[4] = { 0, 1, 3, 2 };
 
 		// If min is not < max, then we don't have values (wasn't set during decode.)
-		if (gstate_c.vertMinV < gstate_c.vertMaxV) {
+		if (gstate_c.vertBounds.minV < gstate_c.vertBounds.maxV) {
 			const float invWidth = 1.0f / (float)framebuffer->bufferWidth;
 			const float invHeight = 1.0f / (float)framebuffer->bufferHeight;
 			// Inverse of half = double.
 			const float invHalfWidth = invWidth * 2.0f;
 			const float invHalfHeight = invHeight * 2.0f;
 
-			const int u1 = gstate_c.vertMinU + gstate_c.curTextureXOffset;
-			const int v1 = gstate_c.vertMinV + gstate_c.curTextureYOffset;
-			const int u2 = gstate_c.vertMaxU + gstate_c.curTextureXOffset;
-			const int v2 = gstate_c.vertMaxV + gstate_c.curTextureYOffset;
+			const int u1 = gstate_c.vertBounds.minU + gstate_c.curTextureXOffset;
+			const int v1 = gstate_c.vertBounds.minV + gstate_c.curTextureYOffset;
+			const int u2 = gstate_c.vertBounds.maxU + gstate_c.curTextureXOffset;
+			const int v2 = gstate_c.vertBounds.maxV + gstate_c.curTextureYOffset;
 
 			const float left = u1 * invHalfWidth - 1.0f;
 			const float right = u2 * invHalfWidth - 1.0f;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1060,10 +1060,15 @@ void TextureCache::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuf
 			const float invHalfWidth = invWidth * 2.0f;
 			const float invHalfHeight = invHeight * 2.0f;
 
-			const float left = gstate_c.vertMinU * invHalfWidth - 1.0f;
-			const float right = gstate_c.vertMaxU * invHalfWidth - 1.0f;
-			const float top = -(gstate_c.vertMinV * invHalfHeight - 1.0f);
-			const float bottom = -(gstate_c.vertMaxV * invHalfHeight - 1.0f);
+			const int u1 = gstate_c.vertMinU + gstate_c.curTextureXOffset;
+			const int v1 = gstate_c.vertMinV + gstate_c.curTextureYOffset;
+			const int u2 = gstate_c.vertMaxU + gstate_c.curTextureXOffset;
+			const int v2 = gstate_c.vertMaxV + gstate_c.curTextureYOffset;
+
+			const float left = u1 * invHalfWidth - 1.0f;
+			const float right = u2 * invHalfWidth - 1.0f;
+			const float top = -(v1 * invHalfHeight - 1.0f);
+			const float bottom = -(v2 * invHalfHeight - 1.0f);
 			// Points are: BL, BR, TR, TL.
 			pos[0] = Pos(left, bottom, -1.0f);
 			pos[1] = Pos(right, bottom, -1.0f);
@@ -1071,10 +1076,10 @@ void TextureCache::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuf
 			pos[3] = Pos(left, top, -1.0f);
 
 			// And also the UVs, same order.
-			const float uvleft = gstate_c.vertMinU * invWidth;
-			const float uvright = gstate_c.vertMaxU * invWidth;
-			const float uvtop = 1.0f - gstate_c.vertMinV * invHeight;
-			const float uvbottom = 1.0f - gstate_c.vertMaxV * invHeight;
+			const float uvleft = u1 * invWidth;
+			const float uvright = u2 * invWidth;
+			const float uvtop = 1.0f - v1 * invHeight;
+			const float uvbottom = 1.0f - v2 * invHeight;
 			uv[0] = UV(uvleft, uvbottom);
 			uv[1] = UV(uvright, uvbottom);
 			uv[2] = UV(uvright, uvtop);
@@ -1118,7 +1123,7 @@ void TextureCache::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuf
 		fbo_bind_color_as_texture(depalFBO, 0);
 		glstate.Restore();
 	} else {
-		framebufferManager_->BindFramebufferColor(GL_TEXTURE0, gstate.getFrameBufRawAddress(), framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV);
+		framebufferManager_->BindFramebufferColor(GL_TEXTURE0, gstate.getFrameBufRawAddress(), framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 	}
 
 	framebufferManager_->RebindFramebuffer();

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -940,7 +940,6 @@ void TextureCache::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffe
 			depal = depalShaderCache_->GetDepalettizeShader(clutFormat, framebuffer->drawnFormat);
 		}
 		if (depal) {
-			const GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
 			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 			const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;
 
@@ -1516,6 +1515,8 @@ void TextureCache::SetTexture(bool force) {
 	gstate_c.textureFullAlpha = entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL;
 	gstate_c.textureSimpleAlpha = entry->GetAlphaStatus() != TexCacheEntry::STATUS_ALPHA_UNKNOWN;
 
+	// This will rebind it, but that's okay.
+	nextTexture_ = entry;
 	UpdateSamplingParams(*entry, true);
 
 	//glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -92,6 +92,8 @@ public:
 
 	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 
+	void ApplyTexture();
+
 private:
 	// Can't be unordered_map, we use lower_bound ... although for some reason that compiles on MSVC.
 	typedef std::map<u64, TexCacheEntry> TexCache;
@@ -112,6 +114,7 @@ private:
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
+	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
 
 	TexCache cache;
 	TexCache secondCache;
@@ -149,6 +152,8 @@ private:
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
+
+	TexCacheEntry *nextTexture_;
 
 	u32 lastBoundTexture;
 	float maxAnisotropyLevel;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -684,7 +684,7 @@ void TransformDrawEngine::DoFlush() {
 							vai->numVerts = indexGen.PureCount();
 						}
 
-						_dbg_assert_msg_(G3D, gstate_c.vertMinV >= gstate_c.vertMaxV, "Should not have checked UVs when caching.");
+						_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 
 						vai->vbo = AllocateBuffer();
 						glstate.arrayBuffer.bind(vai->vbo);
@@ -885,10 +885,10 @@ rotateVBO:
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
 	// Now seems as good a time as any to reset the min/max coords, which we may examine later.
-	gstate_c.vertMinU = 512;
-	gstate_c.vertMinV = 512;
-	gstate_c.vertMaxU = 0;
-	gstate_c.vertMaxV = 0;
+	gstate_c.vertBounds.minU = 512;
+	gstate_c.vertBounds.minV = 512;
+	gstate_c.vertBounds.maxU = 0;
+	gstate_c.vertBounds.maxV = 0;
 
 #ifndef MOBILE_DEVICE
 	host->GPUNotifyDraw();

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -882,6 +882,12 @@ rotateVBO:
 	gstate_c.vertexFullAlpha = true;
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
+	// Now seems as good a time as any to reset the min/max coords, which we may examine later.
+	gstate_c.vertMinU = 512;
+	gstate_c.vertMinV = 512;
+	gstate_c.vertMaxU = 0;
+	gstate_c.vertMaxV = 0;
+
 #ifndef MOBILE_DEVICE
 	host->GPUNotifyDraw();
 #endif

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -684,6 +684,8 @@ void TransformDrawEngine::DoFlush() {
 							vai->numVerts = indexGen.PureCount();
 						}
 
+						_dbg_assert_msg_(G3D, gstate_c.vertMinV >= gstate_c.vertMaxV, "Should not have checked UVs when caching.");
+
 						vai->vbo = AllocateBuffer();
 						glstate.arrayBuffer.bind(vai->vbo);
 						glBufferData(GL_ARRAY_BUFFER, dec_->GetDecVtxFmt().stride * indexGen.MaxIndex(), decoded, GL_STATIC_DRAW);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -507,6 +507,11 @@ struct GPUStateCache {
 	float vpWidthScale;
 	float vpHeightScale;
 
+	u16 vertMinU;
+	u16 vertMinV;
+	u16 vertMaxU;
+	u16 vertMaxV;
+
 	// TODO: These should be accessed from the current VFB object directly.
 	u32 curRTWidth;
 	u32 curRTHeight;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -464,6 +464,13 @@ enum {
 	GPU_PREFER_REVERSE_COLOR_ORDER = FLAG_BIT(31),
 };
 
+struct KnownVertexBounds {
+	u16 minU;
+	u16 minV;
+	u16 maxU;
+	u16 maxV;
+};
+
 struct GPUStateCache {
 	bool Supports(int flag) { return (featureFlags & flag) != 0; }
 
@@ -507,10 +514,7 @@ struct GPUStateCache {
 	float vpWidthScale;
 	float vpHeightScale;
 
-	u16 vertMinU;
-	u16 vertMinV;
-	u16 vertMaxU;
-	u16 vertMaxV;
+	KnownVertexBounds vertBounds;
 
 	// TODO: These should be accessed from the current VFB object directly.
 	u32 curRTWidth;


### PR DESCRIPTION
~~So, this could use some more cleanup and testing, and probably is not yet ready for merge.~~

However, I think it's a good idea with some trade-offs.  Might even add an option for it (maybe no UI.)

Some pros/cons:
- Negative: slows down vertex decoding, through-mode only now (usually not as hot, but could be.)
- Positive: detects when <= 272 pixels need to be hashed, preventing needless re-uploads and un-xBRZ passes.
- Positive: potentially provides a chance to thread some parts of texture caching (with init/finalize steps.)
- Positive: detects when render-to-self and render-with-clut textures can have a smaller subset copied.

~~Might also need some better interaction with the vertex cache.~~

Currently, it only does u16 through - not float through.  Note that u8 through is not usable on hardware so doesn't matter.

There are cases where this might also help with non-through - as long as UV gen is texcoords, we can still detect what part of the texture is being referenced (possibly with prescale/UV scale&offset involved.)  It turns out some games which would benefit from these optimizations use non-through.

One idea I had to avoid the impact of checking the bounds was to check the number of verts and use a different step/jit func.  This would create even more permutations, but could allow the cost to be minimal even for non-through.

-[Unknown]
