### PR TITLE
Fix atlas tool build on linux

### DIFF
--- a/ext/native/gfx/CMakeLists.txt
+++ b/ext/native/gfx/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SRCS
   gl_debug_log.cpp
-  gl_lost_manager.cpp
+  #gl_lost_manager.cpp
   texture_atlas.cpp)
 
 set(SRCS ${SRCS})

--- a/ext/native/tools/CMakeLists.txt
+++ b/ext/native/tools/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(../ext)
 include_directories(../math/lin)
 include_directories(../image)
 include_directories(/usr/local/include)
+include_directories(../../..)
 
 link_directories(/opt/local/lib)
 


### PR DESCRIPTION
It will now build atlas and zim tool with `./b.sh`.