### PR TITLE
CMake: Fix linking X11 when using EGL and not fbdev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,7 +489,7 @@ if(TARGET SDL2::SDL2)
 	target_link_libraries(Common SDL2::SDL2)
 endif()
 
-if(USING_GLES2)
+if(USING_GLES2 OR (USING_EGL AND NOT USING_FBDEV))
 	find_package(X11)
 endif()
 


### PR DESCRIPTION
Worked fine on Mageia 7's armv7hl buildsystem:
[build.0.20181106152619.log](https://github.com/hrydgard/ppsspp/files/2554321/build.0.20181106152619.log)

Fixes #11539