### PR TITLE
GLES: Use mapped device memory when possible

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -30,10 +30,11 @@ void hleCheat(u64 userdata, int cyclesLate);
 
 static inline std::string TrimString(const std::string &s) {
 	auto wsfront = std::find_if_not(s.begin(), s.end(), [](int c) {
-	   return std::isspace(c);
+		// isspace() expects 0 - 255, so convert any sign-extended value.
+	   return std::isspace(c & 0xFF);
    });
    auto wsback = std::find_if_not(s.rbegin(), s.rend(), [](int c){
-	   return std::isspace(c);
+	   return std::isspace(c & 0xFF);
    }).base();
    return wsback > wsfront ? std::string(wsfront, wsback) : std::string();
 }

--- a/ext/native/gfx_es2/gl3stub.c
+++ b/ext/native/gfx_es2/gl3stub.c
@@ -135,6 +135,9 @@ GLboolean gl3stubInit() {
     FIND_PROC(glGetProgramResourceLocationIndexEXT);
     FIND_PROC(glGetFragDataIndexEXT);
 
+    /* EXT_buffer_storage */
+    FIND_PROC(glBufferStorageEXT);
+
     /* OES_copy_image, etc. */
     FIND_PROC(glCopyImageSubDataOES);
 
@@ -365,6 +368,9 @@ GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationIndexedEXT) (GLui
 GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationEXT) (GLuint program, GLuint color, const GLchar *name);
 GL_APICALL GLint          (* GL_APIENTRY glGetProgramResourceLocationIndexEXT) (GLuint program, GLenum programInterface, const GLchar *name);
 GL_APICALL GLint          (* GL_APIENTRY glGetFragDataIndexEXT) (GLuint program, const GLchar *name);
+
+/* EXT_buffer_storage */
+GL_APICALL void           (* GL_APIENTRY glBufferStorageEXT) (GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
 
 /* OES_copy_image, etc. */
 GL_APICALL void           (* GL_APIENTRY glCopyImageSubDataOES) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei width, GLsizei height, GLsizei depth);

--- a/ext/native/gfx_es2/gl3stub.h
+++ b/ext/native/gfx_es2/gl3stub.h
@@ -260,6 +260,10 @@ typedef struct __GLsync *GLsync;
 #define GL_MAP_INVALIDATE_BUFFER_BIT                     0x0008
 #define GL_MAP_FLUSH_EXPLICIT_BIT                        0x0010
 #define GL_MAP_UNSYNCHRONIZED_BIT                        0x0020
+#define GL_MAP_PERSISTENT_BIT_EXT                        0x0040
+#define GL_MAP_COHERENT_BIT_EXT                          0x0080
+#define GL_DYNAMIC_STORAGE_BIT_EXT                       0x0100
+#define GL_CLIENT_STORAGE_BIT_EXT                        0x0200
 #define GL_RG                                            0x8227
 #define GL_RG_INTEGER                                    0x8228
 #define GL_R8                                            0x8229
