### PR TITLE
Fix joystick support for Qt build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,16 @@ elseif(USING_QT_UI)
     include_directories(${CMAKE_CURRENT_BINARY_DIR} Qt Qt/Debugger)
 	set(nativeExtraLibs ${nativeExtraLibs} Qt5::Multimedia Qt5::OpenGL Qt5::Gui Qt5::Core)
 	set(TargetBin PPSSPPQt)
+
+    # Enable SDL if found
+    if (SDL2_FOUND)
+        add_definitions(-DSDL)
+        set(nativeExtra ${nativeExtra}
+            SDL/SDLJoystick.h
+            SDL/SDLJoystick.cpp)
+        set(nativeExtraLibs ${nativeExtraLibs} SDL2::SDL2)
+    endif()
+
 elseif(TARGET SDL2::SDL2)
 	set(TargetBin PPSSPPSDL)
 	# Require SDL

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -12,28 +12,20 @@
 #include "net/resolve.h"
 #include "base/NativeApp.h"
 
-extern "C" {
-	int SDLJoystickThreadWrapper(void *SDLJoy);
-}
-
 class SDLJoystick{
-	friend int ::SDLJoystickThreadWrapper(void *);
 public:
 	SDLJoystick(bool init_SDL = false);
 	~SDLJoystick();
 
-	void startEventLoop();
+	void registerEventHandler();
 	void ProcessInput(SDL_Event &event);
 
 private:
-
-	void runLoop();
 	void setUpController(int deviceIndex);
 	void setUpControllers();
 	keycode_t getKeycodeForButton(SDL_GameControllerButton button);
 	int getDeviceIndex(int instanceId);
-	SDL_Thread *thread ;
-	bool running ;
+	bool registeredAsEventHandler;
 	std::vector<SDL_GameController *> controllers;
 	std::map<int, int> controllerDeviceMap;
 };

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -139,7 +139,7 @@ static int mainInternal(QApplication &a)
 
 #ifdef SDL
 	SDLJoystick joy(true);
-	joy.startEventLoop();
+	joy.registerEventHandler();
 	SDL_Init(SDL_INIT_AUDIO);
 	SDL_AudioSpec fmt, ret_fmt;
 	memset(&fmt, 0, sizeof(fmt));
@@ -334,6 +334,9 @@ void MainUI::initializeGL()
 
 void MainUI::paintGL()
 {
+#ifdef SDL
+    SDL_PumpEvents();
+#endif
     updateAccelerometer();
     UpdateInputState(&input_state);
     time_update();


### PR DESCRIPTION
Define SDL macro in CMakeLists.txt

SDL_WaitEvent can only be called from main thread on MacOS Sierra, use SDL_AddEventWatch and SDL_PumpEvents instead.

Fixes #9157.