### PR TITLE
GLES:Remove texture_half_float extension.

### DIFF
--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -606,7 +606,7 @@ void GPU_GLES::CheckGPUFeatures() {
 	if (maxVertexTextureImageUnits >= 3) // At least 3 for hardware tessellation
 		features |= GPU_SUPPORTS_VERTEX_TEXTURE_FETCH;
 
-	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float || gl_extensions.OES_texture_half_float)
+	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float)
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
 	// If we already have a 16-bit depth buffer, we don't need to round.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -93,7 +93,7 @@ bool CheckSupportInstancedTessellationGLES() {
 	bool vertexTexture = maxVertexTextureImageUnits >= 3; // At least 3 for hardware tessellation
 	bool instanceRendering = gl_extensions.GLES3 || gl_extensions.EXT_gpu_shader4
 		|| (!gl_extensions.IsGLES && gl_extensions.VersionGEThan(3, 1)/*GLSL 1.4*/);
-	bool textureFloat = gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float || gl_extensions.OES_texture_half_float;
+	bool textureFloat = gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float;
 
 	return instanceRendering && vertexTexture && textureFloat;
 #endif

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -291,7 +291,6 @@ void CheckGLExtensions() {
 		gl_extensions.NV_shader_framebuffer_fetch = strstr(extString, "GL_NV_shader_framebuffer_fetch") != 0;
 		gl_extensions.ARM_shader_framebuffer_fetch = strstr(extString, "GL_ARM_shader_framebuffer_fetch") != 0;
 		gl_extensions.OES_texture_float = strstr(extString, "GL_OES_texture_float") != 0;
-		gl_extensions.OES_texture_half_float = strstr(extString, "GL_OES_texture_half_float") != 0;
 
 #if defined(__ANDROID__)
 		// On Android, incredibly, this is not consistently non-zero! It does seem to have the same value though.

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -48,7 +48,6 @@ struct GLExtensions {
 	bool OES_vertex_array_object;
 	bool OES_copy_image;
 	bool OES_texture_float;
-	bool OES_texture_half_float;
 
 	// ARB
 	bool ARB_framebuffer_object;


### PR DESCRIPTION
Yes, I'm not using half-float currently. I was thinking it may need for mobile. But I don't know it actually needs or not for now. So I will reimplement when needed.