### PR TITLE
WIP: Android: Use native canvas API to draw text onto bitmaps. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -867,6 +867,8 @@ add_library(native STATIC
 	ext/native/gfx_es2/draw_text_win.h
 	ext/native/gfx_es2/draw_text_qt.cpp
 	ext/native/gfx_es2/draw_text_qt.h
+	ext/native/gfx_es2/draw_text_android.cpp
+	ext/native/gfx_es2/draw_text_android.h
 	ext/native/gfx_es2/gpu_features.cpp
 	ext/native/gfx_es2/gpu_features.h
 	ext/native/gfx_es2/glsl_program.cpp

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -966,7 +966,7 @@ static bool ExecuteCommands() {
 			break;
 
 		default:
-			ERROR_LOG(SYSTEM, "Unsupported GE dump command: %d", cmd.type);
+			ERROR_LOG(SYSTEM, "Unsupported GE dump command: %d", (int)cmd.type);
 			return false;
 		}
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -676,7 +676,7 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new ItemHeader(sy->T("General")));
 
-#ifdef __ANDROID__
+#if PPSSPP_PLATFORM(ANDROID)
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
 		static const char *screenRotation[] = {"Auto", "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed"};
 		PopupMultiChoice *rot = systemSettings->Add(new PopupMultiChoice(&g_Config.iScreenRotation, co->T("Screen Rotation"), screenRotation, 0, ARRAY_SIZE(screenRotation), co->GetName(), screenManager()));

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -345,16 +345,16 @@ NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen
 			continue;
 		}
 
-#ifndef _WIN32
-		// ar_AE only works on Windows.
+#if !(defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID))
 		if (tempLangs[i].name.find("ar_AE") != std::string::npos) {
 			continue;
 		}
-		// Farsi also only works on Windows.
+
 		if (tempLangs[i].name.find("fa_IR") != std::string::npos) {
 			continue;
 		}
 #endif
+
 		FileInfo lang = tempLangs[i];
 		langs_.push_back(lang);
 

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -345,6 +345,8 @@ NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen
 			continue;
 		}
 
+		// We only support Arabic on platforms where we have support for the native text rendering
+		// APIs, as proper Arabic support is way too difficult to implement ourselves.
 #if !(defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID))
 		if (tempLangs[i].name.find("ar_AE") != std::string::npos) {
 			continue;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -659,7 +659,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 // JavaEGL
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, jobject obj) {
 	// Need to get the local JNI env for the graphics thread. Used later in draw_text_android.
-	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_4);
+	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_6);
 	if (res != JNI_OK) {
 		ELOG("GetEnv failed: %d", res);
 	}
@@ -1031,7 +1031,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 	ANativeWindow *wnd = ANativeWindow_fromSurface(env, _surf);
 
 	// Need to get the local JNI env for the graphics thread. Used later in draw_text_android.
