### PR TITLE
Savedata: Write only one secure entry

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -471,6 +471,7 @@ int SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &saveD
 
 				snprintf(entry->filename, sizeof(entry->filename), "%s", saveFilename.c_str());
 				memcpy(entry->hash, cryptedHash, 16);
+				break;
 			}
 		}
 		sfoFile.SetValue("SAVEDATA_FILE_LIST", (u8 *)updatedList, FILE_LIST_TOTAL_SIZE, (int)FILE_LIST_TOTAL_SIZE);


### PR DESCRIPTION
Regression from 1.6.3.  Before, we were filling all the entries when the first file was saved, a regression from 1976be4.

This caused issues in games that use a single savedata folder for multiple secure files, such as Valkyria Chronicles 3 (but only when you didn't already have a SFO param created.)

-[Unknown]