### PR TITLE
Add reporting for sceKernelDevkitVersion() calls

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -306,7 +306,8 @@ u32 sceKernelDevkitVersion()
 	int minor = (firmwareVersion / 10) % 10;
 	int revision = firmwareVersion % 10;
 	int devkitVersion = (major << 24) | (minor << 16) | (revision << 8) | 0x10;
-	DEBUG_LOG(SCEKERNEL, "sceKernelDevkitVersion (%i) ", devkitVersion);
+
+	DEBUG_LOG_REPORT_ONCE(devkitVer, SCEKERNEL, "%08x=sceKernelDevkitVersion()", devkitVersion);
 	return devkitVersion;
 }
 


### PR DESCRIPTION
We currently default to 1.50 as the reported version, but we more or less emulate a 6.60 system.

I think it may be better to return 6.60 by default, but let's see what would actually be impacted by that first.

Note: at least one homebrew checks this and fails intentionally if it's below 2.xx or so.  I don't remember which now, and I think it crashed anyway even after increasing this.

-[Unknown]
