### PR TITLE
interp: Correct vocp prefix handling

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -2302,8 +2302,6 @@ namespace MIPSComp
 		int n = GetNumVectorElements(sz);
 
 		u8 sregs[4], dregs[4];
-		// Actually, not sure that this instruction accepts an S prefix. We don't apply it in the
-		// interpreter. But whatever.
 		GetVectorRegsPrefixS(sregs, sz, _VS);
 		GetVectorRegsPrefixD(dregs, sz, _VD);
 

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1953,8 +1953,6 @@ namespace MIPSComp {
 		int n = GetNumVectorElements(sz);
 
 		u8 sregs[4], dregs[4];
-		// Actually, not sure that this instruction accepts an S prefix. We don't apply it in the
-		// interpreter. But whatever.
 		GetVectorRegsPrefixS(sregs, sz, _VS);
 		GetVectorRegsPrefixD(dregs, sz, _VD);
 

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1840,12 +1840,13 @@ namespace MIPSComp {
 			DISABLE;
 		}
 
+		// Vector one's complement
+		// d[N] = 1.0 - s[N]
+
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
 
 		u8 sregs[4], dregs[4];
-		// Actually, not sure that this instruction accepts an S prefix. We don't apply it in the
-		// interpreter. But whatever.
 		GetVectorRegsPrefixS(sregs, sz, _VS);
 		GetVectorRegsPrefixD(dregs, sz, _VD);
 

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -549,6 +549,7 @@ namespace MIPSInt
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz);
 		for (int i = 0; i < GetNumVectorElements(sz); i++)
 		{
 			// Always positive NaN.
@@ -567,6 +568,7 @@ namespace MIPSInt
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
+		ApplySwizzleS(s, sz);
 		int n = GetNumVectorElements(sz);
 		float x = s[0];
 		d[0] = nanclamp(1.0f - x, 0.0f, 1.0f);
@@ -577,7 +579,8 @@ namespace MIPSInt
 			d[2] = nanclamp(1.0f - y, 0.0f, 1.0f);
 			d[3] = nanclamp(y, 0.0f, 1.0f);
 			outSize = V_Quad;
-		} 
+		}
+		ApplyPrefixD(d, sz);
 		WriteVector(d, outSize, vd);
 		PC += 4;
 		EatPrefixes();


### PR DESCRIPTION
Also, guess that vsocp also applies prefixes.  See #5549.

Could still be interesting to optimize the prefix handling, but this fixes the bug (which luckily only existed in interp / unknown prefix cases.)

-[Unknown]