### PR TITLE
irjit: Implement lwl/etc.

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -218,7 +218,7 @@ void ArmJit::Compile(u32 em_address) {
 
 	// Drat.  The VFPU hit an uneaten prefix at the end of a block.
 	if (js.startDefaultPrefix && js.MayHavePrefix()) {
-		WARN_LOG(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
+		WARN_LOG_REPORT(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
 		js.LogPrefix();
 
 		// Let's try that one more time.  We won't get back here because we toggled the value.

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -180,7 +180,7 @@ namespace MIPSComp {
 		gpr.SpillLock(rs);
 		// Need to get temps before skipping safe mem.
 		ARM64Reg LR_SCRATCH3 = gpr.GetAndLockTempR();
-		ARM64Reg LR_SCRATCH4 = gpr.GetAndLockTempR();
+		ARM64Reg LR_SCRATCH4 = o == 42 || o == 46 ? gpr.GetAndLockTempR() : INVALID_REG;
 
 		if (!g_Config.bFastMemory && rs != MIPS_REG_SP) {
 			skips = SetScratch1ForSafeAddress(rs, offset, SCRATCH2);

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -204,7 +204,7 @@ void Arm64Jit::Compile(u32 em_address) {
 
 	// Drat.  The VFPU hit an uneaten prefix at the end of a block.
 	if (js.startDefaultPrefix && js.MayHavePrefix()) {
-		WARN_LOG(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
+		WARN_LOG_REPORT(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
 		js.LogPrefix();
 
 		// Let's try that one more time.  We won't get back here because we toggled the value.

--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -40,14 +40,15 @@
 // #define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
 #define DISABLE { Comp_Generic(op); return; }
+#define INVALIDOP { Comp_Generic(op); return; }
 
 namespace MIPSComp {
 
 void IRFrontend::Comp_IType(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
 
-	s32 simm = (s32)(s16)(op & 0xFFFF);  // sign extension
-	u32 uimm = op & 0xFFFF;
+	s32 simm = (s32)_IMM16;  // sign extension
+	u32 uimm = (u16)_IMM16;
 	u32 suimm = (u32)(s32)simm;
 
 	MIPSGPReg rt = _RT;
@@ -80,7 +81,7 @@ void IRFrontend::Comp_IType(MIPSOpcode op) {
 		break;
 
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -104,7 +105,7 @@ void IRFrontend::Comp_RType2(MIPSOpcode op) {
 		ir.Write(IROp::Clz, rd, IRTEMP_0);
 		break;
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -176,7 +177,7 @@ void IRFrontend::Comp_RType3(MIPSOpcode op) {
 		break;
 
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -213,8 +214,9 @@ void IRFrontend::Comp_ShiftType(MIPSOpcode op) {
 	case 4: CompShiftVar(op, IROp::Shl, IROp::ShlImm); break; //sllv
 	case 6: CompShiftVar(op, (sa == 1 ? IROp::Ror : IROp::Shr), (sa == 1 ? IROp::RorImm : IROp::ShrImm)); break; //srlv
 	case 7: CompShiftVar(op, IROp::Sar, IROp::SarImm); break; //srav
+
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -256,7 +258,7 @@ void IRFrontend::Comp_Special3(MIPSOpcode op) {
 	break;
 
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -285,7 +287,7 @@ void IRFrontend::Comp_Allegrex(MIPSOpcode op) {
 		break;
 
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		return;
 	}
 }
@@ -307,7 +309,7 @@ void IRFrontend::Comp_Allegrex2(MIPSOpcode op) {
 		ir.Write(IROp::BSwap32, rd, rt);
 		break;
 	default:
-		Comp_Generic(op);
+		INVALIDOP;
 		break;
 	}
 }
@@ -372,7 +374,7 @@ void IRFrontend::Comp_MulDivType(MIPSOpcode op) {
 		break;
 
 	default:
-		DISABLE;
+		INVALIDOP;
 	}
 }
 

--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -51,6 +51,7 @@
 // #define CONDITIONAL_DISABLE { Comp_Generic(op); return; }
 #define CONDITIONAL_DISABLE ;
 #define DISABLE { Comp_Generic(op); return; }
+#define INVALIDOP { Comp_Generic(op); return; }
 
 namespace MIPSComp {
 
@@ -67,7 +68,7 @@ void IRFrontend::Comp_FPU3op(MIPSOpcode op) {
 	case 2: ir.Write(IROp::FMul, fd, fs, ft); break; //F(fd) = F(fs) * F(ft); //mul
 	case 3: ir.Write(IROp::FDiv, fd, fs, ft); break; //F(fd) = F(fs) / F(ft); //div
 	default:
-		DISABLE;
+		INVALIDOP;
 		return;
 	}
 }
@@ -90,7 +91,7 @@ void IRFrontend::Comp_FPULS(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU, 0, "Trying to interpret FPULS instruction that can't be interpreted");
+		INVALIDOP;
 		break;
 	}
 }
@@ -131,7 +132,7 @@ void IRFrontend::Comp_FPUComp(MIPSOpcode op) {
 		mode = IRFpCompareMode::LessEqualUnordered;
 		break;
 	default:
-		DISABLE;
+		INVALIDOP;
 		return;
 	}
 	ir.Write(IROp::FCmp, (int)mode, fs, ft);
@@ -158,27 +159,17 @@ void IRFrontend::Comp_FPU2op(MIPSOpcode op) {
 		break;
 
 	case 12: //FsI(fd) = (int)floorf(F(fs)+0.5f); break; //round.w.s
-	{
 		ir.Write(IROp::FRound, fd, fs);
 		break;
-	}
-
 	case 13: //FsI(fd) = Rto0(F(fs)));            break; //trunc.w.s
-	{
 		ir.Write(IROp::FTrunc, fd, fs);
 		break;
-	}
-
 	case 14://FsI(fd) = (int)ceilf (F(fs));      break; //ceil.w.s
-	{
 		ir.Write(IROp::FCeil, fd, fs);
 		break;
-	}
 	case 15: //FsI(fd) = (int)floorf(F(fs));      break; //floor.w.s
-	{
 		ir.Write(IROp::FFloor, fd, fs);
 		break;
-	}
 
 	case 32: //F(fd)   = (float)FsI(fs);          break; //cvt.s.w
 		ir.Write(IROp::FCvtSW, fd, fs);
@@ -189,7 +180,7 @@ void IRFrontend::Comp_FPU2op(MIPSOpcode op) {
 		break;
 
 	default:
-		DISABLE;
+		INVALIDOP;
 	}
 }
 
@@ -234,7 +225,7 @@ void IRFrontend::Comp_mxc1(MIPSOpcode op) {
 		}
 		return;
 	default:
-		DISABLE;
+		INVALIDOP;
 		break;
 	}
 }

--- a/Core/MIPS/IR/IRCompLoadStore.cpp
+++ b/Core/MIPS/IR/IRCompLoadStore.cpp
@@ -96,13 +96,16 @@ namespace MIPSComp {
 		case 46: //swr
 			DISABLE;
 			break;
+
 		default:
-			Comp_Generic(op);
+			INVALIDOP;
 			return;
 		}
 	}
 
 	void IRFrontend::Comp_Cache(MIPSOpcode op) {
+		CONDITIONAL_DISABLE;
+
 //		int imm = (s16)(op & 0xFFFF);
 //		int rs = _RS;
 //		int addr = R(rs) + imm;

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1929,7 +1929,7 @@ namespace MIPSComp {
 				ir.Write(IROp::FSub, tempregs[3], sregs[2], sregs[3]);
 			}
 		} else {
-			DISABLE;
+			INVALIDOP;
 		}
 
 		for (int i = 0; i < n; ++i) {

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -32,8 +32,6 @@
 namespace MIPSComp {
 
 IRFrontend::IRFrontend(bool startDefaultPrefix) {
-	logBlocks = 0;
-	dontLogBlocks = 0;
 	js.startDefaultPrefix = true;
 	js.hasSetRounding = false;
 	// js.currentRoundingFunc = convertS0ToSCRATCH1[0];
@@ -267,7 +265,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 			// &MergeLoadStore,
 			// &ThreeOpToTwoOp,
 		};
-		if (IRApplyPasses(passes, ARRAY_SIZE(passes), ir, simplified))
+		if (IRApplyPasses(passes, ARRAY_SIZE(passes), ir, simplified, opts))
 			logBlocks = 1;
 		code = &simplified;
 		//if (ir.GetInstructions().size() >= 24)

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -279,32 +279,32 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		char temp2[256];
-		ILOG("=============== mips %08x ===============", em_address);
+		NOTICE_LOG(JIT, "=============== mips %08x ===============", em_address);
 		for (u32 cpc = em_address; cpc != GetCompilerPC() + 4; cpc += 4) {
 			temp2[0] = 0;
 			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp2, true);
-			ILOG("M: %08x   %s", cpc, temp2);
+			NOTICE_LOG(JIT, "M: %08x   %s", cpc, temp2);
 		}
 	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
-		ILOG("=============== Original IR (%d instructions, %d const) ===============", (int)ir.GetInstructions().size(), (int)ir.GetConstants().size());
+		NOTICE_LOG(JIT, "=============== Original IR (%d instructions, %d const) ===============", (int)ir.GetInstructions().size(), (int)ir.GetConstants().size());
 		for (size_t i = 0; i < ir.GetInstructions().size(); i++) {
 			char buf[256];
 			DisassembleIR(buf, sizeof(buf), ir.GetInstructions()[i], &ir.GetConstants()[0]);
-			ILOG("%s", buf);
+			NOTICE_LOG(JIT, "%s", buf);
 		}
-		ILOG("===============        end         =================");
+		NOTICE_LOG(JIT, "===============        end         =================");
 	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
-		ILOG("=============== IR (%d instructions, %d const) ===============", (int)code->GetInstructions().size(), (int)code->GetConstants().size());
+		NOTICE_LOG(JIT, "=============== IR (%d instructions, %d const) ===============", (int)code->GetInstructions().size(), (int)code->GetConstants().size());
 		for (size_t i = 0; i < code->GetInstructions().size(); i++) {
 			char buf[256];
 			DisassembleIR(buf, sizeof(buf), code->GetInstructions()[i], &code->GetConstants()[0]);
-			ILOG("%s", buf);
+			NOTICE_LOG(JIT, "%s", buf);
 		}
-		ILOG("===============        end         =================");
+		NOTICE_LOG(JIT, "===============        end         =================");
 	}
 
 	if (logBlocks > 0)

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -105,7 +105,7 @@ void IRFrontend::CompileDelaySlot() {
 	js.inDelaySlot = false;
 }
 
-bool IRFrontend::CheckRounding() {
+bool IRFrontend::CheckRounding(u32 blockAddress) {
 	bool cleanSlate = false;
 	if (js.hasSetRounding && !js.lastSetRounding) {
 		WARN_LOG(JIT, "Detected rounding mode usage, rebuilding jit with checks");
@@ -116,7 +116,7 @@ bool IRFrontend::CheckRounding() {
 
 	// Drat.  The VFPU hit an uneaten prefix at the end of a block.
 	if (js.startDefaultPrefix && js.MayHavePrefix()) {
-		WARN_LOG(JIT, "An uneaten prefix at end of block");
+		WARN_LOG_REPORT(JIT, "An uneaten prefix at end of block for %08x", blockAddress);
 		logBlocks = 1;
 		js.LogPrefix();
 

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -86,7 +86,7 @@ public:
 
 	int Replace_fabsf() override;
 	void DoState(PointerWrap &p);
-	bool CheckRounding();  // returns true if we need a do-over
+	bool CheckRounding(u32 blockAddress);  // returns true if we need a do-over
 
 	void DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants, u32 &mipsBytes);
 

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -94,6 +94,10 @@ public:
 		js.EatPrefix();
 	}
 
+	void SetOptions(const IROptions &o) {
+		opts = o;
+	}
+
 private:
 	void RestoreRoundingMode(bool force = false);
 	void ApplyRoundingMode(bool force = false);
@@ -134,9 +138,10 @@ private:
 	// State
 	JitState js;
 	IRWriter ir;
+	IROptions opts{};
 
-	int dontLogBlocks;
-	int logBlocks;
+	int dontLogBlocks = 0;
+	int logBlocks = 0;
 };
 
 }  // namespace

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -207,6 +207,8 @@ const char *GetGPRName(int r) {
 	switch (r) {
 	case IRTEMP_0: return "irtemp0";
 	case IRTEMP_1: return "irtemp1";
+	case IRTEMP_2: return "irtemp2";
+	case IRTEMP_3: return "irtemp3";
 	case IRTEMP_LHS: return "irtemp_lhs";
 	case IRTEMP_RHS: return "irtemp_rhs";
 	default: return "(unk)";

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -275,6 +275,8 @@ enum IRFpCompareMode {
 enum {
 	IRTEMP_0 = 192,
 	IRTEMP_1,
+	IRTEMP_2,
+	IRTEMP_3,
 	IRTEMP_LHS,  // Reserved for use in branches
 	IRTEMP_RHS,  // Reserved for use in branches
 

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -363,6 +363,10 @@ private:
 	std::vector<u32> constPool_;
 };
 
+struct IROptions {
+	bool unalignedLoadStore;
+};
+
 const IRMeta *GetIRMeta(IROp op);
 void DisassembleIR(char *buf, size_t bufsize, IRInst inst, const u32 *constPool);
 void InitIR();

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -74,7 +74,7 @@ void IRJit::Compile(u32 em_address) {
 	// Overwrites the first instruction, and also updates stats.
 	blocks_.FinalizeBlock(block_num);
 
-	if (frontend_.CheckRounding()) {
+	if (frontend_.CheckRounding(em_address)) {
 		// Our assumptions are all wrong so it's clean-slate time.
 		ClearCache();
 		Compile(em_address);

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -41,6 +41,10 @@ IRJit::IRJit(MIPSState *mips) : frontend_(mips->HasDefaultPrefix()), mips_(mips)
 	u32 size = 128 * 1024;
 	// blTrampolines_ = kernelMemory.Alloc(size, true, "trampoline");
 	InitIR();
+
+	IROptions opts{};
+	opts.unalignedLoadStore = true;
+	frontend_.SetOptions(opts);
 }
 
 IRJit::~IRJit() {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -662,6 +662,8 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out) {
 		switch (dest) {
 		case IRTEMP_0:
 		case IRTEMP_1:
+		case IRTEMP_2:
+		case IRTEMP_3:
 		case IRTEMP_LHS:
 		case IRTEMP_RHS:
 			// Unlike other ops, these don't need to persist between blocks.

--- a/Core/MIPS/IR/IRPassSimplify.h
+++ b/Core/MIPS/IR/IRPassSimplify.h
@@ -2,14 +2,14 @@
 
 #include "Core/MIPS/IR/IRInst.h"
 
-typedef bool (*IRPassFunc)(const IRWriter &in, IRWriter &out);
-bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWriter &out);
+typedef bool (*IRPassFunc)(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWriter &out, const IROptions &opts);
 
 // Block optimizer passes of varying usefulness.
-bool PropagateConstants(const IRWriter &in, IRWriter &out);
-bool PurgeTemps(const IRWriter &in, IRWriter &out);
-bool ReduceLoads(const IRWriter &in, IRWriter &out);
-bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out);
-bool OptimizeFPMoves(const IRWriter &in, IRWriter &out);
-bool ReorderLoadStore(const IRWriter &in, IRWriter &out);
-bool MergeLoadStore(const IRWriter &in, IRWriter &out);
+bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool ReduceLoads(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool OptimizeFPMoves(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool ReorderLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool MergeLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts);

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -286,7 +286,7 @@ void Jit::Compile(u32 em_address) {
 
 	// Drat.  The VFPU hit an uneaten prefix at the end of a block.
 	if (js.startDefaultPrefix && js.MayHavePrefix()) {
-		WARN_LOG(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
+		WARN_LOG_REPORT(JIT, "An uneaten prefix at end of block: %08x", GetCompilerPC() - 4);
 		js.LogPrefix();
 
 		// Let's try that one more time.  We won't get back here because we toggled the value.


### PR DESCRIPTION
Also: added an IROptions for things that might drive backends to create different IR.  I realize this is a bit less pure, but it seems like it'll be necessary, and we could make it a bitfield and store it in any cache...

Also, fix an unnecessary asm64jit spill (minor) and add reporting for uneaten prefixes at blocks.  I'm wondering if they often happen in ways that we could continue the block, to avoid it resulting in an uneaten prefix.

I know I've seen it in a loop delay slot before, but can't remember if it was a likely branch.

-[Unknown]