### PR TITLE
Fixed some bugs in spline/bezier.

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -407,7 +407,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 			float bnrm[3], bpos[3];
 
 			if (vertType & GE_VTYPE_NRM_MASK) {
-				// Normals are generated during tesselation anyway, not sure if any need to supply
+				// Normals are generated during tessellation anyway, not sure if any need to supply
 				reader.ReadNrm(nrm);
 			} else {
 				nrm[0] = 0;
@@ -443,7 +443,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 			if (vertType & GE_VTYPE_TC_MASK) {
 				reader.ReadUV(sv.uv);
 			} else {
-				sv.uv[0] = 0.0f;  // This will get filled in during tesselation
+				sv.uv[0] = 0.0f;  // This will get filled in during tessellation
 				sv.uv[1] = 0.0f;
 			}
 			if (vertType & GE_VTYPE_COL_MASK) {
@@ -452,7 +452,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 				memcpy(sv.color, defaultColor, 4);
 			}
 			if (vertType & GE_VTYPE_NRM_MASK) {
-				// Normals are generated during tesselation anyway, not sure if any need to supply
+				// Normals are generated during tessellation anyway, not sure if any need to supply
 				reader.ReadNrm((float *)&sv.nrm);
 			} else {
 				sv.nrm.x = 0.0f;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -32,7 +32,7 @@ enum {
 	VERTEX_BUFFER_MAX = 65536,
 	DECODED_VERTEX_BUFFER_SIZE = VERTEX_BUFFER_MAX * 64,
 	DECODED_INDEX_BUFFER_SIZE = VERTEX_BUFFER_MAX * 16,
-	SPLINE_BUFFER_SIZE = VERTEX_BUFFER_MAX * 20,
+	SPLINE_BUFFER_SIZE = VERTEX_BUFFER_MAX * 26, // At least, this buffer needs greater than 1679616 bytes for Mist Dragon morphing in FF4CC.
 };
 
 class DrawEngineCommon {

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -65,5 +65,5 @@ enum SplineQuality {
 	HIGH_QUALITY = 2,
 };
 
-void TesselateSplinePatch(u8 *&dest, u16 *indices, int &count, const SplinePatchLocal &spatch, u32 origVertType, int maxVertices);
-void TesselateBezierPatch(u8 *&dest, u16 *&indices, int &count, int tess_u, int tess_v, const BezierPatch &patch, u32 origVertType, int maxVertices);
+void TessellateSplinePatch(u8 *&dest, u16 *indices, int &count, const SplinePatchLocal &spatch, u32 origVertType, int maxVertices);
+void TessellateBezierPatch(u8 *&dest, u16 *&indices, int &count, int tess_u, int tess_v, const BezierPatch &patch, u32 origVertType, int maxVertices);


### PR DESCRIPTION
Fixed crashes with Mist Dragon morphing in FF4CC.

I think "tesselate" is not typo but it's a bit minor in "programming language". Because Khronos, Microsoft and NVIDIA etc... uses "tessellate".