### PR TITLE
Fix the build - there's a Vec3 name collision, fixed it using a namespace.

### DIFF
--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -14,6 +14,8 @@
 #include "Core/Reporting.h"
 #include "Core/Config.h"
 
+using namespace Lin;
+
 static void ConvertProjMatrixToVulkan(Matrix4x4 &in) {
 	const Vec3 trans(0, 0, gstate_c.vpZOffset * 0.5f + 0.5f);
 	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -348,7 +348,7 @@ void FramebufferManagerD3D11::MakePixelTexture(const u8 *srcPixels, GEBufferForm
 
 void FramebufferManagerD3D11::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {
 	struct Coord {
-		Vec3 pos; float u, v;
+		Lin::Vec3 pos; float u, v;
 	};
 	Coord coord[4] = {
 		{{x, y, 0}, u0, v0},

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -42,6 +42,8 @@
 #include "GPU/Directx9/DrawEngineDX9.h"
 #include "GPU/Directx9/FramebufferDX9.h"
 
+using namespace Lin;
+
 namespace DX9 {
 
 PSShader::PSShader(LPDIRECT3DDEVICE9 device, FShaderID id, const char *code) : id_(id), shader(nullptr), failed_(false) {

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -48,6 +48,8 @@
 #include "GPU/GLES/DrawEngineGLES.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
 
+using namespace Lin;
+
 Shader::Shader(GLRenderManager *render, const char *code, const std::string &desc, uint32_t glShaderType, bool useHWTransform, uint32_t attrMask, uint64_t uniformMask)
 	  : render_(render), failed_(false), useHWTransform_(useHWTransform), attrMask_(attrMask), uniformMask_(uniformMask) {
 	PROFILE_THIS_SCOPE("shadercomp");

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -317,7 +317,7 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 
 	if ((flags & DRAWTEX_TO_BACKBUFFER) && g_display_rotation != DisplayRotation::ROTATE_0) {
 		for (int i = 0; i < 4; i++) {
-			Vec3 v(vtx[i].x, vtx[i].y, 0.0f);
+			Lin::Vec3 v(vtx[i].x, vtx[i].y, 0.0f);
 			// backwards notation, should fix that...
 			v = v * g_display_rot_matrix;
 			vtx[i].x = v.x;

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -24,6 +24,8 @@
 
 const wchar_t *SimpleGLWindow::windowClass = L"SimpleGLWindow";
 
+using namespace Lin;
+
 void SimpleGLWindow::RegisterClass() {
 	WNDCLASSEX wndClass;
 

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -426,7 +426,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 			272.0f / (float)PSP_CoreParameter().renderHeight,
 		};
 
-		Matrix4x4 ortho;
+		Lin::Matrix4x4 ortho;
 		ortho.setOrtho(-(float)gstate_c.curRTOffsetX, (primaryWindow->TexWidth() - (int)gstate_c.curRTOffsetX) * scale[0], primaryWindow->TexHeight() * scale[1], 0, -1, 1);
 		glUniformMatrix4fv(previewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 		if (previewVao != 0) {
@@ -488,7 +488,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 			glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(u16), indices.data(), GL_STREAM_DRAW);
 		}
 
-		Matrix4x4 ortho;
+		Lin::Matrix4x4 ortho;
 		ortho.setOrtho(0.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, 0.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, -1.0f, 1.0f);
 		glUniformMatrix4fv(texPreviewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 		if (texPreviewVao != 0) {

--- a/ext/native/base/display.cpp
+++ b/ext/native/base/display.cpp
@@ -17,7 +17,7 @@ float pixel_in_dps_y = 1.0f;
 float display_hz = 60.0f;
 
 DisplayRotation g_display_rotation;
-Matrix4x4 g_display_rot_matrix;
+Lin::Matrix4x4 g_display_rot_matrix;
 
 template<class T>
 void RotateRectToDisplayImpl(DisplayRect<T> &rect, T curRTWidth, T curRTHeight) {

--- a/ext/native/base/display.h
+++ b/ext/native/base/display.h
@@ -29,7 +29,7 @@ enum class DisplayRotation {
 };
 
 extern DisplayRotation g_display_rotation;
-extern Matrix4x4 g_display_rot_matrix;
+extern Lin::Matrix4x4 g_display_rot_matrix;
 
 template<class T>
 struct DisplayRect {

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -92,7 +92,7 @@ void DrawBuffer::Flush(bool set_blend_state) {
 	draw_->BindPipeline(pipeline_);
 
 	VsTexColUB ub{};
-	memcpy(ub.WorldViewProj, drawMatrix_.getReadPtr(), sizeof(Matrix4x4));
+	memcpy(ub.WorldViewProj, drawMatrix_.getReadPtr(), sizeof(Lin::Matrix4x4));
 	draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
 	if (vbuf_) {
 		draw_->UpdateBuffer(vbuf_, (const uint8_t *)verts_, 0, sizeof(Vertex) * count_, Draw::UPDATE_DISCARD);

--- a/ext/native/gfx_es2/draw_buffer.h
+++ b/ext/native/gfx_es2/draw_buffer.h
@@ -142,7 +142,7 @@ public:
 
 	static void DoAlign(int flags, float *x, float *y, float *w, float *h);
 
-	void PushDrawMatrix(const Matrix4x4 &m) {
+	void PushDrawMatrix(const Lin::Matrix4x4 &m) {
 		drawMatrixStack_.push_back(drawMatrix_);
 		drawMatrix_ = m;
 	}
@@ -152,7 +152,7 @@ public:
 		drawMatrixStack_.pop_back();
 	}
 
-	Matrix4x4 GetDrawMatrix() {
+	Lin::Matrix4x4 GetDrawMatrix() {
 		return drawMatrix_;
 	}
 
@@ -177,8 +177,8 @@ private:
 		uint32_t rgba;
 	};
 
-	Matrix4x4 drawMatrix_;
-	std::vector<Matrix4x4> drawMatrixStack_;
+	Lin::Matrix4x4 drawMatrix_;
+	std::vector<Lin::Matrix4x4> drawMatrixStack_;
 
 	float alpha_ = 1.0f;
 	std::vector<float> alphaStack_;

--- a/ext/native/math/geom2d.h
+++ b/ext/native/math/geom2d.h
@@ -3,7 +3,7 @@
 #include <cmath>
 
 struct Point {
-	Point() {}
+	Point() : x(0.0f), y(0.0f) {}
 	Point(float x_, float y_) : x(x_), y(y_) {}
 
 	float x;

--- a/ext/native/math/lin/matrix4x4.cpp
+++ b/ext/native/math/lin/matrix4x4.cpp
@@ -14,6 +14,8 @@
 // See http://code.google.com/p/oolongengine/source/browse/trunk/Oolong+Engine2/Math/neonmath/neon_matrix_impl.cpp?spec=svn143&r=143	when we need speed
 // no wait. http://code.google.com/p/math-neon/
 
+namespace Lin {
+
 Matrix4x4 Matrix4x4::simpleInverse() const {
 	Matrix4x4 out;
 	out.xx = xx;
@@ -151,7 +153,6 @@ void Matrix4x4::setViewLookAtD3D(const Vec3 &vFrom, const Vec3 &vAt, const Vec3 
 	ww = 1.0f;
 }
 
-
 void Matrix4x4::setViewFrame(const Vec3 &pos, const Vec3 &vRight, const Vec3 &vView, const Vec3 &vUp) {
 	xx = vRight.x; xy = vUp.x; xz=vView.x; xw = 0.0f;
 	yx = vRight.y; yy = vUp.y; yz=vView.y; yw = 0.0f;
@@ -247,4 +248,6 @@ void Matrix4x4::print() const {
 	char buffer[256];
 	toText(buffer, 256);
 	puts(buffer);
+}
+
 }

--- a/ext/native/math/lin/matrix4x4.h
+++ b/ext/native/math/lin/matrix4x4.h
@@ -3,6 +3,8 @@
 
 #include "math/lin/vec3.h"
 
+namespace Lin {
+
 class Quaternion;
 
 class Matrix4x4 {
@@ -157,6 +159,8 @@ public:
 		wz = wz * scale.z + ww * trans.z;
 	}
 };
+
+}  // namespace Lin
 
 #endif	// _MATH_LIN_MATRIX4X4_H
 

--- a/ext/native/math/lin/plane.cpp
+++ b/ext/native/math/lin/plane.cpp
@@ -1,6 +1,7 @@
 #include "math/lin/matrix4x4.h"
 #include "math/lin/plane.h"
 
+namespace Lin {
 
 void Plane::TransformByIT(const Matrix4x4 &m, Plane *out) {
 	out->x = x * m.xx + y * m.yx + z * m.zx + d * m.wx;
@@ -8,3 +9,5 @@ void Plane::TransformByIT(const Matrix4x4 &m, Plane *out) {
 	out->z = x * m.xz + y * m.yz + z * m.zz + d * m.wz;
 	out->d = x * m.xw + y * m.yw + z * m.zw + d * m.ww;
 }
+
+}  // namespace Lin

--- a/ext/native/math/lin/plane.h
+++ b/ext/native/math/lin/plane.h
@@ -3,6 +3,8 @@
 
 #include "math/lin/vec3.h"
 
+namespace Lin {
+
 class Matrix4x4;
 
 class Plane {
@@ -33,5 +35,7 @@ public:
 	// out cannot be equal to this.
 	void TransformByIT(const Matrix4x4 &matrix, Plane *out);
 };
+
+}  // namespace Lin
 
 #endif

--- a/ext/native/math/lin/quat.cpp
+++ b/ext/native/math/lin/quat.cpp
@@ -1,6 +1,8 @@
 #include "math/lin/quat.h"
 #include "math/lin/matrix4x4.h"
 
+namespace Lin {
+
 void Quaternion::toMatrix(Matrix4x4 *out) const {
 	Matrix4x4 temp;
 	temp.setIdentity();
@@ -122,4 +124,6 @@ Quaternion Quaternion::multiply(const Quaternion &q) const {
 		(w * q.y) + (y * q.w) + (z * q.x) - (x * q.z),
 		(w * q.z) + (z * q.w) + (x * q.y) - (y * q.x),
 		(w * q.w) - (x * q.x) - (y * q.y) - (z * q.z));
+}
+
 }

--- a/ext/native/math/lin/quat.h
+++ b/ext/native/math/lin/quat.h
@@ -3,6 +3,8 @@
 
 #include "math/lin/vec3.h"
 
+namespace Lin {
+
 class Matrix4x4;
 
 class Quaternion
@@ -88,5 +90,7 @@ public:
 		x*=f; y*=f; z*=f; w*=f;
 	}
 };
+
+}  // namespace Lin
 
 #endif	// _MATH_LIN_QUAT_H

--- a/ext/native/math/lin/vec3.cpp
+++ b/ext/native/math/lin/vec3.cpp
@@ -3,6 +3,8 @@
 #include "math/lin/vec3.h"
 #include "math/lin/matrix4x4.h"
 
+namespace Lin {
+
 Vec3 Vec3::operator *(const Matrix4x4 &m) const {
 	return Vec3(x*m.xx + y*m.yx + z*m.zx + m.wx,
 		x*m.xy + y*m.yy + z*m.zy + m.wy,
@@ -26,3 +28,5 @@ Vec3 Vec3::rotatedBy(const Matrix4x4 &m) const {
 		x*m.xy + y*m.yy + z*m.zy,
 		x*m.xz + y*m.yz + z*m.zz);
 }
+
+}  // namespace Lin

--- a/ext/native/math/lin/vec3.h
+++ b/ext/native/math/lin/vec3.h
@@ -4,6 +4,8 @@
 #include <math.h>
 #include <string.h>	// memset
 
+namespace Lin {
+
 class Matrix4x4;
 
 // Hm, doesn't belong in this file.
@@ -141,5 +143,7 @@ public:
 	Vec3 min;
 	Vec3 max;
 };
+
+}  // namespace Lin
 
 #endif	// _MATH_LIN_VEC3

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -14,7 +14,9 @@
 #include "base/logging.h"
 #include "DataFormat.h"
 
+namespace Lin {
 class Matrix4x4;
+}
 
 namespace Draw {
 

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -222,6 +222,8 @@ void UIContext::FillRect(const UI::Drawable &drawable, const Bounds &bounds) {
 void UIContext::PushTransform(const UITransform &transform) {
 	Flush();
 
+	using namespace Lin;
+
 	Matrix4x4 m = Draw()->GetDrawMatrix();
 	const Vec3 &t = transform.translate;
 	Vec3 scaledTranslate = Vec3(

--- a/ext/native/ui/ui_context.h
+++ b/ext/native/ui/ui_context.h
@@ -35,8 +35,8 @@ class DrawBuffer;
 
 struct UITransform {
 	// TODO: Or just use a matrix?
-	Vec3 translate;
-	Vec3 scale;
+	Lin::Vec3 translate;
+	Lin::Vec3 scale;
 	float alpha;
 };
 

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -2,8 +2,11 @@
 
 #include <set>
 
+#include "math/lin/vec3.h"
 #include "ui/screen.h"
 #include "ui/viewgroup.h"
+
+using namespace Lin;
 
 class I18NCategory;
 namespace Draw {


### PR DESCRIPTION
Curiously this name collision (or ambiguity between Vec3 and Vec3<type>) doesn't affect clang.