### PR TITLE
Texcache: Fix "reuse changed textures"

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1486,6 +1486,9 @@ bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 				secondCacheSizeEstimate_ += EstimateTexMemoryUsage(entry);
 				// Is this wise? We simply copy the entry.
 				secondCache_[secondKey].reset(new TexCacheEntry(*entry));
+
+				// Make sure we don't delete the texture we just copied.
+				entry->texturePtr = nullptr;
 				doDelete = false;
 			}
 		}


### PR DESCRIPTION
Broken by 9876365, which stopped generating new texture names/ptrs.

-[Unknown]