### PR TITLE
Include armips assembler in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1111,10 +1111,6 @@ include_directories(ext/xxhash)
 set(CoreExtra)
 set(CoreExtraLibs)
 
-if(WIN32 OR ANDROID)
-	set(CoreExtraLibs ${CoreExtraLibs} armips)
-endif()
-
 set(CoreExtra ${CoreExtra}
 	Core/MIPS/IR/IRCompALU.cpp
 	Core/MIPS/IR/IRCompBranch.cpp

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -18,7 +18,7 @@
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Core/MIPS/MIPSTables.h"
-#include "ElfReader.h"
+#include "Core/ELF/ElfReader.h"
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/HLE/sceKernelMemory.h"

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -7,16 +7,8 @@
 
 #include "Common/CommonTypes.h"
 
-#if defined(_WIN32) || defined(__ANDROID__)
-// Temporarily turned off on Android
-#define USE_ARMIPS
-#endif
-
-
-#ifdef USE_ARMIPS
 // This has to be before basictypes to avoid a define conflict.
 #include "ext/armips/Core/Assembler.h"
-#endif
 
 #include "util/text/utf8.h"
 #include "Core/Debugger/SymbolMap.h"
@@ -33,7 +25,6 @@ std::wstring GetAssembleError()
 	return errorText;
 }
 
-#ifdef USE_ARMIPS
 class PspAssemblerFile: public AssemblerFile
 {
 public:
@@ -72,11 +63,9 @@ private:
 	u64 address;
 	std::wstring dummyWFilename_;
 };
-#endif
 
 bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 {
-#ifdef USE_ARMIPS
 	PspAssemblerFile file;
 	StringList errors;
 
@@ -108,10 +97,6 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 	}
 
 	return true;
-#else
-	errorText = L"Unsupported platform";
-	return false;
-#endif
 }
 
 }  // namespace

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -161,6 +161,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/MIPS/MIPSAnalyst.cpp \
   $(SRC)/Core/MIPS/MIPSDis.cpp \
   $(SRC)/Core/MIPS/MIPSDisVFPU.cpp \
+  $(SRC)/Core/MIPS/MIPSAsm.cpp \
   $(SRC)/Core/MIPS/MIPSInt.cpp.arm \
   $(SRC)/Core/MIPS/MIPSIntVFPU.cpp.arm \
   $(SRC)/Core/MIPS/MIPSStackWalk.cpp \
@@ -397,12 +398,64 @@ EXEC_AND_LIB_FILES := \
 
 LOCAL_MODULE := ppsspp_core
 LOCAL_SRC_FILES := $(EXEC_AND_LIB_FILES)
