### PR TITLE
Windows: Use sufficient buffer for config file paths.

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -391,10 +391,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	langRegion = GetDefaultLangRegion();
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();
 
-	char configFilename[MAX_PATH] = { 0 };
+	std::string configFilename = "";
 	const std::wstring configOption = L"--config=";
 
-	char controlsConfigFilename[MAX_PATH] = { 0 };
+	std::string controlsConfigFilename = "";
 	const std::wstring controlsOption = L"--controlconfig=";
 
 	std::vector<std::wstring> wideArgs = GetWideCmdLine();
@@ -405,14 +405,12 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		if (wideArgs[i][0] == L'-') {
 			if (wideArgs[i].find(configOption) != std::wstring::npos && wideArgs[i].size() > configOption.size()) {
 				const std::wstring tempWide = wideArgs[i].substr(configOption.size());
-				const std::string tempStr = ConvertWStringToUTF8(tempWide);
-				std::strncpy(configFilename, tempStr.c_str(), MAX_PATH);
+				configFilename = ConvertWStringToUTF8(tempWide);
 			}
 
 			if (wideArgs[i].find(controlsOption) != std::wstring::npos && wideArgs[i].size() > controlsOption.size()) {
 				const std::wstring tempWide = wideArgs[i].substr(controlsOption.size());
-				const std::string tempStr = ConvertWStringToUTF8(tempWide);
-				std::strncpy(controlsConfigFilename, tempStr.c_str(), MAX_PATH);
+				controlsConfigFilename = ConvertWStringToUTF8(tempWide);
 			}
 		}
 	}
@@ -428,7 +426,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	g_Config.AddSearchPath("");
 	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
-	g_Config.Load(configFilename, controlsConfigFilename);
+	g_Config.Load(configFilename.c_str(), controlsConfigFilename.c_str());
 
 	bool debugLogLevel = false;
 


### PR DESCRIPTION
MAX_PATH bytes are insufficient when a very long path is converted into UTF-8.

Similar things are [here](https://github.com/hrydgard/ppsspp/blob/master/Windows/MainWindowMenu.cpp#L410-L413), but I haven't touch it since I have no idea what it is for.
