### PR TITLE
Remember Last Remote ISO server

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -339,6 +339,8 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("AutoSaveSymbolMap", &g_Config.bAutoSaveSymbolMap, false, true, true),
 	ConfigSetting("CacheFullIsoInRam", &g_Config.bCacheFullIsoInRam, false, true, true),
 	ConfigSetting("RemoteISOPort", &g_Config.iRemoteISOPort, 0, true, false),
+	ConfigSetting("LastRemoteISOServer", &g_Config.sLastRemoteISOServer, ""),
+	ConfigSetting("LastRemoteISOPort", &g_Config.iLastRemoteISOPort, 0),
 
 #ifdef __ANDROID__
 	ConfigSetting("ScreenRotation", &g_Config.iScreenRotation, 1),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -141,6 +141,8 @@ public:
 	bool bAutoSaveSymbolMap;
 	bool bCacheFullIsoInRam;
 	int iRemoteISOPort;
+	std::string sLastRemoteISOServer;
+	int iLastRemoteISOPort;
 	bool bMemStickInserted;
 
 	int iScreenRotation;  // The rotation angle of the PPSSPP UI. Only supported on Android and possibly other mobile platforms.

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -188,9 +188,6 @@ static bool FindServer(std::string &resultHost, int &resultPort) {
 	Buffer result;
 	int code = 500;
 
-	// Not sure why this is needed here, but windows fails without it.
-	net::Init();
-
 	// Try last server first, if it is set
 	if (g_Config.iLastRemoteISOPort && g_Config.sLastRemoteISOServer != "" && http.Resolve(g_Config.sLastRemoteISOServer.c_str(), g_Config.iLastRemoteISOPort) && http.Connect()) {
 		http.Disconnect();


### PR DESCRIPTION
This change remembers the last remote iso server it was connected to and tries to connect to that first.  It also allows you to manually specify a server by editing the ini.
I have other changes in mind for remote ISOs.  But first a question.  Right now it uses reports.ppsspp.org to find the server which is down.  Is that a permanent change?  If so we need to find another server location method.
Other changes I have in mind:
A manual option in the GUI to specify server
Ability to read apache directory index output. 
Ability to read from subdirectory on webserver. 

I have it working with apache now, but I had to code some php to make the directory listing look like the ppsspp output. 