### PR TITLE
Simplify lowlevel atrac decoding a lot

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1682,8 +1682,6 @@ int __AtracSetContext(Atrac *atrac) {
 #ifdef USE_FFMPEG
 	InitFFmpeg();
 
-	u8* tempbuf = (u8*)av_malloc(atrac->bufferMaxSize_);
-
 	AVCodecID ff_codec;
 	if (atrac->codecType_ == PSP_MODE_AT_3) {
 		ff_codec = AV_CODEC_ID_ATRAC3;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -2344,7 +2344,6 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 				// TODO: What to do, if anything?
 			}
 
-			atrac->firstSampleOffset_ = headersize;
 			atrac->dataOff_ = headersize;
 			atrac->first_.size = headersize;
 			atrac->first_.filesize = headersize + atrac->bytesPerFrame_;
@@ -2372,7 +2371,6 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 			memcpy(at3plusHeader, at3plusHeaderTemplate, headersize);
 			initAT3plusDecoder(atrac, at3plusHeader);
 
-			atrac->firstSampleOffset_ = headersize;
 			atrac->dataOff_ = headersize;
 			atrac->first_.size = headersize;
 			atrac->first_.filesize = headersize + atrac->bytesPerFrame_;
@@ -2448,7 +2446,7 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 
 		if (atrac->bufferPos_ >= atrac->first_.size) {
 			atrac->first_.writableBytes = atrac->bytesPerFrame_;
-			atrac->first_.size = atrac->firstSampleOffset_;
+			atrac->first_.size = atrac->dataOff_;
 			atrac->ForceSeekToSample(0);
 			atrac->bufferPos_ = atrac->dataOff_;
 		}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1703,7 +1703,7 @@ int __AtracSetContext(Atrac *atrac) {
 		// We don't pull this from the RIFF so that we can support OMA also.
 		// The only thing that changes are the jointStereo_ values.
 		atrac->codecCtx_->extradata[0] = 1;
-		atrac->codecCtx_->extradata[3] = 0x10;
+		atrac->codecCtx_->extradata[3] = atrac->channels_ << 3;
 		atrac->codecCtx_->extradata[6] = atrac->jointStereo_;
 		atrac->codecCtx_->extradata[8] = atrac->jointStereo_;
 		atrac->codecCtx_->extradata[10] = 1;
@@ -2293,6 +2293,7 @@ static bool initAT3Decoder(Atrac *atrac, u8 *at3Header, u32 dataSize = 0xffb4a8)
 			at3Header[0x29] = atrac->channels_ << 3;
 			at3Header[0x2c] = at3HeaderMap[i].jointStereo;
 			at3Header[0x2e] = at3HeaderMap[i].jointStereo;
+			atrac->jointStereo_ = at3HeaderMap[i].jointStereo;
 			*(u32 *)(at3Header + sizeof(at3HeaderTemplate) - 4) = dataSize;
 			return true;
 		}


### PR DESCRIPTION
We were doing a lot of things we no longer needed to do, and not doing a couple things we ought to.

These changes really serve to remove interaction between lowlevel and regular decoding.  A bunch of members of Atrac were used but not for anything useful.

It also gets rid of header generation code etc. which is not needed now that we demux directly.

Fixes #8409.

-[Unknown]
