### PR TITLE
Fix crash on SHIELD devices with dual-source blending

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -60,6 +60,8 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	bool bitwiseOps = false;
 	const char *lastFragData = nullptr;
 
+	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(FS_BIT_STENCIL_TO_ALPHA, 2));
+
 	if (gl_extensions.IsGLES) {
 		// ES doesn't support dual source alpha :(
 		if (gstate_c.featureFlags & GPU_SUPPORTS_GLSL_ES_300) {
@@ -69,6 +71,10 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 			glslES30 = true;
 			bitwiseOps = true;
 			texelFetch = "texelFetch";
+
+			if (stencilToAlpha == REPLACE_ALPHA_DUALSOURCE && gl_extensions.EXT_blend_func_extended) {
+				WRITE(p, "#extension GL_EXT_blend_func_extended : require\n");
+			}
 		} else {
 			WRITE(p, "#version 100\n");  // GLSL ES 1.0
 			if (gl_extensions.EXT_gpu_shader4) {
@@ -79,6 +85,10 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 			if (gl_extensions.EXT_blend_func_extended) {
 				// Oldy moldy GLES, so use the fixed output name.
 				fragColor1 = "gl_SecondaryFragColorEXT";
+
+				if (stencilToAlpha == REPLACE_ALPHA_DUALSOURCE && gl_extensions.EXT_blend_func_extended) {
+					WRITE(p, "#extension GL_EXT_blend_func_extended : require\n");
+				}
 			}
 		}
 
@@ -164,7 +174,6 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 	bool textureAtOffset = id.Bit(FS_BIT_TEXTURE_AT_OFFSET);
 
 	ReplaceBlendType replaceBlend = static_cast<ReplaceBlendType>(id.Bits(FS_BIT_REPLACE_BLEND, 3));
-	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(FS_BIT_STENCIL_TO_ALPHA, 2));
 
 	GEBlendSrcFactor replaceBlendFuncA = (GEBlendSrcFactor)id.Bits(FS_BIT_BLENDFUNC_A, 4);
 	GEBlendDstFactor replaceBlendFuncB = (GEBlendDstFactor)id.Bits(FS_BIT_BLENDFUNC_B, 4);

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -156,6 +156,9 @@ LinkedShader::LinkedShader(ShaderID VSID, Shader *vs, ShaderID FSID, Shader *fs,
 		}
 		// Prevent a buffer overflow.
 		numBones = 0;
+		// Avoid weird attribute enables.
+		attrMask = 0;
+		availableUniforms = 0;
 		return;
 	}
 

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -247,7 +247,7 @@ static const GlTypeInfo GLComp[] = {
 };
 
 static inline void VertexAttribSetup(int attrib, int fmt, int stride, u8 *ptr) {
-	if (attrib != -1 && fmt) {
+	if (fmt) {
 		const GlTypeInfo &type = GLComp[fmt];
 		glVertexAttribPointer(attrib, type.count, type.type, type.normalized, stride, ptr);
 	}


### PR DESCRIPTION
The main cause of the crash was the attrMask including random values, causing glDrawArrays to segfault.  However, the real problem was that any shader using dual-source blending was failing to compile.

Not actually tested on any GLES2 device that supports dual-source blending (but did test on an Adreno 3xx.)  That said:

https://www.khronos.org/registry/gles/extensions/EXT/EXT_blend_func_extended.txt

> ```
>     6.  Are there any OpenGL ES Shading Language interactions?
> 
>    RESOLVED: Yes, to use this extension, a #extension line will be needed
>    in the shader requesting the EXT_blend_func_extended functionality.
>    Example:
> 
>        #extension GL_EXT_blend_func_extended : require
> ```

It specifies this for both GLSL ES 1.00 and 3.00/3.10.

I'm relatively sure it used to work.  The error message wasn't precisely clear btw, and just said that two outputs had been bound to the COL0 semantic when linking.  I suspect this is related to Vulkan changes in the driver.

-[Unknown]
