### PR TITLE
A first round of crash fixes from 1.9 crash reports

### DIFF
--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -692,41 +692,66 @@ static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
 
 static u32 sysclib_strcat(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcat(dest=%08x, src=%08x)", dst, src);
-	strcat((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
+		strcat((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	}
 	return dst;
 }
 
 static int sysclib_strcmp(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcmp(dest=%08x, src=%08x)", dst, src);
-	return strcmp((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
+		return strcmp((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	} else {
+		// What to do? Crash, probably.
+		return 0;
+	}
 }
 
 static u32 sysclib_strcpy(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcpy(dest=%08x, src=%08x)", dst, src);
-	strcpy((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
+		strcpy((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+	}
 	return dst;
 }
 
 static u32 sysclib_strlen(u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strlen(src=%08x)", src);
-	return (u32)strlen(Memory::GetCharPointer(src));
+	if (Memory::IsValidAddress(src)) {
+		return (u32)strlen(Memory::GetCharPointer(src));
+	} else {
+		// What to do? Crash, probably.
+		return 0;
+	}
 }
 
 static int sysclib_memcmp(u32 dst, u32 src, u32 size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memcmp(dest=%08x, src=%08x, size=%i)", dst, src, size);
-	return memcmp(Memory::GetCharPointer(dst), Memory::GetCharPointer(src), size);
+	if (Memory::IsValidRange(dst, size) && Memory::IsValidRange(src, size)) {
+		return memcmp(Memory::GetCharPointer(dst), Memory::GetCharPointer(src), size);
+	} else {
+		// What to do? Crash, probably.
+		return 0;
+	}
 }
 
 static int sysclib_sprintf(u32 dst, u32 fmt) {
 	ERROR_LOG(SCEKERNEL, "Unimpl sysclib_sprintf(dest=%08x, src=%08x)", dst, fmt);
-	// TODO
-	return sprintf((char *)Memory::GetPointer(dst), "%s", Memory::GetCharPointer(fmt));
+	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(fmt)) {
+		// TODO: Properly use the format string with more parameters.
+		return sprintf((char *)Memory::GetPointer(dst), "%s", Memory::GetCharPointer(fmt));
+	} else {
+		// What to do? Crash, probably.
+		return 0;
+	}
 }
 
 static u32 sysclib_memset(u32 destAddr, int data, int size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memset(dest=%08x, data=%d ,size=%d)", destAddr, data, size);
-	if (Memory::IsValidAddress(destAddr))
+	if (Memory::IsValidRange(destAddr, size)) {
 		memset(Memory::GetPointer(destAddr), data, size);
+	}
 	return 0;
 }
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -630,9 +630,9 @@ namespace SaveState
 		// Okay, first, let's give the rewind state a shot - maybe we can at least not reset entirely.
 		// Even if this was a rewind, maybe we can still load a previous one.
 		CChunkFileReader::Error result;
-		do
+		do {
 			result = rewindStates.Restore();
-		while (result == CChunkFileReader::ERROR_BROKEN_STATE);
+		} while (result == CChunkFileReader::ERROR_BROKEN_STATE);
 
 		if (result == CChunkFileReader::ERROR_NONE) {
 			return true;

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -431,6 +431,11 @@ bool GameManager::ExtractFile(struct zip *z, int file_index, std::string outFile
 	}
 
 	zip_file *zf = zip_fopen_index(z, file_index, 0);
+	if (!zf) {
+		ERROR_LOG(HLE, "Failed to open file by index (%d) (%s)", file_index, outFilename.c_str());
+		return false;
+	}
+
 	FILE *f = File::OpenCFile(outFilename, "wb");
 	if (f) {
 		size_t pos = 0;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1219,7 +1219,6 @@ void TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETextureForm
 		case GE_CMODE_16BIT_ABGR5551:
 		case GE_CMODE_16BIT_ABGR4444:
 		{
-			const u16 *clut = GetCurrentClut<u16>() + clutSharingOffset;
 			if (clutAlphaLinear_ && mipmapShareClut && !expandTo32bit) {
 				// Here, reverseColors means the CLUT is already reversed.
 				if (reverseColors) {
@@ -1232,6 +1231,7 @@ void TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETextureForm
 					}
 				}
 			} else {
+				const u16 *clut = GetCurrentClut<u16>() + clutSharingOffset;
 				if (expandTo32bit && !reverseColors) {
 					// We simply expand the CLUT to 32-bit, then we deindex as usual. Probably the fastest way.
 					ConvertFormatToRGBA8888(clutformat, expandClut_, clut, 16);

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -288,6 +288,7 @@ int PlayBackgroundAudio() {
 		if (!g_gameInfoCache)
 			return 0;  // race condition?
 
+		// This is very unsafe! TODO: Get rid of this somehow or make threadsafe!
 		std::shared_ptr<GameInfo> gameInfo = g_gameInfoCache->GetInfo(NULL, bgGamePath, GAMEINFO_WANTSND);
 		if (!gameInfo)
 			return 0;

--- a/UI/BackgroundAudio.h
+++ b/UI/BackgroundAudio.h
@@ -4,3 +4,4 @@
 
 void SetBackgroundAudioGame(const std::string &path);
 int PlayBackgroundAudio();
+void UpdateBackgroundAudio();

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -734,6 +734,7 @@ void GameInfoCache::WaitUntilDone(std::shared_ptr<GameInfo> &info) {
 
 
 // Runs on the main thread. Only call from render() and similar, not update()!
+// Can also be called from the audio thread for menu background music.
 std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const std::string &gamePath, int wantFlags) {
 	std::shared_ptr<GameInfo> info;
 

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -61,12 +61,6 @@ class FileLoader;
 enum class IdentifiedFileType;
 
 struct GameInfoTex {
-	GameInfoTex() {}
-	~GameInfoTex() {
-		if (texture) {
-			ELOG("LEAKED GameInfoTex");
-		}
-	}
 	std::string data;
 	std::unique_ptr<ManagedTexture> texture;
 	// The time at which the Icon and the BG were loaded.
@@ -81,8 +75,6 @@ struct GameInfoTex {
 		}
 		texture.reset(nullptr);
 	}
-private:
-	DISALLOW_COPY_AND_ASSIGN(GameInfoTex);
 };
 
 class GameInfo {

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -110,12 +110,15 @@ void InstallZipScreen::update() {
 
 	using namespace UI;
 	if (g_GameManager.GetState() != GameManagerState::IDLE) {
-		progressBar_->SetVisibility(V_VISIBLE);
-		progressBar_->SetProgress(g_GameManager.GetCurrentInstallProgressPercentage());
+		if (progressBar_) {
+			progressBar_->SetVisibility(V_VISIBLE);
+			progressBar_->SetProgress(g_GameManager.GetCurrentInstallProgressPercentage());
+		}
 		backChoice_->SetEnabled(false);
 	} else {
-		if (progressBar_)
+		if (progressBar_) {
 			progressBar_->SetVisibility(V_GONE);
+		}
 		backChoice_->SetEnabled(true);
 		std::string err = g_GameManager.GetInstallError();
 		if (!err.empty()) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -780,6 +780,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	using namespace Draw;
 	Core_SetGraphicsContext(graphicsContext);
 	g_draw = graphicsContext->GetDrawContext();
+	_assert_msg_(G3D, g_draw->GetVshaderPreset(VS_COLOR_2D) != nullptr, "Failed to compile presets");
 	_assert_msg_(G3D, g_draw, "No draw context available!");
 
 	ui_draw2d.SetAtlas(&ui_atlas);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -959,6 +959,12 @@ void RenderOverlays(UIContext *dc, void *userdata) {
 void NativeRender(GraphicsContext *graphicsContext) {
 	g_GameManager.Update();
 
+	if (GetUIState() != UISTATE_INGAME) {
+		// Note: We do this from NativeRender so that the graphics context is
+		// guaranteed valid, to be safe - g_gameInfoCache messes around with textures.
+		UpdateBackgroundAudio();
+	}
+
 	float xres = dp_xres;
 	float yres = dp_yres;
 


### PR DESCRIPTION
Fixes bugs from #12358 and some others. Fixes #12365 .

Most of these were probably missed in the 1.8 round due to the problems the SDK/Google Play had with stack traces from app bundles. So not sure how critical these really are, but I think I'll do a 1.9.3.