### PR TITLE
Use MEMSIZE SFO param to detect 64MB homebrew

### DIFF
--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -58,7 +58,7 @@ bool PBPReader::GetSubFile(PBPSubFile file, std::vector<u8> *out) {
 	const u32 off = header_.offsets[(int)file];
 
 	out->resize(expected);
-	size_t bytes = file_->ReadAt(off, expected, (void *)out->data());
+	size_t bytes = file_->ReadAt(off, expected, &(*out)[0]);
 	if (bytes != expected) {
 		ERROR_LOG(LOADER, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
 		if (bytes < expected) {

--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -21,37 +21,32 @@
 
 #include "Common/Log.h"
 #include "Common/FileUtil.h"
+#include "Core/Loaders.h"
 #include "Core/ELF/PBPReader.h"
 
-PBPReader::PBPReader(const char *filename) : header_(), isELF_(false) {
-	file_ = File::OpenCFile(filename, "rb");
-	if (!file_) {
-		ERROR_LOG(LOADER, "Failed to open PBP file %s", filename);
+PBPReader::PBPReader(FileLoader *fileLoader) : file_(nullptr), header_(), isELF_(false) {
+	if (!fileLoader->Exists()) {
+		ERROR_LOG(LOADER, "Failed to open PBP file %s", fileLoader->Path().c_str());
 		return;
 	}
 
-	fseek(file_, 0, SEEK_END);
-	fileSize_ = ftell(file_);
-	fseek(file_, 0, SEEK_SET);
-	if (fread((char *)&header_, 1, sizeof(header_), file_) != sizeof(header_)) {
-		ERROR_LOG(LOADER, "PBP is too small to be valid: %s", filename);
-		fclose(file_);
-		file_ = nullptr;
+	fileSize_ = (size_t)fileLoader->FileSize();
+	if (fileLoader->ReadAt(0, sizeof(header_), (u8 *)&header_) != sizeof(header_)) {
+		ERROR_LOG(LOADER, "PBP is too small to be valid: %s", fileLoader->Path().c_str());
 		return;
 	}
 	if (memcmp(header_.magic, "\0PBP", 4) != 0) {
 		if (memcmp(header_.magic, "\nFLE", 4) != 0) {
-			DEBUG_LOG(LOADER, "%s: File actually an ELF, not a PBP", filename);
+			DEBUG_LOG(LOADER, "%s: File actually an ELF, not a PBP", fileLoader->Path().c_str());
 			isELF_ = true;
 		} else {
-			ERROR_LOG(LOADER, "Magic number in %s indicated no PBP: %s", filename, header_.magic);
+			ERROR_LOG(LOADER, "Magic number in %s indicated no PBP: %s", fileLoader->Path().c_str(), header_.magic);
 		}
-		fclose(file_);
-		file_ = nullptr;
 		return;
 	}
 
 	DEBUG_LOG(LOADER, "Loading PBP, version = %08x", header_.version);
+	file_ = fileLoader;
 }
 
 bool PBPReader::GetSubFile(PBPSubFile file, std::vector<u8> *out) {
@@ -62,20 +57,15 @@ bool PBPReader::GetSubFile(PBPSubFile file, std::vector<u8> *out) {
 	const size_t expected = GetSubFileSize(file);
 	const u32 off = header_.offsets[(int)file];
 
-	if (fseek(file_, off, SEEK_SET) != 0) {
-		ERROR_LOG(LOADER, "PBP file offset invalid: %d", off);
-		return false;
-	} else {
-		out->resize(expected);
-		size_t bytes = fread((void *)out->data(), 1, expected, file_);
-		if (bytes != expected) {
-			ERROR_LOG(LOADER, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
-			if (bytes < expected) {
-				out->resize(bytes);
-			}
+	out->resize(expected);
+	size_t bytes = file_->ReadAt(off, expected, (void *)out->data());
+	if (bytes != expected) {
+		ERROR_LOG(LOADER, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
+		if (bytes < expected) {
+			out->resize(bytes);
 		}
-		return true;
 	}
+	return true;
 }
 
 void PBPReader::GetSubFileAsString(PBPSubFile file, std::string *out) {
@@ -88,21 +78,16 @@ void PBPReader::GetSubFileAsString(PBPSubFile file, std::string *out) {
 	const u32 off = header_.offsets[(int)file];
 
 	out->resize(expected);
-	if (fseek(file_, off, SEEK_SET) != 0) {
-		ERROR_LOG(LOADER, "PBP file offset invalid: %d", off);
-		out->clear();
-	} else {
-		size_t bytes = fread((void *)out->data(), 1, expected, file_);
-		if (bytes != expected) {
-			ERROR_LOG(LOADER, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
-			if (bytes < expected) {
-				out->resize(bytes);
-			}
+	size_t bytes = file_->ReadAt(off, expected, (void *)out->data());
+	if (bytes != expected) {
+		ERROR_LOG(LOADER, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
+		if (bytes < expected) {
+			out->resize(bytes);
 		}
 	}
 }
 
 PBPReader::~PBPReader() {
-	if (file_)
-		fclose(file_);
+	// Does not take ownership.
+	file_ = nullptr;
 }

--- a/Core/ELF/PBPReader.h
+++ b/Core/ELF/PBPReader.h
@@ -37,13 +37,15 @@ struct PBPHeader {
 	u32_le offsets[8];
 };
 
+class FileLoader;
+
 class PBPReader {
 public:
-	PBPReader(const char *filename);
+	PBPReader(FileLoader *fileLoader);
 	~PBPReader();
 
-	bool IsValid() const { return file_ != 0; }
-	bool IsELF() const { return file_ == 0 && isELF_; }
+	bool IsValid() const { return file_ != nullptr; }
+	bool IsELF() const { return file_ == nullptr && isELF_; }
 
 	bool GetSubFile(PBPSubFile file, std::vector<u8> *out);
 	void GetSubFileAsString(PBPSubFile file, std::string *out);
@@ -58,7 +60,7 @@ public:
 	}
 
 private:
-	FILE *file_;
+	FileLoader *file_;
 	size_t fileSize_;
 	const PBPHeader header_;
 	bool isELF_;

--- a/Core/ELF/PBPReader.h
+++ b/Core/ELF/PBPReader.h
@@ -45,8 +45,7 @@ public:
 	bool IsValid() const { return file_ != 0; }
 	bool IsELF() const { return file_ == 0 && isELF_; }
 
-	// Delete the returned buffer with delete [].
-	u8 *GetSubFile(PBPSubFile file, size_t *outSize);
+	bool GetSubFile(PBPSubFile file, std::vector<u8> *out);
 	void GetSubFileAsString(PBPSubFile file, std::string *out);
 
 	size_t GetSubFileSize(PBPSubFile file) {

--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -86,6 +86,14 @@ u8* ParamSFOData::GetValueData(std::string key, unsigned int *size)
 	return it->second.u_value;
 }
 
+std::vector<std::string> ParamSFOData::GetKeys() {
+	std::vector<std::string> result;
+	for (const auto &pair : values) {
+		result.push_back(pair.first);
+	}
+	return result;
+}
+
 // I'm so sorry Ced but this is highly endian unsafe :(
 bool ParamSFOData::ReadSFO(const u8 *paramsfo, size_t size)
 {

--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -34,6 +34,8 @@ public:
 	std::string GetValueString(std::string key);
 	u8* GetValueData(std::string key, unsigned int *size);
 
+	std::vector<std::string> GetKeys();
+
 	bool ReadSFO(const u8 *paramsfo, size_t size);
 	bool WriteSFO(u8 **paramsfo, size_t *size);
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1377,17 +1377,17 @@ static bool __KernelLoadPBP(const char *filename, std::string *error_string)
 		return false;
 	}
 
-	size_t elfSize;
-	u8 *elfData = pbp.GetSubFile(PBP_EXECUTABLE_PSP, &elfSize);
+	std::vector<u8> elfData;
+	if (!pbp.GetSubFile(PBP_EXECUTABLE_PSP, &elfData)) {
+		return false;
+	}
 	u32 magic;
 	u32 error;
-	Module *module = __KernelLoadELFFromPtr(elfData, PSP_GetDefaultLoadAddress(), false, error_string, &magic, error);
+	Module *module = __KernelLoadELFFromPtr(&elfData[0], PSP_GetDefaultLoadAddress(), false, error_string, &magic, error);
 	if (!module) {
-		delete [] elfData;
 		return false;
 	}
 	mipsr4k.pc = module->nm.entry_addr;
-	delete [] elfData;
 	return true;
 }
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -29,6 +29,7 @@
 #include "Core/HLE/ReplaceTables.h"
 #include "Core/Reporting.h"
 #include "Core/Host.h"
+#include "Core/Loaders.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -1368,11 +1369,11 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromT
 	return module;
 }
 
-static bool __KernelLoadPBP(const char *filename, std::string *error_string)
+static bool __KernelLoadPBP(FileLoader *fileLoader, std::string *error_string)
 {
-	PBPReader pbp(filename);
+	PBPReader pbp(fileLoader);
 	if (!pbp.IsValid()) {
-		ERROR_LOG(LOADER,"%s is not a valid homebrew PSP1.0 PBP",filename);
+		ERROR_LOG(LOADER, "%s is not a valid homebrew PSP1.0 PBP", fileLoader->Path().c_str());
 		*error_string = "Not a valid homebrew PBP";
 		return false;
 	}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -141,9 +141,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 	else if (id == 'PBP\x00') {
 		// Do this PS1 eboot check FIRST before checking other eboot types.
 		// It seems like some are malformed and slip through the PSAR check below.
-		// TODO: Change PBPReader to read FileLoader objects?
-		std::string filename = fileLoader->Path();
-		PBPReader pbp(filename.c_str());
+		PBPReader pbp(fileLoader);
 		if (pbp.IsValid() && !pbp.IsELF()) {
 			std::vector<u8> sfoData;
 			if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {
@@ -166,11 +164,10 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 		// Let's check if we got pointed to a PBP within such a directory.
 		// If so we just move up and return the directory itself as the game.
-		std::string path = File::GetDir(filename);
+		std::string path = File::GetDir(fileLoader->Path());
 		// If loading from memstick...
 		size_t pos = path.find("/PSP/GAME/");
 		if (pos != std::string::npos) {
-			filename = path;
 			return FILETYPE_PSP_PBP_DIRECTORY;
 		}
 		return FILETYPE_PSP_PBP;

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -340,7 +340,7 @@ void Init()
 
 void DoState(PointerWrap &p)
 {
-	auto s = p.Section("Memory", 1, 2);
+	auto s = p.Section("Memory", 1, 3);
 	if (!s)
 		return;
 
@@ -348,7 +348,8 @@ void DoState(PointerWrap &p)
 		if (!g_RemasterMode)
 			g_MemorySize = RAM_NORMAL_SIZE;
 		g_PSPModel = PSP_MODEL_FAT;
-	} else {
+	} else if (s == 2) {
+		// In version 2, we determine memory size based on PSP model.
 		u32 oldMemorySize = g_MemorySize;
 		p.Do(g_PSPModel);
 		p.DoMarker("PSPModel");
@@ -358,6 +359,17 @@ void DoState(PointerWrap &p)
 				Shutdown();
 				Init();
 			}
+		}
+	} else {
+		// In version 3, we started just saving the memory size directly.
+		// It's no longer based strictly on the PSP model.
+		u32 oldMemorySize = g_MemorySize;
+		p.Do(g_PSPModel);
+		p.DoMarker("PSPModel");
+		p.Do(g_MemorySize);
+		if (oldMemorySize != g_MemorySize) {
+			Shutdown();
+			Init();
 		}
 	}
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -131,9 +131,7 @@ void InitMemoryForGamePBP(FileLoader *fileLoader) {
 		return;
 	}
 
-	// TODO: Change PBPReader to read FileLoader objects?
-	std::string filename = fileLoader->Path();
-	PBPReader pbp(filename.c_str());
+	PBPReader pbp(fileLoader);
 	if (pbp.IsValid() && !pbp.IsELF()) {
 		std::vector<u8> sfoData;
 		if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -135,16 +135,13 @@ void InitMemoryForGamePBP(FileLoader *fileLoader) {
 	std::string filename = fileLoader->Path();
 	PBPReader pbp(filename.c_str());
 	if (pbp.IsValid() && !pbp.IsELF()) {
-		size_t sfoSize;
-		u8 *sfoData = pbp.GetSubFile(PBP_PARAM_SFO, &sfoSize);
-		if (sfoData) {
+		std::vector<u8> sfoData;
+		if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {
 			ParamSFOData paramSFO;
-			if (paramSFO.ReadSFO(sfoData, sfoSize)) {
+			if (paramSFO.ReadSFO(sfoData)) {
 				// This is the parameter CFW uses to determine homebrew wants the full 64MB.
 				UseLargeMem(paramSFO.GetValueInt("MEMSIZE"));
 			}
-
-			delete [] sfoData;
 		}
 	}
 }

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -51,79 +51,85 @@
 #include "Core/HLE/sceKernelModule.h"
 #include "Core/HLE/sceKernelMemory.h"
 
+static void UseLargeMem(int memsize) {
+	if (memsize != 1) {
+		// Nothing requested.
+		return;
+	}
+
+	if (Memory::g_PSPModel != PSP_MODEL_FAT) {
+		INFO_LOG(LOADER, "Game requested full PSP-2000 memory access");
+		Memory::g_MemorySize = Memory::RAM_DOUBLE_SIZE;
+	} else {
+		WARN_LOG(LOADER, "Game requested full PSP-2000 memory access, ignoring in PSP-1000 mode");
+	}
+}
+
 // We gather the game info before actually loading/booting the ISO
 // to determine if the emulator should enable extra memory and
 // double-sized texture coordinates.
 void InitMemoryForGameISO(FileLoader *fileLoader) {
-	IFileSystem* umd2;
-
 	if (!fileLoader->Exists()) {
 		return;
 	}
 
+	IFileSystem *fileSystem = nullptr;
+	IFileSystem *blockSystem = nullptr;
 	bool actualIso = false;
-	if (fileLoader->IsDirectory())
-	{
-		umd2 = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
-	}
-	else 
-	{
+	if (fileLoader->IsDirectory()) {
+		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
+		blockSystem = fileSystem;
+	} else {
 		auto bd = constructBlockDevice(fileLoader);
 		// Can't init anything without a block device...
 		if (!bd)
 			return;
 
-		umd2 = new ISOFileSystem(&pspFileSystem, bd);
-		actualIso = true;
+		ISOFileSystem *iso = new ISOFileSystem(&pspFileSystem, bd);
+		fileSystem = iso;
+		blockSystem = new ISOBlockSystem(iso);
 	}
 
-	// Parse PARAM.SFO
-
-	//pspFileSystem.Mount("host0:",umd2);
-
-	IFileSystem *entireIso = 0;
-	if (actualIso) {
-		entireIso = new ISOBlockSystem(static_cast<ISOFileSystem *>(umd2));
-	} else {
-		entireIso = umd2;
-	}
-
-	pspFileSystem.Mount("umd0:", entireIso);
-	pspFileSystem.Mount("umd1:", entireIso);
-	pspFileSystem.Mount("disc0:", umd2);
-	pspFileSystem.Mount("umd:", entireIso);
+	pspFileSystem.Mount("umd0:", blockSystem);
+	pspFileSystem.Mount("umd1:", blockSystem);
+	pspFileSystem.Mount("disc0:", fileSystem);
+	pspFileSystem.Mount("umd:", blockSystem);
+	// TODO: Should we do this?
+	//pspFileSystem.Mount("host0:", fileSystem);
 
 	std::string gameID;
 
 	std::string sfoPath("disc0:/PSP_GAME/PARAM.SFO");
 	PSPFileInfo fileInfo = pspFileSystem.GetFileInfo(sfoPath.c_str());
 
-	if (fileInfo.exists)
-	{
+	if (fileInfo.exists) {
 		std::vector<u8> paramsfo;
 		pspFileSystem.ReadEntireFile(sfoPath, paramsfo);
 		if (g_paramSFO.ReadSFO(paramsfo)) {
+			UseLargeMem(g_paramSFO.GetValueInt("MEMSIZE"));
 			// TODO: Check the SFO for other parameters that might be useful for identifying?
 			gameID = g_paramSFO.GetValueString("DISC_ID");
-
-			for (size_t i = 0; i < ARRAY_SIZE(g_HDRemasters); i++) {
-				if (g_HDRemasters[i].gameID == gameID) {
-					g_RemasterMode = true;
-					Memory::g_MemorySize = g_HDRemasters[i].MemorySize;
-					if (g_HDRemasters[i].DoubleTextureCoordinates)
-						g_DoubleTextureCoordinates = true;
-					break;
-				}
-			}
-			if (g_RemasterMode) {
-				INFO_LOG(LOADER, "HDRemaster found, using increased memory");
-			}
 		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(g_HDRemasters); i++) {
+		if (g_HDRemasters[i].gameID == gameID) {
+			g_RemasterMode = true;
+			Memory::g_MemorySize = g_HDRemasters[i].MemorySize;
+			if (g_HDRemasters[i].DoubleTextureCoordinates)
+				g_DoubleTextureCoordinates = true;
+			break;
+		}
+	}
+	if (g_RemasterMode) {
+		INFO_LOG(LOADER, "HDRemaster found, using increased memory");
 	}
 }
 
 void InitMemoryForGamePBP(FileLoader *fileLoader) {
-	bool useLargeMem = false;
+	if (!fileLoader->Exists()) {
+		return;
+	}
 
 	// TODO: Change PBPReader to read FileLoader objects?
 	std::string filename = fileLoader->Path();
@@ -133,22 +139,12 @@ void InitMemoryForGamePBP(FileLoader *fileLoader) {
 		u8 *sfoData = pbp.GetSubFile(PBP_PARAM_SFO, &sfoSize);
 		if (sfoData) {
 			ParamSFOData paramSFO;
-			paramSFO.ReadSFO(sfoData, sfoSize);
-
-			// This is the parameter CFW uses to determine homebrew wants the full 64MB.
-			int memsize = paramSFO.GetValueInt("MEMSIZE");
-			useLargeMem = memsize == 1;
+			if (paramSFO.ReadSFO(sfoData, sfoSize)) {
+				// This is the parameter CFW uses to determine homebrew wants the full 64MB.
+				UseLargeMem(paramSFO.GetValueInt("MEMSIZE"));
+			}
 
 			delete [] sfoData;
-		}
-	}
-
-	if (useLargeMem) {
-		if (Memory::g_PSPModel != PSP_MODEL_FAT) {
-			INFO_LOG(LOADER, "Homebrew requested full PSP-2000 memory access");
-			Memory::g_MemorySize = Memory::RAM_DOUBLE_SIZE;
-		} else {
-			WARN_LOG(LOADER, "Homebrew requested full PSP-2000 memory access, ignoring in PSP-1000 mode");
 		}
 	}
 }

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -24,3 +24,4 @@ class FileLoader;
 bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 void InitMemoryForGameISO(FileLoader *fileLoader);
+void InitMemoryForGamePBP(FileLoader *fileLoader);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -177,10 +177,7 @@ void CPU_Init() {
 
 	// Default memory settings
 	// Seems to be the safest place currently..
-	if (g_Config.iPSPModel == PSP_MODEL_FAT)
-		Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
-	else
-		Memory::g_MemorySize = Memory::RAM_DOUBLE_SIZE;
+	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
 
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
@@ -208,6 +205,17 @@ void CPU_Init() {
 	case FILETYPE_PSP_ISO_NP:
 	case FILETYPE_PSP_DISC_DIRECTORY:
 		InitMemoryForGameISO(loadedFile);
+		break;
+	case FILETYPE_PSP_PBP_DIRECTORY: {
+		// TODO: Can we get this lower into LoadFile?
+		std::string ebootFilename = loadedFile->Path() + "/EBOOT.PBP";
+		FileLoader *tempLoader = ConstructFileLoader(ebootFilename);
+		InitMemoryForGamePBP(tempLoader);
+		delete tempLoader;
+		break;
+	}
+	case FILETYPE_PSP_PBP:
+		InitMemoryForGamePBP(loadedFile);
 		break;
 	default:
 		break;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -322,16 +322,19 @@ public:
 		case FILETYPE_PSP_PBP:
 		case FILETYPE_PSP_PBP_DIRECTORY:
 			{
-				std::string pbpFile = filename;
-				if (info_->fileType == FILETYPE_PSP_PBP_DIRECTORY)
-					pbpFile += "/EBOOT.PBP";
+				FileLoader *pbpLoader = info_->GetFileLoader();
+				std::unique_ptr<FileLoader> altLoader;
+				if (info_->fileType == FILETYPE_PSP_PBP_DIRECTORY) {
+					pbpLoader = ConstructFileLoader(pbpLoader->Path() + "/EBOOT.PBP");
+					altLoader.reset(pbpLoader);
+				}
 
-				PBPReader pbp(pbpFile.c_str());
+				PBPReader pbp(pbpLoader);
 				if (!pbp.IsValid()) {
 					if (pbp.IsELF()) {
 						goto handleELF;
 					}
-					ERROR_LOG(LOADER, "invalid pbp %s\n", pbpFile.c_str());
+					ERROR_LOG(LOADER, "invalid pbp %s\n", pbpLoader->Path().c_str());
 					return;
 				}
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -336,14 +336,12 @@ public:
 				}
 
 				// First, PARAM.SFO.
-				size_t sfoSize;
-				u8 *sfoData = pbp.GetSubFile(PBP_PARAM_SFO, &sfoSize);
-				{
+				std::vector<u8> sfoData;
+				if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {
 					lock_guard lock(info_->lock);
-					info_->paramSFO.ReadSFO(sfoData, sfoSize);
+					info_->paramSFO.ReadSFO(sfoData);
 					info_->ParseParamSFO();
 				}
-				delete [] sfoData;
 
 				// Then, ICON0.PNG.
 				{

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -116,6 +116,7 @@ public:
 
 	std::vector<std::string> GetSaveDataDirectories();
 
+	std::string GetTitle();
 
 	// Hold this when reading or writing from the GameInfo.
 	// Don't need to hold it when just passing around the pointer,
@@ -123,8 +124,6 @@ public:
 	// to it.
 	recursive_mutex lock;
 
-	std::string path;
-	std::string title;  // for easy access, also available in paramSFO.
 	std::string id;
 	std::string id_version;
 	int disc_total;
@@ -166,6 +165,9 @@ public:
 	bool pending;
 
 protected:
+	// Note: this can change while loading, use GetTitle().
+	std::string title;
+
 	FileLoader *fileLoader;
 	std::string filePath_;
 };

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -66,7 +66,7 @@ void GameScreen::CreateViews() {
 	leftColumn->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameScreen::OnSwitchBack);
 	if (info) {
 		texvGameIcon_ = leftColumn->Add(new Thin3DTextureView(0, IS_DEFAULT, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
-		tvTitle_ = leftColumn->Add(new TextView(info->title, ALIGN_LEFT, false, new AnchorLayoutParams(10, 200, NONE, NONE)));
+		tvTitle_ = leftColumn->Add(new TextView(info->GetTitle(), ALIGN_LEFT, false, new AnchorLayoutParams(10, 200, NONE, NONE)));
 		tvTitle_->SetShadow(true);
 		// This one doesn't need to be updated.
 		leftColumn->Add(new TextView(gamePath_, ALIGN_LEFT, true, new AnchorLayoutParams(10, 250, NONE, NONE)))->SetShadow(true);
@@ -159,7 +159,7 @@ void GameScreen::update(InputState &input) {
 	GameInfo *info = g_gameInfoCache.GetInfo(thin3d, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 
 	if (tvTitle_)
-		tvTitle_->SetText(info->title + " (" + info->id + ")");
+		tvTitle_->SetText(info->GetTitle() + " (" + info->id + ")");
 	if (info->iconTexture && texvGameIcon_)	{
 		texvGameIcon_->SetTexture(info->iconTexture);
 		// Fade the icon with the background.
@@ -277,7 +277,7 @@ void GameScreen::CallbackDeleteGame(bool yes) {
 UI::EventReturn GameScreen::OnCreateShortcut(UI::EventParams &e) {
 	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
 	if (info) {
-		host->CreateDesktopShortcut(gamePath_, info->title);
+		host->CreateDesktopShortcut(gamePath_, info->GetTitle());
 	}
 	return UI::EVENT_DONE;
 }

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -277,8 +277,9 @@ void GameButton::Draw(UIContext &dc) {
 		float tw, th;
 		dc.Draw()->Flush();
 		dc.PushScissor(bounds_);
-		if (title_.empty() && !ginfo->title.empty()) {
-			title_ = ReplaceAll(ginfo->title + discNumInfo, "&", "&&");
+		const std::string currentTitle = ginfo->GetTitle();
+		if (!currentTitle.empty()) {
+			title_ = ReplaceAll(currentTitle + discNumInfo, "&", "&&");
 			title_ = ReplaceAll(title_, "\n", " ");
 		}
 
@@ -310,8 +311,7 @@ void GameButton::Draw(UIContext &dc) {
 	} else {
 		dc.Draw()->Flush();
 	}
-	if (!ginfo->id.empty() && ginfo->hasConfig)
-	{
+	if (ginfo->hasConfig && !ginfo->id.empty()) {
 		dc.Draw()->DrawImage(I_GEAR, x, y + h - ui_images[I_GEAR].h, 1.0f);
 	}
 	if (overlayColor) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -226,8 +226,9 @@ void SavedataButton::Draw(UIContext &dc) {
 	dc.Draw()->Flush();
 	dc.PushScissor(bounds_);
 
-	if (title_.empty() && !ginfo->title.empty()) {
-		title_ = CleanSaveString(ginfo->title);
+	const std::string currentTitle = ginfo->GetTitle();
+	if (!currentTitle.empty()) {
+		title_ = CleanSaveString(currentTitle);
 	}
 	if (subtitle_.empty() && ginfo->gameSize > 0) {
 		std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
@@ -360,7 +361,7 @@ void SavedataScreen::CreateViews() {
 
 UI::EventReturn SavedataScreen::OnSavedataButtonClick(UI::EventParams &e) {
 	GameInfo *ginfo = g_gameInfoCache.GetInfo(screenManager()->getThin3DContext(), e.s, 0);
-	screenManager()->push(new SavedataPopupScreen(e.s, ginfo->title));
+	screenManager()->push(new SavedataPopupScreen(e.s, ginfo->GetTitle()));
 	// the game path: e.s;
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
Now, use 32MB for normal games even in PSP-2000 mode, which is how real firmware behaves.

Warning: this may impact cheats with default settings.  But it only moves closer to accurate with real firmware.

Fixes #2183.

-[Unknown]
