### PR TITLE
Update iOS JIT hack

### DIFF
--- a/ios/main.mm
+++ b/ios/main.mm
@@ -28,7 +28,7 @@ bool get_debugged() {
 	if (rv==0 && flags&CS_DEBUGGED) return true;
 
 	pid_t pid = fork();
-	if (pid) {
+	if (pid > 0) {
 		int st,rv,i=0;
 		do {
 			usleep(500);

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -15,9 +15,53 @@
 #include "base/NativeApp.h"
 #include "profiler/profiler.h"
 
-#define CS_OPS_STATUS	   0   /* return status */
-#define CS_DEBUGGED		 0x10000000  /* process is currently or has previously been debugged and allowed to run with invalid pages */
+#define CS_OPS_STATUS	0		/* return status */
+#define CS_DEBUGGED	0x10000000	/* process is currently or has previously been debugged and allowed to run with invalid pages */
+#define PT_ATTACHEXC	14		/* attach to running process with signal exception */
+#define PT_DETACH	11		/* stop tracing a process */
 int csops(pid_t pid, unsigned int  ops, void * useraddr, size_t usersize);
+#define ptrace(a, b, c, d) syscall(SYS_ptrace, a, b, c, d)
+
+bool get_debugged() {
+	int flags;
+	int rv = csops(getpid(), CS_OPS_STATUS, &flags, sizeof(flags));
+	if (rv==0 && flags&CS_DEBUGGED) return true;
+
+	pid_t pid = fork();
+	if (pid) {
+		int st,rv,i=0;
+		do {
+			usleep(500);
+			rv = waitpid(pid, &st, 0);
+		} while (rv<0 && i++<10);
+		if (rv<0) fprintf(stderr, "Unable to wait for child?\n");
+	} else if (pid == 0) {
+		pid_t ppid = getppid();
+		int rv = ptrace(PT_ATTACHEXC, ppid, 0, 0);
+		if (rv) {
+			perror("Unable to attach to process");
+			exit(1);
+		}
+		for (int i=0; i<100; i++) {
+			usleep(1000);
+			errno = 0;
+			rv = ptrace(PT_DETACH, ppid, 0, 0);
+			if (rv==0) break;
+		}
+		if (rv) {
+			perror("Unable to detach from process");
+			exit(1);
+		}
+		exit(0);
+	} else {
+		perror("Unable to fork");
+	}
+
+	rv = csops(getpid(), CS_OPS_STATUS, &flags, sizeof(flags));
+	if (rv==0 && flags&CS_DEBUGGED) return true;
+
+	return false;
+}
 
 
 std::string System_GetProperty(SystemProperty prop) {
@@ -118,15 +162,9 @@ void Vibrate(int mode) {
 
 int main(int argc, char *argv[])
 {
-	// see https://github.com/hrydgard/ppsspp/issues/11905#issuecomment-476871010
-	uint32_t flags;
-	csops(getpid(), CS_OPS_STATUS, &flags, 0);
-	if (flags & CS_DEBUGGED){
-		//being run either under a debugger or under Electra already
-	}
-	else{
-		// Simulates a debugger. Makes it possible to use JIT (though only W^X)
-		syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
+	// see https://github.com/hrydgard/ppsspp/issues/11905
+	if (!get_debugged()) {
+		fprintf(stderr, "Unable to obtain CS_DEBUGGED -  I will probably die now.\n");
 	}
 	
 	PROFILE_INIT();


### PR DESCRIPTION
The current hack being used to get read/write/execute memory on iOS leaves the process in a very bad state where it can never exit.  I fixed the hack for another project and somebody pointed out that I should let you guys know about it.  The attached hack will get the same RWX memory state but without leaving the process in a bad state that does not allow it to be killed or exit.