### PR TITLE
SoftGPU: Implement mipmapping 

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -229,8 +229,8 @@ static inline void GetTexelCoordinates(int level, float s, float t, int& out_u, 
 	int width = gstate.getTextureWidth(level);
 	int height = gstate.getTextureHeight(level);
 
-	int u = (int)(s * width + 0.375f);
-	int v = (int)(t * height + 0.375f);
+	int u = (int)floorf(s * width + 0.375f / 256.0f);
+	int v = (int)floorf(t * height + 0.375f / 256.0f);
 
 	ApplyTexelClamp<1>(&out_u, &out_v, &u, &v, width, height);
 }
@@ -241,8 +241,8 @@ static inline void GetTexelCoordinatesQuad(int level, float in_s, float in_t, in
 	int width = gstate.getTextureWidth(level);
 	int height = gstate.getTextureHeight(level);
 
-	int base_u = in_s * width * 256;
-	int base_v = in_t * height * 256;
+	int base_u = (int)(in_s * width * 256.0f + 0.375f) - 128;
+	int base_v = (int)(in_t * height * 256.0f + 0.375f) - 128;
 
 	frac_u = (int)(base_u) & 0xff;
 	frac_v = (int)(base_v) & 0xff;
@@ -1131,10 +1131,14 @@ inline void ApplyTexturing(Vec4<int> &prim_color, float s, float t, int maxTexLe
 	// bilinear = false;
 
 	if (gstate.isModeThrough()) {
-		int u_texel = s * 256;
-		int v_texel = t * 256;
-		frac_u = u_texel & 0xff;
-		frac_v = v_texel & 0xff;
+		int u_texel = (int)(s * 256.0f + 0.375f);
+		int v_texel = (int)(t * 256.0f + 0.375f);
+		if (bilinear) {
+			u_texel -= 128;
+			v_texel -= 128;
+			frac_u = u_texel & 0xff;
+			frac_v = v_texel & 0xff;
+		}
 		u_texel >>= 8;
 		v_texel >>= 8;
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -386,7 +386,7 @@ inline static Nearest4 SampleNearest(int level, int u[N], int v[N], const u8 *sr
 		for (int i = 0; i < N; ++i) {
 			const u8 *src = srcptr + GetPixelDataOffset<32>(texbufwidthbytes, u[i], v[i]);
 			u32 val = src[0] + (src[1] << 8) + (src[2] << 16) + (src[3] << 24);
-			res.v[i] = LookupColor(gstate.transformClutIndex(val), level);
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
 		}
 		return res;
 
@@ -394,7 +394,7 @@ inline static Nearest4 SampleNearest(int level, int u[N], int v[N], const u8 *sr
 		for (int i = 0; i < N; ++i) {
 			const u8 *src = srcptr + GetPixelDataOffset<16>(texbufwidthbytes, u[i], v[i]);
 			u16 val = src[0] + (src[1] << 8);
-			res.v[i] = LookupColor(gstate.transformClutIndex(val), level);
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
 		}
 		return res;
 
@@ -402,7 +402,7 @@ inline static Nearest4 SampleNearest(int level, int u[N], int v[N], const u8 *sr
 		for (int i = 0; i < N; ++i) {
 			const u8 *src = srcptr + GetPixelDataOffset<8>(texbufwidthbytes, u[i], v[i]);
 			u8 val = *src;
-			res.v[i] = LookupColor(gstate.transformClutIndex(val), level);
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
 		}
 		return res;
 
@@ -410,6 +410,7 @@ inline static Nearest4 SampleNearest(int level, int u[N], int v[N], const u8 *sr
 		for (int i = 0; i < N; ++i) {
 			const u8 *src = srcptr + GetPixelDataOffset<4>(texbufwidthbytes, u[i], v[i]);
 			u8 val = (u[i] & 1) ? (src[0] >> 4) : (src[0] & 0xF);
+			// Only CLUT4 uses separate mipmap palettes.
 			res.v[i] = LookupColor(gstate.transformClutIndex(val), level);
 		}
 		return res;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -84,7 +84,8 @@ static inline ScreenCoords ClipToScreenInternal(const ClipCoords& coords, bool *
 		*outside_range_flag = true;
 
 	// 16 = 0xFFFF / 4095.9375
-	return ScreenCoords(x * 16, y * 16, z);
+	// Round up at 0.625 to the nearest subpixel.
+	return ScreenCoords(x * 16.0f + 0.375f, y * 16.0f + 0.375f, z);
 }
 
 ScreenCoords TransformUnit::ClipToScreen(const ClipCoords& coords)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -274,8 +274,7 @@ void GameSettingsScreen::CreateViews() {
 #ifdef _WIN32
 	graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gr->T("VSync")));
 #endif
-	CheckBox *mipmapping = graphicsSettings->Add(new CheckBox(&g_Config.bMipMap, gr->T("Mipmapping")));
-	mipmapping->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	graphicsSettings->Add(new CheckBox(&g_Config.bMipMap, gr->T("Mipmapping")));
 
 	CheckBox *hwTransform = graphicsSettings->Add(new CheckBox(&g_Config.bHardwareTransform, gr->T("Hardware Transform")));
 	hwTransform->OnClick.Handle(this, &GameSettingsScreen::OnHardwareTransform);
@@ -324,12 +323,12 @@ void GameSettingsScreen::CreateViews() {
 		}
 		return UI::EVENT_CONTINUE;
 	});
-	bezierChoiceDisable_ = g_Config.bSoftwareRendering || g_Config.bHardwareTessellation;
+	bezierChoiceDisable_ = g_Config.bHardwareTessellation;
 	beziersChoice->SetDisabledPtr(&bezierChoiceDisable_);
 
 	CheckBox *tessellationHW = graphicsSettings->Add(new CheckBox(&g_Config.bHardwareTessellation, gr->T("Hardware Tessellation", "Hardware tessellation (experimental)")));
 	tessellationHW->OnClick.Add([=](EventParams &e) {
-		bezierChoiceDisable_ = g_Config.bSoftwareRendering || g_Config.bHardwareTessellation;
+		bezierChoiceDisable_ = g_Config.bHardwareTessellation;
 		settingInfo_->Show(gr->T("HardwareTessellation Tip", "Uses hardware to make curves, always uses a fixed quality"), e.v);
 		return UI::EVENT_CONTINUE;
 	});
@@ -380,8 +379,7 @@ void GameSettingsScreen::CreateViews() {
 	anisoFiltering->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
 	static const char *texFilters[] = { "Auto", "Nearest", "Linear", "Linear on FMV", };
-	PopupMultiChoice *texFilter = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexFiltering, gr->T("Texture Filter"), texFilters, 1, ARRAY_SIZE(texFilters), gr->GetName(), screenManager()));
-	texFilter->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexFiltering, gr->T("Texture Filter"), texFilters, 1, ARRAY_SIZE(texFilters), gr->GetName(), screenManager()));
 
 	static const char *bufFilters[] = { "Linear", "Nearest", };
 	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));
@@ -794,7 +792,7 @@ UI::EventReturn GameSettingsScreen::OnSoftwareRendering(UI::EventParams &e) {
 	vtxCacheEnable_ = !g_Config.bSoftwareRendering && g_Config.bHardwareTransform;
 	postProcEnable_ = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 	resolutionEnable_ = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
-	bezierChoiceDisable_ = g_Config.bSoftwareRendering || g_Config.bHardwareTessellation;
+	bezierChoiceDisable_ = g_Config.bHardwareTessellation;
 	tessHWEnable_ = IsBackendSupportHWTess() && !g_Config.bSoftwareRendering && g_Config.bHardwareTransform;
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
There's a few things left to fix, but this largely implements all the mipmapping outlined in #9621.  The animations in #6357 work roughly as expected.

Things that remain:
 - [x] Verify behavior of invalid mip mode 3.
 - [x] Correctly handle pixel centers (using du and dv, I assume), especially for BR -> TL texturing.
 - [x] Linear filtering / mipmaps for lines?
 - [x] Check if linear filtering does anything at all for points (maybe for uneven UVs?)
 - [x] Further refactoring for SIMD.

Crisis Core looks quite a bit better with this rounding.  But, this does impact performance negatively overall.

-[Unknown]