### PR TITLE
Destroy FBOs only on actual resize

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -140,11 +140,18 @@ void FramebufferManagerCommon::Init() {
 	BeginFrame();
 }
 
-void FramebufferManagerCommon::UpdateSize() {
+bool FramebufferManagerCommon::UpdateSize() {
+	const bool newRender = renderWidth_ != (float)PSP_CoreParameter().renderWidth || renderHeight_ != (float)PSP_CoreParameter().renderHeight;
+	const bool newSettings = bloomHack_ != g_Config.iBloomHack || trueColor_ != g_Config.bTrueColor;
+
 	renderWidth_ = (float)PSP_CoreParameter().renderWidth;
 	renderHeight_ = (float)PSP_CoreParameter().renderHeight;
 	pixelWidth_ = PSP_CoreParameter().pixelWidth;
 	pixelHeight_ = PSP_CoreParameter().pixelHeight;
+	bloomHack_ = g_Config.iBloomHack;
+	trueColor_ = g_Config.bTrueColor;
+
+	return newRender || newSettings;
 }
 
 void FramebufferManagerCommon::BeginFrame() {
@@ -1105,7 +1112,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, u16 w,
 
 	SetRenderSize(vfb);
 
-	bool trueColor = g_Config.bTrueColor;
+	bool trueColor = trueColor_;
 	if (PSP_CoreParameter().compat.flags().Force04154000Download && vfb->fb_address == 0x00154000) {
 		trueColor = true;
 	}
@@ -1660,7 +1667,7 @@ void FramebufferManagerCommon::SetRenderSize(VirtualFramebuffer *vfb) {
 	float renderWidthFactor = renderWidth_ / 480.0f;
 	float renderHeightFactor = renderHeight_ / 272.0f;
 	bool force1x = false;
-	switch (g_Config.iBloomHack) {
+	switch (bloomHack_) {
 	case 1:
 		force1x = vfb->bufferWidth <= 128 || vfb->bufferHeight <= 64;
 		break;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -285,7 +285,7 @@ protected:
 	// Cardboard Settings Calculator
 	void GetCardboardSettings(CardboardSettings *cardboardSettings);
 
-	void UpdateSize();
+	bool UpdateSize();
 	void SetNumExtraFBOs(int num);
 
 	virtual void DisableState() = 0;
@@ -368,6 +368,8 @@ protected:
 	float renderHeight_;
 	int pixelWidth_;
 	int pixelHeight_;
+	int bloomHack_ = 0;
+	bool trueColor_ = false;
 
 	// Used by post-processing shaders
 	std::vector<Draw::Framebuffer *> extraFBOs_;

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -859,7 +859,7 @@ void FramebufferManagerD3D11::PackDepthbuffer(VirtualFramebuffer *vfb, int x, in
 
 void FramebufferManagerD3D11::EndFrame() {
 	if (resized_) {
-		DestroyAllFBOs(false);
+		DestroyAllFBOs();
 
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
 		const ShaderInfo *shaderInfo = 0;
@@ -904,7 +904,7 @@ void FramebufferManagerD3D11::EndFrame() {
 }
 
 void FramebufferManagerD3D11::DeviceLost() {
-	DestroyAllFBOs(false);
+	DestroyAllFBOs();
 	resized_ = false;
 }
 
@@ -927,7 +927,7 @@ std::vector<FramebufferInfo> FramebufferManagerD3D11::GetFramebufferList() {
 	return list;
 }
 
-void FramebufferManagerD3D11::DestroyAllFBOs(bool forceDelete) {
+void FramebufferManagerD3D11::DestroyAllFBOs() {
 	draw_->BindBackbufferAsRenderTarget();
 	currentRenderVfb_ = 0;
 	displayFramebuf_ = 0;

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -859,8 +859,6 @@ void FramebufferManagerD3D11::PackDepthbuffer(VirtualFramebuffer *vfb, int x, in
 
 void FramebufferManagerD3D11::EndFrame() {
 	if (resized_) {
-		DestroyAllFBOs();
-
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
 		const ShaderInfo *shaderInfo = 0;
 		if (g_Config.sPostShaderName != "Off") {
@@ -891,7 +889,10 @@ void FramebufferManagerD3D11::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		UpdateSize();
+		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+			DestroyAllFBOs();
+		}
+
 		// Seems related - if you're ok with numbers all the time, show some more :)
 		if (g_Config.iShowFPSCounter != 0) {
 			ShowScreenResolution();

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -51,7 +51,7 @@ public:
 
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, bool linearFilter) override;
 
-	void DestroyAllFBOs(bool forceDelete);
+	void DestroyAllFBOs();
 
 	void EndFrame();
 	void Resized() override;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -190,7 +190,7 @@ GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 GPU_D3D11::~GPU_D3D11() {
 	delete depalShaderCache_;
-	framebufferManagerD3D11_->DestroyAllFBOs(true);
+	framebufferManagerD3D11_->DestroyAllFBOs();
 	delete framebufferManagerD3D11_;
 	shaderManagerD3D11_->ClearShaders();
 	delete shaderManagerD3D11_;
@@ -750,7 +750,7 @@ void GPU_D3D11::DoState(PointerWrap &p) {
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerD3D11_->DestroyAllFBOs(true);
+		framebufferManagerD3D11_->DestroyAllFBOs();
 		shaderManagerD3D11_->ClearShaders();
 	}
 }

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -752,7 +752,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 
 	void FramebufferManagerDX9::EndFrame() {
 		if (resized_) {
-			DestroyAllFBOs();
 			// Actually, auto mode should be more granular...
 			// Round up to a zoom factor for the render size.
 			int zoom = g_Config.iInternalResolution;
@@ -775,7 +774,9 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 				PSP_CoreParameter().renderHeight = 272 * zoom;
 			}
 
-			UpdateSize();
+			if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+				DestroyAllFBOs();
+			}
 			// Seems related - if you're ok with numbers all the time, show some more :)
 			if (g_Config.iShowFPSCounter != 0) {
 				ShowScreenResolution();

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -752,7 +752,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 
 	void FramebufferManagerDX9::EndFrame() {
 		if (resized_) {
-			DestroyAllFBOs(false);
+			DestroyAllFBOs();
 			// Actually, auto mode should be more granular...
 			// Round up to a zoom factor for the render size.
 			int zoom = g_Config.iInternalResolution;
@@ -785,7 +785,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	void FramebufferManagerDX9::DeviceLost() {
-		DestroyAllFBOs(false);
+		DestroyAllFBOs();
 		resized_ = false;
 	}
 
@@ -821,7 +821,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		}
 	}
 
-	void FramebufferManagerDX9::DestroyAllFBOs(bool forceDelete) {
+	void FramebufferManagerDX9::DestroyAllFBOs() {
 		draw_->BindBackbufferAsRenderTarget();
 		currentRenderVfb_ = 0;
 		displayFramebuf_ = 0;

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -53,7 +53,7 @@ public:
 
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, bool linearFilter) override;
 
-	void DestroyAllFBOs(bool forceDelete);
+	void DestroyAllFBOs();
 
 	void EndFrame();
 	void Resized() override;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -223,7 +223,7 @@ void GPU_DX9::CheckGPUFeatures() {
 }
 
 GPU_DX9::~GPU_DX9() {
-	framebufferManagerDX9_->DestroyAllFBOs(true);
+	framebufferManagerDX9_->DestroyAllFBOs();
 	delete framebufferManagerDX9_;
 	delete textureCache_;
 	shaderManagerDX9_->ClearCache(true);
@@ -690,7 +690,7 @@ void GPU_DX9::DoState(PointerWrap &p) {
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerDX9_->DestroyAllFBOs(true);
+		framebufferManagerDX9_->DestroyAllFBOs();
 		shaderManagerDX9_->ClearCache(true);
 	}
 }

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -1151,7 +1151,7 @@ void FramebufferManagerGLES::EndFrame() {
 	CHECK_GL_ERROR_IF_DEBUG();
 	if (resized_) {
 		// TODO: Only do this if the new size actually changed the renderwidth/height.
-		DestroyAllFBOs(false);
+		DestroyAllFBOs();
 
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
 		const ShaderInfo *shaderInfo = 0;
@@ -1223,7 +1223,7 @@ void FramebufferManagerGLES::EndFrame() {
 }
 
 void FramebufferManagerGLES::DeviceLost() {
-	DestroyAllFBOs(false);
+	DestroyAllFBOs();
 	DestroyDraw2DProgram();
 	resized_ = false;
 }
@@ -1247,7 +1247,7 @@ std::vector<FramebufferInfo> FramebufferManagerGLES::GetFramebufferList() {
 	return list;
 }
 
-void FramebufferManagerGLES::DestroyAllFBOs(bool forceDelete) {
+void FramebufferManagerGLES::DestroyAllFBOs() {
 	CHECK_GL_ERROR_IF_DEBUG();
 	draw_->BindBackbufferAsRenderTarget();
 	currentRenderVfb_ = 0;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -1150,11 +1150,8 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 void FramebufferManagerGLES::EndFrame() {
 	CHECK_GL_ERROR_IF_DEBUG();
 	if (resized_) {
-		// TODO: Only do this if the new size actually changed the renderwidth/height.
-		DestroyAllFBOs();
-
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
-		const ShaderInfo *shaderInfo = 0;
+		const ShaderInfo *shaderInfo = nullptr;
 		if (g_Config.sPostShaderName != "Off") {
 			shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
 		}
@@ -1183,7 +1180,9 @@ void FramebufferManagerGLES::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		UpdateSize();
+		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+			DestroyAllFBOs();
+		}
 
 		resized_ = false;
 #ifdef _WIN32
@@ -1192,7 +1191,6 @@ void FramebufferManagerGLES::EndFrame() {
 			ShowScreenResolution();
 		}
 #endif
-		ClearBuffer();
 		DestroyDraw2DProgram();
 		SetLineWidth();
 	}

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -64,7 +64,7 @@ public:
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, bool linearFilter) override;
 
-	void DestroyAllFBOs(bool forceDelete);
+	void DestroyAllFBOs();
 
 	virtual void Init() override;
 	void EndFrame();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -188,7 +188,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 }
 
 GPU_GLES::~GPU_GLES() {
-	framebufferManagerGL_->DestroyAllFBOs(true);
+	framebufferManagerGL_->DestroyAllFBOs();
 	shaderManagerGL_->ClearCache(true);
 	depalShaderCache_.Clear();
 	fragmentTestCache_.Clear();
@@ -405,7 +405,7 @@ void GPU_GLES::DeviceRestore() {
 void GPU_GLES::ReinitializeInternal() {
 	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManagerGL_->DestroyAllFBOs(true);
+	framebufferManagerGL_->DestroyAllFBOs();
 	framebufferManagerGL_->Resized();
 }
 
@@ -932,7 +932,7 @@ void GPU_GLES::DoState(PointerWrap &p) {
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerGL_->DestroyAllFBOs(true);
+		framebufferManagerGL_->DestroyAllFBOs();
 		shaderManagerGL_->ClearCache(true);
 	}
 }

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -1040,7 +1040,7 @@ void FramebufferManagerVulkan::BeginFrameVulkan() {
 void FramebufferManagerVulkan::EndFrame() {
 	if (resized_) {
 		// TODO: Only do this if the new size actually changed the renderwidth/height.
-		DestroyAllFBOs(false);
+		DestroyAllFBOs();
 
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
 		const ShaderInfo *shaderInfo = 0;
@@ -1101,7 +1101,7 @@ void FramebufferManagerVulkan::EndFrame() {
 void FramebufferManagerVulkan::DeviceLost() {
 	vulkan2D_.DeviceLost();
 
-	DestroyAllFBOs(false);
+	DestroyAllFBOs();
 	DestroyDeviceObjects();
 	resized_ = false;
 }
@@ -1132,7 +1132,7 @@ std::vector<FramebufferInfo> FramebufferManagerVulkan::GetFramebufferList() {
 	return list;
 }
 
-void FramebufferManagerVulkan::DestroyAllFBOs(bool forceDelete) {
+void FramebufferManagerVulkan::DestroyAllFBOs() {
 	currentRenderVfb_ = 0;
 	displayFramebuf_ = 0;
 	prevDisplayFramebuf_ = 0;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -1039,9 +1039,6 @@ void FramebufferManagerVulkan::BeginFrameVulkan() {
 
 void FramebufferManagerVulkan::EndFrame() {
 	if (resized_) {
-		// TODO: Only do this if the new size actually changed the renderwidth/height.
-		DestroyAllFBOs();
-
 		// Check if postprocessing shader is doing upscaling as it requires native resolution
 		const ShaderInfo *shaderInfo = 0;
 		if (g_Config.sPostShaderName != "Off") {
@@ -1073,7 +1070,9 @@ void FramebufferManagerVulkan::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		UpdateSize();
+		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+			DestroyAllFBOs();
+		}
 
 		resized_ = false;
 #ifdef _WIN32
@@ -1082,7 +1081,6 @@ void FramebufferManagerVulkan::EndFrame() {
 			ShowScreenResolution();
 		}
 #endif
-		ClearBuffer();
 	}
 
 	// We flush to memory last requested framebuffer, if any.

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -74,7 +74,7 @@ public:
 	void DrawTexture(VulkanTexture *texture, float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, VkPipeline pipeline, int uvRotation);
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, bool linearFilter) override;
 
-	void DestroyAllFBOs(bool forceDelete);
+	void DestroyAllFBOs();
 
 	virtual void Init() override;
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -157,7 +157,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 }
 
 GPU_Vulkan::~GPU_Vulkan() {
-	framebufferManagerVulkan_->DestroyAllFBOs(true);
+	framebufferManagerVulkan_->DestroyAllFBOs();
 	depalShaderCache_.Clear();
 	delete pipelineManager_;
 	delete shaderManagerVulkan_;
@@ -315,7 +315,7 @@ void GPU_Vulkan::BuildReportingInfo() {
 void GPU_Vulkan::ReinitializeInternal() {
 	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManagerVulkan_->DestroyAllFBOs(true);
+	framebufferManagerVulkan_->DestroyAllFBOs();
 	framebufferManagerVulkan_->Resized();
 }
 
@@ -823,7 +823,7 @@ void GPU_Vulkan::DoState(PointerWrap &p) {
 		depalShaderCache_.Clear();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerVulkan_->DestroyAllFBOs(true);
+		framebufferManagerVulkan_->DestroyAllFBOs();
 		shaderManagerVulkan_->ClearShaders();
 		pipelineManager_->Clear();
 	}


### PR DESCRIPTION
As a side effect, this means going to settings won't reset all FBOs anymore.  The behavior can still be obtained by changing render resolution or rendering mode.

This makes resizing the window faster on Windows (assuming internal resolution stays constant), and resumes quicker from pause.

-[Unknown]