### PR TITLE
Io: Return error code for write attempt to UMD

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -129,18 +129,20 @@ void PSPGamedataInstallDialog::OpenNextFile() {
 	std::string outputFileName = GetGameDataInstallFileName(&request, inFileNames[readFiles]);
 
 	currentInputFile = pspFileSystem.OpenFile(inputFileName, FILEACCESS_READ);
-	if (!currentInputFile) {
+	if (currentInputFile < 0) {
 		// TODO: Generate an error code?
 		ERROR_LOG_REPORT(SCEUTILITY, "Unable to read from install file: %s", inFileNames[readFiles].c_str());
 		++readFiles;
+		currentInputFile = 0;
 		return;
 	}
 	currentOutputFile = pspFileSystem.OpenFile(outputFileName, (FileAccess)(FILEACCESS_WRITE | FILEACCESS_CREATE | FILEACCESS_TRUNCATE));
-	if (!currentOutputFile) {
+	if (currentOutputFile < 0) {
 		// TODO: Generate an error code?
 		ERROR_LOG(SCEUTILITY, "Unable to write to install file: %s", inFileNames[readFiles].c_str());
 		pspFileSystem.CloseFile(currentInputFile);
 		currentInputFile = 0;
+		currentOutputFile = 0;
 		++readFiles;
 		return;
 	}
@@ -172,10 +174,12 @@ void PSPGamedataInstallDialog::CopyCurrentFileData() {
 }
 
 void PSPGamedataInstallDialog::CloseCurrentFile() {
-	pspFileSystem.CloseFile(currentOutputFile);
+	if (currentOutputFile >= 0)
+		pspFileSystem.CloseFile(currentOutputFile);
 	currentOutputFile = 0;
 
-	pspFileSystem.CloseFile(currentInputFile);
+	if (currentInputFile >= 0)
+		pspFileSystem.CloseFile(currentInputFile);
 	currentInputFile = 0;
 
 	++readFiles;
@@ -208,7 +212,7 @@ void PSPGamedataInstallDialog::WriteSfoFile() {
 	sfoFile.WriteSFO(&sfoData,&sfoSize);
 
 	u32 handle = pspFileSystem.OpenFile(sfopath, (FileAccess)(FILEACCESS_WRITE | FILEACCESS_CREATE | FILEACCESS_TRUNCATE));
-	if (handle != 0) {
+	if (handle >= 0) {
 		pspFileSystem.WriteFile(handle, sfoData, sfoSize);
 		pspFileSystem.CloseFile(handle);
 	}

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -62,7 +62,7 @@ namespace
 	bool ReadPSPFile(std::string filename, u8 **data, s64 dataSize, s64 *readSize)
 	{
 		u32 handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
-		if (handle == 0)
+		if (handle < 0)
 			return false;
 
 		if(dataSize == -1)
@@ -82,7 +82,7 @@ namespace
 	bool WritePSPFile(std::string filename, u8 *data, SceSize dataSize)
 	{
 		u32 handle = pspFileSystem.OpenFile(filename, (FileAccess)(FILEACCESS_WRITE | FILEACCESS_CREATE | FILEACCESS_TRUNCATE));
-		if (handle == 0)
+		if (handle < 0)
 			return false;
 
 		size_t result = pspFileSystem.WriteFile(handle, data, dataSize);
@@ -209,7 +209,7 @@ void SavedataParam::Init()
 	// Create a nomedia file to hide save icons form Android image viewer
 #ifdef __ANDROID__
 	int handle = pspFileSystem.OpenFile(savePath + ".nomedia", (FileAccess)(FILEACCESS_CREATE | FILEACCESS_WRITE), 0);
-	if (handle) {
+	if (handle >= 0) {
 		pspFileSystem.CloseFile(handle);
 	} else {
 		ELOG("Failed to create .nomedia file");

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -36,7 +36,7 @@ std::vector<PSPFileInfo> BlobFileSystem::GetDirListing(std::string path) {
 	return listing;
 }
 
-u32 BlobFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
+int BlobFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
 	u32 newHandle = alloc_->GetNewHandle();
 	entries_[newHandle] = 0;
 	return newHandle;

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017- PPSSPP Project.
+// Copyright (c) 2017- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ public:
 
 	void DoState(PointerWrap &p) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -607,7 +607,7 @@ bool DirectoryFileSystem::RemoveFile(const std::string &filename) {
 	return ReplayApplyDisk(ReplayAction::FILE_REMOVE, retValue, CoreTiming::GetGlobalTimeUs()) != 0;
 }
 
-u32 DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
+int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
 	OpenFileEntry entry;
 	u32 err = 0;
 	bool success = entry.hFile.Open(basePath, filename, access, err);
@@ -1044,10 +1044,10 @@ bool VFSFileSystem::RemoveFile(const std::string &filename) {
 	return false;
 }
 
-u32 VFSFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
+int VFSFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
 	if (access != FILEACCESS_READ) {
 		ERROR_LOG(FILESYS, "VFSFileSystem only supports plain reading");
-		return 0;
+		return SCE_KERNEL_ERROR_ERRNO_INVALID_FLAG;
 	}
 
 	std::string fullName = GetLocalPath(filename);
@@ -1058,7 +1058,7 @@ u32 VFSFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 	u8 *data = VFSReadFile(fullNameC, &size);
 	if (!data) {
 		ERROR_LOG(FILESYS, "VFSFileSystem failed to open %s", filename.c_str());
-		return 0;
+		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	}
 
 	OpenFileEntry entry;

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -92,7 +92,7 @@ public:
 
 	void DoState(PointerWrap &p) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
@@ -137,7 +137,7 @@ public:
 
 	void DoState(PointerWrap &p) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -67,7 +67,8 @@ public:
 	virtual u32 GetNewHandle() override {
 		u32 res = handle_++;
 		if (handle_ < 0) {
-			handle_ = 0;
+			// Some code assumes it'll never become 0.
+			handle_ = 1;
 		}
 		return res;
 	}
@@ -109,7 +110,7 @@ public:
 
 	virtual void DoState(PointerWrap &p) = 0;
 	virtual std::vector<PSPFileInfo> GetDirListing(std::string path) = 0;
-	virtual u32      OpenFile(std::string filename, FileAccess access, const char *devicename=nullptr) = 0;
+	virtual int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) = 0;
 	virtual void     CloseFile(u32 handle) = 0;
 	virtual size_t   ReadFile(u32 handle, u8 *pointer, s64 size) = 0;
 	virtual size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) = 0;
@@ -135,7 +136,7 @@ class EmptyFileSystem : public IFileSystem
 public:
 	virtual void DoState(PointerWrap &p) override {}
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override {std::vector<PSPFileInfo> vec; return vec;}
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=nullptr) override {return 0;}
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override {return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;}
 	void     CloseFile(u32 handle) override {}
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override {return 0;}
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override {return 0;}

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -335,6 +335,11 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 	entry.isRawSector = false;
 	entry.isBlockSectorMode = false;
 
+	if (access & FILEACCESS_WRITE) {
+		ERROR_LOG(FILESYS, "Can't open file %s with write access on an ISO partition", filename.c_str());
+		return SCE_KERNEL_ERROR_ERRNO_INVALID_FLAG;
+	}
+
 	if (filename.compare(0, 8, "/sce_lbn") == 0) {
 		// Raw sector read.
 		u32 sectorStart = 0xFFFFFFFF, readSize = 0xFFFFFFFF;
@@ -362,11 +367,6 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 
 		entries[newHandle] = entry;
 		return newHandle;
-	}
-
-	if (access & FILEACCESS_WRITE) {
-		ERROR_LOG(FILESYS, "Can't open file %s with write access on an ISO partition", filename.c_str());
-		return 0;
 	}
 
 	// May return entireISO for "umd0:"

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -330,7 +330,7 @@ ISOFileSystem::TreeEntry *ISOFileSystem::GetFromPath(const std::string &path, bo
 	}
 }
 
-u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
+int ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename) {
 	OpenFileEntry entry;
 	entry.isRawSector = false;
 	entry.isBlockSectorMode = false;
@@ -346,7 +346,7 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 		parseLBN(filename, &sectorStart, &readSize);
 		if (sectorStart > blockDevice->GetNumBlocks()) {
 			WARN_LOG(FILESYS, "Unable to open raw sector, out of range: %s, sector %08x, max %08x", filename.c_str(), sectorStart, blockDevice->GetNumBlocks());
-			return 0;
+			return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 		}
 		else if (sectorStart == blockDevice->GetNumBlocks())
 		{
@@ -372,7 +372,7 @@ u32 ISOFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 	// May return entireISO for "umd0:"
 	entry.file = GetFromPath(filename);
 	if (!entry.file){
-		return 0;
+		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	}
 
 	if (entry.file == &entireISO)

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -33,7 +33,7 @@ public:
 
 	void DoState(PointerWrap &p) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename = NULL) override;
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;
@@ -110,7 +110,7 @@ public:
 	}
 
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override { return std::vector<PSPFileInfo>(); }
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename = NULL) override {
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override {
 		return isoFileSystem_->OpenFile("", access, devicename);
 	}
 	void     CloseFile(u32 handle) override {

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -321,7 +321,7 @@ int VirtualDiscFileSystem::getFileListIndex(u32 accessBlock, u32 accessSize, boo
 	return -1;
 }
 
-u32 VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename)
+int VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, const char *devicename)
 {
 	OpenFileEntry entry;
 	entry.curOffset = 0;
@@ -396,7 +396,7 @@ u32 VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, con
 		ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, access = %i", (int)access);
 #endif
 		//wwwwaaaaahh!!
-		return 0;
+		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	} else {
 		u32 newHandle = hAlloc->GetNewHandle();
 		entries[newHandle] = entry;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -30,7 +30,7 @@ public:
 	~VirtualDiscFileSystem();
 
 	void DoState(PointerWrap &p) override;
-	u32      OpenFile(std::string filename, FileAccess access, const char *devicename=NULL) override;
+	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) override;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1425,10 +1425,12 @@ static FileNode *__IoOpen(int &error, const char* filename, int flags, int mode)
 
 	PSPFileInfo info = pspFileSystem.GetFileInfo(filename);
 
-	u32 h = pspFileSystem.OpenWithError(error, filename, (FileAccess) access);
-	if (h == 0) {
-		return NULL;
+	int h = pspFileSystem.OpenFile(filename, (FileAccess)access);
+	if (h < 0) {
+		error = h;
+		return nullptr;
 	}
+	error = 0;
 
 	FileNode *f = new FileNode();
 	SceUID id = kernelObjects.Create(f);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1163,7 +1163,7 @@ static int scePsmfPlayerBreak(u32 psmfPlayer)
 }
 
 static int _PsmfPlayerFillRingbuffer(PsmfPlayer *psmfplayer) {
-	if (!psmfplayer->filehandle)
+	if (psmfplayer->filehandle <= 0)
 		return -1;
 	u8* buf = psmfplayer->tempbuf;
 	int tempbufSize = (int)sizeof(psmfplayer->tempbuf);
@@ -1207,7 +1207,7 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 	int delayUs = 1100;
 
 	psmfplayer->filehandle = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
-	if (!psmfplayer->filehandle) {
+	if (psmfplayer->filehandle < 0) {
 		return hleDelayResult(SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT, "psmfplayer set", delayUs);
 	}
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -221,7 +221,7 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 
 	bool hasEncrypted = false;
 	u32 fd;
-	if ((fd = pspFileSystem.OpenFile(bootpath, FILEACCESS_READ)) != 0)
+	if ((fd = pspFileSystem.OpenFile(bootpath, FILEACCESS_READ)) >= 0)
 	{
 		u8 head[4];
 		pspFileSystem.ReadFile(fd, head, 4);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -413,9 +413,12 @@ std::string GameManager::GetISOGameID(FileLoader *loader) const {
 	ISOFileSystem umd(&handles, bd);
 
 	PSPFileInfo info = umd.GetFileInfo("/PSP_GAME/PARAM.SFO");
-	int handle = 0;
+	int handle = -1;
 	if (info.exists) {
 		handle = umd.OpenFile("/PSP_GAME/PARAM.SFO", FILEACCESS_READ);
+	}
+	if (handle < 0) {
+		return "";
 	}
 
 	std::string sfoData;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -301,7 +301,7 @@ static bool ReadFileToString(IFileSystem *fs, const char *filename, std::string 
 	}
 
 	int handle = fs->OpenFile(filename, FILEACCESS_READ);
-	if (!handle) {
+	if (handle < 0) {
 		return false;
 	}
 


### PR DESCRIPTION
Before, we would return file not found, but that's an incorrect error.  God of War was actually triggering this (in the same area as #12400), and retries the open of the sce_lbn file with the proper access flags when it gets the proper error code.

Also, cleanup the OpenWithError stuff and just return error codes directly.  A bit dangerous, but now's the time to break things.  Overall, this should result in better error code handling.

-[Unknown]