### PR TITLE
Include screenshots in compatibility reports

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -47,7 +47,7 @@ namespace Reporting
 {
 	const int DEFAULT_PORT = 80;
 	const u32 SPAM_LIMIT = 100;
-	const int PAYLOAD_BUFFER_SIZE = 100;
+	const int PAYLOAD_BUFFER_SIZE = 200;
 
 	// Internal limiter on number of requests per instance.
 	static u32 spamProtectionCount = 0;
@@ -60,8 +60,9 @@ namespace Reporting
 	// Support is cached here to avoid checking it on every single request.
 	static bool currentSupported = false;
 
-	enum RequestType
+	enum class RequestType
 	{
+		NONE,
 		MESSAGE,
 		COMPAT,
 	};
@@ -75,7 +76,7 @@ namespace Reporting
 		int int2;
 		int int3;
 	};
-	static Payload payloadBuffer[PAYLOAD_BUFFER_SIZE];
+	static Payload payloadBuffer[PAYLOAD_BUFFER_SIZE] = {};
 	static int payloadBufferPos = 0;
 
 	// Returns the full host (e.g. report.ppsspp.org:80.)
@@ -313,7 +314,7 @@ namespace Reporting
 
 		switch (payload.type)
 		{
-		case MESSAGE:
+		case RequestType::MESSAGE:
 			postdata.Add("message", payload.string1);
 			postdata.Add("value", payload.string2);
 			payload.string1.clear();
@@ -323,7 +324,7 @@ namespace Reporting
 			SendReportRequest("/report/message", postdata.ToString(), postdata.GetMimeType());
 			break;
 
-		case COMPAT:
+		case RequestType::COMPAT:
 			postdata.Add("compat", payload.string1);
 			postdata.Add("graphics", StringFromFormat("%d", payload.int1));
 			postdata.Add("speed", StringFromFormat("%d", payload.int2));
@@ -334,6 +335,8 @@ namespace Reporting
 			SendReportRequest("/report/compat", postdata.ToString(), postdata.GetMimeType());
 			break;
 		}
+
+		payload.type = RequestType::NONE;
 
 		return 0;
 	}
@@ -393,9 +396,26 @@ namespace Reporting
 		g_Config.sReportHost = "default";
 	}
 
