### PR TITLE
GPU: Count clears during frameskip

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1466,6 +1466,9 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB)) {
 		// Rough estimate, not sure what's correct.
 		cyclesExecuted += EstimatePerVertexCost() * count;
+		if (gstate.isModeClear()) {
+			gpuStats.numClears++;
+		}
 		return;
 	}
 


### PR DESCRIPTION
This allows the GoW hack to still work during frameskip.  Fixes #10668.

Whitelists aside, I think this will allow for more consistent behavior across other games too.

-[Unknown]