### PR TITLE
Vulkan: Keep state on Clear cmds when used later

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -611,6 +611,10 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass) {
 	ILOG("RenderPass Begin(%x)", fb);
 	for (auto &cmd : pass.commands) {
 		switch (cmd.cmd) {
+		case VKRRenderCommand::REMOVED:
+			ILOG("  REMOVED");
+			break;
+
 		case VKRRenderCommand::BIND_PIPELINE:
 			ILOG("  BindPipeline(%x)", (int)(intptr_t)cmd.pipeline.pipeline);
 			break;
@@ -733,6 +737,9 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 	for (const auto &c : commands) {
 		switch (c.cmd) {
+		case VKRRenderCommand::REMOVED:
+			break;
+
 		case VKRRenderCommand::BIND_PIPELINE:
 			if (c.pipeline.pipeline != lastPipeline) {
 				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, c.pipeline.pipeline);

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -612,7 +612,7 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass) {
 	for (auto &cmd : pass.commands) {
 		switch (cmd.cmd) {
 		case VKRRenderCommand::REMOVED:
-			ILOG("  REMOVED");
+			ILOG("  (Removed)");
 			break;
 
 		case VKRRenderCommand::BIND_PIPELINE:

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -16,6 +16,7 @@ enum {
 };
 
 enum class VKRRenderCommand : uint8_t {
+	REMOVED,
 	BIND_PIPELINE,
 	STENCIL,
 	BLEND,

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -615,9 +615,11 @@ bool VulkanRenderManager::InitDepthStencilBuffer(VkCommandBuffer cmd) {
 
 static void RemoveDrawCommands(std::vector<VkRenderData> *cmds) {
 	// Here we remove any DRAW type commands when we hit a CLEAR.
-	cmds->erase(std::remove_if(cmds->begin(), cmds->end(), [](const VkRenderData &data) {
-		return data.cmd == VKRRenderCommand::DRAW || data.cmd == VKRRenderCommand::DRAW_INDEXED;
-	}), cmds->end());
+	for (auto &c : *cmds) {
+		if (c.cmd == VKRRenderCommand::DRAW || c.cmd == VKRRenderCommand::DRAW_INDEXED) {
+			c.cmd = VKRRenderCommand::REMOVED;
+		}
+	}
 }
 
 static void CleanupRenderCommands(std::vector<VkRenderData> *cmds) {
@@ -631,7 +633,6 @@ static void CleanupRenderCommands(std::vector<VkRenderData> *cmds) {
 
 		switch (c.cmd) {
 		case VKRRenderCommand::REMOVED:
-			// Ignore, in case some other code starts using this.
 			continue;
 
 		case VKRRenderCommand::BIND_PIPELINE:
@@ -671,10 +672,6 @@ static void CleanupRenderCommands(std::vector<VkRenderData> *cmds) {
 			cmds->at(lastOfCmd).cmd = VKRRenderCommand::REMOVED;
 		}
 	}
-
-	cmds->erase(std::remove_if(cmds->begin(), cmds->end(), [](const VkRenderData &data) {
-		return data.cmd == VKRRenderCommand::REMOVED;
-	}), cmds->end());
 }
 
 void VulkanRenderManager::Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask) {


### PR DESCRIPTION
This also removes duplicate state - for example our UI has some duplicate Scissor commands.

Should solve the case from #10997 - and I found a game with a clear in the middle which I used to debug this.  But, still not sure about safety/risk for 1.6.0...

-[Unknown]