### PR TITLE
Allow framebufs to get smaller and affect the offset texture code

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -330,6 +330,10 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 				needsRecreate = needsRecreate || vfb->newHeight > vfb->bufferHeight || vfb->newHeight * 2 < vfb->bufferHeight;
 				if (needsRecreate) {
 					ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);
+				} else {
+					// Even though we won't resize it, let's at least change the size params.
+					vfb->width = drawing_width;
+					vfb->height = drawing_height;
 				}
 			}
 		} else {

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -450,8 +450,8 @@ void SoftwareTransform(
 			// Okay, so we're texturing from outside the framebuffer, but inside the texture height.
 			// Breath of Fire 3 does this to access a render surface at an offset.
 			const u32 bpp = fbman->GetTargetFormat() == GE_FORMAT_8888 ? 4 : 2;
-			const u32 fb_size = bpp * fbman->GetTargetStride() * gstate_c.curTextureHeight;
-			const u32 prevH = gstate_c.curTextureHeight;
+			const u32 prevH = texCache->AttachedDrawingHeight();
+			const u32 fb_size = bpp * fbman->GetTargetStride() * prevH;
 			const u32 prevYOffset = gstate_c.curTextureYOffset;
 			if (texCache->SetOffsetTexture(fb_size)) {
 				const float oldWidthFactor = widthFactor;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Core/Config.h"
+#include "GPU/Common/FramebufferCommon.h"
 #include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/TextureCacheCommon.h"
 #include "GPU/GPUState.h"
@@ -27,6 +28,18 @@ TextureCacheCommon::~TextureCacheCommon() {}
 
 bool TextureCacheCommon::SetOffsetTexture(u32 offset) {
 	return false;
+}
+
+int TextureCacheCommon::AttachedDrawingHeight() {
+	if (nextTexture_) {
+		if (nextTexture_->framebuffer) {
+			return nextTexture_->framebuffer->height;
+		}
+		u16 dim = nextTexture_->dim;
+		const u8 dimY = dim >> 8;
+		return 1 << dimY;
+	}
+	return 0;
 }
 
 void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel) {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -34,6 +34,8 @@ public:
 
 	virtual bool SetOffsetTexture(u32 offset);
 
+	int AttachedDrawingHeight();
+
 	// Wow this is starting to grow big. Soon need to start looking at resizing it.
 	// Must stay a POD.
 	struct TexCacheEntry {
@@ -113,6 +115,8 @@ public:
 
 protected:
 	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel);
+
+	TexCacheEntry *nextTexture_;
 };
 
 inline bool TextureCacheCommon::TexCacheEntry::Matches(u16 dim2, u8 format2, u8 maxLevel2) {

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -151,8 +151,6 @@ private:
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
 
-	TexCacheEntry *nextTexture_;
-
 	LPDIRECT3DTEXTURE9 lastBoundTexture;
 	float maxAnisotropyLevel;
 

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -153,8 +153,6 @@ private:
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
 
-	TexCacheEntry *nextTexture_;
-
 	u32 lastBoundTexture;
 	float maxAnisotropyLevel;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -685,8 +685,8 @@ namespace MainWindow
 			}
 			break;
 
-    case WM_ERASEBKGND:
-      // This window is always covered by DisplayWindow. No reason to erase.
+		case WM_ERASEBKGND:
+			// This window is always covered by DisplayWindow. No reason to erase.
 			return 1;
 
 		case WM_MOVE:


### PR DESCRIPTION
Does this help / fix #7974?  Hopefully it doesn't break other things, it makes sense...

-[Unknown]
