### PR TITLE
Module: Don't report broken stubs from old states

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -301,8 +301,17 @@ public:
 				}
 			} else {
 				// Older save state.  Let's still reload, but this may not pick up new flags, etc.
+				bool foundBroken = false;
 				for (auto func : importedFuncs) {
-					ImportFunc(func, true);
+					if (func.moduleName[KERNELOBJECT_MAX_NAME_LENGTH] != '\0' || !Memory::IsValidAddress(func.stubAddr)) {
+						foundBroken = true;
+					} else {
+						ImportFunc(func, true);
+					}
+				}
+
+				if (foundBroken) {
+					ERROR_LOG(LOADER, "Broken stub import data while loading state");
 				}
 			}
 


### PR DESCRIPTION
We're suddenly getting a steady stream of broken report data for [Invalid address for syscall stub %s %08x](http://report.ppsspp.org/logs/kind/261) (62,645 in September so far), which has been there [for quite a while](https://github.com/hrydgard/ppsspp/commit/9311d405e98a8a2d85be838886c8eaf718f4720b#diff-eb784c656c56255624635d18f7e2f057R245).  It seems like people are loading broken save states (calling that func during load state is kinda new) and that's causing these, as best I can tell.

This just skips importing these, and by checking the module name for corruption, we may actually improve the chances that the state could load properly (although I doubt it's otherwise valid...)

I can't see why the save states would have this broken data, though.  This path is only used for legacy save states, though.

-[Unknown]
