### PR TITLE
Vulkan: Remove refcounts on VKRFramebuffer.

### DIFF
--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -545,7 +545,9 @@ void Jit::BranchVFPUFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 {
 	CONDITIONAL_LOG;
 	if (js.inDelaySlot) {
-		ERROR_LOG_REPORT(JIT, "Branch in VFPU delay slot at %08x in block starting at %08x", GetCompilerPC(), js.blockStart);
+		// I think we can safely just warn-log this without reporting, it's pretty clear that this type
+		// of branch is ignored.
+		WARN_LOG(JIT, "Branch in VFPU delay slot at %08x in block starting at %08x", GetCompilerPC(), js.blockStart);
 		return;
 	}
 	int offset = _IMM16 << 2;

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -348,7 +348,6 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 			iter.fb->color.layout = barrier.newLayout;
 		}
-		iter.fb->Release();
 	}
 
 	// Don't execute empty renderpasses.
@@ -601,10 +600,6 @@ void VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKRStep &step
 	rp_begin.clearValueCount = numClearVals;
 	rp_begin.pClearValues = numClearVals ? clearVal : nullptr;
 	vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
-
-	if (step.render.framebuffer) {
-		step.render.framebuffer->Release();
-	}
 }
 
 void VulkanQueueRunner::PerformCopy(const VKRStep &step, VkCommandBuffer cmd) {
@@ -678,9 +673,6 @@ void VulkanQueueRunner::PerformCopy(const VKRStep &step, VkCommandBuffer cmd) {
 		}
 		vkCmdCopyImage(cmd, src->depth.image, src->depth.layout, dst->depth.image, dst->depth.layout, 1, &copy);
 	}
-
-	src->Release();
-	dst->Release();
 }
 
 void VulkanQueueRunner::PerformBlit(const VKRStep &step, VkCommandBuffer cmd) {
@@ -764,9 +756,6 @@ void VulkanQueueRunner::PerformBlit(const VKRStep &step, VkCommandBuffer cmd) {
 		}
 		vkCmdBlitImage(cmd, src->depth.image, src->depth.layout, dst->depth.image, dst->depth.layout, 1, &blit, step.blit.filter);
 	}
-
-	src->Release();
-	dst->Release();
 }
 
 void VulkanQueueRunner::SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect) {
@@ -867,8 +856,6 @@ void VulkanQueueRunner::PerformReadback(const VKRStep &step, VkCommandBuffer cmd
 	vkCmdCopyImageToBuffer(cmd, srcImage->image, srcImage->layout, readbackBuffer_, 1, &region);
 
 	// NOTE: Can't read the buffer using the CPU here - need to sync first.
-
-	step.readback.src->Release();
 }
 
 void VulkanQueueRunner::PerformReadbackImage(const VKRStep &step, VkCommandBuffer cmd) {

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -29,7 +29,6 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 class VKRFramebuffer {
 public:
 	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRenderPass renderPass, int _width, int _height) : vulkan_(vk) {
-		refcount_ = 1;
 		width = _width;
 		height = _height;
 
@@ -50,6 +49,7 @@ public:
 
 		vkCreateFramebuffer(vulkan_->GetDevice(), &fbci, nullptr, &framebuf);
 	}
+
 	~VKRFramebuffer() {
 		vulkan_->Delete().QueueDeleteImage(color.image);
 		vulkan_->Delete().QueueDeleteImage(depth.image);
@@ -60,11 +60,6 @@ public:
 		vulkan_->Delete().QueueDeleteFramebuffer(framebuf);
 	}
 
-	void AddRef() {
-		refcount_++;
-	}
-	bool Release();
-
 	int numShadows = 1;  // TODO: Support this.
 
 	VkFramebuffer framebuf = VK_NULL_HANDLE;
@@ -73,9 +68,7 @@ public:
 	int width = 0;
 	int height = 0;
 
-private:
 	VulkanContext *vulkan_;
-	std::atomic<int> refcount_;
 };
 
 enum class VKRRunType {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1258,7 +1258,6 @@ public:
 	}
 	VKRFramebuffer *GetFB() const { return buf_; }
 private:
-	VulkanContext *vulkan_;  // Unfortunate to have to keep this in each VKFramebuffer.
 	VKRFramebuffer *buf_;
 };
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1251,10 +1251,14 @@ public:
 	// Inherits ownership so no AddRef.
 	VKFramebuffer(VKRFramebuffer *fb) : buf_(fb) {}
 	~VKFramebuffer() {
-		buf_->Release();
+		buf_->vulkan_->Delete().QueueCallback([](void *fb) {
+			VKRFramebuffer *vfb = static_cast<VKRFramebuffer *>(fb);
+			delete vfb;
+		}, buf_);
 	}
 	VKRFramebuffer *GetFB() const { return buf_; }
 private:
+	VulkanContext *vulkan_;  // Unfortunate to have to keep this in each VKFramebuffer.
 	VKRFramebuffer *buf_;
 };
 


### PR DESCRIPTION
@unknownbrackets  Noticed a framebuffer refcount leak, and changed my mind  :) Let's do it this way instead, should be just as reliable, I think.

Sorry I had you do all the refcount stuff...
