### PR TITLE
Merge vfpu-dot changes and add compat flag for Tekken

### DIFF
--- a/Common/BitScan.h
+++ b/Common/BitScan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ppsspp_config.h"
+#include <cstdint>
 
 #if PPSSPP_PLATFORM(WINDOWS)
 #include "Common/CommonWindows.h"

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -65,6 +65,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceMax60FPS", &flags_.ForceMax60FPS);
 	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
 	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
+	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -65,6 +65,7 @@ struct CompatFlags {
 	bool ForceMax60FPS;
 	bool JitInvalidationHack;
 	bool HideISOFiles;
+	bool MoreAccurateVMMUL;
 };
 
 class IniFile;

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -21,14 +21,16 @@
 #include <cmath>
 #include "math/math_util.h"
 
+#include "Core/Compatibility.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
+#include "Core/System.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Common/CPUDetect.h"
-#include "Core/Config.h"
-#include "Core/Reporting.h"
 
 #include "Core/MIPS/ARM/ArmJit.h"
 #include "Core/MIPS/ARM/ArmRegCache.h"
@@ -1468,12 +1470,16 @@ namespace MIPSComp
 
 	void ArmJit::Comp_Vmmul(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
-		if (js.HasUnknownPrefix()) {
+		if (!js.HasNoPrefix()) {
 			DISABLE;
 		}
 		NEON_IF_AVAILABLE(CompNEON_Vmmul);
 
-		// TODO: This probably ignores prefixes?
+		if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+			// Fall back to interpreter, which has the accurate implementation.
+			// Later we might do something more optimized here.
+			DISABLE;
+		}
 
 		MatrixSize sz = GetMtxSize(op);
 		int n = GetMatrixSide(sz);

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -21,15 +21,16 @@
 #include <cmath>
 #include "math/math_util.h"
 
+#include "Core/Compatibility.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
+#include "Core/System.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Common/CPUDetect.h"
-#include "Core/Config.h"
-#include "Core/Reporting.h"
-
 #include "Common/Arm64Emitter.h"
 #include "Core/MIPS/ARM64/Arm64Jit.h"
 #include "Core/MIPS/ARM64/Arm64RegCache.h"
@@ -1216,6 +1217,12 @@ namespace MIPSComp {
 	void Arm64Jit::Comp_Vmmul(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
 		if (!js.HasNoPrefix()) {
+			DISABLE;
+		}
+
+		if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+			// Fall back to interpreter, which has the accurate implementation.
+			// Later we might do something more optimized here.
 			DISABLE;
 		}
 

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -20,6 +20,7 @@
 #include "math/math_util.h"
 
 #include "Common/CPUDetect.h"
+#include "Core/Compatibility.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
@@ -29,6 +30,7 @@
 #include "Core/MIPS/IR/IRFrontend.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/Reporting.h"
+#include "Core/System.h"
 
 
 // All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
@@ -1239,6 +1241,12 @@ namespace MIPSComp {
 	void IRFrontend::Comp_Vmmul(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_MTX_VMMUL);
 		if (!js.HasNoPrefix()) {
+			DISABLE;
+		}
+
+		if (PSP_CoreParameter().compat.flags().MoreAccurateVMMUL) {
+			// Fall back to interpreter, which has the accurate implementation.
+			// Later we might do something more optimized here.
 			DISABLE;
 		}
 

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -23,9 +23,11 @@
 
 #include "math/math_util.h"
 
+#include "Core/Compatibility.h"
 #include "Core/Core.h"
-#include "Core/Reporting.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
+#include "Core/System.h"
 
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSInt.h"
@@ -467,6 +469,8 @@ namespace MIPSInt
 		ReadMatrix(s, sz, vs);
 		ReadMatrix(t, sz, vt);
 
+		// TODO: Always use the more accurate path in interpreter?
+		bool useAccurateDot = USE_VFPU_DOT || PSP_CoreParameter().compat.flags().MoreAccurateVMMUL;
 		for (int a = 0; a < n; a++) {
 			for (int b = 0; b < n; b++) {
 				union { float f; uint32_t u; } sum = { 0.0f };
@@ -476,7 +480,7 @@ namespace MIPSInt
 					ApplySwizzleT(&t[a * 4], V_Quad);
 				}
 
-				if (USE_VFPU_DOT) {
+				if (useAccurateDot) {
 					sum.f = vfpu_dot(&s[b * 4], &t[a * 4]);
 					if (my_isnan(sum.f)) {
 						sum.u = 0x7f800001;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -618,13 +618,13 @@ namespace MIPSInt
 			case 4: if (s[i] <= 0) d[i] = 0; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;    // vsat0
 			case 5: if (s[i] < -1.0f) d[i] = -1.0f; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;  // vsat1
 			case 16: d[i] = 1.0f / s[i]; break; //vrcp
-			case 17: d[i] = USE_VPFU_SQRT ? 1.0f / vfpu_sqrt(s[i]) : 1.0f / sqrtf(s[i]); break; //vrsq
+			case 17: d[i] = USE_VPFU_SQRT ? vfpu_rsqrt(s[i]) : 1.0f / sqrtf(s[i]); break; //vrsq
 				
 			case 18: { d[i] = vfpu_sin(s[i]); } break; //vsin
 			case 19: { d[i] = vfpu_cos(s[i]); } break; //vcos
 			case 20: d[i] = powf(2.0f, s[i]); break; //vexp2
 			case 21: d[i] = logf(s[i])/log(2.0f); break; //vlog2
-			case 22: d[i] = USE_VPFU_SQRT ? fabsf(vfpu_sqrt(s[i]))  : fabsf(sqrtf(s[i])); break; //vsqrt
+			case 22: d[i] = USE_VPFU_SQRT ? vfpu_sqrt(s[i])  : fabsf(sqrtf(s[i])); break; //vsqrt
 			case 23: d[i] = asinf(s[i]) / M_PI_2; break; //vasin
 			case 24: d[i] = -1.0f / s[i]; break; // vnrcp
 			case 26: { d[i] = -vfpu_sin(s[i]); } break; // vnsin

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1419,8 +1419,14 @@ namespace MIPSInt
 		u32 tprefixAdd = VFPU_SWIZZLE(1, 0, 0, 0);
 		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
 
-		d[0] = s[0] * t[0] - s[1] * t[1];
-		d[0] += s[2] * t[2] + s[3] * t[3];
+		if (USE_VFPU_DOT) {
+			s[1] = -s[1];
+			d[0] = vfpu_dot(s, t);
+		} else {
+			d[0] = s[0] * t[0] - s[1] * t[1];
+			d[0] += s[2] * t[2] + s[3] * t[3];
+		}
+
 		ApplyPrefixD(d, sz);
 		WriteVector(d, V_Single, vd);
 		PC += 4;
@@ -2092,7 +2098,7 @@ namespace MIPSInt
 
 			if (USE_VFPU_DOT) {
 				if (my_isnan(d.f[i])) {
-					d.u[i] = 0x7f800001;
+					d.u[i] = (d.u[i] & 0xff800001) | 1;
 				} else if ((d.u[i] & 0x7F800000) == 0) {
 					d.u[i] &= 0xFF800000;
 				}

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1199,8 +1199,12 @@ namespace MIPSInt
 		ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, sprefixRemove, sprefixAdd), V_Quad);
 
 		float sum = 0.0f;
-		for (int i = 0; i < 4; i++) {
-			sum += s[i] * t[i];
+		if (USE_VFPU_DOT) {
+			sum = vfpu_dot(s, t);
+		} else {
+			for (int i = 0; i < 4; i++) {
+				sum += s[i] * t[i];
+			}
 		}
 		d = my_isnan(sum) ? fabsf(sum) : sum;
 		ApplyPrefixD(&d, V_Single);
@@ -1437,9 +1441,13 @@ namespace MIPSInt
 		u32 tprefixAdd = VFPU_MAKE_CONSTANTS(VFPUConst::ONE, VFPUConst::ONE, VFPUConst::ONE, VFPUConst::ONE);
 		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
 
-		d = 0.0f;
-		for (int i = 0; i < 4; i++) {
-			d += s[i] * t[i];
+		if (USE_VFPU_DOT) {
+			d = vfpu_dot(s, t);
+		} else {
+			d = 0.0f;
+			for (int i = 0; i < 4; i++) {
+				d += s[i] * t[i];
+			}
 		}
 		ApplyPrefixD(&d, V_Single);
 		WriteVector(&d, V_Single, vd);
@@ -1471,9 +1479,13 @@ namespace MIPSInt
 			tprefixAdd = 0;
 		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
 
-		d = 0.0f;
-		for (int i = 0; i < 4; i++) {
-			d += s[i] * t[i];
+		if (USE_VFPU_DOT) {
+			d = vfpu_dot(s, t);
+		} else {
+			d = 0.0f;
+			for (int i = 0; i < 4; i++) {
+				d += s[i] * t[i];
+			}
 		}
 		ApplyPrefixD(&d, V_Single);
 		WriteVector(&d, V_Single, vd);

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -71,6 +71,7 @@
 #endif
 
 static const bool USE_VFPU_DOT = false;
+static const bool USE_VPFU_SQRT = false;
 
 union FloatBits {
 	float f[4];
@@ -617,13 +618,13 @@ namespace MIPSInt
 			case 4: if (s[i] <= 0) d[i] = 0; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;    // vsat0
 			case 5: if (s[i] < -1.0f) d[i] = -1.0f; else {if(s[i] > 1.0f) d[i] = 1.0f; else d[i] = s[i];} break;  // vsat1
 			case 16: d[i] = 1.0f / s[i]; break; //vrcp
-			case 17: d[i] = 1.0f / sqrtf(s[i]); break; //vrsq
+			case 17: d[i] = USE_VPFU_SQRT ? 1.0f / vfpu_sqrt(s[i]) : 1.0f / sqrtf(s[i]); break; //vrsq
 				
 			case 18: { d[i] = vfpu_sin(s[i]); } break; //vsin
 			case 19: { d[i] = vfpu_cos(s[i]); } break; //vcos
 			case 20: d[i] = powf(2.0f, s[i]); break; //vexp2
 			case 21: d[i] = logf(s[i])/log(2.0f); break; //vlog2
-			case 22: d[i] = fabsf(sqrtf(s[i])); break; //vsqrt
+			case 22: d[i] = USE_VPFU_SQRT ? fabsf(vfpu_sqrt(s[i]))  : fabsf(sqrtf(s[i])); break; //vsqrt
 			case 23: d[i] = asinf(s[i]) / M_PI_2; break; //vasin
 			case 24: d[i] = -1.0f / s[i]; break; // vnrcp
 			case 26: { d[i] = -vfpu_sin(s[i]); } break; // vnsin

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -733,7 +733,7 @@ float vfpu_dot(float a[4], float b[4]) {
 	if (max_exp >= 255) {
 		max_exp = 255;
 		mant_sum = 0;
-	} else if (max_exp == 0) {
+	} else if (max_exp <= 0) {
 		return 0.0f;
 	}
 

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -655,12 +655,14 @@ float vfpu_dot(float a[4], float b[4]) {
 				return result.f;
 			}
 			mants[i] = get_mant(0) << EXTRA_BITS;
+			exps[i] = 255;
 		} else if (bexp == 255) {
 			if ((src[1].i & 0x007FFFFF) != 0 || aexp == 0) {
 				result.i = 0x7F800001;
 				return result.f;
 			}
 			mants[i] = get_mant(0) << EXTRA_BITS;
+			exps[i] = 255;
 		} else {
 			// TODO: Adjust precision?
 			uint64_t adjust = (uint64_t)amant * (uint64_t)bmant;

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -647,15 +647,19 @@ float vfpu_dot(float a[4], float b[4]) {
 		int32_t amant = get_mant(src[0].i) << EXTRA_BITS;
 		int32_t bmant = get_mant(src[1].i) << EXTRA_BITS;
 
-		bool anan = aexp == 255 && (src[0].i & 0x007FFFFF) != 0;
-		bool bnan = bexp == 255 && (src[1].i & 0x007FFFFF) != 0;
-		if (anan || bnan) {
-			result.i = 0x7F800001;
-			return result.f;
-		}
-
 		exps[i] = aexp + bexp - 127;
-		if (exps[i] >= 255) {
+		if (aexp == 255) {
+			// INF * 0 = NAN
+			if ((src[0].i & 0x007FFFFF) != 0 || bexp == 0) {
+				result.i = 0x7F800001;
+				return result.f;
+			}
+			mants[i] = get_mant(0) << EXTRA_BITS;
+		} else if (bexp == 255) {
+			if ((src[1].i & 0x007FFFFF) != 0 || aexp == 0) {
+				result.i = 0x7F800001;
+				return result.f;
+			}
 			mants[i] = get_mant(0) << EXTRA_BITS;
 		} else {
 			// TODO: Adjust precision?

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -635,6 +635,7 @@ float vfpu_dot(float a[4], float b[4]) {
 	uint32_t exps[4];
 	int32_t mants[4];
 	uint32_t max_exp = 0;
+	uint32_t last_inf = 0;
 
 	for (int i = 0; i < 4; i++) {
 		exps[i] = get_uexp(intermed[i].i);
@@ -642,6 +643,15 @@ float vfpu_dot(float a[4], float b[4]) {
 		mants[i] = get_mant(intermed[i].i) << EXTRA_BITS;
 		if (exps[i] > max_exp) {
 			max_exp = exps[i];
+		}
+		if (exps[i] == 255) {
+			bool diff_sign = last_inf && get_sign(last_inf) != get_sign(intermed[i].i);
+			bool mant_nan = mants[i] != (0x00800000 << EXTRA_BITS);
+			if (diff_sign || mant_nan) {
+				intermed[0].i = 0x7F800001;
+				return intermed[0].f;
+			}
+			last_inf = intermed[i].i;
 		}
 	}
 

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -607,3 +607,87 @@ float Float16ToFloat32(unsigned short l)
 	}
 	return f;
 }
+
+static uint32_t get_uexp(uint32_t x) {
+	return (x >> 23) & 0xFF;
+}
+
+static int32_t get_mant(uint32_t x) {
+	// Note: this returns the hidden 1.
+	return (x & 0x007FFFFF) | 0x00800000;
+}
+
+static int32_t get_sign(uint32_t x) {
+	return x & 0x80000000;
+}
+
+float vfpu_dot(float a[4], float b[4]) {
+	static const int EXTRA_BITS = 2;
+	union float2int {
+		uint32_t i;
+		float f;
+	} intermed[4];
+
+	for (int i = 0; i < 4; i++) {
+		intermed[i].f = a[i] * b[i];
+	}
+
+	uint32_t exps[4];
+	int32_t mants[4];
+	uint32_t max_exp = 0;
+
+	for (int i = 0; i < 4; i++) {
+		exps[i] = get_uexp(intermed[i].i);
+		// Preserve extra bits of precision in the mantissa during the add.
+		mants[i] = get_mant(intermed[i].i) << EXTRA_BITS;
+		if (exps[i] > max_exp) {
+			max_exp = exps[i];
+		}
+	}
+
+	int32_t mant_sum = 0;
+	for (int i = 0; i < 4; i++) {
+		int exp = max_exp - exps[i];
+		if (exp >= 32) {
+			mants[i] = 0;
+		} else {
+			mants[i] >>= max_exp - exps[i];
+		}
+		if (get_sign(intermed[i].i)) {
+			mants[i] = -mants[i];
+		}
+		mant_sum += mants[i];
+	}
+
+	uint32_t sign_sum = 0;
+	if (mant_sum < 0) {
+		sign_sum = 0x80000000;
+		mant_sum = -mant_sum;
+	}
+	// Chop off the extra bits.
+	mant_sum >>= EXTRA_BITS;
+
+	if (mant_sum == 0 || max_exp == 0) {
+		return 0.0f;
+	}
+
+	while (mant_sum < 0x00800000) {
+		mant_sum <<= 1;
+		max_exp -= 1;
+	}
+	while (mant_sum >= 0x01000000) {
+		mant_sum >>= 1;
+		max_exp += 1;
+	}
+	_dbg_assert_(JIT, (mant_sum & 0x00800000) != 0);
+
+	if (max_exp >= 255) {
+		max_exp = 255;
+		mant_sum = 0;
+	} else if (max_exp == 0) {
+		return 0.0f;
+	}
+
+	intermed[0].i = sign_sum | (max_exp << 23) | (mant_sum & 0x007FFFFF);
+	return intermed[0].f;
+}

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -98,6 +98,7 @@ inline float vfpu_clamp(float v, float min, float max) {
 }
 
 float vfpu_dot(float a[4], float b[4]);
+float vfpu_sqrt(float a);
 
 #define VFPU_FLOAT16_EXP_MAX    0x1f
 #define VFPU_SH_FLOAT16_SIGN    15

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -97,6 +97,8 @@ inline float vfpu_clamp(float v, float min, float max) {
 	return v >= max ? max : (v <= min ? min : v);
 }
 
+float vfpu_dot(float a[4], float b[4]);
+
 #define VFPU_FLOAT16_EXP_MAX    0x1f
 #define VFPU_SH_FLOAT16_SIGN    15
 #define VFPU_MASK_FLOAT16_SIGN  0x1

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -99,6 +99,7 @@ inline float vfpu_clamp(float v, float min, float max) {
 
 float vfpu_dot(float a[4], float b[4]);
 float vfpu_sqrt(float a);
+float vfpu_rsqrt(float a);
 
 #define VFPU_FLOAT16_EXP_MAX    0x1f
 #define VFPU_SH_FLOAT16_SIGN    15

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -624,5 +624,10 @@ NPEH00030 = true
 [MoreAccurateVMMUL]
 # Fixes leg shaking in Tekken 6. The potential for slowdown in other games is large enough
 # that we will not generally apply this accurate mode where not needed.
-ULES01376 = true
 ULUS10466 = true
+ULES01376 = true
+ULJS00224 = true
+NPUH10047 = true
+ULAS42214 = true
+ULJS19054 = true
+NPJH50184 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -620,3 +620,9 @@ NPJH50471 = true
 ULJM06033 = true
 NPJH50559 = true
 NPEH00030 = true
+
+[MoreAccurateVMMUL]
+# Fixes leg shaking in Tekken 6. The potential for slowdown in other games is large enough
+# that we will not generally apply this accurate mode where not needed.
+ULES01376 = true
+ULUS10466 = true


### PR DESCRIPTION
Alternative to #12214 with all the previous commit history for blame.  Interpreter should be unchanged compared to that commit (new constants USE_VFPU_DOT and USE_VFPU_SQRT are used to enable functionality across other ops.)

I do think we probably will want to just enable these by default for interpreter, assuming it doesn't make any op we haven't written jit for too slow.

For jit, it'll require more careful testing to determine where it's worth it - I've considered if a setting might make sense, since TAS users most likely would want the accuracy rather than the speed.  For people viewing Dissidia replays made on a PSP, an option (defaulting off) might make sense.  Ideal would be a fast jit implementation that has no significant FPS impact.

-[Unknown]