### PR TITLE
Don't clear at the start of frame, only when it's time to actually draw to the backbuffer 

### DIFF
--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -424,6 +424,7 @@ void FramebufferManager::DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY,
 }
 
 void FramebufferManager::DrawFramebufferToOutput(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader) {
+
 	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, 512, 272);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_Config.iTexFiltering == TEX_FILTER_NEAREST ? GL_NEAREST : GL_LINEAR);
 
@@ -973,6 +974,15 @@ struct CardboardSettings * FramebufferManager::GetCardboardSettings(struct Cardb
 void FramebufferManager::CopyDisplayToOutput() {
 	fbo_unbind();
 	glstate.viewport.set(0, 0, pixelWidth_, pixelHeight_);
+
+	if (useBufferedRendering_) {
+		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+		glClearDepth(0.0f);
+		glClearStencil(0);
+		// Hardly necessary to clear depth and stencil I guess...
+		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+	}
+
 	currentRenderVfb_ = 0;
 
 	u32 offsetX = 0;

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -977,7 +977,11 @@ void FramebufferManager::CopyDisplayToOutput() {
 
 	if (useBufferedRendering_) {
 		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-		glClearDepth(0.0f);
+#ifdef USING_GLES2
+		glClearDepthf(0.0f);
+#else
+		glClearDepth(0.0);
+#endif
 		glClearStencil(0);
 		// Hardly necessary to clear depth and stencil I guess...
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -815,7 +815,7 @@ void ShaderListScreen::CreateViews() {
 	layout->Add(tabs_);
 	layout->Add(new Button(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 
-	for (int i = 0; i < ARRAY_SIZE(shaderTypes); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(shaderTypes); i++) {
 		ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
 		LinearLayout *shaderList = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
 		ListShaders(shaderTypes[i].type, shaderList);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -90,8 +90,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 
 	//pre-emptive loading of game specific config if possible, to get all the settings
 	GameInfo *info = g_gameInfoCache.GetInfo(NULL, filename, 0);
-	if (info && !info->id.empty())
-	{
+	if (info && !info->id.empty()) {
 		g_Config.loadGameConfig(info->id);
 	}
 
@@ -970,4 +969,10 @@ void EmuScreen::releaseButtons() {
 	input.timestamp = time_now_d();
 	input.id = 0;
 	touch(input);
+}
+
+int EmuScreen::expects() const {
+	// We only want the framework to clear for us when we are running non-buffered. Otherwise, it's a complete waste of time
+	// to clear the backbuffer only to then go off rendering to another buffer. Better to clear when we are actually copying the final image instead.
+	return (g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) ? (SCREEN_EXPECTS_CLEAR | SCREEN_EXPECTS_VIEWPORT) : 0;
 }

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -45,8 +45,6 @@ public:
 	bool key(const KeyInput &key) override;
 	bool axis(const AxisInput &axis) override;
 
-	int expects() const override;
-
 protected:
 	void CreateViews() override;
 	UI::EventReturn OnDevTools(UI::EventParams &params);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -35,18 +35,20 @@ public:
 	EmuScreen(const std::string &filename);
 	~EmuScreen();
 
-	virtual void update(InputState &input) override;
-	virtual void render() override;
-	virtual void deviceLost() override;
-	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
-	virtual void sendMessage(const char *msg, const char *value) override;
+	void update(InputState &input) override;
+	void render() override;
+	void deviceLost() override;
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void sendMessage(const char *msg, const char *value) override;
 
-	virtual bool touch(const TouchInput &touch) override;
-	virtual bool key(const KeyInput &key) override;
-	virtual bool axis(const AxisInput &axis) override;
+	bool touch(const TouchInput &touch) override;
+	bool key(const KeyInput &key) override;
+	bool axis(const AxisInput &axis) override;
+
+	int expects() const override;
 
 protected:
-	virtual void CreateViews() override;
+	void CreateViews() override;
 	UI::EventReturn OnDevTools(UI::EventParams &params);
 
 private:

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -694,18 +694,6 @@ void DrawDownloadsOverlay(UIContext &dc) {
 void NativeRender() {
 	g_GameManager.Update();
 
-	thin3d->Clear(T3DClear::COLOR | T3DClear::DEPTH | T3DClear::STENCIL, 0xFF000000, 0.0f, 0);
-
-	T3DViewport viewport;
-	viewport.TopLeftX = 0;
-	viewport.TopLeftY = 0;
-	viewport.Width = pixel_xres;
-	viewport.Height = pixel_yres;
-	viewport.MaxDepth = 1.0;
-	viewport.MinDepth = 0.0;
-	thin3d->SetViewports(1, &viewport);
-	thin3d->SetTargetSize(pixel_xres, pixel_yres);
-
 	float xres = dp_xres;
 	float yres = dp_yres;
 

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -1,3 +1,4 @@
+#include "base/display.h"
 #include "base/logging.h"
 #include "input/input_state.h"
 #include "ui/screen.h"
@@ -98,6 +99,24 @@ void ScreenManager::resized() {
 
 void ScreenManager::render() {
 	if (!stack_.empty()) {
+		int expects = stack_.back().screen->expects();
+
+		if (expects & SCREEN_EXPECTS_CLEAR) {
+			thin3DContext_->Clear(T3DClear::COLOR | T3DClear::DEPTH | T3DClear::STENCIL, 0xFF000000, 0.0f, 0);
+		}
+
+		if (expects & SCREEN_EXPECTS_VIEWPORT) {
+			T3DViewport viewport;
+			viewport.TopLeftX = 0;
+			viewport.TopLeftY = 0;
+			viewport.Width = pixel_xres;
+			viewport.Height = pixel_yres;
+			viewport.MaxDepth = 1.0;
+			viewport.MinDepth = 0.0;
+			thin3DContext_->SetViewports(1, &viewport);
+			thin3DContext_->SetTargetSize(pixel_xres, pixel_yres);
+		}
+
 		switch (stack_.back().flags) {
 		case LAYER_SIDEMENU:
 		case LAYER_TRANSPARENT:

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -99,24 +99,6 @@ void ScreenManager::resized() {
 
 void ScreenManager::render() {
 	if (!stack_.empty()) {
-		int expects = stack_.back().screen->expects();
-
-		if (expects & SCREEN_EXPECTS_CLEAR) {
-			thin3DContext_->Clear(T3DClear::COLOR | T3DClear::DEPTH | T3DClear::STENCIL, 0xFF000000, 0.0f, 0);
-		}
-
-		if (expects & SCREEN_EXPECTS_VIEWPORT) {
-			T3DViewport viewport;
-			viewport.TopLeftX = 0;
-			viewport.TopLeftY = 0;
-			viewport.Width = pixel_xres;
-			viewport.Height = pixel_yres;
-			viewport.MaxDepth = 1.0;
-			viewport.MinDepth = 0.0;
-			thin3DContext_->SetViewports(1, &viewport);
-			thin3DContext_->SetTargetSize(pixel_xres, pixel_yres);
-		}
-
 		switch (stack_.back().flags) {
 		case LAYER_SIDEMENU:
 		case LAYER_TRANSPARENT:
@@ -128,13 +110,19 @@ void ScreenManager::render() {
 				iter--;
 				iter--;
 				Layer backback = *iter;
-				// Also shift to the right somehow...
+
+				// TODO: Make really sure that this "mismatched" pre/post only happens
+				// when screens are "compatible" (both are UIScreens, for example).
+				backback.screen->preRender();
 				backback.screen->render();
 				stack_.back().screen->render();
+				stack_.back().screen->postRender();
 				break;
 			}
 		default:
+			stack_.back().screen->preRender();
 			stack_.back().screen->render();
+			stack_.back().screen->postRender();
 			break;
 		}
 	} else {

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -33,6 +33,12 @@ enum DialogResult {
 	DR_BACK,
 };
 
+
+enum {
+	SCREEN_EXPECTS_VIEWPORT = 1 << 0,
+	SCREEN_EXPECTS_CLEAR = 1 << 1,
+};
+
 class ScreenManager;
 class UIContext;
 class Thin3DContext;
@@ -68,6 +74,8 @@ public:
 
 	virtual bool isTransparent() const { return false; }
 	virtual bool isTopLevel() const { return false; }
+
+	virtual int expects() const { return SCREEN_EXPECTS_VIEWPORT | SCREEN_EXPECTS_CLEAR; }
 
 private:
 	ScreenManager *screenManager_;

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -33,12 +33,6 @@ enum DialogResult {
 	DR_BACK,
 };
 
-
-enum {
-	SCREEN_EXPECTS_VIEWPORT = 1 << 0,
-	SCREEN_EXPECTS_CLEAR = 1 << 1,
-};
-
 class ScreenManager;
 class UIContext;
 class Thin3DContext;
@@ -52,7 +46,9 @@ public:
 
 	virtual void onFinish(DialogResult reason) {}
 	virtual void update(InputState &input) {}
+	virtual void preRender() {}
 	virtual void render() {}
+	virtual void postRender() {}
 	virtual void deviceLost() {}
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
@@ -74,8 +70,6 @@ public:
 
 	virtual bool isTransparent() const { return false; }
 	virtual bool isTopLevel() const { return false; }
-
-	virtual int expects() const { return SCREEN_EXPECTS_VIEWPORT | SCREEN_EXPECTS_CLEAR; }
 
 private:
 	ScreenManager *screenManager_;

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -1,3 +1,4 @@
+#include "base/display.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "ui/ui_screen.h"
@@ -34,6 +35,24 @@ void UIScreen::update(InputState &input) {
 	if (root_) {
 		UpdateViewHierarchy(input, root_);
 	}
+}
+
+void UIScreen::preRender() {
+	Thin3DContext *thin3d = screenManager()->getThin3DContext();
+	thin3d->Clear(T3DClear::COLOR | T3DClear::DEPTH | T3DClear::STENCIL, 0xFF000000, 0.0f, 0);
+
+	T3DViewport viewport;
+	viewport.TopLeftX = 0;
+	viewport.TopLeftY = 0;
+	viewport.Width = pixel_xres;
+	viewport.Height = pixel_yres;
+	viewport.MaxDepth = 1.0;
+	viewport.MinDepth = 0.0;
+	thin3d->SetViewports(1, &viewport);
+	thin3d->SetTargetSize(pixel_xres, pixel_yres);
+}
+
+void UIScreen::postRender() {
 }
 
 void UIScreen::render() {

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -12,7 +12,9 @@ public:
 	~UIScreen();
 
 	virtual void update(InputState &input) override;
+	virtual void preRender() override;
 	virtual void render() override;
+	virtual void postRender() override;
 
 	virtual bool touch(const TouchInput &touch) override;
 	virtual bool key(const KeyInput &touch) override;


### PR DESCRIPTION
Should help tiler GPUs like PowerVR and Mali a little bit in buffered rendering, and there's no reason this should slow down any other devices. Have not been able to measure any large boosts, but either way, this is the right way to order things.
