### PR TITLE
 Qt: Re-enable Load button to browse for file

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -915,8 +915,7 @@ void MainScreen::CreateViews() {
 	TextView *ver = rightColumnItems->Add(new TextView(versionString, new LinearLayoutParams(Margins(70, -6, 0, 0))));
 	ver->SetSmall(true);
 	ver->SetClip(false);
-// Temporarily disabled the load button for Qt. See #11721
-#if defined(_WIN32) // || defined(USING_QT_UI)
+#if defined(_WIN32) || defined(USING_QT_UI)
 	rightColumnItems->Add(new Choice(mm->T("Load","Load...")))->OnClick.Handle(this, &MainScreen::OnLoadFile);
 #endif
 	rightColumnItems->Add(new Choice(mm->T("Game Settings", "Settings")))->OnClick.Handle(this, &MainScreen::OnGameSettings);
@@ -1028,16 +1027,6 @@ bool MainScreen::UseVerticalLayout() const {
 }
 
 UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
-#if defined(USING_QT_UI)
-	QString fileName = QFileDialog::getOpenFileName(NULL, "Load ROM", g_Config.currentDirectory.c_str(), "PSP ROMs (*.iso *.cso *.pbp *.elf *.zip *.ppdmp)");
-	if (QFile::exists(fileName)) {
-		QDir newPath;
-		g_Config.currentDirectory = newPath.filePath(fileName).toStdString();
-		g_Config.Save();
-		screenManager()->switchScreen(new EmuScreen(fileName.toStdString()));
-	}
-#endif
-
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
 		System_SendMessage("browse_file", "");
 	}

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -34,7 +34,8 @@ public:
 
 	UI::Choice *HomebrewStoreButton() { return homebrewStoreButton_; }
 
-	void FocusGame(std::string gamePath);
+	void FocusGame(const std::string &gamePath);
+	void SetPath(const std::string &path);
 
 protected:
 	virtual bool DisplayTopBar();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -27,10 +27,11 @@
 #include <shellapi.h>
 #include <mmsystem.h>
 
+#include "base/NativeApp.h"
 #include "base/display.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
-#include "base/NativeApp.h"
+#include "i18n/i18n.h"
 #include "profiler/profiler.h"
 #include "thread/threadutil.h"
 #include "util/text/utf8.h"
@@ -58,6 +59,7 @@
 #include "Windows/GEDebugger/GEDebugger.h"
 
 #include "Windows/W32Util/DialogManager.h"
+#include "Windows/W32Util/ShellUtil.h"
 
 #include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/Debugger/CtrlMemView.h"
@@ -274,6 +276,11 @@ void System_SendMessage(const char *command, const char *parameter) {
 		}
 	} else if (!strcmp(command, "browse_file")) {
 		MainWindow::BrowseAndBoot("");
+	} else if (!strcmp(command, "browse_folder")) {
+		I18NCategory *mm = GetI18NCategory("MainMenu");
+		std::string folder = W32Util::BrowseForFolder(MainWindow::GetHWND(), mm->T("Choose folder"));
+		if (folder.size())
+			NativeMessageReceived("browse_folderSelect", folder.c_str());
 	} else if (!strcmp(command, "bgImage_browse")) {
 		MainWindow::BrowseBackground();
 	} else if (!strcmp(command, "toggle_fullscreen")) {


### PR DESCRIPTION
This makes it work the same as Windows, and also cleans up the "Browse..." button which was still crashing.

Fixes the browse part of #11721, and #11808 fixes the flicker so this fixes #11721.

-[Unknown]