### PR TITLE
Incomplete implementation of immediate draws through the 0xF0-0xF9 GPU registers.

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2330,7 +2330,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 	case 0x01020004:
 		// TODO: Should not work for umd0:/, ms0:/, etc.
 		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
-		INFO_LOG(SCEIO, "sceIoIoctl: Asked for file offset of file %i", id);
+		DEBUG_LOG(SCEIO, "sceIoIoctl: Asked for file offset of file %d", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
 			u32 offset = (u32)pspFileSystem.GetSeekPos(f->handle);
 			Memory::Write_U32(offset, outdataPtr);

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -431,7 +431,7 @@ static u32 scePowerSetBusClockFrequency(u32 busfreq) {
 
 static u32 scePowerGetCpuClockFrequencyInt() {
 	int cpuFreq = CoreTiming::GetClockFrequencyMHz();
-	INFO_LOG(HLE,"%i=scePowerGetCpuClockFrequencyInt()", cpuFreq);
+	DEBUG_LOG(HLE,"%i=scePowerGetCpuClockFrequencyInt()", cpuFreq);
 	return cpuFreq;
 }
 
@@ -447,7 +447,7 @@ static u32 scePowerGetBusClockFrequencyInt() {
 
 static float scePowerGetCpuClockFrequencyFloat() {
 	int cpuFreq = CoreTiming::GetClockFrequencyMHz(); 
-	INFO_LOG(HLE, "%f=scePowerGetCpuClockFrequencyFloat()", (float)cpuFreq);
+	DEBUG_LOG(HLE, "%f=scePowerGetCpuClockFrequencyFloat()", (float)cpuFreq);
 	return (float) cpuFreq;
 }
 

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -26,6 +26,8 @@
 #include "Core/Reporting.h"
 #include "GPU/ge_constants.h"
 #include "GPU/Common/ShaderCommon.h"
+#include "GPU/GPUCommon.h"
+
 #if PPSSPP_ARCH(ARM)
 #include "Common/ArmEmitter.h"
 #elif PPSSPP_ARCH(ARM64)
@@ -76,30 +78,6 @@ struct DecVtxFormat {
 
 	uint32_t id;
 	void ComputeID();
-};
-
-struct TransformedVertex
-{
-	union {
-		struct {
-			float x, y, z, fog;     // in case of morph, preblend during decode
-		};
-		float pos[4];
-	};
-	union {
-		struct {
-			float u; float v; float w;   // scaled by uscale, vscale, if there
-		};
-		float uv[3];
-	};
-	union {
-		u8 color0[4];   // prelit
-		u32 color0_32;
-	};
-	union {
-		u8 color1[4];   // prelit
-		u32 color1_32;
-	};
 };
 
 void GetIndexBounds(const void *inds, int count, u32 vertType, u16 *indexLowerBound, u16 *indexUpperBound);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1809,6 +1809,10 @@ void GPUCommon::Execute_MorphWeight(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_ImmVertexAlphaPrim(u32 op, u32 diff) {
+	// Safety check.
+	if (immCount_ >= MAX_IMMBUFFER_SIZE)
+		return;
+
 	uint32_t data = op & 0xFFFFFF;
 	TransformedVertex &v = immBuffer_[immCount_++];
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1832,6 +1832,8 @@ void GPUCommon::Execute_ImmVertexAlphaPrim(u32 op, u32 diff) {
 	if (prim != 7) {
 		immPrim_ = (GEPrimitiveType)prim;
 	} else if (prim == 7 && immCount_ == 2) {
+		// Instead of finding a proper point to flush, we just emit a full rectangle every time one
+		// is finished.
 		FlushImm();
 	}
 }
@@ -1844,10 +1846,10 @@ void GPUCommon::FlushImm() {
 		return;
 	}
 	UpdateUVScaleOffset();
-	// Instead of finding a proper point to flush, we just emit a full rectangle every time one
-	// is finished.
 
-	// And instead of plumbing through, we'll cheat and just turn these into through vertices.
+	// Instead of plumbing through properly (we'd need to inject these pretransformed vertices in the middle
+	// of SoftwareTransform(), which would take a lot of refactoring), we'll cheat and just turn these into
+	// through vertices.
 	// Since the only known use is Thrillville and it only uses it to clear, we just use color and pos.
 	struct ImmVertex {
 		uint32_t color;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -323,9 +323,10 @@ protected:
 
 	TransformedVertex immBuffer_[MAX_IMMBUFFER_SIZE];
 	int immCount_ = 0;
-	int immPrim_ = 0;
+	GEPrimitiveType immPrim_;
 
 private:
+	void FlushImm();
 	// Debug stats.
 	double timeSteppingStarted_;
 	double timeSpentStepping_;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -39,6 +39,29 @@ enum {
 	FLAG_DIRTYONCHANGE = 64,  // NOTE: Either this or FLAG_EXECUTE*, not both!
 };
 
+struct TransformedVertex {
+	union {
+		struct {
+			float x, y, z, fog;     // in case of morph, preblend during decode
+		};
+		float pos[4];
+	};
+	union {
+		struct {
+			float u; float v; float w;   // scaled by uscale, vscale, if there
+		};
+		float uv[3];
+	};
+	union {
+		u8 color0[4];   // prelit
+		u32 color0_32;
+	};
+	union {
+		u8 color1[4];   // prelit
+		u32 color1_32;
+	};
+};
+
 class GPUCommon : public GPUInterface, public GPUDebugInterface {
 public:
 	GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
@@ -123,6 +146,8 @@ public:
 	void Execute_BoneMtxData(u32 op, u32 diff);
 
 	void Execute_MorphWeight(u32 op, u32 diff);
+
+	void Execute_ImmVertexAlphaPrim(u32 op, u32 diff);
 
 	void Execute_Unknown(u32 op, u32 diff);
 
@@ -290,6 +315,15 @@ protected:
 	bool resized_;
 	DrawType lastDraw_;
 	GEPrimitiveType lastPrim_;
+
+	// No idea how big this buffer needs to be.
+	enum {
+		MAX_IMMBUFFER_SIZE = 32,
+	};
+
+	TransformedVertex immBuffer_[MAX_IMMBUFFER_SIZE];
+	int immCount_ = 0;
+	int immPrim_ = 0;
 
 private:
 	// Debug stats.

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -196,8 +196,9 @@ struct GPUgstate {
 				imm_cv,
 				imm_ap,
 				imm_fc,
-				imm_scv;
-			u32 pad05[0xFF- 0xEE];
+				imm_scv;   // 0xF9
+				// In the unlikely case we ever add anything else here, don't forget to update the padding on the next line!
+			u32 pad05[0xFF- 0xF9];
 		};
 	};
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -185,8 +185,18 @@ struct GPUgstate {
 				transfersrcpos,
 				transferdstpos,
 				pad99,
-				transfersize;  // 0xEE
-
+				transfersize,  // 0xEE
+				pad100,         // 0xEF
+				imm_vscx,        // 0xF0
+				imm_vscy,
+				imm_vscz,
+				imm_vtcs,
+				imm_vtct,
+				imm_vtcq,
+				imm_cv,
+				imm_ap,
+				imm_fc,
+				imm_scv;
 			u32 pad05[0xFF- 0xEE];
 		};
 	};


### PR DESCRIPTION
Fixes Thrillville, the only known game to use these. See #7459.

It does not currently support attributes other than color and position, and only triggers for rectangles.