### PR TITLE
Fix alpha test ref in Vulkan

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -412,8 +412,10 @@ void SoftwareTransform(
 	// Experiment: Disable on PowerVR (see issue #6290)
 	// TODO: This bleeds outside the play area in non-buffered mode. Big deal? Probably not.
 	if (maxIndex > 1 && gstate.isModeClear() && prim == GE_PRIM_RECTANGLES && IsReallyAClear(transformed, maxIndex) && gl_extensions.gpuVendor != GPU_VENDOR_POWERVR) {  // && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
-		bool separateAlphaClear = gstate.isClearModeColorMask() != gstate.isClearModeAlphaMask();
-		if (params->allowSeparateAlphaClear || !separateAlphaClear) {
+		// If alpha is not allowed to be separate, it must match for both depth/stencil and color.  Vulkan requires this.
+		bool alphaMatchesColor = gstate.isClearModeColorMask() == gstate.isClearModeAlphaMask();
+		bool depthMatchesStencil = gstate.isClearModeAlphaMask() == gstate.isClearModeDepthMask();
+		if (params->allowSeparateAlphaClear || (alphaMatchesColor && depthMatchesStencil)) {
 			result->color = transformed[1].color0_32;
 			// Need to rescale from a [0, 1] float.  This is the final transformed value.
 			result->depth = ToScaledDepth((s16)(int)(transformed[1].z * 65535.0f));

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -198,7 +198,7 @@ void DrawEngineVulkan::BeginFrame() {
 
 void DrawEngineVulkan::EndFrame() {
 	FrameData *frame = &frame_[curFrame_ & 1];
-	gpuStats.pushSpaceUsed = frame->pushData->GetOffset();
+	gpuStats.pushSpaceUsed = (int)frame->pushData->GetOffset();
 	frame->pushData->End(vulkan_->GetDevice());
 	curFrame_++;
 }

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -268,7 +268,7 @@ bool GenerateVulkanGLSLFragmentShader(const ShaderID &id, char *buffer) {
 			} else {
 				const char *alphaTestFuncs[] = { "#", "#", " != ", " == ", " >= ", " > ", " <= ", " < " };
 				if (alphaTestFuncs[alphaTestFunc][0] != '#') {
-					WRITE(p, "  if ((roundAndScaleTo255i(v.a) & base.alphacolormask.a) %s int(base.alphacolorref.a)) discard;\n", alphaTestFuncs[alphaTestFunc]);
+					WRITE(p, "  if ((roundAndScaleTo255i(v.a) & base.alphacolormask.a) %s base.alphacolorref.a) discard;\n", alphaTestFuncs[alphaTestFunc]);
 				} else {
 					// This means NEVER.  See above.
 					WRITE(p, "  discard;\n");
@@ -293,11 +293,8 @@ bool GenerateVulkanGLSLFragmentShader(const ShaderID &id, char *buffer) {
 			} else {
 				const char *colorTestFuncs[] = { "#", "#", " != ", " == " };
 				if (colorTestFuncs[colorTestFunc][0] != '#') {
-					// Apparently GLES3 does not support vector bitwise ops.
 					WRITE(p, "  ivec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-					const char *maskedFragColor = "ivec3(v_scaled.r & base.alphacolormask.r, v_scaled.g & base.alphacolormask.g, v_scaled.b & base.alphacolormask.b)";
-					const char *maskedColorRef = "ivec3(int(base.alphacolorref.r) & base.alphacolormask.r, int(base.alphacolorref.g) & base.alphacolormask.g, int(base.alphacolorref.b) & base.alphacolormask.b)";
-					WRITE(p, "  if (%s %s %s) discard;\n", maskedFragColor, colorTestFuncs[colorTestFunc], maskedColorRef);
+					WRITE(p, "  if ((v_scaled & base.alphacolormask.rgb) %s (base.alphacolorref.rgb & base.alphacolormask.rgb)) discard;\n", colorTestFuncs[colorTestFunc]);
 				} else {
 					WRITE(p, "  discard;\n");
 				}

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -193,7 +193,7 @@ void ShaderManagerVulkan::BaseUpdateUniforms(int dirtyUniforms) {
 		Uint8x3ToFloat4(ub_base.texEnvColor, gstate.texenvcolor);
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORREF) {
-		Uint8x3ToFloat4_Alpha(ub_base.alphaColorRef, gstate.getColorTestRef(), (float)gstate.getAlphaTestRef());
+		Uint8x3ToFloat4_AlphaUint8(ub_base.alphaColorRef, gstate.getColorTestRef(), gstate.getAlphaTestRef());
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORMASK) {
 		Uint8x3ToInt4(ub_base.colorTestMask, gstate.colortestmask);

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -193,10 +193,10 @@ void ShaderManagerVulkan::BaseUpdateUniforms(int dirtyUniforms) {
 		Uint8x3ToFloat4(ub_base.texEnvColor, gstate.texenvcolor);
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORREF) {
-		Uint8x3ToFloat4_AlphaUint8(ub_base.alphaColorRef, gstate.getColorTestRef(), gstate.getAlphaTestRef());
+		Uint8x3ToInt4_Alpha(ub_base.alphaColorRef, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORMASK) {
-		Uint8x3ToInt4(ub_base.colorTestMask, gstate.colortestmask);
+		Uint8x3ToInt4_Alpha(ub_base.colorTestMask, gstate.getColorTestMask(), gstate.getAlphaTestMask());
 	}
 	if (dirtyUniforms & DIRTY_FOGCOLOR) {
 		Uint8x3ToFloat4(ub_base.fogColor, gstate.fogcolor);

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -96,7 +96,7 @@ struct UB_VS_FS_Base {
 	// Fragment data
 	float fogColor[4];
 	float texEnvColor[4];
-	float alphaColorRef[4];
+	int alphaColorRef[4];
 	int colorTestMask[4];
 	float stencilReplace[4];  // only first float used
 	float blendFixA[4];
@@ -117,7 +117,7 @@ R"(  mat4 proj_mtx;
   vec4 matambientalpha;
   vec3 fogcolor;
   vec3 texenv;
-  vec4 alphacolorref;
+  ivec4 alphacolorref;
   ivec4 alphacolormask;
   float stencilReplaceValue;
   vec3 blendFixA;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -68,7 +68,7 @@
 // TODO: Except for color swizzle, exact matches are available.
 // So we can get rid of the conversion functions entirely.
 #define VULKAN_4444_FORMAT VK_FORMAT_R4G4B4A4_UNORM_PACK16
-#define VULKAN_1555_FORMAT VK_FORMAT_A1R5G5B5_UNORM_PACK16   // TODO: Switch to the one that matches the PSP better.
+#define VULKAN_1555_FORMAT VK_FORMAT_R5G5B5A1_UNORM_PACK16
 #define VULKAN_565_FORMAT  VK_FORMAT_R5G6B5_UNORM_PACK16
 #define VULKAN_8888_FORMAT VK_FORMAT_R8G8B8A8_UNORM
 

--- a/ext/native/math/dataconv.h
+++ b/ext/native/math/dataconv.h
@@ -29,6 +29,13 @@ inline void Uint8x3ToInt4(int i[4], uint32_t u) {
 	i[3] = 0;
 }
 
+inline void Uint8x3ToInt4_Alpha(int i[4], uint32_t u, uint8_t alpha) {
+	i[0] = ((u >> 0) & 0xFF);
+	i[1] = ((u >> 8) & 0xFF);
+	i[2] = ((u >> 16) & 0xFF);
+	i[3] = alpha;
+}
+
 inline void Uint8x3ToFloat4_Alpha(float f[4], uint32_t u, float alpha) {
 	f[0] = ((u >> 0) & 0xFF) * (1.0f / 255.0f);
 	f[1] = ((u >> 8) & 0xFF) * (1.0f / 255.0f);


### PR DESCRIPTION
It needs to be treated as a u8.  Can be seen causing problems (if you can manage to ignore the major depth issues) in Valkyria Chronicles 2, for example, which tests character's hair against 0x7F.  Before this, everyone is bald.

But even when it passes the test, it renders wrong (seems overbright.)  So there are more issues still.

-[Unknown]
