### PR TITLE
Reimport module stubs on load state

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -259,7 +259,7 @@ const HLEModule moduleList[] =
 	{"IoFileMgrForKernel", SZ(IoFileMgrForKernel), IoFileMgrForKernel},
 };
 
-static const int numModules = sizeof(moduleList)/sizeof(HLEModule);
+static const int numModules = ARRAY_SIZE(moduleList);
 
 void RegisterAllModules() {
 	Register_Kernel_Library();

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -709,13 +709,16 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting) {
 	}
 
 	// It hasn't been exported yet, but hopefully it will later.
-	if (GetModuleIndex(func.moduleName) != -1) {
+	bool isKnownModule = GetModuleIndex(func.moduleName) != -1;
+	if (isKnownModule) {
 		WARN_LOG_REPORT(LOADER, "Unknown syscall in known module: %s 0x%08x", func.moduleName, func.nid);
 	} else {
 		INFO_LOG(LOADER, "Function (%s,%08x) unresolved, storing for later resolving", func.moduleName, func.nid);
 	}
-	WriteFuncMissingStub(func.stubAddr, func.nid);
-	currentMIPS->InvalidateICache(func.stubAddr, 8);
+	if (isKnownModule || !reimporting) {
+		WriteFuncMissingStub(func.stubAddr, func.nid);
+		currentMIPS->InvalidateICache(func.stubAddr, 8);
+	}
 }
 
 void ExportFuncSymbol(const FuncSymbolExport &func) {


### PR DESCRIPTION
This way, when we accidentally reorder or change the syscall ids, save states can continue working.

I think it's safe to assume these stubs will exist, because most likely when changing modules and such, the PSP already re-reads them.  Tried to keep it safe anyway.

This also gives us the flexibility to restructure syscall ids or kernel module support or etc.

-[Unknown]
