### PR TITLE
Blit depth only in BlitFramebufferDepth on GLES and Vulkan

### DIFF
--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -540,6 +540,7 @@ void FramebufferManagerD3D11::BlitFramebufferDepth(VirtualFramebuffer *src, Virt
 	bool matchingSize = src->width == dst->width && src->height == dst->height;
 	bool matchingRenderSize = src->renderWidth == dst->renderWidth && src->renderHeight == dst->renderHeight;
 	if (matchingDepthBuffer && matchingSize && matchingRenderSize) {
+		// TODO: Currently, this copies depth AND stencil, which is a problem.  See #9740.
 		draw_->CopyFramebufferImage(src->fbo, 0, 0, 0, 0, dst->fbo, 0, 0, 0, 0, src->renderWidth, src->renderHeight, 1, Draw::FB_DEPTH_BIT);
 		RebindFramebuffer();
 	}

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -401,7 +401,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		bool matchingDepthBuffer = src->z_address == dst->z_address && src->z_stride != 0 && dst->z_stride != 0;
 		bool matchingSize = src->width == dst->width && src->height == dst->height;
 		if (matchingDepthBuffer && matchingSize) {
-			// Should use StretchRect here.
+			// Should use StretchRect here?  Note: should only copy depth and NOT copy stencil.  See #9740.
 		}
 	}
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -470,12 +470,9 @@ void FramebufferManagerGLES::BlitFramebufferDepth(VirtualFramebuffer *src, Virtu
 
 	bool matchingDepthBuffer = src->z_address == dst->z_address && src->z_stride != 0 && dst->z_stride != 0;
 	bool matchingSize = src->width == dst->width && src->height == dst->height;
-	bool matchingRenderSize = src->renderWidth == dst->renderWidth && src->renderHeight == dst->renderHeight;
 
-	if (gstate_c.Supports(GPU_SUPPORTS_ANY_COPY_IMAGE) && matchingDepthBuffer && matchingRenderSize && matchingSize) {
-		draw_->CopyFramebufferImage(src->fbo, 0, 0, 0, 0, dst->fbo, 0, 0, 0, 0, src->renderWidth, src->renderHeight, 1, Draw::FB_DEPTH_BIT);
-		RebindFramebuffer();
-	} else if (matchingDepthBuffer && matchingSize) {
+	// Note: we don't use CopyFramebufferImage here, because it would copy depth AND stencil.  See #9740.
+	if (matchingDepthBuffer && matchingSize) {
 		int w = std::min(src->renderWidth, dst->renderWidth);
 		int h = std::min(src->renderHeight, dst->renderHeight);
 

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -439,9 +439,7 @@ void FramebufferManagerVulkan::BlitFramebufferDepth(VirtualFramebuffer *src, Vir
 	} else if (matchingDepthBuffer && matchingSize) {
 		int w = std::min(src->renderWidth, dst->renderWidth);
 		int h = std::min(src->renderHeight, dst->renderHeight);
-		if (gstate_c.Supports(GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT | GPU_SUPPORTS_NV_FRAMEBUFFER_BLIT)) {
-			draw_->BlitFramebuffer(src->fbo, 0, 0, w, h, dst->fbo, 0, 0, w, h, Draw::FB_DEPTH_BIT, Draw::FB_BLIT_NEAREST);
-		}
+		draw_->BlitFramebuffer(src->fbo, 0, 0, w, h, dst->fbo, 0, 0, w, h, Draw::FB_DEPTH_BIT, Draw::FB_BLIT_NEAREST);
 	}
 }
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1650,8 +1650,16 @@ void VKContext::CopyFramebufferImage(Framebuffer *srcfb, int level, int x, int y
 		vkCmdCopyImage(cmd, src->color.image, src->color.layout, dst->color.image, dst->color.layout, 1, &copy);
 	}
 	if (channelBits & (FB_DEPTH_BIT | FB_STENCIL_BIT)) {
-		copy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-		copy.dstSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+		copy.srcSubresource.aspectMask = 0;
+		copy.dstSubresource.aspectMask = 0;
+		if (channelBits & FB_DEPTH_BIT) {
+			copy.srcSubresource.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+			copy.dstSubresource.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+		}
+		if (channelBits & FB_STENCIL_BIT) {
+			copy.srcSubresource.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+			copy.dstSubresource.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+		}
 		vkCmdCopyImage(cmd, src->depth.image, src->depth.layout, dst->depth.image, dst->depth.layout, 1, &copy);
 	}
 }
@@ -1725,8 +1733,16 @@ bool VKContext::BlitFramebuffer(Framebuffer *srcfb, int srcX1, int srcY1, int sr
 		vkCmdBlitImage(cmd, src->color.image, src->color.layout, dst->color.image, dst->color.layout, 1, &blit, filter == FB_BLIT_LINEAR ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
 	}
 	if (channelBits & (FB_DEPTH_BIT | FB_STENCIL_BIT)) {
-		blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-		blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+		blit.srcSubresource.aspectMask = 0;
+		blit.dstSubresource.aspectMask = 0;
+		if (channelBits & FB_DEPTH_BIT) {
+			blit.srcSubresource.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+			blit.dstSubresource.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+		}
+		if (channelBits & FB_STENCIL_BIT) {
+			blit.srcSubresource.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+			blit.dstSubresource.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+		}
 		vkCmdBlitImage(cmd, src->depth.image, src->depth.layout, dst->depth.image, dst->depth.layout, 1, &blit, filter == FB_BLIT_LINEAR ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
 	}
 	return true;


### PR DESCRIPTION
Fixes #9740 - not actually tested with this game, but I verified with Jeanne d'Arc that depth still works.  Might be good to confirm that Vulkan blits/copies only depth.

These say nothing about the aspects needing to include both depth and stencil:
https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCmdBlitImage.html
https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCmdCopyImage.html

But maybe it doesn't necessarily work everywhere?  Can remove the commit.

-[Unknown]