### PR TITLE
TexCache: Keep maxSeenV on clut variants in sync

### DIFF
--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -1166,7 +1166,7 @@ void GLQueueRunner::PerformReadbackImage(const GLRStep &pass) {
 	int pixelStride = pass.readback_image.srcRect.w;
 	glPixelStorei(GL_PACK_ALIGNMENT, 4);
 
-	GLRect2D rect = pass.readback.srcRect;
+	GLRect2D rect = pass.readback_image.srcRect;
 
 	int size = 4 * rect.w * rect.h;
 	if (size > readbackBufferSize_) {


### PR DESCRIPTION
This ensures that we detect changes properly even when they are outside the max V used with one CLUT.

Fixes #9355, enemy fade out in FF2.

-[Unknown]