### PR TITLE
Fix a savestate issue while a GE list is running

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1138,13 +1138,12 @@ void GPUCommon::DoState(PointerWrap &p) {
 		}
 	}
 	int currentID = 0;
-	if (currentList != NULL) {
-		ptrdiff_t off = currentList - &dls[0];
-		currentID = (int) (off / sizeof(DisplayList));
+	if (currentList != nullptr) {
+		currentID = (int)(currentList - &dls[0]);
 	}
 	p.Do(currentID);
 	if (currentID == 0) {
-		currentList = NULL;
+		currentList = nullptr;
 	} else {
 		currentList = &dls[currentID];
 	}


### PR DESCRIPTION
A very silly mistake...

Also, log that replacements were written only if they are _actually_ written.  Furthermore, detect when we're (for any reason) changing a replacement index and handle that, just in case it ever happens that we have outdated info.

-[Unknown]
