### PR TITLE
GPU: Correct handling of large viewport scaling

### DIFF
--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -30,7 +30,7 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 	// Account for the projection viewport adjustment when viewport is too large.
 	auto reverseViewportX = [](float x) {
 		float pspViewport = (x - gstate.getViewportXCenter()) * (1.0f / gstate.getViewportXScale());
-		return pspViewport * (1.0f / gstate_c.vpWidthScale);
+		return (pspViewport - gstate_c.vpXOffset) * gstate_c.vpWidthScale;
 	};
 	auto reverseViewportY = [flipViewport](float y) {
 		float heightScale = gstate_c.vpHeightScale;
@@ -39,12 +39,12 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 			heightScale = -heightScale;
 		}
 		float pspViewport = (y - gstate.getViewportYCenter()) * (1.0f / gstate.getViewportYScale());
-		return pspViewport * (1.0f / gstate_c.vpHeightScale);
+		return (pspViewport - gstate_c.vpYOffset) * heightScale;
 	};
 	auto reverseViewportZ = [hasNegZ](float z) {
 		float pspViewport = (z - gstate.getViewportZCenter()) * (1.0f / gstate.getViewportZScale());
 		// Differs from GLES: depth is 0 to 1, not -1 to 1.
-		float realViewport = (pspViewport - gstate_c.vpZOffset) * (1.0f / gstate_c.vpDepthScale);
+		float realViewport = (pspViewport - gstate_c.vpZOffset) * gstate_c.vpDepthScale;
 		return hasNegZ ? realViewport : (realViewport * 0.5f + 0.5f);
 	};
 	auto sortPair = [](float a, float b) {

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -282,7 +282,7 @@ void GPU_D3D11::FinishDeferred() {
 
 inline void GPU_D3D11::CheckFlushOp(int cmd, u32 diff) {
 	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if ((cmdFlags & FLAG_FLUSHBEFORE) || (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE))) {
+	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
 		if (dumpThisFrame_) {
 			NOTICE_LOG(G3D, "================ FLUSH ================");
 		}

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -695,10 +695,7 @@ Shader *ShaderManagerGLES::ApplyVertexShader(int prim, u32 vertType, VShaderID *
 			// Can still work with software transform.
 			VShaderID vsidTemp;
 			ComputeVertexShaderID(&vsidTemp, vertType, false);
-			uint32_t attrMask;
-			uint64_t uniformMask;
-			GenerateVertexShader(vsidTemp, codeBuffer_, &attrMask, &uniformMask);
-			vs = new Shader(render_, codeBuffer_, VertexShaderDesc(vsidTemp), GL_VERTEX_SHADER, false, attrMask, uniformMask);
+			vs = CompileVertexShader(vsidTemp);
 		}
 
 		vsCache_.Insert(*VSID, vs);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -425,7 +425,7 @@ void GPU_Vulkan::FinishDeferred() {
 
 inline void GPU_Vulkan::CheckFlushOp(int cmd, u32 diff) {
 	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if ((cmdFlags & FLAG_FLUSHBEFORE) || (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE))) {
+	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
 		if (dumpThisFrame_) {
 			NOTICE_LOG(G3D, "================ FLUSH ================");
 		}

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -392,8 +392,10 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 			glBindVertexArray(previewVao);
 			glEnableVertexAttribArray(previewProgram->a_position);
 
-			glGenBuffers(1, &ibuf);
-			glGenBuffers(1, &vbuf);
+			if (ibuf == 0)
+				glGenBuffers(1, &ibuf);
+			if (vbuf == 0)
+				glGenBuffers(1, &vbuf);
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibuf);
 			glBindBuffer(GL_ARRAY_BUFFER, vbuf);
 
@@ -451,11 +453,15 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 		glScissor((GLint)x, (GLint)-(y + fh - secondWindow->Height()), (GLsizei)fw, (GLsizei)fh);
 		BindPreviewProgram(texPreviewProgram);
 
-		if (texPreviewVao == 0 && gl_extensions.ARB_vertex_array_object) {
+		if (texPreviewVao == 0 && vbuf != 0 && ibuf != 0 && gl_extensions.ARB_vertex_array_object) {
 			glGenVertexArrays(1, &texPreviewVao);
 			glBindVertexArray(texPreviewVao);
 			glEnableVertexAttribArray(texPreviewProgram->a_position);
 
+			if (ibuf == 0)
+				glGenBuffers(1, &ibuf);
+			if (vbuf == 0)
+				glGenBuffers(1, &vbuf);
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibuf);
 			glBindBuffer(GL_ARRAY_BUFFER, vbuf);
 


### PR DESCRIPTION
Oops, divided instead of multiplying.  Also a couple other fixes, I refactored out handling of non-centered large viewports too.  Fixes #5507 based on dump.

-[Unknown]