### PR TITLE
D3D11: Expand 16-bit CLUT textures to 32-bit if not supported.

### DIFF
--- a/GPU/D3D11/DepalettizeShaderD3D11.cpp
+++ b/GPU/D3D11/DepalettizeShaderD3D11.cpp
@@ -85,7 +85,7 @@ ID3D11ShaderResourceView *DepalShaderCacheD3D11::GetClutTexture(GEPaletteFormat 
 	}
 
 	int texturePixels = clutFormat == GE_CMODE_32BIT_ABGR8888 ? 256 : 512;
-
+	int bpp = clutFormat == GE_CMODE_32BIT_ABGR8888 ? 4 : 2;
 	DXGI_FORMAT dstFmt;
 	uint32_t *expanded = nullptr;
 	if (expandTo32bit && clutFormat != GE_CMODE_32BIT_ABGR8888) {
@@ -103,6 +103,7 @@ ID3D11ShaderResourceView *DepalShaderCacheD3D11::GetClutTexture(GEPaletteFormat 
 		}
 		rawClut = expanded;
 		dstFmt = DXGI_FORMAT_B8G8R8A8_UNORM;
+		bpp = 4;
 	}
 	else {
 		dstFmt = GetClutDestFormatD3D11(clutFormat);
@@ -121,7 +122,7 @@ ID3D11ShaderResourceView *DepalShaderCacheD3D11::GetClutTexture(GEPaletteFormat 
 	D3D11_SUBRESOURCE_DATA data{};
 	data.pSysMem = rawClut;
 	// Regardless of format, the CLUT should always be 1024 bytes.
-	data.SysMemPitch = 1024;
+	data.SysMemPitch = texturePixels * bpp;
 
 	DepalTextureD3D11 *tex = new DepalTextureD3D11();
 	// TODO: Look into 1D textures

--- a/GPU/D3D11/DepalettizeShaderD3D11.h
+++ b/GPU/D3D11/DepalettizeShaderD3D11.h
@@ -52,7 +52,7 @@ public:
 	ID3D11PixelShader *GetDepalettizePixelShader(GEPaletteFormat clutFormat, GEBufferFormat pixelFormat);
 	ID3D11VertexShader *GetDepalettizeVertexShader() { return vertexShader_; }
 	ID3D11InputLayout *GetInputLayout() { return inputLayout_; }
-	ID3D11ShaderResourceView *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut);
+	ID3D11ShaderResourceView *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut, bool expandTo32bit);
 	void Clear();
 	void Decimate();
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -339,7 +339,7 @@ public:
 			const float right = u2 * invHalfWidth - 1.0f + xoff;
 			const float top = v1 * invHalfHeight - 1.0f + yoff;
 			const float bottom = v2 * invHalfHeight - 1.0f + yoff;
-			float z = 0.0f;  // was -1.0f for some reason
+			float z = 0.0f;
 			// Points are: BL, BR, TL, TR.
 			verts_[0].pos = Pos(left, bottom, z);
 			verts_[1].pos = Pos(right, bottom, z);

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -396,7 +396,8 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 	}
 
 	if (pshader) {
-		ID3D11ShaderResourceView *clutTexture = depalShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBuf_);
+		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS);
+		ID3D11ShaderResourceView *clutTexture = depalShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBuf_, expand32);
 
 		Draw::Framebuffer *depalFBO = framebufferManagerD3D11_->GetTempFBO(framebuffer->renderWidth, framebuffer->renderHeight, Draw::FBO_8888);
 		shaderManager_->DirtyLastShader();

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -349,11 +349,13 @@ public:
 			const float right = u2 * invHalfWidth - 1.0f + xoff;
 			const float top = v1 * invHalfHeight - 1.0f + yoff;
 			const float bottom = v2 * invHalfHeight - 1.0f + yoff;
+
+			float z = 0.0f;
 			// Points are: BL, BR, TR, TL.
-			verts_[0].pos = Pos(left, bottom, -1.0f);
-			verts_[1].pos = Pos(right, bottom, -1.0f);
-			verts_[2].pos = Pos(right, top, -1.0f);
-			verts_[3].pos = Pos(left, top, -1.0f);
+			verts_[0].pos = Pos(left, bottom, z);
+			verts_[1].pos = Pos(right, bottom, z);
+			verts_[2].pos = Pos(right, top, z);
+			verts_[3].pos = Pos(left, top, z);
 
 			// And also the UVs, same order.
 			const float uvleft = u1 * invWidth;


### PR DESCRIPTION
As reported by @unknownbrackets  here: https://github.com/hrydgard/ppsspp/pull/9319#pullrequestreview-27517079