### PR TITLE
UI: Skip game bg lookup without game

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -483,7 +483,7 @@ static void DoFrameDropLogging(float scaledTimestep) {
 
 		char stats[4096];
 		__DisplayGetDebugStats(stats, sizeof(stats));
-		NOTICE_LOG(HLE, "Dropping frames - budget = %.2fms / %.1ffps, actual = %.2fms (+%.2fms) / %.1ffps\n%s", scaledTimestep * 1000.0, 1.0 / scaledTimestep, actualTimestep * 1000.0, (actualTimestep - scaledTimestep) * 1000.0, 1.0 / actualTimestep, stats);
+		NOTICE_LOG(SCEDISPLAY, "Dropping frames - budget = %.2fms / %.1ffps, actual = %.2fms (+%.2fms) / %.1ffps\n%s", scaledTimestep * 1000.0, 1.0 / scaledTimestep, actualTimestep * 1000.0, (actualTimestep - scaledTimestep) * 1000.0, 1.0 / actualTimestep, stats);
 	} else {
 		gpuStats.ResetFrame();
 		kernelStats.ResetFrame();

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -463,6 +463,7 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 		}
 
 		AVDictionary *opt = nullptr;
+		// Allow ffmpeg to use any number of threads it wants.  Without this, it doesn't use threads.
 		av_dict_set(&opt, "threads", "0", 0);
 		int openResult = avcodec_open2(m_pCodecCtx, pCodec, &opt);
 		av_dict_free(&opt);

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -744,7 +744,7 @@ void GameInfoCache::WaitUntilDone(GameInfo *info) {
 
 // Runs on the main thread.
 GameInfo *GameInfoCache::GetInfo(Draw::DrawContext *draw, const std::string &gamePath, int wantFlags) {
-	GameInfo *info = 0;
+	GameInfo *info = nullptr;
 
 	auto iter = info_.find(gamePath);
 	if (iter != info_.end()) {

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -49,7 +49,7 @@ GameScreen::~GameScreen() {
 void GameScreen::CreateViews() {
 	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 
-	if (!info->id.empty())
+	if (info && !info->id.empty())
 		saveDirs = info->GetSaveDataDirectories(); // Get's very heavy, let's not do it in update()
 
 	I18NCategory *di = GetI18NCategory("Dialog");
@@ -155,9 +155,11 @@ UI::Choice *GameScreen::AddOtherChoice(UI::Choice *choice) {
 	return choice;
 }
 
-UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)
-{
-	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_,0);
+UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e) {
+	GameInfo *info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);
+	if (!info) {
+		return UI::EVENT_SKIPPED;
+	}
 	g_Config.createGameConfig(info->id);
 	g_Config.saveGameConfig(info->id);
 	info->hasConfig = true;
@@ -166,11 +168,12 @@ UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e)
 	return UI::EVENT_DONE;
 }
 
-void GameScreen::CallbackDeleteConfig(bool yes)
-{
-	if (yes)
-	{
-		GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
+void GameScreen::CallbackDeleteConfig(bool yes) {
+	if (yes) {
+		GameInfo *info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);
+		if (!info) {
+			return;
+		}
 		g_Config.deleteGameConfig(info->id);
 		info->hasConfig = false;
 		screenManager()->RecreateAllViews();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -111,8 +111,6 @@ bool IsBackendSupportHWTess() {
 }
 
 void GameSettingsScreen::CreateViews() {
-	GameInfo *info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
-
 	if (editThenRestore_) {
 		g_Config.loadGameConfig(gameID_);
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -102,31 +102,31 @@ void DrawBackground(UIContext &dc, float alpha = 1.0f) {
 }
 
 void DrawGameBackground(UIContext &dc, const std::string &gamePath) {
-	GameInfo *ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), gamePath, GAMEINFO_WANTBG);
+	GameInfo *ginfo = nullptr;
+	if (gamePath.size())
+		ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), gamePath, GAMEINFO_WANTBG);
 	dc.Flush();
 
-	if (ginfo) {
-		bool hasPic = false;
-		double loadTime;
-		if (ginfo->pic1Texture) {
-			dc.GetDrawContext()->BindTexture(0, ginfo->pic1Texture->GetTexture());
-			loadTime = ginfo->timePic1WasLoaded;
-			hasPic = true;
-		} else if (ginfo->pic0Texture) {
-			dc.GetDrawContext()->BindTexture(0, ginfo->pic0Texture->GetTexture());
-			loadTime = ginfo->timePic0WasLoaded;
-			hasPic = true;
-		}
-		if (hasPic) {
-			uint32_t color = whiteAlpha(ease((time_now_d() - loadTime) * 3)) & 0xFFc0c0c0;
-			dc.Draw()->DrawTexRect(dc.GetBounds(), 0,0,1,1, color);
-			dc.Flush();
-			dc.RebindTexture();
-		} else {
-			::DrawBackground(dc, 1.0f);
-			dc.RebindTexture();
-			dc.Flush();
-		}
+	bool hasPic = false;
+	double loadTime;
+	if (ginfo && ginfo->pic1Texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic1Texture->GetTexture());
+		loadTime = ginfo->timePic1WasLoaded;
+		hasPic = true;
+	} else if (ginfo && ginfo->pic0Texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic0Texture->GetTexture());
+		loadTime = ginfo->timePic0WasLoaded;
+		hasPic = true;
+	}
+	if (hasPic) {
+		uint32_t color = whiteAlpha(ease((time_now_d() - loadTime) * 3)) & 0xFFc0c0c0;
+		dc.Draw()->DrawTexRect(dc.GetBounds(), 0,0,1,1, color);
+		dc.Flush();
+		dc.RebindTexture();
+	} else {
+		::DrawBackground(dc, 1.0f);
+		dc.RebindTexture();
+		dc.Flush();
 	}
 }
 


### PR DESCRIPTION
This avoids trying to identify a file without a name.  Mostly just fixes a spurious error log message.

-[Unknown]