### PR TITLE
Improve and enable URL disk cache by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -923,6 +923,8 @@ add_library(native STATIC
 	ext/native/file/fd_util.h
 	ext/native/file/file_util.cpp
 	ext/native/file/file_util.h
+	ext/native/file/free.cpp
+	ext/native/file/free.h
 	ext/native/file/ini_file.cpp
 	ext/native/file/ini_file.h
 	ext/native/file/path.cpp

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -109,6 +109,7 @@ private:
 
 	u64 FreeDiskSpace();
 	u32 DetermineMaxBlocks();
+	u32 CountCachedFiles();
 	void GarbageCollectCacheFiles(u64 goalBytes);
 
 	// File format:

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -104,6 +104,7 @@ private:
 	void LoadCacheIndex();
 	void CreateCacheFile(const std::string &path);
 
+	u64 FreeDiskSpace();
 	u32 DetermineMaxBlocks();
 
 	// File format:

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -104,24 +104,27 @@ private:
 	void LoadCacheIndex();
 	void CreateCacheFile(const std::string &path);
 
+	u32 DetermineMaxBlocks();
+
 	// File format:
 	// 64 magic
 	// 32 version
 	// 32 blockSize
 	// 64 filesize
+	// 32 maxBlocks
 	// index[filesize / blockSize] <-- ~500 KB for 4GB
 	//   32 (fileoffset - headersize) / blockSize -> -1=not present
 	//   16 generation?
 	//   16 hits?
-	// blocks[MAX_BLOCKS]
+	// blocks[up to maxBlocks]
 	//   8 * blockSize
 
 	enum {
-		CACHE_VERSION = 1,
+		CACHE_VERSION = 2,
 		DEFAULT_BLOCK_SIZE = 65536,
 		MAX_BLOCKS_PER_READ = 16,
-		// TODO: Dynamic.
-		MAX_BLOCKS_CACHED = 4096, // 256 MB
+		MAX_BLOCKS_LOWER_BOUND = 256, // 16 MB
+		MAX_BLOCKS_UPPER_BOUND = 8192, // 512 MB
 		INVALID_BLOCK = 0xFFFFFFFF,
 		INVALID_INDEX = 0xFFFFFFFF,
 	};
@@ -131,6 +134,7 @@ private:
 	u32 blockSize_;
 	u16 generation_;
 	u16 oldestGeneration_;
+	u32 maxBlocks_;
 	size_t cacheSize_;
 	size_t indexCount_;
 	recursive_mutex lock_;
@@ -140,6 +144,7 @@ private:
 		u32_le version;
 		u32_le blockSize;
 		s64_le filesize;
+		s32_le maxBlocks;
 	};
 
 	struct BlockInfo {

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -96,7 +96,7 @@ private:
 	u32 AllocateBlock(u32 indexPos);
 
 	struct BlockInfo;
-	void ReadBlockData(u8 *dest, BlockInfo &info, size_t offset, size_t size);
+	bool ReadBlockData(u8 *dest, BlockInfo &info, size_t offset, size_t size);
 	void WriteBlockData(BlockInfo &info, u8 *src);
 	void WriteIndexData(u32 indexPos, BlockInfo &info);
 	s64 GetBlockOffset(u32 block);

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -47,6 +47,8 @@ public:
 	}
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
 
+	static std::vector<std::string> GetCachedPathsInUse();
+
 private:
 	void InitCache();
 	void ShutdownCache();
@@ -100,12 +102,14 @@ private:
 	s64 GetBlockOffset(u32 block);
 
 	std::string MakeCacheFilePath(const std::string &path);
+	std::string MakeCacheFilename(const std::string &path);
 	bool LoadCacheFile(const std::string &path);
 	void LoadCacheIndex();
 	void CreateCacheFile(const std::string &path);
 
 	u64 FreeDiskSpace();
 	u32 DetermineMaxBlocks();
+	void GarbageCollectCacheFiles(u64 goalBytes);
 
 	// File format:
 	// 64 magic
@@ -145,7 +149,7 @@ private:
 		u32_le version;
 		u32_le blockSize;
 		s64_le filesize;
