### PR TITLE
SoftGPU: Use vertexjit for submitted primitives

### DIFF
--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -45,7 +45,7 @@ struct FormatBuffer {
 	}
 };
 
-class ShaderManagerGLES;
+class SoftwareDrawEngine;
 
 class SoftGPU : public GPUCommon {
 public:
@@ -102,6 +102,8 @@ private:
 	u32 displayFramebuf_;
 	u32 displayStride_;
 	GEBufferFormat displayFormat_;
+
+	SoftwareDrawEngine *drawEngine_ = nullptr;
 
 	Draw::Texture *fbTex;
 	Draw::Pipeline *texColor;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "CommonTypes.h"
+#include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Math3D.h"
 
@@ -29,6 +30,17 @@ typedef Vec3<float> ModelCoords;
 typedef Vec3<float> WorldCoords;
 typedef Vec3<float> ViewCoords;
 typedef Vec4<float> ClipCoords; // Range: -w <= x/y/z <= w
+
+class SoftwareDrawEngine : public DrawEngineCommon {
+public:
+	SoftwareDrawEngine();
+	~SoftwareDrawEngine();
+
+	void DispatchFlush() override;
+	void DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int *bytesRead) override;
+
+	VertexDecoder *FindVertexDecoder(u32 vtype);
+};
 
 struct SplinePatch;
 
@@ -126,7 +138,7 @@ public:
 	static DrawingCoords ScreenToDrawing(const ScreenCoords& coords);
 	static ScreenCoords DrawingToScreen(const DrawingCoords& coords);
 
-	static void SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead);
+	static void SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine);
 
 	static bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 	static VertexData ReadVertex(VertexReader& vreader);


### PR DESCRIPTION
This uses the standard cache other rendering uses.  A relatively easy change.

In Legend of Heroes 3, for example, this provides a 10% speed improvement... and 12% when samplerjit is also involved.  But many games show little/no improvement, since it's largely dependent on how many verts are being pushed and how complex they are.

-[Unknown]