### PR TITLE
Vulkan/GL: Set all four coordinates to NaN instead of just W.

### DIFF
--- a/GPU/GLES/VertexShaderGeneratorGLES.cpp
+++ b/GPU/GLES/VertexShaderGeneratorGLES.cpp
@@ -842,7 +842,7 @@ void GenerateVertexShader(const VShaderID &id, char *buffer, uint32_t *attrMask,
 		const char *outMin = "projPos.x < u_cullRangeMin.x || projPos.y < u_cullRangeMin.y || projPos.z < u_cullRangeMin.z";
 		const char *outMax = "projPos.x > u_cullRangeMax.x || projPos.y > u_cullRangeMax.y || projPos.z > u_cullRangeMax.z";
 		WRITE(p, "    if (%s || %s) {\n", outMin, outMax);
-		WRITE(p, "      outPos.w = u_cullRangeMax.w;\n");
+		WRITE(p, "      outPos.xyzw = vec4(u_cullRangeMax.w);\n");
 		WRITE(p, "    }\n");
 		WRITE(p, "  }\n");
 	}

--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
@@ -47,9 +47,6 @@ static const char *vulkan_glsl_preamble =
 // texcoord = 2
 // fog = 3
 
-
-
-
 #undef WRITE
 
 #define WRITE p+=sprintf
@@ -634,7 +631,7 @@ bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer) {
 		const char *outMin = "projPos.x < base.cullRangeMin.x || projPos.y < base.cullRangeMin.y || projPos.z < base.cullRangeMin.z";
 		const char *outMax = "projPos.x > base.cullRangeMax.x || projPos.y > base.cullRangeMax.y || projPos.z > base.cullRangeMax.z";
 		WRITE(p, "    if (%s || %s) {\n", outMin, outMax);
-		WRITE(p, "      outPos.w = base.cullRangeMax.w;\n");
+		WRITE(p, "      outPos.xyzw = vec4(base.cullRangeMax.w);\n");
 		WRITE(p, "    }\n");
 		WRITE(p, "  }\n");
 	}


### PR DESCRIPTION
Fixes range culling on ARM Mali. Fixes #11999.

Could make this vendor specific, but I think this will reliably kill the triangle on all archs...