### PR TITLE
Vulkan: Enable the "accurate depth" codepath, using the same formula as D3D9.

### DIFF
--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -199,6 +199,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	}
 
 	// Mandatory features on Vulkan, which may be checked in "centralized" code
+	features |= GPU_SUPPORTS_ACCURATE_DEPTH;
 	features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
 	features |= GPU_SUPPORTS_FBO;
 	features |= GPU_SUPPORTS_BLEND_MINMAX;


### PR DESCRIPTION
As a side effect, this should fix #10082 since backwards depth is no longer used.