### PR TITLE
Remove obsolete workaround from 5xBR

### DIFF
--- a/assets/shaders/5xBR.vsh
+++ b/assets/shaders/5xBR.vsh
@@ -23,6 +23,6 @@ attribute vec2 a_texcoord0;
 varying vec2 v_texcoord0;
 
 void main() {
-	v_texcoord0 = a_texcoord0 + 0.000001; //precision workaround for HLSL translation
+	v_texcoord0 = a_texcoord0;
 	gl_Position = a_position;
 }


### PR DESCRIPTION
Guess it's the new SPIRV-Cross:3