### PR TITLE
UI: Show a loading message during shader preload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,6 +955,8 @@ add_library(native STATIC
 	ext/native/ui/ui_context.h
 	ext/native/ui/ui_screen.cpp
 	ext/native/ui/ui_screen.h
+	ext/native/ui/ui_tween.cpp
+	ext/native/ui/ui_tween.h
 	ext/native/ui/view.cpp
 	ext/native/ui/view.h
 	ext/native/ui/viewgroup.cpp

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -436,16 +436,16 @@ bool PSP_InitUpdate(std::string *error_string) {
 
 	bool success = coreParameter.fileToStart != "";
 	*error_string = coreParameter.errorString;
-	if (success) {
+	if (success && gpu == nullptr) {
 		success = GPU_Init(coreParameter.graphicsContext, coreParameter.thin3d);
 		if (!success) {
 			PSP_Shutdown();
 			*error_string = "Unable to initialize rendering engine.";
 		}
 	}
-	pspIsInited = success;
-	pspIsIniting = false;
-	return true;
+	pspIsInited = success && GPU_IsReady();
+	pspIsIniting = success && !pspIsInited;
+	return !success || pspIsInited;
 }
 
 bool PSP_Init(const CoreParameter &coreParam, std::string *error_string) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -171,7 +171,8 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	if (discID.size()) {
 		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
 		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) + "/" + discID + ".glshadercache";
-		shaderManagerGL_->LoadAndPrecompile(shaderCachePath_);
+		// Actually precompiled by IsReady() since we're single-threaded.
+		shaderManagerGL_->Load(shaderCachePath_);
 	}
 
 	if (g_Config.bHardwareTessellation) {
@@ -348,6 +349,10 @@ void GPU_GLES::CheckGPUFeatures() {
 #endif
 
 	gstate_c.featureFlags = features;
+}
+
+bool GPU_GLES::IsReady() {
+	return shaderManagerGL_->ContinuePrecompile();
 }
 
 // Let's avoid passing nulls into snprintf().

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -38,6 +38,8 @@ public:
 	// This gets called on startup and when we get back from settings.
 	void CheckGPUFeatures();
 
+	bool IsReady() override;
+
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -167,7 +167,8 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
-	void LoadAndPrecompile(const std::string &filename);
+	void Load(const std::string &filename);
+	bool ContinuePrecompile(float sliceTime = 1.0f / 60.0f);
 	void Save(const std::string &filename);
 
 private:
@@ -203,4 +204,27 @@ private:
 	VSCache vsCache_;
 
 	bool diskCacheDirty_;
+	struct {
+		std::vector<VShaderID> vert;
+		std::vector<FShaderID> frag;
+		std::vector<std::pair<VShaderID, FShaderID>> link;
+
+		size_t vertPos = 0;
+		size_t fragPos = 0;
+		size_t linkPos = 0;
+		double start;
+
+		void Clear() {
+			vert.clear();
+			frag.clear();
+			link.clear();
+			vertPos = 0;
+			fragPos = 0;
+			linkPos = 0;
+		}
+
+		bool Done() {
+			return vertPos >= vert.size() && fragPos >= frag.size() && linkPos >= link.size();
+		}
+	} diskCachePending_;
 };

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -55,6 +55,12 @@ static void SetGPU(T *obj) {
 #undef new
 #endif
 
+bool GPU_IsReady() {
+	if (gpu)
+		return gpu->IsReady();
+	return false;
+}
+
 bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 #if PPSSPP_PLATFORM(UWP)
 	SetGPU(new GPU_D3D11(ctx, draw));

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -105,4 +105,5 @@ namespace Draw {
 }
 
 bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *thin3d);
+bool GPU_IsReady();
 void GPU_Shutdown();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -70,6 +70,9 @@ public:
 	Draw::DrawContext *GetDrawContext() override {
 		return draw_;
 	}
+	bool IsReady() override {
+		return true;
+	}
 	void Reinitialize() override;
 
 	void BeginHostFrame() override;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -168,6 +168,7 @@ public:
 	virtual Draw::DrawContext *GetDrawContext() = 0;
 
 	// Initialization
+	virtual bool IsReady() = 0;
 	virtual void InitClear() = 0;
 	virtual void Reinitialize() = 0;
 

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -56,6 +56,7 @@ protected:
 private:
 	void bootGame(const std::string &filename);
 	void bootComplete();
+	void renderUI();
 	void processAxis(const AxisInput &axis, int direction);
 
 	void pspKey(int pspKeyCode, int flags);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -24,6 +24,7 @@
 #include "input/keycodes.h"
 #include "ui/screen.h"
 #include "ui/ui_screen.h"
+#include "ui/ui_tween.h"
 #include "Common/KeyMap.h"
 
 struct AxisInput;
@@ -98,4 +99,8 @@ private:
 	double saveStatePreviewShownTime_;
 	AsyncImageFileView *saveStatePreview_;
 	int saveStateSlot_;
+
+	UI::View *loadingView_ = nullptr;
+	UI::TextColorTween *loadingViewColor_ = nullptr;
+	UI::VisibilityTween *loadingViewVisible_ = nullptr;
 };

