### PR TITLE
Disable GLEW on macOS

### DIFF
--- a/ext/glew/CMakeLists.txt
+++ b/ext/glew/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(GLEW)
-if(GLEW_FOUND)
+if(NOT APPLE AND GLEW_FOUND)
   add_library(system_glew INTERFACE)
   add_library(Ext::GLEW ALIAS system_glew)
   target_link_libraries(system_glew INTERFACE GLEW::GLEW)


### PR DESCRIPTION
GLEW package, often residing in /opt/local/include or /usr/local/include on macOS, is not useful and pollutes the include space, resulting in bugs like https://github.com/hrydgard/ppsspp/issues/11241. While a proper fix may be to be more careful about include dirs, in this particular case just ensuring GLEW is unused is more beneficial.