### PR TITLE
Android: Have haptic feedback ignore the global setting, but default to off.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -605,7 +605,7 @@ static bool DefaultShowTouchControls() {
 static const float defaultControlScale = 1.15f;
 
 static ConfigSetting controlSettings[] = {
-	ConfigSetting("HapticFeedback", &g_Config.bHapticFeedback, true, true, true),
+	ConfigSetting("HapticFeedback", &g_Config.bHapticFeedback, false, true, true),
 	ConfigSetting("ShowTouchCross", &g_Config.bShowTouchCross, true, true, true),
 	ConfigSetting("ShowTouchCircle", &g_Config.bShowTouchCircle, true, true, true),
 	ConfigSetting("ShowTouchSquare", &g_Config.bShowTouchSquare, true, true, true),

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -904,7 +904,7 @@ static void ProcessFrameCommands(JNIEnv *env) {
 		frameCmd = frameCommands.front();
 		frameCommands.pop();
 
-		WLOG("frameCommand! '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
+		ILOG("frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
 
 		jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
 		jstring param = env->NewStringUTF(frameCmd.params.c_str());

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1091,7 +1091,6 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
     	dlg.show();
     }
 
-
     public boolean processCommand(String command, String params) {
     	SurfaceView surfView = javaGL ? mGLSurfaceView : mSurfaceView;
 		if (command.equals("launchBrowser")) {
@@ -1204,7 +1203,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			Log.i(TAG, "Launching inputbox: " + title + " " + defString);
 			inputBox(title, defString, "OK");
 			return true;
-		} else if (command.equals("vibrate") && surfView != null) {
+		} else if (command.equals("vibrate")) {
 			int milliseconds = -1;
 			if (params != "") {
 				try {
@@ -1219,20 +1218,24 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			// -3 = Long press feedback
 			// Note that these three do not require the VIBRATE Android
 			// permission.
-			switch (milliseconds) {
-			case -1:
-				surfView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
-				break;
-			case -2:
-				surfView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY);
-				break;
-			case -3:
-				surfView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-				break;
-			default:
-				// Requires the vibrate permission, which we don't have, so disabled.
-				// vibrator.vibrate(milliseconds);
-				break;
+			if (surfView != null) {
+				switch (milliseconds) {
+					case -1:
+						surfView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
+						break;
+					case -2:
+						surfView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
+						break;
+					case -3:
+						surfView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
+						break;
+					default:
+						// Requires the vibrate permission, which we don't have, so disabled.
+						// vibrator.vibrate(milliseconds);
+						break;
+				}
+			} else {
+				Log.e(TAG, "Can't vibrate, no surface view");
 			}
 			return true;
 		} else if (command.equals("finish")) {


### PR DESCRIPTION
We don't bother changing the name of the ini setting as it's no big deal.

Fixes #10786