### PR TITLE
Not setting correct width and height causes flickering with frameskip with libretro

### DIFF
--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -52,7 +52,7 @@ public:
 	void SetRenderTarget() override {}
 	void SwapBuffers() override {
 		if (gstate_c.skipDrawReason) {
-			video_cb(NULL, 0, 0, 0);
+			video_cb(NULL, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, 0);
 		} else {
 			video_cb(RETRO_HW_FRAME_BUFFER_VALID, PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, 0);
 		}


### PR DESCRIPTION
Setting the width and height to 0 made the frameskip unusable on lakka/libretro with a XU4 with a MALI GPU T628. The result was that bad flickering happened when in frameskip mode. Once it reached 60fps, no flickering, below that flickering. This change fixes the flickering and calls video_cb with the correct height and width.