### PR TITLE
Check whether the audio is actually played in psmf player

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -234,7 +234,7 @@ public:
 
 	bool HasReachedEnd() {
 		// The pts are ignored - the end is when we're out of data.
-		return mediaengine->IsVideoEnd() && (mediaengine->IsNoAudioData() || !mediaengine->IsActuallyPlayAudio());
+		return mediaengine->IsVideoEnd() && (mediaengine->IsNoAudioData() || !mediaengine->IsActuallyPlayingAudio());
 	}
 
 	u32 filehandle;
@@ -1617,7 +1617,7 @@ static int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	bool doVideoStep = true;
 	if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {
 		doVideoStep = false;
-	} else if (!psmfplayer->mediaengine->IsNoAudioData() && psmfplayer->mediaengine->IsActuallyPlayAudio()) {
+	} else if (!psmfplayer->mediaengine->IsNoAudioData() && psmfplayer->mediaengine->IsActuallyPlayingAudio()) {
 		s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 		// Don't skip the very first frame, sometimes audio starts with an early timestamp.
 		if (deltapts > 0 && psmfplayer->mediaengine->getVideoTimeStamp() > 0) {

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -234,7 +234,7 @@ public:
 
 	bool HasReachedEnd() {
 		// The pts are ignored - the end is when we're out of data.
-		return mediaengine->IsVideoEnd() && mediaengine->IsNoAudioData();
+		return mediaengine->IsVideoEnd() && (mediaengine->IsNoAudioData() || !mediaengine->IsActuallyPlayAudio());
 	}
 
 	u32 filehandle;
@@ -1617,7 +1617,7 @@ static int scePsmfPlayerGetVideoData(u32 psmfPlayer, u32 videoDataAddr)
 	bool doVideoStep = true;
 	if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {
 		doVideoStep = false;
-	} else if (!psmfplayer->mediaengine->IsNoAudioData()) {
+	} else if (!psmfplayer->mediaengine->IsNoAudioData() && psmfplayer->mediaengine->IsActuallyPlayAudio()) {
 		s64 deltapts = psmfplayer->mediaengine->getVideoTimeStamp() - psmfplayer->mediaengine->getAudioTimeStamp();
 		// Don't skip the very first frame, sometimes audio starts with an early timestamp.
 		if (deltapts > 0 && psmfplayer->mediaengine->getVideoTimeStamp() > 0) {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -970,6 +970,10 @@ bool MediaEngine::IsNoAudioData() {
 	return !m_demux->hasNextAudioFrame(NULL, NULL, NULL, NULL);
 }
 
+bool MediaEngine::IsActuallyPlayAudio() {
+	return getAudioTimeStamp() >= 0;
+}
+
 s64 MediaEngine::getVideoTimeStamp() {
 	return m_videopts;
 }

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -970,7 +970,7 @@ bool MediaEngine::IsNoAudioData() {
 	return !m_demux->hasNextAudioFrame(NULL, NULL, NULL, NULL);
 }
 
-bool MediaEngine::IsActuallyPlayAudio() {
+bool MediaEngine::IsActuallyPlayingAudio() {
 	return getAudioTimeStamp() >= 0;
 }
 

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -87,7 +87,7 @@ public:
 
 	bool IsVideoEnd() { return m_isVideoEnd; }
 	bool IsNoAudioData();
-	bool IsActuallyPlayAudio();
+	bool IsActuallyPlayingAudio();
 	int VideoWidth() { return m_desWidth; }
 	int VideoHeight() { return m_desHeight; }
 

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -87,6 +87,7 @@ public:
 
 	bool IsVideoEnd() { return m_isVideoEnd; }
 	bool IsNoAudioData();
+	bool IsActuallyPlayAudio();
 	int VideoWidth() { return m_desWidth; }
 	int VideoHeight() { return m_desHeight; }
 


### PR DESCRIPTION
Fixes #11898, some audio contained in pmf videos seem not be actually played by the games. 
Current code prevents video from moving forward for waiting auido and sync, similar issue will happen.