### PR TITLE
Android: Setup UI callback earlier if possible

### DIFF
--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -838,8 +838,10 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 
 	@Override
 	public void onAttachedToWindow() {
+		Log.i(TAG, "onAttachedToWindow");
+		super.onAttachedToWindow();
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-			Log.i(TAG, "onAttachedToWindow");
 			DisplayCutout cutout = getWindow().getDecorView().getRootWindowInsets().getDisplayCutout();
 			if (cutout != null) {
 				safeInsetLeft = cutout.getSafeInsetLeft();
@@ -854,6 +856,10 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 				safeInsetTop = 0;
 				safeInsetBottom = 0;
 			}
+		}
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+			setupSystemUiCallback();
 		}
 	}
 


### PR DESCRIPTION
As noted in #12391.  I thought about clearing the cached view on detach, but then got worried that could result in double notification registrations.

-[Unknown]