### PR TITLE
Correct state leakage on shader blend/self render

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1368,8 +1368,16 @@ void FramebufferManager::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int 
 		// Make sure our 2D drawing program is ready. Compiles only if not already compiled.
 		CompileDraw2DProgram();
 
-		glViewport(0, 0, dst->renderWidth, dst->renderHeight);
-		DisableState();
+		glstate.viewport.force(0, 0, dst->renderWidth, dst->renderHeight);
+		glstate.blend.force(false);
+		glstate.cullFace.force(false);
+		glstate.depthTest.force(false);
+		glstate.stencilTest.force(false);
+#if !defined(USING_GLES2)
+		glstate.colorLogicOp.force(false);
+#endif
+		glstate.colorMask.force(true, true, true, true);
+		glstate.stencilMask.force(0xFF);
 
 		// The first four coordinates are relative to the 6th and 7th arguments of DrawActiveTexture.
 		// Should maybe revamp that interface.
@@ -1379,6 +1387,15 @@ void FramebufferManager::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int 
 		glBindTexture(GL_TEXTURE_2D, 0);
 		textureCache_->ForgetLastTexture();
 		glstate.viewport.restore();
+		glstate.blend.restore();
+		glstate.cullFace.restore();
+		glstate.depthTest.restore();
+		glstate.stencilTest.restore();
+#if !defined(USING_GLES2)
+		glstate.colorLogicOp.restore();
+#endif
+		glstate.colorMask.restore();
+		glstate.stencilMask.restore();
 	}
 
 	glstate.scissorTest.restore();

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -384,8 +384,6 @@ void TransformDrawEngine::ApplyDrawStateLate() {
 			fragmentTestCache_->BindTestTexture(GL_TEXTURE2);
 		}
 
-		textureCache_->ApplyTexture();
-
 		if (fboTexNeedBind_) {
 			// Note that this is positions, not UVs, that we need the copy from.
 			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr, BINDFBCOLOR_MAY_COPY);
@@ -399,5 +397,9 @@ void TransformDrawEngine::ApplyDrawStateLate() {
 			fboTexBound_ = true;
 			fboTexNeedBind_ = false;
 		}
+
+		// Apply the texture after the FBO tex, since it might unbind the texture.
+		// TODO: Could use a separate texture unit to be safer?
+		textureCache_->ApplyTexture();
 	}
 }


### PR DESCRIPTION
Basically, for devices that don't natively support support blit, a bunch of state would get lost during the draw.  This could happen as the result of anything that attempted to blit.

As a reminder, scenarios in which we blit late in the flush:
- Shader blending that requires knowledge of the destination bits.
- Texturing from the same framebuffer as we're rendering to.

Unfortunately, I no longer have a GLES2 device to verify, but I expect #2917 may be resolved by this.  It looks right on desktop with blit and logic ops both disabled, at least.

-[Unknown]
