### PR TITLE
Core: Log more on graphics backend failures

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -557,6 +557,8 @@ int Config::NextValidBackend() {
 	}
 
 	if (failed.count(iGPUBackend)) {
+		ERROR_LOG(LOADER, "Graphics backend failed for %d, trying another", iGPUBackend);
+
 #if (PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID)) && !PPSSPP_PLATFORM(UWP)
 		if (VulkanMayBeAvailable() && !failed.count((int)GPUBackend::VULKAN)) {
 			return (int)GPUBackend::VULKAN;
@@ -580,6 +582,7 @@ int Config::NextValidBackend() {
 
 		// They've all failed.  Let them try the default.
 		sFailedGPUBackends += ",ALL";
+		ERROR_LOG(LOADER, "All graphics backends failed");
 		return DefaultGPUBackend();
 	}
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -357,9 +357,14 @@ static void CheckFailedGPUBackends() {
 	// Use this if you want to debug a graphics crash...
 	if (g_Config.sFailedGPUBackends == "IGNORE")
 		return;
+	else if (!g_Config.sFailedGPUBackends.empty())
+		ERROR_LOG(LOADER, "Failed graphics backends: %s", g_Config.sFailedGPUBackends.c_str());
 
 	// Okay, let's not try a backend in the failed list.
-	g_Config.iGPUBackend = g_Config.NextValidBackend();
+	int newBackend = g_Config.NextValidBackend();
+	if (newBackend != g_Config.iGPUBackend)
+		WARN_LOG(LOADER, "Failed graphics backend switched from %d to %d", g_Config.iGPUBackend, newBackend);
+	g_Config.iGPUBackend = newBackend;
 	// And then let's - for now - add the current to the failed list.
 	if (g_Config.sFailedGPUBackends.empty()) {
 		g_Config.sFailedGPUBackends = StringFromFormat("%d", g_Config.iGPUBackend);


### PR DESCRIPTION
Just so we can tell for sure in logs what's happening.  Should've logged more from the beginning - d'oh.

-[Unknown]