### PR TITLE
Windows: Translate all items by id, not position

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -118,7 +118,6 @@ namespace MainWindow {
 	void CreateHelpMenu(HMENU menu) {
 		I18NCategory *des = GetI18NCategory("DesktopUI");
 
-		const std::wstring help = ConvertUTF8ToWString(des->T("Help"));
 		const std::wstring visitMainWebsite = ConvertUTF8ToWString(des->T("www.ppsspp.org"));
 		const std::wstring visitForum = ConvertUTF8ToWString(des->T("PPSSPP Forums"));
 		const std::wstring buyGold = ConvertUTF8ToWString(des->T("Buy Gold"));
@@ -126,11 +125,8 @@ namespace MainWindow {
 		const std::wstring discord = ConvertUTF8ToWString(des->T("Discord"));
 		const std::wstring aboutPPSSPP = ConvertUTF8ToWString(des->T("About PPSSPP..."));
 
-		// Simply remove the old help menu and create a new one.
-		RemoveMenu(menu, ID_HELP_MENU, MF_BYCOMMAND);
-
-		HMENU helpMenu = CreatePopupMenu();
-		InsertMenu(menu, ID_HELP_MENU, MF_POPUP | MF_STRING | MF_BYCOMMAND, (UINT_PTR)helpMenu, help.c_str());
+		HMENU helpMenu = GetSubmenuById(menu, ID_HELP_MENU);
+		EmptySubMenu(helpMenu);
 
 		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENWEBSITE, visitMainWebsite.c_str());
 		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENFORUM, visitForum.c_str());
@@ -196,34 +192,26 @@ namespace MainWindow {
 		return true;
 	}
 
-	static void _TranslateMenuItem(const HMENU hMenu, const int menuIDOrPosition, const char *key, bool byCommand = false, const std::wstring& accelerator = L"") {
+	static void TranslateMenuItem(const HMENU hMenu, const int menuID, const std::wstring& accelerator = L"", const char *key = nullptr) {
 		I18NCategory *des = GetI18NCategory("DesktopUI");
 
-		std::wstring translated = ConvertUTF8ToWString(des->T(key));
+		std::wstring translated;
+		if (key == nullptr || !strcmp(key, "")) {
+			translated = ConvertUTF8ToWString(des->T(GetMenuItemInitialText(hMenu, menuID)));
+		} else {
+			translated = ConvertUTF8ToWString(des->T(key));
+		}
 		translated.append(accelerator);
 
-		u32 flags = MF_STRING | (byCommand ? MF_BYCOMMAND : MF_BYPOSITION);
-
-		ModifyMenu(hMenu, menuIDOrPosition, flags, menuIDOrPosition, translated.c_str());
-	}
-
-	void TranslateMenuItem(HMENU menu, int menuID, const std::wstring& accelerator = L"", const char *key = "") {
-		if (key == nullptr || !strcmp(key, ""))
-			_TranslateMenuItem(menu, menuID, GetMenuItemInitialText(menu, menuID).c_str(), true, accelerator);
-		else
-			_TranslateMenuItem(menu, menuID, key, true, accelerator);
-	}
-
-	void TranslateMenu(HMENU menu, const char *key, const int itemID, const std::wstring& accelerator = L"") {
-		_TranslateMenuItem(menu, itemID, key, true, accelerator);
+		ModifyMenu(hMenu, menuID, MF_STRING | MF_BYCOMMAND, menuID, translated.c_str());
 	}
 
 	void DoTranslateMenus(HWND hWnd, HMENU menu) {
-		TranslateMenu(menu, "File", ID_FILE_MENU);
-		TranslateMenu(menu, "Emulation", ID_EMULATION_MENU);
-		TranslateMenu(menu, "Debugging", ID_DEBUG_MENU);
-		TranslateMenu(menu, "Game Settings", ID_OPTIONS_MENU);
-		TranslateMenu(menu, "Help", ID_HELP_MENU);
+		TranslateMenuItem(menu, ID_FILE_MENU);
+		TranslateMenuItem(menu, ID_EMULATION_MENU);
+		TranslateMenuItem(menu, ID_DEBUG_MENU);
+		TranslateMenuItem(menu, ID_OPTIONS_MENU);
+		TranslateMenuItem(menu, ID_HELP_MENU);
 
 		// File menu
 		TranslateMenuItem(menu, ID_FILE_LOAD);
@@ -242,7 +230,7 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_EMULATION_PAUSE);
 		TranslateMenuItem(menu, ID_EMULATION_STOP, L"\tCtrl+W");
 		TranslateMenuItem(menu, ID_EMULATION_RESET, L"\tCtrl+B");
-		TranslateMenuItem(menu, ID_EMULATION_SWITCH_UMD, L"\tCtrl+U", "Switch UMD");
+		TranslateMenuItem(menu, ID_EMULATION_SWITCH_UMD, L"\tCtrl+U");
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_MENU);
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_H);
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_V);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -45,7 +45,7 @@ namespace MainWindow {
 	static W32Util::AsyncBrowseDialog *browseImageDialog;
 	static bool browsePauseAfter;
 
-	static std::map<int, std::string> initialMenuKeys;
+	static std::unordered_map<int, std::string> initialMenuKeys;
 	static std::vector<std::string> availableShaders;
 	static std::string menuLanguageID = "";
 	static bool menuShaderInfoLoaded = false;
@@ -79,44 +79,23 @@ namespace MainWindow {
 		EnableMenuItem(menu, ID_OPTIONS_LANGUAGE, state == UISTATE_INGAME ? MF_GRAYED : MF_ENABLED);
 	}
 
-	// These are used as an offset
-	// to determine which menu item to change.
-	// Make sure to count(from 0) the separators too, when dealing with submenus!!
-	enum MenuItemPosition {
-		// Main menus
-		MENU_FILE = 0,
-		MENU_EMULATION = 1,
-		MENU_DEBUG = 2,
-		MENU_OPTIONS = 3,
-		MENU_HELP = 4,
+	static HMENU GetSubmenuById(HMENU menu, int menuID) {
+		MENUITEMINFO menuInfo{ sizeof(MENUITEMINFO), MIIM_SUBMENU };
+		if (GetMenuItemInfo(menu, menuID, MF_BYCOMMAND, &menuInfo) != FALSE) {
+			return menuInfo.hSubMenu;
+		}
+		return nullptr;
+	}
 
-		// File submenus
-		SUBMENU_FILE_SAVESTATE_SLOT = 6,
-		SUBMENU_FILE_RECORD = 11,
-
-		// Emulation submenus
-		SUBMENU_DISPLAY_ROTATION = 4,
-
-		// Game Settings submenus
-		SUBMENU_DISPLAY_LAYOUT = 7,
-		SUBMENU_CUSTOM_SHADERS = 10,
-		SUBMENU_RENDERING_RESOLUTION = 11,
-		SUBMENU_WINDOW_SIZE = 12,
-		SUBMENU_RENDERING_BACKEND = 13,
-		SUBMENU_RENDERING_MODE = 14,
-		SUBMENU_FRAME_SKIPPING = 15,
-		SUBMENU_TEXTURE_FILTERING = 16,
-		SUBMENU_BUFFER_FILTER = 17,
-		SUBMENU_TEXTURE_SCALING = 18,
-	};
+	static void EmptySubMenu(HMENU menu) {
+		int c = GetMenuItemCount(menu);
+		for (int i = 0; i < c; ++i) {
+			RemoveMenu(menu, i, MF_BYPOSITION);
+		}
+	}
 
 	static std::string GetMenuItemText(HMENU menu, int menuID) {
-		MENUITEMINFO menuInfo;
-		memset(&menuInfo, 0, sizeof(menuInfo));
-		menuInfo.cbSize = sizeof(MENUITEMINFO);
-		menuInfo.fMask = MIIM_STRING;
-		menuInfo.dwTypeData = 0;
-
+		MENUITEMINFO menuInfo{ sizeof(menuInfo), MIIM_STRING };
 		std::string retVal;
 		if (GetMenuItemInfo(menu, menuID, MF_BYCOMMAND, &menuInfo) != FALSE) {
 			wchar_t *buffer = new wchar_t[++menuInfo.cch];
@@ -148,10 +127,10 @@ namespace MainWindow {
 		const std::wstring aboutPPSSPP = ConvertUTF8ToWString(des->T("About PPSSPP..."));
 
 		// Simply remove the old help menu and create a new one.
-		RemoveMenu(menu, MENU_HELP, MF_BYPOSITION);
+		RemoveMenu(menu, ID_HELP_MENU, MF_BYCOMMAND);
 
 		HMENU helpMenu = CreatePopupMenu();
-		InsertMenu(menu, MENU_HELP, MF_POPUP | MF_STRING | MF_BYPOSITION, (UINT_PTR)helpMenu, help.c_str());
+		InsertMenu(menu, ID_HELP_MENU, MF_POPUP | MF_STRING | MF_BYCOMMAND, (UINT_PTR)helpMenu, help.c_str());
 
 		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENWEBSITE, visitMainWebsite.c_str());
 		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENFORUM, visitForum.c_str());
@@ -187,20 +166,12 @@ namespace MainWindow {
 			return false;
 		}
 
-		I18NCategory *des = GetI18NCategory("DesktopUI");
 		I18NCategory *ps = GetI18NCategory("PostShaders");
-		const std::wstring key = ConvertUTF8ToWString(des->T("Postprocessing Shader"));
 
-		HMENU optionsMenu = GetSubMenu(menu, MENU_OPTIONS);
-
-		HMENU shaderMenu = CreatePopupMenu();
-
-		RemoveMenu(optionsMenu, SUBMENU_CUSTOM_SHADERS, MF_BYPOSITION);
-		InsertMenu(optionsMenu, SUBMENU_CUSTOM_SHADERS, MF_POPUP | MF_STRING | MF_BYPOSITION, (UINT_PTR)shaderMenu, key.c_str());
+		HMENU shaderMenu = GetSubmenuById(menu, ID_OPTIONS_SHADER_MENU);
+		EmptySubMenu(shaderMenu);
 
 		int item = ID_SHADERS_BASE + 1;
-		int checkedStatus = -1;
-
 		const char *translatedShaderName = nullptr;
 
 		availableShaders.clear();
@@ -209,7 +180,7 @@ namespace MainWindow {
 			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_GRAYED, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		} else {
 			for (auto i = info.begin(); i != info.end(); ++i) {
-				checkedStatus = MF_UNCHECKED;
+				int checkedStatus = MF_UNCHECKED;
 				availableShaders.push_back(i->section);
 				if (g_Config.sPostShaderName == i->section) {
 					checkedStatus = MF_CHECKED;
@@ -243,34 +214,28 @@ namespace MainWindow {
 			_TranslateMenuItem(menu, menuID, key, true, accelerator);
 	}
 
-	void TranslateMenu(HMENU menu, const char *key, const MenuItemPosition mainMenuPosition, const std::wstring& accelerator = L"") {
-		_TranslateMenuItem(menu, mainMenuPosition, key, false, accelerator);
-	}
-
-	void TranslateSubMenu(HMENU menu, const char *key, const MenuItemPosition mainMenuItem, const MenuItemPosition subMenuItem, const std::wstring& accelerator = L"") {
-		_TranslateMenuItem(GetSubMenu(menu, mainMenuItem), subMenuItem, key, false, accelerator);
+	void TranslateMenu(HMENU menu, const char *key, const int itemID, const std::wstring& accelerator = L"") {
+		_TranslateMenuItem(menu, itemID, key, true, accelerator);
 	}
 
 	void DoTranslateMenus(HWND hWnd, HMENU menu) {
-		// Menu headers and submenu headers don't have resource IDs,
-		// So we have to hardcode strings here, unfortunately.
-		TranslateMenu(menu, "File", MENU_FILE);
-		TranslateMenu(menu, "Emulation", MENU_EMULATION);
-		TranslateMenu(menu, "Debugging", MENU_DEBUG);
-		TranslateMenu(menu, "Game Settings", MENU_OPTIONS);
-		TranslateMenu(menu, "Help", MENU_HELP);
+		TranslateMenu(menu, "File", ID_FILE_MENU);
+		TranslateMenu(menu, "Emulation", ID_EMULATION_MENU);
+		TranslateMenu(menu, "Debugging", ID_DEBUG_MENU);
+		TranslateMenu(menu, "Game Settings", ID_OPTIONS_MENU);
+		TranslateMenu(menu, "Help", ID_HELP_MENU);
 
 		// File menu
 		TranslateMenuItem(menu, ID_FILE_LOAD);
 		TranslateMenuItem(menu, ID_FILE_LOAD_DIR);
 		TranslateMenuItem(menu, ID_FILE_LOAD_MEMSTICK);
 		TranslateMenuItem(menu, ID_FILE_MEMSTICK);
-		TranslateSubMenu(menu, "Savestate Slot", MENU_FILE, SUBMENU_FILE_SAVESTATE_SLOT, L"\tF3");
+		TranslateMenuItem(menu, ID_FILE_SAVESTATE_SLOT_MENU, L"\tF3");
 		TranslateMenuItem(menu, ID_FILE_QUICKLOADSTATE, L"\tF4");
 		TranslateMenuItem(menu, ID_FILE_QUICKSAVESTATE, L"\tF2");
 		TranslateMenuItem(menu, ID_FILE_LOADSTATEFILE);
 		TranslateMenuItem(menu, ID_FILE_SAVESTATEFILE);
-		TranslateSubMenu(menu, "Record", MENU_FILE, SUBMENU_FILE_RECORD);
+		TranslateMenuItem(menu, ID_FILE_RECORD_MENU);
 		TranslateMenuItem(menu, ID_FILE_EXIT, L"\tAlt+F4");
 
 		// Emulation menu
@@ -278,7 +243,7 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_EMULATION_STOP, L"\tCtrl+W");
 		TranslateMenuItem(menu, ID_EMULATION_RESET, L"\tCtrl+B");
 		TranslateMenuItem(menu, ID_EMULATION_SWITCH_UMD, L"\tCtrl+U", "Switch UMD");
-		TranslateSubMenu(menu, "Display Rotation", MENU_EMULATION, SUBMENU_DISPLAY_ROTATION);
+		TranslateMenuItem(menu, ID_EMULATION_ROTATION_MENU);
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_H);
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_V);
 		TranslateMenuItem(menu, ID_EMULATION_ROTATION_H_R);
@@ -319,36 +284,37 @@ namespace MainWindow {
 		// Skip display multipliers x1-x10
 		TranslateMenuItem(menu, ID_OPTIONS_FULLSCREEN, L"\tAlt+Return, F11");
 		TranslateMenuItem(menu, ID_OPTIONS_VSYNC);
-		TranslateSubMenu(menu, "Postprocessing Shader", MENU_OPTIONS, SUBMENU_CUSTOM_SHADERS);
-		TranslateSubMenu(menu, "Rendering Resolution", MENU_OPTIONS, SUBMENU_RENDERING_RESOLUTION, L"\tCtrl+1");
+		TranslateMenuItem(menu, ID_OPTIONS_SHADER_MENU);
+		TranslateMenuItem(menu, ID_OPTIONS_SCREEN_MENU, L"\tCtrl+1");
 		TranslateMenuItem(menu, ID_OPTIONS_SCREENAUTO);
 		// Skip rendering resolution 2x-5x..
-		TranslateSubMenu(menu, "Window Size", MENU_OPTIONS, SUBMENU_WINDOW_SIZE);
+		TranslateMenuItem(menu, ID_OPTIONS_WINDOW_MENU);
 		// Skip window size 1x-4x..
-		TranslateSubMenu(menu, "Backend", MENU_OPTIONS, SUBMENU_RENDERING_BACKEND);
+		TranslateMenuItem(menu, ID_OPTIONS_BACKEND_MENU);
 		TranslateMenuItem(menu, ID_OPTIONS_DIRECT3D11);
 		TranslateMenuItem(menu, ID_OPTIONS_DIRECT3D9);
 		TranslateMenuItem(menu, ID_OPTIONS_OPENGL);
 		TranslateMenuItem(menu, ID_OPTIONS_VULKAN);
 
-		TranslateSubMenu(menu, "Rendering Mode", MENU_OPTIONS, SUBMENU_RENDERING_MODE);
+		TranslateMenuItem(menu, ID_OPTIONS_RENDERMODE_MENU);
 		TranslateMenuItem(menu, ID_OPTIONS_NONBUFFEREDRENDERING);
 		TranslateMenuItem(menu, ID_OPTIONS_BUFFEREDRENDERING);
-		TranslateSubMenu(menu, "Frame Skipping", MENU_OPTIONS, SUBMENU_FRAME_SKIPPING, L"\tF7");
+		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIP_MENU, L"\tF7");
 		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIP_AUTO);
 		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIP_0);
+		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIPTYPE_MENU);
 		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIPTYPE_COUNT);
 		TranslateMenuItem(menu, ID_OPTIONS_FRAMESKIPTYPE_PRCNT);
 		// Skip frameskipping 1-8..
