### PR TITLE
Update default firmware version to 6.60

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -27,7 +27,7 @@ extern const char *PPSSPP_GIT_VERSION;
 
 const int PSP_MODEL_FAT = 0;
 const int PSP_MODEL_SLIM = 1;
-const int PSP_DEFAULT_FIRMWARE = 150;
+const int PSP_DEFAULT_FIRMWARE = 660;
 static const s8 VOLUME_OFF = 0;
 static const s8 VOLUME_MAX = 10;
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -313,7 +313,7 @@ u32 sceKernelDevkitVersion()
 	int revision = firmwareVersion % 10;
 	int devkitVersion = (major << 24) | (minor << 16) | (revision << 8) | 0x10;
 
-	DEBUG_LOG_REPORT_ONCE(devkitVer, SCEKERNEL, "%08x=sceKernelDevkitVersion()", devkitVersion);
+	DEBUG_LOG(SCEKERNEL, "%08x=sceKernelDevkitVersion()", devkitVersion);
 	return devkitVersion;
 }
 


### PR DESCRIPTION
Not many games call sceKernelDevkitVersion(), but we mostly match 6.60.

See also: https://report.ppsspp.org/logs/kind/883?status=any

-[Unknown]