### PR TITLE
Additional Vulkan fixes and cleanups

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -153,20 +153,6 @@ VulkanContext::~VulkanContext() {
 	VulkanFree();
 }
 
-void TransitionToPresent(VkCommandBuffer cmd, VkImage image) {
-	TransitionImageLayout2(cmd, image, VK_IMAGE_ASPECT_COLOR_BIT,
-		VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-		VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-		VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_ACCESS_MEMORY_READ_BIT);
-}
-
-void TransitionFromPresent(VkCommandBuffer cmd, VkImage image) {
-	TransitionImageLayout2(cmd, image, VK_IMAGE_ASPECT_COLOR_BIT,
-		VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-		VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-		VK_ACCESS_MEMORY_READ_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-}
-
 void VulkanContext::BeginFrame() {
 	FrameData *frame = &frame_[curFrame_];
 	// Process pending deletes.

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -306,6 +306,8 @@ public:
 		return swapchainFormat_;
 	}
 
+	// 1 for no frame overlap and thus minimal latency but worst performance.
+	// 2 is an OK compromise, while 3 performs best but risks slightly higher latency.
 	enum {
 		MAX_INFLIGHT_FRAMES = 3,
 	};

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -393,9 +393,6 @@ void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, VkImageAspectFla
 	VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
 	VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask);
 
-void TransitionFromPresent(VkCommandBuffer cmd, VkImage image);
-void TransitionToPresent(VkCommandBuffer cmd, VkImage image);
-
 // GLSL compiler
 void init_glslang();
 void finalize_glslang();

--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -358,14 +358,6 @@ void VulkanTexture::EndCreate(VkCommandBuffer cmd) {
 		VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT);
 }
 
-void VulkanTexture::TransitionForUpload(VkCommandBuffer cmd) {
-	TransitionImageLayout2(cmd, image,
-		VK_IMAGE_ASPECT_COLOR_BIT,
-		VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-		VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT);
-}
-
 void VulkanTexture::Destroy() {
 	if (view != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteImageView(view);

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -35,9 +35,6 @@ public:
 	void UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mipHeight, VkBuffer buffer, uint32_t offset, size_t rowLength);  // rowLength is in pixels
 	void EndCreate(VkCommandBuffer cmd);
 
-	// Dangerous.
-	void TransitionForUpload(VkCommandBuffer cmd);
-
 	int GetNumMips() const { return numMips_; }
 	void Destroy();
 

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -35,6 +35,7 @@ public:
 	void UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mipHeight, VkBuffer buffer, uint32_t offset, size_t rowLength);  // rowLength is in pixels
 	void EndCreate(VkCommandBuffer cmd);
 
+	// Dangerous.
 	void TransitionForUpload(VkCommandBuffer cmd);
 
 	int GetNumMips() const { return numMips_; }

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -236,7 +236,10 @@
     <ClCompile Include="FileSystems\VirtualDiscFileSystem.cpp" />
     <ClCompile Include="Font\PGF.cpp" />
     <ClCompile Include="HDRemaster.cpp" />
-    <ClCompile Include="HLE\HLE.cpp" />
+    <ClCompile Include="HLE\HLE.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MaxSpeed</Optimization>
+      <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Default</BasicRuntimeChecks>
+    </ClCompile>
     <ClCompile Include="HLE\HLEHelperThread.cpp" />
     <ClCompile Include="HLE\HLETables.cpp" />
     <ClCompile Include="HLE\proAdhoc.cpp" />

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -514,9 +514,6 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry, bool replaceIma
 		}
 	}
 
-	// If GLES3 is available, we can preallocate the storage, which makes texture loading more efficient.
-	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-
 	int scaleFactor = standardScaleFactor_;
 
 	// Rachet down scale factor in low-memory mode.
@@ -572,6 +569,8 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry, bool replaceIma
 	if (badMipSizes) {
 		maxLevel = 0;
 	}
