### PR TITLE
Pass Build.BOARD from Java, avoid lookup

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -23,9 +23,6 @@
 #ifdef BLACKBERRY
 #include <bps/deviceinfo.h>
 #endif
-#ifdef ANDROID
-#include <sys/system_properties.h>
-#endif
 
 // Only Linux platforms have /proc/cpuinfo
 #if defined(__linux__)
@@ -45,17 +42,6 @@ std::string GetCPUString() {
 			}
 		}
 	}
-
-#ifdef ANDROID
-	if (cpu_string.empty()) {
-		char temp[PROP_VALUE_MAX];
-		if (__system_property_get("ro.product.board", temp) != 0) {
-			cpu_string = temp;
-		} else if (__system_property_get("ro.product.name", temp) != 0) {
-			cpu_string = temp;
-		}
-	}
-#endif
 
 	if (cpu_string.empty())
 		cpu_string = "Unknown";
@@ -80,17 +66,6 @@ std::string GetCPUBrandString() {
 			}
 		}
 	}
-
-#ifdef ANDROID
-	if (brand_string.empty()) {
-		char temp[PROP_VALUE_MAX];
-		if (__system_property_get("ro.product.model", temp) != 0) {
-			brand_string = temp;
-		} else if (__system_property_get("ro.product.name", temp) != 0) {
-			brand_string = temp;
-		}
-	}
-#endif
 
 	if (brand_string.empty())
 		brand_string = "Unknown";
@@ -296,8 +271,6 @@ void CPUInfo::Detect()
 	// Whether the above detection failed or not, on ARM64 we do have ASIMD/NEON.
 	bNEON = true;
 	bASIMD = true;
-
-	sBugs.bExynos8890Invalidation = strcmp(cpu_string, "universal8890") == 0;
 #endif
 }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -35,6 +35,7 @@
 
 #include "thin3d/thin3d.h"
 #include "Core/Config.cpp"
+#include "Common/CPUDetect.h"
 #include "Common/GraphicsContext.h"
 #include "Common/GL/GLInterfaceBase.h"
 #include "Common/Vulkan/VulkanLoader.h"
@@ -476,7 +477,7 @@ extern "C" jstring Java_org_ppsspp_ppsspp_NativeApp_queryConfig
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
   (JNIEnv *env, jclass, jstring jmodel, jint jdeviceType, jstring jlangRegion, jstring japkpath,
 		jstring jdataDir, jstring jexternalDir, jstring jlibraryDir, jstring jcacheDir, jstring jshortcutParam,
-		jint jAndroidVersion, jboolean jjavaGL) {
+		jint jAndroidVersion, jstring jboard, jboolean jjavaGL) {
 	jniEnvUI = env;
 	javaGL = jjavaGL;
 	setCurrentThreadName("androidInit");
@@ -510,6 +511,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	library_path = GetJavaString(env, jlibraryDir) + "/";
 	std::string shortcut_param = GetJavaString(env, jshortcutParam);
 	std::string cacheDir = GetJavaString(env, jcacheDir);
+	std::string buildBoard = GetJavaString(env, jboard);
 
 	ILOG("NativeApp.init(): External storage path: %s", externalDir.c_str());
 	ILOG("NativeApp.init(): Launch shortcut parameter: %s", shortcut_param.c_str());
@@ -520,6 +522,12 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	bool landscape;
 
 	net::Init();
+
+	// Unfortunately, on the Samsung Galaxy S7, this isn't in /proc/cpuinfo.
+	// We also can't read it from __system_property_get.
+	if (buildBoard == "universal8890") {
+		cpu_info.sBugs.bExynos8890Invalidation = true;
+	}
 
 	NativeGetAppInfo(&app_name, &app_nice_name, &landscape, &version);
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -266,7 +266,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		String languageRegion = Locale.getDefault().getLanguage() + "_" + Locale.getDefault().getCountry();
 
 		NativeApp.audioConfig(optimalFramesPerBuffer, optimalSampleRate);
-		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT, javaGL);
+		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT, Build.BOARD, javaGL);
 
 		sendInitialGrants();
 

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -13,7 +13,7 @@ public class NativeApp {
 	public final static int DEVICE_TYPE_TV = 1;
 	public final static int DEVICE_TYPE_DESKTOP = 2;
 
-	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion, boolean javaGL);
+	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion, String board, boolean javaGL);
 	public static native void audioInit();
 	public static native void audioShutdown();
 	public static native void audioConfig(int optimalFramesPerBuffer, int optimalSampleRate);


### PR DESCRIPTION
Fixes arm64 build with r10, but is ugly coupling.

-[Unknown]
