### PR TITLE
Consistently resolve PBP paths, use /s in recent

### DIFF
--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -54,6 +54,11 @@ DiskCachingFileLoader::~DiskCachingFileLoader() {
 }
 
 bool DiskCachingFileLoader::Exists() {
+	if (cache_->HasData()) {
+		// It may require a slow operation to check - if we have data, let's say yes.
+		// This helps initial load, since we check each recent file for existence.
+		return true;
+	}
 	return backend_->Exists();
 }
 
@@ -716,6 +721,19 @@ void DiskCachingFileLoaderCache::CloseFileHandle() {
 	}
 	f_ = nullptr;
 	fd_ = 0;
+}
+
+bool DiskCachingFileLoaderCache::HasData() const {
+	if (!f_) {
+		return false;
+	}
+
+	for (size_t i = 0; i < blockIndexLookup_.size(); ++i) {
+		if (blockIndexLookup_[i] != INVALID_INDEX) {
+			return true;
+		}
+	}
+	return false;
 }
 
 u64 DiskCachingFileLoaderCache::FreeDiskSpace() {

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -89,6 +89,8 @@ public:
 	// Guaranteed to read at least one block into the cache.
 	size_t SaveIntoCache(FileLoader *backend, s64 pos, size_t bytes, void *data);
 
+	bool HasData() const;
+
 private:
 	void InitCache(const std::string &path);
 	void ShutdownCache();

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -82,8 +82,9 @@ FileLoader *ConstructFileLoader(const std::string &filename);
 // Resolve to the target binary, ISO, or other file (e.g. from a directory.)
 FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader);
 
-// This can modify the string, for example for stripping off the "/EBOOT.PBP"
-// for a FILETYPE_PSP_PBP_DIRECTORY.
+std::string ResolvePBPDirectory(const std::string &filename);
+std::string ResolvePBPFile(const std::string &filename);
+
 IdentifiedFileType Identify_File(FileLoader *fileLoader);
 
 // Can modify the string filename, as it calls IdentifyFile above.

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -829,11 +829,11 @@ namespace MainWindow
 				else
 				{
 					TCHAR filename[512];
-					DragQueryFile(hdrop,0,filename,512);
-					TCHAR *type = filename+_tcslen(filename)-3;
-					
-					NativeMessageReceived("boot", ConvertWStringToUTF8(filename).c_str());
-					Core_EnableStepping(false);
+					if (DragQueryFile(hdrop, 0, filename, 512) != 0) {
+						const std::string utf8_filename = ReplaceAll(ConvertWStringToUTF8(filename), "\\", "/");
+						NativeMessageReceived("boot", utf8_filename.c_str());
+						Core_EnableStepping(false);
+					}
 				}
 			}
 			break;


### PR DESCRIPTION
Drag and drop was using \s causing duplicate recent entries and confusing some of the PBP parsing.  Let's make it all a bit safer.

Found while testing some homebrew.  This makes dragging EBOOT.PBP into PPSSPP work correctly.  Also, it held onto the file handler on error (would eventually free), which was annoying since it locked the file.

Also, made a small change for HTTP disk cached streams - say they exist without checking when we have something cached already.  This improves initial app load time when you have many such streams, since they are synchronously checked for existence.

-[Unknown]
