### PR TITLE
Update armips and reduce warning noise

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -444,11 +444,16 @@ int VulkanContext::GetBestPhysicalDevice() {
 		case VK_PHYSICAL_DEVICE_TYPE_CPU:
 			score += 1;
 			break;
+		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+			score += 2;
+			break;
 		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
 			score += 20;
 			break;
 		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
 			score += 10;
+			break;
+		default:
 			break;
 		}
 		if (props.vendorID == VULKAN_VENDOR_AMD) {

--- a/Common/Vulkan/VulkanLoader.cpp
+++ b/Common/Vulkan/VulkanLoader.cpp
@@ -313,6 +313,8 @@ bool VulkanMayBeAvailable() {
 		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
 			anyGood = true;
 			break;
+		default:
+			break;
 		}
 		// TODO: Should also check queuefamilyproperties for a GRAPHICS queue family? Oh well.
 	}

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -163,7 +163,8 @@ static void RegisterDiscHandlers(http::Server *http, std::unordered_map<std::str
 			char *buf = new char[CHUNK_SIZE];
 			for (s64 pos = 0; pos < len; pos += CHUNK_SIZE) {
 				s64 chunklen = std::min(len - pos, (s64)CHUNK_SIZE);
-				fread(buf, chunklen, 1, fp);
+				if (fread(buf, chunklen, 1, fp) != 1)
+					break;
 				request.Out()->Push(buf, chunklen);
 			}
 			fclose(fp);

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -286,6 +286,9 @@ void GenerateDepalShader(char *buffer, GEBufferFormat pixelFormat, ShaderLanguag
 	case HLSL_DX9:
 		GenerateDepalShaderFloat(buffer, pixelFormat, language);
 		break;
+	case HLSL_D3D11_LEVEL9:
+	default:
+		_assert_msg_(G3D, false, "Depal shader language not supported: %d", (int)language);
 	}
 }
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -83,5 +83,4 @@ private:
 	ShaderManagerD3D11 *shaderManagerD3D11_;
 
 	int lastVsync_;
-	int vertexCost_ = 0;
 };

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -82,7 +82,6 @@ private:
 	ShaderManagerDX9 *shaderManagerDX9_;
 
 	int lastVsync_;
-	int vertexCost_ = 0;
 };
 
 }  // namespace DX9

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -92,5 +92,4 @@ private:
 #ifdef _WIN32
 	int lastVsync_;
 #endif
-	int vertexCost_ = 0;
 };

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -167,7 +167,7 @@ void DrawEngineVulkan::InitDeviceObjects() {
 
 	vertexCache_ = new VulkanPushBuffer(vulkan_, VERTEX_CACHE_SIZE);
 
-	tessDataTransfer = new TessellationDataTransferVulkan(vulkan_, draw_);
+	tessDataTransfer = new TessellationDataTransferVulkan(vulkan_);
 }
 
 DrawEngineVulkan::~DrawEngineVulkan() {
@@ -994,8 +994,8 @@ void DrawEngineVulkan::UpdateUBOs(FrameData *frame) {
 	}
 }
 
