### PR TITLE
Send disc CRC with compatibility reports

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -458,7 +458,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("HighQualityDepth", &g_Config.bHighQualityDepth, true, true, true),
 	ReportedConfigSetting("FrameSkip", &g_Config.iFrameSkip, 0, true, true),
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false, true, true),
-	ReportedConfigSetting("FrameRate", &g_Config.iFpsLimit, 0, true, true),
+	ConfigSetting("FrameRate", &g_Config.iFpsLimit, 0, true, true),
 #ifdef _WIN32
 	ConfigSetting("FrameSkipUnthrottle", &g_Config.bFrameSkipUnthrottle, false, true, true),
 	ConfigSetting("RestartRequired", &g_Config.bRestartRequired, false, false),

--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -25,25 +25,25 @@
 class CachingFileLoader : public FileLoader {
 public:
 	CachingFileLoader(FileLoader *backend);
-	virtual ~CachingFileLoader() override;
+	~CachingFileLoader() override;
 
-	virtual bool Exists() override;
-	virtual bool ExistsFast() override;
-	virtual bool IsDirectory() override;
-	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
+	bool Exists() override;
+	bool ExistsFast() override;
+	bool IsDirectory() override;
+	s64 FileSize() override;
+	std::string Path() const override;
 
-	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override {
-		return ReadAt(filepos_, bytes, count, data);
+	void Seek(s64 absolutePos) override;
+	size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, count, data, flags);
 	}
