### PR TITLE
More gpu centralization

### DIFF
--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -236,6 +236,8 @@ public:
 	void SetRenderSize(VirtualFramebuffer *vfb);
 	void SetSafeSize(u16 w, u16 h);
 
+	virtual void Resized() = 0;
+
 protected:
 	void UpdateSize();
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -63,10 +63,6 @@ TextureCacheCommon::~TextureCacheCommon() {
 	FreeAlignedMemory(clutBufRaw_);
 }
 
-bool TextureCacheCommon::SetOffsetTexture(u32 offset) {
-	return false;
-}
-
 int TextureCacheCommon::AttachedDrawingHeight() {
 	if (nextTexture_) {
 		if (nextTexture_->framebuffer) {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -50,7 +50,8 @@ public:
 	void LoadClut(u32 clutAddr, u32 loadBytes);
 	bool GetCurrentClutBuffer(GPUDebugBuffer &buffer);
 
-	virtual bool SetOffsetTexture(u32 offset);
+	virtual bool SetOffsetTexture(u32 offset) = 0;
+	virtual void Invalidate(u32 addr, int size, GPUInvalidationType type) = 0;
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory are being rendered to.
 	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -52,6 +52,7 @@ public:
 
 	virtual bool SetOffsetTexture(u32 offset) = 0;
 	virtual void Invalidate(u32 addr, int size, GPUInvalidationType type) = 0;
+	virtual void InvalidateAll(GPUInvalidationType type) = 0;
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory are being rendered to.
 	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg);

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -63,7 +63,7 @@ public:
 	void DestroyAllFBOs(bool forceDelete);
 
 	void EndFrame();
-	void Resized();
+	void Resized() override;
 	void DeviceLost();
 	void CopyDisplayToOutput();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -670,41 +670,6 @@ void GPU_DX9::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_DX9::ProcessEvent(GPUEvent ev) {
-	switch (ev.type) {
-	case GPU_EVENT_INIT_CLEAR:
-		InitClearInternal();
-		break;
-
-	case GPU_EVENT_BEGIN_FRAME:
-		BeginFrameInternal();
-		break;
-
-	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
-		CopyDisplayToOutputInternal();
-		break;
-
-	case GPU_EVENT_INVALIDATE_CACHE:
-		InvalidateCacheInternal(ev.invalidate_cache.addr, ev.invalidate_cache.size, ev.invalidate_cache.type);
-		break;
-
-	case GPU_EVENT_FB_MEMCPY:
-		PerformMemoryCopyInternal(ev.fb_memcpy.dst, ev.fb_memcpy.src, ev.fb_memcpy.size);
-		break;
-
-	case GPU_EVENT_FB_MEMSET:
-		PerformMemorySetInternal(ev.fb_memset.dst, ev.fb_memset.v, ev.fb_memset.size);
-		break;
-
-	case GPU_EVENT_FB_STENCIL_UPLOAD:
-		PerformStencilUploadInternal(ev.fb_stencil_upload.dst, ev.fb_stencil_upload.size);
-		break;
-
-	default:
-		GPUCommon::ProcessEvent(ev);
-	}
-}
-
 inline void GPU_DX9::CheckFlushOp(int cmd, u32 diff) {
 	const u8 cmdFlags = cmdInfo_[cmd].flags;
 	if ((cmdFlags & FLAG_FLUSHBEFORE) || (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE))) {

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -394,7 +394,7 @@ static const CommandTableEntry commandTable[] = {
 GPU_DX9::CommandInfo GPU_DX9::cmdInfo_[256];
 
 GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx)
-: resized_(false), gfxCtx_(gfxCtx) {
+: gfxCtx_(gfxCtx) {
 	lastVsync_ = g_Config.bVSync ? 1 : 0;
 	dxstate.SetVSyncInterval(g_Config.bVSync);
 
@@ -2021,11 +2021,6 @@ bool GPU_DX9::PerformStencilUpload(u32 dest, int size) {
 
 void GPU_DX9::ClearCacheNextFrame() {
 	textureCache_.ClearNextFrame();
-}
-
-void GPU_DX9::Resized() {
-	resized_ = true;
-	framebufferManagerDX9_->Resized();
 }
 
 void GPU_DX9::ClearShaderCache() {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -37,6 +37,7 @@ class GPU_DX9 : public GPUCommon {
 public:
 	GPU_DX9(GraphicsContext *gfxCtx);
 	~GPU_DX9();
+
 	void CheckGPUFeatures();
 	void InitClear() override;
 	void PreExecuteOp(u32 op, u32 diff) override;
@@ -61,8 +62,6 @@ public:
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;
 
-	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.
-	void Resized() override;
 	void ClearShaderCache() override;
 	bool DecodeTexture(u8 *dest, const GPUgstate &state) override {
 		return textureCache_.DecodeTexture(dest, state);
@@ -182,7 +181,6 @@ private:
 
 	static CommandInfo cmdInfo_[256];
 
-	bool resized_;
 	int lastVsync_;
 
 	std::string reportingPrimaryInfo_;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -163,7 +163,6 @@ private:
 	void Flush() {
 		drawEngine_.Flush();
 	}
-	void DoBlockTransfer(u32 skipDrawReason);
 	void ApplyDrawState(int prim);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
@@ -175,7 +174,7 @@ private:
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
-	FramebufferManagerDX9 framebufferManager_;
+	FramebufferManagerDX9 *framebufferManagerDX9_;
 	TextureCacheDX9 textureCache_;
 	DepalShaderCacheDX9 depalShaderCache_;
 	DrawEngineDX9 drawEngine_;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -39,13 +39,11 @@ public:
 	~GPU_DX9();
 
 	void CheckGPUFeatures();
-	void InitClear() override;
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void ReapplyGfxStateInternal() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
-	void CopyDisplayToOutput() override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void ClearCacheNextFrame() override;
@@ -57,7 +55,7 @@ public:
 
 	void ClearShaderCache() override;
 	bool DecodeTexture(u8 *dest, const GPUgstate &state) override {
-		return textureCache_.DecodeTexture(dest, state);
+		return textureCacheDX9_->DecodeTexture(dest, state);
 	}
 	bool FramebufferDirty() override;
 	bool FramebufferReallyDirty() override;
@@ -163,7 +161,7 @@ private:
 	void CopyDisplayToOutputInternal();
 
 	FramebufferManagerDX9 *framebufferManagerDX9_;
-	TextureCacheDX9 textureCache_;
+	TextureCacheDX9 *textureCacheDX9_;
 	DepalShaderCacheDX9 depalShaderCache_;
 	DrawEngineDX9 drawEngine_;
 	ShaderManagerDX9 *shaderManager_;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -50,10 +50,6 @@ public:
 	void GetStats(char *buffer, size_t bufsize) override;
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
 	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
-	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
-	bool PerformMemorySet(u32 dest, u8 v, int size) override;
-	bool PerformMemoryDownload(u32 dest, int size) override;
-	bool PerformMemoryUpload(u32 dest, int size) override;
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
@@ -168,8 +164,6 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
-	void PerformMemorySetInternal(u32 dest, u8 v, int size);
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -143,7 +143,6 @@ public:
 
 protected:
 	void FastRunLoop(DisplayList &list) override;
-	void ProcessEvent(GPUEvent ev) override;
 	void FastLoadBoneMatrix(u32 target) override;
 	void FinishDeferred() override;
 
@@ -156,9 +155,10 @@ private:
 	// void ApplyDrawState(int prim);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
-	void InitClearInternal();
-	void BeginFrameInternal();
-	void CopyDisplayToOutputInternal();
+
+	void InitClearInternal() override;
+	void BeginFrameInternal() override;
+	void CopyDisplayToOutputInternal() override;
 
 	FramebufferManagerDX9 *framebufferManagerDX9_;
 	TextureCacheDX9 *textureCacheDX9_;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -48,9 +48,6 @@ public:
 	void CopyDisplayToOutput() override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
-	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
-	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
-	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
@@ -158,14 +155,12 @@ private:
 	void Flush() {
 		drawEngine_.Flush();
 	}
-	void ApplyDrawState(int prim);
+	// void ApplyDrawState(int prim);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformStencilUploadInternal(u32 dest, int size);
-	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
 	FramebufferManagerDX9 *framebufferManagerDX9_;
 	TextureCacheDX9 textureCache_;

--- a/GPU/GLES/Framebuffer.h
+++ b/GPU/GLES/Framebuffer.h
@@ -86,7 +86,7 @@ public:
 
 	virtual void Init() override;
 	void EndFrame();
-	void Resized();
+	void Resized() override;
 	void DeviceLost();
 	void CopyDisplayToOutput();
 	void SetLineWidth();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -664,15 +664,6 @@ void GPU_GLES::DeviceRestore() {
 	UpdateVsyncInterval(true);
 }
 
-void GPU_GLES::InitClear() {
-	ScheduleEvent(GPU_EVENT_INIT_CLEAR);
-}
-
-void GPU_GLES::Reinitialize() {
-	GPUCommon::Reinitialize();
-	ScheduleEvent(GPU_EVENT_REINITIALIZE);
-}
-
 void GPU_GLES::ReinitializeInternal() {
 	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
@@ -812,10 +803,6 @@ bool GPU_GLES::FramebufferReallyDirty() {
 		return dirty;
 	}
 	return true;
-}
-
-void GPU_GLES::CopyDisplayToOutput() {
-	ScheduleEvent(GPU_EVENT_COPY_DISPLAY_TO_OUTPUT);
 }
 
 void GPU_GLES::CopyDisplayToOutputInternal() {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -863,45 +863,6 @@ void GPU_GLES::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_GLES::ProcessEvent(GPUEvent ev) {
-	switch (ev.type) {
-	case GPU_EVENT_INIT_CLEAR:
-		InitClearInternal();
-		break;
-
-	case GPU_EVENT_BEGIN_FRAME:
-		BeginFrameInternal();
-		break;
-
-	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
-		CopyDisplayToOutputInternal();
-		break;
-
-	case GPU_EVENT_INVALIDATE_CACHE:
-		InvalidateCacheInternal(ev.invalidate_cache.addr, ev.invalidate_cache.size, ev.invalidate_cache.type);
-		break;
-
-	case GPU_EVENT_FB_MEMCPY:
-		PerformMemoryCopyInternal(ev.fb_memcpy.dst, ev.fb_memcpy.src, ev.fb_memcpy.size);
-		break;
-
-	case GPU_EVENT_FB_MEMSET:
-		PerformMemorySetInternal(ev.fb_memset.dst, ev.fb_memset.v, ev.fb_memset.size);
-		break;
-
-	case GPU_EVENT_FB_STENCIL_UPLOAD:
-		PerformStencilUploadInternal(ev.fb_stencil_upload.dst, ev.fb_stencil_upload.size);
-		break;
-
-	case GPU_EVENT_REINITIALIZE:
-		ReinitializeInternal();
-		break;
-
-	default:
-		GPUCommon::ProcessEvent(ev);
-	}
-}
-
 inline void GPU_GLES::CheckFlushOp(int cmd, u32 diff) {
 	const u8 cmdFlags = cmdInfo_[cmd].flags;
 	if ((cmdFlags & FLAG_FLUSHBEFORE) || (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE))) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -402,19 +402,24 @@ GPU_GLES::GPU_GLES(GraphicsContext *ctx)
 	CheckGPUFeatures();
 
 	shaderManager_ = new ShaderManager();
+	framebufferManagerGL_ = new FramebufferManager();
+	framebufferManager_ = framebufferManagerGL_;
+	textureCacheGL_ = new TextureCache();
+	textureCache_ = textureCacheGL_;
+
 	drawEngine_.SetShaderManager(shaderManager_);
-	drawEngine_.SetTextureCache(&textureCache_);
-	drawEngine_.SetFramebufferManager(&framebufferManager_);
+	drawEngine_.SetTextureCache(textureCacheGL_);
+	drawEngine_.SetFramebufferManager(framebufferManagerGL_);
 	drawEngine_.SetFragmentTestCache(&fragmentTestCache_);
-	framebufferManager_.Init();
-	framebufferManager_.SetTextureCache(&textureCache_);
-	framebufferManager_.SetShaderManager(shaderManager_);
-	framebufferManager_.SetTransformDrawEngine(&drawEngine_);
-	textureCache_.SetFramebufferManager(&framebufferManager_);
-	textureCache_.SetDepalShaderCache(&depalShaderCache_);
-	textureCache_.SetShaderManager(shaderManager_);
-	textureCache_.SetTransformDrawEngine(&drawEngine_);
-	fragmentTestCache_.SetTextureCache(&textureCache_);
+	framebufferManagerGL_->Init();
+	framebufferManagerGL_->SetTextureCache(textureCacheGL_);
+	framebufferManagerGL_->SetShaderManager(shaderManager_);
+	framebufferManagerGL_->SetTransformDrawEngine(&drawEngine_);
+	textureCacheGL_->SetFramebufferManager(framebufferManagerGL_);
+	textureCacheGL_->SetDepalShaderCache(&depalShaderCache_);
+	textureCacheGL_->SetShaderManager(shaderManager_);
+	textureCacheGL_->SetTransformDrawEngine(&drawEngine_);
+	fragmentTestCache_.SetTextureCache(textureCacheGL_);
 
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {
@@ -457,7 +462,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *ctx)
 	// We restore each frame anyway, but here is convenient for tests.
 	glstate.Restore();
 	drawEngine_.RestoreVAO();
-	textureCache_.NotifyConfigChanged();
+	textureCacheGL_->NotifyConfigChanged();
 
 	// Load shader cache.
 	std::string discID = g_paramSFO.GetValueString("DISC_ID");
@@ -469,7 +474,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *ctx)
 }
 
 GPU_GLES::~GPU_GLES() {
-	framebufferManager_.DestroyAllFBOs(true);
+	framebufferManagerGL_->DestroyAllFBOs(true);
 	shaderManager_->ClearCache(true);
 	depalShaderCache_.Clear();
 	fragmentTestCache_.Clear();
@@ -647,10 +652,10 @@ void GPU_GLES::DeviceLost() {
 	// FBOs appear to survive? Or no?
 	// TransformDraw has registered as a GfxResourceHolder.
 	shaderManager_->ClearCache(false);
-	textureCache_.Clear(false);
+	textureCacheGL_->Clear(false);
 	fragmentTestCache_.Clear(false);
 	depalShaderCache_.Clear();
-	framebufferManager_.DeviceLost();
+	framebufferManagerGL_->DeviceLost();
 }
 
 void GPU_GLES::DeviceRestore() {
@@ -669,10 +674,10 @@ void GPU_GLES::Reinitialize() {
 }
 
 void GPU_GLES::ReinitializeInternal() {
-	textureCache_.Clear(true);
+	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManager_.DestroyAllFBOs(true);
-	framebufferManager_.Resized();
+	framebufferManagerGL_->DestroyAllFBOs(true);
+	framebufferManagerGL_->Resized();
 }
 
 void GPU_GLES::InitClearInternal() {
@@ -742,12 +747,12 @@ void GPU_GLES::BeginFrameInternal() {
 		CheckGPUFeatures();
 		UpdateCmdInfo();
 		drawEngine_.Resized();
-		textureCache_.NotifyConfigChanged();
+		textureCacheGL_->NotifyConfigChanged();
 	}
 	UpdateVsyncInterval(resized_);
 	resized_ = false;
 
-	textureCache_.StartFrame();
+	textureCacheGL_->StartFrame();
 	drawEngine_.DecimateTrackedVertexArrays();
 	drawEngine_.DecimateBuffers();
 	depalShaderCache_.Decimate();
@@ -771,12 +776,12 @@ void GPU_GLES::BeginFrameInternal() {
 	// Not sure if this is really needed.
 	shaderManager_->DirtyUniform(DIRTY_ALL);
 
-	framebufferManager_.BeginFrame();
+	framebufferManagerGL_->BeginFrame();
 }
 
 void GPU_GLES::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {
 	host->GPUNotifyDisplay(framebuf, stride, format);
-	framebufferManager_.SetDisplayFramebuffer(framebuf, stride, format);
+	framebufferManagerGL_->SetDisplayFramebuffer(framebuf, stride, format);
 }
 
 bool GPU_GLES::FramebufferDirty() {
@@ -785,7 +790,7 @@ bool GPU_GLES::FramebufferDirty() {
 		SyncThread();
 	}
 
-	VirtualFramebuffer *vfb = framebufferManager_.GetDisplayVFB();
+	VirtualFramebuffer *vfb = framebufferManagerGL_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
 		vfb->dirtyAfterDisplay = false;
@@ -800,7 +805,7 @@ bool GPU_GLES::FramebufferReallyDirty() {
 		SyncThread();
 	}
 
-	VirtualFramebuffer *vfb = framebufferManager_.GetDisplayVFB();
+	VirtualFramebuffer *vfb = framebufferManagerGL_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;
 		vfb->reallyDirtyAfterDisplay = false;
@@ -815,7 +820,7 @@ void GPU_GLES::CopyDisplayToOutput() {
 
 void GPU_GLES::CopyDisplayToOutputInternal() {
 	// Flush anything left over.
-	framebufferManager_.RebindFramebuffer();
+	framebufferManagerGL_->RebindFramebuffer();
 	drawEngine_.Flush();
 
 	shaderManager_->DirtyLastShader();
@@ -823,8 +828,8 @@ void GPU_GLES::CopyDisplayToOutputInternal() {
 	glstate.depthWrite.set(GL_TRUE);
 	glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
-	framebufferManager_.CopyDisplayToOutput();
-	framebufferManager_.EndFrame();
+	framebufferManagerGL_->CopyDisplayToOutput();
+	framebufferManagerGL_->EndFrame();
 
 	// If buffered, discard the depth buffer of the backbuffer. Don't even know if we need one.
 #if 0
@@ -965,7 +970,7 @@ void GPU_GLES::Execute_Prim(u32 op, u32 diff) {
 	}
 
 	// This also makes skipping drawing very effective.
-	framebufferManager_.SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
+	framebufferManagerGL_->SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
 		drawEngine_.SetupVertexDecoder(gstate.vertType);
 		// Rough estimate, not sure what's correct.
@@ -1034,7 +1039,7 @@ void GPU_GLES::Execute_VertexTypeSkinning(u32 op, u32 diff) {
 
 void GPU_GLES::Execute_Bezier(u32 op, u32 diff) {
 	// This also make skipping drawing very effective.
-	framebufferManager_.SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
+	framebufferManagerGL_->SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
 		// TODO: Should this eat some cycles?  Probably yes.  Not sure if important.
 		return;
@@ -1077,7 +1082,7 @@ void GPU_GLES::Execute_Bezier(u32 op, u32 diff) {
 
 void GPU_GLES::Execute_Spline(u32 op, u32 diff) {
 	// This also make skipping drawing very effective.
-	framebufferManager_.SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
+	framebufferManagerGL_->SetRenderFrameBuffer(gstate_c.framebufChanged, gstate_c.skipDrawReason);
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB))	{
 		// TODO: Should this eat some cycles?  Probably yes.  Not sure if important.
 		return;
@@ -1257,7 +1262,7 @@ void GPU_GLES::Execute_TexLevel(u32 op, u32 diff) {
 
 void GPU_GLES::Execute_LoadClut(u32 op, u32 diff) {
 	gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
-	textureCache_.LoadClut(gstate.getClutAddress(), gstate.getClutLoadBytes());
+	textureCacheGL_->LoadClut(gstate.getClutAddress(), gstate.getClutLoadBytes());
 	// This could be used to "dirty" textures with clut.
 }
 
@@ -2135,102 +2140,13 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numVertsSubmitted,
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
-		(int)framebufferManager_.NumVFBs(),
-		(int)textureCache_.NumLoadedTextures(),
+		(int)framebufferManagerGL_->NumVFBs(),
+		(int)textureCacheGL_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,
 		shaderManager_->NumVertexShaders(),
 		shaderManager_->NumFragmentShaders(),
 		shaderManager_->NumPrograms());
-}
-
-void GPU_GLES::DoBlockTransfer(u32 skipDrawReason) {
-	// TODO: This is used a lot to copy data around between render targets and textures,
-	// and also to quickly load textures from RAM to VRAM. So we should do checks like the following:
-	//  * Does dstBasePtr point to an existing texture? If so maybe reload it immediately.
-	//
-	//  * Does srcBasePtr point to a render target, and dstBasePtr to a texture? If so
-	//    either copy between rt and texture or reassign the texture to point to the render target
-	//
-	// etc....
-
-	u32 srcBasePtr = gstate.getTransferSrcAddress();
-	u32 srcStride = gstate.getTransferSrcStride();
-
-	u32 dstBasePtr = gstate.getTransferDstAddress();
-	u32 dstStride = gstate.getTransferDstStride();
-
-	int srcX = gstate.getTransferSrcX();
-	int srcY = gstate.getTransferSrcY();
-
-	int dstX = gstate.getTransferDstX();
-	int dstY = gstate.getTransferDstY();
-
-	int width = gstate.getTransferWidth();
-	int height = gstate.getTransferHeight();
-
-	int bpp = gstate.getTransferBpp();
-
-	DEBUG_LOG(G3D, "Block transfer: %08x/%x -> %08x/%x, %ix%ix%i (%i,%i)->(%i,%i)", srcBasePtr, srcStride, dstBasePtr, dstStride, width, height, bpp, srcX, srcY, dstX, dstY);
-
-	if (!Memory::IsValidAddress(srcBasePtr)) {
-		ERROR_LOG_REPORT(G3D, "BlockTransfer: Bad source transfer address %08x!", srcBasePtr);
-		return;
-	}
-
-	if (!Memory::IsValidAddress(dstBasePtr)) {
-		ERROR_LOG_REPORT(G3D, "BlockTransfer: Bad destination transfer address %08x!", dstBasePtr);
-		return;
-	}
-	
-	// Check that the last address of both source and dest are valid addresses
-
-	u32 srcLastAddr = srcBasePtr + ((srcY + height - 1) * srcStride + (srcX + width - 1)) * bpp;
-	u32 dstLastAddr = dstBasePtr + ((dstY + height - 1) * dstStride + (dstX + width - 1)) * bpp;
-
-	if (!Memory::IsValidAddress(srcLastAddr)) {
-		ERROR_LOG_REPORT(G3D, "Bottom-right corner of source of block transfer is at an invalid address: %08x", srcLastAddr);
-		return;
-	}
-	if (!Memory::IsValidAddress(dstLastAddr)) {
-		ERROR_LOG_REPORT(G3D, "Bottom-right corner of destination of block transfer is at an invalid address: %08x", srcLastAddr);
-		return;
-	}
-
-	// Tell the framebuffer manager to take action if possible. If it does the entire thing, let's just return.
-	if (!framebufferManager_.NotifyBlockTransferBefore(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason)) {
-		// Do the copy! (Hm, if we detect a drawn video frame (see below) then we could maybe skip this?)
-		// Can use GetPointerUnchecked because we checked the addresses above. We could also avoid them
-		// entirely by walking a couple of pointers...
-		if (srcStride == dstStride && (u32)width == srcStride) {
-			// Common case in God of War, let's do it all in one chunk.
-			u32 srcLineStartAddr = srcBasePtr + (srcY * srcStride + srcX) * bpp;
-			u32 dstLineStartAddr = dstBasePtr + (dstY * dstStride + dstX) * bpp;
-			const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-			u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
-			memcpy(dst, src, width * height * bpp);
-		} else {
-			for (int y = 0; y < height; y++) {
-				u32 srcLineStartAddr = srcBasePtr + ((y + srcY) * srcStride + srcX) * bpp;
-				u32 dstLineStartAddr = dstBasePtr + ((y + dstY) * dstStride + dstX) * bpp;
-
-				const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-				u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
-				memcpy(dst, src, width * bpp);
-			}
-		}
-
-		textureCache_.Invalidate(dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, GPU_INVALIDATE_HINT);
-		framebufferManager_.NotifyBlockTransferAfter(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason);
-	}
-
-#ifndef MOBILE_DEVICE
-	CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
-	CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
-#endif
-
-	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
-	cyclesExecuted += ((height * width * bpp) * 16) / 10;
 }
 
 void GPU_GLES::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
@@ -2243,29 +2159,29 @@ void GPU_GLES::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 
 void GPU_GLES::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type) {
 	if (size > 0)
-		textureCache_.Invalidate(addr, size, type);
+		textureCacheGL_->Invalidate(addr, size, type);
 	else
-		textureCache_.InvalidateAll(type);
+		textureCacheGL_->InvalidateAll(type);
 
-	if (type != GPU_INVALIDATE_ALL && framebufferManager_.MayIntersectFramebuffer(addr)) {
+	if (type != GPU_INVALIDATE_ALL && framebufferManagerGL_->MayIntersectFramebuffer(addr)) {
 		// If we're doing block transfers, we shouldn't need this, and it'll only confuse us.
 		// Vempire invalidates (with writeback) after drawing, but before blitting.
 		if (!g_Config.bBlockTransferGPU || type == GPU_INVALIDATE_SAFE) {
-			framebufferManager_.UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
+			framebufferManagerGL_->UpdateFromMemory(addr, size, type == GPU_INVALIDATE_SAFE);
 		}
 	}
 }
 
 void GPU_GLES::NotifyVideoUpload(u32 addr, int size, int width, int format) {
 	if (Memory::IsVRAMAddress(addr)) {
-		framebufferManager_.NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
+		framebufferManagerGL_->NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
 	}
-	textureCache_.NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
+	textureCacheGL_->NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
 	InvalidateCache(addr, size, GPU_INVALIDATE_SAFE);
 }
 
 void GPU_GLES::PerformMemoryCopyInternal(u32 dest, u32 src, int size) {
-	if (!framebufferManager_.NotifyFramebufferCopy(src, dest, size, false, gstate_c.skipDrawReason)) {
+	if (!framebufferManagerGL_->NotifyFramebufferCopy(src, dest, size, false, gstate_c.skipDrawReason)) {
 		// We use a little hack for Download/Upload using a VRAM mirror.
 		// Since they're identical we don't need to copy.
 		if (!Memory::IsVRAMAddress(dest) || (dest ^ 0x00400000) != src) {
@@ -2276,18 +2192,18 @@ void GPU_GLES::PerformMemoryCopyInternal(u32 dest, u32 src, int size) {
 }
 
 void GPU_GLES::PerformMemorySetInternal(u32 dest, u8 v, int size) {
-	if (!framebufferManager_.NotifyFramebufferCopy(dest, dest, size, true, gstate_c.skipDrawReason)) {
+	if (!framebufferManagerGL_->NotifyFramebufferCopy(dest, dest, size, true, gstate_c.skipDrawReason)) {
 		InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	}
 }
 
 void GPU_GLES::PerformStencilUploadInternal(u32 dest, int size) {
-	framebufferManager_.NotifyStencilUpload(dest, size);
+	framebufferManagerGL_->NotifyStencilUpload(dest, size);
 }
 
 bool GPU_GLES::PerformMemoryCopy(u32 dest, u32 src, int size) {
 	// Track stray copies of a framebuffer in RAM. MotoGP does this.
-	if (framebufferManager_.MayIntersectFramebuffer(src) || framebufferManager_.MayIntersectFramebuffer(dest)) {
+	if (framebufferManagerGL_->MayIntersectFramebuffer(src) || framebufferManagerGL_->MayIntersectFramebuffer(dest)) {
 		if (IsOnSeparateCPUThread()) {
 			GPUEvent ev(GPU_EVENT_FB_MEMCPY);
 			ev.fb_memcpy.dst = dest;
@@ -2309,7 +2225,7 @@ bool GPU_GLES::PerformMemoryCopy(u32 dest, u32 src, int size) {
 
 bool GPU_GLES::PerformMemorySet(u32 dest, u8 v, int size) {
 	// This may indicate a memset, usually to 0, of a framebuffer.
-	if (framebufferManager_.MayIntersectFramebuffer(dest)) {
+	if (framebufferManagerGL_->MayIntersectFramebuffer(dest)) {
 		Memory::Memset(dest, v, size);
 
 		if (IsOnSeparateCPUThread()) {
@@ -2350,7 +2266,7 @@ bool GPU_GLES::PerformMemoryUpload(u32 dest, int size) {
 }
 
 bool GPU_GLES::PerformStencilUpload(u32 dest, int size) {
-	if (framebufferManager_.MayIntersectFramebuffer(dest)) {
+	if (framebufferManagerGL_->MayIntersectFramebuffer(dest)) {
 		if (IsOnSeparateCPUThread()) {
 			GPUEvent ev(GPU_EVENT_FB_STENCIL_UPLOAD);
 			ev.fb_stencil_upload.dst = dest;
@@ -2365,12 +2281,12 @@ bool GPU_GLES::PerformStencilUpload(u32 dest, int size) {
 }
 
 void GPU_GLES::ClearCacheNextFrame() {
-	textureCache_.ClearNextFrame();
+	textureCacheGL_->ClearNextFrame();
 }
 
 void GPU_GLES::Resized() {
 	resized_ = true;
-	framebufferManager_.Resized();
+	framebufferManagerGL_->Resized();
 }
 
 void GPU_GLES::ClearShaderCache() {
@@ -2385,7 +2301,7 @@ void GPU_GLES::CleanupBeforeUI() {
 }
 
 std::vector<FramebufferInfo> GPU_GLES::GetFramebufferList() {
-	return framebufferManager_.GetFramebufferList();
+	return framebufferManagerGL_->GetFramebufferList();
 }
 
 void GPU_GLES::DoState(PointerWrap &p) {
@@ -2395,21 +2311,21 @@ void GPU_GLES::DoState(PointerWrap &p) {
 	// None of these are necessary when saving.
 	// In Freeze-Frame mode, we don't want to do any of this.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_.Clear(true);
+		textureCacheGL_->Clear(true);
 		depalShaderCache_.Clear();
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.textureChanged = TEXCHANGE_UPDATED;
-		framebufferManager_.DestroyAllFBOs(true);
+		framebufferManagerGL_->DestroyAllFBOs(true);
 		shaderManager_->ClearCache(true);
 	}
 }
 
 bool GPU_GLES::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) {
-	u32 fb_address = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.getFrameBufRawAddress() : framebufferManager_.DisplayFramebufAddr();
-	int fb_stride = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufStride() : framebufferManager_.DisplayFramebufStride();
-	GEBufferFormat format = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufFormat() : framebufferManager_.DisplayFramebufFormat();
-	return framebufferManager_.GetFramebuffer(fb_address, fb_stride, format, buffer, maxRes);
+	u32 fb_address = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.getFrameBufRawAddress() : framebufferManagerGL_->DisplayFramebufAddr();
+	int fb_stride = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufStride() : framebufferManagerGL_->DisplayFramebufStride();
+	GEBufferFormat format = type == GPU_DBG_FRAMEBUF_RENDER ? gstate.FrameBufFormat() : framebufferManagerGL_->DisplayFramebufFormat();
+	return framebufferManagerGL_->GetFramebuffer(fb_address, fb_stride, format, buffer, maxRes);
 }
 
 bool GPU_GLES::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
@@ -2419,14 +2335,14 @@ bool GPU_GLES::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 	u32 z_address = gstate.getDepthBufRawAddress();
 	int z_stride = gstate.DepthBufStride();
 
-	return framebufferManager_.GetDepthbuffer(fb_address, fb_stride, z_address, z_stride, buffer);
+	return framebufferManagerGL_->GetDepthbuffer(fb_address, fb_stride, z_address, z_stride, buffer);
 }
 
 bool GPU_GLES::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
 	u32 fb_address = gstate.getFrameBufRawAddress();
 	int fb_stride = gstate.FrameBufStride();
 
-	return framebufferManager_.GetStencilbuffer(fb_address, fb_stride, buffer);
+	return framebufferManagerGL_->GetStencilbuffer(fb_address, fb_stride, buffer);
 }
 
 bool GPU_GLES::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
@@ -2445,8 +2361,8 @@ bool GPU_GLES::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 		gstate.texbufwidth[0] = gstate.texbufwidth[level];
 	}
 
-	textureCache_.SetTexture(true);
-	textureCache_.ApplyTexture();
+	textureCacheGL_->SetTexture(true);
+	textureCacheGL_->ApplyTexture();
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
@@ -2467,7 +2383,7 @@ bool GPU_GLES::GetCurrentTexture(GPUDebugBuffer &buffer, int level) {
 }
 
 bool GPU_GLES::GetCurrentClut(GPUDebugBuffer &buffer) {
-	return textureCache_.GetCurrentClutBuffer(buffer);
+	return textureCacheGL_->GetCurrentClutBuffer(buffer);
 }
 
 bool GPU_GLES::GetOutputFramebuffer(GPUDebugBuffer &buffer) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -397,7 +397,7 @@ static const CommandTableEntry commandTable[] = {
 GPU_GLES::CommandInfo GPU_GLES::cmdInfo_[256];
 
 GPU_GLES::GPU_GLES(GraphicsContext *ctx)
-: resized_(false), gfxCtx_(ctx) {
+: gfxCtx_(ctx) {
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
 
@@ -2282,11 +2282,6 @@ bool GPU_GLES::PerformStencilUpload(u32 dest, int size) {
 
 void GPU_GLES::ClearCacheNextFrame() {
 	textureCacheGL_->ClearNextFrame();
-}
-
-void GPU_GLES::Resized() {
-	resized_ = true;
-	framebufferManagerGL_->Resized();
 }
 
 void GPU_GLES::ClearShaderCache() {

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -51,9 +51,7 @@ public:
 	void CopyDisplayToOutput() override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
-	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
-	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
-	bool PerformStencilUpload(u32 dest, int size) override;
+
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
@@ -167,8 +165,6 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformStencilUploadInternal(u32 dest, int size);
-	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 	void ReinitializeInternal();
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -40,15 +40,12 @@ public:
 	// This gets called on startup and when we get back from settings.
 	void CheckGPUFeatures();
 
-	void InitClear() override;
-	void Reinitialize() override;
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void Execute_Generic(u32 op, u32 diff);
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void ReapplyGfxStateInternal() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
-	void CopyDisplayToOutput() override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -70,7 +70,7 @@ public:
 	void ClearShaderCache() override;
 	void CleanupBeforeUI() override;
 	bool DecodeTexture(u8 *dest, const GPUgstate &state) override {
-		return textureCache_.DecodeTexture(dest, state);
+		return textureCacheGL_->DecodeTexture(dest, state);
 	}
 	bool FramebufferDirty() override;
 	bool FramebufferReallyDirty() override;
@@ -168,7 +168,6 @@ private:
 	void Flush() {
 		drawEngine_.Flush();
 	}
-	void DoBlockTransfer(u32 skipDrawReason);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 	void InitClearInternal();
@@ -184,8 +183,8 @@ private:
 
 	static CommandInfo cmdInfo_[256];
 
-	FramebufferManager framebufferManager_;
-	TextureCache textureCache_;
+	FramebufferManager *framebufferManagerGL_;
+	TextureCache *textureCacheGL_;
 	DepalShaderCache depalShaderCache_;
 	DrawEngineGLES drawEngine_;
 	FragmentTestCache fragmentTestCache_;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -65,8 +65,6 @@ public:
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;
 
-	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.
-	void Resized() override;
 	void ClearShaderCache() override;
 	void CleanupBeforeUI() override;
 	bool DecodeTexture(u8 *dest, const GPUgstate &state) override {
@@ -190,7 +188,6 @@ private:
 	FragmentTestCache fragmentTestCache_;
 	ShaderManager *shaderManager_;
 
-	bool resized_;
 	int lastVsync_;
 
 	std::string reportingPrimaryInfo_;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -53,10 +53,6 @@ public:
 	void GetStats(char *buffer, size_t bufsize) override;
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
 	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
-	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
-	bool PerformMemorySet(u32 dest, u8 v, int size) override;
-	bool PerformMemoryDownload(u32 dest, int size) override;
-	bool PerformMemoryUpload(u32 dest, int size) override;
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
@@ -171,8 +167,6 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
-	void PerformMemorySetInternal(u32 dest, u8 v, int size);
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 	void ReinitializeInternal();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -149,7 +149,6 @@ public:
 
 protected:
 	void FastRunLoop(DisplayList &list) override;
-	void ProcessEvent(GPUEvent ev) override;
 	void FastLoadBoneMatrix(u32 target) override;
 	void FinishDeferred() override;
 
@@ -159,10 +158,12 @@ private:
 	}
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
-	void InitClearInternal();
-	void BeginFrameInternal();
-	void CopyDisplayToOutputInternal();
-	void ReinitializeInternal();
+
+	void InitClearInternal() override;
+	void BeginFrameInternal() override;
+	void CopyDisplayToOutputInternal() override;
+	void ReinitializeInternal() override;
+
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -20,6 +20,7 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceGe.h"
 #include "Core/Debugger/Breakpoints.h"
+#include "Core/MemMapHelpers.h"
 #include "GPU/Common/FramebufferCommon.h"
 #include "GPU/Common/TextureCacheCommon.h"
 
@@ -1412,4 +1413,85 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 
 	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 	cyclesExecuted += ((height * width * bpp) * 16) / 10;
+}
+
+void GPUCommon::PerformMemoryCopyInternal(u32 dest, u32 src, int size) {
+	if (!framebufferManager_->NotifyFramebufferCopy(src, dest, size, false, gstate_c.skipDrawReason)) {
+		// We use a little hack for Download/Upload using a VRAM mirror.
+		// Since they're identical we don't need to copy.
+		if (!Memory::IsVRAMAddress(dest) || (dest ^ 0x00400000) != src) {
+			Memory::Memcpy(dest, src, size);
+		}
+	}
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+}
+
+void GPUCommon::PerformMemorySetInternal(u32 dest, u8 v, int size) {
+	if (!framebufferManager_->NotifyFramebufferCopy(dest, dest, size, true, gstate_c.skipDrawReason)) {
+		InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	}
+}
+
+bool GPUCommon::PerformMemoryCopy(u32 dest, u32 src, int size) {
+	// Track stray copies of a framebuffer in RAM. MotoGP does this.
+	if (framebufferManager_->MayIntersectFramebuffer(src) || framebufferManager_->MayIntersectFramebuffer(dest)) {
+		if (IsOnSeparateCPUThread()) {
+			GPUEvent ev(GPU_EVENT_FB_MEMCPY);
+			ev.fb_memcpy.dst = dest;
+			ev.fb_memcpy.src = src;
+			ev.fb_memcpy.size = size;
+			ScheduleEvent(ev);
+
+			// This is a memcpy, so we need to wait for it to complete.
+			SyncThread();
+		} else {
+			PerformMemoryCopyInternal(dest, src, size);
+		}
+		return true;
+	}
+
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
+bool GPUCommon::PerformMemorySet(u32 dest, u8 v, int size) {
+	// This may indicate a memset, usually to 0, of a framebuffer.
+	if (framebufferManager_->MayIntersectFramebuffer(dest)) {
+		Memory::Memset(dest, v, size);
+
+		if (IsOnSeparateCPUThread()) {
+			GPUEvent ev(GPU_EVENT_FB_MEMSET);
+			ev.fb_memset.dst = dest;
+			ev.fb_memset.v = v;
+			ev.fb_memset.size = size;
+			ScheduleEvent(ev);
+
+			// We don't need to wait for the framebuffer to be updated.
+		} else {
+			PerformMemorySetInternal(dest, v, size);
+		}
+		return true;
+	}
+
+	// Or perhaps a texture, let's invalidate.
+	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
+	return false;
+}
+
+bool GPUCommon::PerformMemoryDownload(u32 dest, int size) {
+	// Cheat a bit to force a download of the framebuffer.
+	// VRAM + 0x00400000 is simply a VRAM mirror.
+	if (Memory::IsVRAMAddress(dest)) {
+		return PerformMemoryCopy(dest ^ 0x00400000, dest, size);
+	}
+	return false;
+}
+
+bool GPUCommon::PerformMemoryUpload(u32 dest, int size) {
+	// Cheat a bit to force an upload of the framebuffer.
+	// VRAM + 0x00400000 is simply a VRAM mirror.
+	if (Memory::IsVRAMAddress(dest)) {
+		return PerformMemoryCopy(dest, dest ^ 0x00400000, size);
+	}
+	return false;
 }

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -56,6 +56,14 @@ void GPUCommon::EndHostFrame() {
 
 }
 
+void GPUCommon::InitClear() {
+	ScheduleEvent(GPU_EVENT_INIT_CLEAR);
+}
+
+void GPUCommon::CopyDisplayToOutput() {
+	ScheduleEvent(GPU_EVENT_COPY_DISPLAY_TO_OUTPUT);
+}
+
 void GPUCommon::Reinitialize() {
 	easy_guard guard(listLock);
 	memset(dls, 0, sizeof(dls));
@@ -72,6 +80,7 @@ void GPUCommon::Reinitialize() {
 	timeSpentStepping_ = 0.0;
 	interruptsEnabled_ = true;
 	UpdateTickEstimate(0);
+	ScheduleEvent(GPU_EVENT_REINITIALIZE);
 }
 
 void GPUCommon::PopDLQueue() {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -698,8 +698,37 @@ void GPUCommon::ProcessEvent(GPUEvent ev) {
 		ReapplyGfxStateInternal();
 		break;
 
+	case GPU_EVENT_INIT_CLEAR:
+		InitClearInternal();
+		break;
+
+	case GPU_EVENT_BEGIN_FRAME:
+		BeginFrameInternal();
+		break;
+
+	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
+		CopyDisplayToOutputInternal();
+		break;
+
+	case GPU_EVENT_INVALIDATE_CACHE:
+		InvalidateCacheInternal(ev.invalidate_cache.addr, ev.invalidate_cache.size, ev.invalidate_cache.type);
+		break;
+
+	case GPU_EVENT_FB_MEMCPY:
+		PerformMemoryCopyInternal(ev.fb_memcpy.dst, ev.fb_memcpy.src, ev.fb_memcpy.size);
+		break;
+
+	case GPU_EVENT_FB_MEMSET:
+		PerformMemorySetInternal(ev.fb_memset.dst, ev.fb_memset.v, ev.fb_memset.size);
+		break;
+
+	case GPU_EVENT_FB_STENCIL_UPLOAD:
+		PerformStencilUploadInternal(ev.fb_stencil_upload.dst, ev.fb_stencil_upload.size);
+		break;
+
 	default:
 		ERROR_LOG_REPORT(G3D, "Unexpected GPU event type: %d", (int)ev);
+		break;
 	}
 }
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -26,7 +26,8 @@
 GPUCommon::GPUCommon() :
 	dumpNextFrame_(false),
 	dumpThisFrame_(false),
-	framebufferManager_(nullptr)
+	framebufferManager_(nullptr),
+	resized_(false)
 {
 	// This assert failed on GCC x86 32-bit (but not MSVC 32-bit!) before adding the
 	// "padding" field at the end. This is important for save state compatibility.
@@ -96,6 +97,11 @@ bool GPUCommon::BusyDrawing() {
 		}
 	}
 	return false;
+}
+
+void GPUCommon::Resized() {
+	resized_ = true;
+	framebufferManager_->Resized();
 }
 
 u32 GPUCommon::DrawSync(int mode) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -14,6 +14,9 @@
 
 typedef ThreadEventQueue<GPUInterface, GPUEvent, GPUEventType, GPU_EVENT_INVALID, GPU_EVENT_SYNC_THREAD, GPU_EVENT_FINISH_EVENT_LOOP> GPUThreadEventQueue;
 
+class FramebufferManagerCommon;
+class TextureCacheCommon;
+
 class GPUCommon : public GPUThreadEventQueue, public GPUDebugInterface {
 public:
 	GPUCommon();
@@ -156,6 +159,8 @@ protected:
 	virtual void FinishDeferred() {
 	}
 
+	void DoBlockTransfer(u32 skipDrawReason);
+
 	void AdvanceVerts(u32 vertType, int count, int bytesRead);
 
 	// Allows early unlocking with a guard.  Do not double unlock.
@@ -169,6 +174,9 @@ protected:
 		recursive_mutex &mtx_;
 		bool locked_;
 	};
+
+	FramebufferManagerCommon *framebufferManager_;
+	TextureCacheCommon *textureCache_;
 
 	typedef std::list<int> DisplayListQueue;
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -60,6 +60,8 @@ public:
 	u32  Break(int mode) override;
 	void ReapplyGfxState() override;
 
+	void CopyDisplayToOutput() override;
+	void InitClear() override;
 	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
 	bool PerformMemorySet(u32 dest, u8 v, int size) override;
 	bool PerformMemoryDownload(u32 dest, int size) override;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -34,6 +34,8 @@ public:
 		interruptsEnabled_ = enable;
 	}
 
+	void Resized() override;
+
 	void ExecuteOp(u32 op, u32 diff) override;
 	void PreExecuteOp(u32 op, u32 diff) override;
 	bool InterpretList(DisplayList &list) override;
@@ -200,6 +202,7 @@ protected:
 	bool dumpNextFrame_;
 	bool dumpThisFrame_;
 	bool interruptsEnabled_;
+	bool resized_;
 
 private:
 	// For CPU/GPU sync.

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -65,6 +65,10 @@ public:
 	bool PerformMemoryDownload(u32 dest, int size) override;
 	bool PerformMemoryUpload(u32 dest, int size) override;
 
+	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
+	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
+	bool PerformStencilUpload(u32 dest, int size) override;
+
 	void Execute_OffsetAddr(u32 op, u32 diff);
 	void Execute_Origin(u32 op, u32 diff);
 	void Execute_Jump(u32 op, u32 diff);
@@ -145,9 +149,6 @@ public:
 	}
 
 protected:
-	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
-	void PerformMemorySetInternal(u32 dest, u8 v, int size);
-
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;
 	void SlowRunLoop(DisplayList &list);
@@ -172,6 +173,11 @@ protected:
 	void DoBlockTransfer(u32 skipDrawReason);
 
 	void AdvanceVerts(u32 vertType, int count, int bytesRead);
+
+	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
+	void PerformMemorySetInternal(u32 dest, u8 v, int size);
+	void PerformStencilUploadInternal(u32 dest, int size);
+	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
 	// Allows early unlocking with a guard.  Do not double unlock.
 	class easy_guard {
@@ -213,6 +219,7 @@ protected:
 	bool resized_;
 
 private:
+
 	// For CPU/GPU sync.
 #ifdef __ANDROID__
 	alignas(16) std::atomic<u64> curTickEst_;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -151,6 +151,11 @@ public:
 	}
 
 protected:
+	virtual void InitClearInternal() {}
+	virtual void BeginFrameInternal() {}
+	virtual void CopyDisplayToOutputInternal() {}
+	virtual void ReinitializeInternal() {}
+
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;
 	void SlowRunLoop(DisplayList &list);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -60,6 +60,11 @@ public:
 	u32  Break(int mode) override;
 	void ReapplyGfxState() override;
 
+	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
+	bool PerformMemorySet(u32 dest, u8 v, int size) override;
+	bool PerformMemoryDownload(u32 dest, int size) override;
+	bool PerformMemoryUpload(u32 dest, int size) override;
+
 	void Execute_OffsetAddr(u32 op, u32 diff);
 	void Execute_Origin(u32 op, u32 diff);
 	void Execute_Jump(u32 op, u32 diff);
@@ -140,6 +145,9 @@ public:
 	}
 
 protected:
+	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
+	void PerformMemorySetInternal(u32 dest, u8 v, int size);
+
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;
 	void SlowRunLoop(DisplayList &list);

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -102,7 +102,7 @@ public:
 	void BeginFrameVulkan();  // there's a BeginFrame in the base class, which this calls
 	void EndFrame();
 
-	void Resized();
+	void Resized() override;
 	void DeviceLost();
 	void DeviceRestore(VulkanContext *vulkan);
 	void CopyDisplayToOutput();

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -393,7 +393,6 @@ static const CommandTableEntry commandTable[] = {
 GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 	: vulkan_((VulkanContext *)ctx->GetAPIContext()),
 		drawEngine_(vulkan_),
-		textureCache_(vulkan_),
 		resized_(false),
 		gfxCtx_(ctx) {
 	UpdateVsyncInterval(true);
@@ -401,18 +400,22 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 
 	shaderManager_ = new ShaderManagerVulkan(vulkan_);
 	pipelineManager_ = new PipelineManagerVulkan(vulkan_);
-	framebufferManager_ = new FramebufferManagerVulkan(vulkan_);
-	drawEngine_.SetTextureCache(&textureCache_);
-	drawEngine_.SetFramebufferManager(framebufferManager_);
+	framebufferManagerVulkan_ = new FramebufferManagerVulkan(vulkan_);
+	framebufferManager_ = framebufferManagerVulkan_;
+	textureCacheVulkan_ = new TextureCacheVulkan(vulkan_);
+	textureCache_ = textureCacheVulkan_;
+
+	drawEngine_.SetTextureCache(textureCacheVulkan_);
+	drawEngine_.SetFramebufferManager(framebufferManagerVulkan_);
 	drawEngine_.SetShaderManager(shaderManager_);
 	drawEngine_.SetPipelineManager(pipelineManager_);
-	framebufferManager_->Init();
-	framebufferManager_->SetTextureCache(&textureCache_);
-	framebufferManager_->SetDrawEngine(&drawEngine_);
-	textureCache_.SetFramebufferManager(framebufferManager_);
-	textureCache_.SetDepalShaderCache(&depalShaderCache_);
-	textureCache_.SetShaderManager(shaderManager_);
-	textureCache_.SetTransformDrawEngine(&drawEngine_);
+	framebufferManagerVulkan_->Init();
+	framebufferManagerVulkan_->SetTextureCache(textureCacheVulkan_);
+	framebufferManagerVulkan_->SetDrawEngine(&drawEngine_);
+	textureCacheVulkan_->SetFramebufferManager(framebufferManagerVulkan_);
+	textureCacheVulkan_->SetDepalShaderCache(&depalShaderCache_);
+	textureCacheVulkan_->SetShaderManager(shaderManager_);
+	textureCacheVulkan_->SetTransformDrawEngine(&drawEngine_);
 
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {
@@ -448,13 +451,12 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 	// Update again after init to be sure of any silly driver problems.
 	UpdateVsyncInterval(true);
 
-	textureCache_.NotifyConfigChanged();
+	textureCacheVulkan_->NotifyConfigChanged();
 }
 
 GPU_Vulkan::~GPU_Vulkan() {
-	framebufferManager_->DestroyAllFBOs(true);
+	framebufferManagerVulkan_->DestroyAllFBOs(true);
 	depalShaderCache_.Clear();
-	delete framebufferManager_;
 	delete pipelineManager_;
 	delete shaderManager_;
 }
@@ -495,14 +497,14 @@ void GPU_Vulkan::BeginHostFrame() {
 		BuildReportingInfo();
 		UpdateCmdInfo();
 		drawEngine_.Resized();
-		textureCache_.NotifyConfigChanged();
+		textureCacheVulkan_->NotifyConfigChanged();
 	}
 	resized_ = false;
 
-	textureCache_.StartFrame();
+	textureCacheVulkan_->StartFrame();
 	depalShaderCache_.Decimate();
 
-	framebufferManager_->BeginFrameVulkan();
+	framebufferManagerVulkan_->BeginFrameVulkan();
 
 	shaderManager_->DirtyShader();
 	shaderManager_->DirtyUniform(DIRTY_ALL);
@@ -518,8 +520,8 @@ void GPU_Vulkan::BeginHostFrame() {
 
 void GPU_Vulkan::EndHostFrame() {
 	drawEngine_.EndFrame();
-	framebufferManager_->EndFrame();
-	textureCache_.EndFrame();
+	framebufferManagerVulkan_->EndFrame();
+	textureCacheVulkan_->EndFrame();
 }
 
 // Needs to be called on GPU thread, not reporting thread.
@@ -610,10 +612,10 @@ void GPU_Vulkan::Reinitialize() {
 }
 
 void GPU_Vulkan::ReinitializeInternal() {
-	textureCache_.Clear(true);
+	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManager_->DestroyAllFBOs(true);
-	framebufferManager_->Resized();
+	framebufferManagerVulkan_->DestroyAllFBOs(true);
+	framebufferManagerVulkan_->Resized();
 }
 
 void GPU_Vulkan::InitClearInternal() {
@@ -703,7 +705,7 @@ void GPU_Vulkan::CopyDisplayToOutputInternal() {
 
 	shaderManager_->DirtyLastShader();
 
-	framebufferManager_->CopyDisplayToOutput();
+	framebufferManagerVulkan_->CopyDisplayToOutput();
 
 	gstate_c.textureChanged = TEXCHANGE_UPDATED;
 }
@@ -1107,7 +1109,7 @@ void GPU_Vulkan::Execute_TexLevel(u32 op, u32 diff) {
 
 void GPU_Vulkan::Execute_LoadClut(u32 op, u32 diff) {
 	gstate_c.textureChanged |= TEXCHANGE_PARAMSONLY;
-	textureCache_.LoadClut(gstate.getClutAddress(), gstate.getClutLoadBytes());
+	textureCacheVulkan_->LoadClut(gstate.getClutAddress(), gstate.getClutLoadBytes());
 	// This could be used to "dirty" textures with clut.
 }
 
@@ -1936,10 +1938,10 @@ void GPU_Vulkan::FastLoadBoneMatrix(u32 target) {
 }
 
 void GPU_Vulkan::DeviceLost() {
-	framebufferManager_->DeviceLost();
+	framebufferManagerVulkan_->DeviceLost();
 	drawEngine_.DeviceLost();
 	pipelineManager_->DeviceLost();
-	textureCache_.DeviceLost();
+	textureCacheVulkan_->DeviceLost();
 	depalShaderCache_.Clear();
 	shaderManager_->ClearShaders();
 }
@@ -1950,10 +1952,10 @@ void GPU_Vulkan::DeviceRestore() {
 	BuildReportingInfo();
 	UpdateCmdInfo();
 
-	framebufferManager_->DeviceRestore(vulkan_);
+	framebufferManagerVulkan_->DeviceRestore(vulkan_);
 	drawEngine_.DeviceRestore(vulkan_);
 	pipelineManager_->DeviceRestore(vulkan_);
-	textureCache_.DeviceRestore(vulkan_);
+	textureCacheVulkan_->DeviceRestore(vulkan_);
 	shaderManager_->DeviceRestore(vulkan_);
 }
 
@@ -1985,7 +1987,7 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
 		(int)framebufferManager_->NumVFBs(),
-		(int)textureCache_.NumLoadedTextures(),
+		(int)textureCacheVulkan_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,
 		shaderManager_->GetNumVertexShaders(),
@@ -1995,95 +1997,6 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		drawStats.pushVertexSpaceUsed,
 		drawStats.pushIndexSpaceUsed
 	);
-}
-
-void GPU_Vulkan::DoBlockTransfer(u32 skipDrawReason) {
-	// TODO: This is used a lot to copy data around between render targets and textures,
-	// and also to quickly load textures from RAM to VRAM. So we should do checks like the following:
-	//  * Does dstBasePtr point to an existing texture? If so maybe reload it immediately.
-	//
-	//  * Does srcBasePtr point to a render target, and dstBasePtr to a texture? If so
-	//    either copy between rt and texture or reassign the texture to point to the render target
-	//
-	// etc....
-
-	u32 srcBasePtr = gstate.getTransferSrcAddress();
-	u32 srcStride = gstate.getTransferSrcStride();
-
-	u32 dstBasePtr = gstate.getTransferDstAddress();
-	u32 dstStride = gstate.getTransferDstStride();
-
-	int srcX = gstate.getTransferSrcX();
-	int srcY = gstate.getTransferSrcY();
-
-	int dstX = gstate.getTransferDstX();
-	int dstY = gstate.getTransferDstY();
-
-	int width = gstate.getTransferWidth();
-	int height = gstate.getTransferHeight();
-
-	int bpp = gstate.getTransferBpp();
-
-	DEBUG_LOG(G3D, "Block transfer: %08x/%x -> %08x/%x, %ix%ix%i (%i,%i)->(%i,%i)", srcBasePtr, srcStride, dstBasePtr, dstStride, width, height, bpp, srcX, srcY, dstX, dstY);
-
-	if (!Memory::IsValidAddress(srcBasePtr)) {
-		ERROR_LOG_REPORT(G3D, "BlockTransfer: Bad source transfer address %08x!", srcBasePtr);
-		return;
-	}
-
-	if (!Memory::IsValidAddress(dstBasePtr)) {
-		ERROR_LOG_REPORT(G3D, "BlockTransfer: Bad destination transfer address %08x!", dstBasePtr);
-		return;
-	}
-
-	// Check that the last address of both source and dest are valid addresses
-
-	u32 srcLastAddr = srcBasePtr + ((srcY + height - 1) * srcStride + (srcX + width - 1)) * bpp;
-	u32 dstLastAddr = dstBasePtr + ((dstY + height - 1) * dstStride + (dstX + width - 1)) * bpp;
-
-	if (!Memory::IsValidAddress(srcLastAddr)) {
-		ERROR_LOG_REPORT(G3D, "Bottom-right corner of source of block transfer is at an invalid address: %08x", srcLastAddr);
-		return;
-	}
-	if (!Memory::IsValidAddress(dstLastAddr)) {
-		ERROR_LOG_REPORT(G3D, "Bottom-right corner of destination of block transfer is at an invalid address: %08x", srcLastAddr);
-		return;
-	}
-
-	// Tell the framebuffer manager to take action if possible. If it does the entire thing, let's just return.
-	if (!framebufferManager_->NotifyBlockTransferBefore(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason)) {
-		// Do the copy! (Hm, if we detect a drawn video frame (see below) then we could maybe skip this?)
-		// Can use GetPointerUnchecked because we checked the addresses above. We could also avoid them
-		// entirely by walking a couple of pointers...
-		if (srcStride == dstStride && (u32)width == srcStride) {
-			// Common case in God of War, let's do it all in one chunk.
-			u32 srcLineStartAddr = srcBasePtr + (srcY * srcStride + srcX) * bpp;
-			u32 dstLineStartAddr = dstBasePtr + (dstY * dstStride + dstX) * bpp;
-			const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-			u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
-			memcpy(dst, src, width * height * bpp);
-		} else {
-			for (int y = 0; y < height; y++) {
-				u32 srcLineStartAddr = srcBasePtr + ((y + srcY) * srcStride + srcX) * bpp;
-				u32 dstLineStartAddr = dstBasePtr + ((y + dstY) * dstStride + dstX) * bpp;
-
-				const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-				u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
-				memcpy(dst, src, width * bpp);
-			}
-		}
-
-		textureCache_.Invalidate(dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, GPU_INVALIDATE_HINT);
-		framebufferManager_->NotifyBlockTransferAfter(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason);
-	}
-
-#ifndef MOBILE_DEVICE
-	CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
-	CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
-#endif
-
-	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
-	cyclesExecuted += ((height * width * bpp) * 16) / 10;
 }
 
 void GPU_Vulkan::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
@@ -2096,9 +2009,9 @@ void GPU_Vulkan::InvalidateCache(u32 addr, int size, GPUInvalidationType type) {
 
 void GPU_Vulkan::InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type) {
 	if (size > 0)
-		textureCache_.Invalidate(addr, size, type);
+		textureCacheVulkan_->Invalidate(addr, size, type);
 	else
-		textureCache_.InvalidateAll(type);
+		textureCacheVulkan_->InvalidateAll(type);
 
 	if (type != GPU_INVALIDATE_ALL && framebufferManager_->MayIntersectFramebuffer(addr)) {
 		// If we're doing block transfers, we shouldn't need this, and it'll only confuse us.
@@ -2181,7 +2094,7 @@ void GPU_Vulkan::NotifyVideoUpload(u32 addr, int size, int width, int format) {
 		// TODO
 		//framebufferManager_.NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
 	}
-	textureCache_.NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
+	textureCacheVulkan_->NotifyVideoUpload(addr, size, width, (GEBufferFormat)format);
 	InvalidateCache(addr, size, GPU_INVALIDATE_SAFE);
 }
 
@@ -2219,12 +2132,12 @@ bool GPU_Vulkan::PerformStencilUpload(u32 dest, int size) {
 }
 
 void GPU_Vulkan::ClearCacheNextFrame() {
-	textureCache_.ClearNextFrame();
+	textureCacheVulkan_->ClearNextFrame();
 }
 
 void GPU_Vulkan::Resized() {
 	resized_ = true;
-	framebufferManager_->Resized();
+	framebufferManagerVulkan_->Resized();
 }
 
 void GPU_Vulkan::ClearShaderCache() {
@@ -2232,7 +2145,7 @@ void GPU_Vulkan::ClearShaderCache() {
 }
 
 std::vector<FramebufferInfo> GPU_Vulkan::GetFramebufferList() {
-	return framebufferManager_->GetFramebufferList();
+	return framebufferManagerVulkan_->GetFramebufferList();
 }
 
 void GPU_Vulkan::DoState(PointerWrap &p) {
@@ -2242,11 +2155,11 @@ void GPU_Vulkan::DoState(PointerWrap &p) {
 	// None of these are necessary when saving.
 	// In Freeze-Frame mode, we don't want to do any of this.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_.Clear(true);
+		textureCacheVulkan_->Clear(true);
 		depalShaderCache_.Clear();
 
 		gstate_c.textureChanged = TEXCHANGE_UPDATED;
-		framebufferManager_->DestroyAllFBOs(true);
+		framebufferManagerVulkan_->DestroyAllFBOs(true);
 		shaderManager_->ClearShaders();
 		pipelineManager_->Clear();
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -722,45 +722,6 @@ void GPU_Vulkan::FastRunLoop(DisplayList &list) {
 void GPU_Vulkan::FinishDeferred() {
 }
 
-void GPU_Vulkan::ProcessEvent(GPUEvent ev) {
-	switch (ev.type) {
-	case GPU_EVENT_INIT_CLEAR:
-		InitClearInternal();
-		break;
-
-	case GPU_EVENT_BEGIN_FRAME:
-		BeginFrameInternal();
-		break;
-
-	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
-		CopyDisplayToOutputInternal();
-		break;
-
-	case GPU_EVENT_INVALIDATE_CACHE:
-		InvalidateCacheInternal(ev.invalidate_cache.addr, ev.invalidate_cache.size, ev.invalidate_cache.type);
-		break;
-
-	case GPU_EVENT_FB_MEMCPY:
-		PerformMemoryCopyInternal(ev.fb_memcpy.dst, ev.fb_memcpy.src, ev.fb_memcpy.size);
-		break;
-
-	case GPU_EVENT_FB_MEMSET:
-		PerformMemorySetInternal(ev.fb_memset.dst, ev.fb_memset.v, ev.fb_memset.size);
-		break;
-
-	case GPU_EVENT_FB_STENCIL_UPLOAD:
-		PerformStencilUploadInternal(ev.fb_stencil_upload.dst, ev.fb_stencil_upload.size);
-		break;
-
-	case GPU_EVENT_REINITIALIZE:
-		ReinitializeInternal();
-		break;
-
-	default:
-		GPUCommon::ProcessEvent(ev);
-	}
-}
-
 inline void GPU_Vulkan::CheckFlushOp(int cmd, u32 diff) {
 	const u8 cmdFlags = cmdInfo_[cmd].flags;
 	if ((cmdFlags & FLAG_FLUSHBEFORE) || (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE))) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -601,15 +601,6 @@ void GPU_Vulkan::BuildReportingInfo() {
 	Reporting::UpdateConfig();
 }
 
-void GPU_Vulkan::InitClear() {
-	ScheduleEvent(GPU_EVENT_INIT_CLEAR);
-}
-
-void GPU_Vulkan::Reinitialize() {
-	GPUCommon::Reinitialize();
-	ScheduleEvent(GPU_EVENT_REINITIALIZE);
-}
-
 void GPU_Vulkan::ReinitializeInternal() {
 	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
@@ -652,10 +643,6 @@ void GPU_Vulkan::UpdateCmdInfo() {
 	// }
 }
 
-void GPU_Vulkan::ReapplyGfxStateInternal() {
-	GPUCommon::ReapplyGfxStateInternal();
-}
-
 void GPU_Vulkan::BeginFrameInternal() {
 }
 
@@ -692,10 +679,6 @@ bool GPU_Vulkan::FramebufferReallyDirty() {
 		return dirty;
 	}
 	return true;
-}
-
-void GPU_Vulkan::CopyDisplayToOutput() {
-	ScheduleEvent(GPU_EVENT_COPY_DISPLAY_TO_OUTPUT);
 }
 
 void GPU_Vulkan::CopyDisplayToOutputInternal() {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -393,7 +393,6 @@ static const CommandTableEntry commandTable[] = {
 GPU_Vulkan::GPU_Vulkan(GraphicsContext *ctx)
 	: vulkan_((VulkanContext *)ctx->GetAPIContext()),
 		drawEngine_(vulkan_),
-		resized_(false),
 		gfxCtx_(ctx) {
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
@@ -2133,11 +2132,6 @@ bool GPU_Vulkan::PerformStencilUpload(u32 dest, int size) {
 
 void GPU_Vulkan::ClearCacheNextFrame() {
 	textureCacheVulkan_->ClearNextFrame();
-}
-
-void GPU_Vulkan::Resized() {
-	resized_ = true;
-	framebufferManagerVulkan_->Resized();
 }
 
 void GPU_Vulkan::ClearShaderCache() {

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -161,7 +161,6 @@ private:
 	void Flush() {
 		drawEngine_.Flush(nullptr);
 	}
-	void DoBlockTransfer(u32 skipDrawReason);
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 	void InitClearInternal();
@@ -178,8 +177,8 @@ private:
 
 	GraphicsContext *gfxCtx_;
 	VulkanContext *vulkan_;
-	FramebufferManagerVulkan *framebufferManager_;
-	TextureCacheVulkan textureCache_;
+	FramebufferManagerVulkan *framebufferManagerVulkan_;
+	TextureCacheVulkan *textureCacheVulkan_;
 	DepalShaderCacheVulkan depalShaderCache_;
 	DrawEngineVulkan drawEngine_;
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -137,10 +137,8 @@ public:
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) override;
 
-
 protected:
 	void FastRunLoop(DisplayList &list) override;
-	void ProcessEvent(GPUEvent ev) override;
 	void FastLoadBoneMatrix(u32 target) override;
 	void FinishDeferred() override;
 
@@ -150,10 +148,10 @@ private:
 	}
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
-	void InitClearInternal();
-	void BeginFrameInternal();
-	void CopyDisplayToOutputInternal();
-	void ReinitializeInternal();
+	void InitClearInternal() override;
+	void BeginFrameInternal() override;
+	void CopyDisplayToOutputInternal() override;
+	void ReinitializeInternal() override;
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();
 	static CommandInfo cmdInfo_[256];

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -55,10 +55,6 @@ public:
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
-	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
-	bool PerformMemorySet(u32 dest, u8 v, int size) override;
-	bool PerformMemoryDownload(u32 dest, int size) override;
-	bool PerformMemoryUpload(u32 dest, int size) override;
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
@@ -164,8 +160,6 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
-	void PerformMemorySetInternal(u32 dest, u8 v, int size);
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 	void ReinitializeInternal();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -67,8 +67,6 @@ public:
 	void DumpNextFrame() override;
 	void DoState(PointerWrap &p) override;
 
-	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.
-	void Resized() override;
 	void ClearShaderCache() override;
 	bool DecodeTexture(u8 *dest, const GPUgstate &state) override {
 		return false;
@@ -188,7 +186,6 @@ private:
 	// Manages state and pipeline objects
 	PipelineManagerVulkan *pipelineManager_;
 
-	bool resized_;
 	int lastVsync_;
 	VkCommandBuffer curCmd_;
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -51,11 +51,8 @@ public:
 	void ReapplyGfxStateInternal() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void CopyDisplayToOutput() override;
-	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
-	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
-	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
@@ -160,8 +157,6 @@ private:
 	void InitClearInternal();
 	void BeginFrameInternal();
 	void CopyDisplayToOutputInternal();
-	void PerformStencilUploadInternal(u32 dest, int size);
-	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 	void ReinitializeInternal();
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -42,15 +42,11 @@ public:
 	void BeginHostFrame() override;
 	void EndHostFrame() override;
 
-	void InitClear() override;
-	void Reinitialize() override;
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void Execute_Generic(u32 op, u32 diff);
 	void ExecuteOp(u32 op, u32 diff) override;
 
-	void ReapplyGfxStateInternal() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
-	void CopyDisplayToOutput() override;
 	void BeginFrame() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void ClearCacheNextFrame() override;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -95,8 +95,8 @@ public:
 	void Clear(bool delete_them);
 	void StartFrame();
 	void EndFrame();
-	void Invalidate(u32 addr, int size, GPUInvalidationType type);
-	void InvalidateAll(GPUInvalidationType type);
+	void Invalidate(u32 addr, int size, GPUInvalidationType type) override;
+	void InvalidateAll(GPUInvalidationType type) override;
 	void ClearNextFrame();
 
 	void DeviceLost();


### PR DESCRIPTION
Doing some groundwork in preparation for adding some new GPU backends. It's icky to work with heavily duplicated code.

In fact, I'm currently considering turning the Vulkan backend into "Modern", and have that call a few thin rendering interfaces, initially Vulkan only, then D3D11 and possibly Metal. Will likely not bother with DX12.

The current GLES and DX9 backends will remain as they are to match those older shader models. Some optimizations I'll do for the new ones are probably no good idea for the old ones.

