### PR TITLE
Android: Properly reset home on config reload

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -276,7 +276,7 @@ void NativeGetAppInfo(std::string *app_dir_name, std::string *app_nice_name, boo
 }
 
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
-bool CheckFontIsUsable(const wchar_t *fontFace) {
+static bool CheckFontIsUsable(const wchar_t *fontFace) {
 	wchar_t actualFontFace[1024] = { 0 };
 
 	HFONT f = CreateFont(0, 0, 0, 0, FW_LIGHT, 0, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, PROOF_QUALITY, VARIABLE_PITCH, fontFace);
@@ -297,6 +297,34 @@ bool CheckFontIsUsable(const wchar_t *fontFace) {
 	return false;
 }
 #endif
+
+static void PostLoadConfig() {
+	// On Windows, we deal with currentDirectory in InitSysDirectories().
+#ifndef _WIN32
+	if (g_Config.currentDirectory.empty()) {
+#if defined(__ANDROID__)
+		g_Config.currentDirectory = g_Config.externalDirectory;
+#elif defined(IOS)
+		g_Config.currentDirectory = g_Config.internalDataDirectory;
+#else
+		if (getenv("HOME") != nullptr)
+			g_Config.currentDirectory = getenv("HOME");
+		else
+			g_Config.currentDirectory = "./";
+#endif
+	}
+#endif
+
+	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to
+	// test new languages without recompiling the entire app, which is a hassle).
+	const std::string langOverridePath = g_Config.memStickDirectory + "PSP/SYSTEM/lang/";
+
+	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
+	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))
+		i18nrepo.LoadIni(g_Config.sLanguageIni);
+	else
+		i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
+}
 
 void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir, bool fs) {
 	net::Init();  // This needs to happen before we load the config. So on Windows we also run it in Main. It's fine to call multiple times.
@@ -336,8 +364,10 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 #endif
 
-#if defined(__ANDROID__)
 	g_Config.internalDataDirectory = savegame_dir;
+	g_Config.externalDirectory = external_dir;
+
+#if defined(__ANDROID__)
 	// Maybe there should be an option to use internal memory instead, but I think
 	// that for most people, using external memory (SDCard/USB Storage) makes the
 	// most sense.
@@ -375,7 +405,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// Note that if we don't have storage permission here, loading the config will
 	// fail and it will be set to the default. Later, we load again when we get permission.
 	g_Config.Load();
-	g_Config.externalDirectory = external_dir;
 #endif
 	LogManager *logman = LogManager::GetInstance();
 
@@ -484,20 +513,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	if (fileToLog)
 		LogManager::GetInstance()->ChangeFileLog(fileToLog);
 
-#ifndef _WIN32
-	if (g_Config.currentDirectory == "") {
-#if defined(__ANDROID__)
-		g_Config.currentDirectory = external_dir;
-#elif defined(IOS) || defined(_WIN32)
-		g_Config.currentDirectory = savegame_dir;
-#else
-		if (getenv("HOME") != NULL)
-			g_Config.currentDirectory = getenv("HOME");
-		else
-			g_Config.currentDirectory = "./";
-#endif
-	}
-#endif
+	PostLoadConfig();
 
 	// Hard reset the logs. TODO: Get rid of this and read from config.
 #ifndef _WIN32
@@ -514,16 +530,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	logger = new AndroidLogger();
 	logman->AddListener(logger);
 #endif
-
-	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to 
-	// test new languages without recompiling the entire app, which is a hassle).
-	const std::string langOverridePath = g_Config.memStickDirectory + "PSP/SYSTEM/lang/";
-
-	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
-	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))
-		i18nrepo.LoadIni(g_Config.sLanguageIni);
-	else
-		i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
 		if (System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) != PERMISSION_STATUS_GRANTED) {
@@ -955,6 +961,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		// with a freshly generated one.
 		ILOG("Reloading config after storage permission grant.");
 		g_Config.Load();
+		PostLoadConfig();
 	}
 }
 


### PR DESCRIPTION
We reload the config once we know we have permission to read it, but that means we have to run any cleanup logic on it again.

This fixes #10975, which happens when you start without a config.

Probably needs some refactoring (we should really load all these paths in one place, even on Windows), but I think this change should be safe for 1.6.0.

-[Unknown]