### PR TITLE
Separate T3DCreate* into its own header to avoid including Windows.h etc in some cases.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,7 @@ add_library(native STATIC
 	ext/native/profiler/profiler.h
 	ext/native/thin3d/thin3d.cpp
 	ext/native/thin3d/thin3d.h
+	ext/native/thin3d/thin3d_create.h
 	${THIN3D_PLATFORMS}
 	ext/native/thread/executor.cpp
 	ext/native/thread/executor.h

--- a/Common/CommonWindows.h
+++ b/Common/CommonWindows.h
@@ -14,4 +14,5 @@
 
 #undef min
 #undef max
+#undef DrawText
 #endif

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -37,6 +37,7 @@
 #include "Common/GraphicsContext.h"
 
 #ifdef _WIN32
+#include "Common/CommonWindows.h"
 #include "Windows/InputDevice.h"
 #endif
 

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -39,6 +39,7 @@ QTM_USE_NAMESPACE
 #include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/System.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/GLRenderManager.h"
 
 // Input

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -4,6 +4,7 @@
 #include "base/NativeApp.h"
 #include "base/display.h"
 #include "gfx_es2/gpu_features.h"
+#include "thin3d/thin3d_create.h"
 
 class GLRenderManager;
 

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -2,6 +2,7 @@
 #include "base/NativeApp.h"
 #include "base/display.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/thin3d_create.h"
 #include "util/text/parsers.h"
 
 #include "Core/System.h"

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -42,6 +42,7 @@
 #include "UI/GameSettingsScreen.h"
 
 #ifdef _WIN32
+#include "Common/CommonWindows.h"
 // Want to avoid including the full header here as it includes d3dx.h
 int GetD3DXVersion();
 #endif

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -14,6 +14,7 @@
 #include "Windows/GPU/D3D11Context.h"
 #include "Windows/W32Util/Misc.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/d3d11_loader.h"
 
 #if PPSSPP_PLATFORM(UWP)

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -14,6 +14,7 @@
 #include "Windows/GPU/D3D9Context.h"
 #include "Windows/W32Util/Misc.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/d3dx9_loader.h"
 
 void D3D9Context::SwapBuffers() {

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -21,6 +21,7 @@
 #include "gfx/gl_common.h"
 #include "gfx/gl_debug_log.h"
 #include "gfx_es2/gpu_features.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/GLRenderManager.h"
 #include "GL/gl.h"
 #include "GL/wglew.h"

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -58,6 +58,7 @@
 
 #include "base/stringutil.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/VulkanRenderManager.h"
 #include "util/text/parsers.h"
 #include "Windows/GPU/WindowsVulkanContext.h"

--- a/android/jni/AndroidEGLContext.cpp
+++ b/android/jni/AndroidEGLContext.cpp
@@ -2,6 +2,7 @@
 #include "base/logging.h"
 #include "base/NativeApp.h"
 #include "gfx_es2/gpu_features.h"
+#include "thin3d/thin3d_create.h"
 
 #include "AndroidEGLContext.h"
 #include "GL/GLInterface/EGLAndroid.h"

--- a/android/jni/AndroidJavaGLContext.h
+++ b/android/jni/AndroidJavaGLContext.h
@@ -6,6 +6,7 @@
 
 #include "AndroidGraphicsContext.h"
 #include "thin3d/GLRenderManager.h"
+#include "thin3d/thin3d_create.h"
 
 // Doesn't do much. Just to fit in.
 class AndroidJavaEGLGraphicsContext : public AndroidGraphicsContext {

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -6,6 +6,7 @@
 #include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanContext.h"
 #include "thin3d/VulkanRenderManager.h"
+#include "thin3d/thin3d_create.h"
 #include "util/text/parsers.h"
 #include "Core/Config.h"
 #include "Core/System.h"

--- a/ext/native/gfx_es2/draw_buffer.h
+++ b/ext/native/gfx_es2/draw_buffer.h
@@ -11,8 +11,6 @@
 #include "math/lin/matrix4x4.h"
 #include "thin3d/thin3d.h"
 
-#undef DrawText
-
 struct Atlas;
 
 enum {

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -243,6 +243,7 @@
     <ClInclude Include="thin3d\DataFormatGL.h" />
     <ClInclude Include="thin3d\GLQueueRunner.h" />
     <ClInclude Include="thin3d\GLRenderManager.h" />
+    <ClInclude Include="thin3d\thin3d_create.h" />
     <ClInclude Include="thin3d\VulkanQueueRunner.h" />
     <ClInclude Include="thin3d\VulkanRenderManager.h" />
     <ClInclude Include="util\text\wrap_text.h" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -338,6 +338,9 @@
     <ClInclude Include="thin3d\DataFormatGL.h">
       <Filter>thin3d</Filter>
     </ClInclude>
+    <ClInclude Include="thin3d\thin3d_create.h">
+      <Filter>thin3d</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 #include <string>
@@ -15,26 +15,6 @@
 #include "DataFormat.h"
 
 class Matrix4x4;
-
-#ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <d3dcommon.h>
-struct IDirect3DDevice9;
-struct IDirect3D9;
-struct IDirect3DDevice9Ex;
-struct IDirect3D9Ex;
-struct ID3D11Device;
-struct ID3D11DeviceContext;
-struct ID3D11Device1;
-struct ID3D11DeviceContext1;
-
-#endif
-
-class VulkanContext;
 
 namespace Draw {
 
@@ -664,16 +644,7 @@ protected:
 	int targetHeight_;
 };
 
-DrawContext *T3DCreateGLContext();
-
 extern const UniformBufferDesc UBPresetDesc;
-
-#ifdef _WIN32
-DrawContext *T3DCreateDX9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, IDirect3DDevice9 *device, IDirect3DDevice9Ex *deviceEx);
-DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, D3D_FEATURE_LEVEL featureLevel, HWND hWnd);
-#endif
-
-DrawContext *T3DCreateVulkanContext(VulkanContext *context, bool split);
 
 // UBs for the preset shaders
 

--- a/ext/native/thin3d/thin3d_create.h
+++ b/ext/native/thin3d/thin3d_create.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "thin3d/thin3d.h"
+
+// Separated this stuff into its own file so we don't get Windows.h included if all we want is the thin3d declarations.
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <d3dcommon.h>
+struct IDirect3DDevice9;
+struct IDirect3D9;
+struct IDirect3DDevice9Ex;
+struct IDirect3D9Ex;
+struct ID3D11Device;
+struct ID3D11DeviceContext;
+struct ID3D11Device1;
+struct ID3D11DeviceContext1;
+
+#endif
+
+class VulkanContext;
+
+namespace Draw {
+
+DrawContext *T3DCreateGLContext();
+
+#ifdef _WIN32
+DrawContext *T3DCreateDX9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, IDirect3DDevice9 *device, IDirect3DDevice9Ex *deviceEx);
+DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, D3D_FEATURE_LEVEL featureLevel, HWND hWnd);
+#endif
+
+DrawContext *T3DCreateVulkanContext(VulkanContext *context, bool split);
+
+}  // namespace Draw

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -36,6 +36,7 @@
 #include "gfx_es2/gpu_features.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
+#include "thin3d/thin3d_create.h"
 
 const bool WINDOW_VISIBLE = false;
 const int WINDOW_WIDTH = 480;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -16,6 +16,7 @@
 #include "net/resolve.h"
 #include "ui/screen.h"
 #include "thin3d/thin3d.h"
+#include "thin3d/thin3d_create.h"
 #include "thin3d/GLRenderManager.h"
 #include "input/keycodes.h"
 #include "gfx_es2/gpu_features.h"


### PR DESCRIPTION
Just some minor code cleanup that will make a further cleanup easier.