### PR TITLE
Fix some Direct3D 9 validation errors

### DIFF
--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -587,7 +587,9 @@ namespace DX9 {
 		if (!fbo)
 			return fbo;
 		fbo_bind_as_render_target(fbo);
+		dxstate.viewport.force(0, 0, w, h);
 		ClearBuffer(true);
+		dxstate.viewport.restore();
 		const TempFBO info = {fbo, gpuStats.numFlips};
 		tempFBOs_[key] = info;
 		return fbo;

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -795,7 +795,7 @@ namespace DX9 {
 				const u32 rw = PSP_CoreParameter().pixelWidth;
 				const u32 rh = PSP_CoreParameter().pixelHeight;
 				const RECT srcRect = {(LONG)(u0 * vfb->renderWidth), (LONG)(v0 * vfb->renderHeight), (LONG)(u1 * vfb->renderWidth), (LONG)(v1 * vfb->renderHeight)};
-				const RECT dstRect = {(LONG)(x * rw / w, y * rh / h), (LONG)((x + w) * rw / w, (y + h) * rh / h)};
+				const RECT dstRect = {(LONG)(x * rw / w), (LONG)(y * rh / h), (LONG)((x + w) * rw / w), (LONG)((y + h) * rh / h)};
 				HRESULT hr = fbo_blit_color(vfb->fbo_dx9, &srcRect, nullptr, &dstRect, g_Config.iBufFilter == SCALE_LINEAR ? D3DTEXF_LINEAR : D3DTEXF_POINT);
 				if (FAILED(hr)) {
 					ERROR_LOG_REPORT_ONCE(blit_fail, G3D, "fbo_blit_color failed on display: %08x", hr);

--- a/GPU/Directx9/helper/dx_state.h
+++ b/GPU/Directx9/helper/dx_state.h
@@ -349,7 +349,12 @@ private:
 	class StateVp {
 		D3DVIEWPORT9 viewport;
 	public:
-		StateVp() { memset(&viewport, 0, sizeof(viewport)); }
+		StateVp() {
+			memset(&viewport, 0, sizeof(viewport));
+			// It's an error if w/h is zero, so let's start with something that can work.
+			viewport.Width = 1;
+			viewport.Height = 1;
+		}
 		inline void set(int x, int y, int w, int h, float n = 0.f, float f = 1.f) {
 			D3DVIEWPORT9 newviewport;
 			newviewport.X = x;


### PR DESCRIPTION
The blitting change ought to improve performance.

I found these while trying to figure out why #8246 didn't work in Direct3D 9, but they aren't actually related to those changes.  I'm pulling them out so they can be merged / tested separately.

-[Unknown]
