### PR TITLE
Cleanup Windows GL core context handling, minor graphics tweaks

### DIFF
--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -604,6 +604,7 @@ void FramebufferManagerD3D11::BindFramebufferAsColorTexture(int stage, VirtualFr
 	} else if (framebuffer != currentRenderVfb_) {
 		draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT, 0);
 	} else {
+		ERROR_LOG_REPORT_ONCE(d3d11SelfTexture, G3D, "Attempting to texture to target");
 		// Badness on D3D11 to bind the currently rendered-to framebuffer as a texture.
 		ID3D11ShaderResourceView *view = nullptr;
 		context_->PSSetShaderResources(stage, 1, &view);

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -203,8 +203,6 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 			// It's already zero, let's skip it.
 			continue;
 		}
-		// DrawActiveTexture unbinds it, so rebind here before setting uniforms.
-		glsl_bind(stencilUploadProgram_);
 		if (dstBuffer->format == GE_FORMAT_4444) {
 			glstate.stencilMask.set((i << 4) | i);
 			glUniform1f(u_stencilValue, i * (16.0f / 255.0f));

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -20,6 +20,7 @@
 #include "Common/Log.h"
 #include "Common/CommonWindows.h"
 #include "gfx/gl_common.h"
+#include "gfx/gl_debug_log.h"
 #include "gfx_es2/gpu_features.h"
 #include "GL/gl.h"
 #include "GL/wglew.h"
@@ -263,8 +264,6 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 	if (gl_extensions.IsCoreContext)
 		glGetError();
 
-	CheckGLExtensions();
-
 	int contextFlags = g_Config.bGfxDebugOutput ? WGL_CONTEXT_DEBUG_BIT_ARB : 0;
 
 	// Alright, now for the modernity. First try a 4.4, then 4.3, context, if that fails try 3.3.
@@ -273,21 +272,21 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 		WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
 		WGL_CONTEXT_MINOR_VERSION_ARB, 4,
 		WGL_CONTEXT_FLAGS_ARB, contextFlags,
-		WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+		WGL_CONTEXT_PROFILE_MASK_ARB, gl_extensions.IsCoreContext ? WGL_CONTEXT_CORE_PROFILE_BIT_ARB : WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
 		0
 	};
 	const int attribs43[] = {
 		WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
 		WGL_CONTEXT_MINOR_VERSION_ARB, 3,
 		WGL_CONTEXT_FLAGS_ARB, contextFlags,
-		WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+		WGL_CONTEXT_PROFILE_MASK_ARB, gl_extensions.IsCoreContext ? WGL_CONTEXT_CORE_PROFILE_BIT_ARB : WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
 		0
 	};
 	const int attribs33[] = {
 		WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
 		WGL_CONTEXT_MINOR_VERSION_ARB, 3,
 		WGL_CONTEXT_FLAGS_ARB, contextFlags,
-		WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+		WGL_CONTEXT_PROFILE_MASK_ARB, gl_extensions.IsCoreContext ? WGL_CONTEXT_CORE_PROFILE_BIT_ARB : WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
 		0
 	};
 
@@ -316,6 +315,9 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 		*error_message = "Failed to re-initialize GLEW.";
 		return false;
 	}
+	// Unfortunately, glew will generate an invalid enum error, ignore.
+	if (gl_extensions.IsCoreContext)
+		glGetError();
 
 	if (!m_hrc) {
 		*error_message = "No m_hrc";
@@ -364,6 +366,7 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
+	CHECK_GL_ERROR_IF_DEBUG();
 	return true;												// Success
 }
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1292,8 +1292,4 @@ namespace MainWindow {
 		}
 		return FALSE;
 	}
-
-	void ChangeMenu() {
-		SetIngameMenuItemStates(GetMenu(GetHWND()), UISTATE_INGAME);
-	}
 }

--- a/Windows/MainWindowMenu.h
+++ b/Windows/MainWindowMenu.h
@@ -10,5 +10,4 @@ namespace MainWindow {
 	void BrowseAndBoot(std::string defaultPath, bool browseDirectory = false);
 	void BrowseAndBootDone();
 	void setTexScalingMultiplier(int level);
-	void ChangeMenu();
 }

--- a/ext/native/gfx/gl_debug_log.cpp
+++ b/ext/native/gfx/gl_debug_log.cpp
@@ -11,6 +11,7 @@ std::string GLEnumToString(uint16_t value) {
 	case GL_UNSIGNED_SHORT_4_4_4_4: return "GL_UNSIGNED_SHORT_4_4_4_4";
 	case GL_UNSIGNED_SHORT_5_5_5_1: return "GL_UNSIGNED_SHORT_5_5_5_1";
 	case GL_UNSIGNED_SHORT_5_6_5: return "GL_UNSIGNED_SHORT_5_6_5";
+	case GL_UNSIGNED_BYTE: return "GL_UNSIGNED_BYTE";
 	case GL_RGBA: return "GL_RGBA";
 	case GL_RGB: return "GL_RGB";
 #if !defined(USING_GLES2)


### PR DESCRIPTION
When adding `SetGLCoreContext(true);` to the top of `WindowsGLContext::Init` I'm seeing a performance improvement in some games.  I only noticed it after removing the incorrect `GLCheckExtensions();` call, but didn't check again without.

This is just minor tweaks, mostly logging related.

Also fixes the vertexjit func disabled in a272a4ee3f4dfd39333ada81879ad65eb0947b64.

-[Unknown]