### PR TITLE
GameManager ZIP handling rework

### DIFF
--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -54,9 +54,8 @@ enum class IdentifiedFileType {
 	UNKNOWN,
 };
 
-
-class FileLoader {
 // NB: It is a REQUIREMENT that implementations of this class are entirely thread safe!
+class FileLoader {
 public:
 	enum class Flags {
 		NONE,

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -143,7 +143,7 @@ ZipFileContents DetectZipFileContents(std::string fileName, ZipFileInfo *info) {
 #ifdef _WIN32
 	struct zip *z = zip_open(ConvertUTF8ToWString(fileName).c_str(), 0, &error);
 #else
-	struct zip *z = zip_open(zipfile.c_str(), 0, &error);
+	struct zip *z = zip_open(fileName.c_str(), 0, &error);
 #endif
 	if (!z) {
 		return ZipFileContents::UNKNOWN;
@@ -228,7 +228,7 @@ bool GameManager::InstallGame(std::string fileName, bool deleteAfter) {
 #ifdef _WIN32
 	struct zip *z = zip_open(ConvertUTF8ToWString(fileName).c_str(), 0, &error);
 #else
-	struct zip *z = zip_open(zipfile.c_str(), 0, &error);
+	struct zip *z = zip_open(fileName.c_str(), 0, &error);
 #endif
 	if (!z) {
 		ERROR_LOG(HLE, "Failed to open ZIP file %s, error code=%i", fileName.c_str(), error);

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -73,6 +73,7 @@ private:
 	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
 	void InstallDone();
+	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
 
 	std::string GetTempFilename() const;
 	std::shared_ptr<http::Download> curDownload_;

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -31,6 +31,8 @@ enum class GameManagerState {
 	INSTALLING,
 };
 
+struct zip;
+
 class GameManager {
 public:
 	GameManager();
@@ -68,6 +70,8 @@ public:
 
 private:
 	bool InstallGame(std::string zipfile, bool deleteAfter = false);
+	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
+	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
 	void InstallDone();
 
 	std::string GetTempFilename() const;

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -69,9 +69,10 @@ public:
 	bool InstallGameOnThread(std::string zipFile, bool deleteAfter);
 
 private:
-	bool InstallGame(std::string zipfile, bool deleteAfter = false);
+	bool InstallGame(std::string zipfile, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
+	bool InstallRawISO(std::string zipFile, std::string originalName);
 	void InstallDone();
 	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
 
@@ -84,3 +85,18 @@ private:
 };
 
 extern GameManager g_GameManager;
+
+enum class ZipFileContents {
+	UNKNOWN,
+	PSP_GAME_DIR,
+	ISO_FILE,
+};
+
+struct ZipFileInfo {
+	int numFiles;
+	int stripChars;  // for PSP game
+	int isoFileIndex;  // for ISO
+};
+
+ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info);
+ZipFileContents DetectZipFileContents(std::string fileName, ZipFileInfo *info);

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -69,10 +69,10 @@ public:
 	bool InstallGameOnThread(std::string url, std::string tempFileName, bool deleteAfter);
 
 private:
-	bool InstallGame(std::string url, std::string tempFileName, bool deleteAfter);
+	bool InstallGame(const std::string &url, const std::string &tempFileName, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
-	bool InstallRawISO(std::string zipFile, std::string originalName, bool deleteAfter);
+	bool InstallRawISO(const std::string &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();
 	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -66,13 +66,13 @@ public:
 	}
 
 	// Only returns false if there's already an installation in progress.
-	bool InstallGameOnThread(std::string zipFile, bool deleteAfter);
+	bool InstallGameOnThread(std::string url, std::string tempFileName, bool deleteAfter);
 
 private:
-	bool InstallGame(std::string zipfile, bool deleteAfter);
+	bool InstallGame(std::string url, std::string tempFileName, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
-	bool InstallRawISO(std::string zipFile, std::string originalName);
+	bool InstallRawISO(std::string zipFile, std::string originalName, bool deleteAfter);
 	void InstallDone();
 	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
 

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -81,7 +81,7 @@ bool InstallZipScreen::key(const KeyInput &key) {
 }
 
 UI::EventReturn InstallZipScreen::OnInstall(UI::EventParams &params) {
-	if (g_GameManager.InstallGameOnThread(zipPath_, deleteZipFile_)) {
+	if (g_GameManager.InstallGameOnThread(zipPath_, zipPath_, deleteZipFile_)) {
 		installStarted_ = true;
 		installChoice_->SetEnabled(false);
 	}

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -26,7 +26,7 @@
 
 class InstallZipScreen : public UIDialogScreenWithBackground {
 public:
-	InstallZipScreen(std::string zipPath) : installChoice_(0), doneView_(0), zipPath_(zipPath), installStarted_(false), deleteZipFile_(false) {}
+	InstallZipScreen(std::string zipPath) : zipPath_(zipPath) {}
 	virtual void update() override;
 	virtual bool key(const KeyInput &key) override;
 
@@ -36,12 +36,12 @@ protected:
 private:
 	UI::EventReturn OnInstall(UI::EventParams &params);
 
-	UI::Choice *installChoice_;
-	UI::Choice *backChoice_;
-	UI::ProgressBar *progressBar_;
-	UI::TextView *doneView_;
+	UI::Choice *installChoice_ = nullptr;
+	UI::Choice *backChoice_ = nullptr;
+	UI::ProgressBar *progressBar_ = nullptr;
+	UI::TextView *doneView_ = nullptr;
 	std::string zipPath_;
-	bool installStarted_;
-	bool deleteZipFile_;
+	bool installStarted_ = false;
+	bool deleteZipFile_ = false;
 };
 

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -284,13 +284,16 @@ void ProductView::Update() {
 }
 
 UI::EventReturn ProductView::OnInstall(UI::EventParams &e) {
-	std::string zipUrl;
+	std::string fileUrl;
 	if (entry_.downloadURL.empty()) {
 		// Construct the URL, easy to predict from our server
-		zipUrl = storeBaseUrl + "files/" + entry_.file + ".zip";
+		std::string shortName = entry_.file;
+		if (shortName.find('.') == std::string::npos)
+			shortName += ".zip";
+		fileUrl = storeBaseUrl + "files/" + shortName;
 	} else {
 		// Use the provided URL, for external hosting.
-		zipUrl = entry_.downloadURL;
+		fileUrl = entry_.downloadURL;
 	}
 	if (installButton_) {
 		installButton_->SetEnabled(false);
@@ -298,8 +301,8 @@ UI::EventReturn ProductView::OnInstall(UI::EventParams &e) {
 	if (cancelButton_) {
 		cancelButton_->SetVisibility(UI::V_VISIBLE);
 	}
-	INFO_LOG(SYSTEM, "Triggering install of %s", zipUrl.c_str());
-	g_GameManager.DownloadAndInstall(zipUrl);
+	INFO_LOG(SYSTEM, "Triggering install of '%s'", fileUrl.c_str());
+	g_GameManager.DownloadAndInstall(fileUrl);
 	return UI::EVENT_DONE;
 }
 


### PR DESCRIPTION
Couldn't stand some of the old code so started refactoring it. Still not really happy with it but it's better.

So the new thing: if the user tries to install a ZIP file from the games tab, it will pre-check for its contents so that it has a chance of actually containing something that we can install, to avoid confusing errors.

Additionally, can extract ISO/CSO files from zip files, which is a better experience than having the emulator say that there's no PSP contents in there while there clearly is.

Some UI improvements and clarifications are needed before merging.