### PR TITLE
Audio: Add volume for alternate speed

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -779,6 +779,7 @@ static ConfigSetting soundSettings[] = {
 	ConfigSetting("ExtraAudioBuffering", &g_Config.bExtraAudioBuffering, false, true, false),
 	ConfigSetting("AudioResampler", &g_Config.bAudioResampler, true, true, true),
 	ConfigSetting("GlobalVolume", &g_Config.iGlobalVolume, VOLUME_MAX, true, true),
+	ConfigSetting("AltSpeedVolume", &g_Config.iAltSpeedVolume, -1, true, true),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -202,6 +202,7 @@ public:
 	int iAudioLatency; // 0 = low , 1 = medium(default) , 2 = high
 	int iAudioBackend;
 	int iGlobalVolume;
+	int iAltSpeedVolume;
 	bool bExtraAudioBuffering;  // For bluetooth
 
 	// UI

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -137,12 +137,19 @@ inline void ClampBufferToS16(s16 *out, const s32 *in, size_t size, s8 volShift) 
 }
 
 inline void ClampBufferToS16WithVolume(s16 *out, const s32 *in, size_t size) {
-	if (g_Config.iGlobalVolume >= VOLUME_MAX) {
+	int volume = g_Config.iGlobalVolume;
+	if (PSP_CoreParameter().fpsLimit != FPSLimit::NORMAL || PSP_CoreParameter().unthrottle) {
+		if (g_Config.iAltSpeedVolume != -1) {
+			volume = g_Config.iAltSpeedVolume;
+		}
+	}
+
+	if (volume >= VOLUME_MAX) {
 		ClampBufferToS16<false>(out, in, size, 0);
-	} else if (g_Config.iGlobalVolume <= VOLUME_OFF) {
+	} else if (volume <= VOLUME_OFF) {
 		memset(out, 0, size * sizeof(s16));
 	} else {
-		ClampBufferToS16<true>(out, in, size, VOLUME_MAX - (s8)g_Config.iGlobalVolume);
+		ClampBufferToS16<true>(out, in, size, VOLUME_MAX - (s8)volume);
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -485,6 +485,12 @@ void GameSettingsScreen::CreateViews() {
 
 	PopupSliderChoice *volume = audioSettings->Add(new PopupSliderChoice(&g_Config.iGlobalVolume, VOLUME_OFF, VOLUME_MAX, a->T("Global volume"), screenManager()));
 	volume->SetEnabledPtr(&g_Config.bEnableSound);
+	volume->SetZeroLabel(a->T("Mute"));
+
+	PopupSliderChoice *altVolume = audioSettings->Add(new PopupSliderChoice(&g_Config.iAltSpeedVolume, VOLUME_OFF, VOLUME_MAX, a->T("Alternate speed volume"), screenManager()));
+	altVolume->SetEnabledPtr(&g_Config.bEnableSound);
+	altVolume->SetZeroLabel(a->T("Mute"));
+	altVolume->SetNegativeDisable(a->T("Use global volume"));
 
 #ifdef _WIN32
 	if (IsVistaOrHigher()) {


### PR DESCRIPTION
Fixes #11605.  Also makes both volumes show "Mute" when set to 0, for clarity versus Use global volume.

-[Unknown]