### PR TITLE
Mouse improvements

### DIFF
--- a/Common/KeyMap.h
+++ b/Common/KeyMap.h
@@ -71,6 +71,7 @@ enum DefaultMaps {
 };
 
 const float AXIS_BIND_THRESHOLD = 0.75f;
+const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
 typedef std::map<int, std::vector<KeyDef>> KeyMapping;
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -884,9 +884,10 @@ void EmuScreen::processAxis(const AxisInput &axis, int direction) {
 	KeyMap::AxisToPspButton(axis.deviceId, axis.axisId, -direction, &resultsOpposite);
 
 	int axisState = 0;
-	if ((direction == 1 && axis.value >= AXIS_BIND_THRESHOLD)) {
+	float threshold = g_Config.bMouseControl ? AXIS_BIND_THRESHOLD_MOUSE : AXIS_BIND_THRESHOLD;
+	if (direction == 1 && axis.value >= threshold) {
 		axisState = 1;
-	} else if (direction == -1 && axis.value <= -AXIS_BIND_THRESHOLD) {
+	} else if (direction == -1 && axis.value <= -threshold) {
 		axisState = -1;
 	} else {
 		axisState = 0;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -884,7 +884,7 @@ void EmuScreen::processAxis(const AxisInput &axis, int direction) {
 	KeyMap::AxisToPspButton(axis.deviceId, axis.axisId, -direction, &resultsOpposite);
 
 	int axisState = 0;
-	float threshold = g_Config.bMouseControl ? AXIS_BIND_THRESHOLD_MOUSE : AXIS_BIND_THRESHOLD;
+	float threshold = axis.deviceId == DEVICE_ID_MOUSE ? AXIS_BIND_THRESHOLD_MOUSE : AXIS_BIND_THRESHOLD;
 	if (direction == 1 && axis.value >= threshold) {
 		axisState = 1;
 	} else if (direction == -1 && axis.value <= -threshold) {

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -246,8 +246,8 @@ void WindowsHost::PollControllers() {
 		axisY.value = my;
 
 		if (GetUIState() == UISTATE_INGAME || g_Config.bMapMouse) {
-			if (fabsf(mx) > 0.01f) NativeAxis(axisX);
-			if (fabsf(my) > 0.01f) NativeAxis(axisY);
+			NativeAxis(axisX);
+			NativeAxis(axisY);
 		}
 	}
 


### PR DESCRIPTION
 Fixes #11226 at least for the mouse, not sure if similar code is used for gamepad sticks.

 Also reduces threshold when mouse control is used to stop people from complaining that simple remapping 3rd party tools works better than PPSSPP mouse control even after tweaking it's sensitivity/smoothing when mapping mouse axis to psp buttons.