### PR TITLE
Allocate more samplers in Vulkan, other fixes

### DIFF
--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1092,7 +1092,7 @@ void TextureCacheVulkan::SetTexture(VulkanPushBuffer *uploadBuffer) {
 			}
 		}
 
-		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && g_Config.iTexScalingLevel != 1 && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
+		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && standardScaleFactor_ != 1 && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
 			if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
 				// INFO_LOG(G3D, "Reloading texture to do the scaling we skipped..");
 				match = false;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -147,7 +147,12 @@ TextureCacheVulkan::TextureCacheVulkan(VulkanContext *vulkan)
 TextureCacheVulkan::~TextureCacheVulkan() {
 	Clear(true);
 	allocator_->Destroy();
-	delete allocator_;
+
+	// We have to delete on queue, so this can free its queued deletions.
+	vulkan_->Delete().QueueCallback([](void *ptr) {
+		auto allocator = static_cast<VulkanDeviceAllocator *>(ptr);
+		delete allocator;
+	}, allocator_);
 }
 
 void TextureCacheVulkan::DownloadFramebufferForClut(u32 clutAddr, u32 bytes) {


### PR DESCRIPTION
Ran into an area that used 104 textures per frame, which is 208 descriptors at a time.

I know these numbers were initially lower, and I'm not really sure what cap they might have, so I figured we could retry on allocation failure.  Should I increase the numbers more?  I suppose a game could use 257 textures possibly...

-[Unknown]
