### PR TITLE
Add .nomedia files to system and textures

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -269,9 +269,11 @@ bool Delete(const std::string &filename) {
 // Returns true if successful, or path already exists.
 bool CreateDir(const std::string &path)
 {
-	DEBUG_LOG(COMMON, "CreateDir('%s')", path.c_str());
+	std::string fn = path;
+	StripTailDirSlashes(fn);
+	DEBUG_LOG(COMMON, "CreateDir('%s')", fn.c_str());
 #ifdef _WIN32
-	if (::CreateDirectory(ConvertUTF8ToWString(path).c_str(), NULL))
+	if (::CreateDirectory(ConvertUTF8ToWString(fn).c_str(), NULL))
 		return true;
 	DWORD error = GetLastError();
 	if (error == ERROR_ALREADY_EXISTS)
@@ -282,25 +284,27 @@ bool CreateDir(const std::string &path)
 	ERROR_LOG(COMMON, "CreateDir: CreateDirectory failed on %s: %i", path.c_str(), error);
 	return false;
 #else
-	if (mkdir(path.c_str(), 0755) == 0)
+	if (mkdir(fn.c_str(), 0755) == 0)
 		return true;
 
 	int err = errno;
 
 	if (err == EEXIST)
 	{
-		WARN_LOG(COMMON, "CreateDir: mkdir failed on %s: already exists", path.c_str());
+		WARN_LOG(COMMON, "CreateDir: mkdir failed on %s: already exists", fn.c_str());
 		return true;
 	}
 
-	ERROR_LOG(COMMON, "CreateDir: mkdir failed on %s: %s", path.c_str(), strerror(err));
+	ERROR_LOG(COMMON, "CreateDir: mkdir failed on %s: %s", fn.c_str(), strerror(err));
 	return false;
 #endif
 }
 
 // Creates the full path of fullPath returns true on success
-bool CreateFullPath(const std::string &fullPath)
+bool CreateFullPath(const std::string &path)
 {
+	std::string fullPath = path;
+	StripTailDirSlashes(fullPath);
 	int panicCounter = 100;
 	VERBOSE_LOG(COMMON, "CreateFullPath: path %s", fullPath.c_str());
 		

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -410,13 +410,8 @@ namespace SaveState
 		}
 		fullDiscId = StringFromFormat("%s_%s", discId.c_str(), discVer.c_str());
 
-		std::string temp = StringFromFormat("ms0:/PSP/PPSSPP_STATE/%s_%d.%s", fullDiscId.c_str(), slot, extension);
-		std::string hostPath;
-		if (pspFileSystem.GetHostPath(temp, hostPath)) {
-			return hostPath;
-		} else {
-			return "";
-		}
+		std::string filename = StringFromFormat("%s_%d.%s", fullDiscId.c_str(), slot, extension);
+		return GetSysDirectory(DIRECTORY_SAVESTATE) + filename;
 	}
 
 	int GetCurrentSlot()
