### PR TITLE
Travis: Cache macOS python (and sdl2, etc.) build as a bottle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ addons:
     update: true
     packages:
       - ccache
-      - python
-      - sdl2
 
 cache:
   apt: true


### PR DESCRIPTION
Currently, we're compiling python from scratch every commit and pull.

These changes set things up so that a bottle (brew's binary package) is generated when compiling, and that is then cached.  The cached bottle is installed next time.  If there's a problem with the cache, it'll just recompile and recache.

This should significantly improve typical Travis macOS/iOS build times (I was seeing them cut down to 10-12 minutes each.)  That said, it won't be faster when this is initially merged to master - it'll get faster in subsequent builds.

I'm hoping this'll reduce timeouts and spurious failures as well.

-[Unknown]