### PR TITLE
SoftGPU Android rescue operation

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -483,7 +483,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("ShowFPSCounter", &g_Config.iShowFPSCounter, 0, true, true),
 	ReportedConfigSetting("GPUBackend", &g_Config.iGPUBackend, 0),
 	ReportedConfigSetting("RenderingMode", &g_Config.iRenderingMode, &DefaultRenderingMode, true, true),
-	ConfigSetting("SoftwareRendering", &g_Config.bSoftwareRendering, false, true, true),
+	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, true, true),
 	ReportedConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true, true, true),
 	ReportedConfigSetting("SoftwareSkinning", &g_Config.bSoftwareSkinning, true, true, true),
 	ReportedConfigSetting("TextureFiltering", &g_Config.iTexFiltering, 1, true, true),

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -262,6 +262,10 @@ void ElfReader::LoadRelocations2(int rel_seg)
 		}else{
 			addr_seg = seg;
 			relocate_to = segmentVAddr[addr_seg];
+			if (!Memory::IsValidAddress(relocate_to)) {
+				ERROR_LOG(LOADER, "ELF: Bad address to relocate to: %08x", relocate_to);
+				continue;
+			}
 
 			if((flag&0x06)==0x00){
 				rel_offset = cmd;
@@ -290,6 +294,10 @@ void ElfReader::LoadRelocations2(int rel_seg)
 
 
 			rel_offset = rel_base+segmentVAddr[off_seg];
+			if (!Memory::IsValidAddress(relocate_to)) {
+				ERROR_LOG(LOADER, "ELF: Bad rel_offset: %08x", rel_offset);
+				continue;
+			}
 
 			if((flag&0x38)==0x00){
 				lo16 = 0;

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -294,7 +294,7 @@ void ElfReader::LoadRelocations2(int rel_seg)
 
 
 			rel_offset = rel_base+segmentVAddr[off_seg];
-			if (!Memory::IsValidAddress(relocate_to)) {
+			if (!Memory::IsValidAddress(rel_offset)) {
 				ERROR_LOG(LOADER, "ELF: Bad rel_offset: %08x", rel_offset);
 				continue;
 			}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -219,7 +219,7 @@ void GameSettingsScreen::CreateViews() {
 	blockTransfer->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
 	bool showSoftGPU = true;
-#if PPSSPP_PLATFORM(ANDROID)
+#ifdef MOBILE_DEVICE
 	// On Android, only show the software rendering setting if it's already enabled.
 	// Can still be turned on through INI file editing.
 	showSoftGPU = g_Config.bSoftwareRendering;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -217,16 +217,25 @@ void GameSettingsScreen::CreateViews() {
 		return UI::EVENT_CONTINUE;
 	});
 	blockTransfer->SetDisabledPtr(&g_Config.bSoftwareRendering);
-	CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (slow)")));
-	softwareGPU->OnClick.Add([=](EventParams &e) {
-		if (g_Config.bSoftwareRendering)
-			settingInfo_->Show(gr->T("SoftGPU Tip", "Currently VERY slow"), e.v);
-		bloomHackEnable_ = !g_Config.bSoftwareRendering && (g_Config.iInternalResolution != 1);
-		return UI::EVENT_CONTINUE;
-	});
-	softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);
-	if (PSP_IsInited())
-		softwareGPU->SetEnabled(false);
+
+	bool showSoftGPU = true;
+#if PPSSPP_PLATFORM(ANDROID)
+	// On Android, only show the software rendering setting if it's already enabled.
+	// Can still be turned on through INI file editing.
+	showSoftGPU = g_Config.bSoftwareRendering;
+#endif
+	if (showSoftGPU) {
+		CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (slow)")));
+		softwareGPU->OnClick.Add([=](EventParams &e) {
+			if (g_Config.bSoftwareRendering)
+				settingInfo_->Show(gr->T("SoftGPU Tip", "Currently VERY slow"), e.v);
+			bloomHackEnable_ = !g_Config.bSoftwareRendering && (g_Config.iInternalResolution != 1);
+			return UI::EVENT_CONTINUE;
+		});
+		softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);
+		if (PSP_IsInited())
+			softwareGPU->SetEnabled(false);
+	}
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Frame Rate Control")));
 	static const char *frameSkip[] = {"Off", "1", "2", "3", "4", "5", "6", "7", "8"};


### PR DESCRIPTION
On Android, crashes in SoftGPU is in the top 3 crashes being reported. 

The cause of the crashes has been found and fixed, it happens to only affect ARMv7 devices.

This probably means that a lot of users are stuck with it enabled, and they won't even see the warning to turn it off if things are slow because it'll just crash. And if they do, it might not have been translated to their language. The software renderer is still too slow to be much use on mobile devices at all.

So what this change does is:

  * Rename the setting to force it off for everyone.
  * Hide the setting on Android if it's not already on. It can thus be turned on from INI and turned off from UI.

With an update, we should get all these users out of their trouble, while the setting can still be turned on for development purposes by editing the ini.
