### PR TITLE
 SaveState: Show warning on old / long use state

### DIFF
--- a/Common/ChunkFile.cpp
+++ b/Common/ChunkFile.cpp
@@ -225,7 +225,7 @@ CChunkFileReader::Error CChunkFileReader::GetFileTitle(const std::string &filena
 	return LoadFileHeader(pFile, header, title);
 }
 
-CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string &filename, const char *gitVersion, u8 *&_buffer, size_t &sz, std::string *failureReason) {
+CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string &filename, std::string *gitVersion, u8 *&_buffer, size_t &sz, std::string *failureReason) {
 	if (!File::Exists(filename)) {
 		*failureReason = "LoadStateDoesntExist";
 		ERROR_LOG(SAVESTATE, "ChunkReader: File doesn't exist");
@@ -262,6 +262,12 @@ CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string &filename, 
 		_buffer = uncomp_buffer;
 		sz = uncomp_size;
 		delete [] buffer;
+	}
+
+	if (header.GitVersion[31]) {
+		*gitVersion = std::string(header.GitVersion, 32);
+	} else {
+		*gitVersion = header.GitVersion;
 	}
 
 	return ERROR_NONE;

--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -622,7 +622,7 @@ public:
 
 	// Load file template
 	template<class T>
-	static Error Load(const std::string &filename, const char *gitVersion, T& _class, std::string *failureReason)
+	static Error Load(const std::string &filename, std::string *gitVersion, T& _class, std::string *failureReason)
 	{
 		*failureReason = "LoadStateWrongVersion";
 
@@ -700,7 +700,7 @@ private:
 		REVISION_CURRENT = REVISION_TITLE,
 	};
 
-	static Error LoadFile(const std::string &filename, const char *gitVersion, u8 *&buffer, size_t &sz, std::string *failureReason);
+	static Error LoadFile(const std::string &filename, std::string *gitVersion, u8 *&buffer, size_t &sz, std::string *failureReason);
 	static Error SaveFile(const std::string &filename, const std::string &title, const char *gitVersion, u8 *buffer, size_t sz);
 	static Error LoadFileHeader(File::IOFile &pFile, SChunkHeader &header, std::string *title);
 };

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -416,6 +416,7 @@ static ConfigSetting cpuSettings[] = {
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
 	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, false),