@@ -878,7 +873,7 @@ namespace SaveState
 	void Init()
 	{
 		// Make sure there's a directory for save slots
-		pspFileSystem.MkDir("ms0:/PSP/PPSSPP_STATE");
+		File::CreateFullPath(GetSysDirectory(DIRECTORY_SAVESTATE));
 
 		std::lock_guard<std::mutex> guard(mutex);
 		rewindStates.Clear();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -596,9 +596,9 @@ void InitSysDirectories() {
 	// expect a standard environment. Skipping THEME though, that's pointless.
 	File::CreateDir(g_Config.memStickDirectory + "PSP");
 	File::CreateDir(g_Config.memStickDirectory + "PSP/COMMON");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/GAME");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/SAVEDATA");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/PPSSPP_STATE");
+	File::CreateDir(GetSysDirectory(DIRECTORY_GAME));
+	File::CreateDir(GetSysDirectory(DIRECTORY_SAVEDATA));
+	File::CreateDir(GetSysDirectory(DIRECTORY_SAVESTATE));
 
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -58,6 +58,7 @@ void TextureReplacer::NotifyConfigChanged() {
 		// If we're saving, auto-create the directory.
 		if (g_Config.bSaveNewTextures && !File::Exists(basePath_ + NEW_TEXTURE_DIR)) {
 			File::CreateFullPath(basePath_ + NEW_TEXTURE_DIR);
+			File::CreateEmptyFile(basePath_ + NEW_TEXTURE_DIR + "/.nomedia");
 		}
 
 		enabled_ = File::Exists(basePath_) && File::IsDirectory(basePath_);
@@ -400,6 +401,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		const std::string saveDirectory = basePath_ + NEW_TEXTURE_DIR + hashfile.substr(0, slash);
 		if (!File::Exists(saveDirectory)) {
 			File::CreateFullPath(saveDirectory);
+			File::CreateEmptyFile(saveDirectory + "/.nomedia");
 		}
 	}
 

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -398,7 +398,7 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 	bool iniLoadedSuccessfully = false;
 	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to 
 	// test new languages without recompiling the entire app, which is a hassle).
-	const std::string langOverridePath = g_Config.memStickDirectory + "PSP/SYSTEM/lang/";
+	const std::string langOverridePath = GetSysDirectory(DIRECTORY_SYSTEM) + "lang/";
 
 	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
 	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -323,7 +323,7 @@ static void PostLoadConfig() {
 
 	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to
 	// test new languages without recompiling the entire app, which is a hassle).
-	const std::string langOverridePath = g_Config.memStickDirectory + "PSP/SYSTEM/lang/";
+	const std::string langOverridePath = GetSysDirectory(DIRECTORY_SYSTEM) + "lang/";
 
 	// If we run into the unlikely case that "lang" is actually a file, just use the built-in translations.
 	if (!File::Exists(langOverridePath) || !File::IsDirectory(langOverridePath))
@@ -336,15 +336,15 @@ void CreateDirectoriesAndroid() {
 	// On Android, create a PSP directory tree in the external_dir,
 	// to hopefully reduce confusion a bit.
 	ILOG("Creating %s", (g_Config.memStickDirectory + "PSP").c_str());
-	File::CreateDir(g_Config.memStickDirectory + "PSP");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/SAVEDATA");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/PPSSPP_STATE");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/GAME");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/SYSTEM");
+	File::CreateFullPath(g_Config.memStickDirectory + "PSP");
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_SAVEDATA));
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_SAVESTATE));
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_GAME));
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_SYSTEM));
 
 	// Avoid media scanners in PPSSPP_STATE and SAVEDATA directories
-	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/PPSSPP_STATE/.nomedia");
-	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/SAVEDATA/.nomedia");
+	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVESTATE) + ".nomedia");
+	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVEDATA) + ".nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SYSTEM) + ".nomedia");
 }
 
@@ -421,8 +421,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 #ifndef _WIN32
 	g_Config.AddSearchPath(user_data_path);
-	g_Config.AddSearchPath(g_Config.memStickDirectory + "PSP/SYSTEM/");
-	g_Config.SetDefaultPath(g_Config.memStickDirectory + "PSP/SYSTEM/");
+	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 
 	// Note that if we don't have storage permission here, loading the config will
 	// fail and it will be set to the default. Later, we load again when we get permission.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -345,6 +345,7 @@ void CreateDirectoriesAndroid() {
 	// Avoid media scanners in PPSSPP_STATE and SAVEDATA directories
 	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/PPSSPP_STATE/.nomedia");
 	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/SAVEDATA/.nomedia");
+	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SYSTEM) + ".nomedia");
 }
 
 void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir) {


### PR DESCRIPTION
Fixes #11324.

While I was there, cleaned up some path handling.  This possibly makes it easier to e.g. put save states somewhere else, or etc.  No need to access them via pspFileSystem.

-[Unknown]