### PR TITLE
Fix avi dump feature by using render buffer with option to use output buffer.

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -169,9 +169,17 @@ static void PreparePacket(AVPacket* pkt) {
 
 void AVIDump::AddFrame()
 {
-	gpuDebug->GetOutputFramebuffer(buf);
-	u32 w = buf.GetStride();
-	u32 h = buf.GetHeight();
+	u32 w = 0;
+	u32 h = 0;
+	if (g_Config.bDumpVideoOutput) {
+		gpuDebug->GetOutputFramebuffer(buf);
+		w = buf.GetStride();
+		h = buf.GetHeight();
+	} else {
+		gpuDebug->GetCurrentFramebuffer(buf, GPU_DBG_FRAMEBUF_RENDER);
+		w = PSP_CoreParameter().renderWidth;
+		h = PSP_CoreParameter().renderHeight;
+	}
 	CheckResolution(w, h);
 	u8 *flipbuffer = nullptr;
 	const u8 *buffer = ConvertBufferToScreenshot(buf, false, flipbuffer, w, h);

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -169,7 +169,7 @@ static void PreparePacket(AVPacket* pkt) {
 
 void AVIDump::AddFrame()
 {
-	gpuDebug->GetCurrentFramebuffer(buf, GPU_DBG_FRAMEBUF_DISPLAY);
+	gpuDebug->GetOutputFramebuffer(buf);
 	u32 w = buf.GetStride();
 	u32 h = buf.GetHeight();
 	CheckResolution(w, h);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -407,6 +407,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("ScreenshotsAsPNG", &g_Config.bScreenshotsAsPNG, false, true, true),
 	ConfigSetting("UseFFV1", &g_Config.bUseFFV1, false),
 	ConfigSetting("DumpFrames", &g_Config.bDumpFrames, false),
+	ConfigSetting("DumpVideoOutput", &g_Config.bDumpVideoOutput, false),
 	ConfigSetting("DumpAudio", &g_Config.bDumpAudio, false),
 	ConfigSetting("SaveLoadResetsAVdumping", &g_Config.bSaveLoadResetsAVdumping, false),
 	ConfigSetting("StateSlot", &g_Config.iCurrentStateSlot, 0, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -60,6 +60,7 @@ public:
 	bool bScreenshotsAsPNG;
 	bool bUseFFV1;
 	bool bDumpFrames;
+	bool bDumpVideoOutput;
 	bool bDumpAudio;
 	bool bSaveLoadResetsAVdumping;
 	bool bEnableLogging;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -107,7 +107,7 @@ static void __EmuScreenVblank()
 	if (g_Config.bDumpFrames && !startDumping)
 	{
 		avi.Start(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
-		osm.Show(sy->T("AVI Dump started."), 3.0f);
+		osm.Show(sy->T("AVI Dump started."), 0.5f);
 		startDumping = true;
 	}
 	if (g_Config.bDumpFrames && startDumping)
@@ -117,7 +117,7 @@ static void __EmuScreenVblank()
 	else if (!g_Config.bDumpFrames && startDumping)
 	{
 		avi.Stop();
-		osm.Show(sy->T("AVI Dump stopped."), 3.0f);
+		osm.Show(sy->T("AVI Dump stopped."), 1.0f);
 		startDumping = false;
 	}
 #endif
@@ -347,7 +347,7 @@ EmuScreen::~EmuScreen() {
 	if (g_Config.bDumpFrames && startDumping)
 	{
 		avi.Stop();
-		osm.Show("AVI Dump stopped.", 3.0f);
+		osm.Show("AVI Dump stopped.", 1.0f);
 		startDumping = false;
 	}
 #endif
@@ -371,7 +371,7 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 }
 
 static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
-	if (!message.empty()) {
+	if (!message.empty() && !g_Config.bDumpFrames) {
 		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -371,7 +371,7 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 }
 
 static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
-	if (!message.empty() && !g_Config.bDumpFrames) {
+	if (!message.empty() && (!g_Config.bDumpFrames || !g_Config.bDumpVideoOutput)) {
 		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -813,7 +813,7 @@ void GameSettingsScreen::CreateViews() {
 #if defined(_WIN32) || (defined(USING_QT_UI) && !defined(MOBILE_DEVICE))
 	systemSettings->Add(new CheckBox(&g_Config.bDumpFrames, sy->T("Record Display")));
 	systemSettings->Add(new CheckBox(&g_Config.bUseFFV1, sy->T("Use Lossless Video Codec (FFV1)")));
-	systemSettings->Add(new CheckBox(&g_Config.bDumpVideoOutput, sy->T("Use output buffer(with overlay) for recording")));
+	systemSettings->Add(new CheckBox(&g_Config.bDumpVideoOutput, sy->T("Use output buffer (with overlay) for recording")));
 	systemSettings->Add(new CheckBox(&g_Config.bDumpAudio, sy->T("Record Audio")));
 	systemSettings->Add(new CheckBox(&g_Config.bSaveLoadResetsAVdumping, sy->T("Reset Recording on Save/Load State")));
 #endif

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -813,6 +813,7 @@ void GameSettingsScreen::CreateViews() {
 #if defined(_WIN32) || (defined(USING_QT_UI) && !defined(MOBILE_DEVICE))
 	systemSettings->Add(new CheckBox(&g_Config.bDumpFrames, sy->T("Record Display")));
 	systemSettings->Add(new CheckBox(&g_Config.bUseFFV1, sy->T("Use Lossless Video Codec (FFV1)")));
+	systemSettings->Add(new CheckBox(&g_Config.bDumpVideoOutput, sy->T("Use output buffer(with overlay) for recording")));
 	systemSettings->Add(new CheckBox(&g_Config.bDumpAudio, sy->T("Record Audio")));
 	systemSettings->Add(new CheckBox(&g_Config.bSaveLoadResetsAVdumping, sy->T("Reset Recording on Save/Load State")));
 #endif

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -676,7 +676,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	if (!boot_filename.empty() && stateToLoad != NULL) {
 		SaveState::Load(stateToLoad, [](SaveState::Status status, const std::string &message, void *) {
-			if (!message.empty() && !g_Config.bDumpFrames) {
+			if (!message.empty() && (!g_Config.bDumpFrames || !g_Config.bDumpVideoOutput)) {
 				osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 			}
 		});

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -676,7 +676,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	if (!boot_filename.empty() && stateToLoad != NULL) {
 		SaveState::Load(stateToLoad, [](SaveState::Status status, const std::string &message, void *) {
-			if (!message.empty()) {
+			if (!message.empty() && !g_Config.bDumpFrames) {
 				osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 			}
 		});

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -271,7 +271,7 @@ void SaveSlotView::Draw(UIContext &dc) {
 }
 
 static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
-	if (!message.empty()) {
+	if (!message.empty() && !g_Config.bDumpFrames) {
 		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -271,7 +271,7 @@ void SaveSlotView::Draw(UIContext &dc) {
 }
 
 static void AfterSaveStateAction(SaveState::Status status, const std::string &message, void *) {
-	if (!message.empty() && !g_Config.bDumpFrames) {
+	if (!message.empty() && (!g_Config.bDumpFrames || !g_Config.bDumpVideoOutput)) {
 		osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 	}
 }

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -280,6 +280,7 @@ namespace MainWindow {
 		// Movie menu
 		TranslateMenuItem(menu, ID_FILE_DUMPFRAMES);
 		TranslateMenuItem(menu, ID_FILE_USEFFV1);
+		TranslateMenuItem(menu, ID_FILE_DUMP_VIDEO_OUTPUT);
 		TranslateMenuItem(menu, ID_FILE_DUMPAUDIO);
 
 		// Skip display multipliers x1-x10
@@ -447,7 +448,7 @@ namespace MainWindow {
 	}
 
 	static void SaveStateActionFinished(SaveState::Status status, const std::string &message, void *userdata) {
-		if (!message.empty() && !g_Config.bDumpFrames) {
+		if (!message.empty() && (!g_Config.bDumpFrames || !g_Config.bDumpVideoOutput)) {
 			osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 		}
 		PostMessage(MainWindow::GetHWND(), WM_USER_SAVESTATE_FINISH, 0, 0);
@@ -1034,6 +1035,10 @@ namespace MainWindow {
 			g_Config.bUseFFV1 = !g_Config.bUseFFV1;
 			break;
 
+		case ID_FILE_DUMP_VIDEO_OUTPUT:
+			g_Config.bDumpVideoOutput = !g_Config.bDumpVideoOutput;
+			break;
+
 		case ID_FILE_DUMPAUDIO:
 			g_Config.bDumpAudio = !g_Config.bDumpAudio;
 			break;
@@ -1083,6 +1088,7 @@ namespace MainWindow {
 		CHECKITEM(ID_OPTIONS_IGNOREWINKEY, g_Config.bIgnoreWindowsKey);
 		CHECKITEM(ID_FILE_DUMPFRAMES, g_Config.bDumpFrames);
 		CHECKITEM(ID_FILE_USEFFV1, g_Config.bUseFFV1);
+		CHECKITEM(ID_FILE_DUMP_VIDEO_OUTPUT, g_Config.bDumpVideoOutput);
 		CHECKITEM(ID_FILE_DUMPAUDIO, g_Config.bDumpAudio);
 
 		static const int displayrotationitems[] = {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -447,7 +447,7 @@ namespace MainWindow {
 	}
 
 	static void SaveStateActionFinished(SaveState::Status status, const std::string &message, void *userdata) {
-		if (!message.empty()) {
+		if (!message.empty() && !g_Config.bDumpFrames) {
 			osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
 		}
 		PostMessage(MainWindow::GetHWND(), WM_USER_SAVESTATE_FINISH, 0, 0);

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -490,6 +490,7 @@ BEGIN
         BEGIN
             MENUITEM "Record Display",                      ID_FILE_DUMPFRAMES
             MENUITEM "Use Lossless Video Codec (FFV1)",     ID_FILE_USEFFV1
+            MENUITEM "Use output buffer for video",         ID_FILE_DUMP_VIDEO_OUTPUT
             MENUITEM "", 0, MFT_SEPARATOR
             MENUITEM "Record Audio",                        ID_FILE_DUMPAUDIO
         END

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -369,6 +369,7 @@
 #define IDC_GEDBG_STEPCOUNT_INC          40201
 #define IDC_GEDBG_STEPCOUNT_JUMP         40202
 #define IDC_GEDBG_STEPCOUNT_COMBO        40203
+#define ID_FILE_DUMP_VIDEO_OUTPUT        40204
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500


### PR DESCRIPTION
Fixes #10632 as tested on 20 fps game.

Fixed with render buffer now:
 - uses render resolution which can get very big very quickly,
 - at the same time will be much faster when forcing x1 res like software rendering.

Changing to output buffer means we're now recording also:
- shader effects(which is good I guess),
- on screen text(possibly annoying, but osm for savestates disabled make it very usable),
- touch screen controls(some might want it, some might not, the feature is not enabled on mobiles anyway so not a big deal).


 ~~One other downside I found is that software rendering isn't recorded correctly with output buffer at least if the game draws by manually copying to vram like that Darkstalkers game which can't render in hardware renderer correctly. It recorded ok with display framebuffer, so maybe giving a choice of buffer for recording would be a nice option, through that's really an edge case.~~ - software renderer recording overall works better with render buffer, through while testing now, it recorded fine even with output buffer, not sure why.