### PR TITLE
Update PowerSaveModeReceiver

### DIFF
--- a/android/jni/native-audio-so.cpp
+++ b/android/jni/native-audio-so.cpp
@@ -157,7 +157,6 @@ OpenSLContext::~OpenSLContext() {
 		bqPlayerObject = nullptr;
 		bqPlayerPlay = nullptr;
 		bqPlayerBufferQueue = nullptr;
-		bqPlayerMuteSolo = nullptr;
 		bqPlayerVolume = nullptr;
 	}
 

--- a/android/jni/native-audio-so.h
+++ b/android/jni/native-audio-so.h
@@ -35,7 +35,6 @@ private:
 	SLObjectItf bqPlayerObject = nullptr;
 	SLPlayItf bqPlayerPlay = nullptr;
 	SLAndroidSimpleBufferQueueItf bqPlayerBufferQueue = nullptr;
-	SLMuteSoloItf bqPlayerMuteSolo = nullptr;
 	SLVolumeItf bqPlayerVolume = nullptr;
 
 	// Double buffering.

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -703,6 +703,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			mSurfaceView.onDestroy();
 			mSurfaceView = null;
 		}
+		PowerSaveModeReceiver.destroy(this);
 		// TODO: Can we ensure that the GL thread has stopped rendering here?
 		// I've seen crashes that seem to indicate that sometimes it hasn't...
 		NativeApp.audioShutdown();
@@ -770,6 +771,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 				mSurfaceView.onResume();
 			}
 		}
+		PowerSaveModeReceiver.sendPowerSaving(this);
 
 		gainAudioFocus(this.audioManager, this.audioFocusChangeListener);
 		NativeApp.resume();


### PR DESCRIPTION
On emulator, power saving updates are delivered immediately using POWER_SAVE_MODE_CHANGED.
On Samsung Note9 with Android9, POWER_SAVE_MODE_CHANGED is never received, so isPowerSaveMode() need to be checked every time the application is resumed.