### PR TITLE
Fix mp3 reset handling, use frame sync for ID3

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -171,15 +171,16 @@ static int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 }
 
 static int sceMp3ResetPlayPosition(u32 mp3) {
-	DEBUG_LOG(ME, "SceMp3ResetPlayPosition(%08x)", mp3);
-
 	AuCtx *ctx = getMp3Ctx(mp3);
 	if (!ctx) {
-		ERROR_LOG(ME, "%s: bad mp3 handle %08x", __FUNCTION__, mp3);
-		return -1;
+		if (mp3 >= MP3_MAX_HANDLES)
+			return hleLogError(ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
+		return hleLogError(ME, ERROR_MP3_NOT_YET_INIT_HANDLE, "unreserved handle");
+	} else if (ctx->Version < 0 || ctx->AuBuf == 0) {
+		return hleLogError(ME, ERROR_MP3_NOT_YET_INIT_HANDLE, "not yet init");
 	}
 
-	return ctx->AuResetPlayPosition();
+	return hleLogSuccessI(ME, ctx->AuResetPlayPosition());
 }
 
 static int sceMp3CheckStreamDataNeeded(u32 mp3) {

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -474,8 +474,16 @@ u32 AuCtx::AuGetInfoToAddStreamData(u32 bufPtr, u32 sizePtr, u32 srcPosPtr) {
 	return 0;
 }
 
-u32 AuCtx::AuResetPlayPositionByFrame(int position) {
-	readPos = position;
+u32 AuCtx::AuResetPlayPositionByFrame(int frame) {
+	// Note: this doesn't correctly handle padding or slot size, but the PSP doesn't either.
+	uint32_t bytesPerSecond = (MaxOutputSample / 8) * BitRate * 1000;
+	readPos = startPos + (frame * bytesPerSecond) / SamplingRate;
+	// Not sure why, but it seems to consistently seek 1 before, maybe in case it's off slightly.
+	if (frame != 0)
+		readPos -= 1;
+	SumDecodedSamples = frame * MaxOutputSample;
+	AuBufAvailable = 0;
+	sourcebuff.clear();
 	return 0;
 }
 

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -481,6 +481,9 @@ u32 AuCtx::AuResetPlayPositionByFrame(int position) {
 
 u32 AuCtx::AuResetPlayPosition() {
 	readPos = startPos;
+	SumDecodedSamples = 0;
+	AuBufAvailable = 0;
+	sourcebuff.clear();
 	return 0;
 }
 

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -351,7 +351,8 @@ u32 AuCtx::AuDecode(u32 pcmAddr) {
 			// get consumed source length
 			int srcPos = decoder->GetSourcePos() + nextSync;
 			// remove the consumed source
-			sourcebuff.erase(0, srcPos);
+			if (srcPos > 0)
+				sourcebuff.erase(sourcebuff.begin(), sourcebuff.begin() + srcPos);
 			// reduce the available Aubuff size
 			// (the available buff size is now used to know if we can read again from file and how many to read)
 			AuBufAvailable -= srcPos;
@@ -430,7 +431,8 @@ u32 AuCtx::AuNotifyAddStreamData(int size) {
 	}
 
 	if (Memory::IsValidRange(AuBuf, size)) {
-		sourcebuff.append((const char *)Memory::GetPointer(AuBuf + offset), size);
+		sourcebuff.resize(sourcebuff.size() + size);
+		Memory::MemcpyUnchecked(&sourcebuff[sourcebuff.size() - size], AuBuf + offset, size);
 	}
 
 	return 0;

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -119,7 +119,11 @@ public:
 	void DoState(PointerWrap &p);
 
 	void EatSourceBuff(int amount) {
-		sourcebuff.erase(0, amount);
+		if (amount > sourcebuff.size()) {
+			amount = (int)sourcebuff.size();
+		}
+		if (amount > 0)
+			sourcebuff.erase(sourcebuff.begin(), sourcebuff.begin() + amount);
 		AuBufAvailable -= amount;
 	}
 	// Au source information. Written to from for example sceAacInit so public for now.
@@ -155,7 +159,7 @@ public:
 private:
 	size_t FindNextMp3Sync();
 
-	std::string sourcebuff; // source buffer
+	std::vector<u8> sourcebuff; // source buffer
 };
 
 


### PR DESCRIPTION
From what I can tell, there's no special ID3 handling in the PSP's MP3 library, and the current logic uses fixed offsets that are not safe.  It should be safe to do what sceMp3 seems to do - just find the next frame sync.

Also:
 * `sceMp3Decode()` always outputs samples, even when the buffer is empty (then just zeros), until the stream end.
 * `sceMp3ResetPlayPosition()` and `sceMp3ResetPlayPositionByFrame()` especially were not at all working right.  Now they actually reset.  `sceMp3ResetPlayPosition(handle)` is basically `sceMp3ResetPlayPositionByFrame(handle, 0)`.
 * Also cleans up `sceMp3Init()` failure.

-[Unknown]