### PR TITLE
Add Jeanne d'Arc to DrawSyncEatCycles hack

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -154,6 +154,13 @@ ULKS46183 = true
 ULJS00260 = true
 ULJS19041 = true
 NPJH50843 = true
+# Helps with Jeanne d'Arc weird 40/40 fps problem #5154
+UCAS40129 = true
+UCJS10048 = true
+UCKS45033 = true
+UCJS18014 = true
+UCUS98700 = true
+NPJG00032 = true
 
 [FakeMipmapChange]
 # This hacks separates each mipmap to independent textures to display wrong-size mipmaps.


### PR DESCRIPTION
Fixes #5154
 ~Or at least shows 30/30 correctly now without any jumping to 40/40, not sure if it really improves anything as I used 60fps hack and the downgrade makes me feel it's not as smooth as I got used to:|.

 Speaking of which, this happens to disable existing 60 fps patch(during battles), so I made a new one which works everywhere:
```
_S UCUS-98700
_G Jeanne d'Arc
_C0 60 fps
_L 0xE0011420 0x0000921E
_L 0x2000921C 0x1000000E
_C0 60 fps [Disable]
_L 0x2000921C 0x1420000E
```
going to post it in the forums if this get's merged.