### PR TITLE
GPU: Download CLUTs when loading at 256 stride

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -2082,6 +2082,11 @@ void FramebufferManagerCommon::DownloadFramebufferForClut(u32 fb_address, u32 lo
 		int w = std::min(pixels % vfb->fb_stride, (int)vfb->width);
 		int h = std::min((pixels + vfb->fb_stride - 1) / vfb->fb_stride, (int)vfb->height);
 
+		if (w == 0 && h > 0) {
+			// Exactly aligned (means pixels == vfb->fb_stride, so modulus gave zero.)
+			w = std::min(vfb->fb_stride, (int)vfb->width);
+		}
+
 		// We might still have a pending draw to the fb in question, flush if so.
 		FlushBeforeCopy();
 


### PR DESCRIPTION
Or otherwise when loading full rows.  Should fix #8406.

It makes the speedometers in #8509 look a bit worse, but I think it's a change that makes sense and it may help other games than just #8406.

-[Unknown]