### PR TITLE
Re-enable FMA3 on MSVC2015+ builds

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -355,8 +355,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	PROFILE_INIT();
 
+#if defined(_M_X64) && defined(_MSC_VER) && _MSC_VER < 1900
 	// FMA3 support in the 2013 CRT is broken on Vista and Windows 7 RTM (fixed in SP1). Just disable it.
-#ifdef _M_X64
 	_set_FMA3_enable(0);
 #endif
 


### PR DESCRIPTION
Fixes #8289.  I didn't notice any problems in cursory testing.

-[Unknown]
