### PR TITLE
Android: Process input prompts more clearly

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -227,13 +227,13 @@ void System_SendMessage(const char *command, const char *parameter) {
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 
-bool System_InputBoxGetString(const char *title, const char *defaultValue, char *outValue, size_t outLength)
-{
-	QString text = emugl->InputBoxGetQString(QString(title), QString(defaultValue));
-	if (text.isEmpty())
-		return false;
-	strcpy(outValue, text.toStdString().c_str());
-	return true;
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
+	QString text = emugl->InputBoxGetQString(QString::fromStdString(title), QString::fromStdString(defaultValue));
+	if (text.isEmpty()) {
+		cb(false, "");
+	} else {
+		cb(true, text.toStdString());
+	}
 }
 
 void Vibrate(int length_ms) {

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -121,7 +121,10 @@ UI::EventReturn ChatMenu::OnSubmit(UI::EventParams &e) {
 	chatEdit_->SetFocus();
 	sendChat(chat);
 #elif PPSSPP_PLATFORM(ANDROID)
-	System_SendMessage("inputbox", "Chat:");
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Chat"), "", [](bool result, const std::string &value) {
+		sendChat(value);
+	});
 #endif
 	return UI::EVENT_DONE;
 }

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -26,13 +26,11 @@ void ChatMenu::CreatePopupContents(UI::ViewGroup *parent) {
 #if defined(USING_WIN_UI)
 	//freeze  the ui when using ctrl + C hotkey need workaround
 	if (g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen) {
-		std::wstring titleText = ConvertUTF8ToWString(n->T("Chat"));
-		std::wstring defaultText = ConvertUTF8ToWString(n->T("Chat Here"));
-		std::wstring inputChars;
-		if (System_InputBoxGetWString(titleText.c_str(), defaultText, inputChars)) {
-			//chatEdit_->SetText(ConvertWStringToUTF8(inputChars));
-			sendChat(ConvertWStringToUTF8(inputChars));
-		}
+		System_InputBoxGetString(n->T("Chat"), n->T("Chat Here"), [](bool result, const std::string &value) {
+			if (result) {
+				sendChat(value);
+			}
+		});
 	}
 #endif
 	chatEdit_->OnEnter.Handle(this, &ChatMenu::OnSubmit);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -265,13 +265,6 @@ void GameSettingsScreen::CreateViews() {
 			softwareGPU->SetEnabled(false);
 	}
 
-	std::vector<std::string> cameraList = Camera::getDeviceList();
-	if (cameraList.size() >= 1) {
-		graphicsSettings->Add(new ItemHeader(gr->T("Camera")));
-		PopupMultiChoiceDynamic *cameraChoice = graphicsSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sCameraDevice, gr->T("Camera Device"), cameraList, nullptr, screenManager()));
-		cameraChoice->OnChoice.Handle(this, &GameSettingsScreen::OnCameraDeviceChange);
-	}
-
 	graphicsSettings->Add(new ItemHeader(gr->T("Frame Rate Control")));
 	static const char *frameSkip[] = {"Off", "1", "2", "3", "4", "5", "6", "7", "8"};
 	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iFrameSkip, gr->T("Frame Skipping"), frameSkip, 0, ARRAY_SIZE(frameSkip), gr->GetName(), screenManager()));
