### PR TITLE
Hardcode the cheats that work around the Tony Hawk's Underground jit issues.

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -63,6 +63,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);
 	CheckSetting(iniFile, gameID, "ForceMax60FPS", &flags_.ForceMax60FPS);
+	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -63,6 +63,7 @@ struct CompatFlags {
 	bool YugiohSaveFix;
 	bool ForceUMDDelay;
 	bool ForceMax60FPS;
+	bool JitInvalidationHack;
 };
 
 class IniFile;

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -306,7 +306,7 @@ void hleCheat(u64 userdata, int cyclesLate) {
 		if (gameTitle == "ULUS10014") {
 			cheatEngine->InvalidateICache(0x08865600, 72);
 			cheatEngine->InvalidateICache(0x08865690, 4);
-		} else if (gameTitle == "ULES00033") {  // euro, also 34 and 35
+		} else if (gameTitle == "ULES00033" || gameTitle == "ULES00034" || gameTitle == "ULES00035") {  // euro, also 34 and 35
 			cheatEngine->InvalidateICache(0x088655D8, 72);
 			cheatEngine->InvalidateICache(0x08865668, 4);
 		} else if (gameTitle == "ULUS10138") {  // MTX MotoTrax. No hack for ULES00581 known.

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -237,6 +237,21 @@ static void __CheatStart() {
 	cheatsEnabled = true;
 }
 
+static int GetRefreshMs() {
+	int refresh = g_Config.iCwCheatRefreshRate;
+
+	if (!cheatsEnabled)
+		refresh = 1000;
+
+	// Horrible hack for Tony Hawk - Underground 2. See #3854. Avoids crashing somehow
+	// but still causes regular JIT invalidations which causes stutters.
+	if (PSP_CoreParameter().compat.flags().JitInvalidationHack) {
+		refresh = 2;
+	}
+
+	return refresh;
+}
+
 void __CheatInit() {
 	// Always register the event, want savestates to be compatible whether cheats on or off.
 	CheatEvent = CoreTiming::RegisterEvent("CheatEvent", &hleCheat);
@@ -245,10 +260,8 @@ void __CheatInit() {
 		__CheatStart();
 	}
 
-	int refresh = g_Config.iCwCheatRefreshRate;
-
 	// Only check once a second for cheats to be enabled.
-	CoreTiming::ScheduleEvent(msToCycles(cheatsEnabled ? refresh : 1000), CheatEvent, 0);
+	CoreTiming::ScheduleEvent(msToCycles(GetRefreshMs()), CheatEvent, 0);
 }
 
 void __CheatShutdown() {
@@ -264,13 +277,11 @@ void __CheatDoState(PointerWrap &p) {
 	p.Do(CheatEvent);
 	CoreTiming::RestoreRegisterEvent(CheatEvent, "CheatEvent", &hleCheat);
 
-	int refresh = g_Config.iCwCheatRefreshRate;
-
 	if (s < 2) {
 		// Before this we didn't have a checkpoint, so reset didn't work.
 		// Let's just force one in.
 		CoreTiming::RemoveEvent(CheatEvent);
-		CoreTiming::ScheduleEvent(msToCycles(cheatsEnabled ? refresh : 1000), CheatEvent, 0);
+		CoreTiming::ScheduleEvent(msToCycles(GetRefreshMs()), CheatEvent, 0);
 	}
 }
 
@@ -284,14 +295,30 @@ void hleCheat(u64 userdata, int cyclesLate) {
 		}
 	}
 
-	int refresh = g_Config.iCwCheatRefreshRate;
+	// Check periodically for cheats.
+	CoreTiming::ScheduleEvent(msToCycles(GetRefreshMs()), CheatEvent, 0);
 
-	// Only check once a second for cheats to be enabled.
-	CoreTiming::ScheduleEvent(msToCycles(cheatsEnabled ? refresh : 1000), CheatEvent, 0);
+	if (PSP_CoreParameter().compat.flags().JitInvalidationHack) {
+		std::string gameTitle = g_paramSFO.GetValueString("DISC_ID");
+
+		// Horrible hack for Tony Hawk - Underground 2. See #3854. Avoids crashing somehow
+		// but still causes regular JIT invalidations which causes stutters.
+		if (gameTitle == "ULUS10014") {
+			cheatEngine->InvalidateICache(0x08865600, 72);
+			cheatEngine->InvalidateICache(0x08865690, 4);
+		} else if (gameTitle == "ULES00033") {  // euro, also 34 and 35
+			cheatEngine->InvalidateICache(0x088655D8, 72);
+			cheatEngine->InvalidateICache(0x08865668, 4);
+		} else if (gameTitle == "ULUS10138") {  // MTX MotoTrax. No hack for ULES00581 known.
+			cheatEngine->InvalidateICache(0x0886DCC0, 72);
+			cheatEngine->InvalidateICache(0x0886DC20, 4);
+			cheatEngine->InvalidateICache(0x0886DD40, 4);
+		}
+	}
 
 	if (!cheatEngine || !cheatsEnabled)
 		return;
-	
+
 	if (g_Config.bReloadCheats) { //Checks if the "reload cheats" button has been pressed.
 		cheatEngine->ParseCheats();
 		g_Config.bReloadCheats = false;

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -45,8 +45,8 @@ public:
 	void Run();
 	bool HasCheats();
 
-private:
 	void InvalidateICache(u32 addr, int size);
+private:
 	u32 GetAddress(u32 value);
 
 	CheatOperation InterpretNextOp(const CheatCode &cheat, size_t &i);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -558,3 +558,16 @@ UCJS10019 = true
 # Tekken 6
 ULES01376 = true
 ULUS10466 = true
+
+[JitInvalidationHack]
+# This is an absolutely awful hack that somehow prevents issues when clearing the JIT,
+# if the game has copied code with EmuHack opcodes or something. Hopefully will be able
+# to remove this in the future.
+# See #3854.
+# Tony Hawk's Underground
+ULUS10014 = true
+ULES00033 = true
+ULES00034 = true
+ULES00035 = true
+# MTX MotoTrax
+ULUS10138 = true


### PR DESCRIPTION
Temporary, horrible hack working around #3854 and also #6544 affecting MTX MotoTrax (US version only)

Not proud of this but it will have to do for 1.8.0. Really want to finally have this game playable by default. Promise I will find a real or at least a better fix in the future....