### PR TITLE
Avoid some warnings, assert more on Vulkan

### DIFF
--- a/ext/native/base/logging.h
+++ b/ext/native/base/logging.h
@@ -102,7 +102,6 @@ const char *GetFn(const char *fn);
 #define ELOG(...) XLOG_IMPL("E", __VA_ARGS__)
 #define FLOG(...) do {XLOG_IMPL("F", __VA_ARGS__); Crash();} while (false)
 
-// TODO: Win32 version using OutputDebugString
 #else
 
 #include <stdio.h>

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -240,7 +240,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 		}
 		case GLRInitStepType::CREATE_INPUT_LAYOUT:
 		{
-			GLRInputLayout *layout = step.create_input_layout.inputLayout;
+			// GLRInputLayout *layout = step.create_input_layout.inputLayout;
 			// Nothing to do unless we want to create vertexbuffer objects (GL 4.5)
 			break;
 		}
@@ -537,7 +537,6 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 		glBindVertexArray(globalVAO_);
 	}
 
-	GLRFramebuffer *fb = step.render.framebuffer;
 	GLRProgram *curProgram = nullptr;
 	int activeSlot = 0;
 	glActiveTexture(GL_TEXTURE0 + activeSlot);
@@ -547,7 +546,6 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 	int colorMask = -1;
 	int depthMask = -1;
 	int depthFunc = -1;
-	int logicOp = -1;
 	GLuint curArrayBuffer = (GLuint)-1;
 	GLuint curElemArrayBuffer = (GLuint)-1;
 	bool depthEnabled = false;
@@ -555,7 +553,10 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 	bool blendEnabled = false;
 	bool cullEnabled = false;
 	bool ditherEnabled = false;
+#ifndef USING_GLES2
+	int logicOp = -1;
 	bool logicEnabled = false;
