### PR TITLE
UI: Allow installing texture packs from zips

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -744,7 +744,7 @@ static ConfigSetting graphicsSettings[] = {
 
 	ReportedConfigSetting("ReplaceTextures", &g_Config.bReplaceTextures, true, true, true),
 	ReportedConfigSetting("SaveNewTextures", &g_Config.bSaveNewTextures, false, true, true),
-	ReportedConfigSetting("IgnoreTextureFilenames", &g_Config.bIgnoreTextureFilenames, true, true, false),
+	ConfigSetting("IgnoreTextureFilenames", &g_Config.bIgnoreTextureFilenames, false, true, true),
 
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1, true, true),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0, true, true),

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -25,6 +25,7 @@
 #include "Common/MemoryUtil.h"
 #include "GPU/ge_constants.h"
 
+class IniFile;
 class TextureCacheCommon;
 class TextureReplacer;
 
@@ -190,6 +191,7 @@ public:
 
 protected:
 	bool LoadIni();
+	bool LoadIniValues(IniFile &ini, bool isOverride = false);
 	void ParseHashRange(const std::string &key, const std::string &value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, int level);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -34,7 +34,11 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"
+#include "Core/Loaders.h"
+#include "Core/ELF/ParamSFO.h"
+#include "Core/ELF/PBPReader.h"
 #include "Core/System.h"
+#include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/Util/GameManager.h"
 #include "i18n/i18n.h"
 
@@ -171,8 +175,11 @@ ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info) {
 	// directory of the Games tab (where else?).
 	bool isPSPMemstickGame = false;
 	bool isZippedISO = false;
+	bool isTexturePack = false;
 	int stripChars = 0;
 	int isoFileIndex = -1;
+	int stripCharsTexturePack = -1;
+	int textureIniIndex = -1;
 
 	for (int i = 0; i < numFiles; i++) {
 		const char *fn = zip_get_name(z, i, 0);
@@ -198,17 +205,33 @@ ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info) {
 				isZippedISO = true;
 				isoFileIndex = i;
 			}
+		} else if (zippedName.find("textures.ini") != std::string::npos) {
+			int slashCount = 0;
+			int slashLocation = -1;
+			countSlashes(zippedName, &slashLocation, &slashCount);
+			if (stripCharsTexturePack == -1 || slashLocation < stripCharsTexturePack + 1) {
+				stripCharsTexturePack = slashLocation + 1;
+				isTexturePack = true;
+				textureIniIndex = i;
+			}
 		}
 	}
 
 	info->stripChars = stripChars;
 	info->numFiles = numFiles;
 	info->isoFileIndex = isoFileIndex;
+	info->textureIniIndex = textureIniIndex;
+	info->ignoreMetaFiles = false;
+
 	// If a ZIP is detected as both, let's let the memstick game interpretation prevail.
 	if (isPSPMemstickGame) {
 		return ZipFileContents::PSP_GAME_DIR;
 	} else if (isZippedISO) {
 		return ZipFileContents::ISO_FILE;
+	} else if (isTexturePack) {
+		info->stripChars = stripCharsTexturePack;
+		info->ignoreMetaFiles = true;
+		return ZipFileContents::TEXTURE_PACK;
 	} else {
 		return ZipFileContents::UNKNOWN;
 	}
