### PR TITLE
Fix hashmap grow bug and add shader id typesafety

### DIFF
--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -150,6 +150,11 @@ private:
 		// This is extremely non-atomic and will need synchronization.
 		std::vector<Pair> old = std::move(map);
 		std::vector<BucketState> oldState = std::move(state);
+		// Can't assume move will clear, it just may clear.
+		map.clear();
+		state.clear();
+
+		int oldCount = count_;
 		capacity_ *= factor;
 		map.resize(capacity_);
 		state.resize(capacity_);
@@ -160,6 +165,7 @@ private:
 				Insert(old[i].key, old[i].value);
 			}
 		}
+		_assert_msg_(SYSTEM, oldCount == count_, "DenseHashMap: count should not change in Grow()");
 	}
 	struct Pair {
 		Key key;
@@ -289,6 +295,11 @@ private:
 		// This is extremely non-atomic and will need synchronization.
 		std::vector<Pair> old = std::move(map);
 		std::vector<BucketState> oldState = std::move(state);
+		// Can't assume move will clear, it just may clear.
+		map.clear();
+		state.clear();
+
+		int oldCount = count_;
 		capacity_ *= factor;
 		map.resize(capacity_);
 		state.resize(capacity_);
@@ -299,6 +310,7 @@ private:
 				Insert(old[i].hash, old[i].value);
 			}
 		}
+		_assert_msg_(SYSTEM, oldCount == count_, "PrehashMap: count should not change in Grow()");
 	}
 	struct Pair {
 		uint32_t hash;

--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -5,6 +5,7 @@
 
 #include "ext/xxhash.h"
 #include "Common/CommonFuncs.h"
+#include "Common/Log.h"
 
 // Whatever random value.
 const uint32_t hashmapSeed = 0x23B58532;
@@ -50,8 +51,9 @@ public:
 			else if (state[p] == BucketState::FREE)
 				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
-			if (p == pos)
-				Crash();
+			if (p == pos) {
+				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Get()");
+			}
 		}
 		return NullValue;
 	}
@@ -68,7 +70,8 @@ public:
 		while (true) {
 			if (state[p] == BucketState::TAKEN) {
 				if (KeyEquals(key, map[p].key)) {
-					Crash();  // Bad! We already got this one. Let's avoid this case.
+					// Bad! We already got this one. Let's avoid this case.
+					_assert_msg_(SYSTEM, false, "DenseHashMap: Duplicate key inserted");
 					return false;
 				}
 				// continue looking....
@@ -79,7 +82,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen thanks to Grow().
-				Crash();
+				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Insert()");
 			}
 		}
 		if (state[p] == BucketState::REMOVED) {
@@ -107,7 +110,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen.
-				Crash();
+				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Remove()");
 			}
 		}
 		return false;
@@ -191,8 +194,9 @@ public:
 			else if (state[p] == BucketState::FREE)
 				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
-			if (p == pos)
-				Crash();
+			if (p == pos) {
+				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Get()");
+			}
 		}
 		return NullValue;
 	}
