### PR TITLE
Qt: don't return dangling pointer

### DIFF
--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -18,12 +18,12 @@
 #include <string>
 #include "Qt/QtHost.h"
 
-const char* QtHost::SymbolMapFilename(std::string currentFilename) {
-	std::string result = currentFilename;
-	size_t dot = result.rfind('.');
-	if (dot == result.npos)
-		return (result + ".map").c_str();
+std::string QtHost::SymbolMapFilename(std::string currentFilename) {
+	size_t dot = currentFilename.rfind('.');
+	if (dot == std::string::npos)
+		currentFilename.append(".map");
+	else
+		currentFilename.replace(dot, -1, ".map");
 
-	result.replace(dot, result.npos, ".map");
-	return result.c_str();
+	return currentFilename;
 }

--- a/Qt/QtHost.h
+++ b/Qt/QtHost.h
@@ -64,13 +64,12 @@ public:
 #endif
 	}
 	virtual bool AttemptLoadSymbolMap() override {
-		return false;
-		// TODO: Make this work with Qt and threaded GL... not sure what's so broken.
-		// auto fn = SymbolMapFilename(PSP_CoreParameter().fileToStart);
-		// return g_symbolMap->LoadSymbolMap(fn);
+		auto fn = SymbolMapFilename(PSP_CoreParameter().fileToStart);
+		return g_symbolMap->LoadSymbolMap(fn.c_str());
 	}
 	void PrepareShutdown() {
-		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart));
+		auto fn = SymbolMapFilename(PSP_CoreParameter().fileToStart);
+		g_symbolMap->SaveSymbolMap(fn.c_str());
 	}
 	void SetWindowTitle(const char *message) override {
 		std::string title = std::string("PPSSPP ") + PPSSPP_GIT_VERSION;
@@ -91,6 +90,6 @@ public:
 	}
 
 private:
-	const char* SymbolMapFilename(std::string currentFilename);
+	std::string SymbolMapFilename(std::string currentFilename);
 	MainWindow* mainWindow;
 };


### PR DESCRIPTION
`result` in `QtHost::SymbolMapFilename` is a local variable, which will be destructed before the function is returned. Thus `result.c_str()` is always a dangling pointer.