### PR TITLE
Make 4xHQ look good without tweaking.

### DIFF
--- a/assets/shaders/4xhqglsl.vsh
+++ b/assets/shaders/4xhqglsl.vsh
@@ -1,6 +1,7 @@
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 uniform vec2 u_texelDelta;
+uniform vec2 u_pixelDelta;
 
 varying vec4 v_texcoord0;
 varying vec4 v_texcoord1;
@@ -10,12 +11,10 @@ varying vec4 v_texcoord4;
 varying vec4 v_texcoord5;
 varying vec4 v_texcoord6;
 
-float scaleoffset = 0.8;
-
 void main()
 {
-  float x = u_texelDelta.x*scaleoffset;
-  float y = u_texelDelta.y*scaleoffset;
+  float x = u_pixelDelta.x*((u_texelDelta.x/u_pixelDelta.x)/2);
+  float y = u_pixelDelta.y*((u_texelDelta.y/u_pixelDelta.y)/2);
   vec2 dg1 = vec2( x,y);
   vec2 dg2 = vec2(-x,y);
   vec2 sd1 = dg1*0.5;


### PR DESCRIPTION
Kind of forgot I made this ~ 4xHQ is an upscaling shader which currently requires tweaking per game, this makes it simply work.

Before without manually tweaking the variable:
![ules00850_before](https://cloud.githubusercontent.com/assets/5485237/19632455/e52a6044-99a6-11e6-8c9e-53c3e8f4a66b.jpg)

After ~ automatic:
![ules00850_after](https://cloud.githubusercontent.com/assets/5485237/19632458/ea4dc5b6-99a6-11e6-80b8-619e583a31d2.jpg)
