### PR TITLE
Reset GPU backend setting on graphics init

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -484,20 +484,20 @@ static int DefaultGPUBackend() {
 #if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID)
 	// Where supported, let's use Vulkan.
 	if (VulkanMayBeAvailable()) {
-		return GPU_BACKEND_VULKAN;
+		return (int)GPUBackend::VULKAN;
 	}
 #endif
 #if PPSSPP_PLATFORM(WINDOWS)
 	// If no Vulkan, use Direct3D 11 on Windows 8+ (most importantly 10.)
 	if (DoesVersionMatchWindows(6, 2, 0, 0, true)) {
-		return GPU_BACKEND_DIRECT3D11;
+		return (int)GPUBackend::DIRECT3D11;
 	}
 #endif
-	return GPU_BACKEND_OPENGL;
+	return (int)GPUBackend::OPENGL;
 }
 
 static bool DefaultVertexCache() {
-	return DefaultGPUBackend() == GPU_BACKEND_OPENGL;
+	return DefaultGPUBackend() == (int)GPUBackend::OPENGL;
 }
 
 static ConfigSetting graphicsSettings[] = {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -57,12 +57,6 @@ enum class GPUBackend {
 	DIRECT3D11 = 2,
 	VULKAN = 3,
 };
-enum {
-	GPU_BACKEND_OPENGL = (int)GPUBackend::OPENGL,
-	GPU_BACKEND_DIRECT3D9 = (int)GPUBackend::DIRECT3D9,
-	GPU_BACKEND_DIRECT3D11 = (int)GPUBackend::DIRECT3D11,
-	GPU_BACKEND_VULKAN = (int)GPUBackend::VULKAN,
-};
 
 enum AudioBackendType {
 	AUDIO_BACKEND_AUTO,

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1928,7 +1928,7 @@ bool FramebufferManagerCommon::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 	}
 
 	// TODO: Maybe should handle flipY inside CopyFramebufferToMemorySync somehow?
-	bool flipY = (g_Config.iGPUBackend == GPU_BACKEND_OPENGL && !useBufferedRendering_) ? true : false;
+	bool flipY = (GetGPUBackend() == GPUBackend::OPENGL && !useBufferedRendering_) ? true : false;
 	buffer.Allocate(w, h, GE_FORMAT_8888, flipY, true);
 	bool retval = draw_->CopyFramebufferToMemorySync(bound, Draw::FB_COLOR_BIT, 0, 0, w, h, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), w);
 	gpuStats.numReadbacks++;
@@ -1960,7 +1960,7 @@ bool FramebufferManagerCommon::GetDepthbuffer(u32 fb_address, int fb_stride, u32
 		h = std::min(h, PSP_CoreParameter().pixelHeight);
 	}
 
-	bool flipY = (g_Config.iGPUBackend == GPU_BACKEND_OPENGL && !useBufferedRendering_) ? true : false;
+	bool flipY = (GetGPUBackend() == GPUBackend::OPENGL && !useBufferedRendering_) ? true : false;
 	if (gstate_c.Supports(GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT)) {
 		buffer.Allocate(w, h, GPU_DBG_FORMAT_FLOAT_DIV_256, flipY);
 	} else {
@@ -1994,7 +1994,7 @@ bool FramebufferManagerCommon::GetStencilbuffer(u32 fb_address, int fb_stride, G
 		h = std::min(h, PSP_CoreParameter().pixelHeight);
 	}
 
-	bool flipY = (g_Config.iGPUBackend == GPU_BACKEND_OPENGL && !useBufferedRendering_) ? true : false;
+	bool flipY = (GetGPUBackend() == GPUBackend::OPENGL && !useBufferedRendering_) ? true : false;
 	// No need to free on failure, the caller/destructor will do that.  Usually this is a reused buffer, anyway.
 	buffer.Allocate(w, h, GPU_DBG_FORMAT_8BIT, flipY);
 	bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_STENCIL_BIT, 0, 0, w,h, Draw::DataFormat::S8, buffer.GetData(), w);

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -783,7 +783,7 @@ bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level
 	// TODO: Centralize.
 	if (nextTexture_->framebuffer) {
 		VirtualFramebuffer *vfb = nextTexture_->framebuffer;
-		bool flipY = g_Config.iGPUBackend == GPU_BACKEND_OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+		bool flipY = GetGPUBackend() == GPUBackend::OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, flipY);
 		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth);
 		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -792,7 +792,7 @@ bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int leve
 	// TODO: Centralize?
 	if (nextTexture_->framebuffer) {
 		VirtualFramebuffer *vfb = nextTexture_->framebuffer;
-		bool flipY = g_Config.iGPUBackend == GPU_BACKEND_OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+		bool flipY = GetGPUBackend() == GPUBackend::OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, flipY);
 		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth);
 		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -33,9 +33,9 @@ QTM_USE_NAMESPACE
 #include "base/NKCodeFromQt.h"
 
 #include "Common/GraphicsContext.h"
