### PR TITLE
Scan the correct sections of modules for code

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -633,6 +633,17 @@ u32 ElfReader::GetTotalSectionSizeByPrefix(const std::string &prefix) const {
 	return total;
 }
 
+std::vector<SectionID> ElfReader::GetCodeSections() const {
+	std::vector<SectionID> ids;
+	for (int i = 0; i < GetNumSections(); ++i) {
+		u32 flags = sections[i].sh_flags;
+		if ((flags & (SHF_ALLOC | SHF_EXECINSTR)) == (SHF_ALLOC | SHF_EXECINSTR)) {
+			ids.push_back(i);
+		}
+	}
+	return ids;
+}
+
 bool ElfReader::LoadSymbols()
 {
 	bool hasSymbols = false;

--- a/Core/ELF/ElfReader.h
+++ b/Core/ELF/ElfReader.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include <vector>
 #include "Common/CommonTypes.h"
-
-#include "ElfTypes.h"
+#include "Core/ELF/ElfTypes.h"
 
 enum {
 	R_MIPS_NONE,
@@ -129,6 +129,8 @@ public:
 	u32 GetTotalTextSize() const;
 	u32 GetTotalDataSize() const;
 	u32 GetTotalSectionSizeByPrefix(const std::string &prefix) const;
+
+	std::vector<SectionID> GetCodeSections() const;
 
 	int LoadInto(u32 vaddr, bool fromTop);
 	bool LoadSymbols();

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1283,7 +1283,18 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 
 		// Some games don't have any sections at all.
 		if (scan && codeSections.empty()) {
-			MIPSAnalyst::ScanForFunctions(module->textStart, module->textEnd, !gotSymbols);
+			u32 scanStart = module->textStart;
+			u32 scanEnd = module->textEnd;
+			// Skip the exports and imports sections, they're not code.
+			if (scanEnd >= std::min(modinfo->libent, modinfo->libstub)) {
+				MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, !gotSymbols);
+				scanStart = std::min(modinfo->libentend, modinfo->libstubend);
+			}
+			if (scanEnd >= std::max(modinfo->libent, modinfo->libstub)) {
+				MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, !gotSymbols);
+				scanStart = std::max(modinfo->libentend, modinfo->libstubend);
+			}
+			MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, !gotSymbols);
 		}
 	}
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1124,8 +1124,10 @@ skip:
 			}
 		}
 
-		currentFunction.end = addr + 4;
-		functions.push_back(currentFunction);
+		if (addr <= endAddr) {
+			currentFunction.end = addr + 4;
+			functions.push_back(currentFunction);
+		}
 
 		for (auto iter = functions.begin(); iter != functions.end(); iter++) {
 			iter->size = iter->end - iter->start + 4;


### PR DESCRIPTION
Before, we were either just scanning the text section, or else scanning too much.  Some games use a separate "init" section or even in some cases multiple sections with code.  This meant we weren't even scanning those.

This more accurately detects those sections, and tries a bit harder to avoid scanning non-code for functions.

-[Unknown]