### PR TITLE
Minor improvements to bezier accuracy

### DIFF
--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -720,8 +720,7 @@ static void _BezierPatchHighQuality(u8 *&dest, u16 *&indices, int &count, int te
 				vert.nrm = Cross(derivU, derivV).Normalized();
 				if (patch.patchFacing)
 					vert.nrm *= -1.0f;
-			}
-			else {
+			} else {
 				vert.nrm.SetZero();
 			}
 
@@ -777,8 +776,8 @@ void TesselateBezierPatch(u8 *&dest, u16 *&indices, int &count, int tess_u, int 
 	}
 }
 
-
-const GEPrimitiveType primType[] = { GE_PRIM_TRIANGLES, GE_PRIM_LINES, GE_PRIM_POINTS };
+// This maps GEPatchPrimType to GEPrimitiveType.
+const GEPrimitiveType primType[] = { GE_PRIM_TRIANGLES, GE_PRIM_LINES, GE_PRIM_POINTS, GE_PRIM_POINTS };
 
 void DrawEngineCommon::SubmitSpline(const void *control_points, const void *indices, int tess_u, int tess_v, int count_u, int count_v, int type_u, int type_v, GEPatchPrimType prim_type, bool computeNormals, bool patchFacing, u32 vertType) {
 	PROFILE_THIS_SCOPE("spline");

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -871,11 +871,6 @@ void GPU_DX9::Execute_Bezier(u32 op, u32 diff) {
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 	}
 
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
-	}
-
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {
 		DEBUG_LOG_REPORT(G3D, "Bezier + morph: %i", (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT);
 	}
@@ -912,11 +907,6 @@ void GPU_DX9::Execute_Spline(u32 op, u32 diff) {
 			return;
 		}
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
-	}
-
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
 	}
 
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -1064,11 +1064,6 @@ void GPU_GLES::Execute_Bezier(u32 op, u32 diff) {
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 	}
 
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
-	}
-
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {
 		DEBUG_LOG_REPORT(G3D, "Bezier + morph: %i", (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT);
 	}
@@ -1105,11 +1100,6 @@ void GPU_GLES::Execute_Spline(u32 op, u32 diff) {
 			return;
 		}
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
-	}
-
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
 	}
 
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -921,11 +921,6 @@ void GPU_Vulkan::Execute_Bezier(u32 op, u32 diff) {
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 	}
 
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
-	}
-
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {
 		DEBUG_LOG_REPORT(G3D, "Bezier + morph: %i", (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT);
 	}
@@ -962,11 +957,6 @@ void GPU_Vulkan::Execute_Spline(u32 op, u32 diff) {
 			return;
 		}
 		indices = Memory::GetPointerUnchecked(gstate_c.indexAddr);
-	}
-
-	if (gstate.getPatchPrimitiveType() == GE_PATCHPRIM_UNKNOWN) {
-		ERROR_LOG_REPORT(G3D, "Unsupported patch primitive %x", gstate.getPatchPrimitiveType());
-		return;
 	}
 
 	if (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) {

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -554,6 +554,7 @@ enum GEPatchPrimType
 	GE_PATCHPRIM_TRIANGLES = 0,
 	GE_PATCHPRIM_LINES = 1,
 	GE_PATCHPRIM_POINTS = 2,
+	// Treated as points.
 	GE_PATCHPRIM_UNKNOWN = 3,
 };
 


### PR DESCRIPTION
Allow division of < 4, and treat UNKNOWN as POINTS.

With this, we visually match the test in hrydgard/pspautotests#185.  Lines are off-by-one and some of the colors are not exact, but in general it all works great (as expected from all the hard work put in by @xebra and @hrydgard.)

-[Unknown]
