### PR TITLE
Add a missing error check to the D3D11 device creation. May help #12039?

### DIFF
--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -123,10 +123,15 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 				}
 			}
 
-			chosenAdapterName = adapterNames[chosenAdapter];
-			hr = CreateTheDevice(adapters[chosenAdapter]);
-			for (int i = 0; i < (int)adapters.size(); i++) {
-				adapters[i]->Release();
+			if (!adapters.empty()) {
+				chosenAdapterName = adapterNames[chosenAdapter];
+				hr = CreateTheDevice(adapters[chosenAdapter]);
+				for (int i = 0; i < (int)adapters.size(); i++) {
+					adapters[i]->Release();
+				}
+			} else {
+				// No adapters found. Trip the error path below.
+				hr = E_FAIL;
 			}
 		}
 	}


### PR DESCRIPTION
(The new thing is checking the result of CreateDXGIFactory. The rest is just indentation changes).

EDIT: Also checks for no adapters.