### PR TITLE
Reset CPU mhz on PPSSPP reset

### DIFF
--- a/Common/ChunkFile.cpp
+++ b/Common/ChunkFile.cpp
@@ -300,7 +300,7 @@ CChunkFileReader::Error CChunkFileReader::SaveFile(const std::string &filename, 
 	}
 
 	// Create header
-	SChunkHeader header;
+	SChunkHeader header{};
 	header.Compress = compressed_buffer ? 1 : 0;
 	header.Revision = REVISION_CURRENT;
 	header.ExpectedSize = (u32)write_len;
@@ -308,7 +308,7 @@ CChunkFileReader::Error CChunkFileReader::SaveFile(const std::string &filename, 
 	truncate_cpy(header.GitVersion, gitVersion);
 
 	// Setup the fixed-length title.
-	char titleFixed[128];
+	char titleFixed[128]{};
 	truncate_cpy(titleFixed, title.c_str());
 
 	// Now let's start writing out the file...

--- a/Common/FixedSizeQueue.h
+++ b/Common/FixedSizeQueue.h
@@ -46,6 +46,8 @@ public:
 		head_ = 0;
 		tail_ = 0;
 		count_ = 0;
+		// Not entirely necessary, but keeps things clean.
+		memset(storage_, 0, sizeof(T) * N);
 	}
 
 	void push(T t) {

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -34,6 +34,7 @@
 #include "Core/Reporting.h"
 #include "Common/ChunkFile.h"
 
+static const int initialHz = 222000000;
 int CPU_HZ = 222000000;
 
 // is this really necessary?
@@ -211,6 +212,7 @@ void Init()
 	lastGlobalTimeUs = 0;
 	hasTsEvents = 0;
 	mhzChangeCallbacks.clear();
+	CPU_HZ = initialHz;
 }
 
 void Shutdown()

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -160,6 +160,7 @@ void __AudioDoState(PointerWrap &p) {
 
 	p.Do(mixFrequency);
 
+	// TODO: This never happens because maxVer=1.
 	if (s >= 2) {
 		resampler.DoState(p);
 	} else {

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -317,6 +317,7 @@ void InterruptState::restore()
 
 void InterruptState::clear()
 {
+	savedCpu.reset();
 }
 
 // http://forums.ps2dev.org/viewtopic.php?t=5687

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -544,7 +544,7 @@ public:
 		p.Do(currentMipscallId);
 		p.Do(currentCallbackId);
 
-		// TODO: How do I "version" adding a DoState method to ThreadContext?
+		// TODO: If we want to "version" a DoState method here, we can just use minVer = 0.
 		p.Do(context);
 
 		if (s <= 3)
@@ -1824,6 +1824,8 @@ void ThreadContext::reset()
 	fcr31 = 0x00000e00;
 	hi = 0xDEADBEEF;
 	lo = 0xDEADBEEF;
+	// Just for a clean state.
+	other[5] = 0;
 }
 
 void __KernelResetThread(Thread *t, int lowestPriority)

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -111,21 +111,21 @@ public:
 
 private:
 	s16 samples[28];
-	int curSample;
+	int curSample = 0;
 
-	u32 data_;
-	u32 read_;
-	int curBlock_;
-	int loopStartBlock_;
-	int numBlocks_;
+	u32 data_ = 0;
+	u32 read_ = 0;
+	int curBlock_ = -1;
+	int loopStartBlock_ = -1;
+	int numBlocks_ = 0;
 
 	// rolling state. start at 0, should probably reset to 0 on loops?
-	int s_1;
-	int s_2;
+	int s_1 = 0;
+	int s_2 = 0;
 
-	bool loopEnabled_;
-	bool loopAtNextBlock_;
-	bool end_;
+	bool loopEnabled_ = false;
+	bool loopAtNextBlock_ = false;
+	bool end_ = false;
 };
 
 class SasAtrac3 {

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -501,5 +501,10 @@ void BlockAllocator::Block::DoState(PointerWrap &p)
 	p.Do(start);
 	p.Do(size);
 	p.Do(taken);
+	// Since we use truncate_cpy, the empty space is not zeroed.  Zero it now.
+	// This avoids saving uninitialized memory.
+	size_t tagLen = strlen(tag);
+	if (tagLen != sizeof(tag))
+		memset(tag + tagLen, 0, sizeof(tag) - tagLen);
 	p.DoArray(tag, sizeof(tag));
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -319,8 +319,8 @@ protected:
 	DisplayList *currentList;
 	DisplayListQueue dlQueue;
 
-	bool interruptRunning;
-	GPURunState gpuState;
+	bool interruptRunning = false;
+	GPURunState gpuState = GPUSTATE_RUNNING;
 	bool isbreak;
 	u64 drawCompleteTicks;
 	u64 busyTicks;


### PR DESCRIPTION
See #5530 - turns out behavior was different after running a certain game because the mhz stuck at 333.

Also zero some memory that's saved.  Some of the tags were cleared before when we used strncpy.  These changes make it more reasonable to diff save states (also see #5530.)

This doesn't fix that bug, but at least we now understand why it behaved differently after running certain games.

-[Unknown]