### PR TITLE
Added ability for the user to override the location of the SDL game controller db file

### DIFF
--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -21,15 +21,32 @@ SDLJoystick::SDLJoystick(bool init_SDL ): thread(NULL), running(true) {
 		SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
 	}
 	
+	char* dbEnvPath = getenv("PPSSPP_GAME_CONTROLLER_DB_PATH");
+	if (dbEnvPath != NULL) {
+		if (!File::Exists(dbEnvPath)) {
+			cout << "WARNING! " << dbEnvPath << " does not exist!" << endl;
+		} else {
+			cout << "loading control pad mappings from " << dbEnvPath << ": ";
+			if (SDL_GameControllerAddMappingsFromFile(dbEnvPath) == -1) {
+				cout << "FAILED! Will try load from your assests directory instead..." << endl;
+			} else {
+				cout << "SUCCESS!" << endl;
+				setUpControllers();
+				return;
+			}
+		}
+	}
+		
 	auto dbPath = File::GetExeDirectory() + "assets/gamecontrollerdb.txt";
 	cout << "loading control pad mappings from " << dbPath << ": ";
- 	
+
 	if (SDL_GameControllerAddMappingsFromFile(dbPath.c_str()) == -1) {
 		cout << "FAILED! Please place gamecontrollerdb.txt in your assets directory." << endl;
-	} else {
- 		cout << "SUCCESS!" << endl;
-		setUpControllers();
+		return;
 	}
+	
+	cout << "SUCCESS!" << endl;
+	setUpControllers();
 }
 
 void SDLJoystick::setUpControllers() {


### PR DESCRIPTION
By default, the SDL2 game controller database file is stored in the assets directory. For some installations (e.g. on a shared system) the user may not have write privileges to PPSSPP's asset files.

Therefore, to allow the user to override the file used for the game controller database, I have added the ability for the user to specify an alternative game controller database file via an environment variable.

If the environment variable PPSSPP_GAME_CONTROLLER_DB_PATH is not set or contains an invalid file, then the file in the assets directory will be used as normal.