### PR TITLE
Audio: Remove latency setting

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -785,7 +785,6 @@ static ConfigSetting graphicsSettings[] = {
 static ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", &g_Config.bEnableSound, true, true, true),
 	ConfigSetting("AudioBackend", &g_Config.iAudioBackend, 0, true, true),
-	ConfigSetting("AudioLatency", &g_Config.iAudioLatency, 1, true, true),
 	ConfigSetting("ExtraAudioBuffering", &g_Config.bExtraAudioBuffering, false, true, false),
 	ConfigSetting("AudioResampler", &g_Config.bAudioResampler, true, true, true),
 	ConfigSetting("GlobalVolume", &g_Config.iGlobalVolume, VOLUME_MAX, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -212,7 +212,6 @@ public:
 
 	// Sound
 	bool bEnableSound;
-	int iAudioLatency; // 0 = low , 1 = medium(default) , 2 = high
 	int iAudioBackend;
 	int iGlobalVolume;
 	int iAltSpeedVolume;

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -53,12 +53,6 @@ AudioDebugStats g_AudioDebugStats;
 // atomic locks are used on the lock. TODO: make this lock-free
 std::atomic_flag atomicLock_;
 
-enum latency {
-	LOW_LATENCY = 0,
-	MEDIUM_LATENCY = 1,
-	HIGH_LATENCY = 2,
-};
-
 int eventAudioUpdate = -1;
 int eventHostAudioUpdate = -1;
 int mixFrequency = 44100;
@@ -110,27 +104,10 @@ void __AudioInit() {
 	mixFrequency = 44100;
 	srcFrequency = 0;
 
-	switch (g_Config.iAudioLatency) {
-	case LOW_LATENCY:
-		chanQueueMaxSizeFactor = 1;
-		chanQueueMinSizeFactor = 1;
-		hwBlockSize = 16;
-		hostAttemptBlockSize = 256;
-		break;
-	case MEDIUM_LATENCY:
-		chanQueueMaxSizeFactor = 2;
-		chanQueueMinSizeFactor = 1;
-		hwBlockSize = 64;
-		hostAttemptBlockSize = 512;
-		break;
-	case HIGH_LATENCY:
-		chanQueueMaxSizeFactor = 4;
-		chanQueueMinSizeFactor = 2;
-		hwBlockSize = 64;
-		hostAttemptBlockSize = 512;
-		break;
-
-	}
+	chanQueueMaxSizeFactor = 2;
+	chanQueueMinSizeFactor = 1;
+	hwBlockSize = 64;
+	hostAttemptBlockSize = 512;
 
 	__AudioCPUMHzChange();
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -542,9 +542,6 @@ void GameSettingsScreen::CreateViews() {
 	audioSettings->Add(new CheckBox(&g_Config.bAutoAudioDevice, a->T("Switch on new audio device")));
 #endif
 
-	static const char *latency[] = { "Low", "Medium", "High" };
-	PopupMultiChoice *lowAudio = audioSettings->Add(new PopupMultiChoice(&g_Config.iAudioLatency, a->T("Audio Latency"), latency, 0, ARRAY_SIZE(latency), gr->GetName(), screenManager()));
-	lowAudio->SetEnabledPtr(&g_Config.bEnableSound);
 #if defined(__ANDROID__)
 	CheckBox *extraAudio = audioSettings->Add(new CheckBox(&g_Config.bExtraAudioBuffering, a->T("AudioBufferingForBluetooth", "Bluetooth-friendly buffer (slower)")));
 	extraAudio->SetEnabledPtr(&g_Config.bEnableSound);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -392,7 +392,6 @@ int main(int argc, const char* argv[])
 	g_Config.bHighQualityDepth = true;
 	g_Config.bMemStickInserted = true;
 	g_Config.bFragmentTestCache = true;
-	g_Config.iAudioLatency = 1;
 	g_Config.bEnableWlan = true;
 	g_Config.sMACAddress = "12:34:56:78:9A:BC";
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -170,7 +170,6 @@ static RetroOption<int> ppsspp_rendering_mode("ppsspp_rendering_mode", "Renderin
 static RetroOption<bool> ppsspp_auto_frameskip("ppsspp_auto_frameskip", "Auto Frameskip", false);
 static RetroOption<int> ppsspp_frameskip("ppsspp_frameskip", "Frameskip", 0, 10);
 static RetroOption<int> ppsspp_frameskiptype("ppsspp_frameskiptype", "Frameskip Type", 0, 10);
-static RetroOption<int> ppsspp_audio_latency("ppsspp_audio_latency", "Audio latency", { "low", "medium", "high" });
 static RetroOption<int> ppsspp_internal_resolution("ppsspp_internal_resolution", "Internal Resolution (restart)", 1, { "480x272", "960x544", "1440x816", "1920x1088", "2400x1360", "2880x1632", "3360x1904", "3840x2176", "4320x2448", "4800x2720" });
 static RetroOption<int> ppsspp_button_preference("ppsspp_button_preference", "Confirmation Button", { { "cross", PSP_SYSTEMPARAM_BUTTON_CROSS }, { "circle", PSP_SYSTEMPARAM_BUTTON_CIRCLE } });
 static RetroOption<bool> ppsspp_fast_memory("ppsspp_fast_memory", "Fast Memory (Speedhack)", true);
@@ -196,7 +195,6 @@ void retro_set_environment(retro_environment_t cb) {
 	vars.push_back(ppsspp_auto_frameskip.GetOptions());
 	vars.push_back(ppsspp_frameskip.GetOptions());
 	vars.push_back(ppsspp_frameskiptype.GetOptions());
-	vars.push_back(ppsspp_audio_latency.GetOptions());
 	vars.push_back(ppsspp_internal_resolution.GetOptions());
 	vars.push_back(ppsspp_button_preference.GetOptions());
 	vars.push_back(ppsspp_fast_memory.GetOptions());
@@ -265,7 +263,6 @@ static void check_variables(CoreParameter &coreParam) {
 	ppsspp_gpu_hardware_transform.Update(&g_Config.bHardwareTransform);
 	ppsspp_frameskip.Update(&g_Config.iFrameSkip);
 	ppsspp_frameskiptype.Update(&g_Config.iFrameSkipType);
-	ppsspp_audio_latency.Update(&g_Config.iAudioLatency);
 	ppsspp_auto_frameskip.Update(&g_Config.bAutoFrameSkip);
 	ppsspp_block_transfer_gpu.Update(&g_Config.bBlockTransferGPU);
 	ppsspp_texture_filtering.Update(&g_Config.iTexFiltering);


### PR DESCRIPTION
This setting only changes some internal values that are shown in tests not to match PSP behavior.  Removed, it now matches how the PSP works.

This setting wasn't really affecting any actual audio latency.  Fixes #11844.

-[Unknown]