### PR TITLE
Cancel remote disc streaming connects faster

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1175,8 +1175,10 @@ UI::EventReturn GameSettingsScreen::OnSysInfo(UI::EventParams &e) {
 
 void DeveloperToolsScreen::CreateViews() {
 	using namespace UI;
-	root_ = new ScrollView(ORIENT_VERTICAL);
-	root_->SetTag("DevToolsSettings");
+	root_ = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, FILL_PARENT));
+	ScrollView *settingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
+	settingsScroll->SetTag("DevToolsSettings");
+	root_->Add(settingsScroll);
 
 	I18NCategory *di = GetI18NCategory("Dialog");
 	I18NCategory *dev = GetI18NCategory("Developer");
@@ -1184,7 +1186,9 @@ void DeveloperToolsScreen::CreateViews() {
 	I18NCategory *a = GetI18NCategory("Audio");
 	I18NCategory *sy = GetI18NCategory("System");
 
-	LinearLayout *list = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
+	AddStandardBack(root_);
+
+	LinearLayout *list = settingsScroll->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	list->SetSpacing(0);
 	list->Add(new ItemHeader(sy->T("General")));
 
@@ -1227,8 +1231,6 @@ void DeveloperToolsScreen::CreateViews() {
 #if !defined(MOBILE_DEVICE)
 	list->Add(new Choice(dev->T("Create/Open textures.ini file for current game")))->OnClick.Handle(this, &DeveloperToolsScreen::OnOpenTexturesIniFile);
 #endif
-	list->Add(new ItemHeader(""));
-	list->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 }
 
 void DeveloperToolsScreen::onFinish(DialogResult result) {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -211,8 +211,8 @@ static bool FindServer(std::string &resultHost, int &resultPort) {
 		}
 	}
 
-	//don't scan if in manual mode
-	if (g_Config.bRemoteISOManual) {
+	// Don't scan if in manual mode.
+	if (g_Config.bRemoteISOManual || scanCancelled) {
 		return false;
 	}
 

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -85,12 +85,15 @@ protected:
 	std::vector<std::string> games_;
 };
 
-class RemoteISOSettingsScreen : public UIScreenWithBackground {
+class RemoteISOSettingsScreen : public UIDialogScreenWithBackground {
 public:
+	RemoteISOSettingsScreen();
 
 protected:
+	void update() override;
 	void CreateViews() override;
 
 	UI::EventReturn OnChangeRemoteISOSubdir(UI::EventParams &e);
 
+	bool serverRunning_ = false;
 };

--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -29,7 +29,7 @@ public:
 	// Inits the sockaddr_in.
 	bool Resolve(const char *host, int port);
 
-	bool Connect(int maxTries = 2, double timeout = 20.0f);
+	bool Connect(int maxTries = 2, double timeout = 20.0f, bool *cancelConnect = nullptr);
 	void Disconnect();
 
 	// Only to be used for bring-up and debugging.


### PR DESCRIPTION
Previously, if you hit cancel, you could wait many seconds for your cancel to register, and the UI would appear to hang.

Now, it checks the flag while connecting, so it cancels much quicker - less than a second always.

This also puts Back in a fixed position at the bottom of the dev tools screen, streaming connect screen, and streaming settings screen.  I left it on the right side in the streaming browse area.

-[Unknown]