### PR TITLE
GPU: Fix alignment on signal jump/call

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1543,8 +1543,7 @@ void GPUCommon::Execute_BoundingBox(u32 op, u32 diff) {
 	// Just resetting, nothing to check bounds for.
 	const u32 data = op & 0x00FFFFFF;
 	if (data == 0) {
-		// TODO: Should this set the bboxResult?  Let's set it true for now.
-		currentList->bboxResult = true;
+		currentList->bboxResult = false;
 		return;
 	}
 	if (((data & 7) == 0) && data <= 64) {  // Sanity check

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1320,7 +1320,7 @@ void GPUCommon::Execute_End(u32 op, u32 diff) {
 					trigger = false;
 					currentList->signal = behaviour;
 					// pc will be increased after we return, counteract that.
-					u32 target = ((signal << 16) | enddata) - 4;
+					u32 target = (((signal << 16) | enddata) & 0xFFFFFFFC) - 4;
 					if (!Memory::IsValidAddress(target)) {
 						ERROR_LOG_REPORT(G3D, "Signal with Jump: bad address. signal/end: %04x %04x", signal, enddata);
 					} else {
@@ -1335,7 +1335,7 @@ void GPUCommon::Execute_End(u32 op, u32 diff) {
 					trigger = false;
 					currentList->signal = behaviour;
 					// pc will be increased after we return, counteract that.
-					u32 target = ((signal << 16) | enddata) - 4;
+					u32 target = (((signal << 16) | enddata) & 0xFFFFFFFC) - 4;
 					if (currentList->stackptr == ARRAY_SIZE(currentList->stack)) {
 						ERROR_LOG_REPORT(G3D, "Signal with Call: stack full. signal/end: %04x %04x", signal, enddata);
 					} else if (!Memory::IsValidAddress(target)) {

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -96,10 +96,13 @@ void NullGPU::ExecuteOp(u32 op, u32 diff) {
 		break;
 
 	case GE_CMD_BOUNDINGBOX:
-		if (data != 0)
+		if (data != 0) {
 			DEBUG_LOG(G3D, "Unsupported bounding box: %06x", data);
-		// bounding box test. Let's assume the box was within the drawing region.
-		currentList->bboxResult = true;
+			// Bounding box test. Let's assume the box was within the drawing region.
+			currentList->bboxResult = true;
+		} else {
+			currentList->bboxResult = false;
+		}
 		break;
 
 	case GE_CMD_VERTEXTYPE:


### PR DESCRIPTION
It shouldn't be possible to make the pc unaligned, and this may have been causing it previously.

See also hrydgard/pspautotests#192.  May affect #9881.

-[Unknown]