### PR TITLE
Fix extract file and sharing violation handling

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -842,9 +842,11 @@ namespace MainWindow {
 				FILE *fp = File::OpenCFile(fn, "wb");
 				u32 handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ, "");
 				u8 buffer[4096];
-				while (pspFileSystem.ReadFile(handle, buffer, sizeof(buffer)) > 0) {
-					fwrite(buffer, sizeof(buffer), 1, fp);
-				}
+				size_t bytes;
+				do {
+					bytes = pspFileSystem.ReadFile(handle, buffer, sizeof(buffer));
+					fwrite(buffer, 1, bytes, fp);
+				} while (bytes == sizeof(buffer));
 				pspFileSystem.CloseFile(handle);
 				fclose(fp);
 			}


### PR DESCRIPTION
While debugging, I had a file open in a hex editor, and discovered that prevented PPSSPP from opening it.  So I added retrying with different sharing settings to work around.

Additionally, extract file was aligning the file to 4K, this reads it more exactly.

-[Unknown]
