### PR TITLE
Remove unused vertex decode steps, jit through s16

### DIFF
--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -89,8 +89,10 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 	args.silent = true;
 	args.memoryFile = &file;
 	args.errorsResult = &errors;
-	
-	g_symbolMap->GetLabels(args.labels);
+
+	if (g_symbolMap) {
+		g_symbolMap->GetLabels(args.labels);
+	}
 
 	errorText = L"";
 	if (!runArmips(args))

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -281,35 +281,6 @@ void VertexDecoder::Step_TcU16ToFloat() const
 	uv[1] = uvdata[1] * (1.0f / 32768.0f);
 }
 
-void VertexDecoder::Step_TcU16Double() const
-{
-	u16 *uv = (u16*)(decoded_ + decFmt.uvoff);
-	const u16 *uvdata = (const u16_le*)(ptr_ + tcoff);
-	uv[0] = uvdata[0] * 2;
-	uv[1] = uvdata[1] * 2;
-}
-
-void VertexDecoder::Step_TcU16Through() const
-{
-	u16 *uv = (u16 *)(decoded_ + decFmt.uvoff);
-	const u16 *uvdata = (const u16_le*)(ptr_ + tcoff);
-	uv[0] = uvdata[0];
-	uv[1] = uvdata[1];
-
-	gstate_c.vertBounds.minU = std::min(gstate_c.vertBounds.minU, uvdata[0]);
-	gstate_c.vertBounds.maxU = std::max(gstate_c.vertBounds.maxU, uvdata[0]);
-	gstate_c.vertBounds.minV = std::min(gstate_c.vertBounds.minV, uvdata[1]);
-	gstate_c.vertBounds.maxV = std::max(gstate_c.vertBounds.maxV, uvdata[1]);
-}
-
-void VertexDecoder::Step_TcU16ThroughDouble() const
-{
-	u16 *uv = (u16 *)(decoded_ + decFmt.uvoff);
-	const u16 *uvdata = (const u16_le*)(ptr_ + tcoff);
-	uv[0] = uvdata[0] * 2;
-	uv[1] = uvdata[1] * 2;
-}
-
 void VertexDecoder::Step_TcU16DoubleToFloat() const
 {
 	float *uv = (float*)(decoded_ + decFmt.uvoff);
@@ -386,51 +357,6 @@ void VertexDecoder::Step_TcFloatPrescale() const {
 	const float *uvdata = (const float*)(ptr_ + tcoff);
 	uv[0] = uvdata[0] * gstate_c.uv.uScale + gstate_c.uv.uOff;
 	uv[1] = uvdata[1] * gstate_c.uv.vScale + gstate_c.uv.vOff;
-}
-
-void VertexDecoder::Step_TcU8Morph() const {
-	float uv[2] = { 0, 0 };
-	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
-		const u8 *uvdata = (const u8 *)(ptr_ + onesize_*n + tcoff);
-
-		uv[0] += (float)uvdata[0] * w;
-		uv[1] += (float)uvdata[1] * w;
-	}
-
-	u8 *out = decoded_ + decFmt.uvoff;
-	out[0] = (int)uv[0];
-	out[1] = (int)uv[1];
-}
-
-void VertexDecoder::Step_TcU16Morph() const {
-	float uv[2] = { 0, 0 };
-	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
-		const u16_le *uvdata = (const u16_le *)(ptr_ + onesize_*n + tcoff);
-
-		uv[0] += (float)uvdata[0] * w;
-		uv[1] += (float)uvdata[1] * w;
-	}
-
-	u16_le *out = (u16_le *)(decoded_ + decFmt.uvoff);
-	out[0] = (int)uv[0];
-	out[1] = (int)uv[1];
-}
-
-void VertexDecoder::Step_TcU16DoubleMorph() const {
-	float uv[2] = { 0, 0 };
-	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
-		const u16_le *uvdata = (const u16_le *)(ptr_ + onesize_*n + tcoff);
-
-		uv[0] += (float)uvdata[0] * w;
-		uv[1] += (float)uvdata[1] * w;
-	}
-
-	u16_le *out = (u16_le *)(decoded_ + decFmt.uvoff);
-	out[0] = (int)(uv[0] * 2.0f);
-	out[1] = (int)(uv[1] * 2.0f);
 }
 
 void VertexDecoder::Step_TcU8MorphToFloat() const {
@@ -920,20 +846,6 @@ static const StepFunction tcstep_prescale_morph_remaster[4] = {
 	&VertexDecoder::Step_TcU8PrescaleMorph,
 	&VertexDecoder::Step_TcU16DoublePrescaleMorph,
 	&VertexDecoder::Step_TcFloatPrescaleMorph,
-};
-
-static const StepFunction tcstep_morph[4] = {
-	0,
-	&VertexDecoder::Step_TcU8Morph,
-	&VertexDecoder::Step_TcU16Morph,
-	&VertexDecoder::Step_TcFloatMorph,
-};
-
-static const StepFunction tcstep_morph_remaster[4] = {
-	0,
-	&VertexDecoder::Step_TcU8Morph,
-	&VertexDecoder::Step_TcU16DoubleMorph,
-	&VertexDecoder::Step_TcFloatMorph,
 };
 
 static const StepFunction tcstep_morphToFloat[4] = {

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -514,17 +514,11 @@ public:
 	void Step_TcU16DoublePrescale() const;
 	void Step_TcFloatPrescale() const;
 
-	void Step_TcU16Double() const;
-	void Step_TcU16Through() const;
-	void Step_TcU16ThroughDouble() const;
 	void Step_TcU16DoubleToFloat() const;
 	void Step_TcU16ThroughToFloat() const;
 	void Step_TcU16ThroughDoubleToFloat() const;
 	void Step_TcFloatThrough() const;
 
-	void Step_TcU8Morph() const;
-	void Step_TcU16Morph() const;
-	void Step_TcU16DoubleMorph() const;
 	void Step_TcU8MorphToFloat() const;
 	void Step_TcU16MorphToFloat() const;
 	void Step_TcU16DoubleMorphToFloat() const;
@@ -675,10 +669,6 @@ public:
 	void Jit_TcU16PrescaleMorph();
 	void Jit_TcFloatPrescaleMorph();
 
-	void Jit_TcU16Double();
-	void Jit_TcU16ThroughDouble();
-
-	void Jit_TcU16Through();
 	void Jit_TcU16ThroughToFloat();
 	void Jit_TcFloatThrough();
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -376,7 +376,7 @@ public:
 		curIBufferOffset_ = offset;
 	}
 
-	void UpdateDynamicUniformBuffer(const void *ub, size_t size);
+	void UpdateDynamicUniformBuffer(const void *ub, size_t size) override;
 
 	// TODO: Add more sophisticated draws.
 	void Draw(int vertexCount, int offset) override;

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -29,7 +29,7 @@ public:
 	void UpdateMemView() override {}
 	void UpdateDisassembly() override {}
 
-	void SetDebugMode(bool mode) { }
+	void SetDebugMode(bool mode) override { }
 
 	void SetGraphicsCore(GPUCore core) { gpuCore_ = core; }
 	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override {return false;}

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -91,8 +91,8 @@ static void DestroyJitHarness() {
 	// Clear our custom module out to be safe.
 	HLEShutdown();
 	CoreTiming::Shutdown();
-	Memory::Shutdown();
 	mipsr4k.Shutdown();
+	Memory::Shutdown();
 	coreState = CORE_POWERDOWN;
 	currentMIPS = nullptr;
 }

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -36,6 +36,10 @@ public:
 		cache_ = new VertexDecoderJitCache();
 
 		g_Config.bVertexDecoderJit = true;
+		// Required for jit to be enabled.
+		g_Config.iCpuCore = (int)CPUCore::JIT;
+		gstate_c.uv.uScale = 1.0f;
+		gstate_c.uv.vScale = 1.0f;
 	}
 	~VertexDecoderTestHarness() {
 		delete src_;
@@ -297,8 +301,7 @@ static bool TestVertex8() {
 
 	for (int jit = 0; jit <= 1; ++jit) {
 		dec.Execute(vtype, 0, jit == 1);
-		dec.Assert8("TestVertex8-TC", 127, 128);
-		dec.Skip(2);
+		dec.AssertFloat("TestVertex8-TC", 127.0f / 128.0f, 1.0f);
 		dec.Assert8("TestVertex8-Nrm", 127, 0, 128);
 		dec.Skip(1);
 		dec.AssertFloat("TestVertex8-Pos", 127.0f / 128.0f, 0.0f, -1.0f);
@@ -317,7 +320,7 @@ static bool TestVertex16() {
 
 	for (int jit = 0; jit <= 1; ++jit) {
 		dec.Execute(vtype, 0, jit == 1);
-		dec.Assert16("TestVertex16-TC", 32767, 32768);
+		dec.AssertFloat("TestVertex16-TC", 32767.0f / 32768.0f, 1.0f);
 		dec.Assert16("TestVertex16-Nrm", 32767, 0, 32768);
 		dec.Skip(2);
 		dec.AssertFloat("TestVertex16-Pos", 32767.0f / 32768.0f, 0.0f, -1.0f);
@@ -354,8 +357,8 @@ static bool TestVertex8Through() {
 
 	for (int jit = 0; jit <= 1; ++jit) {
 		dec.Execute(vtype, 0, jit == 1);
-		dec.Assert8("TestVertex8Through-TC", 127, 128);
-		dec.Skip(2);
+		// Note: this is correct, even in through.
+		dec.AssertFloat("TestVertex8Through-TC", 127.0f / 128.0f, 1.0f);
 		dec.Assert8("TestVertex8Through-Nrm", 127, 0, 128);
 		// Ignoring Pos since s8 through isn't really an option.
 	}
@@ -373,7 +376,7 @@ static bool TestVertex16Through() {
 
 	for (int jit = 0; jit <= 1; ++jit) {
 		dec.Execute(vtype, 0, jit == 1);
-		dec.Assert16("TestVertex16Through-TC", 32767, 32768);
+		dec.AssertFloat("TestVertex16Through-TC", 32767.0f, 32768.0f);
 		dec.Assert16("TestVertex16Through-Nrm", 32767, 0, 32768);
 		dec.Skip(2);
 		dec.AssertFloat("TestVertex16Through-Pos", 32767.0f, 0.0f, 32768.0f);


### PR DESCRIPTION
This is commonly used for UI, so it can sometimes be a decent chunk of verts.  It's >3x as fast using jit in all cases, even with the bounds checks.

Also, I think better to skip the unused non-float TC steps now.

-[Unknown]