### PR TITLE
Try to support Qt keyboard input directly. Fixes #11653

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -357,12 +357,16 @@ bool MainUI::event(QEvent *e)
     case QEvent::KeyPress:
 				{
 					auto qtKeycode = ((QKeyEvent*)e)->key();
-					int nativeKeycode = KeyMapRawQttoNative.find(qtKeycode)->second;
-					NativeKey(KeyInput(DEVICE_ID_KEYBOARD, nativeKeycode, KEY_DOWN));
+					auto iter = KeyMapRawQttoNative.find(qtKeycode);
+					int nativeKeycode = 0;
+					if (iter != KeyMapRawQttoNative.end()) {
+						nativeKeycode = iter->second;
+						NativeKey(KeyInput(DEVICE_ID_KEYBOARD, nativeKeycode, KEY_DOWN));
+					}
+
 					// Also get the unicode value.
 					QString text = ((QKeyEvent*)e)->text();
 					std::string str = text.toStdString();
-
 					// Now, we don't want CHAR events for non-printable characters. Not quite sure how we'll best
 					// do that, but here's one attempt....
 					switch (nativeKeycode) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -803,8 +803,6 @@ void GameSettingsScreen::CreateViews() {
 	// so until then, this is Windows/Desktop only.
 #if !defined(MOBILE_DEVICE)  // TODO: Add all platforms where KEY_CHAR support is added
 	systemSettings->Add(new PopupTextInputChoice(&g_Config.sNickName, sy->T("Change Nickname"), "", 32, screenManager()));
-// #elif defined(USING_QT_UI)
-// systemSettings->Add(new Choice(sy->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 #elif defined(__ANDROID__)
 	systemSettings->Add(new ChoiceWithValueDisplay(&g_Config.sNickName, sy->T("Change Nickname"), (const char *)nullptr))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 #endif

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -643,7 +643,7 @@ void GameSettingsScreen::CreateViews() {
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new CheckBox(&g_Config.bDiscordPresence, n->T("Send Discord Presence information")));
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)
+#if !defined(MOBILE_DEVICE)
 	networkingSettings->Add(new PopupTextInputChoice(&g_Config.proAdhocServer, n->T("Change proAdhocServer Address"), "", 255, screenManager()));
 #elif defined(__ANDROID__)
 	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.proAdhocServer, n->T("Change proAdhocServer Address"), (const char *)nullptr))->OnClick.Handle(this, &GameSettingsScreen::OnChangeproAdhocServerAddress);
@@ -801,13 +801,14 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, sy->T("PSP Model"), models, 0, ARRAY_SIZE(models), sy->GetName(), screenManager()))->SetEnabled(!PSP_IsInited());
 	// TODO: Come up with a way to display a keyboard for mobile users,
 	// so until then, this is Windows/Desktop only.
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
+#if !defined(MOBILE_DEVICE)  // TODO: Add all platforms where KEY_CHAR support is added
 	systemSettings->Add(new PopupTextInputChoice(&g_Config.sNickName, sy->T("Change Nickname"), "", 32, screenManager()));
-#elif defined(USING_QT_UI)
-	systemSettings->Add(new Choice(sy->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
+// #elif defined(USING_QT_UI)
+// systemSettings->Add(new Choice(sy->T("Change Nickname")))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 #elif defined(__ANDROID__)
 	systemSettings->Add(new ChoiceWithValueDisplay(&g_Config.sNickName, sy->T("Change Nickname"), (const char *)nullptr))->OnClick.Handle(this, &GameSettingsScreen::OnChangeNickname);
 #endif
+
 #if defined(_WIN32) || (defined(USING_QT_UI) && !defined(MOBILE_DEVICE))
 	// Screenshot functionality is not yet available on non-Windows/non-Qt
 	systemSettings->Add(new CheckBox(&g_Config.bScreenshotsAsPNG, sy->T("Screenshots as PNG")));

--- a/ext/native/base/NKCodeFromQt.h
+++ b/ext/native/base/NKCodeFromQt.h
@@ -98,5 +98,6 @@ static const std::map<int, int> KeyMapRawQttoNative = InitConstMap<int, int>
 	(Qt::Key_Up, NKCODE_DPAD_UP)
 	(Qt::Key_Right, NKCODE_DPAD_RIGHT)
 	(Qt::Key_Down, NKCODE_DPAD_DOWN)
-	(Qt::Key_Back, NKCODE_BACK);
+	(Qt::Key_Back, NKCODE_BACK)
+	(Qt::Key_Backspace, NKCODE_DEL);
 


### PR DESCRIPTION
Fixes #11653 by avoiding the native dialog which can't be spawned from the main thread.