### PR TITLE
UI: Fix occassional issue starting second game

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -129,6 +129,9 @@ EmuScreen::EmuScreen(const std::string &filename)
 	frameStep_ = false;
 	lastNumFlips = gpuStats.numFlips;
 	startDumping = false;
+	// Make sure we don't leave it at powerdown after the last game.
+	if (coreState == CORE_POWERDOWN)
+		coreState = CORE_STEPPING;
 
 	OnDevMenu.Handle(this, &EmuScreen::OnDevTools);
 }


### PR DESCRIPTION
Sometimes render() would be called before update() after creating EmuScreen, and we'd exit out instead of starting the game.

-[Unknown]