### PR TITLE
UI: Handle messages even when dialog is top

### DIFF
--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -132,6 +132,7 @@ public:
 	void Clear() {
 		memset(state.data(), (int)BucketState::FREE, state.size());
 		count_ = 0;
+		removedCount_ = 0;
 	}
 
 	void Rebuild() {
@@ -277,6 +278,7 @@ public:
 	void Clear() {
 		memset(state.data(), (int)BucketState::FREE, state.size());
 		count_ = 0;
+		removedCount_ = 0;
 	}
 
 	// Gets rid of REMOVED tombstones, making lookups somewhat more efficient.

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -256,7 +256,7 @@ void ControlMappingScreen::sendMessage(const char *message, const char *value) {
 	// Always call the base class method first to handle the most common messages.
 	UIDialogScreenWithBackground::sendMessage(message, value);
 
-	if (!strcmp(message, "settings")) {
+	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new GameSettingsScreen(""));
 	}

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -252,16 +252,6 @@ void ControlMappingScreen::CreateViews() {
 	}
 }
 
-void ControlMappingScreen::sendMessage(const char *message, const char *value) {
-	// Always call the base class method first to handle the most common messages.
-	UIDialogScreenWithBackground::sendMessage(message, value);
-
-	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new GameSettingsScreen(""));
-	}
-}
-
 UI::EventReturn ControlMappingScreen::OnClearMapping(UI::EventParams &params) {
 	KeyMap::g_controllerMap.clear();
 	RecreateViews();

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -33,6 +33,8 @@ class ControlMappingScreen : public UIDialogScreenWithBackground {
 public:
 	ControlMappingScreen() {}
 	void KeyMapped(int pspkey);  // Notification to let us refocus the same one after recreating views.
+	std::string tag() const override { return "control mapping"; }
+
 protected:
 	virtual void CreateViews() override;
 private:

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -35,7 +35,6 @@ public:
 	void KeyMapped(int pspkey);  // Notification to let us refocus the same one after recreating views.
 protected:
 	virtual void CreateViews() override;
-	virtual void sendMessage(const char *message, const char *value) override;
 private:
 	UI::EventReturn OnDefaultMapping(UI::EventParams &params);
 	UI::EventReturn OnClearMapping(UI::EventParams &params);

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -31,6 +31,7 @@ public:
 	virtual bool touch(const TouchInput &touch) override;
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 	virtual void onFinish(DialogResult reason) override;
+	std::string tag() const override { return "display layout screen"; }
 	
 protected:
 	virtual UI::EventReturn OnCenter(UI::EventParams &e);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -311,7 +311,7 @@ static void AfterStateBoot(bool success, const std::string &message, void *ignor
 
 void EmuScreen::sendMessage(const char *message, const char *value) {
 	// External commands, like from the Windows UI.
-	if (!strcmp(message, "pause")) {
+	if (!strcmp(message, "pause") && screenManager()->topScreen() == this) {
 		releaseButtons();
 		screenManager()->push(new GamePauseScreen(gamePath_));
 	} else if (!strcmp(message, "lost_focus")) {
@@ -346,15 +346,15 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			bootPending_ = true;
 			bootGame(value);
 		}
-	} else if (!strcmp(message, "control mapping")) {
+	} else if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		releaseButtons();
 		screenManager()->push(new ControlMappingScreen());
-	} else if (!strcmp(message, "display layout editor")) {
+	} else if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		releaseButtons();
 		screenManager()->push(new DisplayLayoutScreen());
-	} else if (!strcmp(message, "settings")) {
+	} else if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		releaseButtons();
 		screenManager()->push(new GameSettingsScreen(gamePath_));

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -35,7 +35,7 @@ public:
 
 	virtual void update();
 
-	virtual std::string tag() const { return "game"; }
+	std::string tag() const override { return "game"; }
 
 protected:
 	virtual void CreateViews();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1036,11 +1036,11 @@ void GameSettingsScreen::sendMessage(const char *message, const char *value) {
 	// Always call the base class method first to handle the most common messages.
 	UIDialogScreenWithBackground::sendMessage(message, value);
 
-	if (!strcmp(message, "control mapping")) {
+	if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new ControlMappingScreen());
 	}
-	if (!strcmp(message, "display layout editor")) {
+	if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new DisplayLayoutScreen());
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1032,20 +1032,6 @@ void GameSettingsScreen::update() {
 	}
 }
 
-void GameSettingsScreen::sendMessage(const char *message, const char *value) {
-	// Always call the base class method first to handle the most common messages.
-	UIDialogScreenWithBackground::sendMessage(message, value);
-
-	if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new ControlMappingScreen());
-	}
-	if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new DisplayLayoutScreen());
-	}
-}
-
 void GameSettingsScreen::onFinish(DialogResult result) {
 	if (g_Config.bEnableSound) {
 		if (PSP_IsInited() && !IsAudioInitialised())

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -30,6 +30,7 @@ public:
 
 	virtual void update();
 	virtual void onFinish(DialogResult result);
+	std::string tag() const override { return "settings"; }
 
 	UI::Event OnRecentChanged;
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -63,7 +63,6 @@ private:
 	UI::EventReturn OnControlMapping(UI::EventParams &e);
 	UI::EventReturn OnTouchControlLayout(UI::EventParams &e);
 	UI::EventReturn OnDumpNextFrameToLog(UI::EventParams &e);
-	UI::EventReturn OnReloadCheats(UI::EventParams &e);
 	UI::EventReturn OnTiltTypeChange(UI::EventParams &e);
 	UI::EventReturn OnTiltCustomize(UI::EventParams &e);
 	UI::EventReturn OnComboKey(UI::EventParams &e);
@@ -85,7 +84,6 @@ private:
 	UI::EventReturn OnDisplayLayoutEditor(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
 	UI::EventReturn OnHwScaleChange(UI::EventParams &e);
-	UI::EventReturn OnShaderChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 	UI::EventReturn OnRenderingMode(UI::EventParams &e);
 	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
@@ -119,7 +117,6 @@ private:
 	bool postProcEnable_;
 	bool resolutionEnable_;
 	bool bloomHackEnable_;
-	bool bezierChoiceDisable_;
 	bool tessHWEnable_;
 };
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -35,7 +35,6 @@ public:
 
 protected:
 	virtual void CreateViews();
-	virtual void sendMessage(const char *message, const char *value);
 	void CallbackRestoreDefaults(bool yes);
 	void CallbackRenderingBackend(bool yes);
 	bool UseVerticalLayout() const;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -935,18 +935,10 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 	// Always call the base class method first to handle the most common messages.
 	UIScreenWithBackground::sendMessage(message, value);
 
-	if (!strcmp(message, "boot")) {
+	if (!strcmp(message, "boot") && screenManager()->topScreen() == this) {
 		screenManager()->switchScreen(new EmuScreen(value));
 	}
-	if (!strcmp(message, "control mapping")) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new ControlMappingScreen());
-	}
-	if (!strcmp(message, "display layout editor")) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new DisplayLayoutScreen());
-	}
-	if (!strcmp(message, "settings")) {
+	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		screenManager()->push(new GameSettingsScreen(""));
 	}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -938,10 +938,6 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 	if (!strcmp(message, "boot") && screenManager()->topScreen() == this) {
 		screenManager()->switchScreen(new EmuScreen(value));
 	}
