### PR TITLE
Fix: should close on spec #11404

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CMAKE_SYSTEM_PROCESSOR)
 			endif()
 		if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^armv7")
 			set(ARMV7 ON)
-			add_compile_options(-mfpu=neon-vfpv4)
+			add_compile_options(-mfpu=neon)
 			# Horrifying workaround for bug in android cmake stuff for asm files
 			if (ANDROID)
 				set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -target armv7a-none-linux-android")


### PR DESCRIPTION
## Description
Devices that do not support VFPv4 hang or segfault on start

## Motivation and Context
Still support devices like Sony Xperia Play 

## How Has This Been Tested?
Not tested, but expected to work