### PR TITLE
[iOS]: prevent crashing (EXC_BAD_ACCESS) when releasing FFMPEG contex…

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -373,14 +373,10 @@ struct Atrac {
 		avcodec_free_context(&pCodecCtx);
 #else
 		// Future versions may add other things to free, but avcodec_free_context didn't exist yet here.
+		av_freep(&pCodecCtx->extradata);
+		av_freep(&pCodecCtx->subtitle_header);
 		avcodec_close(pCodecCtx);
-		if (pCodecCtx != NULL) {
-			av_freep(&pCodecCtx->extradata);
-			av_freep(&pCodecCtx->subtitle_header);
-			av_freep(&pCodecCtx);
-        } else {
-			ERROR_LOG(ME,"Unexpected: pCodecCtx is NULL");
-        }
+		av_freep(&pCodecCtx);
 #endif
 		av_free_packet(packet);
 		delete packet;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -374,11 +374,11 @@ struct Atrac {
 #else
 		// Future versions may add other things to free, but avcodec_free_context didn't exist yet here.
 		avcodec_close(pCodecCtx);
-        if ( pCodecCtx != NULL ) {
-            av_freep(&pCodecCtx->extradata);
-            av_freep(&pCodecCtx->subtitle_header);
-            av_freep(&pCodecCtx);
-        }
+		if ( pCodecCtx != NULL ) {
+			av_freep(&pCodecCtx->extradata);
+			av_freep(&pCodecCtx->subtitle_header);
+			av_freep(&pCodecCtx);
+		}
 #endif
 		av_free_packet(packet);
 		delete packet;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -374,11 +374,13 @@ struct Atrac {
 #else
 		// Future versions may add other things to free, but avcodec_free_context didn't exist yet here.
 		avcodec_close(pCodecCtx);
-		if ( pCodecCtx != NULL ) {
+		if (pCodecCtx != NULL) {
 			av_freep(&pCodecCtx->extradata);
 			av_freep(&pCodecCtx->subtitle_header);
 			av_freep(&pCodecCtx);
-		}
+        } else {
+			ERROR_LOG(ME,"Unexpected: pCodecCtx is NULL");
+        }
 #endif
 		av_free_packet(packet);
 		delete packet;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -374,9 +374,11 @@ struct Atrac {
 #else
 		// Future versions may add other things to free, but avcodec_free_context didn't exist yet here.
 		avcodec_close(pCodecCtx);
-		av_freep(&pCodecCtx->extradata);
-		av_freep(&pCodecCtx->subtitle_header);
-		av_freep(&pCodecCtx);
+        if ( pCodecCtx != NULL ) {
+            av_freep(&pCodecCtx->extradata);
+            av_freep(&pCodecCtx->subtitle_header);
+            av_freep(&pCodecCtx);
+        }
 #endif
 		av_free_packet(packet);
 		delete packet;


### PR DESCRIPTION
…t by adding NULL check on codec context pointer

Ran into regular crashes when running Final Fantasy VII: Crisis Core (J) on iOS. Tracked the crashes down to this block of code. The codec context pointer was NULL so...yeah :)
