### PR TITLE
softgpu: Correct clear/solid rect BR corner

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1439,9 +1439,9 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1)
 	DrawingCoords scissorTL(gstate.getScissorX1(), gstate.getScissorY1(), 0);
 	DrawingCoords scissorBR(gstate.getScissorX2(), gstate.getScissorY2(), 0);
 	minX = std::max(minX, (int)TransformUnit::DrawingToScreen(scissorTL).x);
-	maxX = std::max(0, std::min(maxX, (int)TransformUnit::DrawingToScreen(scissorBR).x));
+	maxX = std::max(0, std::min(maxX, (int)TransformUnit::DrawingToScreen(scissorBR).x + 16));
 	minY = std::max(minY, (int)TransformUnit::DrawingToScreen(scissorTL).y);
-	maxY = std::max(0, std::min(maxY, (int)TransformUnit::DrawingToScreen(scissorBR).y));
+	maxY = std::max(0, std::min(maxY, (int)TransformUnit::DrawingToScreen(scissorBR).y + 16));
 
 	const int w = (maxX - minX) / 16;
 	if (w <= 0)

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -184,8 +184,8 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 			}
 		}
 	} else {
-		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x;
-		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y;
+		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x + 1;
+		if (pos1.y > scissorBR.y) pos1.y = scissorBR.y + 1;
 		if (pos0.x < scissorTL.x) pos0.x = scissorTL.x;
 		if (pos0.y < scissorTL.y) pos0.y = scissorTL.y;
 		if (!gstate.isStencilTestEnabled() &&


### PR DESCRIPTION
The scissor is inclusive, not exclusive.  This fixes artifacting on the bottom and right edges of the screen in several games.

-[Unknown]