### PR TITLE
UI: Rebind the backbuffer when drawing UI

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1403,6 +1403,8 @@ void EmuScreen::render() {
 		return;
 
 	if (hasVisibleUI()) {
+		// In most cases, this should already be bound and a no-op.
+		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE });
 		cardboardDisableButton_->SetVisibility(g_Config.bEnableCardboardVR ? UI::V_VISIBLE : UI::V_GONE);
 		screenManager()->getUIContext()->BeginFrame();
 		renderUI();


### PR DESCRIPTION
In case it was unbound after copying to display, such as from screen recording.  See #12305.

Have not tested to confirm it fixes it, but I assume it will from the backtrace.

-[Unknown]