### PR TITLE
Prep for splitting texture apply into two phases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1453,6 +1453,7 @@ add_library(GPU OBJECT
 	GPU/Common/FramebufferCommon.h
 	GPU/Common/GPUDebugInterface.cpp
 	GPU/Common/GPUDebugInterface.h
+	GPU/Common/GPUStateUtils.h
 	GPU/Common/DrawEngineCommon.cpp
 	GPU/Common/DrawEngineCommon.h
 	GPU/Common/SplineCommon.cpp

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -1,0 +1,115 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "GPU/ge_constants.h"
+#include "GPU/GPUState.h"
+
+// Dest factors where it's safe to eliminate the alpha test under certain conditions
+static const bool safeDestFactors[16] = {
+	true, // GE_DSTBLEND_SRCCOLOR,
+	true, // GE_DSTBLEND_INVSRCCOLOR,
+	false, // GE_DSTBLEND_SRCALPHA,
+	true, // GE_DSTBLEND_INVSRCALPHA,
+	true, // GE_DSTBLEND_DSTALPHA,
+	true, // GE_DSTBLEND_INVDSTALPHA,
+	false, // GE_DSTBLEND_DOUBLESRCALPHA,
+	false, // GE_DSTBLEND_DOUBLEINVSRCALPHA,
+	true, // GE_DSTBLEND_DOUBLEDSTALPHA,
+	true, // GE_DSTBLEND_DOUBLEINVDSTALPHA,
+	true, //GE_DSTBLEND_FIXB,
+};
+
+static inline bool IsAlphaTestTriviallyTrue() {
+	switch (gstate.getAlphaTestFunction()) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_GEQUAL:
+		if (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed()))
+			return true;  // If alpha is full, it doesn't matter what the ref value is.
+		return gstate.getAlphaTestRef() == 0;
+
+	// Non-zero check. If we have no depth testing (and thus no depth writing), and an alpha func that will result in no change if zero alpha, get rid of the alpha test.
+	// Speeds up Lumines by a LOT on PowerVR.
+	case GE_COMP_NOTEQUAL:
+		if (gstate.getAlphaTestRef() == 255) {
+			// Likely to be rare. Let's just skip the vertexFullAlpha optimization here instead of adding
+			// complicated code to discard the draw or whatnot.
+			return false;
+		}
+		// Fallthrough on purpose
+
+	case GE_COMP_GREATER:
+		{
+#if 0
+			// Easy way to check the values in the debugger without ruining && early-out
+			bool doTextureAlpha = gstate.isTextureAlphaUsed();
+			bool stencilTest = gstate.isStencilTestEnabled();
+			bool depthTest = gstate.isDepthTestEnabled();
+			GEComparison depthTestFunc = gstate.getDepthTestFunction();
+			int alphaRef = gstate.getAlphaTestRef();
+			int blendA = gstate.getBlendFuncA();
+			bool blendEnabled = gstate.isAlphaBlendEnabled();
+			int blendB = gstate.getBlendFuncA();
+#endif
+			return (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed())) || (
+					(!gstate.isStencilTestEnabled() &&
+					!gstate.isDepthTestEnabled() &&
+					gstate.getAlphaTestRef() == 0 &&
+					gstate.isAlphaBlendEnabled() &&
+					gstate.getBlendFuncA() == GE_SRCBLEND_SRCALPHA &&
+					safeDestFactors[(int)gstate.getBlendFuncB()]));
+		}
+
+	case GE_COMP_LEQUAL:
+		return gstate.getAlphaTestRef() == 255;
+
+	case GE_COMP_EQUAL:
+	case GE_COMP_LESS:
+		return false;
+
+	default:
+		return false;
+	}
+}
+
+static inline bool IsAlphaTestAgainstZero() {
+	return gstate.getAlphaTestRef() == 0 && gstate.getAlphaTestMask() == 0xFF;
+}
+
+static inline bool IsColorTestAgainstZero() {
+	return gstate.getColorTestRef() == 0 && gstate.getColorTestMask() == 0xFFFFFF;
+}
+
+static inline bool IsColorTestTriviallyTrue() {
+	switch (gstate.getColorTestFunction()) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_EQUAL:
+	case GE_COMP_NOTEQUAL:
+		return false;
+	default:
+		return false;
+	}
+}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -15,11 +15,63 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-
+#include "Core/Config.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/TextureCacheCommon.h"
+#include "GPU/GPUState.h"
+
+// Ugly.
+extern int g_iNumVideos;
 
 TextureCacheCommon::~TextureCacheCommon() {}
 
 bool TextureCacheCommon::SetOffsetTexture(u32 offset) {
 	return false;
+}
+
+void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel) {
+	minFilt = gstate.texfilter & 0x7;
+	magFilt = (gstate.texfilter>>8) & 1;
+	sClamp = gstate.isTexCoordClampedS();
+	tClamp = gstate.isTexCoordClampedT();
+
+	bool noMip = (gstate.texlevel & 0xFFFFFF) == 0x000001 || (gstate.texlevel & 0xFFFFFF) == 0x100001 ;  // Fix texlevel at 0
+
+	if (maxLevel == 0) {
+		// Enforce no mip filtering, for safety.
+		minFilt &= 1; // no mipmaps yet
+		lodBias = 0.0f;
+	} else {
+		// Texture lod bias should be signed.
+		lodBias = (float)(int)(s8)((gstate.texlevel >> 16) & 0xFF) / 16.0f;
+	}
+
+	if (g_Config.iTexFiltering == TEX_FILTER_LINEAR_VIDEO && g_iNumVideos > 0 && (gstate.getTextureDimension(0) & 0xF) >= 9) {
+		magFilt |= 1;
+		minFilt |= 1;
+	}
+	if (g_Config.iTexFiltering == TEX_FILTER_LINEAR && (!gstate.isColorTestEnabled() || IsColorTestTriviallyTrue())) {
+		// TODO: IsAlphaTestTriviallyTrue() is unsafe here.  vertexFullAlpha is not calculated yet.
+		if (!gstate.isAlphaTestEnabled() || IsAlphaTestTriviallyTrue()) {
+			magFilt |= 1;
+			minFilt |= 1;
+		}
+	}
+	bool forceNearest = g_Config.iTexFiltering == TEX_FILTER_NEAREST;
+	// Force Nearest when color test enabled and rendering resolution greater than 480x272
+	if ((gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue()) && g_Config.iInternalResolution != 1 && gstate.isModeThrough()) {
+		// Some games use 0 as the color test color, which won't be too bad if it bleeds.
+		// Fuchsia and green, etc. are the problem colors.
+		if (gstate.getColorTestRef() != 0) {
+			forceNearest = true;
+		}
+	}
+	if (forceNearest) {
+		magFilt &= ~1;
+		minFilt &= ~1;
+	}
+
+	if (!g_Config.bMipMap || noMip) {
+		minFilt &= 1;
+	}
 }

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -29,7 +29,7 @@ bool TextureCacheCommon::SetOffsetTexture(u32 offset) {
 	return false;
 }
 
