### PR TITLE
Use the display vfb for reporting/save state/TAS screenshots

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -142,7 +142,7 @@ static void PreparePacket(AVPacket* pkt)
 
 void AVIDump::AddFrame()
 {
-	gpuDebug->GetCurrentFramebuffer(buf);
+	gpuDebug->GetCurrentFramebuffer(buf, GPU_DBG_FRAMEBUF_DISPLAY);
 	u32 w = buf.GetStride();
 	u32 h = buf.GetHeight();
 	CheckResolution(w, h);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -643,7 +643,7 @@ namespace SaveState
 				break;
 
 			case SAVESTATE_SAVE_SCREENSHOT:
-				callbackResult = TakeGameScreenshot(op.filename.c_str(), SCREENSHOT_JPG, SCREENSHOT_RENDER);
+				callbackResult = TakeGameScreenshot(op.filename.c_str(), SCREENSHOT_JPG, SCREENSHOT_DISPLAY);
 				if (!callbackResult) {
 					ERROR_LOG(COMMON, "Failed to take a screenshot for the savestate! %s", op.filename.c_str());
 				}

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -221,9 +221,9 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 	u32 w = (u32)-1;
 	u32 h = (u32)-1;
 
-	if (type == SCREENSHOT_RENDER) {
+	if (type == SCREENSHOT_DISPLAY || type == SCREENSHOT_RENDER) {
 		if (gpuDebug) {
-			success = gpuDebug->GetCurrentFramebuffer(buf, GPU_DBG_FRAMEBUF_DISPLAY, maxRes);
+			success = gpuDebug->GetCurrentFramebuffer(buf, type == SCREENSHOT_RENDER ? GPU_DBG_FRAMEBUF_RENDER : GPU_DBG_FRAMEBUF_DISPLAY, maxRes);
 		}
 
 		// Only crop to the top left when using a render screenshot.
@@ -231,10 +231,10 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 		h = maxRes > 0 ? 272 * maxRes : PSP_CoreParameter().renderHeight;
 	} else {
 		if (GetGPUBackend() == GPUBackend::OPENGL) {
-			success = GPU_GLES::GetDisplayFramebuffer(buf);
+			success = GPU_GLES::GetOutputFramebuffer(buf);
 #ifdef _WIN32
 		} else if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
-			success = DX9::GPU_DX9::GetDisplayFramebuffer(buf);
+			success = DX9::GPU_DX9::GetOutputFramebuffer(buf);
 #endif
 		}
 	}

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -223,7 +223,7 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 
 	if (type == SCREENSHOT_RENDER) {
 		if (gpuDebug) {
-			success = gpuDebug->GetCurrentFramebuffer(buf, maxRes);
+			success = gpuDebug->GetCurrentFramebuffer(buf, GPU_DBG_FRAMEBUF_DISPLAY, maxRes);
 		}
 
 		// Only crop to the top left when using a render screenshot.

--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -25,9 +25,12 @@ enum ScreenshotFormat {
 };
 
 enum ScreenshotType {
-	// What's begin show on screen (e.g. including FPS, etc.)
+	// What's being show on screen (e.g. including FPS, etc.)
+	SCREENSHOT_OUTPUT,
+	// What the game rendered (e.g. at render resolution) to the display.
+	// Can only be used while in game.
 	SCREENSHOT_DISPLAY,
-	// What the game rendered (e.g. at render resolution.)
+	// What the game is in-progress rendering now.
 	// Can only be used while in game.
 	SCREENSHOT_RENDER,
 };

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -191,6 +191,13 @@ public:
 		return displayFramebuf_ ? (0x04000000 | displayFramebuf_->fb_address) : 0;
 	}
 
+	u32 DisplayFramebufStride() {
+		return displayFramebuf_ ? displayStride_ : 0;
+	}
+	GEBufferFormat DisplayFramebufFormat() {
+		return displayFramebuf_ ? displayFormat_ : GE_FORMAT_INVALID;
+	}
+
 	bool MayIntersectFramebuffer(u32 start) {
 		// Clear the cache/kernel bits.
 		start = start & 0x3FFFFFFF;

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -66,6 +66,13 @@ enum GPUDebugBufferFormat {
 	GPU_DBG_FORMAT_888_RGB = 0x20,
 };
 
+enum GPUDebugFramebufferType {
+	// The current render target.
+	GPU_DBG_FRAMEBUF_RENDER,
+	// The current display target (not the displayed screen, though.)
+	GPU_DBG_FRAMEBUF_DISPLAY,
+};
+
 inline GPUDebugBufferFormat &operator |=(GPUDebugBufferFormat &lhs, const GPUDebugBufferFormat &rhs) {
 	lhs = GPUDebugBufferFormat((int)lhs | (int)rhs);
 	return lhs;
@@ -206,7 +213,7 @@ public:
 
 	// Needs to be called from the GPU thread, so on the same thread as a notification is fine.
 	// Calling from a separate thread (e.g. UI) may fail.
-	virtual bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) {
+	virtual bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes = -1) {
 		// False means unsupported.
 		return false;
 	}

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -49,6 +49,7 @@ static volatile bool actionComplete;
 // Below are values used to perform actions that return results.
 
 static bool bufferResult;
+static GPUDebugFramebufferType bufferType = GPU_DBG_FRAMEBUF_RENDER;
 static GPUDebugBuffer bufferFrame;
 static GPUDebugBuffer bufferDepth;
 static GPUDebugBuffer bufferStencil;
@@ -84,7 +85,7 @@ static void RunPauseAction() {
 		break;
 
 	case PAUSE_GETFRAMEBUF:
-		bufferResult = gpuDebug->GetCurrentFramebuffer(bufferFrame);
+		bufferResult = gpuDebug->GetCurrentFramebuffer(bufferFrame, bufferType);
 		break;
 
 	case PAUSE_GETDEPTHBUF:
@@ -160,7 +161,8 @@ static bool GetBuffer(const GPUDebugBuffer *&buffer, PauseAction type, const GPU
 	return bufferResult;
 }
 
-bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer) {
+bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer, GPUDebugFramebufferType type) {
+	bufferType = type;
 	return GetBuffer(buffer, PAUSE_GETFRAMEBUF, bufferFrame);
 }
 

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -28,7 +28,7 @@ namespace GPUStepping {
 	bool EnterStepping(std::function<void()> callback);
 	bool IsStepping();
 
-	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer);
+	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer, GPUDebugFramebufferType type);
 	bool GPU_GetCurrentDepthbuffer(const GPUDebugBuffer *&buffer);
 	bool GPU_GetCurrentStencilbuffer(const GPUDebugBuffer *&buffer);
 	bool GPU_GetCurrentTexture(const GPUDebugBuffer *&buffer, int level);

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -1358,7 +1358,7 @@ namespace DX9 {
 		return success;
 	}
 
-	bool FramebufferManagerDX9::GetDisplayFramebuffer(GPUDebugBuffer &buffer) {
+	bool FramebufferManagerDX9::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 		fbo_unbind();
 
 		LPDIRECT3DSURFACE9 renderTarget = nullptr;

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -1311,9 +1311,10 @@ namespace DX9 {
 		resized_ = true;
 	}
 
-	bool FramebufferManagerDX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) {
-		u32 fb_address = gstate.getFrameBufRawAddress();
-		int fb_stride = gstate.FrameBufStride();
+	bool FramebufferManagerDX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) {
+		u32 fb_address = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.getFrameBufRawAddress() : displayFramebufPtr_;
+		int fb_stride = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufStride() : displayStride_;
+		GEBufferFormat fb_format = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufFormat() : displayFormat_;
 
 		VirtualFramebuffer *vfb = currentRenderVfb_;
 		if (!vfb) {
@@ -1322,7 +1323,7 @@ namespace DX9 {
 
 		if (!vfb) {
 			// If there's no vfb and we're drawing there, must be memory?
-			buffer = GPUDebugBuffer(Memory::GetPointer(fb_address | 0x04000000), fb_stride, 512, gstate.FrameBufFormat());
+			buffer = GPUDebugBuffer(Memory::GetPointer(fb_address | 0x04000000), fb_stride, 512, fb_format);
 			return true;
 		}
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -82,7 +82,7 @@ public:
 	void DestroyFramebuf(VirtualFramebuffer *vfb) override;
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u16 h, bool force = false, bool skipCopy = false) override;
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes);
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes);
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -85,7 +85,7 @@ public:
 	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes);
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
-	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
+	static bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 
 	virtual void RebindFramebuffer() override;
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -2146,8 +2146,8 @@ void GPU_DX9::DoState(PointerWrap &p) {
 	}
 }
 
