### PR TITLE
Vulkan: Workaround Adreno discard bug

### DIFF
--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -32,15 +32,17 @@
 static const char *stencil_fs = R"(#version 450
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
+#extension GL_ARB_conservative_depth : enable
+layout (depth_unchanged) out float gl_FragDepth;
 layout (binding = 0) uniform sampler2D tex;
-layout(push_constant) uniform params {
+layout (push_constant) uniform params {
 	int u_stencilValue;
 };
 layout (location = 0) in vec2 v_texcoord0;
 layout (location = 0) out vec4 fragColor0;
 
 void main() {
-	gl_FragDepth = 0.0;
+	gl_FragDepth = gl_FragCoord.z;
 
 	if (u_stencilValue == 0) {
 		fragColor0 = vec4(0.0);


### PR DESCRIPTION
Like #11192, but applied to regular fragment shaders too.  However, I did some more testing: it still works with `depth_unchanged` (ExecutionModeDepthUnchanged) specified.  I think that should prevent any performance impact over and above already using `discard`.

I updated stencil to match, although it shouldn't matter since it doesn't use depth.  Just for consistency.

At first, I planned to do this for Adreno only, but I found a MESA bug that was exactly the same.  Now I'm expecting other mobile drivers did the wrong thing too.  We can easily restrict it `gl_extensions.bugs` if we discover performance impact.

On the topic of bad drivers, the spec says (emphasis mine):

> [Vulkan - 25.4](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#fragops-early-mode)
> The depth bounds test, stencil test, depth test, and occlusion query sample counting are performed before fragment shading **if and only if** early fragment tests are enabled by the fragment shader (see [Early Fragment Tests](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#shaders-fragment-earlytest)).

I realize this probably only specifies *apparent* behavior, but I figured it can't hurt to assert early_fragment_tests since we're detecting the opposite anyway.

-[Unknown]