### PR TITLE
Vulkan: Add some hacks to make Killzone run at playable speeds on mobile

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -59,6 +59,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
 	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
 	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
+	CheckSetting(iniFile, gameID, "KillzoneHack", &flags_.KillzoneHack);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);
 	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -59,6 +59,7 @@ struct CompatFlags {
 	bool DisableAccurateDepth;
 	bool MGS2AcidHack;
 	bool SonicRivalsHack;
+	bool KillzoneHack;
 	bool BlockTransferAllowCreateFB;
 	bool YugiohSaveFix;
 	bool ForceUMDDelay;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -475,6 +475,8 @@ void GPU_Vulkan::InitDeviceObjects() {
 		hacks |= QUEUE_HACK_MGS2_ACID;
 	if (PSP_CoreParameter().compat.flags().SonicRivalsHack)
 		hacks |= QUEUE_HACK_SONIC;
+	if (PSP_CoreParameter().compat.flags().KillzoneHack)
+		hacks |= QUEUE_HACK_KILLZONE;
 	if (hacks) {
 		rm->GetQueueRunner()->EnableHacks(hacks);
 	}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -460,6 +460,13 @@ ULUS10323 = true  # SR2
 ULES00940 = true  # SR2
 ULET00958 = true
 
+[KillzoneHack]
+UCUS98646 = true
+SCES52004 = true
+SCUS97402 = true
+SCKA20048 = true
+SLPM66151 = true
+
 [BlockTransferAllowCreateFB]
 NPJH50686 = true  # Digimon Adventures (JP, and English patches...)
 ULJS00078 = true  # MotoGP

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -13,6 +13,7 @@ struct VKRImage;
 enum {
 	QUEUE_HACK_MGS2_ACID = 1,
 	QUEUE_HACK_SONIC = 2,
+	QUEUE_HACK_KILLZONE = 4,
 };
 
 enum class VKRRenderCommand : uint8_t {
@@ -94,6 +95,7 @@ enum class VKRStepType : uint8_t {
 	BLIT,
 	READBACK,
 	READBACK_IMAGE,
+	SKIP,
 };
 
 enum class VKRRenderPassAction : uint8_t {
@@ -240,6 +242,7 @@ private:
 
 	void ApplyMGSHack(std::vector<VKRStep *> &steps);
 	void ApplySonicHack(std::vector<VKRStep *> &steps);
+	void ApplyKillzoneHack(std::vector<VKRStep *> &steps);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);


### PR DESCRIPTION
Really gross though, we're disabling post-processing effects and there's a small artifact on the right side of the screen.

See #6207.