### PR TITLE
http: Correct new thread executor

### DIFF
--- a/ext/native/thread/executor.cpp
+++ b/ext/native/thread/executor.cpp
@@ -10,13 +10,14 @@ void SameThreadExecutor::Run(std::function<void()> func) {
 }
 
 void NewThreadExecutor::Run(std::function<void()> func) {
-	thread_ = std::thread(func);
+	threads_.push_back(std::thread(func));
 }
 
 NewThreadExecutor::~NewThreadExecutor() {
 	// If Run was ever called...
-	if (thread_.joinable())
-		thread_.join();
+	for (auto &thread : threads_)
+		thread.join();
+	threads_.clear();
 }
 
 }  // namespace threading

--- a/ext/native/thread/executor.h
+++ b/ext/native/thread/executor.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <thread>
+#include <vector>
 
 namespace threading {
 
@@ -23,7 +24,7 @@ public:
 	void Run(std::function<void()> func) override;
 
 private:
-	std::thread thread_;
+	std::vector<std::thread> threads_;
 };
 
 }  // namespace threading


### PR DESCRIPTION
It needs to be able to handle N new threads, oops.  This was causing debugging / remote disc stuff to crash if multiple clients connected (or even if a client disconnected and reconnected.)

-[Unknown]