### PR TITLE
Exit cleanly on Android instead of hard-exiting using exit(0).

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1119,12 +1119,10 @@ UI::EventReturn MainScreen::OnExit(UI::EventParams &e) {
 	// However, let's make sure the config was saved, since it may not have been.
 	g_Config.Save();
 
-	// We shouldn't call NativeShutdown here at all, it should be done by the framework.
 #ifdef ANDROID
 #ifdef ANDROID_NDK_PROFILER
 	moncleanup();
 #endif
-	exit(0);
 #endif
 
 	UpdateUIState(UISTATE_EXIT);
@@ -1144,7 +1142,7 @@ void MainScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 
 			// Refocus the game button itself.
 			int tab = tabHolder_->GetCurrentTab();
-			if (tab >= 0 && tab < gameBrowsers_.size()) {
+			if (tab >= 0 && tab < (int)gameBrowsers_.size()) {
 				gameBrowsers_[tab]->FocusGame(restoreFocusGamePath_);
 			}
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -77,6 +77,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	private Vibrator vibrator;
 
 	private boolean isXperiaPlay;
+	private boolean shuttingDown;
 
     // Allow for multiple connected gamepads but just consider them the same for now.
     // Actually this is not entirely true, see the code.
@@ -362,6 +363,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	@Override
     public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		shuttingDown = false;
 		registerCallbacks();
 
     	updateDisplayMetrics(null);
@@ -477,6 +479,10 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		audioFocusChangeListener = null;
 		audioManager = null;
 		unregisterCallbacks();
+
+		if (shuttingDown) {
+			NativeApp.shutdown();
+		}
 	}
 
     @Override
@@ -951,6 +957,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 			}
 			return true;
 		} else if (command.equals("finish")) {
+			shuttingDown = true;
 			finish();
 		} else if (command.equals("rotate")) {
 			updateScreenRotation();


### PR DESCRIPTION
Not sure if it's wise to merge this just before 1.2.0, but it seems to work fine.
