### PR TITLE
Correcting return value of some mipscalls without after action.

### DIFF
--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -961,6 +961,7 @@ static int sceFontDoneLib(u32 fontLibHandle) {
 	INFO_LOG(SCEFONT, "sceFontDoneLib(%08x)", fontLibHandle);
 	FontLib *fl = GetFontLib(fontLibHandle);
 	if (fl) {
+		currentMIPS->r[MIPS_REG_V0] = 0;
 		fl->Done();
 	}
 	return 0;
@@ -1094,8 +1095,10 @@ static int sceFontClose(u32 fontHandle) {
 	if (font) {
 		DEBUG_LOG(SCEFONT, "sceFontClose(%x)", fontHandle);
 		FontLib *fontLib = font->GetFontLib();
-		if (fontLib)
+		if (fontLib) {
+			currentMIPS->r[MIPS_REG_V0] = 0;
 			fontLib->CloseFont(font);
+		}
 	} else
 		ERROR_LOG(SCEFONT, "sceFontClose(%x) - font not open?", fontHandle);
 	return 0;
@@ -1420,6 +1423,7 @@ static int sceFontFlush(u32 fontHandle) {
 		return ERROR_FONT_INVALID_PARAMETER;
 	}
 
+	currentMIPS->r[MIPS_REG_V0] = 0;
 	font->GetFontLib()->flushFont();
 
 	return 0;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -474,6 +474,7 @@ static int sceNetApctlDisconnect() {
 	ERROR_LOG(SCENET, "UNIMPL %s()", __FUNCTION__);
 	// Like its 'sister' function sceNetAdhocctlDisconnect, we need to alert Apctl handlers that a disconnect took place
 	// or else games like Phantasy Star Portable 2 will hang at certain points (e.g. returning to the main menu after trying to connect to PSN).
+	currentMIPS->r[MIPS_REG_V0] = 0;
 	__UpdateApctlHandlers(0, 0, PSP_NET_APCTL_EVENT_DISCONNECT_REQUEST, 0);
 	return 0;
 }


### PR DESCRIPTION
Fixes #12726, the V0 mipscall saved is the return value from last call instead of current syscall, so likely to return a wrong value. This seems the simplest way to fix, not technical enough though...