### PR TITLE
Create default mapping for unknown control pads in SDL's controller database

### DIFF
--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -50,22 +50,36 @@ void SDLJoystick::setUpControllers() {
 }
 
 void SDLJoystick::setUpController(int deviceIndex) {
-	if (SDL_IsGameController(deviceIndex)) {
-		SDL_GameController *controller = SDL_GameControllerOpen(deviceIndex);
-		if (controller) {
-			if (SDL_GameControllerGetAttached(controller)) {
-				controllers.push_back(controller);
-				controllerDeviceMap[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller))] = deviceIndex;
-				cout << "found control pad: " << SDL_GameControllerName(controller) << ", loading mapping: ";
-				auto mapping = SDL_GameControllerMapping(controller);
-				if (mapping == NULL) {
-					cout << "FAILED" << endl;
-				} else {
-					cout << "SUCCESS, mapping is:" << endl << mapping << endl;
-				}
+	if (!SDL_IsGameController(deviceIndex)) {
+		cout << "Control pad device " << deviceIndex << " not supported by SDL game controller database, attempting to create default mapping..." << endl;
+		int cbGUID = 33;
+		char pszGUID[cbGUID];
+		SDL_Joystick* joystick = SDL_JoystickOpen(deviceIndex);
+		SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(joystick), pszGUID, cbGUID);
+		// create default mapping - this is the PS3 dual shock mapping
+		std::string mapping = string(pszGUID) + "," + string(SDL_JoystickName(joystick)) + ",x:b3,a:b0,b:b1,y:b2,back:b8,guide:b10,start:b9,dpleft:b15,dpdown:b14,dpright:b16,dpup:b13,leftshoulder:b4,lefttrigger:a2,rightshoulder:b6,rightshoulder:b5,righttrigger:a5,leftstick:b7,leftstick:b11,rightstick:b12,leftx:a0,lefty:a1,rightx:a3,righty:a4";
+		if (SDL_GameControllerAddMapping(mapping.c_str()) == 1){
+			cout << "Added default mapping ok" << endl;
+		} else {
+			cout << "Failed to add default mapping" << endl;
+		}
+		SDL_JoystickClose(joystick);
+	}
+	SDL_GameController *controller = SDL_GameControllerOpen(deviceIndex);
+	if (controller) {
+		if (SDL_GameControllerGetAttached(controller)) {
+			controllers.push_back(controller);
+			controllerDeviceMap[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller))] = deviceIndex;
+			cout << "found control pad: " << SDL_GameControllerName(controller) << ", loading mapping: ";
+			auto mapping = SDL_GameControllerMapping(controller);
+			if (mapping == NULL) {
+				//cout << "FAILED" << endl;
+				cout << "Could not find mapping in SDL2 controller database" << endl;
 			} else {
-				SDL_GameControllerClose(controller);
+				cout << "SUCCESS, mapping is:" << endl << mapping << endl;
 			}
+		} else {
+			SDL_GameControllerClose(controller);
 		}
 	}
 }


### PR DESCRIPTION
Updated SDL/SDLJoystick.cpp in response to #9987 

Summary:

If a control pad is not found in SDL's game controller database then a default mapping (based on the Sony PlayStation 3 Dual Shock controller) will be created and added to the in-memory database. Note: this new mapping is temporary and is not written to the control pad database.