### PR TITLE
Specify which games need vertex depth rounding instead of which ones don't

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -45,7 +45,7 @@ void Compatibility::Clear() {
 }
 
 void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
-	CheckSetting(iniFile, gameID, "NoDepthRounding", flags_.NoDepthRounding);
+	CheckSetting(iniFile, gameID, "VertexDepthRounding", flags_.VertexDepthRounding);
 	CheckSetting(iniFile, gameID, "PixelDepthRounding", flags_.PixelDepthRounding);
 }
 

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -45,7 +45,7 @@
 // We already have the Action Replay-based cheat system for such use cases.
 
 struct CompatFlags {
-	bool NoDepthRounding;
+	bool VertexDepthRounding;
 	bool PixelDepthRounding;
 };
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -478,7 +478,7 @@ void DIRECTX9_GPU::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
 	features |= GPU_PREFER_CPU_DOWNLOAD;
 
-	if (!PSP_CoreParameter().compat.flags().NoDepthRounding) {
+	if (PSP_CoreParameter().compat.flags().VertexDepthRounding) {
 		features |= GPU_ROUND_DEPTH_TO_16BIT;
 	}
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -557,7 +557,7 @@ void GLES_GPU::CheckGPUFeatures() {
 	if ((!gl_extensions.IsGLES || gl_extensions.GLES3) && PSP_CoreParameter().compat.flags().PixelDepthRounding) {
 		features |= GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT;
 	} else {
-		if (!PSP_CoreParameter().compat.flags().NoDepthRounding) {
+		if (PSP_CoreParameter().compat.flags().VertexDepthRounding) {
 			features |= GPU_ROUND_DEPTH_TO_16BIT;
 		}
 	}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -28,52 +28,14 @@
 # Issue numbers refer to issues on https://github.com/hrydgard/ppsspp/issues
 # ========================================================================================
 
-[NoDepthRounding]
-# Fight Night Round 3
-# Our accurate rounding of depth to 16-bit precision appears to cause a regression
-# in this game. The game doesn't seem to need it, so let's turn it off.
-# Issue #8004
-ULES00270 = true
-ULUS10066 = true
-
-# Ridge Racer
-# Our accurate rounding of depth to 16-bit precision appears to cause a regression
-# in this game. The game doesn't seem to need it, so let's turn it off.
-# Issue 8031
-UCAS40015 = true
-ULUS10001 = true
-UCKS45002 = true
-UCES00002 = true
-ULJS19002 = true
-UCKS45053 = true
-NPJH50140 = true
-
-# Do the same for Ridge Racer 2, it's nearly the exact same game except more levels and cars.
-ULJS00080 = true
-UCES00422 = true
-NPJH50366 = true
-
-# Same for Lost Heroes (JP).
-ULJS00489 = true
-NPJH50647 = true
-
-# Summon Night 5 (JP). Issue #8181
-ULJS00553 = true
-NPJH50696 = true
-ULJS19096 = true
-
-#MotorStorm Arctic Edge
-UCUS98743 = true
-UCES01250 = true
-UCAS40266 = true
-UCJS10104 = true
-NPJG00047 = true
-UCKS45124 = true
-
-#Saigo no Yakusoku no Monogatari (JP)
-NPJH50416 = true
-UCAS40339 = true
-ULJM05860 = true
+[VertexDepthRounding]
+# Phantasy Star Portable needs depth rounding to 16-bit precision for text to show up.
+# It's enough to do it at the vertex granularity.  #3777
+ULJM05309 = true
+ULUS10410 = true
+ULES01218 = true
+ULJM08023 = true
+ULES01218 = true
 
 [PixelDepthRounding]
 # Heroes Phantasia requires pixel depth rounding.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -36,6 +36,27 @@ ULUS10410 = true
 ULES01218 = true
 ULJM08023 = true
 ULES01218 = true
+# Puyo Puyo Fever 2 
+ULJM05058 = true
+# NBA 2K13 
+ULAS42332 = true 
+ULJS00551 = true
+NPJH50713 = true
+ULJS00596 = true
+ULES01578 = true
+# Power Stone Collection 
+ULES00496 = true
+ULUS10171 = true
+ULJM05178 = true
+# Taiko no Tatsujin Portable DX 
+ULJS00383 = true 
+NPJH50426 = true 
+ULAS42282 = true
+# PhotoKano
+ULJS00378 = true
+NPJH50579 = true
+ULJS19069 = true
+NPJH50579 = true
 
 [PixelDepthRounding]
 # Heroes Phantasia requires pixel depth rounding.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -36,30 +36,30 @@ ULUS10410 = true
 ULES01218 = true
 ULJM08023 = true
 ULES01218 = true
-# Puyo Puyo Fever 2 
+# Puyo Puyo Fever 2   #3663 (layering)
 ULJM05058 = true
-# NBA 2K13 
+# NBA 2K13  #6603 (menu glitches)
 ULAS42332 = true 
 ULJS00551 = true
 NPJH50713 = true
 ULJS00596 = true
 ULES01578 = true
-# Power Stone Collection 
+# Power Stone Collection  #6257 (map arrow)
 ULES00496 = true
 ULUS10171 = true
 ULJM05178 = true
-# Taiko no Tatsujin Portable DX 
+# Taiko no Tatsujin Portable DX    #7920  (missing text)
 ULJS00383 = true 
 NPJH50426 = true 
 ULAS42282 = true
-# PhotoKano
+# PhotoKano  #7920  (missing text)
 ULJS00378 = true
 NPJH50579 = true
 ULJS19069 = true
 NPJH50579 = true
 
 [PixelDepthRounding]
-# Heroes Phantasia requires pixel depth rounding.
+# Heroes Phantasia requires pixel depth rounding.  #6485 (flickering overlaid sprites)
 NPJH50558 = true
 ULJS00456 = true
 ULJS00454 = true


### PR DESCRIPTION
Vertex depth rounding is a not-fully-accurate hack, and most games are better off with the extra depth precision of 24-bit Z than reducing it to a not-fully-accurate 16-bit. So let's only use it where necessary, like in Phantasy Star.

I'm sure I'm missing some games that need it here, let's add them before merge.

See issue #8187.
