### PR TITLE
Mipmaps: Disable slope mode pending a better method. Implementing it entirely as a LOD bias is not the way it works.

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -228,6 +228,7 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 				break;
 			}
 		case GE_TEXLEVEL_MODE_CONST:
+		case GE_TEXLEVEL_MODE_UNKNOWN:
 			key.maxLevel = (int)(lodBias * 256.0f);
 			key.minLevel = (int)(lodBias * 256.0f);
 			key.lodBias = 0;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -142,14 +142,15 @@ static int TexLog2(float delta) {
 	return useful - 127 * 256;
 }
 
-void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, bool &autoMip) {
+void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, GETexLevelMode &mode) {
 	minFilt = gstate.texfilter & 0x7;
 	magFilt = gstate.isMagnifyFilteringEnabled();
 	sClamp = gstate.isTexCoordClampedS();
 	tClamp = gstate.isTexCoordClampedT();
 
 	GETexLevelMode mipMode = gstate.getTexLevelMode();
-	autoMip = mipMode == GE_TEXLEVEL_MODE_AUTO;
+	mode = mipMode;
+	bool autoMip = mipMode == GE_TEXLEVEL_MODE_AUTO;
 	lodBias = (float)gstate.getTexLevelOffset16() * (1.0f / 16.0f);
 	if (mipMode == GE_TEXLEVEL_MODE_SLOPE) {
 		lodBias += 1.0f + TexLog2(gstate.getTextureLodSlope()) * (1.0f / 256.0f);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -211,6 +211,7 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	key.magFilt = magFilt & 1;
 	key.sClamp = sClamp;
 	key.tClamp = tClamp;
+	key.aniso = false;
 
 	if (!key.mipEnable) {
 		key.maxLevel = 0;
@@ -222,7 +223,10 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 			key.maxLevel = entry.maxLevel * 256;
 			key.minLevel = 0;
 			key.lodBias = (int)(lodBias * 256.0f);
-			break;
+			if (gstate_c.Supports(GPU_SUPPORTS_ANISOTROPY) && g_Config.iAnisotropyLevel > 0) {
+				key.aniso = true;
+				break;
+			}
 		case GE_TEXLEVEL_MODE_CONST:
 			key.maxLevel = (int)(lodBias * 256.0f);
 			key.minLevel = (int)(lodBias * 256.0f);
@@ -232,7 +236,7 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 			// It's incorrect to use the slope as a bias. Instead it should be passed
 			// into the shader directly as an explicit lod level, with the bias on top. For now, we just kill the
 			// lodBias in this mode, working around #9772.
-			key.maxLevel = entry.maxLevel;
+			key.maxLevel = entry.maxLevel * 256;
 			key.minLevel = 0;
 			key.lodBias = 0;
 			break;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -142,7 +142,7 @@ static int TexLog2(float delta) {
 	return useful - 127 * 256;
 }
 
-void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, GETexLevelMode &mode) {
+void TextureCacheCommon::GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel, u32 addr, GETexLevelMode &mode) {
 	minFilt = gstate.texfilter & 0x7;
 	magFilt = gstate.isMagnifyFilteringEnabled();
 	sClamp = gstate.isTexCoordClampedS();
@@ -202,7 +202,7 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	u8 maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
+	int maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
 	GETexLevelMode mode;
 	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, mode);
 	key.minFilt = minFilt & 1;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -229,15 +229,15 @@ void TextureCacheCommon::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 			key.lodBias = 0;
 			break;
 		case GE_TEXLEVEL_MODE_SLOPE:
-			// Just do the normal thing without bias.
+			// It's incorrect to use the slope as a bias. Instead it should be passed
+			// into the shader directly as an explicit lod level, with the bias on top. For now, we just kill the
+			// lodBias in this mode, working around #9772.
 			key.maxLevel = entry.maxLevel;
 			key.minLevel = 0;
 			key.lodBias = 0;
 			break;
 		}
 	}
