### PR TITLE
Fix stencil issues in GL on thread

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -719,8 +719,6 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 	float u0 = 0.0f, u1 = 1.0f;
 	float v0 = 0.0f, v1 = 1.0f;
 
-	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height, u1, v1);
-
 	if (useBufferedRendering_ && vfb && vfb->fbo) {
 		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP });
 		SetViewport2D(0, 0, vfb->renderWidth, vfb->renderHeight);
@@ -735,6 +733,8 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 		draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 	}
 	DisableState();
+
+	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height, u1, v1);
 
 	DrawTextureFlags flags = (vfb || g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
 	Bind2DShader();

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -709,11 +709,13 @@ rotateVBO:
 			}
 
 			GLbitfield target = 0;
+			// Without this, we will clear RGB when clearing stencil, which breaks games.
+			uint8_t rgbaMask = (colorMask ? 7 : 0) | (alphaMask ? 8 : 0);
 			if (colorMask || alphaMask) target |= GL_COLOR_BUFFER_BIT;
 			if (alphaMask) target |= GL_STENCIL_BUFFER_BIT;
 			if (depthMask) target |= GL_DEPTH_BUFFER_BIT;
 
-			render_->Clear(clearColor, clearDepth, clearColor >> 24, target);
+			render_->Clear(clearColor, clearDepth, clearColor >> 24, target, rgbaMask);
 			framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
 			int scissorX1 = gstate.getScissorX1();

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -372,6 +372,9 @@ void FramebufferManagerGLES::MakePixelTexture(const u8 *srcPixels, GEBufferForma
 	}
 	render_->TextureImage(drawPixelsTex_, 0, texWidth, height, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, convBuf, false);
 	render_->FinalizeTexture(drawPixelsTex_, 0, false);
+
+	// TODO: Return instead?
+	render_->BindTexture(0, drawPixelsTex_);
 }
 
 void FramebufferManagerGLES::SetViewport2D(int x, int y, int w, int h) {

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -110,6 +110,9 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 		}
 
 		// Let's not bother with the shader if it's just zero.
+		if (dstBuffer->fbo) {
+			draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR });
+		}
 		render_->SetNoBlendAndMask(0x8);
 		render_->Clear(0, 0, 0, GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
 		render_->SetNoBlendAndMask(0xF);

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -113,10 +113,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 		if (dstBuffer->fbo) {
 			draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR });
 		}
-		// TODO: This incorrectly does not apply to the clear currently.
-		render_->SetNoBlendAndMask(0x8);
-		render_->Clear(0, 0, 0, GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
-		render_->SetNoBlendAndMask(0xF);
+		render_->Clear(0, 0, 0, GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT, 0x8);
 		gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_VIEWPORTSCISSOR_STATE);
 		return true;
 	}
@@ -172,7 +169,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 	textureCacheGL_->ForgetLastTexture();
 
 	// We must bind the program after starting the render pass, and set the color mask after clearing.
-	render_->Clear(0, 0, 0, GL_STENCIL_BUFFER_BIT);
+	render_->Clear(0, 0, 0, GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, 0x8);
 	render_->SetStencilFunc(GL_TRUE, GL_ALWAYS, 0xFF, 0xFF);
 	render_->BindProgram(stencilUploadProgram_);
 	render_->SetNoBlendAndMask(0x8);

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -113,6 +113,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 		if (dstBuffer->fbo) {
 			draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR });
 		}
+		// TODO: This incorrectly does not apply to the clear currently.
 		render_->SetNoBlendAndMask(0x8);
 		render_->Clear(0, 0, 0, GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
 		render_->SetNoBlendAndMask(0xF);

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -155,21 +155,22 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, bool skip
 			// It's already zero, let's skip it.
 			continue;
 		}
-		// These feel a little backwards : Mask is the bits that are going to be written, while value
-		// is the "mask" that will be tested against.
-		uint8_t mask = 0;
+
+		// These are the stencil bits that will be written.  We discard when the bit doesn't match.
+		uint8_t writeMask = 0;
+		// This is the value to test the texture alpha against in the shader.
 		uint32_t value = 0;
 		if (dstBuffer->format == GE_FORMAT_4444) {
-			mask = i | (i << 4);
+			writeMask = i | (i << 4);
 			value = i * 16;
 		} else if (dstBuffer->format == GE_FORMAT_5551) {
-			mask = 0xFF;
+			writeMask = 0xFF;
 			value = i * 128;
 		} else {
-			mask = i;
+			writeMask = i;
 			value = i;
 		}
