### PR TITLE
Io: Ensure sign extension for error codes

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -991,7 +991,7 @@ static u32 sceIoReadAsync(int id, u32 data_addr, int size) {
 		int us;
 		bool complete = __IoRead(result, id, data_addr, size, us);
 		if (complete) {
-			f->asyncResult = result;
+			f->asyncResult = (s64)result;
 			DEBUG_LOG(SCEIO, "%llx=sceIoReadAsync(%d, %08x, %x)", f->asyncResult, id, data_addr, size);
 		} else {
 			DEBUG_LOG(SCEIO, "sceIoReadAsync(%d, %08x, %x): deferring result", id, data_addr, size);
@@ -1125,7 +1125,7 @@ static u32 sceIoWriteAsync(int id, u32 data_addr, int size) {
 		int us;
 		bool complete = __IoWrite(result, id, data_addr, size, us);
 		if (complete) {
-			f->asyncResult = result;
+			f->asyncResult = (s64)result;
 			DEBUG_LOG(SCEIO, "%llx=sceIoWriteAsync(%d, %08x, %x)", f->asyncResult, id, data_addr, size);
 		} else {
 			DEBUG_LOG(SCEIO, "sceIoWriteAsync(%d, %08x, %x): deferring result", id, data_addr, size);
@@ -1935,7 +1935,7 @@ static u32 sceIoOpenAsync(const char *filename, int flags, int mode)
 		f = new FileNode();
 		f->handle = kernelObjects.Create(f);
 		f->fullpath = filename;
-		f->asyncResult = error == 0 ? SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND : error;
+		f->asyncResult = error == 0 ? (s64)SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND : (s64)error;
 		f->closePending = true;
 
 		fd = __IoAllocFd(f);


### PR DESCRIPTION
The ternary `cond ? EnumValue : IntValue` was not sign extending consistently across compilers, but we actually want it to always sign extend in either case.  I actually find it weird that it ever sign extended...

Fixes #11019.

-[Unknown]