-bool GPU_DX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) {
-	return framebufferManager_.GetCurrentFramebuffer(buffer, maxRes);
+bool GPU_DX9::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) {
+	return framebufferManager_.GetCurrentFramebuffer(buffer, type, maxRes);
 }
 
 bool GPU_DX9::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -2251,8 +2251,8 @@ bool GPU_DX9::GetCurrentClut(GPUDebugBuffer &buffer) {
 	return textureCache_.GetCurrentClutBuffer(buffer);
 }
 
-bool GPU_DX9::GetDisplayFramebuffer(GPUDebugBuffer &buffer) {
-	return FramebufferManagerDX9::GetDisplayFramebuffer(buffer);
+bool GPU_DX9::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
+	return FramebufferManagerDX9::GetOutputFramebuffer(buffer);
 }
 
 bool GPU_DX9::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -76,7 +76,7 @@ public:
 	}
 	std::vector<FramebufferInfo> GetFramebufferList() override;
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) override;
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes = -1) override;
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -81,7 +81,7 @@ public:
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
-	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
+	static bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 
 	typedef void (GPU_DX9::*CmdFunc)(u32 op, u32 diff);

--- a/GPU/GLES/Framebuffer.cpp
+++ b/GPU/GLES/Framebuffer.cpp
@@ -2016,7 +2016,7 @@ bool FramebufferManager::GetFramebuffer(u32 fb_address, int fb_stride, GEBufferF
 	return true;
 }
 
