### PR TITLE
Android: Enable native keyboard for OSK

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -968,7 +968,7 @@ static ConfigSetting systemParamSettings[] = {
 	ReportedConfigSetting("ButtonPreference", &g_Config.iButtonPreference, PSP_SYSTEMPARAM_BUTTON_CROSS, true, true),
 	ConfigSetting("LockParentalLevel", &g_Config.iLockParentalLevel, 0, true, true),
 	ConfigSetting("WlanAdhocChannel", &g_Config.iWlanAdhocChannel, PSP_SYSTEMPARAM_ADHOC_CHANNEL_AUTOMATIC, true, true),
-#if defined(USING_WIN_UI)
+#if defined(USING_WIN_UI) || defined(USING_QT_UI) || PPSSPP_PLATFORM(ANDROID)
 	ConfigSetting("BypassOSKWithKeyboard", &g_Config.bBypassOSKWithKeyboard, false, true, true),
 #endif
 	ConfigSetting("WlanPowerSave", &g_Config.bWlanPowerSave, (bool) PSP_SYSTEMPARAM_WLAN_POWERSAVE_OFF, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -410,7 +410,6 @@ public:
 
 	int iPSPModel;
 	int iFirmwareVersion;
-	// TODO: Make this work with your platform, too!
 	bool bBypassOSKWithKeyboard;
 
 	// Debugger

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 
 #include "Core/Dialog/PSPDialog.h"
@@ -202,6 +203,14 @@ static const std::string OskKeyboardNames[] =
 	"English Full-width",
 };
 
+enum class PSPOskNativeStatus {
+	IDLE,
+	DONE,
+	WAITING,
+	SUCCESS,
+	FAILURE,
+};
+
 class PSPOskDialog: public PSPDialog {
 public:
 	PSPOskDialog();
@@ -222,9 +231,7 @@ private:
 	void ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16_le>& em_address);
 	void ConvertUCS2ToUTF8(std::string& _string, const wchar_t *input);
 	void RenderKeyboard();
-#if defined(USING_WIN_UI)
 	int NativeKeyboard();
-#endif
 
 	std::wstring CombinationString(bool isInput); // for Japanese, Korean
 	std::wstring CombinationKorean(bool isInput); // for Korea
@@ -243,6 +250,10 @@ private:
 	OskKeyboardDisplay currentKeyboard;
 	OskKeyboardLanguage currentKeyboardLanguage;
 	bool isCombinated;
+
+	std::mutex nativeMutex_;
+	PSPOskNativeStatus nativeStatus_ = PSPOskNativeStatus::IDLE;
+	std::string nativeValue_;
 
 	int i_level; // for Korean Keyboard support
 	int i_value[3]; // for Korean Keyboard support

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -230,9 +230,9 @@ PermissionStatus System_GetPermissionStatus(SystemPermission permission) { retur
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
 	QString text = emugl->InputBoxGetQString(QString::fromStdString(title), QString::fromStdString(defaultValue));
 	if (text.isEmpty()) {
-		cb(false, "");
+		NativeInputBoxReceived(cb, false, "");
 	} else {
-		cb(true, text.toStdString());
+		NativeInputBoxReceived(cb, true, text.toStdString());
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -801,8 +801,8 @@ void GameSettingsScreen::CreateViews() {
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
 	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), sy->GetName(), screenManager()));
-#if defined(USING_WIN_UI)
-	systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Enable Windows native keyboard", "Enable Windows native keyboard")));
+#if defined(USING_WIN_UI) || defined(USING_QT_UI) || PPSSPP_PLATFORM(ANDROID)
+	systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Use system native keyboard")));
 #endif
 #if PPSSPP_PLATFORM(ANDROID)
 	auto memstickPath = systemSettings->Add(new ChoiceWithValueDisplay(&g_Config.memStickDirectory, sy->T("Change Memory Stick folder"), (const char *)nullptr));

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -341,9 +341,9 @@ void EnableCrashingOnCrashes() {
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
 	std::string out;
 	if (InputBox_GetString(MainWindow::GetHInstance(), MainWindow::GetHWND(), ConvertUTF8ToWString(title).c_str(), defaultValue, out)) {
-		cb(true, out);
+		NativeInputBoxReceived(cb, true, out);
 	} else {
-		cb(false, "");
+		NativeInputBoxReceived(cb, false, "");
 	}
 }
 


### PR DESCRIPTION
This does the rest noted in #12691 - makes Windows/Qt use the same async timing (fixing the OSK code to support that.)

That makes it very easy to enable the native keyboard for OSK setting on Android and Qt, since it all works the same now.  Fixes #8995.

-[Unknown]