### PR TITLE
Apply more constant propagation to IR

### DIFF
--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -182,13 +182,13 @@ void IRJit::Comp_RType3(MIPSOpcode op) {
 	}
 }
 
-void IRJit::CompShiftImm(MIPSOpcode op, IROp shiftOpConst, int sa) {
+void IRJit::CompShiftImm(MIPSOpcode op, IROp shiftOpImm, int sa) {
 	MIPSGPReg rd = _RD;
 	MIPSGPReg rt = _RT;
-	ir.Write(shiftOpConst, rd, rt, sa);
+	ir.Write(shiftOpImm, rd, rt, sa);
 }
 
-void IRJit::CompShiftVar(MIPSOpcode op, IROp shiftOp, IROp shiftOpConst) {
+void IRJit::CompShiftVar(MIPSOpcode op, IROp shiftOp, IROp shiftOpImm) {
 	MIPSGPReg rd = _RD;
 	MIPSGPReg rt = _RT;
 	MIPSGPReg rs = _RS;

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -143,10 +143,6 @@ int IRWriter::AddConstantFloat(float value) {
 	return AddConstant(val);
 }
 
-void IRWriter::Simplify() {
-	SimplifyInPlace(&insts_[0], (int)insts_.size(), constPool_.data());
-}
-
 const char *GetGPRName(int r) {
 	if (r < 32) {
 		return currentDebugMIPS->GetRegName(0, r);

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -270,8 +270,6 @@ public:
 		constPool_.clear();
 	}
 
-	void Simplify();
-
 	const std::vector<IRInst> &GetInstructions() const { return insts_; }
 	const std::vector<u32> &GetConstants() const { return constPool_; }
 

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -243,6 +243,17 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 // Each IR block gets a constant pool.
 class IRWriter {
 public:
+	IRWriter &operator =(const IRWriter &w) {
+		insts_ = w.insts_;
+		constPool_ = w.constPool_;
+		return *this;
+	}
+	IRWriter &operator =(IRWriter &&w) {
+		insts_ = std::move(w.insts_);
+		constPool_ = std::move(w.constPool_);
+		return *this;
+	}
+
 	void Write(IROp op, u8 dst = 0, u8 src1 = 0, u8 src2 = 0);
 	void Write(IRInst inst) {
 		insts_.push_back(inst);

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -213,6 +213,8 @@ enum {
 	IRTEMP_RHS,  // Reserved for use in branches
 
 	// Hacky way to get to other state
+	IRREG_VPFU_CTRL_BASE = 208,
+	IRREG_VPFU_CC = 211,
 	IRREG_LO = 226,  // offset of lo in MIPSState / 4
 	IRREG_HI = 227,
 	IRREG_FCR31 = 228,

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -384,7 +384,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			const ReplacementTableEntry *f = GetReplacementFunc(funcIndex);
 			int cycles = f->replaceFunc();
 			mips->downcount -= cycles;
-			return mips->r[MIPS_REG_RA];
+			break;
 		}
 
 		case IROp::Break:

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -21,7 +21,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			memcpy(&mips->f[inst->dest], &constPool[inst->src1], 4);
 			break;
 		case IROp::SetConstV:
-			memcpy(&mips->f[inst->dest], &constPool[inst->src1], 4);
+			memcpy(&mips->v[voffset[inst->dest]], &constPool[inst->src1], 4);
 			break;
 		case IROp::Add:
 			mips->r[inst->dest] = mips->r[inst->src1] + mips->r[inst->src2];

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -340,6 +340,8 @@ void IRJit::Comp_ReplacementFunc(MIPSOpcode op) {
 			MIPSCompileOp(Memory::Read_Instruction(GetCompilerPC(), true), this);
 		} else {
 			ApplyRoundingMode();
+			ir.Write(IROp::Downcount, 0, js.downcountAmount & 0xFF, js.downcountAmount >> 8);
+			ir.Write(IROp::ExitToReg, MIPS_REG_RA, 0, 0);
 			js.compiling = false;
 		}
 	} else {

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -248,15 +248,14 @@ void IRJit::DoJit(u32 em_address, IRBlock *b) {
 	ir.Simplify();
 
 	IRWriter simplified;
-
 	IRWriter *code = &ir;
 	if (true) {
-		if (PropagateConstants(ir, simplified))
+		static const IRPassFunc passes[] = {
+			&PropagateConstants,
+		};
+		if (IRApplyPasses(passes, ARRAY_SIZE(passes), ir, simplified))
 			logBlocks = 1;
 		code = &simplified;
-		// Some blocks in tekken generate curious numbers of constants after propagation.
-		//if (ir.GetConstants().size() >= 64)
-		//	logBlocks = 1;
 	}
 
 	b->SetInstructions(code->GetInstructions(), code->GetConstants());

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -245,8 +245,6 @@ void IRJit::DoJit(u32 em_address, IRBlock *b) {
 		}
 	}
 
-	ir.Simplify();
-
 	IRWriter simplified;
 	IRWriter *code = &ir;
 	if (true) {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -1,23 +1,6 @@
+#include "Common/Log.h"
 #include "Core/MIPS/IR/IRPassSimplify.h"
 #include "Core/MIPS/IR/IRRegCache.h"
-
-void SimplifyInPlace(IRInst *inst, int count, const u32 *constPool) {
-	for (int i = 0; i < count; i++) {
-		switch (inst[i].op) {
-		case IROp::AddConst:
-			if (constPool[inst[i].src2] == 0)
-				inst[i].op = IROp::Mov;
-			else if (inst[i].src1 == 0) {
-				inst[i].op = IROp::SetConst;
-				inst[i].src1 = inst[i].src2;
-			}
-			break;
-		default:
-			break;
-		}
-	}
-}
-
 
 u32 Evaluate(u32 a, u32 b, IROp op) {
 	switch (op) {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -273,7 +273,16 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 			break;
 
 		case IROp::Downcount:
-			out.Write(inst);
+		case IROp::SetPCConst:
+			goto doDefault;
+
+		case IROp::SetPC:
+			if (gpr.IsImm(inst.src1)) {
+				out.Write(IROp::SetPCConst, out.AddConstant(gpr.GetImm(inst.src1)));
+			} else {
+				gpr.MapIn(inst.src1);
+				goto doDefault;
+			}
 			break;
 
 		// FP-only instructions don't need to flush immediates.

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -126,6 +126,9 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 		case IROp::SetConst:
 			gpr.SetImm(inst.dest, constants[inst.src1]);
 			break;
+		case IROp::SetConstF:
+		case IROp::SetConstV:
+			goto doDefault;
 
 		case IROp::Sub:
 		case IROp::Slt:
@@ -380,6 +383,22 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 				out.Write(inst);
 			}
 			break;
+
+		case IROp::ZeroFpCond:
+		case IROp::FCmpUnordered:
+		case IROp::FCmpEqual:
+		case IROp::FCmpEqualUnordered:
+		case IROp::FCmpLessOrdered:
+		case IROp::FCmpLessUnordered:
+		case IROp::FCmpLessEqualOrdered:
+		case IROp::FCmpLessEqualUnordered:
+			gpr.MapDirty(IRREG_FPCOND);
+			goto doDefault;
+
+		case IROp::RestoreRoundingMode:
+		case IROp::ApplyRoundingMode:
+		case IROp::UpdateRoundingMode:
+			goto doDefault;
 
 		case IROp::VfpuCtrlToReg:
 			gpr.MapDirtyIn(inst.dest, IRREG_VPFU_CTRL_BASE + inst.src1);

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -51,6 +51,31 @@ IROp ArithToArithConst(IROp op) {
 	}
 }
 
+bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWriter &out) {
+	if (c == 1) {
+		return passes[0](in, out);
+	}
+
+	bool logBlocks = false;
+
+	IRWriter temp[2];
+	const IRWriter *nextIn = &in;
+	IRWriter *nextOut = &temp[1];
+	for (size_t i = 0; i < c - 1; ++i) {
+		if (passes[i](*nextIn, *nextOut)) {
+			logBlocks = true;
+		}
+
+		temp[0] = std::move(temp[1]);
+		nextIn = &temp[0];
+	}
+
+	if (passes[c - 1](*nextIn, out)) {
+		logBlocks = true;
+	}
+
+	return logBlocks;
+}
 
 bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 	IRRegCache gpr(&out);

--- a/Core/MIPS/IR/IRPassSimplify.h
+++ b/Core/MIPS/IR/IRPassSimplify.h
@@ -5,5 +5,7 @@
 // Dumb example of a simplification pass that can't add or remove instructions.
 void SimplifyInPlace(IRInst *inst, int count, const u32 *constPool);
 
+typedef bool (*IRPassFunc)(const IRWriter &in, IRWriter &out);
+bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWriter &out);
 
 bool PropagateConstants(const IRWriter &in, IRWriter &out);

--- a/Core/MIPS/IR/IRPassSimplify.h
+++ b/Core/MIPS/IR/IRPassSimplify.h
@@ -2,9 +2,6 @@
 
 #include "Core/MIPS/IR/IRInst.h"
 
-// Dumb example of a simplification pass that can't add or remove instructions.
-void SimplifyInPlace(IRInst *inst, int count, const u32 *constPool);
-
 typedef bool (*IRPassFunc)(const IRWriter &in, IRWriter &out);
 bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWriter &out);
 


### PR DESCRIPTION
This handles things like shifts, single-ops, SetPC, and allows for more overlap in other constant handling.

Maybe Symbian will hate this, but I also created a simple way to apply multiple passes in sequence.  This way we can list them simply.

From sampling 4 games, this improved the main standing-still portions by between 2-11% unthrottled on my ivy.  Most of the time this was a gain from ~300% or so (e.g. 300% -> 333%.)

-[Unknown]
