### PR TITLE
More arm64jit improvements

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -3738,7 +3738,11 @@ void ARM64XEmitter::CMPI2R(ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
 bool ARM64XEmitter::TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 	u32 val;
 	bool shift;
-	if (IsImmArithmetic(imm, &val, &shift)) {
+	if (imm == 0) {
+		// Prefer MOV (ORR) instead of ADD for moves.
+		MOV(Rd, Rn);
+		return true;
+	} else if (IsImmArithmetic(imm, &val, &shift)) {
 		ADD(Rd, Rn, val, shift);
 		return true;
 	} else {
@@ -3749,7 +3753,11 @@ bool ARM64XEmitter::TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 bool ARM64XEmitter::TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 	u32 val;
 	bool shift;
-	if (IsImmArithmetic(imm, &val, &shift)) {
+	if (imm == 0) {
+		// Prefer MOV (ORR) instead of ADD for moves.
+		MOV(Rd, Rn);
+		return true;
+	} else if (IsImmArithmetic(imm, &val, &shift)) {
 		SUB(Rd, Rn, val, shift);
 		return true;
 	} else {

--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -1547,6 +1547,10 @@ void ARM64XEmitter::CMP(ARM64Reg Rn, u32 imm, bool shift)
 {
 	EncodeAddSubImmInst(1, true, shift, imm, Rn, Is64Bit(Rn) ? SP : WSP);
 }
+void ARM64XEmitter::CMN(ARM64Reg Rn, u32 imm, bool shift)
+{
+	EncodeAddSubImmInst(0, true, shift, imm, Rn, Is64Bit(Rn) ? SP : WSP);
+}
 
 // Data Processing (Immediate)
 void ARM64XEmitter::MOVZ(ARM64Reg Rd, u32 imm, ShiftAmount pos)
@@ -3754,10 +3758,14 @@ bool ARM64XEmitter::TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 }
 
 bool ARM64XEmitter::TryCMPI2R(ARM64Reg Rn, u64 imm) {
+	s64 negated = Is64Bit(Rn) ? -(s64)imm : -(s32)(u32)imm;
 	u32 val;
 	bool shift;
 	if (IsImmArithmetic(imm, &val, &shift)) {
 		CMP(Rn, val, shift);
+		return true;
+	} else if (IsImmArithmetic((u64)negated, &val, &shift)) {
+		CMN(Rn, val, shift);
 		return true;
 	} else {
 		return false;

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -714,13 +714,13 @@ public:
 	void SUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch = INVALID_REG);
 	void SUBSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch = INVALID_REG);
 
-	bool TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-	bool TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-	bool TryCMPI2R(ARM64Reg Rn, u32 imm);
+	bool TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+	bool TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+	bool TryCMPI2R(ARM64Reg Rn, u64 imm);
 
-	bool TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-	bool TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-	bool TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
+	bool TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+	bool TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+	bool TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
 
 	// Pseudo-instruction for convenience. PUSH pushes 16 bytes even though we only push a single register.
 	// This is so the stack pointer is always 16-byte aligned, which is checked by hardware!

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -591,6 +591,7 @@ public:
 	void SUB(ARM64Reg Rd, ARM64Reg Rn, u32 imm, bool shift = false);
 	void SUBS(ARM64Reg Rd, ARM64Reg Rn, u32 imm, bool shift = false);
 	void CMP(ARM64Reg Rn, u32 imm, bool shift = false);
+	void CMN(ARM64Reg Rn, u32 imm, bool shift = false);
 
 	// Data Processing (Immediate)
 	void MOVZ(ARM64Reg Rd, u32 imm, ShiftAmount pos = SHIFT_0);

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -392,13 +392,11 @@ void Arm64Jit::CompShiftVar(MIPSOpcode op, Arm64Gen::ShiftType shiftType) {
 		return;
 	}
 	gpr.MapDirtyInIn(rd, rs, rt);
-	// Not sure if ARM64 wraps like this so let's do it for it.  (TODO: According to the ARM ARM, it will indeed mask for us so this is not necessary)
-	ANDI2R(SCRATCH1, gpr.R(rs), 0x1F, INVALID_REG);
 	switch (shiftType) {
-	case ST_LSL: LSLV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;
-	case ST_LSR: LSRV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;
-	case ST_ASR: ASRV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;
-	case ST_ROR: RORV(gpr.R(rd), gpr.R(rt), SCRATCH1); break;
+	case ST_LSL: LSLV(gpr.R(rd), gpr.R(rt), gpr.R(rs)); break;
+	case ST_LSR: LSRV(gpr.R(rd), gpr.R(rt), gpr.R(rs)); break;
+	case ST_ASR: ASRV(gpr.R(rd), gpr.R(rt), gpr.R(rs)); break;
+	case ST_ROR: RORV(gpr.R(rd), gpr.R(rt), gpr.R(rs)); break;
 	}
 }
 

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -57,7 +57,7 @@ static u32 EvalAnd(u32 a, u32 b) { return a & b; }
 static u32 EvalAdd(u32 a, u32 b) { return a + b; }
 static u32 EvalSub(u32 a, u32 b) { return a - b; }
 
-void Arm64Jit::CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARM64XEmitter::*arith)(ARM64Reg dst, ARM64Reg src, ARM64Reg src2), bool (ARM64XEmitter::*tryArithI2R)(ARM64Reg dst, ARM64Reg src, u32 val), u32 (*eval)(u32 a, u32 b)) {
+void Arm64Jit::CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARM64XEmitter::*arith)(ARM64Reg dst, ARM64Reg src, ARM64Reg src2), bool (ARM64XEmitter::*tryArithI2R)(ARM64Reg dst, ARM64Reg src, u64 val), u32 (*eval)(u32 a, u32 b)) {
 	if (gpr.IsImm(rs)) {
 		gpr.SetImm(rt, (*eval)(gpr.GetImm(rs), uimm));
 	} else {
@@ -119,7 +119,7 @@ void Arm64Jit::Comp_IType(MIPSOpcode op) {
 			break;
 		}
 		gpr.MapDirtyIn(rt, rs);
-		if (!TryCMPI2R(gpr.R(rs), simm)) {
+		if (!TryCMPI2R(gpr.R(rs), (u32)simm)) {
 			gpr.SetRegImm(SCRATCH1, simm);
 			CMP(gpr.R(rs), SCRATCH1);
 		}
@@ -196,7 +196,7 @@ void Arm64Jit::Comp_RType2(MIPSOpcode op) {
 	}
 }
 
-void Arm64Jit::CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARM64XEmitter::*arith)(ARM64Reg dst, ARM64Reg rm, ARM64Reg rn), bool (ARM64XEmitter::*tryArithI2R)(ARM64Reg dst, ARM64Reg rm, u32 val), u32(*eval)(u32 a, u32 b), bool symmetric) {
+void Arm64Jit::CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARM64XEmitter::*arith)(ARM64Reg dst, ARM64Reg rm, ARM64Reg rn), bool (ARM64XEmitter::*tryArithI2R)(ARM64Reg dst, ARM64Reg rm, u64 val), u32(*eval)(u32 a, u32 b), bool symmetric) {
 	if (gpr.IsImm(rs) && gpr.IsImm(rt)) {
 		gpr.SetImm(rd, (*eval)(gpr.GetImm(rs), gpr.GetImm(rt)));
 		return;

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -262,7 +262,16 @@ void Arm64Jit::Comp_RType3(MIPSOpcode op) {
 
 	case 32: //R(rd) = R(rs) + R(rt);           break; //add
 	case 33: //R(rd) = R(rs) + R(rt);           break; //addu
-		CompType3(rd, rs, rt, &ARM64XEmitter::ADD, &ARM64XEmitter::TryADDI2R, &EvalAdd, true);
+		if (gpr.IsImm(rs) && gpr.GetImm(rs) == 0 && !gpr.IsImm(rt)) {
+			// Special case: actually a mov, avoid arithmetic.
+			gpr.MapDirtyIn(rd, rt);
+			MOV(gpr.R(rd), gpr.R(rt));
+		} else if (gpr.IsImm(rt) && gpr.GetImm(rt) == 0 && !gpr.IsImm(rs)) {
+			gpr.MapDirtyIn(rd, rs);
+			MOV(gpr.R(rd), gpr.R(rs));
+		} else {
+			CompType3(rd, rs, rt, &ARM64XEmitter::ADD, &ARM64XEmitter::TryADDI2R, &EvalAdd, true);
+		}
 		break;
 
 	case 34: //R(rd) = R(rs) - R(rt);           break; //sub

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -574,7 +574,7 @@ void Arm64Jit::Comp_JumpReg(MIPSOpcode op)
 		destReg = gpr.R(rs);  // Safe because FlushAll doesn't change any regs
 		FlushAll();
 	} else {
-		// Delay slot - this case is very rare, might be able to free up R8.
+		// Delay slot - this case is very rare, might be able to free up W24.
 		gpr.MapReg(rs);
 		MOV(destReg, gpr.R(rs));
 		if (andLink)

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -176,17 +176,17 @@ namespace MIPSComp {
 		} else {
 			gpr.MapInIn(rt, rs);
 		}
+		gpr.SpillLock(rt);
+		gpr.SpillLock(rs);
+		// Need to get temps before skipping safe mem.
+		ARM64Reg LR_SCRATCH3 = gpr.GetAndLockTempR();
+		ARM64Reg LR_SCRATCH4 = gpr.GetAndLockTempR();
 
-		if (false && !g_Config.bFastMemory && rs != MIPS_REG_SP) {
+		if (!g_Config.bFastMemory && rs != MIPS_REG_SP) {
 			skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);
 		} else {
 			SetScratch1ToEffectiveAddress(rs, offset);
 		}
-
-		// We can lose rs now, since we have it in SCRATCH1.
-		gpr.SpillLock(rt);
-		ARM64Reg LR_SCRATCH3 = gpr.GetAndLockTempR();
-		ARM64Reg LR_SCRATCH4 = gpr.GetAndLockTempR();
 
 		// Here's our shift amount.
 		ANDI2R(SCRATCH2, SCRATCH1, 3);

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -220,8 +220,8 @@ private:
 	void BranchRSRTComp(MIPSOpcode op, CCFlags cc, bool likely);
 
 	// Utilities to reduce duplicated code
-	void CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARM64XEmitter::*arith)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg src, Arm64Gen::ARM64Reg src2), bool (ARM64XEmitter::*tryArithI2R)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg src, u32 val), u32 (*eval)(u32 a, u32 b));
-	void CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARM64XEmitter::*arithOp2)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg rm, Arm64Gen::ARM64Reg rn), bool (ARM64XEmitter::*tryArithI2R)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg rm, u32 val), u32 (*eval)(u32 a, u32 b), bool symmetric = false);
+	void CompImmLogic(MIPSGPReg rs, MIPSGPReg rt, u32 uimm, void (ARM64XEmitter::*arith)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg src, Arm64Gen::ARM64Reg src2), bool (ARM64XEmitter::*tryArithI2R)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg src, u64 val), u32 (*eval)(u32 a, u32 b));
+	void CompType3(MIPSGPReg rd, MIPSGPReg rs, MIPSGPReg rt, void (ARM64XEmitter::*arithOp2)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg rm, Arm64Gen::ARM64Reg rn), bool (ARM64XEmitter::*tryArithI2R)(Arm64Gen::ARM64Reg dst, Arm64Gen::ARM64Reg rm, u64 val), u32 (*eval)(u32 a, u32 b), bool symmetric = false);
 	void CompShiftImm(MIPSOpcode op, Arm64Gen::ShiftType shiftType, int sa);
 	void CompShiftVar(MIPSOpcode op, Arm64Gen::ShiftType shiftType);
 	void CompVrotShuffle(u8 *dregs, int imm, VectorSize sz, bool negSin);

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -275,6 +275,8 @@ ARM64Reg Arm64RegCache::FindBestToSpill(bool unusedOnly, bool *clobbered) {
 		ARM64Reg reg = allocOrder[i];
 		if (ar[reg].mipsReg != MIPS_REG_INVALID && mr[ar[reg].mipsReg].spillLock)
 			continue;
+		if (ar[reg].tempLocked)
+			continue;
 
 		// As it's in alloc-order, we know it's not static so we don't need to check for that.
 

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -690,6 +690,9 @@ void Arm64RegCache::FlushR(MIPSGPReg r) {
 }
 
 void Arm64RegCache::FlushAll() {
+	// Note: make sure not to change the registers when flushing:
+	// Branching code expects the armreg to retain its value.
+
 	// LO can't be included in a 32-bit pair, since it's 64 bit.
 	// Flush it first so we don't get it confused.
 	FlushR(MIPS_REG_LO);


### PR DESCRIPTION
A few improvements, largely just reducing bloat, and one important fix:
 * Temp regs weren't allocating properly when the regcache was full, which could hang.
 * Use CMN for negative imm CMPs.
 * Cut an instruction on variable shifts (I think it's worth trusting chips since it's specified.)
 * Use CBZ/TBZ/etc. and handle more imm cases in branches.
 * Avoid ADD for register copies (MIPS `addu v0, v1, $0`.)
 * Enable safe memory path for lwl/lwr.

-[Unknown]