### PR TITLE
Graphics context

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -222,6 +222,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="GraphicsContext.h" />
     <ClInclude Include="KeyMap.h" />
     <ClInclude Include="Log.h" />
     <ClInclude Include="LogManager.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -57,6 +57,7 @@
     <ClInclude Include="GL\GLInterfaceBase.h">
       <Filter>GL</Filter>
     </ClInclude>
+    <ClInclude Include="GraphicsContext.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp" />

--- a/Common/GraphicsContext.h
+++ b/Common/GraphicsContext.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include "thin3d/thin3d.h"
+
+// Init is done differently on each platform, and done close to the creation, so it's
+// expected to be implemented by subclasses.
+class GraphicsContext {
+public:
+	virtual ~GraphicsContext() {}
+
+	virtual void Shutdown() = 0;
+	virtual void SwapInterval(int interval) = 0;
+	virtual void SwapBuffers() = 0;
+
+	// Used during window resize. Must be called from the window thread,
+	// not the rendering thread or CPU thread.
+	virtual void Pause() {}
+	virtual void Resume() {}
+
+	virtual void Resize() = 0;
+
+	virtual Thin3DContext *CreateThin3DContext() = 0;
+};
+
+class DummyGraphicsContext : public GraphicsContext {
+public:
+	void Shutdown() override {}
+	void SwapInterval(int interval) override {}
+	void SwapBuffers() override {}
+	void Resize() override {}
+
+	Thin3DContext *CreateThin3DContext() override { return nullptr; }
+};

--- a/Common/GraphicsContext.h
+++ b/Common/GraphicsContext.h
@@ -12,6 +12,7 @@ public:
 
 	virtual void Shutdown() = 0;
 	virtual void SwapInterval(int interval) = 0;
+
 	virtual void SwapBuffers() = 0;
 
 	// Used during window resize. Must be called from the window thread,

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -58,6 +58,10 @@ static GraphicsContext *graphicsContext;
 
 extern InputState input_state;
 
+void Core_SetGraphicsContext(GraphicsContext *ctx) {
+  graphicsContext = ctx;
+}
+
 void Core_NotifyWindowHidden(bool hidden) {
 	windowHidden = hidden;
 	// TODO: Wait until we can react?
@@ -314,9 +318,7 @@ reswitch:
 			return;
 		}
 	}
-
 }
