### PR TITLE
Allow tilt input on Z instead of X

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -857,7 +857,7 @@ static ConfigSetting controlSettings[] = {
 #ifdef MOBILE_DEVICE
 	ConfigSetting("TiltBaseX", &g_Config.fTiltBaseX, 0.0f, true, true),
 	ConfigSetting("TiltBaseY", &g_Config.fTiltBaseY, 0.0f, true, true),
-	ConfigSetting("TiltVertical", &g_Config.TiltVertical, false, true, true),
+	ConfigSetting("TiltOrientation", &g_Config.iTiltOrientation, 0, true, true),
 	ConfigSetting("InvertTiltX", &g_Config.bInvertTiltX, false, true, true),
 	ConfigSetting("InvertTiltY", &g_Config.bInvertTiltY, true, true, true),
 	ConfigSetting("TiltSensitivityX", &g_Config.iTiltSensitivityX, 100, true, true),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -857,6 +857,7 @@ static ConfigSetting controlSettings[] = {
 #ifdef MOBILE_DEVICE
 	ConfigSetting("TiltBaseX", &g_Config.fTiltBaseX, 0.0f, true, true),
 	ConfigSetting("TiltBaseY", &g_Config.fTiltBaseY, 0.0f, true, true),
+	ConfigSetting("TiltVertical", &g_Config.TiltVertical, false, true, true),
 	ConfigSetting("InvertTiltX", &g_Config.bInvertTiltX, false, true, true),
 	ConfigSetting("InvertTiltY", &g_Config.bInvertTiltY, true, true, true),
 	ConfigSetting("TiltSensitivityX", &g_Config.iTiltSensitivityX, 100, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -266,6 +266,8 @@ public:
 	//the base x and y tilt. this inclination is treated as (0,0) and the tilt input
 	//considers this orientation to be equal to no movement of the analog stick.
 	float fTiltBaseX, fTiltBaseY;
+	//tilt vertically will use Z accelerometer axis as X (X would require phone on flat plane)
+	bool TiltVertical;
 	//whether the x axes and y axes should invert directions (left becomes right, top becomes bottom.)
 	bool bInvertTiltX, bInvertTiltY;
 	//the sensitivity of the tilt in the x direction

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -266,8 +266,7 @@ public:
 	//the base x and y tilt. this inclination is treated as (0,0) and the tilt input
 	//considers this orientation to be equal to no movement of the analog stick.
 	float fTiltBaseX, fTiltBaseY;
-	//tilt vertically will use Z accelerometer axis as X (X would require phone on flat plane)
-	bool TiltVertical;
+	int iTiltOrientation;
 	//whether the x axes and y axes should invert directions (left becomes right, top becomes bottom.)
 	bool bInvertTiltX, bInvertTiltY;
 	//the sensitivity of the tilt in the x direction

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1266,7 +1266,10 @@ bool NativeAxis(const AxisInput &axis) {
 	// see [http://developer.android.com/guide/topics/sensors/sensors_overview.html] for details
 	bool portrait = dp_yres > dp_xres;
 	switch (axis.axisId) {
+		//TODO: make this generic.
 		case JOYSTICK_AXIS_ACCELEROMETER_X:
+			if (g_Config.TiltVertical) // use Z axis instead
+				return false;
 			if (portrait) {
 				currentTilt.x_ = axis.value;
 			} else {
@@ -1283,9 +1286,14 @@ bool NativeAxis(const AxisInput &axis) {
 			break;
 
 		case JOYSTICK_AXIS_ACCELEROMETER_Z:
-			//don't handle this now as only landscape is enabled.
-			//TODO: make this generic.
-			return false;
+			if (!g_Config.TiltVertical) // use X axis instead
+				return false;
+			if (portrait) {
+				currentTilt.x_ = axis.value;
+			} else {
+				currentTilt.y_ = axis.value;
+			}
+			break;
 			
 		case JOYSTICK_AXIS_OUYA_UNKNOWN1:
 		case JOYSTICK_AXIS_OUYA_UNKNOWN2:

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1260,6 +1260,13 @@ bool NativeAxis(const AxisInput &axis) {
 	// This is static, since we need to remember where we last were (in terms of orientation)
 	static Tilt currentTilt;
 
+	// tilt on x or y?
+	static bool TiltVertical;
+	if (g_Config.iTiltOrientation == 0)
+		TiltVertical = false;
+	else if (g_Config.iTiltOrientation == 1)
+		TiltVertical = true;
+
 	// x and y are flipped if we are in landscape orientation. The events are
 	// sent with respect to the portrait coordinate system, while we
 	// take all events in landscape.
@@ -1268,8 +1275,12 @@ bool NativeAxis(const AxisInput &axis) {
 	switch (axis.axisId) {
 		//TODO: make this generic.
 		case JOYSTICK_AXIS_ACCELEROMETER_X:
-			if (g_Config.TiltVertical) // use Z axis instead
-				return false;
+			if (TiltVertical) {
+				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
+					TiltVertical = false;
+				else
+					return false; // Tilt on Z instead
+			}
 			if (portrait) {
 				currentTilt.x_ = axis.value;
 			} else {
@@ -1286,12 +1297,16 @@ bool NativeAxis(const AxisInput &axis) {
 			break;
 
 		case JOYSTICK_AXIS_ACCELEROMETER_Z:
-			if (!g_Config.TiltVertical) // use X axis instead
-				return false;
+			if (!TiltVertical) {
+				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
+					TiltVertical = true;
+				else
+					return false; // Tilt on X instead
+			}
 			if (portrait) {
-				currentTilt.x_ = axis.value;
+				currentTilt.x_ = -axis.value;
 			} else {
-				currentTilt.y_ = axis.value;
+				currentTilt.y_ = -axis.value;
 			}
 			break;
 			

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1261,11 +1261,11 @@ bool NativeAxis(const AxisInput &axis) {
 	static Tilt currentTilt;
 
 	// tilt on x or y?
-	static bool TiltVertical;
+	static bool verticalTilt;
 	if (g_Config.iTiltOrientation == 0)
-		TiltVertical = false;
+		verticalTilt = false;
 	else if (g_Config.iTiltOrientation == 1)
-		TiltVertical = true;
+		verticalTilt = true;
 
 	// x and y are flipped if we are in landscape orientation. The events are
 	// sent with respect to the portrait coordinate system, while we
@@ -1275,9 +1275,9 @@ bool NativeAxis(const AxisInput &axis) {
 	switch (axis.axisId) {
 		//TODO: make this generic.
 		case JOYSTICK_AXIS_ACCELEROMETER_X:
-			if (TiltVertical) {
+			if (verticalTilt) {
 				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
-					TiltVertical = false;
+					verticalTilt = false;
 				else
 					return false; // Tilt on Z instead
 			}
@@ -1297,9 +1297,9 @@ bool NativeAxis(const AxisInput &axis) {
 			break;
 
 		case JOYSTICK_AXIS_ACCELEROMETER_Z:
-			if (!TiltVertical) {
+			if (!verticalTilt) {
 				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
-					TiltVertical = true;
+					verticalTilt = true;
 				else
 					return false; // Tilt on X instead
 			}

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -35,7 +35,8 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(new ItemHeader(co->T("Invert Axes")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltX, co->T("Invert Tilt along X axis")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltY, co->T("Invert Tilt along Y axis")));
-	settings->Add(new CheckBox(&g_Config.TiltVertical, co->T("Tilt along Z axis instead of X")));
+	static const char* tiltMode[] = { "Screen parallel to ground", "Screen orthogonal to ground", "Auto-switch" };
+	settings->Add(new PopupMultiChoice(&g_Config.iTiltOrientation, co->T("Base tilt position"), tiltMode, 0, ARRAY_SIZE(tiltMode), co->GetName(), screenManager()));
 
 	settings->Add(new ItemHeader(co->T("Sensitivity")));
 	//TODO: allow values greater than 100? I'm not sure if that's needed.

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -35,7 +35,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(new ItemHeader(co->T("Invert Axes")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltX, co->T("Invert Tilt along X axis")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltY, co->T("Invert Tilt along Y axis")));
-	static const char* tiltMode[] = { "Screen parallel to ground", "Screen orthogonal to ground", "Auto-switch" };
+	static const char* tiltMode[] = { "Screen aligned to ground", "Screen at right angle to ground", "Auto-switch" };
 	settings->Add(new PopupMultiChoice(&g_Config.iTiltOrientation, co->T("Base tilt position"), tiltMode, 0, ARRAY_SIZE(tiltMode), co->GetName(), screenManager()));
 
 	settings->Add(new ItemHeader(co->T("Sensitivity")));

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -35,6 +35,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(new ItemHeader(co->T("Invert Axes")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltX, co->T("Invert Tilt along X axis")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltY, co->T("Invert Tilt along Y axis")));
+	settings->Add(new CheckBox(&g_Config.TiltVertical, co->T("Tilt along Z axis instead of X")));
 
 	settings->Add(new ItemHeader(co->T("Sensitivity")));
 	//TODO: allow values greater than 100? I'm not sure if that's needed.

--- a/UI/TiltEventProcessor.cpp
+++ b/UI/TiltEventProcessor.cpp
@@ -131,6 +131,7 @@ void TiltEventProcessor::GenerateDPadEvent(const Tilt &tilt) {
 	case 6: ctrlMask |= CTRL_UP; break;
 	case 7: ctrlMask |= CTRL_UP | CTRL_RIGHT; break;
 	}
+	ctrlMask &= ~__CtrlPeekButtons();
 	__CtrlButtonDown(ctrlMask);
 	tiltButtonsDown |= ctrlMask;
 }
@@ -153,8 +154,9 @@ void TiltEventProcessor::GenerateActionButtonEvent(const Tilt &tilt) {
 	}
 
 	int direction = (int)(floorf((atan2f(tilt.y_, tilt.x_) / (2.0f * (float)M_PI) * 4.0f) + 0.5f)) & 3;
-	__CtrlButtonDown(buttons[direction]);
-	tiltButtonsDown |= buttons[direction];
+	int downButtons = buttons[direction] & ~__CtrlPeekButtons();
+	__CtrlButtonDown(downButtons);
+	tiltButtonsDown |= downButtons;
 }
 
 void TiltEventProcessor::GenerateTriggerButtonEvent(const Tilt &tilt) {
@@ -173,6 +175,7 @@ void TiltEventProcessor::GenerateTriggerButtonEvent(const Tilt &tilt) {
 		upButtons = CTRL_LTRIGGER;
 	}
 
+	downButtons &= ~__CtrlPeekButtons();
 	__CtrlButtonUp(tiltButtonsDown & upButtons);
 	__CtrlButtonDown(downButtons);
 	tiltButtonsDown = (tiltButtonsDown & ~upButtons) | downButtons;

--- a/UI/TiltEventProcessor.cpp
+++ b/UI/TiltEventProcessor.cpp
@@ -106,12 +106,12 @@ void TiltEventProcessor::GenerateDPadEvent(const Tilt &tilt) {
 	static const int dir[4] = {CTRL_RIGHT, CTRL_DOWN, CTRL_LEFT, CTRL_UP};
 
 	if (tilt.x_ == 0) {
-		__CtrlButtonUp(CTRL_RIGHT | CTRL_LEFT);
+		__CtrlButtonUp(tiltButtonsDown & (CTRL_RIGHT | CTRL_LEFT));
 		tiltButtonsDown &= ~(CTRL_LEFT | CTRL_RIGHT);
 	}
 
 	if (tilt.y_ == 0) {
-		__CtrlButtonUp(CTRL_UP | CTRL_DOWN);
+		__CtrlButtonUp(tiltButtonsDown & (CTRL_UP | CTRL_DOWN));
 		tiltButtonsDown &= ~(CTRL_UP | CTRL_DOWN);
 	}
 
@@ -131,7 +131,6 @@ void TiltEventProcessor::GenerateDPadEvent(const Tilt &tilt) {
 	case 6: ctrlMask |= CTRL_UP; break;
 	case 7: ctrlMask |= CTRL_UP | CTRL_RIGHT; break;
 	}
-
 	__CtrlButtonDown(ctrlMask);
 	tiltButtonsDown |= ctrlMask;
 }
@@ -140,12 +139,12 @@ void TiltEventProcessor::GenerateActionButtonEvent(const Tilt &tilt) {
 	static const int buttons[4] = {CTRL_CIRCLE, CTRL_CROSS, CTRL_SQUARE, CTRL_TRIANGLE};
 
 	if (tilt.x_ == 0) {
-		__CtrlButtonUp(CTRL_SQUARE | CTRL_CIRCLE);
+		__CtrlButtonUp(tiltButtonsDown & (CTRL_SQUARE | CTRL_CIRCLE));
 		tiltButtonsDown &= ~(CTRL_SQUARE | CTRL_CIRCLE);
 	}
 
 	if (tilt.y_ == 0) {
-		__CtrlButtonUp(CTRL_TRIANGLE | CTRL_CROSS);
+		__CtrlButtonUp(tiltButtonsDown & (CTRL_TRIANGLE | CTRL_CROSS));
 		tiltButtonsDown &= ~(CTRL_TRIANGLE | CTRL_CROSS);
 	}
 
@@ -161,8 +160,10 @@ void TiltEventProcessor::GenerateActionButtonEvent(const Tilt &tilt) {
 void TiltEventProcessor::GenerateTriggerButtonEvent(const Tilt &tilt) {
 	u32 upButtons = 0;
 	u32 downButtons = 0;
-	// KISS, let's only look at X.  Expect deadzone to already be applied.
-	if (tilt.x_ == 0.0f) {
+	// Y axis for both
+	if (tilt.y_ < 0.0f) {
+		downButtons = CTRL_LTRIGGER | CTRL_RTRIGGER;
+	} else if (tilt.x_ == 0.0f) {
 		upButtons = CTRL_LTRIGGER | CTRL_RTRIGGER;
 	} else if (tilt.x_ < 0.0f) {
 		downButtons = CTRL_LTRIGGER;
@@ -172,7 +173,7 @@ void TiltEventProcessor::GenerateTriggerButtonEvent(const Tilt &tilt) {
 		upButtons = CTRL_LTRIGGER;
 	}
 
-	__CtrlButtonUp(upButtons);
+	__CtrlButtonUp(tiltButtonsDown & upButtons);
 	__CtrlButtonDown(downButtons);
 	tiltButtonsDown = (tiltButtonsDown & ~upButtons) | downButtons;
 }


### PR DESCRIPTION
By using Z accelerometer axis it's possible to play when the phone screen is not parallel to the ground but rather perpendicular to it, making it easier to controll it from standing or sitting position.

I am totally lost about how to name such an option tho'.

Edit: Fixes #10515 and fixes #12620