### PR TITLE
libretro: don't fail on missing SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -831,7 +831,7 @@ elseif(TARGET SDL2::SDL2)
 		set(nativeExtraLibs ${nativeExtraLibs} pthread)
 	endif()
 	set(TargetBin PPSSPPSDL)
-else()
+elseif(NOT LIBRETRO)
 	message(FATAL_ERROR "Could not find SDL2. Failing.")
 endif()
 


### PR DESCRIPTION
when building libretro core, cmake should not fail on missing SDL, as
libretro uses own code for handling the input. the core builds, links
and runs fine without SDL