-
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 include $(LOCAL_PATH)/Locals.mk
-LOCAL_STATIC_LIBRARIES += ppsspp_core
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SRC)/ext/armips $(LOCAL_C_INCLUDES)
+
+LIBARMIPS_FILES := \
+  $(SRC)/ext/armips/Archs/ARM/Arm.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ArmOpcodes.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ArmParser.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ArmRelocator.cpp \
+  $(SRC)/ext/armips/Archs/ARM/CArmInstruction.cpp \
+  $(SRC)/ext/armips/Archs/ARM/CThumbInstruction.cpp \
+  $(SRC)/ext/armips/Archs/ARM/Pool.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ThumbOpcodes.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/CMipsInstruction.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/Mips.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsElfFile.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsMacros.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsOpcodes.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsParser.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/PsxRelocator.cpp \
+  $(SRC)/ext/armips/Archs/Architecture.cpp \
+  $(SRC)/ext/armips/Commands/CAssemblerCommand.cpp \
+  $(SRC)/ext/armips/Commands/CAssemblerLabel.cpp \
+  $(SRC)/ext/armips/Commands/CDirectiveArea.cpp \
+  $(SRC)/ext/armips/Commands/CDirectiveConditional.cpp \
+  $(SRC)/ext/armips/Commands/CDirectiveData.cpp \
+  $(SRC)/ext/armips/Commands/CDirectiveFile.cpp \
+  $(SRC)/ext/armips/Commands/CDirectiveMessage.cpp \
+  $(SRC)/ext/armips/Commands/CommandSequence.cpp \
+  $(SRC)/ext/armips/Core/ELF/ElfFile.cpp \
+  $(SRC)/ext/armips/Core/ELF/ElfRelocator.cpp \
+  $(SRC)/ext/armips/Core/Assembler.cpp \
+  $(SRC)/ext/armips/Core/Common.cpp \
+  $(SRC)/ext/armips/Core/Expression.cpp \
+  $(SRC)/ext/armips/Core/ExpressionFunctions.cpp \
+  $(SRC)/ext/armips/Core/FileManager.cpp \
+  $(SRC)/ext/armips/Core/Misc.cpp \
+  $(SRC)/ext/armips/Core/SymbolData.cpp \
+  $(SRC)/ext/armips/Core/SymbolTable.cpp \
+  $(SRC)/ext/armips/Parser/DirectivesParser.cpp \
+  $(SRC)/ext/armips/Parser/ExpressionParser.cpp \
+  $(SRC)/ext/armips/Parser/Parser.cpp \
+  $(SRC)/ext/armips/Parser/Tokenizer.cpp \
+  $(SRC)/ext/armips/Util/ByteArray.cpp \
+  $(SRC)/ext/armips/Util/CRC.cpp \
+  $(SRC)/ext/armips/Util/EncodingTable.cpp \
+  $(SRC)/ext/armips/Util/FileClasses.cpp \
+  $(SRC)/ext/armips/Util/Util.cpp
+
+LOCAL_MODULE := libarmips
+LOCAL_SRC_FILES := $(LIBARMIPS_FILES)
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+include $(LOCAL_PATH)/Locals.mk
+LOCAL_STATIC_LIBRARIES += ppsspp_core libarmips
 
 # These are the files just for ppsspp_jni
 LOCAL_MODULE := ppsspp_jni
@@ -450,7 +503,7 @@ endif
 ifeq ($(HEADLESS),1)
   include $(CLEAR_VARS)
   include $(LOCAL_PATH)/Locals.mk
-  LOCAL_STATIC_LIBRARIES += ppsspp_core
+  LOCAL_STATIC_LIBRARIES += ppsspp_core libarmips
 
   # Android 5.0 requires PIE for executables.  Only supported on 4.1+, but this is testing anyway.
   LOCAL_CFLAGS += -fPIE
@@ -468,58 +521,11 @@ endif
 ifeq ($(UNITTEST),1)
   include $(CLEAR_VARS)
   include $(LOCAL_PATH)/Locals.mk
-  LOCAL_STATIC_LIBRARIES += ppsspp_core
+  LOCAL_STATIC_LIBRARIES += ppsspp_core libarmips
 
   # Android 5.0 requires PIE for executables.  Only supported on 4.1+, but this is testing anyway.
   LOCAL_CFLAGS += -fPIE
   LOCAL_LDFLAGS += -fPIE -pie
