### PR TITLE
Android: Avoid pread64 for > 2GB offsets

### DIFF
--- a/Core/FileLoaders/LocalFileLoader.h
+++ b/Core/FileLoaders/LocalFileLoader.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <mutex>
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
 #ifdef _WIN32
@@ -42,4 +43,5 @@ private:
 #endif
 	u64 filesize_;
 	std::string filename_;
+	std::mutex readLock_;
 };


### PR DESCRIPTION
Appears to not actually work as advertised.  See #10862.

Just mutexing the uncommon case seems like a relatively safe and simple solution.  Not actually tested on a > 2GB ISO, though.

-[Unknown]