### PR TITLE
Clean up a few more core profile things

### DIFF
--- a/GPU/GLES/FragmentShaderGenerator.cpp
+++ b/GPU/GLES/FragmentShaderGenerator.cpp
@@ -15,14 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-// SDL 1.2 on Apple does not have support for OpenGL 3 and hence needs
-// special treatment in the shader generator.
-#if defined(__APPLE__)
-const bool forceOpenGL2_0 = true;
-#else
-const bool forceOpenGL2_0 = false;
-#endif
-
 #include <cstdio>
 #include <sstream>
 
@@ -116,8 +108,7 @@ bool GenerateFragmentShader(const ShaderID &id, char *buffer) {
 
 		WRITE(p, "precision lowp float;\n");
 	} else {
-		// TODO: Handle this in VersionGEThan?
-		if (!forceOpenGL2_0 || gl_extensions.IsCoreContext) {
+		if (!gl_extensions.ForceGL2 || gl_extensions.IsCoreContext) {
 			if (gl_extensions.VersionGEThan(3, 3, 0)) {
 				fragColor0 = "fragColor0";
 				texture = "texture";

--- a/GPU/GLES/VertexShaderGenerator.cpp
+++ b/GPU/GLES/VertexShaderGenerator.cpp
@@ -34,14 +34,6 @@
 #include "GPU/Common/ShaderId.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 
-// SDL 1.2 on Apple does not have support for OpenGL 3 and hence needs
-// special treatment in the shader generator.
-#if defined(__APPLE__)
-const bool forceOpenGL2_0 = true;
-#else
-const bool forceOpenGL2_0 = false;
-#endif
-
 #undef WRITE
 
 #define WRITE p+=sprintf
@@ -130,8 +122,7 @@ void GenerateVertexShader(const ShaderID &id, char *buffer) {
 		highpFog = (gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_BAD) ? true : false;
 		highpTexcoord = highpFog;
 	} else {
-		// TODO: Handle this in VersionGEThan?
-		if (!forceOpenGL2_0 || gl_extensions.IsCoreContext) {
+		if (!gl_extensions.ForceGL2 || gl_extensions.IsCoreContext) {
 			if (gl_extensions.VersionGEThan(3, 3, 0)) {
 				glslES30 = true;
 				WRITE(p, "#version 330\n");

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -15,14 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#if !defined(USING_GLES2)
-// SDL 1.2 on Apple does not have support for OpenGL 3 and hence needs
-// special treatment in the shader generator.
-#if defined(__APPLE__)
-#define FORCE_OPENGL_2_0
-#endif
-#endif
-
 #include <cstdio>
 #include <sstream>
 

--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
@@ -50,12 +50,6 @@ static const char *vulkan_glsl_preamble =
 
 
 
-// SDL 1.2 on Apple does not have support for OpenGL 3 and hence needs
-// special treatment in the shader generator.
-#ifdef __APPLE__
-#define FORCE_OPENGL_2_0
-#endif
-
 #undef WRITE
 
 #define WRITE p+=sprintf

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -251,10 +251,17 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 		ExitProcess(1);
 	}
 
+	// Some core profile drivers elide certain extensions from GL_EXTENSIONS/etc.
+	// glewExperimental allows us to force GLEW to search for the pointers anyway.
+	if (gl_extensions.IsCoreContext)
+		glewExperimental = true;
 	if (GLEW_OK != glewInit()) {
 		*error_message = "Failed to initialize GLEW.";
 		return false;
 	}
+	// Unfortunately, glew will generate an invalid enum error, ignore.
+	if (gl_extensions.IsCoreContext)
+		glGetError();
 
 	CheckGLExtensions();
 

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -587,10 +587,17 @@ int main(int argc, char *argv[]) {
 
 
 #ifndef USING_GLES2
+	// Some core profile drivers elide certain extensions from GL_EXTENSIONS/etc.
+	// glewExperimental allows us to force GLEW to search for the pointers anyway.
+	if (gl_extensions.IsCoreContext)
+		glewExperimental = true;
 	if (GLEW_OK != glewInit()) {
 		printf("Failed to initialize glew!\n");
 		return 1;
 	}
+	// Unfortunately, glew will generate an invalid enum error, ignore.
+	if (gl_extensions.IsCoreContext)
+		glGetError();
 
 	if (GLEW_VERSION_2_0) {
 		printf("OpenGL 2.0 or higher.\n");

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -30,6 +30,7 @@
 #include "SDL_audio.h"
 #endif
 #include "QtMain.h"
+#include "gfx_es2/gpu_features.h"
 #include "math/math_util.h"
 
 #include <string.h>
@@ -349,10 +350,17 @@ bool MainUI::event(QEvent *e)
 void MainUI::initializeGL()
 {
 #ifndef USING_GLES2
-        glewInit();
+	// Some core profile drivers elide certain extensions from GL_EXTENSIONS/etc.
+	// glewExperimental allows us to force GLEW to search for the pointers anyway.
+	if (gl_extensions.IsCoreContext)
+		glewExperimental = true;
+	glewInit();
+	// Unfortunately, glew will generate an invalid enum error, ignore.
+	if (gl_extensions.IsCoreContext)
+		glGetError();
 #endif
-        graphicsContext = new QtDummyGraphicsContext();
-        NativeInitGraphics(graphicsContext);
+	graphicsContext = new QtDummyGraphicsContext();
+	NativeInitGraphics(graphicsContext);
 }
 
 void MainUI::paintGL()

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -32,6 +32,9 @@ GLExtensions gl_extensions;
 std::string g_all_gl_extensions;
 std::string g_all_egl_extensions;
 
+static bool extensionsDone = false;
+static bool useCoreContext = false;
+
 bool GLExtensions::VersionGEThan(int major, int minor, int sub) {
 	if (gl_extensions.ver[0] > major)
 		return true;
@@ -73,11 +76,11 @@ void ProcessGPUFeatures() {
 
 void CheckGLExtensions() {
 	// Make sure to only do this once. It's okay to call CheckGLExtensions from wherever.
-	static bool done = false;
-	if (done)
+	if (extensionsDone)
 		return;
-	done = true;
+	extensionsDone = true;
 	memset(&gl_extensions, 0, sizeof(gl_extensions));
+	gl_extensions.IsCoreContext = useCoreContext;
 
 #ifdef USING_GLES2
 	gl_extensions.IsGLES = true;
@@ -376,4 +379,13 @@ void CheckGLExtensions() {
 	int error = glGetError();
 	if (error)
 		ELOG("GL error in init: %i", error);
+}
+
+void SetGLCoreContext(bool flag) {
+	if (extensionsDone)
+		FLOG("SetGLCoreContext() after CheckGLExtensions()");
+
+	useCoreContext = flag;
+	// For convenience, it'll get reset later.
+	gl_extensions.IsCoreContext = useCoreContext;
 }

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -374,6 +374,12 @@ void CheckGLExtensions() {
 	gl_extensions.ARB_pixel_buffer_object = strstr(extString, "GL_ARB_pixel_buffer_object") != 0;
 	gl_extensions.NV_pixel_buffer_object = strstr(extString, "GL_NV_pixel_buffer_object") != 0;
 
+	if (!gl_extensions.IsGLES && gl_extensions.IsCoreContext) {
+		// These are required, and don't need to be specified by the driver (they aren't on Apple.)
+		gl_extensions.ARB_vertex_array_object = true;
+		gl_extensions.ARB_framebuffer_object = true;
+	}
+
 	ProcessGPUFeatures();
 
 	int error = glGetError();

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -379,6 +379,12 @@ void CheckGLExtensions() {
 		gl_extensions.ARB_vertex_array_object = true;
 		gl_extensions.ARB_framebuffer_object = true;
 	}
+#ifdef __APPLE__
+	if (!gl_extensions.IsGLES && !gl_extensions.IsCoreContext) {
+		// Apple doesn't allow OpenGL 3.x+ in compatibility contexts.
+		gl_extensions.ForceGL2 = true;
+	}
+#endif
 
 	ProcessGPUFeatures();
 

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -37,6 +37,7 @@ struct GLExtensions {
 	bool IsGLES;
 	bool IsCoreContext;
 	bool GLES3;  // true if the full OpenGL ES 3.0 is supported
+	bool ForceGL2;
 
 	// OES
 	bool OES_depth24;

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -103,3 +103,4 @@ extern std::string g_all_gl_extensions;
 extern std::string g_all_egl_extensions;
 
 void CheckGLExtensions();
+void SetGLCoreContext(bool flag);


### PR DESCRIPTION
This almost makes core profile (#8277) work.

What's left:
- Mac seems to want exact 1:1 glsl versions, e.g. OpenGL 3.2 needs 150.  `#version 130` fails.
- Had to basically add "#version 150\n#define varying in\n#define gl_FragColor fragColor0\n#define texture2D texture\nout vec4 fragColor0;\n" and "#version 150\n#define attribute in\n#define varying out\n" to all the thin3d and Framebuffer.cpp shaders, etc.  Not very elegant...
- Needs `glBindFragDataLocation` - didn't add yet since it needs the above.
- SDL_GL_SetAttribute needs uncommenting, and SetGLCoreContext.  Probably need to try multiple GL versions to find the right one.

Not sure what the best option is for the prolog... just use the defines?  Maybe have the `glsl_` funcs add it, and use a table to map the glsl version for < 3.3?  Seems kinda silly.

Anyway, with those things, games seem to run fine.  I didn't try many or verify that dual source blending was actually working, though.

-[Unknown]
