### PR TITLE
Add sceUsbAcc stubs, improves EyePet(fixes endless loop on boot)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1610,6 +1610,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/sceUmd.h
 	Core/HLE/sceUsb.cpp
 	Core/HLE/sceUsb.h
+	Core/HLE/sceUsbAcc.cpp
+	Core/HLE/sceUsbAcc.h
 	Core/HLE/sceUsbCam.cpp
 	Core/HLE/sceUsbCam.h
 	Core/HLE/sceUsbGps.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -196,6 +196,7 @@
     <ClCompile Include="Debugger\WebSocket\WebSocketUtils.cpp" />
     <ClCompile Include="FileSystems\BlobFileSystem.cpp" />
     <ClCompile Include="HLE\KUBridge.cpp" />
+    <ClCompile Include="HLE\sceUsbAcc.cpp" />
     <ClCompile Include="HLE\sceUsbCam.cpp" />
     <ClCompile Include="MIPS\IR\IRAsm.cpp" />
     <ClCompile Include="MIPS\IR\IRCompALU.cpp" />
@@ -558,6 +559,7 @@
     <ClInclude Include="FileSystems\BlobFileSystem.h" />
     <ClInclude Include="HLE\KernelThreadDebugInterface.h" />
     <ClInclude Include="HLE\KUBridge.h" />
+    <ClInclude Include="HLE\sceUsbAcc.h" />
     <ClInclude Include="HLE\sceUsbCam.h" />
     <ClInclude Include="MIPS\IR\IRFrontend.h" />
     <ClInclude Include="MIPS\IR\IRInst.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -731,6 +731,9 @@
     <ClCompile Include="Debugger\WebSocket\GPUBufferSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="HLE\sceUsbAcc.cpp">
+      <Filter>HLE\Libraries</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1354,6 +1357,9 @@
     </ClInclude>
     <ClInclude Include="ConfigValues.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="HLE\sceUsbAcc.h">
+      <Filter>HLE\Libraries</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -66,6 +66,7 @@
 #include "sceSsl.h"
 #include "sceUmd.h"
 #include "sceUsb.h"
+#include "sceUsbAcc.h"
 #include "sceUsbCam.h"
 #include "sceUsbGps.h"
 #include "sceUtility.h"
@@ -296,6 +297,7 @@ void RegisterAllModules() {
 	Register_sceNetUpnp();
 	Register_sceNetIfhandle();
 	Register_KUBridge();
+	Register_sceUsbAcc();
 
 	// add new modules here.
 }

--- a/Core/HLE/sceUsbAcc.cpp
+++ b/Core/HLE/sceUsbAcc.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceUsbAcc.h"
+
+// Assuming https://github.com/joel16/usbacc/blob/master/usbacc.c is correct
+// sceUsbAccGetAuthStat should return 0 or one of the two errors on failure
+// sceUsbAccGetInfo should return 0 or one of the 3 errors on failure
+// we don't have to deal with physical Usb connection, so let's just always pass
+
+static int sceUsbAccGetAuthStat() {
+	INFO_LOG(HLE, "UNIMPL sceUsbAccGetAuthStat");
+	return 0;
+}
+
+static int sceUsbAccGetInfo(u32 addr) {
+	INFO_LOG(HLE, "UNIMPL sceUsbAccGetInfo");
+	return 0;
+}
+
+const HLEFunction sceUsbAcc[] =
+{
+	{0X79A1C743, &WrapI_V<sceUsbAccGetAuthStat>,     "sceUsbAccGetAuthStat",                    'i', ""   },
+	{0X0CD7D4AA, &WrapI_U<sceUsbAccGetInfo>,         "sceUsbAccGetInfo",                        'i', "x" },
+};
+
+void Register_sceUsbAcc()
+{
+	RegisterModule("sceUsbAcc", ARRAY_SIZE(sceUsbAcc), sceUsbAcc);
+}

--- a/Core/HLE/sceUsbAcc.h
+++ b/Core/HLE/sceUsbAcc.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+void Register_sceUsbAcc();
+

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -385,6 +385,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/HLE/sceSsl.cpp \
   $(SRC)/Core/HLE/sceUmd.cpp \
   $(SRC)/Core/HLE/sceUsb.cpp \
+  $(SRC)/Core/HLE/sceUsbAcc.cpp \
   $(SRC)/Core/HLE/sceUsbCam.cpp \
   $(SRC)/Core/HLE/sceUsbGps.cpp \
   $(SRC)/Core/HLE/sceUtility.cpp \


### PR DESCRIPTION
fixes #10434

 Through as mentioned there, game will still most likely not be playable as it requires both cam and mic support to play.

 On PC I'm only getting "PPSSPP camera :)" image, there are also glitches when the egg of a pet shows up, but at least the introduction works, so it kind of ups the compatibility from black screen to in-game.