### PR TITLE
Correct prefixes for vbfy, vscl, vzero, vone, vidt

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1966,7 +1966,7 @@ namespace MIPSComp {
 		}
 
 		int subop = (op >> 16) & 0x1F;
-		if (subop == 3) {
+		if (subop == 3 && n == 4) {
 			// vbfy2
 			ir.Write(IROp::FAdd, tempregs[0], sregs[0], sregs[2]);
 			ir.Write(IROp::FAdd, tempregs[1], sregs[1], sregs[3]);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -553,13 +553,14 @@ namespace MIPSInt
 		ReadVector(s, sz, vs);
 
 		// S prefix forces the negate flags.
-		u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
-		ApplyPrefixST(s, sprefix | 0x000F0000, sz);
+		u32 sprefixAdd = VFPU_NEGATE(1, 1, 1, 1);
+		ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, 0, sprefixAdd), sz);
 
 		// T prefix forces constants on and regnum to 1.
 		// That means negate still works, and abs activates a different constant.
-		u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
-		ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x00000055 | 0x0000F000, sz);
+		u32 tprefixRemove = VFPU_ANY_SWIZZLE();
+		u32 tprefixAdd = VFPU_SWIZZLE(1, 1, 1, 1) | VFPU_CONST(1, 1, 1, 1);
+		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), sz);
 
 		for (int i = 0; i < GetNumVectorElements(sz); i++) {
 			// Always positive NaN.  Note that s is always negated from the registers.
@@ -582,13 +583,15 @@ namespace MIPSInt
 
 		// S prefix forces negate in even/odd and xxyy swizzle.
 		// abs works, and applies to final position (not source.)
-		u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
-		ApplyPrefixST(s, (sprefix & ~0x000F00FF) | 0x00000050 | 0x00050000, outSize);
+		u32 sprefixRemove = VFPU_ANY_SWIZZLE() | VFPU_NEGATE(1, 1, 1, 1);
+		u32 sprefixAdd = VFPU_SWIZZLE(0, 0, 1, 1) | VFPU_NEGATE(1, 0, 1, 0);
+		ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, sprefixRemove, sprefixAdd), outSize);
 
 		// T prefix forces constants on and regnum to 0, 1, 0, 1.
 		// That means negate still works, and abs activates a different constant.
-		u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
-		ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x00000011 | 0x0000F000, outSize);
+		u32 tprefixRemove = VFPU_ANY_SWIZZLE();
+		u32 tprefixAdd = VFPU_SWIZZLE(1, 0, 1, 0) | VFPU_CONST(1, 1, 1, 1);
+		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), outSize);
 
 		int n = GetNumVectorElements(sz);
 		// Essentially D prefix saturation is forced.
@@ -1057,13 +1060,14 @@ namespace MIPSInt
 		if (op & 0x10000) {
 			// vbfy2
 			// S prefix forces the negate flags (so z and w are negative.)
-			u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
-			ApplyPrefixST(s, sprefix | 0x000C0000, sz);
+			u32 sprefixAdd = VFPU_NEGATE(0, 0, 1, 1);
+			ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, 0, sprefixAdd), sz);
 
 			// T prefix forces swizzle (zwxy.)
 			// That means negate still works, but constants are a bit weird.
-			u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
-			ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x0000004E, sz);
+			u32 tprefixRemove = VFPU_ANY_SWIZZLE();
+			u32 tprefixAdd = VFPU_SWIZZLE(2, 3, 0, 1);
+			ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), sz);
 
 			// Other sizes don't seem completely predictable.
 			if (sz != V_Quad) {
@@ -1072,13 +1076,14 @@ namespace MIPSInt
 		} else {
 			// vbfy1
 			// S prefix forces the negate flags (so y and w are negative.)
-			u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
-			ApplyPrefixST(s, sprefix | 0x000A0000, sz);
+			u32 sprefixAdd = VFPU_NEGATE(0, 1, 0, 1);
+			ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, 0, sprefixAdd), sz);
 
 			// T prefix forces swizzle (yxwz.)
 			// That means negate still works, but constants are a bit weird.
