### PR TITLE
iOS: Fix crash with USE_PROFILER, pass command line args to NativeInit, misc cleanups

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -55,11 +55,6 @@ static const char *logSectionName = "LogDebug";
 static const char *logSectionName = "Log";
 #endif
 
-
-#ifdef IOS
-extern bool iosCanUseJit;
-#endif
-
 struct ConfigSetting {
 	enum Type {
 		TYPE_TERMINATOR,
@@ -314,11 +309,8 @@ static int DefaultNumWorkers() {
 	return cpu_info.num_cores;
 }
 
-// TODO: Default to IRJit on iOS when it's done.
 static int DefaultCpuCore() {
-#ifdef IOS
-	return (int)(iosCanUseJit ? CPUCore::JIT : CPUCore::INTERPRETER);
-#elif defined(ARM) || defined(ARM64) || defined(_M_IX86) || defined(_M_X64)
+#if defined(ARM) || defined(ARM64) || defined(_M_IX86) || defined(_M_X64)
 	return (int)CPUCore::JIT;
 #else
 	return (int)CPUCore::INTERPRETER;
@@ -326,9 +318,7 @@ static int DefaultCpuCore() {
 }
 
 static bool DefaultCodeGen() {
-#ifdef IOS
-	return iosCanUseJit ? true : false;
-#elif defined(ARM) || defined(ARM64) || defined(_M_IX86) || defined(_M_X64)
+#if defined(ARM) || defined(ARM64) || defined(_M_IX86) || defined(_M_X64)
 	return true;
 #else
 	return false;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -67,11 +67,6 @@
 #include "gfx/gl_common.h"
 #endif
 
-#ifdef IOS
-extern bool iosCanUseJit;
-extern bool targetIsJailbroken;
-#endif
-
 extern bool VulkanMayBeAvailable();
 
 GameSettingsScreen::GameSettingsScreen(std::string gamePath, std::string gameID, bool editThenRestore)

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -130,11 +130,6 @@ std::string config_filename;
 
 bool g_graphicsInited;
 
-#ifdef IOS
-bool iosCanUseJit;
-bool targetIsJailbroken;
-#endif
-
 // Really need to clean this mess of globals up... but instead I add more :P
 bool g_TakeScreenshot;
 static bool isOuya;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -30,10 +30,6 @@
 #define IS_IPAD() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #define IS_IPHONE() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 
-#ifndef kCFCoreFoundationVersionNumber_IOS_9_0
-#define kCFCoreFoundationVersionNumber_IOS_9_0 1240.10
-#endif
-
 class IOSDummyGraphicsContext : public DummyGraphicsContext {
 public:
 	IOSDummyGraphicsContext() {
@@ -53,14 +49,12 @@ private:
 	Draw::DrawContext *draw_;
 };
 
-float dp_xscale = 1.0f;
-float dp_yscale = 1.0f;
+static float dp_xscale = 1.0f;
+static float dp_yscale = 1.0f;
 
-double lastSelectPress = 0.0f;
-double lastStartPress = 0.0f;
-bool simulateAnalog = false;
-
-extern ScreenManager *screenManager;
+static double lastSelectPress = 0.0f;
+static double lastStartPress = 0.0f;
+static bool simulateAnalog = false;
 
 __unsafe_unretained static ViewController* sharedViewController;
 static GraphicsContext *graphicsContext;
@@ -71,8 +65,6 @@ static GraphicsContext *graphicsContext;
 }
 
 @property (nonatomic, strong) EAGLContext* context;
-@property (nonatomic, strong) NSString* documentsPath;
-@property (nonatomic, strong) NSString* bundlePath;
 @property (nonatomic, strong) NSMutableArray<NSDictionary *>* touches;
 //@property (nonatomic) iCadeReaderView* iCadeView;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_6_1
@@ -82,13 +74,6 @@ static GraphicsContext *graphicsContext;
 @end
 
 @implementation ViewController
--(bool) isArm64 {
-	size_t size;
-	cpu_type_t type;
-	size = sizeof(type);
-	sysctlbyname("hw.cputype", &type, &size, NULL, 0);
-	return type == CPU_TYPE_ARM64;
-}
 
 -(id) init {
 	self = [super init];

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -62,9 +62,6 @@ bool simulateAnalog = false;
 
 extern ScreenManager *screenManager;
 
-extern bool iosCanUseJit;
-extern bool targetIsJailbroken;
-
 __unsafe_unretained static ViewController* sharedViewController;
 static GraphicsContext *graphicsContext;
 
@@ -98,26 +95,6 @@ static GraphicsContext *graphicsContext;
 	if (self) {
 		sharedViewController = self;
 		self.touches = [NSMutableArray array];
-		self.documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-		self.bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingString:@"/assets/"];
-
-		iosCanUseJit = true;
-		targetIsJailbroken = false;
-		NSArray *jailPath = [NSArray arrayWithObjects:
-							@"/Applications/Cydia.app",
-							@"/private/var/lib/apt",
-							@"/private/var/stash",
-							@"/usr/sbin/sshd",
-							@"/usr/bin/sshd", nil];
-
-		for (NSString *string in jailPath) {
-			if ([[NSFileManager defaultManager] fileExistsAtPath:string]) {
-				// checking device jailbreak status in order to determine which message to show in GameSettingsScreen
-				targetIsJailbroken = true;
-			}
-		}
-		
-		NativeInit(0, NULL, [self.documentsPath UTF8String], [self.bundlePath UTF8String], NULL);
 
 		iCadeToKeyMap[iCadeJoystickUp]		= NKCODE_DPAD_UP;
 		iCadeToKeyMap[iCadeJoystickRight]	= NKCODE_DPAD_RIGHT;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -6,7 +6,6 @@
 //
 
 #import "ViewController.h"
-#import "AudioEngine.h"
 #import <GLKit/GLKit.h>
 #include <cassert>
 
@@ -78,7 +77,6 @@ static GraphicsContext *graphicsContext;
 @property (nonatomic, strong) NSString* documentsPath;
 @property (nonatomic, strong) NSString* bundlePath;
 @property (nonatomic, strong) NSMutableArray<NSDictionary *>* touches;
-@property (nonatomic) AudioEngine* audioEngine;
 //@property (nonatomic) iCadeReaderView* iCadeView;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_6_1
 @property (nonatomic) GCController *gameController __attribute__((weak_import));

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -112,7 +112,13 @@ int main(int argc, char *argv[])
 {
 	// Simulates a debugger. Makes it possible to use JIT (though only W^X)
 	syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
+	
 	@autoreleasepool {
-        return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), NSStringFromClass([AppDelegate class]));
+		NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+		NSString *bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingString:@"/assets/"];
+		
+		NativeInit(argc, (const char**)argv, documentsPath.UTF8String, bundlePath.UTF8String, NULL);
+		
+		return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), NSStringFromClass([AppDelegate class]));
 	}
 }

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -11,6 +11,7 @@
 #import "PPSSPPUIApplication.h"
 
 #include "base/NativeApp.h"
+#include "profiler/profiler.h"
 
 @interface UIApplication (Private)
 -(void) suspend;
@@ -112,6 +113,8 @@ int main(int argc, char *argv[])
 {
 	// Simulates a debugger. Makes it possible to use JIT (though only W^X)
 	syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
+	
+	PROFILE_INIT();
 	
 	@autoreleasepool {
 		NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];


### PR DESCRIPTION
No user visible changes - this is just to make the code easier to work with and debug.

- Fixes crash on USE_PROFILER by adding the missing call to PROFILE_INIT
- Gets rid of iosCanUseJit and targetIsJailbroken, which cleans up Config.cpp and a few other files
- Pass command line arguments through to NativeInit for easier debugging
- Remove some dead code and properties in ViewController, and make its global variables static