### PR TITLE
Handle divide by zero more accurately in jit

### DIFF
--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -1027,10 +1027,13 @@ namespace MIPSComp
 				FixupBranch skip = J();
 
 				SetJumpTarget(divZero);
-				// TODO: This isn't exactly right.
 				MOV(32, gpr.R(MIPS_REG_HI), R(EAX));
 				MOV(32, gpr.R(MIPS_REG_LO), Imm32(-1));
+				CMP(32, R(EAX), Imm32(0));
+				FixupBranch positiveDivZero = J_CC(CC_GE);
+				MOV(32, gpr.R(MIPS_REG_LO), Imm32(1));
 
+				SetJumpTarget(positiveDivZero);
 				SetJumpTarget(skip);
 				SetJumpTarget(skip2);
 				gpr.UnlockAllX();
@@ -1058,7 +1061,11 @@ namespace MIPSComp
 				SetJumpTarget(divZero);
 				MOV(32, gpr.R(MIPS_REG_HI), R(EAX));
 				MOV(32, gpr.R(MIPS_REG_LO), Imm32(-1));
+				CMP(32, R(EAX), Imm32(0xFFFF));
+				FixupBranch moreThan16Bit = J_CC(CC_A);
+				MOV(32, gpr.R(MIPS_REG_LO), Imm32(0xFFFF));
 
+				SetJumpTarget(moreThan16Bit);
 				SetJumpTarget(skip);
 				gpr.UnlockAllX();
 			}


### PR DESCRIPTION
Before, LO would be 0 on arm (with div support), and closer to accurate on x86 but still wrong.

Now both HI and LO are set properly.  Maybe it'll fix something more.  May at the least make #6672 work on ARM if it doesn't happen to already.

PS: To run headless on ARM, you currently have to comment out some `std::regex_error` in armips... we use it to assemble in unittest, maybe we need a way to disable that feature...

-[Unknown]
