### PR TITLE
Enable ccache for Symbian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,12 @@ cache:
   - apt
   - ccache
 
+# By encrypting the channel name, we disable notifications from forks by default.
+# It's not actually a big secret.
 notifications:
   irc:
-    channels: "chat.freenode.net#ppsspp"
+    channels:
+      - secure: "anmDihJ1uPnDSNDsEe3WQ5o4BsPApJbw6NupsAebt6kBxJm7WYKrSyUVmu/9GXgFvy756HBDVA6eikPtcak1+jLFfyOZqGw3ei69ZNnA+R7aoAzfiXilFqf53Yy2tzydEnF2nBYhJjQZgMBZUVWUD6pdKSXtVg/VZRhVqiDlb+A="
     on_success: change
     on_failure: always
     skip_join: true


### PR DESCRIPTION
Also, disable fork irc notifications by encrypting the channel name as a repo-specific value.

This halves the build time for Symbian under ideal conditions.  Once we switch to clang for Android, we'll also gain a bit more speed.  Hoping to see total elapsed time at 12 minutes or possibly less.

Now all the builds are cached.

-[Unknown]
