### PR TITLE
Added "oldest save" and "slots 1-5" as options for "auto load savestate"

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -398,7 +398,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("ForceLagSync", &g_Config.bForceLagSync, false, true, true),
 
 	ReportedConfigSetting("NumWorkerThreads", &g_Config.iNumWorkerThreads, &DefaultNumWorkers, true, true),
-	ConfigSetting("EnableAutoLoad", &g_Config.bEnableAutoLoad, false, true, true),
+	ConfigSetting("AutoLoadSaveState", &g_Config.iAutoLoadSaveState, 0, true, true),
 	ReportedConfigSetting("EnableCheats", &g_Config.bEnableCheats, false, true, true),
 	ConfigSetting("CwCheatRefreshRate", &g_Config.iCwCheatRefreshRate, 77, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -175,7 +175,7 @@ public:
 	int iCurrentStateSlot;
 	int iRewindFlipFrequency;
 	bool bEnableStateUndo;
-	bool bEnableAutoLoad;
+	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, >2 = slot number + 3
 	bool bEnableCheats;
 	bool bReloadCheats;
 	int iCwCheatRefreshRate;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -71,3 +71,9 @@ enum class SmallDisplayZoom {
 	AUTO = 2,
 	MANUAL = 3,
 };
+
+enum AutoLoadSaveState {
+	OFF = 0,
+	OLDEST = 1,
+	NEWEST = 2,
+};

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -72,7 +72,7 @@ enum class SmallDisplayZoom {
 	MANUAL = 3,
 };
 
-enum AutoLoadSaveState {
+enum class AutoLoadSaveState {
 	OFF = 0,
 	OLDEST = 1,
 	NEWEST = 2,

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -550,6 +550,27 @@ namespace SaveState
 		return false;
 	}
 
+	bool operator > (const tm &t1, const tm &t2) {
+		if (t1.tm_year > t2.tm_year) return true;
+		if (t1.tm_year < t2.tm_year) return false;
+		if (t1.tm_mon > t2.tm_mon) return true;
+		if (t1.tm_mon < t2.tm_mon) return false;
+		if (t1.tm_mday > t2.tm_mday) return true;
+		if (t1.tm_mday < t2.tm_mday) return false;
+		if (t1.tm_hour > t2.tm_hour) return true;
+		if (t1.tm_hour < t2.tm_hour) return false;
+		if (t1.tm_min > t2.tm_min) return true;
+		if (t1.tm_min < t2.tm_min) return false;
+		if (t1.tm_sec > t2.tm_sec) return true;
+		if (t1.tm_sec < t2.tm_sec) return false;
+		return false;
+	}
+
+	bool operator ! (const tm &t1) {
+		if (t1.tm_year || t1.tm_mon || t1.tm_mday || t1.tm_hour || t1.tm_min || t1.tm_sec) return false;
+		return true;
+	}
+
 	int GetNewestSlot(const std::string &gameFilename) {
 		int newestSlot = -1;
 		tm newestDate = {0};
@@ -565,6 +586,23 @@ namespace SaveState
 			}
 		}
 		return newestSlot;
+	}
+
+	int GetOldestSlot(const std::string &gameFilename) {
+		int oldestSlot = -1;
+		tm oldestDate = {0};
+		for (int i = 0; i < NUM_SLOTS; i++) {
+			std::string fn = GenerateSaveSlotFilename(gameFilename, i, STATE_EXTENSION);
+			if (File::Exists(fn)) {
+				tm time;
+				bool success = File::GetModifTime(fn, time);
+				if (success && (!oldestDate || oldestDate > time)) {
+					oldestDate = time;
+					oldestSlot = i;
+				}
+			}
+		}
+		return oldestSlot;
 	}
 
 	std::string GetSlotDateAsString(const std::string &gameFilename, int slot) {

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -51,9 +51,10 @@ namespace SaveState
 
 	int GetCurrentSlot();
 
-	// Returns -1 if there's no newest slot.
+	// Returns -1 if there's no oldest/newest slot.
 	int GetNewestSlot(const std::string &gameFilename);
-
+	int GetOldestSlot(const std::string &gameFilename);
+	
 	std::string GetSlotDateAsString(const std::string &gameFilename, int slot);
 	std::string GenerateSaveSlotFilename(const std::string &gameFilename, int slot, const char *extension);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1337,11 +1337,26 @@ void EmuScreen::renderUI() {
 }
 
 void EmuScreen::autoLoad() {
+	int autoSlot = -1;
+
 	//check if save state has save, if so, load
-	int lastSlot = SaveState::GetNewestSlot(gamePath_);
-	if (g_Config.bEnableAutoLoad && lastSlot != -1) {
-		SaveState::LoadSlot(gamePath_, lastSlot, &AfterSaveStateAction);
-		g_Config.iCurrentStateSlot = lastSlot;
+	switch (g_Config.iAutoLoadSaveState) {
+	case AutoLoadSaveState::OFF: // "AutoLoad Off"
+		return;
+	case AutoLoadSaveState::OLDEST: // "Oldest Save"
+		autoSlot = SaveState::GetOldestSlot(gamePath_);
+		break;
+	case AutoLoadSaveState::NEWEST: // "Newest Save"
+		autoSlot = SaveState::GetNewestSlot(gamePath_);
+		break;
+	default: // try the specific save state slot specified
+		autoSlot = (SaveState::HasSaveInSlot(gamePath_, g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
+		break;
+	}
+
+	if (g_Config.iAutoLoadSaveState && autoSlot != -1) {
+		SaveState::LoadSlot(gamePath_, autoSlot, &AfterSaveStateAction);
+		g_Config.iCurrentStateSlot = autoSlot;
 	}
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1341,12 +1341,12 @@ void EmuScreen::autoLoad() {
 
 	//check if save state has save, if so, load
 	switch (g_Config.iAutoLoadSaveState) {
-	case AutoLoadSaveState::OFF: // "AutoLoad Off"
+	case (int)AutoLoadSaveState::OFF: // "AutoLoad Off"
 		return;
-	case AutoLoadSaveState::OLDEST: // "Oldest Save"
+	case (int)AutoLoadSaveState::OLDEST: // "Oldest Save"
 		autoSlot = SaveState::GetOldestSlot(gamePath_);
 		break;
-	case AutoLoadSaveState::NEWEST: // "Newest Save"
+	case (int)AutoLoadSaveState::NEWEST: // "Newest Save"
 		autoSlot = SaveState::GetNewestSlot(gamePath_);
 		break;
 	default: // try the specific save state slot specified

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -734,8 +734,8 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
-	systemSettings->Add(new CheckBox(&g_Config.bEnableAutoLoad, sy->T("Auto Load Newest Savestate")));
-
+	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), sy->GetName(), screenManager()));
 #if defined(USING_WIN_UI)
 	systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Enable Windows native keyboard", "Enable Windows native keyboard")));
 #endif


### PR DESCRIPTION
This adds some functionality to Auto Load Savestate.  Previously it toggled on/off auto-loading of the newest savestate.
Now there is a choice of newest, oldest or a fixed slot number.
In other emulators I often use an oldest savestate that takes you straight to the main menu "press start" type of screen, to cut down on loading times as my default (good for guests too).  The option of a set slot number just gave some additional flexibility whilst I was there.

In `UI/EmuScreen.cpp` I've used a switch/case and a ternary operator.  I've tried a version that uses if/else instead but couldn't decide which was preferable for readability.  I look forward to your guidance there.