@@ -471,6 +464,13 @@ void GameSettingsScreen::CreateViews() {
 	PopupSliderChoice *cardboardYShift = graphicsSettings->Add(new PopupSliderChoice(&g_Config.iCardboardYShift, -100, 100, gr->T("Cardboard Screen Y Shift", "Y Shift (in % of the void)"), 1, screenManager(), gr->T("% of the void")));
 	cardboardYShift->SetDisabledPtr(&g_Config.bSoftwareRendering);
 #endif
+
+	std::vector<std::string> cameraList = Camera::getDeviceList();
+	if (cameraList.size() >= 1) {
+		graphicsSettings->Add(new ItemHeader(gr->T("Camera")));
+		PopupMultiChoiceDynamic *cameraChoice = graphicsSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sCameraDevice, gr->T("Camera Device"), cameraList, nullptr, screenManager()));
+		cameraChoice->OnChoice.Handle(this, &GameSettingsScreen::OnCameraDeviceChange);
+	}
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Hack Settings", "Hack Settings (these WILL cause glitches)")));
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -982,7 +982,32 @@ UI::EventReturn GameSettingsScreen::OnJitAffectingSetting(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeMemStickDir(UI::EventParams &e) {
 	auto sy = GetI18NCategory("System");
-	System_SendMessage("inputbox", (std::string(sy->T("Memory Stick Folder")) + ":" + g_Config.memStickDirectory).c_str());
+	System_InputBoxGetString(sy->T("Memory Stick Folder"), g_Config.memStickDirectory, [&](bool result, const std::string &value) {
+		auto sy = GetI18NCategory("System");
+		auto di = GetI18NCategory("Dialog");
+
+		if (result) {
+			std::string newPath = value;
+			size_t pos = newPath.find_last_not_of("/");
+			// Gotta have at least something but a /, and also needs to start with a /.
+			if (newPath.empty() || pos == newPath.npos || newPath[0] != '/') {
+				settingInfo_->Show(sy->T("ChangingMemstickPathInvalid", "That path couldn't be used to save Memory Stick files."), nullptr);
+				return;
+			}
+			if (pos != newPath.size() - 1) {
+				newPath = newPath.substr(0, pos + 1);
+			}
+
+			pendingMemstickFolder_ = newPath;
+			std::string promptMessage = sy->T("ChangingMemstickPath", "Save games, save states, and other data will not be copied to this folder.\n\nChange the Memory Stick folder?");
+			if (!File::Exists(newPath)) {
+				promptMessage = sy->T("ChangingMemstickPathNotExists", "That folder doesn't exist yet.\n\nSave games, save states, and other data will not be copied to this folder.\n\nCreate a new Memory Stick folder?");
+			}
+			// Add the path for clarity and proper confirmation.
+			promptMessage += "\n\n" + newPath + "/";
+			screenManager()->push(new PromptScreen(promptMessage, di->T("Yes"), di->T("No"), std::bind(&GameSettingsScreen::CallbackMemstickFolder, this, std::placeholders::_1)));
+		}
+	});
 	return UI::EVENT_DONE;
 }
 
@@ -1139,43 +1164,6 @@ void GameSettingsScreen::onFinish(DialogResult result) {
 	NativeMessageReceived("gpu_clearCache", "");
 }
 
-void GameSettingsScreen::sendMessage(const char *message, const char *value) {
-	UIDialogScreenWithGameBackground::sendMessage(message, value);
-
-	auto sy = GetI18NCategory("System");
-	auto di = GetI18NCategory("Dialog");
-
-	if (!strcmp(message, "inputbox_completed")) {
-		std::vector<std::string> inputboxValue;
-		SplitString(value, ':', inputboxValue);
-
-#if PPSSPP_PLATFORM(ANDROID)
-		if (inputboxValue.size() >= 2 && inputboxValue[0] == sy->T("Memory Stick Folder")) {
-			// Allow colons in the path.
-			std::string newPath = std::string(value).substr(inputboxValue[0].size() + 1);
-			size_t pos = newPath.find_last_not_of("/");
-			// Gotta have at least something but a /, and also needs to start with a /.
-			if (newPath.empty() || pos == newPath.npos || newPath[0] != '/') {
-				settingInfo_->Show(sy->T("ChangingMemstickPathInvalid", "That path couldn't be used to save Memory Stick files."), nullptr);
-				return;
-			}
-			if (pos != newPath.size() - 1) {
-				newPath = newPath.substr(0, pos + 1);
-			}
-
-			pendingMemstickFolder_ = newPath;
-			std::string promptMessage = sy->T("ChangingMemstickPath", "Save games, save states, and other data will not be copied to this folder.\n\nChange the Memory Stick folder?");
-			if (!File::Exists(newPath)) {
-				promptMessage = sy->T("ChangingMemstickPathNotExists", "That folder doesn't exist yet.\n\nSave games, save states, and other data will not be copied to this folder.\n\nCreate a new Memory Stick folder?");
-			}
-			// Add the path for clarity and proper confirmation.
-			promptMessage += "\n\n" + newPath + "/";
-			screenManager()->push(new PromptScreen(promptMessage, di->T("Yes"), di->T("No"), std::bind(&GameSettingsScreen::CallbackMemstickFolder, this, std::placeholders::_1)));
-		}
-#endif
-	}
-}
-
 #if PPSSPP_PLATFORM(ANDROID)
 void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 	auto sy = GetI18NCategory("System");
@@ -1289,86 +1277,73 @@ UI::EventReturn GameSettingsScreen::OnAudioDevice(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat0(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter Quick Chat 1"), g_Config.sQuickChat0, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sQuickChat0 = value;
 		}
 	});
