### PR TITLE
Windows: Allow write-only files to be read later

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -213,7 +213,7 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 	}
 	if (access & FILEACCESS_WRITE) {
 		desired   |= GENERIC_WRITE;
-		sharemode |= FILE_SHARE_WRITE;
+		sharemode |= FILE_SHARE_WRITE | FILE_SHARE_READ;
 	}
 	if (access & FILEACCESS_CREATE) {
 		if (access & FILEACCESS_EXCL) {


### PR DESCRIPTION
Fixes #11939, at least the hang described in that issue.  Seems to match with how the PSP handles file locking.

It's been FILE_SHARE_WRITE only since the "snapshot of source code" commit.

-[Unknown]