### PR TITLE
Use OS to detect core count

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -23,11 +23,14 @@
 #endif
 
 #include <memory.h>
+#include <set>
 #include "base/logging.h"
 #include "base/basictypes.h"
+#include "file/file_util.h"
 
 #include "Common.h"
 #include "CPUDetect.h"
+#include "FileUtil.h"
 #include "StringUtils.h"
 
 #if defined(_WIN32) && !defined(__MINGW32__)
@@ -95,6 +98,28 @@ CPUInfo cpu_info;
 
 CPUInfo::CPUInfo() {
 	Detect();
+}
+
+static std::vector<int> ParseCPUList(const std::string &filename) {
+	std::string data;
+	std::vector<int> results;
+
+	if (readFileToString(true, filename.c_str(), data)) {
+		std::vector<std::string> ranges;
+		SplitString(data, ',', ranges);
+		for (auto range : ranges) {
+			int low = 0, high = 0;
+			int parts = sscanf(range.c_str(), "%d-%d", &low, &high);
+			if (parts == 1) {
+				high = low;
+			}
+			for (int i = low; i <= high; ++i) {
+				results.push_back(i);
+			}
+		}
+	}
+
+	return results;
 }
 
 // Detects the various cpu features
@@ -260,6 +285,93 @@ void CPUInfo::Detect() {
 			num_cores = (cpu_id[2] & 0xFF) + 1;
 		}
 	}
+
+	// The above only gets valid info for the active processor.
+	// Let's rely on OS APIs for accurate information, if available, below.
+
+#if PPSSPP_PLATFORM(WINDOWS)
+#if !PPSSPP_PLATFORM(UWP)
+	typedef BOOL (WINAPI *getLogicalProcessorInformationEx_f)(LOGICAL_PROCESSOR_RELATIONSHIP RelationshipType, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX Buffer, PDWORD ReturnedLength);
+	auto getLogicalProcessorInformationEx = (getLogicalProcessorInformationEx_f)GetProcAddress(GetModuleHandle(L"kernel32.dll"), "GetLogicalProcessorInformationEx");
+#else
+	void *getLogicalProcessorInformationEx = nullptr;
+#endif
+
+	if (getLogicalProcessorInformationEx) {
+#if !PPSSPP_PLATFORM(UWP)
+		DWORD len = 0;
+		getLogicalProcessorInformationEx(RelationAll, nullptr, &len);
+		auto processors = new uint8_t[len];
+		if (getLogicalProcessorInformationEx(RelationAll, (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)processors, &len)) {
+			num_cores = 0;
+			logical_cpu_count = 0;
+			auto p = processors;
+			while (p < processors + len) {
+				const auto &processor = *(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)p;
+				if (processor.Relationship == RelationProcessorCore) {
+					num_cores++;
+					for (int j = 0; j < processor.Processor.GroupCount; ++j) {
+						const auto &mask = processor.Processor.GroupMask[j].Mask;
+						for (int i = 0; i < sizeof(mask) * 8; ++i) {
+							logical_cpu_count += (mask >> i) & 1;
+						}
+					}
+				}
+				p += processor.Size;
+			}
+		}
+		delete [] processors;
+#endif
+	} else {
+		DWORD len = 0;
+		const DWORD sz = sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+		GetLogicalProcessorInformation(nullptr, &len);
+		std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> processors;
+		processors.resize((len + sz - 1) / sz);
+		if (GetLogicalProcessorInformation(&processors[0], &len)) {
+			num_cores = 0;
+			logical_cpu_count = 0;
+			for (auto processor : processors) {
+				if (processor.Relationship == RelationProcessorCore) {
+					num_cores++;
+					for (int i = 0; i < sizeof(processor.ProcessorMask) * 8; ++i) {
+						logical_cpu_count += (processor.ProcessorMask >> i) & 1;
+					}
+				}
+			}
+		}
+	}
+
+	// This seems to be the count per core.  Hopefully all cores are the same, but we counted each above.
+	logical_cpu_count /= num_cores;
+#elif PPSSPP_PLATFORM(LINUX)
+	if (File::Exists("/sys/devices/system/cpu/present")) {
+		// This may not count unplugged cores, but at least it's a best guess.
+		// Also, this assumes the CPU cores are heterogeneous (e.g. all cores could be active simultaneously.)
+		num_cores = 0;
+		logical_cpu_count = 0;
+
+		std::set<int> counted_cores;
+		auto present = ParseCPUList("/sys/devices/system/cpu/present");
+		for (int id : present) {
+			logical_cpu_count++;
+
+			if (counted_cores.count(id) == 0) {
+				num_cores++;
+				counted_cores.insert(id);
+
+				// Also count any thread siblings as counted.
+				auto threads = ParseCPUList(StringFromFormat("/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", id));
+				for (int mark_id : threads) {
+					counted_cores.insert(mark_id);
+				}
+			}
+		}
+	}
+
+	// This seems to be the count per core.  Hopefully all cores are the same, but we counted each above.
+	logical_cpu_count /= num_cores;
+#endif
 }
 
 // Turn the cpu info into a string we can show

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -17,9 +17,12 @@
 
 #if defined(_M_IX86) || defined(_M_X64)
 
