### PR TITLE
Set a working directory for homebrew outside ms0:/PSP/GAME/

### DIFF
--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -74,10 +74,10 @@ static u32 sceVaudioChRelease() {
 
 static u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
 	DEBUG_LOG(SCEAUDIO, "sceVaudioOutputBlocking(%i, %08x)", vol, buffer);
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].leftVolume = vol;
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].rightVolume = vol;
+	chans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = vol;
+	chans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = vol;
 	// TODO: This may be wrong, not sure if's in a different format?
-	chans[PSP_AUDIO_CHANNEL_OUTPUT2].sampleAddress = buffer;
+	chans[PSP_AUDIO_CHANNEL_VAUDIO].sampleAddress = buffer;
 	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, true);
 }
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -289,8 +289,9 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	if (pos != std::string::npos) {
 		ms_path = "ms0:" + path.substr(pos);
 	} else {
-		// Hmm..
-		ms_path = "umd0:";
+		// This is wrong, but it's better than not having a working directory at all.
+		// Note that umd0:/ is actually the writable containing directory, in this case.
+		ms_path = "umd0:/";
 	}
 
 #ifdef _WIN32
@@ -314,9 +315,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		path = rootNorm + "/";
 		pspFileSystem.SetStartingDirectory(filepath);
 	} else {
-		if (pos != std::string::npos) {
-			pspFileSystem.SetStartingDirectory(ms_path);
-		}
+		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
 	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path);


### PR DESCRIPTION
If we really want to prevent running EBOOTs outside ms0:/PSP/GAME/ (and btw, I would argue it could work in any ms0:/ subfolder, as it would on a PSP), we should show a proper error.

Instead, we were just not setting the game up with a starting directly, meaning relative path access would all just fail.

What this does is it sets umd0:/ as the working directory.  For a long time, we've been mounting umd0: as the directory containing the EBOOT.  This means access to `"./resources/foo.png"` is likely to work, at least.

Of course, this won't help homebrew which use hardcoded /PSP/GAME/ paths, or which want to access ../SAVEDATA/ or /PSP/SAVEDATA/, etc.

-[Unknown]