### PR TITLE
Vulkan check for 16bit format support. Fixes running under MoltenVK.

### DIFF
--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -176,10 +176,13 @@ public:
 	VkResult InitDebugMsgCallback(PFN_vkDebugReportCallbackEXT dbgFunc, int bits, void *userdata);
 	void DestroyDebugMsgCallback();
 
-	VkPhysicalDevice GetPhysicalDevice(int n = 0) const {
+	VkPhysicalDevice GetPhysicalDevice(int n) const {
 		return physical_devices_[n];
 	}
-	int GetCurrentPhysicalDevice() const {
+	VkPhysicalDevice GetCurrentPhysicalDevice() const {
+		return physical_devices_[physical_device_];
+	}
+	int GetCurrentPhysicalDeviceIndex() const {
 		return physical_device_;
 	}
 	int GetNumPhysicalDevices() const {
@@ -202,7 +205,7 @@ public:
 
 	const PhysicalDeviceProps &GetPhysicalDeviceProperties(int i = -1) const {
 		if (i < 0)
-			i = GetCurrentPhysicalDevice();
+			i = GetCurrentPhysicalDeviceIndex();
 		return physicalDeviceProperties_[i];
 	}
 

--- a/GPU/Vulkan/DepalettizeShaderVulkan.cpp
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.cpp
@@ -149,6 +149,8 @@ VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat
 		case GE_CMODE_16BIT_BGR5650:
 			ConvertRGBA565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
 			break;
+		default:
+			break;
 		}
 		rawClut = expanded;
 		dstFmt = VK_FORMAT_R8G8B8A8_UNORM;

--- a/GPU/Vulkan/DepalettizeShaderVulkan.cpp
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "Common/ColorConv.h"
 #include "Common/Vulkan/VulkanContext.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/DepalettizeShaderCommon.h"
@@ -120,7 +121,7 @@ DepalShaderVulkan *DepalShaderCacheVulkan::GetDepalettizeShader(uint32_t clutMod
 	return depal;
 }
 
-VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat, u32 clutHash, u32 *rawClut) {
+VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat, u32 clutHash, u32 *rawClut, bool expandTo32bit) {
 	u32 clutId = GetClutID(clutFormat, clutHash);
 	auto oldtex = texCache_.find(clutId);
 	if (oldtex != texCache_.end()) {
@@ -131,7 +132,34 @@ VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat
 
 	VkComponentMapping componentMapping;
 	VkFormat destFormat = GetClutDestFormat(clutFormat, &componentMapping);
+
 	int texturePixels = clutFormat == GE_CMODE_32BIT_ABGR8888 ? 256 : 512;
+	int bpp = clutFormat == GE_CMODE_32BIT_ABGR8888 ? 4 : 2;
+	VkFormat dstFmt;
+	uint32_t *expanded = nullptr;
+	if (expandTo32bit && clutFormat != GE_CMODE_32BIT_ABGR8888) {
+		expanded = new uint32_t[texturePixels];
+		switch (clutFormat) {
+		case GE_CMODE_16BIT_ABGR4444:
+			ConvertRGBA4444ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
+			break;
+		case GE_CMODE_16BIT_ABGR5551:
+			ConvertRGBA5551ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
+			break;
+		case GE_CMODE_16BIT_BGR5650:
+			ConvertRGBA565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
+			break;
+		}
+		rawClut = expanded;
+		dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
+		bpp = 4;
+		componentMapping.r = VkComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY;
+		componentMapping.g = VkComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY;
+		componentMapping.b = VkComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY;
+		componentMapping.a = VkComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY;
+	} else {
+		dstFmt = GetClutDestFormat(clutFormat, &componentMapping);
+	}
 
 	VulkanTexture *vktex = new VulkanTexture(vulkan_);
 	vktex->SetTag("DepalClut");
@@ -152,6 +180,11 @@ VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat
 	tex->texture = vktex;
 	tex->lastFrame = gpuStats.numFlips;
 	texCache_[clutId] = tex;
+
+	if (expandTo32bit) {
+		delete[] expanded;
+	}
+
 	return tex->texture;
 }
 

--- a/GPU/Vulkan/DepalettizeShaderVulkan.h
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.h
@@ -57,7 +57,7 @@ public:
 
 	// This also uploads the palette and binds the correct texture.
 	DepalShaderVulkan *GetDepalettizeShader(uint32_t clutMode, GEBufferFormat pixelFormat);
-	VulkanTexture *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut);
+	VulkanTexture *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut, bool expandTo32bit);
 	void Clear();
 	void Decimate();
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -229,7 +229,6 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_ANY_COPY_IMAGE;
 	features |= GPU_SUPPORTS_OES_TEXTURE_NPOT;
 	features |= GPU_SUPPORTS_LARGE_VIEWPORTS;
-	features |= GPU_SUPPORTS_16BIT_FORMATS;
 	features |= GPU_SUPPORTS_INSTANCE_RENDERING;
 	features |= GPU_SUPPORTS_VERTEX_TEXTURE_FETCH;
 	features |= GPU_SUPPORTS_TEXTURE_FLOAT;
@@ -250,6 +249,15 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	}
 	if (vulkan_->GetDeviceFeatures().enabled.samplerAnisotropy) {
 		features |= GPU_SUPPORTS_ANISOTROPY;
+	}
+
+	uint32_t fmt4444 = draw_->GetDataFormatSupport(Draw::DataFormat::B4G4R4A4_UNORM_PACK16);
+	uint32_t fmt1555 = draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16);
+	uint32_t fmt565 = draw_->GetDataFormatSupport(Draw::DataFormat::R5G6B5_UNORM_PACK16);
+	if ((fmt4444 & Draw::FMT_TEXTURE) && (fmt565 & Draw::FMT_TEXTURE) && (fmt1555 & Draw::FMT_TEXTURE)) {
+		features |= GPU_SUPPORTS_16BIT_FORMATS;
+	} else {
+		INFO_LOG(G3D, "Deficient texture format support: 4444: %d  1555: %d  565: %d", fmt4444, fmt1555, fmt565);
 	}
 
 	if (PSP_CoreParameter().compat.flags().ClearToRAM) {

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -606,6 +606,8 @@ void VulkanQueueRunner::ApplyMGSHack(std::vector<VKRStep *> &steps) {
 				case VKRRenderCommand::DRAW_INDEXED:
 					steps[i]->commands.push_back(steps[j]->commands[k]);
 					break;
+				default:
+					break;
 				}
 			}
 			steps[j]->stepType = VKRStepType::RENDER_SKIP;
@@ -618,6 +620,8 @@ void VulkanQueueRunner::ApplyMGSHack(std::vector<VKRStep *> &steps) {
 				case VKRRenderCommand::DRAW:
 				case VKRRenderCommand::DRAW_INDEXED:
 					steps[i + 1]->commands.push_back(steps[j]->commands[k]);
+					break;
+				default:
 					break;
 				}
 			}
@@ -803,6 +807,8 @@ void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 					if (steps[j]->readback.src == fb) {
 						goto done_fb;
 					}
+					break;
+				default:
 					break;
 				}
 			}


### PR DESCRIPTION
MoltenVK, the Vulkan on Metal compatibility layer, lacks support for texturing using the 16-bit formats, so just like we do in D3D11 on Win7 which has the same problem, we now expand such textures to 32-bit color.

Fixes #12615.

Will make finishing #10654 worthwhile.