### PR TITLE
fix overflow timing

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -642,7 +642,7 @@ void Idle(int maxIdle)
 
 	idledCycles += cyclesDown;
 	currentMIPS->downcount -= cyclesDown;
-	if (currentMIPS->downcount == 0)
+	if (currentMIPS->downcount <= 0)
 		currentMIPS->downcount = -1;
 }
 


### PR DESCRIPTION
Hi, this my try to fix this thing:

```
Core/MIPS/MIPSTables.cpp:1040:29: runtime error: signed integer overflow: -2147483648 + -1 cannot be represented in type 'int'
```

Thx. Cya.