### PR TITLE
Pointer

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -624,7 +624,7 @@ namespace MIPSAnalyst {
 
 		if (IsSVQInstr(op)) {
 			int vt = (((op >> 16) & 0x1f)) | ((op & 1) << 5);
-			float rd[4];
+			FloatBits rd[4]; //float
 			ReadVector(rd, V_Quad, vt);
 			return memcmp(rd, Memory::GetPointer(addr), sizeof(float) * 4) != 0;
 		}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -293,9 +293,7 @@ namespace MIPSInt
 				_dbg_assert_msg_(CPU, 0, "Misaligned lv.q");
 			}
 #ifndef COMMON_BIG_ENDIAN
-			FloatBits mgpr;
-			mgpr._u8 = *Memory::GetPointer(addr);
-			ReadVector(&mgpr, V_Quad, vt);
+			WriteVector((const float*)Memory::GetPointer(addr), V_Quad, vt);
 #else
 			FloatBits lvqd[4]; //float
 
@@ -342,9 +340,7 @@ namespace MIPSInt
 				_dbg_assert_msg_(CPU, 0, "Misaligned sv.q");
 			}
 #ifndef COMMON_BIG_ENDIAN
-			FloatBits mgp;
-			mgp._u8 = *Memory::GetPointer(addr);
-			ReadVector(&mgp, V_Quad, vt);
+			WriteVector((const float*)Memory::GetPointer(addr), V_Quad, vt);
 #else
 			FloatBits svqd[4]; //float
 			ReadVector(svqd, V_Quad, vt);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -293,7 +293,9 @@ namespace MIPSInt
 				_dbg_assert_msg_(CPU, 0, "Misaligned lv.q");
 			}
 #ifndef COMMON_BIG_ENDIAN
-			ReadVector(reinterpret_cast<float *>(Memory::GetPointer(addr)), V_Quad, vt);
+			FloatBits mgpr;
+			mgpr._u8 = *Memory::GetPointer(addr);
+			ReadVector(&mgpr, V_Quad, vt);
 #else
 			FloatBits lvqd[4]; //float
 
@@ -340,7 +342,9 @@ namespace MIPSInt
 				_dbg_assert_msg_(CPU, 0, "Misaligned sv.q");
 			}
 #ifndef COMMON_BIG_ENDIAN
-			ReadVector(reinterpret_cast<float *>(Memory::GetPointer(addr)), V_Quad, vt);
+			FloatBits mgp;
+			mgp._u8 = *Memory::GetPointer(addr);
+			ReadVector(&mgp, V_Quad, vt);
 #else
 			FloatBits svqd[4]; //float
 			ReadVector(svqd, V_Quad, vt);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -70,18 +70,6 @@
 #define M_SQRT1_2  0.707106781186547524401f
 #endif
 
-union FloatBits4 {
-	float f[4];
-	u32 u[4];
-	int i[4];
-};
-
-union FloatBits2 {
-	float f[2];
-	u32 u[2];
-	int i[2];
-};
-
 // Preserves NaN in first param, takes sign of equal second param.
 // Technically, std::max may do this but it's undefined.
 inline float nanmax(float f, float cst)
@@ -150,7 +138,61 @@ void ApplyPrefixST(float *r, u32 data, VectorSize size)
 	}
 }
 
+void ApplyPrefixST(FloatBits *r, u32 data, VectorSize size)
+{
+	// Possible optimization shortcut:
+	if (data == 0xe4)
+		return;
+
+	int n = GetNumVectorElements(size);
+	float origV[4];
+	static const float constantArray[8] = {0.f, 1.f, 2.f, 0.5f, 3.f, 1.f/3.f, 0.25f, 1.f/6.f};
+
+	for (int i = 0; i < n; i++)
+	{
+		origV[i] = r[i].f;
+	}
+
+	for (int i = 0; i < n; i++)
+	{
+		int regnum = (data >> (i*2)) & 3;
+		int abs    = (data >> (8+i)) & 1;
+		int negate = (data >> (16+i)) & 1;
+		int constants = (data >> (12+i)) & 1;
+
+		if (!constants)
+		{
+			// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
+			// TODO: But some ops seem to use const 0 instead?
+			if (regnum >= n) {
+				ERROR_LOG_REPORT(CPU, "Invalid VFPU swizzle: %08x: %i / %d at PC = %08x (%s)", data, regnum, n, currentMIPS->pc, MIPSDisasmAt(currentMIPS->pc));
+				//for (int i = 0; i < 12; i++) {
+				//	ERROR_LOG(CPU, "  vfpuCtrl[%i] = %08x", i, currentMIPS->vfpuCtrl[i]);
+				//}
+				regnum = 0;
+			}
+
+			r[i].f = origV[regnum];
+			if (abs)
+				r[i].f = fabs(r[i].f);
+		}
+		else
+		{
+			r[i].f = constantArray[regnum + (abs<<2)];
+		}
+
+		if (negate)
+			r[i].f = -r[i].f;
+	}
+}
+
+
 inline void ApplySwizzleS(float *v, VectorSize size)
+{
+	ApplyPrefixST(v, currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX], size);
+}
+
+inline void ApplySwizzleS(FloatBits *v, VectorSize size)
 {
 	ApplyPrefixST(v, currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX], size);
 }
@@ -160,7 +202,13 @@ inline void ApplySwizzleT(float *v, VectorSize size)
 	ApplyPrefixST(v, currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX], size);
 }
 
-void ApplyPrefixD(float *v, VectorSize size, bool onlyWriteMask = false)
+
+inline void ApplySwizzleT(FloatBits *v, VectorSize size)
+{
+	ApplyPrefixST(v, currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX], size);
+}
+
+void ApplyPrefixD(FloatBits *v, VectorSize size, bool onlyWriteMask = false)
 {
 	u32 data = currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX];
 	if (!data || onlyWriteMask)
@@ -171,14 +219,14 @@ void ApplyPrefixD(float *v, VectorSize size, bool onlyWriteMask = false)
 		int sat = (data >> (i * 2)) & 3;
 		if (sat == 1)
 		{
-			if (v[i] > 1.0f) v[i] = 1.0f;
+			if (v[i].f > 1.0f) v[i].f = 1.0f;
 			// This includes -0.0f -> +0.0f.
-			if (v[i] <= 0.0f) v[i] = 0.0f;
+			if (v[i].f <= 0.0f) v[i].f = 0.0f;
 		}
 		else if (sat == 3)
 		{
-			if (v[i] > 1.0f)  v[i] = 1.0f;
-			if (v[i] < -1.0f) v[i] = -1.0f;
+			if (v[i].f > 1.0f)  v[i].f = 1.0f;
+			if (v[i].f < -1.0f) v[i].f = -1.0f;
 		}
 	}
 }
@@ -216,7 +264,7 @@ namespace MIPSInt
 				{
 					_dbg_assert_msg_(CPU, 0, "Misaligned lvX.q");
 				}
-				float d[4];
+				FloatBits d[4]; //float
 				ReadVector(d, V_Quad, vt);
 				int offset = (addr >> 2) & 3;
 				if ((op & 2) == 0)
@@ -224,7 +272,7 @@ namespace MIPSInt
 					// It's an LVL
 					for (int i = 0; i < offset + 1; i++)
 					{
-						d[3 - i] = Memory::Read_Float(addr - 4 * i);
+						d[3 - i].f = Memory::Read_Float(addr - 4 * i);
 					}
 				}
 				else
@@ -232,7 +280,7 @@ namespace MIPSInt
 					// It's an LVR
 					for (int i = 0; i < (3 - offset) + 1; i++)
 					{
-						d[i] = Memory::Read_Float(addr + 4 * i);
+						d[i].f = Memory::Read_Float(addr + 4 * i);
 					}
 				}
 				WriteVector(d, V_Quad, vt);
