### PR TITLE
Correct use of maxV when not yet detected

### DIFF
--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -695,13 +695,8 @@ void TextureCacheDX9::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase
 		clutAlphaLinear_ = true;
 		clutAlphaLinearColor_ = clut[15] & 0x0FFF;
 		for (int i = 0; i < 16; ++i) {
-			if ((clut[i] >> 12) != i) {
-				clutAlphaLinear_ = false;
-				break;
-			}
-			// Alpha 0 doesn't matter.
-			// TODO: Well, depending on blend mode etc, it can actually matter, although unlikely.
-			if (i != 0 && (clut[i] >> 12) != clutAlphaLinearColor_) {
+			u16 step = clutAlphaLinearColor_ | (i << 12);
+			if (clut[i] != step) {
 				clutAlphaLinear_ = false;
 				break;
 			}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -729,13 +729,8 @@ void TextureCache::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, b
 		clutAlphaLinear_ = true;
 		clutAlphaLinearColor_ = clut[15] & 0xFFF0;
 		for (int i = 0; i < 16; ++i) {
-			if ((clut[i] & 0xf) != i) {
-				clutAlphaLinear_ = false;
-				break;
-			}
-			// Alpha 0 doesn't matter. 
-			// TODO: Well, depending on blend mode etc, it can actually matter, although unlikely.
-			if (i != 0 && (clut[i] & 0xFFF0) != clutAlphaLinearColor_) {
+			u16 step = clutAlphaLinearColor_ | i;
+			if (clut[i] != step) {
 				clutAlphaLinear_ = false;
 				break;
 			}

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -853,7 +853,7 @@ void TextureCache::ApplyTexture() {
 			// Texture scale/offset and gen modes don't apply in through.
 			// So we can optimize how much of the texture we look at.
 			if (gstate.isModeThrough()) {
-				if (nextTexture_->maxSeenV == 0) {
+				if (nextTexture_->maxSeenV == 0 && gstate_c.vertBounds.maxV > 0) {
 					// Let's not hash less than 272, we might use more later and have to rehash.  272 is very common.
 					nextTexture_->maxSeenV = std::max((u16)272, gstate_c.vertBounds.maxV);
 				} else if (gstate_c.vertBounds.maxV > nextTexture_->maxSeenV) {


### PR DESCRIPTION
This was making us fail to hash certain textures properly.
