### PR TITLE
CMake: Link against OpenGL when using EGL but not GLES2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,15 +182,15 @@ if(NOT OPENGL_LIBRARIES AND USING_GLES2)
 	set(OPENGL_LIBRARIES GLESv2 EGL)
 endif()
 
+if(NOT OPENGL_LIBRARIES)
+	find_package(OpenGL REQUIRED)
+endif()
+
 if(USING_EGL)
 	if(NOT EGL_LIBRARIES)
 		set(EGL_LIBRARIES EGL)
 	endif()
 	set(OPENGL_LIBRARIES ${OPENGL_LIBRARIES} ${EGL_LIBRARIES})
-endif()
-
-if(NOT OPENGL_LIBRARIES)
-	find_package(OpenGL REQUIRED)
 endif()
 
 find_package(SDL2)


### PR DESCRIPTION
At least for Linux armv7hl this seems to be necessary, otherwise build
fails with:

/usr/bin/ld: lib/libnative.a(GLQueueRunner.cpp.o): undefined reference to symbol 'glStencilOp'

Build log failing before this change (Mageia 7 armv7hl): 
[build.0.20181106091318.log](https://github.com/hrydgard/ppsspp/files/2553344/build.0.20181106091318.log)


-----

**Needs testing!**

It works for me to bring compilation further (then I have another issue on Linux/ARM that I'll report in a bit), but I don't know what impact it would have on other platforms, especially embedded ones.

I kept the change minimal, but note that if `USING_GLES2` and `USING_EGL` are both true, `EGL` will end up twice in `OPENGL_LIBRARIES` in the end (both before and after this commit, I didn't change that).