### PR TITLE
Debugger: Stop remote server in full shutdown

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -900,7 +900,6 @@ void NativeShutdownGraphics() {
 	}
 #endif
 
-	ShutdownWebServer();
 	UIBackgroundShutdown();
 
 	delete g_gameInfoCache;
@@ -1346,6 +1345,8 @@ void NativeShutdown() {
 #endif
 
 	ILOG("NativeShutdown called");
+
+	ShutdownWebServer();
 
 	System_SendMessage("finish", "");
 


### PR DESCRIPTION
Hopefully helps #12630, we shouldn't have tied it to graphics.  I think that was a mistake before.

I say hopefully just because I still have trouble reproducing #12630 for some reason, but in theory this should fix it.

-[Unknown]