### PR TITLE
Update Travis versions and improve retry

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -18,53 +18,19 @@ download_extract_zip() {
     unzip $2 2>&1 | pv > /dev/null
 }
 
-brew_install() {
-    brew install $1
-    brew outdated $1 || brew upgrade $1
-}
-
 travis_before_install() {
     git submodule update --init --recursive
-
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        sudo apt-get update -qq
-        sudo apt-get install software-properties-common aria2 pv build-essential libgl1-mesa-dev libglu1-mesa-dev -qq
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        brew update
-        brew_install ccache
-    fi
-}
-
-setup_ccache_script() {
-    if [ ! -e "$1" ]; then
-        mkdir "$1"
-    fi
-
-    echo "#!/bin/bash" > "$1/$3"
-    echo "ccache $2/$3 \$*" >> "$1/$3"
-    chmod +x "$1/$3"
 }
 
 travis_install() {
     # Ubuntu Linux + GCC 4.8
     if [ "$PPSSPP_BUILD_TYPE" = "Linux" ]; then
-        # For libsdl2-dev.
-        sudo add-apt-repository ppa:zoogie/sdl2-snapshots -y
         if [ "$CXX" = "g++" ]; then
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        fi
-        if [ "$QT" = "TRUE" ]; then
-            sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
-        fi
-
-        sudo apt-get update
-        sudo apt-get install libsdl2-dev -qq
-        if [ "$CXX" = "g++" ]; then
-            sudo apt-get install g++-4.8 -qq
+            sudo apt-get install -qq g++-4.8
         fi
 
         if [ "$QT" = "TRUE" ]; then
-            sudo apt-get install -qq qt5-qmake qtmultimedia5-dev qtsystems5-dev qtbase5-dev qtdeclarative5-dev qttools5-dev-tools libqt5webkit5-dev libsqlite3-dev qt5-default
+            sudo apt-get install -qq qt5-qmake qtmultimedia5-dev qtsystems5-dev qtbase5-dev qtdeclarative5-dev qttools5-dev-tools libqt5webkit5-dev libqt5opengl5-dev libsqlite3-dev qt5-default
         fi
 
         download_extract "https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz" cmake-3.6.2-Linux-x86_64.tar.gz
@@ -72,16 +38,7 @@ travis_install() {
 
     # Android NDK + GCC 4.8
     if [ "$PPSSPP_BUILD_TYPE" = "Android" ]; then
-        free -m
-        sudo apt-get install ant -qq
         download_extract_zip http://dl.google.com/android/repository/${NDK_VER}-linux-x86_64.zip ${NDK_VER}-linux-x86_64.zip
-    fi
-
-    if [ "$PPSSPP_BUILD_TYPE" = "macOS" ]; then
-        brew_install sdl2
-        brew upgrade python
-    elif [ "$PPSSPP_BUILD_TYPE" = "iOS" ]; then
-        brew upgrade python
     fi
 
     # Ensure we're using ccache

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 export USE_CCACHE=1
 export NDK_CCACHE=ccache
-NDK_VER=android-ndk-r16b
+NDK_VER=android-ndk-r18b
 
 download_extract() {
     aria2c -x 16 $1 -o $2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,31 @@ sudo: required
 
 language: cpp
 
-dist: trusty
+dist: xenial
 
 addons:
   apt:
+    update: true
     packages:
+      - ant
+      - aria2
       - build-essential
+      - cmake
       - libgl1-mesa-dev
       - libglu1-mesa-dev
-      - cmake
-      - aria2
-      - ant
-      - lib32stdc++6
-      - lib32z1
-      - lib32z1-dev
-      - lib32bz2-1.0
+      - libsdl2-dev
+      - pv
+      - software-properties-common
+    sources:
+      - sourceline: 'ppa:zoogie/sdl2-snapshots'
+      - sourceline: 'ppa:ubuntu-toolchain-r/test'
+      - sourceline: 'ppa:ubuntu-sdk-team/ppa'
+  homebrew:
+    update: true
+    packages:
+      - ccache
+      - python
+      - sdl2
 
 cache:
   apt: true
@@ -75,19 +85,19 @@ matrix:
       env: PPSSPP_BUILD_TYPE=Linux
            LIBRETRO=TRUE
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       compiler: "clang"
       env: PPSSPP_BUILD_TYPE=macOS
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       compiler: "clang"
       env: PPSSPP_BUILD_TYPE=iOS
 
 before_install:
-  - bash .travis.sh travis_before_install
+  - travis_retry bash .travis.sh travis_before_install
 
 install:
-  - bash .travis.sh travis_install
+  - travis_retry bash .travis.sh travis_install
 
 script:
   - bash .travis.sh travis_script


### PR DESCRIPTION
This updates the build platform:
 * Ubuntu Xenial (Trusty is out of main support now)
 * macOS Sierra (El Capitan is out of main support too)
 * NDK r18b (it's 30% smaller than r16, r17, or r19 and we were on r16)

Also move to installing packages using the homebrew and apt addons more, which do it in less steps and automatically perform retries (at least per documentation.)

Goal is to reduce spurious failures.

-[Unknown]