### PR TITLE
Wait for orderly finish of cache before shutdown

### DIFF
--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -312,6 +312,10 @@ bool GPU_GLES::IsReady() {
 	return shaderManagerGL_->ContinuePrecompile();
 }
 
+void  GPU_GLES::CancelReady() {
+	shaderManagerGL_->CancelPrecompile();
+}
+
 void GPU_GLES::BuildReportingInfo() {
 	GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 
@@ -341,6 +345,7 @@ void GPU_GLES::DeviceLost() {
 	// Simply drop all caches and textures.
 	// FBOs appear to survive? Or no?
 	// TransformDraw has registered as a GfxResourceHolder.
+	CancelReady();
 	shaderManagerGL_->DeviceLost();
 	textureCacheGL_->DeviceLost();
 	fragmentTestCache_.DeviceLost();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -39,6 +39,7 @@ public:
 	void CheckGPUFeatures() override;
 
 	bool IsReady() override;
+	void CancelReady() override;
 
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -990,6 +990,10 @@ bool ShaderManagerGLES::ContinuePrecompile(float sliceTime) {
 	return true;
 }
 
+void ShaderManagerGLES::CancelPrecompile() {
+	diskCachePending_.Clear();
+}
+
 void ShaderManagerGLES::Save(const std::string &filename) {
 	if (!diskCacheDirty_) {
 		return;

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -179,6 +179,7 @@ public:
 
 	void Load(const std::string &filename);
 	bool ContinuePrecompile(float sliceTime = 1.0f / 60.0f);
+	void CancelPrecompile();
 	void Save(const std::string &filename);
 
 private:

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -107,9 +107,11 @@ bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 
 void GPU_Shutdown() {
 	// Wait for IsReady, since it might be running on a thread.
-	// Potentially we could set a flag to try to early quit.
-	while (gpu && !gpu->IsReady()) {
-		sleep_ms(10);
+	if (gpu) {
+		gpu->CancelReady();
+		while (!gpu->IsReady()) {
+			sleep_ms(10);
+		}
 	}
 	delete gpu;
 	gpu = nullptr;

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -17,6 +17,7 @@
 
 #include "ppsspp_config.h"
 
+#include "base/timeutil.h"
 #include "Common/GraphicsContext.h"
 #include "Core/Core.h"
 
@@ -105,7 +106,12 @@ bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 #endif
 
 void GPU_Shutdown() {
+	// Wait for IsReady, since it might be running on a thread.
+	// Potentially we could set a flag to try to early quit.
+	while (gpu && !gpu->IsReady()) {
+		sleep_ms(10);
+	}
 	delete gpu;
 	gpu = nullptr;
-	gpuDebug = 0;
+	gpuDebug = nullptr;
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -77,6 +77,8 @@ public:
 	bool IsReady() override {
 		return true;
 	}
+	void CancelReady() override {
+	}
 	void Reinitialize() override;
 
 	void BeginHostFrame() override;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -169,6 +169,7 @@ public:
 
 	// Initialization
 	virtual bool IsReady() = 0;
+	virtual void CancelReady() = 0;
 	virtual void InitClear() = 0;
 	virtual void Reinitialize() = 0;
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -18,6 +18,7 @@
 
 #include <thread>
 #include "base/logging.h"
+#include "base/timeutil.h"
 #include "profiler/profiler.h"
 
 #include "Common/ChunkFile.h"
@@ -117,6 +118,10 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 bool GPU_Vulkan::IsReady() {
 	return shaderCacheLoaded_;
+}
+
+void GPU_Vulkan::CancelReady() {
+	pipelineManager_->CancelCache();
 }
 
 void GPU_Vulkan::LoadCache(std::string filename) {
@@ -492,6 +497,10 @@ void GPU_Vulkan::DestroyDeviceObjects() {
 }
 
 void GPU_Vulkan::DeviceLost() {
+	CancelReady();
+	while (!IsReady()) {
+		sleep_ms(10);
+	}
 	if (!shaderCachePath_.empty()) {
 		SaveCache(shaderCachePath_);
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -110,6 +110,8 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 			shaderCacheLoaded_ = true;
 		});
 		th.detach();
+	} else {
+		shaderCacheLoaded_ = true;
 	}
 }
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -39,6 +39,7 @@ public:
 	void CheckGPUFeatures() override;
 
 	bool IsReady() override;
+	void CancelReady() override;
 
 	// These are where we can reset command buffers etc.
 	void BeginHostFrame() override;

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -709,7 +709,7 @@ bool PipelineManagerVulkan::LoadCache(FILE *file, bool loadRawPipelineCache, Sha
 
 	NOTICE_LOG(G3D, "Creating %d pipelines...", size);
 	for (uint32_t i = 0; i < size; i++) {
-		if (failed) {
+		if (failed || cancelCache_) {
 			break;
 		}
 		StoredVulkanPipelineKey key;
@@ -741,4 +741,8 @@ bool PipelineManagerVulkan::LoadCache(FILE *file, bool loadRawPipelineCache, Sha
 	}
 	NOTICE_LOG(G3D, "Recreated Vulkan pipeline cache (%d pipelines).", (int)size);
 	return true;
+}
+
+void PipelineManagerVulkan::CancelCache() {
+	cancelCache_ = true;
 }

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -98,10 +98,12 @@ public:
 	// Saves data for faster creation next time.
 	void SaveCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext);
 	bool LoadCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout);
+	void CancelCache();
 
 private:
 	DenseHashMap<VulkanPipelineKey, VulkanPipeline *, nullptr> pipelines_;
 	VkPipelineCache pipelineCache_ = VK_NULL_HANDLE;
 	VulkanContext *vulkan_;
 	float lineWidth_ = 1.0f;
+	bool cancelCache_ = false;
 };

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -301,7 +301,7 @@ public:
 		for (auto &iter : shaders) {
 			iter->Release();
 		}
-		render_->DeleteProgram(program_);
+		if (program_) render_->DeleteProgram(program_);
 		if (depthStencil) depthStencil->Release();
 		if (blend) blend->Release();
 		if (raster) raster->Release();


### PR DESCRIPTION
This also tries to cancel loading to prevent a big delay of rotate/lost/mainly, and stops load on device lost.

An example might be loading a game, and then immediately rotating the device (not that uncommon.)  This could cause a lost, but loading would continue in thread, which could cause various issues or crashes.

Based on crash from #11493.

-[Unknown]