### PR TITLE
UI: Only default focus visible things

### DIFF
--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -60,7 +60,7 @@ void DevMenu::CreatePopupContents(UI::ViewGroup *parent) {
 	I18NCategory *dev = GetI18NCategory("Developer");
 	I18NCategory *sy = GetI18NCategory("System");
 
-	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
 	LinearLayout *items = new LinearLayout(ORIENT_VERTICAL);
 
 #if !defined(MOBILE_DEVICE)

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -762,6 +762,7 @@ void MainScreen::CreateViews() {
 		tabRecentGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
 	}
 
+	Button *grantStorageButton = nullptr;
 	if (hasStorageAccess) {
 		ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollAllGames->SetTag("MainScreenAllGames");
@@ -819,7 +820,8 @@ void MainScreen::CreateViews() {
 
 		LinearLayout *buttonHolder = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
-		buttonHolder->Add(new Button(mm->T("Give PPSSPP permission to access storage"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT)))->OnClick.Handle(this, &MainScreen::OnAllowStorage);
+		grantStorageButton = new Button(mm->T("Give PPSSPP permission to access storage"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
+		buttonHolder->Add(grantStorageButton)->OnClick.Handle(this, &MainScreen::OnAllowStorage);
 		buttonHolder->Add(new Spacer(new LinearLayoutParams(1.0f)));
 
 		leftColumn->Add(new Spacer(new LinearLayoutParams(0.1f)));
@@ -878,7 +880,11 @@ void MainScreen::CreateViews() {
 		root_->Add(rightColumn);
 	}
 
-	root_->SetDefaultFocusView(tabHolder_);
+	if (grantStorageButton) {
+		root_->SetDefaultFocusView(grantStorageButton);
+	} else if (tabHolder_->GetVisibility() != V_GONE) {
+		root_->SetDefaultFocusView(tabHolder_);
+	}
 
 	I18NCategory *u = GetI18NCategory("Upgrade");
 

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -33,8 +33,9 @@ void UIScreen::DoRecreateViews() {
 		delete root_;
 		root_ = nullptr;
 		CreateViews();
-		if (root_ && root_->GetDefaultFocusView()) {
-			root_->GetDefaultFocusView()->SetFocus();
+		UI::View *defaultView = root_ ? root_->GetDefaultFocusView() : nullptr;
+		if (defaultView && defaultView->GetVisibility() == UI::V_VISIBLE) {
+			defaultView->SetFocus();
 		}
 		recreateViews_ = false;
 

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -1555,7 +1555,9 @@ void UpdateViewHierarchy(ViewGroup *root) {
 		std::lock_guard<std::mutex> lock(focusLock);
 		EnableFocusMovement(true);
 		if (!GetFocusedView()) {
-			if (root->GetDefaultFocusView()) {
+			View *defaultView = root->GetDefaultFocusView();
+			// Can't focus what you can't see.
+			if (defaultView && defaultView->GetVisibility() == V_VISIBLE) {
 				root->GetDefaultFocusView()->SetFocus();
 			} else {
 				root->SetFocus();

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -24,7 +24,7 @@ struct NeighborResult {
 
 class ViewGroup : public View {
 public:
-	ViewGroup(LayoutParams *layoutParams = 0) : View(layoutParams), defaultFocusView_(0), hasDropShadow_(false), clip_(false) {}
+	ViewGroup(LayoutParams *layoutParams = 0) : View(layoutParams) {}
 	virtual ~ViewGroup();
 
 	// Pass through external events to children.
@@ -83,11 +83,11 @@ public:
 protected:
 	std::mutex modifyLock_;  // Hold this when changing the subviews.
 	std::vector<View *> views_;
-	View *defaultFocusView_;
+	View *defaultFocusView_ = nullptr;
 	Drawable bg_;
 	float dropShadowExpand_ = 0.0f;
-	bool hasDropShadow_;
-	bool clip_;
+	bool hasDropShadow_ = false;
+	bool clip_ = false;
 };
 
 // A frame layout contains a single child view (normally).


### PR DESCRIPTION
The tab holder was now V_GONE, so you couldn't escape it.

Also, default focus the permission grant button, even easier.

-[Unknown]