### PR TITLE
UI: Implement a glowing border touch control style

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -590,7 +590,7 @@ void GameSettingsScreen::CreateViews() {
 		autoHide->SetEnabledPtr(&g_Config.bShowTouchControls);
 		autoHide->SetFormat("%is");
 		autoHide->SetZeroLabel(co->T("Off"));
-		static const char *touchControlStyles[] = {"Classic", "Thin borders"};
+		static const char *touchControlStyles[] = {"Classic", "Thin borders", "Glowing borders"};
 		View *style = controlsSettings->Add(new PopupMultiChoice(&g_Config.iTouchButtonStyle, co->T("Button style"), touchControlStyles, 0, ARRAY_SIZE(touchControlStyles), co->GetName(), screenManager()));
 		style->SetEnabledPtr(&g_Config.bShowTouchControls);
 	}

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -43,8 +43,8 @@ protected:
 
 class MultiTouchButton : public GamepadView {
 public:
-	MultiTouchButton(int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: GamepadView(layoutParams), scale_(scale), bgImg_(bgImg), img_(img) {
+	MultiTouchButton(int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: GamepadView(layoutParams), scale_(scale), bgImg_(bgImg), bgDownImg_(bgDownImg), img_(img) {
 	}
 
 	void Touch(const TouchInput &input) override;
@@ -62,6 +62,7 @@ protected:
 
 private:
 	int bgImg_;
+	int bgDownImg_;
 	int img_;
 	float bgAngle_ = 0.0f;
 	float angle_ = 0.0f;
@@ -70,8 +71,8 @@ private:
 
 class BoolButton : public MultiTouchButton {
 public:
-	BoolButton(bool *value, int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: MultiTouchButton(bgImg, img, scale, layoutParams), value_(value) {
+	BoolButton(bool *value, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), value_(value) {
 
 	}
 	void Touch(const TouchInput &input) override;
@@ -85,8 +86,8 @@ private:
 
 class FPSLimitButton : public MultiTouchButton {
 public:
-	FPSLimitButton(FPSLimit limit, int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: MultiTouchButton(bgImg, img, scale, layoutParams), limit_(limit) {
+	FPSLimitButton(FPSLimit limit, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), limit_(limit) {
 
 	}
 	void Touch(const TouchInput &input) override;
@@ -98,8 +99,8 @@ private:
 
 class PSPButton : public MultiTouchButton {
 public:
-	PSPButton(int pspButtonBit, int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: MultiTouchButton(bgImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit) {
+	PSPButton(int pspButtonBit, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit) {
 	}
 	void Touch(const TouchInput &input) override;
 	bool IsDown() override;
@@ -110,7 +111,7 @@ private:
 
 class PSPDpad : public GamepadView {
 public:
-	PSPDpad(int arrowIndex, int overlayIndex, float scale, float spacing, UI::LayoutParams *layoutParams);
+	PSPDpad(int arrowIndex, int arrowDownIndex, int overlayIndex, float scale, float spacing, UI::LayoutParams *layoutParams);
 
 	void Touch(const TouchInput &input) override;
 	void Draw(UIContext &dc) override;
@@ -119,6 +120,7 @@ public:
 private:
 	void ProcessTouch(float x, float y, bool down);
 	int arrowIndex_;
+	int arrowDownIndex_;
 	int overlayIndex_;
 
 	float scale_;
@@ -130,7 +132,7 @@ private:
 
 class PSPStick : public GamepadView {
 public:
-	PSPStick(int bgImg, int stickImg, int stick, float scale, UI::LayoutParams *layoutParams);
+	PSPStick(int bgImg, int stickImg, int stickDownImg, int stick, float scale, UI::LayoutParams *layoutParams);
 
 	void Touch(const TouchInput &input) override;
 	void Draw(UIContext &dc) override;
@@ -142,6 +144,7 @@ private:
 	int dragPointerId_;
 	int bgImg_;
 	int stickImageIndex_;
+	int stickDownImg_;
 	int stick_;
 	float stick_size_;
 	float scale_;
@@ -160,8 +163,8 @@ const int baseActionButtonSpacing = 60;
 
 class ComboKey : public MultiTouchButton {
 public:
-	ComboKey(int pspButtonBit, int bgImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: MultiTouchButton(bgImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit)  {
+	ComboKey(int pspButtonBit, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit)  {
 	}
 	void Touch(const TouchInput &input) override;
 private:

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -37,13 +37,13 @@ static float local_dp_xres;
 static float local_dp_yres;
 
 static u32 GetButtonColor() {
-	return g_Config.iTouchButtonStyle == 1 ? 0xFFFFFF : 0xc0b080;
+	return g_Config.iTouchButtonStyle != 0 ? 0xFFFFFF : 0xc0b080;
 }
 
 class DragDropButton : public MultiTouchButton {
 public:
 	DragDropButton(ConfigTouchPos &pos, int bgImg, int img)
-	: MultiTouchButton(bgImg, img, pos.scale, new UI::AnchorLayoutParams(fromFullscreenCoord(pos.x), pos.y * local_dp_yres, UI::NONE, UI::NONE, true)),
+	: MultiTouchButton(bgImg, bgImg, img, pos.scale, new UI::AnchorLayoutParams(fromFullscreenCoord(pos.x), pos.y * local_dp_yres, UI::NONE, UI::NONE, true)),
 		x_(pos.x), y_(pos.y), theScale_(pos.scale) {
 		scale_ = theScale_;
 	}


### PR DESCRIPTION
Sorta like #5624, but not really the same because it barely glows.  Just brighter and with a background.  Didn't want to implement complicated bloom or color effects...

I kinda prefer this though, as I like it not covering up even more than my fingers already cover.  When they double in size, sometimes I slip off them because I don't realize where their edges are, too.

-[Unknown]