### PR TITLE
Improve the remaining frames value calculation

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -120,7 +120,7 @@ struct InputBuffer {
 
 struct Atrac;
 int __AtracSetContext(Atrac *atrac);
-void _AtracGenarateContext(Atrac *atrac, SceAtracId *context);
+void _AtracGenerateContext(Atrac *atrac, SceAtracId *context);
 
 struct AtracLoopInfo {
 	int cuePointID;
@@ -904,7 +904,7 @@ u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 	atrac->first.writableBytes = 0;
 	if (atrac->atracContext.IsValid()) {
 		// refresh atracContext
-		_AtracGenarateContext(atrac, atrac->atracContext);
+		_AtracGenerateContext(atrac, atrac->atracContext);
 	}
 	return 0;
 }
@@ -1075,7 +1075,7 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 		}
 		if (atrac->atracContext.IsValid()) {
 			// refresh atracContext
-			_AtracGenarateContext(atrac, atrac->atracContext);
+			_AtracGenerateContext(atrac, atrac->atracContext);
 		}
 	}
 
@@ -2077,7 +2077,7 @@ int _AtracGetIDByContext(u32 contextAddr) {
 	return atracID;
 }
 
-void _AtracGenarateContext(Atrac *atrac, SceAtracId *context) {
+void _AtracGenerateContext(Atrac *atrac, SceAtracId *context) {
 	context->info.buffer = atrac->first.addr;
 	context->info.bufferByte = atrac->atracBufSize;
 	context->info.secondBuffer = atrac->second.addr;
@@ -2133,7 +2133,7 @@ static int _sceAtracGetContextAddress(int atracID) {
 	else
 		WARN_LOG(ME, "%08x=_sceAtracGetContextAddress(%i)", atrac->atracContext.ptr, atracID);
 	if (atrac->atracContext.IsValid())
-		_AtracGenarateContext(atrac, atrac->atracContext);
+		_AtracGenerateContext(atrac, atrac->atracContext);
 	return atrac->atracContext.ptr;
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -67,6 +67,8 @@
 #define ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED 0x80630022
 #define ATRAC_ERROR_BUFFER_IS_EMPTY          0x80630023
 #define ATRAC_ERROR_ALL_DATA_DECODED         0x80630024
+#define ATRAC_ERROR_IS_LOW_LEVEL             0x80630031
+#define ATRAC_ERROR_IS_FOR_SCESAS            0x80630040
 #define ATRAC_ERROR_AA3_INVALID_DATA         0x80631003
 #define ATRAC_ERROR_AA3_SIZE_TOO_SMALL       0x80631004
 
@@ -1369,9 +1371,14 @@ static u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	Atrac *atrac = getAtrac(atracID);
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
-	} else if (!atrac->data_buf) {
+	} else if (atrac->bufferState == ATRAC_STATUS_NO_DATA) {
 		return hleLogError(ME, ATRAC_ERROR_NO_DATA, "no data");
+	} else if (atrac->bufferState == ATRAC_STATUS_LOW_LEVEL) {
+		return hleLogError(ME, ATRAC_ERROR_IS_LOW_LEVEL, "cannot use for low level stream");
+	} else if (atrac->bufferState == ATRAC_STATUS_FOR_SCESAS) {
+		return hleLogError(ME, ATRAC_ERROR_IS_FOR_SCESAS, "cannot use for SAS stream");
 	} else if (!remainingFrames.IsValid()) {
+		// Would crash.
 		return hleReportError(ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid remainingFrames pointer");
 	} else {
 		*remainingFrames = atrac->getRemainFrames();

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -169,6 +169,7 @@ struct Atrac {
 		if (data_buf)
 			delete [] data_buf;
 		data_buf = 0;
+		bufferState = ATRAC_STATUS_NO_DATA;
 
 		if (atracContext.IsValid())
 			kernelMemory.Free(atracContext.ptr);
@@ -1695,6 +1696,9 @@ static int _AtracSetData(Atrac *atrac, u32 buffer, u32 bufferSize) {
 		u32 copybytes = std::min(bufferSize, atrac->first.filesize);
 		Memory::Memcpy(atrac->data_buf, buffer, copybytes);
 		return __AtracSetContext(atrac);
+	} else {
+		// Should not get here, but just in case, force it.
+		atrac->bufferState = ATRAC_STATUS_NO_DATA;
 	}
 
 	return 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -906,7 +906,7 @@ u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 	int addbytes = std::min(bytesToAdd, atrac->first.filesize - atrac->first.fileoffset);
 	Memory::Memcpy(atrac->data_buf + atrac->first.fileoffset, bufPtr, addbytes);
 	atrac->first.size += bytesToAdd;
-	if (atrac->first.size > atrac->first.filesize) {
+	if (atrac->first.size >= atrac->first.filesize) {
 		atrac->first.size = atrac->first.filesize;
 		if (atrac->bufferState == ATRAC_STATUS_HALFWAY_BUFFER)
 			atrac->bufferState = ATRAC_STATUS_ALL_DATA_LOADED;
@@ -948,7 +948,7 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 			atrac->first.fileoffset += addbytes;
 		}
 		atrac->first.size += bytesToAdd;
-		if (atrac->first.size > atrac->first.filesize) {
+		if (atrac->first.size >= atrac->first.filesize) {
 			atrac->first.size = atrac->first.filesize;
 			if (atrac->bufferState == ATRAC_STATUS_HALFWAY_BUFFER)
 				atrac->bufferState = ATRAC_STATUS_ALL_DATA_LOADED;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -299,6 +299,14 @@ struct Atrac {
 			return PSP_ATRAC_ALLDATA_IS_ON_MEMORY;
 		}
 
+		if (currentSample >= endSample && loopNum == 0) {
+			if (bufferState == ATRAC_STATUS_STREAMED_WITHOUT_LOOP) {
+				return PSP_ATRAC_NONLOOP_STREAM_DATA_IS_ON_MEMORY;
+			} else if (bufferState == ATRAC_STATUS_STREAMED_LOOP_FROM_END || bufferState == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER) {
+				return PSP_ATRAC_LOOP_STREAM_DATA_IS_ON_MEMORY;
+			}
+		}
+
 		// Since the first frame is shorter by this offset, add to round up at this offset.
 		const u32 firstOffsetExtra = codecType == PSP_CODEC_AT3PLUS ? 368 : 69;
 		int atracSamplesPerFrame = (codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);


### PR DESCRIPTION
This calculates it, as far as I can tell, correctly in the majority of cases, e.g. when filling a buffer or streaming, and at the ends of streams.

What it doesn't yet get right, which is important but gonna mean changes, is the value when in the middle of a loop.  It's not worse than before afaict; it's just still wrong.  While looping, it will report an incorrectly high value, because it's looking at the "big picture" of all the data it's ever seen.

This really needs to be fixed in the looping logic, I think, but I figured this was a good stopping place to find out what breaks.

This passes hrydgard/pspautotests#179.

-[Unknown]
