### PR TITLE
Avoid reloading save info on move/resize

### DIFF
--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -273,11 +273,6 @@ SavedataBrowser::SavedataBrowser(std::string path, UI::LayoutParams *layoutParam
 	Refresh();
 }
 
-SavedataBrowser::~SavedataBrowser() {
-	g_gameInfoCache->PurgeType(FILETYPE_PPSSPP_SAVESTATE);
-	g_gameInfoCache->PurgeType(FILETYPE_PSP_SAVEDATA_DIRECTORY);
-}
-
 void SavedataBrowser::Refresh() {
 	using namespace UI;
 
@@ -336,6 +331,13 @@ UI::EventReturn SavedataBrowser::SavedataButtonClick(UI::EventParams &e) {
 }
 
 SavedataScreen::SavedataScreen(std::string gamePath) : UIDialogScreenWithGameBackground(gamePath) {
+}
+
+SavedataScreen::~SavedataScreen() {
+	if (g_gameInfoCache) {
+		g_gameInfoCache->PurgeType(FILETYPE_PPSSPP_SAVESTATE);
+		g_gameInfoCache->PurgeType(FILETYPE_PSP_SAVEDATA_DIRECTORY);
+	}
 }
 
 void SavedataScreen::CreateViews() {

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -29,7 +29,6 @@
 class SavedataBrowser : public UI::LinearLayout {
 public:
 	SavedataBrowser(std::string path, UI::LayoutParams *layoutParams = 0);
-	~SavedataBrowser();
 
 	UI::Event OnChoice;
 
@@ -45,6 +44,7 @@ class SavedataScreen : public UIDialogScreenWithGameBackground {
 public:
 	// gamePath can be empty, in that case this screen will show all savedata in the save directory.
 	SavedataScreen(std::string gamePath);
+	~SavedataScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 


### PR DESCRIPTION
We don't really need to do this all the time, we can just do it on exit of the entire screen.  Also fixes a crash on close.  Fixes #8619.

-[Unknown]
