### PR TITLE
Fix a cheat menu crash reported on the forums

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -87,6 +87,11 @@ bool CheatFileParser::Parse() {
 		getline(file_, line, '\n');
 		line = TrimString(line);
 
+		// Minimum length is set to 5 just to match GetCodesList() function
+		// which discards anything shorter when called anyway.
+		// It's decided from shortest possible _ lines name of the game "_G N+"
+		// and a minimum of 1 displayable character in cheat name string "_C0 1"
+		// which both equal to 5 characters.
 		if (line.length() >= 5 && line[0] == '_') {
 			ParseLine(line);
 		} else if (line.length() >= 2 && line[0] == '/' && line[1] == '/') {
@@ -341,7 +346,10 @@ std::vector<std::string> CWCheatEngine::GetCodesList() {
 		getline(list, line, '\n');
 
 		bool validCheatLine = false;
-		// This code is used by cheat menu which doesn't support empty names
+		// This function is called by cheat menu(UI) which doesn't support empty names
+		// minimum 1 non space character is required starting from 5 position.
+		// It also goes through other "_" lines, but they all have to meet this requirement anyway
+		// so we don't have to specify any syntax checks here that are made by cheat engine.
 		if (line.length() >= 5 && line[0] == '_') {
 			for (int i = 4; i < line.length(); i++) {
 				if (line[i] != ' ') {
@@ -350,6 +358,7 @@ std::vector<std::string> CWCheatEngine::GetCodesList() {
 				}
 			}
 		}
+		// Any lines not passing this check are discarded when we save changes to the cheat ini file
 		if (validCheatLine || (line.length() >= 2 && line[0] == '/' && line[1] == '/') || (line.length() >= 1 && line[0] == '#')) {
 			codesList.push_back(TrimString(line));
 		}

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -87,7 +87,7 @@ bool CheatFileParser::Parse() {
 		getline(file_, line, '\n');
 		line = TrimString(line);
 
-		if (line.length() > 2 && line[0] == '_') {
+		if (line.length() >= 5 && line[0] == '_') {
 			ParseLine(line);
 		} else if (line.length() >= 2 && line[0] == '/' && line[1] == '/') {
 			// Comment, ignore.
@@ -340,7 +340,17 @@ std::vector<std::string> CWCheatEngine::GetCodesList() {
 		std::string line;
 		getline(list, line, '\n');
 
-		if (line.length() > 3 && (line.substr(0, 1) == "_" || line.substr(0, 2) == "//")) {
+		bool validCheatLine = false;
+		// This code is used by cheat menu which doesn't support empty names
+		if (line.length() >= 5 && line.substr(0, 1) == "_") {
+			for (int i = 4; i < line.length(); i++) {
+				if (line.substr(i, 1) != " ") {
+					validCheatLine = true;
+					break;
+				}
+			}
+		}
+		if (validCheatLine || (line.length() >= 2 && line.substr(0, 2) == "//") || (line.length() >= 1 && line.substr(0, 1) == "#")) {
 			codesList.push_back(TrimString(line));
 		}
 	}

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -342,15 +342,15 @@ std::vector<std::string> CWCheatEngine::GetCodesList() {
 
 		bool validCheatLine = false;
 		// This code is used by cheat menu which doesn't support empty names
-		if (line.length() >= 5 && line.substr(0, 1) == "_") {
+		if (line.length() >= 5 && line[0] == '_') {
 			for (int i = 4; i < line.length(); i++) {
-				if (line.substr(i, 1) != " ") {
+				if (line[i] != ' ') {
 					validCheatLine = true;
 					break;
 				}
 			}
 		}
-		if (validCheatLine || (line.length() >= 2 && line.substr(0, 2) == "//") || (line.length() >= 1 && line.substr(0, 1) == "#")) {
+		if (validCheatLine || (line.length() >= 2 && line[0] == '/' && line[1] == '/') || (line.length() >= 1 && line[0] == '#')) {
 			codesList.push_back(TrimString(line));
 		}
 	}

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -65,9 +65,9 @@ void CwCheatScreen::CreateCodeList() {
 	bEnableCheat.clear();
 	formattedList_.clear();
 	for (size_t i = 0; i < cheatList.size(); i++) {
-		if (cheatList[i].substr(0, 2) == "_C") {
+		if (cheatList[i][0] == '_' && cheatList[i][1] == 'C') {
 			formattedList_.push_back(cheatList[i].substr(4));
-			if (cheatList[i].substr(2, 1) == "0") {
+			if (cheatList[i][2] == '0') {
 				bEnableCheat.push_back(false);
 			} else {
 				bEnableCheat.push_back(true);
@@ -136,11 +136,11 @@ UI::EventReturn CwCheatScreen::OnEnableAll(UI::EventParams &params) {
 	enableAll = !enableAll;
 	File::OpenCPPFile(fs, activeCheatFile, std::ios::out);
 	for (int j = 0; j < (int)cheatList.size(); j++) {
-		if (cheatList[j].substr(0, 2) == "_C") {
-			if (cheatList[j].substr(2, 1) == "0" && enableAll) {
-				cheatList[j].replace(2, 1, "1");
-			} else if (cheatList[j].substr(2, 1) != "0" && !enableAll) {
-				cheatList[j].replace(2, 1, "0");
+		if (cheatList[j][0] == '_' && cheatList[j][1] == 'C') {
+			if (cheatList[j][2] == '0' && enableAll) {
+				cheatList[j][2] = '1';
+			} else if (cheatList[j][2] != '0' && !enableAll) {
+				cheatList[j][2] = '0';
 			}
 		}
 	}
@@ -190,6 +190,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 	std::vector<std::string> newList;
 
 	std::string cheatFile = GetSysDirectory(DIRECTORY_CHEATS) + "cheat.db";
+	std::string gameID = StringFromFormat("_S %s-%s", gameTitle.substr(0, 4), gameTitle.substr(4));
 
 	std::fstream fs;
 	File::OpenCPPFile(fs, cheatFile, std::ios::in);
@@ -200,7 +201,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 
 	while (fs.good()) {
 		getline(fs, line); // get line from file
-		if (line == "_S " + gameTitle.substr(0, 4) + "-" + gameTitle.substr(4)) {
+		if (line == gameID) {
 			title.push_back(line);
 			getline(fs, line);
 			title.push_back(line);
@@ -208,7 +209,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 				if (finished == false){
 					getline(fs, line);
 				}
-				if (line.substr(0, 2) == "_C") {
+				if (line[0] == '_' && line[1] == 'C') {
 					//Test if cheat already exists in cheatList
 					for (size_t j = 0; j < formattedList_.size(); j++) {
 						if (line.substr(4) == formattedList_[j]) {
@@ -222,13 +223,13 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 					do {
 						newList.push_back(line);
 						getline(fs, line);
-					} while (line.substr(0, 2) == "_L");
+					} while (line[0] == '_' && line[1] == 'L');
 					finished = true;
 				} else {
 					continue;
 				}
 			loop:;
-			} while (line.substr(0, 2) != "_S");
+			} while (fs.good() && line[0] != '_' && line[1] != 'S');
 			finished = true;
 		}
 		if (finished == true)
@@ -242,7 +243,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 	File::OpenCPPFile(fs, activeCheatFile, std::ios::out | std::ios::app);
 
 	auto it = title.begin();
-	if (title2.substr(0, 2) != "_S" && it != title.end() && (++it) != title.end()) {
+	if (title2[0] != '_' && title2[1] != 'S' && it != title.end() && (++it) != title.end()) {
 		fs << title[0] << "\n" << title[1];
 	}
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -190,7 +190,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 	std::vector<std::string> newList;
 
 	std::string cheatFile = GetSysDirectory(DIRECTORY_CHEATS) + "cheat.db";
-	std::string gameID = StringFromFormat("_S %s-%s", gameTitle.substr(0, 4), gameTitle.substr(4));
+	std::string gameID = StringFromFormat("_S %s-%s", gameTitle.substr(0, 4).c_str(), gameTitle.substr(4).c_str());
 
 	std::fstream fs;
 	File::OpenCPPFile(fs, cheatFile, std::ios::in);


### PR DESCRIPTION
Cheat names really shouldn't be empty, even if it wouldn't crash it would look bad.
This also stops lines with # comments from being removed by cheat menu and rising shortest valid "_" lines length to 5.:]

Edit: now also fixes #9804 as the person opening it seems unwilling to open pr.:]
Changed some other substr used in cheat menu as well. I'm guessing it's just safer that way.