### PR TITLE
UI: Keep report image at right aspect ratio

### DIFF
--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -175,7 +175,7 @@ protected:
 		UI::LinearLayout *content = new UI::LinearLayout(UI::ORIENT_VERTICAL);
 		parent->Add(content);
 		UI::Margins contentMargins(10, 0);
-		content->Add(new AsyncImageFileView(filename_, UI::IS_DEFAULT, nullptr, new UI::LinearLayoutParams(480, 272, contentMargins)))->SetCanBeFocused(false);
+		content->Add(new AsyncImageFileView(filename_, UI::IS_KEEP_ASPECT, nullptr, new UI::LinearLayoutParams(480, 272, contentMargins)))->SetCanBeFocused(false);
 	}
 
 private:

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -67,7 +67,7 @@ public:
 	AsyncImageFileView(const std::string &filename, UI::ImageSizeMode sizeMode, PrioritizedWorkQueue *wq, UI::LayoutParams *layoutParams = 0);
 	~AsyncImageFileView();
 
-	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 
 	void DeviceLost() override;

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -261,7 +261,7 @@ void ReportScreen::CreateViews() {
 	if (TakeGameScreenshot(screenshotFilename_.c_str(), ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, &shotWidth, &shotHeight, 4)) {
 		float scale = 340.0f * (1.0f / g_dpi_scale_y) * (1.0f / shotHeight);
 		leftColumnItems->Add(new CheckBox(&includeScreenshot_, rp->T("FeedbackIncludeScreen", "Include a screenshot")))->SetEnabledPtr(&enableReporting_);
-		screenshot_ = leftColumnItems->Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, nullptr, new LinearLayoutParams(shotWidth * scale, shotHeight * scale, Margins(12, 0))));
+		screenshot_ = leftColumnItems->Add(new AsyncImageFileView(screenshotFilename_, IS_KEEP_ASPECT, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(12, 0))));
 	} else {
 		includeScreenshot_ = false;
 		screenshot_ = nullptr;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -101,7 +101,7 @@ public:
 			std::string image_path = ReplaceAll(savePath_, ".ppst", ".jpg");
 			if (File::Exists(image_path)) {
 				PrioritizedWorkQueue *wq = g_gameInfoCache->WorkQueue();
-				toprow->Add(new AsyncImageFileView(image_path, IS_DEFAULT, wq, new LinearLayoutParams(480, 272, Margins(10, 0))));
+				toprow->Add(new AsyncImageFileView(image_path, IS_KEEP_ASPECT, wq, new LinearLayoutParams(480, 272, Margins(10, 0))));
 			} else {
 				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
 			}

--- a/ext/native/ui/view.h
+++ b/ext/native/ui/view.h
@@ -835,6 +835,7 @@ private:
 enum ImageSizeMode {
 	IS_DEFAULT,
 	IS_FIXED,
+	IS_KEEP_ASPECT,
 };
 
 class ImageView : public InertView {


### PR DESCRIPTION
Makes sense to just handle this via the size mode thing.  Fixes the report screen aspect ratio part of #11409.

-[Unknown]