### PR TITLE
Remove usage of deprecated function readdir_r

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -661,13 +661,13 @@ bool DeleteDirRecursively(const std::string &directory)
 	{
 		const std::string virtualName = ConvertWStringToUTF8(ffd.cFileName);
 #else
-	struct dirent dirent, *result = NULL;
+	struct dirent *result = NULL;
 	DIR *dirp = opendir(directory.c_str());
 	if (!dirp)
 		return false;
 
 	// non windows loop
-	while (!readdir_r(dirp, &dirent, &result) && result)
+	while ((result = readdir(dirp)))
 	{
 		const std::string virtualName = result->d_name;
 #endif
@@ -723,13 +723,11 @@ void CopyDir(const std::string &source_path, const std::string &dest_path)
 	if (!File::Exists(source_path)) return;
 	if (!File::Exists(dest_path)) File::CreateFullPath(dest_path);
 
-	struct dirent_large { struct dirent entry; char padding[FILENAME_MAX+1]; };
-	struct dirent_large diren;
 	struct dirent *result = NULL;
 	DIR *dirp = opendir(source_path.c_str());
 	if (!dirp) return;
 
-	while (!readdir_r(dirp, (dirent*) &diren, &result) && result)
+	while ((result = readdir(dirp)))
 	{
 		const std::string virtualName(result->d_name);
 		// check for "." and ".."

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -66,9 +66,6 @@ static bool FixFilenameCase(const std::string &path, std::string &filename)
 	}
 
 	//TODO: lookup filename in cache for "path"
-
-	struct dirent_large { struct dirent entry; char padding[FILENAME_MAX+1]; } diren;
-	struct dirent_large;
 	struct dirent *result = NULL;
 
 	DIR *dirp = opendir(path.c_str());
@@ -77,7 +74,7 @@ static bool FixFilenameCase(const std::string &path, std::string &filename)
 
 	bool retValue = false;
 
-	while (!readdir_r(dirp, (dirent*) &diren, &result) && result)
+	while ((result = readdir(dirp)))
 	{
 		if (strlen(result->d_name) != filenameSize)
 			continue;

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -238,8 +238,6 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 	{
 		const std::string virtualName = ConvertWStringToUTF8(ffd.cFileName);
 #else
-	struct dirent_large { struct dirent entry; char padding[FILENAME_MAX+1]; };
-	struct dirent_large diren;
 	struct dirent *result = NULL;
 
 	//std::string directoryWithSlash = directory;
@@ -250,7 +248,7 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 	if (!dirp)
 		return 0;
 	// non windows loop
-	while (!readdir_r(dirp, (dirent*) &diren, &result) && result)
+	while ((result = readdir(dirp)))
 	{
 		const std::string virtualName(result->d_name);
 #endif


### PR DESCRIPTION
And an ugly Blackberry hack (diren_large).

Fixes #11579 .

(We really have too many copies of the logic of looping through a directory...)