### PR TITLE
CWCheat: minor fixes for comments

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -183,6 +183,11 @@ void CWCheatEngine::CreateCodeList() { //Creates code list to be used in functio
 		if (initialCodesList[i].substr(0,2) == "_L") {
 			if (cheatEnabled == true) {
 				currentcode = initialCodesList[i];
+				std::size_t comment = currentcode.find("//");
+				if (comment != std::string::npos) {
+					currentcode.erase(currentcode.begin() + comment, currentcode.end());
+					//Purge comments after code lines before adding them to codelist
+				}
 				currentcode.erase(currentcode.begin(), currentcode.begin() + 3);
 				codelist.push_back(currentcode);
 			}

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -274,8 +274,10 @@ UI::EventReturn CwCheatScreen::OnCheckBox(UI::EventParams &params) {
 void CwCheatScreen::processFileOn(std::string activatedCheat) {
 	std::fstream fs;
 	for (size_t i = 0; i < cheatList.size(); i++) {
-		if (cheatList[i].substr(4) == activatedCheat) {
-			cheatList[i] = "_C1 " + activatedCheat;
+		if (cheatList[i].length() >= 4) {
+			if (cheatList[i].substr(4) == activatedCheat) {
+				cheatList[i] = "_C1 " + activatedCheat;
+			}
 		}
 	}
 
@@ -293,8 +295,10 @@ void CwCheatScreen::processFileOn(std::string activatedCheat) {
 void CwCheatScreen::processFileOff(std::string deactivatedCheat) {
 	std::fstream fs;
 	for (size_t i = 0; i < cheatList.size(); i++) {
-		if (cheatList[i].substr(4) == deactivatedCheat) {
-			cheatList[i] = "_C0 " + deactivatedCheat;
+		if (cheatList[i].length() >= 4) {
+			if (cheatList[i].substr(4) == deactivatedCheat) {
+				cheatList[i] = "_C0 " + deactivatedCheat;
+			}
 		}
 	}
 


### PR DESCRIPTION
Changes:
- support for comments after code lines which now kind of can be used, but might mess up code list/affect how cheat works,
- fix a crash which would happen when saving cheat ini file with an empty comment line, cheat engine removes unnecessary lines like empty comments completely, but if we go back to UI before that could happen, it would just crash.
