### PR TITLE
Debugger: Update to latest armips

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <algorithm>
+#include <memory>
 
 #include "util/text/utf8.h"
 #include "zlib.h"

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -3,6 +3,7 @@
 #endif
 #include <cstdarg>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -66,7 +67,6 @@ private:
 
 bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 {
-	PspAssemblerFile file;
 	StringList errors;
 
 	wchar_t str[64];
@@ -76,7 +76,7 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address)
 	args.mode = ArmipsMode::MEMORY;
 	args.content = str + ConvertUTF8ToWString(line);
 	args.silent = true;
-	args.memoryFile = &file;
+	args.memoryFile.reset(new PspAssemblerFile());
 	args.errorsResult = &errors;
 
 	if (g_symbolMap) {


### PR DESCRIPTION
Fixes #11231 (which only happens with Kingcom/armips@master.)  Looks like the API changed and smart pointers are being used more - might have fixed a memory leak.  Might as well update.

-[Unknown]