### PR TITLE
ScanForFunctions: Speed up game loading by only trying to insert the newly found functions into the symbol map.

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1022,6 +1022,8 @@ skip:
 	bool ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols) {
 		std::lock_guard<std::recursive_mutex> guard(functions_lock);
 
+		FunctionsVector new_functions;
+
 		AnalyzedFunction currentFunction = {startAddr};
 
 		u32 furthestBranch = 0;
@@ -1142,7 +1144,7 @@ skip:
 					}
 				}
 
-				functions.push_back(currentFunction);
+				new_functions.push_back(currentFunction);
 
 				furthestBranch = 0;
 				addr += 4;
@@ -1157,10 +1159,10 @@ skip:
 
 		if (addr <= endAddr) {
 			currentFunction.end = addr + 4;
-			functions.push_back(currentFunction);
+			new_functions.push_back(currentFunction);
 		}
 
-		for (auto iter = functions.begin(); iter != functions.end(); iter++) {
+		for (auto iter = new_functions.begin(); iter != new_functions.end(); iter++) {
 			iter->size = iter->end - iter->start + 4;
 			if (insertSymbols && !iter->foundInSymbolMap) {
 				char temp[256];
@@ -1168,6 +1170,8 @@ skip:
 			}
 		}
 
+		// Concatenate the new functions to the end of the old ones.
+		functions.insert(functions.end(), new_functions.begin(), new_functions.end());
 		return insertSymbols;
 	}
 


### PR DESCRIPTION
I wondered why ScanForFunctions was so incredibly slow in debug, and the answer wasn't just all the std::map manipulation in g_symbolMap->AddFunction...

It's not very clear in the code (needs some renaming and cleanup) but `functions` is a global vector here and at the end of ScanForFunctions, we'd loop through the entire thing and add all of them to the symbol map. ScanForFunctions is often called many times during load due to lots of little sections in the binary (most of which actually don't contain functions, it turns out) so we ended up trying to add the same large vector of symbols many times.

Now, we just try to add the newly found functions instead of all of the old ones again.

It's no longer somewhat painful to start big games in debug mode, and it is noticeably faster to start up games in general. I don't see how this could break anything, but @unknownbrackets might want a quick look?

(you'd think that the "foundInSymbolMap" thing would prevent this, but it didn't anticipate trying to add all the old symbols repeatedly, which won't have that flag...)