### PR TITLE
Add option to prevent Mipmaps from being dumped

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -80,7 +80,8 @@ bool TextureReplacer::LoadIni() {
 	allowVideo_ = false;
 	ignoreAddress_ = false;
 	reduceHash_ = false;
-	disallowMipmap_ = false;
+	// Prevents dumping the mipmaps.
+	ignoreMipmap_ = false;
 
 	if (File::Exists(basePath_ + INI_FILENAME)) {
 		IniFile ini;
@@ -129,7 +130,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, bool isOverride) {
 	options->Get("ignoreAddress", &ignoreAddress_, ignoreAddress_);
 	// Multiplies sizeInRAM/bytesPerLine in XXHASH by 0.5.
 	options->Get("reduceHash", &reduceHash_, reduceHash_);
-	options->Get("disallowMipmap", &disallowMipmap_, disallowMipmap_);
+	options->Get("ignoreMipmap", &ignoreMipmap_, ignoreMipmap_);
 	if (reduceHash_ && hash_ == ReplacedTextureHash::QUICK) {
 		reduceHash_ = false;
 		ERROR_LOG(G3D, "Texture Replacement: reduceHash option requires safer hash, use xxh32 or xxh64 instead.");
@@ -413,7 +414,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	if (ignoreAddress_) {
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
-	if (disallowMipmap_ && level > 0) {
+	if (ignoreMipmap_ && level > 0) {
 		return;
 	}
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -80,6 +80,7 @@ bool TextureReplacer::LoadIni() {
 	allowVideo_ = false;
 	ignoreAddress_ = false;
 	reduceHash_ = false;
+	disallowMipmap_ = false;
 
 	if (File::Exists(basePath_ + INI_FILENAME)) {
 		IniFile ini;
@@ -128,6 +129,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, bool isOverride) {
 	options->Get("ignoreAddress", &ignoreAddress_, ignoreAddress_);
 	// Multiplies sizeInRAM/bytesPerLine in XXHASH by 0.5.
 	options->Get("reduceHash", &reduceHash_, reduceHash_);
+	options->Get("disallowMipmap", &disallowMipmap_, disallowMipmap_);
 	if (reduceHash_ && hash_ == ReplacedTextureHash::QUICK) {
 		reduceHash_ = false;
 		ERROR_LOG(G3D, "Texture Replacement: reduceHash option requires safer hash, use xxh32 or xxh64 instead.");
@@ -410,6 +412,9 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	u64 cachekey = replacedInfo.cachekey;
 	if (ignoreAddress_) {
 		cachekey = cachekey & 0xFFFFFFFFULL;
+	}
+	if (disallowMipmap_ && level > 0) {
+		return;
 	}
 
 	std::string hashfile = LookupHashFile(cachekey, replacedInfo.hash, level);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -203,7 +203,7 @@ protected:
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;
 	bool reduceHash_ = false;
-	bool disallowMipmap_ = false;
+	bool ignoreMipmap_ = false;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -203,6 +203,7 @@ protected:
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;
 	bool reduceHash_ = false;
+	bool disallowMipmap_ = false;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;


### PR DESCRIPTION
WipEout Pure and Pulse use mipmapping for just about anything;
it is a huge waste of time to sort / blacklist every mip levels to prevent the 'new' folder from being cluttered.

This small change will be very useful to texture modders for games relying massively on mipmaps.

I'm not sure about the name of the setting though, so perhaps anyone has a suggestion ?