### PR TITLE
TexCache: Align bufw properly even for VRAM

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -89,7 +89,7 @@ static const u32 textureAlignMask16[16] = {
 
 u32 GetTextureBufw(int level, u32 texaddr, GETextureFormat format) {
 	// This is a hack to allow for us to draw the huge PPGe texture, which is always in kernel ram.
-	if (texaddr < PSP_GetKernelMemoryEnd())
+	if (texaddr >= PSP_GetKernelMemoryBase() && texaddr < PSP_GetKernelMemoryEnd())
 		return gstate.texbufwidth[level] & 0x1FFF;
 
 	u32 bufw = gstate.texbufwidth[level] & textureAlignMask16[format];


### PR DESCRIPTION
Surprised this issue has been around so long, it's quite an old bug at this point...

Fixes minimap arrows in Manhunt 2 (see #9615.)  I'll say fixes #9615, although not sure if we care about the shadows being totally wrong (I think our shadows are better looking from that singular screenshot, but they aren't correct...)

-[Unknown]