### PR TITLE
Interpolate bezier patch colors/UVs using bernstein

### DIFF
--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -856,7 +856,7 @@ void DrawEngineCommon::SubmitBezier(const void *control_points, const void *indi
 
 	DispatchFlush();
 
-	// TODO: Verify correct functionality with < 4.
+	// Real hardware seems to draw nothing when given < 4 either U or V.
 	if (count_u < 4 || count_v < 4)
 		return;
 

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -32,10 +32,6 @@ struct SimpleVertex {
 	Vec3Packedf pos;
 };
 
-inline float lerp(float a, float b, float x) {
-	return a + x * (b - a);
-}
-
 // We decode all vertices into a common format for easy interpolation and stuff.
 // Not fast but can be optimized later.
 struct BezierPatch {
@@ -48,46 +44,6 @@ struct BezierPatch {
 	GEPatchPrimType primType;
 	bool computeNormals;
 	bool patchFacing;
-
-	struct SamplingParams {
-		float fracU;
-		float fracV;
-		int tl;
-		int tr;
-		int bl;
-		int br;
-
-		SamplingParams(float u, float v) {
-			u *= 3.0f;
-			v *= 3.0f;
-			int iu = (int)floorf(u);
-			int iv = (int)floorf(v);
-			int iu2 = iu + 1;
-			int iv2 = iv + 1;
-			fracU = u - iu;
-			fracV = v - iv;
-
-			if (iu2 > 3)
-				iu2 = 3;
-			if (iv2 > 3)
-				iv2 = 3;
-
-			tl = iu + 4 * iv;
-			tr = iu2 + 4 * iv;
-			bl = iu + 4 * iv2;
-			br = iu2 + 4 * iv2;
-		}
-	};
-
-	void sampleTexUV(float u, float v, float &tu, float &tv) const {
-		const SamplingParams params(u, v);
-		float upperTU = lerp(points[params.tl]->uv[0], points[params.tr]->uv[0], params.fracU);
-		float upperTV = lerp(points[params.tl]->uv[1], points[params.tr]->uv[1], params.fracU);
-		float lowerTU = lerp(points[params.bl]->uv[0], points[params.br]->uv[0], params.fracU);
-		float lowerTV = lerp(points[params.bl]->uv[1], points[params.br]->uv[1], params.fracU);
-		tu = lerp(upperTU, lowerTU, params.fracV);
-		tv = lerp(upperTV, lowerTV, params.fracV);
-	}
 };
 
 struct SplinePatchLocal {
@@ -103,7 +59,7 @@ struct SplinePatchLocal {
 	GEPatchPrimType primType;
 };
 
-enum quality {
+enum SplineQuality {
 	LOW_QUALITY = 0,
 	MEDIUM_QUALITY = 1,
 	HIGH_QUALITY = 2,

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -36,17 +36,6 @@ inline float lerp(float a, float b, float x) {
 	return a + x * (b - a);
 }
 
-// SLOW!
-inline void lerpColor(const Vec4f &a, const Vec4f &b, float x, Vec4f &out) {
-	for (int i = 0; i < 4; i++) {
-		out[i] = a[i] + x * (b[i] - a[i]);
-	}
-}
-
-inline void lerpColor(const u8 *a, const u8 *b, float x, Vec4f &out) {
-	lerpColor(Vec4f::FromRGBA(a), Vec4f::FromRGBA(b), x, out);
-}
-
 // We decode all vertices into a common format for easy interpolation and stuff.
 // Not fast but can be optimized later.
 struct BezierPatch {
@@ -89,16 +78,6 @@ struct BezierPatch {
 			br = iu2 + 4 * iv2;
 		}
 	};
-
-	// Interpolate colors between control points (bilinear, should be good enough).
-	void sampleColor(float u, float v, u8 color[4]) const {
-		const SamplingParams params(u, v);
-		Vec4f upperColor, lowerColor, resultColor;
-		lerpColor(points[params.tl]->color, points[params.tr]->color, params.fracU, upperColor);
-		lerpColor(points[params.bl]->color, points[params.br]->color, params.fracU, lowerColor);
-		lerpColor(upperColor, lowerColor, params.fracV, resultColor);
-		resultColor.ToRGBA(color);
-	}
 
 	void sampleTexUV(float u, float v, float &tu, float &tv) const {
 		const SamplingParams params(u, v);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -356,6 +356,7 @@ int main(int argc, const char* argv[])
 	g_Config.bSoftwareSkinning = true;
 	g_Config.bVertexDecoderJit = true;
 	g_Config.bBlockTransferGPU = true;
+	g_Config.iSplineBezierQuality = 2;
 
 #ifdef _WIN32
 	InitSysDirectories();


### PR DESCRIPTION
This matches my tests almost exactly.  I suspect it will help #7525.

~~I have not yet tested UV coords, they're probably interpolated this way too~~.  UV coords were also improved (exact match to my test) by using this.  Did not measure the speed impact, but I don't really think it'll be bad.  Hopefully.  This is high quality anyway.

The colors this produces are only slightly off - in a blend between red and blue, this produces e.g. (108, 0, 147) but should produce (108, 0, 148).  Pretty acceptable - otherwise it's 1:1.

Fixes #7525, fixes #4551.

-[Unknown]