-		TranslateSubMenu(menu, "Texture Filtering", MENU_OPTIONS, SUBMENU_TEXTURE_FILTERING);
+		TranslateMenuItem(menu, ID_OPTIONS_TEXTUREFILTERING_MENU);
 		TranslateMenuItem(menu, ID_OPTIONS_TEXTUREFILTERING_AUTO);
 		TranslateMenuItem(menu, ID_OPTIONS_NEARESTFILTERING);
 		TranslateMenuItem(menu, ID_OPTIONS_LINEARFILTERING);
 		TranslateMenuItem(menu, ID_OPTIONS_LINEARFILTERING_CG);
-		TranslateSubMenu(menu, "Screen Scaling Filter", MENU_OPTIONS, SUBMENU_BUFFER_FILTER);
+		TranslateMenuItem(menu, ID_OPTIONS_SCREENFILTER_MENU);
 		TranslateMenuItem(menu, ID_OPTIONS_BUFLINEARFILTER);
 		TranslateMenuItem(menu, ID_OPTIONS_BUFNEARESTFILTER);
-		TranslateSubMenu(menu, "Texture Scaling", MENU_OPTIONS, SUBMENU_TEXTURE_SCALING);
+		TranslateMenuItem(menu, ID_OPTIONS_TEXTURESCALING_MENU);
 		TranslateMenuItem(menu, ID_TEXTURESCALING_OFF);
 		// Skip texture scaling 2x-5x...
 		TranslateMenuItem(menu, ID_TEXTURESCALING_XBRZ);

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -498,7 +498,7 @@ BEGIN
         END
     END
 
