### PR TITLE
UI: Pass touch/button releases to all screens

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -381,10 +381,7 @@ static void AfterStateBoot(SaveState::Status status, const std::string &message,
 void EmuScreen::sendMessage(const char *message, const char *value) {
 	// External commands, like from the Windows UI.
 	if (!strcmp(message, "pause") && screenManager()->topScreen() == this) {
-		releaseButtons();
 		screenManager()->push(new GamePauseScreen(gamePath_));
-	} else if (!strcmp(message, "lost_focus")) {
-		releaseButtons();
 	} else if (!strcmp(message, "stop")) {
 		// We will push MainScreen in update().
 		PSP_Shutdown();
@@ -420,15 +417,12 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		RecreateViews();
 	} else if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_PAUSEMENU);
-		releaseButtons();
 		screenManager()->push(new ControlMappingScreen());
 	} else if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_PAUSEMENU);
-		releaseButtons();
 		screenManager()->push(new DisplayLayoutScreen());
 	} else if (!strcmp(message, "settings") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_PAUSEMENU);
-		releaseButtons();
 		screenManager()->push(new GameSettingsScreen(gamePath_));
 	} else if (!strcmp(message, "gpu dump next frame")) {
 		if (gpu)
@@ -1001,7 +995,6 @@ void EmuScreen::CreateViews() {
 }
 
 UI::EventReturn EmuScreen::OnDevTools(UI::EventParams &params) {
-	releaseButtons();
 	I18NCategory *dev = GetI18NCategory("Developer");
 	DevMenu *devMenu = new DevMenu(dev);
 	if (params.v)
@@ -1060,7 +1053,6 @@ void EmuScreen::update() {
 	// This is here to support the iOS on screen back button.
 	if (pauseTrigger_) {
 		pauseTrigger_ = false;
-		releaseButtons();
 		screenManager()->push(new GamePauseScreen(gamePath_));
 	}
 
@@ -1372,15 +1364,6 @@ void EmuScreen::autoLoad() {
 		SaveState::LoadSlot(gamePath_, autoSlot, &AfterSaveStateAction);
 		g_Config.iCurrentStateSlot = autoSlot;
 	}
-}
-
-// TODO: Add generic loss-of-focus handling for Screens, use this.
-void EmuScreen::releaseButtons() {
-	TouchInput input;
-	input.flags = TOUCH_RELEASE_ALL;
-	input.timestamp = time_now_d();
-	input.id = 0;
-	touch(input);
 }
 
 void EmuScreen::resized() {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -66,8 +66,6 @@ private:
 	void setVKeyAnalogX(int stick, int virtualKeyMin, int virtualKeyMax);
 	void setVKeyAnalogY(int stick, int virtualKeyMin, int virtualKeyMax);
 
-	void releaseButtons();
-
 	void autoLoad();
 	void checkPowerDown();
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -157,8 +157,12 @@ public:
 			}
 		} else if (hovering_ && key.deviceId == DEVICE_ID_MOUSE && key.keyCode == NKCODE_EXT_MOUSEBUTTON_2) {
 			// If it's the right mouse button, and it's not otherwise mapped, show the info also.
-			if (key.flags & KEY_UP) {
+			if (key.flags & KEY_DOWN) {
+				showInfoPressed_ = true;
+			}
+			if ((key.flags & KEY_UP) && showInfoPressed_) {
 				showInfo = true;
+				showInfoPressed_ = false;
 			}
 		}
 
@@ -208,6 +212,7 @@ private:
 
 	double holdStart_ = 0.0;
 	bool holdEnabled_ = true;
+	bool showInfoPressed_ = false;
 	bool hovering_ = false;
 };
 


### PR DESCRIPTION
This way, if you go into a menu and release a button, it still gets noticed.  This also goes for axis centering (and therefore vkeys.)

Also, move TOUCH_RELEASE_ALL to all screen switches.  Might as well be consistent.

Fixes #4616.  I think this is a nice, simple way (as noted in the latest comment there.)

-[Unknown]