### PR TITLE
Update PixelDepthRounding list avoid flickering in Phantasy Star games

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -69,3 +69,19 @@ ULJS00456 = true
 ULJS00454 = true
 # Heroes Phantasia Limited Edition Disc requires pixel depth rounding.
 ULJS00455 = true
+# Phantasy Star games flickering
+# Phantasy Star Portable 1
+ULJM05309 = true
+ULUS10410 = true
+ULES01218 = true
+ULJM08023 = true
+ULES01218 = true
+# Phantasy Star Portable 2 JP
+ULJM05493 = true
+NPJH50043 = true
+ULJM08030 = true
+# Phantasy Star Portable 1 Demo
+NPUH90023 = true
+ULJM91014 = true
+# Phantasy Star Portable 2 JP Demo
+ULJM91018 = true


### PR DESCRIPTION
Affect Phantasy Star Portable 1 and Phantasy Star Portable 2 JP version and their demo.
