### PR TITLE
VirtFS: Normalize leading slashes in index.

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -54,7 +54,7 @@ public:
 
 private:
 	void LoadFileListIndex();
-	int getFileListIndex(std::string& fileName);
+	int getFileListIndex(const std::string &fileName);
 	int getFileListIndex(u32 accessBlock, u32 accessSize, bool blockMode = false);
 	std::string GetLocalPath(std::string localpath);
 


### PR DESCRIPTION
Otherwise, we might consider "/x" and "x" to be different files, and fail to use the handler properly.

See unknownbrackets/ppsspp-virtfs-tools#1, I suspect this was the issue there.  This hasn't been such an issue for games that use sce_lbn to look up files rather than their actual names.

-[Unknown]