-#include "Core/System.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
+#include "Core/System.h"
 
 // Input
 void SimulateGamepad();
@@ -44,6 +44,7 @@ class QtDummyGraphicsContext : public DummyGraphicsContext {
 public:
 	QtDummyGraphicsContext() {
 		draw_ = Draw::T3DCreateGLContext();
+		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -25,6 +25,7 @@ QTM_USE_NAMESPACE
 #include "base/timeutil.h"
 #include "file/zip_read.h"
 #include "gfx/gl_common.h"
+#include "gfx_es2/gpu_features.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "thin3d/thin3d.h"
@@ -43,6 +44,7 @@ void SimulateGamepad();
 class QtDummyGraphicsContext : public DummyGraphicsContext {
 public:
 	QtDummyGraphicsContext() {
+		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
 		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -340,6 +340,7 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std:
 	// Finally we can do the regular initialization.
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
+	SetGPUBackend(GPUBackend::OPENGL);
 	bool success = draw_->CreatePresets();
 	assert(success);
 	window_ = window;
@@ -468,6 +469,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 	}
 
 	draw_ = Draw::T3DCreateVulkanContext(vulkan_, false);
+	SetGPUBackend(GPUBackend::VULKAN);
 	bool success = draw_->CreatePresets();
 	assert(success);
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -865,17 +865,18 @@ int main(int argc, char *argv[]) {
 	GraphicsContext *graphicsContext = nullptr;
 	SDL_Window *window = nullptr;
 	std::string error_message;
-	if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
+	if (g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 		SDLGLGraphicsContext *ctx = new SDLGLGraphicsContext();
 		if (ctx->Init(window, x, y, mode, &error_message) != 0) {
 			printf("GL init error '%s'\n", error_message.c_str());
 		}
 		graphicsContext = ctx;
-	} else if (g_Config.iGPUBackend == GPU_BACKEND_VULKAN) {
+	} else if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
 		SDLVulkanGraphicsContext *ctx = new SDLVulkanGraphicsContext();
 		if (!ctx->Init(window, x, y, mode, &error_message)) {
 			printf("Vulkan init error '%s' - falling back to GL\n", error_message.c_str());
-			g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
+			g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
+			SetGPUBackend((GPUBackend)g_Config.iGPUBackend);
 			delete ctx;
 			SDLGLGraphicsContext *glctx = new SDLGLGraphicsContext();
 			glctx->Init(window, x, y, mode, &error_message);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -391,7 +391,7 @@ void SystemInfoScreen::CreateViews() {
 		deviceSpecs->Add(new InfoItem(si->T("Vendor (detected)"), vendor));
 	deviceSpecs->Add(new InfoItem(si->T("Driver Version"), draw->GetInfoString(InfoField::DRIVER)));
 #ifdef _WIN32
-	if (g_Config.iGPUBackend != GPU_BACKEND_VULKAN)
+	if (GetGPUBackend() != GPUBackend::VULKAN)
 		deviceSpecs->Add(new InfoItem(si->T("Driver Version"), System_GetProperty(SYSPROP_GPUDRIVER_VERSION)));
 #if !PPSSPP_PLATFORM(UWP)
 	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
@@ -399,7 +399,7 @@ void SystemInfoScreen::CreateViews() {
 	}
 #endif
 #endif
-	if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
+	if (GetGPUBackend() == GPUBackend::OPENGL) {
 		deviceSpecs->Add(new InfoItem(si->T("Core Context"), gl_extensions.IsCoreContext ? si->T("Yes") : si->T("No")));
 	}
 	deviceSpecs->Add(new ItemHeader(si->T("OS Information")));
@@ -510,7 +510,7 @@ void SystemInfoScreen::CreateViews() {
 	gpuExtensions->SetSpacing(0);
 	gpuExtensionsScroll->Add(gpuExtensions);
 
-	if (g_Config.iGPUBackend == GPU_BACKEND_OPENGL) {
+	if (GetGPUBackend() == GPUBackend::OPENGL) {
 		tabHolder->AddTab(si->T("OGL Extensions"), gpuExtensionsScroll);
 
 		if (!gl_extensions.IsGLES) {
@@ -547,7 +547,7 @@ void SystemInfoScreen::CreateViews() {
 				eglExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 			}
 		}
-	} else if (g_Config.iGPUBackend == GPU_BACKEND_VULKAN) {
+	} else if (GetGPUBackend() == GPUBackend::VULKAN) {
 		tabHolder->AddTab(si->T("Vulkan Features"), gpuExtensionsScroll);
 
 		gpuExtensions->Add(new ItemHeader(si->T("Vulkan Features")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -106,11 +106,11 @@ bool CheckSupportInstancedTessellationGLES() {
 }
 
 bool IsBackendSupportHWTess() {
-	switch (g_Config.iGPUBackend) {
-	case GPU_BACKEND_OPENGL:
+	switch (GetGPUBackend()) {
+	case GPUBackend::OPENGL:
 		return CheckSupportInstancedTessellationGLES();
-	case GPU_BACKEND_VULKAN:
-	case GPU_BACKEND_DIRECT3D11:
+	case GPUBackend::VULKAN:
+	case GPUBackend::DIRECT3D11:
 		return true;
 	}
 	return false;
@@ -180,7 +180,7 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Rendering Mode")));
 	static const char *renderingBackend[] = { "OpenGL", "Direct3D 9", "Direct3D 11", "Vulkan" };
-	PopupMultiChoice *renderingBackendChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iGPUBackend, gr->T("Backend"), renderingBackend, GPU_BACKEND_OPENGL, ARRAY_SIZE(renderingBackend), gr->GetName(), screenManager()));
+	PopupMultiChoice *renderingBackendChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iGPUBackend, gr->T("Backend"), renderingBackend, (int)GPUBackend::OPENGL, ARRAY_SIZE(renderingBackend), gr->GetName(), screenManager()));
 	renderingBackendChoice->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingBackend);
 #if !PPSSPP_PLATFORM(WINDOWS)
 	renderingBackendChoice->HideChoice(1);  // D3D9
@@ -252,7 +252,7 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Features")));
 	// Hide postprocess option on unsupported backends to avoid confusion.
-	if (g_Config.iGPUBackend != GPU_BACKEND_DIRECT3D9) {
+	if (GetGPUBackend() != GPUBackend::DIRECT3D9) {
 		I18NCategory *ps = GetI18NCategory("PostShaders");
 		postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), ps->GetName()));
 		postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -106,19 +106,19 @@ void EmuThreadFunc() {
 		const char *defaultErrorOpenGL = "Failed initializing graphics. Try upgrading your graphics drivers.\n\nWould you like to try switching to DirectX 9?\n\nError message:";
 		const char *defaultErrorDirect3D9 = "Failed initializing graphics. Try upgrading your graphics drivers and directx 9 runtime.\n\nWould you like to try switching to OpenGL?\n\nError message:";
 		const char *genericError;
-		int nextBackend = GPU_BACKEND_DIRECT3D9;
+		GPUBackend nextBackend = GPUBackend::DIRECT3D9;
 		switch (g_Config.iGPUBackend) {
-		case GPU_BACKEND_DIRECT3D9:
-			nextBackend = GPU_BACKEND_OPENGL;
+		case (int)GPUBackend::DIRECT3D9:
+			nextBackend = GPUBackend::OPENGL;
 			genericError = err->T("GenericDirect3D9Error", defaultErrorDirect3D9);
 			break;
-		case GPU_BACKEND_VULKAN:
-			nextBackend = GPU_BACKEND_OPENGL;
+		case (int)GPUBackend::VULKAN:
+			nextBackend = GPUBackend::OPENGL;
 			genericError = err->T("GenericVulkanError", defaultErrorVulkan);
 			break;
-		case GPU_BACKEND_OPENGL:
+		case (int)GPUBackend::OPENGL:
 		default:
-			nextBackend = GPU_BACKEND_DIRECT3D9;
+			nextBackend = GPUBackend::DIRECT3D9;
 			genericError = err->T("GenericOpenGLError", defaultErrorOpenGL);
 			break;
 		}
@@ -129,7 +129,7 @@ void EmuThreadFunc() {
 
 		if (yes) {
 			// Change the config to the alternative and restart.
-			g_Config.iGPUBackend = nextBackend;
+			g_Config.iGPUBackend = (int)nextBackend;
 			g_Config.Save();
 
 			W32Util::ExitAndRestart();

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -10,6 +10,7 @@
 
 #include "Core/Config.h"
 #include "Core/Reporting.h"
+#include "Core/System.h"
 #include "Windows/GPU/D3D11Context.h"
 #include "Windows/W32Util/Misc.h"
 #include "thin3d/thin3d.h"
@@ -140,6 +141,7 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 #endif
 
 	draw_ = Draw::T3DCreateD3D11Context(device_, context_, device1_, context1_, featureLevel_, hWnd_);
+	SetGPUBackend(GPUBackend::DIRECT3D11);
 	bool success = draw_->CreatePresets();  // If we can run D3D11, there's a compiler installed. I think.
 	assert(success);
 

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -113,7 +113,7 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		bool yes = IDYES == MessageBox(hWnd_, error.c_str(), title.c_str(), MB_ICONERROR | MB_YESNO);
 		if (yes) {
 			// Change the config to D3D and restart.
-			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
+			g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D9;
 			g_Config.Save();
 
 			W32Util::ExitAndRestart();

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -9,6 +9,7 @@
 
 #include "Core/Config.h"
 #include "Core/Reporting.h"
+#include "Core/System.h"
 #include "Common/OSVersion.h"
 #include "Windows/GPU/D3D9Context.h"
 #include "Windows/W32Util/Misc.h"
@@ -165,6 +166,7 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		//deviceEx->SetMaximumFrameLatency(1);
 	}
 	draw_ = Draw::T3DCreateDX9Context(d3d_, d3dEx_, adapterId_, device_, deviceEx_);
+	SetGPUBackend(GPUBackend::DIRECT3D9);
 	if (!draw_->CreatePresets()) {
 		// Shader compiler not installed? Return an error so we can fall back to GL.
 		device_->Release();

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -362,6 +362,7 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
+	SetGPUBackend(GPUBackend::OPENGL);
 	bool success = draw_->CreatePresets();  // if we get this far, there will always be a GLSL compiler capable of compiling these.
 	assert(success);
 	CHECK_GL_ERROR_IF_DEBUG();

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -243,7 +243,7 @@ bool WindowsGLContext::Init(HINSTANCE hInst, HWND window, std::string *error_mes
 
 		if (yes) {
 			// Change the config to D3D and restart.
-			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
+			g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D9;
 			g_Config.Save();
 
 			W32Util::ExitAndRestart();

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -51,6 +51,7 @@
 #include <sstream>
 
 #include "Core/Config.h"
+#include "Core/System.h"
 #include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanContext.h"
 #include "Common/Vulkan/VulkanDebug.h"
@@ -131,6 +132,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	bool splitSubmit = g_Config.bGfxDebugSplitSubmit;
 
 	draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, splitSubmit);
+	SetGPUBackend(GPUBackend::VULKAN);
 	bool success = draw_->CreatePresets();
 	assert(success);  // Doesn't fail, we include the compiler.
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -195,7 +195,7 @@ namespace MainWindow {
 		const char *translatedShaderName = nullptr;
 
 		availableShaders.clear();
-		if (g_Config.iGPUBackend == GPU_BACKEND_DIRECT3D9) {
+		if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
 			translatedShaderName = ps->T("Not available in Direct3D9 backend");
 			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_GRAYED, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		} else {
@@ -767,22 +767,22 @@ namespace MainWindow {
 			break;
 
 		case ID_OPTIONS_DIRECT3D9:
-			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
+			g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D9;
 			RestartApp();
 			break;
 
 		case ID_OPTIONS_DIRECT3D11:
-			g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D11;
+			g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D11;
 			RestartApp();
 			break;
 
 		case ID_OPTIONS_OPENGL:
-			g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
+			g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 			RestartApp();
 			break;
 
 		case ID_OPTIONS_VULKAN:
-			g_Config.iGPUBackend = GPU_BACKEND_VULKAN;
+			g_Config.iGPUBackend = (int)GPUBackend::VULKAN;
 			RestartApp();
 			break;
 
@@ -1244,8 +1244,8 @@ namespace MainWindow {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ((i == g_Config.iCurrentStateSlot) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
-		switch (g_Config.iGPUBackend) {
-		case GPU_BACKEND_DIRECT3D9:
+		switch (GetGPUBackend()) {
+		case GPUBackend::DIRECT3D9:
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_ENABLED);
@@ -1255,7 +1255,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_OPENGL, MF_UNCHECKED);
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_UNCHECKED);
 			break;
-		case GPU_BACKEND_OPENGL:
+		case GPUBackend::OPENGL:
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_GRAYED);
@@ -1265,7 +1265,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_OPENGL, MF_CHECKED);
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_UNCHECKED);
 			break;
-		case GPU_BACKEND_VULKAN:
+		case GPUBackend::VULKAN:
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_ENABLED);
@@ -1275,7 +1275,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_OPENGL, MF_UNCHECKED);
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_CHECKED);
 			break;
-		case GPU_BACKEND_DIRECT3D11:
+		case GPUBackend::DIRECT3D11:
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_ENABLED);

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -114,16 +114,16 @@ void WindowsHost::UpdateConsolePosition() {
 bool WindowsHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
 	WindowsGraphicsContext *graphicsContext = nullptr;
 	switch (g_Config.iGPUBackend) {
-	case GPU_BACKEND_OPENGL:
+	case (int)GPUBackend::OPENGL:
 		graphicsContext = new WindowsGLContext();
 		break;
-	case GPU_BACKEND_DIRECT3D9:
+	case (int)GPUBackend::DIRECT3D9:
 		graphicsContext = new D3D9Context();
 		break;
-	case GPU_BACKEND_DIRECT3D11:
+	case (int)GPUBackend::DIRECT3D11:
 		graphicsContext = new D3D11Context();
 		break;
-	case GPU_BACKEND_VULKAN:
+	case (int)GPUBackend::VULKAN:
 		graphicsContext = new WindowsVulkanContext();
 		break;
 	default:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -466,19 +466,19 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				// such as "software-gles", "software-d3d9", and "software-d3d11", or something similar.
 				// For now, software rendering force-activates OpenGL.
 				if (restOfOption == L"directx9") {
-					g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D9;
+					g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D9;
 					g_Config.bSoftwareRendering = false;
 				} else if (restOfOption == L"directx11") {
-					g_Config.iGPUBackend = GPU_BACKEND_DIRECT3D11;
+					g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D11;
 					g_Config.bSoftwareRendering = false;
 				} else if (restOfOption == L"gles") {
-					g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
+					g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 					g_Config.bSoftwareRendering = false;
 				} else if (restOfOption == L"vulkan") {
-					g_Config.iGPUBackend = GPU_BACKEND_VULKAN;
+					g_Config.iGPUBackend = (int)GPUBackend::VULKAN;
 					g_Config.bSoftwareRendering = false;
 				} else if (restOfOption == L"software") {
-					g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
+					g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 					g_Config.bSoftwareRendering = true;
 				}
 			}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1125,7 +1125,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 
 retry:
 
-	bool vulkan = g_Config.iGPUBackend == GPU_BACKEND_VULKAN;
+	bool vulkan = g_Config.iGPUBackend == (int)GPUBackend::VULKAN;
 
 	int tries = 0;
 	AndroidGraphicsContext *graphicsContext;
@@ -1140,8 +1140,8 @@ retry:
 
 		if (!exitRenderLoop && (vulkan && tries < 2)) {
 			ILOG("Trying again, this time with OpenGL.");
-			g_Config.iGPUBackend = GPU_BACKEND_OPENGL;
-			SetGPUBackend((GPUBackend)g_Config.iGPUBackend);  // Wait, why do we need a separate enum here?
+			g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
+			SetGPUBackend((GPUBackend)g_Config.iGPUBackend);
 			tries++;
 			goto retry;
 		}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -135,6 +135,7 @@ bool AndroidEGLGraphicsContext::Init(ANativeWindow *wnd, int backbufferWidth, in
 	gl->MakeCurrent();
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
+	SetGPUBackend(GPUBackend::OPENGL);
 	bool success = draw_->CreatePresets();  // There will always be a GLSL compiler capable of compiling these.
 	assert(success);
 	return true;
@@ -161,6 +162,7 @@ public:
 	AndroidJavaEGLGraphicsContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
+		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}
@@ -339,6 +341,7 @@ bool AndroidVulkanContext::Init(ANativeWindow *wnd, int desiredBackbufferSizeX, 
 	bool success = true;
 	if (g_Vulkan->InitObjects()) {
 		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, g_Config.bGfxDebugSplitSubmit);
+		SetGPUBackend(GPUBackend::VULKAN);
 		success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.
 		assert(success);
 		draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -192,6 +192,7 @@
     <None Include="math\fast\fast_matrix_neon.S" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Qt\QtMain.h" />
     <ClInclude Include="base\backtrace.h" />
     <ClInclude Include="base\basictypes.h" />
     <ClInclude Include="base\buffer.h" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClInclude Include="ui\ui_tween.h">
       <Filter>ui</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Qt\QtMain.h">
+      <Filter>base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -54,6 +54,7 @@ public:
 	GLDummyGraphicsContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
+		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -21,6 +21,7 @@
 #include "gfx_es2/gpu_features.h"
 
 #include "Core/Config.h"
+#include "Core/System.h"
 #include "Common/GraphicsContext.h"
 
 #include <sys/types.h>
@@ -39,6 +40,7 @@ public:
 	IOSDummyGraphicsContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
+		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}


### PR DESCRIPTION
In #10449, there was some confusion around whether Vulkan was working in Qt, and why it was rendering upside down.

To clarify things, this avoids using iGPUBackend for logic (since it ultimately may not reflect the actual currently running backend), and also resets the system backend value on graphics context init.  This fixes the flipped graphics by correctly using a flipped matrix in OpenGL, even when iGPUBackend is set to Vulkan, but ignored - as is the case on Qt.

Additionally, this fixes OpenGL init in Qt.  May help #9270 / #9559.

-[Unknown]