### PR TITLE
More DrawPrim optimizations

### DIFF
--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -949,8 +949,10 @@ void DrawEngineCommon::SubmitSpline(const void *control_points, const void *indi
 		gstate_c.uv.vOff = 0.0f;
 	}
 
+	uint32_t vertTypeID = GetVertTypeID(vertTypeWithIndex16, gstate.getUVGenMode());
+
 	int generatedBytesRead;
-	DispatchSubmitPrim(splineBuffer, quadIndices_, primType[prim_type], count, vertTypeWithIndex16, &generatedBytesRead);
+	DispatchSubmitPrim(splineBuffer, quadIndices_, primType[prim_type], count, vertTypeID, &generatedBytesRead);
 
 	DispatchFlush();
 
@@ -1091,8 +1093,9 @@ void DrawEngineCommon::SubmitBezier(const void *control_points, const void *indi
 		gstate_c.uv.vOff = 0;
 	}
 
+	uint32_t vertTypeID = GetVertTypeID(vertTypeWithIndex16, gstate.getUVGenMode());
 	int generatedBytesRead;
-	DispatchSubmitPrim(splineBuffer, quadIndices_, primType[prim_type], count, vertTypeWithIndex16, &generatedBytesRead);
+	DispatchSubmitPrim(splineBuffer, quadIndices_, primType[prim_type], count, vertTypeID, &generatedBytesRead);
 
 	DispatchFlush();
 

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -39,6 +39,13 @@ alignas(16) static const float by32768[4] = {
 	1.0f / 32768.0f, 1.0f / 32768.0f, 1.0f / 32768.0f, 1.0f / 32768.0f,
 };
 
+alignas(16) static const float by128_11[4] = {
+	1.0f / 128.0f, 1.0f / 128.0f, 1.0f, 1.0f,
+};
+alignas(16) static const float by32768_11[4] = {
+	1.0f / 32768.0f, 1.0f / 32768.0f, 1.0f, 1.0f,
+};
+
 alignas(16) static const u32 threeMasks[4] = { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0 };
 alignas(16) static const u32 aOne[4] = {0, 0, 0, 0x3F800000};
 
@@ -222,20 +229,14 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	// Keep the scale/offset in a few fp registers if we need it.
 	if (prescaleStep) {
 		MOV(PTRBITS, R(tempReg1), ImmPtr(&gstate_c.uv));
-		MOVSS(fpScaleOffsetReg, MDisp(tempReg1, 0));
-		MOVSS(fpScratchReg, MDisp(tempReg1, 4));
-		UNPCKLPS(fpScaleOffsetReg, R(fpScratchReg));
+		MOVAPS(fpScaleOffsetReg, MatR(tempReg1));
 		if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_8BIT) {
-			MOV(PTRBITS, R(tempReg2), ImmPtr(&by128));
+			MOV(PTRBITS, R(tempReg2), ImmPtr(&by128_11));
 			MULPS(fpScaleOffsetReg, MatR(tempReg2));
 		} else if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_16BIT) {
-			MOV(PTRBITS, R(tempReg2), ImmPtr(&by32768));
+			MOV(PTRBITS, R(tempReg2), ImmPtr(&by32768_11));
 			MULPS(fpScaleOffsetReg, MatR(tempReg2));
 		}
-		MOVSS(fpScratchReg, MDisp(tempReg1, 8));
-		MOVSS(fpScratchReg2, MDisp(tempReg1, 12));
-		UNPCKLPS(fpScratchReg, R(fpScratchReg2));
-		UNPCKLPD(fpScaleOffsetReg, R(fpScratchReg));
 	}
 
 	// Let's not bother with a proper stack frame. We just grab the arguments and go.

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -229,7 +229,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	// Keep the scale/offset in a few fp registers if we need it.
 	if (prescaleStep) {
 		MOV(PTRBITS, R(tempReg1), ImmPtr(&gstate_c.uv));
-		MOVAPS(fpScaleOffsetReg, MatR(tempReg1));
+		MOVUPS(fpScaleOffsetReg, MatR(tempReg1));
 		if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_8BIT) {
 			MOV(PTRBITS, R(tempReg2), ImmPtr(&by128_11));
 			MULPS(fpScaleOffsetReg, MatR(tempReg2));

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1498,7 +1498,8 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 	int bytesRead = 0;
 	UpdateUVScaleOffset();
 
-	drawEngineCommon_->SubmitPrim(verts, inds, prim, count, vertexType, &bytesRead);
+	uint32_t vertTypeID = GetVertTypeID(vertexType, gstate.getUVGenMode());
+	drawEngineCommon_->SubmitPrim(verts, inds, prim, count, vertTypeID, &bytesRead);
 	// After drawing, we advance the vertexAddr (when non indexed) or indexAddr (when indexed).
 	// Some games rely on this, they don't bother reloading VADDR and IADDR.
 	// The VADDR/IADDR registers are NOT updated.
@@ -1543,7 +1544,7 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 				inds = Memory::GetPointerUnchecked(indexAddr);
 			}
 
-			drawEngineCommon_->SubmitPrim(verts, inds, newPrim, count, vertexType, &bytesRead);
+			drawEngineCommon_->SubmitPrim(verts, inds, newPrim, count, vertTypeID, &bytesRead);
 			AdvanceVerts(vertexType, count, bytesRead);
 			totalVertCount += count;
 			break;
@@ -2047,7 +2048,8 @@ void GPUCommon::FlushImm() {
 	int vtype = GE_VTYPE_POS_FLOAT | GE_VTYPE_COL_8888 | GE_VTYPE_THROUGH;
 
 	int bytesRead;
-	drawEngineCommon_->DispatchSubmitPrim(temp, nullptr, immPrim_, immCount_, vtype, &bytesRead);
+	uint32_t vertTypeID = GetVertTypeID(vtype, 0);
+	drawEngineCommon_->DispatchSubmitPrim(temp, nullptr, immPrim_, immCount_, vertTypeID, &bytesRead);
 	drawEngineCommon_->DispatchFlush();
 	// TOOD: In the future, make a special path for these.
 	// drawEngineCommon_->DispatchSubmitImm(immBuffer_, immCount_);

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -29,7 +29,7 @@ class NullDrawEngine : public DrawEngineCommon {
 public:
 	void DispatchFlush() override {
 	}
-	void DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int *bytesRead) override {
+	void DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int *bytesRead) override {
 	}
 };
 

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -53,8 +53,8 @@ SoftwareDrawEngine::~SoftwareDrawEngine() {
 void SoftwareDrawEngine::DispatchFlush() {
 }
 
-void SoftwareDrawEngine::DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int *bytesRead) {
-	transformUnit.SubmitPrimitive(verts, inds, prim, vertexCount, vertType, bytesRead, this);
+void SoftwareDrawEngine::DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int *bytesRead) {
+	transformUnit.SubmitPrimitive(verts, inds, prim, vertexCount, vertTypeID, bytesRead, this);
 }
 
 VertexDecoder *SoftwareDrawEngine::FindVertexDecoder(u32 vtype) {


### PR DESCRIPTION
Speeds up GoW games by a few percent, and others probably by a very small amount.

Supporting a few more commands in the inner interpreter lets it stay there for long sequences of drawing commands when drawing characters in GoW, which helps surprisingly much. This seems to point to that it might be time to move the general command interpreter back to a switch statement, which is easier now that we've merged the command interpreters.