### PR TITLE
Net: don't double-delete thread on shutdown

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -82,6 +82,9 @@ void __NetAdhocShutdown() {
 		sceNetAdhocctlTerm();
 	}
 	if (netAdhocInited) {
+		// Should not really call HLE funcs from shutdown.
+		// Prevent attempting to delete the thread, already deleted by shutdown.
+		threadAdhocID = 0;
 		sceNetAdhocTerm();
 	}
 	if (dummyThreadHackAddr) {


### PR DESCRIPTION
Prevents spurious logging / reporting on shutdown.  It's been bugging me, because it shows up in reports just because a game called net init functions.

-[Unknown]
