### PR TITLE
Add validation to sceDisplaySetFramebuf

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -756,6 +756,22 @@ static u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int
 	fbstate.fmt = (GEBufferFormat)pixelformat;
 	fbstate.stride = linesize;
 
+	if (sync != PSP_DISPLAY_SETBUF_IMMEDIATE && sync != PSP_DISPLAY_SETBUF_NEXTFRAME) {
+		return hleLogError(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_MODE, "invalid sync mode");
+	}
+	if (topaddr != 0 && !Memory::IsRAMAddress(topaddr) && !Memory::IsVRAMAddress(topaddr)) {
+		return hleLogError(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_POINTER, "invalid address");
+	}
+	if ((topaddr & 0xF) != 0) {
+		return hleLogError(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_POINTER, "misaligned address");
+	}
+	if ((linesize & 0x3F) != 0 || (linesize == 0 && topaddr != 0)) {
+		return hleLogError(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_SIZE, "invalid stride");
+	}
+	if (pixelformat < 0 || pixelformat > GE_FORMAT_8888) {
+		return hleLogError(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_FORMAT, "invalid format");
+	}
+
 	hleEatCycles(290);
 
 	s64 delayCycles = 0;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -752,11 +752,9 @@ static u32 sceDisplaySetMode(int displayMode, int displayWidth, int displayHeigh
 // Some games (GTA) never call this during gameplay, so bad place to put a framerate counter.
 static u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) {
 	FrameBufferState fbstate = {0};
-	if (topaddr != 0) {
-		fbstate.topaddr = topaddr;
-		fbstate.pspFramebufFormat = (GEBufferFormat)pixelformat;
-		fbstate.pspFramebufLinesize = linesize;
-	}
+	fbstate.topaddr = topaddr;
+	fbstate.pspFramebufFormat = (GEBufferFormat)pixelformat;
+	fbstate.pspFramebufLinesize = linesize;
 
 	hleEatCycles(290);
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -761,7 +761,8 @@ static u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int
 	hleEatCycles(290);
 
 	s64 delayCycles = 0;
-	if (topaddr != framebuf.topaddr && g_Config.iForceMaxEmulatedFPS > 0) {
+	// Don't count transitions between display off and display on.
+	if (topaddr != 0 && topaddr != framebuf.topaddr && framebuf.topaddr != 0 && g_Config.iForceMaxEmulatedFPS > 0) {
 		// Sometimes we get a small number, there's probably no need to delay the thread for this.
 		// sceDisplaySetFramebuf() isn't supposed to delay threads at all.  This is a hack.
 		const int FLIP_DELAY_CYCLES_MIN = 10;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -723,22 +723,20 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 }
 
 static u32 sceDisplayIsVblank() {
-	DEBUG_LOG(SCEDISPLAY,"%i=sceDisplayIsVblank()",isVblank);
-	return isVblank;
+	return hleLogSuccessI(SCEDISPLAY, isVblank);
 }
 
 static u32 sceDisplaySetMode(int displayMode, int displayWidth, int displayHeight) {
-	if (displayWidth <= 0 || displayHeight <= 0 || (displayWidth & 0x7) != 0) {
-		WARN_LOG(SCEDISPLAY, "sceDisplaySetMode INVALID SIZE (%i, %i, %i)", displayMode, displayWidth, displayHeight);
-		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	if (displayMode != PSP_DISPLAY_MODE_LCD || displayWidth != 480 || displayHeight != 272) {
+		WARN_LOG_REPORT(SCEDISPLAY, "Video out requested, not supported: mode=%d size=%d,%d", displayMode, displayWidth, displayHeight);
 	}
-
+	if (displayWidth != 480 || displayHeight != 272) {
+		return hleLogWarning(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_SIZE, "invalid size");
+	}
 	if (displayMode != PSP_DISPLAY_MODE_LCD) {
-		WARN_LOG(SCEDISPLAY, "sceDisplaySetMode INVALID MODE(%i, %i, %i)", displayMode, displayWidth, displayHeight);
-		return SCE_KERNEL_ERROR_INVALID_MODE;
+		return hleLogWarning(SCEDISPLAY, SCE_KERNEL_ERROR_INVALID_MODE, "invalid mode");
 	}
 
-	DEBUG_LOG(SCEDISPLAY,"sceDisplaySetMode(%i, %i, %i)", displayMode, displayWidth, displayHeight);
 	if (!hasSetMode) {
 		gpu->InitClear();
 		hasSetMode = true;
@@ -746,7 +744,7 @@ static u32 sceDisplaySetMode(int displayMode, int displayWidth, int displayHeigh
 	mode = displayMode;
 	width = displayWidth;
 	height = displayHeight;
-	return 0;
+	return hleLogSuccessI(SCEDISPLAY, 0);
 }
 
 // Some games (GTA) never call this during gameplay, so bad place to put a framerate counter.


### PR DESCRIPTION
An interesting thing: per my tests, you can't set a new format or stride without latching it first.  This might catch some curious scenarios where games change fb formats in a sequence that causes a blink or something.

Hoping this will help #8691.  It might've been disabling the display in that way, for example.  But I also realized we were max-60-fps'ing the display off/on, which it must've been doing each frame.

This passes the test in hrydgard/pspautotests#189.

-[Unknown]
