### PR TITLE
Right mouse button as back in menu navigation

### DIFF
--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -339,6 +339,7 @@ void UpdateNativeMenuKeys() {
 		KeyDef(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE),
 		KeyDef(DEVICE_ID_ANY, NKCODE_BACK),
 		KeyDef(DEVICE_ID_ANY, NKCODE_BUTTON_B),
+		KeyDef(DEVICE_ID_MOUSE, NKCODE_EXT_MOUSEBUTTON_4),
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(hardcodedCancelKeys); i++) {

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -419,11 +419,29 @@ bool MainUI::event(QEvent *e) {
 		break;
 	case QEvent::MouseButtonPress:
 	case QEvent::MouseButtonRelease:
-		input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale_x * xscale;
-		input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale_y * yscale;
-		input.flags = (e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP;
-		input.id = 0;
-		NativeTouch(input);
+		switch(((QMouseEvent*)e)->button()) {
+		case Qt::LeftButton:
+			input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale_x * xscale;
+			input.y = ((QMouseEvent*)e)->pos().y() * g_dpi_scale_y * yscale;
+			input.flags = (e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP;
+			input.id = 0;
+			NativeTouch(input);
+			break;
+		case Qt::RightButton:
+			NativeKey(KeyInput(DEVICE_ID_MOUSE, NKCODE_EXT_MOUSEBUTTON_2, (e->type() == QEvent::MouseButtonPress) ? KEY_DOWN : KEY_UP));
+			break;
+		case Qt::MiddleButton:
+			NativeKey(KeyInput(DEVICE_ID_MOUSE, NKCODE_EXT_MOUSEBUTTON_3, (e->type() == QEvent::MouseButtonPress) ? KEY_DOWN : KEY_UP));
+			break;
+		case Qt::ExtraButton1:
+			NativeKey(KeyInput(DEVICE_ID_MOUSE, NKCODE_EXT_MOUSEBUTTON_4, (e->type() == QEvent::MouseButtonPress) ? KEY_DOWN : KEY_UP));
+			break;
+		case Qt::ExtraButton2:
+			NativeKey(KeyInput(DEVICE_ID_MOUSE, NKCODE_EXT_MOUSEBUTTON_5, (e->type() == QEvent::MouseButtonPress) ? KEY_DOWN : KEY_UP));
+			break;
+		default:
+			break;
+		}
 		break;
 	case QEvent::MouseMove:
 		input.x = ((QMouseEvent*)e)->pos().x() * g_dpi_scale_x * xscale;


### PR DESCRIPTION
Add support to navigate back using mouse 2. Fixes #12648.

NOTE: Couldn't test on Windows sadly as I don't have a build environment for that (tested on Linux SDL and Qt).