### PR TITLE
(Libretro) Buildfix - update Makefile.common

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -381,6 +381,7 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
 	       $(COREDIR)/HLE/sceHttp.cpp \
 	       $(COREDIR)/HLE/sceImpose.cpp \
 	       $(COREDIR)/HLE/sceIo.cpp \
+	       $(COREDIR)/HLE/sceUsbMic.cpp \
 	       $(COREDIR)/HLE/sceJpeg.cpp \
 	       $(COREDIR)/HLE/sceKernel.cpp \
 	       $(COREDIR)/HLE/sceKernelAlarm.cpp \


### PR DESCRIPTION
This is needed for a couple of targets to compile.