### PR TITLE
Restores a lost optimization from uv prescale - avoiding flushing. Should fix #9219.

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -86,10 +86,10 @@ static const CommandTableEntry commandTable[] = {
 
 	// Changes that dirty texture scaling.
 	{ GE_CMD_TEXMAPMODE, FLAG_FLUSHBEFOREONCHANGE, DIRTY_UVSCALEOFFSET },
-	{ GE_CMD_TEXSCALEU, FLAG_EXECUTEONCHANGE, DIRTY_UVSCALEOFFSET, &GPU_DX9::Execute_TexScaleU },
-	{ GE_CMD_TEXSCALEV, FLAG_EXECUTEONCHANGE, DIRTY_UVSCALEOFFSET, &GPU_DX9::Execute_TexScaleV },
-	{ GE_CMD_TEXOFFSETU, FLAG_EXECUTEONCHANGE, DIRTY_UVSCALEOFFSET, &GPU_DX9::Execute_TexOffsetU },
-	{ GE_CMD_TEXOFFSETV, FLAG_EXECUTEONCHANGE, DIRTY_UVSCALEOFFSET, &GPU_DX9::Execute_TexOffsetV },
+	{ GE_CMD_TEXSCALEU, FLAG_EXECUTEONCHANGE, 0, &GPUCommon::Execute_TexScaleU },
+	{ GE_CMD_TEXSCALEV, FLAG_EXECUTEONCHANGE, 0, &GPUCommon::Execute_TexScaleV },
+	{ GE_CMD_TEXOFFSETU, FLAG_EXECUTEONCHANGE, 0, &GPUCommon::Execute_TexOffsetU },
+	{ GE_CMD_TEXOFFSETV, FLAG_EXECUTEONCHANGE, 0, &GPUCommon::Execute_TexOffsetV },
 
 	// Changes that dirty the current texture.
 	{ GE_CMD_TEXSIZE0, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTE, 0, &GPU_DX9::Execute_TexSize0 },
@@ -741,6 +741,8 @@ void GPU_DX9::Execute_VertexTypeSkinning(u32 op, u32 diff) {
 }
 
 void GPU_DX9::Execute_Prim(u32 op, u32 diff) {
+	SetDrawType(DRAW_PRIM);
+
 	// This drives all drawing. All other state we just buffer up, then we apply it only
 	// when it's time to draw. As most PSP games set state redundantly ALL THE TIME, this is a huge optimization.
 
@@ -810,6 +812,8 @@ void GPU_DX9::Execute_Prim(u32 op, u32 diff) {
 }
 
 void GPU_DX9::Execute_Bezier(u32 op, u32 diff) {
+	SetDrawType(DRAW_BEZIER);
+
 	// This also make skipping drawing very effective.
 	framebufferManagerDX9_->SetRenderFrameBuffer(gstate_c.IsDirty(DIRTY_FRAMEBUF), gstate_c.skipDrawReason);
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB)) {
@@ -853,6 +857,8 @@ void GPU_DX9::Execute_Bezier(u32 op, u32 diff) {
 }
 
 void GPU_DX9::Execute_Spline(u32 op, u32 diff) {
+	SetDrawType(DRAW_SPLINE);
+
 	// This also make skipping drawing very effective.
 	framebufferManagerDX9_->SetRenderFrameBuffer(gstate_c.IsDirty(DIRTY_FRAMEBUF), gstate_c.skipDrawReason);
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB)) {
@@ -896,26 +902,6 @@ void GPU_DX9::Execute_Spline(u32 op, u32 diff) {
 	// After drawing, we advance pointers - see SubmitPrim which does the same.
 	int count = sp_ucount * sp_vcount;
 	AdvanceVerts(gstate.vertType, count, bytesRead);
-}
-
-void GPU_DX9::Execute_TexScaleU(u32 op, u32 diff) {
-	gstate_c.uv.uScale = getFloat24(op);
-	gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
-}
-
-void GPU_DX9::Execute_TexScaleV(u32 op, u32 diff) {
-	gstate_c.uv.vScale = getFloat24(op);
-	gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
-}
-
-void GPU_DX9::Execute_TexOffsetU(u32 op, u32 diff) {
-	gstate_c.uv.uOff = getFloat24(op);
-	gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
-}
-
-void GPU_DX9::Execute_TexOffsetV(u32 op, u32 diff) {
-	gstate_c.uv.vOff = getFloat24(op);
-	gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
 }
 
 void GPU_DX9::Execute_TexSize0(u32 op, u32 diff) {

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -93,11 +93,6 @@ public:
 	void Execute_LoadClut(u32 op, u32 diff);
 	void Execute_VertexType(u32 op, u32 diff);
 	void Execute_VertexTypeSkinning(u32 op, u32 diff);
-
-	void Execute_TexScaleU(u32 op, u32 diff);
-	void Execute_TexScaleV(u32 op, u32 diff);
-	void Execute_TexOffsetU(u32 op, u32 diff);
-	void Execute_TexOffsetV(u32 op, u32 diff);
 	void Execute_TexSize0(u32 op, u32 diff);
 
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -4,6 +4,7 @@
 #include "Common/MemoryUtil.h"
 #include "Core/ThreadEventQueue.h"
 #include "GPU/GPUInterface.h"
+#include "GPU/GPUState.h"
 #include "GPU/Common/GPUDebugInterface.h"
 
 #if defined(__ANDROID__)
@@ -17,6 +18,13 @@ typedef ThreadEventQueue<GPUInterface, GPUEvent, GPUEventType, GPU_EVENT_INVALID
 class FramebufferManagerCommon;
 class TextureCacheCommon;
 class DrawEngineCommon;
+
+enum DrawType {
+	DRAW_UNKNOWN,
+	DRAW_PRIM,
+	DRAW_SPLINE,
+	DRAW_BEZIER,
+};
 
 class GPUCommon : public GPUThreadEventQueue, public GPUDebugInterface {
 public:
@@ -85,6 +93,11 @@ public:
 	void Execute_Spline(u32 op, u32 diff);
 	void Execute_BoundingBox(u32 op, u32 diff);
 	void Execute_BlockTransferStart(u32 op, u32 diff);
+
+	void Execute_TexScaleU(u32 op, u32 diff);
+	void Execute_TexScaleV(u32 op, u32 diff);
+	void Execute_TexOffsetU(u32 op, u32 diff);
+	void Execute_TexOffsetV(u32 op, u32 diff);
 
 	void Execute_WorldMtxNum(u32 op, u32 diff);
 	void Execute_WorldMtxData(u32 op, u32 diff);
@@ -178,6 +191,13 @@ public:
 	}
 
 protected:
+	void SetDrawType(DrawType type) {
+		if (type != lastDraw_) {
+			gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
+			lastDraw_ = type;
+		}
+	}
+
 	virtual void InitClearInternal() {}
 	virtual void BeginFrameInternal() {}
 	virtual void CopyDisplayToOutputInternal() {}
@@ -262,6 +282,7 @@ protected:
 	bool dumpThisFrame_;
 	bool interruptsEnabled_;
 	bool resized_;
+	DrawType lastDraw_;
 
 private:
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -79,10 +79,6 @@ public:
 	void Execute_Bezier(u32 op, u32 diff);
 	void Execute_Spline(u32 op, u32 diff);
 	void Execute_VertexType(u32 op, u32 diff);
-	void Execute_TexScaleU(u32 op, u32 diff);
-	void Execute_TexScaleV(u32 op, u32 diff);
-	void Execute_TexOffsetU(u32 op, u32 diff);
-	void Execute_TexOffsetV(u32 op, u32 diff);
 	void Execute_TexSize0(u32 op, u32 diff);
 	void Execute_LoadClut(u32 op, u32 diff);
 	void Execute_BoneMtxNum(u32 op, u32 diff);


### PR DESCRIPTION
Also #ifdef away some invalid-address checks in hot paths in the GPU. Fixes #9219