### PR TITLE
UI: Allow startup without UI assets

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -818,7 +818,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	size_t atlas_data_size = 0;
 	if (!g_ui_atlas.IsMetadataLoaded()) {
 		const uint8_t *atlas_data = VFSReadFile("ui_atlas.meta", &atlas_data_size);
-		bool load_success = g_ui_atlas.Load(atlas_data, atlas_data_size);
+		bool load_success = atlas_data != nullptr && g_ui_atlas.Load(atlas_data, atlas_data_size);
 		_assert_msg_(G3D, load_success, "Failed to load ui_atlas.meta");
 		delete[] atlas_data;
 	}

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -496,8 +496,9 @@ void DrawBuffer::DrawTextRect(FontID font, const char *text, float x, float y, f
 
 	std::string toDraw = text;
 	int wrap = align & (FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT);
-	if (wrap) {
-		AtlasWordWrapper wrapper(*atlas->getFont(font), fontscalex, toDraw.c_str(), w, wrap);
+	const AtlasFont *atlasfont = atlas->getFont(font);
+	if (wrap && atlasfont) {
+		AtlasWordWrapper wrapper(*atlasfont, fontscalex, toDraw.c_str(), w, wrap);
 		toDraw = wrapper.Wrapped();
 	}
 

--- a/ext/native/gfx_es2/draw_buffer.cpp
+++ b/ext/native/gfx_es2/draw_buffer.cpp
@@ -250,6 +250,9 @@ inline void rot(float *v, float angle, float xc, float yc) {
 
 void DrawBuffer::DrawImageRotated(ImageID atlas_image, float x, float y, float scale, float angle, Color color, bool mirror_h) {
 	const AtlasImage *image = atlas->getImage(atlas_image);
+	if (!image)
+		return;
+
 	float w = (float)image->w * scale;
 	float h = (float)image->h * scale;
 	float x1 = x - w / 2;

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -38,7 +38,6 @@ void UIContext::BeginFrame() {
 		uitexture_ = CreateTextureFromFile(draw_, "ui_atlas.zim", ImageFileType::ZIM, false);
 		if (!uitexture_) {
 			PanicAlert("Failed to load ui_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.");
-			FLOG("Failed to load ui_atlas.zim");
 		}
 	}
 	uidrawbufferTop_->SetCurZ(0.0f);
@@ -47,9 +46,7 @@ void UIContext::BeginFrame() {
 }
 
 void UIContext::Begin() {
-	draw_->BindSamplerStates(0, 1, &sampler_);
-	draw_->BindTexture(0, uitexture_->GetTexture());
-	UIBegin(ui_pipeline_);
+	BeginPipeline(ui_pipeline_, sampler_);
 }
 
 void UIContext::BeginNoTex() {
@@ -58,13 +55,14 @@ void UIContext::BeginNoTex() {
 }
 
 void UIContext::BeginPipeline(Draw::Pipeline *pipeline, Draw::SamplerState *samplerState) {
-	draw_->BindSamplerStates(0, 1, &sampler_);
-	draw_->BindTexture(0, uitexture_->GetTexture());
+	draw_->BindSamplerStates(0, 1, &samplerState);
+	RebindTexture();
 	UIBegin(pipeline);
 }
 
 void UIContext::RebindTexture() const {
-	draw_->BindTexture(0, uitexture_->GetTexture());
+	if (uitexture_)
+		draw_->BindTexture(0, uitexture_->GetTexture());
 }
 
 void UIContext::Flush() {


### PR DESCRIPTION
This makes it so PPSSPP will actually start, even without UI assets.  One could argue it shouldn't, although I think it depends on platform nowadays.

On Windows, Qt, and Android - the situation is usable, but ugly.  Most text is rendered, so you can get around mostly.

On anything that bypasses the UI, such as a frontend/libretro or just starting with a game argument, save dialogs are borderline usable even without text.  They're bad, but I'd say solidly better than hard crashing.  With text rendering, they're pretty okay.

The worst case here is UI on i.e. SDL.  If you have recent games, they'll show, but basically nothing else will.  But hopefully you'll see the panic message about missing assets.

Fixes #12722.

-[Unknown]