### PR TITLE
Fixed build on Mac OS X.

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -28,6 +28,10 @@
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
 
+#if defined(_M_SSE)
+#include <emmintrin.h>
+#endif
+
 // Ugly.
 extern int g_iNumVideos;
 


### PR DESCRIPTION
Included emmintrin.h for '__m128i' type.
