### PR TITLE
x86-64: Add ability to run without RIP addressing between generated code and global data

### DIFF
--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -120,7 +120,7 @@ static void *SearchForFreeMem(size_t size) {
 
 void *AllocateExecutableMemory(size_t size) {
 #if defined(_WIN32)
-	void *ptr;
+	void *ptr = nullptr;
 	DWORD prot = PAGE_EXECUTE_READWRITE;
 	if (PlatformIsWXExclusive())
 		prot = PAGE_READWRITE;
@@ -128,7 +128,6 @@ void *AllocateExecutableMemory(size_t size) {
 		GetSystemInfo(&sys_info);
 #if defined(_M_X64)
 	if ((uintptr_t)&hint_location > 0xFFFFFFFFULL) {
-
 		size_t aligned_size = round_page(size);
 		ptr = SearchForFreeMem(aligned_size);
 		if (!ptr) {
@@ -140,7 +139,9 @@ void *AllocateExecutableMemory(size_t size) {
 		if (ptr) {
 			ptr = VirtualAlloc(ptr, aligned_size, MEM_RESERVE | MEM_COMMIT, prot);
 		} else {
-			ERROR_LOG(COMMON, "Unable to find nearby executable memory for jit");
+			WARN_LOG(COMMON, "Unable to find nearby executable memory for jit. Proceeding with far memory.");
+			// Can still run, thanks to "RipAccessible".
+			ptr = VirtualAlloc(nullptr, aligned_size, MEM_RESERVE | MEM_COMMIT, prot);
 		}
 	}
 	else

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -129,6 +129,7 @@ void *AllocateExecutableMemory(size_t size) {
 #if defined(_M_X64)
 	if ((uintptr_t)&hint_location > 0xFFFFFFFFULL) {
 		size_t aligned_size = round_page(size);
+#if 1   // Turn off to hunt for RIP bugs on x86-64.
 		ptr = SearchForFreeMem(aligned_size);
 		if (!ptr) {
 			// Let's try again, from the top.
@@ -136,6 +137,7 @@ void *AllocateExecutableMemory(size_t size) {
 			last_executable_addr = 0;
 			ptr = SearchForFreeMem(aligned_size);
 		}
+#endif
 		if (ptr) {
 			ptr = VirtualAlloc(ptr, aligned_size, MEM_RESERVE | MEM_COMMIT, prot);
 		} else {

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1497,8 +1497,8 @@ void XEmitter::MOVQ_xmm(OpArg arg, X64Reg src)
 	else
 	{
 		arg.operandReg = src;
-		arg.WriteRex(this, 0, 0);
 		Write8(0x66);
+		arg.WriteRex(this, 0, 0);
 		Write8(0x0f);
 		Write8(0xD6);
 		arg.WriteRest(this, 0);

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -269,7 +269,7 @@ void OpArg::WriteRest(XEmitter *emit, int extraBytes, X64Reg _operandReg,
 			{
 				mod = 0;
 			}
-			else if (ioff<-128 || ioff>127)
+			else if (ioff < -128 || ioff > 127)
 			{
 				mod = 2; //32-bit displacement
 			}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -1072,6 +1072,8 @@ class XCodeBlock : public CodeBlock<XEmitter> {
 public:
 	void PoisonMemory(int offset) override;
 	bool RipAccessible(const void *ptr) const {
+		// For debugging
+		// return false;
 #ifdef _M_IX86
 		return true;
 #else

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -20,6 +20,7 @@
 
 #include "ppsspp_config.h"
 
+#include <cstddef>
 #include "Common.h"
 #include "CodeBlock.h"
 

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -1073,7 +1073,7 @@ public:
 class XCodeBlock : public CodeBlock<XEmitter> {
 public:
 	void PoisonMemory(int offset) override;
-	bool RipAccessible(void *ptr) const {
+	bool RipAccessible(const void *ptr) const {
 #ifdef _M_IX86
 		return true;
 #else

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -359,8 +359,6 @@ private:
 	void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg);
 	void WriteNormalOp(XEmitter *emit, int bits, NormalOp op, const OpArg &a1, const OpArg &a2);
 
-	void ABI_CalculateFrameSize(u32 mask, size_t rsp_alignment, size_t needed_frame_size, size_t* shadowp, size_t* subtractionp, size_t* xmm_offsetp);
-
 protected:
 	inline void Write8(u8 value)   {*code++ = value;}
 	inline void Write16(u16 value) {*(u16*)code = (value); code += 2;}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -1073,6 +1073,14 @@ public:
 class XCodeBlock : public CodeBlock<XEmitter> {
 public:
 	void PoisonMemory(int offset) override;
+	bool RipAccessible(void *ptr) const {
+#ifdef _M_IX86
+		return true;
+#else
+		ptrdiff_t diff = GetCodePtr() - (const uint8_t *)ptr;
+		return diff > -0x7FFFFFFF && diff < 0x7FFFFFFF;
+#endif
+	}
 };
 
 }  // namespace

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -232,6 +232,8 @@ public:
 	u32 intBranchExit;
 	u32 jitBranchExit;
 
+	u32 savedPC;
+
 	static const u32 FCR0_VALUE = 0x00003351;
 
 #if defined(PPSSPP_ARCH_X86) || defined(PPSSPP_ARCH_AMD64)

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -152,7 +152,12 @@ enum class CPUCore;
 
 // Note that CTXREG is offset to point at the first floating point register, intentionally. This is so that a byte offset
 // can reach both GPR and FPR regs.
-#define MIPSSTATE_VAR(x) MDisp(X64JitConstants::CTXREG, (int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0])))
+#define MIPSSTATE_VAR(x) MDisp(X64JitConstants::CTXREG, \
+	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0])))
+
+// Workaround for compilers that don't like dynamic indexing in offsetof
+#define MIPSSTATE_VAR_ELEM32(x, i) MDisp(X64JitConstants::CTXREG, \
+	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0]) + i * 4)
 
 // To get RIP/relative addressing (requires tight memory control so generated code isn't too far from the binary, and a reachable variable called mips):
 // #define MIPSSTATE_VAR(x) M(&mips->x)

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -224,6 +224,10 @@ public:
 	// Debug stuff
 	u32 debugCount;	// can be used to count basic blocks before crashes, etc.
 
+	// Temps needed for JitBranch.cpp experiments
+	u32 intBranchExit;
+	u32 jitBranchExit;
+
 	static const u32 FCR0_VALUE = 0x00003351;
 
 	u8 VfpuWriteMask() const {

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -203,6 +203,9 @@ public:
 	int llBit;  // ll/sc
 	u32 temp;  // can be used to save temporaries during calculations when we need more than R0 and R1
 
+	// Temporary used around delay slots and similar.
+	u64 saved_flags;
+
 	GMRng rng;	// VFPU hardware random number generator. Probably not the right type.
 
 	// Debug stuff

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -158,6 +158,10 @@ enum class CPUCore;
 
 #endif
 
+enum {
+	NUM_X86_FPU_TEMPS = 16,
+};
+
 class MIPSState
 {
 public:
@@ -229,6 +233,11 @@ public:
 	u32 jitBranchExit;
 
 	static const u32 FCR0_VALUE = 0x00003351;
+
+#if defined(PPSSPP_ARCH_X86) || defined(PPSSPP_ARCH_AMD64)
+	// FPU TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
+	float tempValues[NUM_X86_FPU_TEMPS];
+#endif
 
 	u8 VfpuWriteMask() const {
 		return (vfpuCtrl[VFPU_CTRL_DPREFIX] >> 8) & 0xF;

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -215,7 +215,7 @@ public:
 	bool inDelaySlot;
 	int llBit;  // ll/sc
 	u32 temp;  // can be used to save temporaries during calculations when we need more than R0 and R1
-
+	u32 mxcsrTemp;
 	// Temporary used around delay slots and similar.
 	u64 saved_flags;
 

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -157,7 +157,7 @@ enum class CPUCore;
 
 // Workaround for compilers that don't like dynamic indexing in offsetof
 #define MIPSSTATE_VAR_ELEM32(x, i) MDisp(X64JitConstants::CTXREG, \
-	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0]) + i * 4)
+	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0]) + i * 4))
 
 // To get RIP/relative addressing (requires tight memory control so generated code isn't too far from the binary, and a reachable variable called mips):
 // #define MIPSSTATE_VAR(x) M(&mips->x)

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "util/random/rng.h"
 #include "Common/CommonTypes.h"
 // #include "Core/CoreParameter.h"

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -145,6 +145,14 @@ extern u8 fromvoffset[128];
 
 enum class CPUCore;
 
+#if defined(PPSSPP_ARCH_X86) || defined(PPSSPP_ARCH_AMD64)
+
+// Note that CTXREG is offset to point at the first floating point register, intentionally. This is so that a byte offset
+// can reach both GPR and FPR regs.
+#define MIPSSTATE_VAR(x) MDisp(X64JitConstants::CTXREG, (int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0])))
+
+#endif
+
 class MIPSState
 {
 public:

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -153,6 +153,9 @@ enum class CPUCore;
 // can reach both GPR and FPR regs.
 #define MIPSSTATE_VAR(x) MDisp(X64JitConstants::CTXREG, (int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0])))
 
+// To get RIP/relative addressing (requires tight memory control so generated code isn't too far from the binary, and a reachable variable called mips):
+// #define MIPSSTATE_VAR(x) M(&mips->x)
+
 #endif
 
 class MIPSState

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 
 #include "util/random/rng.h"
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 // #include "Core/CoreParameter.h"
 #include "Core/Opcode.h"
@@ -233,6 +234,8 @@ public:
 	u32 jitBranchExit;
 
 	u32 savedPC;
+
+	u32 MEMORY_ALIGNED16(vcmpResult[4]);
 
 	static const u32 FCR0_VALUE = 0x00003351;
 

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -157,7 +157,7 @@ enum class CPUCore;
 
 // Workaround for compilers that don't like dynamic indexing in offsetof
 #define MIPSSTATE_VAR_ELEM32(x, i) MDisp(X64JitConstants::CTXREG, \
-	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0]) + i * 4))
+	(int)(offsetof(MIPSState, x) - offsetof(MIPSState, f[0]) + (i) * 4))
 
 // To get RIP/relative addressing (requires tight memory control so generated code isn't too far from the binary, and a reachable variable called mips):
 // #define MIPSSTATE_VAR(x) M(&mips->x)

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -237,6 +237,8 @@ public:
 
 	u32 MEMORY_ALIGNED16(vcmpResult[4]);
 
