### PR TITLE
Fix importing first cheat from database list

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -206,7 +206,6 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 			title.push_back(line);
 			getline(fs, line);
 			title.push_back(line);
-			getline(fs, line);
 			do {
 				if (finished == false){
 					getline(fs, line);


### PR DESCRIPTION
It was always skipping first cheat.