--- a/UWP/NativeUWP/NativeUWP.vcxproj
+++ b/UWP/NativeUWP/NativeUWP.vcxproj
@@ -376,6 +376,7 @@
     <ClInclude Include="..\..\ext\native\ui\ui.h" />
     <ClInclude Include="..\..\ext\native\ui\ui_context.h" />
     <ClInclude Include="..\..\ext\native\ui\ui_screen.h" />
+    <ClInclude Include="..\..\ext\native\ui\ui_tween.h" />
     <ClInclude Include="..\..\ext\native\ui\view.h" />
     <ClInclude Include="..\..\ext\native\ui\viewgroup.h" />
     <ClInclude Include="..\..\ext\native\util\const_map.h" />
@@ -1290,6 +1291,7 @@
     <ClCompile Include="..\..\ext\native\ui\ui.cpp" />
     <ClCompile Include="..\..\ext\native\ui\ui_context.cpp" />
     <ClCompile Include="..\..\ext\native\ui\ui_screen.cpp" />
+    <ClCompile Include="..\..\ext\native\ui\ui_tween.cpp" />
     <ClCompile Include="..\..\ext\native\ui\view.cpp" />
     <ClCompile Include="..\..\ext\native\ui\viewgroup.cpp" />
     <ClCompile Include="..\..\ext\native\util\hash\hash.cpp" />

--- a/UWP/NativeUWP/NativeUWP.vcxproj.filters
+++ b/UWP/NativeUWP/NativeUWP.vcxproj.filters
@@ -154,6 +154,9 @@
     <ClCompile Include="..\..\ext\native\ui\ui_screen.cpp">
       <Filter>ui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ext\native\ui\ui_tween.cpp">
+      <Filter>ui</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\ext\native\ui\view.cpp">
       <Filter>ui</Filter>
     </ClCompile>
@@ -588,6 +591,9 @@
       <Filter>ui</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\native\ui\ui_screen.h">
+      <Filter>ui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\native\ui\ui_tween.h">
       <Filter>ui</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\native\ui\view.h">

--- a/ext/native/Android.mk
+++ b/ext/native/Android.mk
@@ -91,6 +91,7 @@ LOCAL_SRC_FILES :=\
     ui/viewgroup.cpp \
     ui/ui.cpp \
     ui/ui_screen.cpp \
+    ui/ui_tween.cpp \
     ui/ui_context.cpp \
     ui/screen.cpp \
     util/text/utf8.cpp \

--- a/ext/native/base/colorutil.cpp
+++ b/ext/native/base/colorutil.cpp
@@ -1,5 +1,14 @@
 #include "base/colorutil.h"
 
