### PR TITLE
Add taptic feedback on virtual buttons (iOS)

### DIFF
--- a/ios/PPSSPPUIApplication.h
+++ b/ios/PPSSPPUIApplication.h
@@ -14,6 +14,9 @@
 @interface PPSSPPUIApplication : UIApplication
 {
 }
+
+@property (nonatomic, strong) UISelectionFeedbackGenerator *feedbackGenerator;
+
 @end
 
 


### PR DESCRIPTION
A small patch to create a smaller, more pleasant haptic feedback for virtual controllers on iOS devices that support Apple's "version 2" Taptic Engine. 

This patch also paves the way for more accurately utilizing the int parameter to Vibrate on iOS.

A note about architecture: I didn't want to move the `Vibrate` function out of `main.mm` under the assumption that it was placed there for a deliberate reason. I did, however, need a place to retain a `UISelectionFeedbackGenerator`, and elected `PPSSPPUIApplication` to the position. Please let me know if you'd like this refactored somehow.

Tested on both iPhone 7 and iPhone 6, iOS 11 and 10 respectively.