### PR TITLE
WIP - Vulkan buffered rendering

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -124,7 +124,6 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_ARCH_32=1;_M_IX86=1;NDEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -156,7 +155,6 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;WIN32;_ARCH_64=1;_M_X64=1;NDEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -1279,6 +1279,11 @@ void TransitionImageLayout(VkCommandBuffer cmd, VkImage image, VkImageAspectFlag
 		/* Make sure any Copy or CPU writes to image are flushed */
 		if (old_image_layout != VK_IMAGE_LAYOUT_UNDEFINED) {
 			image_memory_barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+			if (old_image_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
+				image_memory_barrier.srcAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			} else if (old_image_layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) {
+				image_memory_barrier.srcAccessMask |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+			}
 		}
 		image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 	}

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -1,4 +1,3 @@
-#define __STDC_LIMIT_MACROS
 #include <cstdlib>
 #include <cstdint>
 #include <assert.h>
@@ -1288,6 +1287,13 @@ void TransitionImageLayout(VkCommandBuffer cmd, VkImage image, VkImageAspectFlag
 			}
 		}
 		image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+	}
+
+	if (old_image_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+		image_memory_barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		if (new_image_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+			image_memory_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+		}
 	}
 
 	if (new_image_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -1255,6 +1255,8 @@ void TransitionImageLayout(VkCommandBuffer cmd, VkImage image, VkImageAspectFlag
 	image_memory_barrier.subresourceRange.baseMipLevel = 0;
 	image_memory_barrier.subresourceRange.levelCount = 1;
 	image_memory_barrier.subresourceRange.layerCount = 1;
+	image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 	if (old_image_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
 		image_memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
 	}

--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -370,8 +370,8 @@ void VulkanTexture::EndCreate() {
 		VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
-void VulkanTexture::Transition(VkCommandBuffer cmd, VkImageLayout target) {
-	TransitionImageLayout(cmd, image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+void VulkanTexture::Transition(VkCommandBuffer cmd, VkImageLayout from, VkImageLayout target) {
+	TransitionImageLayout(cmd, image, VK_IMAGE_ASPECT_COLOR_BIT, from, target);
 }
 
 void VulkanTexture::Destroy() {

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -11,7 +11,7 @@ public:
 	VulkanTexture(VulkanContext *vulkan, VulkanDeviceAllocator *allocator = nullptr)
 		: vulkan_(vulkan), image(VK_NULL_HANDLE), mem(VK_NULL_HANDLE), view(VK_NULL_HANDLE),
 		tex_width(0), tex_height(0), numMips_(1), format_(VK_FORMAT_UNDEFINED),
-		mappableImage(VK_NULL_HANDLE), mappableMemory(VK_NULL_HANDLE), needStaging(false),
+		mappableImage(VK_NULL_HANDLE), mappableMemory(VK_NULL_HANDLE),
 		allocator_(allocator), offset_(0) {
 		memset(&mem_reqs, 0, sizeof(mem_reqs));
 	}
@@ -37,6 +37,10 @@ public:
 	int GetNumMips() const { return numMips_; }
 	void Destroy();
 
+	// Outside of render passes or during init only! Use vkCmdClearAttachment inside them.
+	// NOTE: imageLayout must be transferDstOptimal or general.
+	void ClearColor(VkCommandBuffer cmd, uint32_t color, VkImageLayout imageLayout);
+
 	// Used in image copies, etc.
 	VkImage GetImage() const { return image; }
 
@@ -45,6 +49,8 @@ public:
 
 	int32_t GetWidth() const { return tex_width; }
 	int32_t GetHeight() const { return tex_height; }
+
+	void Transition(VkCommandBuffer cmd, VkImageLayout target);
 
 private:
 	void CreateMappableImage();
@@ -61,5 +67,4 @@ private:
 	VkMemoryRequirements mem_reqs;
 	VulkanDeviceAllocator *allocator_;
 	size_t offset_;
-	bool needStaging;
 };

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -50,7 +50,7 @@ public:
 	int32_t GetWidth() const { return tex_width; }
 	int32_t GetHeight() const { return tex_height; }
 
-	void Transition(VkCommandBuffer cmd, VkImageLayout target);
+	void Transition(VkCommandBuffer cmd, VkImageLayout from, VkImageLayout target);
 
 private:
 	void CreateMappableImage();

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -406,6 +406,8 @@ void SoftwareTransform(
 
 	// Here's the best opportunity to try to detect rectangles used to clear the screen, and
 	// replace them with real clears. This can provide a speedup on certain mobile chips.
+	// Potentially we could also detect things like textured rectangles that cover the screen
+	// like FMV.
 	//
 	// An alternative option is to simply ditch all the verts except the first and last to create a single
 	// rectangle out of many. Quite a small optimization though.

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -128,7 +128,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>../common;..;../ext;../ext/native;../ext/native/ext/glew;</AdditionalIncludeDirectories>
@@ -154,7 +153,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>../common;..;../ext;../ext/native;../ext/native/ext/glew;</AdditionalIncludeDirectories>

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -64,6 +64,7 @@ enum {
 DrawEngineVulkan::DrawEngineVulkan(VulkanContext *vulkan)
 	:
 	vulkan_(vulkan), 
+	cmd_(VK_NULL_HANDLE),
 	prevPrim_(GE_PRIM_INVALID),
 	lastVTypeID_(-1),
 	pipelineManager_(nullptr),
@@ -623,7 +624,7 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 	uint32_t vbOffset = 0;
 	
 	if (useHWTransform) {
-		// We don't detect clears in this path, so here we can switch framebuffers if necessary.
+		framebufferManager_->NotifyDraw();
 
 		int vertexCount = 0;
 		int maxIndex = 0;
@@ -740,6 +741,8 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 		// Only here, where we know whether to clear or to draw primitives, should we actually set the current framebuffer! Because that gives use the opportunity
 		// to use a "pre-clear" render pass, for high efficiency on tilers.
 		if (result.action == SW_DRAW_PRIMITIVES) {
+			framebufferManager_->NotifyDraw();
+
 			VulkanPipelineRasterStateKey pipelineKey;
 			VulkanDynamicState dynState;
 			ConvertStateToVulkanKey(*framebufferManager_, shaderManager_, prim, pipelineKey, dynState);

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -381,7 +381,7 @@ bool FramebufferManagerVulkan::UpdateRenderPass() {
 			// to draw something into a new one. Quite likely in this situation that we do not
 			// need to care about the existing contents of the framebuffer, if blending is off.
 		} else {
-			DebugBreak();
+			Crash();
 		}
 	}
 
@@ -883,7 +883,7 @@ void FramebufferManagerVulkan::BlitFramebufferDepth(VirtualFramebuffer *src, Vir
 
 VulkanTexture *FramebufferManagerVulkan::GetFramebufferColor(u32 fbRawAddress, VirtualFramebuffer *framebuffer, int flags) {
 	if (!framebuffer) {
-		DebugBreak();
+		Crash();
 		return nullptr;
 	}
 
@@ -1002,7 +1002,7 @@ void FramebufferManagerVulkan::SubmitRenderPasses(std::vector<FBRenderPass *> &p
 	FBRenderPass *last = nullptr;
 	for (auto &rp : passOrder) {
 		if (rp == last) {
-			DebugBreak();
+			Crash();
 		}
 		last = rp;
 		switch (rp->state) {
@@ -1683,7 +1683,7 @@ void FramebufferManagerVulkan::BeginFrameVulkan() {
 
 void FramebufferManagerVulkan::EndFrame() {
 	if (pendingDependency_) {
-		DebugBreak();
+		Crash();
 	}
 
 	if (resized_) {

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -465,10 +465,10 @@ void FramebufferManagerVulkan::DrawTexture(VulkanTexture *texture, float x, floa
 		return;
 
 	float texCoords[8] = {
-		u0,v0,
-		u1,v0,
-		u1,v1,
-		u0,v1,
+		u0, v0,
+		u1, v0,
+		u1, v1,
+		u0, v1,
 	};
 
 	if (uvRotation != ROTATION_LOCKED_HORIZONTAL) {
@@ -512,24 +512,24 @@ void FramebufferManagerVulkan::DrawTexture(VulkanTexture *texture, float x, floa
 	vkCmdDraw(cmd, 4, 1, 0, 0);
 }
 
-void FramebufferManagerVulkan::DestroyFramebuf(VirtualFramebuffer *v) {
-	textureCache_->NotifyFramebuffer(v->fb_address, v, NOTIFY_FB_DESTROYED);
-	if (v->fbo_vk) {
-		delete v->fbo_vk;
-		v->fbo_vk = 0;
+void FramebufferManagerVulkan::DestroyFramebuf(VirtualFramebuffer *vfb) {
+	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED);
+	if (vfb->fbo_vk) {
+		delete vfb->fbo_vk;
+		vfb->fbo_vk = 0;
 	}
 
 	// Wipe some pointers
-	if (currentRenderVfb_ == v)
+	if (currentRenderVfb_ == vfb)
 		currentRenderVfb_ = 0;
-	if (displayFramebuf_ == v)
+	if (displayFramebuf_ == vfb)
 		displayFramebuf_ = 0;
-	if (prevDisplayFramebuf_ == v)
+	if (prevDisplayFramebuf_ == vfb)
 		prevDisplayFramebuf_ = 0;
-	if (prevPrevDisplayFramebuf_ == v)
+	if (prevPrevDisplayFramebuf_ == vfb)
 		prevPrevDisplayFramebuf_ = 0;
 
-	delete v;
+	delete vfb;
 }
 
 void FramebufferManagerVulkan::RebindFramebuffer() {
@@ -1447,7 +1447,7 @@ void FramebufferManagerVulkan::BeginFrameVulkan() {
 
 	frame.push_->Reset();
 	frame.push_->Begin(vulkan_);
-	
+
 	if (!useBufferedRendering_) {
 		// We only use a single command buffer in this case.
 		curCmd_ = vulkan_->GetSurfaceCommandBuffer();
@@ -1689,7 +1689,6 @@ bool FramebufferManagerVulkan::GetStencilbuffer(u32 fb_address, int fb_stride, G
 	return false;
 }
 
-
 void FramebufferManagerVulkan::ClearBuffer(bool keepState) {
 	// keepState is irrelevant.
 	if (!currentRenderVfb_) {
@@ -1707,4 +1706,12 @@ void FramebufferManagerVulkan::ClearBuffer(bool keepState) {
 	rc.rect.extent.width = currentRenderVfb_->bufferWidth;
 	rc.rect.extent.height = currentRenderVfb_->bufferHeight;
 	vkCmdClearAttachments(curCmd_, 2, clear, 1, &rc);
+}
+
+void FramebufferManagerVulkan::GetRenderPassInfo(char *buf, size_t bufsize) {
+	if (!useBufferedRendering_) {
+		snprintf(buf, bufsize, "(non-buffered rendering - single render pass)");
+		return;
+	}
+	snprintf(buf, bufsize, "(TODO)");
 }

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -89,7 +89,13 @@ struct FBRenderPass {
 	std::vector<FBRenderPass *> dependencies;
 	bool executed;
 	int resumes;
+	int id;
 	RPState state;
+
+	// Statistics/info. not used for function.
+	bool isSecondary;
+	int numDraws;
+	int numClears;
 
 	void AddDependency(FBRenderPass *dep);
 };
@@ -225,6 +231,9 @@ private:
 	std::vector<FBRenderPass *> passOrder_;
 	FBRenderPass *curRenderPass_;
 	VirtualFramebuffer *renderPassVFB_;
+	
+	// When texturing, is set so that when we switch RP, this dependency will be added.
+	FBRenderPass *pendingDependency_;
 
 	enum {
 		MAX_COMMAND_BUFFERS = 32,

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -146,6 +146,8 @@ public:
 		DoNotifyDraw();
 	}
 
+	void GetRenderPassInfo(char *buf, size_t bufsize);
+
 protected:
 	virtual void DisableState() override {}
 	virtual void ClearBuffer(bool keepState = false);
@@ -160,7 +162,6 @@ protected:
 	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
 	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
-
 
 private:
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -1956,6 +1956,9 @@ void GPU_Vulkan::DeviceLost() {
 void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	const DrawEngineVulkanStats &drawStats = drawEngine_.GetStats();
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
+
+	char rpInfo[1024];
+	framebufferManager_->GetRenderPassInfo(rpInfo, sizeof(rpInfo));
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
 		"Draw calls: %i, flushes %i\n"
@@ -1968,7 +1971,8 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		"FBOs active: %i\n"
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Vertex, Fragment, Pipelines loaded: %i, %i, %i\n"
-		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n",
+		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n"
+		"%s\n",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
 		gpuStats.numDrawCalls,
 		gpuStats.numFlushes,
@@ -1989,7 +1993,8 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		pipelineManager_->GetNumPipelines(),
 		drawStats.pushUBOSpaceUsed,
 		drawStats.pushVertexSpaceUsed,
-		drawStats.pushIndexSpaceUsed
+		drawStats.pushIndexSpaceUsed,
+		rpInfo
 	);
 }
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -173,6 +173,7 @@ private:
 	void ReinitializeInternal();
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();
+
 	static CommandInfo cmdInfo_[256];
 
 	GraphicsContext *gfxCtx_;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -512,7 +512,7 @@ void TextureCacheVulkan::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	key.magFilt = magFilt & 1;
 	key.sClamp = sClamp;
 	key.tClamp = tClamp;
-	key.maxLevel = entry.vkTex->texture_->GetNumMips() - 1;
+	key.maxLevel = entry.vkTex ? (entry.vkTex->texture_->GetNumMips() - 1) : 0;
 	/*
 	if (entry.maxLevel != 0) {
 		if (force || entry.lodBias != lodBias) {
@@ -820,18 +820,20 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VkCommandBuffer cmd, TexCacheEn
 		//depalFBO->EndPass(cmd);
 		//depalFBO->TransitionToTexture(cmd);
 		//imageView = depalFBO->GetColorImageView();
+	} else {
+		VulkanTexture *texture = framebufferManager_->GetFramebufferColor(gstate.getFrameBufRawAddress(), framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
+		imageView = texture->GetImageView();
 	}
 
 	/*
 	imageView = depalFBO->GetColorImageView();
 
 	SamplerCacheKey samplerKey;
-	framebufferManager_->RebindFramebuffer();
-	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
-	sampler = GetOrCreateSampler(samplerKey);
 	*/
 
+	
 	SamplerCacheKey key;
+	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, key);
 	UpdateSamplingParams(*nextTexture_, key);
 	key.mipEnable = false;
 	sampler = samplerCache_.GetOrCreateSampler(key);

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -32,9 +32,11 @@ void VulkanFBO::Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int wi
 	color_ = new VulkanTexture(vulkan);
 	depthStencil_ = new VulkanTexture(vulkan);
 
+	VkFormat depthFormat = vulkan->GetDeviceInfo().preferredDepthStencilFormat;
+
 	VkImageCreateFlags flags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	color_->CreateDirect(width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, flags | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, nullptr);
-	depthStencil_->CreateDirect(width, height, 1, VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, flags | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, nullptr);
+	depthStencil_->CreateDirect(width, height, 1, depthFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, nullptr);
 
 	// color_->ClearColor(vulkan->GetInitCommandBuffer(), 0x00FF00FF, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
@@ -63,7 +65,7 @@ void VulkanFBO::Destroy(VulkanContext *vulkan) {
 	}
 }
 
-Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
+Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan), curFrame_(0) {
 	// All resources we need for PSP drawing. Usually only bindings 0 and 2-4 are populated.
 	VkDescriptorSetLayoutBinding bindings[2] = {};
 	bindings[0].descriptorCount = 1;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -20,18 +20,23 @@
 #include "Common/Vulkan/VulkanContext.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
-VulkanFBO::VulkanFBO() : color_(nullptr), depthStencil_(nullptr) {}
+VulkanFBO::VulkanFBO() : color_(nullptr), depthStencil_(nullptr), framebuffer_(VK_NULL_HANDLE) {}
 
 VulkanFBO::~VulkanFBO() {
+	assert(color_ == nullptr);
 	delete color_;
 	delete depthStencil_;
 }
 
 void VulkanFBO::Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int width, int height, VkFormat color_Format) {
 	color_ = new VulkanTexture(vulkan);
+	depthStencil_ = new VulkanTexture(vulkan);
+
 	VkImageCreateFlags flags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	color_->CreateDirect(width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, flags | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, nullptr);
 	depthStencil_->CreateDirect(width, height, 1, VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, flags | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, nullptr);
+
+	// color_->ClearColor(vulkan->GetInitCommandBuffer(), 0x00FF00FF, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 	VkImageView views[2] = { color_->GetImageView(), depthStencil_->GetImageView() };
 
@@ -45,6 +50,17 @@ void VulkanFBO::Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int wi
 	fb.layers = 1;
 
 	vkCreateFramebuffer(vulkan->GetDevice(), &fb, nullptr, &framebuffer_);
+}
+
+void VulkanFBO::Destroy(VulkanContext *vulkan) {
+	delete color_;
+	color_ = nullptr;
+	delete depthStencil_;
+	depthStencil_ = nullptr;
+	if (framebuffer_) {
+		vulkan->Delete().QueueDeleteFramebuffer(framebuffer_);
+		framebuffer_ = VK_NULL_HANDLE;
+	}
 }
 
 Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -42,10 +42,7 @@
 //
 // Each FBO will get its own command buffer for each pass. 
 
-// 
-struct VulkanFBOPass {
-	VkCommandBuffer cmd;
-};
+struct FBRenderPass;
 
 class VulkanFBO {
 public:
@@ -55,6 +52,7 @@ public:
 	// Depth-format is chosen automatically depending on hardware support.
 	// Color format will be 32-bit RGBA.
 	void Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int width, int height, VkFormat colorFormat);
+	void Destroy(VulkanContext *vulkan);
 
 	VulkanTexture *GetColor() { return color_; }
 	VulkanTexture *GetDepthStencil() { return depthStencil_; }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -115,6 +115,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 		break;
 	case GPUBackend::VULKAN:
 		coreParam.gpuCore = GPU_VULKAN;
+		/*
 		if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
 #ifdef _WIN32
 			if (IDYES == MessageBox(MainWindow::GetHWND(), L"The Vulkan backend is not yet compatible with buffered rendering. Switch to non-buffered (WARNING: This will cause glitches with the other backends unless you switch back)", L"Vulkan Experimental Support", MB_ICONINFORMATION | MB_YESNO)) {
@@ -125,6 +126,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 			}
 #endif
 		}
+		*/
 		break;
 	}
 	if (g_Config.bSoftwareRendering) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -144,7 +144,7 @@ void GameSettingsScreen::CreateViews() {
 #else
 	renderingBackendChoice->HideChoice(2);  // D3D11
 #endif
-#if !defined(ANDROID) && !defined(_WIN32)
+#if !defined(_WIN32)
 	// TODO: Add dynamic runtime check for Vulkan support on Android
 	renderingBackendChoice->HideChoice(3);
 #endif

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -63,7 +63,7 @@ extern const char *PPSSPP_GIT_VERSION;
 #ifdef _DEBUG
 static const bool g_validate_ = true;
 #else
-static const bool g_validate_ = false;
+static const bool g_validate_ = true;
 #endif
 
 static VulkanContext *g_Vulkan;

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -63,7 +63,7 @@ extern const char *PPSSPP_GIT_VERSION;
 #ifdef _DEBUG
 static const bool g_validate_ = true;
 #else
-static const bool g_validate_ = true;
+static const bool g_validate_ = false;
 #endif
 
 static VulkanContext *g_Vulkan;

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -141,6 +141,10 @@ static VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugRep
 	if (msgCode == 63 && startsWith(pMsg, "VkDescriptorSet"))
 		return false;
 
+	if (msgCode == 16) {
+		return false;
+	}
+
 #ifdef _WIN32
 	OutputDebugStringA(message.str().c_str());
 	if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {


### PR DESCRIPTION
This is a first stab at Vulkan framebuffer support. Many things don't work, many things are missing. VulkanFBO should be able to contain multiple copies of a framebuffer (from different points of time in a frame) for example. And it seems like the render-pass-sorting won't give all the gains I hoped for because games are stupid (GTA copies the framebuffer to a small texture every frame right in the middle of rendering, which it then does nothing with, splitting a render pass, but still can't avoid it safely).

Plenty of rendering is really broken. 

I'm not sure whether to start over or keep trying to fix this :)
