### PR TITLE
Fix hangs on Android lock/unlock with Vulkan

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1101,6 +1101,10 @@ static void ProcessFrameCommands(JNIEnv *env) {
 }
 
 extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(JNIEnv *env, jobject obj, jobject _surf) {
+	exitRenderLoop = false;
+	// This is up here to prevent race conditions, in case we pause during init.
+	renderLoopRunning = true;
+
 	ANativeWindow *wnd = ANativeWindow_fromSurface(env, _surf);
 
 	// Need to get the local JNI env for the graphics thread. Used later in draw_text_android.
@@ -1113,6 +1117,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 
 	if (wnd == nullptr) {
 		ELOG("Error: Surface is null.");
+		renderLoopRunning = false;
 		return false;
 	}
 
@@ -1131,7 +1136,7 @@ retry:
 	if (!graphicsContext->Init(wnd, desiredBackbufferSizeX, desiredBackbufferSizeY, backbuffer_format, androidVersion)) {
 		ELOG("Failed to initialize graphics context.");
 
-		if (vulkan && tries < 2) {
+		if (!exitRenderLoop && (vulkan && tries < 2)) {
 			ILOG("Trying again, this time with OpenGL.");
 			g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
 			SetGPUBackend((GPUBackend)g_Config.iGPUBackend);  // Wait, why do we need a separate enum here?
@@ -1141,10 +1146,11 @@ retry:
 
 		delete graphicsContext;
 		graphicsContext = nullptr;
+		renderLoopRunning = false;
 		return false;
 	}
 
-	if (!renderer_inited) {
+	if (!exitRenderLoop && !renderer_inited) {
 		NativeInitGraphics(graphicsContext);
 		if (renderer_ever_inited) {
 			NativeDeviceRestore();
@@ -1152,9 +1158,6 @@ retry:
 		renderer_inited = true;
 		renderer_ever_inited = true;
 	}
-
-	exitRenderLoop = false;
-	renderLoopRunning = true;
 
 	while (!exitRenderLoop) {
 		static bool hasSetThreadName = false;
@@ -1174,9 +1177,11 @@ retry:
 	}
 
 	ILOG("Leaving EGL/Vulkan render loop.");
-	g_gameInfoCache->WorkQueue()->Flush();
+	if (g_gameInfoCache)
+		g_gameInfoCache->WorkQueue()->Flush();
 
-	NativeDeviceLost();
+	if (renderer_inited)
+		NativeDeviceLost();
 	renderer_inited = false;
 
 	ILOG("Shutting down graphics context.");

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -432,7 +432,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			// Start emulation using the provided Surface.
 			if (!runEGLRenderLoop(mSurface)) {
 				// Shouldn't happen.
-				Log.e(TAG, "Failed to start up OpenGL");
+				Log.e(TAG, "Failed to start up OpenGL/Vulkan");
 			}
 			Log.i(TAG, "Left the render loop: " + mSurface);
 		}

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -225,8 +225,12 @@ void VulkanRenderManager::StopThread() {
 		// when we restart...
 		for (int i = 0; i < vulkan_->GetInflightFrames(); i++) {
 			auto &frameData = frameData_[i];
-			if (frameData.readyForRun || frameData.hasInitCommands || frameData.steps.size() != 0) {
-				Crash();
+			_assert_(!frameData.readyForRun);
+			_assert_(frameData.steps.empty());
+			if (frameData.hasInitCommands) {
+				// Clear 'em out.  This can happen on restart sometimes.
+				vkEndCommandBuffer(frameData.initCmd);
+				frameData.hasInitCommands = false;
 			}
 			frameData.readyForRun = false;
 			for (size_t i = 0; i < frameData.steps.size(); i++) {


### PR DESCRIPTION
Before these changes, sometimes PPSSPP would not work properly after unlock:
 * It might render in the wrong place or with the wrong orientation (and allow no input, but keep running.)
 * It might just stop and quit.
 * It might hang (static image on screen.)

Interestingly, the `Crash();` seemed to cause the hang, without any real crash.  Not sure why.

With these changes, it now seems to resume properly consistently.  Might take care of #10178 - but there may be more issues than just on my Pixel.

-[Unknown]