### PR TITLE
Vulkan: Fix graphics context on Android

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -60,6 +60,7 @@ static bool powerSaving = false;
 
 void Core_SetGraphicsContext(GraphicsContext *ctx) {
 	graphicsContext = ctx;
+	PSP_CoreParameter().graphicsContext = graphicsContext;
 }
 
 void Core_NotifyWindowHidden(bool hidden) {

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -66,6 +66,10 @@ bool GPU_Init(GraphicsContext *ctx, Thin3DContext *thin3d) {
 		return false;
 	case GPUCORE_VULKAN:
 #ifndef NO_VULKAN
+		if (!ctx) {
+			ERROR_LOG(G3D, "Unable to init Vulkan GPU backend, no context");
+			break;
+		}
 		SetGPU(new GPU_Vulkan(ctx));
 #endif
 		break;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -401,7 +401,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 
 	shaderManager_ = new ShaderManagerVulkan(vulkan_);
 	pipelineManager_ = new PipelineManagerVulkan(vulkan_);
-	framebufferManager_ = new FramebufferManagerVulkan(vulkan_),
+	framebufferManager_ = new FramebufferManagerVulkan(vulkan_);
 	drawEngine_.SetTextureCache(&textureCache_);
 	drawEngine_.SetFramebufferManager(framebufferManager_);
 	drawEngine_.SetShaderManager(shaderManager_);

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -73,17 +73,17 @@ public:
 	MainScreen();
 	~MainScreen();
 
-	virtual bool isTopLevel() const { return true; }
+	bool isTopLevel() const override { return true; }
 
 	// Horrible hack to show the demos & homebrew tab after having installed a game from a zip file.
 	static bool showHomebrewTab;
 
 protected:
-	virtual void CreateViews();
-	virtual void DrawBackground(UIContext &dc);
-	virtual void update(InputState &input);
-	virtual void sendMessage(const char *message, const char *value);
-	virtual void dialogFinished(const Screen *dialog, DialogResult result);
+	void CreateViews() override;
+	void DrawBackground(UIContext &dc) override;
+	void update(InputState &input) override;
+	void sendMessage(const char *message, const char *value) override;
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
 	bool UseVerticalLayout() const;
 	bool DrawBackgroundFor(UIContext &dc, const std::string &gamePath, float progress);
@@ -127,8 +127,8 @@ public:
 	UmdReplaceScreen() {}
 
 protected:
-	virtual void CreateViews();
-	virtual void update(InputState &input);
+	void CreateViews() override;
+	void update(InputState &input) override;
 	//virtual void sendMessage(const char *message, const char *value);
 
 private:

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -35,17 +35,17 @@ class UIScreenWithBackground : public UIScreen {
 public:
 	UIScreenWithBackground() : UIScreen() {}
 protected:
-	virtual void DrawBackground(UIContext &dc) override;
-	virtual void sendMessage(const char *message, const char *value) override;
-	virtual UI::EventReturn OnLanguageChange(UI::EventParams &e);
+	void DrawBackground(UIContext &dc) override;
+	void sendMessage(const char *message, const char *value) override;
+	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 };
 
 class UIScreenWithGameBackground : public UIScreenWithBackground {
 public:
 	UIScreenWithGameBackground(const std::string &gamePath)
 		: UIScreenWithBackground(), gamePath_(gamePath) {}
-	virtual void DrawBackground(UIContext &dc);
-	virtual void sendMessage(const char *message, const char *value) override;
+	void DrawBackground(UIContext &dc) override;
+	void sendMessage(const char *message, const char *value) override;
 protected:
 	std::string gamePath_;
 };
@@ -54,9 +54,9 @@ class UIDialogScreenWithBackground : public UIDialogScreen {
 public:
 	UIDialogScreenWithBackground() : UIDialogScreen() {}
 protected:
-	virtual void DrawBackground(UIContext &dc) override;
-	virtual void sendMessage(const char *message, const char *value) override;
-	virtual UI::EventReturn OnLanguageChange(UI::EventParams &e);
+	void DrawBackground(UIContext &dc) override;
+	void sendMessage(const char *message, const char *value) override;
+	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 
 	void AddStandardBack(UI::ViewGroup *parent);
 };
@@ -65,8 +65,8 @@ class UIDialogScreenWithGameBackground : public UIDialogScreenWithBackground {
 public:
 	UIDialogScreenWithGameBackground(const std::string &gamePath)
 		: UIDialogScreenWithBackground(), gamePath_(gamePath) {}
-	virtual void DrawBackground(UIContext &dc) override;
-	virtual void sendMessage(const char *message, const char *value) override;
+	void DrawBackground(UIContext &dc) override;
+	void sendMessage(const char *message, const char *value) override;
 protected:
 	std::string gamePath_;
 };
@@ -76,7 +76,7 @@ public:
 	PromptScreen(std::string message, std::string yesButtonText, std::string noButtonText,
 		std::function<void(bool)> callback = &NoOpVoidBool);
 
-	virtual void CreateViews() override;
+	void CreateViews() override;
 
 private:
 	UI::EventReturn OnYes(UI::EventParams &e);
@@ -93,8 +93,8 @@ public:
 	NewLanguageScreen(const std::string &title);
 
 private:
-	virtual void OnCompleted(DialogResult result) override;
-	virtual bool ShowButtons() const override { return true; }
+	void OnCompleted(DialogResult result) override;
+	bool ShowButtons() const override { return true; }
 	std::map<std::string, std::pair<std::string, int>> langValuesMapping;
 	std::map<std::string, std::string> titleCodeMapping;
 	std::vector<FileInfo> langs_;
@@ -105,8 +105,8 @@ public:
 	PostProcScreen(const std::string &title);
 
 private:
-	virtual void OnCompleted(DialogResult result) override;
-	virtual bool ShowButtons() const override { return true; }
+	void OnCompleted(DialogResult result) override;
+	bool ShowButtons() const override { return true; }
 	std::vector<ShaderInfo> shaders_;
 };
 
@@ -115,10 +115,10 @@ public:
 	LogoScreen()
 		: frames_(0), switched_(false) {}
 	bool key(const KeyInput &key) override;
-	virtual void update(InputState &input) override;
-	virtual void render() override;
-	virtual void sendMessage(const char *message, const char *value) override;
-	virtual void CreateViews() override {}
+	void update(InputState &input) override;
+	void render() override;
+	void sendMessage(const char *message, const char *value) override;
+	void CreateViews() override {}
 
 private:
 	void Next();
@@ -129,10 +129,10 @@ private:
 class CreditsScreen : public UIDialogScreenWithBackground {
 public:
 	CreditsScreen() : frames_(0) {}
-	virtual void update(InputState &input) override;
-	virtual void render() override;
+	void update(InputState &input) override;
+	void render() override;
 
-	virtual void CreateViews() override;
+	void CreateViews() override;
 
 private:
 	UI::EventReturn OnOK(UI::EventParams &e);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -821,7 +821,9 @@ void NativeDeviceLost() {
 	if (g_gameInfoCache)
 		g_gameInfoCache->Clear();
 	screenManager->deviceLost();
-	gl_lost();
+	if (GetGPUBackend() == GPUBackend::OPENGL) {
+		gl_lost();
+	}
 }
 
 void NativeDeviceRestore() {

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -165,8 +165,6 @@ unsigned int WINAPI TheThread(void *)
 		ExitProcess(1);
 	}
 
-	PSP_CoreParameter().graphicsContext = graphicsContext;
-
 	NativeInitGraphics(graphicsContext);
 	NativeResized();
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -257,6 +257,7 @@ bool AndroidVulkanContext::Init(ANativeWindow *wnd, int desiredBackbufferSizeX, 
 
 	ILOG("Creating vulkan device");
 	if (g_Vulkan->CreateDevice(0) != VK_SUCCESS) {
+		ILOG("Failed to create vulkan device: %s", g_Vulkan->InitError().c_str());
 		return false;
 	}
 	int width = desiredBackbufferSizeX;


### PR DESCRIPTION
This makes Vulkan work on an NVIDIA SHIELD TV, at least.

This is with the latest SHIELD TV Experience update - the Vulkan UI works as well as in game.  Of course, buffered rendering must be off.  This doesn't unhide the setting yet.

Additionally, not fixed here, but TLS seems to not be working in 64-bit on the SHIELD TV.  I had to comment it out in threadutil, or it would crash immediately upon any call to `setCurrentThreadName`.  Not sure why - and it seems fine in 32-bit.  I'm using ndk-r12b, too...

-[Unknown]
