### PR TITLE
Improves depth clamping simulation

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -57,6 +57,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "RequireDefaultCPUClock", &flags_.RequireDefaultCPUClock);
 	CheckSetting(iniFile, gameID, "DisableReadbacks", &flags_.DisableReadbacks);
 	CheckSetting(iniFile, gameID, "DisableAccurateDepth", &flags_.DisableAccurateDepth);
+	CheckSetting(iniFile, gameID, "DisableReverseZ", &flags_.DisableReverseZ);
 	CheckSetting(iniFile, gameID, "MGS2AcidHack", &flags_.MGS2AcidHack);
 	CheckSetting(iniFile, gameID, "SonicRivalsHack", &flags_.SonicRivalsHack);
 	CheckSetting(iniFile, gameID, "BlockTransferAllowCreateFB", &flags_.BlockTransferAllowCreateFB);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -57,6 +57,7 @@ struct CompatFlags {
 	bool RequireDefaultCPUClock;
 	bool DisableReadbacks;
 	bool DisableAccurateDepth;
+	bool DisableReverseZ;
 	bool MGS2AcidHack;
 	bool SonicRivalsHack;
 	bool BlockTransferAllowCreateFB;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -168,7 +168,7 @@ public:
 	bool bFullScreenMulti;
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
-	int bHighQualityDepth;
+	bool bHighQualityDepth;
 	bool bReplaceTextures;
 	bool bSaveNewTextures;
 	bool bIgnoreTextureFilenames;

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -510,6 +510,9 @@ static const float DEPTH_SLICE_FACTOR_HIGH = 4.0f;
 static const float DEPTH_SLICE_FACTOR_16BIT = 256.0f;
 
 float DepthSliceFactor() {
+	if (!gstate.isDepthClampEnabled()) {
+		return 1.0f;
+	}
 	if (gstate_c.Supports(GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT)) {
 		return DEPTH_SLICE_FACTOR_16BIT;
 	}

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -62,7 +62,11 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 		} else {
 			// In old-style depth mode, we're comparing against a value scaled to viewport.
 			// (and possibly incorrectly clipped against it.)
-			scale = vpZScale;
+			if (gstate_c.Supports(GPU_SUPPORTS_REVERSE_Z)) {
+				scale = vpZScale;
+			} else {
+				scale = fabsf(vpZScale);
+			}
 			center = vpZCenter;
 		}
 

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -243,8 +243,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		float halfActualZRange = vpZScale / gstate_c.vpDepthScale;
 		float minz = -((gstate_c.vpZOffset * halfActualZRange) - vpZCenter) - halfActualZRange;
 		float viewZScale = halfActualZRange * 2.0f;
-		// Account for the half pixel offset.
-		float viewZCenter = minz + (DepthSliceFactor() / 256.0f) * 0.5f;
+
+		float viewZCenter = minz;
 		float viewZInvScale;
 
 		if (viewZScale != 0.0) {

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -463,8 +463,7 @@ void SoftwareTransform(
 		bool stencilNotMasked = !gstate.isClearModeAlphaMask() || gstate.getStencilWriteMask() == 0x00;
 		if (matchingComponents && stencilNotMasked) {
 			result->color = transformed[1].color0_32;
-			// Need to rescale from a [0, 1] float.  This is the final transformed value.
-			result->depth = ToScaledDepthFromIntegerScale((int)(transformed[1].z * 65535.0f));
+			result->depth = transformed[1].z;
 			result->action = SW_CLEAR;
 			gpuStats.numClears++;
 			return;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -125,7 +125,7 @@ GPU_D3D11::~GPU_D3D11() {
 }
 
 void GPU_D3D11::CheckGPUFeatures() {
-	u32 features = 0;
+	u64 features = 0;
 
 	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
 		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
@@ -133,11 +133,14 @@ void GPU_D3D11::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
 	features |= GPU_PREFER_CPU_DOWNLOAD;
 
-	// Accurate depth is required on AMD/nVidia (for reverse Z) so we ignore the compat flag to disable it on those. See #9545
 	auto vendor = draw_->GetDeviceCaps().vendor;
 
-	if (!PSP_CoreParameter().compat.flags().DisableAccurateDepth || vendor == Draw::GPUVendor::VENDOR_AMD || vendor == Draw::GPUVendor::VENDOR_NVIDIA) {
+	if (!PSP_CoreParameter().compat.flags().DisableAccurateDepth) {
 		features |= GPU_SUPPORTS_ACCURATE_DEPTH;  // Breaks text in PaRappa for some reason.
+	}
+	// Disable reverse Z on AMD/nVidia, See #9545
+	if (!PSP_CoreParameter().compat.flags().DisableReverseZ && vendor != Draw::GPUVendor::VENDOR_AMD && vendor != Draw::GPUVendor::VENDOR_NVIDIA) {
+		features |= GPU_SUPPORTS_REVERSE_Z;
 	}
 
 #ifndef _M_ARM

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -164,16 +164,20 @@ static NVIDIAGeneration NVIDIAGetDeviceGeneration(int deviceID) {
 }
 
 void GPU_DX9::CheckGPUFeatures() {
-	u32 features = 0;
+	u64 features = 0;
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
 	features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
 	features |= GPU_PREFER_CPU_DOWNLOAD;
 
 	auto vendor = draw_->GetDeviceCaps().vendor;
-	// Accurate depth is required on AMD/nVidia (for reverse Z) so we ignore the compat flag to disable it on those. See #9545
-	if (!PSP_CoreParameter().compat.flags().DisableAccurateDepth || vendor == Draw::GPUVendor::VENDOR_AMD || vendor == Draw::GPUVendor::VENDOR_NVIDIA) {
+	
+	if (!PSP_CoreParameter().compat.flags().DisableAccurateDepth) {
 		features |= GPU_SUPPORTS_ACCURATE_DEPTH;
+	}
+	// Disable reverse Z on AMD/nVidia, See #9545
+	if (!PSP_CoreParameter().compat.flags().DisableReverseZ && vendor != Draw::GPUVendor::VENDOR_AMD && vendor != Draw::GPUVendor::VENDOR_NVIDIA) {
+		features |= GPU_SUPPORTS_REVERSE_Z;
 	}
 
 	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -144,9 +144,16 @@ GPU_GLES::~GPU_GLES() {
 
 // Take the raw GL extension and versioning data and turn into feature flags.
 void GPU_GLES::CheckGPUFeatures() {
-	u32 features = 0;
+	u64 features = 0;
 
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
+
+	if (!PSP_CoreParameter().compat.flags().DisableAccurateDepth) {
+		features |= GPU_SUPPORTS_ACCURATE_DEPTH;
+	}
+	if (!PSP_CoreParameter().compat.flags().DisableReverseZ) {
+		features |= GPU_SUPPORTS_REVERSE_Z;
+	}
 
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
 		if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -461,11 +461,11 @@ struct UVScale {
 	float uOff, vOff;
 };
 
-#define FLAG_BIT(x) (1 << x)
+#define FLAG_BIT(x) ((u64)1 << x)
 
 // Some of these are OpenGL-specific even though this file is neutral, unfortunately.
 // Might want to move this mechanism into the backend later.
-enum {
+enum : unsigned __int64 {
 	GPU_SUPPORTS_DUALSOURCE_BLEND = FLAG_BIT(0),
 	GPU_SUPPORTS_GLSL_ES_300 = FLAG_BIT(1),
 	GPU_SUPPORTS_GLSL_330 = FLAG_BIT(2),
@@ -484,20 +484,21 @@ enum {
 	GPU_SUPPORTS_32BIT_INT_FSHADER = FLAG_BIT(15),
 	GPU_SUPPORTS_LARGE_VIEWPORTS = FLAG_BIT(16),
 	GPU_SUPPORTS_ACCURATE_DEPTH = FLAG_BIT(17),
-	GPU_SUPPORTS_VAO = FLAG_BIT(18),
-	GPU_SUPPORTS_ANY_COPY_IMAGE = FLAG_BIT(19),
-	GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH = FLAG_BIT(20),
-	GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT = FLAG_BIT(21),
-	GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT = FLAG_BIT(22),
-	GPU_ROUND_DEPTH_TO_16BIT = FLAG_BIT(23),  // Can be disabled either per game or if we use a real 16-bit depth buffer
-	GPU_SUPPORTS_TEXTURE_LOD_CONTROL = FLAG_BIT(24),
-	GPU_SUPPORTS_FBO = FLAG_BIT(25),
-	GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT = FLAG_BIT(26),
-	GPU_SUPPORTS_NV_FRAMEBUFFER_BLIT = FLAG_BIT(27),
-	GPU_SUPPORTS_OES_TEXTURE_NPOT = FLAG_BIT(28),
-	GPU_NEEDS_Z_EQUAL_W_HACK = FLAG_BIT(29),
-	GPU_PREFER_CPU_DOWNLOAD = FLAG_BIT(30),
-	GPU_PREFER_REVERSE_COLOR_ORDER = FLAG_BIT(31),
+	GPU_SUPPORTS_REVERSE_Z = FLAG_BIT(18),
+	GPU_SUPPORTS_VAO = FLAG_BIT(19),
+	GPU_SUPPORTS_ANY_COPY_IMAGE = FLAG_BIT(20),
+	GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH = FLAG_BIT(21),
+	GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT = FLAG_BIT(22),
+	GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT = FLAG_BIT(23),
+	GPU_ROUND_DEPTH_TO_16BIT = FLAG_BIT(24),  // Can be disabled either per game or if we use a real 16-bit depth buffer
+	GPU_SUPPORTS_TEXTURE_LOD_CONTROL = FLAG_BIT(25),
+	GPU_SUPPORTS_FBO = FLAG_BIT(26),
+	GPU_SUPPORTS_ARB_FRAMEBUFFER_BLIT = FLAG_BIT(27),
+	GPU_SUPPORTS_NV_FRAMEBUFFER_BLIT = FLAG_BIT(28),
+	GPU_SUPPORTS_OES_TEXTURE_NPOT = FLAG_BIT(29),
+	GPU_NEEDS_Z_EQUAL_W_HACK = FLAG_BIT(30),
+	GPU_PREFER_CPU_DOWNLOAD = FLAG_BIT(31),
+	GPU_PREFER_REVERSE_COLOR_ORDER = FLAG_BIT(32),
 };
 
 struct KnownVertexBounds {
@@ -508,8 +509,8 @@ struct KnownVertexBounds {
 };
 
 struct GPUStateCache {
-	bool Supports(u32 flags) { return (featureFlags & flags) != 0; } // Return true if ANY of flags are true.
-	bool SupportsAll(u32 flags) { return (featureFlags & flags) == flags; } // Return true if ALL flags are true.
+	bool Supports(u64 flags) { return (featureFlags & flags) != 0; } // Return true if ANY of flags are true.
+	bool SupportsAll(u64 flags) { return (featureFlags & flags) == flags; } // Return true if ALL flags are true.
 	uint64_t GetDirtyUniforms() { return dirty & DIRTY_ALL_UNIFORMS; }
 	void Dirty(u64 what) {
 		dirty |= what;
@@ -550,7 +551,7 @@ struct GPUStateCache {
 		}
 	}
 
-	u32 featureFlags;
+	u64 featureFlags;
 
 	u32 vertexAddr;
 	u32 indexAddr;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -434,6 +434,31 @@ NPJH50304 = true
 ULES00703 = true
 ULAS42095 = true
 
+[DisableReverseZ]
+# Midnight Club: LA Remix
+ULUS10383 = true
+ULES01144 = true
+ULJS00180 = true
+ULJS00267 = true
+ULJM05904 = true
+NPJH50440 = true
+# Midnight Club 3 : DUB edition
+ULUS10021 = true
+ULES00108 = true
+
+# Shadow of Destiny (#9545)
+ULUS10459 = true
+NPJH50036 = true
+
+# Dominator
+ULUS10236 = true
+ULES00750 = true
+ULJM05242 = true
+ULJM05371 = true
+NPJH50304 = true
+ULES00703 = true
+ULAS42095 = true
+
 [RequireDefaultCPUClock]
 # GOW : Ghost of Sparta
 UCUS98737 = true


### PR DESCRIPTION
Some differences after this change:
- Reverse Z acts as an independent feature instead of being included in accurate depth.(Makes opengl enable depth clamping simulation)
- Depth silce factor is setted to 1.0 if depth clamp disabled.
- Not rescale Z when clearing Z-buffer(Not sure this).

Helps #7932, in opengl and dx9 backend, if do rescale Z when clearing Z-buffer, the "black screen" will always be front, and start menu(out of depth range) doesn't pass depth test even if be clamped to depth range.