### PR TITLE
Vulkan: Enable renderpass merging for all games

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -59,7 +59,6 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
 	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
 	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
-	CheckSetting(iniFile, gameID, "RenderPassMerge", &flags_.RenderPassMerge);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);
 	CheckSetting(iniFile, gameID, "YugiohSaveFix", &flags_.YugiohSaveFix);
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -59,7 +59,6 @@ struct CompatFlags {
 	bool DisableAccurateDepth;
 	bool MGS2AcidHack;
 	bool SonicRivalsHack;
-	bool RenderPassMerge;
 	bool BlockTransferAllowCreateFB;
 	bool YugiohSaveFix;
 	bool ForceUMDDelay;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -485,8 +485,9 @@ void GPU_Vulkan::InitDeviceObjects() {
 		hacks |= QUEUE_HACK_MGS2_ACID;
 	if (PSP_CoreParameter().compat.flags().SonicRivalsHack)
 		hacks |= QUEUE_HACK_SONIC;
-	if (PSP_CoreParameter().compat.flags().RenderPassMerge)
-		hacks |= QUEUE_HACK_RENDERPASS_MERGE;
+
+	// Always on.
+	hacks |= QUEUE_HACK_RENDERPASS_MERGE;
 
 	if (hacks) {
 		rm->GetQueueRunner()->EnableHacks(hacks);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -648,42 +648,6 @@ ULAS42214 = true
 ULJS19054 = true
 NPJH50184 = true
 
-[RenderPassMerge]
-UCJS10114 = true
-UCKS45084 = true
-# GOW : Ghost of Sparta
-UCUS98737 = true
-UCAS40323 = true
-NPHG00092 = true
-NPEG00044 = true
-NPEG00045 = true
-NPJG00120 = true
-NPUG80508 = true
-UCJS10114 = true
-UCES01401 = true
-UCES01473 = true
-# GOW : Ghost of Sparta Demo
-NPEG90035 = true
-NPUG70125 = true
-NPJG90095 = true
-# GOW : Chains Of Olympus
-UCAS40198 = true
-UCUS98653 = true
-UCES00842 = true
-ULJM05438 = true
-ULJM05348 = true
-UCKS45084 = true
-NPUG80325 = true
-NPEG00023 = true
-NPHG00027 = true
-NPHG00028 = true
-NPJH50170 = true
-UCET00844 = true
-# GOW: Chains of Olympus Demo
-UCUS98705 = true
-UCED00971 = true
-UCUS98713 = true
-
 [ForceSoftwareRenderer]
 # Darkstalkers
 ULES00016 = true

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -495,8 +495,12 @@ void DrawBuffer::DrawTextRect(int font, const char *text, float x, float y, floa
 // ROTATE_* doesn't yet work right.
 void DrawBuffer::DrawText(int font, const char *text, float x, float y, Color color, int align) {
 	// rough estimate
-	if (count_ + strlen(text) * 6 > MAX_VERTS) {
+	size_t textLen = strlen(text);
+	if (count_ + textLen * 6 > MAX_VERTS) {
 		Flush(true);
+		if (textLen * 6 >= MAX_VERTS) {
+			textLen = std::min(MAX_VERTS / 6 - 10, (int)textLen);
+		}
 	}
 
 	const AtlasFont &atlasfont = *atlas->fonts[font];
@@ -508,14 +512,14 @@ void DrawBuffer::DrawText(int font, const char *text, float x, float y, Color co
 	}
 
 	if (align & ROTATE_90DEG_LEFT) {
-		x -= atlasfont.ascend*fontscaley;
+		x -= atlasfont.ascend * fontscaley;
 		// y += h;
+	} else {
+		y += atlasfont.ascend * fontscaley;
 	}
-	else
-		y += atlasfont.ascend*fontscaley;
 	float sx = x;
 	UTF8 utf(text);
-	while (true) {
+	for (size_t i = 0; i < textLen; i++) {
 		if (utf.end())
 			break;
 		cval = utf.next();

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -469,7 +469,7 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 			break;
 		}
 
-		if (profile) {
+		if (profile && profile->timestampDescriptions.size() + 1 < MAX_TIMESTAMP_QUERIES) {
 			vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, profile->queryPool, (uint32_t)profile->timestampDescriptions.size());
 			profile->timestampDescriptions.push_back(StepToString(step));
 		}

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -789,11 +789,13 @@ void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 					if (steps[j]->copy.src == fb || steps[j]->copy.dst == fb) {
 						goto done_fb;
 					}
+					touchedFramebuffers.insert(steps[j]->copy.dst);
 					break;
 				case VKRStepType::BLIT:
 					if (steps[j]->blit.src == fb || steps[j]->blit.dst == fb) {
 						goto done_fb;
 					}
+					touchedFramebuffers.insert(steps[j]->blit.dst);
 					break;
 				case VKRStepType::READBACK:
 					// Not sure this has much effect, when executed READBACK is always the last step

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -85,6 +85,10 @@ enum class VKRRunType {
 	SYNC,
 };
 
+enum {
+	MAX_TIMESTAMP_QUERIES = 128,
+};
+
 class VulkanRenderManager {
 public:
 	VulkanRenderManager(VulkanContext *vulkan);
@@ -298,10 +302,6 @@ private:
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
-
-	enum {
-		MAX_TIMESTAMP_QUERIES = 256,
-	};
 
 	// Submission time state
 	int curWidth_ = -1;


### PR DESCRIPTION
Was introduced in 1.9 for GoW games, but some other games can also benefit (for example Star Wars - The Force Unleashed).

This should have no visible side effects if it's correct (which I believe it is), so why not just enable it globally. If we do find problems with this, they should be fixed instead of disabling it again.