### PR TITLE
Use a VulkanDeviceAllocator for thin3d textures. Saves on allocations.

### DIFF
--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -1,5 +1,6 @@
 #include "Common/Vulkan/VulkanImage.h"
 #include "Common/Vulkan/VulkanMemory.h"
+#include "Common/Log.h"
 
 VkResult VulkanTexture::Create(int w, int h, VkFormat format) {
 	tex_width = w;
@@ -294,6 +295,7 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int numMips,
 
 		res = vkAllocateMemory(vulkan_->GetDevice(), &mem_alloc, NULL, &mem);
 		if (res != VK_SUCCESS) {
+			_assert_msg_(G3D, res != VK_ERROR_TOO_MANY_OBJECTS, "Too many Vulkan memory objects!");
 			assert(res == VK_ERROR_OUT_OF_HOST_MEMORY || res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_TOO_MANY_OBJECTS);
 			return false;
 		}

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -8,7 +8,7 @@ class VulkanDeviceAllocator;
 // Not very optimal - if you have many small textures you should use other strategies.
 class VulkanTexture {
 public:
-	VulkanTexture(VulkanContext *vulkan, VulkanDeviceAllocator *allocator = nullptr)
+	VulkanTexture(VulkanContext *vulkan, VulkanDeviceAllocator *allocator)
 		: vulkan_(vulkan), image(VK_NULL_HANDLE), mem(VK_NULL_HANDLE), view(VK_NULL_HANDLE),
 		tex_width(0), tex_height(0), numMips_(1), format_(VK_FORMAT_UNDEFINED),
 		mappableImage(VK_NULL_HANDLE), mappableMemory(VK_NULL_HANDLE),

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -246,16 +246,15 @@ bool VulkanDeviceAllocator::AllocateFromSlab(Slab &slab, size_t &start, size_t b
 		return false;
 	}
 
-	// Slow linear scan.
 	for (size_t i = 0; i < blocks; ++i) {
 		if (slab.usage[start + i]) {
 			// If we just ran into one, there's probably an allocation size.
 			auto it = slab.allocSizes.find(start + i);
 			if (it != slab.allocSizes.end()) {
-				start += it->second;
+				start += i + it->second;
 			} else {
 				// We don't know how big it is, so just skip to the next one.
-				start += 1;
+				start += i + 1;
 			}
 			return false;
 		}

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -246,15 +246,16 @@ bool VulkanDeviceAllocator::AllocateFromSlab(Slab &slab, size_t &start, size_t b
 		return false;
 	}
 
+	// Slow linear scan.
 	for (size_t i = 0; i < blocks; ++i) {
 		if (slab.usage[start + i]) {
 			// If we just ran into one, there's probably an allocation size.
 			auto it = slab.allocSizes.find(start + i);
 			if (it != slab.allocSizes.end()) {
-				start += i + it->second;
+				start += it->second;
 			} else {
 				// We don't know how big it is, so just skip to the next one.
-				start += i + 1;
+				start += 1;
 			}
 			return false;
 		}

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -169,11 +169,10 @@ void VulkanDeviceAllocator::Destroy() {
 	for (Slab &slab : slabs_) {
 		// Did anyone forget to free?
 		for (auto pair : slab.allocSizes) {
-			if (slab.usage[pair.first] != 2) {
-				// If it's not 2 (queued), there's a problem.
-				// If it's zero, it means allocSizes is somehow out of sync.
-				Crash();
-			}
+			int slabUsage = slab.usage[pair.first];
+			// If it's not 2 (queued), there's a problem.
+			// If it's zero, it means allocSizes is somehow out of sync.
+			_assert_msg_(G3D, slabUsage == 2, "Destroy: slabUsage has unexpected value %d", slabUsage);
 		}
 
 		assert(slab.deviceMemory);

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -278,6 +278,8 @@ bool VulkanDeviceAllocator::AllocateFromSlab(Slab &slab, size_t &start, size_t b
 void VulkanDeviceAllocator::Free(VkDeviceMemory deviceMemory, size_t offset) {
 	assert(!destroyed_);
 
+	_assert_msg_(G3D, !slabs_.empty(), "No slabs - can't be anything to free! double-freed?");
+
 	// First, let's validate.  This will allow stack traces to tell us when frees are bad.
 	size_t start = offset >> SLAB_GRAIN_SHIFT;
 	bool found = false;

--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -146,6 +146,10 @@ public:
 
 	static const size_t ALLOCATE_FAILED = -1;
 
+	int GetBlockCount() const { return (int)slabs_.size(); }
+	int GetMinSlabSize() const { return (int)minSlabSize_; }
+	int GetMaxSlabSize() const { return (int)maxSlabSize_; }
+
 private:
 	static const size_t SLAB_GRAIN_SIZE = 1024;
 	static const uint8_t SLAB_GRAIN_SHIFT = 10;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -296,7 +296,7 @@ void DrawEngineVulkan::BeginFrame() {
 	if (!nullTexture_) {
 		ILOG("INIT : Creating null texture");
 		VkCommandBuffer cmdInit = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
-		nullTexture_ = new VulkanTexture(vulkan_);
+		nullTexture_ = new VulkanTexture(vulkan_, textureCache_->GetAllocator());
 		int w = 8;
 		int h = 8;
 		nullTexture_->CreateDirect(cmdInit, w, h, 1, VK_FORMAT_A8B8G8R8_UNORM_PACK32, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -205,7 +205,8 @@ void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFor
 
 	VkCommandBuffer initCmd = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 
-	drawPixelsTex_ = new VulkanTexture(vulkan_);
+	// There's only ever a few of these alive, don't need to stress the allocator with these big ones.
+	drawPixelsTex_ = new VulkanTexture(vulkan_, nullptr);
 	if (!drawPixelsTex_->CreateDirect(initCmd, width, height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT)) {
 		// out of memory?
 		delete drawPixelsTex_;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -638,6 +638,8 @@ void GPU_Vulkan::DeviceRestore() {
 
 void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	const DrawEngineVulkanStats &drawStats = drawEngine_.GetStats();
+	char texStats[256];
+	textureCacheVulkan_->GetStats(texStats, sizeof(texStats));
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
@@ -652,7 +654,8 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Readbacks: %d\n"
 		"Vertex, Fragment, Pipelines loaded: %i, %i, %i\n"
-		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n",
+		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n"
+		"%s\n",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
 		gpuStats.numDrawCalls,
 		gpuStats.numFlushes,
@@ -674,7 +677,8 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		pipelineManager_->GetNumPipelines(),
 		drawStats.pushUBOSpaceUsed,
 		drawStats.pushVertexSpaceUsed,
-		drawStats.pushIndexSpaceUsed
+		drawStats.pushIndexSpaceUsed,
+		texStats
 	);
 }
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -168,6 +168,7 @@ GPU_Vulkan::~GPU_Vulkan() {
 	framebufferManagerVulkan_->DestroyAllFBOs();
 	vulkan2D_.Shutdown();
 	depalShaderCache_.Clear();
+	drawEngine_.DeviceLost();
 	delete textureCacheVulkan_;
 	delete pipelineManager_;
 	delete shaderManagerVulkan_;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -589,6 +589,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 		}
 
 		if (!allocSuccess) {
+			ERROR_LOG(G3D, "Failed to create texture (%dx%d)", w, h);
 			delete entry->vkTex;
 			entry->vkTex = nullptr;
 		}
@@ -650,9 +651,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry, bool replaceIm
 		if (replaced.Valid()) {
 			entry->SetAlphaStatus(TexCacheEntry::Status(replaced.AlphaStatus()));
 		}
+		entry->vkTex->texture_->EndCreate(cmdInit);
 	}
-
-	entry->vkTex->texture_->EndCreate(cmdInit);
 
 	gstate_c.SetTextureFullAlpha(entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL);
 }

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -816,6 +816,10 @@ bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int leve
 	// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
 	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE);
 	framebufferManager_->RebindFramebuffer();
-
 	return true;
+}
+
+void TextureCacheVulkan::GetStats(char *ptr, size_t size) {
+	snprintf(ptr, size, "Alloc: %d blocks\nSlab min/max: %d/%d\n",
+		allocator_->GetBlockCount(), allocator_->GetMinSlabSize(), allocator_->GetMaxSlabSize());
 }

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -107,6 +107,10 @@ public:
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) override;
 
+	void GetStats(char *ptr, size_t size);
+
+	VulkanDeviceAllocator *GetAllocator() { return allocator_; }
+
 protected:
 	void BindTexture(TexCacheEntry *entry) override;
 	void Unbind() override;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -765,6 +765,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 }
 
 VKContext::~VKContext() {
+	allocator_->Destroy();
 	delete allocator_;
 	// This also destroys all descriptor sets.
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {


### PR DESCRIPTION
~With this merged, just click around the UI for a few secs and you hit 	_assert_msg_(G3D, found, "Failed to find allocation to free! Double-freed?");~

~This can't be good. Wonder if the bug is in the VulkanDeviceAllocator or elsewhere...~

Never mind, was just a silly bug.
