### PR TITLE
Fix some of the Vulkan stencil problems

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -617,9 +617,11 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 		// TODO: Dirty-flag these.
 		vkCmdSetScissor(cmd_, 0, 1, &dynState.scissor);
 		vkCmdSetViewport(cmd_, 0, 1, &dynState.viewport);
-		vkCmdSetStencilReference(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilRef);
-		vkCmdSetStencilWriteMask(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilWriteMask);
-		vkCmdSetStencilCompareMask(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilCompareMask);
+		if (dynState.useStencil) {
+			vkCmdSetStencilWriteMask(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilWriteMask);
+			vkCmdSetStencilCompareMask(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilCompareMask);
+			vkCmdSetStencilReference(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilRef);
+		}
 		float bc[4];
 		Uint8x4ToFloat4(bc, dynState.blendColor);
 		vkCmdSetBlendConstants(cmd_, bc);

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -148,9 +148,9 @@ static VulkanPipeline *CreateVulkanPipeline(VkDevice device, VkPipelineCache pip
 	dynamicStates[numDyn++] = VK_DYNAMIC_STATE_SCISSOR;
 	dynamicStates[numDyn++] = VK_DYNAMIC_STATE_VIEWPORT;
 	if (key.stencilTestEnable) {
+		dynamicStates[numDyn++] = VK_DYNAMIC_STATE_STENCIL_WRITE_MASK;
 		dynamicStates[numDyn++] = VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK;
 		dynamicStates[numDyn++] = VK_DYNAMIC_STATE_STENCIL_REFERENCE;
-		dynamicStates[numDyn++] = VK_DYNAMIC_STATE_STENCIL_WRITE_MASK;
 	}
 	
 	VkPipelineDynamicStateCreateInfo ds = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -179,20 +179,19 @@ void ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManager, ShaderManagerV
 		bool alphaMask = gstate.isClearModeAlphaMask();
 		key.colorWriteMask = (colorMask ? (VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT) : 0) | (alphaMask ? VK_COLOR_COMPONENT_A_BIT : 0);
 
-		GenericStencilFuncState stencilState;
-		ConvertStencilFuncState(stencilState);
-
 		// Stencil Test
-		if (stencilState.enabled) {
+		if (alphaMask) {
 			key.stencilTestEnable = true;
-			key.stencilCompareOp = compareOps[stencilState.testFunc];
-			key.stencilPassOp = stencilOps[stencilState.zPass];
-			key.stencilFailOp = stencilOps[stencilState.sFail];
-			key.stencilDepthFailOp = stencilOps[stencilState.zFail];
+			key.stencilCompareOp = VK_COMPARE_OP_ALWAYS;
+			key.stencilPassOp = VK_STENCIL_OP_REPLACE;
+			key.stencilFailOp = VK_STENCIL_OP_REPLACE;
+			key.stencilDepthFailOp = VK_STENCIL_OP_REPLACE;
 			dynState.useStencil = true;
-			dynState.stencilRef = stencilState.testRef;
-			dynState.stencilCompareMask = stencilState.testMask;
-			dynState.stencilWriteMask = stencilState.writeMask;
+			// In clear mode, the stencil value is set to the alpha value of the vertex.
+			// A normal clear will be 2 points, the second point has the color.
+			// We override this value in the pipeline from software transform for clear rectangles.
+			dynState.stencilRef = 0xFF;
+			dynState.stencilWriteMask = 0xFF;
 		} else {
 			key.stencilTestEnable = false;
 			dynState.useStencil = false;
@@ -208,7 +207,7 @@ void ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManager, ShaderManagerV
 			key.depthCompareOp = compareOps[gstate.getDepthTestFunction()];
 			key.depthWriteEnable = gstate.isDepthWriteEnabled();
 			if (gstate.isDepthWriteEnabled()) {
-				// framebufferManager_->SetDepthUpdated();
+				fbManager.SetDepthUpdated();
 			}
 		} else {
 			key.depthTestEnable = false;
@@ -223,8 +222,8 @@ void ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManager, ShaderManagerV
 		bool bmask = ((gstate.pmskc >> 16) & 0xFF) < 128;
 		bool amask = (gstate.pmska & 0xFF) < 128;
 
-		u8 abits = (gstate.pmska >> 0) & 0xFF;
 #ifndef MOBILE_DEVICE
+		u8 abits = (gstate.pmska >> 0) & 0xFF;
 		u8 rbits = (gstate.pmskc >> 0) & 0xFF;
 		u8 gbits = (gstate.pmskc >> 8) & 0xFF;
 		u8 bbits = (gstate.pmskc >> 16) & 0xFF;
@@ -248,19 +247,24 @@ void ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManager, ShaderManagerV
 		}
 
 		key.colorWriteMask = (rmask ? VK_COLOR_COMPONENT_R_BIT : 0) | (gmask ? VK_COLOR_COMPONENT_G_BIT : 0) | (bmask ? VK_COLOR_COMPONENT_B_BIT : 0) | (amask ? VK_COLOR_COMPONENT_A_BIT : 0);
-		
+
+		GenericStencilFuncState stencilState;
+		ConvertStencilFuncState(stencilState);
+
 		// Stencil Test
-		if (gstate.isStencilTestEnabled()) {
+		if (stencilState.enabled) {
 			key.stencilTestEnable = true;
-			key.stencilCompareOp = compareOps[gstate.getStencilTestFunction()];
-			dynState.stencilRef = gstate.getStencilTestRef();
-			dynState.stencilCompareMask = gstate.getStencilTestMask();
-			key.stencilFailOp = stencilOps[gstate.getStencilOpSFail()];  // stencil fail
-			key.stencilDepthFailOp = stencilOps[gstate.getStencilOpZFail()];  // depth fail
-			key.stencilPassOp = stencilOps[gstate.getStencilOpZPass()]; // depth pass
-			dynState.stencilWriteMask = ~abits;
+			key.stencilCompareOp = compareOps[stencilState.testFunc];
+			key.stencilPassOp = stencilOps[stencilState.zPass];
+			key.stencilFailOp = stencilOps[stencilState.sFail];
+			key.stencilDepthFailOp = stencilOps[stencilState.zFail];
+			dynState.useStencil = true;
+			dynState.stencilRef = stencilState.testRef;
+			dynState.stencilCompareMask = stencilState.testMask;
+			dynState.stencilWriteMask = stencilState.writeMask;
 		} else {
 			key.stencilTestEnable = false;
+			dynState.useStencil = false;
 		}
 	}
 


### PR DESCRIPTION
#8668 is still broken, but the background now shows in one of the places.  I'm still not sure why, but I'm pretty sure these changes are better than what was there before.

I strongly suspect the compareMask is being processed as zero (although we ARE sending it to cmd as 0xFF).  If I make it pass when equal, it passes.  Not equal fails.  The clear also APPEARS to be clearing.

Really need to get stencil reading into the debugger...

-[Unknown]
