### PR TITLE
Handle out of audio more correctly, consistently abuse esBuffer

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1320,7 +1320,9 @@ static int sceMpegInitAu(u32 mpeg, u32 bufferAddr, u32 auPointer)
 
 	if (bufferAddr >= 1 && bufferAddr <= (u32)MPEG_DATA_ES_BUFFERS && ctx->esBuffers[bufferAddr - 1]) {
 		// This esbuffer has been allocated for Avc.
-		sceAu.esBuffer = bufferAddr;   // Can this be right??? not much of a buffer pointer..
+		// Default to 0, since we stuff the stream id in here.  Technically, we shouldn't.
+		// TODO: Do something better to track the AU data.  This used to be bufferAddr.
+		sceAu.esBuffer = 0;
 		sceAu.esSize = MPEG_AVC_ES_SIZE;
 		sceAu.dts = 0;
 		sceAu.pts = 0;
@@ -1328,7 +1330,9 @@ static int sceMpegInitAu(u32 mpeg, u32 bufferAddr, u32 auPointer)
 		sceAu.write(auPointer);
 	} else {
 		// This esbuffer has been left as Atrac.
-		sceAu.esBuffer = bufferAddr;
+		// Default to 0, since we stuff the stream id in here.  Technically, we shouldn't.
+		// TODO: Do something better to track the AU data.  This used to be bufferAddr.
+		sceAu.esBuffer = 0;
 		sceAu.esSize = MPEG_ATRAC_ES_SIZE;
 		sceAu.pts = 0;
 		sceAu.dts = UNKNOWN_TIMESTAMP;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1602,12 +1602,18 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(ME, "video end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ringbuffer->packetsAvail = 0;
+		// TODO: Is this correct?
+		if (!ctx->mediaengine->IsNoAudioData()) {
+			WARN_LOG_REPORT(ME, "Video end without audio end, potentially skipping some audio?");
+		}
 		result = ERROR_MPEG_NO_DATA;
 	}
 
 	if (ctx->atracRegistered && ctx->mediaengine->IsNoAudioData() && !ctx->endOfAudioReached) {
 		WARN_LOG(ME, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ctx->endOfAudioReached = true;
+	}
+	if (ctx->mediaengine->IsNoAudioData()) {
 		result = ERROR_MPEG_NO_DATA;
 	}
 


### PR DESCRIPTION
This returns an error when getting an "au" if there's no audio, every time, instead of just the first time.  Fixes video stopping prematurely in Dan Ball Senki W (#4786.)

It also consistently uses esBuffer for the audio stream, to workaround an error.  This isn't a complete fix, but it's better to be consistent.

Ultimately, it seems like "getting an au" is probably demuxing the frame data, and then decode is supposed to decode that data.  So decode before getting an au is supposed to spit out a decode error, 0x807F00FD.

Doing that right sounds complicated, but at least we can generally avoid this type of error by starting the esBuffers off with 0.

I've tested some games that historically had issues with mpeg changes, and also some of the games noted in #5381, which this is to some degree reverting.  But there can be a million mpeg issues so who knows....

-[Unknown]
