### PR TITLE
UI: Stop caching the draw context in coreParam

### DIFF
--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -54,7 +54,6 @@ struct CoreParameter {
 	GPUCore gpuCore;
 
 	GraphicsContext *graphicsContext = nullptr;  // TODO: Find a better place.
-	Draw::DrawContext *thin3d = nullptr;
 	bool enableSound;  // there aren't multiple sound cores.
 
 	std::string fileToStart;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -35,13 +35,12 @@
 #include "thread/threadutil.h"
 #include "util/text/utf8.h"
 
+#include "Common/GraphicsContext.h"
 #include "Core/MemMap.h"
 #include "Core/HDRemaster.h"
-
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
-
-#include "Debugger/SymbolMap.h"
+#include "Core/Debugger/SymbolMap.h"
 #include "Core/Host.h"
 #include "Core/System.h"
 #include "Core/HLE/HLE.h"
@@ -371,7 +370,8 @@ bool PSP_InitUpdate(std::string *error_string) {
 	*error_string = coreParameter.errorString;
 	if (success && gpu == nullptr) {
 		PSP_SetLoading("Starting graphics...");
-		success = GPU_Init(coreParameter.graphicsContext, coreParameter.thin3d);
+		Draw::DrawContext *draw = coreParameter.graphicsContext ? coreParameter.graphicsContext->GetDrawContext() : nullptr;
+		success = GPU_Init(coreParameter.graphicsContext, draw);
 		if (!success) {
 			*error_string = "Unable to initialize rendering engine.";
 		}

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -108,6 +108,6 @@ namespace Draw {
 	class DrawContext;
 }
 
-bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *thin3d);
+bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw);
 bool GPU_IsReady();
 void GPU_Shutdown();

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -50,7 +50,7 @@ class SoftwareDrawEngine;
 
 class SoftGPU : public GPUCommon {
 public:
-	SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *_thin3D);
+	SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~SoftGPU();
 
 	void CheckGPUFeatures() override {}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -238,7 +238,6 @@ void EmuScreen::bootGame(const std::string &filename) {
 
 	// Preserve the existing graphics context.
 	coreParam.graphicsContext = PSP_CoreParameter().graphicsContext;
-	coreParam.thin3d = screenManager()->getDrawContext();
 	coreParam.enableSound = g_Config.bEnableSound;
 	coreParam.fileToStart = filename;
 	coreParam.mountIso = "";

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -163,8 +163,8 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	Core_UpdateDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
 
 	PSP_BeginHostFrame();
-	if (coreParameter.thin3d)
-		coreParameter.thin3d->BeginFrame();
+	if (coreParameter.graphicsContext && coreParameter.graphicsContext->GetDrawContext())
+		coreParameter.graphicsContext->GetDrawContext()->BeginFrame();
 
 	coreState = CORE_RUNNING;
 	while (coreState == CORE_RUNNING)
@@ -190,8 +190,8 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	}
 	PSP_EndHostFrame();
 
-	if (coreParameter.thin3d)
-		coreParameter.thin3d->EndFrame();
+	if (coreParameter.graphicsContext && coreParameter.graphicsContext->GetDrawContext())
+		coreParameter.graphicsContext->GetDrawContext()->EndFrame();
 
 	PSP_Shutdown();
 
@@ -335,7 +335,6 @@ int main(int argc, const char* argv[])
 	coreParameter.cpuCore = cpuCore;
 	coreParameter.gpuCore = glWorking ? gpuCore : GPUCORE_NULL;
 	coreParameter.graphicsContext = graphicsContext;
-	coreParameter.thin3d = graphicsContext ? graphicsContext->GetDrawContext() : nullptr;
 	coreParameter.enableSound = false;
 	coreParameter.mountIso = mountIso ? mountIso : "";
 	coreParameter.mountRoot = mountRoot ? mountRoot : "";

--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -43,7 +43,6 @@ void LibretroHWRenderContext::ContextReset() {
 
 	if (!draw_) {
 		CreateDrawContext();
-		PSP_CoreParameter().thin3d = draw_;
 		bool success = draw_->CreatePresets();
 		assert(success);
 	}

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -20,7 +20,6 @@ public:
 
 	void Shutdown() override {
 		DestroyDrawContext();
-		PSP_CoreParameter().thin3d = nullptr;
 	}
 	void SwapInterval(int interval) override {}
 	void Resize() override {}


### PR DESCRIPTION
This is possibly getting outdated in some paths of graphics reinit, and then causing crashes.  Let's just always get it from the graphicsContext.

I think this may help the save state failure crash from #12358.

-[Unknown]