### PR TITLE
Modify Hack for Crash Tag Team Racing to fix Gundam games

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -50,6 +50,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DepthRangeHack", &flags_.DepthRangeHack);
 	CheckSetting(iniFile, gameID, "ClearToRAM", &flags_.ClearToRAM);
 	CheckSetting(iniFile, gameID, "Force04154000Download", &flags_.Force04154000Download);
+	CheckSetting(iniFile, gameID, "DrawSyncEatCycles", &flags_.DrawSyncEatCycles);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -50,6 +50,7 @@ struct CompatFlags {
 	bool DepthRangeHack;
 	bool ClearToRAM;
 	bool Force04154000Download;
+	bool DrawSyncEatCycles;
 };
 
 class IniFile;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -408,7 +408,8 @@ int sceGeListSync(u32 displayListID, u32 mode) {
 
 static u32 sceGeDrawSync(u32 mode) {
 	//wait/check entire drawing state
-	hleEatCycles(500000); //HACK(?) : Potential fix for Crash Tag Team Racing and a few Gundam games
+	if (PSP_CoreParameter().compat.flags().DrawSyncEatCycles)
+		hleEatCycles(500000); //HACK(?) : Potential fix for Crash Tag Team Racing and a few Gundam games
 	DEBUG_LOG(SCEGE, "sceGeDrawSync(mode=%d)  (0=wait for completion, 1=peek)", mode);
 	return gpu->DrawSync(mode);
 }

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -408,6 +408,7 @@ int sceGeListSync(u32 displayListID, u32 mode) {
 
 static u32 sceGeDrawSync(u32 mode) {
 	//wait/check entire drawing state
+	hleEatCycles(500000); //HACK(?) : Potential fix for Crash Tag Team Racing and a few Gundam games
 	DEBUG_LOG(SCEGE, "sceGeDrawSync(mode=%d)  (0=wait for completion, 1=peek)", mode);
 	return gpu->DrawSync(mode);
 }

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -332,11 +332,8 @@ static int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 
 	switch (error) {
 	case 0:
-		// HACK: This fixes Crash Tag Team Racing.
 		// Should only wait 1200 cycles though according to Unknown's testing,
-		// and with that it's still broken. So it's not this, unfortunately.
-		// Leaving it in for the 0.9.8 release anyway.
-		hleEatCycles(500000);
+		hleEatCycles(1200);
 		DEBUG_LOG(HLE, "sceKernelVolatileMemLock(%i, %08x, %08x) - success", type, paddr, psize);
 		break;
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -129,3 +129,27 @@ ULJS00033 = true
 UCKS45022 = true
 ULJS19009 = true
 NPJH50141 = true
+
+
+[DrawSyncEatCycles]
+# This replaced Crash Tag Team Racing hack to also fix Gundam games
+# It makes sceGeDrawSync eat a lot of cycles which can affect timing in lots of games,
+# might be negative for others, but happens to fix games below.
+# Crash Tag Team Racing needs it to pass checking memory stick screen.
+ULUS10044 = true
+ULES00168 = true
+ULJM05036 = true
+# Gundam Battle Royale might need it to avoid crashes when certain Ace enemies shows up
+ULJS00083 = true
+ULKS46104 = true
+ULJS19015 = true
+# Gundam Battle Chronicle needs it to avoid crashes after most battles
+ULJS00122 = true
+ULKS46158 = true
+ULJS19021 = true
+# Gundam Battle Universe same problem as above
+ULJS00145 = true
+ULKS46183 = true
+ULJS00260 = true
+ULJS19041 = true
+NPJH50843 = true


### PR DESCRIPTION
 This wasn't tested much yet, I don't even have Crash Tag Team Racing so maybe it's not ok for merging.

 It modifies the hack for CTTR to the other function mentioned in #5468 which turns out to fix Gundam games that is: #7136, #9003 maybe also #9007 /definitely needs more testing, hence why I'm opening this pr.

 So far I tested Gundam Battle Universe and Gundam Battle Chronicle with this, both seems to work, but in place of previous crash they get like 1 glitchy frame, might be caused by this or some other GE function also needing a change in pair with this. Edit: Nvm the glitch is #9275 ;p saw a difference since I updated right before building this heh.
 Edit: Removed custom build as I got CTTR tested which is affected same way as before aka still fixed at least US version from the PS store, but it was potentially affecting different regions differently in the first place?
Fixes #7136, Fixes #9003
Should also fix #9007, but I can't find which Ace units crash it even without this hack, the error from the log posted looks exactly same as from other 2 gundam games through.