### PR TITLE
Make it possible to view vertex decoders through the shader viewing mechanism

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -50,6 +50,27 @@ VertexDecoder *DrawEngineCommon::GetVertexDecoder(u32 vtype) {
 	return dec;
 }
 
+std::vector<std::string> DrawEngineCommon::DebugGetVertexLoaderIDs() {
+	std::vector<std::string> ids;
+	for (auto iter : decoderMap_) {
+		std::string id;
+		id.resize(sizeof(iter.first));
+		memcpy(&id[0], &iter.first, sizeof(iter.first));
+		ids.push_back(id);
+	}
+	return ids;
+}
+
+std::string DrawEngineCommon::DebugGetVertexLoaderString(std::string id, DebugShaderStringType stringType) {
+	u32 mapId;
+	memcpy(&mapId, &id[0], sizeof(mapId));
+	auto iter = decoderMap_.find(mapId);
+	if (iter == decoderMap_.end())
+		return "N/A";
+	else
+		return iter->second->GetString(stringType);
+}
+
 struct Plane {
 	float x, y, z, w;
 	void Set(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -54,6 +54,8 @@ public:
 	void SubmitSpline(const void *control_points, const void *indices, int tess_u, int tess_v, int count_u, int count_v, int type_u, int type_v, GEPatchPrimType prim_type, bool computeNormals, bool patchFacing, u32 vertType);
 	void SubmitBezier(const void *control_points, const void *indices, int tess_u, int tess_v, int count_u, int count_v, GEPatchPrimType prim_type, bool computeNormals, bool patchFacing, u32 vertType);
 
+	std::vector<std::string> DebugGetVertexLoaderIDs();
+	std::string DebugGetVertexLoaderString(std::string id, DebugShaderStringType stringType);
 protected:
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);

--- a/GPU/Common/ShaderCommon.h
+++ b/GPU/Common/ShaderCommon.h
@@ -20,6 +20,8 @@
 enum DebugShaderType {
 	SHADER_TYPE_VERTEX = 0,
 	SHADER_TYPE_FRAGMENT = 1,
+	SHADER_TYPE_GEOMETRY = 2,
+	SHADER_TYPE_VERTEXLOADER = 3,  // Not really a shader, but might as well re-use this mechanism
 };
 
 enum DebugShaderStringType {

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -161,7 +161,7 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_Color5551Morph, &VertexDecoderJitCache::Jit_Color5551Morph},
 };
 
-JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
+JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 	const u8 *start = AlignCode16();
 
@@ -309,6 +309,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 	INFO_LOG(HLE, "%s", temp);
 	*/
 
+	*jittedSize = GetCodePtr() - start;
 	return (JittedVertexDecoder)start;
 }
 

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -140,7 +140,7 @@ static const JitLookup jitLookup[] = {
 };
 
 
-JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
+JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 
 
@@ -287,6 +287,8 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 		}
 		ILOG("==========", temp);
 	}
+
+	*jittedSize = GetCodePtr() - start;
 
 	return (JittedVertexDecoder)start;
 }

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -23,6 +23,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/Reporting.h"
 #include "GPU/ge_constants.h"
+#include "GPU/Common/ShaderCommon.h"
 #ifdef ARM
 #include "Common/ArmEmitter.h"
 #elif defined(ARM64)
@@ -465,6 +466,8 @@ public:
 	bool hasTexcoord() const { return tc != 0; }
 	int VertexSize() const { return size; }  // PSP format size
 
+	std::string GetString(DebugShaderStringType stringType);
+
 	void Step_WeightsU8() const;
 	void Step_WeightsU16() const;
 	void Step_WeightsU8ToFloat() const;
@@ -543,6 +546,7 @@ public:
 	mutable const u8 *ptr_;
 
 	JittedVertexDecoder jitted_;
+	int32_t jittedSize_;
 
 	// "Immutable" state, set at startup
 
@@ -602,7 +606,7 @@ public:
 	VertexDecoderJitCache();
 
 	// Returns a pointer to the code to run.
-	JittedVertexDecoder Compile(const VertexDecoder &dec);
+	JittedVertexDecoder Compile(const VertexDecoder &dec, int32_t *jittedSize);
 	void Clear();
 
 	void Jit_WeightsU8();

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -150,7 +150,7 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_Color5551Morph, &VertexDecoderJitCache::Jit_Color5551Morph},
 };
 
-JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
+JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 	const u8 *start = this->GetCodePtr();
 
@@ -258,6 +258,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
 
 	RET();
 
