### PR TITLE
 Android: Allow using a custom Memory Stick storage path

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -505,10 +505,6 @@ static int DefaultZoomType() {
 	return (int)SmallDisplayZoom::AUTO;
 }
 
-static bool DefaultTimerHack() {
-	return false;
-}
-
 static int DefaultAndroidHwScale() {
 #ifdef __ANDROID__
 	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 19 || System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include "ui/ui_screen.h"
 #include "UI/MiscScreens.h"
 
@@ -30,6 +31,7 @@ public:
 
 	void update() override;
 	void onFinish(DialogResult result) override;
+	void sendMessage(const char *message, const char *value) override;
 	std::string tag() const override { return "settings"; }
 
 	UI::Event OnRecentChanged;
@@ -39,6 +41,9 @@ protected:
 	void CallbackRestoreDefaults(bool yes);
 	void CallbackRenderingBackend(bool yes);
 	void CallbackRenderingDevice(bool yes);
+#if PPSSPP_PLATFORM(ANDROID)
+	void CallbackMemstickFolder(bool yes);
+#endif
 	bool UseVerticalLayout() const;
 
 private:
@@ -90,7 +95,9 @@ private:
 	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
 	UI::EventReturn OnRenderingDevice(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
-#ifdef _WIN32
+#if PPSSPP_PLATFORM(ANDROID)
+	UI::EventReturn OnChangeMemStickDir(UI::EventParams &e);
+#elif defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
 	UI::EventReturn OnSavePathMydoc(UI::EventParams &e);
 	UI::EventReturn OnSavePathOther(UI::EventParams &e);
 #endif
@@ -120,6 +127,10 @@ private:
 	bool resolutionEnable_;
 	bool bloomHackEnable_;
 	bool tessHWEnable_;
+
+#if PPSSPP_PLATFORM(ANDROID)
+	std::string pendingMemstickFolder_;
+#endif
 };
 
 class SettingInfoMessage : public UI::LinearLayout {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -106,8 +106,7 @@ private:
 	UI::EventReturn OnSavedataManager(UI::EventParams &e);
 	UI::EventReturn OnSysInfo(UI::EventParams &e);
 
-	// Temporaries to convert bools to int settings
-	bool cap60FPS_;
+	// Temporaries to convert setting types.
 	int iAlternateSpeedPercent1_;
 	int iAlternateSpeedPercent2_;
 	bool enableReports_;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -466,6 +466,15 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// most sense.
 	g_Config.memStickDirectory = std::string(external_dir) + "/";
 	g_Config.flash0Directory = std::string(external_dir) + "/flash0/";
+
+	std::string memstickDirFile = g_Config.internalDataDirectory + "/memstick_dir.txt";
+	if (File::Exists(memstickDirFile)) {
+		std::string memstickDir;
+		readFileToString(true, memstickDirFile.c_str(), memstickDir);
+		if (!memstickDir.empty() && File::Exists(memstickDir)) {
+			g_Config.memStickDirectory = memstickDir + "/";
+		}
+	}
 #elif defined(IOS)
 	g_Config.memStickDirectory = user_data_path;
 	g_Config.flash0Directory = std::string(external_dir) + "/flash0/";


### PR DESCRIPTION
This allows a user to keep their save data on an insertable card, or otherwise.

Fixes #9573, possibly also #11115 (actually merging seems dangerous and tricky), possibly #6307.  Possibly #11731 too, although the UI isn't ideal for that laser-specific case.

Makes #10199 worse, since it just asks the user to type a path.  I briefly looked at opening a "browse for folder" dialog on Android... but then just backed away slowly.  But some folder browser would be ideal, and much more useful than just an option to store with the app (since that's not necessarily so great if you have an SD card slot.)

Errors are also a bit easy to miss.  It uses the tips to tell you if the path you entered isn't writable.  Maybe it should show a proper error screen...

-[Unknown]