### PR TITLE
net: Use WSAAddressToString for Windows XP

### DIFF
--- a/ext/native/file/fd_util.cpp
+++ b/ext/native/file/fd_util.cpp
@@ -141,17 +141,29 @@ std::string GetLocalIP(int sock) {
 	memset(&server_addr, 0, sizeof(server_addr));
 	socklen_t len = sizeof(server_addr);
 	if (getsockname(sock, (struct sockaddr *)&server_addr, &len) == 0) {
-		char temp[64];
+		char temp[64]{};
+
+		// We clear the port below for WSAAddressToStringA.
 		void *addr;
 		if (server_addr.sa.sa_family == AF_INET6) {
+			server_addr.ipv6.sin6_port = 0;
 			addr = &server_addr.ipv6.sin6_addr;
 		} else {
+			server_addr.ipv4.sin_port = 0;
 			addr = &server_addr.ipv4.sin_addr;
 		}
+#ifdef _WIN32
+		DWORD len = (DWORD)sizeof(temp);
+		// Windows XP doesn't support inet_ntop.
+		if (WSAAddressToStringA((struct sockaddr *)&server_addr, sizeof(server_addr), nullptr, temp, &len) == 0) {
+			return temp;
+		}
+#else
 		const char *result = inet_ntop(server_addr.sa.sa_family, addr, temp, sizeof(temp));
 		if (result) {
 			return result;
 		}
+#endif
 	}
 	return "";
 }


### PR DESCRIPTION
Unfortunately, we don't have inet_ntop on older Windows.

Not actually tested on Windows XP but should be okay.

-[Unknown]