### PR TITLE
Common/Hashmaps.h: add missing <stdint> include

### DIFF
--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint> /* uint32_t */
 #include <cstring>
 #include <vector>
 


### PR DESCRIPTION
On gcc-10 the build fails as:

```
[ 51%] Building CXX object CMakeFiles/Core.dir/GPU/Null/NullGpu.cpp.o
In file included from ../GPU/Common/DrawEngineCommon.h:24,
                 from ../GPU/Null/NullGpu.cpp:18:
../Common/Hashmaps.h:11:7: error: 'uint32_t' does not name a type; did you mean 'u_int32_t'?
   11 | const uint32_t hashmapSeed = 0x23B58532;
      |       ^~~~~~~~
      |       u_int32_t
```

This happens due to improved transitive include hygiene on
gcc-10 headers. The change includes <cstdint> to pull in
'uint32_t' typedef.