### PR TITLE
UI: Temporary solution to the layout issue: Remove the gear button from the recent screen.

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -674,14 +674,18 @@ void GameBrowser::Refresh() {
 			gl->SetSpacing(4.0f);
 			gameList_ = gl;
 		}
-		LinearLayout *gridOptionColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(64.0, 64.0f));
-		gridOptionColumn->Add(new Spacer(12.0));
-		gridOptionColumn->Add(new Choice(ImageID("I_GEAR"), new LayoutParams(64.0f, 64.0f)))->OnClick.Handle(this, &GameBrowser::GridSettingsClick);
-		LinearLayout *grid = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
-		gameList_->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.75));
-		grid->Add(gameList_);
-		grid->Add(gridOptionColumn);
-		Add(grid);
+		// Until we can come up with a better space to put it (next to the tabs?) let's get rid of the icon config
+		// button on the Recent tab, it's ugly. You can use the button from the other tabs.
+
+		// LinearLayout *gridOptionColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(64.0, 64.0f));
+		// gridOptionColumn->Add(new Spacer(12.0));
+		// gridOptionColumn->Add(new Choice(ImageID("I_GEAR"), new LayoutParams(64.0f, 64.0f)))->OnClick.Handle(this, &GameBrowser::GridSettingsClick);
+		// LinearLayout *grid = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		// gameList_->ReplaceLayoutParams(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.75));
+		// grid->Add(gameList_);
+		// grid->Add(gridOptionColumn);
+		// Add(grid);
+		Add(gameList_);
 	}
 
 	// Find games in the current directory and create new ones.


### PR DESCRIPTION
Just until we can figure out a better solution, the current look isn't good.

Can always use the gamelist menu from the other screens.

I'm thinking about maybe putting it next to the tabs instead? Or in the very top right corner?