-bool FramebufferManager::GetDisplayFramebuffer(GPUDebugBuffer &buffer) {
+bool FramebufferManager::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 	fbo_unbind_read();
 
 	int pw = PSP_CoreParameter().pixelWidth;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -111,7 +111,7 @@ public:
 	bool GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat format, GPUDebugBuffer &buffer, int maxRes);
 	bool GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer);
 	bool GetStencilbuffer(u32 fb_address, int fb_stride, GPUDebugBuffer &buffer);
-	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
+	static bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 
 	virtual void RebindFramebuffer() override;
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -2417,10 +2417,10 @@ void GPU_GLES::DoState(PointerWrap &p) {
 	}
 }
 
-bool GPU_GLES::GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) {
-	u32 fb_address = gstate.getFrameBufRawAddress();
-	int fb_stride = gstate.FrameBufStride();
-	GEBufferFormat format = gstate.FrameBufFormat();
+bool GPU_GLES::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) {
+	u32 fb_address = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.getFrameBufRawAddress() : framebufferManager_.DisplayFramebufAddr();
+	int fb_stride = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufStride() : framebufferManager_.DisplayFramebufStride();
+	GEBufferFormat format = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufFormat() : framebufferManager_.DisplayFramebufFormat();
 	return framebufferManager_.GetFramebuffer(fb_address, fb_stride, format, buffer, maxRes);
 }
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -2482,8 +2482,8 @@ bool GPU_GLES::GetCurrentClut(GPUDebugBuffer &buffer) {
 	return textureCache_.GetCurrentClutBuffer(buffer);
 }
 
-bool GPU_GLES::GetDisplayFramebuffer(GPUDebugBuffer &buffer) {
-	return FramebufferManager::GetDisplayFramebuffer(buffer);
+bool GPU_GLES::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
+	return FramebufferManager::GetOutputFramebuffer(buffer);
 }
 
 bool GPU_GLES::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -86,7 +86,7 @@ public:
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
-	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
+	static bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) override;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -81,7 +81,7 @@ public:
 	}
 	std::vector<FramebufferInfo> GetFramebufferList() override;
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes) override;
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) override;
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -84,7 +84,7 @@ public:
 		return !(gstate_c.skipDrawReason & SKIPDRAW_SKIPFRAME);
 	}
 
