### PR TITLE
Warning fixes + more ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,20 @@ if(CMAKE_SYSTEM_PROCESSOR)
 	endif()
 endif()
 
+# Using ccache greatly improves the speed of our CI builds, let's enable for all.
+# Without this, our CI can't use ccache for clang, for some reason.
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+
+	# ccache uses -I when compiling without preprocessor, which makes clang complain.
+	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+		set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+	endif()
+endif(CCACHE_FOUND)
+
 # Remove soon?
 set(USE_FFMPEG ON)
 

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -32,7 +32,7 @@ private:
 	void InvalidateICache(u32 addr, int size);
 	void SkipCodes(int count);
 	void SkipAllCodes();
-	bool cheatsOn, exit2, cheatEnabled;
+	bool exit2, cheatEnabled;
 	int GetAddress(int value);
 	std::vector<std::string> codeNameList;
 

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -166,7 +166,7 @@ public:
 	void CompNEON_ColorConv(MIPSOpcode op);
 	void CompNEON_Vbfy(MIPSOpcode op);
 
-	int Replace_fabsf();
+	int Replace_fabsf() override;
 
 	JitBlockCache *GetBlockCache() override { return &blocks; }
 

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -167,18 +167,18 @@ public:
 	void CompNEON_ColorConv(MIPSOpcode op);
 	void CompNEON_Vbfy(MIPSOpcode op);
 
-	int Replace_fabsf();
+	int Replace_fabsf() override;
 
-	JitBlockCache *GetBlockCache() { return &blocks; }
+	JitBlockCache *GetBlockCache() override { return &blocks; }
 
 	std::vector<u32> SaveAndClearEmuHackOps() override { return blocks.SaveAndClearEmuHackOps(); }
 	void RestoreSavedEmuHackOps(std::vector<u32> saved) override { blocks.RestoreSavedEmuHackOps(saved); }
 
-	void ClearCache();
-	void InvalidateCache();
-	void InvalidateCacheAt(u32 em_address, int length = 4);
+	void ClearCache() override;
+	void InvalidateCache() override;
+	void InvalidateCacheAt(u32 em_address, int length = 4) override;
 
-	void EatPrefix() { js.EatPrefix(); }
+	void EatPrefix() override { js.EatPrefix(); }
 
 	const u8 *GetDispatcher() const override {
 		return dispatcher;

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -84,7 +84,7 @@ public:
 	void Comp_ColorConv(MIPSOpcode op) override;
 	void Comp_Vbfy(MIPSOpcode op) override;
 
-	int Replace_fabsf();
+	int Replace_fabsf() override;
 	void DoState(PointerWrap &p);
 	bool CheckRounding();  // returns true if we need a do-over
 

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -161,9 +161,9 @@ public:
 	std::vector<u32> SaveAndClearEmuHackOps() override { return blocks_.SaveAndClearEmuHackOps(); }
 	void RestoreSavedEmuHackOps(std::vector<u32> saved) override { blocks_.RestoreSavedEmuHackOps(saved); }
 
-	void ClearCache();
-	void InvalidateCache();
-	void InvalidateCacheAt(u32 em_address, int length = 4);
+	void ClearCache() override;
+	void InvalidateCache() override;
+	void InvalidateCacheAt(u32 em_address, int length = 4) override;
 
 	const u8 *GetDispatcher() const override { return nullptr; }
 

--- a/Core/MIPS/MIPS/MipsJit.h
+++ b/Core/MIPS/MIPS/MipsJit.h
@@ -125,20 +125,20 @@ public:
 	void Comp_Vsgn(MIPSOpcode op) override {}
 	void Comp_Vocp(MIPSOpcode op) override {}
 	void Comp_ColorConv(MIPSOpcode op) override {}
-	int Replace_fabsf() { return 0; }
+	int Replace_fabsf() override { return 0; }
 
 	void Comp_Vbfy(MIPSOpcode op) {}
 
-	JitBlockCache *GetBlockCache() { return &blocks; }
+	JitBlockCache *GetBlockCache() override { return &blocks; }
 
 	std::vector<u32> SaveAndClearEmuHackOps() override { return blocks.SaveAndClearEmuHackOps(); }
 	void RestoreSavedEmuHackOps(std::vector<u32> saved) override { blocks.RestoreSavedEmuHackOps(saved); }
 
-	void ClearCache();
-	void InvalidateCache();
-	void InvalidateCacheAt(u32 em_address, int length = 4);
+	void ClearCache() override;
+	void InvalidateCache() override;
+	void InvalidateCacheAt(u32 em_address, int length = 4) override;
 
-	void EatPrefix() { js.EatPrefix(); }
+	void EatPrefix() override { js.EatPrefix(); }
 
 private:
 	void GenerateFixedCode();

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -154,21 +154,21 @@ public:
 		ApplyPrefixST(regs, js.prefixT, sz);
 	}
 	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);
