### PR TITLE
Fix iOS savestate compatibility issue

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -555,8 +555,10 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec)
 		if (e.isRawSector) {
 			positionOnIso = e.sectorStart * 2048ULL + e.seekPos;
 			fileSize = (s64)e.openSize;
+		} else if (e.file == nullptr) {
+			ERROR_LOG(FILESYS, "File no longer exists (loaded savestate with different ISO?)");
+			return 0;
 		} else {
-			_dbg_assert_msg_(FILESYS, e.file != 0, "Expecting non-raw fd to have a tree entry.");
 			positionOnIso = e.file->startingPosition + e.seekPos;
 			fileSize = e.file->size;
 		}


### PR DESCRIPTION
See #8199.  Basically it was the same as Android x86.

I couldn't really test iOS so I tried to make a more specific solution that would load for me.  Basically I detect if padding had been saved (see comments, this is safe), and then use that to pick the size.

I guess if a platform was aligning even differently than that, it might be unsafe, but I put a static assert in for the current expected size, for all platforms.  So we should catch it.

-[Unknown]
