### PR TITLE
Fix crash on resize due to overridden property

### DIFF
--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -88,7 +88,6 @@ static const D3DVERTEXELEMENT9 TransformedVertexElements[] = {
 DrawEngineDX9::DrawEngineDX9(Draw::DrawContext *draw)
 	: decodedVerts_(0),
 		prevPrim_(GE_PRIM_INVALID),
-		lastVType_(-1),
 		shaderManager_(0),
 		textureCache_(0),
 		framebufferManager_(0),

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -187,8 +187,6 @@ private:
 	IndexGenerator indexGen;
 	int decodedVerts_;
 	GEPrimitiveType prevPrim_;
-
-	u32 lastVType_;
 	
 	TransformedVertex *transformed;
 	TransformedVertex *transformedExpanded;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -115,11 +115,9 @@ enum {
 
 enum { VAI_KILL_AGE = 120, VAI_UNRELIABLE_KILL_AGE = 240, VAI_UNRELIABLE_KILL_MAX = 4 };
 
-
 DrawEngineGLES::DrawEngineGLES()
 	: decodedVerts_(0),
 		prevPrim_(GE_PRIM_INVALID),
-		lastVType_(-1),
 		shaderManager_(nullptr),
 		textureCache_(nullptr),
 		framebufferManager_(nullptr),

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -197,8 +197,6 @@ private:
 	int decodedVerts_;
 	GEPrimitiveType prevPrim_;
 
-	u32 lastVType_;
-
 	TransformedVertex *transformed;
 	TransformedVertex *transformedExpanded;
 


### PR DESCRIPTION
Oops.  Saw this in Brave Story when swapping between full screen and windowed rapidly.

-[Unknown]