### PR TITLE
UMD switch: Code clean up and fix a out of range error in thread queue.

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -270,8 +270,7 @@ std::string MetaFileSystem::NormalizePrefix(std::string prefix) const {
 	return prefix;
 }
 
-void MetaFileSystem::Mount(std::string prefix, IFileSystem *system)
-{
+void MetaFileSystem::Mount(std::string prefix, IFileSystem *system) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	MountPoint x;
 	x.prefix = prefix;
@@ -279,8 +278,7 @@ void MetaFileSystem::Mount(std::string prefix, IFileSystem *system)
 	fileSystems.push_back(x);
 }
 
-void MetaFileSystem::Unmount(std::string prefix, IFileSystem *system)
-{
+void MetaFileSystem::Unmount(std::string prefix, IFileSystem *system) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	MountPoint x;
 	x.prefix = prefix;
@@ -288,10 +286,13 @@ void MetaFileSystem::Unmount(std::string prefix, IFileSystem *system)
 	fileSystems.erase(std::remove(fileSystems.begin(), fileSystems.end(), x), fileSystems.end());
 }
 
-void MetaFileSystem::Remount(IFileSystem *oldSystem, IFileSystem *newSystem) {
-	for (auto it = fileSystems.begin(); it != fileSystems.end(); ++it) {
-		if (it->system == oldSystem) {
-			it->system = newSystem;
+void MetaFileSystem::Remount(std::string prefix, IFileSystem *newSystem, bool delOldSystem) {
+	std::lock_guard<std::recursive_mutex> guard(lock);
+	for (auto &it : fileSystems) {
+		if (it.prefix == prefix) {
+			if (delOldSystem)
+				delete it.system;
+			it.system = newSystem;
 		}
 	}
 }

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -286,15 +286,25 @@ void MetaFileSystem::Unmount(std::string prefix, IFileSystem *system) {
 	fileSystems.erase(std::remove(fileSystems.begin(), fileSystems.end(), x), fileSystems.end());
 }
 
-void MetaFileSystem::Remount(std::string prefix, IFileSystem *newSystem, bool delOldSystem) {
+void MetaFileSystem::Remount(std::string prefix, IFileSystem *newSystem) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
+	IFileSystem *oldSystem = nullptr;
 	for (auto &it : fileSystems) {
 		if (it.prefix == prefix) {
-			if (delOldSystem)
-				delete it.system;
+			oldSystem = it.system;
 			it.system = newSystem;
 		}
 	}
+
+	bool delOldSystem = true;
+	for (auto &it : fileSystems) {
+		if (it.system == oldSystem) {
+			delOldSystem = false;
+		}
+	}
+
+	if (delOldSystem)
+		delete oldSystem;
 }
 
 IFileSystem *MetaFileSystem::GetSystemFromFilename(const std::string &filename) {

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -52,7 +52,7 @@ public:
 
 	void Mount(std::string prefix, IFileSystem *system);
 	void Unmount(std::string prefix, IFileSystem *system);
-	void Remount(IFileSystem *oldSystem, IFileSystem *newSystem);
+	void Remount(std::string prefix, IFileSystem *newSystem, bool delOldSystem = true);
 
 	IFileSystem *GetSystem(const std::string &prefix);
 	IFileSystem *GetSystemFromFilename(const std::string &filename);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -52,7 +52,7 @@ public:
 
 	void Mount(std::string prefix, IFileSystem *system);
 	void Unmount(std::string prefix, IFileSystem *system);
-	void Remount(std::string prefix, IFileSystem *newSystem, bool delOldSystem = true);
+	void Remount(std::string prefix, IFileSystem *newSystem);
 
 	IFileSystem *GetSystem(const std::string &prefix);
 	IFileSystem *GetSystemFromFilename(const std::string &filename);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1977,9 +1977,6 @@ static int sceIoChangeAsyncPriority(int id, int priority) {
 		return hleLogSuccessI(SCEIO, 0);
 	}
 
-	if (priority == -1)
-		priority = KernelCurThreadPriority();
-
 	u32 error;
 	FileNode *f = __IoGetFd(id, error);
 	if (!f) {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1967,7 +1967,7 @@ static u32 sceIoChdir(const char *dirname) {
 }
 
 static int sceIoChangeAsyncPriority(int id, int priority) {
-	// priority = -1 is valid
+	// priority = -1 is valid,means the current thread'priority
 	if (priority != -1 && (priority < 0x08 || priority > 0x77)) {
 		return hleLogError(SCEIO, SCE_KERNEL_ERROR_ILLEGAL_PRIORITY, "illegal priority %d", priority);
 	}
@@ -1976,6 +1976,9 @@ static int sceIoChangeAsyncPriority(int id, int priority) {
 		asyncDefaultPriority = priority;
 		return hleLogSuccessI(SCEIO, 0);
 	}
+
+	if (priority == -1)
+		priority = KernelCurThreadPriority();
 
 	u32 error;
 	FileNode *f = __IoGetFd(id, error);

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -425,7 +425,7 @@ static int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout)
 		DEBUG_LOG(SCEIO, "sceUmdWaitDriveStatWithTimer(stat = %08x, timeout = %d): waiting", stat, timeout);
 		__UmdWaitStat(timeout);
 		umdWaitingThreads.push_back(__KernelGetCurThread());
-		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, 0, "umd stat waited with timer");
+		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, false, "umd stat waited with timer");
 		return 0;
 	} else {
 		hleReSchedule("umd stat checked");
@@ -495,45 +495,15 @@ static u32 sceUmdGetErrorStat()
 }
 
 void __UmdReplace(std::string filepath) {
-	// TODO: This should really go through Loaders, no?  What if it's an invalid file?
+	char *error = "";
+	if (!UmdReplace(filepath, error))
+		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error);
 
-	// Only get system from disc0 seems have been enough.
-	IFileSystem* currentUMD = pspFileSystem.GetSystem("disc0:");
-	IFileSystem* currentISOBlock = pspFileSystem.GetSystem("umd0:");
-	if (!currentUMD)
-		return;
-
-	FileLoader *loadedFile = ConstructFileLoader(filepath);
-
-	IFileSystem* umd2;
-	if (!loadedFile->Exists()) {
-		delete loadedFile;
-		return;
-	}
-	UpdateLoadedFile(loadedFile);
-
-	if (loadedFile->IsDirectory()) {
-		umd2 = new VirtualDiscFileSystem(&pspFileSystem, filepath);
-	} else {
-		auto bd = constructBlockDevice(loadedFile);
-		if (!bd)
-			return;
-		umd2 = new ISOFileSystem(&pspFileSystem, bd);
-		pspFileSystem.Remount(currentUMD, umd2);
-
-		if (currentUMD != currentISOBlock) {
-			// We mounted an ISO block system separately.
-			IFileSystem *iso = new ISOBlockSystem(static_cast<ISOFileSystem *>(umd2));
-			pspFileSystem.Remount(currentISOBlock, iso);
-			delete currentISOBlock;
-		}
-	}
-	delete currentUMD;
 	UMDInserted = false;
 	CoreTiming::ScheduleEvent(usToCycles(200*1000), umdInsertChangeEvent, 0); // Wait sceUmdCheckMedium call
 	// TODO Is this always correct if UMD was not activated?
 	u32 notifyArg = PSP_UMD_PRESENT | PSP_UMD_READABLE | PSP_UMD_CHANGED;
-	if (driveCBId != -1)
+	if (driveCBId != 0)
 		__KernelNotifyCallback(driveCBId, notifyArg);
 }
 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -497,7 +497,7 @@ static u32 sceUmdGetErrorStat()
 void __UmdReplace(std::string filepath) {
 	std::string error = "";
 	if (!UmdReplace(filepath, error)) {
-		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error);
+		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error.c_str());
 		return;
 	}
 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -495,7 +495,7 @@ static u32 sceUmdGetErrorStat()
 }
 
 void __UmdReplace(std::string filepath) {
-	char *error = "";
+	std::string error = "";
 	if (!UmdReplace(filepath, error)) {
 		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error);
 		return;

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -496,8 +496,10 @@ static u32 sceUmdGetErrorStat()
 
 void __UmdReplace(std::string filepath) {
 	char *error = "";
-	if (!UmdReplace(filepath, error))
+	if (!UmdReplace(filepath, error)) {
 		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error);
+		return;
+	}
 
 	UMDInserted = false;
 	CoreTiming::ScheduleEvent(usToCycles(200*1000), umdInsertChangeEvent, 0); // Wait sceUmdCheckMedium call

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -355,3 +355,37 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 	coreState = CORE_ERROR;
 	return false;
 }
