### PR TITLE
UI: Avoid drawing dirty pixels from old text strings on Windows

### DIFF
--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -172,8 +172,8 @@ private:
 	UI::EventReturn OnSaveState(UI::EventParams &e);
 	UI::EventReturn OnLoadState(UI::EventParams &e);
 
-	UI::Button *saveStateButton_;
-	UI::Button *loadStateButton_;
+	UI::Button *saveStateButton_ = nullptr;
+	UI::Button *loadStateButton_ = nullptr;
 
 	int slot_;
 	std::string gamePath_;

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -27,7 +27,7 @@
 
 class GamePauseScreen : public UIDialogScreenWithGameBackground {
 public:
-	GamePauseScreen(const std::string &filename) : UIDialogScreenWithGameBackground(filename), finishNextFrame_(false), gamePath_(filename) {}
+	GamePauseScreen(const std::string &filename) : UIDialogScreenWithGameBackground(filename), gamePath_(filename) {}
 	virtual ~GamePauseScreen();
 
 	virtual void dialogFinished(const Screen *dialog, DialogResult dr) override;
@@ -39,7 +39,6 @@ protected:
 	void CallbackDeleteConfig(bool yes);
 
 private:
-	UI::EventReturn OnMainSettings(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
 	UI::EventReturn OnExitToMenu(UI::EventParams &e);
 	UI::EventReturn OnReportFeedback(UI::EventParams &e);
@@ -55,11 +54,8 @@ private:
 	UI::EventReturn OnSwitchUMD(UI::EventParams &e);
 	UI::EventReturn OnState(UI::EventParams &e);
 
-	UI::Choice *saveStateButton_;
-	UI::Choice *loadStateButton_;
-
 	// hack
-	bool finishNextFrame_;
+	bool finishNextFrame_ = false;
 	std::string gamePath_;
 };
 

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -305,10 +305,12 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 	draw_->BindTexture(0, entry->texture);
 
 	// Okay, the texture is bound, let's draw.
-	float w = entry->bmWidth * fontScaleX_ * dpiScale_;
-	float h = entry->bmHeight * fontScaleY_ * dpiScale_;
+	float w = entry->width * fontScaleX_ * dpiScale_;
+	float h = entry->height * fontScaleY_ * dpiScale_;
+	float u = entry->width / (float)entry->bmWidth;
+	float v = entry->height / (float)entry->bmHeight;
 	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
-	target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
+	target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, u, v, color);
 	target.Flush(true);
 }
 

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -227,14 +227,6 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 		size.cx = textRect.right;
 		size.cy = textRect.bottom;
 
-		// GetTextExtentPoint32(ctx_->hDC, wstr.c_str(), (int)wstr.size(), &size);
-		RECT rc = { 0 };
-		rc.right = size.cx + 4;
-		rc.bottom = size.cy + 4;
-		FillRect(ctx_->hDC, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
-		//ExtTextOut(ctx_->hDC, 0, 0, ETO_OPAQUE | ETO_CLIPPED, NULL, wstr.c_str(), (int)wstr.size(), NULL);
-		DrawTextExW(ctx_->hDC, (LPWSTR)wstr.c_str(), (int)wstr.size(), &rc, DT_HIDEPREFIX | DT_TOP | dtAlign, 0);
-
 		if (size.cx > MAX_TEXT_WIDTH)
 			size.cx = MAX_TEXT_WIDTH;
 		if (size.cy > MAX_TEXT_HEIGHT)
@@ -246,6 +238,12 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 		entry->bmWidth = (size.cx + 3) & ~3;
 		entry->bmHeight = (size.cy + 3) & ~3;
 		entry->lastUsedFrame = frameCount_;
+
+		RECT rc = { 0 };
+		rc.right = entry->bmWidth;
+		rc.bottom = entry->bmHeight;
+		FillRect(ctx_->hDC, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
+		DrawTextExW(ctx_->hDC, (LPWSTR)wstr.c_str(), (int)wstr.size(), &rc, DT_HIDEPREFIX | DT_TOP | dtAlign, 0);
 
 		DataFormat texFormat;
 		// For our purposes these are equivalent, so just choose the supported one. D3D can emulate them.


### PR DESCRIPTION
Fixes #10180 by both clearing everything we create as a texture, and also only texturing from the relevant parts.

-[Unknown]