### PR TITLE
Fix building for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1891,8 +1891,8 @@ if(IOS)
       set(APP_DIR_NAME "$<TARGET_FILE_DIR:PPSSPP>")
     endif()
 	add_custom_command(TARGET PPSSPP POST_BUILD
-        COMMAND mkdir -p ${APP_DIR_NAME}
-		COMMAND tar -c -C ${CMAKE_CURRENT_BINARY_DIR} --exclude .DS_Store --exclude .git assets *.png | tar -x -C ${APP_DIR_NAME}
+		COMMAND mkdir -p \"${APP_DIR_NAME}\"
+		COMMAND tar -c -C ${CMAKE_CURRENT_BINARY_DIR} --exclude .DS_Store --exclude .git assets *.png | tar -x -C \"${APP_DIR_NAME}\"
 	)
 	set_target_properties(${TargetBin} PROPERTIES
 		MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/ios/PPSSPP-Info.plist"

--- a/ext/native/profiler/profiler.cpp
+++ b/ext/native/profiler/profiler.cpp
@@ -15,7 +15,12 @@
 
 #define MAX_CATEGORIES 64 // Can be any number, represents max profiled names.
 #define MAX_DEPTH 16      // Can be any number, represents max nesting depth of profiled names.
+#if PPSSPP_PLATFORM(IOS) && defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
+// iOS did not support C++ thread_local before iOS 9
+#define MAX_THREADS 1     // Can be any number, represents concurrent threads calling the profiler.
+#else
 #define MAX_THREADS 4     // Can be any number, represents concurrent threads calling the profiler.
+#endif
 #define HISTORY_SIZE 128 // Must be power of 2
 
 #ifndef _DEBUG

--- a/ext/native/profiler/profiler.cpp
+++ b/ext/native/profiler/profiler.cpp
@@ -11,6 +11,7 @@
 #include "base/logging.h"
 #include "base/timeutil.h"
 #include "gfx_es2/draw_buffer.h"
+#include "ppsspp_config.h"
 #include "profiler/profiler.h"
 
 #define MAX_CATEGORIES 64 // Can be any number, represents max profiled names.


### PR DESCRIPTION
**Fix build on iOS (only iOS 9 and up support thread_local)**
A recent commit used thread_local in profiler.cpp, but Xcode 9.2 errors out if the minimum deployment target is less than 9.0 because older iOS version didn't support thread_local.
So if building for iOS and the minimum deployment target is less than iOS 9, set MAX_THREADS to 1 to avoid thread_local.

**fix cmake when building for iOS in a path with spaces**
Fixes errors that prevent building in a path containing spaces.