### PR TITLE
Add toggle flag to combo button

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -824,6 +824,12 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("ComboKey3Mapping", &g_Config.iCombokey3, 0, true, true),
 	ConfigSetting("ComboKey4Mapping", &g_Config.iCombokey4, 0, true, true),
 
+	ConfigSetting("ComboKey0Toggle", &g_Config.bComboToggle0, false, true, true),
+	ConfigSetting("ComboKey1Toggle", &g_Config.bComboToggle1, false, true, true),
+	ConfigSetting("ComboKey2Toggle", &g_Config.bComboToggle2, false, true, true),
+	ConfigSetting("ComboKey3Toggle", &g_Config.bComboToggle3, false, true, true),
+	ConfigSetting("ComboKey4Toggle", &g_Config.bComboToggle4, false, true, true),
+
 #if defined(_WIN32)
 	// A win32 user seeing touch controls is likely using PPSSPP on a tablet. There it makes
 	// sense to default this to on.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -325,6 +325,12 @@ public:
 	int iCombokey3;
 	int iCombokey4;
 
+	bool bComboToggle0;
+	bool bComboToggle1;
+	bool bComboToggle2;
+	bool bComboToggle3;
+	bool bComboToggle4;
+
 	// Ignored on iOS and other platforms that lack pause.
 	bool bShowTouchPause;
 

--- a/UI/ComboKeyMappingScreen.cpp
+++ b/UI/ComboKeyMappingScreen.cpp
@@ -65,25 +65,31 @@ void Combo_keyScreen::CreateViews() {
 	gridsettings.fillCells = true;
 	GridLayout *grid = rightScroll_->Add(new GridLayout(gridsettings, new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
 
+	bool *toggle;
 	memset(array, 0, sizeof(array));
 	switch (*mode) {
 	case 0: 
+		toggle = &g_Config.bComboToggle0;
 		for (int i = 0; i < 16; i++)
 			array[i] = (0x01 == ((g_Config.iCombokey0 >> i) & 0x01));
 		break;
 	case 1:
+		toggle = &g_Config.bComboToggle1;
 		for (int i = 0; i < 16; i++)
 			array[i] = (0x01 == ((g_Config.iCombokey1 >> i) & 0x01));
 		break;
 	case 2:
+		toggle = &g_Config.bComboToggle2;
 		for (int i = 0; i < 16; i++)
 			array[i] = (0x01 == ((g_Config.iCombokey2 >> i) & 0x01));
 		break;
 	case 3:
+		toggle = &g_Config.bComboToggle3;
 		for (int i = 0; i < 16; i++)
 			array[i] = (0x01 == ((g_Config.iCombokey3 >> i) & 0x01));
 		break;
 	case 4:
+		toggle = &g_Config.bComboToggle4;
 		for (int i = 0; i < 16; i++)
 			array[i] = (0x01 == ((g_Config.iCombokey4 >> i) & 0x01));
 		break;
@@ -138,8 +144,22 @@ void Combo_keyScreen::CreateViews() {
 
 		row->Add(choice);
 		grid->Add(row);
-		
+
 	}
+
+	LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	row->SetSpacing(0);
+
+	CheckBox *checkbox = new CheckBox(toggle, "", "", new LinearLayoutParams(50, WRAP_CONTENT));
+	row->Add(checkbox);
+
+	Choice *choice = new Choice(mc->T("Toggle mode"), new LinearLayoutParams(1.0f));
+	ChoiceEventHandler *choiceEventHandler = new ChoiceEventHandler(checkbox);
+	choice->OnClick.Handle(choiceEventHandler, &ChoiceEventHandler::onChoiceClick);
+	choice->SetCentered(true);
+
+	row->Add(choice);
+	grid->Add(row);
 }
 
 static int arrayToInt(bool ary[16]) {

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -201,15 +201,21 @@ void ComboKey::Touch(const TouchInput &input) {
 					if (g_Config.bHapticFeedback) {
 						Vibrate(HAPTIC_VIRTUAL_KEY);
 					}
-					__CtrlButtonDown(combo[i]);
+					if (!toggle_) {
+						__CtrlButtonDown(combo[i]);
+					} else {
+						if (__CtrlPeekButtons() & combo[i])
+							__CtrlButtonUp(combo[i]);
+						else
+							__CtrlButtonDown(combo[i]);
+					}
 				}
-				else if (lastDown && !down) {
+				else if (lastDown && !down && !toggle_) {
 					__CtrlButtonUp(combo[i]);
 				}
 			}
 		}
 	}
-
 }
 
 bool PSPButton::IsDown() {
@@ -600,9 +606,9 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 		}
 		return nullptr;
 	};
