### PR TITLE
Use a larger buffer for realpath()

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -24,6 +24,7 @@
 
 #include "ppsspp_config.h"
 
+#include <memory>
 #include "FileUtil.h"
 #include "StringUtils.h"
 
@@ -152,11 +153,12 @@ std::string ResolvePath(const std::string &path) {
 		output = output.substr(4);
 	delete [] buf;
 	return output;
+
 #else
-	char buf[PATH_MAX + 1];
-	if (realpath(path.c_str(), buf) == nullptr)
+	std::unique_ptr<char[]> buf(new char[PATH_MAX + 32768]);
+	if (realpath(path.c_str(), buf.get()) == nullptr)
 		return path;
-	return buf;
+	return buf.get();
 #endif
 }
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -48,7 +48,7 @@ bool NeedsTestDiscard() {
 		return true;
 	if (!gstate.isAlphaBlendEnabled())
 		return true;
-	if (gstate.getBlendFuncA() != GE_SRCBLEND_SRCALPHA && gstate.getBlendFuncA() != GE_DSTBLEND_DOUBLESRCALPHA)
+	if (gstate.getBlendFuncA() != GE_SRCBLEND_SRCALPHA && gstate.getBlendFuncA() != GE_SRCBLEND_DOUBLESRCALPHA)
 		return true;
 	// GE_DSTBLEND_DOUBLEINVSRCALPHA is actually inverse double src alpha, and doubling zero is still zero.
 	if (gstate.getBlendFuncB() != GE_DSTBLEND_INVSRCALPHA && gstate.getBlendFuncB() != GE_DSTBLEND_DOUBLEINVSRCALPHA) {


### PR DESCRIPTION
Maybe this will help #11328 and #11318 - since it's now on the heap and libuv uses a larger buffer too.  I decided to be very generous.

If this doesn't help, I think we'll just remove on Mac.

-[Unknown]