-
-	// TODO: Support lod bias stuff
 
 	if (entry.framebuffer) {
 		WARN_LOG_REPORT_ONCE(wrongFramebufAttach, G3D, "Framebuffer still attached in UpdateSamplingParams()?");

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -244,7 +244,7 @@ protected:
 	}
 
 	u32 EstimateTexMemoryUsage(const TexCacheEntry *entry);
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, GETexLevelMode &mode);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, int maxLevel, u32 addr, GETexLevelMode &mode);
 	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);  // Used by D3D11 and Vulkan.
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -72,6 +72,7 @@ struct SamplerCacheKey {
 			bool magFilt : 1;
 			bool sClamp : 1;
 			bool tClamp : 1;
+			bool aniso : 1;
 		};
 	};
 	bool operator < (const SamplerCacheKey &other) const {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -58,25 +58,22 @@ class DrawContext;
 
 // Used by D3D11 and Vulkan, could be used by modern GL
 struct SamplerCacheKey {
-	SamplerCacheKey() : fullKey(0) {}
-
 	union {
-		u32 fullKey;
+		uint64_t fullKey;
 		struct {
+			// These are 8.8 fixed point.
+			int16_t maxLevel;
+			int16_t minLevel;
+			int16_t lodBias;
+
 			bool mipEnable : 1;
 			bool minFilt : 1;
 			bool mipFilt : 1;
 			bool magFilt : 1;
 			bool sClamp : 1;
 			bool tClamp : 1;
-			bool lodAuto : 1;
-			bool : 1;
-			int8_t maxLevel : 4;
-			int8_t : 4;
-			int16_t lodBias : 16;
 		};
 	};
-
 	bool operator < (const SamplerCacheKey &other) const {
 		return fullKey < other.fullKey;
 	}
@@ -248,6 +245,7 @@ protected:
 
 	u32 EstimateTexMemoryUsage(const TexCacheEntry *entry);
 	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, GETexLevelMode &mode);
+	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);  // Used by D3D11 and Vulkan.
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -247,7 +247,7 @@ protected:
 	}
 
 	u32 EstimateTexMemoryUsage(const TexCacheEntry *entry);
-	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, bool &autoMip);
+	void GetSamplingParams(int &minFilt, int &magFilt, bool &sClamp, bool &tClamp, float &lodBias, u8 maxLevel, u32 addr, GETexLevelMode &mode);
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
 	bool AttachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset = 0);

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -176,16 +176,6 @@ GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	// Some of our defaults are different from hw defaults, let's assert them.
 	// We restore each frame anyway, but here is convenient for tests.
 	textureCache_->NotifyConfigChanged();
-
-	if (g_Config.bHardwareTessellation) {
-		if (false) { // TODO: Check GPU features
-			// Disable hardware tessellation.
-			g_Config.bHardwareTessellation = false;
-			ERROR_LOG(G3D, "Hardware Tessellation is unsupported, falling back to software tessellation");
-			I18NCategory *gr = GetI18NCategory("Graphics");
-			host->NotifyUserMessage(gr->T("Turn off Hardware Tessellation - unsupported"), 2.5f, 0xFF3030FF);
-		}
-	}
 }
 
 GPU_D3D11::~GPU_D3D11() {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -176,19 +176,33 @@ void TextureCacheD3D11::UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheK
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
+	GETexLevelMode mode;
 	u8 maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, autoMip);
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, mode);
 	key.minFilt = minFilt & 1;
 	key.mipEnable = (minFilt >> 2) & 1;
 	key.mipFilt = (minFilt >> 1) & 1;
 	key.magFilt = magFilt & 1;
 	key.sClamp = sClamp;
 	key.tClamp = tClamp;
