### PR TITLE
Calculate stream data info a bit more accurately

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -2148,6 +2148,7 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 		return hleLogError(ME, atracID, "no free ID");
 	}
 
+	atrac->outputChannels_ = 2;
 	return _AtracSetData(atracID, buffer, bufferSize, bufferSize, true);
 }
 
@@ -2436,6 +2437,7 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 		return hleLogError(ME, atracID, "no free ID");
 	}
 
+	atrac->outputChannels_ = 2;
 	return _AtracSetData(atracID, buffer, readSize, bufferSize, true);
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1046,12 +1046,14 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 		return hleLogWarning(ME, ATRAC_ERROR_ALL_DATA_LOADED, "stream entirely loaded");
 	}
 
-	atrac->CalculateStreamInfo(nullptr);
+	u32 readOffset;
+	atrac->CalculateStreamInfo(&readOffset);
 
 	if (bytesToAdd > atrac->first_.writableBytes)
 		return hleLogWarning(ME, ATRAC_ERROR_ADD_DATA_IS_TOO_BIG, "too many bytes");
 
 	if (bytesToAdd > 0) {
+		atrac->first_.fileoffset = readOffset;
 		int addbytes = std::min(bytesToAdd, atrac->first_.filesize - atrac->first_.fileoffset);
 		if (!atrac->ignoreDataBuf_) {
 			Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, atrac->first_.addr + atrac->first_.offset, addbytes);


### PR DESCRIPTION
This gets us closer, but there are a few issues before the data can be used directly:
1. It seems like it pre-decodes a frame or two, which sorta makes sense.  We'll need to buffer this at least for savestates, because it can get overwritten before used.
2. It seems like if you set an unaligned size, it moves some data to the start for you.
3. There are a few scenarios in which my numbers are off by a frame - probably some `firstOffsetExtra` related thing again.  But we were much farther off before.
4. I've noticed issues with the remaining frame calculation while testing this (sometimes it uses -2 instead of -3 for looped buffers, maybe when outside the loop?)  Not sure how important.
5. Need to decide whether to just fill packets on a cursor (probably do that) or try to track the file offset at which the buffer is.  Looping may make that complicated.
6. Looping probably doesn't ask for the right data still.  I'm not sure the semantics of when it should rewind, precisely.  But it wasn't doing that before anyway.

I've also cleaned up more logging.

This fixes #8430, fixes #8195, fixes #6636, fixes #8220, fixes #8370, and also fixes #8401.  It's likely to fix things that had problems when they looped.

-[Unknown]
