### PR TITLE
Remove some dependency coupling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1676,7 +1676,6 @@ set(LinkCommon ${CoreLibName} ${CMAKE_THREAD_LIBS_INIT} ${nativeExtraLibs})
 if(HEADLESS)
 	add_executable(PPSSPPHeadless
 		headless/Headless.cpp
-		UI/OnScreenDisplay.cpp
 		headless/StubHost.h
 		headless/Compare.cpp
 		headless/Compare.h)
@@ -1695,7 +1694,6 @@ if(UNITTEST)
 		unittest/JitHarness.cpp
 		Core/MIPS/ARM/ArmRegCache.cpp
 		Core/MIPS/ARM/ArmRegCacheFPU.cpp
-		UI/OnScreenDisplay.cpp
 	)
 	target_link_libraries(unitTest
 		${COCOA_LIBRARY} ${LinkCommon} Common)

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -21,10 +21,11 @@
 #include "Core/CoreParameter.h"
 
 class GraphicsContext;
+struct InputState;
 
 // called from emu thread
-void UpdateRunLoop();
-void Core_Run(GraphicsContext *ctx);
+void UpdateRunLoop(GraphicsContext *input_state);
+void Core_Run(GraphicsContext *ctx, InputState *input_state);
 void Core_Stop();
 void Core_ErrorPause();
 // For platforms that don't call Core_Run

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -1,5 +1,4 @@
 #include "i18n/i18n.h"
-#include "UI/OnScreenDisplay.h"
 #include "Common/StringUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/FileUtil.h"
@@ -7,6 +6,7 @@
 #include "Core/CoreParameter.h"
 #include "Core/CwCheat.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Core/System.h"
@@ -50,7 +50,7 @@ static void __CheatStart() {
 		}
 		if (!File::Exists(activeCheatFile)) {
 			I18NCategory *err = GetI18NCategory("Error");
-			osm.Show(err->T("Unable to create cheat file, disk may be full"));
+			host->NotifyUserMessage(err->T("Unable to create cheat file, disk may be full"));
 		}
 
 	}

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -19,6 +19,7 @@
 #include "base/logging.h"
 #include "Common/ChunkFile.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/Reporting.h"
 #include "Core/System.h"
 #include "Core/Dialog/SavedataParam.h"
@@ -30,7 +31,6 @@
 #include "Core/ELF/ParamSFO.h"
 #include "Core/HW/MemoryStick.h"
 #include "Core/Util/PPGeDraw.h"
-#include "UI/OnScreenDisplay.h"
 
 #include "image/png_load.h"
 
@@ -372,7 +372,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 	if (!pspFileSystem.GetFileInfo(dirPath).exists) {
 		if (!pspFileSystem.MkDir(dirPath)) {
 			I18NCategory *err = GetI18NCategory("Error");
-			osm.Show(err->T("Unable to write savedata, disk may be full"));
+			host->NotifyUserMessage(err->T("Unable to write savedata, disk may be full"));
 		}
 	}
 
@@ -397,7 +397,7 @@ bool SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &save
 		if (EncryptData(decryptMode, cryptedData, &cryptedSize, &aligned_len, cryptedHash, (HasKey(param) ? param->key : 0)) != 0)
 		{
 			I18NCategory *err = GetI18NCategory("Error");
-			osm.Show(err->T("Save encryption failed. This save won't work on real PSP"), 6.0f);
+			host->NotifyUserMessage(err->T("Save encryption failed. This save won't work on real PSP"), 6.0f);
 			ERROR_LOG(SCEUTILITY,"Save encryption failed. This save won't work on real PSP");
 			delete[] cryptedData;
 			cryptedData = 0;
@@ -642,8 +642,8 @@ void SavedataParam::LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8
 			// Don't notify the user if we're not going to upgrade the save.
 			if (!g_Config.bEncryptSave) {
 				I18NCategory *di = GetI18NCategory("Dialog");
-				osm.Show(di->T("When you save, it will load on a PSP, but not an older PPSSPP"), 6.0f);
-				osm.Show(di->T("Old savedata detected"), 6.0f);
+				host->NotifyUserMessage(di->T("When you save, it will load on a PSP, but not an older PPSSPP"), 6.0f);
+				host->NotifyUserMessage(di->T("Old savedata detected"), 6.0f);
 			}
 		} else {
 			if (decryptMode == 5 && prevCryptMode == 3) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -26,8 +26,8 @@
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HW/MemoryStick.h"
+#include "Core/Host.h"
 #include "Core/Reporting.h"
-#include "UI/OnScreenDisplay.h"
 
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
@@ -223,7 +223,7 @@ bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, Fil
 		if (w32err == ERROR_DISK_FULL || w32err == ERROR_NOT_ENOUGH_QUOTA) {
 			// This is returned when the disk is full.
 			I18NCategory *err = GetI18NCategory("Error");
-			osm.Show(err->T("Disk full while writing data"));
+			host->NotifyUserMessage(err->T("Disk full while writing data"));
 			error = SCE_KERNEL_ERROR_ERRNO_NO_PERM;
 		}
 	}
