### PR TITLE
Fix shader blending issues

### DIFF
--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -462,4 +462,8 @@ void DrawEngineD3D11::ApplyDrawStateLate(bool applyStencilRef, uint8_t stencilRe
 		context_->OMSetDepthStencilState(depthStencilState_, applyStencilRef ? stencilRef : dynState_.stencilRef);
 	}
 	gstate_c.Clean(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_BLEND_STATE);
+
+	// Must dirty blend state here so we re-copy next time.  Example: Lunar's spell effects.
+	if (fboTexBound_)
+		gstate_c.Dirty(DIRTY_BLEND_STATE);
 }

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -847,6 +847,10 @@ void DrawEngineVulkan::DoFlush() {
 			ApplyDrawStateLate(renderManager, false, 0, pipeline->useBlendConstant);
 			gstate_c.Clean(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE);
 			lastPipeline_ = pipeline;
+
+			// Must dirty blend state here so we re-copy next time.  Example: Lunar's spell effects.
+			if (fboTexBound_)
+				gstate_c.Dirty(DIRTY_BLEND_STATE);
 		}
 		lastPrim_ = prim;
 
@@ -947,6 +951,10 @@ void DrawEngineVulkan::DoFlush() {
 				ApplyDrawStateLate(renderManager, result.setStencil, result.stencilValue, pipeline->useBlendConstant);
 				gstate_c.Clean(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE);
 				lastPipeline_ = pipeline;
+
+				// Must dirty blend state here so we re-copy next time.  Example: Lunar's spell effects.
+				if (fboTexBound_)
+					gstate_c.Dirty(DIRTY_BLEND_STATE);
 			}
 			lastPrim_ = prim;
 


### PR DESCRIPTION
This fixes Lunar's healing effect, for example.  I double checked that I wasn't crazy about it being wrong for the other backends (it looked weird but potentially intentional.)

GLES threading made it pretty ugly (because of flags reset on each step), but it was a bit off before ever since the state checking optimizations.

Here's a reference YouTube for any who want to verify the correct effect (it's using double dest alpha blending):
https://youtu.be/yYxd-qxDdwo?t=7m40s

-[Unknown]