### PR TITLE
Windows: Check for devices on Windows events only

### DIFF
--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -39,6 +39,7 @@
 unsigned int                  DinputDevice::pInstances = 0;
 LPDIRECTINPUT8                DinputDevice::pDI = NULL;
 std::vector<DIDEVICEINSTANCE> DinputDevice::devices;
+bool DinputDevice::needsCheck_ = true;
 
 // In order from 0.  There can be 128, but most controllers do not have that many.
 static const int dinput_buttons[] = {
@@ -120,7 +121,7 @@ BOOL CALLBACK DinputDevice::DevicesCallback(
 
 void DinputDevice::getDevices(bool refresh)
 {
-	if (devices.empty() || refresh)
+	if (refresh)
 	{
 		getPDI()->EnumDevices(DI8DEVCLASS_GAMECTRL, &DinputDevice::DevicesCallback, NULL, DIEDFL_ATTACHEDONLY);
 	}
@@ -368,6 +369,7 @@ void DinputDevice::ApplyButtons(DIJOYSTATE2 &state) {
 
 size_t DinputDevice::getNumPads()
 {
-	getDevices(true);
+	getDevices(needsCheck_);
+	needsCheck_ = false;
 	return devices.size();
 }

--- a/Windows/DinputDevice.h
+++ b/Windows/DinputDevice.h
@@ -35,6 +35,10 @@ public:
 	virtual int UpdateState();
 	virtual bool IsPad() { return true; }
 	static size_t getNumPads();
+	static void CheckDevices() {
+		needsCheck_ = true;
+	}
+
 private:
 	void ApplyButtons(DIJOYSTATE2 &state);
 	//unfortunate and unclean way to keep only one DirectInput instance around
@@ -52,6 +56,7 @@ private:
 	static unsigned int     pInstances;
 	static std::vector<DIDEVICEINSTANCE> devices;
 	static LPDIRECTINPUT8   pDI;
+	static bool needsCheck_;
 	int                     pDevNum;
 	LPDIRECTINPUTDEVICE8    pJoystick;
 	DIJOYSTATE2             pPrevState;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -54,6 +54,7 @@
 #include "Windows/GEDebugger/GEDebugger.h"
 
 #include "Windows/main.h"
+#include "Windows/DinputDevice.h"
 #include "Windows/EmuThread.h"
 #include "Windows/resource.h"
 
@@ -813,6 +814,10 @@ namespace MainWindow
 		// Not sure why we are actually getting WM_CHAR even though we use RawInput, but alright..
 		case WM_CHAR:
 			return WindowsRawInput::ProcessChar(hWnd, wParam, lParam);
+
+		case WM_DEVICECHANGE:
+			DinputDevice::CheckDevices();
+			return DefWindowProc(hWnd, message, wParam, lParam);
 
 		case WM_VERYSLEEPY_MSG:
 			switch (wParam) {


### PR DESCRIPTION
A user reported stuttering after the periodic checks, and devices failing until unplug/replug.  Presumably, this is caused by poor drivers reacting badly to periodic DirectInput queries, so less queries should help.

http://forums.ppsspp.org/showthread.php?tid=24728&pid=132600#pid132600

This doesn't prevent #11461 from still working for me, although I'm slightly worried the could be some sort of delay before the device is actually available through DirectInput with some devices.

Marking this v1.7.2 if we do a v1.7.2, but I'm not sure it warrants one alone.

-[Unknown]