### PR TITLE
Android scaling fixes

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -132,8 +132,8 @@ bool Core_GetPowerSaving() {
 
 static bool IsWindowSmall(int pixelWidth, int pixelHeight) {
 	// Can't take this from config as it will not be set if windows is maximized.
-	int w = (int)(pixelWidth * g_dpi_scale);
-	int h = (int)(pixelHeight * g_dpi_scale);
+	int w = (int)(pixelWidth * g_dpi_scale_x);
+	int h = (int)(pixelHeight * g_dpi_scale_y);
 	return g_Config.IsPortrait() ? (h < 480 + 80) : (w < 480 + 80);
 }
 
@@ -142,22 +142,27 @@ bool UpdateScreenScale(int width, int height) {
 	bool smallWindow;
 #ifdef _WIN32
 	g_dpi = (float)System_GetPropertyInt(SYSPROP_DISPLAY_DPI);
-	g_dpi_scale = 96.0f / g_dpi;
+	g_dpi_scale_x = 96.0f / g_dpi;
+	g_dpi_scale_y = 96.0f / g_dpi;
 #else
 	g_dpi = 96.0f;
-	g_dpi_scale = 1.0f;
+	g_dpi_scale_x = 1.0f;
+	g_dpi_scale_y = 1.0f;
 #endif
-	g_dpi_scale_real = g_dpi_scale;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
 
 	smallWindow = IsWindowSmall(width, height);
 	if (smallWindow) {
 		g_dpi /= 2.0f;
-		g_dpi_scale *= 2.0f;
+		g_dpi_scale_x *= 2.0f;
+		g_dpi_scale_y *= 2.0f;
 	}
-	pixel_in_dps = 1.0f / g_dpi_scale;
+	pixel_in_dps_x = 1.0f / g_dpi_scale_x;
+	pixel_in_dps_y = 1.0f / g_dpi_scale_y;
 
-	int new_dp_xres = width * g_dpi_scale;
-	int new_dp_yres = height * g_dpi_scale;
+	int new_dp_xres = width * g_dpi_scale_x;
+	int new_dp_yres = height * g_dpi_scale_y;
 
 	bool dp_changed = new_dp_xres != dp_xres || new_dp_yres != dp_yres;
 	bool px_changed = pixel_xres != width || pixel_yres != height;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -141,10 +141,10 @@ static bool IsWindowSmall(int pixelWidth, int pixelHeight) {
 bool UpdateScreenScale(int width, int height) {
 	bool smallWindow;
 #ifdef _WIN32
-	g_dpi = System_GetPropertyInt(SYSPROP_DISPLAY_DPI);
+	g_dpi = (float)System_GetPropertyInt(SYSPROP_DISPLAY_DPI);
 	g_dpi_scale = 96.0f / g_dpi;
 #else
-	g_dpi = 96;
+	g_dpi = 96.0f;
 	g_dpi_scale = 1.0f;
 #endif
 	g_dpi_scale_real = g_dpi_scale;

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -248,7 +248,7 @@ void ReportScreen::CreateViews() {
 	screenshotFilename_ = path + ".reporting.jpg";
 	int shotWidth = 0, shotHeight = 0;
 	if (TakeGameScreenshot(screenshotFilename_.c_str(), SCREENSHOT_JPG, SCREENSHOT_DISPLAY, &shotWidth, &shotHeight, 4)) {
-		float scale = 340.0f * (1.0f / g_dpi_scale) * (1.0f / shotHeight);
+		float scale = 340.0f * (1.0f / g_dpi_scale_y) * (1.0f / shotHeight);
 		leftColumnItems->Add(new CheckBox(&includeScreenshot_, rp->T("FeedbackIncludeScreen", "Include a screenshot")))->SetEnabledPtr(&enableReporting_);
 		screenshot_ = leftColumnItems->Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, nullptr, new LinearLayoutParams(shotWidth * scale, shotHeight * scale, Margins(12, 0))));
 	} else {

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -203,12 +203,14 @@ bool PPSSPP_UWPMain::Render() {
 		// Boost DPI a bit to look better.
 		g_dpi *= 96.0f / 136.0f;
 	}
-	g_dpi_scale = 96.0f / g_dpi;
+	g_dpi_scale_x = 96.0f / g_dpi;
+	g_dpi_scale_y = 96.0f / g_dpi;
 
-	pixel_in_dps = 1.0f / g_dpi_scale;
+	pixel_in_dps_x = 1.0f / g_dpi_scale_x;
+	pixel_in_dps_y = 1.0f / g_dpi_scale_y;
 
-	dp_xres = pixel_xres * g_dpi_scale;
-	dp_yres = pixel_yres * g_dpi_scale;
+	dp_xres = pixel_xres * g_dpi_scale_x;
+	dp_yres = pixel_yres * g_dpi_scale_y;
 
 	context->RSSetViewports(1, &viewport);
 
@@ -281,13 +283,15 @@ bool PPSSPP_UWPMain::OnHardwareButton(HardwareButton button) {
 void PPSSPP_UWPMain::OnTouchEvent(int touchEvent, int touchId, float x, float y, double timestamp) {
 	// We get the coordinate in Windows' device independent pixels already. So let's undo that,
 	// and then apply our own "dpi".
-	float dpiFactor = m_deviceResources->GetActualDpi() / 96.0f;
-	dpiFactor /= pixel_in_dps;
+	float dpiFactor_x = m_deviceResources->GetActualDpi() / 96.0f;
+  float dpiFactor_y = dpiFactor_x;
+	dpiFactor_x /= pixel_in_dps_x;
+	dpiFactor_y /= pixel_in_dps_y;
 
 	TouchInput input{};
 	input.id = touchId;
-	input.x = x * dpiFactor;
-	input.y = y * dpiFactor;
+	input.x = x * dpiFactor_x;
+	input.y = y * dpiFactor_y;
 	input.flags = touchEvent;
 	input.timestamp = timestamp;
 	NativeTouch(input);

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -284,7 +284,7 @@ void PPSSPP_UWPMain::OnTouchEvent(int touchEvent, int touchId, float x, float y,
 	// We get the coordinate in Windows' device independent pixels already. So let's undo that,
 	// and then apply our own "dpi".
 	float dpiFactor_x = m_deviceResources->GetActualDpi() / 96.0f;
-  float dpiFactor_y = dpiFactor_x;
+	float dpiFactor_y = dpiFactor_x;
 	dpiFactor_x /= pixel_in_dps_x;
 	dpiFactor_y /= pixel_in_dps_y;
 

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -45,12 +45,12 @@ CtrlDisplayListView::CtrlDisplayListView(HWND _wnd)
 	
 	instructionSize = 4;
 
-	// In small window mode, g_dpi_scal may have been adjusted.
+	// In small window mode, g_dpi_scale may have been adjusted.
 	const float fontScale = 1.0f / g_dpi_scale_real_y;
 	int fontHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 
-	rowHeight = fontHeight +2;
+	rowHeight = fontHeight + 2;
 
 	font = CreateFont(fontHeight,charWidth,0,0,FW_DONTCARE,FALSE,FALSE,FALSE,DEFAULT_CHARSET,OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,DEFAULT_QUALITY,DEFAULT_PITCH,
 		L"Lucida Console");

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -46,7 +46,7 @@ CtrlDisplayListView::CtrlDisplayListView(HWND _wnd)
 	instructionSize = 4;
 
 	// In small window mode, g_dpi_scal may have been adjusted.
-	const float fontScale = 1.0f / g_dpi_scale_real;
+	const float fontScale = 1.0f / g_dpi_scale_real_y;
 	int fontHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -574,8 +574,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to show the cursor.
 				mouseButtonDown = true;
 
-				float x = GET_X_LPARAM(lParam) * g_dpi_scale;
-				float y = GET_Y_LPARAM(lParam) * g_dpi_scale;
+				float x = GET_X_LPARAM(lParam) * g_dpi_scale_x;
+				float y = GET_Y_LPARAM(lParam) * g_dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch;
@@ -615,8 +615,8 @@ namespace MainWindow
 				prevCursorX = cursorX;
 				prevCursorY = cursorY;
 
-				float x = GET_X_LPARAM(lParam) * g_dpi_scale;
-				float y = GET_Y_LPARAM(lParam) * g_dpi_scale;
+				float x = (float)cursorX * g_dpi_scale_x;
+				float y = (float)cursorY * g_dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				if (wParam & MK_LBUTTON) {
@@ -637,8 +637,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to hide the cursor.
 				mouseButtonDown = false;
 
-				float x = GET_X_LPARAM(lParam) * g_dpi_scale;
-				float y = GET_Y_LPARAM(lParam) * g_dpi_scale;
+				float x = (float)GET_X_LPARAM(lParam) * g_dpi_scale_x;
+				float y = (float)GET_Y_LPARAM(lParam) * g_dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch;

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -10,20 +10,13 @@
 #include "base/NativeApp.h"
 #include "Windows/MainWindow.h"
 
-TouchInputHandler::TouchInputHandler() : 
-		touchInfo(nullptr),
-		closeTouch(nullptr),
-		registerTouch(nullptr)
-{
-
+TouchInputHandler::TouchInputHandler() {
 	touchInfo = (getTouchInputProc) GetProcAddress(
 		GetModuleHandle(TEXT("User32.dll")),
 		"GetTouchInputInfo");
-
 	closeTouch = (closeTouchInputProc) GetProcAddress(
 		GetModuleHandle(TEXT("User32.dll")),
 		"CloseTouchInputHandle");
-
 	registerTouch = (registerTouchProc) GetProcAddress(
 		GetModuleHandle(TEXT("User32.dll")),
 		"RegisterTouchWindow");
@@ -65,8 +58,8 @@ bool TouchInputHandler::GetTouchPoint(HWND hWnd, const TOUCHINPUT &input, float 
 	point.x = (LONG)(TOUCH_COORD_TO_PIXEL(input.x));
 	point.y = (LONG)(TOUCH_COORD_TO_PIXEL(input.y));
 	if (ScreenToClient(hWnd, &point)) {
-		x = point.x * g_dpi_scale;
-		y = point.y * g_dpi_scale;
+		x = point.x * g_dpi_scale_x;
+		y = point.y * g_dpi_scale_y;
 		return true;
 	}
 

--- a/Windows/TouchInputHandler.h
+++ b/Windows/TouchInputHandler.h
@@ -34,7 +34,7 @@ private:
 	void touchDown(int id, float x, float y);
 	void touchMove(int id, float x, float y);
 
-	int touchIds[10];
+	int touchIds[10]{};
 	getTouchInputProc touchInfo;
 	closeTouchInputProc closeTouch;
 	registerTouchProc registerTouch;

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -211,10 +211,11 @@ void WindowsHost::PollControllers() {
 			doPad = false;
 	}
 
-	float scaleFactor = g_dpi_scale * 0.1 * g_Config.fMouseSensitivity;
+	float scaleFactor_x = g_dpi_scale_x * 0.1 * g_Config.fMouseSensitivity;
+	float scaleFactor_y = g_dpi_scale_y * 0.1 * g_Config.fMouseSensitivity;
 
-	float mx = std::max(-1.0f, std::min(1.0f, g_mouseDeltaX * scaleFactor));
-	float my = std::max(-1.0f, std::min(1.0f, g_mouseDeltaY * scaleFactor));
+	float mx = std::max(-1.0f, std::min(1.0f, g_mouseDeltaX * scaleFactor_x));
+	float my = std::max(-1.0f, std::min(1.0f, g_mouseDeltaY * scaleFactor_y));
 	AxisInput axisX, axisY;
 	axisX.axisId = JOYSTICK_AXIS_MOUSE_REL_X;
 	axisX.deviceId = DEVICE_ID_MOUSE;

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -38,10 +38,9 @@
         <meta-data android:name="android.max_aspect" android:value="2.1" />
         <activity
             android:name=".PpssppActivity"
-            android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation|fontScale|uiMode|navigation"
+            android:configChanges="locale|keyboard|keyboardHidden|navigation|uiMode"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-            android:resizeableActivity="false">
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 
             <!-- android:screenOrientation="landscape" -->
             <intent-filter>

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -698,33 +698,6 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 	NativeMessageReceived("recreateviews", "");
 }
 
-// JavaEGL
-extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jobject clazz, jint w, jint h, jint dpi, jfloat refreshRate) {
-	ILOG("NativeApp.displayResize(%i x %i, dpi=%i, refresh=%0.2f)", w, h, dpi, refreshRate);
-
-	pixel_xres = w;
-	pixel_yres = h;
-
-	g_dpi = display_dpi_x;
-	g_dpi_scale_x = 240.0f / g_dpi;
-	g_dpi_scale_y = 240.0f / g_dpi;
-	g_dpi_scale_real_x = g_dpi_scale_x;
-	g_dpi_scale_real_y = g_dpi_scale_y;
-
-	dp_xres = display_xres * g_dpi_scale_x;
-	dp_yres = display_yres * g_dpi_scale_y;
-
-	// Touch scaling is from display pixels to dp pixels.
-	dp_xscale = (float)dp_xres / (float)display_xres;
-	dp_yscale = (float)dp_yres / (float)display_yres;
-
-	pixel_in_dps_x = (float)pixel_xres / dp_xres;
-	pixel_in_dps_y = (float)pixel_yres / dp_yres;
-
-	NativeResized();
-}
-
-
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv *, jclass, jint bufw, jint bufh, jint format) {
 	ILOG("NativeApp.backbufferResize(%d x %d)", bufw, bufh);
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -701,26 +701,11 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jobject clazz, jint w, jint h, jint dpi, jfloat refreshRate) {
 	ILOG("NativeApp.displayResize(%i x %i, dpi=%i, refresh=%0.2f)", w, h, dpi, refreshRate);
 
-	/*
-	g_dpi = dpi;
-	g_dpi_scale = 240.0f / (float)g_dpi;
-	g_dpi_scale_real = g_dpi_scale;
-
 	pixel_xres = w;
 	pixel_yres = h;
-	dp_xres = pixel_xres * g_dpi_scale;
-	dp_yres = pixel_yres * g_dpi_scale;
-	dp_xscale = (float)dp_xres / pixel_xres;
-	dp_yscale = (float)dp_yres / pixel_yres;
-	*/
-	// display_hz = refreshRate;
 
-	pixel_xres = w;
-	pixel_yres = h;
-	// backbuffer_format = format;
-
-	g_dpi = (int)display_dpi;
-	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi = display_dpi;
+	g_dpi_scale = 240.0f / g_dpi;
 	g_dpi_scale_real = g_dpi_scale;
 
 	dp_xres = display_xres * g_dpi_scale;
@@ -988,8 +973,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	pixel_yres = bufh;
 	backbuffer_format = format;
 
-	g_dpi = (int)display_dpi;
-	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi = (float)display_dpi;
+	g_dpi_scale = 240.0f / g_dpi;
 	g_dpi_scale_real = g_dpi_scale;
 
 	dp_xres = display_xres * g_dpi_scale;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -705,20 +705,57 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jo
 	pixel_yres = h;
 
 	g_dpi = display_dpi;
-	g_dpi_scale = 240.0f / g_dpi;
-	g_dpi_scale_real = g_dpi_scale;
+	g_dpi_scale_x = 240.0f / g_dpi;
+	g_dpi_scale_y = 240.0f / g_dpi;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
 
-	dp_xres = display_xres * g_dpi_scale;
-	dp_yres = display_yres * g_dpi_scale;
+	dp_xres = display_xres * g_dpi_scale_x;
+	dp_yres = display_yres * g_dpi_scale_y;
 
 	// Touch scaling is from display pixels to dp pixels.
 	dp_xscale = (float)dp_xres / (float)display_xres;
 	dp_yscale = (float)dp_yres / (float)display_yres;
 
-	pixel_in_dps = (float)pixel_xres / dp_xres;
+	pixel_in_dps_x = (float)pixel_xres / dp_xres;
+	pixel_in_dps_y = (float)pixel_yres / dp_yres;
 
 	NativeResized();
 }
+
+
+extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv *, jclass, jint bufw, jint bufh, jint format) {
+	ILOG("NativeApp.backbufferResize(%d x %d)", bufw, bufh);
+
+	// pixel_*res is the backbuffer resolution.
+	pixel_xres = bufw;
+	pixel_yres = bufh;
+	backbuffer_format = format;
+
+	g_dpi = display_dpi;
+	g_dpi_scale_x = 240.0f / g_dpi;
+	g_dpi_scale_y = 240.0f / g_dpi;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
+
+	dp_xres = display_xres * g_dpi_scale_x;
+	dp_yres = display_yres * g_dpi_scale_y;
+
+	// Touch scaling is from display pixels to dp pixels.
+	dp_xscale = (float)dp_xres / (float)display_xres;
+	dp_yscale = (float)dp_yres / (float)display_yres;
+
+	pixel_in_dps_x = (float)pixel_xres / dp_xres;
+	pixel_in_dps_y = (float)pixel_yres / dp_yres;
+
+	ILOG("dp_xscale=%f dp_yscale=%f", dp_xscale, dp_yscale);
+	ILOG("dp_xres=%d dp_yres=%d", dp_xres, dp_yres);
+	ILOG("pixel_xres=%d pixel_yres=%d", pixel_xres, pixel_yres);
+	ILOG("g_dpi=%d g_dpi_scale_x=%f g_dpi_scale_y", g_dpi, g_dpi_scale_x, g_dpi_scale_y);
+
+	NativeResized();
+}
+
 
 // JavaEGL
 extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env, jobject obj) {
@@ -963,35 +1000,6 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_setDisplayParameters(JN
 	display_yres = yres;
 	display_dpi = dpi;
 	display_hz = refreshRate;
-}
-
-extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv *, jclass, jint bufw, jint bufh, jint format) {
-	ILOG("NativeApp.backbufferResize(%d x %d)", bufw, bufh);
-
-	// pixel_*res is the backbuffer resolution.
-	pixel_xres = bufw;
-	pixel_yres = bufh;
-	backbuffer_format = format;
-
-	g_dpi = (float)display_dpi;
-	g_dpi_scale = 240.0f / g_dpi;
-	g_dpi_scale_real = g_dpi_scale;
-
-	dp_xres = display_xres * g_dpi_scale;
-	dp_yres = display_yres * g_dpi_scale;
-
-	// Touch scaling is from display pixels to dp pixels.
-	dp_xscale = (float)dp_xres / (float)display_xres;
-	dp_yscale = (float)dp_yres / (float)display_yres;
-
-	pixel_in_dps = (float)pixel_xres / dp_xres;
-
-	ILOG("dp_xscale=%f dp_yscale=%f", dp_xscale, dp_yscale);
-	ILOG("dp_xres=%d dp_yres=%d", dp_xres, dp_yres);
-	ILOG("pixel_xres=%d pixel_yres=%d", pixel_xres, pixel_yres);
-	ILOG("g_dpi=%d g_dpi_scale=%f", g_dpi, g_dpi_scale);
-
-	NativeResized();
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_computeDesiredBackbufferDimensions() {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -362,7 +362,8 @@ static int deviceType;
 
 // Should only be used for display detection during startup (for config defaults etc)
 // This is the ACTUAL display size, not the hardware scaled display size.
-static int display_dpi;
+static int display_dpi_x;
+static int display_dpi_y;
 static int display_xres;
 static int display_yres;
 static int backbuffer_format;	// Android PixelFormat enum
@@ -704,7 +705,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayResize(JNIEnv *, jo
 	pixel_xres = w;
 	pixel_yres = h;
 
-	g_dpi = display_dpi;
+	g_dpi = display_dpi_x;
 	g_dpi_scale_x = 240.0f / g_dpi;
 	g_dpi_scale_y = 240.0f / g_dpi;
 	g_dpi_scale_real_x = g_dpi_scale_x;
@@ -732,7 +733,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	pixel_yres = bufh;
 	backbuffer_format = format;
 
-	g_dpi = display_dpi;
+	g_dpi = display_dpi_x;
 	g_dpi_scale_x = 240.0f / g_dpi;
 	g_dpi_scale_y = 240.0f / g_dpi;
 	g_dpi_scale_real_x = g_dpi_scale_x;
@@ -998,7 +999,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_setDisplayParameters(JN
 	ILOG("NativeApp.setDisplayParameters(%d x %d, dpi=%d, refresh=%0.2f)", xres, yres, dpi, refreshRate);
 	display_xres = xres;
 	display_yres = yres;
-	display_dpi = dpi;
+	display_dpi_x = dpi;
+	display_dpi_y = dpi;
 	display_hz = refreshRate;
 }
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -681,7 +681,7 @@ public class NativeActivity extends Activity implements SurfaceHolder.Callback {
 			Point sz = new Point();
 			getDesiredBackbufferSize(sz);
 			if (sz.x > 0) {
-				mGLSurfaceView.getHolder().setFixedSize(sz.x/2, sz.y/2);
+				mGLSurfaceView.getHolder().setFixedSize(sz.x, sz.y);
 			}
         }
     }

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -44,9 +44,6 @@ public class NativeApp {
 
 	public static native boolean mouseWheelEvent(float x, float y);
 
-	// will only be called between init() and shutdown()
-	public static native int audioRender(short[] buffer);
-
 	// Sensor/input data. These are asynchronous, beware!
 	public static native boolean touch(float x, float y, int data, int pointerId);
 

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -18,6 +18,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 import android.view.MotionEvent;
+import android.view.View;
+
 import com.bda.controller.*;
 
 public class NativeGLView extends GLSurfaceView implements SensorEventListener, ControllerListener {

--- a/android/src/org/ppsspp/ppsspp/NativeRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/NativeRenderer.java
@@ -13,77 +13,27 @@ import android.view.Display;
 public class NativeRenderer implements GLSurfaceView.Renderer {
 	private static String TAG = "NativeRenderer";
 	private NativeActivity mActivity;
-	private boolean isDark = false;
-	private int dpi;
-	private float refreshRate;
-
-	private double dpi_scale_x;
-	private double dpi_scale_y;
-
-	int last_width, last_height;
 
 	NativeRenderer(NativeActivity act) {
 		mActivity = act;
-		DisplayMetrics metrics = new DisplayMetrics();
-		Display display = act.getWindowManager().getDefaultDisplay();
-		display.getMetrics(metrics);
-		dpi = metrics.densityDpi;
-
-		refreshRate = display.getRefreshRate();
-	}
-
-	double getDpiScaleX() {
-		return dpi_scale_x;
-	}
-	double getDpiScaleY() {
-		return dpi_scale_y;
-	}
-
-	public void setDark(boolean d) {
-		isDark = d;
-	}
-	
-	public void setFixedSize(int xres, int yres, GLSurfaceView surfaceView) {
-		Log.i(TAG, "Setting surface to fixed size " + xres + "x" + yres);
-		surfaceView.getHolder().setFixedSize(xres, yres);
 	}
 
 	public void onDrawFrame(GL10 unused /*use GLES20*/) {
-		if (isDark) {
-			GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-			GLES20.glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-			GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT | GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_STENCIL_BUFFER_BIT);
-		} else {
-			displayRender();
-		}
+		displayRender();
 	}
 
 	public void onSurfaceCreated(GL10 unused, EGLConfig config) {
-		Log.i(TAG, "onSurfaceCreated");
+		Log.i(TAG, "NativeRenderer: onSurfaceCreated");
 		// Log.i(TAG, "onSurfaceCreated - EGL context is new or was lost");
 		// Actually, it seems that it is here we should recreate lost GL objects.
 		displayInit();
 	}
  
 	public void onSurfaceChanged(GL10 unused, int width, int height) {
-		Point sz = new Point();
-		mActivity.GetScreenSize(sz);
-		double actualW = sz.x;
-		double actualH = sz.y;
-		dpi_scale_x = ((double)width / (double)actualW);
-		dpi_scale_y = ((double)height / (double)actualH);
-		Log.i(TAG, "onSurfaceChanged: Scale: " + dpi_scale_x + "x" + dpi_scale_y + " (width=" + width + ", actualW=" + actualW);
-		int scaled_dpi = (int)((double)dpi * dpi_scale_x);
-		displayResize(width, height, scaled_dpi, refreshRate);
-		last_width = width;
-		last_height = height;
 	}
-
-	// NATIVE METHODS
 
 	// Note: This also means "device lost" and you should reload
 	// all buffered objects. 
 	public native void displayInit(); 
-	public native void displayResize(int w, int h, int dpi, float refreshRate);
 	public native void displayRender();
 }

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -30,7 +30,7 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 	private Controller mController = null;
 	private boolean isMogaPro = false;
 
-	public NativeSurfaceView(NativeActivity activity, int fixedW, int fixedH) {
+	public NativeSurfaceView(NativeActivity activity) {
 		super(activity);
 
 		Log.i(TAG, "NativeSurfaceView");
@@ -39,14 +39,6 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 
 		mController = Controller.getInstance(activity);
-
-		// Maybe we need to use this?
-		if (fixedW != 0 && fixedH != 0) {
-			Log.i(TAG, "Setting surface holder to use a fixed size of " + fixedW + "x" + fixedH + " pixels");
-			this.getHolder().setFixedSize(fixedW, fixedH);
-		} else {
-			Log.i(TAG, "Using default backbuffer size.");
-		}
 
 		// this.getHolder().setFormat(PixelFormat.RGBA_8888);
 

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -631,9 +631,12 @@ int main(int argc, char *argv[]) {
 	NativeInit(remain_argc, (const char **)remain_argv, path, "/tmp", nullptr);
 #endif
 
-	pixel_in_dps = (float)pixel_xres / dp_xres;
-	g_dpi_scale = dp_xres / (float)pixel_xres;
-	g_dpi_scale_real = g_dpi_scale;
+	pixel_in_dps_x = (float)pixel_xres / dp_xres;
+	pixel_in_dps_y = (float)pixel_yres / dp_yres;
+	g_dpi_scale_x = dp_xres / (float)pixel_xres;
+	g_dpi_scale_y = dp_yres / (float)pixel_yres;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
 
 	printf("Pixels: %i x %i\n", pixel_xres, pixel_yres);
 	printf("Virtual pixels: %i x %i\n", dp_xres, dp_yres);

--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -689,8 +689,8 @@ int main(int argc, char *argv[]) {
 	while (true) {
 		SDL_Event event;
 		while (SDL_PollEvent(&event)) {
-			float mx = event.motion.x * g_dpi_scale;
-			float my = event.motion.y * g_dpi_scale;
+			float mx = event.motion.x * g_dpi_scale_x;
+			float my = event.motion.y * g_dpi_scale_y;
 
 			switch (event.type) {
 			case SDL_QUIT:

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -263,15 +263,15 @@ bool MainUI::event(QEvent *e)
                 break;
             case Qt::TouchPointPressed:
             case Qt::TouchPointReleased:
-                input.x = touchPoint.pos().x() * g_dpi_scale * xscale;
-                input.y = touchPoint.pos().y() * g_dpi_scale * yscale;
+                input.x = touchPoint.pos().x() * g_dpi_scale_x * xscale;
+                input.y = touchPoint.pos().y() * g_dpi_scale_y * yscale;
                 input.flags = (touchPoint.state() == Qt::TouchPointPressed) ? TOUCH_DOWN : TOUCH_UP;
                 input.id = touchPoint.id();
                 NativeTouch(input);
                 break;
             case Qt::TouchPointMoved:
-                input.x = touchPoint.pos().x() * g_dpi_scale * xscale;
-                input.y = touchPoint.pos().y() * g_dpi_scale * yscale;
+                input.x = touchPoint.pos().x() * g_dpi_scale_x * xscale;
+                input.y = touchPoint.pos().y() * g_dpi_scale_y * yscale;
                 input.flags = TOUCH_MOVE;
                 input.id = touchPoint.id();
                 NativeTouch(input);
@@ -287,15 +287,15 @@ bool MainUI::event(QEvent *e)
         break;
     case QEvent::MouseButtonPress:
     case QEvent::MouseButtonRelease:
-        input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
-        input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
+        input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale_x * xscale;
+        input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale_y * yscale;
         input.flags = (e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP;
         input.id = 0;
         NativeTouch(input);
         break;
     case QEvent::MouseMove:
-        input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale * xscale;
-        input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale * yscale;
+        input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale_x * xscale;
+        input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale_y * yscale;
         input.flags = TOUCH_MOVE;
         input.id = 0;
         NativeTouch(input);
@@ -437,8 +437,10 @@ int main(int argc, char *argv[])
 		res.transpose();
 	pixel_xres = res.width();
 	pixel_yres = res.height();
-	g_dpi_scale = CalculateDPIScale();
-	g_dpi_scale_real = g_dpi_scale;
+	g_dpi_scale_x = CalculateDPIScale();
+	g_dpi_scale_y = CalculateDPIScale();
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
 	dp_xres = (int)(pixel_xres * g_dpi_scale); dp_yres = (int)(pixel_yres * g_dpi_scale);
 	std::string savegame_dir = ".";
 	std::string external_dir = ".";

--- a/ext/native/base/QtMain.cpp
+++ b/ext/native/base/QtMain.cpp
@@ -441,7 +441,8 @@ int main(int argc, char *argv[])
 	g_dpi_scale_y = CalculateDPIScale();
 	g_dpi_scale_real_x = g_dpi_scale_x;
 	g_dpi_scale_real_y = g_dpi_scale_y;
-	dp_xres = (int)(pixel_xres * g_dpi_scale); dp_yres = (int)(pixel_yres * g_dpi_scale);
+	dp_xres = (int)(pixel_xres * g_dpi_scale_x);
+	dp_yres = (int)(pixel_yres * g_dpi_scale_y);
 	std::string savegame_dir = ".";
 	std::string external_dir = ".";
 #if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)

--- a/ext/native/base/display.cpp
+++ b/ext/native/base/display.cpp
@@ -6,7 +6,7 @@ int dp_yres;
 int pixel_xres;
 int pixel_yres;
 
-int g_dpi = 1;  // will be overwritten
+float g_dpi = 1.0f;  // will be overwritten with a value that makes sense.
 float g_dpi_scale = 1.0f;
 float g_dpi_scale_real = 1.0f;
 float pixel_in_dps = 1.0f;

--- a/ext/native/base/display.cpp
+++ b/ext/native/base/display.cpp
@@ -7,9 +7,12 @@ int pixel_xres;
 int pixel_yres;
 
 float g_dpi = 1.0f;  // will be overwritten with a value that makes sense.
-float g_dpi_scale = 1.0f;
-float g_dpi_scale_real = 1.0f;
-float pixel_in_dps = 1.0f;
+float g_dpi_scale_x = 1.0f;
+float g_dpi_scale_y = 1.0f;
+float g_dpi_scale_real_x = 1.0f;
+float g_dpi_scale_real_y = 1.0f;
+float pixel_in_dps_x = 1.0f;
+float pixel_in_dps_y = 1.0f;
 float display_hz = 60.0f;
 
 DisplayRotation g_display_rotation;

--- a/ext/native/base/display.h
+++ b/ext/native/base/display.h
@@ -11,9 +11,12 @@ extern int pixel_xres;
 extern int pixel_yres;
 
 extern float g_dpi;
-extern float g_dpi_scale;
-extern float g_dpi_scale_real;
-extern float pixel_in_dps;
+extern float g_dpi_scale_x;
+extern float g_dpi_scale_y;
+extern float g_dpi_scale_real_x;
+extern float g_dpi_scale_real_y;
+extern float pixel_in_dps_x;
+extern float pixel_in_dps_y;
 extern float display_hz;
 
 // On some platforms (currently only Windows UWP) we need to manually rotate

--- a/ext/native/base/display.h
+++ b/ext/native/base/display.h
@@ -10,7 +10,7 @@ extern int dp_yres;
 extern int pixel_xres;
 extern int pixel_yres;
 
-extern int g_dpi;
+extern float g_dpi;
 extern float g_dpi_scale;
 extern float g_dpi_scale_real;
 extern float pixel_in_dps;

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -86,14 +86,13 @@ void DrawBuffer::End() {
 
 void DrawBuffer::Flush(bool set_blend_state) {
 	using namespace Draw;
-	if (!pipeline_) {
-		ELOG("No program set!");
-		return;
-	}
-
 	if (count_ == 0)
 		return;
-
+	if (!pipeline_) {
+		ELOG("DrawBuffer: No program set, skipping flush!");
+		count_ = 0;
+		return;
+	}
 	draw_->BindPipeline(pipeline_);
 
 	VsTexColUB ub{};

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -131,15 +131,15 @@ void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int al
 }
 
 void DrawBuffer::hLine(float x1, float y, float x2, uint32_t color) {
-	Rect(x1, y, x2 - x1, pixel_in_dps, color);
+	Rect(x1, y, x2 - x1, pixel_in_dps_y, color);
 }
 
 void DrawBuffer::vLine(float x, float y1, float y2, uint32_t color) {
-	Rect(x, y1, pixel_in_dps, y2 - y1, color);
+	Rect(x, y1, pixel_in_dps_x, y2 - y1, color);
 }
 
 void DrawBuffer::vLineAlpha50(float x, float y1, float y2, uint32_t color) {
-	Rect(x, y1, pixel_in_dps, y2 - y1, (color | 0xFF000000) & 0x7F000000);
+	Rect(x, y1, pixel_in_dps_x, y2 - y1, (color | 0xFF000000) & 0x7F000000);
 }
 
 void DrawBuffer::RectVGradient(float x, float y, float w, float h, uint32_t colorTop, uint32_t colorBottom) {
@@ -152,11 +152,11 @@ void DrawBuffer::RectVGradient(float x, float y, float w, float h, uint32_t colo
 }
 
 void DrawBuffer::RectOutline(float x, float y, float w, float h, uint32_t color, int align) {
-	hLine(x, y, x + w + pixel_in_dps, color);
-	hLine(x, y + h, x + w + pixel_in_dps, color);
+	hLine(x, y, x + w + pixel_in_dps_x, color);
+	hLine(x, y + h, x + w + pixel_in_dps_x, color);
 
-	vLine(x, y, y + h + pixel_in_dps, color);
-	vLine(x + w, y, y + h + pixel_in_dps, color);
+	vLine(x, y, y + h + pixel_in_dps_y, color);
+	vLine(x + w, y, y + h + pixel_in_dps_y, color);
 }
 
 void DrawBuffer::MultiVGradient(float x, float y, float w, float h, GradientStop *stops, int numStops) {

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -34,7 +34,7 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 }
 
 float TextDrawer::CalculateDPIScale() {
-	float scale = g_dpi_scale_x;
+	float scale = g_dpi_scale_y;
 	if (scale >= 1.0f) {
 		scale = 1.0f;
 	}

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -34,7 +34,7 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 }
 
 float TextDrawer::CalculateDPIScale() {
-	float scale = g_dpi_scale;
+	float scale = g_dpi_scale_x;
 	if (scale >= 1.0f) {
 		scale = 1.0f;
 	}

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -273,12 +273,13 @@ GLuint ShaderStageToOpenGL(ShaderStage stage) {
 class OpenGLShaderModule : public ShaderModule, public GfxResourceHolder {
 public:
 	OpenGLShaderModule(ShaderStage stage) : stage_(stage) {
+		ILOG("Shader module created (%p)", this);
 		register_gl_resource_holder(this, "drawcontext_shader_module", 0);
 		glstage_ = ShaderStageToOpenGL(stage);
 	}
 
 	~OpenGLShaderModule() {
-		ILOG("Shader module destroyed");
+		ILOG("Shader module destroyed (%p)", this);
 		if (shader_)
 			glDeleteShader(shader_);
 		unregister_gl_resource_holder(this);

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -90,12 +90,13 @@ Bounds UIContext::GetScissorBounds() {
 void UIContext::ActivateTopScissor() {
 	Bounds bounds;
 	if (scissorStack_.size()) {
-		float scale = pixel_in_dps;
+		float scale_x = pixel_in_dps_x;
+		float scale_y = pixel_in_dps_y;
 		bounds = scissorStack_.back();
-		int x = floorf(scale * bounds.x);
-		int y = floorf(scale * bounds.y);
-		int w = ceilf(scale * bounds.w);
-		int h = ceilf(scale * bounds.h);
+		int x = floorf(scale_x * bounds.x);
+		int y = floorf(scale_y * bounds.y);
+		int w = ceilf(scale_x * bounds.w);
+		int h = ceilf(scale_y * bounds.h);
 		draw_->SetScissorRect(x, y, w, h);
 	} else {
 		// Avoid rounding errors

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -174,8 +174,8 @@ static GraphicsContext *graphicsContext;
 		size.width = h;
 	}
 
-	g_dpi = (IS_IPAD() ? 200 : 150) * scale;
-	g_dpi_scale = 240.0f / (float)g_dpi;
+	g_dpi = (IS_IPAD() ? 200.0f : 150.0f) * scale;
+	g_dpi_scale = 240.0f / g_dpi;
 	g_dpi_scale_real = g_dpi_scale;
 	pixel_xres = size.width * scale;
 	pixel_yres = size.height * scale;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -175,15 +175,18 @@ static GraphicsContext *graphicsContext;
 	}
 
 	g_dpi = (IS_IPAD() ? 200.0f : 150.0f) * scale;
-	g_dpi_scale = 240.0f / g_dpi;
-	g_dpi_scale_real = g_dpi_scale;
+	g_dpi_scale_x = 240.0f / g_dpi;
+	g_dpi_scale_y = 240.0f / g_dpi;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
 	pixel_xres = size.width * scale;
 	pixel_yres = size.height * scale;
 
-	dp_xres = pixel_xres * g_dpi_scale;
-	dp_yres = pixel_yres * g_dpi_scale;
+	dp_xres = pixel_xres * g_dpi_scale_x;
+	dp_yres = pixel_yres * g_dpi_scale_y;
 
-	pixel_in_dps = (float)pixel_xres / (float)dp_xres;
+	pixel_in_dps_x = (float)pixel_xres / (float)dp_xres;
+	pixel_in_dps_y = (float)pixel_yres / (float)dp_yres;
 
 	graphicsContext = new IOSDummyGraphicsContext();
 


### PR DESCRIPTION
This now uses surfaceHolder callbacks to get the pixel width/height for screen sizing, which is more accurate than the old hacky method. This means that we now share the DPI calculations between GL and Vulkan backends (and the EGL setup which is not used) which is good.

This fixes #9866 properly.

Additionally, this splits up dpi scaling in to X and Y components but not really doing anything with that yet. This could be used to support weird pixel ratios but those are not very common these days. Android devices actually do have very slightly different X and Y DPI scaling sometimes but usually too little to really matter, would like to get this right at some point though.