### PR TITLE
PPGe: Use TextDrawer for save UI if available

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -49,6 +49,7 @@
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelInterrupt.h"
+#include "Core/Util/PPGeDraw.h"
 
 #include "GPU/GPU.h"
 #include "GPU/GPUState.h"
@@ -832,6 +833,7 @@ void __DisplayFlip(int cyclesLate) {
 
 void hleAfterFlip(u64 userdata, int cyclesLate) {
 	gpu->BeginFrame();  // doesn't really matter if begin or end of frame.
+	PPGeNotifyFrame();
 
 	// This seems like as good a time as any to check if the config changed.
 	if (lagSyncScheduled != g_Config.bForceLagSync) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -103,6 +103,21 @@ static AtlasCharLine char_one_line;
 static AtlasLineArray char_lines;
 static AtlasTextMetrics char_lines_metrics;
 
+// Overwrite the current text lines buffer so it can be drawn later.
+void PPGePrepareText(const char *text, float x, float y, int align, float scale, float lineHeightScale,
+	int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
+
+// Get the metrics of the bounding box of the currently stated text.
+void PPGeMeasureCurrentText(float *x, float *y, float *w, float *h, int *n);
+
+// These functions must be called between PPGeBegin and PPGeEnd.
+
+// Draw currently buffered text using the state from PPGeGetTextBoundingBox() call.
+// Clears the buffer and state when done.
+void PPGeDrawCurrentText(u32 color = 0xFFFFFFFF);
+
+void PPGeSetTexture(u32 dataAddr, int width, int height);
+
 //only 0xFFFFFF of data is used
 static void WriteCmd(u8 cmd, u32 data) {
 	Memory::Write_U32((cmd << 24) | (data & 0xFFFFFF), dlWritePtr);

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -703,6 +703,8 @@ void PPGeMeasureText(float *w, float *h, int *n,
 		float mw, mh;
 		textDrawer->SetFontScale(scale, scale);
 		int dtalign = (WrapType & PPGE_LINE_WRAP_WORD) ? FLAG_WRAP_TEXT : 0;
+		if (WrapType & PPGE_LINE_USE_ELLIPSIS)
+			dtalign |= FLAG_ELLIPSIZE_TEXT;
 		Bounds b(0, 0, wrapWidth <= 0 ? 480.0f : wrapWidth, 272.0f);
 		textDrawer->MeasureStringRect(text, strlen(text), b, &mw, &mh, dtalign);
 
@@ -792,6 +794,7 @@ int GetPow2(int x) {
 
 static PPGeTextDrawerImage PPGeGetTextImage(const char *text, int align, float scale, float maxWidth, bool wrap) {
 	int tdalign = (align & PPGE_ALIGN_HCENTER) ? ALIGN_HCENTER : 0;
+	tdalign |= FLAG_ELLIPSIZE_TEXT;
 	if (wrap) {
 		tdalign |= FLAG_WRAP_TEXT;
 	}
@@ -806,7 +809,6 @@ static PPGeTextDrawerImage PPGeGetTextImage(const char *text, int align, float s
 	} else {
 		std::vector<uint8_t> bitmapData;
 		textDrawer->SetFontScale(scale, scale);
-		// TODO: Ellipsis on long lines...
 		Bounds b(0, 0, maxWidth, 272.0f);
 		textDrawer->DrawStringBitmapRect(bitmapData, im.entry, Draw::DataFormat::R8_UNORM, text, b, tdalign);
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -824,7 +824,8 @@ static PPGeTextDrawerImage PPGeGetTextImage(const char *text, int align, float s
 		std::vector<uint8_t> bitmapData;
 		textDrawer->SetFontScale(scale, scale);
 		Bounds b(0, 0, maxWidth, 272.0f);
-		textDrawer->DrawStringBitmapRect(bitmapData, im.entry, Draw::DataFormat::R8_UNORM, text, b, tdalign);
+		std::string cleaned = ReplaceAll(text, "\r", "");
+		textDrawer->DrawStringBitmapRect(bitmapData, im.entry, Draw::DataFormat::R8_UNORM, cleaned.c_str(), b, tdalign);
 
 		int bufwBytes = ((im.entry.bmWidth + 31) / 32) * 16;
 		u32 sz = bufwBytes * im.entry.bmHeight;

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -45,10 +45,6 @@ void __PPGeShutdown();
 void PPGeBegin();
 void PPGeEnd();
 
-// If you want to draw using this texture but not go through the PSP GE emulation,
-// jsut call this. Will bind the texture to unit 0.
-void PPGeBindTexture();
-
 enum {
 	PPGE_ALIGN_LEFT        = 0,
 	PPGE_ALIGN_RIGHT       = 16,
@@ -66,11 +62,6 @@ enum {
 };
 
 enum {
-	PPGE_ESCAPE_NONE,
-	PPGE_ESCAPE_BACKSLASHED,
-};
-
-enum {
 	PPGE_LINE_NONE         = 0,
 	PPGE_LINE_USE_ELLIPSIS = 1, // use ellipses in too long words
 	PPGE_LINE_WRAP_WORD    = 2,
@@ -80,19 +71,6 @@ enum {
 // Get the metrics of the bounding box of the text without changing the buffer or state.
 void PPGeMeasureText(float *w, float *h, int *n, 
 					const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
-
-// Overwrite the current text lines buffer so it can be drawn later.
-void PPGePrepareText(const char *text, float x, float y, int align, float scale, float lineHeightScale,
-					int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
-
-// Get the metrics of the bounding box of the currently stated text.
-void PPGeMeasureCurrentText(float *x, float *y, float *w, float *h, int *n);
-
-// These functions must be called between PPGeBegin and PPGeEnd.
-
-// Draw currently buffered text using the state from PPGeGetTextBoundingBox() call.
-// Clears the buffer and state when done.
-void PPGeDrawCurrentText(u32 color = 0xFFFFFFFF);
 
 // Draws some text using the one font we have.
 // Clears the text buffer when done.
@@ -152,6 +130,5 @@ private:
 void PPGeDrawRect(float x1, float y1, float x2, float y2, u32 color);
 
 void PPGeSetDefaultTexture();
-void PPGeSetTexture(u32 dataAddr, int width, int height);
 void PPGeDisableTexture();
 

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -85,6 +85,8 @@ void PPGeDrawImage(ImageID atlasImage, float x, float y, int align, u32 color = 
 void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, int align, u32 color = 0xFFFFFFFF);
 void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color);
 
+void PPGeNotifyFrame();
+
 class PPGeImage {
 public:
 	PPGeImage(const std::string &pspFilename);
@@ -110,8 +112,9 @@ public:
 		return height_;
 	}
 
-private:
 	static void Decimate();
+
+private:
 	static std::vector<PPGeImage *> loadedTextures_;
 
 	std::string filename_;

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -365,7 +365,7 @@ void DrawBuffer::DrawImage2GridH(ImageID atlas_image, float x1, float y1, float 
 class AtlasWordWrapper : public WordWrapper {
 public:
 	// Note: maxW may be height if rotated.
-	AtlasWordWrapper(const AtlasFont &atlasfont, float scale, const char *str, float maxW) : WordWrapper(str, maxW), atlasfont_(atlasfont), scale_(scale) {
+	AtlasWordWrapper(const AtlasFont &atlasfont, float scale, const char *str, float maxW, int flags) : WordWrapper(str, maxW, flags), atlasfont_(atlasfont), scale_(scale) {
 	}
 
 protected:
@@ -442,14 +442,15 @@ void DrawBuffer::MeasureTextRect(FontID font_id, const char *text, int count, co
 	}
 
 	std::string toMeasure = std::string(text, count);
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		const AtlasFont *font = atlas->getFont(font_id);
 		if (!font) {
 			*w = 0.0f;
 			*h = 0.0f;
 			return;
 		}
-		AtlasWordWrapper wrapper(*font, fontscalex, toMeasure.c_str(), bounds.w);
+		AtlasWordWrapper wrapper(*font, fontscalex, toMeasure.c_str(), bounds.w, wrap);
 		toMeasure = wrapper.Wrapped();
 	}
 	MeasureTextCount(font_id, toMeasure.c_str(), (int)toMeasure.length(), w, h);
@@ -491,8 +492,9 @@ void DrawBuffer::DrawTextRect(FontID font, const char *text, float x, float y, f
 	}
 
 	std::string toDraw = text;
-	if (align & FLAG_WRAP_TEXT) {
-		AtlasWordWrapper wrapper(*atlas->getFont(font), fontscalex, toDraw.c_str(), w);
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
+		AtlasWordWrapper wrapper(*atlas->getFont(font), fontscalex, toDraw.c_str(), w, wrap);
 		toDraw = wrapper.Wrapped();
 	}
 

--- a/ext/native/gfx_es2/draw_buffer.h
+++ b/ext/native/gfx_es2/draw_buffer.h
@@ -39,6 +39,7 @@ enum {
 	FLAG_DYNAMIC_ASCII = 2048,
 	FLAG_NO_PREFIX = 4096,  // means to not process ampersands
 	FLAG_WRAP_TEXT = 8192,
+	FLAG_ELLIPSIZE_TEXT = 16384,
 };
 
 namespace Draw {

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -67,6 +67,16 @@ void TextDrawer::DrawStringRect(DrawBuffer &target, const char *str, const Bound
 	DrawString(target, toDraw.c_str(), x, y, color, align);
 }
 
+void TextDrawer::DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, const Bounds &bounds, int align) {
+	std::string toDraw = str;
+	if (align & FLAG_WRAP_TEXT) {
+		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
+		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
+	}
+
+	DrawStringBitmap(bitmapData, entry, texFormat, toDraw.c_str(), align);
+}
+
 TextDrawer *TextDrawer::Create(Draw::DrawContext *draw) {
 	TextDrawer *drawer = nullptr;
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -24,8 +24,8 @@ float TextDrawerWordWrapper::MeasureWidth(const char *str, size_t bytes) {
 	return w;
 }
 
-void TextDrawer::WrapString(std::string &out, const char *str, float maxW) {
-	TextDrawerWordWrapper wrapper(this, str, maxW);
+void TextDrawer::WrapString(std::string &out, const char *str, float maxW, int flags) {
+	TextDrawerWordWrapper wrapper(this, str, maxW, flags);
 	out = wrapper.Wrapped();
 }
 
@@ -59,9 +59,10 @@ void TextDrawer::DrawStringRect(DrawBuffer &target, const char *str, const Bound
 	}
 
 	std::string toDraw = str;
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
+		WrapString(toDraw, str, rotated ? bounds.h : bounds.w, wrap);
 	}
 
 	DrawString(target, toDraw.c_str(), x, y, color, align);
@@ -69,9 +70,10 @@ void TextDrawer::DrawStringRect(DrawBuffer &target, const char *str, const Bound
 
 void TextDrawer::DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, const Bounds &bounds, int align) {
 	std::string toDraw = str;
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
+		WrapString(toDraw, str, rotated ? bounds.h : bounds.w, wrap);
 	}
 
 	DrawStringBitmap(bitmapData, entry, texFormat, toDraw.c_str(), align);

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -35,6 +35,8 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 }
 
 float TextDrawer::CalculateDPIScale() {
+	if (ignoreGlobalDpi_)
+		return dpiScale_;
 	float scale = g_dpi_scale_y;
 	if (scale >= 1.0f) {
 		scale = 1.0f;

--- a/ext/native/gfx_es2/draw_text.cpp
+++ b/ext/native/gfx_es2/draw_text.cpp
@@ -42,6 +42,29 @@ float TextDrawer::CalculateDPIScale() {
 	return scale;
 }
 
+void TextDrawer::DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) {
+	float x = bounds.x;
+	float y = bounds.y;
+	if (align & ALIGN_HCENTER) {
+		x = bounds.centerX();
+	} else if (align & ALIGN_RIGHT) {
+		x = bounds.x2();
+	}
+	if (align & ALIGN_VCENTER) {
+		y = bounds.centerY();
+	} else if (align & ALIGN_BOTTOM) {
+		y = bounds.y2();
+	}
+
+	std::string toDraw = str;
+	if (align & FLAG_WRAP_TEXT) {
+		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
+		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
+	}
+
+	DrawString(target, toDraw.c_str(), x, y, color, align);
+}
+
 TextDrawer *TextDrawer::Create(Draw::DrawContext *draw) {
 	TextDrawer *drawer = nullptr;
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -60,6 +60,7 @@ public:
 	virtual void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) = 0;
 	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align);
 	virtual void DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align = ALIGN_TOPLEFT) = 0;
+	void DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, const Bounds &bounds, int align);
 	// Use for housekeeping like throwing out old strings.
 	virtual void OncePerFrame() = 0;
 

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -58,7 +58,8 @@ public:
 	virtual void MeasureString(const char *str, size_t len, float *w, float *h) = 0;
 	virtual void MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) = 0;
 	virtual void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) = 0;
-	virtual void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) = 0;
+	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align);
+	virtual void DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align = ALIGN_TOPLEFT) = 0;
 	// Use for housekeeping like throwing out old strings.
 	virtual void OncePerFrame() = 0;
 

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -64,6 +64,10 @@ public:
 	virtual void OncePerFrame() = 0;
 
 	float CalculateDPIScale();
+	void SetForcedDPIScale(float dpi) {
+		dpiScale_ = dpi;
+		ignoreGlobalDpi_ = true;
+	}
 
 	// Factory function that selects implementation.
 	static TextDrawer *Create(Draw::DrawContext *draw);
@@ -87,10 +91,11 @@ protected:
 		uint32_t fontHash;
 	};
 
-	int frameCount_;
-	float fontScaleX_;
-	float fontScaleY_;
-	float dpiScale_;
+	int frameCount_ = 0;
+	float fontScaleX_ = 1.0f;
+	float fontScaleY_ = 1.0f;
+	float dpiScale_ = 1.0f;
+	bool ignoreGlobalDpi_ = false;
 };
 
 

--- a/ext/native/gfx_es2/draw_text.h
+++ b/ext/native/gfx_es2/draw_text.h
@@ -78,7 +78,7 @@ protected:
 
 	Draw::DrawContext *draw_;
 	virtual void ClearCache() = 0;
-	void WrapString(std::string &out, const char *str, float maxWidth);
+	void WrapString(std::string &out, const char *str, float maxWidth, int flags);
 
 	struct CacheKey {
 		bool operator < (const CacheKey &other) const {
@@ -102,7 +102,7 @@ protected:
 
 class TextDrawerWordWrapper : public WordWrapper {
 public:
-	TextDrawerWordWrapper(TextDrawer *drawer, const char *str, float maxW) : WordWrapper(str, maxW), drawer_(drawer) {
+	TextDrawerWordWrapper(TextDrawer *drawer, const char *str, float maxW, int flags) : WordWrapper(str, maxW, flags), drawer_(drawer) {
 	}
 
 protected:

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -191,7 +191,6 @@ void TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextS
 	assert(env_->GetArrayLength(imageData) == imageWidth * imageHeight);
 	if (texFormat == Draw::DataFormat::B4G4R4A4_UNORM_PACK16 || texFormat == Draw::DataFormat::R4G4B4A4_UNORM_PACK16) {
 		bitmapData.resize(entry.bmWidth * entry.bmHeight * sizeof(uint16_t));
-
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int x = 0; x < entry.bmWidth; x++) {
 			for (int y = 0; y < entry.bmHeight; y++) {
@@ -200,7 +199,17 @@ void TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextS
 				bitmapData16[entry.bmWidth * y + x] = (uint16_t)v;
 			}
 		}
+	} else if (texFormat == Draw::DataFormat::R8_UNORM) {
+		bitmapData.resize(entry.bmWidth * entry.bmHeight);
+		for (int x = 0; x < entry.bmWidth; x++) {
+			for (int y = 0; y < entry.bmHeight; y++) {
+				uint32_t v = jimage[imageWidth * y + x];
+				v = (v >> 12) & 0xF;  // Just grab some bits from the green channel.
+				bitmapData[entry.bmWidth * y + x] = (uint8_t)(v | (v << 4));
+			}
+		}
 	} else {
+		ELOG("Bad TextDrawer format");
 		assert(false);
 	}
 	env_->ReleaseIntArrayElements(imageData, jimage, 0);

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -154,6 +154,59 @@ void TextDrawerAndroid::MeasureStringRect(const char *str, size_t len, const Bou
 	*h = total_h * dpiScale_;
 }
 
+void TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align) {
+	if (!strlen(str)) {
+		bitmapData.clear();
+		return;
+	}
+
+	double size = 0.0;
+	auto iter = fontMap_.find(fontHash_);
+	if (iter != fontMap_.end()) {
+		size = iter->second.size;
+	} else {
+		ELOG("Missing font");
+	}
+
+	jstring jstr = env_->NewStringUTF(str);
+	uint32_t textSize = env_->CallStaticIntMethod(cls_textRenderer, method_measureText, jstr, size);
+	int imageWidth = (short)(textSize >> 16);
+	int imageHeight = (short)(textSize & 0xFFFF);
+	if (imageWidth <= 0)
+		imageWidth = 1;
+	if (imageHeight <= 0)
+		imageHeight = 1;
+
+	jintArray imageData = (jintArray)env_->CallStaticObjectMethod(cls_textRenderer, method_renderText, jstr, size);
+	env_->DeleteLocalRef(jstr);
+
+	entry.texture = nullptr;
+	entry.bmWidth = imageWidth;
+	entry.width = imageWidth;
+	entry.bmHeight = imageHeight;
+	entry.height = imageHeight;
+	entry.lastUsedFrame = frameCount_;
+
+	jint *jimage = env_->GetIntArrayElements(imageData, nullptr);
+	assert(env_->GetArrayLength(imageData) == imageWidth * imageHeight);
+	if (texFormat == Draw::DataFormat::B4G4R4A4_UNORM_PACK16 || texFormat == Draw::DataFormat::R4G4B4A4_UNORM_PACK16) {
+		bitmapData.resize(entry.bmWidth * entry.bmHeight * sizeof(uint16_t));
+
+		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
+		for (int x = 0; x < entry.bmWidth; x++) {
+			for (int y = 0; y < entry.bmHeight; y++) {
+				uint32_t v = jimage[imageWidth * y + x];
+				v = 0xFFF0 | ((v >> 12) & 0xF);  // Just grab some bits from the green channel.
+				bitmapData16[entry.bmWidth * y + x] = (uint16_t)v;
+			}
+		}
+	} else {
+		assert(false);
+	}
+	env_->ReleaseIntArrayElements(imageData, jimage, 0);
+	env_->DeleteLocalRef(imageData);
+}
+
 void TextDrawerAndroid::DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align) {
 	using namespace Draw;
 	std::string text(NormalizeString(std::string(str)));
@@ -169,66 +222,32 @@ void TextDrawerAndroid::DrawString(DrawBuffer &target, const char *str, float x,
 	if (iter != cache_.end()) {
 		entry = iter->second.get();
 		entry->lastUsedFrame = frameCount_;
-		if (entry->texture)
-			draw_->BindTexture(0, entry->texture);
 	} else {
-		double size = 0.0;
-		auto iter = fontMap_.find(fontHash_);
-		if (iter != fontMap_.end()) {
-			size = iter->second.size;
-		} else {
-			ELOG("Missing font");
-		}
-
-		jstring jstr = env_->NewStringUTF(text.c_str());
-		uint32_t textSize = env_->CallStaticIntMethod(cls_textRenderer, method_measureText, jstr, size);
-		int imageWidth = (short)(textSize >> 16);
-		int imageHeight = (short)(textSize & 0xFFFF);
-		if (imageWidth <= 0)
-			imageWidth = 1;
-		if (imageHeight <= 0)
-			imageHeight = 1;
-
-		jintArray imageData = (jintArray)env_->CallStaticObjectMethod(cls_textRenderer, method_renderText, jstr, size);
-		env_->DeleteLocalRef(jstr);
+		DataFormat texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 
 		entry = new TextStringEntry();
-		entry->bmWidth = imageWidth;
-		entry->width = imageWidth;
-		entry->bmHeight = imageHeight;
-		entry->height = imageHeight;
-		entry->lastUsedFrame = frameCount_;
 
 		TextureDesc desc{};
+		std::vector<uint8_t> bitmapData;
+		DrawStringBitmap(bitmapData, *entry, texFormat, text.c_str(), align);
+		desc.initData.push_back(&bitmapData[0]);
+
 		desc.type = TextureType::LINEAR2D;
-		desc.format = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
+		desc.format = texFormat;
 		desc.width = entry->bmWidth;
 		desc.height = entry->bmHeight;
 		desc.depth = 1;
 		desc.mipLevels = 1;
 		desc.generateMips = false;
 		desc.tag = "TextDrawer";
-
-		uint16_t *bitmapData = new uint16_t[entry->bmWidth * entry->bmHeight];
-		jint* jimage = env_->GetIntArrayElements(imageData, nullptr);
-		assert(env_->GetArrayLength(imageData) == imageWidth * imageHeight);
-		for (int x = 0; x < entry->bmWidth; x++) {
-			for (int y = 0; y < entry->bmHeight; y++) {
-				uint32_t v = jimage[imageWidth * y + x];
-				v = 0xFFF0 | ((v >> 12) & 0xF);  // Just grab some bits from the green channel.
-				bitmapData[entry->bmWidth * y + x] = (uint16_t)v;
-			}
-		}
-		env_->ReleaseIntArrayElements(imageData, jimage, 0);
-		env_->DeleteLocalRef(imageData);
-		desc.initData.push_back((uint8_t *)bitmapData);
 		entry->texture = draw_->CreateTexture(desc);
-		delete[] bitmapData;
 		cache_[key] = std::unique_ptr<TextStringEntry>(entry);
-		if (entry->texture) {
-			draw_->BindTexture(0, entry->texture);
-		}
 	}
+
+	if (entry->texture) {
+		draw_->BindTexture(0, entry->texture);
+	}
+
 	float w = entry->bmWidth * fontScaleX_ * dpiScale_;
 	float h = entry->bmHeight * fontScaleY_ * dpiScale_;
 	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
@@ -245,29 +264,6 @@ void TextDrawerAndroid::ClearCache() {
 	}
 	cache_.clear();
 	sizeCache_.clear();
-}
-
-void TextDrawerAndroid::DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) {
-	float x = bounds.x;
-	float y = bounds.y;
-	if (align & ALIGN_HCENTER) {
-		x = bounds.centerX();
-	} else if (align & ALIGN_RIGHT) {
-		x = bounds.x2();
-	}
-	if (align & ALIGN_VCENTER) {
-		y = bounds.centerY();
-	} else if (align & ALIGN_BOTTOM) {
-		y = bounds.y2();
-	}
-
-	std::string toDraw = str;
-	if (align & FLAG_WRAP_TEXT) {
-		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toDraw, str, rotated ? bounds.h : bounds.w);
-	}
-
-	DrawString(target, toDraw.c_str(), x, y, color, align);
 }
 
 void TextDrawerAndroid::OncePerFrame() {

--- a/ext/native/gfx_es2/draw_text_android.cpp
+++ b/ext/native/gfx_es2/draw_text_android.cpp
@@ -115,9 +115,10 @@ void TextDrawerAndroid::MeasureStringRect(const char *str, size_t len, const Bou
 	}
 
 	std::string toMeasure = std::string(str, len);
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w);
+		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w, wrap);
 	}
 
 	std::vector<std::string> lines;

--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -24,7 +24,7 @@ public:
 	void MeasureString(const char *str, size_t len, float *w, float *h) override;
 	void MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) override;
+	void DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align = ALIGN_TOPLEFT) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 

--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -125,7 +125,15 @@ void TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextString
 				bitmapData16[entry.bmWidth * y + x] = 0xfff0 | (image.pixel(x, y) >> 28);
 			}
 		}
