### PR TITLE
Correct alphatest optimization with late texture decode

### DIFF
--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -306,8 +306,6 @@ void DrawEngineDX9::ApplyDrawStateLate() {
 	// At this point, we know if the vertices are full alpha or not.
 	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
 	if (!gstate.isModeClear()) {
-		// TODO: Test texture?
-
 		textureCache_->ApplyTexture();
 
 		if (fboTexNeedBind_) {
@@ -319,6 +317,8 @@ void DrawEngineDX9::ApplyDrawStateLate() {
 			fboTexBound_ = true;
 			fboTexNeedBind_ = false;
 		}
+
+		// TODO: Test texture?
 	}
 }
 

--- a/GPU/GLES/StateMapping.cpp
+++ b/GPU/GLES/StateMapping.cpp
@@ -373,10 +373,6 @@ void DrawEngineGLES::ApplyDrawStateLate() {
 	// At this point, we know if the vertices are full alpha or not.
 	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
 	if (!gstate.isModeClear()) {
-		if (gstate.isAlphaTestEnabled() || gstate.isColorTestEnabled()) {
-			fragmentTestCache_->BindTestTexture(GL_TEXTURE2);
-		}
-
 		if (fboTexNeedBind_) {
 			// Note that this is positions, not UVs, that we need the copy from.
 			framebufferManager_->BindFramebufferColor(GL_TEXTURE1, gstate.getFrameBufRawAddress(), nullptr, BINDFBCOLOR_MAY_COPY);
@@ -394,5 +390,10 @@ void DrawEngineGLES::ApplyDrawStateLate() {
 		// Apply the texture after the FBO tex, since it might unbind the texture.
 		// TODO: Could use a separate texture unit to be safer?
 		textureCache_->ApplyTexture();
+
+		// Apply last, once we know the alpha params of the texture.
+		if (gstate.isAlphaTestEnabled() || gstate.isColorTestEnabled()) {
+			fragmentTestCache_->BindTestTexture(GL_TEXTURE2);
+		}
 	}
 }


### PR DESCRIPTION
We need to create the test texture after, so that it can optimize out the alpha testing correctly.

It uses a dedicated texture unit, so this should be safe.

-[Unknown]
