### PR TITLE
fix segfault on VirtualDiscFileSystem::GetFileInfo()

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -575,7 +575,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		x.isOnSectorSystem = true;
 		x.startSector = fileList[fileIndex].firstBlock;
 
-		HandlerFileHandle temp;
+		HandlerFileHandle temp = fileList[fileIndex].handler;
 		if (temp.Open(basePath, filename, FILEACCESS_READ)) {
 			x.exists = true;
 			x.size = temp.Seek(0, FILEMOVE_END);


### PR DESCRIPTION
Attempt to bring attention to/fix segfault that occurs on VirtualDiscFileSystem::GetFileInfo() when a valid file handler is specified. 
