### PR TITLE
Fix reads from cache outside the file

### DIFF
--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -72,7 +72,12 @@ size_t CachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 	// While in case the cache size is too small for the entire read.
 	while (readSize < bytes) {
 		SaveIntoCache(absolutePos + readSize, bytes - readSize);
-		readSize += ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+		size_t bytesFromCache = ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+		readSize += bytesFromCache;
+		if (bytesFromCache == 0) {
+			// We can't read any more.
+			break;
+		}
 	}
 
 	StartReadAhead(absolutePos + readSize);

--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -68,6 +68,12 @@ void CachingFileLoader::Seek(s64 absolutePos) {
 }
 
 size_t CachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
+	if (absolutePos >= filesize_) {
+		bytes = 0;
+	} else if (absolutePos + (s64)bytes >= filesize_) {
+		bytes = filesize_ - absolutePos;
+	}
+
 	size_t readSize = ReadFromCache(absolutePos, bytes, data);
 	// While in case the cache size is too small for the entire read.
 	while (readSize < bytes) {

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -82,7 +82,12 @@ size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) 
 		while (readSize < bytes) {
 			readSize += cache_->SaveIntoCache(backend_, absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
 			// If there are already-cached blocks afterward, we have to read them.
-			readSize += cache_->ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+			size_t bytesFromCache = cache_->ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+			readSize += bytesFromCache;
+			if (bytesFromCache == 0) {
+				// We can't read any more.
+				break;
+			}
 		}
 	} else {
 		readSize = backend_->ReadAt(absolutePos, bytes, data);

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -76,6 +76,12 @@ void DiskCachingFileLoader::Seek(s64 absolutePos) {
 size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 	size_t readSize;
 
+	if (absolutePos >= filesize_) {
+		bytes = 0;
+	} else if (absolutePos + (s64)bytes >= filesize_) {
+		bytes = filesize_ - absolutePos;
+	}
+
 	if (cache_ && cache_->IsValid()) {
 		readSize = cache_->ReadFromCache(absolutePos, bytes, data);
 		// While in case the cache size is too small for the entire read.

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -79,7 +79,12 @@ size_t RamCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
 		// While in case the cache size is too small for the entire read.
 		while (readSize < bytes) {
 			SaveIntoCache(absolutePos + readSize, bytes - readSize);
-			readSize += ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+			size_t bytesFromCache = ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
+			readSize += bytesFromCache;
+			if (bytesFromCache == 0) {
+			// We can't read any more.
+				break;
+			}
 		}
 	}
 
@@ -134,7 +139,7 @@ size_t RamCachingFileLoader::ReadFromCache(s64 pos, size_t bytes, void *data) {
 	u8 *p = (u8 *)data;
 
 	// Clamp bytes to what's actually available.
-	if (pos + bytes > filesize_) {
+	if (pos + (s64)bytes > filesize_) {
 		// Should've been caught above, but just in case.
 		if (pos >= filesize_) {
 			return 0;


### PR DESCRIPTION
Homebrew seems to all trigger us to read after the end of file, which was looping infinitely.  Fixes #8773.

Oops.

-[Unknown]
