### PR TITLE
d3d9: Enable GPU info in D3D9 reporting

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -18,6 +18,7 @@
 #include <set>
 
 #include "Common/ChunkFile.h"
+#include "base/NativeApp.h"
 #include "base/logging.h"
 #include "profiler/profiler.h"
 #include "Core/Debugger/Breakpoints.h"
@@ -499,7 +500,11 @@ DIRECTX9_GPU::~DIRECTX9_GPU() {
 
 // Needs to be called on GPU thread, not reporting thread.
 void DIRECTX9_GPU::BuildReportingInfo() {
-	
+	D3DADAPTER_IDENTIFIER9 identifier = {0};
+	pD3D->GetAdapterIdentifier(D3DADAPTER_DEFAULT, 0, &identifier);
+
+	reportingPrimaryInfo_ = identifier.Description;
+	reportingFullInfo_ = reportingPrimaryInfo_ + " - " + System_GetProperty(SYSPROP_GPUDRIVER_VERSION);
 }
 
 void DIRECTX9_GPU::DeviceLost() {

--- a/GPU/Directx9/helper/global.h
+++ b/GPU/Directx9/helper/global.h
@@ -18,6 +18,7 @@ namespace DX9 {
 
 extern LPDIRECT3DDEVICE9 pD3Ddevice;
 extern LPDIRECT3DDEVICE9EX pD3DdeviceEx;
+extern LPDIRECT3D9 pD3D;
 
 extern LPDIRECT3DVERTEXSHADER9      pFramebufferVertexShader; // Vertex Shader
 extern LPDIRECT3DPIXELSHADER9       pFramebufferPixelShader;  // Pixel Shader

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -164,6 +164,7 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 	device->BeginScene();
 	DX9::pD3Ddevice = device;
 	DX9::pD3DdeviceEx = deviceEx;
+	DX9::pD3D = d3d;
 
 	if (!DX9::CompileShaders(*error_message)) {
 		*error_message = "Unable to compile shaders: " + *error_message;
@@ -172,6 +173,7 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		d3d->Release();
 		DX9::pD3Ddevice = nullptr;
 		DX9::pD3DdeviceEx = nullptr;
+		DX9::pD3D = nullptr;
 		device = nullptr;
 		UnloadD3DXDynamic();
 		return false;
@@ -219,6 +221,7 @@ void D3D9Context::Shutdown() {
 	UnloadD3DXDynamic();
 	DX9::pD3Ddevice = nullptr;
 	DX9::pD3DdeviceEx = nullptr;
+	DX9::pD3D = nullptr;
 	device = nullptr;
 	hWnd = nullptr;
 	FreeLibrary(hD3D9);


### PR DESCRIPTION
Really thinking it might be nice to pass thin3d into all the GPUs...

-[Unknown]
