### PR TITLE
Allow shader framebuffer fetch on GLES3 only

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -98,7 +98,7 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 		highpTexcoord = highpFog;
 
 		if (gstate_c.featureFlags & GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH) {
-			if (gl_extensions.GLES3 && gl_extensions.EXT_shader_framebuffer_fetch) {
+			if ((gstate_c.featureFlags & GPU_SUPPORTS_GLSL_ES_300) != 0 && gl_extensions.EXT_shader_framebuffer_fetch) {
 				WRITE(p, "#extension GL_EXT_shader_framebuffer_fetch : require\n");
 				lastFragData = "fragColor0";
 			} else if (gl_extensions.EXT_shader_framebuffer_fetch) {

--- a/GPU/GLES/GLES_GPU.cpp
+++ b/GPU/GLES/GLES_GPU.cpp
@@ -505,9 +505,10 @@ void GLES_GPU::CheckGPUFeatures() {
 	}
 
 	if (gl_extensions.EXT_shader_framebuffer_fetch || gl_extensions.NV_shader_framebuffer_fetch || gl_extensions.ARM_shader_framebuffer_fetch) {
-		// This mostly seems to cause problems. Let's keep this commented out to disable it for everyone.
-		// If found beneficial for something, we can easily add a whitelist here.
-		// features |= GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH;
+		// This has caused problems in the past.  Let's only enable on GLES3.
+		if (features & GPU_SUPPORTS_GLSL_ES_300) {
+			features |= GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH;
+		}
 	}
 	
 	if (gl_extensions.ARB_framebuffer_object || gl_extensions.EXT_framebuffer_object || gl_extensions.IsGLES) {


### PR DESCRIPTION
Note: before we did not support it properly on GLES3 devices.

I'd like to try it again.  See 293ab099bcd355aa131869b67f1bf302fe534f5e.

-[Unknown]
