### PR TITLE
Restore Java EGL support, while keeping the new stuff around as an option

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -411,7 +411,7 @@ static int DefaultAndroidHwScale() {
 	int xres = System_GetPropertyInt(SYSPROP_DISPLAY_XRES);
 	int yres = System_GetPropertyInt(SYSPROP_DISPLAY_YRES);
 
-	if (xres < 960) {
+	if (xres <= 960) {
 		// Smaller than the PSP*2, let's go native.
 		return 0;
 	} else if (xres <= 480 * 3) {  // 720p xres

--- a/GPU/GLES/TransformPipeline.cpp
+++ b/GPU/GLES/TransformPipeline.cpp
@@ -209,8 +209,8 @@ void TransformDrawEngine::DestroyDeviceObjects() {
 	}
 }
 
-void TransformDrawEngine::GLLost() {
-	ILOG("TransformDrawEngine::GLLost()");
+void TransformDrawEngine::GLRestore() {
+	ILOG("TransformDrawEngine::GLRestore()");
 	// The objects have already been deleted.
 	bufferNameCache_.clear();
 	bufferNameInfo_.clear();

--- a/GPU/GLES/TransformPipeline.h
+++ b/GPU/GLES/TransformPipeline.h
@@ -129,7 +129,7 @@ public:
 	void RestoreVAO();
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
-	void GLLost() override;
+	void GLRestore() override;
 	void Resized();
 
 	void DecimateTrackedVertexArrays();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -647,14 +647,18 @@ UI::EventReturn GameSettingsScreen::OnHardwareTransform(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnScreenRotation(UI::EventParams &e) {
 	ILOG("New display rotation: %d", g_Config.iScreenRotation);
+	ILOG("Sending rotate");
 	System_SendMessage("rotate", "");
+	ILOG("Got back from rotate");
 	return UI::EVENT_DONE;
 }
 
 static void RecreateActivity() {
 	const int SYSTEM_JELLYBEAN = 16;
 	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= SYSTEM_JELLYBEAN) {
+		ILOG("Sending recreate");
 		System_SendMessage("recreate", "");
+		ILOG("Got back from recreate");
 	} else {
 		I18NCategory *gr = GetI18NCategory("Graphics");
 		System_SendMessage("toast", gr->T("Must Restart", "You must restart PPSSPP for this change to take effect"));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -193,6 +193,8 @@ void GameSettingsScreen::CreateViews() {
 #ifdef ANDROID
 	static const char *deviceResolutions[] = { "Native device resolution", "Auto (same as Rendering)", "1x PSP", "2x PSP", "3x PSP", "4x PSP", "5x PSP" };
 	int max_res_temp = std::max(System_GetPropertyInt(SYSPROP_DISPLAY_XRES), System_GetPropertyInt(SYSPROP_DISPLAY_YRES)) / 480 + 2;
+	if (max_res_temp == 3)
+		max_res_temp = 4;  // At least allow 2x
 	int max_res = std::min(max_res_temp, (int)ARRAY_SIZE(deviceResolutions));
 	UI::PopupMultiChoice *hwscale = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAndroidHwScale, gr->T("Display Resolution (HW scaler)"), deviceResolutions, 0, max_res, gr->GetName(), screenManager()));
 	hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -766,12 +766,13 @@ void NativeUpdate(InputState &input) {
 	screenManager->update(input);
 }
 
-void NativeDeviceLost() {
-	// g_gameInfoCache.Clear();
+void NativeDeviceRestore() {
+	if (g_gameInfoCache)
+		g_gameInfoCache->Clear();
 	screenManager->deviceLost();
 
 	if (GetGPUBackend() == GPUBackend::OPENGL) {
-		gl_lost();
+		gl_restore();
 	}
 }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -432,8 +432,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 		NativeInitGraphics(graphicsContext);
 		renderer_inited = true;
 	} else {
-		NativeDeviceLost();  // ???
-		ILOG("displayInit: NativeDeviceLost completed.");
+		NativeDeviceRestore();  // ???
+		ILOG("displayInit: NativeDeviceRestore completed.");
 	}
 }
 
@@ -878,9 +878,6 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 
 	ILOG("After render loop.");
 	g_gameInfoCache->WorkQueue()->Flush();
-
-	NativeDeviceLost();
-	ILOG("NativeDeviceLost completed.");
 
 	NativeShutdownGraphics();
 	renderer_inited = false;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -522,9 +522,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 }
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayShutdown(JNIEnv *env, jobject obj) {
+	ILOG("NativeApp.displayShutdown()");
 	if (renderer_inited) {
-		NativeDeviceLost();
-		ILOG("NativeDeviceLost completed.");
 		NativeShutdownGraphics();
 		renderer_inited = false;
 		NativeMessageReceived("recreateviews", "");

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -550,8 +550,8 @@ PermissionStatus System_GetPermissionStatus(SystemPermission permission) {
 extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 	(JNIEnv *, jclass, float x, float y, int code, int pointerId) {
 
-	float scaledX = javaGL ? x : x * dp_xscale;
-	float scaledY = javaGL ? y : y * dp_yscale;
+	float scaledX = x * dp_xscale;
+	float scaledY = y * dp_yscale;
 
 	TouchInput touch;
 	touch.id = pointerId;

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -396,7 +396,8 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		sz.y = NativeApp.getDesiredBackbufferHeight();
 	}
 
-    @Override
+    @SuppressWarnings("deprecation")
+	@Override
     public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		shuttingDown = false;
@@ -452,13 +453,8 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	        if (Build.MANUFACTURER == "OUYA") {
 	        	mGLSurfaceView.getHolder().setFormat(PixelFormat.RGBX_8888);
 	        	mGLSurfaceView.setEGLConfigChooser(new NativeEGLConfigChooser());
-	        } else {
-	        	// Many devices require that we set a config chooser, despite the documentation
-	        	// explicitly stating: "If no setEGLConfigChooser method is called, then by default the view will choose an RGB_888 surface with a depth buffer depth of at least 16 bits."
-	        	// On these devices, I get these crashes: http://stackoverflow.com/questions/14167319/android-opengl-demo-no-config-chosen
-	        	// So let's try it...
-	        	mGLSurfaceView.setEGLConfigChooser(8, 8, 8, 8, 16, 8);
 	        }
+	        // Tried to mess around with config choosers here but fail completely on Xperia Play.
 
 	        mGLSurfaceView.setRenderer(nativeRenderer);
 			setContentView(mGLSurfaceView);

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -13,8 +13,7 @@ public class NativeApp {
 	public final static int DEVICE_TYPE_TV = 1;
 	public final static int DEVICE_TYPE_DESKTOP = 2;
 
-	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion);
-
+	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion, boolean javaGL);
 	public static native void audioInit();
 	public static native void audioShutdown();
 	public static native void audioConfig(int optimalFramesPerBuffer, int optimalSampleRate);
@@ -57,3 +56,4 @@ public class NativeApp {
 
 	public static native String queryConfig(String queryName);
 }
+

--- a/android/src/org/ppsspp/ppsspp/NativeEGLConfigChooser.java
+++ b/android/src/org/ppsspp/ppsspp/NativeEGLConfigChooser.java
@@ -1,0 +1,205 @@
+package org.ppsspp.ppsspp;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLDisplay;
+
+import android.opengl.GLSurfaceView.EGLConfigChooser;
+import android.util.Log;
+
+public class NativeEGLConfigChooser implements EGLConfigChooser {
+	private static final String TAG = "NativeEGLConfigChooser";
+
+	private static final int EGL_OPENGL_ES2_BIT = 4;
+
+	private class ConfigAttribs {
+		EGLConfig config;
+		public int red;
+		public int green;
+		public int blue;
+		public int alpha;
+		public int stencil;
+		public int depth;
+		public int samples;
+		public void Log() {
+			Log.i(TAG, "EGLConfig: red=" + red + " green=" + green + " blue=" + blue + " alpha=" + alpha + " depth=" + depth + " stencil=" + stencil + " samples=" + samples);
+		}
+	}
+
+	int getEglConfigAttrib(EGL10 egl, EGLDisplay display, EGLConfig config, int attr) {
+		int[] value = new int[1];
+		try {
+			if (egl.eglGetConfigAttrib(display, config, attr, value))
+				return value[0];
+			else
+				return -1;
+		} catch (IllegalArgumentException e) {
+			if (config == null) {
+				Log.e(TAG, "Called getEglConfigAttrib with null config. Bad developer.");
+			} else {
+				Log.e(TAG, "Illegal argument to getEglConfigAttrib: attr=" + attr);
+			}
+			return -1;
+		}
+	}
+
+	ConfigAttribs[] getConfigAttribs(EGL10 egl, EGLDisplay display, EGLConfig[] configs) {
+		ConfigAttribs[] attr = new ConfigAttribs[configs.length];
+		for (int i = 0; i < configs.length; i++) {
+			ConfigAttribs cfg = new ConfigAttribs();
+			cfg.config = configs[i];
+			cfg.red = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_RED_SIZE);
+			cfg.green = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_GREEN_SIZE);
+			cfg.blue = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_BLUE_SIZE);
+			cfg.alpha = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_ALPHA_SIZE);
+			cfg.depth = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_DEPTH_SIZE);
+			cfg.stencil = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_STENCIL_SIZE);
+			cfg.samples = getEglConfigAttrib(egl, display, configs[i], EGL10.EGL_SAMPLES);
+			attr[i] = cfg;
+		}
+		return attr;
+	}
+
+	public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display) {
+		// The absolute minimum. We will do our best to choose a better config though.
+		int[] configSpec = {
+			EGL10.EGL_RED_SIZE, 5,
+			EGL10.EGL_GREEN_SIZE, 6,
+			EGL10.EGL_BLUE_SIZE, 5,
+			EGL10.EGL_DEPTH_SIZE, 16,
+			EGL10.EGL_STENCIL_SIZE, 0,
+			EGL10.EGL_SURFACE_TYPE, EGL10.EGL_WINDOW_BIT,
+			EGL10.EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+			EGL10.EGL_NONE
+		};
+
+		int[] num_config = new int[1];
+        if (!egl.eglChooseConfig(display, configSpec, null, 0, num_config)) {
+            throw new IllegalArgumentException("eglChooseConfig failed when counting");
+        }
+
+        int numConfigs = num_config[0];
+        Log.i(TAG, "There are " + numConfigs + " egl configs");
+        if (numConfigs <= 0) {
+            throw new IllegalArgumentException("No configs match configSpec");
+        }
+
+		EGLConfig[] eglConfigs = new EGLConfig[numConfigs];
+		if (!egl.eglChooseConfig(display, configSpec, eglConfigs, numConfigs, num_config)) {
+            throw new IllegalArgumentException("eglChooseConfig failed when retrieving");
+        }
+
+		ConfigAttribs [] configs = getConfigAttribs(egl, display, eglConfigs);
+
+		ConfigAttribs chosen = null;
+
+		// Log them all.
+		for (int i = 0; i < configs.length; i++) {
+			configs[i].Log();
+		}
+
+		// We now ignore destination alpha as a workaround for the Mali issue
+		// where we get badly composited if we use it.
+
+		// First, find our ideal configuration. Prefer depth.
+		for (int i = 0; i < configs.length; i++) {
+			ConfigAttribs c = configs[i];
+			if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 0 && c.stencil >= 8 && c.depth >= 24) {
+				chosen = c;
+				break;
+			}
+		}
+
+		if (chosen == null) {
+			// Then, prefer one with 20-bit depth (Tegra 3)
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 0 && c.stencil >= 8 && c.depth >= 20) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Second, accept one with 16-bit depth.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 0 && c.stencil >= 8 && c.depth >= 16) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Third, accept one with no stencil.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 0 && c.depth >= 16) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Third, accept one with alpha but with stencil, 24-bit depth.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 8 && c.stencil >= 8 && c.depth >= 24) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Third, accept one with alpha but with stencil, 16-bit depth.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red == 8 && c.green == 8 && c.blue == 8 && c.alpha == 8 && c.stencil >= 8 && c.depth >= 16) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Fourth, accept one with 16-bit color but depth and stencil required.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red >= 5 && c.green >= 6 && c.blue >= 5 && c.depth >= 16 && c.stencil >= 8) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Fifth, accept one with 16-bit color but depth required.
+			for (int i = 0; i < configs.length; i++) {
+				ConfigAttribs c = configs[i];
+				if (c.red >= 5 && c.green >= 6 && c.blue >= 5 && c.depth >= 16) {
+					chosen = c;
+					break;
+				}
+			}
+		}
+
+		if (chosen == null) {
+			// Final, accept the first one in the list.
+			if (configs.length > 0)
+				chosen = configs[0];
+		}
+
+		if (chosen == null) {
+            throw new IllegalArgumentException("Failed to find a valid EGL config");
+		}
+
+		Log.i(TAG, "Final chosen config: ");
+		chosen.Log();
+		return chosen.config;
+	}
+
+}

