### PR TITLE
Fix: prevent linkage error if EGL and GLES is not in one big blob

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 include_directories(ext/native)
 
 if(NOT OPENGL_LIBRARIES AND USING_GLES2)
-	set(OPENGL_LIBRARIES GLESv2)
+	set(OPENGL_LIBRARIES GLESv2 EGL)
 endif()
 
 if(USING_EGL)


### PR DESCRIPTION
## Description
Building for GLES2 on my desktop PC 32bit VM Linux Ubuntu machine will give a linkage error:

``lib/libnative.a(gpu_features.cpp.o): In function `CheckGLExtensions()':``
``gpu_features.cpp:(.text+0x141f): undefined reference to `eglQueryString'``
``gpu_features.cpp:(.text+0x144a): undefined reference to `eglGetCurrentDisplay'``
``gpu_features.cpp:(.text+0x145a): undefined reference to `eglQueryString'``
``lib/libnative.a(gl3stub.c.o): In function `gl3stubInit':``
``gl3stub.c:(.text+0xb): undefined reference to `eglGetProcAddress'``
``gl3stub.c:(.text+0x1c): undefined reference to `eglGetProcAddress'``
``gl3stub.c:(.text+0x2d): undefined reference to `eglGetProcAddress'``
``gl3stub.c:(.text+0x3e): undefined reference to `eglGetProcAddress'``
``gl3stub.c:(.text+0x4f): undefined reference to `eglGetProcAddress'``
``lib/libnative.a(gl3stub.c.o):gl3stub.c:(.text+0x60): more undefined references to `eglGetProcAddress'`` ``follow``
``collect2: error: ld returned 1 exit status``
``make[2]: *** [PPSSPPSDL] Error 1``

## Motivation and Context
If i.e libEGL.so and libGLESv2.so don't symbolic link to one driver binary (for MALI it is libmali.so), then
we get those linkage errors.
i.e Mesa has EGL and GLESv2 separated 

## How Has This Been Tested?
Ubuntu 14.04 inside VirtualBox with GalliumVMware backend driver to Mesa

![2018-09-25 1](https://user-images.githubusercontent.com/1681560/46014466-aa233f00-c0cf-11e8-880a-38c3b562d238.png)

