### PR TITLE
Vulkan: Depalettize in shaders

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -58,6 +58,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DisableReadbacks", &flags_.DisableReadbacks);
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
 	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
+	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -57,6 +57,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "RequireDefaultCPUClock", &flags_.RequireDefaultCPUClock);
 	CheckSetting(iniFile, gameID, "DisableReadbacks", &flags_.DisableReadbacks);
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
+	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -57,6 +57,7 @@ struct CompatFlags {
 	bool RequireDefaultCPUClock;
 	bool DisableReadbacks;
 	bool DisableAccurateDepth;
+	bool MGS2AcidHack;
 };
 
 class IniFile;

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -58,6 +58,7 @@ struct CompatFlags {
 	bool DisableReadbacks;
 	bool DisableAccurateDepth;
 	bool MGS2AcidHack;
+	bool SonicRivalsHack;
 };
 
 class IniFile;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -70,7 +70,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 	int mask = gstate.getClutIndexMask();
 	int shift = gstate.getClutIndexShift();
 	int offset = gstate.getClutIndexStartPos();
-	const GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
+	GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
 	// Unfortunately sampling turned our texture into floating point. To avoid this, might be able
 	// to declare them as isampler2D objects, but these require integer textures, which needs more work.
 	// Anyhow, we simply work around this by converting back to integer. Hopefully there will be no loss of precision.

