### PR TITLE
Move SAS mixing to a thread

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -330,10 +330,14 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting(false),
 };
 
+static bool DefaultSasThread() {
+	return cpu_info.num_cores > 1;
+}
+
 static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("Jit", &g_Config.bJit, &DefaultJit, true, true),
 	ReportedConfigSetting("SeparateCPUThread", &g_Config.bSeparateCPUThread, false, true, true),
-	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, true, true, true),
+	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, &DefaultSasThread, true, true),
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -333,6 +333,7 @@ static ConfigSetting generalSettings[] = {
 static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("Jit", &g_Config.bJit, &DefaultJit, true, true),
 	ReportedConfigSetting("SeparateCPUThread", &g_Config.bSeparateCPUThread, false, true, true),
+	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, true, true, true),
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -119,8 +119,9 @@ public:
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;
-	int iIOTimingMethod;
+	bool bSeparateSASThread;
 	bool bSeparateIOThread;
+	int iIOTimingMethod;
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;
 	bool bCacheFullIsoInRam;

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -243,8 +243,7 @@ static u32 _sceSasCore(u32 core, u32 outAddr) {
 
 	__SasEnqueueMix(outAddr);
 
-	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
-	return hleLogSuccessI(SCESAS, hleDelayResult(0, "sas core", 240));
+	return hleLogSuccessI(SCESAS, hleDelayResult(0, "sas core", sas->EstimateMixUs()));
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
@@ -260,8 +259,7 @@ static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int right
 
 	__SasEnqueueMix(inoutAddr, inoutAddr, leftVolume, rightVolume);
 
-	// Actual delay time seems to between 240 and 1000 us, based on grain and possibly other factors.
-	return hleLogSuccessI(SCESAS, hleDelayResult(0, "sas core", 240));
+	return hleLogSuccessI(SCESAS, hleDelayResult(0, "sas core", sas->EstimateMixUs()));
 }
 
 static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -34,6 +34,7 @@
 #include "thread/thread.h"
 #include "thread/threadutil.h"
 #include "Common/Log.h"
+#include "Core/Config.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/MIPS/MIPS.h"
@@ -144,8 +145,12 @@ static void __SasEnqueueMix(u32 outAddr, u32 inAddr = 0, int leftVol = 0, int ri
 void __SasInit() {
 	sas = new SasInstance();
 
-	sasThreadState = SasThreadState::READY;
-	sasThread = new std::thread(__SasThread);
+	if (g_Config.bSeparateSASThread) {
+		sasThreadState = SasThreadState::READY;
+		sasThread = new std::thread(__SasThread);
+	} else {
+		sasThreadState = SasThreadState::DISABLED;
+	}
 }
 
 void __SasDoState(PointerWrap &p) {

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -153,6 +153,14 @@ void __SasDoState(PointerWrap &p) {
 	if (!s)
 		return;
 
+	if (sasThreadState == SasThreadState::QUEUED) {
+		// Wait for the queue to drain.  Don't want to save the wrong stuff.
+		sasDoneMutex.lock();
+		while (sasThreadState == SasThreadState::QUEUED)
+			sasDone.wait(sasDoneMutex);
+		sasDoneMutex.unlock();
+	}
+
 	p.DoClass(sas);
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -558,8 +558,6 @@ void SasInstance::MixVoice(SasVoice &voice) {
 }
 
 void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
-	PROFILE_THIS_SCOPE("mixer");
-
 	int voicesPlayingCount = 0;
 
 	for (int v = 0; v < PSP_SAS_VOICES_MAX; v++) {

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -408,6 +408,20 @@ void SasInstance::SetGrainSize(int newGrainSize) {
 	resampleBuffer = new s16[grainSize * 4 + 3];
 }
 
+int SasInstance::EstimateMixUs() {
+	int voicesPlayingCount = 0;
+
+	for (int v = 0; v < PSP_SAS_VOICES_MAX; v++) {
+		SasVoice &voice = voices[v];
+		if (!voice.playing || voice.paused)
+			continue;
+		voicesPlayingCount++;
+	}
+
+	// Each voice costs extra time, and each byte of grain costs extra time.
+	return 20 + voicesPlayingCount * 68 + (grainSize * 60) / 100;
+}
+
 void SasVoice::ReadSamples(s16 *output, int numSamples) {
 	// Read N samples into the resample buffer. Could do either PCM or VAG here.
 	switch (type) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -278,6 +278,7 @@ public:
 	void ClearGrainSize();
 	void SetGrainSize(int newGrainSize);
 	int GetGrainSize() const { return grainSize; }
+	int EstimateMixUs();
 
 	int maxVoices;
 	int sampleRate;

--- a/UI/ProfilerDraw.cpp
+++ b/UI/ProfilerDraw.cpp
@@ -15,9 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <inttypes.h>
 
+#include "gfx_es2/draw_buffer.h"
 #include "ui/ui_context.h"
+#include "ui/view.h"
 #include "profiler/profiler.h"
 
 static const uint32_t nice_colors[] = {


### PR DESCRIPTION
There are many improvements this could have, but this works as a baseline implementation.  It practically removes mixing from the main thread, so it should be a gain on multi-core CPUs, I hope.  Some games use it for background music and sound effects, where it can matter more.

Other possible improvements:
- More accuracy in Mix thread blocking delay.  In some cases we should wait longer (grain / # voices), which would likely give the thread more time to run.
- More accurate locking behavior: we've observed there's two sets of voice structs, so there might be more interesting behavior that can happen.  This opts to retain existing functionality.
- Busy error codes: I think ERROR_SAS_BUSY is used by some funcs when SAS is busy, rather than locking.

-[Unknown]
