### PR TITLE
Cleanup net init/memory and dialog behavior

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -44,6 +44,11 @@ public:
 	virtual int Shutdown(bool force = false) override;
 	virtual void DoState(PointerWrap &p) override;
 
+protected:
+	bool UseAutoStatus() override {
+		return false;
+	}
+
 private:
 	void DrawBanner();
 	SceUtilityNetconfParam request;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -21,6 +21,7 @@
 #include "Common/ChunkFile.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceKernelMemory.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/Config.h"
 #include "Core/MemMapHelpers.h"
@@ -40,6 +41,9 @@ static bool netInetInited;
 static bool netApctlInited;
 u32 netDropRate = 0;
 u32 netDropDuration = 0;
+u32 netPoolAddr = 0;
+u32 netThread1Addr = 0;
+u32 netThread2Addr = 0;
 
 static struct SceNetMallocStat netMallocStat;
 
@@ -78,7 +82,7 @@ static void __UpdateApctlHandlers(int oldState, int newState, int flag, int erro
 
 // This feels like a dubious proposition, mostly...
 void __NetDoState(PointerWrap &p) {
-	auto s = p.Section("sceNet", 1, 2);
+	auto s = p.Section("sceNet", 1, 3);
 	if (!s)
 		return;
 
@@ -94,6 +98,28 @@ void __NetDoState(PointerWrap &p) {
 		p.Do(netDropRate);
 		p.Do(netDropDuration);
 	}
+	if (s < 3) {
+		netPoolAddr = 0;
+		netThread1Addr = 0;
+		netThread2Addr = 0;
+	} else {
+		p.Do(netPoolAddr);
+		p.Do(netThread1Addr);
+		p.Do(netThread2Addr);
+	}
+}
+
+static inline u32 AllocUser(u32 size, bool fromTop, const char *name) {
+	u32 addr = userMemory.Alloc(size, true, "netstack1");
+	if (addr == -1)
+		return 0;
+	return addr;
+}
+
+static inline void FreeUser(u32 &addr) {
+	if (addr != 0)
+		userMemory.Free(addr);
+	addr = 0;
 }
 
 static u32 sceNetTerm() {
@@ -103,15 +129,47 @@ static u32 sceNetTerm() {
 
 	WARN_LOG(SCENET, "sceNetTerm()");
 	netInited = false;
+	FreeUser(netPoolAddr);
+	FreeUser(netThread1Addr);
+	FreeUser(netThread2Addr);
 
 	return 0;
 }
 
 // TODO: should that struct actually be initialized here?
-static u32 sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netinitPri, u32 netinitStack)  {
-	// May need to Terminate old one first since the game (ie. GTA:VCS) might not called sceNetTerm before the next sceNetInit and behave strangely
-	if (netInited) 
+static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netinitPri, u32 netinitStack)  {
+	// TODO: The correct behavior is actually to allocate more and leak the other threads/pool.
+	// But we reset here for historic reasons (GTA:VCS potentially triggers this.)
+	if (netInited)
 		sceNetTerm();
+
+	if (poolSize == 0) {
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_ILLEGAL_MEMSIZE, "invalid pool size");
+	} else if (calloutPri < 0x08 || calloutPri > 0x77) {
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_ILLEGAL_PRIORITY, "invalid callout thread priority");
+	} else if (netinitPri < 0x08 || netinitPri > 0x77) {
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_ILLEGAL_PRIORITY, "invalid init thread priority");
+	}
+
+	// TODO: Should also start the threads, probably?  For now, let's just allocate.
+	// TODO: Respect the stack size if firmware set to 1.50?
+	u32 stackSize = 4096;
+	netThread1Addr = AllocUser(stackSize, true, "netstack1");
+	if (netThread1Addr == 0) {
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_NO_MEMORY, "unable to allocate thread");
+	}
+	netThread2Addr = AllocUser(stackSize, true, "netstack2");
+	if (netThread2Addr == 0) {
+		FreeUser(netThread1Addr);
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_NO_MEMORY, "unable to allocate thread");
+	}
+
+	netPoolAddr = AllocUser(poolSize, false, "netpool");
+	if (netPoolAddr == 0) {
+		FreeUser(netThread1Addr);
+		FreeUser(netThread2Addr);
+		return hleLogError(SCENET, SCE_KERNEL_ERROR_NO_MEMORY, "unable to allocate pool");
+	}
 
 	WARN_LOG(SCENET, "sceNetInit(poolsize=%d, calloutpri=%i, calloutstack=%d, netintrpri=%i, netintrstack=%d) at %08x", poolSize, calloutPri, calloutStack, netinitPri, netinitStack, currentMIPS->pc);
 	netInited = true;
