### PR TITLE
Zero deleted objects in the kernel object pool

### DIFF
--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -423,6 +423,7 @@ public:
 	}
 };
 
+// TODO: Delete the "occupied" array, rely on non-zero pool entries?
 class KernelObjectPool {
 public:
 	KernelObjectPool();
@@ -440,6 +441,8 @@ public:
 		if (Get<T>(handle, error)) {
 			occupied[handle-handleOffset] = false;
 			delete pool[handle-handleOffset];
+			// Why weren't we zeroing before?
+			pool[handle-handleOffset] = nullptr;
 		}
 		return error;
 	};


### PR DESCRIPTION
Just doing this to narrow down the possible causes of our crashes in WaitSema/SignalSema that I can't reproduce and only have Android auto-reports of... The crash comments do mention the GTA games though.
