### PR TITLE
Fix: in some extreme case on-screen touch controls get stuck on iOS

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -344,6 +344,17 @@ static GraphicsContext *graphicsContext;
 	}
 }
 
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    for(UITouch* touch in touches)
+    {
+        CGPoint point = [touch locationInView:self.view];
+        NSDictionary* dict = [self touchDictBy:touch];
+        [self touchX:point.x y:point.y code:2 pointerId:[[dict objectForKey:@"index"] intValue]];
+        [self.touches removeObject:dict];
+    }
+}
+
 - (void)bindDefaultFBO
 {
 	[(GLKView*)self.view bindDrawable];


### PR DESCRIPTION
In some extreme case, such as backing to home screen when pressing touch controls, touching screen with whole palm, the on-screen touch controls on iOS may get stuck and become fully unresponsive.
In this case actually, iOS send a "touchesCancelled" message to views, which indicates that the touches had been abnormally cancelled.
Fixed absence of processing the message. After some simple tests, it will not get stuck again.