### PR TITLE
Windows: Avoid input race condition on GPU switch

### DIFF
--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -891,10 +891,12 @@ namespace MainWindow
 
 		case WM_USER_RESTART_EMUTHREAD:
 			NativeSetRestarting();
+			InputDevice::StopPolling();
 			EmuThread_Stop();
 			coreState = CORE_POWERUP;
 			ResetUIState();
 			EmuThread_Start();
+			InputDevice::BeginPolling();
 			break;
 
 		case WM_MENUSELECT:


### PR DESCRIPTION
The issue is worse if polling controllers (i.e. XInput) is slow, but we want to stop that thread while we're resetting `host`.

I can't actually reproduce #9702, but hoping this will help.

-[Unknown]