### PR TITLE
OpenGL: Similar to NvOptimusEnablement, use AmdPowerXPressRequestHighPerformance

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -73,6 +73,11 @@ extern "C" {
 	__declspec(dllexport) DWORD NvOptimusEnablement = 1;
 }
 
+// Also on AMD PowerExpress: https://community.amd.com/thread/169965
+extern "C" {
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 CDisasm *disasmWindow[MAX_CPUCOUNT] = {0};
 CGEDebugger *geDebuggerWindow = 0;
 CMemoryDlg *memoryWindow[MAX_CPUCOUNT] = {0};


### PR DESCRIPTION
To select the AMD gpu in OpenGL if there's both an Intel integrated GPU and an AMD one.

Will merge after 1.6.0.