+
+bool UmdReplace(std::string filepath, char *error) {
+	IFileSystem* currentUMD = pspFileSystem.GetSystem("disc0:");
+
+	if (!currentUMD) {
+		error = "has no disc";
+		return false;
+	}
+
+	FileLoader *loadedFile = ConstructFileLoader(filepath);
+
+	if (!loadedFile->Exists()) {
+		delete loadedFile;
+		sprintf(error, "%s doesn't exist", loadedFile->Path().c_str());
+		return false;
+	}
+	UpdateLoadedFile(loadedFile);
+
+	loadedFile = ResolveFileLoaderTarget(loadedFile);
+	IdentifiedFileType type = Identify_File(loadedFile);
+
+	switch (type) {
+	case IdentifiedFileType::PSP_ISO:
+	case IdentifiedFileType::PSP_ISO_NP:
+	case IdentifiedFileType::PSP_DISC_DIRECTORY:
+		ReInitMemoryForGameISO(loadedFile);
+		break;
+	default:
+		sprintf(error, "Unsupported file type: %i", type);
+		return false;
+		break;
+	}
+	return true;
+}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -356,7 +356,7 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 	return false;
 }
 
-bool UmdReplace(std::string filepath, char *error) {
+bool UmdReplace(std::string filepath, std::string &error) {
 	IFileSystem* currentUMD = pspFileSystem.GetSystem("disc0:");
 
 	if (!currentUMD) {
@@ -368,7 +368,7 @@ bool UmdReplace(std::string filepath, char *error) {
 
 	if (!loadedFile->Exists()) {
 		delete loadedFile;
-		sprintf(error, "%s doesn't exist", loadedFile->Path().c_str());
+		error = loadedFile->Path() + " doesn't exist";
 		return false;
 	}
 	UpdateLoadedFile(loadedFile);
@@ -387,7 +387,7 @@ bool UmdReplace(std::string filepath, char *error) {
 
 		break;
 	default:
-		sprintf(error, "Unsupported file type: %i", type);
+		error = "Unsupported file type:" + std::to_string((int)type);
 		return false;
 		break;
 	}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -380,7 +380,11 @@ bool UmdReplace(std::string filepath, char *error) {
 	case IdentifiedFileType::PSP_ISO:
 	case IdentifiedFileType::PSP_ISO_NP:
 	case IdentifiedFileType::PSP_DISC_DIRECTORY:
-		ReInitMemoryForGameISO(loadedFile);
+		if (!ReInitMemoryForGameISO(loadedFile)) {
+			error = "reinit memory failed";
+			return false;
+		}
+
 		break;
 	default:
 		sprintf(error, "Unsupported file type: %i", type);

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -158,3 +158,5 @@ void RegisterFileLoaderFactory(std::string name, std::unique_ptr<FileLoaderFacto
 
 // Can modify the string filename, as it calls IdentifyFile above.
 bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);
+
+bool UmdReplace(std::string filepath, char* error);

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -159,4 +159,4 @@ void RegisterFileLoaderFactory(std::string name, std::unique_ptr<FileLoaderFacto
 // Can modify the string filename, as it calls IdentifyFile above.
 bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);
 
-bool UmdReplace(std::string filepath, char* error);
+bool UmdReplace(std::string filepath, std::string &error);

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -83,7 +83,7 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 
 	IFileSystem *fileSystem = nullptr;
 	IFileSystem *blockSystem = nullptr;
-	//bool actualIso = false;
+
 	if (fileLoader->IsDirectory()) {
 		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
 		blockSystem = fileSystem;
@@ -155,8 +155,7 @@ bool ReInitMemoryForGameISO(FileLoader *fileLoader) {
 	if (fileLoader->IsDirectory()) {
 		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
 		blockSystem = fileSystem;
-	}
-	else {
+	} else {
 		auto bd = constructBlockDevice(fileLoader);
 		if (!bd)
 			return false;
@@ -166,15 +165,11 @@ bool ReInitMemoryForGameISO(FileLoader *fileLoader) {
 		blockSystem = new ISOBlockSystem(iso);
 	}
 
-	if (pspFileSystem.GetSystem("disc0:") != pspFileSystem.GetSystem("umd0:")) {
-		// We mounted an ISO block system separately.
-		pspFileSystem.Remount("umd0:", blockSystem, false);
-		pspFileSystem.Remount("umd1:", blockSystem, false);
+		pspFileSystem.Remount("umd0:", blockSystem);
+		pspFileSystem.Remount("umd1:", blockSystem);
 		pspFileSystem.Remount("umd:", blockSystem);
-	}
-	
-	pspFileSystem.Remount("disc0:", fileSystem);
-	
+		pspFileSystem.Remount("disc0:", fileSystem);
+
 	return true;
 }
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -83,7 +83,7 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 
 	IFileSystem *fileSystem = nullptr;
 	IFileSystem *blockSystem = nullptr;
-	bool actualIso = false;
+	//bool actualIso = false;
 	if (fileLoader->IsDirectory()) {
 		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
 		blockSystem = fileSystem;
@@ -142,6 +142,40 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 	if (g_RemasterMode) {
 		INFO_LOG(LOADER, "HDRemaster found, using increased memory");
 	}
+}
+
+bool ReInitMemoryForGameISO(FileLoader *fileLoader) {
+	if (!fileLoader->Exists()) {
+		return false;
+	}
+
+	IFileSystem *fileSystem = nullptr;
+	IFileSystem *blockSystem = nullptr;
+
+	if (fileLoader->IsDirectory()) {
+		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
+		blockSystem = fileSystem;
+	}
+	else {
+		auto bd = constructBlockDevice(fileLoader);
+		if (!bd)
+			return false;
+
+		ISOFileSystem *iso = new ISOFileSystem(&pspFileSystem, bd);
+		fileSystem = iso;
+		blockSystem = new ISOBlockSystem(iso);
+	}
+
+	if (pspFileSystem.GetSystem("disc0:") != pspFileSystem.GetSystem("umd0:")) {
+		// We mounted an ISO block system separately.
+		pspFileSystem.Remount("umd0:", blockSystem, false);
+		pspFileSystem.Remount("umd1:", blockSystem, false);
+		pspFileSystem.Remount("umd:", blockSystem);
+	}
+	
+	pspFileSystem.Remount("disc0:", fileSystem);
+	
+	return true;
 }
 
 void InitMemoryForGamePBP(FileLoader *fileLoader) {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -165,10 +165,10 @@ bool ReInitMemoryForGameISO(FileLoader *fileLoader) {
 		blockSystem = new ISOBlockSystem(iso);
 	}
 
-		pspFileSystem.Remount("umd0:", blockSystem);
-		pspFileSystem.Remount("umd1:", blockSystem);
-		pspFileSystem.Remount("umd:", blockSystem);
-		pspFileSystem.Remount("disc0:", fileSystem);
+	pspFileSystem.Remount("umd0:", blockSystem);
+	pspFileSystem.Remount("umd1:", blockSystem);
+	pspFileSystem.Remount("umd:", blockSystem);
+	pspFileSystem.Remount("disc0:", fileSystem);
 
 	return true;
 }

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -25,5 +25,6 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string);
 void InitMemoryForGameISO(FileLoader *fileLoader);
+bool ReInitMemoryForGameISO(FileLoader *fileLoader);
 void InitMemoryForGamePBP(FileLoader *fileLoader);
 void PSPLoaders_Shutdown();


### PR DESCRIPTION
- Moveing umd replace to loaders and  minor improvements.
~~- Fixing a out of range error when thread priority is -1.~~ Done in #12547 

Shin Sangoku Musou 6 Special calls `sceIoChangeAsyncPriority()`  with `priority = -1` after switching umd, that cause a shutting down.This game can switch umd normally after this change.