### PR TITLE
Re-add -mmacosx-version-min=10.7 to CMAKE_CXX_FLAGS (because someone removed it at some point?)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ if(NOT MSVC)
 		# comment out the next line to enable default/"standard" architectures (which is a fat armv7/armv7s binary)
 		set(CMAKE_OSX_ARCHITECTURES "armv7")
 	elseif(APPLE)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -U__STRICT_ANSI__")
-		# Karen/angelXwind: --macosx-version-min=10.7 is needed in order to produce binaries that OS X 10.7 Lion can execute. However, it seems that PPSSPP won't support 10.6 or lower without getting rid of -stdlib=libc++ ...which probably won't end well. So I guess PPSSPP will strictly be a 10.7+ app.
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} mmacosx-version-min=10.7 -stdlib=libc++ -U__STRICT_ANSI__")
+		# Karen/angelXwind: -mmacosx-version-min=10.7 is needed in order to produce binaries that OS X 10.7 Lion can execute. However, it seems that PPSSPP won't support 10.6 or lower without getting rid of -stdlib=libc++ ...which probably won't end well. So I guess PPSSPP will strictly be a 10.7+ app.
 		# vit9696: OSX 10.6 builds are possible: http://forums.ppsspp.org/showthread.php?tid=1826&pid=18875#pid18875
 		set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 	else()


### PR DESCRIPTION
This re-adds the `-mmacosx-version-min=10.7` flag to `CMAKE_CXX_FLAGS`.

No idea why it was removed, or who did it — but this fixes the issue where PPSSPP builds don't work on OS X <10.11 ;P
