### PR TITLE
handle cullface, help to #10597

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -522,7 +522,7 @@ void DrawEngineCommon::DecodeVertsStep(u8 *dest, int &i, int &decodedVerts) {
 		decodedVerts += indexUpperBound - indexLowerBound + 1;
 		
 		bool clockwise = true;
-		if (dc.cullMode != -1 && gstate.isCullEnabled() && gstate.getCullMode() != dc.cullMode) {
+		if (gstate.isCullEnabled() && gstate.getCullMode() != dc.cullMode) {
 			clockwise = false;
 		}
 		indexGen.AddPrim(dc.prim, dc.vertexCount, clockwise);
@@ -550,7 +550,7 @@ void DrawEngineCommon::DecodeVertsStep(u8 *dest, int &i, int &decodedVerts) {
 		case GE_VTYPE_IDX_8BIT >> GE_VTYPE_IDX_SHIFT:
 			for (int j = i; j <= lastMatch; j++) {
 				bool clockwise = true;
-				if (drawCalls[j].cullMode != -1 && gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
+				if (gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
 					clockwise = false;
 				}
 				indexGen.TranslatePrim(drawCalls[j].prim, drawCalls[j].vertexCount, (const u8 *)drawCalls[j].inds, indexLowerBound, clockwise);
@@ -559,7 +559,7 @@ void DrawEngineCommon::DecodeVertsStep(u8 *dest, int &i, int &decodedVerts) {
 		case GE_VTYPE_IDX_16BIT >> GE_VTYPE_IDX_SHIFT:
 			for (int j = i; j <= lastMatch; j++) {
 				bool clockwise = true;
-				if (drawCalls[j].cullMode != -1 && gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
+				if (gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
 					clockwise = false;
 				}
 				indexGen.TranslatePrim(drawCalls[j].prim, drawCalls[j].vertexCount, (const u16_le *)drawCalls[j].inds, indexLowerBound, clockwise);
@@ -568,7 +568,7 @@ void DrawEngineCommon::DecodeVertsStep(u8 *dest, int &i, int &decodedVerts) {
 		case GE_VTYPE_IDX_32BIT >> GE_VTYPE_IDX_SHIFT:
 			for (int j = i; j <= lastMatch; j++) {
 				bool clockwise = true;
-				if (drawCalls[j].cullMode != -1 && gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
+				if (gstate.isCullEnabled() && gstate.getCullMode() != drawCalls[j].cullMode) {
 					clockwise = false;
 				}
 				indexGen.TranslatePrim(drawCalls[j].prim, drawCalls[j].vertexCount, (const u32_le *)drawCalls[j].inds, indexLowerBound, clockwise);


### PR DESCRIPTION
Earth Defence Force 2 use `GE_CMD_CULLFACEENABLE` frequently with same value.


maybe this fall back is not necessary, I'm not familiar with other prim, if game use those, it is simple to handle it.
```
if (newPrim != GE_PRIM_TRIANGLES && newPrim != GE_PRIM_TRIANGLE_STRIP && newPrim != GE_PRIM_TRIANGLE_FAN && 
	cullMode != -1 && cullMode != gstate.getCullMode() ) {
	DEBUG_LOG(G3D, "flush cull mode before prim: %d", newPrim);
	drawEngineCommon_->DispatchFlush();
	gstate.cmdmem[GE_CMD_CULL] ^= 1;
	gstate_c.Dirty(DIRTY_RASTER_STATE);
}
```