### PR TITLE
Oops, rebuild FBOs when buffered changes

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -383,8 +383,7 @@ void PSPSaveDialog::DisplaySaveIcon()
 		PPGeDisableTexture();
 	}
 	PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
-	if (curSave.texture != NULL)
-		PPGeSetDefaultTexture();
+	PPGeSetDefaultTexture();
 }
 
 void PSPSaveDialog::DisplaySaveDataInfo1()

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -489,7 +489,6 @@ const HLEFunction *GetSyscallFuncPointer(MIPSOpcode op)
 		ERROR_LOG(HLE, "Syscall had bad function number %d in module %d - probably executing garbage", funcnum, modulenum);
 		return NULL;
 	}
-	DEBUG_LOG(HLE, "Compiling syscall to %s", moduleDB[modulenum].funcTable[funcnum].name);
 	return &moduleDB[modulenum].funcTable[funcnum];
 }
 
@@ -500,6 +499,7 @@ void *GetQuickSyscallFunc(MIPSOpcode op) {
 	const HLEFunction *info = GetSyscallFuncPointer(op);
 	if (!info || !info->func)
 		return nullptr;
+	DEBUG_LOG(HLE, "Compiling syscall to %s", info->name);
 
 	// TODO: Do this with a flag?
 	if (op == idleOp)

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -769,7 +769,7 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, GEBu
 	// Should try to unify this path with the regular path somehow, but this simple solution works for most of the post shaders 
 	// (it always runs at output resolution so FXAA may look odd).
 	float x, y, w, h;
-	int uvRotation = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
+	int uvRotation = useBufferedRendering_ ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 	CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)pixelWidth_, (float)pixelHeight_, uvRotation);
 	if (applyPostShader && useBufferedRendering_) {
 		// Might've changed if the shader was just changed to Off.
@@ -930,7 +930,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 
 		draw_->BindFramebufferAsTexture(vfb->fbo, 0, Draw::FB_COLOR_BIT, 0);
 
-		int uvRotation = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
+		int uvRotation = useBufferedRendering_ ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 
 		// Output coordinates
 		float x, y, w, h;
@@ -1044,7 +1044,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 }
 
 void FramebufferManagerCommon::DecimateFBOs() {
-	if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
+	if (useBufferedRendering_) {
 		draw_->BindBackbufferAsRenderTarget();
 	}
 	currentRenderVfb_ = 0;

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -142,7 +142,7 @@ void FramebufferManagerCommon::Init() {
 
 bool FramebufferManagerCommon::UpdateSize() {
 	const bool newRender = renderWidth_ != (float)PSP_CoreParameter().renderWidth || renderHeight_ != (float)PSP_CoreParameter().renderHeight;
-	const bool newSettings = bloomHack_ != g_Config.iBloomHack || trueColor_ != g_Config.bTrueColor;
+	const bool newSettings = bloomHack_ != g_Config.iBloomHack || trueColor_ != g_Config.bTrueColor || useBufferedRendering_ != (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 
 	renderWidth_ = (float)PSP_CoreParameter().renderWidth;
 	renderHeight_ = (float)PSP_CoreParameter().renderHeight;
@@ -150,6 +150,7 @@ bool FramebufferManagerCommon::UpdateSize() {
 	pixelHeight_ = PSP_CoreParameter().pixelHeight;
 	bloomHack_ = g_Config.iBloomHack;
 	trueColor_ = g_Config.bTrueColor;
+	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 
 	return newRender || newSettings;
 }
@@ -157,7 +158,6 @@ bool FramebufferManagerCommon::UpdateSize() {
 void FramebufferManagerCommon::BeginFrame() {
 	DecimateFBOs();
 	currentRenderVfb_ = 0;
-	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	updateVRAM_ = !(g_Config.iRenderingMode == FB_NON_BUFFERED_MODE || g_Config.iRenderingMode == FB_BUFFERED_MODE);
 }
 

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1736,6 +1736,8 @@ void FramebufferManagerCommon::Resized() {
 		PSP_CoreParameter().renderHeight = 272 * zoom;
 	}
 
+	gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
+
 #ifdef _WIN32
 	// Seems related - if you're ok with numbers all the time, show some more :)
 	if (g_Config.iShowFPSCounter != 0) {

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -265,7 +265,7 @@ public:
 	void SetRenderSize(VirtualFramebuffer *vfb);
 	void SetSafeSize(u16 w, u16 h);
 
-	virtual void Resized() = 0;
+	virtual void Resized();
 
 	Draw::Framebuffer *GetTempFBO(u16 w, u16 h, Draw::FBColorDepth depth = Draw::FBO_8888);
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -75,6 +75,7 @@ struct VirtualFramebuffer {
 	int last_frame_render;
 	int last_frame_displayed;
 	int last_frame_clut;
+	int last_frame_failed;
 	u32 clutUpdatedBytes;
 	bool memoryUpdated;
 	bool depthUpdated;

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -889,7 +889,7 @@ void FramebufferManagerD3D11::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+		if (UpdateSize()) {
 			DestroyAllFBOs();
 		}
 

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -858,55 +858,10 @@ void FramebufferManagerD3D11::PackDepthbuffer(VirtualFramebuffer *vfb, int x, in
 }
 
 void FramebufferManagerD3D11::EndFrame() {
-	if (resized_) {
-		// Check if postprocessing shader is doing upscaling as it requires native resolution
-		const ShaderInfo *shaderInfo = 0;
-		if (g_Config.sPostShaderName != "Off") {
-			shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
-		}
-
-		postShaderIsUpscalingFilter_ = shaderInfo ? shaderInfo->isUpscalingFilter : false;
-
-		// Actually, auto mode should be more granular...
-		// Round up to a zoom factor for the render size.
-		int zoom = g_Config.iInternalResolution;
-		if (zoom == 0) {
-			// auto mode, use the longest dimension
-			if (!g_Config.IsPortrait()) {
-				zoom = (PSP_CoreParameter().pixelWidth + 479) / 480;
-			} else {
-				zoom = (PSP_CoreParameter().pixelHeight + 479) / 480;
-			}
-		}
-		if (zoom <= 1 || postShaderIsUpscalingFilter_)
-			zoom = 1;
-
-		if (g_Config.IsPortrait()) {
-			PSP_CoreParameter().renderWidth = 272 * zoom;
-			PSP_CoreParameter().renderHeight = 480 * zoom;
-		} else {
-			PSP_CoreParameter().renderWidth = 480 * zoom;
-			PSP_CoreParameter().renderHeight = 272 * zoom;
-		}
-
-		if (UpdateSize()) {
-			DestroyAllFBOs();
-		}
-
-		// Seems related - if you're ok with numbers all the time, show some more :)
-		if (g_Config.iShowFPSCounter != 0) {
-			ShowScreenResolution();
-		}
-		resized_ = false;
-
-		// Might have a new post shader - let's compile it.
-		CompilePostShader();
-	}
 }
 
 void FramebufferManagerD3D11::DeviceLost() {
 	DestroyAllFBOs();
-	resized_ = false;
 }
 
 std::vector<FramebufferInfo> FramebufferManagerD3D11::GetFramebufferList() {
@@ -968,7 +923,14 @@ void FramebufferManagerD3D11::FlushBeforeCopy() {
 }
 
 void FramebufferManagerD3D11::Resized() {
-	resized_ = true;
+	FramebufferManagerCommon::Resized();
+
+	if (UpdateSize()) {
+		DestroyAllFBOs();
+	}
+
+	// Might have a new post shader - let's compile it.
+	CompilePostShader();
 }
 
 // Lots of this code could be shared (like the downsampling).

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -153,8 +153,6 @@ private:
 	// Used by post-processing shader
 	std::vector<Draw::Framebuffer *> extraFBOs_;
 
-	bool resized_;
-
 #if 0
 	AsyncPBO *pixelBufObj_; //this isn't that large
 	u8 currentPBO_;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -301,6 +301,7 @@ void GPU_D3D11::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	UpdateCmdInfo();
 	if (resized_) {
+		framebufferManager_->Resized();
 		drawEngine_.Resized();
 		textureCacheD3D11_->NotifyConfigChanged();
 		shaderManagerD3D11_->DirtyLastShader();

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -753,43 +753,10 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	void FramebufferManagerDX9::EndFrame() {
-		if (resized_) {
-			// Actually, auto mode should be more granular...
-			// Round up to a zoom factor for the render size.
-			int zoom = g_Config.iInternalResolution;
-			if (zoom == 0) { // auto mode
-											 // Use the longest dimension
-				if (!g_Config.IsPortrait()) {
-					zoom = (PSP_CoreParameter().pixelWidth + 479) / 480;
-				} else {
-					zoom = (PSP_CoreParameter().pixelHeight + 479) / 480;
-				}
-			}
-			if (zoom <= 1)
-				zoom = 1;
-
-			if (g_Config.IsPortrait()) {
-				PSP_CoreParameter().renderWidth = 272 * zoom;
-				PSP_CoreParameter().renderHeight = 480 * zoom;
-			} else {
-				PSP_CoreParameter().renderWidth = 480 * zoom;
-				PSP_CoreParameter().renderHeight = 272 * zoom;
-			}
-
-			if (UpdateSize()) {
-				DestroyAllFBOs();
-			}
-			// Seems related - if you're ok with numbers all the time, show some more :)
-			if (g_Config.iShowFPSCounter != 0) {
-				ShowScreenResolution();
-			}
-			resized_ = false;
-		}
 	}
 
 	void FramebufferManagerDX9::DeviceLost() {
 		DestroyAllFBOs();
-		resized_ = false;
 	}
 
 	std::vector<FramebufferInfo> FramebufferManagerDX9::GetFramebufferList() {
@@ -868,7 +835,11 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	void FramebufferManagerDX9::Resized() {
-		resized_ = true;
+		FramebufferManagerCommon::Resized();
+
+		if (UpdateSize()) {
+			DestroyAllFBOs();
+		}
 	}
 
 	bool FramebufferManagerDX9::GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat fb_format, GPUDebugBuffer &buffer, int maxRes) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -776,7 +776,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 				PSP_CoreParameter().renderHeight = 272 * zoom;
 			}
 
-			if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+			if (UpdateSize()) {
 				DestroyAllFBOs();
 			}
 			// Seems related - if you're ok with numbers all the time, show some more :)

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -128,8 +128,6 @@ private:
 	// Used by post-processing shader
 	std::vector<Draw::Framebuffer *> extraFBOs_;
 
-	bool resized_;
-
 	struct TempFBO {
 		Draw::Framebuffer *fbo;
 		int last_frame_used;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -268,6 +268,7 @@ void GPU_DX9::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	UpdateCmdInfo();
 	if (resized_) {
+		framebufferManager_->Resized();
 		drawEngine_.Resized();
 		shaderManagerDX9_->DirtyShader();
 		textureCacheDX9_->NotifyConfigChanged();

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -1180,7 +1180,7 @@ void FramebufferManagerGLES::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+		if (UpdateSize()) {
 			DestroyAllFBOs();
 		}
 

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -138,8 +138,6 @@ private:
 	ShaderManagerGLES *shaderManagerGL_;
 	DrawEngineGLES *drawEngine_;
 
-	bool resized_;
-
 	// Not used under ES currently.
 	AsyncPBO *pixelBufObj_; //this isn't that large
 	u8 currentPBO_;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -406,7 +406,6 @@ void GPU_GLES::ReinitializeInternal() {
 	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
 	framebufferManagerGL_->DestroyAllFBOs();
-	framebufferManagerGL_->Resized();
 }
 
 void GPU_GLES::InitClearInternal() {
@@ -429,6 +428,7 @@ void GPU_GLES::BeginHostFrame() {
 	UpdateCmdInfo();
 	if (resized_) {
 		CheckGPUFeatures();
+		framebufferManager_->Resized();
 		drawEngine_.Resized();
 		shaderManagerGL_->DirtyShader();
 		textureCacheGL_->NotifyConfigChanged();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -459,7 +459,6 @@ bool GPUCommon::BusyDrawing() {
 
 void GPUCommon::Resized() {
 	resized_ = true;
-	framebufferManager_->Resized();
 }
 
 u32 GPUCommon::DrawSync(int mode) {

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -1070,7 +1070,7 @@ void FramebufferManagerVulkan::EndFrame() {
 			PSP_CoreParameter().renderHeight = 272 * zoom;
 		}
 
-		if (UpdateSize() || g_Config.iRenderingMode == FB_NON_BUFFERED_MODE) {
+		if (UpdateSize()) {
 			DestroyAllFBOs();
 		}
 

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -166,8 +166,6 @@ private:
 	ShaderManagerVulkan *shaderManagerVulkan_;
 	DrawEngineVulkan *drawEngine_;
 
-	bool resized_;
-
 	AsyncPBOVulkan *pixelBufObj_;
 	int currentPBO_;
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -206,6 +206,7 @@ void GPU_Vulkan::BeginHostFrame() {
 		// In case the GPU changed.
 		BuildReportingInfo();
 		UpdateCmdInfo();
+		framebufferManager_->Resized();
 		drawEngine_.Resized();
 		textureCacheVulkan_->NotifyConfigChanged();
 	}
@@ -316,7 +317,6 @@ void GPU_Vulkan::ReinitializeInternal() {
 	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
 	framebufferManagerVulkan_->DestroyAllFBOs();
-	framebufferManagerVulkan_->Resized();
 }
 
 void GPU_Vulkan::InitClearInternal() {

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -224,8 +224,7 @@ namespace MainWindow
 		if (g_Config.iTexScalingLevel == TEXSCALING_AUTO)
 			setTexScalingMultiplier(0);
 
-		if (gpu)
-			gpu->Resized();
+		NativeMessageReceived("gpu resized", "");
 	}
 
 	void CorrectCursor() {


### PR DESCRIPTION
I'd thought about moving where `useBufferedRendering_` was updated, but then evidently forgot.  This is simpler, and takes care of the part of #9637 that easily reproduces.

-[Unknown]