### PR TITLE
Fix regression caused by the new depal code for Vulkan. Fixes #10993

### DIFF
--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -328,7 +328,7 @@ void TextureCacheGLES::BindTexture(TexCacheEntry *entry) {
 		lastBoundTexture = entry->textureName;
 	}
 	UpdateSamplingParams(*entry, false);
-	gstate_c.useShaderDepal = false;
+	gstate_c.SetUseShaderDepal(false);
 }
 
 void TextureCacheGLES::Unbind() {
@@ -461,7 +461,7 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 
 			// Since we started/ended render passes, might need these.
 			gstate_c.Dirty(DIRTY_DEPAL);
-			gstate_c.useShaderDepal = true;
+			gstate_c.SetUseShaderDepal(true);
 			gstate_c.depalFramebufferFormat = framebuffer->drawnFormat;
 			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 			const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -517,6 +517,12 @@ struct GPUStateCache {
 	bool IsDirty(u64 what) const {
 		return (dirty & what) != 0ULL;
 	}
+	void SetUseShaderDepal(bool depal) {
+		if (depal != useShaderDepal) {
+			useShaderDepal = depal;
+			Dirty(DIRTY_FRAGMENTSHADER_STATE);
+		}
+	}
 	void SetTextureFullAlpha(bool fullAlpha) {
 		if (fullAlpha != textureFullAlpha) {
 			textureFullAlpha = fullAlpha;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -180,7 +180,10 @@ public:
 
 	void SetLineWidth(float lineWidth);
 	void SetDepalTexture(VkImageView depal) {
-		boundDepal_ = depal;
+		if (boundDepal_ != depal) {
+			boundDepal_ = depal;
+			gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
+		}
 	}
 
 private:

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -370,7 +370,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 			return;
 		} else {
 			depalShader = depalShaderCache_->GetDepalettizeShader(clutMode, framebuffer->drawnFormat);
-			drawEngine_->SetDepalTexture(nullptr);
+			drawEngine_->SetDepalTexture(VK_NULL_HANDLE);
 			gstate_c.SetUseShaderDepal(false);
 		}
 	}
@@ -468,7 +468,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 
 		framebufferManager_->RebindFramebuffer();  // TODO: This line should usually not be needed.
 		imageView_ = framebufferManagerVulkan_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
-		drawEngine_->SetDepalTexture(nullptr);
+		drawEngine_->SetDepalTexture(VK_NULL_HANDLE);
 		gstate_c.SetUseShaderDepal(false);
 
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -328,7 +328,7 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
 	UpdateSamplingParams(*entry, key);
 	curSampler_ = samplerCache_.GetOrCreateSampler(key);
 	drawEngine_->SetDepalTexture(VK_NULL_HANDLE);
-	gstate_c.useShaderDepal = false;
+	gstate_c.SetUseShaderDepal(false);
 }
 
 void TextureCacheVulkan::Unbind() {
@@ -344,7 +344,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 	DepalShaderVulkan *depalShader = nullptr;
 	uint32_t clutMode = gstate.clutformat & 0xFFFFFF;
 
-	bool useShaderDepal = true;
+	bool useShaderDepal = framebufferManager_->GetCurrentRenderVFB() != framebuffer;
 
 	if ((entry->status & TexCacheEntry::STATUS_DEPALETTIZE) && !g_Config.bDisableSlowFramebufEffects) {
 		if (useShaderDepal) {
@@ -356,9 +356,9 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 			samplerKey.magFilt = false;
 			samplerKey.minFilt = false;
 			samplerKey.mipFilt = false;
-			// Make sure to update the uniforms.
+			// Make sure to update the uniforms, and also texture - needs a recheck.
 			gstate_c.Dirty(DIRTY_DEPAL);
-			gstate_c.useShaderDepal = true;
+			gstate_c.SetUseShaderDepal(true);
 			gstate_c.depalFramebufferFormat = framebuffer->drawnFormat;
 			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 			const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;
@@ -370,6 +370,8 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 			return;
 		} else {
 			depalShader = depalShaderCache_->GetDepalettizeShader(clutMode, framebuffer->drawnFormat);
+			drawEngine_->SetDepalTexture(nullptr);
+			gstate_c.SetUseShaderDepal(false);
 		}
 	}
 	if (depalShader) {
@@ -466,6 +468,8 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFr
 
 		framebufferManager_->RebindFramebuffer();  // TODO: This line should usually not be needed.
 		imageView_ = framebufferManagerVulkan_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
+		drawEngine_->SetDepalTexture(nullptr);
+		gstate_c.SetUseShaderDepal(false);
 
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}


### PR DESCRIPTION
Not all of this is actually needed to fix it, but it's right I think :)

The issue was that when first texturing using depal and then without depal from another framebuffer, we forgot to reset the depal state so it would use depal even though it shouldn't.