### PR TITLE
Replacement: Show a warning for bad texture names

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -653,6 +653,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("TrueColor", &g_Config.bTrueColor, true, true, true),
 	ReportedConfigSetting("ReplaceTextures", &g_Config.bReplaceTextures, true, true, true),
 	ReportedConfigSetting("SaveNewTextures", &g_Config.bSaveNewTextures, false, true, true),
+	ReportedConfigSetting("IgnoreTextureFilenames", &g_Config.bIgnoreTextureFilenames, true, true, false),
 
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1, true, true),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -168,6 +168,7 @@ public:
 	bool bTrueColor;
 	bool bReplaceTextures;
 	bool bSaveNewTextures;
+	bool bIgnoreTextureFilenames;
 	int iTexScalingLevel; // 0 = auto, 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -636,14 +636,15 @@ bool TextureReplacer::GenerateIni(const std::string &gameID, std::string *genera
 		// Let's also write some defaults.
 		std::fstream fs;
 		File::OpenCPPFile(fs, texturesDirectory + INI_FILENAME, std::ios::out | std::ios::ate);
-		fs << "# This file is optional\n";
-		fs << "# for syntax explanation check:\n";
-		fs << "# - https://github.com/hrydgard/ppsspp/pull/8715 \n";
-		fs << "# - https://github.com/hrydgard/ppsspp/pull/8792 \n";
+		fs << "# This file is optional and describes your textures.\n";
+		fs << "# Some information on syntax available here:\n";
+		fs << "# https://github.com/hrydgard/ppsspp/wiki/Texture-replacement-ini-syntax\n";
 		fs << "[options]\n";
 		fs << "version = 1\n";
 		fs << "hash = quick\n";
 		fs << "\n";
+		fs << "# Use / for folders not \\, avoid special characters, and stick to lowercase.\n";
+		fs << "# See wiki for more info.\n";
 		fs << "[hashes]\n";
 		fs << "\n";
 		fs << "[hashranges]\n";

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -22,11 +22,13 @@
 #endif
 
 #include <algorithm>
+#include "i18n/i18n.h"
 #include "ext/xxhash.h"
 #include "file/ini_file.h"
 #include "Common/ColorConv.h"
 #include "Common/FileUtil.h"
 #include "Core/Config.h"
+#include "Core/Host.h"
 #include "Core/System.h"
 #include "Core/TextureReplacer.h"
 #include "Core/ELF/ParamSFO.h"
@@ -112,17 +114,33 @@ bool TextureReplacer::LoadIni() {
 			ERROR_LOG(G3D, "Unsupported texture replacement version %d, trying anyway", version);
 		}
 