-	void EatPrefix() { js.EatPrefix(); }
+	void EatPrefix() override { js.EatPrefix(); }
 
 	void RestoreRoundingMode(bool force = false);
 	void ApplyRoundingMode(bool force = false);
 	void UpdateRoundingMode();
 
-	JitBlockCache *GetBlockCache() { return &blocks; }
+	JitBlockCache *GetBlockCache() override { return &blocks; }
 	MIPSOpcode GetOriginalOp(MIPSOpcode op) override;
 
 	std::vector<u32> SaveAndClearEmuHackOps() override { return blocks.SaveAndClearEmuHackOps(); }
 	void RestoreSavedEmuHackOps(std::vector<u32> saved) override { blocks.RestoreSavedEmuHackOps(saved); }
 
-	void ClearCache();
+	void ClearCache() override;
 	void InvalidateCache() override;
-	void InvalidateCacheAt(u32 em_address, int length = 4) {
+	void InvalidateCacheAt(u32 em_address, int length = 4) override {
 		if (blocks.RangeMayHaveEmuHacks(em_address, em_address + length)) {
 			blocks.InvalidateICache(em_address, length);
 		}

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -93,19 +93,19 @@ public:
 	LPDIRECT3DSURFACE9 GetOffscreenSurface(LPDIRECT3DSURFACE9 similarSurface, VirtualFramebuffer *vfb);
 
 protected:
-	virtual void DisableState() override;
-	virtual void ClearBuffer(bool keepState = false) override;
-	virtual void FlushBeforeCopy() override;
-	virtual void DecimateFBOs() override;
+	void DisableState() override;
+	void ClearBuffer(bool keepState = false) override;
+	void FlushBeforeCopy() override;
+	void DecimateFBOs() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
-	virtual void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
+	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
-	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
-	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
-	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
-	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
+	void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
+	void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -73,7 +73,7 @@ public:
 		primaryInfo = reportingPrimaryInfo_;
 		fullInfo = reportingFullInfo_;
 	}
-	std::vector<FramebufferInfo> GetFramebufferList();
+	std::vector<FramebufferInfo> GetFramebufferList() override;
 
 	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -121,19 +121,19 @@ public:
 	struct CardboardSettings * GetCardboardSettings(struct CardboardSettings * cardboardSettings);
 
 protected:
-	virtual void DisableState() override;
-	virtual void ClearBuffer(bool keepState = false) override;
-	virtual void FlushBeforeCopy() override;
-	virtual void DecimateFBOs() override;
+	void DisableState() override;
+	void ClearBuffer(bool keepState = false) override;
+	void FlushBeforeCopy() override;
+	void DecimateFBOs() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
-	virtual void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
+	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
-	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
-	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
-	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
-	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
+	void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
+	void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -147,19 +147,19 @@ public:
 	}
 
 protected:
-	virtual void DisableState() override {}
-	virtual void ClearBuffer(bool keepState = false);
-	virtual void FlushBeforeCopy() override;
-	virtual void DecimateFBOs() override;
+	void DisableState() override {}
+	void ClearBuffer(bool keepState = false) override;
+	void FlushBeforeCopy() override;
+	void DecimateFBOs() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
-	virtual void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
+	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	virtual void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
-	virtual void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
-	virtual void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
-	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
-	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb) override;
+	void NotifyRenderFramebufferSwitched(VirtualFramebuffer *prevVfb, VirtualFramebuffer *vfb, bool isClearingDepth) override;
+	void NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) override;
+	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 
 private:

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -39,8 +39,8 @@ public:
 	void CheckGPUFeatures();
 
 	// These are where we can reset command buffers etc.