+	switch (mode) {
+	case GE_TEXLEVEL_MODE_AUTO:
+		key.lodBias = (int)(lodBias * 256.0f);
+		key.maxLevel = maxLevel;
+		key.lodAuto = true;
+		break;
+	case GE_TEXLEVEL_MODE_CONST:
+		key.lodBias = 0;
+		key.maxLevel = maxLevel;
+		key.lodAuto = false;
+		break;
+	case GE_TEXLEVEL_MODE_SLOPE:
+		key.lodBias = 0;
+		key.maxLevel = maxLevel;
+		key.lodAuto = true;
+		break;
+	}
 	// Don't clamp to maxLevel - this may bias magnify levels.
-	key.lodBias = (int)(lodBias * 256.0f);
-	key.maxLevel = maxLevel;
-	key.lodAuto = autoMip;
 
 	if (entry.framebuffer) {
 		WARN_LOG_REPORT_ONCE(wrongFramebufAttach, G3D, "Framebuffer still attached in UpdateSamplingParams()?");
@@ -201,8 +215,8 @@ void TextureCacheD3D11::SetFramebufferSamplingParams(u16 bufferWidth, u16 buffer
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, mode);
 
 	key.minFilt = minFilt & 1;
 	key.mipFilt = 0;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -64,7 +64,7 @@ ID3D11SamplerState *SamplerCacheD3D11::GetOrCreateSampler(ID3D11Device *device, 
 	samp.AddressU = key.sClamp ? D3D11_TEXTURE_ADDRESS_CLAMP : D3D11_TEXTURE_ADDRESS_WRAP;
 	samp.AddressV = key.tClamp ? D3D11_TEXTURE_ADDRESS_CLAMP : D3D11_TEXTURE_ADDRESS_WRAP;
 	samp.AddressW = samp.AddressU;  // Mali benefits from all clamps being the same, and this one is irrelevant.
-	if (gstate_c.Supports(GPU_SUPPORTS_ANISOTROPY) && g_Config.iAnisotropyLevel > 0) {
+	if (key.aniso) {
 		samp.MaxAnisotropy = (float)(1 << g_Config.iAnisotropyLevel);
 	} else {
 		samp.MaxAnisotropy = 1.0f;
@@ -81,7 +81,7 @@ ID3D11SamplerState *SamplerCacheD3D11::GetOrCreateSampler(ID3D11Device *device, 
 		D3D11_FILTER_MIN_MAG_MIP_LINEAR,
 	};
 	// Only switch to aniso if linear min and mag are set.
-	if (samp.MaxAnisotropy > 1.0f && key.magFilt != 0 && key.minFilt != 0)
+	if (key.aniso && key.magFilt != 0 && key.minFilt != 0)
 		samp.Filter = D3D11_FILTER_ANISOTROPIC;
 	else
 		samp.Filter = filters[filterKey];

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -289,7 +289,7 @@ void TextureCacheD3D11::BindTexture(TexCacheEntry *entry) {
 		context_->PSSetShaderResources(0, 1, &textureView);
 		lastBoundTexture = textureView;
 	}
-	SamplerCacheKey key;
+	SamplerCacheKey key{};
 	UpdateSamplingParams(*entry, key);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, key);
 	context_->PSSetSamplers(0, 1, &state);
@@ -469,7 +469,7 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 		framebufferManagerD3D11_->RebindFramebuffer();  // Probably not necessary.
 	}
-	SamplerCacheKey samplerKey;
+	SamplerCacheKey samplerKey{};
 	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, samplerKey);
 	context_->PSSetSamplers(0, 1, &state);

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -72,7 +72,6 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);
 	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int maxLevel, bool replaceImages, int scaleFactor, DXGI_FORMAT dstFmt);
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	TexCacheEntry::Status CheckAlpha(const u32 *pixelData, u32 dstFmt, int stride, int w, int h);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -154,19 +154,22 @@ void TextureCacheDX9::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
+	GETexLevelMode mode;
 	u8 maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, autoMip);
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, mode);
 
 	if (maxLevel != 0) {
-		if (autoMip) {
-			dxstate.texMaxMipLevel.set(0);
+		if (mode == GE_TEXLEVEL_MODE_AUTO) {
+			dxstate.texMaxMipLevel.set(maxLevel);
 			dxstate.texMipLodBias.set(lodBias);
-		} else {
+		} else if (mode == GE_TEXLEVEL_MODE_CONST) {
 			// TODO: This is just an approximation - texMaxMipLevel sets the lowest numbered mip to use.
 			// Unfortunately, this doesn't support a const 1.5 or etc.
 			dxstate.texMaxMipLevel.set(std::max(0, std::min((int)maxLevel, (int)lodBias)));
 			dxstate.texMipLodBias.set(-1000.0f);
+		} else {  // if (mode == GE_TEXLEVEL_MODE_SLOPE{
+			dxstate.texMaxMipLevel.set(maxLevel);
+			dxstate.texMipLodBias.set(0.0f);
 		}
 		entry.lodBias = lodBias;
 	} else {
@@ -195,8 +198,8 @@ void TextureCacheDX9::SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHe
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, mode);
 
 	dxstate.texMinFilter.set(MinFilt[minFilt]);
 	dxstate.texMipFilter.set(MipFilt[minFilt]);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -160,7 +160,7 @@ void TextureCacheDX9::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 
 	if (maxLevel != 0) {
 		if (mode == GE_TEXLEVEL_MODE_AUTO) {
-			dxstate.texMaxMipLevel.set(maxLevel);
+			dxstate.texMaxMipLevel.set(0);
 			dxstate.texMipLodBias.set(lodBias);
 		} else if (mode == GE_TEXLEVEL_MODE_CONST) {
 			// TODO: This is just an approximation - texMaxMipLevel sets the lowest numbered mip to use.
@@ -168,7 +168,7 @@ void TextureCacheDX9::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 			dxstate.texMaxMipLevel.set(std::max(0, std::min((int)maxLevel, (int)lodBias)));
 			dxstate.texMipLodBias.set(-1000.0f);
 		} else {  // if (mode == GE_TEXLEVEL_MODE_SLOPE{
-			dxstate.texMaxMipLevel.set(maxLevel);
+			dxstate.texMaxMipLevel.set(0);
 			dxstate.texMipLodBias.set(0.0f);
 		}
 		entry.lodBias = lodBias;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -148,9 +148,11 @@ void TextureCacheGLES::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, std::max(0.0f, std::min((float)maxLevel, lodBias)));
 				} else {  // mode == GE_TEXLEVEL_MODE_SLOPE) {
 					// It's incorrect to use the slope as a bias. Instead it should be passed
-					// into the shader directly as an explicit lod level. For now, we just kill the
+					// into the shader directly as an explicit lod level, with the bias on top. For now, we just kill the
 					// lodBias in this mode, working around #9772.
+#ifndef USING_GLES2
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, 0.0f);
+#endif
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_LOD, 0);
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)maxLevel);
 				}

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -128,24 +128,31 @@ void TextureCacheGLES::UpdateSamplingParams(TexCacheEntry &entry, bool force) {
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
 	u8 maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, mode);
 
 	if (gstate_c.Supports(GPU_SUPPORTS_TEXTURE_LOD_CONTROL)) {
 		if (maxLevel != 0) {
 			// TODO: What about a swap of autoMip mode?
 			if (force || entry.lodBias != lodBias) {
-				if (autoMip) {
+				if (mode == GE_TEXLEVEL_MODE_AUTO) {
 #ifndef USING_GLES2
 					// Sigh, LOD_BIAS is not even in ES 3.0.. but we could do it in the shader via texture()...
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, lodBias);
 #endif
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_LOD, 0);
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)maxLevel);
-				} else {
+				} else if (mode == GE_TEXLEVEL_MODE_CONST) {
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_LOD, std::max(0.0f, std::min((float)maxLevel, lodBias)));
 					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, std::max(0.0f, std::min((float)maxLevel, lodBias)));
