### PR TITLE
Correct utilityData size calculation for "sizes" savedata call

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -209,9 +209,9 @@ int PSPSaveDialog::Init(int paramAddr)
 	StartFade(true);
 
 	/*INFO_LOG(SCEUTILITY,"Dump Param :");
-	INFO_LOG(SCEUTILITY,"size : %d",param.GetPspParam()->size);
-	INFO_LOG(SCEUTILITY,"language : %d",param.GetPspParam()->language);
-	INFO_LOG(SCEUTILITY,"buttonSwap : %d",param.GetPspParam()->buttonSwap);
+	INFO_LOG(SCEUTILITY,"size : %d",param.GetPspParam()->common.size);
+	INFO_LOG(SCEUTILITY,"language : %d",param.GetPspParam()->common.language);
+	INFO_LOG(SCEUTILITY,"buttonSwap : %d",param.GetPspParam()->common.buttonSwap);
 	INFO_LOG(SCEUTILITY,"result : %d",param.GetPspParam()->common.result);
 	INFO_LOG(SCEUTILITY,"mode : %d",param.GetPspParam()->mode);
 	INFO_LOG(SCEUTILITY,"bind : %d",param.GetPspParam()->bind);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -977,8 +977,21 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 	if (param->utilityData.IsValid())
 	{
 		int total_size = 0;
-		total_size += getSizeNormalized(1); // SFO;
-		total_size += getSizeNormalized((u32)param->dataSize == 0 ? 1 : (u32)param->dataSize); // Save Data
+
+		// The directory record itself.
+		// TODO: Account for number of files / actual record size?
+		total_size += getSizeNormalized(1);
+		// Account for the SFO (is this always 1 sector?)
+		total_size += getSizeNormalized(1);
+		// Add the size of the data itself (don't forget encryption overhead.)
+		// This is only added if a filename is specified.
+		if (param->fileName[0] != 0) {
+			if (g_Config.bEncryptSave) {
+				total_size += getSizeNormalized((u32)param->dataSize + 16);
+			} else {
+				total_size += getSizeNormalized((u32)param->dataSize);
+			}
+		}
 		total_size += getSizeNormalized(param->icon0FileData.size);
 		total_size += getSizeNormalized(param->icon1FileData.size);
 		total_size += getSizeNormalized(param->pic1FileData.size);


### PR DESCRIPTION
Should help #6068, which was verified by the sizes test and JpcspTrace results.  May help saving issues in other games.

I need to work out the best way to structure for pspautotests, but I proved out using tests:
- 32768 - 16 is the cutoff for 1 sector of data size, which makes sense since it needs 16 bytes overhead.
- size = 0 is counted as 16 bytes, even if the buffer is NULL.  So always >= 1 sector.
- No filename causes it to skip the data calculation.

Fieldrunners broke with a previous iteration of this, but it turns out it passes a NULL filename (which is why it doesn't count any sectors for the data.)

-[Unknown]
