### PR TITLE
Atrac: Move buffer offset only if needed

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1258,8 +1258,12 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 				}
 				if ((atrac->bufferState_ & ATRAC_STATUS_STREAMED_MASK) == ATRAC_STATUS_STREAMED_MASK) {
 					// Whatever bytes we have left were added from the loop.
-					atrac->first_.fileoffset = atrac->FileOffsetBySample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_ - atrac->SamplesPerFrame() * 2);
-					// Skip the initial frame at the start.
+					u32 loopOffset = atrac->FileOffsetBySample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_ - atrac->SamplesPerFrame() * 2);
+					// TODO: Hmm, need to manage the buffer better.  But don't move fileoffset if we already have valid data.
+					if (loopOffset > atrac->first_.fileoffset || loopOffset + atrac->bufferValidBytes_ < atrac->first_.fileoffset) {
+						// Skip the initial frame at the start.
+						atrac->first_.fileoffset = atrac->FileOffsetBySample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_ - atrac->SamplesPerFrame() * 2);
+					}
 				}
 			} else if (hitEnd) {
 				finishFlag = 1;


### PR DESCRIPTION
Hmm, need to manage this buffer smarter, though, when streaming.  Right now it's only getting it right enough to ask for the right amount of data, really...

Fixes #8498.  Will get fixed better when implementing reading from PSP RAM for streaming buffers, though.

-[Unknown]
