### PR TITLE
Fix game save in yugioh

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -685,6 +685,7 @@ static ConfigSetting systemParamSettings[] = {
 	ConfigSetting("proAdhocServer", &g_Config.proAdhocServer, "coldbird.net", true, true),
 	ConfigSetting("MacAddress", &g_Config.sMACAddress, &CreateRandMAC, true, true),
 	ConfigSetting("PortOffset", &g_Config.iPortOffset, 0, true, true),
+	ConfigSetting("SavedataCorrectionForyugioh", &g_Config.bSavedataCorrectionForyugioh, false, true, true),
 	ReportedConfigSetting("Language", &g_Config.iLanguage, &DefaultSystemParamLanguage, true, true),
 	ConfigSetting("TimeFormat", &g_Config.iTimeFormat, PSP_SYSTEMPARAM_TIME_FORMAT_24HR, true, true),
 	ConfigSetting("DateFormat", &g_Config.iDateFormat, PSP_SYSTEMPARAM_DATE_FORMAT_YYYYMMDD, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -119,6 +119,7 @@ public:
 	bool bCheckForNewVersion;
 	bool bForceLagSync;
 	bool bFuncReplacements;
+	bool bSavedataCorrectionForyugioh;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -179,8 +179,15 @@ static int sceUtilitySavedataInitStart(u32 paramAddr)
 {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_SAVEDATA)
 	{
-		WARN_LOG(SCEUTILITY, "sceUtilitySavedataInitStart(%08x): wrong dialog type", paramAddr);
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		if (g_Config.bSavedataCorrectionForyugioh)
+		{
+			WARN_LOG(SCEUTILITY, "Savedata Correction");
+			g_Config.bSavedataCorrectionForyugioh = false;
+		}
+		else {
+			WARN_LOG(SCEUTILITY, "sceUtilitySavedataInitStart(%08x): wrong dialog type", paramAddr);
+			return SCE_ERROR_UTILITY_WRONG_TYPE;
+		}
 	}
 
 	oldStatus = 100;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -489,6 +489,8 @@ void GameSettingsScreen::CreateViews() {
 	tools->Add(new ItemHeader(ms->T("Tools")));
 	// These were moved here so use the wrong translation objects, to avoid having to change all inis... This isn't a sustainable situation :P
 	tools->Add(new Choice(sa->T("Savedata Manager")))->OnClick.Handle(this, &GameSettingsScreen::OnSavedataManager);
+// issue #7914	
+	tools->Add(new CheckBox(&g_Config.bSavedataCorrectionForyugioh, sa->T("Savedata correction for yugioh")));
 	tools->Add(new Choice(dev->T("System Information")))->OnClick.Handle(this, &GameSettingsScreen::OnSysInfo);
 	tools->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
 


### PR DESCRIPTION
When use save\load status without game save in a long time
,the game would not allow to save to hang.
This change make the save to fix corrupt.
Fix #7914
