### PR TITLE
Qt: Allow full shutdown and config save on exit.

### DIFF
--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -492,9 +492,6 @@ int main(int argc, char *argv[])
 	
 	int ret = mainInternal(a);
 
-#ifndef MOBILE_DEVICE
-	exit(0);
-#endif
 	NativeShutdownGraphics();
 #ifdef SDL
 	SDL_PauseAudio(1);


### PR DESCRIPTION
We want to save the config on exit, as pointed out by akien-mga.  Also works around what may be a Ubuntu bug, causing segfaults on exit.

Fixes #8026.

-[Unknown]
