### PR TITLE
Use ASharedMemory api instead of direct access to /dev/ashmem

### DIFF
--- a/Common/MemArenaAndroid.cpp
+++ b/Common/MemArenaAndroid.cpp
@@ -20,6 +20,7 @@
 #ifdef __ANDROID__
 
 #include "base/logging.h"
+#include "base/NativeApp.h"
 #include "MemoryUtil.h"
 #include "MemArena.h"
 #include "StringUtils.h"
@@ -39,14 +40,6 @@
 
 bool MemArena::NeedsProbing() {
 	return false;
-}
-
-static int get_sdk_version() {
-	char sdk[PROP_VALUE_MAX] = {0};
-	if (__system_property_get("ro.build.version.sdk", sdk) != 0) {
-		return atoi(sdk);
-	}
-	return -1;
 }
 
 // ashmem_create_region - creates a new ashmem region and returns the file
@@ -111,7 +104,7 @@ void MemArena::GrabLowMemSpace(size_t size) {
 	const char* name = "PPSSPP_RAM";
 
 	// Since version 26 Android provides a new api for accessing SharedMemory.
-	if (get_sdk_version() >= 26) {
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 26) {
 		fd = ashmem_create_region(name, size);
 	} else {
 		fd = legacy_ashmem_create_region(name, size);

--- a/Common/MemArenaAndroid.cpp
+++ b/Common/MemArenaAndroid.cpp
@@ -32,7 +32,6 @@
 #include <sys/ioctl.h>
 #include <linux/ashmem.h>
 #include <dlfcn.h>
-#include <sys/system_properties.h>
 
 // Hopefully this ABI will never change...
 


### PR DESCRIPTION
Hi,

I wasn't able run the ppsspp libretro core in an application with targetSdk set to 29.

Direct access to /dev/ashmem has been deprecated with Android 10: https://developer.android.com/about/versions/10/behavior-changes-10#shared-memory

This fixes the issue, but sadly the clean way to use ASharedMemory directly requires bumping minSdkVersion so I had to fallback to use dlopen().

Feel free to let me know if you want me to change something in this pull request.