### PR TITLE
Ge: Avoid executing invalid pointers

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -353,10 +353,10 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
-	if ((int)listID >= 0)
+	if ((int)listID >= 0) {
 		listID = LIST_ID_MAGIC ^ listID;
-
-	DEBUG_LOG(SCEGE, "List %i enqueued at head.", listID);
+		DEBUG_LOG(SCEGE, "List %i enqueued at head.", listID);
+	}
 	hleEatCycles(480);
 	CoreTiming::ForceCheck();
 	return listID;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -125,8 +125,10 @@ public:
 	void Execute_Iaddr(u32 op, u32 diff);
 	void Execute_Origin(u32 op, u32 diff);
 	void Execute_Jump(u32 op, u32 diff);
+	void Execute_JumpFast(u32 op, u32 diff);
 	void Execute_BJump(u32 op, u32 diff);
 	void Execute_Call(u32 op, u32 diff);
+	void Execute_CallFast(u32 op, u32 diff);
 	void Execute_Ret(u32 op, u32 diff);
 	void Execute_End(u32 op, u32 diff);
 
@@ -287,6 +289,7 @@ protected:
 	virtual void FinishDeferred() {}
 
 	void DoBlockTransfer(u32 skipDrawReason);
+	void DoExecuteCall(u32 target);
 
 	void AdvanceVerts(u32 vertType, int count, int bytesRead) {
 		if ((vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {


### PR DESCRIPTION
This keeps the checks off when "fast memory" is enabled, which seems to logically match the setting.

It also aborts processing the rest of a list when a bad address jump is given, rather than trying to power through.  This seems much better, since we probably don't have valid GE commands after the jump (might be more likely for a CALL, but still...)

I'm going to say this fixes #3407.  We might get new errors logged, but hopefully they'll be closer to the source.  I suspect a big source was enqueue, which on a PSP I think checks some pointers, and crashes on other pointers.  Probably better to return an error.

-[Unknown]