### PR TITLE
Revert limit FPS on clear

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -942,7 +942,7 @@ u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) 
 		u64 now = CoreTiming::GetTicks();
 		s64 cyclesAhead = nextFlipCycles - now;
 		if (cyclesAhead > FLIP_DELAY_CYCLES_MIN) {
-			if (lastFlipsTooFrequent >= FLIP_DELAY_MIN_FLIPS && gpuStats.numClears > 0) {
+			if (lastFlipsTooFrequent >= FLIP_DELAY_MIN_FLIPS) {
 				delayCycles = cyclesAhead;
 			} else {
 				++lastFlipsTooFrequent;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -386,7 +386,7 @@ ULJM05940 = true
 NPJH00142 = true
 
 [ForceUMDDelay]
-# F1 2006
+# F1 2006 won't boot at all with our standard unrealistically fast timing.
 UCES00238 = true
 UCJS10045 = true
 
@@ -413,3 +413,7 @@ NPUG80325 = true
 NPEG00023 = true
 NPHG00028 = true
 NPJG00120 = true
+
+# F1 2006 has extremely long loading times if we don't limit the framerate.
+UCES00238 = true
+UCJS10045 = true


### PR DESCRIPTION
Partially revert #10456 (avoid limit FPS without a clear). 

It's a pretty gnarly hack-upon-a-hack. Better to remove the original hack (limit fps) in the general case.

Builds upon #11768 so merge that first.

Should fix #10763.

Also fixes #11177.