### PR TITLE
Core: Shutdown properly on load failure

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -351,13 +351,17 @@ bool PSP_InitUpdate(std::string *error_string) {
 		PSP_SetLoading("Starting graphics...");
 		success = GPU_Init(coreParameter.graphicsContext, coreParameter.thin3d);
 		if (!success) {
-			PSP_Shutdown();
 			*error_string = "Unable to initialize rendering engine.";
 		}
 	}
-	pspIsInited = success && GPU_IsReady();
-	pspIsIniting = success && !pspIsInited;
-	return !success || pspIsInited;
+	if (!success) {
+		PSP_Shutdown();
+		return true;
+	}
+
+	pspIsInited = GPU_IsReady();
+	pspIsIniting = !pspIsInited;
+	return pspIsInited;
 }
 
 bool PSP_Init(const CoreParameter &coreParam, std::string *error_string) {


### PR DESCRIPTION
In some cases (like missing key - #11054), kernelRunning would be left as true, and trying to load another game would crash because `gpu` would be null.

This is probably a regression from loading the game on a thread.

-[Unknown]