### PR TITLE
GPU: Forget pause signal on new list

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -720,6 +720,8 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 			if (currentList->state != PSP_GE_DL_STATE_PAUSED)
 				return SCE_KERNEL_ERROR_INVALID_VALUE;
 			currentList->state = PSP_GE_DL_STATE_QUEUED;
+			// Make sure we clear the signal so we don't try to pause it again.
+			currentList->signal = PSP_GE_SIGNAL_NONE;
 		}
 
 		dl.state = PSP_GE_DL_STATE_PAUSED;
@@ -786,8 +788,7 @@ u32 GPUCommon::Continue() {
 
 	if (currentList->state == PSP_GE_DL_STATE_PAUSED)
 	{
-		if (!isbreak)
-		{
+		if (!isbreak) {
 			// TODO: Supposedly this returns SCE_KERNEL_ERROR_BUSY in some case, previously it had
 			// currentList->signal == PSP_GE_SIGNAL_HANDLER_PAUSE, but it doesn't reproduce.
 
@@ -799,9 +800,10 @@ u32 GPUCommon::Continue() {
 
 			// We have a list now, so it's not complete.
 			drawCompleteTicks = (u64)-1;
-		}
-		else
+		} else {
 			currentList->state = PSP_GE_DL_STATE_QUEUED;
+			currentList->signal = PSP_GE_SIGNAL_NONE;
+		}
 	}
 	else if (currentList->state == PSP_GE_DL_STATE_RUNNING)
 	{
@@ -2446,6 +2448,14 @@ void GPUCommon::InterruptEnd(int listid) {
 		}
 		dl.waitTicks = 0;
 		__GeTriggerWait(GPU_SYNC_LIST, listid);
+
+		// Make sure the list isn't still queued since it's now completed.
+		if (!dlQueue.empty()) {
+			if (listid == dlQueue.front())
+				PopDLQueue();
+			else
+				dlQueue.remove(listid);
+		}
 	}
 
 	ProcessDLQueue();


### PR DESCRIPTION
Otherwise, when the list gets executed again, we just pause it when it finishes instead of letting it finish properly.

See hrydgard/pspautotests#203.  Hopefully fixes #1782 and #5999.  The comments in 4561440 make me think it will fix it.

-[Unknown]