### PR TITLE
More arm64 optimizations and cleanup

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -2073,7 +2073,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 	}
 	else
 	{
-		_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s immediate offset must be within range of -256 to 256!", __FUNCTION__);
+		_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s immediate offset must be within range of -256 to 255!", __FUNCTION__);
 		encoded_imm = (imm & 0x1FF) << 2;
 		if (type == INDEX_POST)
 			encoded_imm |= 1;

--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -3669,8 +3669,10 @@ void ARM64XEmitter::ANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 		imm &= 0xFFFFFFFF;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		AND(Rd, Rn, imm_r, imm_s, n != 0);
+	} else if (imm == 0) {
+		MOVI2R(Rd, 0);
 	} else {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ANDSI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(JIT, scratch != INVALID_REG, "ANDI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		AND(Rd, Rn, scratch);
 	}
@@ -3680,6 +3682,10 @@ void ARM64XEmitter::ORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 	unsigned int n, imm_s, imm_r;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		ORR(Rd, Rn, imm_r, imm_s, n != 0);
+	} else if (imm == 0) {
+		if (Rd != Rn) {
+			MOV(Rd, Rn);
+		}
 	} else {
 		_assert_msg_(JIT, scratch != INVALID_REG, "ORRI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
@@ -3691,6 +3697,10 @@ void ARM64XEmitter::EORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 	unsigned int n, imm_s, imm_r;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		EOR(Rd, Rn, imm_r, imm_s, n != 0);
+	} else if (imm == 0) {
+		if (Rd != Rn) {
+			MOV(Rd, Rn);
+		}
 	} else {
 		_assert_msg_(JIT, scratch != INVALID_REG, "EORI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
@@ -3702,6 +3712,8 @@ void ARM64XEmitter::ANDSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
 	unsigned int n, imm_s, imm_r;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		ANDS(Rd, Rn, imm_r, imm_s, n != 0);
+	} else if (imm == 0) {
+		ANDS(Rd, Rn, Is64Bit(Rn) ? ZR : WZR, ArithOption(Rd, ST_LSL, 0));
 	} else {
 		_assert_msg_(JIT, scratch != INVALID_REG, "ANDSI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
@@ -3783,6 +3795,9 @@ bool ARM64XEmitter::TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm) {
 	if (IsImmLogical(imm, 32, &n, &imm_s, &imm_r)) {
 		AND(Rd, Rn, imm_r, imm_s, n != 0);
 		return true;
+	} else if (imm == 0) {
+		MOVI2R(Rd, 0);
+		return true;
 	} else {
 		return false;
 	}
@@ -3792,6 +3807,11 @@ bool ARM64XEmitter::TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm) {
 	if (IsImmLogical(imm, 32, &n, &imm_s, &imm_r)) {
 		ORR(Rd, Rn, imm_r, imm_s, n != 0);
 		return true;
+	} else if (imm == 0) {
+		if (Rd != Rn) {
+			MOV(Rd, Rn);
+		}
+		return true;
 	} else {
 		return false;
 	}
@@ -3800,6 +3820,11 @@ bool ARM64XEmitter::TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm) {
 	u32 n, imm_r, imm_s;
 	if (IsImmLogical(imm, 32, &n, &imm_s, &imm_r)) {
 		EOR(Rd, Rn, imm_r, imm_s, n != 0);
+		return true;
+	} else if (imm == 0) {
+		if (Rd != Rn) {
+			MOV(Rd, Rn);
+		}
 		return true;
 	} else {
 		return false;
@@ -3892,7 +3917,7 @@ void ARM64XEmitter::SUBSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
 	if (IsImmArithmetic(imm, &val, &shift)) {
 		SUBS(Rd, Rn, val, shift);
 	} else {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ANDSI2R - failed to construct immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(JIT, scratch != INVALID_REG, "SUBSI2R - failed to construct immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		SUBS(Rd, Rn, scratch);
 	}

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -86,8 +86,8 @@ void Arm64Jit::Comp_IType(MIPSOpcode op) {
 	case 8:	// same as addiu?
 	case 9:	// R(rt) = R(rs) + simm; break;	//addiu
 		// Special-case for small adjustments of pointerified registers. Commonly for SP but happens for others.
-		if (rs == rt && jo.enablePointerify && gpr.IsMappedAsPointer(rs) && IsImmArithmetic(simm < 0 ? -simm : simm, nullptr, nullptr)) {
-			ARM64Reg r32 = gpr.R(rs);
+		if (rs == rt && gpr.IsMappedAsPointer(rs) && IsImmArithmetic(simm < 0 ? -simm : simm, nullptr, nullptr)) {
+			ARM64Reg r32 = gpr.RPtr(rs);
 			gpr.MarkDirty(r32);
 			ARM64Reg r = EncodeRegTo64(r32);
 			if (simm > 0) {

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -102,7 +102,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 		fpr.SpillLock(ft);
 		fpr.MapReg(ft, MAP_NOINIT | MAP_DIRTY);
 		if (gpr.IsImm(rs)) {
-			u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+			u32 addr = offset + gpr.GetImm(rs);
 			gpr.SetRegImm(SCRATCH1, addr);
 		} else {
 			gpr.MapReg(rs);
@@ -129,7 +129,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 
 		fpr.MapReg(ft);
 		if (gpr.IsImm(rs)) {
-			u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+			u32 addr = offset + gpr.GetImm(rs);
 			gpr.SetRegImm(SCRATCH1, addr);
 		} else {
 			gpr.MapReg(rs);

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -103,7 +103,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 		fpr.MapReg(ft, MAP_NOINIT | MAP_DIRTY);
 		if (gpr.IsImm(rs)) {
 			u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
-			gpr.SetRegImm(SCRATCH1_64, (uintptr_t)(Memory::base + addr));
+			gpr.SetRegImm(SCRATCH1, addr);
 		} else {
 			gpr.MapReg(rs);
 			if (g_Config.bFastMemory) {
@@ -111,13 +111,8 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 			} else {
 				skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);
 			}
-			if (jo.enablePointerify) {
-				MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
-			} else {
-				ADD(SCRATCH1_64, SCRATCH1_64, MEMBASEREG);
-			}
 		}
-		fp.LDR(32, INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
+		fp.LDR(32, fpr.R(ft), SCRATCH1_64, ArithOption(MEMBASEREG));
 		for (auto skip : skips) {
 			SetJumpTarget(skip);
 		}
@@ -135,7 +130,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 		fpr.MapReg(ft);
 		if (gpr.IsImm(rs)) {
 			u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
-			gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)(Memory::base));
+			gpr.SetRegImm(SCRATCH1, addr);
 		} else {
 			gpr.MapReg(rs);
 			if (g_Config.bFastMemory) {
@@ -143,13 +138,8 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 			} else {
 				skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);
 			}
-			if (jo.enablePointerify) {
-				MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
-			} else {
-				ADD(SCRATCH1_64, SCRATCH1_64, MEMBASEREG);
-			}
 		}
-		fp.STR(32, INDEX_UNSIGNED, fpr.R(ft), SCRATCH1_64, 0);
+		fp.STR(32, fpr.R(ft), SCRATCH1_64, ArithOption(MEMBASEREG));
 		for (auto skip : skips) {
 			SetJumpTarget(skip);
 		}

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -135,7 +135,7 @@ namespace MIPSComp {
 		std::vector<FixupBranch> skips;
 
 		if (gpr.IsImm(rs) && Memory::IsValidAddress(iaddr)) {
-			u32 addr = iaddr;
+			u32 addr = iaddr & 0x3FFFFFFF;
 			// Need to initialize since this only loads part of the register.
 			// But rs no longer matters (even if rs == rt) since we have the address.
 			gpr.MapReg(rt, load ? MAP_DIRTY : 0);

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -129,8 +129,6 @@ namespace MIPSComp {
 			}
 		}
 
-		DISABLE;
-
 		u32 iaddr = gpr.IsImm(rs) ? offset + gpr.GetImm(rs) : 0xFFFFFFFF;
 		std::vector<FixupBranch> skips;
 
@@ -159,35 +157,21 @@ namespace MIPSComp {
 			case 42: // swl
 				LDR(SCRATCH2, MEMBASEREG, SCRATCH1);
 				ANDI2R(SCRATCH2, SCRATCH2, 0xffffff00 << shift, INVALID_REG);
-				ORR(SCRATCH2, SCRATCH2, SCRATCH2, ArithOption(gpr.R(rt), ST_LSR, 24 - shift));
+				ORR(SCRATCH2, SCRATCH2, gpr.R(rt), ArithOption(gpr.R(rt), ST_LSR, 24 - shift));
 				STR(SCRATCH2, MEMBASEREG, SCRATCH1);
 				break;
 
 			case 46: // swr
 				LDR(SCRATCH2, MEMBASEREG, SCRATCH1);
 				ANDI2R(SCRATCH2, SCRATCH2, 0x00ffffff >> (24 - shift), INVALID_REG);
-				ORR(SCRATCH2, SCRATCH2, SCRATCH2, ArithOption(gpr.R(rt), ST_LSL, shift));
+				ORR(SCRATCH2, SCRATCH2, gpr.R(rt), ArithOption(gpr.R(rt), ST_LSL, shift));
 				STR(SCRATCH2, MEMBASEREG, SCRATCH1);
 				break;
 			}
 			return;
 		}
 
-		switch (o) {
-		case 34: // lwl
-			DISABLE;
-			break;
-
-		case 38: // lwr
-			DISABLE;
-			break;
-
-		case 42: // swl
-			break;
-
-		case 46: // swr
-			break;
-		}
+		DISABLE;
 
 		_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address?  CPU bug?");
 		if (load) {

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -133,13 +133,12 @@ namespace MIPSComp {
 		std::vector<FixupBranch> skips;
 
 		if (gpr.IsImm(rs) && Memory::IsValidAddress(iaddr)) {
-			u32 addr = iaddr & 0x3FFFFFFF;
 			// Need to initialize since this only loads part of the register.
 			// But rs no longer matters (even if rs == rt) since we have the address.
 			gpr.MapReg(rt, load ? MAP_DIRTY : 0);
-			gpr.SetRegImm(SCRATCH1, addr & ~3);
+			gpr.SetRegImm(SCRATCH1, iaddr & ~3);
 
-			u8 shift = (addr & 3) * 8;
+			u8 shift = (iaddr & 3) * 8;
 
 			switch (o) {
 			case 34: // lwl

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -221,7 +221,7 @@ namespace MIPSComp {
 			// CC might be set by slow path below, so load regs first.
 			fpr.MapRegV(vt, MAP_DIRTY | MAP_NOINIT);
 			if (gpr.IsImm(rs)) {
-				u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+				u32 addr = offset + gpr.GetImm(rs);
 				gpr.SetRegImm(SCRATCH1, addr);
 			} else {
 				gpr.MapReg(rs);
@@ -250,7 +250,7 @@ namespace MIPSComp {
 			// CC might be set by slow path below, so load regs first.
 			fpr.MapRegV(vt);
 			if (gpr.IsImm(rs)) {
-				u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+				u32 addr = offset + gpr.GetImm(rs);
 				gpr.SetRegImm(SCRATCH1, addr);
 			} else {
 				gpr.MapReg(rs);
@@ -291,7 +291,7 @@ namespace MIPSComp {
 				fpr.MapRegsAndSpillLockV(vregs, V_Quad, MAP_DIRTY | MAP_NOINIT);
 
 				if (gpr.IsImm(rs)) {
-					u32 addr = (imm + gpr.GetImm(rs)) & 0x3FFFFFFF;
+					u32 addr = imm + gpr.GetImm(rs);
 					gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
 				} else {
 					gpr.MapReg(rs);
@@ -324,7 +324,7 @@ namespace MIPSComp {
 				fpr.MapRegsAndSpillLockV(vregs, V_Quad, 0);
 
 				if (gpr.IsImm(rs)) {
-					u32 addr = (imm + gpr.GetImm(rs)) & 0x3FFFFFFF;
+					u32 addr = imm + gpr.GetImm(rs);
 					gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
 				} else {
 					gpr.MapReg(rs);

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -221,8 +221,8 @@ namespace MIPSComp {
 			// CC might be set by slow path below, so load regs first.
 			fpr.MapRegV(vt, MAP_DIRTY | MAP_NOINIT);
 			if (gpr.IsImm(rs)) {
-				u32 addr = offset + gpr.GetImm(rs);
-				gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
+				u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+				gpr.SetRegImm(SCRATCH1, addr);
 			} else {
 				gpr.MapReg(rs);
 				if (g_Config.bFastMemory) {
@@ -230,14 +230,8 @@ namespace MIPSComp {
 				} else {
 					skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);
 				}
-				// Pointerify
-				if (jo.enablePointerify) {
-					MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
-				} else {
-					ADD(SCRATCH1_64, SCRATCH1_64, MEMBASEREG);
-				}
 			}
-			fp.LDR(32, INDEX_UNSIGNED, fpr.V(vt), SCRATCH1_64, 0);
+			fp.LDR(32, fpr.V(vt), SCRATCH1_64, ArithOption(MEMBASEREG));
 			for (auto skip : skips) {
 				SetJumpTarget(skip);
 			}
@@ -256,8 +250,8 @@ namespace MIPSComp {
 			// CC might be set by slow path below, so load regs first.
 			fpr.MapRegV(vt);
 			if (gpr.IsImm(rs)) {
-				u32 addr = offset + gpr.GetImm(rs);
-				gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
+				u32 addr = (offset + gpr.GetImm(rs)) & 0x3FFFFFFF;
+				gpr.SetRegImm(SCRATCH1, addr);
 			} else {
 				gpr.MapReg(rs);
 				if (g_Config.bFastMemory) {
@@ -265,13 +259,8 @@ namespace MIPSComp {
 				} else {
 					skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);
 				}
-				if (jo.enablePointerify) {
-					MOVK(SCRATCH1_64, ((uint64_t)Memory::base) >> 32, SHIFT_32);
-				} else {
-					ADD(SCRATCH1_64, SCRATCH1_64, MEMBASEREG);
-				}
 			}
-			fp.STR(32, INDEX_UNSIGNED, fpr.V(vt), SCRATCH1_64, 0);
+			fp.STR(32, fpr.V(vt), SCRATCH1_64, ArithOption(MEMBASEREG));
 			for (auto skip : skips) {
 				SetJumpTarget(skip);
 			}
@@ -302,7 +291,7 @@ namespace MIPSComp {
 				fpr.MapRegsAndSpillLockV(vregs, V_Quad, MAP_DIRTY | MAP_NOINIT);
 
 				if (gpr.IsImm(rs)) {
-					u32 addr = imm + gpr.GetImm(rs);
+					u32 addr = (imm + gpr.GetImm(rs)) & 0x3FFFFFFF;
 					gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
 				} else {
 					gpr.MapReg(rs);
@@ -335,7 +324,7 @@ namespace MIPSComp {
 				fpr.MapRegsAndSpillLockV(vregs, V_Quad, 0);
 
 				if (gpr.IsImm(rs)) {
-					u32 addr = imm + gpr.GetImm(rs);
+					u32 addr = (imm + gpr.GetImm(rs)) & 0x3FFFFFFF;
 					gpr.SetRegImm(SCRATCH1_64, addr + (uintptr_t)Memory::base);
 				} else {
 					gpr.MapReg(rs);

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -66,6 +66,11 @@ using namespace Arm64Gen;
 using namespace Arm64JitConstants;
 
 Arm64Jit::Arm64Jit(MIPSState *mips) : blocks(mips, this), gpr(mips, &js, &jo), fpr(mips, &js, &jo), mips_(mips), fp(this) { 
+	// Automatically disable incompatible options.
+	if (((intptr_t)Memory::base & 0x00000000FFFFFFFFUL) != 0) {
+		jo.enablePointerify = false;
+	}
+
 	logBlocks = 0;
 	dontLogBlocks = 0;
 	blocks.Init();

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -434,14 +434,6 @@ Arm64Gen::ARM64Reg Arm64RegCache::MapRegAsPointer(MIPSGPReg reg) {
 		mr[reg].loc = ML_ARMREG;
 		ARM64Reg a = DecodeReg(mr[reg].reg);
 		if (!jo_->enablePointerify) {
-			// First, flush the value.
-			if (ar[a].isDirty) {
-				ARM64Reg storeReg = ARM64RegForFlush(ar[a].mipsReg);
-				if (storeReg != INVALID_REG)
-					emit_->STR(INDEX_UNSIGNED, storeReg, CTXREG, GetMipsRegOffset(ar[a].mipsReg));
-				ar[a].isDirty = false;
-			}
-
 			// Convert to a pointer by adding the base and clearing off the top bits.
 			// If SP, we can probably avoid the top bit clear, let's play with that later.
 			emit_->ADD(EncodeRegTo64(a), EncodeRegTo64(a), MEMBASEREG);

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -101,6 +101,8 @@ public:
 	// Optimally set a register to an imm value (possibly using another register.)
 	void SetRegImm(Arm64Gen::ARM64Reg reg, u64 imm);
 
+	Arm64Gen::ARM64Reg MapTempImm(MIPSGPReg);
+
 	// Returns an ARM register containing the requested MIPS register.
 	Arm64Gen::ARM64Reg MapReg(MIPSGPReg reg, int mapFlags = 0);
 	Arm64Gen::ARM64Reg MapRegAsPointer(MIPSGPReg reg);

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -62,6 +62,7 @@ struct RegARM64 {
 	MIPSGPReg mipsReg;  // if -1, no mipsreg attached.
 	bool isDirty;  // Should the register be written back?
 	bool pointerified;  // Has used movk to move the memory base into the top part of the reg. Note - still usable as 32-bit reg!
+	bool tempLocked; // Reserved for a temp register.
 };
 
 struct RegMIPS {
@@ -124,6 +125,8 @@ public:
 	void FlushR(MIPSGPReg r);
 	void DiscardR(MIPSGPReg r);
 
+	Arm64Gen::ARM64Reg GetAndLockTempR();
+
 	Arm64Gen::ARM64Reg R(MIPSGPReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
 	Arm64Gen::ARM64Reg RPtr(MIPSGPReg preg); // Returns a cached register, if it has been mapped as a pointer
 
@@ -147,6 +150,7 @@ private:
 	const StaticAllocation *GetStaticAllocations(int &count);
 	const Arm64Gen::ARM64Reg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(Arm64Gen::ARM64Reg reg, MIPSGPReg mipsReg, int mapFlags);
+	Arm64Gen::ARM64Reg AllocateReg();
 	Arm64Gen::ARM64Reg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	Arm64Gen::ARM64Reg ARM64RegForFlush(MIPSGPReg r);
 

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -43,6 +43,13 @@ struct BlockCacheStats {
 	std::map<float, u32> bloatMap;
 };
 
+enum class DestroyType {
+	DESTROY,
+	INVALIDATE,
+	// Skips jit unlink, since it'll be poisoned anyway.
+	CLEAR,
+};
+
 // Define this in order to get VTune profile support for the Jit generated code.
 // Add the VTune include/lib directories to the project directories to get this to build.
 // #define USE_VTUNE
@@ -126,7 +133,7 @@ public:
 	// DOES NOT WORK CORRECTLY WITH JIT INLINING
 	void InvalidateICache(u32 address, const u32 length);
 	void InvalidateChangedBlocks();
-	void DestroyBlock(int block_num, bool invalidate);
+	void DestroyBlock(int block_num, DestroyType type);
 
 	// No jit operations may be run between these calls.
 	// Meant to be used to make memory safe for savestates, memcpy, etc.

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -54,11 +54,8 @@ namespace MIPSComp {
 		enablePointerify = false;
 #if PPSSPP_ARCH(ARM64)
 		useStaticAlloc = true;
+		// iOS/etc. may disable at runtime if Memory::base is not nicely aligned.
 		enablePointerify = true;
-#endif
-#if PPSSPP_PLATFORM(IOS)
-		useStaticAlloc = false;
-		enablePointerify = false;
 #endif
 	}
 }

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -440,6 +440,7 @@ void JitSafeMemFuncs::Init(ThunkManager *thunks) {
 	AllocCodeSpace(FUNCS_ARENA_SIZE);
 	thunks_ = thunks;
 
+	BeginWrite();
 	readU32 = GetCodePtr();
 	CreateReadFunc(32, (const void *)&Memory::Read_U32);
 	readU16 = GetCodePtr();
@@ -453,6 +454,7 @@ void JitSafeMemFuncs::Init(ThunkManager *thunks) {
 	CreateWriteFunc(16, (const void *)&Memory::Write_U16);
 	writeU8 = GetCodePtr();
 	CreateWriteFunc(8, (const void *)&Memory::Write_U8);
+	EndWrite();
 }
 
 void JitSafeMemFuncs::Shutdown() {


### PR DESCRIPTION
A few improvements:
 * Allows offsetting pointers and static allocation on unaligned memory base (iOS.)
 * Improves jit cache clearing performance or WX exclusive (iOS.)
 * Auto-detects pointerify support (in case of other platforms, and to make testing easier.)
 * Avoids mapping for store ops if possible (i.e. WZR.)
 * Fixes and enables lwl/lwr (Gods Eater Burst still works.)

-[Unknown]