-    POPUP "Debug",                                          ID_DEBUG_MENU
+    POPUP "Debugging",                                      ID_DEBUG_MENU
     BEGIN
         MENUITEM "Run",                                     ID_TOGGLE_BREAK
         MENUITEM "Break on Load",                           ID_DEBUG_BREAKONLOAD
@@ -521,7 +521,7 @@ BEGIN
         MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
     END
 
-    POPUP "Options",                                        ID_OPTIONS_MENU
+    POPUP "Game Settings",                                  ID_OPTIONS_MENU
     BEGIN
         MENUITEM "Keep PPSSPP On Top",                      ID_OPTIONS_TOPMOST
         MENUITEM "Pause When Not Focused",                  ID_OPTIONS_PAUSE_FOCUS
@@ -633,6 +633,11 @@ BEGIN
         MENUITEM "Enable Sound",                        ID_EMULATION_SOUND
         MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Enable Cheats",                       ID_EMULATION_CHEATS
+    END
+
+    POPUP "Help",                                       ID_HELP_MENU
+    BEGIN
+        MENUITEM "", 0, MFT_SEPARATOR
     END
 END
 

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -448,18 +448,18 @@ IDI_STOPDISABLE         ICON                    "stop1.ico"
 // Menu
 //
 
-IDR_MENU1 MENU
+IDR_MENU1 MENUEX
 BEGIN
