### PR TITLE
arm64: Avoid overflow in imm math

### DIFF
--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -682,6 +682,11 @@ void Arm64RegCache::SetImm(MIPSGPReg r, u64 immVal) {
 		return;
 	}
 
+	if (r != MIPS_REG_LO) {
+		// All regs on the PSP are 32 bit, but LO we treat as HI:LO so is 64 full bits.
+		immVal = immVal & 0xFFFFFFFF;
+	}
+
 	if (mr[r].isStatic) {
 		mr[r].loc = ML_IMM;
 		mr[r].imm = immVal;


### PR DESCRIPTION
When merging LO and HI, imm was converted to 64 bits.  In some places, we put values in there that might overflow, which was causing Wild Arms XF not to run correctly, for example.

-[Unknown]
