### PR TITLE
Android: Fix crash on shutdown/restart

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -359,10 +359,10 @@ bool AndroidVulkanContext::Init(ANativeWindow *wnd, int desiredBackbufferSizeX, 
 void AndroidVulkanContext::Shutdown() {
 	ILOG("AndroidVulkanContext::Shutdown");
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
-	delete draw_;
-	draw_ = nullptr;
 	ILOG("Calling NativeShutdownGraphics");
 	NativeShutdownGraphics();
+	delete draw_;
+	draw_ = nullptr;
 	g_Vulkan->WaitUntilQueueIdle();
 	g_Vulkan->DestroyObjects();
 	g_Vulkan->DestroyDevice();

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -541,7 +541,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		if (badOrientationCount < 3 && requestedPortrait != detectedPortrait) {
 			Log.e(TAG, "Bad orientation detected (w=" + pixelWidth + " h=" + pixelHeight + "! Recreating activity.");
 			badOrientationCount++;
-			recreate();;
+			recreate();
 			return;
 		} else if (requestedPortrait == detectedPortrait) {
 			badOrientationCount = 0;


### PR DESCRIPTION
The text drawing textures needed to be deleted before shutting down their allocator, since #10242.  Fixes #10244.

-[Unknown]