### PR TITLE
Toolchain for nvidia jetson linker tegra lib.

### DIFF
--- a/cmake/Toolchains/nvidiajetsonsdl.armv8.cmake
+++ b/cmake/Toolchains/nvidiajetsonsdl.armv8.cmake
@@ -1,0 +1,17 @@
+if(NOT EXISTS "/usr/lib/aarch64-linux-gnu/tegra")
+  message(FATAL_ERROR "Nvidia Jetson platform not recognized")
+endif()
+
+include_directories(SYSTEM
+  /usr/include/GL
+)
+
+set(ARCH_FLAGS "-march=armv8-a+crc -mtune=cortex-a57 -funsafe-math-optimizations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}"  CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+
+set (CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/lib/aarch64-linux-gnu/tegra" CACHE STRING "" FORCE)
+
+set(OPENGL_LIBRARIES  /usr/lib/aarch64-linux-gnu/tegra/libGLX_nvidia.so.0)
+set(USING_X11_VULKAN ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Creating toolchain specific for NVIDIA jetson by correctly linker graphics library that should be used

With this toolchain linker return linker graphics tegra fine  
Opengl 4.6 and Vulkan loading fine.
it's a workaround for #12001 
```
mrcmunir@mrcmunir-desktop:~/ppsspp/build$ ldd PPSSPPSDL 
	linux-vdso.so.1 (0x0000007f7fae8000)
	libgtk3-nocsd.so.0 => /usr/lib/aarch64-linux-gnu/libgtk3-nocsd.so.0 (0x0000007f7e836000)
	libSDL2-2.0.so.0 => /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 (0x0000007f7e6e7000)
	libGLEW.so.2.0 => /usr/lib/aarch64-linux-gnu/libGLEW.so.2.0 (0x0000007f7e63b000)
	libGLX_nvidia.so.0 => /usr/lib/aarch64-linux-gnu/tegra/libGLX_nvidia.so.0 (0x0000007f7e500000)
	libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000007f7e4bf000)
	libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000007f7e492000)
	libstdc++.so.6 => /usr/lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000007f7e2ff000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000007f7e245000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000007f7e221000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000007f7e1f5000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007f7e09c000)
	/lib/ld-linux-aarch64.so.1 (0x0000007f7fabd000)
	libsndio.so.6.1 => /usr/lib/aarch64-linux-gnu/libsndio.so.6.1 (0x0000007f7e07d000)
	libGL.so.1 => /usr/lib/aarch64-linux-gnu/libGL.so.1 (0x0000007f7df7e000)
	libnvidia-tls.so.32.1.0 => /usr/lib/aarch64-linux-gnu/tegra/libnvidia-tls.so.32.1.0 (0x0000007f7df6c000)
	libnvidia-glcore.so.32.1.0 => /usr/lib/aarch64-linux-gnu/tegra/libnvidia-glcore.so.32.1.0 (0x0000007f7ca81000)
	libX11.so.6 => /usr/lib/aarch64-linux-gnu/libX11.so.6 (0x0000007f7c958000)
	libXext.so.6 => /usr/lib/aarch64-linux-gnu/libXext.so.6 (0x0000007f7c938000)
	libasound.so.2 => /usr/lib/aarch64-linux-gnu/libasound.so.2 (0x0000007f7c843000)
	libbsd.so.0 => /lib/aarch64-linux-gnu/libbsd.so.0 (0x0000007f7c821000)
	libGLX.so.0 => /usr/lib/aarch64-linux-gnu/libGLX.so.0 (0x0000007f7c7e1000)
	libGLdispatch.so.0 => /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0 (0x0000007f7c6b5000)
	libnvdc.so => /usr/lib/aarch64-linux-gnu/tegra/libnvdc.so (0x0000007f7c696000)
	libnvidia-rmapi-tegra.so.32.1.0 => /usr/lib/aarch64-linux-gnu/tegra/libnvidia-rmapi-tegra.so.32.1.0 (0x0000007f7c655000)
	libxcb.so.1 => /usr/lib/aarch64-linux-gnu/libxcb.so.1 (0x0000007f7c625000)
	libnvimp.so => /usr/lib/aarch64-linux-gnu/tegra/libnvimp.so (0x0000007f7c610000)
	libnvrm.so => /usr/lib/aarch64-linux-gnu/tegra/libnvrm.so (0x0000007f7c5ce000)
	libnvrm_gpu.so => /usr/lib/aarch64-linux-gnu/tegra/libnvrm_gpu.so (0x0000007f7c58b000)
	libnvos.so => /usr/lib/aarch64-linux-gnu/tegra/libnvos.so (0x0000007f7c56d000)
	libnvrm_graphics.so => /usr/lib/aarch64-linux-gnu/tegra/libnvrm_graphics.so (0x0000007f7c54e000)
	libXau.so.6 => /usr/lib/aarch64-linux-gnu/libXau.so.6 (0x0000007f7c53b000)
	libXdmcp.so.6 => /usr/lib/aarch64-linux-gnu/libXdmcp.so.6 (0x0000007f7c526000)
	librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000007f7c50f000)
```