### PR TITLE
Improve seeking issues in sceAtrac

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -735,7 +735,6 @@ int Atrac::Analyze() {
 					firstSampleoffset = Memory::Read_U32(first.addr + offset + 4);
 				}
 				if (chunkSize >= 12) {
-					firstSampleoffset = Memory::Read_U32(first.addr + offset + 4);
 					u32 largerOffset = Memory::Read_U32(first.addr + offset + 8);
 					sampleOffsetAdjust = firstSampleoffset - largerOffset;
 				}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -428,12 +428,12 @@ struct Atrac {
 
 	bool FillPacket() {
 		u32 off = getFileOffsetBySample(currentSample);
-		if (off < first.filesize) {
+		if (off < first.size) {
 #ifdef USE_FFMPEG
 			av_init_packet(packet);
 #endif // USE_FFMPEG
 			packet->data = data_buf + off;
-			packet->size = atracBytesPerFrame;
+			packet->size = std::min((u32)atracBytesPerFrame, first.size - off);
 			packet->pos = off;
 
 			return true;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1090,6 +1090,10 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 				}
 			} else if (hitEnd) {
 				finishFlag = 1;
+
+				// Still move forward, so we know that we've read everything.
+				// This seems to be reflected in the context as well.
+				atrac->currentSample += atrac->samplesPerFrame();
 			}
 
 			*finish = finishFlag;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1065,8 +1065,10 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 					if (atrac->getFileOffsetBySample(atrac->currentSample) < atrac->first.filesize) {
 						numSamples = std::min(maxSamples, atrac->samplesPerFrame());
 						u32 outBytes = numSamples * atrac->atracOutputChannels * sizeof(s16);
-						memset(outbuf, 0, outBytes);
-						CBreakPoints::ExecMemCheck(outbufPtr, true, outBytes, currentMIPS->pc);
+						if (outbuf != nullptr) {
+							memset(outbuf, 0, outBytes);
+							CBreakPoints::ExecMemCheck(outbufPtr, true, outBytes, currentMIPS->pc);
+						}
 					}
 				}
 			}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1083,7 +1083,7 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 			int loopEndAdjusted = atrac->loopEndSample - atrac->firstOffsetExtra() - atrac->firstSampleoffset;
 			if ((hitEnd || atrac->currentSample > loopEndAdjusted) && loopNum != 0) {
 				atrac->SeekToSample(atrac->loopStartSample - atrac->firstOffsetExtra() - atrac->firstSampleoffset);
-				if (atrac->bufferState == ATRAC_STATUS_FOR_SCESAS) {
+				if (atrac->bufferState != ATRAC_STATUS_FOR_SCESAS) {
 					if (atrac->loopNum > 0)
 						atrac->loopNum--;
 				}


### PR DESCRIPTION
This reads back pretty correct data, where ever you seek to.  Before, if you seeked in the middle, the first frame or two returned would be off.  This also fixes where it reads data from for some seek values and some atrac files - it was offset incorrectly.

Fixing that offset meant some other changes to handle remain correctly, but it now seems to match my tests properly.

Additionally, fixes a major/stupid typo in loop handling, introduced while messing with sceSas integration.

This fixes #8324 for me, and I expect it will help #8156 as well.

-[Unknown]
