### PR TITLE
Don't reset the log enabled flags on non-Windows platforms.

### DIFF
--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -197,7 +197,7 @@ CISOFileBlockDevice::CISOFileBlockDevice(FileLoader *fileLoader)
 	u64 lastIndexPos = index[indexSize - 1] & 0x7FFFFFFF;
 	u64 expectedFileSize = lastIndexPos << indexShift;
 	if (expectedFileSize > fileSize) {
-		WARN_LOG(LOADER, "Expected CSO to at least be %lld bytes, but file is %lld bytes. File: '%s'",
+		ERROR_LOG(LOADER, "Expected CSO to at least be %lld bytes, but file is %lld bytes. File: '%s'",
 			expectedFileSize, fileSize, fileLoader->Path().c_str());
 		NotifyReadError();
 	}

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -197,7 +197,8 @@ CISOFileBlockDevice::CISOFileBlockDevice(FileLoader *fileLoader)
 	u64 lastIndexPos = index[indexSize - 1] & 0x7FFFFFFF;
 	u64 expectedFileSize = lastIndexPos << indexShift;
 	if (expectedFileSize > fileSize) {
-		ERROR_LOG(LOADER, "Expected CSO to at least be %lld bytes, but file is %lld bytes", expectedFileSize, fileSize);
+		WARN_LOG(LOADER, "Expected CSO to at least be %lld bytes, but file is %lld bytes. File: '%s'",
+			expectedFileSize, fileSize, fileLoader->Path().c_str());
 		NotifyReadError();
 	}
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -650,15 +650,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	PostLoadConfig();
 
-	// Hard reset the logs. TODO: Get rid of this and read from config.
-#ifndef _WIN32
-	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++) {
-		LogTypes::LOG_TYPE type = (LogTypes::LOG_TYPE)i;
-		logman->SetEnabled(type, true);
-		logman->SetLogLevel(type, logLevel);
-	}
-#endif
-
 #if defined(__ANDROID__) || (defined(MOBILE_DEVICE) && !defined(_DEBUG))
 	// Enable basic logging for any kind of mobile device, since LogManager doesn't.
 	// The MOBILE_DEVICE/_DEBUG condition matches LogManager.cpp.


### PR DESCRIPTION
This was just silly. Fixes #12291.