### PR TITLE
Improve shutdown/restart performance with disc streaming

### DIFF
--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -25,7 +25,7 @@
 
 // Takes ownership of backend.
 CachingFileLoader::CachingFileLoader(FileLoader *backend)
-	: filesize_(0), backend_(backend), exists_(-1), isDirectory_(-1), aheadThread_(false) {
+	: backend_(backend) {
 }
 
 void CachingFileLoader::Prepare() {
@@ -287,4 +287,8 @@ void CachingFileLoader::StartReadAhead(s64 pos) {
 		aheadThread_ = false;
 	});
 	th.detach();
+}
+
+void CachingFileLoader::Cancel() {
+	backend_->Cancel();
 }

--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -289,6 +289,10 @@ void CachingFileLoader::StartReadAhead(s64 pos) {
 	th.detach();
 }
 
+bool CachingFileLoader::IsRemote() {
+	return backend_->IsRemote();
+}
+
 void CachingFileLoader::Cancel() {
 	backend_->Cancel();
 }

--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -28,6 +28,7 @@ public:
 	CachingFileLoader(FileLoader *backend);
 	~CachingFileLoader() override;
 
+	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;

--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -39,6 +39,8 @@ public:
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
+	void Cancel() override;
+
 private:
 	void Prepare();
 	void InitCache();
@@ -57,10 +59,10 @@ private:
 		BLOCK_READAHEAD = 4,
 	};
 
-	s64 filesize_;
+	s64 filesize_ = 0;
 	FileLoader *backend_;
-	int exists_;
-	int isDirectory_;
+	int exists_ = -1;
+	int isDirectory_ = -1;
 	u64 generation_;
 	u64 oldestGeneration_;
 	size_t cacheSize_;
@@ -77,6 +79,6 @@ private:
 
 	std::map<s64, BlockInfo> blocks_;
 	std::recursive_mutex blocksMutex_;
-	bool aheadThread_;
+	bool aheadThread_ = false;
 	std::once_flag preparedFlag_;
 };

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -41,19 +41,16 @@ std::mutex DiskCachingFileLoader::cachesMutex_;
 
 // Takes ownership of backend.
 DiskCachingFileLoader::DiskCachingFileLoader(FileLoader *backend)
-	: prepared_(false), filesize_(0), backend_(backend), cache_(nullptr) {
+	: backend_(backend) {
 }
 
 void DiskCachingFileLoader::Prepare() {
-	if (prepared_) {
-		return;
-	}
-	prepared_ = true;
-
-	filesize_ = backend_->FileSize();
-	if (filesize_ > 0) {
-		InitCache();
-	}
+	std::call_once(preparedFlag_, [this]() {
+		filesize_ = backend_->FileSize();
+		if (filesize_ > 0) {
+			InitCache();
+		}
+	});
 }
 
 DiskCachingFileLoader::~DiskCachingFileLoader() {
@@ -118,6 +115,10 @@ size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, 
 	return readSize;
 }
 
+void DiskCachingFileLoader::Cancel() {
+	backend_->Cancel();
+}
+
 std::vector<std::string> DiskCachingFileLoader::GetCachedPathsInUse() {
 	std::lock_guard<std::mutex> guard(cachesMutex_);
 
@@ -156,7 +157,7 @@ void DiskCachingFileLoader::ShutdownCache() {
 }
 
 DiskCachingFileLoaderCache::DiskCachingFileLoaderCache(const std::string &path, u64 filesize)
-	: refCount_(0), filesize_(filesize), origPath_(path), f_(nullptr), fd_(0) {
+	: filesize_(filesize), origPath_(path) {
 	InitCache(path);
 }
 

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -115,6 +115,10 @@ size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, 
 	return readSize;
 }
 
+bool DiskCachingFileLoader::IsRemote() {
+	return backend_->IsRemote();
+}
+
 void DiskCachingFileLoader::Cancel() {
 	backend_->Cancel();
 }

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -32,6 +32,7 @@ public:
 	DiskCachingFileLoader(FileLoader *backend);
 	~DiskCachingFileLoader() override;
 
+	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -43,6 +43,8 @@ public:
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
+	void Cancel() override;
+
 	static std::vector<std::string> GetCachedPathsInUse();
 
 private:
@@ -50,10 +52,10 @@ private:
 	void InitCache();
 	void ShutdownCache();
 
-	bool prepared_;
-	s64 filesize_;
+	std::once_flag preparedFlag_;
+	s64 filesize_ = 0;
 	FileLoader *backend_;
-	DiskCachingFileLoaderCache *cache_;
+	DiskCachingFileLoaderCache *cache_ = nullptr;
 
 	// We don't support concurrent disk cache access (we use memory cached indexes.)
 	// So we have to ensure there's only one of these per.
@@ -139,7 +141,7 @@ private:
 		INVALID_INDEX = 0xFFFFFFFF,
 	};
 
-	int refCount_;
+	int refCount_ = 0;
 	s64 filesize_;
 	u32 blockSize_;
 	u16 generation_;
@@ -176,8 +178,8 @@ private:
 	std::vector<BlockInfo> index_;
 	std::vector<u32> blockIndexLookup_;
 
-	FILE *f_;
-	int fd_;
+	FILE *f_ = nullptr;
+	int fd_ = 0;
 
 	static std::string cacheDir_;
 };

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -30,6 +30,9 @@ public:
 	HTTPFileLoader(const std::string &filename);
 	virtual ~HTTPFileLoader() override;
 
