### PR TITLE
GPU: Properly flip cull on simple triangle lists

### DIFF
--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -218,7 +218,7 @@ void IndexGenerator::TranslateList(int numInds, const ITypeLE *inds, int indexOf
 	indexOffset = index_ - indexOffset;
 	// We only bother doing this minor optimization in triangle list, since it's by far the most
 	// common operation that can benefit.
-	if (sizeof(ITypeLE) == sizeof(inds_[0]) && indexOffset == 0) {
+	if (sizeof(ITypeLE) == sizeof(inds_[0]) && indexOffset == 0 && clockwise) {
 		memcpy(inds_, inds, numInds * sizeof(ITypeLE));
 		inds_ += numInds;
 		count_ += numInds;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1627,7 +1627,12 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 			break;
 		}
 		case GE_CMD_VADDR:
+			gstate.cmdmem[data >> 24] = data;
 			gstate_c.vertexAddr = gstate_c.getRelativeAddress(data & 0x00FFFFFF);
+			break;
+		case GE_CMD_IADDR:
+			gstate.cmdmem[data >> 24] = data;
+			gstate_c.indexAddr = gstate_c.getRelativeAddress(data & 0x00FFFFFF);
 			break;
 		case GE_CMD_OFFSETADDR:
 			gstate.cmdmem[GE_CMD_OFFSETADDR] = data;
@@ -1646,8 +1651,10 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 			// flip face by indices for triangles
 			cullMode = data & 1;
 			break;
+		case GE_CMD_TEXFLUSH:
 		case GE_CMD_NOP:
 		case GE_CMD_NOP_FF:
+			gstate.cmdmem[data >> 24] = data;
 			break;
 		case GE_CMD_BONEMATRIXNUMBER:
 			gstate.cmdmem[GE_CMD_BONEMATRIXNUMBER] = data;
@@ -1689,6 +1696,12 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 			}
 			break;
 		}
+
+		case GE_CMD_TEXBUFWIDTH0:
+		case GE_CMD_TEXADDR0:
+			if (data != gstate.cmdmem[data >> 24])
+				goto bail;
+			break;
 
 		default:
 			// All other commands might need a flush or something, stop this inner loop.


### PR DESCRIPTION
Another optimization was getting in the way, oops.  Fixes #11601.

I'm still not completely sure why this didn't get triggered in the dump, it might be because of jumps being inserted to manage the total list size, though, and CALL flattening that happens because it records executed commands.

-[Unknown]