### PR TITLE
Add: allow touch screen events on fullscreen

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -684,7 +684,6 @@ int main(int argc, char *argv[]) {
 				}
 			case SDL_FINGERMOTION:
 				{
-					if (!g_Config.bFullScreen) { break; }
 					SDL_GetWindowSize(window, &w, &h);
 					touchEvent.type = SDL_MOUSEMOTION;
 					touchEvent.motion.type = SDL_MOUSEMOTION;
@@ -702,7 +701,6 @@ int main(int argc, char *argv[]) {
 				}
 			case SDL_FINGERDOWN:
 				{
-					if (!g_Config.bFullScreen) { break; }
 					SDL_GetWindowSize(window, &w, &h);
 					touchEvent.type = SDL_MOUSEBUTTONDOWN;
 					touchEvent.button.type = SDL_MOUSEBUTTONDOWN;
@@ -732,7 +730,6 @@ int main(int argc, char *argv[]) {
 				}
 			case SDL_FINGERUP:
 				{
-					if(!g_Config.bFullScreen) { break; }
 					SDL_GetWindowSize(window, &w, &h);
 					touchEvent.type = SDL_MOUSEBUTTONUP;
 					touchEvent.button.type = SDL_MOUSEBUTTONUP;


### PR DESCRIPTION
## Description
Disable full screen check for touch screen events

## Motivation and Context
It also works in window mode, moving the window itself on the desktop is done with xinput touch events, every touch event that is done inside the window is handled by SDL2 -> very cool !
No special handling is needed for it

## How Has This Been Tested?
Laptop with touch screen on Ubuntu 18.04
Didn't test it on macOS but i guess that should work the same way