### PR TITLE
x64: Avoid clobbering jr dest in cases

### DIFF
--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -714,8 +714,9 @@ void Jit::WriteExitDestInReg(X64Reg reg) {
 		if (RipAccessible((const void *)coreState)) {
 			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
-			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
-			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+			X64Reg temp = reg == RAX ? RDX : RAX;
+			MOV(PTRBITS, R(temp), ImmPtr((const void *)&coreState));
+			CMP(32, MatR(temp), Imm32(CORE_NEXTFRAME));
 		}
 		FixupBranch skipCheck = J_CC(CC_LE);
 		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -374,7 +374,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 			// If we're rewinding, CORE_NEXTFRAME should not cause a rewind.
 			// It doesn't really matter either way if we're not rewinding.
 			// CORE_RUNNING is <= CORE_NEXTFRAME.
-			if (RipAccessible((const void *)coreState)) {
+			if (RipAccessible((const void *)&coreState)) {
 				CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 			} else {
 				MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
@@ -667,7 +667,7 @@ void Jit::WriteExit(u32 destination, int exit_num) {
 	// If we need to verify coreState and rewind, we may not jump yet.
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		if (RipAccessible((const void *)coreState)) {
+		if (RipAccessible((const void *)&coreState)) {
 			CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
 			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -368,11 +368,14 @@ void JitSafeMem::MemCheckImm(MemoryOpType type)
 		jit_->CallProtectedFunction(&JitMemCheck, iaddr_, size_, type == MEM_WRITE ? 1 : 0);
 
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		if (jit_->RipAccessible((const void *)coreState)) {
+		if (jit_->RipAccessible((const void *)&coreState)) {
 			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
+			// We can't safely overwrite any register, so push.  This is only while debugging.
+			jit_->PUSH(RAX);
 			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+			jit_->POP(RAX);
 		}
 		skipChecks_.push_back(jit_->J_CC(CC_G, true));
 		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE | JitState::AFTER_MEMCHECK_CLEANUP;
@@ -423,11 +426,14 @@ void JitSafeMem::MemCheckAsm(MemoryOpType type)
 	if (possible)
 	{
 		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		if (jit_->RipAccessible((const void *)coreState)) {
+		if (jit_->RipAccessible((const void *)&coreState)) {
 			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
 		} else {
+			// We can't safely overwrite any register, so push.  This is only while debugging.
+			jit_->PUSH(RAX);
 			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
 			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
+			jit_->POP(RAX);
 		}
 		skipChecks_.push_back(jit_->J_CC(CC_G, true));
 		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE | JitState::AFTER_MEMCHECK_CLEANUP;


### PR DESCRIPTION
`WriteExitDestInReg` can be called with RAX/EAX, and in that case we would clobber it with the coreState address.  Was breaking Legend of Heroes 3 (Gagharv not Trails.)

Also fixes a couple typos causing us to avoid rip when we could use it.

-[Unknown]