### PR TITLE
GPU: Handle bad fog params as large signed vals

### DIFF
--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 
 #include "ShaderUniforms.h"
 #include "base/display.h"
@@ -119,22 +120,15 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 			getFloat24(gstate.fog1),
 			getFloat24(gstate.fog2),
 		};
-		if (my_isinf(fogcoef[1])) {
-			// not really sure what a sensible value might be.
-			fogcoef[1] = fogcoef[1] < 0.0f ? -10000.0f : 10000.0f;
-		} else if (my_isnan(fogcoef[1])) {
-			// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
-			// Just put the fog far away at a large finite distance.
-			// Infinities and NaNs are rather unpredictable in shaders on many GPUs
-			// so it's best to just make it a sane calculation.
-			fogcoef[0] = 100000.0f;
-			fogcoef[1] = 1.0f;
+		// The PSP just ignores infnan here (ignoring IEEE), so take it down to a valid float.
+		// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
+		if (my_isnanorinf(fogcoef[0])) {
+			// Not really sure what a sensible value might be, but let's try 64k.
+			fogcoef[0] = std::signbit(fogcoef[0]) ? -65535.0f : 65535.0f;
 		}
-#ifndef MOBILE_DEVICE
-		else if (my_isnanorinf(fogcoef[1]) || my_isnanorinf(fogcoef[0])) {
-			ERROR_LOG_REPORT_ONCE(fognan, G3D, "Unhandled fog NaN/INF combo: %f %f", fogcoef[0], fogcoef[1]);
+		if (my_isnanorinf(fogcoef[1])) {
+			fogcoef[1] = std::signbit(fogcoef[1]) ? -65535.0f : 65535.0f;
 		}
-#endif
 		CopyFloat2(ub->fogCoef, fogcoef);
 	}
 

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <cmath>
 #include "math/math_util.h"
 #include "gfx_es2/gpu_features.h"
 
@@ -181,18 +182,13 @@ void SoftwareTransform(
 	Lighter lighter(vertType);
 	float fog_end = getFloat24(gstate.fog1);
 	float fog_slope = getFloat24(gstate.fog2);
-	// Same fixup as in ShaderManager.cpp
-	if (my_isinf(fog_slope)) {
-		// not really sure what a sensible value might be.
-		fog_slope = fog_slope < 0.0f ? -10000.0f : 10000.0f;
+	// Same fixup as in ShaderManagerGLES.cpp
+	if (my_isnanorinf(fog_end)) {
+		// Not really sure what a sensible value might be, but let's try 64k.
+		fog_end = std::signbit(fog_end) ? -65535.0f : 65535.0f;
 	}
-	if (my_isnan(fog_slope)) {
-		// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
-		// Just put the fog far away at a large finite distance.
-		// Infinities and NaNs are rather unpredictable in shaders on many GPUs
-		// so it's best to just make it a sane calculation.
-		fog_end = 100000.0f;
-		fog_slope = 1.0f;
+	if (my_isnanorinf(fog_slope)) {
+		fog_slope = std::signbit(fog_slope) ? -65535.0f : 65535.0f;
 	}
 
 	int colorIndOffset = 0;


### PR DESCRIPTION
From tests, it seems they're just treated as valid exponents.

Using 65535 since that's the range of depth, can't think of a game using a larger value for a fog parameter, probably never even this large.

Did some more fog tests, I think I had a mistake before when I thought softgpu fog was reversed - but since I was there, I validated how inf/nan behave.  It seems like they act just like vfpu min/max - the exponent is just not treated as special.

This could use validation against MediEvil and any other affected games, though.  But this matches tests.

-[Unknown]