### PR TITLE
Changes shader directory to /assets/shaders

### DIFF
--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -111,7 +111,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 // Scans the directories for shader ini files and collects info about all the shaders found.
 void ReloadAllPostShaderInfo() {
 	std::vector<std::string> directories;
-	directories.push_back("shaders");
+	directories.push_back("assets/shaders");
 	directories.push_back(g_Config.memStickDirectory + "PSP/shaders");
 	LoadPostShaderInfo(directories);
 }


### PR DESCRIPTION
Previously the first directory for custom shaders pointed to
(PPSSPP root)/shaders instead of (PPSSPP root)/assets/shaders, as I
believe it was intended to be.

Related issue: #9831