### PR TITLE
Save FBOs on decimate when a safe size is known

### DIFF
--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -383,24 +383,25 @@ void DoState(PointerWrap &p)
 	p.DoMarker("ScratchPad");
 }
 
-void Shutdown()
-{
+void Shutdown() {
 	lock_guard guard(g_shutdownLock);
 	u32 flags = 0;
-
 	MemoryMap_Shutdown(flags);
-	base = NULL;
+	base = nullptr;
 	DEBUG_LOG(MEMMAP, "Memory system shut down.");
 }
 
-void Clear()
-{
+void Clear() {
 	if (m_pRAM)
 		memset(GetPointerUnchecked(PSP_GetKernelMemoryBase()), 0, g_MemorySize);
 	if (m_pScratchPad)
 		memset(m_pScratchPad, 0, SCRATCHPAD_SIZE);
 	if (m_pVRAM)
 		memset(m_pVRAM, 0, VRAM_SIZE);
+}
+
+bool IsActive() {
+	return base != nullptr;
 }
 
 // Wanting to avoid include pollution, MemMap.h is included a lot.

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -130,6 +130,8 @@ void Init();
 void Shutdown();
 void DoState(PointerWrap &p);
 void Clear();
+// False when shutdown has already been called.
+bool IsActive();
 
 class MemoryInitedLock
 {

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -355,6 +355,9 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 				needsRecreate = needsRecreate || vfb->newHeight > vfb->bufferHeight || vfb->newHeight * 2 < vfb->bufferHeight;
 				if (needsRecreate) {
 					ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);
+					// Let's discard this information, might be wrong now.
+					vfb->safeWidth = 0;
+					vfb->safeHeight = 0;
 				} else {
 					// Even though we won't resize it, let's at least change the size params.
 					vfb->width = drawing_width;
@@ -378,7 +381,8 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 	// None found? Create one.
 	if (!vfb) {
 		vfb = new VirtualFramebuffer();
-		vfb->fbo = 0;
+		memset(vfb, 0, sizeof(VirtualFramebuffer));
+		vfb->fbo = nullptr;
 		vfb->fb_address = params.fb_address;
 		vfb->fb_stride = params.fb_stride;
 		vfb->z_address = params.z_address;
@@ -393,8 +397,6 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 		vfb->bufferWidth = drawing_width;
 		vfb->bufferHeight = drawing_height;
 		vfb->format = params.fmt;
-		vfb->drawnWidth = 0;
-		vfb->drawnHeight = 0;
 		vfb->drawnFormat = params.fmt;
 		vfb->usageFlags = FB_USAGE_RENDERTARGET;
 		SetColorUpdated(vfb, skipDrawReason);
@@ -412,10 +414,6 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 		INFO_LOG(SCEGE, "Creating FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 
 		vfb->last_frame_render = gpuStats.numFlips;
-		vfb->last_frame_used = 0;
-		vfb->last_frame_attached = 0;
-		vfb->last_frame_displayed = 0;
-		vfb->last_frame_clut = 0;
 		frameLastFramebufUsed_ = gpuStats.numFlips;
 		vfbs_.push_back(vfb);
 		currentRenderVfb_ = vfb;
@@ -771,6 +769,7 @@ VirtualFramebuffer *FramebufferManagerCommon::FindDownloadTempBuffer(VirtualFram
 	// Create a new fbo if none was found for the size
 	if (!nvfb) {
 		nvfb = new VirtualFramebuffer();
+		memset(nvfb, 0, sizeof(VirtualFramebuffer));
 		nvfb->fbo = nullptr;
 		nvfb->fb_address = vfb->fb_address;
 		nvfb->fb_stride = vfb->fb_stride;
@@ -964,13 +963,24 @@ void FramebufferManagerCommon::SetRenderSize(VirtualFramebuffer *vfb) {
 		break;
 	}
 
+	if (hackForce04154000Download_ && vfb->fb_address == 0x00154000) {
+		force1x = true;
+	}
+
 	if (force1x && g_Config.iInternalResolution != 1) {
 		vfb->renderWidth = vfb->bufferWidth;
 		vfb->renderHeight = vfb->bufferHeight;
-	}
-	else {
+	} else {
 		vfb->renderWidth = (u16)(vfb->bufferWidth * renderWidthFactor);
 		vfb->renderHeight = (u16)(vfb->bufferHeight * renderHeightFactor);
+	}
+}
+
+void FramebufferManagerCommon::SetSafeSize(u16 w, u16 h) {
+	VirtualFramebuffer *vfb = currentRenderVfb_;
+	if (vfb) {
+		vfb->safeWidth = std::max(vfb->safeWidth, w);
+		vfb->safeHeight = std::max(vfb->safeHeight, h);
 	}
 }
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -99,6 +99,8 @@ struct VirtualFramebuffer {
 	u16 drawnWidth;
 	u16 drawnHeight;
 	GEBufferFormat drawnFormat;
+	u16 safeWidth;
+	u16 safeHeight;
 
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
@@ -224,6 +226,7 @@ public:
 		}
 	}
 	void SetRenderSize(VirtualFramebuffer *vfb);
+	void SetSafeSize(u16 w, u16 h);
 
 protected:
 	void UpdateSize();

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -885,6 +885,10 @@ rotateVBO:
 
 			dxstate.colorMask.set((mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_STENCIL) != 0);
 			pD3Ddevice->Clear(0, NULL, mask, clearColor, clearDepth, clearColor >> 24);
+
+			int scissorX2 = gstate.getScissorX2() + 1;
+			int scissorY2 = gstate.getScissorY2() + 1;
+			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 		}
 	}
 

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -1140,7 +1140,7 @@ namespace DX9 {
 
 	void FramebufferManagerDX9::EndFrame() {
 		if (resized_) {
-			DestroyAllFBOs();
+			DestroyAllFBOs(false);
 			// Actually, auto mode should be more granular...
 			// Round up to a zoom factor for the render size.
 			int zoom = g_Config.iInternalResolution;
@@ -1173,7 +1173,7 @@ namespace DX9 {
 	}
 
 	void FramebufferManagerDX9::DeviceLost() {
-		DestroyAllFBOs();
+		DestroyAllFBOs(false);
 		resized_ = false;
 	}
 
@@ -1218,6 +1218,9 @@ namespace DX9 {
 			if (vfb != displayFramebuf_ && vfb != prevDisplayFramebuf_ && vfb != prevPrevDisplayFramebuf_) {
 				if (age > FBO_OLD_AGE) {
 					INFO_LOG(SCEGE, "Decimating FBO for %08x (%i x %i x %i), age %i", vfb->fb_address, vfb->width, vfb->height, vfb->format, age);
+					if (!g_Config.bDisableSlowFramebufEffects && vfb->safeWidth > 0 && vfb->safeHeight > 0) {
+						ReadFramebufferToMemory(vfb, true, 0, 0, vfb->safeWidth, vfb->safeHeight);
+					}
 					DestroyFramebuf(vfb);
 					vfbs_.erase(vfbs_.begin() + i--);
 				}
@@ -1256,7 +1259,7 @@ namespace DX9 {
 		}
 	}
 
-	void FramebufferManagerDX9::DestroyAllFBOs() {
+	void FramebufferManagerDX9::DestroyAllFBOs(bool forceDelete) {
 		fbo_unbind();
 		currentRenderVfb_ = 0;
 		displayFramebuf_ = 0;
@@ -1266,6 +1269,12 @@ namespace DX9 {
 		for (size_t i = 0; i < vfbs_.size(); ++i) {
 			VirtualFramebuffer *vfb = vfbs_[i];
 			INFO_LOG(SCEGE, "Destroying FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
+			if (!forceDelete && !g_Config.bDisableSlowFramebufEffects && vfb->safeWidth > 0 && vfb->safeHeight > 0) {
+				// But also let's check if Memory is shut down already.
+				if (Memory::IsActive()) {
+					ReadFramebufferToMemory(vfb, true, 0, 0, vfb->safeWidth, vfb->safeHeight);
+				}
+			}
 			DestroyFramebuf(vfb);
 		}
 		vfbs_.clear();

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -60,7 +60,7 @@ public:
 	
 	void DrawActiveTexture(LPDIRECT3DTEXTURE9 texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation);
 
-	void DestroyAllFBOs();
+	void DestroyAllFBOs(bool forceDelete);
 
 	void EndFrame();
 	void Resized();

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -511,7 +511,7 @@ void GPU_DX9::CheckGPUFeatures() {
 }
 
 GPU_DX9::~GPU_DX9() {
-	framebufferManager_.DestroyAllFBOs();
+	framebufferManager_.DestroyAllFBOs(true);
 	shaderManager_->ClearCache(true);
 	delete shaderManager_;
 }
@@ -2137,7 +2137,7 @@ void GPU_DX9::DoState(PointerWrap &p) {
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.textureChanged = TEXCHANGE_UPDATED;
-		framebufferManager_.DestroyAllFBOs();
+		framebufferManager_.DestroyAllFBOs(true);
 		shaderManager_->ClearCache(true);
 	}
 }

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -981,6 +981,10 @@ rotateVBO:
 			glClearStencil(clearColor >> 24);
 			glClear(target);
 			framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
+
+			int scissorX2 = gstate.getScissorX2() + 1;
+			int scissorY2 = gstate.getScissorY2() + 1;
+			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 		}
 	}
 

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -82,7 +82,7 @@ public:
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawActiveTexture(GLuint texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, GLSLProgram *program, int uvRotation);
 
-	void DestroyAllFBOs();
+	void DestroyAllFBOs(bool forceDelete);
 
 	virtual void Init() override;
 	void EndFrame();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -469,7 +469,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *ctx)
 }
 
 GPU_GLES::~GPU_GLES() {
-	framebufferManager_.DestroyAllFBOs();
+	framebufferManager_.DestroyAllFBOs(true);
 	shaderManager_->ClearCache(true);
 	depalShaderCache_.Clear();
 	fragmentTestCache_.Clear();
@@ -660,7 +660,7 @@ void GPU_GLES::Reinitialize() {
 void GPU_GLES::ReinitializeInternal() {
 	textureCache_.Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManager_.DestroyAllFBOs();
+	framebufferManager_.DestroyAllFBOs(true);
 	framebufferManager_.Resized();
 }
 
@@ -2401,7 +2401,7 @@ void GPU_GLES::DoState(PointerWrap &p) {
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.textureChanged = TEXCHANGE_UPDATED;
-		framebufferManager_.DestroyAllFBOs();
+		framebufferManager_.DestroyAllFBOs(true);
 		shaderManager_->ClearCache(true);
 	}
 }

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -826,6 +826,10 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 
 			// We let the framebuffer manager handle the clear. It can use renderpasses to optimize on tilers.
 			framebufferManager_->NotifyClear(gstate.isClearModeColorMask(), gstate.isClearModeAlphaMask(), gstate.isClearModeDepthMask(), result.color, result.depth);
+
+			int scissorX2 = gstate.getScissorX2() + 1;
+			int scissorY2 = gstate.getScissorY2() + 1;
+			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 		}
 	}
 

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -95,7 +95,7 @@ public:
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawTexture(VulkanTexture *texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, VkPipeline pipeline, int uvRotation);
 
-	void DestroyAllFBOs();
+	void DestroyAllFBOs(bool forceDelete);
 
 	virtual void Init() override;
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -455,7 +455,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 }
 
 GPU_Vulkan::~GPU_Vulkan() {
-	framebufferManager_->DestroyAllFBOs();
+	framebufferManager_->DestroyAllFBOs(true);
 	depalShaderCache_.Clear();
 	delete framebufferManager_;
 	delete pipelineManager_;
@@ -614,7 +614,7 @@ void GPU_Vulkan::Reinitialize() {
 void GPU_Vulkan::ReinitializeInternal() {
 	textureCache_.Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManager_->DestroyAllFBOs();
+	framebufferManager_->DestroyAllFBOs(true);
 	framebufferManager_->Resized();
 }
 
@@ -2236,7 +2236,7 @@ void GPU_Vulkan::DoState(PointerWrap &p) {
 		depalShaderCache_.Clear();
 
 		gstate_c.textureChanged = TEXCHANGE_UPDATED;
-		framebufferManager_->DestroyAllFBOs();
+		framebufferManager_->DestroyAllFBOs(true);
 		shaderManager_->ClearShaders();
 		pipelineManager_->Clear();
 	}


### PR DESCRIPTION
We can know that if an FBO is cleared up to scissor, the size of the clear is definitely <= the size of the FBO.  That means we can safely write out the bytes of the clear.

This may help games in #8359 and #6261 as well.  I've classified it under a "slow effect", but it mainly makes FBO decimation slower which ought not be common.

-[Unknown]
