### PR TITLE
Enable EXT_blend_func_extended

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -88,7 +88,10 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 		highpTexcoord = highpFog;
 
 		if (gstate_c.featureFlags & GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH) {
-			if (gl_extensions.EXT_shader_framebuffer_fetch) {
+			if (gl_extensions.GLES3 && gl_extensions.EXT_shader_framebuffer_fetch) {
+				WRITE(p, "#extension GL_EXT_shader_framebuffer_fetch : require\n");
+				lastFragData = "fragColor0";
+			} else if (gl_extensions.EXT_shader_framebuffer_fetch) {
 				WRITE(p, "#extension GL_EXT_shader_framebuffer_fetch : require\n");
 				lastFragData = "gl_LastFragData[0]";
 			} else if (gl_extensions.NV_shader_framebuffer_fetch) {
@@ -252,12 +255,16 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	}
 
 	if (!strcmp(fragColor0, "fragColor0")) {
+		const char *qualifierColor0 = "out";
+		if (lastFragData && !strcmp(lastFragData, fragColor0)) {
+			qualifierColor0 = "inout";
+		}
 		// Output the output color definitions.
 		if (stencilToAlpha == REPLACE_ALPHA_DUALSOURCE) {
-			WRITE(p, "out vec4 fragColor0;\n");
+			WRITE(p, "%s vec4 fragColor0;\n", qualifierColor0);
 			WRITE(p, "out vec4 fragColor1;\n");
 		} else {
-			WRITE(p, "out vec4 fragColor0;\n");
+			WRITE(p, "%s vec4 fragColor0;\n", qualifierColor0);
 		}
 	}
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -471,7 +471,7 @@ GLES_GPU::~GLES_GPU() {
 // Take the raw GL extension and versioning data and turn into feature flags.
 void GLES_GPU::CheckGPUFeatures() {
 	u32 features = 0;
-	if (gl_extensions.ARB_blend_func_extended /*|| gl_extensions.EXT_blend_func_extended*/) {
+	if (gl_extensions.ARB_blend_func_extended || gl_extensions.EXT_blend_func_extended) {
 		if (gl_extensions.gpuVendor == GPU_VENDOR_INTEL || !gl_extensions.VersionGEThan(3, 0, 0)) {
 			// Don't use this extension to off on sub 3.0 OpenGL versions as it does not seem reliable
 			// Also on Intel, see https://github.com/hrydgard/ppsspp/issues/4867

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -107,13 +107,20 @@ LinkedShader::LinkedShader(Shader *vs, Shader *fs, u32 vertType, bool useHWTrans
 	glBindAttribLocation(program, ATTR_COLOR0, "color0");
 	glBindAttribLocation(program, ATTR_COLOR1, "color1");
 
-#ifndef USING_GLES2
+#if !defined(USING_GLES2)
 	if (gstate_c.featureFlags & GPU_SUPPORTS_DUALSOURCE_BLEND) {
 		// Dual source alpha
 		glBindFragDataLocationIndexed(program, 0, 0, "fragColor0");
 		glBindFragDataLocationIndexed(program, 0, 1, "fragColor1");
 	} else if (gl_extensions.VersionGEThan(3, 3, 0)) {
 		glBindFragDataLocation(program, 0, "fragColor0");
+	}
+#elif !defined(IOS)
+	if (gl_extensions.GLES3) {
+		if (gstate_c.featureFlags & GPU_SUPPORTS_DUALSOURCE_BLEND) {
+			glBindFragDataLocationIndexedEXT(program, 0, 0, "fragColor0");
+			glBindFragDataLocationIndexedEXT(program, 0, 1, "fragColor1");
+		}
 	}
 #endif
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -54,6 +54,9 @@ static const GLushort glBlendFactorLookup[(size_t)BlendFactor::COUNT] = {
 #if !defined(USING_GLES2)   // TODO: Remove when we have better headers
 	GL_SRC1_ALPHA,
 	GL_ONE_MINUS_SRC1_ALPHA,
+#elif !defined(IOS)
+	GL_SRC1_ALPHA_EXT,
+	GL_ONE_MINUS_SRC1_ALPHA_EXT,
 #else
 	GL_INVALID_ENUM,
 	GL_INVALID_ENUM,

--- a/ext/native/gfx_es2/gl3stub.c
+++ b/ext/native/gfx_es2/gl3stub.c
@@ -128,6 +128,13 @@ GLboolean gl3stubInit() {
     FIND_PROC(glTexStorage2D);
     FIND_PROC(glTexStorage3D);
     FIND_PROC(glGetInternalformativ);
+
+    /* EXT_blend_func_extended */
+    FIND_PROC(glBindFragDataLocationIndexedEXT);
+    FIND_PROC(glBindFragDataLocationEXT);
+    FIND_PROC(glGetProgramResourceLocationIndexEXT);
+    FIND_PROC(glGetFragDataIndexEXT);
+
     #undef FIND_PROC
 
 #endif // IOS
@@ -349,6 +356,12 @@ GL_APICALL void           (* GL_APIENTRY glInvalidateSubFramebuffer) (GLenum tar
 GL_APICALL void           (* GL_APIENTRY glTexStorage2D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
 GL_APICALL void           (* GL_APIENTRY glTexStorage3D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 GL_APICALL void           (* GL_APIENTRY glGetInternalformativ) (GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint* params);
+
+/* EXT_blend_func_extended */
+GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationIndexedEXT) (GLuint program, GLuint colorNumber, GLuint index, const GLchar *name);
+GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationEXT) (GLuint program, GLuint color, const GLchar *name);
+GL_APICALL GLint          (* GL_APIENTRY glGetProgramResourceLocationIndexEXT) (GLuint program, GLenum programInterface, const GLchar *name);
+GL_APICALL GLint          (* GL_APIENTRY glGetFragDataIndexEXT) (GLuint program, const GLchar *name);
 
 #endif // IOS
 

--- a/ext/native/gfx_es2/gl3stub.h
+++ b/ext/native/gfx_es2/gl3stub.h
@@ -373,6 +373,16 @@ typedef struct __GLsync *GLsync;
 #define GL_NUM_SAMPLE_COUNTS                             0x9380
 #define GL_TEXTURE_IMMUTABLE_LEVELS                      0x82DF
 
+/* EXT_blend_func_extended */
+
+#define GL_SRC1_COLOR_EXT                                0x88F9
+#define GL_SRC1_ALPHA_EXT                                0x8589
+#define GL_ONE_MINUS_SRC1_COLOR_EXT                      0x88FA
+#define GL_ONE_MINUS_SRC1_ALPHA_EXT                      0x88FB
+#define GL_SRC_ALPHA_SATURATE_EXT                        0x0308
+#define GL_LOCATION_INDEX_EXT                            0x930F
+#define GL_MAX_DUAL_SOURCE_DRAW_BUFFERS_EXT              0x88FC
+
 /*-------------------------------------------------------------------------
  * Entrypoint definitions
  *-----------------------------------------------------------------------*/
@@ -483,6 +493,13 @@ extern GL_APICALL void           (* GL_APIENTRY glInvalidateSubFramebuffer) (GLe
 extern GL_APICALL void           (* GL_APIENTRY glTexStorage2D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
 extern GL_APICALL void           (* GL_APIENTRY glTexStorage3D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 extern GL_APICALL void           (* GL_APIENTRY glGetInternalformativ) (GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint* params);
+
+/* EXT_blend_func_extended */
+extern GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationIndexedEXT) (GLuint program, GLuint colorNumber, GLuint index, const GLchar *name);
+extern GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationEXT) (GLuint program, GLuint color, const GLchar *name);
+extern GL_APICALL GLint          (* GL_APIENTRY glGetProgramResourceLocationIndexEXT) (GLuint program, GLenum programInterface, const GLchar *name);
+extern GL_APICALL GLint          (* GL_APIENTRY glGetFragDataIndexEXT) (GLuint program, const GLchar *name);
+
     
 #endif   // IOS
 


### PR DESCRIPTION
Not really tested.  The IOS define is because I don't expect iOS headers to be updated yet.

https://www.khronos.org/registry/gles/extensions/EXT/EXT_blend_func_extended.txt

Also, used an `inout` qualifier for `EXT_shader_framebuffer_fetch`.  This was definitely breaking it on PowerVR Rogue (have no information on if it would work with this change or not), per some logs - shader compile errors.

-[Unknown]