+				} else {  // mode == GE_TEXLEVEL_MODE_SLOPE) {
+					// It's incorrect to use the slope as a bias. Instead it should be passed
+					// into the shader directly as an explicit lod level. For now, we just kill the
+					// lodBias in this mode, working around #9772.
+					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, 0.0f);
+					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_LOD, 0);
+					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, (float)maxLevel);
 				}
 				entry.lodBias = lodBias;
 			}
@@ -185,8 +192,8 @@ void TextureCacheGLES::SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferH
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, mode);
 
 	minFilt &= 1;  // framebuffers can't mipmap.
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -100,9 +100,9 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 		samp.maxAnisotropy = 1.0f;
 		samp.anisotropyEnable = false;
 	}
-	samp.maxLod = (float)key.maxLevel / 256.0f;
-	samp.minLod = (float)key.minLevel / 256.0f;
-	samp.mipLodBias = key.lodBias / 256.0f;
+	samp.maxLod = (float)(int32_t)key.maxLevel * (1.0f / 256.0f);
+	samp.minLod = (float)(int32_t)key.minLevel * (1.0f / 256.0f);
+	samp.mipLodBias = (float)(int32_t)key.lodBias * (1.0f / 256.0f);
 
 	VkResult res = vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &sampler);
 	assert(res == VK_SUCCESS);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -102,7 +102,7 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 		samp.anisotropyEnable = false;
 	}
 
