### PR TITLE
Android: Add missing graphics shutdown calls

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -523,6 +523,9 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 			continue;
 		}
 		EmuThreadJoin();
+
+		graphicsContext->ThreadEnd();
+		graphicsContext->ShutdownFromRenderThread();
 	}
 
 	ILOG("NativeApp.shutdown() -- begin");

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -297,9 +297,8 @@ static GraphicsContext *graphicsContext;
 	}
 #endif
 
-	graphicsContext->Shutdown();
-
 	if (graphicsContext) {
+		graphicsContext->Shutdown();
 		delete graphicsContext;
 		graphicsContext = NULL;
 	}


### PR DESCRIPTION
These were there for graphics restart (like resize) but not for full shutdown, which was causing crashes during shutdown sometimes.

Should fix #10931 (although it doesn't consistently reproduce...)

-[Unknown]