### PR TITLE
SoftGPU: Respect stencil write mask on test fail

### DIFF
--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -252,6 +252,7 @@ struct GPUgstate {
 
 	// Color Mask
 	u32 getColorMask() const { return (pmskc & 0xFFFFFF) | ((pmska & 0xFF) << 24); }
+	u8 getStencilWriteMask() const { return pmska & 0xFF; }
 	bool isLogicOpEnabled() const { return logicOpEnable & 1; }
 	GELogicOp getLogicOp() const { return static_cast<GELogicOp>(lop & 0xF); }
 

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -581,12 +581,16 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 
 	static std::vector<u32> temp_buffer;
 	static std::vector<SimpleVertex> simpleVertices;
-	temp_buffer.resize(65536 * 24 / sizeof(u32));
+	temp_buffer.resize(std::max((int)indexUpperBound, 8192) * 128 / sizeof(u32));
 	simpleVertices.resize(indexUpperBound + 1);
 
 	VertexDecoder vdecoder;
 	VertexDecoderOptions options{};
 	vdecoder.SetVertexType(gstate.vertType, options);
+
+	if (!Memory::IsValidRange(gstate_c.vertexAddr, (indexUpperBound + 1) * vdecoder.VertexSize()))
+		return false;
+
 	DrawEngineCommon::NormalizeVertices((u8 *)(&simpleVertices[0]), (u8 *)(&temp_buffer[0]), Memory::GetPointer(gstate_c.vertexAddr), &vdecoder, indexLowerBound, indexUpperBound, gstate.vertType);
 
 	float world[16];


### PR DESCRIPTION
Improves #6265 behavior (unclear if it fixes the torch in the software renderer, but at least it makes the GE dump render the same as the PSP.)

Decided to apply it here rather than where the stencil value is written, since we already had old stencil.

-[Unknown]