### PR TITLE
Improve atrac parsing and differentiate streaming from data

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1378,13 +1378,18 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writeAddr, u32 writableByt
 			atrac->first.writableBytes = std::min(atrac->first.filesize - atrac->first.size, atrac->first.writableBytes);
 		}
 
+		u32 readOffset = atrac->first.fileoffset;
+		if (atrac->bufferState == ATRAC_STATUS_ALL_DATA_LOADED) {
+			readOffset = 0;
+		}
+
 		atrac->first.offset = 0;
 		if (Memory::IsValidAddress(writeAddr))
 			Memory::Write_U32(atrac->first.addr, writeAddr);
 		if (Memory::IsValidAddress(writableBytesAddr))
 			Memory::Write_U32(atrac->first.writableBytes, writableBytesAddr);
 		if (Memory::IsValidAddress(readOffsetAddr))
-			Memory::Write_U32(atrac->first.fileoffset, readOffsetAddr);
+			Memory::Write_U32(readOffset, readOffsetAddr);
 		if ((Memory::IsValidAddress(writeAddr)) && (Memory::IsValidAddress(writableBytesAddr)) && (Memory::IsValidAddress(readOffsetAddr)))
 			DEBUG_LOG(ME, "sceAtracGetStreamDataInfo(%i, %08x[%08x], %08x[%08x], %08x[%08x])", atracID, 
 				  writeAddr, atrac->first.addr,

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -573,6 +573,7 @@ int Atrac::Analyze() {
 
 	decodeEnd = first.filesize;
 	bool bfoundData = false;
+	u32 dataChunkSize = 0;
 	while (maxSize >= offset + 8 && !bfoundData) {
 		int chunkMagic = Memory::Read_U32(first.addr + offset);
 		u32 chunkSize = Memory::Read_U32(first.addr + offset + 4);
@@ -679,6 +680,7 @@ int Atrac::Analyze() {
 			{
 				bfoundData = true;
 				dataOff = offset;
+				dataChunkSize = chunkSize;
 				if (first.filesize < offset + chunkSize) {
 					WARN_LOG_REPORT(ME, "Atrac data chunk extends beyond riff chunk");
 					first.filesize = offset + chunkSize;
@@ -709,9 +711,9 @@ int Atrac::Analyze() {
 	}
 
 	// if there is no correct endsample, try to guess it
-	if (endSample < 0 && atracBytesPerFrame != 0) {
+	if (endSample <= 0 && atracBytesPerFrame != 0) {
 		int atracSamplesPerFrame = (codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
-		endSample = (first.filesize / atracBytesPerFrame) * atracSamplesPerFrame;
+		endSample = (dataChunkSize / atracBytesPerFrame) * atracSamplesPerFrame;
 	}
 
 	return 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -679,6 +679,11 @@ int Atrac::Analyze() {
 		return ATRAC_ERROR_UNKNOWN_FORMAT;
 	}
 
+	if (!bfoundData) {
+		WARN_LOG_REPORT(ME, "Atrac buffer never had data chunk");
+		return ATRAC_ERROR_SIZE_TOO_SMALL;
+	}
+
 	// set the loopStartSample and loopEndSample by loopinfo
 	if (loopinfoNum > 0) {
 		loopStartSample = loopinfo[0].startSample;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1992,7 +1992,7 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 		// TODO: Should we just keep this in PSP ram then, or something?
 	} else if (!atrac->data_buf) {
 		context->info.state = ATRAC_STATUS_NO_DATA;
-	} else if (atrac->first.size >= atrac->first.filesize) {
+	} else {
 		context->info.state = atrac->bufferState;
 	}
 	if (atrac->firstSampleoffset != 0) {
@@ -2007,9 +2007,9 @@ void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
 	int firstOffsetExtra = atrac->codecType == PSP_CODEC_AT3PLUS ? 368 : 69;
 	context->info.endSample = atrac->endSample + atrac->firstSampleoffset + firstOffsetExtra;
 	context->info.dataEnd = atrac->first.filesize;
-	context->info.curOff = atrac->first.size;
+	context->info.curOff = atrac->getFileOffsetBySample(atrac->currentSample);
 	context->info.decodePos = atrac->getDecodePosBySample(atrac->currentSample);
-	context->info.streamDataByte = atrac->first.size - atrac->firstSampleoffset;
+	context->info.streamDataByte = atrac->first.size - atrac->dataOff;
 
 	u8* buf = (u8*)context;
 	*(u32*)(buf + 0xfc) = atrac->atracID;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1027,13 +1027,13 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 
 			int finishFlag = 0;
 			// TODO: Verify.
-			if (atrac->loopNum != 0 && (atrac->currentSample > atrac->loopEndSample ||
-				(numSamples == 0 && atrac->first.size >= atrac->first.filesize))) {
-				atrac->SeekToSample(atrac->loopStartSample);
+			bool hitEnd = atrac->currentSample >= atrac->endSample || (numSamples == 0 && atrac->first.size >= atrac->first.filesize);
+			int loopEndAdjusted = atrac->loopEndSample - firstOffsetExtra - atrac->firstSampleoffset;
+			if ((hitEnd || atrac->currentSample > loopEndAdjusted) && atrac->loopNum != 0) {
+				atrac->SeekToSample(atrac->loopStartSample - firstOffsetExtra - atrac->firstSampleoffset);
 				if (atrac->loopNum > 0)
-					atrac->loopNum --;
-			} else if (atrac->currentSample >= atrac->endSample ||
-				(numSamples == 0 && atrac->first.size >= atrac->first.filesize)) {
+					atrac->loopNum--;
+			} else if (hitEnd) {
 				finishFlag = 1;
 			}
 
@@ -1739,8 +1739,8 @@ static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 		atrac->loopNum = loopNum;
 		if (loopNum != 0 && atrac->loopinfoNum == 0) {
 			// Just loop the whole audio
-			atrac->loopStartSample = 0;
 			int firstOffsetExtra = atrac->codecType == PSP_CODEC_AT3PLUS ? 368 : 69;
+			atrac->loopStartSample = atrac->firstSampleoffset + firstOffsetExtra;
 			atrac->loopEndSample = atrac->endSample + atrac->firstSampleoffset + firstOffsetExtra;
 		}
 	}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -716,6 +716,12 @@ int Atrac::Analyze() {
 		endSample = (dataChunkSize / atracBytesPerFrame) * atracSamplesPerFrame;
 	}
 
+	int firstOffsetExtra = codecType == PSP_CODEC_AT3PLUS ? 368 : 69;
+	if (loopEndSample != -1 && loopEndSample + firstOffsetExtra >= endSample) {
+		WARN_LOG_REPORT(ME, "Atrac loop after end of data");
+		return ATRAC_ERROR_BAD_CODEC_PARAMS;
+	}
+
 	return 0;
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -244,7 +244,11 @@ struct Atrac {
 		if (s >= 6) {
 			p.Do(bufferState);
 		} else {
-			SetBufferState();
+			if (data_buf == nullptr) {
+				bufferState = ATRAC_STATUS_NO_DATA;
+			} else {
+				SetBufferState();
+			}
 		}
 
 		// Make sure to do this late; it depends on things like atracBytesPerFrame.


### PR DESCRIPTION
Need to create more and better tests, but I've run through a bunch of data and then verified against some games, and this is working.

Much of this is based on the values that are stored in the sceAtrac context buffers.  I'm trying to more or less match them.  It seems they CAN be modified by games as well, so it might be ideal to actually store and maintain state there only...

Anyway, this does a few things:
1. Populates the context data a bit more correctly.
2. Determines streaming vs. non-streaming, which allows "infinite looping" via adding data, as games expect in streaming mode.
3. Doesn't pad failed packets when we're at file end.
4. Calculates sample end more correctly when there's no fact chunk.
5. Buffers first few frames from 0 when seeking, to warm up ffmpeg with data for the decoder.
6. Attempts to get the remaining frame value more correct.  It's still off though, but was off before.
7. Parses fact/smpl chunks more correctly and handles riff size more like firmware.

Still a lot more to do to get it correct.  Gotta start figuring out exactly how looping cuts between samples and in what way the second buffer is used - I'm suspecting that it's used to handle a decode that would need some data from near the end and some near the start?

Also, should fix #8093.  Fixes #7282.

-[Unknown]
