### PR TITLE
Fix and improve fullscreen on 21:9 monitors

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -513,6 +513,7 @@ static ConfigSetting graphicsSettings[] = {
 
 #ifndef MOBILE_DEVICE
 	ConfigSetting("FullScreen", &g_Config.bFullScreen, false),
+	ConfigSetting("FullScreenMulti", &g_Config.bFullScreenMulti, false),
 #endif
 
 	// TODO: Replace these settings with a list of options

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -189,6 +189,7 @@ public:
 	bool bTextureSecondaryCache;
 	bool bVertexDecoderJit;
 	bool bFullScreen;
+	bool bFullScreenMulti;
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	int bHighQualityDepth;

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -38,7 +38,6 @@ public:
 
 	virtual void InitSound() = 0;
 	virtual void UpdateSound() {}
-	virtual void GoFullscreen(bool) {}
 	virtual void ShutdownSound() = 0;
 	virtual void PollControllers() {}
 	virtual void ToggleDebugConsoleVisibility() {}

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -72,12 +72,13 @@ void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW
 				return;
 			}
 		} else if (g_Config.iSmallDisplayZoomType == 2) { // Auto Scaling
+			// Stretch to 1080 for 272*4.  But don't distort if not widescreen (i.e. ultrawide of halfwide.)
 			float pixelCrop = frameH / 270.0f;
 			float resCommonWidescreen = pixelCrop - floor(pixelCrop);
-			if (!rotated && resCommonWidescreen == 0.0f) {
-				*x = 0;
+			if (!rotated && resCommonWidescreen == 0.0f && frameW >= pixelCrop * 480.0f) {
+				*x = floorf((frameW - pixelCrop * 480.0f) * 0.5f);
 				*y = floorf(-pixelCrop);
-				*w = floorf(frameW);
+				*w = floorf(pixelCrop * 480.0f);
 				*h = floorf(pixelCrop * 272.0f);
 				return;
 			}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -263,6 +263,11 @@ void GameSettingsScreen::CreateViews() {
 
 #if !defined(MOBILE_DEVICE)
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gr->T("FullScreen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
+	if (System_GetPropertyInt(SYSPROP_DISPLAY_COUNT) > 1) {
+		CheckBox *fullscreenMulti = new CheckBox(&g_Config.bFullScreenMulti, gr->T("Use all displays"));
+		fullscreenMulti->SetEnabledPtr(&g_Config.bFullScreen);
+		graphicsSettings->Add(fullscreenMulti)->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
+	}
 #endif
 	// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
 	displayEditor_ = graphicsSettings->Add(new Choice(gr->T("Display layout editor")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -972,12 +972,7 @@ UI::EventReturn GameSettingsScreen::OnReloadCheats(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnFullscreenChange(UI::EventParams &e) {
-#if defined(USING_WIN_UI) || defined(USING_QT_UI)
-	host->GoFullscreen(g_Config.bFullScreen);
-#else
-	// SDL, basically.
-	System_SendMessage("toggle_fullscreen", "");
-#endif
+	System_SendMessage("toggle_fullscreen", g_Config.bFullScreen ? "1" : "0");
 	return UI::EVENT_DONE;
 }
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -360,10 +360,6 @@ bool WindowsHost::CreateDesktopShortcut(std::string argumentPath, std::string ga
 	return false;
 }
 
-void WindowsHost::GoFullscreen(bool viewFullscreen) {
-	MainWindow::SendToggleFullscreen(viewFullscreen);
-}
-
 void WindowsHost::ToggleDebugConsoleVisibility() {
 	MainWindow::ToggleDebugConsoleVisibility();
 }

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -66,8 +66,6 @@ public:
 
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
 
-	void GoFullscreen(bool) override;
-
 	std::shared_ptr<KeyboardDevice> keyboard;
 
 	GraphicsContext *GetGraphicsContext() { return gfx_; }

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -212,6 +212,8 @@ int System_GetPropertyInt(SystemProperty prop) {
 		return DEVICE_TYPE_DESKTOP;
 	case SYSPROP_DISPLAY_DPI:
 		return ScreenDPI();
+	case SYSPROP_DISPLAY_COUNT:
+		return GetSystemMetrics(SM_CMONITORS);
 	default:
 		return -1;
 	}

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -263,6 +263,14 @@ void System_SendMessage(const char *command, const char *parameter) {
 		MainWindow::BrowseAndBoot("");
 	} else if (!strcmp(command, "bgImage_browse")) {
 		MainWindow::BrowseBackground();
+	} else if (!strcmp(command, "toggle_fullscreen")) {
+		bool flag = !g_Config.bFullScreen;
+		if (strcmp(parameter, "0") == 0) {
+			flag = false;
+		} else if (strcmp(parameter, "1") == 0) {
+			flag = true;
+		}
+		MainWindow::SendToggleFullscreen(flag);
 	}
 }
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -169,6 +169,7 @@ enum SystemProperty {
 	SYSPROP_DISPLAY_YRES,
 	SYSPROP_DISPLAY_REFRESH_RATE,  // returns 1000*the refresh rate in Hz as it can be non-integer
 	SYSPROP_DISPLAY_DPI,
+	SYSPROP_DISPLAY_COUNT,
 	SYSPROP_MOGA_VERSION,
 
 	SYSPROP_DEVICE_TYPE,

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -66,6 +66,7 @@ GlobalUIState GetUIState();
 
 static SDL_Window* g_Screen = NULL;
 static bool g_ToggleFullScreenNextFrame = false;
+static int g_ToggleFullScreenType;
 static int g_QuitRequested = 0;
 
 static int g_DesktopWidth = 0;
@@ -248,6 +249,14 @@ void Vibrate(int length_ms) {
 void System_SendMessage(const char *command, const char *parameter) {
 	if (!strcmp(command, "toggle_fullscreen")) {
 		g_ToggleFullScreenNextFrame = true;
+		if (strcmp(parameter, "1") == 0) {
+			g_ToggleFullScreenType = 1;
+		} else if (strcmp(parameter, "0") == 0) {
+			g_ToggleFullScreenType = 0;
+		} else {
+			// Just toggle.
+			g_ToggleFullScreenType = -1;
+		}
 	} else if (!strcmp(command, "finish")) {
 		// Do a clean exit
 		g_QuitRequested = true;
@@ -391,7 +400,14 @@ void ToggleFullScreenIfFlagSet() {
 		g_ToggleFullScreenNextFrame = false;
 
 		Uint32 window_flags = SDL_GetWindowFlags(g_Screen);
-		SDL_SetWindowFullscreen(g_Screen, window_flags ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
+		if (g_ToggleFullScreenType == -1) {
+			window_flags ^= SDL_WINDOW_FULLSCREEN_DESKTOP;
+		} else if (g_ToggleFullScreenType == 1) {
+			window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+		} else {
+			window_flags &= ~SDL_WINDOW_FULLSCREEN_DESKTOP;
+		}
+		SDL_SetWindowFullscreen(g_Screen, window_flags);
 	}
 }
 


### PR DESCRIPTION
Ultrawide or 21:9 monitors are becoming more common.  I've recently gotten one to replace two 5:4 monitors I had used previously.

Most people will just run it as a single 21:9 display.  Our code assumed that 1080 tall meant 1920 wide, and so would stretch 33% wider.  At 1079 tall we wouldn't stretch, and there's a separate option to stretch.  This fixes that bug so it centers.

A less common configuration is to use "grid system" software that comes with these monitors, which forces windows into a configured grid (so they are always "maximized" at the borders you've defined.)  I haven't tested PPSSPP on this, but I assume you'd want to disable the grid before using PPSSPP (otherwise it'd be forced to the grid itself.)

Another configuration is to have the monitor exposed to Windows as two 1280x1080 or 1720x1444 displays, which behaves exactly like a traditional dual-monitor setup (maximizing a window takes the left or right half, YouTube fullscreens to one half, etc.)  The 1080 fix also fixes squashing in this configuration on one half.

I've also added a "multi-display" fullscreen, which allows you to use the entire virtual desktop as if it was the single 21:9 display.  The checkbox is only shown if you have multiple displays.

-[Unknown]