+	int NextFreePos()
+	{
+		int start = payloadBufferPos % PAYLOAD_BUFFER_SIZE;
+		do
+		{
+			int pos = payloadBufferPos++ % PAYLOAD_BUFFER_SIZE;
+			if (payloadBuffer[pos].type == RequestType::NONE)
+				return pos;
+		}
+		while (payloadBufferPos != start);
+
+		return -1;
+	}
+
 	void ReportMessage(const char *message, ...)
 	{
 		if (!IsEnabled() || CheckSpamLimited())
+			return;
+		int pos = NextFreePos();
+		if (pos == -1)
 			return;
 
 		const int MESSAGE_BUFFER_SIZE = 65536;
@@ -407,9 +427,8 @@ namespace Reporting
 		temp[MESSAGE_BUFFER_SIZE - 1] = '\0';
 		va_end(args);
 
-		int pos = payloadBufferPos++ % PAYLOAD_BUFFER_SIZE;
 		Payload &payload = payloadBuffer[pos];
-		payload.type = MESSAGE;
+		payload.type = RequestType::MESSAGE;
 		payload.string1 = message;
 		payload.string2 = temp;
 
@@ -421,10 +440,12 @@ namespace Reporting
 	{
 		if (!IsEnabled() || CheckSpamLimited())
 			return;
+		int pos = NextFreePos();
+		if (pos == -1)
+			return;
 
-		int pos = payloadBufferPos++ % PAYLOAD_BUFFER_SIZE;
 		Payload &payload = payloadBuffer[pos];
-		payload.type = MESSAGE;
+		payload.type = RequestType::MESSAGE;
 		payload.string1 = message;
 		payload.string2 = formatted;
 
@@ -436,10 +457,12 @@ namespace Reporting
 	{
 		if (!IsEnabled())
 			return;
+		int pos = NextFreePos();
+		if (pos == -1)
+			return;
 
-		int pos = payloadBufferPos++ % PAYLOAD_BUFFER_SIZE;
 		Payload &payload = payloadBuffer[pos];
-		payload.type = COMPAT;
+		payload.type = RequestType::COMPAT;
 		payload.string1 = compat;
 		payload.int1 = graphics;
 		payload.int2 = speed;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -400,14 +400,16 @@ namespace Reporting
 		return true;
 	}
 
-	void Enable(bool flag, std::string host)
+	bool Enable(bool flag, std::string host)
 	{
 		if (IsSupported() && IsEnabled() != flag)
 		{
 			// "" means explicitly disabled.  Don't ever turn on by default.
 			// "default" means it's okay to turn it on by default.
 			g_Config.sReportHost = flag ? host : "";
+			return true;
 		}
+		return false;
 	}
 
 	void EnableDefault()

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -317,6 +317,8 @@ namespace Reporting
 		case RequestType::MESSAGE:
 			postdata.Add("message", payload.string1);
 			postdata.Add("value", payload.string2);
+			// We tend to get corrupted data, this acts as a very primitive verification check.
+			postdata.Add("verify", payload.string1 + payload.string2);
 			payload.string1.clear();
 			payload.string2.clear();
 
@@ -326,6 +328,8 @@ namespace Reporting
 
 		case RequestType::COMPAT:
 			postdata.Add("compat", payload.string1);
+			// We tend to get corrupted data, this acts as a very primitive verification check.
+			postdata.Add("verify", payload.string1);
 			postdata.Add("graphics", StringFromFormat("%d", payload.int1));
 			postdata.Add("speed", StringFromFormat("%d", payload.int2));
 			postdata.Add("gameplay", StringFromFormat("%d", payload.int3));

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -57,7 +57,8 @@ namespace Reporting
 	bool IsSupported();
 
 	// Set the current enabled state of the reporting system and desired reporting server host.
-	void Enable(bool flag, std::string host);
+	// Returns if anything was changed.
+	bool Enable(bool flag, std::string host);
 
 	// Use the default reporting setting (per compiled settings) of host and enabled state.
 	void EnableDefault();

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -69,7 +69,7 @@ namespace Reporting
 	void ReportMessageFormatted(const char *message, const char *formatted);
 
 	// Report the compatibility of the current game / configuration.
-	void ReportCompatibility(const char *compat, int graphics, int speed, int gameplay);
+	void ReportCompatibility(const char *compat, int graphics, int speed, int gameplay, std::string screenshotFilename);
 
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogOnce(const char *identifier);

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -215,7 +215,7 @@ static const u8 *ConvertBufferTo888RGB(const GPUDebugBuffer &buf, u8 *&temp, u32
 	return buffer;
 }
 
-bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type) {
+bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type, int *width, int *height, int maxRes) {
 	GPUDebugBuffer buf;
 	bool success = false;
 	u32 w = (u32)-1;
@@ -223,12 +223,12 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 
 	if (type == SCREENSHOT_RENDER) {
 		if (gpuDebug) {
-			success = gpuDebug->GetCurrentFramebuffer(buf);
+			success = gpuDebug->GetCurrentFramebuffer(buf, maxRes);
 		}
 
 		// Only crop to the top left when using a render screenshot.
-		w = PSP_CoreParameter().renderWidth;
-		h = PSP_CoreParameter().renderHeight;
+		w = maxRes > 0 ? 480 * maxRes : PSP_CoreParameter().renderWidth;
+		h = maxRes > 0 ? 272 * maxRes : PSP_CoreParameter().renderHeight;
 	} else {
 		if (GetGPUBackend() == GPUBackend::OPENGL) {
 			success = GPU_GLES::GetDisplayFramebuffer(buf);
@@ -260,6 +260,11 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 		if (buffer == nullptr) {
 			success = false;
 		}
+
+		if (width)
+			*width = w;
+		if (height)
+			*height = h;
 
 		if (success && fmt == SCREENSHOT_PNG) {
 			png_image png;

--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -30,4 +30,4 @@ enum ScreenshotType {
 	SCREENSHOT_RENDER,
 };
 
-bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type);
+bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type, int *width = nullptr, int *height = nullptr, int maxRes = -1);

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -206,7 +206,7 @@ public:
 
 	// Needs to be called from the GPU thread, so on the same thread as a notification is fine.
 	// Calling from a separate thread (e.g. UI) may fail.
-	virtual bool GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
+	virtual bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) {
 		// False means unsupported.
 		return false;
 	}

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -82,7 +82,7 @@ public:
 	void DestroyFramebuf(VirtualFramebuffer *vfb);
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false);
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes);
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
@@ -91,6 +91,7 @@ public:
 
 	FBO_DX9 *GetTempFBO(u16 w, u16 h, FBOColorDepth depth = FBO_8888);
 	LPDIRECT3DSURFACE9 GetOffscreenSurface(LPDIRECT3DSURFACE9 similarSurface, VirtualFramebuffer *vfb);
