### PR TITLE
Do not assert in Discord::Shutdown

### DIFF
--- a/UI/DiscordIntegration.cpp
+++ b/UI/DiscordIntegration.cpp
@@ -64,11 +64,12 @@ void Discord::Init() {
 }
 
 void Discord::Shutdown() {
-	assert(initialized_);
+	if (initialized_) {
 #ifdef ENABLE_DISCORD
-	Discord_Shutdown();
+		Discord_Shutdown();
 #endif
-	initialized_ = false;
+		initialized_ = false;
+	}
 }
 
 void Discord::Update() {


### PR DESCRIPTION
`Discord::Shutdown` runs on app exit unconditionally, and thus it's valid to try to call it even when Discord RPC is not running.