### PR TITLE
UI: Trigger view recreate on static sized screens

### DIFF
--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -165,7 +165,11 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 		picked_ = 0;
 	}
 	return true;
-};
+}
+
+void DisplayLayoutScreen::resized() {
+	RecreateViews();
+}
 
 void DisplayLayoutScreen::onFinish(DialogResult reason) {
 	g_Config.Save();

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -31,6 +31,7 @@ public:
 	virtual bool touch(const TouchInput &touch) override;
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 	virtual void onFinish(DialogResult reason) override;
+	virtual void resized() override;
 	std::string tag() const override { return "display layout screen"; }
 	
 protected:

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1099,10 +1099,6 @@ void NativeResized() {
 	// NativeResized can come from any thread so we just set a flag, then process it later.
 	if (g_graphicsInited) {
 		resized = true;
-		if (uiContext) {
-			// Still have to update bounds to avoid problems in display layout and touch controls layout screens
-			uiContext->SetBounds(Bounds(0, 0, dp_xres, dp_yres));
-		}
 	} else {
 		ILOG("NativeResized ignored, not initialized");
 	}

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -279,7 +279,11 @@ bool TouchControlLayoutScreen::touch(const TouchInput &touch) {
 		pickedControl_ = 0;
 	}
 	return true;
-};
+}
+
+void TouchControlLayoutScreen::resized() {
+	RecreateViews();
+}
 
 void TouchControlLayoutScreen::onFinish(DialogResult reason) {
 	g_Config.Save();

--- a/UI/TouchControlLayoutScreen.h
+++ b/UI/TouchControlLayoutScreen.h
@@ -34,6 +34,7 @@ public:
 	virtual bool touch(const TouchInput &touch) override;
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 	virtual void onFinish(DialogResult reason) override;
+	virtual void resized() override;
 
 protected:
 	virtual UI::EventReturn OnReset(UI::EventParams &e);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -279,10 +279,6 @@ namespace MainWindow
 			NativeMessageReceived("gpu_resized", "");
 		}
 
-		if (screenManager) {
-			screenManager->RecreateAllViews();
-		}
-
 		// Don't save the window state if fullscreen.
 		if (!g_Config.bFullScreen) {
 			g_WindowState = newSizingType;

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -309,6 +309,10 @@ void PopupScreen::TriggerFinish(DialogResult result) {
 	OnCompleted(result);
 }
 
+void PopupScreen::resized() {
+	RecreateViews();
+}
+
 void PopupScreen::CreateViews() {
 	using namespace UI;
 	UIContext &dc = *screenManager()->getUIContext();

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -72,6 +72,7 @@ public:
 	virtual bool isTransparent() const override { return true; }
 	virtual bool touch(const TouchInput &touch) override;
 	virtual bool key(const KeyInput &key) override;
+	virtual void resized() override;
 
 	virtual void TriggerFinish(DialogResult result) override;
 


### PR DESCRIPTION
If a screen doesn't size via layout, it needs to recreate views on resize, which is what the resized() method is for.

This way we don't run into possible race condition issues, and also we make sure to resize on all platforms consistently.  Fixes #10396.

-[Unknown]