### PR TITLE
Make ISO filesystem case sensitive and add a few optimizations

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -68,9 +68,9 @@ struct DirectoryEntry
 {
 	u8 size;
 	u8 sectorsInExtendedRecord;
-	u32_le firstDataSectorLE;	// LBA
+	u32_le firstDataSectorLE;       // LBA
 	u32_be firstDataSectorBE;
-	u32_le dataLengthLE;				// Size
+	u32_le dataLengthLE;            // Size
 	u32_be dataLengthBE;
 	u8 years;
 	u8 month;
@@ -79,12 +79,12 @@ struct DirectoryEntry
 	u8 minute;
 	u8 second;
 	u8 offsetFromGMT;
-	u8 flags; // 2 = directory
+	u8 flags;                       // 2 = directory
 	u8 fileUnitSize;
 	u8 interleaveGap;
 	u16_le volSeqNumberLE;
 	u16_be volSeqNumberBE;
-	u8 identifierLength; //identifier comes right after
+	u8 identifierLength;            //identifier comes right after
 	u8 firstIdChar;
 
 #if COMMON_LITTLE_ENDIAN
@@ -341,7 +341,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 			e = ne;
 			size_t l = name.length();
 			path.erase(0, l);
-			if (path.length() == 0 || (path.length()==1 && path[0] == '/'))
+			if (path.length() == 0 || (path.length() == 1 && path[0] == '/'))
 				return e;
 			path.erase(0, 1);
 			while (path[0] == '/')

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -325,13 +325,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 			for (size_t i=0; i<e->children.size(); i++)
 			{
 				std::string n = (e->children[i]->name);
-				for (size_t j = 0; j < n.size(); j++) {
-					n[j] = tolower(n[j]);
-				}
 				std::string curPath = path.substr(0, path.find_first_of('/'));
-				for (size_t j = 0; j < curPath.size(); j++) {
-					curPath[j] = tolower(curPath[j]);
-				}
 
 				if (curPath == n)
 				{

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -297,6 +297,11 @@ void ISOFileSystem::ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root,
 			root->children.push_back(e);
 		}
 	}
+
+    root->fastChildren.reserve(root->children.size());
+    for (TreeEntry *e : root->children) {
+        root->fastChildren[e->name] = e;
+    }
 }
 
 ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catchError)
@@ -323,18 +328,12 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 		if (path.length() > 0)
 		{
             const std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
-			for (size_t i = 0; i < e->children.size(); i++)
-			{
-				const std::string &n = e->children[i]->name;
-
-				if (firstPathComponent == n)
-				{
-					//yay we got it
-					ne = e->children[i];
-					name = n;
-					break;
-				}
-			}
+            auto child = e->fastChildren.find(firstPathComponent);
+            if (child != e->fastChildren.end()) {
+                //yay we got it
+                ne = child->second;
+                name = child->first;
+            }
 		}
 		if (ne)
 		{

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -297,11 +297,6 @@ void ISOFileSystem::ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root,
 			root->children.push_back(e);
 		}
 	}
-
-	root->fastChildren.reserve(root->children.size());
-	for (TreeEntry *e : root->children) {
-		root->fastChildren[e->name] = e;
-	}
 }
 
 ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bool catchError)
@@ -338,14 +333,20 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 				nextSlashIndex = pathLength;
 
 			const std::string firstPathComponent = path.substr(pathIndex, nextSlashIndex - pathIndex);
-			auto child = e->fastChildren.find(firstPathComponent);
-			if (child != e->fastChildren.end()) {
-				//yay we got it
-				ne = child->second;
-				name = child->first;
+			for (size_t i = 0; i < e->children.size(); i++)
+			{
+				const std::string &n = e->children[i]->name;
+				
+				if (firstPathComponent == n)
+				{
+					//yay we got it
+					ne = e->children[i];
+					name = n;
+					break;
+				}
 			}
 		}
-
+		
 		if (ne)
 		{
 			e = ne;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -263,7 +263,7 @@ void ISOFileSystem::ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root,
 			}
 			else
 			{
-				e->name = std::string((char *)&dir.firstIdChar, dir.identifierLength);
+				e->name = std::string((const char *)&dir.firstIdChar, dir.identifierLength);
 				relative = false;
 			}
 
