### PR TITLE
Disable alpha test optimization with logic ops

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -92,6 +92,7 @@ bool IsAlphaTestTriviallyTrue() {
 		return (gstate_c.vertexFullAlpha && (gstate_c.textureFullAlpha || !gstate.isTextureAlphaUsed())) || (
 			(!gstate.isStencilTestEnabled() &&
 				!gstate.isDepthTestEnabled() &&
+				(!gstate.isLogicOpEnabled() || gstate.getLogicOp() == GE_LOGIC_COPY) &&
 				gstate.getAlphaTestRef() == 0 &&
 				gstate.isAlphaBlendEnabled() &&
 				gstate.getBlendFuncA() == GE_SRCBLEND_SRCALPHA &&


### PR DESCRIPTION
We still need to discard the pixels in the case of a logic op, like invert.  Otherwise we will invert the blended pixels too.

See #8632.

-[Unknown]
