### PR TITLE
Improve sceUtilityGamedataInstall a bit

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -31,7 +31,9 @@ std::string saveBasePath = "ms0:/PSP/SAVEDATA/";
 const static int GAMEDATA_INIT_DELAY_US = 200000;
 const static int GAMEDATA_SHUTDOWN_DELAY_US = 2000;
 const static u32 GAMEDATA_BYTES_PER_READ = 32768;
-const static u32 GAMEDATA_READS_PER_UPDATE = 100;
+// TODO: Could adjust based on real-time into frame?  Or eat cycles?
+// If this is too high, some games (e.g. Senjou no Valkyria 3) will lag.
+const static u32 GAMEDATA_READS_PER_UPDATE = 20;
 
 static const std::string SFO_FILENAME = "PARAM.SFO";
 

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -51,9 +51,10 @@ private:
 	void OpenNextFile();
 	void CopyCurrentFileData();
 	void CloseCurrentFile();
+	void WriteSfoFile();
 
 	SceUtilityGamedataInstallParam request;
-	u32 paramAddr;
+	PSPPointer<SceUtilityGamedataInstallParam> param;
 	std::vector<std::string> inFileNames;
 	int numFiles;
 	int readFiles;

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "Core/Dialog/PSPDialog.h"
+#include "Core/Dialog/SavedataParam.h"
 
 struct SceUtilityGamedataInstallParam {
 	pspUtilityDialogCommon common;
@@ -25,12 +26,8 @@ struct SceUtilityGamedataInstallParam {
 	char gameName[13];
 	char ignore1[3];
 	char dataName[20];
-	char gamedataParamsGameTitle[128];
-	char gamedataParamsDataTitle[128];
-	char gamedataParamsData[1024];
-	u8 unknown2;
-	char ignore2[3];
-	char progress[4]; // This is progress value,should be updated.
+	PspUtilitySavedataSFOParam sfoParam;
+	int progress;
 	u32_le unknownResult1;
 	u32_le unknownResult2;
 	char ignore3[48];
@@ -50,6 +47,8 @@ public:
 	std::string GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, std::string filename);
 
 private:
+	void UpdateProgress();
+
 	SceUtilityGamedataInstallParam request;
 	u32 paramAddr;
 	std::vector<std::string> inFileNames;
@@ -58,6 +57,4 @@ private:
 	u64 allFilesSize;  // use this to calculate progress value.
 	u64 allReadSize;   // use this to calculate progress value.
 	int progressValue;
-
-	void updateProgress();
 };

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -48,6 +48,7 @@ public:
 
 private:
 	void UpdateProgress();
+	void OpenNextFile();
 
 	SceUtilityGamedataInstallParam request;
 	u32 paramAddr;
@@ -57,4 +58,8 @@ private:
 	u64 allFilesSize;  // use this to calculate progress value.
 	u64 allReadSize;   // use this to calculate progress value.
 	int progressValue;
+
+	u32 currentInputFile;
+	u32 currentInputBytesLeft;
+	u32 currentOutputFile;
 };

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -49,6 +49,8 @@ public:
 private:
 	void UpdateProgress();
 	void OpenNextFile();
+	void CopyCurrentFileData();
+	void CloseCurrentFile();
 
 	SceUtilityGamedataInstallParam request;
 	u32 paramAddr;


### PR DESCRIPTION
This is still not exact, and I haven't really done any proper testing.  But it gets it a lot closer.

Major changes:
1. Progress now updates evenly during the install, instead of only 0 or 100%.
2. The interface now remains responsive during the file copy / install.
3. A PARAM.SFO file is written after install completes (FF4 seems to clearly expect this.)

With these changes, FF4's install feature appears to work correctly.  Also tested Senjou no Valkyria 3.

-[Unknown]
