### PR TITLE
Core: Asynchronously load the main ELF

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -181,6 +181,8 @@ bool CPU_NextStateNot(CPUThreadState from, CPUThreadState to) {
 }
 
 bool CPU_IsReady() {
+	if (coreState == CORE_POWERUP)
+		return false;
 	return cpuThreadState == CPU_THREAD_RUNNING || cpuThreadState == CPU_THREAD_NOT_RUNNING;
 }
 
@@ -270,7 +272,8 @@ void CPU_Init() {
 
 	// TODO: Check Game INI here for settings, patches and cheats, and modify coreParameter accordingly
 
-	// Why did we check for CORE_POWERDOWN here?
+	// If they shut down early, we'll catch it when load completes.
+	// Note: this may return before init is complete, which is checked if CPU_IsReady().
 	if (!LoadFile(&loadedFile, &coreParameter.errorString)) {
 		CPU_Shutdown();
 		coreParameter.fileToStart = "";
@@ -282,8 +285,6 @@ void CPU_Init() {
 	if (coreParameter.updateRecent) {
 		g_Config.AddRecent(filename);
 	}
-
-	coreState = coreParameter.startPaused ? CORE_STEPPING : CORE_RUNNING;
 }
 
 void CPU_Shutdown() {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -231,8 +231,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 		host->NotifyUserMessage(gr->T("DefaultCPUClockRequired", "Warning: This game requires the CPU clock to be set to default."), 15.0f);
 	}
 
-	loadingViewColor_->Divert(0xFFFFFFFF, 0.15f);
-	loadingViewVisible_->Divert(UI::V_VISIBLE, 0.15f);
+	loadingViewColor_->Divert(0xFFFFFFFF, 0.75f);
+	loadingViewVisible_->Divert(UI::V_VISIBLE, 0.75f);
 }
 
 void EmuScreen::bootComplete() {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -99,6 +99,6 @@ private:
 	int saveStateSlot_;
 
 	UI::View *loadingView_ = nullptr;
-	UI::TextColorTween *loadingViewColor_ = nullptr;
+	UI::CallbackColorTween *loadingViewColor_ = nullptr;
 	UI::VisibilityTween *loadingViewVisible_ = nullptr;
 };

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -62,11 +62,11 @@ private:
 
 RatingChoice::RatingChoice(const char *captionKey, int *value, LayoutParams *layoutParams)
 		: LinearLayout(ORIENT_VERTICAL, layoutParams), value_(value) {
-	SetSpacing(-8.0f);
+	SetSpacing(0.0f);
 
 	I18NCategory *rp = GetI18NCategory("Reporting");
 	group_ = new LinearLayout(ORIENT_HORIZONTAL);
-	Add(new InfoItem(rp->T(captionKey), ""));
+	Add(new TextView(rp->T(captionKey)))->SetShadow(true);
 	Add(group_);
 
 	group_->SetSpacing(0.0f);
@@ -223,7 +223,7 @@ void ReportScreen::CreateViews() {
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
 	LinearLayout *rightColumnItems = new LinearLayout(ORIENT_VERTICAL);
 
-	leftColumnItems->Add(new TextView(rp->T("FeedbackDesc", "How's the emulation?  Let us and the community know!"), new LinearLayoutParams(Margins(12, 5, 0, 5))));
+	leftColumnItems->Add(new TextView(rp->T("FeedbackDesc", "How's the emulation?  Let us and the community know!"), new LinearLayoutParams(Margins(12, 5, 0, 5))))->SetShadow(true);
 	if (!Reporting::IsEnabled()) {
 		reportingNotice_ = leftColumnItems->Add(new TextView(rp->T("FeedbackDisabled", "Compatibility server reports must be enabled."), new LinearLayoutParams(Margins(12, 5, 0, 5))));
 		reportingNotice_->SetShadow(true);
@@ -258,6 +258,7 @@ void ReportScreen::CreateViews() {
 
 	leftColumnItems->Add(new CompatRatingChoice("Overall", (int *)&overall_))->SetEnabledPtr(&enableReporting_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	overallDescription_ = leftColumnItems->Add(new TextView("", new LinearLayoutParams(Margins(10, 0))));
+	overallDescription_->SetShadow(true);
 	leftColumnItems->Add(new RatingChoice("Graphics", &graphics_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	leftColumnItems->Add(new RatingChoice("Speed", &speed_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	leftColumnItems->Add(new RatingChoice("Gameplay", &gameplay_))->SetEnabledPtr(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -837,7 +837,7 @@ void TextView::Draw(UIContext &dc) {
 	dc.SetFontStyle(small_ ? dc.theme->uiFontSmall : dc.theme->uiFont);
 	if (shadow_) {
 		uint32_t shadowColor = 0x80000000;
-		dc.DrawTextRect(text_.c_str(), bounds_, shadowColor, textAlign_);
+		dc.DrawTextRect(text_.c_str(), bounds_.Offset(1.0f, 1.0f), shadowColor, textAlign_);
 	}
 	uint32_t textColor = hasTextColor_ ? textColor_ : dc.theme->infoStyle.fgColor;
 	dc.DrawTextRect(text_.c_str(), bounds_, textColor, textAlign_);


### PR DESCRIPTION
Sometimes it takes a little time.  More importantly, we could background load caches, that might be a tad slow.

Not actually doing any such caching yet, though.  Will be a separate PR later.  Will probably be start as an option.

Also, show the PIC1 image during this time (shader compile too.)  It shouldn't become visible at all if the load time is fast, but right now it also goes black when switching from the menu on a controller.  Could tweak more later (to know if the previous view was showing the BG, I guess...)

-[Unknown]