### PR TITLE
D3D11 postprocessing shaders

### DIFF
--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -58,6 +58,15 @@ void ShaderTranslationShutdown() {
 	glslang::FinalizeProcess();
 }
 
+std::string Preprocess(std::string code, ShaderLanguage lang) {
+	// This takes GL up to the version we need.
+	return code;
+}
+
+std::string Postprocess(std::string code, ShaderLanguage lang) {
+	return code;
+}
+
 bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShaderMetadata *destMetadata, std::string src, ShaderLanguage srcLang, Draw::ShaderStage stage, std::string *errorMessage) {
 	if (srcLang != GLSL_300 && srcLang != GLSL_140)
 		return false;
@@ -73,6 +82,8 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShade
 
 	EShLanguage shaderStage = GetLanguage(stage);
 	glslang::TShader shader(shaderStage);
+
+	std::string preprocessed = Preprocess(src, srcLang);
 
 	shaderStrings[0] = src.c_str();
 	shader.setStrings(shaderStrings, 1);
@@ -134,7 +145,8 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShade
 		options.fixup_clipspace = true;
 		options.shader_model = 50;
 		hlsl.set_options(options);
-		*dest = hlsl.compile();
+		std::string raw = hlsl.compile();
+		*dest = Postprocess(raw, destLang);
 		return true;
 	}
 #endif

--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -113,6 +113,7 @@ static const Builtin builtins[] = {
 
 static const Builtin replacements[] = {
 	{ "mix(", "lerp(" },
+	{ "fract(", "frac(" },
 };
 
 static const char *cbufferDecl = R"(

--- a/GPU/Common/ShaderTranslation.h
+++ b/GPU/Common/ShaderTranslation.h
@@ -27,6 +27,9 @@ struct TranslatedShaderMetadata {
 
 };
 
+void ShaderTranslationInit();
+void ShaderTranslationShutdown();
+
 bool TranslateShader(std::string *dst, ShaderLanguage destLang, TranslatedShaderMetadata *destMetadata, std::string src, ShaderLanguage srcLang, Draw::ShaderStage stage, std::string *errorMessage);
 
 #endif

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -26,7 +26,6 @@ static std::vector<uint8_t> CompileShaderToBytecode(const char *code, size_t cod
 		compiledCode->Release();
 		return compiled;
 	}
-	Crash();
 	return std::vector<uint8_t>();
 }
 

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -9,10 +9,10 @@
 
 #include "D3D11Util.h"
 
-static std::vector<uint8_t> CompileShaderToBytecode(const char *code, size_t codeSize, const char *target) {
+static std::vector<uint8_t> CompileShaderToBytecode(const char *code, size_t codeSize, const char *target, UINT flags) {
 	ID3DBlob *compiledCode = nullptr;
 	ID3DBlob *errorMsgs = nullptr;
-	HRESULT result = ptr_D3DCompile(code, codeSize, nullptr, nullptr, nullptr, "main", target, 0, 0, &compiledCode, &errorMsgs);
+	HRESULT result = ptr_D3DCompile(code, codeSize, nullptr, nullptr, nullptr, "main", target, flags, 0, &compiledCode, &errorMsgs);
 	std::string errors;
 	if (errorMsgs) {
 		errors = std::string((const char *)errorMsgs->GetBufferPointer(), errorMsgs->GetBufferSize());
@@ -30,8 +30,8 @@ static std::vector<uint8_t> CompileShaderToBytecode(const char *code, size_t cod
 	return std::vector<uint8_t>();
 }
 
-ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, std::vector<uint8_t> *byteCodeOut) {
-	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "vs_5_0");
+ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, std::vector<uint8_t> *byteCodeOut, UINT flags) {
+	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "vs_5_0", flags);
 	if (byteCode.empty())
 		return nullptr;
 
@@ -42,8 +42,8 @@ ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *co
 	return vs;
 }
 
-ID3D11PixelShader *CreatePixelShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize) {
-	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "ps_5_0");
+ID3D11PixelShader *CreatePixelShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags) {
+	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "ps_5_0", flags);
 	if (byteCode.empty())
 		return nullptr;
 
@@ -52,8 +52,8 @@ ID3D11PixelShader *CreatePixelShaderD3D11(ID3D11Device *device, const char *code
 	return ps;
 }
 
