### PR TITLE
Vulkan: Allow pre-transition from undefined

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -689,6 +689,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			VkPipelineStageFlags dstStage{};
 			switch (barrier.oldLayout) {
 			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+			case VK_IMAGE_LAYOUT_UNDEFINED:
 				barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 				srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 				break;


### PR DESCRIPTION
This seems like it can happen when download/upload operations break up a render, and happens now with some dumps using the display at the right timing (#11565.)

From what I could tell, the game rendered to a framebuf, then stalled to perform a transfer, so the finalColorLayout was undefined.  Then it resumed, but tried to transition the dependent framebuf from undefined.

I figured using the same stage/access as color attachment was safest, but not certain.

-[Unknown]