### PR TITLE
Modernization of iOS Objective-C code to use Automatic Reference Counting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,6 +692,11 @@ elseif(IOS)
 
 	set_source_files_properties(ios/AppDelegate.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
 	set_source_files_properties(ios/ViewController.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
+	set_source_files_properties(ios/iOSCoreAudio.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
+	set_source_files_properties(ios/PPSSPPUIApplication.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
+	set_source_files_properties(ios/iCade/iCadeReaderView.m PROPERTIES COMPILE_FLAGS -fobjc-arc)
+	set_source_files_properties(ios/main.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
+
 
 	set(TargetBin PPSSPP)
 elseif(USING_QT_UI)

--- a/ios/PPSSPPUIApplication.mm
+++ b/ios/PPSSPPUIApplication.mm
@@ -60,12 +60,6 @@
 
 @implementation PPSSPPUIApplication
 
-- (instancetype)init {
-    auto instance = [super init];
-    instance.delegate = [[AppDelegate alloc] init];
-    return instance;
-}
-
 - (void)decodeKeyEvent:(NSInteger *)eventMem {
     NSInteger eventType = eventMem[GSEVENT_TYPE];
     NSInteger eventScanCode = eventMem[GSEVENTKEY_KEYCODE];

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -221,6 +221,8 @@ static GraphicsContext *graphicsContext;
 
 - (void)dealloc
 {
+	sharedViewController = nil;
+	
 	if ([EAGLContext currentContext] == self.context) {
 		[EAGLContext setCurrentContext:nil];
 	}

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -74,10 +74,10 @@ static GraphicsContext *graphicsContext;
 	std::map<uint16_t, uint16_t> iCadeToKeyMap;
 }
 
-@property (nonatomic) EAGLContext* context;
-@property (nonatomic) NSString* documentsPath;
-@property (nonatomic) NSString* bundlePath;
-@property (nonatomic) NSMutableArray* touches;
+@property (nonatomic, strong) EAGLContext* context;
+@property (nonatomic, strong) NSString* documentsPath;
+@property (nonatomic, strong) NSString* bundlePath;
+@property (nonatomic, strong) NSMutableArray<NSDictionary *>* touches;
 @property (nonatomic) AudioEngine* audioEngine;
 //@property (nonatomic) iCadeReaderView* iCadeView;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_6_1
@@ -214,16 +214,6 @@ static GraphicsContext *graphicsContext;
 #endif
 }
 
-- (void)viewDidUnload
-{
-	[super viewDidUnload];
-
-	if ([EAGLContext currentContext] == self.context) {
-		[EAGLContext setCurrentContext:nil];
-	}
-	self.context = nil;
-}
-
 - (void)didReceiveMemoryWarning
 {
 	[super didReceiveMemoryWarning];
@@ -231,7 +221,10 @@ static GraphicsContext *graphicsContext;
 
 - (void)dealloc
 {
-	[self viewDidUnload];
+	if ([EAGLContext currentContext] == self.context) {
+		[EAGLContext setCurrentContext:nil];
+	}
+	self.context = nil;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_6_1
 	if ([GCController class]) {

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -66,7 +66,7 @@ extern ScreenManager *screenManager;
 extern bool iosCanUseJit;
 extern bool targetIsJailbroken;
 
-ViewController* sharedViewController;
+__unsafe_unretained static ViewController* sharedViewController;
 static GraphicsContext *graphicsContext;
 
 @interface ViewController ()

--- a/ios/iCade/iCadeReaderView.h
+++ b/ios/iCade/iCadeReaderView.h
@@ -50,7 +50,7 @@
 @interface iCadeReaderView : UIView<UIKeyInput> {
     UIView                  *inputView;
     iCadeState              _iCadeState;
-    id<iCadeEventDelegate>  _delegate;
+    id<iCadeEventDelegate>  __weak _delegate;
     
     struct {
         bool stateChanged:1;
@@ -60,7 +60,7 @@
 }
 
 @property (nonatomic, assign) iCadeState iCadeState;
-@property (nonatomic, assign) id<iCadeEventDelegate> delegate;
+@property (nonatomic, weak) id<iCadeEventDelegate> delegate;
 @property (nonatomic, assign) BOOL active;
 
 @end

--- a/ios/iCade/iCadeReaderView.m
+++ b/ios/iCade/iCadeReaderView.m
@@ -49,7 +49,6 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
-    [super dealloc];
 }
 
 - (void)didEnterBackground {

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -113,7 +113,6 @@ int main(int argc, char *argv[])
 	// Simulates a debugger. Makes it possible to use JIT (though only W^X)
 	syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
 	@autoreleasepool {
-        return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), nil);
-        //return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+        return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), NSStringFromClass([AppDelegate class]));
 	}
 }


### PR DESCRIPTION
There shouldn't be any user visible changes. Tested with Valkyria Chronicles 3 and Final Fantasy 4.

Converting to ARC should make it easier to implement Metal for better graphics performance on Apple platforms.

I think ViewController's dealloc method was never being called because sharedViewController maintains a strong reference. So if there are any bugs while shutting down on iOS, this may fix them and make it shut down cleanly.