### PR TITLE
Implement W^X-compatible JIT. Hopefully makes JIT work on iOS again

### DIFF
--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -60,6 +60,7 @@ public:
 	void ClearCodeSpace() {
 		PoisonMemory();
 		ResetCodePtr();
+		ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_WRITE | MEM_PROT_EXEC);
 	}
 
 	// Call this when shutting down. Don't rely on the destructor, even though it'll do the job.
@@ -71,12 +72,6 @@ public:
 #endif
 		region = nullptr;
 		region_size = 0;
-	}
-
-	// Cannot currently be undone. Will write protect the entire code region.
-	// Start over if you need to change the code (call FreeCodeSpace(), AllocCodeSpace()).
-	void WriteProtect() {
-		ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
 	}
 
 	void SetCodePtr(u8 *ptr) override {

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -76,7 +76,7 @@ public:
 	// Cannot currently be undone. Will write protect the entire code region.
 	// Start over if you need to change the code (call FreeCodeSpace(), AllocCodeSpace()).
 	void WriteProtect() {
-		ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
+		ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
 	}
 
 	void SetCodePtr(u8 *ptr) override {

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -38,8 +38,7 @@ protected:
 	size_t region_size;
 };
 
-template<class T> class CodeBlock : public CodeBlockCommon, public T, NonCopyable
-{
+template<class T> class CodeBlock : public CodeBlockCommon, public T, NonCopyable {
 private:
 	// A privately used function to set the executable RAM space to something invalid.
 	// For debugging usefulness it should be used to set the RAM to a host specific breakpoint instruction
@@ -50,8 +49,7 @@ public:
 	virtual ~CodeBlock() { if (region) FreeCodeSpace(); }
 
 	// Call this before you generate any code.
-	void AllocCodeSpace(int size)
-	{
+	void AllocCodeSpace(int size) {
 		region_size = size;
 		region = (u8*)AllocateExecutableMemory(region_size);
 		T::SetCodePointer(region);
@@ -59,15 +57,13 @@ public:
 
 	// Always clear code space with breakpoints, so that if someone accidentally executes
 	// uninitialized, it just breaks into the debugger.
-	void ClearCodeSpace()
-	{
+	void ClearCodeSpace() {
 		PoisonMemory();
 		ResetCodePtr();
 	}
 
 	// Call this when shutting down. Don't rely on the destructor, even though it'll do the job.
-	void FreeCodeSpace()
-	{
+	void FreeCodeSpace() {
 #ifdef __SYMBIAN32__
 		ResetExecutableMemory(region);
 #else
@@ -79,9 +75,8 @@ public:
 
 	// Cannot currently be undone. Will write protect the entire code region.
 	// Start over if you need to change the code (call FreeCodeSpace(), AllocCodeSpace()).
-	void WriteProtect()
-	{
-		WriteProtectMemory(region, region_size, true);
+	void WriteProtect() {
+		ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
 	}
 
 	void SetCodePtr(u8 *ptr) override {

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -71,8 +71,8 @@ public:
 		ResetCodePtr();
 	}
 
-	// BeginWrite/EndWrite assumes that we keep appending. If you don't specify a size and we encounter later executable block, we're screwed.
-	// These CANNOT be nested.
+	// BeginWrite/EndWrite assume that we keep appending. If you don't specify a size and we encounter later executable block, we're screwed.
+	// These CANNOT be nested. We rely on the memory protection starting at READ|WRITE after start and reset.
 	void BeginWrite(size_t sizeEstimate = 1) {
 #ifdef _DEBUG
 		if (writeStart_) {

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -302,8 +302,8 @@ void ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
 		if ((memProtFlags & (MEM_PROT_WRITE | MEM_PROT_EXEC)) == (MEM_PROT_WRITE | MEM_PROT_EXEC))
 			PanicAlert("Bad memory protect : W^X is in effect, can't both write and exec");
 	}
-	// Note - both VirtualProtect and mprotect will affect the full pages containing the requested range,
-	// so no need to round ptr and size down/up.
+	// Note - both VirtualProtect will affect the full pages containing the requested range.
+	// mprotect does not seem to, at least not on Android unless I made a mistake somewhere, so we manually round.
 #ifdef _WIN32
 	uint32_t protect = ConvertProtFlagsWin32(memProtFlags);
 	DWORD oldValue;

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -285,9 +285,8 @@ void FreeAlignedMemory(void* ptr) {
 }
 
 bool PlatformIsWXExclusive() {
-	// Only 64-bit iOS9 really needs this mode, but that's most iOS devices and all future ones,
-	// so let's keep things the same for all of them. Even without block linking, still should be much
-	// faster than IR JIT.
+	// Only iOS really needs this mode currently. Even without block linking, still should be much faster than IR JIT.
+	// This might also come in useful for UWP (Universal Windows Platform) if I'm understanding things correctly.
 #ifdef IOS
 	return true;
 #else
@@ -325,17 +324,16 @@ void ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
 #endif
 }
 
-// Hardcoded in the header. This is a way to check it dynamically in case it ever becomes necessary.
-/*
-#ifdef _WIN32
-
-// 4k on most archs, 8k on Itanium (but who cares).
-// Should not be confused with the allocation granularity which is 65k and is how precise
-// VirtualAlloc allocations can be located in memory. We don't really care about that much though.
 int GetMemoryProtectPageSize() {
-	if (sys_info.dwPageSize == 0)
-		GetSystemInfo(&sys_info);
-	return sys_info.dwPageSize;
-}
+#ifdef _WIN32
+	// This is 4096 on all Windows platforms we care about. 8k on Itanium but meh.
+	return 4096;
+	// For reference, here's how to check:
+	// if (sys_info.dwPageSize == 0)
+	//   GetSystemInfo(&sys_info);
+	// return sys_info.dwPageSize;
+
+#else
+	return PAGE_SIZE;
 #endif
-*/
+}

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -158,8 +158,8 @@ void *AllocateExecutableMemory(size_t size) {
 	if( g_code_chunk == NULL && g_code_heap == NULL)
 	{
 		g_code_chunk = new RChunk();
-		g_code_chunk->CreateLocalCode(CODECHUNK_SIZE, CODECHUNK_SIZE + 3*GetPageSize());
-		g_code_heap = UserHeap::ChunkHeap(*g_code_chunk, CODECHUNK_SIZE, 1, CODECHUNK_SIZE + 3*GetPageSize());
+		g_code_chunk->CreateLocalCode(CODECHUNK_SIZE, CODECHUNK_SIZE + 3*GetMemoryProtectPageSize());
+		g_code_heap = UserHeap::ChunkHeap(*g_code_chunk, CODECHUNK_SIZE, 1, CODECHUNK_SIZE + 3*GetMemoryProtectPageSize());
 		g_next_ptr = reinterpret_cast<u8*>(g_code_heap->AllocZ(CODECHUNK_SIZE));
 		g_orig_ptr = g_next_ptr;
 	}

--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -26,13 +26,22 @@
 using std::size_t;
 #endif
 
+// Returns true if we need to avoid setting both writable and executable at the same time (W^X)
+bool PlatformIsWXExclusive();
+
 void* AllocateExecutableMemory(size_t size, bool exec = true);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size,size_t alignment);
 void FreeAlignedMemory(void* ptr);
-void WriteProtectMemory(void* ptr, size_t size, bool executable = false);
-void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute = false);
+
+// Note that on platforms returning PlatformIsWXExclusive, you cannot set a page to be both readable and writable at the same time.
+
+#define MEM_PROT_READ  1
+#define MEM_PROT_WRITE 2
+#define MEM_PROT_EXEC  4
+void ProtectMemory(void* ptr, size_t size, uint32_t flags);
+
 #ifdef __SYMBIAN32__
 void ResetExecutableMemory(void* ptr);
 #endif

--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -40,7 +40,7 @@ bool PlatformIsWXExclusive();
 void* AllocateExecutableMemory(size_t size);
 void* AllocateMemoryPages(size_t size, uint32_t memProtFlags);
 // Note that on platforms returning PlatformIsWXExclusive, you cannot set a page to be both readable and writable at the same time.
-void ProtectMemoryPages(void* ptr, size_t size, uint32_t memProtFlags);
+void ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags);
 inline void ProtectMemoryPages(const void *start, const void *end, uint32_t memProtFlags) {
 	ProtectMemoryPages((void *)start, (const uint8_t *)end - (const uint8_t *)start, memProtFlags);
 }

--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -54,10 +54,7 @@ void FreeAlignedMemory(void* ptr);
 void ResetExecutableMemory(void* ptr);
 #endif
 
-inline int GetMemoryProtectPageSize() {
-	// This is 4096 on all platforms we care about. 8k on Itanium but meh.
-	return 4096;
-}
+int GetMemoryProtectPageSize();
 
 template <typename T>
 class SimpleBuf {

--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -497,11 +497,11 @@ void MIPSCodeBlock::FreeCodeSpace() {
 }
 
 void MIPSCodeBlock::WriteProtect() {
-	WriteProtectMemory(region, region_size, true);
+	ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
 }
 
 void MIPSCodeBlock::UnWriteProtect() {
-	UnWriteProtectMemory(region, region_size, false);
+	ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC | MEM_PROT_WRITE);
 }
 
 }

--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -497,11 +497,11 @@ void MIPSCodeBlock::FreeCodeSpace() {
 }
 
 void MIPSCodeBlock::WriteProtect() {
-	ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
+	ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
 }
 
 void MIPSCodeBlock::UnWriteProtect() {
-	ProtectMemory(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC | MEM_PROT_WRITE);
+	ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC | MEM_PROT_WRITE);
 }
 
 }

--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -496,14 +496,6 @@ void MIPSCodeBlock::FreeCodeSpace() {
 	region_size = 0;
 }
 
-void MIPSCodeBlock::WriteProtect() {
-	ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC);
-}
-
-void MIPSCodeBlock::UnWriteProtect() {
-	ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_EXEC | MEM_PROT_WRITE);
-}
-
 }
 
 #endif

--- a/Common/MipsEmitter.h
+++ b/Common/MipsEmitter.h
@@ -299,11 +299,6 @@ public:
 		return ptr >= region && ptr < region + region_size;
 	}
 
