### PR TITLE
Fix for bluetooth headset audio stutter

### DIFF
--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -30,10 +30,10 @@ struct AudioDebugStats;
 
 // 16 bit Stereo
 
-#define MAX_SAMPLES     (2*(1024 * 2)) // 2*64ms - had to double it for nVidia Shield which has huge buffers
+#define MAX_SAMPLES     (4*(1024 * 2)) // 4*64ms - we need this huge buffer to bridge Bluetooth transmission delays
 #define INDEX_MASK      (MAX_SAMPLES * 2 - 1)
 
-#define LOW_WATERMARK   1680 // 40 ms
+#define LOW_WATERMARK   3360 // 80 ms
 #define MAX_FREQ_SHIFT  200  // per 32000 Hz
 #define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
 #define CONTROL_AVG     32


### PR DESCRIPTION
It's the same issue we've had before on the NVidia Shield (and to an similiar extend on the OnePlus 3), just on a bigger scale.

This merge fixes bluetooth audio once and for all.
It also has the nice side-effect of fixing some smaller stutters on the OnePlus 3 when using the built-in speakers or wired headphones.

I know it's shooting pidgeons with cannons, but at least it works.
