### PR TITLE
Debugger: Fix connection in Firefox

### DIFF
--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -70,7 +70,7 @@ Request::~Request() {
 	delete out_;
 }
 
-void Request::WriteHttpResponseHeader(int status, int64_t size, const char *mimeType, const char *otherHeaders) const {
+void Request::WriteHttpResponseHeader(const char *ver, int status, int64_t size, const char *mimeType, const char *otherHeaders) const {
 	const char *statusStr;
 	switch (status) {
 	case 200: statusStr = "OK"; break;
@@ -92,7 +92,7 @@ void Request::WriteHttpResponseHeader(int status, int64_t size, const char *mime
 	}
 
 	net::OutputSink *buffer = Out();
-	buffer->Printf("HTTP/1.0 %03d %s\r\n", status, statusStr);
+	buffer->Printf("HTTP/%s %03d %s\r\n", ver, status, statusStr);
 	buffer->Push("Server: PPSSPPServer v0.1\r\n");
 	if (!mimeType || strcmp(mimeType, "websocket") != 0) {
 		buffer->Printf("Content-Type: %s\r\n", mimeType ? mimeType : DEFAULT_MIME_TYPE);
@@ -313,12 +313,12 @@ void Server::HandleRequestDefault(const Request &request) {
 void Server::Handle404(const Request &request) {
 	ILOG("No handler for '%s', falling back to 404.", request.resource());
 	const char *payload = "<html><body>404 not found</body></html>\r\n";
-	request.WriteHttpResponseHeader(404, (int)strlen(payload));
+	request.WriteHttpResponseHeader("1.0", 404, (int)strlen(payload));
 	request.Out()->Push(payload);
 }
 
 void Server::HandleListing(const Request &request) {
-	request.WriteHttpResponseHeader(200, -1, "text/plain");
+	request.WriteHttpResponseHeader("1.0", 200, -1, "text/plain");
 	for (auto iter = handlers_.begin(); iter != handlers_.end(); ++iter) {
 		request.Out()->Printf("%s\n", iter->first.c_str());
 	}

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -50,7 +50,7 @@ class Request {
   bool IsOK() const { return fd_ > 0; }
 
   // If size is negative, no Content-Length: line is written.
-  void WriteHttpResponseHeader(int status, int64_t size = -1, const char *mimeType = nullptr, const char *otherHeaders = nullptr) const;
+  void WriteHttpResponseHeader(const char *ver, int status, int64_t size = -1, const char *mimeType = nullptr, const char *otherHeaders = nullptr) const;
 
 private:
 	net::InputSink *in_;

--- a/ext/native/net/websocket_server.cpp
+++ b/ext/native/net/websocket_server.cpp
@@ -90,12 +90,12 @@ WebSocketServer *WebSocketServer::CreateAsUpgrade(const http::Request &request, 
 	};
 
 	if (!requireHeader("upgrade", "websocket") || !requireHeaderContains("connection", "upgrade")) {
-		request.WriteHttpResponseHeader(400, -1, "text/plain");
+		request.WriteHttpResponseHeader("1.1", 400, -1, "text/plain");
 		request.Out()->Push("Must send a websocket request.");
 		return nullptr;
 	}
 	if (!requireHeader("sec-websocket-version", "13")) {
-		request.WriteHttpResponseHeader(400, -1, "text/plain", "Sec-WebSocket-Version: 13\r\n");
+		request.WriteHttpResponseHeader("1.1", 400, -1, "text/plain", "Sec-WebSocket-Version: 13\r\n");
 		request.Out()->Push("Unsupported version.");
 		return nullptr;
 	}
@@ -110,7 +110,7 @@ WebSocketServer *WebSocketServer::CreateAsUpgrade(const http::Request &request, 
 
 	std::string key;
 	if (!request.GetHeader("sec-websocket-key", &key)) {
-		request.WriteHttpResponseHeader(400, -1, "text/plain");
+		request.WriteHttpResponseHeader("1.1", 400, -1, "text/plain");
 		request.Out()->Push("Cannot accept without key.");
 		return nullptr;
 	}
@@ -123,7 +123,7 @@ WebSocketServer *WebSocketServer::CreateAsUpgrade(const http::Request &request, 
 	std::string otherHeaders = StringFromFormat("Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n%s", acceptKey.c_str(), obtainedProtocolHeader.c_str());
 
 	// Okay, we're good to go then.
-	request.WriteHttpResponseHeader(101, -1, "websocket", otherHeaders.c_str());
+	request.WriteHttpResponseHeader("1.1", 101, -1, "websocket", otherHeaders.c_str());
 	request.WritePartial();
 
 	return new WebSocketServer(request.fd(), request.In(), request.Out());


### PR DESCRIPTION
Firefox now requires HTTP/1.1 or higher, which is reasonable since 1.0 is ancient.  The Upgrade response and WebSocket protocol handling are all HTTP/1.1 safe, so let's just support both versions.

-[Unknown]