### PR TITLE
Improve debugger threadsafety and consistency

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -98,7 +98,7 @@ void Core_Halt(const char *msg)  {
 void Core_Stop() {
 	Core_UpdateState(CORE_POWERDOWN);
 	Core_NotifyShutdown();
-	m_StepCond.notify_one();
+	m_StepCond.notify_all();
 }
 
 bool Core_IsStepping() {
@@ -239,11 +239,11 @@ void Core_RunLoop(GraphicsContext *ctx) {
 
 void Core_DoSingleStep() {
 	singleStepPending = true;
-	m_StepCond.notify_one();
+	m_StepCond.notify_all();
 }
 
 void Core_UpdateSingleStep() {
-	m_StepCond.notify_one();
+	m_StepCond.notify_all();
 }
 
 void Core_SingleStep() {
@@ -253,7 +253,7 @@ void Core_SingleStep() {
 static inline void CoreStateProcessed() {
 	if (coreStatePending) {
 		coreStatePending = false;
-		m_InactiveCond.notify_one();
+		m_InactiveCond.notify_all();
 	}
 }
 
@@ -338,6 +338,6 @@ void Core_EnableStepping(bool step) {
 		host->SetDebugMode(false);
 		coreState = CORE_RUNNING;
 		coreStatePending = false;
-		m_StepCond.notify_one();
+		m_StepCond.notify_all();
 	}
 }

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -28,22 +28,21 @@
 #include "thread/threadutil.h"
 #include "profiler/profiler.h"
 
+#include "Common/GraphicsContext.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/SaveState.h"
 #include "Core/System.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/MIPS/MIPS.h"
-#include "Common/GraphicsContext.h"
 
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
 #include "Windows/InputDevice.h"
 #endif
 
-#include "Host.h"
-
-#include "Core/Debugger/Breakpoints.h"
 
 // Time until we stop considering the core active without user input.
 // Should this be configurable?  2 hours currently.
@@ -84,16 +83,6 @@ void Core_NotifyLifecycle(CoreLifecycle stage) {
 	for (auto it = shutdownFuncs.begin(); it != shutdownFuncs.end(); ++it) {
 		(*it)(stage);
 	}
-}
-
-void Core_ErrorPause() {
-	Core_UpdateState(CORE_ERROR);
-}
-
-void Core_Halt(const char *msg)  {
-	Core_EnableStepping(true);
-	ERROR_LOG(CPU, "CPU HALTED : %s",msg);
-	_dbg_update_();
 }
 
 void Core_Stop() {

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -54,6 +54,7 @@ static std::mutex m_hStepMutex;
 static std::condition_variable m_InactiveCond;
 static std::mutex m_hInactiveMutex;
 static bool singleStepPending = false;
+static int steppingCounter = 0;
 static std::set<Core_ShutdownFunc> shutdownFuncs;
 static bool windowHidden = false;
 static double lastActivity = 0.0;
@@ -334,10 +335,15 @@ void Core_EnableStepping(bool step) {
 		sleep_ms(1);
 		host->SetDebugMode(true);
 		Core_UpdateState(CORE_STEPPING);
+		steppingCounter++;
 	} else {
 		host->SetDebugMode(false);
 		coreState = CORE_RUNNING;
 		coreStatePending = false;
 		m_StepCond.notify_all();
 	}
+}
+
+int Core_GetSteppingCounter() {
+	return steppingCounter;
 }

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -55,7 +55,7 @@ static std::condition_variable m_InactiveCond;
 static std::mutex m_hInactiveMutex;
 static bool singleStepPending = false;
 static int steppingCounter = 0;
-static std::set<Core_ShutdownFunc> shutdownFuncs;
+static std::set<CoreLifecycleFunc> shutdownFuncs;
 static bool windowHidden = false;
 static double lastActivity = 0.0;
 static double lastKeepAwake = 0.0;
@@ -76,13 +76,13 @@ void Core_NotifyActivity() {
 	lastActivity = time_now_d();
 }
 
-void Core_ListenShutdown(Core_ShutdownFunc func) {
+void Core_ListenLifecycle(CoreLifecycleFunc func) {
 	shutdownFuncs.insert(func);
 }
 
-void Core_NotifyShutdown() {
+void Core_NotifyLifecycle(CoreLifecycle stage) {
 	for (auto it = shutdownFuncs.begin(); it != shutdownFuncs.end(); ++it) {
-		(*it)();
+		(*it)(stage);
 	}
 }
 
@@ -98,7 +98,6 @@ void Core_Halt(const char *msg)  {
 
 void Core_Stop() {
 	Core_UpdateState(CORE_POWERDOWN);
-	Core_NotifyShutdown();
 	m_StepCond.notify_all();
 }
 

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -31,12 +31,12 @@ void Core_ErrorPause();
 // For platforms that don't call Core_Run
 void Core_SetGraphicsContext(GraphicsContext *ctx);
 
-void Core_RunRenderThreadFrame();
-
 // called from gui
 void Core_EnableStepping(bool step);
 void Core_DoSingleStep();
 void Core_UpdateSingleStep();
+// Changes every time we enter stepping.
+int Core_GetSteppingCounter();
 
 typedef void (* Core_ShutdownFunc)();
 void Core_ListenShutdown(Core_ShutdownFunc func);

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -38,9 +38,18 @@ void Core_UpdateSingleStep();
 // Changes every time we enter stepping.
 int Core_GetSteppingCounter();
 
-typedef void (* Core_ShutdownFunc)();
-void Core_ListenShutdown(Core_ShutdownFunc func);
-void Core_NotifyShutdown();
+enum class CoreLifecycle {
+	STARTING,
+	// Note: includes failure cases.  Guaranteed call after STARTING.
+	START_COMPLETE,
+	STOPPING,
+	// Guaranteed call after STOPPING.
+	STOPPED,
+};
+
+typedef void (* CoreLifecycleFunc)(CoreLifecycle stage);
+void Core_ListenLifecycle(CoreLifecycleFunc func);
+void Core_NotifyLifecycle(CoreLifecycle stage);
 void Core_Halt(const char *msg);
 
 bool Core_IsStepping();

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -27,7 +27,6 @@ void UpdateRunLoop();
 
 void Core_Run(GraphicsContext *ctx);
 void Core_Stop();
-void Core_ErrorPause();
 // For platforms that don't call Core_Run
 void Core_SetGraphicsContext(GraphicsContext *ctx);
 
@@ -50,7 +49,6 @@ enum class CoreLifecycle {
 typedef void (* CoreLifecycleFunc)(CoreLifecycle stage);
 void Core_ListenLifecycle(CoreLifecycleFunc func);
 void Core_NotifyLifecycle(CoreLifecycle stage);
-void Core_Halt(const char *msg);
 
 bool Core_IsStepping();
 

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -182,7 +182,7 @@ int RegisterEvent(const char *name, TimedCallback callback)
 void AntiCrashCallback(u64 userdata, int cyclesLate)
 {
 	ERROR_LOG(SAVESTATE, "Savestate broken: an unregistered event was called.");
-	Core_Halt("invalid timing events");
+	Core_EnableStepping(true);
 }
 
 void RestoreRegisterEvent(int event_type, const char *name, TimedCallback callback)

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -31,6 +31,7 @@
 #include "Core/Debugger/DisassemblyManager.h"
 
 std::map<u32, DisassemblyEntry*> DisassemblyManager::entries;
+std::recursive_mutex DisassemblyManager::entriesLock_;
 DebugInterface* DisassemblyManager::cpu;
 int DisassemblyManager::maxParamChars = 29;
 
@@ -149,7 +150,8 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 		if (!PSP_IsInited())
 			return;
 
-		auto it = findDisassemblyEntry(entries,address,false);
+		std::lock_guard<std::recursive_mutex> guard(entriesLock_);
+		auto it = findDisassemblyEntry(entries, address, false);
 		if (it != entries.end())
 		{
 			DisassemblyEntry* entry = it->second;
@@ -219,7 +221,8 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 std::vector<BranchLine> DisassemblyManager::getBranchLines(u32 start, u32 size)
 {
 	std::vector<BranchLine> result;
-	
+
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	auto it = findDisassemblyEntry(entries,start,false);
 	if (it != entries.end())
 	{
@@ -235,6 +238,7 @@ std::vector<BranchLine> DisassemblyManager::getBranchLines(u32 start, u32 size)
 
 void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLineInfo& dest)
 {
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
 	{
@@ -267,6 +271,7 @@ void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLin
 
 u32 DisassemblyManager::getStartAddress(u32 address)
 {
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
 	{
@@ -283,6 +288,7 @@ u32 DisassemblyManager::getStartAddress(u32 address)
 
 u32 DisassemblyManager::getNthPreviousAddress(u32 address, int n)
 {
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	while (Memory::IsValidAddress(address))
 	{
 		auto it = findDisassemblyEntry(entries,address,false);
@@ -311,6 +317,7 @@ u32 DisassemblyManager::getNthPreviousAddress(u32 address, int n)
 
 u32 DisassemblyManager::getNthNextAddress(u32 address, int n)
 {
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	while (Memory::IsValidAddress(address))
 	{
 		auto it = findDisassemblyEntry(entries,address,false);
@@ -345,6 +352,7 @@ DisassemblyManager::~DisassemblyManager() {
 
 void DisassemblyManager::clear()
 {
+	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	for (auto it = entries.begin(); it != entries.end(); it++)
 	{
 		delete it->second;
@@ -383,11 +391,13 @@ void DisassemblyFunction::recheck()
 
 int DisassemblyFunction::getNumLines()
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	return (int) lineAddresses.size();
 }
 
 int DisassemblyFunction::getLineNum(u32 address, bool findStart)
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	if (findStart)
 	{
 		int last = (int)lineAddresses.size() - 1;
@@ -418,11 +428,13 @@ int DisassemblyFunction::getLineNum(u32 address, bool findStart)
 
 u32 DisassemblyFunction::getLineAddress(int line)
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	return lineAddresses[line];
 }
 
 bool DisassemblyFunction::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
 		return false;
@@ -434,6 +446,7 @@ void DisassemblyFunction::getBranchLines(u32 start, u32 size, std::vector<Branch
 {
 	u32 end = start+size;
 
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (size_t i = 0; i < lines.size(); i++)
 	{
 		BranchLine& line = lines[i];
@@ -466,6 +479,7 @@ void DisassemblyFunction::generateBranchLines()
 
 	u32 end = address+size;
 
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	DebugInterface* cpu = DisassemblyManager::getCpu();
 	for (u32 funcPos = address; funcPos < end; funcPos += 4)
 	{
@@ -524,6 +538,7 @@ void DisassemblyFunction::generateBranchLines()
 void DisassemblyFunction::addOpcodeSequence(u32 start, u32 end)
 {
 	DisassemblyOpcode* opcode = new DisassemblyOpcode(start,(end-start)/4);
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	entries[start] = opcode;
 	for (u32 pos = start; pos < end; pos += 4)
 	{
@@ -537,18 +552,21 @@ void DisassemblyFunction::load()
 
 	// gather all branch targets
 	std::set<u32> branchTargets;
-	for (size_t i = 0; i < lines.size(); i++)
 	{
-		switch (lines[i].type)
+		std::lock_guard<std::recursive_mutex> guard(lock_);
+		for (size_t i = 0; i < lines.size(); i++)
 		{
-		case LINE_DOWN:
-			branchTargets.insert(lines[i].second);
-			break;
-		case LINE_UP:
-			branchTargets.insert(lines[i].first);
-			break;
-		default:
-			break;
+			switch (lines[i].type)
+			{
+			case LINE_DOWN:
+				branchTargets.insert(lines[i].second);
+				break;
+			case LINE_UP:
+				branchTargets.insert(lines[i].first);
+				break;
+			default:
+				break;
+			}
 		}
 	}
 	
@@ -566,6 +584,7 @@ void DisassemblyFunction::load()
 				addOpcodeSequence(opcodeSequenceStart,funcPos);
 
 			DisassemblyData* data = new DisassemblyData(funcPos,g_symbolMap->GetDataSize(funcPos),g_symbolMap->GetDataType(funcPos));
+			std::lock_guard<std::recursive_mutex> guard(lock_);
 			entries[funcPos] = data;
 			lineAddresses.push_back(funcPos);
 			funcPos += data->getTotalSize();
@@ -581,6 +600,7 @@ void DisassemblyFunction::load()
 			u32 nextPos = (funcPos+3) & ~3;
 
 			DisassemblyComment* comment = new DisassemblyComment(funcPos,nextPos-funcPos,".align","4");
+			std::lock_guard<std::recursive_mutex> guard(lock_);
 			entries[funcPos] = comment;
 			lineAddresses.push_back(funcPos);
 			
@@ -665,6 +685,7 @@ void DisassemblyFunction::load()
 					if (opcodeSequenceStart != opAddress)
 						addOpcodeSequence(opcodeSequenceStart,opAddress);
 
+					std::lock_guard<std::recursive_mutex> guard(lock_);
 					entries[opAddress] = macro;
 					for (int i = 0; i < macro->getNumLines(); i++)
 					{
@@ -686,6 +707,7 @@ void DisassemblyFunction::load()
 
 void DisassemblyFunction::clear()
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (auto it = entries.begin(); it != entries.end(); it++)
 	{
 		delete it->second;
@@ -866,6 +888,7 @@ bool DisassemblyData::disassemble(u32 address, DisassemblyLineInfo& dest, bool i
 		return false;
 	}
 
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = lines.find(address);
 	if (it == lines.end())
 		return false;
@@ -877,6 +900,7 @@ bool DisassemblyData::disassemble(u32 address, DisassemblyLineInfo& dest, bool i
 
 int DisassemblyData::getLineNum(u32 address, bool findStart)
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = lines.upper_bound(address);
 	if (it != lines.end())
 	{
@@ -891,6 +915,7 @@ int DisassemblyData::getLineNum(u32 address, bool findStart)
 
 void DisassemblyData::createLines()
 {
+	std::lock_guard<std::recursive_mutex> guard(lock_);
 	lines.clear();
 	lineAddresses.clear();
 

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -244,29 +244,28 @@ void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLin
 	{
 		analyze(address);
 		it = findDisassemblyEntry(entries,address,false);
-
-		if (it == entries.end())
-		{
-			if (address % 4)
-				dest.totalSize = ((address+3) & ~3)-address;
-			else
-				dest.totalSize = 4;
-			dest.name = "ERROR";
-			dest.params = "Disassembly failure";
-			return;
-		}
 	}
 
-	DisassemblyEntry* entry = it->second;
-	if (entry->disassemble(address,dest,insertSymbols))
-		return;
-	
+	if (it != entries.end()) {
+		DisassemblyEntry *entry = it->second;
+		if (entry->disassemble(address, dest, insertSymbols))
+			return;
+	}
+
+	dest.type = DISTYPE_OTHER;
+	memset(&dest.info, 0, sizeof(dest.info));
+	dest.info.opcodeAddress = address;
 	if (address % 4)
 		dest.totalSize = ((address+3) & ~3)-address;
 	else
 		dest.totalSize = 4;
-	dest.name = "ERROR";
-	dest.params = "Disassembly failure";
+	if (Memory::IsValidRange(address, 4)) {
+		dest.name = "ERROR";
+		dest.params = "Disassembly failure";
+	} else {
+		dest.name = "-";
+		dest.params = "";
+	}
 }
 
 u32 DisassemblyManager::getStartAddress(u32 address)

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <mutex>
 #include "Common/CommonTypes.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/MIPS/MIPSAnalyst.h"
@@ -91,6 +92,7 @@ private:
 	std::vector<BranchLine> lines;
 	std::map<u32,DisassemblyEntry*> entries;
 	std::vector<u32> lineAddresses;
+	std::recursive_mutex lock_;
 };
 
 class DisassemblyOpcode: public DisassemblyEntry
@@ -169,6 +171,7 @@ private:
 	DataType type;
 	std::map<u32,DataEntry> lines;
 	std::vector<u32> lineAddresses;
+	std::recursive_mutex lock_;
 };
 
 class DisassemblyComment: public DisassemblyEntry
@@ -214,6 +217,7 @@ public:
 	static int getMaxParamChars() { return maxParamChars; };
 private:
 	static std::map<u32,DisassemblyEntry*> entries;
+	static std::recursive_mutex entriesLock_;
 	static DebugInterface* cpu;
 	static int maxParamChars;
 };

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -496,10 +496,12 @@ static void __IoManagerThread() {
 	}
 }
 
-static void __IoWakeManager() {
+static void __IoWakeManager(CoreLifecycle stage) {
 	// Ping the thread so that it knows to check coreState.
-	ioManagerThreadEnabled = false;
-	ioManager.FinishEventLoop();
+	if (stage == CoreLifecycle::STOPPING) {
+		ioManagerThreadEnabled = false;
+		ioManager.FinishEventLoop();
+	}
 }
 
 static void __IoVblank() {
@@ -586,7 +588,7 @@ void __IoInit() {
 	ioManagerThreadEnabled = g_Config.bSeparateIOThread;
 	ioManager.SetThreadEnabled(ioManagerThreadEnabled);
 	if (ioManagerThreadEnabled) {
-		Core_ListenShutdown(&__IoWakeManager);
+		Core_ListenLifecycle(&__IoWakeManager);
 		ioManagerThread = new std::thread(&__IoManagerThread);
 		ioManagerThread->detach();
 	}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1415,6 +1415,7 @@ skip:
 		memset(&info, 0, sizeof(info));
 
 		if (!Memory::IsValidAddress(address)) {
+			info.opcodeAddress = address;
 			return info;
 		}
 

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -197,10 +197,12 @@ void ResumeFromStepping() {
 	SetPauseAction(PAUSE_CONTINUE, false);
 }
 
-void ForceUnpause() {
-	SetPauseAction(PAUSE_CONTINUE, false);
-	actionComplete = true;
-	actionWait.notify_all();
+void ForceUnpause(CoreLifecycle stage) {
+	if (stage == CoreLifecycle::STOPPING) {
+		SetPauseAction(PAUSE_CONTINUE, false);
+		actionComplete = true;
+		actionWait.notify_all();
+	}
 }
 
 }  // namespace

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -67,7 +67,7 @@ static void SetPauseAction(PauseAction act, bool waitComplete = true) {
 	pauseLock.unlock();
 
 	actionComplete = false;
-	pauseWait.notify_one();
+	pauseWait.notify_all();
 	while (waitComplete && !actionComplete) {
 		actionWait.wait(guard);
 	}
@@ -113,7 +113,7 @@ static void RunPauseAction() {
 	}
 
 	actionComplete = true;
-	actionWait.notify_one();
+	actionWait.notify_all();
 	pauseAction = PAUSE_BREAK;
 }
 
@@ -200,7 +200,7 @@ void ResumeFromStepping() {
 void ForceUnpause() {
 	SetPauseAction(PAUSE_CONTINUE, false);
 	actionComplete = true;
-	actionWait.notify_one();
+	actionWait.notify_all();
 }
 
 }  // namespace

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -20,6 +20,7 @@
 #include <functional>
 
 #include "Common/CommonTypes.h"
+#include "Core/Core.h"
 #include "GPU/Common/GPUDebugInterface.h"
 
 namespace GPUStepping {
@@ -37,5 +38,5 @@ namespace GPUStepping {
 	bool GPU_SetCmdValue(u32 op);
 
 	void ResumeFromStepping();
-	void ForceUnpause();
+	void ForceUnpause(CoreLifecycle stage);
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -399,15 +399,15 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		// In case we need to position touch controls differently.
 		RecreateViews();
 	} else if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
+		UpdateUIState(UISTATE_PAUSEMENU);
 		releaseButtons();
 		screenManager()->push(new ControlMappingScreen());
 	} else if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
+		UpdateUIState(UISTATE_PAUSEMENU);
 		releaseButtons();
 		screenManager()->push(new DisplayLayoutScreen());
 	} else if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
-		UpdateUIState(UISTATE_MENU);
+		UpdateUIState(UISTATE_PAUSEMENU);
 		releaseButtons();
 		screenManager()->push(new GameSettingsScreen(gamePath_));
 	} else if (!strcmp(message, "gpu dump next frame")) {

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -67,7 +67,7 @@ void CGEDebugger::Init() {
 CGEDebugger::CGEDebugger(HINSTANCE _hInstance, HWND _hParent)
 	: Dialog((LPCSTR)IDD_GEDEBUGGER, _hInstance, _hParent) {
 	GPUBreakpoints::Init();
-	Core_ListenShutdown(ForceUnpause);
+	Core_ListenLifecycle(ForceUnpause);
 
 	// minimum size = a little more than the default
 	RECT windowRect;


### PR DESCRIPTION
These are minor changes to the main core system that allow multiple connections (e.g. from #10909 and Windows debugger, or even multiple WebSockets) to work correctly, as well as a little cleanup.

The shutdown functions are changed to starting/started to enable some locks, but those aren't used yet.  I'm including it here so we can merge this separately and have a build in case there are issues with the other places it impacts.

This should only minorly impact the current Windows debugger, right now.

Note: more changes will come when introducing stepping for Android/etc., but that's for later.

-[Unknown]