### PR TITLE
Cleanup RETURN() in __KernelWaitCurThread()

### DIFF
--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
@@ -448,13 +449,12 @@ static int sceCtrlGetIdleCancelThreshold(u32 idleResetPtr, u32 idleBackPtr)
 	return 0;
 }
 
-static void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
+static int sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, false, false);
 	hleEatCycles(330);
 	if (done != 0)
 	{
-		RETURN(done);
 		DEBUG_LOG(SCECTRL, "%d=sceCtrlReadBufferPositive(%08x, %i)", done, ctrlDataPtr, nBufs);
 	}
 	else
@@ -463,15 +463,15 @@ static void sceCtrlReadBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_POSITIVE, ctrlDataPtr, 0, false, "ctrl buffer waited");
 		DEBUG_LOG(SCECTRL, "sceCtrlReadBufferPositive(%08x, %i) - waiting", ctrlDataPtr, nBufs);
 	}
+	return done;
 }
 
-static void sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
+static int sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, true, false);
 	hleEatCycles(330);
 	if (done != 0)
 	{
-		RETURN(done);
 		DEBUG_LOG(SCECTRL, "%d=sceCtrlReadBufferNegative(%08x, %i)", done, ctrlDataPtr, nBufs);
 	}
 	else
@@ -480,6 +480,7 @@ static void sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 		__KernelWaitCurThread(WAITTYPE_CTRL, CTRL_WAIT_NEGATIVE, ctrlDataPtr, 0, false, "ctrl buffer waited");
 		DEBUG_LOG(SCECTRL, "sceCtrlReadBufferNegative(%08x, %i) - waiting", ctrlDataPtr, nBufs);
 	}
+	return done;
 }
 
 static int sceCtrlPeekBufferPositive(u32 ctrlDataPtr, u32 nBufs)
@@ -525,10 +526,10 @@ static const HLEFunction sceCtrl[] =
 	{0X6A2774F3, &WrapU_U<sceCtrlSetSamplingCycle>,        "sceCtrlSetSamplingCycle",          'x', "x" },
 	{0X02BAAD91, &WrapI_U<sceCtrlGetSamplingCycle>,        "sceCtrlGetSamplingCycle",          'i', "x" },
 	{0XDA6B76A1, &WrapI_U<sceCtrlGetSamplingMode>,         "sceCtrlGetSamplingMode",           'i', "x" },
-	{0X1F803938, &WrapV_UU<sceCtrlReadBufferPositive>,     "sceCtrlReadBufferPositive",        'v', "xx"},
+	{0X1F803938, &WrapI_UU<sceCtrlReadBufferPositive>,     "sceCtrlReadBufferPositive",        'i', "xx"},
 	{0X3A622550, &WrapI_UU<sceCtrlPeekBufferPositive>,     "sceCtrlPeekBufferPositive",        'i', "xx"},
 	{0XC152080A, &WrapI_UU<sceCtrlPeekBufferNegative>,     "sceCtrlPeekBufferNegative",        'i', "xx"},
-	{0X60B81F86, &WrapV_UU<sceCtrlReadBufferNegative>,     "sceCtrlReadBufferNegative",        'v', "xx"},
+	{0X60B81F86, &WrapI_UU<sceCtrlReadBufferNegative>,     "sceCtrlReadBufferNegative",        'i', "xx"},
 	{0XB1D0E5CD, &WrapU_U<sceCtrlPeekLatch>,               "sceCtrlPeekLatch",                 'x', "x" },
 	{0X0B588501, &WrapU_U<sceCtrlReadLatch>,               "sceCtrlReadLatch",                 'x', "x" },
 	{0X348D99D4, nullptr,                                  "sceCtrlSetSuspendingExtraSamples", '?', ""  },

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1498,9 +1498,6 @@ void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 time
 	thread->waitInfo.waitValue = waitValue;
 	thread->waitInfo.timeoutPtr = timeoutPtr;
 
-	// TODO: Remove this once all callers are cleaned up.
-	RETURN(0); //pretend all went OK
-
 	// TODO: time waster
 	if (!reason)
 		reason = "started wait";


### PR DESCRIPTION
This hasn't been needed for a while.  All the callers are wrapped and returning values.

-[Unknown]
