### PR TITLE
Vulkan: Cut down on asserts during init

### DIFF
--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -141,7 +141,7 @@ public:
 	void InitSurfaceAndroid(ANativeWindow *native_window, int width, int height);
 	void ReinitSurfaceAndroid(int width, int height);
 #endif
-	void InitQueue();
+	bool InitQueue();
 	bool InitObjects();
 	bool InitSwapchain();
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -177,7 +177,7 @@ void GameSettingsScreen::CreateViews() {
 	tabHolder->AddTab(ms->T("Graphics"), graphicsSettingsScroll);
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Rendering Mode")));
-	static const char *renderingBackend[] = { "OpenGL", "Direct3D 9", "Direct3D 11", "Vulkan (experimental)" };
+	static const char *renderingBackend[] = { "OpenGL", "Direct3D 9", "Direct3D 11", "Vulkan" };
 	PopupMultiChoice *renderingBackendChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iGPUBackend, gr->T("Backend"), renderingBackend, GPU_BACKEND_OPENGL, ARRAY_SIZE(renderingBackend), gr->GetName(), screenManager()));
 	renderingBackendChoice->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingBackend);
 #if !PPSSPP_PLATFORM(WINDOWS)

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -56,6 +56,7 @@
 
 #include "base/stringutil.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/VulkanRenderManager.h"
 #include "util/text/parsers.h"
 #include "Windows/GPU/WindowsVulkanContext.h"
 
@@ -204,6 +205,12 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	bool success = draw_->CreatePresets();
 	assert(success);  // Doesn't fail, we include the compiler.
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+
+	VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	if (!renderManager->HasBackbuffers()) {
+		Shutdown();
+		return false;
+	}
 	return true;
 }
 

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -204,9 +204,13 @@ public:
 	void CreateBackbuffers();
 	void DestroyBackbuffers();
 
+	bool HasBackbuffers() {
+		return !framebuffers_.empty();
+	}
+
 private:
-	void InitBackbufferFramebuffers(int width, int height);
-	void InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
+	bool InitBackbufferFramebuffers(int width, int height);
+	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
 	void BeginSubmitFrame(int frame);
 	void EndSubmitFrame(int frame);
 	void Submit(int frame, bool triggerFence);


### PR DESCRIPTION
In an attempt to better prevent any hard startup crashes.

Also, remove "(experimental)" from Vulkan.  See also hrydgard/ppsspp-lang#627.

-[Unknown]