### PR TITLE
Minor workaround for 5xBR

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -975,7 +975,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			// flip V.
 			if (needBackBufferYSwap_)
 				std::swap(v0, v1);
-			bool linearFilter = g_Config.iBufFilter == SCALE_LINEAR;
+			bool linearFilter = !postShaderIsUpscalingFilter_ && g_Config.iBufFilter == SCALE_LINEAR;
 
 			shaderManager_->DirtyLastShader();  // dirty lastShader_ BEFORE drawing
 			PostShaderUniforms uniforms{};

--- a/assets/shaders/5xBR.vsh
+++ b/assets/shaders/5xBR.vsh
@@ -23,6 +23,6 @@ attribute vec2 a_texcoord0;
 varying vec2 v_texcoord0;
 
 void main() {
-	v_texcoord0 = a_texcoord0;
+	v_texcoord0 = a_texcoord0 + 0.000001; //precision workaround for HLSL translation
 	gl_Position = a_position;
 }


### PR DESCRIPTION
Also screen scaling filter for upscaling filters that also happen to use postShaderAtOutputResolution_. ~ Comment around there is kind of confusing like it wasn't buffered rendering, but it still is.