### PR TITLE
http: Don't crash on unclean client disconnect

### DIFF
--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -59,7 +59,9 @@ Request::~Request() {
 
 	CHECK(in_->Empty());
 	delete in_;
-	CHECK(out_->Empty());
+	if (!out_->Empty()) {
+		ELOG("Output not empty - connection abort?");
+	}
 	delete out_;
 }
 


### PR DESCRIPTION
This happens even when doing http ISO streaming.  I'd made a change to flush output when a WebSocket disconnects, but this is more bulletproof.

Otherwise the assert trips with CHECK and it segfaults.

-[Unknown]