### PR TITLE
Initial CPU side render-to-clut handling

### DIFF
--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -29,6 +29,7 @@ enum {
 	FB_USAGE_DISPLAYED_FRAMEBUFFER = 1,
 	FB_USAGE_RENDERTARGET = 2,
 	FB_USAGE_TEXTURE = 4,
+	FB_USAGE_CLUT = 8,
 };
 
 enum {
@@ -55,6 +56,7 @@ struct VirtualFramebuffer {
 	int last_frame_attached;
 	int last_frame_render;
 	int last_frame_displayed;
+	int last_frame_clut;
 	bool memoryUpdated;
 	bool depthUpdated;
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -61,7 +61,7 @@ namespace DX9 {
 #define TEXCACHE_MIN_PRESSURE 16 * 1024 * 1024  // Total in VRAM
 #define TEXCACHE_SECOND_MIN_PRESSURE 4 * 1024 * 1024
 
-TextureCacheDX9::TextureCacheDX9() : cacheSizeEstimate_(0), secondCacheSizeEstimate_(0), clearCacheNextFrame_(false), lowMemoryMode_(false), clutBuf_(NULL), clutMaxBytes_(0), texelsScaledThisFrame_(0) {
+TextureCacheDX9::TextureCacheDX9() : cacheSizeEstimate_(0), secondCacheSizeEstimate_(0), clearCacheNextFrame_(false), lowMemoryMode_(false), clutBuf_(NULL), clutMaxBytes_(0), clutRenderAddress_(0), texelsScaledThisFrame_(0) {
 	timesInvalidatedAllThisFrame_ = 0;
 	lastBoundTexture = INVALID_TEX;
 	decimationCounter_ = TEXCACHE_DECIMATION_INTERVAL;
@@ -783,6 +783,7 @@ void TextureCacheDX9::LoadClut(u32 clutAddr, u32 loadBytes) {
 	clutAddr = clutAddr & 0x3FFFFFFF;
 	bool foundFramebuffer = false;
 
+	clutRenderAddress_ = 0;
 	for (size_t i = 0, n = fbCache_.size(); i < n; ++i) {
 		auto framebuffer = fbCache_[i];
 		if ((framebuffer->fb_address | 0x04000000) == clutAddr) {
@@ -790,6 +791,7 @@ void TextureCacheDX9::LoadClut(u32 clutAddr, u32 loadBytes) {
 			framebuffer->usageFlags |= FB_USAGE_CLUT;
 			foundFramebuffer = true;
 			WARN_LOG_REPORT_ONCE(clutrenderdx9, G3D, "Using rendered CLUT for texture decode at %08x (%dx%dx%d)", clutAddr, framebuffer->width, framebuffer->height, framebuffer->colorDepth);
+			clutRenderAddress_ = framebuffer->fb_address;
 		}
 	}
 
@@ -1185,6 +1187,10 @@ void TextureCacheDX9::SetTexture(bool force) {
 		// Check for FBO - slow!
 		if (entry->framebuffer) {
 			if (match) {
+				if (hasClut && clutRenderAddress_ != 0) {
+					WARN_LOG_REPORT_ONCE(clutAndTexRender, G3D, "Using rendered texture with rendered CLUT: texfmt=%d, clutfmt=%d", gstate.getTextureFormat(), gstate.getClutPaletteFormat());
+				}
+
 				SetTextureFramebuffer(entry, entry->framebuffer);
 				entry->lastFrame = gpuStats.numFlips;
 				return;
@@ -1348,6 +1354,10 @@ void TextureCacheDX9::SetTexture(bool force) {
 		VERBOSE_LOG(G3D, "No texture in cache, decoding...");
 		TexCacheEntry entryNew = {0};
 		cache[cachekey] = entryNew;
+
+		if (hasClut && clutRenderAddress_ != 0) {
+			WARN_LOG_REPORT_ONCE(clutUseRender, G3D, "Using texture with rendered CLUT: texfmt=%d, clutfmt=%d", gstate.getTextureFormat(), gstate.getClutPaletteFormat());
+		}
 
 		entry = &cache[cachekey];
 		if (g_Config.bTextureBackoffCache) {

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -789,6 +789,7 @@ void TextureCacheDX9::LoadClut(u32 clutAddr, u32 loadBytes) {
 			framebuffer->last_frame_clut = gpuStats.numFlips;
 			framebuffer->usageFlags |= FB_USAGE_CLUT;
 			foundFramebuffer = true;
+			WARN_LOG_REPORT_ONCE(clutrenderdx9, G3D, "Using rendered CLUT for texture decode at %08x (%dx%dx%d)", clutAddr, framebuffer->width, framebuffer->height, framebuffer->colorDepth);
 		}
 	}
 
@@ -796,7 +797,7 @@ void TextureCacheDX9::LoadClut(u32 clutAddr, u32 loadBytes) {
 	if (Memory::IsValidAddress(clutAddr)) {
 		// It's possible for a game to (successfully) access outside valid memory.
 		u32 bytes = Memory::ValidSize(clutAddr, loadBytes);
-		if (foundFramebuffer) {
+		if (foundFramebuffer && !g_Config.bDisableSlowFramebufEffects) {
 			gpu->PerformMemoryDownload(clutAddr, bytes);
 		}
 

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -150,6 +150,7 @@ private:
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
+	u32 clutRenderAddress_;
 
 	LPDIRECT3DTEXTURE9 lastBoundTexture;
 	float maxAnisotropyLevel;

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -811,6 +811,7 @@ void TextureCache::LoadClut(u32 clutAddr, u32 loadBytes) {
 			framebuffer->last_frame_clut = gpuStats.numFlips;
 			framebuffer->usageFlags |= FB_USAGE_CLUT;
 			foundFramebuffer = true;
+			WARN_LOG_REPORT_ONCE(clutrender, G3D, "Using rendered CLUT for texture decode at %08x (%dx%dx%d)", clutAddr, framebuffer->width, framebuffer->height, framebuffer->colorDepth);
 		}
 	}
 
@@ -818,7 +819,7 @@ void TextureCache::LoadClut(u32 clutAddr, u32 loadBytes) {
 	if (Memory::IsValidAddress(clutAddr)) {
 		// It's possible for a game to (successfully) access outside valid memory.
 		u32 bytes = Memory::ValidSize(clutAddr, loadBytes);
-		if (foundFramebuffer) {
+		if (foundFramebuffer && !g_Config.bDisableSlowFramebufEffects) {
 			gpu->PerformMemoryDownload(clutAddr, bytes);
 		}
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -801,10 +801,27 @@ static inline u32 QuickTexHash(u32 addr, int bufw, int w, int h, GETextureFormat
 }
 
 void TextureCache::LoadClut(u32 clutAddr, u32 loadBytes) {
+	// Clear the uncached bit, etc. to match framebuffers.
+	clutAddr = clutAddr & 0x3FFFFFFF;
+	bool foundFramebuffer = false;
+
+	for (size_t i = 0, n = fbCache_.size(); i < n; ++i) {
+		auto framebuffer = fbCache_[i];
+		if ((framebuffer->fb_address | 0x04000000) == clutAddr) {
+			framebuffer->last_frame_clut = gpuStats.numFlips;
+			framebuffer->usageFlags |= FB_USAGE_CLUT;
+			foundFramebuffer = true;
+		}
+	}
+
 	clutTotalBytes_ = loadBytes;
 	if (Memory::IsValidAddress(clutAddr)) {
 		// It's possible for a game to (successfully) access outside valid memory.
 		u32 bytes = Memory::ValidSize(clutAddr, loadBytes);
+		if (foundFramebuffer) {
+			gpu->PerformMemoryDownload(clutAddr, bytes);
+		}
+
 #ifdef _M_SSE
 		int numBlocks = bytes / 16;
 		if (bytes == loadBytes) {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -152,6 +152,7 @@ private:
 	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
 	bool clutAlphaLinear_;
 	u16 clutAlphaLinearColor_;
+	u32 clutRenderAddress_;
 
 	u32 lastBoundTexture;
 	float maxAnisotropyLevel;


### PR DESCRIPTION
I know this helps Brave Story and Kurohyou.  This is the simple fix, but obviously "doing it right" means doing it on the GPU.

But I want to collect some metrics first on how common this is and what formats of CLUTs are used, and what games are affected.

I'm thinking I would expand 4 bit textures to 8, and shrink all other textures to 8, still on the CPU side.  This way I could upload an R-only texture, and use that fairly directly for the clut offset.  Would need to flag the texture cache entry, so that it gets re-uploaded if the framebuffer goes away, etc., but the semantics of the texture cache (except alpha and cluthash) should still work.

If a render-to-clut is used with a render-to-tex, that will be interesting.  I might just download in that case unless we get reports.

-[Unknown]
