### PR TITLE
Fix two arm64 bugs, one crashing Trails in the Sky

### DIFF
--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -236,8 +236,15 @@ ARM64Reg Arm64RegCache::FindBestToSpill(bool unusedOnly, bool *clobbered) {
 
 		// Awesome, a clobbered reg.  Let's use it.
 		if (MIPSAnalyst::IsRegisterClobbered(ar[reg].mipsReg, compilerPC_, UNUSED_LOOKAHEAD_OPS)) {
-			*clobbered = true;
-			return reg;
+			bool canClobber = true;
+			// HI is stored inside the LO reg.  They both have to clobber at the same time.
+			if (ar[reg].mipsReg == MIPS_REG_LO) {
+				canClobber = MIPSAnalyst::IsRegisterClobbered(MIPS_REG_HI, compilerPC_, UNUSED_LOOKAHEAD_OPS);
+			}
+			if (canClobber) {
+				*clobbered = true;
+				return reg;
+			}
 		}
 
 		// Not awesome.  A used reg.  Let's try to avoid spilling.

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -24,7 +24,7 @@
 namespace Arm64JitConstants {
 
 const Arm64Gen::ARM64Reg DOWNCOUNTREG = Arm64Gen::W23;
-const Arm64Gen::ARM64Reg OTHERTEMPREG = Arm64Gen::X24;
+const Arm64Gen::ARM64Reg OTHERTEMPREG = Arm64Gen::W24;
 const Arm64Gen::ARM64Reg FLAGTEMPREG = Arm64Gen::X25;
 const Arm64Gen::ARM64Reg JITBASEREG = Arm64Gen::X26;
 const Arm64Gen::ARM64Reg CTXREG = Arm64Gen::X27;


### PR DESCRIPTION
Fun, it was making OpenGL code crash actually, but it was just a clobber issue.

Had to pinpoint an exact example where inserting a `gpr.FlushR(MIPS_REG_LO)` helped by bisecting the # of cases, and then examine the jit manually.

-[Unknown]
