### PR TITLE
Cleanup some Atrac code

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -207,6 +207,9 @@ struct Atrac {
 
 		if (atracContext.IsValid())
 			kernelMemory.Free(atracContext.ptr);
+
+		// Clean slate time.
+		failedDecode = false;
 	}
 
 	void SetBufferState() {


### PR DESCRIPTION
I've been wanting to rename some variables (prefixed and otherwise) in atrac for a while, and I finally decided that I might as well, if I'm going to.  Better to do it all in one commit so it can be skipped in history where possible.  Otherwise, I'll just keep adding more code that uses `atracBytesPerSample` and such...

This also makes Analyze() log a bit differently (using new HLE logging), and fixing some HLE struct param info values for that.

Lastly, this includes a small change from #7638: when the game sets brand new data, clear the `failedDecode_` flag, because the new data hasn't failed yet.

-[Unknown]
