### PR TITLE
Put the storage request button front and center

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -181,7 +181,7 @@ ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend) {
 		if (nonAlphaSrcFactors[gstate.getBlendFuncA()] && nonAlphaDestFactors[gstate.getBlendFuncB()]) {
 			return REPLACE_ALPHA_YES;
 		} else {
-			if (gstate_c.featureFlags & GPU_SUPPORTS_DUALSOURCE_BLEND) {
+			if (gstate_c.Supports(GPU_SUPPORTS_DUALSOURCE_BLEND)) {
 				return REPLACE_ALPHA_DUALSOURCE;
 			} else {
 				return REPLACE_ALPHA_NO;
@@ -1039,7 +1039,7 @@ void ConvertBlendState(GenericBlendState &blendState, bool allowShaderBlend) {
 		}
 	}
 
-	if (replaceAlphaWithStencil == REPLACE_ALPHA_DUALSOURCE && gstate_c.Supports(GPU_SUPPORTS_DUALSOURCE_BLEND)) {
+	if (replaceAlphaWithStencil == REPLACE_ALPHA_DUALSOURCE) {
 		glBlendFuncA = toDualSource(glBlendFuncA);
 		glBlendFuncB = toDualSource(glBlendFuncB);
 	}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -724,7 +724,13 @@ void MainScreen::CreateViews() {
 
 	leftColumn->SetClip(true);
 
-	if (g_Config.iMaxRecent > 0) {
+	bool showRecent = g_Config.iMaxRecent > 0;
+	bool hasStorageAccess = System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED;
+	if (showRecent && !hasStorageAccess) {
+		showRecent = !g_Config.recentIsos.empty();
+	}
+
+	if (showRecent) {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollRecentGames->SetTag("MainScreenRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(
@@ -739,7 +745,7 @@ void MainScreen::CreateViews() {
 		tabRecentGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
 	}
 
-	if (System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED) {
+	if (hasStorageAccess) {
 		ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollAllGames->SetTag("MainScreenAllGames");
 		ScrollView *scrollHomebrew = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
@@ -787,7 +793,16 @@ void MainScreen::CreateViews() {
 			showHomebrewTab = false;
 		}
 	} else {
-		leftColumn->Add(new Button(mm->T("Give PPSSPP permission to access storage")))->OnClick.Handle(this, &MainScreen::OnAllowStorage);
+		LinearLayout *buttonHolder = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
+		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
+		buttonHolder->Add(new Button(mm->T("Give PPSSPP permission to access storage"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT)))->OnClick.Handle(this, &MainScreen::OnAllowStorage);
+		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
+
+		leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
+		leftColumn->Add(buttonHolder);
+		leftColumn->Add(new Spacer(10.0f));
+		leftColumn->Add(new TextView(mm->T("PPSSPP can't load games or save right now"), ALIGN_HCENTER, false));
+		leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
 	}
 
 /* if (info) {


### PR DESCRIPTION
`G_CENTER` wouldn't do what I wanted, so I used Spacers.

This adds "PPSSPP can't load games or save right now" below the button, and puts them both in the center of the screen.  Previously, the Recent tab was pushing the button to the bottom of the screen.

Still showing Recent if there are recents, which pretty much only happens if you're me and you launch it using an http URL (which it can load, but maybe not properly cache it seems like?, without storage.)

-[Unknown]
