### PR TITLE
Add timing of sceMpegDelete

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -555,7 +555,7 @@ static int sceMpegDelete(u32 mpeg)
 	delete ctx;
 	mpegMap.erase(Memory::Read_U32(mpeg));
 
-	return 0;
+	return hleDelayResult(0, "mpeg delete", 40000);
 }
 
 


### PR DESCRIPTION
Based on https://github.com/jpcsp/jpcsp/commit/8e4e6334da762be37a90855a686a7decbc29bacf
Fix unknown getpointer in Jak and Daxter in intro
Might help #8606  #7502 #9279 