### PR TITLE
[WIP] External display support on Android

### DIFF
--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -6,6 +6,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.AlertDialog;
+import android.app.Presentation;
 import android.app.UiModeManager;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -19,11 +20,14 @@ import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
+import android.hardware.display.DisplayManager;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.PowerManager;
 import android.os.Vibrator;
 import android.provider.MediaStore;
@@ -89,6 +93,10 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 	private AudioFocusChangeListener audioFocusChangeListener;
 	private AudioManager audioManager;
 	private PowerManager powerManager;
+	private DisplayManager displayManager;
+	private NativeDisplayListener nativeDisplayListener;
+
+	private Presentation mPresentation;
 
 	private Vibrator vibrator;
 
@@ -342,6 +350,39 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		}
 	}
 
+	// Reference: https://developer.android.com/reference/android/app/Presentation
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	public void updatePresentation(Display display) {
+		if (mPresentation != null && mPresentation.getDisplay() != display) {
+			mPresentation.dismiss();
+			mPresentation = null;
+		}
+
+		if (mPresentation == null && display != null) {
+			Log.i(TAG, "show presentation on display: " + display);
+			mPresentation = new Presentation(this, display);
+			mPresentation.show();
+			if (javaGL) {
+				mGLSurfaceView.setVisibility(View.INVISIBLE);
+				mGLSurfaceView.onPause();
+			} else {
+				mSurfaceView.setVisibility(View.INVISIBLE);
+				mSurfaceView.onPause();
+			}
+			View dummyView = new View(this);
+			setContentView(dummyView);
+			if (javaGL) {
+				mPresentation.setContentView(mGLSurfaceView);
+				mGLSurfaceView.onResume();
+				mGLSurfaceView.setVisibility(View.VISIBLE);
+			} else {
+				mPresentation.setContentView(mSurfaceView);
+				mSurfaceView.onResume();
+				mSurfaceView.setVisibility(View.VISIBLE);
+			}
+		}
+	}
+
 	@TargetApi(Build.VERSION_CODES.N)
 	private void updateSustainedPerformanceMode() {
 		if (sustainedPerfSupported) {
@@ -545,6 +586,17 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			setContentView(mSurfaceView);
 			Log.i(TAG, "setcontentview after");
 			ensureRenderLoop();
+		}
+		// Setup external display listener
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+			displayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+			nativeDisplayListener = new NativeDisplayListener(displayManager, this);
+			displayManager.registerDisplayListener(nativeDisplayListener, new Handler(Looper.getMainLooper()));
+			Display[] displays = displayManager.getDisplays();
+			Log.i(TAG, String.format("%d displays connected", displays.length));
+			if (displays.length > 1) {
+				nativeDisplayListener.onDisplayAdded(displays[1].getDisplayId());
+			}
 		}
 	}
 

--- a/android/src/org/ppsspp/ppsspp/NativeDisplayListener.java
+++ b/android/src/org/ppsspp/ppsspp/NativeDisplayListener.java
@@ -1,0 +1,42 @@
+package org.ppsspp.ppsspp;
+
+import android.annotation.TargetApi;
+import android.app.Presentation;
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.os.Build;
+import android.util.Log;
+import android.view.Display;
+
+import java.lang.annotation.Native;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+class NativeDisplayListener implements DisplayManager.DisplayListener {
+
+	private static String TAG = "NativeDisplayListener";
+
+	private DisplayManager displayManager;
+	private NativeActivity nativeActivity;
+
+	NativeDisplayListener(DisplayManager displayManager, NativeActivity nativeActivity) {
+		this.displayManager = displayManager;
+		this.nativeActivity = nativeActivity;
+	}
+
+	@Override
+	public void onDisplayAdded(int displayId) {
+		Display display = displayManager.getDisplay(displayId);
+		Log.i(TAG, String.format("display connected: %s %s", displayId, display.getName()));
+		nativeActivity.updatePresentation(display);
+	}
+
+	@Override
+	public void onDisplayRemoved(int displayId) {
+
+	}
+
+	@Override
+	public void onDisplayChanged(int displayId) {
+
+	}
+}


### PR DESCRIPTION
Just like iOS (#12094), Android also supports external displays (via Miracast, HDMI, etc.). As mentioned by @unknownbrackets, this gives more reason to separate virtual gamepad from game view. I don't have a decent Android device to test. It currently works with virtual display in Android Emulator:

![image](https://user-images.githubusercontent.com/20365903/60078505-a4da4a00-975e-11e9-80a5-0320d204010a.png)

This utilizes [Presentation](https://developer.android.com/reference/android/app/Presentation) API. There are several similarities about external display support on iOS and Android:
- Each display has its own root `Context`(Android) or `UIViewController`(iOS).
- Just like `GLKView` on iOS, `SurfaceView` on Android can be easily moved from one display to another.
- A listener can be setup to monitor display plugging and unplugging.