### PR TITLE
SDL: Prevent mouse capture on macbook trackpad

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -682,6 +682,8 @@ int main(int argc, char *argv[]) {
 					NativeKey(key);
 					break;
 				}
+// This behavior doesn't feel right on a macbook with a touchpad.
+#if !PPSSPP_PLATFORM(MAC)
 			case SDL_FINGERMOTION:
 				{
 					SDL_GetWindowSize(window, &w, &h);
@@ -744,6 +746,7 @@ int main(int argc, char *argv[]) {
 					SDL_PushEvent(&touchEvent);
 					break;
 				}
+#endif
 			case SDL_MOUSEBUTTONDOWN:
 				switch (event.button.button) {
 				case SDL_BUTTON_LEFT:


### PR DESCRIPTION
See #11365.  Just ifdef'ing out the behavior on Mac (not iOS), although there are touchpen attachments for Mac that might benefit from this.  Wasn't sure how to effectively detect touchpad input.

It can make users who rely on the mouse feel trapped, since even in windowed mode, it's basically impossible to access the dock without using a keyboard or exiting PPSSPP (before this change.)

-[Unknown]