### PR TITLE
Allow up to 10x window size on Windows.

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -732,6 +732,12 @@ namespace MainWindow {
 		case ID_OPTIONS_WINDOW2X:   SetWindowSize(2); break;
 		case ID_OPTIONS_WINDOW3X:   SetWindowSize(3); break;
 		case ID_OPTIONS_WINDOW4X:   SetWindowSize(4); break;
+		case ID_OPTIONS_WINDOW5X:   SetWindowSize(5); break;
+		case ID_OPTIONS_WINDOW6X:   SetWindowSize(6); break;
+		case ID_OPTIONS_WINDOW7X:   SetWindowSize(7); break;
+		case ID_OPTIONS_WINDOW8X:   SetWindowSize(8); break;
+		case ID_OPTIONS_WINDOW9X:   SetWindowSize(9); break;
+		case ID_OPTIONS_WINDOW10X:   SetWindowSize(10); break;
 
 		case ID_OPTIONS_RESOLUTIONDUMMY:
 		{
@@ -1107,11 +1113,17 @@ namespace MainWindow {
 			CheckMenuItem(menu, zoomitems[i], MF_BYCOMMAND | ((i == g_Config.iInternalResolution) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
-		static const int windowSizeItems[4] = {
+		static const int windowSizeItems[10] = {
 			ID_OPTIONS_WINDOW1X,
 			ID_OPTIONS_WINDOW2X,
 			ID_OPTIONS_WINDOW3X,
 			ID_OPTIONS_WINDOW4X,
+			ID_OPTIONS_WINDOW5X,
+			ID_OPTIONS_WINDOW6X,
+			ID_OPTIONS_WINDOW7X,
+			ID_OPTIONS_WINDOW8X,
+			ID_OPTIONS_WINDOW9X,
+			ID_OPTIONS_WINDOW10X,
 		};
 
 		RECT rc;

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -492,6 +492,12 @@ BEGIN
             MENUITEM "&2x",                                 ID_OPTIONS_WINDOW2X
             MENUITEM "&3x",                                 ID_OPTIONS_WINDOW3X
             MENUITEM "&4x",                                 ID_OPTIONS_WINDOW4X
+            MENUITEM "&5x",                                 ID_OPTIONS_WINDOW5X
+            MENUITEM "&6x",                                 ID_OPTIONS_WINDOW6X
+            MENUITEM "&7x",                                 ID_OPTIONS_WINDOW7X
+            MENUITEM "&8x",                                 ID_OPTIONS_WINDOW8X
+            MENUITEM "&9x",                                 ID_OPTIONS_WINDOW9X
+            MENUITEM "&10x",                                ID_OPTIONS_WINDOW10X
         END
 
         POPUP "Backend"

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -334,6 +334,11 @@
 #define IDC_GEDBG_RECORD                 40169
 #define ID_GEDBG_EXPORT_IMAGE            40170
 #define ID_GEDBG_ENABLE_PREVIEW          40171
+#define ID_OPTIONS_WINDOW6X              40172
+#define ID_OPTIONS_WINDOW7X              40173
+#define ID_OPTIONS_WINDOW8X              40174
+#define ID_OPTIONS_WINDOW9X              40175
+#define ID_OPTIONS_WINDOW10X             40176
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500
@@ -346,7 +351,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40172
+#define _APS_NEXT_COMMAND_VALUE         40177
 #define _APS_NEXT_CONTROL_VALUE         1200
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
4x can be too small for today's high resolution monitors.