### PR TITLE
TexCache: Fix texture alignment in GLES

### DIFF
--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -41,7 +41,7 @@ u32 QuickTexHashSSE2(const void *checkp, u32 size);
 #define DoQuickTexHash QuickTexHashSSE2
 #define StableQuickTexHash QuickTexHashSSE2
 
-// Pitch must be aligned to 16 bits (as is the case on a PSP)
+// Pitch must be aligned to 16 bytes (as is the case on a PSP)
 void DoUnswizzleTex16Basic(const u8 *texptr, u32 *ydestp, int bxc, int byc, u32 pitch);
 #define DoUnswizzleTex16 DoUnswizzleTex16Basic
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -699,7 +699,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 			mapData = (u32 *)AllocateAlignedMemory(sizeof(u32) * (w * scaleFactor) * (h * scaleFactor), 16);
 			mapRowPitch = w * scaleFactor * 4;
 		} else {
-			mapRowPitch = std::max(bufw, w) * bpp;
+			mapRowPitch = std::max(w * bpp, 16);
 			size_t bufSize = sizeof(u32) * (mapRowPitch / bpp) * h;
 			mapData = (u32 *)AllocateAlignedMemory(bufSize, 16);
 			if (!mapData) {

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -294,6 +294,7 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 					if (lang == HLSL_D3D11) {
 						WRITE(p, "  if ((roundAndScaleTo255i(v.a) & u_alphacolormask.a) %s u_alphacolorref.a) discard;\n", alphaTestFuncs[alphaTestFunc]);
 					} else {
+						// TODO: Use a texture to lookup bitwise ops?
 						WRITE(p, "  if (roundAndScaleTo255f(v.a) %s u_alphacolorref.a) clip(-1);\n", alphaTestFuncs[alphaTestFunc]);
 					}
 				} else {
@@ -319,13 +320,17 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 			} else {
 				const char *colorTestFuncs[] = { "#", "#", " != ", " == " };	// never/always don't make sense
 				if (colorTestFuncs[colorTestFunc][0] != '#') {
-					const char * test = colorTestFuncs[colorTestFunc];
+					const char *test = colorTestFuncs[colorTestFunc];
 					if (lang == HLSL_D3D11) {
 						WRITE(p, "  uint3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-						WRITE(p, "  if ((v_scaled & u_alphacolormask.rgb) %s (u_alphacolorref.rgb & u_alphacolormask.rgb)) discard;\n", colorTestFuncs[colorTestFunc]);
+						WRITE(p, "  uint3 v_masked = v_scaled & u_alphacolormask.rgb;\n");
+						WRITE(p, "  uint3 colorTestRef = u_alphacolorref.rgb & u_alphacolormask.rgb;\n");
+						// We have to test the components separately, or we get incorrect results.  See #10629.
+						WRITE(p, "  if (v_masked.r %s colorTestRef.r && v_masked.g %s colorTestRef.g && v_masked.b %s colorTestRef.b) discard;\n", test, test, test);
 					} else {
+						// TODO: Use a texture to lookup bitwise ops instead?
 						WRITE(p, "  float3 colortest = roundAndScaleTo255v(v.rgb);\n");
-						WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b )) clip(-1);\n", test, test, test);
+						WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b)) clip(-1);\n", test, test, test);
 					}
 				}
 				else {

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -58,7 +58,7 @@ PSShader::PSShader(LPDIRECT3DDEVICE9 device, FShaderID id, const char *code) : i
 			ERROR_LOG(G3D, "Error in shader compilation!");
 		}
 		ERROR_LOG(G3D, "Messages: %s", errorMessage.c_str());