-#elif defined(__ANDROID__)
-	System_SendMessage("inputbox", ("quickchat0:" + g_Config.sQuickChat0).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat1(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter Quick Chat 2"), g_Config.sQuickChat1, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sQuickChat1 = value;
 		}
 	});
-#elif defined(__ANDROID__)
-	System_SendMessage("inputbox", ("quickchat1:" + g_Config.sQuickChat1).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat2(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter Quick Chat 3"), g_Config.sQuickChat2, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sQuickChat2 = value;
 		}
 	});
-#elif defined(__ANDROID__)
-	System_SendMessage("inputbox", ("quickchat2:" + g_Config.sQuickChat2).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat3(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter Quick Chat 4"), g_Config.sQuickChat3, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sQuickChat3 = value;
 		}
 	});
-#elif defined(__ANDROID__)
-	System_SendMessage("inputbox", ("quickchat3:" + g_Config.sQuickChat3).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat4(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter Quick Chat 5"), g_Config.sQuickChat4, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sQuickChat4 = value;
 		}
 	});
-#elif defined(__ANDROID__)
-	System_SendMessage("inputbox", ("quickchat4:" + g_Config.sQuickChat4).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeNickname(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
 	auto n = GetI18NCategory("Networking");
 	System_InputBoxGetString(n->T("Enter a new PSP nickname"), g_Config.sNickName, [](bool result, const std::string &value) {
 		if (result) {
 			g_Config.sNickName = StripSpaces(value);
 		}
 	});
-#elif defined(__ANDROID__)
-	// TODO: The return value is handled in NativeApp::inputbox_completed. This is horrific.
-	System_SendMessage("inputbox", ("nickname:" + g_Config.sNickName).c_str());
 #endif
 	return UI::EVENT_DONE;
 }
@@ -1377,7 +1352,12 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 	auto sy = GetI18NCategory("System");
 
 #if defined(__ANDROID__)
-	System_SendMessage("inputbox", ("IP:" + g_Config.proAdhocServer).c_str());
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("IP"), g_Config.proAdhocServer, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.proAdhocServer = value;
+		}
+	});
 #else
 	screenManager()->push(new HostnameSelectScreen(&g_Config.proAdhocServer, sy->T("proAdhocServer Address:")));
 #endif

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1290,14 +1290,12 @@ UI::EventReturn GameSettingsScreen::OnAudioDevice(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat0(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t chat_len = 64;
-
-	char chat[chat_len];
-	memset(chat, 0, sizeof(chat));
-
-	if (System_InputBoxGetString("Enter Quick Chat 1", g_Config.sQuickChat0.c_str(), chat, chat_len)) {
-		g_Config.sQuickChat0 = chat;
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter Quick Chat 1"), g_Config.sQuickChat0, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sQuickChat0 = value;
+		}
+	});
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("quickchat0:" + g_Config.sQuickChat0).c_str());
 #endif
@@ -1306,14 +1304,12 @@ UI::EventReturn GameSettingsScreen::OnChangeQuickChat0(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat1(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t chat_len = 64;
-
-	char chat[chat_len];
-	memset(chat, 0, sizeof(chat));
-
-	if (System_InputBoxGetString("Enter Quick Chat 2", g_Config.sQuickChat1.c_str(), chat, chat_len)) {
-		g_Config.sQuickChat1 = chat;
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter Quick Chat 2"), g_Config.sQuickChat1, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sQuickChat1 = value;
+		}
+	});
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("quickchat1:" + g_Config.sQuickChat1).c_str());
 #endif
@@ -1322,14 +1318,12 @@ UI::EventReturn GameSettingsScreen::OnChangeQuickChat1(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat2(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t chat_len = 64;
-
-	char chat[chat_len];
-	memset(chat, 0, sizeof(chat));
-
-	if (System_InputBoxGetString("Enter Quick Chat 3", g_Config.sQuickChat2.c_str(), chat, chat_len)) {
-		g_Config.sQuickChat2 = chat;
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter Quick Chat 3"), g_Config.sQuickChat2, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sQuickChat2 = value;
+		}
+	});
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("quickchat2:" + g_Config.sQuickChat2).c_str());
 #endif
