### PR TITLE
Minor warning fixes

### DIFF
--- a/Common/Misc.cpp
+++ b/Common/Misc.cpp
@@ -60,7 +60,9 @@ const char *GetStringErrorMsg(int errCode) {
 	static __thread char err_str[buff_size] = {};
 
 	// Thread safe (XSI-compliant)
-	strerror_r(errCode, err_str, buff_size);
+	if (strerror_r(errCode, err_str, buff_size) == 0) {
+		return "Unknown error";
+	}
 #endif
 
 	return err_str;

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -27,8 +27,6 @@
 #define new DBG_NEW
 #endif
 
-using namespace std;
-
 static const char *validationLayers[] = {
 	"VK_LAYER_LUNARG_standard_validation",
 	/*

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1054,13 +1054,6 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 	return 1;
 }
 
-static inline void DelayBranchTo(MIPSState *curMips, u32 where)
-{
-	curMips->pc += 4;
-	curMips->nextPC = where;
-	curMips->inDelaySlot = true;
-}
-
 const char *MIPSGetName(MIPSOpcode op)
 {
 	static const char *noname = "unk";

--- a/Core/MIPS/x86/CompReplace.cpp
+++ b/Core/MIPS/x86/CompReplace.cpp
@@ -27,7 +27,7 @@ using namespace Gen;
 
 int Jit::Replace_fabsf() {
 	fpr.SpillLock(0, 12);
-	fpr.MapReg(0, MAP_DIRTY | MAP_NOINIT);
+	fpr.MapReg(0, false, true);
 	MOVSS(fpr.RX(0), fpr.R(12));
 	ANDPS(fpr.RX(0), M(&ssNoSignMask));
 	fpr.ReleaseSpillLocks();

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -53,8 +53,8 @@ public:
 
 	const JitOptions &GetJitOptions() { return jo; }
 
-	void DoState(PointerWrap &p);
-	void DoDummyState(PointerWrap &p);
+	void DoState(PointerWrap &p) override;
+	void DoDummyState(PointerWrap &p) override;
 
 	// Compiled ops should ignore delay slots
 	// the compiler will take care of them by itself

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -608,7 +608,7 @@ void FPURegCache::MapReg(const int i, bool doLoad, bool makeDirty) {
 	if (!regs[i].away) {
 		// Reg is at home in the memory register file. Let's pull it out.
 		X64Reg xr = GetFreeXReg();
-		_assert_msg_(JIT, xr >= 0 && xr < NUM_X_FPREGS, "WTF - FPURegCache::MapReg - invalid reg %d", (int)xr);
+		_assert_msg_(JIT, xr < NUM_X_FPREGS, "WTF - FPURegCache::MapReg - invalid reg %d", (int)xr);
 		xregs[xr].mipsReg = i;
 		xregs[xr].dirty = makeDirty;
 		OpArg newloc = ::Gen::R(xr);
@@ -655,7 +655,7 @@ void FPURegCache::StoreFromRegister(int i) {
 
 	if (regs[i].away) {
 		X64Reg xr = regs[i].location.GetSimpleReg();
-		_assert_msg_(JIT, xr >= 0 && xr < NUM_X_FPREGS, "WTF - FPURegCache::StoreFromRegister - invalid reg: x %i (mr: %i). PC=%08x", (int)xr, i, js_->compilerPC);
+		_assert_msg_(JIT, xr < NUM_X_FPREGS, "WTF - FPURegCache::StoreFromRegister - invalid reg: x %i (mr: %i). PC=%08x", (int)xr, i, js_->compilerPC);
 		if (regs[i].lane != 0) {
 			const int *mri = xregs[xr].mipsRegs;
 			int seq = 1;
@@ -738,7 +738,7 @@ void FPURegCache::DiscardR(int i) {
 	_assert_msg_(JIT, !regs[i].location.IsImm(), "FPU can't handle imm yet.");
 	if (regs[i].away) {
 		X64Reg xr = regs[i].location.GetSimpleReg();
-		_assert_msg_(JIT, xr >= 0 && xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
+		_assert_msg_(JIT, xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
 		// Note that we DO NOT write it back here. That's the whole point of Discard.
 		if (regs[i].lane != 0) {
 			// But we can't just discard all of them in SIMD, just the one lane.
@@ -783,7 +783,7 @@ void FPURegCache::DiscardVS(int vreg) {
 	if (vregs[vreg].away) {
 		_assert_msg_(JIT, vregs[vreg].lane != 0, "VS expects a SIMD reg.");
 		X64Reg xr = vregs[vreg].location.GetSimpleReg();
-		_assert_msg_(JIT, xr >= 0 && xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
+		_assert_msg_(JIT, xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
 		// Note that we DO NOT write it back here. That's the whole point of Discard.
 		for (int i = 0; i < 4; ++i) {
 			int mr = xregs[xr].mipsRegs[i];

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -367,6 +367,9 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		case ReplacedTextureFormat::F_8888_BGRA:
 			ConvertBGRA8888ToRGBA8888(saveBuf.data(), (const u32 *)data, (pitch * h) / sizeof(u32));
 			break;
+		case ReplacedTextureFormat::F_8888:
+			// Impossible.  Just so we can get warnings on other missed formats.
+			break;
 		}
 
 		data = saveBuf.data();

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -31,7 +31,7 @@
 #include "GPU/GLES/Framebuffer.h"
 
 static const int leftColumnWidth = 200;
-static const float orgRatio = 1.764706;
+static const float orgRatio = 1.764706f;
 
 // Ugly hackery, need to rework some stuff to get around this
 static float local_dp_xres;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -58,7 +58,6 @@
 #include "util/text/utf8.h"
 #include "Windows/W32Util/ShellUtil.h"
 #include "Windows/W32Util/Misc.h"
-using namespace std;
 
 #endif
 
@@ -729,7 +728,7 @@ UI::EventReturn GameSettingsScreen::OnSavePathMydoc(UI::EventParams &e) {
 		g_Config.memStickDirectory = PPSSPPpath + "memstick/";
 	}
 	else {
-		ofstream myfile;
+		std::ofstream myfile;
 		myfile.open(PPSSPPpath + "installed.txt");
 		if (myfile.is_open()){
 			myfile.close();

--- a/ext/native/base/basictypes.h
+++ b/ext/native/base/basictypes.h
@@ -6,7 +6,6 @@
 #ifdef _WIN32
 #pragma warning(disable:4244)
 #pragma warning(disable:4996)
-#pragma warning(disable:4305)  // truncation from double to float
 #endif
 
 #define DISALLOW_COPY_AND_ASSIGN(t) \

--- a/ext/native/net/sinks.cpp
+++ b/ext/native/net/sinks.cpp
@@ -1,5 +1,3 @@
-#pragma optimize("", off)
-
 #ifdef _WIN32
 
 #define NOMINMAX

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -202,7 +202,7 @@ void fcs2(float theta, float &outsine, float &outcosine) {
 
 	float x = 2 * gamma - gamma * fabs(gamma);
 	float y = 2 * theta - theta * fabs(theta);
-	const float P = 0.225;
+	const float P = 0.225f;
 	outsine = P * (y * fabsf(y) - y) + y;   // Q * y + P * y * abs(y)
 	outcosine = P * (x * fabsf(x) - x) + x;   // Q * y + P * y * abs(y)
 }


### PR DESCRIPTION
Oops, `Replace_fabsf` wasn't marking the result dirty.  Wonder what that could've been breaking, when we were trying to use it...

Enabled the warning that found that (4305) globally.

-[Unknown]
