### PR TITLE
Add an extra check to FindTransferFramebuffers to avoid misdetecting some fb blits

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1352,9 +1352,10 @@ void FramebufferManagerCommon::FindTransferFramebuffers(VirtualFramebuffer *&dst
 			const u32 byteOffset = dstBasePtr - vfb_address;
 			const u32 byteStride = dstStride * bpp;
 			const u32 yOffset = byteOffset / byteStride;
+
 			// Some games use mismatching bitdepths.  But make sure the stride matches.
 			// If it doesn't, generally this means we detected the framebuffer with too large a height.
-			bool match = yOffset < dstYOffset;
+			bool match = yOffset < dstYOffset && yOffset < vfb->height;
 			if (match && vfb_byteStride != byteStride) {
 				// Grand Knights History copies with a mismatching stride but a full line at a time.
 				// Makes it hard to detect the wrong transfers in e.g. God of War.
@@ -1384,7 +1385,7 @@ void FramebufferManagerCommon::FindTransferFramebuffers(VirtualFramebuffer *&dst
 			const u32 byteOffset = srcBasePtr - vfb_address;
 			const u32 byteStride = srcStride * bpp;
 			const u32 yOffset = byteOffset / byteStride;
-			bool match = yOffset < srcYOffset;
+			bool match = yOffset < srcYOffset && yOffset < vfb->height;
 			if (match && vfb_byteStride != byteStride) {
 				if (width != srcStride || (byteStride * height != vfb_byteStride && byteStride * height != vfb_byteWidth)) {
 					match = false;


### PR DESCRIPTION
They could end up out of bounds when we later perform them.

Affected Burnout Legends (which would crash the Vulkan device)