### PR TITLE
Better support zh_gb.pgf

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -645,7 +645,7 @@ static void __LoadInternalFonts() {
 	if (!pspFileSystem.GetFileInfo(fontPath).exists) {
 		pspFileSystem.MkDir(fontPath);
 	}
-	if (pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/zh_gb.pgf").exists) {
+	if ((pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/zh_gb.pgf").exists) && (pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/oldfont.prx").exists)) {
 		for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
 			const FontRegistryEntry &entry = fontRegistry[i];
 			std::string fontFilename = userfontPath + entry.fileName;

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -645,9 +645,26 @@ static void __LoadInternalFonts() {
 	if (!pspFileSystem.GetFileInfo(fontPath).exists) {
 		pspFileSystem.MkDir(fontPath);
 	}
+	if (pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/zh_gb.pgf").exists) {
+		for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
+			const FontRegistryEntry &entry = fontRegistry[i];
+			std::string fontFilename = userfontPath + entry.fileName;
+			PSPFileInfo info = pspFileSystem.GetFileInfo(fontFilename);
+			DEBUG_LOG(SCEFONT, "Loading internal font %s (%i bytes)", fontFilename.c_str(), (int)info.size);
+			std::vector<u8> buffer;
+			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) < 0) {
+				ERROR_LOG(SCEFONT, "Failed opening font");
+				continue;
+			}
+			internalFonts.push_back(new Font(buffer, entry));
+			DEBUG_LOG(SCEFONT, "Loaded font %s", fontFilename.c_str());
+			return;
+		}
+	}
+
 	for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
 		const FontRegistryEntry &entry = fontRegistry[i];
-		std::string fontFilename = userfontPath + entry.fileName; 
+		std::string fontFilename = userfontPath + entry.fileName;
 		PSPFileInfo info = pspFileSystem.GetFileInfo(fontFilename);
 
 		if (!info.exists) {


### PR DESCRIPTION
Before
![1](https://cloud.githubusercontent.com/assets/2177532/17436047/50d97486-5b47-11e6-8006-2192d0423126.jpg)

After
![2](https://cloud.githubusercontent.com/assets/2177532/17436055/5a451a70-5b47-11e6-86fb-92e08a14a92e.jpg)

I don't know that ppsspp doesn't choose best font of "disc0:/PSP_GAME/USRDIR/zh_gb.pgf" of this game,so that I need force to use that font when exist.
