### PR TITLE
Allow debug logging of frame drops

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -520,6 +520,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("FragmentTestCache", &g_Config.bFragmentTestCache, true, true, true),
 
 	ConfigSetting("GfxDebugOutput", &g_Config.bGfxDebugOutput, false, false, false),
+	ConfigSetting("LogFrameDrops", &g_Config.bLogFrameDrops, false, true, false),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -235,6 +235,7 @@ public:
 	bool bShowDebuggerOnLoad;
 	int iShowFPSCounter;
 
+	bool bLogFrameDrops;
 	bool bShowDebugStats;
 	bool bShowAudioDebug;
 	bool bAudioResampler;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -370,16 +370,9 @@ void Core_UpdateState(CoreState newState) {
 	Core_UpdateSingleStep();
 }
 
-void Core_ForceCollectDebugStats(bool flag) {
-	// Don't set the real flag yet, since it may trigger clearing jit cache.
-	coreCollectDebugStatsForced = flag;
-}
-
 static void Core_UpdateCollectDebugStats(bool flag) {
-	bool newFlag = flag || coreCollectDebugStatsForced;
-
-	if (coreCollectDebugStats != newFlag) {
-		coreCollectDebugStats = newFlag;
+	if (coreCollectDebugStats != flag) {
+		coreCollectDebugStats = flag;
 		mipsr4k.ClearJitCache();
 	}
 }
@@ -534,7 +527,7 @@ void PSP_EndHostFrame() {
 }
 
 void PSP_RunLoopUntil(u64 globalticks) {
-	Core_UpdateCollectDebugStats(g_Config.bShowDebugStats);
+	Core_UpdateCollectDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
 
 	SaveState::Process();
 	if (coreState == CORE_POWERDOWN || coreState == CORE_ERROR) {

--- a/Core/System.h
+++ b/Core/System.h
@@ -98,7 +98,6 @@ enum CoreState
 };
 
 extern bool coreCollectDebugStats;
-void Core_ForceCollectDebugStats(bool flag);
 
 extern volatile CoreState coreState;
 extern volatile bool coreStatePending;

--- a/Core/System.h
+++ b/Core/System.h
@@ -97,6 +97,9 @@ enum CoreState
 	CORE_ERROR,
 };
 
+extern bool coreCollectDebugStats;
+void Core_ForceCollectDebugStats(bool flag);
+
 extern volatile CoreState coreState;
 extern volatile bool coreStatePending;
 void Core_UpdateState(CoreState newState);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -848,13 +848,13 @@ u32 GPUCommon::Break(int mode) {
 }
 
 void GPUCommon::NotifySteppingEnter() {
-	if (g_Config.bShowDebugStats) {
+	if (coreCollectDebugStats) {
 		time_update();
 		timeSteppingStarted_ = time_now_d();
 	}
 }
 void GPUCommon::NotifySteppingExit() {
-	if (g_Config.bShowDebugStats) {
+	if (coreCollectDebugStats) {
 		if (timeSteppingStarted_ <= 0.0) {
 			ERROR_LOG(G3D, "Mismatched stepping enter/exit.");
 		}
@@ -867,7 +867,7 @@ void GPUCommon::NotifySteppingExit() {
 bool GPUCommon::InterpretList(DisplayList &list) {
 	// Initialized to avoid a race condition with bShowDebugStats changing.
 	double start = 0.0;
-	if (g_Config.bShowDebugStats) {
+	if (coreCollectDebugStats) {
 		time_update();
 		start = time_now_d();
 	}
@@ -936,7 +936,7 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 
 	list.offsetAddr = gstate_c.offsetAddr;
 
-	if (g_Config.bShowDebugStats) {
+	if (coreCollectDebugStats) {
 		time_update();
 		double total = time_now_d() - start - timeSpentStepping_;
 		hleSetSteppingTime(timeSpentStepping_);
@@ -984,7 +984,7 @@ void GPUCommon::UpdatePC(u32 currentPC, u32 newPC) {
 	cyclesExecuted += 2 * executed;
 	cycleLastPC = newPC;
 
-	if (g_Config.bShowDebugStats) {
+	if (coreCollectDebugStats) {
 		gpuStats.otherGPUCycles += 2 * executed;
 		gpuStats.gpuCommandsAtCallLevel[std::min(currentList->stackptr, 3)] += executed;
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1225,6 +1225,7 @@ void DeveloperToolsScreen::CreateViews() {
 #endif
 
 	list->Add(new CheckBox(&g_Config.bEnableLogging, dev->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
+	list->Add(new CheckBox(&g_Config.bLogFrameDrops, dev->T("Log Dropped Frame Statistics")));
 	list->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLogConfig);
 	list->Add(new ItemHeader(dev->T("Language")));
 	list->Add(new Choice(dev->T("Load language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoadLanguageIni);


### PR DESCRIPTION
Sometimes it's not obvious that frames are occasionally dropping when looking at an FPS counter, especially when frame timing tries to "catch up" for missed frames.  But dropped frames can affect sound, graphics, and even input - of course.

This adds a developer tools setting to log dropped frames with debug stats for that frame.

It definitely happens during FPS transitions, but I think it's correctly a drop: this logs when we passed `lastFrameTime + scaledTimestep`, simply enough.

-[Unknown]