### PR TITLE
Add PostShader option to force 60fps for animated effects

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -631,7 +631,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	// Also let's always flip for animated shaders
 	const ShaderInfo *shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
 	bool postEffectRequiresFlip = false;
-	if (shaderInfo)
+	if (shaderInfo && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE)
 		postEffectRequiresFlip = g_Config.sPostShaderName != "Off" && shaderInfo->requires60fps;
 	const bool fbDirty = gpu->FramebufferDirty();
 	if (fbDirty || noRecentFlip || postEffectRequiresFlip) {

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -52,6 +52,7 @@
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/Common/FramebufferCommon.h"
+#include "GPU/Common/PostShader.h"
 
 struct FrameBufferState {
 	u32 topaddr;
@@ -627,8 +628,13 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	// some work.
 	// But, let's flip at least once every 10 vblanks, to update fps, etc.
 	const bool noRecentFlip = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && numVBlanksSinceFlip >= 10;
+	// Also let's always flip for animated shaders
+	const ShaderInfo *shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
+	bool postEffectRequiresFlip = false;
+	if (shaderInfo)
+		postEffectRequiresFlip = g_Config.sPostShaderName != "Off" && shaderInfo->requires60fps;
 	const bool fbDirty = gpu->FramebufferDirty();
-	if (fbDirty || noRecentFlip) {
+	if (fbDirty || noRecentFlip || postEffectRequiresFlip) {
 		if (g_Config.iShowFPSCounter && g_Config.iShowFPSCounter < 4) {
 			CalculateFPS();
 		}
@@ -636,7 +642,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 		// Setting CORE_NEXTFRAME causes a swap.
 		// Check first though, might've just quit / been paused.
 		const bool fbReallyDirty = gpu->FramebufferReallyDirty();
-		if (fbReallyDirty || noRecentFlip) {
+		if (fbReallyDirty || noRecentFlip || postEffectRequiresFlip) {
 			if (coreState == CORE_RUNNING) {
 				coreState = CORE_NEXTFRAME;
 				gpu->CopyDisplayToOutput();

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -42,6 +42,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 	off.section = "Off";
 	off.outputResolution = false;
 	off.isUpscalingFilter = false;
+	off.requires60fps = false;
 	shaderInfo.push_back(off);
 
 	for (size_t d = 0; d < directories.size(); d++) {
@@ -86,6 +87,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 					info.vertexShaderFile = path + "/" + temp;
 					section.Get("OutputResolution", &info.outputResolution, false);
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
+					section.Get("60fps", &info.requires60fps, false);
 
 					// Let's ignore shaders we can't support. TODO: Not a very good check
 					if (gl_extensions.IsGLES && !gl_extensions.GLES3) {

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -36,6 +36,8 @@ struct ShaderInfo {
 	bool outputResolution;
 	// Use x1 rendering res + nearest screen scaling filter
 	bool isUpscalingFilter;
+	// Force constant/max refresh for animated filters
+	bool requires60fps;
 
 	// TODO: Add support for all kinds of fun options like mapping the depth buffer,
 	// SRGB texture reads, multiple shaders chained, etc.

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -9,6 +9,7 @@ Name=CRT Scanlines
 Author=KillaMaaki
 Fragment=crt.fsh
 Vertex=fxaa.vsh
+60fps=True
 [Natural]
 Name=Natural Colors
 Fragment=natural.fsh


### PR DESCRIPTION
 Option that will make animated post process effects consistent in games with variable fps or when it drops to 0 like during boot, loading screens or that PSPKVM homebrew etc., was requested on forums some time ago as well.

 Not sure if that's best way to do it, but works fine for post process animation without affecting fps counter.