### PR TITLE
Implement and test clz32, use it in the MIPS interpreter cores.

### DIFF
--- a/Common/BitScan.h
+++ b/Common/BitScan.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ppsspp_config.h"
+
+#if PPSSPP_PLATFORM(WINDOWS)
+#include "Common/CommonWindows.h"
+
+// Use this if you know the value is non-zero.
+inline uint32_t clz32_nonzero(uint32_t value) {
+	DWORD index;
+	BitScanReverse(&index, value);
+	return 31 ^ (uint32_t)index;
+}
+
+inline uint32_t clz32(uint32_t value) {
+	if (!value)
+		return 32;
+	DWORD index;
+	BitScanReverse(&index, value);
+	return 31 ^ (uint32_t)index;
+}
+
+#else
+
+// Use this if you know the value is non-zero.
+inline uint32_t clz32_nonzero(uint32_t value) {
+	return __builtin_clz(value);
+}
+
+inline uint32_t clz32(uint32_t value) {
+	if (!value)
+		return 32;
+	return __builtin_clz(value);
+}
+
+#endif

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -128,7 +128,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -384,6 +383,7 @@
     <ClInclude Include="Atomics.h" />
     <ClInclude Include="Atomic_GCC.h" />
     <ClInclude Include="Atomic_Win32.h" />
+    <ClInclude Include="BitScan.h" />
     <ClInclude Include="BitSet.h" />
     <ClInclude Include="ColorConvNEON.h" />
     <ClInclude Include="ChunkFile.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -73,6 +73,7 @@
     <ClInclude Include="OSVersion.h" />
     <ClInclude Include="Hashmaps.h" />
     <ClInclude Include="Vulkan\VulkanDebug.h" />
+    <ClInclude Include="BitScan.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp" />

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -4,6 +4,7 @@
 #include "ppsspp_config.h"
 #include "math/math_util.h"
 #include "Common/Common.h"
+#include "Common/BitScan.h"
 
 #ifdef _M_SSE
 #include <emmintrin.h>
@@ -563,14 +564,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 
 		case IROp::Clz:
 		{
-			int x = 31;
-			int count = 0;
-			int value = mips->r[inst->src1];
-			while (x >= 0 && !(value & (1 << x))) {
-				count++;
-				x--;
-			}
-			mips->r[inst->dest] = count;
+			mips->r[inst->dest] = clz32(mips->r[inst->src1]);
 			break;
 		}
 

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -15,13 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-// MIPS is really trivial :)
-
 #include <cmath>
 
 #include "math/math_util.h"
 
 #include "Common/Common.h"
+#include "Common/BitScan.h"
 #include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/Host.h"
@@ -281,7 +280,6 @@ namespace MIPSInt
 		switch (op & 0x3f) 
 		{
 		case 8: //jr
-			//			LOG(CPU,"returning from: %08x",PC);
 			DelayBranchTo(addr);
 			break;
 		case 9: //jalr
@@ -551,28 +549,10 @@ namespace MIPSInt
 		switch (op & 63)
 		{
 		case 22:	//clz
-			{ //TODO: verify
-				int x = 31;
-				int count=0;
-				while (x >= 0 && !(R(rs) & (1<<x)))
-				{
-					count++;
-					x--;
-				}
-				R(rd) = count;
-			}
+			R(rd) = clz32(R(rs));
 			break;
 		case 23: //clo
-			{ //TODO: verify
-				int x = 31;
-				int count=0;
-				while (x >= 0 && (R(rs) & (1<<x)))
-				{
-					count++;
-					x--;
-				}
-				R(rd) = count;
-			}
+			R(rd) = clz32(~R(rs));
 			break;
 		default:
 			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -31,6 +31,9 @@
 #include <string>
 #include <sstream>
 
+#include "Common/BitScan.h"
+#include "Core/MIPS/MIPSVFPUUtils.h"
+
 #include "base/NativeApp.h"
 #include "base/logging.h"
 #include "input/input_state.h"
@@ -459,6 +462,29 @@ bool TestQuickTexHash() {
 	return true;
 }
 
+bool TestCLZ() {
+	static const uint32_t input[] = {
+		0xFFFFFFFF,
+		0x00FFFFF0,
+		0x00101000,
+		0x00003000,
+		0x00000001,
+		0x00000000,
+	};
+	static const uint32_t expected[] = {
+		0,
+		8,
+		11,
+		18,
+		31,
+		32,
+	};
+	for (int i = 0; i < ARRAY_SIZE(input); i++) {
+		EXPECT_EQ_INT(clz32(input[i]), expected[i]);
+	}
+	return true;
+}
+
 typedef bool (*TestFunc)();
 struct TestItem {
 	const char *name;
@@ -491,6 +517,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(MatrixTranspose),
 	TEST_ITEM(ParseLBN),
 	TEST_ITEM(QuickTexHash),
+	TEST_ITEM(CLZ),
 };
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
This will be useful for our vfpu-dot implementations later (counting leading zeroes is useful in soft-float implementations).

I chose the ARM-like definition (counting leading zeroes instead of returning the index of the top set bit) because for us ARM is generally more performance-challenged.