### PR TITLE
Use unordered lookups for better speed

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <map>
+#include <unordered_map>
 
 #include "base/basictypes.h"
 #include "base/logging.h"
@@ -1251,7 +1252,7 @@ static const ReplacementTableEntry entries[] = {
 
 
 static std::map<u32, u32> replacedInstructions;
-static std::map<std::string, std::vector<int> > replacementNameLookup;
+static std::unordered_map<std::string, std::vector<int> > replacementNameLookup;
 
 void Replacement_Init() {
 	for (int i = 0; i < (int)ARRAY_SIZE(entries); i++) {

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <unordered_map>
 #include <set>
+#include <unordered_set>
 #include "base/mutex.h"
 #include "ext/cityhash/city.h"
 #include "Common/FileUtil.h"
@@ -59,9 +60,22 @@ struct HashMapFunc {
 	bool operator < (const HashMapFunc &other) const {
 		return hash < other.hash || (hash == other.hash && size < other.size);
 	}
+
+	bool operator == (const HashMapFunc &other) const {
+		return hash == other.hash && size == other.size;
+	}
 };
 
-static std::set<HashMapFunc> hashMap;
+namespace std {
+	template <>
+	struct hash<HashMapFunc> {
+		size_t operator()(const HashMapFunc &f) const {
+			return std::hash<u64>()(f.hash) ^ f.size;
+		}
+	};
+}
+
+static std::unordered_set<HashMapFunc> hashMap;
 
 static std::string hashmapFileName;
 


### PR DESCRIPTION
These reduce the time spent on save states.

I logged whenever a rewind snapshot took more than 1/120 of a frame, and it was happening from time to time.  With this, I wasn't seeing them anymore - this was the biggest time outside the memcpy.

I wonder if we could safely map the memory again as private?  Maybe we could get copy on write semantics... would have to backfill the RAM, though.  Might be tricky.

-[Unknown]
