### PR TITLE
Io: Update async priority more correctly

### DIFF
--- a/Core/HLE/HLEHelperThread.cpp
+++ b/Core/HLE/HLEHelperThread.cpp
@@ -16,9 +16,11 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Common/ChunkFile.h"
+#include "Core/CoreTiming.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/HLEHelperThread.h"
+#include "Core/HLE/KernelWaitHelpers.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -89,6 +91,13 @@ bool HLEHelperThread::Stopped() {
 
 void HLEHelperThread::ChangePriority(u32 prio) {
 	KernelChangeThreadPriority(id_, prio);
+}
+
+void HLEHelperThread::Resume(WaitType waitType, SceUID uid, int result) {
+	bool res = HLEKernel::ResumeFromWait(id_, waitType, uid, result);
+	if (!res) {
+		ERROR_LOG(HLE, "Failed to wake helper thread from wait");
+	}
 }
 
 void HLEHelperThread::Forget() {

--- a/Core/HLE/HLEHelperThread.h
+++ b/Core/HLE/HLEHelperThread.h
@@ -19,6 +19,7 @@
 #include "Core/HLE/sceKernel.h"
 
 class PointerWrap;
+enum WaitType : int;
 
 class HLEHelperThread {
 public:
@@ -33,9 +34,14 @@ public:
 	void Terminate();
 	bool Stopped();
 	void ChangePriority(u32 prio);
+	void Resume(WaitType waitType, SceUID uid, int result);
 
 	// For savestates.
 	void Forget();
+
+	u32 Entry() {
+		return entry_;
+	}
 
 private:
 	void AllocEntry(u32 size);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1265,17 +1265,14 @@ static u32 sceIoGetDevType(int id) {
 
 static u32 sceIoCancel(int id)
 {
-	ERROR_LOG_REPORT(SCEIO, "UNIMPL sceIoCancel(%d)", id);
 	u32 error;
 	FileNode *f = __IoGetFd(id, error);
 	if (f) {
-		// TODO: Cancel the async operation if possible?
+		// It seems like this is unsupported for UMDs and memory sticks, based on tests.
+		return hleReportError(SCEIO, SCE_KERNEL_ERROR_UNSUP, "unimplemented or unsupported");
 	} else {
-		ERROR_LOG(SCEIO, "sceIoCancel: unknown id %d", id);
-		error = SCE_KERNEL_ERROR_BADF;
+		return hleLogError(SCEIO, SCE_KERNEL_ERROR_BADF, "invalid fd");
 	}
-
-	return error;
 }
 
 static u32 npdrmLseek(FileNode *f, s32 where, FileMove whence)

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -80,7 +80,7 @@ struct SceKernelSysClock {
 
 // TODO: Map these to PSP wait types.  Most of these are wrong.
 // remember to update the waitTypeNames array in sceKernelThread.cpp when changing these
-enum WaitType
+enum WaitType : int
 {
 	WAITTYPE_NONE         = 0,
 	WAITTYPE_SLEEP        = 1,


### PR DESCRIPTION
This fixes the case shown in #12545, but also handles reset more correctly.  It seems that the default applies at sceIoOpen (or sceIoOpenAsync).  If it's -1, it resolves to the current thread's priority each operation on newer SDK versions, otherwise just on the first one.

-[Unknown]