### PR TITLE
UI: Separate sleep time in frame time graph

### DIFF
--- a/Core/HLE/sceDisplay.h
+++ b/Core/HLE/sceDisplay.h
@@ -40,7 +40,7 @@ void __DisplayGetDebugStats(char stats[], size_t bufsize);
 void __DisplayGetFPS(float *out_vps, float *out_fps, float *out_actual_fps);
 void __DisplayGetVPS(float *out_vps);
 void __DisplayGetAveragedFPS(float *out_vps, float *out_fps);
-double* __DisplayGetFrameTimes(int *out_valid, int *out_pos);
+double *__DisplayGetFrameTimes(int *out_valid, int *out_pos, double **out_sleep);
 int __DisplayGetNumVblanks();
 int __DisplayGetVCount();
 int __DisplayGetFlipCount();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1192,7 +1192,8 @@ static void DrawFPS(DrawBuffer *draw2d, const Bounds &bounds) {
 
 static void DrawFrameTimes(UIContext *ctx) {
 	int valid, pos;
-	double *history = __DisplayGetFrameTimes(&valid, &pos);
+	double *sleepHistory;
+	double *history = __DisplayGetFrameTimes(&valid, &pos, &sleepHistory);
 	int scale = 7000;
 	int width = 600;
 
@@ -1200,7 +1201,9 @@ static void DrawFrameTimes(UIContext *ctx) {
 	ctx->BeginNoTex();
 	int bottom = ctx->GetBounds().y2();
 	for (int i = 0; i < valid; ++i) {
-		ctx->Draw()->vLine(i, bottom, bottom - history[i]*scale,  0xFF3fFF3f);
+		double activeTime = history[i] - sleepHistory[i];
+		ctx->Draw()->vLine(i, bottom, bottom - activeTime * scale, 0xFF3FFF3F);
+		ctx->Draw()->vLine(i, bottom - activeTime * scale, bottom - history[i] * scale, 0x7F3FFF3F);
 	}
 	ctx->Draw()->vLine(pos, bottom, bottom - 512, 0xFFff3F3f);
 


### PR DESCRIPTION
It's useful to know how much of the frame time is active vs inactive.

Obviously, this still overlaps with the profiler, but this is probably a quick way for people to visualize frame timing (with or without lagsync or vsync, etc.)  If you're experiencing frame drops, knowing understanding active vs inactive may help.

For me, this illustrates a much tighter (unsurprisingly) frame time when lag sync is enabled.  Note that it counts the spinloop as "sleep."

-[Unknown]