### PR TITLE
Fix scePowerSetClockFrequency timing

### DIFF
--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -57,6 +57,8 @@ static int powerCbSlots[numberOfCBPowerSlots];
 static std::vector<VolatileWaitingThread> volatileWaitingThreads;
 
 // Should this belong here, or in CoreTiming?
+static int RealpllFreq = 222;
+static int RealbusFreq = 111;
 static int pllFreq = 222;
 static int busFreq = 111;
 
@@ -73,10 +75,12 @@ void __PowerInit() {
 		pllFreq = 222;
 		busFreq = 111;
 	}
+	RealpllFreq = 222;
+	RealbusFreq = 111;
 }
 
 void __PowerDoState(PointerWrap &p) {
-	auto s = p.Section("scePower", 1);
+	auto s = p.Section("scePower",1,2);
 	if (!s)
 		return;
 
@@ -355,20 +359,10 @@ static int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 
 static u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 	if (g_Config.iLockedCPUSpeed > 0) {
-		INFO_LOG(HLE,"scePowerSetClockFrequency(%i,%i,%i): locked by user config at %i, %i, %i", pllfreq, cpufreq, busfreq, g_Config.iLockedCPUSpeed, g_Config.iLockedCPUSpeed, busFreq);
 	}
 	else {
-		if (cpufreq == 0 || cpufreq > 333) {
-			WARN_LOG(HLE,"scePowerSetClockFrequency(%i,%i,%i): invalid frequency", pllfreq, cpufreq, busfreq);
-			return SCE_KERNEL_ERROR_INVALID_VALUE;
 		}
-		// TODO: More restrictions.
-		CoreTiming::SetClockFrequencyMHz(cpufreq);
-		pllFreq = pllfreq;
-		busFreq = busfreq;
-		INFO_LOG(HLE,"scePowerSetClockFrequency(%i,%i,%i)", pllfreq, cpufreq, busfreq);
 	}
-	return hleDelayResult(0, "scepower set clockFrequency", 150000);
 }
 
 static u32 scePowerSetCpuClockFrequency(u32 cpufreq) {


### PR DESCRIPTION
F1 2009 keep calling scePowerSetClockFrequency so that the game is slow
I find out by JPCSPTrace log that same ClockFrequency do not delay

{the syscall parameters have
       to be logged before and after the syscall (i.e. twice)}

> scePower_EBD177D6 0xEBD177D6 3 !ddd
Patching syscall from 0x80F0804 to 0x9FFFF10
> 
04:26:16.778 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.778 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.788 user_main - sceKernelCreateThread 0x09FFF4F0('FileLoadThread_0x08c1f140'), 0x88B5858, 19, 0x800, 0x0, 0x0 = 0xCA9F57
04:26:16.808 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.809 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.842 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.842 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.908 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
04:26:16.909 user_main - scePower_EBD177D6 222, 222, 111 = 0x0