### PR TITLE
Qt: Load texture replacement images

### DIFF
--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -43,7 +43,6 @@ enum class ReplacedTextureFormat {
 enum class ReplacedTextureAlpha {
 	UNKNOWN = 0x04,
 	FULL = 0x00,
-	SIMPLE = 0x08,
 };
 
 // For forward comatibility, we specify the hash.


### PR DESCRIPTION
Still doesn't save, but at least it can use packs.  Improves #9259 (but doesn't fix because no saving.)

We're doing the bitswapping elsewhere, so I assume it's necessary.  Could be faster.

This also stops loading texture levels if an invalid PNG is hit (before it would still try to load the next level.)  Probably very uncommon.

-[Unknown]