### PR TITLE
JitDisable: Add options to disable regalloc across instructions (flush after every instruction)

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -349,7 +349,17 @@ const u8 *ArmJit::DoJit(u32 em_address, JitBlock *b)
 	
 		js.compilerPC += 4;
 		js.numInstructions++;
+
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+			gpr.FlushAll();
+		}
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+			fpr.FlushAll();
+			FlushPrefixV();
+		}
+
 #if !PPSSPP_ARCH(ARMV7)
+		// TODO: Is this path still even supported?
 		if ((GetCodePtr() - b->checkedEntry - partialFlushOffset) > 3200)
 		{
 			// We need to prematurely flush as we are out of range

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -350,10 +350,10 @@ const u8 *ArmJit::DoJit(u32 em_address, JitBlock *b)
 		js.compilerPC += 4;
 		js.numInstructions++;
 
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_GPR)) {
 			gpr.FlushAll();
 		}
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_FPR)) {
 			fpr.FlushAll();
 			FlushPrefixV();
 		}

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -336,6 +336,14 @@ const u8 *Arm64Jit::DoJit(u32 em_address, JitBlock *b) {
 		js.compilerPC += 4;
 		js.numInstructions++;
 
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+			gpr.FlushAll();
+		}
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+			fpr.FlushAll();
+			FlushPrefixV();
+		}
+
 		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
 		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS) {
 			FlushAll();

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -336,10 +336,10 @@ const u8 *Arm64Jit::DoJit(u32 em_address, JitBlock *b) {
 		js.compilerPC += 4;
 		js.numInstructions++;
 
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_GPR)) {
 			gpr.FlushAll();
 		}
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_FPR)) {
 			fpr.FlushAll();
 			FlushPrefixV();
 		}

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -205,6 +205,8 @@ namespace MIPSComp {
 		POINTERIFY = 0x00400000,
 		STATIC_ALLOC = 0x00800000,
 		CACHE_POINTERS = 0x01000000,
+		REGALLOC_GPR = 0x02000000,  // Doesn't really disable regalloc, but flushes after every instr.
+		REGALLOC_FPR = 0x04000000,
 
 		ALL_FLAGS = 0x01FFFFFF,
 	};

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -389,6 +389,14 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 		js.compilerPC += 4;
 		js.numInstructions++;
 
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+			gpr.Flush();
+		}
+		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+			fpr.Flush();
+			FlushPrefixV();
+		}
+
 		// Safety check, in case we get a bunch of really large jit ops without a lot of branching.
 		if (GetSpaceLeft() < 0x800 || js.numInstructions >= JitBlockCache::MAX_BLOCK_INSTRUCTIONS) {
 			FlushAll();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -389,10 +389,10 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 		js.compilerPC += 4;
 		js.numInstructions++;
 
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_GPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_GPR)) {
 			gpr.Flush();
 		}
-		if (jo.disableFlags & (uint32_t)JitDisable::REGALLOC_FPR) {
+		if (jo.Disabled(JitDisable::REGALLOC_FPR)) {
 			fpr.Flush();
 			FlushPrefixV();
 		}

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -350,6 +350,8 @@ static const JitDisableFlag jitDisableFlags[] = {
 	{ MIPSComp::JitDisable::POINTERIFY, "Pointerify" },
 	{ MIPSComp::JitDisable::STATIC_ALLOC, "Static regalloc" },
 	{ MIPSComp::JitDisable::CACHE_POINTERS, "Cached pointers" },
+	{ MIPSComp::JitDisable::REGALLOC_GPR, "GPR Regalloc across instructions" },
+	{ MIPSComp::JitDisable::REGALLOC_FPR, "FPR Regalloc across instructions" },
 };
 
 void JitDebugScreen::CreateViews() {


### PR DESCRIPTION
Might help debugging #9843.

Allows disabling FPR and GPR regalloc separately.