### PR TITLE
Prevent cheat UI from clobbering cheats

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -245,10 +245,17 @@ static void __CheatStop() {
 static void __CheatStart() {
 	__CheatStop();
 
-	std::string gameID = g_paramSFO.GetValueString("DISC_ID");
+	std::string realGameID = g_paramSFO.GetValueString("DISC_ID");
+	std::string gameID = realGameID;
+	const std::string gamePath = PSP_CoreParameter().fileToStart;
+	const bool badGameSFO = realGameID.empty() || !g_paramSFO.GetValueInt("DISC_TOTAL");
+	if (badGameSFO && gamePath.find("/PSP/GAME/") != std::string::npos) {
+		gameID = g_paramSFO.GenerateFakeID(gamePath);
+	}
+
 	cheatEngine = new CWCheatEngine(gameID);
 	// This only generates ini files on boot, let's leave homebrew ini file for UI.
-	if (!gameID.empty()) {
+	if (!realGameID.empty()) {
 		cheatEngine->CreateCheatFile();
 	}
 
@@ -347,10 +354,10 @@ void hleCheat(u64 userdata, int cyclesLate) {
 }
 
 CWCheatEngine::CWCheatEngine(const std::string &gameID) : gameID_(gameID) {
+	filename_ = GetSysDirectory(DIRECTORY_CHEATS) + gameID_ + ".ini";
 }
 
 void CWCheatEngine::CreateCheatFile() {
-	filename_ = GetSysDirectory(DIRECTORY_CHEATS) + gameID_ + ".ini";
 	File::CreateFullPath(GetSysDirectory(DIRECTORY_CHEATS));
 
 	if (!File::Exists(filename_)) {

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -1,6 +1,8 @@
 // Rough and ready CwCheats implementation, disabled by default.
 // Will not enable by default until the TOOD:s have been addressed.
 
+#pragma once
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -34,12 +36,18 @@ struct CheatCode {
 	std::vector<CheatLine> lines;
 };
 
+struct CheatFileInfo {
+	int lineNum;
+	std::string name;
+	bool enabled;
+};
+
 struct CheatOperation;
 
 class CWCheatEngine {
 public:
 	CWCheatEngine();
-	std::vector<std::string> GetCodesList();
+	std::vector<CheatFileInfo> FileInfo();
 	void ParseCheats();
 	void CreateCheatFile();
 	void Run();

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -46,10 +46,11 @@ struct CheatOperation;
 
 class CWCheatEngine {
 public:
-	CWCheatEngine();
+	CWCheatEngine(const std::string &gameID);
 	std::vector<CheatFileInfo> FileInfo();
 	void ParseCheats();
 	void CreateCheatFile();
+	std::string CheatFilename();
 	void Run();
 	bool HasCheats();
 
@@ -67,4 +68,6 @@ private:
 	bool TestIfAddr(const CheatOperation &op, bool(*oper)(int a, int b));
 
 	std::vector<CheatCode> cheats_;
+	std::string gameID_;
+	std::string filename_;
 };

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -91,7 +91,7 @@ void CwCheatScreen::CreateViews() {
 
 	rightColumn->Add(new ItemHeader(cw->T("Cheats")));
 	for (size_t i = 0; i < fileInfo_.size(); ++i) {
-		rightColumn->Add(new CheatCheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
+		rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
 			return OnCheckBox((int)i);
 		});
 	}

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -22,6 +22,8 @@
 #include "ui/ui_context.h"
 #include "UI/MiscScreens.h"
 
+struct CheatFileInfo;
+
 extern std::string activeCheatFile;
 extern std::string gameTitle;
 
@@ -29,9 +31,7 @@ class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
 	CwCheatScreen(std::string gamePath);
 
-	void CreateCodeList();
-	void processFileOn(std::string activatedCheat);
-	void processFileOff(std::string deactivatedCheat);
+	void LoadCheatInfo();
 
 	UI::EventReturn OnAddCheat(UI::EventParams &params);
 	UI::EventReturn OnImportCheat(UI::EventParams &params);
@@ -39,13 +39,20 @@ public:
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
 
 	void onFinish(DialogResult result) override;
+
 protected:
 	void CreateViews() override;
 
 private:
-	UI::EventReturn OnCheckBox(UI::EventParams &params);
-	std::vector<std::string> formattedList_;
-	UI::ScrollView *rightScroll_;
+	UI::EventReturn OnCheckBox(int index);
+
+	enum { INDEX_ALL = -1 };
+	bool RebuildCheatFile(int index);
+
+	UI::ScrollView *rightScroll_ = nullptr;
+	std::vector<CheatFileInfo> fileInfo_;
+	std::string gamePath_;
+	bool enableAllFlag_ = false;
 };
 
 class CheatCheckBox : public UI::CheckBox {

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -58,17 +58,3 @@ private:
 	uint64_t fileCheckHash_;
 	bool enableAllFlag_ = false;
 };
-
-class CheatCheckBox : public UI::CheckBox {
-public:
-	CheatCheckBox(bool *toggle, const std::string &text, UI::LayoutParams *layoutParams = nullptr)
-		: UI::CheckBox(toggle, text, "", layoutParams), text_(text) {
-	}
-
-	std::string Text() {
-		return text_;
-	}
-
-private:
-	std::string text_;
-};

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -28,12 +28,11 @@ extern std::string gameTitle;
 class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
 	CwCheatScreen(std::string gamePath);
-	CwCheatScreen() {}
+
 	void CreateCodeList();
 	void processFileOn(std::string activatedCheat);
 	void processFileOff(std::string deactivatedCheat);
-	const char * name;
-	std::string activatedCheat, deactivatedCheat;
+
 	UI::EventReturn OnAddCheat(UI::EventParams &params);
 	UI::EventReturn OnImportCheat(UI::EventParams &params);
 	UI::EventReturn OnEditCheatFile(UI::EventParams &params);
@@ -49,34 +48,16 @@ private:
 	UI::ScrollView *rightScroll_;
 };
 
-// TODO: Instead just hook the OnClick event on a regular checkbox.
-class CheatCheckBox : public UI::ClickableItem, public CwCheatScreen {
+class CheatCheckBox : public UI::CheckBox {
 public:
-	CheatCheckBox(bool *toggle, const std::string &text, const std::string &smallText = "", UI::LayoutParams *layoutParams = 0)
-		: UI::ClickableItem(layoutParams), toggle_(toggle), text_(text) {
-			OnClick.Handle(this, &CheatCheckBox::OnClicked);
+	CheatCheckBox(bool *toggle, const std::string &text, UI::LayoutParams *layoutParams = nullptr)
+		: UI::CheckBox(toggle, text, "", layoutParams), text_(text) {
 	}
 
-	virtual void Draw(UIContext &dc);
-
-	UI::EventReturn OnClicked(UI::EventParams &e) {
-		bool temp = false;
-		if (toggle_) {
-			*toggle_ = !(*toggle_);
-			temp = *toggle_;
-		}
-		if (temp) {
-			activatedCheat = text_;
-			processFileOn(activatedCheat);
-		} else {
-			deactivatedCheat = text_;
-			processFileOff(deactivatedCheat);
-		}
-		return UI::EVENT_DONE;
+	std::string Text() {
+		return text_;
 	}
 
 private:
-	bool *toggle_;
 	std::string text_;
-	std::string smallText_;
 };

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -24,13 +24,12 @@
 #include "UI/MiscScreens.h"
 
 struct CheatFileInfo;
-
-extern std::string activeCheatFile;
-extern std::string gameTitle;
+class CWCheatEngine;
 
 class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
-	CwCheatScreen(std::string gamePath);
+	CwCheatScreen(const std::string &gamePath);
+	~CwCheatScreen();
 
 	void LoadCheatInfo();
 
@@ -52,8 +51,10 @@ private:
 	bool RebuildCheatFile(int index);
 
 	UI::ScrollView *rightScroll_ = nullptr;
+	CWCheatEngine *engine_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
 	std::string gamePath_;
+	std::string gameID_;
 	int fileCheckCounter_ = 0;
 	uint64_t fileCheckHash_;
 	bool enableAllFlag_ = false;

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <cstdint>
 #include <functional>
 
 #include "ui/view.h"
@@ -38,6 +39,7 @@ public:
 	UI::EventReturn OnEditCheatFile(UI::EventParams &params);
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
 
+	void update() override;
 	void onFinish(DialogResult result) override;
 
 protected:
@@ -52,6 +54,8 @@ private:
 	UI::ScrollView *rightScroll_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
 	std::string gamePath_;
+	int fileCheckCounter_ = 0;
+	uint64_t fileCheckHash_;
 	bool enableAllFlag_ = false;
 };
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -261,8 +261,7 @@ void GameSettingsScreen::CreateViews() {
 			return UI::EVENT_CONTINUE;
 		});
 		softwareGPU->OnClick.Handle(this, &GameSettingsScreen::OnSoftwareRendering);
-		if (PSP_IsInited())
-			softwareGPU->SetEnabled(false);
+		softwareGPU->SetEnabled(!PSP_IsInited());
 	}
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Frame Rate Control")));
@@ -828,6 +827,7 @@ void GameSettingsScreen::CreateViews() {
 	memstickPath->OnClick.Handle(this, &GameSettingsScreen::OnChangeMemStickDir);
 #elif defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
 	SavePathInMyDocumentChoice = systemSettings->Add(new CheckBox(&installed_, sy->T("Save path in My Documents", "Save path in My Documents")));
+	SavePathInMyDocumentChoice->SetEnabled(!PSP_IsInited());
 	SavePathInMyDocumentChoice->OnClick.Handle(this, &GameSettingsScreen::OnSavePathMydoc);
 	SavePathInOtherChoice = systemSettings->Add(new CheckBox(&otherinstalled_, sy->T("Save path in installed.txt", "Save path in installed.txt")));
 	SavePathInOtherChoice->SetEnabled(false);
@@ -843,7 +843,7 @@ void GameSettingsScreen::CreateViews() {
 			if (!(File::Delete(PPSSPPpath + "installedTEMP.txt")))
 				SavePathInMyDocumentChoice->SetEnabled(false);
 			else
-				SavePathInOtherChoice->SetEnabled(true);
+				SavePathInOtherChoice->SetEnabled(!PSP_IsInited());
 		} else
 			SavePathInMyDocumentChoice->SetEnabled(false);
 	} else {
@@ -860,7 +860,7 @@ void GameSettingsScreen::CreateViews() {
 				// Skip UTF-8 encoding bytes if there are any. There are 3 of them.
 				if (tempString.substr(0, 3) == "\xEF\xBB\xBF")
 					tempString = tempString.substr(3);
-				SavePathInOtherChoice->SetEnabled(true);
+				SavePathInOtherChoice->SetEnabled(!PSP_IsInited());
 				if (!(tempString == "")) {
 					installed_ = false;
 					otherinstalled_ = true;
@@ -874,7 +874,7 @@ void GameSettingsScreen::CreateViews() {
 #endif
 
 #if defined(_M_X64)
-	systemSettings->Add(new CheckBox(&g_Config.bCacheFullIsoInRam, sy->T("Cache ISO in RAM", "Cache full ISO in RAM")));
+	systemSettings->Add(new CheckBox(&g_Config.bCacheFullIsoInRam, sy->T("Cache ISO in RAM", "Cache full ISO in RAM")))->SetEnabled(!PSP_IsInited());
 #endif
 
 	systemSettings->Add(new ItemHeader(sy->T("Cheats", "Cheats (experimental, see forums)")));


### PR DESCRIPTION
And some related changes.  Specifically:

 * A few settings are disabled while in game now (either because they don't work or can cause weird cheats behavior.)  Fixes #12000.

 * Cheat names now wrap or get taller as needed to fit.

 * Changes to the cheat file are now monitored and the UI updates when found.  Fixes #6356.

 * You stay on the cheat screen when launching the text editor because it works as expected now.

 * Unrecognized cheat lines are now simply ignored, rather than deleted.  If it can parse them, it can update them without deleting unexpected lines.  Fixes #12320.  Fixes #11398.

 * Moves "Back" to the same bottom left corner most other screens have it in.

-[Unknown]