### PR TITLE
Handle floats and sign extension in HLE logs

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -675,11 +675,15 @@ void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res,
 		retmask = latestSyscall->retmask;
 
 	const char *fmt;
-	// TODO: Floats and other types... move to another func (for return type?)  Hmm.
 	if (retmask == 'x') {
 		fmt = "%08llx=%s(%s)%s";
+		// Truncate the high bits of the result (from any sign extension.)
+		res = (u32)res;
 	} else if (retmask == 'i' || retmask == 'I') {
 		fmt = "%lld=%s(%s)%s";
+	} else if (retmask == 'f') {
+		// TODO: For now, floats are just shown as bits.
+		fmt = "%08x=%s(%s)%s";
 	} else {
 		_assert_msg_(HLE, false, "Invalid return format: %c", retmask);
 		fmt = "%08llx=%s(%s)%s";

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdarg>
+#include <type_traits>
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
 #include "Core/MIPS/MIPS.h"
@@ -166,7 +167,14 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 		va_end(args);
 	}
 
-	hleDoLogInternal(t, level, res, file, line, reportTag, retmask, reason, formatted_reason);
+	u64 fmtRes = res;
+	if (std::is_floating_point<T>::value) {
+		// We reinterpret as the bits for now, so we can have a common helper.
+		fmtRes = *(const u32 *)&res;
+	} else if (std::is_signed<T>::value) {
+		fmtRes = (s64)res;
+	}
+	hleDoLogInternal(t, level, fmtRes, file, line, reportTag, retmask, reason, formatted_reason);
 	return res;
 }
 
@@ -176,7 +184,14 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 		return res;
 	}
 
-	hleDoLogInternal(t, level, res, file, line, reportTag, retmask, nullptr, "");
+	u64 fmtRes = res;
+	if (std::is_floating_point<T>::value) {
+		// We reinterpret as the bits for now, so we can have a common helper.
+		fmtRes = *(const u32 *)&res;
+	} else if (std::is_signed<T>::value) {
+		fmtRes = (s64)res;
+	}
+	hleDoLogInternal(t, level, fmtRes, file, line, reportTag, retmask, nullptr, "");
 	return res;
 }
 


### PR DESCRIPTION
In some cases, we were previously logging sign-extended error codes.  This handles that better using type_traits.

(let's see if this compiles on Symbian...)

-[Unknown]
