### PR TITLE
WIP: Progress toward device restore on Vulkan

### DIFF
--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -66,18 +66,18 @@ class VulkanDeleteList {
 	};
 
 public:
-	void QueueDeleteDescriptorPool(VkDescriptorPool pool) { descPools_.push_back(pool); }
-	void QueueDeleteShaderModule(VkShaderModule module) { modules_.push_back(module); }
-	void QueueDeleteBuffer(VkBuffer buffer) { buffers_.push_back(buffer); }
-	void QueueDeleteBufferView(VkBufferView bufferView) { bufferViews_.push_back(bufferView); }
-	void QueueDeleteImage(VkImage image) { images_.push_back(image); }
-	void QueueDeleteImageView(VkImageView imageView) { imageViews_.push_back(imageView); }
-	void QueueDeleteDeviceMemory(VkDeviceMemory deviceMemory) { deviceMemory_.push_back(deviceMemory); }
-	void QueueDeleteSampler(VkSampler sampler) { samplers_.push_back(sampler); }
-	void QueueDeletePipeline(VkPipeline pipeline) { pipelines_.push_back(pipeline); }
-	void QueueDeletePipelineCache(VkPipelineCache pipelineCache) { pipelineCaches_.push_back(pipelineCache); }
-	void QueueDeleteRenderPass(VkRenderPass renderPass) { renderPasses_.push_back(renderPass); }
-	void QueueDeleteFramebuffer(VkFramebuffer framebuffer) { framebuffers_.push_back(framebuffer); }
+	void QueueDeleteDescriptorPool(VkDescriptorPool &pool) { descPools_.push_back(pool); pool = VK_NULL_HANDLE; }
+	void QueueDeleteShaderModule(VkShaderModule &module) { modules_.push_back(module); module = VK_NULL_HANDLE; }
+	void QueueDeleteBuffer(VkBuffer &buffer) { buffers_.push_back(buffer); buffer = VK_NULL_HANDLE; }
+	void QueueDeleteBufferView(VkBufferView &bufferView) { bufferViews_.push_back(bufferView); bufferView = VK_NULL_HANDLE; }
+	void QueueDeleteImage(VkImage &image) { images_.push_back(image); image = VK_NULL_HANDLE; }
+	void QueueDeleteImageView(VkImageView &imageView) { imageViews_.push_back(imageView); imageView = VK_NULL_HANDLE; }
+	void QueueDeleteDeviceMemory(VkDeviceMemory &deviceMemory) { deviceMemory_.push_back(deviceMemory); deviceMemory = VK_NULL_HANDLE; }
+	void QueueDeleteSampler(VkSampler &sampler) { samplers_.push_back(sampler); sampler = VK_NULL_HANDLE; }
+	void QueueDeletePipeline(VkPipeline &pipeline) { pipelines_.push_back(pipeline); pipeline = VK_NULL_HANDLE; }
+	void QueueDeletePipelineCache(VkPipelineCache &pipelineCache) { pipelineCaches_.push_back(pipelineCache); pipelineCache = VK_NULL_HANDLE; }
+	void QueueDeleteRenderPass(VkRenderPass &renderPass) { renderPasses_.push_back(renderPass); renderPass = VK_NULL_HANDLE; }
+	void QueueDeleteFramebuffer(VkFramebuffer &framebuffer) { framebuffers_.push_back(framebuffer); framebuffer = VK_NULL_HANDLE; }
 	void QueueCallback(void(*func)(void *userdata), void *userdata) { callbacks_.push_back(Callback(func, userdata)); }
 
 	void Take(VulkanDeleteList &del) {

--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -22,11 +22,9 @@ void VulkanTexture::CreateMappableImage() {
 	// If we already have a mappableImage, forget it.
 	if (mappableImage) {
 		vulkan_->Delete().QueueDeleteImage(mappableImage);
-		mappableImage = VK_NULL_HANDLE;
 	}
 	if (mappableMemory) {
 		vulkan_->Delete().QueueDeleteDeviceMemory(mappableMemory);
-		mappableMemory = VK_NULL_HANDLE;
 	}
 
 	bool U_ASSERT_ONLY pass;
@@ -193,9 +191,6 @@ void VulkanTexture::Unlock() {
 		// Then drop the temporary mappable image - although should not be necessary...
 		vulkan_->Delete().QueueDeleteImage(mappableImage);
 		vulkan_->Delete().QueueDeleteDeviceMemory(mappableMemory);
-
-		mappableImage = VK_NULL_HANDLE;
-		mappableMemory = VK_NULL_HANDLE;
 	}
 
 	VkImageViewCreateInfo view_info = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
@@ -218,15 +213,12 @@ void VulkanTexture::Unlock() {
 void VulkanTexture::Wipe() {
 	if (image) {
 		vulkan_->Delete().QueueDeleteImage(image);
-		image = VK_NULL_HANDLE;
 	}
 	if (view) {
 		vulkan_->Delete().QueueDeleteImageView(view);
-		view = VK_NULL_HANDLE;
 	}
 	if (mem && !allocator_) {
 		vulkan_->Delete().QueueDeleteDeviceMemory(mem);
-		mem = VK_NULL_HANDLE;
 	} else if (mem) {
 		allocator_->Free(mem, offset_);
 		mem = VK_NULL_HANDLE;
@@ -371,25 +363,22 @@ void VulkanTexture::EndCreate() {
 }
 
 void VulkanTexture::Destroy() {
-	if (view) {
+	if (view != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteImageView(view);
 	}
-	if (image) {
-		vulkan_->Delete().QueueDeleteImage(image);
+	if (image != VK_NULL_HANDLE) {
 		if (mappableImage == image) {
 			mappableImage = VK_NULL_HANDLE;
 		}
+		vulkan_->Delete().QueueDeleteImage(image);
 	}
-	if (mem && !allocator_) {
-		vulkan_->Delete().QueueDeleteDeviceMemory(mem);
+	if (mem != VK_NULL_HANDLE && !allocator_) {
 		if (mappableMemory == mem) {
 			mappableMemory = VK_NULL_HANDLE;
 		}
-	} else if (mem) {
+		vulkan_->Delete().QueueDeleteDeviceMemory(mem);
+	} else if (mem != VK_NULL_HANDLE) {
 		allocator_->Free(mem, offset_);
+		mem = VK_NULL_HANDLE;
 	}
-
-	view = VK_NULL_HANDLE;
-	image = VK_NULL_HANDLE;
-	mem = VK_NULL_HANDLE;
 }

--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -29,7 +29,7 @@ public:
 	}
 
 	void Destroy(VulkanContext *vulkan) {
-		for (const BufInfo &info : buffers_) {
+		for (BufInfo &info : buffers_) {
 			vulkan->Delete().QueueDeleteBuffer(info.buffer);
 			vulkan->Delete().QueueDeleteDeviceMemory(info.deviceMemory);
 		}

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -288,7 +288,7 @@ void DrawEngineVulkan::BeginFrame() {
 			VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 		uint32_t bindOffset;
 		VkBuffer bindBuf;
-		uint32_t *data = (uint32_t *)frame_[0].pushUBO->Push(w * h * 4, &bindOffset, &bindBuf);
+		uint32_t *data = (uint32_t *)frame->pushUBO->Push(w * h * 4, &bindOffset, &bindBuf);
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
 				// data[y*w + x] = ((x ^ y) & 1) ? 0xFF808080 : 0xFF000000;   // gray/black checkerboard

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -208,7 +208,6 @@ DrawEngineVulkan::~DrawEngineVulkan() {
 void DrawEngineVulkan::FrameData::Destroy(VulkanContext *vulkan) {
 	if (descPool != VK_NULL_HANDLE) {
 		vulkan->Delete().QueueDeleteDescriptorPool(descPool);
-		descPool = VK_NULL_HANDLE;
 	}
 
 	if (pushUBO) {
@@ -234,10 +233,8 @@ void DrawEngineVulkan::DestroyDeviceObjects() {
 	}
 	if (depalSampler_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteSampler(depalSampler_);
-	depalSampler_ = VK_NULL_HANDLE;
 	if (nullSampler_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteSampler(nullSampler_);
-	nullSampler_ = VK_NULL_HANDLE;
 	if (pipelineLayout_ != VK_NULL_HANDLE)
 		vkDestroyPipelineLayout(vulkan_->GetDevice(), pipelineLayout_, nullptr);
 	pipelineLayout_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -87,7 +87,9 @@ public:
 		framebufferManager_ = fbManager;
 	}
 
-	void Resized();  // TODO: Call
+	void Resized();
+	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
 
 	void SetupVertexDecoder(u32 vertType);
 	void SetupVertexDecoderInternal(u32 vertType);
@@ -160,6 +162,9 @@ public:
 private:
 	struct FrameData;
 
+	void InitDeviceObjects();
+	void DestroyDeviceObjects();
+
 	void DecodeVerts(VulkanPushBuffer *push, uint32_t *bindOffset, VkBuffer *vkbuf);
 	void DecodeVertsStep(u8 *dest, int &i, int &decodedVerts);
 
@@ -200,6 +205,8 @@ private:
 		VulkanPushBuffer *pushIndex;
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
 		std::map<DescriptorSetKey, VkDescriptorSet> descSets;
+
+		void Destroy(VulkanContext *vulkan);
 	};
 
 	int curFrame_;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -202,16 +202,12 @@ void FramebufferManagerVulkan::InitDeviceObjects() {
 void FramebufferManagerVulkan::DestroyDeviceObjects() {
 	if (rpLoadColorLoadDepth_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteRenderPass(rpLoadColorLoadDepth_);
-	rpLoadColorLoadDepth_ = VK_NULL_HANDLE;
 	if (rpClearColorLoadDepth_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteRenderPass(rpClearColorLoadDepth_);
-	rpClearColorLoadDepth_ = VK_NULL_HANDLE;
 	if (rpClearColorClearDepth_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteRenderPass(rpClearColorClearDepth_);
-	rpClearColorClearDepth_ = VK_NULL_HANDLE;
 	if (rpLoadColorClearDepth_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteRenderPass(rpLoadColorClearDepth_);
-	rpLoadColorClearDepth_ = VK_NULL_HANDLE;
 
 	for (int i = 0; i < 2; i++) {
 		if (frameData_[i].numCommandBuffers_ > 0) {
@@ -234,26 +230,19 @@ void FramebufferManagerVulkan::DestroyDeviceObjects() {
 
 	if (fsBasicTex_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteShaderModule(fsBasicTex_);
-	fsBasicTex_ = VK_NULL_HANDLE;
 	if (vsBasicTex_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteShaderModule(vsBasicTex_);
-	vsBasicTex_ = VK_NULL_HANDLE;
 
 	if (linearSampler_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteSampler(linearSampler_);
-	linearSampler_ = VK_NULL_HANDLE;
 	if (nearestSampler_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteSampler(nearestSampler_);
-	nearestSampler_ = VK_NULL_HANDLE;
 	if (pipelineBasicTex_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipeline(pipelineBasicTex_);
-	pipelineBasicTex_ = VK_NULL_HANDLE;
 	if (pipelinePostShader_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipeline(pipelinePostShader_);
-	pipelinePostShader_ = VK_NULL_HANDLE;
 	if (pipelineCache2D_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache2D_);
-	pipelineCache2D_ = VK_NULL_HANDLE;
 }
 
 void FramebufferManagerVulkan::NotifyClear(bool clearColor, bool clearAlpha, bool clearDepth, uint32_t color, float depth) {

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -100,6 +100,7 @@ FramebufferManagerVulkan::FramebufferManagerVulkan(VulkanContext *vulkan) :
 FramebufferManagerVulkan::~FramebufferManagerVulkan() {
 	delete[] convBuf_;
 
+	vulkan2D_.Shutdown();
 	DestroyDeviceObjects();
 }
 
@@ -237,10 +238,7 @@ void FramebufferManagerVulkan::DestroyDeviceObjects() {
 		vulkan_->Delete().QueueDeleteSampler(linearSampler_);
 	if (nearestSampler_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteSampler(nearestSampler_);
-	if (pipelineBasicTex_ != VK_NULL_HANDLE)
-		vulkan_->Delete().QueueDeletePipeline(pipelineBasicTex_);
-	if (pipelinePostShader_ != VK_NULL_HANDLE)
-		vulkan_->Delete().QueueDeletePipeline(pipelinePostShader_);
+	// pipelineBasicTex_ and pipelineBasicTex_ come from vulkan2D_.
 	if (pipelineCache2D_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache2D_);
 }
@@ -1541,11 +1539,11 @@ void FramebufferManagerVulkan::EndFrame() {
 }
 
 void FramebufferManagerVulkan::DeviceLost() {
+	vulkan2D_.DeviceLost();
+
 	DestroyAllFBOs(false);
 	DestroyDeviceObjects();
 	resized_ = false;
-
-	vulkan2D_.DeviceLost();
 }
 
 void FramebufferManagerVulkan::DeviceRestore(VulkanContext *vulkan) {

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -104,6 +104,7 @@ public:
 
 	void Resized();
 	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
 	void CopyDisplayToOutput();
 	int GetLineWidth();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old);
@@ -173,6 +174,9 @@ private:
 
 	void PackFramebufferAsync_(VirtualFramebuffer *vfb);
 	void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
+
+	void InitDeviceObjects();
+	void DestroyDeviceObjects();
 
 	VulkanContext *vulkan_;
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -1945,11 +1945,25 @@ void GPU_Vulkan::FastLoadBoneMatrix(u32 target) {
 }
 
 void GPU_Vulkan::DeviceLost() {
-	// TODO
+	framebufferManager_->DeviceLost();
+	drawEngine_.DeviceLost();
+	pipelineManager_->DeviceLost();
+	textureCache_.DeviceLost();
+	depalShaderCache_.Clear();
+	shaderManager_->ClearShaders();
 }
 
 void GPU_Vulkan::DeviceRestore() {
-	// TODO
+	vulkan_ = (VulkanContext *)PSP_CoreParameter().graphicsContext->GetAPIContext();
+	CheckGPUFeatures();
+	BuildReportingInfo();
+	UpdateCmdInfo();
+
+	framebufferManager_->DeviceRestore(vulkan_);
+	drawEngine_.DeviceRestore(vulkan_);
+	pipelineManager_->DeviceRestore(vulkan_);
+	textureCache_.DeviceRestore(vulkan_);
+	shaderManager_->DeviceRestore(vulkan_);
 }
 
 void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -494,6 +494,8 @@ void GPU_Vulkan::BeginHostFrame() {
 
 	if (resized_) {
 		CheckGPUFeatures();
+		// In case the GPU changed.
+		BuildReportingInfo();
 		UpdateCmdInfo();
 		drawEngine_.Resized();
 		textureCache_.NotifyConfigChanged();
@@ -524,7 +526,6 @@ void GPU_Vulkan::EndHostFrame() {
 }
 
 // Needs to be called on GPU thread, not reporting thread.
-// TODO
 void GPU_Vulkan::BuildReportingInfo() {
 	const auto &props = vulkan_->GetPhysicalDeviceProperties();
 	const auto &features = vulkan_->GetFeaturesAvailable();

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -27,6 +27,16 @@ void PipelineManagerVulkan::Clear() {
 	pipelines_.clear();
 }
 
+void PipelineManagerVulkan::DeviceLost() {
+	Clear();
+	vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+}
+
+void PipelineManagerVulkan::DeviceRestore(VulkanContext *vulkan) {
+	vulkan_ = vulkan;
+	pipelineCache_ = vulkan->CreatePipelineCache();
+}
+
 struct DeclTypeInfo {
 	VkFormat type;
 	const char *name;

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -13,7 +13,8 @@ PipelineManagerVulkan::PipelineManagerVulkan(VulkanContext *vulkan) : vulkan_(vu
 
 PipelineManagerVulkan::~PipelineManagerVulkan() {
 	Clear();
-	vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+	if (pipelineCache_ != VK_NULL_HANDLE)
+		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
 }
 
 void PipelineManagerVulkan::Clear() {
@@ -31,7 +32,6 @@ void PipelineManagerVulkan::DeviceLost() {
 	Clear();
 	if (pipelineCache_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
-	pipelineCache_ = VK_NULL_HANDLE;
 }
 
 void PipelineManagerVulkan::DeviceRestore(VulkanContext *vulkan) {

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -29,7 +29,9 @@ void PipelineManagerVulkan::Clear() {
 
 void PipelineManagerVulkan::DeviceLost() {
 	Clear();
-	vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+	if (pipelineCache_ != VK_NULL_HANDLE)
+		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+	pipelineCache_ = VK_NULL_HANDLE;
 }
 
 void PipelineManagerVulkan::DeviceRestore(VulkanContext *vulkan) {

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -87,6 +87,9 @@ public:
 
 	void Clear();
 
+	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
+
 	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
 

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -437,6 +437,11 @@ void ShaderManagerVulkan::BoneUpdateUniforms(int dirtyUniforms) {
 	}
 }
 
+void ShaderManagerVulkan::DeviceRestore(VulkanContext *vulkan) {
+	vulkan_ = vulkan;
+	uboAlignment_ = vulkan_->GetPhysicalDeviceProperties().limits.minUniformBufferOffsetAlignment;
+}
+
 void ShaderManagerVulkan::Clear() {
 	for (auto iter = fsCache_.begin(); iter != fsCache_.end(); ++iter)	{
 		delete iter->second;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -81,7 +81,7 @@ VulkanFragmentShader::VulkanFragmentShader(VulkanContext *vulkan, ShaderID id, c
 }
 
 VulkanFragmentShader::~VulkanFragmentShader() {
-	if (module_) {
+	if (module_ != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteShaderModule(module_);
 	}
 }
@@ -134,7 +134,7 @@ VulkanVertexShader::VulkanVertexShader(VulkanContext *vulkan, ShaderID id, const
 }
 
 VulkanVertexShader::~VulkanVertexShader() {
-	if (module_) {
+	if (module_ != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteShaderModule(module_);
 	}
 }

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -229,6 +229,8 @@ public:
 	ShaderManagerVulkan(VulkanContext *vulkan);
 	~ShaderManagerVulkan();
 
+	void DeviceRestore(VulkanContext *vulkan);
+
 	void GetShaders(int prim, u32 vertType, VulkanVertexShader **vshader, VulkanFragmentShader **fshader, bool useHWTransform);
 	void ClearShaders();
 	void DirtyShader();

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -75,6 +75,9 @@ public:
 	~SamplerCache();
 	VkSampler GetOrCreateSampler(const SamplerCacheKey &key);
 
+	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
+
 private:
 	VulkanContext *vulkan_;
 	std::map<SamplerCacheKey, VkSampler> cache_;
@@ -95,6 +98,9 @@ public:
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);
 	void ClearNextFrame();
+
+	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
 
 	void SetFramebufferManager(FramebufferManagerVulkan *fbManager) {
 		framebufferManager_ = fbManager;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -59,7 +59,6 @@ void Vulkan2D::DestroyDeviceObjects() {
 	for (int i = 0; i < 2; i++) {
 		if (frameData_[i].descPool != VK_NULL_HANDLE) {
 			vulkan_->Delete().QueueDeleteDescriptorPool(frameData_[i].descPool);
-			frameData_[i].descPool = VK_NULL_HANDLE;
 		}
 	}
 	for (auto it : pipelines_) {

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -48,6 +48,37 @@ void VulkanFBO::Create(VulkanContext *vulkan, VkRenderPass rp_compatible, int wi
 }
 
 Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
+	InitDeviceObjects();
+}
+
+Vulkan2D::~Vulkan2D() {
+	DestroyDeviceObjects();
+}
+
+void Vulkan2D::DestroyDeviceObjects() {
+	for (int i = 0; i < 2; i++) {
+		if (frameData_[i].descPool != VK_NULL_HANDLE) {
+			vulkan_->Delete().QueueDeleteDescriptorPool(frameData_[i].descPool);
+			frameData_[i].descPool = VK_NULL_HANDLE;
+		}
+	}
+	for (auto it : pipelines_) {
+		vulkan_->Delete().QueueDeletePipeline(it.second);
+	}
+	pipelines_.clear();
+
+	VkDevice device = vulkan_->GetDevice();
+	if (descriptorSetLayout_ != VK_NULL_HANDLE) {
+		vkDestroyDescriptorSetLayout(device, descriptorSetLayout_, nullptr);
+		descriptorSetLayout_ = VK_NULL_HANDLE;
+	}
+	if (pipelineLayout_ != VK_NULL_HANDLE) {
+		vkDestroyPipelineLayout(device, pipelineLayout_, nullptr);
+		pipelineLayout_ = VK_NULL_HANDLE;
+	}
+}
+
+void Vulkan2D::InitDeviceObjects() {
 	// All resources we need for PSP drawing. Usually only bindings 0 and 2-4 are populated.
 	VkDescriptorSetLayoutBinding bindings[2] = {};
 	bindings[0].descriptorCount = 1;
@@ -96,13 +127,13 @@ Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
 	assert(VK_SUCCESS == res);
 }
 
-Vulkan2D::~Vulkan2D() {
-	VkDevice device = vulkan_->GetDevice();
-	for (int i = 0; i < 2; i++) {
-		vulkan_->Delete().QueueDeleteDescriptorPool(frameData_[i].descPool);
-	}
-	vkDestroyDescriptorSetLayout(device, descriptorSetLayout_, nullptr);
-	vkDestroyPipelineLayout(device, pipelineLayout_, nullptr);
+void Vulkan2D::DeviceLost() {
+	DestroyDeviceObjects();
+}
+
+void Vulkan2D::DeviceRestore(VulkanContext *vulkan) {
+	vulkan_ = vulkan;
+	InitDeviceObjects();
 }
 
 void Vulkan2D::BeginFrame() {

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -55,6 +55,10 @@ Vulkan2D::~Vulkan2D() {
 	DestroyDeviceObjects();
 }
 
+void Vulkan2D::Shutdown() {
+	DestroyDeviceObjects();
+}
+
 void Vulkan2D::DestroyDeviceObjects() {
 	for (int i = 0; i < 2; i++) {
 		if (frameData_[i].descPool != VK_NULL_HANDLE) {

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -81,6 +81,7 @@ public:
 
 	void DeviceLost();
 	void DeviceRestore(VulkanContext *vulkan);
+	void Shutdown();
 
 	VkPipeline GetPipeline(VkPipelineCache cache, VkRenderPass rp, VkShaderModule vs, VkShaderModule fs);
 

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -79,6 +79,9 @@ public:
 	Vulkan2D(VulkanContext *vulkan);
 	~Vulkan2D();
 
+	void DeviceLost();
+	void DeviceRestore(VulkanContext *vulkan);
+
 	VkPipeline GetPipeline(VkPipelineCache cache, VkRenderPass rp, VkShaderModule vs, VkShaderModule fs);
 
 	void BeginFrame();
@@ -95,6 +98,9 @@ public:
 	};
 
 private:
+	void InitDeviceObjects();
+	void DestroyDeviceObjects();
+
 	VulkanContext *vulkan_;
 	VkDescriptorSetLayout descriptorSetLayout_;
 	VkPipelineLayout pipelineLayout_;


### PR DESCRIPTION
Unfortunately, this does not yet work - do you happen to see what I missed?

What does work:
- On Windows, calling shutdown/lost/init/restore works and things are able to keep moving.
- On Android, resuming the app _sometimes_ crashes in thin3d, but usually succeeds.

However, on resume, the screen is just black.  It must be in EmuScreen / GPU somewhere, though, because resume works properly in the main screen (UI.)  It's only broken ingame.  ~~It even crashes going back to the pause screen.~~ Okay, fixed this time.

Anyway, this is closer.  Without these things, it was crashing in various places throughout.

-[Unknown]