@@ -278,7 +278,7 @@ bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, Fil
 	} else if (errno == ENOSPC) {
 		// This is returned when the disk is full.
 		I18NCategory *err = GetI18NCategory("Error");
-		osm.Show(err->T("Disk full while writing data"));
+		host->NotifyUserMessage(err->T("Disk full while writing data"));
 		error = SCE_KERNEL_ERROR_ERRNO_NO_PERM;
 	}
 #endif
@@ -333,13 +333,13 @@ size_t DirectoryFileHandle::Write(const u8* pointer, s64 size)
 	}
 
 	if (diskFull) {
-		// Sign extend on 64-bit.
 		ERROR_LOG(FILESYS, "Disk full");
 		I18NCategory *err = GetI18NCategory("Error");
-		osm.Show(err->T("Disk full while writing data"));
+		host->NotifyUserMessage(err->T("Disk full while writing data"));
 		// We only return an error when the disk is actually full.
 		// When writing this would cause the disk to be full, so it wasn't written, we return 0.
 		if (MemoryStick_FreeSpace() == 0) {
+			// Sign extend on 64-bit.
 			return (size_t)(s64)(s32)SCE_KERNEL_ERROR_ERRNO_DEVICE_NO_FREE_SPACE;
 		}
 	}

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -24,10 +24,10 @@
 #include <cstring>
 #include "util/text/parsers.h"
 #include "Core/Core.h"
+#include "Core/Host.h"
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelMemory.h"
-#include "UI/OnScreenDisplay.h"
 #include "proAdhoc.h" 
 #include "i18n/i18n.h"
 
@@ -1419,7 +1419,7 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	iResult = getaddrinfo(g_Config.proAdhocServer.c_str(),0,NULL,&resultAddr);
 	if (iResult != 0) {
 		ERROR_LOG(SCENET, "DNS Error (%s)\n", g_Config.proAdhocServer.c_str());
-		osm.Show("DNS Error connecting to " + g_Config.proAdhocServer, 8.0f);
+		host->NotifyUserMessage("DNS Error connecting to " + g_Config.proAdhocServer, 8.0f);
 		return iResult;
 	}
 	for (ptr = resultAddr; ptr != NULL; ptr = ptr->ai_next) {
@@ -1442,7 +1442,7 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 		char buffer[512];
 		snprintf(buffer, sizeof(buffer), "Socket error (%i) when connecting to %s/%u.%u.%u.%u:%u", errno, g_Config.proAdhocServer.c_str(), sip[0], sip[1], sip[2], sip[3], ntohs(server_addr.sin_port));
 		ERROR_LOG(SCENET, "%s", buffer);
-		osm.Show(std::string(buffer), 8.0f);
+		host->NotifyUserMessage(buffer, 8.0f);
 		return iResult;
 	}
 
@@ -1458,7 +1458,7 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	changeBlockingMode(metasocket, 1); // Change to non-blocking
 	if (sent > 0) {
 		I18NCategory *n = GetI18NCategory("Networking");
-		osm.Show(n->T("Network Initialized"), 1.0);
+		host->NotifyUserMessage(n->T("Network Initialized"), 1.0);
 		return 0;
 	}
 	else{

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -64,6 +64,8 @@ public:
 	virtual bool CanCreateShortcut() {return false;}
 	virtual bool CreateDesktopShortcut(std::string argumentPath, std::string title) {return false;}
 
+	virtual void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) {}
+
 	// Used for headless.
 	virtual bool ShouldSkipUI() { return false; }
 	virtual void SendDebugOutput(const std::string &output) {}

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -379,10 +379,7 @@ namespace SaveState
 
 	void NextSlot()
 	{
-		I18NCategory *sy = GetI18NCategory("System");
 		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % NUM_SLOTS;
-		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), g_Config.iCurrentStateSlot + 1);
-		osm.Show(msg);
 	}
 
 	void LoadSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData)

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -20,7 +20,6 @@
 
 #include "base/mutex.h"
 #include "base/timeutil.h"
-#include "base/NativeApp.h"
 #include "i18n/i18n.h"
 
 #include "Common/FileUtil.h"
@@ -384,7 +383,6 @@ namespace SaveState
 		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % NUM_SLOTS;
 		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), g_Config.iCurrentStateSlot + 1);
 		osm.Show(msg);
-		NativeMessageReceived("slotchanged", "");
 	}
 
 	void LoadSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData)

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -43,7 +43,6 @@
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "HW/MemoryStick.h"
 #include "GPU/GPUState.h"
