### PR TITLE
Tweak wording to clarify battery save message

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -244,7 +244,11 @@ void EmuScreen::bootComplete() {
 
 	if (Core_GetPowerSaving()) {
 		I18NCategory *sy = GetI18NCategory("System");
+#ifdef ANDROID
+		osm.Show(sy->T("WARNING: Android battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+#else
 		osm.Show(sy->T("WARNING: Battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+#endif
 	}
 
 	System_SendMessage("event", "startgame");

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -794,7 +794,11 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "core_powerSaving") {
 		if (value != "false") {
 			I18NCategory *sy = GetI18NCategory("System");
+#ifdef ANDROID
+			osm.Show(sy->T("WARNING: Android battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+#else
 			osm.Show(sy->T("WARNING: Battery save mode is on"), 2.0f, 0xFFFFFF, -1, true, "core_powerSaving");
+#endif
 		}
 
 		Core_SetPowerSaving(value != "false");


### PR DESCRIPTION
Maybe I'm crazy but I think this'll help clarify it.

Currently Android is the only platform reporting battery status, but Mac, Linux, Windows, iOS, etc. could too.  Maybe "Device battery save mode"?

-[Unknown]
