### PR TITLE
Move window to center

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -25,9 +25,9 @@ MainWindow::MainWindow(QWidget *parent, bool fullscreen) :
 	QDesktopWidget *desktop = QApplication::desktop();
 	int screenNum = QProcessEnvironment::systemEnvironment().value("SDL_VIDEO_FULLSCREEN_HEAD", "0").toInt();
 	
-	// Move window to top left coordinate of selected screen
+	// Move window to the center of selected screen
 	QRect rect = desktop->screenGeometry(screenNum);
-	move(rect.topLeft());
+	move((rect.width()-frameGeometry().width()) / 4, (rect.height()-frameGeometry().height()) / 4);
 
 	SetGameTitle("");
 	emugl = new MainUI(this);


### PR DESCRIPTION
When I start PPSSPP, it appears in left upper corner. On Lubuntu, the headbar goes outside the window and becomes unmovable.
![1](https://user-images.githubusercontent.com/14265316/66361537-cd8df480-e987-11e9-98da-9b5beecddb40.png)
With this patch, it appears almost in the center of window and fixes it.
![2](https://user-images.githubusercontent.com/14265316/66361575-f7dfb200-e987-11e9-8368-7421eef7ecb4.png)
