### PR TITLE
UI: Interpret "unthrottle" to mean leave stepping

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -464,6 +464,9 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 
 	switch (virtualKeyCode) {
 	case VIRTKEY_UNTHROTTLE:
+		if (coreState == CORE_STEPPING) {
+			Core_EnableStepping(false);
+		}
 		PSP_CoreParameter().unthrottle = true;
 		break;
 


### PR DESCRIPTION
This is convenient sometimes.  For one, I usually have it step/not run on load - so this is a convenient way to unpause from a controller.

-[Unknown]