### PR TITLE
Fix high-DPI rendering/input on Windows

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -130,12 +130,21 @@ bool Core_GetPowerSaving() {
 	return powerSaving;
 }
 
+// TODO: Feels like this belongs elsewhere.
 bool UpdateScreenScale(int width, int height, bool smallWindow) {
-	g_dpi = 72;
+#ifdef _WIN32
+	// Use legacy DPI handling, because we still compile as XP compatible we don't get the new SDK, unless
+	// we do unholy tricks.
+	HDC screenDC = GetDC(nullptr);
+	double hPixelsPerInch = GetDeviceCaps(screenDC, LOGPIXELSY);
+	ReleaseDC(nullptr, screenDC);
+
+	g_dpi = hPixelsPerInch;
+	g_dpi_scale = 96.0f / g_dpi;
+#else
+	g_dpi = 96;
 	g_dpi_scale = 1.0f;
-	if (smallWindow) {
-		g_dpi_scale = 2.0f;
-	}
+#endif
 
 	pixel_in_dps = 1.0f / g_dpi_scale;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 
+#include "base/display.h"
 #include "base/NativeApp.h"
 #include "Globals.h"
 
@@ -207,8 +208,8 @@ namespace MainWindow
 		// Can't take this from config as it will not be set if windows is maximized.
 		RECT rc;
 		GetWindowRect(hwndMain, &rc);
-		int width = rc.right - rc.left;
-		int height = rc.bottom - rc.top;
+		int width = (int)((rc.right - rc.left) * g_dpi_scale);
+		int height = (int)((rc.bottom - rc.top) * g_dpi_scale);
 		return g_Config.IsPortrait() ? (height < 480 + 80) : (width < 480 + 80);
 	} 
 
@@ -516,8 +517,6 @@ namespace MainWindow
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
-		// Only apply a factor > 1 in windowed mode.
-		int factor = !IsZoomed(GetHWND()) && !g_Config.bFullScreen && IsWindowSmall() ? 2 : 1;
 		static bool firstErase = true;
 
 		switch (message) {
@@ -555,8 +554,8 @@ namespace MainWindow
 					input_state.mouse_valid = true;
 					input_state.pointer_down[0] = true;
 
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * g_dpi_scale;
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * g_dpi_scale;
 				}
 
 				TouchInput touch;
