### PR TITLE
Avoid wrapping when shifting down the audio after scaling by a 20-bit value. 

### DIFF
--- a/Core/Util/AudioFormat.h
+++ b/Core/Util/AudioFormat.h
@@ -59,6 +59,12 @@ static inline s16 ApplySampleVolume(s16 sample, int vol) {
 #endif
 }
 
+// We sacrifice a little volume precision to fit in 32 bits, for speed.
+// Probably not worth it to make a special path for 64-bit CPUs.
+static inline s16 ApplySampleVolume20Bit(s16 sample, int vol20) {
+	return clamp_s16((sample * (vol20 >> 4)) >> 12);
+}
+
 void SetupAudioFormats();
 void AdjustVolumeBlockStandard(s16 *out, s16 *in, size_t size, int leftVol, int rightVol);
 void ConvertS16ToF32(float *ou, const s16 *in, size_t size);

--- a/Core/Util/AudioFormatNEON.cpp
+++ b/Core/Util/AudioFormatNEON.cpp
@@ -58,9 +58,16 @@ void AdjustVolumeBlockNEON(s16 *out, s16 *in, size_t size, int leftVol, int righ
 		}
 	}
 
-	for (size_t i = 0; i < size; i += 2) {
-		out[i] = ApplySampleVolume(in[i], leftVol);
-		out[i + 1] = ApplySampleVolume(in[i + 1], rightVol);
+	if (leftVol <= 0x7fff && -leftVol <= 0x8000 && rightVol <= 0x7fff && -rightVol <= 0x8000) {
+		for (size_t i = 0; i < size; i += 2) {
+			out[i] = ApplySampleVolume(in[i], leftVol);
+			out[i + 1] = ApplySampleVolume(in[i + 1], rightVol);
+		}
+	} else {
+		for (size_t i = 0; i < size; i += 2) {
+			out[i] = ApplySampleVolume20Bit(in[i], leftVol);
+			out[i + 1] = ApplySampleVolume20Bit(in[i + 1], rightVol);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #9967.

Disables an SSE optimization that doesn't work, will need rethinking (or simply use the same workaround I did in ApplySampleVolume20Bit)