### PR TITLE
Cleanup UI hostname entry

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1216,11 +1216,11 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 		}
 	}
 	else
-		screenManager()->push(new ProAdhocServerScreen);
+		screenManager()->push(new HostnameSelectScreen(g_Config.proAdhocServer));
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("IP:" + g_Config.proAdhocServer).c_str());
 #else
-	screenManager()->push(new ProAdhocServerScreen);
+	screenManager()->push(new HostnameSelectScreen(g_Config.proAdhocServer));
 #endif
 
 	return UI::EVENT_DONE;
@@ -1482,12 +1482,12 @@ void DeveloperToolsScreen::update() {
 	canAllowDebugger_ = !WebServerStopping(WebServerFlags::DEBUGGER);
 }
 
-void ProAdhocServerScreen::CreateViews() {
+void HostnameSelectScreen::CreateViews() {
 	using namespace UI;
 	I18NCategory *sy = GetI18NCategory("System");
 	I18NCategory *di = GetI18NCategory("Dialog");
 
-	tempProAdhocServer = g_Config.proAdhocServer;
+	tempProAdhocServer = targetConfig;
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 	LinearLayout *leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 
@@ -1495,115 +1495,115 @@ void ProAdhocServerScreen::CreateViews() {
 	addrView_ = new TextView(tempProAdhocServer, ALIGN_LEFT, false);
 	leftColumn->Add(addrView_);
 	LinearLayout *rightColumn = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(0, 120, 10, NONE, NONE,10));
-	rightColumn->Add(new Button("0"))->OnClick.Handle(this, &ProAdhocServerScreen::On0Click);
-	rightColumn->Add(new Button("1"))->OnClick.Handle(this, &ProAdhocServerScreen::On1Click);
-	rightColumn->Add(new Button("2"))->OnClick.Handle(this, &ProAdhocServerScreen::On2Click);
-	rightColumn->Add(new Button("3"))->OnClick.Handle(this, &ProAdhocServerScreen::On3Click);
-	rightColumn->Add(new Button("4"))->OnClick.Handle(this, &ProAdhocServerScreen::On4Click);
-	rightColumn->Add(new Button("5"))->OnClick.Handle(this, &ProAdhocServerScreen::On5Click);
-	rightColumn->Add(new Button("6"))->OnClick.Handle(this, &ProAdhocServerScreen::On6Click);
-	rightColumn->Add(new Button("7"))->OnClick.Handle(this, &ProAdhocServerScreen::On7Click);
-	rightColumn->Add(new Button("8"))->OnClick.Handle(this, &ProAdhocServerScreen::On8Click);
-	rightColumn->Add(new Button("9"))->OnClick.Handle(this, &ProAdhocServerScreen::On9Click);
-	rightColumn->Add(new Button("."))->OnClick.Handle(this, &ProAdhocServerScreen::OnPointClick);
-	rightColumn->Add(new Button(di->T("Delete")))->OnClick.Handle(this, &ProAdhocServerScreen::OnDeleteClick);
-	rightColumn->Add(new Button(di->T("Delete all")))->OnClick.Handle(this, &ProAdhocServerScreen::OnDeleteAllClick);
-	rightColumn->Add(new Button(di->T("OK")))->OnClick.Handle(this, &ProAdhocServerScreen::OnOKClick);
-	rightColumn->Add(new Button(di->T("Cancel")))->OnClick.Handle(this, &ProAdhocServerScreen::OnCancelClick);
+	rightColumn->Add(new Button("0"))->OnClick.Handle(this, &HostnameSelectScreen::On0Click);
+	rightColumn->Add(new Button("1"))->OnClick.Handle(this, &HostnameSelectScreen::On1Click);
+	rightColumn->Add(new Button("2"))->OnClick.Handle(this, &HostnameSelectScreen::On2Click);
+	rightColumn->Add(new Button("3"))->OnClick.Handle(this, &HostnameSelectScreen::On3Click);
+	rightColumn->Add(new Button("4"))->OnClick.Handle(this, &HostnameSelectScreen::On4Click);
+	rightColumn->Add(new Button("5"))->OnClick.Handle(this, &HostnameSelectScreen::On5Click);
+	rightColumn->Add(new Button("6"))->OnClick.Handle(this, &HostnameSelectScreen::On6Click);
+	rightColumn->Add(new Button("7"))->OnClick.Handle(this, &HostnameSelectScreen::On7Click);
+	rightColumn->Add(new Button("8"))->OnClick.Handle(this, &HostnameSelectScreen::On8Click);
+	rightColumn->Add(new Button("9"))->OnClick.Handle(this, &HostnameSelectScreen::On9Click);
+	rightColumn->Add(new Button("."))->OnClick.Handle(this, &HostnameSelectScreen::OnPointClick);
+	rightColumn->Add(new Button(di->T("Delete")))->OnClick.Handle(this, &HostnameSelectScreen::OnDeleteClick);
+	rightColumn->Add(new Button(di->T("Delete all")))->OnClick.Handle(this, &HostnameSelectScreen::OnDeleteAllClick);
+	rightColumn->Add(new Button(di->T("OK")))->OnClick.Handle(this, &HostnameSelectScreen::OnOKClick);
+	rightColumn->Add(new Button(di->T("Cancel")))->OnClick.Handle(this, &HostnameSelectScreen::OnCancelClick);
 	root_->Add(leftColumn);
 	root_->Add(rightColumn);
 }
 
-UI::EventReturn ProAdhocServerScreen::On0Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On0Click(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0)
 		tempProAdhocServer.append("0");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On1Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On1Click(UI::EventParams &e) {
 	tempProAdhocServer.append("1");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On2Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On2Click(UI::EventParams &e) {
 	tempProAdhocServer.append("2");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On3Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On3Click(UI::EventParams &e) {
 	tempProAdhocServer.append("3");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On4Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On4Click(UI::EventParams &e) {
 	tempProAdhocServer.append("4");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On5Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On5Click(UI::EventParams &e) {
 	tempProAdhocServer.append("5");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On6Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On6Click(UI::EventParams &e) {
 	tempProAdhocServer.append("6");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On7Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On7Click(UI::EventParams &e) {
 	tempProAdhocServer.append("7");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On8Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On8Click(UI::EventParams &e) {
 	tempProAdhocServer.append("8");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::On9Click(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::On9Click(UI::EventParams &e) {
 	tempProAdhocServer.append("9");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
 
-UI::EventReturn ProAdhocServerScreen::OnPointClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0 && tempProAdhocServer.at(tempProAdhocServer.length() - 1) != '.')
 		tempProAdhocServer.append(".");
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnDeleteClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {
 	if (tempProAdhocServer.length() > 0)
 		tempProAdhocServer.erase(tempProAdhocServer.length() -1, 1);
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnDeleteAllClick(UI::EventParams &e) {
+UI::EventReturn HostnameSelectScreen::OnDeleteAllClick(UI::EventParams &e) {
 	tempProAdhocServer = "";
 	addrView_->SetText(tempProAdhocServer);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnOKClick(UI::EventParams &e) {
-	g_Config.proAdhocServer = StripSpaces(tempProAdhocServer);
+UI::EventReturn HostnameSelectScreen::OnOKClick(UI::EventParams &e) {
+	targetConfig = tempProAdhocServer;
 	UIScreen::OnBack(e);
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn ProAdhocServerScreen::OnCancelClick(UI::EventParams &e) {
-	tempProAdhocServer = g_Config.proAdhocServer;
+UI::EventReturn HostnameSelectScreen::OnCancelClick(UI::EventParams &e) {
+	tempProAdhocServer = targetConfig;
 	UIScreen::OnBack(e);
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -175,14 +175,15 @@ private:
 	bool canAllowDebugger_ = true;
 };
 
-class ProAdhocServerScreen : public UIDialogScreenWithBackground {
+class HostnameSelectScreen : public UIDialogScreenWithBackground {
 public:
-	ProAdhocServerScreen() {}	
+	HostnameSelectScreen(std::string &target) : targetConfig(target) {}
 
 protected:
 	void CreateViews() override;
 
-private:	
+private:
+	std::string &targetConfig;
 	std::string tempProAdhocServer;
 	UI::TextView *addrView_;
 	UI::EventReturn On0Click(UI::EventParams &e);

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -187,12 +187,12 @@ protected:
 	void OnCompleted(DialogResult result) override;
 
 private:
+	void SendEditKey(int keyCode, int flags = 0);
 	UI::EventReturn OnNumberClick(UI::EventParams &e);
 	UI::EventReturn OnPointClick(UI::EventParams &e);
 	UI::EventReturn OnDeleteClick(UI::EventParams &e);
 	UI::EventReturn OnDeleteAllClick(UI::EventParams &e);
 
 	std::string *value_;
-	std::string currentValue_;
-	UI::TextView *addrView_;
+	UI::TextEdit *addrView_;
 };

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -175,30 +175,24 @@ private:
 	bool canAllowDebugger_ = true;
 };
 
-class HostnameSelectScreen : public UIDialogScreenWithBackground {
+class HostnameSelectScreen : public PopupScreen {
 public:
-	HostnameSelectScreen(std::string &target) : targetConfig(target) {}
+	HostnameSelectScreen(std::string *value, const std::string &title)
+		: PopupScreen(title, "OK", "Cancel"), value_(value) {
+	}
+
+	void CreatePopupContents(UI::ViewGroup *parent) override;
 
 protected:
-	void CreateViews() override;
+	void OnCompleted(DialogResult result) override;
 
 private:
-	std::string &targetConfig;
-	std::string tempProAdhocServer;
-	UI::TextView *addrView_;
-	UI::EventReturn On0Click(UI::EventParams &e);
-	UI::EventReturn On1Click(UI::EventParams &e);
-	UI::EventReturn On2Click(UI::EventParams &e);
-	UI::EventReturn On3Click(UI::EventParams &e);
-	UI::EventReturn On4Click(UI::EventParams &e);
-	UI::EventReturn On5Click(UI::EventParams &e);
-	UI::EventReturn On6Click(UI::EventParams &e);
-	UI::EventReturn On7Click(UI::EventParams &e);
-	UI::EventReturn On8Click(UI::EventParams &e);
-	UI::EventReturn On9Click(UI::EventParams &e);
+	UI::EventReturn OnNumberClick(UI::EventParams &e);
 	UI::EventReturn OnPointClick(UI::EventParams &e);
 	UI::EventReturn OnDeleteClick(UI::EventParams &e);
 	UI::EventReturn OnDeleteAllClick(UI::EventParams &e);
-	UI::EventReturn OnOKClick(UI::EventParams &e);
-	UI::EventReturn OnCancelClick(UI::EventParams &e);
+
+	std::string *value_;
+	std::string currentValue_;
+	UI::TextView *addrView_;
 };

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -268,6 +268,8 @@ bool PopupScreen::key(const KeyInput &key) {
 void PopupScreen::update() {
 	UIDialogScreen::update();
 
+	defaultButton_->SetEnabled(CanComplete(DR_OK));
+
 	float animatePos = 1.0f;
 
 	++frames_;
@@ -314,10 +316,12 @@ void PopupScreen::SetPopupOrigin(const UI::View *view) {
 }
 
 void PopupScreen::TriggerFinish(DialogResult result) {
-	finishFrame_ = frames_;
-	finishResult_ = result;
+	if (CanComplete(result)) {
+		finishFrame_ = frames_;
+		finishResult_ = result;
 
-	OnCompleted(result);
+		OnCompleted(result);
+	}
 }
 
 void PopupScreen::resized() {

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -84,6 +84,7 @@ protected:
 	virtual bool FillVertical() const { return false; }
 	virtual UI::Size PopupWidth() const { return 550; }
 	virtual bool ShowButtons() const { return true; }
+	virtual bool CanComplete(DialogResult result) { return true; }
 	virtual void OnCompleted(DialogResult result) {}
 
 	virtual void update() override;

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -225,7 +225,7 @@ private:
 
 class TextEditPopupScreen : public PopupScreen {
 public:
-	TextEditPopupScreen(std::string *value, std::string &placeholder, const std::string &title, int maxLen)
+	TextEditPopupScreen(std::string *value, const std::string &placeholder, const std::string &title, int maxLen)
 		: PopupScreen(title, "OK", "Cancel"), value_(value), placeholder_(placeholder), maxLen_(maxLen) {}
 	virtual void CreatePopupContents(ViewGroup *parent) override;
 


### PR DESCRIPTION
Before, it was a text field on non-mobile, a keyboard input on Android, and a full screen dialog on any other mobile device.

This makes it a bit more consistent, but keeps Android different so that a keyboard can still be used there.  Outside Android, it also attempts to resolve the address you entered and tells you if it didn't resolve.

You can still change it while offline (I think this would be uncommon though), after the DNS check times out.  But in most cases, this will help you validate if you made a typo in the IP or hostname, at least on desktop and non-Android.

Should help #9795 - doesn't really validate "connectivity", but you really want to try to send a ping message because of firewalls that accept and null route invalid connections.  Still, I think it will validate most cases of typos.

Additionally, I think this is UI that makes sense for #7590 since binding on a local address still requires that address to be valid, and I think that can cause confusion.  That said, I think there are options to avoid requiring the user to type an address in a simpler way.

-[Unknown]