### PR TITLE
Avoid thread.detach(), join when needed instead

### DIFF
--- a/Core/FileLoaders/CachingFileLoader.h
+++ b/Core/FileLoaders/CachingFileLoader.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <mutex>
+#include <thread>
 
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
@@ -75,6 +76,7 @@ private:
 
 	std::map<s64, BlockInfo> blocks_;
 	std::recursive_mutex blocksMutex_;
-	bool aheadThread_ = false;
+	bool aheadThreadRunning_ = false;
+	std::thread aheadThread_;
 	std::once_flag preparedFlag_;
 };

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -105,9 +105,11 @@ void RamCachingFileLoader::ShutdownCache() {
 
 	// We can't delete while the thread is running, so have to wait.
 	// This should only happen from the menu.
-	while (aheadThread_) {
+	while (aheadThreadRunning_) {
 		sleep_ms(1);
 	}
+	if (aheadThread_.joinable())
+		aheadThread_.join();
 
 	std::lock_guard<std::mutex> guard(blocksMutex_);
 	blocks_.clear();
@@ -118,7 +120,7 @@ void RamCachingFileLoader::ShutdownCache() {
 }
 
 void RamCachingFileLoader::Cancel() {
-	if (aheadThread_) {
+	if (aheadThreadRunning_) {
 		std::lock_guard<std::mutex> guard(blocksMutex_);
 		aheadCancel_ = true;
 	}
@@ -213,14 +215,16 @@ void RamCachingFileLoader::StartReadAhead(s64 pos) {
 
 	std::lock_guard<std::mutex> guard(blocksMutex_);
 	aheadPos_ = pos;
-	if (aheadThread_) {
+	if (aheadThreadRunning_) {
 		// Already going.
 		return;
 	}
 
-	aheadThread_ = true;
+	aheadThreadRunning_ = true;
 	aheadCancel_ = false;
-	std::thread th([this] {
+	if (aheadThread_.joinable())
+		aheadThread_.join();
+	aheadThread_ = std::thread([this] {
 		setCurrentThreadName("FileLoaderReadAhead");
 
 		while (aheadRemaining_ != 0 && !aheadCancel_) {
@@ -243,9 +247,8 @@ void RamCachingFileLoader::StartReadAhead(s64 pos) {
 			}
 		}
 
-		aheadThread_ = false;
+		aheadThreadRunning_ = false;
 	});
-	th.detach();
 }
 
 u32 RamCachingFileLoader::NextAheadBlock() {

--- a/Core/FileLoaders/RamCachingFileLoader.h
+++ b/Core/FileLoaders/RamCachingFileLoader.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <mutex>
+#include <thread>
 
 #include "Common/CommonTypes.h"
 #include "Core/Loaders.h"
@@ -65,6 +66,7 @@ private:
 	std::mutex blocksMutex_;
 	u32 aheadRemaining_;
 	s64 aheadPos_;
-	bool aheadThread_ = false;
+	std::thread aheadThread_;
+	bool aheadThreadRunning_ = false;
 	bool aheadCancel_ = false;
 };

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -601,7 +601,6 @@ void __IoInit() {
 	if (ioManagerThreadEnabled) {
 		Core_ListenLifecycle(&__IoWakeManager);
 		ioManagerThread = new std::thread(&__IoManagerThread);
-		ioManagerThread->detach();
 	}
 
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_ASYNCIO, __IoAsyncBeginCallback, __IoAsyncEndCallback);
@@ -651,9 +650,10 @@ void __IoShutdown() {
 	ioManagerThreadEnabled = false;
 	ioManager.SyncThread();
 	ioManager.FinishEventLoop();
-	if (ioManagerThread != NULL) {
+	if (ioManagerThread != nullptr) {
+		ioManagerThread->join();
 		delete ioManagerThread;
-		ioManagerThread = NULL;
+		ioManagerThread = nullptr;
 		ioManager.Shutdown();
 	}
 

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -26,3 +26,4 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string);
 void InitMemoryForGameISO(FileLoader *fileLoader);
 void InitMemoryForGamePBP(FileLoader *fileLoader);
+void PSPLoaders_Shutdown();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <deque>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -70,6 +71,13 @@ namespace Reporting
 	// The latest compatibility result from the server.
 	static std::vector<std::string> lastCompatResult;
 
+	static std::mutex pendingMessageLock;
+	static std::condition_variable pendingMessageCond;
+	static std::deque<int> pendingMessages;
+	static bool pendingMessagesDone = false;
+	static std::thread messageThread;
+	static std::thread compatThread;
+
 	enum class RequestType
 	{
 		NONE,
@@ -93,6 +101,7 @@ namespace Reporting
 	static std::condition_variable crcCond;
 	static std::string crcFilename;
 	static std::map<std::string, u32> crcResults;
+	static std::thread crcThread;
 
 	static int CalculateCRCThread() {
 		setCurrentThreadName("ReportCRC");
@@ -133,8 +142,7 @@ namespace Reporting
 		}
 
 		crcFilename = gamePath;
-		std::thread th(CalculateCRCThread);
-		th.detach();
+		crcThread = std::thread(CalculateCRCThread);
 	}
 
 	u32 RetrieveCRC() {
@@ -148,6 +156,8 @@ namespace Reporting
 			it = crcResults.find(gamePath);
 		}
 
+		if (crcThread.joinable())
+			crcThread.join();
 		return it->second;
 	}
 
@@ -295,10 +305,20 @@ namespace Reporting
 		logOnceUsed.clear();
 		everUnsupported = false;
 		currentSupported = IsSupported();
+		pendingMessagesDone = false;
 	}
 
 	void Shutdown()
 	{
+		pendingMessageLock.lock();
+		pendingMessagesDone = true;
+		pendingMessageCond.notify_one();
+		pendingMessageLock.unlock();
+		if (compatThread.joinable())
+			compatThread.join();
+		if (messageThread.joinable())
+			messageThread.join();
+
 		// Just so it can be enabled in the menu again.
 		Init();
 	}
@@ -541,6 +561,28 @@ namespace Reporting
 		return -1;
 	}
 
+	int ProcessPending() {
+		setCurrentThreadName("Report");
+
+		std::unique_lock<std::mutex> guard(pendingMessageLock);
+		while (!pendingMessagesDone) {
+			while (!pendingMessages.empty() && !pendingMessagesDone) {
+				int pos = pendingMessages.front();
+				pendingMessages.pop_front();
+
+				guard.unlock();
+				Process(pos);
+				guard.lock();
+			}
+			if (pendingMessagesDone) {
+				break;
+			}
+			pendingMessageCond.wait(guard);
+		}
+
+		return 0;
+	}
+
 	void ReportMessage(const char *message, ...)
 	{
 		if (!IsEnabled() || CheckSpamLimited())
@@ -563,8 +605,13 @@ namespace Reporting
 		payload.string1 = message;
 		payload.string2 = temp;
 
-		std::thread th(Process, pos);
-		th.detach();
+		std::lock_guard<std::mutex> guard(pendingMessageLock);
+		pendingMessages.push_back(pos);
+		pendingMessageCond.notify_one();
+
+		if (!messageThread.joinable()) {
+			messageThread = std::thread(ProcessPending);
+		}
 	}
 
 	void ReportMessageFormatted(const char *message, const char *formatted)
@@ -580,8 +627,13 @@ namespace Reporting
 		payload.string1 = message;
 		payload.string2 = formatted;
 
-		std::thread th(Process, pos);
-		th.detach();
+		std::lock_guard<std::mutex> guard(pendingMessageLock);
+		pendingMessages.push_back(pos);
+		pendingMessageCond.notify_one();
+
+		if (!messageThread.joinable()) {
+			messageThread = std::thread(ProcessPending);
+		}
 	}
 
 	void ReportCompatibility(const char *compat, int graphics, int speed, int gameplay, const std::string &screenshotFilename)
@@ -600,8 +652,9 @@ namespace Reporting
 		payload.int2 = speed;
 		payload.int3 = gameplay;
 
-		std::thread th(Process, pos);
-		th.detach();
+		if (compatThread.joinable())
+			compatThread.join();
+		compatThread = std::thread(Process, pos);
 	}
 
 	std::vector<std::string> CompatibilitySuggestions() {

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -269,6 +269,7 @@ PSP_LoadingLock::~PSP_LoadingLock() {
 void CPU_Shutdown() {
 	// Since we load on a background thread, wait for startup to complete.
 	PSP_LoadingLock lock;
+	PSPLoaders_Shutdown();
 
 	if (g_Config.bAutoSaveSymbolMap) {
 		host->SaveSymbolMap();

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -86,8 +86,9 @@ private:
 	std::string GetISOGameID(FileLoader *loader) const;
 	std::shared_ptr<http::Download> curDownload_;
 	std::shared_ptr<std::thread> installThread_;
-	bool installInProgress_;
-	float installProgress_;
+	bool installInProgress_ = false;
+	bool installDonePending_ = false;
+	float installProgress_ = 0.0f;
 	std::string installError_;
 };
 

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -288,7 +288,6 @@ bool StartWebServer(WebServerFlags flags) {
 		serverStatus = ServerStatus::STARTING;
 		serverFlags = (int)flags;
 		serverThread = std::thread(&ExecuteWebServer);
-		serverThread.detach();
 		return true;
 
 	default:
@@ -320,4 +319,10 @@ bool WebServerStopped(WebServerFlags flags) {
 		return (serverFlags & (int)flags) == 0;
 	}
 	return serverStatus == ServerStatus::STOPPED;
+}
+
+void ShutdownWebServer() {
+	StopWebServer(WebServerFlags::ALL);
+	if (serverThread.joinable())
+		serverThread.join();
 }

--- a/Core/WebServer.h
+++ b/Core/WebServer.h
@@ -26,5 +26,6 @@ bool StartWebServer(WebServerFlags flags);
 bool StopWebServer(WebServerFlags flags);
 bool WebServerStopping(WebServerFlags flags);
 bool WebServerStopped(WebServerFlags flags);
+void ShutdownWebServer();
 
 bool RemoteISOFileSupported(const std::string &filename);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -869,10 +869,11 @@ void NativeShutdownGraphics() {
 	winAudioBackend = nullptr;
 #endif
 
+	ShutdownWebServer();
+	UIBackgroundShutdown();
+
 	delete g_gameInfoCache;
 	g_gameInfoCache = nullptr;
-
-	UIBackgroundShutdown();
 
 	delete uiContext;
 	uiContext = nullptr;

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -327,7 +327,6 @@ RemoteISOConnectScreen::RemoteISOConnectScreen() : status_(ScanStatus::SCANNING)
 	scanThread_ = new std::thread([](RemoteISOConnectScreen *thiz) {
 		thiz->ExecuteScan();
 	}, this);
-	scanThread_->detach();
 }
 
 RemoteISOConnectScreen::~RemoteISOConnectScreen() {
@@ -341,6 +340,8 @@ RemoteISOConnectScreen::~RemoteISOConnectScreen() {
 			break;
 		}
 	}
+	if (scanThread_->joinable())
+		scanThread_->join();
 	delete scanThread_;
 }
 
@@ -384,11 +385,12 @@ void RemoteISOConnectScreen::update() {
 		status_ = ScanStatus::LOADING;
 
 		// Let's reuse scanThread_.
+		if (scanThread_->joinable())
+			scanThread_->join();
 		delete scanThread_;
 		scanThread_ = new std::thread([](RemoteISOConnectScreen *thiz) {
 			thiz->ExecuteLoad();
 		}, this);
-		scanThread_->detach();
 		break;
 
 	case ScanStatus::FAILED:
@@ -401,11 +403,12 @@ void RemoteISOConnectScreen::update() {
 			status_ = ScanStatus::SCANNING;
 			nextRetry_ = 0.0;
 
+			if (scanThread_->joinable())
+				scanThread_->join();
 			delete scanThread_;
 			scanThread_ = new std::thread([](RemoteISOConnectScreen *thiz) {
 				thiz->ExecuteScan();
 			}, this);
-			scanThread_->detach();
 		}
 		break;
 

--- a/ext/native/net/http_client.cpp
+++ b/ext/native/net/http_client.cpp
@@ -428,16 +428,16 @@ int Client::ReadResponseEntity(Buffer *readbuf, const std::vector<std::string> &
 }
 
 Download::Download(const std::string &url, const std::string &outfile)
-	: progress_(0.0f), url_(url), outfile_(outfile), resultCode_(0), completed_(false), failed_(false), cancelled_(false), hidden_(false) {
+	: url_(url), outfile_(outfile) {
 }
 
 Download::~Download() {
-
+	if (thread_.joinable())
+		thread_.join();
 }
 
 void Download::Start(std::shared_ptr<Download> self) {
-	std::thread th(std::bind(&Download::Do, this, self));
-	th.detach();
+	thread_ = std::thread(std::bind(&Download::Do, this, self));
 }
 
 void Download::SetFailed(int code) {
@@ -577,6 +577,7 @@ void Downloader::CancelAll() {
 	for (size_t i = 0; i < downloads_.size(); i++) {
 		downloads_[i]->Cancel();
 	}
+	downloads_.clear();
 }
 
 }	// http

--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -142,16 +142,17 @@ private:
 	int PerformGET(const std::string &url);
 	std::string RedirectLocation(const std::string &baseUrl);
 	void SetFailed(int code);
-	float progress_;
+	float progress_ = 0.0f;
 	Buffer buffer_;
 	std::vector<std::string> responseHeaders_;
 	std::string url_;
 	std::string outfile_;
-	int resultCode_;
-	bool completed_;
-	bool failed_;
-	bool cancelled_;
-	bool hidden_;
+	std::thread thread_;
+	int resultCode_ = 0;
+	bool completed_ = false;
+	bool failed_ = false;
+	bool cancelled_ = false;
+	bool hidden_ = false;
 	std::function<void(Download &)> callback_;
 };
 


### PR DESCRIPTION
This should help #12323, because the Switch doesn't currently have a thread implementation that supports `detach()`.  So this largely avoids it (though maybe I missed some.)  FYI @m4xw.

There are a few changes in behavior here:

1. Some things will join on game exit now, which could cause a delay in exit that wasn't there before.
2. Reporting now serializes messages, rather than a new thread for each report.  This will probably reduce perf impact, but also report more slowly.  It tries to abort on game exit.

Tried to test each of the parts I changed, but there's probably some risk I missed a join and it might std::system_error.

-[Unknown]