### PR TITLE
Disable vertex range culling when the depthrange hack is enabled.  

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -127,7 +127,9 @@ GPU_D3D11::~GPU_D3D11() {
 void GPU_D3D11::CheckGPUFeatures() {
 	u32 features = 0;
 
-	features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+	}
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
 	features |= GPU_PREFER_CPU_DOWNLOAD;
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -176,21 +176,23 @@ void GPU_DX9::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_ACCURATE_DEPTH;
 	}
 
-	// VS range culling (killing triangles in the vertex shader using NaN) causes problems on Intel.
-	// Also causes problems on old NVIDIA.
-	switch (vendor) {
-	case Draw::GPUVendor::VENDOR_INTEL:
-		break;
-	case Draw::GPUVendor::VENDOR_NVIDIA:
-		// Older NVIDIAs don't seem to like NaNs in their DX9 vertex shaders.
-		// No idea if KEPLER is the right cutoff, but let's go with it.
-		if (NVIDIAGetDeviceGeneration(draw_->GetDeviceCaps().deviceID) >= NV_KEPLER) {
+	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+		// VS range culling (killing triangles in the vertex shader using NaN) causes problems on Intel.
+		// Also causes problems on old NVIDIA.
+		switch (vendor) {
+		case Draw::GPUVendor::VENDOR_INTEL:
+			break;
+		case Draw::GPUVendor::VENDOR_NVIDIA:
+			// Older NVIDIAs don't seem to like NaNs in their DX9 vertex shaders.
+			// No idea if KEPLER is the right cutoff, but let's go with it.
+			if (NVIDIAGetDeviceGeneration(draw_->GetDeviceCaps().deviceID) >= NV_KEPLER) {
+				features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+			}
+			break;
+		default:
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+			break;
 		}
-		break;
-	default:
-		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
-		break;
 	}
 
 	D3DCAPS9 caps;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -149,7 +149,9 @@ void GPU_GLES::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
-		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+		if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+		}
 	}
 
 	if (gl_extensions.ARB_blend_func_extended || gl_extensions.EXT_blend_func_extended) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -181,7 +181,9 @@ GPU_Vulkan::~GPU_Vulkan() {
 void GPU_Vulkan::CheckGPUFeatures() {
 	uint32_t features = 0;
 
-	features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+	}
 
 	switch (vulkan_->GetPhysicalDeviceProperties().properties.vendorID) {
 	case VULKAN_VENDOR_AMD:


### PR DESCRIPTION
I'm not completely sure these really are related, but since the current vertex range culling has bugs with Phantasy Star 2 which also need the depthrange hack, we have at least a temporary workaround for #11576.