+	} else if (texFormat == Draw::DataFormat::R8_UNORM) {
+		bitmapData.resize(entry.bmWidth * entry.bmHeight);
+		for (int x = 0; x < entry.bmWidth; x++) {
+			for (int y = 0; y < entry.bmHeight; y++) {
+				bitmapData[entry.bmWidth * y + x] = image.pixel(x, y) >> 24;
+			}
+		}
 	} else {
+		ELOG("Bad TextDrawer format");
 		assert(false);
 	}
 }

--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -76,9 +76,10 @@ void TextDrawerQt::MeasureString(const char *str, size_t len, float *w, float *h
 
 void TextDrawerQt::MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align) {
 	std::string toMeasure = std::string(str, len);
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w);
+		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w, wrap);
 	}
 
 	QFont* font = fontMap_.find(fontHash_)->second;

--- a/ext/native/gfx_es2/draw_text_qt.h
+++ b/ext/native/gfx_es2/draw_text_qt.h
@@ -27,9 +27,8 @@ protected:
 	uint32_t fontHash_;
 	std::map<uint32_t, QFont *> fontMap_;
 
-	// The key is the CityHash of the string xor the fontHash_.
-	std::map<uint32_t, std::unique_ptr<TextStringEntry>> cache_;
-	std::map<uint32_t, std::unique_ptr<TextMeasureEntry>> sizeCache_;
+	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
+	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };
 
 #endif