-	auto addComboKey = [=](int buttonBit, int bgImg, int bgDownImg, int img, const ConfigTouchPos &touch) -> ComboKey * {
+	auto addComboKey = [=](int buttonBit, bool toggle, int bgImg, int bgDownImg, int img, const ConfigTouchPos &touch) -> ComboKey * {
 		if (touch.show) {
-			return root->Add(new ComboKey(buttonBit, bgImg, bgDownImg, img, touch.scale, buttonLayoutParams(touch)));
+			return root->Add(new ComboKey(buttonBit, toggle, bgImg, bgDownImg, img, touch.scale, buttonLayoutParams(touch)));
 		}
 		return nullptr;
 	};
@@ -673,11 +679,11 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause) {
 	if (g_Config.touchRightAnalogStick.show)
 		root->Add(new PSPStick(stickBg, stickImage, I_STICK, 1, g_Config.touchRightAnalogStick.scale, buttonLayoutParams(g_Config.touchRightAnalogStick)));
 
-	addComboKey(g_Config.iCombokey0, roundImage, I_ROUND, comboKeyImages[0], g_Config.touchCombo0);
-	addComboKey(g_Config.iCombokey1, roundImage, I_ROUND, comboKeyImages[1], g_Config.touchCombo1);
-	addComboKey(g_Config.iCombokey2, roundImage, I_ROUND, comboKeyImages[2], g_Config.touchCombo2);
-	addComboKey(g_Config.iCombokey3, roundImage, I_ROUND, comboKeyImages[3], g_Config.touchCombo3);
-	addComboKey(g_Config.iCombokey4, roundImage, I_ROUND, comboKeyImages[4], g_Config.touchCombo4);
+	addComboKey(g_Config.iCombokey0, g_Config.bComboToggle0, roundImage, I_ROUND, comboKeyImages[0], g_Config.touchCombo0);
+	addComboKey(g_Config.iCombokey1, g_Config.bComboToggle1, roundImage, I_ROUND, comboKeyImages[1], g_Config.touchCombo1);
+	addComboKey(g_Config.iCombokey2, g_Config.bComboToggle2, roundImage, I_ROUND, comboKeyImages[2], g_Config.touchCombo2);
+	addComboKey(g_Config.iCombokey3, g_Config.bComboToggle3, roundImage, I_ROUND, comboKeyImages[3], g_Config.touchCombo3);
+	addComboKey(g_Config.iCombokey4, g_Config.bComboToggle4, roundImage, I_ROUND, comboKeyImages[4], g_Config.touchCombo4);
 
 	return root;
 }

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -172,10 +172,11 @@ const int baseActionButtonSpacing = 60;
 
 class ComboKey : public MultiTouchButton {
 public:
-	ComboKey(int pspButtonBit, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
-		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit)  {
+	ComboKey(int pspButtonBit, bool toggle, int bgImg, int bgDownImg, int img, float scale, UI::LayoutParams *layoutParams)
+		: MultiTouchButton(bgImg, bgDownImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit), toggle_(toggle)  {
 	}
 	void Touch(const TouchInput &input) override;
 private:
 	int pspButtonBit_;
+	bool toggle_;
 };


### PR DESCRIPTION
Add toggle mode to combo button (the combo button it self will not be hold in down animation, as it would make little sense as other input can override the held and there might be multiple button in the combo).

Should help use cases as #10159 a bit.

EDIT: it swap button separately if one is pressed and the other not when is activated, i dunno what should be the expected behaviour with multiple key toggle tho' (remember the last status and change them all? Loop to check if all have been released by other input before?).