### PR TITLE
Write some defaults to textures.ini on creation.

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -680,6 +680,55 @@ void CopyDir(const std::string &source_path, const std::string &dest_path)
 #endif
 }
 
+void openIniFile(const std::string fileName) {
+	std::string iniFile;
+#if defined(_WIN32)
+	iniFile = fileName;
+	// Can't rely on a .txt file extension to auto-open in the right editor,
+	// so let's find notepad
+	wchar_t notepad_path[MAX_PATH + 1];
+	GetSystemDirectory(notepad_path, MAX_PATH);
+	wcscat(notepad_path, L"\\notepad.exe");
+
+	wchar_t ini_path[MAX_PATH + 1] = { 0 };
+	wcsncpy(ini_path, ConvertUTF8ToWString(iniFile).c_str(), MAX_PATH);
+	// Flip any slashes...
+	for (size_t i = 0; i < wcslen(ini_path); i++) {
+		if (ini_path[i] == '/')
+			ini_path[i] = '\\';
+	}
+
+	// One for the space, one for the null.
+	wchar_t command_line[MAX_PATH * 2 + 1 + 1];
+	wsprintf(command_line, L"%s %s", notepad_path, ini_path);
+
+	STARTUPINFO si;
+	memset(&si, 0, sizeof(si));
+	si.cb = sizeof(si);
+	si.wShowWindow = SW_SHOW;
+	PROCESS_INFORMATION pi;
+	memset(&pi, 0, sizeof(pi));
+	UINT retval = CreateProcess(0, command_line, 0, 0, 0, 0, 0, 0, &si, &pi);
+	if (!retval) {
+		ERROR_LOG(COMMON, "Failed creating notepad process");
+	}
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+#elif !defined(MOBILE_DEVICE)
+#if defined(__APPLE__)
+	iniFile = "open ";
+#else
+	iniFile = "xdg-open ";
+#endif
+	iniFile.append(fileName);
+	NOTICE_LOG(BOOT, "Launching %s", iniFile.c_str());
+	int retval = system(iniFile.c_str());
+	if (retval != 0) {
+		ERROR_LOG(COMMON, "Failed to launch ini file");
+	}
+#endif
+}
+
 // Returns the current directory
 std::string GetCurrentDir()
 {

--- a/Common/FileUtil.h
+++ b/Common/FileUtil.h
@@ -113,6 +113,9 @@ std::string GetCurrentDir();
 // Create directory and copy contents (does not overwrite existing files)
 void CopyDir(const std::string &source_path, const std::string &dest_path);
 
+// Opens ini file (cheats, texture replacements etc.)
+void openIniFile(const std::string fileName);
+
 // Set the current directory to given directory
 bool SetCurrentDir(const std::string &directory);
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -172,57 +172,12 @@ UI::EventReturn CwCheatScreen::OnAddCheat(UI::EventParams &params) {
 }
 
 UI::EventReturn CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
-	std::string cheatFile;
 	g_Config.bReloadCheats = true;
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}
 	screenManager()->finishDialog(this, DR_OK);
-#ifdef _WIN32
-	cheatFile = activeCheatFile;
-	// Can't rely on a .txt file extension to auto-open in the right editor,
-	// so let's find notepad
-	wchar_t notepad_path[MAX_PATH + 1];
-	GetSystemDirectory(notepad_path, MAX_PATH);
-	wcscat(notepad_path, L"\\notepad.exe");
-
-	wchar_t cheat_path[MAX_PATH + 1] = {0};
-	wcsncpy(cheat_path, ConvertUTF8ToWString(cheatFile).c_str(), MAX_PATH);
-	// Flip any slashes...
-	for (size_t i = 0; i < wcslen(cheat_path); i++) {
-		if (cheat_path[i] == '/')
-			cheat_path[i] = '\\';
-	}
-
-	// One for the space, one for the null.
-	wchar_t command_line[MAX_PATH * 2 + 1 + 1];
-	wsprintf(command_line, L"%s %s", notepad_path, cheat_path);
-
-	STARTUPINFO si;
-	memset(&si, 0, sizeof(si));
-	si.cb = sizeof(si);
-	si.wShowWindow = SW_SHOW;
-	PROCESS_INFORMATION pi;
-	memset(&pi, 0, sizeof(pi));
-	UINT retval = CreateProcess(0, command_line, 0, 0, 0, 0, 0, 0, &si, &pi);
-	if (!retval) {
-		ERROR_LOG(COMMON, "Failed creating notepad process");
-	}
-	CloseHandle(pi.hThread);
-	CloseHandle(pi.hProcess);
-#elif !defined(MOBILE_DEVICE)
-#if defined(__APPLE__)
-	cheatFile = "open ";
-#else
-	cheatFile = "xdg-open ";
-#endif
-	cheatFile.append(activeCheatFile);
-	NOTICE_LOG(BOOT, "Launching %s", cheatFile.c_str());
-	int retval = system(cheatFile.c_str());
-	if (retval != 0) {
-		ERROR_LOG(COMMON, "Failed to launch cheat file");
-	}
-#endif
+	File::openIniFile(activeCheatFile);
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1158,7 +1158,7 @@ UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) 
 				fclose(f);
 				// Let's also write some defaults
 				std::fstream fs;
