### PR TITLE
Prevent buffer overrun from OSK dialog

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -161,12 +161,13 @@ void PSPOskDialog::ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16_
 		return;
 	}
 
-	char stringBuffer[2048];
+	const size_t maxLength = 2047;
+	char stringBuffer[maxLength + 1];
 	char *string = stringBuffer;
 
-	auto input = em_address;
+	u16_le *input = &em_address[0];
 	int c;
-	while ((c = *input++) != 0)
+	while ((c = *input++) != 0 && string < stringBuffer + maxLength)
 	{
 		if (c < 0x80)
 			*string++ = c;
@@ -190,21 +191,15 @@ void GetWideStringFromPSPPointer(std::wstring& _string, const PSPPointer<u16_le>
 		_string = L"";
 		return;
 	}
-	const size_t maxLength = 2048;
 
-	wchar_t stringBuffer[maxLength];
+	const size_t maxLength = 2047;
+	wchar_t stringBuffer[maxLength + 1];
 	wchar_t *string = stringBuffer;
 
-	auto input = em_address;
+	u16_le *input = &em_address[0];
 	int c;
-	u32 count = 0;
-	while ((c = *input++) != 0)
-	{
-		if ( !(++count >= maxLength) )
-			*string++ = c;
-		else
-			break;
-	}
+	while ((c = *input++) != 0 && string < stringBuffer + maxLength)
+		*string++ = c;
 	*string++ = '\0';
 	_string = stringBuffer;
 }


### PR DESCRIPTION
If there was never a null, by mistake, we'd corrupt memory and then crash.

Occurs in the "Sonymon" homebrew.  Also, yay, utf-16 support in GitHub diffs.

-[Unknown]
