### PR TITLE
Add a compat option to use Unknown's accurate dotprod for VMMUL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ debian/ppsspp/
 
 # YouCompleteMe file
 .ycm_extra_conf.pyc
+
+# Renderdoc
+*.rdc

--- a/Common/BitScan.h
+++ b/Common/BitScan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ppsspp_config.h"
+#include <cstdint>
 
 #if PPSSPP_PLATFORM(WINDOWS)
 #include "Common/CommonWindows.h"

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -65,6 +65,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceMax60FPS", &flags_.ForceMax60FPS);
 	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
 	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
+	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -65,6 +65,7 @@ struct CompatFlags {
 	bool ForceMax60FPS;
 	bool JitInvalidationHack;
 	bool HideISOFiles;
+	bool MoreAccurateVMMUL;
 };
 
 class IniFile;

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -21,7 +21,9 @@
 #include <cmath>
 #include "math/math_util.h"
 
+#include "Core/Compatibility.h"
 #include "Core/MemMap.h"
+#include "Core/System.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
@@ -1468,6 +1470,13 @@ namespace MIPSComp
 
 	void ArmJit::Comp_Vmmul(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
+
+		if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+			// Fall back to interpreter, which has the accurate implementation.
+			// Later we might do something more optimized here.
+			DISABLE;
+		}
+
 		if (js.HasUnknownPrefix()) {
 			DISABLE;
 		}

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -22,14 +22,15 @@
 #include "math/math_util.h"
 
 #include "Core/MemMap.h"
+#include "Core/System.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
-#include "Common/CPUDetect.h"
+#include "Core/Compatibility.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
-
+#include "Common/CPUDetect.h"
 #include "Common/Arm64Emitter.h"
 #include "Core/MIPS/ARM64/Arm64Jit.h"
 #include "Core/MIPS/ARM64/Arm64RegCache.h"
@@ -1215,6 +1216,13 @@ namespace MIPSComp {
 
 	void Arm64Jit::Comp_Vmmul(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
+
+		if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+			// Fall back to interpreter, which has the accurate implementation.
+			// Later we might do something more optimized here.
+			DISABLE;
+		}
+
 		if (!js.HasNoPrefix()) {
 			DISABLE;
 		}

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -97,6 +97,9 @@ inline float vfpu_clamp(float v, float min, float max) {
 	return v >= max ? max : (v <= min ? min : v);
 }
 
+float vfpu_dot(float a[4], float b[4]);
+float vfpu_sqrt(float a);
+
 #define VFPU_FLOAT16_EXP_MAX    0x1f
 #define VFPU_SH_FLOAT16_SIGN    15
 #define VFPU_MASK_FLOAT16_SIGN  0x1

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -29,6 +29,8 @@
 #include "math/math_util.h"
 
 #include "Common/CPUDetect.h"
+#include "Core/Compatibility.h"
+#include "Core/System.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
@@ -2803,6 +2805,12 @@ void Jit::Comp_VScl(MIPSOpcode op) {
 
 void Jit::Comp_Vmmul(MIPSOpcode op) {
 	CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
+
+	if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+		// Fall back to interpreter, which has the accurate implementation.
+		// Later we might do something more optimized here.
+		DISABLE;
+	}
 
 	// TODO: This probably ignores prefixes?
 	if (js.HasUnknownPrefix())

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -620,3 +620,9 @@ NPJH50471 = true
 ULJM06033 = true
 NPJH50559 = true
 NPEH00030 = true
+
+[MoreAccurateVMMUL]
+# Fixes leg shaking in Tekken 6. The potential for slowdown in other games is large enough
+# that we will not generally apply this accurate mode where not needed.
+ULES01376 = true
+ULUS10466 = true


### PR DESCRIPTION
And use it to eliminate the long standing problem of Tekken 6 leg shaking. Fixes #5399.

This is kind of hacky, but it's the first use of our (part mine but mostly @unknownbrackets) recent findings about the accuracy of the VFPU dot product, see https://github.com/hrydgard/ppsspp/issues/2990.

This simply takes the latest version of vfpu_dot from https://github.com/hrydgard/ppsspp/compare/master...unknownbrackets:vfpu-dot?expand=1 (which will need rebasing) and applies it only to vmmul for now, which is enough to eliminate the leg shaking problem in Tekken 6.

It's really just the start, later we will expand the use of these findings, and if performance can be made good enough we'll enable it for all games (with maybe an opt-out for any game that gets hit unusually hard). 