### PR TITLE
Fix vmfvc, vfim -nan, and improve size/swizzle on vh2f/vf2h/vrnds/vdiv

### DIFF
--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1333,16 +1333,16 @@ namespace MIPSComp
 		NEON_IF_AVAILABLE(CompNEON_Vmtvc);
 		CONDITIONAL_DISABLE(VFPU_XFER);
 
-		int vs = _VS;
-		int imm = op & 0xFF;
+		int vd = _VD;
+		int imm = (op >> 8) & 0xFF;
 		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
-			fpr.MapRegV(vs);
+			fpr.MapRegV(vd);
 			if (imm - 128 == VFPU_CTRL_CC) {
 				gpr.MapReg(MIPS_REG_VFPUCC, 0);
-				VMOV(fpr.V(vs), gpr.R(MIPS_REG_VFPUCC));
+				VMOV(fpr.V(vd), gpr.R(MIPS_REG_VFPUCC));
 			} else {
 				ADDI2R(SCRATCHREG1, CTXREG, offsetof(MIPSState, vfpuCtrl[0]) + (imm - 128) * 4, SCRATCHREG2);
-				VLDR(fpr.V(vs), SCRATCHREG1, 0);
+				VLDR(fpr.V(vd), SCRATCHREG1, 0);
 			}
 			fpr.ReleaseSpillLocksAndDiscardTemps();
 		}

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1066,16 +1066,16 @@ namespace MIPSComp {
 	void Arm64Jit::Comp_Vmfvc(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_XFER);
 
-		int vs = _VS;
-		int imm = op & 0xFF;
+		int vd = _VD;
+		int imm = (op >> 8) & 0xFF;
 		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
-			fpr.MapRegV(vs);
+			fpr.MapRegV(vd);
 			if (imm - 128 == VFPU_CTRL_CC) {
 				gpr.MapReg(MIPS_REG_VFPUCC, 0);
-				fp.FMOV(fpr.V(vs), gpr.R(MIPS_REG_VFPUCC));
+				fp.FMOV(fpr.V(vd), gpr.R(MIPS_REG_VFPUCC));
 			} else {
 				ADDI2R(SCRATCH1_64, CTXREG, offsetof(MIPSState, vfpuCtrl[0]) + (imm - 128) * 4, SCRATCH2);
-				fp.LDR(32, INDEX_UNSIGNED, fpr.V(vs), SCRATCH1_64, 0);
+				fp.LDR(32, INDEX_UNSIGNED, fpr.V(vd), SCRATCH1_64, 0);
 			}
 			fpr.ReleaseSpillLocksAndDiscardTemps();
 		}

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -930,6 +930,9 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_Vh2f(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
+		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op)) {
+			DISABLE;
+		}
 
 		// Vector expand half to float
 		// d[N*2] = float(lowerhalf(s[N])), d[N*2+1] = float(upperhalf(s[N]))

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1018,13 +1018,13 @@ namespace MIPSComp {
 		CONDITIONAL_DISABLE(VFPU_XFER);
 
 		// Vector Move from vector control reg (no prefixes)
-		// S[0] = VFPU_CTRL[i]
+		// D[0] = VFPU_CTRL[i]
 
-		int vs = _VS;
-		int imm = op & 0xFF;
+		int vd = _VD;
+		int imm = (op >> 8) & 0xFF;
 		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
 			ir.Write(IROp::VfpuCtrlToReg, IRTEMP_0, imm - 128);
-			ir.Write(IROp::FMovFromGPR, vfpuBase + voffset[vs], IRTEMP_0);
+			ir.Write(IROp::FMovFromGPR, vfpuBase + voffset[vd], IRTEMP_0);
 		} else {
 			INVALIDOP;
 		}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1495,7 +1495,7 @@ namespace MIPSInt
 			if (rt != 0) {
 				if (imm < 128) {
 					R(rt) = VI(imm);
-				} else if (imm < 128 + VFPU_CTRL_MAX) { //mtvc
+				} else if (imm < 128 + VFPU_CTRL_MAX) { //mfvc
 					R(rt) = currentMIPS->vfpuCtrl[imm - 128];
 				} else {
 					//ERROR - maybe need to make this value too an "interlock" value?
@@ -1526,10 +1526,10 @@ namespace MIPSInt
 	}
 
 	void Int_Vmfvc(MIPSOpcode op) {
-		int vs = _VS;
-		int imm = op & 0xFF;
+		int vd = _VD;
+		int imm = (op >> 8) & 0xFF;
 		if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
-			VI(vs) = currentMIPS->vfpuCtrl[imm - 128];
+			VI(vd) = currentMIPS->vfpuCtrl[imm - 128];
 		}
 		PC += 4;
 	}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1327,31 +1327,33 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_Vrnds(MIPSOpcode op)
