### PR TITLE
GPU driver test, first part: Discard+stencil and Discard+depth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,6 +850,7 @@ list(APPEND NativeAppSource
 	UI/PauseScreen.cpp
 	UI/GameScreen.cpp
 	UI/GameSettingsScreen.cpp
+	UI/GPUDriverTestScreen.cpp
 	UI/TiltAnalogSettingsScreen.cpp
 	UI/TiltEventProcessor.cpp
 	UI/TouchControlLayoutScreen.cpp

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -127,8 +127,6 @@ UI::EventReturn DevMenu::OnShaderView(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-
-
 UI::EventReturn DevMenu::OnFreezeFrame(UI::EventParams &e) {
 	if (PSP_CoreParameter().frozen) {
 		PSP_CoreParameter().frozen = false;

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -1,0 +1,178 @@
+#include "GPUDriverTestScreen.h"
+#include "i18n/i18n.h"
+#include "ui/view.h"
+
+static const std::vector<Draw::ShaderSource> fsDiscard = {
+	{Draw::ShaderLanguage::GLSL_ES_200,
+	R"(varying vec4 oColor0;
+	varying vec2 oTexCoord0;
+	uniform sampler2D Sampler0;
+	void main() {
+       vec4 color = texture2D(Sampler0, oTexCoord0) * oColor0;
+	   if (color.a <= 0.0)
+         discard;
+       gl_FragColor = color;
+	})"
+	},
+	{Draw::ShaderLanguage::GLSL_VULKAN,
+	R"(layout(location = 0) in vec4 oColor0;
+	layout(location = 1) in vec2 oTexCoord0;
+	layout(location = 0) out vec4 fragColor0;
+	layout(set = 0, binding = 1) uniform sampler2D Sampler0;
+	void main() {
+      vec4 color = texture(Sampler0, oTexCoord0) * oColor0;
+      if (color.a <= 0.0)
+		discard;
+	  fragColor0 = color;
+    })"
+	},
+};
+
+GPUDriverTestScreen::GPUDriverTestScreen() {
+	using namespace Draw;
+}
+
+GPUDriverTestScreen::~GPUDriverTestScreen() {
+	if (discardWriteStencil_)
+		discardWriteStencil_->Release();
+	if (drawTestStencil_)
+		drawTestStencil_->Release();
+	if (drawTestDepth_)
+		drawTestDepth_->Release();
+	if (discard_)
+		discard_->Release();
+	if (samplerNearest_)
+		samplerNearest_->Release();
+}
+
+void GPUDriverTestScreen::CreateViews() {
+	// Don't bother with views for now.
+	using namespace UI;
+	I18NCategory *di = GetI18NCategory("Dialog");
+	I18NCategory *cr = GetI18NCategory("PSPCredits");
+
+	auto tabs = new TabHolder(UI::ORIENT_HORIZONTAL, 30.0f);
+	root_ = tabs;
+	tabs->AddTab("Discard", new LinearLayout(UI::ORIENT_VERTICAL));
+}
+
+void GPUDriverTestScreen::render() {
+	using namespace Draw;
+	UIScreen::render();
+
+	if (!discardWriteStencil_) {
+		DrawContext *draw = screenManager()->getDrawContext();
+
+		// Create the special shader module.
+
+		discard_ = CreateShader(draw, Draw::ShaderStage::FRAGMENT, fsDiscard);
+
+		InputLayout *inputLayout = ui_draw2d.CreateInputLayout(draw);
+		BlendState *blendOff = draw->CreateBlendState({false, 0xF});
+
+		// Write depth, write stencil.
+		DepthStencilStateDesc dsDesc{};
+		dsDesc.depthTestEnabled = true;
+		dsDesc.depthWriteEnabled = true;
+		dsDesc.depthCompare = Comparison::ALWAYS;
+		dsDesc.stencilEnabled = true;
+		dsDesc.front.compareMask = 0xFF;
+		dsDesc.front.compareOp = Comparison::ALWAYS;
+		dsDesc.front.passOp = StencilOp::REPLACE;
+		dsDesc.front.failOp = StencilOp::ZERO;
+		dsDesc.front.depthFailOp = StencilOp::ZERO;
+		dsDesc.front.reference = 0xFF;
+		dsDesc.front.writeMask = 0xFF;
+		dsDesc.back = dsDesc.front;
+		DepthStencilState *depthStencilWrite = draw->CreateDepthStencilState(dsDesc);
+
+		dsDesc.depthCompare = Comparison::ALWAYS;
+		dsDesc.front.compareOp = Comparison::EQUAL;
+		DepthStencilState *stencilTestEqual = draw->CreateDepthStencilState(dsDesc);
+
+		dsDesc.depthCompare = Comparison::LESS_EQUAL;
+		dsDesc.front.compareOp = Comparison::ALWAYS;
+		DepthStencilState *depthTestEqual = draw->CreateDepthStencilState(dsDesc);
+
+		RasterState *rasterNoCull = draw->CreateRasterState({});
+
+		PipelineDesc discardDesc{
+			Primitive::TRIANGLE_LIST,
+			{ draw->GetVshaderPreset(VS_TEXTURE_COLOR_2D), discard_ },
+			inputLayout, depthStencilWrite, blendOff, rasterNoCull, &vsColBufDesc,
+		};
+		discardWriteStencil_ = draw->CreateGraphicsPipeline(discardDesc);
+
+		PipelineDesc testStencilDesc{
+			Primitive::TRIANGLE_LIST,
+			{ draw->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw->GetFshaderPreset(FS_TEXTURE_COLOR_2D) },
+			inputLayout, stencilTestEqual, blendOff, rasterNoCull, &vsColBufDesc,
+		};
+		drawTestStencil_ = draw->CreateGraphicsPipeline(testStencilDesc);
+
+		PipelineDesc testDepthDesc{
+			Primitive::TRIANGLE_LIST,
+			{draw->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw->GetFshaderPreset(FS_TEXTURE_COLOR_2D)},
+			inputLayout, stencilTestEqual, blendOff, rasterNoCull, &vsColBufDesc,
+		};
+		drawTestDepth_ = draw->CreateGraphicsPipeline(testDepthDesc);
+
+		inputLayout->Release();
+		blendOff->Release();
+		depthStencilWrite->Release();
+		stencilTestEqual->Release();
+		depthTestEqual->Release();
+		rasterNoCull->Release();
+
+		SamplerStateDesc nearestDesc{};
+		samplerNearest_ = draw->CreateSamplerState(nearestDesc);
+	}
+
+	UIContext &dc = *screenManager()->getUIContext();
+	const Bounds &bounds = dc.GetBounds();
+
+	const char *testNames[] = {"Normal", "Z test", "Stencil test"};
+
+	const int numTests = ARRAY_SIZE(testNames);
+
+	uint32_t textColorOK = 0xFF30FF30;
+	uint32_t textColorBAD = 0xFF3030FF;
+	uint32_t bgColorOK = 0xFF106010;
+	uint32_t bgColorBAD = 0xFF101060;
+
+	// Don't want any fancy font texture stuff going on here, so use FLAG_DYNAMIC_ASCII everywhere!
+
+	float testW = 200.f;
+	float padding = 20.0f;
+	UI::Style style = dc.theme->itemStyle;
+
+	float y = 100;
+	float x = dc.GetBounds().centerX() - ((float)numTests * testW + (float)(numTests - 1) * padding) / 2.0f;
+	for (int i = 0; i < 3; i++) {
+		dc.Begin();
+		dc.SetFontScale(1.0f, 1.0f);
+		Bounds bounds = {x - testW / 2, y + 40, testW, 70};
+		dc.DrawText(testNames[i], bounds.x, y, style.fgColor, FLAG_DYNAMIC_ASCII);
+
+		dc.FillRect(UI::Drawable(bgColorOK), bounds);
+		// test bounds
+		dc.Flush();
+
+		dc.BeginPipeline(discardWriteStencil_, samplerNearest_);
+
+		dc.DrawTextRect("TEST OK", bounds, textColorBAD, ALIGN_HCENTER | ALIGN_VCENTER);
+		dc.Flush();
+
+		dc.BeginPipeline(drawTestStencil_, samplerNearest_);
+		dc.FillRect(UI::Drawable(textColorOK), bounds);
+		dc.Flush();
+
+		// Methodology:
+		// 1. Draw text in red, writing to stencil.
+		// 2. Use stencil test equality to make it green.
+
+		x += testW + padding;
+	}
+	dc.SetFontScale(1.0f, 1.0f);
+	dc.Flush();
+}

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -186,11 +186,20 @@ void GPUDriverTestScreen::DiscardTest() {
 
 	// If everything is OK, both the background and the text should be OK.
 
+	dc.Begin();
+	std::string apiName = screenManager()->getDrawContext()->GetInfoString(InfoField::APINAME);
+	std::string vendor = screenManager()->getDrawContext()->GetInfoString(InfoField::VENDORSTRING);
+	std::string driver = screenManager()->getDrawContext()->GetInfoString(InfoField::DRIVER);
+	dc.DrawText(apiName.c_str(), bounds.centerX(), 20, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.DrawText(vendor.c_str(), bounds.centerX(), 60, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.DrawText(driver.c_str(), bounds.centerX(), 100, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.Flush();
+
 	float testW = 200.f;
 	float padding = 20.0f;
 	UI::Style style = dc.theme->itemStyle;
 
-	float y = 100;
+	float y = 150;
 	float x = (dc.GetBounds().w - (float)numTests * testW - (float)(numTests - 1) * padding) / 2.0f;
 	for (int i = 0; i < numTests; i++) {
 		dc.Begin();

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <algorithm>
+
+#include "base/display.h"
+#include "ui/ui_context.h"
+#include "ui/view.h"
+#include "ui/viewgroup.h"
+#include "ui/ui.h"
+
+#include "Common/LogManager.h"
+#include "UI/MiscScreens.h"
+#include "thin3d/thin3d.h"
+
+class GPUDriverTestScreen : public UIDialogScreenWithBackground {
+public:
+	GPUDriverTestScreen();
+	~GPUDriverTestScreen();
+
+	void CreateViews() override;
+	void render() override;
+
+private:
+	Draw::ShaderModule *discard_ = nullptr;
+	Draw::Pipeline *discardWriteStencil_ = nullptr;
+	Draw::Pipeline *drawTestStencil_ = nullptr;
+	Draw::Pipeline *drawTestDepth_ = nullptr;
+	Draw::SamplerState *samplerNearest_ = nullptr;
+};

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -21,9 +21,14 @@ public:
 	void render() override;
 
 private:
+	void DiscardTest();
+
 	Draw::ShaderModule *discard_ = nullptr;
-	Draw::Pipeline *discardWriteStencil_ = nullptr;
-	Draw::Pipeline *drawTestStencil_ = nullptr;
-	Draw::Pipeline *drawTestDepth_ = nullptr;
+	Draw::Pipeline *discardWriteDepthStencil_ = nullptr;
+	Draw::Pipeline *drawTestStencilEqual_ = nullptr;
+	Draw::Pipeline *drawTestStencilNotEqual_ = nullptr;
+	Draw::Pipeline *drawTestDepthLessEqual_ = nullptr;
+	Draw::Pipeline *drawTestDepthGreater_ = nullptr;
 	Draw::SamplerState *samplerNearest_ = nullptr;
+	UI::TabHolder *tabHolder_ = nullptr;
 };

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -27,6 +27,8 @@ private:
 	Draw::Pipeline *discardWriteDepthStencil_ = nullptr;
 	Draw::Pipeline *drawTestStencilEqual_ = nullptr;
 	Draw::Pipeline *drawTestStencilNotEqual_ = nullptr;
+	Draw::Pipeline *drawTestStencilEqualDepthAlways_ = nullptr;
+	Draw::Pipeline *drawTestStencilNotEqualDepthAlways_ = nullptr;
 	Draw::Pipeline *drawTestDepthLessEqual_ = nullptr;
 	Draw::Pipeline *drawTestDepthGreater_ = nullptr;
 	Draw::SamplerState *samplerNearest_ = nullptr;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1293,6 +1293,11 @@ void DeveloperToolsScreen::CreateViews() {
 
 	cpuTests->SetEnabled(TestsAvailable());
 #endif
+	// For now, we only implement GPU driver tests for Vulkan and OpenGL. This is simply
+	// because the D3D drivers are generally solid enough to not need this type of investigation.
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
+	}
 
 	allowDebugger_ = !WebServerStopped(WebServerFlags::DEBUGGER);
 	canAllowDebugger_ = !WebServerStopping(WebServerFlags::DEBUGGER);
@@ -1309,13 +1314,6 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new ItemHeader(dev->T("Texture Replacement")));
 	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")));
 	list->Add(new CheckBox(&g_Config.bReplaceTextures, dev->T("Replace textures")));
-
-	// For now, we only implement GPU driver tests for Vulkan and OpenGL. This is simply
-	// because the D3D drivers are generally solid enough to not need this type of investigation.
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
-		list->Add(new ItemHeader(dev->T("Hardware Tests")));
-		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
-	}
 
 #if !defined(MOBILE_DEVICE)
 	Choice *createTextureIni = list->Add(new Choice(dev->T("Create/Open textures.ini file for current game")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -44,6 +44,7 @@
 #include "UI/TiltAnalogSettingsScreen.h"
 #include "UI/TiltEventProcessor.h"
 #include "UI/ComboKeyMappingScreen.h"
+#include "UI/GPUDriverTestScreen.h"
 
 #include "Common/KeyMap.h"
 #include "Common/FileUtil.h"
@@ -1211,8 +1212,8 @@ UI::EventReturn GameSettingsScreen::OnPostProcShaderChange(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnDeveloperTools(UI::EventParams &e) {
-	screenManager()->push(new DeveloperToolsScreen());
-	return UI::EVENT_DONE;
+screenManager()->push(new DeveloperToolsScreen());
+return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnRemoteISO(UI::EventParams &e) {
@@ -1232,12 +1233,12 @@ UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e) {
 
 //when the tilt event type is modified, we need to reset all tilt settings.
 //refer to the ResetTiltEvents() function for a detailed explanation.
-UI::EventReturn GameSettingsScreen::OnTiltTypeChange(UI::EventParams &e){
+UI::EventReturn GameSettingsScreen::OnTiltTypeChange(UI::EventParams &e) {
 	TiltEventProcessor::ResetTiltEvents();
 	return UI::EVENT_DONE;
 };
 
-UI::EventReturn GameSettingsScreen::OnTiltCustomize(UI::EventParams &e){
+UI::EventReturn GameSettingsScreen::OnTiltCustomize(UI::EventParams &e) {
 	screenManager()->push(new TiltAnalogSettingsScreen());
 	return UI::EVENT_DONE;
 };
@@ -1276,7 +1277,7 @@ void DeveloperToolsScreen::CreateViews() {
 	// iOS can now use JIT on all modes, apparently.
 	// The bool may come in handy for future non-jit platforms though (UWP XB1?)
 
-	static const char *cpuCores[] = { "Interpreter", "Dynarec (JIT)", "IR Interpreter" };
+	static const char *cpuCores[] = {"Interpreter", "Dynarec (JIT)", "IR Interpreter"};
 	PopupMultiChoice *core = list->Add(new PopupMultiChoice(&g_Config.iCpuCore, gr->T("CPU Core"), cpuCores, 0, ARRAY_SIZE(cpuCores), sy->GetName(), screenManager()));
 	core->OnChoice.Handle(this, &DeveloperToolsScreen::OnJitAffectingSetting);
 	if (!canUseJit) {
@@ -1308,6 +1309,14 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new ItemHeader(dev->T("Texture Replacement")));
 	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")));
 	list->Add(new CheckBox(&g_Config.bReplaceTextures, dev->T("Replace textures")));
+
+	// For now, we only implement GPU driver tests for Vulkan and OpenGL. This is simply
+	// because the D3D drivers are generally solid enough to not need this type of investigation.
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		list->Add(new ItemHeader(dev->T("Hardware Tests")));
+		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
+	}
+
 #if !defined(MOBILE_DEVICE)
 	Choice *createTextureIni = list->Add(new Choice(dev->T("Create/Open textures.ini file for current game")));
 	createTextureIni->OnClick.Handle(this, &DeveloperToolsScreen::OnOpenTexturesIniFile);
@@ -1379,6 +1388,11 @@ UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) 
 
 UI::EventReturn DeveloperToolsScreen::OnLogConfig(UI::EventParams &e) {
 	screenManager()->push(new LogConfigScreen());
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn DeveloperToolsScreen::OnGPUDriverTest(UI::EventParams &e) {
+	screenManager()->push(new GPUDriverTestScreen());
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -158,6 +158,7 @@ private:
 	UI::EventReturn OnLogConfig(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 	UI::EventReturn OnRemoteDebugger(UI::EventParams &e);
+	UI::EventReturn OnGPUDriverTest(UI::EventParams &e);
 
 	bool allowDebugger_ = false;
 	bool canAllowDebugger_ = true;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -679,7 +679,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		screenManager->switchScreen(new LogoScreen());
 	}
 
-	screenManager->push(new GPUDriverTestScreen());
+	// Easy testing
+	// screenManager->push(new GPUDriverTestScreen());
 
 	if (g_Config.bRemoteShareOnStartup && g_Config.bRemoteDebuggerOnStartup)
 		StartWebServer(WebServerFlags::ALL);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -96,6 +96,7 @@
 #include "UI/BackgroundAudio.h"
 #include "UI/TextureUtil.h"
 #include "UI/DiscordIntegration.h"
+#include "UI/GPUDriverTestScreen.h"
 
 #if !defined(MOBILE_DEVICE)
 #include "Common/KeyMap.h"

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -679,6 +679,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		screenManager->switchScreen(new LogoScreen());
 	}
 
+	screenManager->push(new GPUDriverTestScreen());
+
 	if (g_Config.bRemoteShareOnStartup && g_Config.bRemoteDebuggerOnStartup)
 		StartWebServer(WebServerFlags::ALL);
 	else if (g_Config.bRemoteShareOnStartup)

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="GamepadEmu.cpp" />
     <ClCompile Include="GameScreen.cpp" />
     <ClCompile Include="GameSettingsScreen.cpp" />
+    <ClCompile Include="GPUDriverTestScreen.cpp" />
     <ClCompile Include="MainScreen.cpp" />
     <ClCompile Include="MiscScreens.cpp" />
     <ClCompile Include="NativeApp.cpp" />
@@ -64,6 +65,7 @@
     <ClInclude Include="GameScreen.h" />
     <ClInclude Include="GameSettingsScreen.h" />
     <ClInclude Include="CwCheatScreen.h" />
+    <ClInclude Include="GPUDriverTestScreen.h" />
     <ClInclude Include="HostTypes.h" />
     <ClInclude Include="MainScreen.h" />
     <ClInclude Include="MiscScreens.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -71,6 +71,9 @@
     </ClCompile>
     <ClCompile Include="TextureUtil.cpp" />
     <ClCompile Include="DiscordIntegration.cpp" />
+    <ClCompile Include="GPUDriverTestScreen.cpp">
+      <Filter>Screens</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -143,6 +146,9 @@
     </ClInclude>
     <ClInclude Include="TextureUtil.h" />
     <ClInclude Include="DiscordIntegration.h" />
+    <ClInclude Include="GPUDriverTestScreen.h">
+      <Filter>Screens</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Screens">

--- a/UWP/UI_UWP/UI_UWP.vcxproj
+++ b/UWP/UI_UWP/UI_UWP.vcxproj
@@ -312,6 +312,7 @@
     <ClInclude Include="..\..\UI\GamepadEmu.h" />
     <ClInclude Include="..\..\UI\GameScreen.h" />
     <ClInclude Include="..\..\UI\GameSettingsScreen.h" />
+    <ClInclude Include="..\..\UI\GPUDriverTestScreen.h" />
     <ClInclude Include="..\..\UI\HostTypes.h" />
     <ClInclude Include="..\..\UI\InstallZipScreen.h" />
     <ClInclude Include="..\..\UI\MainScreen.h" />
@@ -346,6 +347,7 @@
     <ClCompile Include="..\..\UI\GamepadEmu.cpp" />
     <ClCompile Include="..\..\UI\GameScreen.cpp" />
     <ClCompile Include="..\..\UI\GameSettingsScreen.cpp" />
+    <ClCompile Include="..\..\UI\GPUDriverTestScreen.cpp" />
     <ClCompile Include="..\..\UI\InstallZipScreen.cpp" />
     <ClCompile Include="..\..\UI\MainScreen.cpp" />
     <ClCompile Include="..\..\UI\MiscScreens.cpp" />

--- a/UWP/UI_UWP/UI_UWP.vcxproj.filters
+++ b/UWP/UI_UWP/UI_UWP.vcxproj.filters
@@ -15,6 +15,7 @@
     <ClCompile Include="..\..\UI\GamepadEmu.cpp" />
     <ClCompile Include="..\..\UI\GameScreen.cpp" />
     <ClCompile Include="..\..\UI\GameSettingsScreen.cpp" />
+    <ClCompile Include="..\..\UI\GPUDriverTestScreen.cpp" />
     <ClCompile Include="..\..\UI\InstallZipScreen.cpp" />
     <ClCompile Include="..\..\UI\MainScreen.cpp" />
     <ClCompile Include="..\..\UI\MiscScreens.cpp" />
@@ -49,6 +50,7 @@
     <ClInclude Include="..\..\UI\GamepadEmu.h" />
     <ClInclude Include="..\..\UI\GameScreen.h" />
     <ClInclude Include="..\..\UI\GameSettingsScreen.h" />
+    <ClInclude Include="..\..\UI\GPUDriverTestScreen.h" />
     <ClInclude Include="..\..\UI\HostTypes.h" />
     <ClInclude Include="..\..\UI\InstallZipScreen.h" />
     <ClInclude Include="..\..\UI\MainScreen.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -506,6 +506,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/UI/GameScreen.cpp \
   $(SRC)/UI/ControlMappingScreen.cpp \
   $(SRC)/UI/GameSettingsScreen.cpp \
+  $(SRC)/UI/GPUDriverTestScreen.cpp \
   $(SRC)/UI/TiltAnalogSettingsScreen.cpp \
   $(SRC)/UI/TiltEventProcessor.cpp \
   $(SRC)/UI/TouchControlLayoutScreen.cpp \

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -78,6 +78,7 @@ void DrawBuffer::Shutdown() {
 void DrawBuffer::Begin(Draw::Pipeline *program) {
 	pipeline_ = program;
 	count_ = 0;
+	curZ_ = 0.0f;
 }
 
 void DrawBuffer::Flush(bool set_blend_state) {

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -78,7 +78,6 @@ void DrawBuffer::Shutdown() {
 void DrawBuffer::Begin(Draw::Pipeline *program) {
 	pipeline_ = program;
 	count_ = 0;
-	curZ_ = 0.0f;
 }
 
 void DrawBuffer::Flush(bool set_blend_state) {

--- a/ext/native/gfx_es2/draw_buffer.h
+++ b/ext/native/gfx_es2/draw_buffer.h
@@ -97,7 +97,7 @@ public:
 
 	void V(float x, float y, float z, uint32_t color, float u, float v);
 	void V(float x, float y, uint32_t color, float u, float v) {
-		V(x, y, 0.0f, color, u, v);
+		V(x, y, curZ_, color, u, v);
 	}
 
 	void Circle(float x, float y, float radius, float thickness, int segments, float startAngle, uint32_t color, float u_mul);
@@ -166,6 +166,10 @@ public:
 		alphaStack_.pop_back();
 	}
 
+	void SetCurZ(float curZ) {
+		curZ_ = curZ;
+	}
+
 private:
 	struct Vertex {
 		float x, y, z;
@@ -191,5 +195,7 @@ private:
 	bool inited_;
 	float fontscalex;
 	float fontscaley;
+
+	float curZ_ = 0.0f;
 };
 

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -101,11 +101,6 @@ bool RefCountedObject::ReleaseAssertLast() {
 
 // The Vulkan ones can be re-used with modern GL later if desired, as they're just GLSL.
 
-struct ShaderSource {
-	ShaderLanguage lang;
-	const char *src;
-};
-
 static const std::vector<ShaderSource> fsTexCol = {
 	{ShaderLanguage::GLSL_ES_200,
 	"#ifdef GL_ES\n"
@@ -196,6 +191,7 @@ static const std::vector<ShaderSource> vsCol = {
 	"attribute vec3 Position;\n"
 	"attribute vec4 Color0;\n"
 	"varying vec4 oColor0;\n"
+
 	"uniform mat4 WorldViewProj;\n"
 	"void main() {\n"
 	"  gl_Position = WorldViewProj * vec4(Position, 1.0);\n"
@@ -317,7 +313,7 @@ const UniformBufferDesc vsTexColBufDesc{ sizeof(VsTexColUB),{
 	{ "WorldViewProj", 0, -1, UniformType::MATRIX4X4, 0 }
 } };
 
-static ShaderModule *CreateShader(DrawContext *draw, ShaderStage stage, const std::vector<ShaderSource> &sources) {
+ShaderModule *CreateShader(DrawContext *draw, ShaderStage stage, const std::vector<ShaderSource> &sources) {
 	uint32_t supported = draw->GetSupportedShaderLanguages();
 	for (auto iter : sources) {
 		if ((uint32_t)iter.lang & supported) {

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -416,7 +416,6 @@ struct StencilSide {
 	Comparison compareOp;
 	uint8_t compareMask;
 	uint8_t writeMask;
-	uint8_t reference;
 };
 
 struct DepthStencilStateDesc {
@@ -588,6 +587,7 @@ public:
 	virtual void SetScissorRect(int left, int top, int width, int height) = 0;
 	virtual void SetViewports(int count, Viewport *viewports) = 0;
 	virtual void SetBlendFactor(float color[4]) = 0;
+	virtual void SetStencilRef(uint8_t ref) = 0;
 
 	virtual void BindSamplerStates(int start, int count, SamplerState **state) = 0;
 	virtual void BindTextures(int start, int count, Texture **textures) = 0;

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -662,4 +662,13 @@ struct VsColUB {
 };
 extern const UniformBufferDesc vsColBufDesc;
 
+// Useful utility for specifying a shader in multiple languages.
+
+struct ShaderSource {
+	ShaderLanguage lang;
+	const char *src;
+};
+
+ShaderModule *CreateShader(DrawContext *draw, ShaderStage stage, const std::vector<ShaderSource> &sources);
+
 }  // namespace Draw

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -95,6 +95,10 @@ public:
 			blendFactorDirty_ = true;
 		}
 	}
+	void SetStencilRef(uint8_t ref) override {
+		stencilRef_ = ref;
+		stencilRefDirty_ = true;
+	}
 
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int vertexCount, int offset) override;
@@ -204,8 +208,8 @@ private:
 	// Dynamic state
 	float blendFactor_[4]{};
 	bool blendFactorDirty_ = false;
-	uint8_t stencilRef_;
-	bool stencilRefDirty_;
+	uint8_t stencilRef_ = 0;
+	bool stencilRefDirty_ = true;
 
 	// Temporaries
 	ID3D11Texture2D *packTexture_ = nullptr;
@@ -975,7 +979,6 @@ void D3D11DrawContext::BindPipeline(Pipeline *pipeline) {
 	curPipeline_ = dPipeline;
 }
 
-// Gonna need dirtyflags soon..
 void D3D11DrawContext::ApplyCurrentState() {
 	if (curBlend_ != curPipeline_->blend || blendFactorDirty_) {
 		context_->OMSetBlendState(curPipeline_->blend->bs, blendFactor_, 0xFFFFFFFF);

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -154,7 +154,6 @@ public:
 	D3DSTENCILOP stencilZFail;
 	D3DSTENCILOP stencilPass;
 	D3DCMPFUNC stencilCompareOp;
-	uint8_t stencilReference;
 	uint8_t stencilCompareMask;
 	uint8_t stencilWriteMask;
 	void Apply(LPDIRECT3DDEVICE9 device) {
@@ -170,7 +169,6 @@ public:
 			device->SetRenderState(D3DRS_STENCILPASS, stencilPass);
 			device->SetRenderState(D3DRS_STENCILFUNC, stencilCompareOp);
 			device->SetRenderState(D3DRS_STENCILMASK, stencilCompareMask);
-			device->SetRenderState(D3DRS_STENCILREF, stencilReference);
 			device->SetRenderState(D3DRS_STENCILWRITEMASK, stencilWriteMask);
 		}
 	}
@@ -523,6 +521,7 @@ public:
 	void SetScissorRect(int left, int top, int width, int height) override;
 	void SetViewports(int count, Viewport *viewports) override;
 	void SetBlendFactor(float color[4]) override;
+	void SetStencilRef(uint8_t ref) override;
 
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int vertexCount, int offset) override;
@@ -684,7 +683,6 @@ DepthStencilState *D3D9Context::CreateDepthStencilState(const DepthStencilStateD
 	ds->stencilFail = stencilOpToD3D9[(int)desc.front.failOp];
 	ds->stencilZFail = stencilOpToD3D9[(int)desc.front.depthFailOp];
 	ds->stencilWriteMask = desc.front.writeMask;
-	ds->stencilReference = desc.front.reference;
 	ds->stencilCompareMask = desc.front.compareMask;
 	return ds;
 }
@@ -964,6 +962,10 @@ void D3D9Context::SetBlendFactor(float color[4]) {
 	uint32_t b = (uint32_t)(color[2] * 255.0f);
 	uint32_t a = (uint32_t)(color[3] * 255.0f);
 	device_->SetRenderState(D3DRS_BLENDFACTOR, r | (g << 8) | (b << 16) | (a << 24));
+}
+
+void D3D9Context::SetStencilRef(uint8_t ref) {
+	device_->SetRenderState(D3DRS_STENCILREF, (DWORD)ref);
 }
 
 bool D3D9ShaderModule::Compile(LPDIRECT3DDEVICE9 device, const uint8_t *data, size_t size) {

--- a/ext/native/ui/ui.cpp
+++ b/ext/native/ui/ui.cpp
@@ -15,9 +15,9 @@
 DrawBuffer ui_draw2d;
 DrawBuffer ui_draw2d_front;
 
-void UIBegin(Draw::Pipeline *shaderSet) {
-	ui_draw2d.Begin(shaderSet);
-	ui_draw2d_front.Begin(shaderSet);
+void UIBegin(Draw::Pipeline *pipeline) {
+	ui_draw2d.Begin(pipeline);
+	ui_draw2d_front.Begin(pipeline);
 }
 
 void UIFlush() {

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -38,6 +38,8 @@ void UIContext::BeginFrame() {
 			FLOG("Failed to load ui_atlas.zim");
 		}
 	}
+	uidrawbufferTop_->SetCurZ(0.0f);
+	uidrawbuffer_->SetCurZ(0.0f);
 	ActivateTopScissor();
 }
 

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -52,6 +52,12 @@ void UIContext::BeginNoTex() {
 	UIBegin(ui_pipeline_notex_);
 }
 
+void UIContext::BeginPipeline(Draw::Pipeline *pipeline, Draw::SamplerState *samplerState) {
+	draw_->BindSamplerStates(0, 1, &sampler_);
+	draw_->BindTexture(0, uitexture_->GetTexture());
+	UIBegin(pipeline);
+}
+
 void UIContext::RebindTexture() const {
 	draw_->BindTexture(0, uitexture_->GetTexture());
 }
@@ -63,6 +69,11 @@ void UIContext::Flush() {
 	if (uidrawbufferTop_) {
 		uidrawbufferTop_->Flush();
 	}
+}
+
+void UIContext::SetCurZ(float curZ) {
+	ui_draw2d.SetCurZ(curZ);
+	ui_draw2d_front.SetCurZ(curZ);
 }
 
 // TODO: Support transformed bounds using stencil instead.

--- a/ext/native/ui/ui_context.h
+++ b/ext/native/ui/ui_context.h
@@ -51,6 +51,7 @@ public:
 
 	void Begin();
 	void BeginNoTex();
+	void BeginPipeline(Draw::Pipeline *pipeline, Draw::SamplerState *samplerState);
 	void Flush();
 
 	void RebindTexture() const;
@@ -85,6 +86,7 @@ public:
 	void SetBounds(const Bounds &b) { bounds_ = b; }
 	const Bounds &GetBounds() const { return bounds_; }
 	Draw::DrawContext *GetDrawContext() { return draw_; }
+	void SetCurZ(float curZ);
 
 	void PushTransform(const UITransform &transform);
 	void PopTransform();


### PR DESCRIPTION
This test verifies that "fragment discard" affects Z and Stencil operations as well as Color - which some Adreno generations seems to have problems with.

It can be accessed from Settings/Tools/Developer Tools/GPU Driver Test.

The output should look like this:

![gpudrivertest](https://user-images.githubusercontent.com/130929/50221622-037cd080-0396-11e9-84d0-3b4011a5a18a.JPG)

If it fails, the text will probably be invisible covered in green or red.

@unknownbrackets  can you see if this fails as expected on your Adreno hardware?

