### PR TITLE
Improve sanity checks for framebuffer readbacks

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -2064,8 +2064,8 @@ void FramebufferManagerCommon::PackFramebufferSync_(VirtualFramebuffer *vfb, int
 
 	const int dstByteOffset = (y * vfb->fb_stride + x) * dstBpp;
 
-	if (!Memory::IsValidRange(fb_address + dstByteOffset, (h * vfb->fb_stride + w) * dstBpp)) {
-		ERROR_LOG(G3D, "PackFramebufferSync_ would read outside of memory, ignoring");
+	if (!Memory::IsValidRange(fb_address + dstByteOffset, ((h - 1) * vfb->fb_stride + w) * dstBpp)) {
+		ERROR_LOG(G3D, "PackFramebufferSync_ would write outside of memory, ignoring");
 		return;
 	}
 

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -334,6 +334,8 @@ void GLRenderManager::BlitFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLR
 }
 
 bool GLRenderManager::CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride) {
+	_assert_(pixels);
+
 	GLRStep *step = new GLRStep{ GLRStepType::READBACK };
 	step->readback.src = src;
 	step->readback.srcRect = { x, y, w, h };
@@ -365,6 +367,7 @@ bool GLRenderManager::CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspec
 
 void GLRenderManager::CopyImageToMemorySync(GLRTexture *texture, int mipLevel, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride) {
 	_assert_(texture);
+	_assert_(pixels);
 	GLRStep *step = new GLRStep{ GLRStepType::READBACK_IMAGE };
 	step->readback_image.texture = texture;
 	step->readback_image.mipLevel = mipLevel;


### PR DESCRIPTION
If any of these are hit, the checks should probably be in the layer above - but still good to have extra safety.

Should help one of the issues in #11493.