### PR TITLE
Add Test Drive Unlimited to depthRangeHack to disable range culling

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -140,6 +140,12 @@ ULJM91018 = true
 NPJH90062 = true
 # Phantasy Star Portable Infinity Demo
 NPJH90157 = true  # Infinity demo
+# Test Drive Unlimited
+# just to disable range culling without adding another hack
+# since it causes a lot of missing geometry when driving
+ULES00637 = true
+ULKS46126 = true
+ULUS10249 = true
 
 [ClearToRAM]
 # SOCOM Navy Seals games require this. See issue #8973.


### PR DESCRIPTION
Including dump with problem this works around:
[ULUS10249_0001.zip](https://github.com/hrydgard/ppsspp/files/3145292/ULUS10249_0001.zip)

 I guess range culling causes missing road/ground, through not sure if depth range hack on it's own doesn't help as I recall seeing missing triangle or two when riding offroad even before range culling was added, it was just soo rare and hard to reproduce I thought it's game glitch, maybe range culling just made the problem more visible.