+	ConfigSetting("HideStateWarnings", &g_Config.bHideStateWarnings, false, true, true),
 	ConfigSetting("PreloadFunctions", &g_Config.bPreloadFunctions, false, true, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -129,6 +129,7 @@ public:
 	bool bForceLagSync;
 	bool bFuncReplacements;
 	bool bHideSlowWarnings;
+	bool bHideStateWarnings;
 	bool bPreloadFunctions;
 
 	bool bSeparateSASThread;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -241,7 +241,9 @@ namespace SaveState
 	static std::vector<Operation> pending;
 	static std::mutex mutex;
 	static bool hasLoadedState = false;
-	static const int STALE_STATE_USES = 10;
+	static const int STALE_STATE_USES = 2;
+	// 4 hours of total gameplay since the virtual PSP started the game.
+	static const u64 STALE_STATE_TIME = 4 * 3600 * 1000;
 	static int saveStateGeneration = 0;
 	static std::string saveStateInitialGitVersion = "";
 
@@ -261,8 +263,10 @@ namespace SaveState
 			return;
 
 		if (s >= 2) {
+			// This only increments on save, of course.
 			++saveStateGeneration;
 			p.Do(saveStateGeneration);
+			// This saves the first git version to create this save state (or generation of save states.)
 			if (saveStateInitialGitVersion.empty())
 				saveStateInitialGitVersion = PPSSPP_GIT_VERSION;
 			p.Do(saveStateInitialGitVersion);
@@ -638,8 +642,7 @@ namespace SaveState
 
 	bool IsStale() {
 		if (saveStateGeneration >= STALE_STATE_USES) {
-			// Don't show it every time.
-			return saveStateGeneration % 5 == 0;
+			return CoreTiming::GetGlobalTimeUs() > STALE_STATE_TIME;
 		}
 		return false;
 	}

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -705,14 +705,14 @@ namespace SaveState
 					callbackResult = Status::SUCCESS;
 					hasLoadedState = true;
 
-					if (IsStale()) {
+					if (!g_Config.bHideStateWarnings && IsStale()) {
 						// For anyone wondering why (too long to put on the screen in an osm):
 						// Using save states instead of saves simulates many hour play sessions.
 						// Sometimes this exposes game bugs that were rarely seen on real devices,
 						// because few people played on a real PSP for 10 hours straight.
 						callbackMessage = sc->T("Loaded.  Save in game, restart, and load for less bugs.");
 						callbackResult = Status::WARNING;
-					} else if (IsOldVersion()) {
+					} else if (!g_Config.bHideStateWarnings && IsOldVersion()) {
 						// Save states also preserve bugs from old PPSSPP versions, so warn.
 						callbackMessage = sc->T("Loaded.  Save in game, restart, and load for less bugs.");
 						callbackResult = Status::WARNING;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -268,7 +268,6 @@ namespace SaveState
 			p.Do(saveStateInitialGitVersion);
 		} else {
 			saveStateGeneration = 1;
-			saveStateInitialGitVersion = "v0.0.1";
 		}
 
 		// Gotta do CoreTiming first since we'll restore into it.
@@ -699,7 +698,8 @@ namespace SaveState
 			{
 			case SAVESTATE_LOAD:
 				INFO_LOG(SAVESTATE, "Loading state from %s", op.filename.c_str());
-				result = CChunkFileReader::Load(op.filename, PPSSPP_GIT_VERSION, state, &reason);
+				// Use the state's latest version as a guess for saveStateInitialGitVersion.
+				result = CChunkFileReader::Load(op.filename, &saveStateInitialGitVersion, state, &reason);
 				if (result == CChunkFileReader::ERROR_NONE) {
 					callbackMessage = sc->T("Loaded State");
 					callbackResult = Status::SUCCESS;

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -23,7 +23,12 @@
 
 namespace SaveState
 {
-	typedef std::function<void(bool status, const std::string &message, void *cbUserData)> Callback;
+	enum class Status {
+		FAILURE,
+		WARNING,
+		SUCCESS,
+	};
+	typedef std::function<void(Status status, const std::string &message, void *cbUserData)> Callback;
 
 	static const int NUM_SLOTS = 5;
 	static const char *STATE_EXTENSION = "ppst";
@@ -78,6 +83,12 @@ namespace SaveState
 
 	// Returns true if a savestate has been used during this session.
 	bool HasLoadedState();
+
+	// Returns true if the state has been reused instead of real saves many times.
+	bool IsStale();
+
+	// Returns true if state is from an older PPSSPP version.
+	bool IsOldVersion();
 
 	// Check if there's any save stating needing to be done.  Normally called once per frame.
 	void Process();

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -163,10 +163,10 @@ void MainWindow::closeAct()
 	SetGameTitle("");
 }
 
-void SaveStateActionFinished(bool result, const std::string &message, void *userdata)
+void SaveStateActionFinished(SaveState::Status status, const std::string &message, void *userdata)
 {
 	// TODO: Improve messaging?
-	if (!result)
+	if (status == SaveState::Status::FAILURE)
 	{
 		QMessageBox msgBox;
 		msgBox.setWindowTitle("Load Save State");

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -346,14 +346,14 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	RecreateViews();
 }
 
-static void AfterSaveStateAction(bool success, const std::string &message, void *) {
+static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
 	if (!message.empty()) {
-		osm.Show(message, 2.0);
+		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }
 
-static void AfterStateBoot(bool success, const std::string &message, void *ignored) {
-	AfterSaveStateAction(success, message, ignored);
+static void AfterStateBoot(SaveState::Status status, const std::string &message, void *ignored) {
+	AfterSaveStateAction(status, message, ignored);
 	Core_EnableStepping(false);
 	host->UpdateDisassembly();
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -590,9 +590,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 #endif
 
 	if (!boot_filename.empty() && stateToLoad != NULL) {
-		SaveState::Load(stateToLoad, [](bool status, const std::string &message, void *) {
+		SaveState::Load(stateToLoad, [](SaveState::Status status, const std::string &message, void *) {
 			if (!message.empty()) {
-				osm.Show(message, 2.0);
+				osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 			}
 		});
 	}

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -238,9 +238,9 @@ void SaveSlotView::Draw(UIContext &dc) {
 	UI::LinearLayout::Draw(dc);
 }
 
-static void AfterSaveStateAction(bool status, const std::string &message, void *) {
+static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
 	if (!message.empty()) {
-		osm.Show(message, 2.0);
+		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }
 
@@ -373,7 +373,7 @@ void GamePauseScreen::dialogFinished(const Screen *dialog, DialogResult dr) {
 		ScreenshotViewScreen *s = (ScreenshotViewScreen *)dialog;
 		int slot = s->GetSlot();
 		g_Config.iCurrentStateSlot = slot;
-		SaveState::LoadSlot(gamePath_, slot, SaveState::Callback(), 0);
+		SaveState::LoadSlot(gamePath_, slot, &AfterSaveStateAction);
 
 		finishNextFrame_ = true;
 	} else {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -470,9 +470,9 @@ namespace MainWindow {
 		g_Config.iInternalScreenRotation = rotation;
 	}
 
-	static void SaveStateActionFinished(bool result, const std::string &message, void *userdata) {
+	static void SaveStateActionFinished(SaveState::Status status, const std::string &message, void *userdata) {
 		if (!message.empty()) {
-			osm.Show(message, 2.0);
+			osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 		}
 		PostMessage(MainWindow::GetHWND(), WM_USER_SAVESTATE_FINISH, 0, 0);
 	}


### PR DESCRIPTION
This does a few things:

1. Starts tracking the *initial* PPSSPP version used for a save state (not just the latest to save it.)  May be useful for debugging too.
2. Shows a warning message if the initial PPSSPP version is less than the current PPSSPP version.
3. Shows a warning message if a save state has been cycled (loaded, saved, loaded, saved) for >= 10 times, every 5th time.  The goal is to detect using save states instead of save games for long term.
4. Shows save state related errors and warnings for longer than 2s.
5. Adds an ini-only config setting in case these warnings cause people to [freeze during winter](https://xkcd.com/1172/).

This is common guidance on the forum when users report issues, but might as well tell everyone - not just the special few who ask for help.  Used the same message after some consideration, to make translations easier and keep it terse.

Also, in case of features like #8661, it might become even more common to replace in game saves with save states.

-[Unknown]