### PR TITLE
Wrap text in many places where it makes sense

### DIFF
--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -66,17 +66,23 @@ void GameScreen::CreateViews() {
 	leftColumn->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameScreen::OnSwitchBack);
 	if (info) {
 		texvGameIcon_ = leftColumn->Add(new Thin3DTextureView(0, IS_DEFAULT, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
-		tvTitle_ = leftColumn->Add(new TextView(info->GetTitle(), ALIGN_LEFT, false, new AnchorLayoutParams(10, 200, NONE, NONE)));
+
+		LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));
+		leftColumn->Add(infoLayout);
+
+		tvTitle_ = infoLayout->Add(new TextView(info->GetTitle(), ALIGN_LEFT | FLAG_WRAP_TEXT, false, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvTitle_->SetShadow(true);
+		infoLayout->Add(new Spacer(12));
 		// This one doesn't need to be updated.
-		leftColumn->Add(new TextView(gamePath_, ALIGN_LEFT, true, new AnchorLayoutParams(10, 250, NONE, NONE)))->SetShadow(true);
-		tvGameSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, true, new AnchorLayoutParams(10, 290, NONE, NONE)));
+		infoLayout->Add(new TextView(gamePath_, ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetShadow(true);
+		tvGameSize_ = infoLayout->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvGameSize_->SetShadow(true);
-		tvSaveDataSize_ = leftColumn->Add(new TextView("...", ALIGN_LEFT, true, new AnchorLayoutParams(10, 320, NONE, NONE)));
+		tvSaveDataSize_ = infoLayout->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvSaveDataSize_->SetShadow(true);
-		tvInstallDataSize_ = leftColumn->Add(new TextView("", ALIGN_LEFT, true, new AnchorLayoutParams(10, 350, NONE, NONE)));
+		tvInstallDataSize_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvInstallDataSize_->SetShadow(true);
-		tvRegion_ = leftColumn->Add(new TextView("", ALIGN_LEFT, true, new AnchorLayoutParams(10, 380, NONE, NONE)));
+		tvInstallDataSize_->SetVisibility(V_GONE);
+		tvRegion_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvRegion_->SetShadow(true);
 	} else {
 		texvGameIcon_ = nullptr;
@@ -208,6 +214,7 @@ void GameScreen::update(InputState &input) {
 		if (info->installDataSize > 0) {
 			sprintf(temp, "%s: %1.2f %s", ga->T("InstallData"), (float) (info->installDataSize) / 1024.f / 1024.f, ga->T("MB"));
 			tvInstallDataSize_->SetText(temp);
+			tvInstallDataSize_->SetVisibility(UI::V_VISIBLE);
 		}
 	}
 

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -44,6 +44,8 @@ protected:
 	bool isRecentGame(const std::string &gamePath);
 
 private:
+	UI::Choice *AddOtherChoice(UI::Choice *choice);
+
 	// Event handlers
 	UI::EventReturn OnPlay(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
@@ -64,4 +66,10 @@ private:
 	UI::TextView *tvSaveDataSize_;
 	UI::TextView *tvInstallDataSize_;
 	UI::TextView *tvRegion_;
+
+	UI::Choice *btnGameSettings_;
+	UI::Choice *btnCreateGameConfig_;
+	UI::Choice *btnDeleteGameConfig_;
+	UI::Choice *btnDeleteSaveData_;
+	std::vector<UI::Choice *> otherChoices_;
 };

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -284,7 +284,7 @@ void GameButton::Draw(UIContext &dc) {
 			title_ = ReplaceAll(title_, "\n", " ");
 		}
 
-		dc.MeasureText(dc.GetFontStyle(), title_.c_str(), &tw, &th, 0);
+		dc.MeasureText(dc.GetFontStyle(), 1.0f, 1.0f, title_.c_str(), &tw, &th, 0);
 
 		int availableWidth = bounds_.w - 150;
 		float sineWidth = std::max(0.0f, (tw - availableWidth)) / 2.0f;
@@ -367,7 +367,7 @@ void DirButton::Draw(UIContext &dc) {
 	}
 	
 	float tw, th;
-	dc.MeasureText(dc.GetFontStyle(), text.c_str(), &tw, &th, 0);
+	dc.MeasureText(dc.GetFontStyle(), 1.0f, 1.0f, text.c_str(), &tw, &th, 0);
 
 	bool compact = bounds_.w < 180;
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -484,15 +484,14 @@ void GameBrowser::Refresh() {
 		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		if (allowBrowsing_) {
 			topBar->Add(new Spacer(2.0f));
-			Margins pathMargins(5, 0);
-			topBar->Add(new TextView(path_.GetFriendlyPath().c_str(), ALIGN_VCENTER, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
+			topBar->Add(new TextView(path_.GetFriendlyPath().c_str(), ALIGN_VCENTER, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
 #if defined(_WIN32) || defined(USING_QT_UI)
-			topBar->Add(new Choice(mm->T("Browse", "Browse...")))->OnClick.Handle(this, &GameBrowser::HomeClick);
+			topBar->Add(new Choice(mm->T("Browse", "Browse..."), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::HomeClick);
 #else
-			topBar->Add(new Choice(mm->T("Home")))->OnClick.Handle(this, &GameBrowser::HomeClick);
+			topBar->Add(new Choice(mm->T("Home"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::HomeClick);
 #endif
 		} else {
-			topBar->Add(new Spacer(new LinearLayoutParams(1.0f)));
+			topBar->Add(new Spacer(new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
 		}
 
 		ChoiceStrip *layoutChoice = topBar->Add(new ChoiceStrip(ORIENT_HORIZONTAL));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -484,7 +484,7 @@ void GameBrowser::Refresh() {
 		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		if (allowBrowsing_) {
 			topBar->Add(new Spacer(2.0f));
-			topBar->Add(new TextView(path_.GetFriendlyPath().c_str(), ALIGN_VCENTER, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
+			topBar->Add(new TextView(path_.GetFriendlyPath().c_str(), ALIGN_VCENTER | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
 #if defined(_WIN32) || defined(USING_QT_UI)
 			topBar->Add(new Choice(mm->T("Browse", "Browse..."), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::HomeClick);
 #else

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -16,7 +16,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 
 	// Get height
 	float w, h;
-	dc.MeasureText(dc.theme->uiFont, "Wg", &w, &h);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, "Wg", &w, &h);
 
 	float y = 10.0f;
 	// Then draw them all. 
@@ -27,7 +27,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 		if (alpha < 0.0) alpha = 0.0f;
 		// Messages that are wider than the screen are left-aligned instead of centered.
 		float tw, th;
-		dc.MeasureText(dc.theme->uiFont, iter->text.c_str(), &tw, &th);
+		dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, iter->text.c_str(), &tw, &th);
 		float x = bounds_.centerX();
 		int align = ALIGN_TOP | ALIGN_HCENTER;
 		if (tw > bounds_.w) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -51,20 +51,28 @@ std::string GetFileDateAsString(std::string filename) {
 	return "";
 }
 
+static std::string TrimString(const std::string &str) {
+	size_t pos = str.find_last_not_of(" \r\n\t");
+	if (pos != str.npos) {
+		return str.substr(0, pos + 1);
+	}
+	return str;
+}
+
 class SavedataPopupScreen : public PopupScreen {
 public:
-	SavedataPopupScreen(std::string savePath, std::string title) : PopupScreen(title), savePath_(savePath) {
+	SavedataPopupScreen(std::string savePath, std::string title) : PopupScreen(TrimString(title)), savePath_(savePath) {
 	}
 
 	void CreatePopupContents(UI::ViewGroup *parent) override {
 		using namespace UI;
 		GameInfo *ginfo = g_gameInfoCache->GetInfo(screenManager()->getThin3DContext(), savePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
-		LinearLayout *root = new LinearLayout(ORIENT_VERTICAL);
-		parent->Add(root);
+		LinearLayout *content = new LinearLayout(ORIENT_VERTICAL);
+		parent->Add(content);
 		if (!ginfo)
 			return;
 		LinearLayout *toprow = new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
-		root->Add(toprow);
+		content->Add(toprow);
 
 		I18NCategory *sa = GetI18NCategory("Savedata");
 		if (ginfo->fileType == FILETYPE_PSP_SAVEDATA_DIRECTORY) {
@@ -74,15 +82,15 @@ public:
 			if (ginfo->iconTexture) {
 				toprow->Add(new Thin3DTextureView(ginfo->iconTexture, IS_FIXED, new LinearLayoutParams(Margins(10, 5))));
 			}
-			LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
+			LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f));
 			topright->SetSpacing(1.0f);
-			topright->Add(new TextView(savedata_title, 0, false));
+			topright->Add(new TextView(savedata_title, ALIGN_LEFT | FLAG_WRAP_TEXT, false));
 			topright->Add(new TextView(StringFromFormat("%d kB", ginfo->gameSize / 1024), 0, true));
 			topright->Add(new TextView(GetFileDateAsString(savePath_ + "/PARAM.SFO"), 0, true));
 			toprow->Add(topright);
-			root->Add(new Spacer(3.0));
-			root->Add(new TextView(savedata_detail, 0, true, new LinearLayoutParams(Margins(10, 0))));
-			root->Add(new Spacer(3.0));
+			content->Add(new Spacer(3.0));
+			content->Add(new TextView(ReplaceAll(savedata_detail, "\r", ""), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(Margins(10, 0))));
+			content->Add(new Spacer(3.0));
 		} else {
 			std::string image_path = ReplaceAll(savePath_, ".ppst", ".jpg");
 			if (File::Exists(image_path)) {
@@ -91,14 +99,14 @@ public:
 			} else {
 				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))));
 			}
-			root->Add(new TextView(GetFileDateAsString(savePath_), 0, true, new LinearLayoutParams(Margins(10, 5))));
+			content->Add(new TextView(GetFileDateAsString(savePath_), 0, true, new LinearLayoutParams(Margins(10, 5))));
 		}
 
 		I18NCategory *di = GetI18NCategory("Dialog");
 		LinearLayout *buttons = new LinearLayout(ORIENT_HORIZONTAL);
 		buttons->Add(new Button(di->T("Back"), new LinearLayoutParams(1.0)))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 		buttons->Add(new Button(di->T("Delete"), new LinearLayoutParams(1.0)))->OnClick.Handle(this, &SavedataPopupScreen::OnDeleteButtonClick);
-		root->Add(buttons);
+		content->Add(buttons);
 	}
 
 protected:

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -251,7 +251,7 @@ void SavedataButton::Draw(UIContext &dc) {
 		subtitle_ = CleanSaveString(savedata_title) + StringFromFormat(" (%d kB)", ginfo->gameSize / 1024);
 	}
 
-	dc.MeasureText(dc.GetFontStyle(), title_.c_str(), &tw, &th, 0);
+	dc.MeasureText(dc.GetFontStyle(), 1.0f, 1.0f, title_.c_str(), &tw, &th, 0);
 
 	int availableWidth = bounds_.w - 150;
 	float sineWidth = std::max(0.0f, (tw - availableWidth)) / 2.0f;

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -145,11 +145,6 @@ void UIContext::MeasureTextCount(const UI::FontStyle &style, float scaleX, float
 }
 
 void UIContext::MeasureTextRect(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, int count, const Bounds &bounds, float *x, float *y, int align) const {
-	if ((align & FLAG_WRAP_TEXT) == 0) {
-		MeasureTextCount(style, scaleX, scaleY, str, count, x, y, align);
-		return;
-	}
-
 	if (!textDrawer_ || (align & FLAG_DYNAMIC_ASCII)) {
 		float sizeFactor = (float)style.sizePts / 24.0f;
 		Draw()->SetFontScale(scaleX * sizeFactor, scaleY * sizeFactor);

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -127,36 +127,36 @@ void UIContext::SetFontStyle(const UI::FontStyle &fontStyle) {
 	}
 }
 
-void UIContext::MeasureText(const UI::FontStyle &style, const char *str, float *x, float *y, int align) const {
-	MeasureTextCount(style, str, (int)strlen(str), x, y, align);
+void UIContext::MeasureText(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, float *x, float *y, int align) const {
+	MeasureTextCount(style, scaleX, scaleY, str, (int)strlen(str), x, y, align);
 }
 
-void UIContext::MeasureTextCount(const UI::FontStyle &style, const char *str, int count, float *x, float *y, int align) const {
+void UIContext::MeasureTextCount(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, int count, float *x, float *y, int align) const {
 	if (!textDrawer_ || (align & FLAG_DYNAMIC_ASCII)) {
 		float sizeFactor = (float)style.sizePts / 24.0f;
-		Draw()->SetFontScale(fontScaleX_ * sizeFactor, fontScaleY_ * sizeFactor);
+		Draw()->SetFontScale(scaleX * sizeFactor, scaleY * sizeFactor);
 		Draw()->MeasureTextCount(style.atlasFont, str, count, x, y);
 	} else {
 		textDrawer_->SetFont(style.fontName.c_str(), style.sizePts, style.flags);
-		textDrawer_->SetFontScale(fontScaleX_, fontScaleY_);
+		textDrawer_->SetFontScale(scaleX, scaleY);
 		textDrawer_->MeasureString(str, count, x, y);
 		textDrawer_->SetFont(fontStyle_->fontName.c_str(), fontStyle_->sizePts, fontStyle_->flags);
 	}
 }
 
-void UIContext::MeasureTextRect(const UI::FontStyle &style, const char *str, int count, const Bounds &bounds, float *x, float *y, int align) const {
+void UIContext::MeasureTextRect(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, int count, const Bounds &bounds, float *x, float *y, int align) const {
 	if ((align & FLAG_WRAP_TEXT) == 0) {
-		MeasureTextCount(style, str, count, x, y, align);
+		MeasureTextCount(style, scaleX, scaleY, str, count, x, y, align);
 		return;
 	}
 
 	if (!textDrawer_ || (align & FLAG_DYNAMIC_ASCII)) {
 		float sizeFactor = (float)style.sizePts / 24.0f;
-		Draw()->SetFontScale(fontScaleX_ * sizeFactor, fontScaleY_ * sizeFactor);
+		Draw()->SetFontScale(scaleX * sizeFactor, scaleY * sizeFactor);
 		Draw()->MeasureTextRect(style.atlasFont, str, count, bounds, x, y, align);
 	} else {
 		textDrawer_->SetFont(style.fontName.c_str(), style.sizePts, style.flags);
-		textDrawer_->SetFontScale(fontScaleX_, fontScaleY_);
+		textDrawer_->SetFontScale(scaleX, scaleY);
 		textDrawer_->MeasureStringRect(str, count, bounds, x, y, align);
 		textDrawer_->SetFont(fontStyle_->fontName.c_str(), fontStyle_->sizePts, fontStyle_->flags);
 	}

--- a/ext/native/ui/ui_context.h
+++ b/ext/native/ui/ui_context.h
@@ -59,9 +59,9 @@ public:
 	void SetFontStyle(const UI::FontStyle &style);
 	const UI::FontStyle &GetFontStyle() { return *fontStyle_; }
 	void SetFontScale(float scaleX, float scaleY);
-	void MeasureTextCount(const UI::FontStyle &style, const char *str, int count, float *x, float *y, int align = 0) const;
-	void MeasureText(const UI::FontStyle &style, const char *str, float *x, float *y, int align = 0) const;
-	void MeasureTextRect(const UI::FontStyle &style, const char *str, int count, const Bounds &bounds, float *x, float *y, int align = 0) const;
+	void MeasureTextCount(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, int count, float *x, float *y, int align = 0) const;
+	void MeasureText(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, float *x, float *y, int align = 0) const;
+	void MeasureTextRect(const UI::FontStyle &style, float scaleX, float scaleY, const char *str, int count, const Bounds &bounds, float *x, float *y, int align = 0) const;
 	void DrawText(const char *str, float x, float y, uint32_t color, int align = 0);
 	void DrawTextShadow(const char *str, float x, float y, uint32_t color, int align = 0);
 	void DrawTextRect(const char *str, const Bounds &bounds, uint32_t color, int align = 0);

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -369,7 +369,7 @@ void PopupMultiChoice::Draw(UIContext &dc) {
 	dc.SetFontStyle(dc.theme->uiFont);
 
 	float ignore;
-	dc.MeasureText(dc.theme->uiFont, valueText_.c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, valueText_.c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
 	textPadding_.right += paddingX;
 
 	Choice::Draw(dc);
@@ -435,7 +435,7 @@ void PopupSliderChoice::Draw(UIContext &dc) {
 	}
 
 	float ignore;
-	dc.MeasureText(dc.theme->uiFont, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
 	textPadding_.right += paddingX;
 
 	Choice::Draw(dc);
@@ -477,7 +477,7 @@ void PopupSliderChoiceFloat::Draw(UIContext &dc) {
 	}
 
 	float ignore;
-	dc.MeasureText(dc.theme->uiFont, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, temp, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
 	textPadding_.right += paddingX;
 
 	Choice::Draw(dc);
@@ -667,7 +667,7 @@ void PopupTextInputChoice::Draw(UIContext &dc) {
 	dc.SetFontStyle(dc.theme->uiFont);
 
 	float ignore;
-	dc.MeasureText(dc.theme->uiFont, value_->c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, value_->c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
 	textPadding_.right += paddingX;
 
 	Choice::Draw(dc);
@@ -726,7 +726,7 @@ void ChoiceWithValueDisplay::Draw(UIContext &dc) {
 	}
 
 	float ignore;
-	dc.MeasureText(dc.theme->uiFont, valueText.str().c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, valueText.str().c_str(), &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER);
 	textPadding_.right += paddingX;
 
 	Choice::Draw(dc);

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -313,6 +313,14 @@ UI::EventReturn ListPopupScreen::OnListChoice(UI::EventParams &e) {
 
 namespace UI {
 
+std::string ChopTitle(const std::string &title) {
+	size_t pos = title.find('\n');
+	if (pos != title.npos) {
+		return title.substr(0, pos);
+	}
+	return title;
+}
+
 UI::EventReturn PopupMultiChoice::HandleClick(UI::EventParams &e) {
 	restoreFocus_ = HasFocus();
 
@@ -323,7 +331,7 @@ UI::EventReturn PopupMultiChoice::HandleClick(UI::EventParams &e) {
 		choices.push_back(category ? category->T(choices_[i]) : choices_[i]);
 	}
 
-	ListPopupScreen *popupScreen = new ListPopupScreen(text_, choices, *value_ - minVal_,
+	ListPopupScreen *popupScreen = new ListPopupScreen(ChopTitle(text_), choices, *value_ - minVal_,
 		std::bind(&PopupMultiChoice::ChoiceCallback, this, placeholder::_1));
 	popupScreen->SetHiddenChoices(hidden_);
 	screenManager_->push(popupScreen);
@@ -403,7 +411,7 @@ PopupSliderChoiceFloat::PopupSliderChoiceFloat(float *value, float minValue, flo
 EventReturn PopupSliderChoice::HandleClick(EventParams &e) {
 	restoreFocus_ = HasFocus();
 
-	SliderPopupScreen *popupScreen = new SliderPopupScreen(value_, minValue_, maxValue_, text_, step_, units_);
+	SliderPopupScreen *popupScreen = new SliderPopupScreen(value_, minValue_, maxValue_, ChopTitle(text_), step_, units_);
 	popupScreen->OnChange.Handle(this, &PopupSliderChoice::HandleChange);
 	screenManager_->push(popupScreen);
 	return EVENT_DONE;
@@ -445,7 +453,7 @@ void PopupSliderChoice::Draw(UIContext &dc) {
 EventReturn PopupSliderChoiceFloat::HandleClick(EventParams &e) {
 	restoreFocus_ = HasFocus();
 
-	SliderFloatPopupScreen *popupScreen = new SliderFloatPopupScreen(value_, minValue_, maxValue_, text_, step_, units_);
+	SliderFloatPopupScreen *popupScreen = new SliderFloatPopupScreen(value_, minValue_, maxValue_, ChopTitle(text_), step_, units_);
 	popupScreen->OnChange.Handle(this, &PopupSliderChoiceFloat::HandleChange);
 	screenManager_->push(popupScreen);
 	return EVENT_DONE;
@@ -652,7 +660,7 @@ PopupTextInputChoice::PopupTextInputChoice(std::string *value, const std::string
 EventReturn PopupTextInputChoice::HandleClick(EventParams &e) {
 	restoreFocus_ = HasFocus();
 
-	TextEditPopupScreen *popupScreen = new TextEditPopupScreen(value_, placeHolder_, text_, maxLen_);
+	TextEditPopupScreen *popupScreen = new TextEditPopupScreen(value_, placeHolder_, ChopTitle(text_), maxLen_);
 	popupScreen->OnChange.Handle(this, &PopupTextInputChoice::HandleChange);
 	screenManager_->push(popupScreen);
 	return EVENT_DONE;

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -443,7 +443,7 @@ void Choice::GetContentDimensions(const UIContext &dc, float &w, float &h) const
 		w = img.w;
 		h = img.h;
 	} else {
-		dc.MeasureText(dc.theme->uiFont, text_.c_str(), &w, &h);
+		dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), &w, &h);
 	}
 	w += 24;
 	h += 16;
@@ -485,7 +485,7 @@ void Choice::Draw(UIContext &dc) {
 		float scale = 1.0f;
 
 		float actualWidth, actualHeight;
-		dc.MeasureText(dc.theme->uiFont, text_.c_str(), &actualWidth, &actualHeight, ALIGN_VCENTER);
+		dc.MeasureText(dc.theme->uiFont, scale, scale, text_.c_str(), &actualWidth, &actualHeight, ALIGN_VCENTER);
 		if (actualWidth > availWidth) {
 			scale = std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
 		}
@@ -541,7 +541,7 @@ void PopupHeader::Draw(UIContext &dc) {
 
 	float tw, th;
 	dc.SetFontStyle(dc.theme->uiFont);
-	dc.MeasureText(dc.GetFontStyle(), text_.c_str(), &tw, &th, 0);
+	dc.MeasureText(dc.GetFontStyle(), 1.0f, 1.0f, text_.c_str(), &tw, &th, 0);
 
 	float sineWidth = std::max(0.0f, (tw - availableWidth)) / 2.0f;
 
@@ -591,7 +591,7 @@ void CheckBox::Draw(UIContext &dc) {
 	float scale = 1.0f;
 
 	float actualWidth, actualHeight;
-	dc.MeasureText(dc.theme->uiFont, text_.c_str(), &actualWidth, &actualHeight, ALIGN_VCENTER);
+	dc.MeasureText(dc.theme->uiFont, scale, scale, text_.c_str(), &actualWidth, &actualHeight, ALIGN_VCENTER);
 	if (actualWidth > availWidth) {
 		scale = std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
 	}
@@ -608,7 +608,7 @@ void Button::GetContentDimensions(const UIContext &dc, float &w, float &h) const
 		w = img->w;
 		h = img->h;
 	} else {
-		dc.MeasureText(dc.theme->uiFont, text_.c_str(), &w, &h);
+		dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), &w, &h);
 	}
 	// Add some internal padding to not look totally ugly
 	w += 16;
@@ -625,7 +625,7 @@ void Button::Draw(UIContext &dc) {
 	// dc.Draw()->DrawImage4Grid(style.image, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y2(), style.bgColor);
 	dc.FillRect(style.background, bounds_);
 	float tw, th;
-	dc.MeasureText(dc.theme->uiFont, text_.c_str(), &tw, &th);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), &tw, &th);
 	if (tw > bounds_.w || imageID_ != -1) {
 		dc.PushScissor(bounds_);
 	}
@@ -690,7 +690,7 @@ void TextView::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz
 		bounds.h = vert.size == 0 ? 1000.f : vert.size;
 	}
 	ApplyBoundsBySpec(bounds, horiz, vert);
-	dc.MeasureTextRect(small_ ? dc.theme->uiFontSmall : dc.theme->uiFont, text_.c_str(), (int)text_.length(), bounds, &w, &h, textAlign_);
+	dc.MeasureTextRect(small_ ? dc.theme->uiFontSmall : dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), (int)text_.length(), bounds, &w, &h, textAlign_);
 }
 
 void TextView::Draw(UIContext &dc) {
@@ -749,7 +749,7 @@ void TextEdit::Draw(UIContext &dc) {
 
 	if (HasFocus()) {
 		// Hack to find the caret position. Might want to find a better way...
-		dc.MeasureTextCount(dc.theme->uiFont, text_.c_str(), caret_, &w, &h, ALIGN_VCENTER | ALIGN_LEFT);
+		dc.MeasureTextCount(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), caret_, &w, &h, ALIGN_VCENTER | ALIGN_LEFT);
 		float caretX = w;
 		caretX += textX;
 
@@ -763,7 +763,7 @@ void TextEdit::Draw(UIContext &dc) {
 }
 
 void TextEdit::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
-	dc.MeasureText(dc.theme->uiFont, text_.size() ? text_.c_str() : "Wj", &w, &h);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, text_.size() ? text_.c_str() : "Wj", &w, &h);
 	w += 2;
 	h += 2;
 }
@@ -932,7 +932,7 @@ void TextEdit::InsertAtCaret(const char *text) {
 }
 
 void ProgressBar::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
-	dc.MeasureText(dc.theme->uiFont, "  100%  ", &w, &h);
+	dc.MeasureText(dc.theme->uiFont, 1.0f, 1.0f, "  100%  ", &w, &h);
 }
 
 void ProgressBar::Draw(UIContext &dc) {

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -388,6 +388,7 @@ public:
 
 	// Override this for easy standard behaviour. No need to override Measure.
 	virtual void GetContentDimensions(const UIContext &dc, float &w, float &h) const;
+	virtual void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const;
 
 	// Called when the layout is done.
 	void SetBounds(Bounds bounds) { bounds_ = bounds; }
@@ -742,7 +743,7 @@ public:
 	TextView(const std::string &text, int textAlign, bool small, LayoutParams *layoutParams = 0)
 		: InertView(layoutParams), text_(text), textAlign_(textAlign), textColor_(0xFFFFFFFF), small_(small), shadow_(false), focusable_(false), clip_(true) {}
 
-	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 
 	void SetText(const std::string &text) { text_ = text; }

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -273,10 +273,10 @@ struct Margins {
 	Margins(int8_t horiz, int8_t vert) : top(vert), bottom(vert), left(horiz), right(horiz) {}
 	Margins(int8_t l, int8_t t, int8_t r, int8_t b) : top(t), bottom(b), left(l), right(r) {}
 
-	int horiz() {
+	int horiz() const {
 		return left + right;
 	}
-	int vert() {
+	int vert() const {
 		return top + bottom;
 	}
 
@@ -292,10 +292,10 @@ struct Padding {
 	Padding(float horiz, float vert) : top(vert), bottom(vert), left(horiz), right(horiz) {}
 	Padding(float l, float t, float r, float b) : top(t), bottom(b), left(l), right(r) {}
 
-	float horiz() {
+	float horiz() const {
 		return left + right;
 	}
-	float vert() {
+	float vert() const {
 		return top + bottom;
 	}
 
@@ -609,7 +609,7 @@ public:
 		: ClickableItem(layoutParams), atlasImage_(image), iconImage_(-1), centered_(false), highlighted_(false), selected_(false) {}
 
 	virtual void HighlightChanged(bool highlighted);
-	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 	virtual void SetCentered(bool c) {
 		centered_ = c;
@@ -621,6 +621,7 @@ public:
 protected:
 	// hackery
 	virtual bool IsSticky() const { return false; }
+	virtual float CalculateTextScale(const UIContext &dc, float availWidth) const;
 
 	std::string text_;
 	std::string smallText_;
@@ -709,11 +710,14 @@ public:
 	}
 
 	void Draw(UIContext &dc) override;
+	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 
 	EventReturn OnClicked(EventParams &e);
 	//allow external agents to toggle the checkbox
 	void Toggle();
 private:
+	float CalculateTextScale(const UIContext &dc, float availWidth) const;
+
 	bool *toggle_;
 	std::string text_;
 	std::string smallText_;

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -632,7 +632,7 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 
 	if (views_.size()) {
 		if (orientation_ == ORIENT_HORIZONTAL) {
-			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED), MeasureSpec(UNSPECIFIED));
+			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED), MeasureSpec(AT_MOST, measuredHeight_ - margins.vert()));
 			MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		} else {
 			views_[0]->Measure(dc, MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz()), MeasureSpec(UNSPECIFIED));

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -405,12 +405,12 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 
 	int numVisible = 0;
 
-	for (size_t i = 0; i < views_.size(); i++) {
-		if (views_[i]->GetVisibility() == V_GONE)
+	for (View *view : views_) {
+		if (view->GetVisibility() == V_GONE)
 			continue;
 		numVisible++;
 
-		const LinearLayoutParams *linLayoutParams = views_[i]->GetLayoutParams()->As<LinearLayoutParams>();
+		const LinearLayoutParams *linLayoutParams = view->GetLayoutParams()->As<LinearLayoutParams>();
 
 		Margins margins = defaultMargins_;
 
@@ -424,20 +424,21 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 			MeasureSpec v = vert;
 			if (v.type == UNSPECIFIED && measuredHeight_ != 0.0)
 				v = MeasureSpec(AT_MOST, measuredHeight_);
-			views_[i]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v - (float)margins.vert());
+			view->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v - (float)margins.vert());
 		} else if (orientation_ == ORIENT_VERTICAL) {
 			MeasureSpec h = horiz;
-			if (h.type == UNSPECIFIED && measuredWidth_ != 0) h = MeasureSpec(AT_MOST, measuredWidth_);
-			views_[i]->Measure(dc, h - (float)margins.horiz(), MeasureSpec(UNSPECIFIED, measuredHeight_));
+			if (h.type == UNSPECIFIED && measuredWidth_ != 0)
+				h = MeasureSpec(AT_MOST, measuredWidth_);
+			view->Measure(dc, h - (float)margins.horiz(), MeasureSpec(UNSPECIFIED, measuredHeight_));
 		}
 
 		float amount;
 		if (orientation_ == ORIENT_HORIZONTAL) {
-			amount = views_[i]->GetMeasuredWidth() + margins.horiz();
-			maxOther = std::max(maxOther, views_[i]->GetMeasuredHeight() + margins.vert());
+			amount = view->GetMeasuredWidth() + margins.horiz();
+			maxOther = std::max(maxOther, view->GetMeasuredHeight() + margins.vert());
 		} else {
-			amount = views_[i]->GetMeasuredHeight() + margins.vert();
-			maxOther = std::max(maxOther, views_[i]->GetMeasuredWidth() + margins.horiz());
+			amount = view->GetMeasuredHeight() + margins.vert();
+			maxOther = std::max(maxOther, view->GetMeasuredWidth() + margins.horiz());
 		}
 
 		sum += amount;
@@ -469,10 +470,10 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 		float usedWidth = 0.0f;
 
 		// Redistribute the stretchy ones! and remeasure the children!
-		for (size_t i = 0; i < views_.size(); i++) {
-			if (views_[i]->GetVisibility() == V_GONE)
+		for (View *view : views_) {
+			if (view->GetVisibility() == V_GONE)
 				continue;
-			const LinearLayoutParams *linLayoutParams = views_[i]->GetLayoutParams()->As<LinearLayoutParams>();
+			const LinearLayoutParams *linLayoutParams = view->GetLayoutParams()->As<LinearLayoutParams>();
 
 			if (linLayoutParams && linLayoutParams->weight > 0.0f) {
 				Margins margins = defaultMargins_;
@@ -485,8 +486,8 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 				if (horiz.type == EXACTLY) {
 					h.type = EXACTLY;
 				}
-				views_[i]->Measure(dc, h, v - (float)margins.vert());
-				usedWidth += views_[i]->GetMeasuredWidth();
+				view->Measure(dc, h, v - (float)margins.vert());
+				usedWidth += view->GetMeasuredWidth();
 			}
 		}
 
@@ -507,10 +508,10 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 		float usedHeight = 0.0f;
 
 		// Redistribute the stretchy ones! and remeasure the children!
-		for (size_t i = 0; i < views_.size(); i++) {
-			if (views_[i]->GetVisibility() == V_GONE)
+		for (View *view : views_) {
+			if (view->GetVisibility() == V_GONE)
 				continue;
-			const LinearLayoutParams *linLayoutParams = views_[i]->GetLayoutParams()->As<LinearLayoutParams>();
+			const LinearLayoutParams *linLayoutParams = view->GetLayoutParams()->As<LinearLayoutParams>();
 
 			if (linLayoutParams && linLayoutParams->weight > 0.0f) {
 				Margins margins = defaultMargins_;
@@ -523,8 +524,8 @@ void LinearLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 				if (vert.type == EXACTLY) {
 					v.type = EXACTLY;
 				}
-				views_[i]->Measure(dc, h - (float)margins.horiz(), v);
-				usedHeight += views_[i]->GetMeasuredHeight();
+				view->Measure(dc, h - (float)margins.horiz(), v);
+				usedHeight += view->GetMeasuredHeight();
 			}
 		}
 
@@ -627,15 +628,15 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 	}
 
 	// The scroll view itself simply obeys its parent - but also tries to fit the child if possible.
-	MeasureBySpec(layoutParams_->width, 0.0f, horiz, &measuredWidth_);
-	MeasureBySpec(layoutParams_->height, 0.0f, vert, &measuredHeight_);
+	MeasureBySpec(layoutParams_->width, horiz.size, horiz, &measuredWidth_);
+	MeasureBySpec(layoutParams_->height, vert.size, vert, &measuredHeight_);
 
 	if (views_.size()) {
 		if (orientation_ == ORIENT_HORIZONTAL) {
-			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED), MeasureSpec(AT_MOST, measuredHeight_ - margins.vert()));
+			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), MeasureSpec(AT_MOST, measuredHeight_ - margins.vert()));
 			MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		} else {
-			views_[0]->Measure(dc, MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz()), MeasureSpec(UNSPECIFIED));
+			views_[0]->Measure(dc, MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz()), MeasureSpec(UNSPECIFIED, measuredHeight_));
 			MeasureBySpec(layoutParams_->width, views_[0]->GetMeasuredWidth(), horiz, &measuredWidth_);
 		}
 		if (orientation_ == ORIENT_VERTICAL && vert.type != EXACTLY) {
@@ -966,8 +967,8 @@ void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 		Size width = WRAP_CONTENT;
 		Size height = WRAP_CONTENT;
 
-		MeasureSpec specW(UNSPECIFIED, 0.0f);
-		MeasureSpec specH(UNSPECIFIED, 0.0f);
+		MeasureSpec specW(UNSPECIFIED, measuredWidth_);
+		MeasureSpec specH(UNSPECIFIED, measuredHeight_);
 
 		if (!overflow_) {
 			if (horiz.type != UNSPECIFIED) {
@@ -1106,9 +1107,9 @@ TabHolder::TabHolder(Orientation orientation, float stripSize, LayoutParams *lay
 		currentTab_(0) {
 	SetSpacing(0.0f);
 	if (orientation == ORIENT_HORIZONTAL) {
-		tabStrip_ = new ChoiceStrip(orientation, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
+		tabStrip_ = new ChoiceStrip(orientation, new LayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 		tabStrip_->SetTopTabs(true);
-		tabScroll_ = new ScrollView(orientation, new LayoutParams(FILL_PARENT, FILL_PARENT));
+		tabScroll_ = new ScrollView(orientation, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
 		tabScroll_->Add(tabStrip_);
 		Add(tabScroll_);
 	} else {
@@ -1162,7 +1163,7 @@ ChoiceStrip::ChoiceStrip(Orientation orientation, LayoutParams *layoutParams)
 void ChoiceStrip::AddChoice(const std::string &title) {
 	StickyChoice *c = new StickyChoice(title, "",
 			orientation_ == ORIENT_HORIZONTAL ?
-			0 :
+			nullptr :
 			new LinearLayoutParams(FILL_PARENT, ITEM_HEIGHT));
 	c->OnClick.Handle(this, &ChoiceStrip::OnChoiceClick);
 	Add(c);
@@ -1173,7 +1174,7 @@ void ChoiceStrip::AddChoice(const std::string &title) {
 void ChoiceStrip::AddChoice(ImageID buttonImage) {
 	StickyChoice *c = new StickyChoice(buttonImage,
 			orientation_ == ORIENT_HORIZONTAL ?
-			0 :
+			nullptr :
 			new LinearLayoutParams(FILL_PARENT, ITEM_HEIGHT));
 	c->OnClick.Handle(this, &ChoiceStrip::OnChoiceClick);
 	Add(c);


### PR DESCRIPTION
This wraps game titles in the game info screen, savedata info in the pop up, a few paths, etc.

The layout system is changed just slightly to more often specify values for UNSPECIFIED sizes, and more importantly, use that value for FILL_PARENT sizes.  This exposed a lot of places where FILL_PARENT was incorrectly being used as WRAP_CONTENT, especially tab holders.

This also fixes #8020 with more of a fix and less of a workaround.  It was very related - and sometimes when there's network latency, it's nice for the screen to be async as it was originally.

The first two commits are shared with #8898 as they are used by both.

~~Notably, this does not ever wrap checkboxes / choices as mentioned in #8136.  But it makes it significantly more doable.~~ Went ahead and added this.

-[Unknown]