@@ -1338,14 +1332,12 @@ UI::EventReturn GameSettingsScreen::OnChangeQuickChat2(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat3(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t chat_len = 64;
-
-	char chat[chat_len];
-	memset(chat, 0, sizeof(chat));
-
-	if (System_InputBoxGetString("Enter Quick Chat 4", g_Config.sQuickChat3.c_str(), chat, chat_len)) {
-		g_Config.sQuickChat3 = chat;
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter Quick Chat 4"), g_Config.sQuickChat3, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sQuickChat3 = value;
+		}
+	});
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("quickchat3:" + g_Config.sQuickChat3).c_str());
 #endif
@@ -1354,14 +1346,12 @@ UI::EventReturn GameSettingsScreen::OnChangeQuickChat3(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeQuickChat4(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t chat_len = 64;
-
-	char chat[chat_len];
-	memset(chat, 0, sizeof(chat));
-
-	if (System_InputBoxGetString("Enter Quick Chat 5", g_Config.sQuickChat4.c_str(), chat, chat_len)) {
-		g_Config.sQuickChat4 = chat;
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter Quick Chat 5"), g_Config.sQuickChat4, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sQuickChat4 = value;
+		}
+	});
 #elif defined(__ANDROID__)
 	System_SendMessage("inputbox", ("quickchat4:" + g_Config.sQuickChat4).c_str());
 #endif
@@ -1370,14 +1360,12 @@ UI::EventReturn GameSettingsScreen::OnChangeQuickChat4(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeNickname(UI::EventParams &e) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI)
-	const size_t name_len = 256;
-
-	char name[name_len];
-	memset(name, 0, sizeof(name));
-
-	if (System_InputBoxGetString("Enter a new PSP nickname", g_Config.sNickName.c_str(), name, name_len)) {
-		g_Config.sNickName = StripSpaces(name);
-	}
+	auto n = GetI18NCategory("Networking");
+	System_InputBoxGetString(n->T("Enter a new PSP nickname"), g_Config.sNickName, [](bool result, const std::string &value) {
+		if (result) {
+			g_Config.sNickName = StripSpaces(value);
+		}
+	});
 #elif defined(__ANDROID__)
 	// TODO: The return value is handled in NativeApp::inputbox_completed. This is horrific.
 	System_SendMessage("inputbox", ("nickname:" + g_Config.sNickName).c_str());

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -34,7 +34,6 @@ public:
 
 	void update() override;
 	void onFinish(DialogResult result) override;
-	void sendMessage(const char *message, const char *value) override;
 	std::string tag() const override { return "settings"; }
 
 protected:

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -159,13 +159,19 @@ struct PendingMessage {
 	std::string value;
 };
 
+struct PendingInputBox {
+	std::function<void(bool, const std::string &)> cb;
+	bool result;
+	std::string value;
+};
+
 static std::mutex pendingMutex;
 static std::vector<PendingMessage> pendingMessages;
+static std::vector<PendingInputBox> pendingInputBoxes;
 static Draw::DrawContext *g_draw;
 static Draw::Pipeline *colorPipeline;
 static Draw::Pipeline *texColorPipeline;
 static UIContext *uiContext;
-static std::vector<std::string> inputboxValue;
 
 #ifdef _WIN32
 WindowsAudioBackend *winAudioBackend;
@@ -445,6 +451,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	setlocale( LC_ALL, "C" );
 	std::string user_data_path = savegame_dir;
 	pendingMessages.clear();
+	pendingInputBoxes.clear();
 #ifdef IOS
 	user_data_path += "/";
 #endif
@@ -1093,42 +1100,6 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "inputDeviceConnected") {
 		KeyMap::NotifyPadConnected(value);
 	}
