### PR TITLE
Windows: Hide accelerators when they are disabled

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -44,6 +44,7 @@ struct DefMappingStruct {
 };
 
 KeyMapping g_controllerMap;
+int g_controllerMapGeneration = 0;
 std::set<std::string> g_seenPads;
 
 bool g_swapped_keys = false;
@@ -833,6 +834,7 @@ void SetKeyMapping(int btn, KeyDef key, bool replace) {
 		}
 		g_controllerMap[btn].push_back(key);
 	}
+	g_controllerMapGeneration++;
 
 	UpdateNativeMenuKeys();
 }
@@ -956,6 +958,7 @@ void AutoConfForPad(const std::string &name) {
 	// Add a couple of convenient keyboard mappings by default, too.
 	g_controllerMap[VIRTKEY_PAUSE].push_back(KeyDef(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE));
 	g_controllerMap[VIRTKEY_UNTHROTTLE].push_back(KeyDef(DEVICE_ID_KEYBOARD, NKCODE_TAB));
+	g_controllerMapGeneration++;
 #endif
 }
 

--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -85,6 +85,7 @@ class IniFile;
 
 namespace KeyMap {
 	extern KeyMapping g_controllerMap;
+	extern int g_controllerMapGeneration;
 
 	// Key & Button names
 	struct KeyMap_IntStrPair {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -29,6 +29,7 @@
 #include "ui/view.h"
 #include "ui/viewgroup.h"
 
+#include "Core/Host.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/System.h"
 #include "Common/KeyMap.h"
@@ -79,6 +80,7 @@ void ControlMapper::Update() {
 	if (refresh_) {
 		refresh_ = false;
 		Refresh();
+		host->UpdateUI();
 	}
 }
 
@@ -169,6 +171,7 @@ void ControlMapper::MappedCallback(KeyDef kdf) {
 		break;
 	case REPLACEONE:
 		KeyMap::g_controllerMap[pspKey_][actionIndex_] = kdf;
+		KeyMap::g_controllerMapGeneration++;
 		break;
 	default:
 		;
@@ -211,6 +214,7 @@ UI::EventReturn ControlMapper::OnAddMouse(UI::EventParams &params) {
 UI::EventReturn ControlMapper::OnDelete(UI::EventParams &params) {
 	int index = atoi(params.v->Tag().c_str());
 	KeyMap::g_controllerMap[pspKey_].erase(KeyMap::g_controllerMap[pspKey_].begin() + index);
+	KeyMap::g_controllerMapGeneration++;
 	refresh_ = true;
 	return UI::EVENT_DONE;
 }

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -50,6 +50,7 @@ namespace MainWindow {
 	static std::unordered_map<int, std::string> initialMenuKeys;
 	static std::vector<std::string> availableShaders;
 	static std::string menuLanguageID = "";
+	static int menuKeymapGeneration = -1;
 	static bool menuShaderInfoLoaded = false;
 	std::vector<ShaderInfo> menuShaderInfo;
 
@@ -209,6 +210,10 @@ namespace MainWindow {
 	}
 
 	void DoTranslateMenus(HWND hWnd, HMENU menu) {
+		auto useDefHotkey = [](int virtkey) {
+			return KeyMap::g_controllerMap[virtkey].empty();
+		};
+
 		TranslateMenuItem(menu, ID_FILE_MENU);
 		TranslateMenuItem(menu, ID_EMULATION_MENU);
 		TranslateMenuItem(menu, ID_DEBUG_MENU);
@@ -220,9 +225,9 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_FILE_LOAD_DIR);
 		TranslateMenuItem(menu, ID_FILE_LOAD_MEMSTICK);
 		TranslateMenuItem(menu, ID_FILE_MEMSTICK);
-		TranslateMenuItem(menu, ID_FILE_SAVESTATE_SLOT_MENU, L"\tF3");
-		TranslateMenuItem(menu, ID_FILE_QUICKLOADSTATE, L"\tF4");
-		TranslateMenuItem(menu, ID_FILE_QUICKSAVESTATE, L"\tF2");
+		TranslateMenuItem(menu, ID_FILE_SAVESTATE_SLOT_MENU, useDefHotkey(VIRTKEY_NEXT_SLOT) ? L"\tF3" : L"");
+		TranslateMenuItem(menu, ID_FILE_QUICKLOADSTATE, useDefHotkey(VIRTKEY_LOAD_STATE) ? L"\tF4" : L"");
+		TranslateMenuItem(menu, ID_FILE_QUICKSAVESTATE, useDefHotkey(VIRTKEY_SAVE_STATE) ? L"\tF2" : L"");
 		TranslateMenuItem(menu, ID_FILE_LOADSTATEFILE);
 		TranslateMenuItem(menu, ID_FILE_SAVESTATEFILE);
 		TranslateMenuItem(menu, ID_FILE_RECORD_MENU);
@@ -326,7 +331,7 @@ namespace MainWindow {
 		bool changed = false;
 
 		const std::string curLanguageID = i18nrepo.LanguageID();
-		if (curLanguageID != menuLanguageID) {
+		if (curLanguageID != menuLanguageID || menuKeymapGeneration != KeyMap::g_controllerMapGeneration) {
 			DoTranslateMenus(hWnd, menu);
 			menuLanguageID = curLanguageID;
 			changed = true;


### PR DESCRIPTION
Currently, mapping something to load state / save state / etc. causes the default accelerators to become disabled.  In this case, it can be confusing when the menu still shows them.

Fixes #11395.

-[Unknown]