### PR TITLE
Add ini-only "Savedata Upgrade" setting.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -754,6 +754,7 @@ static ConfigSetting systemParamSettings[] = {
 #endif
 	ConfigSetting("WlanPowerSave", &g_Config.bWlanPowerSave, (bool) PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF, true, true),
 	ReportedConfigSetting("EncryptSave", &g_Config.bEncryptSave, true, true, true),
+	ConfigSetting("SavedataUpgrade", &g_Config.bSavedataUpgrade, false, true, false),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -420,6 +420,7 @@ public:
 	int iButtonPreference;
 	int iLockParentalLevel;
 	bool bEncryptSave;
+	bool bSavedataUpgrade;
 
 	// Networking
 	bool bEnableWlan;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -647,6 +647,12 @@ void SavedataParam::LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8
 			} else {
 				WARN_LOG_REPORT(SCEUTILITY, "Savedata loading with detected hashmode %d instead of file's %d", decryptMode, prevCryptMode);
 			}
+			if (g_Config.bSavedataUpgrade) {
+				decryptMode = prevCryptMode;
+				I18NCategory *di = GetI18NCategory("Dialog");
+				host->NotifyUserMessage(di->T("When you save, it will not work on outdated PSP Firmware anymore"), 6.0f);
+				host->NotifyUserMessage(di->T("Old savedata detected"), 6.0f);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #10000 

The option does similar thing as the workaround for old/buggy PPSSPP savedata, except deals with outdated PSP firmware(only cfw?) problem.
 Made it ini-only, non default, but not per game since if someone would be affected by it chances are he might have a lot of such saves for many games.