### PR TITLE
Add support for File app (file browser) on iOS 11

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UISupportsDocumentBrowser</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This option enables File app support on iOS 11+, making it possible to download games and manage data without any computer:
![img_0520](https://user-images.githubusercontent.com/20365903/38779887-5941d2e8-4101-11e8-9a61-a3b33e5c80db.png)
