### PR TITLE
From NDK 16, libc++ is out of beta and gnustl will be deprecated soon, so make the switch.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,7 +109,7 @@ android {
 							'-DANDROID_PLATFORM=android-15',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=gnustl_static',
+							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE'
 				}
 			}
@@ -124,7 +124,7 @@ android {
 							'-DANDROID_PLATFORM=android-15',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=gnustl_static',
+							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
 							'-DGOLD=TRUE'
 				}

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_STL := gnustl_static
+APP_STL := c++_static
 APP_PLATFORM := android-9
 APP_ABI := arm64-v8a armeabi-v7a x86 x86_64
 APP_GNUSTL_CPP_FEATURES := exceptions


### PR DESCRIPTION
No apparent issues, even on Nexus One with Android 2.3.