### PR TITLE
Execute_Prim: Add a smaller "inner interpreter" to speed long up sequences of PRIM commands

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1543,6 +1543,9 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 	// PRIM commands with other commands. A special case that might be interesting is that game
 	// that changes culling mode between each prim, we could just change the triangle winding
 	// right here to still be able to join draw calls.
+	if (debugRecording_)
+		goto bail;
+
 	while (src != stall) {
 		uint32_t data = *src;
 		switch (data >> 24) {


### PR DESCRIPTION
To avoid going back to the runloop during long sequences of PRIM commands, and thus also avoiding all sorts of checking for the current framebuffer etc that are part of Execute_Prim.

Helps performance by a quite measurable 1-5% in several PRIM-heavy games.

Not particularly pretty, but effective.

This is also a first step towards fixing the performance of Earth Defense Force 2 and I believe possibly a couple of other games (Gundam?) which flip cull direction every few primitives.