+	*jittedSize = GetCodePtr() - start;
 	return (JittedVertexDecoder)start;
 }
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -2417,8 +2417,17 @@ bool GLES_GPU::DescribeCodePtr(const u8 *ptr, std::string &name) {
 }
 
 std::vector<std::string> GLES_GPU::DebugGetShaderIDs(DebugShaderType type) {
-	return shaderManager_->DebugGetShaderIDs(type);
+	if (type == SHADER_TYPE_VERTEXLOADER) {
+		return transformDraw_.DebugGetVertexLoaderIDs();
+	} else {
+		return shaderManager_->DebugGetShaderIDs(type);
+	}
 }
+
 std::string GLES_GPU::DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType) {
-	return shaderManager_->DebugGetShaderString(id, type, stringType);
+	if (type == SHADER_TYPE_VERTEXLOADER) {
+		return transformDraw_.DebugGetVertexLoaderString(id, stringType);
+	} else {
+		return shaderManager_->DebugGetShaderString(id, type, stringType);
+	}
 }

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -165,7 +165,6 @@ private:
 		transformDraw_.Flush();
 	}
 	void DoBlockTransfer(u32 skipDrawReason);
-	void ApplyDrawState(int prim);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 	void InitClearInternal();

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -28,7 +28,7 @@ void GeDescribeVertexType(u32 op, char *buffer, int len) {
 	int nrm = (op & GE_VTYPE_NRM_MASK) >> GE_VTYPE_NRM_SHIFT;
 	int pos = (op & GE_VTYPE_POS_MASK) >> GE_VTYPE_POS_SHIFT;
 	int weight = (op & GE_VTYPE_WEIGHT_MASK) >> GE_VTYPE_WEIGHT_SHIFT;
-	int weightCount = (op & GE_VTYPE_WEIGHTCOUNT_MASK) >> GE_VTYPE_WEIGHTCOUNT_SHIFT;
+	int weightCount = ((op & GE_VTYPE_WEIGHTCOUNT_MASK) >> GE_VTYPE_WEIGHTCOUNT_SHIFT) + 1;
 	int morphCount = (op & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT;
 	int idx = (op & GE_VTYPE_IDX_MASK) >> GE_VTYPE_IDX_SHIFT;
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -796,6 +796,13 @@ void ShaderListScreen::ListShaders(DebugShaderType shaderType, UI::LinearLayout 
 	}
 }
 
+struct { DebugShaderType type; const char *name; } shaderTypes[] = {
+	{ SHADER_TYPE_VERTEX, "Vertex" },
+	{ SHADER_TYPE_FRAGMENT, "Fragment" },
+	// { SHADER_TYPE_GEOMETRY, "Geometry" },
+	{ SHADER_TYPE_VERTEXLOADER, "VertexLoader" },
+};
+
 void ShaderListScreen::CreateViews() {
 	using namespace UI;
 
@@ -808,29 +815,19 @@ void ShaderListScreen::CreateViews() {
 	layout->Add(tabs_);
 	layout->Add(new Button(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 
-	ScrollView *vs_scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
-	ScrollView *fs_scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
-
-	LinearLayout *vshaderList = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
-	LinearLayout *fshaderList = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
-
-	ListShaders(SHADER_TYPE_VERTEX, vshaderList);
-	ListShaders(SHADER_TYPE_FRAGMENT, fshaderList);
-
-	vs_scroll->Add(vshaderList);
-	fs_scroll->Add(fshaderList);
-
-	tabs_->AddTab("Vertex", vs_scroll);
-	tabs_->AddTab("Fragment", fs_scroll);
+	for (int i = 0; i < ARRAY_SIZE(shaderTypes); i++) {
+		ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
+		LinearLayout *shaderList = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
+		ListShaders(shaderTypes[i].type, shaderList);
+		scroll->Add(shaderList);
+		tabs_->AddTab(shaderTypes[i].name, scroll);
+	}
 }
 
 UI::EventReturn ShaderListScreen::OnShaderClick(UI::EventParams &e) {
 	using namespace UI;
 	std::string id = e.v->Tag();
-	DebugShaderType type = SHADER_TYPE_VERTEX;
-	if (tabs_->GetCurrentTab() == 1) {
-		type = SHADER_TYPE_FRAGMENT;
-	}
+	DebugShaderType type = shaderTypes[tabs_->GetCurrentTab()].type;
 	screenManager()->push(new ShaderViewScreen(id, type));
 	return EVENT_DONE;
 }


### PR DESCRIPTION
Even though they aren't strictly shaders, they fit the model.
