### PR TITLE
Detect when the game is running slow, and warn

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -384,6 +384,7 @@ static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
+	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, true, true),
 
 	ConfigSetting(false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -131,6 +131,7 @@ public:
 	bool bCheckForNewVersion;
 	bool bForceLagSync;
 	bool bFuncReplacements;
+	bool bHideSlowWarnings;
 
 	// Definitely cannot be changed while game is running.
 	bool bSeparateCPUThread;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -662,7 +662,7 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 		// Let the user know if we're running slow, so they know to adjust settings.
 		// Sometimes users just think the sound emulation is broken.
 		static bool hasNotifiedSlow = false;
-		if (!hasNotifiedSlow && IsRunningSlow()) {
+		if (!g_Config.bHideSlowWarnings && !hasNotifiedSlow && IsRunningSlow()) {
 			I18NCategory *err = GetI18NCategory("Error");
 			host->NotifyUserMessage(err->T("Running slow: try frameskip, sound is choppy when slow"), 6.0f, 0xFF3030FF);
 			hasNotifiedSlow = true;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -360,13 +360,10 @@ namespace Reporting
 		// Just to get an idea of how long they played.
 		postdata.Add("ticks", (const uint64_t)CoreTiming::GetTicks());
 
-		if (g_Config.iShowFPSCounter && g_Config.iShowFPSCounter < 4)
-		{
-			float vps, fps;
-			__DisplayGetAveragedFPS(&vps, &fps);
-			postdata.Add("vps", vps);
-			postdata.Add("fps", fps);
-		}
+		float vps, fps;
+		__DisplayGetAveragedFPS(&vps, &fps);
+		postdata.Add("vps", vps);
+		postdata.Add("fps", fps);
 
 		postdata.Add("savestate_used", SaveState::HasLoadedState());
 	}

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -582,7 +582,9 @@ VSShader *ShaderManagerDX9::ApplyShader(int prim, u32 vertType) {
 		if (vs->Failed()) {
 			I18NCategory *gr = GetI18NCategory("Graphics");
 			ERROR_LOG(G3D, "Shader compilation failed, falling back to software transform");
-			host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
+			if (!g_Config.bHideSlowWarnings) {
+				host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
+			}
 			delete vs;
 
 			ComputeVertexShaderID(&VSID, vertType, false);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -847,7 +847,9 @@ Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, ShaderID *V
 		if (vs->Failed()) {
 			I18NCategory *gr = GetI18NCategory("Graphics");
 			ERROR_LOG(G3D, "Shader compilation failed, falling back to software transform");
-			host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
+			if (!g_Config.bHideSlowWarnings) {
+				host->NotifyUserMessage(gr->T("hardware transform error - falling back to software"), 2.5f, 0xFF3030FF);
+			}
 			delete vs;
 
 			// TODO: Look for existing shader with the appropriate ID, use that instead of generating a new one - however, need to make sure


### PR DESCRIPTION
Many users assume that sound emulation is broken, and don't realize they may need to tweak their settings - we don't even show the FPS counter by default.

I added a hidden ini setting for people who like choppy gameplay, but couldn't think of a compelling reason to add it to the UI.  But would be easy to, of course, if anyone else has a good reason for the new UI setting.

-[Unknown]