### PR TITLE
Simplify depth calculation a bit

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -552,8 +552,8 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		out.viewportY = renderY + displayOffsetY;
 		out.viewportW = curRTWidth * renderWidthFactor;
 		out.viewportH = curRTHeight * renderHeightFactor;
-		out.depthRangeMin = 0.0f;
-		out.depthRangeMax = 1.0f;
+		out.depthRangeMin = ToScaledDepth(0);
+		out.depthRangeMax = ToScaledDepth(65535);
 	} else {
 		// These we can turn into a glViewport call, offset by offsetX and offsetY. Math after.
 		float vpXScale = gstate.getViewportXScale();
@@ -682,6 +682,10 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		}
 #endif
 	}
+}
+
+float ToScaledDepth(u16 z) {
+	return z * (1.0f / 65535.0f);
 }
 
 static const BlendFactor genericALookup[11] = {

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -66,6 +66,7 @@ struct ViewportAndScissor {
 	bool dirtyDepth;
 };
 void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, float renderHeight, int bufferWidth, int bufferHeight, ViewportAndScissor &out);
+float ToScaledDepth(u16 z);
 
 // These are common to all modern APIs and can be easily converted with a lookup table.
 enum class BlendFactor : uint8_t {

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -21,11 +21,12 @@
 #include "Core/Config.h"
 #include "GPU/GPUState.h"
 #include "GPU/Math3D.h"
-#include "GPU/Common/VertexDecoderCommon.h"
-#include "GPU/Common/TransformCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
-#include "GPU/Common/TextureCacheCommon.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/SoftwareTransformCommon.h"
+#include "GPU/Common/TransformCommon.h"
+#include "GPU/Common/TextureCacheCommon.h"
+#include "GPU/Common/VertexDecoderCommon.h"
 
 // This is the software transform pipeline, which is necessary for supporting RECT
 // primitives correctly without geometry shaders, and may be easier to use for
@@ -406,7 +407,8 @@ void SoftwareTransform(
 	// TODO: This bleeds outside the play area in non-buffered mode. Big deal? Probably not.
 	if (maxIndex > 1 && gstate.isModeClear() && prim == GE_PRIM_RECTANGLES && IsReallyAClear(transformed, maxIndex) && gl_extensions.gpuVendor != GPU_VENDOR_POWERVR) {  // && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
 		result->color = transformed[0].color0_32;
-		result->depth = transformed[0].z;
+		// Need to rescale from a [0, 1] float.  This is the final transformed value.
+		result->depth = ToScaledDepth((s16)(int)(transformed[0].z * 65535.0f));
 		result->action = SW_CLEAR;
 		return;
 	}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -58,7 +58,7 @@ namespace DX9 {
 			dxstate.stencilFunc.set(D3DCMP_ALWAYS, 0, 0);
 			dxstate.stencilMask.set(0xFF);
 		}
-		pD3Ddevice->Clear(0, NULL, D3DCLEAR_STENCIL|D3DCLEAR_TARGET |D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), 0, 0);
+		pD3Ddevice->Clear(0, NULL, D3DCLEAR_STENCIL|D3DCLEAR_TARGET |D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), ToScaledDepth(0), 0);
 		if (keepState) {
 			dxstate.scissorTest.restore();
 			dxstate.depthWrite.restore();

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -89,10 +89,11 @@ void FramebufferManager::ClearBuffer(bool keepState) {
 	}
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 	glClearStencil(0);
+	float clearDepth = ToScaledDepth(0);
 #ifdef USING_GLES2
-	glClearDepthf(0.0f);
+	glClearDepthf(clearDepth);
 #else
-	glClearDepth(0.0);
+	glClearDepth(clearDepth);
 #endif
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	if (keepState) {

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -604,8 +604,8 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid) {
 		// The projection already accounts for those, so we need to reverse them.
 		//
 		// Additionally, OpenGL uses a range from [-1, 1].  So we multiply by scale and add the center.
-		viewZScale *= (1.0f / gstate_c.vpDepthScale);
-		viewZCenter -= 65535.0f * (gstate_c.vpZOffset);
+		viewZScale *= 1.0f / gstate_c.vpDepthScale;
+		viewZCenter -= 65535.0f * gstate_c.vpZOffset;
 
 		if (viewZScale != 0.0) {
 			viewZInvScale = 1.0f / viewZScale;


### PR DESCRIPTION
While converting to double (and then realizing I'd made a dumb mistake), I rewrote the code like this.

I think it's clearer and may retain precision slightly better, so it seems a shame to press ctrl-z more times.

It also makes the minz/maxz check much simpler because near/far are guaranteed to be strictly ordered now.  I changed the wording because the numbers are even different again, but I think this will give the best clarity yet since they are strictly ordered now.

Note: doesn't fix anything.  Shouldn't even change the numbers in any real way...

-[Unknown]
