### PR TITLE
Don't attempt shader blending in D3D9

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -768,7 +768,7 @@ void ApplyStencilReplaceAndLogicOp(ReplaceAlphaType replaceAlphaWithStencil, Gen
 
 // Called even if AlphaBlendEnable == false - it also deals with stencil-related blend state.
 
-void ConvertBlendState(GenericBlendState &blendState) {
+void ConvertBlendState(GenericBlendState &blendState, bool allowShaderBlend) {
 	// Blending is a bit complex to emulate.  This is due to several reasons:
 	//
 	//  * Doubled blend modes (src, dst, inversed) aren't supported in OpenGL.
@@ -778,13 +778,12 @@ void ConvertBlendState(GenericBlendState &blendState) {
 	//  * The written output alpha should actually be the stencil value.  Alpha is not written.
 	//
 	// If we can't apply blending, we make a copy of the framebuffer and do it manually.
-	gstate_c.allowShaderBlend = !g_Config.bDisableSlowFramebufEffects;
 
 	blendState.applyShaderBlending = false;
 	blendState.dirtyShaderBlend = false;
 	blendState.useBlendColor = false;
 
-	ReplaceBlendType replaceBlend = ReplaceBlendWithShader(gstate_c.allowShaderBlend, gstate.FrameBufFormat());
+	ReplaceBlendType replaceBlend = ReplaceBlendWithShader(allowShaderBlend, gstate.FrameBufFormat());
 	ReplaceAlphaType replaceAlphaWithStencil = ReplaceAlphaWithStencil(replaceBlend);
 	bool usePreSrc = false;
 

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -135,5 +135,5 @@ struct GenericBlendState {
 	}
 };
 
-void ConvertBlendState(GenericBlendState &blendState);
+void ConvertBlendState(GenericBlendState &blendState, bool allowShaderBlend);
 void ApplyStencilReplaceAndLogicOp(ReplaceAlphaType replaceAlphaWithStencil, GenericBlendState &blendState);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -2094,6 +2094,7 @@ bool DIRECTX9_GPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 	}
 
 	textureCache_.SetTexture(true);
+	textureCache_.ApplyTexture();
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -104,7 +104,6 @@ bool TransformDrawEngineDX9::ApplyShaderBlending() {
 	++blitsThisFrame;
 	if (blitsThisFrame > MAX_REASONABLE_BLITS_PER_FRAME * 2) {
 		WARN_LOG_ONCE(blendingBlit2, G3D, "Skipping additional blits needed for obscure blending: %d per frame, blend %d/%d/%d", blitsThisFrame, gstate.getBlendFuncA(), gstate.getBlendFuncB(), gstate.getBlendEq());
-		ResetShaderBlending();
 		return false;
 	}
 
@@ -157,6 +156,7 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 			ApplyStencilReplaceAndLogicOp(blendState.replaceAlphaWithStencil, blendState);
 		} else {
 			// Until next time, force it off.
+			ResetShaderBlending();
 			gstate_c.allowShaderBlend = false;
 		}
 	} else if (blendState.resetShaderBlending) {

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -86,7 +86,9 @@ static const D3DSTENCILOP stencilOps[] = {
 };
 
 bool TransformDrawEngineDX9::ApplyShaderBlending() {
-	bool skipBlit = false;
+	if (gstate_c.featureFlags & GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH) {
+		return true;
+	}
 
 	static const int MAX_REASONABLE_BLITS_PER_FRAME = 24;
 
@@ -137,9 +139,12 @@ void TransformDrawEngineDX9::ApplyDrawState(int prim) {
 
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 
+	// Unfortunately, this isn't implemented yet.
+	gstate_c.allowShaderBlend = false;
+
 	// Set blend - unless we need to do it in the shader.
 	GenericBlendState blendState;
-	ConvertBlendState(blendState);
+	ConvertBlendState(blendState, gstate_c.allowShaderBlend);
 	ViewportAndScissor vpAndScissor;
 	ConvertViewportAndScissor(useBufferedRendering,
 		framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -130,7 +130,6 @@ bool TransformDrawEngine::ApplyShaderBlending() {
 	++blitsThisFrame;
 	if (blitsThisFrame > MAX_REASONABLE_BLITS_PER_FRAME * 2) {
 		WARN_LOG_ONCE(blendingBlit2, G3D, "Skipping additional blits needed for obscure blending: %d per frame, blend %d/%d/%d", blitsThisFrame, gstate.getBlendFuncA(), gstate.getBlendFuncB(), gstate.getBlendEq());
-		ResetShaderBlending();
 		return false;
 	}
 
@@ -185,6 +184,7 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 			ApplyStencilReplaceAndLogicOp(blendState.replaceAlphaWithStencil, blendState);
 		} else {
 			// Until next time, force it off.
+			ResetShaderBlending();
 			gstate_c.allowShaderBlend = false;
 		}
 	} else if (blendState.resetShaderBlending) {

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -167,10 +167,12 @@ void TransformDrawEngine::ApplyDrawState(int prim) {
 
 	bool useBufferedRendering = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 
+	gstate_c.allowShaderBlend = !g_Config.bDisableSlowFramebufEffects;
+
 	// Do the large chunks of state conversion. We might be able to hide these two behind a dirty-flag each,
 	// to avoid recomputing heavy stuff unnecessarily every draw call.
 	GenericBlendState blendState;
-	ConvertBlendState(blendState);
+	ConvertBlendState(blendState, gstate_c.allowShaderBlend);
 	ViewportAndScissor vpAndScissor;
 	ConvertViewportAndScissor(useBufferedRendering,
 		framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),


### PR DESCRIPTION
As mentioned before, it's not implemented.  So we can't allow it, or it'll just blend wrong.  The `REPLACE_BLEND_COPY_FBO` case in the D3D9 shader generator is:

``` c++
        // Can do REPLACE_BLEND_COPY_FBO in ps_2_0, but need to apply viewport in the vertex shader
        // so that we can have the output position here to sample the texture at.
```

So it'll always replace the color, no blending, if it's enabled right now.

-[Unknown]
