### PR TITLE
Correct interactions between fog, doubling, and color testing

### DIFF
--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -233,7 +233,7 @@ void ComputeFragmentShaderID(ShaderID *id_out) {
 		bool enableFog = gstate.isFogEnabled() && !isModeThrough;
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
-		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
+		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled() && gstate.getTextureFunction() == GE_TEXFUNC_MODULATE;
 		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;

--- a/GPU/Directx9/PixelShaderGeneratorDX9.cpp
+++ b/GPU/Directx9/PixelShaderGeneratorDX9.cpp
@@ -268,6 +268,11 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 					WRITE(p, "  float4 v = p;\n"); break;
 				}
 			}
+
+			if (enableColorDoubling) {
+				// This happens before fog is applied.
+				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
+			}
 		} else {
 			// No texture mapping
 			WRITE(p, "  float4 v = In.v_color0 %s;\n", secondary);
@@ -303,12 +308,13 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 				}
 			}
 		}
-		if (enableColorTest) {
-			// Color doubling happens before the color test, but we try to optimize doubling when test is off.
-			if (enableColorDoubling) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
-			}
 
+		if (enableFog) {
+			WRITE(p, "  float fogCoef = clamp(In.v_fogdepth, 0.0, 1.0);\n");
+			WRITE(p, "  v = lerp(float4(u_fogcolor, v.a), v, fogCoef);\n");
+		}
+
+		if (enableColorTest) {
 			if (colorTestAgainstZero) {
 				// When testing against 0 (common), we can avoid some math.
 				// 0.002 is approximately half of 1.0 / 255.0.
@@ -342,24 +348,10 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 					WRITE(p, lang == HLSL_DX9 ? "  clip(-1);\n" : "  discard;\n");
 				}
 			}
-
-			if (replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
-			}
-		} else {
-			// If there's no color test, we can potentially double and replace blend at once.
-			if (enableColorDoubling && replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 4.0, 0.0, 2.0);\n");
-			} else if (enableColorDoubling) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
-			} else if (replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
-			}
 		}
 
