### PR TITLE
Restore JIT for armv7/armv7s iOS 9 devices, which were erroneously disabled when I fixed PPSSPP's arm64 crashing.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1030,7 +1030,8 @@ void DeveloperToolsScreen::CreateViews() {
 	if (!iosCanUseJit) {
 		canUseJit = false;
 		if (targetIsJailbroken) {
-			list->Add(new TextView(sy->T("iOS9NoDynarec", "Dynarec (JIT) - (JIT temporarily unavailable on iOS 9)")));
+			// if the device is jailbroken and it's being marked as unable to JIT, then that means it must be arm64 iOS 9
+			list->Add(new TextView(sy->T("iOS9NoDynarec", "Dynarec (JIT) - (JIT not yet working on arm64 iOS 9)")));
 		} else {
 			list->Add(new TextView(sy->T("DynarecisJailed", "Dynarec (JIT) - (Not jailbroken - JIT not available)")));
 		}


### PR DESCRIPTION
So... I just realised that my pull request #8152 (which was intended to be a workaround for #8122) pretty much destroyed performance for armv7/armv7s devices running on iOS 9 due to JIT being indiscriminately forcibly disabled.

Oh god, what have I done?

Anyway, this pull request fixes that by only disabling JIT on arm64 >= iOS 9.
