### PR TITLE
SoftGPU: Correct for pixel centers

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1204,9 +1204,6 @@ static inline void ApplyTexturing(Vec4<int> *prim_color, const Vec4<float> &s, c
 	float ds = s[1] - s[0];
 	float dt = t[2] - t[0];
 
-	Vec4<float> os = s + Vec4<float>::AssignToAll(ds * 0.5f);
-	Vec4<float> ot = t + Vec4<float>::AssignToAll(dt * 0.5f);
-
 	// With 8 bits of fraction (because texslope can be fairly precise.)
 	int detail;
 	switch (gstate.getTexLevelMode()) {
@@ -1250,7 +1247,7 @@ static inline void ApplyTexturing(Vec4<int> *prim_color, const Vec4<float> &s, c
 	}
 
 	for (int i = 0; i < 4; ++i) {
-		ApplyTexturing(prim_color[i], os[i], ot[i], level, levelFrac, filt, texptr, texbufwidthbytes);
+		ApplyTexturing(prim_color[i], s[i], t[i], level, levelFrac, filt, texptr, texbufwidthbytes);
 	}
 }
 
@@ -1264,8 +1261,9 @@ struct TriangleEdge {
 };
 
 Vec4<int> TriangleEdge::Start(const ScreenCoords &v0, const ScreenCoords &v1, const ScreenCoords &origin) {
-	Vec4<int> initX = Vec4<int>::AssignToAll(origin.x) + Vec4<int>(0, 16, 0, 16);
-	Vec4<int> initY = Vec4<int>::AssignToAll(origin.y) + Vec4<int>(0, 0, 16, 16);
+	// Start at pixel centers.
+	Vec4<int> initX = Vec4<int>::AssignToAll(origin.x) + Vec4<int>(7, 23, 7, 23);
+	Vec4<int> initY = Vec4<int>::AssignToAll(origin.y) + Vec4<int>(7, 7, 23, 23);
 
 	// orient2d refactored.
 	int xf = v0.y - v1.y;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1201,14 +1201,17 @@ static inline void ApplyTexturing(Vec4<int> *prim_color, const Vec4<float> &s, c
 	int width = gstate.getTextureWidth(0);
 	int height = gstate.getTextureHeight(0);
 
-	float ds = (s[1] - s[0]) * width;
-	float dt = (t[2] - t[0]) * height;
+	float ds = s[1] - s[0];
+	float dt = t[2] - t[0];
+
+	Vec4<float> os = s + Vec4<float>::AssignToAll(ds * 0.5f);
+	Vec4<float> ot = t + Vec4<float>::AssignToAll(dt * 0.5f);
 
 	// With 8 bits of fraction (because texslope can be fairly precise.)
 	int detail;
 	switch (gstate.getTexLevelMode()) {
 	case GE_TEXLEVEL_MODE_AUTO:
-		detail = TexLog2(std::max(ds, dt));
+		detail = TexLog2(std::max(ds * width, dt * height));
 		break;
 	case GE_TEXLEVEL_MODE_SLOPE:
 		// This is always offset by an extra texlevel.
@@ -1247,7 +1250,7 @@ static inline void ApplyTexturing(Vec4<int> *prim_color, const Vec4<float> &s, c
 	}
 
 	for (int i = 0; i < 4; ++i) {
-		ApplyTexturing(prim_color[i], s[i], t[i], level, levelFrac, filt, texptr, texbufwidthbytes);
+		ApplyTexturing(prim_color[i], os[i], ot[i], level, levelFrac, filt, texptr, texbufwidthbytes);
 	}
 }
 
@@ -1677,6 +1680,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 				s *= 1.0f / (float)gstate.getTextureWidth(0);
 				t *= 1.0f / (float)gstate.getTextureHeight(0);
 			}
+			// TODO: ds/dt.
 			ApplyTexturing(prim_color, s, t, 0, 0, magFilt, texptr, texbufwidthbytes);
 		}
 


### PR DESCRIPTION
There's a few minor SIMD changes here, but the biggest change is to render at pixel centers.

Before, when rendering pixel 0,0 we were looking at (0.0, 0.0)'s edge, texturing, etc.  This caused a few errors in tests:
 * The triangles test had a few pixels missing because the edge of one triangle happened to be less than 100% on the pixel on the left side.
 * Texturing was off when U/V had a negative slope.
 * Linear filtering looked a bit "blurry" sometimes.

Starting at the half pixel offset fixes all these problems, and makes a lot of sense.  Plus it's free.

It's not perfect though: it seems very slightly off for [a couple test textures](https://github.com/hrydgard/pspautotests/blob/master/tests/gpu/vertices/texcoords.cpp#L72-L74).  I think it's a rounding issue.  But it's correct in most cases.

-[Unknown]