-
 
 void Core_EnableStepping(bool step) {
 	if (step) {

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -56,11 +56,7 @@ static double lastActivity = 0.0;
 static double lastKeepAwake = 0.0;
 static GraphicsContext *graphicsContext;
 
-#ifdef _WIN32
-InputState input_state;
-#else
 extern InputState input_state;
-#endif
 
 void Core_NotifyWindowHidden(bool hidden) {
 	windowHidden = hidden;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -54,6 +54,7 @@ static std::set<Core_ShutdownFunc> shutdownFuncs;
 static bool windowHidden = false;
 static double lastActivity = 0.0;
 static double lastKeepAwake = 0.0;
+static GraphicsContext *graphicsContext;
 
 #ifdef _WIN32
 InputState input_state;
@@ -163,26 +164,12 @@ void UpdateRunLoop() {
 	}
 
 	if (GetUIState() != UISTATE_EXIT) {
-		NativeRender();
+		NativeRender(graphicsContext);
 	}
 }
 
-#if defined(USING_WIN_UI)
-
-void GPU_SwapBuffers() {
-	switch (g_Config.iGPUBackend) {
-	case GPU_BACKEND_OPENGL:
-		GL_SwapBuffers();
-		break;
-	case GPU_BACKEND_DIRECT3D9:
-		D3D9_SwapBuffers();
-		break;
-	}
-}
-
-#endif
-
-void Core_RunLoop() {
+void Core_RunLoop(GraphicsContext *ctx) {
+	graphicsContext = ctx;
 	while ((GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT) {
 		time_update();
 #if defined(USING_WIN_UI)
@@ -196,7 +183,7 @@ void Core_RunLoop() {
 		if (sleepTime > 0)
 			Sleep(sleepTime);
 		if (!windowHidden) {
-			GPU_SwapBuffers();
+			ctx->SwapBuffers();
 		}
 #else
 		UpdateRunLoop();
@@ -208,7 +195,7 @@ void Core_RunLoop() {
 		UpdateRunLoop();
 #if defined(USING_WIN_UI)
 		if (!windowHidden && !Core_IsStepping()) {
-			GPU_SwapBuffers();
+			ctx->SwapBuffers();
 
 			// Keep the system awake for longer than normal for cutscenes and the like.
 			const double now = time_now_d();
@@ -246,7 +233,7 @@ static inline void CoreStateProcessed() {
 }
 
 // Some platforms, like Android, do not call this function but handle things on their own.
-void Core_Run()
+void Core_Run(GraphicsContext *ctx)
 {
 #if defined(_DEBUG)
 	host->UpdateDisassembly();
@@ -261,7 +248,7 @@ reswitch:
 			if (GetUIState() == UISTATE_EXIT) {
 				return;
 			}
-			Core_RunLoop();
+			Core_RunLoop(ctx);
 #if defined(USING_QT_UI) && !defined(MOBILE_DEVICE)
 			return;
 #else
@@ -273,7 +260,7 @@ reswitch:
 		{
 		case CORE_RUNNING:
 			// enter a fast runloop
-			Core_RunLoop();
+			Core_RunLoop(ctx);
 			break;
 
 		// We should never get here on Android.

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -20,9 +20,11 @@
 #include "Core/System.h"
 #include "Core/CoreParameter.h"
 
+class GraphicsContext;
+
 // called from emu thread
 void UpdateRunLoop();
-void Core_Run();
+void Core_Run(GraphicsContext *ctx);
 void Core_Stop();
 void Core_ErrorPause();
 // called from gui

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -27,6 +27,8 @@ void UpdateRunLoop();
 void Core_Run(GraphicsContext *ctx);
 void Core_Stop();
 void Core_ErrorPause();
+// For platforms that don't call Core_Run
+void Core_SetGraphicsContext(GraphicsContext *ctx);
 // called from gui
 void Core_EnableStepping(bool step);
 void Core_DoSingleStep();

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -35,11 +35,15 @@ enum GPUCore {
 
 class FileLoader;
 
+class GraphicsContext;
+
 // PSP_CoreParameter()
 struct CoreParameter {
 	CoreParameter() : collectEmuLog(0), unthrottle(false), fpsLimit(0), updateRecent(true), freezeNext(false), frozen(false), mountIsoLoader(nullptr) {}
+
 	CPUCore cpuCore;
 	GPUCore gpuCore;
+	GraphicsContext *graphicsContext;  // TODO: Find a better place.
 	bool enableSound;  // there aren't multiple sound cores.
 
 	std::string fileToStart;

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -21,6 +21,7 @@
 #include "Common/CommonTypes.h"
 
 struct InputState;
+class GraphicsContext;
 
 // TODO: Whittle this down. Collecting a bunch of random stuff like this isn't good design :P
 class Host {
@@ -33,7 +34,7 @@ public:
 
 	virtual void SetDebugMode(bool mode) { }
 
-	virtual bool InitGraphics(std::string *error_string) = 0;
+	virtual bool InitGraphics(std::string *error_string, GraphicsContext **ctx) = 0;
 	virtual void ShutdownGraphics() = 0;
 
 	virtual void InitSound() = 0;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -360,6 +360,7 @@ void System_Wake() {
 static bool pspIsInited = false;
 static bool pspIsIniting = false;
 static bool pspIsQuiting = false;
+// Ugly!
 
 bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 	if (pspIsIniting || pspIsQuiting) {
@@ -407,7 +408,7 @@ bool PSP_InitUpdate(std::string *error_string) {
 	bool success = coreParameter.fileToStart != "";
 	*error_string = coreParameter.errorString;
 	if (success) {
-		success = GPU_Init();
+		success = GPU_Init(coreParameter.graphicsContext);
 		if (!success) {
 			PSP_Shutdown();
 			*error_string = "Unable to initialize rendering engine.";

--- a/Core/System.h
+++ b/Core/System.h
@@ -47,6 +47,7 @@ enum PSPDirectories {
 	DIRECTORY_CACHE,
 };
 
+class GraphicsContext;
 
 void UpdateUIState(GlobalUIState newState);
 GlobalUIState GetUIState();

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -19,6 +19,7 @@
 #include "profiler/profiler.h"
 
 #include "Common/ChunkFile.h"
+#include "Common/GraphicsContext.h"
 
 #include "Core/Config.h"
 #include "Core/Debugger/Breakpoints.h"
@@ -394,8 +395,8 @@ static const CommandTableEntry commandTable[] = {
 
 GLES_GPU::CommandInfo GLES_GPU::cmdInfo_[256];
 
-GLES_GPU::GLES_GPU()
-: resized_(false) {
+GLES_GPU::GLES_GPU(GraphicsContext *ctx)
+: resized_(false), gfxCtx_(ctx) {
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
 
@@ -466,7 +467,7 @@ GLES_GPU::~GLES_GPU() {
 	shaderManager_ = nullptr;
 
 #ifdef _WIN32
-	GL_SwapInterval(0);
+	gfxCtx_->SwapInterval(0);
 #endif
 }
 
@@ -674,7 +675,7 @@ inline void GLES_GPU::UpdateVsyncInterval(bool force) {
 		//	// See http://developer.download.nvidia.com/opengl/specs/WGL_EXT_swap_control_tear.txt
 		//	glstate.SetVSyncInterval(-desiredVSyncInterval);
 		//} else {
-			GL_SwapInterval(desiredVSyncInterval);
+		gfxCtx_->SwapInterval(desiredVSyncInterval);
 		//}
 		lastVsync_ = desiredVSyncInterval;
 	}

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -30,10 +30,11 @@
 
 class ShaderManager;
 class LinkedShader;
+class GraphicsContext;
 
 class GLES_GPU : public GPUCommon {
 public:
-	GLES_GPU();
+	GLES_GPU(GraphicsContext *gfxCtx);
 	~GLES_GPU();
 
 	// This gets called on startup and when we get back from settings.
@@ -192,4 +193,6 @@ private:
 
 	std::string reportingPrimaryInfo_;
 	std::string reportingFullInfo_;
+
+	GraphicsContext *gfxCtx_;
 };

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -38,13 +38,13 @@ static void SetGPU(T *obj) {
 	gpuDebug = obj;
 }
 
-bool GPU_Init() {
+bool GPU_Init(GraphicsContext *ctx) {
 	switch (PSP_CoreParameter().gpuCore) {
 	case GPU_NULL:
 		SetGPU(new NullGPU());
 		break;
 	case GPU_GLES:
-		SetGPU(new GLES_GPU());
+		SetGPU(new GLES_GPU(ctx));
 		break;
 	case GPU_SOFTWARE:
 		SetGPU(new SoftGPU());

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -22,6 +22,7 @@
 
 class GPUInterface;
 class GPUDebugInterface;
+class GraphicsContext;
 
 enum SkipDrawReasonFlags {
 	SKIPDRAW_SKIPFRAME = 1,
@@ -103,6 +104,6 @@ extern GPUStatistics gpuStats;
 extern GPUInterface *gpu;
 extern GPUDebugInterface *gpuDebug;
 
-bool GPU_Init();
+bool GPU_Init(GraphicsContext *ctx);
 void GPU_Shutdown();
 void GPU_Reinitialize();

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -37,7 +37,7 @@ public:
 
 	void SetDebugMode(bool mode) override { }
 
-	bool InitGraphics(std::string *error_message) override { return true; }
+	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
 	void ShutdownGraphics() override {}
 
 	void InitSound() override;

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -93,7 +93,7 @@ public:
 			mainWindow->GetDialogDisasm()->SetDebugMode(mode);
 	}
 
-	virtual bool InitGraphics(std::string *error_message) override { return true; }
+	virtual bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
 	virtual void ShutdownGraphics() override {}
 
 	virtual void InitSound() override;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -506,20 +506,8 @@ void NativeInit(int argc, const char *argv[],
 	}
 }
 
-void NativeInitGraphics() {
-#ifndef _WIN32
-	// Force backend to GL
-	g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
-#endif
-
-	if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
-		thin3d = T3DCreateGLContext();
-		CheckGLExtensions();
-	} else {
-#ifdef _WIN32
-		thin3d = D3D9_CreateThin3DContext();
-#endif
-	}
+void NativeInitGraphics(GraphicsContext *graphicsContext) {
+	thin3d = graphicsContext->CreateThin3DContext();
 
 	ui_draw2d.SetAtlas(&ui_atlas);
 	ui_draw2d_front.SetAtlas(&ui_atlas);
@@ -692,7 +680,7 @@ void DrawDownloadsOverlay(UIContext &dc) {
 	dc.Flush();
 }
 
-void NativeRender() {
+void NativeRender(GraphicsContext *graphicsContext) {
 	g_GameManager.Update();
 
 	float xres = dp_xres;
@@ -725,17 +713,16 @@ void NativeRender() {
 
 	if (resized) {
 		resized = false;
-		if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
-#ifdef _WIN32
-			D3D9_Resize(0);
-#endif
-		} else if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
+
+		graphicsContext->Resize();
+		// TODO: Move this to new GraphicsContext objects for each backend.
 #ifndef _WIN32
+		if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
 			PSP_CoreParameter().pixelWidth = pixel_xres;
 			PSP_CoreParameter().pixelHeight = pixel_yres;
 			NativeMessageReceived("gpu resized", "");
-#endif
 		}
+#endif
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -37,7 +37,6 @@
 #if defined(_WIN32)
 #include "Windows/DSoundStream.h"
 #include "Windows/MainWindow.h"
-#include "Windows/GPU/D3D9Context.h"
 #endif
 
 #include "base/display.h"
@@ -68,6 +67,7 @@
 #include "Common/FileUtil.h"
 #include "Common/LogManager.h"
 #include "Common/MemArena.h"
+#include "Common/GraphicsContext.h"
 #include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/FileLoaders/DiskCachingFileLoader.h"

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -507,6 +507,7 @@ void NativeInit(int argc, const char *argv[],
 }
 
 void NativeInitGraphics(GraphicsContext *graphicsContext) {
+	Core_SetGraphicsContext(graphicsContext);
 	thin3d = graphicsContext->CreateThin3DContext();
 
 	ui_draw2d.SetAtlas(&ui_atlas);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -117,8 +117,10 @@ unsigned int WINAPI TheThread(void *)
 
 	host->UpdateUI();
 
+	GraphicsContext *graphicsContext;
+
 	std::string error_string;
-	if (!host->InitGraphics(&error_string)) {
+	if (!host->InitGraphics(&error_string, &graphicsContext)) {
 		I18NCategory *err = GetI18NCategory("Error");
 		Reporting::ReportMessage("Graphics init error: %s", error_string.c_str());
 
@@ -154,7 +156,9 @@ unsigned int WINAPI TheThread(void *)
 		ExitProcess(1);
 	}
 
-	NativeInitGraphics();
+	PSP_CoreParameter().graphicsContext = graphicsContext;
+
+	NativeInitGraphics(graphicsContext);
 	NativeResized();
 
 	INFO_LOG(BOOT, "Done.");
@@ -179,7 +183,7 @@ unsigned int WINAPI TheThread(void *)
 		if (!Core_IsActive())
 			UpdateUIState(UISTATE_MENU);
 
-		Core_Run();
+		Core_Run(graphicsContext);
 	}
 
 shutdown:

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -4,7 +4,9 @@
 #include "base/NativeApp.h"
 #include "base/mutex.h"
 #include "i18n/i18n.h"
+#include "input/input_state.h"
 #include "util/text/utf8.h"
+
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
 #include "../Globals.h"
@@ -28,6 +30,8 @@
 static recursive_mutex emuThreadLock;
 static HANDLE emuThread;
 static volatile long emuThreadReady;
+
+InputState input_state;
 
 extern std::vector<std::wstring> GetWideCmdLine();
 

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -16,6 +16,7 @@
 #include "thin3d/thin3d.h"
 #include "thin3d/d3dx9_loader.h"
 
+// TODO: Move these into the context class.
 static bool has9Ex = false;
 static LPDIRECT3D9 d3d;
 static LPDIRECT3D9EX d3dEx;
@@ -28,7 +29,8 @@ static HWND hWnd;   // Holds Our Window Handle
 static D3DPRESENT_PARAMETERS pp;
 static HMODULE hD3D9;
 
-void D3D9_SwapBuffers() {
+
+void D3D9Context::SwapBuffers() {
 	if (has9Ex) {
 		deviceEx->EndScene();
 		deviceEx->PresentEx(NULL, NULL, NULL, NULL, 0);
@@ -40,7 +42,7 @@ void D3D9_SwapBuffers() {
 	}
 }
 
-Thin3DContext *D3D9_CreateThin3DContext() {
+Thin3DContext *D3D9Context::CreateThin3DContext() {
 	return T3DCreateDX9Context(d3d, d3dEx, adapterId, device, deviceEx);
 }
 
@@ -61,7 +63,12 @@ static void GetRes(int &xres, int &yres) {
 	yres = rc.bottom - rc.top;
 }
 
-bool D3D9_Init(HWND wnd, bool windowed, std::string *error_message) {
+void D3D9Context::SwapInterval(int interval) {
+	// Dummy
+}
+
+bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
+	bool windowed = true;
 	hWnd = wnd;
 
 	DIRECT3DCREATE9EX g_pfnCreate9ex;
@@ -195,7 +202,7 @@ bool D3D9_Init(HWND wnd, bool windowed, std::string *error_message) {
 	return true;
 }
 
-void D3D9_Resize(HWND window) {
+void D3D9Context::Resize() {
 	// This should only be called from the emu thread.
 
 	int xres, yres;
@@ -218,7 +225,7 @@ void D3D9_Resize(HWND window) {
 	}
 }
 
-void D3D9_Shutdown() {
+void D3D9Context::Shutdown() {
 	DX9::DestroyShaders();
 	DX9::fbo_shutdown();
 	device->EndScene();

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -1,6 +1,5 @@
 #include "Common/CommonWindows.h"
 #include <d3d9.h>
-#include <DxErr.h>
 
 #include "GPU/Directx9/helper/global.h"
 #include "GPU/Directx9/helper/dx_fbo.h"
@@ -15,20 +14,6 @@
 #include "Windows/W32Util/Misc.h"
 #include "thin3d/thin3d.h"
 #include "thin3d/d3dx9_loader.h"
-
-// TODO: Move these into the context class.
-static bool has9Ex = false;
-static LPDIRECT3D9 d3d;
-static LPDIRECT3D9EX d3dEx;
-static int adapterId;
-static LPDIRECT3DDEVICE9 device;
-static LPDIRECT3DDEVICE9EX deviceEx;
-static HDC hDC;     // Private GDI Device Context
-static HGLRC hRC;   // Permanent Rendering Context
-static HWND hWnd;   // Holds Our Window Handle
-static D3DPRESENT_PARAMETERS pp;
-static HMODULE hD3D9;
-
 
 void D3D9Context::SwapBuffers() {
 	if (has9Ex) {
@@ -56,7 +41,7 @@ bool IsWin7OrLater() {
 	return (major > 6) || ((major == 6) && (minor >= 1));
 }
 
-static void GetRes(int &xres, int &yres) {
+static void GetRes(HWND hWnd, int &xres, int &yres) {
 	RECT rc;
 	GetClientRect(hWnd, &rc);
 	xres = rc.right - rc.left;
@@ -143,7 +128,7 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		dwBehaviorFlags |= D3DCREATE_SOFTWARE_VERTEXPROCESSING;
 
 	int xres, yres;
-	GetRes(xres, yres);
+	GetRes(hWnd, xres, yres);
 
 	memset(&pp, 0, sizeof(pp));
 	pp.BackBufferWidth = xres;
@@ -206,7 +191,7 @@ void D3D9Context::Resize() {
 	// This should only be called from the emu thread.
 
 	int xres, yres;
-	GetRes(xres, yres);
+	GetRes(hWnd, xres, yres);
 	bool w_changed = pp.BackBufferWidth != xres;
 	bool h_changed = pp.BackBufferHeight != yres;
 

--- a/Windows/GPU/D3D9Context.h
+++ b/Windows/GPU/D3D9Context.h
@@ -3,12 +3,19 @@
 #pragma once
 
 #include "Common/CommonWindows.h"
+#include "Windows/GPU/WindowsGraphicsContext.h"
 
 class Thin3DContext;
 
-bool D3D9_Init(HWND window, bool windowed, std::string *error_message);
-void D3D9_Shutdown();
-void D3D9_Resize(HWND window);
-void D3D9_SwapBuffers();
+class D3D9Context : public WindowsGraphicsContext {
+public:
+	bool Init(HINSTANCE hInst, HWND window, std::string *error_message) override;
+	void Shutdown() override;
+	void SwapInterval(int interval) override;
+	void SwapBuffers() override;
 
-Thin3DContext *D3D9_CreateThin3DContext();
+	void Resize() override;
+
+	Thin3DContext *CreateThin3DContext() override;
+};
+

--- a/Windows/GPU/D3D9Context.h
+++ b/Windows/GPU/D3D9Context.h
@@ -4,11 +4,16 @@
 
 #include "Common/CommonWindows.h"
 #include "Windows/GPU/WindowsGraphicsContext.h"
+#include <d3d9.h>
 
 class Thin3DContext;
 
 class D3D9Context : public WindowsGraphicsContext {
 public:
+	D3D9Context() : has9Ex(false), d3d(nullptr), d3dEx(nullptr), adapterId(-1), device(nullptr), deviceEx(nullptr), hDC(nullptr), hRC(nullptr), hWnd(nullptr), hD3D9(nullptr) {
+		memset(&pp, 0, sizeof(pp));
+	}
+
 	bool Init(HINSTANCE hInst, HWND window, std::string *error_message) override;
 	void Shutdown() override;
 	void SwapInterval(int interval) override;
@@ -17,5 +22,18 @@ public:
 	void Resize() override;
 
 	Thin3DContext *CreateThin3DContext() override;
+
+private:
+	bool has9Ex;
+	LPDIRECT3D9 d3d;
+	LPDIRECT3D9EX d3dEx;
+	int adapterId;
+	LPDIRECT3DDEVICE9 device;
+	LPDIRECT3DDEVICE9EX deviceEx;
+	HDC hDC;     // Private GDI Device Context
+	HGLRC hRC;   // Permanent Rendering Context
+	HWND hWnd;   // Holds Our Window Handle
+	HMODULE hD3D9;
+	D3DPRESENT_PARAMETERS pp;
 };
 

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -31,16 +31,6 @@
 #include "Windows/W32Util/Misc.h"
 #include "Windows/GPU/WindowsGLContext.h"
 
-static HDC hDC;     // Private GDI Device Context
-static HGLRC hRC;   // Permanent Rendering Context
-static HWND hWnd;   // Holds Our Window Handle
-static volatile bool pauseRequested;
-static volatile bool resumeRequested;
-static HANDLE pauseEvent;
-static HANDLE resumeEvent;
-
-static int xres, yres;
-
 void WindowsGLContext::SwapBuffers() {
 	::SwapBuffers(hDC);
 

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -41,8 +41,8 @@ static HANDLE resumeEvent;
 
 static int xres, yres;
 
-void GL_SwapBuffers() {
-	SwapBuffers(hDC);
+void WindowsGLContext::SwapBuffers() {
+	::SwapBuffers(hDC);
 
 	// Used during fullscreen switching to prevent rendering.
 	if (pauseRequested) {
@@ -60,7 +60,7 @@ void GL_SwapBuffers() {
 	// glFinish();
 }
 
-void GL_Pause() {
+void WindowsGLContext::Pause() {
 	if (!hRC) {
 		return;
 	}
@@ -73,7 +73,7 @@ void GL_Pause() {
 	// OK, we now know the rendering thread is paused.
 }
 
-void GL_Resume() {
+void WindowsGLContext::Resume() {
 	if (!hRC) {
 		return;
 	}
@@ -153,7 +153,7 @@ void DebugCallbackARB(GLenum source, GLenum type, GLuint id, GLenum severity,
 	}
 }
 
-bool GL_Init(HWND window, std::string *error_message) {
+bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_message) {
 	*error_message = "ok";
 	hWnd = window;
 	GLuint PixelFormat;
@@ -320,7 +320,7 @@ bool GL_Init(HWND window, std::string *error_message) {
 
 	hRC = m_hrc;
 
-	GL_SwapInterval(0);
+	SwapInterval(0);
 
 	if (g_Config.bGfxDebugOutput) {
 		if (wglewIsSupported("GL_KHR_debug") == 1) {
@@ -361,13 +361,13 @@ bool GL_Init(HWND window, std::string *error_message) {
 	return true;												// Success
 }
 
-void GL_SwapInterval(int interval) {
+void WindowsGLContext::SwapInterval(int interval) {
 	// glew loads wglSwapIntervalEXT if available
 	if (wglSwapIntervalEXT)
 		wglSwapIntervalEXT(interval);
 }
 
-void GL_Shutdown() { 
+void WindowsGLContext::Shutdown() {
 	CloseHandle(pauseEvent);
 	CloseHandle(resumeEvent);
 	if (hRC) {
@@ -391,4 +391,15 @@ void GL_Shutdown() {
 		hDC = NULL;
 	}
 	hWnd = NULL;
+}
+
+void WindowsGLContext::Resize() {
+}
+
+Thin3DContext *WindowsGLContext::CreateThin3DContext() {
+	Thin3DContext *ctx = T3DCreateGLContext();
+	if (ctx) {
+		CheckGLExtensions();
+	}
+	return ctx;
 }

--- a/Windows/GPU/WindowsGLContext.h
+++ b/Windows/GPU/WindowsGLContext.h
@@ -20,4 +20,15 @@ public:
 	void Resize() override;
 
 	Thin3DContext *CreateThin3DContext() override;
+
+private:
+	HDC hDC;     // Private GDI Device Context
+	HGLRC hRC;   // Permanent Rendering Context
+	HWND hWnd;   // Holds Our Window Handle
+	volatile bool pauseRequested;
+	volatile bool resumeRequested;
+	HANDLE pauseEvent;
+	HANDLE resumeEvent;
+
+	int xres, yres;
 };

--- a/Windows/GPU/WindowsGLContext.h
+++ b/Windows/GPU/WindowsGLContext.h
@@ -1,13 +1,23 @@
 #pragma once
 
 #include "Common/CommonWindows.h"
+#include "Windows/GPU/WindowsGraphicsContext.h"
 
-bool GL_Init(HWND window, std::string *error_message);
-void GL_Shutdown();
-void GL_SwapInterval(int interval);
-void GL_SwapBuffers();
+class Thin3DContext;
 
-// Used during window resize. Must be called from the window thread,
-// not the rendering thread or CPU thread.
-void GL_Pause();
-void GL_Resume();
+class WindowsGLContext : public WindowsGraphicsContext {
+public:
+	bool Init(HINSTANCE hInst, HWND window, std::string *error_message) override;
+	void Shutdown() override;
+	void SwapInterval(int interval) override;
+	void SwapBuffers() override;
+
+	// Used during window resize. Must be called from the window thread,
+	// not the rendering thread or CPU thread.
+	void Pause() override;
+	void Resume() override;
+
+	void Resize() override;
+
+	Thin3DContext *CreateThin3DContext() override;
+};

--- a/Windows/GPU/WindowsGraphicsContext.h
+++ b/Windows/GPU/WindowsGraphicsContext.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Common/GraphicsContext.h"
+#include "Common/CommonWindows.h"
+
+class WindowsGraphicsContext : public GraphicsContext {
+public:
+	virtual bool Init(HINSTANCE hInst, HWND window, std::string *error_message) = 0;
+};
+

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -288,12 +288,10 @@ namespace MainWindow
 	}
 
 	void ToggleFullscreen(HWND hWnd, bool goingFullscreen) {
+		GraphicsContext *graphicsContext = PSP_CoreParameter().graphicsContext;
 		// Make sure no rendering is happening during the switch.
-
-		bool isOpenGL = g_Config.iGPUBackend == GPU_BACKEND_OPENGL;
-
-		if (isOpenGL) {
-			GL_Pause();
+		if (graphicsContext) {
+			graphicsContext->Pause();
 		}
 
 		int oldWindowState = g_WindowState;
@@ -355,8 +353,8 @@ namespace MainWindow
 
 		WindowsRawInput::NotifyMenu();
 
-		if (isOpenGL) {
-			GL_Resume();
+		if (graphicsContext) {
+			graphicsContext->Resume();
 		}
 	}
 

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -368,6 +368,7 @@
     <ClInclude Include="GEDebugger\TabDisplayLists.h" />
     <ClInclude Include="GEDebugger\TabState.h" />
     <ClInclude Include="GEDebugger\TabVertices.h" />
+    <ClInclude Include="GPU\WindowsGraphicsContext.h" />
     <ClInclude Include="InputDevice.h" />
     <ClInclude Include="KeyboardDevice.h" />
     <ClInclude Include="MainWindowMenu.h" />

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -275,6 +275,9 @@
     <ClInclude Include="GPU\WindowsGLContext.h">
       <Filter>Windows\System</Filter>
     </ClInclude>
+    <ClInclude Include="GPU\WindowsGraphicsContext.h">
+      <Filter>Windows\System</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="icon1.ico">

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -24,9 +24,11 @@
 extern float mouseDeltaX;
 extern float mouseDeltaY;
 
+class GraphicsContext;
+
 class WindowsHost : public Host {
 public:
-	WindowsHost(HWND mainWindow, HWND displayWindow);
+	WindowsHost(HINSTANCE hInstance, HWND mainWindow, HWND displayWindow);
 
 	~WindowsHost() {
 		UpdateConsolePosition();
@@ -37,7 +39,8 @@ public:
 	void UpdateUI() override;
 	void SetDebugMode(bool mode) override;
 
-	bool InitGraphics(std::string *error_message) override;
+	// If returns false, will return a null context
+	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
 	void PollControllers(InputState &input_state) override;
 	void ShutdownGraphics() override;
 
@@ -65,12 +68,16 @@ public:
 
 	std::shared_ptr<KeyboardDevice> keyboard;
 
+	GraphicsContext *GetGraphicsContext() { return gfx_; }
+
 private:
 	void SetConsolePosition();
 	void UpdateConsolePosition();
 
+	HINSTANCE hInstance_;
 	HWND displayWindow_;
 	HWND mainWindow_;
+	GraphicsContext *gfx_;
 
 	std::list<std::shared_ptr<InputDevice>> input;
 };

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -529,7 +529,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	DialogManager::AddDlg(vfpudlg = new CVFPUDlg(_hInstance, hwndMain, currentDebugMIPS));
 
-	host = new WindowsHost(hwndMain, hwndDisplay);
+	host = new WindowsHost(_hInstance, hwndMain, hwndDisplay);
 	host->SetWindowTitle(0);
 
 	MainWindow::CreateDebugWindows();

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -87,6 +87,7 @@ bool AndroidEGLGraphicsContext::Init(ANativeWindow *wnd, int backbufferWidth, in
 		return false;
 	}
 	gl->MakeCurrent();
+	return true;
 }
 
 void AndroidEGLGraphicsContext::Shutdown() {
@@ -134,10 +135,10 @@ static int desiredBackbufferSizeY;
 static jmethodID postCommand;
 static jobject nativeActivity;
 static volatile bool exitRenderLoop;
-bool renderLoopRunning;
+static bool renderLoopRunning;
 
-float dp_xscale = 1.0f;
-float dp_yscale = 1.0f;
+static float dp_xscale = 1.0f;
+static float dp_yscale = 1.0f;
 
 InputState input_state;
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -28,6 +28,7 @@
 #include "android/jni/native_audio.h"
 #include "gfx/gl_common.h"
 
+#include "Common/GraphicsContext.h"
 #include "Common/GL/GLInterfaceBase.h"
 
 #include "app-android.h"
@@ -41,6 +42,63 @@ struct FrameCommand {
 	std::string command;
 	std::string params;
 };
+
+class AndroidEGLGraphicsContext : public GraphicsContext {
+public:
+	AndroidEGLGraphicsContext() : wnd_(nullptr), gl(nullptr) {}
+	bool Init(ANativeWindow *wnd, int desiredBackbufferSizeX, int desiredBackbufferSizeY, int backbufferFormat);
+	void Shutdown() override;
+	void SwapBuffers() override;
+	void SwapInterval(int interval) override {}
+	void Resize() {}
+	Thin3DContext *CreateThin3DContext() {
+		return T3DCreateGLContext();
+	}
+
+private:
+	ANativeWindow *wnd_;
+	cInterfaceBase *gl;
+};
+
+bool AndroidEGLGraphicsContext::Init(ANativeWindow *wnd, int backbufferWidth, int backbufferHeight, int backbufferFormat) {
+	wnd_ = wnd;
+	gl = HostGL_CreateGLInterface();
+	if (!gl) {
+		ELOG("ERROR: Failed to create GL interface");
+		return false;
+	}
+	ILOG("EGL interface created. Desired backbuffer size: %dx%d", backbufferWidth, backbufferHeight);
+
+	// Apparently we still have to set this through Java through setFixedSize on the bufferHolder for it to take effect...
+	gl->SetBackBufferDimensions(backbufferWidth, backbufferHeight);
+	gl->SetMode(MODE_DETECT_ES);
+
+	bool use565 = false;
+	switch (backbufferFormat) {
+	case 4:  // PixelFormat.RGB_565
+		use565 = true;
+		break;
+	}
+
+	if (!gl->Create(wnd, false, use565)) {
+		ELOG("EGL creation failed");
+		// TODO: What do we do now?
+		delete gl;
+		return false;
+	}
+	gl->MakeCurrent();
+}
+
+void AndroidEGLGraphicsContext::Shutdown() {
+	gl->ClearCurrent();
+	delete gl;
+	ANativeWindow_release(wnd_);
+}
+
+void AndroidEGLGraphicsContext::SwapBuffers() {
+	gl->Swap();
+}
+
 
 static recursive_mutex frameCommandLock;
 static std::queue<FrameCommand> frameCommands;
@@ -87,6 +145,8 @@ static bool renderer_inited = false;
 static bool first_lost = true;
 static std::string library_path;
 static std::map<SystemPermission, PermissionStatus> permissions;
+
+AndroidEGLGraphicsContext *graphicsContext;
 
 void PushCommand(std::string cmd, std::string param) {
 	lock_guard guard(frameCommandLock);
@@ -607,33 +667,15 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 		return false;
 	}
 
-	cInterfaceBase *gl = HostGL_CreateGLInterface();
-	if (!gl) {
-		ELOG("ERROR: Failed to create GL interface");
+	AndroidEGLGraphicsContext *graphicsContext = new AndroidEGLGraphicsContext();
+	if (!graphicsContext->Init(wnd, desiredBackbufferSizeX, desiredBackbufferSizeY, backbuffer_format)) {
+		ELOG("Failed to initialize graphics context.");
+		delete graphicsContext;
 		return false;
 	}
-	ILOG("EGL interface created. Desired backbuffer size: %dx%d", desiredBackbufferSizeX, desiredBackbufferSizeY);
-
-	// Apparently we still have to set this through Java through setFixedSize on the bufferHolder for it to take effect...
-	gl->SetBackBufferDimensions(desiredBackbufferSizeX, desiredBackbufferSizeY);
-	gl->SetMode(MODE_DETECT_ES);
-
-	bool use565 = false;
-	switch (backbuffer_format) {
-	case 4:  // PixelFormat.RGB_565
-		use565 = true;
-		break;
-	}
-
-	if (!gl->Create(wnd, false, use565)) {
-		ELOG("EGL creation failed");
-		// TODO: What do we do now?
-		return false;
-	}
-	gl->MakeCurrent();
 
 	if (!renderer_inited) {
-		NativeInitGraphics();
+		NativeInitGraphics(graphicsContext);
 		renderer_inited = true;
 	}
 
@@ -665,10 +707,10 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 			EndInputState(&input_state);
 		}
 
-		NativeRender();
+		NativeRender(graphicsContext);
 		time_update();
 
-		gl->Swap();
+		graphicsContext->SwapBuffers();
 
 		lock_guard guard(frameCommandLock);
 		while (!frameCommands.empty()) {
@@ -693,10 +735,8 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 	NativeShutdownGraphics();
 	renderer_inited = false;
 
-	gl->ClearCurrent();
-	delete gl;
+	graphicsContext->Shutdown();
 
-	ANativeWindow_release(wnd);
 	renderLoopRunning = false;
 	WLOG("Render loop exited;");
 	return true;

--- a/b.sh
+++ b/b.sh
@@ -28,6 +28,7 @@ do
 		--ios) CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=ios/ios.toolchain.cmake -GXcode ${CMAKE_ARGS}"
 			TARGET_OS=iOS
 			PACKAGE=1
+			echo !!!!!!!!!!!!!!! The error below is expected. Go into build-ios and open the XCodeProj.
 			;;
 		--android) CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=android/android.toolchain.cmake ${CMAKE_ARGS}"
 			TARGET_OS=Android

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -14,6 +14,8 @@ struct TouchInput;
 struct KeyInput;
 struct AxisInput;
 
+class GraphicsContext;
+
 enum SystemPermission {
 	SYSTEM_PERMISSION_STORAGE,
 };
@@ -48,7 +50,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_directory, co
 
 // Runs after NativeInit() at some point. May (and probably should) call OpenGL.
 // Should not initialize anything screen-size-dependent - do that in NativeResized.
-void NativeInitGraphics();
+void NativeInitGraphics(GraphicsContext *graphicsContext);
 
 // Signals that you need to destroy and recreate all buffered OpenGL resources,
 // like textures, vbo etc.
@@ -73,7 +75,7 @@ bool NativeAxis(const AxisInput &axis);
 
 // Called when it's time to render. If the device can keep up, this
 // will also be called sixty times per second. Main thread.
-void NativeRender();
+void NativeRender(GraphicsContext *graphicsContext);
 
 // This should render num_samples 44khz stereo samples.
 // Try not to make too many assumptions on the granularity

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -619,8 +619,8 @@ int main(int argc, char *argv[]) {
 	printf("Pixels: %i x %i\n", pixel_xres, pixel_yres);
 	printf("Virtual pixels: %i x %i\n", dp_xres, dp_yres);
 
-	NativeInitGraphics();
-	GraphicsContext *gfx = new DummyGraphicsContext();
+	GraphicsContext *graphicsContext = new DummyGraphicsContext();
+	NativeInitGraphics(graphicsContext);
 
 	NativeResized();
 
@@ -855,7 +855,7 @@ int main(int argc, char *argv[]) {
 		UpdateRunLoop();
 #else
 		NativeUpdate(input_state);
-		NativeRender();
+		NativeRender(graphicsContext);
 #endif
 		if (g_QuitRequested)
 			break;
@@ -876,8 +876,7 @@ int main(int argc, char *argv[]) {
 #ifdef USING_EGL
 		eglSwapBuffers(g_eglDisplay, g_eglSurface);
 #else
-		if (!keys[SDLK_TAB] || t - lastT >= 1.0/60.0)
-		{
+		if (!keys[SDLK_TAB] || t - lastT >= 1.0/60.0) {
 			SDL_GL_SwapWindow(g_Screen);
 			lastT = t;
 		}
@@ -892,6 +891,8 @@ int main(int argc, char *argv[]) {
 	delete joystick;
 #endif
 	NativeShutdownGraphics();
+	graphicsContext->Shutdown();
+	delete graphicsContext;
 	NativeShutdown();
 	// Faster exit, thanks to the OS. Remove this if you want to debug shutdown
 	// The speed difference is only really noticable on Linux. On Windows you do notice it though

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -46,6 +46,13 @@ SDLJoystick *joystick = NULL;
 #include "Core/Config.h"
 #include "Common/GraphicsContext.h"
 
+class GLDummyGraphicsContext : public DummyGraphicsContext {
+public:
+	Thin3DContext *CreateThin3DContext() override {
+		return T3DCreateGLContext();
+	}
+};
+
 GlobalUIState lastUIState = UISTATE_MENU;
 GlobalUIState GetUIState();
 
@@ -619,7 +626,7 @@ int main(int argc, char *argv[]) {
 	printf("Pixels: %i x %i\n", pixel_xres, pixel_yres);
 	printf("Virtual pixels: %i x %i\n", dp_xres, dp_yres);
 
-	GraphicsContext *graphicsContext = new DummyGraphicsContext();
+	GraphicsContext *graphicsContext = new GLDummyGraphicsContext();
 	NativeInitGraphics(graphicsContext);
 
 	NativeResized();
@@ -851,12 +858,7 @@ int main(int argc, char *argv[]) {
 		SimulateGamepad(keys, &input_state);
 		input_state.pad_buttons = pad_buttons;
 		UpdateInputState(&input_state, true);
-#ifdef PPSSPP
 		UpdateRunLoop();
-#else
-		NativeUpdate(input_state);
-		NativeRender(graphicsContext);
-#endif
 		if (g_QuitRequested)
 			break;
 #if defined(PPSSPP) && !defined(MOBILE_DEVICE)

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -41,15 +41,13 @@ SDLJoystick *joystick = NULL;
 #include "util/text/utf8.h"
 #include "math/math_util.h"
 
-#ifdef PPSSPP
-// Bad: PPSSPP includes from native
 #include "Core/System.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
+#include "Common/GraphicsContext.h"
 
 GlobalUIState lastUIState = UISTATE_MENU;
 GlobalUIState GetUIState();
-#endif
 
 static SDL_Window* g_Screen = NULL;
 static bool g_ToggleFullScreenNextFrame = false;
@@ -622,6 +620,8 @@ int main(int argc, char *argv[]) {
 	printf("Virtual pixels: %i x %i\n", dp_xres, dp_yres);
 
 	NativeInitGraphics();
+	GraphicsContext *gfx = new DummyGraphicsContext();
+
 	NativeResized();
 
 	SDL_AudioSpec fmt, ret_fmt;

--- a/ext/native/base/QtMain.h
+++ b/ext/native/base/QtMain.h
@@ -25,17 +25,25 @@ QTM_USE_NAMESPACE
 #include "gfx/gl_common.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
+#include "thin3d/thin3d.h"
 #include "base/NativeApp.h"
 #include "net/resolve.h"
 #include "base/NKCodeFromQt.h"
 
-// Bad: PPSSPP includes from native
+#include "Common/GraphicsContext.h"
 #include "Core/System.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
 
 // Input
 void SimulateGamepad(InputState *input);
+
+class QtDummyGraphicsContext : public DummyGraphicsContext {
+public:
+	Thin3DContext *CreateThin3DContext() override {
+		return T3DCreateGLContext();
+	}
+};
 
 //GUI
 class MainUI : public QGLWidget
@@ -62,6 +70,9 @@ public:
 		delete acc;
 #endif
 		NativeShutdownGraphics();
+		graphicsContext->Shutdown();
+		delete graphicsContext;
+		graphicsContext = nullptr;
 	}
 
 public slots:
@@ -183,7 +194,8 @@ protected:
 #ifndef USING_GLES2
 		glewInit();
 #endif
-		NativeInitGraphics();
+		graphicsContext = new QtDummyGraphicsContext();
+		NativeInitGraphics(graphicsContext);
 	}
 
 	void paintGL()
@@ -224,6 +236,7 @@ protected:
 
 private:
 	InputState input_state;
+	QtDummyGraphicsContext *graphicsContext;
 #if defined(MOBILE_DEVICE) && !defined(MAEMO)
 	QAccelerometer* acc;
 #endif

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -134,7 +134,7 @@ namespace UI {
 class SliderPopupScreen : public PopupScreen {
 public:
 	SliderPopupScreen(int *value, int minValue, int maxValue, const std::string &title, int step = 1, const std::string &units = "")
-	: PopupScreen(title, "OK", "Cancel"), value_(value), minValue_(minValue), maxValue_(maxValue), step_(step), units_(units) {}
+	: PopupScreen(title, "OK", "Cancel"), units_(units), value_(value), minValue_(minValue), maxValue_(maxValue), step_(step), changing_(false) {}
 	virtual void CreatePopupContents(ViewGroup *parent) override;
 
 	Event OnChange;
@@ -159,7 +159,7 @@ private:
 class SliderFloatPopupScreen : public PopupScreen {
 public:
 	SliderFloatPopupScreen(float *value, float minValue, float maxValue, const std::string &title, float step = 1.0f, const std::string &units = "")
-	: PopupScreen(title, "OK", "Cancel"), value_(value), minValue_(minValue), maxValue_(maxValue), step_(step), units_(units) {}
+	: PopupScreen(title, "OK", "Cancel"), units_(units), value_(value), minValue_(minValue), maxValue_(maxValue), step_(step), changing_(false) {}
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 
 	Event OnChange;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -72,7 +72,7 @@ void D3D9_SwapBuffers() { }
 void GL_SwapBuffers() { }
 void GL_SwapInterval(int) { }
 void NativeUpdate(InputState &input_state) { }
-void NativeRender() { }
+void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 void NativeMessageReceived(const char *message, const char *value) {}
 
@@ -299,15 +299,16 @@ int main(int argc, const char* argv[])
 	host = headlessHost;
 
 	std::string error_string;
-	bool glWorking = host->InitGraphics(&error_string);
+
+	GraphicsContext *graphicsContext;
+	bool glWorking = host->InitGraphics(&error_string, &graphicsContext);
 
 	LogManager::Init();
 	LogManager *logman = LogManager::GetInstance();
 	
 	PrintfLogger *printfLogger = new PrintfLogger();
 
-	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++)
-	{
+	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++) {
 		LogTypes::LOG_TYPE type = (LogTypes::LOG_TYPE)i;
 		logman->SetEnable(type, fullLog);
 		logman->SetLogLevel(type, LogTypes::LDEBUG);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -83,9 +83,7 @@ bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &default
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 
-#ifndef _WIN32
 InputState input_state;
-#endif
 
 int printUsage(const char *progname, const char *reason)
 {

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -21,8 +21,7 @@
 #include "Core/Debugger/SymbolMap.h"
 
 // TODO: Get rid of this junk
-class HeadlessHost : public Host
-{
+class HeadlessHost : public Host {
 public:
 	void UpdateUI() override {}
 
@@ -31,7 +30,7 @@ public:
 
 	void SetDebugMode(bool mode) { }
 
-	bool InitGraphics(std::string *error_message) override {return false;}
+	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override {return false;}
 	void ShutdownGraphics() override {}
 
 	void InitSound() override {}

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -140,7 +140,7 @@ void WindowsHeadlessHost::SetComparisonScreenshot(const std::string &filename)
 	comparisonScreenshot = filename;
 }
 
-bool WindowsHeadlessHost::InitGraphics(std::string *error_message)
+bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext **graphicsContext)
 {
 	hWnd = CreateHiddenWindow();
 
@@ -169,13 +169,14 @@ bool WindowsHeadlessHost::InitGraphics(std::string *error_message)
 	ENFORCE(hRC = wglCreateContext(hDC), "Unable to create GL context.");
 	ENFORCE(wglMakeCurrent(hDC, hRC), "Unable to activate GL context.");
 
-	GL_SwapInterval(0);
+	// GL_SwapInterval(0);
 
 	glewInit();
 	CheckGLExtensions();
 
 	LoadNativeAssets();
 
+	*graphicsContext = new DummyGraphicsContext();
 	return ResizeGL();
 }
 

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -28,7 +28,7 @@
 class WindowsHeadlessHost : public HeadlessHost
 {
 public:
-	virtual bool InitGraphics(std::string *error_message) override;
+	virtual bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
 	virtual void ShutdownGraphics() override;
 
 	virtual void SwapBuffers() override;

--- a/headless/WindowsHeadlessHostDx9.cpp
+++ b/headless/WindowsHeadlessHostDx9.cpp
@@ -33,8 +33,7 @@ const bool WINDOW_VISIBLE = false;
 const int WINDOW_WIDTH = 480;
 const int WINDOW_HEIGHT = 272;
 
-HWND DxCreateWindow()
-{
+HWND DxCreateWindow() {
 	static WNDCLASSEX wndClass = {
 		sizeof(WNDCLASSEX),
 		CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
@@ -58,13 +57,12 @@ HWND DxCreateWindow()
 	return CreateWindowEx(0, _T("PPSSPPHeadless"), _T("PPSSPPHeadless"), style, CW_USEDEFAULT, CW_USEDEFAULT, wr.right - wr.left, wr.bottom - wr.top, NULL, NULL, NULL, NULL);
 }
 
-bool WindowsHeadlessHostDx9::InitGraphics(std::string *error_message)
-{
+bool WindowsHeadlessHostDx9::InitGraphics(std::string *error_message, GraphicsContext **graphicsContext) {
+	*graphicsContext = nullptr;
 	LoadD3DX9Dynamic();
 	hWnd = DxCreateWindow();
 
-	if (WINDOW_VISIBLE)
-	{
+	if (WINDOW_VISIBLE) {
 		ShowWindow(hWnd, TRUE);
 		SetFocus(hWnd);
 	}
@@ -72,15 +70,13 @@ bool WindowsHeadlessHostDx9::InitGraphics(std::string *error_message)
 	DX9::DirectxInit(hWnd);
 
 	LoadNativeAssets();
-
 	
 	DX9::pD3Ddevice->BeginScene();   
 
 	return true;
 }
 
-void WindowsHeadlessHostDx9::ShutdownGraphics()
-{
+void WindowsHeadlessHostDx9::ShutdownGraphics() {
 	DX9::DestroyShaders();
 	DX9::fbo_shutdown();
 	DX9::pD3Ddevice->EndScene();
@@ -89,14 +85,11 @@ void WindowsHeadlessHostDx9::ShutdownGraphics()
 	hWnd = NULL;
 }
 
-bool WindowsHeadlessHostDx9::ResizeGL()
-{
-
+bool WindowsHeadlessHostDx9::ResizeGL() {
 	return true;
 }
 
-void WindowsHeadlessHostDx9::SwapBuffers()
-{	
+void WindowsHeadlessHostDx9::SwapBuffers() {
 	MSG msg;
 	PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);
 	TranslateMessage(&msg);

--- a/headless/WindowsHeadlessHostDx9.h
+++ b/headless/WindowsHeadlessHostDx9.h
@@ -29,7 +29,7 @@
 class WindowsHeadlessHostDx9 : public WindowsHeadlessHost
 {
 public:
-	bool InitGraphics(std::string *error_message) override;
+	bool InitGraphics(std::string *error_message, GraphicsContext **graphicsContext) override;
 	void ShutdownGraphics() override;
 
 	void SwapBuffers() override;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -247,7 +247,7 @@ ViewController* sharedViewController;
 		EndInputState(&input_state);
 	}
 
-	NativeRender();
+	NativeRender(NULL);
 	time_update();
 }
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -15,6 +15,7 @@
 #include "input/input_state.h"
 #include "net/resolve.h"
 #include "ui/screen.h"
+#include "thin3d/thin3d.h"
 #include "input/keycodes.h"
 
 #include "Core/Config.h"
@@ -31,6 +32,13 @@
 #ifndef kCFCoreFoundationVersionNumber_IOS_9_0
 #define kCFCoreFoundationVersionNumber_IOS_9_0 1240.10
 #endif
+
+class IOSDummyGraphicsContext : public DummyGraphicsContext {
+public:
+    Thin3DContext *CreateThin3DContext() override {
+        return T3DCreateGLContext();
+    }
+};
 
 float dp_xscale = 1.0f;
 float dp_yscale = 1.0f;
@@ -104,7 +112,7 @@ static GraphicsContext *graphicsContext;
 				targetIsJailbroken = true;
 				// if we're running on iOS arm64, only iOS <9 is supported with JIT.
 				// if we're running on anything that isn't arm64, then JIT is supported on all iOS versions.
-				if (![self isArm64] || [self isArm64] && kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_IOS_9_0) {
+				if (![self isArm64] || ([self isArm64] && kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_IOS_9_0)) {
 					iosCanUseJit = true;
 				}
 			}
@@ -179,9 +187,9 @@ static GraphicsContext *graphicsContext;
 
 	pixel_in_dps = (float)pixel_xres / (float)dp_xres;
 
-	graphicsContext = new DummyGraphicsContext();
+	graphicsContext = new IOSDummyGraphicsContext();
 
-	NativeInitGraphics();
+	NativeInitGraphics(graphicsContext);
 
 	dp_xscale = (float)dp_xres / (float)pixel_xres;
 	dp_yscale = (float)dp_yres / (float)pixel_yres;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -18,6 +18,7 @@
 #include "input/keycodes.h"
 
 #include "Core/Config.h"
+#include "Common/GraphicsContext.h"
 #include "GPU/GLES/FBO.h"
 
 #include <sys/types.h>
@@ -46,6 +47,7 @@ extern bool iosCanUseJit;
 extern bool targetIsJailbroken;
 
 ViewController* sharedViewController;
+static GraphicsContext *graphicsContext;
 
 @interface ViewController ()
 {
@@ -177,6 +179,8 @@ ViewController* sharedViewController;
 
 	pixel_in_dps = (float)pixel_xres / (float)dp_xres;
 
+	graphicsContext = new DummyGraphicsContext();
+
 	NativeInitGraphics();
 
 	dp_xscale = (float)dp_xres / (float)pixel_xres;
@@ -222,7 +226,10 @@ ViewController* sharedViewController;
 		self.gameController = nil;
 	}
 #endif
-	
+	NativeShutdownGraphics();
+	graphicsContext->Shutdown();
+	delete graphicsContext;
+	graphicsContext = NULL;
 	NativeShutdown();
 }
 
@@ -247,7 +254,7 @@ ViewController* sharedViewController;
 		EndInputState(&input_state);
 	}
 
-	NativeRender(NULL);
+	NativeRender(graphicsContext);
 	time_update();
 }
 

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -36,7 +36,7 @@ struct InputState;
 void D3D9_SwapBuffers() { }
 void GL_SwapBuffers() { }
 void NativeUpdate(InputState &input_state) { }
-void NativeRender() { }
+void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 
 void System_SendMessage(const char *command, const char *parameter) {}

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -33,11 +33,13 @@
 
 #include "base/NativeApp.h"
 #include "base/logging.h"
-#include "Common/CPUDetect.h"
-#include "Common/ArmEmitter.h"
+#include "input/input_state.h"
 #include "ext/disarm.h"
 #include "math/math_util.h"
 #include "util/text/parsers.h"
+
+#include "Common/CPUDetect.h"
+#include "Common/ArmEmitter.h"
 #include "Core/Config.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"
 #include "Core/FileSystems/ISOFileSystem.h"
@@ -45,6 +47,8 @@
 #include "unittest/JitHarness.h"
 #include "unittest/TestVertexJit.h"
 #include "unittest/UnitTest.h"
+
+InputState input_state;
 
 std::string System_GetProperty(SystemProperty prop) { return ""; }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }


### PR DESCRIPTION
Abstract away things like swapbuffers etc before adding even more backends.

Needed to prevent "switch (gpu)" clutter all over the codebase later.

Does not go all the way yet, goal would be a common render loop between platforms but not there yet.
