### PR TITLE
Vulkan: Decimate the texture allocator

### DIFF
--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -157,7 +157,7 @@ void VulkanPushBuffer::Unmap() {
 }
 
 VulkanDeviceAllocator::VulkanDeviceAllocator(VulkanContext *vulkan, size_t minSlabSize, size_t maxSlabSize)
-	: vulkan_(vulkan), lastSlab_(0), minSlabSize_(minSlabSize), maxSlabSize_(maxSlabSize), memoryTypeIndex_(UNDEFINED_MEMORY_TYPE), destroyed_(false) {
+	: vulkan_(vulkan), minSlabSize_(minSlabSize), maxSlabSize_(maxSlabSize) {
 	assert((minSlabSize_ & (SLAB_GRAIN_SIZE - 1)) == 0);
 }
 
@@ -290,7 +290,7 @@ int VulkanDeviceAllocator::ComputeUsagePercent() const {
 			blocksUsed += slabs_[i].usage[j] != 0 ? 1 : 0;
 		}
 	}
-	return 100 * blocksUsed / blockSum;
+	return blockSum == 0 ? 0 : 100 * blocksUsed / blockSum;
 }
 
 void VulkanDeviceAllocator::Free(VkDeviceMemory deviceMemory, size_t offset) {

--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -190,9 +190,9 @@ private:
 
 	VulkanContext *const vulkan_;
 	std::vector<Slab> slabs_;
-	size_t lastSlab_;
+	size_t lastSlab_ = 0;
 	size_t minSlabSize_;
 	const size_t maxSlabSize_;
-	uint32_t memoryTypeIndex_;
-	bool destroyed_;
+	uint32_t memoryTypeIndex_ = UNDEFINED_MEMORY_TYPE;
+	bool destroyed_ = false;
 };

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -779,6 +779,7 @@ void VKContext::BeginFrame() {
 	// OK, we now know that nothing is reading from this frame's data pushbuffer,
 	push_->Reset();
 	push_->Begin(vulkan_);
+	allocator_->Begin();
 
 	frame.descSets_.clear();
 	VkResult result = vkResetDescriptorPool(device_, frame.descriptorPool, 0);
@@ -792,6 +793,7 @@ void VKContext::WaitRenderCompletion(Framebuffer *fbo) {
 void VKContext::EndFrame() {
 	// Stop collecting data in the frame's data pushbuffer.
 	push_->End();
+	allocator_->End();
 
 	renderManager_.Finish();
 


### PR DESCRIPTION
Thin3D wasn't calling Begin/End, which lead to leaks eventually and OOM.  Note that we currently avoid reusing memory (preferring to get a new slab, and let decimate clear the old one.)  We could make it reuse slabs more, by I'm not sure that's desirable.

This was causing softgpu to crash.

-[Unknown]