### PR TITLE
Fix macOS Travis builds

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -79,6 +79,9 @@ travis_install() {
 
     if [ "$PPSSPP_BUILD_TYPE" = "macOS" ]; then
         brew_install sdl2
+        brew upgrade python
+    elif [ "$PPSSPP_BUILD_TYPE" = "iOS" ]; then
+        brew upgrade python
     fi
 
     # Ensure we're using ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ addons:
       - lib32bz2-1.0
 
 cache:
-  - apt
-  - ccache
+  apt: true
+  ccache: true
+  directories:
+    - $HOME/Library/Caches/Homebrew
 
 # By encrypting the channel name, we disable notifications from forks by default.
 # It's not actually a big secret.
@@ -74,14 +76,12 @@ matrix:
            LIBRETRO=TRUE
     - os: osx
       osx_image: xcode8
-      compiler: "clang macos"
+      compiler: "clang"
       env: PPSSPP_BUILD_TYPE=macOS
-           CMAKE=TRUE
     - os: osx
       osx_image: xcode8
-      compiler: "clang ios"
+      compiler: "clang"
       env: PPSSPP_BUILD_TYPE=iOS
-           CMAKE=TRUE
 
 before_install:
   - bash .travis.sh travis_before_install

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -874,6 +874,10 @@ namespace MIPSInt
 			d[0] = ShrinkToHalf(s[0]) | ((u32)ShrinkToHalf(s[1]) << 16);
 			d[1] = ShrinkToHalf(s[2]) | ((u32)ShrinkToHalf(s[3]) << 16);
 			break;
+
+		default:
+			ERROR_LOG_REPORT(CPU, "vf2h with invalid elements");
+			break;
 		}
 		ApplyPrefixD(reinterpret_cast<float *>(d), outsize);
 		WriteVector(reinterpret_cast<float *>(d), outsize, vd);
@@ -939,7 +943,7 @@ namespace MIPSInt
 				break;
 
 			default:
-				ERROR_LOG_REPORT(CPU, "vus2i with more than 2 elements.");
+				ERROR_LOG_REPORT(CPU, "vus2i with more than 2 elements");
 				break;
 			}
 			break;
@@ -963,7 +967,7 @@ namespace MIPSInt
 				break;
 
 			default:
-				ERROR_LOG_REPORT(CPU, "vs2i with more than 2 elements.");
+				ERROR_LOG_REPORT(CPU, "vs2i with more than 2 elements");
 				break;
 			}
 			break;
@@ -2080,6 +2084,10 @@ namespace MIPSInt
 		case V_Single:
 			// t swizzles invalid so the multiply is always zero.
 			d[0] = 0;
+			break;
+
+		default:
+			ERROR_LOG_REPORT(CPU, "vcrsp/vqmul with invalid elements");
 			break;
 		}
 

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -121,27 +121,27 @@ enum MatrixSize {
 	M_Invalid = -1
 };
 
-static u32 VFPU_SWIZZLE(int x, int y, int z, int w) {
+inline u32 VFPU_SWIZZLE(int x, int y, int z, int w) {
 	return (x << 0) | (y << 2) | (z << 4) | (w << 6);
 }
 
-static u32 VFPU_MASK(int x, int y, int z, int w) {
+inline u32 VFPU_MASK(int x, int y, int z, int w) {
 	return (x << 0) | (y << 1) | (z << 2) | (w << 3);
 }
 
-static u32 VFPU_ANY_SWIZZLE() {
+inline u32 VFPU_ANY_SWIZZLE() {
 	return 0x000000FF;
 }
 
-static u32 VFPU_ABS(int x, int y, int z, int w) {
+inline u32 VFPU_ABS(int x, int y, int z, int w) {
 	return VFPU_MASK(x, y, z, w) << 8;
 }
 
-static u32 VFPU_CONST(int x, int y, int z, int w) {
+inline u32 VFPU_CONST(int x, int y, int z, int w) {
 	return VFPU_MASK(x, y, z, w) << 12;
 }
 
-static u32 VFPU_NEGATE(int x, int y, int z, int w) {
+inline u32 VFPU_NEGATE(int x, int y, int z, int w) {
 	return VFPU_MASK(x, y, z, w) << 16;
 }
 
@@ -157,7 +157,7 @@ enum class VFPUConst {
 	SIXTH,
 };
 
-static u32 VFPU_MAKE_CONSTANTS(VFPUConst x, VFPUConst y, VFPUConst z, VFPUConst w) {
+inline u32 VFPU_MAKE_CONSTANTS(VFPUConst x, VFPUConst y, VFPUConst z, VFPUConst w) {
 	u32 result = 0;
 	if (x != VFPUConst::NONE) {
 		// This sets the constant flag and the swizzle/abs flags for the right constant.

--- a/GPU/GLES/DepalettizeShaderGLES.h
+++ b/GPU/GLES/DepalettizeShaderGLES.h
@@ -64,7 +64,6 @@ private:
 
 	GLRenderManager *render_;
 	bool useGL3_;
-	bool vertexShaderFailed_ = false;
 	GLRShader *vertexShader_ = nullptr;
 	std::map<u32, DepalShader *> cache_;
 	std::map<u32, DepalTexture *> texCache_;

--- a/UI/DiscordIntegration.cpp
+++ b/UI/DiscordIntegration.cpp
@@ -31,10 +31,12 @@ Discord g_Discord;
 
 static const char *ppsspp_app_id = "423397985041383434";
 
+#ifdef ENABLE_DISCORD
 // No context argument? What?
 static void handleDiscordError(int errCode, const char *message) {
 	ERROR_LOG(SYSTEM, "Discord error code %d: '%s'", errCode, message);
 }
+#endif
 
 Discord::~Discord() {
 	assert(!initialized_);


### PR DESCRIPTION
For now, this is compiling in Python.  I briefly experimented with changing the build file for cmake, but I didn't have a lot of time to mess with it and it seemed to get somewhat messy.

This also fixes caching for the macOS travis builds so it's not as much slower as it could be.  It seems like there might be a way to cache the built python too, but for now this fixes CI.

-[Unknown]