### PR TITLE
Android: Don't use "hw scaling" on modern devices by default.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -510,6 +510,12 @@ static bool DefaultTimerHack() {
 
 static int DefaultAndroidHwScale() {
 #ifdef __ANDROID__
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 19) {
+		// Arbitrary cutoff at Kitkat - modern devices are usually powerful enough that hw scaling
+		// doesn't really help very much and mostly causes problems. See #11151
+		return 0;
+	}
+
 	// Get the real resolution as passed in during startup, not dp_xres and stuff
 	int xres = System_GetPropertyInt(SYSPROP_DISPLAY_XRES);
 	int yres = System_GetPropertyInt(SYSPROP_DISPLAY_YRES);


### PR DESCRIPTION
It seems to cause more problems than it's worth, see #11151 and multiple other issues with rotation etc.

Should we force this by renaming the config option? And what should the cutoff be? Really old devices usually benefit quite noticeably.

See also #11154 and #11198