### PR TITLE
UI: Load post shader names on non-Windows early

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -121,6 +121,8 @@ static std::string PostShaderTranslateName(const char *value) {
 }
 
 void GameSettingsScreen::CreateViews() {
+	ReloadAllPostShaderInfo();
+
 	if (editThenRestore_) {
 		g_Config.loadGameConfig(gameID_);
 	}


### PR DESCRIPTION
This way the ini "name" is used, rather than the stored code for it.

Fixes #11015.  Worked on Windows because we separately call `ReloadAllPostShaderInfo()` when rendering the menu, so it's been loaded at least once.

-[Unknown]