### PR TITLE
Vulkan: Implement basic integrated GPU profiling.

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -516,8 +516,8 @@ void VulkanContext::ChooseDevice(int physical_device) {
 	vkGetPhysicalDeviceQueueFamilyProperties(physical_devices_[physical_device_], &queue_count, nullptr);
 	assert(queue_count >= 1);
 
-	queue_props.resize(queue_count);
-	vkGetPhysicalDeviceQueueFamilyProperties(physical_devices_[physical_device_], &queue_count, queue_props.data());
+	queueFamilyProperties_.resize(queue_count);
+	vkGetPhysicalDeviceQueueFamilyProperties(physical_devices_[physical_device_], &queue_count, queueFamilyProperties_.data());
 	assert(queue_count >= 1);
 
 	// Detect preferred formats, in this order.
@@ -619,7 +619,7 @@ VkResult VulkanContext::CreateDevice() {
 	queue_info.pQueuePriorities = queue_priorities;
 	bool found = false;
 	for (int i = 0; i < (int)queue_count; i++) {
-		if (queue_props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+		if (queueFamilyProperties_[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
 			queue_info.queueFamilyIndex = i;
 			found = true;
 			break;
@@ -816,7 +816,7 @@ bool VulkanContext::InitQueue() {
 	uint32_t graphicsQueueNodeIndex = UINT32_MAX;
 	uint32_t presentQueueNodeIndex = UINT32_MAX;
 	for (uint32_t i = 0; i < queue_count; i++) {
-		if ((queue_props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
+		if ((queueFamilyProperties_[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
 			if (graphicsQueueNodeIndex == UINT32_MAX) {
 				graphicsQueueNodeIndex = i;
 			}

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -201,6 +201,10 @@ public:
 		return physicalDeviceProperties_[i];
 	}
 
+	const VkQueueFamilyProperties &GetQueueFamilyProperties(int family) const {
+		return queueFamilyProperties_[family];
+	}
+
 	VkResult GetInstanceLayerExtensionList(const char *layerName, std::vector<VkExtensionProperties> &extensions);
 	VkResult GetInstanceLayerProperties();
 
@@ -303,8 +307,8 @@ private:
 	int physical_device_ = -1;
 
 	uint32_t graphics_queue_family_index_ = -1;
-	std::vector<PhysicalDeviceProps> physicalDeviceProperties_{};
-	std::vector<VkQueueFamilyProperties> queue_props;
+	std::vector<PhysicalDeviceProps> physicalDeviceProperties_;
+	std::vector<VkQueueFamilyProperties> queueFamilyProperties_;
 	VkPhysicalDeviceMemoryProperties memory_properties{};
 
 	// Custom collection of things that are good to know

--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -113,6 +113,13 @@ VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 	std::ostringstream message;
 
 	const char *pMessage = pCallbackData->pMessage;
+
+	// Apparent bugs around timestamp validation in the validation layers
+	if (strstr(pMessage, "vkCmdBeginQuery(): VkQueryPool"))
+		return false;
+	if (strstr(pMessage, "vkGetQueryPoolResults() on VkQueryPool"))
+		return false;
+
 	int messageCode = pCallbackData->messageIdNumber;
 	const char *pLayerPrefix = "";
 	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -962,6 +962,7 @@ static ConfigSetting debuggerSettings[] = {
 	ConfigSetting("ShowBottomTabTitles",&g_Config.bShowBottomTabTitles,true),
 	ConfigSetting("ShowDeveloperMenu", &g_Config.bShowDeveloperMenu, false),
 	ConfigSetting("ShowAllocatorDebug", &g_Config.bShowAllocatorDebug, false, false),
+	ConfigSetting("ShowGpuProfile", &g_Config.bShowGpuProfile, false, false),
 	ConfigSetting("SkipDeadbeefFilling", &g_Config.bSkipDeadbeefFilling, false),
 	ConfigSetting("FuncHashMap", &g_Config.bFuncHashMap, false),
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -959,7 +959,7 @@ static ConfigSetting debuggerSettings[] = {
 	ConfigSetting("FontWidth", &g_Config.iFontWidth, 8),
 	ConfigSetting("FontHeight", &g_Config.iFontHeight, 12),
 	ConfigSetting("DisplayStatusBar", &g_Config.bDisplayStatusBar, true),
-	ConfigSetting("ShowBottomTabTitles",&g_Config.bShowBottomTabTitles,true),
+	ConfigSetting("ShowBottomTabTitles",&g_Config.bShowBottomTabTitles, true),
 	ConfigSetting("ShowDeveloperMenu", &g_Config.bShowDeveloperMenu, false),
 	ConfigSetting("ShowAllocatorDebug", &g_Config.bShowAllocatorDebug, false, false),
 	ConfigSetting("ShowGpuProfile", &g_Config.bShowGpuProfile, false, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -68,21 +68,20 @@ public:
 	bool bEnableLogging;
 	bool bDumpDecryptedEboot;
 	bool bFullscreenOnDoubleclick;
-#if defined(USING_WIN_UI)
+
+	// These four are Win UI only
 	bool bPauseOnLostFocus;
 	bool bTopMost;
 	bool bIgnoreWindowsKey;
 	bool bRestartRequired;
-#endif
-#if defined(USING_WIN_UI) || defined(USING_QT_UI) || PPSSPP_PLATFORM(UWP)
+
 	std::string sFont;
-#endif
 
 	bool bPauseWhenMinimized;
 
-#if !defined(MOBILE_DEVICE)
+	// Not used on mobile devices.
 	bool bPauseExitsEmulator;
-#endif
+
 	bool bPauseMenuExitsEmulator;
 
 	// Core
@@ -129,9 +128,8 @@ public:
 	// We have separate device parameters for each backend so it doesn't get erased if you switch backends.
 	// If not set, will use the "best" device.
 	std::string sVulkanDevice;
-#ifdef _WIN32
-	std::string sD3D11Device;
-#endif
+	std::string sD3D11Device;  // Windows only
+
 	bool bSoftwareRendering;
 	bool bHardwareTransform; // only used in the GLES backend
 	bool bSoftwareSkinning;  // may speed up some games
@@ -367,9 +365,7 @@ public:
 	int iPSPModel;
 	int iFirmwareVersion;
 	// TODO: Make this work with your platform, too!
-#if defined(USING_WIN_UI)
 	bool bBypassOSKWithKeyboard;
-#endif
 
 	// Debugger
 	int iDisasmWindowX;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -237,8 +237,8 @@ public:
 	bool bLogFrameDrops;
 	bool bShowDebugStats;
 	bool bShowAudioDebug;
-	bool bAudioResampler;
 	bool bShowGpuProfile;
+	bool bAudioResampler;
 
 	//Analog stick tilting
 	//the base x and y tilt. this inclination is treated as (0,0) and the tilt input

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -238,6 +238,7 @@ public:
 	bool bShowDebugStats;
 	bool bShowAudioDebug;
 	bool bAudioResampler;
+	bool bShowGpuProfile;
 
 	//Analog stick tilting
 	//the base x and y tilt. this inclination is treated as (0,0) and the tilt input

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -26,6 +26,8 @@
 #include "GPU/Vulkan/GPU_Vulkan.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
+#undef DrawText
+
 void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
 	if (!gpu) {
 		return;
@@ -93,4 +95,27 @@ void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
 
 	for (auto iter : texturesToDelete)
 		iter->Release();
+}
+
+void DrawProfilerVis(UIContext *ui, GPUInterface *gpu) {
+	if (!gpu) {
+		return;
+	}
+	using namespace Draw;
+	const int padding = 10;
+	const int columnWidth = 256;
+	const int starty = padding * 8;
+	int x = padding;
+	int y = starty;
+	int w = columnWidth;  // We will double this when actually drawing to make the pixels visible.
+
+	ui->Begin();
+
+	GPU_Vulkan *gpuVulkan = static_cast<GPU_Vulkan *>(gpu);
+
+	std::string text = gpuVulkan->GetGpuProfileString();
+
+	Draw::DrawContext *draw = ui->GetDrawContext();
+	ui->DrawTextShadow(text.c_str(), 10, 50, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	ui->Flush();
 }

--- a/GPU/Vulkan/DebugVisVulkan.h
+++ b/GPU/Vulkan/DebugVisVulkan.h
@@ -24,3 +24,4 @@ class UIContext;
 
 // gpu MUST be an instance of GPU_Vulkan. If not, will definitely crash.
 void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu);
+void DrawProfilerVis(UIContext *ui, GPUInterface *gpu);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -638,3 +638,8 @@ std::string GPU_Vulkan::DebugGetShaderString(std::string id, DebugShaderType typ
 		return std::string();
 	}
 }
+
+std::string GPU_Vulkan::GetGpuProfileString() {
+	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	return rm->GetGpuProfileString();
+}

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -66,6 +66,8 @@ public:
 		return textureCacheVulkan_;
 	}
 
+	std::string GetGpuProfileString();
+
 protected:
 	void FinishDeferred() override;
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -78,7 +78,10 @@ void DevMenu::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &DevMenu::OnDeveloperTools);
 	items->Add(new Choice(dev->T("Jit Compare")))->OnClick.Handle(this, &DevMenu::OnJitCompare);
 	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenu::OnShaderView);
-	items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
+		items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
+		items->Add(new CheckBox(&g_Config.bShowGpuProfile, dev->T("GPU Profile")));
+	}
 	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Handle(this, &DevMenu::OnFreezeFrame);
 	items->Add(new Choice(dev->T("Dump Frame GPU Commands")))->OnClick.Handle(this, &DevMenu::OnDumpFrame);
 	items->Add(new Choice(dev->T("Toggle Audio Debug")))->OnClick.Handle(this, &DevMenu::OnToggleAudioDebug);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1359,6 +1359,11 @@ void EmuScreen::renderUI() {
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN && g_Config.bShowAllocatorDebug) {
 		DrawAllocatorVis(ctx, gpu);
 	}
+
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN && g_Config.bShowGpuProfile) {
+		DrawProfilerVis(ctx, gpu);
+	}
+
 #endif
 
 #ifdef USE_PROFILER

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -350,7 +350,8 @@ void VulkanRenderManager::ThreadFunc() {
 	VLOG("PULL: Quitting");
 }
 
-void VulkanRenderManager::BeginFrame() {
+void VulkanRenderManager::BeginFrame(bool enableProfiling) {
+	gpuProfilingEnabled_ = enableProfiling;
 	VLOG("BeginFrame");
 	VkDevice device = vulkan_->GetDevice();
 
@@ -372,6 +373,7 @@ void VulkanRenderManager::BeginFrame() {
 	vkResetFences(device, 1, &frameData.fence);
 
 	uint64_t queryResults[MAX_TIMESTAMP_QUERIES];
+
 	if (gpuProfilingEnabled_) {
 		// Pull the profiling results from last time and produce a summary!
 		if (frameData.numQueries) {

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -314,7 +314,7 @@ private:
 	VKRStep *curRenderStep_ = nullptr;
 	std::vector<VKRStep *> steps_;
 	bool splitSubmit_ = false;
-	bool gpuProfilingEnabled_ = true;
+	bool gpuProfilingEnabled_ = false;
 
 	// Execution time state
 	bool run_ = true;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -92,7 +92,7 @@ public:
 	void ThreadFunc();
 
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
-	void BeginFrame();
+	void BeginFrame(bool enableProfiling);
 	// Can run on a different thread!
 	void Finish();
 	void Run(int frame);
@@ -242,11 +242,6 @@ public:
 		return &queueRunner_;
 	}
 
-	// Call before BeginFrame.
-	void SetGPUProfilingEnabled(bool enabled) {
-		gpuProfilingEnabled_ = enabled;
-	}
-
 	std::string GetGpuProfileString() const {
 		return frameData_[vulkan_->GetCurFrame()].profileSummary;
 	}
@@ -307,6 +302,9 @@ private:
 		MAX_TIMESTAMP_QUERIES = 256,
 	};
 
+	// Global state
+	bool gpuProfilingEnabled_ = false;
+
 	// Submission time state
 	int curWidth_ = -1;
 	int curHeight_ = -1;
@@ -314,7 +312,6 @@ private:
 	VKRStep *curRenderStep_ = nullptr;
 	std::vector<VKRStep *> steps_;
 	bool splitSubmit_ = false;
-	bool gpuProfilingEnabled_ = false;
 
 	// Execution time state
 	bool run_ = true;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -292,7 +292,6 @@ private:
 		// Profiling.
 		VkQueryPool timestampQueryPool_ = VK_NULL_HANDLE;
 		std::vector<std::string> timestampDescriptions;
-		int numQueries = 0;
 		std::string profileSummary;
 	};
 

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -242,6 +242,15 @@ public:
 		return &queueRunner_;
 	}
 
+	// Call before BeginFrame.
+	void SetGPUProfilingEnabled(bool enabled) {
+		gpuProfilingEnabled_ = enabled;
+	}
+
+	std::string GetGpuProfileString() const {
+		return frameData_[vulkan_->GetCurFrame()].profileSummary;
+	}
+
 private:
 	bool InitBackbufferFramebuffers(int width, int height);
 	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
@@ -284,8 +293,19 @@ private:
 		// Swapchain.
 		bool hasBegun = false;
 		uint32_t curSwapchainImage = -1;
+
+		// Profiling.
+		VkQueryPool timestampQueryPool_ = VK_NULL_HANDLE;
+		std::vector<std::string> timestampDescriptions;
+		int numQueries = 0;
+		std::string profileSummary;
 	};
+
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
+
+	enum {
+		MAX_TIMESTAMP_QUERIES = 256,
+	};
 
 	// Submission time state
 	int curWidth_ = -1;
@@ -294,6 +314,7 @@ private:
 	VKRStep *curRenderStep_ = nullptr;
 	std::vector<VKRStep *> steps_;
 	bool splitSubmit_ = false;
+	bool gpuProfilingEnabled_ = true;
 
 	// Execution time state
 	bool run_ = true;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -879,6 +879,7 @@ VKContext::~VKContext() {
 }
 
 void VKContext::BeginFrame() {
+	renderManager_.SetGPUProfilingEnabled(g_Config.bShowGpuProfile);
 	renderManager_.BeginFrame();
 
 	FrameData &frame = frame_[vulkan_->GetCurFrame()];

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -879,8 +879,7 @@ VKContext::~VKContext() {
 }
 
 void VKContext::BeginFrame() {
-	renderManager_.SetGPUProfilingEnabled(g_Config.bShowGpuProfile);
-	renderManager_.BeginFrame();
+	renderManager_.BeginFrame(g_Config.bShowGpuProfile);
 
 	FrameData &frame = frame_[vulkan_->GetCurFrame()];
 	push_ = frame.pushBuffer;


### PR DESCRIPTION
Currently simply measures the total GPU time of the frame, split into init and main command buffers. Will later be extended to get the execution time of individual render passes.

Enabled using a checkbox in the "Dev menu" (or permanently through ini file).

The goal is to be able to quantify improvements from various attempts at GPU optimization. Framerate isn't good enough for comparisons if you're already at 60 on mobile.

Note: If the GPU is mostly idle it'll downclock. On PC you can unthrottle to get it to run at its proper performance. I'll also later investigate locking the GPU frequency, there are some methods.

![profiler](https://user-images.githubusercontent.com/130929/63388155-bed38a00-c3a7-11e9-841c-1526bc895238.png)
