### PR TITLE
Correct GE debugger font size in small window mode

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -166,6 +166,8 @@ bool UpdateScreenScale(int width, int height) {
 	g_dpi = 96;
 	g_dpi_scale = 1.0f;
 #endif
+	g_dpi_scale_real = g_dpi_scale;
+
 	smallWindow = IsWindowSmall(width, height);
 	if (smallWindow) {
 		g_dpi /= 2;

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -45,8 +45,10 @@ CtrlDisplayListView::CtrlDisplayListView(HWND _wnd)
 	
 	instructionSize = 4;
 
-	int fontHeight = g_Config.iFontHeight / g_dpi_scale;
-	int charWidth = g_Config.iFontWidth / g_dpi_scale;
+	// In small window mode, g_dpi_scal may have been adjusted.
+	const float fontScale = 1.0f / g_dpi_scale_real;
+	int fontHeight = g_Config.iFontHeight * fontScale;
+	int charWidth = g_Config.iFontWidth * fontScale;
 
 	rowHeight = fontHeight +2;
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -636,6 +636,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jo
 	/*
 	g_dpi = dpi;
 	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi_scale_real = g_dpi_scale;
 
 	pixel_xres = w;
 	pixel_yres = h;
@@ -652,6 +653,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jo
 
 	g_dpi = (int)display_dpi;
 	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi_scale_real = g_dpi_scale;
 
 	dp_xres = display_xres * g_dpi_scale;
 	dp_yres = display_yres * g_dpi_scale;
@@ -968,6 +970,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 
 	g_dpi = (int)display_dpi;
 	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi_scale_real = g_dpi_scale;
 
 	dp_xres = display_xres * g_dpi_scale;
 	dp_yres = display_yres * g_dpi_scale;

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -636,6 +636,7 @@ int main(int argc, char *argv[]) {
 
 	pixel_in_dps = (float)pixel_xres / dp_xres;
 	g_dpi_scale = dp_xres / (float)pixel_xres;
+	g_dpi_scale_real = g_dpi_scale;
 
 	printf("Pixels: %i x %i\n", pixel_xres, pixel_yres);
 	printf("Virtual pixels: %i x %i\n", dp_xres, dp_yres);

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -442,6 +442,7 @@ int main(int argc, char *argv[])
 	pixel_xres = res.width();
 	pixel_yres = res.height();
 	g_dpi_scale = CalculateDPIScale();
+	g_dpi_scale_real = g_dpi_scale;
 	dp_xres = (int)(pixel_xres * g_dpi_scale); dp_yres = (int)(pixel_yres * g_dpi_scale);
 	std::string savegame_dir = ".";
 	std::string assets_dir = ".";

--- a/ext/native/base/display.cpp
+++ b/ext/native/base/display.cpp
@@ -8,6 +8,7 @@ int pixel_yres;
 
 int g_dpi = 1;  // will be overwritten
 float g_dpi_scale = 1.0f;
+float g_dpi_scale_real = 1.0f;
 float pixel_in_dps = 1.0f;
 float display_hz = 60.0f;
 

--- a/ext/native/base/display.h
+++ b/ext/native/base/display.h
@@ -12,6 +12,7 @@ extern int pixel_yres;
 
 extern int g_dpi;
 extern float g_dpi_scale;
+extern float g_dpi_scale_real;
 extern float pixel_in_dps;
 extern float display_hz;
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -177,6 +177,7 @@ static GraphicsContext *graphicsContext;
 
 	g_dpi = (IS_IPAD() ? 200 : 150) * scale;
 	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi_scale_real = g_dpi_scale;
 	pixel_xres = size.width * scale;
 	pixel_yres = size.height * scale;
 


### PR DESCRIPTION
This should handle high and low DPI cases correctly, to avoid making the text unreadably small.

05bdf8a didn't account for small-window mode.  I almost just capped the scale, but then if you had a 1x window (though that'd be unusual) on a 4K screen, you'd still get tiny text.

-[Unknown]