### PR TITLE
Statically allocate RA in arm64jit

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -3736,6 +3736,7 @@ void ARM64XEmitter::CMPI2R(ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
 }
 
 bool ARM64XEmitter::TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
+	s64 negated = Is64Bit(Rn) ? -(s64)imm : -(s32)(u32)imm;
 	u32 val;
 	bool shift;
 	if (imm == 0) {
@@ -3745,12 +3746,16 @@ bool ARM64XEmitter::TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 	} else if (IsImmArithmetic(imm, &val, &shift)) {
 		ADD(Rd, Rn, val, shift);
 		return true;
+	} else if (IsImmArithmetic((u64)negated, &val, &shift)) {
+		SUB(Rd, Rn, val, shift);
+		return true;
 	} else {
 		return false;
 	}
 }
 
 bool ARM64XEmitter::TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
+	s64 negated = Is64Bit(Rn) ? -(s64)imm : -(s32)(u32)imm;
 	u32 val;
 	bool shift;
 	if (imm == 0) {
@@ -3759,6 +3764,9 @@ bool ARM64XEmitter::TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 		return true;
 	} else if (IsImmArithmetic(imm, &val, &shift)) {
 		SUB(Rd, Rn, val, shift);
+		return true;
+	} else if (IsImmArithmetic((u64)negated, &val, &shift)) {
+		ADD(Rd, Rn, val, shift);
 		return true;
 	} else {
 		return false;

--- a/Core/MIPS/ARM64/Arm64CompALU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompALU.cpp
@@ -90,11 +90,7 @@ void Arm64Jit::Comp_IType(MIPSOpcode op) {
 			ARM64Reg r32 = gpr.RPtr(rs);
 			gpr.MarkDirty(r32);
 			ARM64Reg r = EncodeRegTo64(r32);
-			if (simm > 0) {
-				ADDI2R(r, r, simm);
-			} else {
-				SUBI2R(r, r, -simm);
-			}
+			ADDI2R(r, r, simm);
 		} else {
 			if (simm >= 0) {
 				CompImmLogic(rs, rt, simm, &ARM64XEmitter::ADD, &ARM64XEmitter::TryADDI2R, &EvalAdd);

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -536,7 +536,7 @@ void Arm64Jit::Comp_JumpReg(MIPSOpcode op)
 		delaySlotIsNice = false;
 	CONDITIONAL_NICE_DELAYSLOT;
 
-	ARM64Reg destReg = OTHERTEMPREG;
+	ARM64Reg destReg = INVALID_REG;
 	if (IsSyscall(delaySlotOp)) {
 		gpr.MapReg(rs);
 		MovToPC(gpr.R(rs));  // For syscall to be able to return.
@@ -574,7 +574,9 @@ void Arm64Jit::Comp_JumpReg(MIPSOpcode op)
 		destReg = gpr.R(rs);  // Safe because FlushAll doesn't change any regs
 		FlushAll();
 	} else {
-		// Delay slot - this case is very rare, might be able to free up W24.
+		// Since we can't be in a delay slot, should be safe to steal FLAGTEMPREG for a temp reg.
+		// It will be saved, even if a function is called.
+		destReg = FLAGTEMPREG;
 		gpr.MapReg(rs);
 		MOV(destReg, gpr.R(rs));
 		if (andLink)

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -69,10 +69,10 @@ void Arm64RegCache::Start(MIPSAnalyst::AnalysisResults &stats) {
 const ARM64Reg *Arm64RegCache::GetMIPSAllocationOrder(int &count) {
 	// See register alloc remarks in Arm64Asm.cpp
 
-	// W19-W22 are most suitable for static allocation. Those that are chosen for static allocation
+	// W19-W23 are most suitable for static allocation. Those that are chosen for static allocation
 	// should be omitted here and added in GetStaticAllocations.
 	static const ARM64Reg allocationOrder[] = {
-		W19, W20, W21, W22, W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15,
+		W19, W20, W21, W22, W23, W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15,
 	};
 	static const ARM64Reg allocationOrderStaticAlloc[] = {
 		W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15,
@@ -93,6 +93,7 @@ const Arm64RegCache::StaticAllocation *Arm64RegCache::GetStaticAllocations(int &
 		{MIPS_REG_V0, W20},
 		{MIPS_REG_V1, W22},
 		{MIPS_REG_A0, W21},
+		{MIPS_REG_RA, W23},
 	};
 
 	if (jo_->useStaticAlloc) {

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -23,8 +23,7 @@
 
 namespace Arm64JitConstants {
 
-const Arm64Gen::ARM64Reg DOWNCOUNTREG = Arm64Gen::W23;
-const Arm64Gen::ARM64Reg OTHERTEMPREG = Arm64Gen::W24;
+const Arm64Gen::ARM64Reg DOWNCOUNTREG = Arm64Gen::W24;
 const Arm64Gen::ARM64Reg FLAGTEMPREG = Arm64Gen::X25;
 const Arm64Gen::ARM64Reg JITBASEREG = Arm64Gen::X26;
 const Arm64Gen::ARM64Reg CTXREG = Arm64Gen::X27;

--- a/Core/MIPS/ARM64/Arm64RegCache.h
+++ b/Core/MIPS/ARM64/Arm64RegCache.h
@@ -92,8 +92,8 @@ public:
 	// Protect the arm register containing a MIPS register from spilling, to ensure that
 	// it's being kept allocated.
 	void SpillLock(MIPSGPReg reg, MIPSGPReg reg2 = MIPS_REG_INVALID, MIPSGPReg reg3 = MIPS_REG_INVALID, MIPSGPReg reg4 = MIPS_REG_INVALID);
-	void ReleaseSpillLock(MIPSGPReg reg);
-	void ReleaseSpillLocks();
+	void ReleaseSpillLock(MIPSGPReg reg, MIPSGPReg reg2 = MIPS_REG_INVALID, MIPSGPReg reg3 = MIPS_REG_INVALID, MIPSGPReg reg4 = MIPS_REG_INVALID);
+	void ReleaseSpillLocksAndDiscardTemps();
 
 	void SetImm(MIPSGPReg reg, u64 immVal);
 	bool IsImm(MIPSGPReg reg) const;
@@ -102,7 +102,8 @@ public:
 	// Optimally set a register to an imm value (possibly using another register.)
 	void SetRegImm(Arm64Gen::ARM64Reg reg, u64 imm);
 
-	Arm64Gen::ARM64Reg MapTempImm(MIPSGPReg);
+	// May fail and return INVALID_REG if it needs flushing.
+	Arm64Gen::ARM64Reg TryMapTempImm(MIPSGPReg);
 
 	// Returns an ARM register containing the requested MIPS register.
 	Arm64Gen::ARM64Reg MapReg(MIPSGPReg reg, int mapFlags = 0);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -228,7 +228,8 @@ bool CtrlDisAsmView::getDisasmAddressText(u32 address, char* dest, bool abbrevia
 		}
 	} else {
 		if (showData) {
-			sprintf(dest, "%08X %08X", address, Memory::Read_Instruction(address, true).encoding);
+			u32 encoding = Memory::IsValidAddress(address) ? Memory::Read_Instruction(address, true).encoding : 0;
+			sprintf(dest, "%08X %08X", address, encoding);
 		} else {
 			sprintf(dest, "%08X", address);
 		}


### PR DESCRIPTION
It's hard to tell if this made an improvement, it might've gained a percentage point or two, but timings are inconsistent.

Anyway, I tried a few different regs and RA was the one that reduced bloat the most, and none of them seemed to have a significant performance impact.  I think reducing average bloat by 5% (e.g. from 520% to 495%) isn't bad, anyway.  The reg was just being wasted before.

-[Unknown]