-    POPUP "File"
+    POPUP "File",                                           ID_FILE_MENU
     BEGIN
         MENUITEM "Load",                                    ID_FILE_LOAD
         MENUITEM "Open Directory...",                       ID_FILE_LOAD_DIR
         MENUITEM "Open from MS:/PSP/GAME...",               ID_FILE_LOAD_MEMSTICK
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Open Memory Stick",                       ID_FILE_MEMSTICK
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
 
-        POPUP "Savestate Slot"
+        POPUP "Savestate Slot",                             ID_FILE_SAVESTATE_SLOT_MENU
         BEGIN
             MENUITEM "&1",                                  ID_FILE_SAVESTATE_SLOT_1
             MENUITEM "&2",                                  ID_FILE_SAVESTATE_SLOT_2
@@ -472,24 +472,24 @@ BEGIN
         MENUITEM "Load State File...",                      ID_FILE_LOADSTATEFILE
         MENUITEM "Save State File...",                      ID_FILE_SAVESTATEFILE
 
-        POPUP "Record"
+        POPUP "Record",                                     ID_FILE_RECORD_MENU
         BEGIN
             MENUITEM "Record Display",                      ID_FILE_DUMPFRAMES
             MENUITEM "Use Lossless Video Codec (FFV1)",     ID_FILE_USEFFV1
