### PR TITLE
MIPS: Fix build so we can compile this again.

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1032,7 +1032,7 @@ static int Hook_youkosohitsujimura_download_frame() {
 #elif defined(_M_X64) || defined(_M_IX86)
 #define JITFUNC(f) (&MIPSComp::Jit::f)
 #elif defined(MIPS)
-#define JITFUNC(f) (&MIPSComp::Jit::f)
+#define JITFUNC(f) (&MIPSComp::MipsJit::f)
 #else
 #define JITFUNC(f) (&MIPSComp::FakeJit::f)
 #endif

--- a/Core/MIPS/JitCommon/JitCommon.cpp
+++ b/Core/MIPS/JitCommon/JitCommon.cpp
@@ -34,8 +34,10 @@ namespace MIPSComp {
 	ArmJit *jit;
 #elif defined(ARM64)
 	Arm64Jit *jit;
-#elif defined(_M_IX86) || defined(_M_X64) || defined(MIPS)
+#elif defined(_M_IX86) || defined(_M_X64)
 	Jit *jit;
+#elif defined(MIPS)
+	MipsJit *jit;
 #else
 	FakeJit *jit;
 #endif

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -216,7 +216,7 @@ void MIPSState::Init() {
 #elif defined(_M_IX86) || defined(_M_X64)
 			MIPSComp::jit = new MIPSComp::Jit(this);
 #elif defined(MIPS)
-			MIPSComp::jit = new MIPSComp::Jit(this);
+			MIPSComp::jit = new MIPSComp::MipsJit(this);
 #else
 			MIPSComp::jit = new MIPSComp::FakeJit(this);
 #endif
@@ -246,7 +246,7 @@ void MIPSState::UpdateCore(CPUCore desired) {
 #elif defined(_M_IX86) || defined(_M_X64)
 			MIPSComp::jit = new MIPSComp::Jit(this);
 #elif defined(MIPS)
-			MIPSComp::jit = new MIPSComp::Jit(this);
+			MIPSComp::jit = new MIPSComp::MipsJit(this);
 #else
 			MIPSComp::jit = new MIPSComp::FakeJit(this);
 #endif

--- a/Core/MIPS/MIPS/MipsJit.h
+++ b/Core/MIPS/MIPS/MipsJit.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "Common/MipsEmitter.h"
+using namespace MIPSGen;
+
 #include "Core/MIPS/JitCommon/JitState.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "../MIPSVFPUUtils.h"
@@ -122,6 +125,8 @@ public:
 	void Comp_Vocp(MIPSOpcode op) {}
 	void Comp_ColorConv(MIPSOpcode op) {}
 	int Replace_fabsf() { return 0; }
+
+	void Comp_Vbfy(MIPSOpcode op) {}
 
 	JitBlockCache *GetBlockCache() { return &blocks; }
 

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -88,7 +88,7 @@ struct MIPSInstruction {
 #elif defined(_M_X64) || defined(_M_IX86)
 #define JITFUNC(f) (&Jit::f)
 #elif defined(MIPS)
-#define JITFUNC(f) (&Jit::f)
+#define JITFUNC(f) (&MipsJit::f)
 #else
 #define JITFUNC(f) (&FakeJit::f)
 #endif

--- a/Core/MIPS/fake/FakeJit.cpp
+++ b/Core/MIPS/fake/FakeJit.cpp
@@ -29,6 +29,7 @@
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/HLE/ReplaceTables.h"
 
+#include "FakeEmitter.h"
 #include "FakeJit.h"
 #include "CPUDetect.h"
 

--- a/Core/MIPS/fake/FakeJit.h
+++ b/Core/MIPS/fake/FakeJit.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "Common/FakeEmitter.h"
 #include "Core/MIPS/JitCommon/JitState.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "../MIPSVFPUUtils.h"

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1145,6 +1145,8 @@ std::string VertexDecoder::GetString(DebugShaderStringType stringType) {
 			lines = DisassembleArm64((const u8 *)jitted_, jittedSize_);
 #elif defined(ARM)
 			lines = DisassembleArm2((const u8 *)jitted_, jittedSize_);
+#elif defined(MIPS)
+			// No MIPS disassembler defined
 #else
 			lines = DisassembleX86((const u8 *)jitted_, jittedSize_);
 #endif

--- a/GPU/Common/VertexDecoderFake.cpp
+++ b/GPU/Common/VertexDecoderFake.cpp
@@ -93,7 +93,7 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_Color5551Morph, &VertexDecoderJitCache::Jit_Color5551Morph},
 };
 
-JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec) {
+JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 	//const u8 *start = AlignCode16();
 

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -18,6 +18,10 @@ else:i86 {
 	SOURCES += $$P/Core/MIPS/x86/*.cpp
 	HEADERS += $$P/Core/MIPS/x86/*.h
 }
+else:mips {
+	SOURCES += $$P/Core/MIPS/MIPS/*.cpp
+	HEADERS += $$P/Core/MIPS/MIPS/*.h
+}
 else {
 	SOURCES += $$P/Core/MIPS/fake/*.cpp
 	HEADERS += $$P/Core/MIPS/fake/*.h


### PR DESCRIPTION
A few platform defines were using an x86 fallback instead of a mips fallback which made it fail for MIPS.
This shouldn't affect Loongson as it has an X86 define as well (which is detected before MIPS).

Now successfully builds for cmake/SDL and qmake/Qt5.
