### PR TITLE
Use thin3d for softgpu drawing (+thin3d improvements)

### DIFF
--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -35,7 +35,7 @@ class LinkedShaderDX9;
 
 class DIRECTX9_GPU : public GPUCommon {
 public:
-	DIRECTX9_GPU();
+	DIRECTX9_GPU(GraphicsContext *gfxCtx);
 	~DIRECTX9_GPU();
 	void CheckGPUFeatures();
 	void InitClear() override;
@@ -187,6 +187,8 @@ private:
 
 	std::string reportingPrimaryInfo_;
 	std::string reportingFullInfo_;
+
+	GraphicsContext *gfxCtx_;
 };
 
 }  // namespace DX9

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -50,11 +50,11 @@ bool GPU_Init(GraphicsContext *ctx) {
 		SetGPU(new GLES_GPU(ctx));
 		break;
 	case GPU_SOFTWARE:
-		SetGPU(new SoftGPU());
+		SetGPU(new SoftGPU(ctx));
 		break;
 	case GPU_DIRECTX9:
 #if defined(_WIN32)
-		SetGPU(new DIRECTX9_GPU());
+		SetGPU(new DIRECTX9_GPU(ctx));
 #endif
 		break;
 	}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -36,28 +36,6 @@
 #include "GPU/Software/Rasterizer.h"
 #include "GPU/Common/FramebufferCommon.h"
 
-// This is horrible, sorry.
-class Matrix4x4 {
-public:
-	union {
-		struct {
-			float xx, xy, xz, xw;
-			float yx, yy, yz, yw;
-			float zx, zy, zz, zw;
-			float wx, wy, wz, ww;
-		};
-		float m[16];
-	};
-
-	void setIdentity() {
-		memset(this, 0, 16 * sizeof(float));
-		xx = 1.0f;
-		yy = 1.0f;
-		zz = 1.0f;
-		ww = 1.0f;
-	}
-};
-
 const int FB_WIDTH = 480;
 const int FB_HEIGHT = 272;
 FormatBuffer fb;
@@ -220,9 +198,14 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight)
 
 	thin3d->SetTexture(0, fbTex);
 	Thin3DShaderSet *texColor = thin3d->GetShaderSetPreset(SS_TEXTURE_COLOR_2D);
-	Matrix4x4 identity;
-	identity.setIdentity();
-	texColor->SetMatrix4x4("WorldViewProj", identity);
+
+	static const float identity4x4[16] = {
+		1.0f, 0.0f, 0.0f, 0.0f,
+		0.0f, 1.0f, 0.0f, 0.0f,
+		0.0f, 0.0f, 1.0f, 0.0f,
+		0.0f, 0.0f, 0.0f, 1.0f,
+	};
+	texColor->SetMatrix4x4("WorldViewProj", identity4x4);
 	thin3d->DrawIndexed(T3DPrimitive::PRIM_TRIANGLES, texColor, vformat, vdata, idata, 6, 0);
 }
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -165,6 +165,11 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight)
 	float x, y, w, h;
 	CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, dstwidth, dstheight, ROTATION_LOCKED_HORIZONTAL);
 
+	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
+		x += 0.5f;
+		y += 0.5f;
+	}
+
 	x /= 0.5f * dstwidth;
 	y /= 0.5f * dstheight;
 	w /= 0.5f * dstwidth;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -131,6 +131,13 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight)
 	thin3d->SetViewports(1, &viewport);
 
 	thin3d->SetBlendState(thin3d->GetBlendStatePreset(BS_OFF));
+	Thin3DSamplerState *sampler;
+	if (g_Config.iBufFilter == SCALE_NEAREST) {
+		sampler = thin3d->GetSamplerStatePreset(T3DSamplerStatePreset::SAMPS_NEAREST);
+	} else {
+		sampler = thin3d->GetSamplerStatePreset(T3DSamplerStatePreset::SAMPS_LINEAR);
+	}
+	thin3d->SetSamplerStates(0, 1, &sampler);
 	thin3d->SetDepthStencilState(depth);
 	thin3d->SetRenderState(T3DRenderState::CULL_MODE, T3DCullMode::NO_CULL);
 	thin3d->SetScissorEnabled(false);
@@ -176,9 +183,6 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight)
 		u1 = 1.0f;
 	}
 	fbTex->Finalize(0);
