### PR TITLE
Kernel: Shutdown when module load fails

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1626,6 +1626,7 @@ bool __KernelLoadExec(const char *filename, u32 paramPtr, std::string *error_str
 			if (param_argp) delete[] param_argp;
 			if (param_key) delete[] param_key;
 		}
+		__KernelShutdown();
 		return false;
 	}
 


### PR DESCRIPTION
This prevents us from trying to reinit next time, which can crash since we never finished initing in the first place.

Fixes the crash here: https://github.com/hrydgard/ppsspp/commit/14c93bdc2b83c4b57d08aaaff151625f143cc1dc#diff-eb784c656c56255624635d18f7e2f057R1580

-[Unknown]