### PR TITLE
GLES: Add disabled code to run GLES on desktop

### DIFF
--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -36,6 +36,9 @@
 #include "Windows/W32Util/Misc.h"
 #include "Windows/GPU/WindowsGLContext.h"
 
+// Currently, just compile time for debugging.  May be NVIDIA only.
+static const int simulateGLES = false;
+
 void WindowsGLContext::SwapBuffers() {
 	// We no longer call RenderManager::Swap here, it's handled by the render thread, which
 	// we're not on here.
@@ -293,6 +296,21 @@ bool WindowsGLContext::InitFromRenderThread(std::string *error_message) {
 	// Alright, now for the modernity. First try a 4.4, then 4.3, context, if that fails try 3.3.
 	// I can't seem to find a way that lets you simply request the newest version available.
 	if (wglewIsSupported("WGL_ARB_create_context") == 1) {
+		if (simulateGLES) {
+			const static int simulateVersions[][2] = { {3, 2}, {3, 1}, {3, 0}, {2, 0} };
+			for (auto ver : simulateVersions) {
+				const int attribsES[] = {
+					WGL_CONTEXT_MAJOR_VERSION_ARB, ver[0],
+					WGL_CONTEXT_MINOR_VERSION_ARB, ver[1],
+					WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_ES2_PROFILE_BIT_EXT,
+					0
+				};
+				m_hrc = wglCreateContextAttribsARB(hDC, 0, attribsES);
+				if (m_hrc)
+					break;
+			}
+		}
+
 		for (int tryCore = 1; tryCore >= 0 && m_hrc == nullptr; --tryCore) {
 			SetGLCoreContext(tryCore == 1);
 

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -214,6 +214,13 @@ void CheckGLExtensions() {
 		}
 	}
 
+#ifndef USING_GLES2
+	if (strstr(versionStr, "OpenGL ES") == versionStr) {
+		// For desktops running GLES.
+		gl_extensions.IsGLES = true;
+	}
+#endif
+
 	if (!gl_extensions.IsGLES) { // For desktop GL
 		gl_extensions.ver[0] = parsed[0];
 		gl_extensions.ver[1] = parsed[1];
@@ -232,7 +239,6 @@ void CheckGLExtensions() {
 		// Start by assuming we're at 2.0.
 		gl_extensions.ver[0] = 2;
 
-#ifdef USING_GLES2
 #ifdef GL_MAJOR_VERSION
 		// Before grabbing the values, reset the error.
 		glGetError();
@@ -254,6 +260,7 @@ void CheckGLExtensions() {
 #endif
 
 		// If the above didn't give us a version, or gave us a crazy version, fallback.
+#ifdef USING_GLES2
 		if (gl_extensions.ver[0] < 3 || gl_extensions.ver[0] > 5) {
 			// Try to load GLES 3.0 only if "3.0" found in version
 			// This simple heuristic avoids issues on older devices where you can only call eglGetProcAddress a limited
@@ -281,6 +288,9 @@ void CheckGLExtensions() {
 				gl_extensions.GLES3 = gl3stubInit();
 			}
 		}
+#else
+		// If we have GLEW/similar, assume GLES3 loaded.
+		gl_extensions.GLES3 = gl_extensions.ver[0] >= 3;
 #endif
 
 		if (gl_extensions.GLES3) {

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -345,9 +345,10 @@ void CheckGLExtensions() {
 	gl_extensions.ARB_buffer_storage = g_set_gl_extensions.count("GL_ARB_buffer_storage") != 0;
 	gl_extensions.ARB_vertex_array_object = g_set_gl_extensions.count("GL_ARB_vertex_array_object") != 0;
 	gl_extensions.ARB_texture_float = g_set_gl_extensions.count("GL_ARB_texture_float") != 0;
-	gl_extensions.EXT_texture_filter_anisotropic = g_set_gl_extensions.count("GL_EXT_texture_filter_anisotropic") != 0;
+	gl_extensions.EXT_texture_filter_anisotropic = g_set_gl_extensions.count("GL_EXT_texture_filter_anisotropic") != 0 || g_set_gl_extensions.count("GL_ARB_texture_filter_anisotropic") != 0;
 	gl_extensions.EXT_draw_instanced = g_set_gl_extensions.count("GL_EXT_draw_instanced") != 0;
 	gl_extensions.ARB_draw_instanced = g_set_gl_extensions.count("GL_ARB_draw_instanced") != 0;
+	gl_extensions.ARB_cull_distance = g_set_gl_extensions.count("GL_ARB_cull_distance") != 0;
 
 	if (gl_extensions.IsGLES) {
 		gl_extensions.OES_texture_npot = g_set_gl_extensions.count("GL_OES_texture_npot") != 0;
@@ -362,6 +363,7 @@ void CheckGLExtensions() {
 		gl_extensions.ARM_shader_framebuffer_fetch = g_set_gl_extensions.count("GL_ARM_shader_framebuffer_fetch") != 0;
 		gl_extensions.OES_texture_float = g_set_gl_extensions.count("GL_OES_texture_float") != 0;
 		gl_extensions.EXT_buffer_storage = g_set_gl_extensions.count("GL_EXT_buffer_storage") != 0;
+		gl_extensions.EXT_clip_cull_distance = g_set_gl_extensions.count("GL_EXT_clip_cull_distance") != 0;
 
 #if defined(__ANDROID__)
 		// On Android, incredibly, this is not consistently non-zero! It does seem to have the same value though.
@@ -521,6 +523,13 @@ void CheckGLExtensions() {
 		}
 		if (gl_extensions.VersionGEThan(4, 4)) {
 			gl_extensions.ARB_buffer_storage = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 5)) {
+			gl_extensions.ARB_cull_distance = true;
+		}
+		if (gl_extensions.VersionGEThan(4, 6)) {
+			// Actually ARB, but they're basically the same.
+			gl_extensions.EXT_texture_filter_anisotropic = true;
 		}
 	}
 

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -63,6 +63,7 @@ struct GLExtensions {
 	bool ARB_texture_float;
 	bool ARB_draw_instanced;
 	bool ARB_buffer_storage;
+	bool ARB_cull_distance;
 
 	// EXT
 	bool EXT_swap_control_tear;
@@ -78,6 +79,7 @@ struct GLExtensions {
 	bool PBO_EXT;
 	bool EXT_draw_instanced;
 	bool EXT_buffer_storage;
+	bool EXT_clip_cull_distance;
 
 	// NV
 	bool NV_shader_framebuffer_fetch;

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -841,7 +841,7 @@ void *GLRBuffer::Map(GLBufferStrategy strategy) {
 		} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
 			// GLES3 or desktop 3.
 			p = glMapBufferRange(target_, 0, size_, access);
-		} else {
+		} else if (!gl_extensions.IsGLES) {
 #ifndef USING_GLES2
 			p = glMapBuffer(target_, GL_READ_WRITE);
 #endif


### PR DESCRIPTION
NVIDIA drivers can be prompted via WGL to create a GLES profile, which is convenient for testing GLES extensions on desktop.  Now it just requires one line to enable.

Only tested on NVIDIA, but runs at least a few games without any GL errors.

Also, detect GL 4.6 as meaning aniso, and set flags for cull distance.

-[Unknown]