-				File::OpenCPPFile(fs, texturesDirectory + "textures.ini", std::ios::out);
+				File::OpenCPPFile(fs, texturesDirectory + "textures.ini", std::ios::out | std::ios::ate);
 				fs << "# This file is optional\n";
 				fs << "# for syntax explanation check:\n";
 				fs << "# - https://github.com/hrydgard/ppsspp/pull/8715 \n";
@@ -1176,52 +1176,7 @@ UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) 
 		enabled_ = File::Exists(texturesDirectory + "textures.ini");
 	}
 	if (enabled_) {
-		std::string texturesIniFile;
-#if defined(_WIN32)
-		texturesIniFile = texturesDirectory + "textures.ini";
-		// Can't rely on a .txt file extension to auto-open in the right editor,
-		// so let's find notepad
-		wchar_t notepad_path[MAX_PATH + 1];
-		GetSystemDirectory(notepad_path, MAX_PATH);
-		wcscat(notepad_path, L"\\notepad.exe");
-
-		wchar_t ini_path[MAX_PATH + 1] = { 0 };
-		wcsncpy(ini_path, ConvertUTF8ToWString(texturesIniFile).c_str(), MAX_PATH);
-		// Flip any slashes...
-		for (size_t i = 0; i < wcslen(ini_path); i++) {
-			if (ini_path[i] == '/')
-				ini_path[i] = '\\';
-		}
-
-		// One for the space, one for the null.
-		wchar_t command_line[MAX_PATH * 2 + 1 + 1];
-		wsprintf(command_line, L"%s %s", notepad_path, ini_path);
-
-		STARTUPINFO si;
-		memset(&si, 0, sizeof(si));
-		si.cb = sizeof(si);
-		si.wShowWindow = SW_SHOW;
-		PROCESS_INFORMATION pi;
-		memset(&pi, 0, sizeof(pi));
-		UINT retval = CreateProcess(0, command_line, 0, 0, 0, 0, 0, 0, &si, &pi);
-		if (!retval) {
-			ERROR_LOG(COMMON, "Failed creating notepad process");
-		}
-		CloseHandle(pi.hThread);
-		CloseHandle(pi.hProcess);
-#elif !defined(MOBILE_DEVICE)
-#if defined(__APPLE__)
-		texturesIniFile = "open ";
-#else
-		texturesIniFile = "xdg-open ";
-#endif
-		texturesIniFile.append(texturesDirectory + "textures.ini");
-		NOTICE_LOG(BOOT, "Launching %s", texturesIniFile.c_str());
-		int retval = system(texturesIniFile.c_str());
-		if (retval != 0) {
-			ERROR_LOG(COMMON, "Failed to launch textures.ini file");
-		}
-#endif
+		File::openIniFile(texturesDirectory + "textures.ini");
 	}
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1156,6 +1156,21 @@ UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) 
 			if (f) {
 				fwrite("\xEF\xBB\xBF", 0, 3, f);
 				fclose(f);
+				// Let's also write some defaults
+				std::fstream fs;
+				File::OpenCPPFile(fs, texturesDirectory + "textures.ini", std::ios::out);
+				fs << "# This file is optional\n";
+				fs << "# for syntax explanation check:\n";
+				fs << "# - https://github.com/hrydgard/ppsspp/pull/8715 \n";
+				fs << "# - https://github.com/hrydgard/ppsspp/pull/8792 \n";
+				fs << "[options]\n";
+				fs << "version = 1\n";
+				fs << "hash = quick\n";
+				fs << "\n";
+				fs << "[hashes]\n";
+				fs << "\n";
+				fs << "[hashranges]\n";
+				fs.close();
 			}
 		}
 		enabled_ = File::Exists(texturesDirectory + "textures.ini");


### PR DESCRIPTION
 Didn't even know, but empty textures.ini file(without [options]) stops texture replacement, so defaults along with some useful info seems nice addition.

 Open to ideas what info should go there.

Edit: Just thinking maybe would be better idea to set some default hash in texture replacer when it's set incorrectly/not set at all? ~ or not after thinking about this I guess once we get more hashes and people start making typos in their names it's better to not work than work incorrectly, automatic defaults are enough.
