### PR TITLE
Set DrawSyncEatCycles for Patapon 2, recommended by pamford45

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -230,6 +230,17 @@ UCJS18014 = true
 UCUS98700 = true
 NPJG00032 = true
 UCJX90019 = true
+# Fixes some double framerate issues in Patapon 2, contributed by pamford45
+UCJS10089 = true
+NPJG00010 = true
+PSPJ30000 = true
+UCAS40232 = true
+UCAS40239 = true
+UCES01177 = true
+UCUS98732 = true
+UCJS18036 = true
+UCAS40292 = true
+UCJS18053 = true
 
 [FakeMipmapChange]
 # This hacks separates each mipmap to independent textures to display wrong-size mipmaps.


### PR DESCRIPTION
pamford45 on Discord says that this fixes numerous double-framerate issues in Patapon 2.

Ideally we should investigate and fix that though... but it might be one of those hard GPU-timing issues.