### PR TITLE
Move non-remastered games to compat.ini

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -50,18 +50,18 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DepthRangeHack", &flags_.DepthRangeHack);
 	CheckSetting(iniFile, gameID, "ClearToRAM", &flags_.ClearToRAM);
 	CheckSetting(iniFile, gameID, "Force04154000Download", &flags_.Force04154000Download);
+	CheckSetting(iniFile, gameID, "DisableReadbacks", &flags_.DisableReadbacks);
 	CheckSetting(iniFile, gameID, "DrawSyncEatCycles", &flags_.DrawSyncEatCycles);
 	CheckSetting(iniFile, gameID, "FakeMipmapChange", &flags_.FakeMipmapChange);
-	CheckSetting(iniFile, gameID, "RequireBufferedRendering", &flags_.RequireBufferedRendering);
-	CheckSetting(iniFile, gameID, "RequireBlockTransfer", &flags_.RequireBlockTransfer);
-	CheckSetting(iniFile, gameID, "RequireDefaultCPUClock", &flags_.RequireDefaultCPUClock);
-	CheckSetting(iniFile, gameID, "DisableReadbacks", &flags_.DisableReadbacks);
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
-	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
-	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);
-	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
 	CheckSetting(iniFile, gameID, "HighMemoryLayout", &flags_.HighMemoryLayout);
+	CheckSetting(iniFile, gameID, "MGAcidHack", &flags_.MGAcidHack);
+	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
+	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
+	CheckSetting(iniFile, gameID, "RequireDefaultCPUClock", &flags_.RequireDefaultCPUClock);
+	CheckSetting(iniFile, gameID, "RequireBlockTransfer", &flags_.RequireBlockTransfer);
+	CheckSetting(iniFile, gameID, "RequireBufferedRendering", &flags_.RequireBufferedRendering);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -61,6 +61,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);
 	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
+	CheckSetting(iniFile, gameID, "HighMemoryLayout", &flags_.HighMemoryLayout);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -61,6 +61,7 @@ struct CompatFlags {
 	bool SonicRivalsHack;
 	bool BlockTransferAllowCreateFB;
 	bool YugiohSaveFix;
+	bool HighMemoryLayout;
 };
 
 class IniFile;

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -50,18 +50,18 @@ struct CompatFlags {
 	bool DepthRangeHack;
 	bool ClearToRAM;
 	bool Force04154000Download;
+	bool DisableReadbacks;
 	bool DrawSyncEatCycles;
 	bool FakeMipmapChange;
-	bool RequireBufferedRendering;
-	bool RequireBlockTransfer;
-	bool RequireDefaultCPUClock;
-	bool DisableReadbacks;
 	bool DisableAccurateDepth;
-	bool MGS2AcidHack;
-	bool SonicRivalsHack;
 	bool BlockTransferAllowCreateFB;
-	bool YugiohSaveFix;
 	bool HighMemoryLayout;
+	bool MGAcidHack;
+	bool SonicRivalsHack;
+	bool YugiohSaveFix;
+	bool RequireDefaultCPUClock;
+	bool RequireBlockTransfer;
+	bool RequireBufferedRendering;
 };
 
 class IniFile;

