### PR TITLE
GLES: Disable range culling on old Tegras, they seem to misbehave

### DIFF
--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -572,7 +572,11 @@ OpenGLContext::OpenGLContext() {
 		}
 	}
 
-	if (caps_.vendor == GPUVendor::VENDOR_VIVANTE || caps_.vendor == GPUVendor::VENDOR_BROADCOM) {
+	// Try to detect old Tegra chips by checking for sub 3.0 GL versions. Like Vivante and Broadcom,
+	// those can't handle NaN values in conditionals.
+	if (caps_.vendor == GPUVendor::VENDOR_VIVANTE ||
+		caps_.vendor == GPUVendor::VENDOR_BROADCOM ||
+		(caps_.vendor == GPUVendor::VENDOR_NVIDIA && !gl_extensions.VersionGEThan(3, 0, 0))) {
 		bugs_.Infest(Bugs::BROKEN_NAN_IN_CONDITIONAL);
 	}
 


### PR DESCRIPTION
See issue #12838.

This is a blind fix - couldn't find my old Shield Portable :(

EDIT: Found it! But it doesn't start. Let's see if we charge it for a while...