@@ -245,14 +293,14 @@ namespace MIPSInt
 				_dbg_assert_msg_(CPU, 0, "Misaligned lv.q");
 			}
 #ifndef COMMON_BIG_ENDIAN
-			WriteVector((const float*)Memory::GetPointer(addr), V_Quad, vt);
+			ReadVector(reinterpret_cast<float *>(Memory::GetPointer(addr)), V_Quad, vt);
 #else
-			float lvqd[4];
+			FloatBits lvqd[4]; //float
 
-			lvqd[0] = Memory::Read_Float(addr);
-			lvqd[1] = Memory::Read_Float(addr + 4);
-			lvqd[2] = Memory::Read_Float(addr + 8);
-			lvqd[3] = Memory::Read_Float(addr + 12);
+			lvqd[0].f = Memory::Read_Float(addr);
+			lvqd[1].f = Memory::Read_Float(addr + 4);
+			lvqd[2].f = Memory::Read_Float(addr + 8);
+			lvqd[3].f = Memory::Read_Float(addr + 12);
 
 			WriteVector(lvqd, V_Quad, vt);
 #endif
@@ -264,7 +312,7 @@ namespace MIPSInt
 				{
 					_dbg_assert_msg_(CPU, 0, "Misaligned svX.q");
 				}
-				float d[4];
+				FloatBits d[4]; //float
 				ReadVector(d, V_Quad, vt);
 				int offset = (addr >> 2) & 3;
 				if ((op&2) == 0)
@@ -272,7 +320,7 @@ namespace MIPSInt
 					// It's an SVL
 					for (int i = 0; i < offset + 1; i++)
 					{
-						Memory::Write_Float(d[3 - i], addr - i * 4);
+						Memory::Write_Float(d[3 - i].f, addr - i * 4);
 					}
 				}
 				else
@@ -280,7 +328,7 @@ namespace MIPSInt
 					// It's an SVR
 					for (int i = 0; i < (3 - offset) + 1; i++)
 					{
-						Memory::Write_Float(d[i], addr + 4 * i);
+						Memory::Write_Float(d[i].f, addr + 4 * i);
 					}
 				}
 				break;
@@ -294,13 +342,13 @@ namespace MIPSInt
 #ifndef COMMON_BIG_ENDIAN
 			ReadVector(reinterpret_cast<float *>(Memory::GetPointer(addr)), V_Quad, vt);
 #else
-			float svqd[4];
+			FloatBits svqd[4]; //float
 			ReadVector(svqd, V_Quad, vt);
 
-			Memory::Write_Float(svqd[0], addr);
-			Memory::Write_Float(svqd[1], addr + 4);
-			Memory::Write_Float(svqd[2], addr + 8);
-			Memory::Write_Float(svqd[3], addr + 12);
+			Memory::Write_Float(svqd[0].f, addr);
+			Memory::Write_Float(svqd[1].f, addr + 4);
+			Memory::Write_Float(svqd[2].f, addr + 8);
+			Memory::Write_Float(svqd[3].f, addr + 12);
 #endif
 			break;
 
@@ -373,9 +421,9 @@ namespace MIPSInt
 			EatPrefixes();
 			return;
 		}
-		float o[4];
+		FloatBits o[4]; //float
 		for (int i = 0; i < n; i++)
-			o[i] = v[i];
+			o[i].f = v[i];
 		ApplyPrefixD(o, sz);
 		WriteVector(o, sz, vd);
 
@@ -389,20 +437,20 @@ namespace MIPSInt
 		s32 imm = (s16)(op&0xFFFF);
 		u16 uimm16 = (op&0xFFFF);
 		//V(vt) = (float)imm;
-		float f[1];
+		FloatBits f[1]; //float
 		int type = (op >> 23) & 7;
 		if (type == 6)
-			f[0] = (float)imm;  // viim
+			f[0].f = (float)imm;  // viim
 		else if (type == 7)
-			f[0] = Float16ToFloat32((u16)uimm16);   // vfim
+			f[0].f = Float16ToFloat32((u16)uimm16);   // vfim
 		else
 		{
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
-			f[0] = 0;
+			f[0].f = 0;
 		}
 		
 		ApplyPrefixD(f, V_Single);
-		V(vt) = f[0];
+		V(vt) = f[0].f;
 		PC += 4;
 		EatPrefixes();
 	}
