### PR TITLE
Set a minimum of 1x1 for Android text bitmap measurement.

### DIFF
--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -54,6 +54,12 @@ public class TextRenderer {
 			total.x = Math.max(sz.x, total.x);
 		}
 		total.y = (int) (p.descent() - p.ascent()) * lines.length + 2;
+		// Returning a 0 size can create problems when the caller
+		// uses the measurement to create a texture.
+		if (total.x < 1)
+			total.x = 1;
+		if (total.y < 1)
+			total.y = 1;
 		return total;
 	}
 
@@ -67,10 +73,6 @@ public class TextRenderer {
 
 		int w = s.x;
 		int h = s.y;
-		if (w == 0)
-			w = 1;
-		if (h == 0)
-			h = 1;
 
 		Bitmap bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
 		Canvas canvas = new Canvas(bmp);

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1078,12 +1078,11 @@ InputLayout *VKContext::CreateInputLayout(const InputLayoutDesc &desc) {
 }
 
 Texture *VKContext::CreateTexture(const TextureDesc &desc) {
-	if (!push_) {
+	if (!push_ || !renderManager_.GetInitCmd()) {
 		// Too early! Fail.
 		ELOG("Can't create textures before the first frame has started.");
 		return nullptr;
 	}
-	_assert_(renderManager_.GetInitCmd());
 	return new VKTexture(vulkan_, renderManager_.GetInitCmd(), push_, desc, allocator_);
 }
 


### PR DESCRIPTION
Should fix some crashes seen on Google Play