### PR TITLE
http: Report errors reading discs

### DIFF
--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -23,24 +23,20 @@
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
 
-class CachingFileLoader : public FileLoader {
+class CachingFileLoader : public ProxiedFileLoader {
 public:
 	CachingFileLoader(FileLoader *backend);
 	~CachingFileLoader() override;
 
-	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string Path() const override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
-
-	void Cancel() override;
 
 private:
 	void Prepare();
@@ -61,7 +57,6 @@ private:
 	};
 
 	s64 filesize_ = 0;
-	FileLoader *backend_;
 	int exists_ = -1;
 	int isDirectory_ = -1;
 	u64 generation_;

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -27,24 +27,19 @@
 
 class DiskCachingFileLoaderCache;
 
-class DiskCachingFileLoader : public FileLoader {
+class DiskCachingFileLoader : public ProxiedFileLoader {
 public:
 	DiskCachingFileLoader(FileLoader *backend);
 	~DiskCachingFileLoader() override;
 
-	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
-	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string Path() const override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
-
-	void Cancel() override;
 
 	static std::vector<std::string> GetCachedPathsInUse();
 
@@ -55,7 +50,6 @@ private:
 
 	std::once_flag preparedFlag_;
 	s64 filesize_ = 0;
-	FileLoader *backend_;
 	DiskCachingFileLoaderCache *cache_ = nullptr;
 
 	// We don't support concurrent disk cache access (we use memory cached indexes.)

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -29,6 +29,7 @@ void HTTPFileLoader::Prepare() {
 	std::call_once(preparedFlag_, [this](){
 		if (!client_.Resolve(url_.Host().c_str(), url_.Port())) {
 			ERROR_LOG(LOADER, "HTTP request failed, unable to resolve: %s port %d", url_.Host().c_str(), url_.Port());
+			latestError_ = "Could not connect (name not resolved)";
 			return;
 		}
 
@@ -36,12 +37,14 @@ void HTTPFileLoader::Prepare() {
 		Connect();
 		if (!connected_) {
 			ERROR_LOG(LOADER, "HTTP request failed, failed to connect: %s port %d", url_.Host().c_str(), url_.Port());
+			latestError_ = "Could not connect (refused to connect)";
 			return;
 		}
 
 		int err = client_.SendRequest("HEAD", url_.Resource().c_str());
 		if (err < 0) {
 			ERROR_LOG(LOADER, "HTTP request failed, failed to send request: %s port %d", url_.Host().c_str(), url_.Port());
+			latestError_ = "Could not connect (could not request data)";
 			Disconnect();
 			return;
 		}
@@ -52,6 +55,7 @@ void HTTPFileLoader::Prepare() {
 		if (code != 200) {
 			// Leave size at 0, invalid.
 			ERROR_LOG(LOADER, "HTTP request failed, got %03d for %s", code, filename_.c_str());
+			latestError_ = "Could not connect (invalid response)";
 			Disconnect();
 			return;
 		}
@@ -141,6 +145,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags f
 
 	int err = client_.SendRequest("GET", url_.Resource().c_str(), requestHeaders, nullptr);
 	if (err < 0) {
+		latestError_ = "Invalid response reading data";
 		Disconnect();
 		return 0;
 	}
@@ -150,6 +155,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags f
 	int code = client_.ReadResponseHeaders(&readbuf, responseHeaders);
 	if (code != 206) {
 		ERROR_LOG(LOADER, "HTTP server did not respond with range, received code=%03d", code);
+		latestError_ = "Invalid response reading data";
 		Disconnect();
 		return 0;
 	}
@@ -188,6 +194,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags f
 
 	if (!supportedResponse) {
 		ERROR_LOG(LOADER, "HTTP server did not respond with the range we wanted.");
+		latestError_ = "Invalid response reading data";
 		return 0;
 	}
 

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -28,17 +28,20 @@ HTTPFileLoader::HTTPFileLoader(const std::string &filename)
 void HTTPFileLoader::Prepare() {
 	std::call_once(preparedFlag_, [this](){
 		if (!client_.Resolve(url_.Host().c_str(), url_.Port())) {
-			// TODO: Should probably set some flag?
+			ERROR_LOG(LOADER, "HTTP request failed, unable to resolve: %s port %d", url_.Host().c_str(), url_.Port());
 			return;
 		}
 
+		client_.SetDataTimeout(20.0);
 		Connect();
 		if (!connected_) {
+			ERROR_LOG(LOADER, "HTTP request failed, failed to connect: %s port %d", url_.Host().c_str(), url_.Port());
 			return;
 		}
 
 		int err = client_.SendRequest("HEAD", url_.Resource().c_str());
 		if (err < 0) {
+			ERROR_LOG(LOADER, "HTTP request failed, failed to send request: %s port %d", url_.Host().c_str(), url_.Port());
 			Disconnect();
 			return;
 		}

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -48,6 +48,10 @@ public:
 		cancelConnect_ = true;
 	}
 
+	std::string LatestError() const override {
+		return latestError_;
+	}
+
 private:
 	void Prepare();
 
@@ -67,6 +71,7 @@ private:
 	std::string filename_;
 	bool connected_ = false;
 	bool cancelConnect_ = false;
+	const char *latestError_ = "";
 
 	std::once_flag preparedFlag_;
 	std::mutex readAtMutex_;

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -28,7 +28,7 @@
 
 // Takes ownership of backend.
 RamCachingFileLoader::RamCachingFileLoader(FileLoader *backend)
-	: backend_(backend) {
+	: ProxiedFileLoader(backend) {
 	filesize_ = backend->FileSize();
 	if (filesize_ > 0) {
 		InitCache();
@@ -39,37 +39,31 @@ RamCachingFileLoader::~RamCachingFileLoader() {
 	if (filesize_ > 0) {
 		ShutdownCache();
 	}
-	// Takes ownership.
-	delete backend_;
 }
 
 bool RamCachingFileLoader::Exists() {
 	if (exists_ == -1) {
-		exists_ = backend_->Exists() ? 1 : 0;
+		exists_ = ProxiedFileLoader::Exists() ? 1 : 0;
 	}
 	return exists_ == 1;
 }
 
 bool RamCachingFileLoader::ExistsFast() {
 	if (exists_ == -1) {
-		return backend_->ExistsFast();
+		return ProxiedFileLoader::ExistsFast();
 	}
 	return exists_ == 1;
 }
 
 bool RamCachingFileLoader::IsDirectory() {
 	if (isDirectory_ == -1) {
-		isDirectory_ = backend_->IsDirectory() ? 1 : 0;
+		isDirectory_ = ProxiedFileLoader::IsDirectory() ? 1 : 0;
 	}
 	return isDirectory_ == 1;
 }
 
 s64 RamCachingFileLoader::FileSize() {
 	return filesize_;
-}
-
-std::string RamCachingFileLoader::Path() const {
-	return backend_->Path();
 }
 
 size_t RamCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags) {
@@ -129,7 +123,7 @@ void RamCachingFileLoader::Cancel() {
 		aheadCancel_ = true;
 	}
 
-	backend_->Cancel();
+	ProxiedFileLoader::Cancel();
 }
 
 size_t RamCachingFileLoader::ReadFromCache(s64 pos, size_t bytes, void *data) {
@@ -269,8 +263,4 @@ u32 RamCachingFileLoader::NextAheadBlock() {
 	}
 
 	return 0xFFFFFFFF;
-}
-
-bool RamCachingFileLoader::IsRemote() {
-	return backend_->IsRemote();
 }

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -23,17 +23,15 @@
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
 
-class RamCachingFileLoader : public FileLoader {
+class RamCachingFileLoader : public ProxiedFileLoader {
 public:
 	RamCachingFileLoader(FileLoader *backend);
 	~RamCachingFileLoader() override;
 
-	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string Path() const override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
@@ -59,7 +57,6 @@ private:
 	};
 
 	s64 filesize_ = 0;
-	FileLoader *backend_;
 	u8 *cache_ = nullptr;
 	int exists_ = -1;
 	int isDirectory_ = -1;

--- a/Core/FileLoaders/RetryingFileLoader.cpp
+++ b/Core/FileLoaders/RetryingFileLoader.cpp
@@ -19,45 +19,36 @@
 
 // Takes ownership of backend.
 RetryingFileLoader::RetryingFileLoader(FileLoader *backend)
-	: backend_(backend) {
-}
-
-RetryingFileLoader::~RetryingFileLoader() {
-	// Takes ownership.
-	delete backend_;
+	: ProxiedFileLoader(backend) {
 }
 
 bool RetryingFileLoader::Exists() {
-	if (!backend_->Exists()) {
+	if (!ProxiedFileLoader::Exists()) {
 		// Retry once, immediately.
-		return backend_->Exists();
+		return ProxiedFileLoader::Exists();
 	}
 	return true;
 }
 
 bool RetryingFileLoader::ExistsFast() {
-	if (!backend_->ExistsFast()) {
+	if (!ProxiedFileLoader::ExistsFast()) {
 		// Retry once, immediately.
-		return backend_->ExistsFast();
+		return ProxiedFileLoader::ExistsFast();
 	}
 	return true;
 }
 
 bool RetryingFileLoader::IsDirectory() {
 	// Can't tell if it's an error either way.
-	return backend_->IsDirectory();
+	return ProxiedFileLoader::IsDirectory();
 }
 
 s64 RetryingFileLoader::FileSize() {
-	s64 filesize = backend_->FileSize();
+	s64 filesize = ProxiedFileLoader::FileSize();
 	if (filesize == 0) {
-		return backend_->FileSize();
+		return ProxiedFileLoader::FileSize();
 	}
 	return filesize;
-}
-
-std::string RetryingFileLoader::Path() const {
-	return backend_->Path();
 }
 
 size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags) {
@@ -71,12 +62,4 @@ size_t RetryingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Fla
 	}
 
 	return readSize;
-}
-
-bool RetryingFileLoader::IsRemote() {
-	return backend_->IsRemote();
-}
-
-void RetryingFileLoader::Cancel() {
-	backend_->Cancel();
 }

--- a/Core/FileLoaders/RetryingFileLoader.h
+++ b/Core/FileLoaders/RetryingFileLoader.h
@@ -20,29 +20,22 @@
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
 
-class RetryingFileLoader : public FileLoader {
+class RetryingFileLoader : public ProxiedFileLoader {
 public:
 	RetryingFileLoader(FileLoader *backend);
-	~RetryingFileLoader() override;
 
-	bool IsRemote() override;
 	bool Exists() override;
 	bool ExistsFast() override;
 	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string Path() const override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
-	void Cancel() override;
-
 private:
 	enum {
 		MAX_RETRIES = 3,
 	};
-
-	FileLoader *backend_;
 };

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -294,7 +294,9 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 
 	case IdentifiedFileType::ERROR_IDENTIFYING:
 		ERROR_LOG(LOADER, "Could not read file");
-		*error_string = "Error reading file";
+		*error_string = fileLoader ? fileLoader->LatestError() : "";
+		if (error_string->empty())
+			*error_string = "Error reading file";
 		break;
 
 	case IdentifiedFileType::ARCHIVE_RAR:

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -93,6 +93,10 @@ public:
 	// Cancel any operations that might block, if possible.
 	virtual void Cancel() {
 	}
+
+	virtual std::string LatestError() const {
+		return "";
+	}
 };
 
 class ProxiedFileLoader : public FileLoader {
@@ -124,6 +128,9 @@ public:
 	}
 	void Cancel() override {
 		backend_->Cancel();
+	}
+	std::string LatestError() const override {
+		return backend_->LatestError();
 	}
 
 protected:

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -95,6 +95,41 @@ public:
 	}
 };
 
+class ProxiedFileLoader : public FileLoader {
+public:
+	ProxiedFileLoader(FileLoader *backend) : backend_(backend) {
+	}
+	~ProxiedFileLoader() override {
+		// Takes ownership.
+		delete backend_;
+	}
+
+	bool IsRemote() override {
+		return backend_->IsRemote();
+	}
+	bool Exists() override {
+		return backend_->Exists();
+	}
+	bool ExistsFast() override {
+		return backend_->ExistsFast();
+	}
+	bool IsDirectory() override {
+		return backend_->IsDirectory();
+	}
+	s64 FileSize() override {
+		return backend_->FileSize();
+	}
+	std::string Path() const override {
+		return backend_->Path();
+	}
+	void Cancel() override {
+		backend_->Cancel();
+	}
+
+protected:
+	FileLoader *backend_;
+};
+
 inline u32 operator & (const FileLoader::Flags &a, const FileLoader::Flags &b) {
 	return (u32)a & (u32)b;
 }

--- a/ext/native/base/buffer.h
+++ b/ext/native/base/buffer.h
@@ -59,12 +59,12 @@ class Buffer {
 
   // Simple I/O.
 
-  // Writes the entire buffer to the file descriptor. Also resets the
-  // size to zero. On failure, data remains in buffer and nothing is
-  // written.
+	// Writes the entire buffer to the file descriptor. Also resets the
+	// size to zero. On failure, data remains in buffer and nothing is
+	// written.
 	bool Flush(int fd);
 	bool FlushToFile(const char *filename);
-  bool FlushSocket(uintptr_t sock);  // Windows portability
+	bool FlushSocket(uintptr_t sock, double timeout = -1.0);  // Windows portability
 
   bool ReadAll(int fd, int hintSize = 0);
   bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);

--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -75,8 +75,14 @@ public:
 	// If your response contains a response, you must read it.
 	int ReadResponseEntity(Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
 
+	void SetDataTimeout(double t) {
+		dataTimeout_ = t;
+	}
+
+protected:
 	const char *userAgent_;
 	const char *httpVersion_;
+	double dataTimeout_ = -1.0;
 };
 
 // Not particularly efficient, but hey - it's a background download, that's pretty cool :P


### PR DESCRIPTION
This also implements better error handling and some cleanup:

 * All FileLoaders that use a backend_ now are ProxiedFileLoaders.  This cuts down on duplicated code.
 * We no longer wait indefinitely for an HTTP response when reading remote discs, and instead timeout.
 * Errors loading games from remote discs are now reported more clearly, instead of always "error reading file".

May help troubleshoot issues here: http://forums.ppsspp.org/showthread.php?tid=19752&pid=133054#pid133054

-[Unknown]