### PR TITLE
Refactor VRAM download, optimize rendered CLUTs

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -123,7 +123,8 @@ FramebufferManagerCommon::FramebufferManagerCommon() :
 	usePostShader_(false),
 	postShaderAtOutputResolution_(false),
 	postShaderIsUpscalingFilter_(false),
-	hackForce04154000Download_(false) {
+	hackForce04154000Download_(false),
+	gameUsesSequentialCopies_(false) {
 	UpdateSize();
 }
 
@@ -727,6 +728,81 @@ void FramebufferManagerCommon::FindTransferFramebuffers(VirtualFramebuffer *&dst
 	if (srcYOffset != (u32)-1) {
 		srcY += srcYOffset;
 		srcX += srcXOffset;
+	}
+}
+
+VirtualFramebuffer *FramebufferManagerCommon::FindDownloadTempBuffer(VirtualFramebuffer *vfb) {
+	// For now we'll keep these on the same struct as the ones that can get displayed
+	// (and blatantly copy work already done above while at it).
+	VirtualFramebuffer *nvfb = 0;
+
+	// We maintain a separate vector of framebuffer objects for blitting.
+	for (size_t i = 0; i < bvfbs_.size(); ++i) {
+		VirtualFramebuffer *v = bvfbs_[i];
+		if (v->fb_address == vfb->fb_address && v->format == vfb->format) {
+			if (v->bufferWidth == vfb->bufferWidth && v->bufferHeight == vfb->bufferHeight) {
+				nvfb = v;
+				v->fb_stride = vfb->fb_stride;
+				v->width = vfb->width;
+				v->height = vfb->height;
+				break;
+			}
+		}
+	}
+
+	// Create a new fbo if none was found for the size
+	if (!nvfb) {
+		nvfb = new VirtualFramebuffer();
+		nvfb->fbo = nullptr;
+		nvfb->fb_address = vfb->fb_address;
+		nvfb->fb_stride = vfb->fb_stride;
+		nvfb->z_address = vfb->z_address;
+		nvfb->z_stride = vfb->z_stride;
+		nvfb->width = vfb->width;
+		nvfb->height = vfb->height;
+		nvfb->renderWidth = vfb->bufferWidth;
+		nvfb->renderHeight = vfb->bufferHeight;
+		nvfb->bufferWidth = vfb->bufferWidth;
+		nvfb->bufferHeight = vfb->bufferHeight;
+		nvfb->format = vfb->format;
+		nvfb->drawnWidth = vfb->drawnWidth;
+		nvfb->drawnHeight = vfb->drawnHeight;
+		nvfb->drawnFormat = vfb->format;
+	}
+
+	nvfb->usageFlags |= FB_USAGE_RENDERTARGET;
+	nvfb->last_frame_render = gpuStats.numFlips;
+	nvfb->dirtyAfterDisplay = true;
+
+	return nvfb;
+}
+
+void FramebufferManagerCommon::OptimizeDownloadRange(VirtualFramebuffer * vfb, int & x, int & y, int & w, int & h) {
+	if (gameUsesSequentialCopies_) {
+		// Ignore the x/y/etc., read the entire thing.
+		x = 0;
+		y = 0;
+		w = vfb->width;
+		h = vfb->height;
+	}
+	if (x == 0 && y == 0 && w == vfb->width && h == vfb->height) {
+		// Mark it as fully downloaded until next render to it.
+		vfb->memoryUpdated = true;
+	} else {
+		// Let's try to set the flag eventually, if the game copies a lot.
+		// Some games copy subranges very frequently.
+		const static int FREQUENT_SEQUENTIAL_COPIES = 3;
+		static int frameLastCopy = 0;
+		static u32 bufferLastCopy = 0;
+		static int copiesThisFrame = 0;
+		if (frameLastCopy != gpuStats.numFlips || bufferLastCopy != vfb->fb_address) {
+			frameLastCopy = gpuStats.numFlips;
+			bufferLastCopy = vfb->fb_address;
+			copiesThisFrame = 0;
+		}
+		if (++copiesThisFrame > FREQUENT_SEQUENTIAL_COPIES) {
+			gameUsesSequentialCopies_ = true;
+		}
 	}
 }
 

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -166,21 +166,18 @@ void FramebufferManagerCommon::SetDisplayFramebuffer(u32 framebuf, u32 stride, G
 }
 
 VirtualFramebuffer *FramebufferManagerCommon::GetVFBAt(u32 addr) {
-	VirtualFramebuffer *match = NULL;
+	VirtualFramebuffer *match = nullptr;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
 		if (MaskedEqual(v->fb_address, addr)) {
 			// Could check w too but whatever
-			if (match == NULL || match->last_frame_render < v->last_frame_render) {
+			if (match == nullptr || match->last_frame_render < v->last_frame_render) {
 				match = v;
 			}
 		}
 	}
-	if (match != NULL) {
-		return match;
-	}
 
-	return 0;
+	return match;
 }
 
 bool FramebufferManagerCommon::MaskedEqual(u32 addr1, u32 addr2) {

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -768,6 +768,16 @@ VirtualFramebuffer *FramebufferManagerCommon::FindDownloadTempBuffer(VirtualFram
 		nvfb->drawnWidth = vfb->drawnWidth;
 		nvfb->drawnHeight = vfb->drawnHeight;
 		nvfb->drawnFormat = vfb->format;
+		nvfb->colorDepth = vfb->colorDepth;
+
+		if (!CreateDownloadTempBuffer(nvfb)) {
+			delete nvfb;
+			return nullptr;
+		}
+
+		bvfbs_.push_back(nvfb);
+	} else {
+		UpdateDownloadTempBuffer(nvfb);
 	}
 
 	nvfb->usageFlags |= FB_USAGE_RENDERTARGET;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -245,6 +245,8 @@ protected:
 	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const;
 	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
+	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) = 0;
+	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) = 0;
 	void OptimizeDownloadRange(VirtualFramebuffer *vfb, int &x, int &y, int &w, int &h);
 
 	void UpdateFramebufUsage(VirtualFramebuffer *vfb);

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -169,7 +169,7 @@ public:
 	void NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp, u32 skipDrawReason);
 
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) = 0;
-	virtual void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) = 0;
+	virtual void DownloadFramebufferForClut(u32 fb_address, u32 loadBytes) = 0;
 	virtual void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) = 0;
 	virtual void DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) = 0;
 	virtual void DrawFramebufferToOutput(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader) = 0;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -57,6 +57,7 @@ struct VirtualFramebuffer {
 	int last_frame_render;
 	int last_frame_displayed;
 	int last_frame_clut;
+	u32 clutUpdatedBytes;
 	bool memoryUpdated;
 	bool depthUpdated;
 
@@ -254,6 +255,7 @@ protected:
 
 	void SetColorUpdated(VirtualFramebuffer *dstBuffer, int skipDrawReason) {
 		dstBuffer->memoryUpdated = false;
+		dstBuffer->clutUpdatedBytes = 0;
 		dstBuffer->dirtyAfterDisplay = true;
 		dstBuffer->drawnWidth = dstBuffer->width;
 		dstBuffer->drawnHeight = dstBuffer->height;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -168,6 +168,7 @@ public:
 	void NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp, u32 skipDrawReason);
 
 	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) = 0;
