### PR TITLE
Fix scanf usage in Visual Studio 2015

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -121,7 +121,7 @@ bool SymbolMap::LoadSymbolMap(const char *filename) {
 		SymbolType type;
 		char name[128] = {0};
 
-		if (sscanf(line, ".module %x %08x %08x %127c", &moduleIndex, &address, &size, name) == 4) {
+		if (sscanf(line, ".module %x %08x %08x %127c", &moduleIndex, &address, &size, name) >= 3) {
 			// Found a module definition.
 			ModuleEntry mod;
 			mod.index = moduleIndex;


### PR DESCRIPTION
It was probably incorrect before, oops.

-[Unknown]
