### PR TITLE
Show PPSSPP version only

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -491,6 +491,13 @@ Q_DECL_EXPORT
 #endif
 int main(int argc, char *argv[])
 {
+	for (int i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "--version")) {
+			printf("%s\n", PPSSPP_GIT_VERSION);
+			return 0;
+		}
+	}
+
 	glslang::InitializeProcess();
 #if defined(Q_OS_LINUX)
 	QApplication::setAttribute(Qt::AA_X11InitThreads, true);

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -448,6 +448,13 @@ static void EmuThreadJoin() {
 #undef main
 #endif
 int main(int argc, char *argv[]) {
+	for (int i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "--version")) {
+			printf("%s\n", PPSSPP_GIT_VERSION);
+			return 0;
+		}
+	}
+
 	glslang::InitializeProcess();
 
 #if PPSSPP_PLATFORM(RPI)


### PR DESCRIPTION
As you already know, that's a common option for Linux programs.
I think this is a basic feature which is currently missing :)

Tested for SDL, but not for Qt as I don't use it, but it should be the same.
I'm not sure if this would be useful for other platforms?
