### PR TITLE
Do not fail on AVERROR_INVALIDDATA

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -556,6 +556,11 @@ struct Atrac {
 			// Let's try the next packet.
 			packet_->size = 0;
 			return ATDECODE_BADFRAME;
+		} else if (bytes_read == AVERROR_INVALIDDATA) {
+			ERROR_LOG(ME, "Invalid data detected.  Ignoring.");
+			// Let's try the next packet.
+			packet_->size = 0;
+			return ATDECODE_BADFRAME;
 		} else if (bytes_read < 0) {
 			ERROR_LOG_REPORT(ME, "avcodec_decode_audio4: Error decoding audio %d / %08x", bytes_read, bytes_read);
 			failedDecode_ = true;


### PR DESCRIPTION
When playing Legend of Heroes, after most battles the audio stops working due to AVERROR_INVALIDDATA.  Ignoring the frame rather than falling through to `failedDecoded_ = true` seemed to address this.
