### PR TITLE
Assorted cleanup of GL texture handling. Fixes #9286

### DIFF
--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -82,7 +82,7 @@ public:
 	}
 
 protected:
-	void SetViewport2D(int x, int y, int w, int h);
+	void SetViewport2D(int x, int y, int w, int h) override;
 	void DisableState() override;
 	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -122,7 +122,7 @@ public:
 protected:
 	void Bind2DShader() override;
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
-	void SetViewport2D(int x, int y, int w, int h);
+	void SetViewport2D(int x, int y, int w, int h) override;
 	void DisableState() override {}
 	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;
@@ -135,7 +135,7 @@ protected:
 private:
 
 	// The returned texture does not need to be free'd, might be returned from a pool (currently single entry)
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
+	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) override;
 	void DoNotifyDraw();
 
 	VkCommandBuffer AllocFrameCommandBuffer();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -412,6 +412,7 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (experimental)")));
 	softwareGPU->OnClick.Add([=](EventParams &e) {
 		settingInfo_->Show(gr->T("SoftGPU Tip", "Currently VERY slow"), e.v);
+		bloomHackEnable_ = !g_Config.bSoftwareRendering && (g_Config.iInternalResolution != 1);
 		return UI::EVENT_CONTINUE;
 	});
 	softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -488,7 +488,7 @@ void TextDrawer::DrawString(DrawBuffer &target, const char *str, float x, float 
 				bitmapData[entry->bmWidth * y + x] = 0xfff0 | image.pixel(x, y) >> 28;
 			}
 		}
-		desc.initData.push_back(bitmapData);
+		desc.initData.push_back((uint8_t *)bitmapData);
 		entry->texture = draw_->CreateTexture(desc);
 		delete [] bitmapData;
 		cache_[entryHash] = std::unique_ptr<TextStringEntry>(entry);

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -476,12 +476,11 @@ void TextDrawer::DrawString(DrawBuffer &target, const char *str, float x, float 
 
 		TextureDesc desc{};
 		desc.type = TextureType::LINEAR2D;
-		desc.format = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
+		desc.format = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
 		desc.width = entry->bmWidth;
 		desc.height = entry->bmHeight;
 		desc.depth = 1;
 		desc.mipLevels = 1;
-		entry->texture = draw_->CreateTexture(desc);
 
 		uint16_t *bitmapData = new uint16_t[entry->bmWidth * entry->bmHeight];
 		for (int x = 0; x < entry->bmWidth; x++) {
@@ -489,10 +488,9 @@ void TextDrawer::DrawString(DrawBuffer &target, const char *str, float x, float 
 				bitmapData[entry->bmWidth * y + x] = 0xfff0 | image.pixel(x, y) >> 28;
 			}
 		}
-		entry->texture->SetImageData(0, 0, 0, entry->bmWidth, entry->bmHeight, 1, 0, entry->bmWidth * 2, (const uint8_t *)bitmapData);
-
+		desc.initData.push_back(bitmapData);
+		entry->texture = draw_->CreateTexture(desc);
 		delete [] bitmapData;
-
 		cache_[entryHash] = std::unique_ptr<TextStringEntry>(entry);
 	}
 	float w = entry->bmWidth * fontScaleX_;

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -111,8 +111,8 @@ enum class StencilOp {
 };
 
 enum class TextureFilter : int {
-	NEAREST,
-	LINEAR,
+	NEAREST = 0,
+	LINEAR = 1,
 };
 
 enum BufferUsageFlag : int {
@@ -273,7 +273,7 @@ enum {
 };
 
 enum class TextureAddressMode {
-	REPEAT,
+	REPEAT = 0,
 	REPEAT_MIRROR,
 	CLAMP_TO_EDGE,
 	CLAMP_TO_BORDER,

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -406,8 +406,6 @@ public:
 
 class Texture : public RefCountedObject {
 public:
-	virtual void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) = 0;
-
 	int Width() { return width_; }
 	int Height() { return height_; }
 	int Depth() { return depth_; }

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -647,10 +647,6 @@ public:
 			view->Release();
 	}
 
-	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) {
-		ELOG("SetImageData not supported, create a new texture instead");
-	}
-
 	ID3D11Texture2D *tex = nullptr;
 	ID3D11ShaderResourceView *view = nullptr;
 };

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -297,10 +297,10 @@ class D3D9Texture : public Texture {
 public:
 	D3D9Texture(LPDIRECT3DDEVICE9 device, LPDIRECT3DDEVICE9EX deviceEx, const TextureDesc &desc);
 	~D3D9Texture();
-	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) override;
 	void SetToSampler(LPDIRECT3DDEVICE9 device, int sampler);
 
 private:
+	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data);
 	bool Create(const TextureDesc &desc);
 	LPDIRECT3DDEVICE9 device_;
 	LPDIRECT3DDEVICE9EX deviceEx_;
@@ -364,7 +364,7 @@ bool D3D9Texture::Create(const TextureDesc &desc) {
 
 	if (desc.initData.size()) {
 		for (int i = 0; i < desc.initData.size(); i++) {
-			this->SetImageData(0, 0, 0, width_, height_, depth_, i, 0, desc.initData[i]);
+			SetImageData(0, 0, 0, width_, height_, depth_, i, 0, desc.initData[i]);
 		}
 	}
 	return true;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -597,11 +597,11 @@ public:
 		Destroy();
 	}
 
-	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data) override;
-
 	VkImageView GetImageView() { return vkTex_->GetImageView(); }
 
 private:
+	void SetImageData(int x, int y, int z, int width, int height, int depth, int level, int stride, const uint8_t *data);
+
 	bool Create(const TextureDesc &desc) {
 		format_ = desc.format;
 		mipLevels_ = desc.mipLevels;


### PR DESCRIPTION
The Shield doesn't support GL_OES_texture_npot, and we accidentally left texture wrapping enabled, so it considered the textures incomplete and drew them black.