### PR TITLE
Build fix for linux using Qt build tools. Should fix #8695.

### DIFF
--- a/Qt/Native.pro
+++ b/Qt/Native.pro
@@ -7,7 +7,7 @@ CONFIG += staticlib
 include(Settings.pri)
 
 # To support Sailfish which is stuck on GCC 4.6
-linux-g++:system($$QMAKE_CXX --version | grep "4.6."): DEFINES+=override
+linux-g++:system($$QMAKE_CXX --version | grep \"4\.6\.\"): DEFINES+=override
 
 INCLUDEPATH += $$P/ext/native
 

--- a/Qt/PPSSPP.pro
+++ b/Qt/PPSSPP.pro
@@ -10,7 +10,7 @@ else: LIBS += -lCore -lGPU -lCommon -lNative
 include(Settings.pri)
 
 # To support Sailfish which is stuck on GCC 4.6
-linux-g++:system($$QMAKE_CXX --version | grep "4.6."): DEFINES+=override
+linux-g++:system($$QMAKE_CXX --version | grep \"4\.6\.\"): DEFINES+=override
 
 lessThan(QT_MAJOR_VERSION, 5) {
 	macx: error(PPSSPP requires Qt5 for OS X but $$[QT_VERSION] was detected.)


### PR DESCRIPTION
Corrects gcc version detection. Before patch some lines in g++ --version output could be incorrectly recognized as version 4.6 and therefore keyword "override" would be declared as macro despite being known to compiler. This was leading to compile error.
