### PR TITLE
GPU: Block mipmap autogen for matching size

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -230,7 +230,7 @@ void TextureCacheCommon::SetTexture(bool force) {
 
 	u8 level = 0;
 	if (IsFakeMipmapChange())
-		level = (gstate.texlevel >> 20) & 0xF;
+		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	u32 texaddr = gstate.getTextureAddress(level);
 	if (!Memory::IsValidAddress(texaddr)) {
 		// Bind a null texture and return.

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -111,6 +111,8 @@ struct TexCacheEntry {
 		// is commonly the only part accessed.  If access is made above 272, we hash the entire
 		// texture, and set this flag to allow scaling the texture just once for the new hash.
 		STATUS_FREE_CHANGE = 0x200,    // Allow one change before marking "frequent".
+
+		STATUS_BAD_MIPS = 0x400,       // Has bad or unusable mipmap levels.
 	};
 
 	// Status, but int so we can zero initialize.

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -571,7 +571,8 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry, bool replaceIma
 	}
 
 	if (IsFakeMipmapChange()) {
-		u8 level = (gstate.texlevel >> 20) & 0xF;
+		// NOTE: Since the level is not part of the cache key, we assume it never changes.
+		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
 		LoadTextureLevel(*entry, replaced, level, maxLevel, replaceImages, scaleFactor, dstFmt);
 	} else {
 		LoadTextureLevel(*entry, replaced, 0, maxLevel, replaceImages, scaleFactor, dstFmt);
@@ -707,7 +708,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 		desc.Width = tw;
 		desc.Height = th;
 		desc.Format = tfmt;
-		desc.MipLevels = IsFakeMipmapChange() ? 1 :levels;
+		desc.MipLevels = IsFakeMipmapChange() ? 1 : levels;
 		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 
 		ASSERT_SUCCESS(device_->CreateTexture2D(&desc, nullptr, &texture));

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -574,7 +574,8 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry, bool replaceImage
 	}
 
 	if (IsFakeMipmapChange()) {
-		u8 level = (gstate.texlevel >> 20) & 0xF;
+		// NOTE: Since the level is not part of the cache key, we assume it never changes.
+		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
 		LoadTextureLevel(*entry, replaced, level, maxLevel, replaceImages, scaleFactor, dstFmt);
 	} else {
 		LoadTextureLevel(*entry, replaced, 0, maxLevel, replaceImages, scaleFactor, dstFmt);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -688,7 +688,8 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry, bool replaceImag
 
 	// Always load base level texture here 
 	if (IsFakeMipmapChange()) {
-		u8 level = (gstate.texlevel >> 20) & 0xF;
+		// NOTE: Since the level is not part of the cache key, we assume it never changes.
+		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
 		LoadTextureLevel(*entry, replaced, level, replaceImages, scaleFactor, dstFmt);
 	} else
 		LoadTextureLevel(*entry, replaced, 0, replaceImages, scaleFactor, dstFmt);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -630,7 +630,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 	}
 
 	if (entry->vkTex) {
-		u8 level = (gstate.texlevel >> 20) & 0xF;
+		// NOTE: Since the level is not part of the cache key, we assume it never changes.
+		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
 		bool fakeMipmap = IsFakeMipmapChange() && level > 0;
 		// Upload the texture data.
 		for (int i = 0; i <= maxLevel; i++) {


### PR DESCRIPTION
If the mips don't get smaller, we can't autogen - the bias in that case is used to select a different texture.  Fixes #9731.  I can't think of any case where we'd want to autogen with equal mip sizes, which are used by several games to do rendering tricks.

This also may improve a minor performance issue on PowerVR in some games, since `maxLevel` on the cache entry was being forced to zero, causing it to fail match every use (presumably.)  But only if h > w which isn't terribly common...

This also ensures that the bias is not used in any cases where we force the maxLevel to 0.

-[Unknown]