### PR TITLE
Detect power saving mode on Android

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -56,9 +56,10 @@ static bool windowHidden = false;
 static double lastActivity = 0.0;
 static double lastKeepAwake = 0.0;
 static GraphicsContext *graphicsContext;
+static bool powerSaving = false;
 
 void Core_SetGraphicsContext(GraphicsContext *ctx) {
-  graphicsContext = ctx;
+	graphicsContext = ctx;
 }
 
 void Core_NotifyWindowHidden(bool hidden) {
@@ -118,6 +119,14 @@ void Core_WaitInactive(int milliseconds) {
 	if (Core_IsActive()) {
 		m_hInactiveEvent.wait_for(m_hInactiveMutex, milliseconds);
 	}
+}
+
+void Core_SetPowerSaving(bool mode) {
+	powerSaving = mode;
+}
+
+bool Core_GetPowerSaving() {
+	return powerSaving;
 }
 
 bool UpdateScreenScale(int width, int height, bool smallWindow) {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -52,3 +52,6 @@ bool UpdateScreenScale(int width, int height, bool smallWindow);
 // Don't run the core when minimized etc.
 void Core_NotifyWindowHidden(bool hidden);
 void Core_NotifyActivity();
+
+void Core_SetPowerSaving(bool mode);
+bool Core_GetPowerSaving();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -18,6 +18,7 @@
 #include "Core/Reporting.h"
 
 #include "Common/CPUDetect.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Config.h"
 #include "Core/CwCheat.h"
@@ -427,7 +428,7 @@ namespace Reporting
 			postdata.Add("graphics", StringFromFormat("%d", payload.int1));
 			postdata.Add("speed", StringFromFormat("%d", payload.int2));
 			postdata.Add("gameplay", StringFromFormat("%d", payload.int3));
-			postdata.Add("crc", StringFromFormat("%08x", RetrieveCRC()));
+			postdata.Add("crc", StringFromFormat("%08x", Core_GetPowerSaving() ? 0 : RetrieveCRC()));
 			AddScreenshotData(postdata, payload.string2);
 			payload.string1.clear();
 			payload.string2.clear();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -196,6 +196,11 @@ void EmuScreen::bootComplete() {
 		}
 	}
 
+	if (Core_GetPowerSaving()) {
+		I18NCategory *sy = GetI18NCategory("System");
+		osm.Show(sy->T("WARNING: Battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+	}
+
 	System_SendMessage("event", "startgame");
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -784,6 +784,14 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		// Show for the same duration as the preview.
 		osm.Show(msg, 2.0f, 0xFFFFFF, -1, true, "savestate_slot");
 	}
+	if (msg == "core_powerSaving") {
+		if (value != "false") {
+			I18NCategory *sy = GetI18NCategory("System");
+			osm.Show(sy->T("WARNING: Battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+		}
+
+		Core_SetPowerSaving(value != "false");
+	}
 }
 
 void NativeUpdate(InputState &input) {

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -23,6 +23,7 @@
 #include "UI/PauseScreen.h"
 #include "UI/ReportScreen.h"
 
+#include "Core/Core.h"
 #include "Core/Reporting.h"
 #include "Core/Screenshot.h"
 #include "Core/System.h"
@@ -224,7 +225,9 @@ void ReportScreen::CreateViews() {
 	}
 
 #ifdef MOBILE_DEVICE
-	leftColumnItems->Add(new TextView(rp->T("FeedbackIncludeCRC", "Note: Battery will be used to send a disc CRC"), new LinearLayoutParams(Margins(12, 5, 0, 5))))->SetEnabledPtr(&enableReporting_);
+	if (!Core_GetPowerSaving()) {
+		leftColumnItems->Add(new TextView(rp->T("FeedbackIncludeCRC", "Note: Battery will be used to send a disc CRC"), new LinearLayoutParams(Margins(12, 5, 0, 5))))->SetEnabledPtr(&enableReporting_);
+	}
 #endif
 
 	std::string path = GetSysDirectory(DIRECTORY_SCREENSHOT);

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -96,6 +96,14 @@
             </intent-filter>
         </activity>
 
+        <receiver android:name=".PowerSaveModeReceiver">
+            <intent-filter>
+                <action android:name="android.os.action.POWER_SAVE_MODE_CHANGED" />
+                <action android:name="android.intent.action.BATTERY_LOW" />
+                <action android:name="android.intent.action.BATTERY_OKAY" />
+            </intent-filter>
+        </receiver>
+
         <meta-data
             android:name="xperiaplayoptimized_content"
             android:resource="@drawable/ic_launcher" />

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -125,16 +125,6 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		}
 	}
 
-	@TargetApi(21)
-	private void sendPowerSaving() {
-		final PowerManager pm = (PowerManager)getSystemService(Context.POWER_SERVICE);
-		if (pm.isPowerSaveMode()) {
-			NativeApp.sendMessage("core_powerSaving", "true");
-		} else {
-			NativeApp.sendMessage("core_powerSaving", "false");
-		}
-	}
-
 	String getApplicationLibraryDir(ApplicationInfo application) {
 	    String libdir = null;
 	    try {
@@ -283,9 +273,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		javaGL = "true".equalsIgnoreCase(NativeApp.queryConfig("androidJavaGL"));
 
 		sendInitialGrants();
-		if (Build.VERSION.SDK_INT >= 21) {
-			sendPowerSaving();
-		}
+		PowerSaveModeReceiver.initAndSend(this);
 
 		// OK, config should be initialized, we can query for screen rotation.
 		if (Build.VERSION.SDK_INT >= 9) {

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -28,6 +28,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.PowerManager;
 import android.os.Vibrator;
 import android.text.InputType;
 import android.util.DisplayMetrics;
@@ -121,6 +122,16 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 			optimalSampleRate = Integer.parseInt(this.audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE));
 		} catch (NumberFormatException e) {
 			// Ignore, if we can't parse it it's bogus and zero is a fine value (means we couldn't detect it).
+		}
+	}
+
+	@TargetApi(21)
+	private void sendPowerSaving() {
+		final PowerManager pm = (PowerManager)getSystemService(Context.POWER_SERVICE);
+		if (pm.isPowerSaveMode()) {
+			NativeApp.sendMessage("core_powerSaving", "true");
+		} else {
+			NativeApp.sendMessage("core_powerSaving", "false");
 		}
 	}
 
@@ -272,6 +283,9 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 		javaGL = "true".equalsIgnoreCase(NativeApp.queryConfig("androidJavaGL"));
 
 		sendInitialGrants();
+		if (Build.VERSION.SDK_INT >= 21) {
+			sendPowerSaving();
+		}
 
 		// OK, config should be initialized, we can query for screen rotation.
 		if (Build.VERSION.SDK_INT >= 9) {

--- a/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
+++ b/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
@@ -1,0 +1,41 @@
+package org.ppsspp.ppsspp;
+
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.PowerManager;
+
+public class PowerSaveModeReceiver extends BroadcastReceiver {
+	private boolean isPowerSaving = false;
+	private boolean isBatteryLow = false;
+
+	@Override
+	public void onReceive(final Context context, final Intent intent) {
+		if (Build.VERSION.SDK_INT >= 21) {
+			isPowerSaving = getPowerSaving(context);
+		} else {
+			isPowerSaving = false;
+		}
+
+		final String action = intent.getAction();
+		if (action.equals(Intent.ACTION_BATTERY_LOW)) {
+			isBatteryLow = true;
+		} else if (action.equals(Intent.ACTION_BATTERY_OKAY)) {
+			isBatteryLow = false;
+		}
+
+		if (isBatteryLow || isPowerSaving) {
+			NativeApp.sendMessage("core_powerSaving", "true");
+		} else {
+			NativeApp.sendMessage("core_powerSaving", "false");
+		}
+	}
+
+	@TargetApi(21)
+	private boolean getPowerSaving(final Context context) {
+		final PowerManager pm = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
+		return pm.isPowerSaveMode();
+	}
+}

--- a/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
+++ b/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
@@ -1,24 +1,22 @@
 package org.ppsspp.ppsspp;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.database.ContentObserver;
+import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
+import android.provider.Settings;
 
 public class PowerSaveModeReceiver extends BroadcastReceiver {
-	private boolean isPowerSaving = false;
-	private boolean isBatteryLow = false;
+	private static boolean isPowerSaving = false;
+	private static boolean isBatteryLow = false;
 
 	@Override
 	public void onReceive(final Context context, final Intent intent) {
-		if (Build.VERSION.SDK_INT >= 21) {
-			isPowerSaving = getPowerSaving(context);
-		} else {
-			isPowerSaving = false;
-		}
-
 		final String action = intent.getAction();
 		if (action.equals(Intent.ACTION_BATTERY_LOW)) {
 			isBatteryLow = true;
@@ -26,16 +24,58 @@ public class PowerSaveModeReceiver extends BroadcastReceiver {
 			isBatteryLow = false;
 		}
 
+		sendPowerSaving(context);
+	}
+
+	public static void initAndSend(final Activity activity) {
+		sendPowerSaving(activity);
+
+		activity.getContentResolver().registerContentObserver(Settings.System.CONTENT_URI, true, new ContentObserver(null) {
+			@Override
+			public void onChange(boolean selfChange, Uri uri) {
+				super.onChange(selfChange, uri);
+
+				String key = uri.getPath();
+				key = key.substring(key.lastIndexOf("/") + 1, key.length());
+				if (key != null && (key.equals("user_powersaver_enable") || key.equals("psm_switch"))) {
+					PowerSaveModeReceiver.sendPowerSaving(activity);
+				}
+			}
+		});
+	}
+
+	@TargetApi(21)
+	private static boolean getNativePowerSaving(final Context context) {
+		final PowerManager pm = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
+		return pm.isPowerSaveMode();
+	}
+
+	private static boolean getExtraPowerSaving(final Context context) {
+		// http://stackoverflow.com/questions/25065635/checking-for-power-saver-mode-programically
+		// HTC (Sense)
+		String htcValue = Settings.System.getString(context.getContentResolver(), "user_powersaver_enable");
+		if (htcValue != null && htcValue.equals("1")) {
+			return true;
+		}
+		// Samsung (Touchwiz)
+		String samsungValue = Settings.System.getString(context.getContentResolver(), "psm_switch");
+		if (samsungValue != null && samsungValue.equals("1")) {
+			return true;
+		}
+		return false;
+	}
+
+	private static void sendPowerSaving(final Context context) {
+		if (Build.VERSION.SDK_INT >= 21) {
+			isPowerSaving = getNativePowerSaving(context) || getExtraPowerSaving(context);
+		} else {
+			isPowerSaving = getExtraPowerSaving(context);
+		}
+
 		if (isBatteryLow || isPowerSaving) {
 			NativeApp.sendMessage("core_powerSaving", "true");
 		} else {
 			NativeApp.sendMessage("core_powerSaving", "false");
 		}
-	}
-
-	@TargetApi(21)
-	private boolean getPowerSaving(final Context context) {
-		final PowerManager pm = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
-		return pm.isPowerSaveMode();
 	}
 }


### PR DESCRIPTION
This doesn't affect games (although, it could), but instead most importantly notifies users.

I'm sure that low battery may notify users anyway, but power saving is more likely not to: I remember on my Galaxy S3 (which I no longer have), it was easy not to notice it was even on.  This shows a message on startup when it is on.

Potentially we could send a low battery level to games which might in some rare cases influence how they render or something.

Anyway, this also disables sending reporting CRCs when power is low / in saving mode.

-[Unknown]
