### PR TITLE
More rounding fixes

### DIFF
--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -130,9 +130,10 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 		FixupBranch skip1 = B(CC_EQ);
 		ADDI2R(SCRATCH2, SCRATCH2, 4);
 		SetJumpTarget(skip1);
-		// We can only skip if the rounding mode is zero and flush is set.
-		CMPI2R(SCRATCH2, 4);
-		// At this point, if it was zero, we can skip the rest.
+
+		// We can skip if the rounding mode is nearest (0) and flush is not set.
+		// (as restoreRoundingMode cleared it out anyway)
+		CMPI2R(SCRATCH2, 0);
 		FixupBranch skip = B(CC_EQ);
 
 		// MIPS Rounding Mode:       ARM Rounding Mode
@@ -154,7 +155,6 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 		// Clear both flush-to-zero and rounding before re-setting them.
 		ANDI2R(SCRATCH1, SCRATCH1, ~((4 | 3) << 22));
-
 		ORR(SCRATCH1, SCRATCH1, SCRATCH2, ArithOption(SCRATCH2, ST_LSL, 22));
 		_MSR(FIELD_FPCR, SCRATCH1_64);
 
@@ -181,8 +181,7 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 		// We can only skip if the rounding mode is zero and flush is not set.
 		// TODO: This actually seems to compare against 3??
-		CMPI2R(SCRATCH2, 3);
-
+		CMPI2R(SCRATCH2, 0);
 		FixupBranch skip2 = B(CC_EQ);
 		MOVI2R(SCRATCH2, 1);
 		MOVP2R(SCRATCH1_64, &js.hasSetRounding);

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -316,8 +316,6 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Don't forget to zap the instruction cache! This must stay at the end of this function.
 	FlushIcache();
-
-	js.currentRoundingFunc = convertS0ToSCRATCH1[0];
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -158,6 +158,10 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 		ORR(SCRATCH1, SCRATCH1, SCRATCH2, ArithOption(SCRATCH2, ST_LSL, 22));
 		_MSR(FIELD_FPCR, SCRATCH1_64);
 
+		SetJumpTarget(skip);
+
+		// !! Can't skip this part at all, unless we restore it in restoreRoundingMode (which would not really be cheaper)
+
 		// Let's update js.currentRoundingFunc with the right convertS0ToSCRATCH1 func.
 		MOVP2R(SCRATCH1_64, convertS0ToSCRATCH1);
 		// We already index this array including the FZ bit.  Easy.
@@ -165,8 +169,6 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 		LDR(SCRATCH2_64, SCRATCH1_64, SCRATCH2);
 		MOVP2R(SCRATCH1_64, &js.currentRoundingFunc);
 		STR(INDEX_UNSIGNED, SCRATCH2_64, SCRATCH1_64, 0);
-
-		SetJumpTarget(skip);
 		RET();
 	}
 
@@ -314,6 +316,8 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Don't forget to zap the instruction cache! This must stay at the end of this function.
 	FlushIcache();
+
+	js.currentRoundingFunc = convertS0ToSCRATCH1[0];
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -89,6 +89,10 @@ void Arm64Jit::DoState(PointerWrap &p) {
 	} else {
 		js.hasSetRounding = 1;
 	}
+
+	if (p.GetMode() == PointerWrap::MODE_READ) {
+		js.currentRoundingFunc = convertS0ToSCRATCH1[(mips_->fcr31) & 3];
+	}
 }
 
 // This is here so the savestate matches between jit and non-jit.

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -70,8 +70,8 @@ Arm64Jit::Arm64Jit(MIPSState *mips) : blocks(mips, this), gpr(mips, &js, &jo), f
 	fpr.SetEmitter(this, &fp);
 	AllocCodeSpace(1024 * 1024 * 16);  // 32MB is the absolute max because that's what an ARM branch instruction can reach, backwards and forwards.
 	GenerateFixedCode(jo);
-
 	js.startDefaultPrefix = mips_->HasDefaultPrefix();
+	js.currentRoundingFunc = convertS0ToSCRATCH1[0];
 }
 
 Arm64Jit::~Arm64Jit() {

--- a/Core/MIPS/JitCommon/JitCommon.cpp
+++ b/Core/MIPS/JitCommon/JitCommon.cpp
@@ -168,11 +168,15 @@ const char *ppsspp_resolver(struct ud*,
 	}
 
 	// But these do.
-	if (MIPSComp::jit->IsInSpace((u8 *)(intptr_t)addr)) {
-		*offset = addr - (uint64_t)MIPSComp::jit->GetBasePtr();
-		return "jitcode";
-	}
 
+	// UGLY HACK because the API is terrible
+	static char buf[128];
+	std::string str;
+	if (MIPSComp::jit->DescribeCodePtr((u8 *)(uintptr_t)addr, str)) {
+		*offset = 0;
+		truncate_cpy(buf, sizeof(buf), str.c_str());
+		return buf;
+	}
 	return NULL;
 }
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -126,6 +126,7 @@ Jit::Jit(MIPSState *mips)
 	fpr.SetEmitter(this);
 	AllocCodeSpace(1024 * 1024 * 16);
 	GenerateFixedCode(jo);
+
 	safeMemFuncs.Init(&thunks);
 
 	js.startDefaultPrefix = mips_->HasDefaultPrefix();


### PR DESCRIPTION
Turns out I wasn't done.

Compared the various rounding setup implementations for the JIT backends and found some differences.

They should now all work exactly the same. The cpu/fpu/fpu test pass for all.

@unknownbrackets , feel like looking through this?

If no more unexpected issues are found, I will release 1.1.1 tomorrow.
