### PR TITLE
GLES: Re-enable non-float depal shader path

### DIFF
--- a/GPU/GLES/DepalettizeShaderGLES.cpp
+++ b/GPU/GLES/DepalettizeShaderGLES.cpp
@@ -54,8 +54,10 @@ void main() {
 DepalShaderCacheGLES::DepalShaderCacheGLES(Draw::DrawContext *draw) {
 	_assert_(draw);
 	render_ = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-	// Pre-build the vertex program
 	useGL3_ = gl_extensions.GLES3 || gl_extensions.VersionGEThan(3, 3);
+}
+
+void DepalShaderCacheGLES::Init() {
 	if (!gstate_c.Supports(GPU_SUPPORTS_32BIT_INT_FSHADER)) {
 		// Use the floating point path, it just can't handle the math.
 		useGL3_ = false;

--- a/GPU/GLES/DepalettizeShaderGLES.h
+++ b/GPU/GLES/DepalettizeShaderGLES.h
@@ -49,6 +49,7 @@ public:
 	// This also uploads the palette and binds the correct texture.
 	DepalShader *GetDepalettizeShader(uint32_t clutMode, GEBufferFormat pixelFormat);
 	GLRTexture *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut);
+	void Init();
 	void Clear();
 	void Decimate();
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -75,6 +75,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerGL_->SetTextureCache(textureCacheGL_);
 	framebufferManagerGL_->SetShaderManager(shaderManagerGL_);
 	framebufferManagerGL_->SetDrawEngine(&drawEngine_);
+	depalShaderCache_.Init();
 	textureCacheGL_->SetFramebufferManager(framebufferManagerGL_);
 	textureCacheGL_->SetDepalShaderCache(&depalShaderCache_);
 	textureCacheGL_->SetShaderManager(shaderManagerGL_);


### PR DESCRIPTION
Was accidentally always detected as unsupported.  We actually had reports of shader errors here, but we thought it was only on AMD or something.

This has been broken since 842290b (v1.7.x).

-[Unknown]