### PR TITLE
Improved Show in Folder behaviour

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -149,6 +149,10 @@ void Vibrate(int length_ms) {
 		length_ms = 25;
 }
 
+void OpenDirectory(const char *path) {
+	// Unsupported
+}
+
 void LaunchBrowser(const char *url)
 {
 	QDesktopServices::openUrl(QUrl(url));

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -126,6 +126,16 @@ void System_SendMessage(const char *command, const char *parameter) {
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 
+void OpenDirectory(const char *path) {
+#if defined(_WIN32)
+	PIDLIST_ABSOLUTE pidl = ILCreateFromPath(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str());
+	if (pidl) {
+		SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
+		ILFree(pidl);
+	}
+#endif
+}
+
 void LaunchBrowser(const char *url) {
 #if defined(MOBILE_DEVICE)
 	ILOG("Would have gone to %s but LaunchBrowser is not implemented on this platform", url);

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -134,7 +134,7 @@ void GameScreen::CreateViews() {
 	if (isRecentGame(gamePath_)) {
 		rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Remove From Recent"))))->OnClick.Handle(this, &GameScreen::OnRemoveFromRecent);
 	}
-#ifdef _WIN32
+#if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
 	rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Show In Folder"))))->OnClick.Handle(this, &GameScreen::OnShowInFolder);
 #endif
 	if (g_Config.bEnableCheats) {
@@ -261,10 +261,7 @@ void GameScreen::render() {
 }
 
 UI::EventReturn GameScreen::OnShowInFolder(UI::EventParams &e) {
-#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
-	std::string str = std::string("explorer.exe /select,\"") + ReplaceAll(gamePath_, "/", "\\") + "\"";
-	_wsystem(ConvertUTF8ToWString(str).c_str());
-#endif
+	OpenDirectory(gamePath_.c_str());
 	return UI::EVENT_DONE;
 }
 

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -432,6 +432,10 @@ void System_SendMessage(const char *command, const char *parameter) {
 	}
 }
 
+void OpenDirectory(const char *path) {
+	// Unsupported
+}
+
 void LaunchBrowser(const char *url) {
 	auto uri = ref new Windows::Foundation::Uri(ToPlatformString(url));
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -26,6 +26,7 @@
 
 #include <Wbemidl.h>
 #include <shellapi.h>
+#include <ShlObj.h>
 #include <mmsystem.h>
 
 #include "base/NativeApp.h"
@@ -96,6 +97,14 @@ static std::string gpuDriverVersion;
 
 HMENU g_hPopupMenus;
 int g_activeWindow = 0;
+
+void OpenDirectory(const char *path) {
+	PIDLIST_ABSOLUTE pidl = ILCreateFromPath(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str());
+	if (pidl) {
+		SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
+		ILFree(pidl);
+	}
+}
 
 void LaunchBrowser(const char *url) {
 	ShellExecute(NULL, L"open", ConvertUTF8ToWString(url).c_str(), NULL, NULL, SW_SHOWNORMAL);

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -247,6 +247,10 @@ void Vibrate(int length_ms) {
 	PushCommand("vibrate", temp);
 }
 
+void OpenDirectory(const char *path) {
+	// Unsupported
+}
+
 void LaunchBrowser(const char *url) {
 	PushCommand("launchBrowser", url);
 }

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -114,6 +114,7 @@ enum {
 	HAPTIC_LONG_PRESS_ACTIVATED = -3,
 };
 void Vibrate(int length_ms);
+void OpenDirectory(const char *path);
 void LaunchBrowser(const char *url);
 void LaunchMarket(const char *url);
 void LaunchEmail(const char *email_address);

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -693,6 +693,10 @@ static GraphicsContext *graphicsContext;
 
 @end
 
+void OpenDirectory(const char *path) {
+	// Unsupported
+}
+
 void LaunchBrowser(char const* url)
 {
 	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithCString:url encoding:NSStringEncodingConversionAllowLossy]]];


### PR DESCRIPTION
This PR overhauls the way "Show in Folder" action in Windows builds of PPSSPP works. Previously it worked by invoking a system call to spawn a new `explorer.exe` instance selected on a specific folder. This had a few drawbacks:

- It spawned a cmd.exe window for a brief moment.
- Every time the option was selected, a new Explorer window was created.

After the change, this code has been removed in favour of Shell functions, [same ones as used by Chromium](https://chromium.googlesource.com/chromium/src.git/+/74ee31beb077c960b510e4d8698e8c6151828190/chrome/common/platform_util_win.cc#83). This not only shows the folder directly, but also brings an already opened folder to front without spawning a new one, if that folder happens to be opened already.

On top of that, code has been changed to remove platform specific code from `GameScreen.cpp`. Now a new `OpenDirectory` function with platform specific implementations exists, identical to how `LaunchBrowser` is handled already.

Lastly, a nonfunctional "Show in Folder" button has been hid in UWP builds. This button never worked there, and possibly never will.