### PR TITLE
Android: When creating shortcuts, put the file path in data, not in extras.

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -965,13 +965,16 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 	if (msg == "moga") {
 		mogaVersion = prm;
 	} else if (msg == "permission_pending") {
+		ILOG("STORAGE PERMISSION: PENDING");
 		// TODO: Add support for other permissions
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_PENDING;
 		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "permission_denied") {
+		ILOG("STORAGE PERMISSION: DENIED");
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_DENIED;
 		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "permission_granted") {
+		ILOG("STORAGE PERMISSION: GRANTED");
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_GRANTED;
 		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "sustained_perf_supported") {

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -75,20 +75,23 @@ public class PpssppActivity extends NativeActivity {
 		// using Intent extra string. Intent extra will be null if launch normal
 		// (from app drawer or file explorer).
 		Intent intent = getIntent();
-		String action = intent.getAction();
-		if (Intent.ACTION_VIEW.equals(action)) {
-			Uri data = intent.getData();
-			if (data != null) {
-				String path = intent.getData().getPath();
-				super.setShortcutParam(path);
-				Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();
-			} else {
-				Log.e(TAG, "Got ACTION_VIEW without a valid uri");
-			}
+		// String action = intent.getAction();
+		Uri data = intent.getData();
+		if (data != null) {
+			String path = intent.getData().getPath();
+			Log.i(TAG, "Found Shortcut Parameter in data: " + path);
+			super.setShortcutParam(path);
+			// Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();
 		} else {
-			super.setShortcutParam(getIntent().getStringExtra(SHORTCUT_EXTRA_KEY));
+			String param = getIntent().getStringExtra(SHORTCUT_EXTRA_KEY);
+			Log.e(TAG, "Got ACTION_VIEW without a valid uri, trying param");
+			if (param != null) {
+				Log.i(TAG, "Found Shortcut Parameter in extra-data: " + param);
+				super.setShortcutParam(getIntent().getStringExtra(SHORTCUT_EXTRA_KEY));
+			} else {
+				Log.e(TAG, "Shortcut missing parameter!");
+			}
 		}
-
 		super.onCreate(savedInstanceState);
 	}
 

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -6,15 +6,18 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.Intent.ShortcutIconResource;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Looper;
+import android.util.Log;
 
 /**
  * This class will respond to android.intent.action.CREATE_SHORTCUT intent from
  * launcher homescreen. Register this class in AndroidManifest.xml.
  */
 public class ShortcutActivity extends Activity {
+	private static final String TAG = "PPSSPP";
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -33,8 +36,12 @@ public class ShortcutActivity extends Activity {
 	private void respondToShortcutRequest(String path) {
 		// This is Intent that will be sent when user execute our shortcut on
 		// homescreen. Set our app as target Context. Set Main activity as
-		// target class. Add any parameter to extra.
+		// target class. Add any parameter as data.
 		Intent shortcutIntent = new Intent(this, PpssppActivity.class);
+		Uri uri = Uri.fromFile(new File(path));
+		Log.i(TAG, "Shortcut URI: " + uri.toString());
+		shortcutIntent.setData(uri);
+
 		shortcutIntent.putExtra(PpssppActivity.SHORTCUT_EXTRA_KEY, path);
 
 		PpssppActivity.CheckABIAndLoadLibrary();


### PR DESCRIPTION
Actually, let's keep extras around now for very limited backwards compatibility but check data first.

Fixes #9920 