### PR TITLE
TexCache: Optimize DXT3/DXT5 decode to single pass

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -384,13 +384,16 @@ void DXTDecoder::DecodeColors(const DXT1Block *src, bool ignore1bitAlpha) {
 }
 
 static inline u8 lerp8(const DXT5Block *src, int n) {
-	float d = n / 7.0f;
-	return (u8)(src->alpha1 + (src->alpha2 - src->alpha1) * d);
+	// These weights translate alpha1/alpha2 to fixed 8.8 point, pre-divided by 7.
+	int weight1 = ((7 - n) << 8) / 7;
+	int weight2 = (n << 8) / 7;
+	return (u8)((src->alpha1 * weight1 + src->alpha2 * weight2) >> 8);
 }
 
 static inline u8 lerp6(const DXT5Block *src, int n) {
-	float d = n / 5.0f;
-	return (u8)(src->alpha1 + (src->alpha2 - src->alpha1) * d);
+	int weight1 = ((5 - n) << 8) / 5;
+	int weight2 = (n << 8) / 5;
+	return (u8)((src->alpha1 * weight1 + src->alpha2 * weight2) >> 8);
 }
 
 void DXTDecoder::DecodeAlphaDXT5(const DXT5Block *src) {


### PR DESCRIPTION
I expect this to fix #10795, although I haven't tested that particular game.

Basically, because we previously decoded DXT1 first, then read that back and applied alpha data to it.  On Vulkan we should only write to memory, and the read was killing performance.

This refactors and writes out colors with alpha data just once.  To test, I made it rebuild the texture each frame, and decode 10 times in a loop - this made that take 1% as long.

Most games don't use DXT, but those that do should get better load times.

-[Unknown]