### PR TITLE
Use PSP threads for async IO

### DIFF
--- a/Core/HLE/HLEHelperThread.cpp
+++ b/Core/HLE/HLEHelperThread.cpp
@@ -49,8 +49,10 @@ HLEHelperThread::HLEHelperThread(const char *threadName, const char *module, con
 }
 
 HLEHelperThread::~HLEHelperThread() {
-	__KernelDeleteThread(id_, SCE_KERNEL_ERROR_THREAD_TERMINATED, "helper deleted");
-	kernelMemory.Free(entry_);
+	if (id_)
+		__KernelDeleteThread(id_, SCE_KERNEL_ERROR_THREAD_TERMINATED, "helper deleted");
+	if (entry_)
+		kernelMemory.Free(entry_);
 }
 
 void HLEHelperThread::AllocEntry(u32 size) {
@@ -83,4 +85,9 @@ void HLEHelperThread::Terminate() {
 
 bool HLEHelperThread::Stopped() {
 	return KernelIsThreadDormant(id_);
+}
+
+void HLEHelperThread::Forget() {
+	id_ = 0;
+	entry_ = 0;
 }

--- a/Core/HLE/HLEHelperThread.cpp
+++ b/Core/HLE/HLEHelperThread.cpp
@@ -55,11 +55,12 @@ HLEHelperThread::~HLEHelperThread() {
 
 void HLEHelperThread::AllocEntry(u32 size) {
 	entry_ = kernelMemory.Alloc(size);
+	Memory::Memset(entry_, 0, size);
 	currentMIPS->InvalidateICache(entry_, size);
 }
 
 void HLEHelperThread::Create(const char *threadName, u32 prio, int stacksize) {
-	id_ = __KernelCreateThreadInternal(threadName, __KernelGetCurThreadModuleId(), entry_, prio, stacksize, 0);
+	id_ = __KernelCreateThreadInternal(threadName, __KernelGetCurThreadModuleId(), entry_, prio, stacksize, 0x00001000);
 }
 
 void HLEHelperThread::DoState(PointerWrap &p) {
@@ -78,4 +79,8 @@ void HLEHelperThread::Start(u32 a0, u32 a1) {
 
 void HLEHelperThread::Terminate() {
 	__KernelStopThread(id_, SCE_KERNEL_ERROR_THREAD_TERMINATED, "helper terminated");
+}
+
+bool HLEHelperThread::Stopped() {
+	return KernelIsThreadDormant(id_);
 }

--- a/Core/HLE/HLEHelperThread.h
+++ b/Core/HLE/HLEHelperThread.h
@@ -31,6 +31,7 @@ public:
 
 	void Start(u32 a0, u32 a1);
 	void Terminate();
+	bool Stopped();
 
 private:
 	void AllocEntry(u32 size);

--- a/Core/HLE/HLEHelperThread.h
+++ b/Core/HLE/HLEHelperThread.h
@@ -33,6 +33,9 @@ public:
 	void Terminate();
 	bool Stopped();
 
+	// For savestates.
+	void Forget();
+
 private:
 	void AllocEntry(u32 size);
 	void Create(const char *threadName, u32 prio, int stacksize);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2038,9 +2038,9 @@ static u32 sceIoOpenAsync(const char *filename, int flags, int mode)
 	params.open.mode = mode;
 	IoStartAsyncThread(fd, f);
 
-	if (f == nullptr) {
+	if (error != 0) {
 		f->asyncResult = (s64)error;
-		return hleLogError(SCEIO, f->asyncResult, "file not found");
+		return hleLogError(SCEIO, fd, "file not found");
 	}
 
 	f->asyncResult = fd;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2151,7 +2151,7 @@ static int sceIoWaitAsyncCB(int id, u32 address) {
 			DEBUG_LOG(SCEIO, "%lli = sceIoWaitAsyncCB(%i, %08x): waiting", f->asyncResult, id, address);
 			// TODO: This seems to re-enable dispatch or something?
 			f->waitingThreads.push_back(__KernelGetCurThread());
-			__KernelWaitCurThread(WAITTYPE_ASYNCIO, f->GetUID(), address, 0, false, "io waited");
+			__KernelWaitCurThread(WAITTYPE_ASYNCIO, f->GetUID(), address, 0, true, "io waited");
 		} else if (f->hasAsyncResult) {
 			DEBUG_LOG(SCEIO, "%lli = sceIoWaitAsyncCB(%i, %08x)", f->asyncResult, id, address);
 			Memory::Write_U64((u64) f->asyncResult, address);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2704,6 +2704,7 @@ static int IoAsyncFinish(int id) {
 		}
 
 		__IoSchedAsync(f, id, us);
+		__KernelWaitCurThread(WAITTYPE_ASYNCIO, id, 0, 0, false, "async io");
 
 		params.op = IoAsyncOp::NONE;
 		return 0;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2131,7 +2131,7 @@ void __KernelReturnFromThread()
 	Thread *thread = __GetCurrentThread();
 	_dbg_assert_msg_(SCEKERNEL, thread != NULL, "Returned from a NULL thread.");
 
-	INFO_LOG(SCEKERNEL,"__KernelReturnFromThread: %d", exitStatus);
+	DEBUG_LOG(SCEKERNEL, "__KernelReturnFromThread: %d", exitStatus);
 	__KernelStopThread(currentThread, exitStatus, "thread returned");
 
 	hleReSchedule("thread returned");

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -399,8 +399,9 @@ public:
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Thread; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Thread; }
 
-	bool AllocateStack(u32 &stackSize)
-	{
+	bool AllocateStack(u32 &stackSize) {
+		_assert_msg_(SCEKERNEL, stackSize >= 0x200, "thread stack should be 256 bytes or larger");
+
 		FreeStack();
 
 		bool fromTop = (nt.attr & PSP_THREAD_ATTR_LOW_STACK) == 0;
@@ -1181,6 +1182,14 @@ const char *__KernelGetThreadName(SceUID threadID)
 	if (t)
 		return t->nt.name;
 	return "ERROR";
+}
+
+bool KernelIsThreadDormant(SceUID threadID) {
+	u32 error;
+	Thread *t = kernelObjects.Get<Thread>(threadID, error);
+	if (t)
+		return (t->nt.status & (THREADSTATUS_DEAD | THREADSTATUS_DORMANT)) != 0;
+	return 0;
 }
 
 u32 __KernelGetWaitValue(SceUID threadID, u32 &error)
@@ -2350,6 +2359,13 @@ int sceKernelTerminateThread(SceUID threadID) {
 SceUID __KernelGetCurThread()
 {
 	return currentThread;
+}
+
+int KernelCurThreadPriority() {
+	Thread *t = __GetCurrentThread();
+	if (t)
+		return t->nt.currentPriority;
+	return 0;
 }
 
 SceUID __KernelGetCurThreadModuleId()

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -161,9 +161,11 @@ KernelObject *__KernelCallbackObject();
 
 void __KernelScheduleWakeup(int threadnumber, s64 usFromNow);
 SceUID __KernelGetCurThread();
+int KernelCurThreadPriority();
 u32 __KernelGetCurThreadStack();
 u32 __KernelGetCurThreadStackStart();
 const char *__KernelGetThreadName(SceUID threadID);
+bool KernelIsThreadDormant(SceUID threadID);
 
 void __KernelSaveContext(ThreadContext *ctx, bool vfpuEnabled);
 void __KernelLoadContext(ThreadContext *ctx, bool vfpuEnabled);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -220,7 +220,7 @@ public:
 
 	void ScheduleFinish(u32 handle) {
 		if (!finishThread) {
-			finishThread = new HLEHelperThread("scePsmfPlayer", "scePsmfPlayer", "__PsmfPlayerFinish", playbackThreadPriority, 0x100);
+			finishThread = new HLEHelperThread("scePsmfPlayer", "scePsmfPlayer", "__PsmfPlayerFinish", playbackThreadPriority, 0x200);
 			finishThread->Start(handle, 0);
 		}
 	}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -543,15 +543,23 @@ void PsmfPlayer::DoState(PointerWrap &p) {
 	}
 	p.Do(psmfPlayerAvcAu);
 	if (s >= 7) {
-		bool hasFinishThread = finishThread != NULL;
+		bool hasFinishThread = finishThread != nullptr;
 		p.Do(hasFinishThread);
 		if (hasFinishThread) {
 			p.Do(finishThread);
+		} else {
+			if (finishThread)
+				finishThread->Forget();
+			delete finishThread;
+			finishThread = nullptr;
 		}
 	} else if (s >= 6) {
 		p.Do(finishThread);
 	} else {
-		finishThread = NULL;
+		if (finishThread)
+			finishThread->Forget();
+		delete finishThread;
+		finishThread = nullptr;
 	}
 
 	if (s >= 8) {


### PR DESCRIPTION
This properly respects the IO async priority setting, and may make IO timing more accurate (especially in areas where it might've been significantly delayed on real firmware.)

This doesn't impact actual timing calculations for finishing IO, which probably still need adjustment (especially the "realistic" or "simulate UMD delays" path.)  But I don't think we should go far down that road until we have the mechanics of the timing in place.

-[Unknown]