### PR TITLE
Fix postprocess shader submenu.

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -174,7 +174,7 @@ namespace MainWindow {
 		}
 		std::vector<ShaderInfo> info = GetAllPostShaderInfo();
 
-		if (menuShaderInfo.size() != info.size() || !std::equal(info.begin(), info.end(), menuShaderInfo.begin())) {
+		if (menuShaderInfo.size() == info.size() && std::equal(info.begin(), info.end(), menuShaderInfo.begin())) {
 			return false;
 		}
 


### PR DESCRIPTION
 Not sure what was the meaning of the original code, I saw that CreateShadersSubmenu was called twice, but since the first time menuShaderInfo was 0, the submenu was never created and menuShaderInfo  never set to shader info and it just generally failed.

 I think that check was ment to skip re-creating when it's same, so I changed it that way.

 Fixes #9639