### PR TITLE
Headless: Allow startup using NULL draw context

### DIFF
--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -61,7 +61,7 @@ bool GPU_IsReady() {
 }
 
 bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
-	_assert_(draw);
+	_assert_(draw || PSP_CoreParameter().gpuCore == GPUCORE_NULL);
 #if PPSSPP_PLATFORM(UWP)
 	SetGPU(new GPU_D3D11(ctx, draw));
 	return true;

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -55,7 +55,7 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
 	std::string error;
 	double errors = CompareScreenshot(pixels, FRAME_STRIDE, FRAME_WIDTH, FRAME_HEIGHT, comparisonScreenshot_, error);
 	if (errors < 0)
-		SendOrCollectDebugOutput(error);
+		SendOrCollectDebugOutput(error + "\n");
 
 	if (errors > 0)
 	{


### PR DESCRIPTION
I suspect this is what was causing the buildbot to time out trying to run tests.

-[Unknown]