### PR TITLE
Patch unusual way of checking for firmware version.

### DIFF
--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -71,7 +71,9 @@ static int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 w
 	fwrite(key, 1, 16, fp);
 	fclose(fp);
 
-	return -1;
+	// We failed decrypting and dumped encrypted files, some games like Idolmaster
+	// use this to check for firmware version, so let's still return no problem.
+	return 0;
 }
 
 static int scePauth_98B83B5D(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)


### PR DESCRIPTION
As left in the comment a few idolmaster games use this pauth function as a tricky way of checking for firmware version. Don't think it even matters what they're trying to decrypt as it's trying to decrypt tiny file on boot and decides whenever user has a good psp firmware or not:].

I think this change is safe, this would be 3rd know game to use pauth files, the other two would freeze/end in endless loop anyway even when we admit failing.

Fixes #8266 