### PR TITLE
Set target to Android 10 (SDK 29).

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -39,7 +39,8 @@
         android:label="@string/app_name" 
         android:logo="@drawable/ic_banner"
         android:isGame="true"
-        android:banner="@drawable/tv_banner">
+        android:banner="@drawable/tv_banner"
+        android:requestLegacyExternalStorage="true">
         <meta-data android:name="android.max_aspect" android:value="2.4" />
         <activity
             android:name=".PpssppActivity"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,8 @@ android {
 			}
 		}
 	}
-	compileSdkVersion 28
-	buildToolsVersion '28.0.3'
+	compileSdkVersion 29
+	buildToolsVersion '29.0.3'
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {
@@ -51,7 +51,7 @@ android {
 		new File("versioncode.txt").write(androidGitVersion.code().toString())
 
 		minSdkVersion 9
-		targetSdkVersion 28
+		targetSdkVersion 29
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
 			versionName ANDROID_VERSION_NAME


### PR DESCRIPTION
Includes a nasty SDK bug workaround.

Setting android:requestLegacyExternalStorage="true" so we can still access storage properly. This is the last and only SDK version in which we'll be able to do this - when we must target Android 11, or run on Android 12, we need to fix https://github.com/hrydgard/ppsspp/issues/11997.