-#include "UI/OnScreenDisplay.h"
 
 namespace SaveState
 {
@@ -389,9 +388,8 @@ namespace SaveState
 			Load(fn, callback, cbUserData);
 		} else {
 			I18NCategory *sy = GetI18NCategory("System");
-			osm.Show(sy->T("Failed to load state. Error in the file system."), 2.0);
 			if (callback)
-				callback(false, cbUserData);
+				callback(false, sy->T("Failed to load state. Error in the file system."), cbUserData);
 		}
 	}
 
@@ -400,7 +398,7 @@ namespace SaveState
 		std::string fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		std::string shot = GenerateSaveSlotFilename(gameFilename, slot, SCREENSHOT_EXTENSION);
 		if (!fn.empty()) {
-			auto renameCallback = [=](bool status, void *data) {
+			auto renameCallback = [=](bool status, const std::string &message, void *data) {
 				if (status) {
 					if (File::Exists(fn)) {
 						File::Delete(fn);
@@ -408,17 +406,16 @@ namespace SaveState
 					File::Rename(fn + ".tmp", fn);
 				}
 				if (callback) {
-					callback(status, data);
+					callback(status, message, data);
 				}
 			};
 			// Let's also create a screenshot.
 			SaveScreenshot(shot, Callback(), 0);
 			Save(fn + ".tmp", renameCallback, cbUserData);
 		} else {
-			I18NCategory *sc = GetI18NCategory("Screen");
-			osm.Show("Failed to save state. Error in the file system.", 2.0);
+			I18NCategory *sy = GetI18NCategory("System");
 			if (callback)
-				callback(false, cbUserData);
+				callback(false, sy->T("Failed to save state. Error in the file system."), cbUserData);
 		}
 	}
 
@@ -564,6 +561,7 @@ namespace SaveState
 			Operation &op = operations[i];
 			CChunkFileReader::Error result;
 			bool callbackResult;
+			std::string callbackMessage;
 			std::string reason;
 
 			I18NCategory *sc = GetI18NCategory("Screen");
@@ -580,16 +578,16 @@ namespace SaveState
 				INFO_LOG(COMMON, "Loading state from %s", op.filename.c_str());
 				result = CChunkFileReader::Load(op.filename, PPSSPP_GIT_VERSION, state, &reason);
 				if (result == CChunkFileReader::ERROR_NONE) {
-					osm.Show(sc->T("Loaded State"), 2.0);
+					callbackMessage = sc->T("Loaded State");
 					callbackResult = true;
 					hasLoadedState = true;
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					HandleFailure();
-					osm.Show(i18nLoadFailure, 2.0);
+					callbackMessage = i18nLoadFailure;
 					ERROR_LOG(COMMON, "Load state failure: %s", reason.c_str());
 					callbackResult = false;
 				} else {
-					osm.Show(sc->T(reason.c_str(), i18nLoadFailure), 2.0);
+					callbackMessage = sc->T(reason.c_str(), i18nLoadFailure);
 					callbackResult = false;
 				}
 				break;
@@ -598,45 +596,48 @@ namespace SaveState
 				INFO_LOG(COMMON, "Saving state to %s", op.filename.c_str());
 				result = CChunkFileReader::Save(op.filename, g_paramSFO.GetValueString("TITLE"), PPSSPP_GIT_VERSION, state);
 				if (result == CChunkFileReader::ERROR_NONE) {
-
-					osm.Show(sc->T("Saved State"), 2.0);
+					callbackMessage = sc->T("Saved State");
 					callbackResult = true;
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					HandleFailure();
-					osm.Show(i18nSaveFailure, 2.0);
+					callbackMessage = i18nSaveFailure;
 					ERROR_LOG(COMMON, "Save state failure: %s", reason.c_str());
 					callbackResult = false;
 				} else {
-					osm.Show(i18nSaveFailure, 2.0);
+					callbackMessage = i18nSaveFailure;
 					callbackResult = false;
 				}
 				break;
 
 			case SAVESTATE_VERIFY:
-				INFO_LOG(COMMON, "Verifying save state system");
 				callbackResult = CChunkFileReader::Verify(state) == CChunkFileReader::ERROR_NONE;
+				if (callbackResult) {
+					INFO_LOG(COMMON, "Verified save state system");
+				} else {
+					ERROR_LOG(COMMON, "Save state system verification failed");
+				}
 				break;
 
 			case SAVESTATE_REWIND:
 				INFO_LOG(COMMON, "Rewinding to recent savestate snapshot");
 				result = rewindStates.Restore();
 				if (result == CChunkFileReader::ERROR_NONE) {
-					osm.Show(sc->T("Loaded State"), 2.0);
+					callbackMessage = sc->T("Loaded State");
 					callbackResult = true;
 					hasLoadedState = true;
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					// Cripes.  Good news is, we might have more.  Let's try those too, better than a reset.
 					if (HandleFailure()) {
 						// Well, we did rewind, even if too much...
-						osm.Show(sc->T("Loaded State"), 2.0);
+						callbackMessage = sc->T("Loaded State");
 						callbackResult = true;
 						hasLoadedState = true;
 					} else {
-						osm.Show(i18nLoadFailure, 2.0);
+						callbackMessage = i18nLoadFailure;
 						callbackResult = false;
 					}
 				} else {
-					osm.Show(i18nLoadFailure, 2.0);
+					callbackMessage = i18nLoadFailure;
 					callbackResult = false;
 				}
 				break;
@@ -655,7 +656,7 @@ namespace SaveState
 			}
 
 			if (op.callback)
