### PR TITLE
Minor sceAtrac and sceUtility tweaks

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -52,6 +52,7 @@
 #define ATRAC_ERROR_BAD_ATRACID              0x80630005
 #define ATRAC_ERROR_UNKNOWN_FORMAT           0x80630006
 #define ATRAC_ERROR_WRONG_CODECTYPE          0x80630007
+#define ATRAC_ERROR_BAD_CODEC_PARAMS         0x80630008
 #define ATRAC_ERROR_ALL_DATA_LOADED          0x80630009
 #define ATRAC_ERROR_NO_DATA                  0x80630010
 #define ATRAC_ERROR_SIZE_TOO_SMALL           0x80630011
@@ -1433,7 +1434,8 @@ int __AtracSetContext(Atrac *atrac) {
 	int ret;
 	if ((ret = avcodec_open2(atrac->pCodecCtx, codec, nullptr)) < 0) {
 		ERROR_LOG(ME, "avcodec_open2: Cannot open audio decoder %d", ret);
-		return -1;
+		// This can mean that the frame size is wrong or etc.
+		return ATRAC_ERROR_BAD_CODEC_PARAMS;
 	}
 
 	if ((ret = __AtracUpdateOutputMode(atrac, atrac->atracOutputChannels)) < 0)

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -573,6 +573,11 @@ int Atrac::Analyze() {
 	while (first.filesize >= offset + 8 && !bfoundData) {
 		int chunkMagic = Memory::Read_U32(first.addr + offset);
 		u32 chunkSize = Memory::Read_U32(first.addr + offset + 4);
+		// Account for odd sized chunks.
+		if (chunkSize & 1) {
+			WARN_LOG_REPORT_ONCE(oddchunk, ME, "RIFF chunk had uneven size");
+		}
+		chunkSize += (chunkSize & 1);
 		offset += 8;
 		if (chunkSize > first.filesize - offset)
 			break;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -293,7 +293,11 @@ static u32 sceUtilityLoadModule(u32 module) {
 	u32 allocSize = info->size;
 	char name[64];
 	snprintf(name, sizeof(name), "UtilityModule/%x", module);
-	currentlyLoadedModules[module] = userMemory.Alloc(allocSize, false, name);
+	if (allocSize != 0) {
+		currentlyLoadedModules[module] = userMemory.Alloc(allocSize, false, name);
+	} else {
+		currentlyLoadedModules[module] = 0;
+	}
 
 	// TODO: Each module has its own timing, technically, but this is a low-end.
 	if (module == 0x3FF)


### PR DESCRIPTION
The sceAtrac change is just to fix technical RIFF parsing compatibility.  The sceUtility one is to prevent an error log for a "bogus allocation size" when the size is 0.

-[Unknown]
