### PR TITLE
Core: Bring over some file IO related Switch changes

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -64,11 +64,7 @@ ConsoleListener::ConsoleListener() : bHidden(true)
 		logPending = new char[LOG_PENDING_MAX];
 	}
 	++refCount;
-#elif defined(ANDROID)
-	bUseColor = false;
-#elif defined(IOS)
-	bUseColor = false;
-#elif PPSSPP_PLATFORM(UWP) || PPSSPP_PLATFORM(SWITCH)
+#elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(UWP) || PPSSPP_PLATFORM(SWITCH)
 	bUseColor = false;
 #elif defined(_MSC_VER)
 	bUseColor = false;

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <cstring>
 
+#include "ppsspp_config.h"
 #include "file/file_util.h"
 #include "file/free.h"
 #include "util/text/utf8.h"
@@ -28,6 +29,11 @@
 #include "Common/CommonWindows.h"
 #include "Core/FileLoaders/DiskCachingFileLoader.h"
 #include "Core/System.h"
+
+#if PPSSPP_PLATFORM(SWITCH)
+// Far from optimal, but I guess it works...
+#define fseeko fseek
+#endif
 
 static const char *CACHEFILE_MAGIC = "ppssppDC";
 static const s64 SAFETY_FREE_DISK_SPACE = 768 * 1024 * 1024; // 768 MB

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -117,7 +117,12 @@ std::string LocalFileLoader::Path() const {
 }
 
 size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags) {
-#if PPSSPP_PLATFORM(ANDROID)
+#if PPSSPP_PLATFORM(SWITCH)
+	// Toolchain has no fancy IO API.  We must lock.
+	std::lock_guard<std::mutex> guard(readLock_);
+	lseek(fd_, absolutePos, SEEK_SET);
+	return read(fd_, data, bytes * count) / bytes;
+#elif PPSSPP_PLATFORM(ANDROID)
 	// pread64 doesn't appear to actually be 64-bit safe, though such ISOs are uncommon.  See #10862.
 	if (absolutePos <= 0x7FFFFFFF) {
 #if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS < 64

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -442,7 +442,8 @@ void DirectoryFileHandle::Close()
 		if (SetEndOfFile(hFile) == 0) {
 			ERROR_LOG_REPORT(FILESYS, "Failed to truncate file.");
 		}
-#else
+#elif !PPSSPP_PLATFORM(SWITCH)
+		// Note: it's not great that Switch cannot truncate appropriately...
 		if (ftruncate(hFile, (off_t)needsTrunc_) != 0) {
 			ERROR_LOG_REPORT(FILESYS, "Failed to truncate file.");
 		}

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -609,7 +609,7 @@ void InitSysDirectories() {
 		INFO_LOG(COMMON, "Memstick directory not present, creating at '%s'", g_Config.memStickDirectory.c_str());
 	}
 
-	const std::string testFile = g_Config.memStickDirectory + "/_writable_test.$$$";
+	const std::string testFile = g_Config.memStickDirectory + "_writable_test.$$$";
 
 	// If any directory is read-only, fall back to the Documents directory.
 	// We're screwed anyway if we can't write to Documents, or can't detect it.

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -55,7 +55,7 @@ std::string GameManager::GetTempFilename() const {
 	GetTempFileName(tempPath, L"PSP", 1, buffer);
 	return ConvertWStringToUTF8(buffer);
 #else
-	return g_Config.memStickDirectory + "/ppsspp.dl";
+	return g_Config.memStickDirectory + "ppsspp.dl";
 #endif
 }
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <pwd.h>
 
+#include "ppsspp_config.h"
 #include "SDL.h"
 #include "SDL/SDLJoystick.h"
 SDLJoystick *joystick = NULL;
@@ -196,7 +197,11 @@ void OpenDirectory(const char *path) {
 }
 
 void LaunchBrowser(const char *url) {
-#if defined(MOBILE_DEVICE)
+#if PPSSPP_PLATFORM(SWITCH)
+	WebWifiConfig conf;
+	webWifiCreate(&conf, NULL, url, 0, 0);
+	webWifiShow(&conf, NULL);
+#elif defined(MOBILE_DEVICE)
 	ILOG("Would have gone to %s but LaunchBrowser is not implemented on this platform", url);
 #elif defined(_WIN32)
 	std::wstring wurl = ConvertUTF8ToWString(url);
@@ -214,7 +219,11 @@ void LaunchBrowser(const char *url) {
 }
 
 void LaunchMarket(const char *url) {
-#if defined(MOBILE_DEVICE)
+#if PPSSPP_PLATFORM(SWITCH)
+	WebWifiConfig conf;
+	webWifiCreate(&conf, NULL, url, 0, 0);
+	webWifiShow(&conf, NULL);
+#elif defined(MOBILE_DEVICE)
 	ILOG("Would have gone to %s but LaunchMarket is not implemented on this platform", url);
 #elif defined(_WIN32)
 	std::wstring wurl = ConvertUTF8ToWString(url);
@@ -258,6 +267,8 @@ std::string System_GetProperty(SystemProperty prop) {
 		return "SDL:Linux";
 #elif __APPLE__
 		return "SDL:macOS";
+#elif PPSSPP_PLATFORM(SWITCH)
+		return "SDL:Horizon";
 #else
 		return "SDL:";
 #endif

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -511,7 +511,7 @@ UI::EventReturn GameBrowser::LastClick(UI::EventParams &e) {
 }
 
 UI::EventReturn GameBrowser::HomeClick(UI::EventParams &e) {
-#ifdef __ANDROID__
+#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(SWITCH)
 	SetPath(g_Config.memStickDirectory);
 #elif defined(USING_QT_UI) || defined(USING_WIN_UI)
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -459,7 +459,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	VFSRegister("", new DirectoryAssetReader("/usr/share/ppsspp/assets/"));
 #endif
 #if PPSSPP_PLATFORM(SWITCH)
-	std::string assetPath = savegame_dir + "assets/";
+	std::string assetPath = user_data_path + "assets/";
 	VFSRegister("", new DirectoryAssetReader(assetPath.c_str()));
 #else
 	VFSRegister("", new DirectoryAssetReader("assets/"));

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -8,6 +8,7 @@
 #define strcasecmp _stricmp
 #endif
 #else
+#include <strings.h>
 #include <dirent.h>
 #include <unistd.h>
 #include <errno.h>
@@ -28,6 +29,13 @@
 #if !defined(__linux__) && !defined(_WIN32) && !defined(__QNX__)
 #define stat64 stat
 #endif
+
+#ifdef HAVE_LIBNX
+// Far from optimal, but I guess it works...
+#define fseeko fseek
+#define ftello ftell
+#define fileno
+#endif // HAVE_LIBNX
 
 FILE *openCFile(const std::string &filename, const char *mode)
 {

--- a/ext/native/net/http_server.cpp
+++ b/ext/native/net/http_server.cpp
@@ -131,6 +131,10 @@ Server::Server(threading::Executor *executor)
   SetFallbackHandler(std::bind(&Server::Handle404, this, std::placeholders::_1));
 }
 
+Server::~Server() {
+	delete executor_;
+}
+
 void Server::RegisterHandler(const char *url_path, UrlHandlerFunc handler) {
   handlers_[std::string(url_path)] = handler;
 }

--- a/ext/native/net/http_server.h
+++ b/ext/native/net/http_server.h
@@ -62,8 +62,9 @@ private:
 // Register handlers on this class to serve stuff.
 class Server {
 public:
+	// Takes ownership.
 	Server(threading::Executor *executor);
-	virtual ~Server() {}
+	virtual ~Server();
 
 	typedef std::function<void(const Request &)> UrlHandlerFunc;
 	typedef std::map<std::string, UrlHandlerFunc> UrlHandlerMap;

--- a/ext/native/thread/executor.cpp
+++ b/ext/native/thread/executor.cpp
@@ -10,7 +10,13 @@ void SameThreadExecutor::Run(std::function<void()> func) {
 }
 
 void NewThreadExecutor::Run(std::function<void()> func) {
-	std::thread(func).detach();
+	thread_ = std::thread(func);
+}
+
+NewThreadExecutor::~NewThreadExecutor() {
+	// If Run was ever called...
+	if (thread_.joinable())
+		thread_.join();
 }
 
 }  // namespace threading

--- a/ext/native/thread/executor.h
+++ b/ext/native/thread/executor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <thread>
 
 namespace threading {
 
@@ -8,6 +9,7 @@ namespace threading {
 class Executor {
 public:
 	virtual void Run(std::function<void()> func) = 0;
+	virtual ~Executor() {}
 };
 
 class SameThreadExecutor : public Executor {
@@ -17,7 +19,11 @@ public:
 
 class NewThreadExecutor : public Executor {
 public:
+	~NewThreadExecutor() override;
 	void Run(std::function<void()> func) override;
+
+private:
+	std::thread thread_;
 };
 
 }  // namespace threading


### PR DESCRIPTION
Reducing the distance from the Switch port code.  These are just file IO related changes, mainly.

Two differences from #12323 @m4xw:

1. LocalFileReader correctly uses locking when doing seek+read.  This prevents a possible issue if two reads occur simultaneously from separate threads.

2. Did not change the calls to `LaunchBrowser()`, just changed `LaunchBrowser()` itself.

Note that some headers, like `strings.h` are now duplicated in that pull.

-[Unknown]