-		renderManager->SetStencilParams(mask, 0xFF, 0xFF);
+		renderManager->SetStencilParams(writeMask, 0xFF, 0xFF);
 		// Need to specify both VERTEX and FRAGMENT bits here since that's what we set up in the pipeline layout, and we need
 		// that for the post shaders. There's probably not really a cost to this.
 		renderManager->PushConstants(vulkan2D_->GetPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT, 0, 4, &value);

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -498,10 +498,10 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 			break;
 		case GLRRenderCommand::CLEAR:
 			glDisable(GL_SCISSOR_TEST);
-			// TODO: We sometimes pass a color mask in that we want to respect (StencilBufferGLES.)
-			// We want to clear to only clear alpha, in that case.
-			glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-			colorMask = 0xF;
+			if (c.clear.colorMask != colorMask) {
+				glColorMask(c.clear.colorMask & 1, (c.clear.colorMask >> 1) & 1, (c.clear.colorMask >> 2) & 1, (c.clear.colorMask >> 3) & 1);
+				colorMask = c.clear.colorMask;
+			}
 			if (c.clear.clearMask & GL_COLOR_BUFFER_BIT) {
 				float color[4];
 				Uint8x4ToFloat4(color, c.clear.clearColor);

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -498,6 +498,8 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 			break;
 		case GLRRenderCommand::CLEAR:
 			glDisable(GL_SCISSOR_TEST);
+			// TODO: We sometimes pass a color mask in that we want to respect (StencilBufferGLES.)
+			// We want to clear to only clear alpha, in that case.
 			glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 			colorMask = 0xF;
 			if (c.clear.clearMask & GL_COLOR_BUFFER_BIT) {

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -117,6 +117,7 @@ struct GLRRenderData {
 			float clearZ;
 			int clearStencil;
 			int clearMask;   // VK_IMAGE_ASPECT_COLOR_BIT etc
+			int colorMask; // Like blend, but for the clear.
 		} clear;
 		struct {
 			int slot;

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -193,6 +193,7 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 	}
 	if (clearMask) {
 		data.clear.clearMask = clearMask;
+		data.clear.colorMask = 0xF;
 		step->commands.push_back(data);
 	}
 

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -157,11 +157,11 @@ void GLRenderManager::StopThread() {
 	}
 }
 
-void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRenderPassAction color, GLRRenderPassAction depth, uint32_t clearColor, float clearDepth, uint8_t clearStencil) {
+void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRenderPassAction color, GLRRenderPassAction depth, GLRRenderPassAction stencil, uint32_t clearColor, float clearDepth, uint8_t clearStencil) {
 	assert(insideFrame_);
 	// Eliminate dupes.
 	if (steps_.size() && steps_.back()->render.framebuffer == fb && steps_.back()->stepType == GLRStepType::RENDER) {
-		if (color != GLRRenderPassAction::CLEAR && depth != GLRRenderPassAction::CLEAR) {
+		if (color != GLRRenderPassAction::CLEAR && depth != GLRRenderPassAction::CLEAR && stencil != GLRRenderPassAction::CLEAR) {
 			// We don't move to a new step, this bind was unnecessary and we can safely skip it.
 			return;
 		}
@@ -184,8 +184,11 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 		data.clear.clearColor = clearColor;
 	}
 	if (depth == GLRRenderPassAction::CLEAR) {
-		clearMask |= GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+		clearMask |= GL_DEPTH_BUFFER_BIT;
 		data.clear.clearZ = clearDepth;
+	}
+	if (stencil == GLRRenderPassAction::CLEAR) {
+		clearMask |= GL_STENCIL_BUFFER_BIT;
 		data.clear.clearStencil = clearStencil;
 	}
 	if (clearMask) {

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -571,13 +571,14 @@ public:
 		curRenderStep_->commands.push_back(data);
 	}
 
-	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask) {
+	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask, int colorMask = 0xF) {
 		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::CLEAR };
 		data.clear.clearMask = clearMask;
 		data.clear.clearColor = clearColor;
 		data.clear.clearZ = clearZ;
 		data.clear.clearStencil = clearStencil;
+		data.clear.colorMask = colorMask;
 		curRenderStep_->commands.push_back(data);
 	}
 

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -310,7 +310,7 @@ public:
 		deleter_.framebuffers.push_back(framebuffer);
 	}
 
-	void BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRenderPassAction color, GLRRenderPassAction depth, uint32_t clearColor, float clearDepth, uint8_t clearStencil);
+	void BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRenderPassAction color, GLRRenderPassAction depth, GLRRenderPassAction stencil, uint32_t clearColor, float clearDepth, uint8_t clearStencil);
 	void BindFramebufferAsTexture(GLRFramebuffer *fb, int binding, int aspectBit, int attachment);
 	bool CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);
 	void CopyImageToMemorySync(GLuint texture, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -391,7 +391,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 	}
 
 	// Don't execute empty renderpasses.
