### PR TITLE
GPU: Improve non dual source stencil replace

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1171,7 +1171,13 @@ void ConvertBlendState(GenericBlendState &blendState, bool allowShaderBlend) {
 			break;
 		}
 	} else if (!IsStencilTestOutputDisabled()) {
-		switch (ReplaceAlphaWithStencilType()) {
+		StencilValueType stencilValue = ReplaceAlphaWithStencilType();
+		if (stencilValue == STENCIL_VALUE_UNIFORM && constantAlpha == 0x00) {
+			stencilValue = STENCIL_VALUE_ZERO;
+		} else if (stencilValue == STENCIL_VALUE_UNIFORM && constantAlpha == 0xFF) {
+			stencilValue = STENCIL_VALUE_ONE;
+		}
+		switch (stencilValue) {
 		case STENCIL_VALUE_KEEP:
 			blendState.setFactors(glBlendFuncA, glBlendFuncB, BlendFactor::ZERO, BlendFactor::ONE);
 			break;


### PR DESCRIPTION
If we're replacing with a constant FF, we can make it work more often.  Fixes #11249.

In the scenario of that game, the dest alpha is already FF, but the source alpha is some low value.  We previously used the `STENCIL_VALUE_UNIFORM` path which took `a = ONE * low value + ZERO * FF`.  This makes it use the `STENCIL_VALUE_ONE` path for `a = ONE * low value + ONE * FF`.

The 00 case is probably not really different, because as I was typing this I realized `constantAlphaGL` would be ZERO and not an actual constant 00 which PowerVR can't handle... still probably better to have a consistent path.

Didn't change the function logic because it might be better to more consistently use a uniform and less shader variations.

-[Unknown]