### PR TITLE
Fix issue where too long filenames could wreck the Install Zip dialog layout

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -96,3 +96,19 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 
 	return true;
 }
+
+std::string GetFilenameFromPath(std::string full_path) {
+	size_t pos;
+#ifdef _WIN32
+	pos = full_path.rfind('\\');
+	if (pos != std::string::npos) {
+		return full_path.substr(pos + 1);
+	}
+#endif
+	pos = full_path.rfind('/');
+	if (pos != std::string::npos) {
+		return full_path.substr(pos + 1);
+	}
+	// No directory components, just return the full path.
+	return full_path;
+}

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -45,3 +45,5 @@ inline void CharArrayFromFormat(char (& out)[Count], const char* format, ...)
 
 // "C:/Windows/winhelp.exe" to "C:/Windows/", "winhelp", ".exe"
 bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _pFilename, std::string* _pExtension);
+
+std::string GetFilenameFromPath(std::string full_path);

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -23,6 +23,7 @@
 #include "UI/ui_atlas.h"
 #include "file/file_util.h"
 
+#include "Common/StringUtils.h"
 #include "Core/Util/GameManager.h"
 #include "UI/InstallZipScreen.h"
 #include "UI/MainScreen.h"
@@ -43,8 +44,9 @@ void InstallZipScreen::CreateViews() {
 	ViewGroup *leftColumn = new AnchorLayout(new LinearLayoutParams(1.0f));
 	root_->Add(leftColumn);
 
+	std::string shortFilename = GetFilenameFromPath(zipPath_);
 	leftColumn->Add(new TextView(iz->T("Install game from ZIP file?"), ALIGN_LEFT, false, new AnchorLayoutParams(10, 10, NONE, NONE)));
-	leftColumn->Add(new TextView(zipPath_, ALIGN_LEFT, false, new AnchorLayoutParams(10, 60, NONE, NONE)));
+	leftColumn->Add(new TextView(shortFilename, ALIGN_LEFT, false, new AnchorLayoutParams(10, 60, NONE, NONE)));
 
 	doneView_ = leftColumn->Add(new TextView("", new AnchorLayoutParams(10, 120, NONE, NONE)));
 	progressBar_ = leftColumn->Add(new ProgressBar(new AnchorLayoutParams(10, 200, 200, NONE)));


### PR DESCRIPTION
Well, technically just shortens the path to avoid the issue.

The issue looked like this:

![image0](https://user-images.githubusercontent.com/130929/52535279-8b56d980-2d4c-11e9-9dba-3bc3a5777314.png)
