### PR TITLE
UI: Keep focus on game after displaying details

### DIFF
--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -41,7 +41,6 @@ GameScreen::GameScreen(const std::string &gamePath) : UIDialogScreenWithGameBack
 }
 
 GameScreen::~GameScreen() {
-	SetBackgroundAudioGame("");
 }
 
 void GameScreen::CreateViews() {

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -34,6 +34,8 @@ public:
 
 	virtual void update(InputState &input);
 
+	virtual std::string tag() const { return "game"; }
+
 protected:
 	virtual void CreateViews();
 	void CallbackDeleteConfig(bool yes);

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -33,6 +33,8 @@ public:
 
 	UI::Choice *HomebrewStoreButton() { return homebrewStoreButton_; }
 
+	void FocusGame(std::string gamePath);
+
 private:
 	void Refresh();
 	bool IsCurrentPathPinned();
@@ -56,6 +58,7 @@ private:
 	std::string lastLink_;
 	int flags_;
 	UI::Choice *homebrewStoreButton_;
+	std::string focusGamePath_;
 };
 
 class MainScreen : public UIScreenWithBackground {
@@ -97,6 +100,9 @@ private:
 
 	UI::LinearLayout *upgradeBar_;
 	UI::TabHolder *tabHolder_;
+
+	std::string restoreFocusGamePath_;
+	std::vector<GameBrowser *> gameBrowsers_;
 
 	std::string highlightedGamePath_;
 	std::string prevHighlightedGamePath_;


### PR DESCRIPTION
Fixes #8539.

Also takes care not to restart the music or re-fade the background, so it's more seamless.

It might be interesting to remember the focus more generically on views when pushing screens and creating dialogs, e.g. by path.  But I think there would be cases where this might not do the right thing, hmm...

-[Unknown]
