### PR TITLE
Persist some UI state when recreating views

### DIFF
--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -220,6 +220,7 @@ void ControlMappingScreen::CreateViews() {
 	AddStandardBack(leftColumn);
 
 	rightScroll_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
+	rightScroll_->SetTag("ControlMapping");
 	rightScroll_->SetScrollToTop(false);
 	LinearLayout *rightColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
 	rightScroll_->Add(rightColumn);

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -78,6 +78,7 @@ void CwCheatScreen::CreateViews() {
 	leftColumn->Add(new PopupSliderChoice(&g_Config.iCwCheatRefreshRate, 1, 1000, cw->T("Refresh Rate"), 1, screenManager()));
 
 	ScrollView *rightScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(0.5f));
+	rightScroll->SetTag("CwCheats");
 	rightScroll->SetScrollToTop(false);
 	LinearLayout *rightColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(200, FILL_PARENT, actionMenuMargins));
 	LayoutParams *layout = new LayoutParams(500, 50, LP_PLAIN);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -330,6 +330,7 @@ void SystemInfoScreen::CreateViews() {
 
 	root_->Add(tabHolder);
 	ViewGroup *deviceSpecsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	deviceSpecsScroll->SetTag("DevSystemInfoDeviceSpecs");
 	LinearLayout *deviceSpecs = new LinearLayout(ORIENT_VERTICAL);
 	deviceSpecs->SetSpacing(0);
 	deviceSpecsScroll->Add(deviceSpecs);
@@ -408,6 +409,7 @@ void SystemInfoScreen::CreateViews() {
 #endif
 
 	ViewGroup *cpuExtensionsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	cpuExtensionsScroll->SetTag("DevSystemInfoCPUExt");
 	LinearLayout *cpuExtensions = new LinearLayout(ORIENT_VERTICAL);
 	cpuExtensions->SetSpacing(0);
 	cpuExtensionsScroll->Add(cpuExtensions);
@@ -422,6 +424,7 @@ void SystemInfoScreen::CreateViews() {
 	}
 
 	ViewGroup *oglExtensionsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	oglExtensionsScroll->SetTag("DevSystemInfoOGLExt");
 	LinearLayout *oglExtensions = new LinearLayout(ORIENT_VERTICAL);
 	oglExtensions->SetSpacing(0);
 	oglExtensionsScroll->Add(oglExtensions);
@@ -450,6 +453,7 @@ void SystemInfoScreen::CreateViews() {
 	// If there aren't any EGL extensions, no need to show the tab.
 	if (exts.size() > 0) {
 		ViewGroup *eglExtensionsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+		eglExtensionsScroll->SetTag("DevSystemInfoEGLExt");
 		LinearLayout *eglExtensions = new LinearLayout(ORIENT_VERTICAL);
 		eglExtensions->SetSpacing(0);
 		eglExtensionsScroll->Add(eglExtensions);
@@ -567,10 +571,12 @@ void JitCompareScreen::CreateViews() {
 
 	ScrollView *midColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(2.0f)));
 	LinearLayout *midColumn = midColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
+	midColumn->SetTag("JitCompareLeftDisasm");
 	leftDisasm_ = midColumn->Add(new LinearLayout(ORIENT_VERTICAL));
 	leftDisasm_->SetSpacing(0.0f);
 
 	ScrollView *rightColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(2.0f)));
+	rightColumnScroll->SetTag("JitCompareRightDisasm");
 	LinearLayout *rightColumn = rightColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
 	rightDisasm_ = rightColumn->Add(new LinearLayout(ORIENT_VERTICAL));
 	rightDisasm_->SetSpacing(0.0f);
@@ -851,6 +857,7 @@ void ShaderViewScreen::CreateViews() {
 	layout->Add(new TextView(gpu->DebugGetShaderString(id_, type_, SHADER_STRING_SHORT_DESC)));
 
 	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
+	scroll->SetTag("DevShaderView");
 	layout->Add(scroll);
 
 	LinearLayout *lineLayout = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -326,6 +326,7 @@ void SystemInfoScreen::CreateViews() {
 	AddStandardBack(root_);
 
 	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, 225, new AnchorLayoutParams(10, 0, 10, 0, false));
+	tabHolder->SetTag("DevSystemInfo");
 
 	root_->Add(tabHolder);
 	ViewGroup *deviceSpecsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
@@ -818,6 +819,7 @@ void ShaderListScreen::CreateViews() {
 	root_ = layout;
 
 	tabs_ = new TabHolder(ORIENT_HORIZONTAL, 40, new LinearLayoutParams(1.0));
+	tabs_->SetTag("DevShaderList");
 	layout->Add(tabs_);
 	layout->Add(new Button(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -128,6 +128,7 @@ void GameSettingsScreen::CreateViews() {
 
 	// Graphics
 	ViewGroup *graphicsSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	graphicsSettingsScroll->SetTag("GameSettingsGraphics");
 	LinearLayout *graphicsSettings = new LinearLayout(ORIENT_VERTICAL);
 	graphicsSettings->SetSpacing(0);
 	graphicsSettingsScroll->Add(graphicsSettings);
@@ -333,6 +334,7 @@ void GameSettingsScreen::CreateViews() {
 
 	// Audio
 	ViewGroup *audioSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	audioSettingsScroll->SetTag("GameSettingsAudio");
 	LinearLayout *audioSettings = new LinearLayout(ORIENT_VERTICAL);
 	audioSettings->SetSpacing(0);
 	audioSettingsScroll->Add(audioSettings);
@@ -367,6 +369,7 @@ void GameSettingsScreen::CreateViews() {
 
 	// Control
 	ViewGroup *controlsSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	controlsSettingsScroll->SetTag("GameSettingsControls");
 	LinearLayout *controlsSettings = new LinearLayout(ORIENT_VERTICAL);
 	controlsSettings->SetSpacing(0);
 	controlsSettingsScroll->Add(controlsSettings);
@@ -455,6 +458,7 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogLimiterDeadzone, 0.0f, 1.0f, co->T("Analog Limiter"), 0.10f, screenManager(), "/ 1.0"));
 
 	ViewGroup *networkingSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	networkingSettingsScroll->SetTag("GameSettingsNetworking");
 	LinearLayout *networkingSettings = new LinearLayout(ORIENT_VERTICAL);
 	networkingSettings->SetSpacing(0);
 	networkingSettingsScroll->Add(networkingSettings);
@@ -475,6 +479,7 @@ void GameSettingsScreen::CreateViews() {
 	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.sMACAddress, n->T("Change Mac Address"), nullptr))->OnClick.Handle(this, &GameSettingsScreen::OnChangeMacAddress);
 
 	ViewGroup *toolsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	toolsScroll->SetTag("GameSettingsTools");
 	LinearLayout *tools = new LinearLayout(ORIENT_VERTICAL);
 	tools->SetSpacing(0);
 	toolsScroll->Add(tools);
@@ -488,6 +493,7 @@ void GameSettingsScreen::CreateViews() {
 
 	// System
 	ViewGroup *systemSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	systemSettingsScroll->SetTag("GameSettingsSystem");
 	LinearLayout *systemSettings = new LinearLayout(ORIENT_VERTICAL);
 	systemSettings->SetSpacing(0);
 	systemSettingsScroll->Add(systemSettings);
@@ -1014,6 +1020,7 @@ UI::EventReturn GameSettingsScreen::OnSysInfo(UI::EventParams &e) {
 void DeveloperToolsScreen::CreateViews() {
 	using namespace UI;
 	root_ = new ScrollView(ORIENT_VERTICAL);
+	root_->SetTag("DevToolsSettings");
 
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *dev = GetI18NCategory("Developer");

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -121,6 +121,7 @@ void GameSettingsScreen::CreateViews() {
 		root_->Add(tabHolder);
 		AddStandardBack(root_);
 	}
+	tabHolder->SetTag("GameSettings");
 	root_->SetDefaultFocusView(tabHolder);
 
 	// TODO: These currently point to global settings, not game specific ones.

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -709,6 +709,7 @@ void MainScreen::CreateViews() {
 
 	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	tabHolder_ = leftColumn;
+	tabHolder_->SetTag("MainScreenGames");
 
 	leftColumn->SetClip(true);
 
@@ -1119,6 +1120,7 @@ void UmdReplaceScreen::CreateViews() {
 	I18NCategory *di = GetI18NCategory("Dialog");
 
 	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
+	leftColumn->SetTag("UmdReplace");
 	leftColumn->SetClip(true);
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(270, FILL_PARENT, actionMenuMargins));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -715,6 +715,7 @@ void MainScreen::CreateViews() {
 
 	if (g_Config.iMaxRecent > 0) {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		scrollRecentGames->SetTag("MainScreenRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(
 			"!RECENT", false, &g_Config.bGridView1, "", "", 0,
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
@@ -727,7 +728,9 @@ void MainScreen::CreateViews() {
 
 	if (System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED) {
 		ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		scrollAllGames->SetTag("MainScreenAllGames");
 		ScrollView *scrollHomebrew = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		scrollHomebrew->SetTag("MainScreenHomebrew");
 
 		GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, true, &g_Config.bGridView2,
 			mm->T("How to get games"), "http://www.ppsspp.org/getgames.html", 0,
@@ -1130,6 +1133,7 @@ void UmdReplaceScreen::CreateViews() {
 
 	if (g_Config.iMaxRecent > 0) {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		scrollRecentGames->SetTag("UmdReplaceRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(
 			"!RECENT", false, &g_Config.bGridView1, "", "", 0,
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
@@ -1139,6 +1143,7 @@ void UmdReplaceScreen::CreateViews() {
 		tabRecentGames->OnHoldChoice.Handle(this, &UmdReplaceScreen::OnGameSelected);
 	}
 	ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	scrollAllGames->SetTag("UmdReplaceAllGames");
 
 	GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, true, &g_Config.bGridView2,
 		mm->T("How to get games"), "http://www.ppsspp.org/getgames.html", 0,

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -346,12 +346,14 @@ void SavedataScreen::CreateViews() {
 	TabHolder *tabs = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
 	tabs->SetTag("Savedata");
 	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	scroll->SetTag("SavedataBrowser");
 	browser_ = scroll->Add(new SavedataBrowser(savedata_dir, new LayoutParams(FILL_PARENT, FILL_PARENT)));
 	browser_->OnChoice.Handle(this, &SavedataScreen::OnSavedataButtonClick);
 
 	tabs->AddTab(sa->T("Save Data"), scroll);
 
 	ScrollView *scroll2 = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	scroll2->SetTag("SavedataStatesBrowser");
 	SavedataBrowser *browser2 = scroll2->Add(new SavedataBrowser(savestate_dir));
 	browser2->OnChoice.Handle(this, &SavedataScreen::OnSavedataButtonClick);
 	tabs->AddTab(sa->T("Save States"), scroll2);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -344,6 +344,7 @@ void SavedataScreen::CreateViews() {
 	root_ = new LinearLayout(ORIENT_VERTICAL);
 
 	TabHolder *tabs = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
+	tabs->SetTag("Savedata");
 	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	browser_ = scroll->Add(new SavedataBrowser(savedata_dir, new LayoutParams(FILL_PARENT, FILL_PARENT)));
 	browser_->OnChoice.Handle(this, &SavedataScreen::OnSavedataButtonClick);

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -400,6 +400,7 @@ void StoreScreen::CreateViews() {
 	} else {
 		content = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
 		ScrollView *leftScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 0.4f));
+		leftScroll->SetTag("StoreMainList");
 		content->Add(leftScroll);
 		LinearLayout *scrollItemView = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
 		leftScroll->Add(scrollItemView);
@@ -411,6 +412,7 @@ void StoreScreen::CreateViews() {
 
 		// TODO: Similar apps, etc etc
 		productPanel_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(0.5f));
+		leftScroll->SetTag("StoreMainProduct");
 		content->Add(productPanel_);
 	}
 	root_->Add(content);

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -27,6 +27,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	I18NCategory *di = GetI18NCategory("Dialog");
 
 	root_ = new ScrollView(ORIENT_VERTICAL);
+	root_->SetTag("TiltAnalogSettings");
 
 	LinearLayout *settings = new LinearLayout(ORIENT_VERTICAL);
 

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -335,6 +335,7 @@ void TouchControlLayoutScreen::CreateViews() {
 	root_->Add(back);
 
 	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, leftColumnWidth, new AnchorLayoutParams(10, 0, 10, 0, false));
+	tabHolder->SetTag("TouchControlLayout");
 	root_->Add(tabHolder);
 
 	// this is more for show than anything else. It's used to provide a boundary

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include "base/display.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
@@ -19,13 +20,23 @@ UIScreen::~UIScreen() {
 
 void UIScreen::DoRecreateViews() {
 	if (recreateViews_) {
+		UI::PersistMap persisted;
+		bool persisting = root_ != nullptr;
+		if (persisting) {
+			root_->PersistData(UI::PERSIST_SAVE, persisted);
+		}
+
 		delete root_;
-		root_ = 0;
+		root_ = nullptr;
 		CreateViews();
 		if (root_ && root_->GetDefaultFocusView()) {
 			root_->GetDefaultFocusView()->SetFocus();
 		}
 		recreateViews_ = false;
+
+		if (persisting) {
+			root_->PersistData(UI::PERSIST_RESTORE, persisted);
+		}
 	}
 }
 

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include <cmath>
 #include <cstdio>
 #include <memory>
@@ -203,9 +204,15 @@ enum FocusFlags {
 	FF_GOTFOCUS = 2
 };
 
-class ViewGroup;
+enum PersistStatus {
+	PERSIST_SAVE,
+	PERSIST_RESTORE,
+};
 
-void Fill(UIContext &dc, const Bounds &bounds, const Drawable &drawable);
+typedef std::vector<int> PersistBuffer;
+typedef std::map<std::string, UI::PersistBuffer> PersistMap;
+
+class ViewGroup;
 
 struct MeasureSpec {
 	MeasureSpec(MeasureSpecType t, float s = 0.0f) : type(t), size(s) {}
@@ -339,6 +346,7 @@ public:
 	virtual std::string Describe() const;
 
 	virtual void FocusChanged(int focusFlags) {}
+	virtual void PersistData(PersistStatus status, PersistMap &storage) {}
 
 	void Move(Bounds bounds) {
 		bounds_ = bounds;

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -1053,6 +1053,28 @@ EventReturn TabHolder::OnTabClick(EventParams &e) {
 	return EVENT_DONE;
 }
 
+void TabHolder::PersistData(PersistStatus status, PersistMap &storage) {
+	const std::string &tag = Tag();
+
+	if (tag.empty()) {
+		return;
+	}
+
+	PersistBuffer &buffer = storage["TabHolder::" + tag];
+	switch (status) {
+	case PERSIST_SAVE:
+		buffer.resize(1);
+		buffer[0] = currentTab_;
+		break;
+
+	case PERSIST_RESTORE:
+		if (buffer.size() == 1) {
+			SetCurrentTab(buffer[0]);
+		}
+		break;
+	}
+}
+
 ChoiceStrip::ChoiceStrip(Orientation orientation, LayoutParams *layoutParams)
 		: LinearLayout(orientation, layoutParams), selected_(0), topTabs_(false) {
 	SetSpacing(0.0f);

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -70,9 +70,16 @@ void ViewGroup::Clear() {
 	lock_guard guard(modifyLock_);
 	for (size_t i = 0; i < views_.size(); i++) {
 		delete views_[i];
-		views_[i] = 0;
+		views_[i] = nullptr;
 	}
 	views_.clear();
+}
+
+void ViewGroup::PersistData(PersistStatus status, PersistMap &storage) {
+	lock_guard guard(modifyLock_);
+	for (size_t i = 0; i < views_.size(); i++) {
+		views_[i]->PersistData(status, storage);
+	}
 }
 
 void ViewGroup::Touch(const TouchInput &input) {

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -245,7 +245,9 @@ public:
 	void Update(const InputState &input_state) override;
 
 	// Override so that we can scroll to the active one after moving the focus.
-	virtual bool SubviewFocused(View *view) override;
+	bool SubviewFocused(View *view) override;
+
+	void PersistData(PersistStatus status, PersistMap &storage) override;
 
 	// Quick hack to prevent scrolling to top in some lists
 	void SetScrollToTop(bool t) { scrollToTopOnSizeChange_ = t; }

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -323,6 +323,8 @@ public:
 	int GetCurrentTab() const { return currentTab_; }
 	std::string Describe() const override { return "TabHolder: " + View::Describe(); }
 
+	void PersistData(PersistStatus status, PersistMap &storage) override;
+
 private:
 	EventReturn OnTabClick(EventParams &e);
 

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -64,6 +64,7 @@ public:
 	virtual void SetBG(const Drawable &bg) { bg_ = bg; }
 
 	virtual void Clear();
+	void PersistData(PersistStatus status, PersistMap &storage) override;
 	View *GetViewByIndex(int index) { return views_[index]; }
 	int GetNumSubviews() const { return (int)views_.size(); }
 	void SetHasDropShadow(bool has) { hasDropShadow_ = has; }


### PR DESCRIPTION
Any reason why scroll views scroll to the top on resize by default?  That doesn't seem like normal UI, for example a web browser doesn't do it.  We clamp the pos anyway, right?  It makes sense if the view is affected by another selection, I suppose...?

Anyway, this maintains the selected tab, and on a small number of views (ones that don't scroll up on size change), the scroll position, on resize.

Open to any better suggestions on the persist buffer... almost used a void \* but figured this would auto-free...

-[Unknown]
