### PR TITLE
Vpl: Correct allocation order when splitting block

### DIFF
--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -213,10 +213,6 @@ struct SceKernelVplHeader {
 		do {
 			auto b = prev->next;
 			if (b->sizeInBlocks > allocBlocks) {
-				if (nextFreeBlock_ == b) {
-					nextFreeBlock_ = prev;
-				}
-				prev = b;
 				b = SplitBlock(b, allocBlocks);
 			}
 
@@ -289,16 +285,13 @@ struct SceKernelVplHeader {
 	void UnlinkFreeBlock(PSPPointer<SceKernelVplBlock> b, PSPPointer<SceKernelVplBlock> prev) {
 		allocatedInBlocks_ += b->sizeInBlocks;
 		prev->next = b->next;
-		if (nextFreeBlock_ == b) {
-			nextFreeBlock_ = prev;
-		}
+		nextFreeBlock_ = prev;
 		b->next = SentinelPtr();
 	}
 
 	PSPPointer<SceKernelVplBlock> SplitBlock(PSPPointer<SceKernelVplBlock> b, u32 allocBlocks) {
-		u32 prev = b->next.ptr;
+		u32 prev = b.ptr;
 		b->sizeInBlocks -= allocBlocks;
-		b->next = b + b->sizeInBlocks;
 
 		b += b->sizeInBlocks;
 		b->sizeInBlocks = allocBlocks;


### PR DESCRIPTION
More fuzz testing produced cases that were still off.  This is simpler but still passes the test.

I'm expecting this to take care of #6682 and not regress #3485.  I think the allocation order is correct now.

It's possible #6057 may even be the same, perhaps.  The game has double-free issues so the order might be important...

-[Unknown]