-	if (step.commands.empty() && step.render.color == VKRRenderPassAction::KEEP && step.render.depthStencil == VKRRenderPassAction::KEEP) {
+	if (step.commands.empty() && step.render.color == VKRRenderPassAction::KEEP && step.render.depth == VKRRenderPassAction::KEEP && step.render.stencil == VKRRenderPassAction::KEEP) {
 		// Nothing to do.
 		return;
 	}
@@ -610,12 +610,12 @@ void VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKRStep &step
 			fb->depth.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 		}
 
-		renderPass = GetRenderPass(step.render.color, step.render.depthStencil, step.render.depthStencil);
+		renderPass = GetRenderPass(step.render.color, step.render.depth, step.render.stencil);
 		if (step.render.color == VKRRenderPassAction::CLEAR) {
 			Uint8x4ToFloat4(clearVal[0].color.float32, step.render.clearColor);
 			numClearVals = 1;
 		}
-		if (step.render.depthStencil == VKRRenderPassAction::CLEAR) {
+		if (step.render.depth == VKRRenderPassAction::CLEAR || step.render.stencil == VKRRenderPassAction::CLEAR) {
 			clearVal[1].depthStencil.depth = step.render.clearDepth;
 			clearVal[1].depthStencil.stencil = step.render.clearStencil;
 			numClearVals = 2;

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -108,7 +108,8 @@ struct VKRStep {
 		struct {
 			VKRFramebuffer *framebuffer;
 			VKRRenderPassAction color;
-			VKRRenderPassAction depthStencil;
+			VKRRenderPassAction depth;
+			VKRRenderPassAction stencil;
 			uint32_t clearColor;
 			float clearDepth;
 			int clearStencil;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -99,7 +99,7 @@ public:
 	// Zaps queued up commands. Use if you know there's a risk you've queued up stuff that has already been deleted. Can happen during in-game shutdown.
 	void Wipe();
 
-	void BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRRenderPassAction color, VKRRenderPassAction depth, uint32_t clearColor, float clearDepth, uint8_t clearStencil);
+	void BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRRenderPassAction color, VKRRenderPassAction depth, VKRRenderPassAction stencil, uint32_t clearColor, float clearDepth, uint8_t clearStencil);
 	VkImageView BindFramebufferAsTexture(VKRFramebuffer *fb, int binding, int aspectBit, int attachment);
 	bool CopyFramebufferToMemorySync(VKRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);
 	void CopyImageToMemorySync(VkImage image, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -186,7 +186,7 @@ public:
 	bool depthWriteEnabled;
 	GLuint depthComp;
 	// TODO: Two-sided
-	GLboolean stencilEnabled;
+	bool stencilEnabled;
 	GLuint stencilFail;
 	GLuint stencilZFail;
 	GLuint stencilPass;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1090,8 +1090,9 @@ void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const Render
 	OpenGLFramebuffer *fb = (OpenGLFramebuffer *)fbo;
 	GLRRenderPassAction color = (GLRRenderPassAction)rp.color;
 	GLRRenderPassAction depth = (GLRRenderPassAction)rp.depth;
+	GLRRenderPassAction stencil = (GLRRenderPassAction)rp.stencil;
 
-	renderManager_.BindFramebufferAsRenderTarget(fb ? fb->framebuffer : nullptr, color, depth, rp.clearColor, rp.clearDepth, rp.clearStencil);
+	renderManager_.BindFramebufferAsRenderTarget(fb ? fb->framebuffer : nullptr, color, depth, stencil, rp.clearColor, rp.clearDepth, rp.clearStencil);
 }
 
 void OpenGLContext::CopyFramebufferImage(Framebuffer *fbsrc, int srcLevel, int srcX, int srcY, int srcZ, Framebuffer *fbdst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits) {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1339,8 +1339,9 @@ void VKContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPass
 	VKFramebuffer *fb = (VKFramebuffer *)fbo;
 	VKRRenderPassAction color = (VKRRenderPassAction)rp.color;
 	VKRRenderPassAction depth = (VKRRenderPassAction)rp.depth;
+	VKRRenderPassAction stencil = (VKRRenderPassAction)rp.stencil;
 
-	renderManager_.BindFramebufferAsRenderTarget(fb ? fb->GetFB() : nullptr, color, depth, rp.clearColor, rp.clearDepth, rp.clearStencil);
+	renderManager_.BindFramebufferAsRenderTarget(fb ? fb->GetFB() : nullptr, color, depth, stencil, rp.clearColor, rp.clearDepth, rp.clearStencil);
 	curFramebuffer_ = fb;
 }
 


### PR DESCRIPTION
This makes Star Ocean work correctly (sans thorough testing) on GLES.  As a bonus, it also fixes stencil on Vulkan too (which kinda worked, but didn't clear properly, so got dirty when you scrolled.)

Also fixes Valkyria Chronicles 3, which wasn't playable at all without the fix.  Very possible other games, I've definitely seen stencil only clears in several effects.

-[Unknown]