### PR TITLE
Add SSAA flag for post process shaders

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1752,17 +1752,20 @@ void FramebufferManagerCommon::Resized() {
 	}
 
 	postShaderIsUpscalingFilter_ = shaderInfo ? shaderInfo->isUpscalingFilter : false;
+	postShaderIsSSAAFilter_ = shaderInfo ? shaderInfo->isSSAAFilter : false;
 
 	// Actually, auto mode should be more granular...
 	// Round up to a zoom factor for the render size.
 	int zoom = g_Config.iInternalResolution;
-	if (zoom == 0) {
+	if (zoom == 0 || postShaderIsSSAAFilter_) {
 		// auto mode, use the longest dimension
 		if (!g_Config.IsPortrait()) {
 			zoom = (PSP_CoreParameter().pixelWidth + 479) / 480;
 		} else {
 			zoom = (PSP_CoreParameter().pixelHeight + 479) / 480;
 		}
+		if (postShaderIsSSAAFilter_)
+			zoom *= 2;
 	}
 	if (zoom <= 1 || postShaderIsUpscalingFilter_)
 		zoom = 1;
@@ -1871,6 +1874,8 @@ void FramebufferManagerCommon::ShowScreenResolution() {
 	messageStream << PSP_CoreParameter().renderWidth << "x" << PSP_CoreParameter().renderHeight << " ";
 	if (postShaderIsUpscalingFilter_) {
 		messageStream << gr->T("(upscaling)") << " ";
+	} else if (postShaderIsSSAAFilter_) {
+		messageStream << gr->T("(supersampling)") << " ";
 	}
 	messageStream << gr->T("Window Size") << ": ";
 	messageStream << PSP_CoreParameter().pixelWidth << "x" << PSP_CoreParameter().pixelHeight;

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1752,20 +1752,20 @@ void FramebufferManagerCommon::Resized() {
 	}
 
 	postShaderIsUpscalingFilter_ = shaderInfo ? shaderInfo->isUpscalingFilter : false;
-	postShaderIsSSAAFilter_ = shaderInfo ? shaderInfo->isSSAAFilter : false;
+	postShaderSSAAFilterLevel_ = shaderInfo ? shaderInfo->SSAAFilterLevel : 0;
 
 	// Actually, auto mode should be more granular...
 	// Round up to a zoom factor for the render size.
 	int zoom = g_Config.iInternalResolution;
-	if (zoom == 0 || postShaderIsSSAAFilter_) {
+	if (zoom == 0 || postShaderSSAAFilterLevel_ >= 2) {
 		// auto mode, use the longest dimension
 		if (!g_Config.IsPortrait()) {
 			zoom = (PSP_CoreParameter().pixelWidth + 479) / 480;
 		} else {
 			zoom = (PSP_CoreParameter().pixelHeight + 479) / 480;
 		}
-		if (postShaderIsSSAAFilter_)
-			zoom *= 2;
+		if (postShaderSSAAFilterLevel_ >= 2)
+			zoom *= postShaderSSAAFilterLevel_;
 	}
 	if (zoom <= 1 || postShaderIsUpscalingFilter_)
 		zoom = 1;
@@ -1874,7 +1874,7 @@ void FramebufferManagerCommon::ShowScreenResolution() {
 	messageStream << PSP_CoreParameter().renderWidth << "x" << PSP_CoreParameter().renderHeight << " ";
 	if (postShaderIsUpscalingFilter_) {
 		messageStream << gr->T("(upscaling)") << " ";
-	} else if (postShaderIsSSAAFilter_) {
+	} else if (postShaderSSAAFilterLevel_ >= 2) {
 		messageStream << gr->T("(supersampling)") << " ";
 	}
 	messageStream << gr->T("Window Size") << ": ";

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -379,7 +379,7 @@ protected:
 	bool usePostShader_ = false;
 	bool postShaderAtOutputResolution_ = false;
 	bool postShaderIsUpscalingFilter_ = false;
-	bool postShaderIsSSAAFilter_ = false;
+	int postShaderSSAAFilterLevel_ = 0;
 
 	std::vector<VirtualFramebuffer *> vfbs_;
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -379,6 +379,7 @@ protected:
 	bool usePostShader_ = false;
 	bool postShaderAtOutputResolution_ = false;
 	bool postShaderIsUpscalingFilter_ = false;
+	bool postShaderIsSSAAFilter_ = false;
 
 	std::vector<VirtualFramebuffer *> vfbs_;
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -42,7 +42,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 	off.section = "Off";
 	off.outputResolution = false;
 	off.isUpscalingFilter = false;
-	off.isSSAAFilter = false;
+	off.SSAAFilterLevel = 0;
 	off.requires60fps = false;
 	shaderInfo.push_back(off);
 
@@ -88,7 +88,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 					info.vertexShaderFile = path + "/" + temp;
 					section.Get("OutputResolution", &info.outputResolution, false);
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
-					section.Get("SSAA", &info.isSSAAFilter, false);
+					section.Get("SSAA", &info.SSAAFilterLevel, 0);
 					section.Get("60fps", &info.requires60fps, false);
 
 					// Let's ignore shaders we can't support. TODO: Not a very good check

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -42,6 +42,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 	off.section = "Off";
 	off.outputResolution = false;
 	off.isUpscalingFilter = false;
+	off.isSSAAFilter = false;
 	off.requires60fps = false;
 	shaderInfo.push_back(off);
 
@@ -87,6 +88,7 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 					info.vertexShaderFile = path + "/" + temp;
 					section.Get("OutputResolution", &info.outputResolution, false);
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
+					section.Get("SSAA", &info.isSSAAFilter, false);
 					section.Get("60fps", &info.requires60fps, false);
 
 					// Let's ignore shaders we can't support. TODO: Not a very good check

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -37,7 +37,7 @@ struct ShaderInfo {
 	// Use x1 rendering res + nearest screen scaling filter
 	bool isUpscalingFilter;
 	// Use 2x display resolution for supersampling with blurry shaders.
-	bool isSSAAFilter;
+	int SSAAFilterLevel;
 	// Force constant/max refresh for animated filters
 	bool requires60fps;
 

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -36,6 +36,8 @@ struct ShaderInfo {
 	bool outputResolution;
 	// Use x1 rendering res + nearest screen scaling filter
 	bool isUpscalingFilter;
+	// Use 2x display resolution for supersampling with blurry shaders.
+	bool isSSAAFilter;
 	// Force constant/max refresh for animated filters
 	bool requires60fps;
 

--- a/assets/shaders/GaussianDownscale.fsh
+++ b/assets/shaders/GaussianDownscale.fsh
@@ -1,0 +1,73 @@
+// PPSSPP: Simple Gauss filter
+// Made by Bigpet
+
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform sampler2D sampler0;
+
+// The inverse of the texture dimensions along X and Y
+uniform vec2 u_texelDelta;
+uniform vec2 u_pixelDelta;
+varying vec2 v_texcoord0;
+
+void main() {
+  // The parameters are hardcoded for now, but could be
+  // made into uniforms to control fromt he program.
+  float GAUSS_SPAN_MAX = 1.5;
+
+  //just a variable to describe the maximu
+  float GAUSS_KERNEL_SIZE = 5.0;
+  //indices
+  //  XX XX 00 XX XX
+  //  XX 01 02 03 XX
+  //  04 05 06 07 08
+  //  XX 09 10 11 XX
+  //  XX XX 12 XX XX
+
+  //filter strength, rather smooth 
+  //  XX XX 01 XX XX
+  //  XX 03 08 03 XX
+  //  01 08 10 08 01
+  //  XX 03 08 03 XX
+  //  XX XX 01 XX XX
+
+  vec2 offset = u_pixelDelta*GAUSS_SPAN_MAX/GAUSS_KERNEL_SIZE;
+  
+  vec3 rgbSimple0 =  1.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 0.0,-2.0)).xyz;
+  vec3 rgbSimple1 =  3.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2(-1.0,-1.0)).xyz;
+  vec3 rgbSimple2 =  8.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 0.0,-1.0)).xyz;
+  vec3 rgbSimple3 =  3.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 1.0,-1.0)).xyz;
+  vec3 rgbSimple4 =  1.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2(-2.0, 0.0)).xyz;
+  vec3 rgbSimple5 =  8.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2(-1.0, 0.0)).xyz;
+  vec3 rgbSimple6 = 10.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 0.0, 0.0)).xyz;
+  vec3 rgbSimple7 =  8.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 1.0, 0.0)).xyz;
+  vec3 rgbSimple8 =  1.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 2.0, 0.0)).xyz;
+  vec3 rgbSimple9 =  3.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2(-1.0, 1.0)).xyz;
+  vec3 rgbSimple10=  8.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 0.0, 1.0)).xyz;
+  vec3 rgbSimple11=  3.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 1.0, 1.0)).xyz;
+  vec3 rgbSimple12=  1.0 * texture2D(sampler0, v_texcoord0.xy + offset * vec2( 0.0, 2.0)).xyz;
+  //vec3 rgbSimple10= vec3(1.0,0.0,0.0);
+  //vec3 rgbSimple11= vec3(1.0,0.0,0.0);
+  //vec3 rgbSimple12= vec3(1.0,0.0,0.0);
+  
+  vec3 rgb =  rgbSimple0 + 
+              rgbSimple1 +
+              rgbSimple2 +
+              rgbSimple3 +
+              rgbSimple4 +
+              rgbSimple5 +
+              rgbSimple6 +
+              rgbSimple7 +
+              rgbSimple8 +
+              rgbSimple9 +
+              rgbSimple10 +
+              rgbSimple11 +
+              rgbSimple12;
+  rgb = rgb / 58.0;
+  gl_FragColor.xyz=rgb;
+  gl_FragColor.a = 1.0;
+}
+

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -87,3 +87,9 @@ Author=guest.r(tweak by LunaMoo)
 Fragment=videoAA.fsh
 Vertex=fxaa.vsh
 OutputResolution=True
+[SSAA(Gauss)]
+Name=Super Sampling AA(Gauss)
+Fragment=GaussianDownscale.fsh
+Vertex=fxaa.vsh
+OutputResolution=True
+SSAA=True

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -92,4 +92,4 @@ Name=Super Sampling AA(Gauss)
 Fragment=GaussianDownscale.fsh
 Vertex=fxaa.vsh
 OutputResolution=True
-SSAA=True
+SSAA=2


### PR DESCRIPTION
 It simply enforces ~~2x~~ chosen multiplier of display resolution, ignoring user render res, best used with blurry effects.

fixes #10535, althrough doesn't change natural colors shader which is in that's issue title as I think modifying existing effects with enforced double auto resolution is bad, instead add's an example SSAA effect using simplified gauss filter.

 When it's used and resolution info is printed on the screen it also add's "(supersampling)" text.