### PR TITLE
Correct stencil upload bugs

### DIFF
--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -86,10 +86,13 @@ struct VirtualFramebuffer {
 	// width/height: The detected size of the current framebuffer.
 	u16 width;
 	u16 height;
-	// renderWidth/renderHeight: The actual size we render at. May be scaled to render at higher resolutions.
+	// renderWidth/renderHeight: The scaled size we render at. May be scaled to render at higher resolutions.
+	// The physical buffer may be larger than renderWidth/renderHeight.
 	u16 renderWidth;
 	u16 renderHeight;
-	// bufferWidth/bufferHeight: The actual (but non scaled) size of the buffer we render to. May only be bigger than width/height.
+	// bufferWidth/bufferHeight: The pre-scaling size of the buffer itself. May only be bigger than width/height.
+	// Actual physical buffer is this size times the render resolution multiplier.
+	// The buffer may be used to render a width or height from 0 to these values without being recreated.
 	u16 bufferWidth;
 	u16 bufferHeight;
 

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -126,12 +126,15 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 		std::vector<GLRShader *> shaders;
 		shaders.push_back(render_->CreateShader(GL_VERTEX_SHADER, vs_code, "stencil"));
 		shaders.push_back(render_->CreateShader(GL_FRAGMENT_SHADER, fs_code, "stencil"));
+		std::vector<GLRProgram::Semantic> semantics;
+		semantics.push_back({ 0, "a_position" });
+		semantics.push_back({ 1, "a_texcoord0" });
 		std::vector<GLRProgram::UniformLocQuery> queries;
 		queries.push_back({ &u_stencilUploadTex, "tex" });
 		queries.push_back({ &u_stencilValue, "u_stencilValue" });
 		std::vector<GLRProgram::Initializer> inits;
 		inits.push_back({ &u_stencilUploadTex, 0, 0 });
-		stencilUploadProgram_ = render_->CreateProgram(shaders, {}, queries, inits, false);
+		stencilUploadProgram_ = render_->CreateProgram(shaders, semantics, queries, inits, false);
 		for (auto iter : shaders) {
 			render_->DeleteShader(iter);
 		}

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -27,6 +27,8 @@
 #include "GPU/Vulkan/TextureCacheVulkan.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
+// This shader references gl_FragDepth to prevent early fragment tests.
+// They shouldn't happen since it uses discard, but Adreno detects that incorrectly - see #10634.
 static const char *stencil_fs = R"(#version 450
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
@@ -38,6 +40,8 @@ layout (location = 0) in vec2 v_texcoord0;
 layout (location = 0) out vec4 fragColor0;
 
 void main() {
+	gl_FragDepth = 0.0;
+
 	if (u_stencilValue == 0) {
 		fragColor0 = vec4(0.0);
 	} else {


### PR DESCRIPTION
GLES was missing the semantic definitions.  I guess it was just using the last ones on desktop or something.  Now it works fine on mobile again.

Vulkan definitely looks like a driver bug, and it's a bug that could easily be affecting regular rendering too.  I didn't test extensively but at least this case is affected:
 * Stencil testing is enabled, thus stencil is being written.
 * Alpha or color testing is enabled, and `discard;` is used in the shader.

I suppose we could statically write to depth (Adreno only?) whenever we also generate a `discard`. (EDIT by hrydgard: a commit for this has now been added)

If we bother detecting that case, we might put `layout(early_fragment_tests) in;` for GL4.2+/Vulkan/GLES3.1+?  It might clarify some case with hardware tessellation or direct depal, etc.

Fixes #10634.

-[Unknown]