### PR TITLE
Module: Hash functions only once during loading

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1268,6 +1268,7 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 		scan = g_Config.bFuncReplacements;
 #endif
 
+		// If the ELF has debug symbols, don't add entries to the symbol table.
 		bool insertSymbols = scan && !reader.LoadSymbols();
 		std::vector<SectionID> codeSections = reader.GetCodeSections();
 		for (SectionID id : codeSections) {
@@ -1281,7 +1282,7 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 				module->textEnd = end;
 
 			if (scan) {
-				MIPSAnalyst::ScanForFunctions(start, end, insertSymbols);
+				insertSymbols = MIPSAnalyst::ScanForFunctions(start, end, insertSymbols);
 			}
 		}
 
@@ -1291,14 +1292,14 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 			u32 scanEnd = module->textEnd;
 			// Skip the exports and imports sections, they're not code.
 			if (scanEnd >= std::min(modinfo->libent, modinfo->libstub)) {
-				MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
+				insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
 				scanStart = std::min(modinfo->libentend, modinfo->libstubend);
 			}
 			if (scanEnd >= std::max(modinfo->libent, modinfo->libstub)) {
-				MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
+				insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
 				scanStart = std::max(modinfo->libentend, modinfo->libstubend);
 			}
-			MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, insertSymbols);
+			insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, insertSymbols);
 		}
 
 		if (scan) {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1268,7 +1268,7 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 		scan = g_Config.bFuncReplacements;
 #endif
 
-		bool gotSymbols = scan && reader.LoadSymbols();
+		bool insertSymbols = scan && !reader.LoadSymbols();
 		std::vector<SectionID> codeSections = reader.GetCodeSections();
 		for (SectionID id : codeSections) {
 			u32 start = reader.GetSectionAddr(id);
@@ -1280,8 +1280,9 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 			if (end > module->textEnd)
 				module->textEnd = end;
 
-			if (scan)
-				MIPSAnalyst::ScanForFunctions(start, end, !gotSymbols);
+			if (scan) {
+				MIPSAnalyst::ScanForFunctions(start, end, insertSymbols);
+			}
 		}
 
 		// Some games don't have any sections at all.
@@ -1290,14 +1291,18 @@ static Module *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 loadAdd
 			u32 scanEnd = module->textEnd;
 			// Skip the exports and imports sections, they're not code.
 			if (scanEnd >= std::min(modinfo->libent, modinfo->libstub)) {
-				MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, !gotSymbols);
+				MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
 				scanStart = std::min(modinfo->libentend, modinfo->libstubend);
 			}
 			if (scanEnd >= std::max(modinfo->libent, modinfo->libstub)) {
-				MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, !gotSymbols);
+				MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
 				scanStart = std::max(modinfo->libentend, modinfo->libstubend);
 			}
-			MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, !gotSymbols);
+			MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, insertSymbols);
+		}
+
+		if (scan) {
+			MIPSAnalyst::FinalizeScan(insertSymbols);
 		}
 	}
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -878,13 +878,16 @@ namespace MIPSAnalyst {
 
 		for (auto iter = functions.begin(), end = functions.end(); iter != end; iter++) {
 			AnalyzedFunction &f = *iter;
+			if (Memory::IsValidRange(f.start, f.end - f.start + 4)) {
+				continue;
+			}
 
 			// This is unfortunate.  In case of emuhacks or relocs, we have to make a copy.
 			buffer.resize((f.end - f.start + 4) / 4);
 			size_t pos = 0;
 			for (u32 addr = f.start; addr <= f.end; addr += 4) {
 				u32 validbits = 0xFFFFFFFF;
-				MIPSOpcode instr = Memory::Read_Instruction(addr, true);
+				MIPSOpcode instr = Memory::ReadUnchecked_Instruction(addr, true);
 				if (MIPS_IS_EMUHACK(instr)) {
 					f.hasHash = false;
 					goto skip;
@@ -1015,7 +1018,7 @@ skip:
 		return furthestJumpbackAddr;
 	}
 
-	void ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols) {
+	void ScanForFunctions(u32 startAddr, u32 endAddr, bool &insertSymbols) {
 		std::lock_guard<std::recursive_mutex> guard(functions_lock);
 
 		AnalyzedFunction currentFunction = {startAddr};
@@ -1163,7 +1166,9 @@ skip:
 				g_symbolMap->AddFunction(DefaultFunctionName(temp, iter->start), iter->start, iter->end - iter->start + 4);
 			}
 		}
+	}
 
+	void FinalizeScan(bool insertSymbols) {
 		HashFunctions();
 
 		std::string hashMapFilename = GetSysDirectory(DIRECTORY_SYSTEM) + "knownfuncs.ini";

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1018,7 +1018,7 @@ skip:
 		return furthestJumpbackAddr;
 	}
 
-	void ScanForFunctions(u32 startAddr, u32 endAddr, bool &insertSymbols) {
+	bool ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols) {
 		std::lock_guard<std::recursive_mutex> guard(functions_lock);
 
 		AnalyzedFunction currentFunction = {startAddr};
@@ -1166,6 +1166,8 @@ skip:
 				g_symbolMap->AddFunction(DefaultFunctionName(temp, iter->start), iter->start, iter->end - iter->start + 4);
 			}
 		}
+
+		return insertSymbols;
 	}
 
 	void FinalizeScan(bool insertSymbols) {

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -105,7 +105,8 @@ namespace MIPSAnalyst
 	// If we have loaded symbols from the elf, we'll register functions as they are touched
 	// so that we don't just dump them all in the cache.
 	void RegisterFunction(u32 startAddr, u32 size, const char *name);
-	void ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols);
+	void ScanForFunctions(u32 startAddr, u32 endAddr, bool &insertSymbols);
+	void FinalizeScan(bool insertSymbols);
 	void ForgetFunctions(u32 startAddr, u32 endAddr);
 	void PrecompileFunctions();
 	void PrecompileFunction(u32 startAddr, u32 length);

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -105,7 +105,8 @@ namespace MIPSAnalyst
 	// If we have loaded symbols from the elf, we'll register functions as they are touched
 	// so that we don't just dump them all in the cache.
 	void RegisterFunction(u32 startAddr, u32 size, const char *name);
-	void ScanForFunctions(u32 startAddr, u32 endAddr, bool &insertSymbols);
+	// Returns new insertSymbols value for FinalizeScan().
+	bool ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols);
 	void FinalizeScan(bool insertSymbols);
 	void ForgetFunctions(u32 startAddr, u32 endAddr);
 	void PrecompileFunctions();


### PR DESCRIPTION
This fixes the loading speed regression from #10501.  We were rehashing and replacing and etc. for each code section.

Some games actually have a tiny text section for each import stub slot, which is extremely cheap to scan, but we were doing a lot of pointless work over and over again for each one.  But this affected anything with > 1 code section anyway, so doing that work once late is ideal.

May help #10673 and #10622.

-[Unknown]