### PR TITLE
Avoid polluting glstate in GetTempFBO()

### DIFF
--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -214,7 +214,7 @@ protected:
 	void UpdateSize();
 
 	virtual void DisableState() = 0;
-	virtual void ClearBuffer() = 0;
+	virtual void ClearBuffer(bool keepState = false) = 0;
 	virtual void ClearDepthBuffer() = 0;
 	virtual void FlushBeforeCopy() = 0;
 	virtual void DecimateFBOs() = 0;

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -94,7 +94,7 @@ public:
 
 protected:
 	virtual void DisableState() override;
-	virtual void ClearBuffer() override;
+	virtual void ClearBuffer(bool keepState = false) override;
 	virtual void ClearDepthBuffer() override;
 	virtual void FlushBeforeCopy() override;
 	virtual void DecimateFBOs() override;

--- a/GPU/Directx9/helper/dx_state.h
+++ b/GPU/Directx9/helper/dx_state.h
@@ -19,8 +19,13 @@ private:
 		inline void set(bool value) {
 			if (_value != value) {
 				_value = value;
-				pD3Ddevice->SetRenderState(cap, value);
+				restore();
 			}
+		}
+		void force(bool value) {
+			bool old = _value;
+			set(value);
+			_value = old;
 		}
 		inline void enable() {
 			set(true);
@@ -51,8 +56,13 @@ private:
 		inline void set(DWORD newp1) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetRenderState(_state1, p1);
+				restore();
 			}
+		}
+		void force(DWORD newp1) {
+			DWORD old = p1;
+			set(newp1);
+			p1 = old;
 		}
 		void restore() {
 			pD3Ddevice->SetRenderState(_state1, p1);
@@ -71,8 +81,13 @@ private:
 		inline void set(DWORD newp1) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetSamplerState(0, _state1, p1);
+				restore();
 			}
+		}
+		void force(DWORD newp1) {
+			DWORD old = p1;
+			set(newp1);
+			p1 = old;
 		}
 		void restore() {
 			pD3Ddevice->SetSamplerState(0, _state1, p1);
@@ -95,8 +110,13 @@ private:
 		inline void set(FLOAT newp1) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetSamplerState(0, _state1, p1d);
+				restore();
 			}
+		}
+		void force(FLOAT newp1) {
+			FLOAT old = p1;
+			set(newp1);
+			p1 = old;
 		}
 		void restore() {
 			pD3Ddevice->SetSamplerState(0, _state1, p1d);
@@ -123,6 +143,13 @@ private:
 				p2 = newp2;
 				pD3Ddevice->SetRenderState(_state2, p2);
 			}
+		}
+		void force(DWORD newp1, DWORD newp2) {
+			DWORD old1 = p1;
+			DWORD old2 = p2;
+			set(newp1, newp2);
+			p1 = old1;
+			p2 = old2;
 		}
 		void restore() {
 			pD3Ddevice->SetRenderState(_state1, p1);
@@ -158,10 +185,19 @@ private:
 				pD3Ddevice->SetRenderState(_state3, p3);
 			}
 		}
+		void force(DWORD newp1, DWORD newp2, DWORD newp3) {
+			DWORD old1 = p1;
+			DWORD old2 = p2;
+			DWORD old3 = p3;
+			set(newp1, newp2, newp3);
+			p1 = old1;
+			p2 = old2;
+			p3 = old3;
+		}
 		void restore() {
-		  pD3Ddevice->SetRenderState(_state1, p1);
-		  pD3Ddevice->SetRenderState(_state2, p2);
-		  pD3Ddevice->SetRenderState(_state3, p3);
+			pD3Ddevice->SetRenderState(_state1, p1);
+			pD3Ddevice->SetRenderState(_state2, p2);
+			pD3Ddevice->SetRenderState(_state3, p3);
 		}
 	};
 
@@ -199,6 +235,17 @@ private:
 				pD3Ddevice->SetRenderState(_state4, p4);
 			}
 		}
