### PR TITLE
Unbreak -DUSING_EGL=off on ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 if(NOT ANDROID AND NOT IOS)
 	if(ARM OR SIMULATOR)
-		set(USING_EGL ON)
+		set(USING_EGL ON CACHE BOOL "Prefer EGL on desktop ARM")
 	endif()
 endif()
 


### PR DESCRIPTION
PPSSPP v1.6.1 is [still](https://github.com/hrydgard/ppsspp/issues/9032#issuecomment-349083552) [broken](https://ptpb.pw/SKpg) on FreeBSD armv6/armv7. And passing `-DUSING_EGL:BOOL=OFF` appears to have no effect.
