### PR TITLE
Qt: Correct DPI accounting in font rendering

### DIFF
--- a/ext/native/gfx_es2/draw_text_qt.cpp
+++ b/ext/native/gfx_es2/draw_text_qt.cpp
@@ -35,7 +35,7 @@ uint32_t TextDrawerQt::SetFont(const char *fontName, int size, int flags) {
 	}
 
 	QFont *font = fontName ? new QFont(fontName) : new QFont();
-	font->setPixelSize(size + 6);
+	font->setPixelSize((int)((size + 6) / dpiScale_));
 	fontMap_[fontHash] = font;
 	fontHash_ = fontHash;
 	return fontHash;
@@ -85,8 +85,8 @@ void TextDrawerQt::MeasureStringRect(const char *str, size_t len, const Bounds &
 	QFont* font = fontMap_.find(fontHash_)->second;
 	QFontMetrics fm(*font);
 	QSize size = fm.size(0, QString::fromUtf8(toMeasure.c_str(), (int)toMeasure.size()));
-	*w = (float)size.width() * fontScaleX_;
-	*h = (float)size.height() * fontScaleY_;
+	*w = (float)size.width() * fontScaleX_ * dpiScale_;
+	*h = (float)size.height() * fontScaleY_ * dpiScale_;
 }
 
 void TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align) {


### PR DESCRIPTION
Like Android, we'll increase the font size at higher DPI.

See https://github.com/hrydgard/ppsspp/commit/70b07f20c91663f0ee9c24736a634c0d71762651#commitcomment-37886391.  @CarterLi does this help?

-[Unknown]