### PR TITLE
Minor refactoring: Make a place for shared Vulkan objects like simple linear samplers

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -136,6 +136,9 @@ public:
 	void SetFramebufferManager(FramebufferManagerVulkan *fbManager) {
 		framebufferManager_ = fbManager;
 	}
+	void SetStockObjects(VulkanStockObjects *stock) {
+		stockObjects_ = stock;
+	}
 
 	void DeviceLost();
 	void DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw);
@@ -212,7 +215,6 @@ private:
 
 	// Secondary texture for shader blending
 	VkImageView boundSecondary_ = VK_NULL_HANDLE;
-	VkSampler samplerSecondary_ = VK_NULL_HANDLE;  // This one is actually never used since we use fetch.
 
 	PrehashMap<VertexArrayInfoVulkan *, nullptr> vai_;
 	VulkanPushBuffer *vertexCache_;
@@ -249,6 +251,7 @@ private:
 	PipelineManagerVulkan *pipelineManager_ = nullptr;
 	TextureCacheVulkan *textureCache_ = nullptr;
 	FramebufferManagerVulkan *framebufferManager_ = nullptr;
+	VulkanStockObjects *stockObjects_ = nullptr;
 
 	// State cache
 	uint64_t dirtyUniforms_;
@@ -261,7 +264,6 @@ private:
 
 	// Null texture
 	VulkanTexture *nullTexture_ = nullptr;
-	VkSampler nullSampler_ = VK_NULL_HANDLE;
 
 	DrawEngineVulkanStats stats_;
 

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -126,19 +126,6 @@ void FramebufferManagerVulkan::InitDeviceObjects() {
 	vsBasicTex_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_VERTEX_BIT, tex_vs, &vs_errors);
 	assert(fsBasicTex_ != VK_NULL_HANDLE);
 	assert(vsBasicTex_ != VK_NULL_HANDLE);
