### PR TITLE
Texture Replacement: allow clut hash only variant.

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -411,9 +411,17 @@ std::string TextureReplacer::LookupHashFile(u64 cachekey, u32 hash, int level) {
 	auto alias = aliases_.find(key);
 	if (alias == aliases_.end()) {
 		// Also check for a few more aliases with zeroed portions:
-		// No data hash.
+		// Only clut hash (very dangerous in theory, in practice not more than missing "just" data hash)
+		key.cachekey = cachekey & 0xFFFFFFFFULL;
 		key.hash = 0;
 		alias = aliases_.find(key);
+
+		if (alias == aliases_.end()) {
+			// No data hash.
+			key.cachekey = cachekey;
+			key.hash = 0;
+			alias = aliases_.find(key);
+		}
 
 		if (alias == aliases_.end()) {
 			// No address.


### PR DESCRIPTION
 I had a bit of mixed feelings about supporting that scary feature, so I looked around my textures folders and actually, clut hash seems to be very unique often the only unique part for the otherwise very troublesome or impossible to replace textures of some 2D games or ui elements in 3D ones.

 So while this is kind of dangerous to support, it really isn't more dangerous than identifying textures without data hash since address is the most unreliable part. Maybe we should just assume that this feature already requires a lot of manual work and is used only by people who can spend enough time to read about it and test stuff before releasing any texture packs to the public.


Fixes #9316
^ althrough would be nice if @AkagiShiroe would actually test this with his case.