-		ERROR_LOG(G3D, "Shader source:\n%s", code);
+		ERROR_LOG(G3D, "Shader source:\n%s", LineNumberString(code).c_str());
 		OutputDebugStringUTF8("Messages:\n");
 		OutputDebugStringUTF8(errorMessage.c_str());
 		Reporting::ReportMessage("D3D error in shader compilation: info: %s / code: %s", errorMessage.c_str(), code);

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -265,10 +265,10 @@ void ShaderManagerDX9::PSUpdateUniforms(u64 dirtyUniforms) {
 		PSSetColorUniform3(CONST_PS_TEXENV, gstate.texenvcolor);
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORREF) {
-		PSSetColorUniform3Alpha255(CONST_PS_ALPHACOLORREF, gstate.getColorTestRef(), gstate.getAlphaTestRef());
+		PSSetColorUniform3Alpha255(CONST_PS_ALPHACOLORREF, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORMASK) {
-		PSSetColorUniform3(CONST_PS_ALPHACOLORMASK, gstate.colortestmask);
+		PSSetColorUniform3Alpha255(CONST_PS_ALPHACOLORMASK, gstate.colortestmask, gstate.getAlphaTestMask());
 	}
 	if (dirtyUniforms & DIRTY_FOGCOLOR) {
 		PSSetColorUniform3(CONST_PS_FOGCOLOR, gstate.fogcolor);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -744,11 +744,8 @@ TexCacheEntry::TexStatus TextureCacheGLES::CheckAlpha(const uint8_t *pixelData, 
 void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int scaleFactor, GLenum dstFmt) {
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
-	bool useUnpack = false;
 	uint8_t *pixelData;
-
-	// TODO: only do this once
-	u32 texByteAlign = 1;
+	int decPitch = 0;
 
 	gpuStats.numTexturesDecoded++;
 
@@ -756,13 +753,12 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 		PROFILE_THIS_SCOPE("replacetex");
 
 		int bpp = replaced.Format(level) == ReplacedTextureFormat::F_8888 ? 4 : 2;
-		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * h * bpp, 16);
-		replaced.Load(level, rearrange, bpp * w);
+		decPitch = w * bpp;
+		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(decPitch * h, 16);
+		replaced.Load(level, rearrange, decPitch);
 		pixelData = rearrange;
 
 		dstFmt = ToGLESFormat(replaced.Format(level));
-
-		texByteAlign = bpp;
 	} else {
 		PROFILE_THIS_SCOPE("decodetex");
 
@@ -771,14 +767,15 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 		int bufw = GetTextureBufw(level, texaddr, GETextureFormat(entry.format));
 
 		int pixelSize = dstFmt == GL_UNSIGNED_BYTE ? 4 : 2;
-		int decPitch = w * pixelSize;
+		// We leave GL_UNPACK_ALIGNMENT at 4, so this must be at least 4.
+		decPitch = std::max(w * pixelSize, 4);
 
 		pixelData = (uint8_t *)AllocateAlignedMemory(decPitch * h * pixelSize, 16);
 		DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false);
 
 		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
 		if ((entry.status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
-			TexCacheEntry::TexStatus alphaStatus = CheckAlpha(pixelData, dstFmt, useUnpack ? bufw : w, w, h);
+			TexCacheEntry::TexStatus alphaStatus = CheckAlpha(pixelData, dstFmt, decPitch / pixelSize, w, h);
 			entry.SetAlphaStatus(alphaStatus, level);
 		} else {
 			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
@@ -789,10 +786,8 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 			scaler.ScaleAlways((u32 *)rearrange, (u32 *)pixelData, dstFmt, w, h, scaleFactor);
 			FreeAlignedMemory(pixelData);
 			pixelData = rearrange;
+			decPitch = w * 4;
 		}
-
-		// Textures are always aligned to 16 bytes bufw, so this could safely be 4 always.
-		texByteAlign = dstFmt == GL_UNSIGNED_BYTE ? 4 : 2;
 
 		if (replacer_.Enabled()) {
 			ReplacedTextureDecodeInfo replacedInfo;
@@ -804,8 +799,7 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 			replacedInfo.scaleFactor = scaleFactor;
 			replacedInfo.fmt = FromGLESFormat(dstFmt);
 
-			int bpp = dstFmt == GL_UNSIGNED_BYTE ? 4 : 2;
-			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, (useUnpack ? bufw : w) * bpp, level, w, h);
+			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, level, w, h);
 		}
 	}
 


### PR DESCRIPTION
This fixes the OpenGL and Direct3D 11 parts of #10629, but not the Vulkan and Direct3D 9 parts.

For textures that were <= 4 pixels wide (not that common), we had a couple invalid assumptions in the GLES path.  First, we left row alignment at 4, which would be an issue for 1 pixel wide 16-bit textures (definitely an edge case, though.)  More importantly, we unswizzled assuming the pitch was aligned to 16 bytes.

While I was there, I fixed Direct3D 11 using bufw (if larger than w) for pitch.  It doesn't need to, but aligning to 16 is ideal (which this was implicitly doing, since bufw is always aligned to 16 bytes.)

I decided to keep it in this same pull, but the color test change is kinda separate.  Basically, `x.rgb == y.rgb` was not working, but `x.r == y.r && x.g == y.g && x.b == y.b` was.  A shame.

-[Unknown]