### PR TITLE
Revert "Fix minor glitch with 5xBR effects."

### DIFF
--- a/assets/shaders/5xBR-lv2.fsh
+++ b/assets/shaders/5xBR-lv2.fsh
@@ -96,7 +96,7 @@ void main() {
 
 	vec2 pS  = 1.0 / u_texelDelta.xy;
 	vec2 fp  = fract(v_texcoord0.xy*pS.xy);
-	vec2 TexCoord_0 = v_texcoord0.xy-fp*u_texelDelta.xy;
+	vec2 TexCoord_0 = v_texcoord0.xy-fp*u_pixelDelta.xy;
 	vec2 dx  = vec2(u_texelDelta.x,0.0);
 	vec2 dy  = vec2(0.0,u_texelDelta.y);
 	vec2 y2  = dy + dy; vec2 x2  = dx + dx;

--- a/assets/shaders/5xBR.fsh
+++ b/assets/shaders/5xBR.fsh
@@ -66,7 +66,7 @@ void main(){
 
 	vec2 pS  = 1.0 / u_texelDelta.xy;
 	vec2 fp  = fract(v_texcoord0.xy*pS.xy);
-	vec2 TexCoord_0 = v_texcoord0.xy-fp*u_texelDelta.xy;
+	vec2 TexCoord_0 = v_texcoord0.xy-fp*u_pixelDelta.xy;
 	vec2 dx  = vec2(u_texelDelta.x,0.0);
 	vec2 dy  = vec2(0.0,u_texelDelta.y);
 	vec2 y2  = dy + dy; vec2 x2  = dx + dx;


### PR DESCRIPTION
Sorry, it appears there's a difference / probably a bug / between D3d11 and OGL in what those uniforms passes, that change looked fine in d3d11, but made stuff ugly in ogl, affecting also native psp games:/.