@@ -322,7 +322,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 		std::string name = "";
 		if (path.length()>0)
 		{
-            std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
+            const std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
 			for (size_t i = 0; i < e->children.size(); i++)
 			{
 				const std::string &n = e->children[i]->name;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -336,7 +336,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 			size_t nextSlashIndex = path.find_first_of('/', pathIndex);
 			if (nextSlashIndex == std::string::npos)
 				nextSlashIndex = pathLength;
-		
+
 			const std::string firstPathComponent = path.substr(pathIndex, nextSlashIndex - pathIndex);
 			auto child = e->fastChildren.find(firstPathComponent);
 			if (child != e->fastChildren.end()) {
@@ -350,7 +350,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 		{
 			e = ne;
 			pathIndex += name.length();
-			while (pathIndex < pathLength && path[pathIndex] == '/')
+			if (pathIndex < pathLength && path[pathIndex] == '/')
 				++pathIndex;
 
 			if (pathLength <= pathIndex)

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -307,14 +307,14 @@ void ISOFileSystem::ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root,
 ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bool catchError)
 {
 	const size_t pathLength = path.length();
-	
+
 	if (pathLength == 0) {
 		// Ah, the device!	"umd0:"
 		return &entireISO;
 	}
 
 	size_t pathIndex = 0;
-	
+
 	// Skip "./"
 	if (pathLength > pathIndex + 1 && path[pathIndex] == '.' && path[pathIndex + 1] == '/')
 		pathIndex += 2;
@@ -322,10 +322,10 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 	// Skip "/"
 	if (pathLength > pathIndex && path[pathIndex] == '/')
 		++pathIndex;
-	
+
 	if (pathLength <= pathIndex)
 		return treeroot;
-	
+
 	TreeEntry *e = treeroot;
 	while (true)
 	{
@@ -336,7 +336,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 			size_t nextSlashIndex = path.find_first_of('/', pathIndex);
 			if (nextSlashIndex == std::string::npos)
 				nextSlashIndex = pathLength;
-
+		
 			const std::string firstPathComponent = path.substr(pathIndex, nextSlashIndex - pathIndex);
 			auto child = e->fastChildren.find(firstPathComponent);
 			if (child != e->fastChildren.end()) {
@@ -699,21 +699,19 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path)
 {
 	std::vector<PSPFileInfo> myVector;
 	TreeEntry *entry = GetFromPath(path);
-	if (!entry)
-	{
+	if (! entry)
 		return myVector;
-	}
 
-    const std::string dot(".");
-    const std::string dotdot("..");
+	const std::string dot(".");
+	const std::string dotdot("..");
 
 	for (size_t i = 0; i < entry->children.size(); i++)
 	{
 		TreeEntry *e = entry->children[i];
 
-        // do not include the relative entries in the list
-        if (e->name == dot || e->name == dotdot)
-            continue;
+		// do not include the relative entries in the list
+		if (e->name == dot || e->name == dotdot)
+			continue;
 
 		PSPFileInfo x;
 		x.name = e->name;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -695,14 +695,17 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path)
 	{
 		return myVector;
 	}
-;
-	for (size_t i=0; i<entry->children.size(); i++)
-)
+
+    const std::string dot(".");
+    const std::string dotdot("..");
+
+	for (size_t i = 0; i < entry->children.size(); i++)
 	{
-		TreeEntry *e = entry->children[i]
-		if(!strcmp(e->name.c_str(), ".") || !strcmp(e->name.c_str(), "..")) // do not include the relative entries in the list
-			continue;
-ue;
+		TreeEntry *e = entry->children[i];
+
+        // do not include the relative entries in the list
+        if (e->name == dot || e->name == dotdot)
+            continue;
 
 		PSPFileInfo x;
 		x.name = e->name;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -325,7 +325,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
             std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
 			for (size_t i = 0; i < e->children.size(); i++)
 			{
-				std::string n = e->children[i]->name;
+				const std::string &n = e->children[i]->name;
 
 				if (firstPathComponent == n)
 				{

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -320,7 +320,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 	{
 		TreeEntry *ne = 0;
 		std::string name = "";
-		if (path.length()>0)
+		if (path.length() > 0)
 		{
             const std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
 			for (size_t i = 0; i < e->children.size(); i++)
@@ -416,7 +416,7 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 		return 0;
 	}
 
-	if (entry.file==&entireISO)
+	if (entry.file == &entireISO)
 		entry.isBlockSectorMode = true;
 
 	entry.seekPos = 0;
@@ -682,7 +682,7 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename)
 		x.exists = true;
 		x.type = entry->isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 		x.isOnSectorSystem = true;
-		x.startSector = entry->startingPosition/2048;
+		x.startSector = entry->startingPosition / 2048;
 	}
 	return x;
 }

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -322,12 +322,12 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(std::string path, bool catc
 		std::string name = "";
 		if (path.length()>0)
 		{
-			for (size_t i=0; i<e->children.size(); i++)
+            std::string firstPathComponent = path.substr(0, path.find_first_of('/'));
+			for (size_t i = 0; i < e->children.size(); i++)
 			{
-				std::string n = (e->children[i]->name);
-				std::string curPath = path.substr(0, path.find_first_of('/'));
+				std::string n = e->children[i]->name;
 
-				if (curPath == n)
+				if (firstPathComponent == n)
 				{
 					//yay we got it
 					ne = e->children[i];
@@ -695,13 +695,14 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path)
 	{
 		return myVector;
 	}
-
+;
 	for (size_t i=0; i<entry->children.size(); i++)
+)
 	{
-		TreeEntry *e = entry->children[i];
-
+		TreeEntry *e = entry->children[i]
 		if(!strcmp(e->name.c_str(), ".") || !strcmp(e->name.c_str(), "..")) // do not include the relative entries in the list
 			continue;
+ue;
 
 		PSPFileInfo x;
 		x.name = e->name;

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -100,7 +100,7 @@ private:
 	std::vector<std::string> restrictTree;
 
 	void ReadDirectory(u32 startsector, u32 dirsize, TreeEntry *root, size_t level);
-	TreeEntry *GetFromPath(std::string path, bool catchError = true);
+	TreeEntry *GetFromPath(const std::string &path, bool catchError = true);
 	std::string EntryFullPath(TreeEntry *e);
 };
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <list>
+#include <unordered_map>
 
 #include "FileSystem.h"
 
@@ -68,7 +69,12 @@ private:
 		bool isDirectory;
 
 		TreeEntry *parent;
-		std::vector<TreeEntry*> children;
+        
+        // slow lookup, in PSP-accurate sorting order
+		std::vector<TreeEntry *> children;
+        
+        // fast lookup, in undefined order
+        std::unordered_map<std::string, TreeEntry *> fastChildren;
 	};
 
 	struct OpenFileEntry

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -19,7 +19,6 @@
 
 #include <map>
 #include <list>
-#include <unordered_map>
 
 #include "FileSystem.h"
 
@@ -69,12 +68,7 @@ private:
 		bool isDirectory;
 
 		TreeEntry *parent;
-
-		// slow lookup, in PSP-accurate sorting order
 		std::vector<TreeEntry *> children;
-
-		// fast lookup, in undefined order
-		std::unordered_map<std::string, TreeEntry *> fastChildren;
 	};
 
 	struct OpenFileEntry

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -69,12 +69,12 @@ private:
 		bool isDirectory;
 
 		TreeEntry *parent;
-        
-        // slow lookup, in PSP-accurate sorting order
+
+		// slow lookup, in PSP-accurate sorting order
 		std::vector<TreeEntry *> children;
-        
-        // fast lookup, in undefined order
-        std::unordered_map<std::string, TreeEntry *> fastChildren;
+
+		// fast lookup, in undefined order
+		std::unordered_map<std::string, TreeEntry *> fastChildren;
 	};
 
 	struct OpenFileEntry


### PR DESCRIPTION
My tests show that the PSP is case sensitive when accessing a UMD.
I also:
1. eliminated some needless std::string copying and reallocation
2. added an unordered_map to TreeEntry in order to optimize a piece of code that performed a linear search in a std::vector

I left that std::vector in so that directory listings will still be in PSP accurate sorting order. The memory cost is probably not too bad.
