### PR TITLE
Basic handling of sceAtrac second buffer

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1244,8 +1244,6 @@ static void AtracGetResetBufferInfo(Atrac *atrac, AtracResetBufferInfo *bufferIn
 			bufferInfo->first.minWriteBytes = 0;
 		}
 		bufferInfo->first.filePos = atrac->first.size;
-
-		atrac->first.writableBytes = bufferInfo->first.writableBytes;
 	} else {
 		// This is without the sample offset.  The file offset also includes the previous batch of samples?
 		int sampleFileOffset = atrac->getFileOffsetBySample(sample - atrac->firstSampleoffset - atrac->samplesPerFrame());
@@ -1591,7 +1589,6 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 				Memory::Memcpy(atrac->data_buf + atrac->first.size, atrac->first.addr + atrac->first.size, bytesWrittenFirstBuf);
 				atrac->first.fileoffset += bytesWrittenFirstBuf;
 				atrac->first.size += bytesWrittenFirstBuf;
-				atrac->first.writableBytes -= bytesWrittenFirstBuf;
 				atrac->first.offset += bytesWrittenFirstBuf;
 			}
 


### PR DESCRIPTION
This allows the second buffer to be set, although the data in it is not actually used.

The size and validation all matches tests.  We shouldn't get into any more trouble than we already do by not using this data, since we will just fill the `data_buf` either way via normal stream data.

Some of the stream data, reset, and remaining frame calculations depend on this data.  It's going to be hard to determine what's wrong if it's caused by a subtle difference and second buffers are not implemented yet.  More importantly, they will likely be necessary to read data from PSP RAM directly.

If a savestate is loaded with older data, the stream is forced to a state that should behave as before.  This prevents games from breaking because they lack second buffers, when loading savestates.

Passes most of hrydgard/pspautotests#183, except the reset test which relies on the second buffer being read from during decode.

-[Unknown]
