### PR TITLE
Fix "No backtrace available to print on this platform" on BSDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1073,6 +1073,8 @@ if(ANDROID)
 	target_link_libraries(native log EGL OpenSLES)
 elseif(WIN32)
 	target_link_libraries(native ws2_32 winmm)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "^(DragonFly|FreeBSD|NetBSD)$")
+	target_link_libraries(native execinfo)
 endif()
 setup_target_project(native native)
 

--- a/ext/native/base/backtrace.cpp
+++ b/ext/native/base/backtrace.cpp
@@ -1,6 +1,6 @@
 #include "base/backtrace.h"
 
-#if defined(__GLIBC__) && !defined(__UCLIBC__)
+#if (defined(__GLIBC__) && !defined(__UCLIBC__)) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <execinfo.h>
 #include <unistd.h>
 


### PR DESCRIPTION
While debugging a Vulkan driver on FreeBSD I've noticed PPSSPP doesn't print stacktrace in case something goes wrong. Found on v1.6.3.

### Before
```
$ ppsspp
I: VulkanLoader.cpp:290: Vulkan test instance created successfully.
I: VulkanLoader.cpp:324: Found working Vulkan API!
Vulkan might be available.
I: Config.cpp:440: Longest display side: -1 pixels. Choosing scale 1
53:45:693 Core/Config.cpp:1052 I[LOADER]: Loading controller config: /home/foo/.config/ppsspp/PSP/SYSTEM/controls.ini
Pixels: 960 x 544
Virtual pixels: 960 x 544
W: VulkanLoader.cpp:369: Vulkan base functions loaded.
W: VulkanLoader.cpp:536: Vulkan instance functions loaded.
I: VulkanContext.cpp:457: Chose physical device 0: 0x8088e4100
W: VulkanLoader.cpp:543: Vulkan device functions loaded.
I: VulkanContext.cpp:581: Device created.

I: VulkanContext.cpp:635: Creating Vulkan surface (960, 544)
I: VulkanContext.cpp:797: swapchain_format: 44 (/2)
I: VulkanContext.cpp:801: gfx_queue_: 0x809ee0120
I: VulkanContext.cpp:833: Supported present mode: 0 (IMMEDIATE)
I: VulkanContext.cpp:833: Supported present mode: 1 (MAILBOX)
I: VulkanContext.cpp:833: Supported present mode: 2 (FIFO)
I: VulkanContext.cpp:857: Chosen present mode: 1 (MAILBOX)
I: VulkanContext.cpp:863: numSwapChainImages: 3
I: VulkanQueueRunner.cpp:8: VulkanQueueRunner::CreateDeviceObjects
I: VulkanRenderManager.cpp:207: Starting Vulkan submission thread (threadInitFrame_ = 0)
I: NativeApp.cpp:659: NativeInitGraphics
I: NativeApp.cpp:735: NativeInitGraphics completed
I: VulkanRenderManager.cpp:335: Running first frame (0)
53:45:949 Common/MsgHandler.cpp:45 E[SYSTEM]: Critical: Lost the Vulkan device!
E: MsgHandler.cpp:72: Lost the Vulkan device!
No backtrace available to print on this platform
zsh: trace trap  ppsspp
```

### After
```
$ ppsspp
I: VulkanLoader.cpp:290: Vulkan test instance created successfully.
I: VulkanLoader.cpp:324: Found working Vulkan API!
Vulkan might be available.
I: Config.cpp:440: Longest display side: -1 pixels. Choosing scale 1
59:32:130 Core/Config.cpp:1052 I[LOADER]: Loading controller config: /home/foo/.config/ppsspp/PSP/SYSTEM/controls.ini
Pixels: 960 x 544
Virtual pixels: 960 x 544
W: VulkanLoader.cpp:369: Vulkan base functions loaded.
W: VulkanLoader.cpp:536: Vulkan instance functions loaded.
I: VulkanContext.cpp:457: Chose physical device 0: 0x808b2d100
W: VulkanLoader.cpp:543: Vulkan device functions loaded.
I: VulkanContext.cpp:581: Device created.

I: VulkanContext.cpp:635: Creating Vulkan surface (960, 544)
I: VulkanContext.cpp:797: swapchain_format: 44 (/2)
I: VulkanContext.cpp:801: gfx_queue_: 0x809ee2120
I: VulkanContext.cpp:833: Supported present mode: 0 (IMMEDIATE)
I: VulkanContext.cpp:833: Supported present mode: 1 (MAILBOX)
I: VulkanContext.cpp:833: Supported present mode: 2 (FIFO)
I: VulkanContext.cpp:857: Chosen present mode: 1 (MAILBOX)
I: VulkanContext.cpp:863: numSwapChainImages: 3
I: VulkanQueueRunner.cpp:8: VulkanQueueRunner::CreateDeviceObjects
I: VulkanRenderManager.cpp:207: Starting Vulkan submission thread (threadInitFrame_ = 0)
I: NativeApp.cpp:659: NativeInitGraphics
I: NativeApp.cpp:735: NativeInitGraphics completed
I: VulkanRenderManager.cpp:335: Running first frame (0)
59:32:382 Common/MsgHandler.cpp:45 E[SYSTEM]: Critical: Lost the Vulkan device!
E: MsgHandler.cpp:72: Lost the Vulkan device!
0x91daca <_Z22PrintBacktraceToStderrv+0x1a> at /usr/local/bin/ppsspp
0x9615ba <_ZN19VulkanRenderManager6SubmitEib+0x27a> at /usr/local/bin/ppsspp
0x96167c <_ZN19VulkanRenderManager14EndSubmitFrameEi+0x2c> at /usr/local/bin/ppsspp
0x95eeab <_ZN19VulkanRenderManager10ThreadFuncEv+0x5b> at /usr/local/bin/ppsspp
0x96200d <_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEM19VulkanRenderManagerFvvEPS7_EEEEEPvSC_+0x3d> at /usr/local/bin/ppsspp
zsh: trace trap  ppsspp
```
