### PR TITLE
GPU: Reset shader state on shader reset

### DIFF
--- a/GPU/D3D11/ShaderManagerD3D11.cpp
+++ b/GPU/D3D11/ShaderManagerD3D11.cpp
@@ -124,8 +124,9 @@ void ShaderManagerD3D11::Clear() {
 	}
 	fsCache_.clear();
 	vsCache_.clear();
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
+	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
 
 void ShaderManagerD3D11::ClearShaders() {
@@ -135,11 +136,11 @@ void ShaderManagerD3D11::ClearShaders() {
 }
 
 void ShaderManagerD3D11::DirtyLastShader() {
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
 	lastVShader_ = nullptr;
 	lastFShader_ = nullptr;
-	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE|DIRTY_FRAGMENTSHADER_STATE);
+	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
 
 uint64_t ShaderManagerD3D11::UpdateUniforms() {

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -510,9 +510,6 @@ void ShaderManagerDX9::Clear() {
 	}
 	fsCache_.clear();
 	vsCache_.clear();
-	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);
-	lastFSID_.clear();
-	lastVSID_.clear();
 	DirtyShader();
 }
 
@@ -523,11 +520,11 @@ void ShaderManagerDX9::ClearCache(bool deleteThem) {
 
 void ShaderManagerDX9::DirtyShader() {
 	// Forget the last shader ID
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
 	lastVShader_ = nullptr;
 	lastPShader_ = nullptr;
-	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);
+	gstate_c.Dirty(DIRTY_ALL_UNIFORMS | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
 
 void ShaderManagerDX9::DirtyLastShader() { // disables vertex arrays

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -764,9 +764,6 @@ void ShaderManagerGLES::Clear() {
 	linkedShaderCache_.clear();
 	fsCache_.Clear();
 	vsCache_.Clear();
-	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);
-	lastFSID_.set_invalid();
-	lastVSID_.set_invalid();
 	DirtyShader();
 }
 
@@ -780,7 +777,7 @@ void ShaderManagerGLES::DirtyShader() {
 	lastFSID_.set_invalid();
 	lastVSID_.set_invalid();
 	DirtyLastShader();
-	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);
+	gstate_c.Dirty(DIRTY_ALL_UNIFORMS | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 	shaderSwitchDirtyUniforms_ = 0;
 }
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -49,7 +49,7 @@ const CommonCommandTableEntry commonCommandTable[] = {
 	// Changes that dirty the framebuffer
 	{ GE_CMD_FRAMEBUFPTR, FLAG_FLUSHBEFOREONCHANGE, DIRTY_FRAMEBUF | DIRTY_TEXTURE_PARAMS },
 	{ GE_CMD_FRAMEBUFWIDTH, FLAG_FLUSHBEFOREONCHANGE, DIRTY_FRAMEBUF | DIRTY_TEXTURE_PARAMS | DIRTY_VIEWPORTSCISSOR_STATE },
-	{ GE_CMD_FRAMEBUFPIXFORMAT, FLAG_FLUSHBEFOREONCHANGE, DIRTY_FRAMEBUF | DIRTY_TEXTURE_PARAMS | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_FRAGMENTSHADER_STATE},
+	{ GE_CMD_FRAMEBUFPIXFORMAT, FLAG_FLUSHBEFOREONCHANGE, DIRTY_FRAMEBUF | DIRTY_TEXTURE_PARAMS | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_FRAGMENTSHADER_STATE },
 	{ GE_CMD_ZBUFPTR, FLAG_FLUSHBEFOREONCHANGE },
 	{ GE_CMD_ZBUFWIDTH, FLAG_FLUSHBEFOREONCHANGE },
 
@@ -1789,7 +1789,7 @@ void GPUCommon::Execute_BoneMtxNum(u32 op, u32 diff) {
 				}
 			}
 
-			const int numPlusCount = (op & 0x7F) + i;
+			const unsigned int numPlusCount = (op & 0x7F) + i;
 			for (unsigned int num = op & 0x7F; num < numPlusCount; num += 12) {
 				gstate_c.Dirty(DIRTY_BONEMATRIX0 << (num / 12));
 			}
@@ -1801,7 +1801,7 @@ void GPUCommon::Execute_BoneMtxNum(u32 op, u32 diff) {
 				}
 			}
 
-			const int numPlusCount = (op & 0x7F) + i;
+			const unsigned int numPlusCount = (op & 0x7F) + i;
 			for (unsigned int num = op & 0x7F; num < numPlusCount; num += 12) {
 				gstate_c.deferredVertTypeDirty |= DIRTY_BONEMATRIX0 << (num / 12);
 			}

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -185,22 +185,22 @@ void ShaderManagerVulkan::Clear() {
 	});
 	fsCache_.Clear();
 	vsCache_.Clear();
-	lastFSID_.clear();
-	lastVSID_.clear();
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
+	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
 
 void ShaderManagerVulkan::ClearShaders() {
 	Clear();
 	DirtyShader();
-	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);
+	gstate_c.Dirty(DIRTY_ALL_UNIFORMS | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
 
 void ShaderManagerVulkan::DirtyShader() {
 	// Forget the last shader ID
-	lastFSID_.clear();
-	lastVSID_.clear();
-	lastVShader_ = nullptr;
-	lastFShader_ = nullptr;
+	lastFSID_.set_invalid();
+	lastVSID_.set_invalid();
+	DirtyLastShader();
 }
 
 void ShaderManagerVulkan::DirtyLastShader() { // disables vertex arrays


### PR DESCRIPTION
Was ending up with lastFSID being -1, but being used.  Also moved away from `.clear()` to `.set_invalid()`.

Seen in gpu/commands/blend test.

-[Unknown]