### PR TITLE
d3d9: Check actual FBO format for INTZ support

### DIFF
--- a/GPU/Directx9/helper/dx_fbo.cpp
+++ b/GPU/Directx9/helper/dx_fbo.cpp
@@ -51,8 +51,11 @@ void fbo_init(LPDIRECT3D9 d3d) {
 	if (d3d) {
 		D3DDISPLAYMODE displayMode;
 		d3d->GetAdapterDisplayMode(D3DADAPTER_DEFAULT, &displayMode);
-		HRESULT intzFormat = d3d->CheckDeviceFormat(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, displayMode.Format, D3DUSAGE_DEPTHSTENCIL, D3DRTYPE_TEXTURE, FOURCC_INTZ);
-		supportsINTZ = SUCCEEDED(intzFormat);
+
+		// To be safe, make sure both the display format and the FBO format support INTZ.
+		HRESULT displayINTZ = d3d->CheckDeviceFormat(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, displayMode.Format, D3DUSAGE_DEPTHSTENCIL, D3DRTYPE_TEXTURE, FOURCC_INTZ);
+		HRESULT fboINTZ = d3d->CheckDeviceFormat(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, D3DFMT_A8R8G8B8, D3DUSAGE_DEPTHSTENCIL, D3DRTYPE_TEXTURE, FOURCC_INTZ);
+		supportsINTZ = SUCCEEDED(displayINTZ) && SUCCEEDED(fboINTZ);
 	}
 }
 


### PR DESCRIPTION
I believe this will fix / help #8593.  Basically, we can't assume that INTZ is supported for 8888 just because it is supported for the display format.

Maybe only 8888 matters, but I figure it'd better to disable it if either one doesn't support it.

-[Unknown]
