### PR TITLE
Vulkan: Improve extension loading, implement dedicated_allocation correctly

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -60,7 +60,7 @@ static const char *validationLayers[] = {
 std::string VulkanVendorString(uint32_t vendorId) {
 	switch (vendorId) {
 	case VULKAN_VENDOR_INTEL: return "Intel";
-	case VULKAN_VENDOR_NVIDIA: return "nVidia";
+	case VULKAN_VENDOR_NVIDIA: return "NVIDIA";
 	case VULKAN_VENDOR_AMD: return "AMD";
 	case VULKAN_VENDOR_ARM: return "ARM";
 	case VULKAN_VENDOR_QUALCOMM: return "Qualcomm";

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -623,6 +623,8 @@ VkResult VulkanContext::CreateDevice() {
 		extensionsLookup_.KHR_dedicated_allocation = EnableDeviceExtension(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
 	}
 	extensionsLookup_.EXT_external_memory_host = EnableDeviceExtension(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+	extensionsLookup_.KHR_depth_stencil_resolve = EnableDeviceExtension(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
+	extensionsLookup_.EXT_shader_stencil_export = EnableDeviceExtension(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 
 	VkDeviceCreateInfo device_info{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
 	device_info.queueCreateInfoCount = 1;

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -77,6 +77,8 @@ const char *PresentModeString(VkPresentModeKHR presentMode) {
 	case VK_PRESENT_MODE_MAILBOX_KHR: return "MAILBOX";
 	case VK_PRESENT_MODE_FIFO_KHR: return "FIFO";
 	case VK_PRESENT_MODE_FIFO_RELAXED_KHR: return "FIFO_RELAXED";
+	case VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR: return "SHARED_DEMAND_REFRESH_KHR";
+	case VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR: return "SHARED_CONTINUOUS_REFRESH_KHR";
 	default: return "UNKNOWN";
 	}
 }
@@ -548,7 +550,6 @@ void VulkanContext::ChooseDevice(int physical_device) {
 	}
 
 	// Optional features
-
 	if (extensionsLookup_.KHR_get_physical_device_properties2) {
 		VkPhysicalDeviceFeatures2 features2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
 		vkGetPhysicalDeviceFeatures2KHR(physical_devices_[physical_device_], &features2);
@@ -568,9 +569,6 @@ void VulkanContext::ChooseDevice(int physical_device) {
 	}
 	if (deviceFeatures_.available.wideLines) {
 		deviceFeatures_.enabled.wideLines = true;
-	}
-	if (deviceFeatures_.available.geometryShader) {
-		deviceFeatures_.enabled.geometryShader = true;
 	}
 	if (deviceFeatures_.available.logicOp) {
 		deviceFeatures_.enabled.logicOp = true;
@@ -674,9 +672,7 @@ VkResult VulkanContext::InitDebugMsgCallback(PFN_vkDebugReportCallbackEXT dbgFun
 	}
 	ILOG("Registering debug report callback");
 
-	VkDebugReportCallbackCreateInfoEXT cb = {};
-	cb.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
-	cb.pNext = nullptr;
+	VkDebugReportCallbackCreateInfoEXT cb{VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT};
 	cb.flags = bits;
 	cb.pfnCallback = dbgFunc;
 	cb.pUserData = userdata;
@@ -769,7 +765,7 @@ VkResult VulkanContext::ReinitSurface() {
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 	case WINDOWSYSTEM_XLIB:
 	{
-		VkXlibSurfaceCreateInfoKHR xlib = { VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR };
+		VkXlibSurfaceCreateInfoKHR xlib{ VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR };
 		xlib.flags = 0;
 		xlib.dpy = (Display *)winsysData1_;
 		xlib.window = (Window)winsysData2_;
@@ -779,7 +775,7 @@ VkResult VulkanContext::ReinitSurface() {
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 	case WINDOWSYSTEM_XCB:
 	{
-		VkXCBSurfaceCreateInfoKHR xcb = { VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR };
+		VkXCBSurfaceCreateInfoKHR xcb{ VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR };
 		xcb.flags = 0;
 		xcb.connection = (Connection *)winsysData1_;
 		xcb.window = (Window)(uintptr_t)winsysData2_;
@@ -789,7 +785,7 @@ VkResult VulkanContext::ReinitSurface() {
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 	case WINDOWSYSTEM_WAYLAND:
 	{
-		VkWaylandSurfaceCreateInfoKHR wayland = { VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR };
+		VkWaylandSurfaceCreateInfoKHR wayland{ VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR };
 		wayland.flags = 0;
 		wayland.display = (wl_display *)winsysData1_;
 		wayland.surface = (wl_surface *)winsysData2_;
@@ -973,7 +969,7 @@ bool VulkanContext::InitSwapchain() {
 		preTransform = surfCapabilities_.currentTransform;
 	}
 
-	VkSwapchainCreateInfoKHR swap_chain_info = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
+	VkSwapchainCreateInfoKHR swap_chain_info{ VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
 	swap_chain_info.surface = surface_;
 	swap_chain_info.minImageCount = desiredNumberOfSwapChainImages;
 	swap_chain_info.imageFormat = swapchainFormat_;

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -101,17 +101,6 @@ private:
 	std::vector<Callback> callbacks_;
 };
 
-// For fast extension-enabled checks.
-struct VulkanDeviceExtensions {
-	bool KHR_get_memory_requirements2;
-	bool KHR_dedicated_allocation;
-	bool EXT_external_memory_host;
-	bool KHR_get_physical_device_properties2;
-	bool KHR_depth_stencil_resolve;
-	bool EXT_shader_stencil_export;
-	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
-};
-
 // Useful for debugging on ARM Mali. This eliminates transaction elimination
 // which can cause artifacts if you get barriers wrong (or if there are driver bugs).
 // Cost is reduced performance on some GPU architectures.
@@ -175,7 +164,11 @@ public:
 
 	bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex);
 
-	VkResult InitDebugMsgCallback(PFN_vkDebugReportCallbackEXT dbgFunc, int bits, void *userdata = nullptr);
+	VkResult InitDebugUtilsCallback(PFN_vkDebugUtilsMessengerCallbackEXT callback, int bits, void *userdata);
+	void DestroyDebugUtilsCallback();
+
+	// Legacy reporting
+	VkResult InitDebugMsgCallback(PFN_vkDebugReportCallbackEXT dbgFunc, int bits, void *userdata);
 	void DestroyDebugMsgCallback();
 
 	VkPhysicalDevice GetPhysicalDevice(int n = 0) const {
@@ -334,6 +327,7 @@ private:
 	VulkanDeleteList globalDeleteList_;
 
 	std::vector<VkDebugReportCallbackEXT> msg_callbacks;
+	std::vector<VkDebugUtilsMessengerEXT> utils_callbacks;
 
 	VkSwapchainKHR swapchain_ = VK_NULL_HANDLE;
 	VkFormat swapchainFormat_;

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -107,6 +107,8 @@ struct VulkanDeviceExtensions {
 	bool KHR_dedicated_allocation;
 	bool EXT_external_memory_host;
 	bool KHR_get_physical_device_properties2;
+	bool KHR_depth_stencil_resolve;
+	bool EXT_shader_stencil_export;
 	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
 };
 

--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -73,8 +73,6 @@ VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugReportObje
 	}
 	message << "[" << pLayerPrefix << "] " << ObjTypeToString(objType) << " Code " << msgCode << " : " << pMsg << "\n";
 
-	if (msgCode == 2)  // Useless perf warning ("Vertex attribute at location X not consumed by vertex shader")
-		return false;
 	if (msgCode == 64)  // Another useless perf warning that will be seen less and less as we optimize -  vkCmdClearAttachments() issued on command buffer object 0x00000195296C6D40 prior to any Draw Cmds. It is recommended you use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.
 		return false;
 	if (msgCode == 5)

--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -56,7 +56,7 @@ const char *ObjTypeToString(VkDebugReportObjectTypeEXT type) {
 	}
 }
 
-VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData) {
+VkBool32 VKAPI_CALL VulkanDebugReportCallback(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData) {
 	const VulkanLogOptions *options = (const VulkanLogOptions *)pUserData;
 	std::ostringstream message;
 
@@ -94,6 +94,63 @@ VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugReportObje
 	}
 #else
 	ILOG("%s", message.str().c_str());
+#endif
+
+	// false indicates that layer should not bail-out of an
+	// API call that had validation failures. This may mean that the
+	// app dies inside the driver due to invalid parameter(s).
+	// That's what would happen without validation layers, so we'll
+	// keep that behavior here.
+	return false;
+}
+
+VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
+	VkDebugUtilsMessageSeverityFlagBitsEXT           messageSeverity,
+	VkDebugUtilsMessageTypeFlagsEXT                  messageType,
+	const VkDebugUtilsMessengerCallbackDataEXT*      pCallbackData,
+	void*                                            pUserData) {
+	const VulkanLogOptions *options = (const VulkanLogOptions *)pUserData;
+	std::ostringstream message;
+
+	const char *pMessage = pCallbackData->pMessage;
+	int messageCode = pCallbackData->messageIdNumber;
+	const char *pLayerPrefix = "";
+	// Ignore perf warnings for now. Could log them, so still want them registered.
+	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+		message << "ERROR(";
+	} else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+		message << "WARNING(";
+	} else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) {
+		message << "INFO(";
+	} else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) {
+		message << "VERBOSE(";
+	}
+
+	if (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) {
+		message << "perf";
+	} else if (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT) {
+		message << "general";
+	} else if (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) {
+		message << "validation";
+	}
+	message << ":" << pCallbackData->messageIdNumber << ") " << pMessage << "\n";
+
+
+#ifdef _WIN32
+	std::string msg = message.str();
+	OutputDebugStringA(msg.c_str());
+	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+		if (options->breakOnError && IsDebuggerPresent()) {
+			DebugBreak();
+		}
+		if (options->msgBoxOnError) {
+			MessageBoxA(NULL, pMessage, "Alert", MB_OK);
+		}
+	} else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+		if (options->breakOnWarning && IsDebuggerPresent() && 0 == (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
+			DebugBreak();
+		}
+	}
 #endif
 
 	// false indicates that layer should not bail-out of an

--- a/Common/Vulkan/VulkanDebug.h
+++ b/Common/Vulkan/VulkanDebug.h
@@ -25,4 +25,5 @@ struct VulkanLogOptions {
 	bool msgBoxOnError;
 };
 
-VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData);
+VkBool32 VKAPI_CALL VulkanDebugReportCallback(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData);
+VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData);

--- a/Common/Vulkan/VulkanLoader.cpp
+++ b/Common/Vulkan/VulkanLoader.cpp
@@ -199,6 +199,8 @@ PFN_vkDestroyDebugReportCallbackEXT dyn_vkDestroyDebugReportCallbackEXT;
 PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesEXT;
 PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
 PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2KHR;
+PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
+PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR;
 
 #ifdef _WIN32
 static HINSTANCE vulkanLibrary;
@@ -568,6 +570,8 @@ void VulkanLoadInstanceFunctions(VkInstance instance) {
 #endif
 
 	LOAD_INSTANCE_FUNC(instance, vkDestroySurfaceKHR);
+	LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceProperties2KHR);
+	LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceFeatures2KHR);
 
 	dyn_vkCreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(instance, "vkCreateDebugReportCallbackEXT");
 	dyn_vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT");
@@ -589,7 +593,6 @@ void VulkanLoadDeviceFunctions(VkDevice device) {
 	LOAD_DEVICE_FUNC(device, vkGetMemoryHostPointerPropertiesEXT);
 	LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2KHR);
 	LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements2KHR);
-
 }
 
 void VulkanFree() {

--- a/Common/Vulkan/VulkanLoader.cpp
+++ b/Common/Vulkan/VulkanLoader.cpp
@@ -193,8 +193,16 @@ PFN_vkAcquireNextImageKHR vkAcquireNextImageKHR;
 PFN_vkQueuePresentKHR vkQueuePresentKHR;
 
 // And the DEBUG_REPORT extension. We dynamically load this.
-PFN_vkCreateDebugReportCallbackEXT dyn_vkCreateDebugReportCallbackEXT;
-PFN_vkDestroyDebugReportCallbackEXT dyn_vkDestroyDebugReportCallbackEXT;
+PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT;
+PFN_vkDestroyDebugReportCallbackEXT vkDestroyDebugReportCallbackEXT;
+
+PFN_vkCreateDebugUtilsMessengerEXT   vkCreateDebugUtilsMessengerEXT;
+PFN_vkDestroyDebugUtilsMessengerEXT	 vkDestroyDebugUtilsMessengerEXT;
+PFN_vkCmdBeginDebugUtilsLabelEXT	 vkCmdBeginDebugUtilsLabelEXT;
+PFN_vkCmdEndDebugUtilsLabelEXT		 vkCmdEndDebugUtilsLabelEXT;
+PFN_vkCmdInsertDebugUtilsLabelEXT	 vkCmdInsertDebugUtilsLabelEXT;
+PFN_vkSetDebugUtilsObjectNameEXT     vkSetDebugUtilsObjectNameEXT;
+PFN_vkSetDebugUtilsObjectTagEXT      vkSetDebugUtilsObjectTagEXT;
 
 PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesEXT;
 PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
@@ -262,19 +270,22 @@ bool VulkanMayBeAvailable() {
 	VkApplicationInfo info{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
 	std::vector<VkPhysicalDevice> devices;
 	bool anyGood = false;
-	const char *instanceExtensions[1]{};
+	const char *instanceExtensions[2]{};
 	VkInstance instance = VK_NULL_HANDLE;
 	VkResult res;
 	uint32_t physicalDeviceCount = 0;
-	uint32_t instanceExtCount = 0;
+	uint32_t instanceExtCount = 1;
+	bool surfaceExtensionFound = false;
+	bool platformSurfaceExtensionFound = false;
 	std::vector<VkExtensionProperties> instanceExts;
+	instanceExtensions[ci.enabledExtensionCount++] = VK_KHR_SURFACE_EXTENSION_NAME;
 
 #ifdef _WIN32
-	const char * const surfaceExtension = VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+	const char * const platformSurfaceExtension = VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
 #elif defined(__ANDROID__)
-	const char *surfaceExtension = VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
+	const char *platformSurfaceExtension = VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 #else
-	const char *surfaceExtension = 0;
+	const char *platformSurfaceExtension = 0;
 #endif
 
 	if (!localEnumerateInstanceExtensionProperties || !localCreateInstance || !localEnumerate || !localDestroyInstance || !localGetPhysicalDeviceProperties)
@@ -297,16 +308,18 @@ bool VulkanMayBeAvailable() {
 		goto bail;
 	}
 
-	if (surfaceExtension) {
+	if (platformSurfaceExtension) {
 		for (auto iter : instanceExts) {
-			if (!strcmp(iter.extensionName, surfaceExtension)) {
-				instanceExtensions[0] = surfaceExtension;
-				ci.enabledExtensionCount = 1;
+			if (!strcmp(iter.extensionName, platformSurfaceExtension)) {
+				instanceExtensions[ci.enabledExtensionCount++] = platformSurfaceExtension;
+				platformSurfaceExtensionFound = true;
 				break;
+			} else if (!strcmp(iter.extensionName, VK_KHR_SURFACE_EXTENSION_NAME)) {
+				surfaceExtensionFound = true;
 			}
 		}
-		if (!ci.enabledExtensionCount) {
-			ELOG("Surface extension not found");
+		if (!platformSurfaceExtensionFound || !surfaceExtensionFound) {
+			ELOG("Platform surface extension not found");
 			goto bail;
 		}
 	}
@@ -411,7 +424,7 @@ bool VulkanLoad() {
 	return true;
 }
 
-void VulkanLoadInstanceFunctions(VkInstance instance) {
+void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanDeviceExtensions &enabledExtensions) {
 	// OK, let's use the above functions to get the rest.
 	LOAD_INSTANCE_FUNC(instance, vkDestroyInstance);
 	LOAD_INSTANCE_FUNC(instance, vkEnumeratePhysicalDevices);
@@ -570,11 +583,26 @@ void VulkanLoadInstanceFunctions(VkInstance instance) {
 #endif
 
 	LOAD_INSTANCE_FUNC(instance, vkDestroySurfaceKHR);
-	LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceProperties2KHR);
-	LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceFeatures2KHR);
 
-	dyn_vkCreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(instance, "vkCreateDebugReportCallbackEXT");
-	dyn_vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT");
+	if (enabledExtensions.KHR_get_physical_device_properties2) {
+		LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceProperties2KHR);
+		LOAD_INSTANCE_FUNC(instance, vkGetPhysicalDeviceFeatures2KHR);
+	}
+
+	if (enabledExtensions.EXT_debug_report) {
+		LOAD_INSTANCE_FUNC(instance, vkCreateDebugReportCallbackEXT);
+		LOAD_INSTANCE_FUNC(instance, vkDestroyDebugReportCallbackEXT);
+	}
+
+	if (enabledExtensions.EXT_debug_utils) {
+		LOAD_INSTANCE_FUNC(instance, vkCreateDebugUtilsMessengerEXT);
+		LOAD_INSTANCE_FUNC(instance, vkDestroyDebugUtilsMessengerEXT);
+		LOAD_INSTANCE_FUNC(instance, vkCmdBeginDebugUtilsLabelEXT);
+		LOAD_INSTANCE_FUNC(instance, vkCmdEndDebugUtilsLabelEXT);
+		LOAD_INSTANCE_FUNC(instance, vkCmdInsertDebugUtilsLabelEXT);
+		LOAD_INSTANCE_FUNC(instance, vkSetDebugUtilsObjectNameEXT);
+		LOAD_INSTANCE_FUNC(instance, vkSetDebugUtilsObjectTagEXT);
+	}
 
 	WLOG("Vulkan instance functions loaded.");
 }
@@ -582,7 +610,7 @@ void VulkanLoadInstanceFunctions(VkInstance instance) {
 // On some implementations, loading functions (that have Device as their first parameter) via vkGetDeviceProcAddr may
 // increase performance - but then these function pointers will only work on that specific device. Thus, this loader is not very
 // good for multi-device.
-void VulkanLoadDeviceFunctions(VkDevice device) {
+void VulkanLoadDeviceFunctions(VkDevice device, const VulkanDeviceExtensions &enabledExtensions) {
 	WLOG("Vulkan device functions loaded.");
 	// TODO: Move more functions VulkanLoadInstanceFunctions to here.
 	LOAD_DEVICE_FUNC(device, vkCreateSwapchainKHR);
@@ -590,9 +618,13 @@ void VulkanLoadDeviceFunctions(VkDevice device) {
 	LOAD_DEVICE_FUNC(device, vkGetSwapchainImagesKHR);
 	LOAD_DEVICE_FUNC(device, vkAcquireNextImageKHR);
 	LOAD_DEVICE_FUNC(device, vkQueuePresentKHR);
-	LOAD_DEVICE_FUNC(device, vkGetMemoryHostPointerPropertiesEXT);
-	LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2KHR);
-	LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements2KHR);
+	if (enabledExtensions.EXT_external_memory_host) {
+		LOAD_DEVICE_FUNC(device, vkGetMemoryHostPointerPropertiesEXT);
+	}
+	if (enabledExtensions.KHR_dedicated_allocation) {
+		LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2KHR);
+		LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements2KHR);
+	}
 }
 
 void VulkanFree() {

--- a/Common/Vulkan/VulkanLoader.h
+++ b/Common/Vulkan/VulkanLoader.h
@@ -204,7 +204,8 @@ extern PFN_vkDestroyDebugReportCallbackEXT dyn_vkDestroyDebugReportCallbackEXT;
 extern PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
 extern PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2KHR;
 extern PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesEXT;
-
+extern PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
+extern PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR;
 
 // Way to do a quick check before even attempting to load.
 bool VulkanMayBeAvailable();

--- a/Common/Vulkan/VulkanLoader.h
+++ b/Common/Vulkan/VulkanLoader.h
@@ -197,8 +197,16 @@ extern PFN_vkQueuePresentKHR vkQueuePresentKHR;
 
 // And the DEBUG_REPORT extension. Since we load this dynamically even in static
 // linked mode, we have to rename it :(
-extern PFN_vkCreateDebugReportCallbackEXT dyn_vkCreateDebugReportCallbackEXT;
-extern PFN_vkDestroyDebugReportCallbackEXT dyn_vkDestroyDebugReportCallbackEXT;
+extern PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT;
+extern PFN_vkDestroyDebugReportCallbackEXT vkDestroyDebugReportCallbackEXT;
+
+extern PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT;
+extern PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT;
+extern PFN_vkCmdBeginDebugUtilsLabelEXT vkCmdBeginDebugUtilsLabelEXT;
+extern PFN_vkCmdEndDebugUtilsLabelEXT vkCmdEndDebugUtilsLabelEXT;
+extern PFN_vkCmdInsertDebugUtilsLabelEXT vkCmdInsertDebugUtilsLabelEXT;
+extern PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT;
+extern PFN_vkSetDebugUtilsObjectTagEXT vkSetDebugUtilsObjectTagEXT;
 
 // Assorted other extensions.
 extern PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
@@ -207,11 +215,30 @@ extern PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesE
 extern PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
 extern PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR;
 
+
+// For fast extension-enabled checks.
+struct VulkanDeviceExtensions {
+	bool EXT_debug_report;
+	bool EXT_debug_utils;
+	bool KHR_maintenance1; // required for KHR_create_renderpass2
+	bool KHR_maintenance2;
+	bool KHR_maintenance3;
+	bool KHR_multiview;  // required for KHR_create_renderpass2
+	bool KHR_get_memory_requirements2;
+	bool KHR_dedicated_allocation;
+	bool KHR_create_renderpass2;
+	bool EXT_external_memory_host;
+	bool KHR_get_physical_device_properties2;
+	bool KHR_depth_stencil_resolve;
+	bool EXT_shader_stencil_export;
+	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
+};
+
 // Way to do a quick check before even attempting to load.
 bool VulkanMayBeAvailable();
 void VulkanSetAvailable(bool available);
 
 bool VulkanLoad();
-void VulkanLoadInstanceFunctions(VkInstance instance);
-void VulkanLoadDeviceFunctions(VkDevice device);
+void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanDeviceExtensions &enabledExtensions);
+void VulkanLoadDeviceFunctions(VkDevice device, const VulkanDeviceExtensions &enabledExtensions);
 void VulkanFree();

--- a/GPU/D3D11/ShaderManagerD3D11.cpp
+++ b/GPU/D3D11/ShaderManagerD3D11.cpp
@@ -96,9 +96,9 @@ ShaderManagerD3D11::ShaderManagerD3D11(Draw::DrawContext *draw, ID3D11Device *de
 	memset(&ub_lights, 0, sizeof(ub_lights));
 	memset(&ub_bones, 0, sizeof(ub_bones));
 
-	INFO_LOG(G3D, "sizeof(ub_base): %d", (int)sizeof(ub_base));
-	INFO_LOG(G3D, "sizeof(ub_lights): %d", (int)sizeof(ub_lights));
-	INFO_LOG(G3D, "sizeof(ub_bones): %d", (int)sizeof(ub_bones));
+	static_assert(sizeof(ub_base) <= 512, "ub_base grew too big");
+	static_assert(sizeof(ub_lights) <= 512, "ub_lights grew too big");
+	static_assert(sizeof(ub_bones) <= 384, "ub_bones grew too big");
 
 	D3D11_BUFFER_DESC desc{sizeof(ub_base), D3D11_USAGE_DYNAMIC, D3D11_BIND_CONSTANT_BUFFER, D3D11_CPU_ACCESS_WRITE };
 	ASSERT_SUCCESS(device_->CreateBuffer(&desc, nullptr, &push_base));

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -1023,7 +1023,7 @@ void TessellationDataTransferVulkan::SendDataToShader(const SimpleVertex *const 
 
 	int size = size_u * size_v;
 
-	int ssboAlignment = vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).limits.minStorageBufferOffsetAlignment;
+	int ssboAlignment = vulkan_->GetPhysicalDeviceProperties().properties.limits.minStorageBufferOffsetAlignment;
 	uint8_t *data = (uint8_t *)push_->PushAligned(size * sizeof(TessData), (uint32_t *)&bufInfo_[0].offset, &bufInfo_[0].buffer, ssboAlignment);
 	bufInfo_[0].range = size * sizeof(TessData);
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -401,7 +401,6 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 
 	VkDescriptorSet desc;
 	VkDescriptorSetAllocateInfo descAlloc{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
-	descAlloc.pNext = nullptr;
 	descAlloc.pSetLayouts = &descriptorSetLayout_;
 	descAlloc.descriptorPool = frame.descPool;
 	descAlloc.descriptorSetCount = 1;

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -237,7 +237,6 @@ static VulkanPipeline *CreateVulkanPipeline(VkDevice device, VkPipelineCache pip
 	inputAssembly.flags = 0;
 	inputAssembly.topology = (VkPrimitiveTopology)key.topology;
 	inputAssembly.primitiveRestartEnable = false;
-
 	int vertexStride = 0;
 
 	int offset = 0;

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -112,10 +112,12 @@ static int SetupVertexAttribs(VkVertexInputAttributeDescription attrs[], const D
 	return count;
 }
 
-static int SetupVertexAttribsPretransformed(VkVertexInputAttributeDescription attrs[], bool needsColor1) {
+static int SetupVertexAttribsPretransformed(VkVertexInputAttributeDescription attrs[], bool needsUV, bool needsColor1) {
 	int count = 0;
 	VertexAttribSetup(&attrs[count++], DEC_FLOAT_4, 0, PspAttributeLocation::POSITION);
-	VertexAttribSetup(&attrs[count++], DEC_FLOAT_3, 16, PspAttributeLocation::TEXCOORD);
+	if (needsUV) {
+		VertexAttribSetup(&attrs[count++], DEC_FLOAT_3, 16, PspAttributeLocation::TEXCOORD);
+	}
 	VertexAttribSetup(&attrs[count++], DEC_U8_4, 28, PspAttributeLocation::COLOR0);
 	if (needsColor1) {
 		VertexAttribSetup(&attrs[count++], DEC_U8_4, 32, PspAttributeLocation::COLOR1);
@@ -245,8 +247,9 @@ static VulkanPipeline *CreateVulkanPipeline(VkDevice device, VkPipelineCache pip
 		attributeCount = SetupVertexAttribs(attrs, *decFmt);
 		vertexStride = decFmt->stride;
 	} else {
+		bool needsUV = vs->GetID().Bit(VS_BIT_DO_TEXTURE);
 		bool needsColor1 = vs->GetID().Bit(VS_BIT_LMODE);
-		attributeCount = SetupVertexAttribsPretransformed(attrs, needsColor1);
+		attributeCount = SetupVertexAttribsPretransformed(attrs, needsUV, needsColor1);
 		vertexStride = 36;
 	}
 

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -682,7 +682,7 @@ bool PipelineManagerVulkan::LoadCache(FILE *file, bool loadRawPipelineCache, Sha
 			WARN_LOG(G3D, "Bad Vulkan pipeline cache header - ignoring");
 			return false;
 		}
-		if (0 != memcmp(header->uuid, vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).pipelineCacheUUID, VK_UUID_SIZE)) {
+		if (0 != memcmp(header->uuid, vulkan_->GetPhysicalDeviceProperties().properties.pipelineCacheUUID, VK_UUID_SIZE)) {
 			// Wrong hardware/driver/etc.
 			WARN_LOG(G3D, "Bad Vulkan pipeline cache UUID - ignoring");
 			return false;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -160,7 +160,7 @@ std::string VulkanVertexShader::GetShaderString(DebugShaderStringType type) cons
 ShaderManagerVulkan::ShaderManagerVulkan(Draw::DrawContext *draw, VulkanContext *vulkan)
 	: ShaderManagerCommon(draw), vulkan_(vulkan), lastVShader_(nullptr), lastFShader_(nullptr), fsCache_(16), vsCache_(16) {
 	codeBuffer_ = new char[16384];
-	uboAlignment_ = vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).limits.minUniformBufferOffsetAlignment;
+	uboAlignment_ = vulkan_->GetPhysicalDeviceProperties().properties.limits.minUniformBufferOffsetAlignment;
 	memset(&ub_base, 0, sizeof(ub_base));
 	memset(&ub_lights, 0, sizeof(ub_lights));
 	memset(&ub_bones, 0, sizeof(ub_bones));
@@ -178,7 +178,7 @@ ShaderManagerVulkan::~ShaderManagerVulkan() {
 void ShaderManagerVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw) {
 	vulkan_ = vulkan;
 	draw_ = draw;
-	uboAlignment_ = vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).limits.minUniformBufferOffsetAlignment;
+	uboAlignment_ = vulkan_->GetPhysicalDeviceProperties().properties.limits.minUniformBufferOffsetAlignment;
 }
 
 void ShaderManagerVulkan::Clear() {
@@ -270,7 +270,7 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 
 	VulkanFragmentShader *fs = fsCache_.Get(FSID);
 	if (!fs) {
-		uint32_t vendorID = vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).vendorID;
+		uint32_t vendorID = vulkan_->GetPhysicalDeviceProperties().properties.vendorID;
 		// Fragment shader not in cache. Let's compile it.
 		GenerateVulkanGLSLFragmentShader(FSID, codeBuffer_, vendorID);
 		fs = new VulkanFragmentShader(vulkan_, FSID, codeBuffer_);
@@ -392,7 +392,7 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		VulkanVertexShader *vs = new VulkanVertexShader(vulkan_, id, codeBuffer_, useHWTransform);
 		vsCache_.Insert(id, vs);
 	}
-	uint32_t vendorID = vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).vendorID;
+	uint32_t vendorID = vulkan_->GetPhysicalDeviceProperties().properties.vendorID;
 	for (int i = 0; i < header.numFragmentShaders; i++) {
 		FShaderID id;
 		if (fread(&id, sizeof(id), 1, f) != 1) {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -165,9 +165,9 @@ ShaderManagerVulkan::ShaderManagerVulkan(Draw::DrawContext *draw, VulkanContext 
 	memset(&ub_lights, 0, sizeof(ub_lights));
 	memset(&ub_bones, 0, sizeof(ub_bones));
 
-	ILOG("sizeof(ub_base): %d", (int)sizeof(ub_base));
-	ILOG("sizeof(ub_lights): %d", (int)sizeof(ub_lights));
-	ILOG("sizeof(ub_bones): %d", (int)sizeof(ub_bones));
+	static_assert(sizeof(ub_base) <= 512, "ub_base grew too big");
+	static_assert(sizeof(ub_lights) <= 512, "ub_lights grew too big");
+	static_assert(sizeof(ub_bones) <= 384, "ub_bones grew too big");
 }
 
 ShaderManagerVulkan::~ShaderManagerVulkan() {

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -237,7 +237,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 			key.colorWriteMask = (rmask ? VK_COLOR_COMPONENT_R_BIT : 0) | (gmask ? VK_COLOR_COMPONENT_G_BIT : 0) | (bmask ? VK_COLOR_COMPONENT_B_BIT : 0) | (amask ? VK_COLOR_COMPONENT_A_BIT : 0);
 
 			// Workaround proposed in #10421, for bug where the color write mask is not applied correctly on Adreno.
-			if ((gstate.pmskc & 0x00FFFFFF) == 0x00FFFFFF && vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).vendorID == VULKAN_VENDOR_QUALCOMM) {
+			if ((gstate.pmskc & 0x00FFFFFF) == 0x00FFFFFF && vulkan_->GetPhysicalDeviceProperties().properties.vendorID == VULKAN_VENDOR_QUALCOMM) {
 				key.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
 				if (!key.blendEnable) {
 					key.blendEnable = true;

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -146,7 +146,7 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, bool skip
 	if (!stencilVs_) {
 		const char *stencil_fs_source = stencil_fs;
 		// See comment above the stencil_fs_adreno definition.
-		if (vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).vendorID == VULKAN_VENDOR_QUALCOMM)
+		if (vulkan_->GetPhysicalDeviceProperties().properties.vendorID == VULKAN_VENDOR_QUALCOMM)
 			stencil_fs_source = stencil_fs_adreno;
 
 		stencilVs_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_VERTEX_BIT, stencil_vs, &error);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -683,7 +683,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			uint32_t bufferOffset;
 			VkBuffer texBuf;
 			// nvidia returns 1 but that can't be healthy... let's align by 16 as a minimum.
-			int pushAlignment = std::max(16, (int)vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).limits.optimalBufferCopyOffsetAlignment);
+			int pushAlignment = std::max(16, (int)vulkan_->GetPhysicalDeviceProperties().properties.limits.optimalBufferCopyOffsetAlignment);
 			void *data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
 			if (replaced.Valid()) {
 				replaced.Load(i, data, stride);

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -160,12 +160,11 @@ VkDescriptorSet Vulkan2D::GetDescriptorSet(VkImageView tex1, VkSampler sampler1,
 	assert(result == VK_SUCCESS);
 
 	// We just don't write to the slots we don't care about.
-	VkWriteDescriptorSet writes[2];
-	memset(writes, 0, sizeof(writes));
+	VkWriteDescriptorSet writes[2]{};
 	// Main and sub textures
 	int n = 0;
-	VkDescriptorImageInfo image1 = {};
-	VkDescriptorImageInfo image2 = {};
+	VkDescriptorImageInfo image1{};
+	VkDescriptorImageInfo image2{};
 	if (tex1) {
 #ifdef VULKAN_USE_GENERAL_LAYOUT_FOR_COLOR
 		image1.imageLayout = VK_IMAGE_LAYOUT_GENERAL;

--- a/UWP/glslang_UWP/glslang_UWP.vcxproj
+++ b/UWP/glslang_UWP/glslang_UWP.vcxproj
@@ -390,6 +390,7 @@
     <ClCompile Include="..\..\ext\glslang\SPIRV\Logger.cpp" />
     <ClCompile Include="..\..\ext\glslang\SPIRV\SpvBuilder.cpp" />
     <ClCompile Include="..\..\ext\glslang\SPIRV\SPVRemapper.cpp" />
+    <ClCompile Include="..\..\ext\glslang\SPIRV\SpvPostProcess.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -114,7 +114,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	if (deviceNum < 0) {
 		deviceNum = g_Vulkan->GetBestPhysicalDevice();
 		if (!g_Config.sVulkanDevice.empty())
-			g_Config.sVulkanDevice = g_Vulkan->GetPhysicalDeviceProperties(deviceNum).deviceName;
+			g_Config.sVulkanDevice = g_Vulkan->GetPhysicalDeviceProperties(deviceNum).properties.deviceName;
 	}
 	g_Vulkan->ChooseDevice(deviceNum);
 	if (g_Vulkan->CreateDevice() != VK_SUCCESS) {
@@ -137,7 +137,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	bool splitSubmit = g_Config.bGfxDebugSplitSubmit;
 
 	draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, splitSubmit);
-	SetGPUBackend(GPUBackend::VULKAN, g_Vulkan->GetPhysicalDeviceProperties(deviceNum).deviceName);
+	SetGPUBackend(GPUBackend::VULKAN, g_Vulkan->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
 	bool success = draw_->CreatePresets();
 	_assert_msg_(G3D, success, "Failed to compile preset shaders");
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -124,8 +124,17 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 		return false;
 	}
 	if (g_validate_) {
-		int bits = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
-		g_Vulkan->InitDebugMsgCallback(&Vulkan_Dbg, bits, &g_LogOptions);
+		if (g_Vulkan->DeviceExtensions().EXT_debug_utils) {
+			int bits = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
+				| VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
+				| VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT
+				| VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT
+				| VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+			g_Vulkan->InitDebugUtilsCallback(&VulkanDebugUtilsCallback, bits, &g_LogOptions);
+		} else {
+			int bits = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
+			g_Vulkan->InitDebugMsgCallback(&VulkanDebugReportCallback, bits, &g_LogOptions);
+		}
 	}
 	g_Vulkan->InitSurface(WINDOWSYSTEM_WIN32, (void *)hInst, (void *)hWnd);
 	if (!g_Vulkan->InitObjects()) {
@@ -160,6 +169,7 @@ void WindowsVulkanContext::Shutdown() {
 	g_Vulkan->WaitUntilQueueIdle();
 	g_Vulkan->DestroyObjects();
 	g_Vulkan->DestroyDevice();
+	g_Vulkan->DestroyDebugUtilsCallback();
 	g_Vulkan->DestroyDebugMsgCallback();
 	g_Vulkan->DestroyInstance();
 

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -160,6 +160,7 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 	if (!success) {
 		g_Vulkan->DestroyObjects();
 		g_Vulkan->DestroyDevice();
+		g_Vulkan->DestroyDebugUtilsCallback();
 		g_Vulkan->DestroyDebugMsgCallback();
 
 		g_Vulkan->DestroyInstance();
@@ -181,6 +182,7 @@ void AndroidVulkanContext::ShutdownFromRenderThread() {
 void AndroidVulkanContext::Shutdown() {
 	ILOG("Calling NativeShutdownGraphics");
 	g_Vulkan->DestroyDevice();
+	g_Vulkan->DestroyDebugUtilsCallback();
 	g_Vulkan->DestroyDebugMsgCallback();
 
 	g_Vulkan->DestroyInstance();

--- a/ext/glslang-build/Android.mk
+++ b/ext/glslang-build/Android.mk
@@ -50,6 +50,7 @@ LOCAL_SRC_FILES := \
     ../glslang/SPIRV/InReadableOrder.cpp \
     ../glslang/SPIRV/SpvBuilder.cpp \
     ../glslang/SPIRV/SPVRemapper.cpp \
+    ../glslang/SPIRV/SpvPostProcess.cpp \
     ../glslang/OGLCompilersDLL/InitializeDll.cpp
 
 

--- a/ext/glslang.vcxproj
+++ b/ext/glslang.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="glslang\SPIRV\InReadableOrder.cpp" />
     <ClCompile Include="glslang\SPIRV\Logger.cpp" />
     <ClCompile Include="glslang\SPIRV\SpvBuilder.cpp" />
+    <ClCompile Include="glslang\SPIRV\SpvPostProcess.cpp" />
     <ClCompile Include="glslang\SPIRV\SPVRemapper.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/ext/glslang.vcxproj.filters
+++ b/ext/glslang.vcxproj.filters
@@ -140,6 +140,9 @@
     <ClCompile Include="glslang\glslang\MachineIndependent\attribute.cpp">
       <Filter>glslang</Filter>
     </ClCompile>
+    <ClCompile Include="glslang\SPIRV\SpvPostProcess.cpp">
+      <Filter>SPIRV</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="glslang\SPIRV\disassemble.h">

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -865,7 +865,7 @@ void VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKRStep &step
 		// See pull request #10723.
 		bool maliBugWorkaround = step.render.numDraws == 0 &&
 			step.render.color == VKRRenderPassAction::CLEAR &&
-			vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).driverVersion == 0xaa9c4b29;
+			vulkan_->GetPhysicalDeviceProperties().properties.driverVersion == 0xaa9c4b29;
 		if (maliBugWorkaround) {
 			TransitionImageLayout2(cmd, step.render.framebuffer->color.image, 0, 1, VK_IMAGE_ASPECT_COLOR_BIT,
 				fb->color.layout, VK_IMAGE_LAYOUT_GENERAL,

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -42,24 +42,39 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 	vkCreateImage(vulkan->GetDevice(), &ici, nullptr, &img.image);
 
 	VkMemoryRequirements memreq;
-	vkGetImageMemoryRequirements(vulkan->GetDevice(), img.image, &memreq);
+
+	bool dedicatedAllocation = false;
+	if (vulkan->DeviceExtensions().KHR_dedicated_allocation) {
+		VkImageMemoryRequirementsInfo2KHR memReqInfo2{VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR};
+		memReqInfo2.image = img.image;
+
+		VkMemoryRequirements2KHR memReq2 = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR};
+		VkMemoryDedicatedRequirementsKHR memDedicatedReq{VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR};
+		memReq2.pNext = &memDedicatedReq;
+
+		vkGetImageMemoryRequirements2KHR(vulkan->GetDevice(), &memReqInfo2, &memReq2);
+
+		memreq = memReq2.memoryRequirements;
+		dedicatedAllocation =
+			(memDedicatedReq.requiresDedicatedAllocation != VK_FALSE) ||
+			(memDedicatedReq.prefersDedicatedAllocation != VK_FALSE);
+	} else {
+		vkGetImageMemoryRequirements(vulkan->GetDevice(), img.image, &memreq);
+	}
 
 	VkMemoryAllocateInfo alloc{ VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
 	alloc.allocationSize = memreq.size;
-
-	/*
-	// Hint to the driver that this allocation is image-specific. Some drivers benefit.
-	// We only bother supporting the KHR extension, not the old NV one.
-	VkMemoryDedicatedAllocateInfoKHR dedicated{ VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR };
-	if (vulkan->DeviceExtensions().DEDICATED_ALLOCATION) {
-		alloc.pNext = &dedicated;
-		dedicated.image = img.image;
+	VkMemoryDedicatedAllocateInfoKHR dedicatedAllocateInfo{VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR};
+	if (dedicatedAllocation) {
+		dedicatedAllocateInfo.image = img.image;
+		alloc.pNext = &dedicatedAllocateInfo;
 	}
-	*/
 
 	vulkan->MemoryTypeFromProperties(memreq.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc.memoryTypeIndex);
+
 	VkResult res = vkAllocateMemory(vulkan->GetDevice(), &alloc, nullptr, &img.memory);
 	assert(res == VK_SUCCESS);
+
 	res = vkBindImageMemory(vulkan->GetDevice(), img.image, img.memory, 0);
 	assert(res == VK_SUCCESS);
 
@@ -554,10 +569,6 @@ bool VulkanRenderManager::InitDepthStencilBuffer(VkCommandBuffer cmd) {
 	image_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 	image_info.flags = 0;
 
-	VkMemoryAllocateInfo mem_alloc = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
-	mem_alloc.allocationSize = 0;
-	mem_alloc.memoryTypeIndex = 0;
-
 	VkMemoryRequirements mem_reqs;
 
 	depth_.format = depth_format;
@@ -568,9 +579,36 @@ bool VulkanRenderManager::InitDepthStencilBuffer(VkCommandBuffer cmd) {
 	if (res != VK_SUCCESS)
 		return false;
 
-	vkGetImageMemoryRequirements(device, depth_.image, &mem_reqs);
+	bool dedicatedAllocation = false;
+	if (vulkan_->DeviceExtensions().KHR_dedicated_allocation) {
+		VkImageMemoryRequirementsInfo2KHR memReqInfo2{VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR};
+		memReqInfo2.image = depth_.image;
 
+		VkMemoryRequirements2KHR memReq2 = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR};
+		VkMemoryDedicatedRequirementsKHR memDedicatedReq{VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR};
+		memReq2.pNext = &memDedicatedReq;
+
+		vkGetImageMemoryRequirements2KHR(vulkan_->GetDevice(), &memReqInfo2, &memReq2);
+
+		mem_reqs = memReq2.memoryRequirements;
+		dedicatedAllocation =
+			(memDedicatedReq.requiresDedicatedAllocation != VK_FALSE) ||
+			(memDedicatedReq.prefersDedicatedAllocation != VK_FALSE);
+	} else {
+		vkGetImageMemoryRequirements(vulkan_->GetDevice(), depth_.image, &mem_reqs);
+	}
+
+
+	VkMemoryAllocateInfo mem_alloc = {VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
 	mem_alloc.allocationSize = mem_reqs.size;
+	mem_alloc.memoryTypeIndex = 0;
+
+	VkMemoryDedicatedAllocateInfoKHR dedicatedAllocateInfo{VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR};
+	if (dedicatedAllocation) {
+		dedicatedAllocateInfo.image = depth_.image;
+		mem_alloc.pNext = &dedicatedAllocateInfo;
+	}
+
 	// Use the memory properties to determine the type of memory required
 	pass = vulkan_->MemoryTypeFromProperties(mem_reqs.memoryTypeBits,
 		0, /* No requirements */

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -138,7 +138,7 @@ VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan) : vulkan_(vulkan
 	queueRunner_.CreateDeviceObjects();
 
 	// Temporary AMD hack for issue #10097
-	if (vulkan_->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDevice()).vendorID == VULKAN_VENDOR_AMD) {
+	if (vulkan_->GetPhysicalDeviceProperties().properties.vendorID == VULKAN_VENDOR_AMD) {
 		useThread_ = false;
 	}
 }

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -655,13 +655,6 @@ public:
 
 	virtual void HandleEvent(Event ev, int width, int height, void *param1 = nullptr, void *param2 = nullptr) = 0;
 
-	// This flushes command buffers and waits for execution at the point of the end of the last
-	// renderpass that wrote to the requested framebuffer. This is needed before trying to read it back
-	// on modern APIs like Vulkan. Ifr the framebuffer is currently being rendered to, we'll just end the render pass.
-	// The next draw call will automatically start up a new one.
-	// APIs like OpenGL won't need to implement this one.
-	virtual void WaitRenderCompletion(Framebuffer *fbo) {}
-
 	// Flush state like scissors etc so the caller can do its own custom drawing.
 	virtual void FlushState() {}
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -427,9 +427,7 @@ public:
 	void EndFrame() override;
 	void WipeQueue() override;
 
-	void FlushState() override {
-	}
-	void WaitRenderCompletion(Framebuffer *fbo) override;
+	void FlushState() override {}
 
 	// From Sascha's code
 	static std::string FormatDriverVersion(const VkPhysicalDeviceProperties &props) {
@@ -894,10 +892,6 @@ void VKContext::BeginFrame() {
 	_assert_(result == VK_SUCCESS);
 }
 
-void VKContext::WaitRenderCompletion(Framebuffer *fbo) {
-	// TODO
-}
-
 void VKContext::EndFrame() {
 	// Stop collecting data in the frame's data pushbuffer.
 	push_->End();
@@ -1014,13 +1008,11 @@ Pipeline *VKContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 	dynamicInfo.dynamicStateCount = depth->info.stencilTestEnable ? ARRAY_SIZE(dynamics) : 2;
 	dynamicInfo.pDynamicStates = dynamics;
 
-	VkPipelineMultisampleStateCreateInfo ms = { VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
-	ms.pNext = nullptr;
+	VkPipelineMultisampleStateCreateInfo ms{ VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
 	ms.pSampleMask = nullptr;
 	ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-	VkPipelineViewportStateCreateInfo vs = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
-	vs.pNext = nullptr;
+	VkPipelineViewportStateCreateInfo vs{ VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
 	vs.viewportCount = 1;
 	vs.scissorCount = 1;
 	vs.pViewports = nullptr;  // dynamic
@@ -1029,8 +1021,7 @@ Pipeline *VKContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 	VkPipelineRasterizationStateCreateInfo rs{ VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
 	raster->ToVulkan(&rs);
 
-	VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
-	info.pNext = nullptr;
+	VkGraphicsPipelineCreateInfo info{ VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
 	info.flags = 0;
 	info.stageCount = (uint32_t)stages.size();
 	info.pStages = stages.data();


### PR DESCRIPTION
Also adds support for the debug_utils extension, which can later be used to annotate Vulkan objects with their PSP addresses and stuff for use in RenderDoc etc if we need to debug on that level.

Some modernization and house-cleaning around the Vulkan loader, and update the glslang submodule.

This should not really change anything visible, except possibly marginally better performance on platforms that benefit from VK_KHR_dedicated_allocation.