### PR TITLE
Update glslang to latest as of 2018-06-26

### DIFF
--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -242,7 +242,16 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShade
 
 	std::vector<unsigned int> spirv;
 	// Can't fail, parsing worked, "linking" worked.
-	glslang::GlslangToSpv(*program.getIntermediate(shaderStage), spirv);
+	glslang::SpvOptions options;
+	options.disableOptimizer = false;
+	options.optimizeSize = false;
+	options.generateDebugInfo = false;
+	glslang::GlslangToSpv(*program.getIntermediate(shaderStage), spirv, &options);
+
+	// For whatever reason, with our config, the above outputs an invalid SPIR-V version, 0.
+	// Patch it up so spirv-cross accepts it.
+	spirv[1] = glslang::EShTargetSpv_1_0;
+
 
 	// Alright, step 1 done. Now let's take this SPIR-V shader and output in our desired format.
 

--- a/ext/glslang-build/Android.mk
+++ b/ext/glslang-build/Android.mk
@@ -9,6 +9,7 @@ LOCAL_ARM_MODE := arm
 LOCAL_SRC_FILES := \
     ../glslang/glslang/GenericCodeGen/CodeGen.cpp \
     ../glslang/glslang/GenericCodeGen/Link.cpp \
+    ../glslang/glslang/MachineIndependent/attribute.cpp \
     ../glslang/glslang/MachineIndependent/Constant.cpp \
     ../glslang/glslang/MachineIndependent/glslang_tab.cpp \
     ../glslang/glslang/MachineIndependent/InfoSink.cpp \

--- a/ext/glslang.vcxproj
+++ b/ext/glslang.vcxproj
@@ -152,6 +152,7 @@
   <ItemGroup>
     <ClCompile Include="glslang\glslang\GenericCodeGen\CodeGen.cpp" />
     <ClCompile Include="glslang\glslang\GenericCodeGen\Link.cpp" />
+    <ClCompile Include="glslang\glslang\MachineIndependent\attribute.cpp" />
     <ClCompile Include="glslang\glslang\MachineIndependent\Constant.cpp" />
     <ClCompile Include="glslang\glslang\MachineIndependent\glslang_tab.cpp" />
     <ClCompile Include="glslang\glslang\MachineIndependent\InfoSink.cpp" />
@@ -207,6 +208,7 @@
     <ClInclude Include="glslang\glslang\Include\revision.h" />
     <ClInclude Include="glslang\glslang\Include\ShHandle.h" />
     <ClInclude Include="glslang\glslang\Include\Types.h" />
+    <ClInclude Include="glslang\glslang\MachineIndependent\attribute.h" />
     <ClInclude Include="glslang\glslang\MachineIndependent\glslang_tab.cpp.h" />
     <ClInclude Include="glslang\glslang\MachineIndependent\gl_types.h" />
     <ClInclude Include="glslang\glslang\MachineIndependent\Initialize.h" />

--- a/ext/glslang.vcxproj.filters
+++ b/ext/glslang.vcxproj.filters
@@ -137,6 +137,9 @@
     <ClCompile Include="glslang\hlsl\hlslTokenStream.cpp">
       <Filter>HLSL</Filter>
     </ClCompile>
+    <ClCompile Include="glslang\glslang\MachineIndependent\attribute.cpp">
+      <Filter>glslang</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="glslang\SPIRV\disassemble.h">
@@ -289,6 +292,9 @@
     </ClInclude>
     <ClInclude Include="glslang\hlsl\hlslTokenStream.h">
       <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\MachineIndependent\attribute.h">
+      <Filter>glslang</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Unlike the previous attempt, this does not simultaneously try to update SPIRV-Cross. That's a whole other ballgame :)

D3D11 is tagged because we use this to translate post-processing shaders, too.

Should fix #11214 - but surprisingly doesn't seem to! Will investigate.