### PR TITLE
Vulkan: Always write gl_PointSize, fixes #12364. 

### DIFF
--- a/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/VertexShaderGeneratorVulkan.cpp
@@ -209,7 +209,6 @@ bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer) {
 		WRITE(p, "  return vec4(v.x, v.y, z * v.w, v.w);\n");
 		WRITE(p, "}\n\n");
 	}
-	WRITE(p, "out gl_PerVertex { vec4 gl_Position; };\n");
 
 	if (doBezier || doSpline) {
 		WRITE(p, "struct TessData {\n");
@@ -635,6 +634,7 @@ bool GenerateVulkanGLSLVertexShader(const VShaderID &id, char *buffer) {
 		WRITE(p, "  }\n");
 	}
 	WRITE(p, "  gl_Position = outPos;\n");
+	WRITE(p, "  gl_PointSize = 1.0;\n");
 
 	if (gstate_c.Supports(GPU_NEEDS_Z_EQUAL_W_HACK)) {
 		// See comment in GPU_Vulkan.cpp.


### PR DESCRIPTION
Also remove unnecessary predeclaration of gl_Position.

Replaces #12393.

The predeclaration used to be required by early versions of glslang but is no longer. Since the GLSL compiler is controlled by us, we don't need to fear incompatibilities.