### PR TITLE
Android: Add both a lost and restore phase

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1068,7 +1068,7 @@ void PSPSaveDialog::ExecuteNotVisibleIOAction() {
 		{
 			bool result = param.GetSize(param.GetPspParam());
 			// TODO: According to JPCSP, should test/verify this part but seems edge casey.
-			if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_DRIVER_READY) {
+			if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_INSERTED) {
 				param.GetPspParam()->common.result = SCE_UTILITY_SAVEDATA_ERROR_RW_NO_MEMSTICK;
 			} else if (result) {
 				param.GetPspParam()->common.result = 0;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -534,6 +534,10 @@ void GPU_DX9::DeviceLost() {
 	framebufferManager_.DeviceLost();
 }
 
+void GPU_DX9::DeviceRestore() {
+	// Nothing needed.
+}
+
 void GPU_DX9::InitClear() {
 	ScheduleEvent(GPU_EVENT_INIT_CLEAR);
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -56,6 +56,7 @@ public:
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
+	void DeviceRestore() override;
 
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -207,14 +207,18 @@ void DrawEngineGLES::DestroyDeviceObjects() {
 	}
 }
 
-void DrawEngineGLES::GLRestore() {
-	ILOG("TransformDrawEngine::GLRestore()");
+void DrawEngineGLES::GLLost() {
+	ILOG("TransformDrawEngine::GLLost()");
 	// The objects have already been deleted.
 	bufferNameCache_.clear();
 	bufferNameInfo_.clear();
 	freeSizedBuffers_.clear();
 	bufferNameCacheSize_ = 0;
 	ClearTrackedVertexArrays();
+}
+
+void DrawEngineGLES::GLRestore() {
+	ILOG("TransformDrawEngine::GLRestore()");
 	InitDeviceObjects();
 }
 

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -129,6 +129,7 @@ public:
 	void RestoreVAO();
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
+	void GLLost() override;
 	void GLRestore() override;
 	void Resized();
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -651,6 +651,10 @@ void GPU_GLES::DeviceLost() {
 	fragmentTestCache_.Clear(false);
 	depalShaderCache_.Clear();
 	framebufferManager_.DeviceLost();
+}
+
+void GPU_GLES::DeviceRestore() {
+	ILOG("GPU_GLES: DeviceRestore");
 
 	UpdateVsyncInterval(true);
 }

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -60,6 +60,7 @@ public:
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
+	void DeviceRestore() override;
 
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -268,6 +268,7 @@ public:
 	virtual void EnableInterrupts(bool enable) = 0;
 
 	virtual void DeviceLost() = 0;
+	virtual void DeviceRestore() = 0;
 	virtual void ReapplyGfxState() = 0;
 	virtual void SyncThread(bool force = false) = 0;
 	virtual void SyncBeginFrame() = 0;

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -43,6 +43,7 @@ public:
 	void ClearCacheNextFrame() override {}
 
 	void DeviceLost() override {}
+	void DeviceRestore() override {}
 	void DumpNextFrame() override {}
 
 	void Resized() override {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -78,6 +78,10 @@ void SoftGPU::DeviceLost() {
 	// Handled by thin3d.
 }
 
+void SoftGPU::DeviceRestore() {
+	// Handled by thin3d.
+}
+
 SoftGPU::~SoftGPU() {
 	vformat->Release();
 	vformat = nullptr;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -69,6 +69,7 @@ public:
 	void ClearCacheNextFrame() override {}
 
 	void DeviceLost() override;
+	void DeviceRestore() override;
 	void DumpNextFrame() override {}
 
 	void Resized() override {}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -1947,6 +1947,10 @@ void GPU_Vulkan::DeviceLost() {
 	// TODO
 }
 
+void GPU_Vulkan::DeviceRestore() {
+	// TODO
+}
+
 void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	const DrawEngineVulkanStats &drawStats = drawEngine_.GetStats();
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -62,6 +62,7 @@ public:
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
+	void DeviceRestore() override;
 
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1097,6 +1097,12 @@ void EmuScreen::deviceLost() {
 	ILOG("EmuScreen::deviceLost()");
 	if (gpu)
 		gpu->DeviceLost();
+}
+
+void EmuScreen::deviceRestore() {
+	ILOG("EmuScreen::deviceRestore()");
+	if (gpu)
+		gpu->DeviceRestore();
 
 	RecreateViews();
 }

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -38,6 +38,7 @@ public:
 	void update(InputState &input) override;
 	void render() override;
 	void deviceLost() override;
+	void deviceRestore() override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void sendMessage(const char *msg, const char *value) override;
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -604,7 +604,7 @@ handleELF:
 		// ILOG("Completed writing info for %s", info_->GetTitle().c_str());
 	}
 
-	virtual float priority() {
+	float priority() override {
 		return info_->lastAccessedTime;
 	}
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -808,11 +808,16 @@ void NativeUpdate(InputState &input) {
 	screenManager->update(input);
 }
 
-void NativeDeviceRestore() {
+void NativeDeviceLost() {
 	if (g_gameInfoCache)
 		g_gameInfoCache->Clear();
 	screenManager->deviceLost();
+	gl_lost();
+}
 
+void NativeDeviceRestore() {
+	NativeDeviceLost();
+	screenManager->deviceRestore();
 	if (GetGPUBackend() == GPUBackend::OPENGL) {
 		gl_restore();
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -697,6 +697,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayShutdown(JNIEnv *env, jobject obj) {
 	ILOG("NativeApp.displayShutdown()");
 	if (renderer_inited) {
+		NativeDeviceLost();
 		NativeShutdownGraphics();
 		renderer_inited = false;
 		NativeMessageReceived("recreateviews", "");

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -584,11 +584,11 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
     	Log.i(TAG, "onStop - do nothing special");
     }
 
-    @Override
+	@Override
 	protected void onDestroy() {
 		super.onDestroy();
-	    if (javaGL) {
-	      	Log.i(TAG, "onDestroy");
+		if (javaGL) {
+			Log.i(TAG, "onDestroy");
 			mGLSurfaceView.onDestroy();
 			nativeRenderer.onDestroyed();
 			NativeApp.audioShutdown();
@@ -597,8 +597,8 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 			audioFocusChangeListener = null;
 			audioManager = null;
 			unregisterCallbacks();
-	    }
-		if (shuttingDown) {
+		}
+		if (shuttingDown || isFinishing()) {
 			NativeApp.shutdown();
 		}
 	}

--- a/ext/native/gfx/gl_lost_manager.cpp
+++ b/ext/native/gfx/gl_lost_manager.cpp
@@ -47,7 +47,6 @@ void gl_restore() {
 		return;
 	}
 
-	// TODO: We should really do this when we get the context back, not during gl_lost...
 	ILOG("gl_restore() restoring %i items:", (int)holders->size());
 	for (size_t i = 0; i < holders->size(); i++) {
 		ILOG("gl_restore(%i / %i, %p, %08x)", (int)(i + 1), (int)holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));
@@ -65,7 +64,6 @@ void gl_lost() {
 		return;
 	}
 
-	// TODO: We should really do this when we get the context back, not during gl_lost...
 	ILOG("gl_lost() clearing %i items:", (int)holders->size());
 	for (size_t i = 0; i < holders->size(); i++) {
 		ILOG("gl_lost(%i / %i, %p, %08x)", (int)(i + 1), (int)holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));

--- a/ext/native/gfx/gl_lost_manager.cpp
+++ b/ext/native/gfx/gl_lost_manager.cpp
@@ -57,6 +57,24 @@ void gl_restore() {
 	inRestore = false;
 }
 
+void gl_lost() {
+	inLost = true;
+	if (!holders) {
+		WLOG("GL resource holder not initialized, cannot process restore request");
+		inLost = false;
+		return;
+	}
+
+	// TODO: We should really do this when we get the context back, not during gl_lost...
+	ILOG("gl_lost() clearing %i items:", (int)holders->size());
+	for (size_t i = 0; i < holders->size(); i++) {
+		ILOG("gl_lost(%i / %i, %p, %08x)", (int)(i + 1), (int)holders->size(), (*holders)[i], *((uint32_t *)((*holders)[i])));
+		(*holders)[i]->GLLost();
+	}
+	ILOG("gl_lost() completed on %i items:", (int)holders->size());
+	inLost = false;
+}
+
 void gl_lost_manager_init() {
 	if (holders) {
 		FLOG("Double GL lost manager init");

--- a/ext/native/gfx/gl_lost_manager.h
+++ b/ext/native/gfx/gl_lost_manager.h
@@ -7,6 +7,7 @@ class GfxResourceHolder {
 public:
 	virtual ~GfxResourceHolder() {}
 	virtual void GLRestore() = 0;
+	virtual void GLLost() = 0;
 };
 
 void gl_lost_manager_init();
@@ -14,6 +15,9 @@ void gl_lost_manager_shutdown();
 
 void register_gl_resource_holder(GfxResourceHolder *holder);
 void unregister_gl_resource_holder(GfxResourceHolder *holder);
+
+// Notifies all objects it's time to forget / delete things.
+void gl_lost();
 
 // Notifies all objects that it's time to be restored.
 void gl_restore();

--- a/ext/native/gfx_es2/glsl_program.cpp
+++ b/ext/native/gfx_es2/glsl_program.cpp
@@ -220,7 +220,7 @@ bool glsl_recompile(GLSLProgram *program, std::string *error_message) {
 	return true;
 }
 
-void GLSLProgram::GLRestore() {
+void GLSLProgram::GLLost() {
 	// Quoth http://developer.android.com/reference/android/opengl/GLSurfaceView.Renderer.html;
 	// "Note that when the EGL context is lost, all OpenGL resources associated with that context will be automatically deleted. 
 	// You do not need to call the corresponding "glDelete" methods such as glDeleteTextures to manually delete these lost resources."
@@ -228,9 +228,12 @@ void GLSLProgram::GLRestore() {
 	// glDeleteShader(this->vsh_);
 	// glDeleteShader(this->fsh_);
 	// glDeleteProgram(this->program_);
-	this->program_ = 0;
-	this->vsh_ = 0;
-	this->fsh_ = 0;
+	program_ = 0;
+	vsh_ = 0;
+	fsh_ = 0;
+}
+
+void GLSLProgram::GLRestore() {
 	ILOG("Restoring GLSL program %s/%s",
 		strlen(this->vshader_filename) > 0 ? this->vshader_filename : "(mem)",
 		strlen(this->fshader_filename) > 0 ? this->fshader_filename : "(mem)");

--- a/ext/native/gfx_es2/glsl_program.h
+++ b/ext/native/gfx_es2/glsl_program.h
@@ -43,6 +43,7 @@ struct GLSLProgram : public GfxResourceHolder {
 	GLuint fsh_;
 	GLuint program_;
 
+	void GLLost() override;
 	void GLRestore() override;
 };
 

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -147,6 +147,14 @@ void ScreenManager::deviceLost() {
 	// TODO: Change this when it becomes necessary.
 }
 
+void ScreenManager::deviceRestore() {
+	for (size_t i = 0; i < stack_.size(); i++) {
+		stack_[i].screen->deviceRestore();
+	}
+	// Dialogs too? Nah, they should only use the standard UI texture anyway.
+	// TODO: Change this when it becomes necessary.
+}
+
 Screen *ScreenManager::topScreen() const {
 	if (!stack_.empty())
 		return stack_.back().screen;

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -50,6 +50,7 @@ public:
 	virtual void render() {}
 	virtual void postRender() {}
 	virtual void deviceLost() {}
+	virtual void deviceRestore() {}
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
 	virtual bool touch(const TouchInput &touch) { return false;  }
@@ -103,6 +104,7 @@ public:
 	void render();
 	void resized();
 	void deviceLost();
+	void deviceRestore();
 	void shutdown();
 
 	// Push a dialog box in front. Currently 1-level only.


### PR DESCRIPTION
It seemed like you may have thought of this at one point.  Here's my theory on what's happening:
1. gl_lost() runs.
2. Some GLLost() creates an object (since it's really "restore".)
3. Some other GLLost() deletes an object (which just happens - unlucky - to be a recently created object.)
4. gl_lost() finishes, but some objects are broken now.

So the goal here is to break those up, and clear/delete things in lost, but recreate on restore.  I don't think it really adds much complexity anywhere.

Could help #8912 or #8906.

-[Unknown]
