### PR TITLE
Fix a wrong assertion on exit and enable logic ops in Vulkan

### DIFF
--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -199,4 +199,5 @@ private:
 	size_t minSlabSize_;
 	const size_t maxSlabSize_;
 	uint32_t memoryTypeIndex_;
+	bool destroyed_;
 };


### PR DESCRIPTION
Oops, caught this in Brave Story while testing the logic ops.  This makes Brave Story's cinematics mostly work, although it needs buffered rendering to look right.

Note that "PowerVR Rogue G6430" has [reported logicOp support](http://vulkan.gpuinfo.org/displayreport.php?id=224), so this will actually be better on mobile devices where we previously never enabled logic ops.

-[Unknown]
