### PR TITLE
GLES: Bring back texture scaling and other removed features

### DIFF
--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -459,15 +459,6 @@ void FramebufferManagerD3D11::BindPostShader(const PostShaderUniforms &uniforms)
 	context_->PSSetConstantBuffers(0, 1, &postConstants_);
 }
 
-void FramebufferManagerD3D11::RebindFramebuffer() {
-	if (currentRenderVfb_ && currentRenderVfb_->fbo) {
-		draw_->BindFramebufferAsRenderTarget(currentRenderVfb_->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP });
-	} else {
-		// Should this even happen?
-		draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP });
-	}
-}
-
 void FramebufferManagerD3D11::ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old) {
 	if (!useBufferedRendering_ || !vfb->fbo) {
 		return;

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -58,7 +58,6 @@ public:
 	void BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags);
 
 	virtual bool NotifyStencilUpload(u32 addr, int size, bool skipZero = false) override;
-	void RebindFramebuffer();
 
 	// TODO: Remove
 	ID3D11Buffer *GetDynamicQuadBuffer() {

--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -139,10 +139,14 @@ DepalShader *DepalShaderCacheGLES::GetDepalettizeShader(uint32_t clutMode, GEBuf
 
 	auto shader = cache_.find(id);
 	if (shader != cache_.end()) {
+		DepalShader *depal = shader->second;
+		// If compile failed previously, try to recover.
+		if (depal->fragShader->failed || vertexShader_->failed)
+			return nullptr;
 		return shader->second;
 	}
 
-	if (vertexShader_ == 0) {
+	if (!vertexShader_) {
 		if (!CreateVertexShader()) {
 			// The vertex shader failed, no need to bother trying the fragment.
 			return nullptr;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -494,7 +494,7 @@ void FramebufferManagerGLES::BlitFramebufferDepth(VirtualFramebuffer *src, Virtu
 
 void FramebufferManagerGLES::BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags) {
 	if (!framebuffer->fbo || !useBufferedRendering_) {
-		render_->BindTexture(0, nullptr);
+		render_->BindTexture(stage, nullptr);
 		gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
 		return;
 	}

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -44,12 +44,11 @@
 #include "GPU/GLES/DrawEngineGLES.h"
 #include "FramebufferManagerGLES.h"
 
-Shader::Shader(GLRenderManager *render, const char *code, const char *desc, uint32_t glShaderType, bool useHWTransform, uint32_t attrMask, uint64_t uniformMask)
+Shader::Shader(GLRenderManager *render, const char *code, const std::string &desc, uint32_t glShaderType, bool useHWTransform, uint32_t attrMask, uint64_t uniformMask)
 	  : render_(render), failed_(false), useHWTransform_(useHWTransform), attrMask_(attrMask), uniformMask_(uniformMask) {
 	PROFILE_THIS_SCOPE("shadercomp");
 	isFragment_ = glShaderType == GL_FRAGMENT_SHADER;
 	source_ = code;
-	std::string descstr(desc);
 #ifdef SHADERLOG
 #ifdef _WIN32
 	OutputDebugStringUTF8(code);
@@ -57,7 +56,7 @@ Shader::Shader(GLRenderManager *render, const char *code, const char *desc, uint
 	printf("%s\n", code);
 #endif
 #endif
-	shader = render->CreateShader(glShaderType, source_, descstr);
+	shader = render->CreateShader(glShaderType, source_, desc);
 }
 
 Shader::~Shader() {
@@ -609,7 +608,7 @@ Shader *ShaderManagerGLES::CompileFragmentShader(FShaderID FSID) {
 		return nullptr;
 	}
 	std::string desc = FragmentShaderDesc(FSID);
-	return new Shader(render_, codeBuffer_, desc.c_str(), GL_FRAGMENT_SHADER, false, 0, uniformMask);
+	return new Shader(render_, codeBuffer_, desc, GL_FRAGMENT_SHADER, false, 0, uniformMask);
 }
 
 Shader *ShaderManagerGLES::CompileVertexShader(VShaderID VSID) {
@@ -618,7 +617,7 @@ Shader *ShaderManagerGLES::CompileVertexShader(VShaderID VSID) {
 	uint64_t uniformMask;
 	GenerateVertexShader(VSID, codeBuffer_, &attrMask, &uniformMask);
 	std::string desc = VertexShaderDesc(VSID);
-	return new Shader(render_, codeBuffer_, desc.c_str(), GL_VERTEX_SHADER, useHWTransform, attrMask, uniformMask);
+	return new Shader(render_, codeBuffer_, desc, GL_VERTEX_SHADER, useHWTransform, attrMask, uniformMask);
 }
 
 Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, VShaderID *VSID) {
@@ -668,7 +667,7 @@ Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, VShaderID *
 			uint32_t attrMask;
 			uint64_t uniformMask;
 			GenerateVertexShader(vsidTemp, codeBuffer_, &attrMask, &uniformMask);
-			vs = new Shader(render_, codeBuffer_, VertexShaderDesc(vsidTemp).c_str(), GL_VERTEX_SHADER, false, attrMask, uniformMask);
+			vs = new Shader(render_, codeBuffer_, VertexShaderDesc(vsidTemp), GL_VERTEX_SHADER, false, attrMask, uniformMask);
 		}
 
 		vsCache_.Insert(*VSID, vs);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -179,7 +179,6 @@ LinkedShader::LinkedShader(GLRenderManager *render, VShaderID VSID, Shader *vs, 
 
 	// The rest, use the "dirty" mechanism.
 	dirtyUniforms = DIRTY_ALL_UNIFORMS;
-	CHECK_GL_ERROR_IF_DEBUG();
 }
 
 LinkedShader::~LinkedShader() {

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -125,7 +125,7 @@ public:
 
 class Shader {
 public:
-	Shader(GLRenderManager *render, const char *code, const char *desc, uint32_t glShaderType, bool useHWTransform, uint32_t attrMask, uint64_t uniformMask);
+	Shader(GLRenderManager *render, const char *code, const std::string &desc, uint32_t glShaderType, bool useHWTransform, uint32_t attrMask, uint64_t uniformMask);
 	~Shader();
 	GLRShader *shader;
 

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -316,6 +316,7 @@ void DrawEngineGLES::ApplyDrawStateLate(bool setStencil, int stencilValue) {
 	if (!gstate.isModeClear()) {
 		if (fboTexNeedBind_) {
 			// Note that this is positions, not UVs, that we need the copy from.
+			// TODO: If the device doesn't support blit, this will corrupt the currently applied texture.
 			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
 			framebufferManager_->RebindFramebuffer();
 			GLRenderManager *renderManager = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -318,6 +318,9 @@ void DrawEngineGLES::ApplyDrawStateLate(bool setStencil, int stencilValue) {
 			// Note that this is positions, not UVs, that we need the copy from.
 			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
 			framebufferManager_->RebindFramebuffer();
+			GLRenderManager *renderManager = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+			// If we are rendering at a higher resolution, linear is probably best for the dest color.
+			renderManager->SetTextureSampler(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR, 0.0f);
 			fboTexBound_ = true;
 			fboTexNeedBind_ = false;
 		}

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -771,9 +771,12 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
 		}
 
-		// TODO: Scale's buffer management doesn't work.
-		//if (scaleFactor > 1)
-		//	scaler.Scale((uint32_t *)pixelData, dstFmt, w, h, scaleFactor);
+		if (scaleFactor > 1) {
+			uint8_t *rearrange = new uint8_t[w * scaleFactor * h * scaleFactor * 4];
+			scaler.ScaleAlways((u32 *)rearrange, (u32 *)pixelData, dstFmt, w, h, scaleFactor);
+			pixelData = rearrange;
+			delete [] finalBuf;
+		}
 
 		if (replacer_.Enabled()) {
 			ReplacedTextureDecodeInfo replacedInfo;

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -156,10 +156,10 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				ELOG("Error in shader compilation! %s\n", infoLog);
 				ELOG("Shader source:\n%s\n", (const char *)code);
 #endif
-				ERROR_LOG(G3D, "Error in shader compilation for: %s", step.create_shader.desc);
+				ERROR_LOG(G3D, "Error in shader compilation for: %s", step.create_shader.shader->desc.c_str());
 				ERROR_LOG(G3D, "Info log: %s", infoLog);
 				ERROR_LOG(G3D, "Shader source:\n%s\n", (const char *)code);
-				Reporting::ReportMessage("Error in shader compilation: info: %s\n%s\n%s", infoLog, step.create_shader.desc, (const char *)code);
+				Reporting::ReportMessage("Error in shader compilation: info: %s\n%s\n%s", infoLog, step.create_shader.shader->desc.c_str(), (const char *)code);
 #ifdef SHADERLOG
 				OutputDebugStringUTF8(infoLog);
 #endif
@@ -167,7 +167,6 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				step.create_shader.shader->failed = true;
 			}
 			delete[] step.create_shader.code;
-			delete[] step.create_shader.desc;
 			step.create_shader.shader->valid = true;
 			break;
 		}

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -101,12 +101,27 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				GLint bufLength = 0;
 				glGetProgramiv(program->program, GL_INFO_LOG_LENGTH, &bufLength);
 				if (bufLength) {
-					char* buf = new char[bufLength];
-					glGetProgramInfoLog(program->program, bufLength, NULL, buf);
+					char *buf = new char[bufLength];
+					glGetProgramInfoLog(program->program, bufLength, nullptr, buf);
+
+					// TODO: Could be other than vs/fs.  Also, we're assuming order here...
+					const char *vsDesc = step.create_program.shaders[0]->desc.c_str();
+					const char *fsDesc = step.create_program.num_shaders > 1 ? step.create_program.shaders[1]->desc.c_str() : nullptr;
+					const char *vsCode = step.create_program.shaders[0]->code.c_str();
+					const char *fsCode = step.create_program.num_shaders > 1 ? step.create_program.shaders[1]->code.c_str() : nullptr;
+					Reporting::ReportMessage("Error in shader program link: info: %s\nfs: %s\n%s\nvs: %s\n%s", buf, fsDesc, fsCode, vsDesc, vsCode);
+
 					ELOG("Could not link program:\n %s", buf);
-					// We've thrown out the source at this point. Might want to do something about that.
+					ERROR_LOG(G3D, "VS desc:\n%s", vsDesc);
+					ERROR_LOG(G3D, "FS desc:\n%s", fsDesc);
+					ERROR_LOG(G3D, "VS:\n%s\n", vsCode);
+					ERROR_LOG(G3D, "FS:\n%s\n", fsCode);
+
 #ifdef _WIN32
 					OutputDebugStringUTF8(buf);
+					OutputDebugStringUTF8(vsCode);
+					if (fsCode)
+						OutputDebugStringUTF8(fsCode);
 #endif
 					delete[] buf;
 				} else {
@@ -166,6 +181,8 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				step.create_shader.shader->valid = false;
 				step.create_shader.shader->failed = true;
 			}
+			// Before we throw away the code, attach it to the shader for debugging.
+			step.create_shader.shader->code = code;
 			delete[] step.create_shader.code;
 			step.create_shader.shader->valid = true;
 			break;

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -1056,8 +1056,8 @@ void GLQueueRunner::fbo_ext_create(const GLRInitStep &step) {
 	fbo->color_texture.target = GL_TEXTURE_2D;
 	fbo->color_texture.wrapS = GL_CLAMP_TO_EDGE;
 	fbo->color_texture.wrapT = GL_CLAMP_TO_EDGE;
-	fbo->color_texture.magFilter = step.texture_image.linearFilter ? GL_LINEAR : GL_NEAREST;
-	fbo->color_texture.minFilter = step.texture_image.linearFilter ? GL_LINEAR : GL_NEAREST;
+	fbo->color_texture.magFilter = GL_LINEAR;
+	fbo->color_texture.minFilter = GL_LINEAR;
 	fbo->color_texture.maxLod = 0.0f;
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, fbo->color_texture.wrapS);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, fbo->color_texture.wrapT);

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -164,6 +164,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				OutputDebugStringUTF8(infoLog);
 #endif
 				step.create_shader.shader->valid = false;
+				step.create_shader.shader->failed = true;
 			}
 			delete[] step.create_shader.code;
 			delete[] step.create_shader.desc;

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -199,9 +199,8 @@ struct GLRInitStep {
 		} create_texture;
 		struct {
 			GLRShader *shader;
-			// These char arrays need to be allocated with new[].
+			// This char arrays needs to be allocated with new[].
 			char *code;
-			char *desc;  // For error logging.
 			GLuint stage;
 		} create_shader;
 		struct {

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -328,6 +328,10 @@ public:
 		targetWidth_ = width;
 		targetHeight_ = height;
 	}
+
+	bool SawOutOfMemory() {
+		return sawOutOfMemory_;
+	}
 private:
 	void InitCreateFramebuffer(const GLRInitStep &step);
 
@@ -374,4 +378,6 @@ private:
 	GLuint AllocTextureName();
 	// Texture name cache. Ripped straight from TextureCacheGLES.
 	std::vector<GLuint> nameCache_;
+
+	bool sawOutOfMemory_ = false;
 };

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -76,6 +76,7 @@ public:
 	// Warning: Won't know until a future frame.
 	bool failed = false;
 	std::string desc;
+	std::string code;
 };
 
 class GLRProgram {

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -75,6 +75,7 @@ public:
 	bool valid = false;
 	// Warning: Won't know until a future frame.
 	bool failed = false;
+	std::string desc;
 };
 
 class GLRProgram {
@@ -227,16 +228,13 @@ public:
 		return step.create_buffer.buffer;
 	}
 
-	GLRShader *CreateShader(GLuint stage, std::string code, std::string desc) {
+	GLRShader *CreateShader(GLuint stage, const std::string &code, const std::string &desc) {
 		GLRInitStep step{ GLRInitStepType::CREATE_SHADER };
 		step.create_shader.shader = new GLRShader();
+		step.create_shader.shader->desc = desc;
 		step.create_shader.stage = stage;
 		step.create_shader.code = new char[code.size() + 1];
 		memcpy(step.create_shader.code, code.data(), code.size() + 1);
-		if (!desc.empty()) {
-			step.create_shader.desc = desc.size() ? new char[desc.size() + 1] : nullptr;
-			memcpy(step.create_shader.desc, desc.data(), desc.size() + 1);
-		}
 		initSteps_.push_back(step);
 		return step.create_shader.shader;
 	}

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -73,6 +73,8 @@ public:
 	}
 	GLuint shader = 0;
 	bool valid = false;
+	// Warning: Won't know until a future frame.
+	bool failed = false;
 };
 
 class GLRProgram {

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -653,6 +653,10 @@ public:
 
 	void StopThread();
 
+	bool SawOutOfMemory() {
+		return queueRunner_.SawOutOfMemory();
+	}
+
 private:
 	void BeginSubmitFrame(int frame);
 	void EndSubmitFrame(int frame);


### PR DESCRIPTION
This brings back texture scaling, by just always scaling (it little less optimal than before.)

The OOM check also returns, but only one glGetError() per frame, after init commands.  Since we create all textures in one go, we may handle crashes better this way... maybe.  There was no noticeable performance impact for me, but we could try KHR_no_error to explicitly allow for async OOM reporting.

Added code and desc to GLRShader to allow for reporting of program link failures.

Didn't fix the issue with shader blending on older devices, but at least added a TODO about it.

-[Unknown]