-	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, int maxRes = -1) override;
+	bool GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes = -1) override;
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level) override;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -1624,7 +1624,7 @@ bool FramebufferManagerVulkan::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 	return false;
 }
 
-bool FramebufferManagerVulkan::GetDisplayFramebuffer(GPUDebugBuffer &buffer) {
+bool FramebufferManagerVulkan::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 	// TODO: Doing this synchronously will require stalling the pipeline. Maybe better
 	// to do it callback-style?
 	/*

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -127,7 +127,7 @@ public:
 	bool GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat format, GPUDebugBuffer &buffer);
 	bool GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer);
 	bool GetStencilbuffer(u32 fb_address, int fb_stride, GPUDebugBuffer &buffer);
-	static bool GetDisplayFramebuffer(GPUDebugBuffer &buffer);
+	static bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 
 	virtual void RebindFramebuffer() override;
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -673,7 +673,7 @@ void TakeScreenshot() {
 		i++;
 	}
 
-	bool success = TakeGameScreenshot(filename, g_Config.bScreenshotsAsPNG ? SCREENSHOT_PNG : SCREENSHOT_JPG, SCREENSHOT_DISPLAY);
+	bool success = TakeGameScreenshot(filename, g_Config.bScreenshotsAsPNG ? SCREENSHOT_PNG : SCREENSHOT_JPG, SCREENSHOT_OUTPUT);
 	if (success) {
 		osm.Show(filename);
 	} else {

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -236,7 +236,7 @@ void ReportScreen::CreateViews() {
 	}
 	screenshotFilename_ = path + ".reporting.jpg";
 	int shotWidth = 0, shotHeight = 0;
-	if (TakeGameScreenshot(screenshotFilename_.c_str(), SCREENSHOT_JPG, SCREENSHOT_RENDER, &shotWidth, &shotHeight, 4)) {
+	if (TakeGameScreenshot(screenshotFilename_.c_str(), SCREENSHOT_JPG, SCREENSHOT_DISPLAY, &shotWidth, &shotHeight, 4)) {
 		float scale = 340.0f * (1.0f / g_dpi_scale) * (1.0f / shotHeight);
 		leftColumnItems->Add(new CheckBox(&includeScreenshot_, rp->T("FeedbackIncludeScreen", "Include a screenshot")))->SetEnabledPtr(&enableReporting_);
 		screenshot_ = leftColumnItems->Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, nullptr, new LinearLayoutParams(shotWidth * scale, shotHeight * scale, Margins(12, 0))));

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -256,7 +256,7 @@ void CGEDebugger::UpdatePrimaryPreview(const GPUgstate &state) {
 	} else {
 		switch (PrimaryDisplayType(fbTabs->CurrentTabIndex())) {
 		case PRIMARY_FRAMEBUF:
-			bufferResult = GPU_GetCurrentFramebuffer(primaryBuffer_);
+			bufferResult = GPU_GetCurrentFramebuffer(primaryBuffer_, GPU_DBG_FRAMEBUF_RENDER);
 			break;
 
 		case PRIMARY_DEPTHBUF:

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -100,7 +100,7 @@ void WindowsHeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
 	const static u32 FRAME_HEIGHT = 272;
 
 	GPUDebugBuffer buffer;
-	gpuDebug->GetCurrentFramebuffer(buffer);
+	gpuDebug->GetCurrentFramebuffer(buffer, GPU_DBG_FRAMEBUF_RENDER);
 	const std::vector<u32> pixels = TranslateDebugBufferToCompare(&buffer, 512, 272);
 
 	std::string error;


### PR DESCRIPTION
I've updated it to three separate options, which make more sense:
- Render (current _in-progress_ rendering - for debugging)
- Display (current displayed PSP screen)
- Output (current output with FPS / whatever else)

And now switched screenshots to Display instead of Render.  This fixes certain areas where you wouldn't have proper screenshots, or they'd be scaled wrong (mainly in PS1 ports that didn't render at 480x272.)

Example of render-screenshot:
http://report.ppsspp.org/uploads/ULUS10297_1.00/compat-44431.jpg

-[Unknown]