-
-	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_Config.iBufFilter == SCALE_NEAREST ? GL_NEAREST : GL_LINEAR);
-	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, g_Config.iBufFilter == SCALE_NEAREST ? GL_NEAREST : GL_LINEAR);
 
 	float x, y, w, h;
 	CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, dstwidth, dstheight, ROTATION_LOCKED_HORIZONTAL);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -50,7 +50,8 @@ FormatBuffer fb;
 FormatBuffer depthbuf;
 u32 clut[4096];
 
-SoftGPU::SoftGPU()
+SoftGPU::SoftGPU(GraphicsContext *gfxCtx)
+	: gfxCtx_(gfxCtx)
 {
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // 4-byte pixel alignment

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -48,7 +48,7 @@ class ShaderManager;
 
 class SoftGPU : public GPUCommon {
 public:
-	SoftGPU();
+	SoftGPU(GraphicsContext *gfxCtx);
 	~SoftGPU();
 	void InitClear() override {}
 	void ExecuteOp(u32 op, u32 diff) override;
@@ -100,4 +100,6 @@ private:
 	u32 displayFramebuf_;
 	u32 displayStride_;
 	GEBufferFormat displayFormat_;
+
+	GraphicsContext *gfxCtx_;
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -98,9 +98,12 @@ void EmuScreen::bootGame(const std::string &filename) {
 
 	CoreParameter coreParam;
 	coreParam.cpuCore = g_Config.bJit ? CPU_JIT : CPU_INTERPRETER;
-	coreParam.gpuCore = g_Config.bSoftwareRendering ? GPU_SOFTWARE : GPU_GLES;
+	coreParam.gpuCore = GPU_GLES;
 	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
 		coreParam.gpuCore = GPU_DIRECTX9;
+	}
+	if (g_Config.bSoftwareRendering) {
+		coreParam.gpuCore = GPU_SOFTWARE;
 	}
 	// Preserve the existing graphics context.
 	coreParam.graphicsContext = PSP_CoreParameter().graphicsContext;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -329,7 +329,7 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (experimental)")));
 	softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);
 
-	if (PSP_IsInited() || g_Config.iGPUBackend != GPU_BACKEND_OPENGL)
+	if (PSP_IsInited())
 		softwareGPU->SetEnabled(false);
 
 	// Audio
@@ -876,11 +876,6 @@ void GameSettingsScreen::CallbackRenderingBackend(bool yes) {
 	// If the user ends up deciding not to restart, set the config back to the current backend
 	// so it doesn't get switched by accident.
 	if (yes) {
-		if (g_Config.iGPUBackend == (int)GPUBackend::DIRECT3D9) {
-			// TODO: Remove once software renderer supports D3D9.
-			g_Config.bSoftwareRendering = false;
-		}
-
 		g_Config.bRestartRequired = true;
 		PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
 	} else {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -691,8 +691,6 @@ namespace MainWindow {
 
 		case ID_OPTIONS_DIRECT3D9:
 			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
-			// TODO: Remove once software renderer supports D3D9.
-			g_Config.bSoftwareRendering = false;
 			g_Config.bRestartRequired = true;
 			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
 			break;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -472,13 +472,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				if (restOfOption == L"directx9") {
 					g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
 					g_Config.bSoftwareRendering = false;
-				}
-				else if (restOfOption == L"gles") {
+				} else if (restOfOption == L"gles") {
 					g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
 					g_Config.bSoftwareRendering = false;
-				}
-				
-				else if (restOfOption == L"software") {
+				} else if (restOfOption == L"software") {
 					g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
 					g_Config.bSoftwareRendering = true;
 				}

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -80,7 +80,7 @@ void DrawBuffer::Flush(bool set_blend_state) {
 	if (count_ == 0)
 		return;
 
-	shaderSet_->SetMatrix4x4("WorldViewProj", drawMatrix_);
+	shaderSet_->SetMatrix4x4("WorldViewProj", drawMatrix_.getReadPtr());
 
 	if (vbuf_) {
 		vbuf_->SubData((const uint8_t *)verts_, 0, sizeof(Vertex) * count_);

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -94,6 +94,12 @@ void Thin3DContext::CreatePresets() {
 	bsPresets_[BS_STANDARD_ALPHA] = CreateBlendState(standard_alpha);
 	bsPresets_[BS_PREMUL_ALPHA] = CreateBlendState(premul_alpha);
 
+	T3DSamplerStateDesc nearest = { CLAMP, CLAMP, NEAREST, NEAREST, NEAREST };
+	T3DSamplerStateDesc linear = { CLAMP, CLAMP, LINEAR, LINEAR, NEAREST };
+
+	sampsPresets_[SAMPS_NEAREST] = CreateSamplerState(nearest);
+	sampsPresets_[SAMPS_LINEAR] = CreateSamplerState(linear);
+
 	vsPresets_[VS_TEXTURE_COLOR_2D] = CreateVertexShader(glsl_vsTexCol, hlslVsTexCol);
 	vsPresets_[VS_COLOR_2D] = CreateVertexShader(glsl_vsCol, hlslVsCol);
 

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -282,7 +282,7 @@ class Thin3DShaderSet : public Thin3DObject {
 public:
 	// TODO: Make some faster way of doing these. Support uniform buffers (and fake them on GL 2.0?)
 	virtual void SetVector(const char *name, float *value, int n) = 0;
-	virtual void SetMatrix4x4(const char *name, const Matrix4x4 &value) = 0;
+	virtual void SetMatrix4x4(const char *name, const float value[16]) = 0;
 };
 
 struct T3DBlendStateDesc {

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -66,6 +66,16 @@ enum T3DBlendFactor : int {
 	FIXED_COLOR,
 };
 
+enum T3DTextureWrap : int {
+	REPEAT,
+	CLAMP,
+};
+
+enum T3DTextureFilter : int {
+	NEAREST,
+	LINEAR,
+};
+
 enum T3DBufferUsage : int {
 	VERTEXDATA = 1,
 	INDEXDATA = 2,
@@ -124,6 +134,12 @@ enum T3DBlendStatePreset : int {
 	BS_PREMUL_ALPHA,
 	BS_ADDITIVE,
 	BS_MAX_PRESET,
+};
+
+enum T3DSamplerStatePreset : int {
+	SAMPS_NEAREST,
+	SAMPS_LINEAR,
+	SAMPS_MAX_PRESET,
 };
 
 enum T3DClear : int {
@@ -207,6 +223,10 @@ class Thin3DBlendState : public Thin3DObject {
 public:
 };
 
+class Thin3DSamplerState : public Thin3DObject {
+public:
+};
+
 class Thin3DDepthStencilState : public Thin3DObject {
 public:
 };
@@ -278,12 +298,21 @@ struct T3DBlendStateDesc {
 	// int colorMask;
 };
 
+struct T3DSamplerStateDesc {
+	T3DTextureWrap wrapS;
+	T3DTextureWrap wrapT;
+	T3DTextureFilter magFilt;
+	T3DTextureFilter minFilt;
+	T3DTextureFilter mipFilt;
+};
+
 class Thin3DContext : public Thin3DObject {
 public:
 	virtual ~Thin3DContext();
 
 	virtual Thin3DDepthStencilState *CreateDepthStencilState(bool depthTestEnabled, bool depthWriteEnabled, T3DComparison depthCompare) = 0;
 	virtual Thin3DBlendState *CreateBlendState(const T3DBlendStateDesc &desc) = 0;
+	virtual Thin3DSamplerState *CreateSamplerState(const T3DSamplerStateDesc &desc) = 0;
 	virtual Thin3DBuffer *CreateBuffer(size_t size, uint32_t usageFlags) = 0;
 	virtual Thin3DShaderSet *CreateShaderSet(Thin3DShader *vshader, Thin3DShader *fshader) = 0;
 	virtual Thin3DVertexFormat *CreateVertexFormat(const std::vector<Thin3DVertexComponent> &components, int stride, Thin3DShader *vshader) = 0;
@@ -297,6 +326,7 @@ public:
 
 	// Note that these DO NOT AddRef so you must not ->Release presets unless you manually AddRef them.
 	Thin3DBlendState *GetBlendStatePreset(T3DBlendStatePreset preset) { return bsPresets_[preset]; }
+	Thin3DSamplerState *GetSamplerStatePreset(T3DSamplerStatePreset preset) { return sampsPresets_[preset]; }
 	Thin3DShader *GetVshaderPreset(T3DVertexShaderPreset preset) { return fsPresets_[preset]; }
 	Thin3DShader *GetFshaderPreset(T3DFragmentShaderPreset preset) { return vsPresets_[preset]; }
 	Thin3DShaderSet *GetShaderSetPreset(T3DShaderSetPreset preset) { return ssPresets_[preset]; }
@@ -307,6 +337,7 @@ public:
 
 	// Bound state objects. Too cumbersome to add them all as parameters to Draw.
 	virtual void SetBlendState(Thin3DBlendState *state) = 0;
+	virtual void SetSamplerStates(int start, int count, Thin3DSamplerState **state) = 0;
 	virtual void SetDepthStencilState(Thin3DDepthStencilState *state) = 0;
 	virtual void SetTextures(int start, int count, Thin3DTexture **textures) = 0;
 
@@ -343,6 +374,7 @@ protected:
 	Thin3DShader *fsPresets_[FS_MAX_PRESET];
 	Thin3DBlendState *bsPresets_[BS_MAX_PRESET];
 	Thin3DShaderSet *ssPresets_[SS_MAX_PRESET];
+	Thin3DSamplerState *sampsPresets_[SAMPS_MAX_PRESET];
 
 	int targetWidth_;
 	int targetHeight_;

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -62,6 +62,12 @@ static const D3DPRIMITIVETYPE primToD3D9[] = {
 	D3DPT_TRIANGLELIST,
 };
 
+static const int primCountDivisor[] = {
+	1,
+	2,
+	3,
+};
+
 class Thin3DDX9DepthStencilState : public Thin3DDepthStencilState {
 public:
 	BOOL depthTestEnabled;
@@ -647,7 +653,7 @@ void Thin3DDX9Context::DrawIndexed(T3DPrimitive prim, Thin3DShaderSet *shaderSet
 	fmt->Apply(device_);
 	vbuf->BindAsVertexBuf(device_, fmt->GetStride(), offset);
 	ibuf->BindAsIndexBuf(device_);
-	device_->DrawIndexedPrimitive(primToD3D9[prim], 0, 0, vertexCount, 0, vertexCount / 3);
+	device_->DrawIndexedPrimitive(primToD3D9[prim], 0, 0, vertexCount, 0, vertexCount / primCountDivisor[prim]);
 }
 
 void Thin3DDX9Context::DrawUP(T3DPrimitive prim, Thin3DShaderSet *shaderSet, Thin3DVertexFormat *format, const void *vdata, int vertexCount) {

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -242,7 +242,7 @@ public:
 		}
 	}
 	void SetVector(LPDIRECT3DDEVICE9 device, const char *name, float *value, int n);
-	void SetMatrix4x4(LPDIRECT3DDEVICE9 device, const char *name, const Matrix4x4 &value);
+	void SetMatrix4x4(LPDIRECT3DDEVICE9 device, const char *name, const float value[16]);
 
 private:
 	bool isPixelShader_;
@@ -258,7 +258,7 @@ public:
 	Thin3DDX9Shader *pshader;
 	void Apply(LPDIRECT3DDEVICE9 device);
 	void SetVector(const char *name, float *value, int n) { vshader->SetVector(device_, name, value, n); pshader->SetVector(device_, name, value, n); }
-	void SetMatrix4x4(const char *name, const Matrix4x4 &value) { vshader->SetMatrix4x4(device_, name, value); }  // pshaders don't usually have matrices
+	void SetMatrix4x4(const char *name, const float value[16]) { vshader->SetMatrix4x4(device_, name, value); }  // pshaders don't usually have matrices
 private:
 	LPDIRECT3DDEVICE9 device_;
 };
@@ -792,10 +792,10 @@ void Thin3DDX9Shader::SetVector(LPDIRECT3DDEVICE9 device, const char *name, floa
 	}
 }
 
-void Thin3DDX9Shader::SetMatrix4x4(LPDIRECT3DDEVICE9 device, const char *name, const Matrix4x4 &value) {
+void Thin3DDX9Shader::SetMatrix4x4(LPDIRECT3DDEVICE9 device, const char *name, const float value[16]) {
 	D3DXHANDLE handle = constantTable_->GetConstantByName(NULL, name);
 	if (handle) {
-		constantTable_->SetFloatArray(device, handle, value.getReadPtr(), 16);
+		constantTable_->SetFloatArray(device, handle, value, 16);
 	}
 }
 

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -327,7 +327,7 @@ public:
 	int GetUniformLoc(const char *name);
 
 	void SetVector(const char *name, float *value, int n) override;
-	void SetMatrix4x4(const char *name, const Matrix4x4 &value) override;
+	void SetMatrix4x4(const char *name, const float value[16]) override;
 
 	void GLLost() override {
 		vshader->Compile(vshader->GetSource().c_str());
@@ -835,11 +835,11 @@ void Thin3DGLShaderSet::SetVector(const char *name, float *value, int n) {
 	}
 }
 
-void Thin3DGLShaderSet::SetMatrix4x4(const char *name, const Matrix4x4 &value) {
+void Thin3DGLShaderSet::SetMatrix4x4(const char *name, const float value[16]) {
 	glUseProgram(program_);
 	int loc = GetUniformLoc(name);
 	if (loc != -1) {
-		glUniformMatrix4fv(loc, 1, false, value.getReadPtr());
+		glUniformMatrix4fv(loc, 1, false, value);
 	}
 }
 

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -813,6 +813,8 @@ void Thin3DGLContext::DrawUP(T3DPrimitive prim, Thin3DShaderSet *shaderSet, Thin
 	fmt->Apply(vdata);
 	ss->Apply();
 
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	glDrawArrays(primToGL[prim], 0, vertexCount);
 
 	ss->Unapply();

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -531,6 +531,11 @@ void Thin3DGLTexture::SetImageData(int x, int y, int z, int width, int height, i
 	default:
 		return;
 	}
+	if (level == 0) {
+		width_ = width;
+		height_ = height;
+		depth_ = depth;
+	}
 
 	Bind();
 	switch (target_) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -794,8 +794,8 @@ void Thin3DGLContext::DrawIndexed(T3DPrimitive prim, Thin3DShaderSet *shaderSet,
 	ss->Apply();
 	// Note: ibuf binding is stored in the VAO, so call this after binding the fmt.
 	ibuf->Bind();
-	
-	glDrawElements(primToGL[prim], offset, GL_INT, 0);
+
+	glDrawElements(primToGL[prim], vertexCount, GL_UNSIGNED_INT, (const void *)(size_t)offset);
 	
 	ss->Unapply();
 	fmt->Unapply();

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -23,6 +23,7 @@ UIContext::~UIContext() {
 void UIContext::Init(Thin3DContext *thin3d, Thin3DShaderSet *uishader, Thin3DShaderSet *uishadernotex, Thin3DTexture *uitexture, DrawBuffer *uidrawbuffer, DrawBuffer *uidrawbufferTop) {
 	thin3d_ = thin3d;
 	blend_ = thin3d_->GetBlendStatePreset(T3DBlendStatePreset::BS_STANDARD_ALPHA);
+	sampler_ = thin3d_->GetSamplerStatePreset(T3DSamplerStatePreset::SAMPS_LINEAR);
 	depth_ = thin3d_->CreateDepthStencilState(false, false, T3DComparison::LESS);
 
 	uishader_ = uishader;
@@ -39,6 +40,7 @@ void UIContext::Init(Thin3DContext *thin3d, Thin3DShaderSet *uishader, Thin3DSha
 
 void UIContext::Begin() {
 	thin3d_->SetBlendState(blend_);
+	thin3d_->SetSamplerStates(0, 1, &sampler_);
 	thin3d_->SetDepthStencilState(depth_);
 	thin3d_->SetRenderState(T3DRenderState::CULL_MODE, T3DCullMode::NO_CULL);
 	thin3d_->SetTexture(0, uitexture_);
@@ -48,6 +50,7 @@ void UIContext::Begin() {
 
 void UIContext::BeginNoTex() {
 	thin3d_->SetBlendState(blend_);
+	thin3d_->SetSamplerStates(0, 1, &sampler_);
 	thin3d_->SetRenderState(T3DRenderState::CULL_MODE, T3DCullMode::NO_CULL);
 
 	UIBegin(uishadernotex_);

--- a/ext/native/ui/ui_context.h
+++ b/ext/native/ui/ui_context.h
@@ -14,6 +14,7 @@ class Thin3DShaderSet;
 class Thin3DDepthStencilState;
 class Thin3DTexture;
 class Thin3DBlendState;
+class Thin3DSamplerState;
 class Texture;
 class DrawBuffer;
 class TextDrawer;
@@ -82,6 +83,7 @@ private:
 	Thin3DContext *thin3D_;
 	Thin3DDepthStencilState *depth_;
 	Thin3DBlendState *blend_;
+	Thin3DSamplerState *sampler_;
 	Thin3DShaderSet *uishader_;
 	Thin3DShaderSet *uishadernotex_;
 	Thin3DTexture *uitexture_;


### PR DESCRIPTION
This adds sampler state handling to thin3d (kinda hacky for GL), and makes softgpu use it.

With this, the software renderer works in both backends.  If someone implemented a DirectX 12 backend, it ought to draw fine there too, and same goes for Vulkan.  Yay.  Independence.

The Matrix4x4 thing is an ugly hack.  Maybe it would be better to change the thin3d method to take a pointer?

-[Unknown]
