### PR TITLE
SDL: ensure swap interval is set correctly for SDL2 kmsdrm driver

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -443,7 +443,6 @@ int main(int argc, char *argv[]) {
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetSwapInterval(1);
 
 	// Force fullscreen if the resolution is too low to run windowed.
 	if (g_DesktopWidth < 480 * 2 && g_DesktopHeight < 272 * 2) {
@@ -570,6 +569,9 @@ int main(int argc, char *argv[]) {
 		NativeInitGraphics(graphicsContext);
 		NativeResized();
 	}
+
+	// Ensure that the swap interval is set after context creation (needed for kmsdrm)
+	SDL_GL_SetSwapInterval(1);
 
 	SDL_AudioSpec fmt, ret_fmt;
 	memset(&fmt, 0, sizeof(fmt));

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -119,10 +119,12 @@ bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetSwapInterval(1);
 
 	screen_ = CreateHiddenWindow();
 	glContext_ = SDL_GL_CreateContext(screen_);
+
+	// Ensure that the swap interval is set after context creation (needed for kmsdrm)
+	SDL_GL_SetSwapInterval(1);
 
 #ifndef USING_GLES2
 	// Some core profile drivers elide certain extensions from GL_EXTENSIONS/etc.


### PR DESCRIPTION
It appears that SDL2's kmsdrm driver ignores the swap interval setting
if the SDL context has not yet been created. Moving the call to after context
creation allows it to work as expected.

Fixes vsync when running ppsspp in a KMS context using the SDL2 kmsdrm driver
(which is especially useful for Raspberry Pi 4 B, but is also needed for other
systems including Raspberry Pi 3B via firmware KMS & Intel Haswell i965 via
KMS on x64).

---

For RetroPie, we're aiming to run everything in a KMS context for the Pi 4B, given that the new board no longer supports the legacy Broadcom driver. 3B will stay on the legacy driver, but it's my hope to allow users the option to compile all software on the older boards (such as 3B) for firmware kms mode as well. For ppsspp's standalone binary, this is done with the aid of the SDL2 `kmsdrm` video driver.

RPI3/4 full build configuration can be referenced in `fkms_rpi4` development branch: https://github.com/RetroPie/RetroPie-Setup/blob/fkms_rpi4/scriptmodules/emulators/ppsspp.sh#L131
(expands to `-DUSING_GLES2=ON -DUSING_EGL=OFF -DARM_NO_VULKAN=ON`). It's also necessary for SDL2 to be built with `--enable-video-kmsdrm`.

For all tested targets*, ppsspp exhibits tearing combined with extreme slowdown, both of which are resolved by this change. Testing on RPI4, Liberty City Stories intro runs at full speed with dips to 20s on indoor scenes, and goes ingame to ~27fps, with no tearing observed.

*I also reproduced the issue on my laptop's i965 driver (which I needed to compile with `-DUSING_GLES2=ON` in order for ppsspp to launch from a KMS framebuffer).