### PR TITLE
add DEFLATE and MD5 to HLE module list

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -893,6 +893,8 @@ static bool IsHLEVersionedModule(const char *name) {
 		"sceCcc_Library",
 		"SceParseHTTPheader_Library",
 		"SceParseURI_Library",
+		"sceDEFLATE_Library",
+		"sceMD5_Library",
 		// Guessing.
 		"sceJpeg",
 		"sceJpeg_library",


### PR DESCRIPTION
Read rationale here: https://github.com/hrydgard/ppsspp/pull/12559#issuecomment-573910196

Fixes issues God Eater, but other modules may still need to be added to this list.

Related issues: #12571 and #12570.