### PR TITLE
Refresh bloomHackEnable_ also on resolution change.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013- PPSSPP Project.
+﻿// Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -941,6 +941,7 @@ UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 	if (g_Config.iAndroidHwScale == 1) {
 		RecreateActivity();
 	}
+	bloomHackEnable_ = g_Config.iInternalResolution != 1;
 	Reporting::UpdateConfig();
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
Should help with confusion like #9508. Althrough in that case I think the user wanted to get more performance from it when using x1 render res which would of course not do anything, any performance improvements from this hack would only be measurable at very high render res and only in games which use a lot of affected effects.