### PR TITLE
Fix game settings behavior on Android shortcut

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1114,6 +1114,12 @@ std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
 	return langValuesMapping;
 }
 
+void Config::Reload() {
+	reload_ = true;
+	Load();
+	reload_ = false;
+}
+
 void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	const bool useIniFilename = iniFileName != nullptr && strlen(iniFileName) > 0;
 	iniFilename_ = FindConfigFile(useIniFilename ? iniFileName : "ppsspp.ini");
@@ -1489,7 +1495,8 @@ bool Config::hasGameConfig(const std::string &pGameId) {
 }
 
 void Config::changeGameSpecific(const std::string &pGameId, const std::string &title) {
-	Save("changeGameSpecific");
+	if (!reload_)
+		Save("changeGameSpecific");
 	gameId_ = pGameId;
 	gameIdTitle_ = title;
 	bGameSpecific = !pGameId.empty();
@@ -1568,7 +1575,7 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 }
 
 void Config::unloadGameConfig() {
-	if (bGameSpecific){
+	if (bGameSpecific) {
 		changeGameSpecific();
 
 		IniFile iniFile;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -452,6 +452,7 @@ public:
 
 	void Load(const char *iniFileName = nullptr, const char *controllerIniFilename = nullptr);
 	void Save(const char *saveReason);
+	void Reload();
 	void RestoreDefaults();
 
 	//per game config managment, should maybe be in it's own class
@@ -490,6 +491,7 @@ protected:
 	void LoadStandardControllerIni();
 
 private:
+	bool reload_ = false;
 	std::string gameId_;
 	std::string gameIdTitle_;
 	std::string iniFilename_;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2732,6 +2732,7 @@ static int IoAsyncFinish(int id) {
 
 		default:
 			ERROR_LOG_REPORT(SCEIO, "Unknown async op %d", params.op);
+			us = 0;
 			break;
 		}
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1174,7 +1174,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		// and I can't risk it before 1.9.0.
 		int gpuBackend = g_Config.iGPUBackend;
 		ILOG("Reloading config after storage permission grant.");
-		g_Config.Load();
+		g_Config.Reload();
 		PostLoadConfig();
 		g_Config.iGPUBackend = gpuBackend;
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -538,6 +538,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	const char *stateToLoad = 0;
 
 	bool gotBootFilename = false;
+	boot_filename = "";
 
 	// Parse command line
 	LogTypes::LOG_LEVELS logLevel = LogTypes::LINFO;

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -88,6 +88,7 @@ public class PpssppActivity extends NativeActivity {
 				super.setShortcutParam(getIntent().getStringExtra(SHORTCUT_EXTRA_KEY));
 			} else {
 				Log.e(TAG, "Shortcut missing parameter!");
+				super.setShortcutParam("");
 			}
 		}
 		super.onCreate(savedInstanceState);


### PR DESCRIPTION
This fixes:
 * The shortcut parameter was being persisted when loading PPSSPP directly after a shortcut.  Now it resets properly.
 * Notifications that we received storage permissions caused the game-specific config to be overwritten with the global config.  Now it avoids saving on reload and just reloads the game-specific config.
 * Also a small uninitialized value issue in an error case.

Fixes #12682.

-[Unknown]