### PR TITLE
Include renderpass definition in Vulkan shader cache entries, should make it more effective again.

### DIFF
--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -131,7 +131,7 @@ void GPU_Vulkan::LoadCache(std::string filename) {
 		VkRenderPass renderPass = g_Config.iRenderingMode == FB_BUFFERED_MODE ?
 			(VkRenderPass)draw_->GetNativeObject(Draw::NativeObject::FRAMEBUFFER_RENDERPASS) :
 			(VkRenderPass)draw_->GetNativeObject(Draw::NativeObject::BACKBUFFER_RENDERPASS);
-		result = pipelineManager_->LoadCache(f, false, shaderManagerVulkan_, &drawEngine_, drawEngine_.GetPipelineLayout(), renderPass);
+		result = pipelineManager_->LoadCache(f, false, shaderManagerVulkan_, draw_, drawEngine_.GetPipelineLayout(), renderPass);
 	}
 	fclose(f);
 	if (!result) {
@@ -148,7 +148,7 @@ void GPU_Vulkan::SaveCache(std::string filename) {
 	if (!f)
 		return;
 	shaderManagerVulkan_->SaveCache(f);
-	pipelineManager_->SaveCache(f, false, shaderManagerVulkan_);
+	pipelineManager_->SaveCache(f, false, shaderManagerVulkan_, draw_);
 	INFO_LOG(G3D, "Saved Vulkan pipeline cache");
 	fclose(f);
 }

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -56,19 +56,6 @@ struct VulkanPipelineKey {
 	std::string GetDescription(DebugShaderStringType stringType) const;
 };
 
-struct StoredVulkanPipelineKey {
-	VulkanPipelineRasterStateKey raster;
-	VShaderID vShaderID;
-	FShaderID fShaderID;
-	uint32_t vtxFmtId;
-	bool useHWTransform;
-
-	// For std::set. Better zero-initialize the struct properly for this to work.
-	bool operator < (const StoredVulkanPipelineKey &other) const {
-		return memcmp(this, &other, sizeof(*this)) < 0;
-	}
-};
-
 enum PipelineFlags {
 	PIPELINE_FLAG_USES_LINES = (1 << 2),
 	PIPELINE_FLAG_USES_BLEND_CONSTANT = (1 << 3),
@@ -109,8 +96,8 @@ public:
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
 
 	// Saves data for faster creation next time.
-	void SaveCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager);
-	bool LoadCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, DrawEngineCommon *drawEngine, VkPipelineLayout layout, VkRenderPass renderPass);
+	void SaveCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext);
+	bool LoadCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, VkRenderPass renderPass);
 
 private:
 	DenseHashMap<VulkanPipelineKey, VulkanPipeline *, nullptr> pipelines_;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -350,7 +350,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 6
+#define CACHE_VERSION 9
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -506,6 +506,8 @@ handleELF:
 			if (File::Exists(screenshotPath)) {
 				if (readFileToString(false, screenshotPath.c_str(), info_->icon.data)) {
 					info_->icon.dataLoaded = true;
+				} else {
+					ERROR_LOG(G3D, "Error loading screenshot data: '%s'", screenshotPath.c_str());
 				}
 			}
 			break;
@@ -795,6 +797,8 @@ void GameInfoCache::SetupTexture(std::shared_ptr<GameInfo> &info, Draw::DrawCont
 			tex.texture = CreateTextureFromFileData(thin3d, (const uint8_t *)tex.data.data(), (int)tex.data.size(), ImageFileType::DETECT);
 			if (tex.texture) {
 				tex.timeLoaded = time_now_d();
+			} else {
+				ERROR_LOG(G3D, "Failed creating texture");
 			}
 		}
 		if ((info->wantFlags & GAMEINFO_WANTBGDATA) == 0) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -312,9 +312,7 @@ void SavedataBrowser::Refresh() {
 		if (!isState && File::Exists(path_ + fileInfo[i].name + "/PARAM.SFO"))
 			isSaveData = true;
 
-		if (isSaveData) {
-			savedataButtons.push_back(new SavedataButton(fileInfo[i].fullName, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::WRAP_CONTENT)));
-		} else if (isState) {
+		if (isSaveData || isState) {
 			savedataButtons.push_back(new SavedataButton(fileInfo[i].fullName, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::WRAP_CONTENT)));
 		}
 	}

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -234,6 +234,11 @@ public:
 		return vulkan_;
 	}
 
+	// Be careful with this. Only meant to be used for fetching render passes for shader cache initialization.
+	VulkanQueueRunner *GetQueueRunner() {
+		return &queueRunner_;
+	}
+
 private:
 	bool InitBackbufferFramebuffers(int width, int height);
 	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.


### PR DESCRIPTION
Just the right thing to do.