### PR TITLE
Small display layout editor improvements

### DIFF
--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -100,10 +100,11 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 			int windowUpperEdge = local_dp_yres / 4;
 			int windowLowerEdge = windowUpperEdge * 3;
 			// And stick display when close to any edge
-			if (touchX > windowLeftEdge - 15 + limitX && touchX < windowLeftEdge + 15 + limitX) touchX = windowLeftEdge + limitX;
-			if (touchX > windowRightEdge - 15 - limitX && touchX < windowRightEdge + 15 - limitX) touchX = windowRightEdge - limitX;
-			if (touchY > windowUpperEdge - 15 + limitY && touchY < windowUpperEdge + 15 + limitY) touchY = windowUpperEdge + limitY;
-			if (touchY > windowLowerEdge - 15 - limitY && touchY < windowLowerEdge + 15 - limitY) touchY = windowLowerEdge - limitY;
+			stickToEdgeX = false; stickToEdgeY = false;
+			if (touchX > windowLeftEdge - 8 + limitX && touchX < windowLeftEdge + 8 + limitX) { touchX = windowLeftEdge + limitX; stickToEdgeX = true; }
+			if (touchX > windowRightEdge - 8 - limitX && touchX < windowRightEdge + 8 - limitX) { touchX = windowRightEdge - limitX; stickToEdgeX = true; }
+			if (touchY > windowUpperEdge - 8 + limitY && touchY < windowUpperEdge + 8 + limitY) { touchY = windowUpperEdge + limitY; stickToEdgeY = true; }
+			if (touchY > windowLowerEdge - 8 - limitY && touchY < windowLowerEdge + 8 - limitY) { touchY = windowLowerEdge - limitY; stickToEdgeY = true; }
 
 			int minX = local_dp_xres / 2;
 			int maxX = local_dp_xres + minX;
@@ -167,8 +168,10 @@ void DisplayLayoutScreen::onFinish(DialogResult reason) {
 }
 
 UI::EventReturn DisplayLayoutScreen::OnCenter(UI::EventParams &e) {
-	g_Config.fSmallDisplayOffsetX = 0.5f;
-	g_Config.fSmallDisplayOffsetY = 0.5f;
+	if (!stickToEdgeX || (stickToEdgeX && stickToEdgeY))
+		g_Config.fSmallDisplayOffsetX = 0.5f;
+	if (!stickToEdgeY || (stickToEdgeX && stickToEdgeY))
+		g_Config.fSmallDisplayOffsetY = 0.5f;
 	RecreateViews();
 	return UI::EVENT_DONE;
 };

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -94,6 +94,17 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 				limitY = limitTemp;
 			}
 
+			// Check where each edge of the screen is
+			int windowLeftEdge = local_dp_xres / 4;
+			int windowRightEdge = windowLeftEdge * 3;
+			int windowUpperEdge = local_dp_yres / 4;
+			int windowLowerEdge = windowUpperEdge * 3;
+			// And stick display when close to any edge
+			if (touchX > windowLeftEdge - 15 + limitX && touchX < windowLeftEdge + 15 + limitX) touchX = windowLeftEdge + limitX;
+			if (touchX > windowRightEdge - 15 - limitX && touchX < windowRightEdge + 15 - limitX) touchX = windowRightEdge - limitX;
+			if (touchY > windowUpperEdge - 15 + limitY && touchY < windowUpperEdge + 15 + limitY) touchY = windowUpperEdge + limitY;
+			if (touchY > windowLowerEdge - 15 - limitY && touchY < windowLowerEdge + 15 - limitY) touchY = windowLowerEdge - limitY;
+
 			int minX = local_dp_xres / 2;
 			int maxX = local_dp_xres + minX;
 			int minY = local_dp_yres / 2;
@@ -106,10 +117,10 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 
 			int newX = bounds.centerX(), newY = bounds.centerY();
 			// Allow moving zoomed in display freely as long as at least noticeable portion of the screen is occupied
-			if (touchX > (local_dp_xres / 2) - limitX - 10 && touchX < (local_dp_xres / 2) + limitX + 10) {
+			if (touchX > minX - limitX - 10 && touchX < minX + limitX + 10) {
 				newX = touchX;
 			}
-			if (touchY > (local_dp_yres / 2) - limitY - 10 && touchY < (local_dp_yres / 2) + limitY + 10) {
+			if (touchY > minY - limitY - 10 && touchY < minY + limitY + 10) {
 				newY = touchY;
 			}
 			picked_->ReplaceLayoutParams(new UI::AnchorLayoutParams(newX, newY, NONE, NONE, true));

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -83,10 +83,7 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 
 			int limitX = g_Config.fSmallDisplayZoomLevel * 120;
 			int limitY = g_Config.fSmallDisplayZoomLevel * 68;
-			if (g_Config.fSmallDisplayZoomLevel < 1) {
-				limitX = 120;
-				limitY = 68;
-			}
+
 			if (bRotated) {
 				//swap X/Y limit for rotated display
 				int limitTemp = limitX;
@@ -135,7 +132,7 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 			float newScale = startScale_ + diffY * movementScale;
 			// Desired scale * 8.0 since the visualization is tiny size and multiplied by 8.
 			if (newScale > 80.0f) newScale = 80.0f;
-			if (newScale < 1.0f) newScale = 1.0f;
+			if (newScale < 8.0f) newScale = 8.0f;
 			picked_->SetScale(newScale);
 			scaleUpdate_ = picked_->GetScale();
 			g_Config.fSmallDisplayZoomLevel = scaleUpdate_ / 8.0f;

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -45,6 +45,8 @@ private:
 	UI::PopupMultiChoice *rotation_;
 	bool displayRotEnable_;
 	bool bRotated;
+	bool stickToEdgeX;
+	bool stickToEdgeY;
 	// Touch down state for drag to resize etc
 	float startX_;
 	float startY_;

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -44,6 +44,7 @@ private:
 	UI::PopupMultiChoice *zoom_;
 	UI::PopupMultiChoice *rotation_;
 	bool displayRotEnable_;
+	bool bRotated;
 	// Touch down state for drag to resize etc
 	float startX_;
 	float startY_;


### PR DESCRIPTION
This:
- corrects touch controlled zoom to max out at 10 to match it's slider,
- changes bounds to make it easier to use high zoom into corners(useful when testing subtle shader effects),
- stick display to edges,
- makes "center" respect that stickiness(saw something alike requested on forums some time ago).