### PR TITLE
Split the Android travis build into each ABI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ addons:
       - libgl1-mesa-dev
       - libglu1-mesa-dev
       - cmake
+      - aria2
+      - ant
+      - lib32stdc++6
+      - lib32z1
+      - lib32z1-dev
+      - lib32bz2-1.0
 
 cache:
   - apt
@@ -34,8 +40,21 @@ matrix:
       env: PPSSPP_BUILD_TYPE=Linux
            CMAKE=TRUE
     - os: linux
-      compiler: "gcc android"
+      compiler: "gcc android-arm64-v8a"
       env: PPSSPP_BUILD_TYPE=Android
+           APP_ABI=arm64-v8a
+    - os: linux
+      compiler: "gcc android-armeabi-v7a"
+      env: PPSSPP_BUILD_TYPE=Android
+           APP_ABI=armeabi-v7a
+    - os: linux
+      compiler: "gcc android-x86"
+      env: PPSSPP_BUILD_TYPE=Android
+           APP_ABI=x86
+    - os: linux
+      compiler: "gcc android-x86_64"
+      env: PPSSPP_BUILD_TYPE=Android
+           APP_ABI=x86_64
     - os: linux
       compiler: "gcc blackberry"
       env: PPSSPP_BUILD_TYPE=Blackberry

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -117,8 +117,8 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
 #define _dbg_assert_(_t_, _a_) \
 	if (!(_a_)) {\
-		ERROR_LOG(_t_, "Error...\n\n  Line: %d\n  File: %s\n  Time: %s\n\nIgnore and continue?", \
-					   __LINE__, __FILE__, __TIME__); \
+		ERROR_LOG(_t_, "Error...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
+					   __LINE__, __FILE__); \
 		if (!PanicYesNo("*** Assertion (see log)***\n")) {Crash();} \
 	}
 #ifdef __SYMBIAN32__


### PR DESCRIPTION
This makes the ccache work properly, and also builds faster anyway due to parallelism.

Unfortunately, Linux/clang/x86, Blackberry, and Symbian still aren't caching.  But this is still a huge win for travis build times.  Greater than 40 min was somewhat unusable.

With an optimally cached build, ~14 min:
https://travis-ci.org/hrydgard/ppsspp/builds/130260147

-[Unknown]
