### PR TITLE
Reduce scale/decode overhead in Direct3D9 and Vulkan

### DIFF
--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <cmath>
 
@@ -502,6 +503,37 @@ bool TextureScaler::IsEmptyOrFlat(u32* data, int pixels, int fmt) {
 		if (data[i] != ref) return false;
 	}
 	return true;
+}
+
+void TextureScaler::ScaleAlways(u32 *&data, u32 &dstFmt, int &width, int &height, int factor) {
+	if (!Scale(data, dstFmt, width, height, factor)) {
+		// This means it was a flat texture.  Vulkan wants the size up front, so we need to make it happen.
+		assert(IsEmptyOrFlat(data, width * height, dstFmt));
+
+		u32 pixel;
+		// Since it's flat, one pixel is enough.  It might end up pointing to data, though.
+		u32 *pixelPointer = &pixel;
+		ConvertTo8888(dstFmt, data, pixelPointer, 1, 1);
+		if (pixelPointer != &pixel) {
+			pixel = *pixelPointer;
+		}
+
+		bufOutput.resize(width * height * factor * factor);
+		dstFmt = Get8888Format();
+		data = bufOutput.data();
+		width *= factor;
+		height *= factor;
+
+		// ABCD.  If A = D, and AB = CD, then they must all be equal (B = C, etc.)
+		if ((pixel & 0x000000FF) == (pixel >> 24) && (pixel & 0x0000FFFF) == (pixel >> 16)) {
+			memset(data, pixel & 0xFF, width * height * sizeof(u32));
+		} else {
+			// Let's hope this is vectorized.
+			for (int i = 0; i < width * height; ++i) {
+				data[i] = pixel;
+			}
+		}
+	}
 }
 
 bool TextureScaler::Scale(u32* &data, u32 &dstFmt, int &width, int &height, int factor) {

--- a/GPU/Common/TextureScalerCommon.h
+++ b/GPU/Common/TextureScalerCommon.h
@@ -27,12 +27,13 @@ public:
 	TextureScaler();
 	~TextureScaler();
 
-	bool Scale(u32* &data, u32 &dstfmt, int &width, int &height, int factor);
+	void ScaleAlways(u32 *&data, u32 &dstFmt, int &width, int &height, int factor);
+	bool Scale(u32 *&data, u32 &dstfmt, int &width, int &height, int factor);
 
 	enum { XBRZ = 0, HYBRID = 1, BICUBIC = 2, HYBRID_BICUBIC = 3 };
 
 protected:
-	virtual void ConvertTo8888(u32 format, u32* source, u32* &dest, int width, int height) = 0;
+	virtual void ConvertTo8888(u32 format, u32 *source, u32 *&dest, int width, int height) = 0;
 	virtual int BytesPerPixel(u32 format) = 0;
 	virtual u32 Get8888Format() = 0;
 

--- a/GPU/Common/TextureScalerCommon.h
+++ b/GPU/Common/TextureScalerCommon.h
@@ -27,8 +27,9 @@ public:
 	TextureScaler();
 	~TextureScaler();
 
-	void ScaleAlways(u32 *&data, u32 &dstFmt, int &width, int &height, int factor);
+	void ScaleAlways(u32 *out, u32 *src, u32 &dstFmt, int &width, int &height, int factor);
 	bool Scale(u32 *&data, u32 &dstfmt, int &width, int &height, int factor);
+	bool ScaleInto(u32 *out, u32 *src, u32 &dstfmt, int &width, int &height, int factor);
 
 	enum { XBRZ = 0, HYBRID = 1, BICUBIC = 2, HYBRID_BICUBIC = 3 };
 

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -81,7 +81,6 @@ private:
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
 	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int maxLevel, bool replaceImages, int scaleFactor, u32 dstFmt);
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	void *DecodeTextureLevelOld(GETextureFormat format, GEPaletteFormat clutformat, int level, u32 &dstFmt, int *bufw = 0);
 	TexCacheEntry::Status CheckAlpha(const u32 *pixelData, u32 dstFmt, int stride, int w, int h);
 	u32 GetCurrentClutHash();
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1399,9 +1399,7 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 	CachedTextureVulkan *tex = entry.vkTex;
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
-	u32 *pixelData;
-	int decPitch;
-	int rowBytes;
+
 	{
 		PROFILE_THIS_SCOPE("decodetex");
 
@@ -1411,8 +1409,8 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 		int bufw = GetTextureBufw(level, texaddr, tfmt);
 		int bpp = dstFmt == VULKAN_8888_FORMAT ? 4 : 2;
 
-		pixelData = (u32 *)writePtr;
-		decPitch = rowPitch;
+		u32 *pixelData = (u32 *)writePtr;
+		int decPitch = rowPitch;
 		if (scaleFactor > 1) {
 			tmpTexBufRearrange.resize(std::max(bufw, w) * h);
 			pixelData = tmpTexBufRearrange.data();
@@ -1425,7 +1423,6 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 			memset(writePtr, 0, rowPitch * h);
 			return;
 		}
-		rowBytes = w * bpp;
 		gpuStats.numTexturesDecoded++;
 
 		if (scaleFactor > 1) {
@@ -1438,14 +1435,14 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 			assert(dstFmt == VULKAN_8888_FORMAT);
 			bpp = sizeof(u32);
 			decPitch = w * bpp;
-			rowBytes = w * bpp;
 
 			if (decPitch != rowPitch) {
 				// Rearrange in place to match the requested pitch.
 				// (it can only be larger than w * bpp, and a match is likely.)
 				for (int y = h - 1; y >= 0; --y) {
-					memcpy(writePtr + rowPitch * y, writePtr + decPitch * y, rowBytes);
+					memcpy(writePtr + rowPitch * y, writePtr + decPitch * y, w * bpp);
 				}
+				decPitch = rowPitch;
 			}
 		}
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1430,7 +1430,8 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 
 		if (scaleFactor > 1) {
 			u32 fmt = dstFmt;
-			scaler.ScaleAlways(pixelData, fmt, w, h, scaleFactor);
+			scaler.ScaleAlways((u32 *)writePtr, pixelData, fmt, w, h, scaleFactor);
+			pixelData = (u32 *)writePtr;
 			dstFmt = (VkFormat)fmt;
 
 			// We always end up at 8888.  Other parts assume this.
@@ -1438,6 +1439,14 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 			bpp = sizeof(u32);
 			decPitch = w * bpp;
 			rowBytes = w * bpp;
+
+			if (decPitch != rowPitch) {
+				// Rearrange in place to match the requested pitch.
+				// (it can only be larger than w * bpp, and a match is likely.)
+				for (int y = h - 1; y >= 0; --y) {
+					memcpy(writePtr + rowPitch * y, writePtr + decPitch * y, rowBytes);
+				}
+			}
 		}
 
 		if ((entry.status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
@@ -1445,14 +1454,6 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 			entry.SetAlphaStatus(alphaStatus, level);
 		} else {
 			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
-		}
-	}
-
-	PROFILE_THIS_SCOPE("loadtex");
-	if (pixelData != (u32 *)writePtr) {
-		// This is used when texture scaling was enabled.
-		for (int y = 0; y < h; y++) {
-			memcpy(writePtr + rowPitch * y, (const uint8_t *)pixelData + decPitch * y, rowBytes);
 		}
 	}
 }