-	if (msg == "inputbox_completed") {
-		SplitString(value, ':', inputboxValue);
-		std::string setString = inputboxValue.size() > 1 ? inputboxValue[1] : "";
-		if (inputboxValue[0] == "IP")
-			g_Config.proAdhocServer = setString;
-		else if (inputboxValue[0] == "nickname")
-			g_Config.sNickName = setString;
-		else if (inputboxValue[0] == "remoteiso_subdir")
-			g_Config.sRemoteISOSubdir = setString;
-		else if (inputboxValue[0] == "remoteiso_server")
-			g_Config.sLastRemoteISOServer = setString;
-
-		if (inputboxValue[0] == "quickchat0")
-			g_Config.sQuickChat0 = setString;
-		if (inputboxValue[0] == "quickchat1")
-			g_Config.sQuickChat1 = setString;
-		if (inputboxValue[0] == "quickchat2")
-			g_Config.sQuickChat2 = setString;
-		if (inputboxValue[0] == "quickchat3")
-			g_Config.sQuickChat3 = setString;
-		if (inputboxValue[0] == "quickchat4")
-			g_Config.sQuickChat4 = setString;
-		if (inputboxValue[0] == "nickname")
-			g_Config.sNickName = setString;
-		if (inputboxValue[0] == "Chat") {
-			if (inputboxValue.size() > 2) 
-			{
-				std::string chatString = value;
-				chatString.erase(0, 5);
-				sendChat(chatString);
-			} else {
-				sendChat(setString);
-			}
-		}
-		inputboxValue.clear();
-	}
 	if (msg == "bgImage_updated") {
 		if (!value.empty()) {
 			std::string dest = GetSysDirectory(DIRECTORY_SYSTEM) + (endsWithNoCase(value, ".jpg") ? "background.jpg" : "background.png");
@@ -1183,15 +1154,21 @@ void NativeUpdate() {
 	PROFILE_END_FRAME();
 
 	std::vector<PendingMessage> toProcess;
+	std::vector<PendingInputBox> inputToProcess;
 	{
 		std::lock_guard<std::mutex> lock(pendingMutex);
 		toProcess = std::move(pendingMessages);
+		inputToProcess = std::move(pendingInputBoxes);
 		pendingMessages.clear();
+		pendingInputBoxes.clear();
 	}
 
-	for (size_t i = 0; i < toProcess.size(); i++) {
-		HandleGlobalMessage(toProcess[i].msg, toProcess[i].value);
-		screenManager->sendMessage(toProcess[i].msg.c_str(), toProcess[i].value.c_str());
+	for (const auto &item : toProcess) {
+		HandleGlobalMessage(item.msg, item.value);
+		screenManager->sendMessage(item.msg.c_str(), item.value.c_str());
+	}
+	for (const auto &item : inputToProcess) {
+		item.cb(item.result, item.value);
 	}
 
 	g_DownloadManager.Update();
@@ -1336,6 +1313,15 @@ void NativeMessageReceived(const char *message, const char *value) {
 	pendingMessage.msg = message;
 	pendingMessage.value = value;
 	pendingMessages.push_back(pendingMessage);
+}
+
+void NativeInputBoxReceived(std::function<void(bool, const std::string &)> cb, bool result, const std::string &value) {
+	std::lock_guard<std::mutex> lock(pendingMutex);
+	PendingInputBox pendingMessage;
+	pendingMessage.cb = cb;
+	pendingMessage.result = result;
+	pendingMessage.value = value;
+	pendingInputBoxes.push_back(pendingMessage);
 }
 
 void NativeResized() {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -520,12 +520,22 @@ void RemoteISOSettingsScreen::CreateViews() {
 }
 
 UI::EventReturn RemoteISOSettingsScreen::OnClickRemoteServer(UI::EventParams &e) {
-	System_SendMessage("inputbox", ("remoteiso_server:" + g_Config.sLastRemoteISOServer).c_str());
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
+	auto ri = GetI18NCategory("RemoteISO");
+	System_InputBoxGetString(ri->T("Remote Server"), g_Config.sLastRemoteISOServer, [](bool result, const std::string &value) {
+		g_Config.sLastRemoteISOServer = value;
+	});
+#endif
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn RemoteISOSettingsScreen::OnClickRemoteISOSubdir(UI::EventParams &e) {
-	System_SendMessage("inputbox", ("remoteiso_subdir:" + g_Config.sRemoteISOSubdir).c_str());
+#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(__ANDROID__)
+	auto ri = GetI18NCategory("RemoteISO");
+	System_InputBoxGetString(ri->T("Remote Subdirectory"), g_Config.sRemoteISOSubdir, [](bool result, const std::string &value) {
+		g_Config.sRemoteISOSubdir = value;
+	});
+#endif
 	return UI::EVENT_DONE;
 }
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -18,6 +18,7 @@
 #include "stdafx.h"
 #include <algorithm>
 #include <cmath>
+#include <functional>
 
 #include "Common/CommonWindows.h"
 #include "Common/OSVersion.h"
@@ -337,23 +338,12 @@ void EnableCrashingOnCrashes() {
 	FreeLibrary(kernel32);
 }
 
-bool System_InputBoxGetString(const char *title, const char *defaultValue, char *outValue, size_t outLength)
-{
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
 	std::string out;
 	if (InputBox_GetString(MainWindow::GetHInstance(), MainWindow::GetHWND(), ConvertUTF8ToWString(title).c_str(), defaultValue, out)) {
-		strcpy(outValue, out.c_str());
-		return true;
+		cb(true, out);
 	} else {
-		return false;
-	}
-}
-
-bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &defaultvalue, std::wstring &outvalue)
-{
-	if (InputBox_GetWString(MainWindow::GetHInstance(), MainWindow::GetHWND(), title, defaultvalue, outvalue)) {
-		return true;
-	} else {
-		return false;
+		cb(false, "");
 	}
 }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -123,6 +123,8 @@ static jmethodID postCommand;
 static jobject nativeActivity;
 static volatile bool exitRenderLoop;
 static bool renderLoopRunning;
+static int inputBoxSequence = 1;
+std::map<int, std::function<void(bool, const std::string &)>> inputBoxCallbacks;
 
 static float dp_xscale = 1.0f;
 static float dp_yscale = 1.0f;
@@ -572,6 +574,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 		ILOG("Not shutting down renderer - not initialized");
 	}
 
+	inputBoxCallbacks.clear();
 	NativeShutdown();
 	VFSShutdown();
 	while (frameCommands.size())
@@ -665,6 +668,33 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	} else {
 		ILOG("NativeApp::backbufferResize: Size didn't change.");
 	}
+}
+
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
+	int seq = inputBoxSequence++;
+	inputBoxCallbacks[seq] = cb;
+
+	std::string serialized = StringFromFormat("%d:%s:%s", seq, title.c_str(), defaultValue.c_str());
+	System_SendMessage("inputbox", serialized.c_str());
+}
+
+extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendInputBox(JNIEnv *env, jclass, jstring jseqID, jboolean result, jstring jvalue) {
+	std::string seqID = GetJavaString(env, jseqID);
+	std::string value = GetJavaString(env, jvalue);
+
+	int seq = 0;
+	if (!TryParse(seqID, &seq)) {
+		ELOG("Invalid inputbox seqID value: %s", seqID.c_str());
+		return;
+	}
+
+	auto entry = inputBoxCallbacks.find(seq);
+	if (entry == inputBoxCallbacks.end()) {
+		ELOG("Did not find inputbox callback for %s, shutdown?", seqID.c_str());
+		return;
+	}
+
+	NativeInputBoxReceived(entry->second, result, value);
 }
 
 void UpdateRunLoopAndroid(JNIEnv *env) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -674,7 +674,7 @@ void System_InputBoxGetString(const std::string &title, const std::string &defau
 	int seq = inputBoxSequence++;
 	inputBoxCallbacks[seq] = cb;
 
-	std::string serialized = StringFromFormat("%d:%s:%s", seq, title.c_str(), defaultValue.c_str());
+	std::string serialized = StringFromFormat("%d:@:%s:@:%s", seq, title.c_str(), defaultValue.c_str());
 	System_SendMessage("inputbox", serialized.c_str());
 }
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1169,8 +1169,8 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 		return bld;
 	}
 
