### PR TITLE
Remove UTF-8 BOMs from a few files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,9 +22,5 @@ charset = utf-16le
 # This file may need to force a BOM so compilers treat as utf-8.
 charset = utf-8-bom
 
-[Windows/GEDebugger/CtrlDisplayListView.cpp]
-# This file may need to force a BOM so compilers treat as utf-8.
-charset = utf-8-bom
-
 [Windows/version.rc]
 charset = utf-16le

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,13 @@ end_of_line = lf
 [Core/Dialog/PSPOskDialog.cpp]
 charset = utf-16le
 
+[ext/native/tools/kanjifilter.h]
+# This file may need to force a BOM so compilers treat as utf-8.
+charset = utf-8-bom
+
+[Windows/GEDebugger/CtrlDisplayListView.cpp]
+# This file may need to force a BOM so compilers treat as utf-8.
+charset = utf-8-bom
+
 [Windows/version.rc]
 charset = utf-16le

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012- PPSSPP Project.
+// Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Core/HLE/sceMd5.cpp
+++ b/Core/HLE/sceMd5.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012- PPSSPP Project.
+// Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/GPU/GLES/DepalettizeShader.cpp
+++ b/GPU/GLES/DepalettizeShader.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014- PPSSPP Project.
+// Copyright (c) 2014- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012- PPSSPP Project.
+// Copyright (c) 2012- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013- PPSSPP Project.
+// Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013- PPSSPP Project.
+// Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -1,4 +1,4 @@
-﻿#include "Windows/GEDebugger/CtrlDisplayListView.h"
+#include "Windows/GEDebugger/CtrlDisplayListView.h"
 #include "Windows/GEDebugger/GEDebugger.h"
 #include "Windows/InputBox.h"
 #include "Windows/Main.h"
@@ -230,7 +230,7 @@ void CtrlDisplayListView::onPaint(WPARAM wParam, LPARAM lParam)
 
 		if (address == list.pc)
 		{
-			TextOut(hdc,pixelPositions.opcodeStart-8,rowY1,L"■",1);
+			TextOut(hdc,pixelPositions.opcodeStart-8,rowY1,L"\x25A0",1);
 		}
 
 		const char* opcode = op.desc.c_str();

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -1,4 +1,4 @@
-﻿#include <limits.h>
+#include <limits.h>
 #include <algorithm>
 
 #include "base/NativeApp.h"

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -1,4 +1,4 @@
-﻿#include <queue>
+#include <queue>
 #include <algorithm>
 
 #include "base/mutex.h"

--- a/ext/native/util/random/rng.h
+++ b/ext/native/util/random/rng.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "base/basictypes.h"
 


### PR DESCRIPTION
With the utf-8 setting in editorconfig, my editor kept removing the BOMs, which really aren't recommended by Unicode anyway.  These files don't even have other Unicode characters.

The only file that did need it is now noted as requiring a BOM in .editorconfig.

-[Unknown]
