### PR TITLE
Libretro: add D3D11 support / fix GL context reset.

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -70,6 +70,8 @@ ConsoleListener::ConsoleListener() : bHidden(true)
 	bUseColor = false;
 #elif PPSSPP_PLATFORM(UWP)
 	bUseColor = false;
+#elif defined(_MSC_VER)
+	bUseColor = false;
 #else
 	bUseColor = isatty(fileno(stdout));
 #endif

--- a/libretro/CMakeLists.txt
+++ b/libretro/CMakeLists.txt
@@ -1,10 +1,15 @@
+
 set(LIBRETRO_SRCS
-  libretro.cpp
-  LibretroGraphicsContext.cpp
-  LibretroGLContext.cpp
-  LibretroVulkanContext.cpp
-  libretro_vulkan.cpp
-)
+	libretro.cpp
+	LibretroGraphicsContext.cpp
+	LibretroGLContext.cpp
+	LibretroVulkanContext.cpp
+	libretro_vulkan.cpp)
+
+if(WIN32)
+	set(LIBRETRO_SRCS ${LIBRETRO_SRCS}
+		LibretroD3D11Context.cpp)
+endif()
 
 include_directories(libretro)
 

--- a/libretro/LibretroD3D11Context.cpp
+++ b/libretro/LibretroD3D11Context.cpp
@@ -88,7 +88,7 @@ void LibretroD3D11Context::SwapBuffers() {
 	d3d11_->context->PSSetShaderResources(0, 1, &SRView_);
 	LibretroHWRenderContext::SwapBuffers();
 
-	ID3D11ShaderResourceView * nullSRV = nullptr;
+	ID3D11ShaderResourceView *nullSRV = nullptr;
 	d3d11_->context->PSSetShaderResources(0, 1, &nullSRV);
 
 	draw_->HandleEvent(Draw::Event::PRESENTED, 0, 0, nullptr, nullptr);

--- a/libretro/LibretroD3D11Context.cpp
+++ b/libretro/LibretroD3D11Context.cpp
@@ -9,7 +9,7 @@
 #endif
 
 bool LibretroD3D11Context::Init() {
-	if (!LibretroHWRenderContext::Init())
+	if (!LibretroHWRenderContext::Init(true))
 		return false;
 
 	g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D11;
@@ -41,15 +41,6 @@ void LibretroD3D11Context::CreateDrawContext() {
 void LibretroD3D11Context::DestroyDrawContext() {
 	LibretroHWRenderContext::DestroyDrawContext();
 	d3d11_ = nullptr;
-}
-
-void LibretroD3D11Context::ContextDestroy()
-{
-	LibretroHWRenderContext::ContextDestroy();
-#if 0
-	// this should be enabled once DeviceLost/DeviceRestore can fully switch to a new draw context.
-	DestroyDrawContext();
-#endif
 }
 
 void LibretroD3D11Context::GotBackbuffer() {

--- a/libretro/LibretroD3D11Context.cpp
+++ b/libretro/LibretroD3D11Context.cpp
@@ -1,0 +1,104 @@
+
+#include "libretro/LibretroD3D11Context.h"
+#include "thin3d/d3d11_loader.h"
+#include <d3d11_1.h>
+
+#ifdef __MINGW32__
+#undef __uuidof
+#define __uuidof(type) IID_##type
+#endif
+
+bool LibretroD3D11Context::Init() {
+	if (!LibretroHWRenderContext::Init())
+		return false;
+
+	g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D11;
+	return true;
+}
+
+void LibretroD3D11Context::CreateDrawContext() {
+	if (!Libretro::environ_cb(RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE, (void **)&d3d11_) || !d3d11_) {
+		ERROR_LOG(G3D, "Failed to get HW rendering interface!\n");
+		return;
+	}
+
+	if (d3d11_->interface_version != RETRO_HW_RENDER_INTERFACE_D3D11_VERSION) {
+		ERROR_LOG(G3D, "HW render interface mismatch, expected %u, got %u!\n", RETRO_HW_RENDER_INTERFACE_D3D11_VERSION, d3d11_->interface_version);
+		return;
+	}
+
+	ptr_D3DCompile = d3d11_->D3DCompile;
+
+	ID3D11Device1 *device1 = nullptr;
+	d3d11_->device->QueryInterface(__uuidof(ID3D11Device1), (void **)&device1);
+
+	ID3D11DeviceContext1 *context1 = nullptr;
+	d3d11_->context->QueryInterface(__uuidof(ID3D11DeviceContext1), (void **)&context1);
+
+	draw_ = Draw::T3DCreateD3D11Context(d3d11_->device, d3d11_->context, device1, context1, d3d11_->featureLevel, NULL);
+}
+
+void LibretroD3D11Context::DestroyDrawContext() {
+	LibretroHWRenderContext::DestroyDrawContext();
+	d3d11_ = nullptr;
+}
+
+void LibretroD3D11Context::ContextDestroy()
+{
+	LibretroHWRenderContext::ContextDestroy();
+#if 0
+	// this should be enabled once DeviceLost/DeviceRestore can fully switch to a new draw context.
+	DestroyDrawContext();
+#endif
+}
+
+void LibretroD3D11Context::GotBackbuffer() {
+	D3D11_TEXTURE2D_DESC desc{};
+	desc.Width = PSP_CoreParameter().pixelWidth;
+	desc.Height = PSP_CoreParameter().pixelHeight;
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.Format = format_;
+	desc.SampleDesc.Count = 1;
+	desc.SampleDesc.Quality = 0;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	desc.CPUAccessFlags = 0;
+	desc.MiscFlags = 0;
+
+	if (SUCCEEDED(d3d11_->device->CreateTexture2D(&desc, nullptr, &texture_))) {
+		if (SUCCEEDED(d3d11_->device->CreateRenderTargetView(texture_, nullptr, &RTView_))) {
+			if (SUCCEEDED(d3d11_->device->CreateShaderResourceView(texture_, nullptr, &SRView_))) {
+				draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, RTView_, texture_);
+				return;
+			}
+			RTView_->Release();
+			RTView_ = nullptr;
+		}
+		texture_->Release();
+		texture_ = nullptr;
+	}
+}
+
+void LibretroD3D11Context::LostBackbuffer() {
+	LibretroGraphicsContext::LostBackbuffer();
+	SRView_->Release();
+	SRView_ = nullptr;
+	RTView_->Release();
+	RTView_ = nullptr;
+	texture_->Release();
+	texture_ = nullptr;
+}
+
+void LibretroD3D11Context::SwapBuffers() {
+	ID3D11RenderTargetView *nullView = nullptr;
+	d3d11_->context->OMSetRenderTargets(1, &nullView, nullptr);
+
+	d3d11_->context->PSSetShaderResources(0, 1, &SRView_);
+	LibretroHWRenderContext::SwapBuffers();
+
+	ID3D11ShaderResourceView * nullSRV = nullptr;
+	d3d11_->context->PSSetShaderResources(0, 1, &nullSRV);
+
+	draw_->HandleEvent(Draw::Event::PRESENTED, 0, 0, nullptr, nullptr);
+}

--- a/libretro/LibretroD3D11Context.h
+++ b/libretro/LibretroD3D11Context.h
@@ -15,8 +15,6 @@ class LibretroD3D11Context : public LibretroHWRenderContext {
 	void CreateDrawContext() override;
 	void DestroyDrawContext() override;
 
-	void ContextDestroy() override;
-
 	GPUCore GetGPUCore() override { return GPUCORE_DIRECTX11; }
 	const char *Ident() override { return "DirectX 11"; }
 private:

--- a/libretro/LibretroD3D11Context.h
+++ b/libretro/LibretroD3D11Context.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#define HAVE_D3D11
+#include "libretro/libretro_d3d.h"
+#include "libretro/LibretroGraphicsContext.h"
+
+class LibretroD3D11Context : public LibretroHWRenderContext {
+	public:
+	LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 11) {}
+	bool Init() override;
+
+	void SwapBuffers() override;
+	void GotBackbuffer() override;
+	void LostBackbuffer() override;
+	void CreateDrawContext() override;
+	void DestroyDrawContext() override;
+
+	void ContextDestroy() override;
+
+	GPUCore GetGPUCore() override { return GPUCORE_DIRECTX11; }
+	const char *Ident() override { return "DirectX 11"; }
+private:
+	retro_hw_render_interface_d3d11 *d3d11_ = nullptr;
+	ID3D11Texture2D *texture_ = nullptr;
+	ID3D11RenderTargetView *RTView_ = nullptr;
+	ID3D11ShaderResourceView *SRView_ = nullptr;
+	DXGI_FORMAT format_ = DXGI_FORMAT_R8G8B8A8_UNORM;
+};

--- a/libretro/LibretroD3D11Context.h
+++ b/libretro/LibretroD3D11Context.h
@@ -5,7 +5,7 @@
 #include "libretro/LibretroGraphicsContext.h"
 
 class LibretroD3D11Context : public LibretroHWRenderContext {
-	public:
+public:
 	LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 11) {}
 	bool Init() override;
 
@@ -17,6 +17,7 @@ class LibretroD3D11Context : public LibretroHWRenderContext {
 
 	GPUCore GetGPUCore() override { return GPUCORE_DIRECTX11; }
 	const char *Ident() override { return "DirectX 11"; }
+
 private:
 	retro_hw_render_interface_d3d11 *d3d11_ = nullptr;
 	ID3D11Texture2D *texture_ = nullptr;

--- a/libretro/LibretroGLContext.cpp
+++ b/libretro/LibretroGLContext.cpp
@@ -6,8 +6,7 @@
 
 #include "libretro/LibretroGLContext.h"
 
-bool LibretroGLContext::Init()
-{
+bool LibretroGLContext::Init() {
 	if (!LibretroHWRenderContext::Init(true))
 		return false;
 
@@ -15,13 +14,10 @@ bool LibretroGLContext::Init()
 	return true;
 }
 
-void LibretroGLContext::CreateDrawContext()
-{
-	if (!glewInitDone)
-	{
+void LibretroGLContext::CreateDrawContext() {
+	if (!glewInitDone) {
 #if !defined(IOS) && !defined(USING_GLES2)
-		if (glewInit() != GLEW_OK)
-		{
+		if (glewInit() != GLEW_OK) {
 			ERROR_LOG(G3D, "glewInit() failed.\n");
 			return;
 		}
@@ -33,8 +29,7 @@ void LibretroGLContext::CreateDrawContext()
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 }
 
-void LibretroGLContext::DestroyDrawContext()
-{
+void LibretroGLContext::DestroyDrawContext() {
 	LibretroHWRenderContext::DestroyDrawContext();
 	renderManager_ = nullptr;
 }

--- a/libretro/LibretroGLContext.cpp
+++ b/libretro/LibretroGLContext.cpp
@@ -8,19 +8,11 @@
 
 bool LibretroGLContext::Init()
 {
-	if (!LibretroHWRenderContext::Init())
+	if (!LibretroHWRenderContext::Init(true))
 		return false;
-
-	libretro_get_proc_address = hw_render_.get_proc_address;
 
 	g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 	return true;
-}
-
-void LibretroGLContext::Shutdown()
-{
-	LibretroGraphicsContext::Shutdown();
-	libretro_get_proc_address = nullptr;
 }
 
 void LibretroGLContext::CreateDrawContext()
@@ -40,6 +32,7 @@ void LibretroGLContext::CreateDrawContext()
 	draw_ = Draw::T3DCreateGLContext();
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 }
+
 void LibretroGLContext::DestroyDrawContext()
 {
 	LibretroHWRenderContext::DestroyDrawContext();

--- a/libretro/LibretroGLContext.h
+++ b/libretro/LibretroGLContext.h
@@ -5,15 +5,14 @@
 #include "thin3d/GLRenderManager.h"
 
 class LibretroGLContext : public LibretroHWRenderContext {
-	public:
+public:
 	LibretroGLContext()
-		 :
 #ifdef USING_GLES2
-			HWRenderContext(RETRO_HW_CONTEXT_OPENGLES2)
+		: HWRenderContext(RETRO_HW_CONTEXT_OPENGLES2)
 #elif defined(HAVE_OPENGL_CORE)
-			HWRenderContext(RETRO_HW_CONTEXT_OPENGL_CORE, 3, 1)
+		: HWRenderContext(RETRO_HW_CONTEXT_OPENGL_CORE, 3, 1)
 #else
-			LibretroHWRenderContext(RETRO_HW_CONTEXT_OPENGL)
+		: LibretroHWRenderContext(RETRO_HW_CONTEXT_OPENGL)
 #endif
 	{
 		hw_render_.bottom_left_origin = true;
@@ -22,8 +21,7 @@ class LibretroGLContext : public LibretroHWRenderContext {
 	bool Init() override;
 	void CreateDrawContext() override;
 	void DestroyDrawContext() override;
-	void SetRenderTarget() override
-	{
+	void SetRenderTarget() override {
 		extern GLuint g_defaultFBO;
 		g_defaultFBO = hw_render_.get_current_framebuffer();
 	}
@@ -31,8 +29,7 @@ class LibretroGLContext : public LibretroHWRenderContext {
 	void ThreadStart() override { renderManager_->ThreadStart(); }
 	bool ThreadFrame() override { return renderManager_->ThreadFrame(); }
 	void ThreadEnd() override { renderManager_->ThreadEnd(); }
-	void StopThread() override
-	{
+	void StopThread() override {
 		renderManager_->WaitUntilQueueIdle();
 		renderManager_->StopThread();
 	}
@@ -40,7 +37,7 @@ class LibretroGLContext : public LibretroHWRenderContext {
 	GPUCore GetGPUCore() override { return GPUCORE_GLES; }
 	const char *Ident() override { return "OpenGL"; }
 
-	private:
+private:
 	GLRenderManager *renderManager_ = nullptr;
 	bool glewInitDone = false;
 };

--- a/libretro/LibretroGLContext.h
+++ b/libretro/LibretroGLContext.h
@@ -20,7 +20,6 @@ class LibretroGLContext : public LibretroHWRenderContext {
 	}
 
 	bool Init() override;
-	void Shutdown() override;
 	void CreateDrawContext() override;
 	void DestroyDrawContext() override;
 	void SetRenderTarget() override

--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -25,8 +25,7 @@ bool LibretroHWRenderContext::Init(bool cache_context) {
 	return Libretro::environ_cb(RETRO_ENVIRONMENT_SET_HW_RENDER, &hw_render_);
 }
 
-LibretroHWRenderContext::LibretroHWRenderContext(retro_hw_context_type context_type, unsigned version_major, unsigned version_minor)
-{
+LibretroHWRenderContext::LibretroHWRenderContext(retro_hw_context_type context_type, unsigned version_major, unsigned version_minor) {
 	hw_render_.context_type = context_type;
 	hw_render_.version_major = version_major;
 	hw_render_.version_minor = version_minor;
@@ -35,17 +34,16 @@ LibretroHWRenderContext::LibretroHWRenderContext(retro_hw_context_type context_t
 	hw_render_.depth = true;
 }
 
-void LibretroHWRenderContext::ContextReset()
-{
+void LibretroHWRenderContext::ContextReset() {
 	INFO_LOG(G3D, "Context reset");
 
 	// needed to restart the thread
 	// TODO: find a way to move this to ContextDestroy.
-	if (!hw_render_.cache_context && Libretro::useEmuThread && draw_ && Libretro::emuThreadState != Libretro::EmuThreadState::PAUSED)
+	if (!hw_render_.cache_context && Libretro::useEmuThread && draw_ && Libretro::emuThreadState != Libretro::EmuThreadState::PAUSED) {
 		DestroyDrawContext();
+	}
 
-	if (!draw_)
-	{
+	if (!draw_) {
 		CreateDrawContext();
 		PSP_CoreParameter().thin3d = draw_;
 		bool success = draw_->CreatePresets();
@@ -54,16 +52,15 @@ void LibretroHWRenderContext::ContextReset()
 
 	GotBackbuffer();
 
-	if (gpu)
+	if (gpu) {
 		gpu->DeviceRestore();
+	}
 }
 
-void LibretroHWRenderContext::ContextDestroy()
-{
+void LibretroHWRenderContext::ContextDestroy() {
 	INFO_LOG(G3D, "Context destroy");
 
-	if (Libretro::useEmuThread)
-	{
+	if (Libretro::useEmuThread) {
 #if 0
 		Libretro::EmuThreadPause();
 #else
@@ -75,62 +72,56 @@ void LibretroHWRenderContext::ContextDestroy()
 
 	gpu->DeviceLost();
 
-	if(!hw_render_.cache_context && !Libretro::useEmuThread)
+	if (!hw_render_.cache_context && !Libretro::useEmuThread) {
 		Shutdown();
+	}
 }
 
-void LibretroGraphicsContext::GotBackbuffer()
-{
-	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
-}
+void LibretroGraphicsContext::GotBackbuffer() { draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight); }
 
-void LibretroGraphicsContext::LostBackbuffer()
-{
-	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, -1, -1);
-}
+void LibretroGraphicsContext::LostBackbuffer() { draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, -1, -1); }
 
-LibretroGraphicsContext *LibretroGraphicsContext::CreateGraphicsContext()
-{
+LibretroGraphicsContext *LibretroGraphicsContext::CreateGraphicsContext() {
 	LibretroGraphicsContext *ctx;
 
 	ctx = new LibretroGLContext();
 
-	if (ctx->Init())
+	if (ctx->Init()) {
 		return ctx;
-
+	}
 	delete ctx;
 
 #ifndef NO_VULKAN
 	ctx = new LibretroVulkanContext();
 
-	if (ctx->Init())
+	if (ctx->Init()) {
 		return ctx;
-
+	}
 	delete ctx;
 #endif
 
 #ifdef _WIN32
 	ctx = new LibretroD3D11Context();
 
-	if (ctx->Init())
+	if (ctx->Init()) {
 		return ctx;
-
+	}
 	delete ctx;
 
 	ctx = new LibretroD3D9Context();
 
-	if (ctx->Init())
+	if (ctx->Init()) {
 		return ctx;
-
+	}
 	delete ctx;
 #endif
 
 #if 1
 	ctx = new LibretroSoftwareContext();
 
-	if (ctx->Init())
+	if (ctx->Init()) {
 		return ctx;
-
+	}
 	delete ctx;
 #endif
 

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -72,9 +72,9 @@ class LibretroD3D9Context : public LibretroHWRenderContext {
 	LibretroD3D9Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 9) {}
 	bool Init() override { return false; }
 
-	void InitDrawContext() override
+	void CreateDrawContext() override
 	{
-		draw_ = Draw::T3DCreateDX9Context();
+		draw_ = Draw::T3DCreateDX9Context(nullptr, nullptr, 0, nullptr, nullptr);
 		draw_->CreatePresets();
 	}
 
@@ -87,9 +87,9 @@ class LibretroD3D11Context : public LibretroHWRenderContext {
 	LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 11) {}
 	bool Init() override { return false; }
 
-	void InitDrawContext() override
+	void CreateDrawContext() override
 	{
-		draw_ = Draw::T3DCreateD3D11Context();
+		draw_ = Draw::T3DCreateD3D11Context(nullptr, nullptr, nullptr, nullptr, D3D_FEATURE_LEVEL_11_0, nullptr);
 		draw_->CreatePresets();
 	}
 

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -50,7 +50,7 @@ class LibretroGraphicsContext : public GraphicsContext {
 class LibretroHWRenderContext : public LibretroGraphicsContext {
 	public:
 	LibretroHWRenderContext(retro_hw_context_type context_type, unsigned version_major = 0, unsigned version_minor = 0);
-	bool Init() override;
+	bool Init(bool cache_context);
 	void SetRenderTarget() override {}
 	void SwapBuffers() override
 	{
@@ -65,8 +65,6 @@ class LibretroHWRenderContext : public LibretroGraphicsContext {
 	protected:
 	retro_hw_render_callback hw_render_ = {};
 };
-
-extern "C" retro_hw_get_proc_address_t libretro_get_proc_address;
 
 #ifdef _WIN32
 class LibretroD3D9Context : public LibretroHWRenderContext {

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -11,7 +11,7 @@
 class LibretroGraphicsContext : public GraphicsContext {
 	public:
 	LibretroGraphicsContext() {}
-	~LibretroGraphicsContext() override {}
+	~LibretroGraphicsContext() override { Shutdown();}
 
 	virtual bool Init() = 0;
 	virtual void SetRenderTarget() {}
@@ -26,12 +26,14 @@ class LibretroGraphicsContext : public GraphicsContext {
 	void SwapInterval(int interval) override {}
 	void Resize() override {}
 
+	virtual void GotBackbuffer();
+	virtual void LostBackbuffer();
+
 	virtual void CreateDrawContext() {}
 	virtual void DestroyDrawContext()
 	{
 		if (!draw_)
 			return;
-		draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, -1, -1);
 		delete draw_;
 		draw_ = nullptr;
 	}
@@ -80,21 +82,6 @@ class LibretroD3D9Context : public LibretroHWRenderContext {
 
 	GPUCore GetGPUCore() override { return GPUCORE_DIRECTX9; }
 	const char *Ident() override { return "DirectX 9"; }
-};
-
-class LibretroD3D11Context : public LibretroHWRenderContext {
-	public:
-	LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 11) {}
-	bool Init() override { return false; }
-
-	void CreateDrawContext() override
-	{
-		draw_ = Draw::T3DCreateD3D11Context(nullptr, nullptr, nullptr, nullptr, D3D_FEATURE_LEVEL_11_0, nullptr);
-		draw_->CreatePresets();
-	}
-
-	GPUCore GetGPUCore() override { return GPUCORE_DIRECTX11; }
-	const char *Ident() override { return "DirectX 11"; }
 };
 #endif
 

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -9,17 +9,16 @@
 #include "GPU/GPUState.h"
 
 class LibretroGraphicsContext : public GraphicsContext {
-	public:
+public:
 	LibretroGraphicsContext() {}
-	~LibretroGraphicsContext() override { Shutdown();}
+	~LibretroGraphicsContext() override { Shutdown(); }
 
 	virtual bool Init() = 0;
 	virtual void SetRenderTarget() {}
 	virtual GPUCore GetGPUCore() = 0;
 	virtual const char *Ident() = 0;
 
-	void Shutdown() override
-	{
+	void Shutdown() override {
 		DestroyDrawContext();
 		PSP_CoreParameter().thin3d = nullptr;
 	}
@@ -30,10 +29,10 @@ class LibretroGraphicsContext : public GraphicsContext {
 	virtual void LostBackbuffer();
 
 	virtual void CreateDrawContext() {}
-	virtual void DestroyDrawContext()
-	{
-		if (!draw_)
+	virtual void DestroyDrawContext() {
+		if (!draw_) {
 			return;
+		}
 		delete draw_;
 		draw_ = nullptr;
 	}
@@ -43,37 +42,36 @@ class LibretroGraphicsContext : public GraphicsContext {
 
 	static retro_video_refresh_t video_cb;
 
-	protected:
+protected:
 	Draw::DrawContext *draw_ = nullptr;
 };
 
 class LibretroHWRenderContext : public LibretroGraphicsContext {
-	public:
+public:
 	LibretroHWRenderContext(retro_hw_context_type context_type, unsigned version_major = 0, unsigned version_minor = 0);
 	bool Init(bool cache_context);
 	void SetRenderTarget() override {}
-	void SwapBuffers() override
-	{
-		if (gstate_c.skipDrawReason)
+	void SwapBuffers() override {
+		if (gstate_c.skipDrawReason) {
 			video_cb(NULL, 0, 0, 0);
-		else
+		} else {
 			video_cb(RETRO_HW_FRAME_BUFFER_VALID, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, 0);
+		}
 	}
 	virtual void ContextReset();
 	virtual void ContextDestroy();
 
-	protected:
+protected:
 	retro_hw_render_callback hw_render_ = {};
 };
 
 #ifdef _WIN32
 class LibretroD3D9Context : public LibretroHWRenderContext {
-	public:
+public:
 	LibretroD3D9Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 9) {}
 	bool Init() override { return false; }
 
-	void CreateDrawContext() override
-	{
+	void CreateDrawContext() override {
 		draw_ = Draw::T3DCreateDX9Context(nullptr, nullptr, 0, nullptr, nullptr);
 		draw_->CreatePresets();
 	}
@@ -84,7 +82,7 @@ class LibretroD3D9Context : public LibretroHWRenderContext {
 #endif
 
 class LibretroSoftwareContext : public LibretroGraphicsContext {
-	public:
+public:
 	LibretroSoftwareContext() {}
 	bool Init() override { return true; }
 	void SwapBuffers() override { video_cb(NULL, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, 0); }
@@ -93,7 +91,7 @@ class LibretroSoftwareContext : public LibretroGraphicsContext {
 };
 
 class LibretroNullContext : public LibretroGraphicsContext {
-	public:
+public:
 	LibretroNullContext() {}
 
 	bool Init() override { return true; }
@@ -106,8 +104,7 @@ namespace Libretro {
 extern LibretroGraphicsContext *ctx;
 extern retro_environment_t environ_cb;
 
-enum class EmuThreadState
-{
+enum class EmuThreadState {
 	DISABLED,
 	START_REQUESTED,
 	RUNNING,
@@ -121,4 +118,4 @@ extern std::atomic<EmuThreadState> emuThreadState;
 void EmuThreadStart();
 void EmuThreadStop();
 void EmuThreadPause();
-}   // namespace Libretro
+} // namespace Libretro

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -1,5 +1,4 @@
 
-
 #include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanContext.h"
 #include "Common/Vulkan/VulkanDebug.h"
@@ -22,19 +21,16 @@ void vk_libretro_wait_for_presentation();
 LibretroVulkanContext::LibretroVulkanContext()
 	: LibretroHWRenderContext(RETRO_HW_CONTEXT_VULKAN, VK_MAKE_VERSION(1, 0, 18)) {}
 
-void LibretroVulkanContext::SwapBuffers()
-{
+void LibretroVulkanContext::SwapBuffers() {
 	vk_libretro_wait_for_presentation();
 	LibretroHWRenderContext::SwapBuffers();
 }
 
-static bool create_device(retro_vulkan_context *context, VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, PFN_vkGetInstanceProcAddr get_instance_proc_addr, const char **required_device_extensions, unsigned num_required_device_extensions, const char **required_device_layers, unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features)
-{
+static bool create_device(retro_vulkan_context *context, VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, PFN_vkGetInstanceProcAddr get_instance_proc_addr, const char **required_device_extensions, unsigned num_required_device_extensions, const char **required_device_layers, unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features) {
 	init_glslang();
 
 	vk = new VulkanContext;
-	if (!vk->InitError().empty())
-	{
+	if (!vk->InitError().empty()) {
 		ERROR_LOG(G3D, "%s", vk->InitError().c_str());
 		return false;
 	}
@@ -44,11 +40,13 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	vk->CreateInstance({});
 
 	int physical_device = 0;
-	while (gpu && vk->GetPhysicalDevice(physical_device) != gpu)
+	while (gpu && vk->GetPhysicalDevice(physical_device) != gpu) {
 		physical_device++;
+	}
 
-	if (!gpu)
+	if (!gpu) {
 		physical_device = vk->GetBestPhysicalDevice();
+	}
 
 	vk->ChooseDevice(physical_device);
 	vk->CreateDevice();
@@ -64,8 +62,9 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	vk->InitSurface(WINDOWSYSTEM_WAYLAND, nullptr, nullptr);
 #endif
 
-	if (!vk->InitQueue())
+	if (!vk->InitQueue()) {
 		return false;
+	}
 
 	context->gpu = vk->GetPhysicalDevice(physical_device);
 	context->device = vk->GetDevice();
@@ -79,8 +78,7 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	return true;
 }
 
-static const VkApplicationInfo *GetApplicationInfo(void)
-{
+static const VkApplicationInfo *GetApplicationInfo(void) {
 	static VkApplicationInfo app_info{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
 	app_info.pApplicationName = "PPSSPP";
 	app_info.applicationVersion = Version(PPSSPP_GIT_VERSION).ToInteger();
@@ -90,10 +88,10 @@ static const VkApplicationInfo *GetApplicationInfo(void)
 	return &app_info;
 }
 
-bool LibretroVulkanContext::Init()
-{
-	if (!LibretroHWRenderContext::Init(false))
+bool LibretroVulkanContext::Init() {
+	if (!LibretroHWRenderContext::Init(false)) {
 		return false;
+	}
 
 	static const struct retro_hw_render_context_negotiation_interface_vulkan iface = { RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN, RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN_VERSION, GetApplicationInfo, create_device, nullptr };
 	Libretro::environ_cb(RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE, (void *)&iface);
@@ -102,12 +100,12 @@ bool LibretroVulkanContext::Init()
 	return true;
 }
 
-void LibretroVulkanContext::Shutdown()
-{
+void LibretroVulkanContext::Shutdown() {
 	LibretroHWRenderContext::Shutdown();
 
-	if (!vk)
+	if (!vk) {
 		return;
+	}
 
 	vk->WaitUntilQueueIdle();
 
@@ -123,16 +121,13 @@ void LibretroVulkanContext::Shutdown()
 
 void *LibretroVulkanContext::GetAPIContext() { return vk; }
 
-void LibretroVulkanContext::CreateDrawContext()
-{
+void LibretroVulkanContext::CreateDrawContext() {
 	retro_hw_render_interface *vulkan;
-	if (!Libretro::environ_cb(RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE, (void **)&vulkan) || !vulkan)
-	{
+	if (!Libretro::environ_cb(RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE, (void **)&vulkan) || !vulkan) {
 		ERROR_LOG(G3D, "Failed to get HW rendering interface!\n");
 		return;
 	}
-	if (vulkan->interface_version != RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION)
-	{
+	if (vulkan->interface_version != RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION) {
 		ERROR_LOG(G3D, "HW render interface mismatch, expected %u, got %u!\n", RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION, vulkan->interface_version);
 		return;
 	}
@@ -140,8 +135,9 @@ void LibretroVulkanContext::CreateDrawContext()
 
 	vk->ReinitSurface(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 
-	if (!vk->InitSwapchain())
+	if (!vk->InitSwapchain()) {
 		return;
+	}
 
 	draw_ = Draw::T3DCreateVulkanContext(vk, false);
 }

--- a/libretro/LibretroVulkanContext.h
+++ b/libretro/LibretroVulkanContext.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#include "Common/Vulkan/VulkanLoader.h"
 #include "libretro/LibretroGraphicsContext.h"
 
 class LibretroVulkanContext : public LibretroHWRenderContext {
 	public:
-	LibretroVulkanContext() : LibretroHWRenderContext(RETRO_HW_CONTEXT_VULKAN, VK_MAKE_VERSION(1, 0, 18)) {}
+	LibretroVulkanContext();
 	~LibretroVulkanContext() override {}
 	bool Init() override;
 	void Shutdown() override;
 	void SwapBuffers() override;
-	void ContextDestroy() override;
 
 	void *GetAPIContext() override;
 	void CreateDrawContext() override;

--- a/libretro/LibretroVulkanContext.h
+++ b/libretro/LibretroVulkanContext.h
@@ -3,7 +3,7 @@
 #include "libretro/LibretroGraphicsContext.h"
 
 class LibretroVulkanContext : public LibretroHWRenderContext {
-	public:
+public:
 	LibretroVulkanContext();
 	~LibretroVulkanContext() override {}
 	bool Init() override;

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -200,13 +200,13 @@ else ifeq ($(platform), qnx)
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
+	TARGET_ARCH = armv7
 	fpic := -fPIC
 	LDFLAGS += -shared -Wl,--version-script=link.T -Wl,--no-undefined
 	FFMPEGINCFLAGS += -I$(FFMPEGDIR)/linux/$(TARGET_ARCH)/include
 	FFMPEGLIBDIR := $(FFMPEGDIR)/linux/$(TARGET_ARCH)/lib
 	FFMPEGLDFLAGS += -L$(FFMPEGLIBDIR) -lavformat -lavcodec -lavutil -lswresample -lswscale
 	INCFLAGS += -I.
-	TARGET_ARCH = arm
 	ifneq (,$(findstring gles,$(platform)))
 		GLES := 1
 		GL_LIB := -lGLESv2 -lEGL

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -280,7 +280,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
-	ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
+	ProgramFiles86w := $(shell echo "$$PROGRAMFILES(x86)")
 	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
 
 	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
@@ -311,6 +311,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 
 	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
 	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
+	VcCompilerLibDir := $(VcCompilerToolsDir)/lib/$(TargetArchMoniker)
 
 	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
@@ -318,7 +319,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
 	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
-	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerLibDir)")
 	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
 
 	# For some reason the HostX86 compiler doesn't like compiling for x64
@@ -327,15 +328,15 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	# NOTE: What about ARM?
 	ifneq (,$(findstring x64,$(TargetArchMoniker)))
 		TARGET_ARCH = x86_64
-		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX64
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX64/$(TargetArchMoniker)
       LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x64
 	else
 		TARGET_ARCH = x86
-		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX86/$(TargetArchMoniker)
       LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x86
 	endif
 
-	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)"):$(PATH)
 	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
 
 	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
@@ -403,10 +404,8 @@ CXXFLAGS    += $(CPUOPTS) $(COREFLAGS) $(FFMPEGINCFLAGS) $(INCFLAGS) $(INCFLAGS_
 CFLAGS		+= $(CPUOPTS) $(COREFLAGS) $(FFMPEGINCFLAGS) $(INCFLAGS) $(INCFLAGS_PLATFORM) $(PLATCFLAGS) $(fpic) $(PLATCFLAGS) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
 
 LDFLAGS		+= $(FFMPEGLDFLAGS) $(fpic)
-ifeq (,$(findstring android,$(platform)))
-   ifeq (,$(findstring msvc,$(platform)))
-      LDFLAGS		+= -lpthread
-   endif
+ifeq (,$(findstring android,$(platform))$(findstring msvc,$(platform)))
+   LDFLAGS	+= -lpthread
 endif
 
 OBJOUT   = -o

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -280,7 +280,9 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
-	ProgramFiles86w := $(shell echo "$$PROGRAMFILES(x86)")
+	b1 := (
+	b2 := )
+	ProgramFiles86w := $(ProgramFiles$(b1)x86$(b2))
 	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
 
 	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
@@ -327,11 +329,11 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	# Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
 	# NOTE: What about ARM?
 	ifneq (,$(findstring x64,$(TargetArchMoniker)))
-		TARGET_ARCH = x86_64
+		override TARGET_ARCH = x86_64
 		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX64/$(TargetArchMoniker)
       LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x64
 	else
-		TARGET_ARCH = x86
+		override TARGET_ARCH = x86
 		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX86/$(TargetArchMoniker)
       LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x86
 	endif

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -417,6 +417,8 @@ ifneq (,$(findstring msvc,$(platform)))
 	OBJOUT = -Fo
 	LINKOUT = -out:
 	LD = link.exe
+else ifneq (,$(findstring osx,$(platform)))
+	LD = $(CXX)
 else
 	LD = $(CXX)
    CFLAGS += -ffunction-sections -fdata-sections

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -636,7 +636,8 @@ SOURCES_CXX += \
 	$(GPUDIR)/D3D11/StencilBufferD3D11.cpp \
 	$(GPUDIR)/D3D11/TextureCacheD3D11.cpp \
 	$(GPUDIR)/D3D11/TextureScalerD3D11.cpp \
-	$(GPUDIR)/D3D11/VertexShaderGeneratorD3D11.cpp
+	$(GPUDIR)/D3D11/VertexShaderGeneratorD3D11.cpp \
+   $(LIBRETRODIR)/LibretroD3D11Context.cpp
 
 SOURCES_CXX += \
    $(NATIVEDIR)/thin3d/thin3d_d3d9.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -673,8 +673,8 @@ endif
 
 GIT_VERSION_SRC = $(CORE_DIR)/git-version.cpp
 GIT_VERSION := $(shell git describe --always || echo v1.4.2-git)
-GIT_VERSION_NO_UPDATE = $(findstring 1,$(shell grep PPSSPP_GIT_VERSION_NO_UPDATE $(GIT_VERSION_SRC)))
-ifneq (,$(findstring $(GIT_VERSION),$(shell grep char $(GIT_VERSION_SRC))))
+GIT_VERSION_NO_UPDATE = $(findstring 1,$(shell grep -s PPSSPP_GIT_VERSION_NO_UPDATE $(GIT_VERSION_SRC)))
+ifneq (,$(findstring $(GIT_VERSION),$(shell grep -s char $(GIT_VERSION_SRC))))
    GIT_VERSION_NO_UPDATE = 1
 endif
 

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -250,7 +250,8 @@ SOURCES_CXX += $(COMMONDIR)/MemArenaWin32.cpp \
 	       $(EXTDIR)/glslang/glslang/OSDependent/Windows/ossource.cpp \
 	       $(NATIVEDIR)/gfx_es2/draw_text_win.cpp
 else ifeq ($(PLATFORM_EXT), darwin)
-SOURCES_CXX += $(COMMONDIR)/MemArenaDarwin.cpp
+SOURCES_CXX += $(COMMONDIR)/MemArenaDarwin.cpp \
+	       $(EXTDIR)/glslang/glslang/OSDependent/Unix/ossource.cpp
 else ifeq ($(PLATFORM_EXT), android)
 SOURCES_CXX += $(COMMONDIR)/MemArenaAndroid.cpp \
 	       $(EXTDIR)/glslang/glslang/OSDependent/Unix/ossource.cpp \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <thread>
 #include <atomic>
+#include <vector>
 
 #include "base/timeutil.h"
 #include "Common/ChunkFile.h"

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -46,18 +46,17 @@ retro_environment_t environ_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
-}   // namespace Libretro
+} // namespace Libretro
 
 using namespace Libretro;
 
 class LibretroHost : public Host {
-	public:
+public:
 	LibretroHost() {}
 	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
 	void ShutdownGraphics() override {}
 	void InitSound() override {}
-	void UpdateSound() override
-	{
+	void UpdateSound() override {
 		extern int hostAttemptBlockSize;
 		const int blockSizeMax = 512;
 		static int16_t audio[blockSizeMax * 2];
@@ -72,69 +71,60 @@ class LibretroHost : public Host {
 };
 
 class PrintfLogger : public LogListener {
-	public:
+public:
 	PrintfLogger(retro_log_callback log) : log_(log.log) {}
-	void Log(const LogMessage &message)
-	{
-		switch (message.level)
-		{
-			case LogTypes::LVERBOSE:
-			case LogTypes::LDEBUG:
-				log_(RETRO_LOG_DEBUG, "[%s] %s", message.log, message.msg.c_str());
-				return;
+	void Log(const LogMessage &message) {
+		switch (message.level) {
+		case LogTypes::LVERBOSE:
+		case LogTypes::LDEBUG:
+			log_(RETRO_LOG_DEBUG, "[%s] %s", message.log, message.msg.c_str());
+			return;
 
-			case LogTypes::LERROR:
-				log_(RETRO_LOG_ERROR, "[%s] %s", message.log, message.msg.c_str());
-				return;
+		case LogTypes::LERROR:
+			log_(RETRO_LOG_ERROR, "[%s] %s", message.log, message.msg.c_str());
+			return;
 
-			case LogTypes::LNOTICE:
-			case LogTypes::LWARNING:
-				log_(RETRO_LOG_WARN, "[%s] %s", message.log, message.msg.c_str());
-				return;
+		case LogTypes::LNOTICE:
+		case LogTypes::LWARNING:
+			log_(RETRO_LOG_WARN, "[%s] %s", message.log, message.msg.c_str());
+			return;
 
-			case LogTypes::LINFO:
-			default:
-				log_(RETRO_LOG_INFO, "[%s] %s", message.log, message.msg.c_str());
-				return;
+		case LogTypes::LINFO:
+		default:
+			log_(RETRO_LOG_INFO, "[%s] %s", message.log, message.msg.c_str());
+			return;
 		}
 	}
 
-	private:
+private:
 	retro_log_printf_t log_;
 };
 static PrintfLogger *printfLogger;
 
 template <typename T> class RetroOption {
-	public:
+public:
 	RetroOption(const char *id, const char *name, std::initializer_list<std::pair<const char *, T>> list) : id_(id), name_(name), list_(list.begin(), list.end()) {}
-	RetroOption(const char *id, const char *name, std::initializer_list<const char *> list) : id_(id), name_(name)
-	{
+	RetroOption(const char *id, const char *name, std::initializer_list<const char *> list) : id_(id), name_(name) {
 		for (auto option : list)
 			list_.push_back({ option, (T)list_.size() });
 	}
-	RetroOption(const char *id, const char *name, T first, std::initializer_list<const char *> list) : id_(id), name_(name)
-	{
+	RetroOption(const char *id, const char *name, T first, std::initializer_list<const char *> list) : id_(id), name_(name) {
 		for (auto option : list)
 			list_.push_back({ option, first + (int)list_.size() });
 	}
-	RetroOption(const char *id, const char *name, T first, int count, int step = 1) : id_(id), name_(name)
-	{
+	RetroOption(const char *id, const char *name, T first, int count, int step = 1) : id_(id), name_(name) {
 		for (T i = first; i < first + count; i += step)
 			list_.push_back({ std::to_string(i), i });
 	}
-	RetroOption(const char *id, const char *name, bool initial) : id_(id), name_(name)
-	{
+	RetroOption(const char *id, const char *name, bool initial) : id_(id), name_(name) {
 		list_.push_back({ initial ? "enabled" : "disabled", initial });
 		list_.push_back({ !initial ? "enabled" : "disabled", !initial });
 	}
-	retro_variable GetOptions()
-	{
-		if (options_.empty())
-		{
+	retro_variable GetOptions() {
+		if (options_.empty()) {
 			options_ = name_;
 			options_.push_back(';');
-			for (auto &option : list_)
-			{
+			for (auto &option : list_) {
 				if (option.first == list_.begin()->first)
 					options_ += std::string(" ") + option.first;
 				else
@@ -143,25 +133,20 @@ template <typename T> class RetroOption {
 		}
 		return { id_, options_.c_str() };
 	}
-	bool Update(T *dest)
-	{
+	bool Update(T *dest) {
 		retro_variable var{ id_ };
 		T val = list_.front().second;
 
-		if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-		{
-			for (auto option : list_)
-			{
-				if (option.first == var.value)
-				{
+		if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+			for (auto option : list_) {
+				if (option.first == var.value) {
 					val = option.second;
 					break;
 				}
 			}
 		}
 
-		if (*dest != val)
-		{
+		if (*dest != val) {
 			*dest = val;
 			return true;
 		}
@@ -169,7 +154,7 @@ template <typename T> class RetroOption {
 		return false;
 	}
 
-	private:
+private:
 	const char *id_;
 	const char *name_;
 	std::string options_;
@@ -200,8 +185,7 @@ static RetroOption<bool> ppsspp_unsafe_func_replacements("ppsspp_unsafe_func_rep
 static RetroOption<bool> ppsspp_sound_speedhack("ppsspp_sound_speedhack", "Sound Speedhack", false);
 static RetroOption<bool> ppsspp_cheats("ppsspp_cheats", "Internal Cheats Support", false);
 
-void retro_set_environment(retro_environment_t cb)
-{
+void retro_set_environment(retro_environment_t cb) {
 	std::vector<retro_variable> vars;
 	vars.push_back(ppsspp_cpu_core.GetOptions());
 	vars.push_back(ppsspp_locked_cpu_speed.GetOptions());
@@ -233,44 +217,41 @@ void retro_set_environment(retro_environment_t cb)
 	cb(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars.data());
 }
 
-static int get_language_auto(void)
-{
+static int get_language_auto(void) {
 	retro_language val = RETRO_LANGUAGE_ENGLISH;
 	environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &val);
 
-	switch (val)
-	{
-		default:
-		case RETRO_LANGUAGE_ENGLISH:
-			return PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
-		case RETRO_LANGUAGE_JAPANESE:
-			return PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
-		case RETRO_LANGUAGE_FRENCH:
-			return PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
-		case RETRO_LANGUAGE_GERMAN:
-			return PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
-		case RETRO_LANGUAGE_SPANISH:
-			return PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
-		case RETRO_LANGUAGE_ITALIAN:
-			return PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
-		case RETRO_LANGUAGE_PORTUGUESE_BRAZIL:
-		case RETRO_LANGUAGE_PORTUGUESE_PORTUGAL:
-			return PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
-		case RETRO_LANGUAGE_RUSSIAN:
-			return PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
-		case RETRO_LANGUAGE_DUTCH:
-			return PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
-		case RETRO_LANGUAGE_KOREAN:
-			return PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
-		case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
-			return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
-		case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
-			return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
+	switch (val) {
+	default:
+	case RETRO_LANGUAGE_ENGLISH:
+		return PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+	case RETRO_LANGUAGE_JAPANESE:
+		return PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
+	case RETRO_LANGUAGE_FRENCH:
+		return PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
+	case RETRO_LANGUAGE_GERMAN:
+		return PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
+	case RETRO_LANGUAGE_SPANISH:
+		return PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
+	case RETRO_LANGUAGE_ITALIAN:
+		return PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
+	case RETRO_LANGUAGE_PORTUGUESE_BRAZIL:
+	case RETRO_LANGUAGE_PORTUGUESE_PORTUGAL:
+		return PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
+	case RETRO_LANGUAGE_RUSSIAN:
+		return PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
+	case RETRO_LANGUAGE_DUTCH:
+		return PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
+	case RETRO_LANGUAGE_KOREAN:
+		return PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
+	case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
+		return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
+	case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
+		return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
 	}
 }
 
-static void check_variables(CoreParameter &coreParam)
-{
+static void check_variables(CoreParameter &coreParam) {
 	bool updated = false;
 
 	if (coreState != CORE_POWERUP && environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && !updated)
@@ -297,15 +278,14 @@ static void check_variables(CoreParameter &coreParam)
 	ppsspp_cpu_core.Update((CPUCore *)&g_Config.iCpuCore);
 
 	ppsspp_language.Update(&g_Config.iLanguage);
-	if (g_Config.iLanguage < 0)
+	if (g_Config.iLanguage < 0) {
 		g_Config.iLanguage = get_language_auto();
+	}
 
-	if (ppsspp_internal_resolution.Update(&g_Config.iInternalResolution))
-	{
+	if (ppsspp_internal_resolution.Update(&g_Config.iInternalResolution)) {
 		coreParam.pixelWidth = coreParam.renderWidth = g_Config.iInternalResolution * 480;
 		coreParam.pixelHeight = coreParam.renderHeight = g_Config.iInternalResolution * 272;
-		if (gpu)
-		{
+		if (gpu) {
 			retro_system_av_info av_info;
 			retro_get_system_av_info(&av_info);
 			environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
@@ -313,11 +293,13 @@ static void check_variables(CoreParameter &coreParam)
 		}
 	}
 
-	if (ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType) && gpu)
+	if (ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType) && gpu) {
 		gpu->ClearCacheNextFrame();
+	}
 
-	if (ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel) && gpu)
+	if (ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel) && gpu) {
 		gpu->ClearCacheNextFrame();
+	}
 }
 
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
@@ -325,8 +307,7 @@ void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
 void retro_set_input_poll(retro_input_poll_t cb) { input_poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 
-void retro_init(void)
-{
+void retro_init(void) {
 #if 0
 	g_Config.Load("");
 #endif
@@ -344,8 +325,7 @@ void retro_init(void)
 	host = new LibretroHost;
 
 	struct retro_log_callback log;
-	if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
-	{
+	if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log)) {
 		printfLogger = new PrintfLogger(log);
 		LogManager *logman = LogManager::GetInstance();
 		logman->RemoveListener(logman->GetConsoleListener());
@@ -358,8 +338,7 @@ void retro_init(void)
 	}
 }
 
-void retro_deinit(void)
-{
+void retro_deinit(void) {
 	LogManager::Shutdown();
 
 	delete printfLogger;
@@ -369,14 +348,12 @@ void retro_deinit(void)
 	host = nullptr;
 }
 
-void retro_set_controller_port_device(unsigned port, unsigned device)
-{
+void retro_set_controller_port_device(unsigned port, unsigned device) {
 	(void)port;
 	(void)device;
 }
 
-void retro_get_system_info(struct retro_system_info *info)
-{
+void retro_get_system_info(struct retro_system_info *info) {
 	*info = {};
 	info->library_name = "PPSSPP";
 	info->library_version = PPSSPP_GIT_VERSION;
@@ -384,8 +361,7 @@ void retro_get_system_info(struct retro_system_info *info)
 	info->valid_extensions = "elf|iso|cso|prx|pbp";
 }
 
-void retro_get_system_av_info(struct retro_system_av_info *info)
-{
+void retro_get_system_av_info(struct retro_system_av_info *info) {
 	*info = {};
 	info->timing.fps = 60.0f / 1.001f;
 	info->timing.sample_rate = SAMPLERATE;
@@ -404,11 +380,11 @@ bool useEmuThread = false;
 std::atomic<EmuThreadState> emuThreadState(EmuThreadState::DISABLED);
 
 static std::thread emuThread;
-static void EmuFrame()
-{
+static void EmuFrame() {
 	ctx->SetRenderTarget();
-	if (ctx->GetDrawContext())
+	if (ctx->GetDrawContext()) {
 		ctx->GetDrawContext()->BeginFrame();
+	}
 
 	gpu->BeginHostFrame();
 
@@ -417,60 +393,55 @@ static void EmuFrame()
 
 	gpu->EndHostFrame();
 
-	if (ctx->GetDrawContext())
+	if (ctx->GetDrawContext()) {
 		ctx->GetDrawContext()->EndFrame();
+	}
 }
 
-static void EmuThreadFunc()
-{
+static void EmuThreadFunc() {
 	setCurrentThreadName("Emu");
 
-	while (true)
-	{
-		switch ((EmuThreadState)emuThreadState)
-		{
-			case EmuThreadState::START_REQUESTED:
-				emuThreadState = EmuThreadState::RUNNING;
-				/* fallthrough */
-			case EmuThreadState::RUNNING:
-				EmuFrame();
-				break;
-			case EmuThreadState::PAUSE_REQUESTED:
-				emuThreadState = EmuThreadState::PAUSED;
-				/* fallthrough */
-			case EmuThreadState::PAUSED:
-				sleep_ms(1);
-				break;
-			default:
-			case EmuThreadState::QUIT_REQUESTED:
-				emuThreadState = EmuThreadState::STOPPED;
-				ctx->StopThread();
-				return;
+	while (true) {
+		switch ((EmuThreadState)emuThreadState) {
+		case EmuThreadState::START_REQUESTED:
+			emuThreadState = EmuThreadState::RUNNING;
+			/* fallthrough */
+		case EmuThreadState::RUNNING:
+			EmuFrame();
+			break;
+		case EmuThreadState::PAUSE_REQUESTED:
+			emuThreadState = EmuThreadState::PAUSED;
+			/* fallthrough */
+		case EmuThreadState::PAUSED:
+			sleep_ms(1);
+			break;
+		default:
+		case EmuThreadState::QUIT_REQUESTED:
+			emuThreadState = EmuThreadState::STOPPED;
+			ctx->StopThread();
+			return;
 		}
 	}
 }
 
-void EmuThreadStart()
-{
+void EmuThreadStart() {
 	bool wasPaused = emuThreadState == EmuThreadState::PAUSED;
 	emuThreadState = EmuThreadState::START_REQUESTED;
 
-	if (!wasPaused)
-	{
+	if (!wasPaused) {
 		ctx->ThreadStart();
 		emuThread = std::thread(&EmuThreadFunc);
 	}
 }
 
-void EmuThreadStop()
-{
-	if (emuThreadState != EmuThreadState::RUNNING)
+void EmuThreadStop() {
+	if (emuThreadState != EmuThreadState::RUNNING) {
 		return;
+	}
 
 	emuThreadState = EmuThreadState::QUIT_REQUESTED;
 
-	while (ctx->ThreadFrame())
-	{
+	while (ctx->ThreadFrame()) {
 		// Need to keep eating frames to allow the EmuThread to exit correctly.
 		continue;
 	}
@@ -479,20 +450,20 @@ void EmuThreadStop()
 	ctx->ThreadEnd();
 }
 
-void EmuThreadPause()
-{
-	if (emuThreadState != EmuThreadState::RUNNING)
+void EmuThreadPause() {
+	if (emuThreadState != EmuThreadState::RUNNING) {
 		return;
+	}
 	emuThreadState = EmuThreadState::PAUSE_REQUESTED;
 	ctx->ThreadFrame();
-	while (emuThreadState != EmuThreadState::PAUSED)
+	while (emuThreadState != EmuThreadState::PAUSED) {
 		sleep_ms(1);
+	}
 }
 
-}   // namespace Libretro
+} // namespace Libretro
 
-bool retro_load_game(const struct retro_game_info *game)
-{
+bool retro_load_game(const struct retro_game_info *game) {
 	struct retro_input_descriptor desc[] = {
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "D-Pad Left" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "D-Pad Up" },
@@ -513,22 +484,21 @@ bool retro_load_game(const struct retro_game_info *game)
 	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
 	enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
-	if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
-	{
+	if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt)) {
 		ERROR_LOG(SYSTEM, "XRGB8888 is not supported.\n");
 		return false;
 	}
 
 	const char *nickname = NULL;
-	if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &nickname) && nickname)
+	if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &nickname) && nickname) {
 		g_Config.sNickName = std::string(nickname);
+	}
 
 	const char *dir_ptr = NULL;
 	static std::string retro_base_dir;
 	static std::string retro_save_dir;
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir_ptr) && dir_ptr)
-	{
+	if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir_ptr) && dir_ptr) {
 		retro_base_dir = dir_ptr;
 		// Make sure that we don't have any lingering slashes, etc, as they break Windows.
 		size_t last = retro_base_dir.find_last_not_of(DIR_SEP_CHRS);
@@ -538,8 +508,7 @@ bool retro_load_game(const struct retro_game_info *game)
 		retro_base_dir = retro_base_dir.substr(0, last) + DIR_SEP;
 	}
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir_ptr) && dir_ptr)
-	{
+	if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir_ptr) && dir_ptr) {
 		retro_save_dir = dir_ptr;
 		// Make sure that we don't have any lingering slashes, etc, as they break Windows.
 		size_t last = retro_save_dir.find_last_not_of(DIR_SEP_CHRS);
@@ -549,13 +518,15 @@ bool retro_load_game(const struct retro_game_info *game)
 		retro_save_dir = retro_save_dir.substr(0, last) + DIR_SEP;
 	}
 
-	if (retro_base_dir.empty())
+	if (retro_base_dir.empty()) {
 		retro_base_dir = File::GetDir(game->path);
+	}
 
 	retro_base_dir += "PPSSPP" DIR_SEP;
 
-	if (retro_save_dir.empty())
+	if (retro_save_dir.empty()) {
 		retro_save_dir = File::GetDir(game->path);
+	}
 
 	g_Config.currentDirectory = retro_base_dir;
 	g_Config.externalDirectory = retro_base_dir;
@@ -592,8 +563,7 @@ bool retro_load_game(const struct retro_game_info *game)
 #endif
 
 	std::string error_string;
-	if (!PSP_InitStart(coreParam, &error_string))
-	{
+	if (!PSP_InitStart(coreParam, &error_string)) {
 		ERROR_LOG(BOOT, "%s", error_string.c_str());
 		return false;
 	}
@@ -601,10 +571,10 @@ bool retro_load_game(const struct retro_game_info *game)
 	return true;
 }
 
-void retro_unload_game(void)
-{
-	if (Libretro::useEmuThread)
+void retro_unload_game(void) {
+	if (Libretro::useEmuThread) {
 		Libretro::EmuThreadStop();
+	}
 
 	PSP_Shutdown();
 	VFSShutdown();
@@ -614,30 +584,27 @@ void retro_unload_game(void)
 	PSP_CoreParameter().graphicsContext = nullptr;
 }
 
-void retro_reset(void)
-{
+void retro_reset(void) {
 	std::string error_string;
 
 	PSP_Shutdown();
 
 #if 0
 	coreState = CORE_POWERUP;
-	if(!PSP_InitStart(PSP_CoreParameter(), &error_string))
+	if (!PSP_InitStart(PSP_CoreParameter(), &error_string))
 	{
 		ERROR_LOG(BOOT, "%s", error_string.c_str());
 		environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
 	}
 #else
-	if (!PSP_Init(PSP_CoreParameter(), &error_string))
-	{
+	if (!PSP_Init(PSP_CoreParameter(), &error_string)) {
 		ERROR_LOG(BOOT, "%s", error_string.c_str());
 		environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
 	}
 #endif
 }
 
-static void retro_input(void)
-{
+static void retro_input(void) {
 	// clang-format off
 	static struct
 	{
@@ -661,36 +628,34 @@ static void retro_input(void)
 
 	input_poll_cb();
 
-	for (int i = 0; i < sizeof(map) / sizeof(*map); i++)
-	{
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, map[i].retro))
+	for (int i = 0; i < sizeof(map) / sizeof(*map); i++) {
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, map[i].retro)) {
 			__CtrlButtonDown(map[i].sceCtrl);
-		else
+		} else {
 			__CtrlButtonUp(map[i].sceCtrl);
+		}
 	}
 
 	__CtrlSetAnalogX(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X) / 32768.0f);
 	__CtrlSetAnalogY(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / -32768.0f);
 }
 
-void retro_run(void)
-{
-	if (PSP_IsIniting())
-	{
+void retro_run(void) {
+	if (PSP_IsIniting()) {
 		std::string error_string;
 #if 0
-		if(!PSP_InitUpdate(&error_string))
+		if (!PSP_InitUpdate(&error_string))
 		{
 			graphics_context->SwapBuffers();
 			return;
 		}
 #else
-		while (!PSP_InitUpdate(&error_string))
+		while (!PSP_InitUpdate(&error_string)) {
 			sleep_ms(4);
+		}
 #endif
 
-		if (!PSP_IsInited())
-		{
+		if (!PSP_IsInited()) {
 			ERROR_LOG(BOOT, "%s", error_string.c_str());
 			environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
 			return;
@@ -701,24 +666,24 @@ void retro_run(void)
 
 	retro_input();
 
-	if (useEmuThread)
-	{
-		if (emuThreadState != EmuThreadState::RUNNING)
+	if (useEmuThread) {
+		if (emuThreadState != EmuThreadState::RUNNING) {
 			EmuThreadStart();
+		}
 
-		if (!ctx->ThreadFrame())
+		if (!ctx->ThreadFrame()) {
 			return;
-	}
-	else
+		}
+	} else {
 		EmuFrame();
+	}
 
 	ctx->SwapBuffers();
 }
 
 unsigned retro_get_region(void) { return RETRO_REGION_NTSC; }
 
-bool retro_load_game_special(unsigned type, const struct retro_game_info *info, size_t num)
-{
+bool retro_load_game_special(unsigned type, const struct retro_game_info *info, size_t num) {
 	(void)type;
 	(void)info;
 	(void)num;
@@ -726,62 +691,53 @@ bool retro_load_game_special(unsigned type, const struct retro_game_info *info, 
 }
 
 namespace SaveState {
-struct SaveStart
-{
+struct SaveStart {
 	void DoState(PointerWrap &p);
 };
-}   // namespace SaveState
+} // namespace SaveState
 
-size_t retro_serialize_size(void)
-{
+size_t retro_serialize_size(void) {
 	SaveState::SaveStart state;
 	return (CChunkFileReader::MeasurePtr(state) + 0x800000) & ~0x7FFFFF;
 }
 
-bool retro_serialize(void *data, size_t size)
-{
+bool retro_serialize(void *data, size_t size) {
 	SaveState::SaveStart state;
 	assert(CChunkFileReader::MeasurePtr(state) <= size);
 	return CChunkFileReader::SavePtr((u8 *)data, state) == CChunkFileReader::ERROR_NONE;
 }
 
-bool retro_unserialize(const void *data, size_t size)
-{
+bool retro_unserialize(const void *data, size_t size) {
 	SaveState::SaveStart state;
 	return CChunkFileReader::LoadPtr((u8 *)data, state) == CChunkFileReader::ERROR_NONE;
 }
 
-void *retro_get_memory_data(unsigned id)
-{
+void *retro_get_memory_data(unsigned id) {
 	(void)id;
 	return NULL;
 }
 
-size_t retro_get_memory_size(unsigned id)
-{
+size_t retro_get_memory_size(unsigned id) {
 	(void)id;
 	return 0;
 }
 
 void retro_cheat_reset(void) {}
 
-void retro_cheat_set(unsigned index, bool enabled, const char *code)
-{
+void retro_cheat_set(unsigned index, bool enabled, const char *code) {
 	(void)index;
 	(void)enabled;
 	(void)code;
 }
 
-int System_GetPropertyInt(SystemProperty prop)
-{
-	switch (prop)
-	{
-		case SYSPROP_AUDIO_SAMPLE_RATE:
-			return SAMPLERATE;
-		case SYSPROP_DISPLAY_REFRESH_RATE:
-			return 60000;
-		default:
-			return -1;
+int System_GetPropertyInt(SystemProperty prop) {
+	switch (prop) {
+	case SYSPROP_AUDIO_SAMPLE_RATE:
+		return SAMPLERATE;
+	case SYSPROP_DISPLAY_REFRESH_RATE:
+		return 60000;
+	default:
+		return -1;
 	}
 }
 

--- a/libretro/libretro_d3d.h
+++ b/libretro/libretro_d3d.h
@@ -1,0 +1,60 @@
+/* Copyright (C) 2010-2016 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------------
+ * The following license statement only applies to this libretro API header (libretro_vulkan.h)
+ * ---------------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the
+ * "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef LIBRETRO_DIRECT3D_H__
+#define LIBRETRO_DIRECT3D_H__
+
+#include "libretro.h"
+
+#ifdef HAVE_D3D11
+
+#include <d3d11.h>
+#include <D3Dcompiler.h>
+
+#define RETRO_HW_RENDER_INTERFACE_D3D11_VERSION 1
+
+struct retro_hw_render_interface_d3d11
+{
+  /* Must be set to RETRO_HW_RENDER_INTERFACE_D3D11. */
+  enum retro_hw_render_interface_type interface_type;
+  /* Must be set to RETRO_HW_RENDER_INTERFACE_D3D11_VERSION. */
+  unsigned interface_version;
+
+  /* Opaque handle to the d3d11 backend in the frontend
+   * which must be passed along to all function pointers
+   * in this interface.
+   */
+  void* handle;
+  ID3D11Device *device;
+  ID3D11DeviceContext *context;
+  D3D_FEATURE_LEVEL featureLevel;
+  pD3DCompile D3DCompile;
+};
+
+
+#endif
+
+#endif /* LIBRETRO_DIRECT3D_H__ */

--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -96,20 +96,19 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice p
 	std::vector<const char *> EnabledExtensionNames(info.ppEnabledExtensionNames, info.ppEnabledExtensionNames + info.enabledExtensionCount);
 	VkPhysicalDeviceFeatures EnabledFeatures = *info.pEnabledFeatures;
 
-	for (int i = 0; i < vk_init_info.num_required_device_layers; i++)
+	for (unsigned i = 0; i < vk_init_info.num_required_device_layers; i++)
 		add_name_unique(EnabledLayerNames, vk_init_info.required_device_layers[i]);
 
-	for (int i = 0; i < vk_init_info.num_required_device_extensions; i++)
+	for (unsigned i = 0; i < vk_init_info.num_required_device_extensions; i++)
 		add_name_unique(EnabledExtensionNames, vk_init_info.required_device_extensions[i]);
 
 	add_name_unique(EnabledExtensionNames, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
-	for (int i = 0; i < sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32); i++)
+	for (unsigned i = 0; i < sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32); i++)
 	{
 		if (((VkBool32 *)vk_init_info.required_features)[i])
 			((VkBool32 *)&EnabledFeatures)[i] = VK_TRUE;
 	}
 
-	static bool DEDICATED_ALLOCATION;
 	for (auto extension_name : EnabledExtensionNames)
 	{
 		if (!strcmp(extension_name, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
@@ -445,6 +444,7 @@ void vk_libretro_init(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR su
 void vk_libretro_set_hwrender_interface(retro_hw_render_interface *hw_render_interface) { vulkan = (retro_hw_render_interface_vulkan *)hw_render_interface; }
 void vk_libretro_shutdown()
 {
+	memset(&vk_init_info, 0x00, sizeof(vk_init_info));
 	vulkan = NULL;
 	DEDICATED_ALLOCATION = false;
 }

--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -10,8 +10,7 @@
 
 static retro_hw_render_interface_vulkan *vulkan;
 
-static struct
-{
+static struct {
 	VkInstance instance;
 	VkPhysicalDevice gpu;
 	VkSurfaceKHR surface;
@@ -36,11 +35,9 @@ extern PFN_vkDestroyImageView vkDestroyImageView;
 extern PFN_vkFreeMemory vkFreeMemory;
 
 #define VULKAN_MAX_SWAPCHAIN_IMAGES 8
-struct VkSwapchainKHR_T
-{
+struct VkSwapchainKHR_T {
 	uint32_t count;
-	struct
-	{
+	struct {
 		VkImage handle;
 		VkDeviceMemory memory;
 		retro_vulkan_image retro_image;
@@ -51,46 +48,43 @@ struct VkSwapchainKHR_T
 };
 static VkSwapchainKHR_T chain;
 
-#define LIBRETRO_VK_WARP_LIST() \
-	LIBRETRO_VK_WARP_FUNC(vkDestroyInstance); \
-	LIBRETRO_VK_WARP_FUNC(vkCreateDevice); \
-	LIBRETRO_VK_WARP_FUNC(vkDestroyDevice); \
-	LIBRETRO_VK_WARP_FUNC(vkGetPhysicalDeviceSurfaceCapabilitiesKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkDestroySurfaceKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkCreateSwapchainKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkGetSwapchainImagesKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkAcquireNextImageKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkQueuePresentKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkDestroySwapchainKHR); \
-	LIBRETRO_VK_WARP_FUNC(vkQueueSubmit); \
-	LIBRETRO_VK_WARP_FUNC(vkQueueWaitIdle); \
-	LIBRETRO_VK_WARP_FUNC(vkCmdPipelineBarrier); \
+#define LIBRETRO_VK_WARP_LIST()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                \
+	LIBRETRO_VK_WARP_FUNC(vkDestroyInstance);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   \
+	LIBRETRO_VK_WARP_FUNC(vkCreateDevice);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      \
+	LIBRETRO_VK_WARP_FUNC(vkDestroyDevice);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     \
+	LIBRETRO_VK_WARP_FUNC(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           \
+	LIBRETRO_VK_WARP_FUNC(vkDestroySurfaceKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 \
+	LIBRETRO_VK_WARP_FUNC(vkCreateSwapchainKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                \
+	LIBRETRO_VK_WARP_FUNC(vkGetSwapchainImagesKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             \
+	LIBRETRO_VK_WARP_FUNC(vkAcquireNextImageKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               \
+	LIBRETRO_VK_WARP_FUNC(vkQueuePresentKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   \
+	LIBRETRO_VK_WARP_FUNC(vkDestroySwapchainKHR);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               \
+	LIBRETRO_VK_WARP_FUNC(vkQueueSubmit);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       \
+	LIBRETRO_VK_WARP_FUNC(vkQueueWaitIdle);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     \
+	LIBRETRO_VK_WARP_FUNC(vkCmdPipelineBarrier);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                \
 	LIBRETRO_VK_WARP_FUNC(vkCreateRenderPass)
 
-#define LIBRETRO_VK_WARP_FUNC(x) \
-	extern PFN_##x x; \
+#define LIBRETRO_VK_WARP_FUNC(x)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               \
+	extern PFN_##x x;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           \
 	PFN_##x x##_org
 
 LIBRETRO_VK_WARP_FUNC(vkGetInstanceProcAddr);
 LIBRETRO_VK_WARP_FUNC(vkGetDeviceProcAddr);
 LIBRETRO_VK_WARP_LIST();
 
-static VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance_libretro(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance_libretro(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
 	*pInstance = vk_init_info.instance;
 	return VK_SUCCESS;
 }
 
-static void add_name_unique(std::vector<const char *> &list, const char *value)
-{
+static void add_name_unique(std::vector<const char *> &list, const char *value) {
 	for (const char *name : list)
 		if (!strcmp(value, name))
 			return;
 
 	list.push_back(value);
 }
-static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkDevice *pDevice)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
 	VkDeviceCreateInfo info = *pCreateInfo;
 	std::vector<const char *> EnabledLayerNames(info.ppEnabledLayerNames, info.ppEnabledLayerNames + info.enabledLayerCount);
 	std::vector<const char *> EnabledExtensionNames(info.ppEnabledExtensionNames, info.ppEnabledExtensionNames + info.enabledExtensionCount);
@@ -103,14 +97,12 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice p
 		add_name_unique(EnabledExtensionNames, vk_init_info.required_device_extensions[i]);
 
 	add_name_unique(EnabledExtensionNames, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
-	for (unsigned i = 0; i < sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32); i++)
-	{
+	for (unsigned i = 0; i < sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32); i++) {
 		if (((VkBool32 *)vk_init_info.required_features)[i])
 			((VkBool32 *)&EnabledFeatures)[i] = VK_TRUE;
 	}
 
-	for (auto extension_name : EnabledExtensionNames)
-	{
+	for (auto extension_name : EnabledExtensionNames) {
 		if (!strcmp(extension_name, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
 			DEDICATED_ALLOCATION = true;
 	}
@@ -124,35 +116,28 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice p
 	return vkCreateDevice_org(physicalDevice, &info, pAllocator, pDevice);
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL vkCreateLibretroSurfaceKHR(VkInstance instance, const void *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkCreateLibretroSurfaceKHR(VkInstance instance, const void *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
 	*pSurface = vk_init_info.surface;
 	return VK_SUCCESS;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR_libretro(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
-{
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR_libretro(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) {
 	VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR_org(physicalDevice, surface, pSurfaceCapabilities);
-	if (res == VK_SUCCESS)
-	{
+	if (res == VK_SUCCESS) {
 		pSurfaceCapabilities->currentExtent.width = -1;
 		pSurfaceCapabilities->currentExtent.height = -1;
 	}
 	return res;
 }
 
-static bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex)
-{
+static bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex) {
 	VkPhysicalDeviceMemoryProperties memory_properties;
 	vkGetPhysicalDeviceMemoryProperties(vulkan->gpu, &memory_properties);
 	// Search memtypes to find first index with those properties
-	for (uint32_t i = 0; i < 32; i++)
-	{
-		if ((typeBits & 1) == 1)
-		{
+	for (uint32_t i = 0; i < 32; i++) {
+		if ((typeBits & 1) == 1) {
 			// Type is available, does it match user properties?
-			if ((memory_properties.memoryTypes[i].propertyFlags & requirements_mask) == requirements_mask)
-			{
+			if ((memory_properties.memoryTypes[i].propertyFlags & requirements_mask) == requirements_mask) {
 				*typeIndex = i;
 				return true;
 			}
@@ -163,20 +148,17 @@ static bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mas
 	return false;
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR_libretro(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR_libretro(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) {
 	uint32_t swapchain_mask = vulkan->get_sync_index_mask(vulkan->handle);
 
 	chain.count = 0;
-	while (swapchain_mask)
-	{
+	while (swapchain_mask) {
 		chain.count++;
 		swapchain_mask >>= 1;
 	}
 	assert(chain.count <= VULKAN_MAX_SWAPCHAIN_IMAGES);
 
-	for (uint32_t i = 0; i < chain.count; i++)
-	{
+	for (uint32_t i = 0; i < chain.count; i++) {
 		{
 			VkImageCreateInfo info{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
 			info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
@@ -202,8 +184,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR_libretro(VkDevice dev
 		alloc.allocationSize = memreq.size;
 
 		VkMemoryDedicatedAllocateInfoKHR dedicated{ VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR };
-		if (DEDICATED_ALLOCATION)
-		{
+		if (DEDICATED_ALLOCATION) {
 			alloc.pNext = &dedicated;
 			dedicated.image = chain.images[i].handle;
 		}
@@ -233,23 +214,19 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR_libretro(VkDevice dev
 
 	return VK_SUCCESS;
 }
-static VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainImagesKHR_libretro(VkDevice device, VkSwapchainKHR swapchain_, uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainImagesKHR_libretro(VkDevice device, VkSwapchainKHR swapchain_, uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages) {
 	VkSwapchainKHR_T *swapchain = (VkSwapchainKHR_T *)swapchain_;
-	if (pSwapchainImages)
-	{
+	if (pSwapchainImages) {
 		assert(*pSwapchainImageCount <= swapchain->count);
 		for (int i = 0; i < *pSwapchainImageCount; i++)
 			pSwapchainImages[i] = swapchain->images[i].handle;
-	}
-	else
+	} else
 		*pSwapchainImageCount = swapchain->count;
 
 	return VK_SUCCESS;
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR_libretro(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR_libretro(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex) {
 	vulkan->wait_sync_index(vulkan->handle);
 	*pImageIndex = vulkan->get_sync_index(vulkan->handle);
 #if 0
@@ -258,8 +235,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR_libretro(VkDevice de
 	return VK_SUCCESS;
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR_libretro(VkQueue queue, const VkPresentInfoKHR *pPresentInfo)
-{
+static VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR_libretro(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
 	VkSwapchainKHR_T *swapchain = (VkSwapchainKHR_T *)pPresentInfo->pSwapchains[0];
 	std::unique_lock<std::mutex> lock(swapchain->mutex);
 #if 0
@@ -278,8 +254,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR_libretro(VkQueue queue, 
 	return VK_SUCCESS;
 }
 
-void vk_libretro_wait_for_presentation()
-{
+void vk_libretro_wait_for_presentation() {
 	std::unique_lock<std::mutex> lock(chain.mutex);
 	if (chain.current_index < 0)
 		chain.condVar.wait(lock);
@@ -292,10 +267,8 @@ void vk_libretro_wait_for_presentation()
 static VKAPI_ATTR void VKAPI_CALL vkDestroyInstance_libretro(VkInstance instance, const VkAllocationCallbacks *pAllocator) {}
 static VKAPI_ATTR void VKAPI_CALL vkDestroyDevice_libretro(VkDevice device, const VkAllocationCallbacks *pAllocator) {}
 static VKAPI_ATTR void VKAPI_CALL vkDestroySurfaceKHR_libretro(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks *pAllocator) {}
-static VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR_libretro(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator)
-{
-	for (int i = 0; i < chain.count; i++)
-	{
+static VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR_libretro(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator) {
+	for (int i = 0; i < chain.count; i++) {
 		vkDestroyImage(device, chain.images[i].handle, pAllocator);
 		vkDestroyImageView(device, chain.images[i].retro_image.image_view, pAllocator);
 		vkFreeMemory(device, chain.images[i].memory, pAllocator);
@@ -306,8 +279,7 @@ static VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR_libretro(VkDevice device
 	chain.current_index = -1;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit_libretro(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence)
-{
+VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit_libretro(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence) {
 	VkResult res = VK_SUCCESS;
 
 #if 0
@@ -315,8 +287,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit_libretro(VkQueue queue, uint32_t su
 		vulkan->set_command_buffers(vulkan->handle, pSubmits[i].commandBufferCount, pSubmits[i].pCommandBuffers);
 #else
 #if 1
-	for (int i = 0; i < submitCount; i++)
-	{
+	for (int i = 0; i < submitCount; i++) {
 		((VkSubmitInfo *)pSubmits)[i].waitSemaphoreCount = 0;
 		((VkSubmitInfo *)pSubmits)[i].pWaitSemaphores = nullptr;
 		((VkSubmitInfo *)pSubmits)[i].signalSemaphoreCount = 0;
@@ -331,26 +302,21 @@ VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit_libretro(VkQueue queue, uint32_t su
 	return res;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL vkQueueWaitIdle_libretro(VkQueue queue)
-{
+VKAPI_ATTR VkResult VKAPI_CALL vkQueueWaitIdle_libretro(VkQueue queue) {
 	vulkan->lock_queue(vulkan->handle);
 	VkResult res = vkQueueWaitIdle_org(queue);
 	vulkan->unlock_queue(vulkan->handle);
 	return res;
 }
 
-VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier_libretro(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers)
-{
+VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier_libretro(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) {
 	VkImageMemoryBarrier *barriers = (VkImageMemoryBarrier *)pImageMemoryBarriers;
-	for (int i = 0; i < imageMemoryBarrierCount; i++)
-	{
-		if (pImageMemoryBarriers[i].oldLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
-		{
+	for (int i = 0; i < imageMemoryBarrierCount; i++) {
+		if (pImageMemoryBarriers[i].oldLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
 			barriers[i].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			barriers[i].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
 		}
-		if (pImageMemoryBarriers[i].newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
-		{
+		if (pImageMemoryBarriers[i].newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
 			barriers[i].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			barriers[i].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 		}
@@ -358,8 +324,7 @@ VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier_libretro(VkCommandBuffer command
 	return vkCmdPipelineBarrier_org(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, barriers);
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass_libretro(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass)
-{
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass_libretro(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
 	if (pCreateInfo->pAttachments[0].finalLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
 		((VkAttachmentDescription *)pCreateInfo->pAttachments)[0].finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
@@ -367,18 +332,15 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass_libretro(VkDevice device, cons
 }
 
 #undef LIBRETRO_VK_WARP_FUNC
-#define LIBRETRO_VK_WARP_FUNC(x) \
-	do \
-	{ \
-		if (!strcmp(pName, #x)) \
-		{ \
-			x##_org = (PFN_##x)fptr; \
-			return (PFN_vkVoidFunction)x##_libretro; \
-		} \
+#define LIBRETRO_VK_WARP_FUNC(x)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               \
+	do {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
+		if (!strcmp(pName, #x)) {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                \
+			x##_org = (PFN_##x)fptr;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              \
+			return (PFN_vkVoidFunction)x##_libretro;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              \
+		}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
 	} while (0)
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstance instance, const char *pName)
-{
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstance instance, const char *pName) {
 	if (false
 #ifdef _WIN32
 		 || !strcmp(pName, "vkCreateWin32SurfaceKHR")
@@ -395,8 +357,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstan
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 		 || !strcmp(pName, "vkCreateWaylandSurfaceKHR")
 #endif
-	)
-	{
+	) {
 		return (PFN_vkVoidFunction)vkCreateLibretroSurfaceKHR;
 	}
 
@@ -409,8 +370,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstan
 	return fptr;
 }
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr_libretro(VkDevice device, const char *pName)
-{
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr_libretro(VkDevice device, const char *pName) {
 	PFN_vkVoidFunction fptr = vkGetDeviceProcAddr_org(device, pName);
 	if (!fptr)
 		return fptr;
@@ -420,8 +380,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr_libretro(VkDevice d
 	return fptr;
 }
 
-void vk_libretro_init(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, PFN_vkGetInstanceProcAddr get_instance_proc_addr, const char **required_device_extensions, unsigned num_required_device_extensions, const char **required_device_layers, unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features)
-{
+void vk_libretro_init(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, PFN_vkGetInstanceProcAddr get_instance_proc_addr, const char **required_device_extensions, unsigned num_required_device_extensions, const char **required_device_layers, unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features) {
 	assert(surface);
 
 	vk_init_info.instance = instance;
@@ -442,8 +401,7 @@ void vk_libretro_init(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR su
 }
 
 void vk_libretro_set_hwrender_interface(retro_hw_render_interface *hw_render_interface) { vulkan = (retro_hw_render_interface_vulkan *)hw_render_interface; }
-void vk_libretro_shutdown()
-{
+void vk_libretro_shutdown() {
 	memset(&vk_init_info, 0x00, sizeof(vk_init_info));
 	vulkan = NULL;
 	DEDICATED_ALLOCATION = false;


### PR DESCRIPTION
D3D11 support is still experimental but it does seem to work well enough. this includes a small change to thin3d_d3d11 by adding a BeginFrame implementation. 

incidentally, I also found a fix for the GL context reset problem which was to simply request for the context to be cached during a reset. DeviceLost/Restore for GL and D3D11 are still unable to switch to a new context, but this is good enough for now I think.

fixes #10784 