--- a/ext/native/gfx_es2/draw_text_qt.h
+++ b/ext/native/gfx_es2/draw_text_qt.h
@@ -17,7 +17,7 @@ public:
 	void MeasureString(const char *str, size_t len, float *w, float *h) override;
 	void MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) override;
+	void DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align = ALIGN_TOPLEFT) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -159,6 +159,9 @@ void TextDrawerWin32::MeasureStringRect(const char *str, size_t len, const Bound
 		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w);
 	}
 
+	TEXTMETRIC metrics{};
+	GetTextMetrics(ctx_->hDC, &metrics);
+
 	std::vector<std::string> lines;
 	SplitString(toMeasure, '\n', lines);
 	float total_w = 0.0f;
@@ -185,8 +188,10 @@ void TextDrawerWin32::MeasureStringRect(const char *str, size_t len, const Bound
 		if (total_w < entry->width * fontScaleX_) {
 			total_w = entry->width * fontScaleX_;
 		}
-		total_h += entry->height * fontScaleY_;
+		int h = i == lines.size() - 1 ? entry->height : metrics.tmHeight + metrics.tmExternalLeading;
+		total_h += h * fontScaleY_;
 	}
+
 	*w = total_w * dpiScale_;
 	*h = total_h * dpiScale_;
 }
