### PR TITLE
Reset views after loading per game config

### DIFF
--- a/Core/Host.h
+++ b/Core/Host.h
@@ -63,6 +63,7 @@ public:
 	virtual bool CreateDesktopShortcut(std::string argumentPath, std::string title) {return false;}
 
 	virtual void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) {}
+	virtual void SendUIMessage(const std::string &message, const std::string &value) {}
 
 	// Used for headless.
 	virtual bool ShouldSkipUI() { return false; }

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -248,6 +248,7 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 
 	//in case we didn't go through EmuScreen::boot
 	g_Config.loadGameConfig(id);
+	host->SendUIMessage("config_loaded", "");
 	INFO_LOG(LOADER,"Loading %s...", bootpath.c_str());
 	return __KernelLoadExec(bootpath.c_str(), 0, error_string);
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -144,7 +144,6 @@ void EmuScreen::bootGame(const std::string &filename) {
 				return;
 			}
 			bootComplete();
-			RecreateViews();
 		}
 		return;
 	}
@@ -155,6 +154,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, filename, 0);
 	if (info && !info->id.empty()) {
 		g_Config.loadGameConfig(info->id);
+		// Reset views in case controls are in a different place.
+		RecreateViews();
 	}
 
 	invalid_ = true;
@@ -356,6 +357,9 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			bootPending_ = true;
 			gamePath_ = value;
 		}
+	} else if (!strcmp(message, "config_loaded")) {
+		// In case we need to position touch controls differently.
+		RecreateViews();
 	} else if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_MENU);
 		releaseButtons();

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -53,6 +53,10 @@ public:
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override {
 		osm.Show(message, duration, color, -1, true, id);
 	}
+
+	void SendUIMessage(const std::string &message, const std::string &value) override {
+		NativeMessageReceived(message.c_str(), value.c_str());
+	}
 };
 
 #if !defined(MOBILE_DEVICE) && defined(USING_QT_UI)
@@ -132,6 +136,10 @@ public:
 
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override {
 		osm.Show(message, duration, color, -1, true, id);
+	}
+
+	void SendUIMessage(const std::string &message, const std::string &value) override {
+		NativeMessageReceived(message.c_str(), value.c_str());
 	}
 
 	bool GPUDebuggingActive()

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -371,3 +371,7 @@ void WindowsHost::ToggleDebugConsoleVisibility() {
 void WindowsHost::NotifyUserMessage(const std::string &message, float duration, u32 color, const char *id) {
 	osm.Show(message, duration, color, -1, true, id);
 }
+
+void WindowsHost::SendUIMessage(const std::string &message, const std::string &value) {
+	NativeMessageReceived(message.c_str(), value.c_str());
+}

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -65,6 +65,7 @@ public:
 	bool CreateDesktopShortcut(std::string argumentPath, std::string title) override;
 
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
+	void SendUIMessage(const std::string &message, const std::string &value) override;
 
 	std::shared_ptr<KeyboardDevice> keyboard;
 

--- a/ext/native/ui/ui_tween.cpp
+++ b/ext/native/ui/ui_tween.cpp
@@ -12,6 +12,46 @@ void Tween::Apply(View *view) {
 	DoApply(view, pos);
 }
 
+template <typename Value>
+void TweenBase<Value>::PersistData(PersistStatus status, std::string anonId, PersistMap &storage) {
+	struct TweenData {
+		float start;
+		float duration;
+		Value from;
+		Value to;
+		bool finishApplied;
+	};
+
+	PersistBuffer &buffer = storage["TweenBase::" + anonId];
+
+	switch (status) {
+	case UI::PERSIST_SAVE:
+		buffer.resize(sizeof(TweenData) / sizeof(int));
+		{
+			TweenData &data = *(TweenData *)&buffer[0];
+			data.start = start_;
+			data.duration = duration_;
+			data.from = from_;
+			data.to = to_;
+			data.finishApplied = finishApplied_;
+		}
+		break;
+	case UI::PERSIST_RESTORE:
+		if (buffer.size() >= sizeof(TweenData) / sizeof(int)) {
+			TweenData data = *(TweenData *)&buffer[0];
+			start_ = data.start;
+			duration_ = data.duration;
+			from_ = data.from;
+			to_ = data.to;
+			finishApplied_ = data.finishApplied;
+		}
+		break;
+	}
+}
+
+template void TweenBase<uint32_t>::PersistData(PersistStatus status, std::string anonId, PersistMap &storage);
+template void TweenBase<Visibility>::PersistData(PersistStatus status, std::string anonId, PersistMap &storage);
+
 uint32_t ColorTween::Current(float pos) {
 	return colorBlend(to_, from_, pos);
 }

--- a/ext/native/ui/ui_tween.h
+++ b/ext/native/ui/ui_tween.h
@@ -23,6 +23,8 @@ public:
 		return finishApplied_ && time_now() >= start_ + duration_;
 	}
 
+	virtual void PersistData(PersistStatus status, std::string anonId, PersistMap &storage) = 0;
+
 protected:
 	float DurationOffset() {
 		return time_now() - start_;
@@ -41,6 +43,7 @@ protected:
 };
 
 // This is the class all tweens inherit from.  Shouldn't be used directly, see below.
+// Note: Value cannot safely be a pointer (without overriding PersistData.)
 template <typename Value>
 class TweenBase: public Tween {
 public:
@@ -101,6 +104,8 @@ public:
 	Value CurrentValue() {
 		return Current(Position());
 	}
+
+	void PersistData(PersistStatus status, std::string anonId, PersistMap &storage) override;
 
 protected:
 	virtual Value Current(float pos) = 0;

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -224,6 +224,11 @@ void View::PersistData(PersistStatus status, std::string anonId, PersistMap &sto
 		}
 		break;
 	}
+
+	ITOA stringify;
+	for (int i = 0; i < (int)tweens_.size(); ++i) {
+		tweens_[i]->PersistData(status, tag + "/" + stringify.p((int)i), storage);
+	}
 }
 
 Point View::GetFocusPosition(FocusDirection dir) {


### PR DESCRIPTION
This makes them move earlier (perhaps instantly), and also retains the fade out (which was killed by recreating views after bootComplete before.)

Used `host` to proxy the message to UI to avoid adding a dependency on UI from Core (for libretro, unitest, headless, etc.)

-[Unknown]