### PR TITLE
GPU: Fix texture handling on framebuf detach

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -713,6 +713,9 @@ void TextureCacheCommon::DetachFramebuffer(TexCacheEntry *entry, u32 address, Vi
 		const u64 cachekey = entry->CacheKey();
 		cacheSizeEstimate_ += EstimateTexMemoryUsage(entry);
 		entry->framebuffer = nullptr;
+		// Force the hash to change in case we had one before.
+		// Otherwise we never recreate the texture.
+		entry->hash ^= 1;
 		fbTexInfo_.erase(cachekey);
 		host->GPUNotifyTextureAttachment(entry->addr);
 	}

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -345,6 +345,7 @@ bool GLRenderManager::CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspec
 }
 
 void GLRenderManager::CopyImageToMemorySync(GLRTexture *texture, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride) {
+	_assert_(texture);
 	GLRStep *step = new GLRStep{ GLRStepType::READBACK_IMAGE };
 	step->readback_image.texture = texture;
 	step->readback_image.mipLevel = mipLevel;


### PR DESCRIPTION
We were never creating/recreating the texture, so we ended up with null.  Caused all sorts of problems.

Maybe this was the cause of the null Vulkan textures?

-[Unknown]