### PR TITLE
Report GLSL compile failures better, workaround depal error

### DIFF
--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -114,7 +114,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 		texturePixels = 512;
 
 	if (shift) {
-		WRITE(p, "  index = (int(uint(index) >> %i) & 0x%02x)", shift, mask);
+		WRITE(p, "  index = (int(uint(index) >> uint(%i)) & 0x%02x)", shift, mask);
 	} else {
 		WRITE(p, "  index = (index & 0x%02x)", mask);
 	}

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -164,15 +164,17 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps) {
 				std::string infoLog = GetInfoLog(program->program, glGetProgramiv, glGetProgramInfoLog);
 
 				// TODO: Could be other than vs/fs.  Also, we're assuming order here...
-				const char *vsDesc = step.create_program.shaders[0]->desc.c_str();
-				const char *fsDesc = step.create_program.num_shaders > 1 ? step.create_program.shaders[1]->desc.c_str() : nullptr;
-				const char *vsCode = step.create_program.shaders[0]->code.c_str();
-				const char *fsCode = step.create_program.num_shaders > 1 ? step.create_program.shaders[1]->code.c_str() : nullptr;
-				Reporting::ReportMessage("Error in shader program link: info: %s\nfs: %s\n%s\nvs: %s\n%s", infoLog.c_str(), fsDesc, fsCode, vsDesc, vsCode);
+				GLRShader *vs = step.create_program.shaders[0];
+				GLRShader *fs = step.create_program.num_shaders > 1 ? step.create_program.shaders[1] : nullptr;
+				std::string vsDesc = vs->desc + (vs->failed ? " (failed)" : "");
+				std::string fsDesc = fs ? (fs->desc + (fs->failed ? " (failed)" : "")) : "(none)";
+				const char *vsCode = vs->code.c_str();
+				const char *fsCode = fs ? fs->code.c_str() : "(none)";
+				Reporting::ReportMessage("Error in shader program link: info: %s\nfs: %s\n%s\nvs: %s\n%s", infoLog.c_str(), fsDesc.c_str(), fsCode, vsDesc.c_str(), vsCode);
 
 				ELOG("Could not link program:\n %s", infoLog.c_str());
-				ERROR_LOG(G3D, "VS desc:\n%s", vsDesc);
-				ERROR_LOG(G3D, "FS desc:\n%s", fsDesc);
+				ERROR_LOG(G3D, "VS desc:\n%s", vsDesc.c_str());
+				ERROR_LOG(G3D, "FS desc:\n%s", fsDesc.c_str());
 				ERROR_LOG(G3D, "VS:\n%s\n", vsCode);
 				ERROR_LOG(G3D, "FS:\n%s\n", fsCode);
 


### PR DESCRIPTION
We're seeing a number of these:

> Error in shader compilation: info: Fragment shader compilation failed. ERROR: 0:15: '>>' :  wrong operand types  no operation '>>' exists that takes a left-hand operand of type 'uint' and a right operand of type 'const int' (or there is no acceptable conversion) ERROR: 1 compilation errors.  No code generated.

Mainly on Adreno 320, but also one Intel device.  I think it's just a compiler bug, but it's a popular GPU and I think this workaround will work (not actually tested on a device producing this error.)

Also, we're getting a lot of blank reports (no info log) or reports that only say the link failed due to compile failure, but nothing about the compile failure.  So beefed up the log pull from GL a bit.

-[Unknown]