### PR TITLE
Fix various issues with GLES on thread

### DIFF
--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -775,16 +775,18 @@ bool TextureCacheD3D11::DecodeTexture(u8 *output, const GPUgstate &state) {
 }
 
 bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
-	ApplyTexture();
 	SetTexture(false);
 	if (!nextTexture_)
 		return false;
 
+	// Apply texture may need to rebuild the texture if we're about to render, or bind a framebuffer.
+	TexCacheEntry *entry = nextTexture_;
+	ApplyTexture();
+
 	// TODO: Centralize.
-	if (nextTexture_->framebuffer) {
-		VirtualFramebuffer *vfb = nextTexture_->framebuffer;
-		bool flipY = GetGPUBackend() == GPUBackend::OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, flipY);
+	if (entry->framebuffer) {
+		VirtualFramebuffer *vfb = entry->framebuffer;
+		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
 		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth);
 		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
 		// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
@@ -794,7 +796,7 @@ bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level
 		return retval;
 	}
 
-	ID3D11Texture2D *texture = (ID3D11Texture2D *)nextTexture_->texturePtr;
+	ID3D11Texture2D *texture = (ID3D11Texture2D *)entry->texturePtr;
 	if (!texture)
 		return false;
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -172,18 +172,26 @@ void DrawEngineGLES::InitDeviceObjects() {
 }
 
 void DrawEngineGLES::DestroyDeviceObjects() {
+	// Beware: this could be called twice in a row, sometimes.
 	for (int i = 0; i < GLRenderManager::MAX_INFLIGHT_FRAMES; i++) {
+		if (!frameData_[i].pushVertex && !frameData_[i].pushIndex)
+			continue;
+
 		render_->UnregisterPushBuffer(i, frameData_[i].pushVertex);
 		render_->UnregisterPushBuffer(i, frameData_[i].pushIndex);
 		frameData_[i].pushVertex->Destroy();
 		frameData_[i].pushIndex->Destroy();
 		delete frameData_[i].pushVertex;
 		delete frameData_[i].pushIndex;
+		frameData_[i].pushVertex = nullptr;
+		frameData_[i].pushIndex = nullptr;
 	}
 
 	ClearTrackedVertexArrays();
 
-	render_->DeleteInputLayout(softwareInputLayout_);
+	if (softwareInputLayout_)
+		render_->DeleteInputLayout(softwareInputLayout_);
+	softwareInputLayout_ = nullptr;
 }
 
 void DrawEngineGLES::ClearInputLayoutMap() {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -784,16 +784,18 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 }
 
 bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
-	ApplyTexture();
 	SetTexture(false);
 	if (!nextTexture_)
 		return false;
 
+	// Apply texture may need to rebuild the texture if we're about to render, or bind a framebuffer.
+	TexCacheEntry *entry = nextTexture_;
+	ApplyTexture();
+
 	// TODO: Centralize?
-	if (nextTexture_->framebuffer) {
-		VirtualFramebuffer *vfb = nextTexture_->framebuffer;
-		bool flipY = GetGPUBackend() == GPUBackend::OPENGL && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, flipY);
+	if (entry->framebuffer) {
+		VirtualFramebuffer *vfb = entry->framebuffer;
+		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
 		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth);
 		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
 		// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
@@ -803,9 +805,9 @@ bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int leve
 		return retval;
 	}
 
-	if (!nextTexture_->vkTex || !nextTexture_->vkTex->texture_)
+	if (!entry->vkTex || !entry->vkTex->texture_)
 		return false;
-	VulkanTexture *texture = nextTexture_->vkTex->texture_;
+	VulkanTexture *texture = entry->vkTex->texture_;
 	VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 
 	GPUDebugBufferFormat bufferFormat;

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -105,9 +105,8 @@ void RenderThreadFunc() {
 	}
 
 	g_graphicsContext->ThreadStart();
-	while (emuThreadState != THREAD_SHUTDOWN) {
-		if (!g_graphicsContext->ThreadFrame())
-			break;
+	while (g_graphicsContext->ThreadFrame()) {
+		continue;
 	}
 	g_graphicsContext->ThreadEnd();
 	g_graphicsContext->ShutdownFromRenderThread();

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -386,6 +386,8 @@ void WindowsGLContext::SwapInterval(int interval) {
 }
 
 void WindowsGLContext::Shutdown() {
+	if (renderManager_)
+		renderManager_->StopThread();
 	glslang::FinalizeProcess();
 }
 

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -947,7 +947,28 @@ void GLQueueRunner::PerformReadback(const GLRStep &pass) {
 }
 
 void GLQueueRunner::PerformReadbackImage(const GLRStep &pass) {
+	GLRTexture *tex = pass.readback_image.texture;
 
+	glBindTexture(GL_TEXTURE_2D, tex->texture);
+
+	CHECK_GL_ERROR_IF_DEBUG();
+
+	int pixelStride = pass.readback_image.srcRect.w;
+	glPixelStorei(GL_PACK_ALIGNMENT, 4);
+
+	GLRect2D rect = pass.readback.srcRect;
+
+	int size = 4 * rect.w * rect.h;
+	if (size > readbackBufferSize_) {
+		delete[] readbackBuffer_;
+		readbackBuffer_ = new uint8_t[size];
+		readbackBufferSize_ = size;
+	}
+
+	glPixelStorei(GL_PACK_ALIGNMENT, 4);
+	glGetTexImage(GL_TEXTURE_2D, pass.readback_image.mipLevel, GL_RGBA, GL_UNSIGNED_BYTE, readbackBuffer_);
+
+	CHECK_GL_ERROR_IF_DEBUG();
 }
 
 void GLQueueRunner::PerformBindFramebufferAsRenderTarget(const GLRStep &pass) {

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -850,7 +850,7 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 	const GLOffset2D &dstPos = step.copy.dstPos;
 
 	GLRFramebuffer *src = step.copy.src;
-	GLRFramebuffer *dst = step.copy.src;
+	GLRFramebuffer *dst = step.copy.dst;
 
 	int srcLevel = 0;
 	int dstLevel = 0;

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -301,7 +301,7 @@ struct GLRStep {
 			Draw::DataFormat dstFormat;
 		} readback;
 		struct {
-			GLint texture;
+			GLRTexture *texture;
 			GLRect2D srcRect;
 			int mipLevel;
 		} readback_image;

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -313,7 +313,7 @@ public:
 	void BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRenderPassAction color, GLRRenderPassAction depth, GLRRenderPassAction stencil, uint32_t clearColor, float clearDepth, uint8_t clearStencil);
 	void BindFramebufferAsTexture(GLRFramebuffer *fb, int binding, int aspectBit, int attachment);
 	bool CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);
-	void CopyImageToMemorySync(GLuint texture, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);
+	void CopyImageToMemorySync(GLRTexture *texture, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride);
 
 	void CopyFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLRFramebuffer *dst, GLOffset2D dstPos, int aspectMask);
 	void BlitFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLRFramebuffer *dst, GLRect2D dstRect, int aspectMask, bool filter);


### PR DESCRIPTION
This has a few fixes:
 * Inter-buffer block transfers.
 * State not reset in a lot of cases.  I don't think it's better to put invalidation in every single place that calls these methods, but this is kinda ugly...
 * Texture preview in debugger.
 * GLES shutdown.

Also snuck in a few Vulkan fixes too.

God of War still has lighting issues, so it wasn't the state I guess.  But this fixes glitches in other games.

-[Unknown]