### PR TITLE
Windows: Prevent applying -1 as inset space

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -174,6 +174,11 @@ float System_GetPropertyFloat(SystemProperty prop) {
 		return QApplication::primaryScreen()->logicalDotsPerInch();
 	case SYSPROP_DISPLAY_DPI:
 		return QApplication::primaryScreen()->physicalDotsPerInch();
+	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:
+	case SYSPROP_DISPLAY_SAFE_INSET_RIGHT:
+	case SYSPROP_DISPLAY_SAFE_INSET_TOP:
+	case SYSPROP_DISPLAY_SAFE_INSET_BOTTOM:
+		return 0.0f;
 	default:
 		return -1;
 	}

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -337,6 +337,11 @@ float System_GetPropertyFloat(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_DISPLAY_REFRESH_RATE:
 		return g_RefreshRate;
+	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:
+	case SYSPROP_DISPLAY_SAFE_INSET_RIGHT:
+	case SYSPROP_DISPLAY_SAFE_INSET_TOP:
+	case SYSPROP_DISPLAY_SAFE_INSET_BOTTOM:
+		return 0.0f;
 	default:
 		return -1;
 	}

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -248,6 +248,11 @@ float System_GetPropertyFloat(SystemProperty prop) {
 		return 60.f;
 	case SYSPROP_DISPLAY_DPI:
 		return (float)ScreenDPI();
+	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:
+	case SYSPROP_DISPLAY_SAFE_INSET_RIGHT:
+	case SYSPROP_DISPLAY_SAFE_INSET_TOP:
+	case SYSPROP_DISPLAY_SAFE_INSET_BOTTOM:
+		return 0.0f;
 	default:
 		return -1;
 	}


### PR DESCRIPTION
This is the root cause of the drift and weird offsetting.

That said, I still think it's probably more correct to apply the offset to the anchor position in the layout editors.

-[Unknown]