### PR TITLE
SDL fails to build without Vulkan

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -36,15 +36,17 @@ SDLJoystick *joystick = NULL;
 #include "Common/Vulkan/VulkanDebug.h"
 #include "math.h"
 
+#if !defined(__APPLE__)
+#include "SDL_syswm.h"
+#endif
+
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include "SDL_syswm.h"
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xlib-xcb.h>
-#include "SDL_syswm.h"
 #endif
 
 #if defined(USING_EGL)


### PR DESCRIPTION
`SDL_SysWMinfo` is used for any non-Apple platform but `SDL_syswm.h` where it's defined is limited to Vulkan.

https://github.com/hrydgard/ppsspp/blob/fe45a059b5ab8546968e27d65eab9cbde42be6bb/SDL/SDLMain.cpp#L42
https://github.com/hrydgard/ppsspp/blob/fe45a059b5ab8546968e27d65eab9cbde42be6bb/SDL/SDLMain.cpp#L432
https://github.com/hrydgard/ppsspp/blob/fe45a059b5ab8546968e27d65eab9cbde42be6bb/SDL/SDLMain.cpp#L158

```
$ c++ -v
FreeBSD clang version 5.0.1 (tags/RELEASE_501/final 320880) (based on LLVM 5.0.1)
Target: x86_64-unknown-freebsd12.0
Thread model: posix
InstalledDir: /usr/bin

$ cmake -GNinja -DUSE_SYSTEM_FFMPEG=on /path/to/ppsspp
$ ninja
[...]
/path/to/ppsspp/SDL/SDLMain.cpp:433:2: error: unknown type name 'SDL_SysWMinfo'; did you mean 'SDL_SysWMmsg'?
        SDL_SysWMinfo sys_info{};
        ^~~~~~~~~~~~~
        SDL_SysWMmsg
/usr/local/include/SDL2/SDL_events.h:507:29: note: 'SDL_SysWMmsg' declared here
typedef struct SDL_SysWMmsg SDL_SysWMmsg;
                            ^
/path/to/ppsspp/SDL/SDLMain.cpp:433:16: error: variable has incomplete type 'SDL_SysWMmsg'
        SDL_SysWMinfo sys_info{};
                      ^
/usr/local/include/SDL2/SDL_events.h:506:8: note: forward declaration of 'SDL_SysWMmsg'
struct SDL_SysWMmsg;
       ^
/path/to/ppsspp/SDL/SDLMain.cpp:439:2: error: unknown type name 'Display'
        Display *display = sys_info.info.x11.display;
        ^
/path/to/ppsspp/SDL/SDLMain.cpp:440:2: error: use of undeclared identifier 'Window'; did you mean 'window'?
        Window x11_window = sys_info.info.x11.window;
        ^~~~~~
        window
/path/to/ppsspp/SDL/SDLMain.cpp:389:50: note: 'window' declared here
bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std::string *error_message) {
                                                 ^
/path/to/ppsspp/SDL/SDLMain.cpp:440:8: error: expected ';' after expression
        Window x11_window = sys_info.info.x11.window;
              ^
              ;
/path/to/ppsspp/SDL/SDLMain.cpp:440:9: error: use of undeclared identifier 'x11_window'
        Window x11_window = sys_info.info.x11.window;
               ^
/path/to/ppsspp/SDL/SDLMain.cpp:440:2: warning: expression result unused [-Wunused-value]
        Window x11_window = sys_info.info.x11.window;
        ^~~~~~
1 warnings and 6 errors generated.
```
