### PR TITLE
Core: Future proof CSO support a bit

### DIFF
--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -72,6 +72,7 @@ private:
 	u32 frameSize;
 	u32 numBlocks;
 	u32 numFrames;
+	int ver_;
 };
 
 


### PR DESCRIPTION
For CSO versions >= 2, respect the header size field and uncompressed frame size behavior.  This will allow more options for future files, like adding a field for the CRC or otherwise.

This is just a quick change since someone was asking about the prospects of adding such a field to CSO.  I figure better to have more versions support any future thing, and this should be pretty safe.

Note: the experimental CSOv2 files output by maxcso can use lz4, which ppsspp still doesn't support.  I'm imagining additional header fields might be in something like a v3.

-[Unknown]