### PR TITLE
Avoid clearing shaders on load state

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -301,7 +301,9 @@ public:
 			} else {
 				// Older save state.  Let's still reload, but this may not pick up new flags, etc.
 				bool foundBroken = false;
-				for (auto func : importedFuncs) {
+				auto importedFuncsState = importedFuncs;
+				importedFuncs.clear();
+				for (auto func : importedFuncsState) {
 					if (func.moduleName[KERNELOBJECT_MAX_NAME_LENGTH] != '\0' || !Memory::IsValidAddress(func.stubAddr)) {
 						foundBroken = true;
 					} else {

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -146,6 +146,8 @@ public:
 
 	void Resized() override;
 
+	void ClearInputLayoutMap();
+
 private:
 	void DecodeVerts();
 	void DoFlush();
@@ -153,8 +155,6 @@ private:
 	void ApplyDrawState(int prim);
 	void ApplyDrawStateLate(bool applyStencilRef, uint8_t stencilRef);
 	void ResetShaderBlending();
-
-	void ClearInputLayoutMap();
 
 	ID3D11InputLayout *SetupDecFmtForDraw(D3D11VertexShader *vshader, const DecVtxFormat &decFmt, u32 pspFmt);
 

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -278,6 +278,7 @@ void GPU_D3D11::DeviceLost() {
 	// Simply drop all caches and textures.
 	// FBOs appear to survive? Or no?
 	shaderManagerD3D11_->ClearShaders();
+	drawEngine_.ClearInputLayoutMap();
 	textureCacheD3D11_->Clear(false);
 	framebufferManagerD3D11_->DeviceLost();
 }
@@ -742,6 +743,7 @@ void GPU_D3D11::ClearCacheNextFrame() {
 
 void GPU_D3D11::ClearShaderCache() {
 	shaderManagerD3D11_->ClearShaders();
+	drawEngine_.ClearInputLayoutMap();
 }
 
 void GPU_D3D11::DoState(PointerWrap &p) {

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -749,13 +749,12 @@ void GPU_D3D11::DoState(PointerWrap &p) {
 
 	// TODO: Some of these things may not be necessary.
 	// None of these are necessary when saving.
-	if (p.mode == p.MODE_READ) {
+	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
 		textureCacheD3D11_->Clear(true);
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 		framebufferManagerD3D11_->DestroyAllFBOs();
-		shaderManagerD3D11_->ClearShaders();
 	}
 }
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -687,7 +687,6 @@ void GPU_DX9::DoState(PointerWrap &p) {
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 		framebufferManagerDX9_->DestroyAllFBOs();
-		shaderManagerDX9_->ClearCache(true);
 	}
 }
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -681,7 +681,7 @@ void GPU_DX9::DoState(PointerWrap &p) {
 
 	// TODO: Some of these things may not be necessary.
 	// None of these are necessary when saving.
-	if (p.mode == p.MODE_READ) {
+	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
 		textureCacheDX9_->Clear(true);
 		drawEngine_.ClearTrackedVertexArrays();
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -930,12 +930,10 @@ void GPU_GLES::DoState(PointerWrap &p) {
 	// In Freeze-Frame mode, we don't want to do any of this.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
 		textureCacheGL_->Clear(true);
-		depalShaderCache_.Clear();
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 		framebufferManagerGL_->DestroyAllFBOs();
-		shaderManagerGL_->ClearCache(true);
 	}
 }
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -897,8 +897,6 @@ void GPU_Vulkan::DoState(PointerWrap &p) {
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 		framebufferManagerVulkan_->DestroyAllFBOs();
-		shaderManagerVulkan_->ClearShaders();
-		pipelineManager_->Clear();
 	}
 }
 


### PR DESCRIPTION
We use vertex shader pointers in our input layout map for D3D11, so they must be cleared when clearing shaders.

But we don't even need to clear shaders on load state, so don't.  We don't really need to do it in any backend - after all, we preload shaders when we can.

Fixes #9637.

-[Unknown]