### PR TITLE
UI: Fix vertical layout settings tabs

### DIFF
--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -617,6 +617,19 @@ void ItemHeader::Draw(UIContext &dc) {
 	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->headerStyle.fgColor);
 }
 
+void ItemHeader::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const {
+	Bounds bounds(0, 0, layoutParams_->width, layoutParams_->height);
+	if (bounds.w < 0) {
+		// If there's no size, let's grow as big as we want.
+		bounds.w = horiz.size == 0 ? MAX_ITEM_SIZE : horiz.size;
+	}
+	if (bounds.h < 0) {
+		bounds.h = vert.size == 0 ? MAX_ITEM_SIZE : vert.size;
+	}
+	ApplyBoundsBySpec(bounds, horiz, vert);
+	dc.MeasureTextRect(dc.theme->uiFontSmall, 1.0f, 1.0f, text_.c_str(), (int)text_.length(), bounds, &w, &h, ALIGN_LEFT | ALIGN_VCENTER);
+}
+
 void PopupHeader::Draw(UIContext &dc) {
 	const float paddingHorizontal = 12;
 	const float availableWidth = bounds_.w - paddingHorizontal * 2;

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -702,6 +702,7 @@ class ItemHeader : public Item {
 public:
 	ItemHeader(const std::string &text, LayoutParams *layoutParams = 0);
 	void Draw(UIContext &dc) override;
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 
 private:
 	std::string text_;

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -1128,7 +1128,7 @@ TabHolder::TabHolder(Orientation orientation, float stripSize, LayoutParams *lay
 	}
 	tabStrip_->OnChoice.Handle(this, &TabHolder::OnTabClick);
 
-	contents_ = new AnchorLayout(new LinearLayoutParams(1.0f));
+	contents_ = new AnchorLayout(new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
 	Add(contents_)->SetClip(true);
 }
 

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -636,14 +636,14 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 	if (views_.size()) {
 		if (orientation_ == ORIENT_HORIZONTAL) {
 			MeasureSpec v = MeasureSpec(AT_MOST, measuredHeight_ - margins.vert());
-			if (measuredHeight_ == 0.0f && layoutParams_->height == WRAP_CONTENT) {
+			if (measuredHeight_ == 0.0f && (vert.type == UNSPECIFIED || layoutParams_->height == WRAP_CONTENT)) {
 				v.type = UNSPECIFIED;
 			}
 			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v);
 			MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		} else {
 			MeasureSpec h = MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz());
-			if (measuredWidth_ == 0.0f && layoutParams_->width == WRAP_CONTENT) {
+			if (measuredWidth_ == 0.0f && (horiz.type == UNSPECIFIED || layoutParams_->width == WRAP_CONTENT)) {
 				h.type = UNSPECIFIED;
 			}
 			views_[0]->Measure(dc, h, MeasureSpec(UNSPECIFIED, measuredHeight_));

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -975,6 +975,19 @@ void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 	MeasureBySpec(layoutParams_->width, 0.0f, horiz, &measuredWidth_);
 	MeasureBySpec(layoutParams_->height, 0.0f, vert, &measuredHeight_);
 
+	MeasureViews(dc, horiz, vert);
+
+	const bool unspecifiedWidth = layoutParams_->width == WRAP_CONTENT && (overflow_ || horiz.type == UNSPECIFIED);
+	const bool unspecifiedHeight = layoutParams_->height == WRAP_CONTENT && (overflow_ || vert.type == UNSPECIFIED);
+	if (unspecifiedWidth || unspecifiedHeight) {
+		// Give everything another chance to size, given the new measurements.
+		MeasureSpec h = unspecifiedWidth ? MeasureSpec(AT_MOST, measuredWidth_) : horiz;
+		MeasureSpec v = unspecifiedHeight ? MeasureSpec(AT_MOST, measuredHeight_) : vert;
+		MeasureViews(dc, h, v);
+	}
+}
+
+void AnchorLayout::MeasureViews(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {
 	for (size_t i = 0; i < views_.size(); i++) {
 		Size width = WRAP_CONTENT;
 		Size height = WRAP_CONTENT;
@@ -1013,6 +1026,11 @@ void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec v
 		}
 
 		views_[i]->Measure(dc, specW, specH);
+
+		if (layoutParams_->width == WRAP_CONTENT)
+			measuredWidth_ = std::max(measuredWidth_, views_[i]->GetMeasuredWidth());
+		if (layoutParams_->height == WRAP_CONTENT)
+			measuredHeight_ = std::max(measuredHeight_, views_[i]->GetMeasuredHeight());
 	}
 }
 

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -133,6 +133,7 @@ public:
 	std::string Describe() const override { return "AnchorLayout: " + View::Describe(); }
 
 private:
+	void MeasureViews(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert);
 	bool overflow_;
 };
 


### PR DESCRIPTION
Turns out these were wrapping content, and just because of the size that got passed down (it has a different hierarchy than horizontal settings), this caused them to be zero width.

This fixes that (should really FILL_PARENT), but also makes scroll views and anchor layouts more reasonably wrap their content (with just those changes, the vertical settings display, but aren't as wide as they could be - which would be the expected WRAP_CONTENT behavior IMHO.)

Fixes #10398.

-[Unknown]