### PR TITLE
Avoid calling any GL calls during shutdown on Android. Should help #11063

### DIFF
--- a/android/jni/AndroidGraphicsContext.h
+++ b/android/jni/AndroidGraphicsContext.h
@@ -23,6 +23,7 @@ public:
 	// Android (EGL, Vulkan) we do have all this info on the render thread.
 	virtual bool InitFromRenderThread(ANativeWindow *wnd, int desiredBackbufferSizeX, int desiredBackbufferSizeY, int backbufferFormat, int androidVersion) = 0;
 	virtual bool Initialized() = 0;
+	virtual void BeginAndroidShutdown() {}
 
 private:
 	using GraphicsContext::InitFromRenderThread;

--- a/android/jni/AndroidJavaGLContext.h
+++ b/android/jni/AndroidJavaGLContext.h
@@ -41,6 +41,10 @@ public:
 		return renderManager_->ThreadFrame();
 	}
 
+	void BeginAndroidShutdown() override {
+		renderManager_->SetSkipGLCalls();
+	}
+
 	void ThreadEnd() override {
 		renderManager_->ThreadEnd();
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -528,13 +528,18 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 	if (renderer_inited && useCPUThread && graphicsContext) {
 		// Only used in Java EGL path.
 		EmuThreadStop();
+		graphicsContext->BeginAndroidShutdown();
+		// Skipping GL calls, the old context is gone.
 		while (graphicsContext->ThreadFrame()) {
+			ILOG("graphicsContext->ThreadFrame executed to clear buffers");
 			continue;
 		}
+		ILOG("Joining emuthread");
 		EmuThreadJoin();
 
 		graphicsContext->ThreadEnd();
 		graphicsContext->ShutdownFromRenderThread();
+		ILOG("Graphics context now shut down from NativeApp_shutdown");
 	}
 
 	ILOG("NativeApp.shutdown() -- begin");
@@ -565,6 +570,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 		ILOG("NativeApp.displayInit() restoring");
 		if (useCPUThread) {
 			EmuThreadStop();
+			graphicsContext->BeginAndroidShutdown();
+			// Skipping GL calls here because the old context is lost.
 			while (graphicsContext->ThreadFrame()) {
 				continue;
 			}

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -107,7 +107,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 				GLRTexture *tex = step.texture_image.texture;
 				if (step.texture_image.allocType == GLRAllocType::ALIGNED) {
 					FreeAlignedMemory(step.texture_image.data);
-				} else {
+				} else if (step.texture_image.allocType == GLRAllocType::NEW) {
 					delete[] step.texture_image.data;
 				}
 				break;
@@ -119,7 +119,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 			}
 			case GLRInitStepType::CREATE_SHADER:
 			{
-				WARN_LOG(G3D, "CREATE_PROGRAM found with skipGLCalls, not good");
+				WARN_LOG(G3D, "CREATE_SHADER found with skipGLCalls, not good");
 				break;
 			}
 			default:
@@ -490,8 +490,8 @@ void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCal
 			const GLRStep &step = *steps[i];
 			switch (step.stepType) {
 			case GLRStepType::RENDER:
+				// TODO: With #11425 there'll be a case where we should really free spline data here.
 				break;
-				// TODO
 			}
 			delete steps[i];
 		}

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -322,9 +322,9 @@ class GLQueueRunner {
 public:
 	GLQueueRunner() {}
 
-	void RunInitSteps(const std::vector<GLRInitStep> &steps);
+	void RunInitSteps(const std::vector<GLRInitStep> &steps, bool skipGLCalls);
 
-	void RunSteps(const std::vector<GLRStep *> &steps);
+	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls);
 	void LogSteps(const std::vector<GLRStep *> &steps);
 
 	void CreateDeviceObjects();

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -693,10 +693,8 @@ void GLPushBuffer::Destroy(bool onRenderThread) {
 		// This will automatically unmap device memory, if needed.
 		// NOTE: We immediately delete the buffer, don't go through the deleter, if we're on the render thread.
 		if (onRenderThread) {
-			// _dbg_assert_(G3D, OnRenderThread());
 			delete info.buffer;
 		} else {
-			// _dbg_assert_(G3D, !OnRenderThread());
 			render_->DeleteBuffer(info.buffer);
 		}
 

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -21,33 +21,51 @@ static bool OnRenderThread() {
 #endif
 
 // Runs on the GPU thread.
-void GLDeleter::Perform(GLRenderManager *renderManager) {
+void GLDeleter::Perform(GLRenderManager *renderManager, bool skipGLCalls) {
 	for (auto pushBuffer : pushBuffers) {
 		renderManager->UnregisterPushBuffer(pushBuffer);
+		if (skipGLCalls) {
+			pushBuffer->Destroy(false);
+		}
 		delete pushBuffer;
 	}
 	pushBuffers.clear();
 	for (auto shader : shaders) {
+		if (skipGLCalls)
+			shader->shader = 0;  // prevent the glDeleteShader
 		delete shader;
 	}
 	shaders.clear();
 	for (auto program : programs) {
+		if (skipGLCalls)
+			program->program = 0;  // prevent the glDeleteProgram
 		delete program;
 	}
 	programs.clear();
 	for (auto buffer : buffers) {
+		if (skipGLCalls)
+			buffer->buffer_ = 0;
 		delete buffer;
 	}
 	buffers.clear();
 	for (auto texture : textures) {
+		if (skipGLCalls)
+			texture->texture = 0;
 		delete texture;
 	}
 	textures.clear();
 	for (auto inputLayout : inputLayouts) {
+		// No GL objects in an inputLayout yet
 		delete inputLayout;
 	}
 	inputLayouts.clear();
 	for (auto framebuffer : framebuffers) {
+		if (skipGLCalls) {
+			framebuffer->z_buffer = 0;
+			framebuffer->stencil_buffer = 0;
+			framebuffer->z_stencil_buffer = 0;
+			framebuffer->handle = 0;
+		}
 		delete framebuffer;
 	}
 	framebuffers.clear();
@@ -65,7 +83,7 @@ GLRenderManager::~GLRenderManager() {
 		_assert_(frameData_[i].deleter_prev.IsEmpty());
 	}
 	// Was anything deleted during shutdown?
-	deleter_.Perform(this);
+	deleter_.Perform(this, false);
 	_assert_(deleter_.IsEmpty());
 }
 
@@ -112,15 +130,15 @@ void GLRenderManager::ThreadEnd() {
 
 	// Good point to run all the deleters to get rid of leftover objects.
 	for (int i = 0; i < MAX_INFLIGHT_FRAMES; i++) {
-		frameData_[i].deleter.Perform(this);
-		frameData_[i].deleter_prev.Perform(this);
+		frameData_[i].deleter.Perform(this, false);
+		frameData_[i].deleter_prev.Perform(this, false);
 		for (int j = 0; j < (int)frameData_[i].steps.size(); j++) {
 			delete frameData_[i].steps[j];
 		}
 		frameData_[i].steps.clear();
 		frameData_[i].initSteps.clear();
 	}
-	deleter_.Perform(this);
+	deleter_.Perform(this, false);
 
 	for (int i = 0; i < (int)steps_.size(); i++) {
 		delete steps_[i];
@@ -154,7 +172,7 @@ bool GLRenderManager::ThreadFrame() {
 			}
 			VLOG("PULL: Setting frame[%d].readyForRun = false", threadFrame_);
 			frameData.readyForRun = false;
-			frameData.deleter_prev.Perform(this);
+			frameData.deleter_prev.Perform(this, skipGLCalls_);
 			frameData.deleter_prev.Take(frameData.deleter);
 			// Previously we had a quick exit here that avoided calling Run() if run_ was suddenly false,
 			// but that created a race condition where frames could end up not finished properly on resize etc.
@@ -481,20 +499,24 @@ void GLRenderManager::Run(int frame) {
 	auto &stepsOnThread = frameData_[frame].steps;
 	auto &initStepsOnThread = frameData_[frame].initSteps;
 	// queueRunner_.LogSteps(stepsOnThread);
-	queueRunner_.RunInitSteps(initStepsOnThread);
+	queueRunner_.RunInitSteps(initStepsOnThread, skipGLCalls_);
 	initStepsOnThread.clear();
 
 	// Run this after RunInitSteps so any fresh GLRBuffers for the pushbuffers can get created.
-	for (auto iter : frameData.activePushBuffers) {
-		iter->Flush();
-		iter->UnmapDevice();
+	if (!skipGLCalls_) {
+		for (auto iter : frameData.activePushBuffers) {
+			iter->Flush();
+			iter->UnmapDevice();
+		}
 	}
 
-	queueRunner_.RunSteps(stepsOnThread);
+	queueRunner_.RunSteps(stepsOnThread, skipGLCalls_);
 	stepsOnThread.clear();
 
-	for (auto iter : frameData.activePushBuffers) {
-		iter->MapDevice(bufferStrategy_);
+	if (!skipGLCalls_) {
+		for (auto iter : frameData.activePushBuffers) {
+			iter->MapDevice(bufferStrategy_);
+		}
 	}
 
 	switch (frameData.type) {
@@ -628,8 +650,8 @@ void GLPushBuffer::Flush() {
 	if (!buffers_[buf_].deviceMemory && writePtr_) {
 		auto &info = buffers_[buf_];
 		if (info.flushOffset != 0) {
-			assert(info.buffer->buffer);
-			glBindBuffer(target_, info.buffer->buffer);
+			assert(info.buffer->buffer_);
+			glBindBuffer(target_, info.buffer->buffer_);
 			glBufferSubData(target_, 0, info.flushOffset, info.localMemory);
 		}
 
@@ -646,7 +668,7 @@ void GLPushBuffer::Flush() {
 			if (info.flushOffset == 0 || !info.deviceMemory)
 				continue;
 
-			glBindBuffer(target_, info.buffer->buffer);
+			glBindBuffer(target_, info.buffer->buffer_);
 			glFlushMappedBufferRange(target_, 0, info.flushOffset);
 			info.flushOffset = 0;
 		}
@@ -664,16 +686,17 @@ bool GLPushBuffer::AddBuffer() {
 	return true;
 }
 
-// Executed on the render thread!
 void GLPushBuffer::Destroy(bool onRenderThread) {
+	if (buf_ == -1)
+		return;  // Already destroyed
 	for (BufInfo &info : buffers_) {
 		// This will automatically unmap device memory, if needed.
 		// NOTE: We immediately delete the buffer, don't go through the deleter, if we're on the render thread.
 		if (onRenderThread) {
-			_dbg_assert_(G3D, OnRenderThread());
+			// _dbg_assert_(G3D, OnRenderThread());
 			delete info.buffer;
 		} else {
-			_dbg_assert_(G3D, !OnRenderThread());
+			// _dbg_assert_(G3D, !OnRenderThread());
 			render_->DeleteBuffer(info.buffer);
 		}
 
@@ -708,7 +731,7 @@ void GLPushBuffer::NextBuffer(size_t minSize) {
 }
 
 void GLPushBuffer::Defragment() {
-	_dbg_assert_(G3D, !OnRenderThread());
+	_dbg_assert_msg_(G3D, !OnRenderThread(), "Defragment must not run on the render thread");
 
 	if (buffers_.size() <= 1) {
 		// Let's take this chance to jetison localMemory we don't need.
@@ -728,7 +751,7 @@ void GLPushBuffer::Defragment() {
 
 	size_ = newSize;
 	bool res = AddBuffer();
-	_assert_(res);
+	_dbg_assert_msg_(G3D, res, "AddBuffer failed");
 }
 
 size_t GLPushBuffer::GetTotalSize() const {
@@ -740,7 +763,7 @@ size_t GLPushBuffer::GetTotalSize() const {
 }
 
 void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
-	_dbg_assert_(G3D, OnRenderThread());
+	_dbg_assert_msg_(G3D, OnRenderThread(), "MapDevice must run on render thread");
 
 	strategy_ = strategy;
 	if (strategy_ == GLBufferStrategy::SUBDATA) {
@@ -749,7 +772,7 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 
 	bool mapChanged = false;
 	for (auto &info : buffers_) {
-		if (!info.buffer->buffer || info.deviceMemory) {
+		if (!info.buffer->buffer_ || info.deviceMemory) {
 			// Can't map - no device buffer associated yet or already mapped.
 			continue;
 		}
@@ -763,7 +786,7 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 			mapChanged = true;
 		}
 
-		assert(info.localMemory || info.deviceMemory);
+		_dbg_assert_msg_(G3D, info.localMemory || info.deviceMemory, "Local or device memory must succeed");
 	}
 
 	if (writePtr_ && mapChanged) {
@@ -774,7 +797,7 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 }
 
 void GLPushBuffer::UnmapDevice() {
-	_dbg_assert_(G3D, OnRenderThread());
+	_dbg_assert_msg_(G3D, OnRenderThread(), "UnmapDevice must run on render thread");
 
 	for (auto &info : buffers_) {
 		if (info.deviceMemory) {
@@ -786,7 +809,7 @@ void GLPushBuffer::UnmapDevice() {
 }
 
 void *GLRBuffer::Map(GLBufferStrategy strategy) {
-	assert(buffer != 0);
+	assert(buffer_ != 0);
 
 	GLbitfield access = GL_MAP_WRITE_BIT;
 	if ((strategy & GLBufferStrategy::MASK_FLUSH) != 0) {
@@ -799,7 +822,7 @@ void *GLRBuffer::Map(GLBufferStrategy strategy) {
 	void *p = nullptr;
 	bool allowNativeBuffer = strategy != GLBufferStrategy::SUBDATA;
 	if (allowNativeBuffer) {
-		glBindBuffer(target_, buffer);
+		glBindBuffer(target_, buffer_);
 
 		if (gl_extensions.ARB_buffer_storage || gl_extensions.EXT_buffer_storage) {
 #ifndef IOS
@@ -831,7 +854,7 @@ void *GLRBuffer::Map(GLBufferStrategy strategy) {
 }
 
 bool GLRBuffer::Unmap() {
-	glBindBuffer(target_, buffer);
+	glBindBuffer(target_, buffer_);
 	mapped_ = false;
 	return glUnmapBuffer(target_) == GL_TRUE;
 }


### PR DESCRIPTION
Should help #11063.

The context is already lost and we're really running shutdown when the process is woken
up again. Additionally, orderly shutdown through the button doesn't happen
on the render thread so remove a couple of asserts that are wrong.