### PR TITLE
Clear memory when clearing drawing

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -15,15 +15,15 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
+
+#include "Common/ColorConv.h"
+#include "Core/Config.h"
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/SplineCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
-
-#include "Core/Config.h"
-
-#include <algorithm>
 
 #define QUAD_INDICES_MAX 65536
 
@@ -114,6 +114,67 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 	const u32 vertTypeID = (vertType & 0xFFFFFF) | (gstate.getUVGenMode() << 24);
 	VertexDecoder *dec = GetVertexDecoder(vertTypeID);
 	return DrawEngineCommon::NormalizeVertices(outPtr, bufPtr, inPtr, dec, lowerBound, upperBound, vertType);
+}
+
+void DrawEngineCommon::ApplyClearToMemory(int x1, int y1, int x2, int y2, u32 clearColor) {
+	u8 *addr = Memory::GetPointer(gstate.getFrameBufAddress());
+	const bool singleByteClear = (clearColor >> 16) == (clearColor & 0xFFFF) && (clearColor >> 24) == (clearColor & 0xFF);
+	const int bpp = gstate.FrameBufFormat() == GE_FORMAT_8888 ? 4 : 2;
+	const int stride = gstate.FrameBufStride();
+	const int width = x2 - x1;
+
+	// Simple, but often alpha is different and gums up the works.
+	if (singleByteClear) {
+		const int byteStride = stride * bpp;
+		const int byteWidth = width * bpp;
+		addr += x1 * bpp;
+		for (int y = y1; y < y2; ++y) {
+			memset(addr + y * byteStride, clearColor, byteWidth);
+		}
+	} else {
+		u16 clear16 = 0;
+		switch (gstate.FrameBufFormat()) {
+		case GE_FORMAT_565: ConvertRGBA8888ToRGB565(&clear16, &clearColor, 1); break;
+		case GE_FORMAT_5551: ConvertRGBA8888ToRGBA5551(&clear16, &clearColor, 1); break;
+		case GE_FORMAT_4444: ConvertRGBA8888ToRGBA4444(&clear16, &clearColor, 1); break;
+		}
+
+		// This will most often be true - rarely is the width not aligned.
+		if ((width & 3) == 0 && (x1 & 3) == 0) {
+			u64 val64 = clearColor | ((u64)clearColor << 32);
+			int xstride = 2;
+			if (bpp == 2) {
+				// Spread to all eight bytes.
+				u64 c2 = clear16 | (clear16 << 16);
+				val64 = c2 | (c2 << 32);
+				xstride = 4;
+			}
+
+			u64 *addr64 = (u64 *)addr;
+			const int stride64 = stride / xstride;
+			const int x1_64 = x1 / xstride;
+			const int x2_64 = x2 / xstride;
+			for (int y = y1; y < y2; ++y) {
+				for (int x = x1_64; x < x2_64; ++x) {
+					addr64[y * stride64 + x] = val64;
+				}
+			}
+		} else if (bpp == 4) {
+			u32 *addr32 = (u32 *)addr;
+			for (int y = y1; y < y2; ++y) {
+				for (int x = x1; x < x2; ++x) {
+					addr32[y * stride + x] = clearColor;
+				}
+			}
+		} else if (bpp == 2) {
+			u16 *addr16 = (u16 *)addr;
+			for (int y = y1; y < y2; ++y) {
+				for (int x = x1; x < x2; ++x) {
+					addr16[y * stride + x] = clear16;
+				}
+			}
+		}
+	}
 }
 
 // This code is HIGHLY unoptimized!

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -60,6 +60,8 @@ protected:
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType);
 
+	void ApplyClearToMemory(int x1, int y1, int x2, int y2, u32 clearColor);
+
 	VertexDecoder *GetVertexDecoder(u32 vtype);
 
 	inline int IndexSize(u32 vtype) const {

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -129,6 +129,8 @@ void FramebufferManagerCommon::Init() {
 	// The game draws solid colors to a small framebuffer, and then reads this directly in VRAM.
 	// We force this framebuffer to 1x and force download it automatically.
 	hackForce04154000Download_ = gameId == "NPJH50631" || gameId == "NPJH50372" || gameId == "NPJH90164" || gameId == "NPJH50515";
+	// Let's also apply to Me & My Katamari.
+	hackForce04154000Download_ = hackForce04154000Download_ || gameId == "ULUS10094" || gameId == "ULES00339" || gameId == "ULJS00033" || gameId == "UCKS45022" || gameId == "ULJS19009" || gameId == "NPJH50141";
 
 	// And an initial clear. We don't clear per frame as the games are supposed to handle that
 	// by themselves.

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -882,7 +882,7 @@ rotateVBO:
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 
-			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && gstate.isClearModeAlphaMask()) {
+			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && (gstate.isClearModeAlphaMask() || gstate.FrameBufFormat() == GE_FORMAT_565)) {
 				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, clearColor);
 			}
 		}

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -876,9 +876,15 @@ rotateVBO:
 			dxstate.colorMask.set((mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_STENCIL) != 0);
 			pD3Ddevice->Clear(0, NULL, mask, clearColor, clearDepth, clearColor >> 24);
 
