### PR TITLE
UI: Fix zip leak in error case

### DIFF
--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -289,11 +289,16 @@ bool GameManager::InstallGame(const std::string &url, const std::string &fileNam
 			File::CreateFullPath(dest);
 			File::CreateEmptyFile(dest + "/.nomedia");
 			return InstallMemstickGame(z, fileName, dest, info, true, deleteAfter);
+		} else {
+			zip_close(z);
+			z = nullptr;
 		}
 		return false;
 	default:
 		ERROR_LOG(HLE, "File not a PSP game, no EBOOT.PBP found.");
 		SetInstallError(sy->T("Not a PSP game"));
+		zip_close(z);
+		z = nullptr;
 		if (deleteAfter)
 			File::Delete(fileName);
 		return false;


### PR DESCRIPTION
Oops, sorry.  Missed this in #12175.

In theory the "Not a PSP game" case shouldn't happen anymore, though.

-[Unknown]