@@ -119,7 +177,7 @@ static u32 sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 	netMallocStat.free = poolSize;
 	netMallocStat.pool = 0;
 	
-	return 0;
+	return hleLogSuccessI(SCENET, 0);
 }
 
 static u32 sceWlanGetEtherAddr(u32 addrAddr) {
@@ -468,7 +526,7 @@ static int sceNetSetDropRate(u32 dropRate, u32 dropDuration)
 }
 
 const HLEFunction sceNet[] = {
-	{0X39AF39A6, &WrapU_UUUUU<sceNetInit>,           "sceNetInit",                      'x', "xxxxx"},
+	{0X39AF39A6, &WrapI_UUUUU<sceNetInit>,           "sceNetInit",                      'i', "xxxxx"},
 	{0X281928A9, &WrapU_V<sceNetTerm>,               "sceNetTerm",                      'x', ""     },
 	{0X89360950, &WrapI_UU<sceNetEtherNtostr>,       "sceNetEtherNtostr",               'i', "xx"   },
 	{0XD27961C9, &WrapI_UU<sceNetEtherStrton>,       "sceNetEtherStrton",               'i', "xx"   },

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -160,8 +160,6 @@ void __NetAdhocInit() {
 }
 
 u32 sceNetAdhocInit() {
-	// Library uninitialized
-	INFO_LOG(SCENET, "sceNetAdhocInit() at %08x", currentMIPS->pc);
 	if (!netAdhocInited) {
 		// Clear Translator Memory
 		memset(&pdp, 0, sizeof(pdp));
@@ -173,17 +171,17 @@ u32 sceNetAdhocInit() {
 		// Create fake PSP Thread for callback
 		// TODO: Should use a separated threads for friendFinder, matchingEvent, and matchingInput and created on AdhocctlInit & AdhocMatchingStart instead of here
 		#define PSP_THREAD_ATTR_KERNEL 0x00001000 // PSP_THREAD_ATTR_KERNEL is located in sceKernelThread.cpp instead of sceKernelThread.h :(
-		//threadAdhocID = __KernelCreateThreadInternal("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x30, 4096, PSP_THREAD_ATTR_KERNEL);
-		threadAdhocID = __KernelCreateThread("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x10, 0x1000, 0, 0, false);
+		// TODO: This should probably be a user thread, but maybe from sceNetAdhocctlInit?
+		threadAdhocID = __KernelCreateThread("AdhocThread", __KernelGetCurThreadModuleId(), dummyThreadHackAddr, 0x10, 0x1000, PSP_THREAD_ATTR_KERNEL, 0, true);
 		if (threadAdhocID > 0) {
 			__KernelStartThread(threadAdhocID, 0, 0);
 		}
 
 		// Return Success
-		return 0;
+		return hleLogSuccessInfoI(SCENET, 0, "at %08x", currentMIPS->pc);
 	}
 	// Already initialized
-	return ERROR_NET_ADHOC_ALREADY_INITIALIZED;
+	return hleLogWarning(SCENET, ERROR_NET_ADHOC_ALREADY_INITIALIZED, "already initialized");
 }
 
 static u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
@@ -1419,7 +1417,6 @@ int sceNetAdhocctlCreateEnterGameModeMin(const char *group_name, int game_type, 
 }
 
 int sceNetAdhocTerm() {
-	INFO_LOG(SCENET, "sceNetAdhocTerm()");
 	// WLAN might be disabled in the middle of successfull multiplayer, but we still need to cleanup all the sockets right?
 
 	if (netAdhocctlInited) sceNetAdhocctlTerm();
@@ -1448,10 +1445,11 @@ int sceNetAdhocTerm() {
 		// if (_manage_modules != 0) sceUtilityUnloadModule(PSP_MODULE_NET_INET);
 		// Library shutdown
 		netAdhocInited = false;
-		return 0;
+		return hleLogSuccessInfoI(SCENET, 0);
 	} else {
-		// Seems to return this when called a second time after being terminated without another initialisation
-		return SCE_KERNEL_ERROR_LWMUTEX_NOT_FOUND;
+		// TODO: Reportedly returns SCE_KERNEL_ERROR_LWMUTEX_NOT_FOUND in some cases?
+		// Only seen returning 0 in tests.
+		return hleLogWarning(SCENET, 0, "already uninitialized");
 	}
 }
 

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -760,6 +760,18 @@ static u32 sceUtilityUnloadNetModule(u32 module)
 	return 0;
 }
 
+static int sceUtilityNpSigninInitStart(u32 paramsPtr) {
+	return hleLogError(SCEUTILITY, 0, "not implemented");
+}
+
+static int sceUtilityNpSigninUpdate(int animSpeed) {
+	return hleLogError(SCEUTILITY, 0, "not implemented");
+}
+
+static int sceUtilityNpSigninGetStatus() {
+	return hleLogError(SCEUTILITY, 0, "not implemented");
+}
+
 static void sceUtilityInstallInitStart(u32 unknown)
 {
 	WARN_LOG_REPORT(SCEUTILITY, "UNIMPL sceUtilityInstallInitStart()");
@@ -925,7 +937,7 @@ const HLEFunction sceUtility[] =
 
 	{0X0251B134, &WrapI_U<sceUtilityScreenshotInitStart>,          "sceUtilityScreenshotInitStart",          'i', "x"  },
 	{0XF9E0008C, &WrapI_V<sceUtilityScreenshotShutdownStart>,      "sceUtilityScreenshotShutdownStart",      'i', ""   },
-	{0XAB083EA9, &WrapI_U<sceUtilityScreenshotUpdate>,             "sceUtilityScreenshotUpdate",             'i', "x"  },
+	{0XAB083EA9, &WrapI_U<sceUtilityScreenshotUpdate>,             "sceUtilityScreenshotUpdate",             'i', "i"  },
 	{0XD81957B7, &WrapI_V<sceUtilityScreenshotGetStatus>,          "sceUtilityScreenshotGetStatus",          'i', ""   },
 	{0X86A03A27, &WrapI_U<sceUtilityScreenshotContStart>,          "sceUtilityScreenshotContStart",          'i', "x"  },
 
@@ -938,10 +950,10 @@ const HLEFunction sceUtility[] =
 	{0XB57E95D9, &WrapI_V<sceUtilityGamedataInstallGetStatus>,     "sceUtilityGamedataInstallGetStatus",     'i', ""   },
 	{0X180F7B62, &WrapI_V<sceUtilityGamedataInstallAbort>,         "sceUtilityGamedataInstallAbort",         'i', ""   },
 
-	{0X16D02AF0, nullptr,                                          "sceUtilityNpSigninInitStart",            '?', ""   },
-	{0XE19C97D6, nullptr,                                          "sceUtilityNpSigninShutdownStart",        '?', ""   },
-	{0XF3FBC572, nullptr,                                          "sceUtilityNpSigninUpdate",               '?', ""   },
-	{0X86ABDB1B, nullptr,                                          "sceUtilityNpSigninGetStatus",            '?', ""   },
+	{0X16D02AF0, &WrapI_U<sceUtilityNpSigninInitStart>,            "sceUtilityNpSigninInitStart",            'i', "x"  },
+	{0XE19C97D6, nullptr,                                          "sceUtilityNpSigninShutdownStart",        'i', ""   },
+	{0XF3FBC572, &WrapI_I<sceUtilityNpSigninUpdate>,               "sceUtilityNpSigninUpdate",               'i', "i"  },
+	{0X86ABDB1B, &WrapI_V<sceUtilityNpSigninGetStatus>,            "sceUtilityNpSigninGetStatus",            'i', ""   },
 
 	{0X1281DA8E, &WrapV_U<sceUtilityInstallInitStart>,             "sceUtilityInstallInitStart",             'v', "x"  },
 	{0X5EF1C24A, nullptr,                                          "sceUtilityInstallShutdownStart",         '?', ""   },

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -470,55 +470,46 @@ static int sceUtilityOskGetStatus()
 }
 
 
-static int sceUtilityNetconfInitStart(u32 paramsAddr)
-{
+static int sceUtilityNetconfInitStart(u32 paramsAddr) {
 	if (currentDialogActive && currentDialogType != UTILITY_DIALOG_NET) {
-		WARN_LOG(SCEUTILITY, "sceUtilityNetconfInitStart(%08x): wrong dialog type", paramsAddr);
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
 	oldStatus = 100;
 	currentDialogType = UTILITY_DIALOG_NET;
-	currentDialogActive = true;	
-	int ret = netDialog.Init(paramsAddr);
-	INFO_LOG(SCEUTILITY, "%08x=sceUtilityNetconfInitStart(%08x)", ret, paramsAddr);
-	return ret;
+	currentDialogActive = true;
+	return hleLogSuccessInfoI(SCEUTILITY, netDialog.Init(paramsAddr));
 }
 
-static int sceUtilityNetconfShutdownStart()
-{
+static int sceUtilityNetconfShutdownStart() {
 	if (currentDialogType != UTILITY_DIALOG_NET) {
-		WARN_LOG(SCEUTILITY, "sceUtilityNetconfShutdownStart(): wrong dialog type");
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
 	currentDialogActive = false;
-	int ret = netDialog.Shutdown();
-	DEBUG_LOG(SCEUTILITY, "%08x=sceUtilityNetconfShutdownStart()",ret);
-	return ret;
+	return hleLogSuccessI(SCEUTILITY, netDialog.Shutdown());
 }
 
-static int sceUtilityNetconfUpdate(int animSpeed)
-{
-	int ret = netDialog.Update(animSpeed);
-	ERROR_LOG(SCEUTILITY, "UNIMPL %08x=sceUtilityNetconfUpdate(%i)", ret, animSpeed);
-	return ret;
-}
-
-static int sceUtilityNetconfGetStatus()
-{
-	// Spam in Danball Senki BOOST
+static int sceUtilityNetconfUpdate(int animSpeed) {
 	if (currentDialogType != UTILITY_DIALOG_NET) {
-		DEBUG_LOG(SCEUTILITY, "sceUtilityNetconfGetStatus(): wrong dialog type");
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
+	}
+
+	return hleLogSuccessI(SCEUTILITY, netDialog.Update(animSpeed));
+}
+
+static int sceUtilityNetconfGetStatus() {
+	if (currentDialogType != UTILITY_DIALOG_NET) {
+		// Spam in Danball Senki BOOST.
+		return hleLogDebug(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 
 	int status = netDialog.GetStatus();
 	if (oldStatus != status) {
 		oldStatus = status;
-		DEBUG_LOG(SCEUTILITY, "%08x=sceUtilityNetconfGetStatus()", status);
+		return hleLogSuccessI(SCEUTILITY, status);
 	}
-	return status;
+	return hleLogSuccessVerboseI(SCEUTILITY, status);
 }
 
 static int sceUtilityCheckNetParam(int id)

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -380,6 +380,7 @@ int main(int argc, const char* argv[])
 	g_Config.bMemStickInserted = true;
 	g_Config.bFragmentTestCache = true;
 	g_Config.iAudioLatency = 1;
+	g_Config.bEnableWlan = true;
 
 #ifdef _WIN32
 	g_Config.internalDataDirectory = "";

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -381,6 +381,7 @@ int main(int argc, const char* argv[])
 	g_Config.bFragmentTestCache = true;
 	g_Config.iAudioLatency = 1;
 	g_Config.bEnableWlan = true;
+	g_Config.sMACAddress = "12:34:56:78:9A:BC";
 
 #ifdef _WIN32
 	g_Config.internalDataDirectory = "";


### PR DESCRIPTION
I'm not really planning to start messing with netplay, but I had created some tests a bit ago to validate some of the initial network funcs etc.

This also makes it so the dialog correctly closes, which may prevent it from locking up other dialogs (like that Yu-gi-oh save issue.)  And it prevents a hang when you try to use online play that requires a sign-in (at least in the games I tried.)

-[Unknown]