### PR TITLE
Vulkan: Add missing barrier between multiple passes to the same target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ debian/ppsspp/
 
 # YouCompleteMe file
 .ycm_extra_conf.pyc
+
+# RenderDoc
+*.rdc

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -412,7 +412,7 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 	// This is what queues up new passes, and can end previous ones.
 	step->render.framebuffer = fb;
 	step->render.color = color;
-	step->render.depth= depth;
+	step->render.depth = depth;
 	step->render.stencil = stencil;
 	step->render.clearColor = clearColor;
 	step->render.clearDepth = clearDepth;
@@ -423,8 +423,13 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 	steps_.push_back(step);
 
 	curRenderStep_ = step;
-	curWidth_ = fb ? fb->width : vulkan_->GetBackbufferWidth();
-	curHeight_ = fb ? fb->height : vulkan_->GetBackbufferHeight();
+	if (fb) {
+		curWidth_ = fb->width;
+		curHeight_ = fb->height;
+	} else {
+		curWidth_ = vulkan_->GetBackbufferWidth();
+		curHeight_ = vulkan_->GetBackbufferHeight();
+	}
 }
 
 bool VulkanRenderManager::CopyFramebufferToMemorySync(VKRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride) {

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -397,6 +397,8 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 			return;
 		}
 	}
+
+	// More redundant bind elimination.
 	if (curRenderStep_ && curRenderStep_->commands.size() == 0 && curRenderStep_->render.color == VKRRenderPassAction::KEEP && curRenderStep_->render.depth == VKRRenderPassAction::KEEP && curRenderStep_->render.stencil == VKRRenderPassAction::KEEP) {
 		// Can trivially kill the last empty render step.
 		assert(steps_.back() == curRenderStep_);
@@ -409,7 +411,6 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 	}
 
 	VKRStep *step = new VKRStep{ VKRStepType::RENDER };
-	// This is what queues up new passes, and can end previous ones.
 	step->render.framebuffer = fb;
 	step->render.color = color;
 	step->render.depth = depth;


### PR DESCRIPTION
Games are sometimes a bit silly and render a bit to one target, a bit to another, then go back and render more to the first. We need to tell Vulkan that there's a sequential dependency, otherwise the driver might try to execute the passes concurrently or out of order. ARM Mali notably does this in newer driver versions.

Fixes #12215. 

There's also potential here for increasing performance by merging passes.