### PR TITLE
Quick hack to enable analog stick sensitivity on non-windows platforms.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -690,8 +690,9 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("XInputAnalogDeadzone", &g_Config.fXInputAnalogDeadzone, 0.24f, true, true),
 	ConfigSetting("XInputAnalogInverseMode", &g_Config.iXInputAnalogInverseMode, 0, true, true),
 	ConfigSetting("XInputAnalogInverseDeadzone", &g_Config.fXInputAnalogInverseDeadzone, 0.0f, true, true),
-	ConfigSetting("XInputAnalogSensitivity", &g_Config.fXInputAnalogSensitivity, 1.0f, true, true),
 #endif
+	// Also reused as generic analog sensitivity
+	ConfigSetting("XInputAnalogSensitivity", &g_Config.fXInputAnalogSensitivity, 1.0f, true, true),
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 
 	ConfigSetting("UseMouse", &g_Config.bMouseControl, false, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -386,6 +386,7 @@ public:
 	float fDInputAnalogInverseDeadzone;
 	float fDInputAnalogSensitivity;
 
+	// We also use the XInput settings as analog settings on other platforms like Android.
 	float fXInputAnalogDeadzone;
 	int iXInputAnalogInverseMode;
 	float fXInputAnalogInverseDeadzone;

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -152,7 +152,7 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 		AxisInput axis;
 		axis.axisId = event.caxis.axis;
 		// 1.2 to try to approximate the PSP's clamped rectangular range.
-		axis.value = 1.2 * event.caxis.value / 32767.0f;
+		axis.value = 1.2 * event.caxis.value * g_Config.fXInputAnalogSensitivity / 32767.0f;
 		if (axis.value > 1.0f) axis.value = 1.0f;
 		if (axis.value < -1.0f) axis.value = -1.0f;
 		axis.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.caxis.which);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -561,6 +561,8 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputAnalogInverseMode, co->T("Analog Mapper Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), co->GetName(), screenManager()));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogInverseDeadzone, 0.0f, 1.0f, co->T("Analog Mapper Low End", "Analog Mapper Low End (Inverse Deadzone)"), 0.01f, screenManager(), "/ 1.0"));
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Mapper High End", "Analog Mapper High End (Axis Sensitivity)"), 0.01f, screenManager(), "x"));
+#else
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Axis Sensitivity", "Analog Axis Sensitivity"), 0.01f, screenManager(), "x"));
 #endif
 
 	controlsSettings->Add(new ItemHeader(co->T("Keyboard", "Keyboard Control Settings")));

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -814,6 +814,10 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 	axis.axisId = axisId;
 	axis.deviceId = deviceId;
 	axis.value = value;
+
+	float sensitivity = g_Config.fXInputAnalogSensitivity;
+	axis.value *= sensitivity;
+
 	return NativeAxis(axis);
 }
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -579,7 +579,7 @@ static GraphicsContext *graphicsContext;
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_X;
-		axisInput.value = value;
+		axisInput.value = value * g_Config.fXInputAnalogSensitivity;
 		NativeAxis(axisInput);
 	};
 	
@@ -588,7 +588,7 @@ static GraphicsContext *graphicsContext;
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_Y;
-		axisInput.value = -value;
+		axisInput.value = -value * g_Config.fXInputAnalogSensitivity;
 		NativeAxis(axisInput);
 	};
 	
@@ -598,7 +598,7 @@ static GraphicsContext *graphicsContext;
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_Z;
-		axisInput.value = value;
+		axisInput.value = value * g_Config.fXInputAnalogSensitivity;
 		NativeAxis(axisInput);
 	};
 	
@@ -607,7 +607,7 @@ static GraphicsContext *graphicsContext;
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_RZ;
-		axisInput.value = -value;
+		axisInput.value = -value * g_Config.fXInputAnalogSensitivity;
 		NativeAxis(axisInput);
 	};
 }


### PR DESCRIPTION
See #8028.

Not really happy with this though as we should instead move sensitivity processing to when we are putting together the struct for the PSP to read, and not in the input layer as it is currently. 