### PR TITLE
Implement software skinning for the Vulkan backend. 

### DIFF
--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -88,7 +88,7 @@ protected:
 	// Cached vertex decoders
 	u32 lastVType_ = -1;
 	std::unordered_map<u32, VertexDecoder *> decoderMap_;
-	VertexDecoder *dec_;
+	VertexDecoder *dec_ = nullptr;
 	VertexDecoderJitCache *decJitCache_;
 	VertexDecoderOptions decOptions_;
 

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -229,7 +229,7 @@ private:
 
 	DeferredDrawCall drawCalls[MAX_DEFERRED_DRAW_CALLS];
 	int numDrawCalls;
-	int vertexCountInDrawCalls;
+	int vertexCountInDrawCalls_;
 
 	int decimationCounter_;
 	int decodeCounter_;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -195,6 +195,7 @@ private:
 
 	// Vertex collector state
 	IndexGenerator indexGen;
+	int decodedVerts_ = 0;
 	GEPrimitiveType prevPrim_;
 
 	TransformedVertex *transformed = nullptr;
@@ -220,13 +221,17 @@ private:
 	VkSampler sampler;
 
 	// Null texture
-	VulkanTexture *nullTexture_;
-	VkSampler nullSampler_;
+	VulkanTexture *nullTexture_ = nullptr;
+	VkSampler nullSampler_ = VK_NULL_HANDLE;
 
 	DeferredDrawCall drawCalls[MAX_DEFERRED_DRAW_CALLS];
-	int numDrawCalls;
-	int vertexCountInDrawCalls;
+	int numDrawCalls = 0;
+	int vertexCountInDrawCalls_ = 0;
 	UVScale uvScale[MAX_DEFERRED_DRAW_CALLS];
+
+	int decimationCounter_ = 0;
+	int decodeCounter_ = 0;
+	u32 dcid_;
 
 	DrawEngineVulkanStats stats_;
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -77,6 +77,7 @@ public:
 	void Execute_Bezier(u32 op, u32 diff);
 	void Execute_Spline(u32 op, u32 diff);
 	void Execute_VertexType(u32 op, u32 diff);
+	void Execute_VertexTypeSkinning(u32 op, u32 diff);
 	void Execute_TexSize0(u32 op, u32 diff);
 	void Execute_LoadClut(u32 op, u32 diff);
 	void Execute_BoneMtxNum(u32 op, u32 diff);


### PR DESCRIPTION
Fixes #9753.

Also starts preparing for vertex caching.

This also opens the door to unify a bunch of code in DrawEngine between the backends.