### PR TITLE
SoftGPU: Sampler jit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,6 +1089,7 @@ list(APPEND CoreExtra
 	Core/MIPS/x86/RegCacheFPU.cpp
 	Core/MIPS/x86/RegCacheFPU.h
 	GPU/Common/VertexDecoderX86.cpp
+	GPU/Software/SamplerX86.cpp
 )
 
 list(APPEND CoreExtra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,6 +1284,8 @@ set(GPU_SOURCES
 	GPU/Software/Lighting.h
 	GPU/Software/Rasterizer.cpp
 	GPU/Software/Rasterizer.h
+	GPU/Software/Sampler.cpp
+	GPU/Software/Sampler.h
 	GPU/Software/SoftGpu.cpp
 	GPU/Software/SoftGpu.h
 	GPU/Software/TransformUnit.cpp

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1673,6 +1673,11 @@ void XEmitter::PUNPCKLWD(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x61, 
 void XEmitter::PUNPCKLDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x62, dest, arg);}
 void XEmitter::PUNPCKLQDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6C, dest, arg);}
 
+void XEmitter::PUNPCKHBW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x68, dest, arg);}
+void XEmitter::PUNPCKHWD(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x69, dest, arg);}
+void XEmitter::PUNPCKHDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6A, dest, arg);}
+void XEmitter::PUNPCKHQDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6D, dest, arg);}
+
 void XEmitter::PSRLW(X64Reg reg, int shift)
 {
 	WriteSSEOp(0x66, 0x71, (X64Reg)2, R(reg));
@@ -1735,6 +1740,11 @@ void XEmitter::PSRAD(X64Reg reg, int shift)
 	WriteSSEOp(0x66, 0x72, (X64Reg)4, R(reg));
 	Write8(shift);
 }
+
+void XEmitter::PMULLW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xD5, dest, arg);}
+void XEmitter::PMULHW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xE5, dest, arg);}
+void XEmitter::PMULHUW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xE4, dest, arg);}
+void XEmitter::PMULUDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xF4, dest, arg);}
 
 void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -756,6 +756,11 @@ public:
 	void PUNPCKLDQ(X64Reg dest, const OpArg &arg);
 	void PUNPCKLQDQ(X64Reg dest, const OpArg &arg);
 
+	void PUNPCKHBW(X64Reg dest, const OpArg &arg);
+	void PUNPCKHWD(X64Reg dest, const OpArg &arg);
+	void PUNPCKHDQ(X64Reg dest, const OpArg &arg);
+	void PUNPCKHQDQ(X64Reg dest, const OpArg &arg);
+
 	void PTEST(X64Reg dest, OpArg arg);
 	void PAND(X64Reg dest, OpArg arg);
 	void PANDN(X64Reg dest, OpArg arg);
@@ -833,6 +838,11 @@ public:
 
 	void PSRAW(X64Reg reg, int shift);
 	void PSRAD(X64Reg reg, int shift);
