### PR TITLE
Fix for a struct padding error affecting Android-x86 savestates

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <type_traits>
+
 #include "base/mutex.h"
 #include "base/timeutil.h"
 #include "Common/ColorConv.h"
@@ -22,6 +24,12 @@ GPUCommon::GPUCommon() :
 	dumpNextFrame_(false),
 	dumpThisFrame_(false)
 {
+	DisplayList x;
+
+	// This assert failed on GCC x86 32-bit (but not MSVC 32-bit!) before adding the 
+	// "padding" field at the end. This is important for save state compatibility.
+	static_assert(sizeof(DisplayList) == 456, "Bad DisplayList size");
+
 	Reinitialize();
 	SetupColorConv();
 	SetThreadEnabled(g_Config.bSeparateCPUThread);
@@ -1061,16 +1069,54 @@ struct DisplayList_v2 {
 	bool bboxResult;
 };
 
+struct DisplayList_v3_no_padding {
+	int id;
+	u32 startpc;
+	u32 pc;
+	u32 stall;
+	DisplayListState state;
+	SignalBehavior signal;
+	int subIntrBase;
+	u16 subIntrToken;
+	DisplayListStackEntry stack[32];
+	int stackptr;
+	bool interrupted;
+	u64 waitTicks;
+	bool interruptsEnabled;
+	bool pendingInterrupt;
+	bool started;
+	PSPPointer<u32_le> context;
+	u32 offsetAddr;
+	bool bboxResult;
+	u32 stackAddr;
+	// See the header
+};
+
 void GPUCommon::DoState(PointerWrap &p) {
 	easy_guard guard(listLock);
 
-	auto s = p.Section("GPUCommon", 1, 3);
+	auto s = p.Section("GPUCommon", 1, 4);
 	if (!s)
 		return;
 
 	p.Do<int>(dlQueue);
-	if (s >= 3) {
+	if (s >= 4) {
 		p.DoArray(dls, ARRAY_SIZE(dls));
+	} else if (s >= 3) {
+#if defined(ANDROID) && defined(_M_IX86)
+		// If this starts failing, we'll need to put some alignment attributes on the Displaylist_v3_no_padding struct above.
+		static_assert(sizeof(DisplayList_v3_no_padding) == 452, "Not the old DisplayList size anymore, see comment");
+		for (size_t i = 0; i < ARRAY_SIZE(dls); ++i) {
+			DisplayList_v3_no_padding oldDL;
+			p.Do(oldDL);
+			// Copy over everything except the last, new member (stackAddr.)
+			memcpy(&dls[i], &oldDL, sizeof(DisplayList_v3_no_padding));
+			dls[i].padding = 0;
+		}
+#else
+		// Android-x86 used to write badly padded data structures.
+		p.DoArray(dls, ARRAY_SIZE(dls));
+#endif
 	} else if (s >= 2) {
 		for (size_t i = 0; i < ARRAY_SIZE(dls); ++i) {
 			DisplayList_v2 oldDL;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -140,6 +140,8 @@ struct DisplayList {
 	u32 offsetAddr;
 	bool bboxResult;
 	u32 stackAddr;
+
+	u32 padding;  // Android x86-32 does not round the structure size up to the closest multiple of 8 like the other platforms.
 };
 
 enum GPUInvalidationType {


### PR DESCRIPTION
This was making it produce savestates that were not compatible with the other platforms.
