### PR TITLE
Remove "sound speed hack"

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -673,7 +673,6 @@ static ConfigSetting soundSettings[] = {
 	ConfigSetting("AudioBackend", &g_Config.iAudioBackend, 0, true, true),
 	ConfigSetting("AudioLatency", &g_Config.iAudioLatency, 1, true, true),
 	ConfigSetting("ExtraAudioBuffering", &g_Config.bExtraAudioBuffering, false, true, false),
-	ConfigSetting("SoundSpeedHack", &g_Config.bSoundSpeedHack, false, true, true),
 	ConfigSetting("AudioResampler", &g_Config.bAudioResampler, true, true, true),
 	ConfigSetting("GlobalVolume", &g_Config.iGlobalVolume, VOLUME_MAX, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -81,7 +81,6 @@ public:
 	bool bPauseExitsEmulator;
 #endif
 	bool bPauseMenuExitsEmulator;
-	bool bPS3Controller;
 
 	// Core
 	bool bIgnoreBadMemAccess;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -201,9 +201,6 @@ public:
 	int iGlobalVolume;
 	bool bExtraAudioBuffering;  // For bluetooth
 
-	// Audio Hack
-	bool bSoundSpeedHack;
-
 	// UI
 	bool bShowDebuggerOnLoad;
 	int iShowFPSCounter;

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -330,15 +330,8 @@ u32 AuCtx::AuDecode(u32 pcmAddr)
 	memset(outbuf, 0, PCMBufSize); // important! empty outbuf to avoid noise
 	u32 outpcmbufsize = 0;
 
-	int repeat = 1;
-	if (g_Config.bSoundSpeedHack){
-		repeat = 2;
-	}
-	int i = 0;
-	// decode frames in sourcebuff and output into PCMBuf (each time, we decode one or two frames)
-	// some games as Miku like one frame each time, some games like DOA like two frames each time
-	while (sourcebuff.size() > 0 && outpcmbufsize < PCMBufSize && i < repeat){
-		i++;
+	// decode frames in sourcebuff and output into PCMBuf, making sure it's filled
+	while (sourcebuff.size() > 0 && outpcmbufsize < PCMBufSize) {
 		int pcmframesize;
 		// decode
 		decoder->Decode((void*)sourcebuff.c_str(), (int)sourcebuff.size(), outbuf, &pcmframesize);
@@ -367,6 +360,7 @@ u32 AuCtx::AuDecode(u32 pcmAddr)
 		outbuf += pcmframesize;
 		// increase FrameNum count
 		FrameNum++;
+		break;
 	}
 	Memory::Write_U32(PCMBuf, pcmAddr);
 	return outpcmbufsize;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -514,9 +514,6 @@ void GameSettingsScreen::CreateViews() {
 		resampling->SetEnabledPtr(&g_Config.bEnableSound);
 	}
 
-	audioSettings->Add(new ItemHeader(a->T("Audio hacks")));
-	audioSettings->Add(new CheckBox(&g_Config.bSoundSpeedHack, a->T("Sound speed hack (DOA etc.)")));
-
 	// Control
 	ViewGroup *controlsSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	controlsSettingsScroll->SetTag("GameSettingsControls");

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -551,8 +551,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					fileToLog = argv[i] + strlen("--log=");
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))
 					stateToLoad = argv[i] + strlen("--state=");
-				if (!strncmp(argv[1], "--PS3", strlen("--PS3")))
-					g_Config.bPS3Controller = true;
 #if !defined(MOBILE_DEVICE)
 				if (!strncmp(argv[i], "--escape-exit", strlen("--escape-exit")))
 					g_Config.bPauseExitsEmulator = true;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -339,8 +339,6 @@ bool SavedataBrowser::ByFilename(const UI::View *v1, const UI::View *v2) {
 
 static time_t GetTotalSize(const SavedataButton *b) {
 	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath()));
-	tm datetm;
-	bool success;
 	switch (Identify_File(fileLoader.get())) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -185,7 +185,6 @@ static RetroOption<bool> ppsspp_gpu_hardware_transform("ppsspp_gpu_hardware_tran
 static RetroOption<bool> ppsspp_vertex_cache("ppsspp_vertex_cache", "Vertex Cache (Speedhack)", true);
 static RetroOption<bool> ppsspp_separate_io_thread("ppsspp_separate_io_thread", "IO Threading", false);
 static RetroOption<bool> ppsspp_unsafe_func_replacements("ppsspp_unsafe_func_replacements", "Unsafe FuncReplacements", true);
-static RetroOption<bool> ppsspp_sound_speedhack("ppsspp_sound_speedhack", "Sound Speedhack", false);
 static RetroOption<bool> ppsspp_cheats("ppsspp_cheats", "Internal Cheats Support", false);
 static RetroOption<IOTimingMethods> ppsspp_io_timing_method("ppsspp_io_timing_method", "IO Timing Method", { { "Fast", IOTimingMethods::IOTIMING_FAST }, { "Host", IOTimingMethods::IOTIMING_HOST }, { "Simulate UMD delays", IOTimingMethods::IOTIMING_REALISTIC } });
 
@@ -213,7 +212,6 @@ void retro_set_environment(retro_environment_t cb) {
 	vars.push_back(ppsspp_vertex_cache.GetOptions());
 	vars.push_back(ppsspp_separate_io_thread.GetOptions());
 	vars.push_back(ppsspp_unsafe_func_replacements.GetOptions());
-	vars.push_back(ppsspp_sound_speedhack.GetOptions());
 	vars.push_back(ppsspp_cheats.GetOptions());
 	vars.push_back(ppsspp_io_timing_method.GetOptions());
 	vars.push_back({});
@@ -278,7 +276,6 @@ static void check_variables(CoreParameter &coreParam) {
 	ppsspp_texture_replacement.Update(&g_Config.bReplaceTextures);
 	ppsspp_separate_io_thread.Update(&g_Config.bSeparateIOThread);
 	ppsspp_unsafe_func_replacements.Update(&g_Config.bFuncReplacements);
-	ppsspp_sound_speedhack.Update(&g_Config.bSoundSpeedHack);
 	ppsspp_cheats.Update(&g_Config.bEnableCheats);
 	ppsspp_locked_cpu_speed.Update(&g_Config.iLockedCPUSpeed);
 	ppsspp_rendering_mode.Update(&g_Config.iRenderingMode);


### PR DESCRIPTION
 No longer fixes #9379 since it now depends on #11993 fixing it, it purely removes the sound speed hack now and changes the weird repeat 1 time code there to a simple break.