### PR TITLE
UWP: Full screen support

### DIFF
--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -217,9 +217,10 @@ void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^
 	// Run() won't start until the CoreWindow is activated.
 	CoreWindow::GetForCurrentThread()->Activate();
 	// On mobile, we force-enter fullscreen mode.
-	if (m_isPhone) {
+	if (m_isPhone) g_Config.bFullScreen = true;
+
+	if (g_Config.bFullScreen)
 		Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->TryEnterFullScreenMode();
-	}
 }
 
 void App::OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args) {
@@ -228,9 +229,10 @@ void App::OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args) {
 	// aware that a deferral may not be held indefinitely. After about five seconds,
 	// the app will be forced to exit.
 	SuspendingDeferral^ deferral = args->SuspendingOperation->GetDeferral();
+	auto app = this;
 
-	create_task([this, deferral]() {
-		m_deviceResources->Trim();
+	create_task([app, deferral]() {
+		app->m_deviceResources->Trim();
 		deferral->Complete();
 	});
 }
@@ -246,6 +248,9 @@ void App::OnResuming(Platform::Object^ sender, Platform::Object^ args) {
 // Window event handlers.
 
 void App::OnWindowSizeChanged(CoreWindow^ sender, WindowSizeChangedEventArgs^ args) {
+	auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	g_Config.bFullScreen = view->IsFullScreenMode;
+
 	int width = sender->Bounds.Width;
 	int height = sender->Bounds.Height;
 	float scale = m_deviceResources->GetDpi() / 96.0f;
@@ -263,10 +268,17 @@ void App::OnWindowSizeChanged(CoreWindow^ sender, WindowSizeChangedEventArgs^ ar
 }
 
 void App::OnVisibilityChanged(CoreWindow^ sender, VisibilityChangedEventArgs^ args) {
+
+	if (args->Visible == false) {
+		// MainScreen::OnExit and even App::OnWindowClosed
+		// doesn't seem to be called when closing the window
+		// Try to save the config here
+		g_Config.Save("App::OnVisibilityChanged");
+	}
 	m_windowVisible = args->Visible;
 }
 
-void App::OnWindowClosed(CoreWindow^ sender, CoreWindowEventArgs^ args) {
+void App::OnWindowClosed(CoreWindow^ sender, CoreWindowEventArgs^ args) {	
 	m_windowClosed = true;
 }
 

--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -278,7 +278,7 @@ void App::OnVisibilityChanged(CoreWindow^ sender, VisibilityChangedEventArgs^ ar
 	m_windowVisible = args->Visible;
 }
 
-void App::OnWindowClosed(CoreWindow^ sender, CoreWindowEventArgs^ args) {	
+void App::OnWindowClosed(CoreWindow^ sender, CoreWindowEventArgs^ args) {
 	m_windowClosed = true;
 }
 

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -429,6 +429,14 @@ void System_SendMessage(const char *command, const char *parameter) {
 				g_main->LoadStorageFile(file);
 			}
 		});
+	} else if (!strcmp(command, "toggle_fullscreen")) {
+		auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		if (strcmp(parameter, "0") == 0) {
+			view->ExitFullScreenMode();
+		}
+		else if (strcmp(parameter, "1") == 0){
+			view->TryEnterFullScreenMode();
+		}
 	}
 }
 

--- a/ext/native/gfx_es2/draw_text_uwp.cpp
+++ b/ext/native/gfx_es2/draw_text_uwp.cpp
@@ -151,6 +151,11 @@ TextDrawerUWP::~TextDrawerUWP() {
 	m_d2dContext->Release();
 	m_d2dDevice->Release();
 	m_d2dFactory->Release();
+
+	m_fontCollection->Release();
+	m_fontSet->Release();
+	m_fontFile->Release();
+	m_fontSetBuilder->Release();
 	m_dwriteFactory->Release();
 	delete ctx_;
 }
@@ -206,6 +211,7 @@ void TextDrawerUWP::MeasureString(const char *str, size_t len, float *w, float *
 		if (iter != fontMap_.end()) {
 			format = iter->second->textFmt;
 		}
+		if (!format) return;
 
 		std::wstring wstr = ConvertUTF8ToWString(ReplaceAll(ReplaceAll(std::string(str, len), "\n", "\r\n"), "&&", "&"));
 
@@ -223,6 +229,7 @@ void TextDrawerUWP::MeasureString(const char *str, size_t len, float *w, float *
 
 		DWRITE_TEXT_METRICS metrics;
 		layout->GetMetrics(&metrics);
+		layout->Release();
 
 		entry = new TextMeasureEntry();
 		entry->width = metrics.width + 1;
@@ -242,6 +249,7 @@ void TextDrawerUWP::MeasureStringRect(const char *str, size_t len, const Bounds 
 	if (iter != fontMap_.end()) {
 		format = iter->second->textFmt;
 	}
+	if (!format) return;
 
 	std::string toMeasure = std::string(str, len);
 	if (align & FLAG_WRAP_TEXT) {
@@ -282,6 +290,7 @@ void TextDrawerUWP::MeasureStringRect(const char *str, size_t len, const Bounds 
 
 			DWRITE_TEXT_METRICS metrics;
 			layout->GetMetrics(&metrics);
+			layout->Release();
 
 			entry = new TextMeasureEntry();
 			entry->width = metrics.width + 1;
@@ -325,6 +334,7 @@ void TextDrawerUWP::DrawString(DrawBuffer &target, const char *str, float x, flo
 		if (iter != fontMap_.end()) {
 			format = iter->second->textFmt;
 		}
+		if (!format) return;
 
 		if (align & ALIGN_HCENTER)
 			format->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);

--- a/ext/native/gfx_es2/draw_text_uwp.h
+++ b/ext/native/gfx_es2/draw_text_uwp.h
@@ -44,7 +44,6 @@ protected:
 	ID2D1Factory5*        m_d2dFactory;
 	ID2D1Device4*         m_d2dDevice;
 	ID2D1DeviceContext4*  m_d2dContext;
-	ID2D1Bitmap1*         m_d2dTargetBitmap;
 	ID2D1SolidColorBrush* m_d2dWhiteBrush;
 
 	// DirectWrite drawing components.


### PR DESCRIPTION
Wire up the full screen toggle in the settings screen.

Note: Win-Shift-Enter is the system-wide full screen keyboard shortcut for UWP.

Also try to save configs when closing the app. (This is not very supported in the UWP platform, but this fix works good enough.)