### PR TITLE
libretro: Fix Android Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,7 +718,7 @@ if(ANDROID)
 		Common/GL/GLInterfaceBase.h
 	)
 
-	set(nativeExtra ${nativeExtra}
+	set(NativeAppSource ${NativeAppSource}
 		ext/native/base/NativeApp.h
 		android/jni/app-android.cpp
 		android/jni/AndroidEGLContext.cpp
@@ -885,7 +885,10 @@ if(ANDROID)
 	elseif(ARM64)
 		set(NativeAppSource ${NativeAppSource} android/jni/Arm64EmitterTest.cpp)
 	endif()
-	set(nativeExtra ${nativeExtra} ${NativeAppSource})
+
+	if (NOT LIBRETRO)
+		set(nativeExtra ${nativeExtra} ${NativeAppSource})
+	endif()
 endif()
 
 set(THIN3D_PLATFORMS ext/native/thin3d/thin3d_gl.cpp

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -806,3 +806,7 @@ void NativeUpdate() {}
 void NativeRender(GraphicsContext *graphicsContext) {}
 void NativeResized() {}
 bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &defaultvalue, std::wstring &outvalue) { return false; }
+
+#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
+std::vector<std::string> __cameraGetDeviceList() { return std::vector<std::string>(); }
+#endif


### PR DESCRIPTION
About a week ago, Android builds started failing on my libretro mirror. The weird thing is, I can't point at a commit or change in infra that caused the failures. But when I went digging, I saw that the flow of the cmake scripts was causing the standalone ui to be built into the libretro android cores, which is certainly not desired.

Secondarily, the camera changes a few days ago didn't account for libretro either. On non-mobile platforms, what was done will work since the calls can still be made, although not ideally since libretro should handle all hardware interactions with a core. But on mobile, the function calls are in the native ui code which isn't available for libretro. So for now, just adding a dummy impl to get things to compile again. Someone later may wish to do a proper impl to interface with the libretro camera api.