-            MENUITEM SEPARATOR
+            MENUITEM "", 0, MFT_SEPARATOR
             MENUITEM "Record Audio",                        ID_FILE_DUMPAUDIO
         END
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Exit",                                    ID_FILE_EXIT
     END
 
-    POPUP "Emulation"
+    POPUP "Emulation",                                      ID_EMULATION_MENU
     BEGIN
         MENUITEM "Pause",                                   ID_EMULATION_PAUSE
         MENUITEM "Stop",                                    ID_EMULATION_STOP
         MENUITEM "Reset",                                   ID_EMULATION_RESET
         MENUITEM "Switch UMD",                              ID_EMULATION_SWITCH_UMD
-        POPUP "Display Rotation"
+        POPUP "Display Rotation",                           ID_EMULATION_ROTATION_MENU
         BEGIN
             MENUITEM "Landscape",                           ID_EMULATION_ROTATION_H
             MENUITEM "Portrait",                            ID_EMULATION_ROTATION_V
@@ -498,22 +498,22 @@ BEGIN
         END
     END
 
-    POPUP "Debug"
+    POPUP "Debug",                                          ID_DEBUG_MENU
     BEGIN
         MENUITEM "Run",                                     ID_TOGGLE_BREAK
         MENUITEM "Break on Load",                           ID_DEBUG_BREAKONLOAD
         MENUITEM "Ignore Illegal Reads/Writes",             ID_DEBUG_IGNOREILLEGALREADS
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Load Map File...",                        ID_DEBUG_LOADMAPFILE
         MENUITEM "Save Map File...",                        ID_DEBUG_SAVEMAPFILE
         MENUITEM "Load .sym File...",                       ID_DEBUG_LOADSYMFILE
         MENUITEM "Save .sym File...",                       ID_DEBUG_SAVESYMFILE
         MENUITEM "Reset Symbol Table",                      ID_DEBUG_RESETSYMBOLTABLE
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Take Screenshot",                         ID_DEBUG_TAKESCREENSHOT
         MENUITEM "Dump Next Frame to Log",                  ID_DEBUG_DUMPNEXTFRAME
         MENUITEM "Show Debug Statistics",                   ID_DEBUG_SHOWDEBUGSTATISTICS
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Disassembly",                             ID_DEBUG_DISASSEMBLY
         MENUITEM "GE Debugger...",                          ID_DEBUG_GEDEBUGGER
         MENUITEM "Extract File...",                         ID_DEBUG_EXTRACTFILE