--- a/GPU/Common/ShaderCommon.h
+++ b/GPU/Common/ShaderCommon.h
@@ -85,15 +85,16 @@ enum : uint64_t {
 	DIRTY_BONEMATRIX6 = 1ULL << 30,
 	DIRTY_BONEMATRIX7 = 1ULL << 31,
 
-	// These are for hardware tessellation
 	DIRTY_BEZIERSPLINE = 1ULL << 32,
 	DIRTY_TEXCLAMP = 1ULL << 33,
 
-	// space for 7 more uniforms.
+	DIRTY_DEPAL = 1ULL << 34,
+
+	// space for 5 more uniform dirty flags. Remember to update DIRTY_ALL_UNIFORMS.
 
 	DIRTY_BONE_UNIFORMS = 0xFF000000ULL,
 
-	DIRTY_ALL_UNIFORMS = 0x3FFFFFFFFULL,
+	DIRTY_ALL_UNIFORMS = 0x7FFFFFFFFULL,
 	DIRTY_ALL_LIGHTS = DIRTY_LIGHT0 | DIRTY_LIGHT1 | DIRTY_LIGHT2 | DIRTY_LIGHT3,
 
 	// Other dirty elements that aren't uniforms!

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -171,6 +171,7 @@ std::string FragmentShaderDesc(const ShaderID &id) {
 	if (id.Bit(FS_BIT_COLOR_DOUBLE)) desc << "2x ";
 	if (id.Bit(FS_BIT_FLATSHADE)) desc << "Flat ";
 	if (id.Bit(FS_BIT_BGRA_TEXTURE)) desc << "BGRA ";
+	if (id.Bit(FS_BIT_SHADER_DEPAL)) desc << "Depal ";
 	if (id.Bit(FS_BIT_SHADER_TEX_CLAMP)) {
 		desc << "TClamp";
 		if (id.Bit(FS_BIT_CLAMP_S)) desc << "S";
@@ -236,6 +237,7 @@ void ComputeFragmentShaderID(ShaderID *id_out) {
 		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;
+		bool useShaderDepal = gstate_c.useShaderDepal;
 
 		ReplaceBlendType replaceBlend = ReplaceBlendWithShader(gstate_c.allowShaderBlend, gstate.FrameBufFormat());
 		ReplaceAlphaType stencilToAlpha = ReplaceAlphaWithStencil(replaceBlend);
@@ -299,6 +301,8 @@ void ComputeFragmentShaderID(ShaderID *id_out) {
 			id.SetBits(FS_BIT_BLENDFUNC_B, 4, gstate.getBlendFuncB());
 		}
 		id.SetBit(FS_BIT_FLATSHADE, doFlatShading);
+
+		id.SetBit(FS_BIT_SHADER_DEPAL, useShaderDepal);
 	}
 
 	*id_out = id;

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -62,7 +62,7 @@ enum {
 	FS_BIT_DO_TEXTURE = 1,
 	FS_BIT_TEXFUNC = 2,  // 3 bits
 	FS_BIT_TEXALPHA = 5,
-	// 6 is free.
+	FS_BIT_SHADER_DEPAL = 6,
 	FS_BIT_SHADER_TEX_CLAMP = 7,
 	FS_BIT_CLAMP_S = 8,
 	FS_BIT_CLAMP_T = 9,

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -200,6 +200,17 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 	if (dirtyUniforms & DIRTY_BEZIERSPLINE) {
 		ub->spline_counts = BytesToUint32(gstate_c.spline_count_u, gstate_c.spline_count_v, gstate_c.spline_type_u, gstate_c.spline_type_v);
 	}
+
+	if (dirtyUniforms & DIRTY_DEPAL) {
+		int indexMask = gstate.getClutIndexMask();
+		int indexShift = gstate.getClutIndexShift();
+		int indexOffset = gstate.getClutIndexStartPos() >> 4;
+		int format = gstate_c.depalFramebufferFormat;
+		uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
+		// Poke in a bilinear filter flag in the top bit.
+		val |= gstate.isMagnifyFilteringEnabled() << 31;
+		ub->depal_mask_shift_off_fmt = val;
+	}
 }
 
 void LightUpdateUniforms(UB_VS_Lights *ub, uint64_t dirtyUniforms) {

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -11,7 +11,7 @@ enum : uint64_t {
 	DIRTY_WORLDMATRIX | DIRTY_PROJTHROUGHMATRIX | DIRTY_VIEWMATRIX | DIRTY_TEXMATRIX | DIRTY_ALPHACOLORREF |
 	DIRTY_PROJMATRIX | DIRTY_FOGCOLOR | DIRTY_FOGCOEF | DIRTY_TEXENV | DIRTY_STENCILREPLACEVALUE |
 	DIRTY_ALPHACOLORMASK | DIRTY_SHADERBLEND | DIRTY_UVSCALEOFFSET | DIRTY_TEXCLAMP | DIRTY_DEPTHRANGE | DIRTY_MATAMBIENTALPHA |
-	DIRTY_BEZIERSPLINE,
+	DIRTY_BEZIERSPLINE | DIRTY_DEPAL,
 	DIRTY_LIGHT_UNIFORMS =
 	DIRTY_LIGHT0 | DIRTY_LIGHT1 | DIRTY_LIGHT2 | DIRTY_LIGHT3 |
 	DIRTY_MATDIFFUSE | DIRTY_MATSPECULAR | DIRTY_MATEMISSIVE | DIRTY_AMBIENT,
@@ -30,7 +30,8 @@ struct UB_VS_FS_Base {
 	float depthRange[4];
 	float fogCoef[2];	float stencil; float pad0;
 	float matAmbient[4];
-	uint32_t spline_counts; int pad1; int pad2; int pad3;
+	uint32_t spline_counts; uint32_t depal_mask_shift_off_fmt;  // 4 params packed into one.
+	int pad2; int pad3;
 	// Fragment data
 	float fogColor[4];
 	float texEnvColor[4];
@@ -54,7 +55,7 @@ R"(  mat4 proj_mtx;
   float stencilReplace;
   vec4 matambientalpha;
   uint spline_counts;
-  int pad1;
+  uint depal_mask_shift_off_fmt;
   int pad2;
   int pad3;
   vec3 fogcolor;
@@ -80,7 +81,7 @@ R"(  float4x4 u_proj;
   float u_stencilReplaceValue;
   float4 u_matambientalpha;
   uint u_spline_counts;
-  int pad1;
+  uint u_depal_mask_shift_off_fmt;
   int pad2;
   int pad3;
   float3 u_fogcolor;

--- a/GPU/GLES/FragmentShaderGeneratorGLES.cpp
+++ b/GPU/GLES/FragmentShaderGeneratorGLES.cpp
@@ -363,7 +363,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniform
 				WRITE(p, "  int depalOffset = (((u_depal >> 16) & 0xFF) << 4);\n");
 				WRITE(p, "  int depalFmt = ((u_depal >> 24) & 0x3);\n");
 				WRITE(p, "  bool bilinear = (u_depal >> 31) != 0;\n");
-				WRITE(p, "  vec2 fraction = fract(%s.xy);\n", texcoord);
+				WRITE(p, "  vec2 fraction = fract(%s.xy * vec2(textureSize(tex, 0).xy));\n", texcoord);
 				WRITE(p, "  ivec4 col; int index0; int index1; int index2; int index3;\n");
 				WRITE(p, "  switch (depalFmt) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
 				WRITE(p, "  case 0:\n");  // 565

--- a/GPU/GLES/FragmentShaderGeneratorGLES.cpp
+++ b/GPU/GLES/FragmentShaderGeneratorGLES.cpp
@@ -157,6 +157,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniform
 	bool doTextureProjection = id.Bit(FS_BIT_DO_TEXTURE_PROJ);
 	bool doTextureAlpha = id.Bit(FS_BIT_TEXALPHA);
 	bool doFlatShading = id.Bit(FS_BIT_FLATSHADE);
+	bool shaderDepal = id.Bit(FS_BIT_SHADER_DEPAL);
 
 	GEComparison alphaTestFunc = (GEComparison)id.Bits(FS_BIT_ALPHA_TEST_FUNC, 3);
 	GEComparison colorTestFunc = (GEComparison)id.Bits(FS_BIT_COLOR_TEST_FUNC, 2);
@@ -215,6 +216,12 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniform
 				WRITE(p, "uniform ivec4 u_alphacolormask;\n");
 			}
 		}
+	}
+
+	if (shaderDepal) {
+		WRITE(p, "uniform sampler2D pal;\n");
+		WRITE(p, "uniform int u_depal;\n");
+		*uniformMask |= DIRTY_DEPAL;
 	}
 
 	StencilValueType replaceAlphaWithStencilType = (StencilValueType)id.Bits(FS_BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4);
@@ -336,10 +343,95 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, uint64_t *uniform
 
 			if (doTextureProjection) {
 				WRITE(p, "  vec4 t = %sProj(tex, %s);\n", texture, texcoord);
+				if (shaderDepal) {
+					WRITE(p, "  vec4 t1 = %sProjOffset(tex, %s, ivec2(1, 0));\n", texture, texcoord);
+					WRITE(p, "  vec4 t2 = %sProjOffset(tex, %s, ivec2(0, 1));\n", texture, texcoord);
+					WRITE(p, "  vec4 t3 = %sProjOffset(tex, %s, ivec2(1, 1));\n", texture, texcoord);
+				}
 			} else {
 				WRITE(p, "  vec4 t = %s(tex, %s.xy);\n", texture, texcoord);
+				if (shaderDepal) {
+					WRITE(p, "  vec4 t1 = %sOffset(tex, %s.xy, ivec2(1, 0));\n", texture, texcoord);
+					WRITE(p, "  vec4 t2 = %sOffset(tex, %s.xy, ivec2(0, 1));\n", texture, texcoord);
+					WRITE(p, "  vec4 t3 = %sOffset(tex, %s.xy, ivec2(1, 1));\n", texture, texcoord);
+				}
 			}
-			WRITE(p, "  vec4 p = v_color0;\n");
+
+			if (shaderDepal) {
+				WRITE(p, "  int depalMask = (u_depal & 0xFF);\n");
+				WRITE(p, "  int depalShift = ((u_depal >> 8) & 0xFF);\n");
+				WRITE(p, "  int depalOffset = (((u_depal >> 16) & 0xFF) << 4);\n");
+				WRITE(p, "  int depalFmt = ((u_depal >> 24) & 0x3);\n");
+				WRITE(p, "  bool bilinear = (u_depal >> 31) != 0;\n");
+				WRITE(p, "  vec2 fraction = fract(%s.xy);\n", texcoord);
+				WRITE(p, "  ivec4 col; int index0; int index1; int index2; int index3;\n");
+				WRITE(p, "  switch (depalFmt) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
+				WRITE(p, "  case 0:\n");  // 565
+				WRITE(p, "    col = ivec4(t.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "    index0 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = ivec4(t1.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index1 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t2.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index2 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t3.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index3 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    }\n");
+				WRITE(p, "    break;\n");
+				WRITE(p, "  case 1:\n");  // 5551
+				WRITE(p, "    col = ivec4(t.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "    index0 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = ivec4(t1.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index1 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t2.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index2 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t3.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index3 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    }\n");
+				WRITE(p, "    break;\n");
+				WRITE(p, "  case 2:\n");  // 4444
+				WRITE(p, "    col = ivec4(t.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "    index0 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = ivec4(t1.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index1 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t2.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index2 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t3.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index3 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "    }\n");
+				WRITE(p, "    break;\n");
+				WRITE(p, "  case 3:\n");  // 8888
+				WRITE(p, "    col = ivec4(t.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "    index0 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = ivec4(t1.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index1 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t2.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index2 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "      col = ivec4(t3.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index3 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "    }\n");
+				WRITE(p, "    break;\n");
+				WRITE(p, "  };\n");
+				WRITE(p, "  index0 = ((index0 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "  t = texelFetch(pal, ivec2(index0, 0), 0);\n");
+				WRITE(p, "  if (bilinear) {\n");
+				WRITE(p, "    index1 = ((index1 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    index2 = ((index2 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    index3 = ((index3 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    t1 = texelFetch(pal, ivec2(index1, 0), 0);\n");
+				WRITE(p, "    t2 = texelFetch(pal, ivec2(index2, 0), 0);\n");
+				WRITE(p, "    t3 = texelFetch(pal, ivec2(index3, 0), 0);\n");
+				WRITE(p, "    t = mix(t, t1, fraction.x);\n");
+				WRITE(p, "    t2 = mix(t2, t3, fraction.x);\n");
+				WRITE(p, "    t = mix(t, t2, fraction.y);\n");
+				WRITE(p, "  }\n");
+			}
+
+			if (texFunc != GE_TEXFUNC_REPLACE || !doTextureAlpha)
+				WRITE(p, "  vec4 p = v_color0;\n");
 
 			if (doTextureAlpha) { // texfmt == RGBA
 				switch (texFunc) {

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -85,6 +85,10 @@ public:
 	int u_blendFixB;
 	int u_fbotexSize;
 
+	// Shader depal
+	int u_pal;  // the texture
+	int u_depal;  // the params
+
 	// Fragment processing inputs
 	int u_alphacolorref;
 	int u_alphacolormask;

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -63,7 +63,7 @@ public:
 		}
 	}
 
-	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
+	void SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight, bool forcePoint);
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) override;
 
 	void DeviceLost();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -161,7 +161,7 @@ const CommonCommandTableEntry commonCommandTable[] = {
 	// These must flush on change, so that LoadClut doesn't have to always flush.
 	{ GE_CMD_CLUTADDR, FLAG_FLUSHBEFOREONCHANGE },
 	{ GE_CMD_CLUTADDRUPPER, FLAG_FLUSHBEFOREONCHANGE },
-	{ GE_CMD_CLUTFORMAT, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS },
+	{ GE_CMD_CLUTFORMAT, FLAG_FLUSHBEFOREONCHANGE, DIRTY_TEXTURE_PARAMS | DIRTY_DEPAL },
 
 	// Morph weights. TODO: Remove precomputation?
 	{ GE_CMD_MORPHWEIGHT0, FLAG_FLUSHBEFOREONCHANGE | FLAG_EXECUTEONCHANGE, 0, &GPUCommon::Execute_MorphWeight },

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -600,6 +600,9 @@ struct GPUStateCache {
 	int spline_type_u;
 	int spline_type_v;
 
+	bool useShaderDepal;
+	GEBufferFormat depalFramebufferFormat;
+
 	u32 getRelativeAddress(u32 data) const;
 	void Reset();
 	void DoState(PointerWrap &p);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -451,7 +451,7 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 		tex[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 #endif
 		tex[0].imageView = imageView;
-		tex[0].sampler = sampler;  // We override sampling when doing depal.
+		tex[0].sampler = sampler;
 		writes[n].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 		writes[n].pNext = nullptr;
 		writes[n].dstBinding = DRAW_BINDING_TEXTURE;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -372,7 +372,7 @@ VkResult DrawEngineVulkan::RecreateDescriptorPool(FrameData &frame, int newSize)
 	VkDescriptorPoolSize dpTypes[3];
 	dpTypes[0].descriptorCount = frame.descPoolSize * 3;
 	dpTypes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-	dpTypes[1].descriptorCount = frame.descPoolSize * 2;  // Don't use these for tess anymore, need max two per set.
+	dpTypes[1].descriptorCount = frame.descPoolSize * 3;  // Don't use these for tess anymore, need max three per set.
 	dpTypes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 	dpTypes[2].descriptorCount = frame.descPoolSize;
 	dpTypes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -20,10 +20,12 @@
 // The Descriptor Set used for the majority of PSP rendering looks like this:
 //
 // * binding 0: Texture/Sampler (the PSP texture)
-// * binding 1: Secondary texture sampler for shader blending or depal palettes
-// * binding 2: Base Uniform Buffer (includes fragment state)
-// * binding 3: Light uniform buffer
-// * binding 4: Bone uniform buffer
+// * binding 1: Secondary texture sampler for shader blending
+// * binding 2: Depal palette
+// * binding 3: Base Uniform Buffer (includes fragment state)
+// * binding 4: Light uniform buffer
+// * binding 5: Bone uniform buffer
+// * binding 6: Tess data storage buffer
 //
 // All shaders conform to this layout, so they are all compatible with the same descriptor set.
 // The format of the various uniform buffers may vary though - vertex shaders that don't skin
@@ -177,6 +179,9 @@ public:
 	}
 
 	void SetLineWidth(float lineWidth);
+	void SetDepalTexture(VkImageView depal) {
+		boundDepal_ = depal;
+	}
 
 private:
 	struct FrameData;
@@ -207,6 +212,7 @@ private:
 
 	// Secondary texture for shader blending
 	VkImageView boundSecondary_ = VK_NULL_HANDLE;
+	VkImageView boundDepal_ = VK_NULL_HANDLE;
 	VkSampler samplerSecondary_ = VK_NULL_HANDLE;  // This one is actually never used since we use fetch.
 
 	PrehashMap<VertexArrayInfoVulkan *, nullptr> vai_;
@@ -217,6 +223,7 @@ private:
 	struct DescriptorSetKey {
 		VkImageView imageView_;
 		VkImageView secondaryImageView_;
+		VkImageView depalImageView_;
 		VkSampler sampler_;
 		VkBuffer base_, light_, bone_;  // All three UBO slots will be set to this. This will usually be identical
 		// for all draws in a frame, except when the buffer has to grow.

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -197,7 +197,7 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 				WRITE(p, "  uint depalOffset = ((base.depal_mask_shift_off_fmt >> 16) & 0xFF) << 4;\n");
 				WRITE(p, "  uint depalFmt = (base.depal_mask_shift_off_fmt >> 24) & 0x3;\n");
 				WRITE(p, "  bool bilinear = (base.depal_mask_shift_off_fmt >> 31) != 0;\n");
-				WRITE(p, "  vec2 fraction = fract(%s.xy);\n", texcoord);
+				WRITE(p, "  vec2 fraction = fract(%s.xy * vec2(textureSize(tex, 0).xy));\n", texcoord);
 				WRITE(p, "  uvec4 col; uint index0; uint index1; uint index2; uint index3;\n");
 				WRITE(p, "  switch (depalFmt) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
 				WRITE(p, "  case 0:\n");  // 565

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -177,8 +177,18 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 
 			if (doTextureProjection) {
 				WRITE(p, "  vec4 t = textureProj(tex, %s);\n", texcoord);
+				if (shaderDepal) {
+					WRITE(p, "  vec4 t1 = textureProjOffset(tex, %s, ivec2(1, 0));\n", texcoord);
+					WRITE(p, "  vec4 t2 = textureProjOffset(tex, %s, ivec2(0, 1));\n", texcoord);
+					WRITE(p, "  vec4 t3 = textureProjOffset(tex, %s, ivec2(1, 1));\n", texcoord);
+				}
 			} else {
 				WRITE(p, "  vec4 t = texture(tex, %s.xy);\n", texcoord);
+				if (shaderDepal) {
+					WRITE(p, "  vec4 t1 = textureOffset(tex, %s.xy, ivec2(1, 0));\n", texcoord);
+					WRITE(p, "  vec4 t2 = textureOffset(tex, %s.xy, ivec2(0, 1));\n", texcoord);
+					WRITE(p, "  vec4 t3 = textureOffset(tex, %s.xy, ivec2(1, 1));\n", texcoord);
+				}
 			}
 
 			if (shaderDepal) {
@@ -186,29 +196,72 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 				WRITE(p, "  uint depalShift = (base.depal_mask_shift_off_fmt >> 8) & 0xFF;\n");
 				WRITE(p, "  uint depalOffset = ((base.depal_mask_shift_off_fmt >> 16) & 0xFF) << 4;\n");
 				WRITE(p, "  uint depalFmt = (base.depal_mask_shift_off_fmt >> 24) & 0x3;\n");
-				WRITE(p, "  bool bilinear = (base.depal_mask_shift_off_fmt >> 31) == 0;\n");
+				WRITE(p, "  bool bilinear = (base.depal_mask_shift_off_fmt >> 31) != 0;\n");
 				WRITE(p, "  vec2 fraction = fract(%s.xy);\n", texcoord);
 				WRITE(p, "  uvec4 col; uint index0; uint index1; uint index2; uint index3;\n");
 				WRITE(p, "  switch (depalFmt) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
 				WRITE(p, "  case 0:\n");  // 565
 				WRITE(p, "    col = uvec4(t.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
 				WRITE(p, "    index0 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = uvec4(t1.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index1 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t2.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index2 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t3.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
+				WRITE(p, "      index3 = (col.b << 11) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
 				WRITE(p, "  case 1:\n");  // 5551
 				WRITE(p, "    col = uvec4(t.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
 				WRITE(p, "    index0 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = uvec4(t1.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index1 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t2.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index2 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t3.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
+				WRITE(p, "      index3 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
+				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
 				WRITE(p, "  case 2:\n");  // 4444
 				WRITE(p, "    col = uvec4(t.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
 				WRITE(p, "    index0 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = uvec4(t1.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index1 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t2.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index2 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t3.rgba * vec4(15.99, 15.99, 15.99, 15.99));\n");
+				WRITE(p, "      index3 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
+				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
 				WRITE(p, "  case 3:\n");  // 8888
 				WRITE(p, "    col = uvec4(t.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
 				WRITE(p, "    index0 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "    if (bilinear) {\n");
+				WRITE(p, "      col = uvec4(t1.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index1 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t2.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index2 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "      col = uvec4(t3.rgba * vec4(255.99, 255.99, 255.99, 255.99));\n");
+				WRITE(p, "      index3 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
+				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
 				WRITE(p, "  };\n");
 				WRITE(p, "  index0 = ((index0 >> depalShift) & depalMask) | depalOffset;\n");
 				WRITE(p, "  t = texelFetch(pal, ivec2(index0, 0), 0);\n");
+				WRITE(p, "  if (bilinear) {\n");
+				WRITE(p, "    index1 = ((index1 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    index2 = ((index2 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    index3 = ((index3 >> depalShift) & depalMask) | depalOffset;\n");
+				WRITE(p, "    t1 = texelFetch(pal, ivec2(index1, 0), 0);\n");
+				WRITE(p, "    t2 = texelFetch(pal, ivec2(index2, 0), 0);\n");
+				WRITE(p, "    t3 = texelFetch(pal, ivec2(index3, 0), 0);\n");
+				WRITE(p, "    t = mix(t, t1, fraction.x);\n");
+				WRITE(p, "    t2 = mix(t2, t3, fraction.x);\n");
+				WRITE(p, "    t = mix(t, t2, fraction.y);\n");
+				WRITE(p, "  }\n");
 			}
 
 			if (texFunc != GE_TEXFUNC_REPLACE || !doTextureAlpha)

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -461,9 +461,10 @@ void GPU_Vulkan::InitDeviceObjects() {
 
 	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	uint32_t hacks = 0;
-	if (PSP_CoreParameter().compat.flags().MGS2AcidHack) {
+	if (PSP_CoreParameter().compat.flags().MGS2AcidHack)
 		hacks |= QUEUE_HACK_MGS2_ACID;
-	}
+	if (PSP_CoreParameter().compat.flags().SonicRivalsHack)
+		hacks |= QUEUE_HACK_SONIC;
 	if (hacks) {
 		rm->GetQueueRunner()->EnableHacks(hacks);
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -42,6 +42,8 @@
 #include "GPU/Vulkan/FramebufferVulkan.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Vulkan/TextureCacheVulkan.h"
+#include "thin3d/VulkanRenderManager.h"
+#include "thin3d/VulkanQueueRunner.h"
 
 #include "Core/MIPS/MIPS.h"
 #include "Core/HLE/sceKernelThread.h"
@@ -456,6 +458,15 @@ void GPU_Vulkan::InitDeviceObjects() {
 		assert(!frameData_[i].push_);
 		frameData_[i].push_ = new VulkanPushBuffer(vulkan_, 64 * 1024);
 	}
+
+	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	uint32_t hacks = 0;
+	if (PSP_CoreParameter().compat.flags().MGS2AcidHack) {
+		hacks |= QUEUE_HACK_MGS2_ACID;
+	}
+	if (hacks) {
+		rm->GetQueueRunner()->EnableHacks(hacks);
+	}
 }
 
 void GPU_Vulkan::DestroyDeviceObjects() {
@@ -467,6 +478,10 @@ void GPU_Vulkan::DestroyDeviceObjects() {
 			frameData_[i].push_ = nullptr;
 		}
 	}
+
+	// Need to turn off hacks when shutting down the GPU. Don't want them running in the menu.
+	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	rm->GetQueueRunner()->EnableHacks(0);
 }
 
 void GPU_Vulkan::DeviceLost() {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -61,10 +61,9 @@ VulkanFragmentShader::VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, 
 		}
 		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
 		ERROR_LOG(G3D, "Shader source:\n%s", code);
-#ifdef SHADERLOG
+		OutputDebugStringA(LineNumberString(code).c_str());
 		OutputDebugStringA("Messages:\n");
 		OutputDebugStringA(errorMessage.c_str());
-#endif
 		Reporting::ReportMessage("Vulkan error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
 	} else {
 		success = vulkan_->CreateShaderModule(spirv, &module_);
@@ -116,6 +115,7 @@ VulkanVertexShader::VulkanVertexShader(VulkanContext *vulkan, VShaderID id, cons
 		}
 		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
 		ERROR_LOG(G3D, "Shader source:\n%s", code);
+		OutputDebugStringA(LineNumberString(code).c_str());
 		OutputDebugStringUTF8("Messages:\n");
 		OutputDebugStringUTF8(errorMessage.c_str());
 		Reporting::ReportMessage("Vulkan error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
@@ -354,7 +354,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 12
+#define CACHE_VERSION 13
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -61,9 +61,11 @@ VulkanFragmentShader::VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, 
 		}
 		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
 		ERROR_LOG(G3D, "Shader source:\n%s", code);
+#ifdef SHADERLOG
 		OutputDebugStringA(LineNumberString(code).c_str());
 		OutputDebugStringA("Messages:\n");
 		OutputDebugStringA(errorMessage.c_str());
+#endif
 		Reporting::ReportMessage("Vulkan error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
 	} else {
 		success = vulkan_->CreateShaderModule(spirv, &module_);
@@ -115,9 +117,11 @@ VulkanVertexShader::VulkanVertexShader(VulkanContext *vulkan, VShaderID id, cons
 		}
 		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
 		ERROR_LOG(G3D, "Shader source:\n%s", code);
+#ifdef SHADERLOG
 		OutputDebugStringA(LineNumberString(code).c_str());
 		OutputDebugStringUTF8("Messages:\n");
 		OutputDebugStringUTF8(errorMessage.c_str());
+#endif
 		Reporting::ReportMessage("Vulkan error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);
 	} else {
 		success = vulkan_->CreateShaderModule(spirv, &module_);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -327,6 +327,8 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
 	SamplerCacheKey key{};
 	UpdateSamplingParams(*entry, key);
 	curSampler_ = samplerCache_.GetOrCreateSampler(key);
+	drawEngine_->SetDepalTexture(VK_NULL_HANDLE);
+	gstate_c.useShaderDepal = false;
 }
 
 void TextureCacheVulkan::Unbind() {
@@ -336,10 +338,29 @@ void TextureCacheVulkan::Unbind() {
 }
 
 void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) {
+	SamplerCacheKey samplerKey{};
+	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
+
 	DepalShaderVulkan *depalShader = nullptr;
 	uint32_t clutMode = gstate.clutformat & 0xFFFFFF;
 	if ((entry->status & TexCacheEntry::STATUS_DEPALETTIZE) && !g_Config.bDisableSlowFramebufEffects) {
-		depalShader = depalShaderCache_->GetDepalettizeShader(clutMode, framebuffer->drawnFormat);
+		bool useShaderDepal = true;
+		if (useShaderDepal) {
+			depalShaderCache_->SetPushBuffer(drawEngine_->GetPushBufferForTextureData());
+			const GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
+			VulkanTexture *clutTexture = depalShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBuf_);
+			drawEngine_->SetDepalTexture(clutTexture->GetImageView());
+			// Only point filtering enabled.
+			samplerKey.magFilt = false;
+			samplerKey.minFilt = false;
+			samplerKey.mipFilt = false;
+			// Make sure to update the uniforms.
+			gstate_c.Dirty(DIRTY_DEPAL);
+			gstate_c.useShaderDepal = true;
+			gstate_c.depalFramebufferFormat = framebuffer->drawnFormat;
+		} else {
+			depalShader = depalShaderCache_->GetDepalettizeShader(clutMode, framebuffer->drawnFormat);
+		}
 	}
 	if (depalShader) {
 		depalShaderCache_->SetPushBuffer(drawEngine_->GetPushBufferForTextureData());
@@ -430,14 +451,12 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 	} else {
 		entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
 
-		framebufferManager_->RebindFramebuffer();  // TODO: This line should not be needed?
+		framebufferManager_->RebindFramebuffer();  // TODO: This line should usually not be needed.
 		imageView_ = framebufferManagerVulkan_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}
 
-	SamplerCacheKey samplerKey{};
-	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 	InvalidateLastTexture(entry);
 }

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -86,6 +86,7 @@ public:
 		lastBoundTexture = nullptr;
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 	}
+
 	void InvalidateLastTexture(TexCacheEntry *entry = nullptr) override {
 		if (!entry || entry->vkTex == lastBoundTexture) {
 			lastBoundTexture = nullptr;

--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
@@ -137,11 +137,11 @@ bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer) {
 	bool flipNormalTess = id.Bit(VS_BIT_NORM_REVERSE_TESS);
 
 	WRITE(p, "\n");
-	WRITE(p, "layout (std140, set = 0, binding = 2) uniform baseVars {\n%s} base;\n", ub_baseStr);
+	WRITE(p, "layout (std140, set = 0, binding = 3) uniform baseVars {\n%s} base;\n", ub_baseStr);
 	if (enableLighting || doShadeMapping)
-		WRITE(p, "layout (std140, set = 0, binding = 3) uniform lightVars {\n%s} light;\n", ub_vs_lightsStr);
+		WRITE(p, "layout (std140, set = 0, binding = 4) uniform lightVars {\n%s} light;\n", ub_vs_lightsStr);
 	if (enableBones)
-		WRITE(p, "layout (std140, set = 0, binding = 4) uniform boneVars {\n%s} bone;\n", ub_vs_bonesStr);
+		WRITE(p, "layout (std140, set = 0, binding = 5) uniform boneVars {\n%s} bone;\n", ub_vs_bonesStr);
 
 	const char *shading = doFlatShading ? "flat " : "";
 
@@ -221,7 +221,7 @@ bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer) {
 		WRITE(p, "  vec4 uv;\n");
 		WRITE(p, "  vec4 color;\n");
 		WRITE(p, "};");
-		WRITE(p, "layout (std430, set = 0, binding = 5) buffer s_tess_data {\n");
+		WRITE(p, "layout (std430, set = 0, binding = 6) buffer s_tess_data {\n");
 		WRITE(p, "  TessData data[];");
 		WRITE(p, "} tess_data;\n");
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -336,5 +336,7 @@ ULUS10006 = true
 ULUS10077 = true
 
 [SonicRivalsHack]
-ULES00622 = true
-ULUS10195 = true
+ULES00622 = true  # SR1
+ULUS10195 = true  # SR1
+ULUS10323 = true  # SR2
+ULES00940 = true  # SR2

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -334,3 +334,7 @@ ULJM05001 = true
 ULAS42007 = true
 ULUS10006 = true
 ULUS10077 = true
+
+[SonicRivalsHack]
+ULES00622 = true
+ULUS10195 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -326,3 +326,11 @@ NPEG00044 = true
 NPJG00120 = true
 UCJS10114 = true
 UCES01401 = true
+
+[MGS2AcidHack]
+ULES00008 = true
+ULJM08001 = true
+ULJM05001 = true
+ULAS42007 = true
+ULUS10006 = true
+ULUS10077 = true

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -4,6 +4,7 @@
 #include "GLRenderManager.h"
 #include "DataFormatGL.h"
 #include "base/logging.h"
+#include "base/stringutil.h"
 #include "gfx/gl_common.h"
 #include "gfx/gl_debug_log.h"
 #include "gfx_es2/gpu_features.h"
@@ -156,9 +157,10 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 
 #ifdef _WIN32
 					OutputDebugStringUTF8(buf);
-					OutputDebugStringUTF8(vsCode);
+					if (vsCode)
+						OutputDebugStringUTF8(LineNumberString(vsCode).c_str());
 					if (fsCode)
-						OutputDebugStringUTF8(fsCode);
+						OutputDebugStringUTF8(LineNumberString(fsCode).c_str());
 #endif
 					delete[] buf;
 				} else {

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -472,6 +472,7 @@ void GLRenderManager::Run(int frame) {
 	auto &initStepsOnThread = frameData_[frame].initSteps;
 	// queueRunner_.LogSteps(stepsOnThread);
 	queueRunner_.RunInitSteps(initStepsOnThread);
+	initStepsOnThread.clear();
 
 	// Run this after RunInitSteps so any fresh GLRBuffers for the pushbuffers can get created.
 	for (auto iter : frameData.activePushBuffers) {
@@ -481,7 +482,6 @@ void GLRenderManager::Run(int frame) {
 
 	queueRunner_.RunSteps(stepsOnThread);
 	stepsOnThread.clear();
-	initStepsOnThread.clear();
 
 	for (auto iter : frameData.activePushBuffers) {
 		iter->MapDevice(bufferStrategy_);

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -10,6 +10,10 @@
 class VKRFramebuffer;
 struct VKRImage;
 
+enum {
+	QUEUE_HACK_MGS2_ACID = 1,
+};
+
 enum class VKRRenderCommand : uint8_t {
 	BIND_PIPELINE,
 	STENCIL,
@@ -152,7 +156,9 @@ public:
 		backbuffer_ = fb;
 		backbufferImage_ = img;
 	}
-	void RunSteps(VkCommandBuffer cmd, const std::vector<VKRStep *> &steps);
+
+	// RunSteps can modify steps but will leave it in a valid state.
+	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps);
 	void LogSteps(const std::vector<VKRStep *> &steps);
 
 	void CreateDeviceObjects();
@@ -205,6 +211,10 @@ public:
 		return found;
 	}
 
+	void EnableHacks(uint32_t hacks) {
+		hacksEnabled_ = hacks;
+	}
+
 private:
 	void InitBackbufferRenderPass();
 
@@ -222,6 +232,8 @@ private:
 	void LogReadbackImage(const VKRStep &pass);
 
 	void ResizeReadbackBuffer(VkDeviceSize requiredSize);
+
+	void ApplyMGSHack(std::vector<VKRStep *> &steps);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
@@ -244,4 +256,7 @@ private:
 	VkDeviceMemory readbackMemory_ = VK_NULL_HANDLE;
 	VkBuffer readbackBuffer_ = VK_NULL_HANDLE;
 	VkDeviceSize readbackBufferSize_ = 0;
+
+	// TODO: Enable based on compat.ini.
+	uint32_t hacksEnabled_ = 0;
 };

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -12,6 +12,7 @@ struct VKRImage;
 
 enum {
 	QUEUE_HACK_MGS2_ACID = 1,
+	QUEUE_HACK_SONIC = 2,
 };
 
 enum class VKRRenderCommand : uint8_t {
@@ -234,6 +235,7 @@ private:
 	void ResizeReadbackBuffer(VkDeviceSize requiredSize);
 
 	void ApplyMGSHack(std::vector<VKRStep *> &steps);
+	void ApplySonicHack(std::vector<VKRStep *> &steps);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);


### PR DESCRIPTION
Should speed things up a little bit in some cases (and a lot in some others), we save a render pass (and switches) at the cost of a rather heavy pixel shader (so in theory could be loss in some high resolution cases).

Sonic Rivals is like four times faster with this. Unfortunately it does still do bad things preventing the full impact of this optimization, it switches to another seemingly unused framebuffer and does a draw many times per frame. 

I thought this would also massively improve Metal Gear Acid 2, but it does this using shader blending in small chunks which forces us to copy the framebuffer before each draw, and to do each copy we must end the renderpass anyway so there's still a ton of passes. 

To solve these we might have to post process the command stream in the queue runner to reorder things in a sane way. 

EDIT: Did just that!  MGS Acid 2 and Sonic Rivals are now fast. See #10908 .

Note: This approach can be easily ported to GLES 3. 