### PR TITLE
Windows: Initialize WindowsHost in EmuThread

### DIFF
--- a/Core/Host.cpp
+++ b/Core/Host.cpp
@@ -20,7 +20,7 @@
 #include "Core/Host.h"
 #include "Core/Debugger/SymbolMap.h"
 
-Host *host;
+Host *host = nullptr;
 
 bool Host::AttemptLoadSymbolMap() {
 	g_symbolMap->Clear();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -330,7 +330,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	VFSRegister("", new DirectoryAssetReader("assets/"));
 	VFSRegister("", new DirectoryAssetReader(savegame_dir));
 
-#if (defined(MOBILE_DEVICE) || !defined(USING_QT_UI)) && !PPSSPP_PLATFORM(WINDOWS)
+#if (defined(MOBILE_DEVICE) || !defined(USING_QT_UI)) && !PPSSPP_PLATFORM(UWP)
 	if (host == nullptr) {
 		host = new NativeHost();
 	}
@@ -1087,7 +1087,7 @@ void NativeShutdown() {
 		gl_lost_manager_shutdown();
 	}
 
-#if !PPSSPP_PLATFORM(WINDOWS)
+#if !PPSSPP_PLATFORM(UWP)
 	delete host;
 	host = nullptr;
 #endif

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -8,11 +8,12 @@
 
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
-#include "../Globals.h"
+#include "Globals.h"
 #include "Windows/EmuThread.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/MainWindow.h"
 #include "Windows/resource.h"
+#include "Windows/WindowsHost.h"
 #include "Core/Reporting.h"
 #include "Core/MemMap.h"
 #include "Core/Core.h"
@@ -90,6 +91,9 @@ unsigned int WINAPI TheThread(void *)
 	_InterlockedExchange(&emuThreadReady, THREAD_INIT);
 
 	setCurrentThreadName("Emu");  // And graphics...
+
+	host = new WindowsHost(MainWindow::GetHInstance(), MainWindow::GetHWND(), MainWindow::GetDisplayHWND());
+	host->SetWindowTitle(nullptr);
 
 	// Convert the command-line arguments to Unicode, then to proper UTF-8 
 	// (the benefit being that we don't have to pollute the UI project with win32 ifdefs and lots of Convert<whatever>To<whatever>).

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -26,7 +26,8 @@
 #include "Common/OSVersion.h"
 
 #include <Windowsx.h>
-
+#include <shellapi.h>
+#include <commctrl.h>
 #include <map>
 #include <string>
 
@@ -34,8 +35,6 @@
 #include "base/NativeApp.h"
 #include "Globals.h"
 
-#include "shellapi.h"
-#include "commctrl.h"
 #include "base/timeutil.h"
 #include "i18n/i18n.h"
 #include "input/input_state.h"
@@ -43,25 +42,23 @@
 #include "thread/threadutil.h"
 #include "util/text/utf8.h"
 
+#include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Windows/InputBox.h"
+#include "Windows/InputDevice.h"
 #include "Windows/GPU/WindowsGLContext.h"
 #include "Windows/Debugger/Debugger_Disasm.h"
 #include "Windows/Debugger/Debugger_MemoryDlg.h"
 #include "Windows/GEDebugger/GEDebugger.h"
-#include "Core/MIPS/JitCommon/JitCommon.h"
-#include "Core/MIPS/JitCommon/JitBlockCache.h"
 
-#include "main.h"
-
-#include "Core/Core.h"
+#include "Windows/main.h"
 #include "Windows/EmuThread.h"
-
-#include "resource.h"
+#include "Windows/resource.h"
 
 #include "Windows/MainWindow.h"
-#include "Windows/WindowsHost.h"
 #include "Common/LogManager.h"
 #include "Common/ConsoleListener.h"
 #include "Windows/W32Util/DialogManager.h"
@@ -69,9 +66,9 @@
 #include "Windows/W32Util/Misc.h"
 #include "Windows/RawInput.h"
 #include "Windows/TouchInputHandler.h"
+#include "Windows/MainWindowMenu.h"
 #include "GPU/GPUInterface.h"
 #include "UI/OnScreenDisplay.h"
-#include "Windows/MainWindowMenu.h"
 #include "UI/GameSettingsScreen.h"
 
 #define MOUSEEVENTF_FROMTOUCH_NOPEN 0xFF515780 //http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -504,9 +504,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	DialogManager::AddDlg(vfpudlg = new CVFPUDlg(_hInstance, hwndMain, currentDebugMIPS));
 
-	host = new WindowsHost(_hInstance, hwndMain, hwndDisplay);
-	host->SetWindowTitle(nullptr);
-
 	MainWindow::CreateDebugWindows();
 
 	const bool minimized = iCmdShow == SW_MINIMIZE || iCmdShow == SW_SHOWMINIMIZED || iCmdShow == SW_SHOWMINNOACTIVE;
@@ -575,7 +572,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	MainWindow::DestroyDebugWindows();
 	DialogManager::DestroyAll();
 	timeEndPeriod(1);
-	delete host;
 
 	LogManager::Shutdown();
 


### PR DESCRIPTION
This seems like a more appropriate place, and a more appropriate thread, for it to be initialized on.

This also means when restarting EmuThread (i.e. backend switch), the host is reinitialized.

-[Unknown]