### PR TITLE
Correct replaced texture formats in Direct3D 9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,8 @@ root = true
 charset = utf-8
 indent_style = tab
 insert_final_newline = true
-trim_trailing_whitespace = true
+# Would be nice, but don't want to change files unnecessarily.
+#trim_trailing_whitespace = true
 
 [*.py]
 indent_style = space

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -1370,7 +1370,9 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &re
 		int levels = scaleFactor == 1 ? maxLevel + 1 : 1;
 		int tw = w, th = h;
 		D3DFORMAT tfmt = (D3DFORMAT)D3DFMT(dstFmt);
-		if (!replaced.GetSize(level, tw, th)) {
+		if (replaced.GetSize(level, tw, th)) {
+			tfmt = (D3DFORMAT)D3DFMT(ToD3D9Format(replaced.Format(level)));
+		} else {
 			tw *= scaleFactor;
 			th *= scaleFactor;
 			if (scaleFactor > 1) {


### PR DESCRIPTION
This was causing some textures to come through incorrectly in replacements.

Also, disable trimming trailing whitespace - it seems like VS at least does it for the entire saved file, not newly added lines.  Causing lots of noise, unfortunately.

-[Unknown]
