### PR TITLE
GPU: Generate normals for curves with lighting

### DIFF
--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -73,10 +73,6 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform)
 
 	bool doBezier = gstate_c.bezier;
 	bool doSpline = gstate_c.spline;
-	// These are the original vertType's values (normalized will always have colors, etc.)
-	bool hasColorTess = (gstate.vertType & GE_VTYPE_COL_MASK) != 0 && (doBezier || doSpline);
-	bool hasTexcoordTess = (gstate.vertType & GE_VTYPE_TC_MASK) != 0 && (doBezier || doSpline);
-	bool hasNormalTess = (gstate.vertType & GE_VTYPE_NRM_MASK) != 0 && (doBezier || doSpline);
 
 	bool enableFog = gstate.isFogEnabled() && !isModeThrough && !gstate.isModeClear();
 	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !isModeThrough;
@@ -138,9 +134,12 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform)
 		if (g_Config.bHardwareTessellation) {
 			id.SetBit(VS_BIT_BEZIER, doBezier);
 			id.SetBit(VS_BIT_SPLINE, doSpline);
-			id.SetBit(VS_BIT_HAS_COLOR_TESS, hasColorTess);
-			id.SetBit(VS_BIT_HAS_TEXCOORD_TESS, hasTexcoordTess);
-			id.SetBit(VS_BIT_HAS_NORMAL_TESS, hasNormalTess);
+			if (doBezier || doSpline) {
+				// These are the original vertType's values (normalized will always have colors, etc.)
+				id.SetBit(VS_BIT_HAS_COLOR_TESS, (gstate.vertType & GE_VTYPE_COL_MASK) != 0);
+				id.SetBit(VS_BIT_HAS_TEXCOORD_TESS, (gstate.vertType & GE_VTYPE_TC_MASK) != 0);
+				id.SetBit(VS_BIT_HAS_NORMAL_TESS, (gstate.vertType & GE_VTYPE_NRM_MASK) != 0 || gstate.isLightingEnabled());
+			}
 			id.SetBit(VS_BIT_NORM_REVERSE_TESS, gstate.isPatchNormalsReversed());
 		}
 	}

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -403,6 +403,7 @@ public:
 								vert.nrm *= -1.0f;
 						} else {
 							vert.nrm.SetZero();
+							vert.nrm.z = 1.0f;
 						}
 					}
 				}
@@ -417,7 +418,7 @@ public:
 
 	static void Tessellate(OutputBuffers &output, const Surface &surface, const ControlPoints &points, const Weight2D &weights, u32 origVertType) {
 		const bool params[] = {
-			(origVertType & GE_VTYPE_NRM_MASK) != 0,
+			(origVertType & GE_VTYPE_NRM_MASK) != 0 || gstate.isLightingEnabled(),
 			(origVertType & GE_VTYPE_COL_MASK) != 0,
 			(origVertType & GE_VTYPE_TC_MASK) != 0,
 			cpu_info.bSSE4_1,


### PR DESCRIPTION
Improves #12354.  This needs to happen even if the vertex has no normals.

Accidentally broken in #11560, since that stopped generating in the lighting case.  I actually wonder if we should just always generate, in case of texgen?

This is probably pretty low risk, if we want to slip it into 1.9.x, then again it can probably wait.

-[Unknown]