### PR TITLE
Lower required cmake version to 2.8.12 to be compatible with downstre…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # vim:noexpandtab:
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(PPSSPP)
 enable_language(ASM)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)


### PR DESCRIPTION
…am distros. Fixes https://github.com/hrydgard/ppsspp/issues/9087

I tested what the actual lowest required cmake version is and it seems to be 2.8.12 which allowed me to compile ppsspp fine in Slackware. This should also make ppsspp more compatible with other distros such as debian and ubuntu. I strongly suggest ppsspp not lead the way in updating cmake and remains compatible / friendly with downstream distros. Thanks!
