### PR TITLE
Fixed some errors from PVS-Studio in Common project

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -280,7 +280,7 @@ std::string CPUInfo::Summarize()
 	if (bSSE4_2) sum += ", SSE4.2";
 	if (HTT) sum += ", HTT";
 	if (bAVX) sum += ", AVX";
-	if (bAVX) sum += ", FMA";
+	if (bFMA) sum += ", FMA";
 	if (bAES) sum += ", AES";
 	if (bLongMode) sum += ", 64-bit support";
 	return sum;

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -408,7 +408,7 @@ void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, const u32 numPixels) 
 		__m128i b = _mm_and_si128(_mm_srli_epi16(c, 8), mask4);
 		// And lastly 00A0 00A0.  No mask needed, we have a wall.
 		__m128i a = _mm_srli_epi16(c, 12);
-		a = _mm_slli_epi16(g, 8);
+		a = _mm_slli_epi16(a, 8);
 
 		// We swizzle after combining - R0G0 R0G0 and B0A0 B0A0 -> RRGG RRGG and BBAA BBAA.
 		__m128i rg = _mm_or_si128(r, g);

--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -121,10 +121,10 @@ void ConsoleListener::Open()
 	{
 		// Open the console window and create the window handle for GetStdHandle()
 		AllocConsole();
-		HWND hConWnd = GetConsoleWindow();
-		ShowWindow(hConWnd, SW_SHOWDEFAULT);
+		hWnd = GetConsoleWindow();
+		ShowWindow(hWnd, SW_SHOWDEFAULT);
 		// disable console close button
-		HMENU hMenu=GetSystemMenu(hConWnd,false);
+		HMENU hMenu=GetSystemMenu(hWnd, false);
 		EnableMenuItem(hMenu,SC_CLOSE,MF_GRAYED|MF_BYCOMMAND);
 		// Save the window handle that AllocConsole() created
 		hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -513,9 +513,6 @@ void ConsoleListener::PixelSpace(int Left, int Top, int Width, int Height, bool 
 	bool DAft = true;
 	std::string SLog = "";
 
-	const HWND hWnd = GetConsoleWindow();
-	//const HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-
 	// Get console info
 	CONSOLE_SCREEN_BUFFER_INFO ConInfo;
 	GetConsoleScreenBufferInfo(hConsole, &ConInfo);
@@ -631,8 +628,6 @@ void ConsoleListener::ClearScreen(bool Cursor)
 	DWORD cCharsWritten; 
 	CONSOLE_SCREEN_BUFFER_INFO csbi; 
 	DWORD dwConSize; 
-	
-	//HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE); 
 	
 	GetConsoleScreenBufferInfo(hConsole, &csbi); 
 	dwConSize = csbi.dwSize.X * csbi.dwSize.Y;

--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -514,7 +514,7 @@ void ConsoleListener::PixelSpace(int Left, int Top, int Width, int Height, bool 
 	std::string SLog = "";
 
 	const HWND hWnd = GetConsoleWindow();
-	const HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+	//const HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
 	// Get console info
 	CONSOLE_SCREEN_BUFFER_INFO ConInfo;
@@ -632,7 +632,7 @@ void ConsoleListener::ClearScreen(bool Cursor)
 	CONSOLE_SCREEN_BUFFER_INFO csbi; 
 	DWORD dwConSize; 
 	
-	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE); 
+	//HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE); 
 	
 	GetConsoleScreenBufferInfo(hConsole, &csbi); 
 	dwConSize = csbi.dwSize.X * csbi.dwSize.Y;

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -46,7 +46,7 @@ public:
 	bool Hidden() const { return bHidden; }
 private:
 #if defined(_WIN32) && !defined(_XBOX)
-	HWND GetHwnd(void);
+	HWND hWnd;
 	HANDLE hConsole;
 
 	static unsigned int WINAPI RunThread(void *lpParam);

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -187,6 +187,7 @@ public:
 
 private:
 	IOFile& operator=(const IOFile&) /*= delete*/;
+	IOFile(const IOFile&) /*= delete*/;
 
 	std::FILE* m_file;
 	bool m_good;

--- a/ext/native/base/mutex.h
+++ b/ext/native/base/mutex.h
@@ -125,6 +125,7 @@ public:
 private:
 	mutexType mut_;
 	recursive_mutex(const recursive_mutex &other);
+	recursive_mutex& operator=(const recursive_mutex& other);
 };
 
 class lock_guard {


### PR DESCRIPTION
Color conversion assigned 'a' twice.
Console listener use local variable with the same name a class member.
Some additionals to nocopy for FileUtils and mutex

Please double check this, i may fix something wrong.
