### PR TITLE
Disable pause button when not using touch.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -413,7 +413,7 @@ static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
-	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, true),
+	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, false),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, true, true),
 
 	ConfigSetting(false),
@@ -612,9 +612,9 @@ static ConfigSetting controlSettings[] = {
 #if defined(_WIN32)
 	// A win32 user seeing touch controls is likely using PPSSPP on a tablet. There it makes
 	// sense to default this to on.
-	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, true, true, true),
+	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, true, true, false),
 #else
-	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, false, true, true),
+	ConfigSetting("ShowTouchPause", &g_Config.bShowTouchPause, false, true, false),
 #endif
 #if defined(USING_WIN_UI)
 	ConfigSetting("IgnoreWindowsKey", &g_Config.bIgnoreWindowsKey, false, true, true),

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -680,12 +680,6 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 		if (g_Config.bShowComboKey4)
 			root->Add(new ComboKey(g_Config.iCombokey4, roundImage, comboKeyImages[4], combo4_key_scale, new AnchorLayoutParams(combo4_key_X, combo4_key_Y, NONE, NONE, true)));
 	}
-	else {
-		// If there's no hardware back button (or ESC key), add a soft button.
-		if (!System_GetPropertyInt(SYSPROP_HAS_BACK_BUTTON) || g_Config.bShowTouchPause) {
-			root->Add(new BoolButton(pause, roundImage, I_ARROW, 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, true)))->SetAngle(90);
-		}
-	}
 
 	return root;
 }


### PR DESCRIPTION
 Currently it displays on all windows platforms by default, even without using touch which seems bad.

Also remove per-game status from some settings which shouldn't be per-game:
- HideSlowWarnings,
- ShowTouchPause.

 I think if the user has a device which is too slow and still get's annoyed by a message which runs for a short time, once per ppsspp instance only after getting slow down for a few seconds, they might not want to be forced to edit every per-game config.

 Same for showing touch pause which is rather per-device choice, not per-game, also it being per game makes it harder to disable, because from my experience not many users even know we have a game/info screen and per-game config can only be changed there.

 Both of those should at least help #9612.
 I know this isn't first issue about the "slow message", but to voice my opposing opinion I really like that reminder, new users always were confusing that with broken sound and probably forever will.