### PR TITLE
OpenGL pseudo shader cache

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -411,6 +411,7 @@ public:
 	std::string memStickDirectory;
 	std::string flash0Directory;
 	std::string internalDataDirectory;
+	std::string appCacheDirectory;
 
 	// Data for upgrade prompt
 	std::string upgradeMessage;  // The actual message from the server is currently not used, need a translation mechanism. So this just acts as a flag.

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -579,6 +579,11 @@ std::string GetSysDirectory(PSPDirectories directoryType) {
 		return g_Config.memStickDirectory + "PSP/PPSSPP_STATE/";
 	case DIRECTORY_CACHE:
 		return g_Config.memStickDirectory + "PSP/SYSTEM/CACHE/";
+	case DIRECTORY_APP_CACHE:
+		if (!g_Config.appCacheDirectory.empty()) {
+			return g_Config.appCacheDirectory;
+		}
+		return g_Config.memStickDirectory + "PSP/SYSTEM/CACHE/";
 	// Just return the memory stick root if we run into some sort of problem.
 	default:
 		ERROR_LOG(FILESYS, "Unknown directory type.");

--- a/Core/System.h
+++ b/Core/System.h
@@ -45,6 +45,7 @@ enum PSPDirectories {
 	DIRECTORY_DUMP,
 	DIRECTORY_SAVESTATE,
 	DIRECTORY_CACHE,
+	DIRECTORY_APP_CACHE,  // Use the OS app cache if available
 };
 
 class GraphicsContext;

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -458,6 +458,11 @@ GLES_GPU::GLES_GPU(GraphicsContext *ctx)
 	glstate.Restore();
 	transformDraw_.RestoreVAO();
 	textureCache_.NotifyConfigChanged();
+
+	// Load shader cache.
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_CACHE));
+	shaderCachePath_ = GetSysDirectory(DIRECTORY_CACHE) + "/" + g_paramSFO.GetValueString("DISC_ID") + ".shadercache";
+	shaderManager_->LoadAndPrecompile(shaderCachePath_);
 }
 
 GLES_GPU::~GLES_GPU() {
@@ -730,6 +735,10 @@ void GLES_GPU::BeginFrameInternal() {
 	} else if (dumpThisFrame_) {
 		dumpThisFrame_ = false;
 	}
+
+	// Save the cache from time to time. TODO: How often?
+	if ((gpuStats.numFlips & 255) == 0)
+		shaderManager_->Save(shaderCachePath_);
 
 	shaderManager_->DirtyShader();
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -462,8 +462,8 @@ GLES_GPU::GLES_GPU(GraphicsContext *ctx)
 	// Load shader cache.
 	std::string discID = g_paramSFO.GetValueString("DISC_ID");
 	if (discID.size()) {
-		File::CreateFullPath(GetSysDirectory(DIRECTORY_CACHE));
-		shaderCachePath_ = GetSysDirectory(DIRECTORY_CACHE) + "/" + g_paramSFO.GetValueString("DISC_ID") + ".shadercache";
+		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
+		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) + "/" + g_paramSFO.GetValueString("DISC_ID") + ".glshadercache";
 		shaderManager_->LoadAndPrecompile(shaderCachePath_);
 	}
 }