-ID3D11ComputeShader *CreateComputeShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize) {
-	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "cs_5_0");
+ID3D11ComputeShader *CreateComputeShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags) {
+	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "cs_5_0", flags);
 	if (byteCode.empty())
 		return nullptr;
 
@@ -61,6 +61,17 @@ ID3D11ComputeShader *CreateComputeShaderD3D11(ID3D11Device *device, const char *
 	device->CreateComputeShader(byteCode.data(), byteCode.size(), nullptr, &cs);
 	return cs;
 }
+
+ID3D11GeometryShader *CreateGeometryShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags) {
+	std::vector<uint8_t> byteCode = CompileShaderToBytecode(code, codeSize, "gs_5_0", flags);
+	if (byteCode.empty())
+		return nullptr;
+
+	ID3D11GeometryShader *gs;
+	device->CreateGeometryShader(byteCode.data(), byteCode.size(), nullptr, &gs);
+	return gs;
+}
+
 
 void StockObjectsD3D11::Create(ID3D11Device *device) {
 	D3D11_BLEND_DESC blend_desc{};

--- a/GPU/D3D11/D3D11Util.h
+++ b/GPU/D3D11/D3D11Util.h
@@ -64,9 +64,10 @@ private:
 	bool nextMapDiscard_ = false;
 };
 
-ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, std::vector<uint8_t> *byteCodeOut);
-ID3D11PixelShader *CreatePixelShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize);
-ID3D11ComputeShader *CreateComputeShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize);
+ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, std::vector<uint8_t> *byteCodeOut, UINT flags = 0);
+ID3D11PixelShader *CreatePixelShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags = 0);
+ID3D11ComputeShader *CreateComputeShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags = 0);
+ID3D11GeometryShader *CreateGeometryShaderD3D11(ID3D11Device *device, const char *code, size_t codeSize, UINT flags = 0);
 
 class StockObjectsD3D11 {
 public:

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -147,6 +147,7 @@ private:
 	ID3D11PixelShader *postPixelShader_ = nullptr;
 	ID3D11InputLayout *postInputLayout_ = nullptr;
 	ID3D11Buffer *postConstants_ = nullptr;
+	static const D3D11_INPUT_ELEMENT_DESC g_PostVertexElements[2];
 
 	// Used by post-processing shader
 	std::vector<Draw::Framebuffer *> extraFBOs_;

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -94,6 +94,7 @@ protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
+	void CompilePostShader();
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void Bind2DShader() override;
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height) override;
@@ -136,9 +137,16 @@ private:
 	ShaderManagerD3D11 *shaderManagerD3D11_;
 	DrawEngineD3D11 *drawEngine_;
 
-	// 1:1 Readback texture, 512x512 fixed
+	// Permanent 1:1 readback texture, 512x512 fixed
 	// For larger debug readbacks, we create/destroy textures on the fly.
 	ID3D11Texture2D *packTexture_;
+
+	// Used by post-processing shader
+	// Postprocessing
+	ID3D11VertexShader *postVertexShader_ = nullptr;
+	ID3D11PixelShader *postPixelShader_ = nullptr;
+	ID3D11InputLayout *postInputLayout_ = nullptr;
+	ID3D11Buffer *postConstants_ = nullptr;
 
 	// Used by post-processing shader
 	std::vector<Draw::Framebuffer *> extraFBOs_;

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -112,6 +112,7 @@ private:
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void CompileDraw2DProgram();
 	void DestroyDraw2DProgram();
+	void CompilePostShader();
 
 	void PackFramebufferAsync_(VirtualFramebuffer *vfb);  // Not used under ES currently
 	void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -977,7 +977,6 @@ namespace MainWindow {
 				g_Config.sPostShaderName = availableShaders[index];
 
 				NativeMessageReceived("gpu resized", "");
-
 				break;
 			}
 

--- a/ext/SPIRV-Cross.vcxproj
+++ b/ext/SPIRV-Cross.vcxproj
@@ -36,7 +36,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140_xp</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -49,7 +48,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140_xp</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
As our post shaders are written in GLSL, we use glslang + SPIRV-Cross to translate them to SPIR-V and then to HLSL. This works, though there is some kind of filtering or precision issue with the 5X postshader. Oh well, at least it mostly works, worth merging.

This is the last missing feature in #9317, just needs some more debugging...