@@ -598,8 +597,8 @@ namespace MainWindow
 
 				{
 					lock_guard guard(input_state.lock);
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * g_dpi_scale;
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * g_dpi_scale;
 				}
 
 				if (wParam & MK_LBUTTON) {
@@ -622,8 +621,8 @@ namespace MainWindow
 				{
 					lock_guard guard(input_state.lock);
 					input_state.pointer_down[0] = false;
-					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * factor; 
-					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * factor;
+					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * g_dpi_scale;
+					input_state.pointer_y[0] = GET_Y_LPARAM(lParam) * g_dpi_scale;
 				}
 				TouchInput touch;
 				touch.id = 0;

--- a/Windows/PPSSPP.manifest
+++ b/Windows/PPSSPP.manifest
@@ -31,7 +31,8 @@
   </trustInfo>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <!-- Should really use True/PM (per-monitor) here but as we are XP-compatible, we don't have access to the headers. -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True</dpiAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include "base/NativeApp.h"
 
+#include "base/display.h"
 #include "Common/Log.h"
 #include "input/input_state.h"
 #include "Windows/RawInput.h"
@@ -202,8 +203,8 @@ namespace WindowsRawInput {
 		KeyInput key;
 		key.deviceId = DEVICE_ID_MOUSE;
 
-		mouseDeltaX += raw->data.mouse.lLastX;
-		mouseDeltaY += raw->data.mouse.lLastY;
+		g_mouseDeltaX += raw->data.mouse.lLastX;
+		g_mouseDeltaY += raw->data.mouse.lLastY;
 
 		if (raw->data.mouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN) {
 			key.flags = KEY_DOWN;

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "base/display.h"
 #include "Common/CommonWindows.h"
 #include "input/input_state.h"
 #include "base/NativeApp.h"
@@ -71,8 +72,8 @@ void TouchInputHandler::handleTouchEvent(HWND hWnd, UINT message, WPARAM wParam,
 				}
 
 				POINT point;
-				point.x = TOUCH_COORD_TO_PIXEL(inputs[i].x);
-				point.y = TOUCH_COORD_TO_PIXEL(inputs[i].y);
+				point.x = (float)(TOUCH_COORD_TO_PIXEL(inputs[i].x)) * g_dpi_scale;
+				point.y = (float)(TOUCH_COORD_TO_PIXEL(inputs[i].y)) * g_dpi_scale;
 
 				if (ScreenToClient(hWnd, &point)){
 					if (inputs[i].dwFlags & TOUCHEVENTF_DOWN)

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -24,10 +24,13 @@
 #include "objbase.h"
 #include "objidl.h"
 #include "shlguid.h"
+#pragma warning(push)
 #pragma warning(disable:4091)  // workaround bug in VS2015 headers
 #include "shlobj.h"
+#pragma warning(pop)
 
 // native stuff
+#include "base/display.h"
 #include "base/NativeApp.h"
 #include "file/file_util.h"
 #include "input/input_state.h"
@@ -62,8 +65,8 @@
 
 static const int numCPUs = 1;
 
-float mouseDeltaX = 0;
-float mouseDeltaY = 0;
+float g_mouseDeltaX = 0;
+float g_mouseDeltaY = 0;
 
 static BOOL PostDialogMessage(Dialog *dialog, UINT message, WPARAM wParam = 0, LPARAM lParam = 0) {
 	return PostMessage(dialog->GetDlgHandle(), message, wParam, lParam);
@@ -74,8 +77,8 @@ WindowsHost::WindowsHost(HINSTANCE hInstance, HWND mainWindow, HWND displayWindo
 		mainWindow_(mainWindow),
 		displayWindow_(displayWindow)
 {
-	mouseDeltaX = 0;
-	mouseDeltaY = 0;
+	g_mouseDeltaX = 0;
+	g_mouseDeltaY = 0;
 
 	//add first XInput device to respond
 	input.push_back(std::shared_ptr<InputDevice>(new XinputDevice()));
@@ -201,12 +204,14 @@ void WindowsHost::PollControllers(InputState &input_state) {
 			doPad = false;
 	}
 
-	mouseDeltaX *= 0.9f;
-	mouseDeltaY *= 0.9f;
+	g_mouseDeltaX *= 0.9f;
+	g_mouseDeltaY *= 0.9f;
 
 	// TODO: Tweak!
-	float mx = std::max(-1.0f, std::min(1.0f, mouseDeltaX * 0.01f));
-	float my = std::max(-1.0f, std::min(1.0f, mouseDeltaY * 0.01f));
+	float scaleFactor = g_dpi_scale * 0.01f;
+
+	float mx = std::max(-1.0f, std::min(1.0f, g_mouseDeltaX * scaleFactor));
+	float my = std::max(-1.0f, std::min(1.0f, g_mouseDeltaY * scaleFactor));
 	AxisInput axisX, axisY;
 	axisX.axisId = JOYSTICK_AXIS_MOUSE_REL_X;
 	axisX.deviceId = DEVICE_ID_MOUSE;

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -21,8 +21,8 @@
 #include <list>
 #include <memory>
 
-extern float mouseDeltaX;
-extern float mouseDeltaY;
+extern float g_mouseDeltaX;
+extern float g_mouseDeltaY;
 
 class GraphicsContext;
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -23,6 +23,7 @@
 #include <shellapi.h>
 #include <mmsystem.h>
 
+#include "base/display.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
 #include "base/NativeApp.h"
@@ -367,8 +368,7 @@ std::vector<std::wstring> GetWideCmdLine() {
 	return wideArgs;
 }
 
-int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLine, int iCmdShow)
-{
+int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLine, int iCmdShow) {
 	setCurrentThreadName("Main");
 
 	CoInitializeEx(NULL, COINIT_MULTITHREADED);

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -37,7 +37,7 @@ float TextDrawerWordWrapper::MeasureWidth(const char *str, size_t bytes) {
 #include <Windows.h>
 
 enum {
-	MAX_TEXT_WIDTH = 1024,
+	MAX_TEXT_WIDTH = 4096,
 	MAX_TEXT_HEIGHT = 512
 };
 

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 
 #include "base/basictypes.h"
 #include "gfx_es2/draw_buffer.h"
@@ -82,6 +83,6 @@ private:
 
 	uint32_t fontHash_;
 	// The key is the CityHash of the string xor the fontHash_.
-	std::map<uint32_t, TextStringEntry *> cache_;
-	std::map<uint32_t, TextMeasureEntry *> sizeCache_;
+	std::map<uint32_t, std::unique_ptr<TextStringEntry> > cache_;
+	std::map<uint32_t, std::unique_ptr<TextMeasureEntry> > sizeCache_;
 };


### PR DESCRIPTION
Turns out this has been broken for a while (well, never working, but since we specified that we were DPI-aware while we really weren't on Windows, things have been wrong).

Also, I'd really like to use modern per-monitor DPI but we can't (without really dirty hacking) as long as we keep XP compatibility, because the XP-compatible Windows SDK only supports up to Windows 7 features, while per-monitor DPI is an 8.1 feature.

Before, on a 4k laptop:
![bad](https://cloud.githubusercontent.com/assets/130929/21983533/5c85aada-dc24-11e6-8494-57ce1b82bdaa.jpg)

After:
![proper](https://cloud.githubusercontent.com/assets/130929/21983536/5f475bd8-dc24-11e6-959a-1705dd93baec.JPG)

Note the razor sharp text and proper proportions.