### PR TITLE
Code cleanup: OpenGL texture format cleanup

### DIFF
--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -107,6 +107,9 @@ void convert5551_dx9(u16* data, u32* out, int width, int l, int u);
 
 // "Complete" set of color conversion functions between the usual formats.
 
+// TODO: Need to revisit the naming convention of these. Seems totally backwards
+// now that we've standardized on Draw::DataFormat.
+
 typedef void (*Convert16bppTo16bppFunc)(u16 *dst, const u16 *src, u32 numPixels);
 typedef void (*Convert16bppTo32bppFunc)(u32 *dst, const u16 *src, u32 numPixels);
 typedef void (*Convert32bppTo16bppFunc)(u16 *dst, const u32 *src, u32 numPixels);

--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -92,17 +92,15 @@ GLRTexture *DepalShaderCacheGLES::GetClutTexture(GEPaletteFormat clutFormat, con
 		return oldtex->second->texture;
 	}
 
-	GLuint dstFmt = getClutDestFormat(clutFormat);
+	Draw::DataFormat dstFmt = getClutDestFormat(clutFormat);
 	int texturePixels = clutFormat == GE_CMODE_32BIT_ABGR8888 ? 256 : 512;
 
 	DepalTexture *tex = new DepalTexture();
 	tex->texture = render_->CreateTexture(GL_TEXTURE_2D);
-	GLuint components = dstFmt == GL_UNSIGNED_SHORT_5_6_5 ? GL_RGB : GL_RGBA;
-	GLuint components2 = components;
 
 	uint8_t *clutCopy = new uint8_t[1024];
 	memcpy(clutCopy, rawClut, 1024);
-	render_->TextureImage(tex->texture, 0, texturePixels, 1, components, components2, dstFmt, clutCopy, GLRAllocType::NEW, false);
+	render_->TextureImage(tex->texture, 0, texturePixels, 1, dstFmt, clutCopy, GLRAllocType::NEW, false);
 
 	tex->lastFrame = gpuStats.numFlips;
 	texCache_[clutId] = tex;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -669,40 +669,40 @@ void TessellationDataTransferGLES::SendDataToShader(const SimpleVertex *const *p
 		prevSizeV = size_v;
 		if (!data_tex[0])
 			data_tex[0] = renderManager_->CreateTexture(GL_TEXTURE_2D);
-		renderManager_->TextureImage(data_tex[0], 0, size_u * 3, size_v, GL_RGBA32F, GL_RGBA, GL_FLOAT, nullptr, GLRAllocType::NONE, false);
+		renderManager_->TextureImage(data_tex[0], 0, size_u * 3, size_v, Draw::DataFormat::R32G32B32A32_FLOAT, nullptr, GLRAllocType::NONE, false);
 		renderManager_->FinalizeTexture(data_tex[0], 0, false);
 	}
 	renderManager_->BindTexture(TEX_SLOT_SPLINE_POINTS, data_tex[0]);
 	// Position
-	renderManager_->TextureSubImage(data_tex[0], 0, 0, 0, size_u, size_v, GL_RGBA, GL_FLOAT, (u8 *)pos, GLRAllocType::NEW);
+	renderManager_->TextureSubImage(data_tex[0], 0, 0, 0, size_u, size_v, Draw::DataFormat::R32G32B32A32_FLOAT, (u8 *)pos, GLRAllocType::NEW);
 	// Texcoord
 	if (hasTexCoord)
-		renderManager_->TextureSubImage(data_tex[0], 0, size_u, 0, size_u, size_v, GL_RGBA, GL_FLOAT, (u8 *)tex, GLRAllocType::NEW);
+		renderManager_->TextureSubImage(data_tex[0], 0, size_u, 0, size_u, size_v, Draw::DataFormat::R32G32B32A32_FLOAT, (u8 *)tex, GLRAllocType::NEW);
 	// Color
 	if (hasColor)
