### PR TITLE
CWC improvements/fixes

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -39,7 +39,9 @@ static void __CheatStart() {
 
 	gameTitle = g_paramSFO.GetValueString("DISC_ID");
 
-	cheatEngine->CreateCheatFile();
+	if (gameTitle != "") { //this only generates ini files on boot, let's leave homebrew ini file for UI
+		cheatEngine->CreateCheatFile();
+	}
 
 	cheatEngine = new CWCheatEngine();
 	cheatEngine->CreateCodeList();

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -269,10 +269,7 @@ inline void trim2(std::string& str) {
 	else str.erase(str.begin(), str.end());
 }
 
-std::vector<std::string> CWCheatEngine::GetCodesList(std::string file) { //Reads the entire cheat list from the appropriate .ini.
-	if (file.empty()) {
-		file = activeCheatFile;
-	}
+std::vector<std::string> CWCheatEngine::GetCodesList() { //Reads the entire cheat list from the appropriate .ini.
 	std::string line;
 	std::vector<std::string> codesList;  // Read from INI here
 #ifdef _WIN32

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -21,7 +21,7 @@ bool CheatsInEffect();
 class CWCheatEngine {
 public:
 	CWCheatEngine();
-	std::vector<std::string> GetCodesList(std::string file = "");
+	std::vector<std::string> GetCodesList();
 	void CreateCodeList();
 	void CreateCheatFile();
 	void Exit();

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -21,8 +21,9 @@ bool CheatsInEffect();
 class CWCheatEngine {
 public:
 	CWCheatEngine();
-	std::vector<std::string> GetCodesList();
+	std::vector<std::string> GetCodesList(std::string file = "");
 	void CreateCodeList();
+	void CreateCheatFile();
 	void Exit();
 	void Run();
 	std::vector<int> GetNextCode();

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -40,10 +40,23 @@ static bool enableAll = false;
 static std::vector<std::string> cheatList;
 static CWCheatEngine *cheatEngine2;
 static std::deque<bool> bEnableCheat;
+static std::string gamePath_;
+
+
+CwCheatScreen::CwCheatScreen(std::string gamePath)
+	: UIDialogScreenWithBackground() {
+	gamePath_ = gamePath;
+}
 
 void CwCheatScreen::CreateCodeList() {
+	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
+	if (info && info->paramSFOLoaded) {
+		gameTitle = info->paramSFO.GetValueString("DISC_ID");
+	}
 	cheatEngine2 = new CWCheatEngine();
-	cheatList = cheatEngine2->GetCodesList();
+	cheatEngine2->CreateCheatFile();
+	cheatList = cheatEngine2->GetCodesList(activeCheatFile);
+
 	bEnableCheat.clear();
 	formattedList_.clear();
 	for (size_t i = 0; i < cheatList.size(); i++) {

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -214,6 +214,10 @@ UI::EventReturn CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
 }
 
 UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
+	if (gameTitle.length() != 9) {
+		WARN_LOG(COMMON, "CWCHEAT: Incorrect ID(%s) - can't import cheats.", gameTitle.c_str());
+		return UI::EVENT_DONE;
+	}
 	std::string line;
 	std::vector<std::string> title;
 	bool finished = false, skip = false;

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -68,7 +68,7 @@ void CwCheatScreen::CreateCodeList() {
 	}
 	cheatEngine2 = new CWCheatEngine();
 	cheatEngine2->CreateCheatFile();
-	cheatList = cheatEngine2->GetCodesList(activeCheatFile);
+	cheatList = cheatEngine2->GetCodesList();
 
 	bEnableCheat.clear();
 	formattedList_.clear();

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -53,6 +53,19 @@ void CwCheatScreen::CreateCodeList() {
 	if (info && info->paramSFOLoaded) {
 		gameTitle = info->paramSFO.GetValueString("DISC_ID");
 	}
+	std::size_t lslash = gamePath_.find_last_of("/");
+	std::size_t lastdot = gamePath_.find_last_of(".");
+	std::string extension = gamePath_.substr(lastdot + 1);
+	for (int i = 0; i < extension.size(); i++) {
+		extension[i] = tolower(extension[i]);
+	}
+	if (extension != "iso" && extension != "cso" && extension != "pbp" || gameTitle == "") {
+		if (extension == "elf") {
+			gameTitle = "ELF000000";
+		} else {
+			gameTitle = gamePath_.substr(lslash + 1);
+		}
+	}
 	cheatEngine2 = new CWCheatEngine();
 	cheatEngine2->CreateCheatFile();
 	cheatList = cheatEngine2->GetCodesList(activeCheatFile);

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -26,6 +26,7 @@ extern std::string gameTitle;
 
 class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
+	CwCheatScreen(std::string gamePath);
 	CwCheatScreen() {}
 	void CreateCodeList();
 	void processFileOn(std::string activatedCheat);

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -25,6 +25,7 @@
 #include "ui/ui_context.h"
 #include "ui/view.h"
 #include "ui/viewgroup.h"
+#include "UI/CwCheatScreen.h"
 #include "UI/EmuScreen.h"
 #include "UI/GameScreen.h"
 #include "UI/GameSettingsScreen.h"
@@ -49,6 +50,7 @@ void GameScreen::CreateViews() {
 
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *ga = GetI18NCategory("Game");
+	I18NCategory *pa = GetI18NCategory("Pause");
 
 	// Information in the top left.
 	// Back button to the bottom left.
@@ -113,6 +115,9 @@ void GameScreen::CreateViews() {
 #ifdef _WIN32
 	rightColumnItems->Add(new Choice(ga->T("Show In Folder")))->OnClick.Handle(this, &GameScreen::OnShowInFolder);
 #endif
+	if (g_Config.bEnableCheats) {
+		rightColumnItems->Add(new Choice(pa->T("Cheats")))->OnClick.Handle(this, &GameScreen::OnCwCheat);
+	}
 }
 
 UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)
@@ -202,6 +207,11 @@ UI::EventReturn GameScreen::OnShowInFolder(UI::EventParams &e) {
 	std::string str = std::string("explorer.exe /select,\"") + ReplaceAll(gamePath_, "/", "\\") + "\"";
 	_wsystem(ConvertUTF8ToWString(str).c_str());
 #endif
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameScreen::OnCwCheat(UI::EventParams &e) {
+	screenManager()->push(new CwCheatScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -55,6 +55,7 @@ private:
 	UI::EventReturn OnShowInFolder(UI::EventParams &e);
 	UI::EventReturn OnCreateConfig(UI::EventParams &e);
 	UI::EventReturn OnDeleteConfig(UI::EventParams &e);
+	UI::EventReturn OnCwCheat(UI::EventParams &e);
 
 	// As we load metadata in the background, we need to be able to update these after the fact.
 	UI::Thin3DTextureView *texvGameIcon_;

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -405,7 +405,7 @@ UI::EventReturn GamePauseScreen::OnRewind(UI::EventParams &e) {
 }
 
 UI::EventReturn GamePauseScreen::OnCwCheat(UI::EventParams &e) {
-	screenManager()->push(new CwCheatScreen());
+	screenManager()->push(new CwCheatScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 


### PR DESCRIPTION
 This solves #8658 althrough I would be lazy to do it just because of the argument mentioned there about someone being lazy to restart emulation when it's required by cheat, my own argument for adding it is for cases where broken cheats crash PPSSPP on boot which might suck on non windows platforms currently.

 It additionally fixes a small problem where first line was removed from newly created files, it could remove first cheat if someone opened automatically created file and added cheats without _S/_G lines that we usually add as PSP legacy, but not actually use them.

 Also invalidates JIT for reading values via 0xE/0xD multi-line skip codes, in some cases where code is moved around/loaded in modules those codes can't read original values otherwise. I don't think that's particulary common issue since people rarely ever used those cheats that way on psp, I do it all the time since they're great to stop long scripts from being written constantly as well as for safety checks.

 Saying so I can't really find any more issues with CWC, people will continue to have problems with PSP cheats where address differs and we can't do much about it, so I guess #7375 could also be closed.

Edit: sorry for pushing it like few times in a row;p I'm quite literally on drugs(well eye drops count as drugs I guess;p) and my vision is quite blurry. Should be fine now.
## 

Fixes #8448, fixes #8658, fixes #8023.  Fixes #7375 (remaining jit invalidations.)
