### PR TITLE
Initial work on supporting sustained perf mode

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -516,12 +516,12 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("FullScreenMulti", &g_Config.bFullScreenMulti, false),
 #endif
 
-	// TODO: Replace these settings with a list of options
 	ConfigSetting("SmallDisplayZoomType", &g_Config.iSmallDisplayZoomType, &DefaultZoomType, true, true),
 	ConfigSetting("SmallDisplayOffsetX", &g_Config.fSmallDisplayOffsetX, 0.5f, true, true),
 	ConfigSetting("SmallDisplayOffsetY", &g_Config.fSmallDisplayOffsetY, 0.5f, true, true),
 	ConfigSetting("SmallDisplayZoomLevel", &g_Config.fSmallDisplayZoomLevel, 1.0f, true, true),
 	ConfigSetting("ImmersiveMode", &g_Config.bImmersiveMode, false, true, true),
+	ConfigSetting("SustainedPerformanceMode", &g_Config.bSustainedPerformanceMode, false, true, true),
 
 	ReportedConfigSetting("TrueColor", &g_Config.bTrueColor, true, true, true),
 	ReportedConfigSetting("ReplaceTextures", &g_Config.bReplaceTextures, true, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -169,6 +169,7 @@ public:
 	float fSmallDisplayOffsetY;
 	float fSmallDisplayZoomLevel; //This is used for zoom values, both in and out.
 	bool bImmersiveMode;  // Mode on Android Kitkat 4.4 that hides the back button etc.
+	bool bSustainedPerformanceMode;  // Android: Slows clocks down to avoid overheating/speed fluctuations.
 	bool bVSync;
 	int iFrameSkip;
 	bool bAutoFrameSkip;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -399,6 +399,7 @@ void SystemInfoScreen::CreateViews() {
 	deviceSpecs->Add(new ItemHeader("OS Information"));
 	deviceSpecs->Add(new InfoItem("Memory Page Size", StringFromFormat("%d bytes", GetMemoryProtectPageSize())));
 	deviceSpecs->Add(new InfoItem("RW/RX exclusive: ", PlatformIsWXExclusive() ? "Yes" : "No"));
+	deviceSpecs->Add(new InfoItem("Sustained perf mode: ", System_GetPropertyBool(SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE) ? "Yes" : "No"));
 
 	const char *build = "Release";
 #ifdef _DEBUG

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -686,6 +686,10 @@ void GameSettingsScreen::CreateViews() {
 		static const char *screenRotation[] = {"Auto", "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed"};
 		PopupMultiChoice *rot = systemSettings->Add(new PopupMultiChoice(&g_Config.iScreenRotation, co->T("Screen Rotation"), screenRotation, 0, ARRAY_SIZE(screenRotation), co->GetName(), screenManager()));
 		rot->OnChoice.Handle(this, &GameSettingsScreen::OnScreenRotation);
+
+		if (System_GetPropertyBool(SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE)) {
+			systemSettings->Add(new CheckBox(&g_Config.bSustainedPerformanceMode, sy->T("Sustained performance mode")))->OnClick.Handle(this, &GameSettingsScreen::OnSustainedPerformanceModeChange);
+		}
 	}
 #endif
 
@@ -845,11 +849,14 @@ UI::EventReturn GameSettingsScreen::OnAdhocGuides(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnImmersiveModeChange(UI::EventParams &e) {
 	System_SendMessage("immersive", "");
-	const int SYSTEM_JELLYBEAN = 16;
-	// recreate doesn't seem reliable on earlier versions.
 	if (g_Config.iAndroidHwScale != 0) {
 		RecreateActivity();
 	}
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnSustainedPerformanceModeChange(UI::EventParams &e) {
+	System_SendMessage("sustainedPerfMode", "");
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -99,6 +99,7 @@ private:
 
 	UI::EventReturn OnScreenRotation(UI::EventParams &e);
 	UI::EventReturn OnImmersiveModeChange(UI::EventParams &e);
+	UI::EventReturn OnSustainedPerformanceModeChange(UI::EventParams &e);
 
 	UI::EventReturn OnAdhocGuides(UI::EventParams &e);
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -238,6 +238,8 @@ std::string NativeQueryConfig(std::string query) {
 		}
 		// Otherwise, some devices prefer the Java init so play it safe.
 		return "true";
+	} else if (query == "sustainedPerformanceMode") {
+		return std::string(g_Config.bSustainedPerformanceMode ? "1" : "0");
 	} else {
 		return "";
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -381,6 +381,8 @@ static float dp_yscale = 1.0f;
 
 static bool renderer_inited = false;
 static bool renderer_ever_inited = false;
+static bool sustainedPerfSupported = false;
+
 // See NativeQueryConfig("androidJavaGL") to change this value.
 static bool javaGL = true;
 
@@ -471,6 +473,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_SUPPORTS_PERMISSIONS:
 		return androidVersion >= 23;	// 6.0 Marshmallow introduced run time permissions.
+	case SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE:
+		return sustainedPerfSupported;  // 7.0 introduced sustained performance mode as an optional feature.
 	case SYSPROP_HAS_BACK_BUTTON:
 		return true;
 	case SYSPROP_HAS_IMAGE_BROWSER:
@@ -908,6 +912,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 	} else if (msg == "permission_granted") {
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_GRANTED;
 		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
+	} else if (msg == "sustained_perf_supported") {
+		sustainedPerfSupported = true;
 	}
 
 	NativeMessageReceived(msg.c_str(), prm.c_str());

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -30,6 +30,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.PowerManager;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.text.InputType;
@@ -84,9 +85,12 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 	private int optimalFramesPerBuffer;
 	private int optimalSampleRate;
 
+	private boolean sustainedPerfSupported;
+
 	// audioFocusChangeListener to listen to changes in audio state
 	private AudioFocusChangeListener audioFocusChangeListener;
 	private AudioManager audioManager;
+	private PowerManager powerManager;
 
 	private Vibrator vibrator;
 
@@ -202,6 +206,13 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
         	// Get the optimal buffer sz
         	detectOptimalAudioSettings();
         }
+		powerManager = (PowerManager)getSystemService(Context.POWER_SERVICE);
+        if (Build.VERSION.SDK_INT >= 24) {
+			if (powerManager.isSustainedPerformanceModeSupported()) {
+				sustainedPerfSupported = true;
+				NativeApp.sendMessage("sustained_perf_supported","1");
+			}
+        }
 
         // isLandscape is used to trigger GetAppInfo currently, we
         boolean landscape = NativeApp.isLandscape();
@@ -277,6 +288,20 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
         if (Build.VERSION.SDK_INT >= 11) {
         	checkForVibrator();
         }
+	}
+
+	@TargetApi(24)
+	private void updateSustainedPerformanceMode() {
+		// Query the native application on the desired rotation.
+		int enable = 0;
+		String str = NativeApp.queryConfig("sustainedPerformanceMode");
+		try {
+			enable = Integer.parseInt(str);
+		} catch (NumberFormatException e) {
+			Log.e(TAG, "Invalid perf mode: " + str);
+			return;
+		}
+		getWindow().setSustainedPerformanceMode(enable != 0);
 	}
 
 	@TargetApi(9)
@@ -388,6 +413,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 
 		// OK, config should be initialized, we can query for screen rotation.
 		updateScreenRotation();
+		updateSustainedPerformanceMode();
 
 		// Keep the screen bright - very annoying if it goes dark when tilting away
 		Window window = this.getWindow();
@@ -1098,16 +1124,18 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			shuttingDown = true;
 			finish();
 		} else if (command.equals("rotate")) {
-	      if (javaGL) {
-	        updateScreenRotation();
-	        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-	          Log.i(TAG, "Must recreate activity on rotation");
-	        }
-	      } else {
-	        if (Build.VERSION.SDK_INT >= 9) {
-	          updateScreenRotation();
-	        }
-	      }
+			if (javaGL) {
+				updateScreenRotation();
+				if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+					Log.i(TAG, "Must recreate activity on rotation");
+				}
+			} else {
+				if (Build.VERSION.SDK_INT >= 9) {
+					updateScreenRotation();
+				}
+			}
+		} else if (command.equals("sustainedPerfMode")) {
+			updateSustainedPerformanceMode();
 		} else if (command.equals("immersive")) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 				updateSystemUiVisibility();

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -210,7 +210,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
         if (Build.VERSION.SDK_INT >= 24) {
 			if (powerManager.isSustainedPerformanceModeSupported()) {
 				sustainedPerfSupported = true;
-				NativeApp.sendMessage("sustained_perf_supported","1");
+				NativeApp.sendMessage("sustained_perf_supported", "1");
 			}
         }
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -184,6 +184,7 @@ enum SystemProperty {
 	SYSPROP_AUDIO_OPTIMAL_FRAMES_PER_BUFFER,
 
 	SYSPROP_SUPPORTS_PERMISSIONS,
+	SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE,
 };
 
 std::string System_GetProperty(SystemProperty prop);


### PR DESCRIPTION
Fixes #9738.

Sustained performance mode is intended for keeping clock frequency down to be able to run for a long time without overheating. Enabling this on a device makes it a good optimization target and will of course also last longer, but will also run slower.

Anyway, I'm surprised that my Nexus 5X with Android O Beta on it returns false when I ask  isSustainedPerformanceModeSupported() , so can't use it on that, strangely. You'd think that it would be supported on the very latest Android...