### PR TITLE
Fix some mpeg issues

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1660,12 +1660,18 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(ME, "video end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ringbuffer->packetsAvail = 0;
+		// TODO: Is this correct?
+		if (!ctx->mediaengine->IsNoAudioData()) {
+			WARN_LOG_REPORT(ME, "Video end without audio end, potentially skipping some audio?");
+		}
 		result = ERROR_MPEG_NO_DATA;
 	}
 
 	if (ctx->atracRegistered && ctx->mediaengine->IsNoAudioData() && !ctx->endOfAudioReached) {
 		WARN_LOG(ME, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ctx->endOfAudioReached = true;
+	}
+	if (ctx->mediaengine->IsNoAudioData()) {
 		result = ERROR_MPEG_NO_DATA;
 	}
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -396,8 +396,12 @@ int MediaEngine::addStreamData(const u8 *buffer, int addSize) {
 #ifdef USE_FFMPEG
 		if (!m_pFormatCtx && m_pdata->getQueueSize() >= 2048) {
 			m_mpegheaderSize = m_pdata->get_front(m_mpegheader, sizeof(m_mpegheader));
-			m_pdata->pop_front(0, m_mpegheaderSize);
-			openContext();
+			int streamOffset = (int)(*(s32_be *)(m_mpegheader + 8));
+			if (streamOffset <= m_mpegheaderSize) {
+				m_mpegheaderSize = streamOffset;
+				m_pdata->pop_front(0, m_mpegheaderSize);
+				openContext();
+			}
 		}
 #endif // USE_FFMPEG
 


### PR DESCRIPTION
It turns out we were mistreating some data in the header in some cases - fixes #9002.

Additionally, c03f6c2 is reported to help #8991 and no longer breaks Patapon.  I'm pretty sure it's correct, so I'm reintroducing it here.

-[Unknown]
