### PR TITLE
Adds --PS3 comand line option for PS3 controller support on SDL.

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -121,6 +121,7 @@ public:
 #if !defined(MOBILE_DEVICE)
 	bool bPauseExitsEmulator;
 #endif
+	bool bPS3Controller;
 
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -17,16 +17,22 @@ SDLJoystick::SDLJoystick(bool init_SDL ): thread(NULL), running(true) {
 		SDL_setenv("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1", 0);
 		SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_VIDEO);
 	}
-	if (g_Config.bPS3Controller)
-		fillMappingPS3();
-	else
-		fillMapping();
 
 	int numjoys = SDL_NumJoysticks();
 	SDL_JoystickEventState(SDL_ENABLE);
 	for (int i = 0; i < numjoys; i++) {
 		joys.push_back(SDL_JoystickOpen(i));
+//		printf("Initialized joystick %d: %s",i,SDL_JoystickNameForIndex(i));
+		if(strstr(SDL_JoystickNameForIndex(i),"PLAYSTATION(R)3 Controller"))
+			g_Config.bPS3Controller = true;
 	}
+
+        if (g_Config.bPS3Controller)
+                fillMappingPS3();
+        else
+                fillMapping();
+
+
 }
 
 SDLJoystick::~SDLJoystick(){

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -1,4 +1,5 @@
 #include "SDL/SDLJoystick.h"
+#include "Core/Config.h"
 
 #include <iostream>
 
@@ -16,7 +17,10 @@ SDLJoystick::SDLJoystick(bool init_SDL ): thread(NULL), running(true) {
 		SDL_setenv("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1", 0);
 		SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_VIDEO);
 	}
-	fillMapping();
+	if (g_Config.bPS3Controller)
+		fillMappingPS3();
+	else
+		fillMapping();
 
 	int numjoys = SDL_NumJoysticks();
 	SDL_JoystickEventState(SDL_ENABLE);

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -15,6 +15,8 @@
 #include "net/resolve.h"
 #include "base/NativeApp.h"
 
+#define _PS3_ true
+
 extern "C" {
 	int SDLJoystickThreadWrapper(void *SDLJoy);
 }
@@ -31,6 +33,30 @@ public:
 private:
 
 	void runLoop();
+	void fillMappingPS3()
+	{
+                SDLJoyButtonMap[14] = NKCODE_BUTTON_1;   // Cross
+                SDLJoyButtonMap[13] = NKCODE_BUTTON_2;   // Circle
+                SDLJoyButtonMap[15] = NKCODE_BUTTON_3;   // Sqlare
+                SDLJoyButtonMap[12] = NKCODE_BUTTON_4;   // Triangle
+                SDLJoyButtonMap[10] = NKCODE_BUTTON_5;   // L1
+                SDLJoyButtonMap[11] = NKCODE_BUTTON_6;   // R1
+                SDLJoyButtonMap[8] = NKCODE_BUTTON_7;   // L2
+                SDLJoyButtonMap[9] = NKCODE_BUTTON_8;   // R2
+                SDLJoyButtonMap[0] = NKCODE_BUTTON_9;   // Select
+                SDLJoyButtonMap[3] = NKCODE_BUTTON_10;  // Start
+                SDLJoyButtonMap[1] = NKCODE_BUTTON_11; // L3
+                SDLJoyButtonMap[2] = NKCODE_BUTTON_12; // R3
+                SDLJoyButtonMap[16] = NKCODE_BUTTON_13; // PS
+                SDLJoyButtonMap[4] = NKCODE_DPAD_UP;
+                SDLJoyButtonMap[6] = NKCODE_DPAD_DOWN;
+                SDLJoyButtonMap[7] = NKCODE_DPAD_LEFT;
+                SDLJoyButtonMap[5] = NKCODE_DPAD_RIGHT;
+                SDLJoyAxisMap[0] = JOYSTICK_AXIS_X;
+                SDLJoyAxisMap[1] = JOYSTICK_AXIS_Y;
+                SDLJoyAxisMap[2] = JOYSTICK_AXIS_Z;
+                SDLJoyAxisMap[3] = JOYSTICK_AXIS_RZ;
+	}
 	void fillMapping()
 	{
 		//TODO: C++11 aggregate initialization

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -15,8 +15,6 @@
 #include "net/resolve.h"
 #include "base/NativeApp.h"
 
-#define _PS3_ true
-
 extern "C" {
 	int SDLJoystickThreadWrapper(void *SDLJoy);
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -415,6 +415,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					fileToLog = argv[i] + strlen("--log=");
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))
 					stateToLoad = argv[i] + strlen("--state=");
+				if (!strncmp(argv[1], "--PS3", strlen("--PS3")))
+					g_Config.bPS3Controller = true;
 #if !defined(MOBILE_DEVICE)
 				if (!strncmp(argv[i], "--escape-exit", strlen("--escape-exit")))
 					g_Config.bPauseExitsEmulator = true;

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -175,3 +175,4 @@ enum SystemProperty {
 
 std::string System_GetProperty(SystemProperty prop);
 int System_GetPropertyInt(SystemProperty prop);
+


### PR DESCRIPTION
Per the request at the forum thread here http://forums.ppsspp.org/showthread.php?tid=20003 I've added support for a --PS3 runtime option to support the PS3 controller's default Linux mappings in the PPSSPP interface.