-	// The return value is sent elsewhere. TODO in java, in SendMessage in C++.
-	public void inputBox(final String title, String defaultText, String defaultAction) {
+	// The return value is sent to C++ via seqID.
+	public void inputBox(final String seqID, final String title, String defaultText, String defaultAction) {
 		final FrameLayout fl = new FrameLayout(this);
 		final EditText input = new EditText(this);
 		input.setGravity(Gravity.CENTER);
@@ -1202,14 +1202,14 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			.setPositiveButton(defaultAction, new DialogInterface.OnClickListener() {
 				@Override
 				public void onClick(DialogInterface d, int which) {
-					NativeApp.sendMessage("inputbox_completed", title + ":" + input.getText().toString());
+					NativeApp.sendInputBox(seqID, true, input.getText().toString());
 					d.dismiss();
 				}
 			})
 			.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
 				@Override
 				public void onClick(DialogInterface d, int which) {
-					NativeApp.sendMessage("inputbox_failed", "");
+					NativeApp.sendInputBox(seqID, false, "");
 					d.cancel();
 				}
 			})
@@ -1311,15 +1311,17 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			inputMethodManager.toggleSoftInputFromWindow(surfView.getApplicationWindowToken(), InputMethodManager.SHOW_FORCED, 0);
 			return true;
 		} else if (command.equals("inputbox")) {
+			String seqID = "";
 			String title = "Input";
 			String defString = "";
-			String[] param = params.split(":");
-			if (param[0].length() > 0)
-				title = param[0];
-			if (param.length > 1)
-				defString = param[1];
-			Log.i(TAG, "Launching inputbox: " + title + " " + defString);
-			inputBox(title, defString, "OK");
+			String[] param = params.split(":", 3);
+			seqID = param[0];
+			if (param.length > 1 && param[1].length() > 0)
+				title = param[1];
+			if (param.length > 2)
+				defString = param[2];
+			Log.i(TAG, "Launching inputbox: #" + seqID + " " + title + " " + defString);
+			inputBox(seqID, title, defString, "OK");
 			return true;
 		} else if (command.equals("vibrate")) {
 			int milliseconds = -1;

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1314,7 +1314,7 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 			String seqID = "";
 			String title = "Input";
 			String defString = "";
-			String[] param = params.split(":", 3);
+			String[] param = params.split(":@:", 3);
 			seqID = param[0];
 			if (param.length > 1 && param[1].length() > 0)
 				title = param[1];

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -48,6 +48,7 @@ public class NativeApp {
 	public static native boolean accelerometer(float x, float y, float z);
 
 	public static native void sendMessage(String msg, String arg);
+	public static native void sendInputBox(String seqID, boolean result, String value);
 
 	public static native String queryConfig(String queryName);
 

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -119,8 +120,7 @@ void OpenDirectory(const char *path);
 void LaunchBrowser(const char *url);
 void LaunchMarket(const char *url);
 void LaunchEmail(const char *email_address);
-bool System_InputBoxGetString(const char *title, const char *defaultValue, char *outValue, size_t outlength);
-bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &defaultValue, std::wstring &outValue);
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb);
 void System_SendMessage(const char *command, const char *parameter);
 PermissionStatus System_GetPermissionStatus(SystemPermission permission);
 void System_AskForPermission(SystemPermission permission);

