### PR TITLE
Add right analog for touch controls.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -859,6 +859,7 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("LKeyX", "LKeyY", "LKeyScale", "ShowTouchLTrigger", &g_Config.touchLKey, defaultTouchPosShow, true, true),
 	ConfigSetting("RKeyX", "RKeyY", "RKeyScale", "ShowTouchRTrigger", &g_Config.touchRKey, defaultTouchPosShow, true, true),
 	ConfigSetting("AnalogStickX", "AnalogStickY", "AnalogStickScale", "ShowAnalogStick", &g_Config.touchAnalogStick, defaultTouchPosShow, true, true),
+	ConfigSetting("RightAnalogStickX", "RightAnalogStickY", "RightAnalogStickScale", "ShowRightAnalogStick", &g_Config.touchRightAnalogStick, defaultTouchPosHide, true, true),
 
 	ConfigSetting("fcombo0X", "fcombo0Y", "comboKeyScale0", "ShowComboKey0", &g_Config.touchCombo0, defaultTouchPosHide, true, true),
 	ConfigSetting("fcombo1X", "fcombo1Y", "comboKeyScale1", "ShowComboKey1", &g_Config.touchCombo1, defaultTouchPosHide, true, true),
@@ -1575,6 +1576,7 @@ void Config::ResetControlLayout() {
 	reset(g_Config.touchLKey);
 	reset(g_Config.touchRKey);
 	reset(g_Config.touchAnalogStick);
+	reset(g_Config.touchRightAnalogStick);
 	reset(g_Config.touchCombo0);
 	reset(g_Config.touchCombo1);
 	reset(g_Config.touchCombo2);

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -287,6 +287,7 @@ public:
 	ConfigTouchPos touchLKey;
 	ConfigTouchPos touchRKey;
 	ConfigTouchPos touchAnalogStick;
+	ConfigTouchPos touchRightAnalogStick;
 
 	ConfigTouchPos touchCombo0;
 	ConfigTouchPos touchCombo1;

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -461,6 +461,9 @@ void InitPadLayout(float xres, float yres, float globalScale) {
 	float Action_button_spacing = g_Config.fActionButtonSpacing * baseActionButtonSpacing;
 	int Action_button_center_X = xres - Action_button_spacing * 2;
 	int Action_button_center_Y = yres - Action_button_spacing * 2;
+	if (g_Config.touchRightAnalogStick.show) {
+		Action_button_center_Y -= 150 * scale;
+	}
 	initTouchPos(g_Config.touchActionButtonCenter, Action_button_center_X, Action_button_center_Y);
 
 	//D-PAD (up down left right) (aka PSP cross)----------------------------
@@ -479,6 +482,12 @@ void InitPadLayout(float xres, float yres, float globalScale) {
 	int analog_stick_X = D_pad_X;
 	int analog_stick_Y = yres - 80 * scale;
 	initTouchPos(g_Config.touchAnalogStick, analog_stick_X, analog_stick_Y);
+
+	//right analog stick-------------------------------------------------
+	//keep the right analog stick right below the face buttons
+	int right_analog_stick_X = Action_button_center_X;
+	int right_analog_stick_Y = yres - 80 * scale;
+	initTouchPos(g_Config.touchRightAnalogStick, right_analog_stick_X, right_analog_stick_Y);
 
 	//select, start, throttle--------------------------------------------
 	//space between the bottom keys (space between select, start and un-throttle)
@@ -641,6 +650,9 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 
 	if (g_Config.touchAnalogStick.show)
 		root->Add(new PSPStick(stickBg, stickImage, I_STICK, 0, g_Config.touchAnalogStick.scale, buttonLayoutParams(g_Config.touchAnalogStick)));
+
+	if (g_Config.touchRightAnalogStick.show)
+		root->Add(new PSPStick(stickBg, stickImage, I_STICK, 1, g_Config.touchRightAnalogStick.scale, buttonLayoutParams(g_Config.touchRightAnalogStick)));
 
 	addComboKey(g_Config.iCombokey0, roundImage, I_ROUND, comboKeyImages[0], g_Config.touchCombo0);
 	addComboKey(g_Config.iCombokey1, roundImage, I_ROUND, comboKeyImages[1], g_Config.touchCombo1);

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -421,6 +421,9 @@ void TouchControlLayoutScreen::CreateViews() {
 	if (g_Config.touchAnalogStick.show) {
 		controls_.push_back(new DragDropButton(g_Config.touchAnalogStick, stickBg, stickImage));
 	}
+	if (g_Config.touchRightAnalogStick.show) {
+		controls_.push_back(new DragDropButton(g_Config.touchRightAnalogStick, stickBg, stickImage));
+	}
 	if (g_Config.touchCombo0.show) {
 		controls_.push_back(new DragDropButton(g_Config.touchCombo0, roundImage, comboKeyImages[0]));
 	}

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -80,6 +80,7 @@ void TouchControlVisibilityScreen::CreateViews() {
 	toggles_.push_back({ "Select", &g_Config.touchSelectKey.show, I_SELECT });
 	toggles_.push_back({ "Dpad", &g_Config.touchDpad.show, -1 });
 	toggles_.push_back({ "Analog Stick", &g_Config.touchAnalogStick.show, -1 });
+	toggles_.push_back({ "Right Analog Stick", &g_Config.touchRightAnalogStick.show, -1 });
 	toggles_.push_back({ "Unthrottle", &g_Config.touchUnthrottleKey.show, -1 });
 	toggles_.push_back({ "Combo0", &g_Config.touchCombo0.show, I_1 });
 	toggles_.push_back({ "Combo1", &g_Config.touchCombo1.show, I_2 });

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -80,7 +80,7 @@ void TouchControlVisibilityScreen::CreateViews() {
 	toggles_.push_back({ "Select", &g_Config.touchSelectKey.show, I_SELECT });
 	toggles_.push_back({ "Dpad", &g_Config.touchDpad.show, -1 });
 	toggles_.push_back({ "Analog Stick", &g_Config.touchAnalogStick.show, -1 });
-	toggles_.push_back({ "Right Analog Stick", &g_Config.touchRightAnalogStick.show, -1 });
+	toggles_.push_back({ "Right Analog Stick\n(not used by most games)", &g_Config.touchRightAnalogStick.show, -1 });
 	toggles_.push_back({ "Unthrottle", &g_Config.touchUnthrottleKey.show, -1 });
 	toggles_.push_back({ "Combo0", &g_Config.touchCombo0.show, I_1 });
 	toggles_.push_back({ "Combo1", &g_Config.touchCombo1.show, I_2 });


### PR DESCRIPTION
 Not to be confused with #9859 which this doesn't fulfill despite that issue name as it's a request for mapping other controls for the analog which this doesn't.

 It only add's a right analog to be used as a proper right analog. This is useful for HD remasters and even more for games patched(ie through CWCheat) to get real right analog controls for example Metal Gear Solid Peace Walker or Ghost in the Shell Stand Alone Complex.

 If set to visible, resetting touch location to defaults will move face keys up and place right analog under reflecting dpad and left analog stick.

![Screenshot_2019-07-18-04-05-42-596_org ppsspp ppssppluna](https://user-images.githubusercontent.com/5485237/61423817-84428180-a911-11e9-8f37-b9002123a852.png)
