### PR TITLE
Workaround for DJ Max Portable's clumsy copy protection. 

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -64,6 +64,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);
 	CheckSetting(iniFile, gameID, "ForceMax60FPS", &flags_.ForceMax60FPS);
 	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
+	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -64,6 +64,7 @@ struct CompatFlags {
 	bool ForceUMDDelay;
 	bool ForceMax60FPS;
 	bool JitInvalidationHack;
+	bool HideISOFiles;
 };
 
 class IniFile;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -30,6 +30,7 @@
 #include "Core/HLE/sceKernel.h"
 #include "Core/HW/MemoryStick.h"
 #include "Core/CoreTiming.h"
+#include "Core/System.h"
 #include "Core/Host.h"
 #include "Core/Replay.h"
 #include "Core/Reporting.h"
@@ -848,6 +849,7 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 		return ReplayApplyDiskListing(myVector, CoreTiming::GetGlobalTimeUs());
 	}
 
+	bool hideISOFiles = PSP_CoreParameter().compat.flags().HideISOFiles;
 	while (true) {
 		PSPFileInfo entry;
 		if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
@@ -864,10 +866,16 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 		else
 			entry.size = findData.nFileSizeLow | ((u64)findData.nFileSizeHigh<<32);
 		entry.name = SimulateVFATBug(ConvertWStringToUTF8(findData.cFileName));
+
+		bool hideFile = false;
+		if (hideISOFiles && (endsWithNoCase(entry.name, ".cso") || endsWithNoCase(entry.name, ".iso"))) {
+			// Workaround for DJ Max Portable, see compat.ini.
+			hideFile = true;
+		}
 		tmFromFiletime(entry.atime, findData.ftLastAccessTime);
 		tmFromFiletime(entry.ctime, findData.ftCreationTime);
 		tmFromFiletime(entry.mtime, findData.ftLastWriteTime);
-		if (!listingRoot || (wcscmp(findData.cFileName, L"..") && wcscmp(findData.cFileName, L".")))
+		if (!hideFile && (!listingRoot || (wcscmp(findData.cFileName, L"..") && wcscmp(findData.cFileName, L"."))))
 			myVector.push_back(entry);
 
 		int retval = FindNextFile(hFind, &findData);
@@ -893,6 +901,7 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 		return ReplayApplyDiskListing(myVector, CoreTiming::GetGlobalTimeUs());
 	}
 
+	bool hideISOFiles = PSP_CoreParameter().compat.flags().HideISOFiles;
 	while ((dirp = readdir(dp)) != NULL) {
 		PSPFileInfo entry;
 		struct stat s;
@@ -905,10 +914,17 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 		entry.access = s.st_mode & 0x1FF;
 		entry.name = SimulateVFATBug(dirp->d_name);
 		entry.size = s.st_size;
+
+		bool hideFile = false;
+		if (hideISOFiles && (endsWithNoCase(entry.name, ".cso") || endsWithNoCase(entry.name, ".iso"))) {
+			// Workaround for DJ Max Portable, see compat.ini.
+			hideFile = true;
+		}
+
 		localtime_r((time_t*)&s.st_atime,&entry.atime);
 		localtime_r((time_t*)&s.st_ctime,&entry.ctime);
 		localtime_r((time_t*)&s.st_mtime,&entry.mtime);
-		if (!listingRoot || (strcmp(dirp->d_name, "..") && strcmp(dirp->d_name, ".")))
+		if (!hideFile && (!listingRoot || (strcmp(dirp->d_name, "..") && strcmp(dirp->d_name, "."))))
 			myVector.push_back(entry);
 	}
 	closedir(dp);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -590,3 +590,33 @@ ULES00034 = true
 ULES00035 = true
 # MTX MotoTrax
 ULUS10138 = true
+
+[HideISOFiles]
+# DJ Max Portable has some crude copy-protection functionality where it looks for ISO/CSO files
+# in a few directories. Prevent this by hiding the files from the game.
+# To be sure, catch all versions and remixes of the game that's been seen in reports.
+# It checks the following directories:
+# /
+# /PSP/
+# /PSP/COMMON
+# /PSP/GAME
+
+ULKS46116 = true
+ULKS46189 = true
+ULKS46190 = true
+ULKS46236 = true
+ULKS46240 = true
+ULKS46059 = true
+ULUS10403 = true
+ULUS10538 = true
+ULKS46050 = true
+ULJM05836 = true
+ULJM46236 = true
+ULJM06034 = true
+NPHH00260 = true
+CF0020046 = true
+CF0020074 = true
+NPJH50471 = true
+ULJM06033 = true
+NPJH50559 = true
+NPEH00030 = true


### PR DESCRIPTION
Fixes #9477 (the game would crash at startup).

It still stays on a blackscreen kinda long on startup, but works fine after.