### PR TITLE
Scroll view fix - workaround

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1452,7 +1452,7 @@ void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	auto di = GetI18NCategory("Dialog");
 	auto sy = GetI18NCategory("System");
 
-	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, 50, 1.0f));
 	LinearLayout *items = new LinearLayout(ORIENT_VERTICAL);
 
 	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));


### PR DESCRIPTION
As mentioned here https://github.com/hrydgard/ppsspp/pull/12646#issuecomment-593800495 it seem removing the weight make the scroll view miss the last item when scrolling, weight and wrap content make the popup all screen long, weight and a small size make the popup right in both situation (not sure why it work tbh).

There is probably some other issues underneath, dunno where tho'.