### PR TITLE
UI: Respect the pause button display setting

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -609,14 +609,12 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("ComboKey3Mapping", &g_Config.iCombokey3, 0, true, true),
 	ConfigSetting("ComboKey4Mapping", &g_Config.iCombokey4, 0, true, true),
 
-#if !defined(IOS)
 #if defined(_WIN32)
 	// A win32 user seeing touch controls is likely using PPSSPP on a tablet. There it makes
 	// sense to default this to on.
 	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, true, true, true),
 #else
 	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, false, true, true),
-#endif
 #endif
 #if defined(USING_WIN_UI)
 	ConfigSetting("IgnoreWindowsKey", &g_Config.bIgnoreWindowsKey, false, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -378,9 +378,8 @@ public:
 	int iCombokey3;
 	int iCombokey4;
 
-#if !defined(IOS)
+	// Ignored on iOS and other platforms that lack pause.
 	bool bShowTouchPause;
-#endif
 
 	bool bHapticFeedback;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -524,16 +524,16 @@ void GameSettingsScreen::CreateViews() {
 
 		// On non iOS systems, offer to let the user see this button.
 		// Some Windows touch devices don't have a back button or other button to call up the menu.
-#if !defined(IOS)
-		CheckBox *enablePauseBtn = controlsSettings->Add(new CheckBox(&g_Config.bShowTouchPause, co->T("Show Touch Pause Menu Button")));
+		if (System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON)) {
+			CheckBox *enablePauseBtn = controlsSettings->Add(new CheckBox(&g_Config.bShowTouchPause, co->T("Show Touch Pause Menu Button")));
 
-		// Don't allow the user to disable it once in-game, so they can't lock themselves out of the menu.
-		if (!PSP_IsInited()) {
-			enablePauseBtn->SetEnabledPtr(&g_Config.bShowTouchControls);
-		} else {
-			enablePauseBtn->SetEnabled(false);
+			// Don't allow the user to disable it once in-game, so they can't lock themselves out of the menu.
+			if (!PSP_IsInited()) {
+				enablePauseBtn->SetEnabledPtr(&g_Config.bShowTouchControls);
+			} else {
+				enablePauseBtn->SetEnabled(false);
+			}
 		}
-#endif
 
 		CheckBox *disableDiags = controlsSettings->Add(new CheckBox(&g_Config.bDisableDpadDiagonals, co->T("Disable D-Pad diagonals (4-way touch)")));
 		disableDiags->SetEnabledPtr(&g_Config.bShowTouchControls);

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -628,7 +628,7 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 		const int stickBg = g_Config.iTouchButtonStyle ? I_STICK_BG_LINE : I_STICK_BG;
 		static const int comboKeyImages[5] = { I_1, I_2, I_3, I_4, I_5 };
 
-		if (!System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON)) {
+		if (!System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON) || g_Config.bShowTouchPause) {
 			root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 		}
 
@@ -682,7 +682,7 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 	}
 	else {
 		// If there's no hardware back button (or ESC key), add a soft button.
-		if (!System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON)) {
+		if (!System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON) || g_Config.bShowTouchPause) {
 			root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
 		}
 	}

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -113,7 +113,7 @@ XinputDevice::XinputDevice() {
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(check_delay); ++i) {
-		check_delay[i] = i;
+		check_delay[i] = (int)i;
 	}
 }
 


### PR DESCRIPTION
As of 22782b6, the setting stopped working.  It can be useful for Windows touch devices.  Fixes #9609.

-[Unknown]