### PR TITLE
Delete obsolete function ClearBuffer

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -533,9 +533,6 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 
 	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
 
-	// TODO: Is this necessary?
-	ClearBuffer();
-
 	// ugly...
 	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
 		gstate_c.Dirty(DIRTY_PROJTHROUGHMATRIX);

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -169,7 +169,7 @@ public:
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format);
 	void DestroyFramebuf(VirtualFramebuffer *v);
 
-	VirtualFramebuffer *DoSetRenderFrameBuffer(const FramebufferHeuristicParams &params, u32 skipDrawReason);
+	VirtualFramebuffer *DoSetRenderFrameBuffer(const FramebufferHeuristicParams &params, u32 skipDrawReason);	
 	VirtualFramebuffer *SetRenderFrameBuffer(bool framebufChanged, int skipDrawReason) {
 		// Inlining this part since it's so frequent.
 		if (!framebufChanged && currentRenderVfb_) {
@@ -290,7 +290,6 @@ protected:
 	void SetNumExtraFBOs(int num);
 
 	virtual void DisableState() = 0;
-	virtual void ClearBuffer(bool keepState = false) = 0;
 	virtual void FlushBeforeCopy() = 0;
 	virtual void DecimateFBOs();  // keeping it virtual to let D3D do a little extra
 

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -207,10 +207,6 @@ void FramebufferManagerD3D11::SetShaderManager(ShaderManagerD3D11 *sm) {
 	shaderManager_ = sm;
 }
 
-void FramebufferManagerD3D11::ClearBuffer(bool keepState) {
-	draw_->Clear(Draw::FBChannel::FB_COLOR_BIT | Draw::FBChannel::FB_DEPTH_BIT | Draw::FBChannel::FB_STENCIL_BIT, 0, ToScaledDepth(0), 0);
-}
-
 void FramebufferManagerD3D11::DisableState() {
 	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0xF], nullptr, 0xFFFFFFFF);
 	context_->RSSetState(stockD3D11.rasterStateNoCull);

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -83,7 +83,6 @@ public:
 
 protected:
 	void DisableState() override;
-	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -81,30 +81,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	D3DDECL_END()
 };
 
-	void FramebufferManagerDX9::ClearBuffer(bool keepState) {
-		if (keepState) {
-			dxstate.scissorTest.force(false);
-			dxstate.depthWrite.force(TRUE);
-			dxstate.colorMask.force(true, true, true, true);
-			dxstate.stencilFunc.force(D3DCMP_ALWAYS, 0, 0);
-			dxstate.stencilMask.force(0xFF);
-		} else {
-			dxstate.scissorTest.disable();
-			dxstate.depthWrite.set(TRUE);
-			dxstate.colorMask.set(true, true, true, true);
-			dxstate.stencilFunc.set(D3DCMP_ALWAYS, 0, 0);
-			dxstate.stencilMask.set(0xFF);
-		}
-		device_->Clear(0, NULL, D3DCLEAR_STENCIL|D3DCLEAR_TARGET |D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), ToScaledDepth(0), 0);
-		if (keepState) {
-			dxstate.scissorTest.restore();
-			dxstate.depthWrite.restore();
-			dxstate.colorMask.restore();
-			dxstate.stencilFunc.restore();
-			dxstate.stencilMask.restore();
-		}
-	}
-
 	void FramebufferManagerDX9::DisableState() {
 		dxstate.blend.disable();
 		dxstate.cullMode.set(false, false);

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -86,7 +86,6 @@ protected:
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void SetViewport2D(int x, int y, int w, int h) override;
 	void DisableState() override;
-	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;
 	void DecimateFBOs() override;
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -69,38 +69,6 @@ static const char basic_vs[] =
 
 void ConvertFromRGBA8888(u8 *dst, const u8 *src, u32 dstStride, u32 srcStride, u32 width, u32 height, GEBufferFormat format);
 
-void FramebufferManagerGLES::ClearBuffer(bool keepState) {
-	if (keepState) {
-		glstate.scissorTest.force(false);
-		glstate.depthWrite.force(GL_TRUE);
-		glstate.colorMask.force(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glstate.stencilFunc.force(GL_ALWAYS, 0, 0);
-		glstate.stencilMask.force(0xFF);
-	} else {
-		glstate.scissorTest.disable();
-		glstate.depthWrite.set(GL_TRUE);
-		glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glstate.stencilFunc.set(GL_ALWAYS, 0, 0);
-		glstate.stencilMask.set(0xFF);
-	}
-	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-	glClearStencil(0);
-	float clearDepth = ToScaledDepth(0);
-#ifdef USING_GLES2
-	glClearDepthf(clearDepth);
-#else
-	glClearDepth(clearDepth);
-#endif
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-	if (keepState) {
-		glstate.scissorTest.restore();
-		glstate.depthWrite.restore();
-		glstate.colorMask.restore();
-		glstate.stencilFunc.restore();
-		glstate.stencilMask.restore();
-	}
-}
-
 void FramebufferManagerGLES::DisableState() {
 	glstate.blend.disable();
 	glstate.cullFace.disable();
@@ -662,8 +630,7 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 		GLenum attachments[3] = { GL_COLOR_ATTACHMENT0, GL_STENCIL_ATTACHMENT, GL_DEPTH_ATTACHMENT };
 		glInvalidateFramebuffer(GL_FRAMEBUFFER, 3, attachments);
 	} else if (gl_extensions.IsGLES) {
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
-		ClearBuffer();
+		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });
 	}
 	CHECK_GL_ERROR_IF_DEBUG();
 }

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -96,7 +96,6 @@ public:
 protected:
 	void SetViewport2D(int x, int y, int w, int h) override;
 	void DisableState() override;
-	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -636,9 +636,7 @@ bool FramebufferManagerVulkan::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb
 		return false;
 	}
 
-	BindFramebufferAsRenderTargetnvfb->fbo);
-	ClearBuffer();
-	glDisable(GL_DITHER);
+	BindFramebufferAsRenderTarget(nvfb->fbo);
 	*/
 	return true;
 }
@@ -654,7 +652,6 @@ void FramebufferManagerVulkan::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb
 		glInvalidateFramebuffer(GL_FRAMEBUFFER, 3, attachments);
 	} else if (gl_extensions.IsGLES) {
 		BindFramebufferAsRenderTargetnvfb->fbo);
-		ClearBuffer();
 	}
 	*/
 }
@@ -1117,9 +1114,4 @@ bool FramebufferManagerVulkan::GetStencilbuffer(u32 fb_address, int fb_stride, G
 	return true;
 	*/
 	return false;
-}
-
-void FramebufferManagerVulkan::ClearBuffer(bool keepState) {
-	// TODO: Ideally, this should never be called.
-	// assert(false);
 }

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -123,7 +123,6 @@ protected:
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void SetViewport2D(int x, int y, int w, int h) override;
 	void DisableState() override {}
-	void ClearBuffer(bool keepState = false) override;
 	void FlushBeforeCopy() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies


### PR DESCRIPTION
Not necessary to call it anymore, framebuffers are cleared another way when created anyway.