### PR TITLE
Reporting: Disallow feedback for fake game ids

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1070,9 +1070,7 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 
 		if (IsHLEVersionedModule(head->modname)) {
 			int ver = (head->module_ver_hi << 8) | head->module_ver_lo;
-			char temp[256];
-			snprintf(temp, sizeof(temp), "Loading module %s with version %%04x, devkit %%08x", head->modname);
-			INFO_LOG_REPORT(SCEMODULE, temp, ver, head->devkitversion);
+			INFO_LOG(SCEMODULE, "Loading module %s with version %04x, devkit %08x", head->modname, ver, head->devkitversion);
 			reportedModule = true;
 
 			if (!strcmp(head->modname, "sceMpeg_library")) {
@@ -1434,9 +1432,7 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 		delete [] newptr;
 
 	if (!reportedModule && IsHLEVersionedModule(modinfo->name)) {
-		char temp[256];
-		snprintf(temp, sizeof(temp), "Loading module %s with version %%04x, devkit %%08x", modinfo->name);
-		INFO_LOG_REPORT(SCEMODULE, temp, modinfo->moduleVersion, devkitVersion);
+		INFO_LOG_REPORT(SCEMODULE, "Loading module %s with version %04x, devkit %08x", modinfo->name, modinfo->moduleVersion, devkitVersion);
 
 		if (!strcmp(modinfo->name, "sceMpeg_library")) {
 			__MpegLoadModule(modinfo->moduleVersion);

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -174,7 +174,7 @@ u32 sceNetAdhocInit() {
 		// TODO: Should use a separated threads for friendFinder, matchingEvent, and matchingInput and created on AdhocctlInit & AdhocMatchingStart instead of here
 		#define PSP_THREAD_ATTR_KERNEL 0x00001000 // PSP_THREAD_ATTR_KERNEL is located in sceKernelThread.cpp instead of sceKernelThread.h :(
 		//threadAdhocID = __KernelCreateThreadInternal("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x30, 4096, PSP_THREAD_ATTR_KERNEL);
-		threadAdhocID = __KernelCreateThread("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x10, 0x1000, 0, PSP_THREAD_ATTR_KERNEL);
+		threadAdhocID = __KernelCreateThread("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x10, 0x1000, 0, 0);
 		if (threadAdhocID > 0) {
 			__KernelStartThread(threadAdhocID, 0, 0);
 		}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1930,85 +1930,8 @@ void GPUCommon::ExecuteOp(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_Unknown(u32 op, u32 diff) {
-	switch (op >> 24) {
-	case GE_CMD_VSCX:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vscx, G3D, "Unsupported Vertex Screen Coordinate X : %06x", op);
-		break;
-
-	case GE_CMD_VSCY:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vscy, G3D, "Unsupported Vertex Screen Coordinate Y : %06x", op);
-		break;
-
-	case GE_CMD_VSCZ:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vscz, G3D, "Unsupported Vertex Screen Coordinate Z : %06x", op);
-		break;
-
-	case GE_CMD_VTCS:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vtcs, G3D, "Unsupported Vertex Texture Coordinate S : %06x", op);
-		break;
-
-	case GE_CMD_VTCT:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vtct, G3D, "Unsupported Vertex Texture Coordinate T : %06x", op);
-		break;
-
-	case GE_CMD_VTCQ:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vtcq, G3D, "Unsupported Vertex Texture Coordinate Q : %06x", op);
-		break;
-
-	case GE_CMD_VCV:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vcv, G3D, "Unsupported Vertex Color Value : %06x", op);
-		break;
-
-	case GE_CMD_VAP:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vap, G3D, "Unsupported Vertex Alpha and Primitive : %06x", op);
-		break;
-
-	case GE_CMD_VFC:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vfc, G3D, "Unsupported Vertex Fog Coefficient : %06x", op);
-		break;
-
-	case GE_CMD_VSCV:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(vscv, G3D, "Unsupported Vertex Secondary Color Value : %06x", op);
-		break;
-
-	case GE_CMD_UNKNOWN_03:
-	case GE_CMD_UNKNOWN_0D:
-	case GE_CMD_UNKNOWN_11:
-	case GE_CMD_UNKNOWN_29:
-	case GE_CMD_UNKNOWN_34:
-	case GE_CMD_UNKNOWN_35:
-	case GE_CMD_UNKNOWN_39:
-	case GE_CMD_UNKNOWN_4E:
-	case GE_CMD_UNKNOWN_4F:
-	case GE_CMD_UNKNOWN_52:
-	case GE_CMD_UNKNOWN_59:
-	case GE_CMD_UNKNOWN_5A:
-	case GE_CMD_UNKNOWN_B6:
-	case GE_CMD_UNKNOWN_B7:
-	case GE_CMD_UNKNOWN_D1:
-	case GE_CMD_UNKNOWN_ED:
-	case GE_CMD_UNKNOWN_EF:
-	case GE_CMD_UNKNOWN_FA:
-	case GE_CMD_UNKNOWN_FB:
-	case GE_CMD_UNKNOWN_FC:
-	case GE_CMD_UNKNOWN_FD:
-	case GE_CMD_UNKNOWN_FE:
-		if ((op & 0xFFFFFF) != 0)
-			WARN_LOG_REPORT_ONCE(unknowncmd, G3D, "Unknown GE command : %08x ", op);
-		break;
-	default:
-		break;
-	}
+	if ((op & 0xFFFFFF) != 0)
+		WARN_LOG_REPORT_ONCE(unknowncmd, G3D, "Unknown GE command : %08x ", op);
 }
 
 void GPUCommon::FastLoadBoneMatrix(u32 target) {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -334,7 +334,7 @@ void GamePauseScreen::CreateViews() {
 
 	// TODO, also might be nice to show overall compat rating here?
 	// Based on their platform or even cpu/gpu/config.  Would add an API for it.
-	if (Reporting::IsSupported() && gameId.size() && gameId != "_") {
+	if (Reporting::IsSupported() && g_paramSFO.GetValueString("DISC_ID").size()) {
 		I18NCategory *rp = GetI18NCategory("Reporting");
 		rightColumnItems->Add(new Choice(rp->T("ReportButton", "Report Feedback")))->OnClick.Handle(this, &GamePauseScreen::OnReportFeedback);
 	}


### PR DESCRIPTION
It's just not realistic for everyone to use the same one, which makes the feedback not work well.

-[Unknown]