### PR TITLE
Add: Touchscreen event support for SDL2

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -355,6 +355,7 @@ int main(int argc, char *argv[]) {
 
 	int set_xres = -1;
 	int set_yres = -1;
+	int w = 0, h = 0;
 	bool portrait = false;
 	bool set_ipad = false;
 	float set_dpi = 1.0f;
@@ -601,7 +602,7 @@ int main(int argc, char *argv[]) {
 
 	while (true) {
 		double startTime = time_now_d();
-		SDL_Event event;
+		SDL_Event event, touchEvent;
 		while (SDL_PollEvent(&event)) {
 			float mx = event.motion.x * g_dpi_scale_x;
 			float my = event.motion.y * g_dpi_scale_y;
@@ -679,6 +680,71 @@ int main(int argc, char *argv[]) {
 					key.keyCode = c;
 					key.deviceId = DEVICE_ID_KEYBOARD;
 					NativeKey(key);
+					break;
+				}
+			case SDL_FINGERMOTION:
+				{
+					if (!g_Config.bFullScreen) { break; }
+					SDL_GetWindowSize(window, &w, &h);
+					touchEvent.type = SDL_MOUSEMOTION;
+					touchEvent.motion.type = SDL_MOUSEMOTION;
+					touchEvent.motion.timestamp = event.tfinger.timestamp;
+					touchEvent.motion.windowID = SDL_GetWindowID(window);
+					touchEvent.motion.which = SDL_TOUCH_MOUSEID;
+					touchEvent.motion.state = SDL_GetMouseState(NULL, NULL);
+					touchEvent.motion.x = event.tfinger.x * w;
+					touchEvent.motion.y = event.tfinger.y * h;
+
+					SDL_WarpMouseInWindow(window, event.tfinger.x * w, event.tfinger.y * h);
+
+					SDL_PushEvent(&touchEvent);
+					break;
+				}
+			case SDL_FINGERDOWN:
+				{
+					if (!g_Config.bFullScreen) { break; }
+					SDL_GetWindowSize(window, &w, &h);
+					touchEvent.type = SDL_MOUSEBUTTONDOWN;
+					touchEvent.button.type = SDL_MOUSEBUTTONDOWN;
+					touchEvent.button.timestamp = SDL_GetTicks();
+					touchEvent.button.windowID = SDL_GetWindowID(window);
+					touchEvent.button.which = SDL_TOUCH_MOUSEID;
+					touchEvent.button.button = SDL_BUTTON_LEFT;
+					touchEvent.button.state = SDL_PRESSED;
+					touchEvent.button.clicks = 1;
+					touchEvent.button.x = event.tfinger.x * w;
+					touchEvent.button.y = event.tfinger.y * h;
+
+					touchEvent.motion.type = SDL_MOUSEMOTION;
+					touchEvent.motion.timestamp = SDL_GetTicks();
+					touchEvent.motion.windowID = SDL_GetWindowID(window);
+					touchEvent.motion.which = SDL_TOUCH_MOUSEID;
+					touchEvent.motion.x = event.tfinger.x * w;
+					touchEvent.motion.y = event.tfinger.y * h;
+					// Any real mouse cursor should also move
+					SDL_WarpMouseInWindow(window, event.tfinger.x * w, event.tfinger.y * h);
+					// First finger down event also has to be a motion to that position
+					SDL_PushEvent(&touchEvent);
+					touchEvent.motion.type = SDL_MOUSEBUTTONDOWN;
+					// Now we push the mouse button event
+					SDL_PushEvent(&touchEvent);
+					break;
+				}
+			case SDL_FINGERUP:
+				{
+					if(!g_Config.bFullScreen) { break; }
+					SDL_GetWindowSize(window, &w, &h);
+					touchEvent.type = SDL_MOUSEBUTTONUP;
+					touchEvent.button.type = SDL_MOUSEBUTTONUP;
+					touchEvent.button.timestamp = SDL_GetTicks();
+					touchEvent.button.windowID = SDL_GetWindowID(window);
+					touchEvent.button.which = SDL_TOUCH_MOUSEID;
+					touchEvent.button.button = SDL_BUTTON_LEFT;
+					touchEvent.button.state = SDL_RELEASED;
+					touchEvent.button.clicks = 1;
+					touchEvent.button.x = event.tfinger.x * w;
+					touchEvent.button.y = event.tfinger.y * h;
+					SDL_PushEvent(&touchEvent);
 					break;
 				}
 			case SDL_MOUSEBUTTONDOWN:


### PR DESCRIPTION
This adds Touchscreen support for SDL2 on Linux and asks for any video driver which is always full screen no matter what the User selects in GUI or adding with start options (only KMSDRM video backend in SDL2 right now).
This is working only in full screen mode right now, I don't have any Linux laptop with touch screen to test with to obtain the relative screen width and height to the window width height. Maybe it wouldn't needed I don't know.

https://youtu.be/QegJlwflkZk?t=375