### PR TITLE
VK: Add INI options to disable some vendor checks, and to disable the shader cache

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -605,8 +605,7 @@ static ConfigSetting graphicsSettings[] = {
 #ifdef _WIN32
 	ConfigSetting("D3D11Device", &g_Config.sD3D11Device, "", true, false),
 #endif
-	ConfigSetting("VendorChecksEnabled", &g_Config.bVendorChecksEnabled, true, false, false),
-	ConfigSetting("ShaderCacheEnabled", &g_Config.bShaderCacheEnabled, true, false, false),
+	ConfigSetting("VendorBugChecksEnabled", &g_Config.bVendorBugChecksEnabled, true, false, false),
 	ReportedConfigSetting("RenderingMode", &g_Config.iRenderingMode, &DefaultRenderingMode, true, true),
 	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, true, true),
 	ReportedConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true, true, true),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -605,6 +605,8 @@ static ConfigSetting graphicsSettings[] = {
 #ifdef _WIN32
 	ConfigSetting("D3D11Device", &g_Config.sD3D11Device, "", true, false),
 #endif
+	ConfigSetting("VendorChecksEnabled", &g_Config.bVendorChecksEnabled, true, false, false),
+	ConfigSetting("ShaderCacheEnabled", &g_Config.bShaderCacheEnabled, true, false, false),
 	ReportedConfigSetting("RenderingMode", &g_Config.iRenderingMode, &DefaultRenderingMode, true, true),
 	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, true, true),
 	ReportedConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -131,8 +131,7 @@ public:
 	bool bSoftwareRendering;
 	bool bHardwareTransform; // only used in the GLES backend
 	bool bSoftwareSkinning;  // may speed up some games
-	bool bVendorChecksEnabled;
-	bool bShaderCacheEnabled;
+	bool bVendorBugChecksEnabled;
 
 	int iRenderingMode; // 0 = non-buffered rendering 1 = buffered rendering
 	int iTexFiltering; // 1 = off , 2 = nearest , 3 = linear , 4 = linear(CG)

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -131,6 +131,8 @@ public:
 	bool bSoftwareRendering;
 	bool bHardwareTransform; // only used in the GLES backend
 	bool bSoftwareSkinning;  // may speed up some games
+	bool bVendorChecksEnabled;
+	bool bShaderCacheEnabled;
 
 	int iRenderingMode; // 0 = non-buffered rendering 1 = buffered rendering
 	int iTexFiltering; // 1 = off , 2 = nearest , 3 = linear , 4 = linear(CG)

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -86,7 +86,9 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer, uint32_
 	bool earlyFragmentTests = ((!enableAlphaTest && !enableColorTest) || testForceToZero) && !gstate_c.Supports(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT);
 	bool hasStencilOutput = stencilToAlpha != REPLACE_ALPHA_NO || id.Bit(FS_BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE) == 0;
 
-	bool isAdreno = vulkanVendorId == VULKAN_VENDOR_QUALCOMM;
+	// TODO: This is a bug affecting shader cache generality - we CANNOT check anything but the shader ID and (indirectly) the game ID in here really.
+	// Need to move this check somehow to the shader ID generator. That's tricky though because it's generic...
+	bool isAdreno = vulkanVendorId == VULKAN_VENDOR_QUALCOMM && g_Config.bVendorChecksEnabled;
 
 	if (earlyFragmentTests) {
 		WRITE(p, "layout (early_fragment_tests) in;\n");

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -88,7 +88,7 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer, uint32_
 
 	// TODO: This is a bug affecting shader cache generality - we CANNOT check anything but the shader ID and (indirectly) the game ID in here really.
 	// Need to move this check somehow to the shader ID generator. That's tricky though because it's generic...
-	bool isAdreno = vulkanVendorId == VULKAN_VENDOR_QUALCOMM && g_Config.bVendorChecksEnabled;
+	bool isAdreno = vulkanVendorId == VULKAN_VENDOR_QUALCOMM && g_Config.bVendorBugChecksEnabled;
 
 	if (earlyFragmentTests) {
 		WRITE(p, "layout (early_fragment_tests) in;\n");

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -101,7 +101,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 	// Load shader cache.
 	std::string discID = g_paramSFO.GetDiscID();
-	if (discID.size() && g_Config.bShaderCacheEnabled) {
+	if (discID.size()) {
 		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
 		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) + "/" + discID + ".vkshadercache";
 		shaderCacheLoaded_ = false;
@@ -202,7 +202,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	}
 
 	// Might enable this later - in the first round we are mostly looking at depth/stencil/discard.
-	// if (g_Config.bDisableVendorChecks)
+	// if (g_Config.bDisableVendorBugChecks)
 	// 	features |= GPU_SUPPORTS_ACCURATE_DEPTH;
 
 	// Mandatory features on Vulkan, which may be checked in "centralized" code
@@ -239,7 +239,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 			features |= GPU_SUPPORTS_DUALSOURCE_BLEND;
 			break;
 		}
-		if (!g_Config.bVendorChecksEnabled)
+		if (!g_Config.bVendorBugChecksEnabled)
 			features |= GPU_SUPPORTS_DUALSOURCE_BLEND;
 	}
 	if (vulkan_->GetFeaturesEnabled().logicOp) {
@@ -507,7 +507,7 @@ void GPU_Vulkan::DeviceLost() {
 	while (!IsReady()) {
 		sleep_ms(10);
 	}
-	if (!shaderCachePath_.empty() && g_Config.bShaderCacheEnabled) {
+	if (!shaderCachePath_.empty()) {
 		SaveCache(shaderCachePath_);
 	}
 	DestroyDeviceObjects();


### PR DESCRIPTION
Couple of settings for investigation of driver bugs by vendors.

It's important to be able to disable the shader cache since we have a stray vendor check in a shader generator... which isn't good.