### PR TITLE
Correct mp3 looping, frame num, and sum decoded

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -452,15 +452,16 @@ static int sceMp3Init(u32 mp3) {
 }
 
 static int sceMp3GetLoopNum(u32 mp3) {
-	DEBUG_LOG(ME, "sceMp3GetLoopNum(%08x)", mp3);
-
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
-		ERROR_LOG(ME, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
-		return -1;
+		if (mp3 >= MP3_MAX_HANDLES)
+			return hleLogError(ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "unreserved handle");
+	} else if (ctx->AuBuf == 0) {
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return ctx->AuGetLoopNum();
+	return hleLogSuccessI(ME, ctx->AuGetLoopNum());
 }
 
 static int sceMp3GetMaxOutputSample(u32 mp3) {
@@ -491,15 +492,19 @@ static int sceMp3GetSumDecodedSample(u32 mp3) {
 }
 
 static int sceMp3SetLoopNum(u32 mp3, int loop) {
-	INFO_LOG(ME, "sceMp3SetLoopNum(%08X, %i)", mp3, loop);
-
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
-		ERROR_LOG(ME, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
-		return -1;
+		if (mp3 >= MP3_MAX_HANDLES)
+			return hleLogError(ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "unreserved handle");
+	} else if (ctx->AuBuf == 0) {
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return ctx->AuSetLoopNum(loop);
+	if (loop < 0)
+		loop = -1;
+
+	return hleLogSuccessI(ME, ctx->AuSetLoopNum(loop));
 }
 
 static int sceMp3GetMp3ChannelNum(u32 mp3) {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -487,15 +487,16 @@ static int sceMp3GetMaxOutputSample(u32 mp3) {
 }
 
 static int sceMp3GetSumDecodedSample(u32 mp3) {
-	INFO_LOG(ME, "sceMp3GetSumDecodedSample(%08X)", mp3);
-
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
-		ERROR_LOG(ME, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
-		return -1;
+		if (mp3 >= MP3_MAX_HANDLES)
+			return hleLogError(ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "unreserved handle");
+	} else if (ctx->AuBuf == 0) {
+		return hleLogError(ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return ctx->AuGetSumDecodedSample();
+	return hleLogSuccessI(ME, ctx->AuGetSumDecodedSample());
 }
 
 static int sceMp3SetLoopNum(u32 mp3, int loop) {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -91,7 +91,7 @@ public:
 };
 
 static std::map<u32, AuCtx *> mp3Map;
-static const int mp3DecodeDelay = 4000;
+static const int mp3DecodeDelay = 2400;
 static bool resourceInited = false;
 
 static AuCtx *getMp3Ctx(u32 mp3) {
@@ -163,9 +163,9 @@ static int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	}
 		
 	int pcmBytes = ctx->AuDecode(outPcmPtr);
-	if (!pcmBytes) {
+	if (pcmBytes > 0) {
 		// decode data successfully, delay thread
-		hleDelayResult(pcmBytes, "mp3 decode", mp3DecodeDelay);
+		return hleDelayResult(pcmBytes, "mp3 decode", mp3DecodeDelay);
 	}
 	return pcmBytes;
 }

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -388,7 +388,7 @@ static int sceMp3Init(u32 mp3) {
 	for (int offset = 0; offset < 1440; ++offset) {
 		header = ParseMp3Header(ctx, offset, &hasID3Tag);
 		// If we hit valid sync bits, then we've found a header.
-		if (((header >> 21) & 0x0FFE) == 0x0FFE) {
+		if ((header & 0xFFC00000) == 0xFFC00000) {
 			// Ignore the data before that.
 			ctx->EatSourceBuff(offset);
 			break;
@@ -398,7 +398,7 @@ static int sceMp3Init(u32 mp3) {
 	static const int PARSE_DELAY_MS = 500;
 
 	// Couldn't find a header after all?
-	if (((header >> 21) & 0x0FFE) != 0x0FFE) {
+	if ((header & 0xFFC00000) != 0xFFC00000) {
 		return hleDelayResult(hleLogWarning(ME, ERROR_AVCODEC_INVALID_DATA, "no header found"), "mp3 init", PARSE_DELAY_MS);
 	}
 
@@ -427,12 +427,9 @@ static int sceMp3Init(u32 mp3) {
 	// this is very important for ID3 tag mp3, since our universal audio decoder is for decoding stream part only.
 	if (hasID3Tag) {
 		// if get ID3 tage, we will decode from 0x400
+		// TODO: This doesn't seem right.
 		ctx->startPos = 0x400;
 		ctx->EatSourceBuff(0x400);
-	} else {
-		// if no ID3 tag, we will decode from the begining of the file
-		// TODO: This seems wrong, since it's an init parameter?
-		ctx->startPos = 0;
 	}
 
 	DEBUG_LOG(ME, "sceMp3Init(): channels=%i, samplerate=%iHz, bitrate=%ikbps", ctx->Channels, ctx->SamplingRate, ctx->BitRate);

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -335,8 +335,8 @@ u32 AuCtx::AuDecode(u32 pcmAddr)
 				readPos = startPos;
 			}
 		} else {
-			// count total output samples
-			SumDecodedSamples += decoder->GetOutSamples();
+			// Update our total decoded samples, but don't count stereo.
+			SumDecodedSamples += decoder->GetOutSamples() / 2;
 			// get consumed source length
 			int srcPos = decoder->GetSourcePos();
 			// remove the consumed source

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -153,6 +153,8 @@ public:
 	int askedReadSize; // the size of data requied to be read from file by the game
 
 private:
+	size_t FindNextMp3Sync();
+
 	std::string sourcebuff; // source buffer
 };
 


### PR DESCRIPTION
Highlights:

 * sceMp3GetFrameNum returns the number of frames the file holds based on its size.
   Note: per hrydgard/pspautotests#199, vbr Xing/Info/etc. isn't handled.
 * sceMp3GetSumDecodedSample should reset to 0 on loop, and isn't doubled for stereo.
 * Looping was being performed in sceMp3NotifyAddStreamData, which my tests show is incorrect.  Both loop and sum decoded go down after decode.
 * If sceMp3Decode was given data before a sync, it would just fail, rather than correctly seeking ahead to the sync.  This may improve playback of some mp3 files.
 * sceMp3Decode was not rescheduling properly, and the delay was too high (much higher than my tests show.)
 * Setting any negative loop count should read only as -1.

All based on tests in hrydgard/pspautotests#199.  Note: some of the tests don't pass, but only due to sceMp3LowLevelInit rescheduling issues.  I still wanted to keep that in the tests to verify error behavior with low level streams.

-[Unknown]