-	samp.maxLod = key.maxLevel;
+	samp.maxLod = 0; // key.maxLevel;
 	samp.minLod = 0.0f;
 	samp.mipLodBias = 0.0f;
 
@@ -217,9 +217,9 @@ void TextureCacheVulkan::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
 	u8 maxLevel = (entry.status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry.maxLevel;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, maxLevel, entry.addr, mode);
 	key.minFilt = minFilt & 1;
 	key.mipEnable = (minFilt >> 2) & 1;
 	key.mipFilt = (minFilt >> 1) & 1;
@@ -227,20 +227,7 @@ void TextureCacheVulkan::UpdateSamplingParams(TexCacheEntry &entry, SamplerCache
 	key.sClamp = sClamp;
 	key.tClamp = tClamp;
 	key.maxLevel = entry.vkTex->texture_->GetNumMips() - 1;
-	/*
-	if (entry.maxLevel != 0) {
-		if (force || entry.lodBias != lodBias) {
-			if (gstate_c.Supports(GPU_SUPPORTS_TEXTURE_LOD_CONTROL)) {
-				if (autoMip) {
-					// TODO
-				} else {
-					// TODO
-				}
-			}
-			entry.lodBias = lodBias;
-		}
-	}
-	*/
+	// TODO: Support lod bias stuff
 
 	if (entry.framebuffer) {
 		WARN_LOG_REPORT_ONCE(wrongFramebufAttach, G3D, "Framebuffer still attached in UpdateSamplingParams()?");
@@ -253,8 +240,8 @@ void TextureCacheVulkan::SetFramebufferSamplingParams(u16 bufferWidth, u16 buffe
 	bool sClamp;
 	bool tClamp;
 	float lodBias;
-	bool autoMip;
-	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, autoMip);
+	GETexLevelMode mode;
+	GetSamplingParams(minFilt, magFilt, sClamp, tClamp, lodBias, 0, 0, mode);
 
 	key.minFilt = minFilt & 1;
 	key.mipFilt = 0;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -325,7 +325,7 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
 	}
 
 	imageView_ = entry->vkTex->texture_->GetImageView();
-	SamplerCacheKey key;
+	SamplerCacheKey key{};
 	UpdateSamplingParams(*entry, key);
 	curSampler_ = samplerCache_.GetOrCreateSampler(key);
 }
@@ -436,7 +436,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}
 
