### PR TITLE
Script mesa3d enable for HW Tesselation working

### DIFF
--- a/tesselationhwON-mesa3drun.sh
+++ b/tesselationhwON-mesa3drun.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "We need force Opengl 3.3 Compatibility context for run HW tesselation in mesa3d open source" 
+MESA_GL_VERSION_OVERRIDE=3.3COMPAT
+export MESA_GL_VERSION_OVERRIDE
+./PPSSPPSDL


### PR DESCRIPTION
By default mesa3d run Opengl 3.0 context and GLSL 1.30 so we needed force Opengl 3.3 context and run Ok HW tesselation
this script is workaround for that function work in mesa3d .