+			int scissorX1 = gstate.getScissorX1();
+			int scissorY1 = gstate.getScissorY1();
 			int scissorX2 = gstate.getScissorX2() + 1;
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
+
+			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && gstate.isClearModeAlphaMask()) {
+				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, clearColor);
+			}
 		}
 	}
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -987,9 +987,15 @@ rotateVBO:
 			glClear(target);
 			framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
+			int scissorX1 = gstate.getScissorX1();
+			int scissorY1 = gstate.getScissorY1();
 			int scissorX2 = gstate.getScissorX2() + 1;
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
+
+			if (g_Config.bBlockTransferGPU && colorMask && alphaMask) {
+				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, clearColor);
+			}
 		}
 	}
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -993,7 +993,7 @@ rotateVBO:
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 
-			if (g_Config.bBlockTransferGPU && colorMask && alphaMask) {
+			if (g_Config.bBlockTransferGPU && colorMask && (alphaMask || gstate.FrameBufFormat() == GE_FORMAT_565)) {
 				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, clearColor);
 			}
 		}

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -817,9 +817,15 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 			// We let the framebuffer manager handle the clear. It can use renderpasses to optimize on tilers.
 			framebufferManager_->NotifyClear(gstate.isClearModeColorMask(), gstate.isClearModeAlphaMask(), gstate.isClearModeDepthMask(), result.color, result.depth);
 
+			int scissorX1 = gstate.getScissorX1();
+			int scissorY1 = gstate.getScissorY1();
 			int scissorX2 = gstate.getScissorX2() + 1;
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
+
+			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && gstate.isClearModeAlphaMask()) {
+				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, result.color);
+			}
 		}
 	}
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -823,7 +823,7 @@ void DrawEngineVulkan::DoFlush(VkCommandBuffer cmd) {
 			int scissorY2 = gstate.getScissorY2() + 1;
 			framebufferManager_->SetSafeSize(scissorX2, scissorY2);
 
-			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && gstate.isClearModeAlphaMask()) {
+			if (g_Config.bBlockTransferGPU && gstate.isClearModeColorMask() && (gstate.isClearModeAlphaMask() || gstate.FrameBufFormat() == GE_FORMAT_565)) {
 				ApplyClearToMemory(scissorX1, scissorY1, scissorX2, scissorY2, result.color);
 			}
 		}


### PR DESCRIPTION
This should help synchronize block transfers better.

Should improve #8973.  An alternative to my earlier version in #8987:
- Corrects 16-bit clearing (need to convert the color.)
- Optimize common case with 64-bit faux simd.
- Fix bug in detecting memset compatible clears.
- Make code common to all GPU backends.

Timing this on my Nexus 5, the cost of a full screen clear is typically around 0.000025s to 0.000056s with the average around 0.000040s or so.  In other words, 0.24% of a 60fps frame - not bad.  One worst case outlier was 0.000142s, or 0.85%.

I think the performance cost is not terrible and didn't notice any major performance decrease... but it could be some game does a bunch of clears per frame, I guess.

~~Unfortunately, this re-breaks Katamari.  It seems it redraws the darn thing a couple times, so what happens with this change is:~~

~~1. It draws it the first time.
2. Draw downloaded and saved to memory.  Flag set.
3. It clears and draws it a second time.
4. Flag is already set, so we don't redownload, of course.~~

~~True single-frame draws will still be benefited (and I'm pretty sure some games do them), but Katamari would need some buffer to not clear in the first couple frames or something... ugh.~~

I decided to just hack it for now.  Maybe we can find a better way, but I'm not sure how to do it in a generic non-performance-killing way....

-[Unknown]