-	SamplerCacheKey samplerKey;
+	SamplerCacheKey samplerKey{};
 	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 	InvalidateLastTexture(entry);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -86,13 +86,12 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 	samp.addressModeU = key.sClamp ? VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE : VK_SAMPLER_ADDRESS_MODE_REPEAT;
 	samp.addressModeV = key.tClamp ? VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE : VK_SAMPLER_ADDRESS_MODE_REPEAT;
 	samp.addressModeW = samp.addressModeU;  // irrelevant, but Mali recommends that all clamp modes are the same if possible.
-	samp.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
 	samp.compareOp = VK_COMPARE_OP_ALWAYS;
 	samp.flags = 0;
 	samp.magFilter = key.magFilt ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
 	samp.minFilter = key.minFilt ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
 	samp.mipmapMode = key.mipFilt ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
-	if (gstate_c.Supports(GPU_SUPPORTS_ANISOTROPY) && g_Config.iAnisotropyLevel > 0) {
+	if (key.aniso) {
 		// Docs say the min of this value and the supported max are used.
 		samp.maxAnisotropy = 1 << g_Config.iAnisotropyLevel;
 		samp.anisotropyEnable = true;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -113,7 +113,6 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);
 	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch,  int level, int scaleFactor, VkFormat dstFmt);
 	VkFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	TexCacheEntry::Status CheckAlpha(const u32 *pixelData, VkFormat dstFmt, int stride, int w, int h);

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -417,6 +417,7 @@ enum GETexLevelMode {
 	GE_TEXLEVEL_MODE_AUTO = 0,
 	GE_TEXLEVEL_MODE_CONST = 1,
 	GE_TEXLEVEL_MODE_SLOPE = 2,
+	GE_TEXLEVEL_MODE_UNKNOWN = 3,  // Behaves like CONST.
 };
 
 enum GEMaterialColorSetting

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -186,10 +186,10 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 			Core_Stop();
 		}
 	}
+	PSP_EndHostFrame();
 
 	if (coreParameter.thin3d)
 		coreParameter.thin3d->EndFrame();
-	PSP_EndHostFrame();
 
 	PSP_Shutdown();
 
@@ -272,7 +272,7 @@ int main(int argc, const char* argv[])
 			else if (!strcasecmp(gpuName, "null"))
 				gpuCore = GPUCORE_NULL;
 			else
-				return printUsage(argv[0], "Unknown gpu backend specified after --graphics=");
+				return printUsage(argv[0], "Unknown gpu backend specified after --graphics=. Allowed: software, directx9, directx11, vulkan, gles, null.");
 		}
 		// Default to GLES if no value selected.
 		else if (!strcmp(argv[i], "--graphics"))

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -353,7 +353,7 @@ int main(int argc, const char* argv[])
 #ifdef USING_GLES2
 	g_Config.iAnisotropyLevel = 0;
 #else
-	g_Config.iAnisotropyLevel = 4;
+	g_Config.iAnisotropyLevel = 0;  // When testing mipmapping we really don't want this.
 #endif
 	g_Config.bVertexCache = true;
 	g_Config.bTrueColor = true;

--- a/test.py
+++ b/test.py
@@ -40,7 +40,7 @@ class Command(object):
   def run(self, timeout):
     def target():
       self.process = subprocess.Popen(self.cmd, bufsize=1, stdin=subprocess.PIPE, stdout=sys.stdout, stderr=subprocess.STDOUT)
-      self.process.stdin.write(self.data)
+      self.process.stdin.write(self.data.encode('utf-8'))
       self.process.stdin.close()
       self.process.communicate()
 
@@ -397,7 +397,7 @@ def run_tests(test_list, args):
     c = Command(cmdline, '\n'.join(test_filenames))
     c.run(TIMEOUT * len(test_filenames))
 
-    print("Ran " + PPSSPP_EXE)
+    print("Ran " + ' '.join(cmdline))
 
 
 def main():


### PR DESCRIPTION
Works around #9772 

@unknownbrackets What do you think? I think slope mode is not a bias on top of the regular automatic calculation, so using lod bias to implement it is wrong no matter what. Better disable it to avoid breaking Tony Hawk.