### PR TITLE
Add initial breakpoint support for IR

### DIFF
--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -221,7 +221,7 @@ MIPSOpcode IRFrontend::GetOffsetInstruction(int offset) {
 	return Memory::Read_Instruction(GetCompilerPC() + 4 * offset);
 }
 
-void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants) {
+void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants, u32 &mipsBytes) {
 	js.cancel = false;
 	js.blockStart = em_address;
 	js.compilerPC = em_address;
@@ -253,6 +253,8 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 			js.compiling = false;
 		}
 	}
+
+	mipsBytes = js.compilerPC - em_address;
 
 	IRWriter simplified;
 	IRWriter *code = &ir;

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -88,7 +88,7 @@ public:
 	void DoState(PointerWrap &p);
 	bool CheckRounding();  // returns true if we need a do-over
 
-	void DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants);
+	void DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants, u32 &mipsBytes);
 
 	void EatPrefix() override {
 		js.EatPrefix();

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -107,6 +107,8 @@ private:
 	void EatInstruction(MIPSOpcode op);
 	MIPSOpcode GetOffsetInstruction(int offset);
 
+	void CheckBreakpoint(u32 addr, int downcountOffset);
+
 	// Utility compilation functions
 	void BranchFPFlag(MIPSOpcode op, IRComparison cc, bool likely);
 	void BranchVFPUFlag(MIPSOpcode op, IRComparison cc, bool likely);

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -156,6 +156,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::SetPC, "SetPC", "_G" },
 	{ IROp::SetPCConst, "SetPC", "_C" },
 	{ IROp::CallReplacement, "CallRepl", "_C" },
+	{ IROp::Breakpoint, "Breakpoint", "" },
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -60,7 +60,7 @@ enum class IROp : u8 {
 	ShrImm,
 	SarImm,
 	RorImm,
-		
+
 	Slt,
 	SltConst,
 	SltU,
@@ -92,7 +92,7 @@ enum class IROp : u8 {
 	MsubU,
 	Div,
 	DivU,
-	
+
 	// These take a constant from the pool as an offset.
 	// Loads from a constant address can be represented by using r0.
 	Load8,
@@ -219,6 +219,7 @@ enum class IROp : u8 {
 	SetPCConst,  // hack to make replacement know PC
 	CallReplacement,
 	Break,
+	Breakpoint,
 };
 
 enum IRComparison {
@@ -315,7 +316,7 @@ enum IRFlags {
 struct IRMeta {
 	IROp op;
 	const char *name;
-	const char types[4];  // GGG  
+	const char types[4];  // GGG
 	u32 flags;
 };
 

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -20,23 +20,20 @@
 #include "Common/ChunkFile.h"
 #include "Common/StringUtils.h"
 
-#include "Core/Reporting.h"
-#include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
-#include "Core/Debugger/SymbolMap.h"
+#include "Core/HLE/sceKernelMemory.h"
 #include "Core/MemMap.h"
-
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/MIPS/MIPSInt.h"
 #include "Core/MIPS/MIPSTables.h"
-#include "Core/HLE/sceKernelMemory.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/MIPS/IR/IRJit.h"
 #include "Core/MIPS/IR/IRPassSimplify.h"
 #include "Core/MIPS/IR/IRInterpreter.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/Reporting.h"
 
 namespace MIPSComp {
 

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -100,6 +100,10 @@ public:
 	bool HasOriginalFirstOp();
 	bool RestoreOriginalFirstOp(int number);
 	bool IsValid() const { return origAddr_ != 0; }
+	void SetOriginalSize(u32 size) {
+		origSize_ = size;
+	}
+	bool OverlapsRange(u32 addr, u32 size);
 
 	void Finalize(int number);
 	void Destroy(int number);
@@ -110,13 +114,14 @@ private:
 	u16 numInstructions_;
 	u16 numConstants_;
 	u32 origAddr_;
+	u32 origSize_;
 	MIPSOpcode origFirstOpcode_;
 };
 
 class IRBlockCache {
 public:
 	void Clear();
-	void InvalidateICache(u32 addess, u32 length);
+	void InvalidateICache(u32 address, u32 length);
 	int GetNumBlocks() const { return (int)blocks_.size(); }
 	int AllocateBlock(int emAddr) {
 		blocks_.push_back(IRBlock(emAddr));

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -77,6 +77,7 @@ namespace MIPSComp {
 		int downcountAmount;
 		int numInstructions;
 		bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
+		bool hadBreakpoints;
 		JitBlock *curBlock;
 
 		u8 hasSetRounding;


### PR DESCRIPTION
This works essentially the same way as in x86's jit.  A few notes:
- No memory breakpoints yet.
- Reordering is suppressed if any breakpoints were considered in the block (this will be true for memory breakpoints too.)
- Initial (likely not optimal) icache invalidation was needed for this to be useful.
- Conditional breakpoints work.

I'm planning to try to implement memory breakpoints in a simpler way than in x86, hopefully.

-[Unknown]
