### PR TITLE
Remove the old style multithreading

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -406,7 +406,6 @@ static bool DefaultSasThread() {
 
 static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("CPUCore", &g_Config.iCpuCore, &DefaultCpuCore, true, true),
-	ReportedConfigSetting("SeparateCPUThread", &g_Config.bSeparateCPUThread, false, true, true),
 	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, &DefaultSasThread, true, true),
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -132,8 +132,6 @@ public:
 	bool bFuncReplacements;
 	bool bHideSlowWarnings;
 
-	// Definitely cannot be changed while game is running.
-	bool bSeparateCPUThread;
 	bool bSeparateSASThread;
 	bool bSeparateIOThread;
 	int iIOTimingMethod;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -251,20 +251,18 @@ void __GeDoState(PointerWrap &p) {
 void __GeShutdown() {
 }
 
-// Warning: may be called from the GPU thread, if there is a separate one (multithread mode).
 bool __GeTriggerSync(GPUSyncType type, int id, u64 atTicks) {
 	u64 userdata = (u64)id << 32 | (u64)type;
 	s64 future = atTicks - CoreTiming::GetTicks();
 	if (type == GPU_SYNC_DRAW) {
-		s64 left = CoreTiming::UnscheduleThreadsafeEvent(geSyncEvent, userdata);
+		s64 left = CoreTiming::UnscheduleEvent(geSyncEvent, userdata);
 		if (left > future)
 			future = left;
 	}
-	CoreTiming::ScheduleEvent_Threadsafe(future, geSyncEvent, userdata);
+	CoreTiming::ScheduleEvent(future, geSyncEvent, userdata);
 	return true;
 }
 
-// Warning: may be called from the GPU thread, if there is a separate one (multithread mode).
 bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks) {
 	GeInterruptData intrdata;
 	intrdata.listid = listid;
@@ -274,7 +272,7 @@ bool __GeTriggerInterrupt(int listid, u32 pc, u64 atTicks) {
 	ge_pending_cb.push_back(intrdata);
 
 	u64 userdata = (u64)listid << 32 | (u64) pc;
-	CoreTiming::ScheduleEvent_Threadsafe(atTicks - CoreTiming::GetTicks(), geInterruptEvent, userdata);
+	CoreTiming::ScheduleEvent(atTicks - CoreTiming::GetTicks(), geInterruptEvent, userdata);
 	return true;
 }
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -193,13 +193,12 @@ static void __GeExecuteInterrupt(u64 userdata, int cyclesLate) {
 	__TriggerInterrupt(PSP_INTR_IMMEDIATE, PSP_GE_INTR, PSP_INTR_SUB_NONE);
 }
 
+// Should we still do this?
 static void __GeCheckCycles(u64 userdata, int cyclesLate) {
 	u64 geTicks = gpu->GetTickEstimate();
 	if (geTicks != 0) {
 		if (CoreTiming::GetTicks() > geTicks + usToCycles(geBehindThresholdUs)) {
 			u64 diff = CoreTiming::GetTicks() - geTicks;
-			// Let the GPU thread catch up.
-			gpu->SyncThread();
 			CoreTiming::Advance();
 		}
 	}
@@ -504,7 +503,6 @@ static int sceGeUnsetCallback(u32 cbID) {
 // unless some insane game pokes it and relies on it...
 u32 sceGeSaveContext(u32 ctxAddr) {
 	DEBUG_LOG(SCEGE, "sceGeSaveContext(%08x)", ctxAddr);
-	gpu->SyncThread();
 
 	if (gpu->BusyDrawing()) {
 		WARN_LOG(SCEGE, "sceGeSaveContext(%08x): lists in process, aborting", ctxAddr);
@@ -524,7 +522,6 @@ u32 sceGeSaveContext(u32 ctxAddr) {
 
 u32 sceGeRestoreContext(u32 ctxAddr) {
 	DEBUG_LOG(SCEGE, "sceGeRestoreContext(%08x)", ctxAddr);
-	gpu->SyncThread();
 
 	if (gpu->BusyDrawing()) {
 		WARN_LOG(SCEGE, "sceGeRestoreContext(%08x): lists in process, aborting", ctxAddr);

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -400,6 +400,7 @@ void SoftwareTransform(
 	// rectangle out of many. Quite a small optimization though.
 	// Experiment: Disable on PowerVR (see issue #6290)
 	// TODO: This bleeds outside the play area in non-buffered mode. Big deal? Probably not.
+	// TODO: Allow creating a depth clear and a color draw.
 	bool reallyAClear = false;
 	if (maxIndex > 1 && prim == GE_PRIM_RECTANGLES && gstate.isModeClear()) {
 		int scissorX2 = gstate.getScissorX2() + 1;

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <map>
 #include <d3d11.h>
 #include <d3d11_1.h>
 
@@ -190,7 +191,8 @@ private:
 	PushBufferD3D11 *pushVerts_;
 	PushBufferD3D11 *pushInds_;
 
-	// D3D11 state object caches
+	// D3D11 state object caches.
+	// TODO: Change them to DenseHashMaps.
 	std::map<uint64_t, ID3D11BlendState *> blendCache_;
 	std::map<uint64_t, ID3D11BlendState1 *> blendCache1_;
 	std::map<uint64_t, ID3D11DepthStencilState *> depthStencilCache_;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -338,13 +338,6 @@ void GPU_D3D11::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat f
 }
 
 bool GPU_D3D11::FramebufferDirty() {
-	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-	if (ThreadEnabled()) {
-		// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-		ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
@@ -353,15 +346,8 @@ bool GPU_D3D11::FramebufferDirty() {
 	}
 	return true;
 }
-bool GPU_D3D11::FramebufferReallyDirty() {
-	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-	if (ThreadEnabled()) {
-		// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-		ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
 
+bool GPU_D3D11::FramebufferReallyDirty() {
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -286,7 +286,7 @@ void GPU_D3D11::DeviceRestore() {
 	// Nothing needed.
 }
 
-void GPU_D3D11::InitClearInternal() {
+void GPU_D3D11::InitClear() {
 	bool useNonBufferedRendering = g_Config.iRenderingMode == FB_NON_BUFFERED_MODE;
 	if (useNonBufferedRendering) {
 		// device_->Clear(0, NULL, D3DCLEAR_STENCIL | D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.f, 0);
@@ -305,8 +305,8 @@ void GPU_D3D11::BeginHostFrame() {
 	}
 }
 
-void GPU_D3D11::ReapplyGfxStateInternal() {
-	GPUCommon::ReapplyGfxStateInternal();
+void GPU_D3D11::ReapplyGfxState() {
+	GPUCommon::ReapplyGfxState();
 
 	// TODO: Dirty our caches for depth states etc
 }
@@ -316,8 +316,8 @@ void GPU_D3D11::EndHostFrame() {
 	draw_->BindPipeline(nullptr);
 }
 
-void GPU_D3D11::BeginFrameInternal() {
-	GPUCommon::BeginFrameInternal();
+void GPU_D3D11::BeginFrame() {
+	GPUCommon::BeginFrame();
 
 	textureCacheD3D11_->StartFrame();
 	drawEngine_.BeginFrame();
@@ -357,7 +357,7 @@ bool GPU_D3D11::FramebufferReallyDirty() {
 	return true;
 }
 
-void GPU_D3D11::CopyDisplayToOutputInternal() {
+void GPU_D3D11::CopyDisplayToOutput() {
 	float blendColor[4]{};
 	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0xF], blendColor, 0xFFFFFFFF);
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -40,7 +40,7 @@ public:
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
-	void ReapplyGfxStateInternal() override;
+	void ReapplyGfxState() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void ClearCacheNextFrame() override;
@@ -96,9 +96,9 @@ private:
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 
-	void InitClearInternal() override;
-	void BeginFrameInternal() override;
-	void CopyDisplayToOutputInternal() override;
+	void InitClear() override;
+	void BeginFrame() override;
+	void CopyDisplayToOutput() override;
 
 	ID3D11Device *device_;
 	ID3D11DeviceContext *context_;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -251,7 +251,7 @@ void GPU_DX9::DeviceRestore() {
 	// Nothing needed.
 }
 
-void GPU_DX9::InitClearInternal() {
+void GPU_DX9::InitClear() {
 	bool useNonBufferedRendering = g_Config.iRenderingMode == FB_NON_BUFFERED_MODE;
 	if (useNonBufferedRendering) {
 		dxstate.depthWrite.set(true);
@@ -272,12 +272,12 @@ void GPU_DX9::BeginHostFrame() {
 	}
 }
 
-void GPU_DX9::ReapplyGfxStateInternal() {
+void GPU_DX9::ReapplyGfxState() {
 	dxstate.Restore();
-	GPUCommon::ReapplyGfxStateInternal();
+	GPUCommon::ReapplyGfxState();
 }
 
-void GPU_DX9::BeginFrameInternal() {
+void GPU_DX9::BeginFrame() {
 	// Turn off vsync when unthrottled
 	int desiredVSyncInterval = g_Config.bVSync ? 1 : 0;
 	if ((PSP_CoreParameter().unthrottle) || (PSP_CoreParameter().fpsLimit == 1))
@@ -292,7 +292,7 @@ void GPU_DX9::BeginFrameInternal() {
 	depalShaderCache_.Decimate();
 	// fragmentTestCache_.Decimate();
 
-	GPUCommon::BeginFrameInternal();
+	GPUCommon::BeginFrame();
 	shaderManagerDX9_->DirtyShader();
 
 	framebufferManager_->BeginFrame();
@@ -323,7 +323,7 @@ bool GPU_DX9::FramebufferReallyDirty() {
 	return true;
 }
 
-void GPU_DX9::CopyDisplayToOutputInternal() {
+void GPU_DX9::CopyDisplayToOutput() {
 	dxstate.depthWrite.set(true);
 	dxstate.colorMask.set(true, true, true, true);
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -304,13 +304,6 @@ void GPU_DX9::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat for
 }
 
 bool GPU_DX9::FramebufferDirty() {
-	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-	if (ThreadEnabled()) {
-		// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-		ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
@@ -319,15 +312,8 @@ bool GPU_DX9::FramebufferDirty() {
 	}
 	return true;
 }
-bool GPU_DX9::FramebufferReallyDirty() {
-	// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-	if (ThreadEnabled()) {
-		// FIXME: Workaround for displaylists sometimes hanging unprocessed.  Not yet sure of the cause.
-		ScheduleEvent(GPU_EVENT_PROCESS_QUEUE);
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
 
+bool GPU_DX9::FramebufferReallyDirty() {
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -41,7 +41,7 @@ public:
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
-	void ReapplyGfxStateInternal() override;
+	void ReapplyGfxState() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void ClearCacheNextFrame() override;
@@ -96,9 +96,9 @@ private:
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 
-	void InitClearInternal() override;
-	void BeginFrameInternal() override;
-	void CopyDisplayToOutputInternal() override;
+	void InitClear() override;
+	void BeginFrame() override;
+	void CopyDisplayToOutput() override;
 
 	LPDIRECT3DDEVICE9 device_;
 	LPDIRECT3DDEVICE9EX deviceEx_;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -504,11 +504,6 @@ void GPU_GLES::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat fo
 }
 
 bool GPU_GLES::FramebufferDirty() {
-	if (ThreadEnabled()) {
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
-
 	VirtualFramebuffer *vfb = framebufferManagerGL_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
@@ -519,11 +514,6 @@ bool GPU_GLES::FramebufferDirty() {
 }
 
 bool GPU_GLES::FramebufferReallyDirty() {
-	if (ThreadEnabled()) {
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
-
 	VirtualFramebuffer *vfb = framebufferManagerGL_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -401,13 +401,14 @@ void GPU_GLES::DeviceRestore() {
 	UpdateVsyncInterval(true);
 }
 
-void GPU_GLES::ReinitializeInternal() {
+void GPU_GLES::Reinitialize() {
+	GPUCommon::Reinitialize();
 	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
 	framebufferManagerGL_->DestroyAllFBOs();
 }
 
-void GPU_GLES::InitClearInternal() {
+void GPU_GLES::InitClear() {
 	bool useNonBufferedRendering = g_Config.iRenderingMode == FB_NON_BUFFERED_MODE;
 	if (useNonBufferedRendering) {
 		glstate.depthWrite.set(GL_TRUE);
@@ -467,13 +468,13 @@ void GPU_GLES::UpdateCmdInfo() {
 	}
 }
 
-void GPU_GLES::ReapplyGfxStateInternal() {
+void GPU_GLES::ReapplyGfxState() {
 	drawEngine_.RestoreVAO();
 	glstate.Restore();
-	GPUCommon::ReapplyGfxStateInternal();
+	GPUCommon::ReapplyGfxState();
 }
 
-void GPU_GLES::BeginFrameInternal() {
+void GPU_GLES::BeginFrame() {
 	UpdateVsyncInterval(resized_);
 	resized_ = false;
 
@@ -483,7 +484,7 @@ void GPU_GLES::BeginFrameInternal() {
 	depalShaderCache_.Decimate();
 	fragmentTestCache_.Decimate();
 
-	GPUCommon::BeginFrameInternal();
+	GPUCommon::BeginFrame();
 
 	// Save the cache from time to time. TODO: How often?
 	if (!shaderCachePath_.empty() && (gpuStats.numFlips & 1023) == 0) {
@@ -523,7 +524,7 @@ bool GPU_GLES::FramebufferReallyDirty() {
 	return true;
 }
 
-void GPU_GLES::CopyDisplayToOutputInternal() {
+void GPU_GLES::CopyDisplayToOutput() {
 	// Flush anything left over.
 	framebufferManagerGL_->RebindFramebuffer();
 	drawEngine_.Flush();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -41,7 +41,7 @@ public:
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
-	void ReapplyGfxStateInternal() override;
+	void ReapplyGfxState() override;
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void GetStats(char *buffer, size_t bufsize) override;
 
@@ -95,10 +95,10 @@ private:
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
 
-	void InitClearInternal() override;
-	void BeginFrameInternal() override;
-	void CopyDisplayToOutputInternal() override;
-	void ReinitializeInternal() override;
+	void InitClear() override;
+	void BeginFrame() override;
+	void CopyDisplayToOutput() override;
+	void Reinitialize() override;
 
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1028,53 +1028,6 @@ inline void GPUCommon::UpdateState(GPURunState state) {
 		downcount = 0;
 }
 
-void GPUCommon::ProcessEvent(GPUEvent ev) {
-	switch (ev.type) {
-	case GPU_EVENT_PROCESS_QUEUE:
-		ProcessDLQueueInternal();
-		break;
-
-	case GPU_EVENT_REAPPLY_GFX_STATE:
-		ReapplyGfxStateInternal();
-		break;
-
-	case GPU_EVENT_INIT_CLEAR:
-		InitClearInternal();
-		break;
-
-	case GPU_EVENT_BEGIN_FRAME:
-		BeginFrameInternal();
-		break;
-
-	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
-		CopyDisplayToOutputInternal();
-		break;
-
-	case GPU_EVENT_INVALIDATE_CACHE:
-		InvalidateCacheInternal(ev.invalidate_cache.addr, ev.invalidate_cache.size, ev.invalidate_cache.type);
-		break;
-
-	case GPU_EVENT_FB_MEMCPY:
-		PerformMemoryCopyInternal(ev.fb_memcpy.dst, ev.fb_memcpy.src, ev.fb_memcpy.size);
-		break;
-
-	case GPU_EVENT_FB_MEMSET:
-		PerformMemorySetInternal(ev.fb_memset.dst, ev.fb_memset.v, ev.fb_memset.size);
-		break;
-
-	case GPU_EVENT_FB_STENCIL_UPLOAD:
-		PerformStencilUploadInternal(ev.fb_stencil_upload.dst, ev.fb_stencil_upload.size);
-		break;
-
-	case GPU_EVENT_REINITIALIZE:
-		break;
-
-	default:
-		ERROR_LOG_REPORT(G3D, "Unexpected GPU event type: %d", (int)ev);
-		break;
-	}
-}
-
 int GPUCommon::GetNextListIndex() {
 	auto iter = dlQueue.begin();
 	if (iter != dlQueue.end()) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -359,11 +359,11 @@ GPUCommon::GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw) :
 	// The compiler was not rounding the struct size up to an 8 byte boundary, which
 	// you'd expect due to the int64 field, but the Linux ABI apparently does not require that.
 	static_assert(sizeof(DisplayList) == 456, "Bad DisplayList size");
-	listLock.set_enabled(g_Config.bSeparateCPUThread);
+	listLock.set_enabled(false);
 
 	Reinitialize();
 	SetupColorConv();
-	SetThreadEnabled(g_Config.bSeparateCPUThread);
+	SetThreadEnabled(false);
 	gstate.Reset();
 	gstate_c.Reset();
 	gpuStats.Reset();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -395,7 +395,6 @@ void GPUCommon::Reinitialize() {
 	busyTicks = 0;
 	timeSpentStepping_ = 0.0;
 	interruptsEnabled_ = true;
-	curTickEst_ = 0;
 }
 
 int GPUCommon::EstimatePerVertexCost() {
@@ -1023,7 +1022,6 @@ int GPUCommon::GetNextListIndex() {
 void GPUCommon::ProcessDLQueue() {
 	startingTicks = CoreTiming::GetTicks();
 	cyclesExecuted = 0;
-	curTickEst_ = std::max(busyTicks, startingTicks + cyclesExecuted);
 
 	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {
@@ -1042,7 +1040,6 @@ void GPUCommon::ProcessDLQueue() {
 				// At the end, we can remove it from the queue and continue.
 				dlQueue.erase(std::remove(dlQueue.begin(), dlQueue.end(), listIndex), dlQueue.end());
 			}
-			curTickEst_ = std::max(busyTicks, startingTicks + cyclesExecuted);
 		}
 	}
 
@@ -1052,7 +1049,6 @@ void GPUCommon::ProcessDLQueue() {
 	busyTicks = std::max(busyTicks, drawCompleteTicks);
 	__GeTriggerSync(GPU_SYNC_DRAW, 1, drawCompleteTicks);
 	// Since the event is in CoreTiming, we're in sync.  Just set 0 now.
-	curTickEst_ = 0;
 }
 
 void GPUCommon::PreExecuteOp(u32 op, u32 diff) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -404,7 +404,7 @@ void GPUCommon::Reinitialize() {
 	busyTicks = 0;
 	timeSpentStepping_ = 0.0;
 	interruptsEnabled_ = true;
-	UpdateTickEstimate(0);
+	curTickEst_ = 0;
 	ScheduleEvent(GPU_EVENT_REINITIALIZE);
 }
 
@@ -1107,7 +1107,7 @@ bool GPUCommon::ProcessDLQueue() {
 void GPUCommon::ProcessDLQueueInternal() {
 	startingTicks = CoreTiming::GetTicks();
 	cyclesExecuted = 0;
-	UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
+	curTickEst_ = std::max(busyTicks, startingTicks + cyclesExecuted);
 
 	// Seems to be correct behaviour to process the list anyway?
 	if (startingTicks < busyTicks) {
@@ -1126,7 +1126,7 @@ void GPUCommon::ProcessDLQueueInternal() {
 				// At the end, we can remove it from the queue and continue.
 				dlQueue.erase(std::remove(dlQueue.begin(), dlQueue.end(), listIndex), dlQueue.end());
 			}
-			UpdateTickEstimate(std::max(busyTicks, startingTicks + cyclesExecuted));
+			curTickEst_ = std::max(busyTicks, startingTicks + cyclesExecuted);
 		}
 	}
 
@@ -1136,7 +1136,7 @@ void GPUCommon::ProcessDLQueueInternal() {
 	busyTicks = std::max(busyTicks, drawCompleteTicks);
 	__GeTriggerSync(GPU_SYNC_DRAW, 1, drawCompleteTicks);
 	// Since the event is in CoreTiming, we're in sync.  Just set 0 now.
-	UpdateTickEstimate(0);
+	curTickEst_ = 0;
 }
 
 void GPUCommon::PreExecuteOp(u32 op, u32 diff) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -127,10 +127,6 @@ public:
 	// Note: Not virtual!
 	inline void Flush();
 
-	u64 GetTickEstimate() override {
-		return curTickEst_;
-	}
-
 #ifdef USE_CRT_DBG
 #undef new
 #endif
@@ -290,8 +286,6 @@ protected:
 	GEPrimitiveType lastPrim_;
 
 private:
-	u64 curTickEst_;
-
 	// Debug stats.
 	double timeSteppingStarted_;
 	double timeSpentStepping_;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -251,8 +251,6 @@ protected:
 	virtual void ReapplyGfxStateInternal();
 	virtual void FastLoadBoneMatrix(u32 target);
 
-	void ProcessEvent(GPUEvent ev);
-
 	// TODO: Unify this.
 	virtual void FinishDeferred() {}
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -66,7 +66,7 @@ public:
 	void PreExecuteOp(u32 op, u32 diff) override;
 
 	bool InterpretList(DisplayList &list) override;
-	virtual bool ProcessDLQueue();
+	void ProcessDLQueue();
 	u32  UpdateStall(int listid, u32 newstall) override;
 	u32  EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head) override;
 	u32  DequeueList(int listid) override;
@@ -79,8 +79,8 @@ public:
 	u32  Break(int mode) override;
 	void ReapplyGfxState() override;
 
-	void CopyDisplayToOutput() override;
-	void InitClear() override;
+	void CopyDisplayToOutput() override = 0;
+	void InitClear() override = 0;
 	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
 	bool PerformMemorySet(u32 dest, u8 v, int size) override;
 	bool PerformMemoryDownload(u32 dest, int size) override;
@@ -105,10 +105,6 @@ public:
 	void Execute_BoundingBox(u32 op, u32 diff);
 	void Execute_BlockTransferStart(u32 op, u32 diff);
 
-	void Execute_TexScaleU(u32 op, u32 diff);
-	void Execute_TexScaleV(u32 op, u32 diff);
-	void Execute_TexOffsetU(u32 op, u32 diff);
-	void Execute_TexOffsetV(u32 op, u32 diff);
 	void Execute_TexLevel(u32 op, u32 diff);
 
 	void Execute_WorldMtxNum(u32 op, u32 diff);
@@ -233,11 +229,7 @@ protected:
 		}
 	}
 
-	virtual void InitClearInternal() {}
 	void BeginFrame() override;
-	virtual void BeginFrameInternal();
-	virtual void CopyDisplayToOutputInternal() {}
-	virtual void ReinitializeInternal() {}
 
 	// To avoid virtual calls to PreExecuteOp().
 	virtual void FastRunLoop(DisplayList &list) = 0;
@@ -247,8 +239,6 @@ protected:
 	void PopDLQueue();
 	void CheckDrawSync();
 	int  GetNextListIndex();
-	void ProcessDLQueueInternal();
-	virtual void ReapplyGfxStateInternal();
 	virtual void FastLoadBoneMatrix(u32 target);
 
 	// TODO: Unify this.
@@ -264,11 +254,6 @@ protected:
 			gstate_c.vertexAddr += bytesRead;
 		}
 	}
-
-	void PerformMemoryCopyInternal(u32 dest, u32 src, int size);
-	void PerformMemorySetInternal(u32 dest, u8 v, int size);
-	void PerformStencilUploadInternal(u32 dest, int size);
-	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
 	FramebufferManagerCommon *framebufferManager_;
 	TextureCacheCommon *textureCache_;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -251,7 +251,6 @@ protected:
 	virtual void ReapplyGfxStateInternal();
 	virtual void FastLoadBoneMatrix(u32 target);
 
-	void ScheduleEvent(GPUEventType event);
 	void ProcessEvent(GPUEvent ev);
 
 	// TODO: Unify this.

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -294,48 +294,6 @@ protected:
 	void PerformStencilUploadInternal(u32 dest, int size);
 	void InvalidateCacheInternal(u32 addr, int size, GPUInvalidationType type);
 
-	// This mutex can be disabled, which is useful for single core mode.
-	class optional_mutex {
-	public:
-		optional_mutex() : enabled_(true) {}
-		void set_enabled(bool enabled) {
-			enabled_ = enabled;
-		}
-		void lock() {
-			if (enabled_)
-				mutex_.lock();
-		}
-		void unlock() {
-			if (enabled_)
-				mutex_.unlock();
-		}
-	private:
-		std::mutex mutex_;
-		bool enabled_;
-	};
-
-
-	// Allows early unlocking with a guard.  Do not double unlock.
-	class easy_guard {
-	public:
-		easy_guard(optional_mutex &mtx) : mtx_(mtx), locked_(true) { mtx_.lock(); }
-		~easy_guard() {
-			if (locked_)
-				mtx_.unlock();
-		}
-		void unlock() {
-			if (locked_)
-				mtx_.unlock();
-			else
-				Crash();
-			locked_ = false;
-		}
-
-	private:
-		optional_mutex &mtx_;
-		bool locked_;
-	};
-
 	FramebufferManagerCommon *framebufferManager_;
 	TextureCacheCommon *textureCache_;
 	DrawEngineCommon *drawEngineCommon_;
@@ -350,7 +308,6 @@ protected:
 	DisplayList dls[DisplayListMaxCount];
 	DisplayList *currentList;
 	DisplayListQueue dlQueue;
-	optional_mutex listLock;
 
 	bool interruptRunning;
 	GPURunState gpuState;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -155,56 +155,6 @@ enum GPUInvalidationType {
 	GPU_INVALIDATE_SAFE,
 };
 
-enum GPUEventType {
-	GPU_EVENT_INVALID,
-	GPU_EVENT_PROCESS_QUEUE,
-	GPU_EVENT_INIT_CLEAR,
-	GPU_EVENT_BEGIN_FRAME,
-	GPU_EVENT_COPY_DISPLAY_TO_OUTPUT,
-	GPU_EVENT_REAPPLY_GFX_STATE,
-	GPU_EVENT_INVALIDATE_CACHE,
-	GPU_EVENT_FINISH_EVENT_LOOP,
-	GPU_EVENT_SYNC_THREAD,
-	GPU_EVENT_FB_MEMCPY,
-	GPU_EVENT_FB_MEMSET,
-	GPU_EVENT_FB_STENCIL_UPLOAD,
-	GPU_EVENT_REINITIALIZE,
-};
-
-struct GPUEvent {
-	GPUEvent(GPUEventType t) : type(t) {}
-	GPUEventType type;
-	union {
-		// GPU_EVENT_INVALIDATE_CACHE
-		struct {
-			u32 addr;
-			int size;
-			GPUInvalidationType type;
-		} invalidate_cache;
-		// GPU_EVENT_FB_MEMCPY
-		struct {
-			u32 dst;
-			u32 src;
-			int size;
-		} fb_memcpy;
-		// GPU_EVENT_FB_MEMSET
-		struct {
-			u32 dst;
-			u8 v;
-			int size;
-		} fb_memset;
-		// GPU_EVENT_FB_STENCIL_UPLOAD
-		struct {
-			u32 dst;
-			int size;
-		} fb_stencil_upload;
-	};
-
-	operator GPUEventType() const {
-		return type;
-	}
-};
-
 namespace Draw {
 class DrawContext;
 }

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -223,7 +223,6 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore() = 0;
 	virtual void ReapplyGfxState() = 0;
-	virtual u64  GetTickEstimate() = 0;
 	virtual void DoState(PointerWrap &p) = 0;
 
 	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -225,10 +225,6 @@ public:
 	virtual void BeginHostFrame() = 0;
 	virtual void EndHostFrame() = 0;
 
-	// Events
-	virtual void RunEventsUntil(u64 globalticks) = 0;
-	virtual void FinishEventLoop() = 0;
-
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;
 	// TODO: Much of this should probably be shared between the different GPU implementations.
@@ -277,8 +273,6 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore() = 0;
 	virtual void ReapplyGfxState() = 0;
-	virtual void SyncThread(bool force = false) = 0;
-	virtual void SyncBeginFrame() = 0;
 	virtual u64  GetTickEstimate() = 0;
 	virtual void DoState(PointerWrap &p) = 0;
 
@@ -289,7 +283,6 @@ public:
 	virtual bool FramebufferDirty() = 0;
 	virtual bool FramebufferReallyDirty() = 0;
 	virtual bool BusyDrawing() = 0;
-	virtual void SetThreadEnabled(bool threadEnabled) = 0;
 
 	// If any jit is being used inside the GPU.
 	virtual bool DescribeCodePtr(const u8 *ptr, std::string &name) = 0;

--- a/GPU/Null/NullGpu.h
+++ b/GPU/Null/NullGpu.h
@@ -40,6 +40,7 @@ public:
 	bool PerformMemoryUpload(u32 dest, int size) override;
 	bool PerformStencilUpload(u32 dest, int size) override;
 	void ClearCacheNextFrame() override {}
+	bool FramebufferDirty() override { return true; }
 
 	void DeviceLost() override {}
 	void DeviceRestore() override {}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -913,11 +913,6 @@ bool SoftGPU::PerformStencilUpload(u32 dest, int size)
 }
 
 bool SoftGPU::FramebufferDirty() {
-	if (g_Config.bSeparateCPUThread) {
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
-
 	if (g_Config.iFrameSkip != 0) {
 		bool dirty = framebufferDirty_;
 		framebufferDirty_ = false;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -28,6 +28,7 @@
 #include "Core/HLE/sceGe.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/Reporting.h"
+#include "Core/Core.h"
 #include "profiler/profiler.h"
 #include "thin3d/thin3d.h"
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -281,13 +281,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 	draw_->BindIndexBuffer(nullptr, 0);
 }
 
-void SoftGPU::CopyDisplayToOutput()
-{
-	CopyDisplayToOutputInternal();
-}
-
-void SoftGPU::CopyDisplayToOutputInternal()
-{
+void SoftGPU::CopyDisplayToOutput() {
 	// The display always shows 480x272.
 	CopyToCurrentFboFromDisplayRam(FB_WIDTH, FB_HEIGHT);
 	framebufferDirty_ = false;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -283,7 +283,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 
 void SoftGPU::CopyDisplayToOutput()
 {
-	ScheduleEvent(GPU_EVENT_COPY_DISPLAY_TO_OUTPUT);
+	CopyDisplayToOutputInternal();
 }
 
 void SoftGPU::CopyDisplayToOutputInternal()
@@ -299,17 +299,6 @@ void SoftGPU::CopyDisplayToOutputInternal()
 	} else {
 		PSP_CoreParameter().renderWidth = 480;
 		PSP_CoreParameter().renderHeight = 272;
-	}
-}
-
-void SoftGPU::ProcessEvent(GPUEvent ev) {
-	switch (ev.type) {
-	case GPU_EVENT_COPY_DISPLAY_TO_OUTPUT:
-		CopyDisplayToOutputInternal();
-		break;
-
-	default:
-		GPUCommon::ProcessEvent(ev);
 	}
 }
 

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -97,8 +97,6 @@ protected:
 	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight);
 
 private:
-	void CopyDisplayToOutputInternal() override;
-
 	bool framebufferDirty_;
 	u32 displayFramebuf_;
 	u32 displayStride_;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -94,7 +94,8 @@ public:
 
 protected:
 	void FastRunLoop(DisplayList &list) override;
-	void ProcessEvent(GPUEvent ev) override;
+	void ScheduleEvent(GPUEvent ev) { ProcessEvent(ev); }
+	void ProcessEvent(GPUEvent ev);
 	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight);
 
 private:

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -94,8 +94,6 @@ public:
 
 protected:
 	void FastRunLoop(DisplayList &list) override;
-	void ScheduleEvent(GPUEvent ev) { ProcessEvent(ev); }
-	void ProcessEvent(GPUEvent ev);
 	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight);
 
 private:

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -332,21 +332,17 @@ void GPU_Vulkan::BuildReportingInfo() {
 	Reporting::UpdateConfig();
 }
 
-void GPU_Vulkan::ReinitializeInternal() {
+void GPU_Vulkan::Reinitialize() {
+	GPUCommon::Reinitialize();
 	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
 	framebufferManagerVulkan_->DestroyAllFBOs();
 }
 
-void GPU_Vulkan::InitClearInternal() {
+void GPU_Vulkan::InitClear() {
 	bool useNonBufferedRendering = g_Config.iRenderingMode == FB_NON_BUFFERED_MODE;
 	if (useNonBufferedRendering) {
-		/*
-		glstate.depthWrite.set(GL_TRUE);
-		glstate.colorMask.set(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glClearColor(0, 0, 0, 1);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		*/
+		// TODO?
 	}
 }
 
@@ -389,7 +385,7 @@ bool GPU_Vulkan::FramebufferReallyDirty() {
 	return true;
 }
 
-void GPU_Vulkan::CopyDisplayToOutputInternal() {
+void GPU_Vulkan::CopyDisplayToOutput() {
 	// Flush anything left over.
 	drawEngine_.Flush();
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -370,11 +370,6 @@ void GPU_Vulkan::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat 
 }
 
 bool GPU_Vulkan::FramebufferDirty() {
-	if (ThreadEnabled()) {
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
-
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->dirtyAfterDisplay;
@@ -385,11 +380,6 @@ bool GPU_Vulkan::FramebufferDirty() {
 }
 
 bool GPU_Vulkan::FramebufferReallyDirty() {
-	if (ThreadEnabled()) {
-		// Allow it to process fully before deciding if it's dirty.
-		SyncThread();
-	}
-
 	VirtualFramebuffer *vfb = framebufferManager_->GetDisplayVFB();
 	if (vfb) {
 		bool dirty = vfb->reallyDirtyAfterDisplay;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -96,9 +96,9 @@ private:
 	}
 	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo();
-	void InitClearInternal() override;
-	void CopyDisplayToOutputInternal() override;
-	void ReinitializeInternal() override;
+	void InitClear() override;
+	void CopyDisplayToOutput() override;
+	void Reinitialize() override;
 	inline void UpdateVsyncInterval(bool force);
 	void UpdateCmdInfo();
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -661,13 +661,6 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new CheckBox(&g_Config.bFastMemory, sy->T("Fast Memory", "Fast Memory (Unstable)")))->OnClick.Handle(this, &GameSettingsScreen::OnJitAffectingSetting);
 
-	auto separateCPUThread = new CheckBox(&g_Config.bSeparateCPUThread, sy->T("Multithreaded (experimental)"));
-	systemSettings->Add(separateCPUThread);
-	separateCPUThread->OnClick.Add([=](EventParams &e) {
-		if (g_Config.bSeparateCPUThread)
-			settingInfo_->Show(sy->T("Multithreaded Tip", "Not always faster, causes glitches/crashing"), e.v);
-		return UI::EVENT_CONTINUE;
-	});
 	systemSettings->Add(new CheckBox(&g_Config.bSeparateIOThread, sy->T("I/O on thread (experimental)")))->SetEnabled(!PSP_IsInited());
 	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)", "Simulate UMD delays" };
 	View *ioTimingMethod = systemSettings->Add(new PopupMultiChoice(&g_Config.iIOTimingMethod, sy->T("IO timing method"), ioTimingMethods, 0, ARRAY_SIZE(ioTimingMethods), sy->GetName(), screenManager()));

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -12,7 +12,7 @@
 #endif
 
 // TODO: Using a thread here is unfinished and does not work correctly.
-const bool useThread = false;
+const bool useThread = true;
 
 #ifndef UINT64_MAX
 #define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL


### PR DESCRIPTION
Running the display list interpreter asynchronously is too dangerous, as has been discussed, and at least for Vulkan we now have a much better alternative, which will soon be turned on by default.

The old stuff does work for some games and there might be some people out there relying on it, but the benefit was never huge and the cost in code complexity and synchronization wasn't worth it.

So bye bye, "Multithreading (experimental)". Vulkan with the new multithreading outperforms the other backends so much it's not even funny sometimes.

Following fixes are by making them obsolete. The new multithreading implementation for Vulkan and the planned one for GL will not have these issues.

Fixes #9712
Fixes #8895 
Fixes #7877
Fixes #7774
Fixes #7494
Fixes #6874
Fixes #6612
Fixes #6441
Fixes #6331
Fixes #6096
Fixes #5989
Fixes #5632
Fixes #5127