### PR TITLE
Io: Prevent error when file locked for writing

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -252,7 +252,7 @@ bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, Fil
 			I18NCategory *err = GetI18NCategory("Error");
 			host->NotifyUserMessage(err->T("Disk full while writing data"));
 			error = SCE_KERNEL_ERROR_ERRNO_NO_PERM;
-		} else {
+		} else if (!success) {
 			error = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 		}
 	}


### PR DESCRIPTION
When reopening with file sharing flags fixed it, we shouldn't set error.  That would cause the open to still fail.

I wasn't able to reproduce a file sharing violation during load, and load went fine... but this is wrong anyway.  I think this will help #11019.

-[Unknown]