### PR TITLE
Linux controller fix

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -295,21 +295,21 @@ static void KeyCodesFromPspButton(int btn, std::vector<keycode_t> *keycodes) {
 }
 
 void UpdateConfirmCancelKeys() {
-	std::vector<keycode_t> confirmKeys, cancelKeys;
-	std::vector<keycode_t> tabLeft, tabRight;
+	std::vector<KeyDef> confirmKeys, cancelKeys;
+	std::vector<KeyDef> tabLeft, tabRight;
 
 	int confirmKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 	int cancelKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
 
-	KeyCodesFromPspButton(confirmKey, &confirmKeys);
-	KeyCodesFromPspButton(cancelKey, &cancelKeys);
-	KeyCodesFromPspButton(CTRL_LTRIGGER, &tabLeft);
-	KeyCodesFromPspButton(CTRL_RTRIGGER, &tabRight);
+	KeyFromPspButton(confirmKey, &confirmKeys);
+	KeyFromPspButton(cancelKey, &cancelKeys);
+	KeyFromPspButton(CTRL_LTRIGGER, &tabLeft);
+	KeyFromPspButton(CTRL_RTRIGGER, &tabRight);
 
 	// Push several hard-coded keys before submitting to native.
-	const keycode_t hardcodedConfirmKeys[] = {
-		NKCODE_SPACE,
-		NKCODE_ENTER,
+	const KeyDef hardcodedConfirmKeys[] = {
+		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_SPACE),
+		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_ENTER),
 	};
 
 	// If they're not already bound, add them in.
@@ -318,9 +318,9 @@ void UpdateConfirmCancelKeys() {
 			confirmKeys.push_back(hardcodedConfirmKeys[i]);
 	}
 
-	const keycode_t hardcodedCancelKeys[] = {
-		NKCODE_ESCAPE,
-		NKCODE_BACK,
+	const KeyDef hardcodedCancelKeys[] = {
+		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE),
+		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_BACK),
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(hardcodedCancelKeys); i++) {

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -294,9 +294,10 @@ static void KeyCodesFromPspButton(int btn, std::vector<keycode_t> *keycodes) {
 	}
 }
 
-void UpdateConfirmCancelKeys() {
+void UpdateNativeMenuKeys() {
 	std::vector<KeyDef> confirmKeys, cancelKeys;
 	std::vector<KeyDef> tabLeft, tabRight;
+	std::vector<KeyDef> upKeys, downKeys, leftKeys, rightKeys;
 
 	int confirmKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 	int cancelKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
@@ -305,6 +306,10 @@ void UpdateConfirmCancelKeys() {
 	KeyFromPspButton(cancelKey, &cancelKeys);
 	KeyFromPspButton(CTRL_LTRIGGER, &tabLeft);
 	KeyFromPspButton(CTRL_RTRIGGER, &tabRight);
+	KeyFromPspButton(CTRL_UP, &upKeys);
+	KeyFromPspButton(CTRL_DOWN, &downKeys);
+	KeyFromPspButton(CTRL_LEFT, &leftKeys);
+	KeyFromPspButton(CTRL_RIGHT, &rightKeys);
 
 	// Push several hard-coded keys before submitting to native.
 	const KeyDef hardcodedConfirmKeys[] = {
@@ -328,6 +333,7 @@ void UpdateConfirmCancelKeys() {
 			cancelKeys.push_back(hardcodedCancelKeys[i]);
 	}
 
+	SetDPadKeys(upKeys, downKeys, leftKeys, rightKeys);
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);
 	SetTabLeftRightKeys(tabLeft, tabRight);
 }
@@ -402,7 +408,7 @@ void SetDefaultKeyMap(DefaultMaps dmap, bool replace) {
 		break;
 	}
 
-	UpdateConfirmCancelKeys();
+	UpdateNativeMenuKeys();
 }
 
 const KeyMap_IntStrPair key_names[] = {
@@ -830,7 +836,7 @@ void SetKeyMapping(int btn, KeyDef key, bool replace) {
 		g_controllerMap[btn].push_back(key);
 	}
 
-	UpdateConfirmCancelKeys();
+	UpdateNativeMenuKeys();
 }
 
 void SetAxisMapping(int btn, int deviceId, int axisId, int direction, bool replace) {
@@ -900,7 +906,7 @@ void LoadFromIni(IniFile &file) {
 		}
 	}
 
-	UpdateConfirmCancelKeys();
+	UpdateNativeMenuKeys();
 }
 
 void SaveToIni(IniFile &file) {

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -325,7 +325,7 @@ void UpdateNativeMenuKeys() {
 
 	const KeyDef hardcodedCancelKeys[] = {
 		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE),
-		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_BACK),
+		KeyDef(DEVICE_ID_ANY, NKCODE_BACK),
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(hardcodedCancelKeys); i++) {

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <vector>
 #include <set>
+#include "input/input_state.h" // KeyDef, AxisPos
 #include "input/keycodes.h"     // keyboard keys
 #include "../Core/HLE/sceCtrl.h"   // psp keys
 
@@ -64,40 +65,6 @@ enum DefaultMaps {
 };
 
 const float AXIS_BIND_THRESHOLD = 0.75f;
-
-class KeyDef {
-public:
-	KeyDef() : deviceId(0), keyCode(0) {}
-	KeyDef(int devId, int k) : deviceId(devId), keyCode(k) {}
-	int deviceId;
-	int keyCode;
-
-	bool operator < (const KeyDef &other) const {
-		if (deviceId < other.deviceId) return true;
-		if (deviceId > other.deviceId) return false;
-		if (keyCode < other.keyCode) return true;
-		return false;
-	}
-	bool operator == (const KeyDef &other) const {
-		if (deviceId != other.deviceId) return false;
-		if (keyCode != other.keyCode) return false;
-		return true;
-	}
-};
-
-struct AxisPos {
-	int axis;
-	float position;
-
-	bool operator < (const AxisPos &other) const {
-		if (axis < other.axis) return true;
-		if (axis > other.axis) return false;
-		return position < other.position;
-	}
-	bool operator == (const AxisPos &other) const {
-		return axis == other.axis && position == other.position;
-	}
-};
 
 typedef std::map<int, std::vector<KeyDef>> KeyMapping;
 

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -126,7 +126,7 @@ namespace KeyMap {
 	void RestoreDefault();
 
 	void SwapAxis();
-	void UpdateConfirmCancelKeys();
+	void UpdateNativeMenuKeys();
 
 	void NotifyPadConnected(const std::string &name);
 	bool IsNvidiaShield(const std::string &name);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -837,7 +837,7 @@ void GameSettingsScreen::onFinish(DialogResult result) {
 
 	host->UpdateUI();
 
-	KeyMap::UpdateConfirmCancelKeys();
+	KeyMap::UpdateNativeMenuKeys();
 }
 
 /*


### PR DESCRIPTION
The PPSSPP side of https://github.com/hrydgard/native/pull/285. The changes here are straight-forward given the native PR. Additionally, renames UpdateConfirmCancelKeys to UpdateNativeMenuKeys, since both with and without this PR, the function handles more than just confirm and cancel.
