### PR TITLE
Recreate all view on resize

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -992,6 +992,7 @@ void NativeMessageReceived(const char *message, const char *value) {
 
 void NativeResized() {
 	resized = true;
+	screenManager->RecreateAllViews();
 
 	if (uiContext) {
 		// Modifying the bounds here can be used to "inset" the whole image to gain borders for TV overscan etc.


### PR DESCRIPTION
Fixes #9340

Not quite sure about performance but the NativeResized shouldn't be call during normal play.

Should it be moved inside `if (uiContext) {`?