@@ -197,7 +202,6 @@ void TextDrawerWin32::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 		return;
 	}
 
-	// Render the string to our bitmap and save to a GL texture.
 	std::wstring wstr = ConvertUTF8ToWString(ReplaceAll(str, "\n", "\r\n"));
 	SIZE size;
 

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "base/display.h"
 #include "base/logging.h"
 #include "base/stringutil.h"
@@ -271,6 +272,17 @@ void TextDrawerWin32::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 				bitmapData16[entry.bmWidth * y + x] = (bAlpha << 12) | 0x0fff;
 			}
 		}
+	} else if (texFormat == Draw::DataFormat::R8_UNORM) {
+		bitmapData.resize(entry.bmWidth * entry.bmHeight);
+		for (int y = 0; y < entry.bmHeight; y++) {
+			for (int x = 0; x < entry.bmWidth; x++) {
+				uint8_t bAlpha = ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff;
+				bitmapData[entry.bmWidth * y + x] = bAlpha;
+			}
+		}
+	} else {
+		ELOG("Bad TextDrawer format");
+		assert(false);
 	}
 }
 

--- a/ext/native/gfx_es2/draw_text_win.cpp
+++ b/ext/native/gfx_es2/draw_text_win.cpp
@@ -154,9 +154,10 @@ void TextDrawerWin32::MeasureStringRect(const char *str, size_t len, const Bound
 	}
 
 	std::string toMeasure = std::string(str, len);
