### PR TITLE
Fix lines in the software renderer

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -240,7 +240,33 @@ void ProcessLine(VertexData& v0, VertexData& v1)
 		return;
 	}
 
-	// TODO: 3D lines
+	VertexData *Vertices[2] = {&v0, &v1};
+
+	int mask0 = CalcClipMask(v0.clippos);
+	int mask1 = CalcClipMask(v1.clippos);
+	int mask = mask0 | mask1;
+
+	if (mask && (gstate.clipEnable & 0x1)) {
+		// discard if any vertex is outside the near clipping plane
+		if (mask & CLIP_NEG_Z_BIT)
+			return;
+
+		CLIP_LINE(CLIP_POS_X_BIT, -1,  0,  0, 1);
+		CLIP_LINE(CLIP_NEG_X_BIT,  1,  0,  0, 1);
+		CLIP_LINE(CLIP_POS_Y_BIT,  0, -1,  0, 1);
+		CLIP_LINE(CLIP_NEG_Y_BIT,  0,  1,  0, 1);
+		CLIP_LINE(CLIP_POS_Z_BIT,  0,  0,  0, 1);
+		CLIP_LINE(CLIP_NEG_Z_BIT,  0,  0,  1, 1);
+	} else if (mask0 & mask1) {
+		// If clipping is disabled, only discard the current primitive
+		// if both vertices lie outside one of the clipping planes
+		return;
+	}
+
+	VertexData data[2] = { *Vertices[0], *Vertices[1] };
+	data[0].screenpos = TransformUnit::ClipToScreen(data[0].clippos);
+	data[1].screenpos = TransformUnit::ClipToScreen(data[1].clippos);
+	Rasterizer::DrawLine(data[0], data[1]);
 }
 
 void ProcessTriangle(VertexData& v0, VertexData& v1, VertexData& v2)

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -246,6 +246,11 @@ void ProcessLine(VertexData& v0, VertexData& v1)
 	int mask1 = CalcClipMask(v1.clippos);
 	int mask = mask0 | mask1;
 
+	if (mask0 & mask1) {
+		// Even if clipping is disabled, we can discard if the line is entirely outside.
+		return;
+	}
+
 	if (mask && (gstate.clipEnable & 0x1)) {
 		// discard if any vertex is outside the near clipping plane
 		if (mask & CLIP_NEG_Z_BIT)
@@ -257,10 +262,6 @@ void ProcessLine(VertexData& v0, VertexData& v1)
 		CLIP_LINE(CLIP_NEG_Y_BIT,  0,  1,  0, 1);
 		CLIP_LINE(CLIP_POS_Z_BIT,  0,  0,  0, 1);
 		CLIP_LINE(CLIP_NEG_Z_BIT,  0,  0,  1, 1);
-	} else if (mask0 & mask1) {
-		// If clipping is disabled, only discard the current primitive
-		// if both vertices lie outside one of the clipping planes
-		return;
 	}
 
 	VertexData data[2] = { *Vertices[0], *Vertices[1] };

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -15,6 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
+#include <cmath>
+
 #include "base/basictypes.h"
 #include "profiler/profiler.h"
 
@@ -28,8 +31,6 @@
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Software/SoftGpu.h"
 #include "GPU/Software/Rasterizer.h"
-
-#include <algorithm>
 
 #if defined(_M_SSE)
 #include <emmintrin.h>
@@ -1650,11 +1651,11 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 		}
 	}
 
-	float x = a.x;
-	float y = a.y;
+	float x = a.x > b.x ? a.x - 1 : a.x;
+	float y = a.y > b.y ? a.y - 1 : a.y;
 	float z = a.z;
 	const int steps1 = steps == 0 ? 1 : steps;
-	for (int i = 0; i <= steps; i++) {
+	for (int i = 0; i < steps; i++) {
 		if (x >= scissorTL.x && y >= scissorTL.y && x <= scissorBR.x && y <= scissorBR.y) {
 			// Interpolate between the two points.
 			Vec4<int> prim_color;
@@ -1691,7 +1692,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 			if (!clearMode)
 				prim_color += Vec4<int>(sec_color, 0);
 
-			ScreenCoords pprime = ScreenCoords(x, y, z);
+			ScreenCoords pprime = ScreenCoords((int)x, (int)y, (int)z);
 
 			DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
 			if (clearMode) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1657,9 +1657,16 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 	for (int i = 0; i <= steps; i++) {
 		if (x >= scissorTL.x && y >= scissorTL.y && x <= scissorBR.x && y <= scissorBR.y) {
 			// Interpolate between the two points.
-			// TODO: gstate.getShadeMode() == GE_SHADE_GOURAUD
-			Vec4<int> prim_color = (v0.color0 * (steps - i) + v1.color0 * i) / steps1;
-			Vec3<int> sec_color = (v0.color1 * (steps - i) + v1.color1 * i) / steps1;
+			Vec4<int> prim_color;
+			Vec3<int> sec_color;
+			if (gstate.getShadeMode() == GE_SHADE_GOURAUD) {
+				prim_color = (v0.color0 * (steps - i) + v1.color0 * i) / steps1;
+				sec_color = (v0.color1 * (steps - i) + v1.color1 * i) / steps1;
+			} else {
+				prim_color = v1.color0;
+				sec_color = v1.color1;
+			}
+
 			// TODO: UVGenMode?
 			Vec2<float> tc = (v0.texturecoords * (float)(steps - i) + v1.texturecoords * (float)i) / steps1;
 


### PR DESCRIPTION
This implements lines in transform mode (such that Persona 2, etc. look good), and also implements mipmapping for them (in case used.)

Also implements a very basic version of antialias, mostly so the incorrect texture UVs don't show like in #6483.

-[Unknown]