-	void BeginHostFrame();
-	void EndHostFrame();
+	void BeginHostFrame() override;
+	void EndHostFrame() override;
 
 	void InitClear() override;
 	void Reinitialize() override;
@@ -145,9 +145,9 @@ public:
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;
-	std::vector<FramebufferInfo> GetFramebufferList();
-	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
-	bool DescribeCodePtr(const u8 *ptr, std::string &name);
+	std::vector<FramebufferInfo> GetFramebufferList() override;
+	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
+	bool DescribeCodePtr(const u8 *ptr, std::string &name) override;
 
 
 protected:

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -157,11 +157,6 @@ static void ConvertProjMatrixToVulkan(Matrix4x4 &in, bool invertedX, bool invert
 	in.translateAndScale(trans, scale);
 }
 
-static void ConvertProjMatrixToVulkanThrough(Matrix4x4 &in) {
-	in.translateAndScale(Vec3(0.0f, 0.0f, 0.5f), Vec3(1.0f, 1.0f, 0.5f));
-}
-
-
 ShaderManagerVulkan::ShaderManagerVulkan(VulkanContext *vulkan)
 	: vulkan_(vulkan), lastVShader_(nullptr), lastFShader_(nullptr), globalDirty_(0xFFFFFFFF) {
 	codeBuffer_ = new char[16384];

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -121,7 +121,7 @@ public:
 	void ApplyTexture(VulkanPushBuffer *uploadBuffer, VkImageView &imageView, VkSampler &sampler);
 
 protected:
-	void DownloadFramebufferForClut(u32 clutAddr, u32 bytes);
+	void DownloadFramebufferForClut(u32 clutAddr, u32 bytes) override;
 
 private:
 	void Decimate();  // Run this once per frame to get rid of old textures.

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -365,7 +365,8 @@ public:
 			maxCount_(500) {}
 	void Draw(UIContext &dc) override;
 	void Update(const InputState &input_state) override;
-	void Axis(const AxisInput &input) override{
+	void Axis(const AxisInput &input) override {
+		// TODO: Check input.deviceId?
 		if (input.axisId == xAxis_) {
 			curX_ = input.value;
 		} else if (input.axisId == yAxis_) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -102,7 +102,7 @@ public:
 	}
 
 protected:
-	virtual UI::Size PopupWidth() const { return 500; }
+	UI::Size PopupWidth() const override { return 500; }
 
 private:
 	UI::EventReturn OnDeleteButtonClick(UI::EventParams &e);

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -478,6 +478,7 @@ ifeq ($(UNITTEST),1)
 	$(SRC)/ext/armips/Core/Assembler.cpp \
 	$(SRC)/ext/armips/Core/Common.cpp \
 	$(SRC)/ext/armips/Core/Expression.cpp \
+	$(SRC)/ext/armips/Core/ExpressionFunctions.cpp \
 	$(SRC)/ext/armips/Core/FileManager.cpp \
 	$(SRC)/ext/armips/Core/Misc.cpp \
 	$(SRC)/ext/armips/Core/SymbolData.cpp \

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -402,8 +402,8 @@ public:
 
 	void Clear(int mask, uint32_t colorval, float depthVal, int stencilVal) override;
 
-	virtual void Begin(bool clear, uint32_t colorval, float depthVal, int stencilVal);
-	virtual void End();
+	void Begin(bool clear, uint32_t colorval, float depthVal, int stencilVal) override;
+	void End() override;
 
 	std::string GetInfoString(T3DInfo info) const override {
 		// TODO: Make these actually query the right information
@@ -562,7 +562,7 @@ public:
 
 	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) override;
 	void Finalize(int zim_flags) override;
-	void AutoGenMipmaps() {}
+	void AutoGenMipmaps() override {}
 
 	VkImageView GetImageView() { return vkTex_->GetImageView(); }
 

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -203,7 +203,6 @@ private:
 	std::string *value_;
 	std::string textEditValue_;
 	std::string placeholder_;
-	int step_;
 	int maxLen_;
 };
 


### PR DESCRIPTION
This brings over clang warning fixes (mostly override) from #8651.

Additionally, it makes ccache work with clang and Blackberry builds.  The only one not working now is Symbian.

-[Unknown]
