### PR TITLE
Improve Video/Audio dumps naming and add option to reset recording on save/load state

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -34,6 +34,10 @@ extern "C" {
 
 #include "GPU/Common/GPUDebugInterface.h"
 
+#include "Core/ELF/ParamSFO.h"
+#include "Core/HLE/sceKernelTime.h"
+#include "StringUtils.h"
+
 #ifdef USE_FFMPEG
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)
@@ -86,10 +90,16 @@ bool AVIDump::CreateAVI() {
 #ifdef USE_FFMPEG
 	AVCodec* codec = nullptr;
 
+	// Use gameID_EmulatedTimestamp for filename
+	std::string discID = g_paramSFO.GetDiscID();
+	std::string video_file_name = StringFromFormat("%s%s_%d.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID, returnEmulatedTime()).c_str();
+
 	s_format_context = avformat_alloc_context();
 	std::stringstream s_file_index_str;
-	s_file_index_str << s_file_index;
-	snprintf(s_format_context->filename, sizeof(s_format_context->filename), "%s", (GetSysDirectory(DIRECTORY_VIDEO) + "framedump" + s_file_index_str.str() + ".avi").c_str());
+	s_file_index_str << video_file_name;
+
+	snprintf(s_format_context->filename, sizeof(s_format_context->filename), "%s", s_file_index_str.str().c_str());
+	INFO_LOG(COMMON, "Recording Video to: %s", s_format_context->filename);
 	// Make sure that the path exists
 	if (!File::Exists(GetSysDirectory(DIRECTORY_VIDEO)))
 		File::CreateDir(GetSysDirectory(DIRECTORY_VIDEO));

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -92,7 +92,7 @@ bool AVIDump::CreateAVI() {
 
 	// Use gameID_EmulatedTimestamp for filename
 	std::string discID = g_paramSFO.GetDiscID();
-	std::string video_file_name = StringFromFormat("%s%s_%d.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
+	std::string video_file_name = StringFromFormat("%s%s_%d.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID.c_str(), KernelTimeNow()).c_str();
 
 	s_format_context = avformat_alloc_context();
 	std::stringstream s_file_index_str;

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -92,7 +92,7 @@ bool AVIDump::CreateAVI() {
 
 	// Use gameID_EmulatedTimestamp for filename
 	std::string discID = g_paramSFO.GetDiscID();
-	std::string video_file_name = StringFromFormat("%s%s_%d.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID, returnEmulatedTime()).c_str();
+	std::string video_file_name = StringFromFormat("%s%s_%d.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
 
 	s_format_context = avformat_alloc_context();
 	std::stringstream s_file_index_str;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -360,6 +360,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("UseFFV1", &g_Config.bUseFFV1, false),
 	ConfigSetting("DumpFrames", &g_Config.bDumpFrames, false),
 	ConfigSetting("DumpAudio", &g_Config.bDumpAudio, false),
+	ConfigSetting("SaveLoadResetsAVdumping", &g_Config.bSaveLoadResetsAVdumping, false),
 	ConfigSetting("StateSlot", &g_Config.iCurrentStateSlot, 0, true, true),
 	ConfigSetting("RewindFlipFrequency", &g_Config.iRewindFlipFrequency, 0, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -105,6 +105,7 @@ public:
 	bool bUseFFV1;
 	bool bDumpFrames;
 	bool bDumpAudio;
+	bool bSaveLoadResetsAVdumping;
 	bool bEnableLogging;
 	bool bDumpDecryptedEboot;
 	bool bFullscreenOnDoubleclick;

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -35,6 +35,9 @@
 #include "Core/System.h"
 #ifndef MOBILE_DEVICE
 #include "Core/WaveFile.h"
+#include "Core/ELF/ParamSFO.h"
+#include "Core/HLE/sceKernelTime.h"
+#include "StringUtils.h"
 #endif
 #include "Core/HLE/__sceAudio.h"
 #include "Core/HLE/sceAudio.h"
@@ -383,9 +386,13 @@ void __AudioUpdate() {
 #ifndef MOBILE_DEVICE
 		if (!m_logAudio) {
 			if (g_Config.bDumpAudio) {
-				std::string audio_file_name = GetSysDirectory(DIRECTORY_AUDIO) + "audiodump.wav";
+				// Use gameID_EmulatedTimestamp for filename
+				std::string discID = g_paramSFO.GetDiscID();
+				std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID, returnEmulatedTime()).c_str();
+				INFO_LOG(COMMON,"Recording audio to: %s", audio_file_name.c_str());
 				// Create the path just in case it doesn't exist
-				File::CreateDir(GetSysDirectory(DIRECTORY_AUDIO));
+				if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))
+					File::CreateDir(GetSysDirectory(DIRECTORY_AUDIO));
 				File::CreateEmptyFile(audio_file_name);
 				__StartLogAudio(audio_file_name);
 			}

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -387,7 +387,7 @@ void __AudioUpdate(bool resetRecording) {
 		if (g_Config.bSaveLoadResetsAVdumping && resetRecording) {
 			__StopLogAudio();
 			std::string discID = g_paramSFO.GetDiscID();
-			std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
+			std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), KernelTimeNow()).c_str();
 			INFO_LOG(COMMON, "Restarted audio recording to: %s", audio_file_name.c_str());
 			if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))
 				File::CreateDir(GetSysDirectory(DIRECTORY_AUDIO));
@@ -398,7 +398,7 @@ void __AudioUpdate(bool resetRecording) {
 			if (g_Config.bDumpAudio) {
 				// Use gameID_EmulatedTimestamp for filename
 				std::string discID = g_paramSFO.GetDiscID();
-				std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
+				std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), KernelTimeNow()).c_str();
 				INFO_LOG(COMMON,"Recording audio to: %s", audio_file_name.c_str());
 				// Create the path just in case it doesn't exist
 				if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -387,7 +387,7 @@ void __AudioUpdate(bool resetRecording) {
 		if (g_Config.bSaveLoadResetsAVdumping && resetRecording) {
 			__StopLogAudio();
 			std::string discID = g_paramSFO.GetDiscID();
-			std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID, returnEmulatedTime()).c_str();
+			std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
 			INFO_LOG(COMMON, "Restarted audio recording to: %s", audio_file_name.c_str());
 			if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))
 				File::CreateDir(GetSysDirectory(DIRECTORY_AUDIO));
@@ -398,7 +398,7 @@ void __AudioUpdate(bool resetRecording) {
 			if (g_Config.bDumpAudio) {
 				// Use gameID_EmulatedTimestamp for filename
 				std::string discID = g_paramSFO.GetDiscID();
-				std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID, returnEmulatedTime()).c_str();
+				std::string audio_file_name = StringFromFormat("%s%s_%d.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), returnEmulatedTime()).c_str();
 				INFO_LOG(COMMON,"Recording audio to: %s", audio_file_name.c_str());
 				// Create the path just in case it doesn't exist
 				if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -33,7 +33,7 @@ struct AudioDebugStats {
 
 void __AudioInit();
 void __AudioDoState(PointerWrap &p);
-void __AudioUpdate();
+void __AudioUpdate(bool resetRecording = false);
 void __AudioShutdown();
 void __AudioSetOutputFrequency(int freq);
 
@@ -49,3 +49,9 @@ void __PushExternalAudio(const s32 *audio, int numSamples);  // Should not be us
 // Audio Dumping stuff
 void __StartLogAudio(const std::string& filename);
 void __StopLogAudio();
+
+class WAVDump
+{
+public:
+	static void Reset();
+};

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -171,3 +171,7 @@ u32 sceKernelLibcGettimeofday(u32 timeAddr, u32 tzAddr)
 	hleReSchedule("libc timeofday");
 	return 0;
 }
+
+u32 returnEmulatedTime() {
+	return (u32)start_time + (u32)(CoreTiming::GetGlobalTimeUs() / 1000000ULL);
+}

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -172,6 +172,6 @@ u32 sceKernelLibcGettimeofday(u32 timeAddr, u32 tzAddr)
 	return 0;
 }
 
-u32 returnEmulatedTime() {
+u32 KernelTimeNow() {
 	return (u32)start_time + (u32)(CoreTiming::GetGlobalTimeUs() / 1000000ULL);
 }

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -27,6 +27,7 @@ int sceKernelSysClock2USec(u32 sysclockPtr, u32 highPtr, u32 lowPtr);
 int sceKernelSysClock2USecWide(u32 lowClock, u32 highClock, u32 lowPtr, u32 highPtr);
 u64 sceKernelUSec2SysClockWide(u32 usec);
 u32 sceKernelLibcClock();
+u32 returnEmulatedTime();
 
 void __KernelTimeInit();
 void __KernelTimeDoState(PointerWrap &p);

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -27,7 +27,7 @@ int sceKernelSysClock2USec(u32 sysclockPtr, u32 highPtr, u32 lowPtr);
 int sceKernelSysClock2USecWide(u32 lowClock, u32 highClock, u32 lowPtr, u32 highPtr);
 u64 sceKernelUSec2SysClockWide(u32 usec);
 u32 sceKernelLibcClock();
-u32 returnEmulatedTime();
+u32 KernelTimeNow();
 
 void __KernelTimeInit();
 void __KernelTimeDoState(PointerWrap &p);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -49,9 +49,6 @@
 #ifndef MOBILE_DEVICE
 #include "Core/AVIDump.h"
 #include "Core/HLE/__sceAudio.h"
-
-AVIDump video;
-WAVDump audio;
 #endif
 
 namespace SaveState
@@ -602,11 +599,11 @@ namespace SaveState
 #ifndef MOBILE_DEVICE
 					if (g_Config.bSaveLoadResetsAVdumping) {
 						if (g_Config.bDumpFrames) {
-							video.Stop();
-							video.Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+							AVIDump::Stop();
+							AVIDump::Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 						}
 						if (g_Config.bDumpAudio) {
-							audio.Reset();
+							WAVDump::Reset();
 						}
 					}
 #endif
@@ -637,11 +634,11 @@ namespace SaveState
 #ifndef MOBILE_DEVICE
 					if (g_Config.bSaveLoadResetsAVdumping) {
 						if (g_Config.bDumpFrames) {
-							video.Stop();
-							video.Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+							AVIDump::Stop();
+							AVIDump::Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 						}
 						if (g_Config.bDumpAudio) {
-							audio.Reset();
+							WAVDump::Reset();
 						}
 					}
 #endif

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -46,6 +46,14 @@
 #include "HW/MemoryStick.h"
 #include "GPU/GPUState.h"
 
+#ifndef MOBILE_DEVICE
+#include "Core/AVIDump.h"
+#include "Core/HLE/__sceAudio.h"
+
+AVIDump video;
+WAVDump audio;
+#endif
+
 namespace SaveState
 {
 	struct SaveStart
@@ -591,6 +599,17 @@ namespace SaveState
 					callbackMessage = sc->T("Loaded State");
 					callbackResult = true;
 					hasLoadedState = true;
+#ifndef MOBILE_DEVICE
+					if (g_Config.bSaveLoadResetsAVdumping) {
+						if (g_Config.bDumpFrames) {
+							video.Stop();
+							video.Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+						}
+						if (g_Config.bDumpAudio) {
+							audio.Reset();
+						}
+					}
+#endif
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					HandleFailure();
 					callbackMessage = i18nLoadFailure;
@@ -615,6 +634,17 @@ namespace SaveState
 				if (result == CChunkFileReader::ERROR_NONE) {
 					callbackMessage = sc->T("Saved State");
 					callbackResult = true;
+#ifndef MOBILE_DEVICE
+					if (g_Config.bSaveLoadResetsAVdumping) {
+						if (g_Config.bDumpFrames) {
+							video.Stop();
+							video.Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+						}
+						if (g_Config.bDumpAudio) {
+							audio.Reset();
+						}
+					}
+#endif
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					HandleFailure();
 					callbackMessage = i18nSaveFailure;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -79,7 +79,7 @@
 #endif
 
 #ifndef MOBILE_DEVICE
-AVIDump avi;
+static AVIDump avi;
 #endif
 
 static bool frameStep_;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -781,6 +781,7 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new CheckBox(&g_Config.bDumpFrames, sy->T("Record Display")));
 	systemSettings->Add(new CheckBox(&g_Config.bUseFFV1, sy->T("Use Lossless Video Codec (FFV1)")));
 	systemSettings->Add(new CheckBox(&g_Config.bDumpAudio, sy->T("Record Audio")));
+	systemSettings->Add(new CheckBox(&g_Config.bSaveLoadResetsAVdumping, sy->T("Reset Recording on Save/Load State")));
 #endif
 	systemSettings->Add(new CheckBox(&g_Config.bDayLightSavings, sy->T("Day Light Saving")));
 	static const char *dateFormat[] = { "YYYYMMDD", "MMDDYYYY", "DDMMYYYY"};


### PR DESCRIPTION
 It might not be optimal, so pointing ugly code that could be improved is welcome:P.
 As far as I tested it works. I think I read some post complaining about avi dumping feature crashing earlier, but forgot where, might need some fixes on it's own, it didn't crashed to me while testing, but I only really ran it on some boot screens.

 Guess this fixes #10099
~ Better naming is probably worth implementing on it's own, generic filenames are just bad.