### PR TITLE
Fix some SDL and Qt screen size weirdness

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -11,6 +11,7 @@
 #include <QDesktopWidget>
 #include <QDesktopServices>
 #include <QLocale>
+#include <QScreen>
 #include <QThread>
 
 #include "ext/glslang/glslang/Public/ShaderLang.h"
@@ -34,6 +35,7 @@
 #include <string.h>
 
 MainUI *emugl = NULL;
+static int refreshRate = 60000;
 
 #ifdef SDL
 extern void mixaudio(void *userdata, Uint8 *stream, int len) {
@@ -67,7 +69,7 @@ int System_GetPropertyInt(SystemProperty prop) {
 	case SYSPROP_AUDIO_SAMPLE_RATE:
 		return 44100;
 	case SYSPROP_DISPLAY_REFRESH_RATE:
-		return 60000;
+		return refreshRate;
 	case SYSPROP_DEVICE_TYPE:
 #if defined(__ANDROID__)
 		return DEVICE_TYPE_MOBILE;
@@ -514,6 +516,9 @@ int main(int argc, char *argv[])
 	g_dpi_scale_real_y = g_dpi_scale_y;
 	dp_xres = (int)(pixel_xres * g_dpi_scale_x);
 	dp_yres = (int)(pixel_yres * g_dpi_scale_y);
+
+	refreshRate = (int)(a.primaryScreen()->refreshRate() * 1000);
+
 	std::string savegame_dir = ".";
 	std::string external_dir = ".";
 #if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -528,12 +528,7 @@ int main(int argc, char *argv[])
 	savegame_dir += "/";
 	external_dir += "/";
 
-	bool fullscreenCLI=false;
-	for (int i = 1; i < argc; i++) {
-		if (!strcmp(argv[i],"--fullscreen"))
-			fullscreenCLI=true;
-	}
-	NativeInit(argc, (const char **)argv, savegame_dir.c_str(), external_dir.c_str(), nullptr, fullscreenCLI);
+	NativeInit(argc, (const char **)argv, savegame_dir.c_str(), external_dir.c_str(), nullptr);
 
 	// TODO: Support other backends than GL, like Vulkan, in the Qt backend.
 	g_Config.iGPUBackend = (int)GPUBackend::OPENGL;

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -110,6 +110,8 @@ public:
 	explicit MainUI(QWidget *parent = 0);
 	~MainUI();
 
+	void resizeGL(int w, int h);
+
 public slots:
 	QString InputBoxGetQString(QString title, QString defaultValue);
 
@@ -123,7 +125,6 @@ protected:
 	bool event(QEvent *e);
 
 	void initializeGL();
-	void resizeGL(int w, int h);
 	void paintGL();
 
 	void updateAccelerometer();

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -382,8 +382,8 @@ void MainWindow::SetWindowScale(int zoom) {
 		// Update to the specified factor.  Let's clamp first.
 		if (zoom < 1)
 			zoom = 1;
-		if (zoom > 4)
-			zoom = 4;
+		if (zoom > 10)
+			zoom = 10;
 
 		width = (g_Config.IsPortrait() ? 272 : 480) * zoom;
 		height = (g_Config.IsPortrait() ? 480 : 272) * zoom;
@@ -496,8 +496,8 @@ void MainWindow::createMenus()
 	// - Screen Size
 	MenuTree* screenMenu = new MenuTree(this, videoMenu,          QT_TR_NOOP("&Screen Size"));
 	screenGroup = new MenuActionGroup(this, screenMenu, SLOT(screenGroup_triggered(QAction *)),
-		QStringList() << "1x" << "2x" << "3x" << "4x",
-		QList<int>()  << 1    << 2    << 3    << 4,
+		QStringList() << "1x" << "2x" << "3x" << "4x" << "5x" << "6x" << "7x" << "8x" << "9x" << "10x",
+		QList<int>()  << 1    << 2    << 3    << 4    << 5    << 6    << 7    << 8    << 9    << 10,
 		QList<int>() << Qt::CTRL + Qt::Key_1 << Qt::CTRL + Qt::Key_2 << Qt::CTRL + Qt::Key_3 << Qt::CTRL + Qt::Key_4);
 
 	MenuTree* displayLayoutMenu = new MenuTree(this, videoMenu, QT_TR_NOOP("&Display Layout Options"));

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -99,12 +99,18 @@ private slots:
 	// Video
 	void anisotropicGroup_triggered(QAction *action) { g_Config.iAnisotropyLevel = action->data().toInt(); }
 
-	void bufferRenderAct() { g_Config.iRenderingMode = !g_Config.iRenderingMode; }
+	void bufferRenderAct() {
+		g_Config.iRenderingMode = !g_Config.iRenderingMode;
+		NativeMessageReceived("gpu_resized", "");
+	}
 	void linearAct() { g_Config.iTexFiltering = (g_Config.iTexFiltering != 0) ? 0 : 3; }
 
 	void screenGroup_triggered(QAction *action) { SetWindowScale(action->data().toInt()); }
 
-	void displayLayoutGroup_triggered(QAction *action) { g_Config.iSmallDisplayZoomType = action->data().toInt(); }
+	void displayLayoutGroup_triggered(QAction *action) {
+		g_Config.iSmallDisplayZoomType = action->data().toInt();
+		NativeMessageReceived("gpu_resized", "");
+	}
 	void transformAct() { g_Config.bHardwareTransform = !g_Config.bHardwareTransform; }
 	void vertexCacheAct() { g_Config.bVertexCache = !g_Config.bVertexCache; }
 	void frameskipAct() { g_Config.iFrameSkip = !g_Config.iFrameSkip; }
@@ -114,7 +120,10 @@ private slots:
 
 	void fullscrAct();
 	void raiseTopMost();
-	void statsAct() { g_Config.bShowDebugStats = !g_Config.bShowDebugStats; }
+	void statsAct() {
+		g_Config.bShowDebugStats = !g_Config.bShowDebugStats;
+		NativeMessageReceived("clear jit", "");
+	}
 	void showFPSAct() { g_Config.iShowFPSCounter = !g_Config.iShowFPSCounter; }
 
 	// Logs

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -30,7 +30,7 @@ class MainWindow : public QMainWindow
 	Q_OBJECT
 
 public:
-	explicit MainWindow(QWidget *parent = 0, bool fullscreen=false);
+	explicit MainWindow(QWidget *parent = nullptr, bool fullscreen = false);
 	~MainWindow() { };
 
 	CoreState GetNextState() { return nextState; }
@@ -144,6 +144,7 @@ private:
 	void bootDone();
 	void SetWindowScale(int zoom);
 	void SetGameTitle(QString text);
+	void SetFullScreen(bool fullscreen);
 	void loadLanguage(const QString &language, bool retranslate);
 	void createMenus();
 

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -158,7 +158,9 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std:
 #endif
 	};
 
-	mode |= SDL_WINDOW_OPENGL;
+	// We start hidden because we have to try several windows.
+	// On Mac, full screen animates so each attempt is slow.
+	mode |= SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
 
 	SDL_GLContext glContext = nullptr;
 	for (size_t i = 0; i < ARRAY_SIZE(attemptVersions); ++i) {
@@ -216,6 +218,9 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std:
 			return 2;
 		}
 	}
+
+	// At this point, we have a window that we can show finally.
+	SDL_ShowWindow(window);
 
 #ifdef USING_EGL
 	EGL_Init();

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -602,11 +602,9 @@ int main(int argc, char *argv[]) {
 					Uint32 window_flags = SDL_GetWindowFlags(window);
 					bool fullscreen = (window_flags & SDL_WINDOW_FULLSCREEN);
 
-					pixel_xres = event.window.data1;
-					pixel_yres = event.window.data2;
-					dp_xres = (float)pixel_xres * dpi_scale;
-					dp_yres = (float)pixel_yres * dpi_scale;
-					NativeResized();
+					if (UpdateScreenScale(event.window.data1, event.window.data2)) {
+						NativeMessageReceived("gpu_resized", "");
+					}
 
 					// Set variable here in case fullscreen was toggled by hotkey
 					g_Config.bFullScreen = fullscreen;
@@ -760,7 +758,7 @@ int main(int argc, char *argv[]) {
 			lastUIState = GetUIState();
 			if (lastUIState == UISTATE_INGAME && g_Config.bFullScreen && !g_Config.bShowTouchControls)
 				SDL_ShowCursor(SDL_DISABLE);
-			if (lastUIState != UISTATE_INGAME && g_Config.bFullScreen)
+			if (lastUIState != UISTATE_INGAME || !g_Config.bFullScreen)
 				SDL_ShowCursor(SDL_ENABLE);
 		}
 #endif

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -345,7 +345,7 @@ void CreateDirectoriesAndroid() {
 	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/SAVEDATA/.nomedia");
 }
 
-void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir, bool fs) {
+void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir) {
 	net::Init();  // This needs to happen before we load the config. So on Windows we also run it in Main. It's fine to call multiple times.
 
 	InitFastMath(cpu_info.bNEON);
@@ -474,6 +474,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 #endif
 				if (!strncmp(argv[i], "--pause-menu-exit", strlen("--pause-menu-exit")))
 					g_Config.bPauseMenuExitsEmulator = true;
+				if (!strcmp(argv[i], "--fullscreen"))
+					g_Config.bFullScreen = true;
 				break;
 			}
 		} else {
@@ -615,7 +617,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	isOuya = KeyMap::IsOuya(sysName);
 
 #if !defined(MOBILE_DEVICE) && defined(USING_QT_UI)
-	MainWindow* mainWindow = new MainWindow(0,fs);
+	MainWindow *mainWindow = new MainWindow(nullptr, g_Config.bFullScreen);
 	mainWindow->show();
 	if (host == nullptr) {
 		host = new QtHost(mainWindow);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -458,9 +458,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				break;
 			}
 
-			if (wideArgs[i] == L"--fullscreen")
-				g_Config.bFullScreen = true;
-
 			if (wideArgs[i] == L"--windowed")
 				g_Config.bFullScreen = false;
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -45,7 +45,7 @@ bool NativeIsAtTopLevel();
 // The very first function to be called after NativeGetAppInfo. Even NativeMix is not called
 // before this, although it may be called at any point in time afterwards (on any thread!)
 // This functions must NOT call OpenGL. Main thread.
-void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir, bool fs=false);
+void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir);
 
 // Runs after NativeInit() at some point. May (and probably should) call OpenGL.
 // Should not initialize anything screen-size-dependent - do that in NativeResized.


### PR DESCRIPTION
Qt was randomly starting up with the wrong size.  This seems to fix that, and improves the fullscreen handling.  May help #8032.

SDL was starting up badly with --fullscreen on Mac, since it animates transition to/from full screen.  Each attempted GL context version caused another animation, so it took several seconds of your screen fading to black and back to your desktop before it would actually start.

I suppose it might happen on other platforms, so starting with the SDL window hidden seems most sane.

-[Unknown]