### PR TITLE
UWP: Fix overscan on Xbox One

### DIFF
--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -170,12 +170,6 @@ bool PPSSPP_UWPMain::Render() {
 	time_update();
 	auto context = m_deviceResources->GetD3DDeviceContext();
 
-	auto bounds = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->VisibleBounds;
-
-	int boundTop = bounds.Top;
-	int boundLeft = bounds.Left;
-	int boundedWidth = bounds.Width;
-	int boundedHeight = bounds.Height;
 
 	switch (m_deviceResources->ComputeDisplayRotation()) {
 	case DXGI_MODE_ROTATION_IDENTITY: g_display_rotation = DisplayRotation::ROTATE_0; break;
@@ -198,8 +192,6 @@ bool PPSSPP_UWPMain::Render() {
 	}
 
 	g_dpi = m_deviceResources->GetActualDpi();
-	pixel_xres = (g_dpi / 96.0f) * boundedWidth;
-	pixel_yres = (g_dpi / 96.0f) * boundedHeight;
 
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
 		// Boost DPI a bit to look better.


### PR DESCRIPTION
This PR corrects overscan values when using the UWP version of PPSSPP on Xbox One. Previously PPSSPP would display with on around 80% of the screen and aligned to top left (so with black bars on right and bottom). With this fix, it displays fullscreen properly.

Windows is unaffected, and reportedly no issues on Windows Phone either.

That's how PPSSPP looks on X1 **without** this fix:
![image](https://user-images.githubusercontent.com/7947461/60125789-d79b3700-978c-11e9-9cee-ca4f4686b9ca.png)
