### PR TITLE
Fix yet more shutdown shenanigans

### DIFF
--- a/Common/GraphicsContext.h
+++ b/Common/GraphicsContext.h
@@ -32,6 +32,7 @@ public:
 	virtual void ThreadStart() {}
 	virtual bool ThreadFrame() { return true; }
 	virtual void ThreadEnd() {}
+	virtual void StopThread() {}
 
 	virtual Draw::DrawContext *GetDrawContext() = 0;
 };

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -208,6 +208,7 @@ void MainUI::EmuThreadFunc() {
 	emuThreadState = (int)EmuThreadState::STOPPED;
 
 	NativeShutdownGraphics();
+	graphicsContext->StopThread();
 }
 
 void MainUI::EmuThreadStart() {

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -82,6 +82,11 @@ public:
 		renderManager_->ThreadEnd();
 	}
 
+	void StopThread() override {
+		renderManager_->WaitUntilQueueIdle();
+		renderManager_->StopThread();
+	}
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	GLRenderManager *renderManager_ = nullptr;

--- a/SDL/SDLGLGraphicsContext.h
+++ b/SDL/SDLGLGraphicsContext.h
@@ -38,6 +38,11 @@ public:
 		renderManager_->ThreadEnd();
 	}
 
+	void StopThread() override {
+		renderManager_->WaitUntilQueueIdle();
+		renderManager_->StopThread();
+	}
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	SDL_Window *window_;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -423,6 +423,7 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext) {
 	emuThreadState = (int)EmuThreadState::STOPPED;
 
 	NativeShutdownGraphics();
+	graphicsContext->StopThread();
 }
 
 static void EmuThreadStart(GraphicsContext *context) {

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -234,6 +234,10 @@ void MainThreadFunc() {
 		}
 	}
 	Core_Stop();
+	if (!useEmuThread) {
+		// Process the shutdown.  Without this, non-GL delays 800ms on shutdown.
+		Core_Run(g_graphicsContext);
+	}
 	Core_WaitInactive(800);
 
 	g_inLoop = false;

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -86,6 +86,9 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext) {
 	emuThreadState = (int)EmuThreadState::STOPPED;
 
 	NativeShutdownGraphics();
+
+	// Ask the main thread to stop.  This prevents a hang on a race condition.
+	graphicsContext->StopThread();
 }
 
 static void EmuThreadStart(GraphicsContext *graphicsContext) {

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -432,3 +432,8 @@ bool WindowsGLContext::ThreadFrame() {
 void WindowsGLContext::ThreadEnd() {
 	renderManager_->ThreadEnd();
 }
+
+void WindowsGLContext::StopThread() {
+	renderManager_->WaitUntilQueueIdle();
+	renderManager_->StopThread();
+}

--- a/Windows/GPU/WindowsGLContext.h
+++ b/Windows/GPU/WindowsGLContext.h
@@ -29,6 +29,7 @@ public:
 	void ThreadStart() override;
 	void ThreadEnd() override;
 	bool ThreadFrame() override;
+	void StopThread() override;
 
 	Draw::DrawContext *GetDrawContext() override { return draw_; }
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -915,7 +915,7 @@ namespace MainWindow
 			MainThread_Stop();
 			coreState = CORE_POWERUP;
 			ResetUIState();
-			MainThread_Start(false);
+			MainThread_Start(g_Config.iGPUBackend == (int)GPUBackend::OPENGL);
 			InputDevice::BeginPolling();
 			break;
 

--- a/android/jni/AndroidJavaGLContext.cpp
+++ b/android/jni/AndroidJavaGLContext.cpp
@@ -27,5 +27,4 @@ void AndroidJavaEGLGraphicsContext::ShutdownFromRenderThread() {
 }
 
 void AndroidJavaEGLGraphicsContext::Shutdown() {
-	// TODO
 }

--- a/android/jni/AndroidJavaGLContext.h
+++ b/android/jni/AndroidJavaGLContext.h
@@ -44,6 +44,11 @@ public:
 		renderManager_->ThreadEnd();
 	}
 
+	void StopThread() override {
+		renderManager_->WaitUntilQueueIdle();
+		renderManager_->StopThread();
+	}
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	GLRenderManager *renderManager_ = nullptr;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -196,6 +196,9 @@ static void EmuThreadFunc() {
 
 	NativeShutdownGraphics();
 
+	// Also ask the main thread to stop, so it doesn't hang waiting for a new frame.
+	graphicsContext->StopThread();
+
 	gJvm->DetachCurrentThread();
 	ILOG("Leaving emu thread");
 }

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -735,7 +735,7 @@ bool OpenGLContext::CopyFramebufferToMemorySync(Framebuffer *src, int channelBit
 		aspect |= GL_DEPTH_BUFFER_BIT;
 	if (channelBits & FB_STENCIL_BIT)
 		aspect |= GL_STENCIL_BUFFER_BIT;
-	renderManager_.CopyFramebufferToMemorySync(fb->framebuffer, aspect, x, y, w, h, dataFormat, (uint8_t *)pixels, pixelStride);
+	renderManager_.CopyFramebufferToMemorySync(fb ? fb->framebuffer : nullptr, aspect, x, y, w, h, dataFormat, (uint8_t *)pixels, pixelStride);
 	return true;
 }
 


### PR DESCRIPTION
The issue is, recently we started running `ThreadFrame()` while waiting for the EmuThread to stop.

However, if EmuThread stops at the wrong time, there won't be any frame queued and `ThreadFrame()` will sit in a cond var waiting for one.  Meanwhile, `emuThreadState` will move to STOPPED and we'll just lock up.

This fixes that by actually calling `StopThread()` (it was never even being called before) from EmuThread after it's all done shutting down.  To be safe, it also waits for all queued items to be processed beforehand.

Also fixes the crash in #10572, but not the fact that screenshots no longer work...

-[Unknown]