### PR TITLE
Depal: Reapply texture when bounds change

### DIFF
--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -338,6 +338,9 @@ public:
 			verts_[1].uv = UV(uvright, uvbottom);
 			verts_[2].uv = UV(uvleft, uvtop);
 			verts_[3].uv = UV(uvright, uvtop);
+
+			// We need to reapply the texture next time since we cropped UV.
+			gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 		}
 	}
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -373,6 +373,9 @@ public:
 			verts_[1].uv = UV(uvright, uvbottom);
 			verts_[2].uv = UV(uvright, uvtop);
 			verts_[3].uv = UV(uvleft, uvtop);
+
+			// We need to reapply the texture next time since we cropped UV.
+			gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 		}
 	}
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -185,7 +185,7 @@ void TextureCacheGLES::SetFramebufferSamplingParams(u16 bufferWidth, u16 bufferH
 		tClamp = true;
 	}
 	float aniso = 0.0f;
-	render_->SetTextureSampler(0, sClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT, tClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT, MagFiltGL[magFilt], MinFiltGL[minFilt], aniso);
+	render_->SetTextureSampler(TEX_SLOT_PSP_TEXTURE, sClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT, tClamp ? GL_CLAMP_TO_EDGE : GL_REPEAT, MagFiltGL[magFilt], MinFiltGL[minFilt], aniso);
 }
 
 static void ConvertColors(void *dstBuf, const void *srcBuf, GLuint dstFmt, int numPixels) {
@@ -400,6 +400,9 @@ public:
 			uv_[1] = UV{ uvright, uvbottom };
 			uv_[2] = UV{ uvright, uvtop };
 			uv_[3] = UV{ uvleft, uvtop };
+
+			// We need to reapply the texture next time since we cropped UV.
+			gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 		}
 	}
 
@@ -451,6 +454,7 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 			const GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
 			GLRTexture *clutTexture = depalShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBuf_);
 			render_->BindTexture(TEX_SLOT_CLUT, clutTexture);
+			render_->SetTextureSampler(TEX_SLOT_CLUT, GL_REPEAT, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_NEAREST, 0.0f);
 			framebufferManagerGL_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 			SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, true);
 			InvalidateLastTexture();
@@ -483,7 +487,7 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 
 		framebufferManagerGL_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_SKIP_COPY);
 		render_->BindTexture(TEX_SLOT_CLUT, clutTexture);
-		render_->SetTextureSampler(TEX_SLOT_CLUT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_NEAREST, 0.0f);
+		render_->SetTextureSampler(TEX_SLOT_CLUT, GL_REPEAT, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_NEAREST, 0.0f);
 
 		shaderApply.Shade(render_);
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -428,6 +428,9 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 			verts[2].v = uvtop;
 			verts[3].u = uvright;
 			verts[3].v = uvtop;
+
+			// We need to reapply the texture next time since we cropped UV.
+			gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 		}
 
 		VkBuffer pushed;


### PR DESCRIPTION
Since we need each slice of the texture when we use bounds to reduce the size.  Fixes #10951.

I'm slightly worried we might not be dirtying TEXTURE_IMAGE if the texture is drawn to (e.g. a clear with texturing disabled), which would also potentially use the wrong texture.  But this fixes the much more common case.

That said, this case is unfortunate - it's using update stall for each slice of the framebuffer bloom blit, so we can't combine into one draw.

-[Unknown]