### PR TITLE
GLES: Improve shader cache logging, another hashmap fix

### DIFF
--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -131,6 +131,7 @@ public:
 
 	void Clear() {
 		memset(state.data(), (int)BucketState::FREE, state.size());
+		count_ = 0;
 	}
 
 	void Rebuild() {
@@ -275,6 +276,7 @@ public:
 
 	void Clear() {
 		memset(state.data(), (int)BucketState::FREE, state.size());
+		count_ = 0;
 	}
 
 	// Gets rid of REMOVED tombstones, making lookups somewhat more efficient.

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -983,14 +983,13 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 	expectedSize += header.numFragmentShaders * sizeof(FShaderID);
 	expectedSize += header.numLinkedPrograms * (sizeof(VShaderID) + sizeof(FShaderID));
 	if (sz != expectedSize) {
-		ERROR_LOG(G3D, "Shader cache file is too large, aborting.");
+		ERROR_LOG(G3D, "Shader cache file is wrong size: %lld instead of %lld", sz, expectedSize);
 		return;
 	}
 
 	for (int i = 0; i < header.numVertexShaders; i++) {
 		VShaderID id;
 		if (!f.ReadArray(&id, 1)) {
-			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
 		}
 		if (!vsCache_.Get(id)) {
@@ -1016,7 +1015,6 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 	for (int i = 0; i < header.numFragmentShaders; i++) {
 		FShaderID id;
 		if (!f.ReadArray(&id, 1)) {
-			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
 		}
 		if (!fsCache_.Get(id)) {
@@ -1029,11 +1027,9 @@ void ShaderManagerGLES::LoadAndPrecompile(const std::string &filename) {
 		VShaderID vsid;
 		FShaderID fsid;
 		if (!f.ReadArray(&vsid, 1)) {
-			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
 		}
 		if (!f.ReadArray(&fsid, 1)) {
-			ERROR_LOG(G3D, "Truncated shader cache file, aborting.");
 			return;
 		}
 		Shader *vs = vsCache_.Get(vsid);


### PR DESCRIPTION
Followup to #10231.  Removed the truncation logs because they shouldn't really happen with the size check anyway.  No need for extra code, especially of the "we enjoy typing" variant.

Fixes #10233.

-[Unknown]