### PR TITLE
Android audio refactor

### DIFF
--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -23,7 +23,8 @@
     <RootNamespace>DaSh</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>PPSSPPWindows</ProjectName>
-    <WindowsTargetPlatformVersion></WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>
+    </WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -295,6 +296,18 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\android\jni\native-audio-so.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\android\jni\native_audio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\android\jni\TestRunner.cpp" />
     <ClCompile Include="..\ext\glew\glew.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -426,6 +439,18 @@
     <ClInclude Include="..\android\jni\app-android.h" />
     <ClInclude Include="..\android\jni\ArmEmitterTest.h" />
     <ClInclude Include="..\android\jni\Arm64EmitterTest.h" />
+    <ClInclude Include="..\android\jni\native-audio-so.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\android\jni\native_audio.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\android\jni\TestRunner.h" />
     <ClInclude Include="..\ios\ViewController.h" />
     <ClInclude Include="..\Qt\Debugger\ctrldisasmview.h" />

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -195,6 +195,12 @@
     <ClCompile Include="..\android\jni\app-android.cpp">
       <Filter>Other Platforms</Filter>
     </ClCompile>
+    <ClCompile Include="..\android\jni\native_audio.cpp">
+      <Filter>Other Platforms</Filter>
+    </ClCompile>
+    <ClCompile Include="..\android\jni\native-audio-so.cpp">
+      <Filter>Other Platforms</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Debugger\CtrlDisAsmView.h">
@@ -356,6 +362,12 @@
       <Filter>Windows\System</Filter>
     </ClInclude>
     <ClInclude Include="..\android\jni\app-android.h">
+      <Filter>Other Platforms</Filter>
+    </ClInclude>
+    <ClInclude Include="..\android\jni\native_audio.h">
+      <Filter>Other Platforms</Filter>
+    </ClInclude>
+    <ClInclude Include="..\android\jni\native-audio-so.h">
       <Filter>Other Platforms</Filter>
     </ClInclude>
   </ItemGroup>

--- a/android/jni/native-audio-so.h
+++ b/android/jni/native-audio-so.h
@@ -1,6 +1,47 @@
 #pragma once
 
+#include <SLES/OpenSLES.h>
+#include <SLES/OpenSLES_Android.h>
+
 typedef int (*AndroidAudioCallback)(short *buffer, int num_samples);
 
-bool OpenSLWrap_Init(AndroidAudioCallback cb, int _FramesPerBuffer, int _SampleRate);
-void OpenSLWrap_Shutdown();
+class AudioContext {
+public:
+	AudioContext(AndroidAudioCallback cb, int _FramesPerBuffer, int _SampleRate);
+	virtual bool Init() { return false; }
+	virtual ~AudioContext() {}
+
+protected:
+	AndroidAudioCallback audioCallback;
+
+	int framesPerBuffer;
+	int sampleRate;
+};
+
+class OpenSLContext : public AudioContext {
+public:
+	OpenSLContext(AndroidAudioCallback cb, int framesPerBuffer, int sampleRate);
+
+	bool Init() override;
+	~OpenSLContext();
+
+private:
+	// engine interfaces
+	SLObjectItf engineObject = nullptr;
+	SLEngineItf engineEngine = nullptr;
+	SLObjectItf outputMixObject = nullptr;
+
+	// buffer queue player interfaces
+	SLObjectItf bqPlayerObject = nullptr;
+	SLPlayItf bqPlayerPlay = nullptr;
+	SLAndroidSimpleBufferQueueItf bqPlayerBufferQueue = nullptr;
+	SLMuteSoloItf bqPlayerMuteSolo = nullptr;
+	SLVolumeItf bqPlayerVolume = nullptr;
+
+	// Double buffering.
+	short *buffer[2]{};
+	int curBuffer = 0;
+
+	static void bqPlayerCallbackWrap(SLAndroidSimpleBufferQueueItf bq, void *context);
+	void BqPlayerCallback(SLAndroidSimpleBufferQueueItf bq);
+};

--- a/android/jni/native_audio.h
+++ b/android/jni/native_audio.h
@@ -3,6 +3,8 @@
 #include "native-audio-so.h"
 #include <string>
 
+struct AndroidAudioState;
+
 // This is the file you should include from your program. It dynamically loads
 // the native_audio.so shared object and sets up the function pointers.
 
@@ -10,7 +12,7 @@
 // 2.2, as it will fail miserably.
 
 // It's okay for optimalFramesPerBuffer and optimalSampleRate to be 0. Defaults will be used.
-bool AndroidAudio_Init(AndroidAudioCallback cb, std::string libraryDir, int optimalFramesPerBuffer, int optimalSampleRate);
-bool AndroidAudio_Pause();
-bool AndroidAudio_Resume();
-void AndroidAudio_Shutdown();
+AndroidAudioState *AndroidAudio_Init(AndroidAudioCallback cb, std::string libraryDir, int optimalFramesPerBuffer, int optimalSampleRate);
+bool AndroidAudio_Pause(AndroidAudioState *state);
+bool AndroidAudio_Resume(AndroidAudioState *state);
+bool AndroidAudio_Shutdown(AndroidAudioState *state);


### PR DESCRIPTION
Prepare for the future addition of AAudio support. In addition, this makes sure we no longer accidentally rely on auto-initialization of globals in any way. Might help #9771.