### PR TITLE
Check invalid address in sceMpegAtracDecode.

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1898,7 +1898,7 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 		return -1;
 	}
 
-	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(auAddr)) {
+	if (!Memory::IsValidAddress(bufferAddr)) {
 		WARN_LOG(ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i): invalid addresses", mpeg, auAddr, bufferAddr, init);
 		return -1;
 	}

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1898,6 +1898,11 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 		return -1;
 	}
 
+	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(auAddr)) {
+		WARN_LOG(ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i): invalid addresses", mpeg, auAddr, bufferAddr, init);
+		return -1;
+	}
+
 	DEBUG_LOG(ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i)", mpeg, auAddr, bufferAddr, init);
 
 	SceMpegAu atracAu;


### PR DESCRIPTION
Fixes #11026. This game calls `sceMpegAtracDecode()` with a `bufferAddr 0`
This check was removed since commit b28f224fe25bbf8e070f93b2f0332c9591e20842 ,seems it's dangerous.