-	// Can possibly be undone. Will write protect the entire code region.
-	// Start over if you need to change the code, though (call FreeCodeSpace(), AllocCodeSpace().)
-	void WriteProtect();
-	void UnWriteProtect();
-
 	void ResetCodePtr() {
 		SetCodePtr(region);
 	}

--- a/Common/Thunk.cpp
+++ b/Common/Thunk.cpp
@@ -43,6 +43,7 @@ void ThunkManager::Init()
 #endif
 
 	AllocCodeSpace(THUNK_ARENA_SIZE);
+	BeginWrite();
 	save_regs = GetCodePtr();
 #ifdef _M_X64
 	for (int i = 2; i < ABI_GetNumXMMRegs(); i++)
@@ -94,6 +95,7 @@ void ThunkManager::Init()
 	MOV(32, R(RDX), M(saved_gpr_state + 4 ));
 #endif
 	RET();
+	EndWrite();
 }
 
 void ThunkManager::Reset()
@@ -141,8 +143,7 @@ int ThunkManager::ThunkStackOffset()
 #endif
 }
 
-const void *ThunkManager::ProtectFunction(const void *function, int num_params)
-{
+const void *ThunkManager::ProtectFunction(const void *function, int num_params) {
 	std::map<const void *, const u8 *>::iterator iter;
 	iter = thunks.find(function);
 	if (iter != thunks.end())
@@ -150,6 +151,7 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params)
 	if (!region)
 		PanicAlert("Trying to protect functions before the emu is started. Bad bad bad.");
 
+	BeginWrite();
 	const u8 *call_point = GetCodePtr();
 	Enter(this, true);
 
@@ -171,6 +173,7 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params)
 
 	Leave(this, true);
 	RET();
