### PR TITLE
Add UI for wifi remote disc streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,7 @@ set(NativeAppSource
 	UI/GamepadEmu.cpp
 	UI/OnScreenDisplay.cpp
 	UI/ControlMappingScreen.cpp
+	UI/RemoteISOScreen.cpp
 	UI/ReportScreen.cpp
 	UI/SavedataScreen.cpp
 	UI/Store.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -995,10 +995,12 @@ add_library(native STATIC
 	ext/native/math/lin/vec3.h
 	ext/native/math/math_util.cpp
 	ext/native/math/math_util.h
-	ext/native/net/http_server.cpp
-	ext/native/net/http_server.h
 	ext/native/net/http_client.cpp
 	ext/native/net/http_client.h
+	ext/native/net/http_headers.cpp
+	ext/native/net/http_headers.h
+	ext/native/net/http_server.cpp
+	ext/native/net/http_server.h
 	ext/native/net/resolve.cpp
 	ext/native/net/resolve.h
 	ext/native/net/sinks.cpp
@@ -1010,6 +1012,8 @@ add_library(native STATIC
 	ext/native/thin3d/thin3d.cpp
 	ext/native/thin3d/thin3d.h
 	ext/native/thin3d/thin3d_gl.cpp
+	ext/native/thread/executor.cpp
+	ext/native/thread/executor.h
 	ext/native/thread/prioritizedworkqueue.cpp
 	ext/native/thread/prioritizedworkqueue.h
 	ext/native/thread/threadutil.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -339,6 +339,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("ReportingHost", &g_Config.sReportHost, "default"),
 	ConfigSetting("AutoSaveSymbolMap", &g_Config.bAutoSaveSymbolMap, false, true, true),
 	ConfigSetting("CacheFullIsoInRam", &g_Config.bCacheFullIsoInRam, false, true, true),
+	ConfigSetting("RemoteISOPort", &g_Config.iRemoteISOPort, 0, true, false),
 
 #ifdef ANDROID
 	ConfigSetting("ScreenRotation", &g_Config.iScreenRotation, 1),
@@ -356,6 +357,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("PauseWhenMinimized", &g_Config.bPauseWhenMinimized, false, true, true),
 	ConfigSetting("DumpDecryptedEboots", &g_Config.bDumpDecryptedEboot, false, true, true),
 	ConfigSetting("FullscreenOnDoubleclick", &g_Config.bFullscreenOnDoubleclick, true, false, false),
+
 	ConfigSetting(false),
 };
 
@@ -510,7 +512,8 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("FragmentTestCache", &g_Config.bFragmentTestCache, true, true, true),
 
 	ConfigSetting("GfxDebugOutput", &g_Config.bGfxDebugOutput, false, false, false),
-	ConfigSetting(false), 
+
+	ConfigSetting(false),
 };
 
 static ConfigSetting soundSettings[] = {
@@ -666,6 +669,7 @@ static ConfigSetting controlSettings[] = {
 static ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", &g_Config.bEnableWlan, false, true, true),
 	ConfigSetting("EnableAdhocServer", &g_Config.bEnableAdhocServer, false, true, true),
+
 	ConfigSetting(false),
 };
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1141,7 +1141,7 @@ void Config::CleanRecent() {
 	std::vector<std::string> cleanedRecent;
 	for (size_t i = 0; i < recentIsos.size(); i++) {
 		FileLoader *loader = ConstructFileLoader(recentIsos[i]);
-		if (loader->Exists()) {
+		if (loader->ExistsFast()) {
 			// Make sure we don't have any redundant items.
 			auto duplicate = std::find(cleanedRecent.begin(), cleanedRecent.end(), recentIsos[i]);
 			if (duplicate == cleanedRecent.end()) {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -138,6 +138,7 @@ public:
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;
 	bool bCacheFullIsoInRam;
+	int iRemoteISOPort;
 
 	int iScreenRotation;  // The rotation angle of the PPSSPP UI. Only supported on Android and possibly other mobile platforms.
 	int iInternalScreenRotation;  // The internal screen rotation angle. Useful for vertical SHMUPs and similar.

--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -28,6 +28,7 @@ public:
 	virtual ~CachingFileLoader() override;
 
 	virtual bool Exists() override;
+	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
 	virtual std::string Path() const override;
@@ -45,6 +46,7 @@ public:
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
 
 private:
+	void Prepare();
 	void InitCache();
 	void ShutdownCache();
 	size_t ReadFromCache(s64 pos, size_t bytes, void *data);
@@ -84,4 +86,5 @@ private:
 	recursive_mutex blocksMutex_;
 	mutable recursive_mutex backendMutex_;
 	bool aheadThread_;
+	bool prepared_;
 };

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -54,7 +54,7 @@ DiskCachingFileLoader::~DiskCachingFileLoader() {
 }
 
 bool DiskCachingFileLoader::Exists() {
-	if (cache_->HasData()) {
+	if (cache_ && cache_->HasData()) {
 		// It may require a slow operation to check - if we have data, let's say yes.
 		// This helps initial load, since we check each recent file for existence.
 		return true;

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -38,8 +38,16 @@ recursive_mutex DiskCachingFileLoader::cachesMutex_;
 
 // Takes ownership of backend.
 DiskCachingFileLoader::DiskCachingFileLoader(FileLoader *backend)
-	: filesize_(0), filepos_(0), backend_(backend), cache_(nullptr) {
-	filesize_ = backend->FileSize();
+	: prepared_(false), filesize_(0), filepos_(0), backend_(backend), cache_(nullptr) {
+}
+
+void DiskCachingFileLoader::Prepare() {
+	if (prepared_) {
+		return;
+	}
+	prepared_ = true;
+
+	filesize_ = backend_->FileSize();
 	if (filesize_ > 0) {
 		InitCache();
 	}
@@ -54,19 +62,22 @@ DiskCachingFileLoader::~DiskCachingFileLoader() {
 }
 
 bool DiskCachingFileLoader::Exists() {
-	if (cache_ && cache_->HasData()) {
-		// It may require a slow operation to check - if we have data, let's say yes.
-		// This helps initial load, since we check each recent file for existence.
-		return true;
-	}
+	Prepare();
 	return backend_->Exists();
 }
 
+bool DiskCachingFileLoader::ExistsFast() {
+	// It may require a slow operation to check - if we have data, let's say yes.
+	// This helps initial load, since we check each recent file for existence.
+	return true;
+}
+
 bool DiskCachingFileLoader::IsDirectory() {
-	return backend_->IsDirectory() ? 1 : 0;
+	return backend_->IsDirectory();
 }
 
 s64 DiskCachingFileLoader::FileSize() {
+	Prepare();
 	return filesize_;
 }
 
@@ -79,6 +90,7 @@ void DiskCachingFileLoader::Seek(s64 absolutePos) {
 }
 
 size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data) {
+	Prepare();
 	size_t readSize;
 
 	if (absolutePos >= filesize_) {

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -31,6 +31,7 @@ public:
 	virtual ~DiskCachingFileLoader() override;
 
 	virtual bool Exists() override;
+	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
 	virtual std::string Path() const override;
@@ -50,9 +51,11 @@ public:
 	static std::vector<std::string> GetCachedPathsInUse();
 
 private:
+	void Prepare();
 	void InitCache();
 	void ShutdownCache();
 
+	bool prepared_;
 	s64 filesize_;
 	s64 filepos_;
 	FileLoader *backend_;

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -29,6 +29,7 @@ public:
 	virtual ~HTTPFileLoader() override;
 
 	virtual bool Exists() override;
+	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
 	virtual std::string Path() const override;
@@ -46,6 +47,8 @@ public:
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data) override;
 
 private:
+	void Prepare();
+
 	void Connect() {
 		if (!connected_) {
 			connected_ = client_.Connect();
@@ -66,4 +69,5 @@ private:
 	http::Client client_;
 	std::string filename_;
 	bool connected_;
+	bool prepared_;
 };

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -48,6 +48,14 @@ bool RamCachingFileLoader::Exists() {
 	return exists_ == 1;
 }
 
+bool RamCachingFileLoader::ExistsFast() {
+	if (exists_ == -1) {
+		lock_guard guard(backendMutex_);
+		return backend_->ExistsFast();
+	}
+	return exists_ == 1;
+}
+
 bool RamCachingFileLoader::IsDirectory() {
 	if (isDirectory_ == -1) {
 		lock_guard guard(backendMutex_);

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -28,6 +28,7 @@ public:
 	~RamCachingFileLoader() override;
 
 	bool Exists() override;
+	bool ExistsFast() override;
 	bool IsDirectory() override;
 	s64 FileSize() override;
 	std::string Path() const override;

--- a/Core/FileLoaders/RetryingFileLoader.cpp
+++ b/Core/FileLoaders/RetryingFileLoader.cpp
@@ -35,6 +35,14 @@ bool RetryingFileLoader::Exists() {
 	return true;
 }
 
+bool RetryingFileLoader::ExistsFast() {
+	if (!backend_->ExistsFast()) {
+		// Retry once, immediately.
+		return backend_->ExistsFast();
+	}
+	return true;
+}
+
 bool RetryingFileLoader::IsDirectory() {
 	// Can't tell if it's an error either way.
 	return backend_->IsDirectory();

--- a/Core/FileLoaders/RetryingFileLoader.h
+++ b/Core/FileLoaders/RetryingFileLoader.h
@@ -26,6 +26,7 @@ public:
 	virtual ~RetryingFileLoader() override;
 
 	virtual bool Exists() override;
+	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
 	virtual std::string Path() const override;

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -54,6 +54,9 @@ public:
 	virtual ~FileLoader() {}
 
 	virtual bool Exists() = 0;
+	virtual bool ExistsFast() {
+		return Exists();
+	}
 	virtual bool IsDirectory() = 0;
 	virtual s64 FileSize() = 0;
 	virtual std::string Path() const = 0;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -34,6 +34,7 @@
 #include "UI/ControlMappingScreen.h"
 #include "UI/DevScreens.h"
 #include "UI/DisplayLayoutScreen.h"
+#include "UI/RemoteISOScreen.h"
 #include "UI/SavedataScreen.h"
 #include "UI/TouchControlLayoutScreen.h"
 #include "UI/TouchControlVisibilityScreen.h"
@@ -499,6 +500,7 @@ void GameSettingsScreen::CreateViews() {
 	tools->Add(new Choice(sa->T("Savedata Manager")))->OnClick.Handle(this, &GameSettingsScreen::OnSavedataManager);
 	tools->Add(new Choice(dev->T("System Information")))->OnClick.Handle(this, &GameSettingsScreen::OnSysInfo);
 	tools->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
+	tools->Add(new Choice(sy->T("Remote disc streaming")))->OnClick.Handle(this, &GameSettingsScreen::OnRemoteISO);
 
 	// System
 	ViewGroup *systemSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
@@ -993,8 +995,14 @@ UI::EventReturn GameSettingsScreen::OnPostProcShaderChange(UI::EventParams &e) {
 	Reporting::UpdateConfig();
 	return UI::EVENT_DONE;
 }
+
 UI::EventReturn GameSettingsScreen::OnDeveloperTools(UI::EventParams &e) {
 	screenManager()->push(new DeveloperToolsScreen());
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnRemoteISO(UI::EventParams &e) {
+	screenManager()->push(new RemoteISOScreen());
 	return UI::EVENT_DONE;
 }
 
@@ -1006,7 +1014,7 @@ UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e) {
 	screenManager()->push(new TouchControlLayoutScreen());
 	return UI::EVENT_DONE;
-};
+}
 
 //when the tilt event type is modified, we need to reset all tilt settings.
 //refer to the ResetTiltEvents() function for a detailed explanation.

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -73,6 +73,7 @@ private:
 	UI::EventReturn OnPostProcShader(UI::EventParams &e);
 	UI::EventReturn OnPostProcShaderChange(UI::EventParams &e);
 	UI::EventReturn OnDeveloperTools(UI::EventParams &e);
+	UI::EventReturn OnRemoteISO(UI::EventParams &e);
 	UI::EventReturn OnChangeNickname(UI::EventParams &e);
 	UI::EventReturn OnChangeproAdhocServerAddress(UI::EventParams &e);
 	UI::EventReturn OnChangeMacAddress(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -457,6 +457,18 @@ UI::EventReturn GameBrowser::PinToggleClick(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
+bool GameBrowser::DisplayTopBar() {
+	return path_.GetPath() != "!RECENT";
+}
+
+bool GameBrowser::HasSpecialFiles(std::vector<std::string> &filenames) {
+	if (path_.GetPath() == "!RECENT") {
+		filenames = g_Config.recentIsos;
+		return true;
+	}
+	return false;
+}
+
 void GameBrowser::Refresh() {
 	using namespace UI;
 
@@ -468,7 +480,7 @@ void GameBrowser::Refresh() {
 	I18NCategory *mm = GetI18NCategory("MainMenu");
 
 	// No topbar on recent screen
-	if (path_.GetPath() != "!RECENT") {
+	if (DisplayTopBar()) {
 		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		if (allowBrowsing_) {
 			topBar->Add(new Spacer(2.0f));
@@ -504,9 +516,10 @@ void GameBrowser::Refresh() {
 	std::vector<DirButton *> dirButtons;
 	std::vector<GameButton *> gameButtons;
 
-	if (path_.GetPath() == "!RECENT") {
-		for (size_t i = 0; i < g_Config.recentIsos.size(); i++) {
-			gameButtons.push_back(new GameButton(g_Config.recentIsos[i], *gridStyle_, new UI::LinearLayoutParams(*gridStyle_ == true ? UI::WRAP_CONTENT : UI::FILL_PARENT, UI::WRAP_CONTENT)));
+	std::vector<std::string> filenames;
+	if (HasSpecialFiles(filenames)) {
+		for (size_t i = 0; i < filenames.size(); i++) {
+			gameButtons.push_back(new GameButton(filenames[i], *gridStyle_, new UI::LinearLayoutParams(*gridStyle_ == true ? UI::WRAP_CONTENT : UI::FILL_PARENT, UI::WRAP_CONTENT)));
 		}
 	} else {
 		std::vector<FileInfo> fileInfo;

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -35,8 +35,13 @@ public:
 
 	void FocusGame(std::string gamePath);
 
-private:
+protected:
+	virtual bool DisplayTopBar();
+	virtual bool HasSpecialFiles(std::vector<std::string> &filenames);
+
 	void Refresh();
+
+private:
 	bool IsCurrentPathPinned();
 	const std::vector<std::string> GetPinnedPaths();
 	const std::string GetBaseName(const std::string &path);
@@ -61,6 +66,8 @@ private:
 	std::string focusGamePath_;
 };
 
+class RemoteISOBrowseScreen;
+
 class MainScreen : public UIScreenWithBackground {
 public:
 	MainScreen();
@@ -78,7 +85,7 @@ protected:
 	virtual void sendMessage(const char *message, const char *value);
 	virtual void dialogFinished(const Screen *dialog, DialogResult result);
 
-private:
+	bool UseVerticalLayout() const;
 	bool DrawBackgroundFor(UIContext &dc, const std::string &gamePath, float progress);
 
 	UI::EventReturn OnGameSelected(UI::EventParams &e);
@@ -112,7 +119,7 @@ private:
 	bool lockBackgroundAudio_;
 	bool lastVertical_;
 
-	bool UseVerticalLayout() const;
+	friend class RemoteISOBrowseScreen;
 };
 
 class UmdReplaceScreen : public UIDialogScreenWithBackground {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -67,14 +67,14 @@ static void RegisterServer(int port) {
 	Buffer theVoid;
 
 	if (http.Resolve(REPORT_HOSTNAME, REPORT_PORT)) {
-		http.Connect();
+		if (http.Connect()) {
+			char resource[1024] = {};
+			std::string ip = fd_util::GetLocalIP(http.sock());
+			snprintf(resource, sizeof(resource) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
 
-		char resource[1024] = {};
-		std::string ip = fd_util::GetLocalIP(http.sock());
-		snprintf(resource, sizeof(resource) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
-
-		http.GET(resource, &theVoid);
-		http.Disconnect();
+			http.GET(resource, &theVoid);
+			http.Disconnect();
+		}
 	}
 }
 
@@ -191,9 +191,10 @@ static bool FindServer(std::string &resultHost, int &resultPort) {
 
 	// Start by requesting a list of recent local ips for this network.
 	if (http.Resolve(REPORT_HOSTNAME, REPORT_PORT)) {
-		http.Connect();
-		code = http.GET("/match/list", &result);
-		http.Disconnect();
+		if (http.Connect()) {
+			code = http.GET("/match/list", &result);
+			http.Disconnect();
+		}
 	}
 
 	if (code != 200 || scanCancelled) {
@@ -244,9 +245,10 @@ static bool LoadGameList(const std::string &host, int port, std::vector<std::str
 
 	// Start by requesting a list of recent local ips for this network.
 	if (http.Resolve(host.c_str(), port)) {
-		http.Connect();
-		code = http.GET("/", &result);
-		http.Disconnect();
+		if (http.Connect()) {
+			code = http.GET("/", &result);
+			http.Disconnect();
+		}
 	}
 
 	if (code != 200 || scanCancelled) {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -263,14 +263,18 @@ void RemoteISOScreen::CreateViews() {
 	// TODO: Could display server address for manual entry.
 
 	rightColumnItems->SetSpacing(0.0f);
-	rightColumnItems->Add(new Choice(sy->T("Browse Games")))->OnClick.Handle(this, &RemoteISOScreen::HandleBrowse);
+	Choice *browseChoice = new Choice(sy->T("Browse Games"));
+	rightColumnItems->Add(browseChoice)->OnClick.Handle(this, &RemoteISOScreen::HandleBrowse);
 	ServerStatus status = RetrieveStatus();
 	if (status == ServerStatus::STOPPING) {
 		rightColumnItems->Add(new Choice(sy->T("Stopping..")))->SetDisabledPtr(&serverStopping_);
+		browseChoice->SetEnabled(false);
 	} else if (status != ServerStatus::STOPPED) {
 		rightColumnItems->Add(new Choice(sy->T("Stop Sharing")))->OnClick.Handle(this, &RemoteISOScreen::HandleStopServer);
+		browseChoice->SetEnabled(false);
 	} else {
 		rightColumnItems->Add(new Choice(sy->T("Share Games (Server)")))->OnClick.Handle(this, &RemoteISOScreen::HandleStartServer);
+		browseChoice->SetEnabled(true);
 	}
 
 	rightColumnItems->Add(new Spacer(25.0));

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -174,6 +174,7 @@ void RemoteISOScreen::CreateViews() {
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
 
+	leftColumnItems->Add(new TextView(sy->T("RemoteISODesc", "Games in your recent list will be shared"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 	leftColumnItems->Add(new TextView(sy->T("RemoteISOWifi", "Note: Connect both devices to the same wifi"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 
 	rightColumnItems->SetSpacing(0.0f);

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -79,7 +79,7 @@ static void RegisterServer(int port) {
 static void ExecuteServer() {
 	setCurrentThreadName("HTTPServer");
 
-	net::Init();
+	net::AutoInit netInit;
 	auto http = new http::Server(new threading::SameThreadExecutor());
 
 	std::map<std::string, std::string> paths;
@@ -156,7 +156,11 @@ static void ExecuteServer() {
 	}
 
 	if (!http->Listen(g_Config.iRemoteISOPort)) {
-		http->Listen(0);
+		if (!http->Listen(0)) {
+			ERROR_LOG(COMMON, "Unable to listen on any port");
+			UpdateStatus(ServerStatus::STOPPED);
+			return;
+		}
 	}
 	UpdateStatus(ServerStatus::RUNNING);
 
@@ -173,7 +177,7 @@ static void ExecuteServer() {
 		}
 	}
 
-	net::Shutdown();
+	http->Stop();
 
 	UpdateStatus(ServerStatus::STOPPED);
 }

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -95,7 +95,7 @@ static void ExecuteServer() {
 		// Let's not serve directories, since they won't work.  Only single files.
 		// Maybe can do PBPs and other files later.  Would be neat to stream virtual disc filesystems.
 		if (endsWithNoCase(basename, ".cso") || endsWithNoCase(basename, ".iso")) {
-			paths[basename] = filename;
+			paths[ReplaceAll(basename, " ", "%20")] = filename;
 		}
 	}
 

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2014- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "i18n/i18n.h"
+#include "net/http_server.h"
+#include "net/resolve.h"
+#include "net/sinks.h"
+#include "thread/thread.h"
+#include "thread/threadutil.h"
+#include "Common/Common.h"
+#include "Common/FileUtil.h"
+#include "Core/Config.h"
+#include "UI/RemoteISOScreen.h"
+
+using namespace UI;
+
+enum class ServerStatus {
+	STOPPED,
+	STARTING,
+	RUNNING,
+	STOPPING,
+};
+
+static std::thread *serverThread = nullptr;
+static ServerStatus serverStatus;
+static recursive_mutex serverStatusLock;
+static condition_variable serverStatusCond;
+
+static void UpdateStatus(ServerStatus s) {
+	lock_guard guard(serverStatusLock);
+	serverStatus = s;
+	serverStatusCond.notify_one();
+}
+
+static ServerStatus RetrieveStatus() {
+	lock_guard guard(serverStatusLock);
+	return serverStatus;
+}
+
+static void ExecuteServer() {
+	setCurrentThreadName("HTTPServer");
+
+	net::Init();
+	auto http = new http::Server(new threading::SameThreadExecutor());
+
+	http->Listen(0);
+	// TODO: Report local IP and port.
+	UpdateStatus(ServerStatus::RUNNING);
+
+	while (RetrieveStatus() == ServerStatus::RUNNING) {
+        http->RunSlice(5.0);
+	}
+
+	net::Shutdown();
+
+	UpdateStatus(ServerStatus::STOPPED);
+}
+
+RemoteISOScreen::RemoteISOScreen() {
+}
+
+void RemoteISOScreen::CreateViews() {
+	I18NCategory *rp = GetI18NCategory("Reporting");
+	I18NCategory *di = GetI18NCategory("Dialog");
+	I18NCategory *sy = GetI18NCategory("System");
+
+	Margins actionMenuMargins(0, 20, 15, 0);
+	Margins contentMargins(0, 20, 5, 5);
+	ViewGroup *leftColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 0.4f, contentMargins));
+	LinearLayout *leftColumnItems = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(WRAP_CONTENT, FILL_PARENT));
+	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
+	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
+
+	leftColumnItems->Add(new TextView(sy->T("RemoteISOWifi", "Note: Connect both devices to the same wifi"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+
+	rightColumnItems->SetSpacing(0.0f);
+	rightColumnItems->Add(new Choice(rp->T("Browse Games")));
+	if (serverStatus != ServerStatus::STOPPED) {
+		rightColumnItems->Add(new Choice(rp->T("Stop Sharing")))->OnClick.Handle(this, &RemoteISOScreen::HandleStopServer);
+	} else {
+		rightColumnItems->Add(new Choice(rp->T("Share Games (Server)")))->OnClick.Handle(this, &RemoteISOScreen::HandleStartServer);
+	}
+
+	rightColumnItems->Add(new Spacer(25.0));
+	rightColumnItems->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+
+	root_ = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
+	root_->Add(leftColumn);
+	root_->Add(rightColumn);
+
+	leftColumn->Add(leftColumnItems);
+	rightColumn->Add(rightColumnItems);
+}
+
+UI::EventReturn RemoteISOScreen::HandleStartServer(UI::EventParams &e) {
+	lock_guard guard(serverStatusLock);
+
+	if (serverStatus != ServerStatus::STOPPED) {
+		return EVENT_SKIPPED;
+	}
+
+	serverStatus = ServerStatus::STARTING;
+	serverThread = new std::thread(&ExecuteServer);
+	serverThread->detach();
+
+	serverStatusCond.wait(serverStatusLock);
+	RecreateViews();
+
+	return EVENT_DONE;
+}
+
+UI::EventReturn RemoteISOScreen::HandleStopServer(UI::EventParams &e) {
+	lock_guard guard(serverStatusLock);
+
+	if (serverStatus != ServerStatus::RUNNING) {
+		return EVENT_SKIPPED;
+	}
+
+	serverStatus = ServerStatus::STOPPING;
+	serverStatusCond.wait(serverStatusLock);
+	delete serverThread;
+	serverThread = nullptr;
+
+	RecreateViews();
+
+	return EVENT_DONE;
+}

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -155,9 +155,12 @@ static void ExecuteServer() {
 		http->RegisterHandler(pair.first.c_str(), handler);
 	}
 
-	http->Listen(0);
+	if (!http->Listen(g_Config.iRemoteISOPort)) {
+		http->Listen(0);
+	}
 	UpdateStatus(ServerStatus::RUNNING);
 
+	g_Config.iRemoteISOPort = http->Port();
 	RegisterServer(http->Port());
 	double lastRegister = real_time_now();
 	while (RetrieveStatus() == ServerStatus::RUNNING) {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -164,7 +164,6 @@ void RemoteISOScreen::update(InputState &input) {
 }
 
 void RemoteISOScreen::CreateViews() {
-	I18NCategory *rp = GetI18NCategory("Reporting");
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *sy = GetI18NCategory("System");
 
@@ -179,14 +178,14 @@ void RemoteISOScreen::CreateViews() {
 	leftColumnItems->Add(new TextView(sy->T("RemoteISOWifi", "Note: Connect both devices to the same wifi"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 
 	rightColumnItems->SetSpacing(0.0f);
-	rightColumnItems->Add(new Choice(rp->T("Browse Games")));
+	rightColumnItems->Add(new Choice(sy->T("Browse Games")));
 	ServerStatus status = RetrieveStatus();
 	if (status == ServerStatus::STOPPING) {
-		rightColumnItems->Add(new Choice(rp->T("Stopping..")))->SetDisabledPtr(&serverStopping_);
+		rightColumnItems->Add(new Choice(sy->T("Stopping..")))->SetDisabledPtr(&serverStopping_);
 	} else if (status != ServerStatus::STOPPED) {
-		rightColumnItems->Add(new Choice(rp->T("Stop Sharing")))->OnClick.Handle(this, &RemoteISOScreen::HandleStopServer);
+		rightColumnItems->Add(new Choice(sy->T("Stop Sharing")))->OnClick.Handle(this, &RemoteISOScreen::HandleStopServer);
 	} else {
-		rightColumnItems->Add(new Choice(rp->T("Share Games (Server)")))->OnClick.Handle(this, &RemoteISOScreen::HandleStartServer);
+		rightColumnItems->Add(new Choice(sy->T("Share Games (Server)")))->OnClick.Handle(this, &RemoteISOScreen::HandleStartServer);
 	}
 
 	rightColumnItems->Add(new Spacer(25.0));

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -27,8 +27,11 @@ public:
 	RemoteISOScreen();
 
 protected:
+	void update(InputState &input) override;
 	void CreateViews() override;
 
 	UI::EventReturn HandleStartServer(UI::EventParams &e);
 	UI::EventReturn HandleStopServer(UI::EventParams &e);
+
+	bool serverRunning_;
 };

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -22,6 +22,12 @@
 #include "ui/viewgroup.h"
 #include "UI/MiscScreens.h"
 
+namespace std {
+	class thread;
+}
+
+class recursive_mutex;
+
 class RemoteISOScreen : public UIScreenWithBackground {
 public:
 	RemoteISOScreen();
@@ -32,7 +38,36 @@ protected:
 
 	UI::EventReturn HandleStartServer(UI::EventParams &e);
 	UI::EventReturn HandleStopServer(UI::EventParams &e);
+	UI::EventReturn HandleBrowse(UI::EventParams &e);
 
 	bool serverRunning_;
 	bool serverStopping_;
+};
+
+class RemoteISOConnectScreen : public UIScreenWithBackground {
+public:
+	RemoteISOConnectScreen();
+	~RemoteISOConnectScreen() override;
+
+protected:
+	void update(InputState &input) override;
+	void CreateViews() override;
+
+	void ExecuteScan();
+	bool IsComplete();
+	void BrowseToURL(const std::string &url);
+
+	bool scanComplete_;
+	double nextRetry_;
+	std::thread *scanThread_;
+	recursive_mutex *scanLock_;
+	std::string url_;
+};
+
+class RemoteISOBrowseScreen : public UIScreenWithBackground {
+public:
+	RemoteISOBrowseScreen(const std::string &url);
+
+protected:
+	void CreateViews() override;
 };

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2016- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "base/functional.h"
+#include "ui/ui_screen.h"
+#include "ui/viewgroup.h"
+#include "UI/MiscScreens.h"
+
+class RemoteISOScreen : public UIScreenWithBackground {
+public:
+	RemoteISOScreen();
+
+protected:
+	void CreateViews() override;
+
+	UI::EventReturn HandleStartServer(UI::EventParams &e);
+	UI::EventReturn HandleStopServer(UI::EventParams &e);
+};

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -34,4 +34,5 @@ protected:
 	UI::EventReturn HandleStopServer(UI::EventParams &e);
 
 	bool serverRunning_;
+	bool serverStopping_;
 };

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -21,6 +21,7 @@
 #include "ui/ui_screen.h"
 #include "ui/viewgroup.h"
 #include "UI/MiscScreens.h"
+#include "UI/MainScreen.h"
 
 namespace std {
 	class thread;
@@ -44,6 +45,15 @@ protected:
 	bool serverStopping_;
 };
 
+enum class ScanStatus {
+	SCANNING,
+	RETRY_SCAN,
+	FOUND,
+	FAILED,
+	LOADING,
+	LOADED,
+};
+
 class RemoteISOConnectScreen : public UIScreenWithBackground {
 public:
 	RemoteISOConnectScreen();
@@ -53,21 +63,27 @@ protected:
 	void update(InputState &input) override;
 	void CreateViews() override;
 
+	ScanStatus GetStatus();
 	void ExecuteScan();
-	bool IsComplete();
-	void BrowseToURL(const std::string &url);
+	void ExecuteLoad();
 
-	bool scanComplete_;
+	UI::TextView *statusView_;
+
+	ScanStatus status_;
 	double nextRetry_;
 	std::thread *scanThread_;
-	recursive_mutex *scanLock_;
-	std::string url_;
+	recursive_mutex *statusLock_;
+	std::string host_;
+	int port_;
+	std::vector<std::string> games_;
 };
 
-class RemoteISOBrowseScreen : public UIScreenWithBackground {
+class RemoteISOBrowseScreen : public MainScreen {
 public:
-	RemoteISOBrowseScreen(const std::string &url);
+	RemoteISOBrowseScreen(const std::vector<std::string> &games);
 
 protected:
 	void CreateViews() override;
+
+	std::vector<std::string> games_;
 };

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="OnScreenDisplay.cpp" />
     <ClCompile Include="PauseScreen.cpp" />
     <ClCompile Include="ProfilerDraw.cpp" />
+    <ClCompile Include="RemoteISOScreen.cpp" />
     <ClCompile Include="ReportScreen.cpp" />
     <ClCompile Include="SavedataScreen.cpp" />
     <ClCompile Include="Store.cpp" />
@@ -66,6 +67,7 @@
     <ClInclude Include="OnScreenDisplay.h" />
     <ClInclude Include="PauseScreen.h" />
     <ClInclude Include="ProfilerDraw.h" />
+    <ClInclude Include="RemoteISOScreen.h" />
     <ClInclude Include="ReportScreen.h" />
     <ClInclude Include="SavedataScreen.h" />
     <ClInclude Include="Store.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -66,6 +66,9 @@
       <Filter>Screens</Filter>
     </ClCompile>
     <ClCompile Include="DisplayLayoutEditor.cpp" />
+    <ClCompile Include="RemoteISOScreen.cpp">
+      <Filter>Screens</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -133,6 +136,9 @@
     </ClInclude>
     <ClInclude Include="DisplayLayoutEditor.h" />
     <ClInclude Include="HostTypes.h" />
+    <ClInclude Include="RemoteISOScreen.h">
+      <Filter>Screens</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Screens">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -395,6 +395,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/UI/EmuScreen.cpp \
   $(SRC)/UI/MainScreen.cpp \
   $(SRC)/UI/MiscScreens.cpp \
+  $(SRC)/UI/RemoteISOScreen.cpp \
   $(SRC)/UI/ReportScreen.cpp \
   $(SRC)/UI/PauseScreen.cpp \
   $(SRC)/UI/SavedataScreen.cpp \

--- a/ext/native/file/fd_util.cpp
+++ b/ext/native/file/fd_util.cpp
@@ -4,11 +4,16 @@
 #include <math.h>
 #include <stdio.h>
 #ifndef _WIN32
-#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/select.h>
+#include <unistd.h>
 #else
 #include <io.h>
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #endif
 #include <fcntl.h>
 
@@ -125,6 +130,19 @@ void SetNonBlocking(int sock, bool non_blocking) {
 		ELOG("Error setting socket nonblocking status");
 	}
 #endif
+}
+
+std::string GetLocalIP(int sock) {
+	struct sockaddr_in server_addr;
+	memset(&server_addr, 0, sizeof(server_addr));
+	socklen_t len = sizeof(server_addr);
+	if (getsockname(sock, (struct sockaddr *)&server_addr, &len) == 0) {
+		char *result = inet_ntoa(*(in_addr *)&server_addr.sin_addr);
+		if (result) {
+			return result;
+		}
+	}
+	return "";
 }
 
 }  // fd_util

--- a/ext/native/file/fd_util.h
+++ b/ext/native/file/fd_util.h
@@ -22,6 +22,8 @@ bool WaitUntilReady(int fd, double timeout, bool for_write = false);
 
 void SetNonBlocking(int fd, bool non_blocking);
 
+std::string GetLocalIP(int sock);
+
 }  // fd_util
 
 #endif  // _FD_UTIL

--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -27,7 +27,7 @@ public:
 	// Inits the sockaddr_in.
 	bool Resolve(const char *host, int port);
 
-	bool Connect(int maxTries = 2);
+	bool Connect(int maxTries = 2, double timeout = 20.0f);
 	void Disconnect();
 
 	// Only to be used for bring-up and debugging.

--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -162,6 +162,10 @@ bool Server::Listen(int port) {
 }
 
 bool Server::RunSlice(double timeout) {
+	if (listener_ < 0 || port_ == 0) {
+		return false;
+	}
+
 	if (timeout <= 0.0) {
 		timeout = 86400.0;
 	}
@@ -182,7 +186,9 @@ bool Server::RunSlice(double timeout) {
 }
 
 bool Server::Run(int port) {
-	Listen(port);
+	if (!Listen(port)) {
+		return false;
+	}
 
 	while (true) {
 		RunSlice(0.0);
@@ -190,6 +196,10 @@ bool Server::Run(int port) {
 
 	// We'll never get here. Ever.
 	return true;
+}
+
+void Server::Stop() {
+	closesocket(listener_);
 }
 
 void Server::HandleConnection(int conn_fd) {

--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -230,7 +230,7 @@ void Server::Handle404(const Request &request) {
 }
 
 void Server::HandleListing(const Request &request) {
-	request.WriteHttpResponseHeader(200, -1);
+	request.WriteHttpResponseHeader(200, -1, "text/plain");
 	for (auto iter = handlers_.begin(); iter != handlers_.end(); ++iter) {
 		request.Out()->Printf("%s\n", iter->first.c_str());
 	}

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -74,6 +74,7 @@ public:
 	// for a new connection to handle.
 	bool RunSlice(double timeout);
 	bool Listen(int port);
+	void Stop();
 
 	void RegisterHandler(const char *url_path, UrlHandlerFunc handler);
 	void SetFallbackHandler(UrlHandlerFunc handler);

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -60,48 +60,50 @@ private:
 
 // Register handlers on this class to serve stuff.
 class Server {
- public:
-  Server(threading::Executor *executor);
+public:
+	Server(threading::Executor *executor);
 
-  typedef std::function<void(const Request &)> UrlHandlerFunc;
-  typedef std::map<std::string, UrlHandlerFunc> UrlHandlerMap;
+	typedef std::function<void(const Request &)> UrlHandlerFunc;
+	typedef std::map<std::string, UrlHandlerFunc> UrlHandlerMap;
 
-  // Runs forever, serving request. If you want to do something else than serve pages,
-  // better put this on a thread. Returns false if failed to start serving, never
-  // returns if successful.
-  bool Run(int port);
-  // May run for (significantly) longer than timeout, but won't wait longer than that
-  // for a new connection to handle.
-  bool RunSlice(double timeout);
-  bool Listen(int port);
+	// Runs forever, serving request. If you want to do something else than serve pages,
+	// better put this on a thread. Returns false if failed to start serving, never
+	// returns if successful.
+	bool Run(int port);
+	// May run for (significantly) longer than timeout, but won't wait longer than that
+	// for a new connection to handle.
+	bool RunSlice(double timeout);
+	bool Listen(int port);
 
-  void RegisterHandler(const char *url_path, UrlHandlerFunc handler);
-  void SetFallbackHandler(UrlHandlerFunc handler);
+	void RegisterHandler(const char *url_path, UrlHandlerFunc handler);
+	void SetFallbackHandler(UrlHandlerFunc handler);
 
-  // If you want to customize things at a lower level than just a simple path handler,
-  // then inherit and override this. Implementations should forward to HandleRequestDefault
-  // if they don't recognize the url.
-  virtual void HandleRequest(const Request &request);
+	// If you want to customize things at a lower level than just a simple path handler,
+	// then inherit and override this. Implementations should forward to HandleRequestDefault
+	// if they don't recognize the url.
+	virtual void HandleRequest(const Request &request);
 
- private:
-  void HandleConnection(int conn_fd);
+	int Port() {
+	  return port_;
+	}
 
-  void GetRequest(Request *request);
+private:
+	void HandleConnection(int conn_fd);
 
-  // Things like default 404, etc.
-  void HandleRequestDefault(const Request &request);
+	// Things like default 404, etc.
+	void HandleRequestDefault(const Request &request);
 
-  // Neat built-in handlers that are tied to the server.
-  void HandleListing(const Request &request);
-  void Handle404(const Request &request);
+	// Neat built-in handlers that are tied to the server.
+	void HandleListing(const Request &request);
+	void Handle404(const Request &request);
 
-  int listener_;
-  int port_;
+	int listener_;
+	int port_;
 
-  UrlHandlerMap handlers_;
-  UrlHandlerFunc fallback_;
+	UrlHandlerMap handlers_;
+	UrlHandlerFunc fallback_;
 
-  threading::Executor *executor_;
+	threading::Executor *executor_;
 };
 
 }  // namespace http

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -70,6 +70,10 @@ class Server {
   // better put this on a thread. Returns false if failed to start serving, never
   // returns if successful.
   bool Run(int port);
+  // May run for (significantly) longer than timeout, but won't wait longer than that
+  // for a new connection to handle.
+  bool RunSlice(double timeout);
+  bool Listen(int port);
 
   void RegisterHandler(const char *url_path, UrlHandlerFunc handler);
   void SetFallbackHandler(UrlHandlerFunc handler);
@@ -86,11 +90,12 @@ class Server {
 
   // Things like default 404, etc.
   void HandleRequestDefault(const Request &request);
-  
+
   // Neat built-in handlers that are tied to the server.
   void HandleListing(const Request &request);
   void Handle404(const Request &request);
 
+  int listener_;
   int port_;
 
   UrlHandlerMap handlers_;


### PR DESCRIPTION
This adds a screen under Tools where you can:
- Start or stop the internal webserver (basically the same as #8775.)
- Browse a server on the same network (didn't add manual IP entry for now, always automatic.)

The sharing is based on your desktop's recent games list.  The UI could probably use some polish but at least it's a basic start.  Both devices must be connected to the same wifi network.

It selects a random port when sharing (via the OS), but for caching reasons, tries to reuse that port if possible next time.

-[Unknown]