@@ -473,6 +473,9 @@ GLES_GPU::~GLES_GPU() {
 	shaderManager_->ClearCache(true);
 	depalShaderCache_.Clear();
 	fragmentTestCache_.Clear();
+	if (!shaderCachePath_.empty()) {
+		shaderManager_->Save(shaderCachePath_);
+	}
 	delete shaderManager_;
 	shaderManager_ = nullptr;
 
@@ -740,7 +743,7 @@ void GLES_GPU::BeginFrameInternal() {
 	}
 
 	// Save the cache from time to time. TODO: How often?
-	if (shaderCachePath_.size() && (gpuStats.numFlips & 1023) == 0) {
+	if (!shaderCachePath_.empty() && (gpuStats.numFlips & 1023) == 0) {
 		shaderManager_->Save(shaderCachePath_);
 	}
 

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -460,9 +460,12 @@ GLES_GPU::GLES_GPU(GraphicsContext *ctx)
 	textureCache_.NotifyConfigChanged();
 
 	// Load shader cache.
-	File::CreateFullPath(GetSysDirectory(DIRECTORY_CACHE));
-	shaderCachePath_ = GetSysDirectory(DIRECTORY_CACHE) + "/" + g_paramSFO.GetValueString("DISC_ID") + ".shadercache";
-	shaderManager_->LoadAndPrecompile(shaderCachePath_);
+	std::string discID = g_paramSFO.GetValueString("DISC_ID");
+	if (discID.size()) {
+		File::CreateFullPath(GetSysDirectory(DIRECTORY_CACHE));
+		shaderCachePath_ = GetSysDirectory(DIRECTORY_CACHE) + "/" + g_paramSFO.GetValueString("DISC_ID") + ".shadercache";
+		shaderManager_->LoadAndPrecompile(shaderCachePath_);
+	}
 }
 
 GLES_GPU::~GLES_GPU() {
@@ -737,8 +740,9 @@ void GLES_GPU::BeginFrameInternal() {
 	}
 
 	// Save the cache from time to time. TODO: How often?
-	if ((gpuStats.numFlips & 255) == 0)
+	if (shaderCachePath_.size() && (gpuStats.numFlips & 1023) == 0) {
 		shaderManager_->Save(shaderCachePath_);
+	}
 
 	shaderManager_->DirtyShader();
 

--- a/GPU/GLES/GLES_GPU.h
+++ b/GPU/GLES/GLES_GPU.h
@@ -196,4 +196,5 @@ private:
 	std::string reportingFullInfo_;
 
 	GraphicsContext *gfxCtx_;
+	std::string shaderCachePath_;
 };

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -1022,6 +1022,7 @@ void ShaderManager::LoadAndPrecompile(const std::string &filename) {
 	double end = time_now_d();
 
 	NOTICE_LOG(G3D, "Compiled and linked %d programs (%d vertex, %d fragment) in %0.1f milliseconds", header.numLinkedPrograms, header.numVertexShaders, header.numFragmentShaders, 1000 * (end - start));
+	NOTICE_LOG(G3D, "Loaded the shader cache from '%s'", filename.c_str());
 	diskCacheDirty_ = false;
 }
 
@@ -1029,6 +1030,10 @@ void ShaderManager::Save(const std::string &filename) {
 	if (!diskCacheDirty_) {
 		return;
 	}
+	if (!linkedShaderCache_.size()) {
+		return;
+	}
+	INFO_LOG(G3D, "Saving the shader cache to '%s'", filename.c_str());
 	FILE *f = File::OpenCFile(filename, "wb");
 	if (!f) {
 		// Can't save, give up for now.

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -29,6 +29,7 @@
 #include "math/lin/matrix4x4.h"
 #include "profiler/profiler.h"
 
+#include "Common/FileUtil.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
 #include "GPU/Math3D.h"
@@ -944,4 +945,109 @@ std::string ShaderManager::DebugGetShaderString(std::string id, DebugShaderType 
 	default:
 		return "N/A";
 	}
+}
+
+// Shader pseudo-cache.
+//
+// We simply store the IDs of the shaders used during gameplay. On next startup of
+// the same game, we simply compile all the shaders from the start, so we don't have to
+// compile them on the fly later. Ideally we would store the actual compiled shaders
+// rather than just their IDs, but OpenGL does not support this, except for a few obscure
+// vendor-specific extensions.
+//
+// If things like GPU supported features have changed since the last time, we discard the cache
+// as sometimes these features might have an effect on the ID bits.
+
+#define CACHE_HEADER_MAGIC 0x83277592
+#define CACHE_VERSION 1
+struct CacheHeader {
+	uint32_t magic;
+	uint32_t version;
+	uint32_t featureFlags;
+	uint32_t reserved;
+	int numVertexShaders;
+	int numFragmentShaders;
+	int numLinkedPrograms;
+};
+
+void ShaderManager::LoadAndPrecompile(const std::string &filename) {
+	FILE *f = File::OpenCFile(filename, "rb");
+	if (!f) {
+		return;
+	}
+	CacheHeader header;
+	if (fread(&header, 1, sizeof(header), f) != sizeof(header)) {
+		fclose(f);
+		return;
+	}
+	if (header.magic != CACHE_HEADER_MAGIC || header.version != CACHE_VERSION || header.featureFlags != gstate_c.featureFlags) {
+		fclose(f);
+		return;
+	}
+	for (int i = 0; i < header.numVertexShaders; i++) {
+		ShaderID id;
+		fread(&id, 1, sizeof(id), f);
+		vsCache_[id] = CompileVertexShader(id);
+	}
+	for (int i = 0; i < header.numFragmentShaders; i++) {
+		ShaderID id;
+		fread(&id, 1, sizeof(id), f);
+		fsCache_[id] = CompileFragmentShader(id);
+	}
+	for (int i = 0; i < header.numLinkedPrograms; i++) {
+		ShaderID vsid, fsid;
+		fread(&vsid, 1, sizeof(vsid), f);
+		fread(&fsid, 1, sizeof(fsid), f);
+		Shader *vs = vsCache_[vsid];
+		Shader *fs = fsCache_[fsid];
+		LinkedShader *ls = new LinkedShader(vsid, vs, fsid, fs, vs->UseHWTransform());
+		LinkedShaderCacheEntry entry(vs, fs, ls);
+		linkedShaderCache_.push_back(entry);
+	}
+	fclose(f);
+	diskCacheDirty_ = false;
+}
+
+void ShaderManager::Save(const std::string &filename) {
+	if (!diskCacheDirty_) {
+		return;
+	}
+	FILE *f = File::OpenCFile(filename, "wb");
+	if (!f) {
+		// Can't save, give up for now.
+		diskCacheDirty_ = false;
+		return;
+	}
+	CacheHeader header;
+	header.magic = CACHE_HEADER_MAGIC;
+	header.version = CACHE_VERSION;
+	header.reserved = 0;
+	header.featureFlags = gstate_c.featureFlags;
+	header.numVertexShaders = NumVertexShaders();
+	header.numFragmentShaders = NumFragmentShaders();
+	header.numLinkedPrograms = NumPrograms();
+	fwrite(&header, 1, sizeof(header), f);
+	for (auto iter : vsCache_) {
+		ShaderID id = iter.first;
+		fwrite(&id, 1, sizeof(id), f);
+	}
+	for (auto iter : fsCache_) {
+		ShaderID id = iter.first;
+		fwrite(&id, 1, sizeof(id), f);
+	}
+	for (auto iter : linkedShaderCache_) {
+		ShaderID vsid, fsid;
+		for (auto iter2 : vsCache_) {
+			if (iter.vs == iter2.second)
+				vsid = iter2.first;
+		}
+		for (auto iter2 : fsCache_) {
+			if (iter.fs == iter2.second)
+				fsid = iter2.first;
+		}
+		fwrite(&vsid, 1, sizeof(vsid), f);
+		fwrite(&fsid, 1, sizeof(fsid), f);
+	}
+	fclose(f);
+	diskCacheDirty_ = false;
 }

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 
 #include "base/logging.h"
+#include "base/timeutil.h"
 #include "math/math_util.h"
 #include "math/lin/matrix4x4.h"
 #include "profiler/profiler.h"
@@ -984,6 +985,9 @@ void ShaderManager::LoadAndPrecompile(const std::string &filename) {
 		fclose(f);
 		return;
 	}
+	time_update();
+	double start = time_now_d();
+
 	for (int i = 0; i < header.numVertexShaders; i++) {
 		ShaderID id;
 		fread(&id, 1, sizeof(id), f);
@@ -1014,6 +1018,10 @@ void ShaderManager::LoadAndPrecompile(const std::string &filename) {
 		linkedShaderCache_.push_back(entry);
 	}
 	fclose(f);
+	time_update();
+	double end = time_now_d();
+
+	NOTICE_LOG(G3D, "Compiled and linked %d programs (%d vertex, %d fragment) in %0.1f milliseconds", header.numLinkedPrograms, header.numVertexShaders, header.numFragmentShaders, 1000 * (end - start));
 	diskCacheDirty_ = false;
 }
 

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -987,7 +987,16 @@ void ShaderManager::LoadAndPrecompile(const std::string &filename) {
 	for (int i = 0; i < header.numVertexShaders; i++) {
 		ShaderID id;
 		fread(&id, 1, sizeof(id), f);
-		vsCache_[id] = CompileVertexShader(id);
+		Shader *vs = CompileVertexShader(id);
+		if (vs->Failed()) {
+			// Give up on using the cache, just bail. We can't safely create the fallback shaders here
+			// without trying to deduce the vertType from the VSID.
+			ERROR_LOG(G3D, "Failed to compile a vertex shader loading from cache. Skipping rest of shader cache.");
+			delete vs;
+			fclose(f);
+			return;
+		}
+		vsCache_[id] = vs;
 	}
 	for (int i = 0; i < header.numFragmentShaders; i++) {
 		ShaderID id;

--- a/GPU/GLES/ShaderManager.h
+++ b/GPU/GLES/ShaderManager.h
@@ -203,6 +203,9 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
+	void LoadAndPrecompile(const std::string &filename);
+	void Save(const std::string &filename);
+
 private:
 	void Clear();
 	Shader *CompileFragmentShader(ShaderID id);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -114,7 +114,7 @@ unsigned int WINAPI TheThread(void *)
 		args.push_back(string.c_str());
 	}
 
-	NativeInit(static_cast<int>(args.size()), &args[0], "1234", "1234");
+	NativeInit(static_cast<int>(args.size()), &args[0], "1234", "1234", nullptr);
 
 	Host *nativeHost = host;
 	host = oldHost;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -275,7 +275,7 @@ extern "C" jstring Java_org_ppsspp_ppsspp_NativeApp_queryConfig
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
   (JNIEnv *env, jclass, jstring jmodel, jint jdeviceType, jstring jlangRegion, jstring japkpath,
-		jstring jdataDir, jstring jexternalDir, jstring jlibraryDir, jstring jshortcutParam,
+		jstring jdataDir, jstring jexternalDir, jstring jlibraryDir, jstring jcacheDir, jstring jshortcutParam,
 		jint jAndroidVersion) {
 	jniEnvUI = env;
 
@@ -309,6 +309,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	std::string user_data_path = GetJavaString(env, jdataDir) + "/";
 	library_path = GetJavaString(env, jlibraryDir) + "/";
 	std::string shortcut_param = GetJavaString(env, jshortcutParam);
+	std::string cacheDir = GetJavaString(env, jcacheDir);
 
 	ILOG("NativeApp.init(): External storage path: %s", externalDir.c_str());
 	ILOG("NativeApp.init(): Launch shortcut parameter: %s", shortcut_param.c_str());
@@ -328,11 +329,11 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 
 	if (shortcut_param.empty()) {
 		const char *argv[2] = {app_name.c_str(), 0};
-		NativeInit(1, argv, user_data_path.c_str(), externalDir.c_str());
+		NativeInit(1, argv, user_data_path.c_str(), externalDir.c_str(), cacheDir.c_str());
 	}
 	else {
 		const char *argv[3] = {app_name.c_str(), shortcut_param.c_str(), 0};
-		NativeInit(2, argv, user_data_path.c_str(), externalDir.c_str());
+		NativeInit(2, argv, user_data_path.c_str(), externalDir.c_str(), cacheDir.c_str());
 	}
 
 	ILOG("NativeApp.init() -- end");

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -239,14 +239,13 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	    String externalStorageDir = sdcard.getAbsolutePath();
 	    String dataDir = this.getFilesDir().getAbsolutePath();
 		String apkFilePath = appInfo.sourceDir;
+		String cacheDir = getCacheDir().getAbsolutePath();
 
 		String model = Build.MANUFACTURER + ":" + Build.MODEL;
 		String languageRegion = Locale.getDefault().getLanguage() + "_" + Locale.getDefault().getCountry();
 
 		NativeApp.audioConfig(optimalFramesPerBuffer, optimalSampleRate);
-		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, shortcutParam, Build.VERSION.SDK_INT);
-
-		NativeApp.sendMessage("cacheDir", getCacheDir().getAbsolutePath());
+		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT);
 
 		sendInitialGrants();
 

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -13,7 +13,7 @@ public class NativeApp {
 	public final static int DEVICE_TYPE_TV = 1;
 	public final static int DEVICE_TYPE_DESKTOP = 2;
 
-	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String shortcutParam, int androidVersion);
+	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion);
 
 	public static native void audioInit();
 	public static native void audioShutdown();

--- a/ext/native/base/BlackberryMain.cpp
+++ b/ext/native/base/BlackberryMain.cpp
@@ -266,7 +266,7 @@ void BlackberryMain::startMain(int argc, char *argv[]) {
 	navigator_request_events(0);
 	dialog_request_events(0);
 	vibration_request_events(0);
-	NativeInit(argc, (const char **)argv, "/accounts/1000/shared/misc/", "app/native/assets/");
+	NativeInit(argc, (const char **)argv, "/accounts/1000/shared/misc/", "app/native/assets/", nullptr);
 	graphicsContext = new GLDummyGraphicsContext();
 	NativeInitGraphics(graphicsContext);
 	audio = new BlackberryAudio();

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -46,7 +46,7 @@ bool NativeIsAtTopLevel();
 // The very first function to be called after NativeGetAppInfo. Even NativeMix is not called
 // before this, although it may be called at any point in time afterwards (on any thread!)
 // This functions must NOT call OpenGL. Main thread.
-void NativeInit(int argc, const char *argv[], const char *savegame_directory, const char *external_directory, bool fs=false);
+void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir, bool fs=false);
 
 // Runs after NativeInit() at some point. May (and probably should) call OpenGL.
 // Should not initialize anything screen-size-dependent - do that in NativeResized.

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -616,9 +616,9 @@ int main(int argc, char *argv[]) {
 #endif
 
 #ifdef _WIN32
-	NativeInit(argc, (const char **)argv, path, "D:\\");
+	NativeInit(argc, (const char **)argv, path, "D:\\", nullptr);
 #else
-	NativeInit(argc, (const char **)argv, path, "/tmp");
+	NativeInit(argc, (const char **)argv, path, "/tmp", nullptr);
 #endif
 
 	pixel_in_dps = (float)pixel_xres / dp_xres;

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
 		if (!strcmp(argv[i],"--fullscreen"))
 			fullscreenCLI=true;
 	}
-	NativeInit(argc, (const char **)argv, savegame_dir.c_str(), assets_dir.c_str(), fullscreenCLI);
+	NativeInit(argc, (const char **)argv, savegame_dir.c_str(), assets_dir.c_str(), nullptr, fullscreenCLI);
 	
 	int ret = mainInternal(a);
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -120,7 +120,7 @@ static GraphicsContext *graphicsContext;
 			}
 		}
 		
-		NativeInit(0, NULL, [self.documentsPath UTF8String], [self.bundlePath UTF8String]);
+		NativeInit(0, NULL, [self.documentsPath UTF8String], [self.bundlePath UTF8String], NULL);
 
 		iCadeToKeyMap[iCadeJoystickUp]		= NKCODE_DPAD_UP;
 		iCadeToKeyMap[iCadeJoystickRight]	= NKCODE_DPAD_RIGHT;


### PR DESCRIPTION
Saves the shader IDs used, then precompiles them the next time on startup. Reduces hitches from mid-frame shader compiles, although of course not the first time you run.
