### PR TITLE
Better path fix x86_64 android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1617,7 +1617,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 if(ANDROID)
   set(CoreExtraLibs ${CoreExtraLibs} android)
   if(X86_64)
-    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-Bsymbolic")
+    set(CoreExtraLibs ${CoreExtraLibs} android -Wl,-Bsymbolic")
   endif()
 endif()	
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1617,7 +1617,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 if(ANDROID)
   set(CoreExtraLibs ${CoreExtraLibs} android)
   if(X86_64)
-    set(CoreExtraLibs ${CoreExtraLibs} android -Wl,-Bsymbolic)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
   endif()
 endif()	
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1617,7 +1617,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 if(ANDROID)
   set(CoreExtraLibs ${CoreExtraLibs} android)
   if(X86_64)
-    set(CoreExtraLibs ${CoreExtraLibs} android -Wl,-Bsymbolic")
+    set(CoreExtraLibs ${CoreExtraLibs} android -Wl,-Bsymbolic)
   endif()
 endif()	
  


### PR DESCRIPTION
Not sure why not needed before when updated my toolchain to NDK15 now  no found -landroid  and error: cannot open crtbegin_dynamic.o: No such file or directory 

So we pull it safe in case not detect sysroot properly.