### PR TITLE
Vulkan: If the first renderpass is an empty clear, merge it into the next one touching the same framebuffer.

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -82,6 +82,7 @@ struct VkRenderData {
 
 enum class VKRStepType : uint8_t {
 	RENDER,
+	RENDER_SKIP,
 	COPY,
 	BLIT,
 	READBACK,


### PR DESCRIPTION
Works around #10723 in Wipeout. Well, almost completely - there's a single glitched frame visible at the start of a race on Mali, but I think we can live with that until ARM fixes their driver.

Should also be a perf improvement for affected games.