### PR TITLE
Windows: Fix over/under write for multibyte chars

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -136,6 +136,7 @@ void ConsoleListener::Open()
 		// Set the console window title
 		SetConsoleTitle(title_.c_str());
 		SetConsoleCP(CP_UTF8);
+		SetConsoleOutputCP(CP_UTF8);
 
 		// Set letter space
 		LetterSpace(openWidth_, LOG_MAX_DISPLAY_LINES);
@@ -503,7 +504,7 @@ void ConsoleListener::WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Tex
 	SetConsoleTextAttribute(hConsole, Color);
 	int wlen = MultiByteToWideChar(CP_UTF8, 0, Text, (int)Len, NULL, NULL);
 	MultiByteToWideChar(CP_UTF8, 0, Text, (int)Len, tempBuf, wlen);
-	WriteConsole(hConsole, tempBuf, (DWORD)Len, &cCharsWritten, NULL);
+	WriteConsole(hConsole, tempBuf, (DWORD)wlen, &cCharsWritten, NULL);
 }
 #endif
 


### PR DESCRIPTION
Windows is still kinda braindead in the way it handles console fonts, but at least this fixes it so we're writing the correct characters to the console.

Previously, when logging CJK/etc., sometimes you'd end up with extra garbage or the string would get cut off (I'm not sure why it'd get cutoff exactly, since it should've always written too much, but it might have been due to encoding errors in the garbage.)

-[Unknown]