+#include "ppsspp_config.h"
 #ifdef __ANDROID__
 #include <sys/stat.h>
 #include <fcntl.h>
+#elif PPSSPP_PLATFORM(MAC)
+#include <sys/sysctl.h>
 #endif
 
 #include <memory.h>
@@ -371,6 +374,16 @@ void CPUInfo::Detect() {
 
 	// This seems to be the count per core.  Hopefully all cores are the same, but we counted each above.
 	logical_cpu_count /= num_cores;
+#elif PPSSPP_PLATFORM(MAC)
+	int num = 0;
+	size_t sz = sizeof(num);
+	if (sysctlbyname("hw.physicalcpu_max", &num, &sz, nullptr, 0) == 0) {
+		num_cores = num;
+		sz = sizeof(num);
+		if (sysctlbyname("hw.logicalcpu_max", &num, &sz, nullptr, 0) == 0) {
+			logical_cpu_count = num / num_cores;
+		}
+	}
 #endif
 }
 

--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -106,11 +106,14 @@ std::string ResolvePath(const std::string &path) {
 	typedef DWORD (WINAPI *getFinalPathNameByHandleW_f)(HANDLE hFile, LPWSTR lpszFilePath, DWORD cchFilePath, DWORD dwFlags);
 	static getFinalPathNameByHandleW_f getFinalPathNameByHandleW = nullptr;
 
+#if PPSSPP_PLATFORM(UWP)
+	getFinalPathNameByHandleW = &GetFinalPathNameByHandleW;
+#else
 	if (!getFinalPathNameByHandleW) {
-		// We leak this, but that's okay since the process should hold onto this DLL for the entire lifetime anyway.
-		HMODULE kernel32 = LoadLibraryW(L"kernel32.dll");
+		HMODULE kernel32 = GetModuleHandle(L"kernel32.dll");
 		getFinalPathNameByHandleW = (getFinalPathNameByHandleW_f)GetProcAddress(kernel32, "GetFinalPathNameByHandleW");
 	}
+#endif
 
 	static const int BUF_SIZE = 32768;
 	wchar_t *buf = new wchar_t[BUF_SIZE];


### PR DESCRIPTION
I think this is the right way to solve the problem.  Fixes #5220.

The problem with cpuid is that to do it correctly, we need to run it on the separate CPUs.  That's a pain, and the OS already does it.  Of course, the OS might be wrong (especially on a non-heterogeneous multiprocessing system), but in that case we have little hope of doing better.

This uses OS APIs to determine core count on Windows, Linux, Android, and Mac - all only for x86 CPUs (no change to ARM for Android or Linux.)

Not actually tested on UWP, but probably uses the right function.  Should still work on XP.

Biggest benefit of this is properly detecting the number of cores to use for texture scaling and the software renderer.  It probably wasn't so terribly wrong before (we only use num_cores), but reporting suggests we have some wrong values creeping in here: 25 (maybe correct), 134, 170, 123, 148, etc.

Also it means we could consider using all threads for num workers - or at least somewhere between.  We typically get better texture scaling or software renderer performance using all threads, e.g. 50% better than using only all cores.

-[Unknown]