### PR TITLE
Fix framebuffer size flopping back and forth

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1532,6 +1532,10 @@ void FramebufferManagerCommon::NotifyBlockTransferAfter(u32 dstBasePtr, int dstS
 					// The buffer isn't big enough, and we have a clear hint of size.  Resize.
 					// This happens in Valkyrie Profile when uploading video at the ending.
 					ResizeFramebufFBO(dstBuffer, dstWidth, dstHeight, false, true);
+					// Make sure we don't flop back and forth.
+					dstBuffer->newWidth = std::max(dstWidth, (int)dstBuffer->width);
+					dstBuffer->newHeight = std::max(dstHeight, (int)dstBuffer->height);
+					dstBuffer->lastFrameNewSize = gpuStats.numFlips;
 				}
 				DrawPixels(dstBuffer, static_cast<int>(dstX * dstXFactor), dstY, srcBase, dstBuffer->format, static_cast<int>(srcStride * dstXFactor), static_cast<int>(dstWidth * dstXFactor), dstHeight);
 				SetColorUpdated(dstBuffer, skipDrawReason);

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -334,7 +334,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 			// Keep track, but this isn't really used.
 			vfb->z_stride = params.z_stride;
 			// Heuristic: In throughmode, a higher height could be used.  Let's avoid shrinking the buffer.
-			if (params.isModeThrough && (int)vfb->width < params.fb_stride) {
+			if (params.isModeThrough && (int)vfb->width <= params.fb_stride) {
 				vfb->width = std::max((int)vfb->width, drawing_width);
 				vfb->height = std::max((int)vfb->height, drawing_height);
 			} else {


### PR DESCRIPTION
This avoids a performance regression in God of War caused by #8867.

Just reusing the existing tracking to make sure we don't flop sizes of framebuffers back and forth.  Still renders the ending video of Valkyrie Profile correctly (although it still crashes at the end because the mpeg is timed inaccurately.)

-[Unknown]