### PR TITLE
Vulkan framebuffer - First steps

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 static const char *validationLayers[] = {
 	"VK_LAYER_GOOGLE_unique_objects",
-	//"VK_LAYER_LUNARG_standard_validation",
+	"VK_LAYER_LUNARG_standard_validation",
 	/*
 	"VK_LAYER_GOOGLE_threading",
 	"VK_LAYER_LUNARG_draw_state",

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -74,6 +74,7 @@ public:
 	void QueueDeleteImageView(VkImageView imageView) { imageViews_.push_back(imageView); }
 	void QueueDeleteDeviceMemory(VkDeviceMemory deviceMemory) { deviceMemory_.push_back(deviceMemory); }
 	void QueueDeleteSampler(VkSampler sampler) { samplers_.push_back(sampler); }
+	void QueueDeletePipeline(VkPipeline pipeline) { pipelines_.push_back(pipeline); }
 	void QueueDeletePipelineCache(VkPipelineCache pipelineCache) { pipelineCaches_.push_back(pipelineCache); }
 	void QueueDeleteRenderPass(VkRenderPass renderPass) { renderPasses_.push_back(renderPass); }
 	void QueueDeleteFramebuffer(VkFramebuffer framebuffer) { framebuffers_.push_back(framebuffer); }
@@ -88,6 +89,7 @@ public:
 		assert(imageViews_.size() == 0);
 		assert(deviceMemory_.size() == 0);
 		assert(samplers_.size() == 0);
+		assert(pipelines_.size() == 0);
 		assert(pipelineCaches_.size() == 0);
 		assert(renderPasses_.size() == 0);
 		assert(framebuffers_.size() == 0);
@@ -100,6 +102,7 @@ public:
 		imageViews_ = std::move(del.imageViews_);
 		deviceMemory_ = std::move(del.deviceMemory_);
 		samplers_ = std::move(del.samplers_);
+		pipelines_ = std::move(del.pipelines_);
 		pipelineCaches_ = std::move(del.pipelineCaches_);
 		renderPasses_ = std::move(del.renderPasses_);
 		framebuffers_ = std::move(del.framebuffers_);
@@ -139,6 +142,10 @@ public:
 			vkDestroySampler(device, sampler, nullptr);
 		}
 		samplers_.clear();
+		for (auto &pipeline : pipelines_) {
+			vkDestroyPipeline(device, pipeline, nullptr);
+		}
+		pipelines_.clear();
 		for (auto &pcache : pipelineCaches_) {
 			vkDestroyPipelineCache(device, pcache, nullptr);
 		}
@@ -166,6 +173,7 @@ private:
 	std::vector<VkImageView> imageViews_;
 	std::vector<VkDeviceMemory> deviceMemory_;
 	std::vector<VkSampler> samplers_;
+	std::vector<VkPipeline> pipelines_;
 	std::vector<VkPipelineCache> pipelineCaches_;
 	std::vector<VkRenderPass> renderPasses_;
 	std::vector<VkFramebuffer> framebuffers_;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -29,17 +29,28 @@
 // Uses integer instructions available since OpenGL 3.0. Suitable for ES 3.0 as well.
 void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLanguage language) {
 	char *p = buffer;
-	if (gl_extensions.IsGLES) {
-		WRITE(p, "#version 300 es\n");
-		WRITE(p, "precision mediump float;\n");
+	if (language == GLSL_VULKAN) {
+		WRITE(p, "#version 140\n");
+		WRITE(p, "#extension GL_ARB_separate_shader_objects : enable\n");
+		WRITE(p, "#extension GL_ARB_shading_language_420pack : enable\n");
+		WRITE(p, "layout(set = 0, binding = 0) uniform sampler2D tex;\n");
+		WRITE(p, "layout(set = 0, binding = 1) uniform sampler2D pal;\n");
+		WRITE(p, "layout(location = 0) in vec2 v_texcoord0;\n");
+		WRITE(p, "layout(location = 0) out vec4 fragColor0\n;");
 	} else {
-		WRITE(p, "#version 330\n");
+		if (gl_extensions.IsGLES) {
+			WRITE(p, "#version 300 es\n");
+			WRITE(p, "precision mediump float;\n");
+		} else {
+			WRITE(p, "#version 330\n");
+		}
+		WRITE(p, "in vec2 v_texcoord0;\n");
+		WRITE(p, "out vec4 fragColor0;\n");
+		WRITE(p, "uniform sampler2D tex;\n");
+		WRITE(p, "uniform sampler2D pal;\n");
 	}
-	WRITE(p, "in vec2 v_texcoord0;\n");
-	WRITE(p, "out vec4 fragColor0;\n");
-	WRITE(p, "uniform sampler2D tex;\n");
-	WRITE(p, "uniform sampler2D pal;\n");
 
+	// TODO: Add support for integer textures. Though it hardly matters.
 	WRITE(p, "void main() {\n");
 	WRITE(p, "  vec4 color = texture(tex, v_texcoord0);\n");
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -158,7 +158,8 @@ public:
 			// that come from elsewhere than gstate.
 			FramebufferHeuristicParams inputs;
 			GetFramebufferHeuristicInputs(&inputs, gstate);
-			return DoSetRenderFrameBuffer(inputs, skipDrawReason);
+			VirtualFramebuffer *vfb = DoSetRenderFrameBuffer(inputs, skipDrawReason);
+			return vfb;
 		}
 	}
 	virtual void RebindFramebuffer() = 0;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -664,9 +664,11 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 			vkCmdSetStencilCompareMask(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilCompareMask);
 			vkCmdSetStencilReference(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilRef);
 		}
-		float bc[4];
-		Uint8x4ToFloat4(bc, dynState.blendColor);
-		vkCmdSetBlendConstants(cmd_, bc);
+		if (dynState.useBlendColor) {
+			float bc[4];
+			Uint8x4ToFloat4(bc, dynState.blendColor);
+			vkCmdSetBlendConstants(cmd_, bc);
+		}
 
 		dirtyUniforms_ |= shaderManager_->UpdateUniforms();
 
@@ -758,10 +760,12 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 			} else if (dynState.useStencil) {
 				vkCmdSetStencilReference(cmd_, VK_STENCIL_FRONT_AND_BACK, dynState.stencilRef);
 			}
+			if (dynState.useBlendColor) {
+				float bc[4];
+				Uint8x4ToFloat4(bc, dynState.blendColor);
+				vkCmdSetBlendConstants(cmd_, bc);
+			}
 
-			float bc[4];
-			Uint8x4ToFloat4(bc, dynState.blendColor);
-			vkCmdSetBlendConstants(cmd_, bc);
 			dirtyUniforms_ |= shaderManager_->UpdateUniforms();
 
 			shaderManager_->GetShaders(prim, lastVTypeID_, &vshader, &fshader, useHWTransform);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -741,7 +741,6 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 
 		// Only here, where we know whether to clear or to draw primitives, should we actually set the current framebuffer! Because that gives use the opportunity
 		// to use a "pre-clear" render pass, for high efficiency on tilers.
-
 		if (result.action == SW_DRAW_PRIMITIVES) {
 			VulkanPipelineRasterStateKey pipelineKey;
 			VulkanDynamicState dynState;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -208,6 +208,7 @@ DrawEngineVulkan::~DrawEngineVulkan() {
 		delete nullTexture_;
 	}
 	delete[] uvScale;
+	vkDestroyPipelineLayout(vulkan_->GetDevice(), pipelineLayout_, nullptr);
 }
 
 void DrawEngineVulkan::BeginFrame() {

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -143,6 +143,10 @@ public:
 
 	void DirtyAllUBOs();
 
+	VulkanPushBuffer *GetPushBufferForTextureData() {
+		return frame_[curFrame_].pushUBO;
+	}
+
 private:
 	struct FrameData;
 

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -85,6 +85,8 @@ FramebufferManagerVulkan::FramebufferManagerVulkan(VulkanContext *vulkan) :
 	vulkan_(vulkan),
 	drawPixelsTex_(nullptr),
 	drawPixelsTexFormat_(GE_FORMAT_INVALID),
+	convBuf_(nullptr),
+	convBufSize_(0),
 	textureCache_(nullptr),
 	shaderManager_(nullptr),
 	resized_(false),
@@ -267,13 +269,13 @@ void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFor
 	// Could share code with the texture cache perhaps.
 	const uint8_t *data = srcPixels;
 	if (srcPixelFormat != GE_FORMAT_8888 || srcStride != width) {
-		data = convBuf_;
 		u32 neededSize = width * height * 4;
 		if (!convBuf_ || convBufSize_ < neededSize) {
 			delete[] convBuf_;
 			convBuf_ = new u8[neededSize];
 			convBufSize_ = neededSize;
 		}
+		data = convBuf_;
 		for (int y = 0; y < height; y++) {
 			switch (srcPixelFormat) {
 			case GE_FORMAT_565:

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -341,7 +341,7 @@ void FramebufferManagerVulkan::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 	vkCmdSetViewport(curCmd_, 0, 1, &vp);
 
 	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height);
-	DrawActiveTexture(drawPixelsTex_, dstX, dstY, width, height, vfb->bufferWidth, vfb->bufferHeight, 0.0f, 0.0f, 1.0f, 1.0f, nullptr, ROTATION_LOCKED_HORIZONTAL);
+	DrawActiveTexture(drawPixelsTex_, dstX, dstY, width, height, vfb->bufferWidth, vfb->bufferHeight, 0.0f, 0.0f, 1.0f, 1.0f, pipelineBasicTex_, ROTATION_LOCKED_HORIZONTAL);
 	textureCache_->ForgetLastTexture();
 }
 
@@ -455,7 +455,7 @@ void FramebufferManagerVulkan::DrawActiveTexture(VulkanTexture *texture, float x
 
 	// TODO: Choose linear or nearest appropriately, see GL impl.
 	vulkan2D_.BindDescriptorSet(cmd, texture->GetImageView(), linearSampler_);
-	vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineBasicTex_);
+	vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 	VkBuffer vbuffer;
 	VkDeviceSize offset = push->Push(vtx, sizeof(vtx), &vbuffer);
 	vkCmdBindVertexBuffers(cmd, 0, 1, &vbuffer, &offset);

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -259,10 +259,10 @@ void FramebufferManagerVulkan::NotifyClear(bool clearColor, bool clearAlpha, boo
 		}
 		vkCmdClearAttachments(curCmd_, count, attach, 1, &rect);
 
-		if (clearColor) {
+		if (clearColor || clearAlpha) {
 			SetColorUpdated(gstate_c.skipDrawReason);
 		}
-		if (clearAlpha) {
+		if (clearDepth) {
 			SetDepthUpdated();
 		}
 	} else {

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -191,9 +191,6 @@ private:
 	ShaderManagerVulkan *shaderManager_;
 	DrawEngineVulkan *drawEngine_;
 
-	// Used for postprocessing tasks and in-render-pass plain 2D draws/blits.
-	VkPipelineLayout simplePipelineLayout_;
-
 	bool resized_;
 
 	AsyncPBOVulkan *pixelBufObj_;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -111,7 +111,7 @@ public:
 	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
 	// For use when texturing from a framebuffer.  May create a duplicate if target.
-	void BindFramebufferColor(int stage, u32 fbRawAddress, VirtualFramebuffer *framebuffer, int flags);
+	VulkanTexture *GetFramebufferColor(u32 fbRawAddress, VirtualFramebuffer *framebuffer, int flags);
 
 	// Reads a rectangular subregion of a framebuffer to the right position in its backing memory.
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h) override;
@@ -141,7 +141,7 @@ public:
 
 	// If within a render pass, this will just issue a regular clear. If beginning a new render pass,
 	// do that.
-	void NotifyClear(bool clearColor, bool clearDepth, uint32_t color, float depth);
+	void NotifyClear(bool clearColor, bool clearAlpha, bool clearDepth, uint32_t color, float depth);
 	void NotifyDraw() {
 		DoNotifyDraw();
 	}
@@ -227,6 +227,9 @@ private:
 	VkShaderModule fsBasicTex_;
 	VkShaderModule vsBasicTex_;
 	VkPipeline pipelineBasicTex_;
+
+	// Postprocessing
+	VkPipeline pipelinePostShader_;
 
 	VkSampler linearSampler_;
 	VkSampler nearestSampler_;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -93,7 +93,7 @@ public:
 
 	// If texture != 0, will bind it.
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
-	void DrawActiveTexture(VulkanTexture *texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, VkPipeline pipeline, int uvRotation);
+	void DrawTexture(VulkanTexture *texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, VkPipeline pipeline, int uvRotation);
 
 	void DestroyAllFBOs();
 
@@ -163,7 +163,9 @@ protected:
 
 
 private:
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
+
+	// The returned texture does not need to be free'd, might be returned from a pool (currently single entry)
+	VulkanTexture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
 	void DoNotifyDraw();
 
 	VkCommandBuffer AllocFrameCommandBuffer();

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -198,7 +198,6 @@ private:
 
 	AsyncPBOVulkan *pixelBufObj_;
 	int currentPBO_;
-	CardboardSettings cardboardSettings;
 
 	enum {
 		MAX_COMMAND_BUFFERS = 32,

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -36,6 +36,7 @@ class DrawEngineVulkan;
 class VulkanContext;
 class ShaderManagerVulkan;
 class VulkanTexture;
+class VulkanPushBuffer;
 
 struct PostShaderUniforms {
 	float texelDelta[2]; float pad[2];
@@ -84,7 +85,7 @@ public:
 		shaderManager_ = sm;
 	}
 	void SetDrawEngine(DrawEngineVulkan *td) {
-		transformDraw_ = td;
+		drawEngine_ = td;
 	}
 
 	void DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) override;
@@ -179,8 +180,6 @@ private:
 	VkCommandBuffer curCmd_;
 	VkCommandBuffer cmdInit_;
 
-	DrawEngineVulkan *drawEngine_;
-
 	// Used by DrawPixels
 	VulkanTexture *drawPixelsTex_;
 	GEBufferFormat drawPixelsTexFormat_;
@@ -190,7 +189,7 @@ private:
 
 	TextureCacheVulkan *textureCache_;
 	ShaderManagerVulkan *shaderManager_;
-	DrawEngineVulkan *transformDraw_;
+	DrawEngineVulkan *drawEngine_;
 
 	// Used for postprocessing tasks and in-render-pass plain 2D draws/blits.
 	VkPipelineLayout simplePipelineLayout_;
@@ -209,6 +208,7 @@ private:
 		VkCommandPool cmdPool_;
 		// Keep track of command buffers we allocated so we can reset or free them at an appropriate point.
 		VkCommandBuffer commandBuffers_[MAX_COMMAND_BUFFERS];
+		VulkanPushBuffer *push_;
 		int numCommandBuffers_;
 		int totalCommandBuffers_;
 	};
@@ -225,4 +225,16 @@ private:
 	VkRenderPass rpLoadColorClearDepth_;
 	VkRenderPass rpClearColorClearDepth_;
 
+	VkPipelineCache pipelineCache2D_;
+
+	// Basic shaders
+	VkShaderModule fsBasicTex_;
+	VkShaderModule vsBasicTex_;
+	VkPipeline pipelineBasicTex_;
+
+	VkSampler linearSampler_;
+	VkSampler nearestSampler_;
+
+	// Simple 2D drawing engine.
+	Vulkan2D vulkan2D_;
 };

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -503,6 +503,11 @@ void GPU_Vulkan::BeginHostFrame() {
 	textureCache_.StartFrame();
 	depalShaderCache_.Decimate();
 
+	framebufferManager_->BeginFrameVulkan();
+
+	shaderManager_->DirtyShader();
+	shaderManager_->DirtyUniform(DIRTY_ALL);
+
 	if (dumpNextFrame_) {
 		NOTICE_LOG(G3D, "DUMPING THIS FRAME");
 		dumpThisFrame_ = true;
@@ -510,11 +515,6 @@ void GPU_Vulkan::BeginHostFrame() {
 	} else if (dumpThisFrame_) {
 		dumpThisFrame_ = false;
 	}
-
-	shaderManager_->DirtyShader();
-	shaderManager_->DirtyUniform(DIRTY_ALL);
-
-	framebufferManager_->BeginFrame();
 }
 
 void GPU_Vulkan::EndHostFrame() {
@@ -840,6 +840,7 @@ void GPU_Vulkan::Execute_Prim(u32 op, u32 diff) {
 
 	// This also makes skipping drawing very effective.
 	framebufferManager_->SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
+
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB)) {
 		drawEngine_.SetupVertexDecoder(gstate.vertType);
 		// Rough estimate, not sure what's correct.

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -54,7 +54,7 @@ static const DeclTypeInfo VComp[] = {
 	{ VK_FORMAT_R16G16_UINT, "R16G16_UINT" }, // DEC_U16A_2,
 };
 
-void VertexAttribSetup(VkVertexInputAttributeDescription *attr, int fmt, int offset, PspAttributeLocation location) {
+static void VertexAttribSetup(VkVertexInputAttributeDescription *attr, int fmt, int offset, PspAttributeLocation location) {
 	attr->location = (uint32_t)location;
 	attr->binding = 0;
 	attr->format = VComp[fmt].type;
@@ -64,7 +64,7 @@ void VertexAttribSetup(VkVertexInputAttributeDescription *attr, int fmt, int off
 // Returns the number of attributes that were set.
 // We could cache these AttributeDescription arrays (with pspFmt as the key), but hardly worth bothering
 // as we will only call this code when we need to create a new VkPipeline.
-int SetupVertexAttribs(VkVertexInputAttributeDescription attrs[], const DecVtxFormat &decFmt) {
+static int SetupVertexAttribs(VkVertexInputAttributeDescription attrs[], const DecVtxFormat &decFmt) {
 	int count = 0;
 	if (decFmt.w0fmt != 0) {
 		VertexAttribSetup(&attrs[count++], decFmt.w0fmt, decFmt.w0off, PspAttributeLocation::W1);
@@ -89,7 +89,7 @@ int SetupVertexAttribs(VkVertexInputAttributeDescription attrs[], const DecVtxFo
 	return count;
 }
 
-int SetupVertexAttribsPretransformed(VkVertexInputAttributeDescription attrs[], const DecVtxFormat &decFmt) {
+static int SetupVertexAttribsPretransformed(VkVertexInputAttributeDescription attrs[], const DecVtxFormat &decFmt) {
 	int count = 0;
 	VertexAttribSetup(&attrs[count++], DEC_FLOAT_4, 0, PspAttributeLocation::POSITION);
 	VertexAttribSetup(&attrs[count++], DEC_FLOAT_3, 16, PspAttributeLocation::TEXCOORD);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -748,7 +748,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VkCommandBuffer cmd, TexCacheEn
 	}
 	if (depal) {
 		// VulkanTexture *clutTexture = depalShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBuf_);
-		VulkanFBO *depalFBO = framebufferManager_->GetTempFBO(framebuffer->renderWidth, framebuffer->renderHeight, VK_FBO_8888);
+		// VulkanFBO *depalFBO = framebufferManager_->GetTempFBO(framebuffer->renderWidth, framebuffer->renderHeight, VK_FBO_8888);
 
 		//depalFBO->BeginPass(cmd);
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1288,6 +1288,8 @@ void TextureCacheVulkan::SetTexture(VulkanPushBuffer *uploadBuffer) {
 			delete entry->vkTex;
 			entry->vkTex = nullptr;
 		}
+	} else {
+		// TODO: If reusing an existing texture object, we must transition it into the correct layout.
 	}
 	lastBoundTexture = entry->vkTex;
 
@@ -1306,6 +1308,8 @@ void TextureCacheVulkan::SetTexture(VulkanPushBuffer *uploadBuffer) {
 			entry->vkTex->texture_->UploadMip(i, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 		}
 	}
+
+	entry->vkTex->texture_->EndCreate();
 
 	gstate_c.textureFullAlpha = entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL;
 	gstate_c.textureSimpleAlpha = entry->GetAlphaStatus() != TexCacheEntry::STATUS_ALPHA_UNKNOWN;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -108,6 +108,7 @@ Vulkan2D::~Vulkan2D() {
 		vulkan_->Delete().QueueDeleteDescriptorPool(frameData_[i].descPool);
 	}
 	vkDestroyDescriptorSetLayout(device, descriptorSetLayout_, nullptr);
+	vkDestroyPipelineLayout(device, pipelineLayout_, nullptr);
 }
 
 void Vulkan2D::BeginFrame() {

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -15,6 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "base/basictypes.h"
+#include "Common/Log.h"
+#include "Common/Vulkan/VulkanContext.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
 VulkanFBO::VulkanFBO() : color_(nullptr), depthStencil_(nullptr) {}
@@ -42,4 +45,291 @@ void VulkanFBO::Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int wi
 	fb.layers = 1;
 
 	vkCreateFramebuffer(vulkan->GetDevice(), &fb, nullptr, &framebuffer_);
+}
+
+Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
+	// All resources we need for PSP drawing. Usually only bindings 0 and 2-4 are populated.
+	VkDescriptorSetLayoutBinding bindings[2] = {};
+	bindings[0].descriptorCount = 1;
+	bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+	bindings[0].binding = 0;
+	bindings[1].descriptorCount = 1;
+	bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+	bindings[1].binding = 1;
+
+	VkDevice device = vulkan_->GetDevice();
+
+	VkDescriptorSetLayoutCreateInfo dsl;
+	dsl.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+	dsl.pNext = nullptr;
+	dsl.bindingCount = 2;
+	dsl.pBindings = bindings;
+	VkResult res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &descriptorSetLayout_);
+	assert(VK_SUCCESS == res);
+
+	VkDescriptorPoolSize dpTypes[1];
+	dpTypes[0].descriptorCount = 200;
+	dpTypes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+
+	VkDescriptorPoolCreateInfo dp;
+	dp.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+	dp.pNext = nullptr;
+	dp.flags = 0;   // Don't want to mess around with individually freeing these, let's go fixed each frame and zap the whole array. Might try the dynamic approach later.
+	dp.maxSets = 200;
+	dp.pPoolSizes = dpTypes;
+	dp.poolSizeCount = ARRAY_SIZE(dpTypes);
+	for (int i = 0; i < 2; i++) {
+		VkResult res = vkCreateDescriptorPool(vulkan_->GetDevice(), &dp, nullptr, &frameData_[i].descPool);
+		assert(VK_SUCCESS == res);
+	}
+
+	VkPushConstantRange push = {};
+	push.offset = 0;
+	push.size = 32;
+	push.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+	VkPipelineLayoutCreateInfo pl;
+	pl.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+	pl.pNext = nullptr;
+	pl.pPushConstantRanges = &push;
+	pl.pushConstantRangeCount = 1;
+	pl.setLayoutCount = 1;
+	pl.pSetLayouts = &descriptorSetLayout_;
+	pl.flags = 0;
+	res = vkCreatePipelineLayout(device, &pl, nullptr, &pipelineLayout_);
+	assert(VK_SUCCESS == res);
+}
+
+Vulkan2D::~Vulkan2D() {
+	VkDevice device = vulkan_->GetDevice();
+	for (int i = 0; i < 2; i++) {
+		vulkan_->Delete().QueueDeleteDescriptorPool(frameData_[i].descPool);
+	}
+	vkDestroyDescriptorSetLayout(device, descriptorSetLayout_, nullptr);
+}
+
+void Vulkan2D::BeginFrame() {
+	FrameData &frame = frameData_[curFrame_];
+	frame.descSets.clear();
+	vkResetDescriptorPool(vulkan_->GetDevice(), frame.descPool, 0);
+}
+
+void Vulkan2D::EndFrame() {
+	curFrame_ = (curFrame_ + 1) & 1;
+}
+
+VkDescriptorSet Vulkan2D::GetDescriptorSet(VkImageView tex1, VkSampler sampler1, VkImageView tex2, VkSampler sampler2) {
+	DescriptorSetKey key;
+	key.imageView[0] = tex1;
+	key.imageView[1] = tex2;
+	key.sampler[0] = sampler1;
+	key.sampler[1] = sampler2;
+
+	FrameData *frame = &frameData_[curFrame_ & 1];
+	auto iter = frame->descSets.find(key);
+	if (iter != frame->descSets.end()) {
+		return iter->second;
+	}
+
+	// Didn't find one in the frame descriptor set cache, let's make a new one.
+	// We wipe the cache on every frame.
+
+	VkDescriptorSet desc;
+	VkDescriptorSetAllocateInfo descAlloc;
+	VkDescriptorImageInfo tex;
+	descAlloc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+	descAlloc.pNext = nullptr;
+	descAlloc.pSetLayouts = &descriptorSetLayout_;
+	descAlloc.descriptorPool = frame->descPool;
+	descAlloc.descriptorSetCount = 1;
+	VkResult result = vkAllocateDescriptorSets(vulkan_->GetDevice(), &descAlloc, &desc);
+	assert(result == VK_SUCCESS);
+
+	// We just don't write to the slots we don't care about.
+	VkWriteDescriptorSet writes[4];
+	memset(writes, 0, sizeof(writes));
+	// Main and sub textures
+	int n = 0;
+	if (tex1) {
+		// TODO: Also support LAYOUT_GENERAL to be able to texture from framebuffers without transitioning them?
+		tex.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		tex.imageView = tex1;
+		tex.sampler = sampler1;
+		writes[n].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[n].pNext = nullptr;
+		writes[n].dstBinding = 0;
+		writes[n].pImageInfo = &tex;
+		writes[n].descriptorCount = 1;
+		writes[n].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		writes[n].dstSet = desc;
+		n++;
+	}
+	if (tex2) {
+		// TODO: Also support LAYOUT_GENERAL to be able to texture from framebuffers without transitioning them?
+		tex.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		tex.imageView = tex2;
+		tex.sampler = sampler2;
+		writes[n].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[n].pNext = nullptr;
+		writes[n].dstBinding = 1;
+		writes[n].pImageInfo = &tex;
+		writes[n].descriptorCount = 1;
+		writes[n].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		writes[n].dstSet = desc;
+		n++;
+	}
+
+	vkUpdateDescriptorSets(vulkan_->GetDevice(), n, writes, 0, nullptr);
+
+	frame->descSets[key] = desc;
+	return desc;
+}
+
+VkPipeline Vulkan2D::GetPipeline(VkPipelineCache cache, VkRenderPass rp, VkShaderModule vs, VkShaderModule fs) {
+	PipelineKey key;
+	key.vs = vs;
+	key.fs = fs;
+
+	auto iter = pipelines_.find(key);
+	if (iter != pipelines_.end()) {
+		return iter->second;
+	}
+
+	VkPipelineColorBlendAttachmentState blend0 = {};
+	blend0.blendEnable = false;
+	blend0.colorWriteMask = 0xF;
+
+	VkPipelineColorBlendStateCreateInfo cbs = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
+	cbs.pAttachments = &blend0;
+	cbs.attachmentCount = 1;
+	cbs.logicOpEnable = false;
+
+	VkPipelineDepthStencilStateCreateInfo dss = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
+	dss.depthBoundsTestEnable = false;
+	dss.stencilTestEnable = false;
+	dss.depthTestEnable = false;
+
+	VkDynamicState dynamicStates[2];
+	int numDyn = 0;
+	dynamicStates[numDyn++] = VK_DYNAMIC_STATE_SCISSOR;
+	dynamicStates[numDyn++] = VK_DYNAMIC_STATE_VIEWPORT;
+
+	VkPipelineDynamicStateCreateInfo ds = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
+	ds.pDynamicStates = dynamicStates;
+	ds.dynamicStateCount = numDyn;
+
+	VkPipelineRasterizationStateCreateInfo rs = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
+	rs.lineWidth = 1.0f;
+
+	VkPipelineMultisampleStateCreateInfo ms = { VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
+	ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+	VkPipelineShaderStageCreateInfo ss[2] = {};
+	ss[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+	ss[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+	ss[0].module = vs;
+	ss[0].pName = "main";
+	ss[0].flags = 0;
+	ss[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+	ss[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+	ss[1].module = fs;
+	ss[1].pName = "main";
+	ss[1].flags = 0;
+
+	VkPipelineInputAssemblyStateCreateInfo inputAssembly = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
+	inputAssembly.flags = 0;
+	inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+	inputAssembly.primitiveRestartEnable = true;
+
+	VkVertexInputAttributeDescription attrs[2];
+	int attributeCount = 2;
+	attrs[0].binding = 0;
+	attrs[0].format = VK_FORMAT_R32G32B32_SFLOAT;
+	attrs[0].location = 0;
+	attrs[0].offset = 0;
+	attrs[1].binding = 0;
+	attrs[1].format = VK_FORMAT_R32G32_SFLOAT;
+	attrs[1].location = 1;
+	attrs[1].offset = 12;
+	int vertexStride = 12 + 8;
+
+	VkVertexInputBindingDescription ibd = {};
+	ibd.binding = 0;
+	ibd.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+	ibd.stride = vertexStride;
+
+	VkPipelineVertexInputStateCreateInfo vis = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
+	vis.vertexBindingDescriptionCount = 1;
+	vis.pVertexBindingDescriptions = &ibd;
+	vis.vertexAttributeDescriptionCount = attributeCount;
+	vis.pVertexAttributeDescriptions = attrs;
+
+	VkPipelineViewportStateCreateInfo views = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
+	views.viewportCount = 1;
+	views.scissorCount = 1;
+	views.pViewports = nullptr;  // dynamic
+	views.pScissors = nullptr;  // dynamic
+
+	VkGraphicsPipelineCreateInfo pipe = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
+	pipe.flags = 0;
+	pipe.stageCount = 2;
+	pipe.pStages = ss;
+	pipe.basePipelineIndex = 0;
+
+	pipe.pColorBlendState = &cbs;
+	pipe.pDepthStencilState = &dss;
+	pipe.pRasterizationState = &rs;
+
+	// We will use dynamic viewport state.
+	pipe.pVertexInputState = &vis;
+	pipe.pViewportState = &views;
+	pipe.pTessellationState = nullptr;
+	pipe.pDynamicState = &ds;
+	pipe.pInputAssemblyState = &inputAssembly;
+	pipe.pMultisampleState = &ms;
+	pipe.layout = pipelineLayout_;
+	pipe.basePipelineHandle = VK_NULL_HANDLE;
+	pipe.basePipelineIndex = 0;
+	pipe.renderPass = rp;
+	pipe.subpass = 0;
+
+	VkPipeline pipeline;
+	VkResult result = vkCreateGraphicsPipelines(vulkan_->GetDevice(), cache, 1, &pipe, nullptr, &pipeline);
+	if (result == VK_SUCCESS) {
+		pipelines_[key] = pipeline;
+		return pipeline;
+	} else {
+		return VK_NULL_HANDLE;
+	}
+}
+
+void Vulkan2D::BindDescriptorSet(VkCommandBuffer cmd, VkImageView tex1, VkSampler sampler1) {
+	VkDescriptorSet descSet = GetDescriptorSet(tex1, sampler1, VK_NULL_HANDLE, VK_NULL_HANDLE);
+	vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout_, 0, 1, &descSet, 0, nullptr);
+}
+
+VkShaderModule CompileShaderModule(VulkanContext *vulkan, VkShaderStageFlagBits stage, const char *code, std::string *error) {
+	std::vector<uint32_t> spirv;
+	bool success = GLSLtoSPV(stage, code, spirv, error);
+	if (!error->empty()) {
+		if (success) {
+			ERROR_LOG(G3D, "Warnings in shader compilation!");
+		} else {
+			ERROR_LOG(G3D, "Error in shader compilation!");
+		}
+		ERROR_LOG(G3D, "Messages: %s", error->c_str());
+		ERROR_LOG(G3D, "Shader source:\n%s", code);
+		OutputDebugStringUTF8("Messages:\n");
+		OutputDebugStringUTF8(error->c_str());
+		return VK_NULL_HANDLE;
+	} else {
+		VkShaderModule module;
+		if (vulkan->CreateShaderModule(spirv, &module)) {
+			return module;
+		} else {
+			return VK_NULL_HANDLE;
+		}
+	}
 }

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <tuple>
+#include <map>
+
+#include "Common/Vulkan/VulkanContext.h"
 #include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanImage.h"
 
@@ -64,3 +68,67 @@ private:
 	// This point specifically to color and depth.
 	VkFramebuffer framebuffer_;
 };
+
+// Similar to a subset of Thin3D, but separate.
+// This is used for things like postprocessing shaders, depal, etc.
+// No UBO data is used, only PushConstants.
+// No transform matrices, only post-proj coordinates.
+// Two textures can be sampled.
+class Vulkan2D {
+public:
+	Vulkan2D(VulkanContext *vulkan);
+	~Vulkan2D();
+
+	VkPipeline GetPipeline(VkPipelineCache cache, VkRenderPass rp, VkShaderModule vs, VkShaderModule fs);
+
+	void BeginFrame();
+	void EndFrame();
+
+	VkDescriptorSet GetDescriptorSet(VkImageView tex1, VkSampler sampler1, VkImageView tex2, VkSampler sampler2);
+
+	// Simple way
+	void BindDescriptorSet(VkCommandBuffer cmd, VkImageView tex1, VkSampler sampler1);
+
+	struct Vertex {
+		float x, y, z;
+		float u, v;
+	};
+
+private:
+	VulkanContext *vulkan_;
+	VkDescriptorSetLayout descriptorSetLayout_;
+	VkPipelineLayout pipelineLayout_;
+
+	// Yes, another one...
+	struct DescriptorSetKey {
+		VkImageView imageView[2];
+		VkSampler sampler[2];
+
+		bool operator < (const DescriptorSetKey &other) const {
+			return std::tie(imageView[0], imageView[1], sampler[0], sampler[1]) <
+				std::tie(other.imageView[0], other.imageView[1], other.sampler[0], other.sampler[1]);
+		}
+	};
+
+	struct PipelineKey {
+		VkShaderModule vs;
+		VkShaderModule fs;
+		VkRenderPass rp;
+		bool operator < (const PipelineKey &other) const {
+			return std::tie(vs, fs, rp) < std::tie(other.vs, other.fs, other.rp);
+		}
+	};
+
+	struct FrameData {
+		VkDescriptorPool descPool;
+		std::map<DescriptorSetKey, VkDescriptorSet> descSets;
+	};
+
+	FrameData frameData_[2];
+	int curFrame_;
+
+	std::map<PipelineKey, VkPipeline> pipelines_;
+};
+
+
+VkShaderModule CompileShaderModule(VulkanContext *vulkan, VkShaderStageFlagBits stage, const char *code, std::string *error);

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -25,6 +25,24 @@
 // VulkanFBO is an approximation of the FBO concept the other backends use
 // to make things as similar as possible without being suboptimal.
 //
+// An FBO can be rendered to and used as a texture multiple times in a frame.
+// Even at multiple sizes, while keeping the same contents.
+// With GL or D3D we'd just rely on the driver managing duplicates for us, but in
+// Vulkan we will want to be able to batch up the whole frame and reorder passes
+// so that all textures are ready before the main scene, instead of switching back and
+// forth. This comes at a memory cost but will be worth it.
+//
+// When we render to a scene, then render to a texture, then go back to the scene and
+// use that texture, we will register that as a dependency. Then we will walk the DAG
+// to find the final order of command buffers, and execute it.
+//
+// Each FBO will get its own command buffer for each pass. 
+
+// 
+struct VulkanFBOPass {
+	VkCommandBuffer cmd;
+};
+
 class VulkanFBO {
 public:
 	VulkanFBO();

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -128,6 +128,9 @@ static VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugRep
 	// https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/issues/121
 	if (msgCode == 6 && (!memcmp(pMsg, "Cannot map", 10) || !memcmp(pMsg, "Cannot sub", 10)))
 		return false;
+	// And for dynamic offsets.
+	if (msgCode == 62 && (!memcmp(pMsg, "VkDesc", 6)))
+		return false;
 
 #ifdef _WIN32
 	OutputDebugStringA(message.str().c_str());


### PR DESCRIPTION
This currently implements some basic 2D drawing infrastructure separate from both the PSP rendering and Thin3D, for internal use by the framebuffer manager, and a first feature that uses it - DrawPixels.

This makes some videos display that didn't before in the Vulkan backend, like the GTA intros.

No actual rendering to framebuffers is implemented yet.
