### PR TITLE
Remove the "Disable alpha test" setting. It breaks too many things.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -777,12 +777,6 @@ static ConfigSetting debuggerSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting speedHackSettings[] = {
-	ReportedConfigSetting("DisableAlphaTest", &g_Config.bDisableAlphaTest, false, true, true),
-
-	ConfigSetting(false),
-};
-
 static ConfigSetting jitSettings[] = {
 	ReportedConfigSetting("DiscardRegsOnJRRA", &g_Config.bDiscardRegsOnJRRA, false, false),
 
@@ -839,7 +833,6 @@ static ConfigSectionSettings sections[] = {
 	{"Network", networkSettings},
 	{"SystemParam", systemParamSettings},
 	{"Debugger", debuggerSettings},
-	{"SpeedHacks", speedHackSettings},
 	{"JIT", jitSettings},
 	{"Upgrade", upgradeSettings},
 	{"Theme", themeSettings},

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -395,10 +395,6 @@ public:
 	float fXInputAnalogSensitivity;
 
 	float fAnalogLimiterDeadzone;
-	// GLES backend-specific hacks. Not saved to the ini file, do not add checkboxes. Will be made into
-	// proper options when good enough.
-	bool bDisableAlphaTest;  // Helps PowerVR performance immensely, breaks some graphics
-	// End GLES hacks.
 
 	// Use the hardware scaler to scale up the image to save fillrate. Similar to Windows' window size, really.
 	int iAndroidHwScale;  // 0 = device resolution. 1 = 480x272 (extended to correct aspect), 2 = 960x544 etc.

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -225,7 +225,7 @@ void ComputeFragmentShaderID(ShaderID *id_out) {
 		bool isModeThrough = gstate.isModeThrough();
 		bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !isModeThrough;
 		bool enableFog = gstate.isFogEnabled() && !isModeThrough;
-		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue() && !g_Config.bDisableAlphaTest;
+		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
 		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
 		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -405,14 +405,6 @@ void GameSettingsScreen::CreateViews() {
 		return UI::EVENT_CONTINUE;
 	});
 
-	CheckBox *alphaHack = graphicsSettings->Add(new CheckBox(&g_Config.bDisableAlphaTest, gr->T("Disable Alpha Test (PowerVR speedup)")));
-	alphaHack->OnClick.Add([=](EventParams &e) {
-		settingInfo_->Show(gr->T("DisableAlphaTest Tip", "Faster by sometimes drawing ugly boxes around things"), e.v);
-		return UI::EVENT_CONTINUE;
-	});
-	alphaHack->OnClick.Handle(this, &GameSettingsScreen::OnShaderChange);
-	alphaHack->SetDisabledPtr(&g_Config.bSoftwareRendering);
-
 	CheckBox *stencilTest = graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gr->T("Disable Stencil Test")));
 	stencilTest->SetDisabledPtr(&g_Config.bSoftwareRendering);
 


### PR DESCRIPTION
The  performance benefits in a few games on older hardware are not worth it, we are able to automatically remove redundant alpha test in many cases now.