### PR TITLE
Threadpool improvements

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -431,6 +431,7 @@
     <ClInclude Include="KeyMap.h" />
     <ClInclude Include="Log.h" />
     <ClInclude Include="LogManager.h" />
+    <ClInclude Include="MakeUnique.h" />
     <ClInclude Include="MathUtil.h" />
     <ClInclude Include="MemArena.h" />
     <ClInclude Include="MemoryUtil.h" />

--- a/Common/MakeUnique.h
+++ b/Common/MakeUnique.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+// Custom make_unique so that C++14 support will not be necessary for compilation
+template<class T, class... Args,
+	typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<class T,
+	typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0, int>::type = 0>
+std::unique_ptr<T> make_unique(std::size_t size)
+{
+	return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
+}
+
+template<class T, class... Args,
+	typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>
+void make_unique(Args&&... args) = delete;
+
+
+template<class T,
+	typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+	std::unique_ptr<T> make_unique_default_init()
+{
+	return std::unique_ptr<T>(new T);
+}
+
+template<class T,
+	typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0, int>::type = 0>
+	std::unique_ptr<T> make_unique_default_init(std::size_t size)
+{
+	return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]);
+}
+
+template<class T, class... Args,
+	typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>
+	void make_unique_default_init(Args&&... args) = delete;

--- a/Common/ThreadPools.cpp
+++ b/Common/ThreadPools.cpp
@@ -1,18 +1,16 @@
 #include "ThreadPools.h"
 
 #include "../Core/Config.h"
+#include "Common/MakeUnique.h"
 
-std::shared_ptr<ThreadPool> GlobalThreadPool::pool;
-bool  GlobalThreadPool::initialized = false;
+std::unique_ptr<ThreadPool> GlobalThreadPool::pool;
+std::once_flag GlobalThreadPool::init_flag;
 
 void GlobalThreadPool::Loop(const std::function<void(int,int)>& loop, int lower, int upper) {
-	Inititialize();
+	std::call_once(init_flag, Inititialize);
 	pool->ParallelLoop(loop, lower, upper);
 }
 
 void GlobalThreadPool::Inititialize() {
-	if(!initialized) {
-		pool = std::make_shared<ThreadPool>(g_Config.iNumWorkerThreads);
-		initialized = true;
-	}
+	pool = make_unique<ThreadPool>(g_Config.iNumWorkerThreads);
 }

--- a/Common/ThreadPools.h
+++ b/Common/ThreadPools.h
@@ -9,7 +9,7 @@ public:
 	static void Loop(const std::function<void(int,int)>& loop, int lower, int upper);
 
 private:
-	static std::shared_ptr<ThreadPool> pool;
-	static bool initialized;
+	static std::unique_ptr<ThreadPool> pool;
+	static std::once_flag init_flag;
 	static void Inititialize();
 };

--- a/ext/native/thread/threadpool.cpp
+++ b/ext/native/thread/threadpool.cpp
@@ -4,7 +4,7 @@
 
 ///////////////////////////// WorkerThread
 
