### PR TITLE
Fixes delete button for downloaded games from homebrew store in UWP

### DIFF
--- a/Common/FileUtil.cpp
+++ b/Common/FileUtil.cpp
@@ -648,10 +648,8 @@ bool CreateEmptyFile(const std::string &filename)
 
 // Deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const std::string &directory)
-{
-#if PPSSPP_PLATFORM(UWP)
-	return false;
-#else
+{	
+	//Removed check, it prevents the UWP from deleting store downloads
 	INFO_LOG(COMMON, "DeleteDirRecursively: %s", directory.c_str());
 
 #ifdef _WIN32
@@ -720,7 +718,6 @@ bool DeleteDirRecursively(const std::string &directory)
 	closedir(dirp);
 #endif
 	return File::DeleteDir(directory);
-#endif
 }
 
 

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -299,7 +299,9 @@ void RegisterAllModules() {
 	Register_sceNetIfhandle();
 	Register_KUBridge();
 	Register_sceUsbAcc();
+#if !PPSSPP_PLATFORM(UWP)
 	Register_sceUsbMic();
+#endif
 
 	// add new modules here.
 }

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -299,9 +299,7 @@ void RegisterAllModules() {
 	Register_sceNetIfhandle();
 	Register_KUBridge();
 	Register_sceUsbAcc();
-#if !PPSSPP_PLATFORM(UWP)
 	Register_sceUsbMic();
-#endif
 
 	// add new modules here.
 }

--- a/Core/HLE/sceUsbMic.h
+++ b/Core/HLE/sceUsbMic.h
@@ -16,5 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #pragma once
-
+//UWP doesn't like this for some reason
+#if !PPSSPP_PLATFORM(UWP)
 void Register_sceUsbMic();
+#endif

--- a/Core/HLE/sceUsbMic.h
+++ b/Core/HLE/sceUsbMic.h
@@ -16,7 +16,4 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #pragma once
-//UWP doesn't like this for some reason
-#if !PPSSPP_PLATFORM(UWP)
 void Register_sceUsbMic();
-#endif


### PR DESCRIPTION
This PR fixes the delete function for homebrew store downloads. Also, had to add condition to void Register_sceUsbMic() function. It was causing errors on build for UWP.