### PR TITLE
Add Phantasy Star Portable 2 JP version to compat.ini

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -36,6 +36,10 @@ ULUS10410 = true
 ULES01218 = true
 ULJM08023 = true
 ULES01218 = true
+# Phantasy Star Portable 2 JP (missing text)
+ULJM05493 = true
+NPJH50043 = true
+ULJM08030 = true
 # Puyo Puyo Fever 2   #3663 (layering)
 ULJM05058 = true
 # NBA 2K13  #6603 (menu glitches)


### PR DESCRIPTION
Phantasy Star Portable 2 JP version is missing text too.
