### PR TITLE
Vulkan: Texture upload through compute, experimental texture scaling too

### DIFF
--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -224,7 +224,6 @@ void VulkanTexture::Touch() {
 }
 
 VkImageView VulkanTexture::CreateViewForMip(int mip) {
-	// Create the view while we're at it.
 	VkImageViewCreateInfo view_info = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 	view_info.image = image_;
 	view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -21,7 +21,11 @@ public:
 	bool CreateDirect(VkCommandBuffer cmd, VulkanDeviceAllocator *allocator, int w, int h, int numMips, VkFormat format, VkImageLayout initialLayout, VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, const VkComponentMapping *mapping = nullptr);
 	void UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mipHeight, VkBuffer buffer, uint32_t offset, size_t rowLength);  // rowLength is in pixels
 	void GenerateMip(VkCommandBuffer cmd, int mip);
-	void EndCreate(VkCommandBuffer cmd, bool vertexTexture = false);
+	void EndCreate(VkCommandBuffer cmd, bool vertexTexture = false, VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+	// When loading mips from compute shaders, you need to pass VK_IMAGE_LAYOUT_GENERAL to the above function.
+	// In addition, ignore UploadMip and GenerateMip, and instead use GetViewForMip. Make sure to delete the returned views when used.
+	VkImageView CreateViewForMip(int mip);
 
 	void Destroy();
 

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -144,14 +144,15 @@ void VulkanPushBuffer::Map() {
 
 void VulkanPushBuffer::Unmap() {
 	_dbg_assert_(G3D, writePtr_ != 0);
-	/*
-	// Should not need this since we use coherent memory.
-	VkMappedMemoryRange range{ VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
-	range.offset = 0;
-	range.size = offset_;
-	range.memory = buffers_[buf_].deviceMemory;
-	vkFlushMappedMemoryRanges(device_, 1, &range);
-	*/
+
+	if ((memoryPropertyMask_ & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0) {
+		VkMappedMemoryRange range{ VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
+		range.offset = 0;
+		range.size = offset_;
+		range.memory = buffers_[buf_].deviceMemory;
+		vkFlushMappedMemoryRanges(vulkan_->GetDevice(), 1, &range);
+	}
+
 	vkUnmapMemory(vulkan_->GetDevice(), buffers_[buf_].deviceMemory);
 	writePtr_ = nullptr;
 }

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -23,8 +23,8 @@
 #include "base/timeutil.h"
 #include "math/math_util.h"
 
-VulkanPushBuffer::VulkanPushBuffer(VulkanContext *vulkan, size_t size, VkBufferUsageFlags usage)
-		: vulkan_(vulkan), size_(size), usage_(usage) {
+VulkanPushBuffer::VulkanPushBuffer(VulkanContext *vulkan, size_t size, VkBufferUsageFlags usage, VkMemoryPropertyFlags memoryPropertyMask)
+		: vulkan_(vulkan), memoryPropertyMask_(memoryPropertyMask), size_(size), usage_(usage) {
 	bool res = AddBuffer();
 	assert(res);
 }
@@ -58,7 +58,7 @@ bool VulkanPushBuffer::AddBuffer() {
 	// Okay, that's the buffer. Now let's allocate some memory for it.
 	VkMemoryAllocateInfo alloc{ VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
 	alloc.allocationSize = reqs.size;
-	vulkan_->MemoryTypeFromProperties(reqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc.memoryTypeIndex);
+	vulkan_->MemoryTypeFromProperties(reqs.memoryTypeBits, memoryPropertyMask_, &alloc.memoryTypeIndex);
 
 	res = vkAllocateMemory(device, &alloc, nullptr, &info.deviceMemory);
 	if (VK_SUCCESS != res) {
@@ -89,7 +89,8 @@ void VulkanPushBuffer::Destroy(VulkanContext *vulkan) {
 
 void VulkanPushBuffer::NextBuffer(size_t minSize) {
 	// First, unmap the current memory.
-	Unmap();
+	if (memoryPropertyMask_ & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+		Unmap();
 
 	buf_++;
 	if (buf_ >= buffers_.size() || minSize > size_) {
@@ -108,7 +109,8 @@ void VulkanPushBuffer::NextBuffer(size_t minSize) {
 
 	// Now, move to the next buffer and map it.
 	offset_ = 0;
-	Map();
+	if (memoryPropertyMask_ & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+		Map();
 }
 
 void VulkanPushBuffer::Defragment(VulkanContext *vulkan) {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -751,6 +751,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1, true, true),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0, true, true),
 	ReportedConfigSetting("TexDeposterize", &g_Config.bTexDeposterize, false, true, true),
+	ReportedConfigSetting("TexHardwareScaling", &g_Config.bTexHardwareScaling, false, true, true),
 	ConfigSetting("VSyncInterval", &g_Config.bVSync, false, true, true),
 	ReportedConfigSetting("BloomHack", &g_Config.iBloomHack, 0, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -170,6 +170,7 @@ public:
 	int iTexScalingLevel; // 0 = auto, 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;
+	bool bTexHardwareScaling;
 	int iFpsLimit1;
 	int iFpsLimit2;
 	int iMaxRecent;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -153,6 +153,8 @@ void DrawEngineVulkan::InitDeviceObjects() {
 		frame_[i].pushUBO = new VulkanPushBuffer(vulkan_, 8 * 1024 * 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
 		frame_[i].pushVertex = new VulkanPushBuffer(vulkan_, 2 * 1024 * 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 		frame_[i].pushIndex = new VulkanPushBuffer(vulkan_, 1 * 1024 * 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
+
+		frame_[i].pushLocal = new VulkanPushBuffer(vulkan_, 1 * 1024 * 1024, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 	}
 
 	VkPipelineLayoutCreateInfo pl{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
@@ -209,6 +211,11 @@ void DrawEngineVulkan::FrameData::Destroy(VulkanContext *vulkan) {
 		delete pushIndex;
 		pushIndex = nullptr;
 	}
+	if (pushLocal) {
+		pushLocal->Destroy(vulkan);
+		delete pushLocal;
+		pushLocal = nullptr;
+	}
 }
 
 void DrawEngineVulkan::DestroyDeviceObjects() {
@@ -264,10 +271,12 @@ void DrawEngineVulkan::BeginFrame() {
 	frame->pushUBO->Reset();
 	frame->pushVertex->Reset();
 	frame->pushIndex->Reset();
+	frame->pushLocal->Reset();
 
 	frame->pushUBO->Begin(vulkan_);
 	frame->pushVertex->Begin(vulkan_);
 	frame->pushIndex->Begin(vulkan_);
+	frame->pushLocal->Begin(vulkan_);
 
 	// TODO: How can we make this nicer...
 	tessDataTransferVulkan->SetPushBuffer(frame->pushUBO);
@@ -324,6 +333,7 @@ void DrawEngineVulkan::EndFrame() {
 	frame->pushUBO->End();
 	frame->pushVertex->End();
 	frame->pushIndex->End();
+	frame->pushLocal->End();
 	vertexCache_->End();
 }
 

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -188,6 +188,11 @@ public:
 		return frame_[vulkan_->GetCurFrame()].pushUBO;
 	}
 
+	// Only use Allocate on this one.
+	VulkanPushBuffer *GetPushBufferLocal() {
+		return frame_[vulkan_->GetCurFrame()].pushLocal;
+	}
+
 	const DrawEngineVulkanStats &GetStats() const {
 		return stats_;
 	}
@@ -257,6 +262,10 @@ private:
 		VulkanPushBuffer *pushUBO = nullptr;
 		VulkanPushBuffer *pushVertex = nullptr;
 		VulkanPushBuffer *pushIndex = nullptr;
+
+		// Special push buffer in GPU local memory, for texture data conversion and similar tasks.
+		VulkanPushBuffer *pushLocal;
+
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
 		DenseHashMap<DescriptorSetKey, VkDescriptorSet, (VkDescriptorSet)VK_NULL_HANDLE> descSets;
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -141,7 +141,8 @@ std::vector<std::string> SamplerCache::DebugGetSamplerIDs() const {
 TextureCacheVulkan::TextureCacheVulkan(Draw::DrawContext *draw, VulkanContext *vulkan)
 	: TextureCacheCommon(draw),
 		vulkan_(vulkan),
-		samplerCache_(vulkan) {
+		samplerCache_(vulkan),
+		upload_(vulkan) {
 	timesInvalidatedAllThisFrame_ = 0;
 	DeviceRestore(vulkan, draw);
 	SetupTextureDecoder();
@@ -180,6 +181,8 @@ void TextureCacheVulkan::DeviceLost() {
 	if (samplerNearest_)
 		vulkan_->Delete().QueueDeleteSampler(samplerNearest_);
 
+	upload_.DeviceLost();
+
 	nextTexture_ = nullptr;
 }
 
@@ -200,6 +203,8 @@ void TextureCacheVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext 
 	samp.minFilter = VK_FILTER_NEAREST;
 	samp.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
 	vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &samplerNearest_);
+
+	upload_.DeviceRestore(vulkan);
 }
 
 void TextureCacheVulkan::ReleaseTexture(TexCacheEntry *entry, bool delete_them) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -836,11 +836,16 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						vkCmdDispatch(cmdInit, (mipWidth + 15) / 16, (mipHeight + 15) / 16, 1);
 
 						// After the compute, before the copy, we need a memory barrier.
-						VkMemoryBarrier barrier{ VK_STRUCTURE_TYPE_MEMORY_BARRIER };
+						VkBufferMemoryBarrier barrier{ VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER };
 						barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
 						barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+						barrier.buffer = localBuf;
+						barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+						barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+						barrier.offset = localOffset;
+						barrier.size = localSize;
 						vkCmdPipelineBarrier(cmdInit, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-							0, 1, &barrier, 0, nullptr, 0, nullptr);
+							0, 0, nullptr, 1, &barrier, 0, nullptr);
 
 						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, localBuf, localOffset, stride / bpp);
 					} else {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -141,11 +141,7 @@ void main() {
 	// Unpack the color (we could look it up in a CLUT here if we wanted...)
 	// It's a bit silly that we need to unpack to float and then have imageStore repack,
 	// but the alternative is to store to a buffer, and then launch a vkCmdCopyBufferToImage instead.
-	vec4 outColor = vec4(
-		(color & 0xFF) * (1.0 / 255.0), 
-		((color >> 8) & 0xFF) * (1.0 / 255.0), 
-		((color >> 16) & 0xFF) * (1.0 / 255.0), 
-		((color >> 24) & 0xFF) * (1.0 / 255.0));
+	vec4 outColor = unpackUnorm4x8(color);
 	imageStore(img, ivec2(x,y), outColor);
 }
 )";
@@ -730,8 +726,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		// Compute experiment
 		if (actualFmt == VULKAN_8888_FORMAT) {
 			// Enable the experiment you want.
-			computeCopy = true;
-			// computeUpload = true;
+			// computeCopy = true;
+			computeUpload = true;
 		}
 
 		if (computeUpload) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1033,14 +1033,14 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	// Don't scale the PPGe texture.
 	if (entry->addr > 0x05000000 && entry->addr < PSP_GetKernelMemoryEnd())
 		scaleFactor = 1;
-	if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) != 0 && scaleFactor != 1) {
+	if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) != 0 && scaleFactor != 1 && !g_Config.bTexHardwareScaling) {
 		// Remember for later that we /wanted/ to scale this texture.
 		entry->status |= TexCacheEntry::STATUS_TO_SCALE;
 		scaleFactor = 1;
 	}
 
 	if (scaleFactor != 1) {
-		if (texelsScaledThisFrame_ >= TEXCACHE_MAX_TEXELS_SCALED) {
+		if (texelsScaledThisFrame_ >= TEXCACHE_MAX_TEXELS_SCALED && !g_Config.bTexHardwareScaling) {
 			entry->status |= TexCacheEntry::STATUS_TO_SCALE;
 			scaleFactor = 1;
 		} else {
@@ -1092,7 +1092,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		// If we want to use the GE debugger, we should add VK_IMAGE_USAGE_TRANSFER_SRC_BIT too...
 
 		// Compute experiment
-		if (actualFmt == VULKAN_8888_FORMAT) {
+		if (actualFmt == VULKAN_8888_FORMAT && scaleFactor > 1 && g_Config.bTexHardwareScaling) {
 			// Enable the experiment you want.
 			// computeCopy = true;
 			computeUpload = true;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -67,6 +67,291 @@ static const VkComponentMapping VULKAN_1555_SWIZZLE = { VK_COMPONENT_SWIZZLE_B, 
 static const VkComponentMapping VULKAN_565_SWIZZLE = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
 static const VkComponentMapping VULKAN_8888_SWIZZLE = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
 
+// 4xBRZ shader - Copyright (C) 2014-2016 DeSmuME team (GPL2+)
+// Hyllian's xBR-vertex code and texel mapping
+// Copyright (C) 2011/2016 Hyllian - sergiogdb@gmail.com
+// TODO: Handles alpha badly for PSP.
+const char *shader4xbrz = R"(
+vec4 premultiply_alpha(vec4 c) { float a = clamp(c.a, 0.0, 1.0); return vec4(c.rgb * a, a); }
+vec4 postdivide_alpha(vec4 c) { return c.a < 0.001? vec4(0.0,0.0,0.0,0.0) : vec4(c.rgb / c.a, c.a); }
+
+#define BLEND_ALPHA 1
+#define BLEND_NONE 0
+#define BLEND_NORMAL 1
+#define BLEND_DOMINANT 2
+#define LUMINANCE_WEIGHT 1.0
+#define EQUAL_COLOR_TOLERANCE 30.0/255.0
+#define STEEP_DIRECTION_THRESHOLD 2.2
+#define DOMINANT_DIRECTION_THRESHOLD 3.6
+
+float reduce(vec4 color) {
+	return dot(color.rgb, vec3(65536.0, 256.0, 1.0));
+}
+
+float DistYCbCr(vec4 pixA, vec4 pixB) {
+	const vec3 w = vec3(0.2627, 0.6780, 0.0593);
+	const float scaleB = 0.5 / (1.0 - w.b);
+	const float scaleR = 0.5 / (1.0 - w.r);
+	vec4 diff = pixA - pixB;
+	float Y = dot(diff.rgb, w);
+	float Cb = scaleB * (diff.b - Y);
+	float Cr = scaleR * (diff.r - Y);
+
+	return sqrt( ((LUMINANCE_WEIGHT * Y) * (LUMINANCE_WEIGHT * Y)) + (Cb * Cb) + (Cr * Cr) + (diff.a * diff.a));
+}
+
+bool IsPixEqual(const vec4 pixA, const vec4 pixB) {
+	return (DistYCbCr(pixA, pixB) < EQUAL_COLOR_TOLERANCE);
+}
+
+bool IsBlendingNeeded(const ivec4 blend) {
+	ivec4 diff = blend - ivec4(BLEND_NONE);
+	return diff.x != 0 || diff.y != 0 || diff.z != 0 || diff.w != 0;
+}
+
+vec4 applyScalingf(uvec2 origxy, uvec2 xy) {
+	float dx = 1.0 / params.width;
+	float dy = 1.0 / params.height;
+
+	//    A1 B1 C1
+	// A0 A  B  C C4
+	// D0 D  E  F F4
+	// G0 G  H  I I4
+	//    G5 H5 I5
+
+	uvec4 t1 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y - 2); // A1 B1 C1
+	uvec4 t2 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y - 1); // A B C
+	uvec4 t3 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 0); // D E F
+	uvec4 t4 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 1); // G H I
+	uvec4 t5 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 2); // G5 H5 I5
+	uvec4 t6 = uvec4(origxy.x - 2, origxy.y - 1, origxy.y, origxy.y + 1); // A0 D0 G0
+	uvec4 t7 = uvec4(origxy.x + 2, origxy.y - 1, origxy.y, origxy.y + 1); // C4 F4 I4
+
+	vec2 f = fract(vec2(float(xy.x) / float(params.scale), float(xy.y) / float(params.scale)));
+
+	//---------------------------------------
+	// Input Pixel Mapping:    |21|22|23|
+	//                       19|06|07|08|09
+	//                       18|05|00|01|10
+	//                       17|04|03|02|11
+	//                         |15|14|13|
+
+	vec4 src[25];
+
+	src[21] = premultiply_alpha(readColorf(t1.xw));
+	src[22] = premultiply_alpha(readColorf(t1.yw));
+	src[23] = premultiply_alpha(readColorf(t1.zw));
+	src[ 6] = premultiply_alpha(readColorf(t2.xw));
+	src[ 7] = premultiply_alpha(readColorf(t2.yw));
+	src[ 8] = premultiply_alpha(readColorf(t2.zw));
+	src[ 5] = premultiply_alpha(readColorf(t3.xw));
+	src[ 0] = premultiply_alpha(readColorf(t3.yw));
+	src[ 1] = premultiply_alpha(readColorf(t3.zw));
+	src[ 4] = premultiply_alpha(readColorf(t4.xw));
+	src[ 3] = premultiply_alpha(readColorf(t4.yw));
+	src[ 2] = premultiply_alpha(readColorf(t4.zw));
+	src[15] = premultiply_alpha(readColorf(t5.xw));
+	src[14] = premultiply_alpha(readColorf(t5.yw));
+	src[13] = premultiply_alpha(readColorf(t5.zw));
+	src[19] = premultiply_alpha(readColorf(t6.xy));
+	src[18] = premultiply_alpha(readColorf(t6.xz));
+	src[17] = premultiply_alpha(readColorf(t6.xw));
+	src[ 9] = premultiply_alpha(readColorf(t7.xy));
+	src[10] = premultiply_alpha(readColorf(t7.xz));
+	src[11] = premultiply_alpha(readColorf(t7.xw));
+
+	float v[9];
+	v[0] = reduce(src[0]);
+	v[1] = reduce(src[1]);
+	v[2] = reduce(src[2]);
+	v[3] = reduce(src[3]);
+	v[4] = reduce(src[4]);
+	v[5] = reduce(src[5]);
+	v[6] = reduce(src[6]);
+	v[7] = reduce(src[7]);
+	v[8] = reduce(src[8]);
+
+	ivec4 blendResult = ivec4(BLEND_NONE);
+
+	// Preprocess corners
+	// Pixel Tap Mapping: --|--|--|--|--
+	//                    --|--|07|08|--
+	//                    --|05|00|01|10
+	//                    --|04|03|02|11
+	//                    --|--|14|13|--
+	// Corner (1, 1)
+	if ( ((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
+		float dist_03_01 = DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + DistYCbCr(src[14], src[ 2]) + DistYCbCr(src[ 2], src[10]) + (4.0 * DistYCbCr(src[ 3], src[ 1]));
+		float dist_00_02 = DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[ 3], src[13]) + DistYCbCr(src[ 7], src[ 1]) + DistYCbCr(src[ 1], src[11]) + (4.0 * DistYCbCr(src[ 0], src[ 2]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_03_01) < dist_00_02;
+		blendResult[2] = ((dist_03_01 < dist_00_02) && (v[0] != v[1]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|--|--|--|--
+	//                    --|06|07|--|--
+	//                    18|05|00|01|--
+	//                    17|04|03|02|--
+	//                    --|15|14|--|--
+	// Corner (0, 1)
+	if ( ((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
+		float dist_04_00 = DistYCbCr(src[17], src[ 5]) + DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[15], src[ 3]) + DistYCbCr(src[ 3], src[ 1]) + (4.0 * DistYCbCr(src[ 4], src[ 0]));
+		float dist_05_03 = DistYCbCr(src[18], src[ 4]) + DistYCbCr(src[ 4], src[14]) + DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + (4.0 * DistYCbCr(src[ 5], src[ 3]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_03) < dist_04_00;
+		blendResult[3] = ((dist_04_00 > dist_05_03) && (v[0] != v[5]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|--|22|23|--
+	//                    --|06|07|08|09
+	//                    --|05|00|01|10
+	//                    --|--|03|02|--
+	//                    --|--|--|--|--
+	// Corner (1, 0)
+	if ( ((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
+		float dist_00_08 = DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[ 7], src[23]) + DistYCbCr(src[ 3], src[ 1]) + DistYCbCr(src[ 1], src[ 9]) + (4.0 * DistYCbCr(src[ 0], src[ 8]));
+		float dist_07_01 = DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + DistYCbCr(src[22], src[ 8]) + DistYCbCr(src[ 8], src[10]) + (4.0 * DistYCbCr(src[ 7], src[ 1]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_07_01) < dist_00_08;
+		blendResult[1] = ((dist_00_08 > dist_07_01) && (v[0] != v[7]) && (v[0] != v[1])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|21|22|--|--
+	//                    19|06|07|08|--
+	//                    18|05|00|01|--
+	//                    --|04|03|--|--
+	//                    --|--|--|--|--
+	// Corner (0, 0)
+	if ( ((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
+		float dist_05_07 = DistYCbCr(src[18], src[ 6]) + DistYCbCr(src[ 6], src[22]) + DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + (4.0 * DistYCbCr(src[ 5], src[ 7]));
+		float dist_06_00 = DistYCbCr(src[19], src[ 5]) + DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[21], src[ 7]) + DistYCbCr(src[ 7], src[ 1]) + (4.0 * DistYCbCr(src[ 6], src[ 0]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_07) < dist_06_00;
+		blendResult[0] = ((dist_05_07 < dist_06_00) && (v[0] != v[5]) && (v[0] != v[7])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	vec4 dst[16];
+	dst[ 0] = src[0];
+	dst[ 1] = src[0];
+	dst[ 2] = src[0];
+	dst[ 3] = src[0];
+	dst[ 4] = src[0];
+	dst[ 5] = src[0];
+	dst[ 6] = src[0];
+	dst[ 7] = src[0];
+	dst[ 8] = src[0];
+	dst[ 9] = src[0];
+	dst[10] = src[0];
+	dst[11] = src[0];
+	dst[12] = src[0];
+	dst[13] = src[0];
+	dst[14] = src[0];
+	dst[15] = src[0];
+
+	// Scale pixel
+	if (IsBlendingNeeded(blendResult) == true) {
+		float dist_01_04 = DistYCbCr(src[1], src[4]);
+		float dist_03_08 = DistYCbCr(src[3], src[8]);
+		bool haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[4]) && (v[5] != v[4]);
+		bool haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
+		bool needBlend = (blendResult[2] != BLEND_NONE);
+		bool doLineBlend = (  blendResult[2] >= BLEND_DOMINANT ||
+			((blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+			(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+			(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false) ) == false );
+
+		vec4 blendPix = ( DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3]) ) ? src[1] : src[3];
+		dst[ 2] = mix(dst[ 2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[10] = mix(dst[10], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[11] = mix(dst[11], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[13] = mix(dst[13], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[14] = mix(dst[14], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[7], src[2]);
+		dist_03_08 = DistYCbCr(src[1], src[6]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[2]) && (v[3] != v[2]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
+		needBlend = (blendResult[1] != BLEND_NONE);
+		doLineBlend = (  blendResult[1] >= BLEND_DOMINANT ||
+			!((blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+			(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+			(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1]) ) ? src[7] : src[1];
+		dst[ 1] = mix(dst[ 1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[10] = mix(dst[10], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[11] = mix(dst[11], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[5], src[8]);
+		dist_03_08 = DistYCbCr(src[7], src[4]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[8]) && (v[1] != v[8]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
+		needBlend = (blendResult[0] != BLEND_NONE);
+		doLineBlend = (  blendResult[0] >= BLEND_DOMINANT ||
+			!((blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+			(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+			(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7]) ) ? src[5] : src[7];
+		dst[ 0] = mix(dst[ 0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[3], src[6]);
+		dist_03_08 = DistYCbCr(src[5], src[2]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[6]) && (v[7] != v[6]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
+		needBlend = (blendResult[3] != BLEND_NONE);
+		doLineBlend = (  blendResult[3] >= BLEND_DOMINANT ||
+			!((blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+			(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+			(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5]) ) ? src[3] : src[5];
+		dst[ 3] = mix(dst[ 3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[13] = mix(dst[13], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[14] = mix(dst[14], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+	}
+
+	// select output pixel
+	vec4 res = mix(mix(mix(mix(dst[ 6], dst[ 7], step(0.25, f.x)),
+					mix(dst[ 8], dst[ 9], step(0.75, f.x)),
+					step(0.50, f.x)),
+				mix(mix(dst[ 5], dst[ 0], step(0.25, f.x)),
+					mix(dst[ 1], dst[10], step(0.75, f.x)),
+					step(0.50, f.x)),
+				step(0.25, f.y)),
+		mix(mix(mix(dst[ 4], dst[ 3], step(0.25, f.x)),
+					mix(dst[ 2], dst[11], step(0.75, f.x)),
+					step(0.50, f.x)),
+				mix(mix(dst[15], dst[14], step(0.25, f.x)),
+					mix(dst[13], dst[12], step(0.75, f.x)),
+					step(0.50, f.x)),
+				step(0.75, f.y)),
+		step(0.50, f.y));
+
+	return postdivide_alpha(res);
+}
+
+uint applyScalingu(uvec2 origxy, uvec2 xy) {
+	return packUnorm4x8(applyScalingf(origxy, xy));
+}
+)";
+
 const char *copyShader = R"(
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
@@ -86,24 +371,37 @@ layout(std430, binding = 2) buffer Buf2 {
 layout(push_constant) uniform Params {
 	int width;
 	int height;
+	int scale;
 } params;
 
-void main() {
-	uint x = gl_GlobalInvocationID.x;
-	uint y = gl_GlobalInvocationID.y;
-	// Kill off any out-of-image threads to avoid stray writes.
-	// Should only happen on the tiniest mipmaps as PSP textures are power-of-2,
-	// and we use a 16x16 workgroup size.
-	if (x >= params.width || gl_GlobalInvocationID.y >= params.height)
-    return;
-
+uint readColoru(uvec2 p) {
 	// Note that if the pixels are packed, we can do multiple stores
 	// and only launch this compute shader for every N pixels,
 	// by slicing the width in half and multiplying x by 2, for example.
-	uint color = buf1.data[y * params.width + x];
-	buf2.data[y * params.width + x] = color;
+	return buf1.data[p.y * params.width + p.x];
 }
 
+vec4 readColorf(uvec2 p) {
+	return unpackUnorm4x8(readColoru(p));
+}
+
+%s
+
+void main() {
+	uvec2 xy = gl_GlobalInvocationID.xy;
+	// Kill off any out-of-image threads to avoid stray writes.
+	// Should only happen on the tiniest mipmaps as PSP textures are power-of-2,
+	// and we use a 16x16 workgroup size.
+	if (xy.x >= params.width || xy.y >= params.height)
+		return;
+
+	uvec2 origxy = xy / params.scale;
+	if (params.scale == 1) {
+		buf2.data[xy.y * params.width + xy.x] = readColoru(origxy);
+	} else {
+		buf2.data[xy.y * params.width + xy.x] = applyScalingu(origxy, xy);
+	}
+}
 )";
 
 const char *uploadShader = R"(
@@ -123,26 +421,39 @@ layout(std430, binding = 1) buffer Buf {
 layout(push_constant) uniform Params {
 	int width;
 	int height;
+	int scale;
 } params;
 
-void main() {
-	uint x = gl_GlobalInvocationID.x;
-	uint y = gl_GlobalInvocationID.y;
-	// Kill off any out-of-image threads to avoid stray writes.
-	// Should only happen on the tiniest mipmaps as PSP textures are power-of-2,
-	// and we use a 16x16 workgroup size.
-	if (x >= params.width || gl_GlobalInvocationID.y >= params.height)
-    return;
-
+uint readColoru(uvec2 p) {
 	// Note that if the pixels are packed, we can do multiple stores
 	// and only launch this compute shader for every N pixels,
 	// by slicing the width in half and multiplying x by 2, for example.
-	uint color = buf.data[y * params.width + x];
+	return buf.data[p.y * params.width + p.x];
+}
+
+vec4 readColorf(uvec2 p) {
 	// Unpack the color (we could look it up in a CLUT here if we wanted...)
 	// It's a bit silly that we need to unpack to float and then have imageStore repack,
 	// but the alternative is to store to a buffer, and then launch a vkCmdCopyBufferToImage instead.
-	vec4 outColor = unpackUnorm4x8(color);
-	imageStore(img, ivec2(x,y), outColor);
+	return unpackUnorm4x8(readColoru(p));
+}
+
+%s
+
+void main() {
+	uvec2 xy = gl_GlobalInvocationID.xy;
+	// Kill off any out-of-image threads to avoid stray writes.
+	// Should only happen on the tiniest mipmaps as PSP textures are power-of-2,
+	// and we use a 16x16 workgroup size.
+	if (xy.x >= params.width || xy.y >= params.height)
+		return;
+
+	uvec2 origxy = xy / params.scale;
+	if (params.scale == 1) {
+		imageStore(img, ivec2(xy.x, xy.y), readColorf(origxy));
+	} else {
+		imageStore(img, ivec2(xy.x, xy.y), applyScalingf(origxy, xy));
+	}
 }
 )";
 
@@ -287,9 +598,12 @@ void TextureCacheVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext 
 	vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &samplerNearest_);
 
 	std::string error;
-	uploadCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, uploadShader, &error);
+	std::string fullUploadShader = StringFromFormat(uploadShader, shader4xbrz);
+	std::string fullCopyShader = StringFromFormat(copyShader, shader4xbrz);
+
+	uploadCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullUploadShader.c_str(), &error);
 	_dbg_assert_msg_(G3D, uploadCS_ != VK_NULL_HANDLE, "failed to compile upload shader");
-	copyCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, copyShader, &error);
+	copyCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullCopyShader.c_str(), &error);
 	_dbg_assert_msg_(G3D, copyCS_!= VK_NULL_HANDLE, "failed to compile copy shader");
 
 	computeShaderManager_.DeviceRestore(vulkan);
@@ -808,18 +1122,19 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 					entry->vkTex->UploadMip(cmdInit, 0, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 					break;
 				} else {
-					LoadTextureLevel(*entry, (uint8_t *)data, stride, i, scaleFactor, dstFmt);
 					if (computeUpload) {
+						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, 1, dstFmt);
 						// This format can be used with storage images.
 						VkImageView view = entry->vkTex->CreateViewForMip(i);
 						VkDescriptorSet descSet = computeShaderManager_.GetDescriptorSet(view, texBuf, bufferOffset, size);
-						struct Params { int x; int y; } params{ mipWidth, mipHeight };
+						struct Params { int x; int y; int s; } params{ mipWidth, mipHeight, scaleFactor };
 						vkCmdBindPipeline(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipeline(uploadCS_));
 						vkCmdBindDescriptorSets(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipelineLayout(), 0, 1, &descSet, 0, nullptr);
 						vkCmdPushConstants(cmdInit, computeShaderManager_.GetPipelineLayout(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(params), &params);
 						vkCmdDispatch(cmdInit, (mipWidth + 15) / 16, (mipHeight + 15) / 16, 1);
 						vulkan_->Delete().QueueDeleteImageView(view);
 					} else if (computeCopy) {
+						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, 1, dstFmt);
 						// Simple test of using a "copy shader" before the upload. This one could unswizzle or whatever
 						// and will work for any texture format including 16-bit as long as the shader is written to pack it into int32 size bits
 						// which is the smallest possible write.
@@ -831,7 +1146,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						VkDescriptorSet descSet = computeShaderManager_.GetDescriptorSet(VK_NULL_HANDLE, texBuf, bufferOffset, size, localBuf, localOffset, localSize);
 						vkCmdBindPipeline(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipeline(copyCS_));
 						vkCmdBindDescriptorSets(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipelineLayout(), 0, 1, &descSet, 0, nullptr);
-						struct Params { int x; int y; } params{ mipWidth, mipHeight };
+						struct Params { int x; int y; int s; } params{ mipWidth, mipHeight, scaleFactor };
 						vkCmdPushConstants(cmdInit, computeShaderManager_.GetPipelineLayout(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(params), &params);
 						vkCmdDispatch(cmdInit, (mipWidth + 15) / 16, (mipHeight + 15) / 16, 1);
 
@@ -849,6 +1164,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, localBuf, localOffset, stride / bpp);
 					} else {
+						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, scaleFactor, dstFmt);
 						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 					}
 				}

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -145,6 +145,8 @@ private:
 	DrawEngineVulkan *drawEngine_;
 	Vulkan2D *vulkan2D_;
 
+	VkShaderModule uploadCS_ = VK_NULL_HANDLE;
+
 	// Bound state to emulate an API similar to the others
 	VkImageView imageView_ = VK_NULL_HANDLE;
 	VkSampler curSampler_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -127,7 +127,7 @@ private:
 	VulkanDeviceAllocator *allocator_ = nullptr;
 	VulkanPushBuffer *push_ = nullptr;
 
-	VulkanComputeUploader upload_;
+	VulkanComputeShaderManager computeShaderManager_;
 
 	SamplerCache samplerCache_;
 
@@ -146,6 +146,7 @@ private:
 	Vulkan2D *vulkan2D_;
 
 	VkShaderModule uploadCS_ = VK_NULL_HANDLE;
+	VkShaderModule copyCS_ = VK_NULL_HANDLE;
 
 	// Bound state to emulate an API similar to the others
 	VkImageView imageView_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -25,6 +25,7 @@
 #include "Common/Vulkan/VulkanContext.h"
 #include "GPU/Vulkan/TextureScalerVulkan.h"
 #include "GPU/Common/TextureCacheCommon.h"
+#include "GPU/Vulkan/VulkanUtil.h"
 
 struct VirtualFramebuffer;
 class FramebufferManagerVulkan;
@@ -125,6 +126,8 @@ private:
 	VulkanContext *vulkan_ = nullptr;
 	VulkanDeviceAllocator *allocator_ = nullptr;
 	VulkanPushBuffer *push_ = nullptr;
+
+	VulkanComputeUploader upload_;
 
 	SamplerCache samplerCache_;
 

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -161,6 +161,7 @@ private:
 
 	struct FrameData {
 		VkDescriptorPool descPool;
+		int numDescriptors;
 	};
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
 

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -168,7 +168,7 @@ private:
 		VkShaderModule module;
 	};
 	
-	DenseHashMap<PipelineKey, VkPipeline, VK_NULL_HANDLE> pipelines_;
+	DenseHashMap<PipelineKey, VkPipeline, (VkPipeline)VK_NULL_HANDLE> pipelines_;
 };
 
 

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -126,10 +126,10 @@ private:
 };
 
 // Manager for compute shaders that upload things (and those have two bindings: a storage buffer to read from and an image to write to).
-class VulkanComputeUploader {
+class VulkanComputeShaderManager {
 public:
-	VulkanComputeUploader(VulkanContext *vulkan);
-	~VulkanComputeUploader();
+	VulkanComputeShaderManager(VulkanContext *vulkan);
+	~VulkanComputeShaderManager();
 
 	void DeviceLost() {
 		DestroyDeviceObjects();
@@ -140,7 +140,7 @@ public:
 	}
 
 	// Note: This doesn't cache. The descriptor is for immediate use only.
-	VkDescriptorSet GetDescriptorSet(VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, VkImageView image);
+	VkDescriptorSet GetDescriptorSet(VkImageView image, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, VkBuffer buffer2 = VK_NULL_HANDLE, VkDeviceSize offset2 = 0, VkDeviceSize range2 = 0);
 
 	// This of course caches though.
 	VkPipeline GetPipeline(VkShaderModule cs);

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -20,6 +20,7 @@
 #include <tuple>
 #include <map>
 
+#include "Common/Hashmaps.h"
 #include "Common/Vulkan/VulkanContext.h"
 #include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanImage.h"
@@ -122,6 +123,49 @@ private:
 
 	std::map<PipelineKey, VkPipeline> pipelines_;
 	std::vector<VkPipeline> keptPipelines_;
+};
+
+// Manager for compute shaders that upload things (and those have two bindings: a storage buffer to read from and an image to write to).
+class VulkanComputeUploader {
+public:
+	VulkanComputeUploader(VulkanContext *vulkan);
+	~VulkanComputeUploader();
+
+	void DeviceLost() {
+		DestroyDeviceObjects();
+	}
+	void DeviceRestore(VulkanContext *vulkan) {
+		vulkan_ = vulkan;
+		InitDeviceObjects();
+	}
+
+	// Note: This doesn't cache. The descriptor is for immediate use only.
+	VkDescriptorSet GetDescriptorSet(VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, VkImageView image);
+
+	// This of course caches though.
+	VkPipeline GetPipeline(VkShaderModule cs);
+	VkPipelineLayout GetPipelineLayout() const { return pipelineLayout_; }
+
+private:
+	void InitDeviceObjects();
+	void DestroyDeviceObjects();
+
+	VulkanContext *vulkan_ = nullptr;
+	VkPipelineCache cache_ = VK_NULL_HANDLE;
+	VkDescriptorSetLayout descriptorSetLayout_ = VK_NULL_HANDLE;
+	VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+	VkPipelineCache pipelineCache_ = VK_NULL_HANDLE;
+
+	struct FrameData {
+		VkDescriptorPool descPool;
+	};
+	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
+
+	struct PipelineKey {
+		VkShaderModule module;
+	};
+	
+	DenseHashMap<PipelineKey, VkPipeline, VK_NULL_HANDLE> pipelines_;
 };
 
 

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -146,6 +146,9 @@ public:
 	VkPipeline GetPipeline(VkShaderModule cs);
 	VkPipelineLayout GetPipelineLayout() const { return pipelineLayout_; }
 
+	void BeginFrame();
+	void EndFrame();
+
 private:
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();


### PR DESCRIPTION
This performs plain RGBA8 texture uploads using a compute shader directly.

Mostly intended as a proof of concept for now, but we could easily replace the compute shader with something that does smart upscaling, or even do the unswizzling and format conversion in it, avoiding lots of CPU work. 

This one takes pushbuffer memory and writes to a storage image. This unfortunately requires that the destination format supports being a storage image, which on most devices limits us to RGBA8888.

An alternative approach would be to have the compute shader read from the pushbuffer and write to a device-local buffer, and then issue a vkCopyBufferToImage from the latter to the image, which should be cheap and would allow us to use this to upload 16-bit format textures as well.

EDIT: Added code for alternative approachs as well - though for upscaling, we probably always want to output RGBA8888.