### PR TITLE
GLES: Set target w/h in buffered rendering

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -975,8 +975,8 @@ void EmuScreen::preRender() {
 		viewport.MaxDepth = 1.0;
 		viewport.MinDepth = 0.0;
 		draw->SetViewports(1, &viewport);
-		draw->SetTargetSize(pixel_xres, pixel_yres);
 	}
+	draw->SetTargetSize(pixel_xres, pixel_yres);
 }
 
 void EmuScreen::postRender() {


### PR DESCRIPTION
Otherwise, the flipped scissors don't update on window resize.

Example: when toggling fullscreen.  This was causing the FPS not to show from a smaller window.