### PR TITLE
Utility: Only require avcodec for mp4

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -69,7 +69,7 @@ static const int sslModuleDeps[] = {0x0102, 0};
 static const int httpStorageModuleDeps[] = {0x00100, 0x0102, 0x0103, 0x0104, 0x0105, 0};
 static const int atrac3PlusModuleDeps[] = {0x0300, 0};
 static const int mpegBaseModuleDeps[] = {0x0300, 0};
-static const int mp4ModuleDeps[] = {0x0300, 0x0303, 0};
+static const int mp4ModuleDeps[] = {0x0300, 0};
 
 struct ModuleLoadInfo {
 	ModuleLoadInfo(int m, u32 s) : mod(m), size(s), dependencies(noDeps) {


### PR DESCRIPTION
Test was ambiguous - testing more carefully only 300 is required.  Not sure how I got this wrong before since only 300 was required for the others...

Fixes #8926.

-[Unknown]
