### PR TITLE
 UI: Delay game config/discord until game info load

### DIFF
--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -99,7 +99,7 @@ static const LogNameTableEntry logTable[] = {
 	{LogTypes::SCECTRL,    "SCECTRL"},
 	{LogTypes::SCEDISPLAY, "SCEDISP"},
 	{LogTypes::SCEFONT,    "SCEFONT"},
-	{LogTypes::SCEGE,      "SCESCEGE"},
+	{LogTypes::SCEGE,      "SCEGE"},
 	{LogTypes::SCEINTC,    "SCEINTC"},
 	{LogTypes::SCEIO,      "SCEIO"},
 	{LogTypes::SCEKERNEL,  "SCEKERNEL"},

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -189,9 +189,14 @@ void EmuScreen::bootGame(const std::string &filename) {
 
 	I18NCategory *sc = GetI18NCategory("Screen");
 
-	//pre-emptive loading of game specific config if possible, to get all the settings
+	invalid_ = true;
+
+	// We don't want to boot with the wrong game specific config, so wait until info is ready.
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, filename, 0);
-	if (info && !info->id.empty()) {
+	if (!info || info->pending)
+		return;
+
+	if (!info->id.empty()) {
 		g_Config.loadGameConfig(info->id);
 		// Reset views in case controls are in a different place.
 		RecreateViews();
@@ -200,8 +205,6 @@ void EmuScreen::bootGame(const std::string &filename) {
 	} else {
 		g_Discord.SetPresenceGame(sc->T("Untitled PSP game"));
 	}
-
-	invalid_ = true;
 
 	CoreParameter coreParam{};
 	coreParam.cpuCore = (CPUCore)g_Config.iCpuCore;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -353,8 +353,10 @@ public:
 	}
 
 	void run() override {
-		if (!info_->LoadFromPath(gamePath_))
+		if (!info_->LoadFromPath(gamePath_)) {
+			info_->pending = false;
 			return;
+		}
 		// In case of a remote file, check if it actually exists before locking.
 		if (!info_->GetFileLoader()->Exists()) {
 			info_->pending = false;
@@ -381,6 +383,7 @@ public:
 						goto handleELF;
 					}
 					ERROR_LOG(LOADER, "invalid pbp %s\n", pbpLoader->Path().c_str());
+					info_->pending = false;
 					info_->working = false;
 					return;
 				}
@@ -549,11 +552,13 @@ handleELF:
 				// few files.
 				auto fl = info_->GetFileLoader();
 				if (!fl) {
+					info_->pending = false;
 					info_->working = false;
 					return;  // Happens with UWP currently, TODO...
 				}
 				BlockDevice *bd = constructBlockDevice(info_->GetFileLoader().get());
 				if (!bd) {
+					info_->pending = false;
 					info_->working = false;
 					return;  // nothing to do here..
 				}


### PR DESCRIPTION
Only tested this lightly to make sure it doesn't break anything.  It fixes a race condition in some scenarios of game load.  It should either fix or at least help #11309 and #10835, but I didn't have time to directly test those.

Added some extra safety to make sure we don't hang in case a bad file makes its way to this stage.

-[Unknown]