### PR TITLE
Fix postprocessing shader support on macOS

### DIFF
--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -324,6 +324,9 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, TranslatedShade
 		// Set some options.
 		spirv_cross::CompilerGLSL::Options options;
 		options.version = gl_extensions.GLSLVersion();
+		// macOS OpenGL 4.1 implementation does not support GL_ARB_shading_language_420pack.
+		// Prevent explicit binding location emission enabled in SPIRV-Cross by default.
+		options.enable_420pack_extension = gl_extensions.ARB_shading_language_420pack;
 		glsl.set_common_options(options);
 		// Compile to GLSL, ready to give to GL driver.
 		*dest = glsl.compile();

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -335,6 +335,7 @@ void CheckGLExtensions() {
 	gl_extensions.EXT_blend_func_extended = g_set_gl_extensions.count("GL_EXT_blend_func_extended") != 0;
 	gl_extensions.ARB_conservative_depth = g_set_gl_extensions.count("GL_ARB_conservative_depth") != 0;
 	gl_extensions.ARB_shader_image_load_store = (g_set_gl_extensions.count("GL_ARB_shader_image_load_store") != 0) || (g_set_gl_extensions.count("GL_EXT_shader_image_load_store") != 0);
+	gl_extensions.ARB_shading_language_420pack = (g_set_gl_extensions.count("GL_ARB_shading_language_420pack") != 0);
 	gl_extensions.EXT_bgra = g_set_gl_extensions.count("GL_EXT_bgra") != 0;
 	gl_extensions.EXT_gpu_shader4 = g_set_gl_extensions.count("GL_EXT_gpu_shader4") != 0;
 	gl_extensions.NV_framebuffer_blit = g_set_gl_extensions.count("GL_NV_framebuffer_blit") != 0;

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -57,6 +57,7 @@ struct GLExtensions {
 	bool ARB_blend_func_extended;  // dual source blending
 	bool EXT_blend_func_extended;  // dual source blending (GLES, new 2015)
 	bool ARB_shader_image_load_store;
+	bool ARB_shading_language_420pack;
 	bool ARB_conservative_depth;
 	bool ARB_copy_image;
 	bool ARB_vertex_array_object;


### PR DESCRIPTION
Check GL_ARB_shading_language_420pack availability, which SPIRV-Cross assumes
present by default, causing explicit binding location generation during shader
translation.