### PR TITLE
Remove the "Disable stencil test" hack setting

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -654,7 +654,6 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0, true, true),
 	ReportedConfigSetting("TexDeposterize", &g_Config.bTexDeposterize, false, true, true),
 	ConfigSetting("VSyncInterval", &g_Config.bVSync, false, true, true),
-	ReportedConfigSetting("DisableStencilTest", &g_Config.bDisableStencilTest, false, true, true),
 	ReportedConfigSetting("BloomHack", &g_Config.iBloomHack, 0, true, true),
 
 	// Not really a graphics setting...

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -184,7 +184,6 @@ public:
 	bool bEnableCheats;
 	bool bReloadCheats;
 	int iCwCheatRefreshRate;
-	bool bDisableStencilTest;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
 	bool bTimerHack;
 	bool bBlockTransferGPU;

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -661,7 +661,7 @@ static int Hook_hexyzforce_monoclome_thread() {
 
 static int Hook_starocean_write_stencil() {
 	const u32 fb_address = currentMIPS->r[MIPS_REG_T7];
-	if (Memory::IsVRAMAddress(fb_address) && !g_Config.bDisableStencilTest) {
+	if (Memory::IsVRAMAddress(fb_address)) {
 		gpu->PerformStencilUpload(fb_address, 0x00088000);
 	}
 	return 0;

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1342,7 +1342,7 @@ static void ConvertStencilFunc5551(GenericStencilFuncState &state) {
 }
 
 void ConvertStencilFuncState(GenericStencilFuncState &state) {
-	state.enabled = gstate.isStencilTestEnabled() && !g_Config.bDisableStencilTest;
+	state.enabled = gstate.isStencilTestEnabled();
 	if (!state.enabled)
 		return;
 

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -194,8 +194,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 		}
 	}
 
-	bool enableStencilTest = !g_Config.bDisableStencilTest;
-
 	if (gstate_c.IsDirty(DIRTY_RASTER_STATE)) {
 		gstate_c.Clean(DIRTY_RASTER_STATE);
 		// Set Dither
@@ -231,7 +229,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 			// Stencil Test
 			bool alphaMask = gstate.isClearModeAlphaMask();
-			if (alphaMask && enableStencilTest) {
+			if (alphaMask) {
 				dxstate.stencilTest.enable();
 				dxstate.stencilOp.set(D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE);
 				dxstate.stencilFunc.set(D3DCMP_ALWAYS, 255, 0xFF);

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -271,13 +271,12 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
 		gstate_c.Clean(DIRTY_DEPTHSTENCIL_STATE);
-		bool enableStencilTest = !g_Config.bDisableStencilTest;
 		if (gstate.isModeClear()) {
 			// Depth Test
 			if (gstate.isClearModeDepthMask()) {
 				framebufferManager_->SetDepthUpdated();
 			}
-			renderManager->SetStencilFunc(gstate.isClearModeAlphaMask() && enableStencilTest, GL_ALWAYS, 0xFF, 0xFF);
+			renderManager->SetStencilFunc(gstate.isClearModeAlphaMask(), GL_ALWAYS, 0xFF, 0xFF);
 			renderManager->SetStencilOp(0xFF, GL_REPLACE, GL_REPLACE, GL_REPLACE);
 			renderManager->SetDepth(true, gstate.isClearModeDepthMask() ? true : false, GL_ALWAYS);
 		} else {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -467,9 +467,6 @@ void GameSettingsScreen::CreateViews() {
 		return UI::EVENT_CONTINUE;
 	});
 
-	CheckBox *stencilTest = graphicsSettings->Add(new CheckBox(&g_Config.bDisableStencilTest, gr->T("Disable Stencil Test")));
-	stencilTest->SetDisabledPtr(&g_Config.bSoftwareRendering);
-
 	static const char *bloomHackOptions[] = { "Off", "Safe", "Balanced", "Aggressive" };
 	PopupMultiChoice *bloomHack = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iBloomHack, gr->T("Lower resolution for effects (reduces artifacts)"), bloomHackOptions, 0, ARRAY_SIZE(bloomHackOptions), gr->GetName(), screenManager()));
 	bloomHackEnable_ = !g_Config.bSoftwareRendering && (g_Config.iInternalResolution != 1);


### PR DESCRIPTION
Doesn't seem to serve much purpose anymore.  Fixes #6288.