### PR TITLE
UI: Translate HAT and left analog the same way

### DIFF
--- a/ext/native/ui/root.cpp
+++ b/ext/native/ui/root.cpp
@@ -253,8 +253,11 @@ bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
 		NEG = 2,
 	};
 	struct PrevState {
-		DirState x = DirState::NONE;
-		DirState y = DirState::NONE;
+		PrevState() : x(DirState::NONE), y(DirState::NONE) {
+		}
+
+		DirState x;
+		DirState y;
 	};
 	struct StateKey {
 		int deviceId;

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -14,7 +14,7 @@
 static const bool ClickDebug = false;
 
 UIScreen::UIScreen()
-	: Screen(), root_(nullptr), translation_(0.0f), scale_(1.0f), recreateViews_(true), hatDown_(0) {
+	: Screen() {
 }
 
 UIScreen::~UIScreen() {
@@ -182,39 +182,11 @@ void UIDialogScreen::sendMessage(const char *msg, const char *value) {
 }
 
 bool UIScreen::axis(const AxisInput &axis) {
-	// Simple translation of hat to keys for Shield and other modern pads.
-	// TODO: Use some variant of keymap?
-	int flags = 0;
-	if (axis.axisId == JOYSTICK_AXIS_HAT_X) {
-		if (axis.value < -0.7f)
-			flags |= PAD_BUTTON_LEFT;
-		if (axis.value > 0.7f)
-			flags |= PAD_BUTTON_RIGHT;
-	}
-	if (axis.axisId == JOYSTICK_AXIS_HAT_Y) {
-		if (axis.value < -0.7f)
-			flags |= PAD_BUTTON_UP;
-		if (axis.value > 0.7f)
-			flags |= PAD_BUTTON_DOWN;
-	}
-
-	// Yeah yeah, this should be table driven..
-	int pressed = flags & ~hatDown_;
-	int released = ~flags & hatDown_;
-	if (pressed & PAD_BUTTON_LEFT) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_LEFT, KEY_DOWN));
-	if (pressed & PAD_BUTTON_RIGHT) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_RIGHT, KEY_DOWN));
-	if (pressed & PAD_BUTTON_UP) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_UP, KEY_DOWN));
-	if (pressed & PAD_BUTTON_DOWN) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_DOWN, KEY_DOWN));
-	if (released & PAD_BUTTON_LEFT) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_LEFT, KEY_UP));
-	if (released & PAD_BUTTON_RIGHT) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_RIGHT, KEY_UP));
-	if (released & PAD_BUTTON_UP) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_UP, KEY_UP));
-	if (released & PAD_BUTTON_DOWN) key(KeyInput(DEVICE_ID_KEYBOARD, NKCODE_DPAD_DOWN, KEY_UP));
-	hatDown_ = flags;
 	if (root_) {
 		UI::AxisEvent(axis, root_);
 		return true;
 	}
-	return (pressed & (PAD_BUTTON_LEFT | PAD_BUTTON_RIGHT | PAD_BUTTON_UP | PAD_BUTTON_DOWN)) != 0;
+	return false;
 }
 
 UI::EventReturn UIScreen::OnBack(UI::EventParams &e) {

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -44,17 +44,15 @@ protected:
 
 	virtual void RecreateViews() override { recreateViews_ = true; }
 
-	UI::ViewGroup *root_;
-	Vec3 translation_;
-	Vec3 scale_;
+	UI::ViewGroup *root_ = nullptr;
+	Vec3 translation_ = Vec3(0.0f);
+	Vec3 scale_ = Vec3(1.0f);
 	float alpha_ = 1.0f;
 
 private:
 	void DoRecreateViews();
 
-	bool recreateViews_;
-
-	int hatDown_;
+	bool recreateViews_ = true;
 };
 
 class UIDialogScreen : public UIScreen {


### PR DESCRIPTION
Before, we were resetting our HAT state for each axis we got, so we'd act like you pressed the arrow more times for each axis your device has.

A similar thing was possible if you had multiple pads, and this even happened in the left analog stick handling.

Fixes #12423.

-[Unknown]