### PR TITLE
Add a "START+SELECT+L+R" combo to trigger the PPSSPP menu

### DIFF
--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <string>
+#include <algorithm>
 
 using namespace std;
 
@@ -138,6 +139,10 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 				key.flags = KEY_DOWN;
 				key.keyCode = code;
 				key.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.cbutton.which);
+				keysPressedCombo.push_back(code);
+				if ( checkGuideCombo() ) {
+					key.keyCode = NKCODE_BACK;
+				}
 				NativeKey(key);
 			}
 		}
@@ -150,6 +155,7 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 				key.flags = KEY_UP;
 				key.keyCode = code;
 				key.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.cbutton.which);
+				keysPressedCombo.erase(std::remove(keysPressedCombo.begin(), keysPressedCombo.end(), code), keysPressedCombo.end());
 				NativeKey(key);
 			}
 		}
@@ -193,4 +199,15 @@ int SDLJoystick::getDeviceIndex(int instanceId) {
 			return -1;
 	}
 	return it->second;
+}
+
+bool SDLJoystick::checkGuideCombo() {
+	if (  std::find(keysPressedCombo.begin(), keysPressedCombo.end(), NKCODE_BUTTON_5) != keysPressedCombo.end() &&
+	      std::find(keysPressedCombo.begin(), keysPressedCombo.end(), NKCODE_BUTTON_6) != keysPressedCombo.end() &&
+	      std::find(keysPressedCombo.begin(), keysPressedCombo.end(), NKCODE_BUTTON_9) != keysPressedCombo.end() &&
+	      std::find(keysPressedCombo.begin(), keysPressedCombo.end(), NKCODE_BUTTON_10) != keysPressedCombo.end() ) {
+		// Found the magic combo L + R + Start + Select
+		return true;
+	}
+	return false;
 }

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -28,4 +28,6 @@ private:
 	bool registeredAsEventHandler;
 	std::vector<SDL_GameController *> controllers;
 	std::map<int, int> controllerDeviceMap;
+	std::vector<keycode_t> keysPressedCombo;
+	bool checkGuideCombo();
 };


### PR DESCRIPTION
Sadly all pads don't have a Guide/PS/Home button that can be mapped to the PPSSPP Menu. sing the gamecontrollersdb.txt made it even more difficult to map such a key. This PR adds a START + SELECT + L + R combo to trigger the PPSSPP menu.