+
+	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 
 	if (IsFakeMipmapChange()) {
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -79,7 +79,6 @@ enum {
 DrawEngineVulkan::DrawEngineVulkan(VulkanContext *vulkan, Draw::DrawContext *draw)
 	:	vulkan_(vulkan),
 		draw_(draw),
-		curFrame_(0),
 		stats_{},
 		vai_(1024) {
 	decOptions_.expandAllWeightsToFloat = false;
@@ -279,7 +278,8 @@ void DrawEngineVulkan::DeviceRestore(VulkanContext *vulkan) {
 void DrawEngineVulkan::BeginFrame() {
 	lastPipeline_ = nullptr;
 
-	FrameData *frame = &frame_[curFrame_];
+	int curFrame = vulkan_->GetCurFrame();
+	FrameData *frame = &frame_[curFrame];
 
 	// First reset all buffers, then begin. This is so that Reset can free memory and Begin can allocate it,
 	// if growing the buffer is needed. Doing it this way will reduce fragmentation if more than one buffer
@@ -358,16 +358,13 @@ void DrawEngineVulkan::BeginFrame() {
 }
 
 void DrawEngineVulkan::EndFrame() {
-	FrameData *frame = &frame_[curFrame_];
+	FrameData *frame = &frame_[vulkan_->GetCurFrame()];
 	stats_.pushUBOSpaceUsed = (int)frame->pushUBO->GetOffset();
 	stats_.pushVertexSpaceUsed = (int)frame->pushVertex->GetOffset();
 	stats_.pushIndexSpaceUsed = (int)frame->pushIndex->GetOffset();
 	frame->pushUBO->End();
 	frame->pushVertex->End();
 	frame->pushIndex->End();
-	curFrame_++;
-	if (curFrame_ >= vulkan_->GetInflightFrames())
-		curFrame_ = 0;
 	vertexCache_->End();
 }
 
@@ -520,7 +517,7 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 	assert(light != VK_NULL_HANDLE);
 	assert(bone != VK_NULL_HANDLE);
 
-	FrameData *frame = &frame_[curFrame_];
+	FrameData *frame = &frame_[vulkan_->GetCurFrame()];
 	if (!gstate_c.bezier && !gstate_c.spline) { // Has no cache when HW tessellation.
 		VkDescriptorSet d = frame->descSets.Get(key);
 		if (d != VK_NULL_HANDLE)
@@ -668,7 +665,7 @@ void DrawEngineVulkan::DoFlush() {
 	// Since we have a new cmdbuf, dirty our dynamic state so it gets re-set.
 	// gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE|DIRTY_DEPTHSTENCIL_STATE|DIRTY_BLEND_STATE);
 
-	FrameData *frame = &frame_[curFrame_];
+	FrameData *frame = &frame_[vulkan_->GetCurFrame()];
 
 	bool textureNeedsApply = false;
 	if (gstate_c.IsDirty(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS) && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -57,7 +57,7 @@ enum {
 };
 
 #define VERTEXCACHE_DECIMATION_INTERVAL 17
-#define DESCRIPTORSET_DECIMATION_INTERVAL 13
+#define DESCRIPTORSET_DECIMATION_INTERVAL 1  // Temporarily cut to 1. Handle reuse breaks this when textures get deleted.
 
 enum { VAI_KILL_AGE = 120, VAI_UNRELIABLE_KILL_AGE = 240, VAI_UNRELIABLE_KILL_MAX = 4 };
 
@@ -295,6 +295,7 @@ void DrawEngineVulkan::BeginFrame() {
 
 	// TODO : Find a better place to do this.
 	if (!nullTexture_) {
+		ILOG("INIT : Creating null texture");
 		VkCommandBuffer cmdInit = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 		nullTexture_ = new VulkanTexture(vulkan_);
 		int w = 8;
@@ -1087,6 +1088,7 @@ void DrawEngineVulkan::UpdateUBOs(FrameData *frame) {
 
 void DrawEngineVulkan::TessellationDataTransferVulkan::PrepareBuffers(float *&pos, float *&tex, float *&col, int size, bool hasColor, bool hasTexCoords) {
 	int rowPitch;
+	ILOG("INIT : Prep tess");
 
 	VkCommandBuffer cmd = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 	// Position

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -168,7 +168,7 @@ public:
 	}
 
 	VulkanPushBuffer *GetPushBufferForTextureData() {
-		return frame_[curFrame_].pushUBO;
+		return frame_[vulkan_->GetCurFrame()].pushUBO;
 	}
 
 	const DrawEngineVulkanStats &GetStats() const {
@@ -233,7 +233,6 @@ private:
 	};
 
 	GEPrimitiveType lastPrim_ = GE_PRIM_INVALID;
-	int curFrame_;
 	FrameData frame_[VulkanContext::MAX_INFLIGHT_FRAMES];
 
 	// Other

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -206,22 +206,17 @@ void FramebufferManagerVulkan::Init() {
 }
 
 void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) {
-	if (drawPixelsTex_ && (drawPixelsTexFormat_ != srcPixelFormat || drawPixelsTex_->GetWidth() != width || drawPixelsTex_->GetHeight() != height)) {
+	if (drawPixelsTex_) {
 		delete drawPixelsTex_;
 		drawPixelsTex_ = nullptr;
 	}
 
 	VkCommandBuffer initCmd = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 
-	if (!drawPixelsTex_) {
-		drawPixelsTex_ = new VulkanTexture(vulkan_);
-		drawPixelsTex_->CreateDirect(initCmd, width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-		// Initialize backbuffer texture for DrawPixels
-		drawPixelsTexFormat_ = srcPixelFormat;
-	} else {
-		// TODO: We may want to double-buffer these, when we have more frames hanging about.
-		drawPixelsTex_->TransitionForUpload(initCmd);
-	}
+	drawPixelsTex_ = new VulkanTexture(vulkan_);
+	drawPixelsTex_->CreateDirect(initCmd, width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+	// Initialize backbuffer texture for DrawPixels
+	drawPixelsTexFormat_ = srcPixelFormat;
 
 	// TODO: We can just change the texture format and flip some bits around instead of this.
 	// Could share code with the texture cache perhaps.

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -214,7 +214,13 @@ void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFor
 	VkCommandBuffer initCmd = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 
 	drawPixelsTex_ = new VulkanTexture(vulkan_);
-	drawPixelsTex_->CreateDirect(initCmd, width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+	if (!drawPixelsTex_->CreateDirect(initCmd, width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT)) {
+		// out of memory?
+		delete drawPixelsTex_;
+		drawPixelsTex_ = nullptr;
+		overrideImageView_ = VK_NULL_HANDLE;
+		return;
+	}
 	// Initialize backbuffer texture for DrawPixels
 	drawPixelsTexFormat_ = srcPixelFormat;
 

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -225,6 +225,7 @@ void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFor
 
 	// TODO: We can just change the texture format and flip some bits around instead of this.
 	// Could share code with the texture cache perhaps.
+	// Could also convert directly into the pushbuffer easily.
 	const uint8_t *data = srcPixels;
 	if (srcPixelFormat != GE_FORMAT_8888 || srcStride != width) {
 		u32 neededSize = width * height * 4;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -218,16 +218,16 @@ void GPU_Vulkan::BeginHostFrame() {
 
 	textureCacheVulkan_->StartFrame();
 
-
-	FrameData &frame = frameData_[curFrame_];
+	int curFrame = vulkan_->GetCurFrame();
+	FrameData &frame = frameData_[curFrame];
 
 	frame.push_->Reset();
 	frame.push_->Begin(vulkan_);
 
 	framebufferManagerVulkan_->BeginFrameVulkan();
-	framebufferManagerVulkan_->SetPushBuffer(frameData_[curFrame_].push_);
-	depalShaderCache_.SetPushBuffer(frameData_[curFrame_].push_);
-	textureCacheVulkan_->SetPushBuffer(frameData_[curFrame_].push_);
+	framebufferManagerVulkan_->SetPushBuffer(frameData_[curFrame].push_);
+	depalShaderCache_.SetPushBuffer(frameData_[curFrame].push_);
+	textureCacheVulkan_->SetPushBuffer(frameData_[curFrame].push_);
 
 	vulkan2D_.BeginFrame();
 
@@ -244,15 +244,11 @@ void GPU_Vulkan::BeginHostFrame() {
 }
 
 void GPU_Vulkan::EndHostFrame() {
-	FrameData &frame = frameData_[curFrame_];
+	int curFrame = vulkan_->GetCurFrame();
+	FrameData &frame = frameData_[curFrame];
 	frame.push_->End();
 
 	vulkan2D_.EndFrame();
-
-	curFrame_++;
-	if (curFrame_ >= vulkan_->GetInflightFrames()) {
-		curFrame_ = 0;
-	}
 
 	drawEngine_.EndFrame();
 	framebufferManagerVulkan_->EndFrame();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -134,5 +134,4 @@ private:
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES]{};
-	int curFrame_ = 0;
 };

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -550,6 +550,11 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 	int h = gstate.getTextureHeight(0);
 	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
 	if (replaced.GetSize(0, w, h)) {
+		if (replaceImages) {
+			// Since we're replacing the texture, we can't replace the image inside.
+			ReleaseTexture(entry, true);
+			replaceImages = false;
+		}
 		// We're replacing, so we won't scale.
 		scaleFactor = 1;
 		entry->status |= TexCacheEntry::STATUS_IS_SCALED;
@@ -586,7 +591,9 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 	if (replaced.Valid()) {
 		actualFmt = ToVulkanFormat(replaced.Format(0));
 	}
-	if (!entry->vkTex) {
+
+	if (!entry->vkTex) {  // Change to "if (true) {" to always recreate.
+		delete entry->vkTex;
 		entry->vkTex = new CachedTextureVulkan();
 		entry->vkTex->texture_ = new VulkanTexture(vulkan_, allocator_);
 		VulkanTexture *image = entry->vkTex->texture_;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -592,7 +592,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 		actualFmt = ToVulkanFormat(replaced.Format(0));
 	}
 
-	if (!entry->vkTex) {  // Change to "if (true) {" to always recreate.
+	{
 		delete entry->vkTex;
 		entry->vkTex = new CachedTextureVulkan();
 		entry->vkTex->texture_ = new VulkanTexture(vulkan_, allocator_);
@@ -643,8 +643,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 			delete entry->vkTex;
 			entry->vkTex = nullptr;
 		}
-	} else {
-		entry->vkTex->texture_->TransitionForUpload(cmdInit);
 	}
 	lastBoundTexture = entry->vkTex;
 

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -20,7 +20,7 @@
 #include "Common/Vulkan/VulkanContext.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
-Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan), curFrame_(0) {
+Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
 	InitDeviceObjects();
 }
 
@@ -121,15 +121,13 @@ void Vulkan2D::DeviceRestore(VulkanContext *vulkan) {
 }
 
 void Vulkan2D::BeginFrame() {
-	FrameData &frame = frameData_[curFrame_];
+	int curFrame = vulkan_->GetCurFrame();
+	FrameData &frame = frameData_[curFrame];
 	frame.descSets.clear();
 	vkResetDescriptorPool(vulkan_->GetDevice(), frame.descPool, 0);
 }
 
 void Vulkan2D::EndFrame() {
-	curFrame_++;
-	if (curFrame_ >= vulkan_->GetInflightFrames())
-		curFrame_ = 0;
 }
 
 VkDescriptorSet Vulkan2D::GetDescriptorSet(VkImageView tex1, VkSampler sampler1, VkImageView tex2, VkSampler sampler2) {
@@ -139,7 +137,8 @@ VkDescriptorSet Vulkan2D::GetDescriptorSet(VkImageView tex1, VkSampler sampler1,
 	key.sampler[0] = sampler1;
 	key.sampler[1] = sampler2;
 
-	FrameData *frame = &frameData_[curFrame_];
+	int curFrame = vulkan_->GetCurFrame();
+	FrameData *frame = &frameData_[curFrame];
 	auto iter = frame->descSets.find(key);
 	if (iter != frame->descSets.end()) {
 		return iter->second;

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -104,7 +104,6 @@ private:
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
-	int curFrame_ = 0;
 
 	std::map<PipelineKey, VkPipeline> pipelines_;
 };

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -536,7 +536,6 @@ void VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKRStep &step
 		}
 
 		renderPass = renderPasses_[RPIndex(step.render.color, step.render.depthStencil)];
-		// VLOG("Switching framebuffer to FBO (fc=%d, cmd=%x, rp=%x)", frameNum_, (int)(uintptr_t)cmd_, (int)(uintptr_t)renderPass);
 		if (step.render.color == VKRRenderPassAction::CLEAR) {
 			Uint8x4ToFloat4(clearVal[0].color.float32, step.render.clearColor);
 			numClearVals = 1;

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -54,16 +54,16 @@ void VulkanQueueRunner::InitBackbufferRenderPass() {
 	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-	attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;  // We don't want to preserve the backbuffer between frames so we really don't care.
+	attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;  // We only render once to the backbuffer per frame so we can do this here.
 	attachments[0].flags = 0;
 
 	attachments[1].format = vulkan_->GetDeviceInfo().preferredDepthStencilFormat;  // must use this same format later for the back depth buffer.
 	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;  // Don't care about storing backbuffer Z - we clear it anyway.
 	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	attachments[1].flags = 0;

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -68,7 +68,7 @@ void VulkanQueueRunner::InitBackbufferRenderPass() {
 	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	attachments[1].flags = 0;
 
-	VkAttachmentReference color_reference = {};
+	VkAttachmentReference color_reference{};
 	color_reference.attachment = 0;
 	color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -76,7 +76,7 @@ void VulkanQueueRunner::InitBackbufferRenderPass() {
 	depth_reference.attachment = 1;
 	depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkSubpassDescription subpass = {};
+	VkSubpassDescription subpass{};
 	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 	subpass.flags = 0;
 	subpass.inputAttachmentCount = 0;
@@ -88,14 +88,23 @@ void VulkanQueueRunner::InitBackbufferRenderPass() {
 	subpass.preserveAttachmentCount = 0;
 	subpass.pPreserveAttachments = nullptr;
 
-	VkRenderPassCreateInfo rp_info = { VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO };
-	rp_info.pNext = nullptr;
+	// For the built-in layout transitions.
+	VkSubpassDependency dep{};
+	dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+	dep.dstSubpass = 0;
+	dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	dep.srcAccessMask = 0;
+	dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+	dep.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+	VkRenderPassCreateInfo rp_info{ VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO };
 	rp_info.attachmentCount = 2;
 	rp_info.pAttachments = attachments;
 	rp_info.subpassCount = 1;
 	rp_info.pSubpasses = &subpass;
-	rp_info.dependencyCount = 0;
-	rp_info.pDependencies = nullptr;
+	rp_info.dependencyCount = 1;
+	rp_info.pDependencies = &dep;
 
 	res = vkCreateRenderPass(vulkan_->GetDevice(), &rp_info, nullptr, &backbufferRenderPass_);
 	assert(res == VK_SUCCESS);
@@ -112,7 +121,7 @@ void VulkanQueueRunner::InitRenderpasses() {
 	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-	attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;  // TODO: Look into auto-transitioning to SAMPLED when appropriate.
 	attachments[0].flags = 0;
 
 	attachments[1].format = vulkan_->GetDeviceInfo().preferredDepthStencilFormat;
@@ -125,15 +134,15 @@ void VulkanQueueRunner::InitRenderpasses() {
 	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	attachments[1].flags = 0;
 
-	VkAttachmentReference color_reference = {};
+	VkAttachmentReference color_reference{};
 	color_reference.attachment = 0;
 	color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-	VkAttachmentReference depth_reference = {};
+	VkAttachmentReference depth_reference{};
 	depth_reference.attachment = 1;
 	depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkSubpassDescription subpass = {};
+	VkSubpassDescription subpass{};
 	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 	subpass.flags = 0;
 	subpass.inputAttachmentCount = 0;
@@ -145,13 +154,12 @@ void VulkanQueueRunner::InitRenderpasses() {
 	subpass.preserveAttachmentCount = 0;
 	subpass.pPreserveAttachments = nullptr;
 
-	VkRenderPassCreateInfo rp = { VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO };
+	VkRenderPassCreateInfo rp{ VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO };
 	rp.attachmentCount = 2;
 	rp.pAttachments = attachments;
 	rp.subpassCount = 1;
 	rp.pSubpasses = &subpass;
 	rp.dependencyCount = 0;
-	rp.pDependencies = nullptr;
 
 	for (int depth = 0; depth < 3; depth++) {
 		switch ((VKRRenderPassAction)depth) {
@@ -199,6 +207,73 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, const std::vector<VKRStep 
 		}
 		delete steps[i];
 	}
+}
+
+void VulkanQueueRunner::LogSteps(const std::vector<VKRStep *> &steps) {
+	ILOG("=======================================");
+	for (int i = 0; i < steps.size(); i++) {
+		const VKRStep &step = *steps[i];
+		switch (step.stepType) {
+		case VKRStepType::RENDER:
+			LogRenderPass(step);
+			break;
+		case VKRStepType::COPY:
+			LogCopy(step);
+			break;
+		case VKRStepType::BLIT:
+			LogBlit(step);
+			break;
+		case VKRStepType::READBACK:
+			LogReadback(step);
+			break;
+		}
+	}
+}
+
+void VulkanQueueRunner::LogRenderPass(const VKRStep &pass) {
+	int fb = (int)(intptr_t)(pass.render.framebuffer ? pass.render.framebuffer->framebuf : 0);
+	ILOG("RenderPass Begin(%x)", fb);
+	for (auto &cmd : pass.commands) {
+		switch (cmd.cmd) {
+		case VKRRenderCommand::BIND_PIPELINE:
+			ILOG("  BindPipeline(%x)", (int)(intptr_t)cmd.pipeline.pipeline);
+			break;
+		case VKRRenderCommand::BLEND:
+			ILOG("  Blend(%f, %f, %f, %f)", cmd.blendColor.color[0], cmd.blendColor.color[1], cmd.blendColor.color[2], cmd.blendColor.color[3]);
+			break;
+		case VKRRenderCommand::CLEAR:
+			ILOG("  Clear");
+			break;
+		case VKRRenderCommand::DRAW:
+			ILOG("  Draw(%d)", cmd.draw.count);
+			break;
+		case VKRRenderCommand::DRAW_INDEXED:
+			ILOG("  DrawIndexed(%d)", cmd.drawIndexed.count);
+			break;
+		case VKRRenderCommand::SCISSOR:
+			ILOG("  Scissor(%d, %d, %d, %d)", (int)cmd.scissor.scissor.offset.x, (int)cmd.scissor.scissor.offset.y, (int)cmd.scissor.scissor.extent.width, (int)cmd.scissor.scissor.extent.height);
+			break;
+		case VKRRenderCommand::STENCIL:
+			ILOG("  Stencil(ref=%d, compare=%d, write=%d)", cmd.stencil.stencilRef, cmd.stencil.stencilCompareMask, cmd.stencil.stencilWriteMask);
+			break;
+		case VKRRenderCommand::VIEWPORT:
+			ILOG("  Viewport(%f, %f, %f, %f, %f, %f)", cmd.viewport.vp.x, cmd.viewport.vp.y, cmd.viewport.vp.width, cmd.viewport.vp.height, cmd.viewport.vp.minDepth, cmd.viewport.vp.maxDepth);
+			break;
+		}
+	}
+	ILOG("RenderPass End(%x)", fb);
+}
+
+void VulkanQueueRunner::LogCopy(const VKRStep &pass) {
+	ILOG("Copy()");
+}
+
+void VulkanQueueRunner::LogBlit(const VKRStep &pass) {
+	ILOG("Blit()");
+}
+
+void VulkanQueueRunner::LogReadback(const VKRStep &pass) {
+	ILOG("Readback");
 }
 
 void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer cmd) {

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -141,6 +141,7 @@ public:
 		backbuffer_ = fb;
 	}
 	void RunSteps(VkCommandBuffer cmd, const std::vector<VKRStep *> &steps);
+	void LogSteps(const std::vector<VKRStep *> &steps);
 
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
@@ -167,6 +168,11 @@ private:
 	void PerformCopy(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformBlit(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformReadback(const VKRStep &pass, VkCommandBuffer cmd);
+
+	void LogRenderPass(const VKRStep &pass);
+	void LogCopy(const VKRStep &pass);
+	void LogBlit(const VKRStep &pass);
+	void LogReadback(const VKRStep &pass);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -555,6 +555,8 @@ void VulkanRenderManager::Finish() {
 }
 
 // Can be called multiple times with no bad side effects. This is so that we can either begin a frame the normal way,
+// or stop it in the middle for a synchronous readback, then start over again mostly normally but without repeating
+// the backbuffer image acquisition.
 void VulkanRenderManager::BeginSubmitFrame(int frame) {
 	FrameData &frameData = frameData_[frame];
 	if (!frameData.hasBegun) {


### PR DESCRIPTION
- Fixes depal with low-bit-depth palettes.
- Optimizes the backbuffer render pass to not write back the depth buffer (slight speedup on mobile).
- Fixes a few potential data races due to locking of texture data that might be in flight.
- Works around a video flickering issue caused by my descriptor optimization by turning it off.

