### PR TITLE
Fix system ffmpeg integration for Linux OSes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ include_directories(ext/native/ext/stb_vorbis)
 
 if(USE_FFMPEG)
 	if(USE_SYSTEM_FFMPEG)
+		add_definitions(-DUSE_SYSTEM_FFMPEG)
 		include(FindFFMPEG)
 	else()
 		set(FFMPEG_FOUND OFF)

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -32,6 +32,11 @@
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
+#ifdef USE_SYSTEM_FFMPEG
+#define PIX_FMT_RGBA AV_PIX_FMT_RGBA
+#define CODEC_ID_H264 AV_CODEC_ID_H264
+#endif
+
 // MPEG AVC elementary stream.
 static const int MPEG_AVC_ES_SIZE = 2048;          // MPEG packet size.
 

--- a/Qt/Settings.pri
+++ b/Qt/Settings.pri
@@ -20,7 +20,8 @@ include(Platform/ArchDetection.pri)
 # Work out platform name
 include(Platform/OSDetection.pri)
 # OS dependent paths
-!system_ffmpeg: INCLUDEPATH += $$P/ffmpeg/$${PLATFORM_NAME}/$${PLATFORM_ARCH}/include
+!system_ffmpeg: INCLUDEPATH += $$P/ffmpeg/$${PLATFORM_NAME}/$${PLATFORM_ARCH}/include 
+system_ffmpeg: DEFINES += USE_SYSTEM_FFMPEG
 
 !contains(CONFIG, staticlib) {
 	QMAKE_LIBDIR += $$CONFIG_DIR


### PR DESCRIPTION
Issue: https://github.com/hrydgard/ppsspp/issues/7955

It finally occured to me that it the "old_pix_fmts.h" header file didn't exist in the upstream FFMPEG source and that it was there that the old variable names that ppsspp use were defined.

This pull allows for proper compilation when using the local system ffmpeg libraries. It would fail otherwise, throwing something allong the lines of:

```
ppsspp/Core/HLE/sceMpeg.cpp:776:21: error: ‘PIX_FMT_RGBA’ was not declared in this scope
  pmp_want_pix_fmt = PIX_FMT_RGBA;
                     ^
ppsspp/Core/HLE/sceMpeg.cpp:779:45: error: ‘CODEC_ID_H264’ was not declared in this scope
  AVCodec * pmp_Codec = avcodec_find_decoder(CODEC_ID_H264);
```
