### PR TITLE
Implement Xinput vibration CWCheat (PPSSPP specific 0xA code type)

### DIFF
--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -44,7 +44,6 @@ public:
 	void CreateCheatFile();
 	void Run();
 	bool HasCheats();
-
 	void InvalidateICache(u32 addr, int size);
 private:
 	u32 GetAddress(u32 value);

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -87,6 +87,12 @@ static std::mutex ctrlMutex;
 
 static int ctrlTimer = -1;
 
+static u16 leftVibration = 0;
+static u16 rightVibration = 0;
+// The higher the dropout, the longer Vibration will run
+static u8 vibrationLeftDropout = 160;
+static u8 vibrationRightDropout = 160;
+
 // STATE END
 //////////////////////////////////////////////////////////////////////////
 
@@ -287,6 +293,10 @@ retry:
 static void __CtrlVblank()
 {
 	emuRapidFireFrames++;
+
+	// Reduce gamepad Vibration by set % each frame
+	leftVibration *= (float)vibrationLeftDropout / 256.0f;
+	rightVibration *= (float)vibrationRightDropout / 256.0f;
 
 	// This always runs, so make sure we're in vblank mode.
 	if (ctrlCycle == 0)
@@ -562,4 +572,27 @@ void Register_sceCtrl()
 void Register_sceCtrl_driver()
 {
 	RegisterModule("sceCtrl_driver", ARRAY_SIZE(sceCtrl), sceCtrl);
+}
+
+u16 sceCtrlGetRightVibration() {
+	return rightVibration;
+}
+
+u16 sceCtrlGetLeftVibration() {
+	return leftVibration;
+}
+
+namespace SceCtrl {
+	void SetRightVibration(u16 rVibration) {
+		rightVibration = rVibration;
+	}
+	void SetLeftVibration(u16 lVibration) {
+		leftVibration = lVibration;
+	}
+	void SetVibrationRightDropout(u8 vibrationRDropout) {
+		vibrationRightDropout = vibrationRDropout;
+	}
+	void SetVibrationLeftDropout(u8 vibrationLDropout) {
+		vibrationLeftDropout = vibrationLDropout;
+	}
 }

--- a/Core/HLE/sceCtrl.h
+++ b/Core/HLE/sceCtrl.h
@@ -87,3 +87,13 @@ void __CtrlPeekAnalog(int stick, float *x, float *y);
 u32 __CtrlReadLatch();
 
 void Register_sceCtrl_driver();
+
+u16 sceCtrlGetRightVibration();
+u16 sceCtrlGetLeftVibration();
+
+namespace SceCtrl {
+	void SetLeftVibration(u16 lVibration);
+	void SetRightVibration(u16 rVibration);
+	void SetVibrationLeftDropout(u8 vibrationLDropout);
+	void SetVibrationRightDropout(u8 vibrationRDropout);
+};

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -11,17 +11,23 @@
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "XinputDevice.h"
+#include "Core/Core.h"
+#include "Core/HLE/sceCtrl.h"
+#include "Common/Timer.h"
 
 // Utilities to dynamically load XInput. Adapted from SDL.
 
 #if !PPSSPP_PLATFORM(UWP)
 
 typedef DWORD (WINAPI *XInputGetState_t) (DWORD dwUserIndex, XINPUT_STATE* pState);
+typedef DWORD (WINAPI *XInputSetState_t) (DWORD dwUserIndex, XINPUT_VIBRATION* pVibration);
 
 static XInputGetState_t PPSSPP_XInputGetState = NULL;
+static XInputSetState_t PPSSPP_XInputSetState = NULL;
 static DWORD PPSSPP_XInputVersion = 0;
 static HMODULE s_pXInputDLL = 0;
 static int s_XInputDLLRefCount = 0;
+static int newVibrationTime = 0;
 
 static void UnloadXInputDLL();
 
@@ -65,6 +71,17 @@ static int LoadXInputDLL() {
 		return -1;
 	}
 
+	/* Let's try the name first, then fall back to a non-Ex version (xinput9_1_0.dll doesn't have Ex) */
+	PPSSPP_XInputSetState = (XInputSetState_t)GetProcAddress((HMODULE)s_pXInputDLL, "XInputSetStateEx");
+	if (!PPSSPP_XInputSetState) {
+		PPSSPP_XInputSetState = (XInputSetState_t)GetProcAddress((HMODULE)s_pXInputDLL, "XInputSetState");
+	}
+
+	if (!PPSSPP_XInputSetState) {
+		UnloadXInputDLL();
+		return -1;
+	}
+
 	return 0;
 }
 
