### PR TITLE
Disallow HLE thread termination in interrupts

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2220,37 +2220,30 @@ int sceKernelTerminateDeleteThread(int threadID)
 	}
 }
 
-int sceKernelTerminateThread(SceUID threadID)
-{
-	if (threadID == 0 || threadID == currentThread)
-	{
-		ERROR_LOG(SCEKERNEL, "sceKernelTerminateThread(%i): cannot terminate current thread", threadID);
-		return SCE_KERNEL_ERROR_ILLEGAL_THID;
+int sceKernelTerminateThread(SceUID threadID) {
+	if (__IsInInterrupt() && sceKernelGetCompiledSdkVersion() >= 0x03080000) {
+		return hleLogError(SCEKERNEL, SCE_KERNEL_ERROR_ILLEGAL_CONTEXT, "in interrupt");
+	}
+	if (threadID == 0 || threadID == currentThread) {
+		return hleLogError(SCEKERNEL, SCE_KERNEL_ERROR_ILLEGAL_THID, "cannot terminate current thread");
 	}
 
 	u32 error;
 	Thread *t = kernelObjects.Get<Thread>(threadID, error);
-	if (t)
-	{
-		if (t->isStopped())
-		{
-			ERROR_LOG(SCEKERNEL, "sceKernelTerminateThread(%i): already stopped", threadID);
-			return SCE_KERNEL_ERROR_DORMANT;
+	if (t) {
+		if (t->isStopped()) {
+			return hleLogError(SCEKERNEL, SCE_KERNEL_ERROR_DORMANT, "already stopped");
 		}
 
-		INFO_LOG(SCEKERNEL, "sceKernelTerminateThread(%i)", threadID);
 		// TODO: Should this reschedule?  Seems like not.
 		__KernelStopThread(threadID, SCE_KERNEL_ERROR_THREAD_TERMINATED, "thread terminated");
 
 		// On terminate, we reset the thread priority.  On exit, we don't always (see __KernelResetThread.)
 		t->nt.currentPriority = t->nt.initialPriority;
 
-		return 0;
-	}
-	else
-	{
-		ERROR_LOG(SCEKERNEL, "sceKernelTerminateThread(%i): thread doesn't exist", threadID);
-		return error;
+		return hleLogSuccessInfoI(SCEKERNEL, 0);
+	} else {
+		return hleLogError(SCEKERNEL, error, "thread doesn't exist");
 	}
 }
 


### PR DESCRIPTION
But only for certain SDK versions, as per testing.

This can help make tests run more correctly, because our tests that run `checkpoint()` attempt to terminate a thread and re-start it in order to check rescheduling.  This is supposed to fail during an interrupt, but only in newer SDK versions.

-[Unknown]
