### PR TITLE
Resizable game icons

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -450,6 +450,7 @@ static ConfigSetting generalSettings[] = {
 
 	ConfigSetting("ShowRegionOnGameIcon", &g_Config.bShowRegionOnGameIcon, false, true, true),
 	ConfigSetting("ShowIDOnGameIcon", &g_Config.bShowIDOnGameIcon, false, true, true),
+	ConfigSetting("GameGridScale", &g_Config.fGameGridScale, 1.0, true, true),
 	ConfigSetting("GridView1", &g_Config.bGridView1, true),
 	ConfigSetting("GridView2", &g_Config.bGridView2, true),
 	ConfigSetting("GridView3", &g_Config.bGridView3, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -211,6 +211,7 @@ public:
 	int iShowFPSCounter;
 	bool bShowRegionOnGameIcon;
 	bool bShowIDOnGameIcon;
+	float fGameGridScale;
 
 	// TODO: Maybe move to a separate theme system.
 	uint32_t uItemStyleFg;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -722,9 +722,6 @@ void GameSettingsScreen::CreateViews() {
 #endif
 
 	systemSettings->Add(new CheckBox(&g_Config.bCheckForNewVersion, sy->T("VersionCheck", "Check for new versions of PPSSPP")));
-	if (g_Config.iMaxRecent > 0)
-		systemSettings->Add(new Choice(sy->T("Clear Recent Games List")))->OnClick.Handle(this, &GameSettingsScreen::OnClearRecents);
-
 	const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";
 	const std::string bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) + "background.jpg";
 	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
@@ -987,12 +984,6 @@ UI::EventReturn GameSettingsScreen::OnSavePathOther(UI::EventParams &e) {
 }
 
 #endif
-
-UI::EventReturn GameSettingsScreen::OnClearRecents(UI::EventParams &e) {
-	g_Config.recentIsos.clear();
-	OnRecentChanged.Trigger(e);
-	return UI::EVENT_DONE;
-}
 
 UI::EventReturn GameSettingsScreen::OnChangeBackground(UI::EventParams &e) {
 	const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -722,8 +722,6 @@ void GameSettingsScreen::CreateViews() {
 #endif
 
 	systemSettings->Add(new CheckBox(&g_Config.bCheckForNewVersion, sy->T("VersionCheck", "Check for new versions of PPSSPP")));
-	systemSettings->Add(new CheckBox(&g_Config.bShowIDOnGameIcon, sy->T("Show ID on game selection screen")));
-	systemSettings->Add(new CheckBox(&g_Config.bShowRegionOnGameIcon, sy->T("Show region flag on game selection screen")));
 	if (g_Config.iMaxRecent > 0)
 		systemSettings->Add(new Choice(sy->T("Clear Recent Games List")))->OnClick.Handle(this, &GameSettingsScreen::OnClearRecents);
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -36,7 +36,6 @@ public:
 	void onFinish(DialogResult result) override;
 	void sendMessage(const char *message, const char *value) override;
 	std::string tag() const override { return "settings"; }
-
 	UI::Event OnRecentChanged;
 
 protected:

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -36,7 +36,6 @@ public:
 	void onFinish(DialogResult result) override;
 	void sendMessage(const char *message, const char *value) override;
 	std::string tag() const override { return "settings"; }
-	UI::Event OnRecentChanged;
 
 protected:
 	void CreateViews() override;
@@ -86,7 +85,6 @@ private:
 	UI::EventReturn OnChangeNickname(UI::EventParams &e);
 	UI::EventReturn OnChangeproAdhocServerAddress(UI::EventParams &e);
 	UI::EventReturn OnChangeMacAddress(UI::EventParams &e);
-	UI::EventReturn OnClearRecents(UI::EventParams &e);
 	UI::EventReturn OnChangeBackground(UI::EventParams &e);
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
 	UI::EventReturn OnDisplayLayoutEditor(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1452,7 +1452,7 @@ void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	auto di = GetI18NCategory("Dialog");
 	auto sy = GetI18NCategory("System");
 
-	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
+	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	LinearLayout *items = new LinearLayout(ORIENT_VERTICAL);
 
 	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -126,8 +126,8 @@ public:
 	void Draw(UIContext &dc) override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override {
 		if (gridStyle_) {
-			w = 144;
-			h = 80;
+			w = 144*g_Config.fGameGridScale;
+			h = 80*g_Config.fGameGridScale;
 		} else {
 			w = 500;
 			h = 50;
@@ -234,7 +234,7 @@ void GameButton::Draw(UIContext &dc) {
 
 	int x = bounds_.x;
 	int y = bounds_.y;
-	int w = 144;
+	int w = gridStyle_ ? bounds_.w : 144;
 	int h = bounds_.h;
 
 	UI::Style style = dc.theme->itemStyle;
@@ -262,7 +262,7 @@ void GameButton::Draw(UIContext &dc) {
 
 		// Adjust position so we don't stretch the image vertically or horizontally.
 		// Make sure it's not wider than 144 (like Doom Legacy homebrew), ugly in the grid mode.
-		float nw = std::min(h * tw / th, 144.0f);
+		float nw = std::min(h * tw / th, (float)w);
 		x += (w - nw) / 2.0f;
 		w = nw;
 	}
@@ -375,7 +375,7 @@ void GameButton::Draw(UIContext &dc) {
 		const AtlasImage *gearImage = dc.Draw()->GetAtlas()->getImage(ImageID("I_GEAR"));
 		if (gearImage) {
 			if (gridStyle_) {
-				dc.Draw()->DrawImage(ImageID("I_GEAR"), x, y + h - gearImage->h, 1.0f);
+				dc.Draw()->DrawImage(ImageID("I_GEAR"), x, y + h - gearImage->h*g_Config.fGameGridScale, g_Config.fGameGridScale);
 			} else {
 				dc.Draw()->DrawImage(ImageID("I_GEAR"), x - gearImage->w, y, 1.0f);
 			}
@@ -394,14 +394,15 @@ void GameButton::Draw(UIContext &dc) {
 		const AtlasImage *image = dc.Draw()->GetAtlas()->getImage(regionIcons[ginfo->region]);
 		if (image) {
 			if (gridStyle_) {
-				dc.Draw()->DrawImage(regionIcons[ginfo->region], x + w - image->w - 5, y + h - image->h - 5, 1.0f);
+				dc.Draw()->DrawImage(regionIcons[ginfo->region], x + w - (image->w + 5)*g_Config.fGameGridScale,
+							y + h - (image->h + 5)*g_Config.fGameGridScale, g_Config.fGameGridScale);
 			} else {
 				dc.Draw()->DrawImage(regionIcons[ginfo->region], x - 2 - image->w - 3, y + h - image->h - 5, 1.0f);
 			}
 		}
 	}
 	if (gridStyle_ && g_Config.bShowIDOnGameIcon) {
-		dc.SetFontScale(0.5f, 0.5f);
+		dc.SetFontScale(0.5f*g_Config.fGameGridScale, 0.5f*g_Config.fGameGridScale);
 		dc.DrawText(ginfo->id_version.c_str(), x+5, y+1, 0xFF000000, ALIGN_TOPLEFT);
 		dc.DrawText(ginfo->id_version.c_str(), x+4, y, 0xFFffFFff, ALIGN_TOPLEFT);
 		dc.SetFontScale(1.0f, 1.0f);
@@ -414,10 +415,10 @@ void GameButton::Draw(UIContext &dc) {
 
 class DirButton : public UI::Button {
 public:
-	DirButton(const std::string &path, UI::LayoutParams *layoutParams)
-		: UI::Button(path, layoutParams), path_(path), absolute_(false) {}
-	DirButton(const std::string &path, const std::string &text, UI::LayoutParams *layoutParams = 0)
-		: UI::Button(text, layoutParams), path_(path), absolute_(true) {}
+	DirButton(const std::string &path, bool gridStyle, UI::LayoutParams *layoutParams)
+		: UI::Button(path, layoutParams), path_(path), gridStyle_(gridStyle), absolute_(false) {}
+	DirButton(const std::string &path, const std::string &text, bool gridStyle, UI::LayoutParams *layoutParams = 0)
+		: UI::Button(text, layoutParams), path_(path), gridStyle_(gridStyle), absolute_(true) {}
 
 	virtual void Draw(UIContext &dc);
 
@@ -432,6 +433,7 @@ public:
 private:
 	std::string path_;
 	bool absolute_;
+	bool gridStyle_;
 };
 
 void DirButton::Draw(UIContext &dc) {
@@ -452,17 +454,20 @@ void DirButton::Draw(UIContext &dc) {
 	}
 
 	float tw, th;
-	dc.MeasureText(dc.GetFontStyle(), 1.0f, 1.0f, text.c_str(), &tw, &th, 0);
+	dc.MeasureText(dc.GetFontStyle(), gridStyle_ ? g_Config.fGameGridScale : 1.0, gridStyle_ ? g_Config.fGameGridScale : 1.0, text.c_str(), &tw, &th, 0);
 
-	bool compact = bounds_.w < 180;
+	bool compact = bounds_.w < 180 * (gridStyle_ ? g_Config.fGameGridScale : 1.0);
 
+	if (gridStyle_) {
+		dc.SetFontScale(g_Config.fGameGridScale, g_Config.fGameGridScale);
+	}
 	if (compact) {
 		// No icon, except "up"
 		dc.PushScissor(bounds_);
 		if (image == ImageID("I_FOLDER")) {
 			dc.DrawText(text.c_str(), bounds_.x + 5, bounds_.centerY(), style.fgColor, ALIGN_VCENTER);
 		} else {
-			dc.Draw()->DrawImage(image, bounds_.centerX(), bounds_.centerY(), 1.0f, 0xFFFFFFFF, ALIGN_CENTER);
+			dc.Draw()->DrawImage(image, bounds_.centerX(), bounds_.centerY(), gridStyle_ ? g_Config.fGameGridScale : 1.0, 0xFFFFFFFF, ALIGN_CENTER);
 		}
 		dc.PopScissor();
 	} else {
@@ -471,18 +476,20 @@ void DirButton::Draw(UIContext &dc) {
 			dc.PushScissor(bounds_);
 			scissor = true;
 		}
-
-		dc.Draw()->DrawImage(image, bounds_.x + 72, bounds_.centerY(), .88f, 0xFFFFFFFF, ALIGN_CENTER);
+		dc.Draw()->DrawImage(image, bounds_.x + 72, bounds_.centerY(), 0.88f*(gridStyle_ ? g_Config.fGameGridScale : 1.0), 0xFFFFFFFF, ALIGN_CENTER);
 		dc.DrawText(text.c_str(), bounds_.x + 150, bounds_.centerY(), style.fgColor, ALIGN_VCENTER);
 
 		if (scissor) {
 			dc.PopScissor();
 		}
 	}
+	if (gridStyle_) {
+		dc.SetFontScale(1.0, 1.0);
+	}
 }
 
-GameBrowser::GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams)
-	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), path_(path), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink) {
+GameBrowser::GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams)
+	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), path_(path), gridStyle_(gridStyle), screenManager_(screenManager), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink) {
 	using namespace UI;
 	Refresh();
 }
@@ -558,8 +565,44 @@ void GameBrowser::Update() {
 	}
 }
 
+void GameBrowser::Draw(UIContext &dc) {
+	using namespace UI;
+
+	if (lastScale_ != g_Config.fGameGridScale || lastLayoutWasGrid_ != *gridStyle_) {
+		Refresh();
+	}
+
+	if (hasDropShadow_) {
+		// Darken things behind.
+		dc.FillRect(UI::Drawable(0x60000000), dc.GetBounds().Expand(dropShadowExpand_));
+		float dropsize = 30.0f;
+		dc.Draw()->DrawImage4Grid(dc.theme->dropShadow4Grid,
+			bounds_.x - dropsize, bounds_.y,
+			bounds_.x2() + dropsize, bounds_.y2()+dropsize*1.5f, 0xDF000000, 3.0f);
+	}
+
+	if (clip_) {
+		dc.PushScissor(bounds_);
+	}
+
+	dc.FillRect(bg_, bounds_);
+	for (View *view : views_) {
+		if (view->GetVisibility() == V_VISIBLE) {
+			// Check if bounds are in current scissor rectangle.
+			if (dc.GetScissorBounds().Intersects(dc.TransformBounds(view->GetBounds())))
+				view->Draw(dc);
+		}
+	}
+	if (clip_) {
+		dc.PopScissor();
+	}
+}
+
 void GameBrowser::Refresh() {
 	using namespace UI;
+
+	lastScale_ = g_Config.fGameGridScale;
+	lastLayoutWasGrid_ = *gridStyle_;
 
 	homebrewStoreButton_ = nullptr;
 	// Kill all the contents
@@ -582,23 +625,40 @@ void GameBrowser::Refresh() {
 		} else {
 			topBar->Add(new Spacer(new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
 		}
-
 		ChoiceStrip *layoutChoice = topBar->Add(new ChoiceStrip(ORIENT_HORIZONTAL));
 		layoutChoice->AddChoice(ImageID("I_GRID"));
 		layoutChoice->AddChoice(ImageID("I_LINES"));
 		layoutChoice->SetSelection(*gridStyle_ ? 0 : 1);
 		layoutChoice->OnChoice.Handle(this, &GameBrowser::LayoutChange);
+		topBar->Add(new Choice(ImageID("I_GEAR"), new LayoutParams(64.0f, 64.0f)))->OnClick.Handle(this, &GameBrowser::GridSettingsClick);
 		Add(topBar);
-	}
 
-	if (*gridStyle_) {
-		gameList_ = new UI::GridLayout(UI::GridLayoutSettings(150, 85), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		if (*gridStyle_) {
+			gameList_ = new UI::GridLayout(UI::GridLayoutSettings(150*g_Config.fGameGridScale, 85*g_Config.fGameGridScale), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+			Add(gameList_);
+		} else {
+			UI::LinearLayout *gl = new UI::LinearLayout(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+			gl->SetSpacing(4.0f);
+			gameList_ = gl;
+			Add(gameList_);
+		}
 	} else {
-		UI::LinearLayout *gl = new UI::LinearLayout(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
-		gl->SetSpacing(4.0f);
-		gameList_ = gl;
+		if (*gridStyle_) {
+			gameList_ = new UI::GridLayout(UI::GridLayoutSettings(150*g_Config.fGameGridScale, 85*g_Config.fGameGridScale), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		} else {
+			UI::LinearLayout *gl = new UI::LinearLayout(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+			gl->SetSpacing(4.0f);
+			gameList_ = gl;
+		}
+		LinearLayout *gridOptionColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(64.0, 64.0f));
+		gridOptionColumn->Add(new Spacer(12.0));
+		gridOptionColumn->Add(new Choice(ImageID("I_GEAR"), new LayoutParams(64.0f, 64.0f)))->OnClick.Handle(this, &GameBrowser::GridSettingsClick);
+		LinearLayout *grid = new LinearLayout(ORIENT_HORIZONTAL);
+		gameList_->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.75));
+		grid->Add(gameList_);
+		grid->Add(gridOptionColumn);
+		Add(grid);
 	}
-	Add(gameList_);
 
 	// Find games in the current directory and create new ones.
 	std::vector<DirButton *> dirButtons;
@@ -627,7 +687,7 @@ void GameBrowser::Refresh() {
 
 			if (!isGame && !isSaveData) {
 				if (browseFlags_ & BrowseFlags::NAVIGATE) {
-					dirButtons.push_back(new DirButton(fileInfo[i].fullName, fileInfo[i].name, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)));
+					dirButtons.push_back(new DirButton(fileInfo[i].fullName, fileInfo[i].name, *gridStyle_, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)));
 				}
 			} else {
 				gameButtons.push_back(new GameButton(fileInfo[i].fullName, *gridStyle_, new UI::LinearLayoutParams(*gridStyle_ == true ? UI::WRAP_CONTENT : UI::FILL_PARENT, UI::WRAP_CONTENT)));
@@ -655,13 +715,13 @@ void GameBrowser::Refresh() {
 	}
 
 	if (browseFlags_ & BrowseFlags::NAVIGATE) {
-		gameList_->Add(new DirButton("..", new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
+		gameList_->Add(new DirButton("..", *gridStyle_, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
 			OnClick.Handle(this, &GameBrowser::NavigateClick);
 
 		// Add any pinned paths before other directories.
 		auto pinnedPaths = GetPinnedPaths();
 		for (auto it = pinnedPaths.begin(), end = pinnedPaths.end(); it != end; ++it) {
-			gameList_->Add(new DirButton(*it, GetBaseName(*it), new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
+			gameList_->Add(new DirButton(*it, GetBaseName(*it), *gridStyle_, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
 				OnClick.Handle(this, &GameBrowser::NavigateClick);
 		}
 	}
@@ -842,7 +902,7 @@ void MainScreen::CreateViews() {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollRecentGames->SetTag("MainScreenRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(
-			"!RECENT", BrowseFlags::NONE, &g_Config.bGridView1, "", "",
+			"!RECENT", BrowseFlags::NONE, &g_Config.bGridView1, screenManager(), "", "",
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 		scrollRecentGames->Add(tabRecentGames);
 		gameBrowsers_.push_back(tabRecentGames);
@@ -860,10 +920,10 @@ void MainScreen::CreateViews() {
 		ScrollView *scrollHomebrew = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollHomebrew->SetTag("MainScreenHomebrew");
 
-		GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, BrowseFlags::STANDARD, &g_Config.bGridView2,
+		GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, BrowseFlags::STANDARD, &g_Config.bGridView2, screenManager(),
 			mm->T("How to get games"), "https://www.ppsspp.org/getgames.html",
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
-		GameBrowser *tabHomebrew = new GameBrowser(GetSysDirectory(DIRECTORY_GAME), BrowseFlags::HOMEBREW_STORE, &g_Config.bGridView3,
+		GameBrowser *tabHomebrew = new GameBrowser(GetSysDirectory(DIRECTORY_GAME), BrowseFlags::HOMEBREW_STORE, &g_Config.bGridView3, screenManager(),
 			mm->T("How to get homebrew & demos", "How to get homebrew && demos"), "https://www.ppsspp.org/gethomebrew.html",
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 
@@ -1221,6 +1281,16 @@ UI::EventReturn MainScreen::OnRecentChange(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
+UI::EventReturn GameBrowser::GridSettingsClick(UI::EventParams &e) {
+	auto sy = GetI18NCategory("System");
+	auto *gridSettings = new GridSettingsScreen(sy->T("Games list settings"));
+	if (e.v)
+		gridSettings->SetPopupOrigin(e.v);
+
+	screenManager_->push(gridSettings);
+	return UI::EVENT_DONE;
+}
+
 UI::EventReturn MainScreen::OnCredits(UI::EventParams &e) {
 	screenManager()->push(new CreditsScreen());
 	return UI::EVENT_DONE;
@@ -1314,7 +1384,7 @@ void UmdReplaceScreen::CreateViews() {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollRecentGames->SetTag("UmdReplaceRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(
-			"!RECENT", BrowseFlags::NONE, &g_Config.bGridView1, "", "",
+			"!RECENT", BrowseFlags::NONE, &g_Config.bGridView1, screenManager(), "", "",
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 		scrollRecentGames->Add(tabRecentGames);
 		leftColumn->AddTab(mm->T("Recent"), scrollRecentGames);
@@ -1324,7 +1394,7 @@ void UmdReplaceScreen::CreateViews() {
 	ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollAllGames->SetTag("UmdReplaceAllGames");
 
-	GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, BrowseFlags::STANDARD, &g_Config.bGridView2,
+	GameBrowser *tabAllGames = new GameBrowser(g_Config.currentDirectory, BrowseFlags::STANDARD, &g_Config.bGridView2, screenManager(),
 		mm->T("How to get games"), "https://www.ppsspp.org/getgames.html",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 
@@ -1374,5 +1444,41 @@ UI::EventReturn UmdReplaceScreen::OnGameSettings(UI::EventParams &e) {
 UI::EventReturn UmdReplaceScreen::OnGameSelectedInstant(UI::EventParams &e) {
 	__UmdReplace(e.s);
 	TriggerFinish(DR_OK);
+	return UI::EVENT_DONE;
+}
+
+void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
+	using namespace UI;
+
+	auto di = GetI18NCategory("Dialog");
+	auto sy = GetI18NCategory("System");
+
+	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
+	LinearLayout *items = new LinearLayout(ORIENT_VERTICAL);
+
+	items->Add(new ItemHeader(sy->T("View style")));
+	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));
+	items->Add(new CheckBox(&g_Config.bGridView2, sy->T("Display Games on a grid")));
+	items->Add(new CheckBox(&g_Config.bGridView3, sy->T("Display Homebrew on a grid")));
+
+	items->Add(new ItemHeader(sy->T("Grid icon size")));
+	items->Add(new Choice(sy->T("Increase size")))->OnClick.Handle(this, &GridSettingsScreen::GridPlusClick);
+	items->Add(new Choice(sy->T("Decrease size")))->OnClick.Handle(this, &GridSettingsScreen::GridMinusClick);
+
+	items->Add(new ItemHeader(sy->T("Extra info")));
+	items->Add(new CheckBox(&g_Config.bShowIDOnGameIcon, sy->T("Show ID on game selection screen")));
+	items->Add(new CheckBox(&g_Config.bShowRegionOnGameIcon, sy->T("Show region flag on game selection screen")));
+
+	scroll->Add(items);
+	parent->Add(scroll);
+}
+
+UI::EventReturn GridSettingsScreen::GridPlusClick(UI::EventParams &e) {
+	g_Config.fGameGridScale = std::min(g_Config.fGameGridScale*1.25f, MAX_GAME_GRID_SCALE);
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GridSettingsScreen::GridMinusClick(UI::EventParams &e) {
+	g_Config.fGameGridScale = std::max(g_Config.fGameGridScale/1.25f, MIN_GAME_GRID_SCALE);
 	return UI::EVENT_DONE;
 }

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -80,6 +80,7 @@ private:
 	UI::EventReturn HomeClick(UI::EventParams &e);
 	UI::EventReturn PinToggleClick(UI::EventParams &e);
 	UI::EventReturn GridSettingsClick(UI::EventParams &e);
+	UI::EventReturn OnRecentClear(UI::EventParams &e);
 
 	UI::ViewGroup *gameList_ = nullptr;
 	PathBrowser path_;
@@ -123,7 +124,6 @@ protected:
 	// Event handlers
 	UI::EventReturn OnLoadFile(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
-	UI::EventReturn OnRecentChange(UI::EventParams &e);
 	UI::EventReturn OnCredits(UI::EventParams &e);
 	UI::EventReturn OnSupport(UI::EventParams &e);
 	UI::EventReturn OnPPSSPPOrg(UI::EventParams &e);
@@ -173,10 +173,12 @@ class GridSettingsScreen : public PopupScreen {
 public:
 	GridSettingsScreen(std::string label) : PopupScreen(label) {}
 	void CreatePopupContents(UI::ViewGroup *parent) override;
+	UI::Event OnRecentChanged;
 
 private:
 	UI::EventReturn GridPlusClick(UI::EventParams &e);
 	UI::EventReturn GridMinusClick(UI::EventParams &e);
+	UI::EventReturn OnRecentClearClick(UI::EventParams &e);
 	const float MAX_GAME_GRID_SCALE = 3.0;
 	const float MIN_GAME_GRID_SCALE = 0.8;
 };

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -47,7 +47,7 @@ static inline bool operator &(const BrowseFlags &lhs, const BrowseFlags &rhs) {
 
 class GameBrowser : public UI::LinearLayout {
 public:
-	GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
+	GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
 
 	UI::Event OnChoice;
 	UI::Event OnHoldChoice;
@@ -57,7 +57,7 @@ public:
 
 	void FocusGame(const std::string &gamePath);
 	void SetPath(const std::string &path);
-
+	void Draw(UIContext &dc) override;
 	void Update() override;
 
 protected:
@@ -79,6 +79,7 @@ private:
 	UI::EventReturn LastClick(UI::EventParams &e);
 	UI::EventReturn HomeClick(UI::EventParams &e);
 	UI::EventReturn PinToggleClick(UI::EventParams &e);
+	UI::EventReturn GridSettingsClick(UI::EventParams &e);
 
 	UI::ViewGroup *gameList_ = nullptr;
 	PathBrowser path_;
@@ -89,6 +90,9 @@ private:
 	UI::Choice *homebrewStoreButton_ = nullptr;
 	std::string focusGamePath_;
 	bool listingPending_ = false;
+	float lastScale_ = 1.0f;
+	bool lastLayoutWasGrid_ = true;
+	ScreenManager *screenManager_;
 };
 
 class RemoteISOBrowseScreen;
@@ -163,4 +167,16 @@ private:
 
 	UI::EventReturn OnCancel(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
+};
+
+class GridSettingsScreen : public PopupScreen {
+public:
+	GridSettingsScreen(std::string label) : PopupScreen(label) {}
+	void CreatePopupContents(UI::ViewGroup *parent) override;
+
+private:
+	UI::EventReturn GridPlusClick(UI::EventParams &e);
+	UI::EventReturn GridMinusClick(UI::EventParams &e);
+	const float MAX_GAME_GRID_SCALE = 3.0;
+	const float MIN_GAME_GRID_SCALE = 0.8;
 };

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -383,8 +383,8 @@ void RemoteISOConnectScreen::ExecuteLoad() {
 
 class RemoteGameBrowser : public GameBrowser {
 public:
-	RemoteGameBrowser(const std::string &url, const std::vector<std::string> &games, BrowseFlags browseFlags, bool *gridStyle_, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
-	: GameBrowser(url, browseFlags, gridStyle_, lastText, lastLink, layoutParams) {
+	RemoteGameBrowser(const std::string &url, const std::vector<std::string> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
+	: GameBrowser(url, browseFlags, gridStyle_, screenManager, lastText, lastLink, layoutParams) {
 		games_ = games;
 		Refresh();
 	}
@@ -427,7 +427,7 @@ void RemoteISOBrowseScreen::CreateViews() {
 	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollRecentGames->SetTag("RemoteGamesTab");
 	RemoteGameBrowser *tabRemoteGames = new RemoteGameBrowser(
-		url_, games_, BrowseFlags::PIN, &g_Config.bGridView1, "", "",
+		url_, games_, BrowseFlags::PIN, &g_Config.bGridView1, screenManager(), "", "",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	scrollRecentGames->Add(tabRemoteGames);
 	gameBrowsers_.push_back(tabRemoteGames);


### PR DESCRIPTION
As mentioned in #12353 game icon size may end up looking too small.

Design wise I'm not sure where to place the "+" and "-" button (and there might be a better way to center the text on them than 2 spaces), it used the topBar enabling it partially for "recent game" with 
+, -, and grid/list mode (icon size affect grid only).

Some screenshot on a 1080p display (the scale is a bit extreme here, it's more to give an idea)

![base](https://user-images.githubusercontent.com/13517524/75384381-4dd4d800-58de-11ea-84e3-c5aac78b7812.png) standard size

![b](https://user-images.githubusercontent.com/13517524/75383427-9ab7af00-58dc-11ea-9356-357f2491dab5.png) increased size



I also wonder if the icon look too blurry to use this way and some better scaling might be needed.