@@ -236,7 +259,7 @@ bool GameManager::InstallGame(const std::string &url, const std::string &fileNam
 	installInProgress_ = true;
 
 	std::string pspGame = GetSysDirectory(DIRECTORY_GAME);
-	INFO_LOG(HLE, "Installing '%s' into '%s'", fileName.c_str(), pspGame.c_str());
+	std::string dest = pspGame;
 	int error = 0;
 #ifdef _WIN32
 	struct zip *z = zip_open(ConvertUTF8ToWString(fileName).c_str(), 0, &error);
@@ -252,20 +275,146 @@ bool GameManager::InstallGame(const std::string &url, const std::string &fileNam
 	ZipFileContents contents = DetectZipFileContents(z, &info);
 	switch (contents) {
 	case ZipFileContents::PSP_GAME_DIR:
+		INFO_LOG(HLE, "Installing '%s' into '%s'", fileName.c_str(), pspGame.c_str());
 		// InstallMemstickGame contains code to close z.
-		return InstallMemstickGame(z, fileName, pspGame, info.numFiles, info.stripChars, deleteAfter);
+		return InstallMemstickGame(z, fileName, pspGame, info, false, deleteAfter);
 	case ZipFileContents::ISO_FILE:
+		INFO_LOG(HLE, "Installing '%s' into its containing directory", fileName.c_str());
+		// InstallZippedISO contains code to close z.
 		return InstallZippedISO(z, info.isoFileIndex, fileName, deleteAfter);
+	case ZipFileContents::TEXTURE_PACK:
+		// InstallMemstickGame contains code to close z, and works for textures too.
+		if (DetectTexturePackDest(z, info.textureIniIndex, &dest)) {
+			INFO_LOG(HLE, "Installing '%s' into '%s'", fileName.c_str(), dest.c_str());
+			File::CreateFullPath(dest);
+			File::CreateEmptyFile(dest + "/.nomedia");
+			return InstallMemstickGame(z, fileName, dest, info, true, deleteAfter);
+		}
+		return false;
 	default:
 		ERROR_LOG(HLE, "File not a PSP game, no EBOOT.PBP found.");
-		installProgress_ = 0.0f;
-		installInProgress_ = false;
-		installError_ = sy->T("Not a PSP game");
-		InstallDone();
+		SetInstallError(sy->T("Not a PSP game"));
 		if (deleteAfter)
 			File::Delete(fileName);
 		return false;
 	}
+}
+
+bool GameManager::DetectTexturePackDest(struct zip *z, int iniIndex, std::string *dest) {
+	I18NCategory *iz = GetI18NCategory("InstallZip");
+
+	struct zip_stat zstat;
+	zip_stat_index(z, iniIndex, 0, &zstat);
+
+	if (zstat.size >= 32 * 1024 * 1024) {
+		SetInstallError(iz->T("Texture pack doesn't support install"));
+		return false;
+	}
+
+	std::string buffer;
+	buffer.resize(zstat.size);
+	zip_file *zf = zip_fopen_index(z, iniIndex, 0);
+	if (zip_fread(zf, &buffer[0], buffer.size()) != (ssize_t)zstat.size) {
+		SetInstallError(iz->T("Zip archive corrupt"));
+		return false;
+	}
+
+	IniFile ini;
+	std::stringstream sstream(buffer);
+	ini.Load(sstream);
+
+	auto games = ini.GetOrCreateSection("games")->ToMap();
+	if (games.empty()) {
+		SetInstallError(iz->T("Texture pack doesn't support install"));
+		return false;
+	}
+
+	std::string gameID = games.begin()->first;
+	if (games.size() > 1) {
+		// Check for any supported game on their recent list and use that instead.
+		for (const std::string &path : g_Config.recentIsos) {
+			std::string recentID = GetGameID(path);
+			if (games.find(recentID) != games.end()) {
+				gameID = recentID;
+				break;
+			}
+		}
+	}
+
+	std::string pspTextures = GetSysDirectory(DIRECTORY_TEXTURES);
+	*dest = pspTextures + gameID + "/";
+	return true;
+}
+
+void GameManager::SetInstallError(const std::string &err) {
+	installProgress_ = 0.0f;
+	installInProgress_ = false;
+	installError_ = err;
+	InstallDone();
+}
+
+std::string GameManager::GetGameID(const std::string &path) const {
+	auto loader = ConstructFileLoader(path);
+	std::string id;
+
+	switch (Identify_File(loader)) {
+	case IdentifiedFileType::PSP_PBP_DIRECTORY:
+		delete loader;
+		loader = ConstructFileLoader(ResolvePBPFile(path));
+		id = GetPBPGameID(loader);
+		break;
+
+	case IdentifiedFileType::PSP_PBP:
+		id = GetPBPGameID(loader);
+		break;
+
+	case IdentifiedFileType::PSP_ISO:
+	case IdentifiedFileType::PSP_ISO_NP:
+		id = GetISOGameID(loader);
+		break;
+
+	default:
+		id.clear();
+		break;
+	}
+
+	delete loader;
+	return id;
+}
+
+std::string GameManager::GetPBPGameID(FileLoader *loader) const {
+	PBPReader pbp(loader);
+	std::vector<u8> sfoData;
+	if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {
+		ParamSFOData sfo;
+		sfo.ReadSFO(sfoData);
+		return sfo.GetValueString("DISC_ID");
+	}
+	return "";
+}
+
+std::string GameManager::GetISOGameID(FileLoader *loader) const {
+	SequentialHandleAllocator handles;
+	BlockDevice *bd = constructBlockDevice(loader);
+	if (!bd) {
+		return "";
+	}
+	ISOFileSystem umd(&handles, bd);
+
+	PSPFileInfo info = umd.GetFileInfo("/PSP_GAME/PARAM.SFO");
+	int handle = 0;
+	if (info.exists) {
+		handle = umd.OpenFile("/PSP_GAME/PARAM.SFO", FILEACCESS_READ);
+	}
+
+	std::string sfoData;
+	sfoData.resize(info.size);
+	umd.ReadFile(handle, (u8 *)&sfoData[0], info.size);
+	umd.CloseFile(handle);
+
+	ParamSFOData sfo;
+	sfo.ReadSFO((const u8 *)sfoData.data(), sfoData.size());
+	return sfo.GetValueString("DISC_ID");
 }
 
 bool GameManager::ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes) {
@@ -319,18 +468,33 @@ bool GameManager::ExtractFile(struct zip *z, int file_index, std::string outFile
 	}
 }
 
