### PR TITLE
Init rtcBaseTime.tv_usec to 0 to return matching time in some syscalls

### DIFF
--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -129,7 +129,7 @@ void __RtcInit()
 	timeval tv;
 	gettimeofday(&tv, NULL);
 	rtcBaseTime.tv_sec = tv.tv_sec;
-	rtcBaseTime.tv_usec = tv.tv_usec;
+	rtcBaseTime.tv_usec = 0;
 	// Precalculate the current time in microseconds (rtcMagicOffset is offset to 1970.)
 	rtcBaseTicks = 1000000ULL * rtcBaseTime.tv_sec + rtcBaseTime.tv_usec + rtcMagicOffset;
 }


### PR DESCRIPTION
Alternatively we could make sceKernelLibcTime do more, but those added usec doesn't matter in fact might be incorrect as they cause unstable results depending on time the app was booted.
Fixes #9711, probably also #8748.