### PR TITLE
UI: Refactor game icon/bg loading

### DIFF
--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -202,15 +202,15 @@ void GameScreen::update() {
 
 	if (tvTitle_)
 		tvTitle_->SetText(info->GetTitle() + " (" + info->id + ")");
-	if (info->iconTexture && texvGameIcon_)	{
-		texvGameIcon_->SetTexture(info->iconTexture->GetTexture());
+	if (info->icon.texture && texvGameIcon_) {
+		texvGameIcon_->SetTexture(info->icon.texture->GetTexture());
 		// Fade the icon with the background.
-		double loadTime = info->timeIconWasLoaded;
-		if (info->pic1Texture) {
-			loadTime = std::max(loadTime, info->timePic1WasLoaded);
+		double loadTime = info->icon.timeLoaded;
+		if (info->pic1.texture) {
+			loadTime = std::max(loadTime, info->pic1.timeLoaded);
 		}
-		if (info->pic0Texture) {
-			loadTime = std::max(loadTime, info->timePic0WasLoaded);
+		if (info->pic0.texture) {
+			loadTime = std::max(loadTime, info->pic0.timeLoaded);
 		}
 		uint32_t color = whiteAlpha(ease((time_now_d() - loadTime) * 3));
 		texvGameIcon_->SetColor(color);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -180,8 +180,8 @@ void GameButton::Draw(UIContext &dc) {
 	u32 color = 0, shadowColor = 0;
 	using namespace UI;
 
-	if (ginfo->iconTexture) {
-		texture = ginfo->iconTexture->GetTexture();
+	if (ginfo->icon.texture) {
+		texture = ginfo->icon.texture->GetTexture();
 	}
 
 	int x = bounds_.x;
@@ -207,8 +207,8 @@ void GameButton::Draw(UIContext &dc) {
 	}
 
 	if (texture) {
-		color = whiteAlpha(ease((time_now_d() - ginfo->timeIconWasLoaded) * 2));
-		shadowColor = blackAlpha(ease((time_now_d() - ginfo->timeIconWasLoaded) * 2));
+		color = whiteAlpha(ease((time_now_d() - ginfo->icon.timeLoaded) * 2));
+		shadowColor = blackAlpha(ease((time_now_d() - ginfo->icon.timeLoaded) * 2));
 		float tw = texture->Width();
 		float th = texture->Height();
 
@@ -1017,17 +1017,17 @@ bool MainScreen::DrawBackgroundFor(UIContext &dc, const std::string &gamePath, f
 		dc.RebindTexture();
 
 		// Let's not bother if there's no picture.
-		if (!ginfo || (!ginfo->pic1Texture && !ginfo->pic0Texture)) {
+		if (!ginfo || (!ginfo->pic1.texture && !ginfo->pic0.texture)) {
 			return false;
 		}
 	} else {
 		return false;
 	}
 
-	if (ginfo->pic1Texture) {
-		dc.GetDrawContext()->BindTexture(0, ginfo->pic1Texture->GetTexture());
-	} else if (ginfo->pic0Texture) {
-		dc.GetDrawContext()->BindTexture(0, ginfo->pic0Texture->GetTexture());
+	if (ginfo->pic1.texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic1.texture->GetTexture());
+	} else if (ginfo->pic0.texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic0.texture->GetTexture());
 	}
 
 	uint32_t color = whiteAlpha(ease(progress)) & 0xFFc0c0c0;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -109,13 +109,13 @@ void DrawGameBackground(UIContext &dc, const std::string &gamePath) {
 
 	bool hasPic = false;
 	double loadTime;
-	if (ginfo && ginfo->pic1Texture) {
-		dc.GetDrawContext()->BindTexture(0, ginfo->pic1Texture->GetTexture());
-		loadTime = ginfo->timePic1WasLoaded;
+	if (ginfo && ginfo->pic1.texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic1.texture->GetTexture());
+		loadTime = ginfo->pic1.timeLoaded;
 		hasPic = true;
-	} else if (ginfo && ginfo->pic0Texture) {
-		dc.GetDrawContext()->BindTexture(0, ginfo->pic0Texture->GetTexture());
-		loadTime = ginfo->timePic0WasLoaded;
+	} else if (ginfo && ginfo->pic0.texture) {
+		dc.GetDrawContext()->BindTexture(0, ginfo->pic0.texture->GetTexture());
+		loadTime = ginfo->pic0.timeLoaded;
 		hasPic = true;
 	}
 	if (hasPic) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -80,8 +80,8 @@ public:
 			std::string savedata_detail = ginfo->paramSFO.GetValueString("SAVEDATA_DETAIL");
 			std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
 
-			if (ginfo->iconTexture) {
-				toprow->Add(new TextureView(ginfo->iconTexture->GetTexture(), IS_FIXED, new LinearLayoutParams(Margins(10, 5))));
+			if (ginfo->icon.texture) {
+				toprow->Add(new TextureView(ginfo->icon.texture->GetTexture(), IS_FIXED, new LinearLayoutParams(Margins(10, 5))));
 			}
 			LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f));
 			topright->SetSpacing(1.0f);
@@ -159,8 +159,8 @@ void SavedataButton::Draw(UIContext &dc) {
 	u32 color = 0, shadowColor = 0;
 	using namespace UI;
 
-	if (ginfo->iconTexture) {
-		texture = ginfo->iconTexture->GetTexture();
+	if (ginfo->icon.texture) {
+		texture = ginfo->icon.texture->GetTexture();
 	}
 
 	int x = bounds_.x;
@@ -184,8 +184,8 @@ void SavedataButton::Draw(UIContext &dc) {
 	dc.Draw()->Flush();
 
 	if (texture) {
-		color = whiteAlpha(ease((time_now_d() - ginfo->timeIconWasLoaded) * 2));
-		shadowColor = blackAlpha(ease((time_now_d() - ginfo->timeIconWasLoaded) * 2));
+		color = whiteAlpha(ease((time_now_d() - ginfo->icon.timeLoaded) * 2));
+		shadowColor = blackAlpha(ease((time_now_d() - ginfo->icon.timeLoaded) * 2));
 		float tw = texture->Width();
 		float th = texture->Height();
 


### PR DESCRIPTION
This also default-initializes the atomic flags, which seems to fix a race condition I was sometimes experiencing with missing icons.  b0bd7e3 removed the custom atomic thing, which had an initializer baked in.

Also switched to a struct to simplify a few operations that run against each icon/pic0/pic1.

-[Unknown]