+
+	void PMULLW(X64Reg dest, const OpArg &arg);
+	void PMULHW(X64Reg dest, const OpArg &arg);
+	void PMULHUW(X64Reg dest, const OpArg &arg);
+	void PMULUDQ(X64Reg dest, const OpArg &arg);
 
 	// SSE4: data type conversions
 	void PMOVSXBW(X64Reg dest, OpArg arg);

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -1075,7 +1075,6 @@ static const float MEMORY_ALIGNED16(byColor565[4]) = { 255.0f / 31.0f, 255.0f / 
 
 void VertexDecoderJitCache::Jit_Color565Morph() {
 	MOV(PTRBITS, R(tempReg1), ImmPtr(&gstate_c.morphWeights[0]));
-	MOV(32, R(tempReg2), Imm32(1));
 	MOVDQA(XMM5, M(color565Mask));
 	MOVAPS(XMM6, M(byColor565));
 

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -352,6 +352,7 @@
     <ClCompile Include="Software\Lighting.cpp" />
     <ClCompile Include="Software\Rasterizer.cpp" />
     <ClCompile Include="Software\Sampler.cpp" />
+    <ClCompile Include="Software\SamplerX86.cpp" />
     <ClCompile Include="Software\SoftGpu.cpp" />
     <ClCompile Include="Software\TransformUnit.cpp" />
     <ClCompile Include="Common\TextureDecoder.cpp" />

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -250,6 +250,7 @@
     <ClInclude Include="Software\Clipper.h" />
     <ClInclude Include="Software\Lighting.h" />
     <ClInclude Include="Software\Rasterizer.h" />
+    <ClInclude Include="Software\Sampler.h" />
     <ClInclude Include="Software\SoftGpu.h" />
     <ClInclude Include="Software\TransformUnit.h" />
     <ClInclude Include="Common\TextureDecoder.h" />
@@ -350,6 +351,7 @@
     <ClCompile Include="Software\Clipper.cpp" />
     <ClCompile Include="Software\Lighting.cpp" />
     <ClCompile Include="Software\Rasterizer.cpp" />
+    <ClCompile Include="Software\Sampler.cpp" />
     <ClCompile Include="Software\SoftGpu.cpp" />
     <ClCompile Include="Software\TransformUnit.cpp" />
     <ClCompile Include="Common\TextureDecoder.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -516,5 +516,8 @@
     <ClCompile Include="Software\Sampler.cpp">
       <Filter>Software</Filter>
     </ClCompile>
+    <ClCompile Include="Software\SamplerX86.cpp">
+      <Filter>Software</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -259,6 +259,9 @@
     <ClInclude Include="Common\ShaderTranslation.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="Software\Sampler.h">
+      <Filter>Software</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -509,6 +512,9 @@
     </ClCompile>
     <ClCompile Include="Vulkan\FramebufferVulkan.cpp">
       <Filter>Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Software\Sampler.cpp">
+      <Filter>Software</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1003,7 +1003,7 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, u8 fog, const Vec4<in
 	SetPixelColor(p.x, p.y, new_color);
 }
 
-static inline void ApplyTexturing(Sampler::NearestFunc sampler, Vec4<int> &prim_color, float s, float t, int texlevel, int frac_texlevel, bool bilinear, u8 *texptr[], int texbufw[]) {
+static inline void ApplyTexturing(Sampler::Funcs sampler, Vec4<int> &prim_color, float s, float t, int texlevel, int frac_texlevel, bool bilinear, u8 *texptr[], int texbufw[]) {
 	int u[8] = {0}, v[8] = {0};   // 1.23.8 fixed point
 	int frac_u[2], frac_v[2];
 
@@ -1021,9 +1021,9 @@ static inline void ApplyTexturing(Sampler::NearestFunc sampler, Vec4<int> &prim_
 			GetTexelCoordinates(texlevel + 1, s, t, u[1], v[1]);
 		}
 
-		texcolor0 = Vec4<int>::FromRGBA(sampler(u[0], v[0], tptr0, bufw0, texlevel));
+		texcolor0 = Vec4<int>::FromRGBA(sampler.nearest(u[0], v[0], tptr0, bufw0, texlevel));
 		if (frac_texlevel) {
-			texcolor1 = Vec4<int>::FromRGBA(sampler(u[1], v[1], tptr1, bufw1, texlevel + 1));
+			texcolor1 = Vec4<int>::FromRGBA(sampler.nearest(u[1], v[1], tptr1, bufw1, texlevel + 1));
 		}
 	} else {
 		GetTexelCoordinatesQuad(texlevel, s, t, u, v, frac_u[0], frac_v[0]);
@@ -1031,9 +1031,9 @@ static inline void ApplyTexturing(Sampler::NearestFunc sampler, Vec4<int> &prim_
 			GetTexelCoordinatesQuad(texlevel + 1, s, t, u + 4, v + 4, frac_u[1], frac_v[1]);
 		}
 
-		texcolor0 = Sampler::SampleLinear(sampler, u, v, frac_u[0], frac_v[0], tptr0, bufw0, texlevel);
+		texcolor0 = Vec4<int>::FromRGBA(sampler.linear(u, v, frac_u[0], frac_v[0], tptr0, bufw0, texlevel));
 		if (frac_texlevel) {
-			texcolor1 = Sampler::SampleLinear(sampler, u + 4, v + 4, frac_u[1], frac_v[1], tptr1, bufw1, texlevel + 1);
+			texcolor1 = Vec4<int>::FromRGBA(sampler.linear(u + 4, v + 4, frac_u[1], frac_v[1], tptr1, bufw1, texlevel + 1));
 		}
 	}
 
@@ -1106,7 +1106,7 @@ static inline void CalculateSamplingParams(const float ds, const float dt, const
 	}
 }
 
-static inline void ApplyTexturing(Sampler::NearestFunc sampler, Vec4<int> *prim_color, const Vec4<float> &s, const Vec4<float> &t, int maxTexLevel, u8 *texptr[], int texbufw[]) {
+static inline void ApplyTexturing(Sampler::Funcs sampler, Vec4<int> *prim_color, const Vec4<float> &s, const Vec4<float> &t, int maxTexLevel, u8 *texptr[], int texbufw[]) {
 	float ds = s[1] - s[0];
 	float dt = t[2] - t[0];
 
@@ -1245,7 +1245,7 @@ void DrawTriangleSlice(
 	// This is common, and when we interpolate, we lose accuracy.
 	const bool flatZ = v0.screenpos.z == v1.screenpos.z && v0.screenpos.z == v2.screenpos.z;
 
-	Sampler::NearestFunc sampler = Sampler::GetNearestFunc();
+	Sampler::Funcs sampler = Sampler::GetFuncs();
 
 	for (pprime.y = minY + hy1 * 32; pprime.y < minY + hy2 * 32; pprime.y += 32,
 										w0_base = e0.StepY(w0_base),
@@ -1414,7 +1414,7 @@ void DrawPoint(const VertexData &v0)
 
 	bool clearMode = gstate.isModeClear();
 
-	Sampler::NearestFunc sampler = Sampler::GetNearestFunc();
+	Sampler::Funcs sampler = Sampler::GetFuncs();
 
 	if (gstate.isTextureMapEnabled() && !clearMode) {
 		int texbufw[8] = {0};
@@ -1519,7 +1519,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 		}
 	}
 
-	Sampler::NearestFunc sampler = Sampler::GetNearestFunc();
+	Sampler::Funcs sampler = Sampler::GetFuncs();
 
 	float x = a.x > b.x ? a.x - 1 : a.x;
 	float y = a.y > b.y ? a.y - 1 : a.y;
@@ -1638,12 +1638,12 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 	int texbufw = GetTextureBufw(level, texaddr, texfmt);
 	u8 *texptr = Memory::GetPointer(texaddr);
 
-	Sampler::NearestFunc sampler = Sampler::GetNearestFunc();
+	Sampler::Funcs sampler = Sampler::GetFuncs();
 
 	u32 *row = (u32 *)buffer.GetData();
 	for (int y = 0; y < h; ++y) {
 		for (int x = 0; x < w; ++x) {
-			row[x] = sampler(x, y, texptr, texbufw, level);
+			row[x] = sampler.nearest(x, y, texptr, texbufw, level);
 		}
 		row += w;
 	}

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -94,7 +94,7 @@ void SamplerJitCache::Clear() {
 }
 
 void SamplerJitCache::ComputeSamplerID(SamplerID *id_out) {
-	SamplerID id;
+	SamplerID id{};
 
 	id.texfmt = gstate.getTextureFormat();
 	id.clutfmt = gstate.getClutPaletteFormat();
@@ -104,6 +104,11 @@ void SamplerJitCache::ComputeSamplerID(SamplerID *id_out) {
 	id.hasClutMask = gstate.getClutIndexMask() != 0xFF;
 	id.hasClutShift = gstate.getClutIndexShift() != 0;
 	id.hasClutOffset = gstate.getClutIndexStartPos() != 0;
+	for (int i = 0; i <= gstate.getTextureMaxLevel(); ++i) {
+		if (gstate.getTextureAddress(i) == 0) {
+			id.hasInvalidPtr = true;
+		}
+	}
 
 	*id_out = id;
 }

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -97,14 +97,17 @@ void SamplerJitCache::ComputeSamplerID(SamplerID *id_out) {
 	SamplerID id{};
 
 	id.texfmt = gstate.getTextureFormat();
-	id.clutfmt = gstate.getClutPaletteFormat();
 	id.swizzle = gstate.isTextureSwizzled();
 	// Only CLUT4 can use separate CLUTs per mimap.
-	id.useSharedClut = gstate.isClutSharedForMipmaps() || gstate.getTextureFormat() != GE_TFMT_CLUT4;
-	id.hasClutMask = gstate.getClutIndexMask() != 0xFF;
-	id.hasClutShift = gstate.getClutIndexShift() != 0;
-	id.hasClutOffset = gstate.getClutIndexStartPos() != 0;
-	for (int i = 0; i <= gstate.getTextureMaxLevel(); ++i) {
+	id.useSharedClut = gstate.getTextureFormat() != GE_TFMT_CLUT4 || !gstate.isMipmapEnabled() || gstate.isClutSharedForMipmaps();
+	if (gstate.isTextureFormatIndexed()) {
+		id.clutfmt = gstate.getClutPaletteFormat();
+		id.hasClutMask = gstate.getClutIndexMask() != 0xFF;
+		id.hasClutShift = gstate.getClutIndexShift() != 0;
+		id.hasClutOffset = gstate.getClutIndexStartPos() != 0;
+	}
+	int maxLevel = gstate.isMipmapEnabled() ? gstate.getTextureMaxLevel() : 0;
+	for (int i = 0; i <= maxLevel; ++i) {
 		if (gstate.getTextureAddress(i) == 0) {
 			id.hasInvalidPtr = true;
 		}

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -418,32 +418,13 @@ static u32 SampleNearest(int u, int v, const u8 *tptr, int bufw, int level) {
 static u32 SampleLinear(int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw, int texlevel) {
 	Nearest4 c = SampleNearest<4>(u, v, tptr, bufw, texlevel);
 
-#if defined(_M_SSE)
-	const __m128i z = _mm_setzero_si128();
-
-	__m128i cvec = _mm_load_si128((const __m128i *)c.v);
-	__m128i tvec = _mm_unpacklo_epi8(cvec, z);
-	tvec = _mm_mullo_epi16(tvec, _mm_set1_epi16(0x100 - frac_v));
-	__m128i bvec = _mm_unpackhi_epi8(cvec, z);
-	bvec = _mm_mullo_epi16(bvec, _mm_set1_epi16(frac_v));
-
-	// This multiplies the left and right sides.  We shift right after, although this may round down...
-	__m128i rowmult = _mm_set_epi16(frac_u, frac_u, frac_u, frac_u, 0x100 - frac_u, 0x100 - frac_u, 0x100 - frac_u, 0x100 - frac_u);
-	__m128i tmp = _mm_mulhi_epu16(_mm_add_epi16(tvec, bvec), rowmult);
-
-	// Now we need to add the left and right sides together.
-	__m128i res = _mm_add_epi16(tmp, _mm_shuffle_epi32(tmp, _MM_SHUFFLE(3, 2, 3, 2)));
-	return Vec4<int>(_mm_unpacklo_epi16(res, z)).ToRGBA();
-#else
 	Vec4<int> texcolor_tl = Vec4<int>::FromRGBA(c.v[0]);
 	Vec4<int> texcolor_tr = Vec4<int>::FromRGBA(c.v[1]);
 	Vec4<int> texcolor_bl = Vec4<int>::FromRGBA(c.v[2]);
 	Vec4<int> texcolor_br = Vec4<int>::FromRGBA(c.v[3]);
-	// 0x100 causes a slight bias to tl, but without it we'd have to divide by 255 * 255.
 	Vec4<int> t = texcolor_tl * (0x100 - frac_u) + texcolor_tr * frac_u;
 	Vec4<int> b = texcolor_bl * (0x100 - frac_u) + texcolor_br * frac_u;
 	return ((t * (0x100 - frac_v) + b * frac_v) / (256 * 256)).ToRGBA();
-#endif
 }
 
 };

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -123,10 +123,10 @@ NearestFunc SamplerJitCache::GetSampler(const SamplerID &id) {
 }
 
 template <unsigned int texel_size_bits>
-static inline int GetPixelDataOffset(unsigned int row_pitch_bytes, unsigned int u, unsigned int v)
+static inline int GetPixelDataOffset(unsigned int row_pitch_pixels, unsigned int u, unsigned int v)
 {
 	if (!gstate.isTextureSwizzled())
-		return (v * (row_pitch_bytes * texel_size_bits >> 3)) + (u * texel_size_bits >> 3);
+		return (v * (row_pitch_pixels * texel_size_bits >> 3)) + (u * texel_size_bits >> 3);
 
 	const int tile_size_bits = 32;
 	const int tiles_in_block_horizontal = 4;
@@ -136,7 +136,7 @@ static inline int GetPixelDataOffset(unsigned int row_pitch_bytes, unsigned int 
 	int tile_u = u / texels_per_tile;
 	int tile_idx = (v % tiles_in_block_vertical) * (tiles_in_block_horizontal) +
 	// TODO: not sure if the *texel_size_bits/8 factor is correct
-					(v / tiles_in_block_vertical) * ((row_pitch_bytes*texel_size_bits/(tile_size_bits))*tiles_in_block_vertical) +
+					(v / tiles_in_block_vertical) * ((row_pitch_pixels*texel_size_bits/(tile_size_bits))*tiles_in_block_vertical) +
 					(tile_u % tiles_in_block_horizontal) +
 					(tile_u / tiles_in_block_horizontal) * (tiles_in_block_horizontal*tiles_in_block_vertical);
 

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -1,0 +1,232 @@
+// Copyright (c) 2017- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Common/ColorConv.h"
+#include "Core/Reporting.h"
+#include "GPU/Common/TextureDecoder.h"
+#include "GPU/GPUState.h"
+#include "GPU/Software/Sampler.h"
+
+#if defined(_M_SSE)
+#include <emmintrin.h>
+#endif
+
+using namespace Math3D;
+
+extern u32 clut[4096];
+
+namespace Sampler {
+
+template <unsigned int texel_size_bits>
+static inline int GetPixelDataOffset(unsigned int row_pitch_bytes, unsigned int u, unsigned int v)
+{
+	if (!gstate.isTextureSwizzled())
+		return (v * (row_pitch_bytes * texel_size_bits >> 3)) + (u * texel_size_bits >> 3);
+
+	const int tile_size_bits = 32;
+	const int tiles_in_block_horizontal = 4;
+	const int tiles_in_block_vertical = 8;
+
+	int texels_per_tile = tile_size_bits / texel_size_bits;
+	int tile_u = u / texels_per_tile;
+	int tile_idx = (v % tiles_in_block_vertical) * (tiles_in_block_horizontal) +
+	// TODO: not sure if the *texel_size_bits/8 factor is correct
+					(v / tiles_in_block_vertical) * ((row_pitch_bytes*texel_size_bits/(tile_size_bits))*tiles_in_block_vertical) +
+					(tile_u % tiles_in_block_horizontal) +
+					(tile_u / tiles_in_block_horizontal) * (tiles_in_block_horizontal*tiles_in_block_vertical);
+
+	return tile_idx * (tile_size_bits / 8) + ((u % texels_per_tile) * texel_size_bits) / 8;
+}
+
+static inline u32 LookupColor(unsigned int index, unsigned int level)
+{
+	const bool mipmapShareClut = gstate.isClutSharedForMipmaps();
+	const int clutSharingOffset = mipmapShareClut ? 0 : level * 16;
+
+	switch (gstate.getClutPaletteFormat()) {
+	case GE_CMODE_16BIT_BGR5650:
+		return RGB565ToRGBA8888(reinterpret_cast<u16*>(clut)[index + clutSharingOffset]);
+
+	case GE_CMODE_16BIT_ABGR5551:
+		return RGBA5551ToRGBA8888(reinterpret_cast<u16*>(clut)[index + clutSharingOffset]);
+
+	case GE_CMODE_16BIT_ABGR4444:
+		return RGBA4444ToRGBA8888(reinterpret_cast<u16*>(clut)[index + clutSharingOffset]);
+
+	case GE_CMODE_32BIT_ABGR8888:
+		return clut[index + clutSharingOffset];
+
+	default:
+		ERROR_LOG_REPORT(G3D, "Software: Unsupported palette format: %x", gstate.getClutPaletteFormat());
+		return 0;
+	}
+}
+
+struct Nearest4 {
+	MEMORY_ALIGNED16(u32 v[4]);
+
+	operator u32() const {
+		return v[0];
+	}
+};
+
+template <int N>
+inline static Nearest4 SampleNearest(int level, int u[N], int v[N], const u8 *srcptr, int texbufw)
+{
+	Nearest4 res;
+	if (!srcptr) {
+		memset(res.v, 0, sizeof(res.v));
+		return res;
+	}
+
+	GETextureFormat texfmt = gstate.getTextureFormat();
+
+	// TODO: Should probably check if textures are aligned properly...
+
+	switch (texfmt) {
+	case GE_TFMT_4444:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<16>(texbufw, u[i], v[i]);
+			res.v[i] = RGBA4444ToRGBA8888(*(const u16 *)src);
+		}
+		return res;
+	
+	case GE_TFMT_5551:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<16>(texbufw, u[i], v[i]);
+			res.v[i] = RGBA5551ToRGBA8888(*(const u16 *)src);
+		}
+		return res;
+
+	case GE_TFMT_5650:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<16>(texbufw, u[i], v[i]);
+			res.v[i] = RGB565ToRGBA8888(*(const u16 *)src);
+		}
+		return res;
+
+	case GE_TFMT_8888:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<32>(texbufw, u[i], v[i]);
+			res.v[i] = *(const u32 *)src;
+		}
+		return res;
+
+	case GE_TFMT_CLUT32:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<32>(texbufw, u[i], v[i]);
+			u32 val = src[0] + (src[1] << 8) + (src[2] << 16) + (src[3] << 24);
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
+		}
+		return res;
+
+	case GE_TFMT_CLUT16:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<16>(texbufw, u[i], v[i]);
+			u16 val = src[0] + (src[1] << 8);
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
+		}
+		return res;
+
+	case GE_TFMT_CLUT8:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<8>(texbufw, u[i], v[i]);
+			u8 val = *src;
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), 0);
+		}
+		return res;
+
+	case GE_TFMT_CLUT4:
+		for (int i = 0; i < N; ++i) {
+			const u8 *src = srcptr + GetPixelDataOffset<4>(texbufw, u[i], v[i]);
+			u8 val = (u[i] & 1) ? (src[0] >> 4) : (src[0] & 0xF);
+			// Only CLUT4 uses separate mipmap palettes.
+			res.v[i] = LookupColor(gstate.transformClutIndex(val), level);
+		}
+		return res;
+
+	case GE_TFMT_DXT1:
+		for (int i = 0; i < N; ++i) {
+			const DXT1Block *block = (const DXT1Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
+			u32 data[4 * 4];
+			DecodeDXT1Block(data, block, 4, 4, false);
+			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+		}
+		return res;
+
+	case GE_TFMT_DXT3:
+		for (int i = 0; i < N; ++i) {
+			const DXT3Block *block = (const DXT3Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
+			u32 data[4 * 4];
+			DecodeDXT3Block(data, block, 4, 4);
+			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+		}
+		return res;
+
+	case GE_TFMT_DXT5:
+		for (int i = 0; i < N; ++i) {
+			const DXT5Block *block = (const DXT5Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
+			u32 data[4 * 4];
+			DecodeDXT5Block(data, block, 4, 4);
+			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+		}
+		return res;
+
+	default:
+		ERROR_LOG_REPORT(G3D, "Software: Unsupported texture format: %x", texfmt);
+		memset(res.v, 0, sizeof(res.v));
+		return res;
+	}
+}
+
+Vec4<int> SampleNearest(int level, int u, int v, const u8 *tptr, int bufw) {
+	return Vec4<int>::FromRGBA(SampleNearest<1>(level, &u, &v, tptr, bufw));
+}
+
+Vec4<int> SampleLinear(int texlevel, int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw) {
+#if defined(_M_SSE)
+	Nearest4 c = SampleNearest<4>(texlevel, u, v, tptr, bufw);
+
+	const __m128i z = _mm_setzero_si128();
+
+	__m128i cvec = _mm_load_si128((const __m128i *)c.v);
+	__m128i tvec = _mm_unpacklo_epi8(cvec, z);
+	tvec = _mm_mullo_epi16(tvec, _mm_set1_epi16(0x100 - frac_v));
+	__m128i bvec = _mm_unpackhi_epi8(cvec, z);
+	bvec = _mm_mullo_epi16(bvec, _mm_set1_epi16(frac_v));
+
+	// This multiplies the left and right sides.  We shift right after, although this may round down...
+	__m128i rowmult = _mm_set_epi16(frac_u, frac_u, frac_u, frac_u, 0x100 - frac_u, 0x100 - frac_u, 0x100 - frac_u, 0x100 - frac_u);
+	__m128i tmp = _mm_mulhi_epu16(_mm_add_epi16(tvec, bvec), rowmult);
+
+	// Now we need to add the left and right sides together.
+	__m128i res = _mm_add_epi16(tmp, _mm_shuffle_epi32(tmp, _MM_SHUFFLE(3, 2, 3, 2)));
+	return Vec4<int>(_mm_unpacklo_epi16(res, z));
+#else
+	Nearest4 nearest = SampleNearest<4>(texlevel, u, v, tptr, bufw);
+	Vec4<int> texcolor_tl = Vec4<int>::FromRGBA(nearest.v[0]);
+	Vec4<int> texcolor_tr = Vec4<int>::FromRGBA(nearest.v[1]);
+	Vec4<int> texcolor_bl = Vec4<int>::FromRGBA(nearest.v[2]);
+	Vec4<int> texcolor_br = Vec4<int>::FromRGBA(nearest.v[3]);
+	// 0x100 causes a slight bias to tl, but without it we'd have to divide by 255 * 255.
+	Vec4<int> t = texcolor_tl * (0x100 - frac_u) + texcolor_tr * frac_u;
+	Vec4<int> b = texcolor_bl * (0x100 - frac_u) + texcolor_br * frac_u;
+	return (t * (0x100 - frac_v) + b * frac_v) / (256 * 256);
+#endif
+}
+
+};

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "GPU/Math3D.h"
+
+namespace Sampler {
+
+Math3D::Vec4<int> SampleNearest(int level, int u, int v, const u8 *tptr, int bufwbytes);
+Math3D::Vec4<int> SampleLinear(int level, int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufwbytes);
+
+};

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -48,6 +48,7 @@ struct SamplerID {
 			bool hasClutMask : 1;
 			bool hasClutShift : 1;
 			bool hasClutOffset : 1;
+			bool hasInvalidPtr : 1;
 		};
 	};
 

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -106,7 +106,7 @@ private:
 	bool Jit_Decode5650();
 	bool Jit_Decode5551();
 	bool Jit_Decode4444();
-	bool Jit_TransformClutIndex(const SamplerID &id);
+	bool Jit_TransformClutIndex(const SamplerID &id, int bitsPerIndex);
 	bool Jit_ReadClutColor(const SamplerID &id);
 
 #if PPSSPP_ARCH(ARM64)

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -102,6 +102,7 @@ private:
 
 	bool Jit_ReadTextureFormat(const SamplerID &id);
 	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
+	bool Jit_GetTexDataSwizzled(const SamplerID &id, int bitsPerTexel);
 	bool Jit_Decode5650();
 	bool Jit_Decode5551();
 	bool Jit_Decode4444();

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -75,6 +75,8 @@ NearestFunc GetNearestFunc();
 void Init();
 void Shutdown();
 
+bool DescribeCodePtr(const u8 *ptr, std::string &name);
+
 Math3D::Vec4<int> SampleLinear(NearestFunc sampler, int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw, int level);
 
 #if PPSSPP_ARCH(ARM)
@@ -96,6 +98,9 @@ public:
 	// Returns a pointer to the code to run.
 	NearestFunc GetSampler(const SamplerID &id);
 	void Clear();
+
+	std::string DescribeCodePtr(const u8 *ptr);
+	std::string DescribeSamplerID(const SamplerID &id);
 
 private:
 	NearestFunc Compile(const SamplerID &id);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -109,6 +109,7 @@ private:
 	bool Jit_ReadTextureFormat(const SamplerID &id);
 	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
 	bool Jit_GetTexDataSwizzled(const SamplerID &id, int bitsPerTexel);
+	bool Jit_GetTexDataSwizzled4();
 	bool Jit_Decode5650();
 	bool Jit_Decode5551();
 	bool Jit_Decode4444();

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -100,6 +100,7 @@ public:
 private:
 	NearestFunc Compile(const SamplerID &id);
 
+	bool Jit_ReadTextureFormat(const SamplerID &id);
 	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
 	bool Jit_Decode5650();
 	bool Jit_Decode5551();

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -40,9 +40,9 @@ struct SamplerID {
 	union {
 		u32 fullKey;
 		struct {
-			int8_t texfmt : 4;
-			int8_t clutfmt : 2;
-			int8_t : 2;
+			uint8_t texfmt : 4;
+			uint8_t clutfmt : 2;
+			uint8_t : 2;
 			bool swizzle : 1;
 			bool useSharedClut : 1;
 			bool hasClutMask : 1;

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -100,6 +100,13 @@ public:
 private:
 	NearestFunc Compile(const SamplerID &id);
 
+	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
+	bool Jit_Decode5650();
+	bool Jit_Decode5551();
+	bool Jit_Decode4444();
+	bool Jit_TransformClutIndex(const SamplerID &id);
+	bool Jit_ReadClutColor(const SamplerID &id);
+
 #if PPSSPP_ARCH(ARM64)
 	Arm64Gen::ARM64FloatEmitter fp;
 #endif

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -67,6 +67,60 @@ NearestFunc SamplerJitCache::Compile(const SamplerID &id) {
 	GETextureFormat fmt = (GETextureFormat)id.texfmt;
 	bool success = true;
 	switch (fmt) {
+	case GE_TFMT_5650:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_Decode5650();
+		break;
+
+	case GE_TFMT_5551:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_Decode5551();
+		break;
+
+	case GE_TFMT_4444:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_Decode4444();
+		break;
+
+	case GE_TFMT_8888:
+		success = Jit_GetTexData(id, 32);
+		break;
+
+	case GE_TFMT_CLUT32:
+		success = Jit_GetTexData(id, 32);
+		if (success)
+			success = Jit_TransformClutIndex(id);
+		if (success)
+			success = Jit_ReadClutColor(id);
+		break;
+
+	case GE_TFMT_CLUT16:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_TransformClutIndex(id);
+		if (success)
+			success = Jit_ReadClutColor(id);
+		break;
+
+	case GE_TFMT_CLUT8:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_TransformClutIndex(id);
+		if (success)
+			success = Jit_ReadClutColor(id);
+		break;
+
+	case GE_TFMT_CLUT4:
+		success = Jit_GetTexData(id, 16);
+		if (success)
+			success = Jit_TransformClutIndex(id);
+		if (success)
+			success = Jit_ReadClutColor(id);
+		break;
+
 	default:
 		success = false;
 	}
@@ -89,6 +143,30 @@ NearestFunc SamplerJitCache::Compile(const SamplerID &id) {
 
 	EndWrite();
 	return (NearestFunc)start;
+}
+
+bool SamplerJitCache::Jit_GetTexData(const SamplerID &id, int bitsPerTexel) {
+	return false;
+}
+
+bool SamplerJitCache::Jit_Decode5650() {
+	return false;
+}
+
+bool SamplerJitCache::Jit_Decode5551() {
+	return false;
+}
+
+bool SamplerJitCache::Jit_Decode4444() {
+	return false;
+}
+
+bool SamplerJitCache::Jit_TransformClutIndex(const SamplerID &id) {
+	return false;
+}
+
+bool SamplerJitCache::Jit_ReadClutColor(const SamplerID &id) {
+	return false;
 }
 
 };

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2017- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include <emmintrin.h>
+#include "Common/x64Emitter.h"
+#include "GPU/Software/Sampler.h"
+#include "GPU/ge_constants.h"
+
+using namespace Gen;
+
+namespace Sampler {
+
+#ifdef _WIN32
+static const X64Reg resultReg = RAX;
+static const X64Reg tempReg1 = R10;
+static const X64Reg tempReg2 = R11;
+static const X64Reg uReg = RCX;
+static const X64Reg vReg = RDX;
+static const X64Reg srcReg = R8;
+static const X64Reg bufwReg = R9;
+// TODO: levelReg on stack
+#else
+static const X64Reg resultReg = RAX;
+static const X64Reg tempReg1 = R9;
+static const X64Reg tempReg2 = R10;
+static const X64Reg uReg = RDI;
+static const X64Reg vReg = RSI
+static const X64Reg srcReg = RDX;
+static const X64Reg bufwReg = RCX;
+static const X64Reg levelReg = R8;
+#endif
+
+NearestFunc SamplerJitCache::Compile(const SamplerID &id) {
+	BeginWrite();
+	const u8 *start = this->AlignCode16();
+
+	SUB(PTRBITS, R(ESP), Imm8(64));
+	MOVUPS(MDisp(ESP, 0), XMM4);
+	MOVUPS(MDisp(ESP, 16), XMM5);
+	MOVUPS(MDisp(ESP, 32), XMM6);
+	MOVUPS(MDisp(ESP, 48), XMM7);
+
+	// Early exit on !srcPtr.
+	CMP(PTRBITS, R(srcReg), Imm32(0));
+	FixupBranch nonZeroSrc = J_CC(CC_NZ);
+	XOR(32, R(RAX), R(RAX));
+	FixupBranch zeroSrc = J(true);
+	SetJumpTarget(nonZeroSrc);
+
+	GETextureFormat fmt = (GETextureFormat)id.texfmt;
+	bool success = true;
+	switch (fmt) {
+	default:
+		success = false;
+	}
+
+	if (!success) {
+		EndWrite();
+		SetCodePtr(const_cast<u8 *>(start));
+		return nullptr;
+	}
+
+	SetJumpTarget(zeroSrc);
+
+	MOVUPS(XMM4, MDisp(ESP, 0));
+	MOVUPS(XMM5, MDisp(ESP, 16));
+	MOVUPS(XMM6, MDisp(ESP, 32));
+	MOVUPS(XMM7, MDisp(ESP, 48));
+	ADD(PTRBITS, R(ESP), Imm8(64));
+
+	RET();
+
+	EndWrite();
+	return (NearestFunc)start;
+}
+
+};
+
+#endif

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -447,7 +447,7 @@ bool SamplerJitCache::Jit_ReadClutColor(const SamplerID &id) {
 
 	MOV(PTRBITS, R(tempReg1), ImmPtr(clut));
 
-	switch (gstate.getClutPaletteFormat()) {
+	switch ((GEPaletteFormat)id.clutfmt) {
 	case GE_CMODE_16BIT_BGR5650:
 		MOVZX(32, 16, resultReg, MComplex(tempReg1, resultReg, SCALE_2, 0));
 		return Jit_Decode5650();

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -434,8 +434,15 @@ bool SamplerJitCache::Jit_TransformClutIndex(const SamplerID &id, int bitsPerInd
 
 bool SamplerJitCache::Jit_ReadClutColor(const SamplerID &id) {
 	if (!id.useSharedClut) {
-		// TODO: Load level, SHL 4, and add to resultReg.
-		return false;
+#ifdef _WIN32
+		// The argument was saved on the stack.
+		MOV(32, R(tempReg2), MDisp(RSP, 40));
+		LEA(32, tempReg2, MScaled(tempReg2, SCALE_4, 0));
+#else
+		// We need to multiply by 16 and add, LEA allows us to copy too.
+		LEA(32, tempReg2, MScaled(levelReg, SCALE_4, 0));
+#endif
+		LEA(64, resultReg, MComplex(resultReg, tempReg2, SCALE_4, 0));
 	}
 
 	MOV(PTRBITS, R(tempReg1), ImmPtr(clut));

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -995,3 +995,12 @@ bool SoftGPU::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &v
 {
 	return drawEngine_->transformUnit.GetCurrentSimpleVertices(count, vertices, indices);
 }
+
+bool SoftGPU::DescribeCodePtr(const u8 *ptr, std::string &name) {
+	std::string subname;
+	if (Sampler::DescribeCodePtr(ptr, subname)) {
+		name = "SamplerJit:" + subname;
+		return true;
+	}
+	return false;
+}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -31,9 +31,10 @@
 #include "profiler/profiler.h"
 #include "thin3d/thin3d.h"
 
+#include "GPU/Software/Rasterizer.h"
+#include "GPU/Software/Sampler.h"
 #include "GPU/Software/SoftGpu.h"
 #include "GPU/Software/TransformUnit.h"
-#include "GPU/Software/Rasterizer.h"
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
 
@@ -99,6 +100,7 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	displayStride_ = 512;
 	displayFormat_ = GE_FORMAT_8888;
 
+	Sampler::Init();
 	drawEngine_ = new SoftwareDrawEngine();
 	drawEngineCommon_ = drawEngine_;
 }
@@ -127,6 +129,8 @@ SoftGPU::~SoftGPU() {
 	samplerNearest = nullptr;
 	samplerLinear->Release();
 	samplerLinear = nullptr;
+
+	Sampler::Shutdown();
 }
 
 void SoftGPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -91,6 +91,8 @@ public:
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 
+	bool DescribeCodePtr(const u8 *ptr, std::string &name) override;
+
 protected:
 	void FastRunLoop(DisplayList &list) override;
 	void ProcessEvent(GPUEvent ev) override;

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj
@@ -344,6 +344,7 @@
     <ClInclude Include="..\..\GPU\Software\Clipper.h" />
     <ClInclude Include="..\..\GPU\Software\Lighting.h" />
     <ClInclude Include="..\..\GPU\Software\Rasterizer.h" />
+    <ClInclude Include="..\..\GPU\Software\Sampler.h" />
     <ClInclude Include="..\..\GPU\Software\SoftGpu.h" />
     <ClInclude Include="..\..\GPU\Software\TransformUnit.h" />
     <ClInclude Include="pch.h" />
@@ -397,6 +398,7 @@
     <ClCompile Include="..\..\GPU\Software\Clipper.cpp" />
     <ClCompile Include="..\..\GPU\Software\Lighting.cpp" />
     <ClCompile Include="..\..\GPU\Software\Rasterizer.cpp" />
+    <ClCompile Include="..\..\GPU\Software\Sampler.cpp" />
     <ClCompile Include="..\..\GPU\Software\SoftGpu.cpp" />
     <ClCompile Include="..\..\GPU\Software\TransformUnit.cpp" />
     <ClCompile Include="pch.cpp">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -244,6 +244,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/GPU/Software/Clipper.cpp \
   $(SRC)/GPU/Software/Lighting.cpp \
   $(SRC)/GPU/Software/Rasterizer.cpp.arm \
+  $(SRC)/GPU/Software/Sampler.cpp \
   $(SRC)/GPU/Software/SoftGpu.cpp \
   $(SRC)/GPU/Software/TransformUnit.cpp \
   $(SRC)/Core/ELF/ElfReader.cpp \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -28,7 +28,8 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/JitSafeMem.cpp \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
-  $(SRC)/GPU/Common/VertexDecoderX86.cpp
+  $(SRC)/GPU/Common/VertexDecoderX86.cpp \
+  $(SRC)/GPU/Software/SamplerX86.cpp
 endif
 
 ifeq ($(TARGET_ARCH_ABI),x86_64)
@@ -48,7 +49,8 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/JitSafeMem.cpp \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
-  $(SRC)/GPU/Common/VertexDecoderX86.cpp
+  $(SRC)/GPU/Common/VertexDecoderX86.cpp \
+  $(SRC)/GPU/Software/SamplerX86.cpp
 endif
 
 ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)


### PR DESCRIPTION
This also makes linear interpolation retain more accuracy, which is important in some games (this is done in jit and not jit.)

It's not a terribly big improvement, but it is better by usually around 10%.  I think it can be improved by implementing more jit.  Also - with this code, jit is 27% faster than it off.  A big part of that difference is that the func call is no longer inlined.  I think more jit will improve it further.

It also seems like spreading the render onto multiple threads doesn't help as much with this code, though I'm no longer sure that isn't just profiling numbers being confused by the jit code...

-[Unknown]