### PR TITLE
Remove "Always Depth Write" setting. One step forward for #8171

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -532,7 +532,6 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("TexDeposterize", &g_Config.bTexDeposterize, false, true, true),
 	ConfigSetting("VSyncInterval", &g_Config.bVSync, false, true, true),
 	ReportedConfigSetting("DisableStencilTest", &g_Config.bDisableStencilTest, false, true, true),
-	ReportedConfigSetting("AlwaysDepthWrite", &g_Config.bAlwaysDepthWrite, false, true, true),
 	ReportedConfigSetting("BloomHack", &g_Config.iBloomHack, 0, true, true),
 
 	// Not really a graphics setting...

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -209,7 +209,6 @@ public:
 	bool bReloadCheats;
 	int iCwCheatRefreshRate;
 	bool bDisableStencilTest;
-	bool bAlwaysDepthWrite;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
 	bool bTimerHack;
 	bool bBlockTransferGPU;

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -195,7 +195,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 		}
 	}
 
-	bool alwaysDepthWrite = g_Config.bAlwaysDepthWrite;
 	bool enableStencilTest = !g_Config.bDisableStencilTest;
 
 	{
@@ -222,7 +221,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			dxstate.depthTest.enable();
 			dxstate.depthFunc.set(D3DCMP_ALWAYS);
 			dxstate.depthWrite.set(gstate.isClearModeDepthMask());
-			if (gstate.isClearModeDepthMask() || alwaysDepthWrite) {
+			if (gstate.isClearModeDepthMask()) {
 				framebufferManager_->SetDepthUpdated();
 			}
 

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -277,13 +277,12 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 	}
 
 	{
-		bool alwaysDepthWrite = g_Config.bAlwaysDepthWrite;
 		bool enableStencilTest = !g_Config.bDisableStencilTest;
 		if (gstate.isModeClear()) {
 			// Depth Test
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);
-			glstate.depthWrite.set(gstate.isClearModeDepthMask() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
+			glstate.depthWrite.set(gstate.isClearModeDepthMask() ? GL_TRUE : GL_FALSE);
 			if (gstate.isClearModeDepthMask() || alwaysDepthWrite) {
 				framebufferManager_->SetDepthUpdated();
 			}
@@ -306,8 +305,8 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			if (gstate.isDepthTestEnabled()) {
 				glstate.depthTest.enable();
 				glstate.depthFunc.set(compareOps[gstate.getDepthTestFunction()]);
-				glstate.depthWrite.set(gstate.isDepthWriteEnabled() || alwaysDepthWrite ? GL_TRUE : GL_FALSE);
-				if (gstate.isDepthWriteEnabled() || alwaysDepthWrite) {
+				glstate.depthWrite.set(gstate.isDepthWriteEnabled() ? GL_TRUE : GL_FALSE);
+				if (gstate.isDepthWriteEnabled()) {
 					framebufferManager_->SetDepthUpdated();
 				}
 			} else {

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -283,7 +283,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			glstate.depthTest.enable();
 			glstate.depthFunc.set(GL_ALWAYS);
 			glstate.depthWrite.set(gstate.isClearModeDepthMask() ? GL_TRUE : GL_FALSE);
-			if (gstate.isClearModeDepthMask() || alwaysDepthWrite) {
+			if (gstate.isClearModeDepthMask()) {
 				framebufferManager_->SetDepthUpdated();
 			}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -425,9 +425,6 @@ void GameSettingsScreen::CreateViews() {
 	CheckBox *stencilTest = graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gr->T("Disable Stencil Test")));
 	stencilTest->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
-	CheckBox *depthWrite = graphicsSettings->Add(new CheckBox(&g_Config.bAlwaysDepthWrite, gr->T("Always Depth Write")));
-	depthWrite->SetDisabledPtr(&g_Config.bSoftwareRendering);
-
 	static const char *bloomHackOptions[] = { "Off", "Safe", "Balanced", "Aggressive" };
 	PopupMultiChoice *bloomHack = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iBloomHack, gr->T("Lower resolution for effects (reduces artifacts)"), bloomHackOptions, 0, ARRAY_SIZE(bloomHackOptions), gr->GetName(), screenManager()));
 	bloomHackEnable_ = !g_Config.bSoftwareRendering && (g_Config.iInternalResolution != 1);


### PR DESCRIPTION
This option was only for working around a problem in Saint Seiya and Jeanne D'Arc on ES 2.0 devices where we can't blit depth buffers. Don't really think it's worth keeping, ES 2.0 devices are a diminishing part of the market and they are probably mostly not fast enough to run these games very well anyway. 

#8171 