### PR TITLE
GPU: Assume a scissor of 481x273 is a mistake

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -234,6 +234,10 @@ void FramebufferManagerCommon::EstimateDrawingSize(u32 fb_address, GEBufferForma
 			drawing_width = scissor_width;
 			drawing_height = std::max(drawing_height, scissor_height);
 		}
+		if (scissor_width == 481 && region_width == 480 && scissor_height == 273 && region_height == 272) {
+			drawing_width = 480;
+			drawing_height = 272;
+		}
 	} else {
 		// If viewport wasn't valid, let's just take the greatest anything regardless of stride.
 		drawing_width = std::min(std::max(region_width, scissor_width), fb_stride);


### PR DESCRIPTION
We already do this for viewport, and only when region is still a correct size.  Helps flicker in Everybody's Golf.  I think it's relatively safe.

See comments in #12355 - this was causing flicker.  It's possible this is related to #6655, because I think this flicker only occurs on the green.

This doesn't fix the Vulkan perf issue mentioned there, though.

-[Unknown]