### PR TITLE
GPU: Force use of indexes on cull mode flip

### DIFF
--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -77,6 +77,10 @@ void IndexGenerator::AddList(int numVerts, bool clockwise) {
 	count_ += numVerts;
 	prim_ = GE_PRIM_TRIANGLES;
 	seenPrims_ |= 1 << GE_PRIM_TRIANGLES;
+	if (!clockwise) {
+		// Make sure we don't treat this as pure.
+		seenPrims_ |= 1 << GE_PRIM_TRIANGLE_STRIP;
+	}
 }
 
 void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
@@ -96,7 +100,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	if (numTris > 0)
 		count_ += numTris * 3;
 	// This is so we can detect one single strip by just looking at seenPrims_.
-	if (!seenPrims_) {
+	if (!seenPrims_ && clockwise) {
 		seenPrims_ = 1 << GE_PRIM_TRIANGLE_STRIP;
 		prim_ = GE_PRIM_TRIANGLE_STRIP;
 		pureCount_ = numVerts;
@@ -123,6 +127,10 @@ void IndexGenerator::AddFan(int numVerts, bool clockwise) {
 	count_ += numTris * 3;
 	prim_ = GE_PRIM_TRIANGLES;
 	seenPrims_ |= 1 << GE_PRIM_TRIANGLE_FAN;
+	if (!clockwise) {
+		// Make sure we don't treat this as pure.
+		seenPrims_ |= 1 << GE_PRIM_TRIANGLE_STRIP;
+	}
 }
 
 //Lines

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -176,7 +176,6 @@ struct FShaderID : ShaderID {
 };
 
 
-bool CanUseHardwareTransform(int prim);
 void ComputeVertexShaderID(ShaderID *id, uint32_t vertexType, bool useHWTransform);
 // Generates a compact string that describes the shader. Useful in a list to get an overview
 // of the current flora of shaders.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1537,7 +1537,7 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 	}
 
 	void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
-	void *inds = 0;
+	void *inds = nullptr;
 	u32 vertexType = gstate.vertType;
 	if ((vertexType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		u32 indexAddr = gstate_c.indexAddr;
@@ -1602,9 +1602,10 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 			}
 
 			GEPrimitiveType newPrim = static_cast<GEPrimitiveType>((data >> 16) & 7);
+			SetDrawType(DRAW_PRIM, newPrim);
 			// TODO: more efficient updating of verts/inds
 			verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
-			inds = 0;
+			inds = nullptr;
 			if ((vertexType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 				inds = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 			}


### PR DESCRIPTION
Since we flip in the index, it can't be pure in this case.  Fixes #11601 for real maybe.

We were lucky enough to hit the triangle just at MAX_DEFERRED_DRAW_CALLS, so it flushed right before.  This meant that the clipped cull mode triangle draw was the only thing in the index generator.  Tricky.

I also added `SetDrawType()` for safety, but I'm not convinced the things it does are needed, except for non-triangles (which is already handled in `PrimCompatible`, so maybe the dirtying should be moved in there...)

-[Unknown]