### PR TITLE
Provide clearer errors for invalid ISOs

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -201,7 +201,7 @@ ISOFileSystem::~ISOFileSystem() {
 }
 
 void ISOFileSystem::ReadDirectory(TreeEntry *root) {
-	for (u32 secnum = root->startsector, endsector = root->startsector + root->dirsize /2048; secnum < endsector; ++secnum) {
+	for (u32 secnum = root->startsector, endsector = root->startsector + (root->dirsize + 2047) / 2048; secnum < endsector; ++secnum) {
 		u8 theSector[2048];
 		if (!blockDevice->ReadBlock(secnum, theSector)) {
 			ERROR_LOG(FILESYS, "Error reading block for directory %s - skipping", root->name.c_str());
@@ -233,10 +233,10 @@ void ISOFileSystem::ReadDirectory(TreeEntry *root) {
 			if (dir.identifierLength == 1 && (dir.firstIdChar == '\x00' || dir.firstIdChar == '.')) {
 				entry->name = ".";
 				relative = true;
-			}	else if (dir.identifierLength == 1 && dir.firstIdChar == '\x01')			{
+			} else if (dir.identifierLength == 1 && dir.firstIdChar == '\x01') {
 				entry->name = "..";
 				relative = true;
-			}	else {
+			} else {
 				entry->name = std::string((const char *)&dir.firstIdChar, dir.identifierLength);
 				relative = false;
 			}
@@ -250,7 +250,7 @@ void ISOFileSystem::ReadDirectory(TreeEntry *root) {
 			entry->dirsize = dir.dataLength();
 			entry->valid = isFile;  // Can pre-mark as valid if file, as we don't recurse into those.
 			// Let's not excessively spam the log - I commented this line out.
-			//DEBUG_LOG(FILESYS, "%s: %s %08x %08x %i", e->isDirectory?"D":"F", e->name.c_str(), dir.firstDataSectorLE, e->startingPosition, e->startingPosition);
+			//DEBUG_LOG(FILESYS, "%s: %s %08x %08x %i", entry->isDirectory?"D":"F", entry->name.c_str(), dir.firstDataSectorLE, entry->startingPosition, entry->startingPosition);
 
 			if (entry->isDirectory && !relative) {
 				if (entry->startsector == root->startsector) {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -231,6 +231,24 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string)
 		// try unencrypted BOOT.BIN
 		bootpath = "disc0:/PSP_GAME/SYSDIR/BOOT.BIN";
 	}
+
+	// Fail early with a clearer message for some types of ISOs.
+	if (!pspFileSystem.GetFileInfo(bootpath).exists) {
+		// Can't tell for sure if it's PS1 or PS2, but doesn't much matter.
+		if (pspFileSystem.GetFileInfo("disc0:/SYSTEM.CNF;1").exists || pspFileSystem.GetFileInfo("disc0:/PSX.EXE;1").exists) {
+			*error_string = "PPSSPP plays PSP games, not Playstation 1 or 2 games.";
+		} else if (pspFileSystem.GetFileInfo("disc0:/UMD_VIDEO/PLAYLIST.UMD").exists) {
+			*error_string = "PPSSPP doesn't support UMD Video.";
+		} else if (pspFileSystem.GetFileInfo("disc0:/UMD_AUDIO/PLAYLIST.UMD").exists) {
+			*error_string = "PPSSPP doesn't support UMD Music.";
+		} else if (pspFileSystem.GetDirListing("disc0:/").empty()) {
+			*error_string = "Not a valid disc image.";
+		} else {
+			*error_string = "A PSP game couldn't be found on the disc.";
+		}
+		return false;
+	}
+
 	//in case we didn't go through EmuScreen::boot
 	g_Config.loadGameConfig(id);
 	INFO_LOG(LOADER,"Loading %s...", bootpath.c_str());


### PR DESCRIPTION
The default message, "Could not load game.  Could not find executable technobabble" is probably not the clearest way to tell someone PPSSPP can't play their disc.

This adds some basic detection:
- PS1 and PS2 games will typically have SYSTEM.CNF;1.
- UMD Video and UMD Music are easily detected, except sometimes when they also have a GAME EBOOT that is invalid.  Oh well.
- ISOs which don't even have a root directory structure are straight out.

Additionally, when I tried a PS2 game to verify, I discovered that it was an invalid ISO... or actually, that it didn't round up the data length for directory sectors.  Who knows, maybe this will fix some oddly mastered PSP game.

See also: http://forums.ppsspp.org/showthread.php?tid=19152

-[Unknown]
