### PR TITLE
Vulkan async pipeline creation

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1215,6 +1215,8 @@ bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *sourceCode, 
 		return false; // something didn't work
 	}
 
+	// TODO: Propagate warnings into errorMessages even if we succeeded here.
+
 	// Note that program does not take ownership of &shader, so this is fine.
 	program.addShader(&shader);
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -841,6 +841,9 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass, bool verbose) {
 			case VKRRenderCommand::REMOVED:
 				INFO_LOG(G3D, "  (Removed)");
 				break;
+			case VKRRenderCommand::BIND_PIPELINE:
+				INFO_LOG(G3D, "  BindPipeline(%x)", (int)(intptr_t)cmd.pipeline.pipeline);
+				break;
 			case VKRRenderCommand::BIND_GRAPHICS_PIPELINE:
 				INFO_LOG(G3D, "  BindGraphicsPipeline(%x)", (int)(intptr_t)cmd.graphics_pipeline.pipeline);
 				break;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -841,9 +841,11 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass, bool verbose) {
 			case VKRRenderCommand::REMOVED:
 				INFO_LOG(G3D, "  (Removed)");
 				break;
-
-			case VKRRenderCommand::BIND_PIPELINE:
-				INFO_LOG(G3D, "  BindPipeline(%x)", (int)(intptr_t)cmd.pipeline.pipeline);
+			case VKRRenderCommand::BIND_GRAPHICS_PIPELINE:
+				INFO_LOG(G3D, "  BindGraphicsPipeline(%x)", (int)(intptr_t)cmd.graphics_pipeline.pipeline);
+				break;
+			case VKRRenderCommand::BIND_COMPUTE_PIPELINE:
+				INFO_LOG(G3D, "  BindComputePipeline(%x)", (int)(intptr_t)cmd.compute_pipeline.pipeline);
 				break;
 			case VKRRenderCommand::BLEND:
 				INFO_LOG(G3D, "  BlendColor(%08x)", cmd.blendColor.color);
@@ -1236,6 +1238,9 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 	VKRFramebuffer *fb = step.render.framebuffer;
 
+	VkPipeline lastGraphicsPipeline = VK_NULL_HANDLE;
+	VkPipeline lastComputePipeline = VK_NULL_HANDLE;
+
 	auto &commands = step.commands;
 
 	// We can do a little bit of state tracking here to eliminate some calls into the driver.
@@ -1251,16 +1256,54 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		case VKRRenderCommand::REMOVED:
 			break;
 
+		// Still here to support binding of non-async pipelines.
 		case VKRRenderCommand::BIND_PIPELINE:
-			if (c.pipeline.pipeline != lastPipeline) {
-				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, c.pipeline.pipeline);
-				lastPipeline = c.pipeline.pipeline;
+		{
+			VkPipeline pipeline = c.pipeline.pipeline;
+			if (pipeline != lastGraphicsPipeline) {
+				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+				lastGraphicsPipeline = pipeline;
 				// Reset dynamic state so it gets refreshed with the new pipeline.
 				lastStencilWriteMask = -1;
 				lastStencilCompareMask = -1;
 				lastStencilReference = -1;
 			}
 			break;
+		}
+
+		case VKRRenderCommand::BIND_GRAPHICS_PIPELINE:
+		{
+			VKRGraphicsPipeline *pipeline = c.graphics_pipeline.pipeline;
+			if (!pipeline->pipeline) {
+				// Late! Compile it.
+				if (!pipeline->Create(vulkan_))
+					break;
+			}
+			if (pipeline->pipeline != lastGraphicsPipeline) {
+				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->pipeline);
+				lastGraphicsPipeline = pipeline->pipeline;
+				// Reset dynamic state so it gets refreshed with the new pipeline.
+				lastStencilWriteMask = -1;
+				lastStencilCompareMask = -1;
+				lastStencilReference = -1;
+			}
+			break;
+		}
+
+		case VKRRenderCommand::BIND_COMPUTE_PIPELINE:
+		{
+			VKRComputePipeline *pipeline = c.compute_pipeline.pipeline;
+			if (!pipeline->pipeline) {
+				// Late! Compile it.
+				if (!pipeline->Create(vulkan_))
+					break;
+			}
+			if (pipeline->pipeline != lastComputePipeline) {
+				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
+				lastComputePipeline = pipeline->pipeline;
+			}
+			break;
+		}
 
 		case VKRRenderCommand::VIEWPORT:
 			if (fb != nullptr) {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
+#include <condition_variable>
+
 
 #include "Common/Data/Collections/Hashmaps.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
@@ -254,6 +257,15 @@ public:
 		hacksEnabled_ = hacks;
 	}
 
