### PR TITLE
Make use of OnSystemUiVisibilityChangeListener to check whether navbar is hidden

### DIFF
--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -211,7 +211,7 @@ void AndroidVulkanContext::SwapBuffers() {
 }
 
 void AndroidVulkanContext::Resize() {
-	ILOG("AndroidVulkanContext::Resize begin (%d, %d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+	ILOG("AndroidVulkanContext::Resize begin (oldsize: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	g_Vulkan->DestroyObjects();
@@ -220,7 +220,7 @@ void AndroidVulkanContext::Resize() {
 	g_Vulkan->ReinitSurface();
 	g_Vulkan->InitObjects();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
-	ILOG("AndroidVulkanContext::Resize end (%d, %d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+	ILOG("AndroidVulkanContext::Resize end (final size: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 }
 
 void AndroidVulkanContext::SwapInterval(int interval) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -629,6 +629,7 @@ static void recalculateDpi() {
 	pixel_in_dps_x = (float)pixel_xres / dp_xres;
 	pixel_in_dps_y = (float)pixel_yres / dp_yres;
 
+	ILOG("RecalcDPI: display_xres=%d display_yres=%d", display_xres, display_yres);
 	ILOG("RecalcDPI: g_dpi=%f g_dpi_scale_x=%f g_dpi_scale_y=%f", g_dpi, g_dpi_scale_x, g_dpi_scale_y);
 	ILOG("RecalcDPI: dp_xscale=%f dp_yscale=%f", dp_xscale, dp_yscale);
 	ILOG("RecalcDPI: dp_xres=%d dp_yres=%d", dp_xres, dp_yres);
@@ -904,6 +905,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_setDisplayParameters(JN
 	display_hz = refreshRate;
 
 	recalculateDpi();
+	NativeResized();
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_computeDesiredBackbufferDimensions() {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -611,6 +611,30 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 	NativeMessageReceived("recreateviews", "");
 }
 
+static void recalculateDpi() {
+	g_dpi = display_dpi_x;
+	g_dpi_scale_x = 240.0f / display_dpi_x;
+	g_dpi_scale_y = 240.0f / display_dpi_y;
+	g_dpi_scale_real_x = g_dpi_scale_x;
+	g_dpi_scale_real_y = g_dpi_scale_y;
+
+	dp_xres = display_xres * g_dpi_scale_x;
+	dp_yres = display_yres * g_dpi_scale_y;
+
+	// Touch scaling is from display pixels to dp pixels.
+	// Wait, doesn't even make sense... this is equal to g_dpi_scale_x. TODO: Figure out what's going on!
+	dp_xscale = (float)dp_xres / (float)display_xres;
+	dp_yscale = (float)dp_yres / (float)display_yres;
+
+	pixel_in_dps_x = (float)pixel_xres / dp_xres;
+	pixel_in_dps_y = (float)pixel_yres / dp_yres;
+
+	ILOG("RecalcDPI: g_dpi=%f g_dpi_scale_x=%f g_dpi_scale_y=%f", g_dpi, g_dpi_scale_x, g_dpi_scale_y);
+	ILOG("RecalcDPI: dp_xscale=%f dp_yscale=%f", dp_xscale, dp_yscale);
+	ILOG("RecalcDPI: dp_xres=%d dp_yres=%d", dp_xres, dp_yres);
+	ILOG("RecalcDPI: pixel_xres=%d pixel_yres=%d", pixel_xres, pixel_yres);
+}
+
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv *, jclass, jint bufw, jint bufh, jint format) {
 	ILOG("NativeApp.backbufferResize(%d x %d)", bufw, bufh);
 
@@ -622,32 +646,13 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	pixel_yres = bufh;
 	backbuffer_format = format;
 
-	g_dpi = display_dpi_x;
-	g_dpi_scale_x = 240.0f / g_dpi;
-	g_dpi_scale_y = 240.0f / g_dpi;
-	g_dpi_scale_real_x = g_dpi_scale_x;
-	g_dpi_scale_real_y = g_dpi_scale_y;
-
-	dp_xres = display_xres * g_dpi_scale_x;
-	dp_yres = display_yres * g_dpi_scale_y;
-
-	// Touch scaling is from display pixels to dp pixels.
-	dp_xscale = (float)dp_xres / (float)display_xres;
-	dp_yscale = (float)dp_yres / (float)display_yres;
-
-	pixel_in_dps_x = (float)pixel_xres / dp_xres;
-	pixel_in_dps_y = (float)pixel_yres / dp_yres;
-
-	ILOG("g_dpi=%f g_dpi_scale_x=%f g_dpi_scale_y=%f", g_dpi, g_dpi_scale_x, g_dpi_scale_y);
-	ILOG("dp_xscale=%f dp_yscale=%f", dp_xscale, dp_yscale);
-	ILOG("dp_xres=%d dp_yres=%d", dp_xres, dp_yres);
-	ILOG("pixel_xres=%d pixel_yres=%d", pixel_xres, pixel_yres);
+	recalculateDpi();
 
 	if (new_size) {
 		ILOG("Size change detected (previously %d,%d) - calling NativeResized()", old_w, old_h);
 		NativeResized();
 	} else {
-		ILOG("NativeApp::backbufferReisze: Size didn't change.");
+		ILOG("NativeApp::backbufferResize: Size didn't change.");
 	}
 }
 
@@ -897,6 +902,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_setDisplayParameters(JN
 	display_dpi_x = dpi;
 	display_dpi_y = dpi;
 	display_hz = refreshRate;
+
+	recalculateDpi();
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_computeDesiredBackbufferDimensions() {

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -53,8 +53,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Locale;
 
-import static android.view.View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
-
 public abstract class NativeActivity extends Activity implements SurfaceHolder.Callback {
 	// Remember to loadLibrary your JNI .so in a static {} block
 
@@ -414,14 +412,13 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			flags |= View.SYSTEM_UI_FLAG_LOW_PROFILE;
 		}
 		if (useImmersive()) {
-			flags |= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+			flags |= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN;
 		}
 		if (getWindow().getDecorView() != null) {
 			getWindow().getDecorView().setSystemUiVisibility(flags);
 		} else {
-			Log.e(TAG, "updateSystemUiVisibility: decor view not yet created, ignoring");
+			Log.e(TAG, "updateSystemUiVisibility: decor view not yet created, ignoring for now");
 		}
-
 		updateDisplayMeasurements();
 	}
 
@@ -606,6 +603,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		Log.w(TAG, "Surface changed. Resolution: " + width + "x" + height + " Format: " + format);
 		// The window size might have changed (immersive mode, native fullscreen on some devices)
 		NativeApp.backbufferResize(width, height, format);
+		updateDisplayMeasurements();
 		mSurface = holder.getSurface();
 		if (!javaGL) {
 			// If we got a surface, this starts the thread. If not, it doesn't.
@@ -678,7 +676,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 				// whether it's because of our or system actions.
 				// We will try to force it to follow our preference but will not stupidly
 				// act as if it's visible if it's not.
-				navigationHidden = ((visibility & SYSTEM_UI_FLAG_HIDE_NAVIGATION) != 0);
+				navigationHidden = ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) != 0);
 				// TODO: Check here if it's the state we want.
 				Log.i(TAG, "SystemUiVisibilityChange! visibility=" + visibility + " navigationHidden: " + navigationHidden);
 				updateDisplayMeasurements();
@@ -812,7 +810,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			updateSystemUiVisibility();
 		}
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-			densityDpi = (float) newConfig.densityDpi;
+			densityDpi = (float)newConfig.densityDpi;
 		}
 	}
 

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -116,7 +116,6 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 
 	@Override
 	public void onPause() {
-		Log.i(TAG, "onPause");
 		super.onPause();
 		mSensorManager.unregisterListener(this);
 		if (mController != null) {
@@ -131,7 +130,6 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
 		if (mController != null) {
 			mController.onResume();
-
 			// According to the docs, the Moga's state can be inconsistent here.
 			// We should do a one time poll. TODO
 		}

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -3,6 +3,7 @@ package org.ppsspp.ppsspp;
 // Touch- and sensor-enabled SurfaceView.
 // Supports simple multitouch and pressure.
 // DPI scaling is handled by the native code.
+// Used by the Vulkan backend (and EGL, but that path is no longer active)
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -115,6 +116,7 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 	}
 
 	public void onPause() {
+		Log.i(TAG, "onPause");
 		mSensorManager.unregisterListener(this);
 		if (mController != null) {
 			mController.onPause();

--- a/ext/native/ui/screen.cpp
+++ b/ext/native/ui/screen.cpp
@@ -125,6 +125,7 @@ void ScreenManager::deviceRestored() {
 }
 
 void ScreenManager::resized() {
+	ILOG("ScreenManager::resized(dp: %dx%d)", dp_xres, dp_yres);
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	// Have to notify the whole stack, otherwise there will be problems when going back
 	// to non-top screens.


### PR DESCRIPTION
Affects DPI calculations. Mostly fixes #12381 .

Also recalculate all dp parameters after either display or buffer size changed, to avoid an old race condition.

This seems to work very well on my phones, except the oddball I7S and its builtin fullscreen button in the navbar, which still misbehaves - what happens is that it thinks it's still in non-fullscreen and getMetrics doesn't return the navbar-hidden display size. So we need to use another way to get the size it seems for that to work - but maybe the implementation is just broken.