--- a/android/src/org/ppsspp/ppsspp/NativeEGLConfigChooser.java
+++ b/android/src/org/ppsspp/ppsspp/NativeEGLConfigChooser.java
@@ -4,6 +4,7 @@ import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLDisplay;
 
+import android.graphics.PixelFormat;
 import android.opengl.GLSurfaceView.EGLConfigChooser;
 import android.util.Log;
 
@@ -11,6 +12,9 @@ public class NativeEGLConfigChooser implements EGLConfigChooser {
 	private static final String TAG = "NativeEGLConfigChooser";
 
 	private static final int EGL_OPENGL_ES2_BIT = 4;
+
+	NativeEGLConfigChooser() {
+	}
 
 	private class ConfigAttribs {
 		EGLConfig config;
@@ -60,6 +64,7 @@ public class NativeEGLConfigChooser implements EGLConfigChooser {
 		return attr;
 	}
 
+	@Override
 	public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display) {
 		// The absolute minimum. We will do our best to choose a better config though.
 		int[] configSpec = {
@@ -70,6 +75,7 @@ public class NativeEGLConfigChooser implements EGLConfigChooser {
 			EGL10.EGL_STENCIL_SIZE, 0,
 			EGL10.EGL_SURFACE_TYPE, EGL10.EGL_WINDOW_BIT,
 			EGL10.EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+			// EGL10.EGL_TRANSPARENT_TYPE, EGL10.EGL_NONE
 			EGL10.EGL_NONE
 		};
 
@@ -98,8 +104,10 @@ public class NativeEGLConfigChooser implements EGLConfigChooser {
 			configs[i].Log();
 		}
 
+
 		// We now ignore destination alpha as a workaround for the Mali issue
 		// where we get badly composited if we use it.
+		// Though, that may be possible to fix by using EGL10.EGL_TRANSPARENT_TYPE, EGL10.EGL_NONE.
 
 		// First, find our ideal configuration. Prefer depth.
 		for (int i = 0; i < configs.length; i++) {

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -75,8 +75,6 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 		boolean canReadToolType = Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 
 		int numTouchesHandled = 0;
-		float scaleX = (float)mActivity.getRenderer().getDpiScaleX();
-		float scaleY = (float)mActivity.getRenderer().getDpiScaleY();
 		for (int i = 0; i < ev.getPointerCount(); i++) {
 			int pid = ev.getPointerId(i);
 			int code = 0;
@@ -108,7 +106,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 					code |= tool << 10;  // We use the Android tool type codes
 				}
 				// Can't use || due to short circuit evaluation
-				numTouchesHandled += NativeApp.touch(scaleX * ev.getX(i), scaleY * ev.getY(i), code, pid) ? 1 : 0;
+				numTouchesHandled += NativeApp.touch(ev.getX(i), ev.getY(i), code, pid) ? 1 : 0;
 			}
 		}
 		return numTouchesHandled > 0;

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -1,6 +1,8 @@
 package org.ppsspp.ppsspp;
 
-// Touch- and sensor-enabled SurfaceView.
+// Touch- and sensor-enabled GLSurfaceView.
+// Used when javaGL = true.
+//
 // Supports simple multitouch and pressure.
 // DPI scaling is handled by the native code.
 
@@ -128,6 +130,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 
 	@Override
 	public void onPause() {
+		Log.i(TAG, "onPause");
 		super.onPause();
 		mSensorManager.unregisterListener(this);
 		if (mController != null) {
@@ -137,6 +140,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 
 	@Override
 	public void onResume() {
+		Log.i(TAG, "onResume");
 		super.onResume();
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
 		if (mController != null) {
@@ -148,6 +152,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 	}
 
 	public void onDestroy() {
+		Log.i(TAG, "onDestroy");
 		if (mController != null) {
 			mController.exit();
 		}

--- a/android/src/org/ppsspp/ppsspp/NativeRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/NativeRenderer.java
@@ -1,0 +1,94 @@
+package org.ppsspp.ppsspp;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+import android.graphics.Point;
+import android.opengl.GLES20;
+import android.opengl.GLSurfaceView;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.Display;
+
+public class NativeRenderer implements GLSurfaceView.Renderer {
+	private static String TAG = "NativeRenderer";
+	private NativeActivity mActivity;
+	private boolean isDark = false;
+	private int dpi;
+	private float refreshRate;
+
+	private double dpi_scale_x;
+	private double dpi_scale_y;
+
+	int last_width, last_height;
+
+	NativeRenderer(NativeActivity act) {
+		mActivity = act;
+		DisplayMetrics metrics = new DisplayMetrics();
+		Display display = act.getWindowManager().getDefaultDisplay();
+		display.getMetrics(metrics);
+		dpi = metrics.densityDpi;
+
+		refreshRate = display.getRefreshRate();
+	}
+
+	double getDpiScaleX() {
+		return dpi_scale_x;
+	}
+	double getDpiScaleY() {
+		return dpi_scale_y;
+	}
+
+	public void setDark(boolean d) {
+		isDark = d;
+	}
+	
+	public void setFixedSize(int xres, int yres, GLSurfaceView surfaceView) {
+		Log.i(TAG, "Setting surface to fixed size " + xres + "x" + yres);
+		surfaceView.getHolder().setFixedSize(xres, yres);
+	}
+
+	public void onDrawFrame(GL10 unused /*use GLES20*/) {
+		if (isDark) {
+			GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+			GLES20.glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+			GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT | GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_STENCIL_BUFFER_BIT);
+		} else {
+			displayRender();
+		}
+	}
+
+	public void onSurfaceCreated(GL10 unused, EGLConfig config) {
+		// Log.i(TAG, "onSurfaceCreated - EGL context is new or was lost");
+		// Actually, it seems that it is here we should recreate lost GL objects.
+		displayInit();
+	}
+ 
+	public void onSurfaceChanged(GL10 unused, int width, int height) {
+		Point sz = new Point();
+		mActivity.GetScreenSize(sz);
+		double actualW = sz.x;
+		double actualH = sz.y;
+		dpi_scale_x = ((double)width / (double)actualW);
+		dpi_scale_y = ((double)height / (double)actualH);
+		Log.i(TAG, "onSurfaceChanged: " + dpi_scale_x + "x" + dpi_scale_y + " (width=" + width + ", actualW=" + actualW);
+		int scaled_dpi = (int)((double)dpi * dpi_scale_x);
+		displayResize(width, height, scaled_dpi, refreshRate);
+		last_width = width;
+		last_height = height;
+	}
+
+	// Not override, it's custom.
+	public void onDestroyed() {
+		displayShutdown();
+	}
+	
+	// NATIVE METHODS
+
+	// Note: This also means "device lost" and you should reload
+	// all buffered objects. 
+	public native void displayInit(); 
+	public native void displayResize(int w, int h, int dpi, float refreshRate);
+	public native void displayRender();
+	public native void displayShutdown();
+}

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -2,6 +2,7 @@ package org.ppsspp.ppsspp;
 
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.graphics.Point;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
@@ -72,11 +73,11 @@ public class PpssppActivity extends NativeActivity {
 		// (from app drawer or file explorer).
 		Intent intent = getIntent();
 		String action = intent.getAction();
-		if(intent.ACTION_VIEW.equals(action))
-		{ 
+		if(Intent.ACTION_VIEW.equals(action))
+		{
 			String path = intent.getData().getPath();
 			super.setShortcutParam(path);
-			Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();	
+			Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();
 		}
 		else super.setShortcutParam(getIntent().getStringExtra(SHORTCUT_EXTRA_KEY));
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -52,9 +52,12 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 // Should not initialize anything screen-size-dependent - do that in NativeResized.
 void NativeInitGraphics(GraphicsContext *graphicsContext);
 
-// Signals that you need to destroy and recreate all buffered OpenGL resources,
+// Signals that you need to forget all buffered OpenGL resources,
 // like textures, vbo etc.
 void NativeDeviceLost();
+
+// Signals that it's time to recreate buffered OpenGL resources
+void NativeDeviceRestore();
 
 // If you want to change DPI stuff (such as modifying dp_xres and dp_yres), this is the
 // place to do it. You should only read g_dpi_scale and pixel_xres and pixel_yres in this,

--- a/ext/native/gfx/gl_lost_manager.cpp
+++ b/ext/native/gfx/gl_lost_manager.cpp
@@ -7,10 +7,11 @@
 std::vector<GfxResourceHolder *> *holders;
 
 static bool inLost;
+static bool inRestore;
 
 void register_gl_resource_holder(GfxResourceHolder *holder) {
-	if (inLost) {
-		FLOG("BAD: Should not call register_gl_resource_holder from lost path");
+	if (inLost || inRestore) {
+		FLOG("BAD: Should not call register_gl_resource_holder from lost/restore path");
 		return;
 	}
 	if (holders) {
@@ -21,8 +22,8 @@ void register_gl_resource_holder(GfxResourceHolder *holder) {
 }
 
 void unregister_gl_resource_holder(GfxResourceHolder *holder) {
-	if (inLost) {
-		FLOG("BAD: Should not call unregister_gl_resource_holder from lost path");
+	if (inLost || inRestore) {
+		FLOG("BAD: Should not call unregister_gl_resource_holder from lost/restore path");
 		return;
 	}
 	if (holders) {
@@ -38,22 +39,22 @@ void unregister_gl_resource_holder(GfxResourceHolder *holder) {
 	}
 }
 
-void gl_lost() {
-	inLost = true;
+void gl_restore() {
+	inRestore = true;
 	if (!holders) {
-		WLOG("GL resource holder not initialized, cannot process lost request");
-		inLost = false;
+		WLOG("GL resource holder not initialized, cannot process restore request");
+		inRestore = false;
 		return;
 	}
 
 	// TODO: We should really do this when we get the context back, not during gl_lost...
-	ILOG("gl_lost() restoring %i items:", (int)holders->size());
+	ILOG("gl_restore() restoring %i items:", (int)holders->size());
 	for (size_t i = 0; i < holders->size(); i++) {
-		ILOG("GLLost(%i / %i, %p, %08x)", (int)(i + 1), (int) holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));
-		(*holders)[i]->GLLost();
+		ILOG("gl_restore(%i / %i, %p, %08x)", (int)(i + 1), (int)holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));
+		(*holders)[i]->GLRestore();
 	}
-	ILOG("gl_lost() completed on %i items:", (int)holders->size());
-	inLost = false;
+	ILOG("gl_restore() completed on %i items:", (int)holders->size());
+	inRestore = false;
 }
 
 void gl_lost_manager_init() {

--- a/ext/native/gfx/gl_lost_manager.h
+++ b/ext/native/gfx/gl_lost_manager.h
@@ -6,7 +6,7 @@
 class GfxResourceHolder {
 public:
 	virtual ~GfxResourceHolder() {}
-	virtual void GLLost() = 0;
+	virtual void GLRestore() = 0;
 };
 
 void gl_lost_manager_init();
@@ -15,5 +15,5 @@ void gl_lost_manager_shutdown();
 void register_gl_resource_holder(GfxResourceHolder *holder);
 void unregister_gl_resource_holder(GfxResourceHolder *holder);
 
-// Notifies all objects about the loss.
-void gl_lost();
+// Notifies all objects that it's time to be restored.
+void gl_restore();

--- a/ext/native/gfx_es2/glsl_program.cpp
+++ b/ext/native/gfx_es2/glsl_program.cpp
@@ -220,7 +220,7 @@ bool glsl_recompile(GLSLProgram *program, std::string *error_message) {
 	return true;
 }
 
-void GLSLProgram::GLLost() {
+void GLSLProgram::GLRestore() {
 	// Quoth http://developer.android.com/reference/android/opengl/GLSurfaceView.Renderer.html;
 	// "Note that when the EGL context is lost, all OpenGL resources associated with that context will be automatically deleted. 
 	// You do not need to call the corresponding "glDelete" methods such as glDeleteTextures to manually delete these lost resources."
@@ -228,16 +228,15 @@ void GLSLProgram::GLLost() {
 	// glDeleteShader(this->vsh_);
 	// glDeleteShader(this->fsh_);
 	// glDeleteProgram(this->program_);
-	ILOG("Restoring GLSL program %s/%s",
-		strlen(this->vshader_filename) > 0 ? this->vshader_filename : "(mem)",
-		strlen(this->fshader_filename) > 0 ? this->fshader_filename : "(mem)");
 	this->program_ = 0;
 	this->vsh_ = 0;
 	this->fsh_ = 0;
+	ILOG("Restoring GLSL program %s/%s",
+		strlen(this->vshader_filename) > 0 ? this->vshader_filename : "(mem)",
+		strlen(this->fshader_filename) > 0 ? this->fshader_filename : "(mem)");
 	glsl_recompile(this);
-	// Note that uniforms are still lost, hopefully the client sets them every frame at a minimum...
+	// Note that any shader uniforms are still lost, hopefully the client sets them every frame at a minimum...
 }
-
 
 int glsl_attrib_loc(const GLSLProgram *program, const char *name) {
 	return glGetAttribLocation(program->program_, name);

--- a/ext/native/gfx_es2/glsl_program.h
+++ b/ext/native/gfx_es2/glsl_program.h
@@ -43,7 +43,7 @@ struct GLSLProgram : public GfxResourceHolder {
 	GLuint fsh_;
 	GLuint program_;
 
-	void GLLost();
+	void GLRestore() override;
 };
 
 // C API, old skool. Not much point either...

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -120,7 +120,7 @@ void UIContext::SetFontStyle(const UI::FontStyle &fontStyle) {
 	*fontStyle_ = fontStyle;
 	if (textDrawer_) {
 		textDrawer_->SetFontScale(fontScaleX_, fontScaleY_);
-		Text()->SetFont(fontStyle.fontName.c_str(), fontStyle.sizePts, fontStyle.flags);
+		textDrawer_->SetFont(fontStyle.fontName.c_str(), fontStyle.sizePts, fontStyle.flags);
 	}
 }
 


### PR DESCRIPTION
Did not restore the old DPI code, reusing the new instead.

To switch back to C++ EGL, change javaGL in NativeActivity.java.

Fixes issue #8638 and hopefully others like #8618.

Indentation in the Java files is a complete mess. I'll have to clean that up after this is merged.
