### PR TITLE
x86jit: Force INF * 0 to +NAN

### DIFF
--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -708,7 +708,11 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			mips->f[inst->dest] = mips->f[inst->src1] - mips->f[inst->src2];
 			break;
 		case IROp::FMul:
-			mips->f[inst->dest] = mips->f[inst->src1] * mips->f[inst->src2];
+			if ((my_isinf(mips->f[inst->src1]) && mips->f[inst->src2] == 0.0f) || (my_isinf(mips->f[inst->src2]) && mips->f[inst->src1] == 0.0f)) {
+				mips->fi[inst->dest] = 0x7fc00000;
+			} else {
+				mips->f[inst->dest] = mips->f[inst->src1] * mips->f[inst->src2];
+			}
 			break;
 		case IROp::FDiv:
 			mips->f[inst->dest] = mips->f[inst->src1] / mips->f[inst->src2];

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -974,7 +974,14 @@ namespace MIPSInt
 		{
 		case 0: F(fd) = F(fs) + F(ft); break; // add.s
 		case 1: F(fd) = F(fs) - F(ft); break; // sub.s
-		case 2: F(fd) = F(fs) * F(ft); break; // mul.s
+		case 2: // mul.s
+			if ((my_isinf(F(fs)) && F(ft) == 0.0f) || (my_isinf(F(ft)) && F(fs) == 0.0f)) {
+				// Must be positive NAN, see #12519.
+				FI(fd) = 0x7fc00000;
+			} else {
+				F(fd) = F(fs) * F(ft);
+			}
+			break;
 		case 3: F(fd) = F(fs) / F(ft); break; // div.s
 		default:
 			_dbg_assert_msg_(CPU,0,"Trying to interpret FPU3Op instruction that can't be interpreted");


### PR DESCRIPTION
Fixes #12519 - this is needed for some graphics to render properly.  Seems to already happen on ARM, so no change to armjit.  Thanks to @iota97 for the investigation.

@iota97 does this help #12519?

Could also help #12436.

-[Unknown]