### PR TITLE
GLES: Specify glsl version precisely in depal, fix some shader errors

### DIFF
--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -51,7 +51,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 			WRITE(p, "precision mediump float;\n");
 			WRITE(p, "precision highp int;\n");
 		} else {
-			WRITE(p, "#version 330\n");
+			WRITE(p, "#version %d\n", gl_extensions.GLSLVersion());
 		}
 		WRITE(p, "in vec2 v_texcoord0;\n");
 		WRITE(p, "out vec4 fragColor0;\n");

--- a/GPU/D3D11/DepalettizeShaderD3D11.cpp
+++ b/GPU/D3D11/DepalettizeShaderD3D11.cpp
@@ -47,7 +47,7 @@ VS_OUT main(VS_IN input) {
   output.Texcoord = input.a_texcoord0;
   output.Position = float4(input.a_position, 1.0);
   return output;
-};
+}
 )";
 
 static const D3D11_INPUT_ELEMENT_DESC g_DepalVertexElements[] = {

--- a/GPU/Directx9/DepalettizeShaderDX9.cpp
+++ b/GPU/Directx9/DepalettizeShaderDX9.cpp
@@ -50,7 +50,7 @@ VS_OUT main(VS_IN input) {
   output.Texcoord = input.a_texcoord0;
   output.Position = float4(input.a_position, 1.0);
   return output;
-};
+}
 )";
 
 DepalShaderCacheDX9::DepalShaderCacheDX9(Draw::DrawContext *draw) : vertexShader_(nullptr) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -61,7 +61,7 @@ VS_OUT main( VS_IN In ) {
 	Out.ProjPos = In.ObjPos;
 	Out.Uv = In.Uv;
 	return Out;
-};
+}
 )";
 
 static const char *pscode = R"(
@@ -72,7 +72,7 @@ struct PS_IN {
 float4 main( PS_IN In ) : COLOR {
 	float4 c =  tex2D(s, In.Uv);
 	return c;
-};
+}
 )";
 
 static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {

--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -35,7 +35,7 @@ varying vec2 v_texcoord0;
 void main() {
   v_texcoord0 = a_texcoord0;
   gl_Position = a_position;
-};
+}
 )";
 
 static const char *depalVShader300 = R"(
@@ -48,7 +48,7 @@ out vec2 v_texcoord0;
 void main() {
   v_texcoord0 = a_texcoord0;
   gl_Position = a_position;
-};
+}
 )";
 
 DepalShaderCacheGLES::DepalShaderCacheGLES(Draw::DrawContext *draw) {

--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -75,8 +75,9 @@ bool DepalShaderCacheGLES::CreateVertexShader() {
 	std::string prelude;
 	if (gl_extensions.IsGLES) {
 		prelude = useGL3_ ? "#version 300 es\n" : "#version 100\n";
-	} else if (useGL3_) {
-		prelude = "#version 330\n";
+	} else {
+		// We need to add a corresponding #version.  Apple drivers fail without an exact match.
+		prelude = StringFromFormat("#version %d\n", gl_extensions.GLSLVersion());
 	}
 	vertexShader_ = render_->CreateShader(GL_VERTEX_SHADER, prelude + src, "depal");
 	return true;

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -27,7 +27,7 @@
 
 static const char *depth_dl_fs = R"(
 #ifdef GL_ES
-#if GL_FRAGMENT_PRECISION_HIGH
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else
 precision mediump float;

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -27,7 +27,7 @@
 
 static const char *stencil_fs = R"(
 #ifdef GL_ES
-#if GL_FRAGMENT_PRECISION_HIGH
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else
 precision mediump float;  // just hope it's enough..

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -579,7 +579,7 @@ std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage) {
 	std::string temp;
 	std::string version = "";
 	if (!gl_extensions.IsGLES && gl_extensions.IsCoreContext) {
-		// We need to add a corresponding #version.  Apple drives fail without an exact match.
+		// We need to add a corresponding #version.  Apple drivers fail without an exact match.
 		version = StringFromFormat("#version %d\n", gl_extensions.GLSLVersion());
 	}
 	if (stage == GL_FRAGMENT_SHADER) {


### PR DESCRIPTION
Should prevent more of #11588 on vertex shaders (seen in reporting), and may help Apple devices some too.

-[Unknown]