+	EndWrite();
 
 	thunks[function] = call_point;
 	return (const void *)call_point;

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -135,9 +135,11 @@ const u8 *XEmitter::AlignCode16()
 
 const u8 *XEmitter::AlignCodePage()
 {
-	int c = int((u64)code & 4095);
+	// Memory protection pages matter.
+	int page_size = GetMemoryProtectPageSize();
+	int c = int((u64)code & (page_size - 1));
 	if (c)
-		ReserveCodeSpace(4096-c);
+		ReserveCodeSpace(page_size - c);
 	return code;
 }
 

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -72,7 +72,7 @@ namespace MIPSComp {
 using namespace ArmJitConstants;
 
 void ArmJit::GenerateFixedCode() {
-	const u8 *start = GetCodePtr();
+	const u8 *start = AlignCodePage();
 
 	// LR == SCRATCHREG2 on ARM32 so it needs to be pushed.
 	restoreRoundingMode = AlignCode16(); {
@@ -279,6 +279,10 @@ void ArmJit::GenerateFixedCode() {
 	// Don't forget to zap the instruction cache!
 	FlushLitPool();
 	FlushIcache();
+
+	// Freeze the dispatcher code
+	const void *end = AlignCodePage();
+	ProtectMemoryPages(start, end, MEM_PROT_READ | MEM_PROT_EXEC);
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -73,6 +73,7 @@ using namespace ArmJitConstants;
 
 void ArmJit::GenerateFixedCode() {
 	const u8 *start = AlignCodePage();
+	BeginWrite();
 
 	// LR == SCRATCHREG2 on ARM32 so it needs to be pushed.
 	restoreRoundingMode = AlignCode16(); {
@@ -280,9 +281,9 @@ void ArmJit::GenerateFixedCode() {
 	FlushLitPool();
 	FlushIcache();
 
-	// Freeze the dispatcher code
-	const void *end = AlignCodePage();
-	ProtectMemoryPages(start, end, MEM_PROT_READ | MEM_PROT_EXEC);
+	// Let's spare the pre-generated code from unprotect-reprotect.
+	AlignCodePage();
+	EndWrite();
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -94,7 +94,7 @@ namespace MIPSComp {
 using namespace Arm64JitConstants;
 
 void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
-	const u8 *start = AlignCode16();
+	const u8 *start = AlignCodePage();
 	if (jo.useStaticAlloc) {
 		saveStaticRegisters = AlignCode16();
 		STR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
@@ -316,6 +316,9 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Don't forget to zap the instruction cache! This must stay at the end of this function.
 	FlushIcache();
+	// Freeze the dispatcher code
+	const void *end = AlignCodePage();
+	ProtectMemoryPages(start, end, MEM_PROT_READ | MEM_PROT_EXEC);
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -95,6 +95,8 @@ using namespace Arm64JitConstants;
 
 void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 	const u8 *start = AlignCodePage();
+	BeginWrite();
+
 	if (jo.useStaticAlloc) {
 		saveStaticRegisters = AlignCode16();
 		STR(INDEX_UNSIGNED, DOWNCOUNTREG, CTXREG, offsetof(MIPSState, downcount));
@@ -316,9 +318,9 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Don't forget to zap the instruction cache! This must stay at the end of this function.
 	FlushIcache();
-	// Freeze the dispatcher code
-	const void *end = AlignCodePage();
-	ProtectMemoryPages(start, end, MEM_PROT_READ | MEM_PROT_EXEC);
+	// Let's spare the pre-generated code from unprotect-reprotect.
+	AlignCodePage();
+	EndWrite();
 }
 
 }  // namespace MIPSComp

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/CPUDetect.h"
 #include "Core/MIPS/JitCommon/JitState.h"
+#include "Common/MemoryUtil.h"
 
 namespace MIPSComp {
 	JitOptions::JitOptions() {
@@ -40,7 +41,9 @@ namespace MIPSComp {
 		useASIMDVFPU = false;  // true
 
 		// Common
-		enableBlocklink = true;
+
+		// We can get block linking to work with W^X by doing even more unprotect/re-protect, but let's try without first.
+		enableBlocklink = !PlatformIsWXExclusive();
 		immBranches = false;
 		continueBranches = false;
 		continueJumps = false;

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -64,6 +64,7 @@ void ImHere() {
 
 void Jit::GenerateFixedCode(JitOptions &jo) {
 	const u8 *start = AlignCodePage();
+	BeginWrite();
 
 	restoreRoundingMode = AlignCode16(); {
 		STMXCSR(M(&mips_->temp));
@@ -217,10 +218,9 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 
+	// Let's spare the pre-generated code from unprotect-reprotect.
 	endOfPregeneratedCode = AlignCodePage();
-
-	// Freeze the pre-generated code.
-	ProtectMemoryPages(start, endOfPregeneratedCode, MEM_PROT_READ | MEM_PROT_EXEC);
+	EndWrite();
 }
 
 }  // namespace

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -63,7 +63,7 @@ void ImHere() {
 }
 
 void Jit::GenerateFixedCode(JitOptions &jo) {
-	const u8 *start = AlignCode16();
+	const u8 *start = AlignCodePage();
 
 	restoreRoundingMode = AlignCode16(); {
 		STMXCSR(M(&mips_->temp));
@@ -217,7 +217,10 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 
-	endOfPregeneratedCode = GetCodePtr();
+	endOfPregeneratedCode = AlignCodePage();
+
+	// Freeze the pre-generated code.
+	ProtectMemoryPages(start, endOfPregeneratedCode, MEM_PROT_READ | MEM_PROT_EXEC);
 }
 
 }  // namespace

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -163,6 +163,7 @@ static const JitLookup jitLookup[] = {
 
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
+	BeginWrite();
 	const u8 *start = AlignCode16();
 
 	bool prescaleStep = false;
@@ -313,6 +314,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	*/
 
 	*jittedSize = GetCodePtr() - start;
+	EndWrite();
 	return (JittedVertexDecoder)start;
 }
 

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -143,7 +143,7 @@ static const JitLookup jitLookup[] = {
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 
-
+	BeginWrite();
 	const u8 *start = AlignCode16();
 
 	bool prescaleStep = false;
@@ -300,7 +300,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	}
 
 	*jittedSize = GetCodePtr() - start;
-
+	EndWrite();
 	return (JittedVertexDecoder)start;
 }
 

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1402,7 +1402,6 @@ std::string VertexDecoder::GetString(DebugShaderStringType stringType) {
 	}
 }
 
-
 VertexDecoderJitCache::VertexDecoderJitCache()
 #ifdef ARM64
  : fp(this)

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -159,7 +159,8 @@ static const JitLookup jitLookup[] = {
 
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
-	const u8 *start = this->GetCodePtr();
+	BeginWrite();
+	const u8 *start = this->AlignCode16();
 
 #ifdef _M_IX86
 	// Store register values
@@ -270,6 +271,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	RET();
 
 	*jittedSize = GetCodePtr() - start;
+	EndWrite();
 	return (JittedVertexDecoder)start;
 }
 

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -102,11 +102,11 @@ DrawEngineDX9::DrawEngineDX9()
 	// Allocate nicely aligned memory. Maybe graphics drivers will
 	// appreciate it.
 	// All this is a LOT of memory, need to see if we can cut down somehow.
-	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE);
-	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE);
-	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE);
-	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE);
-	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE);
+	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 
 	if (g_Config.bPrescaleUV) {
 		uvScale = new UVScale[MAX_DEFERRED_DRAW_CALLS];

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -136,11 +136,11 @@ DrawEngineGLES::DrawEngineGLES()
 	// Allocate nicely aligned memory. Maybe graphics drivers will
 	// appreciate it.
 	// All this is a LOT of memory, need to see if we can cut down somehow.
-	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE);
-	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE);
-	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE);
-	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE);
-	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE);
+	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 
 	if (g_Config.bPrescaleUV) {
 		uvScale = new UVScale[MAX_DEFERRED_DRAW_CALLS];

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -87,11 +87,11 @@ DrawEngineVulkan::DrawEngineVulkan(VulkanContext *vulkan)
 	// Allocate nicely aligned memory. Maybe graphics drivers will
 	// appreciate it.
 	// All this is a LOT of memory, need to see if we can cut down somehow.
-	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE);
-	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE);
-	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE);
-	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE);
-	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE);
+	decoded = (u8 *)AllocateMemoryPages(DECODED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	decIndex = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	splineBuffer = (u8 *)AllocateMemoryPages(SPLINE_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 
 	indexGen.Setup(decIndex);
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -361,7 +361,7 @@ public:
 		info_->DisposeFileLoader();
 	}
 
-	virtual void run() {
+	void run() override {
 		if (!info_->LoadFromPath(gamePath_))
 			return;
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -99,7 +99,7 @@ static GraphicsContext *graphicsContext;
 
 		ram_temp_file = [[NSTemporaryDirectory() stringByAppendingPathComponent:@"ram_tmp.file"] fileSystemRepresentation];
 		
-		iosCanUseJit = false;
+		iosCanUseJit = true;
 		targetIsJailbroken = false;
 		NSArray *jailPath = [NSArray arrayWithObjects:
 							@"/Applications/Cydia.app",
@@ -112,11 +112,6 @@ static GraphicsContext *graphicsContext;
 			if ([[NSFileManager defaultManager] fileExistsAtPath:string]) {
 				// checking device jailbreak status in order to determine which message to show in GameSettingsScreen
 				targetIsJailbroken = true;
-				// if we're running on iOS arm64, only iOS <9 is supported with JIT.
-				// if we're running on anything that isn't arm64, then JIT is supported on all iOS versions.
-				if (![self isArm64] || ([self isArm64] && kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_IOS_9_0)) {
-					iosCanUseJit = true;
-				}
 			}
 		}
 		

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -94,6 +94,8 @@ void Vibrate(int length_ms) {
 
 int main(int argc, char *argv[])
 {
+  // Simulates a debugger. Makes it possible to use JIT (though only W^X)
+  syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
 	@autoreleasepool {
 		return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
 	}

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -4,6 +4,7 @@
 #import <string>
 #import <stdio.h>
 #import <stdlib.h>
+#import <sys/syscall.h>
 #import <AudioToolbox/AudioToolbox.h>
 
 #import "AppDelegate.h"

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -58,16 +58,16 @@ std::string System_GetProperty(SystemProperty prop) {
 }
 
 int System_GetPropertyInt(SystemProperty prop) {
-  switch (prop) {
-  case SYSPROP_AUDIO_SAMPLE_RATE:
-    return 44100;
-  case SYSPROP_DISPLAY_REFRESH_RATE:
-    return 60000;
-  case SYSPROP_DEVICE_TYPE:
-    return DEVICE_TYPE_MOBILE;
-  default:
-    return -1;
-  }
+	switch (prop) {
+	case SYSPROP_AUDIO_SAMPLE_RATE:
+		return 44100;
+	case SYSPROP_DISPLAY_REFRESH_RATE:
+		return 60000;
+	case SYSPROP_DEVICE_TYPE:
+		return DEVICE_TYPE_MOBILE;
+	default:
+		return -1;
+	}
 }
 
 void System_SendMessage(const char *command, const char *parameter) {
@@ -94,8 +94,8 @@ void Vibrate(int length_ms) {
 
 int main(int argc, char *argv[])
 {
-  // Simulates a debugger. Makes it possible to use JIT (though only W^X)
-  syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
+	// Simulates a debugger. Makes it possible to use JIT (though only W^X)
+	syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
 	@autoreleasepool {
 		return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
 	}


### PR DESCRIPTION
Will hopefully fix issue #8122, with a lot less of a speed hit than @vit9696's patch (thanks for that!)

For now, block linking is disabled in this mode. Would like confirmation that this works on iOS before doing the work to enable it.

To play around with this mode on other platforms, simply change PlatformIsWXExclusive in MemoryUtil.cpp to always return true. Speed hit appears to be minimal, disregarding the loss of block linking.

Please let me know if this works or not in the comments. I've enabled the mode and tested on Android and Windows, and those are fine.
