### PR TITLE
Windows: Fix loading files with a long path.

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -404,18 +404,6 @@ namespace MainWindow {
 				Core_EnableStepping(false);
 			}
 
-			// TODO: What is this for / what does it fix?
-			if (browseDialog->GetType() != W32Util::AsyncBrowseDialog::DIR) {
-				// Decode the filename with fullpath.
-				char drive[MAX_PATH];
-				char dir[MAX_PATH];
-				char fname[MAX_PATH];
-				char ext[MAX_PATH];
-				_splitpath(filename.c_str(), drive, dir, fname, ext);
-
-				filename = std::string(drive) + std::string(dir) + std::string(fname) + std::string(ext);
-			}
-
 			filename = ReplaceAll(filename, "\\", "/");
 			NativeMessageReceived("boot", filename.c_str());
 		}


### PR DESCRIPTION
Better handling of a path which exceeds MAX_PATH when converted into UTF-8.

This fixes #10539.
It seems like the code block I removed does nothing but breaking the given paths.