### PR TITLE
Buildfixes + Travis caching

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+export NDK_CCACHE=ccache
 NDK_VER=android-ndk-r10d
 
 download_extract() {
@@ -85,7 +86,7 @@ travis_script() {
 	# Compile PPSSPP
 	if [ "$PPSSPP_BUILD_TYPE" = "Linux" ]; then
 		if [ "$CXX" = "g++" ]; then
-			export CXX="g++-4.8" CC="gcc-4.8"
+			export CXX="ccache g++-4.8" CC="ccache gcc-4.8"
 		fi
 
 		if [ "$QT" = "TRUE" ]; then
@@ -123,6 +124,8 @@ travis_script() {
 }
 
 travis_after_success() {
+	ccache -s
+
 	if [ "$PPSSPP_BUILD_TYPE" = "Linux" ]; then
 		./test.py
 	fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,19 @@ sudo: required
 
 language: cpp
 
-os: linux
-
 dist: trusty
 
-compiler:
-  - gcc
+addons:
+  apt:
+    packages:
+      - build-essential
+      - libgl1-mesa-dev
+      - libglu1-mesa-dev
+      - cmake
 
-env:
-  - PPSSPP_BUILD_TYPE=Linux
-    CMAKE=TRUE
-  - PPSSPP_BUILD_TYPE=Android
-  - PPSSPP_BUILD_TYPE=Blackberry
-    CMAKE=TRUE
-  - PPSSPP_BUILD_TYPE=Symbian
+cache:
+  - apt
+  - ccache
 
 notifications:
   irc:
@@ -30,15 +29,31 @@ notifications:
 
 matrix:
   include:
-    - compiler: clang
+    - os: linux
+      compiler: "gcc linux"
       env: PPSSPP_BUILD_TYPE=Linux
            CMAKE=TRUE
-    - compiler: gcc
+    - os: linux
+      compiler: "gcc android"
+      env: PPSSPP_BUILD_TYPE=Android
+    - os: linux
+      compiler: "gcc blackberry"
+      env: PPSSPP_BUILD_TYPE=Blackberry
+           CMAKE=TRUE
+    - os: linux
+      compiler: "gcc symbian"
+      env: PPSSPP_BUILD_TYPE=Symbian
+    - os: linux
+      compiler: "clang linux"
+      env: PPSSPP_BUILD_TYPE=Linux
+           CMAKE=TRUE
+    - os: linux
+      compiler: "gcc qt"
       env: PPSSPP_BUILD_TYPE=Linux
            QT=TRUE
 # Can't get iOS to work.
 #    - os: osx
-#      compiler: clang
+#      compiler: "clang ios"
 #      env: PPSSPP_BUILD_TYPE=iOS
 #           CMAKE=TRUE
 

--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -31,8 +31,6 @@
 #include "Core/MIPS/IR/IRFrontend.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 
-#include "Common/Arm64Emitter.h"
-
 #define _RS MIPS_GET_RS(op)
 #define _RT MIPS_GET_RT(op)
 #define _RD MIPS_GET_RD(op)

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -261,7 +261,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 		ILOG("=============== Original IR (%d instructions, %d const) ===============", (int)ir.GetInstructions().size(), (int)ir.GetConstants().size());
 		for (size_t i = 0; i < ir.GetInstructions().size(); i++) {
 			char buf[256];
-			DisassembleIR(buf, sizeof(buf), ir.GetInstructions()[i], ir.GetConstants().data());
+			DisassembleIR(buf, sizeof(buf), ir.GetInstructions()[i], &ir.GetConstants()[0]);
 			ILOG("%s", buf);
 		}
 		ILOG("===============        end         =================");
@@ -271,7 +271,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 		ILOG("=============== IR (%d instructions, %d const) ===============", (int)code->GetInstructions().size(), (int)code->GetConstants().size());
 		for (size_t i = 0; i < code->GetInstructions().size(); i++) {
 			char buf[256];
-			DisassembleIR(buf, sizeof(buf), code->GetInstructions()[i], code->GetConstants().data());
+			DisassembleIR(buf, sizeof(buf), code->GetInstructions()[i], &code->GetConstants()[0]);
 			ILOG("%s", buf);
 		}
 		ILOG("===============        end         =================");

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -6,6 +6,16 @@
 #include "Common/CommonTypes.h"
 #include "Core/MIPS/MIPS.h"
 
+#ifdef __SYMBIAN32__
+// Seems std::move() doesn't exist, so assuming it can't do moves at all.
+namespace std {
+	template <typename T>
+	const T &move(const T &x) {
+		return x;
+	}
+};
+#endif
+
 // Basic IR
 //
 // This IR refers implicitly to the MIPS register set and is simple to interpret.

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -19,6 +19,7 @@
 
 #include <cstring>
 
+#include "Common/Common.h"
 #include "Common/CPUDetect.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
@@ -47,6 +48,31 @@ public:
 		origFirstOpcode_ = b.origFirstOpcode_;
 		b.instr_ = nullptr;
 		b.const_ = nullptr;
+	}
+
+	IRBlock(const IRBlock &b) {
+		*this = b;
+	}
+
+	IRBlock &operator=(const IRBlock &b) {
+		// No std::move on Symbian...  But let's try not to use elsewhere.
+#ifndef __SYMBIAN32__
+		_assert_(false);
+#endif
+		numInstructions_ = b.numInstructions_;
+		numConstants_ = b.numConstants_;
+		instr_ = new IRInst[numInstructions_];
+		if (numInstructions_) {
+			memcpy(instr_, b.instr_, sizeof(IRInst) * numInstructions_);
+		}
+		const_ = new u32[numConstants_];
+		if (numConstants_) {
+			memcpy(const_, b.const_, sizeof(u32) * numConstants_);
+		}
+		origAddr_ = b.origAddr_;
+		origFirstOpcode_ = b.origFirstOpcode_;
+
+		return *this;
 	}
 
 	~IRBlock() {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -102,7 +102,6 @@ bool OptimizeFPMoves(const IRWriter &in, IRWriter &out) {
 	//FMovToGPR a0, f12
 	//FMov f14, f12
 
-	const u32 *constants = in.GetConstants().data();
 	bool logBlocks = false;
 	IRInst prev;
 	prev.op = IROp::Nop;
@@ -134,7 +133,6 @@ bool OptimizeFPMoves(const IRWriter &in, IRWriter &out) {
 
 // Might be useful later on x86.
 bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out) {
-	const u32 *constants = in.GetConstants().data();
 	bool logBlocks = false;
 	for (int i = 0; i < (int)in.GetInstructions().size(); i++) {
 		IRInst inst = in.GetInstructions()[i];
@@ -178,7 +176,7 @@ bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out) {
 bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 	IRRegCache gpr(&out);
 
-	const u32 *constants = in.GetConstants().data();
+	const u32 *constants = &in.GetConstants()[0];
 	bool logBlocks = false;
 	for (int i = 0; i < (int)in.GetInstructions().size(); i++) {
 		IRInst inst = in.GetInstructions()[i];

--- a/Qt/Core.pro
+++ b/Qt/Core.pro
@@ -38,6 +38,7 @@ SOURCES += $$P/Core/*.cpp \ # Core
 	$$P/Core/HLE/*.cpp \
 	$$P/Core/HW/*.cpp \
 	$$P/Core/MIPS/*.cpp \
+	$$P/Core/MIPS/IR/*.cpp \
 	$$P/Core/MIPS/JitCommon/*.cpp \
 	$$P/Core/Util/AudioFormat.cpp \
 	$$P/Core/Util/BlockAllocator.cpp \
@@ -56,6 +57,7 @@ HEADERS += $$P/Core/*.h \
 	$$P/Core/HLE/*.h \
 	$$P/Core/HW/*.h \
 	$$P/Core/MIPS/*.h \
+	$$P/Core/MIPS/IR/*.h \
 	$$P/Core/MIPS/JitCommon/*.h \
 	$$P/Core/Util/AudioFormat.h \
 	$$P/Core/Util/BlockAllocator.h \

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -515,8 +515,6 @@ void MainWindow::createMenus()
 	MenuTree* optionsMenu = new MenuTree(this, menuBar(), QT_TR_NOOP("&Options"));
 	// - Core
 	MenuTree* coreMenu = new MenuTree(this, optionsMenu,      QT_TR_NOOP("&Core"));
-	coreMenu->add(new MenuAction(this, SLOT(dynarecAct()),        QT_TR_NOOP("&CPU Dynarec")))
-		->addEventChecked(&g_Config.bJit);
 	coreMenu->add(new MenuAction(this, SLOT(vertexDynarecAct()),  QT_TR_NOOP("&Vertex Decoder Dynarec")))
 		->addEventChecked(&g_Config.bVertexDecoderJit);
 	coreMenu->add(new MenuAction(this, SLOT(fastmemAct()),        QT_TR_NOOP("Fast &Memory (unstable)")))

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -87,7 +87,6 @@ private slots:
 
 	// Options
 	// Core
-	void dynarecAct() { g_Config.iCpuCore = g_Config.iCpuCore == CPU_CORE_INTERPRETER ? CPU_CORE_JIT : CPU_CORE_INTERPRETER; }
 	void vertexDynarecAct() { g_Config.bVertexDecoderJit = !g_Config.bVertexDecoderJit; }
 	void fastmemAct() { g_Config.bFastMemory = !g_Config.bFastMemory; }
 	void ignoreIllegalAct() { g_Config.bIgnoreBadMemAccess = !g_Config.bIgnoreBadMemAccess; }


### PR DESCRIPTION
The compiler names are a hack that makes it cache per-environment, which many people are currently using.  Otherwise, they trash each others caches due to race conditions.

Actually, the cache is currently only working for Linux / gcc / cmake and Linux / gcc / qt.  I really want to get it working mainly for Android, but I don't know why it isn't working... maybe we can override the CC or there's more NDK env vars to set.

Anyway, this makes the build clean so we can merge.

-[Unknown]
