### PR TITLE
Fix glCopyImageSubData even more

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -423,8 +423,6 @@ void __DisplayGetDebugStats(char stats[], size_t bufsize) {
 		"Most active syscall: %s : %0.2f ms\n"
 		"Draw calls: %i, flushes %i\n"
 		"Cached Draw calls: %i\n"
-		"Alpha Tested draws: %i\n"
-		"Non Alpha Tested draws: %i\n"
 		"Num Tracked Vertex Arrays: %i\n"
 		"Cycles executed: %d (%f per vertex)\n"
 		"Commands per call level: %i %i %i %i\n"
@@ -447,8 +445,6 @@ void __DisplayGetDebugStats(char stats[], size_t bufsize) {
 		gpuStats.numDrawCalls,
 		gpuStats.numFlushes,
 		gpuStats.numCachedDrawCalls,
-		gpuStats.numAlphaTestedDraws,
-		gpuStats.numNonAlphaTestedDraws,
 		gpuStats.numTrackedVertexArrays,
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles,

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -257,11 +257,6 @@ void ComputeFragmentShaderID(ShaderID *id_out, uint32_t vertType) {
 			id.SetBits(FS_BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4, ReplaceAlphaWithStencilType());
 		}
 
-		if (enableAlphaTest)
-			gpuStats.numAlphaTestedDraws++;
-		else
-			gpuStats.numNonAlphaTestedDraws++;
-
 		// 2 bits.
 		id.SetBits(FS_BIT_REPLACE_LOGIC_OP_TYPE, 2, ReplaceLogicOpType());
 

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -66,8 +66,6 @@ struct GPUStatistics {
 		numShaderSwitches = 0;
 		numFlushes = 0;
 		numTexturesDecoded = 0;
-		numAlphaTestedDraws = 0;
-		numNonAlphaTestedDraws = 0;
 		msProcessingDisplayLists = 0;
 		vertexGPUCycles = 0;
 		otherGPUCycles = 0;
@@ -90,9 +88,6 @@ struct GPUStatistics {
 	int vertexGPUCycles;
 	int otherGPUCycles;
 	int gpuCommandsAtCallLevel[4];
-
-	int numAlphaTestedDraws;
-	int numNonAlphaTestedDraws;
 
 	// Total statistics, updated by the GPU core in UpdateStats
 	int numVBlanks;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -311,6 +311,12 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight)
 	glDisableVertexAttribArray(attr_tex);
 
 	glBindTexture(GL_TEXTURE_2D, 0);
+
+	if (vao != 0) {
+		glBindVertexArray(0);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	}
 }
 
 void SoftGPU::CopyDisplayToOutput()

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -28,9 +28,6 @@ static HWND hWnd;   // Holds Our Window Handle
 static D3DPRESENT_PARAMETERS pp;
 static HMODULE hD3D9;
 
-// TODO: Make config?
-static bool enableGLDebug = true;
-
 void D3D9_SwapBuffers() {
 	if (has9Ex) {
 		deviceEx->EndScene();


### PR DESCRIPTION
So, when we download using on-GPU color conversion, we blit first to a framebuffer of the specified format.  Then we download from that.  Because the internal formats differ, `glCopyImageSubData()` doesn't work and fails.

I was able to reproduce this in Gods Eater Burst, where the save menu flickers again without this change.  Also mentioned in #7347.

-[Unknown]
