### PR TITLE
Psmf: Ignore stream size with old PsmfPlayer libs

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -51,6 +51,7 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceMpeg.h"
+#include "Core/HLE/scePsmf.h"
 #include "Core/HLE/sceIo.h"
 #include "Core/HLE/KernelWaitHelpers.h"
 #include "Core/ELF/ParamSFO.h"
@@ -1065,6 +1066,9 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromT
 			if (!strcmp(head->modname, "sceMpeg_library")) {
 				__MpegLoadModule(ver);
 			}
+			if (!strcmp(head->modname, "scePsmfP_library") || !strcmp(head->modname, "scePsmfPlayer")) {
+				__PsmfPlayerLoadModule(head->devkitversion);
+			}
 		}
 
 		const u8 *in = ptr;
@@ -1420,6 +1424,9 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, u32 loadAddress, bool fromT
 
 		if (!strcmp(modinfo->name, "sceMpeg_library")) {
 			__MpegLoadModule(modinfo->moduleVersion);
+		}
+		if (!strcmp(modinfo->name, "scePsmfP_library") || !strcmp(modinfo->name, "scePsmfPlayer")) {
+			__PsmfPlayerLoadModule(devkitVersion);
 		}
 	}
 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -232,14 +232,8 @@ public:
 	}
 
 	bool HasReachedEnd() {
-		if (psmfPlayerLibVersion >= 0x05050010) {
-			bool videoPtsEnd = (s64)psmfPlayerAvcAu.pts >= (s64)totalDurationTimestamp - VIDEO_FRAME_DURATION_TS;
-			// If we're out of video data and have no audio, it's over even if the pts isn't there yet.
-			return videoPtsEnd || (mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData());			
-		}
-		else {// Older versions just read until the end of the file. 
-			return (mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData());
-		}
+		// The pts are ignored - the end is when we're out of data.
+		return mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData();
 	}
 
 	u32 filehandle;

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -50,10 +50,11 @@ const int PSMF_PLAYER_WARMUP_FRAMES = 3;
 
 static const int VIDEO_FRAME_DURATION_TS = 3003;
 
-int audioSamples = 2048;  
-int audioSamplesBytes = audioSamples * 4;
-int videoPixelMode = GE_CMODE_32BIT_ABGR8888;
-int videoLoopStatus = PSMF_PLAYER_CONFIG_NO_LOOP;
+static const int audioSamples = 2048;
+static const int audioSamplesBytes = audioSamples * 4;
+static int videoPixelMode = GE_CMODE_32BIT_ABGR8888;
+static int videoLoopStatus = PSMF_PLAYER_CONFIG_NO_LOOP;
+static int psmfPlayerLibVersion = 0;
 
 enum PsmfPlayerError {
 	ERROR_PSMF_NOT_INITIALIZED       = 0x80615001,
@@ -647,14 +648,17 @@ static PsmfPlayer *getPsmfPlayer(u32 psmfplayer)
 		return 0;
 }
 
-void __PsmfInit()
-{
+void __PsmfInit() {
 	videoPixelMode = GE_CMODE_32BIT_ABGR8888;
 	videoLoopStatus = PSMF_PLAYER_CONFIG_NO_LOOP;
+	psmfPlayerLibVersion = 0;
 }
 
-void __PsmfDoState(PointerWrap &p)
-{
+void __PsmfPlayerLoadModule(int devkitVersion) {
+	psmfPlayerLibVersion = devkitVersion;
+}
+
+void __PsmfDoState(PointerWrap &p) {
 	auto s = p.Section("scePsmf", 1);
 	if (!s)
 		return;
@@ -662,19 +666,23 @@ void __PsmfDoState(PointerWrap &p)
 	p.Do(psmfMap);
 }
 
-void __PsmfPlayerDoState(PointerWrap &p)
-{
-	auto s = p.Section("scePsmfPlayer", 1);
+void __PsmfPlayerDoState(PointerWrap &p) {
+	auto s = p.Section("scePsmfPlayer", 1, 2);
 	if (!s)
 		return;
 
 	p.Do(psmfPlayerMap);
 	p.Do(videoPixelMode);
 	p.Do(videoLoopStatus);
+	if (s >= 2) {
+		p.Do(psmfPlayerLibVersion);
+	} else {
+		// Assume the latest, which is what we were emulating before.
+		psmfPlayerLibVersion = 0x06060010;
+	}
 }
 
-void __PsmfShutdown()
-{
+void __PsmfShutdown() {
 	for (auto it = psmfMap.begin(), end = psmfMap.end(); it != end; ++it)
 		delete it->second;
 	for (auto it = psmfPlayerMap.begin(), end = psmfPlayerMap.end(); it != end; ++it)
@@ -1233,7 +1241,13 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 
 	int mpegoffset = *(s32_be *)(buf + PSMF_STREAM_OFFSET_OFFSET);
 	psmfplayer->readSize = size - mpegoffset;
-	psmfplayer->streamSize = *(s32_be *)(buf + PSMF_STREAM_SIZE_OFFSET);
+	if (psmfPlayerLibVersion >= 0x05050010) {
+		psmfplayer->streamSize = *(s32_be *)(buf + PSMF_STREAM_SIZE_OFFSET);
+	} else {
+		// Older versions just read until the end of the file.
+		PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
+		psmfplayer->streamSize = info.size - offset - mpegoffset;
+	}
 	psmfplayer->fileoffset = offset + mpegoffset;
 	psmfplayer->mediaengine->loadStream(buf, 2048, std::max(2048 * 500, tempbufSize));
 	_PsmfPlayerFillRingbuffer(psmfplayer);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -232,9 +232,14 @@ public:
 	}
 
 	bool HasReachedEnd() {
-		bool videoPtsEnd = (s64)psmfPlayerAvcAu.pts >= (s64)totalDurationTimestamp - VIDEO_FRAME_DURATION_TS;
-		// If we're out of video data and have no audio, it's over even if the pts isn't there yet.
-		return videoPtsEnd || (mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData());
+		if (psmfPlayerLibVersion >= 0x05050010) {
+			bool videoPtsEnd = (s64)psmfPlayerAvcAu.pts >= (s64)totalDurationTimestamp - VIDEO_FRAME_DURATION_TS;
+			// If we're out of video data and have no audio, it's over even if the pts isn't there yet.
+			return videoPtsEnd || (mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData());			
+		}
+		else {// Older versions just read until the end of the file. 
+			return (mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData());
+		}
 	}
 
 	u32 filehandle;

--- a/Core/HLE/scePsmf.h
+++ b/Core/HLE/scePsmf.h
@@ -21,6 +21,7 @@ void Register_scePsmf();
 void Register_scePsmfPlayer();
 
 void __PsmfInit();
+void __PsmfPlayerLoadModule(int devkitVersion);
 void __PsmfDoState(PointerWrap &p);
 void __PsmfPlayerDoState(PointerWrap &p);
 void __PsmfShutdown();


### PR DESCRIPTION
Until 5.50, the stream size was not used.  See #6574.

-[Unknown]
