### PR TITLE
Debugger: reset step counter on game stop

### DIFF
--- a/Core/Debugger/WebSocket/SteppingBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/SteppingBroadcaster.cpp
@@ -56,6 +56,7 @@ void SteppingBroadcaster::Broadcast(net::WebSocketServer *ws) {
 		lastCounter_ = steppingCounter;
 		prevState_ = coreState;
 	} else {
+		lastCounter_ = -1;
 		prevState_ = CORE_POWERDOWN;
 	}
 }


### PR DESCRIPTION
Minor change to the debugger.  This way we ensure that a game reset will retrigger a stepping notification.

-[Unknown]