### PR TITLE
D3D11: Fix texture scaling with blank first half

### DIFF
--- a/GPU/D3D11/TextureScalerD3D11.cpp
+++ b/GPU/D3D11/TextureScalerD3D11.cpp
@@ -25,7 +25,7 @@
 #include "GPU/D3D11/GPU_D3D11.h"
 
 int TextureScalerD3D11::BytesPerPixel(u32 format) {
-	return format == GE_FORMAT_8888 ? 4 : 2;
+	return format == DXGI_FORMAT_B8G8R8A8_UNORM ? 4 : 2;
 }
 
 u32 TextureScalerD3D11::Get8888Format() {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -281,10 +281,10 @@ void GPU_GLES::CheckGPUFeatures() {
 	if (gl_extensions.OES_texture_npot)
 		features |= GPU_SUPPORTS_OES_TEXTURE_NPOT;
 
-	if (gl_extensions.EXT_unpack_subimage || !gl_extensions.IsGLES)
+	if (gl_extensions.EXT_unpack_subimage)
 		features |= GPU_SUPPORTS_UNPACK_SUBIMAGE;
 
-	if (gl_extensions.EXT_blend_minmax || gl_extensions.GLES3)
+	if (gl_extensions.EXT_blend_minmax)
 		features |= GPU_SUPPORTS_BLEND_MINMAX;
 
 	if (gl_extensions.OES_copy_image || gl_extensions.NV_copy_image || gl_extensions.EXT_copy_image || gl_extensions.ARB_copy_image)

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -363,6 +363,7 @@ void CheckGLExtensions() {
 
 	// GLES 3 subsumes many ES2 extensions.
 	if (gl_extensions.GLES3) {
+		gl_extensions.EXT_blend_minmax = true;
 		gl_extensions.EXT_unpack_subimage = true;
 	}
 


### PR DESCRIPTION
It was being detected as "flat" incorrectly.

-[Unknown]