-	virtual size_t Read(size_t bytes, void *data) override {
-		return ReadAt(filepos_, bytes, data);
+	size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, data, flags);
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override {
-		return ReadAt(absolutePos, bytes * count, data) / bytes;
+	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
+	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 private:
 	void Prepare();
@@ -51,7 +51,7 @@ private:
 	void ShutdownCache();
 	size_t ReadFromCache(s64 pos, size_t bytes, void *data);
 	// Guaranteed to read at least one block into the cache.
-	void SaveIntoCache(s64 pos, size_t bytes, bool readingAhead = false);
+	void SaveIntoCache(s64 pos, size_t bytes, Flags flags, bool readingAhead = false);
 	bool MakeCacheSpaceFor(size_t blocks, bool readingAhead);
 	void StartReadAhead(s64 pos);
 

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -28,25 +28,25 @@ class DiskCachingFileLoaderCache;
 class DiskCachingFileLoader : public FileLoader {
 public:
 	DiskCachingFileLoader(FileLoader *backend);
-	virtual ~DiskCachingFileLoader() override;
+	~DiskCachingFileLoader() override;
 
-	virtual bool Exists() override;
-	virtual bool ExistsFast() override;
-	virtual bool IsDirectory() override;
-	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
+	bool Exists() override;
+	bool ExistsFast() override;
+	bool IsDirectory() override;
+	s64 FileSize() override;
+	std::string Path() const override;
 
-	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override {
-		return ReadAt(filepos_, bytes, count, data);
+	void Seek(s64 absolutePos) override;
+	size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, count, data, flags);
 	}
-	virtual size_t Read(size_t bytes, void *data) override {
-		return ReadAt(filepos_, bytes, data);
+	size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, data, flags);
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override {
-		return ReadAt(absolutePos, bytes * count, data) / bytes;
+	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
+	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 	static std::vector<std::string> GetCachedPathsInUse();
 
@@ -90,7 +90,7 @@ public:
 
 	size_t ReadFromCache(s64 pos, size_t bytes, void *data);
 	// Guaranteed to read at least one block into the cache.
-	size_t SaveIntoCache(FileLoader *backend, s64 pos, size_t bytes, void *data);
+	size_t SaveIntoCache(FileLoader *backend, s64 pos, size_t bytes, void *data, FileLoader::Flags flags);
 
 	bool HasData() const;
 

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -123,7 +123,7 @@ void HTTPFileLoader::Seek(s64 absolutePos) {
 	filepos_ = absolutePos;
 }
 
-size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
+size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags) {
 	Prepare();
 	s64 absoluteEnd = std::min(absolutePos + (s64)bytes, filesize_);
 	if (absolutePos >= filesize_ || bytes == 0) {

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -35,16 +35,16 @@ public:
 	virtual std::string Path() const override;
 
 	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override {
-		return ReadAt(filepos_, bytes, count, data);
+	virtual size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, count, data, flags);
 	}
-	virtual size_t Read(size_t bytes, void *data) override {
-		return ReadAt(filepos_, bytes, data);
+	virtual size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, data, flags);
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override {
-		return ReadAt(absolutePos, bytes * count, data) / bytes;
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 private:
 	void Prepare();

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -81,7 +81,7 @@ void LocalFileLoader::Seek(s64 absolutePos) {
 #endif
 }
 
-size_t LocalFileLoader::Read(size_t bytes, size_t count, void *data) {
+size_t LocalFileLoader::Read(size_t bytes, size_t count, void *data, Flags flags) {
 #ifdef ANDROID
 	return read(fd_, data, bytes * count) / bytes;
 #else
@@ -89,7 +89,7 @@ size_t LocalFileLoader::Read(size_t bytes, size_t count, void *data) {
 #endif
 }
 
-size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) {
+size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags) {
 	Seek(absolutePos);
 	return Read(bytes, count, data);
 }

--- a/Core/FileLoaders/LocalFileLoader.h
+++ b/Core/FileLoaders/LocalFileLoader.h
@@ -31,8 +31,8 @@ public:
 	virtual std::string Path() const override;
 
 	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override;
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override;
+	virtual size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
 
 private:
 	// First only used by Android, but we can keep it here for everyone.

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -34,23 +34,23 @@ public:
 	std::string Path() const override;
 
 	void Seek(s64 absolutePos) override;
-	size_t Read(size_t bytes, size_t count, void *data) override {
-		return ReadAt(filepos_, bytes, count, data);
+	size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, count, data, flags);
 	}
-	size_t Read(size_t bytes, void *data) override {
-		return ReadAt(filepos_, bytes, data);
+	size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, data, flags);
 	}
-	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override {
-		return ReadAt(absolutePos, bytes * count, data) / bytes;
+	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
-	size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
+	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 private:
 	void InitCache();
 	void ShutdownCache();
 	size_t ReadFromCache(s64 pos, size_t bytes, void *data);
 	// Guaranteed to read at least one block into the cache.
-	void SaveIntoCache(s64 pos, size_t bytes);
+	void SaveIntoCache(s64 pos, size_t bytes, Flags flags);
 	void StartReadAhead(s64 pos);
 	u32 NextAheadBlock();
 

--- a/Core/FileLoaders/RetryingFileLoader.cpp
+++ b/Core/FileLoaders/RetryingFileLoader.cpp
@@ -64,13 +64,13 @@ void RetryingFileLoader::Seek(s64 absolutePos) {
 	filepos_ = absolutePos;
 }
 
-size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
-	size_t readSize = backend_->ReadAt(absolutePos, bytes, data);
+size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags) {
+	size_t readSize = backend_->ReadAt(absolutePos, bytes, data, flags);
 
 	int retries = 0;
 	while (readSize < bytes && retries < MAX_RETRIES) {
 		u8 *p = (u8 *)data;
-		readSize += backend_->ReadAt(absolutePos + readSize, bytes - readSize, p + readSize);
+		readSize += backend_->ReadAt(absolutePos + readSize, bytes - readSize, p + readSize, flags);
 		++retries;
 	}
 

--- a/Core/FileLoaders/RetryingFileLoader.h
+++ b/Core/FileLoaders/RetryingFileLoader.h
@@ -23,25 +23,25 @@
 class RetryingFileLoader : public FileLoader {
 public:
 	RetryingFileLoader(FileLoader *backend);
-	virtual ~RetryingFileLoader() override;
+	~RetryingFileLoader() override;
 
-	virtual bool Exists() override;
-	virtual bool ExistsFast() override;
-	virtual bool IsDirectory() override;
-	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
+	bool Exists() override;
+	bool ExistsFast() override;
+	bool IsDirectory() override;
+	s64 FileSize() override;
+	std::string Path() const override;
 
-	virtual void Seek(s64 absolutePos) override;
-	virtual size_t Read(size_t bytes, size_t count, void *data) override {
-		return ReadAt(filepos_, bytes, count, data);
+	void Seek(s64 absolutePos) override;
+	size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, count, data, flags);
 	}
-	virtual size_t Read(size_t bytes, void *data) override {
-		return ReadAt(filepos_, bytes, data);
+	size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(filepos_, bytes, data, flags);
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) override {
-		return ReadAt(absolutePos, bytes * count, data) / bytes;
+	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
+		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
+	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 private:
 	enum {

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -45,6 +45,21 @@ BlockDevice *constructBlockDevice(FileLoader *fileLoader) {
 		return new FileBlockDevice(fileLoader);
 }
 
+u32 BlockDevice::CalculateCRC() {
+	u32 crc = crc32(0, Z_NULL, 0);
+
+	u8 block[2048];
+	for (u32 i = 0; i < GetNumBlocks(); ++i) {
+		if (!ReadBlock(i, block, true)) {
+			ERROR_LOG(HLE, "Failed to read block for CRC");
+			return 0;
+		}
+		crc = crc32(crc, block, 2048);
+	}
+
+	return crc;
+}
+
 
 FileBlockDevice::FileBlockDevice(FileLoader *fileLoader)
 	: fileLoader_(fileLoader) {

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -54,8 +54,9 @@ FileBlockDevice::FileBlockDevice(FileLoader *fileLoader)
 FileBlockDevice::~FileBlockDevice() {
 }
 
-bool FileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr) {
-	if (fileLoader_->ReadAt((u64)blockNumber * (u64)GetBlockSize(), 1, 2048, outPtr) != 2048) {
+bool FileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr, bool uncached) {
+	FileLoader::Flags flags = uncached ? FileLoader::Flags::HINT_UNCACHED : FileLoader::Flags::NONE;
+	if (fileLoader_->ReadAt((u64)blockNumber * (u64)GetBlockSize(), 1, 2048, outPtr, flags) != 2048) {
 		DEBUG_LOG(FILESYS, "Could not read 2048 bytes from block");
 		return false;
 	}
@@ -178,8 +179,9 @@ CISOFileBlockDevice::~CISOFileBlockDevice()
 	delete [] zlibBuffer;
 }
 
-bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr) 
+bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr, bool uncached)
 {
+	FileLoader::Flags flags = uncached ? FileLoader::Flags::HINT_UNCACHED : FileLoader::Flags::NONE;
 	if ((u32)blockNumber >= numBlocks)
 	{
 		memset(outPtr, 0, GetBlockSize());
@@ -200,7 +202,7 @@ bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 	const int plain = idx & 0x80000000;
 	if (plain)
 	{
-		int readSize = (u32)fileLoader_->ReadAt(compressedReadPos + compressedOffset, 1, GetBlockSize(), outPtr);
+		int readSize = (u32)fileLoader_->ReadAt(compressedReadPos + compressedOffset, 1, GetBlockSize(), outPtr, flags);
 		if (readSize < GetBlockSize())
 			memset(outPtr + readSize, 0, GetBlockSize() - readSize);
 	}
@@ -211,7 +213,7 @@ bool CISOFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 	}
 	else
 	{
-		const u32 readSize = (u32)fileLoader_->ReadAt(compressedReadPos, 1, compressedReadSize, readBuffer);
+		const u32 readSize = (u32)fileLoader_->ReadAt(compressedReadPos, 1, compressedReadSize, readBuffer, flags);
 
 		z.zalloc = Z_NULL;
 		z.zfree = Z_NULL;
@@ -423,8 +425,9 @@ NPDRMDemoBlockDevice::~NPDRMDemoBlockDevice()
 
 int lzrc_decompress(void *out, int out_len, void *in, int in_len);
 
-bool NPDRMDemoBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
+bool NPDRMDemoBlockDevice::ReadBlock(int blockNumber, u8 *outPtr, bool uncached)
 {
+	FileLoader::Flags flags = uncached ? FileLoader::Flags::HINT_UNCACHED : FileLoader::Flags::NONE;
 	lock_guard guard(mutex_);
 	CIPHER_KEY ckey;
 	int block, lba, lzsize;
@@ -453,7 +456,7 @@ bool NPDRMDemoBlockDevice::ReadBlock(int blockNumber, u8 *outPtr)
 	else
 		readBuf = blockBuf;
 
-	readSize = fileLoader_->ReadAt(psarOffset+table[block].offset, 1, table[block].size, readBuf);
+	readSize = fileLoader_->ReadAt(psarOffset+table[block].offset, 1, table[block].size, readBuf, flags);
 	if(readSize != (size_t)table[block].size){
 		if((u32)block==(numBlocks-1))
 			return true;

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -45,6 +45,8 @@ public:
 	}
 	int GetBlockSize() const { return 2048;}  // forced, it cannot be changed by subclasses
 	virtual u32 GetNumBlocks() = 0;
+
+	u32 CalculateCRC();
 };
 
 

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -33,7 +33,7 @@ class BlockDevice
 {
 public:
 	virtual ~BlockDevice() {}
-	virtual bool ReadBlock(int blockNumber, u8 *outPtr) = 0;
+	virtual bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) = 0;
 	virtual bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
 		for (int b = 0; b < count; ++b) {
 			if (!ReadBlock(minBlock + b, outPtr)) {
@@ -53,7 +53,7 @@ class CISOFileBlockDevice : public BlockDevice
 public:
 	CISOFileBlockDevice(FileLoader *fileLoader);
 	~CISOFileBlockDevice();
-	bool ReadBlock(int blockNumber, u8 *outPtr) override;
+	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() override { return numBlocks; }
 
@@ -76,7 +76,7 @@ class FileBlockDevice : public BlockDevice
 public:
 	FileBlockDevice(FileLoader *fileLoader);
 	~FileBlockDevice();
-	bool ReadBlock(int blockNumber, u8 *outPtr) override;
+	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() override {return (u32)(filesize_ / GetBlockSize());}
 
@@ -102,7 +102,7 @@ public:
 	NPDRMDemoBlockDevice(FileLoader *fileLoader);
 	~NPDRMDemoBlockDevice();
 
-	bool ReadBlock(int blockNumber, u8 *outPtr) override;
+	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	u32 GetNumBlocks() override {return (u32)lbaSize;}
 
 private:

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -51,6 +51,12 @@ enum IdentifiedFileType {
 
 class FileLoader {
 public:
+	enum class Flags {
+		NONE,
+		// Not necessary to read from / store into cache.
+		HINT_UNCACHED,
+	};
+
 	virtual ~FileLoader() {}
 
 	virtual bool Exists() = 0;
@@ -71,15 +77,19 @@ public:
 	}
 
 	virtual void Seek(s64 absolutePos) = 0;
-	virtual size_t Read(size_t bytes, size_t count, void *data) = 0;
-	virtual size_t Read(size_t bytes, void *data) {
-		return Read(1, bytes, data);
+	virtual size_t Read(size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) = 0;
+	virtual size_t Read(size_t bytes, void *data, Flags flags = Flags::NONE) {
+		return Read(1, bytes, data, flags);
 	}
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data) = 0;
-	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) {
-		return ReadAt(absolutePos, 1, bytes, data);
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) = 0;
+	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) {
+		return ReadAt(absolutePos, 1, bytes, data, flags);
 	}
 };
+
+inline u32 operator & (const FileLoader::Flags &a, const FileLoader::Flags &b) {
+	return (u32)a & (u32)b;
+}
 
 FileLoader *ConstructFileLoader(const std::string &filename);
 // Resolve to the target binary, ISO, or other file (e.g. from a directory.)

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -415,6 +415,7 @@ namespace Reporting
 			payload.string2.clear();
 
 			postdata.Finish();
+			serverWorking = true;
 			if (!SendReportRequest("/report/message", postdata.ToString(), postdata.GetMimeType()))
 				serverWorking = false;
 			break;
@@ -432,6 +433,7 @@ namespace Reporting
 			payload.string2.clear();
 
 			postdata.Finish();
+			serverWorking = true;
 			if (!SendReportRequest("/report/compat", postdata.ToString(), postdata.GetMimeType(), &output)) {
 				serverWorking = false;
 			} else {

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -70,7 +70,7 @@ namespace Reporting
 	void ReportMessageFormatted(const char *message, const char *formatted);
 
 	// Report the compatibility of the current game / configuration.
-	void ReportCompatibility(const char *compat, int graphics, int speed, int gameplay, std::string screenshotFilename);
+	void ReportCompatibility(const char *compat, int graphics, int speed, int gameplay, const std::string &screenshotFilename);
 
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogOnce(const char *identifier);

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#pragma once
+
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
 #include <string>
@@ -74,6 +76,15 @@ namespace Reporting
 
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogOnce(const char *identifier);
+
+	enum class Status {
+		WORKING,
+		BUSY,
+		FAILING,
+	};
+
+	// Whether server requests appear to be working.
+	Status GetStatus();
 
 	// Return the currently active host (or blank if not active.)
 	std::string ServerHost();

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -309,6 +309,7 @@ void ReportFinishScreen::CreateViews() {
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
 
 	leftColumnItems->Add(new TextView(rp->T("FeedbackThanks", "Thanks for your feedback."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+	leftColumnItems->Add(new TextView(rp->T("FeedbackDelayInfo", "Your data is being submitted in the background."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 
 	rightColumnItems->SetSpacing(0.0f);
 	rightColumnItems->Add(new Choice(rp->T("View Feedback")))->OnClick.Handle(this, &ReportFinishScreen::HandleViewFeedback);

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -223,6 +223,10 @@ void ReportScreen::CreateViews() {
 		reportingNotice_ = nullptr;
 	}
 
+#ifdef MOBILE_DEVICE
+	leftColumnItems->Add(new TextView(rp->T("FeedbackIncludeCRC", "Note: Battery will be used to send a disc CRC"), new LinearLayoutParams(Margins(12, 5, 0, 5))))->SetEnabledPtr(&enableReporting_);
+#endif
+
 	std::string path = GetSysDirectory(DIRECTORY_SCREENSHOT);
 	if (!File::Exists(path)) {
 		File::CreateDir(path);

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -294,7 +294,7 @@ EventReturn ReportScreen::HandleBrowser(EventParams &e) {
 }
 
 ReportFinishScreen::ReportFinishScreen(const std::string &gamePath)
-	: UIScreenWithGameBackground(gamePath) {
+	: UIScreenWithGameBackground(gamePath), resultNotice_(nullptr), setStatus_(false) {
 }
 
 void ReportFinishScreen::CreateViews() {
@@ -309,7 +309,7 @@ void ReportFinishScreen::CreateViews() {
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
 
 	leftColumnItems->Add(new TextView(rp->T("FeedbackThanks", "Thanks for your feedback."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
-	leftColumnItems->Add(new TextView(rp->T("FeedbackDelayInfo", "Your data is being submitted in the background."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+	resultNotice_ = leftColumnItems->Add(new TextView(rp->T("FeedbackDelayInfo", "Your data is being submitted in the background."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 
 	rightColumnItems->SetSpacing(0.0f);
 	rightColumnItems->Add(new Choice(rp->T("View Feedback")))->OnClick.Handle(this, &ReportFinishScreen::HandleViewFeedback);
@@ -323,6 +323,30 @@ void ReportFinishScreen::CreateViews() {
 
 	leftColumn->Add(leftColumnItems);
 	rightColumn->Add(rightColumnItems);
+}
+
+void ReportFinishScreen::update(InputState &input) {
+	I18NCategory *rp = GetI18NCategory("Reporting");
+
+	if (!setStatus_) {
+		Reporting::Status status = Reporting::GetStatus();
+		switch (status) {
+		case Reporting::Status::WORKING:
+			resultNotice_->SetText(rp->T("FeedbackSubmitDone", "Your data has been submitted."));
+			break;
+
+		case Reporting::Status::FAILING:
+			resultNotice_->SetText(rp->T("FeedbackSubmitFail", "Could not submit data to server.  Try updating PPSSPP."));
+			break;
+
+		case Reporting::Status::BUSY:
+		default:
+			// Can't update yet.
+			break;
+		}
+	}
+
+	UIScreenWithGameBackground::update(input);
 }
 
 UI::EventReturn ReportFinishScreen::HandleViewFeedback(UI::EventParams &e) {

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -55,7 +55,11 @@ public:
 	ReportFinishScreen(const std::string &gamePath);
 
 protected:
+	void update(InputState &input) override;
 	void CreateViews() override;
 
 	UI::EventReturn HandleViewFeedback(UI::EventParams &e);
+
+	UI::TextView *resultNotice_;
+	bool setStatus_;
 };


### PR DESCRIPTION
From published sequential read statistics, it looks like the vast majority of Android devices will be able to do a full read of any UMD-size ISO in <= 30 seconds (and the slowest devices, < 90s.)  This performs that operation on a background thread.

For the disk and memory caches (i.e. HTTP), it'll be slower, but I added a flag to avoid letting it throw away good cache data.

I do have a bit of a catch-22 here though.  Ideally I'd like to notify the user if their crc is bad.  Basically, I see people reporting games I have and know work (and also games marked as Perfect by others on the same devices) as "Doesn't boot", which either means they're submitting garbage, have some horribly bad settings, or have a corrupted ISO.

Perhaps if they submit poor feedback (e.g. < ingame, or <= ingame?), we could make them wait for the submission to complete, and then show some result?  Alternatively, it could start CRCing as soon as they open the report screen, and interrupt them on that screen with the results.  Not sure.  Neither option sounds great.

Any result could also contain recommended settings changes based on other, better reports.

Note that this also allows differentiating things like fan translations, which typically don't change the game id.

-[Unknown]
