### PR TITLE
Add: ban only Mali-4x GPU from 3.x context, they do not support GLES 3.x

### DIFF
--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -244,8 +244,8 @@ void CheckGLExtensions() {
 					gl_extensions.ver[1] = 1;
 				}
 				gl_extensions.GLES3 = true;
-				// Though, let's ban Mali from the GLES 3 path for now, see #4078
-				if (strstr(renderer, "Mali") != 0) {
+				// Though, let's ban Mali-4x from the GLES 3 path, see #4078
+				if (strstr(renderer, "Mali-4") != 0) {
 					gl_extensions.GLES3 = false;
 				}
 			} else {


### PR DESCRIPTION
Here are various GPU Render Strings:

Mali-400
Mali-450
Mali-T600
Mali-T620
Mali-T720
Mali-T760
Mali-T820
Mali-T830
Mali-T880

As of Mali-Tx they support OpenGL ES 3.1 
https://en.wikipedia.org/wiki/Mali_(GPU)#Variants
