### PR TITLE
UI: Suppress state slot switch preview during boot

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -202,6 +202,8 @@ void EmuScreen::bootComplete() {
 	}
 
 	System_SendMessage("event", "startgame");
+
+	saveStateSlot_ = SaveState::GetCurrentSlot();
 }
 
 EmuScreen::~EmuScreen() {
@@ -804,7 +806,7 @@ void EmuScreen::update(InputState &input) {
 		screenManager()->push(new GamePauseScreen(gamePath_));
 	}
 
-	if (saveStatePreview_) {
+	if (saveStatePreview_ && !bootPending_) {
 		int currentSlot = SaveState::GetCurrentSlot();
 		if (saveStateSlot_ != currentSlot) {
 			saveStateSlot_ = currentSlot;


### PR DESCRIPTION
Boot may change the slot if the game has game-specific settings, but we shouldn't show the preview.

Should fix #8916.

-[Unknown]
