### PR TITLE
Dispatcher core state fix

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -663,8 +663,10 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 		// Sometimes users just think the sound emulation is broken.
 		static bool hasNotifiedSlow = false;
 		if (!g_Config.bHideSlowWarnings && !hasNotifiedSlow && IsRunningSlow()) {
+#ifndef _DEBUG
 			I18NCategory *err = GetI18NCategory("Error");
 			host->NotifyUserMessage(err->T("Running slow: try frameskip, sound is choppy when slow"), 6.0f, 0xFF3030FF);
+#endif
 			hasNotifiedSlow = true;
 		}
 

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -177,13 +177,15 @@ void ArmJit::GenerateFixedCode() {
 		QuickCallFunction(R0, &CoreTiming::Advance);
 		ApplyRoundingMode(true);
 		RestoreDowncount();
-		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
+		FixupBranch skipToCoreStateCheck = B(); //skip the downcount check
 
 		dispatcherCheckCoreState = GetCodePtr();
 
 		// The result of slice decrementation should be in flags if somebody jumped here
 		// IMPORTANT - We jump on negative, not carry!!!
 		FixupBranch bailCoreState = B_CC(CC_MI);
+
+		SetJumpTarget(skipToCoreStateCheck);
 
 		MOVI2R(R0, (u32)(uintptr_t)&coreState);
 		LDR(R0, R0);
@@ -202,7 +204,6 @@ void ArmJit::GenerateFixedCode() {
 			// IMPORTANT - We jump on negative, not carry!!!
 			FixupBranch bail = B_CC(CC_MI);
 
-			SetJumpTarget(skipToRealDispatch);
 			SetJumpTarget(skipToRealDispatch2);
 
 			dispatcherNoCheck = GetCodePtr();

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -217,13 +217,15 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 		QuickCallFunction(SCRATCH1_64, &CoreTiming::Advance);
 		ApplyRoundingMode(true);
 		LoadStaticRegisters();
-		FixupBranch skipToRealDispatch = B(); //skip the sync and compare first time
+		FixupBranch skipToCoreStateCheck = B();  //skip the downcount check
 
 		dispatcherCheckCoreState = GetCodePtr();
 
 		// The result of slice decrementation should be in flags if somebody jumped here
 		// IMPORTANT - We jump on negative, not carry!!!
 		FixupBranch bailCoreState = B(CC_MI);
+
+		SetJumpTarget(skipToCoreStateCheck);
 
 		MOVP2R(SCRATCH1_64, &coreState);
 		LDR(INDEX_UNSIGNED, SCRATCH1, SCRATCH1_64, 0);
@@ -242,7 +244,6 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 			// IMPORTANT - We jump on negative, not carry!!!
 			FixupBranch bail = B(CC_MI);
 
-			SetJumpTarget(skipToRealDispatch);
 			SetJumpTarget(skipToRealDispatch2);
 
 			dispatcherNoCheck = GetCodePtr();

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -144,7 +144,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 		RestoreRoundingMode(true);
 		ABI_CallFunction(reinterpret_cast<void *>(&CoreTiming::Advance));
 		ApplyRoundingMode(true);
-		FixupBranch skipToRealDispatch = J(); //skip the sync and compare first time
+		FixupBranch skipToCoreStateCheck = J();  //skip the downcount check
 
 		dispatcherCheckCoreState = GetCodePtr();
 
@@ -152,6 +152,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 		// IMPORTANT - We jump on negative, not carry!!!
 		FixupBranch bailCoreState = J_CC(CC_S, true);
 
+		SetJumpTarget(skipToCoreStateCheck);
 		CMP(32, M(&coreState), Imm32(0));
 		FixupBranch badCoreState = J_CC(CC_NZ, true);
 		FixupBranch skipToRealDispatch2 = J(); //skip the sync and compare first time
@@ -162,7 +163,6 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 			// IMPORTANT - We jump on negative, not carry!!!
 			FixupBranch bail = J_CC(CC_S, true);
 
-			SetJumpTarget(skipToRealDispatch);
 			SetJumpTarget(skipToRealDispatch2);
 
 			dispatcherNoCheck = GetCodePtr();


### PR DESCRIPTION
Fix bug where dispatcher would not check core state directly after Advance.

Fixes #9398 properly (it was previously hidden somehow with extra backbuffer binds)