+	void NotifyCompileDone() {
+		compileDone_.notify_all();
+	}
+
+	void WaitForCompileNotification() {
+		std::unique_lock<std::mutex> lock(compileDoneMutex_);
+		compileDone_.wait(lock);
+	}
+
 private:
 	void InitBackbufferRenderPass();
 
@@ -302,4 +314,8 @@ private:
 
 	// TODO: Enable based on compat.ini.
 	uint32_t hacksEnabled_ = 0;
+
+	// Compile done notifications.
+	std::mutex compileDoneMutex_;
+	std::condition_variable compileDone_;
 };

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -9,6 +9,8 @@
 #include "Common/GPU/DataFormat.h"
 
 class VKRFramebuffer;
+struct VKRGraphicsPipeline;
+struct VKRComputePipeline;
 struct VKRImage;
 
 enum {
@@ -20,7 +22,9 @@ enum {
 
 enum class VKRRenderCommand : uint8_t {
 	REMOVED,
-	BIND_PIPELINE,
+	BIND_PIPELINE,  // raw pipeline
+	BIND_GRAPHICS_PIPELINE,  // async
+	BIND_COMPUTE_PIPELINE,  // async
 	STENCIL,
 	BLEND,
 	VIEWPORT,
@@ -45,6 +49,12 @@ struct VkRenderData {
 		struct {
 			VkPipeline pipeline;
 		} pipeline;
+		struct {
+			VKRGraphicsPipeline *pipeline;
+		} graphics_pipeline;
+		struct {
+			VKRComputePipeline *pipeline;
+		} compute_pipeline;
 		struct {
 			VkPipelineLayout pipelineLayout;
 			VkDescriptorSet ds;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -33,8 +33,10 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan) {
 	delete desc;
 	desc = nullptr;
 	if (result == VK_INCOMPLETE) {
-		// Bad return value seen on Adreno in Burnout :(  Try to ignore?
-		// Create a placeholder to avoid creating over and over if something is broken.
+		// Bad (disallowed by spec) return value seen on Adreno in Burnout :(  Try to ignore?
+		// Would really like to log more here, we could probably attach more info to desc.
+		//
+		// At least create a null placeholder to avoid creating over and over if something is broken.
 		pipeline = VK_NULL_HANDLE;
 		return true;
 	} else if (result != VK_SUCCESS) {
@@ -58,6 +60,7 @@ bool VKRComputePipeline::Create(VulkanContext *vulkan) {
 	desc = nullptr;
 	if (result != VK_SUCCESS) {
 		pipeline = VK_NULL_HANDLE;
+		ERROR_LOG(G3D, "Failed creating compute pipeline! result='%s'", VulkanResultToString(result));
 		return false;
 	}
 	return true;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -22,6 +22,43 @@
 
 using namespace PPSSPP_VK;
 
+bool VKRGraphicsPipeline::Create(VulkanContext *vulkan) {
+	if (!desc) {
+		// Already failed to create this one.
+		return false;
+	}
+	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &pipeline);
+	delete desc;
+	desc = nullptr;
+	if (result == VK_INCOMPLETE) {
+		// Bad return value seen on Adreno in Burnout :(  Try to ignore?
+		// Create a placeholder to avoid creating over and over if something is broken.
+		pipeline = VK_NULL_HANDLE;
+		return true;
+	} else if (result != VK_SUCCESS) {
+		pipeline = VK_NULL_HANDLE;
+		ERROR_LOG(G3D, "Failed creating graphics pipeline! result='%s'", VulkanResultToString(result));
+		return false;
+	} else {
+		return true;
+	}
+}
+
+bool VKRComputePipeline::Create(VulkanContext *vulkan) {
+	if (!desc) {
+		// Already failed to create this one.
+		return false;
+	}
+	VkResult result = vkCreateComputePipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &pipeline);
+	delete desc;
+	desc = nullptr;
+	if (result != VK_SUCCESS) {
+		pipeline = VK_NULL_HANDLE;
+		return false;
+	}
+	return true;
+}
+
 VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRenderPass renderPass, int _width, int _height, const char *tag) : vulkan_(vk) {
 	width = _width;
 	height = _height;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -914,6 +914,8 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("InflightFrames", &g_Config.iInflightFrames, 3, true, false),
 	ConfigSetting("RenderDuplicateFrames", &g_Config.bRenderDuplicateFrames, false, true, true),
 
+	ConfigSetting("ShaderCache", &g_Config.bShaderCache, true, false, false),  // Doesn't save. Ini-only.
+
 	ConfigSetting(false),
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -224,6 +224,7 @@ public:
 	bool bFragmentTestCache;
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;
+	bool bShaderCache;  // Hidden ini-only setting, useful for debugging shader compile times.
 
 	std::vector<std::string> vPostShaderNames; // Off for chain end (only Off for no shader)
 	std::map<std::string, float> mPostShaderSetting;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -103,10 +103,14 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	// Load shader cache.
 	std::string discID = g_paramSFO.GetDiscID();
 	if (discID.size()) {
-		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
-		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".glshadercache");
-		// Actually precompiled by IsReady() since we're single-threaded.
-		shaderManagerGL_->Load(shaderCachePath_);
+		if (g_Config.bShaderCache) {
+			File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
+			shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".glshadercache");
+			// Actually precompiled by IsReady() since we're single-threaded.
+			shaderManagerGL_->Load(shaderCachePath_);
+		} else {
+			INFO_LOG(G3D, "Shader cache disabled. Not loading.");
+		}
 	}
 
 	if (g_Config.bHardwareTessellation) {
@@ -129,7 +133,11 @@ GPU_GLES::~GPU_GLES() {
 	// everything should already be cleared since DeviceLost has been run.
 
 	if (shaderCachePath_.Valid() && draw_) {
-		shaderManagerGL_->Save(shaderCachePath_);
+		if (g_Config.bShaderCache) {
+			shaderManagerGL_->Save(shaderCachePath_);
+		} else {
+			INFO_LOG(G3D, "Shader cache disabled. Not saving.");
+		}
 	}
 
 	framebufferManagerGL_->DestroyAllFBOs();

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -826,7 +826,7 @@ void DrawEngineVulkan::DoFlush() {
 
 			Draw::NativeObject object = framebufferManager_->UseBufferedRendering() ? Draw::NativeObject::FRAMEBUFFER_RENDERPASS : Draw::NativeObject::BACKBUFFER_RENDERPASS;
 			VkRenderPass renderPass = (VkRenderPass)draw_->GetNativeObject(object);
-			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(pipelineLayout_, renderPass, pipelineKey_, &dec_->decFmt, vshader, fshader, true);
+			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, renderPass, pipelineKey_, &dec_->decFmt, vshader, fshader, true);
 			if (!pipeline || !pipeline->pipeline) {
 				// Already logged, let's bail out.
 				return;
@@ -957,7 +957,7 @@ void DrawEngineVulkan::DoFlush() {
 				}
 				Draw::NativeObject object = framebufferManager_->UseBufferedRendering() ? Draw::NativeObject::FRAMEBUFFER_RENDERPASS : Draw::NativeObject::BACKBUFFER_RENDERPASS;
 				VkRenderPass renderPass = (VkRenderPass)draw_->GetNativeObject(object);
-				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(pipelineLayout_, renderPass, pipelineKey_, &dec_->decFmt, vshader, fshader, false);
+				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, renderPass, pipelineKey_, &dec_->decFmt, vshader, fshader, false);
 				if (!pipeline || !pipeline->pipeline) {
 					// Already logged, let's bail out.
 					return;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -123,6 +123,11 @@ void GPU_Vulkan::CancelReady() {
 }
 
 void GPU_Vulkan::LoadCache(const Path &filename) {
+	if (!g_Config.bShaderCache) {
+		INFO_LOG(G3D, "Shader cache disabled. Not loading.");
+		return;
+	}
+
 	PSP_SetLoading("Loading shader cache...");
 	// Actually precompiled by IsReady() since we're single-threaded.
 	FILE *f = File::OpenCFile(filename, "rb");
@@ -148,6 +153,11 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 }
 
 void GPU_Vulkan::SaveCache(const Path &filename) {
+	if (!g_Config.bShaderCache) {
+		INFO_LOG(G3D, "Shader cache disabled. Not saving.");
+		return;
+	}
+
 	if (!draw_) {
 		// Already got the lost message, we're in shutdown.
 		WARN_LOG(G3D, "Not saving shaders - shutting down from in-game.");

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -35,8 +35,12 @@ void PipelineManagerVulkan::Clear() {
 
 	pipelines_.Iterate([&](const VulkanPipelineKey &key, VulkanPipeline *value) {
 		if (value->pipeline) {
-			vulkan_->Delete().QueueDeletePipeline(value->pipeline->pipeline);
+			VkPipeline pipeline = value->pipeline->pipeline;
+			vulkan_->Delete().QueueDeletePipeline(pipeline);
 			delete value->pipeline;
+		} else {
+			// Something went wrong.
+			ERROR_LOG(G3D, "Null pipeline found in PipelineManagerVulkan::Clear - didn't wait for asyncs?");
 		}
 		delete value;
 	});

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -25,8 +25,10 @@
 #include "GPU/Common/ShaderCommon.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 #include "GPU/Vulkan/StateMappingVulkan.h"
-
 #include "GPU/Vulkan/VulkanQueueRunner.h"
+
+struct VKRGraphicsPipeline;
+class VulkanRenderManager;
 
 struct VulkanPipelineKey {
 	VulkanPipelineRasterStateKey raster;  // prim is included here
@@ -48,7 +50,7 @@ struct VulkanPipelineKey {
 
 // Simply wraps a Vulkan pipeline, providing some metadata.
 struct VulkanPipeline {
-	VkPipeline pipeline;
+	VKRGraphicsPipeline *pipeline;
 	int flags;  // PipelineFlags enum above.
 
 	bool UsesBlendConstant() const { return (flags & PIPELINE_FLAG_USES_BLEND_CONSTANT) != 0; }
@@ -67,7 +69,7 @@ public:
 	PipelineManagerVulkan(VulkanContext *ctx);
 	~PipelineManagerVulkan();
 
-	VulkanPipeline *GetOrCreatePipeline(VkPipelineLayout layout, VkRenderPass renderPass, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, bool useHwTransform);
+	VulkanPipeline *GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, VkRenderPass renderPass, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, bool useHwTransform);
 	int GetNumPipelines() const { return (int)pipelines_.size(); }
 
 	void Clear();


### PR DESCRIPTION
An experiment trying to reduce shader stutters by doing Vulkan pipeline creation on a separate thread. Later could be done on multiple threads to further utilize many-cores. (Warning: Pipelines using the same vs/ps should be on the same thread, sequentially!)

Ideally, compilation to SPIR-V and shader module creation should also be moved to this thread. Additionally, texture upscaling and so on could also be done on a thread.