### PR TITLE
Enable extra ram for The Elder Scrolls Travels Oblivion USA Beta and Melodie alpha

### DIFF
--- a/Core/HDRemaster.cpp
+++ b/Core/HDRemaster.cpp
@@ -30,6 +30,12 @@ extern const struct HDRemaster g_HDRemasters[] = {
 	{ "ULJM05277", 0x04C00000, true, "ULJM-05277|0E8D71AFAA4F62D8|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
 	{ "ULJM05353", 0x04C00000, true, "ULJM-05353|0061DA67EBD6B9C6|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition
 	{ "ULUS12345", 0x04000000, false, "ULUS-12345|6E197A8FB304B3DB|0001|G" }, // Saints Row 2 / Undercover - alpha (needs extra ram, not a remaster)
+	{ "UCUS12345", 0x04000000, false, "UCUS-12345|909D53E8B45B4B4A|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 09062006 (needs extra ram, not a remaster)
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BC7AE2442B7CD085|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 21112006 (needs extra ram, not a remaster)
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|6035DE628DC1C924|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 31012007 (needs extra ram, not a remaster)
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BBE65F2837A488C2|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 01022007 (needs extra ram, not a remaster)
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|55BE9ADC13B14D65|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 27042007 (needs extra ram, not a remaster)
+	{ "PETR00010", 0x04000000, false, "PETR-00010|0C274C92FF78330E|0001|G" }, // Melodie - alpha (needs extra ram, not a remaster)
 };
 
 const size_t g_HDRemastersCount = ARRAY_SIZE(g_HDRemasters);


### PR DESCRIPTION
For boot up those games.
![01](https://cloud.githubusercontent.com/assets/3481559/16034976/2c75175e-3247-11e6-8491-c4b9b9f72a9e.png)
![02](https://cloud.githubusercontent.com/assets/3481559/16034977/2c87a856-3247-11e6-98be-4c8585a1d628.png)