@@ -217,7 +221,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen thanks to Grow().
-				Crash();
+				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Insert()");
 			}
 		}
 		if (state[p] == BucketState::REMOVED) {
@@ -244,7 +248,7 @@ public:
 			}
 			p = (p + 1) & mask;
 			if (p == pos) {
-				Crash();
+				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Remove()");
 			}
 		}
 		return false;

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1323,7 +1323,7 @@ void ConvertStencilFuncState(GenericStencilFuncState &state) {
 		return;
 
 	// The PSP's mask is reversed (bits not to write.)
-	state.writeMask = (~(gstate.pmska >> 0)) & 0xFF;
+	state.writeMask = (~gstate.pmska) & 0xFF;
 
 	state.sFail = gstate.getStencilOpSFail();
 	state.zFail = gstate.getStencilOpZFail();

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -14,20 +14,25 @@ enum {
 	VS_BIT_ENABLE_FOG = 2,
 	VS_BIT_HAS_COLOR = 3,
 	VS_BIT_DO_TEXTURE = 4,
+	// 5 is free.
 	VS_BIT_DO_TEXTURE_TRANSFORM = 6,
+	// 7 is free.
 	VS_BIT_USE_HW_TRANSFORM = 8,
 	VS_BIT_HAS_NORMAL = 9,  // conditioned on hw transform
 	VS_BIT_NORM_REVERSE = 10,
 	VS_BIT_HAS_TEXCOORD = 11,
 	VS_BIT_HAS_COLOR_TESS = 12,  // 1 bit
 	VS_BIT_HAS_TEXCOORD_TESS = 13,  // 1 bit
-	VS_BIT_NORM_REVERSE_TESS = 14, // 1 bit 1 free after
+	VS_BIT_NORM_REVERSE_TESS = 14, // 1 bit
+	// 15 is free.
 	VS_BIT_UVGEN_MODE = 16,
 	VS_BIT_UVPROJ_MODE = 18,  // 2, can overlap with LS0
 	VS_BIT_LS0 = 18,  // 2
 	VS_BIT_LS1 = 20,  // 2
 	VS_BIT_BONES = 22,  // 3 should be enough, not 8
+	// 25 - 29 are free.
 	VS_BIT_ENABLE_BONES = 30,
+	// 31 is free.
 	VS_BIT_LIGHT0_COMP = 32,  // 2 bits
 	VS_BIT_LIGHT0_TYPE = 34,  // 2 bits
 	VS_BIT_LIGHT1_COMP = 36,  // 2 bits
@@ -43,7 +48,8 @@ enum {
 	VS_BIT_LIGHT2_ENABLE = 54,
 	VS_BIT_LIGHT3_ENABLE = 55,
 	VS_BIT_LIGHTING_ENABLE = 56,
-	VS_BIT_WEIGHT_FMTSCALE = 57,  // only two bits, 1 free after
+	VS_BIT_WEIGHT_FMTSCALE = 57,  // only two bits
+	// 59 - 61 are free.
 	VS_BIT_FLATSHADE = 62, // 1 bit
 	VS_BIT_BEZIER = 63, // 1 bit
 	// No more free
@@ -56,6 +62,7 @@ enum {
 	FS_BIT_DO_TEXTURE = 1,
 	FS_BIT_TEXFUNC = 2,  // 3 bits
 	FS_BIT_TEXALPHA = 5,
+	// 6 is free.
 	FS_BIT_SHADER_TEX_CLAMP = 7,
 	FS_BIT_CLAMP_S = 8,
 	FS_BIT_CLAMP_T = 9,
@@ -76,9 +83,10 @@ enum {
 	FS_BIT_REPLACE_BLEND = 32,  // 3 bits
 	FS_BIT_BLENDEQ = 35,  // 3 bits
 	FS_BIT_BLENDFUNC_A = 38,  // 4 bits
-	FS_BIT_BLENDFUNC_B = 42,
+	FS_BIT_BLENDFUNC_B = 42,  // 4 bits
 	FS_BIT_FLATSHADE = 46,
 	FS_BIT_BGRA_TEXTURE = 47,
+	// 48+ are free.
 };
 
 struct ShaderID {

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -156,6 +156,24 @@ struct ShaderID {
 	}
 };
 
+struct VShaderID : ShaderID {
+	VShaderID() : ShaderID() {
+	}
+
+	explicit VShaderID(ShaderID &src) {
+		memcpy(d, src.d, sizeof(d));
+	}
+};
+
+struct FShaderID : ShaderID {
+	FShaderID() : ShaderID() {
+	}
+
+	explicit FShaderID(ShaderID &src) {
+		memcpy(d, src.d, sizeof(d));
+	}
+};
+
 
 bool CanUseHardwareTransform(int prim);
 void ComputeVertexShaderID(ShaderID *id, uint32_t vertexType, bool useHWTransform);

--- a/GPU/D3D11/FragmentShaderGeneratorD3D11.cpp
+++ b/GPU/D3D11/FragmentShaderGeneratorD3D11.cpp
@@ -19,6 +19,6 @@
 #include "GPU/D3D11/FragmentShaderGeneratorD3D11.h"
 #include "GPU/Directx9/PixelShaderGeneratorDX9.h"
 
-void GenerateFragmentShaderD3D11(const ShaderID &id, char *buffer, ShaderLanguage lang) {
+void GenerateFragmentShaderD3D11(const FShaderID &id, char *buffer, ShaderLanguage lang) {
 	DX9::GenerateFragmentShaderHLSL(id, buffer, lang);
 }

--- a/GPU/D3D11/FragmentShaderGeneratorD3D11.h
+++ b/GPU/D3D11/FragmentShaderGeneratorD3D11.h
@@ -19,4 +19,4 @@
 
 #include "GPU/Common/ShaderId.h"
 
-void GenerateFragmentShaderD3D11(const ShaderID &id, char *buffer, ShaderLanguage lang);
+void GenerateFragmentShaderD3D11(const FShaderID &id, char *buffer, ShaderLanguage lang);

--- a/GPU/D3D11/ShaderManagerD3D11.cpp
+++ b/GPU/D3D11/ShaderManagerD3D11.cpp
@@ -38,7 +38,7 @@
 #include "GPU/D3D11/VertexShaderGeneratorD3D11.h"
 #include "GPU/D3D11/D3D11Util.h"
 
-D3D11FragmentShader::D3D11FragmentShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, ShaderID id, const char *code, bool useHWTransform)
+D3D11FragmentShader::D3D11FragmentShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, FShaderID id, const char *code, bool useHWTransform)
 	: device_(device), id_(id), failed_(false), useHWTransform_(useHWTransform), module_(0) {
 	source_ = code;
 
@@ -63,7 +63,7 @@ std::string D3D11FragmentShader::GetShaderString(DebugShaderStringType type) con
 	}
 }
 
-D3D11VertexShader::D3D11VertexShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, ShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting)
+D3D11VertexShader::D3D11VertexShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, VShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting)
 	: device_(device), id_(id), failed_(false), useHWTransform_(useHWTransform), module_(nullptr), usesLighting_(usesLighting) {
 	source_ = code;
 
@@ -178,8 +178,8 @@ void ShaderManagerD3D11::BindUniforms() {
 }
 
 void ShaderManagerD3D11::GetShaders(int prim, u32 vertType, D3D11VertexShader **vshader, D3D11FragmentShader **fshader, bool useHWTransform) {
-	ShaderID VSID;
-	ShaderID FSID;
+	VShaderID VSID;
+	FShaderID FSID;
 
 	if (gstate_c.IsDirty(DIRTY_VERTEXSHADER_STATE)) {
 		gstate_c.Clean(DIRTY_VERTEXSHADER_STATE);
@@ -268,7 +268,7 @@ std::string ShaderManagerD3D11::DebugGetShaderString(std::string id, DebugShader
 	switch (type) {
 	case SHADER_TYPE_VERTEX:
 	{
-		auto iter = vsCache_.find(shaderId);
+		auto iter = vsCache_.find(VShaderID(shaderId));
 		if (iter == vsCache_.end()) {
 			return "";
 		}
@@ -277,7 +277,7 @@ std::string ShaderManagerD3D11::DebugGetShaderString(std::string id, DebugShader
 
 	case SHADER_TYPE_FRAGMENT:
 	{
-		auto iter = fsCache_.find(shaderId);
+		auto iter = fsCache_.find(FShaderID(shaderId));
 		if (iter == fsCache_.end()) {
 			return "";
 		}

--- a/GPU/D3D11/ShaderManagerD3D11.h
+++ b/GPU/D3D11/ShaderManagerD3D11.h
@@ -31,7 +31,7 @@ class D3D11PushBuffer;
 
 class D3D11FragmentShader {
 public:
-	D3D11FragmentShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, ShaderID id, const char *code, bool useHWTransform);
+	D3D11FragmentShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, FShaderID id, const char *code, bool useHWTransform);
 	~D3D11FragmentShader();
 
 	const std::string &source() const { return source_; }
@@ -49,12 +49,12 @@ protected:
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
-	ShaderID id_;
+	FShaderID id_;
 };
 
 class D3D11VertexShader {
 public:
-	D3D11VertexShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, ShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting);
+	D3D11VertexShader(ID3D11Device *device, D3D_FEATURE_LEVEL featureLevel, VShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting);
 	~D3D11VertexShader();
 
 	const std::string &source() const { return source_; }
@@ -81,7 +81,7 @@ protected:
 	bool failed_;
 	bool useHWTransform_;
 	bool usesLighting_;
-	ShaderID id_;
+	VShaderID id_;
 };
 
 class D3D11PushBuffer;
@@ -123,10 +123,10 @@ private:
 	ID3D11DeviceContext *context_;
 	D3D_FEATURE_LEVEL featureLevel_;
 
-	typedef std::map<ShaderID, D3D11FragmentShader *> FSCache;
+	typedef std::map<FShaderID, D3D11FragmentShader *> FSCache;
 	FSCache fsCache_;
 
-	typedef std::map<ShaderID, D3D11VertexShader *> VSCache;
+	typedef std::map<VShaderID, D3D11VertexShader *> VSCache;
 	VSCache vsCache_;
 
 	char *codeBuffer_;
@@ -144,6 +144,6 @@ private:
 	D3D11FragmentShader *lastFShader_;
 	D3D11VertexShader *lastVShader_;
 
-	ShaderID lastFSID_;
-	ShaderID lastVSID_;
+	FShaderID lastFSID_;
+	VShaderID lastVSID_;
 };

--- a/GPU/D3D11/VertexShaderGeneratorD3D11.cpp
+++ b/GPU/D3D11/VertexShaderGeneratorD3D11.cpp
@@ -19,7 +19,7 @@
 #include "GPU/D3D11/VertexShaderGeneratorD3D11.h"
 #include "GPU/Directx9/VertexShaderGeneratorDX9.h"
 
-void GenerateVertexShaderD3D11(const ShaderID &id, char *buffer, bool *usesLighting, ShaderLanguage lang) {
+void GenerateVertexShaderD3D11(const VShaderID &id, char *buffer, bool *usesLighting, ShaderLanguage lang) {
 	*usesLighting = true;
 	DX9::GenerateVertexShaderHLSL(id, buffer, lang);
 }

--- a/GPU/D3D11/VertexShaderGeneratorD3D11.h
+++ b/GPU/D3D11/VertexShaderGeneratorD3D11.h
@@ -19,4 +19,4 @@
 
 #include "GPU/Common/ShaderId.h"
 
-void GenerateVertexShaderD3D11(const ShaderID &id, char *buffer, bool *usesLighting, ShaderLanguage lang);
+void GenerateVertexShaderD3D11(const VShaderID &id, char *buffer, bool *usesLighting, ShaderLanguage lang);

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -33,7 +33,7 @@ namespace DX9 {
 
 // Missing: Z depth range
 // Also, logic ops etc, of course, as they are not supported in DX9.
-bool GenerateFragmentShaderHLSL(const ShaderID &id, char *buffer, ShaderLanguage lang) {
+bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguage lang) {
 	char *p = buffer;
 
 	bool lmode = id.Bit(FS_BIT_LMODE);

--- a/GPU/Directx9/PixelShaderGeneratorDX9.h
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.h
@@ -22,7 +22,7 @@
 
 namespace DX9 {
 
-bool GenerateFragmentShaderHLSL(const ShaderID &id, char *buffer, ShaderLanguage lang = HLSL_DX9);
+bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguage lang = HLSL_DX9);
 
 #define CONST_PS_TEXENV 0
 #define CONST_PS_ALPHACOLORREF 1

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -41,7 +41,7 @@
 
 namespace DX9 {
 
-PSShader::PSShader(LPDIRECT3DDEVICE9 device, ShaderID id, const char *code) : id_(id), shader(nullptr), failed_(false) {
+PSShader::PSShader(LPDIRECT3DDEVICE9 device, FShaderID id, const char *code) : id_(id), shader(nullptr), failed_(false) {
 	source_ = code;
 #ifdef SHADERLOG
 	OutputDebugString(ConvertUTF8ToWString(code).c_str());
@@ -91,7 +91,7 @@ std::string PSShader::GetShaderString(DebugShaderStringType type) const {
 	}
 }
 
-VSShader::VSShader(LPDIRECT3DDEVICE9 device, ShaderID id, const char *code, bool useHWTransform) : id_(id), shader(nullptr), failed_(false), useHWTransform_(useHWTransform) {
+VSShader::VSShader(LPDIRECT3DDEVICE9 device, VShaderID id, const char *code, bool useHWTransform) : id_(id), shader(nullptr), failed_(false), useHWTransform_(useHWTransform) {
 	source_ = code;
 #ifdef SHADERLOG
 	OutputDebugString(ConvertUTF8ToWString(code).c_str());
@@ -539,7 +539,7 @@ void ShaderManagerDX9::DirtyLastShader() { // disables vertex arrays
 VSShader *ShaderManagerDX9::ApplyShader(int prim, u32 vertType) {
 	bool useHWTransform = CanUseHardwareTransform(prim);
 
-	ShaderID VSID;
+	VShaderID VSID;
 	if (gstate_c.IsDirty(DIRTY_VERTEXSHADER_STATE)) {
 		gstate_c.Clean(DIRTY_VERTEXSHADER_STATE);
 		ComputeVertexShaderID(&VSID, vertType, useHWTransform);
@@ -547,7 +547,7 @@ VSShader *ShaderManagerDX9::ApplyShader(int prim, u32 vertType) {
 		VSID = lastVSID_;
 	}
 
-	ShaderID FSID;
+	FShaderID FSID;
 	if (gstate_c.IsDirty(DIRTY_FRAGMENTSHADER_STATE)) {
 		gstate_c.Clean(DIRTY_FRAGMENTSHADER_STATE);
 		ComputeFragmentShaderID(&FSID);
@@ -660,7 +660,7 @@ std::string ShaderManagerDX9::DebugGetShaderString(std::string id, DebugShaderTy
 	switch (type) {
 	case SHADER_TYPE_VERTEX:
 	{
-		auto iter = vsCache_.find(shaderId);
+		auto iter = vsCache_.find(VShaderID(shaderId));
 		if (iter == vsCache_.end()) {
 			return "";
 		}
@@ -669,7 +669,7 @@ std::string ShaderManagerDX9::DebugGetShaderString(std::string id, DebugShaderTy
 
 	case SHADER_TYPE_FRAGMENT:
 	{
-		auto iter = fsCache_.find(shaderId);
+		auto iter = fsCache_.find(FShaderID(shaderId));
 		if (iter == fsCache_.end()) {
 			return "";
 		}

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -37,7 +37,7 @@ class VSShader;
 
 class PSShader {
 public:
-	PSShader(LPDIRECT3DDEVICE9 device, ShaderID id, const char *code);
+	PSShader(LPDIRECT3DDEVICE9 device, FShaderID id, const char *code);
 	~PSShader();
 
 	const std::string &source() const { return source_; }
@@ -51,12 +51,12 @@ public:
 protected:	
 	std::string source_;
 	bool failed_;
-	ShaderID id_;
+	FShaderID id_;
 };
 
 class VSShader {
 public:
-	VSShader(LPDIRECT3DDEVICE9 device, ShaderID id, const char *code, bool useHWTransform);
+	VSShader(LPDIRECT3DDEVICE9 device, VShaderID id, const char *code, bool useHWTransform);
 	~VSShader();
 
 	const std::string &source() const { return source_; }
@@ -72,7 +72,7 @@ protected:
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
-	ShaderID id_;
+	VShaderID id_;
 };
 
 class ShaderManagerDX9 : public ShaderManagerCommon {
@@ -114,18 +114,18 @@ private:
 
 	LPDIRECT3DDEVICE9 device_;
 
-	ShaderID lastFSID_;
-	ShaderID lastVSID_;
+	FShaderID lastFSID_;
+	VShaderID lastVSID_;
 
 	char *codeBuffer_;
 
 	VSShader *lastVShader_;
 	PSShader *lastPShader_;
 
-	typedef std::map<ShaderID, PSShader *> FSCache;
+	typedef std::map<FShaderID, PSShader *> FSCache;
 	FSCache fsCache_;
 
-	typedef std::map<ShaderID, VSShader *> VSCache;
+	typedef std::map<VShaderID, VSShader *> VSCache;
 	VSCache vsCache_;
 };
 

--- a/GPU/Directx9/VertexShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.cpp
@@ -55,7 +55,7 @@ enum DoLightComputation {
 	LIGHT_FULL,
 };
 
-void GenerateVertexShaderHLSL(const ShaderID &id, char *buffer, ShaderLanguage lang) {
+void GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage lang) {
 	char *p = buffer;
 	const u32 vertType = gstate.vertType;
 

--- a/GPU/Directx9/VertexShaderGeneratorDX9.h
+++ b/GPU/Directx9/VertexShaderGeneratorDX9.h
@@ -23,7 +23,7 @@ namespace DX9 {
 
 // #define USE_BONE_ARRAY
 
-	void GenerateVertexShaderHLSL(const ShaderID &id, char *buffer, ShaderLanguage lang = HLSL_DX9);
+	void GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage lang = HLSL_DX9);
 
 #define CONST_VS_PROJ 0
 #define CONST_VS_PROJ_THROUGH 4

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -449,7 +449,7 @@ void DrawEngineGLES::DoFlush() {
 	ApplyDrawState(prim);
 	CHECK_GL_ERROR_IF_DEBUG();
 
-	ShaderID vsid;
+	VShaderID vsid;
 	Shader *vshader = shaderManager_->ApplyVertexShader(prim, lastVType_, &vsid);
 
 	if (vshader->UseHWTransform()) {

--- a/GPU/GLES/FragmentShaderGeneratorGLES.cpp
+++ b/GPU/GLES/FragmentShaderGeneratorGLES.cpp
@@ -36,7 +36,7 @@
 // #define DEBUG_SHADER
 
 // Missing: Z depth range
-bool GenerateFragmentShader(const ShaderID &id, char *buffer, uint64_t *uniformMask) {
+bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniformMask) {
 	char *p = buffer;
 
 	*uniformMask = 0;

--- a/GPU/GLES/FragmentShaderGeneratorGLES.h
+++ b/GPU/GLES/FragmentShaderGeneratorGLES.h
@@ -17,6 +17,6 @@
 
 #pragma once
 
-struct ShaderID;
+struct FShaderID;
 
-bool GenerateFragmentShader(const ShaderID &id, char *buffer, uint64_t *uniformMask);
+bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniformMask);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -92,7 +92,7 @@ Shader::~Shader() {
 		glDeleteShader(shader);
 }
 
-LinkedShader::LinkedShader(ShaderID VSID, Shader *vs, ShaderID FSID, Shader *fs, bool useHWTransform, bool preloading)
+LinkedShader::LinkedShader(VShaderID VSID, Shader *vs, FShaderID FSID, Shader *fs, bool useHWTransform, bool preloading)
 		: useHWTransform_(useHWTransform) {
 	PROFILE_THIS_SCOPE("shaderlink");
 
@@ -359,7 +359,7 @@ static inline void ScaleProjMatrix(Matrix4x4 &in) {
 	in.translateAndScale(trans, scale);
 }
 
-void LinkedShader::use(const ShaderID &VSID, LinkedShader *previous) {
+void LinkedShader::use(const VShaderID &VSID, LinkedShader *previous) {
 	glUseProgram(program);
 	int enable, disable;
 	if (previous) {
@@ -384,7 +384,7 @@ void LinkedShader::stop() {
 	}
 }
 
-void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid) {
+void LinkedShader::UpdateUniforms(u32 vertType, const VShaderID &vsid) {
 	CHECK_GL_ERROR_IF_DEBUG();
 
 	u64 dirty = dirtyUniforms & availableUniforms;
@@ -710,10 +710,10 @@ void ShaderManagerGLES::Clear() {
 	for (auto iter = linkedShaderCache_.begin(); iter != linkedShaderCache_.end(); ++iter) {
 		delete iter->ls;
 	}
-	fsCache_.Iterate([&](const ShaderID &key, Shader *shader) {
+	fsCache_.Iterate([&](const FShaderID &key, Shader *shader) {
 		delete shader;
 	});
-	vsCache_.Iterate([&](const ShaderID &key, Shader *shader) {
+	vsCache_.Iterate([&](const VShaderID &key, Shader *shader) {
 		delete shader;
 	});
 	linkedShaderCache_.clear();
@@ -743,7 +743,7 @@ void ShaderManagerGLES::DirtyLastShader() { // disables vertex arrays
 	lastVShaderSame_ = false;
 }
 
-Shader *ShaderManagerGLES::CompileFragmentShader(ShaderID FSID) {
+Shader *ShaderManagerGLES::CompileFragmentShader(FShaderID FSID) {
 	uint64_t uniformMask;
 	if (!GenerateFragmentShader(FSID, codeBuffer_, &uniformMask)) {
 		return nullptr;
@@ -751,7 +751,7 @@ Shader *ShaderManagerGLES::CompileFragmentShader(ShaderID FSID) {
 	return new Shader(FSID, codeBuffer_, GL_FRAGMENT_SHADER, false, 0, uniformMask);
 }
 
-Shader *ShaderManagerGLES::CompileVertexShader(ShaderID VSID) {
+Shader *ShaderManagerGLES::CompileVertexShader(VShaderID VSID) {
 	bool useHWTransform = VSID.Bit(VS_BIT_USE_HW_TRANSFORM);
 	uint32_t attrMask;
 	uint64_t uniformMask;
@@ -759,7 +759,7 @@ Shader *ShaderManagerGLES::CompileVertexShader(ShaderID VSID) {
 	return new Shader(VSID, codeBuffer_, GL_VERTEX_SHADER, useHWTransform, attrMask, uniformMask);
 }
 
-Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, ShaderID *VSID) {
+Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, VShaderID *VSID) {
 	uint64_t dirty = gstate_c.GetDirtyUniforms();
 	if (dirty) {
 		if (lastShader_)
@@ -801,7 +801,7 @@ Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, ShaderID *V
 			// next time and we'll do this over and over...
 
 			// Can still work with software transform.
-			ShaderID vsidTemp;
+			VShaderID vsidTemp;
 			ComputeVertexShaderID(&vsidTemp, vertType, false);
 			uint32_t attrMask;
 			uint64_t uniformMask;
@@ -815,8 +815,8 @@ Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, ShaderID *V
 	return vs;
 }
 
-LinkedShader *ShaderManagerGLES::ApplyFragmentShader(ShaderID VSID, Shader *vs, u32 vertType, int prim) {
-	ShaderID FSID;
+LinkedShader *ShaderManagerGLES::ApplyFragmentShader(VShaderID VSID, Shader *vs, u32 vertType, int prim) {
+	FShaderID FSID;
 	if (gstate_c.IsDirty(DIRTY_FRAGMENTSHADER_STATE)) {
 		gstate_c.Clean(DIRTY_FRAGMENTSHADER_STATE);
 		ComputeFragmentShaderID(&FSID);
@@ -890,7 +890,7 @@ std::vector<std::string> ShaderManagerGLES::DebugGetShaderIDs(DebugShaderType ty
 	switch (type) {
 	case SHADER_TYPE_VERTEX:
 		{
-			vsCache_.Iterate([&](const ShaderID &id, Shader *shader) {
+			vsCache_.Iterate([&](const VShaderID &id, Shader *shader) {
 				std::string idstr;
 				id.ToString(&idstr);
 				ids.push_back(idstr);
@@ -899,7 +899,7 @@ std::vector<std::string> ShaderManagerGLES::DebugGetShaderIDs(DebugShaderType ty
 		break;
 	case SHADER_TYPE_FRAGMENT:
 		{
-			fsCache_.Iterate([&](const ShaderID &id, Shader *shader) {
+			fsCache_.Iterate([&](const FShaderID &id, Shader *shader) {
 				std::string idstr;
 				id.ToString(&idstr);
 				ids.push_back(idstr);
@@ -918,13 +918,13 @@ std::string ShaderManagerGLES::DebugGetShaderString(std::string id, DebugShaderT
 	switch (type) {
 	case SHADER_TYPE_VERTEX:
 	{
-		Shader *vs = vsCache_.Get(shaderId);
+		Shader *vs = vsCache_.Get(VShaderID(shaderId));
 		return vs ? vs->GetShaderString(stringType, shaderId) : "";
 	}
 
 	case SHADER_TYPE_FRAGMENT:
 	{
-		Shader *fs = fsCache_.Get(shaderId);
+		Shader *fs = fsCache_.Get(FShaderID(shaderId));
 		return fs->GetShaderString(stringType, shaderId);
 	}
 	default:
@@ -975,7 +975,7 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 		return;
 
 	for (int i = 0; i < header.numVertexShaders; i++) {
-		ShaderID id;
+		VShaderID id;
 		if (!f.ReadArray(&id, 1)) {
 			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
@@ -1001,7 +1001,7 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 		}
 	}
 	for (int i = 0; i < header.numFragmentShaders; i++) {
-		ShaderID id;
+		FShaderID id;
 		if (!f.ReadArray(&id, 1)) {
 			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
@@ -1013,7 +1013,8 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 		}
 	}
 	for (int i = 0; i < header.numLinkedPrograms; i++) {
-		ShaderID vsid, fsid;
+		VShaderID vsid;
+		FShaderID fsid;
 		if (!f.ReadArray(&vsid, 1)) {
 			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -43,12 +43,12 @@ enum {
 
 class LinkedShader {
 public:
-	LinkedShader(ShaderID VSID, Shader *vs, ShaderID FSID, Shader *fs, bool useHWTransform, bool preloading = false);
+	LinkedShader(VShaderID VSID, Shader *vs, FShaderID FSID, Shader *fs, bool useHWTransform, bool preloading = false);
 	~LinkedShader();
 
-	void use(const ShaderID &VSID, LinkedShader *previous);
+	void use(const VShaderID &VSID, LinkedShader *previous);
 	void stop();
-	void UpdateUniforms(u32 vertType, const ShaderID &VSID);
+	void UpdateUniforms(u32 vertType, const VShaderID &VSID);
 
 	Shader *vs_;
 	// Set to false if the VS failed, happens on Mali-400 a lot for complex shaders.
@@ -154,8 +154,8 @@ public:
 
 	// This is the old ApplyShader split into two parts, because of annoying information dependencies.
 	// If you call ApplyVertexShader, you MUST call ApplyFragmentShader soon afterwards.
-	Shader *ApplyVertexShader(int prim, u32 vertType, ShaderID *VSID);
-	LinkedShader *ApplyFragmentShader(ShaderID VSID, Shader *vs, u32 vertType, int prim);
+	Shader *ApplyVertexShader(int prim, u32 vertType, VShaderID *VSID);
+	LinkedShader *ApplyFragmentShader(VShaderID VSID, Shader *vs, u32 vertType, int prim);
 
 	void DirtyShader();
 	void DirtyLastShader() override;  // disables vertex arrays
@@ -172,8 +172,8 @@ public:
 
 private:
 	void Clear();
-	Shader *CompileFragmentShader(ShaderID id);
-	Shader *CompileVertexShader(ShaderID id);
+	Shader *CompileFragmentShader(FShaderID id);
+	Shader *CompileVertexShader(VShaderID id);
 
 	struct LinkedShaderCacheEntry {
 		LinkedShaderCacheEntry(Shader *vs_, Shader *fs_, LinkedShader *ls_)
@@ -189,17 +189,17 @@ private:
 
 	bool lastVShaderSame_;
 
-	ShaderID lastFSID_;
-	ShaderID lastVSID_;
+	FShaderID lastFSID_;
+	VShaderID lastVSID_;
 
 	LinkedShader *lastShader_;
 	u64 shaderSwitchDirtyUniforms_;
 	char *codeBuffer_;
 
-	typedef DenseHashMap<ShaderID, Shader *, nullptr> FSCache;
+	typedef DenseHashMap<FShaderID, Shader *, nullptr> FSCache;
 	FSCache fsCache_;
 
-	typedef DenseHashMap<ShaderID, Shader *, nullptr> VSCache;
+	typedef DenseHashMap<VShaderID, Shader *, nullptr> VSCache;
 	VSCache vsCache_;
 
 	bool diskCacheDirty_;

--- a/GPU/GLES/VertexShaderGeneratorGLES.cpp
+++ b/GPU/GLES/VertexShaderGeneratorGLES.cpp
@@ -95,7 +95,7 @@ enum DoLightComputation {
 // is a bit of a rare configuration, although quite common on mobile.
 
 
-void GenerateVertexShader(const ShaderID &id, char *buffer, uint32_t *attrMask, uint64_t *uniformMask) {
+void GenerateVertexShader(const VShaderID &id, char *buffer, uint32_t *attrMask, uint64_t *uniformMask) {
 	char *p = buffer;
 	*attrMask = 0;
 	*uniformMask = 0;

--- a/GPU/GLES/VertexShaderGeneratorGLES.h
+++ b/GPU/GLES/VertexShaderGeneratorGLES.h
@@ -21,6 +21,6 @@
 
 // #define USE_BONE_ARRAY
 
-struct ShaderID;
+struct VShaderID;
 
-void GenerateVertexShader(const ShaderID &id, char *buffer, uint32_t *attrMask, uint64_t *uniformMask);
+void GenerateVertexShader(const VShaderID &id, char *buffer, uint32_t *attrMask, uint64_t *uniformMask);

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -41,7 +41,7 @@ static const char *vulkan_glsl_preamble =
 #define WRITE p+=sprintf
 
 // Missing: Z depth range
-bool GenerateVulkanGLSLFragmentShader(const ShaderID &id, char *buffer) {
+bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 	char *p = buffer;
 
 	const char *lastFragData = nullptr;

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.h
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.h
@@ -18,6 +18,6 @@
 
 #pragma once
 
-struct ShaderID;
+struct FShaderID;
 
-bool GenerateVulkanGLSLFragmentShader(const ShaderID &id, char *buffer);
+bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer);

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -33,7 +33,7 @@ class VulkanPushBuffer;
 
 class VulkanFragmentShader {
 public:
-	VulkanFragmentShader(VulkanContext *vulkan, ShaderID id, const char *code, bool useHWTransform);
+	VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, const char *code, bool useHWTransform);
 	~VulkanFragmentShader();
 
 	const std::string &source() const { return source_; }
@@ -51,12 +51,12 @@ protected:
 	std::string source_;
 	bool failed_;
 	bool useHWTransform_;
-	ShaderID id_;
+	FShaderID id_;
 };
 
 class VulkanVertexShader {
 public:
-	VulkanVertexShader(VulkanContext *vulkan, ShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting);
+	VulkanVertexShader(VulkanContext *vulkan, VShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting);
 	~VulkanVertexShader();
 
 	const std::string &source() const { return source_; }
@@ -81,7 +81,7 @@ protected:
 	bool failed_;
 	bool useHWTransform_;
 	bool usesLighting_;
-	ShaderID id_;
+	VShaderID id_;
 };
 
 class VulkanPushBuffer;
@@ -128,10 +128,10 @@ private:
 
 	VulkanContext *vulkan_;
 
-	typedef DenseHashMap<ShaderID, VulkanFragmentShader *, nullptr> FSCache;
+	typedef DenseHashMap<FShaderID, VulkanFragmentShader *, nullptr> FSCache;
 	FSCache fsCache_;
 
-	typedef DenseHashMap<ShaderID, VulkanVertexShader *, nullptr> VSCache;
+	typedef DenseHashMap<VShaderID, VulkanVertexShader *, nullptr> VSCache;
 	VSCache vsCache_;
 
 	char *codeBuffer_;
@@ -145,6 +145,6 @@ private:
 	VulkanFragmentShader *lastFShader_;
 	VulkanVertexShader *lastVShader_;
 
-	ShaderID lastFSID_;
-	ShaderID lastVSID_;
+	FShaderID lastFSID_;
+	VShaderID lastVSID_;
 };

--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
@@ -97,7 +97,7 @@ enum DoLightComputation {
 // TODO: Skip all this if we can actually get a 16-bit depth buffer along with stencil, which
 // is a bit of a rare configuration, although quite common on mobile.
 
-bool GenerateVulkanGLSLVertexShader(const ShaderID &id, char *buffer, bool *usesLighting) {
+bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer, bool *usesLighting) {
 	char *p = buffer;
 
 	WRITE(p, "%s", vulkan_glsl_preamble);

--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.h
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.h
@@ -2,4 +2,4 @@
 
 #include "GPU/Common/ShaderId.h"
 
-bool GenerateVulkanGLSLVertexShader(const ShaderID &id, char *buffer, bool *usesLighting);
+bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer, bool *usesLighting);


### PR DESCRIPTION
Expected to take care of #10210.  Still not actually reproduced, though.

Grow() made the assumption that `std::move(foo)` would default construct/clear/etc. `foo`, which isn't a guarantee.  This explicitly clears the state and map, and adds an assert to validate the count stayed constant (just in case, although it wasn't actually wrong.)

Before I found this, I added typesafety for VShaderID/FShaderID, which didn't help, but I think is still worthwhile to keep.

Additionally, this validates shader cache filesize on load, which should prevent the incorrect shaders from being preloaded, even if they were saved in a previous session.

-[Unknown]