### PR TITLE
SoftGPU: Fix rendering when using Direct3D 9

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -169,7 +169,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 		break;
 	case GPUBackend::VULKAN:
 		coreParam.gpuCore = GPUCORE_VULKAN;
-		if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
+		if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !g_Config.bSoftwareRendering) {
 #ifdef _WIN32
 			if (IDYES == MessageBox(MainWindow::GetHWND(), L"The Vulkan backend is not yet compatible with buffered rendering. Switch to non-buffered (WARNING: This will cause glitches with the other backends unless you switch back)", L"Vulkan Experimental Support", MB_ICONINFORMATION | MB_YESNO)) {
 				g_Config.iRenderingMode = FB_NON_BUFFERED_MODE;

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -925,23 +925,19 @@ void D3D9Context::Clear(int mask, uint32_t colorval, float depthVal, int stencil
 }
 
 void D3D9Context::SetScissorRect(int left, int top, int width, int height) {
-	RECT rc;
-	rc.left = left;
-	rc.top = top;
-	rc.right = left + width;
-	rc.bottom = top + height;
-	device_->SetScissorRect(&rc);
+	using namespace DX9;
+
+	dxstate.scissorRect.set(left, top, left + width, top + height);
 }
 
 void D3D9Context::SetViewports(int count, Viewport *viewports) {
-	D3DVIEWPORT9 vp;
-	vp.X = (DWORD)viewports[0].TopLeftX;
-	vp.Y = (DWORD)viewports[0].TopLeftY;
-	vp.Width = (DWORD)viewports[0].Width;
-	vp.Height = (DWORD)viewports[0].Height;
-	vp.MinZ = viewports[0].MinDepth;
-	vp.MaxZ = viewports[0].MaxDepth;
-	device_->SetViewport(&vp);
+	using namespace DX9;
+
+	int x = (int)viewports[0].TopLeftX;
+	int y = (int)viewports[0].TopLeftY;
+	int w = (int)viewports[0].Width;
+	int h = (int)viewports[0].Height;
+	dxstate.viewport.set(x, y, w, h, viewports[0].MinDepth, viewports[0].MaxDepth);
 }
 
 void D3D9Context::SetBlendFactor(float color[4]) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1537,6 +1537,7 @@ void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo) {
 	// in ES 2.0 that actually separate them anyway of course, so doesn't matter.
 	fbo_bind_fb_target(false, fb->handle);
 	// Always restore viewport after render target binding
+	// TODO: Should we set viewports this way too?
 	glstate.viewport.restore();
 	CHECK_GL_ERROR_IF_DEBUG();
 }


### PR DESCRIPTION
Since we restore dxstate when setting a framebuffer or backbuffer, we need something that populates it.

It doesn't seem to be a problem in OpenGL, though, and I'm not sure if we're somehow relying on that, so I didn't change it there.

-[Unknown]