--- a/ext/native/base/NativeApp.h
+++ b/ext/native/base/NativeApp.h
@@ -35,6 +35,9 @@ void NativeGetAppInfo(std::string *app_dir_name, std::string *app_nice_name, boo
 // Generic host->C++ messaging, used for functionality like system-native popup input boxes.
 void NativeMessageReceived(const char *message, const char *value);
 
+// This is used to communicate back and thread requested input box strings.
+void NativeInputBoxReceived(std::function<void(bool, const std::string &)> cb, bool result, const std::string &value);
+
 // Easy way for the Java side to ask the C++ side for configuration options, such as
 // the rotation lock which must be controlled from Java on Android.
 // It is currently not called on non-Android platforms.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -81,7 +81,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 	return false;
 }
 void System_SendMessage(const char *command, const char *parameter) {}
-bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &defaultvalue, std::wstring &outvalue) { return false; }
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -37,7 +37,7 @@ void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 
 void System_SendMessage(const char *command, const char *parameter) {}
-bool System_InputBoxGetWString(const wchar_t *title, const std::wstring &defaultvalue, std::wstring &outvalue) { return false; }
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 


### PR DESCRIPTION
This is not a monumental change, but I think it makes the inputbox handling a lot more sane.  Mostly it just keeps the related code nearby.

The communication between Java and C++ is still through messages, although these are now parsed consistently:
 * Each input box gets an ID, rather than relying on a sometimes untranslated title.
 * The titles are now translated (and have always been shown to the user.)  However, this title must not have an unlikely and specific character sequence in it.
 * The default and result values can now have any characters in them without problems.

Windows/Qt and Android now use the same API for input boxes, which uses a callback:

```c++
System_InputBoxGetString("Enter a value", "42", [](bool result, const std::string &value) {
    if (result) {
        ILOG("User entered: %s", value.c_str());
    } else {
        ILOG("User canceled or input failed");
    }
});
```

On Windows/Qt, the callback is called immediately (similar to before.)  On Android, it's called during NativeUpdate().  In the future, Windows/Qt should be moved to update as well for consistency, but the OSK code will need some updates.  Just not wanting to break everything at once.

This should make changes like chat or #8995 far less murky and confusing.

A hazard might exist if you leave a screen and then complete an input box it opened, although I'm not sure how you could do that.  I tried to manage the risk during shutdown by purging the callbacks.

Disclaimer: I did not actually test Qt.

-[Unknown]