-	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
-		screenManager()->push(new GameSettingsScreen(""));
-	}
 	if (!strcmp(message, "permission_granted") && !strcmp(value, "storage")) {
 		RecreateViews();
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -165,13 +165,13 @@ void HandleCommonMessages(const char *message, const char *value, ScreenManager 
 		if (PSP_IsInited()) {
 			currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
 		}
-	} else if (!strcmp(message, "control mapping") && isActiveScreen) {
+	} else if (!strcmp(message, "control mapping") && isActiveScreen && activeScreen->tag() != "control mapping") {
 		UpdateUIState(UISTATE_MENU);
 		manager->push(new ControlMappingScreen());
-	} else if (!strcmp(message, "display layout editor") && isActiveScreen) {
+	} else if (!strcmp(message, "display layout editor") && isActiveScreen && activeScreen->tag() != "display layout screen") {
 		UpdateUIState(UISTATE_MENU);
 		manager->push(new DisplayLayoutScreen());
-	} else if (!strcmp(message, "settings") && isActiveScreen) {
+	} else if (!strcmp(message, "settings") && isActiveScreen && activeScreen->tag() != "settings") {
 		UpdateUIState(UISTATE_MENU);
 		manager->push(new GameSettingsScreen(""));
 	} else if (!strcmp(message, "language screen") && isActiveScreen) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -155,7 +155,7 @@ void DrawGameBackground(UIContext &dc, const std::string &gamePath) {
 	}
 }
 
