### PR TITLE
Add missing ID for CTTR compat hack.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -145,6 +145,7 @@ UCES00373 = true
 # Crash Tag Team Racing needs it to pass checking memory stick screen.
 ULUS10044 = true
 ULES00168 = true
+ULES00172 = true
 ULJM05036 = true
 # Gundam Battle Royale might need it to avoid crashes when certain Ace enemies shows up
 ULJS00083 = true


### PR DESCRIPTION
Fixes #9806 

I remember adding this hack myself, and took ID's from gamefaqs release data ~ apparently they have incomplete info:P.