### PR TITLE
Fix OES_texture_float to GL_OES_texture_float.

### DIFF
--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -600,7 +600,7 @@ void GPU_GLES::CheckGPUFeatures() {
 	if (maxVertexTextureImageUnits >= 3) // At least 3 for hardware tessellation
 		features |= GPU_SUPPORTS_VERTEX_TEXTURE_FETCH;
 
-	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float)
+	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float || gl_extensions.OES_texture_half_float)
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
 	// If we already have a 16-bit depth buffer, we don't need to round.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -83,7 +83,7 @@ bool CheckSupportInstancedTessellation() {
 	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &maxVertexTextureImageUnits);
 	bool vertexTexture = maxVertexTextureImageUnits >= 3; // At least 3 for hardware tessellation
 	bool instanceRendering = gl_extensions.EXT_gpu_shader4;
-	bool textureFloat = gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float;
+	bool textureFloat = gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float || gl_extensions.OES_texture_half_float;
 
 	return instanceRendering && vertexTexture && textureFloat;
 }

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -280,6 +280,7 @@ void CheckGLExtensions() {
 		gl_extensions.NV_shader_framebuffer_fetch = strstr(extString, "GL_NV_shader_framebuffer_fetch") != 0;
 		gl_extensions.ARM_shader_framebuffer_fetch = strstr(extString, "GL_ARM_shader_framebuffer_fetch") != 0;
 		gl_extensions.OES_texture_float = strstr(extString, "GL_OES_texture_float") != 0;
+		gl_extensions.OES_texture_half_float = strstr(extString, "GL_OES_texture_half_float") != 0;
 
 #if defined(__ANDROID__)
 		// On Android, incredibly, this is not consistently non-zero! It does seem to have the same value though.

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -279,7 +279,7 @@ void CheckGLExtensions() {
 		gl_extensions.EXT_shader_framebuffer_fetch = strstr(extString, "GL_EXT_shader_framebuffer_fetch") != 0;
 		gl_extensions.NV_shader_framebuffer_fetch = strstr(extString, "GL_NV_shader_framebuffer_fetch") != 0;
 		gl_extensions.ARM_shader_framebuffer_fetch = strstr(extString, "GL_ARM_shader_framebuffer_fetch") != 0;
-		gl_extensions.OES_texture_float = strstr(extString, "OES_texture_float") != 0;
+		gl_extensions.OES_texture_float = strstr(extString, "GL_OES_texture_float") != 0;
 
 #if defined(__ANDROID__)
 		// On Android, incredibly, this is not consistently non-zero! It does seem to have the same value though.

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -48,6 +48,7 @@ struct GLExtensions {
 	bool OES_vertex_array_object;
 	bool OES_copy_image;
 	bool OES_texture_float;
+	bool OES_texture_half_float;
 
 	// ARB
 	bool ARB_framebuffer_object;


### PR DESCRIPTION
I hope to fix #9234.

I think OES_texture_float is only for WebGL extensions, correct extension is GL_OES_texture_float.
Sorry, I was misunderstanding.