+		bool filenameWarning = false;
 		if (ini.HasSection("hashes")) {
 			auto hashes = ini.GetOrCreateSection("hashes")->ToMap();
 			// Format: hashname = filename.png
+			bool checkFilenames = g_Config.bSaveNewTextures && g_Config.bIgnoreTextureFilenames;
 			for (const auto &item : hashes) {
 				ReplacementAliasKey key(0, 0, 0);
 				if (sscanf(item.first.c_str(), "%16llx%8x_%d", &key.cachekey, &key.hash, &key.level) >= 1) {
 					aliases_[key] = item.second;
+					if (checkFilenames) {
+#if PPSSPP_PLATFORM(WINDOWS)
+						// Uppercase probably means the filenames don't match.
+						// Avoiding an actual check of the filenames to avoid performance impact.
+						filenameWarning = filenameWarning || item.second.find_first_of("\\ABCDEFGHIJKLMNOPQRSTUVWXYZ") != std::string::npos;
+#else
+						filenameWarning = filenameWarning || item.second.find_first_of("\\:<>|?*") != std::string::npos;
+#endif
+					}
 				} else {
 					ERROR_LOG(G3D, "Unsupported syntax under [hashes]: %s", item.first.c_str());
 				}
 			}
+		}
+
+		if (filenameWarning) {
+			I18NCategory *err = GetI18NCategory("Error");
+			host->NotifyUserMessage(err->T("textures.ini filenames may not be cross-platform"), 6.0f);
 		}
 
 		if (ini.HasSection("hashranges")) {

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -613,3 +613,41 @@ void ReplacedTexture::Load(int level, void *out, int rowPitch) {
 	png_image_free(&png);
 #endif
 }
+
+bool TextureReplacer::GenerateIni(const std::string &gameID, std::string *generatedFilename) {
+	if (gameID.empty())
+		return false;
+
+	std::string texturesDirectory = GetSysDirectory(DIRECTORY_TEXTURES) + gameID + "/";
+	if (!File::Exists(texturesDirectory)) {
+		File::CreateFullPath(texturesDirectory);
+	}
+
+	if (generatedFilename)
+		*generatedFilename = texturesDirectory + INI_FILENAME;
+	if (File::Exists(texturesDirectory + INI_FILENAME))
+		return true;
+
+	FILE *f = File::OpenCFile(texturesDirectory + INI_FILENAME, "wb");
+	if (f) {
+		fwrite("\xEF\xBB\xBF", 0, 3, f);
+		fclose(f);
+
+		// Let's also write some defaults.
+		std::fstream fs;
+		File::OpenCPPFile(fs, texturesDirectory + INI_FILENAME, std::ios::out | std::ios::ate);
+		fs << "# This file is optional\n";
+		fs << "# for syntax explanation check:\n";
+		fs << "# - https://github.com/hrydgard/ppsspp/pull/8715 \n";
+		fs << "# - https://github.com/hrydgard/ppsspp/pull/8792 \n";
+		fs << "[options]\n";
+		fs << "version = 1\n";
+		fs << "hash = quick\n";
+		fs << "\n";
+		fs << "[hashes]\n";
+		fs << "\n";
+		fs << "[hashranges]\n";
+		fs.close();
+	}
+	return File::Exists(texturesDirectory + INI_FILENAME);
+}

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -186,6 +186,8 @@ public:
 
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 
+	static bool GenerateIni(const std::string &gameID, std::string *generatedFilename);
+
 protected:
 	bool LoadIni();
 	void ParseHashRange(const std::string &key, const std::string &value);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -53,6 +53,7 @@
 #include "Core/Host.h"
 #include "Core/System.h"
 #include "Core/Reporting.h"
+#include "Core/TextureReplacer.h"
 #include "Core/WebServer.h"
 #include "GPU/Common/PostShader.h"
 #include "android/jni/TestRunner.h"
@@ -1345,38 +1346,9 @@ UI::EventReturn DeveloperToolsScreen::OnLoadLanguageIni(UI::EventParams &e) {
 
 UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) {
 	std::string gameID = g_paramSFO.GetDiscID();
-	std::string texturesDirectory = GetSysDirectory(DIRECTORY_TEXTURES) + gameID + "/";
-	bool enabled_ = !gameID.empty();
-	if (enabled_) {
-		if (!File::Exists(texturesDirectory)) {
-			File::CreateFullPath(texturesDirectory);
-		}
-		if (!File::Exists(texturesDirectory + "textures.ini")) {
-			FILE *f = File::OpenCFile(texturesDirectory + "textures.ini", "wb");
-			if (f) {
-				fwrite("\xEF\xBB\xBF", 0, 3, f);
-				fclose(f);
-				// Let's also write some defaults
-				std::fstream fs;
-				File::OpenCPPFile(fs, texturesDirectory + "textures.ini", std::ios::out | std::ios::ate);
-				fs << "# This file is optional\n";
-				fs << "# for syntax explanation check:\n";
-				fs << "# - https://github.com/hrydgard/ppsspp/pull/8715 \n";
-				fs << "# - https://github.com/hrydgard/ppsspp/pull/8792 \n";
-				fs << "[options]\n";
-				fs << "version = 1\n";
-				fs << "hash = quick\n";
-				fs << "\n";
-				fs << "[hashes]\n";
-				fs << "\n";
-				fs << "[hashranges]\n";
-				fs.close();
-			}
-		}
-		enabled_ = File::Exists(texturesDirectory + "textures.ini");
-	}
-	if (enabled_) {
-		File::openIniFile(texturesDirectory + "textures.ini");
+	std::string generatedFilename;
+	if (TextureReplacer::GenerateIni(gameID, &generatedFilename)) {
+		File::openIniFile(generatedFilename);
 	}
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
Fixes #11081.  Assumes any uppercase character on Windows is bad, but doesn't actually check filenames to avoid a performance impact (I was worried people would just turn off the check if it made things slow.)

-[Unknown]