### PR TITLE
Sticky touch analog

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -868,6 +868,7 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("TouchButtonOpacity", &g_Config.iTouchButtonOpacity, 65, true, true),
 	ConfigSetting("TouchButtonHideSeconds", &g_Config.iTouchButtonHideSeconds, 20, true, true),
 	ConfigSetting("AutoCenterTouchAnalog", &g_Config.bAutoCenterTouchAnalog, false, true, true),
+	ConfigSetting("StickyTouchAnalog", &g_Config.bStickyTouchAnalog, false, true, true),
 	ConfigSetting("AnalogAutoRotSpeed", &g_Config.fAnalogAutoRotSpeed, 15.0f, true, true),
 
 	// Snap touch control position

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -304,6 +304,7 @@ public:
 
 	// Floating analog stick (recenters on thumb on press).
 	bool bAutoCenterTouchAnalog;
+	bool bStickyTouchAnalog;
 
 	//space between PSP buttons
 	//the PSP button's center (triangle, circle, square, cross)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -592,6 +592,10 @@ void GameSettingsScreen::CreateViews() {
 		CheckBox *floatingAnalog = controlsSettings->Add(new CheckBox(&g_Config.bAutoCenterTouchAnalog, co->T("Auto-centering analog stick")));
 		floatingAnalog->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+		// Sticky touch analog
+		CheckBox *stickyAnalog = controlsSettings->Add(new CheckBox(&g_Config.bStickyTouchAnalog, co->T("Sticky analog stick (tap to reset)")));
+		stickyAnalog->SetEnabledPtr(&g_Config.bShowTouchControls);
+
 		// Combo key setup
 		Choice *comboKey = controlsSettings->Add(new Choice(co->T("Combo Key Setup")));
 		comboKey->OnClick.Handle(this, &GameSettingsScreen::OnComboKey);

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -444,6 +444,7 @@ void PSPStick::Touch(const TouchInput &input) {
 				centerY_ = bounds_.centerY();
 			}
 			dragPointerId_ = input.id;
+			lastTouchDownTime_ = time_now();
 			ProcessTouch(input.x, input.y, true);
 		}
 	}
@@ -483,7 +484,7 @@ void PSPStick::ProcessTouch(float x, float y, bool down) {
 
 		__CtrlSetAnalogX(dx, stick_);
 		__CtrlSetAnalogY(-dy, stick_);
-	} else {
+	} else if (!g_Config.bStickyTouchAnalog || time_now() - lastTouchDownTime_ < 0.2f) {
 		__CtrlSetAnalogX(0.0f, stick_);
 		__CtrlSetAnalogY(0.0f, stick_);
 	}

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -174,6 +174,7 @@ private:
 
 	float centerX_;
 	float centerY_;
+	float lastTouchDownTime_;
 };
 
 //initializes the layout from Config. if a default layout does not exist,


### PR DESCRIPTION
Will make the touch analog keep his position after the finger goes up, can be reset to center by tapping it.

I'm not sure how much useful this could actually be, but I guess still might have it's use cases in game where you need to perform action while using the analog at the same time without having to claw.