### PR TITLE
PPGe: Fix dialog button positioning

### DIFF
--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -148,10 +148,9 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
 		WRAP_WIDTH = 372.0f;
 
 	float y = 140.0f;
-	float h, sy ,ey;
-	int n;
-	PPGeMeasureText(0, &h, &n, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
-	float h2 = h * n / 2.0f;
+	float h, sy, ey;
+	PPGeMeasureText(nullptr, &h, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
+	float h2 = h / 2.0f;
 	ey = y + h2 + 20.0f;
 
 	if (hasYesNo)
@@ -172,7 +171,7 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
 			yesColor = 0xFFFFFFFF;
 			noColor  = 0xFFFFFFFF;
 		}
-		PPGeMeasureText(&w, &h, 0, choiceText, FONT_SCALE);
+		PPGeMeasureText(&w, &h, choiceText, FONT_SCALE);
 		w = 15.0f;
 		h = 8.0f;
 		float y2 = y + h2 + 8.0f;

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -534,9 +534,8 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 {
 	const float WRAP_WIDTH = 254.0f;
 	float y = 136.0f, h;
-	int n;
-	PPGeMeasureText(0, &h, &n, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
-	float h2 = h * (float)n / 2.0f;
+	PPGeMeasureText(nullptr, &h, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
+	float h2 = h / 2.0f;
 	if (hasYesNo)
 	{
 		auto di = GetI18NCategory("Dialog");
@@ -555,7 +554,7 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 			yesColor = 0xFFFFFFFF;
 			noColor  = 0xFFFFFFFF;
 		}
-		PPGeMeasureText(&w, &h, 0, choiceText, FONT_SCALE);
+		PPGeMeasureText(&w, &h, choiceText, FONT_SCALE);
 		w = w / 2.0f + 5.5f;
 		h /= 2.0f;
 		float y2 = y + h2 + 4.0f;

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -128,9 +128,6 @@ std::map<PPGeTextDrawerCacheKey, PPGeTextDrawerImage> textDrawerImages;
 void PPGePrepareText(const char *text, float x, float y, int align, float scale, float lineHeightScale,
 	int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
-// Get the metrics of the bounding box of the currently stated text.
-void PPGeMeasureCurrentText(float *x, float *y, float *w, float *h, int *n);
-
 // These functions must be called between PPGeBegin and PPGeEnd.
 
 // Draw currently buffered text using the state from PPGeGetTextBoundingBox() call.
@@ -710,9 +707,7 @@ static bool HasTextDrawer() {
 	return textDrawer != nullptr;
 }
 
-void PPGeMeasureText(float *w, float *h, int *n, 
-					const char *text, float scale, int WrapType, int wrapWidth)
-{
+void PPGeMeasureText(float *w, float *h, const char *text, float scale, int WrapType, int wrapWidth) {
 	if (HasTextDrawer()) {
 		float mw, mh;
 		textDrawer->SetFontScale(scale, scale);
@@ -726,15 +721,6 @@ void PPGeMeasureText(float *w, float *h, int *n,
 			*w = mw;
 		if (h)
 			*h = mh;
-		if (n) {
-			// Cheap way to get the n.
-			float oneLine, twoLines;
-			textDrawer->MeasureString("|", 1, &mw, &oneLine);
-			textDrawer->MeasureStringRect("|\n|", 3, Bounds(0, 0, 480, 272), &mw, &twoLines);
-
-			float lineHeight = twoLines - oneLine;
-			*n = (int)((mh + (lineHeight - 1)) / lineHeight);
-		}
 		return;
 	}
 
@@ -743,16 +729,13 @@ void PPGeMeasureText(float *w, float *h, int *n,
 			*w = 0;
 		if (h)
 			*h = 0;
-		if (n)
-			*n = 0;
 		return;
 	}
 
 	const AtlasFont &atlasfont = g_ppge_atlas.fonts[0];
 	AtlasTextMetrics metrics = BreakLines(text, atlasfont, 0, 0, 0, scale, scale, WrapType, wrapWidth, true);
 	if (w) *w = metrics.maxWidth;
-	if (h) *h = metrics.lineHeight;
-	if (n) *n = metrics.numLines;
+	if (h) *h = metrics.lineHeight * metrics.numLines;
 }
 
 void PPGePrepareText(const char *text, float x, float y, int align, float scale, float lineHeightScale, int WrapType, int wrapWidth)
@@ -762,15 +745,6 @@ void PPGePrepareText(const char *text, float x, float y, int align, float scale,
 		return;
 	}
 	char_lines_metrics = BreakLines(text, atlasfont, x, y, align, scale, lineHeightScale, WrapType, wrapWidth, false);
-}
-
-void PPGeMeasureCurrentText(float *x, float *y, float *w, float *h, int *n)
-{
-	if (x) *x = char_lines_metrics.x;
-	if (y) *y = char_lines_metrics.y;
-	if (w) *w = char_lines_metrics.maxWidth;
-	if (h) *h = char_lines_metrics.lineHeight;
-	if (n) *n = char_lines_metrics.numLines;
 }
 
 static void PPGeResetCurrentText() {

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -69,8 +69,7 @@ enum {
 };
 
 // Get the metrics of the bounding box of the text without changing the buffer or state.
-void PPGeMeasureText(float *w, float *h, int *n, 
-					const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
+void PPGeMeasureText(float *w, float *h, const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
 // Draws some text using the one font we have.
 // Clears the text buffer when done.


### PR DESCRIPTION
The measure was previously the line height, but always ultimately used as the full text height.  This just makes it always full height, which is what the text drawer path was producing.

Fixes #12753.

-[Unknown]