### PR TITLE
Vulkan: Discard negative width/height framebuffer blits. 

### DIFF
--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -493,8 +493,10 @@ void FramebufferManagerVulkan::BlitFramebuffer(VirtualFramebuffer *dst, int dstX
 		h -= srcY + h - src->bufferHeight;
 	}
 
-	if (w == 0 || h == 0)
+	if (w <= 0 || h <= 0) {
+		// The whole rectangle got clipped.
 		return;
+	}
 
 	float srcXFactor = (float)src->renderWidth / (float)src->bufferWidth;
 	float srcYFactor = (float)src->renderHeight / (float)src->bufferHeight;


### PR DESCRIPTION
Should fix #12531 .

However, the root cause is still a little unclear..