### PR TITLE
OpenGL: Generate shader code directly from the shader IDs without looking at gstate

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -422,7 +422,7 @@ void ComputeFragmentShaderID(ShaderID *id_out, uint32_t vertType) {
 }
 
 // Missing: Z depth range
-void GenerateFragmentShader(const ShaderID &id, char *buffer) {
+bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	char *p = buffer;
 
 	// In GLSL ES 3.0, you use "in" variables instead of varying.
@@ -1017,8 +1017,8 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 		break;
 
 	default:
-		WRITE(p, "ERROR STA");
-		break;
+		ERROR_LOG(G3D, "Bad stencil-to-alpha type, corrupt ID?");
+		return false;
 	}
 
 	LogicOpReplaceType replaceLogicOpType = (LogicOpReplaceType)id.Bits(BIT_REPLACE_LOGIC_OP_TYPE, 2);
@@ -1033,8 +1033,8 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 		break;
 
 	default:
-		WRITE(p, "ERROR LTA");
-		break;
+		ERROR_LOG(G3D, "Bad logic op type, corrupt ID?");
+		return false;
 	}
 
 #ifdef DEBUG_SHADER
@@ -1046,5 +1046,7 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	}
 #endif
 	WRITE(p, "}\n");
+
+	return true;
 }
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -535,7 +535,7 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	bool textureAtOffset = id.Bit(BIT_TEXTURE_AT_OFFSET);
 
 	ReplaceBlendType replaceBlend = static_cast<ReplaceBlendType>(id.Bits(BIT_REPLACE_BLEND, 3));
-	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(BIT_STENCIL_TO_ALPHA, 4));
+	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(BIT_STENCIL_TO_ALPHA, 2));
 
 	GEBlendSrcFactor replaceBlendFuncA = (GEBlendSrcFactor)id.Bits(BIT_BLENDFUNC_A, 4);
 	GEBlendDstFactor replaceBlendFuncB = (GEBlendDstFactor)id.Bits(BIT_BLENDFUNC_B, 4);
@@ -1015,6 +1015,10 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	case REPLACE_ALPHA_NO:
 		WRITE(p, "  %s = v;\n", fragColor0);
 		break;
+
+	default:
+		WRITE(p, "ERROR STA");
+		break;
 	}
 
 	LogicOpReplaceType replaceLogicOpType = (LogicOpReplaceType)id.Bits(BIT_REPLACE_LOGIC_OP_TYPE, 2);
@@ -1026,6 +1030,10 @@ void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 		WRITE(p, "  %s.rgb = vec3(1.0, 1.0, 1.0) - %s.rgb;\n", fragColor0, fragColor0);
 		break;
 	case LOGICOPTYPE_NORMAL:
+		break;
+
+	default:
+		WRITE(p, "ERROR LTA");
 		break;
 	}
 

--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -16,9 +16,8 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #if !defined(USING_GLES2)
-// We do not yet enable OpenGL 3 on Apple, so we need
-// special treatment in the shader generator. However, the GL version check
-// should be enough? TODO
+// SDL 1.2 on Apple does not have support for OpenGL 3 and hence needs
+// special treatment in the shader generator.
 #if defined(__APPLE__)
 #define FORCE_OPENGL_2_0
 #endif
@@ -300,14 +299,44 @@ static inline LogicOpReplaceType ReplaceLogicOpType() {
 	return LOGICOPTYPE_NORMAL;
 }
 
+// Local
+enum {
+	BIT_CLEARMODE = 0,
+	BIT_DO_TEXTURE = 1,
+	BIT_TEXFUNC = 2,  // 3 bits
+	BIT_TEXALPHA = 5,
+	BIT_FLIP_TEXTURE = 6,
+	BIT_SHADER_TEX_CLAMP = 7,
+	BIT_CLAMP_S = 8,
+	BIT_CLAMP_T = 9,
+	BIT_TEXTURE_AT_OFFSET = 10,
+	BIT_LMODE = 11,
+	BIT_ALPHA_TEST = 12,
+	BIT_ALPHA_TEST_FUNC = 13,  // 3 bits
+	BIT_ALPHA_AGAINST_ZERO = 16,
+	BIT_COLOR_TEST = 17,
+	BIT_COLOR_TEST_FUNC = 18,  // 2 bits
+	BIT_COLOR_AGAINST_ZERO = 20,
+	BIT_ENABLE_FOG = 21,
+	BIT_DO_TEXTURE_PROJ = 22,
+	BIT_COLOR_DOUBLE = 23,
+	BIT_STENCIL_TO_ALPHA = 24,  // 2 bits
+	BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE = 26,  // 4 bits
+	BIT_REPLACE_LOGIC_OP_TYPE = 30,  // 2 bits
+	BIT_REPLACE_BLEND = 32,  // 3 bits
+	BIT_BLENDEQ = 35,  // 3 bits
+	BIT_BLENDFUNC_A = 38,  // 4 bits
+	BIT_BLENDFUNC_B = 42,
+	BIT_FLATSHADE = 46,
+};
+
 // Here we must take all the bits of the gstate that determine what the fragment shader will
 // look like, and concatenate them together into an ID.
