### PR TITLE
Add an editorconfig to keep formatting consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+end_of_line = lf
+
+[Core/Dialog/PSPOskDialog.cpp]
+charset = utf-16le
+
+[Windows/version.rc]
+charset = utf-16le


### PR DESCRIPTION
This may help to reduce indentation / etc. issues, depending on what editor people use.

Visual Studio doesn't support by default, but there's an extension:
https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328

GitHub and a few editors also have native support.

-[Unknown]
