### PR TITLE
Vulkan: Implement pretransform (performance optimization)

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -929,7 +929,7 @@ bool VulkanContext::InitSwapchain() {
 
 	if (physicalDeviceProperties_[physical_device_].properties.vendorID == VULKAN_VENDOR_IMGTEC) {
 		// Swap chain width hack to avoid issue #11743 (PowerVR driver bug).
-		// TODO: Check if still broken if pretransform is used
+		// TODO: Check if still broken if pretransform is used!
 		swapChainExtent_.width &= ~31;
 	}
 
@@ -1021,7 +1021,7 @@ bool VulkanContext::InitSwapchain() {
 	swap_chain_info.surface = surface_;
 	swap_chain_info.minImageCount = desiredNumberOfSwapChainImages;
 	swap_chain_info.imageFormat = swapchainFormat_;
-	swap_chain_info.imageColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
+	swap_chain_info.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 	swap_chain_info.imageExtent.width = swapChainExtent_.width;
 	swap_chain_info.imageExtent.height = swapChainExtent_.height;
 	swap_chain_info.preTransform = preTransform;
@@ -1030,8 +1030,9 @@ bool VulkanContext::InitSwapchain() {
 	swap_chain_info.oldSwapchain = VK_NULL_HANDLE;
 	swap_chain_info.clipped = true;
 	swap_chain_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-	if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
-		swap_chain_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+	// Don't ask for TRANSFER_DST for the swapchain image, we don't use that.
+	// if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+	//	swap_chain_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
 #ifndef ANDROID
 	// We don't support screenshots on Android
@@ -1056,7 +1057,7 @@ bool VulkanContext::InitSwapchain() {
 		ELOG("vkCreateSwapchainKHR failed!");
 		return false;
 	}
-
+	ILOG("Created swapchain: %dx%d", swap_chain_info.imageExtent.width, swap_chain_info.imageExtent.height);
 	return true;
 }
 

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -895,6 +895,20 @@ int clamp(int x, int a, int b) {
 	return x;
 }
 
+static std::string surface_transforms_to_string(VkSurfaceTransformFlagsKHR transformFlags) {
+	std::string str;
+	if (transformFlags & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) str += "IDENTITY ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR) str += "ROTATE_90 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR) str += "ROTATE_180 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR) str += "ROTATE_270 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR) str += "HMIRROR ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR) str += "HMIRROR_90 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR) str += "HMIRROR_180 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR) str += "HMIRROR_270 ";
+	if (transformFlags & VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR) str += "INHERIT ";
+	return str;
+}
+
 bool VulkanContext::InitSwapchain() {
 	VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_devices_[physical_device_], surface_, &surfCapabilities_);
 	assert(res == VK_SUCCESS);
@@ -963,7 +977,11 @@ bool VulkanContext::InitSwapchain() {
 	}
 
 	VkSurfaceTransformFlagBitsKHR preTransform;
-	if (surfCapabilities_.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+	std::string supportedTransforms = surface_transforms_to_string(surfCapabilities_.supportedTransforms);
+	std::string currentTransform = surface_transforms_to_string(surfCapabilities_.currentTransform);
+	ILOG("Supported transforms: %s", supportedTransforms.c_str());
+	ILOG("Current transform: %s", currentTransform.c_str());
+	if (surfCapabilities_.supportedTransforms & (VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR | VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR)) {
 		preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 	} else {
 		preTransform = surfCapabilities_.currentTransform;

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -734,7 +734,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 		// We are drawing to the back buffer so need to flip.
 		if (needBackBufferYSwap_)
 			std::swap(v0, v1);
-		flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+		flags = flags | DRAWTEX_TO_BACKBUFFER;
 		float x, y, w, h;
 		CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)pixelWidth_, (float)pixelHeight_, ROTATION_LOCKED_HORIZONTAL);
 		SetViewport2D(x, y, w, h);
@@ -809,7 +809,7 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, GEBu
 		std::swap(v0, v1);
 
 	DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