-	if (align & FLAG_WRAP_TEXT) {
+	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
+	if (wrap) {
 		bool rotated = (align & (ROTATE_90DEG_LEFT | ROTATE_90DEG_RIGHT)) != 0;
-		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w);
+		WrapString(toMeasure, toMeasure.c_str(), rotated ? bounds.h : bounds.w, wrap);
 	}
 
 	TEXTMETRIC metrics{};

--- a/ext/native/gfx_es2/draw_text_win.h
+++ b/ext/native/gfx_es2/draw_text_win.h
@@ -24,7 +24,7 @@ public:
 	void MeasureString(const char *str, size_t len, float *w, float *h) override;
 	void MeasureStringRect(const char *str, size_t len, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, const char *str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	void DrawStringRect(DrawBuffer &target, const char *str, const Bounds &bounds, uint32_t color, int align) override;
+	void DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align = ALIGN_TOPLEFT) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 

--- a/ext/native/util/text/wrap_text.h
+++ b/ext/native/util/text/wrap_text.h
@@ -4,8 +4,8 @@
 
 class WordWrapper {
 public:
-	WordWrapper(const char *str, float maxW)
-		: str_(str), maxW_(maxW) {
+	WordWrapper(const char *str, float maxW, int flags)
+		: str_(str), maxW_(maxW), flags_(flags) {
 	}
 
 	std::string Wrapped();
@@ -23,7 +23,9 @@ protected:
 
 	const char *const str_;
 	const float maxW_;
+	const int flags_;
 	std::string out_;
+
 	// Index of last output / start of current word.
 	int lastIndex_ = 0;
 	// Index of last line start.
@@ -32,6 +34,10 @@ protected:
 	float x_ = 0.0f;
 	// Most recent width of word since last index.
 	float wordWidth_ = 0.0f;
+	// Width of "..." when flag is set, zero otherwise.
+	float ellipsisWidth_ = 0.0f;
 	// Force the next word to cut partially and wrap.
 	bool forceEarlyWrap_ = false;
+	// Skip all characters until the next newline.
+	bool scanForNewline_ = false;
 };


### PR DESCRIPTION
On Android, Windows, and Qt, this renders text for PPGe (in game save dialogs, message dialogs, etc.) with system fonts.

The benefit of this is that it should handle various languages, combining characters, etc. better.  And just like with the UI, it won't have problems with missing characters either.

This also updates Qt's TextDrawer to cache the proper way, but I haven't tested Qt.

Fixes #10621, fixes #1904, fixes #1650, fixes #2127, and fixes #10879 (I think, the spacing looks better anyway.)  It doesn't fix these on SDL, but we have #6681 for that already.

Also slipped in a small fix for decimating PPGe images.

-[Unknown]