### PR TITLE
Send initial permission grant for storage when available

### DIFF
--- a/android/custom_rules.xml
+++ b/android/custom_rules.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="PPSSPP" default="help">
+    <condition property="ndkbuild_exe" value="ndk-build.cmd" else="ndk-build">
+        <os family="windows" />
+    </condition>
     <property name="ndkbuildopt" value=""/>
     <target name="-pre-build">
-        <exec executable="${ndk.dir}/ndk-build" failonerror="true">
+        <exec executable="${ndk.dir}/${ndkbuild_exe}" failonerror="true">
             <arg line="-j4 ${ndkbuildopt}"/>
             <env key="NDK_MODULE_PATH" path="../ext:../ext/native/ext"/>
         </exec>
     </target>
     <target name="clean" depends="android_rules.clean">
-        <exec executable="${ndk.dir}/ndk-build" failonerror="true">
+        <exec executable="${ndk.dir}/${ndkbuild_exe}" failonerror="true">
             <arg value="clean"/>
             <env key="NDK_MODULE_PATH" path="../ext:../ext/native/ext"/>
         </exec>

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -172,6 +172,16 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		}
 	}
 
+	@TargetApi(23)
+	public void sendInitialGrants() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			// Let's start out granted if it was granted already.
+			if (this.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+				NativeApp.sendMessage("permission_granted", "storage");
+			}
+		}
+	}
+
 	@Override
 	public void onRequestPermissionsResult(int requestCode,
 	        String permissions[], int[] grantResults) {
@@ -238,6 +248,8 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, shortcutParam, installID, Build.VERSION.SDK_INT);
 
 		NativeApp.sendMessage("cacheDir", getCacheDir().getAbsolutePath());
+
+		sendInitialGrants();
 
         vibrator = (Vibrator)getSystemService(VIBRATOR_SERVICE);
         if (Build.VERSION.SDK_INT >= 11) {


### PR DESCRIPTION
This checks for the permission at startup and immediately sends a grant message if available.  This way, if they already granted the permission, it won't prompt them every time they start PPSSPP.

-[Unknown]
