### PR TITLE
RFC: Remove unused exports / sections in jni so

### DIFF
--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -17,6 +17,9 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_STATIC_LIBRARIES := native libzip glslang
 LOCAL_LDLIBS := -lz -landroid -lGLESv2 -lOpenSLES -lEGL -ldl -llog
+ifneq ($(NDK_DEBUG),1)
+  LOCAL_LDFLAGS += -Wl,--gc-sections -Wl,--exclude-libs,ALL
+endif
 
 # ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)


### PR DESCRIPTION
This prevents all the symbols from being exported as visible from the static libs, since Java doesn't need them to be visible.

This reduces the ppsspp_jni.so size by 1MB when building only armv7.  I'm hitting the x86 build issue so not sure of the full gain, but I assume it would be about ~4MB less from the so.  The APK is only 367KB smaller for armv7, so probably a smaller total reduction in APK size.

The big downside is stack traces.  Here's an example before and after (inserted intentional crash):

```
backtrace:
    #00 pc 00240bc4  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (_ZN19CISOFileBlockDevice9ReadBlockEiPh+27)
    #01 pc 002421ff  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (_ZN13ISOFileSystemC1EP16IHandleAllocatorP11BlockDevice+154)
    #02 pc 001586cb  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (_ZN16GameInfoWorkItem3runEv+410)
    #03 pc 003c6d10  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so
    #04 pc 003c6880  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (_ZNSt6thread12RunAndDeleteINS_4FuncISt5_BindIFPFvP20PrioritizedWorkQueueES4_EEEEEEPvSA_+16)
    #05 pc 0003f45f  /system/lib/libc.so (_ZL15__pthread_startPv+30)
    #06 pc 00019b43  /system/lib/libc.so (__start_thread+6)

backtrace:
    #00 pc 0018e46c  /data/app/org.ppsspp.ppsspp-2/lib/arm/libppsspp_jni.so
    #01 pc 0018faa7  /data/app/org.ppsspp.ppsspp-2/lib/arm/libppsspp_jni.so
    #02 pc 000ab50b  /data/app/org.ppsspp.ppsspp-2/lib/arm/libppsspp_jni.so (_ZN16GameInfoWorkItem3runEv+410)
    #03 pc 002f7350  /data/app/org.ppsspp.ppsspp-2/lib/arm/libppsspp_jni.so
    #04 pc 002f6ec0  /data/app/org.ppsspp.ppsspp-2/lib/arm/libppsspp_jni.so
    #05 pc 0003f45f  /system/lib/libc.so (_ZL15__pthread_startPv+30)
    #06 pc 00019b43  /system/lib/libc.so (__start_thread+6)
```

I assume there are benefits to a smaller executable footprint, but I'm not sure if it's worth it.  I do like stack traces.  I tried `-g` but of course, that seems to be stripped.

Note: I assume `static` functions are already not included in stack traces for this reason.  But class members are always visible, I think.

-[Unknown]
