### PR TITLE
TexCache: Decimate CLUT variants more often

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -46,6 +46,8 @@
 #define TEXTURE_KILL_AGE_LOWMEM 60
 // Not used in lowmem mode.
 #define TEXTURE_SECOND_KILL_AGE 100
+// Used when there are multiple CLUT variants of a texture.
+#define TEXTURE_KILL_AGE_CLUT 12
 
 // Try to be prime to other decimation intervals.
 #define TEXCACHE_DECIMATION_INTERVAL 13
@@ -454,6 +456,22 @@ void TextureCacheCommon::SetTexture(bool force) {
 			entry->status = TexCacheEntry::STATUS_UNRELIABLE;
 		}
 
+		if (hasClut && clutRenderAddress_ == 0xFFFFFFFF) {
+			const u64 cachekeyMin = (u64)(texaddr & 0x3FFFFFFF) << 32;
+			const u64 cachekeyMax = cachekeyMin + (1ULL << 32);
+			bool found = false;
+			for (auto it = cache_.lower_bound(cachekeyMin), end = cache_.upper_bound(cachekeyMax); it != end; ++it) {
+				if (it->second->cluthash != entry->cluthash) {
+					it->second->status |= TexCacheEntry::STATUS_CLUT_VARIANTS;
+					found = true;
+				}
+			}
+
+			if (found) {
+				entry->status |= TexCacheEntry::STATUS_CLUT_VARIANTS;
+			}
+		}
+
 		nextNeedsChange_ = false;
 	}
 
@@ -505,8 +523,10 @@ void TextureCacheCommon::Decimate() {
 		const u32 had = cacheSizeEstimate_;
 
 		ForgetLastTexture();
-		int killAge = lowMemoryMode_ ? TEXTURE_KILL_AGE_LOWMEM : TEXTURE_KILL_AGE;
+		int killAgeBase = lowMemoryMode_ ? TEXTURE_KILL_AGE_LOWMEM : TEXTURE_KILL_AGE;
 		for (TexCache::iterator iter = cache_.begin(); iter != cache_.end(); ) {
+			bool hasClut = (iter->second->status & TexCacheEntry::STATUS_CLUT_VARIANTS) != 0;
+			int killAge = hasClut ? TEXTURE_KILL_AGE_CLUT : killAgeBase;
 			if (iter->second->lastFrame + killAge < gpuStats.numFlips) {
 				DeleteTexture(iter++);
 			} else {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -108,8 +108,7 @@ struct TexCacheEntry {
 		STATUS_ALPHA_FULL = 0x00,      // Has no alpha channel, or always full alpha.
 		STATUS_ALPHA_MASK = 0x04,
 
-		// 0x08 free.
-
+		STATUS_CLUT_VARIANTS = 0x08,   // Has multiple CLUT variants.
 		STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 6 frames in between.)
 		STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
 		STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.


### PR DESCRIPTION
May help #10418.  Though we should probably try to handle going over limit better than crashing.

This cuts down on the first mission's texture allocation to 1/3 (about 120 instead of 360.)  Having 6+ variants shouldn't be too common, so should be mostly safe.

This impacts Popolocrois by about 14% reduction in performance with retain changed textures on, but makes it very slightly faster with it off (though still much slower than with it on.)  I think that's pretty acceptable, and it's an edge case game.

-[Unknown]