### PR TITLE
UI: Prevent stretching game icons on detail screen

### DIFF
--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -68,7 +68,7 @@ void GameScreen::CreateViews() {
 
 	leftColumn->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameScreen::OnSwitchBack);
 	if (info) {
-		leftColumn->Add(new GameIconView(gamePath_, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
+		leftColumn->Add(new GameIconView(gamePath_, 2.0f, new AnchorLayoutParams(144 * 2, 80 * 2, 10, 10, NONE, NONE)));
 
 		LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));
 		leftColumn->Add(infoLayout);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -85,7 +85,7 @@ public:
 			std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
 
 			if (ginfo->icon.texture) {
-				toprow->Add(new GameIconView(savePath_, new LinearLayoutParams(Margins(10, 5))));
+				toprow->Add(new GameIconView(savePath_, 2.0f, new LinearLayoutParams(Margins(10, 5))));
 			}
 			LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f));
 			topright->SetSpacing(1.0f);

--- a/UI/TextureUtil.cpp
+++ b/UI/TextureUtil.cpp
@@ -228,8 +228,8 @@ void GameIconView::Draw(UIContext &dc) {
 		return;
 	}
 
-	textureWidth_ = info->icon.texture->Width();
-	textureHeight_ = info->icon.texture->Height();
+	textureWidth_ = info->icon.texture->Width() * scale_;
+	textureHeight_ = info->icon.texture->Height() * scale_;
 
 	// Fade icon with the backgrounds.
 	double loadTime = info->icon.timeLoaded;
@@ -241,9 +241,13 @@ void GameIconView::Draw(UIContext &dc) {
 	}
 	uint32_t color = whiteAlpha(ease((time_now_d() - loadTime) * 3));
 
+	// Adjust size so we don't stretch the image vertically or horizontally.
+	// Make sure it's not wider than 144 (like Doom Legacy homebrew), ugly in the grid mode.
+	float nw = std::min(bounds_.h * textureWidth_ / textureHeight_, (float)bounds_.w);
+
 	dc.Flush();
 	dc.GetDrawContext()->BindTexture(0, info->icon.texture->GetTexture());
-	dc.Draw()->Rect(bounds_.x, bounds_.y, bounds_.w, bounds_.h, color);
+	dc.Draw()->Rect(bounds_.x, bounds_.y, nw, bounds_.h, color);
 	dc.Flush();
 	dc.RebindTexture();
 }

--- a/UI/TextureUtil.h
+++ b/UI/TextureUtil.h
@@ -44,14 +44,15 @@ std::unique_ptr<ManagedTexture> CreateTextureFromFileData(Draw::DrawContext *dra
 
 class GameIconView : public UI::InertView {
 public:
-	GameIconView(std::string gamePath, UI::LayoutParams *layoutParams = 0)
-		: InertView(layoutParams), gamePath_(gamePath) {}
+	GameIconView(std::string gamePath, float scale, UI::LayoutParams *layoutParams = 0)
+		: InertView(layoutParams), gamePath_(gamePath), scale_(scale) {}
 
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 
 private:
 	std::string gamePath_;
+	float scale_ = 1.0f;
 	int textureWidth_ = 0;
 	int textureHeight_ = 0;
 };


### PR DESCRIPTION
Also, make them a bit bigger in the save data screen.  This was bugging me when looking at some minis recently.

-[Unknown]