### PR TITLE
Enable IPv6 for reporting / sharing / etc.

### DIFF
--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -6,6 +6,7 @@
 
 #include "base/basictypes.h"
 #include "base/buffer.h"
+#include "net/resolve.h"
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -28,7 +29,7 @@ public:
 	virtual ~Connection();
 
 	// Inits the sockaddr_in.
-	bool Resolve(const char *host, int port);
+	bool Resolve(const char *host, int port, DNSType type = DNSType::ANY);
 
 	bool Connect(int maxTries = 2, double timeout = 20.0f, bool *cancelConnect = nullptr);
 	void Disconnect();

--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -130,9 +130,21 @@ void Server::SetFallbackHandler(UrlHandlerFunc handler) {
 	fallback_ = handler;
 }
 
-bool Server::Listen(int port) {
+bool Server::Listen(int port, net::DNSType type) {
+	bool success = false;
+	if (type == net::DNSType::ANY || type == net::DNSType::IPV6) {
+		success = Listen6(port, type == net::DNSType::IPV6);
+	}
+	if (!success && (type == net::DNSType::ANY || type == net::DNSType::IPV4)) {
+		success = Listen4(port);
+	}
+	return success;
+}
+
+bool Server::Listen4(int port) {
 	listener_ = socket(AF_INET, SOCK_STREAM, 0);
-	CHECK_GE(listener_, 0);
+	if (listener_ < 0)
+		return false;
 
 	struct sockaddr_in server_addr;
 	memset(&server_addr, 0, sizeof(server_addr));
@@ -145,6 +157,7 @@ bool Server::Listen(int port) {
 	setsockopt(listener_, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt));
 
 	if (bind(listener_, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+		closesocket(listener_);
 		ELOG("Failed to bind to port %i. Bailing.", port);
 		return false;
 	}
@@ -152,11 +165,58 @@ bool Server::Listen(int port) {
 	fd_util::SetNonBlocking(listener_, true);
 
 	// 1024 is the max number of queued requests.
-	CHECK_GE(listen(listener_, 1024), 0);
+	if (listen(listener_, 1024) < 0) {
+		closesocket(listener_);
+		return false;
+	}
 
 	socklen_t len = sizeof(server_addr);
 	if (getsockname(listener_, (struct sockaddr *)&server_addr, &len) == 0) {
 		port = ntohs(server_addr.sin_port);
+	}
+
+	ILOG("HTTP server started on port %i", port);
+	port_ = port;
+
+	return true;
+}
+
+bool Server::Listen6(int port, bool ipv6_only) {
+	listener_ = socket(AF_INET6, SOCK_STREAM, 0);
+	if (listener_ < 0)
+		return false;
+
+	struct sockaddr_in6 server_addr;
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sin6_family = AF_INET6;
+	server_addr.sin6_addr = in6addr_any;
+	server_addr.sin6_port = htons(port);
+
+	int opt = 1;
+	// Enable re-binding to avoid the pain when restarting the server quickly.
+	setsockopt(listener_, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt));
+
+	// Enable listening on IPv6 and IPv4?
+	opt = ipv6_only ? 1 : 0;
+	setsockopt(listener_, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&opt, sizeof(opt));
+
+	if (bind(listener_, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+		closesocket(listener_);
+		ELOG("Failed to bind to port %i. Bailing.", port);
+		return false;
+	}
+
+	fd_util::SetNonBlocking(listener_, true);
+
+	// 1024 is the max number of queued requests.
+	if (listen(listener_, 1024) < 0) {
+		closesocket(listener_);
+		return false;
+	}
+
+	socklen_t len = sizeof(server_addr);
+	if (getsockname(listener_, (struct sockaddr *)&server_addr, &len) == 0) {
+		port = ntohs(server_addr.sin6_port);
 	}
 
 	ILOG("HTTP server started on port %i", port);
@@ -177,9 +237,13 @@ bool Server::RunSlice(double timeout) {
 		return false;
 	}
 
-	sockaddr client_addr;
+	union {
+		struct sockaddr sa;
+		struct sockaddr_in ipv4;
+		struct sockaddr_in6 ipv6;
+	} client_addr;
 	socklen_t client_addr_size = sizeof(client_addr);
-	int conn_fd = accept(listener_, &client_addr, &client_addr_size);
+	int conn_fd = accept(listener_, &client_addr.sa, &client_addr_size);
 	if (conn_fd >= 0) {
 		executor_->Run(std::bind(&Server::HandleConnection, this, conn_fd));
 		return true;

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -6,6 +6,7 @@
 
 #include "base/buffer.h"
 #include "net/http_headers.h"
+#include "net/resolve.h"
 #include "thread/executor.h"
 
 namespace net {
@@ -73,7 +74,7 @@ public:
 	// May run for (significantly) longer than timeout, but won't wait longer than that
 	// for a new connection to handle.
 	bool RunSlice(double timeout);
-	bool Listen(int port);
+	bool Listen(int port, net::DNSType type = net::DNSType::ANY);
 	void Stop();
 
 	void RegisterHandler(const char *url_path, UrlHandlerFunc handler);
@@ -89,6 +90,9 @@ public:
 	}
 
 private:
+	bool Listen6(int port, bool ipv6_only);
+	bool Listen4(int port);
+
 	void HandleConnection(int conn_fd);
 
 	// Things like default 404, etc.

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -85,7 +85,7 @@ public:
 	virtual void HandleRequest(const Request &request);
 
 	int Port() {
-	  return port_;
+		return port_;
 	}
 
 private:

--- a/ext/native/net/resolve.cpp
+++ b/ext/native/net/resolve.cpp
@@ -77,7 +77,7 @@ char *DNSResolve(const char *host)
 	return ip;
 }
 
-bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error)
+bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error, DNSType type)
 {
 	addrinfo hints = {0};
 	// TODO: Might be uses to lookup other values.
@@ -89,7 +89,11 @@ bool DNSResolve(const std::string &host, const std::string &service, addrinfo **
 	// http://stackoverflow.com/questions/1408030/what-is-the-purpose-of-the-ai-v4mapped-flag-in-getaddrinfo
 	hints.ai_flags = /*AI_V4MAPPED |*/ AI_ADDRCONFIG;
 #endif
-	hints.ai_protocol = IPPROTO_TCP;
+	hints.ai_protocol = 0;
+	if (type == DNSType::IPV4)
+		hints.ai_family = AF_INET;
+	else if (type == DNSType::IPV6)
+		hints.ai_family = AF_INET6;
 
 	const char *servicep = service.length() == 0 ? NULL : service.c_str();
 

--- a/ext/native/net/resolve.h
+++ b/ext/native/net/resolve.h
@@ -14,7 +14,13 @@ void Shutdown();
 char *DNSResolveTry(const char *host, const char **err);
 char *DNSResolve(const char *host);
 
-bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error);
+enum class DNSType {
+	ANY = 0,
+	IPV4 = 1,
+	IPV6 = 2,
+};
+
+bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error, DNSType type = DNSType::ANY);
 void DNSResolveFree(addrinfo *res);
 
 int inet_pton(int af, const char* src, void* dst);


### PR DESCRIPTION
There's some (slight) risk a client may be on a network where ipv6 doesn't properly work, but is available.  This should try ipv4 even in that case, but I haven't tested it on such a network.

There's two reasons to go for ipv6:

1. The public IP is used to match devices in the same network.  Now that report.ppsspp.org is ipv6, this is required for matching to work from an ipv6 client (e.g. a web browser, lua script, etc. for #10909.)

2. We shouldn't be "part of the problem" for ipv4, as slight as our contribution to that is.  Now version.json, homebrew downloads, etc. route via ipv6.

Should wait for post-1.6.1 or whatever.  Tested this on Android/Windows/Mac, it both connects and listens properly there.

-[Unknown]