-	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_4);
+	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_6);
 	if (res != JNI_OK) {
 		ELOG("GetEnv failed: %d", res);
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -28,6 +28,7 @@
 #include "thread/threadutil.h"
 #include "file/zip_read.h"
 #include "input/input_state.h"
+#include "input/keycodes.h"
 #include "profiler/profiler.h"
 #include "math/math_util.h"
 #include "net/resolve.h"
@@ -49,7 +50,7 @@
 
 #include "app-android.h"
 
-static JNIEnv *jniEnvUI;
+JNIEnv *jniEnvUI;
 
 enum {
 	ANDROID_VERSION_GINGERBREAD = 9,

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -50,7 +50,9 @@
 
 #include "app-android.h"
 
-JNIEnv *jniEnvUI;
+JNIEnv *jniEnvMain;
+JNIEnv *jniEnvGraphics;
+JavaVM *javaVM;
 
 enum {
 	ANDROID_VERSION_GINGERBREAD = 9,
@@ -531,7 +533,9 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	(JNIEnv *env, jclass, jstring jmodel, jint jdeviceType, jstring jlangRegion, jstring japkpath,
 		jstring jdataDir, jstring jexternalDir, jstring jlibraryDir, jstring jcacheDir, jstring jshortcutParam,
 		jint jAndroidVersion, jstring jboard) {
-	jniEnvUI = env;
+	jniEnvMain = env;
+	env->GetJavaVM(&javaVM);
+
 	setCurrentThreadName("androidInit");
 
 	ILOG("NativeApp.init() -- begin");
@@ -654,6 +658,12 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 
 // JavaEGL
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, jobject obj) {
+	// Need to get the local JNI env for the graphics thread. Used later in draw_text_android.
+	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_4);
+	if (res != JNI_OK) {
+		ELOG("GetEnv failed: %d", res);
+	}
+
 	if (javaGL && !graphicsContext) {
 		graphicsContext = new AndroidJavaEGLGraphicsContext();
 	}
@@ -1019,6 +1029,12 @@ static void ProcessFrameCommands(JNIEnv *env) {
 
 extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(JNIEnv *env, jobject obj, jobject _surf) {
 	ANativeWindow *wnd = ANativeWindow_fromSurface(env, _surf);
+
+	// Need to get the local JNI env for the graphics thread. Used later in draw_text_android.
+	int res = javaVM->GetEnv((void **)&jniEnvGraphics, JNI_VERSION_1_4);
+	if (res != JNI_OK) {
+		ELOG("GetEnv failed: %d", res);
+	}
 
 	WLOG("runEGLRenderLoop. display_xres=%d display_yres=%d", display_xres, display_yres);
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1110,6 +1110,7 @@ retry:
 	graphicsContext = nullptr;
 	renderLoopRunning = false;
 	WLOG("Render loop function exited.");
+	jniEnvGraphics = nullptr;
 	return true;
 }
 

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -6,6 +6,7 @@
 
 #include <jni.h>
 
-extern JNIEnv *jniEnvUI;
+extern JNIEnv *jniEnvMain;
+extern JNIEnv *jniEnvGraphics;
 
 #endif

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -8,5 +8,6 @@
 
 extern JNIEnv *jniEnvMain;
 extern JNIEnv *jniEnvGraphics;
+extern JavaVM *javaVM;
 
 #endif

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "input/keycodes.h"
+#include "ppsspp_config.h"
 
-// Compatability we alias the keycodes
-// since native's keycodes are based on
-// android keycodes.
-typedef enum _keycode_t AndroidKeyCodes;
+#if PPSSPP_PLATFORM(ANDROID)
+
+#include <jni.h>
+
+extern JNIEnv *jniEnvUI;
+
+#endif

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -406,6 +406,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	@Override
     public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		TextRenderer.init(this);
 		shuttingDown = false;
 		registerCallbacks();
 

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -12,7 +12,7 @@ public class TextRenderer {
 		bg = new Paint();
 		bg.setColor(Color.BLACK);
 	}
-	public static int measureText(String string, double textSize) {
+	private static Point measure(String string, double textSize) {
 		Rect bound = new Rect();
 		p.setTextSize((float)textSize);
 		p.getTextBounds(string, 0, string.length(), bound);
@@ -20,20 +20,22 @@ public class TextRenderer {
 		int h = (int)(p.descent() - p.ascent() + 2.0f);
 		// Round width up to even already here to avoid annoyances from odd-width 16-bit textures which
 		// OpenGL does not like - each line must be 4-byte aligned
-		w = (w + 3) & ~1;
-		return (w << 16) | h;
+		w = (w + 5) & ~1;
+		Point p = new Point();
+		p.x = w;
+		p.y = h;
+		return p;
+	}
+	public static int measureText(String string, double textSize) {
+		Point s = measure(string, textSize);
+		return (s.x << 16) | s.y;
 	}
 	public static int[] renderText(String string, double textSize) {
-		Rect bound = new Rect();
-		p.setTextSize((float)textSize);
-		p.getTextBounds(string, 0, string.length(), bound);
-		int w = bound.width();
-		int h = (int)(p.descent() - p.ascent() + 2.0f);
-		// Round width up to even already here to avoid annoyances from odd-width 16-bit textures which
-		// OpenGL does not like - each line must be 4-byte aligned
-		w = (w + 3) & ~1;
+		Point s = measure(string, textSize);
 
-		float baseline = -p.ascent();
+		int w = s.x;
+		int h = s.y;
+
 		Bitmap bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
 		Canvas canvas = new Canvas(bmp);
 		canvas.drawRect(0.0f, 0.0f, w, h, bg);

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -1,16 +1,29 @@
 package org.ppsspp.ppsspp;
+import android.content.Context;
 import android.graphics.*;
+import android.util.Log;
 
 import java.nio.ByteBuffer;
 
 public class TextRenderer {
 	private static Paint p;
 	private static Paint bg;
+	private static Typeface robotoCondensed;
+	private static final String TAG = "TextRenderer";
 	static {
 		p = new Paint(Paint.SUBPIXEL_TEXT_FLAG | Paint.ANTI_ALIAS_FLAG);
 		p.setColor(Color.WHITE);
 		bg = new Paint();
 		bg.setColor(Color.BLACK);
+	}
+	public static void init(Context ctx) {
+		robotoCondensed = Typeface.createFromAsset(ctx.getAssets(), "Roboto-Condensed.ttf");
+		if (robotoCondensed != null) {
+			Log.i(TAG, "Successfully loaded Roboto Condensed");
+			p.setTypeface(robotoCondensed);
+		} else {
+			Log.e(TAG, "Failed to load Roboto Condensed");
+		}
 	}
 	private static Point measure(String string, double textSize) {
 		Rect bound = new Rect();

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -1,0 +1,48 @@
+package org.ppsspp.ppsspp;
+import android.graphics.*;
+import android.graphics.drawable.*;
+
+import java.nio.ByteBuffer;
+
+public class TextRenderer {
+	static int measureText(String string, float textSize) {
+		Paint p;
+		p = new Paint(Paint.ANTI_ALIAS_FLAG);
+		Rect bound = new Rect();
+		p.setTextSize(textSize);
+		p.getTextBounds(string, 0, string.length(), bound);
+		int packedBounds = (bound.width() << 16) | bound.height();
+		return packedBounds;
+	}
+	static short[] renderText(String string, float textSize) {
+		Paint p;
+		p = new Paint(Paint.ANTI_ALIAS_FLAG);
+		Rect bound = new Rect();
+		p.setTextSize(textSize);
+		p.getTextBounds(string, 0, string.length(), bound);
+		Bitmap bmp = Bitmap.createBitmap(bound.width(), bound.height(), Bitmap.Config.ARGB_4444);
+		Canvas canvas = new Canvas(bmp);
+		p.setColor(Color.WHITE);
+		canvas.drawText(string, 0, 0, p);
+
+		int bufSize = bmp.getRowBytes() * bmp.getHeight() * 2;  // 2 = sizeof(ARGB_4444)
+		ByteBuffer buf = ByteBuffer.allocate(bufSize);
+		bmp.copyPixelsFromBuffer(buf);
+		byte[] bytes = buf.array();
+
+		// Output array size must match return value of measureText
+		short[] output = new short[bound.width() * bound.height()];
+
+		// 16-bit pixels but stored as bytes.
+		for (int y = 0; y < bound.height(); y++) {
+			int srcOffset = y * bmp.getRowBytes();
+			int dstOffset = y * bound.width();
+			for (int x = 0; x < bound.width(); x++) {
+				int val = bytes[srcOffset + x * 2];
+				val = (val << 12) | 0xFFF;
+				output[dstOffset + x] = (short)val;
+			}
+		}
+		return output;
+	}
+}

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -17,11 +17,10 @@ public class TextRenderer {
 		p.setTextSize((float)textSize);
 		p.getTextBounds(string, 0, string.length(), bound);
 		int w = bound.width();
-		int h = bound.height();
+		int h = (int)(p.descent() - p.ascent() + 2.0f);
 		// Round width up to even already here to avoid annoyances from odd-width 16-bit textures which
 		// OpenGL does not like - each line must be 4-byte aligned
 		w = (w + 3) & ~1;
-		h += 2;
 		return (w << 16) | h;
 	}
 	public static int[] renderText(String string, double textSize) {
@@ -29,18 +28,17 @@ public class TextRenderer {
 		p.setTextSize((float)textSize);
 		p.getTextBounds(string, 0, string.length(), bound);
 		int w = bound.width();
-		int h = bound.height();
+		int h = (int)(p.descent() - p.ascent() + 2.0f);
 		// Round width up to even already here to avoid annoyances from odd-width 16-bit textures which
 		// OpenGL does not like - each line must be 4-byte aligned
 		w = (w + 3) & ~1;
-		h += 2;
 
 		float baseline = -p.ascent();
 		Bitmap bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
 		Canvas canvas = new Canvas(bmp);
 		canvas.drawRect(0.0f, 0.0f, w, h, bg);
 		p.setColor(Color.WHITE);
-		canvas.drawText(string, 1, -bound.top + 1, p);
+		canvas.drawText(string, 1, -p.ascent() + 1, p);
 
 		int [] pixels = new int[w * h];
 		bmp.getPixels(pixels, 0, w, 0, 0, w, h);

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -18,10 +18,11 @@ public class TextRenderer {
 		Rect bound = new Rect();
 		p.setTextSize(textSize);
 		p.getTextBounds(string, 0, string.length(), bound);
+		float baseline = -p.ascent();
 		Bitmap bmp = Bitmap.createBitmap(bound.width(), bound.height(), Bitmap.Config.ARGB_4444);
 		Canvas canvas = new Canvas(bmp);
 		p.setColor(Color.WHITE);
-		canvas.drawText(string, 0, 0, p);
+		canvas.drawText(string, 0, baseline, p);
 
 		int bufSize = bmp.getRowBytes() * bmp.getHeight() * 2;  // 2 = sizeof(ARGB_4444)
 		ByteBuffer buf = ByteBuffer.allocate(bufSize);
@@ -37,7 +38,6 @@ public class TextRenderer {
 			int dstOffset = y * bound.width();
 			for (int x = 0; x < bound.width(); x++) {
 				int val = bytes[srcOffset + x * 2];
-				val = (val << 12) | 0xFFF;
 				output[dstOffset + x] = (short)val;
 			}
 		}

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -1,20 +1,18 @@
 package org.ppsspp.ppsspp;
 import android.graphics.*;
-import android.graphics.drawable.*;
 
 import java.nio.ByteBuffer;
 
 public class TextRenderer {
-	static int measureText(String string, float textSize) {
+	public static int measureText(String string, float textSize) {
 		Paint p;
 		p = new Paint(Paint.ANTI_ALIAS_FLAG);
 		Rect bound = new Rect();
 		p.setTextSize(textSize);
 		p.getTextBounds(string, 0, string.length(), bound);
-		int packedBounds = (bound.width() << 16) | bound.height();
-		return packedBounds;
+		return (bound.width() << 16) | bound.height();
 	}
-	static short[] renderText(String string, float textSize) {
+	public static short[] renderText(String string, float textSize) {
 		Paint p;
 		p = new Paint(Paint.ANTI_ALIAS_FLAG);
 		Rect bound = new Rect();

--- a/ext/native/Android.mk
+++ b/ext/native/Android.mk
@@ -74,6 +74,7 @@ LOCAL_SRC_FILES :=\
     gfx_es2/gl3stub.c \
     gfx_es2/draw_buffer.cpp.arm \
     gfx_es2/draw_text.cpp.arm \
+    gfx_es2/draw_text_android.cpp.arm \
   	gfx/GLStateCache.cpp.arm \
     gfx/gl_debug_log.cpp \
     gfx/gl_lost_manager.cpp \

--- a/ext/native/Android.mk
+++ b/ext/native/Android.mk
@@ -75,7 +75,7 @@ LOCAL_SRC_FILES :=\
     gfx_es2/draw_buffer.cpp.arm \
     gfx_es2/draw_text.cpp.arm \
     gfx_es2/draw_text_android.cpp.arm \
-  	gfx/GLStateCache.cpp.arm \
+    gfx/GLStateCache.cpp.arm \
     gfx/gl_debug_log.cpp \
     gfx/gl_lost_manager.cpp \
     gfx/texture_atlas.cpp \

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -35,11 +35,9 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 
 float TextDrawer::CalculateDPIScale() {
 	float scale = g_dpi_scale;
-#if !PPSSPP_PLATFORM(ANDROID)
 	if (scale >= 1.0f) {
 		scale = 1.0f;
 	}
-#endif
 	return scale;
 }
 

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -8,6 +8,7 @@
 #include "gfx_es2/draw_text.h"
 #include "gfx_es2/draw_text_win.h"
 #include "gfx_es2/draw_text_qt.h"
+#include "gfx_es2/draw_text_android.h"
 
 TextDrawer::TextDrawer(Draw::DrawContext *draw) : draw_(draw) {
 	// These probably shouldn't be state.
@@ -45,6 +46,8 @@ TextDrawer *TextDrawer::Create(Draw::DrawContext *draw) {
 	return new TextDrawerWin32(draw);
 #elif defined(USING_QT_UI)
 	return new TextDrawerQt(draw);
+#elif PPSSPP_PLATFORM(ANDROID)
+	return new TextDrawerAndroid(draw);
 #else
 	return nullptr;
 #endif

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -42,13 +42,17 @@ float TextDrawer::CalculateDPIScale() {
 }
 
 TextDrawer *TextDrawer::Create(Draw::DrawContext *draw) {
+	TextDrawer *drawer = nullptr;
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
-	return new TextDrawerWin32(draw);
+	drawer = new TextDrawerWin32(draw);
 #elif defined(USING_QT_UI)
-	return new TextDrawerQt(draw);
+	drawer = new TextDrawerQt(draw);
 #elif PPSSPP_PLATFORM(ANDROID)
-	return new TextDrawerAndroid(draw);
-#else
-	return nullptr;
+	drawer = new TextDrawerAndroid(draw);
 #endif
+	if (drawer && !drawer->IsReady()) {
+		delete drawer;
+		drawer = nullptr;
+	}
+	return drawer;
 }

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -35,9 +35,11 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 
 float TextDrawer::CalculateDPIScale() {
 	float scale = g_dpi_scale;
+#if !PPSSPP_PLATFORM(ANDROID)
 	if (scale >= 1.0f) {
 		scale = 1.0f;
 	}
+#endif
 	return scale;
 }
 

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -51,6 +51,7 @@ class TextDrawer {
 public:
 	virtual ~TextDrawer();
 
+	virtual bool IsReady() const { return true; }
 	virtual uint32_t SetFont(const char *fontName, int size, int flags) = 0;
 	virtual void SetFont(uint32_t fontHandle) = 0;  // Shortcut once you've set the font once.
 	void SetFontScale(float xscale, float yscale);

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -72,7 +72,6 @@ protected:
 
 	Draw::DrawContext *draw_;
 	virtual void ClearCache() = 0;
-	virtual void RecreateFonts() = 0;  // On DPI change
 	void WrapString(std::string &out, const char *str, float maxWidth);
 
 	int frameCount_;

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -135,7 +135,10 @@ void TextDrawerAndroid::DrawString(DrawBuffer &target, const char *str, float x,
 		jshort* jimage = env_->GetShortArrayElements(imageData, nullptr);
 		for (int x = 0; x < entry->bmWidth; x++) {
 			for (int y = 0; y < entry->bmHeight; y++) {
-				bitmapData[entry->bmWidth * y + x] = jimage[imageWidth * y + x];
+				int v = jimage[imageWidth * y + x];
+				v = (v << 4) | v;
+				v = (v << 8) | v;
+				bitmapData[entry->bmWidth * y + x] = v;
 			}
 		}
 		env_->ReleaseShortArrayElements(imageData, jimage, 0);

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -1,0 +1,208 @@
+#include "base/display.h"
+#include "base/logging.h"
+#include "base/stringutil.h"
+#include "thin3d/thin3d.h"
+#include "util/hash/hash.h"
+#include "util/text/wrap_text.h"
+#include "util/text/utf8.h"
+#include "gfx_es2/draw_text.h"
+#include "gfx_es2/draw_text_android.h"
+
+#include "android/jni/app-android.h"
+
+#if PPSSPP_PLATFORM(ANDROID)
+
+#include <jni.h>
+
+TextDrawerAndroid::TextDrawerAndroid(Draw::DrawContext *draw) : TextDrawer(draw) {
+	env_ = jniEnvUI;
+	cls_textRenderer = env_->FindClass("org/ppsspp/ppsspp/TextRenderer");
+	method_measureText = env_->GetStaticMethodID(cls_textRenderer, "measureText", "(ILjava/lang/String;F");
+	method_renderText = env_->GetStaticMethodID(cls_textRenderer, "renderText", "([SLjava/lang/String;F");
+	ILOG("method_measureText: %p", method_measureText);
+	ILOG("method_renderText: %p", method_renderText);
+	curSize_ = 12;
+}
+
+TextDrawerAndroid::~TextDrawerAndroid() {
+	ClearCache();
+}
+
+uint32_t TextDrawerAndroid::SetFont(const char *fontName, int size, int flags) {
+	// We will only use the default font
+	uint32_t fontHash = 0; //hash::Fletcher((const uint8_t *)fontName, strlen(fontName));
+	fontHash ^= size;
+	fontHash ^= flags << 10;
+
+	auto iter = fontMap_.find(fontHash);
+	if (iter != fontMap_.end()) {
+		fontHash_ = fontHash;
+		return fontHash;
+	}
+
+	curSize_ = size;
+	AndroidFontEntry entry;
+	entry.size = curSize_;
+	fontMap_[fontHash] = entry;
+	fontHash_ = fontHash;
+	return fontHash;
+}
+
+void TextDrawerAndroid::SetFont(uint32_t fontHandle) {
+	uint32_t fontHash = fontHandle;
+	auto iter = fontMap_.find(fontHash);
+	if (iter != fontMap_.end()) {
+		curSize_ = iter->second.size;
+	}
+}
+
+void TextDrawerAndroid::RecreateFonts() {
+
+}
+
+void TextDrawerAndroid::MeasureString(const char *str, size_t len, float *w, float *h) {
+	std::string stdstring(str, len);
+	jstring jstr = env_->NewStringUTF(stdstring.c_str());
+	uint32_t size = env_->CallStaticIntMethod(cls_textRenderer, method_measureText, jstr, curSize_);
+	*w = (size >> 16) * fontScaleX_;
+	*h = (size & 0xFFFF) * fontScaleY_;
+	env_->DeleteLocalRef(jstr);
+}
+
+void TextDrawerAndroid::MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align) {
+	std::string toMeasure = std::string(str, len);
+	if (align & FLAG_WRAP_TEXT) {
+		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
+		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w);
+	}
+
+	jstring jstr = env_->NewStringUTF(toMeasure.c_str());
+	uint32_t size = env_->CallStaticIntMethod(cls_textRenderer, method_measureText, jstr, curSize_);
+	*w = (size >> 16) * fontScaleX_;
+	*h = (size & 0xFFFF) * fontScaleY_;
+	env_->DeleteLocalRef(jstr);
+}
+
+void TextDrawerAndroid::DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align) {
+	using namespace Draw;
+	if (!strlen(str))
+		return;
+
+	uint32_t stringHash = hash::Fletcher((const uint8_t *)str, strlen(str));
+	uint32_t entryHash = stringHash ^ fontHash_ ^ (align << 24);
+
+	target.Flush(true);
+
+	TextStringEntry *entry;
+
+	auto iter = cache_.find(entryHash);
+	if (iter != cache_.end()) {
+		entry = iter->second.get();
+		entry->lastUsedFrame = frameCount_;
+		draw_->BindTexture(0, entry->texture);
+	} else {
+		jstring jstr = env_->NewStringUTF(str);
+		uint32_t size = env_->CallStaticIntMethod(cls_textRenderer, method_measureText, jstr, curSize_);
+		int imageWidth = (size >> 16) * fontScaleX_;
+		int imageHeight = (size & 0xFFFF) * fontScaleY_;
+		jshortArray imageData = (jshortArray)env_->CallObjectMethod(cls_textRenderer, method_renderText, jstr, curSize_);
+		env_->DeleteLocalRef(jstr);
+
+		entry = new TextStringEntry();
+		entry->bmWidth = entry->width = imageWidth;
+		entry->bmHeight = entry->height = imageHeight;
+		entry->lastUsedFrame = frameCount_;
+
+		TextureDesc desc{};
+		desc.type = TextureType::LINEAR2D;
+		desc.format = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		desc.width = entry->bmWidth;
+		desc.height = entry->bmHeight;
+		desc.depth = 1;
+		desc.mipLevels = 1;
+
+		uint16_t *bitmapData = new uint16_t[entry->bmWidth * entry->bmHeight];
+		jshort* jimage = env_->GetShortArrayElements(imageData, nullptr);
+		for (int x = 0; x < entry->bmWidth; x++) {
+			for (int y = 0; y < entry->bmHeight; y++) {
+				bitmapData[entry->bmWidth * y + x] = jimage[imageWidth * y + x];
+			}
+		}
+		env_->ReleaseShortArrayElements(imageData, jimage, 0);
+		desc.initData.push_back((uint8_t *)bitmapData);
+		entry->texture = draw_->CreateTexture(desc);
+		delete[] bitmapData;
+		cache_[entryHash] = std::unique_ptr<TextStringEntry>(entry);
+	}
+	float w = entry->bmWidth * fontScaleX_;
+	float h = entry->bmHeight * fontScaleY_;
+	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
+	target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
+	target.Flush(true);
+}
+
+void TextDrawerAndroid::ClearCache() {
+	for (auto &iter : cache_) {
+		if (iter.second->texture)
+			iter.second->texture->Release();
+	}
+	cache_.clear();
+	sizeCache_.clear();
+}
+
+void TextDrawerAndroid::DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) {
+	float x = bounds.x;
+	float y = bounds.y;
+	if (align & ALIGN_HCENTER) {
+		x = bounds.centerX();
+	} else if (align & ALIGN_RIGHT) {
+		x = bounds.x2();
+	}
+	if (align & ALIGN_VCENTER) {
+		y = bounds.centerY();
+	} else if (align & ALIGN_BOTTOM) {
+		y = bounds.y2();
+	}
+
+	std::string toDraw = str;
+	if (align & FLAG_WRAP_TEXT) {
+		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
+		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
+	}
+
+	DrawString(target, toDraw.c_str(), x, y, color, align);
+}
+
+void TextDrawerAndroid::OncePerFrame() {
+	frameCount_++;
+	// If DPI changed (small-mode, future proper monitor DPI support), drop everything.
+	float newDpiScale = CalculateDPIScale();
+	if (newDpiScale != dpiScale_) {
+		dpiScale_ = newDpiScale;
+		ClearCache();
+		RecreateFonts();
+	}
+
+	// Drop old strings. Use a prime number to reduce clashing with other rhythms
+	if (frameCount_ % 23 == 0) {
+		for (auto iter = cache_.begin(); iter != cache_.end();) {
+			if (frameCount_ - iter->second->lastUsedFrame > 100) {
+				if (iter->second->texture)
+					iter->second->texture->Release();
+				cache_.erase(iter++);
+			} else {
+				iter++;
+			}
+		}
+
+		for (auto iter = sizeCache_.begin(); iter != sizeCache_.end(); ) {
+			if (frameCount_ - iter->second->lastUsedFrame > 100) {
+				sizeCache_.erase(iter++);
+			} else {
+				iter++;
+			}
+		}
+	}
+}
+
+#endif

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -18,6 +18,7 @@ public:
 	TextDrawerAndroid(Draw::DrawContext *draw);
 	~TextDrawerAndroid();
 
+	bool IsReady() const override;
 	uint32_t SetFont(const char *fontName, int size, int flags) override;
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(const char *str, size_t len, float *w, float *h) override;

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -10,7 +10,7 @@
 #include <jni.h>
 
 struct AndroidFontEntry {
-	float size;
+	double size;
 };
 
 class TextDrawerAndroid : public TextDrawer {
@@ -30,7 +30,6 @@ public:
 
 protected:
 	void ClearCache() override;
-	void RecreateFonts() override;  // On DPI change
 
 private:
 	std::string NormalizeString(std::string str);
@@ -40,14 +39,14 @@ private:
 	jclass cls_textRenderer;
 	jmethodID method_measureText;
 	jmethodID method_renderText;
-	double curSize_;
 
-	uint32_t fontHash_;
+	uint32_t fontHash_;  // Just the size.
 
 	std::map<uint32_t, AndroidFontEntry> fontMap_;
 
-	// The key is the CityHash of the string xor the fontHash_.
+	// The key is the CityHash of the string xor the fontHash_ (though the fontHash_ is just the size).
 	std::map<uint32_t, std::unique_ptr<TextStringEntry>> cache_;
+	std::map<uint32_t, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };
 
 #endif

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -40,11 +40,11 @@ private:
 	jmethodID method_measureText;
 	jmethodID method_renderText;
 
-	uint32_t fontHash_;  // Just the size.
+	uint32_t fontHash_;
 
 	std::map<uint32_t, AndroidFontEntry> fontMap_;
 
-	// The key is the CityHash of the string xor the fontHash_ (though the fontHash_ is just the size).
+	// The key is the CityHash of the string xor the fontHash_.
 	std::map<uint32_t, std::unique_ptr<TextStringEntry>> cache_;
 	std::map<uint32_t, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "ppsspp_config.h"
+
+#include <map>
+#include "gfx_es2/draw_text.h"
+
+#if PPSSPP_PLATFORM(ANDROID)
+
+#include <jni.h>
+
+struct AndroidFontEntry {
+	float size;
+};
+
+class TextDrawerAndroid : public TextDrawer {
+public:
+	TextDrawerAndroid(Draw::DrawContext *draw);
+	~TextDrawerAndroid();
+
+	uint32_t SetFont(const char *fontName, int size, int flags) override;
+	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
+	void MeasureString(const char *str, size_t len, float *w, float *h) override;
+	void MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
+	void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
+	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) override;
+	// Use for housekeeping like throwing out old strings.
+	void OncePerFrame() override;
+
+protected:
+	void ClearCache() override;
+	void RecreateFonts() override;  // On DPI change
+
+	// JNI functions
+	JNIEnv *env_;
+	jclass cls_textRenderer;
+	jmethodID method_measureText;
+	jmethodID method_renderText;
+	float curSize_;
+
+	uint32_t fontHash_;
+
+	std::map<uint32_t, AndroidFontEntry> fontMap_;
+
+	// The key is the CityHash of the string xor the fontHash_.
+	std::map<uint32_t, std::unique_ptr<TextStringEntry>> cache_;
+	std::map<uint32_t, std::unique_ptr<TextMeasureEntry>> sizeCache_;
+};
+
+#endif

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -32,6 +32,9 @@ protected:
 	void ClearCache() override;
 	void RecreateFonts() override;  // On DPI change
 
+private:
+	std::string NormalizeString(std::string str);
+
 	// JNI functions
 	JNIEnv *env_;
 	jclass cls_textRenderer;

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -37,7 +37,7 @@ protected:
 	jclass cls_textRenderer;
 	jmethodID method_measureText;
 	jmethodID method_renderText;
-	float curSize_;
+	double curSize_;
 
 	uint32_t fontHash_;
 
@@ -45,7 +45,6 @@ protected:
 
 	// The key is the CityHash of the string xor the fontHash_.
 	std::map<uint32_t, std::unique_ptr<TextStringEntry>> cache_;
-	std::map<uint32_t, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };
 
 #endif

--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -15,7 +15,6 @@
 #include <QtGui/QFontMetrics>
 #include <QtOpenGL/QGLWidget>
 
-
 TextDrawerQt::TextDrawerQt(Draw::DrawContext *draw) : TextDrawer(draw) {
 }
 
@@ -43,10 +42,6 @@ uint32_t TextDrawerQt::SetFont(const char *fontName, int size, int flags) {
 }
 
 void TextDrawerQt::SetFont(uint32_t fontHandle) {
-
-}
-
-void TextDrawerQt::RecreateFonts() {
 
 }
 

--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -172,7 +172,6 @@ void TextDrawerQt::OncePerFrame() {
 	if (newDpiScale != dpiScale_) {
 		dpiScale_ = newDpiScale;
 		ClearCache();
-		RecreateFonts();
 	}
 
 	// Drop old strings. Use a prime number to reduce clashing with other rhythms

--- a/ext/native/gfx_es2/draw_text_qt.h
+++ b/ext/native/gfx_es2/draw_text_qt.h
@@ -23,7 +23,6 @@ public:
 
 protected:
 	void ClearCache() override;
-	void RecreateFonts() override;  // On DPI change
 
 	uint32_t fontHash_;
 	std::map<uint32_t, QFont *> fontMap_;

--- a/ext/native/gfx_es2/draw_text_win.h
+++ b/ext/native/gfx_es2/draw_text_win.h
@@ -30,7 +30,7 @@ public:
 
 protected:
 	void ClearCache() override;
-	void RecreateFonts() override;  // On DPI change
+	void RecreateFonts();  // On DPI change
 
 	TextDrawerContext *ctx_;
 	std::map<uint32_t, std::unique_ptr<TextDrawerFontContext>> fontMap_;

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="gfx\gl_debug_log.h" />
     <ClInclude Include="gfx\gl_lost_manager.h" />
     <ClInclude Include="gfx\texture_atlas.h" />
+    <ClInclude Include="gfx_es2\draw_text_android.h" />
     <ClInclude Include="gfx_es2\draw_text_qt.h" />
     <ClInclude Include="gfx_es2\draw_text_win.h" />
     <ClInclude Include="thin3d\d3d11_loader.h" />
@@ -692,6 +693,7 @@
     <ClCompile Include="gfx\gl_debug_log.cpp" />
     <ClCompile Include="gfx\gl_lost_manager.cpp" />
     <ClCompile Include="gfx\texture_atlas.cpp" />
+    <ClCompile Include="gfx_es2\draw_text_android.cpp" />
     <ClCompile Include="gfx_es2\draw_text_qt.cpp" />
     <ClCompile Include="gfx_es2\draw_text_win.cpp" />
     <ClCompile Include="thin3d\d3d11_loader.cpp" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClInclude Include="gfx_es2\draw_text_qt.h">
       <Filter>gfx</Filter>
     </ClInclude>
+    <ClInclude Include="gfx_es2\draw_text_android.h">
+      <Filter>gfx</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">
@@ -776,6 +779,9 @@
       <Filter>gfx</Filter>
     </ClCompile>
     <ClCompile Include="gfx_es2\draw_text_qt.cpp">
+      <Filter>gfx</Filter>
+    </ClCompile>
+    <ClCompile Include="gfx_es2\draw_text_android.cpp">
       <Filter>gfx</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -675,6 +675,7 @@ OpenGLTexture::OpenGLTexture(const TextureDesc &desc) {
 	type_ = desc.type;
 	target_ = TypeToTarget(desc.type);
 	canWrap_ = isPowerOf2(width_) && isPowerOf2(height_);
+	mipLevels_ = desc.mipLevels;
 	if (!desc.initData.size())
 		return;
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -675,6 +675,9 @@ enum class TextureState {
 };
 
 bool VKTexture::Create(const TextureDesc &desc) {
+	// Zero-sized textures not allowed.
+	if (desc.width * desc.height * desc.depth == 0)
+		return false;
 	format_ = desc.format;
 	mipLevels_ = desc.mipLevels;
 	width_ = desc.width;


### PR DESCRIPTION
Fixes Arabic, Farsi, and all missing Chinese and Korean characters in the main UI permanently on Android, by rendering fonts natively just like we do on Windows and with Qt.

(though for proper Arabic we should also do right-to-left layout - maybe someday :) )

There's some weird sizing issue that can happen sometimes when changing rotation and display resolution, haven't quite figured that out yet. Other than that, it looks pretty good.

Just uses whatever font it gets on the canvas, maybe should be more explicit about getting the font we want? It looks a bit wide?

EDIT: Changed to use our bundled Roboto-Condensed. Missing characters will fallback to whatever font Android chooses to substitute with. The result is great, looks like before and some new language work.

![screen](https://cloud.githubusercontent.com/assets/130929/26804958/22a47898-4a4a-11e7-9b55-cd3cbb9cfdb1.png)


Helps #8423 on Android.
Replaces #8543 on Android.