### PR TITLE
UI: Avoid using game info cache in savedata sort

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -110,27 +110,11 @@ bool GameInfo::Delete() {
 	}
 }
 
-static int64_t GetDirectoryRecursiveSize(const std::string &path) {
-	std::vector<FileInfo> fileInfo;
-	getFilesInDir(path.c_str(), &fileInfo);
-	int64_t sizeSum = 0;
-	// Note: getFileInDir does not fill in fileSize properly.
-	for (size_t i = 0; i < fileInfo.size(); i++) {
-		FileInfo finfo;
-		getFileInfo(fileInfo[i].fullName.c_str(), &finfo);
-		if (!finfo.isDirectory)
-			sizeSum += finfo.size;
-		else
-			sizeSum += GetDirectoryRecursiveSize(finfo.fullName);
-	}
-	return sizeSum;
-}
-
 u64 GameInfo::GetGameSizeInBytes() {
 	switch (fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return GetDirectoryRecursiveSize(ResolvePBPDirectory(filePath_));
+		return getDirectoryRecursiveSize(ResolvePBPDirectory(filePath_), nullptr, GETFILES_GETHIDDEN);
 
 	default:
 		return GetFileLoader()->FileSize();

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -297,6 +297,22 @@ size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const 
 	return foundEntries;
 }
 
+int64_t getDirectoryRecursiveSize(const std::string &path, const char *filter, int flags) {
+	std::vector<FileInfo> fileInfo;
+	getFilesInDir(path.c_str(), &fileInfo, filter, flags);
+	int64_t sizeSum = 0;
+	// Note: getFileInDir does not fill in fileSize properly.
+	for (size_t i = 0; i < fileInfo.size(); i++) {
+		FileInfo finfo;
+		getFileInfo(fileInfo[i].fullName.c_str(), &finfo);
+		if (!finfo.isDirectory)
+			sizeSum += finfo.size;
+		else
+			sizeSum += getDirectoryRecursiveSize(finfo.fullName, filter, flags);
+	}
+	return sizeSum;
+}
+
 #ifdef _WIN32
 // Returns a vector with the device names
 std::vector<std::string> getWindowsDrives()

--- a/ext/native/file/file_util.h
+++ b/ext/native/file/file_util.h
@@ -34,7 +34,8 @@ FILE *openCFile(const std::string &filename, const char *mode);
 enum {
 	GETFILES_GETHIDDEN = 1
 };
-size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const char *filter = 0, int flags = 0);
+size_t getFilesInDir(const char *directory, std::vector<FileInfo> *files, const char *filter = nullptr, int flags = 0);
+int64_t getDirectoryRecursiveSize(const std::string &path, const char *filter = nullptr, int flags = 0);
 
 #ifdef _WIN32
 std::vector<std::string> getWindowsDrives();


### PR DESCRIPTION
It can change mid-sort causing the sorting results to be inconsistent, which will crash many implementations of std::stable_sort.

Also, fix an issue where it kept resorting after it didn't need to and make it strictly ordered for equal dates/sizes.  And include hidden dotfiles in total size calculation, since they'd get deleted.

Fixes #11892.  I could see this going in for a 1.8.x but don't think it's necessary - the default sort is fine, and the alternate sort options have always had this bug.

-[Unknown]