+	float sincostemp[2];
+
 	static const u32 FCR0_VALUE = 0x00003351;
 
 #if defined(PPSSPP_ARCH_X86) || defined(PPSSPP_ARCH_AMD64)

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -149,7 +149,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 
 		SetJumpTarget(skipToCoreStateCheck);
 		if (RipAccessible((const void *)&coreState)) {
-			CMP(32, M(&coreState), Imm32(0));
+			CMP(32, M(&coreState), Imm32(0));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			CMP(32, MatR(RAX), Imm32(0));
@@ -211,7 +211,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 		SetJumpTarget(bailCoreState);
 
 		if (RipAccessible((const void *)&coreState)) {
-			CMP(32, M(&coreState), Imm32(0));
+			CMP(32, M(&coreState), Imm32(0));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			CMP(32, MatR(RAX), Imm32(0));

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -70,21 +70,21 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 	BeginWrite();
 
 	restoreRoundingMode = AlignCode16(); {
-		STMXCSR(M(&mips_->temp));
+		STMXCSR(MIPSSTATE_VAR(temp));
 		// Clear the rounding mode and flush-to-zero bits back to 0.
-		AND(32, M(&mips_->temp), Imm32(~(7 << 13)));
-		LDMXCSR(M(&mips_->temp));
+		AND(32, MIPSSTATE_VAR(temp), Imm32(~(7 << 13)));
+		LDMXCSR(MIPSSTATE_VAR(temp));
 		RET();
 	}
 
 	applyRoundingMode = AlignCode16(); {
-		MOV(32, R(EAX), M(&mips_->fcr31));
+		MOV(32, R(EAX), MIPSSTATE_VAR(fcr31));
 		AND(32, R(EAX), Imm32(0x01000003));
 
 		// If it's 0 (nearest + no flush0), we don't actually bother setting - we cleared the rounding
 		// mode out in restoreRoundingMode anyway. This is the most common.
 		FixupBranch skip = J_CC(CC_Z);
-		STMXCSR(M(&mips_->temp));
+		STMXCSR(MIPSSTATE_VAR(temp));
 
 		// The MIPS bits don't correspond exactly, so we have to adjust.
 		// 0 -> 0 (skip2), 1 -> 3, 2 -> 2 (skip2), 3 -> 1
@@ -96,15 +96,15 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 		// Adjustment complete, now reconstruct MXCSR
 		SHL(32, R(EAX), Imm8(13));
 		// Before setting new bits, we must clear the old ones.
-		AND(32, M(&mips_->temp), Imm32(~(7 << 13)));   // Clearing bits 13-14 (rounding mode) and 15 (flush to zero)
-		OR(32, M(&mips_->temp), R(EAX));
+		AND(32, MIPSSTATE_VAR(temp), Imm32(~(7 << 13)));   // Clearing bits 13-14 (rounding mode) and 15 (flush to zero)
+		OR(32, MIPSSTATE_VAR(temp), R(EAX));
 
-		TEST(32, M(&mips_->fcr31), Imm32(1 << 24));
+		TEST(32, MIPSSTATE_VAR(fcr31), Imm32(1 << 24));
 		FixupBranch skip3 = J_CC(CC_Z);
-		OR(32, M(&mips_->temp), Imm32(1 << 15));
+		OR(32, MIPSSTATE_VAR(temp), Imm32(1 << 15));
 		SetJumpTarget(skip3);
 
-		LDMXCSR(M(&mips_->temp));
+		LDMXCSR(MIPSSTATE_VAR(temp));
 		SetJumpTarget(skip);
 		RET();
 	}
@@ -112,7 +112,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 	updateRoundingMode = AlignCode16(); {
 		// If it's only ever 0, we don't actually bother applying or restoring it.
 		// This is the most common situation.
-		TEST(32, M(&mips_->fcr31), Imm32(0x01000003));
+		TEST(32, MIPSSTATE_VAR(fcr31), Imm32(0x01000003));
 		FixupBranch skip = J_CC(CC_Z);
 #ifdef _M_X64
 		// TODO: Move the hasSetRounding flag somewhere we can reach it through the context pointer, or something.
@@ -167,7 +167,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 
 			dispatcherNoCheck = GetCodePtr();
 
-			MOV(32, R(EAX), M(&mips_->pc));
+			MOV(32, R(EAX), MIPSSTATE_VAR(pc));
 			dispatcherInEAXNoCheck = GetCodePtr();
 
 #ifdef MASKED_PSP_MEMORY
@@ -185,9 +185,8 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 			SHR(32, R(EDX), Imm8(24));
 			CMP(32, R(EDX), Imm8(MIPS_EMUHACK_OPCODE >> 24));
 			FixupBranch notfound = J_CC(CC_NE);
-				if (enableDebug)
-				{
-					ADD(32, M(&mips_->debugCount), Imm8(1));
+				if (enableDebug) {
+					ADD(32, MIPSSTATE_VAR(debugCount), Imm8(1));
 				}
 				//grab from list and jump to it
 				AND(32, R(EAX), Imm32(MIPS_EMUHACK_VALUE_MASK));

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -658,8 +658,6 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 	js.compiling = false;
 }
 
-static u32 savedPC;
-
 void Jit::Comp_JumpReg(MIPSOpcode op)
 {
 	CONDITIONAL_LOG;
@@ -725,21 +723,18 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 			MOV(32, R(EAX), gpr.R(rs));
 		}
 		FlushAll();
-	}
-	else
-	{
+	} else {
 		// Latch destination now - save it in memory.
 		gpr.MapReg(rs, true, false);
-		MOV(32, M(&savedPC), gpr.R(rs));
+		MOV(32, MIPSSTATE_VAR(savedPC), gpr.R(rs));
 		if (andLink)
 			gpr.SetImm(rd, GetCompilerPC() + 8);
 		CompileDelaySlot(DELAYSLOT_NICE);
-		MOV(32, R(EAX), M(&savedPC));
+		MOV(32, R(EAX), MIPSSTATE_VAR(savedPC));
 		FlushAll();
 	}
 
-	switch (op & 0x3f)
-	{
+	switch (op & 0x3f) {
 	case 8: //jr
 		break;
 	case 9: //jalr

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -686,7 +686,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 	{
 		// If this is a syscall, write the pc (for thread switching and other good reasons.)
 		gpr.MapReg(rs, true, false);
-		MOV(32, M(&mips_->pc), gpr.R(rs));
+		MOV(32, MIPSSTATE_VAR(pc), gpr.R(rs));
 		if (andLink)
 			gpr.SetImm(rd, GetCompilerPC() + 8);
 		CompileDelaySlot(DELAYSLOT_FLUSH);
@@ -788,7 +788,7 @@ void Jit::Comp_Syscall(MIPSOpcode op)
 	js.downcountAmount = -offset;
 
 	if (!js.inDelaySlot) {
-		MOV(32, M(&mips_->pc), Imm32(GetCompilerPC() + 4));
+		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC() + 4));
 	}
 
 #ifdef USE_PROFILER

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -98,8 +98,6 @@ void Jit::Comp_FPU3op(MIPSOpcode op) {
 	}
 }
 
-static u32 MEMORY_ALIGNED16(ssLoadStoreTemp);
-
 void Jit::Comp_FPULS(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	s32 offset = _IMM16;
@@ -137,8 +135,8 @@ void Jit::Comp_FPULS(MIPSOpcode op) {
 				MOVSS(dest, fpr.RX(ft));
 			if (safe.PrepareSlowWrite())
 			{
-				MOVSS(M(&ssLoadStoreTemp), fpr.RX(ft));
-				safe.DoSlowWrite(safeMemFuncs.writeU32, M(&ssLoadStoreTemp));
+				MOVSS(MIPSSTATE_VAR(temp), fpr.RX(ft));
+				safe.DoSlowWrite(safeMemFuncs.writeU32, MIPSSTATE_VAR(temp));
 			}
 			safe.Finish();
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -249,8 +249,8 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 			MOV(32, R(TEMPREG), M(&mxcsrTemp));
 			AND(32, R(TEMPREG), Imm32(~(3 << 13)));
 			OR(32, R(TEMPREG), Imm32(setMXCSR << 13));
-			MOV(32, M(&mips_->temp), R(TEMPREG));
-			LDMXCSR(M(&mips_->temp));
+			MOV(32, MIPSSTATE_VAR(temp), R(TEMPREG));
+			LDMXCSR(MIPSSTATE_VAR(temp));
 		}
 
 		(this->*conv)(TEMPREG, fpr.R(fs));
@@ -388,7 +388,7 @@ void Jit::Comp_mxc1(MIPSOpcode op) {
 				gpr.MapReg(MIPS_REG_FPCOND, true, false);
 			}
 			gpr.MapReg(rt, false, true);
-			MOV(32, gpr.R(rt), M(&mips_->fcr31));
+			MOV(32, gpr.R(rt), MIPSSTATE_VAR(fcr31));
 			if (wasImm) {
 				if (gpr.GetImm(MIPS_REG_FPCOND) & 1) {
 					OR(32, gpr.R(rt), Imm32(1 << 23));
@@ -426,7 +426,7 @@ void Jit::Comp_mxc1(MIPSOpcode op) {
 			RestoreRoundingMode();
 			if (gpr.IsImm(rt)) {
 				gpr.SetImm(MIPS_REG_FPCOND, (gpr.GetImm(rt) >> 23) & 1);
-				MOV(32, M(&mips_->fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
+				MOV(32, MIPSSTATE_VAR(fcr31), Imm32(gpr.GetImm(rt) & 0x0181FFFF));
 				if ((gpr.GetImm(rt) & 0x1000003) == 0) {
 					// Default nearest / no-flush mode, just leave it cleared.
 				} else {
@@ -440,8 +440,8 @@ void Jit::Comp_mxc1(MIPSOpcode op) {
 				MOV(32, gpr.R(MIPS_REG_FPCOND), gpr.R(rt));
 				SHR(32, gpr.R(MIPS_REG_FPCOND), Imm8(23));
 				AND(32, gpr.R(MIPS_REG_FPCOND), Imm32(1));
-				MOV(32, M(&mips_->fcr31), gpr.R(rt));
-				AND(32, M(&mips_->fcr31), Imm32(0x0181FFFF));
+				MOV(32, MIPSSTATE_VAR(fcr31), gpr.R(rt));
+				AND(32, MIPSSTATE_VAR(fcr31), Imm32(0x0181FFFF));
 				gpr.UnlockAll();
 				UpdateRoundingMode();
 				ApplyRoundingMode();

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -151,7 +151,6 @@ void Jit::Comp_FPULS(MIPSOpcode op) {
 	}
 }
 
-static const u64 MEMORY_ALIGNED16(ssOneBits[2])	= {0x0000000100000001ULL, 0x0000000100000001ULL};
 static const u64 MEMORY_ALIGNED16(ssSignBits2[2])	= {0x8000000080000000ULL, 0x8000000080000000ULL};
 static const u64 MEMORY_ALIGNED16(ssNoSignMask[2]) = {0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL};
 
@@ -312,14 +311,13 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		}
 		break;
 
-
 	case 4:	//F(fd)	= sqrtf(F(fs)); break; //sqrt
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
 		SQRTSS(fpr.RX(fd), fpr.R(fs));
 		break;
 
-	case 13: //FsI(fd) = F(fs)>=0 ? (int)floorf(F(fs)) : (int)ceilf(F(fs)); break;//trunc.w.s
+	case 13: //FsI(fd) = F(fs)>=0 ? (int)floorf(F(fs)) : (int)ceilf(F(fs)); break; //trunc.w.s
 		execRounding(&XEmitter::CVTTSS2SI, -1);
 		break;
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -277,14 +277,15 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 5:	//F(fd)	= fabsf(F(fs)); break; //abs
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
+		MOV(PTRBITS, R(TEMPREG), ImmPtr(&ssNoSignMask[0]));
 		if (fd != fs && fpr.IsMapped(fs)) {
-			MOVAPS(fpr.RX(fd), M(ssNoSignMask));
+			MOVAPS(fpr.RX(fd), MatR(TEMPREG));
 			ANDPS(fpr.RX(fd), fpr.R(fs));
 		} else {
 			if (fd != fs) {
 				MOVSS(fpr.RX(fd), fpr.R(fs));
 			}
-			ANDPS(fpr.RX(fd), M(ssNoSignMask));
+			ANDPS(fpr.RX(fd), MatR(TEMPREG));
 		}
 		break;
 
@@ -299,14 +300,15 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 	case 7:	//F(fd)	= -F(fs);			 break; //neg
 		fpr.SpillLock(fd, fs);
 		fpr.MapReg(fd, fd == fs, true);
+		MOV(PTRBITS, R(TEMPREG), ImmPtr(&ssSignBits2[0]));
 		if (fd != fs && fpr.IsMapped(fs)) {
-			MOVAPS(fpr.RX(fd), M(ssSignBits2));
+			MOVAPS(fpr.RX(fd), MatR(TEMPREG));
 			XORPS(fpr.RX(fd), fpr.R(fs));
 		} else {
 			if (fd != fs) {
 				MOVSS(fpr.RX(fd), fpr.R(fs));
 			}
-			XORPS(fpr.RX(fd), M(ssSignBits2));
+			XORPS(fpr.RX(fd), MatR(TEMPREG));
 		}
 		break;
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -228,8 +228,6 @@ void Jit::Comp_FPUComp(MIPSOpcode op) {
 	}
 }
 
-static u32 mxcsrTemp;
-
 void Jit::Comp_FPU2op(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 	
@@ -245,8 +243,8 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 			setMXCSR = -1;
 		}
 		if (setMXCSR != -1) {
-			STMXCSR(M(&mxcsrTemp));
-			MOV(32, R(TEMPREG), M(&mxcsrTemp));
+			STMXCSR(MIPSSTATE_VAR(mxcsrTemp));
+			MOV(32, R(TEMPREG), MIPSSTATE_VAR(mxcsrTemp));
 			AND(32, R(TEMPREG), Imm32(~(3 << 13)));
 			OR(32, R(TEMPREG), Imm32(setMXCSR << 13));
 			MOV(32, MIPSSTATE_VAR(temp), R(TEMPREG));
@@ -273,7 +271,7 @@ void Jit::Comp_FPU2op(MIPSOpcode op) {
 		MOVD_xmm(fpr.RX(fd), R(TEMPREG));
 
 		if (setMXCSR != -1) {
-			LDMXCSR(M(&mxcsrTemp));
+			LDMXCSR(MIPSSTATE_VAR(mxcsrTemp));
 		}
 	};
 

--- a/Core/MIPS/x86/CompReplace.cpp
+++ b/Core/MIPS/x86/CompReplace.cpp
@@ -32,7 +32,8 @@ int Jit::Replace_fabsf() {
 	fpr.SpillLock(0, 12);
 	fpr.MapReg(0, false, true);
 	MOVSS(fpr.RX(0), fpr.R(12));
-	ANDPS(fpr.RX(0), M(&ssNoSignMask));
+	MOV(PTRBITS, R(RAX), ImmPtr(&ssNoSignMask));
+	ANDPS(fpr.RX(0), MatR(RAX));
 	fpr.ReleaseSpillLocks();
 	return 4;  // Number of instructions in the MIPS function
 }

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1465,7 +1465,7 @@ void Jit::Comp_Vcmp(MIPSOpcode op) {
 
 		MOV(32, R(TEMPREG), MIPSSTATE_VAR(vcmpResult[0]));
 		for (int i = 1; i < n; ++i) {
-			OR(32, R(TEMPREG), MIPSSTATE_VAR(vcmpResult[i]));
+			OR(32, R(TEMPREG), MIPSSTATE_VAR_ELEM32(vcmpResult[0], i));
 		}
 
 		// Aggregate the bits. Urgh, expensive. Can optimize for the case of one comparison,
@@ -2441,7 +2441,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 					// In case we have a saved prefix.
 					FlushPrefixV();
 					gpr.MapReg(rt, false, true);
-					MOV(32, gpr.R(rt), MIPSSTATE_VAR(vfpuCtrl[imm - 128]));
+					MOV(32, gpr.R(rt), MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128));
 				}
 			} else {
 				//ERROR - maybe need to make this value too an "interlock" value?
@@ -2473,7 +2473,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 				}
 			} else {
 				gpr.MapReg(rt, true, false);
-				MOV(32, MIPSSTATE_VAR(vfpuCtrl[imm - 128]), gpr.R(rt));
+				MOV(32, MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128), gpr.R(rt));
 			}
 
 			// TODO: Optimization if rt is Imm?
@@ -2505,7 +2505,7 @@ void Jit::Comp_Vmfvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, true, false);
 			MOVD_xmm(fpr.VX(vs), gpr.R(MIPS_REG_VFPUCC));
 		} else {
-			MOVSS(fpr.VX(vs), MIPSSTATE_VAR(vfpuCtrl[imm - 128]));
+			MOVSS(fpr.VX(vs), MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128));
 		}
 		fpr.ReleaseSpillLocks();
 	}
@@ -2521,7 +2521,7 @@ void Jit::Comp_Vmtvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, false, true);
 			MOVD_xmm(gpr.R(MIPS_REG_VFPUCC), fpr.VX(vs));
 		} else {
-			MOVSS(MIPSSTATE_VAR(vfpuCtrl[imm - 128]), fpr.VX(vs));
+			MOVSS(MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128), fpr.VX(vs));
 		}
 		fpr.ReleaseSpillLocks();
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -973,10 +973,8 @@ void Jit::Comp_Vcmov(MIPSOpcode op) {
 	fpr.ReleaseSpillLocks();
 }
 
