### PR TITLE
UI: Scale option text down when there's no space

### DIFF
--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -406,7 +406,7 @@ void TextDrawer::WrapString(std::string &out, const char *str, float maxW) {
 
 void TextDrawer::SetFontScale(float xscale, float yscale) {
 	fontScaleX_ = xscale;
-	fontScaleY_ = xscale;
+	fontScaleY_ = yscale;
 }
 
 void TextDrawer::DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) {

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -137,8 +137,10 @@ void UIContext::MeasureTextCount(const UI::FontStyle &style, const char *str, in
 		Draw()->SetFontScale(fontScaleX_ * sizeFactor, fontScaleY_ * sizeFactor);
 		Draw()->MeasureTextCount(style.atlasFont, str, count, x, y);
 	} else {
+		textDrawer_->SetFont(style.fontName.c_str(), style.sizePts, style.flags);
 		textDrawer_->SetFontScale(fontScaleX_, fontScaleY_);
 		textDrawer_->MeasureString(str, count, x, y);
+		textDrawer_->SetFont(fontStyle_->fontName.c_str(), fontStyle_->sizePts, fontStyle_->flags);
 	}
 }
 
@@ -153,8 +155,10 @@ void UIContext::MeasureTextRect(const UI::FontStyle &style, const char *str, int
 		Draw()->SetFontScale(fontScaleX_ * sizeFactor, fontScaleY_ * sizeFactor);
 		Draw()->MeasureTextRect(style.atlasFont, str, count, bounds, x, y, align);
 	} else {
+		textDrawer_->SetFont(style.fontName.c_str(), style.sizePts, style.flags);
 		textDrawer_->SetFontScale(fontScaleX_, fontScaleY_);
 		textDrawer_->MeasureStringRect(str, count, bounds, x, y, align);
+		textDrawer_->SetFont(fontStyle_->fontName.c_str(), fontStyle_->sizePts, fontStyle_->flags);
 	}
 }
 

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -365,9 +365,14 @@ void PopupMultiChoice::Draw(UIContext &dc) {
 	if (!IsEnabled()) {
 		style = dc.theme->itemDisabledStyle;
 	}
-	Choice::Draw(dc);
 	int paddingX = 12;
 	dc.SetFontStyle(dc.theme->uiFont);
+
+	float ignore;
+	dc.MeasureText(dc.theme->uiFont, valueText_.c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	textPadding_.right += paddingX;
+
+	Choice::Draw(dc);
 	dc.DrawText(valueText_.c_str(), bounds_.x2() - paddingX, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 }
 
@@ -419,15 +424,22 @@ void PopupSliderChoice::Draw(UIContext &dc) {
 	if (!IsEnabled()) {
 		style = dc.theme->itemDisabledStyle;
 	}
-	Choice::Draw(dc);
+	int paddingX = 12;
+	dc.SetFontStyle(dc.theme->uiFont);
+
 	char temp[32];
 	if (zeroLabel_.size() && *value_ == 0) {
 		strcpy(temp, zeroLabel_.c_str());
 	} else {
 		sprintf(temp, fmt_, *value_);
 	}
-	dc.SetFontStyle(dc.theme->uiFont);
-	dc.DrawText(temp, bounds_.x2() - 12, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
+
+	float ignore;
+	dc.MeasureText(dc.theme->uiFont, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	textPadding_.right += paddingX;
+
+	Choice::Draw(dc);
+	dc.DrawText(temp, bounds_.x2() - paddingX, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 }
 
 EventReturn PopupSliderChoiceFloat::HandleClick(EventParams &e) {
@@ -454,15 +466,22 @@ void PopupSliderChoiceFloat::Draw(UIContext &dc) {
 	if (!IsEnabled()) {
 		style = dc.theme->itemDisabledStyle;
 	}
-	Choice::Draw(dc);
+	int paddingX = 12;
+	dc.SetFontStyle(dc.theme->uiFont);
+
 	char temp[32];
 	if (zeroLabel_.size() && *value_ == 0.0f) {
 		strcpy(temp, zeroLabel_.c_str());
 	} else {
 		sprintf(temp, fmt_, *value_);
 	}
-	dc.SetFontStyle(dc.theme->uiFont);
-	dc.DrawText(temp, bounds_.x2() - 12, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
+
+	float ignore;
+	dc.MeasureText(dc.theme->uiFont, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	textPadding_.right += paddingX;
+
+	Choice::Draw(dc);
+	dc.DrawText(temp, bounds_.x2() - paddingX, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 }
 
 EventReturn SliderPopupScreen::OnDecrease(EventParams &params) {
@@ -644,8 +663,14 @@ void PopupTextInputChoice::Draw(UIContext &dc) {
 	if (!IsEnabled()) {
 		style = dc.theme->itemDisabledStyle;
 	}
-	Choice::Draw(dc);
+	int paddingX = 12;
 	dc.SetFontStyle(dc.theme->uiFont);
+
+	float ignore;
+	dc.MeasureText(dc.theme->uiFont, value_->c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	textPadding_.right += paddingX;
+
+	Choice::Draw(dc);
 	dc.DrawText(value_->c_str(), bounds_.x2() - 12, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 }
 
@@ -683,12 +708,14 @@ void TextEditPopupScreen::OnCompleted(DialogResult result) {
 
 void ChoiceWithValueDisplay::Draw(UIContext &dc) {
 	Style style = dc.theme->itemStyle;
-	std::ostringstream valueText;
-	Choice::Draw(dc);
+	if (!IsEnabled()) {
+		style = dc.theme->itemDisabledStyle;
+	}
+	int paddingX = 12;
 	dc.SetFontStyle(dc.theme->uiFont);
 
 	I18NCategory *category = GetI18NCategory(category_);
-
+	std::ostringstream valueText;
 	if (sValue_ != nullptr) {
 		if (category)
 			valueText << category->T(*sValue_);
@@ -698,7 +725,12 @@ void ChoiceWithValueDisplay::Draw(UIContext &dc) {
 		valueText << *iValue_;
 	}
 
-	dc.DrawText(valueText.str().c_str(), bounds_.x2() - 12, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
+	float ignore;
+	dc.MeasureText(dc.theme->uiFont, valueText.str().c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	textPadding_.right += paddingX;
+
+	Choice::Draw(dc);
+	dc.DrawText(valueText.str().c_str(), bounds_.x2() - paddingX, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 }
 
 }  // namespace UI

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -273,6 +273,13 @@ struct Margins {
 	Margins(int8_t horiz, int8_t vert) : top(vert), bottom(vert), left(horiz), right(horiz) {}
 	Margins(int8_t l, int8_t t, int8_t r, int8_t b) : top(t), bottom(b), left(l), right(r) {}
 
+	int horiz() {
+		return left + right;
+	}
+	int vert() {
+		return top + bottom;
+	}
+
 	int8_t top;
 	int8_t bottom;
 	int8_t left;

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -286,6 +286,25 @@ struct Margins {
 	int8_t right;
 };
 
+struct Padding {
+	Padding() : top(0), bottom(0), left(0), right(0) {}
+	explicit Padding(float all) : top(all), bottom(all), left(all), right(all) {}
+	Padding(float horiz, float vert) : top(vert), bottom(vert), left(horiz), right(horiz) {}
+	Padding(float l, float t, float r, float b) : top(t), bottom(b), left(l), right(r) {}
+
+	float horiz() {
+		return left + right;
+	}
+	float vert() {
+		return top + bottom;
+	}
+
+	float top;
+	float bottom;
+	float left;
+	float right;
+};
+
 enum LayoutParamsType {
 	LP_PLAIN = 0,
 	LP_LINEAR = 1,
@@ -602,11 +621,11 @@ protected:
 	// hackery
 	virtual bool IsSticky() const { return false; }
 
-	int height_;
 	std::string text_;
 	std::string smallText_;
 	ImageID atlasImage_;
 	ImageID iconImage_;  // Only applies for text, non-centered
+	Padding textPadding_;
 	bool centered_;
 	bool highlighted_;
 

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -424,20 +424,20 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 			MeasureSpec v = vert;
 			if (v.type == UNSPECIFIED && measuredHeight_ != 0.0)
 				v = MeasureSpec(AT_MOST, measuredHeight_);
-			views_[i]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v - (float)(margins.top + margins.bottom));
+			views_[i]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v - (float)margins.vert());
 		} else if (orientation_ == ORIENT_VERTICAL) {
 			MeasureSpec h = horiz;
 			if (h.type == UNSPECIFIED && measuredWidth_ != 0) h = MeasureSpec(AT_MOST, measuredWidth_);
-			views_[i]->Measure(dc, h - (float)(margins.left + margins.right), MeasureSpec(UNSPECIFIED, measuredHeight_));
+			views_[i]->Measure(dc, h - (float)margins.horiz(), MeasureSpec(UNSPECIFIED, measuredHeight_));
 		}
 
 		float amount;
 		if (orientation_ == ORIENT_HORIZONTAL) {
-			amount = views_[i]->GetMeasuredWidth() + margins.left + margins.right;
-			maxOther = std::max(maxOther, views_[i]->GetMeasuredHeight() + margins.top + margins.bottom);
+			amount = views_[i]->GetMeasuredWidth() + margins.horiz();
+			maxOther = std::max(maxOther, views_[i]->GetMeasuredHeight() + margins.vert());
 		} else {
-			amount = views_[i]->GetMeasuredHeight() + margins.top + margins.bottom;
-			maxOther = std::max(maxOther, views_[i]->GetMeasuredWidth() + margins.left + margins.right);
+			amount = views_[i]->GetMeasuredHeight() + margins.vert();
+			maxOther = std::max(maxOther, views_[i]->GetMeasuredWidth() + margins.horiz());
 		}
 
 		sum += amount;
@@ -478,15 +478,14 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 				Margins margins = defaultMargins_;
 				if (linLayoutParams->HasMargins())
 					margins = linLayoutParams->margins;
-				int marginSum = margins.left + margins.right;
 				MeasureSpec v = vert;
 				if (v.type == UNSPECIFIED && measuredHeight_ != 0.0)
 					v = MeasureSpec(AT_MOST, measuredHeight_);
-				MeasureSpec h(AT_MOST, unit * linLayoutParams->weight - marginSum);
+				MeasureSpec h(AT_MOST, unit * linLayoutParams->weight - margins.horiz());
 				if (horiz.type == EXACTLY) {
 					h.type = EXACTLY;
 				}
-				views_[i]->Measure(dc, h, v - (float)(margins.top + margins.bottom));
+				views_[i]->Measure(dc, h, v - (float)margins.vert());
 				usedWidth += views_[i]->GetMeasuredWidth();
 			}
 		}
@@ -517,15 +516,14 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 				Margins margins = defaultMargins_;
 				if (linLayoutParams->HasMargins())
 					margins = linLayoutParams->margins;
-				int marginSum = margins.top + margins.bottom;
 				MeasureSpec h = horiz;
 				if (h.type == UNSPECIFIED && measuredWidth_ != 0.0)
 					h = MeasureSpec(AT_MOST, measuredWidth_);
-				MeasureSpec v(AT_MOST, unit * linLayoutParams->weight - marginSum);
+				MeasureSpec v(AT_MOST, unit * linLayoutParams->weight - margins.vert());
 				if (vert.type == EXACTLY) {
 					v.type = EXACTLY;
 				}
-				views_[i]->Measure(dc, h - (float)(margins.left + margins.right), v);
+				views_[i]->Measure(dc, h - (float)margins.horiz(), v);
 				usedHeight += views_[i]->GetMeasuredHeight();
 			}
 		}
@@ -569,10 +567,10 @@ void LinearLayout::Layout() {
 
 		if (orientation_ == ORIENT_HORIZONTAL) {
 			itemBounds.x = pos;
-			itemBounds.w = views_[i]->GetMeasuredWidth() + margins.left + margins.right;
+			itemBounds.w = views_[i]->GetMeasuredWidth() + margins.horiz();
 		} else {
 			itemBounds.y = pos;
-			itemBounds.h = views_[i]->GetMeasuredHeight() + margins.top + margins.bottom;
+			itemBounds.h = views_[i]->GetMeasuredHeight() + margins.vert();
 		}
 
 		Bounds innerBounds;
@@ -637,7 +635,7 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED), MeasureSpec(UNSPECIFIED));
 			MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		} else {
-			views_[0]->Measure(dc, MeasureSpec(AT_MOST, measuredWidth_ - (margins.left + margins.right)), MeasureSpec(UNSPECIFIED));
+			views_[0]->Measure(dc, MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz()), MeasureSpec(UNSPECIFIED));
 			MeasureBySpec(layoutParams_->width, views_[0]->GetMeasuredWidth(), horiz, &measuredWidth_);
 		}
 		if (orientation_ == ORIENT_VERTICAL && vert.type != EXACTLY) {
@@ -666,8 +664,8 @@ void ScrollView::Layout() {
 		margins = linLayoutParams->margins;
 	}
 
-	scrolled.w = views_[0]->GetMeasuredWidth() - (margins.left + margins.right);
-	scrolled.h = views_[0]->GetMeasuredHeight() - (margins.top + margins.bottom);
+	scrolled.w = views_[0]->GetMeasuredWidth() - margins.horiz();
+	scrolled.h = views_[0]->GetMeasuredHeight() - margins.vert();
 
 	float layoutScrollPos = ClampedScrollPos(scrollPos_);
 


### PR DESCRIPTION
This way, smaller or portrait screens just get smaller text, rather than jumbled text going off the side.  Particularly important for some translations.

See #8136 (went with 80% which is already pretty small.)  This should be familiar to mobile users since it's done automatically by web browsers in some cases, as well as some other apps.

-[Unknown]