--- a/Core/HDRemaster.cpp
+++ b/Core/HDRemaster.cpp
@@ -29,13 +29,6 @@ extern const struct HDRemaster g_HDRemasters[] = {
 	{ "ULJM05170", 0x04000000, true, "ULJM-05170|55C069C631B22685|0001|G" }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
 	{ "ULJM05277", 0x04C00000, true, "ULJM-05277|0E8D71AFAA4F62D8|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
 	{ "ULJM05353", 0x04C00000, true, "ULJM-05353|0061DA67EBD6B9C6|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition
-	{ "ULUS12345", 0x04000000, false, "ULUS-12345|6E197A8FB304B3DB|0001|G" }, // Saints Row 2 / Undercover - alpha (needs extra ram, not a remaster)
-	{ "UCUS12345", 0x04000000, false, "UCUS-12345|909D53E8B45B4B4A|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 09062006 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BC7AE2442B7CD085|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 21112006 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|6035DE628DC1C924|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 31012007 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BBE65F2837A488C2|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 01022007 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|55BE9ADC13B14D65|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 27042007 (needs extra ram, not a remaster)
-	{ "PETR00010", 0x04000000, false, "PETR-00010|0C274C92FF78330E|0001|G" }, // Melodie - alpha (needs extra ram, not a remaster)
 };
 
 const size_t g_HDRemastersCount = ARRAY_SIZE(g_HDRemasters);

--- a/Core/HDRemaster.cpp
+++ b/Core/HDRemaster.cpp
@@ -21,14 +21,13 @@
 bool g_RemasterMode;
 bool g_DoubleTextureCoordinates;
 
-// TODO: Do all of the remasters aside from Monster Hunter/Shin Sangoku use double texture coordinates?
 extern const struct HDRemaster g_HDRemasters[] = {
-	{ "NPJB40001", 0x04000000, false }, // MONSTER HUNTER PORTABLE 3rd HD Ver.
-	{ "NPJB40002", 0x04000000, true }, // K-ON Houkago Live HD Ver
-	{ "NPJB40003", 0x04000000, false }, // Shin Sangoku Musou Multi Raid 2 HD Ver
-	{ "ULJM05170", 0x04000000, true, "ULJM-05170|55C069C631B22685|0001|G" }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
-	{ "ULJM05277", 0x04C00000, true, "ULJM-05277|0E8D71AFAA4F62D8|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
-	{ "ULJM05353", 0x04C00000, true, "ULJM-05353|0061DA67EBD6B9C6|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition
+	{ "NPJB40001", "NPJB-40001|9E5068A8E12454A5|0001|G", 0x04000000, false}, // Monster Hunter Portable 3rd
+	{ "NPJB40002", "NPJB-40002|91B2BE27FA482C91|0001|G", 0x04000000, true},  // K-ON! Houkago Live!!
+	{ "NPJB40003", "NPJB-40003|679CE3A6453B0F68|0001|G", 0x04000000, false}, // Shin Sangoku Musou: Multi Raid 2
+	{ "ULJM05170", "ULJM-05170|55C069C631B22685|0001|G", 0x04000000, false}, // Eiyuu Densetsu: Sora no Kiseki FC
+	{ "ULJM05277", "ULJM-05277|0E8D71AFAA4F62D8|0001|G", 0x04C00000, false}, // Eiyuu Densetsu: Sora no Kiseki SC
+	{ "ULJM05353", "ULJM-05353|0061DA67EBD6B9C6|0001|G", 0x04C00000, false}  // Eiyuu Densetsu: Sora no Kiseki the 3rd
 };
 
 const size_t g_HDRemastersCount = ARRAY_SIZE(g_HDRemasters);

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -28,9 +28,9 @@ extern bool g_DoubleTextureCoordinates;
 
 struct HDRemaster {
 	const char *gameID;
+	const char *umdDataValue;
 	u32 memorySize;
 	bool doubleTextureCoordinates;
-	const char *umdDataValue;
 };
 
 extern const struct HDRemaster g_HDRemasters[];

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -128,7 +128,7 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 		if (entry.gameID != gameID) {
 			continue;
 		}
-		if (entry.umdDataValue && umdData.find(entry.umdDataValue) == umdData.npos) {
+		if (umdData.find(entry.umdDataValue) == umdData.npos) {
 			continue;
 		}
 
@@ -204,7 +204,7 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 	// Bypass Chinese translation patches, see comment above.
 	for (size_t i = 0; i < ARRAY_SIZE(altBootNames); i++) {
 		if (pspFileSystem.GetFileInfo(altBootNames[i]).exists) {
-			bootpath = altBootNames[i];			
+			bootpath = altBootNames[i];
 		}
 	}
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -180,13 +180,10 @@ void CPU_Init() {
 	currentMIPS = &mipsr4k;
 
 	g_symbolMap = new SymbolMap();
-
-	// Default memory settings
-	// Seems to be the safest place currently..
-	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MB of ram by default
-
 	g_RemasterMode = false;
 	g_DoubleTextureCoordinates = false;
+
+	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE; // 32 MiB
 	Memory::g_PSPModel = g_Config.iPSPModel;
 
 	std::string filename = coreParameter.fileToStart;
@@ -227,6 +224,10 @@ void CPU_Init() {
 	// likely to collide with any commercial ones.
 	std::string discID = g_paramSFO.GetDiscID();
 	coreParameter.compat.Load(discID);
+
+	// Some games need more RAM
+	if (PSP_CoreParameter().compat.flags().HighMemoryLayout)
+		Memory::g_MemorySize = Memory::RAM_DOUBLE_SIZE; // 64 MiB
 
 	Memory::Init();
 	mipsr4k.Reset();

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -475,8 +475,8 @@ void GPU_Vulkan::InitDeviceObjects() {
 
 	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	uint32_t hacks = 0;
-	if (PSP_CoreParameter().compat.flags().MGS2AcidHack)
-		hacks |= QUEUE_HACK_MGS2_ACID;
+	if (PSP_CoreParameter().compat.flags().MGAcidHack)
+		hacks |= QUEUE_HACK_MGACID;
 	if (PSP_CoreParameter().compat.flags().SonicRivalsHack)
 		hacks |= QUEUE_HACK_SONIC;
 	if (hacks) {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -43,7 +43,7 @@ ULJM08030 = true
 # Puyo Puyo Fever 2   #3663 (layering)
 ULJM05058 = true
 # NBA 2K13  #6603 (menu glitches)
-ULAS42332 = true 
+ULAS42332 = true
 ULJS00551 = true
 NPJH50713 = true
 ULJS00596 = true
@@ -54,8 +54,8 @@ ULES00496 = true
 ULUS10171 = true
 ULJM05178 = true
 # Taiko no Tatsujin Portable DX    #7920  (missing text)
-ULJS00383 = true 
-NPJH50426 = true 
+ULJS00383 = true
+NPJH50426 = true
 ULAS42282 = true
 # PhotoKano  #7920  (missing text)
 ULJS00378 = true
@@ -236,7 +236,7 @@ ULJM08033 = true
 NPJH50373 = true
 # Grand Knights History
 ULJS00394 = true
-ULJS19068 = true	
+ULJS19068 = true
 NPJH50518 = true
 # Tactics Ogre
 ULUS10565 = true
@@ -282,7 +282,7 @@ ULJM08033 = true
 NPJH50373 = true
 # Grand Knights History need it to fix blackboxes on characters and flickering texture . See issues #2135 , #6099
 ULJS00394 = true
-ULJS19068 = true	
+ULJS19068 = true
 NPJH50518 = true
 # TODO: Will add some games in the future
 
@@ -362,7 +362,7 @@ ULJM05260 = true
 ULES00925 = true
 ULES00926 = true
 
-# Yu-Gi-Oh! Duel Monsters GX: Tag Force 3 
+# Yu-Gi-Oh! Duel Monsters GX: Tag Force 3
 ULES01183 = true
 ULJM05373 = true
 
@@ -374,14 +374,14 @@ ULES01362 = true
 # Yu-Gi-Oh! 5D's Tag Force 5
 ULUS10555 = true
 ULJM05734 = true
- 
+
 # Yu-Gi-Oh! 5D's Tag Force 6
 ULJM-05940 = true
 NPJH-50794 = true
-  
-# Yu-Gi-Oh! 5D's Tag Force 
+
+# Yu-Gi-Oh! 5D's Tag Force
 ULJM05940 = true
- 
+
 # Yu-Gi-Oh! ARC-V Tag Force Special
 NPJH00142 = true
 
@@ -395,4 +395,3 @@ UCUS12345 = true
 ULET00501 = true
 # The Elder Scrolls Travels: Oblivion
 ABCD01234561 = true
-

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1,397 +1,458 @@
-# ========================================================================================
+# ==============================================================================
 # compat.ini for PPSSPP
-# ========================================================================================
+# ==============================================================================
 #
 # This file is not meant to be user-editable, although is kept as a separate ini
 # file instead of compiled into the code for debugging purposes.
 #
 # The uses cases are strict:
-#   * Enable fixes for things we can't reasonably emulate without completely ruining
-#     performance for other games, such as the screen copies in Dangan Ronpa
-#   * Disabling accuracy features like 16-bit depth rounding, when we can't seem to
-#     implement them at all in a 100% compatible way
-#   * Emergency game-specific compatibility fixes before releases, such as the GTA
-#     music problem where every attempted fix has reduced compatibility with other games
+#   * Enable fixes for things we can't reasonably emulate without completely
+#     ruining performance for other games, such as the screen copies in Dangan
+#     Ronpa.
+#   * Disabling accuracy features like 16-bit depth rounding, when we can't seem
+#     to implement them at all in a 100% compatible way.
+#   * Emergency game-specific compatibility fixes before releases, such as the
+#     GTA music problem (#7863) where every attempted fix has reduced
+#     compatibility with other games.
 #   * Enable "unsafe" performance optimizations that some games can tolerate and
 #     others cannot. We do not currently have any of those.
 #
 # This functionality should NOT be used for any of the following:
 #   * Cheats
 #   * Fun hacks, like enlarged heads or whatever
-#   * Fixing general compatibility issues. First try to find a general solution. Try hard.
+#   * Fixing general compatibility issues. First try to find a general solution.
 #
 # Game IDs can be looked up at GameFAQs, for example:
 # http://www.gamefaqs.com/psp/925776-grand-theft-auto-liberty-city-stories/data
 # Sometimes the information may be incomplete though.
 #
-# ========================================================================================
+# ==============================================================================
 # Issue numbers refer to issues on https://github.com/hrydgard/ppsspp/issues
-# ========================================================================================
+# ==============================================================================
 
+###########
+# GENERAL #
+###########
+# Forces 16-bit precision (instead of 24-bit) vertex depth rounding
+# https://github.com/hrydgard/ppsspp/pull/8433
 [VertexDepthRounding]
-# Phantasy Star Portable needs depth rounding to 16-bit precision for text to show up.
-# It's enough to do it at the vertex granularity.  #3777
-ULJM05309 = true
-ULUS10410 = true
-ULES01218 = true
-ULJM08023 = true
-ULES01218 = true
-# Phantasy Star Portable 2 JP (missing text)
-ULJM05493 = true
-NPJH50043 = true
-ULJM08030 = true
-# Puyo Puyo Fever 2   #3663 (layering)
-ULJM05058 = true
-# NBA 2K13  #6603 (menu glitches)
-ULAS42332 = true
-ULJS00551 = true
-NPJH50713 = true
-ULJS00596 = true
+# NBA 2K13 (#6603)
+NPJH50713 = true # NODUMP
+ULAS42332 = true # NODUMP
 ULES01578 = true
+ULJS00551 = true
+ULJS00596 = true # NODUMP
 ULUS10598 = true
-# Power Stone Collection  #6257 (map arrow)
-ULES00496 = true
-ULUS10171 = true
-ULJM05178 = true
-# Taiko no Tatsujin Portable DX    #7920  (missing text)
-ULJS00383 = true
-NPJH50426 = true
-ULAS42282 = true
-# PhotoKano  #7920  (missing text)
-ULJS00378 = true
-NPJH50579 = true
-ULJS19069 = true
-NPJH50579 = true
-
-[PixelDepthRounding]
-# Heroes Phantasia requires pixel depth rounding.  #6485 (flickering overlaid sprites)
-NPJH50558 = true
-ULJS00456 = true
-ULJS00454 = true
-# Heroes Phantasia Limited Edition Disc requires pixel depth rounding.
-ULJS00455 = true
-# Phantasy Star games flickering
-# Phantasy Star Portable 1
+# Phantasy Star Portable (#3777)
+NPJH90002 = true # NODUMP
+NPUH90023 = true # NODUMP
+ULES01218 = true
 ULJM05309 = true
-ULUS10410 = true
-ULES01218 = true
-ULJM08023 = true
-ULES01218 = true
-# Phantasy Star Portable 2 JP
-ULJM05493 = true
-NPJH50043 = true
-ULJM08030 = true
-# Phantasy Star Portable 1 Demo
-NPUH90023 = true
+ULJM08023 = true # NODUMP
 ULJM91014 = true
-NPJH90002 = true
-# Phantasy Star Portable 2 JP Demo
-ULJM91018 = true
-NPJH90062 = true
-
-[DepthRangeHack]
-# Phantasy Star Portable 2 and Infinity both use viewport depth outside [0, 1].
-# This gets clamped in our current implementation, but attempts to fix it run into
-# Other bugs, so we've restored this hack for now.
-ULJM05493 = true
+ULUS10410 = true
+# Phantasy Star Portable 2
+# TODO: ULJM91018 (Special Taikenban)
 NPJH50043 = true
-ULJM08030 = true
+NPJH90062 = true
 ULES01439 = true
+ULJM05493 = true # NODUMP
+ULJM08030 = true # NODUMP
 ULUS10529 = true
-ULJM91018 = true  # Infinity demo disc?
-NPJH90157 = true  # Infinity demo
-ULJM05732 = true
+# PhotoKano (#7920)
+NPJH50579 = true # NODUMP
+ULJS00378 = true
+ULJS19069 = true # NODUMP
+# Power Stone Collection (#6257)
+ULES00496 = true
+ULJM05178 = true # Power Stone Portable
+ULUS10171 = true
+# Puyo Puyo Fever 2 (#3663)
+ULJM05058 = true
+# Taiko no Tatsujin Portable DX (#7920)
+NPJH50426 = true
+ULAS42282 = true # NODUMP
+ULJS00383 = true # NODUMP
+
+# Forces fragment shader depth rounding
+# https://github.com/hrydgard/ppsspp/pull/8454
+[PixelDepthRounding]
+# Heroes Phantasia (#6485)
+NPJH50558 = true
+ULJS00454 = true # NODUMP
+ULJS00455 = true
+ULJS00456 = true # NODUMP
+# Phantasy Star Portable (#3777)
+NPJH90002 = true # NODUMP
+NPUH90023 = true # NODUMP
+ULES01218 = true
+ULJM05309 = true
+ULJM08023 = true # NODUMP
+ULJM91014 = true
+ULUS10410 = true
+# Phantasy Star Portable 2
+# TODO: ULJM91018 (Special Taikenban)
+NPJH50043 = true
+NPJH90062 = true # NODUMP
+ULES01439 = true
+ULJM05493 = true # NODUMP
+ULJM08030 = true # NODUMP
+ULUS10529 = true
+
+# Modifies projection matrix to work around clamped negative depth range
+# https://github.com/hrydgard/ppsspp/pull/7069
+[DepthRangeHack]
+# Phantasy Star Portable
+NPJH90002 = true # NODUMP
+NPUH90023 = true # NODUMP
+ULES01218 = true
+ULJM05309 = true
+ULJM08023 = true # NODUMP
+ULJM91014 = true
+ULUS10410 = true
+# Phantasy Star Portable 2 (#1788)
+# TODO: ULJM91018 (Special Taikenban)
+NPJH50043 = true
+NPJH90062 = true # NODUMP
+ULES01439 = true
+ULJM05493 = true # NODUMP
+ULJM08030 = true # NODUMP
+ULUS10529 = true
+# Phantasy Star Portable 2 Infinity (#1788)
 NPJH50332 = true
+NPJH90157 = true # NODUMP
+ULJM05732 = true
+ULJM91022 = true
 
+# Clears memory when clearing drawing
+# https://github.com/hrydgard/ppsspp/pull/8994
 [ClearToRAM]
-# SOCOM Navy Seals games require this. See issue #8973.
-# Navy Seals
-UCUS98615 = true
-ULES00038 = true
+# TODO: SOCOM - U.S. Navy SEALs - Fireteam Bravo 2
+#       UCES00543, UCKS45043, UCUS98691, UCUS80171, UCUS98645
+#       SOCOM - U.S. Navy SEALs - Tactical Strike (#8973)
+#       NPUG80220, UCES00855, UCUS98649, UCUS98714
+
+# SOCOM - U.S. Navy SEALs - Fireteam Bravo
+UCES00038 = true
 UCKS45021 = true
-# Fireteam Bravo 3
-UCJS10102 = true
-NPJG00035 = true
+UCUS98615 = true
+UCUS98637 = true
+UCUS98638 = true
+# SOCOM - U.S. Navy SEALs - Fireteam Bravo 3 (#8973)
+NPHG00032 = true
+NPJG00035 = true # SOCOM - U.S. Navy SEALs - Portable
+UCES01242 = true # SOCOM - Fireteam Bravo 3
+UCJS10102 = true # NODUMP
 UCUS98716 = true
-UCES01242 = true
 
+# Sets 0x00154000 framebuffer to 1x and force-downloads it automatically
+# https://github.com/hrydgard/ppsspp/pull/8994
 [Force04154000Download]
-# This applies a hack to Dangan Ronpa, its demo, and its sequel.
-# The game draws solid colors to a small framebuffer, and then reads this directly in VRAM.
-# We force this framebuffer to 1x and force download it automatically.
-NPJH50631 = true
+# Dangan-Ronpa - Kibou no Gakuen to Zetsubou no Koukousei
 NPJH50372 = true
-NPJH90164 = true
 NPJH50515 = true
-# Let's also apply to Me & My Katamari.
-ULUS10094 = true
+NPJH90164 = true # NODUMP
+# Me & My Katamari
+NPJH50141 = true # NODUMP
+UCKS45022 = true # Abamama Osheotda! Eoseo Gullyeora!
 ULES00339 = true
-ULJS00033 = true
-UCKS45022 = true
-ULJS19009 = true
-NPJH50141 = true
+ULJS00033 = true # Boku no Watashi no Katamari Damacy
+ULJS19009 = true # NODUMP
+ULUS10094 = true
+# Super Dangan-Ronpa 2 - Sayonara Zetsubou Gakuen
+NPJH50631 = true
 
+# Skips copying the framebuffer to RAM and displays it directly
+# https://github.com/hrydgard/ppsspp/commit/05930ea3
 [DisableReadbacks]
-# MotoGP copies the framebuffer to RAM every frame. We have a hack to display it directly,
-# which means we don't also need a readback.
+# Moto GP
+UCES00373 = true
 ULJS00078 = true
 ULUS10153 = true
-UCES00373 = true
 
+# Makes sceGeDrawSync eat 500000 cycles
+# https://github.com/hrydgard/ppsspp/pull/9274
 [DrawSyncEatCycles]
-# This replaced Crash Tag Team Racing hack to also fix Gundam games
-# It makes sceGeDrawSync eat a lot of cycles which can affect timing in lots of games,
-# might be negative for others, but happens to fix games below.
-# Crash Tag Team Racing needs it to pass checking memory stick screen.
-ULUS10044 = true
+# Crash Tag Team Racing (#5468)
 ULES00168 = true
+ULES00169 = true
+ULES00170 = true
+ULES00171 = true
 ULES00172 = true
-ULJM05036 = true
-# Gundam Battle Royale might need it to avoid crashes when certain Ace enemies shows up
-ULJS00083 = true
-ULKS46104 = true
-ULJS19015 = true
-# Gundam Battle Chronicle needs it to avoid crashes after most battles
+ULES00173 = true
+ULJM05036 = true # Crash Bandicoot - Gacchanko World
+ULUS10044 = true
+# Gundam Battle Chronicle (#9003)
 ULJS00122 = true
-ULKS46158 = true
-ULJS19021 = true
-# Gundam Battle Universe same problem as above
+ULJS19021 = true # NODUMP
+ULKS46158 = true # NODUMP
+# Gundam Battle Royale (#9007)
+ULJS00083 = true
+ULJS19015 = true # NODUMP
+ULKS46104 = true # NODUMP
+# Gundam Battle Universe (#7136)
+NPJH50843 = true # NODUMP
 ULJS00145 = true
-ULKS46183 = true
-ULJS00260 = true
-ULJS19041 = true
-NPJH50843 = true
-# Helps with Jeanne d'Arc weird 40/40 fps problem #5154
-UCAS40129 = true
+ULJS00260 = true # NODUMP
+ULJS19041 = true # NODUMP
+ULKS46183 = true # NODUMP
+# Jeanne d'Arc [##5154]
+NPJG00032 = true # NODUMP
+UCAS40129 = true # NODUMP
 UCJS10048 = true
-UCKS45033 = true
-UCJS18014 = true
+UCJS18014 = true # NODUMP
+UCJX90019 = true # Jeanne d'Arc - Senkou Taikenban
+UCKS45033 = true # NODUMP
 UCUS98700 = true
-NPJG00032 = true
+UCUS98706 = true
 
+# Separates each mipmap to independent textures to display wrong-size mipmaps
+# https://github.com/hrydgard/ppsspp/pull/9299
 [FakeMipmapChange]
-# This hacks separates each mipmap to independent textures to display wrong-size mipmaps.
-# For example this requires games like Tactics Ogre(Japanese) to display multi bytes fonts stored in mipmaps.
-# See issue #5350.
-# Tactics Ogre(Japanese)
-ULJM05753 = true
-NPJH50348 = true
-ULJM06009 = true
-
-[RequireBufferedRendering]
-# Warn the user that the game will not work and have issue, if buffered rendering is not enabled.
-# Midnight Club: LA Remix
-ULUS10383 = true
-ULES01144 = true
-ULJS00180 = true
-ULJS00267 = true
-ULJM05904 = true
-NPJH50440 = true
-# Midnight Club 3 : DUB edition
-ULUS10021 = true
-ULES00108 = true
-# GTA : VCS
-ULUS10160 = true
-ULES00502 = true
-ULJM05297 = true
-ULJM05395 = true
-ULJM05884 = true
-NPJH50827 = true
-# GTA : LCS
-ULUS10041 = true
-ULES00151 = true
-ULJM05255 = true
-ULJM05359 = true
-ULJM05885 = true
-NPJH50825 = true
-# GOW : Chains Of Olympus
-UCUS98653 = true
-UCUS98705 = true
-UCES00842 = true
-ULJM05438 = true
-ULJM05348 = true
-UCKS45084 = true
-NPUG80325 = true
-NPEG00023 = true
-NPHG00028 = true
-NPJG00120 = true
-# Daxter
-UCUS98618 = true
-UCES00044 = true
-NPUG80329 = true
-NPEG00025 = true
-# Ys Seven
-ULUS10551 = true
-ULJM05475 = true
-NPEH00065 = true
-NPJH50350 = true
-ULJM08041 = true
-NPEH00065 = true
-# The Legend of Heroes: Trails in the Sky
-ULUS10540 = true
-ULUS10578 = true
-ULES01556 = true
-ULJM05170 = true
-ULJM08033 = true
-NPJH50373 = true
-# Grand Knights History
-ULJS00394 = true
-ULJS19068 = true
-NPJH50518 = true
-# Tactics Ogre
-ULUS10565 = true
+# Tactics Ogre - Let Us Cling Together (#5350)
+NPJH50348 = true # NODUMP
+UCKS45164 = true # NODUMP
 ULES01500 = true
-ULJM05753 = true
-NPJH50348 = true
-ULJM06009 = true
-UCKS45164 = true
-# Metal Gear Solid : Peace Walker
-ULUS10509 = true
-ULES01372 = true
-ULJM08038 = true
-NPJH50045 = true
-ULJM05630 = true
-# Star Ocean : Second Evolution
-ULUS10375 = true
-ULES01187 = true
-ULJM05591 = true
-ULJM05325 = true
-UCAS40203 = true
-# Driver 76
-ULUS10235 = true
-ULES00740 = true
-# Chili Con Carnage
-ULUS10216 = true
-ULES00629 = true
+ULJM05753 = true # Tactics Ogre - Unmei no Wa
+ULJM06009 = true # NODUMP
+ULUS10565 = true
 
-[RequireBlockTransfer]
-# Warn the user that the game will have issue graphic, if simulate block transfer is not enabled.
-# Ys Seven need it to fix minimap. See issues #2928
-ULUS10551 = true
-ULJM05475 = true
-NPEH00065 = true
-NPJH50350 = true
-ULJM08041 = true
-NPEH00065 = true
-# The Legend of Heroes: Trails in the Sky need it to fix graphical glitch in menu screen. See issues #8053
-ULUS10540 = true
-ULUS10578 = true
-ULES01556 = true
-ULJM05170 = true
-ULJM08033 = true
-NPJH50373 = true
-# Grand Knights History need it to fix blackboxes on characters and flickering texture . See issues #2135 , #6099
-ULJS00394 = true
-ULJS19068 = true
-NPJH50518 = true
-# TODO: Will add some games in the future
-
+# Disables the accurate depth path
+# https://github.com/hrydgard/ppsspp/commit/6a3d418
 [DisableAccurateDepth]
-# Midnight Club: LA Remix
-ULUS10383 = true
-ULES01144 = true
-ULJS00180 = true
-ULJS00267 = true
-ULJM05904 = true
-NPJH50440 = true
-# Midnight Club 3 : DUB edition
-ULUS10021 = true
-ULES00108 = true
-
-# Shadow of Destiny (#9545)
-ULUS10459 = true
-NPJH50036 = true
-
-# Burnout games have problems with this on Mali, and have no use for it
-# Legends
-ULES00125 = true
-ULUS10025 = true
-ULJM05228 = true
-NPJH50305 = true
-ULJM05049 = true
-# Dominator
-ULUS10236 = true
+# Burnout Dominator
+NPJH50304 = true # NODUMP
+ULES00703 = true
 ULES00750 = true
 ULJM05242 = true
-ULJM05371 = true
-NPJH50304 = true
-ULES00703 = true
+ULJM05371 = true # NODUMP
+ULUS10236 = true
+# Burnout Legends
+NPJH50305 = true # NODUMP
+ULES00125 = true
+ULJM05049 = true
+ULJM05228 = true
+ULKS46027 = true
+ULUS10025 = true
+ULUS10025 = true
+# Midnight Club - L.A. Remix
+NPJH50440 = true # NODUMP
+ULES01144 = true
+ULJM05904 = true
+ULJS00180 = true
+ULJS00267 = true # NODUMP
+ULUS10383 = true
+# Midnight Club 3 - DUB Edition (#10087)
+ULES00108 = true
+ULUS10021 = true
+# Shadow of Destiny (#9545)
+ULJM05512 = true # Shadow of Memories
+ULUS10459 = true
 
-[RequireDefaultCPUClock]
-# GOW : Ghost of Sparta
-UCUS98737 = true
-UCAS40323 = true
-NPHG00092 = true
-NPEG00044 = true
-NPJG00120 = true
-UCJS10114 = true
-UCES01401 = true
-
-[MGS2AcidHack]
-ULES00008 = true
-ULJM08001 = true
-ULJM05001 = true
-ULAS42007 = true
-ULUS10006 = true
-ULUS10077 = true
-
-[SonicRivalsHack]
-ULES00622 = true  # SR1
-ULUS10195 = true  # SR1
-ULUS10323 = true  # SR2
-ULES00940 = true  # SR2
-
+# Allow virtual framebuffer readbacks
+# https://github.com/hrydgard/ppsspp/pull/11531
 [BlockTransferAllowCreateFB]
-NPJH50686 = true  # Digimon Adventures (JP, and English patches...)
-ULJS00078 = true  # MotoGP
-ULUS10153 = true  # MotoGP
-UCES00373 = true  # MotoGP
+# Digimon Adventure
+NPJH50686 = true
+# Moto GP
+UCES00373 = true
+ULJS00078 = true
+ULUS10153 = true
 
-[YugiohSaveFix]
-# The cause of Yu-gi-oh series 's bad save (cannot save) are load "save status" and use cwcheat,
-# but the real cause still unknown. #7914
-
-# Yu-Gi-Oh! Duel Monsters GX: Tag Force
-ULJM05151 = true
-ULES00600 = true
-ULUS10136 = true
-
-# Yu-Gi-Oh! Duel Monsters GX: Tag Force 2
-ULUS10302 = true
-ULJM05260 = true
-ULES00925 = true
-ULES00926 = true
-
-# Yu-Gi-Oh! Duel Monsters GX: Tag Force 3
-ULES01183 = true
-ULJM05373 = true
-
-# Yu-Gi-Oh! 5D's Tag Force 4
-ULUS10481 = true
-ULJM05479 = true
-ULES01362 = true
-
-# Yu-Gi-Oh! 5D's Tag Force 5
-ULUS10555 = true
-ULJM05734 = true
-
-# Yu-Gi-Oh! 5D's Tag Force 6
-ULJM-05940 = true
-NPJH-50794 = true
-
-# Yu-Gi-Oh! 5D's Tag Force
-ULJM05940 = true
-
-# Yu-Gi-Oh! ARC-V Tag Force Special
-NPJH00142 = true
-
+# Increases RAM from 32 MiB to 64 MiB
+# https://github.com/hrydgard/ppsspp/pull/11686
 [HighMemoryLayout]
 # Melodie
 PETR00010 = true
-# Saints Row: Undercover
+# Saints Row - Undercover (#8522)
 ULUS12345 = true
-# Silent Hill Origins (Beta)
+# Silent Hill Origins
 UCUS12345 = true
 ULET00501 = true
-# The Elder Scrolls Travels: Oblivion
+# The Elder Scrolls Travels - Oblivion
 ABCD01234561 = true
+
+#################
+# GAME SPECIFIC #
+#################
+[MGAcidHack]
+# https://github.com/hrydgard/ppsspp/pull/10911
+# Metal Gear Ac!d
+ULAS42007 = true # NODUMP
+ULES00008 = true
+ULJM05001 = true
+ULJM08001 = true # NODUMP
+ULUS10006 = true
+# Metal Gear Ac!d 2
+# TODO: Does this affect MGA2?
+ULES00284 = true
+ULJM05047 = true
+ULKS46065 = true
+ULUS10077 = true
+
+[SonicRivalsHack]
+# https://github.com/hrydgard/ppsspp/pull/10911
+# Sonic Rivals
+ULES00622 = true
+ULUS10195 = true
+# Sonic Rivals 2
+# TODO: ULET00958
+ULES00940 = true
+ULUS10323 = true
+
+[YugiohSaveFix]
+# https://github.com/hrydgard/ppsspp/pull/11600
+# Yu-Gi-Oh! GX - Tag Force (#7914)
+ULES00600 = true
+ULJM05151 = true # Yu-Gi-Oh! Duel Monsters GX - Tag Force
+ULUS10136 = true
+# Yu-Gi-Oh! GX - Tag Force 2
+ULES00925 = true
+ULES00926 = true # NODUMP
+ULJM05260 = true # Yu-Gi-Oh! Duel Monsters GX - Tag Force 2
+ULUS10302 = true
+# Yu-Gi-Oh! GX - Tag Force 3
+ULES01183 = true
+ULJM05373 = true # Yu-Gi-Oh! Duel Monsters GX - Tag Force 3
+# Yu-Gi-Oh! 5D's - Tag Force 4
+ULES01362 = true
+ULJM05479 = true
+ULUS10481 = true
+# Yu-Gi-Oh! 5D's - Tag Force 5
+ULES01474 = true
+ULJM05734 = true
+ULUS10555 = true
+# Yu-Gi-Oh! 5D's - Tag Force 6
+NPJH50794 = true # NODUMP
+ULJM05940 = true
+# Yu-Gi-Oh! GX - ARC-V Tag Force Special
+NPJH00142 = true
+
+###########################
+# REQUIRE DEFAULT SETTING #
+###########################
+[RequireBlockTransfer]
+# Grand Knights History
+NPJH50518 = true # NODUMP
+ULJS00394 = true
+ULJS19068 = true # NODUMP
+# The Legend of Heroes - Trails in the Sky
+NPJH50373 = true # NODUMP
+ULES01556 = true
+ULJM05170 = true # Eiyuu Densetsu - Sora no Kiseki FC
+ULJM08033 = true # NODUMP
+ULUS10540 = true
+ULUS10578 = true # NODUMP
+# Ys Seven
+NPEH00065 = true
+NPJH50350 = true # NODUMP
+ULJM05475 = true
+ULJM08041 = true # NODUMP
+ULUS10551 = true
+
+[RequireBufferedRendering]
+# Chili Con Carnage
+ULES00629 = true
+ULUS10216 = true
+# Daxter
+NPEG00025 = true
+NPUG80329 = true
+UCES00044 = true
+UCKS45025 = true
+UCUS98618 = true
+UCUS98654 = true
+# Driver 76
+ULES00740 = true
+ULUS10235 = true
+# God of War - Chains of Olympus
+# TODO: UCUS98705 (Battle of Attica SE), UCUS98713 (Battle of Attica)
+NPEG00023 = true
+NPHG00027 = true
+NPHG00028 = true # NODUMP
+NPJG00120 = true # NODUMP
+NPJH50170 = true # God of War - Rakujitsu no Hisoukyoku
+NPUG80325 = true
+UCAS40198 = true
+UCED00970 = true
+UCES00842 = true
+UCET00844 = true
+UCKS45084 = true
+UCUS98653 = true
+UCUS98719 = true
+ULJM05348 = true # God of War - Rakujitsu no Hisoukyoku
+# Grand Knights History
+NPJH50518 = true # NODUMP
+ULJS00394 = true
+ULJS19068 = true # NODUMP
+# Grand Theft Auto - Liberty City Stories
+NPJH50825 = true # NODUMP
+ULES00151 = true
+ULES00182 = true
+ULJM05255 = true
+ULJM05359 = true # NODUMP
+ULJM05885 = true
+ULUS10041 = true
+# Grand Theft Auto - Vice City Stories
+NPJH50827 = true # NODUMP
+ULES00502 = true
+ULES00503 = true
+ULJM05297 = true
+ULJM05395 = true # NODUMP
+ULJM05884 = true
+ULUS10160 = true
+# Metal Gear Solid - Peace Walker
+# TODO: NPJH90063
+NPJH50045 = true
+ULES01372 = true
+ULJM05630 = true # NODUMP
+ULJM08038 = true # NODUMP
+ULUS10509 = true
+# Midnight Club - L.A. Remix
+NPJH50440 = true # NODUMP
+ULES01144 = true
+ULJM05904 = true
+ULJS00180 = true
+ULJS00267 = true # NODUMP
+ULUS10383 = true
+# Midnight Club 3 - DUB Edition
+ULES00108 = true
+ULUS10021 = true
+# Star Ocean - Second Evolution
+UCAS40203 = true # NODUMP
+ULES01187 = true
+ULJM05325 = true
+ULJM05591 = true # NODUMP
+ULUS10375 = true
+# Tactics Ogre - Let Us Cling Together
+NPJH50348 = true # NODUMP
+UCKS45164 = true # NODUMP
+ULES01500 = true
+ULJM05753 = true # Tactics Ogre - Unmei no Wa
+ULJM06009 = true # NODUMP
+ULUS10565 = true
+# The Legend of Heroes - Trails in the Sky
+NPJH50373 = true # NODUMP
+ULES01556 = true
+ULJM05170 = true # Eiyuu Densetsu - Sora no Kiseki FC
+ULJM08033 = true # NODUMP
+ULUS10540 = true
+ULUS10578 = true # NODUMP
+# Ys Seven
+NPEH00065 = true
+NPJH50350 = true # NODUMP
+ULJM05475 = true
+ULJM08041 = true # NODUMP
+ULUS10551 = true
+
+[RequireDefaultCPUClock]
+# God of War - Ghost of Sparta [#7411]
+NPEG00044 = true
+NPEG00045 = true
+NPHG00092 = true
+NPJG00120 = true # NODUMP
+NPUG80508 = true
+UCAS40323 = true # NODUMP
+UCES01401 = true
+UCES01473 = true
+UCJS10114 = true # God of War - Koutan no Kokuin
+UCUS98737 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -384,3 +384,15 @@ ULJM05940 = true
  
 # Yu-Gi-Oh! ARC-V Tag Force Special
 NPJH00142 = true
+
+[HighMemoryLayout]
+# Melodie
+PETR00010 = true
+# Saints Row: Undercover
+ULUS12345 = true
+# Silent Hill Origins (Beta)
+UCUS12345 = true
+ULET00501 = true
+# The Elder Scrolls Travels: Oblivion
+ABCD01234561 = true
+

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -357,7 +357,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 
 void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps) {
 	// Optimizes renderpasses, then sequences them.
-	// Planned optimizations: 
+	// Planned optimizations:
 	//  * Create copies of render target that are rendered to multiple times and textured from in sequence, and push those render passes
 	//    as early as possible in the frame (Wipeout billboards).
 
@@ -409,9 +409,9 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 
 	// Queue hacks.
 	if (hacksEnabled_) {
-		if (hacksEnabled_ & QUEUE_HACK_MGS2_ACID) {
+		if (hacksEnabled_ & QUEUE_HACK_MGACID) {
 			// Massive speedup.
-			ApplyMGSHack(steps);
+			ApplyMGAHack(steps);
 		}
 		if (hacksEnabled_ & QUEUE_HACK_SONIC) {
 			ApplySonicHack(steps);
@@ -443,7 +443,7 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 	}
 }
 
-void VulkanQueueRunner::ApplyMGSHack(std::vector<VKRStep *> &steps) {
+void VulkanQueueRunner::ApplyMGAHack(std::vector<VKRStep *> &steps) {
 	// We want to turn a sequence of copy,render(1),copy,render(1),copy,render(1) to copy,copy,copy,render(n).
 
 	for (int i = 0; i < (int)steps.size() - 3; i++) {

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -11,7 +11,7 @@ class VKRFramebuffer;
 struct VKRImage;
 
 enum {
-	QUEUE_HACK_MGS2_ACID = 1,
+	QUEUE_HACK_MGACID = 1,
 	QUEUE_HACK_SONIC = 2,
 };
 
@@ -238,7 +238,7 @@ private:
 
 	void ResizeReadbackBuffer(VkDeviceSize requiredSize);
 
-	void ApplyMGSHack(std::vector<VKRStep *> &steps);
+	void ApplyMGAHack(std::vector<VKRStep *> &steps);
 	void ApplySonicHack(std::vector<VKRStep *> &steps);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);


### PR DESCRIPTION
Moved non-remastered games from `HDRemaster.cpp` to `compat.ini` (where they belong imo) and added the Silent Hill Origins betas. I opted to use flags since it was easier to implement but I would suggest to specify the memorySize in the ini instead so it's more future proof.

It's not really the scope of this PR but I tried to clean up the `compat.ini` a bit and ended up spending too much time at it  ¯\_(ツ)_/¯
I've tried to find the original pull request/issue for each section/game but it may not be all correct. I'm going to try to fill in the gaps at some point.
About that `NODUMP` comment in the ini: I've checked No-Intros database for all the games listed in there and added some missing Game IDs. Game IDs which I could not find have a `NODUMP` comment now, which are either not dumped yet (like the PSN games starting with `N`) or don't even exist (I suspect most of them). For example [Gundam Battle Chronicle (Korean)](https://renascene.com/info/umd/3006) has the Box ID `ULKS-46158` but the game is identical to the japanese version `ULJS-00122`. I left them in the ini just in case but I would remove them at some point since No-Intro has almost every dumped game anyway.

---
How is the compatibility when running games with 64 MiB RAM these days? I was following the [initial PoC](https://github.com/hrydgard/ppsspp/issues/1494) when it still crashed with higher memory; has this been resolved since? Can we make 64 MiB default when **PSP-2000/3000** is selected in **PSP model**? I have `Force High Memory Layout` enabled on my PSP-2000 Pro-C and I've never encountered any bugs. And I don't think [this](https://github.com/hrydgard/ppsspp/pull/2381#discussion_r4814085) is really relevant anymore.

Also a little suggestion: the HD remasters have a texture size of [1024px](http://www.psdevwiki.com/ps3/PSP_Emulation#PSP_HD_Remasters) which corresponds to a resolution of 1024x580 (which is also the resolution they run on the PS3/PSV PSP emulator).
Should we run them at that resolution by default since running them at native PSP resolution pretty much negates the effect of an HD remaster anyway? I don't want to unnecessarily complicate things so I propose that increasing the resolution (`n`xPSP) should in that case yield `width = 1024 * ceil(n / 2)` and `height = 580 * ceil(n / 2)`.