### PR TITLE
Refactor Android resize management and improve restart

### DIFF
--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -132,6 +132,9 @@ protected:
 	};
 	TrackedTouch touches_[MAX_TOUCH_POINTS]{};
 
-	virtual void CreateViews() override;
+	void CreateViews() override;
+
 	UI::EventReturn OnImmersiveModeChange(UI::EventParams &e);
+	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
+	UI::EventReturn OnRecreateActivity(UI::EventParams &e);
 };

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1195,14 +1195,25 @@ void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 }
 #endif
 
+void GameSettingsScreen::TriggerRestart(const char *why) {
+	// Extra save here to make sure the choice really gets saved even if there are shutdown bugs in
+	// the GPU backend code.
+	g_Config.Save(why);
+	std::string param = "--gamesettings";
+	if (editThenRestore_) {
+		// We won't pass the gameID, so don't resume back into settings.
+		param = "";
+	} else if (!gamePath_.empty()) {
+		param += " \"" + ReplaceAll(ReplaceAll(gamePath_, "\\", "\\\\"), "\"", "\\\"") + "\"";
+	}
+	System_SendMessage("graphics_restart", param.c_str());
+}
+
 void GameSettingsScreen::CallbackRenderingBackend(bool yes) {
 	// If the user ends up deciding not to restart, set the config back to the current backend
 	// so it doesn't get switched by accident.
 	if (yes) {
-		// Extra save here to make sure the choice really gets saved even if there are shutdown bugs in
-		// the GPU backend code.
-		g_Config.Save("GameSettingsScreen::RenderingBackendYes");
-		System_SendMessage("graphics_restart", "");
+		TriggerRestart("GameSettingsScreen::RenderingBackendYes");
 	} else {
 		g_Config.iGPUBackend = (int)GetGPUBackend();
 	}
@@ -1212,10 +1223,7 @@ void GameSettingsScreen::CallbackRenderingDevice(bool yes) {
 	// If the user ends up deciding not to restart, set the config back to the current backend
 	// so it doesn't get switched by accident.
 	if (yes) {
-		// Extra save here to make sure the choice really gets saved even if there are shutdown bugs in
-		// the GPU backend code.
-		g_Config.Save("GameSettingsScreen::RenderingDeviceYes");
-		System_SendMessage("graphics_restart", "");
+		TriggerRestart("GameSettingsScreen::RenderingDeviceYes");
 	} else {
 		std::string *deviceNameSetting = GPUDeviceNameSetting();
 		if (deviceNameSetting)
@@ -1227,8 +1235,7 @@ void GameSettingsScreen::CallbackRenderingDevice(bool yes) {
 
 void GameSettingsScreen::CallbackInflightFrames(bool yes) {
 	if (yes) {
-		g_Config.Save("GameSettingsScreen::InflightFramesYes");
-		System_SendMessage("graphics_restart", "");
+		TriggerRestart("GameSettingsScreen::InflightFramesYes");
 	} else {
 		g_Config.iInflightFrames = prevInflightFrames_;
 	}

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -48,6 +48,8 @@ protected:
 	bool UseVerticalLayout() const;
 
 private:
+	void TriggerRestart(const char *why);
+
 	std::string gameID_;
 	bool lastVertical_;
 	UI::CheckBox *enableReportsCheckbox_;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -420,7 +420,14 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 void LogoScreen::Next() {
 	if (!switched_) {
 		switched_ = true;
-		if (boot_filename.size()) {
+		if (gotoGameSettings_) {
+			if (boot_filename.size()) {
+				screenManager()->switchScreen(new EmuScreen(boot_filename));
+			} else {
+				screenManager()->switchScreen(new MainScreen());
+			}
+			screenManager()->push(new GameSettingsScreen(boot_filename));
+		} else if (boot_filename.size()) {
 			screenManager()->switchScreen(new EmuScreen(boot_filename));
 		} else {
 			screenManager()->switchScreen(new MainScreen());

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -114,8 +114,8 @@ private:
 
 class LogoScreen : public UIScreen {
 public:
-	LogoScreen()
-		: frames_(0), switched_(false) {}
+	LogoScreen(bool gotoGameSettings = false)
+		: gotoGameSettings_(gotoGameSettings) {}
 	bool key(const KeyInput &key) override;
 	bool touch(const TouchInput &touch) override;
 	void update() override;
@@ -125,8 +125,9 @@ public:
 
 private:
 	void Next();
-	int frames_;
-	bool switched_;
+	int frames_ = 0;
+	bool switched_ = false;
+	bool gotoGameSettings_ = false;
 };
 
 class CreditsScreen : public UIDialogScreenWithBackground {

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -290,6 +290,9 @@ bool WindowsGLContext::InitFromRenderThread(std::string *error_message) {
 	// Unfortunately, glew will generate an invalid enum error, ignore.
 	glGetError();
 
+	// Reset in case we're in a backend switch.
+	ResetGLExtensions();
+
 	int contextFlags = g_Config.bGfxDebugOutput ? WGL_CONTEXT_DEBUG_BIT_ARB : 0;
 
 	HGLRC m_hrc = nullptr;

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -153,13 +153,20 @@ namespace W32Util
 		moduleFilename.resize(sz);
 	}
 
-	void ExitAndRestart() {
+	void ExitAndRestart(bool overrideArgs, const std::string &args) {
 		// This preserves arguments (for example, config file) and working directory.
 		std::wstring workingDirectory;
 		std::wstring moduleFilename;
 		GetSelfExecuteParams(workingDirectory, moduleFilename);
 
-		const wchar_t *cmdline = RemoveExecutableFromCommandLine(GetCommandLineW());
+		const wchar_t *cmdline;
+		std::wstring wargs;
+		if (overrideArgs) {
+			wargs = ConvertUTF8ToWString(args);
+			cmdline = wargs.c_str();
+		} else {
+			cmdline = RemoveExecutableFromCommandLine(GetCommandLineW());
+		}
 		ShellExecute(nullptr, nullptr, moduleFilename.c_str(), cmdline, workingDirectory.c_str(), SW_SHOW);
 
 		ExitProcess(0);

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -11,7 +11,7 @@ namespace W32Util
 	BOOL CopyTextToClipboard(HWND hwnd, const char *text);
 	BOOL CopyTextToClipboard(HWND hwnd, const std::wstring &wtext);
 	void MakeTopMost(HWND hwnd, bool topMost);
-	void ExitAndRestart();
+	void ExitAndRestart(bool overrideArgs = false, const std::string &args = "");
 	void GetSelfExecuteParams(std::wstring &workingDirectory, std::wstring &moduleFilename);
 }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1026,14 +1026,21 @@ void getDesiredBackbufferSize(int &sz_x, int &sz_y) {
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_setDisplayParameters(JNIEnv *, jclass, jint xres, jint yres, jint dpi, jfloat refreshRate) {
 	ILOG("NativeApp.setDisplayParameters(%d x %d, dpi=%d, refresh=%0.2f)", xres, yres, dpi, refreshRate);
-	display_xres = xres;
-	display_yres = yres;
-	display_dpi_x = dpi;
-	display_dpi_y = dpi;
-	display_hz = refreshRate;
+	bool changed = false;
+	changed = changed || display_xres != xres || display_yres != yres;
+	changed = changed || display_dpi_x != dpi || display_dpi_y != dpi;
+	changed = changed || display_hz != refreshRate;
 
-	recalculateDpi();
-	NativeResized();
+	if (changed) {
+		display_xres = xres;
+		display_yres = yres;
+		display_dpi_x = dpi;
+		display_dpi_y = dpi;
+		display_hz = refreshRate;
+
+		recalculateDpi();
+		NativeResized();
+	}
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_computeDesiredBackbufferDimensions() {

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1316,6 +1316,7 @@ public abstract class NativeActivity extends Activity {
 			if (params.equals("ingame")) {
 				// Keep the screen bright - very annoying if it goes dark when tilting away
 				window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+				updateSustainedPerformanceMode();
 			} else {
 				// Only keep the screen bright ingame.
 				window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -75,6 +75,7 @@ public abstract class NativeActivity extends Activity {
 	protected NativeRenderer nativeRenderer;
 
 	private String shortcutParam = "";
+	private static String overrideShortcutParam = null;
 
 	public static String runCommand;
 	public static String commandParameter;
@@ -302,9 +303,11 @@ public abstract class NativeActivity extends Activity {
 
 		String model = Build.MANUFACTURER + ":" + Build.MODEL;
 		String languageRegion = Locale.getDefault().getLanguage() + "_" + Locale.getDefault().getCountry();
+		String shortcut = overrideShortcutParam == null ? shortcutParam : overrideShortcutParam;
+		overrideShortcutParam = null;
 
 		NativeApp.audioConfig(optimalFramesPerBuffer, optimalSampleRate);
-		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcutParam, Build.VERSION.SDK_INT, Build.BOARD);
+		NativeApp.init(model, deviceType, languageRegion, apkFilePath, dataDir, externalStorageDir, libraryDir, cacheDir, shortcut, Build.VERSION.SDK_INT, Build.BOARD);
 
 		// Allow C++ to tell us to use JavaGL or not.
 		javaGL = "true".equalsIgnoreCase(NativeApp.queryConfig("androidJavaGL"));
@@ -1254,6 +1257,9 @@ public abstract class NativeActivity extends Activity {
 			recreate();
 		} else if (command.equals("graphics_restart")) {
 			Log.i(TAG, "graphics_restart");
+			if (params != null && !params.equals("")) {
+				overrideShortcutParam = params;
+			}
 			shuttingDown = true;
 			recreate();
 		} else if (command.equals("ask_permission") && params.equals("storage")) {

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -29,14 +29,12 @@ import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.text.InputType;
 import android.util.Log;
-import android.view.Display;
 import android.view.Gravity;
 import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
-import android.view.OrientationEventListener;
 import android.view.Surface;
 import android.view.SurfaceView;
 import android.view.View;
@@ -423,7 +421,7 @@ public abstract class NativeActivity extends Activity {
 		} else {
 			Log.e(TAG, "updateSystemUiVisibility: decor view not yet created, ignoring for now");
 		}
-		sizeManager.updateDisplayMeasurements();
+		sizeManager.checkDisplayMeasurements();
 	}
 
 	// Need API 11 to check for existence of a vibrator? Zany.
@@ -751,7 +749,7 @@ public abstract class NativeActivity extends Activity {
 		// onConfigurationChanged not called on multi-window change
 		Log.i(TAG, "onMultiWindowModeChanged: isInMultiWindowMode = " + isInMultiWindowMode);
 		super.onMultiWindowModeChanged(isInMultiWindowMode, newConfig);
-		sizeManager.updateDisplayMeasurements();
+		sizeManager.checkDisplayMeasurements();
 	}
 
 	// keep this static so we can call this even if we don't

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -12,6 +12,8 @@ public class PpssppActivity extends NativeActivity {
 	private static final String TAG = "PpssppActivity";
 	// Key used by shortcut.
 	public static final String SHORTCUT_EXTRA_KEY = "org.ppsspp.ppsspp.Shortcuts";
+	// Key used for debugging.
+	public static final String ARGS_EXTRA_KEY = "org.ppsspp.ppsspp.Args";
 
 	private static boolean m_hasUnsupportedABI = false;
 	private static boolean m_hasNoNativeBinary = false;
@@ -78,14 +80,18 @@ public class PpssppActivity extends NativeActivity {
 		if (data != null) {
 			String path = intent.getData().getPath();
 			Log.i(TAG, "Found Shortcut Parameter in data: " + path);
-			super.setShortcutParam(path);
+			super.setShortcutParam("\"" + path.replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
 			// Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();
 		} else {
 			String param = getIntent().getStringExtra(SHORTCUT_EXTRA_KEY);
+			String args = getIntent().getStringExtra(ARGS_EXTRA_KEY);
 			Log.e(TAG, "Got ACTION_VIEW without a valid uri, trying param");
 			if (param != null) {
 				Log.i(TAG, "Found Shortcut Parameter in extra-data: " + param);
-				super.setShortcutParam(getIntent().getStringExtra(SHORTCUT_EXTRA_KEY));
+				super.setShortcutParam("\"" + param.replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
+			} else if (args != null) {
+				Log.i(TAG, "Found args parameter in extra-data: " + args);
+				super.setShortcutParam(args);
 			} else {
 				Log.e(TAG, "Shortcut missing parameter!");
 				super.setShortcutParam("");

--- a/ext/native/gfx_es2/gpu_features.cpp
+++ b/ext/native/gfx_es2/gpu_features.cpp
@@ -38,9 +38,9 @@ PFNGLISVERTEXARRAYOESPROC glIsVertexArrayOES;
 
 GLExtensions gl_extensions;
 std::string g_all_gl_extensions;
-std::set<std::string> g_set_gl_extensions;
+static std::set<std::string> g_set_gl_extensions;
 std::string g_all_egl_extensions;
-std::set<std::string> g_set_egl_extensions;
+static std::set<std::string> g_set_egl_extensions;
 
 static bool extensionsDone = false;
 static bool useCoreContext = false;
@@ -562,6 +562,15 @@ void SetGLCoreContext(bool flag) {
 	useCoreContext = flag;
 	// For convenience, it'll get reset later.
 	gl_extensions.IsCoreContext = useCoreContext;
+}
+
+void ResetGLExtensions() {
+	extensionsDone = false;
+
+	gl_extensions = {};
+	gl_extensions.IsCoreContext = useCoreContext;
+	g_all_gl_extensions.clear();
+	g_all_egl_extensions.clear();
 }
 
 static const char *glsl_fragment_prelude =

--- a/ext/native/gfx_es2/gpu_features.h
+++ b/ext/native/gfx_es2/gpu_features.h
@@ -120,5 +120,6 @@ extern std::string g_all_egl_extensions;
 
 void CheckGLExtensions();
 void SetGLCoreContext(bool flag);
+void ResetGLExtensions();
 
 std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage);

--- a/ext/native/ui/screen.h
+++ b/ext/native/ui/screen.h
@@ -147,7 +147,6 @@ private:
 	void switchToNext();
 	void processFinishDialog();
 
-	Screen *nextScreen_;
 	UIContext *uiContext_;
 	Draw::DrawContext *thin3DContext_;
 
@@ -166,4 +165,5 @@ private:
 	// Dialog stack. These are shown "on top" of base screens and the Android back button works as expected.
 	// Used for options, in-game menus and other things you expect to be able to back out from onto something.
 	std::vector<Layer> stack_;
+	std::vector<Layer> nextStack_;
 };


### PR DESCRIPTION
From a functional perspective, this mainly:
 * Makes it so when you change backends, you return to settings.
 * Gives you more testing options in the touch screen tester (such as restarting or changing backend.)
 * Makes it possible to pass args to PPSSPP on Android, i.e. `-d`, `-i`, `--log`, etc.

Was trying to help #12425.  I remember I saw a sizing problem a couple months ago myself, so this was to try to reproduce it.  I didn't, but I think the changes are still beneficial.  Also a small change that may help #11018 a bit.

I did make it also debounce display measurement resizes, because I saw them bounce back and forth sometimes and cause us to reinit graphics multiple times (making things slower.)  With the delay, I'm not seeing this anymore.  I'm hoping that could improve any remaining size issues.

-[Unknown]

======
Fixes #10916