### PR TITLE
Fix "copy type" pointer cwc

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -439,7 +439,7 @@ void CWCheatEngine::Run() {
 					int count = arg2 & 0xFFFF;
 					int type = (arg2 >> 16) & 0xF;
 					for (int i = 1; i < count; i ++ ) {
-						if (i+1 < count) {
+						if (i < count) {
 							code = GetNextCode();
 							if (code.size() < 2) {
 								// User provided incomplete cheat. Should warn but would be very spammy...
@@ -452,8 +452,8 @@ void CWCheatEngine::Run() {
 							case 0x1: // type copy byte
 								{
 									int srcAddr = Memory::Read_U32(addr) + offset;
-									int dstAddr = Memory::Read_U16(addr + baseOffset) + (arg3 & 0x0FFFFFFF);
-									if (Memory::IsValidAddress(dstAddr) && Memory::IsValidAddress(srcAddr)) {
+									int dstAddr = Memory::Read_U32(addr + baseOffset) + (arg3 & 0x0FFFFFFF);
+									if (Memory::IsValidAddress(dstAddr) && Memory::IsValidAddress(srcAddr) && Memory::IsValidAddress(srcAddr + arg) && Memory::IsValidAddress(dstAddr + arg)) {
 										Memory::MemcpyUnchecked(dstAddr, srcAddr, arg);
 									}
 									type = -1; //Done


### PR DESCRIPTION
 Blah I honestly have no idea if that's how this should work because the only documentation of those pointer codes seems to be in:
http://wikiwiki.jp/cwcheat/?CODE%A4%CE%B8%FA%B2%CC
;]
had hard time to even find which of those was broken with people who use those not being very informative, ended up just making the code work with some existing cheats.
 At worst it's now broken differently I guess, worked for a bunch of stuff through.>.>