### PR TITLE
Android: In v21 and later, make the navigation bar black using styles.xml

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:name=".PpssppActivity"
             android:configChanges="locale|keyboard|keyboardHidden|navigation|uiMode"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+            android:theme="@style/ppsspp_style">
 
             <!-- android:screenOrientation="landscape" -->
             <intent-filter>

--- a/android/res/values-v21/styles.xml
+++ b/android/res/values-v21/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<color name="black">#FF000000</color>
+	<style name="ppsspp_style">
+		<item name="android:windowFullscreen">true</item>
+		<item name="android:windowNoTitle">true</item>
+		<item name="android:navigationBarColor">@color/black</item>
+	</style>
+</resources>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<color name="black">#FF000000</color>
+	<style name="ppsspp_style">
+		<item name="android:windowFullscreen">true</item>
+		<item name="android:windowNoTitle">true</item>
+	</style>
+</resources>


### PR DESCRIPTION
From v21, we can control its color. It's just nicer to have it black when not in immersive mode (which currently has some issues with touch precision which I'm intending to fix, well just did in #11072)

Just gonna test this on a few devices then merge.