### PR TITLE
Android: Properly restore savestate screenshots on the Pause screen on task switching away and back.

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -681,6 +681,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	screenManager->setUIContext(uiContext);
 	screenManager->setDrawContext(g_draw);
 	screenManager->setPostRenderCallback(&RenderOverlays, nullptr);
+	screenManager->deviceRestored();
 
 #ifdef _WIN32
 	winAudioBackend = CreateAudioBackend((AudioBackendType)g_Config.iAudioBackend);
@@ -702,6 +703,8 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 }
 
 void NativeShutdownGraphics() {
+	screenManager->deviceLost();
+
 	if (gpu)
 		gpu->DeviceLost();
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -49,7 +49,7 @@ AsyncImageFileView::AsyncImageFileView(const std::string &filename, UI::ImageSiz
 AsyncImageFileView::~AsyncImageFileView() {}
 
 void AsyncImageFileView::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
-	if (texture_) {
+	if (texture_ && texture_->GetTexture()) {
 		float texw = (float)texture_->Width();
 		float texh = (float)texture_->Height();
 		switch (sizeMode_) {
@@ -77,6 +77,16 @@ void AsyncImageFileView::SetFilename(std::string filename) {
 	}
 }
 
+void AsyncImageFileView::DeviceLost() {
+	if (texture_.get())
+		texture_->DeviceLost();
+}
+
+void AsyncImageFileView::DeviceRestored(Draw::DrawContext *draw) {
+	if (texture_.get())
+		texture_->DeviceRestored(draw);
+}
+
 void AsyncImageFileView::Draw(UIContext &dc) {
 	using namespace Draw;
 	if (!texture_ && !textureFailed_ && !filename_.empty()) {
@@ -90,7 +100,7 @@ void AsyncImageFileView::Draw(UIContext &dc) {
 	}
 
 	// TODO: involve sizemode
-	if (texture_) {
+	if (texture_ && texture_->GetTexture()) {
 		dc.Flush();
 		dc.GetDrawContext()->BindTexture(0, texture_->GetTexture());
 		dc.Draw()->Rect(bounds_.x, bounds_.y, bounds_.w, bounds_.h, color_);

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -60,8 +60,8 @@ private:
 
 class PrioritizedWorkQueue;
 
-// TextureView takes a texture that is assumed to be alive during the lifetime
-// of the view. TODO: Actually make async using the task.
+// AsyncImageFileView loads a texture from a file, and reloads it as necessary.
+// TODO: Actually make async, doh.
 class AsyncImageFileView : public UI::Clickable {
 public:
 	AsyncImageFileView(const std::string &filename, UI::ImageSizeMode sizeMode, PrioritizedWorkQueue *wq, UI::LayoutParams *layoutParams = 0);
@@ -69,6 +69,9 @@ public:
 
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
+
+	void DeviceLost() override;
+	void DeviceRestored(Draw::DrawContext *draw) override;
 
 	void SetFilename(std::string filename);
 	void SetColor(uint32_t color) { color_ = color; }

--- a/UI/TextureUtil.h
+++ b/UI/TextureUtil.h
@@ -23,14 +23,19 @@ public:
 
 	bool LoadFromFile(const std::string &filename, ImageFileType type = ImageFileType::DETECT, bool generateMips = false);
 	bool LoadFromFileData(const uint8_t *data, size_t dataSize, ImageFileType type = ImageFileType::DETECT, bool generateMips = false);
-	Draw::Texture *GetTexture() { return texture_; }  // For immediate use, don't store.
+	Draw::Texture *GetTexture();  // For immediate use, don't store.
 	int Width() const { return texture_->Width(); }
 	int Height() const { return texture_->Height(); }
+
+	void DeviceLost();
+	void DeviceRestored(Draw::DrawContext *draw);
 
 private:
 	Draw::Texture *texture_ = nullptr;
 	Draw::DrawContext *draw_;
 	std::string filename_;  // Textures that are loaded from files can reload themselves automatically.
+	bool generateMips_ = false;
+	bool loadPending_ = false;
 };
 
 std::unique_ptr<ManagedTexture> CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips = false);

--- a/ext/native/file/zip_read.cpp
+++ b/ext/native/file/zip_read.cpp
@@ -366,7 +366,7 @@ uint8_t *VFSReadFile(const char *filename, size_t *size) {
 		}
 	}
 	if (!fileSystemFound) {
-		ELOG("Missing filesystem for %s", filename);
+		ELOG("Missing filesystem for '%s'", filename);
 	}  // Otherwise, the file was just missing. No need to log.
 	return 0;
 }

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -97,6 +97,16 @@ bool ScreenManager::axis(const AxisInput &axis) {
 	}
 }
 
+void ScreenManager::deviceLost() {
+	for (auto &iter : stack_)
+		iter.screen->deviceLost();
+}
+
+void ScreenManager::deviceRestored() {
+	for (auto &iter : stack_)
+		iter.screen->deviceRestored();
+}
+
 void ScreenManager::resized() {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	// Have to notify the whole stack, otherwise there will be problems when going back

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -58,6 +58,8 @@ public:
 	virtual bool key(const KeyInput &key) { return false; }
 	virtual bool axis(const AxisInput &touch) { return false; }
 	virtual void sendMessage(const char *msg, const char *value) {}
+	virtual void deviceLost() {}
+	virtual void deviceRestored() {}
 
 	virtual void RecreateViews() {}
 
@@ -114,6 +116,9 @@ public:
 	void render();
 	void resized();
 	void shutdown();
+
+	void deviceLost();
+	void deviceRestored();
 
 	// Push a dialog box in front. Currently 1-level only.
 	void push(Screen *screen, int layerFlags = 0);

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -61,6 +61,16 @@ void UIScreen::update() {
 	}
 }
 
+void UIScreen::deviceLost() {
+	if (root_)
+		root_->DeviceLost();
+}
+
+void UIScreen::deviceRestored() {
+	if (root_)
+		root_->DeviceRestored(screenManager()->getDrawContext());
+}
+
 void UIScreen::preRender() {
 	using namespace Draw;
 	Draw::DrawContext *draw = screenManager()->getDrawContext();

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -15,16 +15,18 @@ public:
 	UIScreen();
 	~UIScreen();
 
-	virtual void update() override;
-	virtual void preRender() override;
-	virtual void render() override;
-	virtual void postRender() override;
+	void update() override;
+	void preRender() override;
+	void render() override;
+	void postRender() override;
+	void deviceLost() override;
+	void deviceRestored() override;
 
-	virtual bool touch(const TouchInput &touch) override;
-	virtual bool key(const KeyInput &touch) override;
-	virtual bool axis(const AxisInput &touch) override;
+	bool touch(const TouchInput &touch) override;
+	bool key(const KeyInput &touch) override;
+	bool axis(const AxisInput &touch) override;
 
-	virtual TouchInput transformTouch(const TouchInput &touch) override;
+	TouchInput transformTouch(const TouchInput &touch) override;
 
 	virtual void TriggerFinish(DialogResult result);
 

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -33,6 +33,7 @@ class Texture;
 class UIContext;
 
 namespace Draw {
+	class DrawContext;
 	class Texture;
 }
 
@@ -364,6 +365,9 @@ public:
 	virtual void Touch(const TouchInput &input) {}
 	virtual void Axis(const AxisInput &input) {}
 	virtual void Update();
+
+	virtual void DeviceLost() {}
+	virtual void DeviceRestored(Draw::DrawContext *draw) {}
 
 	// If this view covers these coordinates, it should add itself and its children to the list.
 	virtual void Query(float x, float y, std::vector<View *> &list);

--- a/ext/native/ui/viewgroup.cpp
+++ b/ext/native/ui/viewgroup.cpp
@@ -117,6 +117,20 @@ void ViewGroup::Axis(const AxisInput &input) {
 	}
 }
 
+void ViewGroup::DeviceLost() {
+	std::lock_guard<std::mutex> guard(modifyLock_);
+	for (auto iter = views_.begin(); iter != views_.end(); ++iter) {
+		(*iter)->DeviceLost();
+	}
+}
+
+void ViewGroup::DeviceRestored(Draw::DrawContext *draw) {
+	std::lock_guard<std::mutex> guard(modifyLock_);
+	for (auto iter = views_.begin(); iter != views_.end(); ++iter) {
+		(*iter)->DeviceRestored(draw);
+	}
+}
+
 void ViewGroup::Draw(UIContext &dc) {
 	if (hasDropShadow_) {
 		// Darken things behind.
@@ -124,7 +138,7 @@ void ViewGroup::Draw(UIContext &dc) {
 		float dropsize = 30.0f;
 		dc.Draw()->DrawImage4Grid(dc.theme->dropShadow4Grid,
 			bounds_.x - dropsize, bounds_.y,
-			bounds_.x2() + dropsize, bounds_.y2()+dropsize*1.5, 0xDF000000, 3.0f);
+			bounds_.x2() + dropsize, bounds_.y2()+dropsize*1.5f, 0xDF000000, 3.0f);
 	}
 
 	if (clip_) {

--- a/ext/native/ui/viewgroup.h
+++ b/ext/native/ui/viewgroup.h
@@ -38,6 +38,9 @@ public:
 	virtual void Update() override;
 	virtual void Query(float x, float y, std::vector<View *> &list) override;
 
+	virtual void DeviceLost() override;
+	virtual void DeviceRestored(Draw::DrawContext *draw) override;
+
 	virtual void Draw(UIContext &dc) override;
 
 	// These should be unused.


### PR DESCRIPTION
Fixes Vulkan crashes that could happen in this situation (or later on exit) too.

Basically plumbs through DeviceLost/DeviceRestored to view elements and into ManagedTexture.