### PR TITLE
Allow more options in texture [hashes] syntax

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -319,6 +319,19 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		}
 	}
 
+#ifdef _WIN32
+	size_t slash = hashfile.find_last_of("/\\");
+#else
+	size_t slash = hashfile.find_last_of("/");
+#endif
+	if (slash != hashfile.npos) {
+		// Create any directory structure as needed.
+		const std::string saveDirectory = basePath_ + NEW_TEXTURE_DIR + hashfile.substr(0, slash);
+		if (!File::Exists(saveDirectory)) {
+			File::CreateFullPath(saveDirectory);
+		}
+	}
+
 	// Only save the hashed portion of the PNG.
 	int lookupW = w / replacedInfo.scaleFactor;
 	int lookupH = h / replacedInfo.scaleFactor;


### PR DESCRIPTION
Variants supported:

```
[hashes]
# Address + CLUT (palette) + data hash + mipmap level 0.
094b89907dcca1a5ee284131_0 = very/organized/things/texture1.png

# Level defaults to 0.
094b89907dcca1a5ee284131 = very/organized/things/texture2.png

# Ignore the texture with this CLUT regardless of data.
094b89907dcca1a500000000_0 =

# The same CLUT / data at any address:
000000007dcca1a5ee284131 = very/organized/things/texture3.png

# The same address / data with any CLUT:
094b899000000000ee284131 = very/organized/things/texture4.png

# The same data at any address (collisions might happen):
0000000000000000ee284131 = very/organized/things/texture3.png
```

That's in order of precedence.  The first match is selected (e.g. if the full hash is specified and matches, a "wildcard" won't even be used.)

These were the most useful I could think of.  I think the most common usage would be this one:

```
# The same CLUT / data at any address:
000000007dcca1a5ee284131 = very/organized/things/texture3.png
```

Also, this fixes creation of textures with a path specified (although pre-specifying is unlikely, it can happen when creating a second color variation based on an existing replacement set.)

-[Unknown]
