### PR TITLE
Make const mipmaps more consistent

### DIFF
--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -71,8 +71,9 @@ struct SamplerCacheKey {
 			bool tClamp : 1;
 			bool lodAuto : 1;
 			bool : 1;
-			int8_t lodBias : 8;
 			int8_t maxLevel : 4;
+			int8_t : 4;
+			int16_t lodBias : 16;
 		};
 	};
 
@@ -242,7 +243,7 @@ protected:
 	}
 
 	u32 EstimateTexMemoryUsage(const TexCacheEntry *entry);
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, bool &autoMip);
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -154,27 +154,18 @@ void TextureCacheDX9::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, entry.maxLevel, entry.addr);
+	bool autoMip;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, entry.maxLevel, entry.addr, autoMip);
 
 	if (entry.maxLevel != 0) {
-		GETexLevelMode mode = gstate.getTexLevelMode();
-		switch (mode) {
-		case GE_TEXLEVEL_MODE_AUTO:
+		if (autoMip) {
 			dxstate.texMaxMipLevel.set(0);
 			dxstate.texMipLodBias.set(lodBias);
-			break;
-		case GE_TEXLEVEL_MODE_CONST:
+		} else {
 			// TODO: This is just an approximation - texMaxMipLevel sets the lowest numbered mip to use.
 			// Unfortunately, this doesn't support a const 1.5 or etc.
-			dxstate.texMaxMipLevel.set((int)lodBias);
+			dxstate.texMaxMipLevel.set(std::max(0, std::min((int)entry.maxLevel, (int)lodBias)));
 			dxstate.texMipLodBias.set(-1000.0f);
-			break;
-		case GE_TEXLEVEL_MODE_SLOPE:
-			WARN_LOG_REPORT_ONCE(texSlope, G3D, "Unsupported texture lod slope: %f + %f", gstate.getTextureLodSlope(), lodBias);
-			// TODO: This behavior isn't correct.
-			dxstate.texMaxMipLevel.set(0);
-			dxstate.texMipLodBias.set(lodBias);
-			break;
 		}
 		entry.lodBias = lodBias;
 	} else {
@@ -203,7 +194,8 @@ void TextureCacheDX9::SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHe
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0);
+	bool autoMip;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
 
 	dxstate.texMinFilter.set(MinFilt[minFilt]);
 	dxstate.texMipFilter.set(MipFilt[minFilt]);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -124,6 +124,7 @@ const CommonCommandTableEntry commonCommandTable[] = {
 	{ GE_CMD_TEXSIZE7, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS },
 	{ GE_CMD_TEXFORMAT, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_IMAGE },
 	{ GE_CMD_TEXLEVEL, FLAG_EXECUTEONCHANGE, DIRTY_TEXTURE_PARAMS, &GPUCommon::Execute_TexLevel },
+	{ GE_CMD_TEXLODSLOPE, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS },
 	{ GE_CMD_TEXADDR0, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_IMAGE | DIRTY_UVSCALEOFFSET },
 	{ GE_CMD_TEXADDR1, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS },
 	{ GE_CMD_TEXADDR2, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS },
@@ -265,7 +266,6 @@ const CommonCommandTableEntry commonCommandTable[] = {
 
 	// Ignored commands
 	{ GE_CMD_TEXFLUSH, 0 },
-	{ GE_CMD_TEXLODSLOPE, 0 },
 	{ GE_CMD_TEXSYNC, 0 },
 
 	// These are just nop or part of other later commands.
@@ -1416,7 +1416,7 @@ void GPUCommon::Execute_TexLevel(u32 op, u32 diff) {
 	if (diff == 0xFFFFFFFF) return;
 
 	gstate.texlevel ^= diff;
-	if (gstate.getTexLevelMode() == GE_TEXLEVEL_MODE_CONST && (0x00FF0000 & gstate.texlevel) != 0) {
+	if (gstate.getTexLevelMode() != GE_TEXLEVEL_MODE_AUTO && (0x00FF0000 & gstate.texlevel) != 0) {
 		Flush();
 	}
 	gstate.texlevel ^= diff;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1226,7 +1226,7 @@ static inline void ApplyTexturing(Vec4<int> *prim_color, const Vec4<float> &s, c
 		break;
 	case GE_TEXLEVEL_MODE_CONST:
 	default:
-		// TODO: Verify what 3 does.
+		// Unused value 3 operates the same as CONST.
 		detail = 0;
 		break;
 	}

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -211,7 +211,8 @@ void TextureCacheVulkan::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, entry.maxLevel, entry.addr);
+	bool autoMip;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, entry.maxLevel, entry.addr, autoMip);
 	key.minFilt = minFilt & 1;
 	key.mipEnable = (minFilt >> 2) & 1;
 	key.mipFilt = (minFilt >> 1) & 1;
@@ -223,17 +224,10 @@ void TextureCacheVulkan::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	if (entry.maxLevel != 0) {
 		if (force || entry.lodBias != lodBias) {
 			if (gstate_c.Supports(GPU_SUPPORTS_TEXTURE_LOD_CONTROL)) {
-				GETexLevelMode mode = gstate.getTexLevelMode();
-				switch (mode) {
-				case GE_TEXLEVEL_MODE_AUTO:
+				if (autoMip) {
 					// TODO
-					break;
-				case GE_TEXLEVEL_MODE_CONST:
-					// Sigh, LOD_BIAS is not even in ES 3.0..
-					break;
-				case GE_TEXLEVEL_MODE_SLOPE:
+				} else {
 					// TODO
-					break;
 				}
 			}
 			entry.lodBias = lodBias;
@@ -252,7 +246,8 @@ void TextureCacheVulkan::SetFramebufferSamplingParams(u16 bufferWidth, u16 buffe
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0);
+	bool autoMip;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
 
 	key.minFilt = minFilt & 1;
 	key.mipFilt = 0;


### PR DESCRIPTION
From what I can tell, slope is entirely constant.  It sorta makes sense if you think of the slope as the UV slope, and this is an alternative to AUTO using the calculated slope.

Senjou no Valkyria 3 uses this on lamps.  I didn't find a case with a slope other than 0.015, but the bias is then varied between -2 and 0, which in other words varies the level between 0 and 1 (even though there are 7 mip levels.)  Maybe there are areas that use other slope values... I only checked two maps using them.

Anyway, this makes slope and const equivalent (after adding slope to bias), and flushes when slope changes.

-[Unknown]