### PR TITLE
Add "ignoreAddress" to texture replacement.

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -94,6 +94,11 @@ bool TextureReplacer::LoadIni() {
 		options->Get("video", &allowVideo_, false);
 		options->Get("ignoreAddress", &ignoreAddress_, false);
 
+		if (ignoreAddress_ && hash_ == ReplacedTextureHash::QUICK) {
+			ignoreAddress_ = false;
+			ERROR_LOG(G3D, "Texture Replacement: ignoreAddress option requires safer hash, use xxh32 or xxh64 instead.");
+		}
+
 		int version = 0;
 		if (options->Get("version", &version, 0) && version > VERSION) {
 			ERROR_LOG(G3D, "Unsupported texture replacement version %d, trying anyway", version);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -199,6 +199,7 @@ protected:
 	bool enabled_;
 	bool allowVideo_;
 	bool ignoreAddress_;
+	bool reduceHash_;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -196,6 +196,7 @@ protected:
 	SimpleBuf<u32> saveBuf;
 	bool enabled_;
 	bool allowVideo_;
+	bool ignoreAddress_;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -50,6 +50,8 @@ enum class ReplacedTextureAlpha {
 enum class ReplacedTextureHash {
 	// TODO: Maybe only support crc32c for now?
 	QUICK,
+	XXH32,
+	XXH64,
 };
 
 struct ReplacedTextureLevel {


### PR DESCRIPTION
 If option "ignoreAddress" is set to true address is zeroed when deciding filename and checking if it doesn't already exist. Also skips some work when populating replacement without affecting "hashranges" as I guess it still could have use for some constant textures like ui elements even if most of the textures in-game would constantly change addresses.
Fixes #9665