-		if (enableFog) {
-			WRITE(p, "  float fogCoef = clamp(In.v_fogdepth, 0.0, 1.0);\n");
-			WRITE(p, "  v = lerp(float4(u_fogcolor, v.a), v, fogCoef);\n");
+		if (replaceBlend == REPLACE_BLEND_2X_SRC) {
+			WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
 		}
 
 		if (replaceBlend == REPLACE_BLEND_PRE_SRC || replaceBlend == REPLACE_BLEND_PRE_SRC_2X_ALPHA) {

--- a/GPU/GLES/FragmentTestCacheGLES.cpp
+++ b/GPU/GLES/FragmentTestCacheGLES.cpp
@@ -81,6 +81,8 @@ void FragmentTestCacheGLES::BindTestTexture(int slot) {
 	GLRTexture *tex = CreateTestTexture(funcs, refs, masks, valid);
 	lastTexture_ = tex;
 	render_->BindTexture(slot, tex);
+	// We only need to do this once for the texture.
+	render_->SetTextureSampler(slot, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_NEAREST, 0.0f);
 	FragmentTestTexture item;
 	item.lastFrame = gpuStats.numFlips;
 	item.texture = tex;

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -157,7 +157,7 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 		// Color and depth values of second vertex are used for the whole rectangle
 		buf[0].color0 = buf[1].color0 = buf[2].color0 = buf[3].color0;
 		buf[0].color1 = buf[1].color1 = buf[2].color1 = buf[3].color1;
-		buf[0].fogdepth = buf[1].fogdepth = buf[2].fogdepth = buf[3].fogdepth = 1.0f;
+		buf[0].fogdepth = buf[1].fogdepth = buf[2].fogdepth = buf[3].fogdepth;
 
 		VertexData* topleft = &buf[0];
 		VertexData* topright = &buf[1];

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -484,9 +484,8 @@ static inline bool StencilTestPassed(u8 stencil)
 	return true;
 }
 
-static inline u8 ApplyStencilOp(int op, int x, int y)
-{
-	u8 old_stencil = GetPixelStencil(x, y); // TODO: Apply mask?
+static inline u8 ApplyStencilOp(int op, u8 old_stencil) {
+	// TODO: Apply mask to reference or old stencil?
 	u8 reference_stencil = gstate.getStencilTestRef(); // TODO: Apply mask?
 
 	switch (op) {
@@ -916,7 +915,7 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, u8 fog, const Vec4<in
 	// TODO: Is it safe to ignore gstate.isDepthTestEnabled() when clear mode is enabled? Probably yes
 	if (!clearMode && (gstate.isStencilTestEnabled() || gstate.isDepthTestEnabled())) {
 		if (gstate.isStencilTestEnabled() && !StencilTestPassed(stencil)) {
-			stencil = ApplyStencilOp(gstate.getStencilOpSFail(), p.x, p.y);
+			stencil = ApplyStencilOp(gstate.getStencilOpSFail(), stencil);
 			SetPixelStencil(p.x, p.y, stencil);
 			return;
 		}
@@ -924,12 +923,12 @@ inline void DrawSinglePixel(const DrawingCoords &p, u16 z, u8 fog, const Vec4<in
 		// Also apply depth at the same time.  If disabled, same as passing.
 		if (gstate.isDepthTestEnabled() && !DepthTestPassed(p.x, p.y, z)) {
 			if (gstate.isStencilTestEnabled()) {
-				stencil = ApplyStencilOp(gstate.getStencilOpZFail(), p.x, p.y);
+				stencil = ApplyStencilOp(gstate.getStencilOpZFail(), stencil);
 				SetPixelStencil(p.x, p.y, stencil);
 			}
 			return;
 		} else if (gstate.isStencilTestEnabled()) {
-			stencil = ApplyStencilOp(gstate.getStencilOpZPass(), p.x, p.y);
+			stencil = ApplyStencilOp(gstate.getStencilOpZPass(), stencil);
 		}
 
 		if (gstate.isDepthTestEnabled() && gstate.isDepthWriteEnabled()) {

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -339,6 +339,11 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 					WRITE(p, "  vec4 v = p;\n"); break;
 				}
 			}
+
+			if (enableColorDoubling) {
+				// This happens before fog is applied.
+				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
+			}
 		} else {
 			// No texture mapping
 			WRITE(p, "  vec4 v = v_color0 %s;\n", secondary);
@@ -374,12 +379,13 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 			}
 		}
 
-		if (enableColorTest) {
-			// Color doubling happens before the color test, but we try to optimize doubling when test is off.
-			if (enableColorDoubling) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
-			}
+		if (enableFog) {
+			WRITE(p, "  float fogCoef = clamp(v_fogdepth, 0.0, 1.0);\n");
+			WRITE(p, "  v = mix(vec4(base.fogcolor, v.a), v, fogCoef);\n");
+			// WRITE(p, "  v.x = v_depth;\n");
+		}
 
+		if (enableColorTest) {
 			if (colorTestAgainstZero) {
 				// When testing against 0 (common), we can avoid some math.
 				// Have my doubts that this special case is actually worth it, but whatever.
@@ -403,25 +409,10 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer) {
 					WRITE(p, "  %s\n", discardStatement);
 				}
 			}
-
-			if (replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
-			}
-		} else {
-			// If there's no color test, we can potentially double and replace blend at once.
-			if (enableColorDoubling && replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 4.0, 0.0, 2.0);\n");
-			} else if (enableColorDoubling) {
-				WRITE(p, "  v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);\n");
-			} else if (replaceBlend == REPLACE_BLEND_2X_SRC) {
-				WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
-			}
 		}
 
-		if (enableFog) {
-			WRITE(p, "  float fogCoef = clamp(v_fogdepth, 0.0, 1.0);\n");
-			WRITE(p, "  v = mix(vec4(base.fogcolor, v.a), v, fogCoef);\n");
-			// WRITE(p, "  v.x = v_depth;\n");
+		if (replaceBlend == REPLACE_BLEND_2X_SRC) {
+			WRITE(p, "  v.rgb = v.rgb * 2.0;\n");
 		}
 
 		if (replaceBlend == REPLACE_BLEND_PRE_SRC || replaceBlend == REPLACE_BLEND_PRE_SRC_2X_ALPHA) {

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -373,6 +373,7 @@ int main(int argc, const char* argv[])
 	g_Config.iSplineBezierQuality = 2;
 	g_Config.bHighQualityDepth = true;
 	g_Config.bMemStickInserted = true;
+	g_Config.bFragmentTestCache = true;
 
 #ifdef _WIN32
 	InitSysDirectories();


### PR DESCRIPTION
I'm not sure what I got wrong in #5090, but my current tests show pretty clearly that the result of color doubling is what's subject to the color test.  In fact, even fog is applied prior to the color test (but before doubling.)

I now think that color doubling is just an option on the modulate texture func, since that's exactly how it behaves.  The bit does nothing for other texture funcs and when texturing is off.

~~Fog was also broken (backwards - fogCoef was inverted, basically) in the software renderer (forgot to make a separate commit for this.)~~

At this point, the `DrawSinglePixel()` func feels pretty well tested, except dithering of course.

-[Unknown]