### PR TITLE
Add some load/store passes, fix bug in vx2i

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -933,8 +933,17 @@ namespace MIPSComp {
 		case 7: // mtv
 			if (imm < 128) {
 				ir.Write(IROp::FMovFromGPR, vfpuBase + voffset[imm], rt);
-			} else if ((imm - 128) < 16) {
+			} else if ((imm - 128) < VFPU_CTRL_MAX) {
 				ir.Write(IROp::SetCtrlVFPU, imm - 128, rt);
+
+				// TODO: Optimization if rt is Imm?
+				if (imm - 128 == VFPU_CTRL_SPREFIX) {
+					js.prefixSFlag = JitState::PREFIX_UNKNOWN;
+				} else if (imm - 128 == VFPU_CTRL_TPREFIX) {
+					js.prefixTFlag = JitState::PREFIX_UNKNOWN;
+				} else if (imm - 128 == VFPU_CTRL_DPREFIX) {
+					js.prefixDFlag = JitState::PREFIX_UNKNOWN;
+				}
 			} else {
 				DISABLE;
 			}

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -236,6 +236,8 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 			&OptimizeFPMoves,
 			&PropagateConstants,
 			&PurgeTemps,
+			// &ReorderLoadStore,
+			// &MergeLoadStore,
 			// &ThreeOpToTwoOp,
 		};
 		if (IRApplyPasses(passes, ARRAY_SIZE(passes), ir, simplified))

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -1,5 +1,6 @@
-#include <utility>
 #include <algorithm>
+#include <cstring>
+#include <utility>
 
 #include "Common/Log.h"
 #include "Core/MIPS/IR/IRInterpreter.h"

--- a/Core/MIPS/IR/IRPassSimplify.h
+++ b/Core/MIPS/IR/IRPassSimplify.h
@@ -11,3 +11,5 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out);
 bool ReduceLoads(const IRWriter &in, IRWriter &out);
 bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out);
 bool OptimizeFPMoves(const IRWriter &in, IRWriter &out);
+bool ReorderLoadStore(const IRWriter &in, IRWriter &out);
+bool MergeLoadStore(const IRWriter &in, IRWriter &out);


### PR DESCRIPTION
This corrects the fade colors in God Eater Burst.

Not sure if the MergeLoadStores has much value.  Originally I tried to merge some 4x float loads with it but it didn't work out since the address can be unaligned...

There are cases where stores happen e.g. Store8 +0x10, Store8 +0x11.  I'm guessing they're separate byte-sized members.  It happens some when compiling any decent chunk of code.

-[Unknown]
