### PR TITLE
Darkstalkers Chronicle: Add specializations and speedhacks to get it kinda playable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ build.ios
 versionname.txt
 versioncode.txt
 build*/
+android/.cxx
 
 # Temp file used by jenkins windows build (TODO: remove)
 desc.txt

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -67,6 +67,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
 	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
 	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);
+	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -68,6 +68,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
 	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);
 	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
+	CheckSetting(iniFile, gameID, "DarkStalkersPresentHack", &flags_.DarkStalkersPresentHack);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -68,6 +68,7 @@ struct CompatFlags {
 	bool HideISOFiles;
 	bool MoreAccurateVMMUL;
 	bool ForceSoftwareRenderer;
+	bool DarkStalkersPresentHack;
 };
 
 class IniFile;

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -67,6 +67,7 @@ struct CompatFlags {
 	bool JitInvalidationHack;
 	bool HideISOFiles;
 	bool MoreAccurateVMMUL;
+	bool ForceSoftwareRenderer;
 };
 
 class IniFile;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -130,7 +130,7 @@ enum UtilityDialogType {
 
 // Only a single dialog is allowed at a time.
 static UtilityDialogType currentDialogType;
-static bool currentDialogActive;
+bool currentDialogActive;
 static PSPSaveDialog saveDialog;
 static PSPMsgDialog msgDialog;
 static PSPOskDialog oskDialog;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -349,6 +349,11 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 
 	CPU_Init();
 
+	// Compat flags get loaded in CPU_Init (which is a bit of a misnomer) so we check for SW renderer here.
+	if (g_Config.bSoftwareRendering || PSP_CoreParameter().compat.flags().ForceSoftwareRenderer) {
+		coreParameter.gpuCore = GPUCORE_SOFTWARE;
+	}
+
 	*error_string = coreParameter.errorString;
 	bool success = coreParameter.fileToStart != "";
 	if (!success) {

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -197,6 +197,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>Common/DbgNew.h</ForcedIncludeFiles>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -625,6 +625,10 @@ public:
 		*this = *this / f;
 	}
 
+	bool operator ==(const Vec4 &other) const {
+		return x == other.x && y == other.y && z == other.z && w == other.w;
+	}
+
 	T Length2() const
 	{
 		return x*x + y*y + z*z + w*w;

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -17,12 +17,17 @@
 
 #include <algorithm>
 
+#include "Core/System.h"
+
 #include "GPU/GPUState.h"
 
 #include "GPU/Software/Clipper.h"
 #include "GPU/Software/Rasterizer.h"
 
 #include "profiler/profiler.h"
+
+
+extern bool g_DarkStalkerStretch;
 
 namespace Clipper {
 
@@ -204,6 +209,13 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 		bool alpha_check = true;
 		if ((coord_check || !gstate.isTextureMapEnabled()) && state_check && alpha_check) {
 			Rasterizer::DrawPSXSprite(v0, v1);
+			return;
+		}
+
+		// Eliminate the stretch blit in DarkStalkers.
+		// We compensate for that when blitting the framebuffer in SoftGpu.cpp.
+		if (PSP_CoreParameter().compat.flags().DarkStalkersPresentHack && v0.texturecoords.x == 64.0f && v0.texturecoords.y == 16.0f && v1.texturecoords.x == 448.0f && v1.texturecoords.y == 240.0f) {
+			g_DarkStalkerStretch = true;
 			return;
 		}
 

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -208,7 +208,7 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 		bool state_check = !gstate.isModeClear();
 		bool alpha_check = true;
 		if ((coord_check || !gstate.isTextureMapEnabled()) && state_check && alpha_check) {
-			Rasterizer::DrawPSXSprite(v0, v1);
+			Rasterizer::DrawSprite(v0, v1);
 			return;
 		}
 

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -51,26 +51,28 @@ static inline int CalcClipMask(const ClipCoords& v)
 
 #define AddInterpolatedVertex(t, out, in, numVertices) \
 { \
-	Vertices[numVertices]->Lerp(t, *Vertices[out], *Vertices[in]); \
-	numVertices++; \
+	Vertices[numVertices++]->Lerp(t, *Vertices[out], *Vertices[in]); \
 }
 
-#define DIFFERENT_SIGNS(x,y) ((x <= 0 && y > 0) || (x > 0 && y <= 0))
+inline bool DIFFERENT_SIGNS(float x, float y) {
+	return ((x <= 0 && y > 0) || (x > 0 && y <= 0));
+}
 
-#define CLIP_DOTPROD(I, A, B, C, D) \
-	(Vertices[I]->clippos.x * A + Vertices[I]->clippos.y * B + Vertices[I]->clippos.z * C + Vertices[I]->clippos.w * D)
+inline float CLIP_DOTPROD(const VertexData &vert, float A, float B, float C, float D) {
+	return (vert.clippos.x * A + vert.clippos.y * B + vert.clippos.z * C + vert.clippos.w * D);
+}
 
 #define POLY_CLIP( PLANE_BIT, A, B, C, D )							\
 {																	\
 	if (mask & PLANE_BIT) {											\
 		int idxPrev = inlist[0];									\
-		float dpPrev = CLIP_DOTPROD(idxPrev, A, B, C, D );			\
+		float dpPrev = CLIP_DOTPROD(*Vertices[idxPrev], A, B, C, D );\
 		int outcount = 0;											\
 																	\
 		inlist[n] = inlist[0];										\
 		for (int j = 1; j <= n; j++) { 								\
 			int idx = inlist[j];									\
-			float dp = CLIP_DOTPROD(idx, A, B, C, D );				\
+			float dp = CLIP_DOTPROD(*Vertices[idx], A, B, C, D );	\
 			if (dpPrev >= 0) {										\
 				outlist[outcount++] = idxPrev;						\
 			}														\
@@ -104,9 +106,9 @@ static inline int CalcClipMask(const ClipCoords& v)
 
 #define CLIP_LINE(PLANE_BIT, A, B, C, D)						\
 {																\
-	if (mask & PLANE_BIT) {											\
-		float dp0 = CLIP_DOTPROD(0, A, B, C, D );				\
-		float dp1 = CLIP_DOTPROD(1, A, B, C, D );				\
+	if (mask & PLANE_BIT) {										\
+		float dp0 = CLIP_DOTPROD(*Vertices[0], A, B, C, D );		\
+		float dp1 = CLIP_DOTPROD(*Vertices[1], A, B, C, D );		\
 		int i = 0;												\
 																\
 		if (mask0 & PLANE_BIT) {								\
@@ -116,7 +118,7 @@ static inline int CalcClipMask(const ClipCoords& v)
 				AddInterpolatedVertex(t, 1, 0, i);				\
 			}													\
 		}														\
-		dp0 = CLIP_DOTPROD(0, A, B, C, D );						\
+		dp0 = CLIP_DOTPROD(*Vertices[0], A, B, C, D );						\
 																\
 		if (mask1 & PLANE_BIT) {								\
 			if (dp1 < 0) {										\

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -198,7 +198,7 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 
 		// Color and depth values of second vertex are used for the whole rectangle
 		buf[0].color0 = buf[1].color0 = buf[2].color0 = buf[3].color0;
-		buf[0].color1 = buf[1].color1 = buf[2].color1 = buf[3].color1;
+		buf[0].color1 = buf[1].color1 = buf[2].color1 = buf[3].color1;  // is color1 ever used in through mode?
 		buf[0].clippos.w = buf[1].clippos.w = buf[2].clippos.w = buf[3].clippos.w = 1.0f;
 		buf[0].fogdepth = buf[1].fogdepth = buf[2].fogdepth = buf[3].fogdepth = 1.0f;
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1332,7 +1332,7 @@ static inline Vec4<int> ModulateRGBA(const Vec4<int>& prim_color, const Vec4<int
 	} else {
 		out_rgb = prim_color.rgb() * texcolor.rgb() / 255;
 	}
-	out_a = (rgba) ? (prim_color.a() * texcolor.a() / 255) : prim_color.a();
+	out_a = (prim_color.a() * texcolor.a() / 255);
 #endif
 
 	return Vec4<int>(out_rgb.r(), out_rgb.g(), out_rgb.b(), out_a);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1372,8 +1372,8 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 		}
 
 		// First clip the right and bottom sides, since we don't need to adjust the deltas.
-		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x;
-		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y;
+		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x + 1;
+		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y + 1;
 		// Now clip the other sides.
 		if (pos0.x < scissorTL.x) {
 			s_start += (scissorTL.x - pos0.x) * ds;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1287,8 +1287,20 @@ void DrawTriangleSlice(
 	}
 }
 
+// Slow but can handle all input.
+void SafeScanline(int s, int ds, int t, int x1, int x2, int y, int z, const u8 *texptr, int texbufw, Sampler::Funcs &sampler, Vec4<int> v0_color) {
+	for (int x = x1; x < x2; x++) {
+		Vec4<int> prim_color = v0_color;
+		Vec4<int> tex_color = Vec4<int>::FromRGBA(sampler.nearest(s, t, texptr, texbufw, 0));
+		prim_color = GetTextureFunctionOutput(prim_color, tex_color);
+		DrawingCoords pos(x, y, z);
+		DrawSinglePixel<false>(pos, (u16)z, 1.0f, prim_color);
+		s += ds;
+	}
+}
+
 void DrawPSXSprite(const VertexData& v0, const VertexData& v1) {
-	u8 *texptr = nullptr;
+	const u8 *texptr = nullptr;
 
 	GETextureFormat texfmt = gstate.getTextureFormat();
 	u32 texaddr = gstate.getTextureAddress(0);
@@ -1302,17 +1314,44 @@ void DrawPSXSprite(const VertexData& v0, const VertexData& v1) {
 	DrawingCoords pos0 = TransformUnit::ScreenToDrawing(v0.screenpos);
 	DrawingCoords pos1 = TransformUnit::ScreenToDrawing(v1.screenpos);
 
+	DrawingCoords scissorTL(gstate.getScissorX1(), gstate.getScissorY1(), 0);
+	DrawingCoords scissorBR(gstate.getScissorX2(), gstate.getScissorY2(), 0);
+
 	int z = pos0.z;
 	float fog = 1.0f;
 
 	if (gstate.isTextureMapEnabled()) {
 		// 1:1 (but with mirror support) texture mapping!
-		int s = v0.texturecoords.x;
-		int t = v0.texturecoords.y;
+		int s_start = v0.texturecoords.x;
+		int t_start = v0.texturecoords.y;
 		int ds = v1.texturecoords.x > v0.texturecoords.x ? 1 : -1;
 		int dt = v1.texturecoords.y > v0.texturecoords.y ? 1 : -1;
+
+		if (ds < 0) {
+			s_start += ds;
+		}
+		if (dt < 0) {
+			t_start += dt;
+		}
+
+		// First clip the right and bottom sides, since we don't need to adjust the deltas.
+		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x;
+		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y;
+		// Now clip the other sides.
+		if (pos0.x < scissorTL.x) {
+			s_start += (scissorTL.x - pos0.x) * ds;
+			pos0.x = scissorTL.x;
+		}
+		if (pos0.y < scissorTL.y) {
+			t_start += (scissorTL.y - pos0.y) * dt;
+			pos0.y = scissorTL.y;
+		}
+
+		int t = t_start;
 		for (int y = pos0.y; y < pos1.y; y++) {
-			s = v0.texturecoords.x;
+			int s = s_start;
+			SafeScanline(s, ds, t, pos0.x, pos1.x, y, z, texptr, texbufw, sampler, v0.color0);
+			/*
 			for (int x = pos0.x; x < pos1.x; x++) {
 				Vec4<int> prim_color = v0.color0;
 				Vec4<int> tex_color = Vec4<int>::FromRGBA(sampler.nearest(s, t, texptr, texbufw, 0));
@@ -1321,10 +1360,14 @@ void DrawPSXSprite(const VertexData& v0, const VertexData& v1) {
 				DrawSinglePixel<false>(pos, (u16)z, fog, prim_color);
 				s += ds;
 			}
+			*/
 			t += dt;
 		}
-	}
-	else {
+	} else {
+		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x;
+		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y;
+		if (pos0.x < scissorTL.x) pos0.x = scissorTL.x;
+		if (pos0.y < scissorTL.y) pos0.y = scissorTL.y;
 		for (int y = pos0.y; y < pos1.y; y++) {
 			for (int x = pos0.x; x < pos1.x; x++) {
 				Vec4<int> prim_color = v0.color0;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1291,13 +1291,13 @@ void DrawTriangleSlice(
 inline void DrawSinglePixel5551(u16 *pixel, const Vec4<int> &color_in) {
 	u32 new_color;
 	if (color_in.a() == 255) {
+		new_color = color_in.ToRGBA() & 0xFFFFFF;
+	} else {
 		const u32 old_color = RGBA5551ToRGBA8888(*pixel);
 		const Vec4<int> dst = Vec4<int>::FromRGBA(old_color);
 		Vec3<int> blended = AlphaBlendingResult(color_in, dst);
 		// ToRGB() always automatically clamps.
 		new_color = blended.ToRGB();
-	} else {
-		new_color = color_in.ToRGBA() & 0xFFFFFF;
 	}
 
 	new_color |= (*pixel & 0x8000) ? 0xff000000 : 0x00000000;

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -27,7 +27,7 @@ namespace Rasterizer {
 void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& v2);
 void DrawPoint(const VertexData &v0);
 void DrawLine(const VertexData &v0, const VertexData &v1);
-void DrawPSXSprite(const VertexData &v0, const VertexData &v1);
+void DrawSprite(const VertexData &v0, const VertexData &v1);
 void ClearRectangle(const VertexData &v0, const VertexData &v1);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -27,6 +27,7 @@ namespace Rasterizer {
 void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& v2);
 void DrawPoint(const VertexData &v0);
 void DrawLine(const VertexData &v0, const VertexData &v1);
+void DrawPSXSprite(const VertexData &v0, const VertexData &v1);
 void ClearRectangle(const VertexData &v0, const VertexData &v1);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -208,7 +208,6 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		u1 = 447.5f / 512.0f;
 		v1 = 16.0f / 272.0f;
 		v0 = 240.0f / 272.0f;
-		g_DarkStalkerStretch = false;
 	} else if (!Memory::IsValidAddress(displayFramebuf_) || srcwidth == 0 || srcheight == 0) {
 		hasImage = false;
 		u1 = 1.0f;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -198,8 +198,6 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 			// RB swapped, compensate with a shader.
 			desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
 			pipeline = texColorRBSwizzle;
-		} else {
-			// Shouldn't happen (once I'm done with the backends).
 		}
 		desc.width = displayStride_ == 0 ? srcwidth : displayStride_;
 		desc.height = srcheight;
@@ -217,10 +215,17 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		desc.height = srcheight;
 		desc.initData.push_back(data);
 		desc.format = Draw::DataFormat::R8G8B8A8_UNORM;
-	} else if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN && displayFormat_ == GE_FORMAT_5551) {
+	} else if (displayFormat_ == GE_FORMAT_5551) {
 		u8 *data = Memory::GetPointer(displayFramebuf_);
-		desc.swizzle = Draw::TextureSwizzle::BGRA;
 		desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
+		if (draw_->GetDataFormatSupport(Draw::DataFormat::A1B5G5R5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
+			// The perfect one.
+			desc.format = Draw::DataFormat::A1B5G5R5_UNORM_PACK16;
+		} else if (draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
+			// RB swapped, compensate with a shader.
+			desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
+			pipeline = texColorRBSwizzle;
+		}
 		desc.width = displayStride_ == 0 ? srcwidth : displayStride_;
 		desc.height = srcheight;
 		desc.initData.push_back(data);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -44,6 +44,10 @@ struct FormatBuffer {
 	inline u32 Get32(int x, int y, int stride) {
 		return as32[x + y * stride];
 	}
+
+	inline u16 *Get16Ptr(int x, int y, int stride) {
+		return &as16[x + y * stride];
+	}
 };
 
 class SoftwareDrawEngine;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -108,6 +108,7 @@ private:
 
 	Draw::Texture *fbTex;
 	Draw::Pipeline *texColor;
+	Draw::Pipeline *texColorRBSwizzle;
 	std::vector<u32> fbTexBuffer;
 
 	Draw::SamplerState *samplerNearest = nullptr;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -470,6 +470,27 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 					data[2].color0 == data[3].color0) {
 					// It's a rectangle!
 					Clipper::ProcessRect(data[0], data[3]);
+					break;
+				}
+				// There's the other vertex order too...
+				if (data[0].screenpos.x == data[2].screenpos.x &&
+					data[0].screenpos.y == data[1].screenpos.y &&
+					data[1].screenpos.x == data[3].screenpos.x &&
+					data[2].screenpos.y == data[3].screenpos.y &&
+					data[2].screenpos.y > data[0].screenpos.y &&  // Avoid rotation handling
+					data[1].screenpos.x > data[0].screenpos.x &&
+					data[0].texturecoords.x == data[2].texturecoords.x &&
+					data[0].texturecoords.y == data[1].texturecoords.y &&
+					data[1].texturecoords.x == data[3].texturecoords.x &&
+					data[2].texturecoords.y == data[3].texturecoords.y &&
+					data[2].texturecoords.y > data[0].texturecoords.y &&
+					data[1].texturecoords.x > data[0].texturecoords.x &&
+					data[0].color0 == data[1].color0 &&
+					data[1].color0 == data[2].color0 &&
+					data[2].color0 == data[3].color0) {
+					// It's a rectangle!
+					Clipper::ProcessRect(data[0], data[3]);
+					break;
 				}
 			}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -232,9 +232,6 @@ void EmuScreen::bootGame(const std::string &filename) {
 		break;
 #endif
 	}
-	if (g_Config.bSoftwareRendering) {
-		coreParam.gpuCore = GPUCORE_SOFTWARE;
-	}
 
 	// Preserve the existing graphics context.
 	coreParam.graphicsContext = PSP_CoreParameter().graphicsContext;

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -116,6 +116,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 		if (!g_Config.sVulkanDevice.empty())
 			g_Config.sVulkanDevice = g_Vulkan->GetPhysicalDeviceProperties(deviceNum).properties.deviceName;
 	}
+
 	g_Vulkan->ChooseDevice(deviceNum);
 	if (g_Vulkan->CreateDevice() != VK_SUCCESS) {
 		*error_message = g_Vulkan->InitError();

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -688,3 +688,8 @@ UCUS98713 = true
 # Darkstalkers
 ULES00016 = true
 ULUS10005 = true
+
+[DarkStalkersPresentHack]
+# Darkstalkers
+ULES00016 = true
+ULUS10005 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -683,3 +683,8 @@ UCET00844 = true
 UCUS98705 = true
 UCED00971 = true
 UCUS98713 = true
+
+[ForceSoftwareRenderer]
+# Darkstalkers
+ULES00016 = true
+ULUS10005 = true

--- a/ext/native/base/display.cpp
+++ b/ext/native/base/display.cpp
@@ -17,7 +17,7 @@ float pixel_in_dps_y = 1.0f;
 float display_hz = 60.0f;
 
 DisplayRotation g_display_rotation;
-Lin::Matrix4x4 g_display_rot_matrix;
+Lin::Matrix4x4 g_display_rot_matrix = Lin::Matrix4x4::identity();
 
 template<class T>
 void RotateRectToDisplayImpl(DisplayRect<T> &rect, T curRTWidth, T curRTHeight) {

--- a/ext/native/math/lin/matrix4x4.h
+++ b/ext/native/math/lin/matrix4x4.h
@@ -57,7 +57,11 @@ public:
 		empty();
 		xx=yy=zz=f; ww=1.0f;
 	}
-
+	static Matrix4x4 identity() {
+		Matrix4x4 id;
+		id.setIdentity();
+		return id;
+	}
 	void setIdentity() {
 		setScaling(1.0f);
 	}

--- a/ext/native/thin3d/DataFormat.h
+++ b/ext/native/thin3d/DataFormat.h
@@ -30,6 +30,7 @@ enum class DataFormat : uint8_t {
 	R5G5B5A1_UNORM_PACK16, // A1 in the LOWER bit
 	B5G5R5A1_UNORM_PACK16, // A1 in the LOWER bit
 	A1R5G5B5_UNORM_PACK16, // A1 in the UPPER bit.
+	A1B5G5R5_UNORM_PACK16, // A1 in the UPPER bit. OpenGL-only.
 
 	R16_FLOAT,
 	R16G16_FLOAT,

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -146,6 +146,50 @@ static const std::vector<ShaderSource> fsTexCol = {
 	}
 };
 
+static const std::vector<ShaderSource> fsTexColRBSwizzle = {
+	{ShaderLanguage::GLSL_ES_200,
+	"#ifdef GL_ES\n"
+	"precision lowp float;\n"
+	"#endif\n"
+	"#if __VERSION__ >= 130\n"
+	"#define varying in\n"
+	"#define texture2D texture\n"
+	"#define gl_FragColor fragColor0\n"
+	"out vec4 fragColor0;\n"
+	"#endif\n"
+	"varying vec4 oColor0;\n"
+	"varying vec2 oTexCoord0;\n"
+	"uniform sampler2D Sampler0;\n"
+	"void main() { gl_FragColor = texture2D(Sampler0, oTexCoord0).zyxw * oColor0; }\n"
+	},
+	{ShaderLanguage::HLSL_D3D9,
+	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
+	"sampler2D Sampler0 : register(s0);\n"
+	"float4 main(PS_INPUT input) : COLOR0 {\n"
+	"  return input.color * tex2D(Sampler0, input.uv).zyxw;\n"
+	"}\n"
+	},
+	{ShaderLanguage::HLSL_D3D11,
+	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
+	"SamplerState samp : register(s0);\n"
+	"Texture2D<float4> tex : register(t0);\n"
+	"float4 main(PS_INPUT input) : SV_Target {\n"
+	"  float4 col = input.color * tex.Sample(samp, input.uv).bgra;\n"
+	"  return col;\n"
+	"}\n"
+	},
+	{ShaderLanguage::GLSL_VULKAN,
+	"#version 140\n"
+	"#extension GL_ARB_separate_shader_objects : enable\n"
+	"#extension GL_ARB_shading_language_420pack : enable\n"
+	"layout(location = 0) in vec4 oColor0;\n"
+	"layout(location = 1) in vec2 oTexCoord0;\n"
+	"layout(location = 0) out vec4 fragColor0\n;"
+	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
+	"void main() { fragColor0 = texture(Sampler0, oTexCoord0).bgra * oColor0; }\n"
+	}
+};
+
 static const std::vector<ShaderSource> fsCol = {
 	{ ShaderLanguage::GLSL_ES_200,
 	"#ifdef GL_ES\n"
@@ -330,8 +374,9 @@ bool DrawContext::CreatePresets() {
 
 	fsPresets_[FS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::FRAGMENT, fsTexCol);
 	fsPresets_[FS_COLOR_2D] = CreateShader(this, ShaderStage::FRAGMENT, fsCol);
+	fsPresets_[FS_TEXTURE_COLOR_2D_RB_SWIZZLE] = CreateShader(this, ShaderStage::FRAGMENT, fsTexColRBSwizzle);
 
-	return vsPresets_[VS_TEXTURE_COLOR_2D] && vsPresets_[VS_COLOR_2D] && fsPresets_[FS_TEXTURE_COLOR_2D] && fsPresets_[FS_COLOR_2D];
+	return vsPresets_[VS_TEXTURE_COLOR_2D] && vsPresets_[VS_COLOR_2D] && fsPresets_[FS_TEXTURE_COLOR_2D] && fsPresets_[FS_COLOR_2D] && fsPresets_[FS_TEXTURE_COLOR_2D_RB_SWIZZLE];
 }
 
 void DrawContext::DestroyPresets() {

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -515,9 +515,16 @@ struct DeviceCaps {
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };
 
+// Some predefined swizzle
+enum class TextureSwizzle {
+	NO_SWIZZLE = 0,
+	BGRA = 1,
+};
+
 struct TextureDesc {
 	TextureType type;
 	DataFormat format;
+	TextureSwizzle swizzle;
 	int width;
 	int height;
 	int depth;

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -146,6 +146,7 @@ enum VertexShaderPreset : int {
 enum FragmentShaderPreset : int {
 	FS_COLOR_2D,
 	FS_TEXTURE_COLOR_2D,
+	FS_TEXTURE_COLOR_2D_RB_SWIZZLE,
 	FS_MAX_PRESET,
 };
 

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -516,16 +516,9 @@ struct DeviceCaps {
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };
 
-// Some predefined swizzle
-enum class TextureSwizzle {
-	NO_SWIZZLE = 0,
-	BGRA = 1,
-};
-
 struct TextureDesc {
 	TextureType type;
 	DataFormat format;
-	TextureSwizzle swizzle;
 	int width;
 	int height;
 	int depth;

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -348,6 +348,10 @@ bool D3D9Texture::Create(const TextureDesc &desc) {
 	format_ = desc.format;
 	tex_ = NULL;
 	d3dfmt_ = FormatToD3DFMT(desc.format);
+
+	if (d3dfmt_ == D3DFMT_UNKNOWN) {
+		return false;
+	}
 	HRESULT hr = E_FAIL;
 
 	D3DPOOL pool = D3DPOOL_MANAGED;
@@ -424,6 +428,7 @@ void D3D9Texture::SetImageData(int x, int y, int z, int width, int height, int d
 					}
 					break;
 				case DataFormat::A4R4G4B4_UNORM_PACK16:
+				case DataFormat::A1R5G5B5_UNORM_PACK16:
 					// Native
 					memcpy(dest, source, width * sizeof(uint16_t));
 					break;
@@ -436,6 +441,10 @@ void D3D9Texture::SetImageData(int x, int y, int z, int width, int height, int d
 
 				case DataFormat::B8G8R8A8_UNORM:
 					memcpy(dest, source, sizeof(uint32_t) * width);
+					break;
+				default:
+					// Unhandled data format copy.
+					DebugBreak();
 					break;
 				}
 			}

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -699,7 +699,20 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 		// Gonna have to generate some, which requires TRANSFER_SRC
 		usageBits |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	}
-	if (!vkTex_->CreateDirect(cmd, alloc, width_, height_, mipLevels_, vulkanFormat, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, usageBits)) {
+
+	VkComponentMapping mapping{};  // Defaults to no swizzle
+	switch (desc.swizzle) {
+	case TextureSwizzle::NO_SWIZZLE:
+		break;
+	case TextureSwizzle::BGRA:
+		mapping.r = VK_COMPONENT_SWIZZLE_B;
+		mapping.g = VK_COMPONENT_SWIZZLE_G;
+		mapping.b = VK_COMPONENT_SWIZZLE_R;
+		mapping.a = VK_COMPONENT_SWIZZLE_A;
+		break;
+	}
+
+	if (!vkTex_->CreateDirect(cmd, alloc, width_, height_, mipLevels_, vulkanFormat, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, usageBits, &mapping)) {
 		ELOG("Failed to create VulkanTexture: %dx%dx%d fmt %d, %d levels", width_, height_, depth_, (int)vulkanFormat, mipLevels_);
 		return false;
 	}

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -700,19 +700,7 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 		usageBits |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	}
 
-	VkComponentMapping mapping{};  // Defaults to no swizzle
-	switch (desc.swizzle) {
-	case TextureSwizzle::NO_SWIZZLE:
-		break;
-	case TextureSwizzle::BGRA:
-		mapping.r = VK_COMPONENT_SWIZZLE_B;
-		mapping.g = VK_COMPONENT_SWIZZLE_G;
-		mapping.b = VK_COMPONENT_SWIZZLE_R;
-		mapping.a = VK_COMPONENT_SWIZZLE_A;
-		break;
-	}
-
-	if (!vkTex_->CreateDirect(cmd, alloc, width_, height_, mipLevels_, vulkanFormat, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, usageBits, &mapping)) {
+	if (!vkTex_->CreateDirect(cmd, alloc, width_, height_, mipLevels_, vulkanFormat, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, usageBits)) {
 		ELOG("Failed to create VulkanTexture: %dx%dx%d fmt %d, %d levels", width_, height_, depth_, (int)vulkanFormat, mipLevels_);
 		return false;
 	}

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1371,6 +1371,8 @@ uint32_t VKContext::GetDataFormatSupport(DataFormat fmt) const {
 		return 0;
 	case DataFormat::A4R4G4B4_UNORM_PACK16:
 		return 0;
+	case DataFormat::A1R5G5B5_UNORM_PACK16:
+		return FMT_RENDERTARGET | FMT_TEXTURE;
 
 	case DataFormat::R8G8B8A8_UNORM:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_INPUTLAYOUT;


### PR DESCRIPTION
Darkstalkers Chronicles is a game that does bad things. Specifically it uses the PSP CPU to draw on top of GPU rendered graphics, which PPSSPP's hardware rendering can't normally handle.

This pull request is:

 * A compat setting that forces software rendering on for this game
 * Optimizations to the software rasterizer, specifically for rectangular draws (which avoids triangle interpolation math).
 * A hack to identify a specific stretch blit in Darkstalkers and replace it with a hardware stretch at the end

Together, it's enough to get Darkstalkers playable at a good speed on PC and kinda playable-ish on high powered mobile devices. And looking sharper than on the real PSP due to avoiding the extra stretch to 480x272. Fixes #6647 .

~~NOTE: This currently doesn't work on OpenGL, but will soon.~~ Works fine on all backends now!

Plenty more can be done to optimize the software rasterizer for this game and in general.