### PR TITLE
Make "Invalid immediate address" assertion non fatal on iOS ARM64 JIT

### DIFF
--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -366,7 +366,15 @@ namespace MIPSComp {
 			} else {
 				// This actually gets hit in micro machines! rs = ZR rt = ZR. Probably a bug.
 				// Leaving this a debug assert for future investigation.
+#ifdef __APPLE__
+				if (__builtin_expect(gpr.IsImm(rs), 0)) {
+					// FIXME: This is common on iOS, for instance, in Medal of Honor: Heroes (ULUS10141).
+					// Since it is impossible to continue after _dbg_assert_msg_ on iOS, just log it for now.
+					ERROR_LOG(JIT, "Invalid immediate address?  CPU bug?");
+				}
+#else
 				_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address?  CPU bug?");
+#endif
 
 				// If we already have a targetReg, we optimized an imm, and rs is already mapped.
 				if (targetReg == INVALID_REG) {


### PR DESCRIPTION
This works around crashes when using JIT on iOS in ULUS10141 (Medal of Honor Heroes) at least.

Tested iOS JIT on not jailbroken iPhone on iOS 12.1.4.