### PR TITLE
Android: Fix dismiss of native OSK dialog

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -682,6 +682,14 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendInputBox(JNIEnv *en
 	std::string seqID = GetJavaString(env, jseqID);
 	std::string value = GetJavaString(env, jvalue);
 
+	static std::string lastSeqID = "";
+	if (lastSeqID == seqID) {
+		// We send this on dismiss, so twice in many cases.
+		DLOG("Ignoring duplicate sendInputBox");
+		return;
+	}
+	lastSeqID = seqID;
+
 	int seq = 0;
 	if (!TryParse(seqID, &seq)) {
 		ELOG("Invalid inputbox seqID value: %s", seqID.c_str());

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1213,6 +1213,12 @@ public abstract class NativeActivity extends Activity implements SurfaceHolder.C
 					d.cancel();
 				}
 			})
+			.setOnDismissListener(new DialogInterface.OnDismissListener() {
+				@Override
+				public void onDismiss(DialogInterface d) {
+					NativeApp.sendInputBox(seqID, false, "");
+				}
+			})
 			.create();
 
 		dlg.setCancelable(true);


### PR DESCRIPTION
See #12732.  To keep things simple, I made it just ignore duplicate seqIDs, since this will send two for confirm (one success, then a failure when it closes.)

-[Unknown]