### PR TITLE
Silence travis gcc version errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,29 +39,29 @@ notifications:
 matrix:
   include:
     - os: linux
-      compiler: "gcc linux"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Linux
     - os: linux
-      compiler: "gcc android-arm64-v8a"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Android
            APP_ABI=arm64-v8a
     - os: linux
-      compiler: "gcc android-armeabi-v7a"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Android
            APP_ABI=armeabi-v7a
     - os: linux
-      compiler: "gcc android-x86"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Android
            APP_ABI=x86
     - os: linux
-      compiler: "gcc android-x86_64"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Android
            APP_ABI=x86_64
     - os: linux
       compiler: "clang linux"
       env: PPSSPP_BUILD_TYPE=Linux
     - os: linux
-      compiler: "gcc qt"
+      compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Linux
            QT=TRUE
     - os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,7 +665,7 @@ elseif(IOS)
 	if(EXISTS "${CMAKE_IOS_SDK_ROOT}/System/Library/Frameworks/GameController.framework")
 		set(nativeExtraLibs ${nativeExtraLibs} "-weak_framework GameController")
 	endif()
-	
+
 	if(NOT ICONV_LIBRARY)
 		set(nativeExtraLibs ${nativeExtraLibs} iconv)
 	endif()
@@ -1630,8 +1630,8 @@ if(ANDROID)
   if(X86_64)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
   endif()
-endif()	
- 
+endif()
+
 set(CoreExtraLibs ${CoreExtraLibs} armips)
 
 set(GlslangLibs glslang OGLCompiler OSDependent SPIRV SPVRemapper)


### PR DESCRIPTION
This should silence the following silly errors from the travis logs. Apparently clang does not have this problem...

Please wait for the buildbot to test this.
```
$ gcc linux --version

gcc: error: linux: No such file or directory
```
```
$ gcc android-arm64-v8a --version

gcc: error: android-arm64-v8a: No such file or directory
```
```
$ gcc android-armeabi-v7a --version

gcc: error: android-armeabi-v7a: No such file or directory
```
```
$ gcc android-x86 --version

gcc: error: android-x86: No such file or directory
```
```
$ gcc android-x86_64 --version

gcc: error: android-x86_64: No such file or directory
```
```
$ gcc qt --version

gcc: error: qt: No such file or directory
```