### PR TITLE
GPU: Correctly flush on cull mode change

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1706,9 +1706,12 @@ bail:
 		currentList->pc += cmdCount * 4;
 		// flush back cull mode
 		if (cullMode != gstate.getCullMode()) {
+			// We rewrote everything to the old cull mode, so flush first.
+			drawEngineCommon_->DispatchFlush();
+
+			// Now update things for next time.
 			gstate.cmdmem[GE_CMD_CULL] ^= 1;
 			gstate_c.Dirty(DIRTY_RASTER_STATE);
-			drawEngineCommon_->DispatchFlush();
 		}
 	}
 


### PR DESCRIPTION
Fixes #11593 and fixes #11591 (at least based on the GE dumps.)

We rewrote all the verts to match the old cull mode, so that's what we need to flush using.  We can only change to the new cull mode afterward.

-[Unknown]