### PR TITLE
Cleanup display and touch control layout editors a bit more

### DIFF
--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <vector>
 
 #include "base/colorutil.h"
@@ -35,8 +36,9 @@
 static const int leftColumnWidth = 200;
 static const float orgRatio = 1.764706f;
 
+static const float UI_DISPLAY_SCALE = 8.0f;
 static float ScaleSettingToUI() {
-	float scale = g_Config.fSmallDisplayZoomLevel * 8.0f;
+	float scale = g_Config.fSmallDisplayZoomLevel * UI_DISPLAY_SCALE;
 	// Account for 1x display doubling dps.
 	if (g_dpi_scale_x > 1.0f) {
 		scale *= g_dpi_scale_x;
@@ -53,35 +55,35 @@ static void UpdateScaleSetting(float scale) {
 }
 
 static void UpdateScaleSettingFromUI(float scale) {
-	UpdateScaleSetting(scale / 8.0f);
+	UpdateScaleSetting(scale / UI_DISPLAY_SCALE);
 }
 
 class DragDropDisplay : public MultiTouchDisplay {
 public:
-	DragDropDisplay(float &x, float &y, ImageID img, float &scale, const Bounds &screenBounds)
+	DragDropDisplay(float &x, float &y, ImageID img, float scale, const Bounds &screenBounds)
 		: MultiTouchDisplay(img, scale, new UI::AnchorLayoutParams(x * screenBounds.w, y * screenBounds.h, UI::NONE, UI::NONE, true)),
-		x_(x), y_(y), theScale_(scale), screenBounds_(screenBounds) {
-		scale_ = theScale_;
+		x_(x), y_(y), screenBounds_(screenBounds) {
+		UpdateScale(scale);
 	}	
 
-	virtual void SaveDisplayPosition() {
+	void SaveDisplayPosition() {
 		x_ = bounds_.centerX() / screenBounds_.w;
 		y_ = bounds_.centerY() / screenBounds_.h;
-		scale_ = theScale_;
 	}
 
-	virtual float GetScale() const { return theScale_; }
-	virtual void SetScale(float s) { theScale_ = s; scale_ = s; }
+	void UpdateScale(float s) {
+		scale_ = s;
+	}
+	float Scale() {
+		return scale_;
+	}
 
 private:
 	float &x_, &y_;
-	float &theScale_;
 	const Bounds &screenBounds_;
 };
 
 DisplayLayoutScreen::DisplayLayoutScreen() {
-	picked_ = nullptr;
-	mode_ = nullptr;
 };
 
 bool DisplayLayoutScreen::touch(const TouchInput &touch) {
@@ -95,11 +97,11 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 	}
 
 	const Bounds &screen_bounds = screenManager()->getUIContext()->GetBounds();
-	if ((touch.flags & TOUCH_MOVE) && picked_ != nullptr) {
-		int touchX = touch.x - offsetTouchX;
-		int touchY = touch.y - offsetTouchY;
+	if ((touch.flags & TOUCH_MOVE) != 0 && dragging_) {
+		int touchX = touch.x - offsetTouchX_;
+		int touchY = touch.y - offsetTouchY_;
 		if (mode == 0) {
-			const auto &prevParams = picked_->GetLayoutParams()->As<AnchorLayoutParams>();
+			const auto &prevParams = displayRepresentation_->GetLayoutParams()->As<AnchorLayoutParams>();
 			Point newPos(prevParams->left, prevParams->top);
 
 			int limitX = g_Config.fSmallDisplayZoomLevel * 120;
@@ -108,11 +110,9 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 			const int quarterResX = screen_bounds.w / 4;
 			const int quarterResY = screen_bounds.h / 4;
 
-			if (bRotated) {
+			if (bRotated_) {
 				//swap X/Y limit for rotated display
-				int limitTemp = limitX;
-				limitX = limitY;
-				limitY = limitTemp;
+				std::swap(limitX, limitY);
 			}
 
 			// Check where each edge of the screen is
@@ -121,11 +121,12 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 			const int windowUpperEdge = quarterResY;
 			const int windowLowerEdge = windowUpperEdge * 3;
 			// And stick display when close to any edge
-			stickToEdgeX = false; stickToEdgeY = false;
-			if (touchX > windowLeftEdge - 8 + limitX && touchX < windowLeftEdge + 8 + limitX) { touchX = windowLeftEdge + limitX; stickToEdgeX = true; }
-			if (touchX > windowRightEdge - 8 - limitX && touchX < windowRightEdge + 8 - limitX) { touchX = windowRightEdge - limitX; stickToEdgeX = true; }
-			if (touchY > windowUpperEdge - 8 + limitY && touchY < windowUpperEdge + 8 + limitY) { touchY = windowUpperEdge + limitY; stickToEdgeY = true; }
-			if (touchY > windowLowerEdge - 8 - limitY && touchY < windowLowerEdge + 8 - limitY) { touchY = windowLowerEdge - limitY; stickToEdgeY = true; }
+			stickToEdgeX_ = false;
+			stickToEdgeY_ = false;
+			if (touchX > windowLeftEdge - 8 + limitX && touchX < windowLeftEdge + 8 + limitX) { touchX = windowLeftEdge + limitX; stickToEdgeX_ = true; }
+			if (touchX > windowRightEdge - 8 - limitX && touchX < windowRightEdge + 8 - limitX) { touchX = windowRightEdge - limitX; stickToEdgeX_ = true; }
+			if (touchY > windowUpperEdge - 8 + limitY && touchY < windowUpperEdge + 8 + limitY) { touchY = windowUpperEdge + limitY; stickToEdgeY_ = true; }
+			if (touchY > windowLowerEdge - 8 - limitY && touchY < windowLowerEdge + 8 - limitY) { touchY = windowLowerEdge - limitY; stickToEdgeY_ = true; }
 
 			const int minX = screen_bounds.w / 2;
 			const int maxX = screen_bounds.w + minX;
@@ -148,39 +149,30 @@ bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 			if (touchY > minY - limitY - 10 && touchY < minY + limitY + 10) {
 				newPos.y = touchY;
 			}
-			picked_->ReplaceLayoutParams(new AnchorLayoutParams(newPos.x, newPos.y, NONE, NONE, true));
+			displayRepresentation_->ReplaceLayoutParams(new AnchorLayoutParams(newPos.x, newPos.y, NONE, NONE, true));
 		} else if (mode == 1) {
-			// Resize. Vertical = scaling, horizontal = spacing;
-			// Up should be bigger so let's negate in that direction
-			float diffX = (touchX - startX_);
+			// Resize. Vertical = scaling; Up should be bigger so let's negate in that direction
 			float diffY = -(touchY - startY_);
 
 			float movementScale = 0.5f;
 			float newScale = startScale_ + diffY * movementScale;
 			// Desired scale * 8.0 since the visualization is tiny size and multiplied by 8.
-			if (newScale > 80.0f) newScale = 80.0f;
-			if (newScale < 8.0f) newScale = 8.0f;
-			picked_->SetScale(newScale);
-			scaleUpdate_ = picked_->GetScale();
-			UpdateScaleSettingFromUI(scaleUpdate_);
+			newScale = clamp_value(newScale, UI_DISPLAY_SCALE, UI_DISPLAY_SCALE * 10.0f);
+			displayRepresentation_->UpdateScale(newScale);
+			UpdateScaleSettingFromUI(newScale);
 		}
 	}
-	if ((touch.flags & TOUCH_DOWN) && picked_ == 0) {
-		picked_ = displayRepresentation_;
-		if (picked_) {
-			const Bounds &bounds = picked_->GetBounds();
-			startX_ = bounds.centerX();
-			startY_ = bounds.centerY();
-			offsetTouchX = touch.x - startX_;
-			offsetTouchY = touch.y - startY_;
-			startScale_ = picked_->GetScale();
-		}
+	if ((touch.flags & TOUCH_DOWN) != 0 && !dragging_) {
+		dragging_ = true;
+		const Bounds &bounds = displayRepresentation_->GetBounds();
+		startY_ = bounds.centerY();
+		offsetTouchX_ = touch.x - bounds.centerX();
+		offsetTouchY_ = touch.y - bounds.centerY();
+		startScale_ = displayRepresentation_->Scale();
 	}
-	if ((touch.flags & TOUCH_UP) && picked_ != 0) {
-		const Bounds &bounds = picked_->GetBounds();
-		startScale_ = picked_->GetScale();
-		picked_->SaveDisplayPosition();
-		picked_ = nullptr;
+	if ((touch.flags & TOUCH_UP) != 0 && dragging_) {
+		displayRepresentation_->SaveDisplayPosition();
+		dragging_ = false;
 	}
 	return true;
 }
@@ -194,9 +186,9 @@ void DisplayLayoutScreen::onFinish(DialogResult reason) {
 }
 
 UI::EventReturn DisplayLayoutScreen::OnCenter(UI::EventParams &e) {
-	if (!stickToEdgeX || (stickToEdgeX && stickToEdgeY))
+	if (!stickToEdgeX_ || (stickToEdgeX_ && stickToEdgeY_))
 		g_Config.fSmallDisplayOffsetX = 0.5f;
-	if (!stickToEdgeY || (stickToEdgeX && stickToEdgeY))
+	if (!stickToEdgeY_ || (stickToEdgeX_ && stickToEdgeY_))
 		g_Config.fSmallDisplayOffsetY = 0.5f;
 	RecreateViews();
 	return UI::EVENT_DONE;
@@ -207,7 +199,7 @@ UI::EventReturn DisplayLayoutScreen::OnZoomTypeChange(UI::EventParams &e) {
 		const Bounds &bounds = screenManager()->getUIContext()->GetBounds();
 		float autoBound = bounds.w / 480.0f;
 		UpdateScaleSetting(autoBound);
-		displayRepresentationScale_ = ScaleSettingToUI();
+		displayRepresentation_->UpdateScale(ScaleSettingToUI());
 		g_Config.fSmallDisplayOffsetX = 0.5f;
 		g_Config.fSmallDisplayOffsetY = 0.5f;
 	}
@@ -267,22 +259,11 @@ void DisplayLayoutScreen::CreateViews() {
 	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, vertPreviewPadding - vertBoundariesHeight, NONE, NONE)));
 	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, NONE, NONE, vertPreviewPadding - vertBoundariesHeight)));
 
-	static const char *zoomLevels[] = { "Stretching", "Partial Stretch", "Auto Scaling", "Manual Scaling" };
-	zoom_ = new PopupMultiChoice(&g_Config.iSmallDisplayZoomType, di->T("Options"), zoomLevels, 0, ARRAY_SIZE(zoomLevels), gr->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, previewWidth - 200.0f, NONE, NONE, 10));
-	zoom_->OnChoice.Handle(this, &DisplayLayoutScreen::OnZoomTypeChange);
-
-	static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
-	rotation_ = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, previewWidth - 200.0f, 10, NONE, bounds.h - 64 - 10));
-	rotation_->SetEnabledFunc([] {
-		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-	});
 	bool displayRotEnable = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
