### PR TITLE
FBO API cleanup

### DIFF
--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -978,17 +978,6 @@ namespace DX9 {
 		int dstY1 = dstY * dstYFactor;
 		int dstY2 = (dstY + h) * dstYFactor;
 
-		LPDIRECT3DSURFACE9 srcSurf = fbo_get_color_for_read(src->fbo_dx9);
-		LPDIRECT3DSURFACE9 dstSurf = fbo_get_color_for_write(dst->fbo_dx9);
-		D3DSURFACE_DESC srcDesc;
-		D3DSURFACE_DESC dstDesc;
-		srcSurf->GetDesc(&srcDesc);
-		dstSurf->GetDesc(&dstDesc);
-		srcX2 = std::min(srcX2, (int)srcDesc.Width);
-		srcY2 = std::min(srcY2, (int)srcDesc.Height);
-		dstX2 = std::min(dstX2, (int)dstDesc.Width);
-		dstY2 = std::min(dstY2, (int)dstDesc.Height);
-
 		// Direct3D 9 doesn't support rect -> self.
 		FBO_DX9 *srcFBO = src->fbo_dx9;
 		if (src == dst) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -356,7 +356,7 @@ namespace DX9 {
 			return;
 		}
 
-		vfb->fbo_dx9 = fbo_create(vfb->renderWidth, vfb->renderHeight, 1, true, (FBOColorDepth)vfb->colorDepth);
+		vfb->fbo_dx9 = fbo_create({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, (FBOColorDepth)vfb->colorDepth });
 		if (old.fbo_dx9) {
 			INFO_LOG(SCEGE, "Resizing FBO for %08x : %i x %i x %i", vfb->fb_address, w, h, vfb->format);
 			if (vfb->fbo) {
@@ -610,7 +610,7 @@ namespace DX9 {
 		}
 
 		textureCache_->ForgetLastTexture();
-		FBO_DX9 *fbo = fbo_create(w, h, 1, false, depth);
+		FBO_DX9 *fbo = fbo_create({ w, h, 1, 1, false, depth });
 		if (!fbo)
 			return fbo;
 		fbo_bind_as_render_target(fbo);
@@ -934,7 +934,7 @@ namespace DX9 {
 	bool FramebufferManagerDX9::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 		nvfb->colorDepth = FBO_8888;
 
-		nvfb->fbo_dx9 = fbo_create(nvfb->width, nvfb->height, 1, true, (FBOColorDepth)nvfb->colorDepth);
+		nvfb->fbo_dx9 = fbo_create({ nvfb->width, nvfb->height, 1, 1, true, (FBOColorDepth)nvfb->colorDepth });
 		if (!(nvfb->fbo_dx9)) {
 			ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 			return false;
@@ -1330,8 +1330,8 @@ namespace DX9 {
 				// Let's resize.  We must stretch to a render target first.
 				w = vfb->width * maxRes;
 				h = vfb->height * maxRes;
-				tempFBO = fbo_create(w, h, 1, false);
-				if (SUCCEEDED(fbo_blit(vfb->fbo_dx9, 0, 0, vfb->renderWidth, vfb->renderHeight, tempFBO, 0, 0, w, h, FB_COLOR_BIT, g_Config.iBufFilter == SCALE_LINEAR ? FB_BLIT_LINEAR : FB_BLIT_NEAREST))) {
+				tempFBO = fbo_create({ w, h, 1, 1, false, FBO_8888 });
+				if (fbo_blit(vfb->fbo_dx9, 0, 0, vfb->renderWidth, vfb->renderHeight, tempFBO, 0, 0, w, h, FB_COLOR_BIT, g_Config.iBufFilter == SCALE_LINEAR ? FB_BLIT_LINEAR : FB_BLIT_NEAREST)) {
 					renderTarget = (LPDIRECT3DSURFACE9)fbo_get_api_texture(tempFBO, FB_COLOR_BIT | FB_SURFACE_BIT, 0);
 				}
 			}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -559,8 +559,8 @@ namespace DX9 {
 			// Doesn't work.  Use a shader maybe?
 			fbo_bind_backbuffer_as_render_target();
 
-			LPDIRECT3DTEXTURE9 srcTex = fbo_get_depth_texture(src->fbo_dx9);
-			LPDIRECT3DTEXTURE9 dstTex = fbo_get_depth_texture(dst->fbo_dx9);
+			LPDIRECT3DTEXTURE9 srcTex = (LPDIRECT3DTEXTURE9)fbo_get_api_texture(src->fbo_dx9, FB_DEPTH_BIT, 0);
+			LPDIRECT3DTEXTURE9 dstTex = (LPDIRECT3DTEXTURE9)fbo_get_api_texture(dst->fbo_dx9, FB_DEPTH_BIT, 0);
 
 			if (srcTex && dstTex) {
 				D3DSURFACE_DESC srcDesc;
@@ -1063,7 +1063,7 @@ namespace DX9 {
 		// Right now that's always 8888.
 		DEBUG_LOG(HLE, "Reading framebuffer to mem, fb_address = %08x", fb_address);
 
-		LPDIRECT3DSURFACE9 renderTarget = fbo_get_color_for_read(vfb->fbo_dx9);
+		LPDIRECT3DSURFACE9 renderTarget = (LPDIRECT3DSURFACE9)fbo_get_api_texture(vfb->fbo_dx9, FB_COLOR_BIT | FB_SURFACE_BIT, 0);
 		D3DSURFACE_DESC desc;
 		renderTarget->GetDesc(&desc);
 
@@ -1102,7 +1102,7 @@ namespace DX9 {
 
 		DEBUG_LOG(SCEGE, "Reading depthbuffer to mem at %08x for vfb=%08x", z_address, vfb->fb_address);
 
-		LPDIRECT3DTEXTURE9 tex = fbo_get_depth_texture(vfb->fbo_dx9);
+		LPDIRECT3DTEXTURE9 tex = (LPDIRECT3DTEXTURE9)fbo_get_api_texture(vfb->fbo_dx9, FB_DEPTH_BIT, 0);
 		if (tex) {
 			D3DSURFACE_DESC desc;
 			D3DLOCKED_RECT locked;
@@ -1320,8 +1320,7 @@ namespace DX9 {
 			buffer = GPUDebugBuffer(Memory::GetPointer(fb_address | 0x04000000), fb_stride, 512, fb_format);
 			return true;
 		}
-
-		LPDIRECT3DSURFACE9 renderTarget = vfb->fbo_dx9 ? fbo_get_color_for_read(vfb->fbo_dx9) : nullptr;
+		LPDIRECT3DSURFACE9 renderTarget = vfb->fbo_dx9 ? (LPDIRECT3DSURFACE9)fbo_get_api_texture(vfb->fbo_dx9, FB_COLOR_BIT | FB_SURFACE_BIT, 0) : nullptr;
 		bool success = false;
 		if (renderTarget) {
 			FBO_DX9 *tempFBO = nullptr;
@@ -1333,7 +1332,7 @@ namespace DX9 {
 				h = vfb->height * maxRes;
 				tempFBO = fbo_create(w, h, 1, false);
 				if (SUCCEEDED(fbo_blit(vfb->fbo_dx9, 0, 0, vfb->renderWidth, vfb->renderHeight, tempFBO, 0, 0, w, h, FB_COLOR_BIT, g_Config.iBufFilter == SCALE_LINEAR ? FB_BLIT_LINEAR : FB_BLIT_NEAREST))) {
-					renderTarget = fbo_get_color_for_read(tempFBO);
+					renderTarget = (LPDIRECT3DSURFACE9)fbo_get_api_texture(tempFBO, FB_COLOR_BIT | FB_SURFACE_BIT, 0);
 				}
 			}
 
@@ -1412,7 +1411,7 @@ namespace DX9 {
 		}
 
 		bool success = false;
-		LPDIRECT3DTEXTURE9 tex = fbo_get_depth_texture(vfb->fbo_dx9);
+		LPDIRECT3DTEXTURE9 tex = (LPDIRECT3DTEXTURE9)fbo_get_api_texture(vfb->fbo_dx9, FB_DEPTH_BIT, 0);
 		if (tex) {
 			D3DSURFACE_DESC desc;
 			D3DLOCKED_RECT locked;
@@ -1456,7 +1455,7 @@ namespace DX9 {
 		}
 
 		bool success = false;
-		LPDIRECT3DTEXTURE9 tex = fbo_get_depth_texture(vfb->fbo_dx9);
+		LPDIRECT3DTEXTURE9 tex = (LPDIRECT3DTEXTURE9)fbo_get_api_texture(vfb->fbo_dx9, FB_DEPTH_BIT, 0);
 		if (tex) {
 			D3DSURFACE_DESC desc;
 			D3DLOCKED_RECT locked;

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -700,12 +700,12 @@ namespace DX9 {
 				BlitFramebuffer(&copyInfo, x, y, framebuffer, x, y, w, h, 0);
 
 				RebindFramebuffer();
-				pD3Ddevice->SetTexture(stage, fbo_get_color_texture(renderCopy));
+				fbo_bind_as_texture(renderCopy, stage, FB_COLOR_BIT, 0);
 			} else {
-				pD3Ddevice->SetTexture(stage, fbo_get_color_texture(framebuffer->fbo_dx9));
+				fbo_bind_as_texture(framebuffer->fbo_dx9, stage, FB_COLOR_BIT, 0);
 			}
 		} else {
-			pD3Ddevice->SetTexture(stage, fbo_get_color_texture(framebuffer->fbo_dx9));
+			fbo_bind_as_texture(framebuffer->fbo_dx9, stage, FB_COLOR_BIT, 0);
 		}
 	}
 
@@ -812,7 +812,7 @@ namespace DX9 {
 		if (vfb->fbo) {
 			DEBUG_LOG(SCEGE, "Displaying FBO %08x", vfb->fb_address);
 			DisableState();
-			LPDIRECT3DTEXTURE9 colorTexture = fbo_get_color_texture(vfb->fbo_dx9);
+			fbo_bind_as_texture(vfb->fbo_dx9, 0, FB_COLOR_BIT, 0);
 
 			// Output coordinates
 			float x, y, w, h;
@@ -846,7 +846,7 @@ namespace DX9 {
 					}
 					dxstate.texMipFilter.set(D3DTEXF_NONE);
 					dxstate.texMipLodBias.set(0);
-					DrawActiveTexture(colorTexture, x, y, w, h, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight, u0, v0, u1, v1, uvRotation);
+					DrawActiveTexture(0, x, y, w, h, (float)PSP_CoreParameter().pixelWidth, (float)PSP_CoreParameter().pixelHeight, u0, v0, u1, v1, uvRotation);
 				}
 			}
 			/* 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -787,7 +787,7 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 
 		shaderApply.Shade();
 
-		fbo_bind_as_texture(depalFBO, FB_COLOR_BIT, 0);
+		fbo_bind_as_texture(depalFBO, 0, FB_COLOR_BIT, 0);
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 		const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -787,7 +787,7 @@ void TextureCacheDX9::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFrame
 
 		shaderApply.Shade();
 
-		fbo_bind_color_as_texture(depalFBO, 0);
+		fbo_bind_as_texture(depalFBO, FB_COLOR_BIT, 0);
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 		const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;

--- a/GPU/Directx9/helper/dx_fbo.cpp
+++ b/GPU/Directx9/helper/dx_fbo.cpp
@@ -66,13 +66,13 @@ void fbo_shutdown() {
 	deviceDSsurf->Release();
 }
 
-FBO_DX9 *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth) {
+FBO_DX9 *fbo_create(const FramebufferDesc &desc) {
 	static uint32_t id = 0;
 
 	FBO_DX9 *fbo = new FBO_DX9();
-	fbo->width = width;
-	fbo->height = height;
-	fbo->colorDepth = colorDepth;
+	fbo->width = desc.width;
+	fbo->height = desc.height;
+	fbo->colorDepth = desc.colorDepth;
 	fbo->depthstenciltex = nullptr;
 
 	HRESULT rtResult = pD3Ddevice->CreateTexture(fbo->width, fbo->height, 1, D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &fbo->tex, NULL);
@@ -102,7 +102,6 @@ FBO_DX9 *fbo_create(int width, int height, int num_color_textures, bool z_stenci
 		delete fbo;
 		return NULL;
 	}
-
 	fbo->id = id++;
 	return fbo;
 }

--- a/GPU/Directx9/helper/dx_fbo.cpp
+++ b/GPU/Directx9/helper/dx_fbo.cpp
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
+
 #include "global.h"
 #include <stdint.h>
 #include <string.h>
@@ -149,17 +151,17 @@ LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO_DX9 *fbo) {
 	return fbo->surf;
 }
 
-void fbo_bind_as_texture(FBO_DX9 *fbo, FBOChannel channelBit, int color) {
+void fbo_bind_as_texture(FBO_DX9 *fbo, int binding, FBOChannel channelBit, int color) {
 	switch (channelBit) {
 	case FB_DEPTH_BIT:
 		if (fbo->depthstenciltex) {
-			pD3Ddevice->SetTexture(0, fbo->depthstenciltex);
+			pD3Ddevice->SetTexture(binding, fbo->depthstenciltex);
 		}
 		break;
 	case FB_COLOR_BIT:
 	default:
 		if (fbo->tex) {
-			pD3Ddevice->SetTexture(0, fbo->tex);
+			pD3Ddevice->SetTexture(binding, fbo->tex);
 		}
 		break;
 	}

--- a/GPU/Directx9/helper/dx_fbo.cpp
+++ b/GPU/Directx9/helper/dx_fbo.cpp
@@ -147,10 +147,6 @@ LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo) {
 	return fbo->surf;
 }
 
-LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO_DX9 *fbo) {
-	return fbo->surf;
-}
-
 void fbo_bind_as_texture(FBO_DX9 *fbo, int binding, FBOChannel channelBit, int color) {
 	switch (channelBit) {
 	case FB_DEPTH_BIT:

--- a/GPU/Directx9/helper/dx_fbo.cpp
+++ b/GPU/Directx9/helper/dx_fbo.cpp
@@ -134,13 +134,28 @@ void fbo_bind_as_render_target(FBO_DX9 *fbo) {
 	dxstate.viewport.restore();
 }
 
-
-LPDIRECT3DTEXTURE9 fbo_get_color_texture(FBO_DX9 *fbo) {
-	return fbo->tex;
-}
-
-LPDIRECT3DTEXTURE9 fbo_get_depth_texture(FBO_DX9 *fbo) {
-	return fbo->depthstenciltex;
+uintptr_t fbo_get_api_texture(FBO_DX9 *fbo, int channelBits, int attachment) {
+	if (channelBits & FB_SURFACE_BIT) {
+		switch (channelBits & 7) {
+		case FB_DEPTH_BIT:
+			return (uintptr_t)fbo->depthstencil;
+		case FB_STENCIL_BIT:
+			return (uintptr_t)fbo->depthstencil;
+		case FB_COLOR_BIT:
+		default:
+			return (uintptr_t)fbo->surf;
+		}
+	} else {
+		switch (channelBits & 7) {
+		case FB_DEPTH_BIT:
+			return (uintptr_t)fbo->depthstenciltex;
+		case FB_STENCIL_BIT:
+			return 0;  // Can't texture from stencil
+		case FB_COLOR_BIT:
+		default:
+			return (uintptr_t)fbo->tex;
+		}
+	}
 }
 
 LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo) {

--- a/GPU/Directx9/helper/dx_fbo.h
+++ b/GPU/Directx9/helper/dx_fbo.h
@@ -58,7 +58,7 @@ bool fbo_blit(FBO_DX9 *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO_DX9 
 // These functions should be self explanatory.
 void fbo_bind_as_render_target(FBO_DX9 *fbo);
 // color must be 0.
-void fbo_bind_as_texture(FBO_DX9 *fbo, FBOChannel channelBit, int color);
+void fbo_bind_as_texture(FBO_DX9 *fbo, int binding, FBOChannel channelBit, int color);
 LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo);
 LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO_DX9 *fbo);
 void fbo_bind_backbuffer_as_render_target();

--- a/GPU/Directx9/helper/dx_fbo.h
+++ b/GPU/Directx9/helper/dx_fbo.h
@@ -45,6 +45,14 @@ enum FBBlitFilter {
 	FB_BLIT_LINEAR = 1,
 };
 
+struct FramebufferDesc {
+	int width;
+	int height;
+	int depth;
+	int numColorAttachments;
+	bool z_stencil;
+	FBOColorDepth colorDepth;
+};
 // Creates a simple FBO with a RGBA32 color buffer stored in a texture, and
 // optionally an accompanying Z/stencil buffer.
 // No mipmap support.
@@ -52,7 +60,7 @@ enum FBBlitFilter {
 // you lose bound texture state.
 
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
-FBO_DX9 *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
+FBO_DX9 *fbo_create(const FramebufferDesc &desc);
 void fbo_destroy(FBO_DX9 *fbo);
 
 bool fbo_blit(FBO_DX9 *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO_DX9 *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter);

--- a/GPU/Directx9/helper/dx_fbo.h
+++ b/GPU/Directx9/helper/dx_fbo.h
@@ -32,6 +32,17 @@ enum FBOColorDepth {
 	FBO_5551,
 };
 
+enum FBOChannel {
+	FB_COLOR_BIT = 1,
+	FB_DEPTH_BIT = 2,
+	FB_STENCIL_BIT = 4,
+};
+
+enum FBBlitFilter {
+	FB_BLIT_NEAREST = 0,
+	FB_BLIT_LINEAR = 1,
+};
+
 // Creates a simple FBO with a RGBA32 color buffer stored in a texture, and
 // optionally an accompanying Z/stencil buffer.
 // No mipmap support.
@@ -40,19 +51,19 @@ enum FBOColorDepth {
 
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
 FBO_DX9 *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
+void fbo_destroy(FBO_DX9 *fbo);
+
+bool fbo_blit(FBO_DX9 *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO_DX9 *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter);
 
 // These functions should be self explanatory.
 void fbo_bind_as_render_target(FBO_DX9 *fbo);
-// color must be 0, for now.
-void fbo_bind_color_as_texture(FBO_DX9 *fbo, int color);
-void fbo_bind_depth_as_texture(FBO_DX9 *fbo);
+// color must be 0.
+void fbo_bind_as_texture(FBO_DX9 *fbo, FBOChannel channelBit, int color);
 LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo);
 LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO_DX9 *fbo);
-void fbo_unbind();
-void fbo_destroy(FBO_DX9 *fbo);
+void fbo_bind_backbuffer_as_render_target();
 void fbo_get_dimensions(FBO_DX9 *fbo, int *w, int *h);
 void fbo_resolve(FBO_DX9 *fbo);
-HRESULT fbo_blit_color(FBO_DX9 *src, const RECT *srcRect, FBO_DX9 *dst, const RECT *dstRect, D3DTEXTUREFILTERTYPE filter);
 
 LPDIRECT3DTEXTURE9 fbo_get_color_texture(FBO_DX9 *fbo);
 LPDIRECT3DTEXTURE9 fbo_get_depth_texture(FBO_DX9 *fbo);

--- a/GPU/Directx9/helper/dx_fbo.h
+++ b/GPU/Directx9/helper/dx_fbo.h
@@ -60,7 +60,6 @@ void fbo_bind_as_render_target(FBO_DX9 *fbo);
 // color must be 0.
 void fbo_bind_as_texture(FBO_DX9 *fbo, int binding, FBOChannel channelBit, int color);
 LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo);
-LPDIRECT3DSURFACE9 fbo_get_color_for_write(FBO_DX9 *fbo);
 void fbo_bind_backbuffer_as_render_target();
 void fbo_get_dimensions(FBO_DX9 *fbo, int *w, int *h);
 void fbo_resolve(FBO_DX9 *fbo);

--- a/GPU/Directx9/helper/dx_fbo.h
+++ b/GPU/Directx9/helper/dx_fbo.h
@@ -36,6 +36,8 @@ enum FBOChannel {
 	FB_COLOR_BIT = 1,
 	FB_DEPTH_BIT = 2,
 	FB_STENCIL_BIT = 4,
+
+	FB_SURFACE_BIT = 32,
 };
 
 enum FBBlitFilter {
@@ -59,13 +61,12 @@ bool fbo_blit(FBO_DX9 *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO_DX9 
 void fbo_bind_as_render_target(FBO_DX9 *fbo);
 // color must be 0.
 void fbo_bind_as_texture(FBO_DX9 *fbo, int binding, FBOChannel channelBit, int color);
-LPDIRECT3DSURFACE9 fbo_get_color_for_read(FBO_DX9 *fbo);
 void fbo_bind_backbuffer_as_render_target();
 void fbo_get_dimensions(FBO_DX9 *fbo, int *w, int *h);
 void fbo_resolve(FBO_DX9 *fbo);
 
-LPDIRECT3DTEXTURE9 fbo_get_color_texture(FBO_DX9 *fbo);
-LPDIRECT3DTEXTURE9 fbo_get_depth_texture(FBO_DX9 *fbo);
+// Escape route until we complete the API
+uintptr_t fbo_get_api_texture(FBO_DX9 *fbo, int channelBits, int attachment);
 
 // To get default depth and rt surface
 void fbo_init(LPDIRECT3D9 d3d);

--- a/GPU/GLES/FBO.cpp
+++ b/GPU/GLES/FBO.cpp
@@ -373,23 +373,23 @@ void fbo_copy_image(FBO *src, int srcLevel, int srcX, int srcY, int srcZ, FBO *d
 #if defined(USING_GLES2)
 #ifndef IOS
 	glCopyImageSubDataOES(
-		fbo_get_color_texture(src), GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
-		fbo_get_color_texture(dst), GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
+		src->color_texture, GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
+		dst->color_texture, GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
 		width, height, depth);
 	return;
 #endif
 #else
 	if (gl_extensions.ARB_copy_image) {
 		glCopyImageSubData(
-			fbo_get_color_texture(src), GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
-			fbo_get_color_texture(dst), GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
+			src->color_texture, GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
+			dst->color_texture, GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
 			width, height, depth);
 		return;
 	} else if (gl_extensions.NV_copy_image) {
 		// Older, pre GL 4.x NVIDIA cards.
 		glCopyImageSubDataNV(
-			fbo_get_color_texture(src), GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
-			fbo_get_color_texture(dst), GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
+			src->color_texture, GL_TEXTURE_2D, srcLevel, srcX, srcY, srcZ,
+			dst->color_texture, GL_TEXTURE_2D, dstLevel, dstX, dstY, dstZ,
 			width, height, depth);
 		return;
 	}
@@ -457,16 +457,4 @@ void fbo_destroy(FBO *fbo) {
 void fbo_get_dimensions(FBO *fbo, int *w, int *h) {
 	*w = fbo->width;
 	*h = fbo->height;
-}
-
-int fbo_get_color_texture(FBO *fbo) {
-	return fbo->color_texture;
-}
-
-int fbo_get_depth_buffer(FBO *fbo) {
-	return fbo->z_buffer;
-}
-
-int fbo_get_stencil_buffer(FBO *fbo) {
-	return fbo->stencil_buffer;
 }

--- a/GPU/GLES/FBO.cpp
+++ b/GPU/GLES/FBO.cpp
@@ -369,10 +369,6 @@ void fbo_bind_for_read(FBO *fbo) {
 	fbo_bind_fb_target(true, fbo->handle);
 }
 
-void fbo_unbind_read() {
-	fbo_bind_fb_target(true, 0);
-}
-
 void fbo_copy_image(FBO *src, int srcLevel, int srcX, int srcY, int srcZ, FBO *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth) {
 #if defined(USING_GLES2)
 #ifndef IOS

--- a/GPU/GLES/FBO.cpp
+++ b/GPU/GLES/FBO.cpp
@@ -381,7 +381,8 @@ void fbo_blit(FBO *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO *dst, in
 	}
 }
 
-void fbo_bind_as_texture(FBO *fbo, FBOChannel channelBit, int color) {
+void fbo_bind_as_texture(FBO *fbo, int binding, FBOChannel channelBit, int color) {
+	// glActiveTexture(GL_TEXTURE0 + binding);
 	switch (channelBit) {
 	case FB_COLOR_BIT:
 	default:

--- a/GPU/GLES/FBO.cpp
+++ b/GPU/GLES/FBO.cpp
@@ -381,6 +381,11 @@ void fbo_blit(FBO *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO *dst, in
 	}
 }
 
+uintptr_t fbo_get_api_texture(FBO *fbo, FBOChannel channelBit, int attachment) {
+	// Unimplemented
+	return 0;
+}
+
 void fbo_bind_as_texture(FBO *fbo, int binding, FBOChannel channelBit, int color) {
 	// glActiveTexture(GL_TEXTURE0 + binding);
 	switch (channelBit) {

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -44,6 +44,15 @@ enum FBBlitFilter {
 	FB_BLIT_LINEAR = 1,
 };
 
+struct FramebufferDesc {
+	int width;
+	int height;
+	int depth;
+	int numColorAttachments;
+	bool z_stencil;
+	FBOColorDepth colorDepth;
+};
+
 // Creates a simple FBO with a RGBA32 color buffer stored in a texture, and
 // optionally an accompanying Z/stencil buffer.
 // No mipmap support.
@@ -51,7 +60,7 @@ enum FBBlitFilter {
 // you lose bound texture state.
 
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
-FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
+FBO *fbo_create(const FramebufferDesc &desc);
 void fbo_destroy(FBO *fbo);
 
 void fbo_copy_image(FBO *src, int level, int x, int y, int z, FBO *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth);

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -62,7 +62,7 @@ int fbo_preferred_z_bitdepth();
 // These functions should be self explanatory.
 void fbo_bind_as_render_target(FBO *fbo);
 // color must be 0, for now.
-void fbo_bind_as_texture(FBO *fbo, FBOChannel channelBit, int attachment);
+void fbo_bind_as_texture(FBO *fbo, int binding, FBOChannel channelBit, int attachment);
 void fbo_bind_for_read(FBO *fbo);
 
 void fbo_bind_backbuffer_as_render_target();

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -66,5 +66,6 @@ void fbo_bind_as_texture(FBO *fbo, int binding, FBOChannel channelBit, int attac
 void fbo_bind_for_read(FBO *fbo);
 
 void fbo_bind_backbuffer_as_render_target();
+uintptr_t fbo_get_api_texture(FBO *fbo, FBOChannel channelBit, int attachment);
 
 void fbo_get_dimensions(FBO *fbo, int *w, int *h);

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -69,7 +69,3 @@ void fbo_unbind();
 void fbo_unbind_render_target();
 void fbo_destroy(FBO *fbo);
 void fbo_get_dimensions(FBO *fbo, int *w, int *h);
-
-int fbo_get_color_texture(FBO *fbo);
-int fbo_get_depth_buffer(FBO *fbo);
-int fbo_get_stencil_buffer(FBO *fbo);

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -43,11 +43,9 @@ enum FBOColorDepth {
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
 FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
 
-int fbo_standard_z_depth();
+void fbo_copy_image(FBO *src, int level, int x, int y, int z, FBO *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth);
 
-// Create an opaque FBO from a native GL FBO, optionally reusing an existing FBO structure.
-// Useful for overriding the backbuffer FBO that is generated outside of this wrapper.
-FBO *fbo_create_from_native_fbo(GLuint native_fbo, FBO *fbo = NULL);
+int fbo_standard_z_depth();
 int fbo_check_framebuffer_status(FBO *fbo);
 
 // These functions should be self explanatory.
@@ -64,5 +62,3 @@ void fbo_get_dimensions(FBO *fbo, int *w, int *h);
 int fbo_get_color_texture(FBO *fbo);
 int fbo_get_depth_buffer(FBO *fbo);
 int fbo_get_stencil_buffer(FBO *fbo);
-
-void fbo_override_backbuffer(FBO *fbo);  // Makes unbind bind this instead of the real backbuffer.

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -33,6 +33,16 @@ enum FBOColorDepth {
 	FBO_5551,
 };
 
+enum FBOChannel {
+	FB_COLOR_BIT = 1,
+	FB_DEPTH_BIT = 2,
+	FB_STENCIL_BIT = 4,
+};
+
+enum FBBlitFilter {
+	FB_BLIT_NEAREST = 0,
+	FB_BLIT_LINEAR = 1,
+};
 
 // Creates a simple FBO with a RGBA32 color buffer stored in a texture, and
 // optionally an accompanying Z/stencil buffer.
@@ -44,6 +54,8 @@ enum FBOColorDepth {
 FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
 
 void fbo_copy_image(FBO *src, int level, int x, int y, int z, FBO *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth);
+
+void fbo_blit(FBO *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter);
 
 int fbo_standard_z_depth();
 int fbo_check_framebuffer_status(FBO *fbo);

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -67,7 +67,6 @@ void fbo_bind_color_as_texture(FBO *fbo, int color);
 void fbo_bind_for_read(FBO *fbo);
 void fbo_unbind();
 void fbo_unbind_render_target();
-void fbo_unbind_read();
 void fbo_destroy(FBO *fbo);
 void fbo_get_dimensions(FBO *fbo, int *w, int *h);
 

--- a/GPU/GLES/FBO.h
+++ b/GPU/GLES/FBO.h
@@ -52,20 +52,19 @@ enum FBBlitFilter {
 
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
 FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
+void fbo_destroy(FBO *fbo);
 
 void fbo_copy_image(FBO *src, int level, int x, int y, int z, FBO *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth);
-
 void fbo_blit(FBO *src, int srcX1, int srcY1, int srcX2, int srcY2, FBO *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter);
 
-int fbo_standard_z_depth();
-int fbo_check_framebuffer_status(FBO *fbo);
+int fbo_preferred_z_bitdepth();
 
 // These functions should be self explanatory.
 void fbo_bind_as_render_target(FBO *fbo);
 // color must be 0, for now.
-void fbo_bind_color_as_texture(FBO *fbo, int color);
+void fbo_bind_as_texture(FBO *fbo, FBOChannel channelBit, int attachment);
 void fbo_bind_for_read(FBO *fbo);
-void fbo_unbind();
-void fbo_unbind_render_target();
-void fbo_destroy(FBO *fbo);
+
+void fbo_bind_backbuffer_as_render_target();
+
 void fbo_get_dimensions(FBO *fbo, int *w, int *h);

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -862,12 +862,12 @@ void FramebufferManagerGLES::BindFramebufferColor(int stage, u32 fbRawAddress, V
 
 			BlitFramebuffer(&copyInfo, x, y, framebuffer, x, y, w, h, 0);
 
-			fbo_bind_as_texture(renderCopy, FB_COLOR_BIT, 0);
+			fbo_bind_as_texture(renderCopy, 0, FB_COLOR_BIT, 0);
 		} else {
-			fbo_bind_as_texture(framebuffer->fbo, FB_COLOR_BIT, 0);
+			fbo_bind_as_texture(framebuffer->fbo, 0, FB_COLOR_BIT, 0);
 		}
 	} else {
-		fbo_bind_as_texture(framebuffer->fbo, FB_COLOR_BIT, 0);
+		fbo_bind_as_texture(framebuffer->fbo, 0, FB_COLOR_BIT, 0);
 	}
 
 	if (stage != GL_TEXTURE0) {
@@ -1014,7 +1014,7 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 		DEBUG_LOG(SCEGE, "Displaying FBO %08x", vfb->fb_address);
 		DisableState();
 
-		fbo_bind_as_texture(vfb->fbo, FB_COLOR_BIT, 0);
+		fbo_bind_as_texture(vfb->fbo, 0, FB_COLOR_BIT, 0);
 
 		int uvRotation = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 
@@ -1065,7 +1065,7 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 				ERROR_LOG(G3D, "WTF?");
 				return;
 			}
-			fbo_bind_as_texture(extraFBOs_[0], FB_COLOR_BIT, 0);
+			fbo_bind_as_texture(extraFBOs_[0], 0, FB_COLOR_BIT, 0);
 
 			// We are doing the DrawActiveTexture call directly to the backbuffer after here. Hence, we must
 			// flip V.
@@ -1295,7 +1295,7 @@ void FramebufferManagerGLES::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, 
 		fbo_blit(src->fbo, srcX1, srcY1, srcX2, srcY2, dst->fbo, dstX1, dstY1, dstX2, dstY2, FB_COLOR_BIT, FB_BLIT_NEAREST);
 	} else {
 		fbo_bind_as_render_target(dst->fbo);
-		fbo_bind_as_texture(src->fbo, FB_COLOR_BIT, 0);
+		fbo_bind_as_texture(src->fbo, 0, FB_COLOR_BIT, 0);
 
 		// Make sure our 2D drawing program is ready. Compiles only if not already compiled.
 		CompileDraw2DProgram();

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -1293,7 +1293,6 @@ void FramebufferManagerGLES::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, 
 	glstate.scissorTest.force(false);
 	if (useBlit) {
 		fbo_blit(src->fbo, srcX1, srcY1, srcX2, srcY2, dst->fbo, dstX1, dstY1, dstX2, dstY2, FB_COLOR_BIT, FB_BLIT_NEAREST);
-		fbo_unbind_read();
 	} else {
 		fbo_bind_as_render_target(dst->fbo);
 		fbo_bind_color_as_texture(src->fbo, 0);
@@ -1579,7 +1578,6 @@ void FramebufferManagerGLES::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 			fbo_bind_for_read(vfb->fbo);
 		} else {
 			ERROR_LOG_REPORT_ONCE(vfbfbozero, SCEGE, "PackFramebufferAsync_: vfb->fbo == 0");
-			fbo_unbind_read();
 			return;
 		}
 
@@ -1588,7 +1586,6 @@ void FramebufferManagerGLES::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 
 		if (fbStatus != GL_FRAMEBUFFER_COMPLETE) {
 			ERROR_LOG(SCEGE, "Incomplete source framebuffer, aborting read");
-			fbo_unbind_read();
 			return;
 		}
 
@@ -1610,7 +1607,6 @@ void FramebufferManagerGLES::PackFramebufferAsync_(VirtualFramebuffer *vfb) {
 			SafeGLReadPixels(0, 0, vfb->fb_stride, vfb->height, pixelFormat, pixelType, 0);
 		}
 
-		fbo_unbind_read();
 		unbind = true;
 
 		pixelBufObj_[currentPBO_].fb_address = fb_address;
@@ -1633,7 +1629,6 @@ void FramebufferManagerGLES::PackFramebufferSync_(VirtualFramebuffer *vfb, int x
 		fbo_bind_for_read(vfb->fbo);
 	} else {
 		ERROR_LOG_REPORT_ONCE(vfbfbozero, SCEGE, "PackFramebufferSync_: vfb->fbo == 0");
-		fbo_unbind_read();
 		return;
 	}
 
@@ -1693,8 +1688,6 @@ void FramebufferManagerGLES::PackFramebufferSync_(VirtualFramebuffer *vfb, int x
 		GLenum attachments[3] = { GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT };
 		glInvalidateFramebuffer(target, 3, attachments);
 	}
-
-	fbo_unbind_read();
 }
 
 void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h) {
@@ -1736,8 +1729,6 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 			depth[i] = (int)scaled;
 		}
 	}
-
-	fbo_unbind_read();
 }
 
 void FramebufferManagerGLES::EndFrame() {
@@ -1969,14 +1960,11 @@ bool FramebufferManagerGLES::GetFramebuffer(u32 fb_address, int fb_stride, GEBuf
 	SafeGLReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, buffer.GetData());
 
 	// We may have clitted to a temp FBO.
-	fbo_unbind_read();
 	RebindFramebuffer();
 	return true;
 }
 
 bool FramebufferManagerGLES::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
-	fbo_unbind_read();
-
 	int pw = PSP_CoreParameter().pixelWidth;
 	int ph = PSP_CoreParameter().pixelHeight;
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -121,7 +121,7 @@ void FramebufferManagerGLES::SetNumExtraFBOs(int num) {
 	extraFBOs_.clear();
 	for (int i = 0; i < num; i++) {
 		// No depth/stencil for post processing
-		FBO *fbo = fbo_create(renderWidth_, renderHeight_, 1, false, FBO_8888);
+		FBO *fbo = fbo_create({ (int)renderWidth_, (int)renderHeight_, 1, 1, false, FBO_8888 });
 		extraFBOs_.push_back(fbo);
 
 		// The new FBO is still bound after creation, but let's bind it anyway.
@@ -612,7 +612,7 @@ void FramebufferManagerGLES::ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w, u
 		return;
 	}
 
-	vfb->fbo = fbo_create(vfb->renderWidth, vfb->renderHeight, 1, true, (FBOColorDepth)vfb->colorDepth);
+	vfb->fbo = fbo_create({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, (FBOColorDepth)vfb->colorDepth });
 	if (old.fbo) {
 		INFO_LOG(SCEGE, "Resizing FBO for %08x : %i x %i x %i", vfb->fb_address, w, h, vfb->format);
 		if (vfb->fbo) {
@@ -801,7 +801,7 @@ FBO *FramebufferManagerGLES::GetTempFBO(u16 w, u16 h, FBOColorDepth depth) {
 	}
 
 	textureCache_->ForgetLastTexture();
-	FBO *fbo = fbo_create(w, h, 1, false, depth);
+	FBO *fbo = fbo_create({ w, h, 1, 1, false, depth });
 	if (!fbo)
 		return fbo;
 	fbo_bind_as_render_target(fbo);
@@ -1211,8 +1211,8 @@ bool FramebufferManagerGLES::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 		}
 	}
 
-	nvfb->fbo = fbo_create(nvfb->width, nvfb->height, 1, false, (FBOColorDepth)nvfb->colorDepth);
-	if (!(nvfb->fbo)) {
+	nvfb->fbo = fbo_create({ nvfb->width, nvfb->height, 1, 1, false, (FBOColorDepth)nvfb->colorDepth });
+	if (!nvfb->fbo) {
 		ERROR_LOG(SCEGE, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 		return false;
 	}

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -1014,7 +1014,7 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 		DEBUG_LOG(SCEGE, "Displaying FBO %08x", vfb->fb_address);
 		DisableState();
 
-		GLuint colorTexture = fbo_get_color_texture(vfb->fbo);
+		fbo_bind_color_as_texture(vfb->fbo, 0);
 
 		int uvRotation = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 
@@ -1036,15 +1036,15 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 			if (cardboardSettings.enabled) {
 				// Left Eye Image
 				glstate.viewport.set(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 
 				// Right Eye Image
 				glstate.viewport.set(cardboardSettings.rightEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 			} else {
 				// Fullscreen Image
 				glstate.viewport.set(0, 0, pixelWidth_, pixelHeight_);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, uvRotation);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, uvRotation);
 			}
 		} else if (usePostShader_ && extraFBOs_.size() == 1 && !postShaderAtOutputResolution_) {
 			// An additional pass, post-processing shader to the extra FBO.
@@ -1055,7 +1055,7 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 			shaderManager_->DirtyLastShader();  // dirty lastShader_
 			glsl_bind(postShaderProgram_);
 			UpdatePostShaderUniforms(vfb->bufferWidth, vfb->bufferHeight, renderWidth_, renderHeight_);
-			DrawActiveTexture(colorTexture, 0, 0, fbo_w, fbo_h, fbo_w, fbo_h, 0.0f, 0.0f, 1.0f, 1.0f, postShaderProgram_, ROTATION_LOCKED_HORIZONTAL);
+			DrawActiveTexture(0, 0, 0, fbo_w, fbo_h, fbo_w, fbo_h, 0.0f, 0.0f, 1.0f, 1.0f, postShaderProgram_, ROTATION_LOCKED_HORIZONTAL);
 
 			fbo_unbind();
 
@@ -1065,7 +1065,7 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 				ERROR_LOG(G3D, "WTF?");
 				return;
 			}
-			colorTexture = fbo_get_color_texture(extraFBOs_[0]);
+			fbo_bind_color_as_texture(extraFBOs_[0], 0);
 
 			// We are doing the DrawActiveTexture call directly to the backbuffer after here. Hence, we must
 			// flip V.
@@ -1074,15 +1074,15 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 			if (g_Config.bEnableCardboard) {
 				// Left Eye Image
 				glstate.viewport.set(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 
 				// Right Eye Image
 				glstate.viewport.set(cardboardSettings.rightEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 			} else {
 				// Fullscreen Image
 				glstate.viewport.set(0, 0, pixelWidth_, pixelHeight_);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, uvRotation);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, uvRotation);
 			}
 
 			if (gl_extensions.GLES3 && glInvalidateFramebuffer != nullptr) {
@@ -1101,15 +1101,15 @@ void FramebufferManagerGLES::CopyDisplayToOutput() {
 			if (g_Config.bEnableCardboard) {
 				// Left Eye Image
 				glstate.viewport.set(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 
 				// Right Eye Image
 				glstate.viewport.set(cardboardSettings.rightEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, nullptr, ROTATION_LOCKED_HORIZONTAL);
 			} else {
 				// Fullscreen Image
 				glstate.viewport.set(0, 0, pixelWidth_, pixelHeight_);
-				DrawActiveTexture(colorTexture, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, postShaderProgram_, uvRotation);
+				DrawActiveTexture(0, x, y, w, h, (float)pixelWidth_, (float)pixelHeight_, u0, v0, u1, v1, postShaderProgram_, uvRotation);
 			}
 		}
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -605,14 +605,14 @@ void GPU_GLES::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
 	// If we already have a 16-bit depth buffer, we don't need to round.
-	if (fbo_standard_z_depth() > 16) {
+	if (fbo_preferred_z_bitdepth() > 16) {
 		if (!g_Config.bHighQualityDepth && (features & GPU_SUPPORTS_ACCURATE_DEPTH) != 0) {
 			features |= GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT;
 		} else if (PSP_CoreParameter().compat.flags().PixelDepthRounding) {
 			if (!gl_extensions.IsGLES || gl_extensions.GLES3) {
 				// Use fragment rounding on desktop and GLES3, most accurate.
 				features |= GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT;
-			} else if (fbo_standard_z_depth() == 24 && (features & GPU_SUPPORTS_ACCURATE_DEPTH) != 0) {
+			} else if (fbo_preferred_z_bitdepth() == 24 && (features & GPU_SUPPORTS_ACCURATE_DEPTH) != 0) {
 				// Here we can simulate a 16 bit depth buffer by scaling.
 				// Note that the depth buffer is fixed point, not floating, so dividing by 256 is pretty good.
 				features |= GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT;

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -171,7 +171,6 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 	glstate.stencilOp.set(GL_REPLACE, GL_REPLACE, GL_REPLACE);
 
 	bool useBlit = gstate_c.Supports(GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT | GPU_SUPPORTS_NV_FRAMEBUFFER_BLIT);
-	bool useNV = useBlit && !gstate_c.Supports(GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT);
 
 	// Our fragment shader (and discard) is slow.  Since the source is 1x, we can stencil to 1x.
 	// Then after we're done, we'll just blit it across and stretch it there.
@@ -221,15 +220,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 	glstate.stencilMask.set(0xFF);
 
 	if (useBlit) {
-		fbo_bind_as_render_target(dstBuffer->fbo);
-		fbo_bind_for_read(blitFBO);
-		if (!useNV) {
-			glBlitFramebuffer(0, 0, w, h, 0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight, GL_STENCIL_BUFFER_BIT, GL_NEAREST);
-		} else {
-#if defined(USING_GLES2) && defined(__ANDROID__)  // We only support this extension on Android, it's not even available on PC.
-			glBlitFramebufferNV(0, 0, w, h, 0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight, GL_STENCIL_BUFFER_BIT, GL_NEAREST);
-#endif // defined(USING_GLES2) && defined(__ANDROID__)
-		}
+		fbo_blit(blitFBO, 0, 0, w, h, dstBuffer->fbo, 0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight, FB_STENCIL_BIT, FB_BLIT_NEAREST);
 	}
 
 	RebindFramebuffer();

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -862,7 +862,7 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 
 		shaderApply.Shade();
 
-		fbo_bind_as_texture(depalFBO, FB_COLOR_BIT, 0);
+		fbo_bind_as_texture(depalFBO, 0, FB_COLOR_BIT, 0);
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 		const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -862,7 +862,7 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 
 		shaderApply.Shade();
 
-		fbo_bind_color_as_texture(depalFBO, 0);
+		fbo_bind_as_texture(depalFBO, FB_COLOR_BIT, 0);
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 		const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -1201,7 +1201,6 @@ void FramebufferManagerVulkan::BlitFramebuffer(VirtualFramebuffer *dst, int dstX
 		return;
 	}
 
-	// glBlitFramebuffer can clip, but glCopyImageSubData is more restricted.
 	// In case the src goes outside, we just skip the optimization in that case.
 	const bool sameSize = dstX2 - dstX1 == srcX2 - srcX1 && dstY2 - dstY1 == srcY2 - srcY1;
 	const bool sameDepth = dst->colorDepth == src->colorDepth;

--- a/Qt/Debugger/debugger_displaylist.cpp
+++ b/Qt/Debugger/debugger_displaylist.cpp
@@ -1353,7 +1353,7 @@ void Debugger_DisplayList::UpdateRenderBufferGUI()
 		memset(data,0,FRAME_WIDTH * FRAME_HEIGHT * 4);
 		if(currentRenderFrameDisplay == 0)
 		{
-			fbo_bind_color_as_texture(currentTextureDisplay,0);
+			fbo_bind_as_texture(currentTextureDisplay, 0, FB_COLOR_BIT, 0);
 			glGetTexImage(GL_TEXTURE_2D, 0, GL_BGRA, GL_UNSIGNED_BYTE, data);
 		}
 	}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -44,7 +44,6 @@
 #include "Core/System.h"
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
-#include "GPU/GLES/FBO.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceDisplay.h"

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1028,9 +1028,6 @@ void EmuScreen::render() {
 	if (invalid_)
 		return;
 
-	if (useBufferedRendering && GetGPUBackend() == GPUBackend::OPENGL)
-		fbo_unbind();
-
 	if (!osm.IsEmpty() || g_Config.bShowDebugStats || g_Config.iShowFPSCounter || g_Config.bShowTouchControls || g_Config.bShowDeveloperMenu || g_Config.bShowAudioDebug || saveStatePreview_->GetVisibility() != UI::V_GONE || g_Config.bShowFrameProfiler) {
 		DrawContext *thin3d = screenManager()->getDrawContext();
 


### PR DESCRIPTION
This makes it so that both DX and GL use almost identical APIs to handle FBO:s. This is a step towards being able to share more FBO code, which will make implementing FBO support for Vulkan and DX11 much easier in the future.

No new functionality, everything should work the same and I don't expect any perf loss.