### PR TITLE
D3D11 DrawContext fixes

### DIFF
--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -94,7 +94,7 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	PipelineDesc pipelineDesc{
 		Primitive::TRIANGLE_LIST,
 		{ draw_->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw_->GetFshaderPreset(FS_TEXTURE_COLOR_2D) },
-		inputLayout, depth, blendstateOff, rasterNoCull
+		inputLayout, depth, blendstateOff, rasterNoCull, &vsTexColBufDesc
 	};
 	texColor = draw_->CreateGraphicsPipeline(pipelineDesc);
 
@@ -250,8 +250,10 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 			0.0f, 0.0f, 0.0f, 1.0f,
 		};
 
-		texColor->SetMatrix4x4("WorldViewProj", identity4x4);
+		VsTexColUB ub{};
+		memcpy(ub.WorldViewProj, identity4x4, sizeof(float) * 16);
 		draw_->BindPipeline(texColor);
+		draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
 		draw_->BindVertexBuffers(0, 1, &vdata, nullptr);
 		draw_->BindIndexBuffer(idata, 0);
 		draw_->DrawIndexed(6, 0);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -354,7 +354,7 @@ void SystemInfoScreen::CreateViews() {
 
 	DrawContext *draw = screenManager()->getDrawContext();
 
-	deviceSpecs->Add(new InfoItem("3D API", draw->GetInfoString(InfoField::APINAME)));
+	deviceSpecs->Add(new InfoItem("3D API", std::string(draw->GetInfoString(InfoField::APINAME))));
 	deviceSpecs->Add(new InfoItem("Vendor", std::string(draw->GetInfoString(InfoField::VENDORSTRING)) + " (" + draw->GetInfoString(InfoField::VENDOR) + ")"));
 	deviceSpecs->Add(new InfoItem("Model", draw->GetInfoString(InfoField::RENDERER)));
 #ifdef _WIN32

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -596,12 +596,12 @@ void NativeInitGraphics(GraphicsContext *graphicsContext) {
 	PipelineDesc colorDesc{
 		Primitive::TRIANGLE_LIST,
 		{ g_draw->GetVshaderPreset(VS_COLOR_2D), g_draw->GetFshaderPreset(FS_COLOR_2D) },
-		inputLayout, depth, blendNormal, rasterNoCull
+		inputLayout, depth, blendNormal, rasterNoCull, &vsColBufDesc,
 	};
 	PipelineDesc texColorDesc{
 		Primitive::TRIANGLE_LIST,
 		{ g_draw->GetVshaderPreset(VS_TEXTURE_COLOR_2D), g_draw->GetFshaderPreset(FS_TEXTURE_COLOR_2D) },
-		inputLayout, depth, blendNormal, rasterNoCull
+		inputLayout, depth, blendNormal, rasterNoCull, &vsTexColBufDesc,
 	};
 
 	colorPipeline = g_draw->CreateGraphicsPipeline(colorDesc);

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -90,8 +90,12 @@ void DrawBuffer::Flush(bool set_blend_state) {
 	if (count_ == 0)
 		return;
 
-	pipeline_->SetMatrix4x4("WorldViewProj", drawMatrix_.getReadPtr());
 	draw_->BindPipeline(pipeline_);
+
+	VsTexColUB ub{};
+	memcpy(ub.WorldViewProj, drawMatrix_.getReadPtr(), sizeof(Matrix4x4));
+	// pipeline_->SetMatrix4x4("WorldViewProj", drawMatrix_.getReadPtr());
+	draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
 	if (vbuf_) {
 		draw_->UpdateBuffer(vbuf_, (const uint8_t *)verts_, 0, sizeof(Vertex) * count_, Draw::UPDATE_DISCARD);
 		draw_->BindVertexBuffers(0, 1, &vbuf_, nullptr);

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -300,7 +300,7 @@ void TextDrawer::DrawString(DrawBuffer &target, const char *str, float x, float 
 			for (int y = 0; y < entry->bmHeight; y++) {
 				for (int x = 0; x < entry->bmWidth; x++) {
 					uint8_t bAlpha = (uint8_t)(ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff);
-					bitmapData32[entry->bmWidth * y + x] = (bAlpha) | 0xffffff00;
+					bitmapData32[entry->bmWidth * y + x] = (bAlpha << 24) | 0x00ffffff;
 				}
 			}
 			desc.initData.push_back((uint8_t *)bitmapData32);

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -86,7 +86,8 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"SamplerState samp : register(s0);\n"
 	"Texture2D<float4> tex : register(t0);\n"
 	"float4 main(PS_INPUT input) : SV_Target {\n"
-	"  return input.color * tex.Sample(samp, input.uv);\n"
+	"  float4 col = input.color * tex.Sample(samp, input.uv);\n"
+	"  return col;\n"
 	"}\n"
 	},
 	{ShaderLanguage::GLSL_VULKAN,
@@ -158,7 +159,9 @@ static const std::vector<ShaderSource> vsCol = {
 	{ ShaderLanguage::HLSL_D3D11,
 	"struct VS_INPUT { float3 Position : POSITION; float4 Color0 : COLOR0; };\n"
 	"struct VS_OUTPUT { float4 Color0 : COLOR0; float4 Position : SV_Position; };\n"
-	"float4x4 WorldViewProj : register(c0);\n"
+	"cbuffer ConstantBuffer : register(b0) {\n"
+	"  matrix WorldViewProj;\n"
+	"};\n"
 	"VS_OUTPUT main(VS_INPUT input) {\n"
 	"  VS_OUTPUT output;\n"
 	"  output.Position = mul(float4(input.Position, 1.0), WorldViewProj);\n"
@@ -217,7 +220,9 @@ static const std::vector<ShaderSource> vsTexCol = {
 	{ ShaderLanguage::HLSL_D3D11,
 	"struct VS_INPUT { float3 Position : POSITION; float2 Texcoord0 : TEXCOORD0; float4 Color0 : COLOR0; };\n"
 	"struct VS_OUTPUT { float4 Color0 : COLOR0; float2 Texcoord0 : TEXCOORD0; float4 Position : SV_Position; };\n"
-	"float4x4 WorldViewProj : register(c0);\n"
+	"cbuffer ConstantBuffer : register(b0) {\n"
+	"  matrix WorldViewProj;\n"
+	"};\n"
 	"VS_OUTPUT main(VS_INPUT input) {\n"
 	"  VS_OUTPUT output;\n"
 	"  output.Position = mul(WorldViewProj, float4(input.Position, 1.0));\n"

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -220,7 +220,7 @@ static const std::vector<ShaderSource> vsTexCol = {
 	"float4x4 WorldViewProj : register(c0);\n"
 	"VS_OUTPUT main(VS_INPUT input) {\n"
 	"  VS_OUTPUT output;\n"
-	"  output.Position = mul(float4(input.Position, 1.0), WorldViewProj);\n"
+	"  output.Position = mul(WorldViewProj, float4(input.Position, 1.0));\n"
 	"  output.Texcoord0 = input.Texcoord0;\n"
 	"  output.Color0 = input.Color0;\n"
 	"  return output;\n"

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -184,10 +184,9 @@ static const std::vector<ShaderSource> vsCol = {
 	}
 };
 
-static const UniformBufferDesc vsColBuf { { { 0, UniformType::MATRIX4X4, 0 } } };
-struct VsColUB {
-	float WorldViewProj[16];
-};
+const UniformBufferDesc vsColBufDesc { sizeof(VsColUB), {
+	{ "WorldViewProj", 0, -1, UniformType::MATRIX4X4, 0 }
+} };
 
 static const std::vector<ShaderSource> vsTexCol = {
 	{ ShaderLanguage::GLSL_ES_200,
@@ -248,10 +247,9 @@ static const std::vector<ShaderSource> vsTexCol = {
 	}
 };
 
-static const UniformBufferDesc vsTexColDesc{ { { 0, UniformType::MATRIX4X4, 0 } } };
-struct VsTexColUB {
-	float WorldViewProj[16];
-};
+const UniformBufferDesc vsTexColBufDesc{ sizeof(VsTexColUB),{
+	{ "WorldViewProj", 0, -1, UniformType::MATRIX4X4, 0 }
+} };
 
 static ShaderModule *CreateShader(DrawContext *draw, ShaderStage stage, const std::vector<ShaderSource> &sources) {
 	uint32_t supported = draw->GetSupportedShaderLanguages();

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -522,7 +522,7 @@ struct PipelineDesc {
 	DepthStencilState *depthStencil;
 	BlendState *blend;
 	RasterState *raster;
-	UniformBufferDesc *uniformDesc;
+	const UniformBufferDesc *uniformDesc;
 };
 
 struct DeviceCaps {

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -430,20 +430,22 @@ struct InputLayoutDesc {
 class InputLayout : public RefCountedObject { };
 
 enum class UniformType : int8_t {
-	FLOAT, FLOAT2, FLOAT3, FLOAT4,
+	FLOAT4,
 	MATRIX4X4,
 };
 
 // For emulation of uniform buffers on D3D9/GL
 struct UniformDesc {
-	int16_t offset;
+	const char *name;  // For GL
+	int16_t vertexReg;        // For D3D
+	int16_t fragmentReg;      // For D3D
 	UniformType type;
-	int8_t reg;  // For D3D
-
+	int16_t offset;
 	// TODO: Support array elements etc.
 };
 
 struct UniformBufferDesc {
+	size_t uniformBufferSize;
 	std::vector<UniformDesc> uniforms;
 };
 
@@ -520,6 +522,7 @@ struct PipelineDesc {
 	DepthStencilState *depthStencil;
 	BlendState *blend;
 	RasterState *raster;
+	UniformBufferDesc *uniformDesc;
 };
 
 struct DeviceCaps {
@@ -602,6 +605,10 @@ public:
 	virtual void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) = 0;
 	virtual void BindIndexBuffer(Buffer *indexBuffer, int offset) = 0;
 
+	// Only supports a single dynamic uniform buffer, for maximum compatibility with the old APIs and ease of emulation.
+	// More modern methods will be added later.
+	virtual void UpdateDynamicUniformBuffer(const void *ub, size_t size) = 0;
+
 	void BindTexture(int stage, Texture *texture) {
 		BindTextures(stage, 1, &texture);
 	}  // from sampler 0 and upwards
@@ -645,11 +652,24 @@ size_t DataFormatSizeInBytes(DataFormat fmt);
 
 DrawContext *T3DCreateGLContext();
 
+extern const UniformBufferDesc UBPresetDesc;
+
 #ifdef _WIN32
 DrawContext *T3DCreateDX9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, IDirect3DDevice9 *device, IDirect3DDevice9Ex *deviceEx);
 DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, HWND hWnd);
 #endif
 
 DrawContext *T3DCreateVulkanContext(VulkanContext *context);
+
+// UBs for the preset shaders
+
+struct VsTexColUB {
+	float WorldViewProj[16];
+};
+extern const UniformBufferDesc vsTexColBufDesc;
+struct VsColUB {
+	float WorldViewProj[16];
+};
+extern const UniformBufferDesc vsColBufDesc;
 
 }  // namespace Draw

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -456,9 +456,6 @@ public:
 
 class Pipeline : public RefCountedObject {
 public:
-	// TODO: Use a uniform-buffer based interface instead.
-	virtual void SetVector(const char *name, float *value, int n) = 0;
-	virtual void SetMatrix4x4(const char *name, const float value[16]) = 0;
 	virtual bool RequiresBuffer() = 0;
 };
 

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -520,9 +520,6 @@ public:
 		if (dynamicUniformsView)
 			dynamicUniformsView->Release();
 	}
-	// TODO: Refactor away these.
-	void SetVector(const char *name, float *value, int n) { }
-	void SetMatrix4x4(const char *name, const float value[16]) { }  // pshaders don't usually have matrices
 	bool RequiresBuffer() {
 		return true;
 	}

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -729,14 +729,14 @@ Pipeline *D3D11DrawContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 		dPipeline->dynamicUniformsSize = desc.uniformDesc->uniformBufferSize;
 		D3D11_BUFFER_DESC bufdesc{};
 		bufdesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-		bufdesc.ByteWidth = dPipeline->dynamicUniformsSize;
-		bufdesc.StructureByteStride = dPipeline->dynamicUniformsSize;
+		bufdesc.ByteWidth = (UINT)dPipeline->dynamicUniformsSize;
+		bufdesc.StructureByteStride = (UINT)dPipeline->dynamicUniformsSize;
 		bufdesc.Usage = D3D11_USAGE_DYNAMIC;
 		bufdesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		HRESULT hr = device_->CreateBuffer(&bufdesc, nullptr, &dPipeline->dynamicUniforms);
 		D3D11_SHADER_RESOURCE_VIEW_DESC bufview{};
 		bufview.Buffer.ElementOffset = 0;
-		bufview.Buffer.ElementWidth = dPipeline->dynamicUniformsSize;
+		bufview.Buffer.ElementWidth = (UINT)dPipeline->dynamicUniformsSize;
 		bufview.Buffer.FirstElement = 0;
 		bufview.Buffer.NumElements = 1;
 		hr = device_->CreateShaderResourceView(dPipeline->dynamicUniforms, &bufview, &dPipeline->dynamicUniformsView);
@@ -835,6 +835,10 @@ void D3D11DrawContext::ApplyCurrentState() {
 	context_->IASetVertexBuffers(0, 1, nextVertexBuffers_, (UINT *)curPipeline_->input->strides.data(), (UINT *)nextVertexBufferOffsets_);
 	if (nextIndexBuffer_) {
 		context_->IASetIndexBuffer(nextIndexBuffer_, DXGI_FORMAT_R32_UINT, nextIndexBufferOffset_);
+	}
+
+	if (curPipeline_->dynamicUniforms) {
+		context_->VSSetShaderResources(0, 1, &curPipeline_->dynamicUniformsView);
 	}
 }
 

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -816,6 +816,14 @@ Buffer *D3D9Context::CreateBuffer(size_t size, uint32_t usageFlags) {
 	return new D3D9Buffer(device_, size, usageFlags);
 }
 
+inline void Transpose4x4(float out[16], const float in[16]) {
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			out[i * 4 + j] = in[j * 4 + i];
+		}
+	}
+}
+
 void D3D9Context::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 	if (size != curPipeline_->dynamicUniforms.uniformBufferSize)
 		Crash();
@@ -829,9 +837,11 @@ void D3D9Context::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 			count = 4;
 			break;
 		}
-		const float *srcPtr = (const float *)((uint8_t *)ub + uniform.offset);
+		const float *srcPtr = (const float *)((const uint8_t *)ub + uniform.offset);
 		if (uniform.vertexReg != -1) {
-			device_->SetVertexShaderConstantF(uniform.vertexReg, srcPtr, count);
+			float transp[16];
+			Transpose4x4(transp, srcPtr);
+			device_->SetVertexShaderConstantF(uniform.vertexReg, transp, count);
 		}
 		if (uniform.fragmentReg != -1) {
 			device_->SetPixelShaderConstantF(uniform.fragmentReg, srcPtr, count);

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -398,16 +398,10 @@ public:
 		if (raster) raster->Release();
 		if (inputLayout) inputLayout->Release();
 	}
-	bool RequiresBuffer() override {
-		return inputLayout->RequiresBuffer();
-	}
 
 	bool LinkShaders();
 
 	int GetUniformLoc(const char *name);
-
-	void SetVector(const char *name, float *value, int n) override;
-	void SetMatrix4x4(const char *name, const float value[16]) override;
 
 	void GLLost() override {
 		program_ = 0;
@@ -421,6 +415,10 @@ public:
 			iter->Compile(iter->GetLanguage(), (const uint8_t *)iter->GetSource().c_str(), iter->GetSource().size());
 		}
 		LinkShaders();
+	}
+
+	bool RequiresBuffer() override {
+		return inputLayout->RequiresBuffer();
 	}
 
 	GLuint prim;
@@ -1065,27 +1063,6 @@ int OpenGLPipeline::GetUniformLoc(const char *name) {
 		uniformCache_[name] = info;
 	}
 	return loc;
-}
-
-void OpenGLPipeline::SetVector(const char *name, float *value, int n) {
-	glUseProgram(program_);
-	int loc = GetUniformLoc(name);
-	if (loc != -1) {
-		switch (n) {
-		case 1: glUniform1fv(loc, 1, value); break;
-		case 2: glUniform1fv(loc, 2, value); break;
-		case 3: glUniform1fv(loc, 3, value); break;
-		case 4: glUniform1fv(loc, 4, value); break;
-		}
-	}
-}
-
-void OpenGLPipeline::SetMatrix4x4(const char *name, const float value[16]) {
-	glUseProgram(program_);
-	int loc = GetUniformLoc(name);
-	if (loc != -1) {
-		glUniformMatrix4fv(loc, 1, false, value);
-	}
 }
 
 void OpenGLContext::BindPipeline(Pipeline *pipeline) {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -263,7 +263,7 @@ public:
 class VKPipeline : public Pipeline {
 public:
 	VKPipeline(size_t size) {
-		uboSize_ = size;
+		uboSize_ = (int)size;
 		ubo_ = new uint8_t[uboSize_];
 	}
 	~VKPipeline() {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -280,10 +280,6 @@ public:
 	}
 
 	int GetUniformLoc(const char *name);
-
-	void SetVector(const char *name, float *value, int n) override;
-	void SetMatrix4x4(const char *name, const float value[16]) override;
-
 	int GetUBOSize() const {
 		return uboSize_;
 	}
@@ -1091,17 +1087,6 @@ int VKPipeline::GetUniformLoc(const char *name) {
 	}
 
 	return loc;
-}
-
-void VKPipeline::SetVector(const char *name, float *value, int n) {
-	// TODO: Implement
-}
-
-void VKPipeline::SetMatrix4x4(const char *name, const float value[16]) {
-	int loc = GetUniformLoc(name);
-	if (loc != -1) {
-		memcpy(ubo_ + loc, value, 16 * sizeof(float));
-	}
 }
 
 inline VkPrimitiveTopology PrimToVK(Primitive prim) {


### PR DESCRIPTION
With this, PPSSPP's UI can now render in D3D11 mode.

Still need to add an actual PSP graphics backend... but that will be easier thanks to the recent refactorings.