-		renderManager_->TextureSubImage(data_tex[0], 0, size_u * 2, 0, size_u, size_v, GL_RGBA, GL_FLOAT, (u8 *)col, GLRAllocType::NEW);
+		renderManager_->TextureSubImage(data_tex[0], 0, size_u * 2, 0, size_u, size_v, Draw::DataFormat::R32G32B32A32_FLOAT, (u8 *)col, GLRAllocType::NEW);
 
 	// Weight U
 	if (prevSizeWU < weights.size_u) {
 		prevSizeWU = weights.size_u;
 		if (!data_tex[1])
 			data_tex[1] = renderManager_->CreateTexture(GL_TEXTURE_2D);
-		renderManager_->TextureImage(data_tex[1], 0, weights.size_u * 2, 1, GL_RGBA32F, GL_RGBA, GL_FLOAT, nullptr, GLRAllocType::NONE, false);
+		renderManager_->TextureImage(data_tex[1], 0, weights.size_u * 2, 1, Draw::DataFormat::R32G32B32A32_FLOAT, nullptr, GLRAllocType::NONE, false);
 		renderManager_->FinalizeTexture(data_tex[1], 0, false);
 	}
 	renderManager_->BindTexture(TEX_SLOT_SPLINE_WEIGHTS_U, data_tex[1]);
-	renderManager_->TextureSubImage(data_tex[1], 0, 0, 0, weights.size_u * 2, 1, GL_RGBA, GL_FLOAT, (u8 *)weights.u, GLRAllocType::NONE);
+	renderManager_->TextureSubImage(data_tex[1], 0, 0, 0, weights.size_u * 2, 1, Draw::DataFormat::R32G32B32A32_FLOAT, (u8 *)weights.u, GLRAllocType::NONE);
 
 	// Weight V
 	if (prevSizeWV < weights.size_v) {
 		prevSizeWV = weights.size_v;
 		if (!data_tex[2])
 			data_tex[2] = renderManager_->CreateTexture(GL_TEXTURE_2D);
-		renderManager_->TextureImage(data_tex[2], 0, weights.size_v * 2, 1, GL_RGBA32F, GL_RGBA, GL_FLOAT, nullptr, GLRAllocType::NONE, false);
+		renderManager_->TextureImage(data_tex[2], 0, weights.size_v * 2, 1, Draw::DataFormat::R32G32B32A32_FLOAT, nullptr, GLRAllocType::NONE, false);
 		renderManager_->FinalizeTexture(data_tex[2], 0, false);
 	}
 	renderManager_->BindTexture(TEX_SLOT_SPLINE_WEIGHTS_V, data_tex[2]);
-	renderManager_->TextureSubImage(data_tex[2], 0, 0, 0, weights.size_v * 2, 1, GL_RGBA, GL_FLOAT, (u8 *)weights.v, GLRAllocType::NONE);
+	renderManager_->TextureSubImage(data_tex[2], 0, 0, 0, weights.size_v * 2, 1, Draw::DataFormat::R32G32B32A32_FLOAT, (u8 *)weights.v, GLRAllocType::NONE);
 }
 
 void TessellationDataTransferGLES::EndFrame() {

--- a/GPU/GLES/FragmentTestCacheGLES.cpp
+++ b/GPU/GLES/FragmentTestCacheGLES.cpp
@@ -145,7 +145,7 @@ GLRTexture *FragmentTestCacheGLES::CreateTestTexture(const GEComparison funcs[4]
 	}
 
 	GLRTexture *tex = render_->CreateTexture(GL_TEXTURE_2D);
-	render_->TextureImage(tex, 0, 256, 1, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, data);
+	render_->TextureImage(tex, 0, 256, 1, Draw::DataFormat::R8G8B8A8_UNORM, data);
 	return tex;
 }
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -379,7 +379,7 @@ void FramebufferManagerGLES::MakePixelTexture(const u8 *srcPixels, GEBufferForma
 			break;
 		}
 	}