-	bRotated = false;
+	bRotated_ = false;
 	if (displayRotEnable && (g_Config.iInternalScreenRotation == ROTATION_LOCKED_VERTICAL || g_Config.iInternalScreenRotation == ROTATION_LOCKED_VERTICAL180)) {
-		bRotated = true;
+		bRotated_ = true;
 	}
-	// Visual representation image is just icon size and have to be scaled 8 times to match PSP native resolution which is used as 1.0 for zoom
-	displayRepresentationScale_ = ScaleSettingToUI();
 
 	HighlightLabel *label = nullptr;
 	mode_ = nullptr;
@@ -291,7 +272,7 @@ void DisplayLayoutScreen::CreateViews() {
 			label = new HighlightLabel(gr->T("Auto Scaling"), new AnchorLayoutParams(WRAP_CONTENT, 64.0f, bounds.w / 2.0f, bounds.h / 2.0f, NONE, NONE, true));
 			float autoBound = bounds.h / 270.0f;
 			// Case of screen rotated ~ only works with buffered rendering
-			if (bRotated) {
+			if (bRotated_) {
 				autoBound = bounds.h / 480.0f;
 			} else { // Without rotation in common cases like 1080p we cut off 2 pixels of height, this reflects other cases
 				float resCommonWidescreen = autoBound - floor(autoBound);
@@ -306,7 +287,6 @@ void DisplayLayoutScreen::CreateViews() {
 				}
 			}
 			UpdateScaleSetting(autoBound);
-			displayRepresentationScale_ = ScaleSettingToUI();
 			g_Config.fSmallDisplayOffsetX = 0.5f;
 			g_Config.fSmallDisplayOffsetY = 0.5f;
 		} else { // Manual Scaling
@@ -324,11 +304,11 @@ void DisplayLayoutScreen::CreateViews() {
 			mode_->AddChoice(di->T("Resize"));
 			mode_->SetSelection(0);
 		}
-		displayRepresentation_ = new DragDropDisplay(g_Config.fSmallDisplayOffsetX, g_Config.fSmallDisplayOffsetY, ImageID("I_PSP_DISPLAY"), displayRepresentationScale_, bounds);
+		displayRepresentation_ = new DragDropDisplay(g_Config.fSmallDisplayOffsetX, g_Config.fSmallDisplayOffsetY, ImageID("I_PSP_DISPLAY"), ScaleSettingToUI(), bounds);
 		displayRepresentation_->SetVisibility(V_VISIBLE);
 	} else { // Stretching
 		label = new HighlightLabel(gr->T("Stretching"), new AnchorLayoutParams(WRAP_CONTENT, 64.0f, bounds.w / 2.0f, bounds.h / 2.0f, NONE, NONE, true));
-		displayRepresentation_ = new DragDropDisplay(g_Config.fSmallDisplayOffsetX, g_Config.fSmallDisplayOffsetY, ImageID("I_PSP_DISPLAY"), displayRepresentationScale_, bounds);
+		displayRepresentation_ = new DragDropDisplay(g_Config.fSmallDisplayOffsetX, g_Config.fSmallDisplayOffsetY, ImageID("I_PSP_DISPLAY"), ScaleSettingToUI(), bounds);
 		displayRepresentation_->SetVisibility(V_INVISIBLE);
 		float width = previewWidth;
 		float height = previewHeight;
@@ -337,16 +317,16 @@ void DisplayLayoutScreen::CreateViews() {
 			stretched->SetEnabled(false);
 			root_->Add(stretched);
 		} else { // Partially stretched
-			float origRatio = !bRotated ? 480.0f / 272.0f : 272.0f / 480.0f;
+			float origRatio = !bRotated_ ? 480.0f / 272.0f : 272.0f / 480.0f;
 			float frameRatio = width / height;
 			if (origRatio > frameRatio) {
 				height = width / origRatio;
-				if (!bRotated && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
+				if (!bRotated_ && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
 					height = (272.0f + height) / 2.0f;
 				}
 			} else {
 				width = height * origRatio;
-				if (bRotated && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
+				if (bRotated_ && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
 					width = (272.0f + height) / 2.0f;
 				}
 			}
@@ -355,12 +335,10 @@ void DisplayLayoutScreen::CreateViews() {
 			root_->Add(stretched);
 		}
 	}
-	if (bRotated) {
+	if (bRotated_) {
 		displayRepresentation_->SetAngle(90.0f);
 	}
 
-	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10));
-	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 	root_->Add(displayRepresentation_);
 	if (mode_) {
 		root_->Add(mode_);
@@ -368,7 +346,20 @@ void DisplayLayoutScreen::CreateViews() {
 	if (label) {
 		root_->Add(label);
 	}
-	root_->Add(zoom_);
-	root_->Add(rotation_);
+
+	static const char *zoomLevels[] = { "Stretching", "Partial Stretch", "Auto Scaling", "Manual Scaling" };
+	auto zoom = new PopupMultiChoice(&g_Config.iSmallDisplayZoomType, di->T("Options"), zoomLevels, 0, ARRAY_SIZE(zoomLevels), gr->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, previewWidth - 200.0f, NONE, NONE, 10));
+	zoom->OnChoice.Handle(this, &DisplayLayoutScreen::OnZoomTypeChange);
+	root_->Add(zoom);
+
+	static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
+	auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, previewWidth - 200.0f, 10, NONE, bounds.h - 64 - 10));
+	rotation->SetEnabledFunc([] {
+		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+	});
+	root_->Add(rotation);
+
+	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10));
+	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 	root_->Add(back);
 }

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -39,19 +39,16 @@ protected:
 	virtual UI::EventReturn OnZoomTypeChange(UI::EventParams &e);
 
 private:
-	DragDropDisplay *picked_;
-	DragDropDisplay *displayRepresentation_;
-	UI::ChoiceStrip *mode_;
-	UI::PopupMultiChoice *zoom_;
-	UI::PopupMultiChoice *rotation_;
-	bool bRotated;
-	bool stickToEdgeX;
-	bool stickToEdgeY;
+	DragDropDisplay *displayRepresentation_ = nullptr;
+	UI::ChoiceStrip *mode_ = nullptr;
+	bool dragging_ = false;
+	bool bRotated_ = false;
+	bool stickToEdgeX_ = false;
+	bool stickToEdgeY_ = false;
 	// Touch down state for drag to resize etc
-	float startX_;
-	float startY_;
-	float startScale_, scaleUpdate_;
-	float displayRepresentationScale_;
-	int offsetTouchX, offsetTouchY;
+	float startY_ = 0.0f;
+	float startScale_ = 1.0f;
+	int offsetTouchX_ = 0;
+	int offsetTouchY_ = 0;
 	
 };


### PR DESCRIPTION
Fixes #12797 in the same way as before, not converting back and forth between center coords.  Gets rid of the local_dp_* hacks and simplifies some code.

-[Unknown]