### PR TITLE
Respect secureVersion based on tests

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -797,7 +797,7 @@ static ConfigSetting systemParamSettings[] = {
 #endif
 	ConfigSetting("WlanPowerSave", &g_Config.bWlanPowerSave, (bool) PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF, true, true),
 	ReportedConfigSetting("EncryptSave", &g_Config.bEncryptSave, true, true, true),
-	ConfigSetting("SavedataUpgrade", &g_Config.bSavedataUpgrade, false, true, false),
+	ConfigSetting("SavedataUpgradeVersion", &g_Config.bSavedataUpgrade, true, true, false),
 
 	ConfigSetting(false),
 };

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -362,6 +362,16 @@ int SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &saveD
 	if (!param) {
 		return SCE_UTILITY_SAVEDATA_ERROR_SAVE_MS_NOSPACE;
 	}
+	if (param->secureVersion > 3) {
+		ERROR_LOG_REPORT(SCEUTILITY, "Savedata version requested on save: %d", param->secureVersion);
+		return SCE_UTILITY_SAVEDATA_ERROR_SAVE_PARAM;
+	} else if (param->secureVersion != 0) {
+		if (param->secureVersion != 1 && !HasKey(param)) {
+			ERROR_LOG_REPORT(SCEUTILITY, "Savedata version with missing key on save: %d", param->secureVersion);
+			return SCE_UTILITY_SAVEDATA_ERROR_SAVE_PARAM;
+		}
+		WARN_LOG_REPORT(SCEUTILITY, "Savedata version requested on save: %d", param->secureVersion);
+	}
 
 	std::string dirPath = GetSaveFilePath(param, GetSaveDir(param, saveDirName));
 
@@ -573,7 +583,14 @@ int SavedataParam::Load(SceUtilitySavedataParam *param, const std::string &saveD
 }
 
 int SavedataParam::LoadSaveData(SceUtilitySavedataParam *param, const std::string &saveDirName, const std::string &dirPath, bool secureMode) {
-	if (param->secureVersion != 0) {
+	if (param->secureVersion > 3) {
+		ERROR_LOG_REPORT(SCEUTILITY, "Savedata version requested: %d", param->secureVersion);
+		return SCE_UTILITY_SAVEDATA_ERROR_LOAD_PARAM;
+	} else if (param->secureVersion != 0) {
+		if (param->secureVersion != 1 && !HasKey(param)) {
+			ERROR_LOG_REPORT(SCEUTILITY, "Savedata version with missing key: %d", param->secureVersion);
+			return SCE_UTILITY_SAVEDATA_ERROR_LOAD_PARAM;
+		}
 		WARN_LOG_REPORT(SCEUTILITY, "Savedata version requested: %d", param->secureVersion);
 	}
 	u8 *data_ = param->dataBuf;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -306,8 +306,8 @@ public:
 	std::string GetSaveDir(const SceUtilitySavedataParam *param, const std::string &saveDirName) const;
 	bool Delete(SceUtilitySavedataParam* param, int saveId = -1);
 	int DeleteData(SceUtilitySavedataParam* param);
-	bool Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode = true);
-	bool Load(SceUtilitySavedataParam* param, const std::string &saveDirName, int saveId = -1, bool secureMode = true);
+	int Save(SceUtilitySavedataParam* param, const std::string &saveDirName, bool secureMode = true);
+	int Load(SceUtilitySavedataParam* param, const std::string &saveDirName, int saveId = -1, bool secureMode = true);
 	int GetSizes(SceUtilitySavedataParam* param);
 	bool GetList(SceUtilitySavedataParam* param);
 	int GetFilesList(SceUtilitySavedataParam* param);
@@ -354,7 +354,7 @@ private:
 	void SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, std::string saveName);
 	void ClearFileInfo(SaveFileInfo &saveInfo, const std::string &saveName);
 
-	bool LoadSaveData(SceUtilitySavedataParam *param, const std::string &saveDirName, const std::string& dirPath, bool secureMode);
+	int LoadSaveData(SceUtilitySavedataParam *param, const std::string &saveDirName, const std::string& dirPath, bool secureMode);
 	void LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8 *saveData, int &saveSize, int prevCryptMode, bool &saveDone);
 	void LoadNotCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8 *saveData, int &saveSize);
 	void LoadSFO(SceUtilitySavedataParam *param, const std::string& dirPath);

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -253,7 +253,7 @@ struct SceUtilitySavedataParam
 
 	u8 key[16];
 
-	s32_le secureVersion;
+	u32_le secureVersion;
 	s32_le multiStatus;
 
 	// Function 11 LIST


### PR DESCRIPTION
The secureVersion values 1, 2, and 3 map to save modes 1, 3 and 5 respectively.  On SDK versions below 3.00, secureVersion 3 maps to mode 1.  The only other allowed value is 0, and versions 2 and 3 require a key.

There are some loading/saving scenarios which should fail, but I left TODOs instead of making them fail to keep things safe.

Also, this enables upgrading saves by default.  I think it will break pre 0.9.9 savedata, but it's long enough ago that CFW data and wrong secureVersion data is probably more common.

Hoping this will help #11200 and #11165, but not tested (don't have either game.)

Tests at hrydgard/pspautotests#195.

-[Unknown]