-void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel) {
+void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel) {
 	minFilt = gstate.texfilter & 0x7;
 	magFilt = (gstate.texfilter>>8) & 1;
 	sClamp = gstate.isTexCoordClampedS();

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -19,9 +19,19 @@
 
 #include "Common/CommonTypes.h"
 
+enum TextureFiltering {
+	TEX_FILTER_AUTO = 1,
+	TEX_FILTER_NEAREST = 2,
+	TEX_FILTER_LINEAR = 3,
+	TEX_FILTER_LINEAR_VIDEO = 4,
+};
+
 class TextureCacheCommon {
 public:
 	virtual ~TextureCacheCommon();
 
 	virtual bool SetOffsetTexture(u32 offset);
+
+protected:
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 };

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -68,6 +68,7 @@ public:
 		int numInvalidated;
 		u32 framesUntilNextFullHash;
 		u8 format;
+		u8 maxLevel;
 		u16 dim;
 		u16 bufw;
 		union {
@@ -77,7 +78,6 @@ public:
 		int invalidHint;
 		u32 fullhash;
 		u32 cluthash;
-		int maxLevel;
 		float lodBias;
 
 		// Cache the current filter settings so we can avoid setting it again.
@@ -107,13 +107,13 @@ public:
 				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
 			}
 		}
-		bool Matches(u16 dim2, u8 format2, int maxLevel2);
+		bool Matches(u16 dim2, u8 format2, u8 maxLevel2);
 	};
 
 protected:
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel);
 };
 
-inline bool TextureCacheCommon::TexCacheEntry::Matches(u16 dim2, u8 format2, int maxLevel2) {
+inline bool TextureCacheCommon::TexCacheEntry::Matches(u16 dim2, u8 format2, u8 maxLevel2) {
 	return dim == dim2 && format == format2 && maxLevel == maxLevel2;
 }

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -26,12 +26,94 @@ enum TextureFiltering {
 	TEX_FILTER_LINEAR_VIDEO = 4,
 };
 
+struct VirtualFramebuffer;
+
 class TextureCacheCommon {
 public:
 	virtual ~TextureCacheCommon();
 
 	virtual bool SetOffsetTexture(u32 offset);
 
+	// Wow this is starting to grow big. Soon need to start looking at resizing it.
+	// Must stay a POD.
+	struct TexCacheEntry {
+		// After marking STATUS_UNRELIABLE, if it stays the same this many frames we'll trust it again.
+		const static int FRAMES_REGAIN_TRUST = 1000;
+
+		enum Status {
+			STATUS_HASHING = 0x00,
+			STATUS_RELIABLE = 0x01,        // Don't bother rehashing.
+			STATUS_UNRELIABLE = 0x02,      // Always recheck hash.
+			STATUS_MASK = 0x03,
+
+			STATUS_ALPHA_UNKNOWN = 0x04,
+			STATUS_ALPHA_FULL = 0x00,      // Has no alpha channel, or always full alpha.
+			STATUS_ALPHA_SIMPLE = 0x08,    // Like above, but also has 0 alpha (e.g. 5551.)
+			STATUS_ALPHA_MASK = 0x0c,
+
+			STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 15 frames in between.)
+			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
+			STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
+			STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
+		};
+
+		// Status, but int so we can zero initialize.
+		int status;
+		u32 addr;
+		u32 hash;
+		VirtualFramebuffer *framebuffer;  // if null, not sourced from an FBO.
+		u32 sizeInRAM;
+		int lastFrame;
+		int numFrames;
+		int numInvalidated;
+		u32 framesUntilNextFullHash;
+		u8 format;
+		u16 dim;
+		u16 bufw;
+		union {
+			u32 textureName;
+			void *texturePtr;
+		};
+		int invalidHint;
+		u32 fullhash;
+		u32 cluthash;
+		int maxLevel;
+		float lodBias;
+
+		// Cache the current filter settings so we can avoid setting it again.
+		// (OpenGL madness where filter settings are attached to each texture).
+		u8 magFilt;
+		u8 minFilt;
+		bool sClamp;
+		bool tClamp;
+
+		Status GetHashStatus() {
+			return Status(status & STATUS_MASK);
+		}
+		void SetHashStatus(Status newStatus) {
+			status = (status & ~STATUS_MASK) | newStatus;
+		}
+		Status GetAlphaStatus() {
+			return Status(status & STATUS_ALPHA_MASK);
+		}
+		void SetAlphaStatus(Status newStatus) {
+			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
+		}
+		void SetAlphaStatus(Status newStatus, int level) {
+			// For non-level zero, only set more restrictive.
+			if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
+				SetAlphaStatus(newStatus);
+			} else if (newStatus == STATUS_ALPHA_SIMPLE && GetAlphaStatus() == STATUS_ALPHA_FULL) {
+				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
+			}
+		}
+		bool Matches(u16 dim2, u8 format2, int maxLevel2);
+	};
+
 protected:
 	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 };
