### PR TITLE
Headless: Add simple GL thread handling

### DIFF
--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "headless/StubHost.h"
+#include <thread>
 
 #undef HEADLESSHOST_CLASS
 #define HEADLESSHOST_CLASS WindowsHeadlessHost
@@ -38,8 +39,20 @@ public:
 protected:
 	void LoadNativeAssets();
 
+	enum class RenderThreadState {
+		IDLE,
+		START_REQUESTED,
+		STARTING,
+		START_FAILED,
+		STARTED,
+		STOP_REQUESTED,
+		STOPPING,
+		STOPPED,
+	};
+
 	HWND hWnd;
 	HDC hDC;
 	HGLRC hRC;
 	GraphicsContext *gfx_;
+	volatile RenderThreadState threadState_ = RenderThreadState::IDLE;
 };


### PR DESCRIPTION
Because of the way headless works and runs tests, it was a lot simpler to use a separate thread (unlike elsewhere) for the GL rendering.  Hopefully this difference doesn't bite us later.

Before this, it simply crashes.

-[Unknown]