+	LPDIRECT3DSURFACE9 GetOffscreenSurface(D3DFORMAT fmt, u32 w, u32 h);
 
 protected:
 	void DisableState() override;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -2142,8 +2142,8 @@ void GPU_DX9::DoState(PointerWrap &p) {
 	}
 }
 
-bool GPU_DX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
-	return framebufferManager_.GetCurrentFramebuffer(buffer);
+bool GPU_DX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) {
+	return framebufferManager_.GetCurrentFramebuffer(buffer, maxRes);
 }
 
 bool GPU_DX9::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -75,13 +75,13 @@ public:
 	}
 	std::vector<FramebufferInfo> GetFramebufferList() override;
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer);
-	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
-	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
-	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) override;
+	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
+	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
+	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
 	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
-	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
+	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 
 	typedef void (GPU_DX9::*CmdFunc)(u32 op, u32 diff);
 	struct CommandInfo {

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -108,7 +108,7 @@ public:
 	void DestroyFramebuf(VirtualFramebuffer *vfb) override;
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false) override;
 
-	bool GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat format, GPUDebugBuffer &buffer);
+	bool GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat format, GPUDebugBuffer &buffer, int maxRes);
 	bool GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer);
 	bool GetStencilbuffer(u32 fb_address, int fb_stride, GPUDebugBuffer &buffer);
 	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -2413,11 +2413,11 @@ void GPU_GLES::DoState(PointerWrap &p) {
 	}
 }
 
-bool GPU_GLES::GetCurrentFramebuffer(GPUDebugBuffer &buffer) {
+bool GPU_GLES::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) {
 	u32 fb_address = gstate.getFrameBufRawAddress();
 	int fb_stride = gstate.FrameBufStride();
 	GEBufferFormat format = gstate.FrameBufFormat();
-	return framebufferManager_.GetFramebuffer(fb_address, fb_stride, format, buffer);
+	return framebufferManager_.GetFramebuffer(fb_address, fb_stride, format, buffer, maxRes);
 }
 
 bool GPU_GLES::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -80,7 +80,7 @@ public:
 	}
 	std::vector<FramebufferInfo> GetFramebufferList() override;
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer) override;
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) override;
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -821,7 +821,7 @@ bool SoftGPU::FramebufferDirty() {
 	return true;
 }
 
-bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer)
+bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes)
 {
 	const int w = gstate.getRegionX2() - gstate.getRegionX1() + 1;
 	const int h = gstate.getRegionY2() - gstate.getRegionY1() + 1;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -83,7 +83,7 @@ public:
 		return !(gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME);
 	}
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer) override;
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) override;
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -333,7 +333,7 @@ void GamePauseScreen::CreateViews() {
 
 	// TODO, also might be nice to show overall compat rating here?
 	// Based on their platform or even cpu/gpu/config.  Would add an API for it.
-	if (Reporting::IsEnabled() && gameId.size() && gameId != "_") {
+	if (Reporting::IsSupported() && gameId.size() && gameId != "_") {
 		I18NCategory *rp = GetI18NCategory("Reporting");
 		rightColumnItems->Add(new Choice(rp->T("ReportButton", "Report Feedback")))->OnClick.Handle(this, &GamePauseScreen::OnReportFeedback);
 	}

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -80,6 +80,8 @@ void AsyncImageFileView::Draw(UIContext &dc) {
 		texture_ = dc.GetThin3DContext()->CreateTextureFromFile(filename_.c_str(), DETECT);
 		if (!texture_)
 			textureFailed_ = true;
+		else if (textureAutoGen_)
+			texture_->AutoGenMipmaps();
 	}
 
 	if (HasFocus()) {

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -68,7 +68,7 @@ class PrioritizedWorkQueue;
 class AsyncImageFileView : public UI::Clickable {
 public:
 	AsyncImageFileView(const std::string &filename, UI::ImageSizeMode sizeMode, PrioritizedWorkQueue *wq, UI::LayoutParams *layoutParams = 0)
-		: UI::Clickable(layoutParams), canFocus_(true), filename_(filename), color_(0xFFFFFFFF), sizeMode_(sizeMode), texture_(NULL), textureFailed_(false), fixedSizeW_(0.0f), fixedSizeH_(0.0f) {}
+		: UI::Clickable(layoutParams), canFocus_(true), filename_(filename), color_(0xFFFFFFFF), sizeMode_(sizeMode), texture_(NULL), textureFailed_(false), textureAutoGen_(true), fixedSizeW_(0.0f), fixedSizeH_(0.0f) {}
 	~AsyncImageFileView() {
 		delete texture_;
 	}
@@ -81,6 +81,7 @@ public:
 	void SetOverlayText(std::string text) { text_ = text; }
 	void SetFixedSize(float fixW, float fixH) { fixedSizeW_ = fixW; fixedSizeH_ = fixH; }
 	void SetCanBeFocused(bool can) { canFocus_ = can; }
+	void SetAutoGenMipmaps(bool a) { textureAutoGen_ = a; }
 
 	bool CanBeFocused() const override { return canFocus_; }
 
@@ -95,6 +96,7 @@ private:
 
 	Thin3DTexture *texture_;
 	bool textureFailed_;
+	bool textureAutoGen_;
 	float fixedSizeW_;
 	float fixedSizeH_;
 };

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -153,7 +153,9 @@ void CompatRatingChoice::SetupChoices() {
 
 ReportScreen::ReportScreen(const std::string &gamePath)
 	: UIScreenWithGameBackground(gamePath), overall_(-1), graphics_(-1), speed_(-1), gameplay_(-1),
-	ratingEnabled_(true), includeScreenshot_(true) {
+	includeScreenshot_(true) {
+	enableReporting_ = Reporting::IsEnabled();
+	ratingEnabled_ = enableReporting_;
 }
 
 void ReportScreen::update(InputState &input) {
@@ -179,32 +181,58 @@ EventReturn ReportScreen::HandleChoice(EventParams &e) {
 		gameplay_ = -1;
 		ratingEnabled_ = true;
 	}
-	submit_->SetEnabled(overall_ >= 0 && graphics_ >= 0 && speed_ >= 0 && gameplay_ >= 0);
+	UpdateSubmit();
+	return EVENT_DONE;
+}
+
+EventReturn ReportScreen::HandleReportingChange(EventParams &e) {
+	if (overall_ == 4) {
+		ratingEnabled_ = false;
+	} else {
+		ratingEnabled_ = enableReporting_;
+	}
+	if (reportingNotice_) {
+		reportingNotice_->SetTextColor(enableReporting_ ? 0xFFFFFFFF : 0xFF3030FF);
+	}
+	UpdateSubmit();
 	return EVENT_DONE;
 }
 
 void ReportScreen::CreateViews() {
 	I18NCategory *rp = GetI18NCategory("Reporting");
 	I18NCategory *di = GetI18NCategory("Dialog");
-	Margins actionMenuMargins(0, 100, 15, 0);
-	ViewGroup *leftColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 0.4f));
+	I18NCategory *sy = GetI18NCategory("System");
+
+	Margins actionMenuMargins(0, 20, 15, 0);
+	Margins contentMargins(0, 20, 5, 5);
+	ViewGroup *leftColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 0.4f, contentMargins));
 	LinearLayout *leftColumnItems = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(WRAP_CONTENT, FILL_PARENT));
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
 
-	leftColumnItems->Add(new InfoItem(rp->T("FeedbackDesc", "How's the emulation?  Let us and the community know!"), ""));
+	leftColumnItems->Add(new TextView(rp->T("FeedbackDesc", "How's the emulation?  Let us and the community know!"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+	if (!Reporting::IsEnabled()) {
+		reportingNotice_ = leftColumnItems->Add(new TextView(rp->T("FeedbackDisabled", "Compatibility server reports must be enabled."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+		reportingNotice_->SetShadow(true);
+		reportingNotice_->SetTextColor(0xFF3030FF);
+		CheckBox *reporting = leftColumnItems->Add(new CheckBox(&enableReporting_, sy->T("Enable Compatibility Server Reports")));
+		reporting->SetEnabled(Reporting::IsSupported());
+		reporting->OnClick.Handle(this, &ReportScreen::HandleReportingChange);
+	} else {
+		reportingNotice_ = nullptr;
+	}
 
 	screenshotFilename_ = GetSysDirectory(DIRECTORY_SCREENSHOT) + ".reporting.jpg";
 	int shotWidth = 0, shotHeight = 0;
 	if (TakeGameScreenshot(screenshotFilename_.c_str(), SCREENSHOT_JPG, SCREENSHOT_RENDER, &shotWidth, &shotHeight, 4)) {
 		float scale = 340.0f * (1.0f / g_dpi_scale) * (1.0f / shotHeight);
-		leftColumnItems->Add(new CheckBox(&includeScreenshot_, rp->T("FeedbackIncludeScreen", "Include a screenshot")));
+		leftColumnItems->Add(new CheckBox(&includeScreenshot_, rp->T("FeedbackIncludeScreen", "Include a screenshot")))->SetEnabledPtr(&enableReporting_);
 		screenshot_ = leftColumnItems->Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, nullptr, new LinearLayoutParams(shotWidth * scale, shotHeight * scale, Margins(12, 0))));
 	} else {
 		includeScreenshot_ = false;
 	}
 
-	leftColumnItems->Add(new CompatRatingChoice("Overall", &overall_))->OnChoice.Handle(this, &ReportScreen::HandleChoice);
+	leftColumnItems->Add(new CompatRatingChoice("Overall", &overall_))->SetEnabledPtr(&enableReporting_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	leftColumnItems->Add(new RatingChoice("Graphics", &graphics_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	leftColumnItems->Add(new RatingChoice("Speed", &speed_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	leftColumnItems->Add(new RatingChoice("Gameplay", &gameplay_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
@@ -213,7 +241,7 @@ void ReportScreen::CreateViews() {
 	rightColumnItems->Add(new Choice(rp->T("Open Browser")))->OnClick.Handle(this, &ReportScreen::HandleBrowser);
 	submit_ = new Choice(rp->T("Submit Feedback"));
 	rightColumnItems->Add(submit_)->OnClick.Handle(this, &ReportScreen::HandleSubmit);
-	submit_->SetEnabled(overall_ >= 0 && graphics_ >= 0 && speed_ >= 0 && gameplay_ >= 0);
+	UpdateSubmit();
 
 	rightColumnItems->Add(new Spacer(25.0));
 	rightColumnItems->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
@@ -226,6 +254,10 @@ void ReportScreen::CreateViews() {
 	rightColumn->Add(rightColumnItems);
 }
 
+void ReportScreen::UpdateSubmit() {
+	submit_->SetEnabled(enableReporting_ && overall_ >= 0 && graphics_ >= 0 && speed_ >= 0 && gameplay_ >= 0);
+}
+
 EventReturn ReportScreen::HandleSubmit(EventParams &e) {
 	const char *compat;
 	switch (overall_) {
@@ -235,6 +267,11 @@ EventReturn ReportScreen::HandleSubmit(EventParams &e) {
 	case 3: compat = "menu"; break;
 	case 4: compat = "none"; break;
 	default: compat = "unknown"; break;
+	}
+
+	if (Reporting::Enable(enableReporting_, "report.ppsspp.org")) {
+		Reporting::UpdateConfig();
+		g_Config.Save();
 	}
 
 	std::string filename = includeScreenshot_ ? screenshotFilename_ : "";

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -237,7 +237,8 @@ EventReturn ReportScreen::HandleSubmit(EventParams &e) {
 	default: compat = "unknown"; break;
 	}
 
-	Reporting::ReportCompatibility(compat, graphics_ + 1, speed_ + 1, gameplay_ + 1);
+	std::string filename = includeScreenshot_ ? screenshotFilename_ : "";
+	Reporting::ReportCompatibility(compat, graphics_ + 1, speed_ + 1, gameplay_ + 1, filename);
 	screenManager()->finishDialog(this, DR_OK);
 	return EVENT_DONE;
 }

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -27,6 +27,8 @@ public:
 	ReportScreen(const std::string &gamePath);
 
 protected:
+	void update(InputState &input) override;
+
 	UI::EventReturn HandleChoice(UI::EventParams &e);
 	UI::EventReturn HandleSubmit(UI::EventParams &e);
 	UI::EventReturn HandleBrowser(UI::EventParams &e);
@@ -34,9 +36,13 @@ protected:
 	virtual void CreateViews();
 
 	UI::Choice *submit_;
+	UI::View *screenshot_;
+	std::string screenshotFilename_;
+
 	int overall_;
 	int graphics_;
 	int speed_;
 	int gameplay_;
 	bool ratingEnabled_;
+	bool includeScreenshot_;
 };

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -28,21 +28,24 @@ public:
 
 protected:
 	void update(InputState &input) override;
+	void CreateViews() override;
+	void UpdateSubmit();
 
 	UI::EventReturn HandleChoice(UI::EventParams &e);
 	UI::EventReturn HandleSubmit(UI::EventParams &e);
 	UI::EventReturn HandleBrowser(UI::EventParams &e);
-
-	virtual void CreateViews();
+	UI::EventReturn HandleReportingChange(UI::EventParams &e);
 
 	UI::Choice *submit_;
 	UI::View *screenshot_;
+	UI::TextView *reportingNotice_;
 	std::string screenshotFilename_;
 
 	int overall_;
 	int graphics_;
 	int speed_;
 	int gameplay_;
+	bool enableReporting_;
 	bool ratingEnabled_;
 	bool includeScreenshot_;
 };

--- a/ext/native/net/url.h
+++ b/ext/native/net/url.h
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <cstdarg>
+#include <vector>
 
 #include "base/basictypes.h"
 
@@ -145,10 +146,16 @@ struct MultipartFormDataEncoder : UrlEncoder
 		char temp[64];
 		snprintf(temp, sizeof(temp), "Content-Length: %d\r\n", (int)value.size());
 		data += temp;
+		data += "Content-Transfer-Encoding: binary\r\n";
 		data += "\r\n";
 
 		data += value;
 		data += "\r\n";
+	}
+
+	void Add(const std::string &key, const std::vector<uint8_t> &value, const std::string &filename, const std::string &mimeType)
+	{
+		Add(key, std::string((const char *)&value[0], value.size()), filename, mimeType);
 	}
 
 	virtual void Finish()


### PR DESCRIPTION
The main high level things this does:
- Adds a way to cap screenshot dimensions at high resolutions, no UI.
- Allows optional screenshots (max 1920x1088) and icon upload to the server.
- Enables mipmaps for savestate screenshots in more places.
- Shows the Feedback button even when reporting is disabled, and prompts to enable.

The reason reporting is required is that reports (especially negative ones) without error information aren't very useful.  We could disconnect it, with some changes.

Note: currently the server is storing but not serving these images.  For security reasons, we'll need to validate the uploaded images before serving, but at least they aren't going into a blackhole

-[Unknown]
