### PR TITLE
Render small window fonts at double resolution

### DIFF
--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -66,6 +66,7 @@ public:
 	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align);
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame();
+	float CalculateDPIScale();
 
 private:
 	Draw::DrawContext *draw_;
@@ -77,7 +78,7 @@ private:
 	int frameCount_;
 	float fontScaleX_;
 	float fontScaleY_;
-	float last_dpi_scale_;
+	float dpiScale_;
 
 	TextDrawerContext *ctx_;
 #if defined(USING_QT_UI)


### PR DESCRIPTION
Otherwise, they become blurry at half-pixel offsets (such as when a settings pop up with width 550 = 275 real pixels is centered.)

#9218 / #9216 caused the DPI to apply to the rendered font size, which is good, but also reduced the size of fonts in small window mode.  This simply restores the previous behavior for small window only.

-[Unknown]