### PR TITLE
GPU: Avoid memory corruption on bone matrix > 96

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1739,7 +1739,8 @@ void GPUCommon::Execute_BoneMtxNum(u32 op, u32 diff) {
 	const int end = 12 * 8 - (op & 0x7F);
 	int i = 0;
 
-	bool fastLoad = !debugRecording_;
+	// TODO: Validate what should happen when explicitly setting num to 96 or higher.
+	bool fastLoad = !debugRecording_ && end > 0;
 	if (currentList->pc < currentList->stall && currentList->pc + end * 4 >= currentList->stall) {
 		fastLoad = false;
 	}


### PR DESCRIPTION
See #9574.  Seen in Zill O'll Infinite, thanks to @Kitsu-neechan for tracking this down.

This may have been causing the issues in other backends as well.  Still need to validate the correct behavior here (I wouldn't put 96 being the same as 0 past the hardware, but it probably just ignores it like this.)

That issue also has a case of minz being greater than maxz, which also needs to be double checked.  Not sure what happens when you draw, throughmode or not...

-[Unknown]