@@ -521,7 +521,7 @@ BEGIN
         MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
     END
 
-    POPUP "Options"
+    POPUP "Options",                                        ID_OPTIONS_MENU
     BEGIN
         MENUITEM "Keep PPSSPP On Top",                      ID_OPTIONS_TOPMOST
         MENUITEM "Pause When Not Focused",                  ID_OPTIONS_PAUSE_FOCUS
@@ -530,11 +530,14 @@ BEGIN
         MENUITEM "Control Mapping...",                      ID_OPTIONS_CONTROLS
         MENUITEM "Display Layout Editor",                   ID_OPTIONS_DISPLAY_LAYOUT
         MENUITEM "More Settings...",                        ID_OPTIONS_MORE_SETTINGS
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Fullscreen",                              ID_OPTIONS_FULLSCREEN
         MENUITEM "VSync",                                   ID_OPTIONS_VSYNC
-        MENUITEM "Postprocessing Shader",                   ID_OPTIONS_FXAA
-        POPUP "Rendering Resolution"
+        POPUP "Postprocessing Shader",                      ID_OPTIONS_SHADER_MENU
+        BEGIN
+            MENUITEM "", 0, MFT_SEPARATOR
+        END
+        POPUP "Rendering Resolution",                       ID_OPTIONS_SCREEN_MENU
         BEGIN
             MENUITEM "Auto",                                ID_OPTIONS_SCREENAUTO
             MENUITEM "&1x",                                 ID_OPTIONS_SCREEN1X
