### PR TITLE
Minor GE debugger fixes

### DIFF
--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -536,15 +536,15 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 			DrawingCoords drawPos = ScreenToDrawing(screenPos);
 
 			if (gstate.vertType & GE_VTYPE_TC_MASK) {
-				vertices[i].u = vert.uv[0];
-				vertices[i].v = vert.uv[1];
+				vertices[i].u = vert.uv[0] * (float)gstate.getTextureWidth(0);
+				vertices[i].v = vert.uv[1] * (float)gstate.getTextureHeight(0);
 			} else {
 				vertices[i].u = 0.0f;
 				vertices[i].v = 0.0f;
 			}
 			vertices[i].x = drawPos.x;
 			vertices[i].y = drawPos.y;
-			vertices[i].z = 1.0;
+			vertices[i].z = drawPos.z;
 			if (gstate.vertType & GE_VTYPE_COL_MASK) {
 				memcpy(vertices[i].c, vert.color, sizeof(vertices[i].c));
 			} else {
@@ -552,6 +552,10 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 			}
 		}
 	}
+
+	// The GE debugger expects these to be set.
+	gstate_c.curTextureWidth = gstate.getTextureWidth(0);
+	gstate_c.curTextureHeight = gstate.getTextureHeight(0);
 
 	return true;
 }

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -657,7 +657,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 	case CMD_FMT_TEXLEVEL:
 		{
 			const char *mipLevelModes[] = {
-				"auto",
+				"auto + bias",
 				"bias",
 				"slope + bias",
 			};
@@ -665,9 +665,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			const int biasFixed = (s8)(value >> 16);
 			const float bias = (float)biasFixed / 16.0f;
 
-			if (mipLevel == 0 && bias == 0) {
-				swprintf(dest, L"%S", mipLevelModes[mipLevel]);
-			} else if (mipLevel == 1 || mipLevel == 2) {
+			if (mipLevel == 0 || mipLevel == 1 || mipLevel == 2) {
 				swprintf(dest, L"%S: %f", mipLevelModes[mipLevel], bias);
 			} else {
 				swprintf(dest, L"%06x", value);


### PR DESCRIPTION
This mainly fixes the texture vertex preview in SoftGPU, and also cleans up bias display (previously we acted like auto could not have a bias, both in the debugger and in the GPU.)

-[Unknown]