### PR TITLE
Make PPSSPP aware of Windows 10 (mostly for the info screen).

### DIFF
--- a/Windows/PPSSPP.manifest
+++ b/Windows/PPSSPP.manifest
@@ -19,6 +19,21 @@
            processorArchitecture="*"/>
     </dependentAssembly>
   </dependency>
+  <!-- Windows doesn't need to use the lie shim with PPSSPP. -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+    <application> 
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/> 
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application> 
+  </compatibility>
   <!-- Identify the application security requirements. -->
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -112,6 +112,7 @@ std::string GetWindowsVersion() {
 	const bool IsWindows7SP1 = DoesVersionMatchWindows(6, 1, 1, 0);
 	const bool IsWindows8 = DoesVersionMatchWindows(6, 2);
 	const bool IsWindows8_1 = DoesVersionMatchWindows(6, 3);
+	const bool IsWindows10 = DoesVersionMatchWindows(10, 0);
 
 	if (IsWindowsXPSP2)
 		return "Microsoft Windows XP, Service Pack 2";
@@ -139,6 +140,9 @@ std::string GetWindowsVersion() {
 
 	if (IsWindows8_1)
 		return "Microsoft Windows 8.1";
+
+	if (IsWindows10)
+		return "Microsoft Windows 10";
 
 	return "Unsupported version of Microsoft Windows.";
 }


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/7894. I tested it on my Windows 10 laptop and it seems to work fine and dandy. ~~Windows XP is untested though. I'll try to test it in a virtual machine soon.~~ Windows XP works fine in the VM I tested.