@@ -548,7 +551,7 @@ BEGIN
             MENUITEM "&9x",                                 ID_OPTIONS_SCREEN9X
             MENUITEM "&10x",                                ID_OPTIONS_SCREEN10X
         END
-        POPUP "Window Size"
+        POPUP "Window Size",                                ID_OPTIONS_WINDOW_MENU
         BEGIN
             MENUITEM "&1x",                                 ID_OPTIONS_WINDOW1X
             MENUITEM "&2x",                                 ID_OPTIONS_WINDOW2X
@@ -562,7 +565,7 @@ BEGIN
             MENUITEM "&10x",                                ID_OPTIONS_WINDOW10X
         END
 
-        POPUP "Backend"
+        POPUP "Backend",                                    ID_OPTIONS_BACKEND_MENU
         BEGIN
             MENUITEM "Direct3D9",                           ID_OPTIONS_DIRECT3D9
             MENUITEM "Direct3D11",                          ID_OPTIONS_DIRECT3D11
@@ -570,15 +573,15 @@ BEGIN
             MENUITEM "Vulkan",                              ID_OPTIONS_VULKAN
         END
 
-        POPUP "Rendering Mode"
+        POPUP "Rendering Mode",                             ID_OPTIONS_RENDERMODE_MENU
         BEGIN
             MENUITEM "Non-Buffered Rendering",              ID_OPTIONS_NONBUFFEREDRENDERING
             MENUITEM "Buffered Rendering",                  ID_OPTIONS_BUFFEREDRENDERING
         END
-        POPUP "Frame Skipping"
+        POPUP "Frame Skipping",                             ID_OPTIONS_FRAMESKIP_MENU
         BEGIN
             MENUITEM "Auto",                                ID_OPTIONS_FRAMESKIP_AUTO
-            MENUITEM SEPARATOR
+            MENUITEM "", 0, MFT_SEPARATOR
             MENUITEM "Off",                                 ID_OPTIONS_FRAMESKIP_0
             MENUITEM "&1",                                  ID_OPTIONS_FRAMESKIP_1
             MENUITEM "&2",                                  ID_OPTIONS_FRAMESKIP_2
@@ -589,25 +592,25 @@ BEGIN
             MENUITEM "&7",                                  ID_OPTIONS_FRAMESKIP_7
             MENUITEM "&8",                                  ID_OPTIONS_FRAMESKIP_8
         END
-        POPUP "Frame Skipping Type"
+        POPUP "Frame Skipping Type",                        ID_OPTIONS_FRAMESKIPTYPE_MENU
         BEGIN
             MENUITEM "Skip Number of Frames",               ID_OPTIONS_FRAMESKIPTYPE_COUNT
             MENUITEM "Skip Percent of FPS",                 ID_OPTIONS_FRAMESKIPTYPE_PRCNT
         END
-        POPUP "Texture Filtering"
+        POPUP "Texture Filtering",                          ID_OPTIONS_TEXTUREFILTERING_MENU
         BEGIN
             MENUITEM "Auto",                                ID_OPTIONS_TEXTUREFILTERING_AUTO
             MENUITEM "Nearest",                             ID_OPTIONS_NEARESTFILTERING
             MENUITEM "Linear",                              ID_OPTIONS_LINEARFILTERING
             MENUITEM "Linear on FMV",                       ID_OPTIONS_LINEARFILTERING_CG
         END
-        POPUP "Screen Scaling Filter"
+        POPUP "Screen Scaling Filter",                      ID_OPTIONS_SCREENFILTER_MENU
         BEGIN
             MENUITEM "Linear",                              ID_OPTIONS_BUFLINEARFILTER
             MENUITEM "Nearest",                             ID_OPTIONS_BUFNEARESTFILTER
         END
 
