### PR TITLE
Android: Allow using OpenGL 4.x with javaGL disabled

### DIFF
--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -25,15 +25,10 @@
 #include "GPU/GLES/TextureCacheGLES.h"
 #include "GPU/Common/DepalettizeShaderCommon.h"
 
-#ifdef _WIN32
-#define SHADERLOG
-#endif
-
 static const char *depalVShader100 =
-#ifdef USING_GLES2
-"#version 100\n"
+"#ifdef GL_ES\n"
 "precision highp float;\n"
-#endif
+"#endif\n"
 "attribute vec4 a_position;\n"
 "attribute vec2 a_texcoord0;\n"
 "varying vec2 v_texcoord0;\n"
@@ -43,12 +38,9 @@ static const char *depalVShader100 =
 "}\n";
 
 static const char *depalVShader300 =
-#ifdef USING_GLES2
-"#version 300 es\n"
+"#ifdef GL_ES\n"
 "precision highp float;\n"
-#else
-"#version 330\n"
-#endif
+"#endif\n"
 "in vec4 a_position;\n"
 "in vec2 a_texcoord0;\n"
 "out vec2 v_texcoord0;\n"
@@ -76,7 +68,13 @@ void DepalShaderCacheGLES::DeviceRestore(Draw::DrawContext *draw) {
 
 bool DepalShaderCacheGLES::CreateVertexShader() {
 	std::string src(useGL3_ ? depalVShader300 : depalVShader100);
-	vertexShader_ = render_->CreateShader(GL_VERTEX_SHADER, src, "depal");
+	std::string prelude;
+	if (gl_extensions.IsGLES) {
+		prelude = useGL3_ ? "#version 300 es\n" : "#version 100\n";
+	} else if (useGL3_) {
+		prelude = "#version 330\n";
+	}
+	vertexShader_ = render_->CreateShader(GL_VERTEX_SHADER, prelude + src, "depal");
 	return true;
 }
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -54,9 +54,9 @@ static const char tex_fs[] =
 	"#define gl_FragColor fragColor0\n"
 	"out vec4 fragColor0;\n"
 	"#endif\n"
-#ifdef USING_GLES2
+	"#ifdef GL_ES\n"
 	"precision mediump float;\n"
-#endif
+	"#endif\n"
 	"uniform sampler2D sampler0;\n"
 	"varying vec2 v_texcoord0;\n"
 	"void main() {\n"

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -55,9 +55,7 @@ static const char tex_fs[] =
 	"}\n";
 
 static const char basic_vs[] =
-#ifndef USING_GLES2
 	"#version 120\n"
-#endif
 	"attribute vec4 a_position;\n"
 	"attribute vec2 a_texcoord0;\n"
 	"uniform mat4 u_viewproj;\n"

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -36,9 +36,7 @@ static const char preview_fs[] =
 	"}\n";
 
 static const char preview_vs[] =
-#ifndef USING_GLES2
 	"#version 120\n"
-#endif
 	"attribute vec4 a_position;\n"
 	"uniform mat4 u_viewproj;\n"
 	"void main() {\n"

--- a/android/jni/AndroidEGLContext.cpp
+++ b/android/jni/AndroidEGLContext.cpp
@@ -22,7 +22,7 @@ bool AndroidEGLGraphicsContext::InitFromRenderThread(ANativeWindow *wnd, int des
 
 	// Apparently we still have to set this through Java through setFixedSize on the bufferHolder for it to take effect...
 	gl->SetBackBufferDimensions(backbufferWidth, backbufferHeight);
-	gl->SetMode(MODE_DETECT_ES);
+	gl->SetMode(MODE_DETECT);
 
 	bool use565 = false;
 
@@ -44,6 +44,8 @@ bool AndroidEGLGraphicsContext::InitFromRenderThread(ANativeWindow *wnd, int des
 		return false;
 	}
 	gl->MakeCurrent();
+	if (gl->GetMode() == GLInterfaceMode::MODE_OPENGL)
+		SetGLCoreContext(true);
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
 	SetGPUBackend(GPUBackend::OPENGL);

--- a/android/jni/AndroidEGLContext.cpp
+++ b/android/jni/AndroidEGLContext.cpp
@@ -47,15 +47,21 @@ bool AndroidEGLGraphicsContext::InitFromRenderThread(ANativeWindow *wnd, int des
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
 	SetGPUBackend(GPUBackend::OPENGL);
+	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	bool success = draw_->CreatePresets();  // There will always be a GLSL compiler capable of compiling these.
 	assert(success);
 	return true;
 }
 
-void AndroidEGLGraphicsContext::Shutdown() {
+void AndroidEGLGraphicsContext::ShutdownFromRenderThread() {
+	ILOG("AndroidEGLGraphicsContext::Shutdown");
+	renderManager_->WaitUntilQueueIdle();
+	renderManager_ = nullptr;  // owned by draw_.
 	delete draw_;
 	draw_ = nullptr;
-	NativeShutdownGraphics();
+}
+
+void AndroidEGLGraphicsContext::Shutdown() {
 	gl->ClearCurrent();
 	gl->Shutdown();
 	delete gl;

--- a/android/jni/AndroidEGLContext.h
+++ b/android/jni/AndroidEGLContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "thin3d/GLRenderManager.h"
 #include "AndroidGraphicsContext.h"
 #include "Common/GL/GLInterfaceBase.h"
 
@@ -7,6 +8,7 @@ class AndroidEGLGraphicsContext : public AndroidGraphicsContext {
 public:
 	AndroidEGLGraphicsContext() : draw_(nullptr), wnd_(nullptr), gl(nullptr) {}
 	bool InitFromRenderThread(ANativeWindow *wnd, int desiredBackbufferSizeX, int desiredBackbufferSizeY, int backbufferFormat, int androidVersion) override;
+	void ShutdownFromRenderThread() override;
 	void Shutdown() override;
 	void SwapBuffers() override;
 	void SwapInterval(int interval) override {}
@@ -18,8 +20,26 @@ public:
 		return draw_ != nullptr;
 	}
 
+	void ThreadStart() override {
+		renderManager_->ThreadStart();
+	}
+
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
+	}
+
+	void ThreadEnd() override {
+		renderManager_->ThreadEnd();
+	}
+
+	void StopThread() override {
+		renderManager_->WaitUntilQueueIdle();
+		renderManager_->StopThread();
+	}
+
 private:
 	Draw::DrawContext *draw_;
 	ANativeWindow *wnd_;
 	cInterfaceBase *gl;
+	GLRenderManager *renderManager_ = nullptr;
 };

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -116,7 +116,7 @@ void CheckGLExtensions() {
 	gl_extensions.IsCoreContext = useCoreContext;
 
 #ifdef USING_GLES2
-	gl_extensions.IsGLES = true;
+	gl_extensions.IsGLES = !useCoreContext;
 #endif
 
 	const char *renderer = (const char *)glGetString(GL_RENDERER);
@@ -201,6 +201,10 @@ void CheckGLExtensions() {
 		// Most of it could be enabled on lower GPUs as well, but let's start this way.
 		if (gl_extensions.VersionGEThan(4, 3, 0)) {
 			gl_extensions.GLES3 = true;
+#ifdef USING_GLES2
+			// Try to load up the other funcs if we're not using glew.
+			gl3stubInit();
+#endif
 		}
 	} else {
 		// Start by assuming we're at 2.0.

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -347,11 +347,10 @@ public:
 		return caps_;
 	}
 	uint32_t GetSupportedShaderLanguages() const override {
-#if defined(USING_GLES2)
-		return (uint32_t)ShaderLanguage::GLSL_ES_200 | (uint32_t)ShaderLanguage::GLSL_ES_300;
-#else
-		return (uint32_t)ShaderLanguage::GLSL_ES_200 | (uint32_t)ShaderLanguage::GLSL_410;
-#endif
+		if (gl_extensions.IsGLES)
+			return (uint32_t)ShaderLanguage::GLSL_ES_200 | (uint32_t)ShaderLanguage::GLSL_ES_300;
+		else
+			return (uint32_t)ShaderLanguage::GLSL_ES_200 | (uint32_t)ShaderLanguage::GLSL_410;
 	}
 	uint32_t GetDataFormatSupport(DataFormat fmt) const override;
 
@@ -1163,11 +1162,8 @@ uint32_t OpenGLContext::GetDataFormatSupport(DataFormat fmt) const {
 	case DataFormat::B4G4R4A4_UNORM_PACK16:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_AUTOGEN_MIPS;  // native support
 	case DataFormat::A4R4G4B4_UNORM_PACK16:
-#ifndef USING_GLES2
 		// Can support this if _REV formats are supported.
-		return FMT_TEXTURE;
-#endif
-		return 0;
+		return gl_extensions.IsGLES ? 0 : FMT_TEXTURE;
 
 	case DataFormat::R8G8B8A8_UNORM:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_INPUTLAYOUT | FMT_AUTOGEN_MIPS;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -350,11 +350,7 @@ int main(int argc, const char* argv[])
 	g_Config.bAutoSaveSymbolMap = false;
 	g_Config.iRenderingMode = 1;
 	g_Config.bHardwareTransform = true;
-#ifdef USING_GLES2
-	g_Config.iAnisotropyLevel = 0;
-#else
 	g_Config.iAnisotropyLevel = 0;  // When testing mipmapping we really don't want this.
-#endif
 	g_Config.bVertexCache = true;
 	g_Config.bTrueColor = true;
 	g_Config.iLanguage = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;


### PR DESCRIPTION
Currently, this does **not** disable Java EGL, it just makes the non-Java path work again and able to run desktop OpenGL (e.g. runs on the SHIELD just fine.)

I think we could try the C++ EGL path again with the EGL heuristics from the SDL path (ideally combining them - SDL should possibly just use the EGL interface classes, but might need some tweaks for core vs compat detection.)

Unfortunately, I don't have the devices that were broken by that change to test.  I think it's very possible they were alpha compositing issues, but can't be sure.

Anyway - to test this on a SHIELD, just apply this change:

```diff
diff --git a/UI/NativeApp.cpp b/UI/NativeApp.cpp
index 2d9326969..d6f2e277f 100644
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -242,7 +242,7 @@ std::string NativeQueryConfig(std::string query) {
       return "false";
     }
     // Otherwise, some devices prefer the Java init so play it safe.
-    return "true";
+    return "false";
   } else if (query == "sustainedPerformanceMode") {
     return std::string(g_Config.bSustainedPerformanceMode ? "1" : "0");
   } else {
```

-[Unknown]