### PR TITLE
Vulkan: Framebuffer manager: Use an allocator for "MakePixelTexture" images.

### DIFF
--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -5,7 +5,7 @@
 class VulkanDeviceAllocator;
 
 // Wrapper around what you need to use a texture.
-// Not very optimal - if you have many small textures you should use other strategies.
+// ALWAYS use an allocator when calling CreateDirect.
 class VulkanTexture {
 public:
 	VulkanTexture(VulkanContext *vulkan)

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -99,6 +99,7 @@ private:
 	TextureCacheVulkan *textureCacheVulkan_ = nullptr;
 	ShaderManagerVulkan *shaderManagerVulkan_ = nullptr;
 	DrawEngineVulkan *drawEngineVulkan_ = nullptr;
+	VulkanDeviceAllocator *allocator_ = nullptr;
 	VulkanPushBuffer *push_;
 
 	enum {


### PR DESCRIPTION
Fixes #12355 (or at a minimum, will improve it).