### PR TITLE
Enable debugger / breakpoints / stepping on ARM / ARM64

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -272,6 +272,8 @@ void Core_ProcessStepping() {
 		return;
 	}
 
+	// We're not inside jit now, so it's safe to clear the breakpoints.
+	CBreakPoints::ClearTemporaryBreakPoints();
 	host->UpdateDisassembly();
 	host->UpdateMemView();
 

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -329,7 +329,6 @@ void Core_Run(GraphicsContext *ctx) {
 
 void Core_EnableStepping(bool step) {
 	if (step) {
-		sleep_ms(1);
 		host->SetDebugMode(true);
 		Core_UpdateState(CORE_STEPPING);
 		steppingCounter++;

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -34,6 +34,7 @@ void Core_SetGraphicsContext(GraphicsContext *ctx);
 void Core_EnableStepping(bool step);
 void Core_DoSingleStep();
 void Core_UpdateSingleStep();
+void Core_ProcessStepping();
 // Changes every time we enter stepping.
 int Core_GetSteppingCounter();
 
@@ -54,6 +55,7 @@ bool Core_IsStepping();
 
 bool Core_IsActive();
 bool Core_IsInactive();
+// Warning: these currently work only on Windows.
 void Core_WaitInactive();
 void Core_WaitInactive(int milliseconds);
 

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -488,17 +488,20 @@ u32 CBreakPoints::CheckSkipFirst()
 	return 0;
 }
 
-const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges()
-{
+const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges(bool write) {
 	std::vector<MemCheck> ranges = memChecks_;
-	for (auto it = memChecks_.begin(), end = memChecks_.end(); it != end; ++it)
-	{
-		MemCheck check = *it;
+	for (const auto &check : memChecks_) {
+		if (!(check.cond & MEMCHECK_READ) && !write)
+			continue;
+		if (!(check.cond & MEMCHECK_WRITE) && write)
+			continue;
+
+		MemCheck copy = check;
 		// Toggle the cached part of the address.
-		check.start ^= 0x40000000;
-		if (check.end != 0)
-			check.end ^= 0x40000000;
-		ranges.push_back(check);
+		copy.start ^= 0x40000000;
+		if (copy.end != 0)
+			copy.end ^= 0x40000000;
+		ranges.push_back(copy);
 	}
 
 	return ranges;

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -33,11 +33,6 @@ u64 CBreakPoints::breakSkipFirstTicks_ = 0;
 std::vector<MemCheck> CBreakPoints::memChecks_;
 std::vector<MemCheck *> CBreakPoints::cleanupMemChecks_;
 
-MemCheck::MemCheck()
-{
-	numHits = 0;
-}
-
 void MemCheck::Log(u32 addr, bool write, int size, u32 pc) {
 	if (result & BREAK_ACTION_LOG) {
 		if (logFormat.empty()) {

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -156,7 +156,7 @@ public:
 	static u32 CheckSkipFirst();
 
 	// Includes uncached addresses.
-	static const std::vector<MemCheck> GetMemCheckRanges();
+	static const std::vector<MemCheck> GetMemCheckRanges(bool write);
 
 	static const std::vector<MemCheck> GetMemChecks();
 	static const std::vector<BreakPoint> GetBreakpoints();

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -21,8 +21,7 @@
 
 #include "Core/Debugger/DebugInterface.h"
 
-enum BreakAction
-{
+enum BreakAction {
 	BREAK_ACTION_IGNORE = 0x00,
 	BREAK_ACTION_LOG = 0x01,
 	BREAK_ACTION_PAUSE = 0x02,
@@ -37,35 +36,27 @@ static inline BreakAction operator | (const BreakAction &lhs, const BreakAction 
 	return BreakAction((u32)lhs | (u32)rhs);
 }
 
-struct BreakPointCond
-{
-	DebugInterface *debug;
+struct BreakPointCond {
+	DebugInterface *debug = nullptr;
 	PostfixExpression expression;
 	std::string expressionString;
 
-	BreakPointCond() : debug(nullptr)
-	{
-	}
-
-	u32 Evaluate()
-	{
+	u32 Evaluate() {
 		u32 result;
-		if (debug->parseExpression(expression,result) == false) return 0;
+		if (debug->parseExpression(expression, result) == false)
+			return 0;
 		return result;
 	}
 };
 
-struct BreakPoint
-{
-	BreakPoint() : hasCond(false) {}
-
+struct BreakPoint {
 	u32	addr;
 	bool temporary;
 
-	BreakAction result;
+	BreakAction result = BREAK_ACTION_IGNORE;
 	std::string logFormat;
 
-	bool hasCond;
+	bool hasCond = false;
 	BreakPointCond cond;
 
 	bool IsEnabled() const {
@@ -80,8 +71,7 @@ struct BreakPoint
 	}
 };
 
-enum MemCheckCondition
-{
+enum MemCheckCondition {
 	MEMCHECK_READ = 0x01,
 	MEMCHECK_WRITE = 0x02,
 	MEMCHECK_WRITE_ONCHANGE = 0x04,
@@ -89,21 +79,19 @@ enum MemCheckCondition
 	MEMCHECK_READWRITE = 0x03,
 };
 
-struct MemCheck
-{
-	MemCheck();
+struct MemCheck {
 	u32 start;
 	u32 end;
 
-	MemCheckCondition cond;
-	BreakAction result;
+	MemCheckCondition cond = MEMCHECK_READ;
+	BreakAction result = BREAK_ACTION_IGNORE;
 	std::string logFormat;
 
-	u32 numHits;
+	u32 numHits = 0;
 
-	u32 lastPC;
-	u32 lastAddr;
-	int lastSize;
+	u32 lastPC = 0;
+	u32 lastAddr = 0;
+	int lastSize = 0;
 
 	BreakAction Action(u32 addr, bool write, int size, u32 pc);
 	void JitBefore(u32 addr, bool write, int size, u32 pc);

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -152,10 +152,10 @@ static int Replace_memcpy() {
 		}
 	}
 	RETURN(destPtr);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -194,10 +194,10 @@ static int Replace_memcpy_jak() {
 	currentMIPS->r[MIPS_REG_A2] = 0;
 	currentMIPS->r[MIPS_REG_A3] = destPtr + bytes;
 	RETURN(destPtr);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 5 + bytes * 8 + 2;  // approximation. This is a slow memcpy - a byte copy loop..
 }
 
@@ -222,10 +222,10 @@ static int Replace_memcpy16() {
 		}
 	}
 	RETURN(destPtr);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -260,10 +260,10 @@ static int Replace_memcpy_swizzled() {
 	}
 
 	RETURN(0);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(srcPtr, false, pitch * h, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, pitch * h, currentMIPS->pc);
-#endif
+
 	return 10 + (pitch * h) / 4;  // approximation
 }
 
@@ -288,10 +288,10 @@ static int Replace_memmove() {
 		}
 	}
 	RETURN(destPtr);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(srcPtr, false, bytes, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -310,9 +310,9 @@ static int Replace_memset() {
 		}
 	}
 	RETURN(destPtr);
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -342,9 +342,8 @@ static int Replace_memset_jak() {
 	currentMIPS->r[MIPS_REG_A3] = -1;
 	RETURN(destPtr);
 
-#ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(destPtr, true, bytes, currentMIPS->pc);
-#endif
+
 	return 5 + bytes * 6 + 2;  // approximation (hm, inspecting the disasm this should be 5 + 6 * bytes + 2, but this is what works..)
 }
 
@@ -591,11 +590,9 @@ static int Replace_dl_write_matrix() {
 #endif
 	}
 
-#ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(PARAM(2), false, count * sizeof(float), currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(PARAM(0) + 2 * sizeof(u32), true, sizeof(u32), currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dlStruct[2], true, (count + 1) * sizeof(u32), currentMIPS->pc);
-#endif
 
 	dlStruct[2] += (1 + count) * 4;
 	RETURN(dlStruct[2]);

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -654,10 +654,10 @@ static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 				*dstp++ = *srcp++;
 		}
 	}
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(src, false, size, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dst, true, size, currentMIPS->pc);
-#endif
+
 	return dst;
 }
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -766,9 +766,8 @@ int MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMo
 		delete [] imgbuf;
 	}
 
-#ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(bufferPtr, true, videoImageSize, currentMIPS->pc);
-#endif
+
 	return videoImageSize;
 #endif // USE_FFMPEG
 	return 0;
@@ -822,9 +821,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineRGBA(imgbuf, data, width);
 			data += m_desWidth * sizeof(u32);
 			imgbuf += videoLineSize;
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u32), true, width * sizeof(u32), currentMIPS->pc);
-#endif
 		}
 		break;
 
@@ -834,9 +831,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR5650(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += videoLineSize;
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
-#endif
 		}
 		break;
 
@@ -846,9 +841,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR5551(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += videoLineSize;
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
-#endif
 		}
 		break;
 
@@ -858,9 +851,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 			writeVideoLineABGR4444(imgbuf, data, width);
 			data += m_desWidth * sizeof(u16);
 			imgbuf += videoLineSize;
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(bufferPtr + y * frameWidth * sizeof(u16), true, width * sizeof(u16), currentMIPS->pc);
-#endif
 		}
 		break;
 
@@ -954,9 +945,8 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 		if (!m_audioContext->Decode(audioFrame, frameSize, buffer, &outbytes)) {
 			ERROR_LOG(ME, "Audio (%s) decode failed during video playback", GetCodecName(m_audioType));
 		}
-#ifndef MOBILE_DEVICE
+
 		CBreakPoints::ExecMemCheck(bufferPtr, true, outbytes, currentMIPS->pc);
-#endif
 	}
 
 	return 0x2000;

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -50,8 +50,6 @@ public:
 	virtual void SaveSymbolMap() {}
 	virtual void SetWindowTitle(const char *message) {}
 
-	virtual void SendCoreWait(bool) {}
-
 	// While debugging is active, it's perfectly fine for these to block.
 	virtual bool GPUDebuggingActive() { return false; }
 	virtual void GPUNotifyCommand(u32 pc) {}

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -238,7 +238,6 @@ void ArmJit::GenerateFixedCode() {
 		B_CC(CC_EQ, outerLoop);
 
 	SetJumpTarget(badCoreState);
-	breakpointBailout = GetCodePtr();
 
 	SaveDowncount();
 	RestoreRoundingMode(true);

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -93,6 +93,7 @@ extern int logBlocks;
 void ArmJit::Comp_FPULS(MIPSOpcode op)
 {
 	CONDITIONAL_DISABLE;
+	CheckMemoryBreakpoint();
 
 	s32 offset = (s16)(op & 0xFFFF);
 	int ft = _FT;

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -112,6 +112,7 @@ namespace MIPSComp
 
 	void ArmJit::Comp_ITypeMemLR(MIPSOpcode op, bool load) {
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 		int offset = (signed short)(op & 0xFFFF);
 		MIPSGPReg rt = _RT;
 		MIPSGPReg rs = _RS;
@@ -120,6 +121,7 @@ namespace MIPSComp
 		if (!js.inDelaySlot) {
 			// Optimisation: Combine to single unaligned load/store
 			bool isLeft = (o == 34 || o == 42);
+			CheckMemoryBreakpoint(1);
 			MIPSOpcode nextOp = GetOffsetInstruction(1);
 			// Find a matching shift in opposite direction with opposite offset.
 			if (nextOp == (isLeft ? (op.encoding + (4<<26) - 3)
@@ -259,6 +261,7 @@ namespace MIPSComp
 	void ArmJit::Comp_ITypeMem(MIPSOpcode op)
 	{
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 		int offset = (signed short)(op&0xFFFF);
 		bool load = false;
 		MIPSGPReg rt = _RT;

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -226,6 +226,7 @@ namespace MIPSComp
 	void ArmJit::Comp_SV(MIPSOpcode op) {
 		NEON_IF_AVAILABLE(CompNEON_SV);
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 
 		s32 offset = (signed short)(op & 0xFFFC);
 		int vt = ((op >> 16) & 0x1f) | ((op & 3) << 5);
@@ -332,6 +333,7 @@ namespace MIPSComp
 	{
 		NEON_IF_AVAILABLE(CompNEON_SVQ);
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 
 		int imm = (signed short)(op&0xFFFC);
 		int vt = (((op >> 16) & 0x1f)) | ((op&1) << 5);

--- a/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
@@ -159,6 +159,7 @@ void ArmJit::CompNEON_VecDo3(MIPSOpcode op) {
 
 void ArmJit::CompNEON_SV(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
+	CheckMemoryBreakpoint();
 	
 	// Remember to use single lane stores here and not VLDR/VSTR - switching usage
 	// between NEON and VFPU can be expensive on some chips.
@@ -276,6 +277,7 @@ inline int MIPS_GET_VQVT(u32 op) {
 
 void ArmJit::CompNEON_SVQ(MIPSOpcode op) {
 	CONDITIONAL_DISABLE;
+	CheckMemoryBreakpoint();
 
 	int offset = (signed short)(op & 0xFFFC);
 	int vt = MIPS_GET_VQVT(op.encoding);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -215,6 +215,8 @@ private:
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInR(ArmGen::ARMReg Reg);
 	void WriteSyscallExit();
+	bool CheckJitBreakpoint(u32 addr, int downcountOffset);
+	bool CheckMemoryBreakpoint(int instructionOffset = 0);
 
 	// Utility compilation functions
 	void BranchFPFlag(MIPSOpcode op, CCFlags cc, bool likely);

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -313,8 +313,6 @@ public:
 
 	const u8 *restoreRoundingMode;
 	const u8 *applyRoundingMode;
-
-	const u8 *breakpointBailout;
 };
 
 }	// namespace MIPSComp

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -275,7 +275,6 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 		B(CC_EQ, outerLoop);
 
 	SetJumpTarget(badCoreState);
-	breakpointBailout = GetCodePtr();
 
 	SaveStaticRegisters();
 	RestoreRoundingMode(true);

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -81,6 +81,7 @@ void Arm64Jit::Comp_FPU3op(MIPSOpcode op) {
 void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 {
 	CONDITIONAL_DISABLE;
+	CheckMemoryBreakpoint();
 
 	// Surprisingly, these work fine alraedy.
 
@@ -88,7 +89,6 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 	// u32 addr = R(rs) + offset;
-	// logBlocks = 1;
 	std::vector<FixupBranch> skips;
 	switch (op >> 26) {
 	case 49: //FI(ft) = Memory::Read_U32(addr); break; //lwc1

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -111,6 +111,7 @@ namespace MIPSComp {
 
 	void Arm64Jit::Comp_ITypeMemLR(MIPSOpcode op, bool load) {
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 		int offset = (signed short)(op & 0xFFFF);
 		MIPSGPReg rt = _RT;
 		MIPSGPReg rs = _RS;
@@ -119,6 +120,7 @@ namespace MIPSComp {
 		if (!js.inDelaySlot) {
 			// Optimisation: Combine to single unaligned load/store
 			bool isLeft = (o == 34 || o == 42);
+			CheckMemoryBreakpoint(1);
 			MIPSOpcode nextOp = GetOffsetInstruction(1);
 			// Find a matching shift in opposite direction with opposite offset.
 			if (nextOp == (isLeft ? (op.encoding + (4 << 26) - 3) : (op.encoding - (4 << 26) + 3))) {
@@ -255,6 +257,7 @@ namespace MIPSComp {
 
 	void Arm64Jit::Comp_ITypeMem(MIPSOpcode op) {
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 
 		int offset = (signed short)(op & 0xFFFF);
 		bool load = false;

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -202,6 +202,7 @@ namespace MIPSComp {
 
 	void Arm64Jit::Comp_SV(MIPSOpcode op) {
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 
 		s32 offset = (signed short)(op & 0xFFFC);
 		int vt = ((op >> 16) & 0x1f) | ((op & 3) << 5);
@@ -275,6 +276,7 @@ namespace MIPSComp {
 
 	void Arm64Jit::Comp_SVQ(MIPSOpcode op) {
 		CONDITIONAL_DISABLE;
+		CheckMemoryBreakpoint();
 
 		int imm = (signed short)(op&0xFFFC);
 		int vt = (((op >> 16) & 0x1f)) | ((op&1) << 5);

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -274,8 +274,6 @@ public:
 	const u8 *dispatcher;
 	const u8 *dispatcherNoCheck;
 
-	const u8 *breakpointBailout;
-
 	const u8 *saveStaticRegisters;
 	const u8 *loadStaticRegisters;
 

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -214,6 +214,8 @@ private:
 	void WriteExit(u32 destination, int exit_num);
 	void WriteExitDestInR(Arm64Gen::ARM64Reg Reg);
 	void WriteSyscallExit();
+	bool CheckJitBreakpoint(u32 addr, int downcountOffset);
+	bool CheckMemoryBreakpoint(int instructionOffset = 0);
 
 	// Utility compilation functions
 	void BranchFPFlag(MIPSOpcode op, CCFlags cc, bool likely);

--- a/Core/MIPS/MIPS/MipsJit.h
+++ b/Core/MIPS/MIPS/MipsJit.h
@@ -181,8 +181,6 @@ public:
 	const u8 *dispatcherPCInR0;
 	const u8 *dispatcher;
 	const u8 *dispatcherNoCheck;
-
-	const u8 *breakpointBailout;
 };
 
 typedef void (MipsJit::*MIPSCompileFunc)(MIPSOpcode opcode);

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -211,11 +211,6 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 
-	breakpointBailout = GetCodePtr();
-	RestoreRoundingMode(true);
-	ABI_PopAllCalleeSavedRegsAndAdjustStack();
-	RET();
-
 	// Let's spare the pre-generated code from unprotect-reprotect.
 	endOfPregeneratedCode = AlignCodePage();
 	EndWrite();

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -320,8 +320,6 @@ private:
 	const u8 *dispatcherNoCheck;
 	const u8 *dispatcherInEAXNoCheck;
 
-	const u8 *breakpointBailout;
-
 	const u8 *restoreRoundingMode;
 	const u8 *applyRoundingMode;
 

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -376,17 +376,10 @@ void JitSafeMem::MemCheckImm(MemoryOpType type)
 
 void JitSafeMem::MemCheckAsm(MemoryOpType type)
 {
-	const auto memchecks = CBreakPoints::GetMemCheckRanges();
-	bool possible = false;
+	const auto memchecks = CBreakPoints::GetMemCheckRanges(type == MEM_WRITE);
+	bool possible = !memchecks.empty();
 	for (auto it = memchecks.begin(), end = memchecks.end(); it != end; ++it)
 	{
-		if (!(it->cond & MEMCHECK_READ) && type == MEM_READ)
-			continue;
-		if (!(it->cond & MEMCHECK_WRITE) && type == MEM_WRITE)
-			continue;
-
-		possible = true;
-
 		FixupBranch skipNext, skipNextRange;
 		if (it->end != 0)
 		{

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -446,9 +446,8 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength) {
 		for (size_t i = 0; i < _iLength; i++)
 			Write_U8(_iValue, (u32)(_Address + i));
 	}
-#ifndef MOBILE_DEVICE
+
 	CBreakPoints::ExecMemCheck(_Address, true, _iLength, currentMIPS->pc);
-#endif
 }
 
 } // namespace

--- a/Core/MemMapHelpers.h
+++ b/Core/MemMapHelpers.h
@@ -33,9 +33,7 @@ inline void Memcpy(const u32 to_address, const void *from_data, const u32 len)
 	u8 *to = GetPointer(to_address);
 	if (to) {
 		memcpy(to, from_data, len);
-#ifndef MOBILE_DEVICE
 		CBreakPoints::ExecMemCheck(to_address, true, len, currentMIPS->pc);
-#endif
 	}
 	// if not, GetPointer will log.
 }
@@ -45,9 +43,7 @@ inline void Memcpy(void *to_data, const u32 from_address, const u32 len)
 	const u8 *from = GetPointer(from_address);
 	if (from) {
 		memcpy(to_data, from, len);
-#ifndef MOBILE_DEVICE
 		CBreakPoints::ExecMemCheck(from_address, false, len, currentMIPS->pc);
-#endif
 	}
 	// if not, GetPointer will log.
 }
@@ -55,9 +51,7 @@ inline void Memcpy(void *to_data, const u32 from_address, const u32 len)
 inline void Memcpy(const u32 to_address, const u32 from_address, const u32 len)
 {
 	Memcpy(GetPointer(to_address), from_address, len);
-#ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(to_address, true, len, currentMIPS->pc);
-#endif
 }
 
 void Memset(const u32 _Address, const u8 _Data, const u32 _iLength);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -430,9 +430,23 @@ void PSP_EndHostFrame() {
 	}
 }
 
+void PSP_RunLoopWhileState() {
+	// We just run the CPU until we get to vblank. This will quickly sync up pretty nicely.
+	// The actual number of cycles doesn't matter so much here as we will break due to CORE_NEXTFRAME, most of the time hopefully...
+	int blockTicks = usToCycles(1000000 / 10);
+
+	// Run until CORE_NEXTFRAME
+	while (coreState == CORE_RUNNING || coreState == CORE_STEPPING) {
+		PSP_RunLoopFor(blockTicks);
+	}
+}
+
 void PSP_RunLoopUntil(u64 globalticks) {
 	SaveState::Process();
 	if (coreState == CORE_POWERDOWN || coreState == CORE_ERROR) {
+		return;
+	} else if (coreState == CORE_STEPPING) {
+		Core_ProcessStepping();
 		return;
 	}
 

--- a/Core/System.h
+++ b/Core/System.h
@@ -70,6 +70,7 @@ void PSP_Shutdown();
 
 void PSP_BeginHostFrame();
 void PSP_EndHostFrame();
+void PSP_RunLoopWhileState();
 void PSP_RunLoopUntil(u64 globalticks);
 void PSP_RunLoopFor(int cycles);
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2576,10 +2576,8 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 		framebufferManager_->NotifyBlockTransferAfter(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason);
 	}
 
-#ifndef MOBILE_DEVICE
 	CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
 	CBreakPoints::ExecMemCheck(dstBasePtr + (dstY * dstStride + dstX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
-#endif
 
 	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 	cyclesExecuted += ((height * width * bpp) * 16) / 10;

--- a/GPU/Null/NullGpu.cpp
+++ b/GPU/Null/NullGpu.cpp
@@ -344,10 +344,8 @@ void NullGPU::ExecuteOp(u32 op, u32 diff) {
 				memcpy(dst, src, width * bpp);
 			}
 
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
 			CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
-#endif
 
 			// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 			cyclesExecuted += ((height * width * bpp) * 16) / 10;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -648,10 +648,8 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff) {
 				memcpy(dst, src, width * bpp);
 			}
 
-#ifndef MOBILE_DEVICE
 			CBreakPoints::ExecMemCheck(srcBasePtr + (srcY * srcStride + srcX) * bpp, false, height * srcStride * bpp, currentMIPS->pc);
 			CBreakPoints::ExecMemCheck(dstBasePtr + (srcY * dstStride + srcX) * bpp, true, height * dstStride * bpp, currentMIPS->pc);
-#endif
 
 			// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 			cyclesExecuted += ((height * width * bpp) * 16) / 10;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1193,14 +1193,7 @@ void EmuScreen::render() {
 
 	PSP_BeginHostFrame();
 
-	// We just run the CPU until we get to vblank. This will quickly sync up pretty nicely.
-	// The actual number of cycles doesn't matter so much here as we will break due to CORE_NEXTFRAME, most of the time hopefully...
-	int blockTicks = usToCycles(1000000 / 10);
-
-	// Run until CORE_NEXTFRAME
-	while (coreState == CORE_RUNNING) {
-		PSP_RunLoopFor(blockTicks);
-	}
+	PSP_RunLoopWhileState();
 
 	// Hopefully coreState is now CORE_NEXTFRAME
 	if (coreState == CORE_NEXTFRAME) {

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -809,7 +809,6 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 	if (_bDebug && GetUIState() == UISTATE_INGAME && PSP_IsInited())
 	{
 		Core_WaitInactive(TEMP_BREAKPOINT_WAIT_MS);
-		CBreakPoints::ClearTemporaryBreakPoints();
 		breakpointList->reloadBreakpoints();
 		threadList->reloadThreads();
 		stackTraceView->loadStackTrace();


### PR DESCRIPTION
This adjusts the core run loop so that it takes into account CORE_STEPPING.

One possible impact of this might be issues if the game hits CORE_STEPPING - I'm not sure exactly what we would've done before, but now we'll stall waiting for a debugger to attach.  Maybe if the remote debugger setting is off on mobile we should immediately exit the game?

This also makes single stepping more reliable, locking properly and using a counter so individual stepping events can correctly be identified.  This fixes some race conditions that are more common when debugging remotely with higher latency.

-[Unknown]