### PR TITLE
Remove all uses of stat() on Windows. Buggy on XP with VS 2015.

### DIFF
--- a/Common/ChunkFile.cpp
+++ b/Common/ChunkFile.cpp
@@ -169,7 +169,7 @@ CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string& _rFilename
 	}
 
 	// Check file size
-	const u64 fileSize = File::GetSize(_rFilename);
+	const u64 fileSize = File::GetFileSize(_rFilename);
 	static const u64 headerSize = sizeof(SChunkHeader);
 	if (fileSize < headerSize)
 	{

--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -77,8 +77,6 @@ inline u64 __rotr64(u64 x, unsigned int shift){
 	#define fseeko _fseeki64
 	#define ftello _ftelli64
 	#define atoll _atoi64
-	#define stat64 _stat64
-	#define fstat64 _fstat64
 	#define fileno _fileno
 #ifndef _XBOX
 	#if _M_IX86

--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -440,9 +440,9 @@ bool GetFileDetails(const std::string &filename, FileDetails *details) {
 		return false;
 	details->isDirectory = (attr.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 	details->size = ((u64)attr.nFileSizeHigh << 32) | (u64)attr.nFileSizeLow;
-	details->st_atime = FiletimeToStatTime(attr.ftLastAccessTime);
-	details->st_mtime = FiletimeToStatTime(attr.ftLastWriteTime);
-	details->st_ctime = FiletimeToStatTime(attr.ftCreationTime);
+	details->atime = FiletimeToStatTime(attr.ftLastAccessTime);
+	details->mtime = FiletimeToStatTime(attr.ftLastWriteTime);
+	details->ctime = FiletimeToStatTime(attr.ftCreationTime);
 	if (attr.dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
 		details->access = 0444;  // Read
 	} else {
@@ -460,9 +460,9 @@ bool GetFileDetails(const std::string &filename, FileDetails *details) {
 	if (stat64(filename.c_str(), &buf) == 0) {
 		details->size = buf.st_size;
 		details->isDirectory = S_ISDIR(buf.st_mode);
-		details->st_atime = buf.st_atime;
-		details->st_mtime = buf.st_mtime;
-		details->st_ctime = buf.st_ctime;
+		details->atime = buf.st_atime;
+		details->mtime = buf.st_mtime;
+		details->ctime = buf.st_ctime;
 		details->access = buf.st_mode & 0x1ff;
 		return true;
 	} else {
@@ -475,7 +475,7 @@ bool GetModifTime(const std::string &filename, tm &return_time) {
 	memset(&return_time, 0, sizeof(return_time));
 	FileDetails details;
 	if (GetFileDetails(filename, &details)) {
-		time_t t = details.st_mtime;
+		time_t t = details.mtime;
 		localtime_r((time_t*)&t, &return_time);
 		return true;
 	} else {

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -45,6 +45,15 @@ struct FSTEntry
 	std::vector<FSTEntry> children;
 };
 
+struct FileDetails {
+	bool isDirectory;
+	u64 size;
+	uint64_t st_atime;
+	uint64_t st_mtime;
+	uint64_t st_ctime;
+	uint32_t access;  // st_mode & 0x1ff
+};
+
 // Mostly to handle utf-8 filenames better on Windows.
 FILE *OpenCFile(const std::string &filename, const char *mode);
 bool OpenCPPFile(std::fstream & stream, const std::string &filename, std::ios::openmode mode);
@@ -54,6 +63,9 @@ bool Exists(const std::string &filename);
 
 // Returns true if filename is a directory
 bool IsDirectory(const std::string &filename);
+
+// Returns file attributes.
+bool GetFileDetails(const std::string &filename, FileDetails *details);
 
 // Returns struct with modification date of file
 bool GetModifTime(const std::string &filename, tm &return_time);

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -48,9 +48,9 @@ struct FSTEntry
 struct FileDetails {
 	bool isDirectory;
 	u64 size;
-	uint64_t st_atime;
-	uint64_t st_mtime;
-	uint64_t st_ctime;
+	uint64_t atime;
+	uint64_t mtime;
+	uint64_t ctime;
 	uint32_t access;  // st_mode & 0x1ff
 };
 

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -59,13 +59,10 @@ bool IsDirectory(const std::string &filename);
 bool GetModifTime(const std::string &filename, tm &return_time);
 
 // Returns the size of filename (64bit)
-u64 GetSize(const std::string &filename);
-
-// Overloaded GetSize, accepts file descriptor
-u64 GetSize(const int fd);
+u64 GetFileSize(const std::string &filename);
 
 // Overloaded GetSize, accepts FILE*
-u64 GetSize(FILE *f);
+u64 GetFileSize(FILE *f);
 
 // Returns true if successful, or path already exists.
 bool CreateDir(const std::string &filename);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -687,9 +687,9 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 		} else {
 			x.size = details.size;
 			x.access = details.access;
-			time_t atime = details.st_atime;
-			time_t ctime = details.st_ctime;
-			time_t mtime = details.st_mtime;
+			time_t atime = details.atime;
+			time_t ctime = details.ctime;
+			time_t mtime = details.mtime;
 
 			localtime_r((time_t*)&atime, &x.atime);
 			localtime_r((time_t*)&ctime, &x.ctime);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -676,22 +676,25 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 	x.exists = true;
 
 	if (x.type != FILETYPE_DIRECTORY) {
-#ifdef _WIN32
-		struct _stat64i32 s;
-		// TODO: Find a Win32 way to get the atime, ctime etc.
-		if (_wstat64i32(ConvertUTF8ToWString(fullName).c_str(), &s) != 0) {
-			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: _wstat64i32 failed: %s", fullName.c_str());
-		}
-#else
-		struct stat s;
-		stat(fullName.c_str(), &s);
-#endif
+		File::FileDetails details;
+		if (!File::GetFileDetails(fullName, &details)) {
+			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: GetFileDetails failed: %s", fullName.c_str());
+			x.size = 0;
+			x.access = 0;
+			memset(&x.atime, 0, sizeof(x.atime));
+			memset(&x.ctime, 0, sizeof(x.ctime));
+			memset(&x.mtime, 0, sizeof(x.mtime));
+		} else {
+			x.size = details.size;
+			x.access = details.access;
+			time_t atime = details.st_atime;
+			time_t ctime = details.st_ctime;
+			time_t mtime = details.st_mtime;
 
-		x.size = File::GetFileSize(fullName);
-		x.access = s.st_mode & 0x1FF;
-		localtime_r((time_t*)&s.st_atime, &x.atime);
-		localtime_r((time_t*)&s.st_ctime, &x.ctime);
-		localtime_r((time_t*)&s.st_mtime, &x.mtime);
+			localtime_r((time_t*)&atime, &x.atime);
+			localtime_r((time_t*)&ctime, &x.ctime);
+			localtime_r((time_t*)&mtime, &x.mtime);
+		}
 	}
 
 	return x;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -606,9 +606,9 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		} else {
 			x.size = details.size;
 			x.access = details.access;
-			time_t atime = details.st_atime;
-			time_t ctime = details.st_ctime;
-			time_t mtime = details.st_mtime;
+			time_t atime = details.atime;
+			time_t ctime = details.ctime;
+			time_t mtime = details.mtime;
 
 			localtime_r((time_t*)&atime, &x.atime);
 			localtime_r((time_t*)&ctime, &x.ctime);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -593,16 +593,16 @@ void InitSysDirectories() {
 			g_Config.memStickDirectory = myDocsPath;
 	}
 
-	const std::string testFile = "/_writable_test.$$$";
+	const std::string testFile = g_Config.memStickDirectory + "/_writable_test.$$$";
 
 	// If any directory is read-only, fall back to the Documents directory.
 	// We're screwed anyway if we can't write to Documents, or can't detect it.
-	if (!File::CreateEmptyFile(g_Config.memStickDirectory + testFile))
+	if (!File::CreateEmptyFile(testFile))
 		g_Config.memStickDirectory = myDocsPath;
 
 	// Clean up our mess.
-	if (File::Exists(g_Config.memStickDirectory + testFile))
-		File::Delete(g_Config.memStickDirectory + testFile);
+	if (File::Exists(testFile))
+		File::Delete(testFile);
 
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -591,6 +591,7 @@ void InitSysDirectories() {
 	if (!File::Exists(g_Config.memStickDirectory)) {
 		if (!File::CreateDir(g_Config.memStickDirectory))
 			g_Config.memStickDirectory = myDocsPath;
+		INFO_LOG(COMMON, "Memstick directory not present, creating at '%s'", g_Config.memStickDirectory.c_str());
 	}
 
 	const std::string testFile = g_Config.memStickDirectory + "/_writable_test.$$$";

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -110,10 +110,10 @@ void GameManager::Update() {
 			InstallGame(zipName);
 			// Doesn't matter if the install succeeds or not, we delete the temp file to not squander space.
 			// TODO: Handle disk full?
-			deleteFile(zipName.c_str());
+			File::Delete(zipName.c_str());
 		} else {
 			ERROR_LOG(HLE, "Expected HTTP status code 200, got status code %i. Install cancelled.", curDownload_->ResultCode());
-			deleteFile(zipName.c_str());
+			File::Delete(zipName.c_str());
 		}
 		curDownload_.reset();
 	}
@@ -251,7 +251,7 @@ bool GameManager::InstallGame(std::string zipfile, bool deleteAfter) {
 						buffer = 0;
 						fclose(f);
 						zip_fclose(zf);
-						deleteFile(outFilename.c_str());
+						File::Delete(outFilename.c_str());
 						// Yes it's a goto. Sue me. I think it's appropriate here.
 						goto bail;
 					}
@@ -278,7 +278,7 @@ bool GameManager::InstallGame(std::string zipfile, bool deleteAfter) {
 	installInProgress_ = false;
 	installError_ = "";
 	if (deleteAfter) {
-		deleteFile(zipfile.c_str());
+		File::Delete(zipfile.c_str());
 	}
 	InstallDone();
 	return true;
@@ -290,13 +290,13 @@ bail:
 	installInProgress_ = false;
 	installError_ = sy->T("Storage full");
 	if (deleteAfter) {
-		deleteFile(zipfile.c_str());
+		File::Delete(zipfile.c_str());
 	}
 	for (size_t i = 0; i < createdFiles.size(); i++) {
-		deleteFile(createdFiles[i].c_str());
+		File::Delete(createdFiles[i].c_str());
 	}
 	for (auto iter = createdDirs.begin(); iter != createdDirs.end(); ++iter) {
-		deleteDir(iter->c_str());
+		File::DeleteDir(iter->c_str());
 	}
 	InstallDone();
 	return false;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -55,7 +55,7 @@ bool GameInfo::Delete() {
 		{
 			// Just delete the one file (TODO: handle two-disk games as well somehow).
 			const char *fileToRemove = filePath_.c_str();
-			deleteFile(fileToRemove);
+			File::Delete(fileToRemove);
 			auto i = std::find(g_Config.recentIsos.begin(), g_Config.recentIsos.end(), fileToRemove);
 			if (i != g_Config.recentIsos.end()) {
 				g_Config.recentIsos.erase(i);
@@ -84,7 +84,7 @@ bool GameInfo::Delete() {
 	case FILETYPE_ARCHIVE_7Z:
 		{
 			const char *fileToRemove = filePath_.c_str();
-			deleteFile(fileToRemove);
+			File::Delete(fileToRemove);
 			return true;
 		}
 
@@ -227,10 +227,10 @@ bool GameInfo::DeleteAllSaveData() {
 
 		u64 totalSize = 0;
 		for (size_t i = 0; i < fileInfo.size(); i++) {
-			deleteFile(fileInfo[i].fullName.c_str());
+			File::Delete(fileInfo[i].fullName.c_str());
 		}
 
-		deleteDir(saveDataDir[j].c_str());
+		File::DeleteDir(saveDataDir[j].c_str());
 	}
 	return true;
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -339,9 +339,9 @@ void NativeInit(int argc, const char *argv[],
 	// On Android, create a PSP directory tree in the external_directory,
 	// to hopefully reduce confusion a bit.
 	ILOG("Creating %s", (g_Config.memStickDirectory + "PSP").c_str());
-	mkDir((g_Config.memStickDirectory + "PSP").c_str());
-	mkDir((g_Config.memStickDirectory + "PSP/SAVEDATA").c_str());
-	mkDir((g_Config.memStickDirectory + "PSP/GAME").c_str());
+	File::CreateDir((g_Config.memStickDirectory + "PSP").c_str());
+	File::CreateDir((g_Config.memStickDirectory + "PSP/SAVEDATA").c_str());
+	File::CreateDir((g_Config.memStickDirectory + "PSP/GAME").c_str());
 #endif
 
 	const char *fileToLog = 0;

--- a/ext/native/ext/libzip/zip_open.c
+++ b/ext/native/ext/libzip/zip_open.c
@@ -432,7 +432,7 @@ _zip_headercomp(struct zip_dirent *h1, int local1p, struct zip_dirent *h2,
 
 
 static struct zip *
-#ifdef _UNICODE
+#ifdef UNICODE
 _zip_allocate_new(const wchar_t *fn, int *zep)
 #else
 _zip_allocate_new(const char *fn, int *zep)

--- a/ext/native/ext/libzip/zipint.h
+++ b/ext/native/ext/libzip/zipint.h
@@ -36,6 +36,11 @@
 
 #include <zlib.h>
 
+// Symbian is nuts
+#if !defined(_WIN32) && defined(UNICODE)
+#undef UNICODE
+#endif
+
 #ifdef _MSC_VER
 #define ZIP_EXTERN
 #define fseeko fseek

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -144,12 +144,6 @@ bool readDataFromFile(bool text_file, unsigned char* &data, const unsigned int s
 	return true;
 }
 
-
-#define DIR_SEP "/"
-#define DIR_SEP_CHR '\\'
-
-#ifndef METRO
-
 // Returns true if filename is a directory
 bool isDirectory(const std::string &filename) {
 	FileInfo info;
@@ -177,7 +171,6 @@ bool getFileInfo(const char *path, FileInfo *fileInfo) {
 	struct stat64 file_info;
 
 	std::string copy(path);
-	stripTailDirSlashes(copy);
 
 	int result = stat64(copy.c_str(), &file_info);
 
@@ -315,8 +308,6 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 		std::sort(files->begin(), files->end());
 	return foundEntries;
 }
-
-#endif
 
 std::string getDir(const std::string &path)
 {

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -150,36 +150,6 @@ bool readDataFromFile(bool text_file, unsigned char* &data, const unsigned int s
 
 #ifndef METRO
 
-// Remove any ending forward slashes from directory paths
-// Modifies argument.
-static void stripTailDirSlashes(std::string &fname)
-{
-	if (fname.length() > 1)
-	{
-		size_t i = fname.length() - 1;
-		while (fname[i] == DIR_SEP_CHR)
-			fname[i--] = '\0';
-	}
-	return;
-}
-
-// Returns true if file filename exists
-bool exists(const std::string &filename) {
-#ifdef _WIN32
-	std::wstring wstr = ConvertUTF8ToWString(filename);
-	return GetFileAttributes(wstr.c_str()) != 0xFFFFFFFF;
-#else
-	struct stat64 file_info;
-
-	std::string copy(filename);
-	stripTailDirSlashes(copy);
-
-	int result = stat64(copy.c_str(), &file_info);
-
-	return (result == 0);
-#endif
-}
-
 // Returns true if filename is a directory
 bool isDirectory(const std::string &filename) {
 	FileInfo info;
@@ -346,31 +316,6 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 	return foundEntries;
 }
 
-void deleteFile(const char *file)
-{
-#ifdef _WIN32
-	if (!DeleteFile(ConvertUTF8ToWString(file).c_str())) {
-		ELOG("Error deleting %s: %i", file, GetLastError());
-	}
-#else
-	int err = unlink(file);
-	if (err) {
-		ELOG("Error unlinking %s: %i", file, err);
-	}
-#endif
-}
-
-void deleteDir(const char *dir)
-{
-#ifdef _WIN32
-	if (!RemoveDirectory(ConvertUTF8ToWString(dir).c_str())) {
-		ELOG("Error deleting directory %s: %i", dir, GetLastError());
-	}
-#else
-	rmdir(dir);
-#endif
-}
-
 #endif
 
 std::string getDir(const std::string &path)
@@ -399,15 +344,6 @@ std::string getFilename(std::string path) {
 		return path.substr(off);
 	else
 		return path;
-}
-
-void mkDir(const std::string &path)
-{
-#ifdef _WIN32
-	mkdir(path.c_str());
-#else
-	mkdir(path.c_str(), 0777);
-#endif
 }
 
 #ifdef _WIN32

--- a/ext/native/file/file_util.h
+++ b/ext/native/file/file_util.h
@@ -37,10 +37,6 @@ enum {
 	GETFILES_GETHIDDEN = 1
 };
 size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const char *filter = 0, int flags = 0);
-void deleteFile(const char *file);
-void deleteDir(const char *file);
-bool exists(const std::string &filename);
-void mkDir(const std::string &path);
 std::string getDir(const std::string &path);
 
 #ifdef _WIN32

--- a/ext/native/gfx_es2/glsl_program.cpp
+++ b/ext/native/gfx_es2/glsl_program.cpp
@@ -74,28 +74,6 @@ GLSLProgram *glsl_create_source(const char *vshader_src, const char *fshader_src
 	return program;
 }
 
-bool glsl_up_to_date(GLSLProgram *program) {
-	struct stat vs, fs;
-	stat(program->vshader_filename, &vs);
-	stat(program->fshader_filename, &fs);
-	if ((time_t)vs.st_mtime != program->vshader_mtime ||
-			(time_t)fs.st_mtime != program->fshader_mtime) {
-		return false;
-	} else {
-		return true;
-	}
-}
-
-void glsl_refresh() {
-	ILOG("glsl_refresh()");
-	for (std::set<GLSLProgram *>::const_iterator iter = active_programs.begin();
-		iter != active_programs.end(); ++iter) {
-			if (!glsl_up_to_date(*iter)) {
-				glsl_recompile(*iter);
-			}
-	}
-}
-
 // Not wanting to change ReadLocalFile semantics.
 // Needs to use delete [], not delete like auto_ptr, and can't use unique_ptr because of Symbian.
 struct AutoCharArrayBuf {

--- a/ext/native/gfx_es2/glsl_program.h
+++ b/ext/native/gfx_es2/glsl_program.h
@@ -61,8 +61,3 @@ void glsl_bind(const GLSLProgram *program);
 void glsl_unbind();
 int glsl_attrib_loc(const GLSLProgram *program, const char *name);
 int glsl_uniform_loc(const GLSLProgram *program, const char *name);
-
-// Expensive, try to only call this once per second or so and only when developing.
-// fstat-s all the source files of all the shaders to see if they
-// should be recompiled, and recompiles them if so.
-void glsl_refresh();


### PR DESCRIPTION
Might possibly help #7967 (XP) by avoiding _wstat64? That would be a libc bug though.
