### PR TITLE
Remove legacy InputState tracking

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -23,7 +23,6 @@
 #include "base/NativeApp.h"
 #include "base/display.h"
 #include "base/timeutil.h"
-#include "input/input_state.h"
 #include "thread/threadutil.h"
 #include "profiler/profiler.h"
 
@@ -191,25 +190,25 @@ bool UpdateScreenScale(int width, int height) {
 	return false;
 }
 
-void UpdateRunLoop(InputState *input_state) {
+void UpdateRunLoop() {
 	if (windowHidden && g_Config.bPauseWhenMinimized) {
 		sleep_ms(16);
 		return;
 	}
-	NativeUpdate(*input_state);
+	NativeUpdate();
 
 	if (GetUIState() != UISTATE_EXIT) {
 		NativeRender(graphicsContext);
 	}
 }
 
-void Core_RunLoop(GraphicsContext *ctx, InputState *input_state) {
+void Core_RunLoop(GraphicsContext *ctx) {
 	graphicsContext = ctx;
 	while ((GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT) {
 		time_update();
 #if defined(USING_WIN_UI)
 		double startTime = time_now_d();
-		UpdateRunLoop(input_state);
+		UpdateRunLoop();
 
 		// Simple throttling to not burn the GPU in the menu.
 		time_update();
@@ -221,13 +220,13 @@ void Core_RunLoop(GraphicsContext *ctx, InputState *input_state) {
 			ctx->SwapBuffers();
 		}
 #else
-		UpdateRunLoop(input_state);
+		UpdateRunLoop();
 #endif
 	}
 
 	while (!coreState && GetUIState() == UISTATE_INGAME) {
 		time_update();
-		UpdateRunLoop(input_state);
+		UpdateRunLoop();
 #if defined(USING_WIN_UI)
 		if (!windowHidden && !Core_IsStepping()) {
 			ctx->SwapBuffers();
@@ -268,7 +267,7 @@ static inline void CoreStateProcessed() {
 }
 
 // Some platforms, like Android, do not call this function but handle things on their own.
-void Core_Run(GraphicsContext *ctx, InputState *input_state)
+void Core_Run(GraphicsContext *ctx)
 {
 #if defined(_DEBUG)
 	host->UpdateDisassembly();
@@ -283,7 +282,7 @@ reswitch:
 			if (GetUIState() == UISTATE_EXIT) {
 				return;
 			}
-			Core_RunLoop(ctx, input_state);
+			Core_RunLoop(ctx);
 #if defined(USING_QT_UI) && !defined(MOBILE_DEVICE)
 			return;
 #else
@@ -295,7 +294,7 @@ reswitch:
 		{
 		case CORE_RUNNING:
 			// enter a fast runloop
-			Core_RunLoop(ctx, input_state);
+			Core_RunLoop(ctx);
 			break;
 
 		// We should never get here on Android.

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -21,11 +21,10 @@
 #include "Core/CoreParameter.h"
 
 class GraphicsContext;
-struct InputState;
 
 // called from emu thread
-void UpdateRunLoop(InputState *input_state);
-void Core_Run(GraphicsContext *ctx, InputState *input_state);
+void UpdateRunLoop();
+void Core_Run(GraphicsContext *ctx);
 void Core_Stop();
 void Core_ErrorPause();
 // For platforms that don't call Core_Run

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -20,7 +20,6 @@
 #include <string>
 #include "Common/CommonTypes.h"
 
-struct InputState;
 class GraphicsContext;
 
 // TODO: Whittle this down. Collecting a bunch of random stuff like this isn't good design :P
@@ -41,7 +40,7 @@ public:
 	virtual void UpdateSound() {}
 	virtual void GoFullscreen(bool) {}
 	virtual void ShutdownSound() = 0;
-	virtual void PollControllers(InputState &input_state) {}
+	virtual void PollControllers() {}
 	virtual void ToggleDebugConsoleVisibility() {}
 
 	//this is sent from EMU thread! Make sure that Host handles it properly!

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -146,7 +146,6 @@ private:
 	QString currentLanguage;
 
 	CoreState nextState;
-	InputState input_state;
 	GlobalUIState lastUIState;
 
 	Debugger_Disasm *dialogDisasm;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -41,7 +41,7 @@ class ControlMapper : public UI::LinearLayout {
 public:
 	ControlMapper(ControlMappingScreen *ctrlScreen, int pspKey, std::string keyName, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams = 0);
 
-	virtual void Update(const InputState &input);
+	void Update() override;
 	int GetPspKey() const { return pspKey_; }
 private:
 	void Refresh();
@@ -74,7 +74,7 @@ ControlMapper::ControlMapper(ControlMappingScreen *ctrlScreen, int pspKey, std::
 	Refresh();
 }
 
-void ControlMapper::Update(const InputState &input) {
+void ControlMapper::Update() {
 	if (refresh_) {
 		refresh_ = false;
 		Refresh();
@@ -371,7 +371,7 @@ public:
 			curX_(0.0f), curY_(0.0f),
 			maxCount_(500) {}
 	void Draw(UIContext &dc) override;
-	void Update(const InputState &input_state) override;
+	void Update() override;
 	void Axis(const AxisInput &input) override {
 		// TODO: Check input.deviceId?
 		if (input.axisId == xAxis_) {
@@ -427,7 +427,7 @@ void JoystickHistoryView::Draw(UIContext &dc) {
 	}
 }
 
-void JoystickHistoryView::Update(const InputState &input_state) {
+void JoystickHistoryView::Update() {
 	locations_.push_back(Location(curX_, curY_));
 	if ((int)locations_.size() > maxCount_) {
 		locations_.pop_front();

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -168,8 +168,8 @@ void LogScreen::UpdateLog() {
 	toBottom_ = true;
 }
 
-void LogScreen::update(InputState &input) {
-	UIDialogScreenWithBackground::update(input);
+void LogScreen::update() {
+	UIDialogScreenWithBackground::update();
 	if (toBottom_) {
 		toBottom_ = false;
 		scroll_->ScrollToBottom();

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -63,7 +63,7 @@ class LogScreen : public UIDialogScreenWithBackground {
 public:
 	LogScreen() : toBottom_(false) {}
 	void CreateViews() override;
-	void update(InputState &input) override;
+	void update() override;
 
 private:
 	void UpdateLog();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -832,45 +832,6 @@ void EmuScreen::update(InputState &input) {
 	// Virtual keys.
 	__CtrlSetRapidFire(virtKeys[VIRTKEY_RAPID_FIRE - VIRTKEY_FIRST]);
 
-	// Apply tilt to left stick
-	// TODO: Make into an axis
-#ifdef MOBILE_DEVICE
-	/*
-	if (g_Config.bAccelerometerToAnalogHoriz) {
-		// Get the "base" coordinate system which is setup by the calibration system
-		float base_x = g_Config.fTiltBaseX;
-		float base_y = g_Config.fTiltBaseY;
-
-		//convert the current input into base coordinates and normalize
-		//TODO: check if all phones give values between [-50, 50]. I'm not sure how iOS works.
-		float normalized_input_x = (input.acc.y - base_x) / 50.0 ;
-		float normalized_input_y = (input.acc.x - base_y) / 50.0 ;
-
-		//TODO: need a better name for computed x and y.
-		float delta_x =  tiltInputCurve(normalized_input_x * 2.0 * (g_Config.iTiltSensitivityX)) ;
-
-		//if the invert is enabled, invert the motion
-		if (g_Config.bInvertTiltX) {
-			delta_x *= -1;
-		}
-
-		float delta_y =  tiltInputCurve(normalized_input_y * 2.0 * (g_Config.iTiltSensitivityY)) ;
-
-		if (g_Config.bInvertTiltY) {
-			delta_y *= -1;
-		}
-
-		//clamp the delta between [-1, 1]
-		leftstick_x += clamp1(delta_x);
-		__CtrlSetAnalogX(clamp1(leftstick_x), CTRL_STICK_LEFT);
-
-
-		leftstick_y += clamp1(delta_y);
-		__CtrlSetAnalogY(clamp1(leftstick_y), CTRL_STICK_LEFT);
-	}
-	*/
-#endif
-
 	// Make sure fpsLimit starts at 0
 	if (PSP_CoreParameter().fpsLimit != 0 && PSP_CoreParameter().fpsLimit != 1) {
 		PSP_CoreParameter().fpsLimit = 0;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -785,11 +785,11 @@ UI::EventReturn EmuScreen::OnDevTools(UI::EventParams &params) {
 	return UI::EVENT_DONE;
 }
 
-void EmuScreen::update(InputState &input) {
+void EmuScreen::update() {
 	if (bootPending_)
 		bootGame(gamePath_);
 
-	UIScreen::update(input);
+	UIScreen::update();
 
 	// Simply forcibly update to the current screen size every frame. Doesn't cost much.
 	// If bounds is set to be smaller than the actual pixel resolution of the display, respect that.

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -35,7 +35,7 @@ public:
 	EmuScreen(const std::string &filename);
 	~EmuScreen();
 
-	void update(InputState &input) override;
+	void update() override;
 	void render() override;
 	void deviceLost() override;
 	void deviceRestore() override;

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -188,8 +188,8 @@ UI::EventReturn GameScreen::OnDeleteConfig(UI::EventParams &e)
 	return UI::EVENT_DONE;
 }
 
-void GameScreen::update(InputState &input) {
-	UIScreen::update(input);
+void GameScreen::update() {
+	UIScreen::update();
 
 	I18NCategory *ga = GetI18NCategory("Game");
 

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -33,7 +33,7 @@ public:
 	GameScreen(const std::string &gamePath);
 	~GameScreen();
 
-	virtual void update(InputState &input);
+	virtual void update();
 
 	virtual std::string tag() const { return "game"; }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -953,8 +953,8 @@ UI::EventReturn GameSettingsScreen::OnDumpNextFrameToLog(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-void GameSettingsScreen::update(InputState &input) {
-	UIScreen::update(input);
+void GameSettingsScreen::update() {
+	UIScreen::update();
 	g_Config.iForceMaxEmulatedFPS = cap60FPS_ ? 60 : 0;
 
 	g_Config.iFpsLimit = (iAlternateSpeedPercent_ * 60) / 100;

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -28,7 +28,7 @@ class GameSettingsScreen : public UIDialogScreenWithGameBackground {
 public:
 	GameSettingsScreen(std::string gamePath, std::string gameID = "", bool editThenRestore = false);
 
-	virtual void update(InputState &input);
+	virtual void update();
 	virtual void onFinish(DialogResult result);
 
 	UI::Event OnRecentChanged;

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -41,7 +41,7 @@ void GamepadView::Touch(const TouchInput &input) {
 	secondsWithoutTouch_ = 0.0f;
 }
 
-void GamepadView::Update(const InputState &input) {
+void GamepadView::Update() {
 	const float now = time_now();
 	float delta = now - lastFrameTime_;
 	if (delta > 0) {

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -31,7 +31,7 @@ public:
 	bool Key(const KeyInput &input) override {
 		return false;
 	}
-	void Update(const InputState &input) override;
+	void Update() override;
 
 protected:
 	float GetButtonOpacity();

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -76,7 +76,7 @@ UI::EventReturn InstallZipScreen::OnInstall(UI::EventParams &params) {
 	return UI::EVENT_DONE;
 }
 
-void InstallZipScreen::update(InputState &input) {
+void InstallZipScreen::update() {
 	I18NCategory *iz = GetI18NCategory("InstallZip");
 
 	using namespace UI;
@@ -95,5 +95,5 @@ void InstallZipScreen::update(InputState &input) {
 			MainScreen::showHomebrewTab = true;
 		}
 	}
-	UIScreen::update(input);
+	UIScreen::update();
 }

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -27,7 +27,7 @@
 class InstallZipScreen : public UIDialogScreenWithBackground {
 public:
 	InstallZipScreen(std::string zipPath) : installChoice_(0), doneView_(0), zipPath_(zipPath), installStarted_(false), deleteZipFile_(false) {}
-	virtual void update(InputState &input) override;
+	virtual void update() override;
 	virtual bool key(const KeyInput &key) override;
 
 protected:

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -132,7 +132,7 @@ public:
 		return Clickable::Key(key);
 	}
 
-	void Update(const InputState &input_state) override {
+	void Update() override {
 		// Hold button for 1.5 seconds to launch the game options
 		if (holdEnabled_ && holdStart_ != 0.0 && holdStart_ < time_now_d() - 1.5) {
 			TriggerOnHoldClick();
@@ -949,8 +949,8 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 	}
 }
 
-void MainScreen::update(InputState &input) {
-	UIScreen::update(input);
+void MainScreen::update() {
+	UIScreen::update();
 	UpdateUIState(UISTATE_MENU);
 	bool vertical = UseVerticalLayout();
 	if (vertical != lastVertical_) {
@@ -1239,9 +1239,9 @@ void UmdReplaceScreen::CreateViews() {
 	root_->Add(rightColumn);
 }
 
-void UmdReplaceScreen::update(InputState &input) {
+void UmdReplaceScreen::update() {
 	UpdateUIState(UISTATE_PAUSEMENU);
-	UIScreen::update(input);
+	UIScreen::update();
 }
 
 UI::EventReturn UmdReplaceScreen::OnGameSelected(UI::EventParams &e) {

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -82,7 +82,7 @@ public:
 protected:
 	void CreateViews() override;
 	void DrawBackground(UIContext &dc) override;
-	void update(InputState &input) override;
+	void update() override;
 	void sendMessage(const char *message, const char *value) override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
@@ -129,7 +129,7 @@ public:
 
 protected:
 	void CreateViews() override;
-	void update(InputState &input) override;
+	void update() override;
 	//virtual void sendMessage(const char *message, const char *value);
 
 private:

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -416,7 +416,7 @@ const float logoScreenSeconds = 2.5f;
 void LogoScreen::update(InputState &input_state) {
 	UIScreen::update(input_state);
 	frames_++;
-	if (frames_ > 60 * logoScreenSeconds || input_state.pointer_down[0]) {
+	if (frames_ > 60 * logoScreenSeconds) {
 		Next();
 	}
 }
@@ -429,6 +429,14 @@ void LogoScreen::sendMessage(const char *message, const char *value) {
 
 bool LogoScreen::key(const KeyInput &key) {
 	if (key.deviceId != DEVICE_ID_MOUSE) {
+		Next();
+		return true;
+	}
+	return false;
+}
+
+bool LogoScreen::touch(const TouchInput &touch) {
+	if (touch.flags & TOUCH_DOWN) {
 		Next();
 		return true;
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -413,8 +413,8 @@ void LogoScreen::Next() {
 
 const float logoScreenSeconds = 2.5f;
 
-void LogoScreen::update(InputState &input_state) {
-	UIScreen::update(input_state);
+void LogoScreen::update() {
+	UIScreen::update();
 	frames_++;
 	if (frames_ > 60 * logoScreenSeconds) {
 		Next();
@@ -558,8 +558,8 @@ UI::EventReturn CreditsScreen::OnOK(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-void CreditsScreen::update(InputState &input_state) {
-	UIScreen::update(input_state);
+void CreditsScreen::update() {
+	UIScreen::update();
 	UpdateUIState(UISTATE_MENU);
 	frames_++;
 }

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -115,6 +115,7 @@ public:
 	LogoScreen()
 		: frames_(0), switched_(false) {}
 	bool key(const KeyInput &key) override;
+	bool touch(const TouchInput &touch) override;
 	void update(InputState &input) override;
 	void render() override;
 	void sendMessage(const char *message, const char *value) override;

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -116,7 +116,7 @@ public:
 		: frames_(0), switched_(false) {}
 	bool key(const KeyInput &key) override;
 	bool touch(const TouchInput &touch) override;
-	void update(InputState &input) override;
+	void update() override;
 	void render() override;
 	void sendMessage(const char *message, const char *value) override;
 	void CreateViews() override {}
@@ -130,7 +130,7 @@ private:
 class CreditsScreen : public UIDialogScreenWithBackground {
 public:
 	CreditsScreen() : frames_(0) {}
-	void update(InputState &input) override;
+	void update() override;
 	void render() override;
 
 	void CreateViews() override;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -864,7 +864,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	}
 }
 
-void NativeUpdate(InputState &input) {
+void NativeUpdate() {
 	PROFILE_END_FRAME();
 
 	{
@@ -877,7 +877,7 @@ void NativeUpdate(InputState &input) {
 	}
 
 	g_DownloadManager.Update();
-	screenManager->update(input);
+	screenManager->update();
 }
 
 void NativeDeviceLost() {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -264,9 +264,9 @@ UI::EventReturn SaveSlotView::OnScreenshotClick(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-void GamePauseScreen::update(InputState &input) {
+void GamePauseScreen::update() {
 	UpdateUIState(UISTATE_PAUSEMENU);
-	UIScreen::update(input);
+	UIScreen::update();
 
 	if (finishNextFrame_) {
 		screenManager()->finishDialog(this, DR_CANCEL);

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -34,7 +34,7 @@ public:
 
 protected:
 	virtual void CreateViews() override;
-	virtual void update(InputState &input) override;
+	virtual void update() override;
 	virtual void sendMessage(const char *message, const char *value) override;
 	void CallbackDeleteConfig(bool yes);
 

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -342,8 +342,8 @@ static bool LoadGameList(const std::string &host, int port, std::vector<std::str
 RemoteISOScreen::RemoteISOScreen() : serverRunning_(false), serverStopping_(false) {
 }
 
-void RemoteISOScreen::update(InputState &input) {
-	UIScreenWithBackground::update(input);
+void RemoteISOScreen::update() {
+	UIScreenWithBackground::update();
 
 	bool nowRunning = RetrieveStatus() != ServerStatus::STOPPED;
 	if (serverStopping_ && !nowRunning) {
@@ -486,10 +486,10 @@ void RemoteISOConnectScreen::CreateViews() {
 	rightColumn->Add(rightColumnItems);
 }
 
-void RemoteISOConnectScreen::update(InputState &input) {
+void RemoteISOConnectScreen::update() {
 	I18NCategory *sy = GetI18NCategory("System");
 
-	UIScreenWithBackground::update(input);
+	UIScreenWithBackground::update();
 
 	ScanStatus s = GetStatus();
 	switch (s) {

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -30,7 +30,7 @@ public:
 	RemoteISOScreen();
 
 protected:
-	void update(InputState &input) override;
+	void update() override;
 	void CreateViews() override;
 
 	UI::EventReturn HandleStartServer(UI::EventParams &e);
@@ -57,7 +57,7 @@ public:
 	~RemoteISOConnectScreen() override;
 
 protected:
-	void update(InputState &input) override;
+	void update() override;
 	void CreateViews() override;
 
 	ScanStatus GetStatus();

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -41,7 +41,7 @@ public:
 	Event OnChoice;
 
 protected:
-	void Update(const InputState &input_state) override;
+	void Update() override;
 
 	virtual void SetupChoices();
 	virtual int TotalChoices() {
@@ -73,8 +73,8 @@ RatingChoice::RatingChoice(const char *captionKey, int *value, LayoutParams *lay
 	SetupChoices();
 }
 
-void RatingChoice::Update(const InputState &input_state) {
-	LinearLayout::Update(input_state);
+void RatingChoice::Update() {
+	LinearLayout::Update();
 
 	for (int i = 0; i < TotalChoices(); i++) {
 		StickyChoice *chosen = GetChoice(i);
@@ -160,7 +160,7 @@ ReportScreen::ReportScreen(const std::string &gamePath)
 	ratingEnabled_ = enableReporting_;
 }
 
-void ReportScreen::update(InputState &input) {
+void ReportScreen::update() {
 	if (screenshot_) {
 		if (includeScreenshot_) {
 			screenshot_->SetVisibility(V_VISIBLE);
@@ -168,7 +168,7 @@ void ReportScreen::update(InputState &input) {
 			screenshot_->SetVisibility(V_GONE);
 		}
 	}
-	UIScreenWithGameBackground::update(input);
+	UIScreenWithGameBackground::update();
 }
 
 EventReturn ReportScreen::HandleChoice(EventParams &e) {
@@ -332,7 +332,7 @@ void ReportFinishScreen::CreateViews() {
 	rightColumn->Add(rightColumnItems);
 }
 
-void ReportFinishScreen::update(InputState &input) {
+void ReportFinishScreen::update() {
 	I18NCategory *rp = GetI18NCategory("Reporting");
 
 	if (!setStatus_) {
@@ -353,7 +353,7 @@ void ReportFinishScreen::update(InputState &input) {
 		}
 	}
 
-	UIScreenWithGameBackground::update(input);
+	UIScreenWithGameBackground::update();
 }
 
 UI::EventReturn ReportFinishScreen::HandleViewFeedback(UI::EventParams &e) {

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -28,7 +28,7 @@ public:
 	ReportScreen(const std::string &gamePath);
 
 protected:
-	void update(InputState &input) override;
+	void update() override;
 	void CreateViews() override;
 	void UpdateSubmit();
 
@@ -56,7 +56,7 @@ public:
 	ReportFinishScreen(const std::string &gamePath);
 
 protected:
-	void update(InputState &input) override;
+	void update() override;
 	void CreateViews() override;
 
 	UI::EventReturn HandleViewFeedback(UI::EventParams &e);

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -175,12 +175,12 @@ public:
 	ProductItemView(const StoreEntry &entry, UI::LayoutParams *layoutParams = 0)
 		: UI::Choice(entry.name, layoutParams), entry_(entry) {}
 
-	virtual void GetContentDimensions(const UIContext &dc, float &w, float &h) const {
+	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override {
 		w = 300;
 		h = 164;
 	}
-	virtual void Update(const InputState &input_state);
-	virtual void Draw(UIContext &dc);
+	void Update() override;
+	void Draw(UIContext &dc) override;
 
 	StoreEntry GetEntry() const { return entry_; }
 
@@ -193,8 +193,8 @@ void ProductItemView::Draw(UIContext &dc) {
 	// dc.DrawText(entry_.name.c_str(), bounds_.centerX(), bounds_.centerY(), 0xFFFFFFFF, ALIGN_CENTER);
 }
 
-void ProductItemView::Update(const InputState &input_state) {
-	View::Update(input_state);
+void ProductItemView::Update() {
+	View::Update();
 }
 
 // This is a "details" view of a game. Lets you install it.
@@ -205,7 +205,7 @@ public:
 		CreateViews();
 	}
 
-	virtual void Update(const InputState &input_state);
+	void Update() override;
 
 	UI::Event OnClickLaunch;
 
@@ -263,7 +263,7 @@ void ProductView::CreateViews() {
 	Add(new TextView(temp));
 }
 
-void ProductView::Update(const InputState &input_state) {
+void ProductView::Update() {
 	if (wasInstalled_ != IsGameInstalled()) {
 		CreateViews();
 	}
@@ -272,7 +272,7 @@ void ProductView::Update(const InputState &input_state) {
 	}
 	if (cancelButton_ && g_GameManager.GetState() != GameManagerState::DOWNLOADING)
 		cancelButton_->SetVisibility(UI::V_GONE);
-	View::Update(input_state);
+	View::Update();
 }
 
 UI::EventReturn ProductView::OnInstall(UI::EventParams &e) {
@@ -336,8 +336,8 @@ StoreScreen::~StoreScreen() {
 }
 
 // Handle async download tasks
-void StoreScreen::update(InputState &input) {
-	UIDialogScreenWithBackground::update(input);
+void StoreScreen::update() {
+	UIDialogScreenWithBackground::update();
 
 	g_DownloadManager.Update();
 

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -62,11 +62,11 @@ public:
 	StoreScreen();
 	~StoreScreen();
 
-	virtual void update(InputState &input);
-	virtual std::string tag() const { return "store"; }
+	void update() override;
+	std::string tag() const override { return "store"; }
 
 protected:
-	virtual void CreateViews();
+	void CreateViews() override;
 	UI::EventReturn OnGameSelected(UI::EventParams &e);
 	UI::EventReturn OnRetry(UI::EventParams &e);
 	UI::EventReturn OnGameLaunch(UI::EventParams &e);

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -55,10 +55,6 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 }
 
-void TiltAnalogSettingsScreen::update(InputState &input) {
-	UIScreen::update(input);
-}
-
 bool TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
 	if (axis.deviceId == DEVICE_ID_ACCELEROMETER) {
 		// Historically, we've had X and Y swapped, likely due to portrait vs landscape.

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -57,12 +57,20 @@ void TiltAnalogSettingsScreen::CreateViews() {
 
 void TiltAnalogSettingsScreen::update(InputState &input) {
 	UIScreen::update(input);
-	//I'm not sure why y is x and x is y. i's probably because of the orientation
-	//of the screen (the x and y are in portrait coordinates). once portrait and 
-	//reverse-landscape is enabled, this will probably have to change.
-	//If needed, we can add a "swap x and y" option. 
-	currentTiltX_ = input.acc.y;
-	currentTiltY_ = input.acc.x;
+}
+
+bool TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
+	if (axis.deviceId == DEVICE_ID_ACCELEROMETER) {
+		// Historically, we've had X and Y swapped, likely due to portrait vs landscape.
+		// TODO: We may want to configure this based on screen orientation.
+		if (axis.axisId == JOYSTICK_AXIS_ACCELEROMETER_X) {
+			currentTiltY_ = axis.value;
+		}
+		if (axis.axisId == JOYSTICK_AXIS_ACCELEROMETER_Y) {
+			currentTiltX_ = axis.value;
+		}
+	}
+	return false;
 }
 
 UI::EventReturn TiltAnalogSettingsScreen::OnCalibrate(UI::EventParams &e) {

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -26,8 +26,10 @@ class TiltAnalogSettingsScreen : public UIDialogScreenWithBackground {
 public:
 	TiltAnalogSettingsScreen() : currentTiltX_(0), currentTiltY_(0) {}
 
-	virtual void CreateViews();
-	virtual void update(InputState &input);
+	void CreateViews() override;
+	void update(InputState &input) override;
+	bool axis(const AxisInput &axis) override;
+
 private:
 	UI::EventReturn OnCalibrate(UI::EventParams &e);
 	float currentTiltX_, currentTiltY_;

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -27,7 +27,6 @@ public:
 	TiltAnalogSettingsScreen() : currentTiltX_(0), currentTiltY_(0) {}
 
 	void CreateViews() override;
-	void update(InputState &input) override;
 	bool axis(const AxisInput &axis) override;
 
 private:

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -221,7 +221,7 @@ inline float LinearMaps(short val, short a0, short a1, short b0, short b1) {
 	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
 }
 
-int DinputDevice::UpdateState(InputState &input_state) {
+int DinputDevice::UpdateState() {
 	if (!pJoystick) return -1;
 
 	DIJOYSTATE2 js;
@@ -234,7 +234,7 @@ int DinputDevice::UpdateState(InputState &input_state) {
 	if(FAILED(pJoystick->GetDeviceState(sizeof(DIJOYSTATE2), &js)))
 		return -1;
 
-	ApplyButtons(js, input_state);
+	ApplyButtons(js);
 
 	if (analog)	{
 		AxisInput axis;
@@ -308,7 +308,7 @@ int DinputDevice::UpdateState(InputState &input_state) {
 	return -1;
 }
 
-void DinputDevice::ApplyButtons(DIJOYSTATE2 &state, InputState &input_state) {
+void DinputDevice::ApplyButtons(DIJOYSTATE2 &state) {
 	BYTE *buttons = state.rgbButtons;
 	u32 downMask = 0x80;
 

--- a/Windows/DinputDevice.h
+++ b/Windows/DinputDevice.h
@@ -32,11 +32,11 @@ public:
 	//getDevices(), enumerates all devices if not done yet
 	DinputDevice(int devnum);
 	~DinputDevice();
-	virtual int UpdateState(InputState &input_state);
+	virtual int UpdateState();
 	virtual bool IsPad() { return true; }
 	static size_t getNumPads();
 private:
-	void ApplyButtons(DIJOYSTATE2 &state, InputState &input_state);
+	void ApplyButtons(DIJOYSTATE2 &state);
 	//unfortunate and unclean way to keep only one DirectInput instance around
 	static LPDIRECTINPUT8 getPDI();
 	//unfortunate and unclean way to keep track of the number of devices and the

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -32,8 +32,6 @@ static std::mutex emuThreadLock;
 static HANDLE emuThread;
 static volatile long emuThreadReady;
 
-InputState input_state;
-
 extern std::vector<std::wstring> GetWideCmdLine();
 
 enum EmuThreadStatus : long
@@ -191,7 +189,7 @@ unsigned int WINAPI TheThread(void *)
 		if (!Core_IsActive())
 			UpdateUIState(UISTATE_MENU);
 
-		Core_Run(graphicsContext, &input_state);
+		Core_Run(graphicsContext);
 	}
 
 shutdown:

--- a/Windows/InputDevice.cpp
+++ b/Windows/InputDevice.cpp
@@ -37,14 +37,9 @@ static std::mutex inputMutex;
 static std::condition_variable inputEndCond;
 static bool focused = true;
 
-extern InputState input_state;
-
 inline static void ExecuteInputPoll() {
-	// Hm, we may hold the input_state lock for quite a while (time it takes to poll all devices)...
-	// If that becomes an issue, maybe should poll to a copy of inputstate and only hold the lock while
-	// copying that one to the real one?
 	if (host && (focused || !g_Config.bGamepadOnlyFocused)) {
-		host->PollControllers(input_state);
+		host->PollControllers();
 	}
 }
 

--- a/Windows/InputDevice.cpp
+++ b/Windows/InputDevice.cpp
@@ -43,7 +43,6 @@ inline static void ExecuteInputPoll() {
 	// Hm, we may hold the input_state lock for quite a while (time it takes to poll all devices)...
 	// If that becomes an issue, maybe should poll to a copy of inputstate and only hold the lock while
 	// copying that one to the real one?
-	std::lock_guard<std::mutex> guard(input_state.lock);
 	if (host && (focused || !g_Config.bGamepadOnlyFocused)) {
 		host->PollControllers(input_state);
 	}

--- a/Windows/InputDevice.h
+++ b/Windows/InputDevice.h
@@ -22,12 +22,10 @@
 
 #include "Common/CommonTypes.h"
 
-struct InputState;
-
 class InputDevice {
 public:
 	enum { UPDATESTATE_SKIP_PAD = 0x1234};
-	virtual int UpdateState(InputState &input_state) = 0;
+	virtual int UpdateState() = 0;
 	virtual bool IsPad() = 0;
 
 	static void BeginPolling();

--- a/Windows/KeyboardDevice.cpp
+++ b/Windows/KeyboardDevice.cpp
@@ -117,7 +117,7 @@ std::map<int, int> windowsTransTable = InitConstMap<int, int>
 	(VK_LBUTTON, NKCODE_EXT_MOUSEBUTTON_1)
 	(VK_RBUTTON, NKCODE_EXT_MOUSEBUTTON_2);
 
-int KeyboardDevice::UpdateState(InputState &input_state) {
+int KeyboardDevice::UpdateState() {
 	// Nothing to do, all done in WM_INPUT
 	return 0;
 }

--- a/Windows/KeyboardDevice.h
+++ b/Windows/KeyboardDevice.h
@@ -7,7 +7,7 @@ extern std::map<int, int> windowsTransTable;
 
 class KeyboardDevice : public InputDevice {
 public:
-	virtual int UpdateState(InputState &input_state);
+	virtual int UpdateState();
 	virtual bool IsPad() { return false; }
 	
 private:

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -548,7 +548,6 @@ namespace MainWindow
 				mouseButtonDown = true;
 				{
 					std::lock_guard<std::mutex> guard(input_state.lock);
-					input_state.mouse_valid = true;
 					input_state.pointer_down[0] = true;
 
 					input_state.pointer_x[0] = GET_X_LPARAM(lParam) * g_dpi_scale;

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -18,11 +18,11 @@
 #include <set>
 #include <algorithm>
 #include <vector>
-#include "base/NativeApp.h"
 
+#include "base/NativeApp.h"
 #include "base/display.h"
-#include "Common/Log.h"
 #include "input/input_state.h"
+#include "Common/Log.h"
 #include "Windows/RawInput.h"
 #include "Windows/KeyboardDevice.h"
 #include "Windows/MainWindow.h"
@@ -55,8 +55,6 @@
 #define HID_USAGE_GENERIC_MULTIAXIS    ((USHORT) 0x07)
 #endif
 
-extern InputState input_state;
-
 namespace WindowsRawInput {
 	static std::set<int> keyboardKeysDown;
 	static void *rawInputBuffer;
@@ -64,6 +62,8 @@ namespace WindowsRawInput {
 	static bool menuActive;
 	static bool focused = true;
 	static bool mouseRightDown = false;
+	static float mouseX = 0.0f;
+	static float mouseY = 0.0f;
 
 	void Init() {
 		RAWINPUTDEVICE dev[3];
@@ -197,8 +197,8 @@ namespace WindowsRawInput {
 		TouchInput touch;
 		touch.id = 0;
 		touch.flags = TOUCH_MOVE;
-		touch.x = input_state.pointer_x[0];
-		touch.y = input_state.pointer_y[0];
+		touch.x = mouseX;
+		touch.y = mouseY;
 
 		KeyInput key;
 		key.deviceId = DEVICE_ID_MOUSE;
@@ -271,6 +271,11 @@ namespace WindowsRawInput {
 
 		// Docs say to call DefWindowProc to perform necessary cleanup.
 		return DefWindowProc(hWnd, WM_INPUT, wParam, lParam);
+	}
+
+	void SetMousePos(float x, float y) {
+		mouseX = x;
+		mouseY = y;
 	}
 
 	void GainFocus() {

--- a/Windows/RawInput.h
+++ b/Windows/RawInput.h
@@ -22,6 +22,7 @@ namespace WindowsRawInput {
 	LRESULT Process(HWND hWnd, WPARAM wParam, LPARAM lParam);
 	// Not actually RawInput but it kinda belongs here anyway.
 	LRESULT ProcessChar(HWND hWnd, WPARAM wParam, LPARAM lParam);
+	void SetMousePos(float x, float y);
 	void GainFocus();
 	void LoseFocus();
 	void NotifyMenu();

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -6,11 +6,8 @@
 
 #include "base/display.h"
 #include "Common/CommonWindows.h"
-#include "input/input_state.h"
 #include "base/NativeApp.h"
 #include "Windows/MainWindow.h"
-
-extern InputState input_state;
 
 TouchInputHandler::TouchInputHandler() : 
 		touchInfo(nullptr),
@@ -49,25 +46,12 @@ void TouchInputHandler::handleTouchEvent(HWND hWnd, UINT message, WPARAM wParam,
 			for (UINT i = 0; i < inputCount; i++) {
 				int id = 0;
 
-				//here we map the windows touch id to the ppsspp internal touch id
-				//currently we ignore the fact that the mouse uses  touch id 0, so that 
-				//the mouse could possibly interfere with the mapping so for safety 
-				//the maximum amount of touch points is MAX_POINTERS-1 
-				std::map<int, int>::const_iterator it = touchTranslate.find(inputs[i].dwID);
-				if (it != touchTranslate.end()) //check if we already mapped this touch id
-				{
+				// Find or allocate an id for the touch.
+				auto it = touchTranslate.find(inputs[i].dwID);
+				if (it != touchTranslate.end()) {
 					id = it->second;
-				}
-				else
-				{
-					if (touchTranslate.size() + 1 >= MAX_POINTERS) //check if we're tracking too many points
-					{
-						touchUp(touchTranslate.begin()->second, 0, 0);
-						touchTranslate.erase(touchTranslate.begin());
-					}
-					//finding first free internal touch id and map this windows id to an internal id
-					bool *first_free = std::find(input_state.pointer_down, input_state.pointer_down + MAX_POINTERS, false);
-					id = (int)(first_free - input_state.pointer_down) / (int)sizeof(bool);
+				} else {
+					id = (int)touchTranslate.size();
 					touchTranslate[inputs[i].dwID] = id;
 				}
 
@@ -129,11 +113,6 @@ void TouchInputHandler::touchUp(int id, float x, float y){
 	touchevent.x = x;
 	touchevent.y = y;
 	touchevent.flags = TOUCH_UP;
-	input_state.lock.lock();
-	input_state.pointer_down[id] = false;
-	input_state.pointer_x[id] = x;
-	input_state.pointer_y[id] = y;
-	input_state.lock.unlock();
 	NativeTouch(touchevent);
 }
 
@@ -143,11 +122,6 @@ void TouchInputHandler::touchDown(int id, float x, float y){
 	touchevent.x = x;
 	touchevent.y = y;
 	touchevent.flags = TOUCH_DOWN;
-	input_state.lock.lock();
-	input_state.pointer_down[id] = true;
-	input_state.pointer_x[id] = x;
-	input_state.pointer_y[id] = y;
-	input_state.lock.unlock();
 	NativeTouch(touchevent);
 }
 
@@ -157,10 +131,6 @@ void TouchInputHandler::touchMove(int id, float x, float y){
 	touchevent.x = x;
 	touchevent.y = y;
 	touchevent.flags = TOUCH_MOVE;
-	input_state.lock.lock();
-	input_state.pointer_x[id] = x;
-	input_state.pointer_y[id] = y;
-	input_state.lock.unlock();
 	NativeTouch(touchevent);
 }
 

--- a/Windows/TouchInputHandler.h
+++ b/Windows/TouchInputHandler.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <map>
-
 typedef BOOL(WINAPI *getTouchInputProc)(
 	HTOUCHINPUT hTouchInput,
 	UINT cInputs,
@@ -20,22 +18,22 @@ typedef BOOL(WINAPI *registerTouchProc)(
 
 class TouchInputHandler
 {
-private:
-	std::map<int, int> touchTranslate;
-	getTouchInputProc touchInfo;
-	closeTouchInputProc closeTouch;
-	registerTouchProc registerTouch;
-
 public:
 	TouchInputHandler();
 	~TouchInputHandler();
 	void handleTouchEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 	void registerTouchWindow(HWND wnd);
 	bool hasTouch();
+
 private:
 	void disablePressAndHold(HWND hWnd);
 	void touchUp(int id, float x, float y);
 	void touchDown(int id, float x, float y);
 	void touchMove(int id, float x, float y);
+
+	int touchIds[10];
+	getTouchInputProc touchInfo;
+	closeTouchInputProc closeTouch;
+	registerTouchProc registerTouch;
 };
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -196,14 +196,14 @@ void WindowsHost::SetDebugMode(bool mode) {
 			PostDialogMessage(disasmWindow[i], WM_DEB_SETDEBUGLPARAM, 0, (LPARAM)mode);
 }
 
-void WindowsHost::PollControllers(InputState &input_state) {
+void WindowsHost::PollControllers() {
 	bool doPad = true;
 	for (auto iter = this->input.begin(); iter != this->input.end(); iter++)
 	{
 		auto device = *iter;
 		if (!doPad && device->IsPad())
 			continue;
-		if (device->UpdateState(input_state) == InputDevice::UPDATESTATE_SKIP_PAD)
+		if (device->UpdateState() == InputDevice::UPDATESTATE_SKIP_PAD)
 			doPad = false;
 	}
 

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -41,7 +41,7 @@ public:
 
 	// If returns false, will return a null context
 	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
-	void PollControllers(InputState &input_state) override;
+	void PollControllers() override;
 	void ShutdownGraphics() override;
 
 	void InitSound() override;

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -200,7 +200,7 @@ bool NormalizedDeadzoneDiffers(u8 x1, u8 x2, const u8 thresh) {
 	return false;
 }
 
-int XinputDevice::UpdateState(InputState &input_state) {
+int XinputDevice::UpdateState() {
 	if (!s_pXInputDLL)
 		return 0;
 
@@ -212,7 +212,7 @@ int XinputDevice::UpdateState(InputState &input_state) {
 			continue;
 		DWORD dwResult = PPSSPP_XInputGetState(i, &state);
 		if (dwResult == ERROR_SUCCESS) {
-			UpdatePad(i, state, input_state);
+			UpdatePad(i, state);
 			anySuccess = true;
 		}
 	}
@@ -221,13 +221,13 @@ int XinputDevice::UpdateState(InputState &input_state) {
 	return anySuccess ? UPDATESTATE_SKIP_PAD : 0;
 }
 
-void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, InputState &input_state) {
+void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state) {
 	static bool notified = false;
 	if (!notified) {
 		notified = true;
 		KeyMap::NotifyPadConnected("Xbox 360 Pad");
 	}
-	ApplyButtons(pad, state, input_state);
+	ApplyButtons(pad, state);
 
 	const float STICK_DEADZONE = g_Config.fXInputAnalogDeadzone;
 	const int STICK_INV_MODE = g_Config.iXInputAnalogInverseMode;
@@ -288,7 +288,7 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, InputState &inp
 	this->check_delay[pad] = 0;
 }
 
-void XinputDevice::ApplyButtons(int pad, const XINPUT_STATE &state, InputState &input_state) {
+void XinputDevice::ApplyButtons(int pad, const XINPUT_STATE &state) {
 	u32 buttons = state.Gamepad.wButtons;
 
 	u32 downMask = buttons & (~prevButtons[pad]);

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -8,12 +8,12 @@ class XinputDevice : public InputDevice {
 public:
 	XinputDevice();
 	~XinputDevice();
-	virtual int UpdateState(InputState &input_state);
+	virtual int UpdateState();
 	virtual bool IsPad() { return true; }
 
 private:
-	void UpdatePad(int pad, const XINPUT_STATE &state, InputState &input_state);
-	void ApplyButtons(int pad, const XINPUT_STATE &state, InputState &input_state);
+	void UpdatePad(int pad, const XINPUT_STATE &state);
+	void ApplyButtons(int pad, const XINPUT_STATE &state);
 	int check_delay[4]{};
 	XINPUT_STATE prevState[4]{};
 	u32 prevButtons[4]{};

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -360,8 +360,6 @@ static bool renderLoopRunning;
 static float dp_xscale = 1.0f;
 static float dp_yscale = 1.0f;
 
-InputState input_state;
-
 static bool renderer_inited = false;
 static bool renderer_ever_inited = false;
 // See NativeQueryConfig("androidJavaGL") to change this value.
@@ -506,7 +504,6 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	ILOG("NativeApp.init() -- begin");
 	PROFILE_INIT();
 
-	memset(&input_state, 0, sizeof(input_state));
 	renderer_inited = false;
 	renderer_ever_inited = false;
 	androidVersion = jAndroidVersion;
@@ -672,7 +669,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 	}
 
 	if (renderer_inited) {
-		NativeUpdate(input_state);
+		NativeUpdate();
 
 		NativeRender(graphicsContext);
 		time_update();
@@ -1018,7 +1015,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 			setCurrentThreadName("AndroidRender");
 		}
 
-		NativeUpdate(input_state);
+		NativeUpdate();
 
 		NativeRender(graphicsContext);
 		time_update();

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -828,14 +828,6 @@ extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEn
 	if (!renderer_inited)
 		return false;
 
-	// Theoretically this needs locking but I doubt it matters. Worst case, the X
-	// from one "sensor frame" will be used together with Y from the next.
-	// Should look into quantization though, for compressed movement storage.
-	input_state.accelerometer_valid = true;
-	input_state.acc.x = x;
-	input_state.acc.y = y;
-	input_state.acc.z = z;
-
 	AxisInput axis;
 	axis.deviceId = DEVICE_ID_ACCELEROMETER;
 	axis.flags = 0;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -736,23 +736,8 @@ extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 	touch.x = scaledX;
 	touch.y = scaledY;
 	touch.flags = code;
-	if (code & 2) {
-		input_state.pointer_down[pointerId] = true;
-	} else if (code & 4) {
-		input_state.pointer_down[pointerId] = false;
-	}
 
 	bool retval = NativeTouch(touch);
-	{
-		std::lock_guard<std::mutex> guard(input_state.lock);
-		if (pointerId >= MAX_POINTERS) {
-			ELOG("Too many pointers: %i", pointerId);
-			return false;	// We ignore 8+ pointers entirely.
-		}
-		input_state.pointer_x[pointerId] = scaledX;
-		input_state.pointer_y[pointerId] = scaledY;
-		input_state.mouse_valid = true;
-	}
 	return retval;
 }
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -8,8 +8,7 @@
 // from the framework, which exposes the native JNI api which is a bit
 // more complicated.
 
-// This is defined in input/input_state.h.
-struct InputState;
+// These are defined in input/input_state.h.
 struct TouchInput;
 struct KeyInput;
 struct AxisInput;
@@ -66,7 +65,7 @@ void NativeResized();
 
 // Called ~sixty times a second, delivers the current input state.
 // Main thread.
-void NativeUpdate(InputState &input);
+void NativeUpdate();
 
 // Delivers touch events "instantly", without waiting for the next frame so that NativeUpdate can deliver.
 // Useful for triggering audio events, saving a few ms.

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -654,7 +654,6 @@ int main(int argc, char *argv[]) {
 	float t = 0;
 	float lastT = 0;
 	while (true) {
-		input_state.accelerometer_valid = false;
 		input_state.mouse_valid = true;
 
 		SDL_Event event;

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -344,8 +344,6 @@ int System_GetPropertyInt(SystemProperty prop) {
 	}
 }
 
-InputState input_state;
-
 extern void mixaudio(void *userdata, Uint8 *stream, int len) {
 	NativeMix((short *)stream, len / 4);
 }
@@ -824,7 +822,7 @@ int main(int argc, char *argv[]) {
 		if (g_QuitRequested)
 			break;
 		const uint8_t *keys = SDL_GetKeyboardState(NULL);
-		UpdateRunLoop(&input_state);
+		UpdateRunLoop();
 		if (g_QuitRequested)
 			break;
 #if defined(PPSSPP) && !defined(MOBILE_DEVICE)

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -653,9 +653,9 @@ int main(int argc, char *argv[]) {
 	int framecount = 0;
 	float t = 0;
 	float lastT = 0;
-	while (true) {
-		input_state.mouse_valid = true;
+	bool mouseDown = false;
 
+	while (true) {
 		SDL_Event event;
 		while (SDL_PollEvent(&event)) {
 			float mx = event.motion.x * g_dpi_scale;
@@ -742,10 +742,7 @@ int main(int argc, char *argv[]) {
 				switch (event.button.button) {
 				case SDL_BUTTON_LEFT:
 					{
-						input_state.pointer_x[0] = mx;
-						input_state.pointer_y[0] = my;
-						input_state.pointer_down[0] = true;
-						input_state.mouse_valid = true;
+						mouseDown = true;
 						TouchInput input;
 						input.x = mx;
 						input.y = my;
@@ -783,10 +780,7 @@ int main(int argc, char *argv[]) {
 					NativeKey(key);
 				}
 			case SDL_MOUSEMOTION:
-				if (input_state.pointer_down[0]) {
-					input_state.pointer_x[0] = mx;
-					input_state.pointer_y[0] = my;
-					input_state.mouse_valid = true;
+				if (mouseDown) {
 					TouchInput input;
 					input.x = mx;
 					input.y = my;
@@ -799,11 +793,7 @@ int main(int argc, char *argv[]) {
 				switch (event.button.button) {
 				case SDL_BUTTON_LEFT:
 					{
-						input_state.pointer_x[0] = mx;
-						input_state.pointer_y[0] = my;
-						input_state.pointer_down[0] = false;
-						input_state.mouse_valid = true;
-						//input_state.mouse_buttons_up = 1;
+						mouseDown = false;
 						TouchInput input;
 						input.x = mx;
 						input.y = my;

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -249,10 +249,6 @@ bool MainUI::event(QEvent *e)
                 break;
             case Qt::TouchPointPressed:
             case Qt::TouchPointReleased:
-                input_state.pointer_down[touchPoint.id()] = (touchPoint.state() == Qt::TouchPointPressed);
-                input_state.pointer_x[touchPoint.id()] = touchPoint.pos().x() * g_dpi_scale * xscale;
-                input_state.pointer_y[touchPoint.id()] = touchPoint.pos().y() * g_dpi_scale * yscale;
-
                 input.x = touchPoint.pos().x() * g_dpi_scale * xscale;
                 input.y = touchPoint.pos().y() * g_dpi_scale * yscale;
                 input.flags = (touchPoint.state() == Qt::TouchPointPressed) ? TOUCH_DOWN : TOUCH_UP;
@@ -260,9 +256,6 @@ bool MainUI::event(QEvent *e)
                 NativeTouch(input);
                 break;
             case Qt::TouchPointMoved:
-                input_state.pointer_x[touchPoint.id()] = touchPoint.pos().x() * g_dpi_scale * xscale;
-                input_state.pointer_y[touchPoint.id()] = touchPoint.pos().y() * g_dpi_scale * yscale;
-
                 input.x = touchPoint.pos().x() * g_dpi_scale * xscale;
                 input.y = touchPoint.pos().y() * g_dpi_scale * yscale;
                 input.flags = TOUCH_MOVE;
@@ -280,10 +273,6 @@ bool MainUI::event(QEvent *e)
         break;
     case QEvent::MouseButtonPress:
     case QEvent::MouseButtonRelease:
-        input_state.pointer_down[0] = (e->type() == QEvent::MouseButtonPress);
-        input_state.pointer_x[0] = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
-        input_state.pointer_y[0] = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
-
         input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
         input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
         input.flags = (e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP;
@@ -291,9 +280,6 @@ bool MainUI::event(QEvent *e)
         NativeTouch(input);
         break;
     case QEvent::MouseMove:
-        input_state.pointer_x[0] = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
-        input_state.pointer_y[0] = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
-
         input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
         input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
         input.flags = TOUCH_MOVE;

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -348,23 +348,20 @@ void MainUI::updateAccelerometer()
         // TODO: Toggle it depending on whether it is enabled
         QAccelerometerReading *reading = acc->reading();
         if (reading) {
-            input_state.acc.x = reading->x();
-            input_state.acc.y = reading->y();
-            input_state.acc.z = reading->z();
             AxisInput axis;
             axis.deviceId = DEVICE_ID_ACCELEROMETER;
             axis.flags = 0;
 
             axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
-            axis.value = input_state.acc.x;
+            axis.value = reading->x();
             NativeAxis(axis);
 
             axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
-            axis.value = input_state.acc.y;
+            axis.value = reading->y();
             NativeAxis(axis);
 
             axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
-            axis.value = input_state.acc.z;
+            axis.value = reading->z();
             NativeAxis(axis);
         }
 #endif

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -30,7 +30,6 @@
 
 #include <string.h>
 
-InputState input_state;
 MainUI *emugl = NULL;
 
 #ifdef SDL
@@ -325,7 +324,7 @@ void MainUI::paintGL()
 #endif
     updateAccelerometer();
     time_update();
-    UpdateRunLoop(&input_state);
+    UpdateRunLoop();
 }
 
 void MainUI::updateAccelerometer()

--- a/ext/native/base/QtMain.h
+++ b/ext/native/base/QtMain.h
@@ -36,7 +36,7 @@ QTM_USE_NAMESPACE
 #include "Core/Config.h"
 
 // Input
-void SimulateGamepad(InputState *input);
+void SimulateGamepad();
 
 class QtDummyGraphicsContext : public DummyGraphicsContext {
 public:
@@ -81,7 +81,6 @@ protected:
 	void updateAccelerometer();
 
 private:
-	InputState input_state;
 	QtDummyGraphicsContext *graphicsContext;
 
 	float xscale, yscale;

--- a/ext/native/input/input_state.h
+++ b/ext/native/input/input_state.h
@@ -1,10 +1,5 @@
 #pragma once
 
-// InputState is the simple way of getting input. All the input we have is collected
-// to a canonical Xbox360-style pad fully automatically.
-//
-// Recommended for use in game UIs and games that don't have advanced needs.
-//
 // For more detailed and configurable input, implement NativeTouch, NativeKey and NativeAxis and do your
 // own mapping. Might later move the mapping system from PPSSPP to native.
 
@@ -77,8 +72,6 @@ enum {
 	PAD_BUTTON_UNTHROTTLE = 1 << 20, // Click Tab to unthrottle
 };
 
-#define MAX_POINTERS 10
-
 #ifndef MAX_KEYQUEUESIZE
 #define MAX_KEYQUEUESIZE 20
 #endif
@@ -105,23 +98,6 @@ public:
 	}
 };
 
-// Collection of all possible inputs, and automatically computed
-// deltas where applicable.
-struct InputState {
-	// Lock this whenever you access the data in this struct.
-	mutable std::mutex lock;
-	InputState() {
-		memset(pointer_down, 0, sizeof(pointer_down));
-	}
-
-	int pointer_x[MAX_POINTERS];
-	int pointer_y[MAX_POINTERS];
-	bool pointer_down[MAX_POINTERS];
-
-private:
-	DISALLOW_COPY_AND_ASSIGN(InputState);
-};
-
 enum {
 	TOUCH_MOVE = 1 << 0,
 	TOUCH_DOWN = 1 << 1,
@@ -146,7 +122,7 @@ enum {
 struct TouchInput {
 	float x;
 	float y;
-	int id;  // can be relied upon to be 0...MAX_POINTERS
+	int id;
 	int flags;
 	double timestamp;
 };

--- a/ext/native/input/input_state.h
+++ b/ext/native/input/input_state.h
@@ -111,8 +111,7 @@ struct InputState {
 	// Lock this whenever you access the data in this struct.
 	mutable std::mutex lock;
 	InputState()
-		: mouse_valid(false),
-			accelerometer_valid(false) {
+		: mouse_valid(false) {
 		memset(pointer_down, 0, sizeof(pointer_down));
 	}
 
@@ -123,10 +122,6 @@ struct InputState {
 	int pointer_x[MAX_POINTERS];
 	int pointer_y[MAX_POINTERS];
 	bool pointer_down[MAX_POINTERS];
-
-	// Accelerometer
-	bool accelerometer_valid;
-	Vec3 acc;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(InputState);

--- a/ext/native/input/input_state.h
+++ b/ext/native/input/input_state.h
@@ -122,7 +122,7 @@ enum {
 struct TouchInput {
 	float x;
 	float y;
-	int id;
+	int id; // Needs to be <= GestureDetector::MAX_PTRS (10.)
 	int flags;
 	double timestamp;
 };

--- a/ext/native/input/input_state.h
+++ b/ext/native/input/input_state.h
@@ -110,14 +110,9 @@ public:
 struct InputState {
 	// Lock this whenever you access the data in this struct.
 	mutable std::mutex lock;
-	InputState()
-		: mouse_valid(false) {
+	InputState() {
 		memset(pointer_down, 0, sizeof(pointer_down));
 	}
-
-	// Mouse/touch style input
-	// There are up to 8 mice / fingers.
-	volatile bool mouse_valid;
 
 	int pointer_x[MAX_POINTERS];
 	int pointer_y[MAX_POINTERS];

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -38,13 +38,13 @@ void ScreenManager::switchScreen(Screen *screen) {
 	}
 }
 
-void ScreenManager::update(InputState &input) {
+void ScreenManager::update() {
 	if (nextScreen_) {
 		switchToNext();
 	}
 
 	if (stack_.size()) {
-		stack_.back().screen->update(input);
+		stack_.back().screen->update();
 	}
 }
 

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -24,8 +24,6 @@ namespace UI {
 	class View;
 }
 
-struct InputState;
-
 enum DialogResult {
 	DR_OK,
 	DR_CANCEL,
@@ -49,7 +47,7 @@ public:
 	}
 
 	virtual void onFinish(DialogResult reason) {}
-	virtual void update(InputState &input) {}
+	virtual void update() {}
 	virtual void preRender() {}
 	virtual void render() {}
 	virtual void postRender() {}
@@ -97,7 +95,7 @@ public:
 	virtual ~ScreenManager();
 
 	void switchScreen(Screen *screen);
-	void update(InputState &input);
+	void update();
 
 	void setUIContext(UIContext *context) { uiContext_ = context; }
 	UIContext *getUIContext() { return uiContext_; }

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -50,11 +50,11 @@ void UIScreen::DoRecreateViews() {
 	}
 }
 
-void UIScreen::update(InputState &input) {
+void UIScreen::update() {
 	DoRecreateViews();
 
 	if (root_) {
-		UpdateViewHierarchy(input, root_);
+		UpdateViewHierarchy(root_);
 	}
 }
 
@@ -340,7 +340,7 @@ UI::EventReturn PopupMultiChoice::HandleClick(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-void PopupMultiChoice::Update(const InputState &input_state) {
+void PopupMultiChoice::Update() {
 	UpdateText();
 }
 

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -15,7 +15,7 @@ public:
 	UIScreen();
 	~UIScreen();
 
-	virtual void update(InputState &input) override;
+	virtual void update() override;
 	virtual void preRender() override;
 	virtual void render() override;
 	virtual void postRender() override;
@@ -222,7 +222,7 @@ public:
 	}
 
 	virtual void Draw(UIContext &dc) override;
-	virtual void Update(const InputState &input_state) override;
+	virtual void Update() override;
 
 	void HideChoice(int c) {
 		hidden_.insert(c);

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -1107,7 +1107,7 @@ void Slider::Draw(UIContext &dc) {
 	dc.DrawText(temp, bounds_.x2() - 22, bounds_.centerY(), 0xFFFFFFFF, ALIGN_CENTER);
 }
 
-void Slider::Update(const InputState &input_state) {
+void Slider::Update() {
 	if (repeat_ >= 0) {
 		repeat_++;
 	}
@@ -1216,7 +1216,7 @@ void SliderFloat::Draw(UIContext &dc) {
 	dc.DrawText(temp, bounds_.x2() - 22, bounds_.centerY(), 0xFFFFFFFF, ALIGN_CENTER);
 }
 
-void SliderFloat::Update(const InputState &input_state) {
+void SliderFloat::Update() {
 	if (repeat_ >= 0) {
 		repeat_++;
 	}

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -27,7 +27,6 @@
 struct KeyInput;
 struct TouchInput;
 struct AxisInput;
-struct InputState;
 
 class DrawBuffer;
 class Texture;
@@ -362,7 +361,7 @@ public:
 	virtual bool Key(const KeyInput &input) { return false; }
 	virtual void Touch(const TouchInput &input) {}
 	virtual void Axis(const AxisInput &input) {}
-	virtual void Update(const InputState &input_state) {}
+	virtual void Update() {}
 
 	// If this view covers these coordinates, it should add itself and its children to the list.
 	virtual void Query(float x, float y, std::vector<View *> &list);
@@ -456,7 +455,7 @@ public:
 	bool Key(const KeyInput &input) override { return false; }
 	void Touch(const TouchInput &input) override {}
 	bool CanBeFocused() const override { return false; }
-	void Update(const InputState &input_state) override {}
+	void Update() override {}
 };
 
 
@@ -515,7 +514,7 @@ public:
 	void Draw(UIContext &dc) override;
 	bool Key(const KeyInput &input) override;
 	void Touch(const TouchInput &input) override;
-	void Update(const InputState &input_state) override;
+	void Update() override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 	void SetShowPercent(bool s) { showPercent_ = s; }
 
@@ -545,7 +544,7 @@ public:
 	void Draw(UIContext &dc) override;
 	bool Key(const KeyInput &input) override;
 	void Touch(const TouchInput &input) override;
-	void Update(const InputState &input_state) override;
+	void Update() override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 
 	// OK to call this from the outside after having modified *value_

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -21,22 +21,6 @@ static std::mutex focusLock;
 static std::vector<int> focusMoves;
 extern bool focusForced;
 
-// TODO: Seems like this drag stuff is no longer used.
-#define MAX_POINTERS 10
-bool dragCaptured[MAX_POINTERS];
-
-void CaptureDrag(int id) {
-	dragCaptured[id] = true;
-}
-
-void ReleaseDrag(int id) {
-	dragCaptured[id] = false;
-}
-
-bool IsDragCaptured(int id) {
-	return dragCaptured[id];
-}
-
 void ApplyGravity(const Bounds outer, const Margins &margins, float w, float h, int gravity, Bounds &inner) {
 	inner.w = w;
 	inner.h = h;
@@ -753,13 +737,13 @@ void ScrollView::Touch(const TouchInput &input) {
 
 	if (input.flags & TOUCH_UP) {
 		float info[4];
-		if (!IsDragCaptured(input.id) && gesture_.GetGestureInfo(gesture, info)) {
+		if (gesture_.GetGestureInfo(gesture, info)) {
 			inertia_ = info[1];
 		}
 	}
 
 	TouchInput input2;
-	if (CanScroll() && !IsDragCaptured(input.id)) {
+	if (CanScroll()) {
 		input2 = gesture_.Update(input, bounds_);
 		float info[4];
 		if (gesture_.GetGestureInfo(gesture, info) && !(input.flags & TOUCH_DOWN)) {

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -20,6 +20,9 @@ const float ITEM_HEIGHT = 64.f;
 static std::mutex focusLock;
 static std::vector<int> focusMoves;
 extern bool focusForced;
+
+// TODO: Seems like this drag stuff is no longer used.
+#define MAX_POINTERS 10
 bool dragCaptured[MAX_POINTERS];
 
 void CaptureDrag(int id) {
@@ -156,11 +159,11 @@ void ViewGroup::Draw(UIContext &dc) {
 	}
 }
 
-void ViewGroup::Update(const InputState &input_state) {
+void ViewGroup::Update() {
 	for (auto iter = views_.begin(); iter != views_.end(); ++iter) {
 		// TODO: If there is a transformation active, transform input coordinates accordingly.
 		if ((*iter)->GetVisibility() != V_GONE)
-			(*iter)->Update(input_state);
+			(*iter)->Update();
 	}
 }
 
@@ -938,11 +941,11 @@ bool ScrollView::CanScroll() const {
 	}
 }
 
-void ScrollView::Update(const InputState &input_state) {
+void ScrollView::Update() {
 	if (visibility_ != V_VISIBLE) {
 		inertia_ = 0.0f;
 	}
-	ViewGroup::Update(input_state);
+	ViewGroup::Update();
 
 	Gesture gesture = orientation_ == ORIENT_VERTICAL ? GESTURE_DRAG_VERTICAL : GESTURE_DRAG_HORIZONTAL;
 	gesture_.UpdateFrame();
@@ -1467,7 +1470,7 @@ bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
 	return true;
 }
 
-void UpdateViewHierarchy(const InputState &input_state, ViewGroup *root) {
+void UpdateViewHierarchy(ViewGroup *root) {
 	ProcessHeldKeys(root);
 	frameCount++;
 
@@ -1499,7 +1502,7 @@ void UpdateViewHierarchy(const InputState &input_state, ViewGroup *root) {
 		focusMoves.clear();
 	}
 
-	root->Update(input_state);
+	root->Update();
 	DispatchEvents();
 }
 

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -414,8 +414,4 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root);
 bool TouchEvent(const TouchInput &touch, ViewGroup *root);
 bool AxisEvent(const AxisInput &axis, ViewGroup *root);
 
-void CaptureDrag(int id);
-void ReleaseDrag(int id);
-bool IsDragCaptured(int id);
-
 }  // namespace UI

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -32,7 +32,7 @@ public:
 	// By default, a container will layout to its own bounds.
 	virtual void Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) override = 0;
 	virtual void Layout() override = 0;
-	virtual void Update(const InputState &input_state) override;
+	virtual void Update() override;
 	virtual void Query(float x, float y, std::vector<View *> &list) override;
 
 	virtual void Draw(UIContext &dc) override;
@@ -244,7 +244,7 @@ public:
 	void ScrollToBottom();
 	void ScrollRelative(float distance);
 	bool CanScroll() const;
-	void Update(const InputState &input_state) override;
+	void Update() override;
 
 	// Override so that we can scroll to the active one after moving the focus.
 	bool SubviewFocused(View *view) override;
@@ -408,7 +408,7 @@ private:
 };
 
 void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root);
-void UpdateViewHierarchy(const InputState &input_state, ViewGroup *root);
+void UpdateViewHierarchy(ViewGroup *root);
 // Hooks arrow keys for navigation
 bool KeyEvent(const KeyInput &key, ViewGroup *root);
 bool TouchEvent(const TouchInput &touch, ViewGroup *root);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -19,7 +19,6 @@
 #include "Log.h"
 #include "LogManager.h"
 #include "base/NativeApp.h"
-#include "input/input_state.h"
 #include "base/timeutil.h"
 
 #include "Compare.h"
@@ -64,9 +63,8 @@ public:
 	}
 };
 
-struct InputState;
 // Temporary hacks around annoying linking errors.
-void NativeUpdate(InputState &input_state) { }
+void NativeUpdate() { }
 void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -264,8 +264,6 @@ static GraphicsContext *graphicsContext;
 
 - (void)touchX:(float)x y:(float)y code:(int)code pointerId:(int)pointerId
 {
-	std::lock_guard<std::mutex> guard(input_state.lock);
-
 	float scale = [UIScreen mainScreen].scale;
 	
 	if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]) {
@@ -276,19 +274,14 @@ static GraphicsContext *graphicsContext;
 	float scaledY = (int)(y * dp_yscale) * scale;
 
 	TouchInput input;
-
-	input_state.pointer_x[pointerId] = scaledX;
-	input_state.pointer_y[pointerId] = scaledY;
 	input.x = scaledX;
 	input.y = scaledY;
 	switch (code) {
 		case 1 :
-			input_state.pointer_down[pointerId] = true;
 			input.flags = TOUCH_DOWN;
 			break;
 
 		case 2 :
-			input_state.pointer_down[pointerId] = false;
 			input.flags = TOUCH_UP;
 			break;
 
@@ -296,7 +289,6 @@ static GraphicsContext *graphicsContext;
 			input.flags = TOUCH_MOVE;
 			break;
 	}
-	input_state.mouse_valid = true;
 	input.id = pointerId;
 	NativeTouch(input);
 }

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -57,7 +57,6 @@ double lastStartPress = 0.0f;
 bool simulateAnalog = false;
 
 extern ScreenManager *screenManager;
-InputState input_state;
 
 extern bool iosCanUseJit;
 extern bool targetIsJailbroken;
@@ -253,7 +252,7 @@ static GraphicsContext *graphicsContext;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-	NativeUpdate(input_state);
+	NativeUpdate();
 	NativeRender(graphicsContext);
 	time_update();
 }

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -253,11 +253,7 @@ static GraphicsContext *graphicsContext;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-	{
-		std::lock_guard<std::mutex> guard(input_state.lock);
-		NativeUpdate(input_state);
-	}
-
+	NativeUpdate(input_state);
 	NativeRender(graphicsContext);
 	time_update();
 }

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -19,7 +19,6 @@
 
 #include "base/timeutil.h"
 #include "base/NativeApp.h"
-#include "input/input_state.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -31,9 +30,8 @@
 #include "Core/CoreTiming.h"
 #include "Core/HLE/HLE.h"
 
-struct InputState;
 // Temporary hacks around annoying linking errors.  Copied from Headless.
-void NativeUpdate(InputState &input_state) { }
+void NativeUpdate() { }
 void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 


### PR DESCRIPTION
This removes the rest of it.

Mostly there are no real changes, except:
 * Minor changes Windows mouse events (to track x/y outside input_state.)
 * Windows touch event handling - isolated id tracking (untested.)
 * Logo and Tilt settings screens tweaked to use events.

-[Unknown]