### PR TITLE
Naruto Shippuden Ultimate Ninja 3: Probably a better fix for the video hang issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ desc.txt
 
 Logs
 Memstick
-memstick
+memstick*
 Cheats
 
 /git-version.cpp

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1599,7 +1599,6 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		Memory::Write_U32(1, attrAddr);
 	}
 
-
 	DEBUG_LOG(ME, "%x=sceMpegGetAvcAu(%08x, %08x, %08x, %08x)", result, mpeg, streamId, auAddr, attrAddr);
 	// TODO: sceMpegGetAvcAu seems to modify esSize, and delay when it's > 1000 or something.
 	// There's definitely more to it, but ultimately it seems games should expect it to delay randomly.
@@ -1664,6 +1663,7 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	// Instead, let's abuse it to keep track of the stream number.
 	if (streamInfo != ctx->streamMap.end()) {
 		atracAu.esBuffer = streamInfo->second.num;
+		ctx->mediaengine->setAudioStream(streamInfo->second.num);
 	}
 
 	int result = 0;

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -49,7 +49,7 @@ static const int PSMF_AUDIO_STREAM_ID = 0xBD;
 struct SceMpegAu {
 	s64_le pts;  // presentation time stamp
 	s64_le dts;  // decode time stamp
-	u32_le esBuffer;
+	u32_le esBuffer;  // WARNING: We abuse this to keep track of the stream number!
 	u32_le esSize;
 
 	void read(u32 addr);


### PR DESCRIPTION
Fixes #9591, replaces #11772 

Needs testing with other games!