+	bool IsRemote() override {
+		return true;
+	}
 	virtual bool Exists() override;
 	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -41,14 +41,14 @@ public:
 	}
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
+	void Cancel() override {
+		cancelConnect_ = true;
+	}
+
 private:
 	void Prepare();
 
-	void Connect() {
-		if (!connected_) {
-			connected_ = client_.Connect();
-		}
-	}
+	void Connect();
 
 	void Disconnect() {
 		if (connected_) {
@@ -57,12 +57,13 @@ private:
 		connected_ = false;
 	}
 
-	s64 filesize_;
-	s64 filepos_;
+	s64 filesize_ = 0;
+	s64 filepos_ = 0;
 	Url url_;
 	http::Client client_;
 	std::string filename_;
-	bool connected_;
+	bool connected_ = false;
+	bool cancelConnect_ = false;
 
 	std::once_flag preparedFlag_;
 	std::mutex readAtMutex_;

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -270,3 +270,7 @@ u32 RamCachingFileLoader::NextAheadBlock() {
 
 	return 0xFFFFFFFF;
 }
+
+bool RamCachingFileLoader::IsRemote() {
+	return backend_->IsRemote();
+}

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -28,7 +28,7 @@
 
 // Takes ownership of backend.
 RamCachingFileLoader::RamCachingFileLoader(FileLoader *backend)
-	: filesize_(0), backend_(backend), exists_(-1), isDirectory_(-1), aheadThread_(false) {
+	: backend_(backend) {
 	filesize_ = backend->FileSize();
 	if (filesize_ > 0) {
 		InitCache();
@@ -107,11 +107,7 @@ void RamCachingFileLoader::InitCache() {
 }
 
 void RamCachingFileLoader::ShutdownCache() {
-	{
-		std::lock_guard<std::mutex> guard(blocksMutex_);
-		// Try to have the thread stop.
-		aheadRemaining_ = 0;
-	}
+	Cancel();
 
 	// We can't delete while the thread is running, so have to wait.
 	// This should only happen from the menu.
@@ -125,6 +121,15 @@ void RamCachingFileLoader::ShutdownCache() {
 		free(cache_);
 		cache_ = nullptr;
 	}
+}
+
+void RamCachingFileLoader::Cancel() {
+	if (aheadThread_) {
+		std::lock_guard<std::mutex> guard(blocksMutex_);
+		aheadCancel_ = true;
+	}
+
+	backend_->Cancel();
 }
 
 size_t RamCachingFileLoader::ReadFromCache(s64 pos, size_t bytes, void *data) {
@@ -220,10 +225,11 @@ void RamCachingFileLoader::StartReadAhead(s64 pos) {
 	}
 
 	aheadThread_ = true;
+	aheadCancel_ = false;
 	std::thread th([this] {
 		setCurrentThreadName("FileLoaderReadAhead");
 
-		while (aheadRemaining_ != 0) {
+		while (aheadRemaining_ != 0 && !aheadCancel_) {
 			// Where should we look?
 			const u32 cacheStartPos = NextAheadBlock();
 			if (cacheStartPos == 0xFFFFFFFF) {

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -39,6 +39,8 @@ public:
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
+	void Cancel() override;
+
 private:
 	void InitCache();
 	void ShutdownCache();
@@ -55,15 +57,16 @@ private:
 		BLOCK_READAHEAD = 4,
 	};
 
-	s64 filesize_;
+	s64 filesize_ = 0;
 	FileLoader *backend_;
-	u8 *cache_;
-	int exists_;
-	int isDirectory_;
+	u8 *cache_ = nullptr;
+	int exists_ = -1;
+	int isDirectory_ = -1;
 
 	std::vector<u8> blocks_;
 	std::mutex blocksMutex_;
 	u32 aheadRemaining_;
 	s64 aheadPos_;
-	bool aheadThread_;
+	bool aheadThread_ = false;
+	bool aheadCancel_ = false;
 };

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -28,6 +28,7 @@ public:
 	RamCachingFileLoader(FileLoader *backend);
 	~RamCachingFileLoader() override;
 
+	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;

--- a/Core/FileLoaders/RetryingFileLoader.cpp
+++ b/Core/FileLoaders/RetryingFileLoader.cpp
@@ -72,3 +72,7 @@ size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Fla
 
 	return readSize;
 }
+
+void RetryingFileLoader::Cancel() {
+	backend_->Cancel();
+}

--- a/Core/FileLoaders/RetryingFileLoader.cpp
+++ b/Core/FileLoaders/RetryingFileLoader.cpp
@@ -73,6 +73,10 @@ size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Fla
 	return readSize;
 }
 
+bool RetryingFileLoader::IsRemote() {
+	return backend_->IsRemote();
+}
+
 void RetryingFileLoader::Cancel() {
 	backend_->Cancel();
 }

--- a/Core/FileLoaders/RetryingFileLoader.h
+++ b/Core/FileLoaders/RetryingFileLoader.h
@@ -25,6 +25,7 @@ public:
 	RetryingFileLoader(FileLoader *backend);
 	~RetryingFileLoader() override;
 
+	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;

--- a/Core/FileLoaders/RetryingFileLoader.h
+++ b/Core/FileLoaders/RetryingFileLoader.h
@@ -36,6 +36,8 @@ public:
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
+	void Cancel() override;
+
 private:
 	enum {
 		MAX_RETRIES = 3,

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -86,6 +86,10 @@ public:
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) {
 		return ReadAt(absolutePos, 1, bytes, data, flags);
 	}
+
+	// Cancel any operations that might block, if possible.
+	virtual void Cancel() {
+	}
 };
 
 inline u32 operator & (const FileLoader::Flags &a, const FileLoader::Flags &b) {

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -66,6 +66,9 @@ public:
 
 	virtual ~FileLoader() {}
 
+	virtual bool IsRemote() {
+		return false;
+	}
 	virtual bool Exists() = 0;
 	virtual bool ExistsFast() {
 		return Exists();

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -54,7 +54,7 @@ GameInfo::~GameInfo() {
 	icon.Clear();
 	pic0.Clear();
 	pic1.Clear();
-	delete fileLoader;
+	fileLoader.reset();
 }
 
 bool GameInfo::Delete() {
@@ -218,8 +218,7 @@ bool GameInfo::LoadFromPath(const std::string &gamePath) {
 	std::lock_guard<std::mutex> guard(lock);
 	// No need to rebuild if we already have it loaded.
 	if (filePath_ != gamePath) {
-		delete fileLoader;
-		fileLoader = ConstructFileLoader(gamePath);
+		fileLoader.reset(ConstructFileLoader(gamePath));
 		if (!fileLoader)
 			return false;
 		filePath_ = gamePath;
@@ -231,16 +230,15 @@ bool GameInfo::LoadFromPath(const std::string &gamePath) {
 	return fileLoader ? fileLoader->Exists() : true;
 }
 
-FileLoader *GameInfo::GetFileLoader() {
+std::shared_ptr<FileLoader> GameInfo::GetFileLoader() {
 	if (!fileLoader) {
-		fileLoader = ConstructFileLoader(filePath_);
+		fileLoader.reset(ConstructFileLoader(filePath_));
 	}
 	return fileLoader;
 }
 
 void GameInfo::DisposeFileLoader() {
-	delete fileLoader;
-	fileLoader = nullptr;
+	fileLoader.reset();
 }
 
 bool GameInfo::DeleteAllSaveData() {
@@ -373,24 +371,22 @@ public:
 		{
 			std::lock_guard<std::mutex> lock(info_->lock);
 			info_->working = true;
-			info_->fileType = Identify_File(info_->GetFileLoader());
+			info_->fileType = Identify_File(info_->GetFileLoader().get());
 		}
 
 		switch (info_->fileType) {
 		case IdentifiedFileType::PSP_PBP:
 		case IdentifiedFileType::PSP_PBP_DIRECTORY:
 			{
-				FileLoader *pbpLoader = info_->GetFileLoader();
-				std::unique_ptr<FileLoader> altLoader;
+				auto pbpLoader = info_->GetFileLoader();
 				if (info_->fileType == IdentifiedFileType::PSP_PBP_DIRECTORY) {
 					std::string ebootPath = ResolvePBPFile(gamePath_);
 					if (ebootPath != gamePath_) {
-						pbpLoader = ConstructFileLoader(ebootPath);
-						altLoader.reset(pbpLoader);
+						pbpLoader.reset(ConstructFileLoader(ebootPath));
 					}
 				}
 
-				PBPReader pbp(pbpLoader);
+				PBPReader pbp(pbpLoader.get());
 				if (!pbp.IsValid()) {
 					if (pbp.IsELF()) {
 						goto handleELF;
@@ -559,10 +555,10 @@ handleELF:
 				// Let's assume it's an ISO.
 				// TODO: This will currently read in the whole directory tree. Not really necessary for just a
 				// few files.
-				FileLoader *fl = info_->GetFileLoader();
+				auto fl = info_->GetFileLoader();
 				if (!fl)
 					return;  // Happens with UWP currently, TODO...
-				BlockDevice *bd = constructBlockDevice(info_->GetFileLoader());
+				BlockDevice *bd = constructBlockDevice(info_->GetFileLoader().get());
 				if (!bd)
 					return;  // nothing to do here..
 				ISOFileSystem umd(&handles, bd);
@@ -700,7 +696,7 @@ void GameInfoCache::Clear() {
 
 void GameInfoCache::CancelAll() {
 	for (auto info : info_) {
-		FileLoader *fl = info.second->GetFileLoader();
+		auto fl = info.second->GetFileLoader();
 		if (fl) {
 			fl->Cancel();
 		}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -674,6 +674,8 @@ void GameInfoCache::Init() {
 }
 
 void GameInfoCache::Shutdown() {
+	CancelAll();
+
 	if (gameInfoWQ_) {
 		StopProcessingWorkQueue(gameInfoWQ_);
 		delete gameInfoWQ_;
@@ -682,11 +684,22 @@ void GameInfoCache::Shutdown() {
 }
 
 void GameInfoCache::Clear() {
+	CancelAll();
+
 	if (gameInfoWQ_) {
 		gameInfoWQ_->Flush();
 		gameInfoWQ_->WaitUntilDone();
 	}
 	info_.clear();
+}
+
+void GameInfoCache::CancelAll() {
+	for (auto info : info_) {
+		FileLoader *fl = info.second->GetFileLoader();
+		if (fl) {
+			fl->Cancel();
+		}
+	}
 }
 
 void GameInfoCache::FlushBGs() {

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -650,6 +650,11 @@ handleELF:
 	}
 
 	float priority() override {
+		auto fl = info_->GetFileLoader();
+		if (fl && fl->IsRemote()) {
+			// Increase the value so remote info loads after non-remote.
+			return info_->lastAccessedTime + 1000.0f;
+		}
 		return info_->lastAccessedTime;
 	}
 

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -173,6 +173,7 @@ public:
 
 	PrioritizedWorkQueue *WorkQueue() { return gameInfoWQ_; }
 
+	void CancelAll();
 	void WaitUntilDone(std::shared_ptr<GameInfo> &info);
 
 private:

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <atomic>
 
@@ -93,7 +94,7 @@ public:
 	bool DeleteAllSaveData();
 	bool LoadFromPath(const std::string &gamePath);
 
-	FileLoader *GetFileLoader();
+	std::shared_ptr<FileLoader> GetFileLoader();
 	void DisposeFileLoader();
 
 	u64 GetGameSizeInBytes();
@@ -148,7 +149,7 @@ protected:
 	// Note: this can change while loading, use GetTitle().
 	std::string title;
 
-	FileLoader *fileLoader = nullptr;
+	std::shared_ptr<FileLoader> fileLoader;
 	std::string filePath_;
 
 private:

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1171,8 +1171,6 @@ retry:
 	}
 
 	ILOG("Leaving EGL/Vulkan render loop.");
-	if (g_gameInfoCache)
-		g_gameInfoCache->WorkQueue()->Flush();
 
 	NativeShutdownGraphics();
 	renderer_inited = false;


### PR DESCRIPTION
When the network isn't connected, this used to stall for a while, because workers were busy waiting for a connect to succeed.

-[Unknown]