### PR TITLE
Allow audio to be enabled in the menu

### DIFF
--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -185,11 +185,6 @@ void SetBackgroundAudioGame(const std::string &path) {
 		return;
 	}
 
-	if (!g_Config.bEnableSound) {
-		ClearBackgroundAudio();
-		return;
-	}
-
 	ClearBackgroundAudio();
 	gameLastChanged = time_now_d();
 	bgGamePath = path;


### PR DESCRIPTION
Previously, if it was disabled at first, enabling it wouldn't work - you still would not get the audio.

It still checks the setting when actually trying to play.

-[Unknown]
