### PR TITLE
UI: Improve initial permission grant

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -734,8 +734,8 @@ void MainScreen::CreateViews() {
 
 	Margins actionMenuMargins(0, 10, 10, 0);
 
-	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
-	tabHolder_ = leftColumn;
+	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
+	ViewGroup *leftColumn = tabHolder_;
 	tabHolder_->SetTag("MainScreenGames");
 	gameBrowsers_.clear();
 
@@ -810,6 +810,13 @@ void MainScreen::CreateViews() {
 			showHomebrewTab = false;
 		}
 	} else {
+		if (!showRecent) {
+			leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
+			// Just so it's destroyed on recreate.
+			leftColumn->Add(tabHolder_);
+			tabHolder_->SetVisibility(V_GONE);
+		}
+
 		LinearLayout *buttonHolder = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
 		buttonHolder->Add(new Button(mm->T("Give PPSSPP permission to access storage"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT)))->OnClick.Handle(this, &MainScreen::OnAllowStorage);
@@ -821,13 +828,6 @@ void MainScreen::CreateViews() {
 		leftColumn->Add(new TextView(mm->T("PPSSPP can't load games or save right now"), ALIGN_HCENTER, false));
 		leftColumn->Add(new Spacer(new LinearLayoutParams(0.1f)));
 	}
-
-/* if (info) {
-		texvGameIcon_ = leftColumn->Add(new TextureView(0, IS_DEFAULT, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
-		tvTitle_ = leftColumn->Add(new TextView(0, info->title, ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 200, NONE, NONE)));
-		tvGameSize_ = leftColumn->Add(new TextView(0, "...", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 250, NONE, NONE)));
-		tvSaveDataSize_ = leftColumn->Add(new TextView(0, "...", ALIGN_LEFT, 1.0f, new AnchorLayoutParams(10, 290, NONE, NONE)));
-	} */
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL);
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -799,13 +799,13 @@ void MainScreen::CreateViews() {
 		tabHomebrew->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
 
 		if (g_Config.recentIsos.size() > 0) {
-			leftColumn->SetCurrentTab(0);
+			tabHolder_->SetCurrentTab(0, true);
 		} else if (g_Config.iMaxRecent > 0) {
-			leftColumn->SetCurrentTab(1);
+			tabHolder_->SetCurrentTab(1, true);
 		}
 
 		if (backFromStore_ || showHomebrewTab) {
-			leftColumn->SetCurrentTab(2);
+			tabHolder_->SetCurrentTab(2, true);
 			backFromStore_ = false;
 			showHomebrewTab = false;
 		}
@@ -1224,9 +1224,9 @@ void UmdReplaceScreen::CreateViews() {
 	rightColumnItems->Add(new Choice(mm->T("Game Settings")))->OnClick.Handle(this, &UmdReplaceScreen::OnGameSettings);
 
 	if (g_Config.recentIsos.size() > 0) {
-		leftColumn->SetCurrentTab(0);
+		leftColumn->SetCurrentTab(0, true);
 	} else if (g_Config.iMaxRecent > 0) {
-		leftColumn->SetCurrentTab(1);
+		leftColumn->SetCurrentTab(1, true);
 	}
 
 	root_ = new LinearLayout(ORIENT_HORIZONTAL);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -734,12 +734,12 @@ void MainScreen::CreateViews() {
 
 	Margins actionMenuMargins(0, 10, 10, 0);
 
-	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
 	tabHolder_ = leftColumn;
 	tabHolder_->SetTag("MainScreenGames");
 	gameBrowsers_.clear();
 
-	leftColumn->SetClip(true);
+	tabHolder_->SetClip(true);
 
 	bool showRecent = g_Config.iMaxRecent > 0;
 	bool hasStorageAccess = System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED;
@@ -756,7 +756,7 @@ void MainScreen::CreateViews() {
 		scrollRecentGames->Add(tabRecentGames);
 		gameBrowsers_.push_back(tabRecentGames);
 
-		leftColumn->AddTab(mm->T("Recent"), scrollRecentGames);
+		tabHolder_->AddTab(mm->T("Recent"), scrollRecentGames);
 		tabRecentGames->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
 		tabRecentGames->OnHoldChoice.Handle(this, &MainScreen::OnGameSelected);
 		tabRecentGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
@@ -786,8 +786,8 @@ void MainScreen::CreateViews() {
 		scrollHomebrew->Add(tabHomebrew);
 		gameBrowsers_.push_back(tabHomebrew);
 
-		leftColumn->AddTab(mm->T("Games"), scrollAllGames);
-		leftColumn->AddTab(mm->T("Homebrew & Demos"), scrollHomebrew);
+		tabHolder_->AddTab(mm->T("Games"), scrollAllGames);
+		tabHolder_->AddTab(mm->T("Homebrew & Demos"), scrollHomebrew);
 
 		tabAllGames->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
 		tabHomebrew->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
@@ -815,11 +815,11 @@ void MainScreen::CreateViews() {
 		buttonHolder->Add(new Button(mm->T("Give PPSSPP permission to access storage"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT)))->OnClick.Handle(this, &MainScreen::OnAllowStorage);
 		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
 
-		leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
+		leftColumn->Add(new Spacer(new LinearLayoutParams(0.1f)));
 		leftColumn->Add(buttonHolder);
 		leftColumn->Add(new Spacer(10.0f));
 		leftColumn->Add(new TextView(mm->T("PPSSPP can't load games or save right now"), ALIGN_HCENTER, false));
-		leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
+		leftColumn->Add(new Spacer(new LinearLayoutParams(0.1f)));
 	}
 
 /* if (info) {
@@ -869,12 +869,10 @@ void MainScreen::CreateViews() {
 	if (vertical) {
 		root_ = new LinearLayout(ORIENT_VERTICAL);
 		rightColumn->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.75));
-		leftColumn->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
 		root_->Add(rightColumn);
 		root_->Add(leftColumn);
 	} else {
 		root_ = new LinearLayout(ORIENT_HORIZONTAL);
-		leftColumn->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
 		rightColumn->ReplaceLayoutParams(new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
 		root_->Add(leftColumn);
 		root_->Add(rightColumn);

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -310,7 +310,7 @@ public:
 		return tabContents;
 	}
 
-	void SetCurrentTab(int tab);
+	void SetCurrentTab(int tab, bool skipTween = false);
 
 	int GetCurrentTab() const { return currentTab_; }
 	std::string Describe() const override { return "TabHolder: " + View::Describe(); }


### PR DESCRIPTION
Removes the questionable adding of random views to a tab holder, and also avoids transition on restore.

I don't have other photo apps like in #10401, but I'm guessing it is the first frame of a recreate views animation.  Can look at it more later this week, haven't had much time.

-[Unknown]