### PR TITLE
Vulkan: Don't merge render passes if read from

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -364,6 +364,7 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 
 		if (steps.size() > 1 && steps[j]->stepType == VKRStepType::RENDER &&
 			steps[j]->render.numDraws == 0 &&
+			steps[j]->render.numReads == 0 &&
 			steps[j]->render.color == VKRRenderPassAction::CLEAR &&
 			steps[j]->render.stencil == VKRRenderPassAction::CLEAR &&
 			steps[j]->render.depth == VKRRenderPassAction::CLEAR) {
@@ -391,6 +392,7 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 					steps[i]->copy.src == steps[j]->render.framebuffer) {
 					// Can't eliminate the clear if a game copies from it before it's
 					// rendered to. However this should be rare.
+					// TODO: This should never happen when we check numReads now.
 					break;
 				}
 			}

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -122,6 +122,8 @@ struct VKRStep {
 			float clearDepth;
 			int clearStencil;
 			int numDraws;
+			// Downloads and textures from this pass.
+			int numReads;
 			VkImageLayout finalColorLayout;
 		} render;
 		struct {


### PR DESCRIPTION
In the future, we might actually track dependencies so we can smartly sort the render passes instead.

See #11079 - screen got brighter because a cleared framebuffer was used as a texture.  This should prevent the combine so the texture is actually clear at that point.

I don't have flOw so this hasn't been tested yet.

-[Unknown]