### PR TITLE
Undo arm64 fix: was a local problem, after all

### DIFF
--- a/Common/Misc.cpp
+++ b/Common/Misc.cpp
@@ -23,10 +23,6 @@
 #if defined(__APPLE__) || defined(__SYMBIAN32__)
 #define __thread
 #endif
-// Experiencing emutls crashes on ARM64 Android, so disabling for now.
-#if defined(ANDROID) && !defined(ARM64)
-#define __thread
-#endif
 
 #ifdef _WIN32
 #include "CommonWindows.h"

--- a/ext/native/thread/threadutil.cpp
+++ b/ext/native/thread/threadutil.cpp
@@ -1,8 +1,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #define TLS_SUPPORTED
-// Experiencing emutls crashes on ARM64 Android, so disabling for now.
-#elif defined(ANDROID) && !defined(ARM64)
+#elif defined(ANDROID)
 #define TLS_SUPPORTED
 #endif
 


### PR DESCRIPTION
Sorry, had forgotten to update `local.properties` with the r13 version, so it wasn't using it.  D'oh.

It does work in r13.

-[Unknown]
