### PR TITLE
GLES: Use accurate GLSL ver in postshader convert

### DIFF
--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -310,11 +310,7 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShade
 		spirv_cross::ShaderResources resources = glsl.get_shader_resources();
 		// Set some options.
 		spirv_cross::CompilerGLSL::Options options;
-		if (gl_extensions.ver[0] >= 4) {
-			options.version = 400;
-		} else {
-			options.version = 300;
-		}
+		options.version = gl_extensions.GLSLVersion();
 		glsl.set_options(options);
 		// Compile to GLSL, ready to give to GL driver.
 		*dest = glsl.compile();

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -54,6 +54,23 @@ bool GLExtensions::VersionGEThan(int major, int minor, int sub) {
 	return gl_extensions.ver[2] >= sub;
 }
 
+int GLExtensions::GLSLVersion() {
+	// Used for shader translation and core contexts (Apple drives fail without an exact match.)
+	if (gl_extensions.VersionGEThan(3, 3)) {
+		return gl_extensions.ver[0] * 100 + gl_extensions.ver[1] * 10;
+	} else if (gl_extensions.VersionGEThan(3, 2)) {
+		return 150;
+	} else if (gl_extensions.VersionGEThan(3, 1)) {
+		return 140;
+	} else if (gl_extensions.VersionGEThan(3, 0)) {
+		return 130;
+	} else if (gl_extensions.VersionGEThan(2, 1)) {
+		return 120;
+	} else {
+		return 110;
+	}
+}
+
 void ProcessGPUFeatures() {
 	gl_extensions.bugs = 0;
 
@@ -505,15 +522,7 @@ std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage) {
 	std::string version = "";
 	if (!gl_extensions.IsGLES && gl_extensions.IsCoreContext) {
 		// We need to add a corresponding #version.  Apple drives fail without an exact match.
-		if (gl_extensions.VersionGEThan(3, 3)) {
-			version = StringFromFormat("#version %d%d0\n", gl_extensions.ver[0], gl_extensions.ver[1]);
-		} else if (gl_extensions.VersionGEThan(3, 2)) {
-			version = "#version 150\n";
-		} else if (gl_extensions.VersionGEThan(3, 1)) {
-			version = "#version 140\n";
-		} else {
-			version = "#version 130\n";
-		}
+		version = StringFromFormat("#version %d\n", gl_extensions.GLSLVersion());
 	}
 	if (stage == GL_FRAGMENT_SHADER) {
 		temp = version + glsl_fragment_prelude + source;

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -103,6 +103,7 @@ struct GLExtensions {
 
 	// greater-or-equal than
 	bool VersionGEThan(int major, int minor, int sub = 0);
+	int GLSLVersion();
 };
 
 extern GLExtensions gl_extensions;


### PR DESCRIPTION
Fixes #11180.  Validated with a 3.3 and 4.6 context, and also validated that hardcoding 110 as the version works.

But it should only actually use this for core profiles (so never GL 2.x) and higher anyway.

-[Unknown]