@@ -500,9 +504,12 @@ extern GL_APICALL void           (* GL_APIENTRY glBindFragDataLocationEXT) (GLui
 extern GL_APICALL GLint          (* GL_APIENTRY glGetProgramResourceLocationIndexEXT) (GLuint program, GLenum programInterface, const GLchar *name);
 extern GL_APICALL GLint          (* GL_APIENTRY glGetFragDataIndexEXT) (GLuint program, const GLchar *name);
 
+/* EXT_buffer_storage */
+extern GL_APICALL void           (* GL_APIENTRY glBufferStorageEXT) (GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
+
 /* OES_copy_image, etc. */
 extern GL_APICALL void           (* GL_APIENTRY glCopyImageSubDataOES) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei width, GLsizei height, GLsizei depth);
-    
+
 #endif   // IOS
 
 #ifdef __cplusplus

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -299,6 +299,7 @@ void CheckGLExtensions() {
 	gl_extensions.OES_copy_image = strstr(extString, "GL_OES_copy_image") != 0;
 	gl_extensions.EXT_copy_image = strstr(extString, "GL_EXT_copy_image") != 0;
 	gl_extensions.ARB_copy_image = strstr(extString, "GL_ARB_copy_image") != 0;
+	gl_extensions.ARB_buffer_storage = strstr(extString, "GL_ARB_buffer_storage") != 0;
 	gl_extensions.ARB_vertex_array_object = strstr(extString, "GL_ARB_vertex_array_object") != 0;
 	gl_extensions.ARB_texture_float = strstr(extString, "GL_ARB_texture_float") != 0;
 	gl_extensions.EXT_texture_filter_anisotropic = strstr(extString, "GL_EXT_texture_filter_anisotropic") != 0;
@@ -317,6 +318,7 @@ void CheckGLExtensions() {
 		gl_extensions.NV_shader_framebuffer_fetch = strstr(extString, "GL_NV_shader_framebuffer_fetch") != 0;
 		gl_extensions.ARM_shader_framebuffer_fetch = strstr(extString, "GL_ARM_shader_framebuffer_fetch") != 0;
 		gl_extensions.OES_texture_float = strstr(extString, "GL_OES_texture_float") != 0;
+		gl_extensions.EXT_buffer_storage = strstr(extString, "GL_EXT_buffer_storage") != 0;
 
 #if defined(__ANDROID__)
 		// On Android, incredibly, this is not consistently non-zero! It does seem to have the same value though.
@@ -458,7 +460,7 @@ void CheckGLExtensions() {
 			// ARB_vertex_attrib_binding = true;
 		}
 		if (gl_extensions.VersionGEThan(4, 4)) {
-			// ARB_buffer_storage = true;
+			gl_extensions.ARB_buffer_storage = true;
 		}
 	}
 

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -61,6 +61,7 @@ struct GLExtensions {
 	bool ARB_vertex_array_object;
 	bool ARB_texture_float;
 	bool ARB_draw_instanced;
+	bool ARB_buffer_storage;
 
 	// EXT
 	bool EXT_swap_control_tear;
@@ -75,6 +76,7 @@ struct GLExtensions {
 	bool EXT_texture_filter_anisotropic;
 	bool PBO_EXT;
 	bool EXT_draw_instanced;
+	bool EXT_buffer_storage;
 
 	// NV
 	bool NV_shader_framebuffer_fetch;

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -770,6 +770,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 			// TODO: Add fast path for glBindVertexBuffer
 			GLRInputLayout *layout = c.bindVertexBuffer.inputLayout;
 			GLuint buf = c.bindVertexBuffer.buffer ? c.bindVertexBuffer.buffer->buffer : 0;
+			assert(!c.bindVertexBuffer.buffer->Mapped());
 			if (buf != curArrayBuffer) {
 				glBindBuffer(GL_ARRAY_BUFFER, buf);
 				curArrayBuffer = buf;
@@ -797,12 +798,14 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 				Crash();
 			} else if (c.bind_buffer.target == GL_ELEMENT_ARRAY_BUFFER) {
 				GLuint buf = c.bind_buffer.buffer ? c.bind_buffer.buffer->buffer : 0;
+				assert(!c.bind_buffer.buffer->Mapped());
 				if (buf != curElemArrayBuffer) {
 					glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buf);
 					curElemArrayBuffer = buf;
 				}
 			} else {
 				GLuint buf = c.bind_buffer.buffer ? c.bind_buffer.buffer->buffer : 0;
+				assert(!c.bind_buffer.buffer->Mapped());
 				glBindBuffer(c.bind_buffer.target, buf);
 			}
 			break;

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -701,6 +701,7 @@ void *GLRBuffer::Map(GLbitfield access) {
 
 	void *p = nullptr;
 	if (gl_extensions.ARB_buffer_storage || gl_extensions.EXT_buffer_storage) {
+#ifndef IOS
 		if (!hasStorage_) {
 #ifdef USING_GLES2
 			glBufferStorageEXT(target_, size_, nullptr, access & (GL_MAP_READ_BIT | GL_MAP_WRITE_BIT));
@@ -709,6 +710,7 @@ void *GLRBuffer::Map(GLbitfield access) {
 #endif
 			hasStorage_ = true;
 		}
+#endif
 		p = glMapBufferRange(target_, 0, size_, access);
 	} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
 		// GLES3 or desktop 3.

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -668,7 +668,7 @@ void GLPushBuffer::MapDevice() {
 
 		assert(!info.deviceMemory);
 		// TODO: Can we use GL_WRITE_ONLY?
-		info.deviceMemory = (uint8_t *)info.buffer->Map(GL_READ_WRITE, GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
+		info.deviceMemory = (uint8_t *)info.buffer->Map(GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 
 		if (!info.deviceMemory && !info.localMemory) {
 			// Somehow it failed, let's dodge crashing.
@@ -695,7 +695,7 @@ void GLPushBuffer::UnmapDevice() {
 	}
 }
 
-void *GLRBuffer::Map(GLenum accessOld, GLbitfield accessNew) {
+void *GLRBuffer::Map(GLbitfield access) {
 	assert(buffer != 0);
 	glBindBuffer(target_, buffer);
 
@@ -703,19 +703,19 @@ void *GLRBuffer::Map(GLenum accessOld, GLbitfield accessNew) {
 	if (gl_extensions.ARB_buffer_storage || gl_extensions.EXT_buffer_storage) {
 		if (!hasStorage_) {
 #ifdef USING_GLES2
-			glBufferStorageEXT(target_, size_, nullptr, GL_MAP_WRITE_BIT);
+			glBufferStorageEXT(target_, size_, nullptr, access & (GL_MAP_READ_BIT | GL_MAP_WRITE_BIT));
 #else
-			glBufferStorage(target_, size_, nullptr, GL_MAP_WRITE_BIT);
+			glBufferStorage(target_, size_, nullptr, access & (GL_MAP_READ_BIT | GL_MAP_WRITE_BIT));
 #endif
 			hasStorage_ = true;
 		}
-		p = glMapBufferRange(target_, 0, size_, accessNew);
+		p = glMapBufferRange(target_, 0, size_, access);
 	} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
 		// GLES3 or desktop 3.
-		p = glMapBufferRange(target_, 0, size_, accessNew);
+		p = glMapBufferRange(target_, 0, size_, access);
 	} else {
 #ifndef USING_GLES2
-		p = glMapBuffer(target_, accessOld);
+		p = glMapBuffer(target_, GL_READ_WRITE);
 #endif
 	}
 

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -152,6 +152,7 @@ public:
 
 private:
 	bool mapped_ = false;
+	bool hasStorage_ = false;
 };
 
 enum class GLRRunType {
@@ -760,6 +761,7 @@ public:
 		GLRBuffer *buffer = nullptr;
 		uint8_t *localMemory = nullptr;
 		uint8_t *deviceMemory = nullptr;
+		size_t flushOffset = 0;
 	};
 
 public:

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -139,18 +139,8 @@ public:
 		}
 	}
 
-	void *Map(GLenum access) {
-		glBindBuffer(target_, buffer);
-		void *p = glMapBuffer(target_, access);
-		mapped_ = p != nullptr;
-		return p;
-	}
-
-	bool Unmap() {
-		glBindBuffer(target_, buffer);
-		mapped_ = false;
-		return glUnmapBuffer(target_) == GL_TRUE;
-	}
+	void *Map(GLenum accessOld, GLbitfield accessNew);
+	bool Unmap();
 
 	bool Mapped() {
 		return mapped_;

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -138,10 +138,30 @@ public:
 			glDeleteBuffers(1, &buffer);
 		}
 	}
+
+	void *Map(GLenum access) {
+		glBindBuffer(target_, buffer);
+		void *p = glMapBuffer(target_, access);
+		mapped_ = p != nullptr;
+		return p;
+	}
+
+	bool Unmap() {
+		glBindBuffer(target_, buffer);
+		mapped_ = false;
+		return glUnmapBuffer(target_) == GL_TRUE;
+	}
+
+	bool Mapped() {
+		return mapped_;
+	}
+
 	GLuint buffer = 0;
 	GLuint target_;
 	int size_;
+
 private:
+	bool mapped_ = false;
 };
 
 enum class GLRRunType {
@@ -747,8 +767,9 @@ private:
 class GLPushBuffer {
 public:
 	struct BufInfo {
-		GLRBuffer *buffer;
-		uint8_t *deviceMemory;
+		GLRBuffer *buffer = nullptr;
+		uint8_t *localMemory = nullptr;
+		uint8_t *deviceMemory = nullptr;
 	};
 
 public:
@@ -835,6 +856,10 @@ public:
 
 	void Flush();
 
+protected:
+	void MapDevice();
+	void UnmapDevice();
+
 private:
 	bool AddBuffer();
 	void NextBuffer(size_t minSize);
@@ -847,4 +872,6 @@ private:
 	size_t size_ = 0;
 	uint8_t *writePtr_ = nullptr;
 	GLuint target_;
+
+	friend class GLRenderManager;
 };

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -139,7 +139,7 @@ public:
 		}
 	}
 
-	void *Map(GLenum accessOld, GLbitfield accessNew);
+	void *Map(GLbitfield access);
 	bool Unmap();
 
 	bool Mapped() {


### PR DESCRIPTION
This improves God of War by ~~6%~~ 18% with glMapBufferRange for me, for example.  Only tested on desktop, though.

Still uses local memory at first, and switches to device memory on the next frame.

Note: adding `GL_MAP_INVALIDATE_BUFFER_BIT` would make it much slower.  Not sure about mobile.

-[Unknown]