### PR TITLE
Windows: Make init crash warnings more generic

### DIFF
--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -148,8 +148,8 @@ void MainThreadFunc() {
 		Reporting::ReportMessage("Graphics init error: %s", "ALL");
 
 		auto err = GetI18NCategory("Error");
-		const char *defaultErrorAll = "Failed initializing any graphics. Try upgrading your graphics drivers.";
-		const char *genericError = err->T("GenericAllGraphicsError", defaultErrorAll);
+		const char *defaultErrorAll = "PPSSPP failed to startup with any graphics backend. Try upgrading your graphics and other drivers.";
+		const char *genericError = err->T("GenericAllStartupError", defaultErrorAll);
 		std::wstring title = ConvertUTF8ToWString(err->T("GenericGraphicsError", "Graphics Error"));
 		MessageBox(0, ConvertUTF8ToWString(genericError).c_str(), title.c_str(), MB_OK);
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -291,7 +291,7 @@ void System_SendMessage(const char *command, const char *parameter) {
 		}
 	} else if (!strcmp(command, "graphics_failedBackend")) {
 		auto err = GetI18NCategory("Error");
-		const char *backendSwitchError = err->T("GenericBackendSwitchError", "PPSSPP crashed while initializing graphics. Try upgrading your graphics drivers.\n\nGraphics backend has been switched:");
+		const char *backendSwitchError = err->T("GenericBackendSwitchCrash", "PPSSPP crashed while starting. This usually means a graphics driver problem. Try upgrading your graphics drivers.\n\nGraphics backend has been switched:");
 		std::wstring full_error = ConvertUTF8ToWString(StringFromFormat("%s %s", backendSwitchError, parameter));
 		std::wstring title = ConvertUTF8ToWString(err->T("GenericGraphicsError", "Graphics Error"));
 		MessageBox(MainWindow::GetHWND(), full_error.c_str(), title.c_str(), MB_OK);


### PR DESCRIPTION
Let's not trap ourselves in the mindset that it MUST be graphics.

#12845 didn't make sense until I realized I let myself be tricked by my own error message.

-[Unknown]