### PR TITLE
Improvements to WordWrapper

### DIFF
--- a/ext/native/util/text/wrap_text.h
+++ b/ext/native/util/text/wrap_text.h
@@ -13,7 +13,7 @@ public:
 protected:
 	virtual float MeasureWidth(const char *str, size_t bytes) = 0;
 	void Wrap();
-	void WrapBeforeWord();
+	bool WrapBeforeWord();
 	void AppendWord(int endIndex, bool addNewline);
 
 	static bool IsCJK(uint32_t c);
@@ -27,7 +27,7 @@ protected:
 	// Index of last output / start of current word.
 	int lastIndex_ = 0;
 	// Index of last line start.
-	int lastLineStart_ = 0;
+	size_t lastLineStart_ = 0;
 	// Position the current word starts at.
 	float x_ = 0.0f;
 	// Most recent width of word since last index.


### PR DESCRIPTION
This PR started as a change to word wrapping (basically 1.), but when rebasing and cleaning up for submission I realized more can be done. Therefore, this PR introduces several styling changes and introduces a functionality change to `WordWrapper` class:

- When wrapping before word, left trim whitespaces to prevent newlines from starting indented
- Changes `lastLineStart_` to `size_t` to cut down on nasty typecasts
- Replaces `operator +=` with explicit call to `append` to make intent more clear and reduce memory allocations

That's how the change looks in action:

Before:
![image](https://user-images.githubusercontent.com/7947461/58649687-0d273e80-830d-11e9-95b0-f8d81e21cedc.png)

After:
![image](https://user-images.githubusercontent.com/7947461/58649751-36e06580-830d-11e9-975e-588581abf1d1.png)

Notice that a wrapped string is now left trimmed of whitespaces, so it doesn't appear indented.


When analyzing the safety of this change @unknownbrackets mentioned I could test this by feeding it a very long word which would have wrapped, and here's the result - it appears to look identical before and after the change.

Before:
![image](https://user-images.githubusercontent.com/7947461/58649968-d140a900-830d-11e9-8a34-5265860d421a.png)

After:
![image](https://user-images.githubusercontent.com/7947461/58649884-9d658380-830d-11e9-8ac1-3bd2bc1218d7.png)