+
+inline bool TextureCacheCommon::TexCacheEntry::Matches(u16 dim2, u8 format2, int maxLevel2) {
+	return dim == dim2 && format == format2 && maxLevel == maxLevel2;
+}

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -77,10 +77,6 @@ enum ReplaceBlendType {
 	REPLACE_BLEND_COPY_FBO,
 };
 
-bool IsAlphaTestAgainstZero();
-bool IsAlphaTestTriviallyTrue();
-bool IsColorTestAgainstZero();
-bool IsColorTestTriviallyTrue();
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend);
 ReplaceBlendType ReplaceBlendWithShader(bool allowShaderBlend);

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -150,11 +150,7 @@ bool TransformDrawEngineDX9::ApplyShaderBlending() {
 		return false;
 	}
 
-	framebufferManager_->BindFramebufferColor(1, nullptr, false);
-	// If we are rendering at a higher resolution, linear is probably best for the dest color.
-	pD3Ddevice->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
-	pD3Ddevice->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
-	fboTexBound_ = true;
+	fboTexNeedBind_ = true;
 
 	shaderManager_->DirtyUniform(DIRTY_SHADERBLEND);
 	return true;
@@ -807,6 +803,23 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 		}
 
 		dxstate.viewport.set(left, top, right - left, bottom - top, depthRangeMin, depthRangeMax);
+	}
+}
+
+void TransformDrawEngineDX9::ApplyDrawStateLate() {
+	// At this point, we know if the vertices are full alpha or not.
+	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
+	if (!gstate.isModeClear()) {
+		// TODO: Test texture?
+
+		if (fboTexNeedBind_) {
+			framebufferManager_->BindFramebufferColor(1, nullptr, false);
+			// If we are rendering at a higher resolution, linear is probably best for the dest color.
+			pD3Ddevice->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+			pD3Ddevice->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
+			fboTexBound_ = true;
+			fboTexNeedBind_ = false;
+		}
 	}
 }
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -1047,7 +1047,7 @@ void TextureCacheDX9::SetTexture(bool force) {
 	}
 	
 	int bufw = GetTextureBufw(0, texaddr, format);
-	int maxLevel = gstate.getTextureMaxLevel();
+	u8 maxLevel = gstate.getTextureMaxLevel();
 
 	u32 texhash = MiniHash((const u32 *)Memory::GetPointer(texaddr));
 	u32 fullhash = 0;
