### PR TITLE
Vulkan: Don't merge render passes where the second one begins with a clear.

### DIFF
--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -308,7 +308,7 @@ void ConvertRGBA565ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 		b = _mm_or_si128(_mm_slli_epi16(b, 3), _mm_srli_epi16(b, 2));
 		b = _mm_and_si128(b, mask8);
 
-		// Always set to 00FF 00FF.
+		// Always set alpha to 00FF 00FF.
 		__m128i a = _mm_slli_epi16(mask8, 8);
 
 		// Now combine them, RRGG RRGG and BBAA BBAA, and then interleave.
@@ -472,36 +472,36 @@ void ConvertRGBA4444ToBGRA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 	u8 *dst = (u8 *)dst32;
 	for (u32 x = 0; x < numPixels; x++) {
 		u16 c = src[x];
-		u32 r = c & 0x000f;
-		u32 g = (c >> 4) & 0x000f;
-		u32 b = (c >> 8) & 0x000f;
-		u32 a = (c >> 12) & 0x000f;
+		u32 r = Convert4To8(c & 0x000f);
+		u32 g = Convert4To8((c >> 4) & 0x000f);
+		u32 b = Convert4To8((c >> 8) & 0x000f);
+		u32 a = Convert4To8((c >> 12) & 0x000f);
 
-		dst[x] = (r << (16 + 4)) | (g << (8 + 4)) | (b << 4) | (a << (24 + 4));
+		dst[x] = (a << 24) | (r << 16) | (g << 8) | b;
 	}
 }
 
 void ConvertRGBA5551ToBGRA8888(u32 *dst, const u16 *src, u32 numPixels) {
 	for (u32 x = 0; x < numPixels; x++) {
 		u16 c = src[x];
-		u32 r = c & 0x001f;
-		u32 g = (c >> 5) & 0x001f;
-		u32 b = (c >> 10) & 0x001f;
+		u32 r = Convert5To8(c & 0x001f);
+		u32 g = Convert6To8((c >> 5) & 0x001f);
+		u32 b = Convert5To8((c >> 10) & 0x001f);
 		// We force an arithmetic shift to get the sign bits/
 		u32 a = ((s32)(s16)c) & 0xff000000;
 
-		dst[x] = (r << (16 + 3)) | (g << (8 + 3)) | (b << 3) | a;
+		dst[x] = a | (r << 16) | (g << 8) | b;
 	}
 }
 
 void ConvertRGB565ToBGRA8888(u32 *dst, const u16 *src, u32 numPixels) {
 	for (u32 x = 0; x < numPixels; x++) {
 		u16 c = src[x];
-		u32 r = c & 0x001f;
-		u32 g = (c >> 5) & 0x003f;
-		u32 b = (c >> 11) & 0x001f;
+		u32 r = Convert5To8(c & 0x001f);
+		u32 g = Convert6To8((c >> 5) & 0x003f);
+		u32 b = Convert5To8((c >> 11) & 0x001f);
 
-		dst[x] = (r << (16 + 3)) | (g << (8 + 2)) | (b << 3) | 0xFF000000;
+		dst[x] = 0xFF000000 | (r << 16) | (g << 8) | b;
 	}
 }
 

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1212,7 +1212,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 	}
 }
 
-// This is called from detected memcopies only. Not block transfers.
+// This is called from detected memcopies and framebuffer initialization from VRAM. Not block transfers.
 // MotoGP goes this path so we need to catch those copies here.
 bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size, bool isMemset, u32 skipDrawReason) {
 	if (size == 0) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -400,10 +400,11 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 		shaderApply.Use(depalShaderCache_->GetDepalettizeVertexShader(), depalShaderCache_->GetInputLayout());
 
 		ID3D11ShaderResourceView *nullTexture = nullptr;
-		framebufferManagerD3D11_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_SKIP_COPY | BINDFBCOLOR_FORCE_SELF);
+		context_->PSSetShaderResources(0, 1, &nullTexture);  // In case the target was used in the last draw call. Happens in Sega Rally.
 		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
 		context_->PSSetShaderResources(3, 1, &clutTexture);
 		context_->PSSetSamplers(3, 1, &stockD3D11.samplerPoint2DWrap);
+		framebufferManagerD3D11_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_SKIP_COPY | BINDFBCOLOR_FORCE_SELF);
 		context_->PSSetSamplers(0, 1, &stockD3D11.samplerPoint2DWrap);
 		shaderApply.Shade();
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -399,10 +399,11 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 		shaderApply.ApplyBounds(gstate_c.vertBounds, gstate_c.curTextureXOffset, gstate_c.curTextureYOffset, xoff, yoff);
 		shaderApply.Use(depalShaderCache_->GetDepalettizeVertexShader(), depalShaderCache_->GetInputLayout());
 
+		ID3D11ShaderResourceView *nullTexture = nullptr;
+		framebufferManagerD3D11_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_SKIP_COPY | BINDFBCOLOR_FORCE_SELF);
 		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
 		context_->PSSetShaderResources(3, 1, &clutTexture);
 		context_->PSSetSamplers(3, 1, &stockD3D11.samplerPoint2DWrap);
-		framebufferManagerD3D11_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_SKIP_COPY | BINDFBCOLOR_FORCE_SELF);
 		context_->PSSetSamplers(0, 1, &stockD3D11.samplerPoint2DWrap);
 		shaderApply.Shade();
 

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -776,7 +776,10 @@ void VulkanQueueRunner::ApplyRenderPassMerge(std::vector<VKRStep *> &steps) {
 					if (steps[j]->dependencies.contains(touchedFramebuffers)) {
 						goto done_fb;
 					}
-					if (steps[j]->render.framebuffer == fb) {
+					if (steps[j]->render.framebuffer == fb &&
+						steps[j]->render.color != VKRRenderPassAction::CLEAR &&
+						steps[j]->render.depth != VKRRenderPassAction::CLEAR &&
+						steps[j]->render.stencil != VKRRenderPassAction::CLEAR) {
 						// ok. Now, if it's a render, slurp up all the commands
 						// and kill the step.
 						// Also slurp up any pretransitions.


### PR DESCRIPTION
Fixes #12819 . Thankfully, this optimization survives that check in God of War where it's really important.

This dig also uncovered that our implementation of ReformatFramebufferFrom is bad in Vulkan (although fast...) but that doesn't turn out to really matter for that issue at least.

Also threw in a few minor things I found and fixed along the way.