### PR TITLE
GPU: Download safe size on next create, too

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -542,6 +542,8 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 	if (!useBufferedRendering_) {
 		// Let's ignore rendering to targets that have not (yet) been displayed.
 		gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
+	} else if (currentRenderVfb_) {
+		DownloadFramebufferOnSwitch(currentRenderVfb_);
 	}
 
 	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);


### PR DESCRIPTION
In some cases, games will create a series of framebufs for later render-to-texture (which might get decimated before then.)  Before, we weren't downloading them if they were only used once, as intended.

Before, this was only being done on `NotifyRenderFramebufferSwitched`, but that doesn't get called when switching to a NEW framebuf.

-[Unknown]