### PR TITLE
Fix building on rpi - #9104

### DIFF
--- a/Common/ColorConvNEON.cpp
+++ b/Common/ColorConvNEON.cpp
@@ -16,7 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
-#if PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64)
+#if PPSSPP_ARCH(ARM_NEON)
 
 #include <arm_neon.h>
 #include "ColorConvNEON.h"
@@ -109,4 +109,4 @@ void ConvertRGB565ToBGR565NEON(u16 *dst, const u16 *src, const u32 numPixels) {
 	}
 }
 
-#endif // PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64)
+#endif // PPSSPP_ARCH(ARM_NEON)

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -310,7 +310,7 @@ ReliableHash64Func DoReliableHash64 = &XXH64;
 
 // This has to be done after CPUDetect has done its magic.
 void SetupTextureDecoder() {
-#if PPSSPP_ARCH(ARM)
+#if PPSSPP_ARCH(ARM_NEON)
 	if (cpu_info.bNEON) {
 		DoQuickTexHash = &QuickTexHashNEON;
 		StableQuickTexHash = &QuickTexHashNEON;

--- a/cmake/Toolchains/raspberry.armv6.cmake
+++ b/cmake/Toolchains/raspberry.armv6.cmake
@@ -8,20 +8,16 @@ include_directories(SYSTEM
   /opt/vc/include/interface/vmcx_host/linux
 )
 
-link_directories(
-  /opt/vc/lib
-)
-
 add_definitions(
   -DPPSSPP_PLATFORM_RPI=1
 )
 
 set(ARCH_FLAGS "-mfpu=vfp -march=armv6j -mfloat-abi=hard")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}")
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
 
-set(OPENGL_LIBRARIES GLESv2 bcm_host)
+set(OPENGL_LIBRARIES /opt/vc/lib/libGLESv2.so /opt/vc/lib/libbcm_host.so)
 set(USING_GLES2 ON)
 set(USING_FBDEV ON)
 

--- a/cmake/Toolchains/raspberry.armv7.cmake
+++ b/cmake/Toolchains/raspberry.armv7.cmake
@@ -8,21 +8,17 @@ include_directories(SYSTEM
   /opt/vc/include/interface/vmcx_host/linux
 )
 
-link_directories(
-  /opt/vc/lib
-)
-
 add_definitions(
   -DPPSSPP_PLATFORM_RPI=1
   -U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
 )
 
 set(ARCH_FLAGS "-mcpu=cortex-a7 -mfpu=neon -mfloat-abi=hard")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}")
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}"  CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
 
-set(OPENGL_LIBRARIES GLESv2 bcm_host)
+set(OPENGL_LIBRARIES /opt/vc/lib/libGLESv2.so /opt/vc/lib/libbcm_host.so)
 set(USING_GLES2 ON)
 set(USING_FBDEV ON)
 set(ARMV7 ON)


### PR DESCRIPTION
Check for PPSSPP_ARCH(ARM_NEON) for neon code
Fix up rpi armv6/armv6 toolchain to work around issue with CMAKE_*_FLAGS not being set.