+		void force(DWORD newp1, DWORD newp2, DWORD newp3, DWORD newp4) {
+			DWORD old1 = p1;
+			DWORD old2 = p2;
+			DWORD old3 = p3;
+			DWORD old4 = p4;
+			set(newp1, newp2, newp3, newp4);
+			p1 = old1;
+			p2 = old2;
+			p3 = old3;
+			p4 = old4;
+		}
 		void restore() {
 			pD3Ddevice->SetRenderState(_state1, p1);
 			pD3Ddevice->SetRenderState(_state2, p2);
@@ -219,8 +266,13 @@ private:
 			DWORD newc = D3DCOLOR_COLORVALUE(v[0], v[1], v[2], v[3]);
 			if (c != newc) {
 				c = newc;
-				pD3Ddevice->SetRenderState(D3DRS_BLENDFACTOR, c);
+				restore();
 			}
+		}
+		void force(const float v[4]) {
+			DWORD old = c;
+			set(v);
+			c = old;
 		}
 		inline void restore() {
 			pD3Ddevice->SetRenderState(D3DRS_BLENDFACTOR, c);
@@ -251,9 +303,13 @@ private:
 			}
 			if (mask != newmask) {
 				mask = newmask;
-				pD3Ddevice->SetRenderState(D3DRS_COLORWRITEENABLE, mask);
+				restore();
 			}
-			
+		}
+		void force(bool r, bool g, bool b, bool a) {
+			DWORD old = mask;
+			set(r, g, b, a);
+			mask = old;
 		}
 		inline void restore() {
 			pD3Ddevice->SetRenderState(D3DRS_COLORWRITEENABLE, mask);
@@ -267,12 +323,14 @@ private:
 			DirectXState::state_count++;
 		}
 		inline void set(bool) {
-			
+			// Nothing.
+		}
+		void force(bool) {
+			// Nothing.
 		}
 		inline void restore() {
-			
+			// Nothing.
 		}
-
 		inline void enable() {
 			set(true);
 		}