+template <typename T>
+static T clamp(T f, T low, T high) {
+	if (f < low)
+		return low;
+	if (f > high)
+		return high;
+	return f;
+}
+
 uint32_t whiteAlpha(float alpha) {
 	if (alpha < 0.0f) alpha = 0.0f;
 	if (alpha > 1.0f) alpha = 1.0f;
@@ -20,6 +29,20 @@ uint32_t colorAlpha(uint32_t rgb, float alpha) {
 	return ((int)(alpha*255)<<24) | (rgb & 0xFFFFFF);
 }
 
+uint32_t colorBlend(uint32_t rgb1, uint32_t rgb2, float alpha) {
+	float invAlpha = (1.0f - alpha);
+	int r = (int)(((rgb1 >> 0) & 0xFF) * alpha + ((rgb2 >> 0) & 0xFF) * invAlpha);
+	int g = (int)(((rgb1 >> 8) & 0xFF) * alpha + ((rgb2 >> 8) & 0xFF) * invAlpha);
+	int b = (int)(((rgb1 >> 16) & 0xFF) * alpha + ((rgb2 >> 16) & 0xFF) * invAlpha);
+	int a = (int)(((rgb1 >> 24) & 0xFF) * alpha + ((rgb2 >> 24) & 0xFF) * invAlpha);
+
+	uint32_t c = clamp(a, 0, 255) << 24;
+	c |= clamp(b, 0, 255) << 16;
+	c |= clamp(g, 0, 255) << 8;
+	c |= clamp(r, 0, 255);
+	return c;
+}
+
 uint32_t alphaMul(uint32_t color, float alphaMul) {
 	uint32_t rgb = color & 0xFFFFFF;
 	int32_t alpha = color >> 24;
@@ -38,17 +61,7 @@ uint32_t rgba(float r, float g, float b, float alpha) {
 }
 
 uint32_t rgba_clamp(float r, float g, float b, float a) {
-	if (r > 1.0f) r = 1.0f;
-	if (g > 1.0f) g = 1.0f;
-	if (b > 1.0f) b = 1.0f;
-	if (a > 1.0f) a = 1.0f;
-
-	if (r < 0.0f) r = 0.0f;
-	if (g < 0.0f) g = 0.0f;
-	if (b < 0.0f) b = 0.0f;
-	if (a < 0.0f) a = 0.0f;
-
-	return rgba(r,g,b,a);
+	return rgba(clamp(r, 0.0f, 1.0f), clamp(g, 0.0f, 1.0f), clamp(b, 0.0f, 1.0f), clamp(a, 0.0f, 1.0f));
 }
 
 /* hsv2rgb.c

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -285,6 +285,7 @@
     <ClInclude Include="ui\ui.h" />
     <ClInclude Include="ui\ui_context.h" />
     <ClInclude Include="ui\ui_screen.h" />
+    <ClInclude Include="ui\ui_tween.h" />
     <ClInclude Include="ui\view.h" />
     <ClInclude Include="ui\viewgroup.h" />
     <ClInclude Include="util\random\rng.h" />
@@ -752,6 +753,7 @@
     <ClCompile Include="ui\ui.cpp" />
     <ClCompile Include="ui\ui_context.cpp" />
     <ClCompile Include="ui\ui_screen.cpp" />
+    <ClCompile Include="ui\ui_tween.cpp" />
     <ClCompile Include="ui\view.cpp" />
     <ClCompile Include="ui\viewgroup.cpp" />
     <ClCompile Include="util\hash\hash.cpp" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClInclude Include="thin3d\DataFormat.h">
       <Filter>thin3d</Filter>
     </ClInclude>
+    <ClInclude Include="ui\ui_tween.h">
+      <Filter>ui</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">
@@ -795,6 +798,9 @@
     </ClCompile>
     <ClCompile Include="thin3d\VulkanRenderManager.cpp">
       <Filter>thin3d</Filter>
+    </ClCompile>
+    <ClCompile Include="ui\ui_tween.cpp">
+      <Filter>ui</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/ext/native/ui/ui_tween.cpp
+++ b/ext/native/ui/ui_tween.cpp
@@ -1,0 +1,31 @@
+﻿#include "base/colorutil.h"
+#include "ui/ui_tween.h"
+#include "ui/view.h"
+
+namespace UI {
+
+uint32_t ColorTween::Current() {
+	return colorBlend(to_, from_, Position());
+}
+
+void TextColorTween::Apply(View *view) {
+	// TODO: No validation without RTTI?
+	TextView *tv = (TextView *)view;
+	tv->SetTextColor(Current());
+}
+
+void VisibilityTween::Apply(View *view) {
+	view->SetVisibility(Current());
+}
+
+Visibility VisibilityTween::Current() {
+	// Prefer V_VISIBLE over V_GONE/V_INVISIBLE.
+	float p = Position();
+	if (from_ == V_VISIBLE && p < 1.0f)
+		return from_;
+	if (to_ == V_VISIBLE && p > 0.0f)
+		return to_;
+	return p >= 1.0f ? to_ : from_;
+}
+
+}  // namespace

--- a/ext/native/ui/ui_tween.cpp
+++ b/ext/native/ui/ui_tween.cpp
@@ -4,23 +4,30 @@
 
 namespace UI {
 
-uint32_t ColorTween::Current() {
-	return colorBlend(to_, from_, Position());
+void Tween::Apply(View *view) {
+	if (time_now() >= start_ + duration_)
+		finishApplied_ = true;
+
+	float pos = Position();
+	DoApply(view, pos);
 }
 
-void TextColorTween::Apply(View *view) {
+uint32_t ColorTween::Current(float pos) {
+	return colorBlend(to_, from_, pos);
+}
+
+void TextColorTween::DoApply(View *view, float pos) {
 	// TODO: No validation without RTTI?
 	TextView *tv = (TextView *)view;
-	tv->SetTextColor(Current());
+	tv->SetTextColor(Current(pos));
 }
 
-void VisibilityTween::Apply(View *view) {
-	view->SetVisibility(Current());
+void VisibilityTween::DoApply(View *view, float pos) {
+	view->SetVisibility(Current(pos));
 }
 
-Visibility VisibilityTween::Current() {
+Visibility VisibilityTween::Current(float p) {
 	// Prefer V_VISIBLE over V_GONE/V_INVISIBLE.
-	float p = Position();
 	if (from_ == V_VISIBLE && p < 1.0f)
 		return from_;
 	if (to_ == V_VISIBLE && p > 0.0f)

--- a/ext/native/ui/ui_tween.h
+++ b/ext/native/ui/ui_tween.h
@@ -1,0 +1,118 @@
+﻿#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include "base/timeutil.h"
+#include "ui/view.h"
+
+namespace UI {
+
+// This is the class to use in Update().
+class Tween {
+public:
+	Tween(float duration, float (*curve)(float)) : duration_(duration), curve_(curve) {
+		start_ = time_now();
+	}
+	virtual ~Tween() {
+	}
+
+	// Actually apply the tween to a view.
+	virtual void Apply(View *view) = 0;
+
+	bool Finished() {
+		return time_now() >= start_ + duration_;
+	}
+
+protected:
+	float DurationOffset() {
+		return time_now() - start_;
+	}
+
+	float Position() {
+		return curve_(std::min(1.0f, DurationOffset() / duration_));
+	}
+
+	float start_;
+	float duration_;
+	float (*curve_)(float);
+};
+
+// This is the class all tweens inherit from.  Shouldn't be used directly, see below.
+template <typename Value>
+class TweenBase: public Tween {
+public:
+	TweenBase(Value from, Value to, float duration, float (*curve)(float) = [](float f) { return f; })
+		: Tween(duration, curve), from_(from), to_(to) {
+	}
+
+	// Use this to change the destination value.
+	// Useful when a state flips while the tween is half-way through.
+	void Divert(const Value &newTo) {
+		const Value newFrom = Current();
+
+		// Are we already part way through another transition?
+		if (!Finished()) {
+			if (newTo == to_) {
+				// Already on course.  Don't change.
+			} else if (newTo == from_) {
+				// Reversing, adjust start_ to be smooth from the current value.
+				float newOffset = duration_ - DurationOffset();
+				start_ = time_now() - newOffset;
+			} else {
+				// Otherwise, start over.
+				start_ = time_now();
+			}
+		} else {
+			// Already finished, so restart.
+			start_ = time_now();
+		}
+
+		from_ = newFrom;
+		to_ = newTo;
+	}
+
+	// Stop animating the value.
+	void Stop() {
+		Reset(Current());
+	}
+
+	// Use when the value is explicitly reset.  Implicitly stops the tween.
+	void Reset(const Value &newFrom) {
+		from_ = newFrom;
+		to_ = newFrom;
+	}
+
+protected:
+	virtual Value Current() = 0;
+
+	Value from_;
+	Value to_;
+};
+
+// Generic - subclass this for specific color handling.
+class ColorTween : public TweenBase<uint32_t> {
+public:
+	using TweenBase::TweenBase;
+
+protected:
+	uint32_t Current() override;
+};
+
+class TextColorTween : public ColorTween {
+public:
+	using ColorTween::ColorTween;
+
+	void Apply(View *view) override;
+};
+
+class VisibilityTween : public TweenBase<Visibility> {
+public:
+	using TweenBase::TweenBase;
+
+	void Apply(View *view) override;
+
+protected:
+	Visibility Current() override;
+};
+
+}  // namespace

--- a/ext/native/ui/ui_tween.h
+++ b/ext/native/ui/ui_tween.h
@@ -54,7 +54,7 @@ public:
 		const Value newFrom = Current(Position());
 
 		// Are we already part way through another transition?
-		if (!Finished()) {
+		if (time_now() < start_ + duration_) {
 			if (newTo == to_) {
 				// Already on course.  Don't change.
 			} else if (newTo == from_) {
@@ -90,6 +90,16 @@ public:
 	void Reset(const Value &newFrom) {
 		from_ = newFrom;
 		to_ = newFrom;
+	}
+
+	const Value &FromValue() const {
+		return from_;
+	}
+	const Value &ToValue() const {
+		return to_;
+	}
+	Value CurrentValue() {
+		return Current(Position());
 	}
 
 protected:

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -12,6 +12,7 @@
 #include "ui/ui.h"
 #include "ui/view.h"
 #include "ui/ui_context.h"
+#include "ui/ui_tween.h"
 #include "thin3d/thin3d.h"
 #include "base/NativeApp.h"
 
@@ -160,6 +161,18 @@ View::~View() {
 	if (HasFocus())
 		SetFocusedView(0);
 	RemoveQueuedEvents(this);
+
+	// Could use unique_ptr, but then we have to include tween everywhere.
+	for (auto &tween : tweens_)
+		delete tween;
+	tweens_.clear();
+}
+
+void View::Update() {
+	for (Tween *tween : tweens_) {
+		if (!tween->Finished())
+			tween->Apply(this);
+	}
 }
 
 void View::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {
@@ -1119,6 +1132,7 @@ void Slider::Draw(UIContext &dc) {
 }
 
 void Slider::Update() {
+	View::Update();
 	if (repeat_ >= 0) {
 		repeat_++;
 	}
@@ -1228,6 +1242,7 @@ void SliderFloat::Draw(UIContext &dc) {
 }
 
 void SliderFloat::Update() {
+	View::Update();
 	if (repeat_ >= 0) {
 		repeat_++;
 	}

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -224,9 +224,6 @@ struct MeasureSpec {
 	float size;
 };
 
-class View;
-
-
 // Should cover all bases.
 struct EventParams {
 	View *v;
@@ -349,6 +346,8 @@ private:
 
 View *GetFocusedView();
 
+class Tween;
+
 class View {
 public:
 	View(LayoutParams *layoutParams = 0) : layoutParams_(layoutParams), visibility_(V_VISIBLE), measuredWidth_(0), measuredHeight_(0), enabledPtr_(0), enabled_(true), enabledMeansDisabled_(false) {
@@ -363,7 +362,7 @@ public:
 	virtual bool Key(const KeyInput &input) { return false; }
 	virtual void Touch(const TouchInput &input) {}
 	virtual void Axis(const AxisInput &input) {}
-	virtual void Update() {}
+	virtual void Update();
 
 	// If this view covers these coordinates, it should add itself and its children to the list.
 	virtual void Query(float x, float y, std::vector<View *> &list);
@@ -424,6 +423,12 @@ public:
 
 	Point GetFocusPosition(FocusDirection dir);
 
+	template <class T>
+	T *AddTween(T *t) {
+		tweens_.push_back(t);
+		return t;
+	}
+
 protected:
 	// Inputs to layout
 	std::unique_ptr<LayoutParams> layoutParams_;
@@ -437,6 +442,8 @@ protected:
 
 	// Outputs of layout. X/Y are absolute screen coordinates, hierarchy is "gone" here.
 	Bounds bounds_;
+
+	std::vector<Tween *> tweens_;
 
 private:
 	bool *enabledPtr_;
@@ -455,7 +462,6 @@ public:
 	bool Key(const KeyInput &input) override { return false; }
 	void Touch(const TouchInput &input) override {}
 	bool CanBeFocused() const override { return false; }
-	void Update() override {}
 };
 
 


### PR DESCRIPTION
A few things:
 * Add a UI tween class to manage animations (didn't change anywhere yet.)
 * Make shader precompile asynchronous, but still block game start.
 * Show a "Loading game..." message while precompiling, which fades out on top of game (but only shows if loading takes time.)

Also, with this, we could for example also preload shaders on Vulkan, but probably do it just using a thread.

Not sure if this might've been causing ANRs or something on first load when GL took several seconds to preload.

-[Unknown]