### PR TITLE
arm64: Use XXH64 for vertex hashing, etc.

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -257,8 +257,8 @@ void DoUnswizzleTex16Basic(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 
 QuickTexHashFunc DoQuickTexHash = &QuickTexHashBasic;
 UnswizzleTex16Func DoUnswizzleTex16 = &DoUnswizzleTex16Basic;
 ReliableHash32Func DoReliableHash32 = &XXH32;
-#endif
 ReliableHash64Func DoReliableHash64 = &XXH64;
+#endif
 #endif
 
 // This has to be done after CPUDetect has done its magic.

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -60,12 +60,11 @@ typedef u32 ReliableHashType;
 #define DoUnswizzleTex16 DoUnswizzleTex16NEON
 #define DoReliableHash32 ReliableHash32NEON
 
-// TODO: NEON version of this too?  Since we're 64, might be faster.
-typedef u64 (*ReliableHash64Func)(const void *input, size_t len, u64 seed);
-extern ReliableHash64Func DoReliableHash64;
+#include "ext/xxhash.h"
+#define DoReliableHash64 XXH64
 
-#define DoReliableHash DoReliableHash32
-typedef u32 ReliableHashType;
+#define DoReliableHash XXH64
+typedef u64 ReliableHashType;
 
 #else
 typedef u32 (*QuickTexHashFunc)(const void *checkp, u32 size);

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -52,7 +52,7 @@ enum {
 };
 
 // Avoiding the full include of TextureDecoder.h.
-#ifdef _M_X64
+#if (defined(_M_SSE) && defined(_M_X64)) || defined(ARM64)
 typedef u64 ReliableHashType;
 #else
 typedef u32 ReliableHashType;

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -53,7 +53,7 @@ enum {
 };
 
 // Avoiding the full include of TextureDecoder.h.
-#ifdef _M_X64
+#if (defined(_M_SSE) && defined(_M_X64)) || defined(ARM64)
 typedef u64 ReliableHashType;
 #else
 typedef u32 ReliableHashType;


### PR DESCRIPTION
Based on benchmarks, it performs better than XXH32 on an A57.

It doesn't seem worth trying to NEON it, since my benchmark showed that there was no gain in the 32-bit version.  I didn't check to see if maybe it's managing to vectorize it itself (probably?)

Here were my numbers:

```
XXH32            1mb: 000000004e9fed0b took 0.167478
DoReliableHash32 1mb: 000000004e9fed0b took 0.167298
XXH64            1mb: b0d69569023cffb3 took 0.143518
DoReliableHash64 1mb: b0d69569023cffb3 took 0.143667
XXH32            1kb: 000000009b9de3be took 0.175752
DoReliableHash32 1kb: 000000009b9de3be took 0.174055
XXH64            1kb: 5d0cbff334f9e8b7 took 0.158472
DoReliableHash64 1kb: 5d0cbff334f9e8b7 took 0.158495
```

So that's almost a 10% decrease in time taken for small chunks of hashing.  Of course, other processors might behave differently, but it seems logical that it would hold for all 64-bit ARM.

-[Unknown]
