### PR TITLE
use GLRenderManager on iOS

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -47,20 +47,20 @@ public:
 	Draw::DrawContext *GetDrawContext() override {
 		return draw_;
 	}
-    void ThreadStart() override {
-        renderManager_->ThreadStart();
-    }
-    
-    bool ThreadFrame() override {
-        return renderManager_->ThreadFrame();
-    }
-    
-    void ThreadEnd() override {
-        renderManager_->ThreadEnd();
-    }
+	void ThreadStart() override {
+		renderManager_->ThreadStart();
+	}
+
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
+	}
+
+	void ThreadEnd() override {
+		renderManager_->ThreadEnd();
+	}
 private:
 	Draw::DrawContext *draw_;
-    GLRenderManager *renderManager_;
+	GLRenderManager *renderManager_;
 };
 
 static float dp_xscale = 1.0f;
@@ -169,7 +169,7 @@ static GraphicsContext *graphicsContext;
 	pixel_in_dps_y = (float)pixel_yres / (float)dp_yres;
 
 	graphicsContext = new IOSGraphicsContext();
-    
+	
 	NativeInitGraphics(graphicsContext);
     graphicsContext->ThreadStart();
 
@@ -188,14 +188,14 @@ static GraphicsContext *graphicsContext;
 		}
 	}
 #endif
-   
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-        while (threadEnabled) {
-            NativeUpdate();
-            NativeRender(graphicsContext);
-            time_update();
-        }
-    });
+	
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+		while (threadEnabled) {
+			NativeUpdate();
+			NativeRender(graphicsContext);
+			time_update();
+		}
+	});
 }
 
 - (void)didReceiveMemoryWarning
@@ -219,8 +219,8 @@ static GraphicsContext *graphicsContext;
 		self.gameController = nil;
 	}
 #endif
-    threadEnabled = false;
-    graphicsContext->ThreadEnd();
+	threadEnabled = false;
+	graphicsContext->ThreadEnd();
 	NativeShutdownGraphics();
 	graphicsContext->Shutdown();
 	delete graphicsContext;
@@ -242,7 +242,7 @@ static GraphicsContext *graphicsContext;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-    graphicsContext->ThreadFrame();
+	graphicsContext->ThreadFrame();
 }
 
 - (void)touchX:(float)x y:(float)y code:(int)code pointerId:(int)pointerId

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -171,7 +171,7 @@ static GraphicsContext *graphicsContext;
 	graphicsContext = new IOSGraphicsContext();
 	
 	NativeInitGraphics(graphicsContext);
-    graphicsContext->ThreadStart();
+	graphicsContext->ThreadStart();
 
 	dp_xscale = (float)dp_xres / (float)pixel_xres;
 	dp_yscale = (float)dp_yres / (float)pixel_yres;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -219,6 +219,7 @@ static GraphicsContext *graphicsContext;
 		self.gameController = nil;
 	}
 #endif
+    threadEnabled = false;
     graphicsContext->ThreadEnd();
 	NativeShutdownGraphics();
 	graphicsContext->Shutdown();

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -36,7 +36,7 @@ public:
 	IOSGraphicsContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
-        renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+		renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -16,6 +16,7 @@
 #include "net/resolve.h"
 #include "ui/screen.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/GLRenderManager.h"
 #include "input/keycodes.h"
 #include "gfx_es2/gpu_features.h"
 
@@ -30,23 +31,36 @@
 #define IS_IPAD() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #define IS_IPHONE() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 
-class IOSDummyGraphicsContext : public DummyGraphicsContext {
+class IOSGraphicsContext : public DummyGraphicsContext {
 public:
-	IOSDummyGraphicsContext() {
+	IOSGraphicsContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext();
+        renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}
-	~IOSDummyGraphicsContext() {
+	~IOSGraphicsContext() {
 		delete draw_;
 	}
 	Draw::DrawContext *GetDrawContext() override {
 		return draw_;
 	}
+    void ThreadStart() override {
+        renderManager_->ThreadStart();
+    }
+    
+    bool ThreadFrame() override {
+        return renderManager_->ThreadFrame();
+    }
+    
+    void ThreadEnd() override {
+        renderManager_->ThreadEnd();
+    }
 private:
 	Draw::DrawContext *draw_;
+    GLRenderManager *renderManager_;
 };
 
 static float dp_xscale = 1.0f;
@@ -55,6 +69,7 @@ static float dp_yscale = 1.0f;
 static double lastSelectPress = 0.0f;
 static double lastStartPress = 0.0f;
 static bool simulateAnalog = false;
+static bool threadEnabled = true;
 
 __unsafe_unretained static ViewController* sharedViewController;
 static GraphicsContext *graphicsContext;
@@ -153,9 +168,10 @@ static GraphicsContext *graphicsContext;
 	pixel_in_dps_x = (float)pixel_xres / (float)dp_xres;
 	pixel_in_dps_y = (float)pixel_yres / (float)dp_yres;
 
-	graphicsContext = new IOSDummyGraphicsContext();
-
+	graphicsContext = new IOSGraphicsContext();
+    
 	NativeInitGraphics(graphicsContext);
+    graphicsContext->ThreadStart();
 
 	dp_xscale = (float)dp_xres / (float)pixel_xres;
 	dp_yscale = (float)dp_yres / (float)pixel_yres;
@@ -172,6 +188,14 @@ static GraphicsContext *graphicsContext;
 		}
 	}
 #endif
+   
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        while (threadEnabled) {
+            NativeUpdate();
+            NativeRender(graphicsContext);
+            time_update();
+        }
+    });
 }
 
 - (void)didReceiveMemoryWarning
@@ -195,6 +219,7 @@ static GraphicsContext *graphicsContext;
 		self.gameController = nil;
 	}
 #endif
+    graphicsContext->ThreadEnd();
 	NativeShutdownGraphics();
 	graphicsContext->Shutdown();
 	delete graphicsContext;
@@ -216,9 +241,7 @@ static GraphicsContext *graphicsContext;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-	NativeUpdate();
-	NativeRender(graphicsContext);
-	time_update();
+    graphicsContext->ThreadFrame();
 }
 
 - (void)touchX:(float)x y:(float)y code:(int)code pointerId:(int)pointerId


### PR DESCRIPTION
A quick test in Final Fantasy 4 on an iPhone 6 showed an increase in fast-forward emulation speed from 530% to 770%, woohoo!

This also seems to improve audio quality - it's smooth with only occasional "micro-stutter".