--- a/GPU/Vulkan/TextureScalerVulkan.cpp
+++ b/GPU/Vulkan/TextureScalerVulkan.cpp
@@ -44,39 +44,6 @@ u32 TextureScalerVulkan::Get8888Format() {
 	return VULKAN_8888_FORMAT;
 }
 
-void TextureScalerVulkan::ScaleAlways(u32 *&data, u32 &dstFmt, int &width, int &height, int factor) {
-	if (!Scale(data, dstFmt, width, height, factor)) {
-		// This means it was a flat texture.  Vulkan wants the size up front, so we need to make it happen.
-		assert(IsEmptyOrFlat(data, width * height, dstFmt));
-
-		u32 pixel;
-		// Since it's flat, one pixel is enough.  It might end up pointing to data, though.
-		u32 *pixelPointer = &pixel;
-		ConvertTo8888(dstFmt, data, pixelPointer, 1, 1);
-		if (pixelPointer != &pixel) {
-			pixel = *pixelPointer;
-		}
-
-		bufOutput.resize(width * height * factor * factor);
-		dstFmt = Get8888Format();
-		data = bufOutput.data();
-		width *= factor;
-		height *= factor;
-
-		// ABCD.  If A = D, and AB = CD, then they must all be equal (B = C, etc.)
-		if ((pixel & 0x000000FF) == (pixel >> 24) && (pixel & 0x0000FFFF) == (pixel >> 16)) {
-			memset(data, pixel & 0xFF, width * height * sizeof(u32));
-		} else {
-			// TODO: Optimize.
-			for (int y = 0; y < height; ++y) {
-				for (int x = 0; x < width; ++x) {
-					data[y * width + x] = pixel;
-				}
-			}
-		}
-	}
-}
-
 void TextureScalerVulkan::ConvertTo8888(u32 format, u32* source, u32* &dest, int width, int height) {
 	switch (format) {
 	case VULKAN_8888_FORMAT:

--- a/GPU/Vulkan/TextureScalerVulkan.h
+++ b/GPU/Vulkan/TextureScalerVulkan.h
@@ -21,9 +21,6 @@
 #include "GPU/Common/TextureScalerCommon.h"
 
 class TextureScalerVulkan : public TextureScaler {
-public:
-	void ScaleAlways(u32* &data, u32 &dstFmt, int &width, int &height, int factor);
-
 protected:
 	void ConvertTo8888(u32 format, u32* source, u32* &dest, int width, int height) override;
 	int BytesPerPixel(u32 format) override;


### PR DESCRIPTION
In Direct3D 9, we get a buffer to fill just like Vulkan - so it's easy to decode directly into it, just like Vulkan.  This seems to improve texture decode speed by 8%, give or take.

Additionally, it's a small improvement, but this also scales directly into the buffer, avoiding memcpy, in most cases (typically the width will be aligned.)

-[Unknown]