-	flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+	flags = flags | DRAWTEX_TO_BACKBUFFER;
 	if (cardboardSettings.enabled) {
 		// Left Eye Image
 		SetViewport2D(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
@@ -979,7 +979,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 			Bind2DShader();
 			DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
-			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+			flags = flags | DRAWTEX_TO_BACKBUFFER;
 			// We are doing the DrawActiveTexture call directly to the backbuffer here. Hence, we must
 			// flip V.
 			if (needBackBufferYSwap_)
@@ -1010,7 +1010,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			CalculatePostShaderUniforms(vfb->bufferWidth, vfb->bufferHeight, renderWidth_, renderHeight_, &uniforms);
 			BindPostShader(uniforms);
 			DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
-			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+			flags = flags | DRAWTEX_TO_BACKBUFFER;
 			DrawActiveTexture(0, 0, fbo_w, fbo_h, fbo_w, fbo_h, 0.0f, 0.0f, 1.0f, 1.0f, ROTATION_LOCKED_HORIZONTAL, flags);
 
 			draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
@@ -1030,7 +1030,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 				std::swap(v0, v1);
 			Bind2DShader();
 			flags = (!postShaderIsUpscalingFilter_ && g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
-			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+			flags = flags | DRAWTEX_TO_BACKBUFFER;
 			if (g_Config.bEnableCardboard) {
 				// Left Eye Image
 				SetViewport2D(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
@@ -1054,7 +1054,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			if (needBackBufferYSwap_)
 				std::swap(v0, v1);
 			DrawTextureFlags flags = (!postShaderIsUpscalingFilter_ && g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
-			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
+			flags = flags | DRAWTEX_TO_BACKBUFFER;
 
 			PostShaderUniforms uniforms{};
 			CalculatePostShaderUniforms(vfb->bufferWidth, vfb->bufferHeight, vfb->renderWidth, vfb->renderHeight, &uniforms);

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -725,6 +725,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 	float u0 = 0.0f, u1 = 1.0f;
 	float v0 = 0.0f, v1 = 1.0f;
 
+	DrawTextureFlags flags = (vfb || g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
 	if (useBufferedRendering_ && vfb && vfb->fbo) {
 		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP });
 		SetViewport2D(0, 0, vfb->renderWidth, vfb->renderHeight);
@@ -733,6 +734,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 		// We are drawing to the back buffer so need to flip.
 		if (needBackBufferYSwap_)
 			std::swap(v0, v1);
+		flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 		float x, y, w, h;
 		CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)pixelWidth_, (float)pixelHeight_, ROTATION_LOCKED_HORIZONTAL);
 		SetViewport2D(x, y, w, h);
@@ -741,7 +743,6 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 
 	MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height, u1, v1);
 
-	DrawTextureFlags flags = (vfb || g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
 	Bind2DShader();
 	DrawActiveTexture(dstX, dstY, width, height, vfb->bufferWidth, vfb->bufferHeight, u0, v0, u1, v1, ROTATION_LOCKED_HORIZONTAL, flags);
 	gpuStats.numUploads++;
@@ -808,6 +809,7 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, GEBu
 		std::swap(v0, v1);
 
 	DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+	flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 	if (cardboardSettings.enabled) {
 		// Left Eye Image
 		SetViewport2D(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
@@ -975,10 +977,11 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });
 			draw_->BindFramebufferAsTexture(vfb->fbo, 0, Draw::FB_COLOR_BIT, 0);
 			draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
+			Bind2DShader();
 			DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 			// We are doing the DrawActiveTexture call directly to the backbuffer here. Hence, we must
 			// flip V.
-			Bind2DShader();
 			if (needBackBufferYSwap_)
 				std::swap(v0, v1);
 			if (cardboardSettings.enabled) {
@@ -1007,6 +1010,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			CalculatePostShaderUniforms(vfb->bufferWidth, vfb->bufferHeight, renderWidth_, renderHeight_, &uniforms);
 			BindPostShader(uniforms);
 			DrawTextureFlags flags = g_Config.iBufFilter == SCALE_LINEAR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 			DrawActiveTexture(0, 0, fbo_w, fbo_h, fbo_w, fbo_h, 0.0f, 0.0f, 1.0f, 1.0f, ROTATION_LOCKED_HORIZONTAL, flags);
 
 			draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
@@ -1026,6 +1030,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 				std::swap(v0, v1);
 			Bind2DShader();
 			flags = (!postShaderIsUpscalingFilter_ && g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 			if (g_Config.bEnableCardboard) {
 				// Left Eye Image
 				SetViewport2D(cardboardSettings.leftEyeXPosition, cardboardSettings.screenYPosition, cardboardSettings.screenWidth, cardboardSettings.screenHeight);
@@ -1049,6 +1054,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput() {
 			if (needBackBufferYSwap_)
 				std::swap(v0, v1);
 			DrawTextureFlags flags = (!postShaderIsUpscalingFilter_ && g_Config.iBufFilter == SCALE_LINEAR) ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+			flags = (DrawTextureFlags)(flags | DRAWTEX_TO_BACKBUFFER);
 
 			PostShaderUniforms uniforms{};
 			CalculatePostShaderUniforms(vfb->bufferWidth, vfb->bufferHeight, vfb->renderWidth, vfb->renderHeight, &uniforms);

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -158,6 +158,10 @@ enum DrawTextureFlags {
 	DRAWTEX_TO_BACKBUFFER = 8,
 };
 
+inline DrawTextureFlags operator | (const DrawTextureFlags &lhs, const DrawTextureFlags &rhs) {
+	return DrawTextureFlags((u32)lhs | (u32)rhs);
+}
+
 enum class TempFBO {
 	DEPAL,
 	BLIT,

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -155,6 +155,7 @@ enum DrawTextureFlags {
 	DRAWTEX_LINEAR = 1,
 	DRAWTEX_KEEP_TEX = 2,
 	DRAWTEX_KEEP_STENCIL_ALPHA = 4,
+	DRAWTEX_TO_BACKBUFFER = 8,
 };
 
 enum class TempFBO {

--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -24,6 +24,9 @@
 // DbgNew is not compatible with Glslang
 #ifdef DBG_NEW
 #undef new
+#undef free
+#undef malloc
+#undef realloc
 #endif
 
 #include "base/logging.h"

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -20,6 +20,7 @@
 
 #include "profiler/profiler.h"
 
+#include "base/display.h"
 #include "base/timeutil.h"
 #include "math/lin/matrix4x4.h"
 #include "math/dataconv.h"
@@ -300,6 +301,16 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 	for (int i = 0; i < 4; i++) {
 		vtx[i].x = vtx[i].x * invDestW - 1.0f;
 		vtx[i].y = vtx[i].y * invDestH - 1.0f;
+	}
+
+	if (g_display_rotation != DisplayRotation::ROTATE_0) {
+		for (int i = 0; i < 4; i++) {
+			// backwards notation, should fix that...
+			Vec3 v(vtx[i].x, vtx[i].y, 0.0f);
+			v = v * g_display_rot_matrix;
+			vtx[i].x = v.x;
+			vtx[i].y = v.y;
+		}
 	}
 
 	draw_->FlushState();

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -303,7 +303,7 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 		vtx[i].y = vtx[i].y * invDestH - 1.0f;
 	}
 
-	if (g_display_rotation != DisplayRotation::ROTATE_0) {
+	if ((flags & DRAWTEX_TO_BACKBUFFER) && g_display_rotation != DisplayRotation::ROTATE_0) {
 		for (int i = 0; i < 4; i++) {
 			// backwards notation, should fix that...
 			Vec3 v(vtx[i].x, vtx[i].y, 0.0f);

--- a/ext/native/math/lin/matrix4x4.cpp
+++ b/ext/native/math/lin/matrix4x4.cpp
@@ -234,36 +234,6 @@ void Matrix4x4::setOrthoVulkan(float left, float right, float top, float bottom,
 	ww = 1.0f;
 }
 
-void Matrix4x4::setProjectionInf(const float near_plane, const float fov_horiz, const float aspect) {
-	empty();
-	float f = fov_horiz*0.5f;
-	xx = 1.0f / tanf(f);
-	yy = 1.0f / tanf(f*aspect);
-	zz = 1;
-	wz = -near_plane;
-	zw = 1.0f;
-}
-
-void Matrix4x4::setRotationAxisAngle(const Vec3 &axis, float angle) {
-	Quaternion quat;
-	quat.setRotation(axis, angle);
-	quat.toMatrix(this);
-}
-
-// from a (Position, Rotation, Scale) vec3 quat vec3 tuple
-Matrix4x4 Matrix4x4::fromPRS(const Vec3 &positionv, const Quaternion &rotv, const Vec3 &scalev) {
-	Matrix4x4 newM;
-	newM.setIdentity();
-	Matrix4x4 rot, scale;
-	rotv.toMatrix(&rot);
-	scale.setScaling(scalev);
-	newM = rot * scale;
-	newM.wx = positionv.x;
-	newM.wy = positionv.y;
-	newM.wz = positionv.z;
-	return newM;
-}
-
 void Matrix4x4::toText(char *buffer, int len) const {
 	snprintf(buffer, len, "%f %f %f %f\n%f %f %f %f\n%f %f %f %f\n%f %f %f %f\n",
 		xx,xy,xz,xw,

--- a/ext/native/math/lin/matrix4x4.h
+++ b/ext/native/math/lin/matrix4x4.h
@@ -111,6 +111,34 @@ public:
 		zz = 1.0f; 
 		ww = 1.0f;
 	}
+	// Exact angles to avoid any artifacts.
+	void setRotationZ90() {
+		empty();
+		float c = 0.0f;
+		float s = 1.0f;
+		xx = c;		xy = s;
+		yx = -s;	 yy = c;
+		zz = 1.0f;
+		ww = 1.0f;
+	}
+	void setRotationZ180() {
+		empty();
+		float c = -1.0f;
+		float s = 0.0f;
+		xx = c;		xy = s;
+		yx = -s;	 yy = c;
+		zz = 1.0f;
+		ww = 1.0f;
+	}
+	void setRotationZ270() {
+		empty();
+		float c = 0.0f;
+		float s = -1.0f;
+		xx = c;		xy = s;
+		yx = -s;	 yy = c;
+		zz = 1.0f;
+		ww = 1.0f;
+	}
 	void setRotationAxisAngle(const Vec3 &axis, float angle);
 
 

--- a/ext/native/math/lin/matrix4x4.h
+++ b/ext/native/math/lin/matrix4x4.h
@@ -35,7 +35,6 @@ public:
 		wx = v.x; wy = v.y; wz = v.z;
 	}
 
-
 	const float &operator[](int i) const {
 		return *(((const float *)this) + i);
 	}
@@ -56,25 +55,12 @@ public:
 		empty();
 		xx=yy=zz=f; ww=1.0f;
 	}
-	void setScaling(const Vec3 f) {
-		empty();
-		xx=f.x;
-		yy=f.y;
-		zz=f.z;
-		ww=1.0f;
-	}
 
 	void setIdentity() {
 		setScaling(1.0f);
 	}
 	void setTranslation(const Vec3 &trans) {
 		setIdentity();
-		wx = trans.x;
-		wy = trans.y;
-		wz = trans.z;
-	}
-	void setTranslationAndScaling(const Vec3 &trans, const Vec3 &scale) {
-		setScaling(scale);
 		wx = trans.x;
 		wy = trans.y;
 		wz = trans.z;
@@ -86,28 +72,28 @@ public:
 
 	void setRotationX(const float a) {
 		empty();
-		float c=cosf(a);
-		float s=sinf(a);
+		float c = cosf(a);
+		float s = sinf(a);
 		xx = 1.0f;
-		yy =	c;			yz = s;
-		zy = -s;			zz = c;
+		yy = c; yz = s;
+		zy = -s; zz = c;
 		ww = 1.0f;
 	}
 	void setRotationY(const float a)	 {
 		empty();
-		float c=cosf(a);
-		float s=sinf(a);
-		xx = c;									 xz = -s;
-		yy =	1.0f;
-		zx = s;									 zz = c	;
+		float c = cosf(a);
+		float s = sinf(a);
+		xx = c; xz = -s;
+		yy = 1.0f;
+		zx = s; zz = c;
 		ww = 1.0f;
 	}
 	void setRotationZ(const float a)	 {
 		empty();
-		float c=cosf(a);
-		float s=sinf(a);
-		xx = c;		xy = s;
-		yx = -s;	 yy = c;
+		float c = cosf(a);
+		float s = sinf(a);
+		xx = c; xy = s;
+		yx = -s; yy = c;
 		zz = 1.0f; 
 		ww = 1.0f;
 	}
@@ -116,8 +102,8 @@ public:
 		empty();
 		float c = 0.0f;
 		float s = 1.0f;
-		xx = c;		xy = s;
-		yx = -s;	 yy = c;
+		xx = c; xy = s;
+		yx = -s; yy = c;
 		zz = 1.0f;
 		ww = 1.0f;
 	}
@@ -125,8 +111,8 @@ public:
 		empty();
 		float c = -1.0f;
 		float s = 0.0f;
-		xx = c;		xy = s;
-		yx = -s;	 yy = c;
+		xx = c; xy = s;
+		yx = -s; yy = c;
 		zz = 1.0f;
 		ww = 1.0f;
 	}
@@ -134,49 +120,24 @@ public:
 		empty();
 		float c = 0.0f;
 		float s = -1.0f;
-		xx = c;		xy = s;
-		yx = -s;	 yy = c;
+		xx = c; xy = s;
+		yx = -s; yy = c;
 		zz = 1.0f;
 		ww = 1.0f;
 	}
-	void setRotationAxisAngle(const Vec3 &axis, float angle);
-
 
 	void setRotation(float x,float y, float z);
 	void setProjection(float near_plane, float far_plane, float fov_horiz, float aspect = 0.75f);
 	void setProjectionD3D(float near_plane, float far_plane, float fov_horiz, float aspect = 0.75f);
-	void setProjectionInf(float near_plane, float fov_horiz, float aspect = 0.75f);
 	void setOrtho(float left, float right, float bottom, float top, float near, float far);
 	void setOrthoD3D(float left, float right, float bottom, float top, float near, float far);
 	void setOrthoVulkan(float left, float right, float top, float bottom, float near, float far);
-	void setShadow(float Lx, float Ly, float Lz, float Lw) {
-		float Pa=0;
-		float Pb=1;
-		float Pc=0;
-		float Pd=0;
-		//P = normalize(Plane);
-		float d = (Pa*Lx + Pb*Ly + Pc*Lz + Pd*Lw);
-
-		xx=Pa * Lx + d;	xy=Pa * Ly;		 xz=Pa * Lz;		 xw=Pa * Lw;
-		yx=Pb * Lx;			yy=Pb * Ly + d; yz=Pb * Lz;		 yw=Pb * Lw;
-		zx=Pc * Lx;			zy=Pc * Ly;		 zz=Pc * Lz + d; zw=Pc * Lw;
-		wx=Pd * Lx;			wy=Pd * Ly;		 wz=Pd * Lz;		 ww=Pd * Lw + d;
-	}
 
 	void setViewLookAt(const Vec3 &from, const Vec3 &at, const Vec3 &worldup);
 	void setViewLookAtD3D(const Vec3 &from, const Vec3 &at, const Vec3 &worldup);
 	void setViewFrame(const Vec3 &pos, const Vec3 &right, const Vec3 &forward, const Vec3 &up);
-	void stabilizeOrtho() {
-		/*
-		front().normalize();
-		right().normalize();
-		up() = front() % right();
-		right() = up() % front();
-		*/
-	}
 	void toText(char *buffer, int len) const;
 	void print() const;
-	static Matrix4x4 fromPRS(const Vec3 &position, const Quaternion &normal, const Vec3 &scale);
 
 	void translateAndScale(const Vec3 &trans, const Vec3 &scale) {
 		xx = xx * scale.x + xw * trans.x;

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -375,7 +375,10 @@ void DrawContext::RotateRectToDisplay(FRect &rect, float curRTWidth, float curRT
 	case DisplayRotation::ROTATE_270: {
 		float origX = rect.x;
 		float origY = rect.y;
-		// TODO
+		float rtw = curRTHeight;
+		float rth = curRTWidth;
+		rect.x = origY;
+		rect.y = rtw - rect.w - origX;
 		std::swap(rect.w, rect.h);
 		break;
 	}

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "base/logging.h"
+#include "base/display.h"
 #include "thin3d/thin3d.h"
 #include "Common/Log.h"
 #include "Common/ColorConv.h"
@@ -350,6 +351,35 @@ void DrawContext::DestroyPresets() {
 
 DrawContext::~DrawContext() {
 	DestroyPresets();
+}
+
+void DrawContext::RotateRectToDisplay(FRect &rect, float curRTWidth, float curRTHeight) {
+	if (g_display_rotation == DisplayRotation::ROTATE_0)
+		return;
+	switch (g_display_rotation) {
+	case DisplayRotation::ROTATE_180:
+		rect.x = curRTWidth - rect.w - rect.x;
+		rect.y = curRTHeight - rect.h - rect.y;
+		break;
+	case DisplayRotation::ROTATE_90: {
+		// Note that curRTWidth_ and curRTHeight_ are "swapped"!
+		float origX = rect.x;
+		float origY = rect.y;
+		float rtw = curRTHeight;
+		float rth = curRTWidth;
+		rect.x = rth - rect.h - origY;
+		rect.y = origX;
+		std::swap(rect.w, rect.h);
+		break;
+	}
+	case DisplayRotation::ROTATE_270: {
+		float origX = rect.x;
+		float origY = rect.y;
+		// TODO
+		std::swap(rect.w, rect.h);
+		break;
+	}
+	}
 }
 
 // TODO: SSE/NEON

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -661,6 +661,11 @@ public:
 	virtual void FlushState() {}
 
 protected:
+	struct FRect {
+		float x, y, w, h;
+	};
+	void RotateRectToDisplay(FRect &rect, float curRTWidth, float curRTHeight);
+
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];
 


### PR DESCRIPTION
Apply the pretransform that the operating system wants when drawing to the backbuffer.

This should save a lot of memory bandwidth on mobile devices that can't rotate images natively in the display engine. Fixes #12099.

Hopefully this will close the gap in the few instances where GL is currently faster (since GL drivers do this automatically).

Needs a bit of testing before merge.

Explanation for why this helps is here:
https://arm-software.github.io/vulkan_best_practice_for_mobile_developers/samples/surface_rotation/surface_rotation_tutorial.html