### PR TITLE
Allow C++ to determine use of JavaGL

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -230,6 +230,13 @@ std::string NativeQueryConfig(std::string query) {
 		return std::string(temp);
 	} else if (query == "force44khz") {
 		return std::string("0");
+	} else if (query == "androidJavaGL") {
+		// If we're using Vulkan, we say no... need C++ to use Vulkan.
+		if (GetGPUBackend() == GPUBackend::VULKAN) {
+			return "false";
+		}
+		// Otherwise, some devices prefer the Java init so play it safe.
+		return "true";
 	} else {
 		return "";
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -343,6 +343,7 @@ InputState input_state;
 
 static bool renderer_inited = false;
 static bool first_lost = true;
+// See NativeQueryConfig("androidJavaGL") to change this value.
 static bool javaGL = true;
 
 static std::string library_path;
@@ -477,9 +478,8 @@ extern "C" jstring Java_org_ppsspp_ppsspp_NativeApp_queryConfig
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
   (JNIEnv *env, jclass, jstring jmodel, jint jdeviceType, jstring jlangRegion, jstring japkpath,
 		jstring jdataDir, jstring jexternalDir, jstring jlibraryDir, jstring jcacheDir, jstring jshortcutParam,
-		jint jAndroidVersion, jstring jboard, jboolean jjavaGL) {
+		jint jAndroidVersion, jstring jboard) {
 	jniEnvUI = env;
-	javaGL = jjavaGL;
 	setCurrentThreadName("androidInit");
 
 	ILOG("NativeApp.init() -- begin");
@@ -543,6 +543,9 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 		const char *argv[3] = {app_name.c_str(), shortcut_param.c_str(), 0};
 		NativeInit(2, argv, user_data_path.c_str(), externalDir.c_str(), cacheDir.c_str());
 	}
+
+	// Now that we've loaded config, set javaGL.
+	javaGL = NativeQueryConfig("androidJavaGL") == "true";
 
 	ILOG("NativeApp.init() -- end");
 }

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -60,7 +60,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	// Allows us to skip a lot of initialization on secondary calls to onCreate.
 	private static boolean initialized = false;
 
-	// Change this to false to switch to C++ EGL.
+	// False to use C++ EGL, queried from C++ after NativeApp.init.
 	private static boolean javaGL = true;
 
 	// Graphics and audio interfaces for EGL (javaGL = false)
@@ -266,7 +266,10 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		String languageRegion = Locale.getDefault().getLanguage() + "_" + Locale.getDefault().getCountry();
 
 		NativeApp.audioConfig(optimalFramesPerBuffer, optimalSampleRate);
-		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT, Build.BOARD, javaGL);
+		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT, Build.BOARD);
+
+		// Allow C++ to tell us to use JavaGL or not.
+		javaGL = NativeApp.queryConfig("androidJavaGL") == "true";
 
 		sendInitialGrants();
 

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -13,7 +13,7 @@ public class NativeApp {
 	public final static int DEVICE_TYPE_TV = 1;
 	public final static int DEVICE_TYPE_DESKTOP = 2;
 
-	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion, String board, boolean javaGL);
+	public static native void init(String model, int deviceType, String languageRegion, String apkPath, String dataDir, String externalDir, String libraryDir, String cacheDir, String shortcutParam, int androidVersion, String board);
 	public static native void audioInit();
 	public static native void audioShutdown();
 	public static native void audioConfig(int optimalFramesPerBuffer, int optimalSampleRate);


### PR DESCRIPTION
This way, if we enable/fix Vulkan, it can still be an option while the C++ EGL init issues with some devices are investigated.

It's a shame to have two paths, but since we already have two, we might as well use them appropriately.

Note: Vulkan not working still, so tested this by hardcoding to "false" to make sure both paths are functional.

-[Unknown]
