### PR TITLE
Fix crash on FreeBSD x86_64 when starting a game

### DIFF
--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -157,7 +157,7 @@ void *AllocateExecutableMemory(size_t size) {
 	}
 #else
 	static char *map_hint = 0;
-#if defined(_M_X64)
+#if defined(_M_X64) && !defined(MAP_32BIT)
 	// Try to request one that is close to our memory location if we're in high memory.
 	// We use a dummy global variable to give us a good location to start from.
 	if (!map_hint) {
@@ -179,7 +179,7 @@ void *AllocateExecutableMemory(size_t size) {
 	void* ptr = mmap(map_hint, size, prot,
 		MAP_ANON | MAP_PRIVATE
 #if defined(_M_X64) && defined(MAP_32BIT)
-		| ((uintptr_t) map_hint == 0 ? MAP_32BIT : 0)
+		| MAP_32BIT
 #endif
 		, -1, 0);
 
@@ -196,7 +196,7 @@ void *AllocateExecutableMemory(size_t size) {
 		ERROR_LOG(MEMMAP, "Failed to allocate executable memory (%d)", (int)size);
 		PanicAlert("Failed to allocate executable memory\n%s", GetLastErrorMsg());
 	}
-#if defined(_M_X64) && !defined(_WIN32)
+#if defined(_M_X64) && !defined(_WIN32) && !defined(MAP_32BIT)
 	else if ((uintptr_t)map_hint <= 0xFFFFFFFF) {
 		// Round up if we're below 32-bit mark, probably allocating sequentially.
 		map_hint += round_page(size);


### PR DESCRIPTION
`MAP_32BIT` code appears to have regressed by #6694 but the fallback doesn't work on FreeBSD with defaults limits. So, I'm trying to get rid of [a downstream hack](https://github.com/freebsd/freebsd-ports/blob/064f9430ec/emulators/ppsspp/files/patch-Common_MemoryUtil.cpp).

https://lists.freebsd.org/pipermail/freebsd-stable/2011-December/065032.html
