### PR TITLE
Vulkan: Further improvements to GPU profiling

### DIFF
--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -116,6 +116,7 @@ void DrawProfilerVis(UIContext *ui, GPUInterface *gpu) {
 	std::string text = gpuVulkan->GetGpuProfileString();
 
 	Draw::DrawContext *draw = ui->GetDrawContext();
+	ui->SetFontScale(0.4f, 0.4f);
 	ui->DrawTextShadow(text.c_str(), 10, 50, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 	ui->Flush();
 }

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -704,16 +704,20 @@ std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
 	char buffer[256];
 	switch (step.stepType) {
 	case VKRStepType::RENDER:
-		snprintf(buffer, sizeof(buffer), "RenderPass (fb: %p)", step.render.framebuffer);
+	{
+		int w = step.render.framebuffer ? step.render.framebuffer->width : vulkan_->GetBackbufferWidth();
+		int h = step.render.framebuffer ? step.render.framebuffer->height : vulkan_->GetBackbufferHeight();
+		snprintf(buffer, sizeof(buffer), "RenderPass (draws: %d, %dx%d, fb: %p, )", step.render.numDraws, w, h, step.render.framebuffer);
 		break;
+	}
 	case VKRStepType::COPY:
 		snprintf(buffer, sizeof(buffer), "Copy (%dx%d)", step.copy.srcRect.extent.width, step.copy.srcRect.extent.height);
 		break;
 	case VKRStepType::BLIT:
-		snprintf(buffer, sizeof(buffer), "Blit");
+		snprintf(buffer, sizeof(buffer), "Blit (%dx%d->%dx%d)", step.blit.srcRect.extent.width, step.blit.srcRect.extent.height, step.blit.dstRect.extent.width, step.blit.dstRect.extent.height);
 		break;
 	case VKRStepType::READBACK:
-		snprintf(buffer, sizeof(buffer), "Readback");
+		snprintf(buffer, sizeof(buffer), "Readback (%dx%d)", step.readback.srcRect.extent.width, step.readback.srcRect.extent.height);
 		break;
 	case VKRStepType::READBACK_IMAGE:
 		snprintf(buffer, sizeof(buffer), "ReadbackImage");

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -374,7 +374,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 	return pass;
 }
 
-void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps) {
+void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, VkQueryPool queryPool, std::vector<std::string> *timestampDescriptions) {
 	// Optimizes renderpasses, then sequences them.
 	// Planned optimizations: 
 	//  * Create copies of render target that are rendered to multiple times and textured from in sequence, and push those render passes
@@ -460,6 +460,11 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 			break;
 		case VKRStepType::RENDER_SKIP:
 			break;
+		}
+
+		if (queryPool) {
+			vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, queryPool, (uint32_t)timestampDescriptions->size());
+			timestampDescriptions->push_back(StepToString(step));
 		}
 	}
 
@@ -695,10 +700,39 @@ void VulkanQueueRunner::ApplySonicHack(std::vector<VKRStep *> &steps) {
 	}
 }
 
+std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
+	char buffer[256];
+	switch (step.stepType) {
+	case VKRStepType::RENDER:
+		snprintf(buffer, sizeof(buffer), "RenderPass (fb: %p)", step.render.framebuffer);
+		break;
+	case VKRStepType::COPY:
+		snprintf(buffer, sizeof(buffer), "Copy (%dx%d)", step.copy.srcRect.extent.width, step.copy.srcRect.extent.height);
+		break;
+	case VKRStepType::BLIT:
+		snprintf(buffer, sizeof(buffer), "Blit");
+		break;
+	case VKRStepType::READBACK:
+		snprintf(buffer, sizeof(buffer), "Readback");
+		break;
+	case VKRStepType::READBACK_IMAGE:
+		snprintf(buffer, sizeof(buffer), "ReadbackImage");
+		break;
+	case VKRStepType::RENDER_SKIP:
+		snprintf(buffer, sizeof(buffer), "(SKIPPED RenderPass)");
+		break;
+	default:
+		buffer[0] = 0;
+		break;
+	}
+	return std::string(buffer);
+}
+
 void VulkanQueueRunner::LogSteps(const std::vector<VKRStep *> &steps) {
 	ILOG("=======================================");
 	for (size_t i = 0; i < steps.size(); i++) {
 		const VKRStep &step = *steps[i];
+		ILOG("%s", StepToString(step).c_str());
 		switch (step.stepType) {
 		case VKRStepType::RENDER:
 			LogRenderPass(step);

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -163,8 +163,10 @@ public:
 	}
 
 	// RunSteps can modify steps but will leave it in a valid state.
-	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps);
+	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, VkQueryPool queryPool, std::vector<std::string> *timestampDescriptions);
 	void LogSteps(const std::vector<VKRStep *> &steps);
+
+	std::string StepToString(const VKRStep &step) const;
 
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -962,12 +962,6 @@ void VulkanRenderManager::Submit(int frame, bool triggerFence) {
 		_assert_msg_(G3D, res == VK_SUCCESS, "vkEndCommandBuffer failed (init)! result=%s", VulkanResultToString(res));
 	}
 
-	if (frameData.profilingEnabled_) {
-		int numQueries = (int)frameData.timestampDescriptions.size();
-		vkCmdWriteTimestamp(frameData.mainCmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, frameData.timestampQueryPool_, numQueries);
-		frameData.timestampDescriptions.push_back("mainCmd");
-	}
-
 	VkResult res = vkEndCommandBuffer(frameData.mainCmd);
 	_assert_msg_(G3D, res == VK_SUCCESS, "vkEndCommandBuffer failed (main)! result=%s", VulkanResultToString(res));
 

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -291,6 +291,7 @@ private:
 
 		// Profiling.
 		VkQueryPool timestampQueryPool_ = VK_NULL_HANDLE;
+		bool profilingEnabled_;
 		std::vector<std::string> timestampDescriptions;
 		std::string profileSummary;
 	};
@@ -300,9 +301,6 @@ private:
 	enum {
 		MAX_TIMESTAMP_QUERIES = 256,
 	};
-
-	// Global state
-	bool gpuProfilingEnabled_ = false;
 
 	// Submission time state
 	int curWidth_ = -1;


### PR DESCRIPTION
Shows execution time per render pass, shrinks the text (some games use a lot of them, and still won't fit on screen as it is unfortunately).