### PR TITLE
Clean up compatibility rating slightly

### DIFF
--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -331,7 +331,7 @@ void GamePauseScreen::CreateViews() {
 
 	// TODO, also might be nice to show overall compat rating here?
 	// Based on their platform or even cpu/gpu/config.  Would add an API for it.
-	if (Reporting::IsEnabled()) {
+	if (Reporting::IsEnabled() && gameId.size() && gameId != "_") {
 		I18NCategory *rp = GetI18NCategory("Reporting");
 		rightColumnItems->Add(new Choice(rp->T("ReportButton", "Report Feedback")))->OnClick.Handle(this, &GamePauseScreen::OnReportFeedback);
 	}

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -38,4 +38,5 @@ protected:
 	int graphics_;
 	int speed_;
 	int gameplay_;
+	bool ratingEnabled_;
 };


### PR DESCRIPTION
This disables no-name reporting for compatibility ratings, and forces "Doesn't boot" / "Nothing" compatibility to use "Bad" for all other settings.  Some people were confusingly saying "Great graphics emulation" for "Doesn't boot".

Found while running these stats:
http://forums.ppsspp.org/showthread.php?tid=19211
https://github.com/unknownbrackets/ppsspp/wiki/Compatibility-report-statistics

-[Unknown]