@@ -1294,7 +1294,7 @@ void TextureCacheDX9::SetTexture(bool force) {
 
 	// Adjust maxLevel to actually present levels..
 	bool badMipSizes = false;
-	for (int i = 0; i <= maxLevel; i++) {
+	for (u32 i = 0; i <= maxLevel; i++) {
 		// If encountering levels pointing to nothing, adjust max level.
 		u32 levelTexaddr = gstate.getTextureAddress(i);
 		if (!Memory::IsValidAddress(levelTexaddr)) {
@@ -1368,7 +1368,7 @@ void TextureCacheDX9::SetTexture(bool force) {
 
 	// Mipmapping is only enabled when texture scaling is disabled.
 	if (maxLevel > 0 && g_Config.iTexScalingLevel == 1) {
-		for (int i = 1; i <= maxLevel; i++) {
+		for (u32 i = 1; i <= maxLevel; i++) {
 			LoadTextureLevel(*entry, i, maxLevel, replaceImages, scaleFactor, dstFmt);
 		}
 	}

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -35,13 +35,6 @@ class FramebufferManagerDX9;
 class DepalShaderCacheDX9;
 class ShaderManagerDX9;
 
-enum TextureFiltering {
-	AUTO = 1,
-	NEAREST = 2,
-	LINEAR = 3,   
-	LINEARFMV = 4,
-};
-
 enum FramebufferNotification {
 	NOTIFY_FB_CREATED,
 	NOTIFY_FB_UPDATED,
@@ -168,7 +161,6 @@ private:
 	void DeleteTexture(TexCache::iterator it);
 	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
 	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, u32 dstFmt, int bufw);
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, int maxLevel, bool replaceImages, int scaleFactor, u32 dstFmt);
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -79,78 +79,6 @@ public:
 
 	void ForgetLastTexture();
 
-	// Wow this is starting to grow big. Soon need to start looking at resizing it.
-	// Must stay a POD.
-	struct TexCacheEntry {
-		// After marking STATUS_UNRELIABLE, if it stays the same this many frames we'll trust it again.
-		const static int FRAMES_REGAIN_TRUST = 1000;
-
-		enum Status {
-			STATUS_HASHING = 0x00,
-			STATUS_RELIABLE = 0x01,        // Don't bother rehashing.
-			STATUS_UNRELIABLE = 0x02,      // Always recheck hash.
-			STATUS_MASK = 0x03,
-
-			STATUS_ALPHA_UNKNOWN = 0x04,
-			STATUS_ALPHA_FULL = 0x00,      // Has no alpha channel, or always full alpha.
-			STATUS_ALPHA_SIMPLE = 0x08,    // Like above, but also has 0 alpha (e.g. 5551.)
-			STATUS_ALPHA_MASK = 0x0c,
-
-			STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 15 frames in between.)
-			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
-			STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
-			STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
-		};
-
-		// Status, but int so we can zero initialize.
-		int status;
-		u32 addr;
-		u32 hash;
-		VirtualFramebuffer *framebuffer;  // if null, not sourced from an FBO.
-		u32 sizeInRAM;
-		int lastFrame;
-		int numFrames;
-		int numInvalidated;
-		u32 framesUntilNextFullHash;
-		u8 format;
-		u16 dim;
-		u16 bufw;
-		LPDIRECT3DTEXTURE9 texture;
-		int invalidHint;
-		u32 fullhash;
-		u32 cluthash;
-		int maxLevel;
-		float lodBias;
-
-		Status GetHashStatus() {
-			return Status(status & STATUS_MASK);
-		}
-		void SetHashStatus(Status newStatus) {
-			status = (status & ~STATUS_MASK) | newStatus;
-		}
-		Status GetAlphaStatus() {
-			return Status(status & STATUS_ALPHA_MASK);
-		}
-		void SetAlphaStatus(Status newStatus) {
-			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
-		}
-		void SetAlphaStatus(Status newStatus, int level) {
-			// For non-level zero, only set more restrictive.
-			if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
-				SetAlphaStatus(newStatus);
-			} else if (newStatus == STATUS_ALPHA_SIMPLE && GetAlphaStatus() == STATUS_ALPHA_FULL) {
-				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
-			}
-		}
-		bool Matches(u16 dim2, u8 format2, int maxLevel2);
-		void ReleaseTexture() {
-			if (texture) {
-				texture->Release();
-				texture = NULL;
-			}
-		}
-	};
-
 	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 
 private:
@@ -174,7 +102,16 @@ private:
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
 
-	TexCacheEntry *GetEntryAt(u32 texaddr);
+	LPDIRECT3DTEXTURE9 &DxTex(TexCacheEntry *entry) {
+		return *(LPDIRECT3DTEXTURE9 *)&entry->texturePtr;
+	}
+	void ReleaseTexture(TexCacheEntry *entry) {
+		LPDIRECT3DTEXTURE9 &texture = DxTex(entry);
+		if (texture) {
+			texture->Release();
+			texture = nullptr;
+		}
+	}
 
 	TexCache cache;
 	TexCache secondCache;

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -90,6 +90,7 @@ TransformDrawEngineDX9::TransformDrawEngineDX9()
 		decodeCounter_(0),
 		dcid_(0),
 		uvScale(0),
+		fboTexNeedBind_(false),
 		fboTexBound_(false) {
 
 	memset(&decOptions_, 0, sizeof(decOptions_));
@@ -777,6 +778,8 @@ rotateVBO:
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
+		ApplyDrawStateLate();
+		vshader = shaderManager_->ApplyShader(prim, lastVType_);
 		IDirect3DVertexDeclaration9 *pHardwareVertexDecl = SetupDecFmtForDraw(vshader, dec_->GetDecVtxFmt(), dec_->VertexType());
 
 		if (pHardwareVertexDecl) {
@@ -807,6 +810,9 @@ rotateVBO:
 		} else {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
+
+		ApplyDrawStateLate();
+		vshader = shaderManager_->ApplyShader(prim, lastVType_);
 
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
 		prim = indexGen.Prim();

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -811,9 +811,6 @@ rotateVBO:
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		ApplyDrawStateLate();
-		vshader = shaderManager_->ApplyShader(prim, lastVType_);
-
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
 		prim = indexGen.Prim();
 		// Undo the strip optimization, not supported by the SW code yet.
@@ -833,6 +830,9 @@ rotateVBO:
 			prim, decoded, indexGen.VertexCount(),
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 			maxIndex, framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result, -1.0f);
+
+		ApplyDrawStateLate();
+		vshader = shaderManager_->ApplyShader(prim, lastVType_);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {
 			if (result.setStencil) {

--- a/GPU/Directx9/TransformPipelineDX9.h
+++ b/GPU/Directx9/TransformPipelineDX9.h
@@ -247,6 +247,7 @@ private:
 
 	UVScale *uvScale;
 
+	bool fboTexNeedBind_;
 	bool fboTexBound_;
 };
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -30,6 +30,7 @@
 #include "gfx_es2/gpu_features.h"
 #include "Core/Reporting.h"
 #include "Core/Config.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/GLES/FragmentShaderGenerator.h"
 #include "GPU/GLES/Framebuffer.h"
 #include "GPU/GLES/ShaderManager.h"
@@ -39,86 +40,6 @@
 #define WRITE p+=sprintf
 
 // #define DEBUG_SHADER
-
-// Dest factors where it's safe to eliminate the alpha test under certain conditions
-const bool safeDestFactors[16] = {
-	true, // GE_DSTBLEND_SRCCOLOR,
-	true, // GE_DSTBLEND_INVSRCCOLOR,
-	false, // GE_DSTBLEND_SRCALPHA,
-	true, // GE_DSTBLEND_INVSRCALPHA,
-	true, // GE_DSTBLEND_DSTALPHA,
-	true, // GE_DSTBLEND_INVDSTALPHA,
-	false, // GE_DSTBLEND_DOUBLESRCALPHA,
-	false, // GE_DSTBLEND_DOUBLEINVSRCALPHA,
-	true, // GE_DSTBLEND_DOUBLEDSTALPHA,
-	true, // GE_DSTBLEND_DOUBLEINVDSTALPHA,
-	true, //GE_DSTBLEND_FIXB,
-};
-
-bool IsAlphaTestTriviallyTrue() {
-	switch (gstate.getAlphaTestFunction()) {
-	case GE_COMP_NEVER:
-		return false;
-
-	case GE_COMP_ALWAYS:
-		return true;
-
-	case GE_COMP_GEQUAL:
-		if (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed()))
-			return true;  // If alpha is full, it doesn't matter what the ref value is.
-		return gstate.getAlphaTestRef() == 0;
-
-	// Non-zero check. If we have no depth testing (and thus no depth writing), and an alpha func that will result in no change if zero alpha, get rid of the alpha test.
-	// Speeds up Lumines by a LOT on PowerVR.
-	case GE_COMP_NOTEQUAL:
-		if (gstate.getAlphaTestRef() == 255) {
-			// Likely to be rare. Let's just skip the vertexFullAlpha optimization here instead of adding
-			// complicated code to discard the draw or whatnot.
-			return false;
-		}
-		// Fallthrough on purpose
-
-	case GE_COMP_GREATER:
-		{
-#if 0
-			// Easy way to check the values in the debugger without ruining && early-out
-			bool doTextureAlpha = gstate.isTextureAlphaUsed();
-			bool stencilTest = gstate.isStencilTestEnabled();
-			bool depthTest = gstate.isDepthTestEnabled();
-			GEComparison depthTestFunc = gstate.getDepthTestFunction();
-			int alphaRef = gstate.getAlphaTestRef();
-			int blendA = gstate.getBlendFuncA();
-			bool blendEnabled = gstate.isAlphaBlendEnabled();
-			int blendB = gstate.getBlendFuncA();
-#endif
-			return (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed())) || (
-					(!gstate.isStencilTestEnabled() &&
-					!gstate.isDepthTestEnabled() &&
-					gstate.getAlphaTestRef() == 0 &&
-					gstate.isAlphaBlendEnabled() &&
-					gstate.getBlendFuncA() == GE_SRCBLEND_SRCALPHA &&
-					safeDestFactors[(int)gstate.getBlendFuncB()]));
-		}
-
-	case GE_COMP_LEQUAL:
-		return gstate.getAlphaTestRef() == 255;
-
-	case GE_COMP_EQUAL:
-	case GE_COMP_LESS:
-		return false;
-
-	default:
-		return false;
-	}
-}
-
-bool IsAlphaTestAgainstZero() {
-	return gstate.getAlphaTestRef() == 0 && gstate.getAlphaTestMask() == 0xFF;
-}
-
-bool IsColorTestAgainstZero() {
-	return gstate.getColorTestRef() == 0 && gstate.getColorTestMask() == 0xFFFFFF;
-}
 
 const bool nonAlphaSrcFactors[16] = {
 	true,  // GE_SRCBLEND_DSTCOLOR,
@@ -202,6 +123,7 @@ StencilValueType ReplaceAlphaWithStencilType() {
 	case GE_FORMAT_INVALID:
 		switch (gstate.getStencilOpZPass()) {
 		case GE_STENCILOP_REPLACE:
+			// TODO: Could detect zero here and force ZERO - less uniform updates?
 			return STENCIL_VALUE_UNIFORM;
 
 		case GE_STENCILOP_ZERO:
@@ -223,22 +145,6 @@ StencilValueType ReplaceAlphaWithStencilType() {
 	}
 
 	return STENCIL_VALUE_KEEP;
-}
-
-bool IsColorTestTriviallyTrue() {
-	switch (gstate.getColorTestFunction()) {
-	case GE_COMP_NEVER:
-		return false;
-
-	case GE_COMP_ALWAYS:
-		return true;
-
-	case GE_COMP_EQUAL:
-	case GE_COMP_NOTEQUAL:
-		return false;
-	default:
-		return false;
-	}
 }
 
 ReplaceBlendType ReplaceBlendWithShader(bool allowShaderBlend) {

--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -52,10 +52,6 @@ enum ReplaceBlendType {
 	REPLACE_BLEND_COPY_FBO,
 };
 
-bool IsAlphaTestAgainstZero();
-bool IsAlphaTestTriviallyTrue();
-bool IsColorTestAgainstZero();
-bool IsColorTestTriviallyTrue();
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend);
 ReplaceBlendType ReplaceBlendWithShader(bool allowShaderBlend);

--- a/GPU/GLES/FragmentTestCache.cpp
+++ b/GPU/GLES/FragmentTestCache.cpp
@@ -16,7 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Core/Config.h"
-#include "GPU/GLES/FragmentShaderGenerator.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/GLES/FragmentTestCache.h"
 #include "GPU/GPUState.h"
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -389,7 +389,7 @@ void FramebufferManager::DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY,
 
 void FramebufferManager::DrawFramebuffer(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader) {
 	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, 512, 272);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_Config.iTexFiltering == NEAREST ? GL_NEAREST : GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_Config.iTexFiltering == TEX_FILTER_NEAREST ? GL_NEAREST : GL_LINEAR);
 
 	DisableState();
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -190,13 +190,7 @@ bool TransformDrawEngine::ApplyShaderBlending() {
 		return false;
 	}
 
-	framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr);
-	glActiveTexture(GL_TEXTURE1);
-	// If we are rendering at a higher resolution, linear is probably best for the dest color.
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glActiveTexture(GL_TEXTURE0);
-	fboTexBound_ = true;
+	fboTexNeedBind_ = true;
 
 	shaderManager_->DirtyUniform(DIRTY_SHADERBLEND);
 	return true;
@@ -905,6 +899,17 @@ void TransformDrawEngine::ApplyDrawStateLate() {
 	if (!gstate.isModeClear()) {
 		if (gstate.isAlphaTestEnabled() || gstate.isColorTestEnabled()) {
 			fragmentTestCache_->BindTestTexture(GL_TEXTURE2);
+		}
+
+		if (fboTexNeedBind_) {
+			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr);
+			glActiveTexture(GL_TEXTURE1);
+			// If we are rendering at a higher resolution, linear is probably best for the dest color.
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glActiveTexture(GL_TEXTURE0);
+			fboTexBound_ = true;
+			fboTexNeedBind_ = false;
 		}
 	}
 }

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1114,7 +1114,7 @@ void TextureCache::SetTexture(bool force) {
 	}
 
 	int bufw = GetTextureBufw(0, texaddr, format);
-	int maxLevel = gstate.getTextureMaxLevel();
+	u8 maxLevel = gstate.getTextureMaxLevel();
 
 	u32 texhash = MiniHash((const u32 *)Memory::GetPointerUnchecked(texaddr));
 	u32 fullhash = 0;
@@ -1362,7 +1362,7 @@ void TextureCache::SetTexture(bool force) {
 
 	// Adjust maxLevel to actually present levels..
 	bool badMipSizes = false;
-	for (int i = 0; i <= maxLevel; i++) {
+	for (u32 i = 0; i <= maxLevel; i++) {
 		// If encountering levels pointing to nothing, adjust max level.
 		u32 levelTexaddr = gstate.getTextureAddress(i);
 		if (!Memory::IsValidAddress(levelTexaddr)) {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -133,12 +133,12 @@ void TextureCache::Clear(bool delete_them) {
 	lastBoundTexture = -1;
 	if (delete_them) {
 		for (TexCache::iterator iter = cache.begin(); iter != cache.end(); ++iter) {
-			DEBUG_LOG(G3D, "Deleting texture %i", iter->second.texture);
-			glDeleteTextures(1, &iter->second.texture);
+			DEBUG_LOG(G3D, "Deleting texture %i", iter->second.textureName);
+			glDeleteTextures(1, &iter->second.textureName);
 		}
 		for (TexCache::iterator iter = secondCache.begin(); iter != secondCache.end(); ++iter) {
-			DEBUG_LOG(G3D, "Deleting texture %i", iter->second.texture);
-			glDeleteTextures(1, &iter->second.texture);
+			DEBUG_LOG(G3D, "Deleting texture %i", iter->second.textureName);
+			glDeleteTextures(1, &iter->second.textureName);
 		}
 		if (!nameCache_.empty()) {
 			glDeleteTextures((GLsizei)nameCache_.size(), &nameCache_[0]);
@@ -156,7 +156,7 @@ void TextureCache::Clear(bool delete_them) {
 }
 
 void TextureCache::DeleteTexture(TexCache::iterator it) {
-	glDeleteTextures(1, &it->second.texture);
+	glDeleteTextures(1, &it->second.textureName);
 	auto fbInfo = fbTexInfo_.find(it->second.addr);
 	if (fbInfo != fbTexInfo_.end()) {
 		fbTexInfo_.erase(fbInfo);
@@ -197,7 +197,7 @@ void TextureCache::Decimate() {
 		for (TexCache::iterator iter = secondCache.begin(); iter != secondCache.end(); ) {
 			// In low memory mode, we kill them all.
 			if (lowMemoryMode_ || iter->second.lastFrame + TEXTURE_SECOND_KILL_AGE < gpuStats.numFlips) {
-				glDeleteTextures(1, &iter->second.texture);
+				glDeleteTextures(1, &iter->second.textureName);
 				secondCacheSizeEstimate_ -= EstimateTexMemoryUsage(&iter->second);
 				secondCache.erase(iter++);
 			} else {
@@ -793,10 +793,6 @@ static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, GETextureFormat
 	return DoQuickTexHash(checkp, sizeInRAM);
 }
 
-inline bool TextureCache::TexCacheEntry::Matches(u16 dim2, u8 format2, int maxLevel2) {
-	return dim == dim2 && format == format2 && maxLevel == maxLevel2;
-}
-
 void TextureCache::LoadClut(u32 clutAddr, u32 loadBytes) {
 	clutTotalBytes_ = loadBytes;
 	if (Memory::IsValidAddress(clutAddr)) {
@@ -1173,7 +1169,7 @@ void TextureCache::SetTexture(bool force) {
 					// Exponential backoff up to 512 frames.  Textures are often reused.
 					if (entry->numFrames > 32) {
 						// Also, try to add some "randomness" to avoid rehashing several textures the same frame.
-						entry->framesUntilNextFullHash = std::min(512, entry->numFrames) + (entry->texture & 15);
+						entry->framesUntilNextFullHash = std::min(512, entry->numFrames) + (entry->textureName & 15);
 					} else {
 						entry->framesUntilNextFullHash = entry->numFrames;
 					}
@@ -1257,9 +1253,9 @@ void TextureCache::SetTexture(bool force) {
 			// TODO: Mark the entry reliable if it's been safe for long enough?
 			//got one!
 			entry->lastFrame = gpuStats.numFlips;
-			if (entry->texture != lastBoundTexture) {
-				glBindTexture(GL_TEXTURE_2D, entry->texture);
-				lastBoundTexture = entry->texture;
+			if (entry->textureName != lastBoundTexture) {
+				glBindTexture(GL_TEXTURE_2D, entry->textureName);
+				lastBoundTexture = entry->textureName;
 				gstate_c.textureFullAlpha = entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL;
 				gstate_c.textureSimpleAlpha = entry->GetAlphaStatus() != TexCacheEntry::STATUS_ALPHA_UNKNOWN;
 			}
@@ -1277,10 +1273,10 @@ void TextureCache::SetTexture(bool force) {
 					// Instead, let's use glTexSubImage to replace the images.
 					replaceImages = true;
 				} else {
-					if (entry->texture == lastBoundTexture) {
+					if (entry->textureName == lastBoundTexture) {
 						lastBoundTexture = -1;
 					}
-					glDeleteTextures(1, &entry->texture);
+					glDeleteTextures(1, &entry->textureName);
 				}
 			}
 			// Clear the reliable bit if set.
@@ -1345,7 +1341,7 @@ void TextureCache::SetTexture(bool force) {
 
 	// Always generate a texture name, we might need it if the texture is replaced later.
 	if (!replaceImages) {
-		entry->texture = AllocTextureName();
+		entry->textureName = AllocTextureName();
 	}
 
 	// Before we go reading the texture from memory, let's check for render-to-texture.
@@ -1361,8 +1357,8 @@ void TextureCache::SetTexture(bool force) {
 		entry->lastFrame = gpuStats.numFlips;
 		return;
 	}
-	glBindTexture(GL_TEXTURE_2D, entry->texture);
-	lastBoundTexture = entry->texture;
+	glBindTexture(GL_TEXTURE_2D, entry->textureName);
+	lastBoundTexture = entry->textureName;
 
 	// Adjust maxLevel to actually present levels..
 	bool badMipSizes = false;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -660,53 +660,6 @@ static const GLuint MagFiltGL[2] = {
 	GL_LINEAR
 };
 
-void TextureCache::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel) {
-	minFilt = gstate.texfilter & 0x7;
-	magFilt = (gstate.texfilter>>8) & 1;
-	sClamp = gstate.isTexCoordClampedS();
-	tClamp = gstate.isTexCoordClampedT();
-
-	bool noMip = (gstate.texlevel & 0xFFFFFF) == 0x000001 || (gstate.texlevel & 0xFFFFFF) == 0x100001 ;  // Fix texlevel at 0
-
-	if (maxLevel == 0) {
-		// Enforce no mip filtering, for safety.
-		minFilt &= 1; // no mipmaps yet
-		lodBias = 0.0f;
-	} else {
-		// Texture lod bias should be signed.
-		lodBias = (float)(int)(s8)((gstate.texlevel >> 16) & 0xFF) / 16.0f;
-	}
-
-	if (g_Config.iTexFiltering == LINEARFMV && g_iNumVideos > 0 && (gstate.getTextureDimension(0) & 0xF) >= 9) {
-		magFilt |= 1;
-		minFilt |= 1;
-	}
-	if (g_Config.iTexFiltering == LINEAR && (!gstate.isColorTestEnabled() || IsColorTestTriviallyTrue())) {
-		// TODO: IsAlphaTestTriviallyTrue() is unsafe here.  vertexFullAlpha is not calculated yet.
-		if (!gstate.isAlphaTestEnabled() || IsAlphaTestTriviallyTrue()) {
-			magFilt |= 1;
-			minFilt |= 1;
-		}
-	}
-	bool forceNearest = g_Config.iTexFiltering == NEAREST;
-	// Force Nearest when color test enabled and rendering resolution greater than 480x272
-	if ((gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue()) && g_Config.iInternalResolution != 1 && gstate.isModeThrough()) {
-		// Some games use 0 as the color test color, which won't be too bad if it bleeds.
-		// Fuchsia and green, etc. are the problem colors.
-		if (gstate.getColorTestRef() != 0) {
-			forceNearest = true;
-		}
-	}
-	if (forceNearest) {
-		magFilt &= ~1;
-		minFilt &= ~1;
-	}
-
-	if (!g_Config.bMipMap || noMip) {
-		minFilt &= 1;
-	}
-}
-
 // This should not have to be done per texture! OpenGL is silly yo
 void TextureCache::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 	int minFilt;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -33,13 +33,6 @@ class FramebufferManager;
 class DepalShaderCache;
 class ShaderManager;
 
-enum TextureFiltering {
-	AUTO = 1,
-	NEAREST = 2,
-	LINEAR = 3,
-	LINEARFMV = 4,
-};
-
 enum FramebufferNotification {
 	NOTIFY_FB_CREATED,
 	NOTIFY_FB_UPDATED,
@@ -180,7 +173,6 @@ private:
 	void DeleteTexture(TexCache::iterator it);
 	void *UnswizzleFromMem(const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
 	void *ReadIndexedTex(int level, const u8 *texptr, int bytesPerIndex, GLuint dstFmt, int bufw);
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel);
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, int level, bool replaceImages, int scaleFactor, GLenum dstFmt);
 	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -90,79 +90,6 @@ public:
 	// Only used by Qt UI?
 	bool DecodeTexture(u8 *output, const GPUgstate &state);
 
-	// Wow this is starting to grow big. Soon need to start looking at resizing it.
-	// Must stay a POD.
-	struct TexCacheEntry {
-		// After marking STATUS_UNRELIABLE, if it stays the same this many frames we'll trust it again.
-		const static int FRAMES_REGAIN_TRUST = 1000;
-
-		enum Status {
-			STATUS_HASHING = 0x00,
-			STATUS_RELIABLE = 0x01,        // Don't bother rehashing.
-			STATUS_UNRELIABLE = 0x02,      // Always recheck hash.
-			STATUS_MASK = 0x03,
-
-			STATUS_ALPHA_UNKNOWN = 0x04,
-			STATUS_ALPHA_FULL = 0x00,      // Has no alpha channel, or always full alpha.
-			STATUS_ALPHA_SIMPLE = 0x08,    // Like above, but also has 0 alpha (e.g. 5551.)
-			STATUS_ALPHA_MASK = 0x0c,
-
-			STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 15 frames in between.)
-			STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
-			STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
-			STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
-		};
-
-		// Status, but int so we can zero initialize.
-		int status;
-		u32 addr;
-		u32 hash;
-		VirtualFramebuffer *framebuffer;  // if null, not sourced from an FBO.
-		u32 sizeInRAM;
-		int lastFrame;
-		int numFrames;
-		int numInvalidated;
-		u32 framesUntilNextFullHash;
-		u8 format;
-		u16 dim;
-		u16 bufw;
-		u32 texture;  //GLuint
-		int invalidHint;
-		u32 fullhash;
-		u32 cluthash;
-		int maxLevel;
-		float lodBias;
-
-		// Cache the current filter settings so we can avoid setting it again.
-		// (OpenGL madness where filter settings are attached to each texture).
-		u8 magFilt;
-		u8 minFilt;
-		bool sClamp;
-		bool tClamp;
-
-		Status GetHashStatus() {
-			return Status(status & STATUS_MASK);
-		}
-		void SetHashStatus(Status newStatus) {
-			status = (status & ~STATUS_MASK) | newStatus;
-		}
-		Status GetAlphaStatus() {
-			return Status(status & STATUS_ALPHA_MASK);
-		}
-		void SetAlphaStatus(Status newStatus) {
-			status = (status & ~STATUS_ALPHA_MASK) | newStatus;
-		}
-		void SetAlphaStatus(Status newStatus, int level) {
-			// For non-level zero, only set more restrictive.
-			if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
-				SetAlphaStatus(newStatus);
-			} else if (newStatus == STATUS_ALPHA_SIMPLE && GetAlphaStatus() == STATUS_ALPHA_FULL) {
-				SetAlphaStatus(STATUS_ALPHA_SIMPLE);
-			}
-		}
-		bool Matches(u16 dim2, u8 format2, int maxLevel2);
-	};
-
 	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 
 private:
@@ -185,8 +112,6 @@ private:
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer);
 	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
-
-	TexCacheEntry *GetEntryAt(u32 texaddr);
 
 	TexCache cache;
 	TexCache secondCache;

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -126,6 +126,7 @@ TransformDrawEngine::TransformDrawEngine()
 		decodeCounter_(0),
 		dcid_(0),
 		uvScale(0),
+		fboTexNeedBind_(false),
 		fboTexBound_(false) {
 	decimationCounter_ = VERTEXCACHE_DECIMATION_INTERVAL;
 	memset(&decOptions_, 0, sizeof(decOptions_));

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -787,8 +787,6 @@ rotateVBO:
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		ApplyDrawStateLate();
-		LinkedShader *program = shaderManager_->ApplyFragmentShader(vshader, prim, lastVType_);
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
 		prim = indexGen.Prim();
 		// Undo the strip optimization, not supported by the SW code yet.
@@ -807,6 +805,9 @@ rotateVBO:
 			prim, decoded, indexGen.VertexCount(),
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 			maxIndex, framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result, 1.0);
+
+		ApplyDrawStateLate();
+		LinkedShader *program = shaderManager_->ApplyFragmentShader(vshader, prim, lastVType_);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {
 			if (result.setStencil) {

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -250,5 +250,6 @@ private:
 
 	UVScale *uvScale;
 
+	bool fboTexNeedBind_;
 	bool fboTexBound_;
 };

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -185,6 +185,7 @@
     <ClInclude Include="Common\DrawEngineCommon.h" />
     <ClInclude Include="Common\FramebufferCommon.h" />
     <ClInclude Include="Common\GPUDebugInterface.h" />
+    <ClInclude Include="Common\GPUStateUtils.h" />
     <ClInclude Include="Common\IndexGenerator.h" />
     <ClInclude Include="Common\PostShader.h" />
     <ClInclude Include="Common\SoftwareTransformCommon.h" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClInclude Include="GLES\GLStateCache.h">
       <Filter>GLES</Filter>
     </ClInclude>
+    <ClInclude Include="Common\GPUStateUtils.h">
+      <Filter>Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">

--- a/Windows/WndMainWindow.cpp
+++ b/Windows/WndMainWindow.cpp
@@ -1588,10 +1588,10 @@ namespace MainWindow
 					g_Config.iShowFPSCounter = !g_Config.iShowFPSCounter;
 					break;
 
-				case ID_OPTIONS_TEXTUREFILTERING_AUTO: setTexFiltering(AUTO); break;
-				case ID_OPTIONS_NEARESTFILTERING:      setTexFiltering(NEAREST); break;
-				case ID_OPTIONS_LINEARFILTERING:       setTexFiltering(LINEAR); break;
-				case ID_OPTIONS_LINEARFILTERING_CG:    setTexFiltering(LINEARFMV); break;
+				case ID_OPTIONS_TEXTUREFILTERING_AUTO: setTexFiltering(TEX_FILTER_AUTO); break;
+				case ID_OPTIONS_NEARESTFILTERING:      setTexFiltering(TEX_FILTER_NEAREST); break;
+				case ID_OPTIONS_LINEARFILTERING:       setTexFiltering(TEX_FILTER_LINEAR); break;
+				case ID_OPTIONS_LINEARFILTERING_CG:    setTexFiltering(TEX_FILTER_LINEAR_VIDEO); break;
 
 				case ID_OPTIONS_BUFLINEARFILTER:       setBufFilter(SCALE_LINEAR); break;
 				case ID_OPTIONS_BUFNEARESTFILTER:      setBufFilter(SCALE_NEAREST); break;
@@ -1918,11 +1918,10 @@ namespace MainWindow
 			ID_OPTIONS_LINEARFILTERING,
 			ID_OPTIONS_LINEARFILTERING_CG,
 		};
-		if(g_Config.iTexFiltering < AUTO)
-			g_Config.iTexFiltering = AUTO;
-
-		else if(g_Config.iTexFiltering > LINEARFMV)
-			g_Config.iTexFiltering = LINEARFMV;
+		if (g_Config.iTexFiltering < TEX_FILTER_AUTO)
+			g_Config.iTexFiltering = TEX_FILTER_AUTO;
+		else if (g_Config.iTexFiltering > TEX_FILTER_LINEAR_VIDEO)
+			g_Config.iTexFiltering = TEX_FILTER_LINEAR_VIDEO;
 
 		for (int i = 0; i < ARRAY_SIZE(texfilteringitems); i++) {
 			CheckMenuItem(menu, texfilteringitems[i], MF_BYCOMMAND | ((i + 1) == g_Config.iTexFiltering ? MF_CHECKED : MF_UNCHECKED));


### PR DESCRIPTION
This mostly centralizes some code and paths between GLES and Direct3D 9, and defers a few things until a bit later.

This is a lot of the lines changed for tex-split (#7870), but there aren't any major changes to the way things work here.  The changes are:
- GetSamplingParams() is moved to TextureCacheCommon (no changes.)
- TexCacheEntry is moved to TextureCacheCommon (minor changes to share the same structure.)
- Functions to check if fragment tests can be optimized out are moved to GPUStateUtils (no changes.)
- When using a texture copy for shader blending, make the copy and bind it after vert decode.
- Finalize which shader to use after vert decode in software transform.

I was a bit lazy in Direct3D9 - it currently decides the shader twice.  More ideally this might be split out to match GLES.

-[Unknown]
