### PR TITLE
Update PowerSaveModeReceiver (again)

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -102,14 +102,6 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name=".PowerSaveModeReceiver">
-            <intent-filter>
-                <action android:name="android.os.action.POWER_SAVE_MODE_CHANGED" />
-                <action android:name="android.intent.action.BATTERY_LOW" />
-                <action android:name="android.intent.action.BATTERY_OKAY" />
-            </intent-filter>
-        </receiver>
-
         <meta-data
             android:name="xperiaplayoptimized_content"
             android:resource="@drawable/ic_launcher" />

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -106,6 +106,8 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 	private InputDeviceState inputPlayerC;
 	private String inputPlayerADesc;
 
+	private PowerSaveModeReceiver mPowerSaveModeReceiver = null;
+
 	private static LocationHelper mLocationHelper;
 	private static CameraHelper mCameraHelper;
 
@@ -311,7 +313,6 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		javaGL = "true".equalsIgnoreCase(NativeApp.queryConfig("androidJavaGL"));
 
 		sendInitialGrants();
-		PowerSaveModeReceiver.initAndSend(this);
 
 		// OK, config should be initialized, we can query for screen rotation.
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
@@ -487,6 +488,10 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		if (!initialized) {
 			Initialize();
 			initialized = true;
+		}
+
+		if (mPowerSaveModeReceiver == null) {
+			mPowerSaveModeReceiver = new PowerSaveModeReceiver(this);
 		}
 
 		// OK, config should be initialized, we can query for screen rotation.
@@ -703,7 +708,10 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			mSurfaceView.onDestroy();
 			mSurfaceView = null;
 		}
-		PowerSaveModeReceiver.destroy(this);
+		if (mPowerSaveModeReceiver != null) {
+			mPowerSaveModeReceiver.destroy(this);
+			mPowerSaveModeReceiver = null;
+		}
 		// TODO: Can we ensure that the GL thread has stopped rendering here?
 		// I've seen crashes that seem to indicate that sometimes it hasn't...
 		NativeApp.audioShutdown();
@@ -771,7 +779,6 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 				mSurfaceView.onResume();
 			}
 		}
-		PowerSaveModeReceiver.sendPowerSaving(this);
 
 		gainAudioFocus(this.audioManager, this.audioFocusChangeListener);
 		NativeApp.resume();


### PR DESCRIPTION
The previous patch had an issue: PowerSaveModeReceiver was registered in NativeActivity::Initialize() which is called only once, but when the activity is recreated (eg: caused by device rotation), the receiver wasn't registered against the new activity context. This is the reason why the Intent was not received  sometimes.
In this patch, PowerSaveModeReceiver is now registered in onCreate, so it will be called again when the activity is recreated; the explicit call from onResume is removed; and all 3 intents are handled my the same receiver. 
The changes are required because POWER_SAVE_MODE_CHANGED is not delivered to receivers declared in manifest: https://stackoverflow.com/a/38859740