### PR TITLE
SDL: Ignore audio switch events in first second

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -910,7 +910,9 @@ int main(int argc, char *argv[]) {
 					if (!name) {
 						break;
 					}
-					if (g_Config.bAutoAudioDevice || g_Config.sAudioDevice == name) {
+					// Don't start auto switching for a second, because some devices init on start.
+					bool doAutoSwitch = g_Config.bAutoAudioDevice && framecount > 60;
+					if (doAutoSwitch || g_Config.sAudioDevice == name) {
 						StopSDLAudioDevice();
 						InitSDLAudioDevice(name ? name : "");
 					}


### PR DESCRIPTION
We get new device events right on start, which makes auto switch away from the preferred / most recent device otherwise.  Fixes #12536.

-[Unknown]