-void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager) {
+void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager, Screen *activeScreen) {
 	if (!strcmp(message, "clear jit")) {
 		if (MIPSComp::jit && PSP_IsInited()) {
 			MIPSComp::jit->ClearCache();
@@ -163,9 +163,11 @@ void HandleCommonMessages(const char *message, const char *value, ScreenManager 
 		if (PSP_IsInited()) {
 			currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
 		}
-	} else if (!strcmp(message, "control mapping")) {
+	} else if (!strcmp(message, "control mapping") && manager->topScreen() == activeScreen) {
+		UpdateUIState(UISTATE_MENU);
 		manager->push(new ControlMappingScreen());
-	} else if (!strcmp(message, "display layout editor")) {
+	} else if (!strcmp(message, "display layout editor") && manager->topScreen() == activeScreen) {
+		UpdateUIState(UISTATE_MENU);
 		manager->push(new DisplayLayoutScreen());
 	} else if (!strcmp(message, "window minimized")) {
 		if (!strcmp(value, "true")) {
@@ -191,7 +193,7 @@ void UIScreenWithGameBackground::DrawBackground(UIContext &dc) {
 }
 
 void UIScreenWithGameBackground::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "settings")) {
+	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		screenManager()->push(new GameSettingsScreen(gamePath_));
 	} else {
 		UIScreenWithBackground::sendMessage(message, value);
@@ -203,7 +205,7 @@ void UIDialogScreenWithGameBackground::DrawBackground(UIContext &dc) {
 }
 
 void UIDialogScreenWithGameBackground::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "settings")) {
+	if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		screenManager()->push(new GameSettingsScreen(gamePath_));
 	} else {
 		UIDialogScreenWithBackground::sendMessage(message, value);
@@ -211,13 +213,13 @@ void UIDialogScreenWithGameBackground::sendMessage(const char *message, const ch
 }
 
 void UIScreenWithBackground::sendMessage(const char *message, const char *value) {
-	HandleCommonMessages(message, value, screenManager());
+	HandleCommonMessages(message, value, screenManager(), this);
 	I18NCategory *dev = GetI18NCategory("Developer");
-	if (!strcmp(message, "language screen")) {
+	if (!strcmp(message, "language screen") && screenManager()->topScreen() == this) {
 		auto langScreen = new NewLanguageScreen(dev->T("Language"));
 		langScreen->OnChoice.Handle(this, &UIScreenWithBackground::OnLanguageChange);
 		screenManager()->push(langScreen);
-	} else if (!strcmp(message, "settings")) {
+	} else if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		screenManager()->push(new GameSettingsScreen("", ""));
 	}
 }
@@ -252,13 +254,13 @@ void UIDialogScreenWithBackground::AddStandardBack(UI::ViewGroup *parent) {
 }
 
 void UIDialogScreenWithBackground::sendMessage(const char *message, const char *value) {
-	HandleCommonMessages(message, value, screenManager());
+	HandleCommonMessages(message, value, screenManager(), this);
 	I18NCategory *dev = GetI18NCategory("Developer");
-	if (!strcmp(message, "language screen")) {
+	if (!strcmp(message, "language screen") && screenManager()->topScreen() == this) {
 		auto langScreen = new NewLanguageScreen(dev->T("Language"));
 		langScreen->OnChoice.Handle(this, &UIDialogScreenWithBackground::OnLanguageChange);
 		screenManager()->push(langScreen);
-	} else if (!strcmp(message, "settings")) {
+	} else if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		screenManager()->push(new GameSettingsScreen("", ""));
 	}
 }
@@ -447,7 +449,7 @@ void LogoScreen::update() {
 }
 
 void LogoScreen::sendMessage(const char *message, const char *value) {
-	if (!strcmp(message, "boot")) {
+	if (!strcmp(message, "boot") && screenManager()->topScreen() == this) {
 		screenManager()->switchScreen(new EmuScreen(value));
 	}
 }

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -39,7 +39,6 @@ public:
 protected:
 	void DrawBackground(UIContext &dc) override;
 	void sendMessage(const char *message, const char *value) override;
-	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 };
 
 class UIScreenWithGameBackground : public UIScreenWithBackground {
@@ -58,7 +57,6 @@ public:
 protected:
 	void DrawBackground(UIContext &dc) override;
 	void sendMessage(const char *message, const char *value) override;
-	UI::EventReturn OnLanguageChange(UI::EventParams &e);
 
 	void AddStandardBack(UI::ViewGroup *parent);
 };

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -433,6 +433,7 @@ UI::EventReturn GamePauseScreen::OnCreateConfig(UI::EventParams &e)
 	screenManager()->topScreen()->RecreateViews();
 	return UI::EVENT_DONE;
 }
+
 UI::EventReturn GamePauseScreen::OnDeleteConfig(UI::EventParams &e)
 {
 	I18NCategory *di = GetI18NCategory("Dialog");
@@ -442,14 +443,4 @@ UI::EventReturn GamePauseScreen::OnDeleteConfig(UI::EventParams &e)
 		std::bind(&GamePauseScreen::CallbackDeleteConfig, this, std::placeholders::_1)));
 
 	return UI::EVENT_DONE;
-}
-
-
-void GamePauseScreen::sendMessage(const char *message, const char *value) {
-	UIDialogScreenWithGameBackground::sendMessage(message, value);
-	// Since the language message isn't allowed to be in native, we have to have add this
-	// to every screen which directly inherits from UIScreen(which are few right now, luckily).
-	if (!strcmp(message, "language")) {
-		screenManager()->RecreateAllViews();
-	}
 }

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -35,7 +35,6 @@ public:
 protected:
 	virtual void CreateViews() override;
 	virtual void update() override;