-bool GameManager::InstallMemstickGame(struct zip *z, std::string zipfile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter) {
+bool GameManager::InstallMemstickGame(struct zip *z, const std::string &zipfile, const std::string &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter) {
 	size_t allBytes = 0;
 	size_t bytesCopied = 0;
 
 	I18NCategory *sy = GetI18NCategory("System");
 
+	auto fileAllowed = [&](const char *fn) {
+		if (!allowRoot && strchr(fn, '/') == 0)
+			return false;
+
+		const char *basefn = strrchr(fn, '/');
+		basefn = basefn ? basefn + 1 : fn;
+
+		if (info.ignoreMetaFiles) {
+			if (basefn[0] == '.' || !strcmp(basefn, "Thumbs.db") || !strcmp(basefn, "desktop.ini"))
+				return false;
+		}
+
+		return true;
+	};
+
 	// Create all the directories first in one pass
 	std::set<std::string> createdDirs;
-	for (int i = 0; i < numFiles; i++) {
+	for (int i = 0; i < info.numFiles; i++) {
 		const char *fn = zip_get_name(z, i, 0);
 		std::string zippedName = fn;
-		std::string outFilename = pspGame + zippedName.substr(stripChars);
+		std::string outFilename = dest + zippedName.substr(info.stripChars);
 		bool isDir = *outFilename.rbegin() == '/';
 		if (!isDir && outFilename.find("/") != std::string::npos) {
 			outFilename = outFilename.substr(0, outFilename.rfind('/'));
@@ -339,7 +503,7 @@ bool GameManager::InstallMemstickGame(struct zip *z, std::string zipfile, std::s
 			File::CreateFullPath(outFilename.c_str());
 			createdDirs.insert(outFilename);
 		}
-		if (!isDir && strchr(fn, '/') != 0) {
+		if (!isDir && fileAllowed(fn)) {
 			struct zip_stat zstat;
 			if (zip_stat_index(z, i, 0, &zstat) >= 0) {
 				allBytes += zstat.size;
@@ -349,13 +513,13 @@ bool GameManager::InstallMemstickGame(struct zip *z, std::string zipfile, std::s
 
 	// Now, loop through again in a second pass, writing files.
 	std::vector<std::string> createdFiles;
-	for (int i = 0; i < numFiles; i++) {
+	for (int i = 0; i < info.numFiles; i++) {
 		const char *fn = zip_get_name(z, i, 0);
 		// Note that we do NOT write files that are not in a directory, to avoid random
 		// README files etc.
-		if (strchr(fn, '/') != 0) {
-			fn += stripChars;
-			std::string outFilename = pspGame + fn;
+		if (fileAllowed(fn)) {
+			fn += info.stripChars;
+			std::string outFilename = dest + fn;
 			bool isDir = *outFilename.rbegin() == '/';
 			if (isDir)
 				continue;
@@ -367,10 +531,10 @@ bool GameManager::InstallMemstickGame(struct zip *z, std::string zipfile, std::s
 			}
 		}
 	}
-	INFO_LOG(HLE, "Extracted %i files (%i bytes / %i).", numFiles, (int)bytesCopied, (int)allBytes);
+	INFO_LOG(HLE, "Extracted %i files (%i bytes / %i).", info.numFiles, (int)bytesCopied, (int)allBytes);
 
 	zip_close(z);
-	z = 0;
+	z = nullptr;
 	installProgress_ = 1.0f;
 	installInProgress_ = false;
 	installError_ = "";
@@ -381,11 +545,8 @@ bool GameManager::InstallMemstickGame(struct zip *z, std::string zipfile, std::s
 	return true;
 
 bail:
-	zip_close(z);
 	// We end up here if disk is full or couldn't write to storage for some other reason.
-	installProgress_ = 0.0f;
-	installInProgress_ = false;
-	installError_ = sy->T("Storage full");
+	zip_close(z);
 	// We don't delete the original in this case. Try to delete the files we created so far.
 	for (size_t i = 0; i < createdFiles.size(); i++) {
 		File::Delete(createdFiles[i].c_str());
@@ -393,7 +554,7 @@ bail:
 	for (auto iter = createdDirs.begin(); iter != createdDirs.end(); ++iter) {
 		File::DeleteDir(iter->c_str());
 	}
-	InstallDone();
+	SetInstallError(sy->T("Storage full"));
 	return false;
 }
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -32,6 +32,8 @@ enum class GameManagerState {
 };
 
 struct zip;
+class FileLoader;
+struct ZipFileInfo;
 
 class GameManager {
 public:
@@ -70,13 +72,18 @@ public:
 
 private:
 	bool InstallGame(const std::string &url, const std::string &tempFileName, bool deleteAfter);
-	bool InstallMemstickGame(struct zip *z, std::string zipFile, std::string pspGame, int numFiles, int stripChars, bool deleteAfter);
+	bool InstallMemstickGame(struct zip *z, const std::string &zipFile, const std::string &pspGame, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
 	bool InstallRawISO(const std::string &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();
 	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
+	bool DetectTexturePackDest(struct zip *z, int iniIndex, std::string *dest);
+	void SetInstallError(const std::string &err);
 
 	std::string GetTempFilename() const;
+	std::string GetGameID(const std::string &path) const;
+	std::string GetPBPGameID(FileLoader *loader) const;
+	std::string GetISOGameID(FileLoader *loader) const;
 	std::shared_ptr<http::Download> curDownload_;
 	std::shared_ptr<std::thread> installThread_;
 	bool installInProgress_;
@@ -90,12 +97,15 @@ enum class ZipFileContents {
 	UNKNOWN,
 	PSP_GAME_DIR,
 	ISO_FILE,
+	TEXTURE_PACK,
 };
 
 struct ZipFileInfo {
 	int numFiles;
 	int stripChars;  // for PSP game
 	int isoFileIndex;  // for ISO
+	int textureIniIndex;  // for textures
+	bool ignoreMetaFiles;
 };
 
 ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info);

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -63,13 +63,30 @@ void InstallZipScreen::CreateViews() {
 		installChoice_ = rightColumnItems->Add(new Choice(iz->T("Install")));
 		installChoice_->OnClick.Handle(this, &InstallZipScreen::OnInstall);
 		backChoice_ = rightColumnItems->Add(new Choice(di->T("Back")));
-		backChoice_->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);  // OK so that EmuScreen will handle it right
 		rightColumnItems->Add(new CheckBox(&deleteZipFile_, iz->T("Delete ZIP file")));
+
+		returnToHomebrew_ = true;
+	} else if (contents == ZipFileContents::TEXTURE_PACK) {
+		std::string question = iz->T("Install textures from ZIP file?");
+		leftColumn->Add(new TextView(question, ALIGN_LEFT, false, new AnchorLayoutParams(10, 10, NONE, NONE)));
+		leftColumn->Add(new TextView(shortFilename, ALIGN_LEFT, false, new AnchorLayoutParams(10, 60, NONE, NONE)));
+
+		doneView_ = leftColumn->Add(new TextView("", new AnchorLayoutParams(10, 120, NONE, NONE)));
+		progressBar_ = leftColumn->Add(new ProgressBar(new AnchorLayoutParams(10, 200, 200, NONE)));
+
+		installChoice_ = rightColumnItems->Add(new Choice(iz->T("Install")));
+		installChoice_->OnClick.Handle(this, &InstallZipScreen::OnInstall);
+		backChoice_ = rightColumnItems->Add(new Choice(di->T("Back")));
+		rightColumnItems->Add(new CheckBox(&deleteZipFile_, iz->T("Delete ZIP file")));
+
+		returnToHomebrew_ = false;
 	} else {
 		leftColumn->Add(new TextView(iz->T("Zip file does not contain PSP software"), ALIGN_LEFT, false, new AnchorLayoutParams(10, 10, NONE, NONE)));
 		backChoice_ = rightColumnItems->Add(new Choice(di->T("Back")));
-		backChoice_->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);  // OK so that EmuScreen will handle it right
 	}
+
+	// OK so that EmuScreen will handle it right.
+	backChoice_->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);
 }
 
 bool InstallZipScreen::key(const KeyInput &key) {
@@ -107,7 +124,7 @@ void InstallZipScreen::update() {
 		} else if (installStarted_) {
 			if (doneView_)
 				doneView_->SetText(iz->T("Installed!"));
-			MainScreen::showHomebrewTab = true;
+			MainScreen::showHomebrewTab = returnToHomebrew_;
 		}
 	}
 	UIScreen::update();

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -41,6 +41,7 @@ private:
 	UI::ProgressBar *progressBar_ = nullptr;
 	UI::TextView *doneView_ = nullptr;
 	std::string zipPath_;
+	bool returnToHomebrew_ = true;
 	bool installStarted_ = false;
 	bool deleteZipFile_ = false;
 };


### PR DESCRIPTION
Related, this also allows using region-specific texture ini content.

There's no UI to select a game ID to install for.  So the best instructions to give users would be:

> To install the texture pack:
> 1. Load the game first, then pause and return to the menu.
> 2. Now select the zip (or drag into PPSSPP on desktop) and install.
> 3. Profit?

My theory is that most users will only have one region anyway.  The multi-region use case probably means a user who will be able to figure out unzipping it themselves.  Otherwise, their preferred recent is likely to be the most recent region they have played.

For texture pack authors, all you need to do is add the following to textures.ini:

```ini
[games]
ULES12345 = textures.ini
ULJS12345 = textures.ini
ULUS12345 = textures.ini
```

If you use something other than "textures.ini", it will load that file *in addition to* textures.ini.  It uses exactly the same format.  Make sure the filename is lowercase so it works on all platforms.

Fixes #11737.

-[Unknown]