### PR TITLE
Correct clamped depth offset

### DIFF
--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -260,7 +260,7 @@ static void ConvertProjMatrixToD3D(Matrix4x4 &in, bool invertedX, bool invertedY
 	if (invertedY)
 		yoff = -yoff;
 
-	const Vec3 trans(xoff, yoff, gstate_c.vpZOffset + 0.5f);
+	const Vec3 trans(xoff, yoff, gstate_c.vpZOffset * 0.5f + 0.5f);
 	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 	in.translateAndScale(trans, scale);
 }

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -378,7 +378,7 @@ static inline void ScaleProjMatrix(Matrix4x4 &in) {
 		// GL upside down is a pain as usual.
 		yOffset = -yOffset;
 	}
-	const Vec3 trans(gstate_c.vpXOffset, yOffset, gstate_c.vpZOffset * 2.0f);
+	const Vec3 trans(gstate_c.vpXOffset, yOffset, gstate_c.vpZOffset);
 	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale);
 	in.translateAndScale(trans, scale);
 }


### PR DESCRIPTION
Oops, forgot to fix this when I fixed the scale.  It's already for a [-1, 1] range, and needs to be corrected for accordingly.  D'oh.

Fixes #8425, other depth issues in Phantasy Star Portable 2.

For clarity, here's example math I did just to be sure:

```
WANTED: [1519, 53751]
GL RANGE: [0, 53751]

Standard depth for GL range:
Z = (z * 26875.5) + 26875.5
Z => [0, 53751]

Adjusted depth:
z' = (z * 1.028260) - 0.028260
z' => [-1.056520, 1.0]

Z = (z' * 26875.5) + 26875.5
Z => [-1519.00326, 53751]

Where scale and offset above came from:
vpZscale = 27635
drift = -1519
glRange = 53751 - 0;
zScale = (vpZscale * 2) / glRange = 1.028260
zOffset = drift / glRange = -0.028260
```

-[Unknown]
