### PR TITLE
Ignore broken pipe / SIGPIPE signal to avoid crash

### DIFF
--- a/ext/native/base/buffer.cpp
+++ b/ext/native/base/buffer.cpp
@@ -143,7 +143,7 @@ bool Buffer::FlushToFile(const char *filename) {
 
 bool Buffer::FlushSocket(uintptr_t sock) {
 	for (size_t pos = 0, end = data_.size(); pos < end; ) {
-		int sent = send(sock, &data_[pos], (int)(end - pos), 0);
+		int sent = send(sock, &data_[pos], (int)(end - pos), MSG_NOSIGNAL);
 		if (sent < 0) {
 			ELOG("FlushSocket failed");
 			return false;

--- a/ext/native/base/buffer.cpp
+++ b/ext/native/base/buffer.cpp
@@ -13,6 +13,11 @@
 #include <unistd.h>
 #endif
 
+#ifndef MSG_NOSIGNAL
+// Default value to 0x00 (do nothing) in systems where it's not supported.
+#define MSG_NOSIGNAL 0x00
+#endif
+
 #include "base/logging.h"
 #include "base/timeutil.h"
 #include "file/fd_util.h"


### PR DESCRIPTION
Every time I enabled the remote debugger setting, the emulator crashed immediately. Even without running any game. Also, it started to crash on the start-up, without showing the UI yet. In all cases the crash was because a broken pipe (SIGPIPE).

I am running Linux (Fedora 28) and the issue affects to both QT and SDL versions. Tested with the latest commit of master branch.

Thanks @unknownbrackets for suggesting the fix!
The issue is fixed by ignoring the SIGPIPE signal in the `send` call. The error is still returned as `EPIPE` so it can be handled without crashing the whole application.

Stacktrace:
```
Thread 3 "Downloader::Do" received signal SIGPIPE, Broken pipe.
#0  0x00007ffff7bc808e in send () from /lib64/libpthread.so.0
#1  0x00000000008fd8ad in Buffer::FlushSocket (this=0x7fffc7ffe5b0, sock=26) at /lab/romhacking/emulators/ppsspp/ext/native/base/buffer.cpp:146
#2  0x0000000000921ef0 in http::Client::SendRequestWithData (this=0x7fffc7ffe780, method=0x1231eb5 "GET", resource=0x7fffc7ffe8c0 "/version.json", data="", otherHeaders=0x1231e90 "Accept: */*\r\nAccept-Encoding: gzip\r\n", progress=0x206
6540) at /lab/romhacking/emulators/ppsspp/ext/native/net/http_client.cpp:286
#3  0x0000000000921dc0 in http::Client::SendRequest (this=0x7fffc7ffe780, method=0x1231eb5 "GET", resource=0x7fffc7ffe8c0 "/version.json", otherHeaders=0x1231e90 "Accept: */*\r\nAccept-Encoding: gzip\r\n", progress=0x2066540) at /lab/rom
hacking/emulators/ppsspp/ext/native/net/http_client.cpp:263
#4  0x000000000092197d in http::Client::GET (this=0x7fffc7ffe780, resource=0x7fffc7ffe8c0 "/version.json", output=0x2066548, responseHeaders=std::vector of length 0, capacity 0, progress=0x2066540, cancelled=0x20665a6) at /lab/romhacking
/emulators/ppsspp/ext/native/net/http_client.cpp:208
#5  0x0000000000921a75 in http::Client::GET (this=0x7fffc7ffe780, resource=0x7fffc7ffe8c0 "/version.json", output=0x2066548, progress=0x2066540, cancelled=0x20665a6) at /lab/romhacking/emulators/ppsspp/ext/native/net/http_client.cpp:228
#6  0x0000000000922b3a in http::Download::Do (this=0x2066540, self=std::shared_ptr<http::Download> (use count 4, weak count 0) = {...}) at /lab/romhacking/emulators/ppsspp/ext/native/net/http_client.cpp:457
```