### PR TITLE
Add sceKernelLoadExec_28D0D249.

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -886,6 +886,7 @@ const HLEFunction LoadExecForKernel[] =
 {
 	{0x4AC57943, &WrapI_I<sceKernelRegisterExitCallback>,            "sceKernelRegisterExitCallback",             'i', "i",      HLE_KERNEL_SYSCALL },
 	{0XA3D5E142, nullptr,                                            "LoadExecForKernel_a3d5e142",                '?', ""        },
+	{0X28D0D249, &WrapI_CU<sceKernelLoadExec>,                       "sceKernelLoadExec_28D0D249",                'i', "sx"      },
 };
  
 void Register_LoadExecForKernel()


### PR DESCRIPTION
Fixes #9075
At least allows games to load and play, since as mentioned in that issue, the game's pauses like every second or two, it has a slight variation depending on how quickly the game is launched or some other factor. Not really sure if that's emulation issue or homebrew bug, but I doubt anyone would release homebrew that works that way:P.

 On a side note tried to test some compat.ini hacks with it and realized those currently can't work for homebrew ~ no gameID, blah.:c