### PR TITLE
Show a confirmation screen after feedback submit

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -80,7 +80,7 @@ namespace Reporting
 	static int payloadBufferPos = 0;
 
 	// Returns the full host (e.g. report.ppsspp.org:80.)
-	inline std::string ServerHost()
+	std::string ServerHost()
 	{
 		if (g_Config.sReportHost.compare("default") == 0)
 			return "";
@@ -257,10 +257,17 @@ namespace Reporting
 		return logOnceUsed.insert(identifier).second;
 	}
 
-	void AddGameInfo(UrlEncoder &postdata)
+	std::string CurrentGameID()
 	{
 		// TODO: Maybe ParamSFOData shouldn't include nulls in std::strings?  Don't work to break savedata, though...
-		postdata.Add("game", StripTrailingNull(g_paramSFO.GetValueString("DISC_ID")) + "_" + StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION")));
+		const std::string disc_id = StripTrailingNull(g_paramSFO.GetValueString("DISC_ID"));
+		const std::string disc_version = StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION"));
+		return disc_id + "_" + disc_version;
+	}
+
+	void AddGameInfo(UrlEncoder &postdata)
+	{
+		postdata.Add("game", CurrentGameID());
 		postdata.Add("game_title", StripTrailingNull(g_paramSFO.GetValueString("TITLE")));
 		postdata.Add("sdkver", sceKernelGetCompiledSdkVersion());
 	}

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -74,4 +74,10 @@ namespace Reporting
 
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogOnce(const char *identifier);
+
+	// Return the currently active host (or blank if not active.)
+	std::string ServerHost();
+
+	// Return the current game id.
+	std::string CurrentGameID();
 }

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -283,10 +283,49 @@ EventReturn ReportScreen::HandleSubmit(EventParams &e) {
 	std::string filename = includeScreenshot_ ? screenshotFilename_ : "";
 	Reporting::ReportCompatibility(compat, graphics_ + 1, speed_ + 1, gameplay_ + 1, filename);
 	screenManager()->finishDialog(this, DR_OK);
+	screenManager()->push(new ReportFinishScreen(gamePath_));
 	return EVENT_DONE;
 }
 
 EventReturn ReportScreen::HandleBrowser(EventParams &e) {
-	LaunchBrowser("http://report.ppsspp.org/");
+	const std::string url = "http://" + Reporting::ServerHost() + "/";
+	LaunchBrowser(url.c_str());
+	return EVENT_DONE;
+}
+
+ReportFinishScreen::ReportFinishScreen(const std::string &gamePath)
+	: UIScreenWithGameBackground(gamePath) {
+}
+
+void ReportFinishScreen::CreateViews() {
+	I18NCategory *rp = GetI18NCategory("Reporting");
+	I18NCategory *di = GetI18NCategory("Dialog");
+
+	Margins actionMenuMargins(0, 20, 15, 0);
+	Margins contentMargins(0, 20, 5, 5);
+	ViewGroup *leftColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 0.4f, contentMargins));
+	LinearLayout *leftColumnItems = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(WRAP_CONTENT, FILL_PARENT));
+	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
+	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
+
+	leftColumnItems->Add(new TextView(rp->T("FeedbackThanks", "Thanks for your feedback."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+
+	rightColumnItems->SetSpacing(0.0f);
+	rightColumnItems->Add(new Choice(rp->T("View Feedback")))->OnClick.Handle(this, &ReportFinishScreen::HandleViewFeedback);
+
+	rightColumnItems->Add(new Spacer(25.0));
+	rightColumnItems->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+
+	root_ = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
+	root_->Add(leftColumn);
+	root_->Add(rightColumn);
+
+	leftColumn->Add(leftColumnItems);
+	rightColumn->Add(rightColumnItems);
+}
+
+UI::EventReturn ReportFinishScreen::HandleViewFeedback(UI::EventParams &e) {
+	const std::string url = "http://" + Reporting::ServerHost() + "/game/" + Reporting::CurrentGameID();
+	LaunchBrowser(url.c_str());
 	return EVENT_DONE;
 }

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -49,3 +49,13 @@ protected:
 	bool ratingEnabled_;
 	bool includeScreenshot_;
 };
+
+class ReportFinishScreen : public UIScreenWithGameBackground {
+public:
+	ReportFinishScreen(const std::string &gamePath);
+
+protected:
+	void CreateViews() override;
+
+	UI::EventReturn HandleViewFeedback(UI::EventParams &e);
+};


### PR DESCRIPTION
Two purposes:
1. Some people are reporting feedback multiple times, clearly.  Maybe they just want to spam, but it's also possible they're not sure they submitted correctly.
2. This provides an initial way the user can see other people's feedback, e.g. potentially letting them know that the game is playable for other users or etc.

-[Unknown]
