### PR TITLE
Use draws for alpha-only clears, minor changes

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -28,7 +28,7 @@
 
 using namespace std;
 
-VulkanContext::VulkanContext(const char *app_name, uint32_t flags)
+VulkanContext::VulkanContext(const char *app_name, int app_ver, uint32_t flags)
 	: device_(nullptr),
 	gfx_queue_(VK_NULL_HANDLE),
 #ifdef _WIN32
@@ -88,8 +88,9 @@ VulkanContext::VulkanContext(const char *app_name, uint32_t flags)
 	app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
 	app_info.pNext = NULL;
 	app_info.pApplicationName = app_name;
-	app_info.applicationVersion = 1;
+	app_info.applicationVersion = app_ver;
 	app_info.pEngineName = app_name;
+	// Let's increment this when we make major engine/context changes.
 	app_info.engineVersion = 1;
 #ifdef ANDROID
 	// For some strange reason, the Shield TV wants 1.0.2, not 1.0.3.

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -150,7 +150,7 @@ private:
 // Optionally, it can create a depth buffer for you as well.
 class VulkanContext {
 public:
-	VulkanContext(const char *app_name, uint32_t flags);
+	VulkanContext(const char *app_name, int app_ver, uint32_t flags);
 	~VulkanContext();
 
 	VkResult CreateDevice(int physical_device);

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -38,5 +38,14 @@ struct SoftwareTransformResult {
 	u8 stencilValue;
 };
 
-void SoftwareTransform(int prim, u8 *decoded, int vertexCount, u32 vertexType, u16 *&inds, int indexType, const DecVtxFormat &decVtxFormat, int &maxIndex, FramebufferManagerCommon *fbman, TextureCacheCommon *texCache, TransformedVertex *transformed, TransformedVertex *transformedExpanded, TransformedVertex *&drawBuffer,
-	int &numTrans, bool &drawIndexed, SoftwareTransformResult *result, float ySign);
+struct SoftwareTransformParams {
+	u8 *decoded;
+	TransformedVertex *transformed;
+	TransformedVertex *transformedExpanded;
+	FramebufferManagerCommon *fbman;
+	TextureCacheCommon *texCache;
+	bool allowSeparateAlphaClear;
+};
+
+void SoftwareTransform(int prim, int vertexCount, u32 vertexType, u16 *&inds, int indexType, const DecVtxFormat &decVtxFormat, int &maxIndex, TransformedVertex *&drawBuffer,
+	int &numTrans, bool &drawIndexed, const SoftwareTransformParams *params, SoftwareTransformResult *result);

--- a/GPU/Directx9/TransformPipelineDX9.cpp
+++ b/GPU/Directx9/TransformPipelineDX9.cpp
@@ -828,11 +828,20 @@ rotateVBO:
 		SoftwareTransformResult result;
 		memset(&result, 0, sizeof(result));
 
+		SoftwareTransformParams params;
+		memset(&params, 0, sizeof(params));
+		params.decoded = decoded;
+		params.transformed = transformed;
+		params.transformedExpanded = transformedExpanded;
+		params.fbman = framebufferManager_;
+		params.texCache = textureCache_;
+		params.allowSeparateAlphaClear = true;
+
 		int maxIndex = indexGen.MaxIndex();
 		SoftwareTransform(
-			prim, decoded, indexGen.VertexCount(),
+			prim, indexGen.VertexCount(),
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
-			maxIndex, framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result, 1.0f);
+			maxIndex, drawBuffer, numTrans, drawIndexed, &params, &result);
 
 		ApplyDrawStateLate();
 		vshader = shaderManager_->ApplyShader(prim, lastVType_);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1987,7 +1987,7 @@ bool FramebufferManager::GetFramebuffer(u32 fb_address, int fb_stride, GEBufferF
 		return true;
 	}
 
-	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GE_FORMAT_8888, false, true);
+	buffer.Allocate(vfb->renderWidth, vfb->renderHeight, GE_FORMAT_8888, !useBufferedRendering_, true);
 	if (vfb->fbo)
 		fbo_bind_for_read(vfb->fbo);
 	if (gl_extensions.GLES3 || !gl_extensions.IsGLES)

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -890,11 +890,21 @@ rotateVBO:
 		SoftwareTransformResult result;
 		memset(&result, 0, sizeof(result));
 
