### PR TITLE
Core: Reduce frame idle delay

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -596,10 +596,9 @@ static void DoFrameIdleTiming() {
 
 	// If we have over at least a vblank of spare time, maintain at least 30fps in delay.
 	// This prevents fast forward during loading screens.
-	const double thresh = lastFrameTime + (numVBlanksSinceFlip - 1) * scaledVblank;
-	if (numVBlanksSinceFlip >= 2 && time_now_d() < thresh) {
-		// Give a little extra wiggle room in case the next vblank does more work.
-		const double goal = lastFrameTime + numVBlanksSinceFlip * scaledVblank - 0.001;
+	// Give a little extra wiggle room in case the next vblank does more work.
+	const double goal = lastFrameTime + (numVBlanksSinceFlip - 1) * scaledVblank - 0.001;
+	if (numVBlanksSinceFlip >= 2 && time_now_d() < goal) {
 		while (time_now_d() < goal) {
 #ifdef _WIN32
 			sleep_ms(1);


### PR DESCRIPTION
Otherwise we only have a single vblank of time left.  Sometimes that's not enough - often this is while loading, before a bunch of new drawing.

Effectively, this change makes us only sleep one vblank at a time (before we would sometimes sleep two.)  Sound in games that don't draw while playing music still works fine (i.e. Brave Story - #5947.)

-[Unknown]