### PR TITLE
1.6.1 crashfixes

### DIFF
--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -70,6 +70,10 @@ DepalShaderCacheGLES::~DepalShaderCacheGLES() {
 	Clear();
 }
 
+void DepalShaderCacheGLES::DeviceRestore(Draw::DrawContext *draw) {
+	render_ = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+}
+
 bool DepalShaderCacheGLES::CreateVertexShader() {
 	std::string src(useGL3_ ? depalVShader300 : depalVShader100);
 	vertexShader_ = render_->CreateShader(GL_VERTEX_SHADER, src, "depal");

--- a/GPU/GLES/DepalettizeShaderGLES.h
+++ b/GPU/GLES/DepalettizeShaderGLES.h
@@ -54,6 +54,11 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
+	void DeviceLost() {
+		Clear();
+	}
+	void DeviceRestore(Draw::DrawContext *draw);
+
 private:
 	bool CreateVertexShader();
 

--- a/GPU/GLES/FragmentTestCacheGLES.cpp
+++ b/GPU/GLES/FragmentTestCacheGLES.cpp
@@ -35,6 +35,10 @@ FragmentTestCacheGLES::~FragmentTestCacheGLES() {
 	Clear();
 }
 
+void FragmentTestCacheGLES::DeviceRestore(Draw::DrawContext *draw) {
+	render_ = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+}
+
 void FragmentTestCacheGLES::BindTestTexture(int slot) {
 	if (!g_Config.bFragmentTestCache) {
 		return;

--- a/GPU/GLES/FragmentTestCacheGLES.h
+++ b/GPU/GLES/FragmentTestCacheGLES.h
@@ -67,6 +67,10 @@ public:
 
 	void BindTestTexture(int slot);
 
+	void DeviceLost() {
+		Clear(false);
+	}
+	void DeviceRestore(Draw::DrawContext *draw);
 	void Clear(bool deleteThem = true);
 	void Decimate();
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -58,7 +58,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 	GLRenderManager *render = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 
-	shaderManagerGL_ = new ShaderManagerGLES(render);
+	shaderManagerGL_ = new ShaderManagerGLES(draw);
 	framebufferManagerGL_ = new FramebufferManagerGLES(draw, render);
 	framebufferManager_ = framebufferManagerGL_;
 	textureCacheGL_ = new TextureCacheGLES(draw);
@@ -331,11 +331,10 @@ void GPU_GLES::DeviceLost() {
 	// Simply drop all caches and textures.
 	// FBOs appear to survive? Or no?
 	// TransformDraw has registered as a GfxResourceHolder.
-	drawEngine_.ClearInputLayoutMap();
-	shaderManagerGL_->ClearCache(false);
+	shaderManagerGL_->DeviceLost();
 	textureCacheGL_->DeviceLost();
-	fragmentTestCache_.Clear(false);
-	depalShaderCache_.Clear();
+	fragmentTestCache_.DeviceLost();
+	depalShaderCache_.DeviceLost();
 	drawEngine_.DeviceLost();
 	framebufferManagerGL_->DeviceLost();
 	// Don't even try to access the lost device.
@@ -349,9 +348,12 @@ void GPU_GLES::DeviceRestore() {
 	UpdateCmdInfo();
 	UpdateVsyncInterval(true);
 
+	shaderManagerGL_->DeviceRestore(draw_);
 	textureCacheGL_->DeviceRestore(draw_);
 	framebufferManagerGL_->DeviceRestore(draw_);
 	drawEngine_.DeviceRestore(draw_);
+	fragmentTestCache_.DeviceRestore(draw_);
+	depalShaderCache_.DeviceRestore(draw_);
 }
 
 void GPU_GLES::Reinitialize() {

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -574,8 +574,9 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid) {
 	}
 }
 
-ShaderManagerGLES::ShaderManagerGLES(GLRenderManager *render)
-		: render_(render), lastShader_(nullptr), shaderSwitchDirtyUniforms_(0), diskCacheDirty_(false), fsCache_(16), vsCache_(16) {
+ShaderManagerGLES::ShaderManagerGLES(Draw::DrawContext *draw)
+		: lastShader_(nullptr), shaderSwitchDirtyUniforms_(0), diskCacheDirty_(false), fsCache_(16), vsCache_(16) {
+	render_ = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	codeBuffer_ = new char[16384];
 	lastFSID_.set_invalid();
 	lastVSID_.set_invalid();
@@ -605,6 +606,14 @@ void ShaderManagerGLES::Clear() {
 void ShaderManagerGLES::ClearCache(bool deleteThem) {
 	// TODO: Recreate all from the diskcache when we come back.
 	Clear();
+}
+
+void ShaderManagerGLES::DeviceLost() {
+	Clear();
+}
+
+void ShaderManagerGLES::DeviceRestore(Draw::DrawContext *draw) {
+	render_ = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 }
 
 void ShaderManagerGLES::DirtyShader() {

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -152,7 +152,7 @@ private:
 
 class ShaderManagerGLES : public ShaderManagerCommon {
 public:
-	ShaderManagerGLES(GLRenderManager *render);
+	ShaderManagerGLES(Draw::DrawContext *draw);
 	~ShaderManagerGLES();
 
 	void ClearCache(bool deleteThem);  // TODO: deleteThem currently not respected
@@ -161,6 +161,9 @@ public:
 	// If you call ApplyVertexShader, you MUST call ApplyFragmentShader soon afterwards.
 	Shader *ApplyVertexShader(int prim, u32 vertType, VShaderID *VSID);
 	LinkedShader *ApplyFragmentShader(VShaderID VSID, Shader *vs, u32 vertType, int prim);
+
+	void DeviceLost();
+	void DeviceRestore(Draw::DrawContext *draw);
 
 	void DirtyShader();
 	void DirtyLastShader() override;  // disables vertex arrays

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -216,12 +216,12 @@ void GameScreen::update() {
 
 	if (info->gameSize) {
 		char temp[256];
-		sprintf(temp, "%s: %1.1f %s", ga->T("Game"), (float) (info->gameSize) / 1024.f / 1024.f, ga->T("MB"));
+		snprintf(temp, sizeof(temp), "%s: %1.1f %s", ga->T("Game"), (float) (info->gameSize) / 1024.f / 1024.f, ga->T("MB"));
 		tvGameSize_->SetText(temp);
-		sprintf(temp, "%s: %1.2f %s", ga->T("SaveData"), (float) (info->saveDataSize) / 1024.f / 1024.f, ga->T("MB"));
+		snprintf(temp, sizeof(temp), "%s: %1.2f %s", ga->T("SaveData"), (float) (info->saveDataSize) / 1024.f / 1024.f, ga->T("MB"));
 		tvSaveDataSize_->SetText(temp);
 		if (info->installDataSize > 0) {
-			sprintf(temp, "%s: %1.2f %s", ga->T("InstallData"), (float) (info->installDataSize) / 1024.f / 1024.f, ga->T("MB"));
+			snprintf(temp, sizeof(temp), "%s: %1.2f %s", ga->T("InstallData"), (float) (info->installDataSize) / 1024.f / 1024.f, ga->T("MB"));
 			tvInstallDataSize_->SetText(temp);
 			tvInstallDataSize_->SetVisibility(UI::V_VISIBLE);
 		}

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -2,7 +2,7 @@
 // Does not involve context creation etc, that should be handled separately - only does drawing.
 
 // The goals may change in the future though.
-// MIT licensed, by Henrik Rydgård 2014.
+// MIT licensed, by Henrik RydgÃ¥rd 2014.
 
 #pragma once
 
@@ -597,7 +597,8 @@ public:
 	virtual void UpdateDynamicUniformBuffer(const void *ub, size_t size) = 0;
 
 	void BindTexture(int stage, Texture *texture) {
-		BindTextures(stage, 1, &texture);
+		Texture *textures[1] = { texture };
+		BindTextures(stage, 1, textures);
 	}  // from sampler 0 and upwards
 
 	// Call this with 0 to signal that you have been drawing on your own, and need the state reset on the next pipeline bind.

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -730,7 +730,6 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 
 	queue_ = vulkan->GetGraphicsQueue();
 	queueFamilyIndex_ = vulkan->GetGraphicsQueueFamilyIndex();
-	memset(boundTextures_, 0, sizeof(boundTextures_));
 
 	VkDescriptorPoolSize dpTypes[2];
 	dpTypes[0].descriptorCount = 200;
@@ -873,8 +872,8 @@ VkDescriptorSet VKContext::GetOrCreateDescriptorSet(VkBuffer buf) {
 	bufferDesc.range = curPipeline_->GetUBOSize();
 
 	VkDescriptorImageInfo imageDesc;
-	imageDesc.imageView = boundTextures_[0]->GetImageView();
-	imageDesc.sampler = boundSamplers_[0]->GetSampler();
+	imageDesc.imageView = boundTextures_[0] ? boundTextures_[0]->GetImageView() : VK_NULL_HANDLE;
+	imageDesc.sampler = boundSamplers_[0] ? boundSamplers_[0]->GetSampler() : VK_NULL_HANDLE;
 #ifdef VULKAN_USE_GENERAL_LAYOUT_FOR_COLOR
 	imageDesc.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 #else
@@ -1122,7 +1121,7 @@ void VKContext::UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset,
 void VKContext::BindTextures(int start, int count, Texture **textures) {
 	for (int i = start; i < start + count; i++) {
 		boundTextures_[i] = static_cast<VKTexture *>(textures[i]);
-		boundImageView_[i] = boundTextures_[i]->GetImageView();
+		boundImageView_[i] = boundTextures_[i] ? boundTextures_[i]->GetImageView() : VK_NULL_HANDLE;
 	}
 }
 


### PR DESCRIPTION
I think "GLES: Properly restore the pointer to the render manager in more places" will fix most of the major crashes from #11104 .