### PR TITLE
Windows: Fix a small memory leak.

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -349,6 +349,8 @@ std::vector<std::wstring> GetWideCmdLine() {
 	wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
 
 	std::vector<std::wstring> wideArgs(wargv, wargv + wargc);
+	LocalFree(wargv);
+
 	return wideArgs;
 }
 


### PR DESCRIPTION
```CommandLineToArgvW()``` allocates a memory block which must be freed by ```LocalFree()```.