-DrawEngineVulkan::TessellationDataTransferVulkan::TessellationDataTransferVulkan(VulkanContext *vulkan, Draw::DrawContext *draw)
-	: TessellationDataTransfer(), vulkan_(vulkan), draw_(draw) {
+DrawEngineVulkan::TessellationDataTransferVulkan::TessellationDataTransferVulkan(VulkanContext *vulkan)
+	: TessellationDataTransfer(), vulkan_(vulkan) {
 }
 
 DrawEngineVulkan::TessellationDataTransferVulkan::~TessellationDataTransferVulkan() {

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -280,7 +280,7 @@ private:
 	// Hardware tessellation
 	class TessellationDataTransferVulkan : public TessellationDataTransfer {
 	public:
-		TessellationDataTransferVulkan(VulkanContext *vulkan, Draw::DrawContext *draw);
+		TessellationDataTransferVulkan(VulkanContext *vulkan);
 		~TessellationDataTransferVulkan();
 
 		void SetPushBuffer(VulkanPushBuffer *push) { push_ = push; }
@@ -299,10 +299,8 @@ private:
 
 	private:
 		VulkanContext *vulkan_;
-		Draw::DrawContext *draw_;
 		VulkanPushBuffer *push_;  // Updated each frame.
 
-		int size_ = 0;
 		uint32_t offset_ = 0;
 		uint32_t range_ = 0;
 		VkBuffer buf_ = VK_NULL_HANDLE;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -104,8 +104,9 @@ bool DoesBackendSupportHWTess() {
 	case GPUBackend::VULKAN:
 	case GPUBackend::DIRECT3D11:
 		return true;
+	default:
+		return false;
 	}
-	return false;
 }
 
 static std::string PostShaderTranslateName(const char *value) {

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -421,7 +421,8 @@ LIBARMIPS_FILES := \
   $(SRC)/ext/armips/Archs/ARM/Arm.cpp \
   $(SRC)/ext/armips/Archs/ARM/ArmOpcodes.cpp \
   $(SRC)/ext/armips/Archs/ARM/ArmParser.cpp \
-  $(SRC)/ext/armips/Archs/ARM/ArmRelocator.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ArmElfRelocator.cpp \
+  $(SRC)/ext/armips/Archs/ARM/ArmExpressionFunctions.cpp \
   $(SRC)/ext/armips/Archs/ARM/CArmInstruction.cpp \
   $(SRC)/ext/armips/Archs/ARM/CThumbInstruction.cpp \
   $(SRC)/ext/armips/Archs/ARM/Pool.cpp \
@@ -429,6 +430,8 @@ LIBARMIPS_FILES := \
   $(SRC)/ext/armips/Archs/MIPS/CMipsInstruction.cpp \
   $(SRC)/ext/armips/Archs/MIPS/Mips.cpp \
   $(SRC)/ext/armips/Archs/MIPS/MipsElfFile.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsElfRelocator.cpp \
+  $(SRC)/ext/armips/Archs/MIPS/MipsExpressionFunctions.cpp \
   $(SRC)/ext/armips/Archs/MIPS/MipsMacros.cpp \
   $(SRC)/ext/armips/Archs/MIPS/MipsOpcodes.cpp \
   $(SRC)/ext/armips/Archs/MIPS/MipsParser.cpp \

--- a/ext/cmake/armips/CMakeLists.txt
+++ b/ext/cmake/armips/CMakeLists.txt
@@ -78,8 +78,10 @@ add_library(armips
 	${ARMIPS_PATH}/Archs/ARM/ArmOpcodes.h
 	${ARMIPS_PATH}/Archs/ARM/ArmParser.cpp
 	${ARMIPS_PATH}/Archs/ARM/ArmParser.h
-	${ARMIPS_PATH}/Archs/ARM/ArmRelocator.cpp
-	${ARMIPS_PATH}/Archs/ARM/ArmRelocator.h
+	${ARMIPS_PATH}/Archs/ARM/ArmElfRelocator.cpp
+	${ARMIPS_PATH}/Archs/ARM/ArmElfRelocator.h
+	${ARMIPS_PATH}/Archs/ARM/ArmExpressionFunctions.cpp
+	${ARMIPS_PATH}/Archs/ARM/ArmExpressionFunctions.h
 	${ARMIPS_PATH}/Archs/ARM/CArmInstruction.cpp
 	${ARMIPS_PATH}/Archs/ARM/CArmInstruction.h
 	${ARMIPS_PATH}/Archs/ARM/CThumbInstruction.cpp
@@ -95,6 +97,10 @@ add_library(armips
 	${ARMIPS_PATH}/Archs/MIPS/Mips.h
 	${ARMIPS_PATH}/Archs/MIPS/MipsElfFile.cpp
 	${ARMIPS_PATH}/Archs/MIPS/MipsElfFile.h
+	${ARMIPS_PATH}/Archs/MIPS/MipsElfRelocator.cpp
+	${ARMIPS_PATH}/Archs/MIPS/MipsElfRelocator.h
+	${ARMIPS_PATH}/Archs/MIPS/MipsExpressionFunctions.cpp
+	${ARMIPS_PATH}/Archs/MIPS/MipsExpressionFunctions.h
 	${ARMIPS_PATH}/Archs/MIPS/MipsMacros.cpp
 	${ARMIPS_PATH}/Archs/MIPS/MipsMacros.h
 	${ARMIPS_PATH}/Archs/MIPS/MipsOpcodes.cpp

--- a/ext/libarmips.vcxproj
+++ b/ext/libarmips.vcxproj
@@ -234,9 +234,10 @@
   <ItemGroup>
     <ClCompile Include="armips\Archs\Architecture.cpp" />
     <ClCompile Include="armips\Archs\ARM\Arm.cpp" />
+    <ClCompile Include="armips\Archs\ARM\ArmElfRelocator.cpp" />
+    <ClCompile Include="armips\Archs\ARM\ArmExpressionFunctions.cpp" />
     <ClCompile Include="armips\Archs\ARM\ArmOpcodes.cpp" />
     <ClCompile Include="armips\Archs\ARM\ArmParser.cpp" />
-    <ClCompile Include="armips\Archs\ARM\ArmRelocator.cpp" />
     <ClCompile Include="armips\Archs\ARM\CArmInstruction.cpp" />
     <ClCompile Include="armips\Archs\ARM\CThumbInstruction.cpp" />
     <ClCompile Include="armips\Archs\ARM\Pool.cpp" />
@@ -244,6 +245,8 @@
     <ClCompile Include="armips\Archs\MIPS\CMipsInstruction.cpp" />
     <ClCompile Include="armips\Archs\MIPS\Mips.cpp" />
     <ClCompile Include="armips\Archs\MIPS\MipsElfFile.cpp" />
+    <ClCompile Include="armips\Archs\MIPS\MipsElfRelocator.cpp" />
+    <ClCompile Include="armips\Archs\MIPS\MipsExpressionFunctions.cpp" />
     <ClCompile Include="armips\Archs\MIPS\MipsMacros.cpp" />
     <ClCompile Include="armips\Archs\MIPS\MipsOpcodes.cpp" />
     <ClCompile Include="armips\Archs\MIPS\MipsParser.cpp" />
@@ -287,9 +290,10 @@
   <ItemGroup>
     <ClInclude Include="armips\Archs\Architecture.h" />
     <ClInclude Include="armips\Archs\ARM\Arm.h" />
+    <ClInclude Include="armips\Archs\ARM\ArmElfRelocator.h" />
+    <ClInclude Include="armips\Archs\ARM\ArmExpressionFunctions.h" />
     <ClInclude Include="armips\Archs\ARM\ArmOpcodes.h" />
     <ClInclude Include="armips\Archs\ARM\ArmParser.h" />
-    <ClInclude Include="armips\Archs\ARM\ArmRelocator.h" />
     <ClInclude Include="armips\Archs\ARM\CArmInstruction.h" />
     <ClInclude Include="armips\Archs\ARM\CThumbInstruction.h" />
     <ClInclude Include="armips\Archs\ARM\Pool.h" />
@@ -297,6 +301,8 @@
     <ClInclude Include="armips\Archs\MIPS\CMipsInstruction.h" />
     <ClInclude Include="armips\Archs\MIPS\Mips.h" />
     <ClInclude Include="armips\Archs\MIPS\MipsElfFile.h" />
+    <ClInclude Include="armips\Archs\MIPS\MipsElfRelocator.h" />
+    <ClInclude Include="armips\Archs\MIPS\MipsExpressionFunctions.h" />
     <ClInclude Include="armips\Archs\MIPS\MipsMacros.h" />
     <ClInclude Include="armips\Archs\MIPS\MipsOpcodes.h" />
     <ClInclude Include="armips\Archs\MIPS\MipsParser.h" />

--- a/ext/libarmips.vcxproj.filters
+++ b/ext/libarmips.vcxproj.filters
@@ -42,9 +42,6 @@
     <ClCompile Include="armips\Archs\ARM\ArmOpcodes.cpp">
       <Filter>Archs\ARM</Filter>
     </ClCompile>
-    <ClCompile Include="armips\Archs\ARM\ArmRelocator.cpp">
-      <Filter>Archs\ARM</Filter>
-    </ClCompile>
     <ClCompile Include="armips\Archs\ARM\CArmInstruction.cpp">
       <Filter>Archs\ARM</Filter>
     </ClCompile>
@@ -163,6 +160,18 @@
     <ClCompile Include="armips\Core\ExpressionFunctions.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="armips\Archs\ARM\ArmElfRelocator.cpp">
+      <Filter>Archs\ARM</Filter>
+    </ClCompile>
+    <ClCompile Include="armips\Archs\MIPS\MipsElfRelocator.cpp">
+      <Filter>Archs\MIPS</Filter>
+    </ClCompile>
+    <ClCompile Include="armips\Archs\ARM\ArmExpressionFunctions.cpp">
+      <Filter>Archs\ARM</Filter>
+    </ClCompile>
+    <ClCompile Include="armips\Archs\MIPS\MipsExpressionFunctions.cpp">
+      <Filter>Archs\MIPS</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="armips\Archs\Architecture.h">
@@ -172,9 +181,6 @@
       <Filter>Archs\ARM</Filter>
     </ClInclude>
     <ClInclude Include="armips\Archs\ARM\ArmOpcodes.h">
-      <Filter>Archs\ARM</Filter>
-    </ClInclude>
-    <ClInclude Include="armips\Archs\ARM\ArmRelocator.h">
       <Filter>Archs\ARM</Filter>
     </ClInclude>
     <ClInclude Include="armips\Archs\ARM\CArmInstruction.h">
@@ -300,6 +306,18 @@
     </ClInclude>
     <ClInclude Include="armips\Core\ExpressionFunctions.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="armips\Archs\ARM\ArmElfRelocator.h">
+      <Filter>Archs\ARM</Filter>
+    </ClInclude>
+    <ClInclude Include="armips\Archs\MIPS\MipsElfRelocator.h">
+      <Filter>Archs\MIPS</Filter>
+    </ClInclude>
+    <ClInclude Include="armips\Archs\ARM\ArmExpressionFunctions.h">
+      <Filter>Archs\ARM</Filter>
+    </ClInclude>
+    <ClInclude Include="armips\Archs\MIPS\MipsExpressionFunctions.h">
+      <Filter>Archs\MIPS</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ext/native/ext/jpge/jpgd.cpp
+++ b/ext/native/ext/jpge/jpgd.cpp
@@ -563,7 +563,7 @@ inline int jpeg_decoder::huff_decode(huff_tables *pH, int& extra_bits)
 
 // Tables and macro used to fully decode the DPCM differences.
 static const int s_extend_test[16] = { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
-static const int s_extend_offset[16] = { 0, ((-1)<<1) + 1, ((-1)<<2) + 1, ((-1)<<3) + 1, ((-1)<<4) + 1, ((-1)<<5) + 1, ((-1)<<6) + 1, ((-1)<<7) + 1, ((-1)<<8) + 1, ((-1)<<9) + 1, ((-1)<<10) + 1, ((-1)<<11) + 1, ((-1)<<12) + 1, ((-1)<<13) + 1, ((-1)<<14) + 1, ((-1)<<15) + 1 };
+static const int s_extend_offset[16] = { 0, -(1<<1) + 1, -(1<<2) + 1, -(1<<3) + 1, -(1<<4) + 1, -(1<<5) + 1, -(1<<6) + 1, -(1<<7) + 1, -(1<<8) + 1, -(1<<9) + 1, -(1<<10) + 1, -(1<<11) + 1, -(1<<12) + 1, -(1<<13) + 1, -(1<<14) + 1, -(1<<15) + 1 };
 //static const int s_extend_mask[] = { 0, (1<<0), (1<<1), (1<<2), (1<<3), (1<<4), (1<<5), (1<<6), (1<<7), (1<<8), (1<<9), (1<<10), (1<<11), (1<<12), (1<<13), (1<<14), (1<<15), (1<<16) };
 // The logical AND's in this macro are to shut up static code analysis (aren't really necessary - couldn't find another way to do this)
 #define JPGD_HUFF_EXTEND(x, s) (((x) < s_extend_test[s & 15]) ? ((x) + s_extend_offset[s & 15]) : (x))

--- a/ext/native/ext/rg_etc1/rg_etc1.cpp
+++ b/ext/native/ext/rg_etc1/rg_etc1.cpp
@@ -1805,7 +1805,7 @@ namespace rg_etc1
          {
             if (block_inten[0] > m_pSorted_luma[n - 1])
             {
-               const uint min_error = (uint)(labs(block_inten[0] - m_pSorted_luma[n - 1]));
+               const uint min_error = (uint)(labs((int)block_inten[0] - (int)m_pSorted_luma[n - 1]));
                if (min_error >= trial_solution.m_error)
                   continue;
             }
@@ -1819,7 +1819,7 @@ namespace rg_etc1
          {
             if (m_pSorted_luma[0] > block_inten[3])
             {
-               const uint min_error = (uint)(labs(m_pSorted_luma[0] - block_inten[3]));
+               const uint min_error = (uint)(labs((int)m_pSorted_luma[0] - (int)block_inten[3]));
                if (min_error >= trial_solution.m_error)
                   continue;
             }

--- a/ext/udis86/syn.c
+++ b/ext/udis86/syn.c
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <inttypes.h>
 #include "types.h"
 #include "decode.h"
 #include "syn.h"
@@ -137,14 +138,14 @@ ud_syn_print_addr(struct ud *u, uint64_t addr)
     name = u->sym_resolver(u, addr, &offset);
     if (name) {
       if (offset) {
-        ud_asmprintf(u, "%s%+" FMT64 "d", name, offset);
+        ud_asmprintf(u, "%s%+" PRId64, name, offset);
       } else {
         ud_asmprintf(u, "%s", name);
       }
       return;
     }
   }
-  ud_asmprintf(u, "0x%" FMT64 "x", addr);
+  ud_asmprintf(u, "0x%" PRIx64, addr);
 }
 
 
@@ -171,7 +172,7 @@ ud_syn_print_imm(struct ud* u, const struct ud_operand *op)
     default: UD_ASSERT(!"invalid offset"); v = 0; /* keep cc happy */
     }
   }
-  ud_asmprintf(u, "0x%" FMT64 "x", v);
+  ud_asmprintf(u, "0x%" PRIx64, v);
 }
 
 uint64_t
@@ -193,7 +194,7 @@ ud_syn_print_mem_disp(struct ud* u, const struct ud_operand *op, int sign)
     case 64: v = op->lval.uqword; break;
     default: UD_ASSERT(!"invalid offset"); v = 0; /* keep cc happy */
     }
-    ud_asmprintf(u, "0x%" FMT64 "x", v);
+    ud_asmprintf(u, "0x%" PRIx64, v);
   } else {
     int64_t v;
     UD_ASSERT(op->offset != 64);
@@ -206,9 +207,9 @@ ud_syn_print_mem_disp(struct ud* u, const struct ud_operand *op, int sign)
     if (op->base == UD_R_RIP) {
       ud_syn_print_addr(u, ud_syn_rip_target(u, op));
     } else if (v < 0) {
-      ud_asmprintf(u, "-0x%" FMT64 "x", -v);
+      ud_asmprintf(u, "-0x%" PRIx64, -v);
     } else if (v > 0) {
-      ud_asmprintf(u, "%s0x%" FMT64 "x", sign? "+" : "", v);
+      ud_asmprintf(u, "%s0x%" PRIx64, sign? "+" : "", v);
     }
   }
 }

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -71,7 +71,9 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
 		FILE *bmp = File::OpenCFile(comparisonScreenshot_, "rb");
 		if (bmp)
 		{
-			fread(&header, sizeof(header), 1, bmp);
+			if (fread(&header, sizeof(header), 1, bmp) != 1) {
+				SendOrCollectDebugOutput("Failed to read original screenshot header.\n");
+			}
 			fclose(bmp);
 		}
 


### PR DESCRIPTION
This cuts down on a bunch of warnings.  There were especially a lot since including armips in the Android build from tinyformat.

-[Unknown]