### PR TITLE
Vulkan: Request cached memory for readbacks.

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -261,6 +261,7 @@ private:
 	VkDeviceMemory readbackMemory_ = VK_NULL_HANDLE;
 	VkBuffer readbackBuffer_ = VK_NULL_HANDLE;
 	VkDeviceSize readbackBufferSize_ = 0;
+	bool readbackBufferIsCoherent_ = false;
 
 	// TODO: Enable based on compat.ini.
 	uint32_t hacksEnabled_ = 0;


### PR DESCRIPTION
 First try coherent too but also support non-coherent cached memory through manual invalidation.

Should speed up readbacks slightly.

This is just a common sense optimization, I haven't measured it. Writes to
coherent non-cached memory is OK due to hardware write combining, but for
reads you really want cached to avoid a memory transaction for every
single read (instead reading full cache lines).

~~TODO: I need to test on ARM Mali before merging.~~