### PR TITLE
Mutex around PBP file access

### DIFF
--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -344,9 +344,12 @@ bool CISOFileBlockDevice::ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
 }
 
 
+recursive_mutex NPDRMDemoBlockDevice::mutex_;
+
 NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FileLoader *fileLoader)
 	: fileLoader_(fileLoader)
 {
+	lock_guard guard(mutex_);
 	MAC_KEY mkey;
 	CIPHER_KEY ckey;
 	u8 np_header[256];
@@ -412,6 +415,7 @@ NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FileLoader *fileLoader)
 
 NPDRMDemoBlockDevice::~NPDRMDemoBlockDevice()
 {
+	lock_guard guard(mutex_);
 	delete [] table;
 	delete [] tempBuf;
 	delete [] blockBuf;
@@ -421,6 +425,7 @@ int lzrc_decompress(void *out, int out_len, void *in, int in_len);
 
 bool NPDRMDemoBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 {
+	lock_guard guard(mutex_);
 	CIPHER_KEY ckey;
 	int block, lba, lzsize;
 	size_t readSize;

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -25,6 +25,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/ELF/PBPReader.h"
+#include "base/mutex.h"
 
 class FileLoader;
 
@@ -106,6 +107,7 @@ public:
 
 private:
 	FileLoader *fileLoader_;
+	static recursive_mutex mutex_;
 	u32 lbaSize;
 
 	u32 psarOffset;


### PR DESCRIPTION
There's some thread safety issue in there, this makes it so we can read thumbnails without crashing sometimes - should fix #7330.

-[Unknown]
