### PR TITLE
Android: Don't cache env in text drawer

### DIFF
--- a/ext/native/gfx_es2/draw_text_android.h
+++ b/ext/native/gfx_es2/draw_text_android.h
@@ -35,7 +35,6 @@ private:
 	std::string NormalizeString(std::string str);
 
 	// JNI functions
-	JNIEnv *env_;
 	jclass cls_textRenderer;
 	jmethodID method_measureText;
 	jmethodID method_renderText;


### PR DESCRIPTION
For PPGe, the thread is changing on lost, so we can't use the cached env.

Fixes #12805.

-[Unknown]