### PR TITLE
Vulkan: De-duplicate pipelines when storing cache

### DIFF
--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -135,10 +135,11 @@ public:
 	bool EnableDeviceExtension(const char *extension);
 	VkResult CreateDevice();
 
-	const std::string &InitError() { return init_error_; }
+	const std::string &InitError() const { return init_error_; }
 
-	VkDevice GetDevice() { return device_; }
-	VkInstance GetInstance() { return instance_; }
+	VkDevice GetDevice() const { return device_; }
+	VkInstance GetInstance() const { return instance_; }
+	uint32_t GetFlags() const { return flags_; }
 
 	VulkanDeleteList &Delete() { return globalDeleteList_; }
 

--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -58,6 +58,12 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int numMips,
 		image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	}
 
+	// The graphics debugger always "needs" TRANSFER_SRC but in practice doesn't matter - 
+	// unless validation is on. So let's only force it on when being validated, for now.
+	if (vulkan_->GetFlags() & VULKAN_FLAG_VALIDATE) {
+		image_create_info.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+	}
+
 	VkResult res = vkCreateImage(vulkan_->GetDevice(), &image_create_info, NULL, &image_);
 	if (res != VK_SUCCESS) {
 		_assert_(res == VK_ERROR_OUT_OF_HOST_MEMORY || res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_TOO_MANY_OBJECTS);

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -53,6 +53,7 @@ struct VulkanPipelineKey {
 	void FromString(const std::string &str) {
 		memcpy(this, &str[0], sizeof(*this));
 	}
+	std::string GetDescription(DebugShaderStringType stringType) const;
 };
 
 struct StoredVulkanPipelineKey {

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstring>
 #include "Common/Hashmaps.h"
 
 #include "GPU/Common/VertexDecoderCommon.h"
@@ -60,6 +61,11 @@ struct StoredVulkanPipelineKey {
 	FShaderID fShaderID;
 	uint32_t vtxFmtId;
 	bool useHWTransform;
+
+	// For std::set. Better zero-initialize the struct properly for this to work.
+	bool operator < (const StoredVulkanPipelineKey &other) const {
+		return memcmp(this, &other, sizeof(*this)) < 0;
+	}
 };
 
 enum PipelineFlags {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -350,7 +350,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 5
+#define CACHE_VERSION 6
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;


### PR DESCRIPTION
The new variety of renderpasses with different transitions causes duplication. Hopefully drivers are smart enough to re-use work between similar pipelines (that are the same except for the renderpass) as much as possible...  Otherwise we have to store flags describing which types of renderpass each pipeline belongs to as well.