+	virtual void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) = 0;
 	virtual void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) = 0;
 	virtual void DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) = 0;
 	virtual void DrawFramebufferToOutput(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader) = 0;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -244,6 +244,8 @@ protected:
 
 	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const;
+	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
+	void OptimizeDownloadRange(VirtualFramebuffer *vfb, int &x, int &y, int &w, int &h);
 
 	void UpdateFramebufUsage(VirtualFramebuffer *vfb);
 
@@ -278,9 +280,11 @@ protected:
 	bool postShaderIsUpscalingFilter_;
 
 	std::vector<VirtualFramebuffer *> vfbs_;
+	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)
 	std::set<std::pair<u32, u32>> knownFramebufferRAMCopies_;
 
 	bool hackForce04154000Download_;
+	bool gameUsesSequentialCopies_;
 
 	// Sampled in BeginFrame for safety.
 	float renderWidth_;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -157,6 +157,7 @@ protected:
 	u32 clutTotalBytes_;
 	u32 clutMaxBytes_;
 	u32 clutRenderAddress_;
+	u32 clutRenderOffset_;
 	int standardScaleFactor_;
 };
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -139,6 +139,8 @@ protected:
 	virtual bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0) = 0;
 	virtual void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer) = 0;
 
+	virtual void DownloadFramebufferForClut(u32 clutAddr, u32 bytes) = 0;
+
 	TexCache cache;
 	std::vector<VirtualFramebuffer *> fbCache_;
 

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -859,7 +859,7 @@ namespace DX9 {
 		}
 	}
 