-
-	VkSamplerCreateInfo samp = { VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
-	samp.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	samp.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	samp.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	samp.magFilter = VK_FILTER_NEAREST;
-	samp.minFilter = VK_FILTER_NEAREST;
-	VkResult res = vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &nearestSampler_);
-	assert(res == VK_SUCCESS);
-	samp.magFilter = VK_FILTER_LINEAR;
-	samp.minFilter = VK_FILTER_LINEAR;
-	res = vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &linearSampler_);
-	assert(res == VK_SUCCESS);
 }
 
 void FramebufferManagerVulkan::DestroyDeviceObjects() {
@@ -153,11 +140,6 @@ void FramebufferManagerVulkan::DestroyDeviceObjects() {
 		vulkan_->Delete().QueueDeleteShaderModule(stencilFs_);
 	if (stencilVs_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteShaderModule(stencilVs_);
-
-	if (linearSampler_ != VK_NULL_HANDLE)
-		vulkan_->Delete().QueueDeleteSampler(linearSampler_);
-	if (nearestSampler_ != VK_NULL_HANDLE)
-		vulkan_->Delete().QueueDeleteSampler(nearestSampler_);
 
 	if (postVs_)
 		vulkan_->Delete().QueueDeleteShaderModule(postVs_);
@@ -335,7 +317,7 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 	VkImageView view = overrideImageView_ ? overrideImageView_ : (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_TEXTURE0_IMAGEVIEW);
 	if ((flags & DRAWTEX_KEEP_TEX) == 0)
 		overrideImageView_ = VK_NULL_HANDLE;
-	VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(view, (flags & DRAWTEX_LINEAR) ? linearSampler_ : nearestSampler_, VK_NULL_HANDLE, VK_NULL_HANDLE);
+	VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(view, (flags & DRAWTEX_LINEAR) ? stockObjects_->samplerLinear : stockObjects_->samplerNearest, VK_NULL_HANDLE, VK_NULL_HANDLE);
 	VkBuffer vbuffer;
 	VkDeviceSize offset = push_->Push(vtx, sizeof(vtx), &vbuffer);
 	renderManager->BindPipeline(cur2DPipeline_);

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -57,6 +57,7 @@ public:
 	void SetDrawEngine(DrawEngineVulkan *td);
 	void SetVulkan2D(Vulkan2D *vk2d) { vulkan2D_ = vk2d; }
 	void SetPushBuffer(VulkanPushBuffer *push) { push_ = push; }
+	void SetStockObjects(VulkanStockObjects *stock) { stockObjects_ = stock; }
 
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) override;
@@ -117,6 +118,7 @@ private:
 	ShaderManagerVulkan *shaderManagerVulkan_;
 	DrawEngineVulkan *drawEngineVulkan_;
 	VulkanPushBuffer *push_;
+	VulkanStockObjects *stockObjects_;
 
 	enum {
 		MAX_COMMAND_BUFFERS = 32,
@@ -134,7 +136,6 @@ private:
 	VkShaderModule stencilVs_ = VK_NULL_HANDLE;
 	VkShaderModule stencilFs_ = VK_NULL_HANDLE;
 
-
 	VkPipeline cur2DPipeline_ = VK_NULL_HANDLE;
 
 	// Postprocessing
@@ -142,9 +143,6 @@ private:
 	VkShaderModule postFs_ = VK_NULL_HANDLE;
 	VkPipeline pipelinePostShader_ = VK_NULL_HANDLE;
 	PostShaderUniforms postShaderUniforms_;
-
-	VkSampler linearSampler_;
-	VkSampler nearestSampler_;
 
 	// hack!
 	VkImageView overrideImageView_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -76,7 +76,8 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 		vulkan_((VulkanContext *)gfxCtx->GetAPIContext()),
 		drawEngine_(vulkan_, draw),
 		depalShaderCache_(draw, vulkan_),
-		vulkan2D_(vulkan_) {
+		vulkan2D_(vulkan_),
+		stockObjects_(vulkan_) {
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
 
@@ -93,11 +94,13 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	drawEngine_.SetFramebufferManager(framebufferManagerVulkan_);
 	drawEngine_.SetShaderManager(shaderManagerVulkan_);
 	drawEngine_.SetPipelineManager(pipelineManager_);
+	drawEngine_.SetStockObjects(&stockObjects_);
 	framebufferManagerVulkan_->SetVulkan2D(&vulkan2D_);
 	framebufferManagerVulkan_->Init();
 	framebufferManagerVulkan_->SetTextureCache(textureCacheVulkan_);
 	framebufferManagerVulkan_->SetDrawEngine(&drawEngine_);
 	framebufferManagerVulkan_->SetShaderManager(shaderManagerVulkan_);
+	framebufferManagerVulkan_->SetStockObjects(&stockObjects_);
 	textureCacheVulkan_->SetDepalShaderCache(&depalShaderCache_);
 	textureCacheVulkan_->SetFramebufferManager(framebufferManagerVulkan_);
 	textureCacheVulkan_->SetShaderManager(shaderManagerVulkan_);
@@ -628,6 +631,7 @@ void GPU_Vulkan::DeviceLost() {
 	textureCacheVulkan_->DeviceLost();
 	depalShaderCache_.DeviceLost();
 	shaderManagerVulkan_->ClearShaders();
+	stockObjects_.DeviceLost();
 }
 
 void GPU_Vulkan::DeviceRestore() {
@@ -639,6 +643,7 @@ void GPU_Vulkan::DeviceRestore() {
 	BuildReportingInfo();
 	UpdateCmdInfo();
 
+	stockObjects_.DeviceRestore(vulkan_);
 	framebufferManagerVulkan_->DeviceRestore(vulkan_, draw_);
 	vulkan2D_.DeviceRestore(vulkan_);
 	drawEngine_.DeviceRestore(vulkan_, draw_);

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -104,6 +104,7 @@ private:
 	TextureCacheVulkan *textureCacheVulkan_;
 	DepalShaderCacheVulkan depalShaderCache_;
 	DrawEngineVulkan drawEngine_;
+	VulkanStockObjects stockObjects_;
 
 	// Manages shaders and UBO data
 	ShaderManagerVulkan *shaderManagerVulkan_;

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -148,7 +148,7 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, bool skip
 	renderManager->SetScissor({ { 0, 0, },{ (uint32_t)w, (uint32_t)h } });
 	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE);
 
-	VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(overrideImageView_, nearestSampler_, VK_NULL_HANDLE, VK_NULL_HANDLE);
+	VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(overrideImageView_, stockObjects_->samplerNearest, VK_NULL_HANDLE, VK_NULL_HANDLE);
 
 	for (int i = 1; i < values; i += i) {
 		if (!(usedBits & i)) {

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -36,6 +36,7 @@ class VulkanContext;
 class VulkanTexture;
 class VulkanPushBuffer;
 class VulkanDeviceAllocator;
+class VulkanStockObjects;
 
 class CachedTextureVulkan {
 public:
@@ -91,7 +92,9 @@ public:
 	void SetPushBuffer(VulkanPushBuffer *push) {
 		push_ = push;
 	}
-
+	void SetStockObjects(VulkanStockObjects *stock) {
+		stockObjects_ = stock;
+	}
 	void ForgetLastTexture() override {
 		lastBoundTexture = nullptr;
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
@@ -150,12 +153,11 @@ private:
 	ShaderManagerVulkan *shaderManagerVulkan_;
 	DrawEngineVulkan *drawEngine_;
 	Vulkan2D *vulkan2D_;
+	VulkanStockObjects *stockObjects_;
 
 	// Bound state to emulate an API similar to the others
 	VkImageView imageView_ = VK_NULL_HANDLE;
 	VkSampler curSampler_ = VK_NULL_HANDLE;
-
-	VkSampler samplerNearest_ = VK_NULL_HANDLE;
 };
 
 VkFormat getClutDestFormatVulkan(GEPaletteFormat format);

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -20,6 +20,47 @@
 #include "Common/Vulkan/VulkanContext.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
+VulkanStockObjects::VulkanStockObjects(VulkanContext *vulkan) : vulkan_(vulkan) {
+	InitDeviceObjects();
+}
+
+VulkanStockObjects::~VulkanStockObjects() {
+	DestroyDeviceObjects();
+}
+
+void VulkanStockObjects::InitDeviceObjects() {
+	VkResult res;
+	VkDevice device = vulkan_->GetDevice();
+	VkSamplerCreateInfo samp { VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+	samp.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samp.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samp.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samp.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+	samp.flags = 0;
+	samp.magFilter = VK_FILTER_NEAREST;
+	samp.minFilter = VK_FILTER_NEAREST;
+	res = vkCreateSampler(device, &samp, nullptr, &samplerNearest);
+	assert(VK_SUCCESS == res);
+	samp.magFilter = VK_FILTER_LINEAR;
+	samp.minFilter = VK_FILTER_LINEAR;
+	res = vkCreateSampler(device, &samp, nullptr, &samplerLinear);
+	assert(VK_SUCCESS == res);
+}
+
+void VulkanStockObjects::DestroyDeviceObjects() {
+	vulkan_->Delete().QueueDeleteSampler(samplerNearest);
+	vulkan_->Delete().QueueDeleteSampler(samplerLinear);
+}
+
+void VulkanStockObjects::DeviceLost() {
+	DestroyDeviceObjects();
+}
+
+void VulkanStockObjects::DeviceRestore(VulkanContext *vulkan) {
+	vulkan_ = vulkan;
+	InitDeviceObjects();
+}
+
 Vulkan2D::Vulkan2D(VulkanContext *vulkan) : vulkan_(vulkan) {
 	InitDeviceObjects();
 }


### PR DESCRIPTION
VulkanStockObjects, like our D3D11 stock objects.