-WorkerThread::WorkerThread() : active(true), started(false) {
+WorkerThread::WorkerThread() {
 	thread.reset(new std::thread(std::bind(&WorkerThread::WorkFunc, this)));
 	while(!started) { };
 }
@@ -80,7 +80,7 @@ void LoopWorkerThread::WorkFunc() {
 
 ///////////////////////////// ThreadPool
 
-ThreadPool::ThreadPool(int numThreads) : workersStarted(false) {
+ThreadPool::ThreadPool(int numThreads) {
 	if (numThreads <= 0) {
 		numThreads_ = 1;
 		ILOG("ThreadPool: Bad number of threads %i", numThreads);

--- a/ext/native/thread/threadpool.cpp
+++ b/ext/native/thread/threadpool.cpp
@@ -6,7 +6,6 @@
 
 WorkerThread::WorkerThread() {
 	thread.reset(new std::thread(std::bind(&WorkerThread::WorkFunc, this)));
-	while(!started) { };
 }
 
 WorkerThread::~WorkerThread() {
@@ -35,7 +34,6 @@ void WorkerThread::WaitForCompletion() {
 void WorkerThread::WorkFunc() {
 	setCurrentThreadName("Worker");
 	std::unique_lock<std::mutex> guard(mutex);
-	started = true;
 	while (active) {
 		// 'active == false' is one of the conditions for signaling,
 		// do not "optimize" it
@@ -54,7 +52,6 @@ void WorkerThread::WorkFunc() {
 
 LoopWorkerThread::LoopWorkerThread() : WorkerThread(true) {
 	thread.reset(new std::thread(std::bind(&LoopWorkerThread::WorkFunc, this)));
-	while (!started) { };
 }
 
 void LoopWorkerThread::Process(std::function<void(int, int)> work, int start, int end) {
@@ -69,7 +66,6 @@ void LoopWorkerThread::Process(std::function<void(int, int)> work, int start, in
 void LoopWorkerThread::WorkFunc() {
 	setCurrentThreadName("LoopWorker");
 	std::unique_lock<std::mutex> guard(mutex);
-	started = true;
 	while (active) {
 		// 'active == false' is one of the conditions for signaling,
 		// do not "optimize" it

--- a/ext/native/thread/threadpool.cpp
+++ b/ext/native/thread/threadpool.cpp
@@ -17,9 +17,9 @@ WorkerThread::~WorkerThread() {
 	thread->join();
 }
 
-void WorkerThread::Process(const std::function<void()>& work) {
+void WorkerThread::Process(std::function<void()> work) {
 	mutex.lock();
-	work_ = work;
+	work_ = std::move(work);
 	jobsTarget = jobsDone + 1;
 	signal.notify_one();
 	mutex.unlock();
@@ -53,9 +53,9 @@ LoopWorkerThread::LoopWorkerThread() : WorkerThread(true) {
 	while (!started) { };
 }
 
-void LoopWorkerThread::Process(const std::function<void(int, int)> &work, int start, int end) {
+void LoopWorkerThread::Process(std::function<void(int, int)> work, int start, int end) {
 	std::lock_guard<std::mutex> guard(mutex);
-	work_ = work;
+	work_ = std::move(work);
 	start_ = start;
 	end_ = end;
 	jobsTarget = jobsDone + 1;

--- a/ext/native/thread/threadpool.h
+++ b/ext/native/thread/threadpool.h
@@ -27,7 +27,7 @@ protected:
 	std::condition_variable signal; // used to signal new work
 	std::condition_variable done; // used to signal work completion
 	std::mutex mutex, doneMutex; // associated with each respective condition variable
-	volatile bool active = true, started = false;
+	bool active = true;
 	int jobsDone = 0;
 	int jobsTarget = 0;
 private:

--- a/ext/native/thread/threadpool.h
+++ b/ext/native/thread/threadpool.h
@@ -21,32 +21,32 @@ public:
 	void WaitForCompletion();
 
 protected:
-	WorkerThread(bool ignored) : active(true), started(false) {}
-	virtual void WorkFunc();
+	WorkerThread(bool ignored) {}
 
 	std::unique_ptr<std::thread> thread; // the worker thread
 	std::condition_variable signal; // used to signal new work
 	std::condition_variable done; // used to signal work completion
 	std::mutex mutex, doneMutex; // associated with each respective condition variable
-	volatile bool active, started;
+	volatile bool active = true, started = false;
 	int jobsDone = 0;
 	int jobsTarget = 0;
 private:
+	virtual void WorkFunc();
+
 	std::function<void()> work_; // the work to be done by this thread
 
-	WorkerThread(const WorkerThread& other); // prevent copies
-	void operator =(const WorkerThread &other);
+	WorkerThread(const WorkerThread& other) = delete; // prevent copies
+	void operator =(const WorkerThread &other) = delete;
 };
 
-class LoopWorkerThread : public WorkerThread {
+class LoopWorkerThread final : public WorkerThread {
 public:
 	LoopWorkerThread();
 	void Process(const std::function<void(int, int)> &work, int start, int end);
 
-protected:
-	virtual void WorkFunc();
-
 private:
+	virtual void WorkFunc() override;
+
 	int start_;
 	int end_;
 	std::function<void(int, int)> work_; // the work to be done by this thread
@@ -68,10 +68,10 @@ private:
 	std::vector<std::shared_ptr<LoopWorkerThread>> workers;
 	std::mutex mutex; // used to sequentialize loop execution
 
-	bool workersStarted;
+	bool workersStarted = false;
 	void StartWorkers();
 	
-	ThreadPool(const ThreadPool& other); // prevent copies
-	void operator =(const ThreadPool &other);
+	ThreadPool(const ThreadPool& other) = delete; // prevent copies
+	void operator =(const ThreadPool &other) = delete;
 };
 

--- a/ext/native/thread/threadpool.h
+++ b/ext/native/thread/threadpool.h
@@ -16,7 +16,7 @@ public:
 	virtual ~WorkerThread();
 
 	// submit a new work item
-	void Process(const std::function<void()>& work);
+	void Process(std::function<void()> work);
 	// wait for a submitted work item to be completed
 	void WaitForCompletion();
 
@@ -42,7 +42,7 @@ private:
 class LoopWorkerThread final : public WorkerThread {
 public:
 	LoopWorkerThread();
-	void Process(const std::function<void(int, int)> &work, int start, int end);
+	void Process(std::function<void(int, int)> work, int start, int end);
 
 private:
 	virtual void WorkFunc() override;

--- a/ext/native/thread/threadpool.h
+++ b/ext/native/thread/threadpool.h
@@ -12,8 +12,10 @@
 // Only handles a single item of work at a time.
 class WorkerThread {
 public:
-	WorkerThread();
+	WorkerThread() = default;
 	virtual ~WorkerThread();
+
+	void StartUp();
 
 	// submit a new work item
 	void Process(std::function<void()> work);
@@ -21,9 +23,7 @@ public:
 	void WaitForCompletion();
 
 protected:
-	WorkerThread(bool ignored) {}
-
-	std::unique_ptr<std::thread> thread; // the worker thread
+	std::thread thread; // the worker thread
 	std::condition_variable signal; // used to signal new work
 	std::condition_variable done; // used to signal work completion
 	std::mutex mutex, doneMutex; // associated with each respective condition variable
@@ -41,7 +41,7 @@ private:
 
 class LoopWorkerThread final : public WorkerThread {
 public:
-	LoopWorkerThread();
+	LoopWorkerThread() = default;
 	void Process(std::function<void(int, int)> work, int start, int end);
 
 private:
@@ -65,7 +65,7 @@ public:
 
 private:
 	int numThreads_;
-	std::vector<std::shared_ptr<LoopWorkerThread>> workers;
+	std::vector<std::unique_ptr<LoopWorkerThread>> workers;
 	std::mutex mutex; // used to sequentialize loop execution
 
 	bool workersStarted = false;


### PR DESCRIPTION
This PR consists of several independent improvements to `WorkerThread`, `ThreadPool` and `GlobalThreadPool` classes. Those include:

- proper thread safety for `GlobalThreadPool`.
- interface cleanup for `WorkerThread`.
- fixes for spurious wakeups in `WorkerThread`, which also allowed me to retire blocking while constructing such, dubiously synced using a volatile bool.
- cleaned up `ThreadPool` worker threads init, now starting as many threads as **actually** used. Previously, the last thread would never be used as the callee also counts as performing work.

About the last listed change - I made it start one thread less, but maybe it should still start it and actually use it, by dividing work between `numThreads_ + 1` threads?