### PR TITLE
Core: Fix memory range guard check

### DIFF
--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -306,16 +306,13 @@ inline bool IsValidAddress(const u32 address) {
 inline u32 ValidSize(const u32 address, const u32 requested_size) {
 	u32 max_size;
 	if ((address & 0x3E000000) == 0x08000000) {
-		max_size = 0x08000000 + g_MemorySize - address;
-	}
-	else if ((address & 0x3F800000) == 0x04000000) {
-		max_size = 0x04800000 - address;
-	}
-	else if ((address & 0xBFFF0000) == 0x00010000) {
-		max_size = 0x00014000 - address;
-	}
-	else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
-		max_size = 0x08000000 + g_MemorySize - address;
+		max_size = 0x08000000 + g_MemorySize - (address & 0x3E000000);
+	} else if ((address & 0x3F800000) == 0x04000000) {
+		max_size = 0x04800000 - (address & 0x3F800000);
+	} else if ((address & 0xBFFF0000) == 0x00010000) {
+		max_size = 0x00014000 - (address & 0xBFFF0000);
+	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
+		max_size = 0x08000000 + g_MemorySize - (address & 0x3F000000);
 	} else {
 		max_size = 0;
 	}

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1409,7 +1409,7 @@ VirtualFramebuffer *FramebufferManagerCommon::CreateRAMFramebuffer(uint32_t fbAd
 	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, (Draw::FBColorDepth)vfb->colorDepth });
 	vfbs_.push_back(vfb);
 
-	size_t byteSize = ColorBufferByteSize(vfb);
+	u32 byteSize = ColorBufferByteSize(vfb);
 	if (fbAddress + byteSize > framebufRangeEnd_) {
 		framebufRangeEnd_ = fbAddress + byteSize;
 	}


### PR DESCRIPTION
Yeah, this needs a check.  Was allowing sizes with the high bits set, which could cause all kinds of weird issues and crashes.

Figured it's an important enough function that it really needs a test.

-[Unknown]