-void ComputeFragmentShaderID(ShaderID *id) {
-	int id0 = 0;
-	int id1 = 0;
+void ComputeFragmentShaderID(ShaderID *id_out, uint32_t vertType) {
+	ShaderID id;
 	if (gstate.isModeClear()) {
 		// We only need one clear shader, so let's ignore the rest of the bits.
-		id0 = 1;
+		id.SetBit(BIT_CLEARMODE);
 	} else {
 		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
 		bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough();
@@ -317,6 +346,7 @@ void ComputeFragmentShaderID(ShaderID *id) {
 		bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;
+
 		ReplaceBlendType replaceBlend = ReplaceBlendWithShader(gstate_c.allowShaderBlend);
 		ReplaceAlphaType stencilToAlpha = ReplaceAlphaWithStencil(replaceBlend);
 
@@ -326,45 +356,47 @@ void ComputeFragmentShaderID(ShaderID *id) {
 
 		// id0 |= (gstate.isModeClear() & 1);
 		if (gstate.isTextureMapEnabled()) {
-			id0 |= 1 << 1;
-			id0 |= gstate.getTextureFunction() << 2;
-			id0 |= (doTextureAlpha & 1) << 5; // rgb or rgba
-			id0 |= (gstate_c.flipTexture & 1) << 6;
-
+			id.SetBit(BIT_DO_TEXTURE);
+			id.SetBits(BIT_TEXFUNC, 3, gstate.getTextureFunction());
+			id.SetBit(BIT_TEXALPHA, doTextureAlpha & 1); // rgb or rgba
+			id.SetBit(BIT_FLIP_TEXTURE, gstate_c.flipTexture);
+			// TODO
 			if (gstate_c.needShaderTexClamp) {
 				bool textureAtOffset = gstate_c.curTextureXOffset != 0 || gstate_c.curTextureYOffset != 0;
-				// 3 bits total.
-				id0 |= 1 << 7;
-				id0 |= gstate.isTexCoordClampedS() << 8;
-				id0 |= gstate.isTexCoordClampedT() << 9;
-				id0 |= (textureAtOffset & 1) << 10;
+				// 4 bits total.
+				id.SetBit(BIT_SHADER_TEX_CLAMP);
+				id.SetBit(BIT_CLAMP_S, gstate.isTexCoordClampedS());
+				id.SetBit(BIT_CLAMP_T, gstate.isTexCoordClampedT());
+				id.SetBit(BIT_TEXTURE_AT_OFFSET, textureAtOffset);
 			}
 		}
 
-		id0 |= (lmode & 1) << 11;
+		id.SetBit(BIT_LMODE, lmode);
 #if !defined(DX9_USE_HW_ALPHA_TEST)
 		if (enableAlphaTest) {
 			// 5 bits total.
-			id0 |= 1 << 12;
-			id0 |= gstate.getAlphaTestFunction() << 13;
-			id0 |= (IsAlphaTestAgainstZero() & 1) << 16;
+			id.SetBit(BIT_ALPHA_TEST);
+			id.SetBits(BIT_ALPHA_TEST_FUNC, 3, gstate.getAlphaTestFunction());
+			id.SetBit(BIT_ALPHA_AGAINST_ZERO, IsAlphaTestAgainstZero());
 		}
 #endif
 		if (enableColorTest) {
 			// 4 bits total.
-			id0 |= 1 << 17;
-			id0 |= gstate.getColorTestFunction() << 18;
-			id0 |= (IsColorTestAgainstZero() & 1) << 20;
+			id.SetBit(BIT_COLOR_TEST);
+			id.SetBits(BIT_COLOR_TEST_FUNC, 2, gstate.getColorTestFunction());
+			id.SetBit(BIT_COLOR_AGAINST_ZERO, IsColorTestAgainstZero());
 		}
-		id0 |= (enableFog & 1) << 21;
-		id0 |= (doTextureProjection & 1) << 22;
-		id0 |= (enableColorDoubling & 1) << 23;
+
+		id.SetBit(BIT_ENABLE_FOG, enableFog);
+		id.SetBit(BIT_DO_TEXTURE_PROJ, doTextureProjection);
+		id.SetBit(BIT_COLOR_DOUBLE, enableColorDoubling);
+
 		// 2 bits
-		id0 |= (stencilToAlpha) << 24;
+		id.SetBits(BIT_STENCIL_TO_ALPHA, 2, stencilToAlpha);
 
 		if (stencilToAlpha != REPLACE_ALPHA_NO) {
 			// 4 bits
-			id0 |= ReplaceAlphaWithStencilType() << 26;
+			id.SetBits(BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4, ReplaceAlphaWithStencilType());
 		}
 
 		if (enableAlphaTest)
@@ -373,25 +405,24 @@ void ComputeFragmentShaderID(ShaderID *id) {
 			gpuStats.numNonAlphaTestedDraws++;
 
 		// 2 bits.
-		id0 |= ReplaceLogicOpType() << 30;
+		id.SetBits(BIT_REPLACE_LOGIC_OP_TYPE, 2, ReplaceLogicOpType());
 
 		// 3 bits.
-		id1 |= replaceBlend << 0;
+		id.SetBits(BIT_REPLACE_BLEND, 3, replaceBlend);
 		if (replaceBlend > REPLACE_BLEND_STANDARD) {
 			// 11 bits total.
-			id1 |= gstate.getBlendEq() << 3;
-			id1 |= gstate.getBlendFuncA() << 6;
-			id1 |= gstate.getBlendFuncB() << 10;
+			id.SetBits(BIT_BLENDEQ, 3, gstate.getBlendEq());
+			id.SetBits(BIT_BLENDFUNC_A, 4, gstate.getBlendFuncA());
+			id.SetBits(BIT_BLENDFUNC_B, 4, gstate.getBlendFuncB());
 		}
-		id1 |= (doFlatShading & 1) << 14;
+		id.SetBit(BIT_FLATSHADE, doFlatShading);
 	}
 
-	id->d[0] = id0;
-	id->d[1] = id1;
+	*id_out = id;
 }
 
 // Missing: Z depth range
-void GenerateFragmentShader(char *buffer) {
+void GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	char *p = buffer;
 
 	// In GLSL ES 3.0, you use "in" variables instead of varying.
@@ -482,48 +513,61 @@ void GenerateFragmentShader(char *buffer) {
 		varying = "in";
 	}
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
-	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
-	bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough() && !gstate.isModeClear();
-	bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !gstate.isModeClear() && !g_Config.bDisableAlphaTest;
-	bool alphaTestAgainstZero = IsAlphaTestAgainstZero();
-	bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue() && !gstate.isModeClear();
-	bool colorTestAgainstZero = IsColorTestAgainstZero();
-	bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
-	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
-	bool doTextureAlpha = gstate.isTextureAlphaUsed();
-	bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT && !gstate.isModeClear();
+	bool lmode = id.Bit(BIT_LMODE);
+	bool doTexture = id.Bit(BIT_DO_TEXTURE);
+	bool enableFog = id.Bit(BIT_ENABLE_FOG);
+	bool enableAlphaTest = id.Bit(BIT_ALPHA_TEST);
 
-	bool textureAtOffset = gstate_c.curTextureXOffset != 0 || gstate_c.curTextureYOffset != 0;
-	ReplaceBlendType replaceBlend = ReplaceBlendWithShader(gstate_c.allowShaderBlend);
-	ReplaceAlphaType stencilToAlpha = ReplaceAlphaWithStencil(replaceBlend);
+	bool alphaTestAgainstZero = id.Bit(BIT_ALPHA_AGAINST_ZERO);
+	bool enableColorTest = id.Bit(BIT_COLOR_TEST);
+	bool colorTestAgainstZero = id.Bit(BIT_COLOR_AGAINST_ZERO);
+	bool enableColorDoubling = id.Bit(BIT_COLOR_DOUBLE);
+	bool doTextureProjection = id.Bit(BIT_DO_TEXTURE_PROJ);
+	bool doTextureAlpha = id.Bit(BIT_TEXALPHA);
+	bool doFlatShading = id.Bit(BIT_FLATSHADE);
+	bool flipTexture = id.Bit(BIT_FLIP_TEXTURE);
+
+	GEComparison alphaTestFunc = (GEComparison)id.Bits(BIT_ALPHA_TEST_FUNC, 3);
+	GEComparison colorTestFunc = (GEComparison)id.Bits(BIT_COLOR_TEST_FUNC, 2);
+	bool needShaderTexClamp = id.Bit(BIT_SHADER_TEX_CLAMP);
+
+	GETexFunc texFunc = (GETexFunc)id.Bits(BIT_TEXFUNC, 3);
+	bool textureAtOffset = id.Bit(BIT_TEXTURE_AT_OFFSET);
+
+	ReplaceBlendType replaceBlend = static_cast<ReplaceBlendType>(id.Bits(BIT_REPLACE_BLEND, 3));
+	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(BIT_STENCIL_TO_ALPHA, 4));
+
+	GEBlendSrcFactor replaceBlendFuncA = (GEBlendSrcFactor)id.Bits(BIT_BLENDFUNC_A, 4);
+	GEBlendDstFactor replaceBlendFuncB = (GEBlendDstFactor)id.Bits(BIT_BLENDFUNC_B, 4);
+	GEBlendMode replaceBlendEq = (GEBlendMode)id.Bits(BIT_BLENDEQ, 3);
+
+	bool isModeClear = id.Bit(BIT_CLEARMODE);
 
 	const char *shading = "";
 	if (glslES30)
 		shading = doFlatShading ? "flat" : "";
 
-	if (gstate_c.textureFullAlpha && gstate.getTextureFunction() != GE_TEXFUNC_REPLACE)
-		doTextureAlpha = false;
-
 	if (doTexture)
 		WRITE(p, "uniform sampler2D tex;\n");
-	if (!gstate.isModeClear() && replaceBlend > REPLACE_BLEND_STANDARD) {
-		if (!(gstate_c.featureFlags & GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH) && replaceBlend == REPLACE_BLEND_COPY_FBO) {
+
+	if (!isModeClear && replaceBlend > REPLACE_BLEND_STANDARD) {
+		if (!gstate_c.Supports(GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH) && replaceBlend == REPLACE_BLEND_COPY_FBO) {
 			if (!texelFetch) {
 				WRITE(p, "uniform vec2 u_fbotexSize;\n");
 			}
 			WRITE(p, "uniform sampler2D fbotex;\n");
 		}
-		if (gstate.getBlendFuncA() == GE_SRCBLEND_FIXA) {
+		if (replaceBlendFuncA == GE_SRCBLEND_FIXA) {
 			WRITE(p, "uniform vec3 u_blendFixA;\n");
 		}
-		if (gstate.getBlendFuncB() == GE_DSTBLEND_FIXB) {
+		if (replaceBlendFuncB == GE_DSTBLEND_FIXB) {
 			WRITE(p, "uniform vec3 u_blendFixB;\n");
 		}
 	}
-	if (gstate_c.needShaderTexClamp && doTexture) {
+
+	if (needShaderTexClamp && doTexture) {
 		WRITE(p, "uniform vec4 u_texclamp;\n");
-		if (textureAtOffset) {
+		if (id.Bit(BIT_TEXTURE_AT_OFFSET)) {
 			WRITE(p, "uniform vec2 u_texclampoff;\n");
 		}
 	}
@@ -538,10 +582,12 @@ void GenerateFragmentShader(char *buffer) {
 			}
 		}
 	}
-	if (stencilToAlpha && ReplaceAlphaWithStencilType() == STENCIL_VALUE_UNIFORM) {
+
+	StencilValueType replaceAlphaWithStencilType = (StencilValueType)id.Bits(BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4);
+	if (stencilToAlpha && replaceAlphaWithStencilType == STENCIL_VALUE_UNIFORM) {
 		WRITE(p, "uniform float u_stencilReplaceValue;\n");
 	}
-	if (gstate.isTextureMapEnabled() && gstate.getTextureFunction() == GE_TEXFUNC_BLEND)
+	if (doTexture && texFunc == GE_TEXFUNC_BLEND)
 		WRITE(p, "uniform vec3 u_texenv;\n");
 
 	WRITE(p, "%s %s vec4 v_color0;\n", shading, varying);
@@ -587,13 +633,13 @@ void GenerateFragmentShader(char *buffer) {
 	}
 
 	// PowerVR needs a custom modulo function. For some reason, this has far higher precision than the builtin one.
-	if ((gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_BAD) && gstate_c.needShaderTexClamp) {
+	if ((gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_BAD) && needShaderTexClamp) {
 		WRITE(p, "float mymod(float a, float b) { return a - b * floor(a / b); }\n");
 	}
 
 	WRITE(p, "void main() {\n");
 
-	if (gstate.isModeClear()) {
+	if (isModeClear) {
 		// Clear mode does not allow any fancy shading.
 		WRITE(p, "  vec4 v = v_color0;\n");
 	} else {
@@ -606,11 +652,11 @@ void GenerateFragmentShader(char *buffer) {
 			secondary = "";
 		}
 
-		if (gstate.isTextureMapEnabled()) {
+		if (doTexture) {
 			const char *texcoord = "v_texcoord";
 			// TODO: Not sure the right way to do this for projection.
 			// This path destroys resolution on older PowerVR no matter what I do, so we disable it on SGX 540 and lesser, and live with the consequences.
-			if (gstate_c.needShaderTexClamp && !(gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_TERRIBLE)) {
+			if (needShaderTexClamp && !(gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_TERRIBLE)) {
 				// We may be clamping inside a larger surface (tex = 64x64, buffer=480x272).
 				// We may also be wrapping in such a surface, or either one in a too-small surface.
 				// Obviously, clamping to a smaller surface won't work.  But better to clamp to something.
@@ -619,19 +665,19 @@ void GenerateFragmentShader(char *buffer) {
 				if (doTextureProjection) {
 					ucoord += " / v_texcoord.z";
 					vcoord = "(v_texcoord.y / v_texcoord.z)";
-					// Vertex texcoords are NOT flipped when projecting despite gstate_c.flipTexture.
-				} else if (gstate_c.flipTexture) {
+					// Vertex texcoords are NOT flipped when projecting despite flipTexture.
+				} else if (flipTexture) {
 					vcoord = "1.0 - " + vcoord;
 				}
 
 				std::string modulo = (gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_BAD) ? "mymod" : "mod";
 
-				if (gstate.isTexCoordClampedS()) {
+				if (id.Bit(BIT_CLAMP_S)) {
 					ucoord = "clamp(" + ucoord + ", u_texclamp.z, u_texclamp.x - u_texclamp.z)";
 				} else {
 					ucoord = modulo + "(" + ucoord + ", u_texclamp.x)";
 				}
-				if (gstate.isTexCoordClampedT()) {
+				if (id.Bit(BIT_CLAMP_T)) {
 					vcoord = "clamp(" + vcoord + ", u_texclamp.w, u_texclamp.y - u_texclamp.w)";
 				} else {
 					vcoord = modulo + "(" + vcoord + ", u_texclamp.y)";
@@ -641,7 +687,7 @@ void GenerateFragmentShader(char *buffer) {
 					vcoord = "(" + vcoord + " + u_texclampoff.y)";
 				}
 
-				if (gstate_c.flipTexture) {
+				if (flipTexture) {
 					vcoord = "1.0 - " + vcoord;
 				}
 
@@ -649,7 +695,7 @@ void GenerateFragmentShader(char *buffer) {
 				texcoord = "fixedcoord";
 				// We already projected it.
 				doTextureProjection = false;
-			} else if (doTextureProjection && gstate_c.flipTexture) {
+			} else if (doTextureProjection && flipTexture) {
 				// Since we need to flip v, we project manually.
 				WRITE(p, "  vec2 fixedcoord = vec2(v_texcoord.x / v_texcoord.z, 1.0 - (v_texcoord.y / v_texcoord.z));\n");
 				texcoord = "fixedcoord";
@@ -664,7 +710,7 @@ void GenerateFragmentShader(char *buffer) {
 			WRITE(p, "  vec4 p = v_color0;\n");
 
 			if (doTextureAlpha) { // texfmt == RGBA
-				switch (gstate.getTextureFunction()) {
+				switch (texFunc) {
 				case GE_TEXFUNC_MODULATE:
 					WRITE(p, "  vec4 v = p * t%s;\n", secondary); 
 					break;
@@ -691,7 +737,7 @@ void GenerateFragmentShader(char *buffer) {
 					WRITE(p, "  vec4 v = p;\n"); break;
 				}
 			} else { // texfmt == RGB
-				switch (gstate.getTextureFunction()) {
+				switch (texFunc) {
 				case GE_TEXFUNC_MODULATE:
 					WRITE(p, "  vec4 v = vec4(t.rgb * p.rgb, p.a)%s;\n", secondary); 
 					break;
@@ -738,7 +784,6 @@ void GenerateFragmentShader(char *buffer) {
 
 		if (enableAlphaTest) {
 			if (alphaTestAgainstZero) {
-				GEComparison alphaTestFunc = gstate.getAlphaTestFunction();
 				// When testing against 0 (extremely common), we can avoid some math.
 				// 0.002 is approximately half of 1.0 / 255.0.
 				if (alphaTestFunc == GE_COMP_NOTEQUAL || alphaTestFunc == GE_COMP_GREATER) {
@@ -755,7 +800,6 @@ void GenerateFragmentShader(char *buffer) {
 				WRITE(p, "  float aResult = %s(testtex, vec2(%s, 0)).a;\n", texture, alphaTestXCoord.c_str());
 				WRITE(p, "  if (aResult < 0.5) discard;\n");
 			} else {
-				GEComparison alphaTestFunc = gstate.getAlphaTestFunction();
 				const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };
 				if (alphaTestFuncs[alphaTestFunc][0] != '#') {
 					if (bitwiseOps) {
@@ -777,7 +821,6 @@ void GenerateFragmentShader(char *buffer) {
 
 		if (enableColorTest) {
 			if (colorTestAgainstZero) {
-				GEComparison colorTestFunc = gstate.getColorTestFunction();
 				// When testing against 0 (common), we can avoid some math.
 				// 0.002 is approximately half of 1.0 / 255.0.
 				if (colorTestFunc == GE_COMP_NOTEQUAL) {
@@ -794,7 +837,6 @@ void GenerateFragmentShader(char *buffer) {
 				WRITE(p, "  float rResult = %s(testtex, vec2(vScale256.r, 0)).r;\n", texture);
 				WRITE(p, "  float gResult = %s(testtex, vec2(vScale256.g, 0)).g;\n", texture);
 				WRITE(p, "  float bResult = %s(testtex, vec2(vScale256.b, 0)).b;\n", texture);
-				GEComparison colorTestFunc = gstate.getColorTestFunction();
 				if (colorTestFunc == GE_COMP_EQUAL) {
 					// Equal means all parts must be equal.
 					WRITE(p, "  if (rResult < 0.5 || gResult < 0.5 || bResult < 0.5) discard;\n");
@@ -803,7 +845,6 @@ void GenerateFragmentShader(char *buffer) {
 					WRITE(p, "  if (rResult < 0.5 && gResult < 0.5 && bResult < 0.5) discard;\n");
 				}
 			} else {
-				GEComparison colorTestFunc = gstate.getColorTestFunction();
 				const char *colorTestFuncs[] = { "#", "#", " != ", " == " };
 				if (colorTestFuncs[colorTestFunc][0] != '#') {
 					if (bitwiseOps) {
@@ -837,9 +878,8 @@ void GenerateFragmentShader(char *buffer) {
 		}
 
 		if (replaceBlend == REPLACE_BLEND_PRE_SRC || replaceBlend == REPLACE_BLEND_PRE_SRC_2X_ALPHA) {
-			GEBlendSrcFactor funcA = gstate.getBlendFuncA();
 			const char *srcFactor = "ERROR";
-			switch (funcA) {
+			switch (replaceBlendFuncA) {
 			case GE_SRCBLEND_DSTCOLOR:          srcFactor = "ERROR"; break;
 			case GE_SRCBLEND_INVDSTCOLOR:       srcFactor = "ERROR"; break;
 			case GE_SRCBLEND_SRCALPHA:          srcFactor = "vec3(v.a)"; break;
@@ -867,15 +907,10 @@ void GenerateFragmentShader(char *buffer) {
 				WRITE(p, "  lowp vec4 destColor = %s(fbotex, ivec2(gl_FragCoord.x, gl_FragCoord.y), 0);\n", texelFetch);
 			}
 
-			GEBlendSrcFactor funcA = gstate.getBlendFuncA();
-			GEBlendDstFactor funcB = gstate.getBlendFuncB();
-			GEBlendMode eq = gstate.getBlendEq();
-
 			const char *srcFactor = "vec3(1.0)";
 			const char *dstFactor = "vec3(0.0)";
 
-			switch (funcA)
-			{
+			switch (replaceBlendFuncA) {
 			case GE_SRCBLEND_DSTCOLOR:          srcFactor = "destColor.rgb"; break;
 			case GE_SRCBLEND_INVDSTCOLOR:       srcFactor = "(vec3(1.0) - destColor.rgb)"; break;
 			case GE_SRCBLEND_SRCALPHA:          srcFactor = "vec3(v.a)"; break;
@@ -888,8 +923,7 @@ void GenerateFragmentShader(char *buffer) {
 			case GE_SRCBLEND_DOUBLEINVDSTALPHA: srcFactor = "vec3(1.0 - destColor.a * 2.0)"; break;
 			case GE_SRCBLEND_FIXA:              srcFactor = "u_blendFixA"; break;
 			}
-			switch (funcB)
-			{
+			switch (replaceBlendFuncB) {
 			case GE_DSTBLEND_SRCCOLOR:          dstFactor = "v.rgb"; break;
 			case GE_DSTBLEND_INVSRCCOLOR:       dstFactor = "(vec3(1.0) - v.rgb)"; break;
 			case GE_DSTBLEND_SRCALPHA:          dstFactor = "vec3(v.a)"; break;
@@ -903,8 +937,7 @@ void GenerateFragmentShader(char *buffer) {
 			case GE_DSTBLEND_FIXB:              dstFactor = "u_blendFixB"; break;
 			}
 
-			switch (eq)
-			{
+			switch (replaceBlendEq) {
 			case GE_BLENDMODE_MUL_AND_ADD:
 				WRITE(p, "  v.rgb = v.rgb * %s + destColor.rgb * %s;\n", srcFactor, dstFactor);
 				break;
@@ -934,7 +967,7 @@ void GenerateFragmentShader(char *buffer) {
 	std::string replacedAlpha = "0.0";
 	char replacedAlphaTemp[64] = "";
 	if (stencilToAlpha != REPLACE_ALPHA_NO) {
-		switch (ReplaceAlphaWithStencilType()) {
+		switch (replaceAlphaWithStencilType) {
 		case STENCIL_VALUE_UNIFORM:
 			replacedAlpha = "u_stencilReplaceValue";
 			break;
@@ -984,7 +1017,8 @@ void GenerateFragmentShader(char *buffer) {
 		break;
 	}
 
-	switch (ReplaceLogicOpType()) {
+	LogicOpReplaceType replaceLogicOpType = (LogicOpReplaceType)id.Bits(BIT_REPLACE_LOGIC_OP_TYPE, 2);
+	switch (replaceLogicOpType) {
 	case LOGICOPTYPE_ONE:
 		WRITE(p, "  %s.rgb = vec3(1.0, 1.0, 1.0);\n", fragColor0);
 		break;

--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -21,8 +21,8 @@
 
 struct ShaderID;
 
-void ComputeFragmentShaderID(ShaderID *id);
-void GenerateFragmentShader(char *buffer);
+void ComputeFragmentShaderID(ShaderID *id, uint32_t vertType);
+void GenerateFragmentShader(const ShaderID &id, char *buffer);
 
 enum StencilValueType {
 	STENCIL_VALUE_UNIFORM,

--- a/GPU/GLES/FragmentShaderGenerator.h
+++ b/GPU/GLES/FragmentShaderGenerator.h
@@ -22,7 +22,7 @@
 struct ShaderID;
 
 void ComputeFragmentShaderID(ShaderID *id, uint32_t vertType);
-void GenerateFragmentShader(const ShaderID &id, char *buffer);
+bool GenerateFragmentShader(const ShaderID &id, char *buffer);
 
 enum StencilValueType {
 	STENCIL_VALUE_UNIFORM,

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -799,7 +799,7 @@ Shader *ShaderManager::ApplyVertexShader(int prim, u32 vertType) {
 	Shader *vs;
 	if (vsIter == vsCache_.end())	{
 		// Vertex shader not in cache. Let's compile it.
-		GenerateVertexShader(prim, vertType, codeBuffer_, useHWTransform);
+		GenerateVertexShader(VSID, codeBuffer_);
 		vs = new Shader(codeBuffer_, GL_VERTEX_SHADER, useHWTransform, VSID);
 
 		if (vs->Failed()) {
@@ -813,7 +813,9 @@ Shader *ShaderManager::ApplyVertexShader(int prim, u32 vertType) {
 			// next time and we'll do this over and over...
 
 			// Can still work with software transform.
-			GenerateVertexShader(prim, vertType, codeBuffer_, false);
+			ShaderID vsidTemp;
+			ComputeVertexShaderID(&vsidTemp, vertType, false);
+			GenerateVertexShader(vsidTemp, codeBuffer_);
 			vs = new Shader(codeBuffer_, GL_VERTEX_SHADER, false, VSID);
 		}
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -839,7 +839,9 @@ LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertT
 	Shader *fs;
 	if (fsIter == fsCache_.end())	{
 		// Fragment shader not in cache. Let's compile it.
-		GenerateFragmentShader(FSID, codeBuffer_);
+		if (!GenerateFragmentShader(FSID, codeBuffer_)) {
+			return nullptr;
+		}
 		fs = new Shader(codeBuffer_, GL_FRAGMENT_SHADER, vs->UseHWTransform(), FSID);
 		fsCache_[FSID] = fs;
 	} else {

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -15,15 +15,14 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#ifdef _WIN32
-#define SHADERLOG
-#endif
+// #define SHADERLOG
 
-#ifdef SHADERLOG
+#if defined(_WIN32) && defined(SHADERLOG)
 #include "Common/CommonWindows.h"
 #endif
 
 #include <map>
+#include <cstdio>
 
 #include "base/logging.h"
 #include "math/math_util.h"
@@ -42,11 +41,16 @@
 #include "Framebuffer.h"
 #include "i18n/i18n.h"
 
-Shader::Shader(const char *code, uint32_t shaderType, bool useHWTransform, const ShaderID &shaderID) : failed_(false), useHWTransform_(useHWTransform), id_(shaderID) {
+Shader::Shader(const char *code, uint32_t shaderType, bool useHWTransform, const ShaderID &shaderID)
+	  : id_(shaderID), failed_(false), useHWTransform_(useHWTransform) {
 	PROFILE_THIS_SCOPE("shadercomp");
 	source_ = code;
 #ifdef SHADERLOG
+#ifdef _WIN32
 	OutputDebugStringUTF8(code);
+#else
+	printf("%s\n", code);
+#endif
 #endif
 	shader = glCreateShader(shaderType);
 	glShaderSource(shader, 1, &code, 0);
@@ -702,8 +706,11 @@ void LinkedShader::UpdateUniforms(u32 vertType) {
 	}
 }
 
-ShaderManager::ShaderManager() : lastShader_(NULL), globalDirty_(0xFFFFFFFF), shaderSwitchDirty_(0) {
+ShaderManager::ShaderManager()
+		: lastShader_(nullptr), globalDirty_(0xFFFFFFFF), shaderSwitchDirty_(0) {
 	codeBuffer_ = new char[16384];
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
 }
 
 ShaderManager::~ShaderManager() {
@@ -725,8 +732,8 @@ void ShaderManager::Clear() {
 	fsCache_.clear();
 	vsCache_.clear();
 	globalDirty_ = 0xFFFFFFFF;
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
 	DirtyShader();
 }
 
@@ -736,8 +743,8 @@ void ShaderManager::ClearCache(bool deleteThem) {
 
 void ShaderManager::DirtyShader() {
 	// Forget the last shader ID
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
 	DirtyLastShader();
 	globalDirty_ = 0xFFFFFFFF;
 	shaderSwitchDirty_ = 0;
@@ -746,24 +753,16 @@ void ShaderManager::DirtyShader() {
 void ShaderManager::DirtyLastShader() { // disables vertex arrays
 	if (lastShader_)
 		lastShader_->stop();
-	lastShader_ = 0;
+	lastShader_ = nullptr;
 	lastVShaderSame_ = false;
 }
 
 // This is to be used when debugging why incompatible shaders are being linked, like is
 // happening as I write this in Tactics Ogre
 bool ShaderManager::DebugAreShadersCompatibleForLinking(Shader *vs, Shader *fs) {
-	// Check clear mode flag just for starters.
-	ShaderID vsid = vs->ID();
-	ShaderID fsid = fs->ID();
-
-	// TODO: Make the flag fields more similar?
-	// Check DoTexture
-	if (((vsid.d[0] >> 4) & 1) != ((fsid.d[0] >> 1) & 1)) {
-		ERROR_LOG(G3D, "Texture enable flag mismatch!");
-		return false;
-	}
-
+	// ShaderID vsid = vs->ID();
+	// ShaderID fsid = fs->ID();
+	// TODO: Redo these checks.
 	return true;
 }
 
@@ -848,7 +847,7 @@ LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertT
 	}
 
 	// Okay, we have both shaders. Let's see if there's a linked one.
-	LinkedShader *ls = NULL;
+	LinkedShader *ls = nullptr;
 
 	u32 switchDirty = shaderSwitchDirty_;
 	for (auto iter = linkedShaderCache_.begin(); iter != linkedShaderCache_.end(); ++iter) {
@@ -861,11 +860,11 @@ LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertT
 	}
 	shaderSwitchDirty_ = 0;
 
-	if (ls == NULL) {
+	if (ls == nullptr) {
 		// Check if we can link these.
 #ifdef _DEBUG
 		if (!DebugAreShadersCompatibleForLinking(vs, fs)) {
-			return NULL;
+			return nullptr;
 		}
 #endif
 		ls = new LinkedShader(vs, fs, vertType, vs->UseHWTransform(), lastShader_);  // This does "use" automatically

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -826,7 +826,7 @@ Shader *ShaderManager::ApplyVertexShader(int prim, u32 vertType) {
 
 LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertType) {
 	ShaderID FSID;
-	ComputeFragmentShaderID(&FSID);
+	ComputeFragmentShaderID(&FSID, vertType);
 	if (lastVShaderSame_ && FSID == lastFSID_) {
 		lastShader_->UpdateUniforms(vertType);
 		return lastShader_;
@@ -838,7 +838,7 @@ LinkedShader *ShaderManager::ApplyFragmentShader(Shader *vs, int prim, u32 vertT
 	Shader *fs;
 	if (fsIter == fsCache_.end())	{
 		// Fragment shader not in cache. Let's compile it.
-		GenerateFragmentShader(codeBuffer_);
+		GenerateFragmentShader(FSID, codeBuffer_);
 		fs = new Shader(codeBuffer_, GL_FRAGMENT_SHADER, vs->UseHWTransform(), FSID);
 		fsCache_[FSID] = fs;
 	} else {

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -34,6 +34,11 @@ struct ShaderID {
 			d[i] = 0;
 		}
 	}
+	void set_invalid() {
+		for (int i = 0; i < ARRAY_SIZE(d); i++) {
+			d[i] = 0xFFFFFFFF;
+		}
+	}
 
 	u32 d[2];
 	bool operator < (const ShaderID &other) const {

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "base/basictypes.h"
-#include "../../Globals.h"
+#include "Globals.h"
 #include <map>
 #include "VertexShaderGenerator.h"
 #include "FragmentShaderGenerator.h"
@@ -26,8 +26,15 @@
 class Shader;
 
 struct ShaderID {
-	ShaderID() { d[0] = 0xFFFFFFFF; }
-	void clear() { d[0] = 0xFFFFFFFF; }
+	ShaderID() {
+		clear();
+	}
+	void clear() {
+		for (int i = 0; i < ARRAY_SIZE(d); i++) {
+			d[i] = 0;
+		}
+	}
+
 	u32 d[2];
 	bool operator < (const ShaderID &other) const {
 		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
@@ -44,6 +51,26 @@ struct ShaderID {
 				return false;
 		}
 		return true;
+	}
+
+	int Bit(int bit) const {
+		return (d[bit >> 5] >> (bit & 31)) & 1;
+	}
+	// Does not handle crossing 32-bit boundaries
+	int Bits(int bit, int count) const {
+		const int mask = (1 << count) - 1;
+		return (d[bit >> 5] >> (bit & 31)) & mask;
+	}
+	void SetBit(int bit, bool value = true) {
+		if (value) {
+			d[bit >> 5] |= 1 << (bit & 31);
+		}
+	}
+	void SetBits(int bit, int count, int value) {
+		if (value != 0) {
+			const int mask = (1 << count) - 1;
+			d[bit >> 5] |= (value & mask) << (bit & 31);
+		}
 	}
 };
 

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -15,7 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdlib>
 #include <locale.h>
 
 #include "gfx_es2/gpu_features.h"
@@ -42,13 +43,53 @@
 
 #define WRITE p+=sprintf
 
+// These bits are internal to this file, although the resulting IDs will be externally visible.
+// TODO: We will cut away many of these, turning them into uniforms. This should reduce the number
+// of generated shaders drastically.
+enum {
+	BIT_LMODE = 0,
+	BIT_IS_THROUGH = 1,
+	BIT_ENABLE_FOG = 2,
+	BIT_HAS_COLOR = 3,
+	BIT_DO_TEXTURE = 4,
+	BIT_FLIP_TEXTURE = 5,
+	BIT_DO_TEXTURE_PROJ = 6,
+	BIT_USE_HW_TRANSFORM = 8,
+	BIT_HAS_NORMAL = 9,  // conditioned on hw transform
+	BIT_NORM_REVERSE = 10,
+	BIT_HAS_TEXCOORD = 11,
+	BIT_UVGEN_MODE = 16,
+	BIT_UVPROJ_MODE = 18,  // 2, can overlap with LS0
+	BIT_LS0 = 18,  // 2
+	BIT_LS1 = 20,  // 2
+	BIT_BONES = 22,  // 3 should be enough, not 8
+	BIT_ENABLE_BONES = 30,
+	BIT_LIGHT0_COMP = 32,
+	BIT_LIGHT0_TYPE = 34,
+	BIT_LIGHT1_COMP = 36,
+	BIT_LIGHT1_TYPE = 38,
+	BIT_LIGHT2_COMP = 40,
+	BIT_LIGHT2_TYPE = 42,
+	BIT_LIGHT3_COMP = 44,
+	BIT_LIGHT3_TYPE = 46,
+	BIT_MATERIAL_UPDATE = 48,
+	BIT_LIGHT0_ENABLE = 52,
+	BIT_LIGHT1_ENABLE = 53,
+	BIT_LIGHT2_ENABLE = 54,
+	BIT_LIGHT3_ENABLE = 55,
+	BIT_LIGHTING_ENABLE = 56,
+	BIT_WEIGHT_FMTSCALE = 57,
+	BIT_TEXCOORD_FMTSCALE = 60,
+	BIT_FLATSHADE = 62,
+};
+
 bool CanUseHardwareTransform(int prim) {
 	if (!g_Config.bHardwareTransform)
 		return false;
 	return !gstate.isModeThrough() && prim != GE_PRIM_RECTANGLES;
 }
 
-void ComputeVertexShaderID(ShaderID *id, u32 vertType, bool useHWTransform) {
+void ComputeVertexShaderID(ShaderID *id_out, u32 vertType, bool useHWTransform) {
 	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
 	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 	bool doShadeMapping = gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP;
@@ -59,67 +100,74 @@ void ComputeVertexShaderID(ShaderID *id, u32 vertType, bool useHWTransform) {
 	bool hasTexcoord = (vertType & GE_VTYPE_TC_MASK) != 0;
 	bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough() && !gstate.isModeClear();
 	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled();
+	// lmode: && !isModeThrough!?
 
-	int id0 = 0;
-	int id1 = 0;
+	ShaderID id;
+	id.SetBit(BIT_LMODE, lmode);
+	id.SetBit(BIT_IS_THROUGH, gstate.isModeThrough());
+	id.SetBit(BIT_ENABLE_FOG, enableFog);
+	id.SetBit(BIT_HAS_COLOR, hasColor);
 
-	id0 = lmode & 1;
-	id0 |= (gstate.isModeThrough() & 1) << 1;
-	id0 |= (enableFog & 1) << 2;
-	id0 |= (hasColor & 1) << 3;
 	if (doTexture) {
-		id0 |= 1 << 4;
-		id0 |= (gstate_c.flipTexture & 1) << 5;
-		id0 |= (doTextureProjection & 1) << 6;
+		id.SetBit(BIT_DO_TEXTURE);
+		id.SetBit(BIT_FLIP_TEXTURE, gstate_c.flipTexture);
+		id.SetBit(BIT_DO_TEXTURE_PROJ, doTextureProjection);
 	}
 
 	if (useHWTransform) {
-		id0 |= 1 << 8;
-		id0 |= (hasNormal & 1) << 9;
+		id.SetBit(BIT_USE_HW_TRANSFORM);
+		id.SetBit(BIT_HAS_NORMAL, hasNormal);
 
-		// UV generation mode
-		id0 |= gstate.getUVGenMode() << 16;
+		// UV generation mode.
+		id.SetBits(BIT_UVGEN_MODE, 2, gstate.getUVGenMode());
 
 		// The next bits are used differently depending on UVgen mode
 		if (doTextureProjection) {
-			id0 |= gstate.getUVProjMode() << 18;
+			id.SetBits(BIT_UVPROJ_MODE, 2, gstate.getUVProjMode());
 		} else if (doShadeMapping) {
-			id0 |= gstate.getUVLS0() << 18;
-			id0 |= gstate.getUVLS1() << 20;
+			id.SetBits(BIT_LS0, 2, gstate.getUVLS0());
+			id.SetBits(BIT_LS1, 2, gstate.getUVLS1());
 		}
 
-		// Bones
-		if (vertTypeIsSkinningEnabled(vertType))
-			id0 |= (TranslateNumBones(vertTypeGetNumBoneWeights(vertType)) - 1) << 22;
+		// Bones.
+		bool enableBones = vertTypeIsSkinningEnabled(vertType);
+		id.SetBit(BIT_ENABLE_BONES, enableBones);
+		if (enableBones) {
+			id.SetBits(BIT_BONES, 3, TranslateNumBones(vertTypeGetNumBoneWeights(vertType)) - 1);
+		}
 
 		// Okay, d[1] coming up. ==============
-
 		if (gstate.isLightingEnabled() || doShadeMapping) {
 			// Light bits
 			for (int i = 0; i < 4; i++) {
-				id1 |= gstate.getLightComputation(i) << (i * 4);
-				id1 |= gstate.getLightType(i) << (i * 4 + 2);
+				// TODO: if (gstate.isLightChanEnabled(i)) {
+					id.SetBits(BIT_LIGHT0_COMP + 4 * i, 2, gstate.getLightComputation(i));
+					id.SetBits(BIT_LIGHT0_TYPE + 4 * i, 2, gstate.getLightType(i));
+				// }
 			}
-			id1 |= (gstate.materialupdate & 7) << 16;
+			id.SetBits(BIT_MATERIAL_UPDATE, 3, gstate.getMaterialUpdate() & 7);
+			// TODO: Optimize by shifting in all the light bits together.
 			for (int i = 0; i < 4; i++) {
-				id1 |= (gstate.isLightChanEnabled(i) & 1) << (20 + i);
+				id.SetBit(BIT_LIGHT0_ENABLE + i, gstate.isLightChanEnabled(i) != 0);
 			}
 			// doShadeMapping is stored as UVGenMode, so this is enough for isLightingEnabled.
-			id1 |= 1 << 24;
+			id.SetBit(BIT_LIGHTING_ENABLE);
 		}
-		// 2 bits.
-		id1 |= (vertTypeGetWeightMask(vertType) >> GE_VTYPE_WEIGHT_SHIFT) << 25;
-		id1 |= (gstate.areNormalsReversed() & 1) << 27;
+
+		// 2 bits. We should probably send in the weight scalefactor as a uniform instead,
+		// or simply preconvert all weights to floats.
+		id.SetBits(BIT_WEIGHT_FMTSCALE, 2, vertTypeGetWeightMask(vertType));
+		id.SetBit(BIT_NORM_REVERSE, gstate.areNormalsReversed());
 		if (doTextureProjection && gstate.getUVProjMode() == GE_PROJMAP_UV) {
-			id1 |= ((vertType & GE_VTYPE_TC_MASK) >> GE_VTYPE_TC_SHIFT) << 28;  // two bits
+			id.SetBit(BIT_TEXCOORD_FMTSCALE, (vertType & GE_VTYPE_TC_MASK) >> GE_VTYPE_TC_SHIFT);  // two bits
 		} else {
-			id1 |= (hasTexcoord & 1) << 28;
+			id.SetBit(BIT_HAS_TEXCOORD, hasTexcoord);
 		}
 	}
-	id1 |= (doFlatShading & 1) << 29;
 
-	id->d[0] = id0;
-	id->d[1] = id1;
+	id.SetBit(BIT_FLATSHADE, doFlatShading);
+
+	*id_out = id;
 }
 
 static const char * const boneWeightAttrDecl[9] = {
@@ -179,10 +227,10 @@ enum DoLightComputation {
 // is a bit of a rare configuration, although quite common on mobile.
 
 
-void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransform) {
+void GenerateVertexShader(const ShaderID &id, char *buffer) {
 	char *p = buffer;
 
-// #define USE_FOR_LOOP
+	// #define USE_FOR_LOOP
 
 	// In GLSL ES 3.0, you use "out" variables instead.
 	bool glslES30 = false;
@@ -208,6 +256,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		highpTexcoord = highpFog;
 	} else {
 		// TODO: Handle this in VersionGEThan?
+
 #if !defined(FORCE_OPENGL_2_0)
 	if (gl_extensions.VersionGEThan(3, 3, 0)) {
 		glslES30 = true;
@@ -231,40 +280,55 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		boneWeightDecl = boneWeightInDecl;
 	}
 
+	bool lmode = id.Bit(BIT_LMODE) && !gstate.isModeThrough();  // TODO: Different expression than in shaderIDgen
+	bool doTexture = id.Bit(BIT_DO_TEXTURE);
+	bool doTextureProjection = id.Bit(BIT_DO_TEXTURE_PROJ);
 
-	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !gstate.isModeThrough();
-	bool doTexture = gstate.isTextureMapEnabled() && !gstate.isModeClear();
-	bool doTextureProjection = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
-	bool doShadeMapping = gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP;
-	bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT && !gstate.isModeClear();
+	GETexMapMode uvGenMode = static_cast<GETexMapMode>(id.Bits(BIT_UVGEN_MODE, 2));
 
-	bool hasColor = (vertType & GE_VTYPE_COL_MASK) != 0 || !useHWTransform;
-	bool hasNormal = (vertType & GE_VTYPE_NRM_MASK) != 0 && useHWTransform;
-	bool hasTexcoord = (vertType & GE_VTYPE_TC_MASK) != 0 || !useHWTransform;
-	bool enableFog = gstate.isFogEnabled() && !gstate.isModeThrough() && !gstate.isModeClear();
-	bool throughmode = (vertType & GE_VTYPE_THROUGH_MASK) != 0;
-	bool flipV = gstate_c.flipTexture;  // This also means that we are texturing from a render target
-	bool flipNormal = gstate.areNormalsReversed();
+	// this is only valid for some settings of uvGenMode
+	GETexProjMapMode uvProjMode = static_cast<GETexProjMapMode>(id.Bits(BIT_UVPROJ_MODE, 2));
+	bool doShadeMapping = uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP;
+	bool doFlatShading = id.Bit(BIT_FLATSHADE);
+
+	bool isModeThrough = id.Bit(BIT_IS_THROUGH);
+	bool useHWTransform = id.Bit(BIT_USE_HW_TRANSFORM);
+	bool hasColor = id.Bit(BIT_HAS_COLOR) || !useHWTransform;
+	bool hasNormal = id.Bit(BIT_HAS_NORMAL) && useHWTransform;
+	bool hasTexcoord = id.Bit(BIT_HAS_TEXCOORD) || !useHWTransform;
+	bool enableFog = id.Bit(BIT_ENABLE_FOG);
+	bool throughmode = id.Bit(BIT_IS_THROUGH);
+	bool flipV = id.Bit(BIT_FLIP_TEXTURE);  // This also means that we are texturing from a render target
+	bool flipNormal = id.Bit(BIT_NORM_REVERSE);
+	int ls0 = id.Bits(BIT_LS0, 2);
+	int ls1 = id.Bits(BIT_LS1, 2);
+	bool enableBones = id.Bit(BIT_ENABLE_BONES);
+	bool enableLighting = id.Bit(BIT_LIGHTING_ENABLE);
+	int matUpdate = id.Bits(BIT_MATERIAL_UPDATE, 3);
 
 	const char *shading = "";
 	if (glslES30)
-		shading = doFlatShading ? "flat" : "";
+		shading = doFlatShading ? "flat " : "";
 
 	DoLightComputation doLight[4] = {LIGHT_OFF, LIGHT_OFF, LIGHT_OFF, LIGHT_OFF};
 	if (useHWTransform) {
-		int shadeLight0 = doShadeMapping ? gstate.getUVLS0() : -1;
-		int shadeLight1 = doShadeMapping ? gstate.getUVLS1() : -1;
+		int shadeLight0 = doShadeMapping ? ls0 : -1;
+		int shadeLight1 = doShadeMapping ? ls1 : -1;
 		for (int i = 0; i < 4; i++) {
 			if (i == shadeLight0 || i == shadeLight1)
 				doLight[i] = LIGHT_SHADE;
-			if (gstate.isLightingEnabled() && gstate.isLightChanEnabled(i))
+			if (id.Bit(BIT_LIGHTING_ENABLE) && id.Bit(BIT_LIGHT0_ENABLE + i))
 				doLight[i] = LIGHT_FULL;
 		}
 	}
 
-	if (vertTypeIsSkinningEnabled(vertType)) {
-		WRITE(p, "%s", boneWeightDecl[TranslateNumBones(vertTypeGetNumBoneWeights(vertType))]);
+	int numBoneWeights = 0;
+	int boneWeightScale = id.Bits(BIT_WEIGHT_FMTSCALE, 2);
+	if (enableBones) {
+		numBoneWeights = 1 + id.Bits(BIT_BONES, 3);
+		WRITE(p, "%s", boneWeightDecl[numBoneWeights]);
 	}
+	int texFmtScale = id.Bits(BIT_TEXCOORD_FMTSCALE, 2);
 
 	if (useHWTransform)
 		WRITE(p, "%s vec3 position;\n", attribute);
@@ -286,14 +350,14 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			WRITE(p, "%s lowp vec3 color1;\n", attribute);
 	}
 
-	if (gstate.isModeThrough())	{
+	if (isModeThrough)	{
 		WRITE(p, "uniform mat4 u_proj_through;\n");
 	} else {
 		WRITE(p, "uniform mat4 u_proj;\n");
 		// Add all the uniforms we'll need to transform properly.
 	}
 
-	bool prescale = g_Config.bPrescaleUV && !throughmode && (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_COORDS || gstate.getUVGenMode() == GE_TEXMAP_UNKNOWN);
+	bool prescale = g_Config.bPrescaleUV && !throughmode && (uvGenMode == GE_TEXMAP_TEXTURE_COORDS || uvGenMode == GE_TEXMAP_UNKNOWN);
 
 	if (useHWTransform) {
 		// When transforming by hardware, we need a great deal more uniforms...
@@ -301,17 +365,16 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		WRITE(p, "uniform mat4 u_view;\n");
 		if (doTextureProjection)
 			WRITE(p, "uniform mediump mat4 u_texmtx;\n");
-		if (vertTypeIsSkinningEnabled(vertType)) {
-			int numBones = TranslateNumBones(vertTypeGetNumBoneWeights(vertType));
+		if (enableBones) {
 #ifdef USE_BONE_ARRAY
-			WRITE(p, "uniform mediump mat4 u_bone[%i];\n", numBones);
+			WRITE(p, "uniform mediump mat4 u_bone[%i];\n", numBoneWeights);
 #else
-			for (int i = 0; i < numBones; i++) {
+			for (int i = 0; i < numBoneWeights; i++) {
 				WRITE(p, "uniform mat4 u_bone%i;\n", i);
 			}
 #endif
 		}
-		if (doTexture && (flipV || !prescale || gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP || gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX)) {
+		if (doTexture && (flipV || !prescale || uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP || uvGenMode == GE_TEXMAP_TEXTURE_MATRIX)) {
 			WRITE(p, "uniform vec4 u_uvscaleoffset;\n");
 		}
 		for (int i = 0; i < 4; i++) {
@@ -320,12 +383,13 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 				WRITE(p, "uniform vec3 u_lightpos%i;\n", i);
 			}
 			if (doLight[i] == LIGHT_FULL) {
-				GELightType type = gstate.getLightType(i);
+				GELightType type = static_cast<GELightType>(id.Bits(BIT_LIGHT0_TYPE + 4*i, 2));
+				GELightComputation comp = static_cast<GELightComputation>(id.Bits(BIT_LIGHT0_COMP + 4*i, 2));
 
 				if (type != GE_LIGHTTYPE_DIRECTIONAL)
 					WRITE(p, "uniform mediump vec3 u_lightatt%i;\n", i);
 
-				if (type == GE_LIGHTTYPE_SPOT || type == GE_LIGHTTYPE_UNKNOWN) { 
+				if (type == GE_LIGHTTYPE_SPOT || type == GE_LIGHTTYPE_UNKNOWN) {
 					WRITE(p, "uniform mediump vec3 u_lightdir%i;\n", i);
 					WRITE(p, "uniform mediump float u_lightangle%i;\n", i);
 					WRITE(p, "uniform mediump float u_lightspotCoef%i;\n", i);
@@ -333,13 +397,14 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 				WRITE(p, "uniform lowp vec3 u_lightambient%i;\n", i);
 				WRITE(p, "uniform lowp vec3 u_lightdiffuse%i;\n", i);
 
-				if (gstate.isUsingSpecularLight(i))
+				if (comp != GE_LIGHTCOMP_ONLYDIFFUSE) {
 					WRITE(p, "uniform lowp vec3 u_lightspecular%i;\n", i);
+				}
 			}
 		}
-		if (gstate.isLightingEnabled()) {
+		if (enableLighting) {
 			WRITE(p, "uniform lowp vec4 u_ambient;\n");
-			if ((gstate.materialupdate & 2) == 0 || !hasColor)
+			if ((matUpdate & 2) == 0 || !hasColor)
 				WRITE(p, "uniform lowp vec3 u_matdiffuse;\n");
 			// if ((gstate.materialupdate & 4) == 0)
 			WRITE(p, "uniform lowp vec4 u_matspecular;\n");  // Specular coef is contained in alpha
@@ -358,17 +423,18 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		WRITE(p, "uniform highp vec4 u_depthRange;\n");
 	}
 
-	WRITE(p, "%s %s lowp vec4 v_color0;\n", shading, varying);
+	WRITE(p, "%s%s lowp vec4 v_color0;\n", shading, varying);
 	if (lmode) {
-		WRITE(p, "%s %s lowp vec3 v_color1;\n", shading, varying);
-	}
-	if (doTexture) {
-		if (doTextureProjection)
-			WRITE(p, "%s %s vec3 v_texcoord;\n", varying, highpTexcoord ? "highp" : "mediump");
-		else
-			WRITE(p, "%s %s vec2 v_texcoord;\n", varying, highpTexcoord ? "highp" : "mediump");
+		WRITE(p, "%s%s lowp vec3 v_color1;\n", shading, varying);
 	}
 
+	if (doTexture) {
+		if (doTextureProjection) {
+			WRITE(p, "%s %s vec3 v_texcoord;\n", varying, highpTexcoord ? "highp" : "mediump");
+		} else {
+			WRITE(p, "%s %s vec2 v_texcoord;\n", varying, highpTexcoord ? "highp" : "mediump");
+		}
+	}
 
 	if (enableFog) {
 		// See the fragment shader generator
@@ -380,7 +446,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 	}
 
 	// See comment above this function (GenerateVertexShader).
-	if (!gstate.isModeThrough() && gstate_c.Supports(GPU_ROUND_DEPTH_TO_16BIT)) {
+	if (!isModeThrough && gstate_c.Supports(GPU_ROUND_DEPTH_TO_16BIT)) {
 		// Apply the projection and viewport to get the Z buffer value, floor to integer, undo the viewport and projection.
 		WRITE(p, "\nvec4 depthRoundZVP(vec4 v) {\n");
 		WRITE(p, "  float z = v.z / v.w;\n");
@@ -414,7 +480,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		if (enableFog) {
 			WRITE(p, "  v_fogdepth = position.w;\n");
 		}
-		if (gstate.isModeThrough())	{
+		if (isModeThrough)	{
 			WRITE(p, "  gl_Position = u_proj_through * vec4(position.xyz, 1.0);\n");
 		} else {
 			// The viewport is used in this case, so need to compensate for that.
@@ -426,7 +492,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 		}
 	} else {
 		// Step 1: World Transform / Skinning
-		if (!vertTypeIsSkinningEnabled(vertType)) {
+		if (!enableBones) {
 			// No skinning, just standard T&L.
 			WRITE(p, "  vec3 worldpos = (u_world * vec4(position.xyz, 1.0)).xyz;\n");
 			if (hasNormal)
@@ -434,10 +500,8 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			else
 				WRITE(p, "  mediump vec3 worldnormal = vec3(0.0, 0.0, 1.0);\n");
 		} else {
-			int numWeights = TranslateNumBones(vertTypeGetNumBoneWeights(vertType));
-
 			static const char *rescale[4] = {"", " * 1.9921875", " * 1.999969482421875", ""}; // 2*127.5f/128.f, 2*32767.5f/32768.f, 1.0f};
-			const char *factor = rescale[vertTypeGetWeightMask(vertType) >> GE_VTYPE_WEIGHT_SHIFT];
+			const char *factor = rescale[texFmtScale];
 
 			static const char * const boneWeightAttr[8] = {
 				"w1.x", "w1.y", "w1.z", "w1.w",
@@ -448,7 +512,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 
 			// To loop through the weights, we unfortunately need to put them in a float array.
 			// GLSL ES sucks - no way to directly initialize an array!
-			switch (numWeights) {
+			switch (numBoneWeights) {
 			case 1: WRITE(p, "  float w[1]; w[0] = w1;\n"); break;
 			case 2: WRITE(p, "  float w[2]; w[0] = w1.x; w[1] = w1.y;\n"); break;
 			case 3: WRITE(p, "  float w[3]; w[0] = w1.x; w[1] = w1.y; w[2] = w1.z;\n"); break;
@@ -460,8 +524,8 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			}
 
 			WRITE(p, "  mat4 skinMatrix = w[0] * u_bone[0];\n");
-			if (numWeights > 1) {
-				WRITE(p, "  for (int i = 1; i < %i; i++) {\n", numWeights);
+			if (numBoneWeights > 1) {
+				WRITE(p, "  for (int i = 1; i < %i; i++) {\n", numBoneWeights);
 				WRITE(p, "    skinMatrix += w[i] * u_bone[i];\n");
 				WRITE(p, "  }\n");
 			}
@@ -469,29 +533,29 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 #else
 
 #ifdef USE_BONE_ARRAY
-			if (numWeights == 1)
+			if (numBoneWeights == 1)
 				WRITE(p, "  mat4 skinMatrix = w1 * u_bone[0]");
 			else
 				WRITE(p, "  mat4 skinMatrix = w1.x * u_bone[0]");
-			for (int i = 1; i < numWeights; i++) {
+			for (int i = 1; i < numBoneWeights; i++) {
 				const char *weightAttr = boneWeightAttr[i];
 				// workaround for "cant do .x of scalar" issue
-				if (numWeights == 1 && i == 0) weightAttr = "w1";
-				if (numWeights == 5 && i == 4) weightAttr = "w2";
+				if (numBoneWeights == 1 && i == 0) weightAttr = "w1";
+				if (numBoneWeights == 5 && i == 4) weightAttr = "w2";
 				WRITE(p, " + %s * u_bone[%i]", weightAttr, i);
 			}
 #else
 			// Uncomment this to screw up bone shaders to check the vertex shader software fallback
 			// WRITE(p, "THIS SHOULD ERROR! #error");
-			if (numWeights == 1)
+			if (numBoneWeights == 1)
 				WRITE(p, "  mat4 skinMatrix = w1 * u_bone0");
 			else
 				WRITE(p, "  mat4 skinMatrix = w1.x * u_bone0");
-			for (int i = 1; i < numWeights; i++) {
+			for (int i = 1; i < numBoneWeights; i++) {
 				const char *weightAttr = boneWeightAttr[i];
 				// workaround for "cant do .x of scalar" issue
-				if (numWeights == 1 && i == 0) weightAttr = "w1";
-				if (numWeights == 5 && i == 4) weightAttr = "w2";
+				if (numBoneWeights == 1 && i == 0) weightAttr = "w1";
+				if (numBoneWeights == 5 && i == 4) weightAttr = "w2";
 				WRITE(p, " + %s * u_bone%i", weightAttr, i);
 			}
 #endif
@@ -523,24 +587,25 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 
 		// TODO: Declare variables for dots for shade mapping if needed.
 
-		const char *ambientStr = (gstate.materialupdate & 1) && hasColor ? "color0" : "u_matambientalpha";
-		const char *diffuseStr = (gstate.materialupdate & 2) && hasColor ? "color0.rgb" : "u_matdiffuse";
-		const char *specularStr = (gstate.materialupdate & 4) && hasColor ? "color0.rgb" : "u_matspecular.rgb";
+		const char *ambientStr = (matUpdate & 1) && hasColor ? "color0" : "u_matambientalpha";
+		const char *diffuseStr = (matUpdate & 2) && hasColor ? "color0.rgb" : "u_matdiffuse";
+		const char *specularStr = (matUpdate & 4) && hasColor ? "color0.rgb" : "u_matspecular.rgb";
 
 		bool diffuseIsZero = true;
 		bool specularIsZero = true;
 		bool distanceNeeded = false;
 
-		if (gstate.isLightingEnabled()) {
+		if (enableLighting) {
 			WRITE(p, "  lowp vec4 lightSum0 = u_ambient * %s + vec4(u_matemissive, 0.0);\n", ambientStr);
 
 			for (int i = 0; i < 4; i++) {
+				GELightType type = static_cast<GELightType>(id.Bits(BIT_LIGHT0_TYPE + 4*i, 2));
+				GELightComputation comp = static_cast<GELightComputation>(id.Bits(BIT_LIGHT0_COMP + 4*i, 2));
 				if (doLight[i] != LIGHT_FULL)
 					continue;
 				diffuseIsZero = false;
-				if (gstate.isUsingSpecularLight(i))
+				if (comp != GE_LIGHTCOMP_ONLYDIFFUSE)
 					specularIsZero = false;
-				GELightType type = gstate.getLightType(i);
 				if (type != GE_LIGHTTYPE_DIRECTIONAL)
 					distanceNeeded = true;
 			}
@@ -564,7 +629,8 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			if (doLight[i] != LIGHT_FULL)
 				continue;
 
-			GELightType type = gstate.getLightType(i);
+			GELightType type = static_cast<GELightType>(id.Bits(BIT_LIGHT0_TYPE + 4*i, 2));
+			GELightComputation comp = static_cast<GELightComputation>(id.Bits(BIT_LIGHT0_COMP + 4*i, 2));
 
 			if (type == GE_LIGHTTYPE_DIRECTIONAL) {
 				// We prenormalize light positions for directional lights.
@@ -575,8 +641,8 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 				WRITE(p, "  toLight /= distance;\n");
 			}
 
-			bool doSpecular = gstate.isUsingSpecularLight(i);
-			bool poweredDiffuse = gstate.isUsingPoweredDiffuseLight(i);
+			bool doSpecular = comp != GE_LIGHTCOMP_ONLYDIFFUSE;
+			bool poweredDiffuse = comp == GE_LIGHTCOMP_BOTHWITHPOWDIFFUSE;
 
 			WRITE(p, "  mediump float dot%i = max(dot(toLight, worldnormal), 0.0);\n", i);
 			if (poweredDiffuse) {
@@ -622,7 +688,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			WRITE(p, "  lightSum0.rgb += (u_lightambient%i * %s.rgb + diffuse)%s;\n", i, ambientStr, timesLightScale);
 		}
 
-		if (gstate.isLightingEnabled()) {
+		if (id.Bit(BIT_LIGHTING_ENABLE)) {
 			// Sum up ambient, emissive here.
 			if (lmode) {
 				WRITE(p, "  v_color0 = clamp(lightSum0, 0.0, 1.0);\n");
@@ -652,7 +718,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 
 		// Step 3: UV generation
 		if (doTexture) {
-			switch (gstate.getUVGenMode()) {
+			switch (uvGenMode) {
 			case GE_TEXMAP_TEXTURE_COORDS:  // Scale-offset. Easy.
 			case GE_TEXMAP_UNKNOWN: // Not sure what this is, but Riviera uses it.  Treating as coords works.
 				if (prescale && !flipV) {
@@ -673,7 +739,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			case GE_TEXMAP_TEXTURE_MATRIX:  // Projection mapping.
 				{
 					std::string temp_tc;
-					switch (gstate.getUVProjMode()) {
+					switch (uvProjMode) {
 					case GE_PROJMAP_POSITION:  // Use model space XYZ as source
 						temp_tc = "vec4(position.xyz, 1.0)";
 						break;
@@ -682,7 +748,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 							// prescale is false here.
 							if (hasTexcoord) {
 								static const char *rescaleuv[4] = {"", " * 1.9921875", " * 1.999969482421875", ""}; // 2*127.5f/128.f, 2*32767.5f/32768.f, 1.0f};
-								const char *factor = rescaleuv[(vertType & GE_VTYPE_TC_MASK) >> GE_VTYPE_TC_SHIFT];
+								const char *factor = rescaleuv[texFmtScale];
 								temp_tc = StringFromFormat("vec4(texcoord.xy %s, 0.0, 1.0)", factor);
 							} else {
 								temp_tc = "vec4(0.0, 0.0, 0.0, 1.0)";
@@ -708,7 +774,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 				break;
 
 			case GE_TEXMAP_ENVIRONMENT_MAP:  // Shade mapping - use dots from light sources.
-				WRITE(p, "  v_texcoord = u_uvscaleoffset.xy * vec2(1.0 + dot(normalize(u_lightpos%i), worldnormal), 1.0 + dot(normalize(u_lightpos%i), worldnormal)) * 0.5;\n", gstate.getUVLS0(), gstate.getUVLS1());
+				WRITE(p, "  v_texcoord = u_uvscaleoffset.xy * vec2(1.0 + dot(normalize(u_lightpos%i), worldnormal), 1.0 + dot(normalize(u_lightpos%i), worldnormal)) * 0.5;\n", ls0, ls1);
 				break;
 
 			default:
@@ -717,7 +783,7 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 			}
 
 			// Will flip in the fragment for GE_TEXMAP_TEXTURE_MATRIX.
-			if (flipV && gstate.getUVGenMode() != GE_TEXMAP_TEXTURE_MATRIX)
+			if (flipV && uvGenMode != GE_TEXMAP_TEXTURE_MATRIX)
 				WRITE(p, "  v_texcoord.y = 1.0 - v_texcoord.y;\n");
 		}
 
@@ -727,4 +793,3 @@ void GenerateVertexShader(int prim, u32 vertType, char *buffer, bool useHWTransf
 	}
 	WRITE(p, "}\n");
 }
-

--- a/GPU/GLES/VertexShaderGenerator.h
+++ b/GPU/GLES/VertexShaderGenerator.h
@@ -26,4 +26,4 @@ struct ShaderID;
 bool CanUseHardwareTransform(int prim);
 
 void ComputeVertexShaderID(ShaderID *id, u32 vertexType, bool useHWTransform);
-void GenerateVertexShader(int prim, u32 vertexType, char *buffer, bool useHWTransform);
+void GenerateVertexShader(const ShaderID &id, char *buffer);


### PR DESCRIPTION
The whole shader is (or should be!) uniquely defined in the shader ID, so no need to go back and look at the gstate. This also is early preps for some interesting ideas like masking away parts of the shader ID and passing in the shader ID as a uniform, for an "ubershader" approach.

An additional use would be logging the shader IDs for a game and precompiling them on the next startup to avoid stutters.

Some things are left to move into the shader ID like config options and gpu features.
