### PR TITLE
Android build: Enable AAPT2

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableAapt2=true


### PR DESCRIPTION
This appears to be all that's needed to enable building Android "app bundles", which automatically splits the APK by ABI for Play Store downloads, reducing the download size in future official versions.