-static s32 vminmax_sreg;
-
 static s32 DoVminSS(s32 treg) {
-	s32 sreg = vminmax_sreg;
+	s32 sreg = currentMIPS->temp;
 
 	// If both are negative, we flip the comparison (not two's compliment.)
 	if (sreg < 0 && treg < 0) {
@@ -989,7 +987,7 @@ static s32 DoVminSS(s32 treg) {
 }
 
 static s32 DoVmaxSS(s32 treg) {
-	s32 sreg = vminmax_sreg;
+	s32 sreg = currentMIPS->temp;
 
 	// This is the same logic as vmin, just reversed.
 	if (sreg < 0 && treg < 0) {
@@ -1205,7 +1203,7 @@ void Jit::Comp_VecDo3(MIPSOpcode op) {
 					UCOMISS(tempxregs[i], R(XMM0));
 					FixupBranch skip = J_CC(CC_NP, true);
 
-					MOVSS(M(&vminmax_sreg), tempxregs[i]);
+					MOVSS(MIPSSTATE_VAR(temp), tempxregs[i]);
 					MOVD_xmm(R(EAX), XMM0);
 					CallProtectedFunction(&DoVminSS, R(EAX));
 					MOVD_xmm(tempxregs[i], R(EAX));
@@ -1222,7 +1220,7 @@ void Jit::Comp_VecDo3(MIPSOpcode op) {
 					UCOMISS(tempxregs[i], R(XMM0));
 					FixupBranch skip = J_CC(CC_NP, true);
 
-					MOVSS(M(&vminmax_sreg), tempxregs[i]);
+					MOVSS(MIPSSTATE_VAR(temp), tempxregs[i]);
 					MOVD_xmm(R(EAX), XMM0);
 					CallProtectedFunction(&DoVmaxSS, R(EAX));
 					MOVD_xmm(tempxregs[i], R(EAX));

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2352,12 +2352,12 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			DIVSS(tempxregs[i], R(XMM0));
 			break;
 		case 18: // d[i] = sinf((float)M_PI_2 * s[i]); break; //vsin
-			LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
+			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&SinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
 		case 19: // d[i] = cosf((float)M_PI_2 * s[i]); break; //vcos
-			LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
+			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&CosOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[1]));
 			break;
@@ -2373,7 +2373,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ANDPS(tempxregs[i], MatR(TEMPREG));
 			break;
 		case 23: // d[i] = asinf(s[i]) / M_PI_2; break; //vasin
-			LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
+			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&ASinScaled, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
@@ -2385,7 +2385,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			MOVSS(tempxregs[i], R(XMM0));
 			break;
 		case 26: // d[i] = -sinf((float)M_PI_2 * s[i]); break; // vnsin
-			LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
+			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&NegSinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2176,7 +2176,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 #ifdef _WIN32
 		LEA(64, RDX, MIPSSTATE_VAR(sincostemp[0]));
 #else
-		LEA(64, RSI, MIPSSTATE_VAR(sincostemp[0]));
+		LEA(64, RDI, MIPSSTATE_VAR(sincostemp[0]));
 #endif
 		ABI_CallFunction(thunks.ProtectFunction((const void *)sinCosFunc, 0));
 #else
@@ -3519,7 +3519,7 @@ void Jit::Comp_VRot(MIPSOpcode op) {
 #ifdef _WIN32
 	LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
 #else
-	LEA(64, RSI, MIPSSTATE_VAR(sincostemp));
+	LEA(64, RDI, MIPSSTATE_VAR(sincostemp));
 #endif
 	MOVSS(XMM0, fpr.V(sreg));
 	ABI_CallFunction(negSin1 ? (const void *)&SinCosNegSin : (const void *)&SinCos);

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1465,7 +1465,8 @@ void Jit::Comp_Vcmp(MIPSOpcode op) {
 			PCMPEQW(XMM1, R(XMM1));
 			XORPS(XMM0, R(XMM1));
 		}
-		ANDPS(XMM0, M(vcmpMask[n - 1]));
+		MOV(PTRBITS, R(TEMPREG), ImmPtr(&vcmpMask[n - 1]));
+		ANDPS(XMM0, MatR(TEMPREG));
 		MOVAPS(MIPSSTATE_VAR(vcmpResult), XMM0);
 
 		MOV(32, R(TEMPREG), MIPSSTATE_VAR(vcmpResult[0]));
@@ -2981,7 +2982,7 @@ void Jit::Comp_Vmmul(MIPSOpcode op) {
 void Jit::Comp_Vmscl(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 
-	// TODO: This probably ignores prefixes?
+	// TODO: This op probably ignores prefixes?
 	if (js.HasUnknownPrefix())
 		DISABLE;
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -973,10 +973,10 @@ void Jit::Comp_Vcmov(MIPSOpcode op) {
 	fpr.ReleaseSpillLocks();
 }
 
-static s32 MEMORY_ALIGNED16(vminmax_sreg[4]);
+static s32 vminmax_sreg;
 
 static s32 DoVminSS(s32 treg) {
-	s32 sreg = vminmax_sreg[0];
+	s32 sreg = vminmax_sreg;
 
 	// If both are negative, we flip the comparison (not two's compliment.)
 	if (sreg < 0 && treg < 0) {
@@ -989,7 +989,7 @@ static s32 DoVminSS(s32 treg) {
 }
 
 static s32 DoVmaxSS(s32 treg) {
-	s32 sreg = vminmax_sreg[0];
+	s32 sreg = vminmax_sreg;
 
 	// This is the same logic as vmin, just reversed.
 	if (sreg < 0 && treg < 0) {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2174,9 +2174,9 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 		MOVSS(XMM0, fpr.V(sreg));
 		// TODO: This reg might be different on Linux...
 #ifdef _WIN32
-		LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
+		LEA(64, RDX, MIPSSTATE_VAR(sincostemp[0]));
 #else
-		LEA(64, RSI, MIPSSTATE_VAR(sincostemp));
+		LEA(64, RSI, MIPSSTATE_VAR(sincostemp[0]));
 #endif
 		ABI_CallFunction(thunks.ProtectFunction((const void *)sinCosFunc, 0));
 #else
@@ -2186,7 +2186,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 		} else {
 			MOV(32, R(EAX), fpr.V(sreg));
 		}
-		CallProtectedFunction((const void *)sinCosFunc, R(EAX), Imm32((uint32_t)(uintptr_t)mips_->sincostemp));
+		CallProtectedFunction((const void *)sinCosFunc, R(EAX), Imm32((uint32_t)(uintptr_t)&mips_->sincostemp[0]));
 #endif
 	};
 
@@ -2352,12 +2352,10 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			DIVSS(tempxregs[i], R(XMM0));
 			break;
 		case 18: // d[i] = sinf((float)M_PI_2 * s[i]); break; //vsin
-			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&SinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
 		case 19: // d[i] = cosf((float)M_PI_2 * s[i]); break; //vcos
-			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&CosOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[1]));
 			break;
@@ -2373,7 +2371,6 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			ANDPS(tempxregs[i], MatR(TEMPREG));
 			break;
 		case 23: // d[i] = asinf(s[i]) / M_PI_2; break; //vasin
-			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&ASinScaled, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
@@ -2385,7 +2382,6 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			MOVSS(tempxregs[i], R(XMM0));
 			break;
 		case 26: // d[i] = -sinf((float)M_PI_2 * s[i]); break; // vnsin
-			LEA(PTRBITS, RDX, MIPSSTATE_VAR(sincostemp[0]));
 			trigCallHelper(&NegSinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -1831,8 +1831,8 @@ void Jit::Comp_Vf2i(MIPSOpcode op) {
 		if (setMXCSR != 0) {
 			OR(32, R(TEMPREG), Imm32(setMXCSR << 13));
 		}
-		MOV(32, M(&mips_->temp), R(TEMPREG));
-		LDMXCSR(M(&mips_->temp));
+		MOV(32, MIPSSTATE_VAR(temp), R(TEMPREG));
+		LDMXCSR(MIPSSTATE_VAR(temp));
 	}
 
 	u8 sregs[4], dregs[4];

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2383,7 +2383,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 					// In case we have a saved prefix.
 					FlushPrefixV();
 					gpr.MapReg(rt, false, true);
-					MOV(32, gpr.R(rt), M(&mips_->vfpuCtrl[imm - 128]));
+					MOV(32, gpr.R(rt), MIPSSTATE_VAR(vfpuCtrl[imm - 128]));
 				}
 			} else {
 				//ERROR - maybe need to make this value too an "interlock" value?
@@ -2415,7 +2415,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 				}
 			} else {
 				gpr.MapReg(rt, true, false);
-				MOV(32, M(&mips_->vfpuCtrl[imm - 128]), gpr.R(rt));
+				MOV(32, MIPSSTATE_VAR(vfpuCtrl[imm - 128]), gpr.R(rt));
 			}
 
 			// TODO: Optimization if rt is Imm?
@@ -2447,7 +2447,7 @@ void Jit::Comp_Vmfvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, true, false);
 			MOVD_xmm(fpr.VX(vs), gpr.R(MIPS_REG_VFPUCC));
 		} else {
-			MOVSS(fpr.VX(vs), M(&mips_->vfpuCtrl[imm - 128]));
+			MOVSS(fpr.VX(vs), MIPSSTATE_VAR(vfpuCtrl[imm - 128]));
 		}
 		fpr.ReleaseSpillLocks();
 	}
@@ -2463,7 +2463,7 @@ void Jit::Comp_Vmtvc(MIPSOpcode op) {
 			gpr.MapReg(MIPS_REG_VFPUCC, false, true);
 			MOVD_xmm(gpr.R(MIPS_REG_VFPUCC), fpr.VX(vs));
 		} else {
-			MOVSS(M(&mips_->vfpuCtrl[imm - 128]), fpr.VX(vs));
+			MOVSS(MIPSSTATE_VAR(vfpuCtrl[imm - 128]), fpr.VX(vs));
 		}
 		fpr.ReleaseSpillLocks();
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -374,7 +374,12 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 			// If we're rewinding, CORE_NEXTFRAME should not cause a rewind.
 			// It doesn't really matter either way if we're not rewinding.
 			// CORE_RUNNING is <= CORE_NEXTFRAME.
-			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			if (RipAccessible((const void *)coreState)) {
+				CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			} else {
+				MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+				CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+			}
 			FixupBranch skipCheck = J_CC(CC_LE);
 			if (js.afterOp & JitState::AFTER_REWIND_PC_BAD_STATE)
 				MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -375,7 +375,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 			// It doesn't really matter either way if we're not rewinding.
 			// CORE_RUNNING is <= CORE_NEXTFRAME.
 			if (RipAccessible((const void *)coreState)) {
-				CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+				CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 			} else {
 				MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 				CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
@@ -668,7 +668,7 @@ void Jit::WriteExit(u32 destination, int exit_num) {
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
 		if (RipAccessible((const void *)coreState)) {
-			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
@@ -712,7 +712,7 @@ void Jit::WriteExitDestInReg(X64Reg reg) {
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
 		if (RipAccessible((const void *)coreState)) {
-			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -193,7 +193,7 @@ void Jit::FlushPrefixV() {
 
 void Jit::WriteDowncount(int offset) {
 	const int downcount = js.downcountAmount + offset;
-	SUB(32, M(&mips_->downcount), downcount > 127 ? Imm32(downcount) : Imm8(downcount));
+	SUB(32, MIPSSTATE_VAR(downcount), downcount > 127 ? Imm32(downcount) : Imm8(downcount));
 }
 
 void Jit::RestoreRoundingMode(bool force) {
@@ -226,13 +226,13 @@ void Jit::SaveFlags() {
 #if defined(_M_X64)
 	// On X64, the above misaligns the stack. However there might be a cheaper solution than this.
 	POP(64, R(EAX));
-	MOV(64, MDisp(X64JitConstants::CTXREG, offsetof(MIPSState, saved_flags)), R(EAX));
+	MOV(64, MIPSSTATE_VAR(saved_flags), R(EAX));
 #endif
 }
 
 void Jit::LoadFlags() {
 #if defined(_M_X64)
-	MOV(64, R(EAX), MDisp(X64JitConstants::CTXREG, offsetof(MIPSState, saved_flags)));
+	MOV(64, R(EAX), MIPSSTATE_VAR(saved_flags));
 	PUSH(64, R(EAX));
 #endif
 	POPF();
@@ -347,7 +347,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	b->checkedEntry = (u8 *)GetCodePtr();
 	// Downcount flag check. The last block decremented downcounter, and the flag should still be available.
 	FixupBranch skip = J_CC(CC_NS);
-	MOV(32, M(&mips_->pc), Imm32(js.blockStart));
+	MOV(32, MIPSSTATE_VAR(pc), Imm32(js.blockStart));
 	JMP(outerLoop, true);  // downcount hit zero - go advance.
 	SetJumpTarget(skip);
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -329,8 +329,7 @@ MIPSOpcode Jit::GetOffsetInstruction(int offset) {
 	return Memory::Read_Instruction(GetCompilerPC() + 4 * offset);
 }
 
-const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
-{
+const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 	js.cancel = false;
 	js.blockStart = js.compilerPC = mips_->pc;
 	js.lastContinuedPC = 0;
@@ -394,8 +393,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 		js.numInstructions++;
 
 		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
-		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS)
-		{
+		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS) {
 			FlushAll();
 			WriteExit(GetCompilerPC(), js.nextExit++);
 			js.compiling = false;
@@ -405,10 +403,9 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	b->codeSize = (u32)(GetCodePtr() - b->normalEntry);
 	NOP();
 	AlignCode4();
-	if (js.lastContinuedPC == 0)
+	if (js.lastContinuedPC == 0) {
 		b->originalSize = js.numInstructions;
-	else
-	{
+	} else {
 		// We continued at least once.  Add the last proxy and set the originalSize correctly.
 		blocks.ProxyBlock(js.blockStart, js.lastContinuedPC, (GetCompilerPC() - js.lastContinuedPC) / sizeof(u32), GetCodePtr());
 		b->originalSize = js.initialBlockSize;
@@ -416,8 +413,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b)
 	return b->normalEntry;
 }
 
-void Jit::AddContinuedBlock(u32 dest)
-{
+void Jit::AddContinuedBlock(u32 dest) {
 	// The first block is the root block.  When we continue, we create proxy blocks after that.
 	if (js.lastContinuedPC == 0)
 		js.initialBlockSize = js.numInstructions;
@@ -703,8 +699,7 @@ void Jit::WriteExit(u32 destination, int exit_num) {
 
 void Jit::WriteExitDestInReg(X64Reg reg) {
 	// If we need to verify coreState and rewind, we may not jump yet.
-	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE))
-	{
+	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
 		CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
 		FixupBranch skipCheck = J_CC(CC_LE);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -355,7 +355,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 	MIPSAnalyst::AnalysisResults analysis = MIPSAnalyst::Analyze(em_address);
 
 	gpr.Start(mips_, &js, &jo, analysis);
-	fpr.Start(mips_, &js, &jo, analysis);
+	fpr.Start(mips_, &js, &jo, analysis, RipAccessible(&mips_->v[0]));
 
 	js.numInstructions = 0;
 	while (js.compiling) {

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -48,8 +48,6 @@ namespace MIPSComp
 {
 using namespace Gen;
 
-static u64 saved_flags;
-
 const bool USE_JIT_MISSMAP = false;
 static std::map<std::string, u32> notJitOps;
 
@@ -228,13 +226,13 @@ void Jit::SaveFlags() {
 #if defined(_M_X64)
 	// On X64, the above misaligns the stack. However there might be a cheaper solution than this.
 	POP(64, R(EAX));
-	MOV(64, M(&saved_flags), R(EAX));
+	MOV(64, MDisp(X64JitConstants::CTXREG, offsetof(MIPSState, saved_flags)), R(EAX));
 #endif
 }
 
 void Jit::LoadFlags() {
 #if defined(_M_X64)
-	MOV(64, R(EAX), M(&saved_flags));
+	MOV(64, R(EAX), MDisp(X64JitConstants::CTXREG, offsetof(MIPSState, saved_flags)));
 	PUSH(64, R(EAX));
 #endif
 	POPF();
@@ -429,10 +427,6 @@ void Jit::AddContinuedBlock(u32 dest)
 }
 
 bool Jit::DescribeCodePtr(const u8 *ptr, std::string &name) {
-#if defined(_M_X64)
-	if (ptr == (const u8 *)&saved_flags)
-		name = "saved_flags";
-#endif
 	if (ptr == applyRoundingMode)
 		name = "applyRoundingMode";
 	else if (ptr == updateRoundingMode)

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -667,7 +667,12 @@ void Jit::WriteExit(u32 destination, int exit_num) {
 	// If we need to verify coreState and rewind, we may not jump yet.
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+		if (RipAccessible((const void *)coreState)) {
+			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+		} else {
+			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+		}
 		FixupBranch skipCheck = J_CC(CC_LE);
 		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));
 		WriteSyscallExit();
@@ -706,7 +711,12 @@ void Jit::WriteExitDestInReg(X64Reg reg) {
 	// If we need to verify coreState and rewind, we may not jump yet.
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+		if (RipAccessible((const void *)coreState)) {
+			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+		} else {
+			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+		}
 		FixupBranch skipCheck = J_CC(CC_LE);
 		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));
 		WriteSyscallExit();

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -369,7 +369,7 @@ void JitSafeMem::MemCheckImm(MemoryOpType type)
 
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
 		if (jit_->RipAccessible((const void *)coreState)) {
-			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
 			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
@@ -424,7 +424,7 @@ void JitSafeMem::MemCheckAsm(MemoryOpType type)
 	{
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
 		if (jit_->RipAccessible((const void *)coreState)) {
-			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));
+			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
 			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -268,7 +268,7 @@ void JitSafeMem::DoSlowWrite(const void *safeFunc, const OpArg& src, int suboffs
 		jit_->MOV(32, R(EDX), src);
 	}
 	if (!g_Config.bIgnoreBadMemAccess) {
-		jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->GetCompilerPC()));
+		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
 	}
 	// This is a special jit-ABI'd function.
 	jit_->CALL(safeFunc);
@@ -298,7 +298,7 @@ bool JitSafeMem::PrepareSlowRead(const void *safeFunc)
 		}
 
 		if (!g_Config.bIgnoreBadMemAccess) {
-			jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->GetCompilerPC()));
+			jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
 		}
 		// This is a special jit-ABI'd function.
 		jit_->CALL(safeFunc);
@@ -332,7 +332,7 @@ void JitSafeMem::NextSlowRead(const void *safeFunc, int suboffset)
 	}
 
 	if (!g_Config.bIgnoreBadMemAccess) {
-		jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->GetCompilerPC()));
+		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
 	}
 	// This is a special jit-ABI'd function.
 	jit_->CALL(safeFunc);
@@ -364,7 +364,7 @@ void JitSafeMem::MemCheckImm(MemoryOpType type)
 		if (!(check->cond & MEMCHECK_WRITE) && type == MEM_WRITE)
 			return;
 
-		jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->GetCompilerPC()));
+		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
 		jit_->CallProtectedFunction(&JitMemCheck, iaddr_, size_, type == MEM_WRITE ? 1 : 0);
 
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
@@ -404,7 +404,7 @@ void JitSafeMem::MemCheckAsm(MemoryOpType type)
 		// Keep the stack 16-byte aligned, just PUSH/POP 4 times.
 		for (int i = 0; i < 4; ++i)
 			jit_->PUSH(xaddr_);
-		jit_->MOV(32, M(&jit_->mips_->pc), Imm32(jit_->GetCompilerPC()));
+		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
 		jit_->ADD(32, R(xaddr_), Imm32(offset_));
 		jit_->CallProtectedFunction(&JitMemCheck, R(xaddr_), size_, type == MEM_WRITE ? 1 : 0);
 		for (int i = 0; i < 4; ++i)

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -327,16 +327,16 @@ OpArg GPRRegCache::GetDefaultLocation(MIPSGPReg reg) const {
 	}
 	switch (reg) {
 	case MIPS_REG_HI:
-		return M(&mips->hi);
+		return MIPSSTATE_VAR(hi);
 	case MIPS_REG_LO:
-		return M(&mips->lo);
+		return MIPSSTATE_VAR(lo);
 	case MIPS_REG_FPCOND:
-		return M(&mips->fpcond);
+		return MIPSSTATE_VAR(fpcond);
 	case MIPS_REG_VFPUCC:
-		return M(&mips->vfpuCtrl[VFPU_CTRL_CC]);
+		return MIPSSTATE_VAR(vfpuCtrl[VFPU_CTRL_CC]);
 	default:
 		ERROR_LOG_REPORT(JIT, "bad mips register %i", reg);
-		return M(&mips->r[0]);
+		return MIPSSTATE_VAR(r[0]);
 	}
 }
 

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -899,13 +899,13 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 		if (useRip_) {
 			return M(&mips->v[voffset[reg - 32]]);  // rip accessible
 		} else {
-			return MIPSSTATE_VAR(v[voffset[reg - 32]]);  // rip accessible
+			return MIPSSTATE_VAR_ELEM32(v[0], voffset[reg - 32]);  // rip accessible
 		}
 	} else {
 		if (useRip_) {
 			return M(&mips->tempValues[reg - 32 - 128]);
 		} else {
-			return MIPSSTATE_VAR(tempValues[reg - 32 - 128]);
+			return MIPSSTATE_VAR_ELEM32(tempValues[0], reg - 32 - 128);
 		}
 	}
 }

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -897,6 +897,8 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 		return MDisp(CTXREG, reg * 4);
 	} else if (reg < 32 + 128) {
 		return M(&mips->v[voffset[reg - 32]]);
+		// This should work, but doesn't seem to. Maybe used from somewhere where CTXREG is not yet set properly.
+		// return MDisp(CTXREG, offsetof(MIPSState, v[0]) - offsetof(MIPSState, f[0]) + voffset[reg - 32] * sizeof(float));
 	} else {
 		return M(&tempValues[reg - 32 - 128]);
 	}

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -896,11 +896,11 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 		if (useRip_) {
 			return M(&mips->v[voffset[reg - 32]]);  // rip accessible
 		} else {
-			return MIPSSTATE_VAR_ELEM32(v[0], voffset[reg - 32]);  // rip accessible
+			return MIPSSTATE_VAR_ELEM32(v[0], voffset[reg - 32]);
 		}
 	} else {
 		if (useRip_) {
-			return M(&mips->tempValues[reg - 32 - 128]);
+			return M(&mips->tempValues[reg - 32 - 128]);  // rip accessible
 		} else {
 			return MIPSSTATE_VAR_ELEM32(tempValues[0], reg - 32 - 128);
 		}

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -895,10 +895,10 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 		return MDisp(CTXREG, reg * 4);
 	} else if (reg < 32 + 128) {
 		return M(&mips->v[voffset[reg - 32]]);
-		// This should work, but doesn't seem to. Maybe used from somewhere where CTXREG is not yet set properly.
-		// return MDisp(CTXREG, offsetof(MIPSState, v[0]) - offsetof(MIPSState, f[0]) + voffset[reg - 32] * sizeof(float));
+		// This should work, but doesn't seem to (crashes Crisis Core). Seems a bad instruction is generated somehow...
+		// return MIPSSTATE_VAR(v[voffset[reg - 32]]);
 	} else {
-		return M(&mips->tempValues[reg - 32 - 128]);
+		return MIPSSTATE_VAR(tempValues[reg - 32 - 128]);
 	}
 }
 

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -614,9 +614,6 @@ void FPURegCache::MapReg(const int i, bool doLoad, bool makeDirty) {
 		xregs[xr].dirty = makeDirty;
 		OpArg newloc = ::Gen::R(xr);
 		if (doLoad)	{
-			if (!regs[i].location.IsImm() && (regs[i].location.offset & 0x3)) {
-				PanicAlert("WARNING - misaligned fp register location %i", i);
-			}
 			emit->MOVSS(xr, regs[i].location);
 		}
 		regs[i].location = newloc;

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -897,9 +897,9 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 	} else if (reg < 32 + 128) {
 		// Here, RIP has the advantage so let's use it when possible
 		if (useRip_) {
-			return M(&mips->v[voffset[reg - 32]]);
+			return M(&mips->v[voffset[reg - 32]]);  // rip accessible
 		} else {
-			return MIPSSTATE_VAR(v[voffset[reg - 32]]);
+			return MIPSSTATE_VAR(v[voffset[reg - 32]]);  // rip accessible
 		}
 	} else {
 		if (useRip_) {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -97,7 +97,7 @@ public:
 	FPURegCache();
 	~FPURegCache() {}
 
-	void Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats);
+	void Start(MIPSState *mips, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats, bool useRip);
 	void MapReg(int preg, bool doLoad = true, bool makeDirty = true);
 	void StoreFromRegister(int preg);
 	void StoreFromRegisterV(int preg) {
@@ -231,6 +231,7 @@ private:
 	X64CachedFPReg xregs[NUM_X_FPREGS];
 	MIPSCachedFPReg *vregs;
 
+	bool useRip_;
 	bool pendingFlush;
 	bool initialReady;
 	MIPSCachedFPReg regsInitial[NUM_MIPS_FPRS];

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -44,9 +44,8 @@
 // and do it the old way.
 
 enum {
-	NUM_TEMPS = 16,
 	TEMP0 = 32 + 128,
-	NUM_MIPS_FPRS = 32 + 128 + NUM_TEMPS,
+	NUM_MIPS_FPRS = 32 + 128 + NUM_X86_FPU_TEMPS,
 };
 
 #ifdef _M_X64
@@ -236,9 +235,6 @@ private:
 	bool initialReady;
 	MIPSCachedFPReg regsInitial[NUM_MIPS_FPRS];
 	X64CachedFPReg xregsInitial[NUM_X_FPREGS];
-
-	// TEMP0, etc. are swapped in here if necessary (e.g. on x86.)
-	static float tempValues[NUM_TEMPS];
 
 	Gen::XEmitter *emit;
 	MIPSComp::JitState *js_;

--- a/Core/System.h
+++ b/Core/System.h
@@ -72,8 +72,6 @@ void PSP_BeginHostFrame();
 void PSP_EndHostFrame();
 void PSP_RunLoopUntil(u64 globalticks);
 void PSP_RunLoopFor(int cycles);
-void PSP_BeginFrame();
-void PSP_EndFrame();
 
 void Audio_Init();
 
@@ -88,8 +86,7 @@ void InitSysDirectories();
 #endif
 
 // RUNNING must be at 0, NEXTFRAME must be at 1.
-enum CoreState
-{
+enum CoreState {
 	CORE_RUNNING = 0,
 	CORE_NEXTFRAME = 1,
 	CORE_STEPPING,

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -202,17 +202,21 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	// Later we might want to do this when the matrices are loaded instead.
 	int boneCount = 0;
 	if (dec.weighttype && g_Config.bSoftwareSkinning && dec.morphcount == 1) {
-		MOVAPS(XMM4, M(&threeMasks));
+		MOV(PTRBITS, R(tempReg1), ImmPtr(&threeMasks));
+		MOVAPS(XMM4, MatR(tempReg1));
+		MOV(PTRBITS, R(tempReg1), ImmPtr(&aOne));
+		MOVUPS(XMM5, MatR(tempReg1));
+		MOV(PTRBITS, R(tempReg2), ImmPtr(gstate.boneMatrix));
 		for (int i = 0; i < dec.nweights; i++) {
-			MOVUPS(XMM0, M((gstate.boneMatrix + 12 * i)));
-			MOVUPS(XMM1, M((gstate.boneMatrix + 12 * i + 3)));
-			MOVUPS(XMM2, M((gstate.boneMatrix + 12 * i + 3 * 2)));
-			MOVUPS(XMM3, M((gstate.boneMatrix + 12 * i + 3 * 3)));
+			MOVUPS(XMM0, MDisp(tempReg2, 12 * i));
+			MOVUPS(XMM1, MDisp(tempReg2, 12 * i + 3));
+			MOVUPS(XMM2, MDisp(tempReg2, 12 * i + 3 * 2));
+			MOVUPS(XMM3, MDisp(tempReg2, 12 * i + 3 * 3));
 			ANDPS(XMM0, R(XMM4));
 			ANDPS(XMM1, R(XMM4));
 			ANDPS(XMM2, R(XMM4));
 			ANDPS(XMM3, R(XMM4));
-			ORPS(XMM3, M(&aOne));
+			ORPS(XMM3, R(XMM5));
 			MOVAPS(M((bones + 16 * i)), XMM0);
 			MOVAPS(M((bones + 16 * i + 4)), XMM1);
 			MOVAPS(M((bones + 16 * i + 8)), XMM2);

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -231,9 +231,11 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		MOVSS(fpScratchReg, MDisp(tempReg1, 4));
 		UNPCKLPS(fpScaleOffsetReg, R(fpScratchReg));
 		if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_8BIT) {
-			MULPS(fpScaleOffsetReg, M(&by128));
+			MOV(PTRBITS, R(tempReg2), ImmPtr(&by128));
+			MULPS(fpScaleOffsetReg, MatR(tempReg2));
 		} else if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_16BIT) {
-			MULPS(fpScaleOffsetReg, M(&by32768));
+			MOV(PTRBITS, R(tempReg2), ImmPtr(&by32768));
+			MULPS(fpScaleOffsetReg, MatR(tempReg2));
 		}
 		MOVSS(fpScratchReg, MDisp(tempReg1, 8));
 		MOVSS(fpScratchReg2, MDisp(tempReg1, 12));

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -206,12 +206,12 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		MOVAPS(XMM4, MatR(tempReg1));
 		MOV(PTRBITS, R(tempReg1), ImmPtr(&aOne));
 		MOVUPS(XMM5, MatR(tempReg1));
-		MOV(PTRBITS, R(tempReg2), ImmPtr(gstate.boneMatrix));
+		MOV(PTRBITS, R(tempReg1), ImmPtr(gstate.boneMatrix));
 		for (int i = 0; i < dec.nweights; i++) {
-			MOVUPS(XMM0, MDisp(tempReg2, 12 * i));
-			MOVUPS(XMM1, MDisp(tempReg2, 12 * i + 3));
-			MOVUPS(XMM2, MDisp(tempReg2, 12 * i + 3 * 2));
-			MOVUPS(XMM3, MDisp(tempReg2, 12 * i + 3 * 3));
+			MOVUPS(XMM0, MDisp(tempReg1, (12 * i) * 4));
+			MOVUPS(XMM1, MDisp(tempReg1, (12 * i + 3) * 4));
+			MOVUPS(XMM2, MDisp(tempReg1, (12 * i + 3 * 2) * 4));
+			MOVUPS(XMM3, MDisp(tempReg1, (12 * i + 3 * 3) * 4));
 			ANDPS(XMM0, R(XMM4));
 			ANDPS(XMM1, R(XMM4));
 			ANDPS(XMM2, R(XMM4));

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -207,6 +207,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		MOV(PTRBITS, R(tempReg1), ImmPtr(&aOne));
 		MOVUPS(XMM5, MatR(tempReg1));
 		MOV(PTRBITS, R(tempReg1), ImmPtr(gstate.boneMatrix));
+		MOV(PTRBITS, R(tempReg2), ImmPtr(bones));
 		for (int i = 0; i < dec.nweights; i++) {
 			MOVUPS(XMM0, MDisp(tempReg1, (12 * i) * 4));
 			MOVUPS(XMM1, MDisp(tempReg1, (12 * i + 3) * 4));
@@ -217,10 +218,10 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			ANDPS(XMM2, R(XMM4));
 			ANDPS(XMM3, R(XMM4));
 			ORPS(XMM3, R(XMM5));
-			MOVAPS(M((bones + 16 * i)), XMM0);
-			MOVAPS(M((bones + 16 * i + 4)), XMM1);
-			MOVAPS(M((bones + 16 * i + 8)), XMM2);
-			MOVAPS(M((bones + 16 * i + 12)), XMM3);
+			MOVAPS(MDisp(tempReg2, (16 * i) * 4), XMM0);
+			MOVAPS(MDisp(tempReg2, (16 * i + 4) * 4), XMM1);
+			MOVAPS(MDisp(tempReg2, (16 * i + 8) * 4), XMM2);
+			MOVAPS(MDisp(tempReg2, (16 * i + 12) * 4), XMM3);
 		}
 	}
 

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -1081,8 +1081,10 @@ void VertexDecoderJitCache::Jit_Color4444Morph() {
 	if (!cpu_info.bSSE4_1) {
 		PXOR(fpScratchReg4, R(fpScratchReg4));
 	}
-	MOVDQA(XMM5, M(color4444mask));
-	MOVAPS(XMM6, M(byColor4444));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(color4444mask));
+	MOVDQA(XMM5, MatR(tempReg2));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(byColor4444));
+	MOVAPS(XMM6, MatR(tempReg2));
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {
@@ -1126,8 +1128,10 @@ static const float MEMORY_ALIGNED16(byColor565[4]) = { 255.0f / 31.0f, 255.0f / 
 
 void VertexDecoderJitCache::Jit_Color565Morph() {
 	MOV(PTRBITS, R(tempReg1), ImmPtr(&gstate_c.morphWeights[0]));
-	MOVDQA(XMM5, M(color565Mask));
-	MOVAPS(XMM6, M(byColor565));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(color565Mask));
+	MOVDQA(XMM5, MatR(tempReg2));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(byColor565));
+	MOVAPS(XMM6, MatR(tempReg2));
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {
@@ -1179,8 +1183,10 @@ static const float MEMORY_ALIGNED16(byColor5551[4]) = { 255.0f / 31.0f, 255.0f /
 
 void VertexDecoderJitCache::Jit_Color5551Morph() {
 	MOV(PTRBITS, R(tempReg1), ImmPtr(&gstate_c.morphWeights[0]));
-	MOVDQA(XMM5, M(color5551Mask));
-	MOVAPS(XMM6, M(byColor5551));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(color5551Mask));
+	MOVDQA(XMM5, MatR(tempReg2));
+	MOV(PTRBITS, R(tempReg2), ImmPtr(byColor5551));
+	MOVAPS(XMM6, MatR(tempReg2));
 
 	bool first = true;
 	for (int n = 0; n < dec_->morphcount; ++n) {

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -1237,7 +1237,7 @@ void VertexDecoderJitCache::Jit_WriteMorphColor(int outOff, bool checkAlpha) {
 		CMP(32, R(tempReg1), Imm32(0xFF000000));
 		FixupBranch skip = J_CC(CC_AE, false);
 		if (RipAccessible(&gstate_c.vertexFullAlpha)) {
-			MOV(8, M(&gstate_c.vertexFullAlpha), Imm8(0));
+			MOV(8, M(&gstate_c.vertexFullAlpha), Imm8(0));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(tempReg2), ImmPtr(&gstate_c.vertexFullAlpha));
 			MOV(8, MatR(tempReg2), Imm8(0));


### PR DESCRIPTION
It's fine to run faster if we can arrange things so that the generated code is close to the binary in memory, but if not, we should still be able to run. 

This will make us more resilient to strange ASLR implementations and embedding within other programs like RetroArch.

This should work around but not properly fix #9741.