### PR TITLE
Hide post process option in unsupported backends(d3d9)

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -256,11 +256,14 @@ void GameSettingsScreen::CreateViews() {
 	altSpeed->SetZeroLabel(gr->T("Unlimited"));
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Features")));
-	I18NCategory *ps = GetI18NCategory("PostShaders");
-	postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), ps->GetName()));
-	postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
-	postProcEnable_ = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
-	postProcChoice_->SetEnabledPtr(&postProcEnable_);
+	// Hide postprocess option on unsupported backends to avoid confusion.
+	if (g_Config.iGPUBackend != GPU_BACKEND_DIRECT3D9) {
+		I18NCategory *ps = GetI18NCategory("PostShaders");
+		postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), ps->GetName()));
+		postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
+		postProcEnable_ = !g_Config.bSoftwareRendering && (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+		postProcChoice_->SetEnabledPtr(&postProcEnable_);
+	}
 
 #if !defined(MOBILE_DEVICE)
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gr->T("FullScreen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -195,16 +195,21 @@ namespace MainWindow {
 		const char *translatedShaderName = nullptr;
 
 		availableShaders.clear();
-		for (auto i = info.begin(); i != info.end(); ++i) {
-			checkedStatus = MF_UNCHECKED;
-			availableShaders.push_back(i->section);
-			if (g_Config.sPostShaderName == i->section) {
-				checkedStatus = MF_CHECKED;
+		if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
+			translatedShaderName = ps->T("Not available in Direct3D9 backend");
+			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_GRAYED, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
+		} else {
+			for (auto i = info.begin(); i != info.end(); ++i) {
+				checkedStatus = MF_UNCHECKED;
+				availableShaders.push_back(i->section);
+				if (g_Config.sPostShaderName == i->section) {
+					checkedStatus = MF_CHECKED;
+				}
+
+				translatedShaderName = ps->T(i->section.c_str());
+
+				AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 			}
-
-			translatedShaderName = ps->T(i->section.c_str());
-
-			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		}
 
 		menuShaderInfo = info;


### PR DESCRIPTION
 I could just gray it out, but since backend change requires restart and graphics settings screen is screaming "too many options", one less felt nicer.