### PR TITLE
IR the remaining ALU ops, correct div by zero

### DIFF
--- a/Core/MIPS/ARM/ArmCompALU.cpp
+++ b/Core/MIPS/ARM/ArmCompALU.cpp
@@ -760,9 +760,9 @@ namespace MIPSComp
 			if (gpr.IsImm(rt) && (gpr.GetImm(rt) & (gpr.GetImm(rt) - 1)) == 0) {
 				u32 denominator = gpr.GetImm(rt);
 				if (denominator == 0) {
-					// TODO: Is this correct?
-					gpr.SetImm(MIPS_REG_LO, 0);
-					gpr.SetImm(MIPS_REG_HI, 0);
+					gpr.MapDirtyIn(MIPS_REG_HI, rs);
+					gpr.SetImm(MIPS_REG_LO, -1);
+					MOV(gpr.R(MIPS_REG_HI), gpr.R(rs));
 				} else {
 					gpr.MapDirtyDirtyIn(MIPS_REG_LO, MIPS_REG_HI, rs);
 					// Remainder is just an AND, neat.

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -636,8 +636,8 @@ void Arm64Jit::Comp_MulDivType(MIPSOpcode op) {
 		if (gpr.IsImm(rt) && (gpr.GetImm(rt) & (gpr.GetImm(rt) - 1)) == 0) {
 			u32 denominator = gpr.GetImm(rt);
 			if (denominator == 0) {
-				// TODO: Is this correct?
-				gpr.SetImm(MIPS_REG_LO, 0);
+				// TODO: This isn't exactly right.
+				gpr.SetImm(MIPS_REG_LO, -1);
 			} else {
 				gpr.MapDirtyIn(MIPS_REG_LO, rs);
 				// Remainder is just an AND, neat.

--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -348,12 +348,10 @@ void IRFrontend::Comp_MulDivType(MIPSOpcode op) {
 		break;
 
 	case 26: //div
-		DISABLE;
 		ir.Write(IROp::Div, 0, rs, rt);
 		break;
 
 	case 27: //divu
-		DISABLE;
 		ir.Write(IROp::DivU, 0, rs, rt);
 		break;
 

--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -294,6 +294,7 @@ void IRFrontend::Comp_Allegrex2(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	MIPSGPReg rt = _RT;
 	MIPSGPReg rd = _RD;
+
 	// Don't change $zr.
 	if (rd == 0)
 		return;

--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -358,22 +358,18 @@ void IRFrontend::Comp_MulDivType(MIPSOpcode op) {
 		break;
 
 	case 28: //madd
-		DISABLE;
 		ir.Write(IROp::Madd, 0, rs, rt);
 		break;
 
 	case 29: //maddu
-		DISABLE;
 		ir.Write(IROp::MaddU, 0, rs, rt);
 		break;
 
 	case 46: // msub
-		DISABLE;
 		ir.Write(IROp::Msub, 0, rs, rt);
 		break;
 
 	case 47: // msubu
-		DISABLE;
 		ir.Write(IROp::MsubU, 0, rs, rt);
 		break;
 

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -53,6 +53,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::MfHi, "MfHi", "G" },
 	{ IROp::Ext8to32, "Ext8to32", "GG" },
 	{ IROp::Ext16to32, "Ext16to32", "GG" },
+	{ IROp::ReverseBits, "ReverseBits", "GG" },
 	{ IROp::Load8, "Load8", "GGC" },
 	{ IROp::Load8Ext, "Load8", "GGC" },
 	{ IROp::Load16, "Load16", "GGC" },

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -111,6 +111,7 @@ enum class IROp : u8 {
 
 	Ext8to32,
 	Ext16to32,
+	ReverseBits,
 
 	FAdd,
 	FSub,

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -87,6 +87,9 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 		case IROp::Ext16to32:
 			mips->r[inst->dest] = (s32)(s16)mips->r[inst->src1];
 			break;
+		case IROp::ReverseBits:
+			mips->r[inst->dest] = ReverseBits32(mips->r[inst->src1]);
+			break;
 
 		case IROp::Load8:
 			mips->r[inst->dest] = Memory::ReadUnchecked_U8(mips->r[inst->src1] + constPool[inst->src2]);

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -438,6 +438,36 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 		}
 
+		case IROp::Div:
+		{
+			s32 numerator = (s32)mips->r[inst->src1];
+			s32 denominator = (s32)mips->r[inst->src2];
+			if (numerator == (s32)0x80000000 && denominator == -1) {
+				mips->lo = 0x80000000;
+				mips->hi = -1;
+			} else if (denominator != 0) {
+				mips->lo = (u32)(numerator / denominator);
+				mips->hi = (u32)(numerator % denominator);
+			} else {
+				mips->lo = numerator < 0 ? 1 : -1;
+				mips->hi = numerator;
+			}
+			break;
+		}
+		case IROp::DivU:
+		{
+			u32 numerator = mips->r[inst->src1];
+			u32 denominator = mips->r[inst->src2];
+			if (denominator != 0) {
+				mips->lo = numerator / denominator;
+				mips->hi = numerator % denominator;
+			} else {
+				mips->lo = numerator <= 0xFFFF ? 0xFFFF : -1;
+				mips->hi = numerator;
+			}
+			break;
+		}
+
 		case IROp::BSwap16:
 		{
 			u32 x = mips->r[inst->src1];

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -405,6 +405,38 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			memcpy(&mips->lo, &result, 8);
 			break;
 		}
+		case IROp::Madd:
+		{
+			s64 result;
+			memcpy(&result, &mips->lo, 8);
+			result += (s64)(s32)mips->r[inst->src1] * (s64)(s32)mips->r[inst->src2];
+			memcpy(&mips->lo, &result, 8);
+			break;
+		}
+		case IROp::MaddU:
+		{
+			s64 result;
+			memcpy(&result, &mips->lo, 8);
+			result += (u64)mips->r[inst->src1] * (u64)mips->r[inst->src2];
+			memcpy(&mips->lo, &result, 8);
+			break;
+		}
+		case IROp::Msub:
+		{
+			s64 result;
+			memcpy(&result, &mips->lo, 8);
+			result -= (s64)(s32)mips->r[inst->src1] * (s64)(s32)mips->r[inst->src2];
+			memcpy(&mips->lo, &result, 8);
+			break;
+		}
+		case IROp::MsubU:
+		{
+			s64 result;
+			memcpy(&result, &mips->lo, 8);
+			result -= (u64)mips->r[inst->src1] * (u64)mips->r[inst->src2];
+			memcpy(&mips->lo, &result, 8);
+			break;
+		}
 
 		case IROp::BSwap16:
 		{

--- a/Core/MIPS/IR/IRInterpreter.h
+++ b/Core/MIPS/IR/IRInterpreter.h
@@ -5,4 +5,19 @@
 class MIPSState;
 struct IRInst;
 
+inline static u32 ReverseBits32(u32 v) {
+	// http://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel
+	// swap odd and even bits
+	v = ((v >> 1) & 0x55555555) | ((v & 0x55555555) << 1);
+	// swap consecutive pairs
+	v = ((v >> 2) & 0x33333333) | ((v & 0x33333333) << 2);
+	// swap nibbles ...
+	v = ((v >> 4) & 0x0F0F0F0F) | ((v & 0x0F0F0F0F) << 4);
+	// swap bytes
+	v = ((v >> 8) & 0x00FF00FF) | ((v & 0x00FF00FF) << 8);
+	// swap 2-byte long pairs
+	v = ( v >> 16             ) | ( v               << 16);
+	return v;
+}
+
 u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int count);

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -350,6 +350,12 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 
 		case IROp::Mult:
 		case IROp::MultU:
+		case IROp::Madd:
+		case IROp::MaddU:
+		case IROp::Msub:
+		case IROp::MsubU:
+		case IROp::Div:
+		case IROp::DivU:
 			gpr.MapInIn(inst.src1, inst.src2);
 			goto doDefault;
 

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -1,6 +1,7 @@
 #include <utility>
 
 #include "Common/Log.h"
+#include "Core/MIPS/IR/IRInterpreter.h"
 #include "Core/MIPS/IR/IRPassSimplify.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 
@@ -51,6 +52,7 @@ u32 Evaluate(u32 a, IROp op) {
 	case IROp::BSwap32: return swap32(a);
 	case IROp::Ext8to32: return (u32)(s32)(s8)(u8)a;
 	case IROp::Ext16to32: return (u32)(s32)(s16)(u16)a;
+	case IROp::ReverseBits: return ReverseBits32(a);
 	case IROp::Clz: {
 		int x = 31;
 		int count = 0;
@@ -277,6 +279,7 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 		case IROp::BSwap32:
 		case IROp::Ext8to32:
 		case IROp::Ext16to32:
+		case IROp::ReverseBits:
 		case IROp::Clz:
 			if (gpr.IsImm(inst.src1)) {
 				gpr.SetImm(inst.dest, Evaluate(gpr.GetImm(inst.src1), inst.op));

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -660,11 +660,13 @@ namespace MIPSInt
 				s32 b = (s32)R(rt);
 				if (a == (s32)0x80000000 && b == -1) {
 					LO = 0x80000000;
+					HI = -1;
 				} else if (b != 0) {
 					LO = (u32)(a / b);
 					HI = (u32)(a % b);
 				} else {
-					LO = HI = 0;	// Not sure what the right thing to do is?
+					LO = a < 0 ? 1 : -1;
+					HI = a;
 				}
 			}
 			break;
@@ -672,12 +674,12 @@ namespace MIPSInt
 			{
 				u32 a = R(rs);
 				u32 b = R(rt);
-				if (b != 0) 
-				{
+				if (b != 0) {
 					LO = (a/b);
 					HI = (a%b);
 				} else {
-					LO = HI = 0;
+					LO = a <= 0xFFFF ? 0xFFFF : -1;
+					HI = a;
 				}
 			}
 			break;

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -1002,6 +1002,9 @@ namespace MIPSComp
 				// For CMP.
 				gpr.KillImmediate(rs, true, false);
 				gpr.KillImmediate(rt, true, false);
+
+				MOV(32, R(EAX), gpr.R(rs));
+
 				CMP(32, gpr.R(rt), Imm32(0));
 				FixupBranch divZero = J_CC(CC_E);
 
@@ -1010,14 +1013,13 @@ namespace MIPSComp
 				FixupBranch notOverflow = J_CC(CC_NE);
 				CMP(32, gpr.R(rt), Imm32((u32) -1));
 				FixupBranch notOverflow2 = J_CC(CC_NE);
-				// TODO: Should HI be set to anything?
 				MOV(32, gpr.R(MIPS_REG_LO), Imm32(0x80000000));
+				MOV(32, gpr.R(MIPS_REG_HI), Imm32(-1));
 				FixupBranch skip2 = J();
 
 				SetJumpTarget(notOverflow);
 				SetJumpTarget(notOverflow2);
 
-				MOV(32, R(EAX), gpr.R(rs));
 				CDQ();
 				IDIV(32, gpr.R(rt));
 				MOV(32, gpr.R(MIPS_REG_HI), R(EDX));
@@ -1025,9 +1027,9 @@ namespace MIPSComp
 				FixupBranch skip = J();
 
 				SetJumpTarget(divZero);
-				// TODO: Is this the right way to handle a divide by zero?
-				MOV(32, gpr.R(MIPS_REG_HI), Imm32(0));
-				MOV(32, gpr.R(MIPS_REG_LO), Imm32(0));
+				// TODO: This isn't exactly right.
+				MOV(32, gpr.R(MIPS_REG_HI), R(EAX));
+				MOV(32, gpr.R(MIPS_REG_LO), Imm32(-1));
 
 				SetJumpTarget(skip);
 				SetJumpTarget(skip2);
@@ -1041,20 +1043,21 @@ namespace MIPSComp
 				gpr.KillImmediate(MIPS_REG_HI, false, true);
 				gpr.KillImmediate(MIPS_REG_LO, false, true);
 				gpr.KillImmediate(rt, true, false);
-				CMP(32, gpr.R(rt), Imm32(0));
-				FixupBranch divZero = J_CC(CC_E);
 
 				MOV(32, R(EAX), gpr.R(rs));
 				MOV(32, R(EDX), Imm32(0));
+
+				CMP(32, gpr.R(rt), Imm32(0));
+				FixupBranch divZero = J_CC(CC_E);
+
 				DIV(32, gpr.R(rt));
 				MOV(32, gpr.R(MIPS_REG_HI), R(EDX));
 				MOV(32, gpr.R(MIPS_REG_LO), R(EAX));
 				FixupBranch skip = J();
 
 				SetJumpTarget(divZero);
-				// TODO: Is this the right way to handle a divide by zero?
-				MOV(32, gpr.R(MIPS_REG_HI), Imm32(0));
-				MOV(32, gpr.R(MIPS_REG_LO), Imm32(0));
+				MOV(32, gpr.R(MIPS_REG_HI), R(EAX));
+				MOV(32, gpr.R(MIPS_REG_LO), Imm32(-1));
 
 				SetJumpTarget(skip);
 				gpr.UnlockAllX();

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -107,6 +107,7 @@ int printUsage(const char *progname, const char *reason)
 
 	fprintf(stderr, "  -v, --verbose         show the full passed/failed result\n");
 	fprintf(stderr, "  -i                    use the interpreter\n");
+	fprintf(stderr, "  --ir                  use ir interpreter\n");
 	fprintf(stderr, "  -j                    use jit (default)\n");
 	fprintf(stderr, "  -c, --compare         compare with output in file.expected\n");
 	fprintf(stderr, "\nSee headless.txt for details.\n");
@@ -239,7 +240,7 @@ int main(int argc, const char* argv[])
 			cpuCore = CPU_CORE_INTERPRETER;
 		else if (!strcmp(argv[i], "-j"))
 			cpuCore = CPU_CORE_JIT;
-		else if (!strcmp(argv[i], "-ir"))
+		else if (!strcmp(argv[i], "--ir"))
 			cpuCore = CPU_CORE_IRJIT;
 		else if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compare"))
 			autoCompare = true;


### PR DESCRIPTION
For div by zero, I got around the crash by not letting the assembler know I was dividing:

https://github.com/unknownbrackets/ps2autotests/blob/master/tests/cpu/iop/muldiv.c#L32

Anyway, I verified with a PSP test too (need to add to pspautotests), and the behavior is slightly different and weirder, as seen here.  I also updated the jits passingly but they're not 100% accurate still, just figured it's better to be closer wrong.  Probably no game divides by zero anyway...

Also, I normalized the convention to "Comp_Generic" for "this doesn't make sense" and "DISABLE" for "I don't know how to do this right now" in ALU, probably makes sense...

-[Unknown]