+#endif
 	GLuint blendEqColor = (GLuint)-1;
 	GLuint blendEqAlpha = (GLuint)-1;
 

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -578,7 +578,7 @@ void GLRenderManager::WaitUntilQueueIdle() {
 
 GLPushBuffer::GLPushBuffer(GLRenderManager *render, GLuint target, size_t size) : render_(render), target_(target), size_(size) {
 	bool res = AddBuffer();
-	assert(res);
+	_assert_(res);
 }
 
 GLPushBuffer::~GLPushBuffer() {
@@ -720,7 +720,7 @@ void GLPushBuffer::Defragment() {
 
 	size_ = newSize;
 	bool res = AddBuffer();
-	assert(res);
+	_assert_(res);
 }
 
 size_t GLPushBuffer::GetTotalSize() const {

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -14,9 +14,11 @@
 #endif
 
 static std::thread::id renderThreadId;
+#if MAX_LOGLEVEL >= DEBUG_LEVEL
 static bool OnRenderThread() {
 	return std::this_thread::get_id() == renderThreadId;
 }
+#endif
 
 // Runs on the GPU thread.
 void GLDeleter::Perform(GLRenderManager *renderManager) {
@@ -698,7 +700,7 @@ void GLPushBuffer::NextBuffer(size_t minSize) {
 }
 
 void GLPushBuffer::Defragment() {
-	_dbg_assert_(G3D, std::this_thread::get_id() != renderThreadId);
+	_dbg_assert_(G3D, !OnRenderThread());
 
 	if (buffers_.size() <= 1) {
 		// Let's take this chance to jetison localMemory we don't need.

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -64,7 +64,6 @@ void VulkanQueueRunner::ResizeReadbackBuffer(VkDeviceSize requiredSize) {
 
 void VulkanQueueRunner::DestroyDeviceObjects() {
 	ILOG("VulkanQueueRunner::DestroyDeviceObjects");
-	VkDevice device = vulkan_->GetDevice();
 	vulkan_->Delete().QueueDeleteDeviceMemory(readbackMemory_);
 	vulkan_->Delete().QueueDeleteBuffer(readbackBuffer_);
 	readbackBufferSize_ = 0;
@@ -675,9 +674,8 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			barrier.subresourceRange.layerCount = 1;
 			barrier.subresourceRange.levelCount = 1;
 			barrier.image = iter.fb->color.image;
-			barrier.srcAccessMask = 0;
-			VkPipelineStageFlags srcStage;
-			VkPipelineStageFlags dstStage;
+			VkPipelineStageFlags srcStage{};
+			VkPipelineStageFlags dstStage{};
 			switch (barrier.oldLayout) {
 			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
 				barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
@@ -729,7 +727,6 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 	VKRFramebuffer *fb = step.render.framebuffer;
 
 	VkPipeline lastPipeline = VK_NULL_HANDLE;
-	VkDescriptorSet lastDescSet = VK_NULL_HANDLE;
 
 	auto &commands = step.commands;
 

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -248,7 +248,6 @@ private:
 
 	VkFramebuffer backbuffer_;
 	VkImage backbufferImage_;
-	VkFramebuffer curFramebuffer_ = VK_NULL_HANDLE;
 
 	VkRenderPass backbufferRenderPass_ = VK_NULL_HANDLE;
 	VkRenderPass framebufferRenderPass_ = VK_NULL_HANDLE;

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -91,7 +91,7 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 		break;
 	default:
 		Crash();
-		break;
+		return;
 	}
 
 	TransitionImageLayout2(cmd, img.image, 0, 1, aspects,
@@ -263,7 +263,6 @@ void VulkanRenderManager::DestroyBackbuffers() {
 	StopThread();
 	vulkan_->WaitUntilQueueIdle();
 
-	VkDevice device = vulkan_->GetDevice();
 	for (uint32_t i = 0; i < swapchainImageCount_; i++) {
 		vulkan_->Delete().QueueDeleteImageView(swapchainImages_[i].view);
 	}
@@ -289,7 +288,6 @@ VulkanRenderManager::~VulkanRenderManager() {
 	vkDestroySemaphore(device, acquireSemaphore_, nullptr);
 	vkDestroySemaphore(device, renderingCompleteSemaphore_, nullptr);
 	for (int i = 0; i < vulkan_->GetInflightFrames(); i++) {
-		VkCommandBuffer cmdBuf[2]{ frameData_[i].mainCmd, frameData_[i].initCmd };
 		vkFreeCommandBuffers(device, frameData_[i].cmdPoolInit, 1, &frameData_[i].initCmd);
 		vkFreeCommandBuffers(device, frameData_[i].cmdPoolMain, 1, &frameData_[i].mainCmd);
 		vkDestroyCommandPool(device, frameData_[i].cmdPoolInit, nullptr);
@@ -450,7 +448,7 @@ bool VulkanRenderManager::CopyFramebufferToMemorySync(VKRFramebuffer *src, int a
 
 	FlushSync();
 
-	Draw::DataFormat srcFormat;
+	Draw::DataFormat srcFormat = Draw::DataFormat::UNDEFINED;
 	if (aspectBits & VK_IMAGE_ASPECT_COLOR_BIT) {
 		if (src) {
 			switch (src->color.format) {

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -384,7 +384,7 @@ VkCommandBuffer VulkanRenderManager::GetInitCmd() {
 			VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
 		};
 		VkResult res = vkBeginCommandBuffer(frameData.initCmd, &begin);
-		assert(res == VK_SUCCESS);
+		_assert_(res == VK_SUCCESS);
 		frameData.hasInitCommands = true;
 	}
 	return frameData_[curFrame].initCmd;
@@ -1008,7 +1008,7 @@ void VulkanRenderManager::EndSyncFrame(int frame) {
 		VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
 	};
 	VkResult res = vkBeginCommandBuffer(frameData.mainCmd, &begin);
-	assert(res == VK_SUCCESS);
+	_assert_(res == VK_SUCCESS);
 
 	if (useThread_) {
 		std::unique_lock<std::mutex> lock(frameData.push_mutex);

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -260,7 +260,6 @@ private:
 	ShaderLanguage language_;
 	GLRShader *shader_ = nullptr;
 	GLuint glstage_ = 0;
-	bool ok_ = false;
 	std::string source_;  // So we can recompile in case of context loss.
 };
 
@@ -1039,8 +1038,6 @@ OpenGLInputLayout::~OpenGLInputLayout() {
 }
 
 void OpenGLInputLayout::Compile(const InputLayoutDesc &desc) {
-	int semMask = 0;
-
 	// TODO: This is only accurate if there's only one stream. But whatever, for now we
 	// never use multiple streams anyway.
 	stride = (GLsizei)desc.bindings[0].stride;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -707,7 +707,6 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 	vkTex_ = new VulkanTexture(vulkan_, alloc);
 	vkTex_->SetTag(desc.tag);
 	VkFormat vulkanFormat = DataFormatToVulkan(format_);
-	int stride = desc.width * (int)DataFormatSizeInBytes(format_);
 	int bpp = GetBpp(vulkanFormat);
 	int bytesPerPixel = bpp / 8;
 	int usageBits = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -661,7 +661,7 @@ public:
 		s.mipmapMode = desc.mipFilter == TextureFilter::LINEAR ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
 		s.maxLod = desc.maxLod;
 		VkResult res = vkCreateSampler(vulkan_->GetDevice(), &s, nullptr, &sampler_);
-		assert(VK_SUCCESS == res);
+		_assert_(VK_SUCCESS == res);
 	}
 	~VKSamplerState() {
 		vulkan_->Delete().QueueDeleteSampler(sampler_);
@@ -788,7 +788,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {
 		frame_[i].pushBuffer = new VulkanPushBuffer(vulkan_, 1024 * 1024);
 		VkResult res = vkCreateDescriptorPool(device_, &dp, nullptr, &frame_[i].descriptorPool);
-		assert(res == VK_SUCCESS);
+		_assert_(res == VK_SUCCESS);
 	}
 
 	// binding 0 - uniform data
@@ -862,7 +862,7 @@ void VKContext::BeginFrame() {
 
 	frame.descSets_.clear();
 	VkResult result = vkResetDescriptorPool(device_, frame.descriptorPool, 0);
-	assert(result == VK_SUCCESS);
+	_assert_(result == VK_SUCCESS);
 }
 
 void VKContext::WaitRenderCompletion(Framebuffer *fbo) {
@@ -903,7 +903,7 @@ VkDescriptorSet VKContext::GetOrCreateDescriptorSet(VkBuffer buf) {
 	alloc.pSetLayouts = &descriptorSetLayout_;
 	alloc.descriptorSetCount = 1;
 	VkResult res = vkAllocateDescriptorSets(device_, &alloc, &descSet);
-	assert(VK_SUCCESS == res);
+	_assert_(VK_SUCCESS == res);
 
 	VkDescriptorBufferInfo bufferDesc;
 	bufferDesc.buffer = buf;


### PR DESCRIPTION
Mostly just cleans up some warnings in the debug output.  Also converts some `assert(success);` into `_assert_(success);`.

-[Unknown]