### PR TITLE
Add memory breakpoints to IR as well

### DIFF
--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -134,6 +134,7 @@ public:
 
 	static MemCheck *GetMemCheck(u32 address, int size);
 	static void ExecMemCheck(u32 address, bool write, int size, u32 pc);
+	static void ExecOpMemCheck(u32 address, u32 pc);
 
 	// Executes memchecks but used by the jit.  Cleanup finalizes after jit is done.
 	static void ExecMemCheckJitBefore(u32 address, bool write, int size, u32 pc);
@@ -147,6 +148,8 @@ public:
 
 	static const std::vector<MemCheck> GetMemChecks();
 	static const std::vector<BreakPoint> GetBreakpoints();
+
+	static bool HasMemChecks();
 
 	static void Update(u32 addr = 0);
 

--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -78,6 +78,8 @@ void IRFrontend::Comp_FPULS(MIPSOpcode op) {
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 
+	CheckMemoryBreakpoint(rs, offset);
+
 	switch (op >> 26) {
 	case 49: //FI(ft) = Memory::Read_U32(addr); break; //lwc1
 		ir.Write(IROp::LoadFloat, ft, rs, ir.AddConstant(offset));

--- a/Core/MIPS/IR/IRCompLoadStore.cpp
+++ b/Core/MIPS/IR/IRCompLoadStore.cpp
@@ -15,30 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-
-// Optimization ideas:
-//
-// It's common to see sequences of stores writing or reading to a contiguous set of
-// addresses in function prologues/epilogues:
-//  sw s5, 104(sp)
-//  sw s4, 100(sp)
-//  sw s3, 96(sp)
-//  sw s2, 92(sp)
-//  sw s1, 88(sp)
-//  sw s0, 84(sp)
-//  sw ra, 108(sp)
-//  mov s4, a0
-//  mov s3, a1
-//  ...
-// Such sequences could easily be detected and turned into nice contiguous
-// sequences of ARM stores instead of the current 3 instructions per sw/lw.
-//
-// Also, if we kept track of the likely register content of a cached register,
-// (pointer or data), we could avoid many BIC instructions.
-
-
-#include "Core/MemMap.h"
 #include "Core/Config.h"
+#include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -80,6 +58,8 @@ namespace MIPSComp {
 			// Don't load anything into $zr
 			return;
 		}
+
+		CheckMemoryBreakpoint(rs, offset);
 
 		int addrReg = IRTEMP_0;
 		switch (o) {

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -19,17 +19,17 @@
 
 #include "math/math_util.h"
 
+#include "Common/CPUDetect.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
-#include "Common/CPUDetect.h"
-#include "Core/Config.h"
-#include "Core/Reporting.h"
-
 #include "Core/MIPS/IR/IRFrontend.h"
 #include "Core/MIPS/IR/IRRegCache.h"
+#include "Core/Reporting.h"
+
 
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
 // Currently known non working ones should have DISABLE.
@@ -277,6 +277,9 @@ namespace MIPSComp {
 		s32 offset = (signed short)(op & 0xFFFC);
 		int vt = ((op >> 16) & 0x1f) | ((op & 3) << 5);
 		MIPSGPReg rs = _RS;
+
+		CheckMemoryBreakpoint(rs, offset);
+
 		switch (op >> 26) {
 		case 50: //lv.s
 			ir.Write(IROp::LoadFloat, vfpuBase + voffset[vt], rs, ir.AddConstant(offset));
@@ -299,6 +302,8 @@ namespace MIPSComp {
 
 		u8 vregs[4];
 		GetVectorRegs(vregs, V_Quad, vt);
+
+		CheckMemoryBreakpoint(rs, imm);
 
 		switch (op >> 26) {
 		case 54: //lv.q

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -107,7 +107,8 @@ private:
 	void EatInstruction(MIPSOpcode op);
 	MIPSOpcode GetOffsetInstruction(int offset);
 
-	void CheckBreakpoint(u32 addr, int downcountOffset);
+	void CheckBreakpoint(u32 addr);
+	void CheckMemoryBreakpoint(int rs, int offset);
 
 	// Utility compilation functions
 	void BranchFPFlag(MIPSOpcode op, IRComparison cc, bool likely);

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -156,7 +156,8 @@ static const IRMeta irMeta[] = {
 	{ IROp::SetPC, "SetPC", "_G" },
 	{ IROp::SetPCConst, "SetPC", "_C" },
 	{ IROp::CallReplacement, "CallRepl", "_C" },
-	{ IROp::Breakpoint, "Breakpoint", "" },
+	{ IROp::Breakpoint, "Breakpoint", "", IRFLAG_EXIT },
+	{ IROp::MemoryCheck, "MemoryCheck", "_GC", IRFLAG_EXIT },
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -196,7 +196,7 @@ enum class IROp : u8 {
 	// Fake/System instructions
 	Interpret,
 
-	// Emit this before you exits. Semantic is to set the downcount
+	// Emit this before you exit. Semantic is to set the downcount
 	// that will be used at the actual exit.
 	Downcount,  // src1 + (src2<<8)
 
@@ -220,6 +220,7 @@ enum class IROp : u8 {
 	CallReplacement,
 	Break,
 	Breakpoint,
+	MemoryCheck,
 };
 
 enum IRComparison {

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -230,7 +230,10 @@ bool IRBlock::OverlapsRange(u32 addr, u32 size) {
 
 MIPSOpcode IRJit::GetOriginalOp(MIPSOpcode op) {
 	IRBlock *b = blocks_.GetBlock(op.encoding & 0xFFFFFF);
-	return b->GetOriginalFirstOp();
+	if (b) {
+		return b->GetOriginalFirstOp();
+	}
+	return op;
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -561,6 +561,8 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out) {
 		case IROp::ExitToConstIfGtZ:
 		case IROp::ExitToConstIfLeZ:
 		case IROp::ExitToConstIfLtZ:
+		case IROp::Breakpoint:
+		case IROp::MemoryCheck:
 		default:
 		{
 		doDefaultAndFlush:

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -582,6 +582,41 @@ namespace MIPSAnalyst {
 		return (op & MIPSTABLE_IMM_MASK) == 0xF8000000;
 	}
 
+	int OpMemoryAccessSize(u32 pc) {
+		const auto op = Memory::Read_Instruction(pc, true);
+		MIPSInfo info = MIPSGetInfo(op);
+		if ((info & (IN_MEM | OUT_MEM)) == 0) {
+			return 0;
+		}
+
+		// TODO: Verify lwl/lwr/etc.?
+		switch (info & MEMTYPE_MASK) {
+		case MEMTYPE_BYTE:
+			return 1;
+		case MEMTYPE_HWORD:
+			return 2;
+		case MEMTYPE_WORD:
+		case MEMTYPE_FLOAT:
+			return 4;
+		case MEMTYPE_VQUAD:
+			return 16;
+		}
+
+		return 0;
+	}
+
+	bool IsOpMemoryWrite(u32 pc) {
+		const auto op = Memory::Read_Instruction(pc, true);
+		MIPSInfo info = MIPSGetInfo(op);
+		return (info & OUT_MEM) != 0;
+	}
+
+	bool OpHasDelaySlot(u32 pc) {
+		const auto op = Memory::Read_Instruction(pc, true);
+		MIPSInfo info = MIPSGetInfo(op);
+		return (info & DELAYSLOT) != 0;
+	}
+
 	bool OpWouldChangeMemory(u32 pc, u32 addr, u32 size) {
 		const auto op = Memory::Read_Instruction(pc, true);
 

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -131,14 +131,15 @@ namespace MIPSAnalyst
 	bool IsSyscall(MIPSOpcode op);
 
 	bool OpWouldChangeMemory(u32 pc, u32 addr, u32 size);
+	int OpMemoryAccessSize(u32 pc);
+	bool IsOpMemoryWrite(u32 pc);
+	bool OpHasDelaySlot(u32 pc);
 
-	void Shutdown();
-	
 	typedef struct {
 		DebugInterface* cpu;
 		u32 opcodeAddress;
 		MIPSOpcode encodedOpcode;
-		
+
 		// shared between branches and conditional moves
 		bool isConditional;
 		bool conditionMet;


### PR DESCRIPTION
This makes them work, although they aren't terribly efficient (since it asks C++ for _EVERY_ memory access.)  A jit backend could apply optimizations though, similar to the current jit.

Also, I realized we can probably still reorder as long as we ensure Breakpoint/MemoryCheck are considered "barriers" in any optimization passes.

However, breakpoints in likely delay slots don't work.  Consider that you set a breakpoint in a delay slot.  When it hits, you hit "Go" to continue past it.  This won't work, and the cycle count will increase by 2 each time you hit Go (since it's written BEFORE considering the delay slot's breakpoint.)  You'll have to step into twice to skip it.

The alternative would be writing the downcount for each exit (I think that's what we do in jit), although that'd bloat the IR slightly.  Or doing that only when breakpoints exist.

-[Unknown]
