### PR TITLE
Remove redundant minSdkVersion and targetSdkVersion settings from AndroidManifest.xml

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,10 +6,6 @@
     android:versionName="1.6.3.0">
     <!-- Note that versionCode should be in the format xyzzrrrr. Example: 16030000 -->
 
-    <uses-sdk
-        android:minSdkVersion="9"
-        android:targetSdkVersion="28" />
-
     <uses-feature android:glEsVersion="0x00020000" />
     <uses-feature android:name="android.hardware.screen.landscape" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />


### PR DESCRIPTION
They're defined in a gradle file anyway and having them in both places causes problems with the new SDK.