### PR TITLE
Improve VAO core profile performance

### DIFF
--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -587,7 +587,13 @@ void GLES_GPU::BuildReportingInfo() {
 	const char *glRenderer = GetGLStringAlways(GL_RENDERER);
 	const char *glVersion = GetGLStringAlways(GL_VERSION);
 	const char *glSlVersion = GetGLStringAlways(GL_SHADING_LANGUAGE_VERSION);
-	const char *glExtensions = GetGLStringAlways(GL_EXTENSIONS);
+	const char *glExtensions = nullptr;
+
+	if (gl_extensions.VersionGEThan(3, 0)) {
+		glExtensions = g_all_gl_extensions.c_str();
+	} else {
+		glExtensions = GetGLStringAlways(GL_EXTENSIONS);
+	}
 
 	char temp[16384];
 	snprintf(temp, sizeof(temp), "%s (%s %s), %s (extensions: %s)", glVersion, glVendor, glRenderer, glSlVersion, glExtensions);

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -193,6 +193,7 @@ void TransformDrawEngine::InitDeviceObjects() {
 }
 
 void TransformDrawEngine::DestroyDeviceObjects() {
+	ClearTrackedVertexArrays();
 	if (!bufferNameCache_.empty()) {
 		glstate.arrayBuffer.unbind();
 		glstate.elementArrayBuffer.unbind();
@@ -205,7 +206,6 @@ void TransformDrawEngine::DestroyDeviceObjects() {
 			glDeleteVertexArrays(1, &sharedVao_);
 		}
 	}
-	ClearTrackedVertexArrays();
 }
 
 void TransformDrawEngine::GLLost() {

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -77,7 +77,6 @@ public:
 		drawsUntilNextFullHash = 0;
 		flags = 0;
 	}
-	~VertexArrayInfo();
 
 	enum Status {
 		VAI_NEW,
@@ -205,6 +204,7 @@ private:
 
 	GLuint AllocateBuffer(size_t sz);
 	void FreeBuffer(GLuint buf);
+	void FreeVertexArray(VertexArrayInfo *vai);
 
 	u32 ComputeMiniHash();
 	ReliableHashType ComputeHash();  // Reads deferred vertex data.

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -203,7 +203,7 @@ private:
 	bool ApplyShaderBlending();
 	void ResetShaderBlending();
 
-	GLuint AllocateBuffer();
+	GLuint AllocateBuffer(size_t sz);
 	void FreeBuffer(GLuint buf);
 
 	u32 ComputeMiniHash();
@@ -237,7 +237,15 @@ private:
 
 	// Vertex buffer objects
 	// Element buffer objects
+	struct BufferNameInfo {
+		BufferNameInfo() : sz(0), used(false) {}
+		BufferNameInfo(size_t s) : sz(s), used(true) {}
+
+		size_t sz;
+		bool used;
+	};
 	std::vector<GLuint> bufferNameCache_;
+	std::vector<BufferNameInfo> bufferNameInfo_;
 	std::vector<GLuint> buffersThisFrame_;
 	GLuint sharedVao_;
 

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -238,14 +238,14 @@ private:
 	// Vertex buffer objects
 	// Element buffer objects
 	struct BufferNameInfo {
-		BufferNameInfo() : sz(0), used(false) {}
-		BufferNameInfo(size_t s) : sz(s), used(true) {}
+		BufferNameInfo() : sz(0), used(false), lastFrame(0) {}
 
 		size_t sz;
 		bool used;
+		int lastFrame;
 	};
 	std::vector<GLuint> bufferNameCache_;
-	std::vector<BufferNameInfo> bufferNameInfo_;
+	std::unordered_map<GLuint, BufferNameInfo> bufferNameInfo_;
 	std::vector<GLuint> buffersThisFrame_;
 	GLuint sharedVao_;
 
@@ -261,6 +261,7 @@ private:
 	int vertexCountInDrawCalls;
 
 	int decimationCounter_;
+	int bufferDecimationCounter_;
 	int decodeCounter_;
 	u32 dcid_;
 

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -247,6 +247,7 @@ private:
 	std::vector<GLuint> bufferNameCache_;
 	std::unordered_map<GLuint, BufferNameInfo> bufferNameInfo_;
 	std::vector<GLuint> buffersThisFrame_;
+	size_t bufferNameCacheSize_;
 	GLuint sharedVao_;
 
 	// Other

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -133,7 +133,24 @@ void DebugCallbackARB(GLenum source, GLenum type, GLuint id, GLenum severity,
 	char finalMessage[256];
 	FormatDebugOutputARB(finalMessage, 256, source, type, id, severity, message);
 	OutputDebugStringA(finalMessage);
-	NOTICE_LOG(G3D, "GL: %s", finalMessage);
+
+	switch (type) {
+	case GL_DEBUG_TYPE_ERROR_ARB:
+	case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB:
+	case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB:
+		ERROR_LOG(G3D, "GL: %s", finalMessage);
+		break;
+
+	case GL_DEBUG_TYPE_PORTABILITY_ARB:
+	case GL_DEBUG_TYPE_PERFORMANCE_ARB:
+		NOTICE_LOG(G3D, "GL: %s", finalMessage);
+		break;
+
+	case GL_DEBUG_TYPE_OTHER_ARB:
+	default:
+		INFO_LOG(G3D, "GL: %s", finalMessage);
+		break;
+	}
 }
 
 bool GL_Init(HWND window, std::string *error_message) {

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -271,7 +271,7 @@ bool GL_Init(HWND window, std::string *error_message) {
 	};
 
 	HGLRC	m_hrc;
-	if(wglewIsSupported("WGL_ARB_create_context") == 1) {
+	if (wglewIsSupported("WGL_ARB_create_context") == 1) {
 		m_hrc = wglCreateContextAttribsARB(hDC, 0, attribs44);
 		if (!m_hrc)
 			m_hrc = wglCreateContextAttribsARB(hDC, 0, attribs43);
@@ -305,20 +305,33 @@ bool GL_Init(HWND window, std::string *error_message) {
 
 	GL_SwapInterval(0);
 
-	// TODO: Also support GL_KHR_debug which might be more widely supported?
-	if (g_Config.bGfxDebugOutput && glewIsSupported("GL_ARB_debug_output")) {
-		glGetError();
-		glDebugMessageCallbackARB((GLDEBUGPROCARB)&DebugCallbackARB, 0); // print debug output to stderr
-		if (glGetError()) {
-			ERROR_LOG(G3D, "Failed to register a debug log callback");
-		}
-		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
-		if (glGetError()) {
-			ERROR_LOG(G3D, "Failed to enable synchronous debug output");
+	if (g_Config.bGfxDebugOutput) {
+		if (wglewIsSupported("GL_KHR_debug") == 1) {
+			glGetError();
+			glDebugMessageCallback((GLDEBUGPROC)&DebugCallbackARB, nullptr);
+			if (glGetError()) {
+				ERROR_LOG(G3D, "Failed to register a debug log callback");
+			}
+			glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+			if (glGetError()) {
+				ERROR_LOG(G3D, "Failed to enable synchronous debug output");
+			}
+		} else if (glewIsSupported("GL_ARB_debug_output")) {
+			glGetError();
+			glDebugMessageCallbackARB((GLDEBUGPROCARB)&DebugCallbackARB, 0); // print debug output to stderr
+			if (glGetError()) {
+				ERROR_LOG(G3D, "Failed to register a debug log callback");
+			}
+			glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+			if (glGetError()) {
+				ERROR_LOG(G3D, "Failed to enable synchronous debug output");
+			}
+
+			// For extra verbosity uncomment this (MEDIUM and HIGH are on by default):
+			// glDebugMessageControlARB(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_LOW_ARB, 0, nullptr, GL_TRUE);
 		}
 
-		// For extra verbosity uncomment this (MEDIUM and HIGH are on by default):
-		// glDebugMessageControlARB(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_LOW_ARB, 0, nullptr, GL_TRUE);
+		glEnable(GL_DEBUG_OUTPUT);
 	}
 
 	pauseRequested = false;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -105,10 +105,10 @@ public:
 		
 #if !defined(USING_GLES2)
 		if (logicEnabled) {
-			glEnable(GL_LOGIC_OP);
+			glEnable(GL_COLOR_LOGIC_OP);
 			glLogicOp(logicOp);
 		} else {
-			glDisable(GL_LOGIC_OP);
+			glDisable(GL_COLOR_LOGIC_OP);
 		}
 #endif
 	}


### PR DESCRIPTION
Based on @Sonicadvance1's suggestions, I tried using a buffer cache based on the size of the buffer (so they would not get resized at runtime, if possible.)  I also increased the buffer cache size.

This helped significantly.  For me, performance is now the same/better with `gl_extensions.IsCoreContext = true;` compared to with it off.  Before, it was significantly worse.

This may also help even with it off, because it will prefer a buffer that has the same size for the vertex cache as well.

-[Unknown]
