### PR TITLE
Avoid crash in virtfs if handler fails to load

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -112,13 +112,16 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 		size_t handler_pos = line.find(':', filename_pos);
 		if (handler_pos != line.npos) {
 			entry.fileName = line.substr(filename_pos, handler_pos - filename_pos);
+
 			std::string handler = line.substr(handler_pos + 1);
 			size_t trunc = handler.find_last_not_of("\r\n");
 			if (trunc != handler.npos && trunc != handler.size())
 				handler.resize(trunc + 1);
+
 			if (handlers.find(handler) == handlers.end())
 				handlers[handler] = new Handler(handler.c_str(), this);
-			entry.handler = handlers[handler];
+			if (handlers[handler]->IsValid())
+				entry.handler = handlers[handler];
 		} else {
 			entry.fileName = line.substr(filename_pos);
 		}

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -831,6 +831,8 @@ VirtualDiscFileSystem::Handler::Handler(const char *filename, VirtualDiscFileSys
 			dlclose(library);
 			library = NULL;
 		}
+	} else {
+		ERROR_LOG(FILESYS, "Unable to load handler: %s", filename);
 	}
 #ifdef _WIN32
 #undef dlopen

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1204,12 +1204,12 @@ static void ConvertStencilFunc5551(GenericStencilFuncState &state) {
 	const u8 maskedRef = state.testRef & state.testMask;
 	const u8 usedRef = (state.testRef & 0x80) != 0 ? 0xFF : 0x00;
 
-	auto rewriteFunc = [&](GEComparison func, u8 ref, u8 mask = 0xFF) {
+	auto rewriteFunc = [&](GEComparison func, u8 ref) {
 		// We can only safely rewrite if it doesn't use the ref, or if the ref is the same.
 		if (!usesRef || usedRef == ref) {
 			state.testFunc = func;
 			state.testRef = ref;
-			state.testMask = mask;
+			state.testMask = 0xFF;
 		}
 	};
 	auto rewriteRef = [&](bool always) {


### PR DESCRIPTION
A failure to load can mean the so/dll doesn't exist, is for the wrong platform, doesn't have all the funcs, or fails to init.

-[Unknown]
