### PR TITLE
More UI tweaks for save manager, etc.

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -443,6 +443,14 @@ handleELF:
 
 		case FILETYPE_PPSSPP_SAVESTATE:
 		{
+			// Let's use the screenshot as an icon, too.
+			std::string screenshotPath = ReplaceAll(gamePath_, ".ppst", ".jpg");
+			lock_guard guard(info_->lock);
+			if (File::Exists(screenshotPath)) {
+				if (readFileToString(false, screenshotPath.c_str(), info_->iconTextureData)) {
+					info_->iconDataLoaded = true;
+				}
+			}
 			break;
 		}
 
@@ -709,7 +717,7 @@ again:
 void GameInfoCache::SetupTexture(GameInfo *info, std::string &textureData, Thin3DContext *thin3d, Thin3DTexture *&tex, double &loadTime) {
 	if (textureData.size()) {
 		if (!tex) {
-			tex = thin3d->CreateTextureFromFileData((const uint8_t *)textureData.data(), (int)textureData.size(), T3DImageType::PNG);
+			tex = thin3d->CreateTextureFromFileData((const uint8_t *)textureData.data(), (int)textureData.size(), T3DImageType::DETECT);
 			if (tex) {
 				loadTime = time_now_d();
 			}

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -84,7 +84,7 @@ public:
 			root->Add(new TextView(savedata_detail, 0, true, new LinearLayoutParams(Margins(10, 0))));
 			root->Add(new Spacer(3.0));
 		} else {
-			std::string image_path = ReplaceAll(savePath_, "ppst", "jpg");
+			std::string image_path = ReplaceAll(savePath_, ".ppst", ".jpg");
 			if (File::Exists(image_path)) {
 				PrioritizedWorkQueue *wq = g_gameInfoCache.WorkQueue();
 				toprow->Add(new AsyncImageFileView(image_path, IS_DEFAULT, wq, new UI::LayoutParams(500, 500/16*9)));
@@ -182,6 +182,11 @@ void SavedataButton::Draw(UIContext &dc) {
 		float nw = h * tw / th;
 		x += (w - nw) / 2.0f;
 		w = nw;
+
+		if (texture->Width() >= w * 2 || texture->Height() >= h * 2) {
+			// Better to use mipmaps, then.  This is probably a large savestate screenshot.
+			texture->AutoGenMipmaps();
+		}
 	}
 
 	int txOffset = down_ ? 4 : 0;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -501,6 +501,7 @@ Thin3DTexture *Thin3DGLContext::CreateTexture(T3DTextureType type, T3DImageForma
 void Thin3DGLTexture::AutoGenMipmaps() {
 	Bind();
 	glGenerateMipmap(target_);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
 }
 
 void Thin3DGLTexture::SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -427,6 +427,7 @@ GLuint TypeToTarget(T3DTextureType type) {
 class Thin3DGLTexture : public Thin3DTexture, GfxResourceHolder {
 public:
 	Thin3DGLTexture() : tex_(0), target_(0) {
+		generatedMips_ = false;
 		width_ = 0;
 		height_ = 0;
 		depth_ = 0;
@@ -434,6 +435,7 @@ public:
 		register_gl_resource_holder(this);
 	}
 	Thin3DGLTexture(T3DTextureType type, T3DImageFormat format, int width, int height, int depth, int mipLevels) : tex_(0), target_(TypeToTarget(type)), format_(format), mipLevels_(mipLevels) {
+		generatedMips_ = false;
 		width_ = width;
 		height_ = height;
 		depth_ = depth;
@@ -446,6 +448,7 @@ public:
 	}
 
 	bool Create(T3DTextureType type, T3DImageFormat format, int width, int height, int depth, int mipLevels) override {
+		generatedMips_ = false;
 		format_ = format;
 		target_ = TypeToTarget(type);
 		mipLevels_ = mipLevels;
@@ -459,6 +462,7 @@ public:
 		if (tex_) {
 			glDeleteTextures(1, &tex_);
 			tex_ = 0;
+			generatedMips_ = false;
 		}
 	}
 	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) override;
@@ -469,6 +473,7 @@ public:
 	}
 
 	void GLLost() override {
+		generatedMips_ = false;
 		if (!filename_.empty()) {
 			if (LoadFromFile(filename_.c_str())) {
 				ILOG("Reloaded lost texture %s", filename_.c_str());
@@ -488,6 +493,7 @@ private:
 
 	T3DImageFormat format_;
 	int mipLevels_;
+	bool generatedMips_;
 };
 
 Thin3DTexture *Thin3DGLContext::CreateTexture() {
@@ -499,9 +505,12 @@ Thin3DTexture *Thin3DGLContext::CreateTexture(T3DTextureType type, T3DImageForma
 }
 
 void Thin3DGLTexture::AutoGenMipmaps() {
-	Bind();
-	glGenerateMipmap(target_);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
+	if (!generatedMips_) {
+		Bind();
+		glGenerateMipmap(target_);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
+		generatedMips_ = true;
+	}
 }
 
 void Thin3DGLTexture::SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) {

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -658,9 +658,8 @@ void TextView::Draw(UIContext &dc) {
 		clip = false;
 	}
 	if (clip) {
-		Bounds clipRect = bounds_.Expand(10);  // TODO: Remove this hackery
 		dc.Flush();
-		dc.PushScissor(clipRect);
+		dc.PushScissor(bounds_);
 	}
 	// In case it's been made focusable.
 	if (HasFocus()) {

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -35,8 +35,8 @@ bool IsDragCaptured(int id) {
 }
 
 void ApplyGravity(const Bounds outer, const Margins &margins, float w, float h, int gravity, Bounds &inner) {
-	inner.w = w - (margins.left + margins.right);
-	inner.h = h - (margins.top + margins.bottom);
+	inner.w = w;
+	inner.h = h;
 
 	switch (gravity & G_HORIZMASK) {
 	case G_LEFT: inner.x = outer.x + margins.left; break;

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -746,7 +746,6 @@ void ScrollView::Touch(const TouchInput &input) {
 		float info[4];
 		if (gesture_.GetGestureInfo(gesture, info) && !(input.flags & TOUCH_DOWN)) {
 			float pos = scrollStart_ - info[0];
-			ClampScrollPos(pos);
 			scrollPos_ = pos;
 			scrollTarget_ = pos;
 			scrollToTarget_ = false;
@@ -842,7 +841,6 @@ void ScrollView::PersistData(PersistStatus status, std::string anonId, PersistMa
 	case PERSIST_RESTORE:
 		if (buffer.size() == 1) {
 			float pos = *(float *)&buffer[0];
-			ClampScrollPos(pos);
 			scrollPos_ = pos;
 			scrollTarget_ = pos;
 			scrollToTarget_ = false;
@@ -864,13 +862,11 @@ void ScrollView::SetVisibility(Visibility visibility) {
 void ScrollView::ScrollTo(float newScrollPos) {
 	scrollTarget_ = newScrollPos;
 	scrollToTarget_ = true;
-	ClampScrollPos(scrollTarget_);
 }
 
 void ScrollView::ScrollRelative(float distance) {
 	scrollTarget_ = scrollPos_ + distance;
 	scrollToTarget_ = true;
-	ClampScrollPos(scrollTarget_);
 }
 
 void ScrollView::ClampScrollPos(float &pos) {
@@ -917,6 +913,8 @@ void ScrollView::Update(const InputState &input_state) {
 	ViewGroup::Update(input_state);
 	gesture_.UpdateFrame();
 	if (scrollToTarget_) {
+		ClampScrollPos(scrollTarget_);
+
 		inertia_ = 0.0f;
 		if (fabsf(scrollTarget_ - scrollPos_) < 0.5f) {
 			scrollPos_ = scrollTarget_;
@@ -929,8 +927,9 @@ void ScrollView::Update(const InputState &input_state) {
 		inertia_ *= friction;
 		if (fabsf(inertia_) < stop_threshold)
 			inertia_ = 0.0f;
-		ClampScrollPos(scrollPos_);
 	}
+
+	ClampScrollPos(scrollPos_);
 }
 
 void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -293,6 +293,7 @@ public:
 	Event OnChoice;
 
 private:
+	StickyChoice *Choice(int index);
 	EventReturn OnChoiceClick(EventParams &e);
 
 	int selected_;


### PR DESCRIPTION
This changes the way scroll pos clamping is handled a bit, and fixes restoring scroll view on tabbed strips when a secondary tab is selected.

It also shows save state screenshots as icons in the save manager, and fixes some text clipping bugs.

-[Unknown]
