### PR TITLE
Touch layout remove redundant range check

### DIFF
--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -264,15 +264,9 @@ bool TouchControlLayoutScreen::touch(const TouchInput &touch) {
 			validRange.y += bounds.h * 0.5f;
 			validRange.h -= bounds.h;
 
-			// Check x and y independently, since even if x is blocked, y may not be.
-			if (validRange.Contains(touch.x, newPos.y) || validRange.Contains(touch.x, touch.y)) {
-				newPos.x = touch.x;
-			}
-			if (validRange.Contains(newPos.x, touch.y) || validRange.Contains(touch.x, touch.y)) {
-				newPos.y = touch.y;
-			}
+			newPos.x = touch.x;
+			newPos.y = touch.y;
 			if (g_Config.bTouchSnapToGrid) {
-				newPos = ClampTo(newPos, validRange);
 				newPos.x -= (int)(newPos.x - bounds.w) % g_Config.iTouchSnapGridSize;
 				newPos.y -= (int)(newPos.y - bounds.h) % g_Config.iTouchSnapGridSize;
 			}


### PR DESCRIPTION
Remove the old range check as clamp should do it already (also we clamp at the end already so no need to to it twice in the grid I think).

This fix the motion getting stuck "one frame" behind when it get out in the next:
![out](https://user-images.githubusercontent.com/13517524/78123065-e8f52c00-740d-11ea-81b5-736fe4e2ac8b.gif)
