### PR TITLE
Update .gitignore for libretro builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ build*/
 # Temp file used by jenkins windows build (TODO: remove)
 desc.txt
 
-
 Logs
 Memstick
 memstick
@@ -95,6 +94,9 @@ tags
 debian/files
 debian/ppsspp.substvars
 debian/ppsspp/
+
+# Libretro build
+*.o
 
 # YouCompleteMe file
 .ycm_extra_conf.pyc


### PR DESCRIPTION
This would be helpful for the libretro port. I am submitting it here because I rather change upstream files in the libretro repo as little as possible even if its just a `.gitignore`.