### PR TITLE
Video: Enable threads for video decoding

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -458,14 +458,18 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 
 		// Find the decoder for the video stream
 		AVCodec *pCodec = avcodec_find_decoder(m_pCodecCtx->codec_id);
-		if (pCodec == NULL) {
+		if (pCodec == nullptr) {
 			return false;
 		}
 
-		// Open codec
-		if (avcodec_open2(m_pCodecCtx, pCodec, nullptr) < 0) {
-			return false; // Could not open codec
+		AVDictionary *opt = nullptr;
+		av_dict_set(&opt, "threads", "0", 0);
+		int openResult = avcodec_open2(m_pCodecCtx, pCodec, &opt);
+		av_dict_free(&opt);
+		if (openResult < 0) {
+			return false;
 		}
+
 		m_pCodecCtxs[streamNum] = m_pCodecCtx;
 	}
 #endif


### PR DESCRIPTION
Narrowing it down to #8867 really helped.  This was previously getting (accidentally?) enabled by the call to `avformat_find_stream_info()`.  We skip that now, so threads seem to be disabled.  It's definitely using threads before that change.

Weirdly, all that function seems to do related to threads is to disable them for a separate, temporary codec used to detect things about the streams.  Maybe there's some global state that's changed.

See #9262 - this fixes it for me, but want to let @zminhquanz confirm.

Also worth noting: we only call `avformat_find_stream_info()` here.  I'm not sure if Atrac/PMP/recording/etc. might benefit from a similar change.

-[Unknown]