### PR TITLE
Fix audio lag in Qt without SDL.

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -370,8 +370,7 @@ void __AudioUpdate() {
 // numFrames is number of stereo frames.
 // This is called from *outside* the emulator thread.
 int __AudioMix(short *outstereo, int numFrames, int sampleRate) {
-	resampler.Mix(outstereo, numFrames, false, sampleRate);
-	return numFrames;
+    return resampler.Mix(outstereo, numFrames, false, sampleRate);
 }
 
 const AudioDebugStats *__AudioGetDebugStats() {

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -421,8 +421,13 @@ void MainAudio::run()
     output = new QAudioOutput(fmt);
     output->setBufferSize(mixlen);
     feed = output->start();
-    if (feed != NULL)
+    if (feed != NULL) {
+        // buffering has already done in the internal mixed buffer
+        // use a small interval to copy mixed audio stream from
+        // internal buffer to audio output buffer as soon as possible
+        // use 1 instead of 0 to prevent CPU exhausting
         timer = startTimer(1);
+    }
 }
 
 void MainAudio::timerEvent(QTimerEvent *)

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -422,7 +422,7 @@ void MainAudio::run()
     output->setBufferSize(mixlen);
     feed = output->start();
     if (feed != NULL)
-        timer = startTimer((1000*AUDIO_SAMPLES) / AUDIO_FREQ);
+        timer = startTimer(1);
 }
 
 void MainAudio::timerEvent(QTimerEvent *)


### PR DESCRIPTION
__AudioMix now returns the actual frame count instead of the requested frame count.
