### PR TITLE
Use snap grid on resize as well

### DIFF
--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -265,11 +265,9 @@ bool TouchControlLayoutScreen::touch(const TouchInput &touch) {
 					diffX -= (int)(touch.x - startX_) % (g_Config.iTouchSnapGridSize/2);
 					diffY += (int)(touch.y - startY_) % (g_Config.iTouchSnapGridSize/2);
 			}
-
 			float movementScale = 0.02f;
 			float newScale = startScale_ + diffY * movementScale; 
 			float newSpacing = startSpacing_ + diffX * movementScale;
-
 			if (newScale > 3.0f) newScale = 3.0f;
 			if (newScale < 0.5f) newScale = 0.5f;
 			if (newSpacing > 3.0f) newSpacing = 3.0f;

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -260,9 +260,16 @@ bool TouchControlLayoutScreen::touch(const TouchInput &touch) {
 			float diffX = (touch.x - startX_);
 			float diffY = -(touch.y - startY_);
 
+			// Snap to grid
+			if (g_Config.bTouchSnapToGrid) {
+					diffX -= (int)(touch.x - startX_) % (g_Config.iTouchSnapGridSize/2);
+					diffY += (int)(touch.y - startY_) % (g_Config.iTouchSnapGridSize/2);
+			}
+
 			float movementScale = 0.02f;
 			float newScale = startScale_ + diffY * movementScale; 
 			float newSpacing = startSpacing_ + diffX * movementScale;
+
 			if (newScale > 3.0f) newScale = 3.0f;
 			if (newScale < 0.5f) newScale = 0.5f;
 			if (newSpacing > 3.0f) newSpacing = 3.0f;

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -340,7 +340,7 @@ void TouchControlLayoutScreen::CreateViews() {
 	// 	->OnChange.Handle(this, &GameSettingsScreen::OnChangeControlScaling);
 
 	CheckBox *snap = new CheckBox(&g_Config.bTouchSnapToGrid, di->T("Snap"), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 228));
-	PopupSliderChoice *gridSize = new PopupSliderChoice(&g_Config.iTouchSnapGridSize, 1, 256, di->T("Grid"), screenManager(), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 158));
+	PopupSliderChoice *gridSize = new PopupSliderChoice(&g_Config.iTouchSnapGridSize, 2, 256, di->T("Grid"), screenManager(), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 158));
 	gridSize->SetEnabledPtr(&g_Config.bTouchSnapToGrid);
 
 	mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 140 + 158 + 64 + 10));


### PR DESCRIPTION
Fix #12566, grid size is halved on resize as it seem more natural on the move scale.

About rendering the grid to screen as mentioned in #12565, any suggestion?