### PR TITLE
Allow shortcut min/max on Windows, fix config save on exit

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1085,13 +1085,14 @@ UI::EventReturn MainScreen::OnExit(UI::EventParams &e) {
 	// Request the framework to exit cleanly.
 	System_SendMessage("finish", "");
 
+	// However, let's make sure the config was saved, since it may not have been.
+	g_Config.Save();
+
 	// We shouldn't call NativeShutdown here at all, it should be done by the framework.
 #ifdef ANDROID
 #ifdef ANDROID_NDK_PROFILER
 	moncleanup();
 #endif
-	// However, let's make sure the config was saved, since it may not have been.
-	g_Config.Save();
 	exit(0);
 #endif
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1090,6 +1090,8 @@ UI::EventReturn MainScreen::OnExit(UI::EventParams &e) {
 #ifdef ANDROID_NDK_PROFILER
 	moncleanup();
 #endif
+	// However, let's make sure the config was saved, since it may not have been.
+	g_Config.Save();
 	exit(0);
 #endif
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -360,6 +360,10 @@ namespace MainWindow
 		}
 	}
 
+	void Minimize() {
+		ShowWindow(hwndMain, SW_MINIMIZE);
+	}
+
 	RECT DetermineWindowRectangle() {
 		RECT rc;
 

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -62,6 +62,7 @@ namespace MainWindow
 	HINSTANCE GetHInstance();
 	HWND GetDisplayHWND();
 	void ToggleFullscreen(HWND hWnd, bool goingFullscreen);
+	void Minimize();
 	void SendToggleFullscreen(bool fullscreen);  // To be used off-thread
 	void ToggleDebugConsoleVisibility();
 	void SetInternalResolution(int res = -1);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -482,6 +482,11 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	g_Config.bEnableLogging = true;
 #endif
 
+	if (iCmdShow == SW_MAXIMIZE) {
+		// Consider this to mean --fullscreen.
+		g_Config.bFullScreen = true;
+	}
+
 	LogManager::Init();
 	// Consider at least the following cases before changing this code:
 	//   - By default in Release, the console should be hidden by default even if logging is enabled.
@@ -520,6 +525,11 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	host->SetWindowTitle(0);
 
 	MainWindow::CreateDebugWindows();
+
+	const bool minimized = iCmdShow == SW_MINIMIZE || iCmdShow == SW_SHOWMINIMIZED || iCmdShow == SW_SHOWMINNOACTIVE;
+	if (minimized) {
+		MainWindow::Minimize();
+	}
 
 	// Emu thread is always running!
 	EmuThread_Start();

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -879,15 +879,15 @@ int main(int argc, char *argv[]) {
 #ifndef _WIN32
 	delete joystick;
 #endif
+	NativeShutdownGraphics();
+	NativeShutdown();
 	// Faster exit, thanks to the OS. Remove this if you want to debug shutdown
 	// The speed difference is only really noticable on Linux. On Windows you do notice it though
 #ifndef MOBILE_DEVICE
 	exit(0);
 #endif
-	NativeShutdownGraphics();
 	SDL_PauseAudio(1);
 	SDL_CloseAudio();
-	NativeShutdown();
 #ifdef USING_EGL
 	EGL_Close();
 #endif


### PR DESCRIPTION
On Linux, Mac, and Android, it seems like the config was not always being saved on exit.  I think maybe even iOS too, not sure.  Since you can pin/unpin and change the current directory in the game browser, this sorta needs to happen.

Additionally, adds support for the min/max shortcut.  It's not very important, but it's a nice-to-have for certain tooling workflows to be able to start minimized.

-[Unknown]
