### PR TITLE
Re-enable HW tess for flat shading, but disable in throughmode

### DIFF
--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -66,5 +66,6 @@ enum SplineQuality {
 	HIGH_QUALITY = 2,
 };
 
+bool CanUseHardwareTessellation(GEPatchPrimType prim);
 void TessellateSplinePatch(u8 *&dest, u16 *indices, int &count, const SplinePatchLocal &spatch, u32 origVertType, int maxVertices);
 void TessellateBezierPatch(u8 *&dest, u16 *&indices, int &count, int tess_u, int tess_v, const BezierPatch &patch, u32 origVertType);

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -538,7 +538,8 @@ void ShaderManagerDX9::DirtyLastShader() { // disables vertex arrays
 
 VSShader *ShaderManagerDX9::ApplyShader(int prim, u32 vertType) {
 	// Always use software for flat shading to fix the provoking index.
-	bool useHWTransform = CanUseHardwareTransform(prim) && gstate.getShadeMode() != GE_SHADE_FLAT;
+	bool tess = gstate_c.bezier || gstate_c.spline;
+	bool useHWTransform = CanUseHardwareTransform(prim) && (tess || gstate.getShadeMode() != GE_SHADE_FLAT);
 
 	VShaderID VSID;
 	if (gstate_c.IsDirty(DIRTY_VERTEXSHADER_STATE)) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -24,9 +24,10 @@
 #include "Core/HLE/sceGe.h"
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/MemMapHelpers.h"
-#include "GPU/Common/FramebufferCommon.h"
-#include "GPU/Common/TextureCacheCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/FramebufferCommon.h"
+#include "GPU/Common/SplineCommon.h"
+#include "GPU/Common/TextureCacheCommon.h"
 #include "GPU/Debugger/Record.h"
 
 const CommonCommandTableEntry commonCommandTable[] = {
@@ -1729,7 +1730,7 @@ void GPUCommon::Execute_Bezier(u32 op, u32 diff) {
 	bool computeNormals = gstate.isLightingEnabled();
 	bool patchFacing = gstate.patchfacing & 1;
 
-	if (g_Config.bHardwareTessellation && g_Config.bHardwareTransform && !g_Config.bSoftwareRendering) {
+	if (CanUseHardwareTessellation(patchPrim)) {
 		gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE);
 		gstate_c.bezier = true;
 		if (gstate_c.spline_count_u != bz_ucount) {
@@ -1793,7 +1794,7 @@ void GPUCommon::Execute_Spline(u32 op, u32 diff) {
 	bool patchFacing = gstate.patchfacing & 1;
 	u32 vertType = gstate.vertType;
 
-	if (g_Config.bHardwareTessellation && g_Config.bHardwareTransform && !g_Config.bSoftwareRendering) {
+	if (CanUseHardwareTessellation(patchPrim)) {
 		gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE);
 		gstate_c.spline = true;
 		bool countsChanged = gstate_c.spline_count_u != sp_ucount || gstate_c.spline_count_v != sp_vcount;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -578,7 +578,7 @@ void DrawEngineVulkan::DoFlush() {
 	GEPrimitiveType prim = prevPrim_;
 
 	// Always use software for flat shading to fix the provoking index.
-	bool useHWTransform = CanUseHardwareTransform(prim) && gstate.getShadeMode() != GE_SHADE_FLAT;
+	bool useHWTransform = CanUseHardwareTransform(prim) && (tess || gstate.getShadeMode() != GE_SHADE_FLAT);
 
 	VulkanVertexShader *vshader = nullptr;
 	VulkanFragmentShader *fshader = nullptr;

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -563,7 +563,7 @@ inline GEPrimitiveType PatchPrimToPrim(GEPatchPrimType type) {
 	case GE_PATCHPRIM_TRIANGLES: return GE_PRIM_TRIANGLES;
 	case GE_PATCHPRIM_LINES: return GE_PRIM_LINES;
 	case GE_PATCHPRIM_POINTS: return GE_PRIM_POINTS;
-	case GE_PATCHPRIM_UNKNOWN: default: return GE_PRIM_KEEP_PREVIOUS;  // just something
+	case GE_PATCHPRIM_UNKNOWN: default: return GE_PRIM_POINTS; // Treated as points.
 	}
 }
 


### PR DESCRIPTION
This gives a more consistent path for using HW tessellation, and also checks that we can use hardware transform - which means:

 * If we draw lines/points in software, those will fall back (see #8276.)
 * Through mode won't try to use HW tessellation (since it doesn't use HW transform.)
 * If we want to disable HW tessellation for some other case, we have a single place to check.

But it also re-enables flat shading for HW tessellation, since that wasn't intentional.

Should help #11229 - but not tested with any flat splines or beziers.

-[Unknown]