@@ -282,9 +340,9 @@ private:
 	};
 
 	class StateVp {
-	D3DVIEWPORT9 viewport;
+		D3DVIEWPORT9 viewport;
 	public:
-		inline void set(int x, int y, int w, int h,  float n = 0.f, float f = 1.f) {
+		inline void set(int x, int y, int w, int h, float n = 0.f, float f = 1.f) {
 			D3DVIEWPORT9 newviewport;
 			newviewport.X = x;
 			newviewport.Y = y;
@@ -295,8 +353,14 @@ private:
 
 			if (memcmp(&viewport, &newviewport, sizeof(viewport))) {
 				viewport = newviewport;
-				pD3Ddevice->SetViewport(&viewport);
+				restore();
 			}
+		}
+
+		void force(int x, int y, int w, int h, float n = 0.f, float f = 1.f) {
+			D3DVIEWPORT9 old = viewport;
+			set(x, y, w, h, n, f);
+			viewport = old;
 		}
 
 		inline void restore() {
@@ -307,12 +371,18 @@ private:
 	class StateScissor {
 		RECT rect;
 	public:
-		inline void set(int x1, int y1, int x2, int y2)  {
+		inline void set(int x1, int y1, int x2, int y2) {
 			RECT newrect = {x1, y1, x2, y2};
 			if (memcmp(&rect, &newrect, sizeof(rect))) {
 				rect = newrect;
-				pD3Ddevice->SetScissorRect(&rect);
+				restore();
 			}
+		}
+
+		void force(int x1, int y1, int x2, int y2) {
+			RECT old = rect;
+			set(x1, y1, x2, y2);
+			rect = old;
 		}
 
 		inline void restore() {
@@ -337,8 +407,13 @@ private:
 			}
 			if (cull != newcull) {
 				cull = newcull;
-				pD3Ddevice->SetRenderState(D3DRS_CULLMODE, cull);
+				restore();
 			}
+		}
+		void force(int wantcull, int cullmode) {
+			DWORD old = cull;
+			set(wantcull, cullmode);
+			cull = old;
 		}
 		inline void restore() {
 			pD3Ddevice->SetRenderState(D3DRS_CULLMODE, cull);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -86,12 +86,20 @@ static const char color_vs[] =
 
 void ConvertFromRGBA8888(u8 *dst, const u8 *src, u32 dstStride, u32 srcStride, u32 width, u32 height, GEBufferFormat format);
 
-void FramebufferManager::ClearBuffer() {
-	glstate.scissorTest.disable();
-	glstate.depthWrite.set(GL_TRUE);
-	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glstate.stencilFunc.set(GL_ALWAYS, 0, 0);
-	glstate.stencilMask.set(0xFF);
+void FramebufferManager::ClearBuffer(bool keepState) {
+	if (keepState) {
+		glstate.scissorTest.force(false);
+		glstate.depthWrite.force(GL_TRUE);
+		glstate.colorMask.force(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		glstate.stencilFunc.force(GL_ALWAYS, 0, 0);
+		glstate.stencilMask.force(0xFF);
+	} else {
+		glstate.scissorTest.disable();
+		glstate.depthWrite.set(GL_TRUE);
+		glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		glstate.stencilFunc.set(GL_ALWAYS, 0, 0);
+		glstate.stencilMask.set(0xFF);
+	}
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 	glClearStencil(0);
 #ifdef USING_GLES2
@@ -100,6 +108,13 @@ void FramebufferManager::ClearBuffer() {
 	glClearDepth(0.0);
 #endif
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+	if (keepState) {
+		glstate.scissorTest.restore();
+		glstate.depthWrite.restore();
+		glstate.colorMask.restore();
+		glstate.stencilFunc.restore();
+		glstate.stencilMask.restore();
+	}
 }
 
 void FramebufferManager::ClearDepthBuffer() {
@@ -859,7 +874,7 @@ FBO *FramebufferManager::GetTempFBO(u16 w, u16 h, FBOColorDepth depth) {
 	if (!fbo)
 		return fbo;
 	fbo_bind_as_render_target(fbo);
-	ClearBuffer();
+	ClearBuffer(true);
 	const TempFBO info = {fbo, gpuStats.numFlips};
 	tempFBOs_[key] = info;
 	return fbo;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -845,7 +845,7 @@ void FramebufferManager::BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFr
 
 			// Let's only do this if not clearing depth.
 			fbo_bind_for_read(src->fbo);
-			glDisable(GL_SCISSOR_TEST);
+			glstate.scissorTest.force(false);
 
 			if (useNV) {
 #if defined(USING_GLES2) && defined(ANDROID)  // We only support this extension on Android, it's not even available on PC.
@@ -1324,7 +1324,7 @@ void FramebufferManager::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int 
 	}
 
 	fbo_bind_as_render_target(dst->fbo);
-	glDisable(GL_SCISSOR_TEST);
+	glstate.scissorTest.force(false);
 
 	bool useBlit = gstate_c.Supports(GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT | GPU_SUPPORTS_NV_FRAMEBUFFER_BLIT);
 	bool useNV = useBlit && !gstate_c.Supports(GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -124,7 +124,7 @@ public:
 
 protected:
 	virtual void DisableState() override;
-	virtual void ClearBuffer() override;
+	virtual void ClearBuffer(bool keepState = false) override;
 	virtual void ClearDepthBuffer() override;
 	virtual void FlushBeforeCopy() override;
 	virtual void DecimateFBOs() override;

--- a/GPU/GLES/GLStateCache.h
+++ b/GPU/GLES/GLStateCache.h
@@ -14,21 +14,22 @@ private:
 	template<GLenum cap, bool init>
 	class BoolState {
 	private:
-		bool _value;
+		bool v;
 	public:
-		BoolState() : _value(init) {
+		BoolState() : v(init) {
 			OpenGLState::state_count++;
 		}
 
 		inline void set(bool value) {
-			if (value && value != _value) {
-				_value = value;
-				glEnable(cap);
+			if (value != v) {
+				v = value;
+				restore();
 			}
-			if (!value && value != _value) {
-				_value = value;
-				glDisable(cap);
-			}
+		}
+		inline void force(bool value) {
+			bool old = v;
+			set(v);
+			v = old;
 		}
 		inline void enable() {
 			set(true);
@@ -40,10 +41,10 @@ private:
 			return isset();
 		}
 		inline bool isset() {
-			return _value;
+			return v;
 		}
 		void restore() {
-			if (_value)
+			if (v)
 				glEnable(cap);
 			else
 				glDisable(cap);
@@ -60,10 +61,15 @@ private:
 		void set(p1type newp1) { \
 			if (newp1 != p1) { \
 				p1 = newp1; \
-				func(p1); \
+				restore(); \
 			} \
 		} \
-		void restore() { \
+		void force(p1type newp1) { \
+			p1type old = p1; \
+			set(newp1); \
+			p1 = old; \
+		} \
+		inline void restore() { \
 			func(p1); \
 		} \
 	}
@@ -80,8 +86,15 @@ private:
 			if (newp1 != p1 || newp2 != p2) { \
 				p1 = newp1; \
 				p2 = newp2; \
-				func(p1, p2); \
+				restore(); \
 			} \
+		} \
+		void force(p1type newp1, p2type newp2) { \
+			p1type old1 = p1; \
+			p2type old2 = p2; \
+			set(newp1, newp2); \
+			p1 = old1; \
+			p2 = old2; \
 		} \
 		inline void restore() { \
 			func(p1, p2); \
@@ -102,8 +115,17 @@ private:
 				p1 = newp1; \
 				p2 = newp2; \
 				p3 = newp3; \
-				func(p1, p2, p3); \
+				restore(); \
 			} \
+		} \
+		void force(p1type newp1, p2type newp2, p3type newp3) { \
+			p1type old1 = p1; \
+			p2type old2 = p2; \
+			p3type old3 = p3; \
+			set(newp1, newp2, newp3); \
+			p1 = old1; \
+			p2 = old2; \
+			p3 = old3; \
 		} \
 		inline void restore() { \
 			func(p1, p2, p3); \
@@ -126,8 +148,19 @@ private:
 				p2 = newp2; \
 				p3 = newp3; \
 				p4 = newp4; \
-				func(p1, p2, p3, p4); \
+				restore(); \
 			} \
+		} \
+		void force(p1type newp1, p2type newp2, p3type newp3, p4type newp4) { \
+			p1type old1 = p1; \
+			p2type old2 = p2; \
+			p3type old3 = p3; \
+			p4type old4 = p4; \
+			set(newp1, newp2, newp3, newp4); \
+			p1 = old1; \
+			p2 = old2; \
+			p3 = old3; \
+			p4 = old4; \
 		} \
 		inline void restore() { \
 			func(p1, p2, p3, p4); \
@@ -143,10 +176,16 @@ private:
 			OpenGLState::state_count++; \
 		} \
 		inline void set(const float v[4]) { \
-			if (memcmp(p,v,sizeof(float)*4)) { \
-				memcpy(p,v,sizeof(float)*4); \
-				func(p[0], p[1], p[2], p[3]); \
+			if (memcmp(p, v, sizeof(float) * 4)) { \
+				memcpy(p, v, sizeof(float) * 4); \
+				restore(); \
 			} \
+		} \
+		void force(const float v[4]) { \
+			float old[4]; \
+			memcpy(old, p, sizeof(float) * 4); \
+			set(v); \
+			memcpy(p, old, sizeof(float) * 4); \
 		} \
 		inline void restore() { \
 			func(p[0], p[1], p[2], p[3]); \
@@ -163,9 +202,14 @@ private:
 		} \
 		inline void bind(GLuint val) { \
 			if (val_ != val) { \
-				func(target, val); \
 				val_ = val; \
+				restore(); \
 			} \
+		} \
+		inline void force(GLuint val) { \
+			GLuint old = val_; \
+			bind(val); \
+			val_ = val; \
 		} \
 		inline void unbind() { \
 			bind(0); \

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -1105,14 +1105,13 @@ void TextureCache::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuf
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-		glDisable(GL_BLEND);
-		glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glDisable(GL_SCISSOR_TEST);
-		glDisable(GL_CULL_FACE);
-		glDisable(GL_DEPTH_TEST);
-		glDisable(GL_STENCIL_TEST);
+		glstate.blend.force(false);
+		glstate.colorMask.force(true, true, true, true);
+		glstate.scissorTest.force(false);
+		glstate.cullFace.force(false);
+		glstate.depthTest.force(false);
 #if !defined(USING_GLES2)
-		glDisable(GL_LOGIC_OP);
+		glstate.colorLogicOp.force(false);
 #endif
 		glViewport(0, 0, framebuffer->renderWidth, framebuffer->renderHeight);
 


### PR DESCRIPTION
I think this is #8145.  Basically, when creating a temp FBO for blending (or for depal), we would kill some of the state setup for rendering.  And then proceed to render that way.

This could fix other things, maybe even #8035.

Maybe I can just preserve for all callers, but I was worried some might be setting state semi-intentionally.  It's called in a lot of places.

Anyway, this also adds `force()` methods to all the glstate properties.  My rationale is just to keep the syntax the same, so it's clearer.  I thought about doing an auto/smart thing, or `unforce()`, but decided against the complexity for now...

-[Unknown]
