### PR TITLE
UI: Reinit UI texture during game when used

### DIFF
--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -56,6 +56,7 @@ private:
 	void bootGame(const std::string &filename);
 	bool bootAllowStorage(const std::string &filename);
 	void bootComplete();
+	bool hasVisibleUI();
 	void renderUI();
 	void processAxis(const AxisInput &axis, int direction);
 
@@ -79,6 +80,7 @@ private:
 	bool invalid_;
 	bool quit_;
 	bool stopRender_ = false;
+	bool hasVisibleUI_ = true;
 	std::string errorMessage_;
 
 	// If set, pauses at the end of the frame.


### PR DESCRIPTION
Otherwise we may try to use it when it doesn't exist.  This should only happen on graphics restart.

I'm not exactly sure why we wouldn't have caught this before, but it seems missing - we don't call `UIScreen::preRender()` in `EmuScreen::preRender()`, which should in theory make `uitexture_` nullptr if anything tries to use it (such as renderUI in the trace of the first crash in #11116.)

I did not actually reproduce the crash.

Let's say "fixes #11116" since the other two are already addressed.

-[Unknown]