### PR TITLE
Fix case sensitivity messup in sceIoDread.

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2190,7 +2190,9 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		if (undesiredChars == std::string::npos) {
 			std::size_t ldot = info.name.find_last_of(".");
 			std::string filename = info.name.substr(0, ldot);
-			std::string extension = info.name.substr(ldot + 1);
+			std::string extension = "";
+			if (ldot)
+				std::string extension = info.name.substr(ldot + 1);
 			if (filename.size() <= 8 && extension.size() <= 3) {
 				// PSP wears an uppercase glasses for 8.3 all-lowercase filenames
 				for (char &c : info.name) {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2186,9 +2186,17 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		PSPFileInfo &info = dir->listing[dir->index];
 		__IoGetStat(&entry->d_stat, info);
 
-		// PSP wears an uppercase glasses for filenames
-		for (char &c : info.name) {
-			c = toupper(c);
+		std::size_t undesiredChars = info.name.find_first_not_of("abcdefghijklmnopqrstuvwxyz01234567890.");
+		if (undesiredChars == std::string::npos) {
+			std::size_t ldot = info.name.find_last_of(".");
+			std::string filename = info.name.substr(0, ldot);
+			std::string extension = info.name.substr(ldot + 1);
+			if (filename.size() <= 8 && extension.size() <= 3) {
+				// PSP wears an uppercase glasses for 8.3 all-lowercase filenames
+				for (char &c : info.name) {
+					c = toupper(c);
+				}
+			}
 		}
 		strncpy(entry->d_name, info.name.c_str(), 256);
 		entry->d_name[255] = '\0';

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2186,6 +2186,10 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		PSPFileInfo &info = dir->listing[dir->index];
 		__IoGetStat(&entry->d_stat, info);
 
+		// PSP wears an uppercase glasses for filenames
+		for (char &c : info.name) {
+			c = toupper(c);
+		}
 		strncpy(entry->d_name, info.name.c_str(), 256);
 		entry->d_name[255] = '\0';
 		


### PR DESCRIPTION
Check Wolf3D homebrew as an example:
-[download](http://www.brewology.com/downloads/download.php?id=9730&mcid=1)
the game checks for lowercase files in it's code, however only returns results when the files are all caps.

 On PSP it should work with both lower and upper case, so I assume we have to list all files as uppercase and that's the proposed change in this pr.