### PR TITLE
Compress rewind snapshots off thread

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -194,6 +194,7 @@ void __KernelShutdown()
 	CoreTiming::ClearPendingEvents();
 	CoreTiming::UnregisterAllEvents();
 	Reporting::Shutdown();
+	SaveState::Shutdown();
 
 	kernelRunning = false;
 }

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -30,6 +30,7 @@ namespace SaveState
 	static const char *SCREENSHOT_EXTENSION = "jpg";
 
 	void Init();
+	void Shutdown();
 
 	// Cycle through the 5 savestate slots
 	void NextSlot();


### PR DESCRIPTION
This can take a chunk of time, and doesn't need to finish until next frame anyway, so we have plenty of time to do it.

This allows us to still keep a healthy number of snapshots around, but with a less stutter.

-[Unknown]
