### PR TITLE
GE:Bugfix of some backend.

### DIFF
--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -43,7 +43,7 @@
 
 namespace DX9 {
 
-const D3DPRIMITIVETYPE glprim[8] = {
+const D3DPRIMITIVETYPE d3d9prim[8] = {
 	D3DPT_POINTLIST,
 	D3DPT_LINELIST,
 	D3DPT_LINESTRIP,
@@ -499,9 +499,9 @@ rotateVBO:
 			device_->SetVertexDeclaration(pHardwareVertexDecl);
 			if (vb_ == NULL) {
 				if (useElements) {
-					device_->DrawIndexedPrimitiveUP(glprim[prim], 0, maxIndex + 1, D3DPrimCount(glprim[prim], vertexCount), decIndex, D3DFMT_INDEX16, decoded, dec_->GetDecVtxFmt().stride);
+					device_->DrawIndexedPrimitiveUP(d3d9prim[prim], 0, maxIndex + 1, D3DPrimCount(d3d9prim[prim], vertexCount), decIndex, D3DFMT_INDEX16, decoded, dec_->GetDecVtxFmt().stride);
 				} else {
-					device_->DrawPrimitiveUP(glprim[prim], D3DPrimCount(glprim[prim], vertexCount), decoded, dec_->GetDecVtxFmt().stride);
+					device_->DrawPrimitiveUP(d3d9prim[prim], D3DPrimCount(d3d9prim[prim], vertexCount), decoded, dec_->GetDecVtxFmt().stride);
 				}
 			} else {
 				device_->SetStreamSource(0, vb_, 0, dec_->GetDecVtxFmt().stride);
@@ -509,9 +509,9 @@ rotateVBO:
 				if (useElements) {
 					device_->SetIndices(ib_);
 
-					device_->DrawIndexedPrimitive(glprim[prim], 0, 0, maxIndex + 1, 0, D3DPrimCount(glprim[prim], vertexCount));
+					device_->DrawIndexedPrimitive(d3d9prim[prim], 0, 0, maxIndex + 1, 0, D3DPrimCount(d3d9prim[prim], vertexCount));
 				} else {
-					device_->DrawPrimitive(glprim[prim], 0, D3DPrimCount(glprim[prim], vertexCount));
+					device_->DrawPrimitive(d3d9prim[prim], 0, D3DPrimCount(d3d9prim[prim], vertexCount));
 				}
 			}
 		}
@@ -568,9 +568,9 @@ rotateVBO:
 
 			device_->SetVertexDeclaration(transformedVertexDecl_);
 			if (drawIndexed) {
-				device_->DrawIndexedPrimitiveUP(glprim[prim], 0, maxIndex, D3DPrimCount(glprim[prim], numTrans), inds, D3DFMT_INDEX16, drawBuffer, sizeof(TransformedVertex));
+				device_->DrawIndexedPrimitiveUP(d3d9prim[prim], 0, maxIndex, D3DPrimCount(d3d9prim[prim], numTrans), inds, D3DFMT_INDEX16, drawBuffer, sizeof(TransformedVertex));
 			} else {
-				device_->DrawPrimitiveUP(glprim[prim], D3DPrimCount(glprim[prim], numTrans), drawBuffer, sizeof(TransformedVertex));
+				device_->DrawPrimitiveUP(d3d9prim[prim], D3DPrimCount(d3d9prim[prim], numTrans), drawBuffer, sizeof(TransformedVertex));
 			}
 		} else if (result.action == SW_CLEAR) {
 			u32 clearColor = result.color;

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -327,8 +327,9 @@ void ShaderManagerDX9::VSUpdateUniforms(u64 dirtyUniforms) {
 		Matrix4x4 flippedMatrix;
 		memcpy(&flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
 
-		const bool invertedY = gstate_c.vpHeight < 0;
-		if (!invertedY) {
+		// Invert value because d3d uses a different coordinate system from opengl.
+		const bool invertedY = !(gstate_c.vpHeight < 0);
+		if (invertedY) {
 			flippedMatrix[1] = -flippedMatrix[1];
 			flippedMatrix[5] = -flippedMatrix[5];
 			flippedMatrix[9] = -flippedMatrix[9];
@@ -342,7 +343,7 @@ void ShaderManagerDX9::VSUpdateUniforms(u64 dirtyUniforms) {
 			flippedMatrix[12] = -flippedMatrix[12];
 		}
 
-		ConvertProjMatrixToD3D(flippedMatrix, invertedX, !invertedY);
+		ConvertProjMatrixToD3D(flippedMatrix, invertedX, invertedY);
 
 		VSSetMatrix(CONST_VS_PROJ, flippedMatrix.getReadPtr());
 	}

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -342,7 +342,7 @@ void ShaderManagerDX9::VSUpdateUniforms(u64 dirtyUniforms) {
 			flippedMatrix[12] = -flippedMatrix[12];
 		}
 
-		ConvertProjMatrixToD3D(flippedMatrix, invertedX, invertedY);
+		ConvertProjMatrixToD3D(flippedMatrix, invertedX, !invertedY);
 
 		VSSetMatrix(CONST_VS_PROJ, flippedMatrix.getReadPtr());
 	}

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -562,21 +562,17 @@ rotateVBO:
 		if (vertexCount > 0x10000 / 3)
 			vertexCount = 0x10000 / 3;
 #endif
-		// Update viewport width & height before ST.
-		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
-			gstate_c.vpWidth = gstate.getViewportXScale() * 2.0f;
-			gstate_c.vpHeight = gstate.getViewportYScale() * 2.0f;
-		}
+		if (textureNeedsApply)
+			textureCache_->ApplyTexture();
+
+		// Should update draw state before ST.
+		ApplyDrawState(prim);
 
 		SoftwareTransform(
 			prim, vertexCount,
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),
 			maxIndex, drawBuffer, numTrans, drawIndexed, &params, &result);
 
-		if (textureNeedsApply)
-			textureCache_->ApplyTexture();
-
-		ApplyDrawState(prim);
 		ApplyDrawStateLate(result.setStencil, result.stencilValue);
 
 		LinkedShader *program = shaderManager_->ApplyFragmentShader(vsid, vshader, lastVType_, prim);

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -562,6 +562,12 @@ rotateVBO:
 		if (vertexCount > 0x10000 / 3)
 			vertexCount = 0x10000 / 3;
 #endif
+		// Update viewport width & height before ST.
+		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
+			gstate_c.vpWidth = gstate.getViewportXScale() * 2.0f;
+			gstate_c.vpHeight = gstate.getViewportYScale() * 2.0f;
+		}
+
 		SoftwareTransform(
 			prim, vertexCount,
 			dec_->VertexType(), inds, GE_VTYPE_IDX_16BIT, dec_->GetDecVtxFmt(),

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -895,6 +895,12 @@ void DrawEngineVulkan::DoFlush() {
 		params.allowSeparateAlphaClear = false;
 		params.provokeFlatFirst = true;
 
+		// Update viewport width & height before ST.
+		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
+			gstate_c.vpWidth = gstate.getViewportXScale() * 2.0f;
+			gstate_c.vpHeight = gstate.getViewportYScale() * 2.0f;
+		}
+
 		int maxIndex = indexGen.MaxIndex();
 		SoftwareTransform(
 			prim, indexGen.VertexCount(),


### PR DESCRIPTION
This helps #12529.
List the graphics of all backend here:
#### `Before:`

- #### `opengl & vulkan:broken`

![1](https://user-images.githubusercontent.com/3080636/71621357-cb93a480-2c09-11ea-867b-7914abccaeed.jpg)

- #### `D3D9:has an incorrect offset`

![2](https://user-images.githubusercontent.com/3080636/71621360-d4847600-2c09-11ea-8ebc-99c2a2a28f7f.jpg)

- #### `D3D11:normal`

![3](https://user-images.githubusercontent.com/3080636/71621369-e36b2880-2c09-11ea-84a7-05694a76895b.jpg)

#### `After:`
Do normal thing as d3d11.