### PR TITLE
Reject invalid MPEG puts for certain lib versions

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1414,7 +1414,7 @@ void PostPutAction::run(MipsCall &call) {
 
 
 // Program signals that it has written data to the ringbuffer and gets a callback ?
-static u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 available)
+static u32 sceMpegRingbufferPut(u32 ringbufferAddr, int numPackets, int available)
 {
 	numPackets = std::min(numPackets, available);
 	if (numPackets <= 0) {
@@ -1444,7 +1444,7 @@ static u32 sceMpegRingbufferPut(u32 ringbufferAddr, u32 numPackets, u32 availabl
 		// TODO: Should call this multiple times until we get numPackets.
 		// Normally this would be if it did not read enough, but also if available > packets.
 		// Should ultimately return the TOTAL number of returned packets.
-		u32 packetsThisRound = std::min(numPackets, (u32)ringbuffer->packets);
+		u32 packetsThisRound = std::min(numPackets, (s32)ringbuffer->packets);
 		u32 args[3] = {(u32)ringbuffer->data, packetsThisRound, (u32)ringbuffer->callback_args};
 		__KernelDirectMipsCall(ringbuffer->callback_addr, action, args, 3, false);
 	} else {
@@ -2184,7 +2184,7 @@ const HLEFunction sceMpeg[] =
 	{0XA11C7026, &WrapI_UU<sceMpegAvcDecodeMode>,              "sceMpegAvcDecodeMode",               'i', "xx"     },
 	{0X37295ED8, &WrapU_UUUUUU<sceMpegRingbufferConstruct>,    "sceMpegRingbufferConstruct",         'x', "xxxxxx" },
 	{0X13407F13, &WrapU_U<sceMpegRingbufferDestruct>,          "sceMpegRingbufferDestruct",          'x', "x"      },
-	{0XB240A59E, &WrapU_UUU<sceMpegRingbufferPut>,             "sceMpegRingbufferPut",               'x', "xxx"    },
+	{0XB240A59E, &WrapU_UII<sceMpegRingbufferPut>,             "sceMpegRingbufferPut",               'x', "xxx"    },
 	{0XB5F6DC87, &WrapI_U<sceMpegRingbufferAvailableSize>,     "sceMpegRingbufferAvailableSize",     'i', "x"      },
 	{0XD7A29F46, &WrapU_I<sceMpegRingbufferQueryMemSize>,      "sceMpegRingbufferQueryMemSize",      'x', "i"      },
 	{0X769BEBB6, &WrapI_U<sceMpegRingbufferQueryPackNum>,      "sceMpegRingbufferQueryPackNum",      'i', "x"      },

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -68,8 +68,9 @@ static const int MPEG_DATA_STREAM = 3;      // Arbitrary user defined type. Can 
 static const int MPEG_AUDIO_STREAM = 15;
 static const int MPEG_AU_MODE_DECODE = 0;
 static const int MPEG_AU_MODE_SKIP = 1;
-static const u32 MPEG_MEMSIZE = 0x10000;          // 64k.
-static const int MPEG_AVC_DECODE_SUCCESS = 1;       // Internal value.
+static const u32 MPEG_MEMSIZE_0104 = 0x0b3DB;
+static const u32 MPEG_MEMSIZE_0105 = 0x10000;     // 64k.
+static const int MPEG_AVC_DECODE_SUCCESS = 1;     // Internal value.
 
 static const int atracDecodeDelayMs = 3000;
 static const int avcFirstDelayMs = 3600;
@@ -467,6 +468,13 @@ static u32 sceMpegRingbufferConstruct(u32 ringbufferAddr, u32 numPackets, u32 da
 	return 0;
 }
 
+static u32 MpegRequiredMem() {
+	if (mpegLibVersion < 0x0105) {
+		return MPEG_MEMSIZE_0104;
+	}
+	return MPEG_MEMSIZE_0105;
+}
+
 static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop)
 {
 	if (!Memory::IsValidAddress(mpegAddr)) {
@@ -474,7 +482,7 @@ static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr
 		return -1;
 	}
 
-	if (size < MPEG_MEMSIZE) {
+	if (size < MpegRequiredMem()) {
 		WARN_LOG(ME, "ERROR_MPEG_NO_MEMORY=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)", mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
 		return ERROR_MPEG_NO_MEMORY;
 	}
@@ -1537,10 +1545,8 @@ static u32 sceMpegFinish()
 	return hleDelayResult(0, "mpeg finish", 250);
 }
 
-static u32 sceMpegQueryMemSize()
-{
-	DEBUG_LOG(ME, "%i = sceMpegQueryMemSize()",MPEG_MEMSIZE);
-	return MPEG_MEMSIZE;
+static u32 sceMpegQueryMemSize() {
+	return hleLogSuccessX(ME, MpegRequiredMem());
 }
 
 static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -270,7 +270,7 @@ static MpegContext *getMpegCtx(u32 mpegAddr) {
 static void InitRingbuffer(SceMpegRingBuffer *buf, int packets, int data, int size, int callback_addr, int callback_args) {
 	buf->packets = packets;
 	buf->packetsRead = 0;
-	buf->packetsWritten = 0;
+	buf->packetsWritePos = 0;
 	buf->packetsAvail = 0;
 	buf->packetSize = 2048;
 	buf->data = data;
@@ -1387,8 +1387,11 @@ void PostPutAction::run(MipsCall &call) {
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ringAddr_);
 
 	MpegContext *ctx = getMpegCtx(ringbuffer->mpeg);
+	int writeOffset = ringbuffer->packetsWritePos % (s32)ringbuffer->packets;
+	const u8 *data = Memory::GetPointer(ringbuffer->data + writeOffset * 2048);
 
 	int packetsAdded = currentMIPS->r[MIPS_REG_V0];
+
 	if (ringbuffer->packetsRead == 0 && ctx->mediaengine && packetsAdded > 0) {
 		// init mediaEngine
 		AnalyzeMpeg(ctx->mpegheader, ctx);
@@ -1399,12 +1402,12 @@ void PostPutAction::run(MipsCall &call) {
 			WARN_LOG(ME, "sceMpegRingbufferPut clamping packetsAdded old=%i new=%i", packetsAdded, ringbuffer->packets - ringbuffer->packetsAvail);
 			packetsAdded = ringbuffer->packets - ringbuffer->packetsAvail;
 		}
-		int actuallyAdded = ctx->mediaengine == NULL ? 8 : ctx->mediaengine->addStreamData(Memory::GetPointer(ringbuffer->data), packetsAdded * 2048) / 2048;
+		int actuallyAdded = ctx->mediaengine == NULL ? 8 : ctx->mediaengine->addStreamData(data, packetsAdded * 2048) / 2048;
 		if (actuallyAdded != packetsAdded) {
 			WARN_LOG_REPORT(ME, "sceMpegRingbufferPut(): unable to enqueue all added packets, going to overwrite some frames.");
 		}
 		ringbuffer->packetsRead += packetsAdded;
-		ringbuffer->packetsWritten += packetsAdded;
+		ringbuffer->packetsWritePos += packetsAdded;
 		ringbuffer->packetsAvail += packetsAdded;
 	}
 	DEBUG_LOG(ME, "packetAdded: %i packetsRead: %i packetsTotal: %i", packetsAdded, ringbuffer->packetsRead, ringbuffer->packets);
@@ -1444,8 +1447,9 @@ static u32 sceMpegRingbufferPut(u32 ringbufferAddr, int numPackets, int availabl
 		// TODO: Should call this multiple times until we get numPackets.
 		// Normally this would be if it did not read enough, but also if available > packets.
 		// Should ultimately return the TOTAL number of returned packets.
-		u32 packetsThisRound = std::min(numPackets, (s32)ringbuffer->packets);
-		u32 args[3] = {(u32)ringbuffer->data, packetsThisRound, (u32)ringbuffer->callback_args};
+		int writeOffset = ringbuffer->packetsWritePos % (s32)ringbuffer->packets;
+		u32 packetsThisRound = std::min(numPackets, (s32)ringbuffer->packets - writeOffset);
+		u32 args[3] = {(u32)ringbuffer->data + (u32)writeOffset * 2048, packetsThisRound, (u32)ringbuffer->callback_args};
 		__KernelDirectMipsCall(ringbuffer->callback_addr, action, args, 3, false);
 	} else {
 		ERROR_LOG_REPORT(ME, "sceMpegRingbufferPut: callback_addr zero");
@@ -1765,7 +1769,7 @@ static u32 sceMpegFlushAllStream(u32 mpeg)
 	if (ringbuffer.IsValid()) {
 		ringbuffer->packetsAvail = 0;
 		ringbuffer->packetsRead = 0;
-		ringbuffer->packetsWritten = 0;
+		ringbuffer->packetsWritePos = 0;
 	}
 
 	return 0;

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -56,8 +56,9 @@ struct SceMpegAu {
 struct SceMpegRingBuffer {
 	// PSP info
 	s32_le packets;
+	// Misused: this is used as total read, but should be read offset (within ring.)
 	s32_le packetsRead;
-	s32_le packetsWritten;
+	s32_le packetsWritePos;
 	s32_le packetsAvail; // pspsdk: unk2, noxa: iUnk0
 	s32_le packetSize; // 2048
 	u32_le data; // address, ring buffer

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -158,7 +158,7 @@ void MpegDemux::demux(int audioChannel)
 {
 	if (audioChannel >= 0)
 		m_audioChannel = audioChannel;
-	while (m_index < m_len)
+	while (m_index < m_readSize)
 	{
 		if (m_index + 2048 > m_readSize)
 			break;
@@ -202,7 +202,7 @@ void MpegDemux::demux(int audioChannel)
 	}
 	if (m_index < m_readSize) {
 		int size = m_readSize - m_index;
-		memcpy(m_buf, m_buf + m_index, size);
+		memmove(m_buf, m_buf + m_index, size);
 		m_index = 0;
 		m_readSize = size;
 	} else {

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -53,7 +53,7 @@ private:
 		return (((s64) (c & 0x0E)) << 29) | ((read16() >> 1) << 15) | (read16() >> 1);
 	}
 	bool isEOF() const {
-		return m_index >= m_len;
+		return m_index >= m_readSize;
 	}
 	void skip(int n) {
 		if (n > 0) {

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -15,7 +15,7 @@ public:
 	~MpegDemux();
 
 	bool addStreamData(const u8 *buf, int addSize);
-	void demux(int audioChannel);
+	bool demux(int audioChannel);
 
 	// return its framesize
 	int getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2, s64 *pts = NULL);
@@ -64,7 +64,7 @@ private:
 		}
 	}
 	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
-	int demuxStream(bool bdemux, int startCode, int channel);
+	int demuxStream(bool bdemux, int startCode, int length, int channel);
 	bool skipPackHeader();
 
 	int m_index;

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -46,6 +46,9 @@ private:
 	int read16() {
 		return (read8() << 8) | read8();
 	}
+	int read24() {
+		return (read8() << 16) | (read8() << 8) | read8();
+	}
 	s64 readPts() {
 		return readPts(read8());
 	}
@@ -62,6 +65,7 @@ private:
 	}
 	int readPesHeader(PesHeader &pesHeader, int length, int startCode);
 	int demuxStream(bool bdemux, int startCode, int channel);
+	bool skipPackHeader();
 
 	int m_index;
 	int m_len;


### PR DESCRIPTION
The good news: this reportedly fixes #3318, and fixes #6657.

This change is probably a bit risky, but I've tested a number of games and haven't run into any video problems.  I still don't really know what "PMP videos" are and have not tested the specialized code dedicated to them.

Here are the major things this does:
1. Prevents searching for a startcode beyond available data.  This could've been causing corrupted audio frames in some cases.
2. More strictly and more immediately demuxes MPEG frames.  This may also help corrupted audio frames, but might also break somewhere it was accidentally working.
3. Exposes the MPEG write position to the game in an actual ring.  This is how it's really supposed to work anyway, and might make it easier to decode more directly from PSP RAM some day.
4. Reduces the required mpeg memory for older libs, per tests.  Might matter for some memory allocation.
5. Advances packetsAvail incrementally (required for #3318), rather than resetting it after decode.  I played this one safe, and only did it for the necessary lib versions.

However, one note: I have found two 1.03 mpeg.prx's that have different behavior.  Technically, some of this behavior is correct for 1.03a but not for 1.03b.  Hoping it doesn't matter, I don't want to go down the route of crcing them for version numbers...

-[Unknown]