-	void FramebufferManagerDX9::DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) {
+	void FramebufferManagerDX9::DownloadFramebufferForClut(u32 fb_address, u32 loadBytes) {
 		VirtualFramebuffer *vfb = GetVFBAt(fb_address);
 		if (vfb && vfb->fb_stride != 0) {
 			const u32 bpp = vfb->drawnFormat == GE_FORMAT_8888 ? 4 : 2;
@@ -888,10 +888,6 @@ namespace DX9 {
 				textureCache_->ForgetLastTexture();
 				RebindFramebuffer();
 			}
-		}
-
-		if (Memory::IsValidAddress(fb_address | 0x04000000)) {
-			Memory::MemcpyUnchecked(clut, fb_address | 0x04000000, loadBytes);
 		}
 	}
 

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -849,32 +849,32 @@ namespace DX9 {
 		if (vfb) {
 			// We'll pseudo-blit framebuffers here to get a resized version of vfb.
 			VirtualFramebuffer *nvfb = FindDownloadTempBuffer(vfb);
-
-			// Create a new fbo if none was found for the size
-			if (!nvfb->fbo_dx9) {
-				nvfb->colorDepth = FBO_8888;
-
-				textureCache_->ForgetLastTexture();
-				nvfb->fbo_dx9 = fbo_create(nvfb->width, nvfb->height, 1, true, (FBOColorDepth)nvfb->colorDepth);
-				if (!(nvfb->fbo_dx9)) {
-					ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
-					delete nvfb;
-					return;
-				}
-
-				bvfbs_.push_back(nvfb);
-				fbo_bind_as_render_target(nvfb->fbo_dx9);
-				ClearBuffer();
-			} else {
-				textureCache_->ForgetLastTexture();
-			}
-
 			OptimizeDownloadRange(vfb, x, y, w, h);
 			BlitFramebuffer(nvfb, x, y, vfb, x, y, w, h, 0);
 
 			PackFramebufferDirectx9_(nvfb, x, y, w, h);
+
+			textureCache_->ForgetLastTexture();
 			RebindFramebuffer();
 		}
+	}
+
+	bool FramebufferManagerDX9::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
+		nvfb->colorDepth = FBO_8888;
+
+		nvfb->fbo_dx9 = fbo_create(nvfb->width, nvfb->height, 1, true, (FBOColorDepth)nvfb->colorDepth);
+		if (!(nvfb->fbo_dx9)) {
+			ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
+			return false;
+		}
+
+		fbo_bind_as_render_target(nvfb->fbo_dx9);
+		ClearBuffer();
+		return true;
+	}
+
+	void FramebufferManagerDX9::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
+		// Nothing to do here.
 	}
 
 	void FramebufferManagerDX9::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) {

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -135,7 +135,6 @@ private:
 	std::vector<FBO *> extraFBOs_;
 
 	bool resized_;
-	bool gameUsesSequentialCopies_;
 
 	struct TempFBO {
 		FBO_DX9 *fbo;
@@ -146,7 +145,6 @@ private:
 		int last_frame_used;
 	};
 
-	std::vector<VirtualFramebuffer *> bvfbs_; // blitting FBOs
 	std::map<u64, TempFBO> tempFBOs_;
 	std::map<u64, OffscreenSurface> offscreenSurfaces_;
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -73,7 +73,8 @@ public:
 
 	void BindFramebufferColor(int stage, VirtualFramebuffer *framebuffer, int flags);
 
-	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
+	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
+	void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) override;
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -105,6 +105,8 @@ protected:
 	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
 	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
 	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
 	void CompileDraw2DProgram();

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -74,7 +74,7 @@ public:
 	void BindFramebufferColor(int stage, VirtualFramebuffer *framebuffer, int flags);
 
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
-	void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) override;
+	void DownloadFramebufferForClut(u32 fb_address, u32 loadBytes) override;
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -476,6 +476,7 @@ void DIRECTX9_GPU::CheckGPUFeatures() {
 
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
 	features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
+	features |= GPU_PREFER_CPU_DOWNLOAD;
 
 	if (!PSP_CoreParameter().compat.flags().NoDepthRounding) {
 		features |= GPU_ROUND_DEPTH_TO_16BIT;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -805,7 +805,7 @@ void TextureCacheDX9::ApplyTexture() {
 }
 
 void TextureCacheDX9::DownloadFramebufferForClut(u32 clutAddr, u32 bytes) {
-	framebufferManager_->DownloadFramebufferForClut(clutBufRaw_, clutAddr, bytes);
+	framebufferManager_->DownloadFramebufferForClut(clutAddr, bytes);
 }
 
 class TextureShaderApplierDX9 {

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -804,6 +804,10 @@ void TextureCacheDX9::ApplyTexture() {
 	nextTexture_ = nullptr;
 }
 
+void TextureCacheDX9::DownloadFramebufferForClut(u32 clutAddr, u32 bytes) {
+	framebufferManager_->DownloadFramebufferForClut(clutBufRaw_, clutAddr, bytes);
+}
+
 class TextureShaderApplierDX9 {
 public:
 	struct Pos {

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -72,6 +72,9 @@ public:
 
 	void ApplyTexture();
 
+protected:
+	void DownloadFramebufferForClut(u32 clutAddr, u32 bytes) override;
+
 private:
 	void Decimate();  // Run this once per frame to get rid of old textures.
 	void DeleteTexture(TexCache::iterator it);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1762,6 +1762,7 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb, int x, in
 
 	bool convert = vfb->format != GE_FORMAT_8888 || UseBGRA8888();
 	const int dstBpp = vfb->format == GE_FORMAT_8888 ? 4 : 2;
+	const int packWidth = x + w < vfb->width ? x + w : vfb->width;
 
 	if (!convert) {
 		packed = (GLubyte *)Memory::GetPointer(fb_address);
@@ -1786,11 +1787,11 @@ void FramebufferManager::PackFramebufferSync_(VirtualFramebuffer *vfb, int x, in
 		}
 
 		int byteOffset = y * vfb->fb_stride * 4;
-		SafeGLReadPixels(0, y, vfb->fb_stride, h, glfmt, GL_UNSIGNED_BYTE, packed + byteOffset);
+		SafeGLReadPixels(0, y, h == 1 ? packWidth : vfb->fb_stride, h, glfmt, GL_UNSIGNED_BYTE, packed + byteOffset);
 
 		if (convert) {
 			int dstByteOffset = y * vfb->fb_stride * dstBpp;
-			ConvertFromRGBA8888(Memory::GetPointer(fb_address + dstByteOffset), packed + byteOffset, vfb->fb_stride, vfb->fb_stride, vfb->width, h, vfb->format);
+			ConvertFromRGBA8888(Memory::GetPointer(fb_address + dstByteOffset), packed + byteOffset, vfb->fb_stride, vfb->fb_stride, packWidth, h, vfb->format);
 		}
 	}
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1256,20 +1256,24 @@ void FramebufferManager::DownloadFramebufferForClut(void *clut, u32 fb_address, 
 		int w = std::min(pixels % vfb->fb_stride, (int)vfb->width);
 		int h = std::min((pixels + vfb->fb_stride - 1) / vfb->fb_stride, (int)vfb->height);
 
-		// We intentionally don't call OptimizeDownloadRange() here - we don't want to over download.
-		// CLUT framebuffers are often incorrectly estimated in size.
-		if (x == 0 && y == 0 && w == vfb->width && h == vfb->height) {
-			vfb->memoryUpdated = true;
+		// No need to download if we already have it.
+		if (!vfb->memoryUpdated && vfb->clutUpdatedBytes < loadBytes) {
+			// We intentionally don't call OptimizeDownloadRange() here - we don't want to over download.
+			// CLUT framebuffers are often incorrectly estimated in size.
+			if (x == 0 && y == 0 && w == vfb->width && h == vfb->height) {
+				vfb->memoryUpdated = true;
+			}
+			vfb->clutUpdatedBytes = loadBytes;
+
+			// We'll pseudo-blit framebuffers here to get a resized version of vfb.
+			VirtualFramebuffer *nvfb = FindDownloadTempBuffer(vfb);
+			BlitFramebuffer(nvfb, x, y, vfb, x, y, w, h, 0);
+
+			PackFramebufferSync_(nvfb, x, y, w, h);
+
+			textureCache_->ForgetLastTexture();
+			RebindFramebuffer();
 		}
-
-		// We'll pseudo-blit framebuffers here to get a resized version of vfb.
-		VirtualFramebuffer *nvfb = FindDownloadTempBuffer(vfb);
-		BlitFramebuffer(nvfb, x, y, vfb, x, y, w, h, 0);
-
-		PackFramebufferSync_(nvfb, x, y, w, h);
-
-		textureCache_->ForgetLastTexture();
-		RebindFramebuffer();
 	}
 
 	if (Memory::IsValidAddress(fb_address | 0x04000000)) {

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1241,7 +1241,7 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 	}
 }
 
-void FramebufferManager::DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) {
+void FramebufferManager::DownloadFramebufferForClut(u32 fb_address, u32 loadBytes) {
 	PROFILE_THIS_SCOPE("gpu-readback");
 	// Flush async just in case.
 	PackFramebufferAsync_(nullptr);
@@ -1274,10 +1274,6 @@ void FramebufferManager::DownloadFramebufferForClut(void *clut, u32 fb_address, 
 			textureCache_->ForgetLastTexture();
 			RebindFramebuffer();
 		}
-	}
-
-	if (Memory::IsValidAddress(fb_address | 0x04000000)) {
-		Memory::MemcpyUnchecked(clut, fb_address | 0x04000000, loadBytes);
 	}
 }
 

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1241,6 +1241,42 @@ void FramebufferManager::ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool s
 	}
 }
 
+void FramebufferManager::DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) {
+	PROFILE_THIS_SCOPE("gpu-readback");
+	// Flush async just in case.
+	PackFramebufferAsync_(nullptr);
+
+	VirtualFramebuffer *vfb = GetVFBAt(fb_address);
+	if (vfb && vfb->fb_stride != 0) {
+		const u32 bpp = vfb->drawnFormat == GE_FORMAT_8888 ? 4 : 2;
+		int x = 0;
+		int y = 0;
+		int pixels = loadBytes / bpp;
+		// The height will be 1 for each stride or part thereof.
+		int w = std::min(pixels % vfb->fb_stride, (int)vfb->width);
+		int h = std::min((pixels + vfb->fb_stride - 1) / vfb->fb_stride, (int)vfb->height);
+
+		// We intentionally don't call OptimizeDownloadRange() here - we don't want to over download.
+		// CLUT framebuffers are often incorrectly estimated in size.
+		if (x == 0 && y == 0 && w == vfb->width && h == vfb->height) {
+			vfb->memoryUpdated = true;
+		}
+
+		// We'll pseudo-blit framebuffers here to get a resized version of vfb.
+		VirtualFramebuffer *nvfb = FindDownloadTempBuffer(vfb);
+		BlitFramebuffer(nvfb, x, y, vfb, x, y, w, h, 0);
+
+		PackFramebufferSync_(nvfb, x, y, w, h);
+
+		textureCache_->ForgetLastTexture();
+		RebindFramebuffer();
+	}
+
+	if (Memory::IsValidAddress(fb_address | 0x04000000)) {
+		Memory::MemcpyUnchecked(clut, fb_address | 0x04000000, loadBytes);
+	}
+}
+
 bool FramebufferManager::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	// When updating VRAM, it need to be exact format.
 	if (!gstate_c.Supports(GPU_PREFER_CPU_DOWNLOAD)) {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -102,7 +102,7 @@ public:
 
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
-	void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) override;
+	void DownloadFramebufferForClut(u32 fb_address, u32 loadBytes) override;
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -135,6 +135,8 @@ protected:
 	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
 	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
 	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
 	void UpdatePostShaderUniforms(int bufferWidth, int bufferHeight, int renderWidth, int renderHeight);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -171,14 +171,12 @@ private:
 	std::vector<FBO *> extraFBOs_;
 
 	bool resized_;
-	bool gameUsesSequentialCopies_;
 
 	struct TempFBO {
 		FBO *fbo;
 		int last_frame_used;
 	};
 
-	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)
 	std::map<u64, TempFBO> tempFBOs_;
 
 	// Not used under ES currently.

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -101,7 +101,8 @@ public:
 	void BindFramebufferColor(int stage, u32 fbRawAddress, VirtualFramebuffer *framebuffer, int flags);
 
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
-	virtual void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
+	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
+	void DownloadFramebufferForClut(void *clut, u32 fb_address, u32 loadBytes) override;
 
 	std::vector<FramebufferInfo> GetFramebufferList();
 

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -879,6 +879,10 @@ void TextureCache::ApplyTexture() {
 	nextTexture_ = nullptr;
 }
 