-		s32_le maxBlocks;
+		u32_le maxBlocks;
 	};
 
 	struct BlockInfo {

--- a/Core/HW/SasReverb.cpp
+++ b/Core/HW/SasReverb.cpp
@@ -228,7 +228,7 @@ void SasReverb::ProcessReverb(int16_t *output, const int16_t *input, size_t inpu
 	// This runs at 22khz.
 	// Very unoptimized, straight from the description. Can probably be reformulated into something way more efficient.
 	// Or we could actually template the whole thing with the parameters as template arguments, as the presets are fixed.
-	for (int i = 0; i < inputSize; i++) {
+	for (size_t i = 0; i < inputSize; i++) {
 		// Dividing by two here is an incorrect hack. Some multiplication factor is needed to prevent the reverb from getting too loud, though.
 		int16_t LeftInput = input[i * 2] >> 1;
 		int16_t RightInput = input[i * 2 + 1] >> 1;

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -36,7 +36,7 @@
 
 FileLoader *ConstructFileLoader(const std::string &filename) {
 	if (filename.find("http://") == 0 || filename.find("https://") == 0)
-		return new CachingFileLoader(new RetryingFileLoader(new HTTPFileLoader(filename)));
+		return new CachingFileLoader(new DiskCachingFileLoader(new RetryingFileLoader(new HTTPFileLoader(filename))));
 	return new LocalFileLoader(filename);
 }
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -457,6 +457,9 @@ ReplaceBlendType ReplaceBlendWithShader(bool allowShaderBlend, GEBufferFormat bu
 			return REPLACE_BLEND_STANDARD;
 		}
 	}
+
+	// Should never get here.
+	return REPLACE_BLEND_STANDARD;
 }
 
 LogicOpReplaceType ReplaceLogicOpType() {

--- a/ext/native/Android.mk
+++ b/ext/native/Android.mk
@@ -41,6 +41,7 @@ LOCAL_SRC_FILES :=\
     file/fd_util.cpp \
     file/chunk_file.cpp \
     file/file_util.cpp \
+    file/free.cpp \
     file/path.cpp \
     file/ini_file.cpp \
     file/zip_read.cpp \

--- a/ext/native/file/CMakeLists.txt
+++ b/ext/native/file/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(SRCS
   chunk_file.cpp
   zip_read.cpp
-  file_util.cpp)
+  file_util.cpp
+  free.cpp)
 
 set(SRCS ${SRCS})
 

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -269,7 +269,7 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 			(virtualName[2] == '\0')))
 			continue;
 
-		// Remove dotfiles (should be made optional?)
+		// Remove dotfiles (optional with flag.)
 		if (!(flags & GETFILES_GETHIDDEN) && virtualName[0] == '.')
 			continue;
 

--- a/ext/native/file/free.cpp
+++ b/ext/native/file/free.cpp
@@ -1,0 +1,56 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <sys/stat.h>
+#else
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#if defined(ANDROID)
+#include <sys/types.h>
+#include <sys/vfs.h>
+#define statvfs statfs
+#elif defined(__SYMBIAN32__)
+#include <mw/QSystemStorageInfo>
+QTM_USE_NAMESPACE
+#else
+#include <sys/statvfs.h>
+#endif
+#include <ctype.h>
+#include <fcntl.h>
+#endif
+
+#include "base/basictypes.h"
+#include "util/text/utf8.h"
+
+bool free_disk_space(const std::string &dir, uint64_t &space) {
+#ifdef _WIN32
+	const std::wstring w32path = ConvertUTF8ToWString(dir);
+	ULARGE_INTEGER free;
+	if (GetDiskFreeSpaceExW(w32path.c_str(), &free, nullptr, nullptr)) {
+		space = free.QuadPart;
+		return true;
+	}
+#elif defined(__SYMBIAN32__)
+	QSystemStorageInfo storageInfo;
+	space = (uint64_t)storageInfo.availableDiskSpace("E");
+	return true;
+#else
+	struct statvfs diskstat;
+	int res = statvfs(dir.c_str(), &diskstat);
+
+	if (res == 0) {
+#ifndef ANDROID
+		if (diskstat.f_flag & ST_RDONLY) {
+			space = 0;
+			return true;
+		}
+#endif
+		space = (uint64_t)diskstat.f_bavail * (uint64_t)diskstat.f_frsize;
+		return true;
+	}
+#endif
+
+	// We can't know how much is free.
+	return false;
+}

--- a/ext/native/file/free.h
+++ b/ext/native/file/free.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+#include "base/basictypes.h"
+
+bool free_disk_space(const std::string &dir, uint64_t &space);

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -226,6 +226,7 @@
     <ClInclude Include="file\ini_file.h" />
     <ClInclude Include="file\vfs.h" />
     <ClInclude Include="file\zip_read.h" />
+    <ClInclude Include="file\free.h" />
     <ClInclude Include="gfx\gl_common.h" />
     <ClInclude Include="gfx\gl_debug_log.h" />
     <ClInclude Include="gfx\gl_lost_manager.h" />
@@ -680,6 +681,7 @@
     <ClCompile Include="file\path.cpp" />
     <ClCompile Include="file\ini_file.cpp" />
     <ClCompile Include="file\zip_read.cpp" />
+    <ClCompile Include="file\free.cpp" />
     <ClCompile Include="gfx\gl_debug_log.cpp" />
     <ClCompile Include="gfx\gl_lost_manager.cpp" />
     <ClCompile Include="gfx\texture_atlas.cpp" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -302,6 +302,9 @@
     <ClInclude Include="input\keycodes.h">
       <Filter>input</Filter>
     </ClInclude>
+    <ClInclude Include="file\free.h">
+      <Filter>file</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">
@@ -735,6 +738,9 @@
     </ClCompile>
     <ClCompile Include="base\QtMain.cpp">
       <Filter>base</Filter>
+    </ClCompile>
+    <ClCompile Include="file\free.cpp">
+      <Filter>file</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This measures free space to determine:
- If there's enough free space to enable disk caching (requires at least 768 MB free PLUS disk cache filesize.)
- Garbage collects cache files when attempting to create new cache files.
- Dynamically sizes the cache files based on available space, attempting to allow for multiple cache files.
- Should detect failure on any unexpected out of disk space and failover to source (disable cache.)

It can be improved more, but I think it's good enough to enable by default now.  I do rely on the OS freeing the cache space (this happens automatically on Android, AFAIU, and we store in its cache dir) if it runs low.

This properly integrates with the Android UI; e.g. I see that the app is using 51 MB of cache space and can clear it.

-[Unknown]
