### PR TITLE
WASAPI: Discovered by chance that pwstrDeviceId can be null in OnDefaultDeviceChanged. 

### DIFF
--- a/Windows/WASAPIStream.cpp
+++ b/Windows/WASAPIStream.cpp
@@ -91,7 +91,8 @@ public:
 			return S_OK;
 		}
 
-		if (!wcscmp(currentDevice_, pwstrDeviceId)) {
+		// pwstrDeviceId can be null. We consider that a new device, I think?
+		if (pwstrDeviceId && !wcscmp(currentDevice_, pwstrDeviceId)) {
 			// Already the current device, nothing to do.
 			return S_OK;
 		}


### PR DESCRIPTION
Treating it as a new device.

May help #12081  ?