### PR TITLE
Allow choosing to use the system snappy or not.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(SIMULATOR "Set to ON when targeting an x86 simulator of an ARM platform" 
 option(LIBRETRO "Set to ON to generate the libretro target" OFF)
 # :: Options
 option(USE_FFMPEG "Build with FFMPEG support" ${USE_FFMPEG})
+option(USE_SYSTEM_SNAPPY "Dynamically link against system snappy" ${USE_SYSTEM_SNAPPY})
 option(USE_SYSTEM_FFMPEG "Dynamically link against system FFMPEG" ${USE_SYSTEM_FFMPEG})
 option(USE_SYSTEM_LIBZIP "Dynamically link against system libzip" ${USE_SYSTEM_LIBZIP})
 option(USE_WAYLAND_WSI "Set to ON to require Wayland support for Vulkan" ${USE_WAYLAND_WSI})

--- a/ext/snappy/CMakeLists.txt
+++ b/ext/snappy/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(Snappy)
 
-if(SNAPPY_FOUND)
+if(SNAPPY_FOUND AND USE_SYSTEM_SNAPPY)
   add_library(system_snappy INTERFACE)
   add_library(Ext::Snappy ALIAS system_snappy)
   target_link_libraries(system_snappy INTERFACE Snappy::Snappy)


### PR DESCRIPTION
I think it can be useful to configure to use the system snappy or the included static snappy. Opinions?