### PR TITLE
irjit: Properly account for delay slots in size

### DIFF
--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -104,6 +104,8 @@ void IRFrontend::BranchRSRTComp(MIPSOpcode op, IRComparison cc, bool likely) {
 	FlushAll();
 	ir.Write(IROp::ExitToConst, ir.AddConstant(targetAddr));
 
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 
@@ -141,6 +143,9 @@ void IRFrontend::BranchRSZeroComp(MIPSOpcode op, IRComparison cc, bool andLink, 
 	// Taken
 	FlushAll();
 	ir.Write(IROp::ExitToConst, ir.AddConstant(targetAddr));
+
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 
@@ -206,6 +211,9 @@ void IRFrontend::BranchFPFlag(MIPSOpcode op, IRComparison cc, bool likely) {
 		CompileDelaySlot();
 	FlushAll();
 	ir.Write(IROp::ExitToConst, ir.AddConstant(targetAddr));
+
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 
@@ -261,6 +269,9 @@ void IRFrontend::BranchVFPUFlag(MIPSOpcode op, IRComparison cc, bool likely) {
 	// Taken
 	FlushAll();
 	ir.Write(IROp::ExitToConst, ir.AddConstant(targetAddr));
+
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 
@@ -314,6 +325,9 @@ void IRFrontend::Comp_Jump(MIPSOpcode op) {
 
 	FlushAll();
 	ir.Write(IROp::ExitToConst, ir.AddConstant(targetAddr));
+
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 
@@ -338,6 +352,9 @@ void IRFrontend::Comp_JumpReg(MIPSOpcode op) {
 			ir.WriteSetConstant(rd, GetCompilerPC() + 8);
 		CompileDelaySlot();
 		// Syscall (the delay slot) does FlushAll.
+
+		// Account for the delay slot itself in total bytes.
+		js.compilerPC += 4;
 		return;  // Syscall (delay slot) wrote exit code.
 	} else if (delaySlotIsNice) {
 		if (andLink)
@@ -371,6 +388,9 @@ void IRFrontend::Comp_JumpReg(MIPSOpcode op) {
 	js.downcountAmount = 0;
 
 	ir.Write(IROp::ExitToReg, 0, destReg, 0);
+
+	// Account for the delay slot.
+	js.compilerPC += 4;
 	js.compiling = false;
 }
 

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -278,7 +278,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		char temp2[256];
 		NOTICE_LOG(JIT, "=============== mips %08x ===============", em_address);
-		for (u32 cpc = em_address; cpc != GetCompilerPC() + 4; cpc += 4) {
+		for (u32 cpc = em_address; cpc != GetCompilerPC(); cpc += 4) {
 			temp2[0] = 0;
 			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp2, true);
 			NOTICE_LOG(JIT, "M: %08x   %s", cpc, temp2);


### PR DESCRIPTION
Otherwise we think blocks are 4 bytes too short, which can affect invalidation.

-[Unknown]