### PR TITLE
UI: Consistently set bgaudio on game start

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -110,7 +110,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 		return;
 	}
 
-	SetBackgroundAudioGame(filename);
+	SetBackgroundAudioGame("");
 
 	//pre-emptive loading of game specific config if possible, to get all the settings
 	GameInfo *info = g_gameInfoCache->GetInfo(NULL, filename, 0);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -52,6 +52,7 @@
 #include "Core/HLE/__sceAudio.h"
 
 #include "UI/ui_atlas.h"
+#include "UI/BackgroundAudio.h"
 #include "UI/OnScreenDisplay.h"
 #include "UI/GamepadEmu.h"
 #include "UI/PauseScreen.h"
@@ -108,6 +109,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 		}
 		return;
 	}
+
+	SetBackgroundAudioGame(filename);
 
 	//pre-emptive loading of game specific config if possible, to get all the settings
 	GameInfo *info = g_gameInfoCache->GetInfo(NULL, filename, 0);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -928,7 +928,6 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 
 	if (!strcmp(message, "boot")) {
 		screenManager()->switchScreen(new EmuScreen(value));
-		SetBackgroundAudioGame(value);
 	}
 	if (!strcmp(message, "control mapping")) {
 		UpdateUIState(UISTATE_MENU);

--- a/ext/native/base/stringutil.cpp
+++ b/ext/native/base/stringutil.cpp
@@ -250,13 +250,20 @@ bool TryParse(const std::string &str, bool *const output)
 
 void SplitString(const std::string& str, const char delim, std::vector<std::string>& output)
 {
-	std::istringstream iss(str);
-	output.resize(1);
+	size_t next = 0;
+	for (size_t pos = 0, len = str.length(); pos < len; ++pos) {
+		if (str[pos] == delim) {
+			output.push_back(str.substr(next, pos - next));
+			// Skip the delimiter itself.
+			next = pos + 1;
+		}
+	}
 
-	while (std::getline(iss, *output.rbegin(), delim))
-		output.push_back("");
-
-	output.pop_back();
+	if (next == 0) {
+		output.push_back(str);
+	} else if (next < str.length()) {
+		output.push_back(str.substr(next));
+	}
 }
 
 std::string ReplaceAll(std::string result, const std::string& src, const std::string& dest)

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -29,6 +29,12 @@ struct TextStringEntry {
 	int lastUsedFrame;
 };
 
+struct TextMeasureEntry {
+	int width;
+	int height;
+	int lastUsedFrame;
+};
+
 // Not yet functional
 enum {
 	FONTSTYLE_BOLD = 1,
@@ -75,4 +81,5 @@ private:
 	uint32_t fontHash_;
 	// The key is the CityHash of the string xor the fontHash_.
 	std::map<uint32_t, TextStringEntry *> cache_;
+	std::map<uint32_t, TextMeasureEntry *> sizeCache_;
 };


### PR DESCRIPTION
Before we were doing it only in certain cases.  This now means that background audio will always play on the pause screen.

The alternative would be never playing it on the pause screen.  I'm not really sure which is best, so figured we might as well play music.

Fixes #8944, fixes #8953.

-[Unknown]
