### PR TITLE
Fix cpu core change during runtime

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1123,6 +1123,7 @@ void DeveloperToolsScreen::CreateViews() {
 
 	static const char *cpuCores[] = { "Interpreter", "Dynarec (JIT)", "IR Interpreter" };
 	PopupMultiChoice *core = list->Add(new PopupMultiChoice(&g_Config.iCpuCore, gr->T("CPU Core"), cpuCores, 0, ARRAY_SIZE(cpuCores), sy->GetName(), screenManager()));
+	core->OnChoice.Handle(this, &DeveloperToolsScreen::OnJitAffectingSetting);
 	if (!canUseJit) {
 		core->HideChoice(1);
 	}


### PR DESCRIPTION
Some change must've lost this - the core wasn't updating without a game restart.  Now it does.

An example where this could've confused people: comparing ir interpreter with interpreter, switching back and forth.

-[Unknown]
