### PR TITLE
Rename rapid fire touch control

### DIFF
--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -89,7 +89,7 @@ void TouchControlVisibilityScreen::CreateViews() {
 	toggles_.push_back({ "Combo4", &g_Config.touchCombo4.show, I_5 });
 	toggles_.push_back({ "Alt speed 1", &g_Config.touchSpeed1Key.show, -1 });
 	toggles_.push_back({ "Alt speed 2", &g_Config.touchSpeed2Key.show, -1 });
-	toggles_.push_back({ "Rapid Fire", &g_Config.touchRapidFireKey.show, -1 });
+	toggles_.push_back({ "RapidFire", &g_Config.touchRapidFireKey.show, -1 });
 
 	auto mc = GetI18NCategory("MappableControls");
 


### PR DESCRIPTION
It already exists for control mapping, let's reuse the translation.