### PR TITLE
UI: Keep rendering UI even while stepping

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -442,6 +442,10 @@ void PSP_RunLoopWhileState() {
 	// Run until CORE_NEXTFRAME
 	while (coreState == CORE_RUNNING || coreState == CORE_STEPPING) {
 		PSP_RunLoopFor(blockTicks);
+		if (coreState == CORE_STEPPING) {
+			// Keep the UI responsive.
+			break;
+		}
 	}
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1230,8 +1230,13 @@ void EmuScreen::render() {
 		// set back to running for the next frame
 		coreState = CORE_RUNNING;
 	} else if (coreState == CORE_STEPPING) {
-		// If we're stepping, it's convenient not to clear the screen.
-		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE });
+		// If we're stepping, it's convenient not to clear the screen entirely, so we copy display to output.
+		// This won't work in non-buffered, but that's fine.
+		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE });
+		// Just to make sure.
+		if (PSP_IsInited()) {
+			gpu->CopyDisplayToOutput();
+		}
 	} else {
 		// Didn't actually reach the end of the frame, ran out of the blockTicks cycles.
 		// In this case we need to bind and wipe the backbuffer, at least.


### PR DESCRIPTION
This makes it possible to "get out" on mobile by pressing unthrottle or back, and means that the device won't appear unresponsive to the OS.

It also means the on-device DevMenu etc. is still usable while stepping.

For non-buffered, it will clear the screen - but otherwise, it will ask the graphics to simply recopy the display framebuf, which I think makes sense.

-[Unknown]