-	render_->TextureImage(drawPixelsTex_, 0, width, height, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, convBuf, GLRAllocType::NEW, false);
+	render_->TextureImage(drawPixelsTex_, 0, width, height, Draw::DataFormat::R8G8B8A8_UNORM, convBuf, GLRAllocType::NEW, false);
 	render_->FinalizeTexture(drawPixelsTex_, 0, false);
 
 	// TODO: Return instead?

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -89,11 +89,11 @@ void TextureCacheGLES::Clear(bool delete_them) {
 Draw::DataFormat getClutDestFormat(GEPaletteFormat format) {
 	switch (format) {
 	case GE_CMODE_16BIT_ABGR4444:
-		return Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		return Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 	case GE_CMODE_16BIT_ABGR5551:
-		return Draw::DataFormat::B5G5R5A1_UNORM_PACK16;
+		return Draw::DataFormat::R5G5B5A1_UNORM_PACK16;
 	case GE_CMODE_16BIT_BGR5650:
-		return Draw::DataFormat::B5G6R5_UNORM_PACK16;
+		return Draw::DataFormat::R5G6B5_UNORM_PACK16;
 	case GE_CMODE_32BIT_ABGR8888:
 		return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
@@ -192,14 +192,14 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, Draw::DataFormat dst
 	const u32 *src = (const u32 *)srcBuf;
 	u32 *dst = (u32 *)dstBuf;
 	switch (dstFmt) {
-	case Draw::DataFormat::B4G4R4A4_UNORM_PACK16:
+	case Draw::DataFormat::R4G4B4A4_UNORM_PACK16:
 		ConvertRGBA4444ToABGR4444((u16 *)dst, (const u16 *)src, numPixels);
 		break;
 	// Final Fantasy 2 uses this heavily in animated textures.
-	case Draw::DataFormat::B5G5R5A1_UNORM_PACK16:
+	case Draw::DataFormat::R5G5B5A1_UNORM_PACK16:
 		ConvertRGBA5551ToABGR1555((u16 *)dst, (const u16 *)src, numPixels);
 		break;
-	case Draw::DataFormat::B5G6R5_UNORM_PACK16:
+	case Draw::DataFormat::R5G6B5_UNORM_PACK16:
 		ConvertRGB565ToBGR565((u16 *)dst, (const u16 *)src, numPixels);
 		break;
 	default:
@@ -517,18 +517,18 @@ void TextureCacheGLES::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFram
 ReplacedTextureFormat FromDataFormat(Draw::DataFormat fmt) {
 	// TODO: 16-bit formats are incorrect, since swizzled.
 	switch (fmt) {
-	case Draw::DataFormat::B5G6R5_UNORM_PACK16: return ReplacedTextureFormat::F_0565_ABGR;
-	case Draw::DataFormat::B5G5R5A1_UNORM_PACK16: return ReplacedTextureFormat::F_1555_ABGR;
-	case Draw::DataFormat::B4G4R4A4_UNORM_PACK16: return ReplacedTextureFormat::F_4444_ABGR;
+	case Draw::DataFormat::R5G6B5_UNORM_PACK16: return ReplacedTextureFormat::F_0565_ABGR;
+	case Draw::DataFormat::R5G5B5A1_UNORM_PACK16: return ReplacedTextureFormat::F_1555_ABGR;
+	case Draw::DataFormat::R4G4B4A4_UNORM_PACK16: return ReplacedTextureFormat::F_4444_ABGR;
 	case Draw::DataFormat::R8G8B8A8_UNORM: default: return ReplacedTextureFormat::F_8888;
 	}
 }
 
 Draw::DataFormat ToDataFormat(ReplacedTextureFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_5650: return Draw::DataFormat::B5G6R5_UNORM_PACK16;
-	case ReplacedTextureFormat::F_5551: return Draw::DataFormat::B5G5R5A1_UNORM_PACK16;
-	case ReplacedTextureFormat::F_4444: return Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+	case ReplacedTextureFormat::F_5650: return Draw::DataFormat::R5G6B5_UNORM_PACK16;
+	case ReplacedTextureFormat::F_5551: return Draw::DataFormat::R5G5B5A1_UNORM_PACK16;
+	case ReplacedTextureFormat::F_4444: return Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 	case ReplacedTextureFormat::F_8888: default: return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
@@ -708,11 +708,11 @@ Draw::DataFormat TextureCacheGLES::GetDestFormat(GETextureFormat format, GEPalet
 	case GE_TFMT_CLUT32:
 		return getClutDestFormat(clutFormat);
 	case GE_TFMT_4444:
-		return Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		return Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 	case GE_TFMT_5551:
-		return Draw::DataFormat::B5G5R5A1_UNORM_PACK16;
+		return Draw::DataFormat::R5G5B5A1_UNORM_PACK16;
 	case GE_TFMT_5650:
-		return Draw::DataFormat::B5G6R5_UNORM_PACK16;
+		return Draw::DataFormat::R5G6B5_UNORM_PACK16;
 	case GE_TFMT_8888:
 	case GE_TFMT_DXT1:
 	case GE_TFMT_DXT3:
@@ -725,13 +725,13 @@ Draw::DataFormat TextureCacheGLES::GetDestFormat(GETextureFormat format, GEPalet
 TexCacheEntry::TexStatus TextureCacheGLES::CheckAlpha(const uint8_t *pixelData, Draw::DataFormat dstFmt, int stride, int w, int h) {
 	CheckAlphaResult res;
 	switch (dstFmt) {
-	case Draw::DataFormat::B4G4R4A4_UNORM_PACK16:
+	case Draw::DataFormat::R4G4B4A4_UNORM_PACK16:
 		res = CheckAlphaABGR4444Basic((const uint32_t *)pixelData, stride, w, h);
 		break;
-	case Draw::DataFormat::B5G5R5A1_UNORM_PACK16:
+	case Draw::DataFormat::R5G5B5A1_UNORM_PACK16:
 		res = CheckAlphaABGR1555Basic((const uint32_t *)pixelData, stride, w, h);
 		break;
-	case Draw::DataFormat::B5G6R5_UNORM_PACK16:
+	case Draw::DataFormat::R5G6B5_UNORM_PACK16:
 		// Never has any alpha.
 		res = CHECKALPHA_FULL;
 		break;

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -76,10 +76,10 @@ protected:
 
 private:
 	void UpdateSamplingParams(TexCacheEntry &entry, bool force);
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int scaleFactor, GLenum dstFmt);
-	GLenum GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
+	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int scaleFactor, Draw::DataFormat dstFmt);
+	Draw::DataFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 
-	TexCacheEntry::TexStatus CheckAlpha(const uint8_t *pixelData, GLenum dstFmt, int stride, int w, int h);
+	TexCacheEntry::TexStatus CheckAlpha(const uint8_t *pixelData, Draw::DataFormat dstFmt, int stride, int w, int h);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) override;
 
@@ -101,4 +101,4 @@ private:
 	enum { INVALID_TEX = -1 };
 };
 
-GLenum getClutDestFormat(GEPaletteFormat format);
+Draw::DataFormat getClutDestFormat(GEPaletteFormat format);

--- a/GPU/GLES/TextureScalerGLES.cpp
+++ b/GPU/GLES/TextureScalerGLES.cpp
@@ -28,30 +28,32 @@
 #include "Common/ColorConv.h"
 #include "Common/Log.h"
 #include "Common/ThreadPools.h"
+#include "thin3d/DataFormat.h"
 
 int TextureScalerGLES::BytesPerPixel(u32 format) {
-	return (format == GL_UNSIGNED_BYTE) ? 4 : 2;
+	return ((Draw::DataFormat)format == Draw::DataFormat::R8G8B8A8_UNORM) ? 4 : 2;
 }
 
 u32 TextureScalerGLES::Get8888Format() {
-	return GL_UNSIGNED_BYTE;
+	return (u32)Draw::DataFormat::R8G8B8A8_UNORM;
 }
 
 void TextureScalerGLES::ConvertTo8888(u32 format, u32* source, u32* &dest, int width, int height) {
-	switch(format) {
-	case GL_UNSIGNED_BYTE:
+	Draw::DataFormat fmt = (Draw::DataFormat)format;
+	switch (fmt) {
+	case Draw::DataFormat::R8G8B8A8_UNORM:
 		dest = source; // already fine
 		break;
 
-	case GL_UNSIGNED_SHORT_4_4_4_4:
+	case Draw::DataFormat::B4G4R4A4_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert4444_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 
-	case GL_UNSIGNED_SHORT_5_6_5:
+	case Draw::DataFormat::B5G6R5_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert565_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 
-	case GL_UNSIGNED_SHORT_5_5_5_1:
+	case Draw::DataFormat::B5G5R5A1_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert5551_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 

--- a/GPU/GLES/TextureScalerGLES.cpp
+++ b/GPU/GLES/TextureScalerGLES.cpp
@@ -45,15 +45,15 @@ void TextureScalerGLES::ConvertTo8888(u32 format, u32* source, u32* &dest, int w
 		dest = source; // already fine
 		break;
 
-	case Draw::DataFormat::B4G4R4A4_UNORM_PACK16:
+	case Draw::DataFormat::R4G4B4A4_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert4444_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 
-	case Draw::DataFormat::B5G6R5_UNORM_PACK16:
+	case Draw::DataFormat::R5G6B5_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert565_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 
-	case Draw::DataFormat::B5G5R5A1_UNORM_PACK16:
+	case Draw::DataFormat::R5G5B5A1_UNORM_PACK16:
 		GlobalThreadPool::Loop(std::bind(&convert5551_gl, (u16*)source, dest, width, std::placeholders::_1, std::placeholders::_2), 0, height);
 		break;
 

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -201,7 +201,7 @@ void TextDrawerAndroid::DrawString(DrawBuffer &target, const char *str, float x,
 
 		TextureDesc desc{};
 		desc.type = TextureType::LINEAR2D;
-		desc.format = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		desc.format = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 		desc.width = entry->bmWidth;
 		desc.height = entry->bmHeight;
 		desc.depth = 1;

--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -105,7 +105,7 @@ void TextDrawerQt::DrawString(DrawBuffer &target, const char *str, float x, floa
 
 		TextureDesc desc{};
 		desc.type = TextureType::LINEAR2D;
-		desc.format = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		desc.format = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 		desc.width = entry->bmWidth;
 		desc.height = entry->bmHeight;
 		desc.depth = 1;

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -258,6 +258,8 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 			texFormat = Draw::DataFormat::A4R4G4B4_UNORM_PACK16;
 		else if (draw_->GetDataFormatSupport(Draw::DataFormat::B4G4R4A4_UNORM_PACK16) & FMT_TEXTURE)
 			texFormat = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		else if (draw_->GetDataFormatSupport(Draw::DataFormat::R4G4B4A4_UNORM_PACK16) & FMT_TEXTURE)
+			texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 		else
 			texFormat = Draw::DataFormat::R8G8B8A8_UNORM;
 
@@ -275,7 +277,7 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 				}
 			}
 			desc.initData.push_back((uint8_t *)bitmapData32);
-		} else if (texFormat == Draw::DataFormat::B4G4R4A4_UNORM_PACK16) {
+		} else if (texFormat == Draw::DataFormat::B4G4R4A4_UNORM_PACK16 || texFormat == Draw::DataFormat::R4G4B4A4_UNORM_PACK16) {
 			bitmapData16 = new uint16_t[entry->bmWidth * entry->bmHeight];
 			for (int y = 0; y < entry->bmHeight; y++) {
 				for (int x = 0; x < entry->bmWidth; x++) {

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -256,10 +256,10 @@ void TextDrawerWin32::DrawString(DrawBuffer &target, const char *str, float x, f
 		// For our purposes these are equivalent, so just choose the supported one. D3D can emulate them.
 		if (draw_->GetDataFormatSupport(Draw::DataFormat::A4R4G4B4_UNORM_PACK16) & FMT_TEXTURE)
 			texFormat = Draw::DataFormat::A4R4G4B4_UNORM_PACK16;
-		else if (draw_->GetDataFormatSupport(Draw::DataFormat::B4G4R4A4_UNORM_PACK16) & FMT_TEXTURE)
-			texFormat = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
 		else if (draw_->GetDataFormatSupport(Draw::DataFormat::R4G4B4A4_UNORM_PACK16) & FMT_TEXTURE)
 			texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
+		else if (draw_->GetDataFormatSupport(Draw::DataFormat::B4G4R4A4_UNORM_PACK16) & FMT_TEXTURE)
+			texFormat = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
 		else
 			texFormat = Draw::DataFormat::R8G8B8A8_UNORM;
 

--- a/ext/native/thin3d/DataFormatGL.cpp
+++ b/ext/native/thin3d/DataFormatGL.cpp
@@ -64,29 +64,6 @@ bool Thin3DFormatToFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuint 
 		alignment = 16;
 		break;
 
-#ifndef USING_GLES2
-	case DataFormat::A4R4G4B4_UNORM_PACK16:
-		internalFormat = GL_RGBA;
-		format = GL_RGBA;
-		type = GL_UNSIGNED_SHORT_4_4_4_4_REV;
-		alignment = 2;
-		break;
-
-	case DataFormat::R5G6B5_UNORM_PACK16:
-		internalFormat = GL_RGB;
-		format = GL_RGB;
-		type = GL_UNSIGNED_SHORT_5_6_5_REV;
-		alignment = 2;
-		break;
-
-	case DataFormat::A1R5G5B5_UNORM_PACK16:
-		internalFormat = GL_RGBA;
-		format = GL_RGBA;
-		type = GL_UNSIGNED_SHORT_1_5_5_5_REV;
-		alignment = 2;
-		break;
-#endif
-
 	default:
 		return false;
 	}

--- a/ext/native/thin3d/DataFormatGL.cpp
+++ b/ext/native/thin3d/DataFormatGL.cpp
@@ -57,6 +57,13 @@ bool Thin3DFormatToFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuint 
 		alignment = 2;
 		break;
 
+	case DataFormat::R32G32B32A32_FLOAT:
+		internalFormat = GL_RGBA32F;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+
 #ifndef USING_GLES2
 	case DataFormat::A4R4G4B4_UNORM_PACK16:
 		internalFormat = GL_RGBA;

--- a/ext/native/thin3d/DataFormatGL.cpp
+++ b/ext/native/thin3d/DataFormatGL.cpp
@@ -36,21 +36,21 @@ bool Thin3DFormatToFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuint 
 		alignment = 1;
 		break;
 
-	case DataFormat::B4G4R4A4_UNORM_PACK16:
+	case DataFormat::R4G4B4A4_UNORM_PACK16:
 		internalFormat = GL_RGBA;
 		format = GL_RGBA;
 		type = GL_UNSIGNED_SHORT_4_4_4_4;
 		alignment = 2;
 		break;
 
-	case DataFormat::B5G6R5_UNORM_PACK16:
+	case DataFormat::R5G6B5_UNORM_PACK16:
 		internalFormat = GL_RGB;
 		format = GL_RGB;
 		type = GL_UNSIGNED_SHORT_5_6_5;
 		alignment = 2;
 		break;
 
-	case DataFormat::B5G5R5A1_UNORM_PACK16:
+	case DataFormat::R5G5B5A1_UNORM_PACK16:
 		internalFormat = GL_RGBA;
 		format = GL_RGBA;
 		type = GL_UNSIGNED_SHORT_5_5_5_1;

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -9,6 +9,7 @@
 #include "gfx/gl_common.h"
 #include "gfx/gl_debug_log.h"
 #include "gfx_es2/gpu_features.h"
+#include "thin3d/DataFormatGL.h"
 #include "math/dataconv.h"
 #include "math/math_util.h"
 
@@ -315,7 +316,11 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 			if (!step.texture_image.data && step.texture_image.allocType != GLRAllocType::NONE)
 				Crash();
 			// For things to show in RenderDoc, need to split into glTexImage2D(..., nullptr) and glTexSubImage.
-			glTexImage2D(tex->target, step.texture_image.level, step.texture_image.internalFormat, step.texture_image.width, step.texture_image.height, 0, step.texture_image.format, step.texture_image.type, step.texture_image.data);
+
+			GLenum internalFormat, format, type;
+			int alignment;
+			Thin3DFormatToFormatAndType(step.texture_image.format, internalFormat, format, type, alignment);
+			glTexImage2D(tex->target, step.texture_image.level, internalFormat, step.texture_image.width, step.texture_image.height, 0, format, type, step.texture_image.data);
 			allocatedTextures = true;
 			if (step.texture_image.allocType == GLRAllocType::ALIGNED) {
 				FreeAlignedMemory(step.texture_image.data);
@@ -1110,7 +1115,10 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 			if (!c.texture_subimage.data)
 				Crash();
 			// For things to show in RenderDoc, need to split into glTexImage2D(..., nullptr) and glTexSubImage.
-			glTexSubImage2D(tex->target, c.texture_subimage.level, c.texture_subimage.x, c.texture_subimage.y, c.texture_subimage.width, c.texture_subimage.height, c.texture_subimage.format, c.texture_subimage.type, c.texture_subimage.data);
+			GLuint internalFormat, format, type;
+			int alignment;
+			Thin3DFormatToFormatAndType(c.texture_subimage.format, internalFormat, format, type, alignment);
+			glTexSubImage2D(tex->target, c.texture_subimage.level, c.texture_subimage.x, c.texture_subimage.y, c.texture_subimage.width, c.texture_subimage.height, format, type, c.texture_subimage.data);
 			if (c.texture_subimage.allocType == GLRAllocType::ALIGNED) {
 				FreeAlignedMemory(c.texture_subimage.data);
 			} else if (c.texture_subimage.allocType == GLRAllocType::NEW) {

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -142,8 +142,7 @@ struct GLRRenderData {
 		} texture;
 		struct {
 			GLRTexture *texture;
-			GLenum format;
-			GLenum type;
+			Draw::DataFormat format;
 			int level;
 			int x;
 			int y;
@@ -254,9 +253,7 @@ struct GLRInitStep {
 		} buffer_subdata;
 		struct {
 			GLRTexture *texture;
-			GLenum internalFormat;
-			GLenum format;
-			GLenum type;
+			Draw::DataFormat format;
 			int level;
 			int width;
 			int height;

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -525,13 +525,11 @@ public:
 	}
 
 	// Takes ownership over the data pointer and delete[]-s it.
-	void TextureImage(GLRTexture *texture, int level, int width, int height, GLenum internalFormat, GLenum format, GLenum type, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW, bool linearFilter = false) {
+	void TextureImage(GLRTexture *texture, int level, int width, int height, Draw::DataFormat format, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW, bool linearFilter = false) {
 		GLRInitStep step{ GLRInitStepType::TEXTURE_IMAGE };
 		step.texture_image.texture = texture;
 		step.texture_image.data = data;
-		step.texture_image.internalFormat = internalFormat;
 		step.texture_image.format = format;
-		step.texture_image.type = type;
 		step.texture_image.level = level;
 		step.texture_image.width = width;
 		step.texture_image.height = height;
@@ -540,13 +538,12 @@ public:
 		initSteps_.push_back(step);
 	}
 
-	void TextureSubImage(GLRTexture *texture, int level, int x, int y, int width, int height, GLenum format, GLenum type, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW) {
+	void TextureSubImage(GLRTexture *texture, int level, int x, int y, int width, int height, Draw::DataFormat format, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW) {
 		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData _data{ GLRRenderCommand::TEXTURE_SUBIMAGE };
 		_data.texture_subimage.texture = texture;
 		_data.texture_subimage.data = data;
 		_data.texture_subimage.format = format;
-		_data.texture_subimage.type = type;
 		_data.texture_subimage.level = level;
 		_data.texture_subimage.x = x;
 		_data.texture_subimage.y = y;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1213,12 +1213,10 @@ void OpenGLContext::GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) {
 uint32_t OpenGLContext::GetDataFormatSupport(DataFormat fmt) const {
 	switch (fmt) {
 	case DataFormat::B8G8R8A8_UNORM:
-		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_AUTOGEN_MIPS;
 	case DataFormat::B4G4R4A4_UNORM_PACK16:
+	case DataFormat::B5G6R5_UNORM_PACK16:
+	case DataFormat::B5G5R5A1_UNORM_PACK16:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_AUTOGEN_MIPS;  // native support
-	case DataFormat::A4R4G4B4_UNORM_PACK16:
-		// Can support this if _REV formats are supported.
-		return gl_extensions.IsGLES ? 0 : FMT_TEXTURE;
 
 	case DataFormat::R8G8B8A8_UNORM:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_INPUTLAYOUT | FMT_AUTOGEN_MIPS;

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1212,9 +1212,9 @@ void OpenGLContext::GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) {
 
 uint32_t OpenGLContext::GetDataFormatSupport(DataFormat fmt) const {
 	switch (fmt) {
-	case DataFormat::B4G4R4A4_UNORM_PACK16:
-	case DataFormat::B5G6R5_UNORM_PACK16:
-	case DataFormat::B5G5R5A1_UNORM_PACK16:
+	case DataFormat::R4G4B4A4_UNORM_PACK16:
+	case DataFormat::R5G6B5_UNORM_PACK16:
+	case DataFormat::R5G5B5A1_UNORM_PACK16:
 		return FMT_RENDERTARGET | FMT_TEXTURE | FMT_AUTOGEN_MIPS;  // native support
 
 	case DataFormat::R8G8B8A8_UNORM:

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -726,23 +726,17 @@ void OpenGLTexture::SetImageData(int x, int y, int z, int width, int height, int
 		depth_ = depth;
 	}
 
-	GLuint internalFormat;
-	GLuint format;
-	GLuint type;
-	int alignment;
-	if (!Thin3DFormatToFormatAndType(format_, internalFormat, format, type, alignment)) {
-		return;
-	}
-
 	if (stride == 0)
 		stride = width;
 
+
+	size_t alignment = DataFormatSizeInBytes(format_);
 	// Make a copy of data with stride eliminated.
 	uint8_t *texData = new uint8_t[(size_t)(width * height * alignment)];
 	for (int y = 0; y < height; y++) {
 		memcpy(texData + y * width * alignment, data + y * stride * alignment, width * alignment);
 	}
-	render_->TextureImage(tex_, level, width, height, internalFormat, format, type, texData);
+	render_->TextureImage(tex_, level, width, height, format_, texData);
 }
 
 #ifdef DEBUG_READ_PIXELS

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1212,7 +1212,6 @@ void OpenGLContext::GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) {
 
 uint32_t OpenGLContext::GetDataFormatSupport(DataFormat fmt) const {
 	switch (fmt) {
-	case DataFormat::B8G8R8A8_UNORM:
 	case DataFormat::B4G4R4A4_UNORM_PACK16:
 	case DataFormat::B5G6R5_UNORM_PACK16:
 	case DataFormat::B5G5R5A1_UNORM_PACK16:


### PR DESCRIPTION
Discovered during work on #12443 that some of our OpenGL enums had red/blue swapped in their names.

We also had some code dealing with GL formats that are not available on GLES. I removed that, to reduce the number of code paths.

GL three-part texture formats are very confusing so I changed the GLRenderManager interface to take Draw::DataFormat instead. 

This should have no functional change (but will make future work easier).