-        POPUP "Texture Scaling"
+        POPUP "Texture Scaling",                        ID_OPTIONS_TEXTURESCALING_MENU
         BEGIN
             MENUITEM "Off",                             ID_TEXTURESCALING_OFF
             MENUITEM "Auto",                            ID_TEXTURESCALING_AUTO
@@ -615,20 +618,20 @@ BEGIN
             MENUITEM "&3x",                             ID_TEXTURESCALING_3X
             MENUITEM "&4x",                             ID_TEXTURESCALING_4X
             MENUITEM "&5x",                             ID_TEXTURESCALING_5X
-            MENUITEM SEPARATOR
+            MENUITEM "", 0, MFT_SEPARATOR
             MENUITEM "xBRZ",                            ID_TEXTURESCALING_XBRZ
             MENUITEM "Hybrid",                          ID_TEXTURESCALING_HYBRID
             MENUITEM "Bicubic",                         ID_TEXTURESCALING_BICUBIC
             MENUITEM "Hybrid + Bicubic",                ID_TEXTURESCALING_HYBRID_BICUBIC
-            MENUITEM SEPARATOR
+            MENUITEM "", 0, MFT_SEPARATOR
             MENUITEM "Deposterize",                     ID_TEXTURESCALING_DEPOSTERIZE
         END
         MENUITEM "Hardware Transform",                  ID_OPTIONS_HARDWARETRANSFORM
         MENUITEM "Vertex Cache",                        ID_OPTIONS_VERTEXCACHE
         MENUITEM "Show FPS Counter",                    ID_OPTIONS_SHOWFPS
-        MENUITEM SEPARATOR
-        MENUITEM "Enable Sound",                        ID_EMULATION_SOUND, CHECKED
-        MENUITEM SEPARATOR
+        MENUITEM "", 0, MFT_SEPARATOR
+        MENUITEM "Enable Sound",                        ID_EMULATION_SOUND
+        MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Enable Cheats",                       ID_EMULATION_CHEATS
     END
 END

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -288,7 +288,7 @@
 #define IDC_GEDBG_LISTS_ALLLISTS         40123
 #define IDC_GEDBG_LISTS_STACK            40124
 #define IDC_GEDBG_LISTS_SELECTEDLIST     40125
-#define ID_OPTIONS_FXAA                  40126
+#define ID_OPTIONS_SHADER_MENU           40126
 #define IDC_DEBUG_BOTTOMTABS             40127
 #define ID_DEBUG_HIDEBOTTOMTABS          40128
 #define ID_DEBUG_TOGGLEBOTTOMTABTITLES   40129
@@ -345,6 +345,23 @@
 #define IDC_GEDBG_STEPCURVE              40179
 #define ID_OPTIONS_FRAMESKIPTYPE_COUNT   40180
 #define ID_OPTIONS_FRAMESKIPTYPE_PRCNT   40181
+#define ID_FILE_MENU                     40182
+#define ID_EMULATION_MENU                40183
+#define ID_DEBUG_MENU                    40184
+#define ID_OPTIONS_MENU                  40185
+#define ID_HELP_MENU                     40186
+#define ID_FILE_SAVESTATE_SLOT_MENU      40187
+#define ID_FILE_RECORD_MENU              40188
+#define ID_EMULATION_ROTATION_MENU       40189
+#define ID_OPTIONS_SCREEN_MENU           40190
+#define ID_OPTIONS_WINDOW_MENU           40191
+#define ID_OPTIONS_BACKEND_MENU          40192
+#define ID_OPTIONS_RENDERMODE_MENU       40193
+#define ID_OPTIONS_FRAMESKIP_MENU        40194
+#define ID_OPTIONS_FRAMESKIPTYPE_MENU    40195
+#define ID_OPTIONS_TEXTUREFILTERING_MENU 40196
+#define ID_OPTIONS_SCREENFILTER_MENU     40197
+#define ID_OPTIONS_TEXTURESCALING_MENU   40198
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500
@@ -357,7 +374,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40178
+#define _APS_NEXT_COMMAND_VALUE         40199
 #define _APS_NEXT_CONTROL_VALUE         1200
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
Fixes #11571.  Seems safer.

-[Unknown]