### PR TITLE
Use InitMemoryForGamePBP also for homebrew(PSP_PBP_DIRECTORY).

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -230,11 +230,10 @@ void CPU_Init() {
 		InitMemoryForGameISO(loadedFile);
 		break;
 	case IdentifiedFileType::PSP_PBP:
-		InitMemoryForGamePBP(loadedFile);
-		break;
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 		// This is normal for homebrew.
 		// ERROR_LOG(LOADER, "PBP directory resolution failed.");
+		InitMemoryForGamePBP(loadedFile);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Fixes #9719

Makes "Quake 2 by CROW_BAR" playable again which will be another nicely working homebrew, not counting it's mp3 problem:].