+		// TODO: Keep this static?  Faster than repopulating?
+		SoftwareTransformParams params;
+		memset(&params, 0, sizeof(params));
+		params.decoded = decoded;
+		params.transformed = transformed;
+		params.transformedExpanded = transformedExpanded;
+		params.fbman = framebufferManager_;
+		params.texCache = textureCache_;
+		params.allowSeparateAlphaClear = true;
+
 		int maxIndex = indexGen.MaxIndex();
 		SoftwareTransform(
-			prim, decoded, indexGen.VertexCount(),
+			prim, indexGen.VertexCount(),
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
-			maxIndex, framebufferManager_, textureCache_, transformed, transformedExpanded, drawBuffer, numTrans, drawIndexed, &result, 1.0);
+			maxIndex, drawBuffer, numTrans, drawIndexed, &params, &result);
 		ApplyDrawStateLate();
 
 		LinkedShader *program = shaderManager_->ApplyFragmentShader(vsid, vshader, lastVType_, prim);

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -22,6 +22,9 @@
     <Filter Include="Debugger">
       <UniqueIdentifier>{0cbddc00-4aa3-41d0-bed2-a454d37f838e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Vulkan">
+      <UniqueIdentifier>{3c621896-140c-4c8b-8e4d-a478bfdeca8a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ge_constants.h">
@@ -201,18 +204,42 @@
     <ClInclude Include="Common\ShaderId.h">
       <Filter>Common</Filter>
     </ClInclude>
-    <ClInclude Include="Vulkan\GPU_Vulkan.h" />
-    <ClInclude Include="Vulkan\DrawEngineVulkan.h" />
-    <ClInclude Include="Vulkan\TextureCacheVulkan.h" />
-    <ClInclude Include="Vulkan\FramebufferVulkan.h" />
-    <ClInclude Include="Vulkan\PipelineManagerVulkan.h" />
-    <ClInclude Include="Vulkan\VulkanUtil.h" />
-    <ClInclude Include="Vulkan\VertexShaderGeneratorVulkan.h" />
-    <ClInclude Include="Vulkan\FragmentShaderGeneratorVulkan.h" />
-    <ClInclude Include="Vulkan\ShaderManagerVulkan.h" />
-    <ClInclude Include="Vulkan\TextureScalerVulkan.h" />
-    <ClInclude Include="Vulkan\DepalettizeShaderVulkan.h" />
-    <ClInclude Include="Vulkan\StateMappingVulkan.h" />
+    <ClInclude Include="Vulkan\DepalettizeShaderVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\DrawEngineVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\FragmentShaderGeneratorVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\FramebufferVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\GPU_Vulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\PipelineManagerVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\ShaderManagerVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\StateMappingVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\TextureCacheVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\TextureScalerVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\VertexShaderGeneratorVulkan.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Vulkan\VulkanUtil.h">
+      <Filter>Vulkan</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -398,16 +425,38 @@
     <ClCompile Include="Common\ShaderId.cpp">
       <Filter>Common</Filter>
     </ClCompile>
-    <ClCompile Include="Vulkan\GPU_Vulkan.cpp" />
-    <ClCompile Include="Vulkan\StateMappingVulkan.cpp" />
-    <ClCompile Include="Vulkan\PipelineManagerVulkan.cpp" />
-    <ClCompile Include="Vulkan\VertexShaderGeneratorVulkan.cpp" />
-    <ClCompile Include="Vulkan\DrawEngineVulkan.cpp" />
-    <ClCompile Include="Vulkan\FramebufferVulkan.cpp" />
-    <ClCompile Include="Vulkan\FragmentShaderGeneratorVulkan.cpp" />
-    <ClCompile Include="Vulkan\ShaderManagerVulkan.cpp" />
-    <ClCompile Include="Vulkan\TextureCacheVulkan.cpp" />
-    <ClCompile Include="Vulkan\TextureScalerVulkan.cpp" />
-    <ClCompile Include="Vulkan\DepalettizeShaderVulkan.cpp" />
+    <ClCompile Include="Vulkan\DepalettizeShaderVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\DrawEngineVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\FragmentShaderGeneratorVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\FramebufferVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\GPU_Vulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\PipelineManagerVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\ShaderManagerVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\StateMappingVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\TextureCacheVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\TextureScalerVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Vulkan\VertexShaderGeneratorVulkan.cpp">
+      <Filter>Vulkan</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -531,6 +531,10 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 		shaderManager_->UpdateUniforms();
 		shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, useHWTransform);
 		VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(pipelineLayout_, pipelineKey, dec_, vshader, fshader, true);
+		if (!pipeline) {
+			// Already logged, let's bail out.
+			return;
+		}
 		vkCmdBindPipeline(cmd_, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->pipeline);  // TODO: Avoid if same as last draw.
 
 		if (pipeline->uniformBlocks & UB_VS_FS_BASE) {
@@ -620,6 +624,10 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 			shaderManager_->UpdateUniforms();
 			shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, useHWTransform);
 			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(pipelineLayout_, pipelineKey, dec_, vshader, fshader, false);
+			if (!pipeline) {
+				// Already logged, let's bail out.
+				return;
+			}
 			vkCmdBindPipeline(cmd_, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->pipeline);  // TODO: Avoid if same as last draw.
 
 			if (pipeline->uniformBlocks & UB_VS_FS_BASE) {

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -197,6 +197,11 @@ static VulkanPipeline *CreateVulkanPipeline(VkDevice device, VkPipelineCache pip
 	ss[1].pName = "main";
 	ss[1].flags = 0;
 
+	if (!ss[0].module || !ss[1].module) {
+		ERROR_LOG(G3D, "Failed creating graphics pipeline - bad shaders");
+		return nullptr;
+	}
+
 	VkPipelineInputAssemblyStateCreateInfo inputAssembly;
 	inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 	inputAssembly.pNext = nullptr;

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -54,7 +54,10 @@
 #include "Common/Vulkan/VulkanContext.h"
 
 #include "thin3d/thin3d.h"
+#include "util/text/parsers.h"
 #include "Windows/GPU/WindowsVulkanContext.h"
+
+extern const char *PPSSPP_GIT_VERSION;
 
 static const bool g_validate_ = true;
 static VulkanContext *g_Vulkan;
@@ -156,7 +159,8 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	g_LogOptions.breakOnWarning = true;
 	g_LogOptions.msgBoxOnError = false;
 
-	g_Vulkan = new VulkanContext("PPSSPP", (g_validate_ ? VULKAN_FLAG_VALIDATE : 0) | VULKAN_FLAG_PRESENT_MAILBOX);
+	Version gitVer(PPSSPP_GIT_VERSION);
+	g_Vulkan = new VulkanContext("PPSSPP", gitVer.ToInteger(), (g_validate_ ? VULKAN_FLAG_VALIDATE : 0) | VULKAN_FLAG_PRESENT_MAILBOX);
 	g_Vulkan->CreateDevice(0);
 	if (g_validate_) {
 		int bits = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -213,7 +213,8 @@ bool AndroidVulkanContext::Init(ANativeWindow *wnd, int desiredBackbufferSizeX, 
 	g_LogOptions.msgBoxOnError = false;
 
 	ILOG("Creating vulkan context");
-	g_Vulkan = new VulkanContext("PPSSPP", VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED);
+	Version gitVer(PPSSPP_GIT_VERSION);
+	g_Vulkan = new VulkanContext("PPSSPP", gitVer.ToInteger(), VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED);
 	if (!g_Vulkan->GetInstance()) {
 		ELOG("Failed to create vulkan context");
 		return false;

--- a/ext/native/util/text/parsers.cpp
+++ b/ext/native/util/text/parsers.cpp
@@ -22,6 +22,11 @@ std::string Version::ToString() const {
 	return std::string(temp);
 }
 
+int Version::ToInteger() const {
+	// This allows for ~2000 major versions, ~100 minor versions, and ~10000 sub versions.
+	return major * 1000000 + minor * 10000 + sub;
+}
+
 bool ParseMacAddress(std::string str, uint8_t macAddr[6]) {
 	int mac[6];
 	if (6 != sscanf(str.c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5])) {

--- a/ext/native/util/text/parsers.h
+++ b/ext/native/util/text/parsers.h
@@ -48,6 +48,7 @@ struct Version {
 	}
 
 	std::string ToString() const;
+	int ToInteger() const;
 private:
 	bool ParseVersionString(std::string str);
 };


### PR DESCRIPTION
Figured I'd move the static state out to a struct.  Already being passed as parameters to the stack anyway.

Since we're optimizing it to a SW_CLEAR in the first place, seems most logical to simply not perform that optimization when it's not supported, rather than try to map it back to a box.

7d482c8 is actually GLES, but found it while trying to use the GLES GE debugger to see why things were rendering wrong in Vulkan.  I can separate it out, though...

Also added the app version on init.

-[Unknown]
