### PR TITLE
GPU: Split up software transform into phases

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -324,12 +324,8 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 					}
 				}
 			} else {
-				if (reader.hasColor0()) {
-					for (int j = 0; j < 4; j++) {
-						c0[j] = unlitColor[j];
-					}
-				} else {
-					c0 = Vec4f::FromRGBA(gstate.getMaterialAmbientRGBA());
+				for (int j = 0; j < 4; j++) {
+					c0[j] = unlitColor[j];
 				}
 				if (lmode) {
 					// c1 is already 0.

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -25,6 +25,7 @@ class FramebufferManagerCommon;
 class TextureCacheCommon;
 
 enum SoftwareTransformAction {
+	SW_NOT_READY,
 	SW_DRAW_PRIMITIVES,
 	SW_CLEAR,
 };
@@ -35,8 +36,11 @@ struct SoftwareTransformResult {
 	float depth;
 
 	bool setStencil;
-	bool textureChanged;
 	u8 stencilValue;
+
+	TransformedVertex *drawBuffer;
+	int drawNumTrans;
+	bool drawIndexed;
 };
 
 struct SoftwareTransformParams {
@@ -50,5 +54,15 @@ struct SoftwareTransformParams {
 	bool provokeFlatFirst;
 };
 
-void SoftwareTransform(int prim, int vertexCount, u32 vertexType, u16 *&inds, int indexType, const DecVtxFormat &decVtxFormat, int &maxIndex, TransformedVertex *&drawBuffer,
-	int &numTrans, bool &drawIndexed, const SoftwareTransformParams *params, SoftwareTransformResult *result);
+class SoftwareTransform {
+public:
+	SoftwareTransform(SoftwareTransformParams &params) : params_(params) {
+	}
+
+	void Decode(int prim, u32 vertexType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result);
+	void DetectOffsetTexture(int maxIndex);
+	void BuildDrawingParams(int prim, int vertexCount, u32 vertType, u16 *&inds, int &maxIndex, SoftwareTransformResult *result);
+
+protected:
+	const SoftwareTransformParams &params_;
+};


### PR DESCRIPTION
This also moves a few more output parameters to result, which I think is clearer.

This makes it easier to deal with GLES state, specifically the viewport state and texture application dependencies.

-[Unknown]