### PR TITLE
Don't dirty texture state when kicking off a display list. 

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1103,10 +1103,6 @@ void GPUCommon::ProcessDLQueueInternal() {
 	cyclesExecuted = 0;
 	UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
 
-	// Game might've written new texture data.
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-	gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
-
 	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {
 		DEBUG_LOG(G3D, "Can't execute a list yet, still busy for %lld ticks", busyTicks - startingTicks);


### PR DESCRIPTION
This might hide real bugs and affect performance, and should not be necessary?