### PR TITLE
adds missing button for wii-u pro gamepad, DPAD_RIGHT

### DIFF
--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -78,6 +78,7 @@ private:
 		SDLJoyButtonMap[13] = NKCODE_BUTTON_4;
 		SDLJoyButtonMap[14] = NKCODE_BUTTON_1;
 		SDLJoyButtonMap[15] = NKCODE_BUTTON_11;
+		SDLJoyButtonMap[16] = NKCODE_BUTTON_12;
 
 		SDLJoyAxisMap[0] = JOYSTICK_AXIS_X;
 		SDLJoyAxisMap[1] = JOYSTICK_AXIS_Y;


### PR DESCRIPTION
In Arch Linux with a bluetooth wii-u pro controller, I ran into an issue where the DPAD_RIGHT did not detect input and could not be set for use. I was sure the button/input was working. This is likely related to #5526 (closed).

It turns out the SDLJoyButtonMapping maps a limited number of buttons(when not _WIN32) only goes 0 through 15, and this was the indexed 16 button. This simple addition allows JoyButton index 16 to be mapped.

```
    SDLJoyButtonMap[16] = NKCODE_BUTTON_12;
```

---

There's potential for further refinement (not part of this pull request), but at the risk of breaking a load of an older controls.ini file... NKCODEs are still mismatched in linux (360 controller and wii-u pro gamepad), but they were not changed to so that a user's controls.ini will load correctly. 0-4 are not DPAD for either the wii-u pro controller or the xbox360 controller, they actually 13-16. At the risk of screwing up someone's load of controls.ini, a more appropriate mapping would be

```
    SDLJoyButtonMap[0] = NKCODE_BUTTON_1;
    SDLJoyButtonMap[1] = NKCODE_BUTTON_2;
    SDLJoyButtonMap[2] = NKCODE_BUTTON_3;
    SDLJoyButtonMap[3] = NKCODE_BUTTON_4;
    SDLJoyButtonMap[4] = NKCODE_BUTTON_5;
    SDLJoyButtonMap[5] = NKCODE_BUTTON_6;
    SDLJoyButtonMap[6] = NKCODE_BUTTON_7;
    SDLJoyButtonMap[7] = NKCODE_BUTTON_8;
    SDLJoyButtonMap[8] = NKCODE_BUTTON_9;
    SDLJoyButtonMap[9] = NKCODE_BUTTON_10;
    SDLJoyButtonMap[10] = NKCODE_BUTTON_11;
    SDLJoyButtonMap[11] = NKCODE_BUTTON_12;
    SDLJoyButtonMap[12] = NKCODE_BUTTON_13;
    SDLJoyButtonMap[13] = NKCODE_DPAD_UP;
    SDLJoyButtonMap[14] = NKCODE_DPAD_DOWN;
    SDLJoyButtonMap[15] = NKCODE_DPAD_LEFT;
    SDLJoyButtonMap[16] = NKCODE_DPAD_RIGHT;

    SDLJoyAxisMap[0] = JOYSTICK_AXIS_X;
    SDLJoyAxisMap[1] = JOYSTICK_AXIS_Y;
    SDLJoyAxisMap[2] = JOYSTICK_AXIS_Z;
    SDLJoyAxisMap[3] = JOYSTICK_AXIS_RZ;
    SDLJoyAxisMap[4] = JOYSTICK_AXIS_LTRIGGER;
    SDLJoyAxisMap[5] = JOYSTICK_AXIS_RTRIGGER;
```

index 8 and 9 are SELECT and START on the wiiu pro controller, but are different for a 360 controller. So I thought it better to go with NKCODE_BUTTON with this proposal. 
