### PR TITLE
Work that may or may not be towards fixing the Adreno/PowerVR shutdown crashes

### DIFF
--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -206,7 +206,7 @@ int PlayBackgroundAudio() {
 	// last changed... (to prevent crazy amount of reads when skipping through a list)
 	if (!at3Reader && bgGamePath.size() && (time_now_d() - gameLastChanged > 0.5)) {
 		// Grab some audio from the current game and play it.
-		GameInfo *gameInfo = g_gameInfoCache.GetInfo(NULL, bgGamePath, GAMEINFO_WANTSND);
+		GameInfo *gameInfo = g_gameInfoCache->GetInfo(NULL, bgGamePath, GAMEINFO_WANTSND);
 		if (!gameInfo)
 			return 0;
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -89,7 +89,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 	}
 
 	//pre-emptive loading of game specific config if possible, to get all the settings
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, filename, 0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, filename, 0);
 	if (info && !info->id.empty()) {
 		g_Config.loadGameConfig(info->id);
 	}
@@ -139,7 +139,7 @@ void EmuScreen::bootComplete() {
 	host->BootDone();
 	host->UpdateDisassembly();
 
-	g_gameInfoCache.FlushBGs();
+	g_gameInfoCache->FlushBGs();
 
 	NOTICE_LOG(BOOT, "Loading %s...", PSP_CoreParameter().fileToStart.c_str());
 	autoLoad();

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -48,10 +48,13 @@
 GameInfoCache g_gameInfoCache;
 
 GameInfo::~GameInfo() {
-	delete iconTexture;
-	delete pic0Texture;
-	delete pic1Texture;
-	delete fileLoader;
+	if (iconTexture)
+		iconTexture->Release();
+	if (pic0Texture)
+		pic0Texture->Release();
+	if (pic1Texture)
+		pic1Texture->Release();
+	DisposeFileLoader();
 }
 
 bool GameInfo::Delete() {
@@ -622,27 +625,26 @@ void GameInfoCache::Clear() {
 			iter->second->pic0TextureData.clear();
 			iter->second->pic0DataLoaded = false;
 		}
-		if (iter->second->pic0Texture) {
-			delete iter->second->pic0Texture;
-			iter->second->pic0Texture = 0;
-		}
 		if (!iter->second->pic1TextureData.empty()) {
 			iter->second->pic1TextureData.clear();
 			iter->second->pic1DataLoaded = false;
-		}
-		if (iter->second->pic1Texture) {
-			delete iter->second->pic1Texture;
-			iter->second->pic1Texture = 0;
 		}
 		if (!iter->second->iconTextureData.empty()) {
 			iter->second->iconTextureData.clear();
 			iter->second->iconDataLoaded = false;
 		}
-		if (iter->second->iconTexture) {
-			delete iter->second->iconTexture;
-			iter->second->iconTexture = 0;
+		if (iter->second->pic0Texture) {
+			iter->second->pic0Texture->Release();
+			iter->second->pic0Texture = nullptr;
 		}
-
+		if (iter->second->pic1Texture) {
+			iter->second->pic1Texture->Release();
+			iter->second->pic1Texture = nullptr;
+		}
+		if (iter->second->iconTexture) {
+			iter->second->iconTexture->Release();
+			iter->second->iconTexture = nullptr;
+		}
 		if (!iter->second->sndFileData.empty()) {
 			iter->second->sndFileData.clear();
 			iter->second->sndDataLoaded = false;
@@ -660,7 +662,7 @@ void GameInfoCache::FlushBGs() {
 			iter->second->pic0DataLoaded = false;
 		}
 		if (iter->second->pic0Texture) {
-			delete iter->second->pic0Texture;
+			iter->second->pic0Texture->Release();
 			iter->second->pic0Texture = 0;
 		}
 
@@ -669,7 +671,7 @@ void GameInfoCache::FlushBGs() {
 			iter->second->pic1DataLoaded = false;
 		}
 		if (iter->second->pic1Texture) {
-			delete iter->second->pic1Texture;
+			iter->second->pic1Texture->Release();
 			iter->second->pic1Texture = 0;
 		}
 
@@ -734,6 +736,7 @@ again:
 	GameInfoWorkItem *item = new GameInfoWorkItem(gamePath, info);
 	gameInfoWQ_->Add(item);
 
+	ILOG("Storing info for %s", gamePath.c_str());
 	info->pending = true;
 	info_[gamePath] = info;
 	return info;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -45,7 +45,7 @@
 #define unique_ptr auto_ptr
 #endif
 
-GameInfoCache g_gameInfoCache;
+GameInfoCache *g_gameInfoCache;
 
 GameInfo::~GameInfo() {
 	if (iconTexture)
@@ -586,6 +586,7 @@ handleELF:
 		}
 		info_->pending = false;
 		info_->DisposeFileLoader();
+		ILOG("Completed writing info for %s", info_->GetTitle().c_str());
 	}
 
 	virtual float priority() {
@@ -598,9 +599,13 @@ private:
 	DISALLOW_COPY_AND_ASSIGN(GameInfoWorkItem);
 };
 
+GameInfoCache::GameInfoCache() : gameInfoWQ_(nullptr) {
+	Init();
+}
 
 GameInfoCache::~GameInfoCache() {
 	Clear();
+	Shutdown();
 }
 
 void GameInfoCache::Init() {
@@ -617,8 +622,10 @@ void GameInfoCache::Shutdown() {
 }
 
 void GameInfoCache::Clear() {
-	if (gameInfoWQ_)
+	if (gameInfoWQ_) {
 		gameInfoWQ_->Flush();
+		gameInfoWQ_->WaitUntilDone();
+	}
 	for (auto iter = info_.begin(); iter != info_.end(); iter++) {
 		lock_guard lock(iter->second->lock);
 		if (!iter->second->pic0TextureData.empty()) {

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -175,13 +175,12 @@ protected:
 
 class GameInfoCache {
 public:
-	GameInfoCache() : gameInfoWQ_(0) {}
+	GameInfoCache();
 	~GameInfoCache();
 
 	// This creates a background worker thread!
-	void Init();
-	void Shutdown();
 	void Clear();
+	void ClearTextures();
 	void PurgeType(IdentifiedFileType fileType);
 
 	// All data in GameInfo including iconTexture may be zero the first time you call this
@@ -199,6 +198,8 @@ public:
 	}
 
 private:
+	void Init();
+	void Shutdown();
 	void SetupTexture(GameInfo *info, std::string &textureData, Thin3DContext *thin3d, Thin3DTexture *&tex, double &loadTime);
 
 	// Maps ISO path to info.
@@ -209,4 +210,4 @@ private:
 };
 
 // This one can be global, no good reason not to.
-extern GameInfoCache g_gameInfoCache;
+extern GameInfoCache *g_gameInfoCache;

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -171,6 +171,9 @@ protected:
 
 	FileLoader *fileLoader;
 	std::string filePath_;
+
+private:
+	DISALLOW_COPY_AND_ASSIGN(GameInfo);
 };
 
 class GameInfoCache {

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -44,8 +44,8 @@ GameScreen::~GameScreen() {
 }
 
 void GameScreen::CreateViews() {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
-	g_gameInfoCache.WaitUntilDone(info);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	g_gameInfoCache->WaitUntilDone(info);
 
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *ga = GetI18NCategory("Game");
@@ -117,7 +117,7 @@ void GameScreen::CreateViews() {
 
 UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)
 {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_,0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_,0);
 	g_Config.createGameConfig(info->id);
 	g_Config.saveGameConfig(info->id);
 	info->hasConfig = true;
@@ -130,7 +130,7 @@ void GameScreen::CallbackDeleteConfig(bool yes)
 {
 	if (yes)
 	{
-		GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+		GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 		g_Config.deleteGameConfig(info->id);
 		info->hasConfig = false;
 		screenManager()->RecreateAllViews();
@@ -155,7 +155,7 @@ void GameScreen::update(InputState &input) {
 
 	Thin3DContext *thin3d = screenManager()->getThin3DContext();
 
-	GameInfo *info = g_gameInfoCache.GetInfo(thin3d, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	GameInfo *info = g_gameInfoCache->GetInfo(thin3d, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 
 	if (tvTitle_)
 		tvTitle_->SetText(info->GetTitle() + " (" + info->id + ")");
@@ -216,7 +216,7 @@ UI::EventReturn GameScreen::OnPlay(UI::EventParams &e) {
 }
 
 UI::EventReturn GameScreen::OnGameSettings(UI::EventParams &e) {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 	if (info && info->paramSFOLoaded) {
 		std::string discID = info->paramSFO.GetValueString("DISC_ID");
 		screenManager()->push(new GameSettingsScreen(gamePath_, discID, true));
@@ -227,7 +227,7 @@ UI::EventReturn GameScreen::OnGameSettings(UI::EventParams &e) {
 UI::EventReturn GameScreen::OnDeleteSaveData(UI::EventParams &e) {
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *ga = GetI18NCategory("Game");
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 	if (info) {
 		// Check that there's any savedata to delete
 		std::vector<std::string> saveDirs = info->GetSaveDataDirectories();
@@ -243,7 +243,7 @@ UI::EventReturn GameScreen::OnDeleteSaveData(UI::EventParams &e) {
 }
 
 void GameScreen::CallbackDeleteSaveData(bool yes) {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 	if (yes) {
 		info->DeleteAllSaveData();
 		info->saveDataSize = 0;
@@ -254,7 +254,7 @@ void GameScreen::CallbackDeleteSaveData(bool yes) {
 UI::EventReturn GameScreen::OnDeleteGame(UI::EventParams &e) {
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *ga = GetI18NCategory("Game");
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 	if (info) {
 		screenManager()->push(
 			new PromptScreen(di->T("DeleteConfirmGame", "Do you really want to delete this game\nfrom your device? You can't undo this."), ga->T("ConfirmDelete"), di->T("Cancel"),
@@ -265,16 +265,16 @@ UI::EventReturn GameScreen::OnDeleteGame(UI::EventParams &e) {
 }
 
 void GameScreen::CallbackDeleteGame(bool yes) {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 	if (yes) {
 		info->Delete();
-		g_gameInfoCache.Clear();
+		g_gameInfoCache->Clear();
 		screenManager()->switchScreen(new MainScreen());
 	}
 }
 
 UI::EventReturn GameScreen::OnCreateShortcut(UI::EventParams &e) {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 	if (info) {
 		host->CreateDesktopShortcut(gamePath_, info->GetTitle());
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -77,7 +77,7 @@ bool GameSettingsScreen::UseVerticalLayout() const {
 }
 
 void GameSettingsScreen::CreateViews() {
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 
 	if (bEditThenRestore)
 	{

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -173,7 +173,7 @@ private:
 };
 
 void GameButton::Draw(UIContext &dc) {
-	GameInfo *ginfo = g_gameInfoCache.GetInfo(dc.GetThin3DContext(), gamePath_, 0);
+	GameInfo *ginfo = g_gameInfoCache->GetInfo(dc.GetThin3DContext(), gamePath_, 0);
 	Thin3DTexture *texture = 0;
 	u32 color = 0, shadowColor = 0;
 	using namespace UI;
@@ -976,7 +976,7 @@ bool MainScreen::DrawBackgroundFor(UIContext &dc, const std::string &gamePath, f
 
 	GameInfo *ginfo = 0;
 	if (!gamePath.empty()) {
-		ginfo = g_gameInfoCache.GetInfo(dc.GetThin3DContext(), gamePath, GAMEINFO_WANTBG);
+		ginfo = g_gameInfoCache->GetInfo(dc.GetThin3DContext(), gamePath, GAMEINFO_WANTBG);
 		// Loading texture data may bind a texture.
 		dc.RebindTexture();
 
@@ -1009,7 +1009,7 @@ UI::EventReturn MainScreen::OnGameSelected(UI::EventParams &e) {
 	std::string path = e.s;
 #endif
 	GameInfo *ginfo = 0;
-	ginfo = g_gameInfoCache.GetInfo(nullptr, path, GAMEINFO_WANTBG);
+	ginfo = g_gameInfoCache->GetInfo(nullptr, path, GAMEINFO_WANTBG);
 	if (ginfo && ginfo->fileType == FILETYPE_PSP_SAVEDATA_DIRECTORY) {
 		return UI::EVENT_DONE;
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -105,7 +105,7 @@ void DrawBackground(UIContext &dc, float alpha = 1.0f) {
 }
 
 void DrawGameBackground(UIContext &dc, const std::string &gamePath) {
-	GameInfo *ginfo = g_gameInfoCache.GetInfo(dc.GetThin3DContext(), gamePath, GAMEINFO_WANTBG);
+	GameInfo *ginfo = g_gameInfoCache->GetInfo(dc.GetThin3DContext(), gamePath, GAMEINFO_WANTBG);
 	dc.Flush();
 
 	if (ginfo) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -603,19 +603,24 @@ void NativeShutdownGraphics() {
 	winAudioBackend = NULL;
 #endif
 
+	ILOG("screenman");
 	screenManager->deviceLost();
 
-	delete g_gameInfoCache;
-	g_gameInfoCache = nullptr;
-
+	ILOG("uitexture");
 	uiTexture->Release();
 
+	ILOG("uicontext");
 	delete uiContext;
 	uiContext = NULL;
+
+	ILOG("gameinfocache");
+	delete g_gameInfoCache;
+	g_gameInfoCache = nullptr;
 
 	ui_draw2d.Shutdown();
 	ui_draw2d_front.Shutdown();
 
+	ILOG("thin3d");
 	thin3d->Release();
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -480,8 +480,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	if (!boot_filename.empty() && stateToLoad != NULL)
 		SaveState::Load(stateToLoad);
 
-	g_gameInfoCache.Init();
-
 	screenManager = new ScreenManager();
 	if (skipLogo) {
 		screenManager->switchScreen(new EmuScreen(boot_filename));
@@ -595,6 +593,8 @@ void NativeInitGraphics(GraphicsContext *graphicsContext) {
 	winAudioBackend = CreateAudioBackend((AudioBackendType)g_Config.iAudioBackend);
 	winAudioBackend->Init(MainWindow::GetHWND(), &Win32Mix, 44100);
 #endif
+
+	g_gameInfoCache = new GameInfoCache();
 }
 
 void NativeShutdownGraphics() {
@@ -605,9 +605,8 @@ void NativeShutdownGraphics() {
 
 	screenManager->deviceLost();
 
-	g_gameInfoCache.Clear();
-	g_gameInfoCache.Clear();
-	g_gameInfoCache.Clear();
+	delete g_gameInfoCache;
+	g_gameInfoCache = nullptr;
 
 	uiTexture->Release();
 
@@ -758,10 +757,10 @@ void NativeUpdate(InputState &input) {
 
 void NativeDeviceLost() {
 	if (GetGPUBackend() == GPUBackend::OPENGL) {
-		// gl_lost();
+		gl_lost();
 	}
-	// screenManager->deviceLost();
-	// g_gameInfoCache.Clear();
+	screenManager->deviceLost();
+	// g_gameInfoCache->Clear();
 	// Should dirty EVERYTHING
 }
 
@@ -924,8 +923,6 @@ void NativeShutdown() {
 	screenManager->shutdown();
 	delete screenManager;
 	screenManager = 0;
-
-	g_gameInfoCache.Shutdown();
 
 	delete host;
 	host = 0;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -606,6 +606,8 @@ void NativeShutdownGraphics() {
 	screenManager->deviceLost();
 
 	g_gameInfoCache.Clear();
+	g_gameInfoCache.Clear();
+	g_gameInfoCache.Clear();
 
 	uiTexture->Release();
 
@@ -755,12 +757,11 @@ void NativeUpdate(InputState &input) {
 }
 
 void NativeDeviceLost() {
-	g_gameInfoCache.Clear();
-	screenManager->deviceLost();
-
 	if (GetGPUBackend() == GPUBackend::OPENGL) {
-		gl_lost();
+		// gl_lost();
 	}
+	// screenManager->deviceLost();
+	// g_gameInfoCache.Clear();
 	// Should dirty EVERYTHING
 }
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -181,7 +181,7 @@ SaveSlotView::SaveSlotView(const std::string &gameFilename, int slot, UI::Layout
 	using namespace UI;
 
 	screenshotFilename_ = SaveState::GenerateSaveSlotFilename(gamePath_, slot, "jpg");
-	PrioritizedWorkQueue *wq = g_gameInfoCache.WorkQueue();
+	PrioritizedWorkQueue *wq = g_gameInfoCache->WorkQueue();
 	Add(new Spacer(5));
 
 	AsyncImageFileView *fv = Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, wq, new UI::LayoutParams(82 * 2, 47 * 2)));
@@ -409,7 +409,7 @@ UI::EventReturn GamePauseScreen::OnSwitchUMD(UI::EventParams &e) {
 void GamePauseScreen::CallbackDeleteConfig(bool yes)
 {
 	if (yes) {
-		GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+		GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 		g_Config.unloadGameConfig();
 		g_Config.deleteGameConfig(info->id);
 		info->hasConfig = false;
@@ -423,7 +423,7 @@ UI::EventReturn GamePauseScreen::OnCreateConfig(UI::EventParams &e)
 	g_Config.createGameConfig(gameId);
 	g_Config.changeGameSpecific(gameId);
 	g_Config.saveGameConfig(gameId);
-	GameInfo *info = g_gameInfoCache.GetInfo(NULL, gamePath_, 0);
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 	if (info) {
 		info->hasConfig = true;
 	}

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -58,7 +58,7 @@ public:
 
 	void CreatePopupContents(UI::ViewGroup *parent) override {
 		using namespace UI;
-		GameInfo *ginfo = g_gameInfoCache.GetInfo(screenManager()->getThin3DContext(), savePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
+		GameInfo *ginfo = g_gameInfoCache->GetInfo(screenManager()->getThin3DContext(), savePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 		LinearLayout *root = new LinearLayout(ORIENT_VERTICAL);
 		parent->Add(root);
 		if (!ginfo)
@@ -86,7 +86,7 @@ public:
 		} else {
 			std::string image_path = ReplaceAll(savePath_, ".ppst", ".jpg");
 			if (File::Exists(image_path)) {
-				PrioritizedWorkQueue *wq = g_gameInfoCache.WorkQueue();
+				PrioritizedWorkQueue *wq = g_gameInfoCache->WorkQueue();
 				toprow->Add(new AsyncImageFileView(image_path, IS_DEFAULT, wq, new UI::LayoutParams(500, 500/16*9)));
 			} else {
 				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))));
@@ -128,7 +128,7 @@ private:
 };
 
 UI::EventReturn SavedataPopupScreen::OnDeleteButtonClick(UI::EventParams &e) {
-	GameInfo *ginfo = g_gameInfoCache.GetInfo(nullptr, savePath_, GAMEINFO_WANTSIZE);
+	GameInfo *ginfo = g_gameInfoCache->GetInfo(nullptr, savePath_, GAMEINFO_WANTSIZE);
 	ginfo->Delete();
 	screenManager()->finishDialog(this, DR_NO);
 	return UI::EVENT_DONE;
@@ -142,7 +142,7 @@ static std::string CleanSaveString(std::string str) {
 }
 
 void SavedataButton::Draw(UIContext &dc) {
-	GameInfo *ginfo = g_gameInfoCache.GetInfo(dc.GetThin3DContext(), savePath_, GAMEINFO_WANTSIZE);
+	GameInfo *ginfo = g_gameInfoCache->GetInfo(dc.GetThin3DContext(), savePath_, GAMEINFO_WANTSIZE);
 	Thin3DTexture *texture = 0;
 	u32 color = 0, shadowColor = 0;
 	using namespace UI;
@@ -274,8 +274,8 @@ SavedataBrowser::SavedataBrowser(std::string path, UI::LayoutParams *layoutParam
 }
 
 SavedataBrowser::~SavedataBrowser() {
-	g_gameInfoCache.PurgeType(FILETYPE_PPSSPP_SAVESTATE);
-	g_gameInfoCache.PurgeType(FILETYPE_PSP_SAVEDATA_DIRECTORY);
+	g_gameInfoCache->PurgeType(FILETYPE_PPSSPP_SAVESTATE);
+	g_gameInfoCache->PurgeType(FILETYPE_PSP_SAVEDATA_DIRECTORY);
 }
 
 void SavedataBrowser::Refresh() {
@@ -368,7 +368,7 @@ void SavedataScreen::CreateViews() {
 }
 
 UI::EventReturn SavedataScreen::OnSavedataButtonClick(UI::EventParams &e) {
-	GameInfo *ginfo = g_gameInfoCache.GetInfo(screenManager()->getThin3DContext(), e.s, 0);
+	GameInfo *ginfo = g_gameInfoCache->GetInfo(screenManager()->getThin3DContext(), e.s, 0);
 	screenManager()->push(new SavedataPopupScreen(e.s, ginfo->GetTitle()));
 	// the game path: e.s;
 	return UI::EVENT_DONE;

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -193,6 +193,9 @@ unsigned int WINAPI TheThread(void *)
 shutdown:
 	_InterlockedExchange(&emuThreadReady, THREAD_SHUTDOWN);
 
+	NativeDeviceLost();
+	// ILOG("NativeDeviceLost completed.");
+
 	NativeShutdownGraphics();
 
 	host->ShutdownSound();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -552,7 +552,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		{
 			//hack to enable/disable menu command accelerate keys
 			MainWindow::UpdateCommands();
-
+			 
 			//hack to make it possible to get to main window from floating windows with Esc
 			if (msg.hwnd != hwndMain && msg.wParam == VK_ESCAPE)
 				BringWindowToTop(hwndMain);
@@ -600,8 +600,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	delete host;
 
 	g_Config.Save();
-	g_gameInfoCache.Clear();
-	g_gameInfoCache.Shutdown();
 	LogManager::Shutdown();
 
 	if (g_Config.bRestartRequired) {

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -608,5 +608,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	CoUninitialize();
 
+	_CrtCheckMemory();
+
 	return 0;
 }

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -740,7 +740,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 	}
 
 	ILOG("After render loop.");
-	g_gameInfoCache.WorkQueue()->Flush();
+	g_gameInfoCache->WorkQueue()->Flush();
 
 	NativeDeviceLost();
 	ILOG("NativeDeviceLost completed.");

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -32,6 +32,8 @@
 #include "Common/GraphicsContext.h"
 #include "Common/GL/GLInterfaceBase.h"
 
+#include "UI/GameInfoCache.h"  // TEMP
+
 #include "app-android.h"
 
 static JNIEnv *jniEnvUI;
@@ -377,11 +379,11 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_pause(JNIEnv *, jclass) {
 }
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
-	ILOG("NativeApp.shutdown() -- begin");
+	ILOG("NativeApp.shutdown() -- setting flag");
+	WLOG("Shutting down for real.");
 	NativeShutdown();
 	VFSShutdown();
 	net::Shutdown();
-	ILOG("NativeApp.shutdown() -- end");
 }
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayShutdown(JNIEnv *env, jobject obj) {
@@ -558,6 +560,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 	NativeMessageReceived(msg.c_str(), prm.c_str());
 }
 
+// This must exit immediately.
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeActivity_exitEGLRenderLoop(JNIEnv *env, jobject obj) {
 	if (!renderLoopRunning) {
 		ELOG("Render loop already exited");
@@ -661,6 +664,23 @@ extern "C" jint JNICALL Java_org_ppsspp_ppsspp_NativeApp_getDesiredBackbufferHei
 	return desiredBackbufferSizeY;
 }
 
+void ProcessFrameCommands(JNIEnv *env) {
+	lock_guard guard(frameCommandLock);
+	while (!frameCommands.empty()) {
+		FrameCommand frameCmd;
+		frameCmd = frameCommands.front();
+		frameCommands.pop();
+
+		WLOG("frameCommand! '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
+
+		jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
+		jstring param = env->NewStringUTF(frameCmd.params.c_str());
+		env->CallVoidMethod(nativeActivity, postCommand, cmd, param);
+		env->DeleteLocalRef(cmd);
+		env->DeleteLocalRef(param);
+	}
+}
+
 extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(JNIEnv *env, jobject obj, jobject _surf) {
 	ANativeWindow *wnd = ANativeWindow_fromSurface(env, _surf);
 
@@ -716,23 +736,12 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 
 		graphicsContext->SwapBuffers();
 
-		lock_guard guard(frameCommandLock);
-		while (!frameCommands.empty()) {
-			FrameCommand frameCmd;
-			frameCmd = frameCommands.front();
-			frameCommands.pop();
-
-			WLOG("frameCommand! '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
-
-			jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
-			jstring param = env->NewStringUTF(frameCmd.params.c_str());
-			env->CallVoidMethod(nativeActivity, postCommand, cmd, param);
-			env->DeleteLocalRef(cmd);
-			env->DeleteLocalRef(param);
-		}
+		ProcessFrameCommands(env);
 	}
 
-	// Restore lost device objects. TODO: This feels like the wrong place for this.
+	ILOG("After render loop.");
+	g_gameInfoCache.WorkQueue()->Flush();
+
 	NativeDeviceLost();
 	ILOG("NativeDeviceLost completed.");
 
@@ -742,6 +751,6 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 	graphicsContext->Shutdown();
 
 	renderLoopRunning = false;
-	WLOG("Render loop exited;");
+	WLOG("Render loop function exited;");
 	return true;
 }

--- a/ext/native/gfx/gl_lost_manager.cpp
+++ b/ext/native/gfx/gl_lost_manager.cpp
@@ -49,10 +49,10 @@ void gl_lost() {
 	// TODO: We should really do this when we get the context back, not during gl_lost...
 	ILOG("gl_lost() restoring %i items:", (int)holders->size());
 	for (size_t i = 0; i < holders->size(); i++) {
-		ILOG("GLLost(%i / %i, %p)", (int)(i + 1), (int) holders->size(), (*holders)[i]);
+		ILOG("GLLost(%i / %i, %p, %08x)", (int)(i + 1), (int) holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));
 		(*holders)[i]->GLLost();
 	}
-	ILOG("gl_lost() completed restoring %i items:", (int)holders->size());
+	ILOG("gl_lost() completed on %i items:", (int)holders->size());
 	inLost = false;
 }
 

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include <string>
 
+#include "base/logging.h"
+
 class Matrix4x4;
 
 enum T3DBlendEquation : int {
@@ -194,7 +196,11 @@ struct T3DViewport {
 class Thin3DObject {
 public:
 	Thin3DObject() : refcount_(1) {}
-	virtual ~Thin3DObject() {}
+	virtual ~Thin3DObject() {
+		if (refcount_ != 0) {
+			WLOG("Deleting object %p but refcount = %d", this, refcount_);
+		}
+	}
 
 	virtual void AddRef() { refcount_++; }
 	virtual void Release() { refcount_--; if (!refcount_) delete this; }

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -203,7 +203,13 @@ public:
 	}
 
 	virtual void AddRef() { refcount_++; }
-	virtual void Release() { refcount_--; if (!refcount_) delete this; }
+	virtual void Release() { 
+		refcount_--; 
+		if (!refcount_) {
+			WLOG("ref count reached 0 - delete this");
+			delete this;
+		}
+	}
 
 private:
 	int refcount_;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -475,6 +475,7 @@ public:
 	void GLLost() override {
 		// We lost our GL context - zero out the tex_.
 		tex_ = 0;
+		generatedMips_ = false;
 		// Don't try to restore stuff, that's not what this is for. Lost just means
 		// that all our textures and buffers are invalid.
 	}

--- a/ext/native/thread/prioritizedworkqueue.h
+++ b/ext/native/thread/prioritizedworkqueue.h
@@ -23,7 +23,7 @@ private:
 
 class PrioritizedWorkQueue {
 public:
-	PrioritizedWorkQueue() : done_(false) {}
+	PrioritizedWorkQueue() : done_(false), working_(false) {}
 	~PrioritizedWorkQueue();
 	// Takes ownership.
 	void Add(PrioritizedWorkQueueItem *item);
@@ -36,8 +36,13 @@ public:
 	void Stop();
 	void WaitUntilDone();
 
+	bool IsWorking() {
+		return working_;
+	}
+
 private:
 	bool done_;
+	bool working_;
 	recursive_mutex mutex_;
 	condition_variable notEmpty_;
 


### PR DESCRIPTION
Nexus 4 is affected, and yeah, repro'd on PowerVR too (Zenfone).

And this stuff doesn't help. But instead it crashes a bit more consistently, which should help finding a solution... Here's a typical crash, although there are a few variants:

```
F/libc    (18861): heap corruption detected by dlfree
F/libc    (18861): Fatal signal 6 (SIGABRT), code -6 in tid 18896 (AndroidRender)
I/DEBUG   (  194): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG   (  194): Build fingerprint: 'google/occam/mako:5.1.1/LMY48T/2237560:user/release-keys'
I/DEBUG   (  194): Revision: '11'
I/DEBUG   (  194): ABI: 'arm'
I/DEBUG   (  194): pid: 18861, tid: 18896, name: AndroidRender  >>> org.ppsspp.ppsspp <<<
I/DEBUG   (  194): signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
I/DEBUG   (  194): Abort message: 'heap corruption detected by dlfree'
I/DEBUG   (  194):     r0 00000000  r1 000049d0  r2 00000006  r3 00000000
I/DEBUG   (  194):     r4 a19f8dd8  r5 00000006  r6 0000003e  r7 0000010c
I/DEBUG   (  194):     r8 b6e3f1a0  r9 a19f8a48  sl b75e0d98  fp a35740e0
I/DEBUG   (  194):     ip 000049d0  sp a19f89b0  lr b6df9989  pc b6e1ee24  cpsr 600f0010
I/DEBUG   (  194):
I/DEBUG   (  194): backtrace:
I/DEBUG   (  194):     #00 pc 0003be24  /system/lib/libc.so (tgkill+12)
I/DEBUG   (  194):     #01 pc 00016985  /system/lib/libc.so (pthread_kill+52)
I/DEBUG   (  194):     #02 pc 00017597  /system/lib/libc.so (raise+10)
I/DEBUG   (  194):     #03 pc 00013d3d  /system/lib/libc.so (__libc_android_abort+36)
I/DEBUG   (  194):     #04 pc 000124ec  /system/lib/libc.so (abort+4)
I/DEBUG   (  194):     #05 pc 00015073  /system/lib/libc.so (__libc_fatal+16)
I/DEBUG   (  194):     #06 pc 00029719  /system/lib/libc.so (__bionic_heap_corruption_error+8)
I/DEBUG   (  194):     #07 pc 0002b78d  /system/lib/libc.so (dlfree+312)
I/DEBUG   (  194):     #08 pc 00012257  /system/lib/libc.so (free+10)
I/DEBUG   (  194):     #09 pc 00122d35  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (GameInfo::~GameInfo()+316)
```

The crashes are consistently "Heap corruption" of various kinds, and always happen during or after clearing the gameInfo cache. I can't find what's wrong with it though...

Does not happen on Windows, whatever I do I can't provoke it.

Does not happen on my 64-bit devices. Does not happen on my Android 2.3 devices. Only seems to happens on Android 4.x devices.
