### PR TITLE
Display: Resched interrupt before vblank threads

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -645,6 +645,9 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 
 	CoreTiming::ScheduleEvent(msToCycles(vblankMs) - cyclesLate, leaveVblankEvent, vbCount + 1);
 
+	// Trigger VBlank interrupt handlers.
+	__TriggerInterrupt(PSP_INTR_IMMEDIATE | PSP_INTR_ONLY_IF_ENABLED | PSP_INTR_ALWAYS_RESCHED, PSP_VBLANK_INTR, PSP_INTR_SUB_ALL);
+
 	// Wake up threads waiting for VBlank
 	u32 error;
 	bool wokeThreads = false;
@@ -662,9 +665,6 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	if (wokeThreads) {
 		__KernelReSchedule("entered vblank");
 	}
-
-	// Trigger VBlank interrupt handlers.
-	__TriggerInterrupt(PSP_INTR_IMMEDIATE | PSP_INTR_ONLY_IF_ENABLED | PSP_INTR_ALWAYS_RESCHED, PSP_VBLANK_INTR, PSP_INTR_SUB_ALL);
 
 	numVBlanks++;
 	numVBlanksSinceFlip++;

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -955,7 +955,10 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 	displayFramebuf_ = vfb;
 
 	if (vfb->fbo) {
-		DEBUG_LOG(FRAMEBUF, "Displaying FBO %08x", vfb->fb_address);
+		if (coreState == CORE_STEPPING)
+			VERBOSE_LOG(FRAMEBUF, "Displaying FBO %08x", vfb->fb_address);
+		else
+			DEBUG_LOG(FRAMEBUF, "Displaying FBO %08x", vfb->fb_address);
 
 		int uvRotation = useBufferedRendering_ ? g_Config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 


### PR DESCRIPTION
This seems more correct.  It also seems to prevent the issue in #11414 from being visible.  Maybe we say it fixes it...

That said, I do think there's a separate bug there, just am having trouble finding it.  All our draw params seem right...

-[Unknown]