-			u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
-			ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x000000B1, sz);
+			u32 tprefixRemove = VFPU_ANY_SWIZZLE();
+			u32 tprefixAdd = VFPU_SWIZZLE(1, 0, 3, 2);
+			ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), sz);
 
 			if (sz != V_Quad && sz != V_Pair) {
 				ERROR_LOG_REPORT_ONCE(vbfy2, CPU, "vfby1 with incorrect size");
@@ -1278,26 +1283,25 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_VScl(MIPSOpcode op)
-	{
-		float s[4];
-		float d[4];
+	void Int_VScl(MIPSOpcode op) {
+		float s[4], t[4], d[4];
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
 		ApplySwizzleS(s, sz);
-		float scale = V(vt);
-		if (currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX] != 0xE4)
-		{
-			// WARN_LOG(CPU, "Broken T prefix used with VScl: %08x / %08x", currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX], op);
-			ApplySwizzleT(&scale, V_Single);
-		}
+
+		// T prefix forces swizzle (zzzz for some reason, so we force V_Quad.)
+		// That means negate still works, but constants are a bit weird.
+		t[2] = V(vt);
+		u32 tprefixRemove = VFPU_ANY_SWIZZLE();
+		u32 tprefixAdd = VFPU_SWIZZLE(2, 2, 2, 2);
+		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
+
 		int n = GetNumVectorElements(sz);
-		for (int i = 0; i < n; i++)
-		{
-			d[i] = s[i] * scale;
+		for (int i = 0; i < n; i++) {
+			d[i] = s[i] * t[i];
 		}
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -373,26 +373,23 @@ namespace MIPSInt
 		PC += 4;
 	}
 
-	void Int_Viim(MIPSOpcode op)
-	{
+	void Int_Viim(MIPSOpcode op) {
 		int vt = _VT;
 		s32 imm = (s16)(op&0xFFFF);
 		u16 uimm16 = (op&0xFFFF);
-		//V(vt) = (float)imm;
 		float f[1];
 		int type = (op >> 23) & 7;
-		if (type == 6)
+		if (type == 6) {
 			f[0] = (float)imm;  // viim
-		else if (type == 7)
+		} else if (type == 7) {
 			f[0] = Float16ToFloat32((u16)uimm16);   // vfim
-		else
-		{
+		} else {
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
 			f[0] = 0;
 		}
 		
 		ApplyPrefixD(f, V_Single);
-		V(vt) = f[0];
+		WriteVector(f, V_Single, vt);
 		PC += 4;
 		EatPrefixes();
 	}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1045,33 +1045,51 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_Vbfy(MIPSOpcode op)
-	{
-		float s[4];
-		float d[4];
+	void Int_Vbfy(MIPSOpcode op) {
+		float s[4]{}, t[4]{}, d[4];
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
-		ApplySwizzleS(s, sz);
+		ReadVector(t, sz, vs);
+
 		int n = GetNumVectorElements(sz);
-		if (op & 0x10000)
-		{
+		if (op & 0x10000) {
 			// vbfy2
-			d[0] = s[0] + s[2];
-			d[1] = s[1] + s[3];
-			d[2] = s[0] - s[2];
-			d[3] = s[1] - s[3];
-		}
-		else
-		{
-			d[0] = s[0] + s[1];
-			d[1] = s[0] - s[1];
-			if (n == 4) {
-				d[2] = s[2] + s[3];
-				d[3] = s[2] - s[3];
+			// S prefix forces the negate flags (so z and w are negative.)
+			u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
+			ApplyPrefixST(s, sprefix | 0x000C0000, sz);
+
+			// T prefix forces swizzle (zwxy.)
+			// That means negate still works, but constants are a bit weird.
+			u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
+			ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x0000004E, sz);
+
+			// Other sizes don't seem completely predictable.
+			if (sz != V_Quad) {
+				ERROR_LOG_REPORT_ONCE(vbfy2, CPU, "vfby2 with incorrect size");
+			}
+		} else {
+			// vbfy1
+			// S prefix forces the negate flags (so y and w are negative.)
+			u32 sprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_SPREFIX];
+			ApplyPrefixST(s, sprefix | 0x000A0000, sz);
+
+			// T prefix forces swizzle (yxwz.)
+			// That means negate still works, but constants are a bit weird.
+			u32 tprefix = currentMIPS->vfpuCtrl[VFPU_CTRL_TPREFIX];
+			ApplyPrefixST(t, (tprefix & ~0x000000FF) | 0x000000B1, sz);
+
+			if (sz != V_Quad && sz != V_Pair) {
+				ERROR_LOG_REPORT_ONCE(vbfy2, CPU, "vfby1 with incorrect size");
 			}
 		}
+
+		d[0] = s[0] + t[0];
+		d[1] = s[1] + t[1];
+		d[2] = s[2] + t[2];
+		d[3] = s[3] + t[3];
+
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -176,19 +176,27 @@ void ReadVector(float *rd, VectorSize size, int reg) {
 }
 
 void WriteVector(const float *rd, VectorSize size, int reg) {
+	if (size == V_Single) {
+		// Optimize the common case.
+		if (!currentMIPS->VfpuWriteMask(0)) {
+			V(reg) = rd[0];
+		}
+		return;
+	}
+
+	const int mtx = (reg>>2)&7;
+	const int col = reg & 3;
+	int transpose = (reg>>5)&1;
 	int row = 0;
 	int length = 0;
 
 	switch (size) {
-	case V_Single: V(reg) = rd[0]; return; // transpose = 0; row=(reg>>5)&3; length = 1; break;
+	case V_Single: _dbg_assert_(JIT, 0); return; // transpose = 0; row=(reg>>5)&3; length = 1; break;
 	case V_Pair:   row=(reg>>5)&2; length = 2; break;
 	case V_Triple: row=(reg>>6)&1; length = 3; break;
 	case V_Quad:   row=(reg>>5)&2; length = 4; break;
 	default: _assert_msg_(JIT, 0, "%s: Bad vector size", __FUNCTION__);
 	}
-	const int mtx = (reg>>2)&7;
-	const int col = reg & 3;
-	int transpose = (reg>>5)&1;
 
 	if (currentMIPS->VfpuWriteMask() == 0) {
 		if (transpose) {

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -214,6 +214,11 @@ void WriteVector(const float *rd, VectorSize size, int reg) {
 	}
 }
 
+u32 VFPURewritePrefix(int ctrl, u32 remove, u32 add) {
+	u32 prefix = currentMIPS->vfpuCtrl[ctrl];
+	return (prefix & ~remove) | add;
+}
+
 void ReadMatrix(float *rd, MatrixSize size, int reg) {
 	int mtx = (reg >> 2) & 7;
 	int col = reg & 3;

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -144,6 +144,36 @@ static u32 VFPU_NEGATE(int x, int y, int z, int w) {
 	return VFPU_MASK(x, y, z, w) << 16;
 }
 
+enum class VFPUConst {
+	NONE = -1,
+	ZERO,
+	ONE,
+	TWO,
+	HALF,
+	THREE,
+	THIRD,
+	FOURTH,
+	SIXTH,
+};
+
+static u32 VFPU_MAKE_CONSTANTS(VFPUConst x, VFPUConst y, VFPUConst z, VFPUConst w) {
+	u32 result = 0;
+	if (x != VFPUConst::NONE) {
+		// This sets the constant flag and the swizzle/abs flags for the right constant.
+		result |= (((int)x & 3) << 0) | (((int)x & 4) << 6) | (1 << 12);
+	}
+	if (y != VFPUConst::NONE) {
+		result |= (((int)y & 3) << 2) | (((int)y & 4) << 7) | (1 << 13);
+	}
+	if (z != VFPUConst::NONE) {
+		result |= (((int)z & 3) << 4) | (((int)z & 4) << 8) | (1 << 14);
+	}
+	if (w != VFPUConst::NONE) {
+		result |= (((int)w & 3) << 6) | (((int)w & 4) << 9) | (1 << 15);
+	}
+	return result;
+}
+
 u32 VFPURewritePrefix(int ctrl, u32 remove, u32 add);
 
 void ReadMatrix(float *rd, MatrixSize size, int reg);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -120,6 +120,32 @@ enum MatrixSize {
 	M_Invalid = -1
 };
 
+static u32 VFPU_SWIZZLE(int x, int y, int z, int w) {
+	return (x << 0) | (y << 2) | (z << 4) | (w << 6);
+}
+
+static u32 VFPU_MASK(int x, int y, int z, int w) {
+	return (x << 0) | (y << 1) | (z << 2) | (w << 3);
+}
+
+static u32 VFPU_ANY_SWIZZLE() {
+	return 0x000000FF;
+}
+
+static u32 VFPU_ABS(int x, int y, int z, int w) {
+	return VFPU_MASK(x, y, z, w) << 8;
+}
+
+static u32 VFPU_CONST(int x, int y, int z, int w) {
+	return VFPU_MASK(x, y, z, w) << 12;
+}
+
+static u32 VFPU_NEGATE(int x, int y, int z, int w) {
+	return VFPU_MASK(x, y, z, w) << 16;
+}
+
+u32 VFPURewritePrefix(int ctrl, u32 remove, u32 add);
+
 void ReadMatrix(float *rd, MatrixSize size, int reg);
 void WriteMatrix(const float *rs, MatrixSize size, int reg);
 


### PR DESCRIPTION
Also, apply the write mask in interp to single lane ops (would be a weird nop though, so unlikely.)

Note: these changes generally only affect the interpreter.  Broken off of #11948.

-[Unknown]