### PR TITLE
To avoid strange images in Android gallery, pre-create TEXTURES with .nomedia

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -344,11 +344,15 @@ void CreateDirectoriesAndroid() {
 	File::CreateFullPath(GetSysDirectory(DIRECTORY_SAVESTATE));
 	File::CreateFullPath(GetSysDirectory(DIRECTORY_GAME));
 	File::CreateFullPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	File::CreateFullPath(GetSysDirectory(DIRECTORY_TEXTURES));
 
-	// Avoid media scanners in PPSSPP_STATE and SAVEDATA directories
+	// Avoid media scanners in PPSSPP_STATE and SAVEDATA directories,
+	// and in the root PSP directory as well.
+	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/.nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVESTATE) + ".nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVEDATA) + ".nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SYSTEM) + ".nomedia");
+	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_TEXTURES) + ".nomedia");
 }
 
 static void CheckFailedGPUBackends() {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -348,7 +348,6 @@ void CreateDirectoriesAndroid() {
 
 	// Avoid media scanners in PPSSPP_STATE and SAVEDATA directories,
 	// and in the root PSP directory as well.
-	File::CreateEmptyFile(g_Config.memStickDirectory + "PSP/.nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVESTATE) + ".nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SAVEDATA) + ".nomedia");
 	File::CreateEmptyFile(GetSysDirectory(DIRECTORY_SYSTEM) + ".nomedia");


### PR DESCRIPTION
Also add .nomedia to the root PSP directory.

Issue reported by Solaris on Discord.