### PR TITLE
Change Bloom Hack aggressive detection to include GOW games bloom.

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1713,7 +1713,7 @@ void FramebufferManagerCommon::SetRenderSize(VirtualFramebuffer *vfb) {
 		force1x = vfb->bufferWidth <= 256 || vfb->bufferHeight <= 128;
 		break;
 	case 3:
-		force1x = vfb->bufferWidth < 480 || vfb->bufferHeight < 272;
+		force1x = vfb->bufferWidth < 480 || vfb->bufferWidth > 800 || vfb->bufferHeight < 272; // GOW uses ‭864‬x272
 		break;
 	}
 


### PR DESCRIPTION
Aggressive was kind of useless with balanced detecting all known cases already, so it should be fine to just dump GOW case into aggressive.

The result is on the ugly side, through some might still preffer that than the double image, maybe in the future effects like that could be additionally filtered somehow to keep them blurry, but without the aliasing or use the detection to remove them and just use post process for similar, but higher quality effects.

 Works in both GOW games as a side effect might improve performance slightly when not using x1 render res, but probably not noticeably.

Effects sampled at high res:
![NPEG00023_00000](https://user-images.githubusercontent.com/5485237/67149002-5c631100-f2a6-11e9-9d1a-3e517446c1d2.jpg)

Effects at x1:
![NPEG00023_00001](https://user-images.githubusercontent.com/5485237/67149003-608f2e80-f2a6-11e9-98bd-a74d53343e4f.jpg)
