### PR TITLE
Module: Reinit gpu only on runtime module load

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1635,8 +1635,6 @@ void __KernelLoadReset() {
 		HLEShutdown();
 		Replacement_Init();
 		HLEInit();
-		assert(gpu);
-		gpu->Reinitialize();
 	}
 
 	__KernelModuleInit();
@@ -1836,6 +1834,9 @@ int sceKernelLoadExec(const char *filename, u32 paramPtr)
 		Core_UpdateState(CORE_ERROR);
 		return -1;
 	}
+	if (gpu) {
+		gpu->Reinitialize();
+	}
 	return 0;
 }
 
@@ -1920,6 +1921,9 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr) {
 			NOTICE_LOG_REPORT(LOADER, "Module %s is blacklisted or undecryptable - we try __KernelLoadExec", name);
 			// Name might get deleted.
 			const std::string safeName = name;
+			if (gpu) {
+				gpu->Reinitialize();
+			}
 			return __KernelLoadExec(safeName.c_str(), 0, &error_string);
 		} else {
 			hleLogError(LOADER, error, "failed to load");


### PR DESCRIPTION
During initial loading, we load the module in a thread.  It's not deterministic if the gpu will load before or after the ELF, which can cause a crash.

There's no real reason to Reinitialize() it there, though.  We already Reinitialize() on gpu start.

I think this was a crash we saw at one point in the Play crash reports.

-[Unknown]