### PR TITLE
Vulkan GPU profiler: Measure the CPU time spent on the render thread recording command buffers.

### DIFF
--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -173,6 +173,14 @@ struct TransitionRequest {
 	VkImageLayout targetLayout;
 };
 
+struct QueueProfileContext {
+	VkQueryPool queryPool;
+	std::vector<std::string> timestampDescriptions;
+	std::string profileSummary;
+	double cpuStartTime;
+	double cpuEndTime;
+};
+
 struct VKRStep {
 	VKRStep(VKRStepType _type) : stepType(_type) {}
 	~VKRStep() {}
@@ -232,7 +240,7 @@ public:
 	}
 
 	// RunSteps can modify steps but will leave it in a valid state.
-	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, VkQueryPool queryPool, std::vector<std::string> *timestampDescriptions);
+	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
 	void LogSteps(const std::vector<VKRStep *> &steps);
 
 	std::string StepToString(const VKRStep &step) const;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -258,7 +258,7 @@ public:
 	}
 
 	std::string GetGpuProfileString() const {
-		return frameData_[vulkan_->GetCurFrame()].profileSummary;
+		return frameData_[vulkan_->GetCurFrame()].profile.profileSummary;
 	}
 
 private:
@@ -305,10 +305,8 @@ private:
 		uint32_t curSwapchainImage = -1;
 
 		// Profiling.
-		VkQueryPool timestampQueryPool_ = VK_NULL_HANDLE;
+		QueueProfileContext profile;
 		bool profilingEnabled_;
-		std::vector<std::string> timestampDescriptions;
-		std::string profileSummary;
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];


### PR DESCRIPTION
As expected, this is generally close to zero on NV, while several milliseconds on mobile (which is why the render thread really helps there).