### PR TITLE
Windows: Show a message when failing over backend

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -402,8 +402,11 @@ static void CheckFailedGPUBackends() {
 
 	// Okay, let's not try a backend in the failed list.
 	g_Config.iGPUBackend = g_Config.NextValidBackend();
-	if (lastBackend != g_Config.iGPUBackend)
-		WARN_LOG(LOADER, "Failed graphics backend switched from %d to %d", lastBackend, g_Config.iGPUBackend);
+	if (lastBackend != g_Config.iGPUBackend) {
+		std::string param = GPUBackendToString((GPUBackend)lastBackend) + " -> " + GPUBackendToString((GPUBackend)g_Config.iGPUBackend);
+		System_SendMessage("graphics_failedBackend", param.c_str());
+		WARN_LOG(LOADER, "Failed graphics backend switched from %s (%d to %d)", param.c_str(), lastBackend, g_Config.iGPUBackend);
+	}
 	// And then let's - for now - add the current to the failed list.
 	if (g_Config.sFailedGPUBackends.empty()) {
 		g_Config.sFailedGPUBackends = GPUBackendToString((GPUBackend)g_Config.iGPUBackend);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -132,6 +132,18 @@ void MainThreadFunc() {
 	bool performingRestart = NativeIsRestarting();
 	NativeInit(static_cast<int>(args.size()), &args[0], "1234", "1234", nullptr);
 
+	if (g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		if (!useEmuThread) {
+			// Okay, we must've switched to OpenGL.  Let's flip the emu thread on.
+			useEmuThread = true;
+			setCurrentThreadName("Render");
+		}
+	} else if (useEmuThread) {
+		// We must've failed over from OpenGL, flip the emu thread off.
+		useEmuThread = false;
+		setCurrentThreadName("Emu");
+	}
+
 	if (g_Config.sFailedGPUBackends.find("ALL") != std::string::npos) {
 		Reporting::ReportMessage("Graphics init error: %s", "ALL");
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -284,6 +284,12 @@ void System_SendMessage(const char *command, const char *parameter) {
 			g_Config.bRestartRequired = true;
 			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
 		}
+	} else if (!strcmp(command, "graphics_failedBackend")) {
+		auto err = GetI18NCategory("Error");
+		const char *backendSwitchError = err->T("GenericBackendSwitchError", "PPSSPP crashed while initializing graphics. Try upgrading your graphics drivers.\n\nGraphics backend has been switched:");
+		std::wstring full_error = ConvertUTF8ToWString(StringFromFormat("%s %s", backendSwitchError, parameter));
+		std::wstring title = ConvertUTF8ToWString(err->T("GenericGraphicsError", "Graphics Error"));
+		MessageBox(MainWindow::GetHWND(), full_error.c_str(), title.c_str(), MB_OK);
 	} else if (!strcmp(command, "setclipboardtext")) {
 		if (OpenClipboard(MainWindow::GetDisplayHWND())) {
 			std::wstring data = ConvertUTF8ToWString(parameter);


### PR DESCRIPTION
Best that we make sure people know when this has happened, probably.

Also, fix the fallback to OpenGL, which was broken on Windows.  Unlike Android/Linux/etc., we already decided thread handling by that point, but it might change.

-[Unknown]