-				op.callback(callbackResult, op.cbUserData);
+				op.callback(callbackResult, callbackMessage, op.cbUserData);
 		}
 		if (operations.size()) {
 			// Avoid triggering frame skipping due to slowdown

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -23,7 +23,7 @@
 
 namespace SaveState
 {
-	typedef std::function<void(bool status, void *cbUserData)> Callback;
+	typedef std::function<void(bool status, const std::string &message, void *cbUserData)> Callback;
 
 	static const int NUM_SLOTS = 5;
 	static const char *STATE_EXTENSION = "ppst";

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -22,13 +22,13 @@
 #include "Common/Common.h"
 #include "Core/Config.h"
 #include "Core/CoreParameter.h"
+#include "Core/Host.h"
 #include "Core/Reporting.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Core/System.h"
 #include "GPU/Common/FramebufferCommon.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
-#include "UI/OnScreenDisplay.h"  // Gross dependency!
 
 void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW, float origH, float frameW, float frameH, int rotation) {
 	float outW;
@@ -1012,5 +1012,5 @@ void FramebufferManagerCommon::ShowScreenResolution() {
 	messageStream << gr->T("Window Size") << ": ";
 	messageStream << PSP_CoreParameter().pixelWidth << "x" << PSP_CoreParameter().pixelHeight;
 
-	osm.Show(messageStream.str(), 2.0f, 0xFFFFFF, -1, true, "resize");
+	host->NotifyUserMessage(messageStream.str(), 2.0f, 0xFFFFFF, "resize");
 }

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -22,12 +22,14 @@
 #include <map>
 #include "helper/global.h"
 #include "base/logging.h"
+#include "i18n/i18n.h"
 #include "math/lin/matrix4x4.h"
 #include "math/math_util.h"
 #include "util/text/utf8.h"
 
 #include "Common/Common.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/Reporting.h"
 #include "GPU/Math3D.h"
 #include "GPU/GPUState.h"
@@ -35,7 +37,6 @@
 #include "GPU/Directx9/ShaderManagerDX9.h"
 #include "GPU/Directx9/DrawEngineDX9.h"
 #include "GPU/Directx9/FramebufferDX9.h"
-#include "UI/OnScreenDisplay.h"
 
 namespace DX9 {
 
@@ -613,8 +614,9 @@ VSShader *ShaderManagerDX9::ApplyShader(int prim, u32 vertType) {
 		vs = new VSShader(VSID, codeBuffer_, useHWTransform);
 
 		if (vs->Failed()) {
+			I18NCategory *gr = GetI18NCategory("Graphics");
 			ERROR_LOG(HLE, "Shader compilation failed, falling back to software transform");
-			osm.Show("hardware transform error - falling back to software", 2.5f, 0xFF3030FF, -1, true);
+			host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
 			delete vs;
 
 			ComputeVertexShaderID(&VSID, vertType, false);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -46,8 +46,6 @@
 #include "GPU/GLES/DrawEngineGLES.h"
 #include "GPU/GLES/ShaderManager.h"
 
-#include "UI/OnScreenDisplay.h"
-
 // #define DEBUG_READ_PIXELS 1
 
 static const char tex_fs[] =
@@ -180,9 +178,9 @@ void FramebufferManager::CompileDraw2DProgram() {
 					}
 				}
 				if (!firstLine.empty()) {
-					osm.Show("Post-shader error: " + firstLine + "...", 10.0f, 0xFF3090FF);
+					host->NotifyUserMessage("Post-shader error: " + firstLine + "...", 10.0f, 0xFF3090FF);
 				} else {
-					osm.Show("Post-shader error, see log for details", 10.0f, 0xFF3090FF);
+					host->NotifyUserMessage("Post-shader error, see log for details", 10.0f, 0xFF3090FF);
 				}
 				usePostShader_ = false;
 			} else {

--- a/GPU/GLES/ShaderManager.cpp
+++ b/GPU/GLES/ShaderManager.cpp
@@ -26,12 +26,14 @@
 
 #include "base/logging.h"
 #include "base/timeutil.h"
+#include "i18n/i18n.h"
 #include "math/math_util.h"
 #include "math/lin/matrix4x4.h"
 #include "profiler/profiler.h"
 
 #include "Common/FileUtil.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/Reporting.h"
 #include "GPU/Math3D.h"
 #include "GPU/GPUState.h"
@@ -39,9 +41,7 @@
 #include "GPU/GLES/GLStateCache.h"
 #include "GPU/GLES/ShaderManager.h"
 #include "GPU/GLES/DrawEngineGLES.h"
-#include "UI/OnScreenDisplay.h"
 #include "Framebuffer.h"
-#include "i18n/i18n.h"
 
 Shader::Shader(const char *code, uint32_t glShaderType, bool useHWTransform)
 	  : failed_(false), useHWTransform_(useHWTransform) {
@@ -845,7 +845,7 @@ Shader *ShaderManager::ApplyVertexShader(int prim, u32 vertType, ShaderID *VSID)
 		if (vs->Failed()) {
 			I18NCategory *gr = GetI18NCategory("Graphics");
 			ERROR_LOG(G3D, "Shader compilation failed, falling back to software transform");
-			osm.Show(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF, -1, true);
+			host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
 			delete vs;
 
 			// TODO: Look for existing shader with the appropriate ID, use that instead of generating a new one - however, need to make sure

--- a/GPU/GLES/TextureCache.cpp
+++ b/GPU/GLES/TextureCache.cpp
@@ -38,7 +38,6 @@
 #include "GPU/GLES/ShaderManager.h"
 #include "GPU/GLES/DrawEngineGLES.h"
 #include "GPU/Common/TextureDecoder.h"
-#include "UI/OnScreenDisplay.h"
 
 #ifdef _M_SSE
 #include <xmmintrin.h>
@@ -1917,9 +1916,9 @@ void TextureCache::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &repla
 
 				I18NCategory *err = GetI18NCategory("Error");
 				if (scaleFactor > 1) {
-					osm.Show(err->T("Warning: Video memory FULL, reducing upscaling and switching to slow caching mode"), 2.0f);
+					host->NotifyUserMessage(err->T("Warning: Video memory FULL, reducing upscaling and switching to slow caching mode"), 2.0f);
 				} else {
-					osm.Show(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
+					host->NotifyUserMessage(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
 				}
 			} else if (err != GL_NO_ERROR) {
 				// We checked the err anyway, might as well log if there is one.

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -50,8 +50,6 @@
 #include "GPU/Vulkan/ShaderManagerVulkan.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
-#include "UI/OnScreenDisplay.h"
-
 const VkFormat framebufFormat = VK_FORMAT_R8G8B8A8_UNORM;
 
 static const char tex_fs[] = R"(#version 400

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -39,7 +39,6 @@
 #include "GPU/Vulkan/FramebufferVulkan.h"
 #include "GPU/Vulkan/FragmentShaderGeneratorVulkan.h"
 #include "GPU/Vulkan/VertexShaderGeneratorVulkan.h"
-#include "UI/OnScreenDisplay.h"
 
 VulkanFragmentShader::VulkanFragmentShader(VulkanContext *vulkan, ShaderID id, const char *code, bool useHWTransform)
 	: vulkan_(vulkan), id_(id), failed_(false), useHWTransform_(useHWTransform), module_(0) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -42,7 +42,6 @@
 #include "GPU/Vulkan/ShaderManagerVulkan.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Common/TextureDecoder.h"
-#include "UI/OnScreenDisplay.h"
 
 #ifdef _M_SSE
 #include <xmmintrin.h>
@@ -1360,9 +1359,9 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry,VulkanPushBuffe
 
 			I18NCategory *err = GetI18NCategory("Error");
 			if (scaleFactor > 1) {
-				osm.Show(err->T("Warning: Video memory FULL, reducing upscaling and switching to slow caching mode"), 2.0f);
+				host->NotifyUserMessage(err->T("Warning: Video memory FULL, reducing upscaling and switching to slow caching mode"), 2.0f);
 			} else {
-				osm.Show(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
+				host->NotifyUserMessage(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
 			}
 
 			scaleFactor = 1;

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -178,7 +178,7 @@ void MainWindow::closeAct()
 	SetGameTitle("");
 }
 
-void SaveStateActionFinished(bool result, void *userdata)
+void SaveStateActionFinished(bool result, const std::string &message, void *userdata)
 {
 	// TODO: Improve messaging?
 	if (!result)

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -398,6 +398,7 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		break;
 	case VIRTKEY_NEXT_SLOT:
 		SaveState::NextSlot();
+		NativeMessageReceived("savestate_displayslot", "");
 		break;
 	case VIRTKEY_TOGGLE_FULLSCREEN:
 		System_SendMessage("toggle_fullscreen", "");

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -811,8 +811,14 @@ void EmuScreen::update(InputState &input) {
 			}
 		}
 
-		if (time_now_d() - saveStatePreviewShownTime_ > 2 && saveStatePreview_->GetVisibility() == UI::V_VISIBLE) {
-			saveStatePreview_->SetVisibility(UI::V_GONE);
+		if (saveStatePreview_->GetVisibility() == UI::V_VISIBLE) {
+			double endTime = saveStatePreviewShownTime_ + 2.0;
+			float alpha = clamp_value((endTime - time_now_d()) * 4.0, 0.0, 1.0);
+			saveStatePreview_->SetColor(colorAlpha(0x00FFFFFF, alpha));
+
+			if (time_now_d() - saveStatePreviewShownTime_ > 2) {
+				saveStatePreview_->SetVisibility(UI::V_GONE);
+			}
 		}
 	}
 }

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -89,4 +89,5 @@ private:
 
 	double saveStatePreviewShownTime_;
 	AsyncImageFileView *saveStatePreview_;
+	int saveStateSlot_;
 };

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "Core/Host.h"
+#include "UI/OnScreenDisplay.h"
 
 #if !defined(MOBILE_DEVICE) && defined(USING_QT_UI)
 #include "Core/Debugger/SymbolMap.h"
@@ -50,6 +51,10 @@ public:
 	bool IsDebuggingEnabled() override {return false;}
 	bool AttemptLoadSymbolMap() override {return false;}
 	void SetWindowTitle(const char *message) override {}
+
+	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override {
+		osm.Show(message, duration, color, -1, true, id);
+	}
 };
 
 #if !defined(MOBILE_DEVICE) && defined(USING_QT_UI)
@@ -126,6 +131,11 @@ public:
 
 		mainWindow->setWindowTitle(title);
 	}
+
+	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override {
+		osm.Show(message, duration, color, -1, true, id);
+	}
+
 	bool GPUDebuggingActive()
 	{
 		auto dialogDisplayList = mainWindow->GetDialogDisplaylist();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -770,7 +770,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		I18NCategory *sy = GetI18NCategory("System");
 		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), SaveState::GetCurrentSlot() + 1);
 		// Show for the same duration as the preview.
-		osm.Show(msg, 2.0f);
+		osm.Show(msg, 2.0f, 0xFFFFFF, -1, true, "savestate_slot");
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -769,7 +769,8 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "savestate_displayslot") {
 		I18NCategory *sy = GetI18NCategory("System");
 		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), SaveState::GetCurrentSlot() + 1);
-		osm.Show(msg);
+		// Show for the same duration as the preview.
+		osm.Show(msg, 2.0f);
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -489,8 +489,13 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 #endif
 
-	if (!boot_filename.empty() && stateToLoad != NULL)
-		SaveState::Load(stateToLoad);
+	if (!boot_filename.empty() && stateToLoad != NULL) {
+		SaveState::Load(stateToLoad, [](bool status, const std::string &message, void *) {
+			if (!message.empty()) {
+				osm.Show(message, 2.0);
+			}
+		});
+	}
 
 	screenManager = new ScreenManager();
 	if (skipLogo) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -766,6 +766,11 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 			g_Config.sNickName = inputboxValue[1];
 		inputboxValue.clear();
 	}
+	if (msg == "savestate_displayslot") {
+		I18NCategory *sy = GetI18NCategory("System");
+		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), SaveState::GetCurrentSlot() + 1);
+		osm.Show(msg);
+	}
 }
 
 void NativeUpdate(InputState &input) {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -40,6 +40,7 @@
 #include "UI/ReportScreen.h"
 #include "UI/CwCheatScreen.h"
 #include "UI/MainScreen.h"
+#include "UI/OnScreenDisplay.h"
 #include "UI/GameInfoCache.h"
 
 void AsyncImageFileView::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
@@ -224,9 +225,15 @@ void SaveSlotView::Draw(UIContext &dc) {
 	UI::LinearLayout::Draw(dc);
 }
 
+static void AfterSaveStateAction(bool status, const std::string &message, void *) {
+	if (!message.empty()) {
+		osm.Show(message, 2.0);
+	}
+}
+
 UI::EventReturn SaveSlotView::OnLoadState(UI::EventParams &e) {
 	g_Config.iCurrentStateSlot = slot_;
-	SaveState::LoadSlot(gamePath_, slot_, SaveState::Callback(), 0);
+	SaveState::LoadSlot(gamePath_, slot_, &AfterSaveStateAction);
 	UI::EventParams e2;
 	e2.v = this;
 	OnStateLoaded.Trigger(e2);
@@ -235,7 +242,7 @@ UI::EventReturn SaveSlotView::OnLoadState(UI::EventParams &e) {
 
 UI::EventReturn SaveSlotView::OnSaveState(UI::EventParams &e) {
 	g_Config.iCurrentStateSlot = slot_;
-	SaveState::SaveSlot(gamePath_, slot_, SaveState::Callback(), 0);
+	SaveState::SaveSlot(gamePath_, slot_, &AfterSaveStateAction);
 	UI::EventParams e2;
 	e2.v = this;
 	OnStateSaved.Trigger(e2);
@@ -389,7 +396,7 @@ UI::EventReturn GamePauseScreen::OnReportFeedback(UI::EventParams &e) {
 }
 
 UI::EventReturn GamePauseScreen::OnRewind(UI::EventParams &e) {
-	SaveState::Rewind(SaveState::Callback(), 0);
+	SaveState::Rewind(&AfterSaveStateAction);
 
 	screenManager()->finishDialog(this, DR_CANCEL);
 	return UI::EVENT_DONE;

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -60,6 +60,7 @@
     <ClInclude Include="GameScreen.h" />
     <ClInclude Include="GameSettingsScreen.h" />
     <ClInclude Include="CwCheatScreen.h" />
+    <ClInclude Include="HostTypes.h" />
     <ClInclude Include="MainScreen.h" />
     <ClInclude Include="MiscScreens.h" />
     <ClInclude Include="OnScreenDisplay.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -132,6 +132,7 @@
       <Filter>Screens</Filter>
     </ClInclude>
     <ClInclude Include="DisplayLayoutEditor.h" />
+    <ClInclude Include="HostTypes.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Screens">

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -192,7 +192,7 @@ unsigned int WINAPI TheThread(void *)
 		if (!Core_IsActive())
 			UpdateUIState(UISTATE_MENU);
 
-		Core_Run(graphicsContext);
+		Core_Run(graphicsContext, &input_state);
 	}
 
 shutdown:

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -400,7 +400,10 @@ namespace MainWindow {
 		g_Config.iInternalScreenRotation = rotation;
 	}
 
-	static void SaveStateActionFinished(bool result, void *userdata) {
+	static void SaveStateActionFinished(bool result, const std::string &message, void *userdata) {
+		if (!message.empty()) {
+			osm.Show(message, 2.0);
+		}
 		PostMessage(MainWindow::GetHWND(), WM_USER_SAVESTATE_FINISH, 0, 0);
 	}
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -580,6 +580,7 @@ namespace MainWindow {
 		case ID_FILE_SAVESTATE_NEXT_SLOT:
 		{
 			SaveState::NextSlot();
+			NativeMessageReceived("savestate_displayslot", "");
 			break;
 		}
 
@@ -588,6 +589,7 @@ namespace MainWindow {
 			if (KeyMap::g_controllerMap[VIRTKEY_NEXT_SLOT].empty())
 			{
 				SaveState::NextSlot();
+				NativeMessageReceived("savestate_displayslot", "");
 			}
 			break;
 		}

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -34,10 +34,12 @@
 #include "input/keycodes.h"
 #include "util/text/utf8.h"
 
+#include "Common/StringUtils.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/CoreParameter.h"
 #include "Core/System.h"
+#include "Core/Debugger/SymbolMap.h"
 #include "Windows/EmuThread.h"
 #include "Windows/DSoundStream.h"
 #include "Windows/WindowsHost.h"
@@ -54,10 +56,8 @@
 #include "Windows/XinputDevice.h"
 #include "Windows/KeyboardDevice.h"
 
-#include "Core/Debugger/SymbolMap.h"
-
-#include "Common/StringUtils.h"
 #include "Windows/main.h"
+#include "UI/OnScreenDisplay.h"
 
 static const int numCPUs = 1;
 
@@ -347,4 +347,8 @@ void WindowsHost::GoFullscreen(bool viewFullscreen) {
 
 void WindowsHost::ToggleDebugConsoleVisibility() {
 	MainWindow::ToggleDebugConsoleVisibility();
+}
+
+void WindowsHost::NotifyUserMessage(const std::string &message, float duration, u32 color, const char *id) {
+	osm.Show(message, duration, color, -1, true, id);
 }

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -64,6 +64,8 @@ public:
 	bool CanCreateShortcut() override;
 	bool CreateDesktopShortcut(std::string argumentPath, std::string title) override;
 
+	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
+
 	void GoFullscreen(bool) override;
 
 	std::shared_ptr<KeyboardDevice> keyboard;

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -169,7 +169,6 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/MIPS/IR/IRPassSimplify.cpp \
   $(SRC)/Core/MIPS/IR/IRRegCache.cpp \
   $(SRC)/UI/ui_atlas.cpp \
-  $(SRC)/UI/OnScreenDisplay.cpp \
   $(SRC)/ext/libkirk/AES.c \
   $(SRC)/ext/libkirk/amctrl.c \
   $(SRC)/ext/libkirk/SHA1.c \
@@ -411,6 +410,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/UI/TouchControlVisibilityScreen.cpp \
   $(SRC)/UI/CwCheatScreen.cpp \
   $(SRC)/UI/InstallZipScreen.cpp \
+  $(SRC)/UI/OnScreenDisplay.cpp \
   $(SRC)/UI/ProfilerDraw.cpp \
   $(SRC)/UI/NativeApp.cpp \
   $(SRC)/UI/ComboKeyMappingScreen.cpp

--- a/ext/native/base/BlackberryMain.cpp
+++ b/ext/native/base/BlackberryMain.cpp
@@ -348,7 +348,7 @@ void BlackberryMain::runMain() {
 			switchDisplay(screen_ui);
 		}
 		time_update();
-		UpdateRunLoop();
+		UpdateRunLoop(&input_state);
 		// This handles VSync
 		if (emulating)
 			eglSwapBuffers(egl_disp[screen_emu], egl_surf[screen_emu]);

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -859,7 +859,7 @@ int main(int argc, char *argv[]) {
 		SimulateGamepad(keys, &input_state);
 		input_state.pad_buttons = pad_buttons;
 		UpdateInputState(&input_state, true);
-		UpdateRunLoop();
+		UpdateRunLoop(&input_state);
 		if (g_QuitRequested)
 			break;
 #if defined(PPSSPP) && !defined(MOBILE_DEVICE)

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -360,7 +360,7 @@ void MainUI::paintGL()
     updateAccelerometer();
     UpdateInputState(&input_state);
     time_update();
-    UpdateRunLoop();
+    UpdateRunLoop(&input_state);
 }
 
 void MainUI::updateAccelerometer()

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -66,10 +66,6 @@ public:
 
 struct InputState;
 // Temporary hacks around annoying linking errors.
-void D3D9_SwapBuffers() { }
-void GL_SwapBuffers() { }
-void GL_SwapInterval(int) { }
-void Vulkan_SwapBuffers() {}
 void NativeUpdate(InputState &input_state) { }
 void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -69,7 +69,6 @@ struct InputState;
 void NativeUpdate(InputState &input_state) { }
 void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
-void NativeMessageReceived(const char *message, const char *value) {}
 
 std::string System_GetProperty(SystemProperty prop) { return ""; }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -82,8 +82,6 @@ bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &default
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 
-InputState input_state;
-
 int printUsage(const char *progname, const char *reason)
 {
 	if (reason != NULL)

--- a/headless/Headless.vcxproj
+++ b/headless/Headless.vcxproj
@@ -224,7 +224,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\ext\native\ext\glew\glew.c" />
-    <ClCompile Include="..\UI\OnScreenDisplay.cpp" />
     <ClCompile Include="..\Windows\GPU\D3D9Context.cpp" />
     <ClCompile Include="..\Windows\GPU\WindowsGLContext.cpp" />
     <ClCompile Include="..\Windows\GPU\WindowsVulkanContext.cpp" />
@@ -266,7 +265,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\UI\OnScreenDisplay.h" />
     <ClInclude Include="Compare.h" />
     <ClInclude Include="StubHost.h" />
     <ClInclude Include="WindowsHeadlessHost.h" />

--- a/headless/Headless.vcxproj.filters
+++ b/headless/Headless.vcxproj.filters
@@ -3,7 +3,6 @@
   <ItemGroup>
     <ClCompile Include="Headless.cpp" />
     <ClCompile Include="Compare.cpp" />
-    <ClCompile Include="..\UI\OnScreenDisplay.cpp" />
     <ClCompile Include="..\ext\native\ext\glew\glew.c" />
     <ClCompile Include="..\Windows\GPU\D3D9Context.cpp">
       <Filter>Windows</Filter>
@@ -28,7 +27,6 @@
   <ItemGroup>
     <ClInclude Include="StubHost.h" />
     <ClInclude Include="Compare.h" />
-    <ClInclude Include="..\UI\OnScreenDisplay.h" />
     <ClInclude Include="WindowsHeadlessHost.h">
       <Filter>Windows</Filter>
     </ClInclude>

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -33,8 +33,6 @@
 
 struct InputState;
 // Temporary hacks around annoying linking errors.  Copied from Headless.
-void D3D9_SwapBuffers() { }
-void GL_SwapBuffers() { }
 void NativeUpdate(InputState &input_state) { }
 void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -50,7 +50,6 @@
 
 std::string System_GetProperty(SystemProperty prop) { return ""; }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }
-void NativeMessageReceived(const char *message, const char *value) {}
 
 #ifndef M_PI_2
 #define M_PI_2     1.57079632679489661923

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -51,8 +51,6 @@
 std::string System_GetProperty(SystemProperty prop) { return ""; }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }
 void NativeMessageReceived(const char *message, const char *value) {}
-void GL_SwapInterval(int) {}
-void Vulkan_SwapBuffers() {}
 
 #ifndef M_PI_2
 #define M_PI_2     1.57079632679489661923

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -48,8 +48,6 @@
 #include "unittest/TestVertexJit.h"
 #include "unittest/UnitTest.h"
 
-InputState input_state;
-
 std::string System_GetProperty(SystemProperty prop) { return ""; }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }
 void NativeMessageReceived(const char *message, const char *value) {}


### PR DESCRIPTION
This removes usage of `input_state` and `osm` from within Core and GPU, to clean up ugly cross dependency issues.

For one thing, this likely makes it easier to use PPSSPP's core with a different UI (like retroarch or something), but it also makes headless linkage simpler.

-[Unknown]
