### PR TITLE
Android: Disable building HLSL support in glslang, works around #12105

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -8,6 +8,11 @@ endif()
 set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "let's not build binaries we don't need" FORCE)
 set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ON CACHE BOOL "let's not use exceptions" FORCE)
 
+# This is really a workaround for an NDK 20 compiler issue (PPSSPP issue #12105), but shouldn't hurt.
+if(ANDROID)
+set(ENABLE_HLSL OFF CACHE BOOL "let's not build HLSL support we don't need" FORCE)
+endif()
+
 add_subdirectory(glslang)
 add_subdirectory(snappy)
 add_subdirectory(udis86)


### PR DESCRIPTION
Tested with NDK 20.0.5594570, 32-bit ARM Android now builds without crashing the compiler.

Though I really don't know if that compiler should be trusted given this...