### PR TITLE
SDL: Fix EGL build

### DIFF
--- a/SDL/SDLGLGraphicsContext.h
+++ b/SDL/SDLGLGraphicsContext.h
@@ -8,7 +8,9 @@
 #include "Common/GraphicsContext.h"
 
 // TODO: Move this to a better place.
-void EGL_Open();
+#if defined(USING_EGL)
+int8_t EGL_Open();
+#endif
 
 class SDLGLGraphicsContext : public DummyGraphicsContext {
 public:


### PR DESCRIPTION
Dumb typo.  Confirmed to fix things in #10534.

But it still needs the `fbset` hack since we're not using an EGL config chooser type flow here.

-[Unknown]