### PR TITLE
When creating temp framebuffers for download, size them using bufferWidth/Height instead of width/height.

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -265,7 +265,7 @@ void hleCheckCurrentCallbacks()
 void hleReSchedule(const char *reason)
 {
 #ifdef _DEBUG
-	_dbg_assert_msg_(HLE, reason != 0 && strlen(reason) < 256, "hleReSchedule: Invalid or too long reason.");
+	_dbg_assert_msg_(HLE, reason != nullptr && strlen(reason) < 256, "hleReSchedule: Invalid or too long reason.");
 #endif
 
 	hleAfterSyscall |= HLE_AFTER_RESCHED;

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -569,7 +569,7 @@ void FramebufferManagerD3D11::BindFramebufferAsColorTexture(int stage, VirtualFr
 bool FramebufferManagerD3D11::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	nvfb->colorDepth = Draw::FBO_8888;
 
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->width, nvfb->height, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
+	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
 	if (!(nvfb->fbo)) {
 		ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 		return false;

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -464,7 +464,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	bool FramebufferManagerDX9::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 		nvfb->colorDepth = Draw::FBO_8888;
 
-		nvfb->fbo = draw_->CreateFramebuffer({ nvfb->width, nvfb->height, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
+		nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
 		if (!(nvfb->fbo)) {
 			ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 			return false;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -579,7 +579,7 @@ bool FramebufferManagerGLES::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 		}
 	}
 
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->width, nvfb->height, 1, 1, false, (Draw::FBColorDepth)nvfb->colorDepth });
+	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, false, (Draw::FBColorDepth)nvfb->colorDepth });
 	if (!nvfb->fbo) {
 		ERROR_LOG(FRAMEBUF, "Error creating GL FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 		return false;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -459,7 +459,7 @@ VkImageView FramebufferManagerVulkan::BindFramebufferAsColorTexture(int stage, V
 bool FramebufferManagerVulkan::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	nvfb->colorDepth = Draw::FBO_8888;
 
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->height, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
+	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
 	if (!(nvfb->fbo)) {
 		ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
 		return false;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -691,6 +691,9 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	colorPipeline = g_draw->CreateGraphicsPipeline(colorDesc);
 	texColorPipeline = g_draw->CreateGraphicsPipeline(texColorDesc);
 
+	_assert_(colorPipeline);
+	_assert_(texColorPipeline);
+
 	// Release these now, reference counting should ensure that they get completely released
 	// once we delete both pipelines.
 	inputLayout->Release();
@@ -1159,7 +1162,8 @@ bool NativeIsRestarting() {
 }
 
 void NativeShutdown() {
-	screenManager->shutdown();
+	if (screenManager)
+		screenManager->shutdown();
 	delete screenManager;
 	screenManager = nullptr;
 

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -858,8 +858,14 @@ Pipeline *OpenGLContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 	}
 	OpenGLPipeline *pipeline = new OpenGLPipeline(&renderManager_);
 	for (auto iter : desc.shaders) {
-		iter->AddRef();
-		pipeline->shaders.push_back(static_cast<OpenGLShaderModule *>(iter));
+		if (iter) {
+			iter->AddRef();
+			pipeline->shaders.push_back(static_cast<OpenGLShaderModule *>(iter));
+		} else {
+			ELOG("ERROR: Tried to create graphics pipeline with a null shader module");
+			delete pipeline;
+			return nullptr;
+		}
 	}
 	if (pipeline->LinkShaders()) {
 		// Build the rest of the virtual pipeline object.
@@ -878,7 +884,7 @@ Pipeline *OpenGLContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 	} else {
 		ELOG("Failed to create pipeline - shaders failed to link");
 		delete pipeline;
-		return NULL;
+		return nullptr;
 	}
 }
 


### PR DESCRIPTION
Or maybe we should make sure to only download within the width/height by
adding more clamps at the beginning of ReadFramebufferToMemory but seems
more dangerous, at least if we want to sneak this one into 1.6.3..

Plus some minor things.

Should help #11113