### PR TITLE
irjit: Embed constant inside IRInst (now 64-bit)

### DIFF
--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -92,7 +92,7 @@ void IRFrontend::BranchRSRTComp(MIPSOpcode op, IRComparison cc, bool likely) {
 		CompileDelaySlot();
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	FlushAll();
@@ -133,7 +133,7 @@ void IRFrontend::BranchRSZeroComp(MIPSOpcode op, IRComparison cc, bool andLink, 
 		CompileDelaySlot();
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	FlushAll();
@@ -200,7 +200,7 @@ void IRFrontend::BranchFPFlag(MIPSOpcode op, IRComparison cc, bool likely) {
 		CompileDelaySlot();
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	FlushAll();
@@ -249,7 +249,7 @@ void IRFrontend::BranchVFPUFlag(MIPSOpcode op, IRComparison cc, bool likely) {
 		CompileDelaySlot();
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	if (delaySlotIsBranch && (signed short)(delaySlotOp & 0xFFFF) != (signed short)(op & 0xFFFF) - 1)
@@ -320,7 +320,7 @@ void IRFrontend::Comp_Jump(MIPSOpcode op) {
 	}
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	FlushAll();
@@ -384,7 +384,7 @@ void IRFrontend::Comp_JumpReg(MIPSOpcode op) {
 	}
 
 	int dcAmount = js.downcountAmount;
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	ir.Write(IROp::ExitToReg, 0, destReg, 0);
@@ -397,7 +397,7 @@ void IRFrontend::Comp_JumpReg(MIPSOpcode op) {
 void IRFrontend::Comp_Syscall(MIPSOpcode op) {
 	// Note: If we're in a delay slot, this is off by one compared to the interpreter.
 	int dcAmount = js.downcountAmount + (js.inDelaySlot ? -1 : 0);
-	ir.Write(IROp::Downcount, 0, dcAmount & 0xFF, dcAmount >> 8);
+	ir.Write(IROp::Downcount, 0, ir.AddConstant(dcAmount));
 	js.downcountAmount = 0;
 
 	// If not in a delay slot, we need to update PC.

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -162,7 +162,7 @@ void IRFrontend::Comp_ReplacementFunc(MIPSOpcode op) {
 			MIPSCompileOp(Memory::Read_Instruction(GetCompilerPC(), true), this);
 		} else {
 			ApplyRoundingMode();
-			ir.Write(IROp::Downcount, 0, js.downcountAmount & 0xFF, js.downcountAmount >> 8);
+			ir.Write(IROp::Downcount, 0, ir.AddConstant(js.downcountAmount));
 			ir.Write(IROp::ExitToReg, 0, MIPS_REG_RA, 0);
 			js.compiling = false;
 		}
@@ -319,7 +319,7 @@ void IRFrontend::CheckBreakpoint(u32 addr) {
 		// TODO: In likely branches, downcount will be incorrect.
 		int downcountOffset = js.inDelaySlot && js.downcountAmount >= 2 ? -2 : 0;
 		int downcountAmount = js.downcountAmount + downcountOffset;
-		ir.Write(IROp::Downcount, 0, downcountAmount & 0xFF, downcountAmount >> 8);
+		ir.Write(IROp::Downcount, 0, ir.AddConstant(downcountAmount));
 		// Note that this means downcount can't be metadata on the block.
 		js.downcountAmount = -downcountOffset;
 		ir.Write(IROp::Breakpoint);
@@ -342,7 +342,7 @@ void IRFrontend::CheckMemoryBreakpoint(int rs, int offset) {
 			downcountOffset = 0;
 		}
 		int downcountAmount = js.downcountAmount + downcountOffset;
-		ir.Write(IROp::Downcount, 0, downcountAmount & 0xFF, downcountAmount >> 8);
+		ir.Write(IROp::Downcount, 0, ir.AddConstant(downcountAmount));
 		// Note that this means downcount can't be metadata on the block.
 		js.downcountAmount = -downcountOffset;
 		ir.Write(IROp::MemoryCheck, 0, rs, ir.AddConstant(offset));

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -219,7 +219,7 @@ MIPSOpcode IRFrontend::GetOffsetInstruction(int offset) {
 	return Memory::Read_Instruction(GetCompilerPC() + 4 * offset);
 }
 
-void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants, u32 &mipsBytes) {
+void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes) {
 	js.cancel = false;
 	js.blockStart = em_address;
 	js.compilerPC = em_address;
@@ -244,12 +244,6 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 		MIPSCompileOp(inst, this);
 		js.compilerPC += 4;
 		js.numInstructions++;
-
-		if (ir.GetConstants().size() > 64) {
-			// Need to break the block
-			ir.Write(IROp::ExitToConst, ir.AddConstant(js.compilerPC));
-			js.compiling = false;
-		}
 	}
 
 	mipsBytes = js.compilerPC - em_address;
@@ -273,7 +267,6 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 	}
 
 	instructions = code->GetInstructions();
-	constants = code->GetConstants();
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		char temp2[256];
@@ -286,20 +279,20 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, std::v
 	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
-		NOTICE_LOG(JIT, "=============== Original IR (%d instructions, %d const) ===============", (int)ir.GetInstructions().size(), (int)ir.GetConstants().size());
+		NOTICE_LOG(JIT, "=============== Original IR (%d instructions) ===============", (int)ir.GetInstructions().size());
 		for (size_t i = 0; i < ir.GetInstructions().size(); i++) {
 			char buf[256];
-			DisassembleIR(buf, sizeof(buf), ir.GetInstructions()[i], &ir.GetConstants()[0]);
+			DisassembleIR(buf, sizeof(buf), ir.GetInstructions()[i]);
 			NOTICE_LOG(JIT, "%s", buf);
 		}
 		NOTICE_LOG(JIT, "===============        end         =================");
 	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
-		NOTICE_LOG(JIT, "=============== IR (%d instructions, %d const) ===============", (int)code->GetInstructions().size(), (int)code->GetConstants().size());
+		NOTICE_LOG(JIT, "=============== IR (%d instructions) ===============", (int)code->GetInstructions().size());
 		for (size_t i = 0; i < code->GetInstructions().size(); i++) {
 			char buf[256];
-			DisassembleIR(buf, sizeof(buf), code->GetInstructions()[i], &code->GetConstants()[0]);
+			DisassembleIR(buf, sizeof(buf), code->GetInstructions()[i]);
 			NOTICE_LOG(JIT, "%s", buf);
 		}
 		NOTICE_LOG(JIT, "===============        end         =================");

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -88,7 +88,7 @@ public:
 	void DoState(PointerWrap &p);
 	bool CheckRounding(u32 blockAddress);  // returns true if we need a do-over
 
-	void DoJit(u32 em_address, std::vector<IRInst> &instructions, std::vector<u32> &constants, u32 &mipsBytes);
+	void DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes);
 
 	void EatPrefix() override {
 		js.EatPrefix();

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -174,7 +174,10 @@ void IRWriter::Write(IROp op, u8 dst, u8 src1, u8 src2) {
 	inst.dest = dst;
 	inst.src1 = src1;
 	inst.src2 = src2;
+	inst.constant = nextConst_;
 	insts_.push_back(inst);
+
+	nextConst_ = 0;
 }
 
 void IRWriter::WriteSetConstant(u8 dst, u32 value) {
@@ -182,16 +185,8 @@ void IRWriter::WriteSetConstant(u8 dst, u32 value) {
 }
 
 int IRWriter::AddConstant(u32 value) {
-	for (size_t i = 0; i < constPool_.size(); i++) {
-		if (constPool_[i] == value)
-			return (int)i;
-	}
-	constPool_.push_back(value);
-	if (constPool_.size() > 255) {
-		// Cannot have more than 256 constants in a block!
-		Crash();
-	}
-	return (int)constPool_.size() - 1;
+	nextConst_ = value;
+	return 255;
 }
 
 int IRWriter::AddConstantFloat(float value) {
@@ -215,7 +210,7 @@ const char *GetGPRName(int r) {
 	}
 }
 
-void DisassembleParam(char *buf, int bufSize, u8 param, char type, const u32 *constPool) {
+void DisassembleParam(char *buf, int bufSize, u8 param, char type, u32 constant) {
 	static const char *vfpuCtrlNames[VFPU_CTRL_MAX] = {
 		"SPFX",
 		"TPFX",
@@ -271,7 +266,7 @@ void DisassembleParam(char *buf, int bufSize, u8 param, char type, const u32 *co
 		}
 		break;
 	case 'C':
-		snprintf(buf, bufSize, "%08x", constPool[param]);
+		snprintf(buf, bufSize, "%08x", constant);
 		break;
 	case 'I':
 		snprintf(buf, bufSize, "%02x", param);
@@ -302,7 +297,7 @@ const IRMeta *GetIRMeta(IROp op) {
 	return metaIndex[(int)op];
 }
 
-void DisassembleIR(char *buf, size_t bufsize, IRInst inst, const u32 *constPool) {
+void DisassembleIR(char *buf, size_t bufsize, IRInst inst) {
 	const IRMeta *meta = GetIRMeta(inst.op);
 	if (!meta) {
 		snprintf(buf, bufsize, "Unknown %d", (int)inst.op);
@@ -311,9 +306,9 @@ void DisassembleIR(char *buf, size_t bufsize, IRInst inst, const u32 *constPool)
 	char bufDst[16];
 	char bufSrc1[16];
 	char bufSrc2[16];
-	DisassembleParam(bufDst, sizeof(bufDst) - 2, inst.dest, meta->types[0], constPool);
-	DisassembleParam(bufSrc1, sizeof(bufSrc1) - 2, inst.src1, meta->types[1], constPool);
-	DisassembleParam(bufSrc2, sizeof(bufSrc2), inst.src2, meta->types[2], constPool);
+	DisassembleParam(bufDst, sizeof(bufDst) - 2, inst.dest, meta->types[0], inst.constant);
+	DisassembleParam(bufSrc1, sizeof(bufSrc1) - 2, inst.src1, meta->types[1], inst.constant);
+	DisassembleParam(bufSrc2, sizeof(bufSrc2), inst.src2, meta->types[2], inst.constant);
 	if (meta->types[1] && meta->types[0] != '_') {
 		strcat(bufDst, ", ");
 	}

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -141,7 +141,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::Vec2Pack31To16, "Vec2Pack31To16", "2V" },
 
 	{ IROp::Interpret, "Interpret", "_C" },
-	{ IROp::Downcount, "Downcount", "_II" },
+	{ IROp::Downcount, "Downcount", "_C" },
 	{ IROp::ExitToPC, "ExitToPC", "", IRFLAG_EXIT },
 	{ IROp::ExitToConst, "Exit", "C", IRFLAG_EXIT },
 	{ IROp::ExitToConstIfEq, "ExitIfEq", "CGG", IRFLAG_EXIT },

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -313,10 +313,7 @@ struct IRMeta {
 	u32 flags;
 };
 
-// 32 bits.
-// TODO: Evaluate whether it would make sense to switch to 64-bit ops with immediates
-// included instead of storing immediates separately. Would simplify things at some memory
-// storage and bandwidth cost.
+// 64 bits.
 struct IRInst {
 	IROp op;
 	union {
@@ -325,22 +322,21 @@ struct IRInst {
 	};
 	u8 src1;
 	u8 src2;
+	u32 constant;
 };
 
 // Returns the new PC.
-u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int count);
+u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count);
 
 // Each IR block gets a constant pool.
 class IRWriter {
 public:
 	IRWriter &operator =(const IRWriter &w) {
 		insts_ = w.insts_;
-		constPool_ = w.constPool_;
 		return *this;
 	}
 	IRWriter &operator =(IRWriter &&w) {
 		insts_ = std::move(w.insts_);
-		constPool_ = std::move(w.constPool_);
 		return *this;
 	}
 
@@ -355,15 +351,13 @@ public:
 
 	void Clear() {
 		insts_.clear();
-		constPool_.clear();
 	}
 
 	const std::vector<IRInst> &GetInstructions() const { return insts_; }
-	const std::vector<u32> &GetConstants() const { return constPool_; }
 
 private:
 	std::vector<IRInst> insts_;
-	std::vector<u32> constPool_;
+	u32 nextConst_ = 0;
 };
 
 struct IROptions {
@@ -371,5 +365,5 @@ struct IROptions {
 };
 
 const IRMeta *GetIRMeta(IROp op);
-void DisassembleIR(char *buf, size_t bufsize, IRInst inst, const u32 *constPool);
+void DisassembleIR(char *buf, size_t bufsize, IRInst inst);
 void InitIR();

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -58,7 +58,7 @@ u32 RunMemCheck(u32 pc, u32 addr) {
 	return coreState != CORE_RUNNING ? 1 : 0;
 }
 
-u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int count) {
+u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 	const IRInst *end = inst + count;
 	while (inst != end) {
 		switch (inst->op) {
@@ -66,10 +66,10 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			_assert_(false);
 			break;
 		case IROp::SetConst:
-			mips->r[inst->dest] = constPool[inst->src1];
+			mips->r[inst->dest] = inst->constant;
 			break;
 		case IROp::SetConstF:
-			memcpy(&mips->f[inst->dest], &constPool[inst->src1], 4);
+			memcpy(&mips->f[inst->dest], &inst->constant, 4);
 			break;
 		case IROp::Add:
 			mips->r[inst->dest] = mips->r[inst->src1] + mips->r[inst->src2];
@@ -90,19 +90,19 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			mips->r[inst->dest] = mips->r[inst->src1];
 			break;
 		case IROp::AddConst:
-			mips->r[inst->dest] = mips->r[inst->src1] + constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] + inst->constant;
 			break;
 		case IROp::SubConst:
-			mips->r[inst->dest] = mips->r[inst->src1] - constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] - inst->constant;
 			break;
 		case IROp::AndConst:
-			mips->r[inst->dest] = mips->r[inst->src1] & constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] & inst->constant;
 			break;
 		case IROp::OrConst:
-			mips->r[inst->dest] = mips->r[inst->src1] | constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] | inst->constant;
 			break;
 		case IROp::XorConst:
-			mips->r[inst->dest] = mips->r[inst->src1] ^ constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] ^ inst->constant;
 			break;
 		case IROp::Neg:
 			mips->r[inst->dest] = -(s32)mips->r[inst->src1];
@@ -121,40 +121,40 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 
 		case IROp::Load8:
-			mips->r[inst->dest] = Memory::ReadUnchecked_U8(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->r[inst->dest] = Memory::ReadUnchecked_U8(mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Load8Ext:
-			mips->r[inst->dest] = (s32)(s8)Memory::ReadUnchecked_U8(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->r[inst->dest] = (s32)(s8)Memory::ReadUnchecked_U8(mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Load16:
-			mips->r[inst->dest] = Memory::ReadUnchecked_U16(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->r[inst->dest] = Memory::ReadUnchecked_U16(mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Load16Ext:
-			mips->r[inst->dest] = (s32)(s16)Memory::ReadUnchecked_U16(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->r[inst->dest] = (s32)(s16)Memory::ReadUnchecked_U16(mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Load32:
-			mips->r[inst->dest] = Memory::ReadUnchecked_U32(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->r[inst->dest] = Memory::ReadUnchecked_U32(mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::LoadFloat:
-			mips->f[inst->dest] = Memory::ReadUnchecked_Float(mips->r[inst->src1] + constPool[inst->src2]);
+			mips->f[inst->dest] = Memory::ReadUnchecked_Float(mips->r[inst->src1] + inst->constant);
 			break;
 
 		case IROp::Store8:
-			Memory::WriteUnchecked_U8(mips->r[inst->src3], mips->r[inst->src1] + constPool[inst->src2]);
+			Memory::WriteUnchecked_U8(mips->r[inst->src3], mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Store16:
-			Memory::WriteUnchecked_U16(mips->r[inst->src3], mips->r[inst->src1] + constPool[inst->src2]);
+			Memory::WriteUnchecked_U16(mips->r[inst->src3], mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::Store32:
-			Memory::WriteUnchecked_U32(mips->r[inst->src3], mips->r[inst->src1] + constPool[inst->src2]);
+			Memory::WriteUnchecked_U32(mips->r[inst->src3], mips->r[inst->src1] + inst->constant);
 			break;
 		case IROp::StoreFloat:
-			Memory::WriteUnchecked_Float(mips->f[inst->src3], mips->r[inst->src1] + constPool[inst->src2]);
+			Memory::WriteUnchecked_Float(mips->f[inst->src3], mips->r[inst->src1] + inst->constant);
 			break;
 
 		case IROp::LoadVec4:
 		{
-			u32 base = mips->r[inst->src1] + constPool[inst->src2];
+			u32 base = mips->r[inst->src1] + inst->constant;
 #if defined(_M_SSE)
 			_mm_store_ps(&mips->f[inst->dest], _mm_load_ps((const float *)Memory::GetPointerUnchecked(base)));
 #else
@@ -165,7 +165,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 		}
 		case IROp::StoreVec4:
 		{
-			u32 base = mips->r[inst->src1] + constPool[inst->src2];
+			u32 base = mips->r[inst->src1] + inst->constant;
 #if defined(_M_SSE)
 			_mm_store_ps((float *)Memory::GetPointerUnchecked(base), _mm_load_ps(&mips->f[inst->dest]));
 #else
@@ -474,11 +474,11 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 
 		case IROp::SltConst:
-			mips->r[inst->dest] = (s32)mips->r[inst->src1] < (s32)constPool[inst->src2];
+			mips->r[inst->dest] = (s32)mips->r[inst->src1] < (s32)inst->constant;
 			break;
 
 		case IROp::SltUConst:
-			mips->r[inst->dest] = mips->r[inst->src1] < constPool[inst->src2];
+			mips->r[inst->dest] = mips->r[inst->src1] < inst->constant;
 			break;
 
 		case IROp::MovZ:
@@ -731,34 +731,34 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 
 		case IROp::ExitToConst:
-			return constPool[inst->dest];
+			return inst->constant;
 
 		case IROp::ExitToReg:
 			return mips->r[inst->src1];
 
 		case IROp::ExitToConstIfEq:
 			if (mips->r[inst->src1] == mips->r[inst->src2])
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 		case IROp::ExitToConstIfNeq:
 			if (mips->r[inst->src1] != mips->r[inst->src2])
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 		case IROp::ExitToConstIfGtZ:
 			if ((s32)mips->r[inst->src1] > 0)
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 		case IROp::ExitToConstIfGeZ:
 			if ((s32)mips->r[inst->src1] >= 0)
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 		case IROp::ExitToConstIfLtZ:
 			if ((s32)mips->r[inst->src1] < 0)
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 		case IROp::ExitToConstIfLeZ:
 			if ((s32)mips->r[inst->src1] <= 0)
-				return constPool[inst->dest];
+				return inst->constant;
 			break;
 
 		case IROp::Downcount:
@@ -770,13 +770,13 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 
 		case IROp::SetPCConst:
-			mips->pc = constPool[inst->src1];
+			mips->pc = inst->constant;
 			break;
 
 		case IROp::Syscall:
 			// IROp::SetPC was (hopefully) executed before.
 		{
-			MIPSOpcode op(constPool[inst->src1]);
+			MIPSOpcode op(inst->constant);
 			CallSyscall(op);
 			if (coreState != CORE_RUNNING)
 				CoreTiming::ForceCheck();
@@ -788,14 +788,14 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 
 		case IROp::Interpret:  // SLOW fallback. Can be made faster. Ideally should be removed but may be useful for debugging.
 		{
-			MIPSOpcode op(constPool[inst->src1]);
+			MIPSOpcode op(inst->constant);
 			MIPSInterpret(op);
 			break;
 		}
 
 		case IROp::CallReplacement:
 		{
-			int funcIndex = constPool[inst->src1];
+			int funcIndex = inst->constant;
 			const ReplacementTableEntry *f = GetReplacementFunc(funcIndex);
 			int cycles = f->replaceFunc();
 			mips->downcount -= cycles;
@@ -810,7 +810,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			return mips->pc + 4;
 
 		case IROp::SetCtrlVFPU:
-			mips->vfpuCtrl[inst->dest] = constPool[inst->src1];
+			mips->vfpuCtrl[inst->dest] = inst->constant;
 			break;
 
 		case IROp::SetCtrlVFPUReg:
@@ -829,7 +829,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int c
 			break;
 
 		case IROp::MemoryCheck:
-			if (RunMemCheck(mips->pc, mips->r[inst->src1] + constPool[inst->src2])) {
+			if (RunMemCheck(mips->pc, mips->r[inst->src1] + inst->constant)) {
 				CoreTiming::ForceCheck();
 				return mips->pc;
 			}

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -762,7 +762,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			break;
 
 		case IROp::Downcount:
-			mips->downcount -= (inst->src1) | ((inst->src2) << 8);
+			mips->downcount -= inst->constant;
 			break;
 
 		case IROp::SetPC:

--- a/Core/MIPS/IR/IRInterpreter.h
+++ b/Core/MIPS/IR/IRInterpreter.h
@@ -20,4 +20,4 @@ inline static u32 ReverseBits32(u32 v) {
 	return v;
 }
 
-u32 IRInterpret(MIPSState *mips, const IRInst *inst, const u32 *constPool, int count);
+u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count);

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -70,10 +70,9 @@ void IRJit::Compile(u32 em_address) {
 	IRBlock *b = blocks_.GetBlock(block_num);
 
 	std::vector<IRInst> instructions;
-	std::vector<u32> constants;
 	u32 mipsBytes;
-	frontend_.DoJit(em_address, instructions, constants, mipsBytes);
-	b->SetInstructions(instructions, constants);
+	frontend_.DoJit(em_address, instructions, mipsBytes);
+	b->SetInstructions(instructions);
 	b->SetOriginalSize(mipsBytes);
 	// Overwrites the first instruction, and also updates stats.
 	blocks_.FinalizeBlock(block_num);
@@ -104,7 +103,7 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 			if (opcode == MIPS_EMUHACK_OPCODE) {
 				u32 data = inst & 0xFFFFFF;
 				IRBlock *block = blocks_.GetBlock(data);
-				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetConstants(), block->GetNumInstructions());
+				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetNumInstructions());
 			} else {
 				// RestoreRoundingMode(true);
 				Compile(mips_->pc);

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -38,40 +38,30 @@ namespace MIPSComp {
 // TODO : Use arena allocators. For now let's just malloc.
 class IRBlock {
 public:
-	IRBlock() : instr_(nullptr), const_(nullptr), numInstructions_(0), numConstants_(0), origAddr_(0), origSize_(0) {}
-	IRBlock(u32 emAddr) : instr_(nullptr), const_(nullptr), numInstructions_(0), numConstants_(0), origAddr_(emAddr), origSize_(0) {}
+	IRBlock() : instr_(nullptr), numInstructions_(0), origAddr_(0), origSize_(0) {}
+	IRBlock(u32 emAddr) : instr_(nullptr), numInstructions_(0), origAddr_(emAddr), origSize_(0) {}
 	IRBlock(IRBlock &&b) {
 		instr_ = b.instr_;
-		const_ = b.const_;
 		numInstructions_ = b.numInstructions_;
-		numConstants_ = b.numConstants_;
 		origAddr_ = b.origAddr_;
 		origSize_ = b.origSize_;
 		origFirstOpcode_ = b.origFirstOpcode_;
 		b.instr_ = nullptr;
-		b.const_ = nullptr;
 	}
 
 	~IRBlock() {
 		delete[] instr_;
-		delete[] const_;
 	}
 
-	void SetInstructions(const std::vector<IRInst> &inst, const std::vector<u32> &constants) {
+	void SetInstructions(const std::vector<IRInst> &inst) {
 		instr_ = new IRInst[inst.size()];
 		numInstructions_ = (u16)inst.size();
 		if (!inst.empty()) {
 			memcpy(instr_, &inst[0], sizeof(IRInst) * inst.size());
 		}
-		const_ = new u32[constants.size()];
-		numConstants_ = (u16)constants.size();
-		if (!constants.empty()) {
-			memcpy(const_, &constants[0], sizeof(u32) * constants.size());
-		}
 	}
 
 	const IRInst *GetInstructions() const { return instr_; }
-	const u32 *GetConstants() const { return const_; }
 	int GetNumInstructions() const { return numInstructions_; }
 	MIPSOpcode GetOriginalFirstOp() const { return origFirstOpcode_; }
 	bool HasOriginalFirstOp();
@@ -92,9 +82,7 @@ public:
 
 private:
 	IRInst *instr_;
-	u32 *const_;
 	u16 numInstructions_;
-	u16 numConstants_;
 	u32 origAddr_;
 	u32 origSize_;
 	MIPSOpcode origFirstOpcode_;


### PR DESCRIPTION
This simplifies a bunch of code and improves compile performance by about 30% (averaged), at the cost of 25% more memory (averaged.)  I also got a ~3% ir interpreter perf boost with this in one game, but didn't heavily benchmark runtime.

This also removes the block truncation due to running out of consts, which was (infrequently) happening.

For now, keeping the AddConstant API the same, although it probably makes sense to change it.  An op can no longer reference two consts (which never happens anyway.)

-[Unknown]
  