### PR TITLE
Allow background joystick input on SDL

### DIFF
--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -14,8 +14,8 @@ static int SDLJoystickEventHandlerWrapper(void* userdata, SDL_Event* event)
 }
 
 SDLJoystick::SDLJoystick(bool init_SDL ) : registeredAsEventHandler(false) {
+	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 	if (init_SDL) {
-		SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 		SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
 	}
 	


### PR DESCRIPTION
`init_SDL` seem to be false when building PPSSPPSDL.

Motivation: https://github.com/hrydgard/ppsspp/pull/1566#issuecomment-17131688

Currently, the workaround is using environment variable when running ppsspp: `SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS=1`

Note: This new behavior can be disable using environment variable:
`SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS=0`