### PR TITLE
Handle audio SRC mixing more correctly

### DIFF
--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -36,6 +36,7 @@ void __AudioDoState(PointerWrap &p);
 void __AudioUpdate(bool resetRecording = false);
 void __AudioShutdown();
 void __AudioSetOutputFrequency(int freq);
+void __AudioSetSRCFrequency(int freq);
 
 // May return SCE_ERROR_AUDIO_CHANNEL_BUSY if buffer too large
 u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -248,10 +248,10 @@ static u32 sceAudioChRelease(u32 chan) {
 		ERROR_LOG(SCEAUDIO, "sceAudioChRelease(%i) - channel not reserved", chan);
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	}
-	DEBUG_LOG(SCEAUDIO, "sceAudioChRelease(%i)", chan);
+	// TODO: Does this error if busy?
 	chans[chan].reset();
 	chans[chan].reserved = false;
-	return 1;
+	return hleLogSuccessI(SCEAUDIO, 0);
 }
 
 static u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -329,6 +329,7 @@ static u32 sceAudioOutput2Reserve(u32 sampleCount) {
 	chan.sampleCount = sampleCount;
 	chan.format = PSP_AUDIO_FORMAT_STEREO;
 	chan.reserved = true;
+	__AudioSetSRCFrequency(0);
 	return hleLogSuccessI(SCEAUDIO, 0);
 }
 
@@ -432,10 +433,8 @@ static u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 	chan.reserved = true;
 	chan.sampleCount = sampleCount;
 	chan.format = format == 2 ? PSP_AUDIO_FORMAT_STEREO : PSP_AUDIO_FORMAT_MONO;
-	// TODO: Zero probably means don't change?  Or it means default?
-	if (freq != 0) {
-		__AudioSetOutputFrequency(freq);
-	}
+	// Zero means default to 44.1kHz.
+	__AudioSetSRCFrequency(freq);
 	return hleLogSuccessI(SCEAUDIO, 0);
 }
 

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -56,7 +56,7 @@ static u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
 	chans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = 0;
 	chans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = 0;
 	vaudioReserved = true;
-	__AudioSetOutputFrequency(freq);
+	__AudioSetSRCFrequency(freq);
 	return 0;
 }
 

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -293,4 +293,6 @@ void StereoResampler::DoState(PointerWrap &p) {
 	auto s = p.Section("resampler", 1);
 	if (!s)
 		return;
+	if (p.mode == p.MODE_READ)
+		Clear();
 }

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -377,6 +377,7 @@ int main(int argc, const char* argv[])
 	g_Config.bHighQualityDepth = true;
 	g_Config.bMemStickInserted = true;
 	g_Config.bFragmentTestCache = true;
+	g_Config.iAudioLatency = 1;
 
 #ifdef _WIN32
 	InitSysDirectories();


### PR DESCRIPTION
This fixes some return values and handles sample rate conversion to a very basic degree.

Per tests in hrydgard/pspautotests#202, the SRC functions of course don't affect global audio frequency, and are just sample rate converted.  As of master without this code, we ignore their sample rate which means we consume their samples at an incorrect rate, which affects both playback and timing.

These changes make the tests much closer, although some of the timing is still off.

Games probably using sample rate conversion:
https://report.ppsspp.org/logs/kind/715?status=any
(ignore it being set to 0, that means don't perform conversion.)

Have not tested any of those games, and obviously the experimental resampling is ugly.

-[Unknown]