### PR TITLE
Replace the most critical unordered_maps and maps with faster maps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ add_library(Common STATIC
 	Common/KeyMap.cpp
 	Common/KeyMap.h
 	Common/LogManager.cpp
+	Common/Hashmaps.h
 	Common/LogManager.h
 	Common/MemArenaAndroid.cpp
 	Common/MemArenaDarwin.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -22,7 +22,8 @@
     <ProjectGuid>{3FCDBAE2-5103-4350-9A8E-848CE9C73195}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Common</RootNamespace>
-    <WindowsTargetPlatformVersion></WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>
+    </WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -226,6 +227,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="GraphicsContext.h" />
+    <ClInclude Include="Hashmaps.h" />
     <ClInclude Include="KeyMap.h" />
     <ClInclude Include="Log.h" />
     <ClInclude Include="LogManager.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -74,6 +74,7 @@
       <Filter>Vulkan</Filter>
     </ClInclude>
     <ClInclude Include="OSVersion.h" />
+    <ClInclude Include="Hashmaps.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp" />

--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -115,9 +115,8 @@ public:
 		return count_;
 	}
 
-	// TODO: Find a way to avoid std::function. I tried using a templated argument
-	// but couldn't get it to pass the compiler.
-	inline void Iterate(std::function<void(const typename Key &key, typename Value value)> func) {
+	template<class T>
+	inline void Iterate(T func) {
 		for (auto &iter : map) {
 			if (iter.state == BucketState::TAKEN) {
 				func(iter.key, iter.value);
@@ -253,9 +252,8 @@ public:
 		return count_;
 	}
 
-	// TODO: Find a way to avoid std::function. I tried using a templated argument
-	// but couldn't get it to pass the compiler.
-	void Iterate(std::function<void(uint32_t hash, typename Value value)> func) {
+	template<class T>
+	void Iterate(T func) {
 		for (auto &iter : map) {
 			if (iter.state == BucketState::TAKEN) {
 				func(iter.hash, iter.value);

--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -1,0 +1,271 @@
+#pragma once
+
+#include "ext/xxhash.h"
+#include <functional>
+
+// Whatever random value.
+const uint32_t hashmapSeed = 0x23B58532;
+
+// TODO: Try hardware CRC. Unfortunately not available on older Intels or ARM32.
+// Seems to be ubiquitous on ARM64 though.
+template<class K>
+inline uint32_t HashKey(const K &k) {
+	return XXH32(&k, sizeof(k), hashmapSeed);
+}
+template<class K>
+inline bool KeyEquals(const K &a, const K &b) {
+	return !memcmp(&a, &b, sizeof(K));
+}
+
+enum class BucketState {
+	FREE,
+	TAKEN,
+	REMOVED,  // for linear probing to work we need tombstones
+};
+
+
+// Uses linear probing for cache-friendliness. Not segregating values from keys because
+// we always use very small values, so it's probably better to have them in the same
+// cache-line as the corresponding key.
+// Enforces that value are pointers to make sure that combined storage makes sense.
+template <class Key, class Value>
+class DenseHashMap {
+public:
+	DenseHashMap(int initialCapacity) : capacity_(initialCapacity) {
+		map.resize(initialCapacity);
+	}
+
+	// Returns nullptr if no entry was found.
+	Value Get(const Key &key) {
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = HashKey(key) & mask;
+		// No? Let's go into search mode. Linear probing.
+		uint32_t p = pos;
+		while (true) {
+			if (map[p].state == BucketState::TAKEN && KeyEquals(key, map[p].key))
+				return map[p].value;
+			else if (map[p].state == BucketState::FREE)
+				return nullptr;
+			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
+			if (p == pos)
+				DebugBreak();
+		}
+		return nullptr;
+	}
+
+	// Returns false if we already had the key! Which is a bit different.
+	bool Insert(const Key &key, Value value) {
+		// Check load factor, resize if necessary. We never shrink.
+		if (count_ > capacity_ / 2) {
+			Grow();
+		}
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = HashKey(key) & mask;
+		uint32_t p = pos;
+		while (true) {
+			if (map[p].state == BucketState::TAKEN) {
+				if (KeyEquals(key, map[p].key)) {
+					DebugBreak();  // Bad! We already got this one. Let's avoid this case.
+					return false;
+				}
+				// continue looking....
+			} else {
+				// Got a place, either removed or FREE.
+				break;
+			}
+			p = (p + 1) & mask;
+			if (p == pos) {
+				// FULL! Error. Should not happen thanks to Grow().
+				DebugBreak();
+			}
+		}
+		map[p].state = BucketState::TAKEN;
+		map[p].key = key;
+		map[p].value = value;
+		count_++;
+		return true;
+	}
+
+	void Remove(const Key &key) {
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = HashKey(key) & mask;
+		uint32_t p = pos;
+		while (map[p].state != BucketState::FREE) {
+			if (map[p].state == BucketState::TAKEN && KeyEquals(key, map[p].key)) {
+				// Got it! Mark it as removed.
+				map[p].state = BucketState::REMOVED;
+				count_--;
+				return;
+			}
+			p = (p + 1) & mask;
+			if (p == pos) {
+				// FULL! Error. Should not happen.
+				DebugBreak();
+			}
+		}
+	}
+
+	size_t size() const {
+		return count_;
+	}
+
+	// TODO: Find a way to avoid std::function. I tried using a templated argument
+	// but couldn't get it to pass the compiler.
+	inline void Iterate(std::function<void(const typename Key &key, typename Value value)> func) {
+		for (auto &iter : map) {
+			if (iter.state == BucketState::TAKEN) {
+				func(iter.key, iter.value);
+			}
+		}
+	}
+
+	void Clear() {
+		// TODO: Speedup?
+		map.clear();
+		map.resize(capacity_);
+	}
+
+private:
+	void Grow() {
+		// We simply move out the existing data, then we re-insert the old.
+		// This is extremely non-atomic and will need synchronization.
+		std::vector<Pair> old = std::move(map);
+		capacity_ *= 2;
+		map.clear();
+		map.resize(capacity_);
+		count_ = 0;  // Insert will update it.
+		for (auto &iter : old) {
+			if (iter.state == BucketState::TAKEN) {
+				Insert(iter.key, iter.value);
+			}
+		}
+	}
+	struct Pair {
+		BucketState state;
+		Key key;
+		Value value;
+	};
+	std::vector<Pair> map;
+	int capacity_;
+	int count_ = 0;
+};
+
+// Like the above, uses linear probing for cache-friendliness.
+// Does not perform hashing at all so expects well-distributed keys.
+template <class Value>
+class PrehashMap {
+public:
+	PrehashMap(int initialCapacity) : capacity_(initialCapacity) {
+		map.resize(initialCapacity);
+	}
+
+	// Returns nullptr if no entry was found.
+	Value Get(uint32_t hash) {
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = hash & mask;
+		// No? Let's go into search mode. Linear probing.
+		uint32_t p = pos;
+		while (true) {
+			if (map[p].state == BucketState::TAKEN && hash == map[p].hash)
+				return map[p].value;
+			else if (map[p].state == BucketState::FREE)
+				return nullptr;
+			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
+			if (p == pos)
+				DebugBreak();
+		}
+		return nullptr;
+	}
+
+	// Returns false if we already had the key! Which is a bit different.
+	bool Insert(uint32_t hash, Value value) {
+		// Check load factor, resize if necessary. We never shrink.
+		if (count_ > capacity_ / 2) {
+			Grow();
+		}
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = hash & mask;
+		uint32_t p = pos;
+		while (map[p].state != BucketState::FREE) {
+			if (map[p].state == BucketState::TAKEN) {
+				if (hash == map[p].hash)
+					return false;  // Bad!
+			} else {
+				// Got a place, either removed or FREE.
+				break;
+			}
+			p = (p + 1) & mask;
+			if (p == pos) {
+				// FULL! Error. Should not happen thanks to Grow().
+				DebugBreak();
+			}
+		}
+		map[p].state = BucketState::TAKEN;
+		map[p].hash = hash;
+		map[p].value = value;
+		count_++;
+		return true;
+	}
+
+	void Remove(uint32_t hash) {
+		uint32_t mask = capacity_ - 1;
+		uint32_t pos = hash & mask;
+		uint32_t p = pos;
+		while (map[p].state != BucketState::FREE) {
+			if (map[p].state == BucketState::TAKEN && hash == map[p].hash) {
+				// Got it!
+				map[p].state = BucketState::REMOVED;
+				count_--;
+				return;
+			}
+			p = (p + 1) & mask;
+			if (p == pos) {
+				// FULL! Error. Should not happen.
+				DebugBreak();
+			}
+		}
+	}
+
+	size_t size() {
+		return count_;
+	}
+
+	// TODO: Find a way to avoid std::function. I tried using a templated argument
+	// but couldn't get it to pass the compiler.
+	void Iterate(std::function<void(uint32_t hash, typename Value value)> func) {
+		for (auto &iter : map) {
+			if (iter.state == BucketState::TAKEN) {
+				func(iter.hash, iter.value);
+			}
+		}
+	}
+
+	void Clear() {
+		// TODO: Speedup?
+		map.clear();
+		map.resize(capacity_);
+	}
+
+private:
+	void Grow() {
+		// We simply move out the existing data, then we re-insert the old.
+		// This is extremely non-atomic and will need synchronization.
+		std::vector<Pair> old = std::move(map);
+		capacity_ *= 2;
+		map.clear();
+		map.resize(capacity_);
+		for (auto &iter : old) {
+			if (iter.state == BucketState::TAKEN) {
+				Insert(iter.hash, iter.value);
+			}
+		}
+	}
+	struct Pair {
+		BucketState state;
+		uint32_t hash;
+		Value value;
+	};
+	std::vector<Pair> map;
+	int capacity_;
+	int count_ = 0;
+};

--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -29,7 +29,7 @@ enum class BucketState {
 // we always use very small values, so it's probably better to have them in the same
 // cache-line as the corresponding key.
 // Enforces that value are pointers to make sure that combined storage makes sense.
-template <class Key, class Value>
+template <class Key, class Value, Value NullValue>
 class DenseHashMap {
 public:
 	DenseHashMap(int initialCapacity) : capacity_(initialCapacity) {
@@ -46,12 +46,12 @@ public:
 			if (map[p].state == BucketState::TAKEN && KeyEquals(key, map[p].key))
 				return map[p].value;
 			else if (map[p].state == BucketState::FREE)
-				return nullptr;
+				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
 			if (p == pos)
 				Crash();
 		}
-		return nullptr;
+		return NullValue;
 	}
 
 	// Returns false if we already had the key! Which is a bit different.
@@ -170,7 +170,7 @@ private:
 
 // Like the above, uses linear probing for cache-friendliness.
 // Does not perform hashing at all so expects well-distributed keys.
-template <class Value>
+template <class Value, Value NullValue>
 class PrehashMap {
 public:
 	PrehashMap(int initialCapacity) : capacity_(initialCapacity) {
@@ -187,12 +187,12 @@ public:
 			if (map[p].state == BucketState::TAKEN && hash == map[p].hash)
 				return map[p].value;
 			else if (map[p].state == BucketState::FREE)
-				return nullptr;
+				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
 			if (p == pos)
 				Crash();
 		}
-		return nullptr;
+		return NullValue;
 	}
 
 	// Returns false if we already had the key! Which is a bit different.

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -17,11 +17,10 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include <d3d11.h>
 #include <d3d11_1.h>
 
+#include "Common/Hashmaps.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Common/IndexGenerator.h"
@@ -168,7 +167,7 @@ private:
 	ID3D11DeviceContext *context_;
 	ID3D11DeviceContext1 *context1_;
 
-	std::unordered_map<u32, VertexArrayInfoD3D11 *> vai_;
+	PrehashMap<VertexArrayInfoD3D11 *> vai_;
 
 	struct InputLayoutKey {
 		D3D11VertexShader *vshader;
@@ -182,7 +181,7 @@ private:
 		}
 	};
 
-	std::map<InputLayoutKey, ID3D11InputLayout *> inputLayoutMap_;
+	DenseHashMap<InputLayoutKey, ID3D11InputLayout *> inputLayoutMap_;
 
 	// Other
 	ShaderManagerD3D11 *shaderManager_ = nullptr;

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -167,7 +167,7 @@ private:
 	ID3D11DeviceContext *context_;
 	ID3D11DeviceContext1 *context1_;
 
-	PrehashMap<VertexArrayInfoD3D11 *> vai_;
+	PrehashMap<VertexArrayInfoD3D11 *, nullptr> vai_;
 
 	struct InputLayoutKey {
 		D3D11VertexShader *vshader;
@@ -181,7 +181,7 @@ private:
 		}
 	};
 
-	DenseHashMap<InputLayoutKey, ID3D11InputLayout *> inputLayoutMap_;
+	DenseHashMap<InputLayoutKey, ID3D11InputLayout *, nullptr> inputLayoutMap_;
 
 	// Other
 	ShaderManagerD3D11 *shaderManager_ = nullptr;

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -154,8 +154,8 @@ private:
 
 	LPDIRECT3DDEVICE9 device_ = nullptr;
 
-	PrehashMap<VertexArrayInfoDX9 *> vai_;
-	DenseHashMap<u32, IDirect3DVertexDeclaration9 *> vertexDeclMap_;
+	PrehashMap<VertexArrayInfoDX9 *, nullptr> vai_;
+	DenseHashMap<u32, IDirect3DVertexDeclaration9 *, nullptr> vertexDeclMap_;
 
 	// SimpleVertex
 	IDirect3DVertexDeclaration9* transformedVertexDecl_ = nullptr;

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -17,10 +17,9 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include <d3d9.h>
 
+#include "Common/Hashmaps.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Common/IndexGenerator.h"
@@ -155,8 +154,8 @@ private:
 
 	LPDIRECT3DDEVICE9 device_ = nullptr;
 
-	std::unordered_map<u32, VertexArrayInfoDX9 *> vai_;
-	std::unordered_map<u32, IDirect3DVertexDeclaration9 *> vertexDeclMap_;
+	PrehashMap<VertexArrayInfoDX9 *> vai_;
+	DenseHashMap<u32, IDirect3DVertexDeclaration9 *> vertexDeclMap_;
 
 	// SimpleVertex
 	IDirect3DVertexDeclaration9* transformedVertexDecl_ = nullptr;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -375,6 +375,7 @@ void DrawEngineGLES::DecimateTrackedVertexArrays() {
 			vai_.Remove(hash);
 		}
 	});
+	vai_.Maintain();
 }
 
 GLuint DrawEngineGLES::AllocateBuffer(size_t sz) {

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -115,7 +115,7 @@ enum {
 
 enum { VAI_KILL_AGE = 120, VAI_UNRELIABLE_KILL_AGE = 240, VAI_UNRELIABLE_KILL_MAX = 4 };
 
-DrawEngineGLES::DrawEngineGLES() {
+DrawEngineGLES::DrawEngineGLES() : vai_(256) {
 
 	decOptions_.expandAllWeightsToFloat = false;
 	decOptions_.expand8BitNormalsToFloat = false;
@@ -344,11 +344,11 @@ void DrawEngineGLES::MarkUnreliable(VertexArrayInfo *vai) {
 }
 
 void DrawEngineGLES::ClearTrackedVertexArrays() {
-	for (auto vai = vai_.begin(); vai != vai_.end(); vai++) {
-		FreeVertexArray(vai->second);
-		delete vai->second;
-	}
-	vai_.clear();
+	vai_.Iterate([&](uint32_t hash, VertexArrayInfo *vai){
+		FreeVertexArray(vai);
+		delete vai;
+	});
+	vai_.Clear();
 }
 
 void DrawEngineGLES::DecimateTrackedVertexArrays() {
@@ -361,22 +361,20 @@ void DrawEngineGLES::DecimateTrackedVertexArrays() {
 	const int threshold = gpuStats.numFlips - VAI_KILL_AGE;
 	const int unreliableThreshold = gpuStats.numFlips - VAI_UNRELIABLE_KILL_AGE;
 	int unreliableLeft = VAI_UNRELIABLE_KILL_MAX;
-	for (auto iter = vai_.begin(); iter != vai_.end(); ) {
+	vai_.Iterate([&](uint32_t hash, VertexArrayInfo *vai) {
 		bool kill;
-		if (iter->second->status == VertexArrayInfo::VAI_UNRELIABLE) {
+		if (vai->status == VertexArrayInfo::VAI_UNRELIABLE) {
 			// We limit killing unreliable so we don't rehash too often.
-			kill = iter->second->lastFrame < unreliableThreshold && --unreliableLeft >= 0;
+			kill = vai->lastFrame < unreliableThreshold && --unreliableLeft >= 0;
 		} else {
-			kill = iter->second->lastFrame < threshold;
+			kill = vai->lastFrame < threshold;
 		}
 		if (kill) {
-			FreeVertexArray(iter->second);
-			delete iter->second;
-			vai_.erase(iter++);
-		} else {
-			++iter;
+			FreeVertexArray(vai);
+			delete vai;
+			vai_.Remove(hash);
 		}
-	}
+	});
 }
 
 GLuint DrawEngineGLES::AllocateBuffer(size_t sz) {
@@ -460,8 +458,6 @@ void DrawEngineGLES::DoFlush() {
 	PROFILE_THIS_SCOPE("flush");
 	CHECK_GL_ERROR_IF_DEBUG();
 
-
-
 	gpuStats.numFlushes++;
 	gpuStats.numTrackedVertexArrays = (int)vai_.size();
 
@@ -485,14 +481,10 @@ void DrawEngineGLES::DoFlush() {
 
 		if (useCache) {
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
-			auto iter = vai_.find(id);
-			VertexArrayInfo *vai;
-			if (iter != vai_.end()) {
-				// We've seen this before. Could have been a cached draw.
-				vai = iter->second;
-			} else {
+			VertexArrayInfo *vai = vai_.Get(id);
+			if (!vai) {
 				vai = new VertexArrayInfo();
-				vai_[id] = vai;
+				vai_.Insert(id, vai);
 			}
 
 			switch (vai->status) {

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <Common/Hashmaps.h>
 #include <unordered_map>
 
 #include "GPU/GPUState.h"
@@ -165,7 +166,7 @@ private:
 
 	void MarkUnreliable(VertexArrayInfo *vai);
 
-	std::unordered_map<u32, VertexArrayInfo *> vai_;
+	PrehashMap<VertexArrayInfo *> vai_;
 
 	// Vertex buffer objects
 	// Element buffer objects

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -166,7 +166,7 @@ private:
 
 	void MarkUnreliable(VertexArrayInfo *vai);
 
-	PrehashMap<VertexArrayInfo *> vai_;
+	PrehashMap<VertexArrayInfo *, nullptr> vai_;
 
 	// Vertex buffer objects
 	// Element buffer objects

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -228,7 +228,7 @@ private:
 		VulkanPushBuffer *pushVertex;
 		VulkanPushBuffer *pushIndex;
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
-		DenseHashMap<DescriptorSetKey, VkDescriptorSet, VK_NULL_HANDLE> descSets;
+		DenseHashMap<DescriptorSetKey, VkDescriptorSet, (VkDescriptorSet)VK_NULL_HANDLE> descSets;
 
 		void Destroy(VulkanContext *vulkan);
 	};

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -32,6 +32,8 @@
 #include <map>
 #include <unordered_map>
 
+#include "Common/Hashmaps.h"
+
 #include "GPU/Vulkan/VulkanUtil.h"
 
 #include "GPU/GPUState.h"
@@ -195,7 +197,7 @@ private:
 	VulkanPipeline *lastPipeline_;
 	VkDescriptorSet lastDs_ = VK_NULL_HANDLE;
 
-	std::unordered_map<u32, VertexArrayInfoVulkan *> vai_;
+	PrehashMap<VertexArrayInfoVulkan *> vai_;
 	VulkanPushBuffer *vertexCache_;
 	int decimationCounter_ = 0;
 
@@ -219,12 +221,14 @@ private:
 
 	// We alternate between these.
 	struct FrameData {
+		FrameData() : descSets(1024) {}
+
 		VkDescriptorPool descPool;
 		VulkanPushBuffer *pushUBO;
 		VulkanPushBuffer *pushVertex;
 		VulkanPushBuffer *pushIndex;
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
-		std::map<DescriptorSetKey, VkDescriptorSet> descSets;
+		DenseHashMap<DescriptorSetKey, VkDescriptorSet> descSets;
 
 		void Destroy(VulkanContext *vulkan);
 	};

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -197,7 +197,7 @@ private:
 	VulkanPipeline *lastPipeline_;
 	VkDescriptorSet lastDs_ = VK_NULL_HANDLE;
 
-	PrehashMap<VertexArrayInfoVulkan *> vai_;
+	PrehashMap<VertexArrayInfoVulkan *, nullptr> vai_;
 	VulkanPushBuffer *vertexCache_;
 	int decimationCounter_ = 0;
 
@@ -228,7 +228,7 @@ private:
 		VulkanPushBuffer *pushVertex;
 		VulkanPushBuffer *pushIndex;
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
-		DenseHashMap<DescriptorSetKey, VkDescriptorSet> descSets;
+		DenseHashMap<DescriptorSetKey, VkDescriptorSet, VK_NULL_HANDLE> descSets;
 
 		void Destroy(VulkanContext *vulkan);
 	};

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -97,7 +97,7 @@ public:
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
 
 private:
-	DenseHashMap<VulkanPipelineKey, VulkanPipeline *> pipelines_;
+	DenseHashMap<VulkanPipelineKey, VulkanPipeline *, nullptr> pipelines_;
 	VkPipelineCache pipelineCache_;
 	VulkanContext *vulkan_;
 };

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <map>
+#include "Common/Hashmaps.h"
 
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/ShaderId.h"
@@ -97,7 +97,7 @@ public:
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
 
 private:
-	std::map<VulkanPipelineKey, VulkanPipeline *> pipelines_;
+	DenseHashMap<VulkanPipelineKey, VulkanPipeline *> pipelines_;
 	VkPipelineCache pipelineCache_;
 	VulkanContext *vulkan_;
 };


### PR DESCRIPTION
Implemented two new hash maps, FastHashMap and PrehashMap. 

In microbenchmarks on 20-byte keys, FastHashMap beats unordered_map by 10-50% depending on workload, and beats map by 400%.

Though of course overall this is just another 1-2% of performance, with enough of those real change starts to happen.

The removal strategy simply uses a flag to avoid false negatives (see Deletion here: https://en.wikipedia.org/wiki/Linear_probing). This does affect the performance of failed lookups in tables that we don't clear often, but those are not too common. Still, might be worth trying to improve that.