-
-  LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SRC)/ext/armips $(LOCAL_C_INCLUDES)
-
-  LIBARMIPS_FILES := \
-	$(SRC)/ext/armips/Archs/ARM/Arm.cpp \
-	$(SRC)/ext/armips/Archs/ARM/ArmOpcodes.cpp \
-	$(SRC)/ext/armips/Archs/ARM/ArmParser.cpp \
-	$(SRC)/ext/armips/Archs/ARM/ArmRelocator.cpp \
-	$(SRC)/ext/armips/Archs/ARM/CArmInstruction.cpp \
-	$(SRC)/ext/armips/Archs/ARM/CThumbInstruction.cpp \
-	$(SRC)/ext/armips/Archs/ARM/Pool.cpp \
-	$(SRC)/ext/armips/Archs/ARM/ThumbOpcodes.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/CMipsInstruction.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/Mips.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/MipsElfFile.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/MipsMacros.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/MipsOpcodes.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/MipsParser.cpp \
-	$(SRC)/ext/armips/Archs/MIPS/PsxRelocator.cpp \
-	$(SRC)/ext/armips/Archs/Architecture.cpp \
-	$(SRC)/ext/armips/Commands/CAssemblerCommand.cpp \
-	$(SRC)/ext/armips/Commands/CAssemblerLabel.cpp \
-	$(SRC)/ext/armips/Commands/CDirectiveArea.cpp \
-	$(SRC)/ext/armips/Commands/CDirectiveConditional.cpp \
-	$(SRC)/ext/armips/Commands/CDirectiveData.cpp \
-	$(SRC)/ext/armips/Commands/CDirectiveFile.cpp \
-	$(SRC)/ext/armips/Commands/CDirectiveMessage.cpp \
-	$(SRC)/ext/armips/Commands/CommandSequence.cpp \
-	$(SRC)/ext/armips/Core/ELF/ElfFile.cpp \
-	$(SRC)/ext/armips/Core/ELF/ElfRelocator.cpp \
-	$(SRC)/ext/armips/Core/Assembler.cpp \
-	$(SRC)/ext/armips/Core/Common.cpp \
-	$(SRC)/ext/armips/Core/Expression.cpp \
-	$(SRC)/ext/armips/Core/ExpressionFunctions.cpp \
-	$(SRC)/ext/armips/Core/FileManager.cpp \
-	$(SRC)/ext/armips/Core/Misc.cpp \
-	$(SRC)/ext/armips/Core/SymbolData.cpp \
-	$(SRC)/ext/armips/Core/SymbolTable.cpp \
-	$(SRC)/ext/armips/Parser/DirectivesParser.cpp \
-	$(SRC)/ext/armips/Parser/ExpressionParser.cpp \
-	$(SRC)/ext/armips/Parser/Parser.cpp \
-	$(SRC)/ext/armips/Parser/Tokenizer.cpp \
-	$(SRC)/ext/armips/Util/ByteArray.cpp \
-	$(SRC)/ext/armips/Util/CRC.cpp \
-	$(SRC)/ext/armips/Util/EncodingTable.cpp \
-	$(SRC)/ext/armips/Util/FileClasses.cpp \
-	$(SRC)/ext/armips/Util/Util.cpp
 
   ifeq ($(findstring arm64-v8a,$(TARGET_ARCH_ABI)),arm64-v8a)
     TESTARMEMITTER_FILE = $(SRC)/unittest/TestArm64Emitter.cpp
@@ -539,8 +545,6 @@ ifeq ($(UNITTEST),1)
 
   LOCAL_MODULE := ppsspp_unittest
   LOCAL_SRC_FILES := \
-    $(LIBARMIPS_FILES) \
-    $(SRC)/Core/MIPS/MIPSAsm.cpp \
     $(SRC)/unittest/JitHarness.cpp \
     $(SRC)/unittest/TestVertexJit.cpp \
     $(TESTARMEMITTER_FILE) \

--- a/ext/native/util/text/utf8.cpp
+++ b/ext/native/util/text/utf8.cpp
@@ -463,6 +463,20 @@ std::wstring ConvertUTF8ToWString(const std::string &source) {
 
 #else
 
+std::string ConvertWStringToUTF8(const std::wstring &wstr) {
+	std::string s;
+	// Worst case.
+	s.resize(wstr.size() * 4);
+
+	size_t pos = 0;
+	for (wchar_t c : wstr) {
+		pos += UTF8::encode(&s[pos], c);
+	}
+
+	s.resize(pos);
+	return s;
+}
+
 static size_t ConvertUTF8ToWStringInternal(wchar_t *dest, size_t destSize, const std::string &source) {
 	const wchar_t *const orig = dest;
 	const wchar_t *const destEnd = dest + destSize;

--- a/ext/native/util/text/utf8.h
+++ b/ext/native/util/text/utf8.h
@@ -83,6 +83,10 @@ bool UTF8StringHasNonASCII(const char *utf8string);
 std::string ConvertWStringToUTF8(const std::wstring &wstr);
 std::string ConvertWStringToUTF8(const wchar_t *wstr);
 
+#else
+
+std::string ConvertWStringToUTF8(const std::wstring &wstr);
+
 #endif
 
 // Dest size in units, not bytes.


### PR DESCRIPTION
This is needed for #10909 and separated in case of build problems / so it can be merged separately for a testable build from the buildbot.

-[Unknown]