### PR TITLE
Add basic TextureReplacement UI options.

### DIFF
--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -127,6 +127,7 @@ private:
 	UI::EventReturn OnLoggingChanged(UI::EventParams &e);
 	UI::EventReturn OnLoadLanguageIni(UI::EventParams &e);
 	UI::EventReturn OnSaveLanguageIni(UI::EventParams &e);
+	UI::EventReturn OnOpenTexturesIniFile(UI::EventParams &e);
 	UI::EventReturn OnLogConfig(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 };


### PR DESCRIPTION
Don't think it's all that useful for feature which requires manual work, but might avoid potential confusion with changing ppsspp.ini with ppsspp running.

Developer tools screen seems like a fitting place.
![trui](https://cloud.githubusercontent.com/assets/5485237/16248748/7499c834-3811-11e6-9f10-c69c2aa558e6.jpg)