+void TextureCache::DownloadFramebufferForClut(u32 clutAddr, u32 bytes) {
+	framebufferManager_->DownloadFramebufferForClut(clutBufRaw_, clutAddr, bytes);
+}
+
 class TextureShaderApplier {
 public:
 	struct Pos {

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -880,7 +880,7 @@ void TextureCache::ApplyTexture() {
 }
 
 void TextureCache::DownloadFramebufferForClut(u32 clutAddr, u32 bytes) {
-	framebufferManager_->DownloadFramebufferForClut(clutBufRaw_, clutAddr, bytes);
+	framebufferManager_->DownloadFramebufferForClut(clutAddr, bytes);
 }
 
 class TextureShaderApplier {

--- a/GPU/GLES/TextureCache.h
+++ b/GPU/GLES/TextureCache.h
@@ -87,6 +87,9 @@ public:
 
 	void ApplyTexture();
 
+protected:
+	void DownloadFramebufferForClut(u32 clutAddr, u32 bytes) override;
+
 private:
 	void Decimate();  // Run this once per frame to get rid of old textures.
 	void DeleteTexture(TexCache::iterator it);

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -70,6 +70,7 @@ enum CmdFormatType {
 	CMD_FMT_TEXWRAP,
 	CMD_FMT_TEXFILTER,
 	CMD_FMT_TEXMAPMODE,
+	CMD_FMT_SHADEMODEL,
 };
 
 struct TabStateRow {
@@ -114,8 +115,7 @@ static const TabStateRow stateLightingRows[] = {
 	{ L"Material specular",    GE_CMD_MATERIALSPECULAR,        CMD_FMT_HEX },
 	{ L"Mat. specular coef",   GE_CMD_MATERIALSPECULARCOEF,    CMD_FMT_FLOAT24 },
 	{ L"Reverse normals",      GE_CMD_REVERSENORMAL,           CMD_FMT_FLAG },
-	// TODO: Format?
-	{ L"Shade model",          GE_CMD_SHADEMODE,               CMD_FMT_NUM },
+	{ L"Shade model",          GE_CMD_SHADEMODE,               CMD_FMT_SHADEMODEL },
 	// TODO: Format?
 	{ L"Light mode",           GE_CMD_LIGHTMODE,               CMD_FMT_NUM, GE_CMD_LIGHTINGENABLE },
 	{ L"Light type 0",         GE_CMD_LIGHTTYPE0,              CMD_FMT_NUM, GE_CMD_LIGHTENABLE0 },
@@ -457,6 +457,16 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			} else {
 				swprintf(dest, L"%06x", value);
 			}
+		}
+		break;
+
+	case CMD_FMT_SHADEMODEL:
+		if (value == 0) {
+			swprintf(dest, L"flat");
+		} else if (value == 1) {
+			swprintf(dest, L"gouraud");
+		} else {
+			swprintf(dest, L"%06x", value);
 		}
 		break;
 


### PR DESCRIPTION
This fixes #8252.  I set out to fix that and I ended up greatly improving the performance of Brave Story in battles with the CLUT download.

Turns out, we were downloading too much, and doing it over and over.  This optimization is huge for Brave Story, pretty much as good as #8246... but note that one without a bunch more work, that won't work with texture scaling.

Anyway, the only real downside of this is that it adds another flag that needs to be reset on every render.  I think the driver overhead is larger and this is fairly cheap, hopefully.

Improvement:
Boss battle (fairy complicated enemies): 192% -> 696%
Rabbit battle: 469% -> 745%

These changes don't prevent #8246, but for reference, the same numbers with that branch:

Boss battle: 640%
Rabbit battle: 800%

Based on the way the game renders (using a few different CLUTs for a set of textures that draw the enemy), we end up re-rendering several textures many times.  In the boss battle especially.  This is why the changes in this pull are actually faster for that example.

-[Unknown]
