### PR TITLE
Add axis event listener to the analog test screen.

### DIFF
--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -432,6 +432,21 @@ bool AnalogTestScreen::key(const KeyInput &key) {
 	return true;
 }
 
+bool AnalogTestScreen::axis(const AxisInput &axis) {
+	// This is mainly to catch axis events that would otherwise get translated
+	// into arrow keys, since seeing keyboard arrow key events appear when using
+	// a controller would be confusing for the user.
+	char buf[512];
+	if (axis.value > AXIS_BIND_THRESHOLD || axis.value < -AXIS_BIND_THRESHOLD) {
+		int value = axis.value > AXIS_BIND_THRESHOLD ? 1 : -1;
+		snprintf(buf, sizeof(buf), "Axis: %d (value %1.3f) Device ID: %d",
+			axis.axisId, axis.value, axis.deviceId);
+		lastKeyEvent_->SetText(buf);
+		return true;
+	}
+	return false;
+}
+
 void AnalogTestScreen::CreateViews() {
 	using namespace UI;
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -74,6 +74,7 @@ public:
 	AnalogTestScreen() {}
 
 	bool key(const KeyInput &key) override;
+	bool axis(const AxisInput &axis) override;
 
 protected:
 	virtual void CreateViews() override;


### PR DESCRIPTION
I thought that we might as well display the axisId/deviceId/value of the last axis event, if we're going to override the axis function anyway.
