### PR TITLE
Make sceMp3 more accurate, fix wrong output count

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -495,15 +495,16 @@ static int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32
 }
 
 static int sceMp3NotifyAddStreamData(u32 mp3, int size) {
-	DEBUG_LOG(ME, "sceMp3NotifyAddStreamData(%08X, %i)", mp3, size);
-
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
-		ERROR_LOG(ME, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
-		return -1;
+		if (mp3 >= MP3_MAX_HANDLES)
+			return hleLogError(ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "unreserved handle");
+	} else if (ctx->AuBuf == 0) {
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return ctx->AuNotifyAddStreamData(size);
+	return hleLogSuccessI(ME, ctx->AuNotifyAddStreamData(size));
 }
 
 static int sceMp3ReleaseMp3Handle(u32 mp3) {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -27,6 +27,7 @@
 #include "Core/Reporting.h"
 #include "Core/HW/SimpleAudioDec.h"
 
+static const u32 ERROR_MP3_RESOURCE_NOT_INIT = 0x80671201;
 
 struct Mp3Context {
 public:
@@ -186,6 +187,10 @@ static int sceMp3CheckStreamDataNeeded(u32 mp3) {
 }
 
 static u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
+	if (!resourceInited) {
+		return hleLogError(ME, ERROR_MP3_RESOURCE_NOT_INIT, "sceMp3InitResource must be called first");
+	}
+
 	INFO_LOG(ME, "sceMp3ReserveMp3Handle(%08x)", mp3Addr);
 	if (!Memory::IsValidAddress(mp3Addr)){
 		ERROR_LOG(ME, "sceMp3ReserveMp3Handle(%08x) invalid address %08x", mp3Addr, mp3Addr);
@@ -526,8 +531,8 @@ static u32 sceMp3ResetPlayPositionByFrame(u32 mp3, int position) {
 	return ctx->AuResetPlayPositionByFrame(position);
 }
 
-static u32 sceMp3LowLevelInit(u32 mp3) {
-	INFO_LOG(ME, "sceMp3LowLevelInit(%i)", mp3);
+static u32 sceMp3LowLevelInit(u32 mp3, u32 unk) {
+	INFO_LOG(ME, "sceMp3LowLevelInit(%i, %i)", mp3, unk);
 	auto ctx = new AuCtx;
 
 	ctx->audioType = PSP_CODEC_MP3;
@@ -597,7 +602,7 @@ const HLEFunction sceMp3[] = {
 	{0XAE6D2027, &WrapU_U<sceMp3GetMPEGVersion>,            "sceMp3GetMPEGVersion",           'x', "x"    },
 	{0X3548AEC8, &WrapU_U<sceMp3GetFrameNum>,               "sceMp3GetFrameNum",              'x', "x"    },
 	{0X0840E808, &WrapU_UI<sceMp3ResetPlayPositionByFrame>, "sceMp3ResetPlayPositionByFrame", 'x', "xi"   },
-	{0X1B839B83, &WrapU_U<sceMp3LowLevelInit>,              "sceMp3LowLevelInit",             'x', "x"    },
+	{0X1B839B83, &WrapU_UU<sceMp3LowLevelInit>,             "sceMp3LowLevelInit",             'x', "xx"   },
 	{0XE3EE2C81, &WrapU_UUUUU<sceMp3LowLevelDecode>,        "sceMp3LowLevelDecode",           'x', "xxxxx"}
 };
 

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -136,7 +136,6 @@ void __Mp3DoState(PointerWrap &p) {
 			mp3->readPos = mp3_old->readPosition;
 			mp3->AuBufAvailable = 0; // reset to read from file
 			mp3->askedReadSize = 0;
-			mp3->realReadSize = 0;
 
 			mp3->audioType = PSP_CODEC_MP3;
 			mp3->decoder = new SimpleAudio(mp3->audioType);

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -298,11 +298,6 @@ AuCtx::AuCtx() {
 	PCMBuf = 0;
 	PCMBufSize = 2048;
 	AuBufAvailable = 0;
-	SamplingRate = 44100;
-	freq = SamplingRate;
-	BitRate = 0;
-	Channels = 2;
-	Version = 0;
 	SumDecodedSamples = 0;
 	MaxOutputSample = 0;
 	askedReadSize = 0;

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -299,7 +299,6 @@ AuCtx::AuCtx() {
 	PCMBufSize = 2048;
 	AuBufAvailable = 0;
 	SumDecodedSamples = 0;
-	MaxOutputSample = 0;
 	askedReadSize = 0;
 	audioType = 0;
 	FrameNum = 0;

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -138,7 +138,7 @@ public:
 	// State variables. These should be relatively easy to move into private.
 	u32 SumDecodedSamples;
 	int LoopNum;
-	u32 MaxOutputSample;
+	u32 MaxOutputSample = 0;
 	int FrameNum; // number of decoded frame
 
 	// Au decoder

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -99,6 +99,7 @@ public:
 
 	u32 AuNotifyAddStreamData(int size);
 	int AuCheckStreamDataNeeded();
+	int AuStreamBytesNeeded();
 	u32 AuResetPlayPosition();
 	u32 AuResetPlayPositionByFrame(int position);
 

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -100,6 +100,7 @@ public:
 	u32 AuNotifyAddStreamData(int size);
 	int AuCheckStreamDataNeeded();
 	int AuStreamBytesNeeded();
+	int AuStreamWorkareaSize();
 	u32 AuResetPlayPosition();
 	u32 AuResetPlayPositionByFrame(int position);
 

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -105,7 +105,7 @@ public:
 	u32 AuSetLoopNum(int loop);
 	u32 AuGetLoopNum();
 
-	u32 AuGetInfoToAddStreamData(u32 buff, u32 size, u32 srcPos);
+	u32 AuGetInfoToAddStreamData(u32 bufPtr, u32 sizePtr, u32 srcPosPtr);
 	u32 AuGetMaxOutputSample() const { return MaxOutputSample; }
 	u32 AuGetSumDecodedSample() const { return SumDecodedSamples; }
 	int AuGetChannelNum() const { return Channels; }
@@ -149,7 +149,6 @@ public:
 	int AuBufAvailable; // the available buffer of AuBuf to be able to recharge data
 	int readPos; // read position in audio source file
 	int askedReadSize; // the size of data requied to be read from file by the game
-	int realReadSize; // the really read size from file
 
 private:
 	std::string sourcebuff; // source buffer

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -129,11 +129,11 @@ public:
 	u32 AuBufSize;
 	u32 PCMBuf;
 	u32 PCMBufSize;
-	int freq;
-	int BitRate;
-	int SamplingRate;
-	int Channels;
-	int Version;
+	int freq = -1;
+	int BitRate = 0;
+	int SamplingRate = -1;
+	int Channels = 0;
+	int Version = -1;
 
 	// State variables. These should be relatively easy to move into private.
 	u32 SumDecodedSamples;


### PR DESCRIPTION
This is based on the tests in hrydgard/pspautotests#198.

The most important change here is the one to `sceMp3GetMaxOutputSample()`.  Before, this simply returned 1/4 of the provided buffer (so, size of buffer in shorts, stereo.)  But the function is actually supposed to return the frame size.  On a PSP, I can only make it produce 1152.

Some games use this value to determine how much to read after decode.  Most games had enough space for 2 frames because that's the minimum size of the output buffer, which I suspect is why the "sound speed hack" helped.  Some games (like Orbit) rely on the "knowledge" that a frame is 1152, and don't call this function.

I suspect this will help #9379, but I only have limited games to verify with.

Other than that, this only touches/improves the tested functions, but fixes a few things:

 * Correct error codes throughout tested functions.
 * Reschedule on init functions more correctly.
 * Allocate handles as 0 and 1 only, which could've been relied on by a game as an array index.
 * Only modify stream metadata in `sceMp3NotifyAddStreamData()`, not `sceMp3GetInfoToAddStreamData()` (which is just a read only getter.)  May fix games that call GetInfo multiple times per add.
 * Ask for less data, better matching what the PSP asks for (still not exactly right, since after the initial filling, it should only ask for half the buffer at a time.)
 * Release handles on `sceMp3TermResource()`.
 * Allow mp3 frames to be offset within provided data (search for sync marker.)
 * Reject invalid mp3 frame headers (left it more forgiving than on a PSP.)

-[Unknown]