### PR TITLE
Decorate shaders for core profile support

### DIFF
--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -49,6 +49,12 @@
 // #define DEBUG_READ_PIXELS 1
 
 static const char tex_fs[] =
+	"#if __VERSION__ >= 130\n"
+	"#define varying in\n"
+	"#define texture2D texture\n"
+	"#define gl_FragColor fragColor0\n"
+	"out vec4 fragColor0;\n"
+	"#endif\n"
 #ifdef USING_GLES2
 	"precision mediump float;\n"
 #endif
@@ -59,6 +65,10 @@ static const char tex_fs[] =
 	"}\n";
 
 static const char basic_vs[] =
+	"#if __VERSION__ >= 130\n"
+	"#define attribute in\n"
+	"#define varying out\n"
+	"#endif\n"
 	"attribute vec4 a_position;\n"
 	"attribute vec2 a_texcoord0;\n"
 	"varying vec2 v_texcoord0;\n"
@@ -87,7 +97,10 @@ void FramebufferManagerGLES::DisableState() {
 void FramebufferManagerGLES::CompileDraw2DProgram() {
 	if (!draw2dprogram_) {
 		std::string errorString;
-		draw2dprogram_ = glsl_create_source(basic_vs, tex_fs, &errorString);
+		static std::string vs_code, fs_code;
+		vs_code = ApplyGLSLPrelude(basic_vs, GL_VERTEX_SHADER);
+		fs_code = ApplyGLSLPrelude(tex_fs, GL_FRAGMENT_SHADER);
+		draw2dprogram_ = glsl_create_source(vs_code.c_str(), fs_code.c_str(), &errorString);
 		if (!draw2dprogram_) {
 			ERROR_LOG_REPORT(G3D, "Failed to compile draw2dprogram! This shouldn't happen.\n%s", errorString.c_str());
 		} else {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -299,7 +299,7 @@ void GPU_GLES::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_ANISOTROPY;
 
 	bool canUseInstanceID = gl_extensions.EXT_draw_instanced || gl_extensions.ARB_draw_instanced;
-	bool canDefInstanceID = gl_extensions.IsGLES || gl_extensions.EXT_gpu_shader4;
+	bool canDefInstanceID = gl_extensions.IsGLES || gl_extensions.EXT_gpu_shader4 || gl_extensions.VersionGEThan(3, 1);
 	bool instanceRendering = gl_extensions.GLES3 || (canUseInstanceID && canDefInstanceID);
 		features |= GPU_SUPPORTS_INSTANCE_RENDERING;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -94,7 +94,7 @@ bool CheckSupportInstancedTessellationGLES() {
 	bool vertexTexture = maxVertexTextureImageUnits >= 3; // At least 3 for hardware tessellation
 
 	bool canUseInstanceID = gl_extensions.EXT_draw_instanced || gl_extensions.ARB_draw_instanced;
-	bool canDefInstanceID = gl_extensions.IsGLES || gl_extensions.EXT_gpu_shader4;
+	bool canDefInstanceID = gl_extensions.IsGLES || gl_extensions.EXT_gpu_shader4 || gl_extensions.VersionGEThan(3, 1);
 	bool instanceRendering = gl_extensions.GLES3 || (canUseInstanceID && canDefInstanceID);
 
 	bool textureFloat = gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float;

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -394,7 +394,7 @@ void CheckGLExtensions() {
 #endif
 
 	// This is probably a waste of time, implementations lie.
-	if (gl_extensions.IsGLES || strstr(extString, "GL_ARB_ES2_compatibility")) {
+	if (gl_extensions.IsGLES || strstr(extString, "GL_ARB_ES2_compatibility") || gl_extensions.VersionGEThan(4, 1)) {
 		const GLint precisions[6] = {
 			GL_LOW_FLOAT, GL_MEDIUM_FLOAT, GL_HIGH_FLOAT,
 			GL_LOW_INT, GL_MEDIUM_INT, GL_HIGH_INT
@@ -419,6 +419,47 @@ void CheckGLExtensions() {
 		gl_extensions.ARB_vertex_array_object = true;
 		gl_extensions.ARB_framebuffer_object = true;
 	}
+
+	// Add any extensions that are included in core.  May be elided.
+	if (!gl_extensions.IsGLES) {
+		if (gl_extensions.VersionGEThan(3, 0)) {
+			gl_extensions.ARB_texture_float = true;
+		}
+		if (gl_extensions.VersionGEThan(3, 1)) {
+			gl_extensions.ARB_draw_instanced = true;
+			// ARB_uniform_buffer_object = true;
+		}
+		if (gl_extensions.VersionGEThan(3, 2)) {
+			// ARB_depth_clamp = true;
+		}
+		if (gl_extensions.VersionGEThan(3, 3)) {
+			gl_extensions.ARB_blend_func_extended = true;
+			// ARB_explicit_attrib_location = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 0)) {
+			// ARB_gpu_shader5 = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 1)) {
+			// ARB_get_program_binary = true;
+			// ARB_separate_shader_objects = true;
+			// ARB_shader_precision = true;
+			// ARB_viewport_array = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 2)) {
+			// ARB_texture_storage = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 3)) {
+			gl_extensions.ARB_copy_image = true;
+			// ARB_explicit_uniform_location = true;
+			// ARB_stencil_texturing = true;
+			// ARB_texture_view = true;
+			// ARB_vertex_attrib_binding = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 4)) {
+			// ARB_buffer_storage = true;
+		}
+	}
+
 #ifdef __APPLE__
 	if (!gl_extensions.IsGLES && !gl_extensions.IsCoreContext) {
 		// Apple doesn't allow OpenGL 3.x+ in compatibility contexts.

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -444,3 +444,31 @@ void SetGLCoreContext(bool flag) {
 	// For convenience, it'll get reset later.
 	gl_extensions.IsCoreContext = useCoreContext;
 }
+
+static const char *glsl_fragment_prelude =
+"#ifdef GL_ES\n"
+"precision mediump float;\n"
+"#endif\n";
+
+std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage) {
+	std::string temp;
+	std::string version = "";
+	if (!gl_extensions.IsGLES && gl_extensions.IsCoreContext) {
+		// We need to add a corresponding #version.  Apple drives fail without an exact match.
+		if (gl_extensions.VersionGEThan(3, 3)) {
+			version = StringFromFormat("#version %d%d0\n", gl_extensions.ver[0], gl_extensions.ver[1]);
+		} else if (gl_extensions.VersionGEThan(3, 2)) {
+			version = "#version 150\n";
+		} else if (gl_extensions.VersionGEThan(3, 1)) {
+			version = "#version 140\n";
+		} else {
+			version = "#version 130\n";
+		}
+	}
+	if (stage == GL_FRAGMENT_SHADER) {
+		temp = version + glsl_fragment_prelude + source;
+	} else if (stage == GL_VERTEX_SHADER) {
+		temp = version + source;
+	}
+	return temp;
+}

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include "base/NativeApp.h"
 
 enum {
@@ -110,3 +111,5 @@ extern std::string g_all_egl_extensions;
 
 void CheckGLExtensions();
 void SetGLCoreContext(bool flag);
+
+std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage);

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -69,6 +69,12 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"#ifdef GL_ES\n"
 	"precision lowp float;\n"
 	"#endif\n"
+	"#if __VERSION__ >= 130\n"
+	"#define varying in\n"
+	"#define texture2D texture\n"
+	"#define gl_FragColor fragColor0\n"
+	"out vec4 fragColor0;\n"
+	"#endif\n"
 	"varying vec4 oColor0;\n"
 	"varying vec2 oTexCoord0;\n"
 	"uniform sampler2D Sampler0;\n"
@@ -107,6 +113,11 @@ static const std::vector<ShaderSource> fsCol = {
 	"#ifdef GL_ES\n"
 	"precision lowp float;\n"
 	"#endif\n"
+	"#if __VERSION__ >= 130\n"
+	"#define varying in\n"
+	"#define gl_FragColor fragColor0\n"
+	"out vec4 fragColor0;\n"
+	"#endif\n"
 	"varying vec4 oColor0;\n"
 	"void main() { gl_FragColor = oColor0; }\n"
 	},
@@ -136,6 +147,10 @@ static const std::vector<ShaderSource> fsCol = {
 
 static const std::vector<ShaderSource> vsCol = {
 	{ ShaderLanguage::GLSL_ES_200,
+	"#if __VERSION__ >= 130\n"
+	"#define attribute in\n"
+	"#define varying out\n"
+	"#endif\n"
 	"attribute vec3 Position;\n"
 	"attribute vec4 Color0;\n"
 	"varying vec4 oColor0;\n"
@@ -193,6 +208,10 @@ const UniformBufferDesc vsColBufDesc { sizeof(VsColUB), {
 
 static const std::vector<ShaderSource> vsTexCol = {
 	{ ShaderLanguage::GLSL_ES_200,
+	"#if __VERSION__ >= 130\n"
+	"#define attribute in\n"
+	"#define varying out\n"
+	"#endif\n"
 	"attribute vec3 Position;\n"
 	"attribute vec4 Color0;\n"
 	"attribute vec2 TexCoord0;\n"

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1042,10 +1042,6 @@ bool OpenGLPipeline::LinkShaders() {
 	glBindAttribLocation(program_, SEM_NORMAL, "Normal");
 	glBindAttribLocation(program_, SEM_TANGENT, "Tangent");
 	glBindAttribLocation(program_, SEM_BINORMAL, "Binormal");
-
-	if (gl_extensions.VersionGEThan(3, 3, 0)) {
-		glBindFragDataLocation(program_, 0, "fragColor0");
-	}
 	glLinkProgram(program_);
 
 	GLint linkStatus = GL_FALSE;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -163,11 +163,6 @@ static const unsigned short primToGL[] = {
 
 class OpenGLBuffer;
 
-static const char *glsl_fragment_prelude =
-"#ifdef GL_ES\n"
-"precision mediump float;\n"
-"#endif\n";
-
 class OpenGLBlendState : public BlendState {
 public:
 	bool enabled;
@@ -332,9 +327,9 @@ bool OpenGLShaderModule::Compile(ShaderLanguage language, const uint8_t *data, s
 	language_ = language;
 
 	std::string temp;
-	// Add the prelude on automatically for fragment shaders.
-	if (glstage_ == GL_FRAGMENT_SHADER) {
-		temp = std::string(glsl_fragment_prelude) + source_;
+	// Add the prelude on automatically.
+	if (glstage_ == GL_FRAGMENT_SHADER || glstage_ == GL_VERTEX_SHADER) {
+		temp = ApplyGLSLPrelude(source_, glstage_);
 		source_ = temp.c_str();
 	}
 
@@ -1047,6 +1042,10 @@ bool OpenGLPipeline::LinkShaders() {
 	glBindAttribLocation(program_, SEM_NORMAL, "Normal");
 	glBindAttribLocation(program_, SEM_TANGENT, "Tangent");
 	glBindAttribLocation(program_, SEM_BINORMAL, "Binormal");
+
+	if (gl_extensions.VersionGEThan(3, 3, 0)) {
+		glBindFragDataLocation(program_, 0, "fragColor0");
+	}
 	glLinkProgram(program_);
 
 	GLint linkStatus = GL_FALSE;


### PR DESCRIPTION
Needs more testing, but this mostly takes care of #8277 (although it doesn't change the SDL flags yet.)  With this and the SDL flags set, games and UI both run and display things with a OpenGL 4.1 core profile on Mac OS X.

To test on Mac, edit `ext/native/base/PCMain.cpp` and change:
```diff
diff --git a/ext/native/base/PCMain.cpp b/ext/native/base/PCMain.cpp
index 362b5ff..7dc9548 100644
--- a/ext/native/base/PCMain.cpp
+++ b/ext/native/base/PCMain.cpp
@@ -441,9 +441,10 @@ int main(int argc, char *argv[]) {
        // latest supported by MacOSX (really, really sad...)
        // Requires SDL 2.0
        // We really should upgrade to SDL 2.0 soon.
-       //SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-       //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-       //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+       SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+       SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+       SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+       SetGLCoreContext(true);
 #endif

 #ifdef USING_EGL
```
(the same essential change can be used in SDLHeadlessHost.cpp too.)

More importantly, I'm not sure if this could break some OpenGL 3.0 desktop device, or certain GLES drivers.  But it ought to work.

As for changing the SDL flags - not sure if we need to have fallback for < 3.00.

-[Unknown]