### PR TITLE
Flip immediately if that's OK, instead of waiting for VBlank.

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -853,7 +853,8 @@ void __DisplaySetFramebuf(u32 topaddr, int linesize, int pixelFormat, int sync) 
 		framebuf = fbstate;
 		gpu->SetDisplayFramebuffer(framebuf.topaddr, framebuf.stride, framebuf.fmt);
 		// IMMEDIATE means that the buffer is fine. We can just flip immediately.
-		__DisplayFlip(0);
+		if (!flippedThisFrame)
+			__DisplayFlip(0);
 	} else {
 		// Delay the write until vblank
 		latchedFramebuf = fbstate;


### PR DESCRIPTION
This can save up to a frame of graphics latency, in games that change the display pointer "immediately" instead of through the latch mechanism, which seem to be many.

For better perceived responsiveness in music games etc.

One concern is that since we're not doing the flip from a scheduled event in this case, we might end up running a little bit of code before we check coreState and end the frame. Instead, maybe we should schedule an event ASAP that ends up calling __DisplayFlip, and hope that we manage to get out before it starts rendering the next frame...

@unknownbrackets , opinions?

Not merging this until all the emergency 1.5 releases are done :)