-	{
+	void Int_Vrnds(MIPSOpcode op) {
 		int vd = _VD;
 		int seed = VI(vd);
+		// Swizzles apply a constant value, constants/abs/neg work to vary the seed.
+		ApplySwizzleS(reinterpret_cast<float *>(&seed), V_Single);
 		currentMIPS->rng.Init(seed);
 		PC += 4;
 		EatPrefixes();
 	}
 
-	void Int_VrndX(MIPSOpcode op)
-	{
+	void Int_VrndX(MIPSOpcode op) {
 		FloatBits d;
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
-		for (int i = 0; i < n; i++)
-		{
-			switch ((op >> 16) & 0x1f)
-			{
+		for (int i = 0; i < n; i++) {
+			switch ((op >> 16) & 0x1f) {
 			case 1: d.u[i] = currentMIPS->rng.R32(); break;  // vrndi
 			case 2: d.f[i] = 1.0f + ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf1   TODO: make more accurate
 			case 3: d.f[i] = 2.0f + 2 * ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf2   TODO: make more accurate
 			default: _dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
 			}
 		}
+		// D prefix is broken and applies to the last element only (mask and sat.)
+		u32 lastmask = (currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] & (1 << 8)) << (n - 1);
+		u32 lastsat = (currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] & 3) << (n + n - 2);
+		currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] = lastmask | lastsat;
 		ApplyPrefixD(d.f, sz);
 		WriteVector(d.f, sz, vd);
 		PC += 4;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1803,51 +1803,64 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_VecDo3(MIPSOpcode op)
-	{
+	void Int_VecDo3(MIPSOpcode op) {
+		float s[4], t[4], d[4];
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
-		float s[4];
-		float t[4];
-		float d[4];
+
+		int optype = 0;
+		switch (op >> 26) {
+		case 24: //VFPU0
+			switch ((op >> 23) & 7) {
+			case 0: optype = 0; break;
+			case 1: optype = 1; break;
+			case 7: optype = 7; break;
+			default: goto bad;
+			}
+			break;
+		case 25: //VFPU1
+			switch ((op >> 23) & 7) {
+			case 0: optype = 8; break;
+			default: goto bad;
+			}
+			break;
+		default:
+		bad:
+			_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+			break;
+		}
+
+		int n = GetNumVectorElements(sz);
 		ReadVector(s, sz, vs);
-		ApplySwizzleS(s, sz);
 		ReadVector(t, sz, vt);
-		ApplySwizzleT(t, sz);
-		for (int i = 0; i < GetNumVectorElements(sz); i++)
-		{
-			switch(op >> 26)
-			{
-			case 24: //VFPU0
-				switch ((op >> 23)&7)
-				{
-				case 0: d[i] = s[i] + t[i]; break; //vadd
-				case 1: d[i] = s[i] - t[i]; break; //vsub
-				case 7: d[i] = s[i] / t[i]; break; //vdiv
-				default: goto bad;
-				}
-				break;
-			case 25: //VFPU1
-				switch ((op >> 23)&7)
-				{
-				case 0: d[i] = s[i] * t[i]; break; //vmul
-				default: goto bad;
-				}
-				break;
-			default:
-bad:
-				_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
-				break;
+		if (optype != 7) {
+			ApplySwizzleS(s, sz);
+			ApplySwizzleT(t, sz);
+		} else {
+			// The prefix handling of S/T is a bit odd, probably the HW doesn't do it in parallel.
+			// The X prefix is applied to the last element in sz.
+			ApplySwizzleS(&s[n - 1], V_Single);
+			ApplySwizzleT(&t[n - 1], V_Single);
+		}
+
+		for (int i = 0; i < n; i++) {
+			switch (optype) {
+			case 0: d[i] = s[i] + t[i]; break; //vadd
+			case 1: d[i] = s[i] - t[i]; break; //vsub
+			case 7: d[i] = s[i] / t[i]; break; //vdiv
+			case 8: d[i] = s[i] * t[i]; break; //vmul
 			}
 		}
-		ApplyPrefixD(d, sz);
+
+		// The D prefix (even mask) is ignored by vdiv only (vmul, etc. do apply it.)
+		if (optype != 7)
+			ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;
 		EatPrefixes();
 	}
-
 	
 	void Int_CrossQuat(MIPSOpcode op)
 	{

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -717,8 +717,7 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_Vh2f(MIPSOpcode op)
-	{
+	void Int_Vh2f(MIPSOpcode op) {
 		u32 s[4];
 		float d[4];
 		int vd = _VD;
@@ -735,15 +734,13 @@ namespace MIPSInt
 			d[1] = ExpandHalf(s[0] >> 16);
 			break;
 		case V_Pair:
+		default:
+			// All other sizes are treated the same.
 			outsize = V_Quad;
 			d[0] = ExpandHalf(s[0] & 0xFFFF);
 			d[1] = ExpandHalf(s[0] >> 16);
 			d[2] = ExpandHalf(s[1] & 0xFFFF);
 			d[3] = ExpandHalf(s[1] >> 16);
-			break;
-		default:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret Int_Vh2f instruction that can't be interpreted");
-			memset(d, 0, sizeof(d));
 			break;
 		}
 		ApplyPrefixD(d, outsize);
@@ -752,31 +749,29 @@ namespace MIPSInt
 		EatPrefixes();
 	}
 
-	void Int_Vf2h(MIPSOpcode op)
-	{
-		float s[4];
+	void Int_Vf2h(MIPSOpcode op) {
+		float s[4]{};
 		u32 d[4];
 		int vd = _VD;
 		int vs = _VS;
 		VectorSize sz = GetVecSize(op);
 		ReadVector(s, sz, vs);
-		ApplySwizzleS(s, sz);
+		// Swizzle can cause V_Single to properly write both components.
+		// TODO: Minor, but negate shouldn't apply to invalid here.  Maybe always?
+		ApplySwizzleS(s, V_Quad);
 		
 		VectorSize outsize = V_Single;
 		switch (sz) {
+		case V_Single:
 		case V_Pair:
 			outsize = V_Single;
 			d[0] = ShrinkToHalf(s[0]) | ((u32)ShrinkToHalf(s[1]) << 16);
 			break;
+		case V_Triple:
 		case V_Quad:
 			outsize = V_Pair;
 			d[0] = ShrinkToHalf(s[0]) | ((u32)ShrinkToHalf(s[1]) << 16);
 			d[1] = ShrinkToHalf(s[2]) | ((u32)ShrinkToHalf(s[3]) << 16);
-			break;
-		default:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret Int_Vf2h instruction that can't be interpreted");
-			d[0] = 0;
-			d[1] = 0;
 			break;
 		}
 		ApplyPrefixD(reinterpret_cast<float *>(d), outsize);

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -573,19 +573,17 @@ float Float16ToFloat32(unsigned short l)
 	int exponent = (float16 >> VFPU_SH_FLOAT16_EXP) & VFPU_MASK_FLOAT16_EXP;
 	unsigned int fraction = float16 & VFPU_MASK_FLOAT16_FRAC;
 
-	float signf = (sign == 1) ? -1.0f : 1.0f;
-
 	float f;
 	if (exponent == VFPU_FLOAT16_EXP_MAX)
 	{
-		if (fraction == 0)
-			f = std::numeric_limits<float>::infinity(); //(*info->fprintf_func) (info->stream, "%cInf", signchar);
-		else
-			f = std::numeric_limits<float>::quiet_NaN(); //(*info->fprintf_func) (info->stream, "%cNaN", signchar);
+		float2int.i = sign << 31;
+		float2int.i |= 255 << 23;
+		float2int.i |= fraction;
+		f = float2int.f;
 	}
 	else if (exponent == 0 && fraction == 0)
 	{
-		f = 0.0f * signf;
+		f = sign == 1 ? -0.0f : 0.0f;
 	}
 	else
 	{

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -35,7 +35,7 @@ inline int Xpose(int v) {
 
 // Some games depend on exact values, but sinf() and cosf() aren't always precise.
 // Stepping down to [0, 2pi) helps, but we also check common exact-result values.
-// TODO: cos(2) and sin(1) should be -0.0, but doing that gives wrong results (possibly from floorf.)
+// TODO: cos(1) and sin(2) should be -0.0, but doing that gives wrong results (possibly from floorf.)
 
 inline float vfpu_sin(float angle) {
 	angle -= floorf(angle * 0.25f) * 4.f;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2528,15 +2528,15 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 
 void Jit::Comp_Vmfvc(MIPSOpcode op) {
 	CONDITIONAL_DISABLE(VFPU_XFER);
-	int vs = _VS;
-	int imm = op & 0xFF;
+	int vd = _VD;
+	int imm = (op >> 8) & 0xFF;
 	if (imm >= 128 && imm < 128 + VFPU_CTRL_MAX) {
-		fpr.MapRegV(vs, MAP_DIRTY | MAP_NOINIT);
+		fpr.MapRegV(vd, MAP_DIRTY | MAP_NOINIT);
 		if (imm - 128 == VFPU_CTRL_CC) {
 			gpr.MapReg(MIPS_REG_VFPUCC, true, false);
-			MOVD_xmm(fpr.VX(vs), gpr.R(MIPS_REG_VFPUCC));
+			MOVD_xmm(fpr.VX(vd), gpr.R(MIPS_REG_VFPUCC));
 		} else {
-			MOVSS(fpr.VX(vs), MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128));
+			MOVSS(fpr.VX(vd), MIPSSTATE_VAR_ELEM32(vfpuCtrl[0], imm - 128));
 		}
 		fpr.ReleaseSpillLocks();
 	}


### PR DESCRIPTION
Split off #11948 and only really impacts interpreter.

The vdiv prefix handling isn't perfect, but you can see its weird lane behavior here.

The vmfvc op was just broken, but is probably rarely used.  The vfim change fixes the sign of infinity most importantly, and also nan.

Also some wiring to zero in here.

-[Unknown]