### PR TITLE
Android: Reload the config after getting storage permission, and ask immediately.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -920,7 +920,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	IniFile iniFile;
 	if (!iniFile.Load(iniFilename_)) {
-		ERROR_LOG(LOADER, "Failed to read %s. Setting config to default.", iniFilename_.c_str());
+		ERROR_LOG(LOADER, "Failed to read '%s'. Setting config to default.", iniFilename_.c_str());
 		// Continue anyway to initialize the config.
 	}
 
@@ -1080,7 +1080,7 @@ void Config::Save() {
 		CleanRecent();
 		IniFile iniFile;
 		if (!iniFile.Load(iniFilename_.c_str())) {
-			ERROR_LOG(LOADER, "Error saving config - can't read ini %s", iniFilename_.c_str());
+			ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", iniFilename_.c_str());
 		}
 
 		// Need to do this somewhere...
@@ -1121,21 +1121,21 @@ void Config::Save() {
 			LogManager::GetInstance()->SaveConfig(log);
 
 		if (!iniFile.Save(iniFilename_.c_str())) {
-			ERROR_LOG(LOADER, "Error saving config - can't write ini %s", iniFilename_.c_str());
+			ERROR_LOG(LOADER, "Error saving config - can't write ini '%s'", iniFilename_.c_str());
 			System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
 			return;
 		}
-		INFO_LOG(LOADER, "Config saved: %s", iniFilename_.c_str());
+		INFO_LOG(LOADER, "Config saved: '%s'", iniFilename_.c_str());
 
 		if (!bGameSpecific) //otherwise we already did this in saveGameConfig()
 		{
 			IniFile controllerIniFile;
 			if (!controllerIniFile.Load(controllerIniFilename_.c_str())) {
-				ERROR_LOG(LOADER, "Error saving config - can't read ini %s", controllerIniFilename_.c_str());
+				ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", controllerIniFilename_.c_str());
 			}
 			KeyMap::SaveToIni(controllerIniFile);
 			if (!controllerIniFile.Save(controllerIniFilename_.c_str())) {
-				ERROR_LOG(LOADER, "Error saving config - can't write ini %s", controllerIniFilename_.c_str());
+				ERROR_LOG(LOADER, "Error saving config - can't write ini '%s'", controllerIniFilename_.c_str());
 				return;
 			}
 			INFO_LOG(LOADER, "Controller config saved: %s", controllerIniFilename_.c_str());

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -791,19 +791,17 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 		ILOG("STORAGE PERMISSION: PENDING");
 		// TODO: Add support for other permissions
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_PENDING;
-		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "permission_denied") {
 		ILOG("STORAGE PERMISSION: DENIED");
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_DENIED;
-		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "permission_granted") {
 		ILOG("STORAGE PERMISSION: GRANTED");
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_GRANTED;
-		NativePermissionStatus(SYSTEM_PERMISSION_STORAGE, PERMISSION_STATUS_PENDING);
 	} else if (msg == "sustained_perf_supported") {
 		sustainedPerfSupported = true;
 	}
 
+	// Ensures that the receiver can handle it on a sensible thread.
 	NativeMessageReceived(msg.c_str(), prm.c_str());
 }
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -97,25 +97,11 @@ void NativeSetMixer(void* mixer);
 void NativeShutdownGraphics();
 void NativeShutdown();
 
-// Called on app.onCreate and app.onDestroy (?). Tells the app to save/restore
-// light state. If app was fully rebooted between these calls, it's okay if some minor
-// state is lost (position in level) but the level currently playihg, or the song
-// currently being edited, or whatever, should be restored properly. In this case,
-// firstTime will be set so that appropriate action can be taken (or not taken when
-// it's not set).
-//
-// Note that NativeRestore is always called on bootup.
-void NativeRestoreState(bool firstTime);  // onCreate
-void NativeSaveState();  // onDestroy
-
-void NativePermissionStatus(SystemPermission permission, PermissionStatus status);
-
 // Calls back into Java / SDL
 // These APIs must be implemented by every port (for example app-android.cpp, SDLMain.cpp).
 // You are free to call these.
 void SystemToast(const char *text);
 void ShowKeyboard();
-void ShowAd(int x, int y, bool center_x);
 
 // Vibrate either takes a number of milliseconds to vibrate unconditionally,
 // or you can specify these constants for "standard" feedback. On Android,


### PR DESCRIPTION
Should help #10670 (where we accidentally overwrote config after failing to load it).

Unfortunately can't retroactively fix old builds :)