### PR TITLE
Auto rotate over a square

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1186,12 +1186,13 @@ void EmuScreen::update() {
 
 	if (autoRotatingAnalogCW_) {
 		const float now = time_now_d();
-		__CtrlSetAnalogX(cos(now*-g_Config.fAnalogAutoRotSpeed), 0);
-		__CtrlSetAnalogY(sin(now*-g_Config.fAnalogAutoRotSpeed), 0);
+		// Clamp to a square
+		__CtrlSetAnalogX(std::min(1.0f, std::max(-1.0f, 1.42f*cosf(now*-g_Config.fAnalogAutoRotSpeed))), 0);
+		__CtrlSetAnalogY(std::min(1.0f, std::max(-1.0f, 1.42f*sinf(now*-g_Config.fAnalogAutoRotSpeed))), 0);
 	} else if (autoRotatingAnalogCCW_) {
 		const float now = time_now_d();
-		__CtrlSetAnalogX(cos(now*g_Config.fAnalogAutoRotSpeed), 0);
-		__CtrlSetAnalogY(sin(now*g_Config.fAnalogAutoRotSpeed), 0);
+		__CtrlSetAnalogX(std::min(1.0f, std::max(-1.0f, 1.42f*cosf(now*g_Config.fAnalogAutoRotSpeed))), 0);
+		__CtrlSetAnalogY(std::min(1.0f, std::max(-1.0f, 1.42f*sinf(now*g_Config.fAnalogAutoRotSpeed))), 0);
 	}
 
 	// This is here to support the iOS on screen back button.

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -202,8 +202,9 @@ void AnalogRotationButton::Update() {
 
 	if (autoRotating_) {
 		float speed = clockWise_ ? -g_Config.fAnalogAutoRotSpeed : g_Config.fAnalogAutoRotSpeed;
-		__CtrlSetAnalogX(cos(now*speed), 0);
-		__CtrlSetAnalogY(sin(now*speed), 0);
+		// Clamp to a square
+		__CtrlSetAnalogX(std::min(1.0f, std::max(-1.0f, 1.42f*cosf(now*speed))), 0);
+		__CtrlSetAnalogY(std::min(1.0f, std::max(-1.0f, 1.42f*sinf(now*speed))), 0);
 	}
 }
 


### PR DESCRIPTION
At first I thought the analog would get only to 1/sqrt(2) at the corner as the HW was a circle, after seeing #11552 this is probabbly safer for QTE.