### PR TITLE
Disable last texture reuse for now in Vulkan

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -464,7 +464,9 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 	VkImageView imageView = VK_NULL_HANDLE;
 	VkSampler sampler = VK_NULL_HANDLE;
 
-	if (gstate_c.textureChanged != TEXCHANGE_UNCHANGED && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
+	// TODO: The descriptor set seems to be unbinding the texture when not specified.  Cache it or the imageView instead?
+	// TODO: Add this back when fixed: gstate_c.textureChanged != TEXCHANGE_UNCHANGED &&
+	if (!gstate.isModeClear() && gstate.isTextureMapEnabled()) {
 		textureCache_->SetTexture();
 		gstate_c.textureChanged = TEXCHANGE_UNCHANGED;
 		if (gstate_c.needShaderTexClamp) {


### PR DESCRIPTION
Note: there is still missing drawing in Final Fantasy 4, but only some text after this change.

Because we use a fresh descriptor set with different state, we can't reuse the texture that way (since there will never be a write for the texture in the active set, I think?)  We could cache the imageView and sampler, but anyway, for now we can just recalc the texture every time.  It's slower, but it works.

-[Unknown]
