### PR TITLE
SDL: Allow toggling fullscreen for GLES2 on desktops.

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -441,7 +441,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// If we're on mobile, don't try for windowed either.
-#if defined(USING_GLES2) || defined(MOBILE_DEVICE)
+#if defined(MOBILE_DEVICE)
     mode |= SDL_WINDOW_FULLSCREEN;
 #else
     mode |= SDL_WINDOW_RESIZABLE;


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/11627

Note: This works for linux, but I am not sure what other platforms rely on the old behavior other than android and IOS which should be defined under `MOBILE_DEVICE`.