### PR TITLE
Vulkan: Automatically merge render passes to the same target when possible

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -59,6 +59,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
 	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
 	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
+	CheckSetting(iniFile, gameID, "RenderPassMerge", &flags_.RenderPassMerge);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);
 	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -59,6 +59,7 @@ struct CompatFlags {
 	bool DisableAccurateDepth;
 	bool MGS2AcidHack;
 	bool SonicRivalsHack;
+	bool RenderPassMerge;
 	bool BlockTransferAllowCreateFB;
 	bool YugiohSaveFix;
 	bool ForceUMDDelay;

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -118,5 +118,6 @@ void DrawProfilerVis(UIContext *ui, GPUInterface *gpu) {
 	Draw::DrawContext *draw = ui->GetDrawContext();
 	ui->SetFontScale(0.4f, 0.4f);
 	ui->DrawTextShadow(text.c_str(), 10, 50, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	ui->SetFontScale(1.0f, 1.0f);
 	ui->Flush();
 }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -475,6 +475,9 @@ void GPU_Vulkan::InitDeviceObjects() {
 		hacks |= QUEUE_HACK_MGS2_ACID;
 	if (PSP_CoreParameter().compat.flags().SonicRivalsHack)
 		hacks |= QUEUE_HACK_SONIC;
+	if (PSP_CoreParameter().compat.flags().RenderPassMerge)
+		hacks |= QUEUE_HACK_RENDERPASS_MERGE;
+
 	if (hacks) {
 		rm->GetQueueRunner()->EnableHacks(hacks);
 	}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -633,3 +633,39 @@ NPUH10047 = true
 ULAS42214 = true
 ULJS19054 = true
 NPJH50184 = true
+
+[RenderPassMerge]
+UCJS10114 = true
+UCKS45084 = true
+# GOW : Ghost of Sparta
+UCUS98737 = true
+UCAS40323 = true
+NPHG00092 = true
+NPEG00044 = true
+NPEG00045 = true
+NPJG00120 = true
+NPUG80508 = true
+UCJS10114 = true
+UCES01401 = true
+UCES01473 = true
+# GOW : Ghost of Sparta Demo
+NPEG90035 = true
+NPUG70125 = true
+NPJG90095 = true
+# GOW : Chains Of Olympus
+UCAS40198 = true
+UCUS98653 = true
+UCES00842 = true
+ULJM05438 = true
+ULJM05348 = true
+UCKS45084 = true
+NPUG80325 = true
+NPEG00023 = true
+NPHG00027 = true
+NPHG00028 = true
+NPJH50170 = true
+UCET00844 = true
+# GOW: Chains of Olympus Demo
+UCUS98705 = true
+UCED00971 = true
+UCUS98713 = true

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -741,7 +741,6 @@ std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
 void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 	// First let's count how many times each framebuffer is rendered to.
 	// If it's more than one, let's do our best to merge them. This can help God of War quite a bit.
-
 	std::map<VKRFramebuffer *, int> counts;
 	for (int i = 0; i < (int)steps.size(); i++) {
 		if (steps[i]->stepType == VKRStepType::RENDER) {
@@ -778,20 +777,20 @@ void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 					if (steps[j]->render.framebuffer != fb) {
 						touchedFramebuffers.insert(steps[j]->render.framebuffer);
 					}
-					// keep going.
 					break;
 				case VKRStepType::COPY:
-					if (steps[j]->copy.src == fb) {
-						// We're done.
+					if (steps[j]->copy.src == fb || steps[j]->copy.dst == fb) {
 						goto done_fb;
 					}
 					break;
 				case VKRStepType::BLIT:
-					if (steps[j]->blit.src == fb) {
+					if (steps[j]->blit.src == fb || steps[j]->blit.dst == fb) {
 						goto done_fb;
 					}
 					break;
 				case VKRStepType::READBACK:
+					// Not sure this has much effect, when executed READBACK is always the last step
+					// since we stall the GPU and wait immediately after.
 					if (steps[j]->readback.src == fb) {
 						goto done_fb;
 					}

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -773,12 +773,8 @@ void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 						// ok. Now, if it's a render, slurp up all the commands
 						// and kill the step.
 						// Also slurp up any pretransitions.
-						for (int k = 0; k < (int)steps[j]->preTransitions.size(); k++) {
-							steps[i]->preTransitions.push_back(steps[j]->preTransitions[k]);
-						}
-						for (int k = 0; k < (int)steps[j]->commands.size(); k++) {
-							steps[i]->commands.push_back(steps[j]->commands[k]);
-						}
+						steps[i]->preTransitions.insert(steps[i]->preTransitions.end(), steps[j]->preTransitions.begin(), steps[j]->preTransitions.end());
+						steps[i]->commands.insert(steps[i]->commands.end(), steps[j]->commands.begin(), steps[j]->commands.end());
 						steps[j]->stepType = VKRStepType::RENDER_SKIP;
 					}
 					// keep going.

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -48,6 +48,20 @@ struct TinySet {
 		}
 		return false;
 	}
+	bool contains(const TinySet<T, MaxFastSize> &otherSet) {
+		// Awkward, kind of ruins the fun.
+		for (int i = 0; i < fastCount; i++) {
+			if (otherSet.contains(fastLookup_[i]))
+				return true;
+		}
+		if (slowLookup_) {
+			for (auto x : *slowLookup_) {
+				if (otherSet.contains(x))
+					return true;
+			}
+		}
+		return false;
+	}
 
 private:
 	void insertSlow(T t) {

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -13,6 +13,58 @@ struct VKRImage;
 enum {
 	QUEUE_HACK_MGS2_ACID = 1,
 	QUEUE_HACK_SONIC = 2,
+	// Killzone PR = 4.
+	QUEUE_HACK_RENDERPASS_MERGE = 8,
+};
+
+// Insert-only small-set implementation. Performs no allocation unless MaxFastSize is exceeded.
+template <class T, int MaxFastSize>
+struct TinySet {
+	~TinySet() { delete slowLookup_; }
+	inline void insert(T t) {
+		// Fast linear scan.
+		for (int i = 0; i < fastCount; i++) {
+			if (fastLookup_[i] == t)
+				return;  // We already have it.
+		}
+		// Fast insertion
+		if (fastCount < MaxFastSize) {
+			fastLookup_[fastCount++] = t;
+			return;
+		}
+		// Fall back to slow path.
+		insertSlow(t);
+	}
+	bool contains(T t) const {
+		for (int i = 0; i < fastCount; i++) {
+			if (fastLookup_[i] == t)
+				return true;
+		}
+		if (slowLookup_) {
+			for (auto x : *slowLookup_) {
+				if (x == t)
+					return true;
+			}
+		}
+		return false;
+	}
+
+private:
+	void insertSlow(T t) {
+		if (!slowLookup_) {
+			slowLookup_ = new std::vector<T>();
+		} else {
+			for (size_t i = 0; i < slowLookup_->size(); i++) {
+				if ((*slowLookup_)[i] == t)
+					return;
+			}
+		}
+		slowLookup_->push_back(t);
+	}
+	T fastLookup_[MaxFastSize];
+	int fastCount = 0;
+	int slowCount = 0;
+	std::vector<T> *slowLookup_ = nullptr;
 };
 
 enum class VKRRenderCommand : uint8_t {
@@ -109,9 +161,12 @@ struct TransitionRequest {
 
 struct VKRStep {
 	VKRStep(VKRStepType _type) : stepType(_type) {}
+	~VKRStep() {}
+
 	VKRStepType stepType;
 	std::vector<VkRenderData> commands;
 	std::vector<TransitionRequest> preTransitions;
+	TinySet<VKRFramebuffer *, 8> dependencies;
 	union {
 		struct {
 			VKRFramebuffer *framebuffer;
@@ -242,6 +297,7 @@ private:
 
 	void ApplyMGSHack(std::vector<VKRStep *> &steps);
 	void ApplySonicHack(std::vector<VKRStep *> &steps);
+	void ApplyRenderPassMerge(std::vector<VKRStep *> &steps);
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -858,7 +858,8 @@ void VulkanRenderManager::BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect,
 }
 
 VkImageView VulkanRenderManager::BindFramebufferAsTexture(VKRFramebuffer *fb, int binding, int aspectBit, int attachment) {
-	// Mark the dependency and return the image.
+	_dbg_assert_(G3D, curRenderStep_ != nullptr);
+	// Mark the dependency, check for required transitions, and return the image.
 
 	for (int i = (int)steps_.size() - 1; i >= 0; i--) {
 		if (steps_[i]->stepType == VKRStepType::RENDER && steps_[i]->render.framebuffer == fb) {
@@ -870,6 +871,9 @@ VkImageView VulkanRenderManager::BindFramebufferAsTexture(VKRFramebuffer *fb, in
 			break;
 		}
 	}
+
+	// Track dependencies fully.
+	curRenderStep_->dependencies.insert(fb);
 
 	if (!curRenderStep_->preTransitions.empty() &&
 			curRenderStep_->preTransitions.back().fb == fb &&


### PR DESCRIPTION
Should speed things up a bit on mobile in some games that do stupid things like GoW. Currently only enabled in GoW, but plan to enable this globally as it should be quite cheap when nothing is detected.

Enabling it globally will happen after 1.9.0 (due to the risk, there are probably some pass dependencies it doesn't yet detect) but might add some more games first.

Hopefully this will be enough to bring Vulkan up to GL speed on some Adrenos (see #12228).