### PR TITLE
Debugger: Fix subtexture readback crash

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1246,6 +1246,10 @@ static void ConvertStencilFunc5551(GenericStencilFuncState &state) {
 			state.testRef = usedRef;
 			// Nuke the mask as well, since this is always/never, just for consistency.
 			state.testMask = 0xFF;
+		} else {
+			// Not used, so let's make the ref 0xFF which is a useful value later.
+			state.testRef = 0xFF;
+			state.testMask = 0xFF;
 		}
 	};
 
@@ -1340,6 +1344,10 @@ static void ConvertStencilFunc5551(GenericStencilFuncState &state) {
 		// If it's == 0 (as optimized above), then we can rewrite INCR to INVERT.
 		// Otherwise we get 1, which we mostly handle, but won't INVERT correctly.
 		rewriteOps(GE_STENCILOP_INCR, GE_STENCILOP_INVERT);
+	}
+	if (!usesRef && state.testRef == 0xFF) {
+		// Safe to use REPLACE instead of INCR.
+		rewriteOps(GE_STENCILOP_INCR, GE_STENCILOP_REPLACE);
 	}
 }
 


### PR DESCRIPTION
Also slight improvement to stencil values in a 5551 framebuffer case.  I'm not sure if it'll fix anything itself (I think we mostly treat != 0 as 255 already.)

-[Unknown]