### PR TITLE
Display: Flip at least once every 10 frames

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -625,15 +625,16 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	// We flip only if the framebuffer was dirty. This eliminates flicker when using
 	// non-buffered rendering. The interaction with frame skipping seems to need
 	// some work.
-	// But, let's flip at least once every 10 frames if possible, since there may be sound effects.
-	if (gpu->FramebufferDirty() || (g_Config.iRenderingMode != 0 && numVBlanksSinceFlip >= 10)) {
+	// But, let's flip at least once every 10 vblanks, to update fps, etc.
+	const bool noRecentFlip = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && numVBlanksSinceFlip >= 10;
+	if (gpu->FramebufferDirty() || noRecentFlip) {
 		if (g_Config.iShowFPSCounter && g_Config.iShowFPSCounter < 4) {
 			CalculateFPS();
 		}
 
 		// Setting CORE_NEXTFRAME causes a swap.
 		// Check first though, might've just quit / been paused.
-		if (gpu->FramebufferReallyDirty()) {
+		if (gpu->FramebufferReallyDirty() || noRecentFlip) {
 			if (coreState == CORE_RUNNING) {
 				coreState = CORE_NEXTFRAME;
 				gpu->CopyDisplayToOutput();


### PR DESCRIPTION
If we don't do this, the FPS doesn't update, and on some platforms, we never read input.  This can basically mean that PPSSPP will hang.

Apparently, this is happening in #3391 (it uploads an image and doesn't flip until you confirm via controller.)  Without this, you're stuck (even with #8891.)

This also explains why Maverick Hunter X completely hung on Linux prior to the mpeg fix.

-[Unknown]
