### PR TITLE
Core: Track graphics startup failures and cycle

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -121,6 +121,7 @@ public:
 
 	// GFX
 	int iGPUBackend;
+	std::string sFailedGPUBackends;
 	// We have separate device parameters for each backend so it doesn't get erased if you switch backends.
 	// If not set, will use the "best" device.
 	std::string sVulkanDevice;
@@ -441,6 +442,7 @@ public:
 	void GetReportingInfo(UrlEncoder &data);
 
 	bool IsPortrait() const;
+	int NextValidBackend();
 
 protected:
 	void LoadStandardControllerIni();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -353,6 +353,10 @@ static void CheckFailedGPUBackends() {
 			g_Config.sFailedGPUBackends = data;
 	}
 
+	// Use this if you want to debug a graphics crash...
+	if (g_Config.sFailedGPUBackends == "IGNORE")
+		return;
+
 	// Okay, let's not try a backend in the failed list.
 	g_Config.iGPUBackend = g_Config.NextValidBackend();
 	// And then let's - for now - add the current to the failed list.
@@ -374,6 +378,9 @@ static void CheckFailedGPUBackends() {
 }
 
 static void ClearFailedGPUBackends() {
+	if (g_Config.sFailedGPUBackends == "IGNORE")
+		return;
+
 	// We've successfully started graphics without crashing, hurray.
 	// In case they update drivers and have totally different problems much later, clear the failed list.
 	g_Config.sFailedGPUBackends.clear();

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -145,6 +145,7 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		if (yes) {
 			// Change the config to D3D and restart.
 			g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D9;
+			g_Config.sFailedGPUBackends.clear();
 			g_Config.Save();
 
 			W32Util::ExitAndRestart();

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -267,6 +267,7 @@ bool WindowsGLContext::InitFromRenderThread(std::string *error_message) {
 			std::wstring whichD3D9 = ConvertUTF8ToWString(err->T("D3D9or11", d3d9Or11));
 			bool d3d9 = IDYES == MessageBox(hWnd_, whichD3D9.c_str(), title.c_str(), MB_YESNO);
 			g_Config.iGPUBackend = d3d9 ? (int)GPUBackend::DIRECT3D9 : (int)GPUBackend::DIRECT3D11;
+			g_Config.sFailedGPUBackends.clear();
 			g_Config.Save();
 
 			W32Util::ExitAndRestart();


### PR DESCRIPTION
If the graphics driver segfaults, or some plugin segfaults, let's try a different one next time.  This gives better hope of starting up next time.

Still lets them use the default if all attempts fail, but doesn't automatically cycle anymore after that (so same behavior as before.)  One downside is any crash during startup will cause it to cycle, since it can't quite tell.  I was worried a threaded render might crash less than immediately.

If the setting is set to "IGNORE" it won't do anything, which makes it easier to debug a crash on startup.  I considered maybe setting it to IGNORE on first successful startup, but I'm not sure...

On Windows, shows a message if they all failed (which could take 5 tries.)

This may help issues like #10752, #11280, #11166, and #9600.  And even #9980 / #8698.

-[Unknown]