@@ -411,18 +459,18 @@ namespace MIPSInt
 	{
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
-		float f[4];
+		FloatBits f[4]; //float
 		switch (sz)
 		{
 		case V_Pair:
-			f[0] = (vd&1)==0 ? 1.0f : 0.0f;
-			f[1] = (vd&1)==1 ? 1.0f : 0.0f;
+			f[0].f = (vd&1)==0 ? 1.0f : 0.0f;
+			f[1].f = (vd&1)==1 ? 1.0f : 0.0f;
 			break;
 		case V_Quad:
-			f[0] = (vd&3)==0 ? 1.0f : 0.0f;
-			f[1] = (vd&3)==1 ? 1.0f : 0.0f;
-			f[2] = (vd&3)==2 ? 1.0f : 0.0f;
-			f[3] = (vd&3)==3 ? 1.0f : 0.0f;
+			f[0].f = (vd&3)==0 ? 1.0f : 0.0f;
+			f[1].f = (vd&3)==1 ? 1.0f : 0.0f;
+			f[2].f = (vd&3)==2 ? 1.0f : 0.0f;
+			f[3].f = (vd&3)==3 ? 1.0f : 0.0f;
 			break;
 		default:
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
@@ -471,7 +519,7 @@ namespace MIPSInt
 	{
 		float d[16];
 		float s[16];
-		float t[1];
+		FloatBits t[1]; //float
 
 		int vd = _VD;
 		int vs = _VS;
@@ -486,7 +534,7 @@ namespace MIPSInt
 		{
 			for (int b = 0; b < n; b++)
 			{
-				d[a*4 + b] = s[a*4 + b] * t[0];
+				d[a*4 + b] = s[a*4 + b] * t[0].f;
 			}
 		}
 
@@ -516,7 +564,7 @@ namespace MIPSInt
 
 	void Int_VV2Op(MIPSOpcode op)
 	{
-		float s[4], d[4];
+		FloatBits s[4], d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -526,24 +574,24 @@ namespace MIPSInt
 		{
 			switch ((op >> 16) & 0x1f)
 			{
-			case 0: d[i] = s[i]; break; //vmov
-			case 1: d[i] = fabsf(s[i]); break; //vabs
-			case 2: d[i] = -s[i]; break; //vneg
+			case 0: d[i].f = s[i].f; break; //vmov
+			case 1: d[i].f = fabsf(s[i].f); break; //vabs
+			case 2: d[i].f = -s[i].f; break; //vneg
 			// vsat0 changes -0.0 to +0.0, both retain NAN.
-			case 4: if (s[i] <= 0) d[i] = 0; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;    // vsat0
-			case 5: if (s[i] < -1.0f) d[i] = -1.0f; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;  // vsat1
-			case 16: d[i] = 1.0f / s[i]; break; //vrcp
-			case 17: d[i] = 1.0f / sqrtf(s[i]); break; //vrsq
+			case 4: if (s[i].f <= 0) d[i].f = 0; else {if(s[i].f > 1.0f) d[i].f = 1.0f; else d[i].f = s[i].f;} break;    // vsat0
+			case 5: if (s[i].f < -1.0f) d[i].f = -1.0f; else {if(s[i].f > 1.0f) d[i].f = 1.0f; else d[i].f = s[i].f;} break;  // vsat1
+			case 16: d[i].f = 1.0f / s[i].f; break; //vrcp
+			case 17: d[i].f = 1.0f / sqrtf(s[i].f); break; //vrsq
 				
-			case 18: { d[i] = vfpu_sin(s[i]); } break; //vsin
-			case 19: { d[i] = vfpu_cos(s[i]); } break; //vcos
-			case 20: d[i] = powf(2.0f, s[i]); break; //vexp2
-			case 21: d[i] = logf(s[i])/log(2.0f); break; //vlog2
-			case 22: d[i] = fabsf(sqrtf(s[i])); break; //vsqrt
-			case 23: d[i] = asinf(s[i]) / M_PI_2; break; //vasin
-			case 24: d[i] = -1.0f / s[i]; break; // vnrcp
-			case 26: { d[i] = -vfpu_sin(s[i]); } break; // vnsin
-			case 28: d[i] = 1.0f / powf(2.0, s[i]); break; // vrexp2
+			case 18: { d[i].f = vfpu_sin(s[i].f); } break; //vsin
+			case 19: { d[i].f = vfpu_cos(s[i].f); } break; //vcos
+			case 20: d[i].f = powf(2.0f, s[i].f); break; //vexp2
+			case 21: d[i].f = logf(s[i].f)/log(2.0f); break; //vlog2
+			case 22: d[i].f = fabsf(sqrtf(s[i].f)); break; //vsqrt
+			case 23: d[i].f = asinf(s[i].f) / M_PI_2; break; //vasin
+			case 24: d[i].f = -1.0f / s[i].f; break; // vnrcp
+			case 26: { d[i].f = -vfpu_sin(s[i].f); } break; // vnsin
+			case 28: d[i].f = 1.0f / powf(2.0, s[i].f); break; // vrexp2
 			default:
 				_dbg_assert_msg_(CPU,0,"Trying to interpret VV2Op instruction that can't be interpreted");
 				break;
@@ -557,7 +605,7 @@ namespace MIPSInt
 
 	void Int_Vocp(MIPSOpcode op)
 	{
-		float s[4], d[4];
+		FloatBits s[4], d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -565,7 +613,7 @@ namespace MIPSInt
 		for (int i = 0; i < GetNumVectorElements(sz); i++)
 		{
 			// Always positive NaN.
-			d[i] = my_isnan(s[i]) ? fabsf(s[i]) : 1.0f - s[i];
+			d[i].f = my_isnan(s[i].f) ? fabsf(s[i].f) : 1.0f - s[i].f;
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -575,20 +623,20 @@ namespace MIPSInt
 	
 	void Int_Vsocp(MIPSOpcode op)
 	{
-		float s[4], d[4];
+		FloatBits s[4], d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		int n = GetNumVectorElements(sz);
-		float x = s[0];
-		d[0] = nanclamp(1.0f - x, 0.0f, 1.0f);
-		d[1] = nanclamp(x, 0.0f, 1.0f);
+		float x = s[0].f;
+		d[0].f = nanclamp(1.0f - x, 0.0f, 1.0f);
+		d[1].f = nanclamp(x, 0.0f, 1.0f);
 		VectorSize outSize = V_Pair;
 		if (n > 1) {
-			float y = s[1];
-			d[2] = nanclamp(1.0f - y, 0.0f, 1.0f);
-			d[3] = nanclamp(y, 0.0f, 1.0f);
+			float y = s[1].f;
+			d[2].f = nanclamp(1.0f - y, 0.0f, 1.0f);
+			d[3].f = nanclamp(y, 0.0f, 1.0f);
 			outSize = V_Quad;
 		} 
 		WriteVector(d, outSize, vd);
@@ -598,7 +646,7 @@ namespace MIPSInt
 
 	void Int_Vsgn(MIPSOpcode op)
 	{
-		float s[4], d[4];
+		FloatBits s[4], d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -608,13 +656,13 @@ namespace MIPSInt
 		{
 			// To handle NaNs correctly, we do this with integer hackery
 			u32 val;
-			memcpy(&val, &s[i], sizeof(u32));
+			memcpy(&val, &s[i].f, sizeof(u32));
 			if (val == 0 || val == 0x80000000)
-				d[i] = 0.0f;
+				d[i].f = 0.0f;
 			else if ((val >> 31) == 0)
-				d[i] = 1.0f;
+				d[i].f = 1.0f;
 			else
-				d[i] = -1.0f;
+				d[i].f = -1.0f;
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -628,142 +676,141 @@ namespace MIPSInt
 	}
 
 	void Int_Vf2i(MIPSOpcode op) {
-		FloatBits4 s; //float
-		FloatBits4 d; //int
+		FloatBits s[4]; //float
+		FloatBits d[4]; //int
 		int vd = _VD;
 		int vs = _VS;
 		int imm = (op >> 16) & 0x1f;
 		float mult = (float)(1UL << imm);
 		VectorSize sz = GetVecSize(op);
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz); //TODO: and the mask to kill everything but swizzle
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz); //TODO: and the mask to kill everything but swizzle
 		for (int i = 0; i < GetNumVectorElements(sz); i++) {
-			if (my_isnan(s.f[i])) {
-				d.i[i] = 0x7FFFFFFF;
+			if (my_isnan(s[i].f)) {
+				d[i].i = 0x7FFFFFFF;
 				continue;
 			}
-			double sv = s.f[i] * mult; // (float)0x7fffffff == (float)0x80000000
+			double sv = s[i].f * mult; // (float)0x7fffffff == (float)0x80000000
 			// Cap/floor it to 0x7fffffff / 0x80000000
 			if (sv > (double)0x7fffffff) {
-				d.i[i] = 0x7fffffff;
+				d[i].i = 0x7fffffff;
 			} else if (sv <= (double)(int)0x80000000) {
-				d.i[i] = 0x80000000;
+				d[i].i = 0x80000000;
 			} else {
 				switch ((op >> 21) & 0x1f)
 				{
-				case 16: d.i[i] = (int)round_vfpu_n(sv); break; //(floor(sv + 0.5f)); break; //n
-				case 17: d.i[i] = s.f[i]>=0 ? (int)floor(sv) : (int)ceil(sv); break; //z
-				case 18: d.i[i] = (int)ceil(sv); break; //u
-				case 19: d.i[i] = (int)floor(sv); break; //d
-				default: d.i[i] = 0x7FFFFFFF; break;
+				case 16: d[i].i = (int)round_vfpu_n(sv); break; //(floor(sv + 0.5f)); break; //n
+				case 17: d[i].i = s[i].f>=0 ? (int)floor(sv) : (int)ceil(sv); break; //z
+				case 18: d[i].i = (int)ceil(sv); break; //u
+				case 19: d[i].i = (int)floor(sv); break; //d
+				default: d[i].i = 0x7FFFFFFF; break;
 				}
 			}
 		}
-		ApplyPrefixD(d.f, sz, true);
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz, true);
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vi2f(MIPSOpcode op)
 	{
-		FloatBits4 s; //int
-		FloatBits4 d; //float
+		FloatBits s[4]; //int
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		int imm = (op >> 16) & 0x1f;
 		float mult = 1.0f/(float)(1UL << imm);
 		VectorSize sz = GetVecSize(op);
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz); //TODO: and the mask to kill everything but swizzle
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz); //TODO: and the mask to kill everything but swizzle
 		for (int i = 0; i < GetNumVectorElements(sz); i++)
 		{
-			d.f[i] = s.f[i] * mult;
+			d[i].f = s[i].f * mult;
 		}
-		ApplyPrefixD(d.f, sz); //TODO: and the mask to kill everything but mask
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz); //TODO: and the mask to kill everything but mask
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vh2f(MIPSOpcode op)
 	{
-		FloatBits4 s; //u32
-		FloatBits4 d; //float
+		FloatBits s[4]; //u32
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz);
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz);
 		
 		VectorSize outsize = V_Pair;
 		switch (sz) {
 		case V_Single:
 			outsize = V_Pair;
-			d.f[0] = ExpandHalf(s.u[0] & 0xFFFF);
-			d.f[1] = ExpandHalf(s.u[0] >> 16);
+			d[0].f = ExpandHalf(s[0].u & 0xFFFF);
+			d[1].f = ExpandHalf(s[0].u >> 16);
 			break;
 		case V_Pair:
 			outsize = V_Quad;
-			d.f[0] = ExpandHalf(s.u[0] & 0xFFFF);
-			d.f[1] = ExpandHalf(s.u[0] >> 16);
-			d.f[2] = ExpandHalf(s.u[1] & 0xFFFF);
-			d.f[3] = ExpandHalf(s.u[1] >> 16);
+			d[0].f = ExpandHalf(s[0].u & 0xFFFF);
+			d[1].f = ExpandHalf(s[0].u >> 16);
+			d[2].f = ExpandHalf(s[1].u & 0xFFFF);
+			d[3].f = ExpandHalf(s[1].u >> 16);
 			break;
 		default:
 			_dbg_assert_msg_(CPU, 0, "Trying to interpret Int_Vh2f instruction that can't be interpreted");
-			memset(d.f, 0, sizeof(d.f));
+			memset(d, 0, sizeof(d));
 			break;
 		}
-		ApplyPrefixD(d.f, outsize);
-		WriteVector(d.f, outsize, vd);
+		ApplyPrefixD(d, outsize);
+		WriteVector(d, outsize, vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vf2h(MIPSOpcode op)
 	{
-		FloatBits4 s; //float
-		FloatBits4 d; //u32
+		FloatBits s[4]; //float
+		FloatBits d[4]; //u32
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz);
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz);
 		
 		VectorSize outsize = V_Single;
 		switch (sz) {
 		case V_Pair:
 			outsize = V_Single;
-			d.u[0] = ShrinkToHalf(s.f[0]) | ((u32)ShrinkToHalf(s.f[1]) << 16);
+			d[0].u = ShrinkToHalf(s[0].f) | ((u32)ShrinkToHalf(s[1].f) << 16);
 			break;
 		case V_Quad:
 			outsize = V_Pair;
-			d.u[0] = ShrinkToHalf(s.f[0]) | ((u32)ShrinkToHalf(s.f[1]) << 16);
-			d.u[1] = ShrinkToHalf(s.f[2]) | ((u32)ShrinkToHalf(s.f[3]) << 16);
+			d[0].u = ShrinkToHalf(s[0].f) | ((u32)ShrinkToHalf(s[1].f) << 16);
+			d[1].u = ShrinkToHalf(s[2].f) | ((u32)ShrinkToHalf(s[3].f) << 16);
 			break;
 		default:
 			_dbg_assert_msg_(CPU, 0, "Trying to interpret Int_Vf2h instruction that can't be interpreted");
-			d.u[0] = 0;
-			d.u[1] = 0;
+			d[0].u = 0;
+			d[1].u = 0;
 			break;
 		}
-		ApplyPrefixD(d.f, outsize);
-		WriteVector(d.f, outsize, vd);
+		ApplyPrefixD(d, outsize);
+		WriteVector(d, outsize, vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vx2i(MIPSOpcode op)
 	{
-		FloatBits4 s; //u32
-		FloatBits4 d; //u32
-		d = {0};
+		FloatBits s[4]; //u32
+		FloatBits d[4]; //u32
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		VectorSize oz = sz;
-		ReadVector(s.f, sz, vs);
+		ReadVector(s, sz, vs);
 		// ForbidVPFXS
 
 		switch ((op >> 16) & 3) {
@@ -774,10 +821,10 @@ namespace MIPSInt
 			// I guess it's used for fixed-point math, and fills more bits to facilitate
 			// conversion between 8-bit and 16-bit values.  But then why not do it in vc2i?
 			{
-				u32 value = s.u[0];
+				u32 value = s[0].u;
 				u32 value2 = value / 2;
 				for (int i = 0; i < 4; i++) {
-					d.u[i] = (u32)((value & 0xFF) * 0x01010101) >> 1;
+					d[i].u = (u32)((value & 0xFF) * 0x01010101) >> 1;
 					value >>= 8;
 				}
 				oz = V_Quad;
@@ -787,11 +834,11 @@ namespace MIPSInt
 		case 1:  // vc2i
 			// Quad is the only option
 			{
-				u32 value = s.u[0];
-				d.u[0] = (value & 0xFF) << 24;
-				d.u[1] = (value & 0xFF00) << 16;
-				d.u[2] = (value & 0xFF0000) << 8;
-				d.u[3] = (value & 0xFF000000);
+				u32 value = s[0].u;
+				d[0].u = (value & 0xFF) << 24;
+				d[1].u = (value & 0xFF00) << 16;
+				d[2].u = (value & 0xFF0000) << 8;
+				d[3].u = (value & 0xFF000000);
 				oz = V_Quad;
 			}
 			break;
@@ -805,9 +852,9 @@ namespace MIPSInt
 				// Intentional fallthrough.
 			case V_Single:
 				for (int i = 0; i < GetNumVectorElements(sz); i++) {
-					u32 value = s.u[i];
-					d.u[i * 2] = (value & 0xFFFF) << 15;
-					d.u[i * 2 + 1] = (value & 0xFFFF0000) >> 1;
+					u32 value = s[i].u;
+					d[i * 2].u = (value & 0xFFFF) << 15;
+					d[i * 2 + 1].u = (value & 0xFFFF0000) >> 1;
 				}
 				break;
 
@@ -826,9 +873,9 @@ namespace MIPSInt
 				// Intentional fallthrough.
 			case V_Single:
 				for (int i = 0; i < GetNumVectorElements(sz); i++) {
-					u32 value = s.u[i];
-					d.u[i * 2] = (value & 0xFFFF) << 16;
-					d.u[i * 2 + 1] = value & 0xFFFF0000;
+					u32 value = s[i].u;
+					d[i * 2].u = (value & 0xFFFF) << 16;
+					d[i * 2 + 1].u = value & 0xFFFF0000;
 				}
 				break;
 
@@ -843,33 +890,32 @@ namespace MIPSInt
 			break;
 		}
 		
-		ApplyPrefixD(d.f,oz, true);  // Only write mask
-		WriteVector(d.f,oz,vd);
+		ApplyPrefixD(d,oz, true);  // Only write mask
+		WriteVector(d,oz,vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vi2x(MIPSOpcode op)
 	{
-		FloatBits4 s; //int
-		FloatBits2 d; //u32
-		d = {0};
+		FloatBits s[4]; //int
+		FloatBits d[2]; //u32
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		VectorSize oz;
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz); //TODO: and the mask to kill everything but swizzle
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz); //TODO: and the mask to kill everything but swizzle
 		switch ((op >> 16)&3)
 		{
 		case 0: //vi2uc
 			{
 				for (int i = 0; i < 4; i++)
 				{
-					int v = s.i[i];
+					int v = s[i].i;
 					if (v < 0) v = 0;
 					v >>= 23;
-					d.u[0] |= ((u32)v & 0xFF) << (i * 8);
+					d[0].u |= ((u32)v & 0xFF) << (i * 8);
 				}
 				oz = V_Single;
 			}
@@ -879,8 +925,8 @@ namespace MIPSInt
 			{
 				for (int i = 0; i < 4; i++)
 				{
-					u32 v = s.i[i];
-					d.u[0] |= (v >> 24) << (i * 8);
+					u32 v = s[i].i;
+					d[0].u |= (v >> 24) << (i * 8);
 				}
 				oz = V_Single;
 			}
@@ -889,13 +935,13 @@ namespace MIPSInt
 		case 2:  //vi2us
 			{
 				for (int i = 0; i < GetNumVectorElements(sz) / 2; i++) {
-					int low = s.i[i * 2];
-					int high = s.i[i * 2 + 1];
+					int low = s[i * 2].i;
+					int high = s[i * 2 + 1].i;
 					if (low < 0) low = 0;
 					if (high < 0) high = 0;
 					low >>= 15;
 					high >>= 15;
-					d.u[i] = low | (high << 16);
+					d[i].u = low | (high << 16);
 				}
 				switch (sz) {
 				case V_Quad: oz = V_Pair; break;
@@ -910,11 +956,11 @@ namespace MIPSInt
 		case 3:  //vi2s
 			{
 				for (int i = 0; i < GetNumVectorElements(sz) / 2; i++) {
-					u32 low = s.i[i * 2];
-					u32 high = s.i[i * 2 + 1];
+					u32 low = s[i * 2].i;
+					u32 high = s[i * 2 + 1].i;
 					low >>= 16;
 					high >>= 16;
-					d.u[i] = low | (high << 16);
+					d[i].u = low | (high << 16);
 				}
 				switch (sz) {
 				case V_Quad: oz = V_Pair; break;
@@ -931,8 +977,8 @@ namespace MIPSInt
 			oz = V_Single;
 			break;
 		}
-		ApplyPrefixD(d.f,oz);
-		WriteVector(d.f,oz,vd);
+		ApplyPrefixD(d,oz);
+		WriteVector(d,oz,vd);
 		PC += 4;
 		EatPrefixes();
 	}
@@ -941,13 +987,13 @@ namespace MIPSInt
 	{
 		int vd = _VD;
 		int vs = _VS;
-		FloatBits4 s; //u32
+		FloatBits s[4]; //u32
 		VectorSize sz = V_Quad;
-		ReadVector(s.f, sz, vs);
+		ReadVector(s, sz, vs);
 		u16 colors[4];
 		for (int i = 0; i < 4; i++)
 		{
-			u32 in = s.u[i];
+			u32 in = s[i].u;
 			u16 col = 0;
 			switch ((op >> 16) & 3)
 			{
@@ -980,18 +1026,17 @@ namespace MIPSInt
 			}
 			colors[i] = col;
 		}
-		FloatBits2 ov; //u32
-		ov.u[0] = (u32)colors[0] | (colors[1] << 16);
-		ov.u[1] = (u32)colors[2] | (colors[3] << 16);
-		WriteVector(ov.f, V_Pair, vd);
+		FloatBits ov[2]; //u32
+		ov[0].u = (u32)colors[0] | (colors[1] << 16);
+		ov[1].u = (u32)colors[2] | (colors[3] << 16);
+		WriteVector(ov, V_Pair, vd);
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_VDot(MIPSOpcode op)
 	{
-		float s[4], t[4];
-		float d;
+		FloatBits s[4], t[4], d; //float
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
@@ -1004,9 +1049,9 @@ namespace MIPSInt
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{
-			sum += s[i]*t[i];
+			sum += s[i].f*t[i].f;
 		}
-		d = sum;
+		d.f = sum;
 		ApplyPrefixD(&d,V_Single);
 		WriteVector(&d, V_Single, vd);
 		PC += 4;
@@ -1015,8 +1060,7 @@ namespace MIPSInt
 
 	void Int_VHdp(MIPSOpcode op)
 	{
-		float s[4], t[4];
-		float d;
+		FloatBits s[4], t[4], d; //float
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
@@ -1029,9 +1073,9 @@ namespace MIPSInt
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{
-			sum += (i == n - 1) ? t[i] : s[i]*t[i];
+			sum += (i == n - 1) ? t[i].f : s[i].f*t[i].f;
 		}
-		d = my_isnan(sum) ? fabsf(sum) : sum;
+		d.f = my_isnan(sum) ? fabsf(sum) : sum;
 		ApplyPrefixD(&d,V_Single);
 		WriteVector(&d, V_Single, vd);
 		PC += 4;
@@ -1040,8 +1084,8 @@ namespace MIPSInt
 
 	void Int_Vbfy(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -1051,18 +1095,18 @@ namespace MIPSInt
 		if (op & 0x10000)
 		{
 			// vbfy2
-			d[0] = s[0] + s[2];
-			d[1] = s[1] + s[3];
-			d[2] = s[0] - s[2];
-			d[3] = s[1] - s[3];
+			d[0].f = s[0].f + s[2].f;
+			d[1].f = s[1].f + s[3].f;
+			d[2].f = s[0].f - s[2].f;
+			d[3].f = s[1].f - s[3].f;
 		}
 		else
 		{
-			d[0] = s[0] + s[1];
-			d[1] = s[0] - s[1];
+			d[0].f = s[0].f + s[1].f;
+			d[1].f = s[0].f - s[1].f;
 			if (n == 4) {
-				d[2] = s[2] + s[3];
-				d[3] = s[2] - s[3];
+				d[2].f = s[2].f + s[3].f;
+				d[3].f = s[2].f - s[3].f;
 			}
 		}
 		ApplyPrefixD(d, sz);
@@ -1073,21 +1117,21 @@ namespace MIPSInt
 	
 	void Int_Vsrt1(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
-		float x = s[0];
-		float y = s[1];
-		float z = s[2];
-		float w = s[3];
-		d[0] = std::min(x, y);
-		d[1] = std::max(x, y);
-		d[2] = std::min(z, w);
-		d[3] = std::max(z, w);
+		float x = s[0].f;
+		float y = s[1].f;
+		float z = s[2].f;
+		float w = s[3].f;
+		d[0].f = std::min(x, y);
+		d[1].f = std::max(x, y);
+		d[2].f = std::min(z, w);
+		d[3].f = std::max(z, w);
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1096,21 +1140,21 @@ namespace MIPSInt
 
 	void Int_Vsrt2(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
-		float x = s[0];
-		float y = s[1];
-		float z = s[2];
-		float w = s[3];
-		d[0] = std::min(x, w);
-		d[1] = std::min(y, z);
-		d[2] = std::max(y, z);
-		d[3] = std::max(x, w);
+		float x = s[0].f;
+		float y = s[1].f;
+		float z = s[2].f;
+		float w = s[3].f;
+		d[0].f = std::min(x, w);
+		d[1].f = std::min(y, z);
+		d[2].f = std::max(y, z);
+		d[3].f = std::max(x, w);
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1119,21 +1163,21 @@ namespace MIPSInt
 
 	void Int_Vsrt3(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
-		float x = s[0];
-		float y = s[1];
-		float z = s[2];
-		float w = s[3];
-		d[0] = std::max(x, y);
-		d[1] = std::min(x, y);
-		d[2] = std::max(z, w);
-		d[3] = std::min(z, w);
+		float x = s[0].f;
+		float y = s[1].f;
+		float z = s[2].f;
+		float w = s[3].f;
+		d[0].f = std::max(x, y);
+		d[1].f = std::min(x, y);
+		d[2].f = std::max(z, w);
+		d[3].f = std::min(z, w);
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1142,21 +1186,21 @@ namespace MIPSInt
 
 	void Int_Vsrt4(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
-		float x = s[0];
-		float y = s[1];
-		float z = s[2];
-		float w = s[3];
-		d[0] = std::max(x, w);
-		d[1] = std::max(y, z);
-		d[2] = std::min(y, z);
-		d[3] = std::min(x, w);
+		float x = s[0].f;
+		float y = s[1].f;
+		float z = s[2].f;
+		float w = s[3].f;
+		d[0].f = std::max(x, w);
+		d[1].f = std::max(y, z);
+		d[2].f = std::min(y, z);
+		d[3].f = std::min(x, w);
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1166,8 +1210,8 @@ namespace MIPSInt
 	void Int_Vcrs(MIPSOpcode op)
 	{
 		//half a cross product
-		float s[4], t[4];
-		float d[4];
+		FloatBits s[4], t[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
@@ -1178,9 +1222,9 @@ namespace MIPSInt
 		ReadVector(s, sz, vs);
 		ReadVector(t, sz, vt);
 		// no swizzles allowed
-		d[0] = s[1] * t[2];
-		d[1] = s[2] * t[0];
-		d[2] = s[0] * t[1];
+		d[0].f = s[1].f * t[2].f;
+		d[1].f = s[2].f * t[0].f;
+		d[2].f = s[0].f * t[1].f;
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
@@ -1189,8 +1233,8 @@ namespace MIPSInt
 	
 	void Int_Vdet(MIPSOpcode op)
 	{
-		float s[4], t[4];
-		float d[4];
+		FloatBits s[4], t[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
@@ -1202,7 +1246,7 @@ namespace MIPSInt
 		ReadVector(t, sz, vt);
 		// TODO: The swizzle on t behaves oddly with constants, but sign changes seem to work.
 		// Also, seems to round in a non-standard way (sometimes toward zero, not always.)
-		d[0] = s[0] * t[1] - s[1] * t[0];
+		d[0].f = s[0].f * t[1].f - s[1].f * t[0].f;
 		ApplyPrefixD(d, sz);
 		WriteVector(d, V_Single, vd);
 		PC += 4;
@@ -1211,8 +1255,8 @@ namespace MIPSInt
 	
 	void Int_Vfad(MIPSOpcode op)
 	{
-		float s[4];
-		float d;
+		FloatBits s[4]; //float
+		FloatBits d; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -1222,19 +1266,19 @@ namespace MIPSInt
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{
-			sum += s[i];
+			sum += s[i].f;
 		}
-		d = sum;
+		d.f = sum;
 		ApplyPrefixD(&d,V_Single);
-		V(vd) = d;
+		V(vd) = d.f;
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_Vavg(MIPSOpcode op)
 	{
-		float s[4];
-		float d;
+		FloatBits s[4]; //float
+		FloatBits d; //float
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
@@ -1244,19 +1288,19 @@ namespace MIPSInt
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{
-			sum += s[i];
+			sum += s[i].f;
 		}
-		d = sum / n;
+		d.f = sum / n;
 		ApplyPrefixD(&d, V_Single);
-		V(vd) = d;
+		V(vd) = d.f;
 		PC += 4;
 		EatPrefixes();
 	}
 
 	void Int_VScl(MIPSOpcode op)
 	{
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
@@ -1272,7 +1316,7 @@ namespace MIPSInt
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++)
 		{
-			d[i] = s[i] * scale;
+			d[i].f = s[i].f * scale;
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -1291,7 +1335,7 @@ namespace MIPSInt
 
 	void Int_VrndX(MIPSOpcode op)
 	{
-		FloatBits4 d;
+		FloatBits d[4];
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
@@ -1299,14 +1343,14 @@ namespace MIPSInt
 		{
 			switch ((op >> 16) & 0x1f)
 			{
-			case 1: d.u[i] = currentMIPS->rng.R32(); break;  // vrndi
-			case 2: d.f[i] = 1.0f + ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf1   TODO: make more accurate
-			case 3: d.f[i] = 2.0f + 2 * ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf2   TODO: make more accurate
+			case 1: d[i].u = currentMIPS->rng.R32(); break;  // vrndi
+			case 2: d[i].f = 1.0f + ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf1   TODO: make more accurate
+			case 3: d[i].f = 2.0f + 2 * ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf2   TODO: make more accurate
 			default: _dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
 			}
 		}
-		ApplyPrefixD(d.f, sz);
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz);
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
@@ -1322,13 +1366,13 @@ namespace MIPSInt
 		vfpu_sincos(V(vs), sine, cosine);
 		if (negSin)
 			sine = -sine;
-		float d[4] = {0};
+		FloatBits d[4]; //float
 		if (((imm >> 2) & 3) == (imm & 3)) {
 			for (int i = 0; i < 4; i++)
-				d[i] = sine;
+				d[i].f = sine;
 		}
-		d[(imm >> 2) & 3] = sine;
-		d[imm & 3] = cosine;
+		d[(imm >> 2) & 3].f = sine;
+		d[imm & 3].f = cosine;
 		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
@@ -1356,18 +1400,18 @@ namespace MIPSInt
 
 		float s[16];
 		ReadMatrix(s, msz, vs);
-		float t[4];
+		FloatBits t[4]; //float
 		ReadVector(t, sz, vt);
-		float d[4];
+		FloatBits d[4]; //float
 
 		if (homogenous)
 		{
 			for (int i = 0; i < n; i++)
 			{
-				d[i] = 0.0f;
+				d[i].f = 0.0f;
 				for (int k = 0; k < n; k++)
 				{
-					d[i] += (k == n-1) ? s[i*4+k] : (s[i*4+k] * t[k]);
+					d[i].f += (k == n-1) ? s[i*4+k] : (s[i*4+k] * t[k].f);
 				}
 			}
 		}
@@ -1375,10 +1419,10 @@ namespace MIPSInt
 		{
 			for (int i = 0; i < n; i++)
 			{
-				d[i] = 0.0f;
+				d[i].f = 0.0f;
 				for (int k = 0; k < n; k++)
 				{
-					d[i] += s[i*4+k] * t[k];
+					d[i].f += s[i*4+k] * t[k].f;
 				}
 			}
 		}
@@ -1479,7 +1523,11 @@ namespace MIPSInt
 
 		VectorSize sz = GetVecSize(op);
 		float c = cst_constants[conNum];
-		float temp[4] = {c,c,c,c};
+		FloatBits temp[4]; //float 
+		temp[0].f = c;
+		temp[1].f = c;
+		temp[2].f = c;
+		temp[3].f = c;
 		ApplyPrefixD(temp, sz);
 		WriteVector(temp, sz, vd);
 		PC += 4;
@@ -1493,8 +1541,8 @@ namespace MIPSInt
 		int cond = op & 0xf;
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
-		float s[4];
-		float t[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
@@ -1510,24 +1558,24 @@ namespace MIPSInt
 			switch (cond)
 			{
 			case VC_FL: c = 0; break;
-			case VC_EQ: c = s[i] == t[i]; break;
-			case VC_LT: c = s[i] < t[i]; break;
-			case VC_LE: c = s[i] <= t[i]; break;
+			case VC_EQ: c = s[i].f == t[i].f; break;
+			case VC_LT: c = s[i].f < t[i].f; break;
+			case VC_LE: c = s[i].f <= t[i].f; break;
 
 			case VC_TR: c = 1; break;
-			case VC_NE: c = s[i] != t[i]; break;
-			case VC_GE: c = s[i] >= t[i]; break;
-			case VC_GT: c = s[i] > t[i]; break;
+			case VC_NE: c = s[i].f != t[i].f; break;
+			case VC_GE: c = s[i].f >= t[i].f; break;
+			case VC_GT: c = s[i].f > t[i].f; break;
 
-			case VC_EZ: c = s[i] == 0.0f || s[i] == -0.0f; break;
-			case VC_EN: c = my_isnan(s[i]); break;
-			case VC_EI: c = my_isinf(s[i]); break;
-			case VC_ES: c = my_isnanorinf(s[i]); break;   // Tekken Dark Resurrection
+			case VC_EZ: c = s[i].f == 0.0f || s[i].f == -0.0f; break;
+			case VC_EN: c = my_isnan(s[i].f); break;
+			case VC_EI: c = my_isinf(s[i].f); break;
+			case VC_ES: c = my_isnanorinf(s[i].f); break;   // Tekken Dark Resurrection
 
-			case VC_NZ: c = s[i] != 0; break;
-			case VC_NN: c = !my_isnan(s[i]); break;
-			case VC_NI: c = !my_isinf(s[i]); break;
-			case VC_NS: c = !(my_isnanorinf(s[i])); break;   // How about t[i] ?
+			case VC_NZ: c = s[i].f != 0; break;
+			case VC_NN: c = !my_isnan(s[i].f); break;
+			case VC_NI: c = !my_isinf(s[i].f); break;
+			case VC_NS: c = !(my_isnanorinf(s[i].f)); break;   // How about t[i] ?
 
 			default:
 				_dbg_assert_msg_(CPU,0,"Unsupported vcmp condition code %d", cond);
@@ -1556,13 +1604,13 @@ namespace MIPSInt
 		VectorSize sz = GetVecSize(op);
 		int numElements = GetNumVectorElements(sz);
 
-		FloatBits4 s;
-		FloatBits4 t;
-		FloatBits4 d;
-		ReadVector(s.f, sz, vs);
-		ApplySwizzleS(s.f, sz);
-		ReadVector(t.f, sz, vt);
-		ApplySwizzleT(t.f, sz);
+		FloatBits s[4];
+		FloatBits t[4];
+		FloatBits d[4];
+		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz);
+		ReadVector(t, sz, vt);
+		ApplySwizzleT(t, sz);
 
 		// If both are zero, take t's sign.
 		// Otherwise: -NAN < -INF < real < INF < NAN (higher mantissa is farther from 0.)
@@ -1570,31 +1618,31 @@ namespace MIPSInt
 		switch ((op >> 23) & 3) {
 		case 2: // vmin
 			for (int i = 0; i < numElements; i++) {
-				if (my_isnanorinf(s.f[i]) || my_isnanorinf(t.f[i])) {
+				if (my_isnanorinf(s[i].f) || my_isnanorinf(t[i].f)) {
 					// If both are negative, we flip the comparison (not two's compliment.)
-					if (s.i[i] < 0 && t.i[i] < 0) {
+					if (s[i].i < 0 && t[i].i < 0) {
 						// If at least one side is NAN, we take the highest mantissa bits.
-						d.i[i] = std::max(t.i[i], s.i[i]);
+						d[i].i = std::max(t[i].i, s[i].i);
 					} else {
 						// Otherwise, we take the lowest value (negative or lowest mantissa.)
-						d.i[i] = std::min(t.i[i], s.i[i]);
+						d[i].i = std::min(t[i].i, s[i].i);
 					}
 				} else {
-					d.f[i] = std::min(t.f[i], s.f[i]);
+					d[i].f = std::min(t[i].f, s[i].f);
 				}
 			}
 			break;
 		case 3: // vmax
 			for (int i = 0; i < numElements; i++) {
 				// This is the same logic as vmin, just reversed.
-				if (my_isnanorinf(s.f[i]) || my_isnanorinf(t.f[i])) {
-					if (s.i[i] < 0 && t.i[i] < 0) {
-						d.i[i] = std::min(t.i[i], s.i[i]);
+				if (my_isnanorinf(s[i].f) || my_isnanorinf(t[i].f)) {
+					if (s[i].i < 0 && t[i].i < 0) {
+						d[i].i = std::min(t[i].i, s[i].i);
 					} else {
-						d.i[i] = std::max(t.i[i], s.i[i]);
+						d[i].i = std::max(t[i].i, s[i].i);
 					}
 				} else {
-					d.f[i] = std::max(t.f[i], s.f[i]);
+					d[i].f = std::max(t[i].f, s[i].f);
 				}
 			}
 			break;
@@ -1604,8 +1652,8 @@ namespace MIPSInt
 			EatPrefixes();
 			return;
 		}
-		ApplyPrefixD(d.f, sz);
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz);
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
@@ -1616,17 +1664,17 @@ namespace MIPSInt
 		int vs = _VS;
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
-		float s[4];
-		float t[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
 		ApplySwizzleT(t, sz);
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n ; i++) {
-			float a = s[i] - t[i];
-			d[i] = (float) ((0.0 < a) - (a < 0.0));
+			float a = s[i].f - t[i].f;
+			d[i].f = (float) ((0.0 < a) - (a < 0.0));
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -1641,18 +1689,18 @@ namespace MIPSInt
 		int cond = op&15;
 		VectorSize sz = GetVecSize(op);
 		int numElements = GetNumVectorElements(sz);
-		float s[4];
-		float t[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
 		ApplySwizzleT(t, sz);
 		for (int i = 0; i < GetNumVectorElements(sz); i++) {
-			if ( my_isnan(s[i]) || my_isnan(t[i]) )
-				d[i] = 0.0f;
+			if ( my_isnan(s[i].f) || my_isnan(t[i].f) )
+				d[i].f = 0.0f;
 			else
-				d[i] = s[i] >= t[i] ? 1.0f : 0.0f;
+				d[i].f = s[i].f >= t[i].f ? 1.0f : 0.0f;
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -1667,18 +1715,18 @@ namespace MIPSInt
 		int cond = op&15;
 		VectorSize sz = GetVecSize(op);
 		int numElements = GetNumVectorElements(sz);
-		float s[4];
-		float t[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
 		ApplySwizzleT(t, sz);
 		for (int i = 0; i < GetNumVectorElements(sz); i++) {
-			if ( my_isnan(s[i]) || my_isnan(t[i]) )
-				d[i] = 0.0f;
+			if ( my_isnan(s[i].f) || my_isnan(t[i].f) )
+				d[i].f = 0.0f;
 			else
-				d[i] = s[i] < t[i] ? 1.0f : 0.0f;
+				d[i].f = s[i].f < t[i].f ? 1.0f : 0.0f;
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
@@ -1695,8 +1743,8 @@ namespace MIPSInt
 		int imm3 = (op >> 16) & 7;
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
-		float s[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(d, sz, vd); //Yes!
@@ -1708,7 +1756,7 @@ namespace MIPSInt
 			if (((CC >> imm3) & 1) == !tf)
 			{
 				for (int i = 0; i < n; i++)
-					d[i] = s[i];
+					d[i].f = s[i].f;
 			}
 		}
 		else if (imm3 == 6)
@@ -1716,7 +1764,7 @@ namespace MIPSInt
 			for (int i = 0; i < n; i++)
 			{
 				if (((CC >> i) & 1) == !tf)
-					d[i] = s[i];
+					d[i].f = s[i].f;
 			}
 		}
 		else
@@ -1735,9 +1783,9 @@ namespace MIPSInt
 		int vs = _VS;
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
-		float s[4];
-		float t[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
@@ -1749,16 +1797,16 @@ namespace MIPSInt
 			case 24: //VFPU0
 				switch ((op >> 23)&7)
 				{
-				case 0: d[i] = s[i] + t[i]; break; //vadd
-				case 1: d[i] = s[i] - t[i]; break; //vsub
-				case 7: d[i] = s[i] / t[i]; break; //vdiv
+				case 0: d[i].f = s[i].f + t[i].f; break; //vadd
+				case 1: d[i].f = s[i].f - t[i].f; break; //vsub
+				case 7: d[i].f = s[i].f / t[i].f; break; //vdiv
 				default: goto bad;
 				}
 				break;
 			case 25: //VFPU1
 				switch ((op >> 23)&7)
 				{
-				case 0: d[i] = s[i] * t[i]; break; //vmul
+				case 0: d[i].f = s[i].f * t[i].f; break; //vmul
 				default: goto bad;
 				}
 				break;
@@ -1781,31 +1829,31 @@ bad:
 		int vs = _VS;
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
-		float s[4];
-		float t[4];
-		float d[4];
+		FloatBits s[4]; //float
+		FloatBits t[4]; //float
+		FloatBits d[4]; //float
 		ReadVector(s, sz, vs);
 		ReadVector(t, sz, vt);
 		switch (sz)
 		{
 		case V_Triple:  // vcrsp.t
-			d[0] = s[1]*t[2] - s[2]*t[1];
-			d[1] = s[2]*t[0] - s[0]*t[2];
-			d[2] = s[0]*t[1] - s[1]*t[0];
+			d[0].f = s[1].f*t[2].f - s[2].f*t[1].f;
+			d[1].f = s[2].f*t[0].f - s[0].f*t[2].f;
+			d[2].f = s[0].f*t[1].f - s[1].f*t[0].f;
 			break;
 
 		case V_Quad:   // vqmul.q
-			d[0] = s[0]*t[3] + s[1]*t[2] - s[2]*t[1] + s[3]*t[0];
-			d[1] = -s[0]*t[2] + s[1]*t[3] + s[2]*t[0] + s[3]*t[1];
-			d[2] = s[0]*t[1] - s[1]*t[0] + s[2]*t[3] + s[3]*t[2];
-			d[3] = -s[0]*t[0] - s[1]*t[1] - s[2]*t[2] + s[3]*t[3];
+			d[0].f = s[0].f*t[3].f + s[1].f*t[2].f - s[2].f*t[1].f + s[3].f*t[0].f;
+			d[1].f = -s[0].f*t[2].f + s[1].f*t[3].f + s[2].f*t[0].f + s[3].f*t[1].f;
+			d[2].f = s[0].f*t[1].f - s[1].f*t[0].f + s[2].f*t[3].f + s[3].f*t[2].f;
+			d[3].f = -s[0].f*t[0].f - s[1].f*t[1].f - s[2].f*t[2].f + s[3].f*t[3].f;
 			break;
 
 		default:
 			Reporting::ReportMessage("CrossQuat instruction with wrong size");
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
-			d[0] = 0;
-			d[1] = 0;
+			d[0].f = 0;
+			d[1].f = 0;
 			break;
 		}
 		WriteVector(d, sz, vd);
@@ -1831,21 +1879,21 @@ bad:
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 
-		FloatBits4 d;
-		FloatBits4 s;
+		FloatBits d[4];
+		FloatBits s[4];
 		u8 exp = (u8)((op >> 16) & 0xFF);
 
-		ReadVector(s.f, sz, vs);
+		ReadVector(s, sz, vs);
 		// TODO: Test swizzle, t?
-		ApplySwizzleS(s.f, sz);
+		ApplySwizzleS(s, sz);
 
 		if (sz != V_Single) {
 			ERROR_LOG_REPORT(CPU, "vwbn not implemented for size %d", GetNumVectorElements(sz));
 		}
 		for (int i = 0; i < GetNumVectorElements(sz); ++i) {
-			u32 sigbit = s.u[i] & 0x80000000;
-			u32 prevExp = (s.u[i] & 0x7F800000) >> 23;
-			u32 mantissa = (s.u[i] & 0x007FFFFF) | 0x00800000;
+			u32 sigbit = s[i].u & 0x80000000;
+			u32 prevExp = (s[i].u & 0x7F800000) >> 23;
+			u32 mantissa = (s[i].u & 0x007FFFFF) | 0x00800000;
 			if (prevExp != 0xFF && prevExp != 0) {
 				if (exp > prevExp) {
 					s8 shift = (exp - prevExp) & 0xF;
@@ -1854,13 +1902,13 @@ bad:
 					s8 shift = (prevExp - exp) & 0xF;
 					mantissa = mantissa << shift;
 				}
-				d.u[i] = sigbit | (mantissa & 0x007FFFFF) | (exp << 23);
+				d[i].u = sigbit | (mantissa & 0x007FFFFF) | (exp << 23);
 			} else {
-				d.u[i] = s.u[i] | (exp << 23);
+				d[i].u = s[i].u | (exp << 23);
 			}
 		}
-		ApplyPrefixD(d.f, sz);
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz);
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
@@ -1872,28 +1920,28 @@ bad:
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
 
-		FloatBits4 d;
-		FloatBits4 s;
+		FloatBits d[4];
+		FloatBits s[4];
 		u8 exp = (u8)(127 + VI(vt));
 
-		ReadVector(s.f, sz, vs);
+		ReadVector(s, sz, vs);
 		// TODO: Test swizzle, t?
-		ApplySwizzleS(s.f, sz);
+		ApplySwizzleS(s, sz);
 
 		if (sz != V_Single) {
 			ERROR_LOG_REPORT(CPU, "vsbn not implemented for size %d", GetNumVectorElements(sz));
 		}
 		for (int i = 0; i < GetNumVectorElements(sz); ++i) {
 			// Simply replace the exponent bits.
-			u32 prev = s.u[i] & 0x7F800000;
+			u32 prev = s[i].u & 0x7F800000;
 			if (prev != 0 && prev != 0x7F800000) {
-				d.u[i] = (s.u[i] & ~0x7F800000) | (exp << 23);
+				d[i].u = (s[i].u & ~0x7F800000) | (exp << 23);
 			} else {
-				d.u[i] = s.u[i];
+				d[i].u = s[i].u;
 			}
 		}
-		ApplyPrefixD(d.f, sz);
-		WriteVector(d.f, sz, vd);
+		ApplyPrefixD(d, sz);
+		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -79,8 +79,20 @@ enum MatrixSize {
 	M_Invalid = -1
 };
 
+union FloatBits {
+	float f;
+	u32 u;
+	int i;
+};
+
 void ReadMatrix(float *rd, MatrixSize size, int reg);
 void WriteMatrix(const float *rs, MatrixSize size, int reg);
+
+void WriteVector(const float *rs, VectorSize N, int reg);
+void ReadVector(float *rd, VectorSize N, int reg);
+
+void WriteVector(const FloatBits *rd, VectorSize size, int reg);
+void ReadVector(FloatBits *rd, VectorSize size, int reg);
 
 void WriteVector(const float *rs, VectorSize N, int reg);
 void ReadVector(float *rd, VectorSize N, int reg);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -83,6 +83,7 @@ union FloatBits {
 	float f;
 	u32 u;
 	int i;
+	u8 _u8;
 };
 
 void ReadMatrix(float *rd, MatrixSize size, int reg);


### PR DESCRIPTION
Hi well, continue the conversation of https://github.com/hrydgard/ppsspp/pull/8550, trying to avoid non-portable code an option was use the FloatBits union to work(idea of @unknownbrackets ), the intention is skip the most posible transform pointers of differents types like (rd is float):

```
u32 *rdu = (u32 *)rd;
```

@unknownbrackets say functions like ReadVector should ideally only read float values.

```
We're explicitly wanting to look at the bits stored in that float and work with them individually. It might 
make sense to use a union instead, and in some places we do.... but I don't think ReadVector should 
necessarily read into something other than a float.

-[Unknown]
```

but actually this functions use float and u32 values transforming between it. .

Basically this do, before, some float enter to ReadVector, then ReadVector use float, and in some part convert it to u32 and use it.
now, some FloatBits enter to ReadVector, from there acces to the float and u32 value.

FloatBits was already implementd in code, (only in some parts), now its only a generalization of it, and i move it to the header.
