### PR TITLE
Fix jpeg's with width not matching psp buffer size.

### DIFF
--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -141,7 +141,7 @@ static int __DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr) {
 			u32 *abgr = (u32*)Memory::GetPointer(imageAddr);
 			int pspWidth;
 			for (int w = 2; w < 2048; w *= 2) {
-				if (w >= width) {
+				if (w >= width && w >= height) {
 					pspWidth = w;
 					break;
 				}
@@ -151,7 +151,7 @@ static int __DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr) {
 					abgr[x] = convertARGBtoABGR(imageBuffer[x]);
 				}
 				imageBuffer += width;
-				abgr += pspWidth; // Smallest value power of 2 fitting width.
+				abgr += pspWidth; // Smallest value power of 2 fitting width and height(needs to be square!)
 			}
 	}
 

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -139,8 +139,8 @@ static int __DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr) {
 	if (actual_components == 3) {
 			u24_be *imageBuffer = (u24_be*)jpegBuf;
 			u32 *abgr = (u32*)Memory::GetPointer(imageAddr);
-			int pspWidth;
-			for (int w = 2; w < 2048; w *= 2) {
+			int pspWidth = 0;
+			for (int w = 2; w <= 4096; w *= 2) {
 				if (w >= width && w >= height) {
 					pspWidth = w;
 					break;

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -139,12 +139,19 @@ static int __DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr) {
 	if (actual_components == 3) {
 			u24_be *imageBuffer = (u24_be*)jpegBuf;
 			u32 *abgr = (u32*)Memory::GetPointer(imageAddr);
+			int pspWidth;
+			for (int w = 2; w < 2048; w *= 2) {
+				if (w >= width) {
+					pspWidth = w;
+					break;
+				}
+			}
 			for (int y = 0; y < height; ++y) {
 				for (int x = 0; x < width; x++)	{
 					abgr[x] = convertARGBtoABGR(imageBuffer[x]);
 				}
 				imageBuffer += width;
-				abgr += width;
+				abgr += pspWidth; // Smallest value power of 2 fitting width.
 			}
 	}
 
@@ -230,7 +237,7 @@ static int __JpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr) {
 #ifdef JPEG_DEBUG
 		char jpeg_fname[256];
 		u8 *jpegDumpBuf = Memory::GetPointer(jpegAddr);
-		u32 jpeg_xxhash = XXH32((const char *)jpegBuf, jpegSize, 0xC0108888);
+		u32 jpeg_xxhash = XXH32((const char *)jpegDumpBuf, jpegSize, 0xC0108888);
 		sprintf(jpeg_fname, "Jpeg\\%X.jpg", jpeg_xxhash);
 		FILE *wfp = fopen(jpeg_fname, "wb");
 		if (!wfp) {


### PR DESCRIPTION
 I got one of those playView apps and turns out jpeg needed a bit more work when jpeg width does not match psp buffer sizes:].
Currently:
![jpeg width broken](https://cloud.githubusercontent.com/assets/5485237/26674812/eca1cea2-46c1-11e7-955a-8155bb9e051d.jpg)
With fix:
![jpeg width fixed](https://cloud.githubusercontent.com/assets/5485237/26674832/05cfe10c-46c2-11e7-862e-b7aadf44cc1c.jpg)


 I think such change might also be required in __JpegConvertRGBToYCbCr, but I don't know what games use sceJpegDecodeMJpegYCbCr to test. Should I just blindly add it?:P It makes sense, but I don't know anything bugged by it.

This should hopefully fix #1504, but if it plays movies like the one I got, those still have some unimplemented stuff.


Edit: Heh noticed one problem still even with this ~ 
![jpeg another issue](https://cloud.githubusercontent.com/assets/5485237/26675942/099513da-46c6-11e7-9d31-c831f154a759.jpg)
Don't understand why it happens, doesn't seem to be decode problem, that texture just get's wrong buffer width?:| ~ this should be 128x256 looking like that:
![d3acf089](https://cloud.githubusercontent.com/assets/5485237/26676062/8c64bf18-46c6-11e7-9b47-b9efa75c892e.jpg)
Edit: pspWidth definitely get's 128 for this, checked with hash just to be sure I get info from correct jpeg, don't understand why it's happening:|, is there any code outside of sceJpeg that could be causing this?
 I think the only way for this to make sense if texture made from jpeg would have to be square as that's how all other textures end up, I'll see how that works.:]
Last edit: :P Yeah it needs to be square, fixed it:
![jpeg fixed again](https://cloud.githubusercontent.com/assets/5485237/26678469/f268dd76-46d0-11e7-85a4-aae8925a0d75.jpg)
