### PR TITLE
Add: EGL info for GLES on Linux

### DIFF
--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -418,6 +418,15 @@ void CheckGLExtensions() {
 	} else {
 		g_all_egl_extensions = "";
 	}
+#elif defined(USING_GLES2) && defined(__linux__)
+	const char *eglString = eglQueryString(NULL, EGL_EXTENSIONS);
+	if (eglString) {
+		g_all_egl_extensions = std::string(eglString);
+		g_all_egl_extensions.append(" ");
+		g_all_egl_extensions.append(eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS));
+	} else {
+		g_all_egl_extensions = "";
+	}
 #endif
 
 	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &gl_extensions.maxVertexTextureUnits);


### PR DESCRIPTION
That String is only for Information for the more advanced user, but it was empty on GLES even SDL2 is using EGL, see video at about ~6:16 

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/QegJlwflkZk/0.jpg)](https://www.youtube.com/watch?v=QegJlwflkZk)


 