### PR TITLE
Download single-use renders right away

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -544,6 +544,20 @@ void FramebufferManagerCommon::UpdateFromMemory(u32 addr, int size, bool safe) {
 	}
 }
 
+void FramebufferManagerCommon::DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb) {
+	if (vfb && vfb->safeWidth > 0 && vfb->safeHeight > 0 && !vfb->firstFrameSaved) {
+		// Some games will draw to some memory once, and use it as a render-to-texture later.
+		// To support this, we save the first frame to memory when we have a save w/h.
+		// Saving each frame would be slow.
+		if (!g_Config.bDisableSlowFramebufEffects) {
+			ReadFramebufferToMemory(vfb, true, 0, 0, vfb->safeWidth, vfb->safeHeight);
+			vfb->firstFrameSaved = true;
+			vfb->safeWidth = 0;
+			vfb->safeHeight = 0;
+		}
+	}
+}
+
 bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool isMemset, u32 skipDrawReason) {
 	if (updateVRAM_ || size == 0) {
 		return false;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -62,6 +62,7 @@ struct VirtualFramebuffer {
 	u32 clutUpdatedBytes;
 	bool memoryUpdated;
 	bool depthUpdated;
+	bool firstFrameSaved;
 
 	u32 fb_address;
 	u32 z_address;
@@ -252,6 +253,7 @@ protected:
 	void ShowScreenResolution();
 
 	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
+	void DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb);
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp) const;
 	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
 	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) = 0;


### PR DESCRIPTION
Should prevent issues with the memory being reused soon after, hopefully.  See also #8781 and #7695.

This fixes the issues in #8781 but still makes the Katamari thing work.

In some ways, this may be better.  In a lot of scenarios where we fail to detect block transfers, this is likely to give at least more useful data than before, which might've been nothing or some really old framebuffer.

-[Unknown]
