### PR TITLE
SoftGPU: Rasterize triangles in chunks of 4 pixels

### DIFF
--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -599,6 +599,10 @@ public:
 	{
 		return Vec4(x*other.x, y*other.y, z*other.z, w*other.w);
 	}
+	Vec4 operator | (const Vec4 &other) const
+	{
+		return Vec4(x | other.x, y | other.y, z | other.z, w | other.w);
+	}
 	template<typename V>
 	Vec4 operator * (const V& f) const
 	{

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -634,6 +634,12 @@ public:
 		return Vec4(VecClamp(x, l, h), VecClamp(y, l, h), VecClamp(z, l, h), VecClamp(w, l, h));
 	}
 
+	Vec4 Reciprocal() const
+	{
+		const T one = 1.0f;
+		return Vec4(one / x, one / y, one / z, one / w);
+	}
+
 	// Only implemented for T=float
 	float Length() const;
 	void SetLength(const float l);


### PR DESCRIPTION
Currently, this is generally a bit slower, but it's a step in the right direction.

The last commit shows the benefit of this change in one area.  Sample performance change in Tales of Destiny 2 (before this PR -> after this PR w/throughmode perf):

130% -> 200% - Logos during intro
35% -> 70% - Load save screen
64% -> 50% - 3D overworld

-[Unknown]