### PR TITLE
Replay: Add file header handling and ignore PSP/GAME reads

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -98,7 +98,7 @@ static bool FixFilenameCase(const std::string &path, std::string &filename)
 	return retValue;
 }
 
-bool FixPathCase(std::string& basePath, std::string &path, FixPathCaseBehavior behavior)
+bool FixPathCase(const std::string &basePath, std::string &path, FixPathCaseBehavior behavior)
 {
 	size_t len = path.size();
 
@@ -158,25 +158,25 @@ DirectoryFileSystem::~DirectoryFileSystem() {
 	CloseAll();
 }
 
-std::string DirectoryFileHandle::GetLocalPath(std::string& basePath, std::string localpath)
+std::string DirectoryFileHandle::GetLocalPath(const std::string &basePath, std::string localpath)
 {
 	if (localpath.empty())
 		return basePath;
 
 	if (localpath[0] == '/')
-		localpath.erase(0,1);
-	//Convert slashes
+		localpath.erase(0, 1);
+
+	std::string result = basePath + localpath;
 #ifdef _WIN32
-	for (size_t i = 0; i < localpath.size(); i++) {
-		if (localpath[i] == '/')
-			localpath[i] = '\\';
+	for (char &c : result) {
+		if (c == '/')
+			c = '\\';
 	}
 #endif
-	return basePath + localpath;
+	return result;
 }
 
-bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, FileAccess access, u32 &error)
-{
+bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileName, FileAccess access, u32 &error) {
 	error = 0;
 
 #if HOST_IS_CASE_SENSITIVE
@@ -190,7 +190,7 @@ bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, Fil
 	// else we try fopen first (in case we're lucky) before simulating case insensitivity
 #endif
 
-	std::string fullName = GetLocalPath(basePath,fileName);
+	std::string fullName = GetLocalPath(basePath, fileName);
 	VERBOSE_LOG(FILESYS,"Actually opening %s", fullName.c_str());
 
 	// On the PSP, truncating doesn't lose data.  If you seek later, you'll recover it.
@@ -322,6 +322,11 @@ bool DirectoryFileHandle::Open(std::string &basePath, std::string &fileName, Fil
 	}
 #endif
 
+	// Try to detect reads/writes to PSP/GAME to avoid them in replays.
+	if (fullName.find("/PSP/GAME/") != fullName.npos || fullName.find("\\PSP\\GAME\\") != fullName.npos) {
+		inGameDir_ = true;
+	}
+
 	return success;
 }
 
@@ -333,7 +338,7 @@ size_t DirectoryFileHandle::Read(u8* pointer, s64 size)
 		// On a PSP. it actually is truncated, but the data wasn't erased.
 		off_t off = (off_t)Seek(0, FILEMOVE_CURRENT);
 		if (needsTrunc_ <= off) {
-			return replay_ ? ReplayApplyDiskRead(pointer, 0, (uint32_t)size, CoreTiming::GetGlobalTimeUs()) : 0;
+			return replay_ ? ReplayApplyDiskRead(pointer, 0, (uint32_t)size, inGameDir_, CoreTiming::GetGlobalTimeUs()) : 0;
 		}
 		if (needsTrunc_ < off + size) {
 			size = needsTrunc_ - off;
@@ -344,7 +349,7 @@ size_t DirectoryFileHandle::Read(u8* pointer, s64 size)
 #else
 	bytesRead = read(hFile, pointer, size);
 #endif
-	return replay_ ? ReplayApplyDiskRead(pointer, (uint32_t)bytesRead, (uint32_t)size, CoreTiming::GetGlobalTimeUs()) : bytesRead;
+	return replay_ ? ReplayApplyDiskRead(pointer, (uint32_t)bytesRead, (uint32_t)size, inGameDir_, CoreTiming::GetGlobalTimeUs()) : bytesRead;
 }
 
 size_t DirectoryFileHandle::Write(const u8* pointer, s64 size)
@@ -369,6 +374,10 @@ size_t DirectoryFileHandle::Write(const u8* pointer, s64 size)
 		if (needsTrunc_ < off) {
 			needsTrunc_ = off;
 		}
+	}
+
+	if (replay_) {
+		bytesWritten = ReplayApplyDiskWrite(pointer, (uint64_t)bytesWritten, (uint64_t)size, &diskFull, inGameDir_, CoreTiming::GetGlobalTimeUs());
 	}
 
 	if (diskFull) {

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -54,7 +54,7 @@ enum FixPathCaseBehavior {
 	FPC_PARTIAL_ALLOWED,  // don't care how many exist (mkdir recursive)
 };
 
-bool FixPathCase(std::string& basePath, std::string &path, FixPathCaseBehavior behavior);
+bool FixPathCase(const std::string &basePath, std::string &path, FixPathCaseBehavior behavior);
 #endif
 
 struct DirectoryFileHandle {
@@ -70,12 +70,13 @@ struct DirectoryFileHandle {
 #endif
 	s64 needsTrunc_ = -1;
 	bool replay_ = true;
+	bool inGameDir_ = false;
 
 	DirectoryFileHandle(Flags flags) : replay_(flags != SKIP_REPLAY) {
 	}
 
-	std::string GetLocalPath(std::string& basePath, std::string localpath);
-	bool Open(std::string& basePath, std::string& fileName, FileAccess access, u32 &err);
+	std::string GetLocalPath(const std::string &basePath, std::string localpath);
+	bool Open(const std::string &basePath, std::string &fileName, FileAccess access, u32 &err);
 	size_t Read(u8* pointer, s64 size);
 	size_t Write(const u8* pointer, s64 size);
 	size_t Seek(s32 position, FileMove type);

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -188,3 +188,7 @@ std::string KernelTimeNowFormatted() {
 	std::string timestamp = StringFromFormat("%04d-%02d-%02d_%02d-%02d-%02d", years, months, days, hours, minutes, seconds);
 	return timestamp;
 }
+
+void KernelTimeSetBase(int64_t seconds) {
+	start_time = (time_t)seconds;
+}

--- a/Core/HLE/sceKernelTime.h
+++ b/Core/HLE/sceKernelTime.h
@@ -28,6 +28,7 @@ int sceKernelSysClock2USecWide(u32 lowClock, u32 highClock, u32 lowPtr, u32 high
 u64 sceKernelUSec2SysClockWide(u32 usec);
 u32 sceKernelLibcClock();
 std::string KernelTimeNowFormatted();
+void KernelTimeSetBase(int64_t seconds);
 
 void __KernelTimeInit();
 void __KernelTimeDoState(PointerWrap &p);

--- a/Core/HLE/sceRtc.h
+++ b/Core/HLE/sceRtc.h
@@ -27,6 +27,8 @@ struct PSPTimeval {
 };
 
 void __RtcTimeOfDay(PSPTimeval *tv);
+int32_t RtcBaseTime(int32_t *micro = nullptr);
+void RtcSetBaseTime(int32_t seconds, int32_t micro = 0);
 
 void Register_sceRtc();
 void __RtcInit();

--- a/Core/Replay.cpp
+++ b/Core/Replay.cpp
@@ -24,6 +24,8 @@
 #include "Core/Replay.h"
 #include "Core/FileSystems/FileSystem.h"
 #include "Core/HLE/sceCtrl.h"
+#include "Core/HLE/sceKernelTime.h"
+#include "Core/HLE/sceRtc.h"
 
 enum class ReplayState {
 	IDLE,
@@ -31,19 +33,42 @@ enum class ReplayState {
 	SAVE,
 };
 
+// Overall structure of file format:
+//
+// - ReplayFileHeader with basic data about replay (mostly timestamp for sync.)
+// - An indeterminate sequence of events:
+//   - ReplayItemHeader (primary event details)
+//   - Side data of bytes listed in header, if SIDEDATA flag set on action.
+//
+// The header doesn't say how long the replay is, because new events are
+// appended to the file as they occur.  It is usually near, and always less than:
+//
+// (fileSize - sizeof(ReplayFileHeader)) / sizeof(ReplayItemHeader)
+
 // File data formats below.
 #pragma pack(push, 1)
 
+static const char *REPLAY_MAGIC = "PPREPLAY";
+static const int REPLAY_VERSION_MIN = 1;
+static const int REPLAY_VERSION_CURRENT = 1;
+
+struct ReplayFileHeader {
+	char magic[8];
+	u32_le version = REPLAY_VERSION_CURRENT;
+	u32_le reserved[3]{};
+	u64_le rtcBaseSeconds;
+};
+
 struct ReplayItemHeader {
 	ReplayAction action;
-	uint64_t timestamp;
+	u64_le timestamp;
 	union {
-		uint32_t buttons;
+		u32_le buttons;
 		uint8_t analog[2][2];
-		uint32_t result;
-		uint64_t result64;
+		u32_le result;
+		u64_le result64;
 		// NOTE: Certain action types have data, always sized by this/result.
-		uint32_t size;
+		u32_le size;
 	};
 
 	ReplayItemHeader(ReplayAction a, uint64_t t) {
@@ -68,14 +93,14 @@ static const int REPLAY_MAX_FILENAME = 256;
 
 struct ReplayFileInfo {
 	char filename[REPLAY_MAX_FILENAME]{};
-	int64_t size = 0;
-	uint16_t access = 0;
+	s64_le size = 0;
+	u16_le access = 0;
 	uint8_t exists = 0;
 	uint8_t isDirectory = 0;
 
-	int64_t atime = 0;
-	int64_t ctime = 0;
-	int64_t mtime = 0;
+	s64_le atime = 0;
+	s64_le ctime = 0;
+	s64_le mtime = 0;
 };
 
 #pragma pack(pop)
@@ -100,8 +125,6 @@ static uint8_t lastAnalog[2][2]{};
 
 static size_t replayDiskPos = 0;
 static bool diskFailed = false;
-
-// TODO: File format either needs rtc and rand seed, or must be paired with a save state.
 
 void ReplayExecuteBlob(const std::vector<u8> &data) {
 	ReplayAbort();
@@ -145,28 +168,52 @@ bool ReplayExecuteFile(const std::string &filename) {
 		return false;
 	}
 
-	// TODO: Header handling.
-	// Include initial rand state or timestamp?
-
-	// TODO: Maybe stream instead.
-	size_t sz = File::GetFileSize(fp);
-	if (sz == 0) {
-		ERROR_LOG(SYSTEM, "Empty replay data");
-		fclose(fp);
-		return false;
-	}
-
 	std::vector<u8> data;
-	data.resize(sz);
+	auto loadData = [&]() {
+		// TODO: Maybe stream instead.
+		size_t sz = File::GetFileSize(fp);
+		if (sz <= sizeof(ReplayFileHeader)) {
+			ERROR_LOG(SYSTEM, "Empty replay data");
+			return false;
+		}
 
-	if (fread(&data[0], sz, 1, fp) != 1) {
-		ERROR_LOG(SYSTEM, "Could not read replay data");
+		ReplayFileHeader fh;
+		if (fread(&fh, sizeof(fh), 1, fp) != 1) {
+			ERROR_LOG(SYSTEM, "Could not read replay file header");
+			return false;
+		}
+		sz -= sizeof(fh);
+
+		if (memcmp(fh.magic, REPLAY_MAGIC, sizeof(fh.magic)) != 0) {
+			ERROR_LOG(SYSTEM, "Replay header corrupt");
+			return false;
+		}
+
+		if (fh.version < REPLAY_VERSION_MIN) {
+			ERROR_LOG(SYSTEM, "Replay version %d unsupported", fh.version);
+			return false;
+		} else if (fh.version > REPLAY_VERSION_CURRENT) {
+			WARN_LOG(SYSTEM, "Replay version %d scary and futuristic, trying anyway", fh.version);
+		}
+
+		data.resize(sz);
+
+		if (fread(&data[0], sz, 1, fp) != 1) {
+			ERROR_LOG(SYSTEM, "Could not read replay data");
+			return false;
+		}
+
+		return true;
+	};
+
+	if (loadData()) {
 		fclose(fp);
-		return false;
+		ReplayExecuteBlob(data);
+		return true;
 	}
 
-	ReplayExecuteBlob(data);
-	return true;
+	fclose(fp);
+	return false;
 }
 
 bool ReplayHasMoreEvents() {
@@ -219,13 +266,18 @@ bool ReplayFlushFile(const std::string &filename) {
 		return false;
 	}
 
-	// TODO: Header handling.
-	// Include initial rand state or timestamp?
-	replaySaveWroteHeader = true;
+	bool success = true;
+	if (!replaySaveWroteHeader) {
+		ReplayFileHeader fh;
+		memcpy(fh.magic, REPLAY_MAGIC, sizeof(fh.magic));
+		fh.rtcBaseSeconds = RtcBaseTime();
+
+		success = fwrite(&fh, sizeof(fh), 1, fp) == 1;
+		replaySaveWroteHeader = true;
+	}
 
 	size_t c = replayItems.size();
-	bool success = true;
-	if (c != 0) {
+	if (success && c != 0) {
 		// TODO: Maybe stream instead.
 		std::vector<u8> data;
 		ReplayFlushBlob(&data);

--- a/Core/Replay.h
+++ b/Core/Replay.h
@@ -68,6 +68,7 @@ void ReplayAbort();
 void ReplayApplyCtrl(uint32_t &buttons, uint8_t analog[2][2], uint64_t t);
 uint32_t ReplayApplyDisk(ReplayAction action, uint32_t result, uint64_t t);
 uint64_t ReplayApplyDisk64(ReplayAction action, uint64_t result, uint64_t t);
-uint32_t ReplayApplyDiskRead(void *data, uint32_t readSize, uint32_t dataSize, uint64_t t);
+uint32_t ReplayApplyDiskRead(void *data, uint32_t readSize, uint32_t dataSize, bool inGameDir, uint64_t t);
+uint64_t ReplayApplyDiskWrite(const void *data, uint64_t writeSize, uint64_t dataSize, bool *diskFull, bool inGameDir, uint64_t t);
 PSPFileInfo ReplayApplyDiskFileInfo(const PSPFileInfo &data, uint64_t t);
 std::vector<PSPFileInfo> ReplayApplyDiskListing(const std::vector<PSPFileInfo> &data, uint64_t t);

--- a/Core/Replay.h
+++ b/Core/Replay.h
@@ -46,7 +46,7 @@ enum class ReplayAction : uint8_t {
 
 struct PSPFileInfo;
 
-// Replay from data in memory.
+// Replay from data in memory.  Does not manipulate base time / RNG state.
 void ReplayExecuteBlob(const std::vector<u8> &data);
 // Replay from data in a file.  Returns false if invalid.
 bool ReplayExecuteFile(const std::string &filename);


### PR DESCRIPTION
Mainly, this adds some basic header handling to #10888, so that it can include the base time.  I left some reserved slots in case we decide to make other random state less deterministic between runs without breaking BC reads of replay files.

I'm thinking of trying to create a plugin to record PSP control inputs (would ignore IO to focus on rhythm stuff) as noted in #12092.  It could just use this same format and replay framework in PPSSPP.  The biggest challenge to that will be loading screen timing, but maybe a value in PSP RAM can be found that indicates "in game" to align timing...

Also adds some code to best-effort address the concern brought up in #12104 of recording DLC data in replays (obviously commercial games, in general, would either be UMDs or mounted PBPs, and not go through DirectoryFileSystem.)

-[Unknown]