### PR TITLE
Implement pipeline/shader cache for Vulkan, to avoid shader compile stutters on second and subsequent runs.

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -937,17 +937,6 @@ void VulkanContext::DestroyDevice() {
 	device_ = nullptr;
 }
 
-VkPipelineCache VulkanContext::CreatePipelineCache() {
-	VkPipelineCache cache;
-	VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
-	pc.pInitialData = nullptr;
-	pc.initialDataSize = 0;
-	pc.flags = 0;
-	VkResult res = vkCreatePipelineCache(device_, &pc, nullptr, &cache);
-	assert(VK_SUCCESS == res);
-	return cache;
-}
-
 bool VulkanContext::CreateShaderModule(const std::vector<uint32_t> &spirv, VkShaderModule *shaderModule) {
 	VkShaderModuleCreateInfo sm{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
 	sm.pCode = spirv.data();

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -142,8 +142,6 @@ public:
 
 	VulkanDeleteList &Delete() { return globalDeleteList_; }
 
-	VkPipelineCache CreatePipelineCache();
-
 	// The parameters are whatever the chosen window system wants.
 	void InitSurface(WindowSystem winsys, void *data1, void *data2, int width = -1, int height = -1);
 	void ReinitSurface(int width = -1, int height = -1);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -88,6 +88,8 @@ public:
 		return numDrawCalls;
 	}
 
+	VertexDecoder *GetVertexDecoder(u32 vtype);
+
 protected:
 	virtual void ClearTrackedVertexArrays() {}
 
@@ -105,8 +107,6 @@ protected:
 	void DecodeVertsStep(u8 *dest, int &i, int &decodedVerts);
 
 	bool ApplyShaderBlending();
-
-	VertexDecoder *GetVertexDecoder(u32 vtype);
 
 	inline int IndexSize(u32 vtype) const {
 		const u32 indexType = (vtype & GE_VTYPE_IDX_MASK);

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -75,6 +75,21 @@ void DecVtxFormat::ComputeID() {
 	id = uvfmt | (c0fmt << 4) | (c1fmt << 8) | (nrmfmt << 12) | (posfmt << 16);
 }
 
+void DecVtxFormat::InitializeFromID(uint32_t id) {
+	this->id = id;
+	uvfmt = (id & 0xF);
+	c0fmt = ((id >> 4) & 0xF);
+	c1fmt = ((id >> 8) & 0xF);
+	nrmfmt = ((id >> 12) & 0xF);
+	posfmt = ((id >> 16) & 0xF);
+	uvoff = 0;
+	c0off = uvoff + DecFmtSize(uvfmt);
+	c1off = c0off + DecFmtSize(c0fmt);
+	nrmoff = c1off + DecFmtSize(c1fmt);
+	posoff = nrmoff + DecFmtSize(nrmfmt);
+	stride = posoff + DecFmtSize(posfmt);
+}
+
 void GetIndexBounds(const void *inds, int count, u32 vertType, u16 *indexLowerBound, u16 *indexUpperBound) {
 	// Find index bounds. Could cache this in display lists.
 	// Also, this could be greatly sped up with SSE2/NEON, although rarely a bottleneck.

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -72,10 +72,11 @@ struct DecVtxFormat {
 	u8 c1fmt; u8 c1off;
 	u8 nrmfmt; u8 nrmoff;
 	u8 posfmt; u8 posoff;
-	short stride;
+	u8 stride;
 
 	uint32_t id;
 	void ComputeID();
+	void InitializeFromID(uint32_t id);
 };
 
 void GetIndexBounds(const void *inds, int count, u32 vertType, u16 *indexLowerBound, u16 *indexUpperBound);

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -109,7 +109,7 @@ void DrawEngineGLES::DeviceRestore() {
 
 void DrawEngineGLES::InitDeviceObjects() {
 	for (int i = 0; i < GLRenderManager::MAX_INFLIGHT_FRAMES; i++) {
-		frameData_[i].pushVertex = new GLPushBuffer(render_, GL_ARRAY_BUFFER, 1024 * 1024);
+		frameData_[i].pushVertex = new GLPushBuffer(render_, GL_ARRAY_BUFFER, 256 * 1024);
 		frameData_[i].pushIndex = new GLPushBuffer(render_, GL_ELEMENT_ARRAY_BUFFER, 256 * 1024);
 
 		render_->RegisterPushBuffer(i, frameData_[i].pushVertex);

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -419,7 +419,7 @@ void GPU_GLES::BeginFrame() {
 
 	GPUCommon::BeginFrame();
 
-	// Save the cache from time to time. TODO: How often?
+	// Save the cache from time to time. TODO: How often? We save on exit, so shouldn't need to do this all that often.
 	if (!shaderCachePath_.empty() && (gpuStats.numFlips & 4095) == 0) {
 		shaderManagerGL_->Save(shaderCachePath_);
 	}

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -255,9 +255,7 @@ void DrawEngineVulkan::BeginFrame() {
 	// TODO: How can we make this nicer...
 	((TessellationDataTransferVulkan *)tessDataTransfer)->SetPushBuffer(frame->pushUBO);
 
-	// TODO : Find a better place to do this.
 	if (!nullTexture_) {
-		ILOG("INIT : Creating null texture");
 		VkCommandBuffer cmdInit = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 		nullTexture_ = new VulkanTexture(vulkan_, textureCache_->GetAllocator());
 		int w = 8;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -80,6 +80,9 @@ private:
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
 
+	void LoadCache(std::string filename);
+	void SaveCache(std::string filename);
+
 	VulkanContext *vulkan_;
 	FramebufferManagerVulkan *framebufferManagerVulkan_;
 	TextureCacheVulkan *textureCacheVulkan_;
@@ -100,4 +103,6 @@ private:
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES]{};
+
+	std::string shaderCachePath_;
 };

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -42,7 +42,7 @@ struct VulkanPipelineKey {
 	VkRenderPass renderPass;
 	VkShaderModule vShader;
 	VkShaderModule fShader;
-	uint32_t vtxDecId;
+	uint32_t vtxFmtId;
 	bool useHWTransform;
 
 	void ToString(std::string *str) const {
@@ -52,6 +52,14 @@ struct VulkanPipelineKey {
 	void FromString(const std::string &str) {
 		memcpy(this, &str[0], sizeof(*this));
 	}
+};
+
+struct StoredVulkanPipelineKey {
+	VulkanPipelineRasterStateKey raster;
+	VShaderID vShaderID;
+	FShaderID fShaderID;
+	uint32_t vtxFmtId;
+	bool useHWTransform;
 };
 
 enum PipelineFlags {
@@ -74,6 +82,8 @@ struct VulkanPipeline {
 class VulkanContext;
 class VulkanVertexShader;
 class VulkanFragmentShader;
+class ShaderManagerVulkan;
+class DrawEngineCommon;
 
 class PipelineManagerVulkan {
 public:
@@ -93,9 +103,13 @@ public:
 	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
 
+	// Saves data for faster creation next time.
+	void SaveCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager);
+	bool LoadCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, DrawEngineCommon *drawEngine, VkPipelineLayout layout, VkRenderPass renderPass);
+
 private:
 	DenseHashMap<VulkanPipelineKey, VulkanPipeline *, nullptr> pipelines_;
-	VkPipelineCache pipelineCache_;
+	VkPipelineCache pipelineCache_ = VK_NULL_HANDLE;
 	VulkanContext *vulkan_;
 	float lineWidth_ = 1.0f;
 };

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdio>
+
 #include "base/basictypes.h"
 #include "Common/Hashmaps.h"
 #include "Common/Vulkan/VulkanMemory.h"
@@ -33,16 +35,16 @@ class VulkanPushBuffer;
 
 class VulkanFragmentShader {
 public:
-	VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, const char *code, bool useHWTransform);
+	VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, const char *code);
 	~VulkanFragmentShader();
 
 	const std::string &source() const { return source_; }
 
 	bool Failed() const { return failed_; }
-	bool UseHWTransform() const { return useHWTransform_; }
 
 	std::string GetShaderString(DebugShaderStringType type) const;
 	VkShaderModule GetModule() const { return module_; }
+	const FShaderID &GetID() { return id_; }
 
 protected:	
 	VkShaderModule module_;
@@ -50,13 +52,12 @@ protected:
 	VulkanContext *vulkan_;
 	std::string source_;
 	bool failed_;
-	bool useHWTransform_;
 	FShaderID id_;
 };
 
 class VulkanVertexShader {
 public:
-	VulkanVertexShader(VulkanContext *vulkan, VShaderID id, const char *code, int vertType, bool useHWTransform, bool usesLighting);
+	VulkanVertexShader(VulkanContext *vulkan, VShaderID id, const char *code, bool useHWTransform, bool usesLighting);
 	~VulkanVertexShader();
 
 	const std::string &source() const { return source_; }
@@ -69,6 +70,7 @@ public:
 
 	std::string GetShaderString(DebugShaderStringType type) const;
 	VkShaderModule GetModule() const { return module_; }
+	const VShaderID &GetID() { return id_; }
 
 protected:
 	VkShaderModule module_;
@@ -98,6 +100,12 @@ public:
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }
 	int GetNumFragmentShaders() const { return (int)fsCache_.size(); }
 
+	// Used for saving/loading the cache. Don't need to be particularly fast.
+	VulkanVertexShader *GetVertexShaderFromID(VShaderID id) { return vsCache_.Get(id); }
+	VulkanFragmentShader *GetFragmentShaderFromID(FShaderID id) { return fsCache_.Get(id); }
+	VulkanVertexShader *GetVertexShaderFromModule(VkShaderModule module);
+	VulkanFragmentShader *GetFragmentShaderFromModule(VkShaderModule module);
+
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
@@ -114,6 +122,9 @@ public:
 	uint32_t PushLightBuffer(VulkanPushBuffer *dest, VkBuffer *buf) {
 		return dest->PushAligned(&ub_lights, sizeof(ub_lights), uboAlignment_, buf);
 	}
+
+	bool LoadCache(FILE *f);
+	void SaveCache(FILE *f);
 
 private:
 	void Clear();

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -62,7 +62,10 @@ void Vulkan2D::DestroyDeviceObjects() {
 }
 
 void Vulkan2D::InitDeviceObjects() {
-	pipelineCache_ = vulkan_->CreatePipelineCache();
+	VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
+	VkResult res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
+	assert(VK_SUCCESS == res);
+
 	VkDescriptorSetLayoutBinding bindings[2] = {};
 	// Texture.
 	bindings[0].descriptorCount = 1;
@@ -80,7 +83,7 @@ void Vulkan2D::InitDeviceObjects() {
 	VkDescriptorSetLayoutCreateInfo dsl = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
 	dsl.bindingCount = 2;
 	dsl.pBindings = bindings;
-	VkResult res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &descriptorSetLayout_);
+	res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &descriptorSetLayout_);
 	assert(VK_SUCCESS == res);
 
 	VkDescriptorPoolSize dpTypes[1];

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -773,7 +773,9 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	res = vkCreatePipelineLayout(device_, &pl, nullptr, &pipelineLayout_);
 	assert(VK_SUCCESS == res);
 
-	pipelineCache_ = vulkan_->CreatePipelineCache();
+	VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
+	res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
+	assert(VK_SUCCESS == res);
 
 	renderManager_.SetSplitSubmit(splitSubmit);
 


### PR DESCRIPTION
Stores IDs like GL. Doesn't bother storing the pipeline caches, they got pretty large. There's a disabled option if anyone wants to try it, but it's pretty quick anyway.

Doesn't do the progressive loading thing yet though.