@@ -81,6 +98,7 @@ static void UnloadXInputDLL() {
 static int LoadXInputDLL() { return 0; }
 static void UnloadXInputDLL() {}
 #define PPSSPP_XInputGetState XInputGetState
+#define PPSSPP_XInputSetState XInputSetState
 #endif
 
 #ifndef XUSER_MAX_COUNT
@@ -231,11 +249,13 @@ int XinputDevice::UpdateState() {
 	for (int i = 0; i < XUSER_MAX_COUNT; i++) {
 		XINPUT_STATE state;
 		ZeroMemory(&state, sizeof(XINPUT_STATE));
+		XINPUT_VIBRATION vibration;
+		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
 		if (check_delay[i]-- > 0)
 			continue;
 		DWORD dwResult = PPSSPP_XInputGetState(i, &state);
 		if (dwResult == ERROR_SUCCESS) {
-			UpdatePad(i, state);
+			UpdatePad(i, state, vibration);
 			anySuccess = true;
 		} else {
 			check_delay[i] = 30;
@@ -247,13 +267,14 @@ int XinputDevice::UpdateState() {
 	return anySuccess ? UPDATESTATE_SKIP_PAD : 0;
 }
 
-void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state) {
+void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATION &vibration) {
 	static bool notified = false;
 	if (!notified) {
 		notified = true;
 		KeyMap::NotifyPadConnected("Xbox 360 Pad");
 	}
 	ApplyButtons(pad, state);
+	ApplyVibration(pad, vibration);
 
 	const float STICK_DEADZONE = g_Config.fXInputAnalogDeadzone;
 	const int STICK_INV_MODE = g_Config.iXInputAnalogInverseMode;
@@ -338,3 +359,34 @@ void XinputDevice::ApplyButtons(int pad, const XINPUT_STATE &state) {
 		}
 	}
 }
+
+
+void XinputDevice::ApplyVibration(int pad, XINPUT_VIBRATION &vibration) {
+	if (PSP_IsInited()) {
+		newVibrationTime = Common::Timer::GetTimeMs() >> 6;
+		// We have to run PPSSPP_XInputSetState at time intervals
+		// since it bugs otherwise with very high unthrottle speeds
+		// and freezes at constant vibration or no vibration at all.
+		if (abs(newVibrationTime - prevVibrationTime) >= 1) {
+			if (GetUIState() == UISTATE_INGAME) {
+				vibration.wLeftMotorSpeed = sceCtrlGetLeftVibration(); // use any value between 0-65535 here
+				vibration.wRightMotorSpeed = sceCtrlGetRightVibration(); // use any value between 0-65535 here
+			} else {
+				vibration.wLeftMotorSpeed = 0;
+				vibration.wRightMotorSpeed = 0;
+			}
+
+			if ((prevVibration[pad].wLeftMotorSpeed != vibration.wLeftMotorSpeed || prevVibration[pad].wRightMotorSpeed != vibration.wRightMotorSpeed)) {
+				PPSSPP_XInputSetState(pad, &vibration);
+				prevVibration[pad] = vibration;
+			}
+			prevVibrationTime = newVibrationTime;
+		}
+	} else {
+		DWORD dwResult = PPSSPP_XInputSetState(pad, &vibration);
+		if (dwResult != ERROR_SUCCESS) {
+			check_delay[pad] = 30;
+		}
+	}
+}
+

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -2,7 +2,7 @@
 
 #include "InputDevice.h"
 #include "Xinput.h"
-
+#include "Core/HLE/sceCtrl.h"
 
 class XinputDevice final : public InputDevice {
 public:
@@ -11,9 +11,12 @@ public:
 	virtual int UpdateState() override;
 
 private:
-	void UpdatePad(int pad, const XINPUT_STATE &state);
+	void UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATION &vibration);
 	void ApplyButtons(int pad, const XINPUT_STATE &state);
+	void ApplyVibration(int pad, XINPUT_VIBRATION &vibration);
 	int check_delay[4]{};
 	XINPUT_STATE prevState[4]{};
+	XINPUT_VIBRATION prevVibration[4]{};
+	int prevVibrationTime = 0;
 	u32 prevButtons[4]{};
 };


### PR DESCRIPTION
Just something I was fooling around with, this basically adds a new PPSSPP specific code type(0xA) which can set left and right vibration(separately) for Xinput gamepads.

Test CWCheat which applies various force and length on left/right(dpad/face buttons), button activated will work in any game, but ultimately with some test cheats this could be used to for example vibrate on character being hit or whatever.

```
_C0 Vibration TEST PRESS Keys to trigger
//Test different power
_L 0xD0000000 0x10001000 //Triangle
_L 0xA0000000 0x00F0FFFF
_L 0xD0000000 0x10002000 //Circle
_L 0xA0000000 0x00F02000
_L 0xD0000000 0x10004000 //Cross
_L 0xA0000000 0x00F06000
_L 0xD0000000 0x10008000 //Square
_L 0xA0000000 0x00F08000
//Test Different lenght
_L 0xD0000000 0x10000010 //Up
_L 0xA010F000 0x00000000
_L 0xD0000000 0x10000020 //Right
_L 0xA080F000 0x00000000
_L 0xD0000000 0x10000040 //Down
_L 0xA0F0F000 0x00000000
_L 0xD0000000 0x10000080 //Left
_L 0xA0C0F000 0x00000000
_C0 Vibration read from memory TEST
_L 0xA1000000 0x08801000
//activate this cheat after the read from memory test to start vibration
_C0 write to memory vibration values
_L 0x20001000 0xF000F000
_L 0x20001004 0x00F000F0
//and later this one to stop it
_C0 clear vibration values from memory
_L 0x20001000 0x00000000
_L 0x20001004 0x00000000

```

Syntax of the new cheat is:

```
0xA0NNLLLL 0x00MMRRRR
Where:
NN/MM is lenght the vibration last
LLLL/RRRR is the vibration power
can be set separately to left and right motor

syntax for read from memory is:
0xA1000000 0xNNNNNNNN
where 0xNNNNNNNN is the address that at the following offsets reads values for:
+0x0 = left vibration(u16)
+0x2 = right vibration(u16)
+0x4 =  left vibration time(u8)
+0x6 = right vibration time(u8)
```
 When activated it constantly sets vibration and it's lenght, so it's use should be combined with test codes like 0xD/0xE to activate vibration on specific events or key presses.

 With read from memory version we can for example rise vibration together with car speed or something alike althrough we still have to do the math in our own script injected to memory and hooked to game code that would provide the data in such format.

 This currently works by sending cheat activated vibration and vibration lenght(dropout) to sceCtrl from where Xinput(potentially dinput and other vibration stuff in the future) can grab it.
