### PR TITLE
GLES: Correct invalid scissor handling

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -571,10 +571,17 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 	// This is a bit of a hack as the render buffer isn't always that size
 	// We always scissor on non-buffered so that clears don't spill outside the frame.
 	out.scissorEnable = true;
-	out.scissorX = renderX + displayOffsetX + scissorX1 * renderWidthFactor;
-	out.scissorY = renderY + displayOffsetY + scissorY1 * renderHeightFactor;
-	out.scissorW = (scissorX2 - scissorX1) * renderWidthFactor;
-	out.scissorH = (scissorY2 - scissorY1) * renderHeightFactor;
+	if (scissorX2 < scissorX1 || scissorY2 < scissorY1) {
+		out.scissorX = 0;
+		out.scissorY = 0;
+		out.scissorW = 0;
+		out.scissorH = 0;
+	} else {
+		out.scissorX = renderX + displayOffsetX + scissorX1 * renderWidthFactor;
+		out.scissorY = renderY + displayOffsetY + scissorY1 * renderHeightFactor;
+		out.scissorW = (scissorX2 - scissorX1) * renderWidthFactor;
+		out.scissorH = (scissorY2 - scissorY1) * renderHeightFactor;
+	}
 
 	int curRTWidth = gstate_c.curRTWidth;
 	int curRTHeight = gstate_c.curRTHeight;


### PR DESCRIPTION
OpenGL simply wasn't updating the scissor.  Direct3D 9 (also improved) seemed to maybe flip it automatically (incorrect.)

Expecting this to help #11444.  Per hardware tests, we should correctly not draw in this case.

-[Unknown]