### PR TITLE
Fix I forgot typo declaration x64_64 android port.

### DIFF
--- a/ext/native/gfx/gl_common.h
+++ b/ext/native/gfx/gl_common.h
@@ -53,8 +53,8 @@ typedef void (EGLAPIENTRYP PFNGLDRAWTEXTURENVPROC) (GLuint texture, GLuint sampl
 extern PFNGLDRAWTEXTURENVPROC glDrawTextureNV;
 #ifndef ARM64
 typedef void (EGLAPIENTRYP PFNGLBLITFRAMEBUFFERNVPROC) (
-	GLint srcX0, GLint srcY0, GLint srcX1, GLuint srcY1,
-	GLint dstX0, GLint dstY0, GLint dstX1, GLuint dstY1,
+	GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1,
+	GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1,
 	GLbitfield mask, GLenum filter);
 #endif
 extern PFNGLBLITFRAMEBUFFERNVPROC glBlitFramebufferNV;


### PR DESCRIPTION
Acording in the usr/include/GLES2/gl2ext.h 

typedef void (GL_APIENTRYP PFNGLBLITFRAMEBUFFERNVPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
