### PR TITLE
Add a hidden ini setting to disable graphics backends

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -679,10 +679,14 @@ static bool DefaultVertexCache() {
 template <typename T, std::string (*FTo)(T), T (*FFrom)(const std::string &)>
 struct ConfigTranslator {
 	static std::string To(int v) {
-		return FTo(T(v));
+		return StringFromInt(v) + " (" + FTo(T(v)) + ")";
 	}
 
 	static int From(const std::string &v) {
+		int result;
+		if (TryParse(v, &result)) {
+			return result;
+		}
 		return (int)FFrom(v);
 	}
 };

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -550,7 +550,7 @@ int Config::NextValidBackend() {
 	SplitString(sFailedGPUBackends, ',', split);
 	for (const auto &str : split) {
 		if (!str.empty() && str != "ALL") {
-			failed.insert(atoi(str.c_str()));
+			failed.insert((int)GPUBackendFromString(str));
 		}
 	}
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -23,6 +23,7 @@
 
 #include "ppsspp_config.h"
 #include "Common/CommonTypes.h"
+#include "Core/ConfigValues.h"
 
 extern const char *PPSSPP_GIT_VERSION;
 
@@ -124,6 +125,7 @@ public:
 	// GFX
 	int iGPUBackend;
 	std::string sFailedGPUBackends;
+	std::string sDisabledGPUBackends;
 	// We have separate device parameters for each backend so it doesn't get erased if you switch backends.
 	// If not set, will use the "best" device.
 	std::string sVulkanDevice;
@@ -441,6 +443,7 @@ public:
 
 	bool IsPortrait() const;
 	int NextValidBackend();
+	bool IsBackendEnabled(GPUBackend backend, bool validate = true);
 
 protected:
 	void LoadStandardControllerIni();

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -19,6 +19,10 @@
 
 #include <cstdint>
 #include <string>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
+#include "Common/CommonFuncs.h"
 
 const int PSP_MODEL_FAT = 0;
 const int PSP_MODEL_SLIM = 1;
@@ -70,13 +74,13 @@ inline std::string GPUBackendToString(GPUBackend backend) {
 }
 
 inline GPUBackend GPUBackendFromString(const std::string &backend) {
-	if (backend == "OPENGL" || backend == "0")
+	if (!strcasecmp(backend.c_str(), "OPENGL") || backend == "0")
 		return GPUBackend::OPENGL;
-	if (backend == "DIRECT3D9" || backend == "1")
+	if (!strcasecmp(backend.c_str(), "DIRECT3D9") || backend == "1")
 		return GPUBackend::DIRECT3D9;
-	if (backend == "DIRECT3D11" || backend == "2")
+	if (!strcasecmp(backend.c_str(), "DIRECT3D11") || backend == "2")
 		return GPUBackend::DIRECT3D11;
-	if (backend == "VULKAN" || backend == "3")
+	if (!strcasecmp(backend.c_str(), "VULKAN") || backend == "3")
 		return GPUBackend::VULKAN;
 	return GPUBackend::OPENGL;
 }

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 const int PSP_MODEL_FAT = 0;
 const int PSP_MODEL_SLIM = 1;
@@ -52,6 +53,33 @@ enum class GPUBackend {
 	DIRECT3D11 = 2,
 	VULKAN = 3,
 };
+
+inline std::string GPUBackendToString(GPUBackend backend) {
+	switch (backend) {
+	case GPUBackend::OPENGL:
+		return "OPENGL";
+	case GPUBackend::DIRECT3D9:
+		return "DIRECT3D9";
+	case GPUBackend::DIRECT3D11:
+		return "DIRECT3D11";
+	case GPUBackend::VULKAN:
+		return "VULKAN";
+	}
+	// Intentionally not a default so we get a warning.
+	return "INVALID";
+}
+
+inline GPUBackend GPUBackendFromString(const std::string &backend) {
+	if (backend == "OPENGL" || backend == "0")
+		return GPUBackend::OPENGL;
+	if (backend == "DIRECT3D9" || backend == "1")
+		return GPUBackend::DIRECT3D9;
+	if (backend == "DIRECT3D11" || backend == "2")
+		return GPUBackend::DIRECT3D11;
+	if (backend == "VULKAN" || backend == "3")
+		return GPUBackend::VULKAN;
+	return GPUBackend::OPENGL;
+}
 
 enum AudioBackendType {
 	AUDIO_BACKEND_AUTO,

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -822,7 +822,7 @@ void NotifyDisplay(u32 framebuf, int stride, int fmt) {
 		int linesize, pixelFormat;
 	};
 
-	DisplayBufData disp{ framebuf, stride, fmt };
+	DisplayBufData disp{ { framebuf }, stride, fmt };
 
 	FlushRegisters();
 	u32 ptr = (u32)pushbuf.size();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -68,8 +68,6 @@
 #include "Windows/W32Util/ShellUtil.h"
 #endif
 
-extern bool VulkanMayBeAvailable();
-
 GameSettingsScreen::GameSettingsScreen(std::string gamePath, std::string gameID, bool editThenRestore)
 	: UIDialogScreenWithGameBackground(gamePath), gameID_(gameID), enableReports_(false), editThenRestore_(editThenRestore) {
 	lastVertical_ = UseVerticalLayout();
@@ -199,26 +197,17 @@ void GameSettingsScreen::CreateViews() {
 	static const char *renderingBackend[] = { "OpenGL", "Direct3D 9", "Direct3D 11", "Vulkan" };
 	PopupMultiChoice *renderingBackendChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iGPUBackend, gr->T("Backend"), renderingBackend, (int)GPUBackend::OPENGL, ARRAY_SIZE(renderingBackend), gr->GetName(), screenManager()));
 	renderingBackendChoice->OnChoice.Handle(this, &GameSettingsScreen::OnRenderingBackend);
-#if !PPSSPP_PLATFORM(WINDOWS)
-	renderingBackendChoice->HideChoice(1);  // D3D9
-	renderingBackendChoice->HideChoice(2);  // D3D11
-#else
-#if !PPSSPP_API(ANY_GL)
-	renderingBackendChoice->HideChoice(0);  // OpenGL
+
+	if (!g_Config.IsBackendEnabled(GPUBackend::OPENGL))
+		renderingBackendChoice->HideChoice((int)GPUBackend::OPENGL);
+	if (!g_Config.IsBackendEnabled(GPUBackend::DIRECT3D9))
+		renderingBackendChoice->HideChoice((int)GPUBackend::DIRECT3D9);
+	if (!g_Config.IsBackendEnabled(GPUBackend::DIRECT3D11))
+		renderingBackendChoice->HideChoice((int)GPUBackend::DIRECT3D11);
+	if (!g_Config.IsBackendEnabled(GPUBackend::VULKAN))
+		renderingBackendChoice->HideChoice((int)GPUBackend::VULKAN);
 #endif
-	if (!DoesVersionMatchWindows(6, 0, 0, 0, true)) {
-		// Hide the D3D11 choice if Windows version is older than Windows Vista.
-		renderingBackendChoice->HideChoice(2);  // D3D11
-	}
-#endif
-	bool vulkanAvailable = false;
-#ifndef IOS
-	vulkanAvailable = VulkanMayBeAvailable();
-#endif
-	if (!vulkanAvailable) {
-		renderingBackendChoice->HideChoice(3);
-	}
-#endif
+
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
 	// Backends that don't allow a device choice will only expose one device.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -392,9 +392,9 @@ static void CheckFailedGPUBackends() {
 		WARN_LOG(LOADER, "Failed graphics backend switched from %d to %d", lastBackend, g_Config.iGPUBackend);
 	// And then let's - for now - add the current to the failed list.
 	if (g_Config.sFailedGPUBackends.empty()) {
-		g_Config.sFailedGPUBackends = StringFromFormat("%d", g_Config.iGPUBackend);
+		g_Config.sFailedGPUBackends = GPUBackendToString((GPUBackend)g_Config.iGPUBackend);
 	} else if (g_Config.sFailedGPUBackends.find("ALL") == std::string::npos) {
-		g_Config.sFailedGPUBackends += StringFromFormat(",%d", g_Config.iGPUBackend);
+		g_Config.sFailedGPUBackends += "," + GPUBackendToString((GPUBackend)g_Config.iGPUBackend);
 	}
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1290,14 +1290,11 @@ namespace MainWindow {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ((i == g_Config.iCurrentStateSlot) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
-		bool allowD3D11 = DoesVersionMatchWindows(6, 0, 0, 0, true);
-		bool allowVulkan = VulkanMayBeAvailable();
+		bool allowD3D9 = g_Config.IsBackendEnabled(GPUBackend::DIRECT3D9);
+		bool allowD3D11 = g_Config.IsBackendEnabled(GPUBackend::DIRECT3D11);
+		bool allowOpenGL = g_Config.IsBackendEnabled(GPUBackend::OPENGL);
+		bool allowVulkan = g_Config.IsBackendEnabled(GPUBackend::VULKAN);
 
-#if PPSSPP_API(ANY_GL)
-		bool allowOpenGL = true;
-#else
-		bool allowOpenGL = false;
-#endif
 		switch (GetGPUBackend()) {
 		case GPUBackend::DIRECT3D9:
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_GRAYED);
@@ -1310,7 +1307,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_UNCHECKED);
 			break;
 		case GPUBackend::OPENGL:
-			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
+			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, allowD3D9 ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, allowD3D11 ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_VULKAN, allowVulkan ? MF_ENABLED : MF_GRAYED);
@@ -1320,7 +1317,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_UNCHECKED);
 			break;
 		case GPUBackend::VULKAN:
-			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
+			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, allowD3D9 ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, allowD3D11 ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, allowOpenGL ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_VULKAN, MF_GRAYED);
@@ -1330,7 +1327,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, ID_OPTIONS_VULKAN, MF_CHECKED);
 			break;
 		case GPUBackend::DIRECT3D11:
-			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, MF_ENABLED);
+			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D9, allowD3D9 ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_DIRECT3D11, MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_OPENGL, allowOpenGL ? MF_ENABLED : MF_GRAYED);
 			EnableMenuItem(menu, ID_OPTIONS_VULKAN, allowVulkan ? MF_ENABLED : MF_GRAYED);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -572,7 +572,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 #ifndef _DEBUG
 	// See #11719 - too many Vulkan drivers crash on basic init.
-	VulkanSetAvailable(DetectVulkanInExternalProcess());
+	if (g_Config.IsBackendEnabled(GPUBackend::VULKAN)) {
+		VulkanSetAvailable(DetectVulkanInExternalProcess());
+	}
 #endif
 
 	if (iCmdShow == SW_MAXIMIZE) {


### PR DESCRIPTION
This also shows them as identifiers, for example "VULKAN" instead of "3" (both in the main setting and disabled/failed settings.)  Of course, this change will mean that downgrading would reset the backend (since it won't be a number), but I don't think that's terrible.

With this setting, if someone has an Android device with broken Vulkan drivers (which has been reported) that crash, there's at least an option to disable in the ini so they can still use the ini settings.

Additionally centralizes some of the backend support checks, so that they aren't directly in the game settings screen, for example.

-[Unknown]