### PR TITLE
UI: Send prompt results even on back/cancel

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -275,20 +275,23 @@ void PromptScreen::CreateViews() {
 	Choice *yesButton = rightColumnItems->Add(new Choice(yesButtonText_));
 	yesButton->OnClick.Handle(this, &PromptScreen::OnYes);
 	root_->SetDefaultFocusView(yesButton);
-	if (noButtonText_ != "")
+	if (!noButtonText_.empty())
 		rightColumnItems->Add(new Choice(noButtonText_))->OnClick.Handle(this, &PromptScreen::OnNo);
 }
 
 UI::EventReturn PromptScreen::OnYes(UI::EventParams &e) {
-	callback_(true);
 	TriggerFinish(DR_OK);
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn PromptScreen::OnNo(UI::EventParams &e) {
-	callback_(false);
 	TriggerFinish(DR_CANCEL);
 	return UI::EVENT_DONE;
+}
+
+void PromptScreen::TriggerFinish(DialogResult result) {
+	callback_(result == DR_OK || result == DR_YES);
+	UIDialogScreenWithBackground::TriggerFinish(result);
 }
 
 PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title) {

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -78,6 +78,8 @@ public:
 
 	void CreateViews() override;
 
+	void TriggerFinish(DialogResult result) override;
+
 private:
 	UI::EventReturn OnYes(UI::EventParams &e);
 	UI::EventReturn OnNo(UI::EventParams &e);


### PR DESCRIPTION
Before, if you went to the GPU backend prompt, and canceled, it would never call the callback, and so the g_Config value never got reset.

-[Unknown]