-	virtual void sendMessage(const char *message, const char *value) override;
 	void CallbackDeleteConfig(bool yes);
 
 private:

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -127,6 +127,7 @@ public:
 
 	// Pops the dialog away.
 	void finishDialog(Screen *dialog, DialogResult result = DR_OK);
+	Screen *dialogParent(const Screen *dialog) const;
 
 	// Instant touch, separate from the update() mechanism.
 	bool touch(const TouchInput &touch);

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -162,6 +162,13 @@ bool UIDialogScreen::key(const KeyInput &key) {
 	return retval;
 }
 
+void UIDialogScreen::sendMessage(const char *msg, const char *value) {
+	Screen *screen = screenManager()->dialogParent(this);
+	if (screen) {
+		screen->sendMessage(msg, value);
+	}
+}
+
 bool UIScreen::axis(const AxisInput &axis) {
 	// Simple translation of hat to keys for Shield and other modern pads.
 	// TODO: Use some variant of keymap?

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -55,7 +55,8 @@ private:
 class UIDialogScreen : public UIScreen {
 public:
 	UIDialogScreen() : UIScreen(), finished_(false) {}
-	virtual bool key(const KeyInput &key) override;
+	bool key(const KeyInput &key) override;
+	void sendMessage(const char *msg, const char *value) override;
 
 private:
 	bool finished_;


### PR DESCRIPTION
Before screen transitions, dialogs went away immediately, but now they (quickly) animate out.

Unfortunately, as a side effect, the dialog received messages - such as ones to clear caches.  We always want these messages to be handled by the parent, really.

This does exactly that.  It also centralizes and cleans up some common messages, to cut down on duplicate code, and places where menu options wouldn't work.  It also fixes some cases of duplicate pushes on the main screen.

Fixes #10224 - now the CPU core can be changed without restarting, again.

-[Unknown]