### PR TITLE
Core: Clear debug stats on frame start

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -457,8 +457,6 @@ void __DisplayGetDebugStats(char *stats, size_t bufsize) {
 		kernelStats.summedSlowestSyscallName ? kernelStats.summedSlowestSyscallName : "(none)",
 		kernelStats.summedSlowestSyscallTime * 1000.0f,
 		statbuf);
-	gpuStats.ResetFrame();
-	kernelStats.ResetFrame();
 }
 
 enum {
@@ -484,9 +482,6 @@ static void DoFrameDropLogging(float scaledTimestep) {
 		char stats[4096];
 		__DisplayGetDebugStats(stats, sizeof(stats));
 		NOTICE_LOG(SCEDISPLAY, "Dropping frames - budget = %.2fms / %.1ffps, actual = %.2fms (+%.2fms) / %.1ffps\n%s", scaledTimestep * 1000.0, 1.0 / scaledTimestep, actualTimestep * 1000.0, (actualTimestep - scaledTimestep) * 1000.0, 1.0 / actualTimestep, stats);
-	} else {
-		gpuStats.ResetFrame();
-		kernelStats.ResetFrame();
 	}
 }
 
@@ -684,9 +679,9 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 		}
 
 		// Setting CORE_NEXTFRAME causes a swap.
-		// Check first though, might've just quit / been paused.
 		const bool fbReallyDirty = gpu->FramebufferReallyDirty();
 		if (fbReallyDirty || noRecentFlip || postEffectRequiresFlip) {
+			// Check first though, might've just quit / been paused.
 			if (coreState == CORE_RUNNING) {
 				coreState = CORE_NEXTFRAME;
 				gpu->CopyDisplayToOutput();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -370,11 +370,14 @@ void Core_UpdateState(CoreState newState) {
 	Core_UpdateSingleStep();
 }
 
-static void Core_UpdateCollectDebugStats(bool flag) {
+static void Core_UpdateDebugStats(bool flag) {
 	if (coreCollectDebugStats != flag) {
 		coreCollectDebugStats = flag;
 		mipsr4k.ClearJitCache();
 	}
+
+	kernelStats.ResetFrame();
+	gpuStats.ResetFrame();
 }
 
 void System_Wake() {
@@ -527,7 +530,7 @@ void PSP_EndHostFrame() {
 }
 
 void PSP_RunLoopUntil(u64 globalticks) {
-	Core_UpdateCollectDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
+	Core_UpdateDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
 
 	SaveState::Process();
 	if (coreState == CORE_POWERDOWN || coreState == CORE_ERROR) {


### PR DESCRIPTION
This way we can log drops and debug stats at the same time - oops.

`PSP_RunLoopUntil` is only meant to be called once per frame, although /technically/ it may not necessarily be.  I think this is a relatively good place, though, as it starts the stats fresh.

-[Unknown]