### PR TITLE
Refactor postshader handling to apply for softgpu / D3D9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1359,6 +1359,8 @@ set(GPU_SOURCES
 	GPU/Common/GPUStateUtils.h
 	GPU/Common/DrawEngineCommon.cpp
 	GPU/Common/DrawEngineCommon.h
+	GPU/Common/PresentationCommon.cpp
+	GPU/Common/PresentationCommon.h
 	GPU/Common/ShaderId.cpp
 	GPU/Common/ShaderId.h
 	GPU/Common/ShaderUniforms.cpp

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -278,7 +278,7 @@ void ConvertRGBA8888ToRGBA4444(u16 *dst, const u32 *src, u32 numPixels) {
 	}
 }
 
-void ConvertRGBA565ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
+void ConvertRGB565ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 #ifdef _M_SSE
 	const __m128i mask5 = _mm_set1_epi16(0x001f);
 	const __m128i mask6 = _mm_set1_epi16(0x003f);
@@ -435,7 +435,7 @@ void ConvertRGBA4444ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 	}
 }
 
-void ConvertABGR565ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
+void ConvertBGR565ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 	u8 *dst = (u8 *)dst32;
 	for (u32 x = 0; x < numPixels; x++) {
 		u16 col = src[x];

--- a/Common/ColorConv.h
+++ b/Common/ColorConv.h
@@ -126,11 +126,11 @@ void ConvertBGRA8888ToRGBA5551(u16 *dst, const u32 *src, u32 numPixels);
 void ConvertBGRA8888ToRGB565(u16 *dst, const u32 *src, u32 numPixels);
 void ConvertBGRA8888ToRGBA4444(u16 *dst, const u32 *src, u32 numPixels);
 
-void ConvertRGBA565ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
+void ConvertRGB565ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA5551ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA4444ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 
-void ConvertABGR565ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
+void ConvertBGR565ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 void ConvertABGR1555ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 void ConvertABGR4444ToRGBA8888(u32 *dst, const u16 *src, u32 numPixels);
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -466,7 +466,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		saveBuf.resize((pitch * h) / sizeof(u16));
 		switch (replacedInfo.fmt) {
 		case ReplacedTextureFormat::F_5650:
-			ConvertRGBA565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
+			ConvertRGB565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
 			break;
 		case ReplacedTextureFormat::F_5551:
 			ConvertRGBA5551ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
@@ -475,7 +475,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 			ConvertRGBA4444ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
 			break;
 		case ReplacedTextureFormat::F_0565_ABGR:
-			ConvertABGR565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
+			ConvertBGR565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
 			break;
 		case ReplacedTextureFormat::F_1555_ABGR:
 			ConvertABGR1555ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -21,7 +21,6 @@
 #include <cmath>
 
 #include "ext/native/thin3d/thin3d.h"
-#include "base/timeutil.h"
 #include "gfx_es2/gpu_features.h"
 
 #include "i18n/i18n.h"
@@ -32,7 +31,6 @@
 #include "Core/CoreParameter.h"
 #include "Core/Host.h"
 #include "Core/Reporting.h"
-#include "Core/ELF/ParamSFO.h"
 #include "Core/System.h"
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/FramebufferCommon.h"

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -735,8 +735,9 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 			case GE_FORMAT_8888:
 				if (preferredPixelsFormat_ == Draw::DataFormat::B8G8R8A8_UNORM)
 					ConvertRGBA8888ToBGRA8888(dst, src32, width);
+				// This means use original pointer as-is.  May avoid or optimize a copy.
 				else
-					memcpy(dst, src32, 4 * width);
+					return false;
 				break;
 
 			case GE_FORMAT_INVALID:
@@ -744,6 +745,7 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 				break;
 			}
 		}
+		return true;
 	};
 
 	Draw::TextureDesc desc{

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -782,15 +782,13 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, GEBu
 	if (needBackBufferYSwap_) {
 		flags |= OutputFlags::BACKBUFFER_FLIPPED;
 	}
+	// DrawActiveTexture reverses these, probably to match "up".
+	if (GetGPUBackend() == GPUBackend::DIRECT3D9 || GetGPUBackend() == GPUBackend::DIRECT3D11) {
+		flags |= OutputFlags::POSITION_FLIPPED;
+	}
 
 	PostShaderUniforms uniforms{};
 	presentation_->CalculatePostShaderUniforms(512, 272, textureCache_->VideoIsPlaying(), &uniforms);
-
-	// TODO: DrawActiveTexture reverses these, but I'm not sure why?  Investigate.
-	if (GetGPUBackend() == GPUBackend::DIRECT3D9 || GetGPUBackend() == GPUBackend::DIRECT3D11) {
-		std::swap(v0, v1);
-	}
-
 	presentation_->SourceTexture(pixelsTex);
 	presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1, uniforms);
 	pixelsTex->Release();
@@ -950,18 +948,15 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 		if (needBackBufferYSwap_) {
 			flags |= OutputFlags::BACKBUFFER_FLIPPED;
 		}
+		// DrawActiveTexture reverses these, probably to match "up".
+		if (GetGPUBackend() == GPUBackend::DIRECT3D9 || GetGPUBackend() == GPUBackend::DIRECT3D11) {
+			flags |= OutputFlags::POSITION_FLIPPED;
+		}
 
 		PostShaderUniforms uniforms{};
 		int actualWidth = (vfb->bufferWidth * vfb->renderWidth) / vfb->width;
 		int actualHeight = (vfb->bufferHeight * vfb->renderHeight) / vfb->height;
 		presentation_->CalculatePostShaderUniforms(actualWidth, actualHeight, textureCache_->VideoIsPlaying(), &uniforms);
-
-		// DrawActiveTexture reverses these, probably to match "up".
-		// TODO: Maybe use a flag instead.
-		if (GetGPUBackend() == GPUBackend::DIRECT3D9 || GetGPUBackend() == GPUBackend::DIRECT3D11) {
-			std::swap(v0, v1);
-		}
-
 		presentation_->SourceFramebuffer(vfb->fbo);
 		presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1, uniforms);
 	} else if (useBufferedRendering_) {

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -715,7 +715,7 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 				if (preferredPixelsFormat_ == Draw::DataFormat::B8G8R8A8_UNORM)
 					ConvertRGB565ToBGRA8888(dst, src16, width);
 				else
-					ConvertRGBA565ToRGBA8888(dst, src16, width);
+					ConvertRGB565ToRGBA8888(dst, src16, width);
 				break;
 
 			case GE_FORMAT_5551:

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -308,7 +308,7 @@ public:
 protected:
 	virtual void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SetViewport2D(int x, int y, int w, int h);
-	virtual Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) = 0;
+	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1);
 	virtual void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) = 0;
 	virtual void Bind2DShader() = 0;
 
@@ -397,6 +397,7 @@ protected:
 	int bloomHack_ = 0;
 
 	bool needGLESRebinds_ = false;
+	Draw::DataFormat preferredPixelsFormat_ = Draw::DataFormat::R8G8B8A8_UNORM;
 
 	struct TempFBOInfo {
 		Draw::Framebuffer *fbo;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -229,7 +229,7 @@ public:
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, bool sync, int x, int y, int w, int h);
 
 	void DownloadFramebufferForClut(u32 fb_address, u32 loadBytes);
-	void DrawFramebufferToOutput(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, bool applyPostShader);
+	void DrawFramebufferToOutput(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride);
 
 	void DrawPixels(VirtualFramebuffer *vfb, int dstX, int dstY, const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -313,10 +313,8 @@ protected:
 	virtual void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) = 0;
 	virtual void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) = 0;
 	virtual void Bind2DShader() = 0;
-	virtual void BindPostShader(const PostShaderUniforms &uniforms) = 0;
 
 	bool UpdateSize();
-	void SetNumExtraFBOs(int num);
 
 	void FlushBeforeCopy();
 	virtual void DecimateFBOs();  // keeping it virtual to let D3D do a little extra
@@ -385,8 +383,6 @@ protected:
 	u32 framebufRangeEnd_ = 0;
 
 	bool useBufferedRendering_ = false;
-	bool usePostShader_ = false;
-	bool postShaderAtOutputResolution_ = false;
 	bool postShaderIsUpscalingFilter_ = false;
 	int postShaderSSAAFilterLevel_ = 0;
 
@@ -401,9 +397,6 @@ protected:
 	int pixelWidth_;
 	int pixelHeight_;
 	int bloomHack_ = 0;
-
-	// Used by post-processing shaders
-	std::vector<Draw::Framebuffer *> extraFBOs_;
 
 	bool needGLESRebinds_ = false;
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -46,22 +46,7 @@ namespace Draw {
 	class Framebuffer;
 }
 
-struct CardboardSettings {
-	bool enabled;
-	float leftEyeXPosition;
-	float rightEyeXPosition;
-	float screenYPosition;
-	float screenWidth;
-	float screenHeight;
-};
-
 class VulkanFBO;
-
-struct PostShaderUniforms {
-	float texelDelta[2]; float pixelDelta[2];
-	float time[4];
-	float video;
-};
 
 struct VirtualFramebuffer {
 	int last_frame_used;
@@ -191,9 +176,11 @@ class DrawContext;
 }
 
 struct GPUDebugBuffer;
-class TextureCacheCommon;
-class ShaderManagerCommon;
+struct PostShaderUniforms;
 class DrawEngineCommon;
+class PresentationCommon;
+class ShaderManagerCommon;
+class TextureCacheCommon;
 
 class FramebufferManagerCommon {
 public:
@@ -322,15 +309,11 @@ public:
 
 protected:
 	virtual void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
-	virtual void SetViewport2D(int x, int y, int w, int h);
-	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int renderWidth, int renderHeight, PostShaderUniforms *uniforms);
+	void SetViewport2D(int x, int y, int w, int h);
 	virtual void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) = 0;
 	virtual void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) = 0;
 	virtual void Bind2DShader() = 0;
 	virtual void BindPostShader(const PostShaderUniforms &uniforms) = 0;
-
-	// Cardboard Settings Calculator
-	void GetCardboardSettings(CardboardSettings *cardboardSettings);
 
 	bool UpdateSize();
 	void SetNumExtraFBOs(int num);
@@ -377,6 +360,8 @@ protected:
 		if ((skipDrawReason & SKIPDRAW_SKIPFRAME) == 0)
 			dstBuffer->reallyDirtyAfterDisplay = true;
 	}
+
+	PresentationCommon *presentation_ = nullptr;
 
 	Draw::DrawContext *draw_ = nullptr;
 	TextureCacheCommon *textureCache_ = nullptr;
@@ -437,5 +422,3 @@ protected:
 		FBO_OLD_USAGE_FLAG = 15,
 	};
 };
-
-void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW, float origH, float frameW, float frameH, int rotation);

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -176,7 +176,6 @@ class DrawContext;
 }
 
 struct GPUDebugBuffer;
-struct PostShaderUniforms;
 class DrawEngineCommon;
 class PresentationCommon;
 class ShaderManagerCommon;

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -138,7 +138,6 @@ enum BindFramebufferColorFlags {
 enum DrawTextureFlags {
 	DRAWTEX_NEAREST = 0,
 	DRAWTEX_LINEAR = 1,
-	DRAWTEX_KEEP_TEX = 2,
 	DRAWTEX_KEEP_STENCIL_ALPHA = 4,
 	DRAWTEX_TO_BACKBUFFER = 8,
 };
@@ -309,7 +308,7 @@ public:
 protected:
 	virtual void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SetViewport2D(int x, int y, int w, int h);
-	virtual void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) = 0;
+	virtual Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) = 0;
 	virtual void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) = 0;
 	virtual void Bind2DShader() = 0;
 

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -296,6 +296,7 @@ public:
 	void SetSafeSize(u16 w, u16 h);
 
 	virtual void Resized();
+	virtual void DestroyAllFBOs();
 
 	Draw::Framebuffer *GetTempFBO(TempFBO reason, u16 w, u16 h, Draw::FBColorDepth colorDepth = Draw::FBO_8888);
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -28,9 +28,10 @@
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 #include "GPU/Math3D.h"
+#include "GPU/Common/FramebufferCommon.h"
+#include "GPU/Common/PresentationCommon.h"
 #include "GPU/Common/ShaderId.h"
 #include "GPU/Common/VertexDecoderCommon.h"
-#include "GPU/Common/FramebufferCommon.h"
 
 #include "GPU/Common/GPUStateUtils.h"
 

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -538,8 +538,9 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		Draw::SamplerState *sampler = useNearest ? samplerNearest_ : samplerLinear_;
 		draw_->BindSamplerStates(0, 1, &sampler);
 
-		float post_v0 = flags & OutputFlags::BACKBUFFER_FLIPPED ? 1.0f : 0.0f;
-		float post_v1 = flags & OutputFlags::BACKBUFFER_FLIPPED ? 0.0f : 1.0f;
+		bool flipped = GetGPUBackend() == GPUBackend::DIRECT3D9 || GetGPUBackend() == GPUBackend::DIRECT3D11;
+		float post_v0 = !flipped ? 1.0f : 0.0f;
+		float post_v1 = !flipped ? 0.0f : 1.0f;
 		verts[4] = { -1, -1, 0, 0, post_v1, 0xFFFFFFFF }; // TL
 		verts[5] = { -1, 1, 0, 0, post_v0, 0xFFFFFFFF }; // BL
 		verts[6] = { 1, 1, 0, 1, post_v0, 0xFFFFFFFF }; // BR

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -320,8 +320,8 @@ void PresentationCommon::CreateDeviceObjects() {
 	// TODO: Use 4 and a strip?  shorts?
 	idata_ = draw_->CreateBuffer(sizeof(int) * 6, BufferUsageFlag::DYNAMIC | BufferUsageFlag::INDEXDATA);
 
-	samplerNearest_ = draw_->CreateSamplerState({ TextureFilter::NEAREST, TextureFilter::NEAREST, TextureFilter::NEAREST });
-	samplerLinear_ = draw_->CreateSamplerState({ TextureFilter::LINEAR, TextureFilter::LINEAR, TextureFilter::LINEAR });
+	samplerNearest_ = draw_->CreateSamplerState({ TextureFilter::NEAREST, TextureFilter::NEAREST, TextureFilter::NEAREST, 0.0f, TextureAddressMode::CLAMP_TO_EDGE, TextureAddressMode::CLAMP_TO_EDGE, TextureAddressMode::CLAMP_TO_EDGE });
+	samplerLinear_ = draw_->CreateSamplerState({ TextureFilter::LINEAR, TextureFilter::LINEAR, TextureFilter::LINEAR, 0.0f, TextureAddressMode::CLAMP_TO_EDGE, TextureAddressMode::CLAMP_TO_EDGE, TextureAddressMode::CLAMP_TO_EDGE });
 
 	texColor_ = CreatePipeline({ draw_->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw_->GetFshaderPreset(FS_TEXTURE_COLOR_2D) }, false, &vsTexColBufDesc);
 	texColorRBSwizzle_ = CreatePipeline({ draw_->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw_->GetFshaderPreset(FS_TEXTURE_COLOR_2D_RB_SWIZZLE) }, false, &vsTexColBufDesc);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include <cassert>
+#include <cmath>
+#include "base/display.h"
+#include "base/timeutil.h"
+#include "thin3d/thin3d.h"
+#include "Core/Config.h"
+#include "Core/ConfigValues.h"
+#include "Core/System.h"
+#include "Core/HLE/sceDisplay.h"
+#include "GPU/Common/PostShader.h"
+#include "GPU/Common/PresentationCommon.h"
+
+struct Vertex {
+	float x, y, z;
+	float u, v;
+	uint32_t rgba;
+};
+
+void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW, float origH, float frameW, float frameH, int rotation) {
+	float outW;
+	float outH;
+
+	bool rotated = rotation == ROTATION_LOCKED_VERTICAL || rotation == ROTATION_LOCKED_VERTICAL180;
+
+	if (g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::STRETCH) {
+		outW = frameW;
+		outH = frameH;
+	} else {
+		if (g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::MANUAL) {
+			float offsetX = (g_Config.fSmallDisplayOffsetX - 0.5f) * 2.0f * frameW;
+			float offsetY = (g_Config.fSmallDisplayOffsetY - 0.5f) * 2.0f * frameH;
+			// Have to invert Y for GL
+			if (GetGPUBackend() == GPUBackend::OPENGL) {
+				offsetY = offsetY * -1.0f;
+			}
+			float customZoom = g_Config.fSmallDisplayZoomLevel;
+			float smallDisplayW = origW * customZoom;
+			float smallDisplayH = origH * customZoom;
+			if (!rotated) {
+				*x = floorf(((frameW - smallDisplayW) / 2.0f) + offsetX);
+				*y = floorf(((frameH - smallDisplayH) / 2.0f) + offsetY);
+				*w = floorf(smallDisplayW);
+				*h = floorf(smallDisplayH);
+				return;
+			} else {
+				*x = floorf(((frameW - smallDisplayH) / 2.0f) + offsetX);
+				*y = floorf(((frameH - smallDisplayW) / 2.0f) + offsetY);
+				*w = floorf(smallDisplayH);
+				*h = floorf(smallDisplayW);
+				return;
+			}
+		} else if (g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::AUTO) {
+			// Stretch to 1080 for 272*4.  But don't distort if not widescreen (i.e. ultrawide of halfwide.)
+			float pixelCrop = frameH / 270.0f;
+			float resCommonWidescreen = pixelCrop - floor(pixelCrop);
+			if (!rotated && resCommonWidescreen == 0.0f && frameW >= pixelCrop * 480.0f) {
+				*x = floorf((frameW - pixelCrop * 480.0f) * 0.5f);
+				*y = floorf(-pixelCrop);
+				*w = floorf(pixelCrop * 480.0f);
+				*h = floorf(pixelCrop * 272.0f);
+				return;
+			}
+		}
+
+		float origRatio = !rotated ? origW / origH : origH / origW;
+		float frameRatio = frameW / frameH;
+
+		if (origRatio > frameRatio) {
+			// Image is wider than frame. Center vertically.
+			outW = frameW;
+			outH = frameW / origRatio;
+			// Stretch a little bit
+			if (!rotated && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH)
+				outH = (frameH + outH) / 2.0f; // (408 + 720) / 2 = 564
+		} else {
+			// Image is taller than frame. Center horizontally.
+			outW = frameH * origRatio;
+			outH = frameH;
+			if (rotated && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH)
+				outW = (frameH + outH) / 2.0f; // (408 + 720) / 2 = 564
+		}
+	}
+
+	*x = floorf((frameW - outW) / 2.0f);
+	*y = floorf((frameH - outH) / 2.0f);
+	*w = floorf(outW);
+	*h = floorf(outH);
+}
+
+PresentationCommon::PresentationCommon(Draw::DrawContext *draw) : draw_(draw) {
+	CreateDeviceObjects();
+}
+
+PresentationCommon::~PresentationCommon() {
+	DestroyDeviceObjects();
+}
+
+void PresentationCommon::GetCardboardSettings(CardboardSettings *cardboardSettings) {
+	// Calculate Cardboard Settings
+	float cardboardScreenScale = g_Config.iCardboardScreenSize / 100.0f;
+	float cardboardScreenWidth = pixelWidth_ / 2.0f * cardboardScreenScale;
+	float cardboardScreenHeight = pixelHeight_ / 2.0f * cardboardScreenScale;
+	float cardboardMaxXShift = (pixelWidth_ / 2.0f - cardboardScreenWidth) / 2.0f;
+	float cardboardUserXShift = g_Config.iCardboardXShift / 100.0f * cardboardMaxXShift;
+	float cardboardLeftEyeX = cardboardMaxXShift + cardboardUserXShift;
+	float cardboardRightEyeX = pixelWidth_ / 2.0f + cardboardMaxXShift - cardboardUserXShift;
+	float cardboardMaxYShift = pixelHeight_ / 2.0f - cardboardScreenHeight / 2.0f;
+	float cardboardUserYShift = g_Config.iCardboardYShift / 100.0f * cardboardMaxYShift;
+	float cardboardScreenY = cardboardMaxYShift + cardboardUserYShift;
+
+	cardboardSettings->enabled = g_Config.bEnableCardboardVR;
+	cardboardSettings->leftEyeXPosition = cardboardLeftEyeX;
+	cardboardSettings->rightEyeXPosition = cardboardRightEyeX;
+	cardboardSettings->screenYPosition = cardboardScreenY;
+	cardboardSettings->screenWidth = cardboardScreenWidth;
+	cardboardSettings->screenHeight = cardboardScreenHeight;
+}
+
+void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int renderWidth, int renderHeight, bool hasVideo, PostShaderUniforms *uniforms) {
+	float u_delta = 1.0f / bufferWidth;
+	float v_delta = 1.0f / bufferHeight;
+	float u_pixel_delta = 1.0f / renderWidth;
+	float v_pixel_delta = 1.0f / renderHeight;
+	if (postShaderAtOutputResolution_) {
+		float x, y, w, h;
+		CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, (float)pixelWidth_, (float)pixelHeight_, ROTATION_LOCKED_HORIZONTAL);
+		u_pixel_delta = 1.0f / w;
+		v_pixel_delta = 1.0f / h;
+	}
+	int flipCount = __DisplayGetFlipCount();
+	int vCount = __DisplayGetVCount();
+	float time[4] = { time_now(), (vCount % 60) * 1.0f / 60.0f, (float)vCount, (float)(flipCount % 60) };
+
+	uniforms->texelDelta[0] = u_delta;
+	uniforms->texelDelta[1] = v_delta;
+	uniforms->pixelDelta[0] = u_pixel_delta;
+	uniforms->pixelDelta[1] = v_pixel_delta;
+	memcpy(uniforms->time, time, 4 * sizeof(float));
+	uniforms->video = hasVideo;
+}
+
+void PresentationCommon::UpdateShaderInfo(const ShaderInfo *shaderInfo) {
+	postShaderAtOutputResolution_ = shaderInfo->outputResolution;
+}
+
+void PresentationCommon::DeviceLost() {
+	DestroyDeviceObjects();
+}
+
+void PresentationCommon::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
+	CreateDeviceObjects();
+}
+
+void PresentationCommon::CreateDeviceObjects() {
+	using namespace Draw;
+
+	// TODO: Maybe get rid of color0.
+	InputLayoutDesc inputDesc = {
+		{
+			{ sizeof(Vertex), false },
+		},
+		{
+			{ 0, SEM_POSITION, DataFormat::R32G32B32_FLOAT, 0 },
+			{ 0, SEM_TEXCOORD0, DataFormat::R32G32_FLOAT, 12 },
+			{ 0, SEM_COLOR0, DataFormat::R8G8B8A8_UNORM, 20 },
+		},
+	};
+
+	vdata_ = draw_->CreateBuffer(sizeof(Vertex) * 4, BufferUsageFlag::DYNAMIC | BufferUsageFlag::VERTEXDATA);
+	// TODO: Use 4 and a strip?  shorts?
+	idata_ = draw_->CreateBuffer(sizeof(int) * 6, BufferUsageFlag::DYNAMIC | BufferUsageFlag::INDEXDATA);
+
+	InputLayout *inputLayout = draw_->CreateInputLayout(inputDesc);
+	DepthStencilState *depth = draw_->CreateDepthStencilState({ false, false, Comparison::LESS });
+	BlendState *blendstateOff = draw_->CreateBlendState({ false, 0xF });
+	RasterState *rasterNoCull = draw_->CreateRasterState({});
+
+	samplerNearest_ = draw_->CreateSamplerState({ TextureFilter::NEAREST, TextureFilter::NEAREST, TextureFilter::NEAREST });
+	samplerLinear_ = draw_->CreateSamplerState({ TextureFilter::LINEAR, TextureFilter::LINEAR, TextureFilter::LINEAR });
+
+	PipelineDesc pipelineDesc{
+		Primitive::TRIANGLE_LIST,
+		{ draw_->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw_->GetFshaderPreset(FS_TEXTURE_COLOR_2D) },
+		inputLayout, depth, blendstateOff, rasterNoCull, &vsTexColBufDesc
+	};
+	texColor_ = draw_->CreateGraphicsPipeline(pipelineDesc);
+
+	PipelineDesc pipelineDescRBSwizzle{
+		Primitive::TRIANGLE_LIST,
+		{ draw_->GetVshaderPreset(VS_TEXTURE_COLOR_2D), draw_->GetFshaderPreset(FS_TEXTURE_COLOR_2D_RB_SWIZZLE) },
+		inputLayout, depth, blendstateOff, rasterNoCull, &vsTexColBufDesc
+	};
+	texColorRBSwizzle_ = draw_->CreateGraphicsPipeline(pipelineDescRBSwizzle);
+
+	inputLayout->Release();
+	depth->Release();
+	blendstateOff->Release();
+	rasterNoCull->Release();
+}
+
+template <typename T>
+static void DoRelease(T *&obj) {
+	if (obj)
+		obj->Release();
+	obj = nullptr;
+}
+
+void PresentationCommon::DestroyDeviceObjects() {
+	DoRelease(texColor_);
+	DoRelease(texColorRBSwizzle_);
+	DoRelease(samplerNearest_);
+	DoRelease(samplerLinear_);
+	DoRelease(vdata_);
+	DoRelease(idata_);
+}
+
+void PresentationCommon::CopyToOutput(OutputFlags flags, float x, float y, float x2, float y2, float u0, float v0, float u1, float v1) {
+	Draw::Pipeline *pipeline = flags & OutputFlags::RB_SWIZZLE ? texColorRBSwizzle_ : texColor_;
+
+	Draw::SamplerState *sampler;
+	if (flags & OutputFlags::NEAREST) {
+		sampler = samplerNearest_;
+	} else {
+		sampler = samplerLinear_;
+	}
+	draw_->BindSamplerStates(0, 1, &sampler);
+
+	const Vertex verts[4] = {
+		{ x, y, 0,    u0, v0,  0xFFFFFFFF }, // TL
+		{ x, y2, 0,   u0, v1,  0xFFFFFFFF }, // BL
+		{ x2, y2, 0,  u1, v1,  0xFFFFFFFF }, // BR
+		{ x2, y, 0,   u1, v0,  0xFFFFFFFF }, // TR
+	};
+	draw_->UpdateBuffer(vdata_, (const uint8_t *)verts, 0, sizeof(verts), Draw::UPDATE_DISCARD);
+
+	int indexes[] = { 0, 1, 2, 0, 2, 3 };
+	draw_->UpdateBuffer(idata_, (const uint8_t *)indexes, 0, sizeof(indexes), Draw::UPDATE_DISCARD);
+
+	Draw::VsTexColUB ub{};
+	memcpy(ub.WorldViewProj, g_display_rot_matrix.m, sizeof(float) * 16);
+	draw_->BindPipeline(pipeline);
+	draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
+	draw_->BindVertexBuffers(0, 1, &vdata_, nullptr);
+	draw_->BindIndexBuffer(idata_, 0);
+	draw_->DrawIndexed(6, 0);
+	draw_->BindIndexBuffer(nullptr, 0);
+}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -612,4 +612,6 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 
 	DoRelease(srcFramebuffer_);
 	DoRelease(srcTexture_);
+
+	draw_->BindPipeline(nullptr);
 }

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+struct CardboardSettings {
+	bool enabled;
+	float leftEyeXPosition;
+	float rightEyeXPosition;
+	float screenYPosition;
+	float screenWidth;
+	float screenHeight;
+};
+
+struct PostShaderUniforms {
+	float texelDelta[2]; float pixelDelta[2];
+	float time[4];
+	float video;
+};
+
+void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW, float origH, float frameW, float frameH, int rotation);
+
+namespace Draw {
+class Buffer;
+class DrawContext;
+class Pipeline;
+class SamplerState;
+}
+
+struct ShaderInfo;
+class TextureCacheCommon;
+
+enum class OutputFlags {
+	LINEAR = 0x0000,
+	NEAREST = 0x0001,
+	RB_SWIZZLE = 0x0002,
+};
+
+inline OutputFlags operator | (const OutputFlags &lhs, const OutputFlags &rhs) {
+	return OutputFlags((int)lhs | (int)rhs);
+}
+inline OutputFlags operator |= (OutputFlags &lhs, const OutputFlags &rhs) {
+	lhs = lhs | rhs;
+	return lhs;
+}
+inline bool operator & (const OutputFlags &lhs, const OutputFlags &rhs) {
+	return ((int)lhs & (int)rhs) != 0;
+}
+
+class PresentationCommon {
+public:
+	PresentationCommon(Draw::DrawContext *draw);
+	~PresentationCommon();
+
+	void UpdateSize(int w, int h) {
+		pixelWidth_ = w;
+		pixelHeight_ = h;
+	}
+	void UpdateShaderInfo(const ShaderInfo *shaderInfo);
+
+	void DeviceLost();
+	void DeviceRestore(Draw::DrawContext *draw);
+
+	void GetCardboardSettings(CardboardSettings *cardboardSettings);
+	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int renderWidth, int renderHeight, bool hasVideo, PostShaderUniforms *uniforms);
+
+	// TODO: Cleanup
+	void CopyToOutput(OutputFlags flags, float x, float y, float x2, float y2, float u0, float v0, float u1, float v1);
+
+protected:
+	void CreateDeviceObjects();
+	void DestroyDeviceObjects();
+
+	Draw::DrawContext *draw_;
+	Draw::Pipeline *texColor_ = nullptr;
+	Draw::Pipeline *texColorRBSwizzle_ = nullptr;
+	Draw::SamplerState *samplerNearest_ = nullptr;
+	Draw::SamplerState *samplerLinear_ = nullptr;
+	Draw::Buffer *vdata_ = nullptr;
+	Draw::Buffer *idata_ = nullptr;
+
+	int pixelWidth_ = 0;
+	int pixelHeight_ = 0;
+	bool postShaderAtOutputResolution_ = false;
+};

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -84,6 +84,10 @@ public:
 		lang_ = lang;
 	}
 
+	bool HasPostShader() {
+		return usePostShader_;
+	}
+
 	bool UpdatePostShader();
 	void UpdateShaderInfo(const ShaderInfo *shaderInfo);
 

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -37,8 +37,10 @@ void CenterDisplayOutputRect(float *x, float *y, float *w, float *h, float origW
 namespace Draw {
 class Buffer;
 class DrawContext;
+class Framebuffer;
 class Pipeline;
 class SamplerState;
+class Texture;
 }
 
 struct ShaderInfo;
@@ -48,6 +50,7 @@ enum class OutputFlags {
 	LINEAR = 0x0000,
 	NEAREST = 0x0001,
 	RB_SWIZZLE = 0x0002,
+	BACKBUFFER_FLIPPED = 0x0004,
 };
 
 inline OutputFlags operator | (const OutputFlags &lhs, const OutputFlags &rhs) {
@@ -79,7 +82,9 @@ public:
 	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int renderWidth, int renderHeight, bool hasVideo, PostShaderUniforms *uniforms);
 
 	// TODO: Cleanup
-	void CopyToOutput(OutputFlags flags, float x, float y, float x2, float y2, float u0, float v0, float u1, float v1);
+	void SourceTexture(Draw::Texture *texture);
+	void SourceFramebuffer(Draw::Framebuffer *fb);
+	void CopyToOutput(OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
 
 protected:
 	void CreateDeviceObjects();
@@ -92,6 +97,9 @@ protected:
 	Draw::SamplerState *samplerLinear_ = nullptr;
 	Draw::Buffer *vdata_ = nullptr;
 	Draw::Buffer *idata_ = nullptr;
+
+	Draw::Texture *srcTexture_ = nullptr;
+	Draw::Framebuffer *srcFramebuffer_ = nullptr;
 
 	int pixelWidth_ = 0;
 	int pixelHeight_ = 0;

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -56,6 +56,7 @@ enum class OutputFlags {
 	NEAREST = 0x0001,
 	RB_SWIZZLE = 0x0002,
 	BACKBUFFER_FLIPPED = 0x0004,
+	POSITION_FLIPPED = 0x0008,
 };
 
 inline OutputFlags operator | (const OutputFlags &lhs, const OutputFlags &rhs) {

--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -96,8 +96,8 @@ R"(#version 430
 #extension GL_ARB_shading_language_420pack : enable
 )";
 
-static const char *pushconstantBufferDecl = R"(
-layout(push_constant) uniform data {
+static const char *vulkanUboDecl = R"(
+layout (std140, set = 0, binding = 0) uniform Data {
 	vec2 u_texelDelta;
 	vec2 u_pixelDelta;
 	vec4 u_time;
@@ -155,7 +155,7 @@ bool ConvertToVulkanGLSL(std::string *dest, TranslatedShaderMetadata *destMetada
 		const char *replacement;
 	} replacements[] = {
 		{ Draw::ShaderStage::VERTEX, "attribute vec4 a_position;", "layout(location = 0) in vec4 a_position;" },
-		{ Draw::ShaderStage::VERTEX, "attribute vec2 a_texcoord0;", "layout(location = 1) in vec2 a_texcoord0;"},
+		{ Draw::ShaderStage::VERTEX, "attribute vec2 a_texcoord0;", "layout(location = 2) in vec2 a_texcoord0;"},
 		{ Draw::ShaderStage::VERTEX, "varying vec2 v_position;", "layout(location = 0) out vec2 v_position;" },
 		{ Draw::ShaderStage::FRAGMENT, "varying vec2 v_position;", "layout(location = 0) in vec2 v_position;" },
 		{ Draw::ShaderStage::FRAGMENT, "texture2D(", "texture(" },
@@ -167,7 +167,7 @@ bool ConvertToVulkanGLSL(std::string *dest, TranslatedShaderMetadata *destMetada
 		out << "layout (location = 0) out vec4 fragColor0;\n";
 	}
 	// Output the uniform buffer.
-	out << pushconstantBufferDecl;
+	out << vulkanUboDecl;
 
 	// Alright, now let's go through it line by line and zap the single uniforms
 	// and perform replacements.
@@ -178,7 +178,7 @@ bool ConvertToVulkanGLSL(std::string *dest, TranslatedShaderMetadata *destMetada
 		if (line.find("uniform bool") != std::string::npos) {
 			continue;
 		} else if (line.find("uniform sampler2D") == 0) {
-			line = "layout(set = 0, binding = 0) " + line;
+			line = "layout(set = 0, binding = 1) " + line;
 		} else if (line.find("uniform ") != std::string::npos) {
 			continue;
 		} else if (2 == sscanf(line.c_str(), "varying vec%d v_texcoord%d;", &vecSize, &num)) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -916,7 +916,7 @@ bool TextureCacheCommon::SetOffsetTexture(u32 yOffset) {
 
 	u32 texaddr = gstate.getTextureAddress(0);
 	GETextureFormat fmt = gstate.getTextureFormat();
-	const u32 bpp = fmt == GE_FORMAT_8888 ? 4 : 2;
+	const u32 bpp = fmt == GE_TFMT_8888 ? 4 : 2;
 	const u32 texaddrOffset = yOffset * gstate.getTextureWidth(0) * bpp;
 
 	if (!Memory::IsValidAddress(texaddr) || !Memory::IsValidAddress(texaddr + texaddrOffset)) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1178,7 +1178,7 @@ static inline void ConvertFormatToRGBA8888(GETextureFormat format, u32 *dst, con
 		ConvertRGBA5551ToRGBA8888(dst, src, numPixels);
 		break;
 	case GE_TFMT_5650:
-		ConvertRGBA565ToRGBA8888(dst, src, numPixels);
+		ConvertRGB565ToRGBA8888(dst, src, numPixels);
 		break;
 	default:
 		_dbg_assert_msg_(G3D, false, "Incorrect texture format.");

--- a/GPU/D3D11/DepalettizeShaderD3D11.cpp
+++ b/GPU/D3D11/DepalettizeShaderD3D11.cpp
@@ -94,7 +94,7 @@ ID3D11ShaderResourceView *DepalShaderCacheD3D11::GetClutTexture(GEPaletteFormat 
 			ConvertRGBA5551ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
 			break;
 		case GE_CMODE_16BIT_BGR5650:
-			ConvertRGBA565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
+			ConvertRGB565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
 			break;
 		}
 		rawClut = expanded;

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -129,6 +129,7 @@ FramebufferManagerD3D11::FramebufferManagerD3D11(Draw::DrawContext *draw)
 	ShaderTranslationInit();
 
 	presentation_->SetLanguage(HLSL_D3D11);
+	preferredPixelsFormat_ = Draw::DataFormat::B8G8R8A8_UNORM;
 }
 
 FramebufferManagerD3D11::~FramebufferManagerD3D11() {
@@ -176,54 +177,6 @@ void FramebufferManagerD3D11::SetShaderManager(ShaderManagerD3D11 *sm) {
 void FramebufferManagerD3D11::SetDrawEngine(DrawEngineD3D11 *td) {
 	drawEngineD3D11_ = td;
 	drawEngine_ = td;
-}
-
-Draw::Texture *FramebufferManagerD3D11::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) {
-	auto generateTexture = [&](uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride) {
-		for (int y = 0; y < height; y++) {
-			const u16_le *src16 = (const u16_le *)srcPixels + srcStride * y;
-			const u32_le *src32 = (const u32_le *)srcPixels + srcStride * y;
-			u32 *dst = (u32 *)(data + byteStride * y);
-			switch (srcPixelFormat) {
-			case GE_FORMAT_565:
-				ConvertRGB565ToBGRA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_5551:
-				ConvertRGBA5551ToBGRA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_4444:
-				ConvertRGBA4444ToBGRA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_8888:
-				ConvertRGBA8888ToBGRA8888(dst, src32, width);
-				break;
-
-			case GE_FORMAT_INVALID:
-				_dbg_assert_msg_(G3D, false, "Invalid pixelFormat passed to DrawPixels().");
-				break;
-			}
-		}
-	};
-
-	Draw::TextureDesc desc{
-		Draw::TextureType::LINEAR2D,
-		Draw::DataFormat::B8G8R8A8_UNORM,
-		width,
-		height,
-		1,
-		1,
-		false,
-		"DrawPixels",
-		{ (uint8_t *)srcPixels },
-		generateTexture,
-	};
-	Draw::Texture *tex = draw_->CreateTexture(desc);
-	if (!tex)
-		ERROR_LOG(G3D, "Failed to create drawpixels texture");
-	return tex;
 }
 
 void FramebufferManagerD3D11::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <d3d11.h>
 #include <D3Dcompiler.h>
 
@@ -22,12 +23,9 @@
 #include "math/lin/matrix4x4.h"
 #include "ext/native/thin3d/thin3d.h"
 #include "base/basictypes.h"
-#include "file/vfs.h"
-#include "file/zip_read.h"
 
 #include "Common/ColorConv.h"
 #include "Common/MathUtil.h"
-#include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -38,7 +36,6 @@
 #include "GPU/Debugger/Stepping.h"
 
 #include "GPU/Common/FramebufferCommon.h"
-#include "GPU/Common/PostShader.h"
 #include "GPU/Common/PresentationCommon.h"
 #include "GPU/Common/ShaderTranslation.h"
 #include "GPU/Common/TextureDecoder.h"
@@ -46,10 +43,6 @@
 #include "GPU/D3D11/ShaderManagerD3D11.h"
 #include "GPU/D3D11/TextureCacheD3D11.h"
 #include "GPU/D3D11/DrawEngineD3D11.h"
-
-#include "ext/native/thin3d/thin3d.h"
-
-#include <algorithm>
 
 #ifdef _M_SSE
 #include <emmintrin.h>

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -38,9 +38,10 @@
 #include "GPU/Debugger/Stepping.h"
 
 #include "GPU/Common/FramebufferCommon.h"
+#include "GPU/Common/PostShader.h"
+#include "GPU/Common/PresentationCommon.h"
 #include "GPU/Common/ShaderTranslation.h"
 #include "GPU/Common/TextureDecoder.h"
-#include "GPU/Common/PostShader.h"
 #include "GPU/D3D11/FramebufferManagerD3D11.h"
 #include "GPU/D3D11/ShaderManagerD3D11.h"
 #include "GPU/D3D11/TextureCacheD3D11.h"
@@ -243,6 +244,7 @@ void FramebufferManagerD3D11::CompilePostShader() {
 	shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
 	if (shaderInfo) {
 		postShaderAtOutputResolution_ = shaderInfo->outputResolution;
+		presentation_->UpdateShaderInfo(shaderInfo);
 		size_t sz;
 		char *vs = (char *)VFSReadFile(shaderInfo->vertexShaderFile.c_str(), &sz);
 		if (!vs)

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -498,39 +498,3 @@ void FramebufferManagerD3D11::EndFrame() {
 void FramebufferManagerD3D11::DeviceLost() {
 	DestroyAllFBOs();
 }
-
-void FramebufferManagerD3D11::DestroyAllFBOs() {
-	currentRenderVfb_ = nullptr;
-	displayFramebuf_ = nullptr;
-	prevDisplayFramebuf_ = nullptr;
-	prevPrevDisplayFramebuf_ = nullptr;
-
-	for (size_t i = 0; i < vfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = vfbs_[i];
-		INFO_LOG(FRAMEBUF, "Destroying FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-		DestroyFramebuf(vfb);
-	}
-	vfbs_.clear();
-
-	for (size_t i = 0; i < bvfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = bvfbs_[i];
-		DestroyFramebuf(vfb);
-	}
-	bvfbs_.clear();
-
-	for (auto &tempFB : tempFBOs_) {
-		tempFB.second.fbo->Release();
-	}
-	tempFBOs_.clear();
-}
-
-void FramebufferManagerD3D11::Resized() {
-	FramebufferManagerCommon::Resized();
-
-	if (UpdateSize()) {
-		DestroyAllFBOs();
-	}
-
-	// Might have a new post shader - let's compile it.
-	presentation_->UpdatePostShader();
-}

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -25,7 +25,6 @@
 
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
-#include "Core/Config.h"
 #include "ext/native/thin3d/thin3d.h"
 
 class TextureCacheD3D11;
@@ -98,7 +97,6 @@ private:
 
 	u8 *convBuf = nullptr;
 
-	int plainColorLoc_;
 	ID3D11PixelShader *stencilUploadPS_ = nullptr;
 	ID3D11VertexShader *stencilUploadVS_ = nullptr;
 	ID3D11InputLayout *stencilUploadInputLayout_ = nullptr;
@@ -111,8 +109,4 @@ private:
 	TextureCacheD3D11 *textureCacheD3D11_;
 	ShaderManagerD3D11 *shaderManagerD3D11_;
 	DrawEngineD3D11 *drawEngineD3D11_;
-
-	// Used by post-processing shader
-	// Postprocessing
-	static const D3D11_INPUT_ELEMENT_DESC g_PostVertexElements[2];
 };

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -68,8 +68,6 @@ protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
-	void CompilePostShader();
-	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void Bind2DShader() override;
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
@@ -116,9 +114,5 @@ private:
 
 	// Used by post-processing shader
 	// Postprocessing
-	ID3D11VertexShader *postVertexShader_ = nullptr;
-	ID3D11PixelShader *postPixelShader_ = nullptr;
-	ID3D11InputLayout *postInputLayout_ = nullptr;
-	ID3D11Buffer *postConstants_ = nullptr;
 	static const D3D11_INPUT_ELEMENT_DESC g_PostVertexElements[2];
 };

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -68,7 +68,7 @@ protected:
 
 private:
 	void Bind2DShader() override;
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
+	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SimpleBlit(
 		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2,
@@ -79,12 +79,6 @@ private:
 	ID3D11DeviceContext *context_;
 	D3D_FEATURE_LEVEL featureLevel_;
 
-	// Used by DrawPixels
-	ID3D11Texture2D *drawPixelsTex_ = nullptr;
-	ID3D11ShaderResourceView *drawPixelsTexView_ = nullptr;
-	int drawPixelsTexW_ = 0;
-	int drawPixelsTexH_ = 0;
-
 	ID3D11VertexShader *quadVertexShader_;
 	ID3D11PixelShader *quadPixelShader_;
 	ID3D11InputLayout *quadInputLayout_;
@@ -94,8 +88,6 @@ private:
 	const UINT quadStride_ = 20;
 	const UINT quadOffset_ = 0;
 	static const D3D11_INPUT_ELEMENT_DESC g_QuadVertexElements[2];
-
-	u8 *convBuf = nullptr;
 
 	ID3D11PixelShader *stencilUploadPS_ = nullptr;
 	ID3D11VertexShader *stencilUploadVS_ = nullptr;

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -68,7 +68,6 @@ protected:
 
 private:
 	void Bind2DShader() override;
-	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SimpleBlit(
 		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2,

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -41,10 +41,7 @@ public:
 	void SetDrawEngine(DrawEngineD3D11 *td);
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) override;
 
-	void DestroyAllFBOs();
-
 	void EndFrame();
-	void Resized() override;
 	void DeviceLost();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old) override;
 

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -359,11 +359,12 @@ void GPU_D3D11::DoState(PointerWrap &p) {
 	// TODO: Some of these things may not be necessary.
 	// None of these are necessary when saving.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCacheD3D11_->Clear(true);
+		textureCache_->Clear(true);
+		depalShaderCache_->Clear();
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerD3D11_->DestroyAllFBOs();
+		framebufferManager_->DestroyAllFBOs();
 	}
 }
 

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -597,37 +597,12 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	void FramebufferManagerDX9::DestroyAllFBOs() {
-		currentRenderVfb_ = 0;
-		displayFramebuf_ = 0;
-		prevDisplayFramebuf_ = 0;
-		prevPrevDisplayFramebuf_ = 0;
-
-		for (size_t i = 0; i < vfbs_.size(); ++i) {
-			VirtualFramebuffer *vfb = vfbs_[i];
-			INFO_LOG(FRAMEBUF, "Destroying FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-			DestroyFramebuf(vfb);
-		}
-		vfbs_.clear();
-
-		for (size_t i = 0; i < bvfbs_.size(); ++i) {
-			VirtualFramebuffer *vfb = bvfbs_[i];
-			DestroyFramebuf(vfb);
-		}
-		bvfbs_.clear();
+		FramebufferManagerCommon::DestroyAllFBOs();
 
 		for (auto &it : offscreenSurfaces_) {
 			it.second.surface->Release();
 		}
 		offscreenSurfaces_.clear();
-	}
-
-	void FramebufferManagerDX9::Resized() {
-		FramebufferManagerCommon::Resized();
-
-		if (UpdateSize()) {
-			DestroyAllFBOs();
-		}
-		presentation_->UpdatePostShader();
 	}
 
 	bool FramebufferManagerDX9::GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat fb_format, GPUDebugBuffer &buffer, int maxRes) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -117,6 +117,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		ShaderTranslationInit();
 
 		presentation_->SetLanguage(HLSL_DX9);
+		preferredPixelsFormat_ = Draw::DataFormat::B8G8R8A8_UNORM;
 	}
 
 	FramebufferManagerDX9::~FramebufferManagerDX9() {
@@ -157,54 +158,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	void FramebufferManagerDX9::SetDrawEngine(DrawEngineDX9 *td) {
 		drawEngineD3D9_ = td;
 		drawEngine_ = td;
-	}
-
-	Draw::Texture *FramebufferManagerDX9::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) {
-		auto generateTexture = [&](uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride) {
-			for (int y = 0; y < height; y++) {
-				const u16_le *src16 = (const u16_le *)srcPixels + srcStride * y;
-				const u32_le *src32 = (const u32_le *)srcPixels + srcStride * y;
-				u32 *dst = (u32 *)(data + byteStride * y);
-				switch (srcPixelFormat) {
-				case GE_FORMAT_565:
-					ConvertRGB565ToBGRA8888(dst, src16, width);
-					break;
-
-				case GE_FORMAT_5551:
-					ConvertRGBA5551ToBGRA8888(dst, src16, width);
-					break;
-
-				case GE_FORMAT_4444:
-					ConvertRGBA4444ToBGRA8888(dst, src16, width);
-					break;
-
-				case GE_FORMAT_8888:
-					ConvertRGBA8888ToBGRA8888(dst, src32, width);
-					break;
-
-				case GE_FORMAT_INVALID:
-					_dbg_assert_msg_(G3D, false, "Invalid pixelFormat passed to DrawPixels().");
-					break;
-				}
-			}
-		};
-
-		Draw::TextureDesc desc{
-			Draw::TextureType::LINEAR2D,
-			Draw::DataFormat::B8G8R8A8_UNORM,
-			width,
-			height,
-			1,
-			1,
-			false,
-			"DrawPixels",
-			{ (uint8_t *)srcPixels },
-			generateTexture,
-		};
-		Draw::Texture *tex = draw_->CreateTexture(desc);
-		if (!tex)
-			ERROR_LOG(G3D, "Failed to create drawpixels texture");
-		return tex;
 	}
 
 	void FramebufferManagerDX9::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -239,11 +239,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		// D3DXSaveTextureToFile("game:\\cc.png", D3DXIFF_PNG, drawPixelsTex_, NULL);
 	}
 
-	void FramebufferManagerDX9::SetViewport2D(int x, int y, int w, int h) {
-		D3DVIEWPORT9 vp{ (DWORD)x, (DWORD)y, (DWORD)w, (DWORD)h, 0.0f, 1.0f };
-		device_->SetViewport(&vp);
-	}
-
 	void FramebufferManagerDX9::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {
 		// TODO: StretchRect instead when possible?
 		float coord[20] = {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -19,7 +19,6 @@
 #include "ext/native/thin3d/thin3d.h"
 
 #include "Common/ColorConv.h"
-#include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -31,6 +31,8 @@
 
 #include "gfx/d3d9_state.h"
 #include "GPU/Common/FramebufferCommon.h"
+#include "GPU/Common/PresentationCommon.h"
+#include "GPU/Common/ShaderTranslation.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Directx9/FramebufferDX9.h"
 #include "GPU/Directx9/ShaderManagerDX9.h"
@@ -112,6 +114,10 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		nullTex_->LockRect(0, &rect, nullptr, D3DLOCK_DISCARD);
 		memset(rect.pBits, 0, 4);
 		nullTex_->UnlockRect(0);
+
+		ShaderTranslationInit();
+
+		presentation_->SetLanguage(HLSL_DX9);
 	}
 
 	FramebufferManagerDX9::~FramebufferManagerDX9() {
@@ -305,10 +311,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		device_->SetVertexDeclaration(pFramebufferVertexDecl);
 		device_->SetPixelShader(pFramebufferPixelShader);
 		device_->SetVertexShader(pFramebufferVertexShader);
-	}
-
-	void FramebufferManagerDX9::BindPostShader(const PostShaderUniforms &uniforms) {
-		Bind2DShader();
 	}
 
 	void FramebufferManagerDX9::ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old) {
@@ -702,8 +704,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 			it.second.surface->Release();
 		}
 		offscreenSurfaces_.clear();
-
-		SetNumExtraFBOs(0);
 	}
 
 	void FramebufferManagerDX9::Resized() {
@@ -712,6 +712,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		if (UpdateSize()) {
 			DestroyAllFBOs();
 		}
+		presentation_->UpdatePostShader();
 	}
 
 	bool FramebufferManagerDX9::GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat fb_format, GPUDebugBuffer &buffer, int maxRes) {

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -120,6 +120,8 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	FramebufferManagerDX9::~FramebufferManagerDX9() {
+		ShaderTranslationShutdown();
+
 		if (pFramebufferVertexShader) {
 			pFramebufferVertexShader->Release();
 			pFramebufferVertexShader = nullptr;

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -27,7 +27,6 @@
 
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
-#include "Core/Config.h"
 #include "ext/native/thin3d/thin3d.h"
 
 namespace DX9 {
@@ -97,7 +96,6 @@ private:
 
 	u8 *convBuf = nullptr;
 
-	int plainColorLoc_;
 	LPDIRECT3DPIXELSHADER9 stencilUploadPS_ = nullptr;
 	LPDIRECT3DVERTEXSHADER9 stencilUploadVS_ = nullptr;
 	bool stencilUploadFailed_ = false;

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -47,7 +47,6 @@ public:
 	void DestroyAllFBOs();
 
 	void EndFrame();
-	void Resized() override;
 	void DeviceLost();
 	void ReformatFramebufferFrom(VirtualFramebuffer *vfb, GEBufferFormat old) override;
 

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -69,7 +69,6 @@ public:
 
 protected:
 	void Bind2DShader() override;
-	void BindPostShader(const PostShaderUniforms &uniforms) override;
 	void DecimateFBOs() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -27,7 +27,6 @@
 
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
-#include "ext/native/thin3d/thin3d.h"
 
 namespace DX9 {
 
@@ -77,7 +76,7 @@ protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
+	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h) override;
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	bool GetRenderTargetFramebuffer(LPDIRECT3DSURFACE9 renderTarget, LPDIRECT3DSURFACE9 offscreen, int w, int h, GPUDebugBuffer &buffer);
@@ -85,16 +84,9 @@ private:
 	LPDIRECT3DDEVICE9 device_;
 	LPDIRECT3DDEVICE9 deviceEx_;
 
-	// Used by DrawPixels
-	LPDIRECT3DTEXTURE9 drawPixelsTex_ = nullptr;
-	int drawPixelsTexW_;
-	int drawPixelsTexH_;
-
 	LPDIRECT3DVERTEXSHADER9 pFramebufferVertexShader = nullptr;
 	LPDIRECT3DPIXELSHADER9 pFramebufferPixelShader = nullptr;
 	LPDIRECT3DVERTEXDECLARATION9 pFramebufferVertexDecl = nullptr;
-
-	u8 *convBuf = nullptr;
 
 	LPDIRECT3DPIXELSHADER9 stencilUploadPS_ = nullptr;
 	LPDIRECT3DVERTEXSHADER9 stencilUploadVS_ = nullptr;

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -70,7 +70,6 @@ public:
 protected:
 	void Bind2DShader() override;
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
-	void SetViewport2D(int x, int y, int w, int h) override;
 	void DecimateFBOs() override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -76,7 +76,6 @@ protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
-	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h) override;
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	bool GetRenderTargetFramebuffer(LPDIRECT3DSURFACE9 renderTarget, LPDIRECT3DSURFACE9 offscreen, int w, int h, GPUDebugBuffer &buffer);

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -396,11 +396,12 @@ void GPU_DX9::DoState(PointerWrap &p) {
 	// TODO: Some of these things may not be necessary.
 	// None of these are necessary when saving.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCacheDX9_->Clear(true);
+		textureCache_->Clear(true);
+		depalShaderCache_.Clear();
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerDX9_->DestroyAllFBOs();
+		framebufferManager_->DestroyAllFBOs();
 	}
 }
 

--- a/GPU/Directx9/StencilBufferDX9.cpp
+++ b/GPU/Directx9/StencilBufferDX9.cpp
@@ -202,6 +202,8 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, bool skipZer
 	float u1 = 1.0f;
 	float v1 = 1.0f;
 	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight, u1, v1);
+	if (!tex)
+		return false;
 
 	device_->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_STENCIL, D3DCOLOR_RGBA(0, 0, 0, 0), 0.0f, 0);
 

--- a/GPU/Directx9/StencilBufferDX9.cpp
+++ b/GPU/Directx9/StencilBufferDX9.cpp
@@ -201,7 +201,7 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, bool skipZer
 
 	float u1 = 1.0f;
 	float v1 = 1.0f;
-	MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight, u1, v1);
+	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight, u1, v1);
 
 	device_->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_STENCIL, D3DCOLOR_RGBA(0, 0, 0, 0), 0.0f, 0);
 
@@ -220,7 +220,7 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, bool skipZer
 	device_->SetPixelShader(stencilUploadPS_);
 	device_->SetVertexShader(stencilUploadVS_);
 
-	device_->SetTexture(0, drawPixelsTex_);
+	draw_->BindTextures(0, 1, &tex);
 
 	shaderManagerDX9_->DirtyLastShader();
 	textureCacheDX9_->ForgetLastTexture();
@@ -248,6 +248,8 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, bool skipZer
 			ERROR_LOG_REPORT(G3D, "Failed to draw stencil bit %x: %08x", i, hr);
 		}
 	}
+
+	tex->Release();
 	dxstate.stencilMask.set(0xFF);
 	dxstate.viewport.restore();
 	RebindFramebuffer();

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -166,56 +166,6 @@ FramebufferManagerGLES::~FramebufferManagerGLES() {
 	delete [] convBuf_;
 }
 
-Draw::Texture *FramebufferManagerGLES::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) {
-	// TODO: We can just change the texture format and flip some bits around instead of this.
-	// Could share code with the texture cache perhaps.
-	auto generateTexture = [&](uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride) {
-		for (int y = 0; y < height; y++) {
-			const u16_le *src16 = (const u16_le *)srcPixels + srcStride * y;
-			const u32_le *src32 = (const u32_le *)srcPixels + srcStride * y;
-			u32 *dst = (u32 *)(data + byteStride * y);
-			switch (srcPixelFormat) {
-			case GE_FORMAT_565:
-				ConvertRGBA565ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_5551:
-				ConvertRGBA5551ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_4444:
-				ConvertRGBA4444ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_8888:
-				memcpy(dst, src32, 4 * width);
-				break;
-
-			case GE_FORMAT_INVALID:
-				_dbg_assert_msg_(G3D, false, "Invalid pixelFormat passed to DrawPixels().");
-				break;
-			}
-		}
-	};
-
-	Draw::TextureDesc desc{
-		Draw::TextureType::LINEAR2D,
-		Draw::DataFormat::R8G8B8A8_UNORM,
-		width,
-		height,
-		1,
-		1,
-		false,
-		"DrawPixels",
-		{ (uint8_t *)srcPixels },
-		generateTexture,
-	};
-	Draw::Texture *tex = draw_->CreateTexture(desc);
-	if (!tex)
-		ERROR_LOG(G3D, "Failed to create drawpixels texture");
-	return tex;
-}
-
 // x, y, w, h are relative coordinates against destW/destH, which is not very intuitive.
 // TODO: This could totally use fbo_blit in many cases.
 void FramebufferManagerGLES::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -23,13 +23,7 @@
 #include "gfx/gl_debug_log.h"
 #include "gfx_es2/glsl_program.h"
 #include "thin3d/thin3d.h"
-
-#include "base/timeutil.h"
-#include "file/vfs.h"
-#include "math/lin/matrix4x4.h"
-
 #include "Common/ColorConv.h"
-#include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -38,9 +32,7 @@
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/FramebufferCommon.h"
-#include "GPU/Common/PostShader.h"
 #include "GPU/Common/PresentationCommon.h"
-#include "GPU/Common/ShaderTranslation.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Debugger/Stepping.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
@@ -158,11 +150,6 @@ void FramebufferManagerGLES::DestroyDeviceObjects() {
 		render_->DeleteProgram(draw2dprogram_);
 		draw2dprogram_ = nullptr;
 	}
-	// Will usually be clear already.
-	for (auto iter : postShaderModules_) {
-		render_->DeleteShader(iter);
-	}
-	postShaderModules_.clear();
 	if (drawPixelsTex_) {
 		render_->DeleteTexture(drawPixelsTex_);
 		drawPixelsTex_ = 0;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -449,41 +449,10 @@ void FramebufferManagerGLES::DeviceRestore(Draw::DrawContext *draw) {
 	CreateDeviceObjects();
 }
 
-void FramebufferManagerGLES::DestroyAllFBOs() {
-	currentRenderVfb_ = 0;
-	displayFramebuf_ = 0;
-	prevDisplayFramebuf_ = 0;
-	prevPrevDisplayFramebuf_ = 0;
-
-	for (size_t i = 0; i < vfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = vfbs_[i];
-		INFO_LOG(FRAMEBUF, "Destroying FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-		DestroyFramebuf(vfb);
-	}
-	vfbs_.clear();
-
-	for (size_t i = 0; i < bvfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = bvfbs_[i];
-		DestroyFramebuf(vfb);
-	}
-	bvfbs_.clear();
-
-	for (auto &tempFB : tempFBOs_) {
-		tempFB.second.fbo->Release();
-	}
-	tempFBOs_.clear();
-}
-
 void FramebufferManagerGLES::Resized() {
 	FramebufferManagerCommon::Resized();
 
 	render_->Resize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
-	if (UpdateSize()) {
-		DestroyAllFBOs();
-	}
-
-	// Might have a new post shader - let's compile it.
-	presentation_->UpdatePostShader();
 
 	// render_->SetLineWidth(renderWidth_ / 480.0f);
 }

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -22,7 +22,6 @@
 // Also provides facilities for drawing and later converting raw
 // pixel data.
 
-#include "Core/Config.h"
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferCommon.h"
 #include "thin3d/GLRenderManager.h"
@@ -91,12 +90,10 @@ private:
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
 	GLRProgram *draw2dprogram_ = nullptr;
-	std::vector<GLRShader *> postShaderModules_;
 
 	GLRProgram *stencilUploadProgram_ = nullptr;
 	int u_stencilUploadTex = -1;
 	int u_stencilValue = -1;
-	int u_postShaderTex = -1;
 
 	GLRProgram *depthDownloadProgram_ = nullptr;
 	int u_depthDownloadTex = -1;
@@ -106,12 +103,6 @@ private:
 	
 	// Cached uniform locs
 	int u_draw2d_tex = -1;
-
-	int plainColorLoc_ = -1;
-	int videoLoc_ = -1;
-	int timeLoc_ = -1;
-	int pixelDeltaLoc_ = -1;
-	int deltaLoc_ = -1;
 
 	TextureCacheGLES *textureCacheGL_ = nullptr;
 	ShaderManagerGLES *shaderManagerGL_ = nullptr;

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -73,7 +73,6 @@ private:
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
 
-	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void Bind2DShader() override;
 	void CompileDraw2DProgram();
 

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -64,8 +64,6 @@ public:
 	void DeviceRestore(Draw::DrawContext *draw);
 
 protected:
-	void SetViewport2D(int x, int y, int w, int h) override;
-
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -76,10 +76,7 @@ private:
 
 	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void Bind2DShader() override;
-	void BindPostShader(const PostShaderUniforms &uniforms) override;
-	void ShowPostShaderError(const std::string &errorMessage);
 	void CompileDraw2DProgram();
-	void CompilePostShader();
 
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 
@@ -94,7 +91,6 @@ private:
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
 	GLRProgram *draw2dprogram_ = nullptr;
-	GLRProgram *postShaderProgram_ = nullptr;
 	std::vector<GLRShader *> postShaderModules_;
 
 	GLRProgram *stencilUploadProgram_ = nullptr;

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -43,8 +43,6 @@ public:
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) override;
 
-	void DestroyAllFBOs();
-
 	virtual void Init() override;
 	void EndFrame();
 	void Resized() override;

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -73,7 +73,7 @@ private:
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
 
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
+	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 	void Bind2DShader() override;
 	void CompileDraw2DProgram();
 
@@ -81,14 +81,9 @@ private:
 
 	GLRenderManager *render_;
 
-	// Used by DrawPixels
-	GLRTexture *drawPixelsTex_ = nullptr;
-	GEBufferFormat drawPixelsTexFormat_ = GE_FORMAT_INVALID;
-	int drawPixelsTexW_ = 0;
-	int drawPixelsTexH_ = 0;
-
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
+
 	GLRProgram *draw2dprogram_ = nullptr;
 
 	GLRProgram *stencilUploadProgram_ = nullptr;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -342,9 +342,7 @@ void GPU_GLES::DeviceRestore() {
 
 void GPU_GLES::Reinitialize() {
 	GPUCommon::Reinitialize();
-	textureCacheGL_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManagerGL_->DestroyAllFBOs();
 }
 
 void GPU_GLES::InitClear() {
@@ -510,11 +508,12 @@ void GPU_GLES::DoState(PointerWrap &p) {
 	// None of these are necessary when saving.
 	// In Freeze-Frame mode, we don't want to do any of this.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCacheGL_->Clear(true);
+		textureCache_->Clear(true);
+		depalShaderCache_.Clear();
 		drawEngine_.ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerGL_->DestroyAllFBOs();
+		framebufferManager_->DestroyAllFBOs();
 	}
 }
 

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -177,8 +177,11 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 
 	float u1 = 1.0f;
 	float v1 = 1.0f;
-	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height, u1, v1);
 	textureCacheGL_->ForgetLastTexture();
+	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height, u1, v1);
+	if (!tex)
+		return false;
+
 	draw_->BindTextures(TEX_SLOT_PSP_TEXTURE, 1, &tex);
 
 	// We must bind the program after starting the render pass, and set the color mask after clearing.

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -177,8 +177,9 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 
 	float u1 = 1.0f;
 	float v1 = 1.0f;
-	MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height, u1, v1);
+	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height, u1, v1);
 	textureCacheGL_->ForgetLastTexture();
+	draw_->BindTextures(TEX_SLOT_PSP_TEXTURE, 1, &tex);
 
 	// We must bind the program after starting the render pass, and set the color mask after clearing.
 	render_->SetScissor({ 0, 0, w, h });
@@ -211,6 +212,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, bool skipZe
 		draw_->BlitFramebuffer(blitFBO, 0, 0, w, h, dstBuffer->fbo, 0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight, Draw::FB_STENCIL_BIT, Draw::FB_BLIT_NEAREST);
 	}
 
+	tex->Release();
 	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_VIEWPORTSCISSOR_STATE);
 	RebindFramebuffer();
 	return true;

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -377,6 +377,7 @@
     <ClInclude Include="Common\GPUStateUtils.h" />
     <ClInclude Include="Common\IndexGenerator.h" />
     <ClInclude Include="Common\PostShader.h" />
+    <ClInclude Include="Common\PresentationCommon.h" />
     <ClInclude Include="Common\ShaderCommon.h" />
     <ClInclude Include="Common\ShaderId.h" />
     <ClInclude Include="Common\ShaderTranslation.h" />
@@ -529,6 +530,7 @@
     <ClCompile Include="Common\GPUStateUtils.cpp" />
     <ClCompile Include="Common\IndexGenerator.cpp" />
     <ClCompile Include="Common\PostShader.cpp" />
+    <ClCompile Include="Common\PresentationCommon.cpp" />
     <ClCompile Include="Common\ShaderCommon.cpp" />
     <ClCompile Include="Common\ShaderId.cpp" />
     <ClCompile Include="Common\ShaderTranslation.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -285,6 +285,9 @@
     <ClInclude Include="Software\RasterizerRectangle.h">
       <Filter>Software</Filter>
     </ClInclude>
+    <ClInclude Include="Common\PresentationCommon.h">
+      <Filter>Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -565,6 +568,9 @@
     </ClCompile>
     <ClCompile Include="Software\RasterizerRectangle.cpp">
       <Filter>Software</Filter>
+    </ClCompile>
+    <ClCompile Include="Common\PresentationCommon.cpp">
+      <Filter>Common</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -459,6 +459,11 @@ void GPUCommon::Reinitialize() {
 	busyTicks = 0;
 	timeSpentStepping_ = 0.0;
 	interruptsEnabled_ = true;
+
+	if (textureCache_)
+		textureCache_->Clear(true);
+	if (framebufferManager_)
+		framebufferManager_->DestroyAllFBOs();
 }
 
 void GPUCommon::UpdateVsyncInterval(bool force) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -303,10 +303,10 @@ protected:
 		}
 	}
 
-	FramebufferManagerCommon *framebufferManager_;
-	TextureCacheCommon *textureCache_;
-	DrawEngineCommon *drawEngineCommon_;
-	ShaderManagerCommon *shaderManager_;
+	FramebufferManagerCommon *framebufferManager_ = nullptr;
+	TextureCacheCommon *textureCache_ = nullptr;
+	DrawEngineCommon *drawEngineCommon_ = nullptr;
+	ShaderManagerCommon *shaderManager_ = nullptr;
 
 	GraphicsContext *gfxCtx_;
 	Draw::DrawContext *draw_;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1169,10 +1169,10 @@ void DrawTriangleSlice(
 	TriangleEdge e2;
 
 	if (byY) {
-		maxY = std::min(maxY, minY + h2 * 16 * 2);
+		maxY = std::min(maxY, minY + h2 * 16 * 2) - 1;
 		minY += h1 * 16 * 2;
 	} else {
-		maxX = std::min(maxX, minX + h2 * 16 * 2);
+		maxX = std::min(maxX, minX + h2 * 16 * 2) - 1;
 		minX += h1 * 16 * 2;
 	}
 
@@ -1187,7 +1187,7 @@ void DrawTriangleSlice(
 
 	Sampler::Funcs sampler = Sampler::GetFuncs();
 
-	for (pprime.y = minY; pprime.y < maxY; pprime.y += 32,
+	for (pprime.y = minY; pprime.y <= maxY; pprime.y += 32,
 										w0_base = e0.StepY(w0_base),
 										w1_base = e1.StepY(w1_base),
 										w2_base = e2.StepY(w2_base)) {
@@ -1197,7 +1197,7 @@ void DrawTriangleSlice(
 
 		// TODO: Maybe we can clip the edges instead?
 		int scissorYPlus1 = pprime.y + 16 > maxY ? -1 : 0;
-		Vec4<int> scissor_mask = Vec4<int>(0, maxX - minX - 1, scissorYPlus1, (maxX - minX - 1) | scissorYPlus1);
+		Vec4<int> scissor_mask = Vec4<int>(0, maxX - minX, scissorYPlus1, (maxX - minX) | scissorYPlus1);
 		Vec4<int> scissor_step = Vec4<int>(0, -32, 0, -32);
 
 		pprime.x = minX;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -218,10 +218,10 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 			desc.height = srcheight;
 			desc.initData.push_back(data);
 		}
-		u0 = 64.5f / 512.0f;
-		u1 = 447.5f / 512.0f;
-		v1 = 16.0f / 272.0f;
-		v0 = 240.0f / 272.0f;
+		u0 = 64.5f / (float)desc.width;
+		u1 = 447.5f / (float)desc.width;
+		v1 = 16.0f / (float)desc.height;
+		v0 = 240.0f / (float)desc.height;
 	} else if (!Memory::IsValidAddress(displayFramebuf_) || srcwidth == 0 || srcheight == 0) {
 		hasImage = false;
 		u1 = 1.0f;
@@ -234,7 +234,6 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 	} else if (displayFormat_ == GE_FORMAT_5551) {
 		u8 *data = Memory::GetPointer(displayFramebuf_);
 		bool fillDesc = true;
-		desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
 		if (draw_->GetDataFormatSupport(Draw::DataFormat::A1B5G5R5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
 			// The perfect one.
 			desc.format = Draw::DataFormat::A1B5G5R5_UNORM_PACK16;
@@ -244,6 +243,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 			outputFlags |= OutputFlags::RB_SWIZZLE;
 		} else {
 			ConvertTextureDescFrom16(desc, srcwidth, srcheight);
+			u1 = 1.0f;
 			fillDesc = false;
 		}
 		if (fillDesc) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -145,7 +145,7 @@ void SoftGPU::ConvertTextureDescFrom16(Draw::TextureDesc &desc, int srcwidth, in
 
 		switch (displayFormat_) {
 		case GE_FORMAT_565:
-			ConvertRGBA565ToRGBA8888(buf_line, fb_line, srcwidth);
+			ConvertRGB565ToRGBA8888(buf_line, fb_line, srcwidth);
 			break;
 
 		case GE_FORMAT_5551:

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -270,7 +270,6 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		outputFlags |= OutputFlags::BACKBUFFER_FLIPPED;
 	}
 
-	// TODO, also deal with RB swizzle.
 	PostShaderUniforms uniforms{};
 	presentation_->CalculatePostShaderUniforms(desc.width, desc.height, false, &uniforms);
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -238,7 +238,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 
 	presentation_->UpdateSize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 	presentation_->SourceTexture(fbTex);
-	presentation_->CopyToOutput(outputFlags, ROTATION_LOCKED_HORIZONTAL, u0, v0, u1, v1);
+	presentation_->CopyToOutput(outputFlags, g_Config.iInternalScreenRotation, u0, v0, u1, v1);
 }
 
 void SoftGPU::CopyDisplayToOutput(bool reallyDirty) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -197,6 +197,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 	bool hasImage = true;
 
 	OutputFlags outputFlags = g_Config.iBufFilter == SCALE_NEAREST ? OutputFlags::NEAREST : OutputFlags::LINEAR;
+	bool hasPostShader = presentation_->HasPostShader();
 
 	if (PSP_CoreParameter().compat.flags().DarkStalkersPresentHack && displayFormat_ == GE_FORMAT_5551 && g_DarkStalkerStretch) {
 		u8 *data = Memory::GetPointer(0x04088000);
@@ -204,7 +205,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		if (draw_->GetDataFormatSupport(Draw::DataFormat::A1B5G5R5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
 			// The perfect one.
 			desc.format = Draw::DataFormat::A1B5G5R5_UNORM_PACK16;
-		} else if (draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
+		} else if (!hasPostShader && (draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16) & Draw::FMT_TEXTURE)) {
 			// RB swapped, compensate with a shader.
 			desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
 			outputFlags |= OutputFlags::RB_SWIZZLE;
@@ -237,7 +238,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		if (draw_->GetDataFormatSupport(Draw::DataFormat::A1B5G5R5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
 			// The perfect one.
 			desc.format = Draw::DataFormat::A1B5G5R5_UNORM_PACK16;
-		} else if (draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
+		} else if (!hasPostShader && (draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16) & Draw::FMT_TEXTURE)) {
 			// RB swapped, compensate with a shader.
 			desc.format = Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
 			outputFlags |= OutputFlags::RB_SWIZZLE;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -236,9 +236,12 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		std::swap(v0, v1);
 	}
 
-	presentation_->UpdateSize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
+	// TODO, also deal with RB swizzle.
+	PostShaderUniforms uniforms{};
+
+	presentation_->UpdateSize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 	presentation_->SourceTexture(fbTex);
-	presentation_->CopyToOutput(outputFlags, g_Config.iInternalScreenRotation, u0, v0, u1, v1);
+	presentation_->CopyToOutput(outputFlags, g_Config.iInternalScreenRotation, u0, v0, u1, v1, uniforms);
 }
 
 void SoftGPU::CopyDisplayToOutput(bool reallyDirty) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -232,39 +232,13 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 
 	fbTex = draw_->CreateTexture(desc);
 
-	float dstwidth = (float)PSP_CoreParameter().pixelWidth;
-	float dstheight = (float)PSP_CoreParameter().pixelHeight;
-
-	float x, y, w, h;
-	CenterDisplayOutputRect(&x, &y, &w, &h, 480.0f, 272.0f, dstwidth, dstheight, ROTATION_LOCKED_HORIZONTAL);
-
-	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
-		x += 0.5f;
-		y += 0.5f;
-	}
-
-	x /= 0.5f * dstwidth;
-	y /= 0.5f * dstheight;
-	w /= 0.5f * dstwidth;
-	h /= 0.5f * dstheight;
-	float x2 = x + w;
-	float y2 = y + h;
-	x -= 1.0f;
-	y -= 1.0f;
-	x2 -= 1.0f;
-	y2 -= 1.0f;
-
 	if (GetGPUBackend() == GPUBackend::VULKAN) {
 		std::swap(v0, v1);
 	}
 
-	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
-	Draw::Viewport viewport = { 0.0f, 0.0f, dstwidth, dstheight, 0.0f, 1.0f };
-	draw_->SetViewports(1, &viewport);
-	draw_->SetScissorRect(0, 0, dstwidth, dstheight);
-
-	draw_->BindTexture(0, fbTex);
-	presentation_->CopyToOutput(outputFlags, x, y, x2, y2, u0, v0, u1, v1);
+	presentation_->UpdateSize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
+	presentation_->SourceTexture(fbTex);
+	presentation_->CopyToOutput(outputFlags, ROTATION_LOCKED_HORIZONTAL, u0, v0, u1, v1);
 }
 
 void SoftGPU::CopyDisplayToOutput(bool reallyDirty) {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -50,6 +50,7 @@ struct FormatBuffer {
 	}
 };
 
+class PresentationCommon;
 class SoftwareDrawEngine;
 
 class SoftGPU : public GPUCommon {
@@ -109,17 +110,11 @@ private:
 	u32 displayStride_;
 	GEBufferFormat displayFormat_;
 
+	PresentationCommon *presentation_ = nullptr;
 	SoftwareDrawEngine *drawEngine_ = nullptr;
 
-	Draw::Texture *fbTex;
-	Draw::Pipeline *texColor;
-	Draw::Pipeline *texColorRBSwizzle;
+	Draw::Texture *fbTex = nullptr;
 	std::vector<u32> fbTexBuffer_;
-
-	Draw::SamplerState *samplerNearest = nullptr;
-	Draw::SamplerState *samplerLinear = nullptr;
-	Draw::Buffer *vdata = nullptr;
-	Draw::Buffer *idata = nullptr;
 };
 
 // TODO: These shouldn't be global.

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -77,7 +77,7 @@ public:
 	void DeviceLost() override;
 	void DeviceRestore() override;
 
-	void Resized() override {}
+	void Resized() override;
 	void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) override {
 		primaryInfo = "Software";
 		fullInfo = "Software";

--- a/GPU/Vulkan/DepalettizeShaderVulkan.cpp
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.cpp
@@ -147,7 +147,7 @@ VulkanTexture *DepalShaderCacheVulkan::GetClutTexture(GEPaletteFormat clutFormat
 			ConvertRGBA5551ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
 			break;
 		case GE_CMODE_16BIT_BGR5650:
-			ConvertRGBA565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
+			ConvertRGB565ToRGBA8888(expanded, (const uint16_t *)rawClut, texturePixels);
 			break;
 		default:
 			break;

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -270,18 +270,6 @@ void FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFor
 	overrideImageView_ = drawPixelsTex_->GetImageView();
 }
 
-void FramebufferManagerVulkan::SetViewport2D(int x, int y, int w, int h) {
-	Draw::Viewport vp;
-	vp.MinDepth = 0.0;
-	vp.MaxDepth = 1.0;
-	vp.TopLeftX = (float)x;
-	vp.TopLeftY = (float)y;
-	vp.Width = (float)w;
-	vp.Height = (float)h;
-	// Since we're about to override it.
-	draw_->SetViewports(1, &vp);
-}
-
 void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {
 	float texCoords[8] = {
 		u0,v0,
@@ -554,6 +542,7 @@ void FramebufferManagerVulkan::EndFrame() {
 void FramebufferManagerVulkan::DeviceLost() {
 	DestroyAllFBOs();
 	DestroyDeviceObjects();
+	presentation_->DeviceLost();
 
 	if (allocator_) {
 		allocator_->Destroy();
@@ -570,6 +559,7 @@ void FramebufferManagerVulkan::DeviceLost() {
 void FramebufferManagerVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw) {
 	vulkan_ = vulkan;
 	draw_ = draw;
+	presentation_->DeviceRestore(draw);
 
 	_assert_(!allocator_);
 
@@ -641,6 +631,7 @@ void FramebufferManagerVulkan::CompilePostShader() {
 	std::string fsSource;
 	if (shaderInfo) {
 		postShaderAtOutputResolution_ = shaderInfo->outputResolution;
+		presentation_->UpdateShaderInfo(shaderInfo);
 		size_t sz;
 		char *vs = (char *)VFSReadFile(shaderInfo->vertexShaderFile.c_str(), &sz);
 		if (!vs)

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -448,39 +448,3 @@ void FramebufferManagerVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawCo
 
 	InitDeviceObjects();
 }
-
-void FramebufferManagerVulkan::DestroyAllFBOs() {
-	currentRenderVfb_ = 0;
-	displayFramebuf_ = 0;
-	prevDisplayFramebuf_ = 0;
-	prevPrevDisplayFramebuf_ = 0;
-
-	for (size_t i = 0; i < vfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = vfbs_[i];
-		INFO_LOG(FRAMEBUF, "Destroying FBO for %08x : %i x %i x %i", vfb->fb_address, vfb->width, vfb->height, vfb->format);
-		DestroyFramebuf(vfb);
-	}
-	vfbs_.clear();
-
-	for (size_t i = 0; i < bvfbs_.size(); ++i) {
-		VirtualFramebuffer *vfb = bvfbs_[i];
-		DestroyFramebuf(vfb);
-	}
-	bvfbs_.clear();
-
-	for (auto &tempFB : tempFBOs_) {
-		tempFB.second.fbo->Release();
-	}
-	tempFBOs_.clear();
-}
-
-void FramebufferManagerVulkan::Resized() {
-	FramebufferManagerCommon::Resized();
-
-	if (UpdateSize()) {
-		DestroyAllFBOs();
-	}
-
-	// Might have a new post shader - let's compile it.
-	presentation_->UpdatePostShader();
-}

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -176,58 +176,6 @@ void FramebufferManagerVulkan::Init() {
 	Resized();
 }
 
-Draw::Texture *FramebufferManagerVulkan::MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) {
-	auto generateTexture = [&](uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride) {
-		for (int y = 0; y < height; y++) {
-			const u16_le *src16 = (const u16_le *)srcPixels + srcStride * y;
-			const u32_le *src32 = (const u32_le *)srcPixels + srcStride * y;
-			u32 *dst = (u32 *)(data + byteStride * y);
-			switch (srcPixelFormat) {
-			case GE_FORMAT_565:
-				ConvertRGBA565ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_5551:
-				ConvertRGBA5551ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_4444:
-				ConvertRGBA4444ToRGBA8888(dst, src16, width);
-				break;
-
-			case GE_FORMAT_8888:
-				memcpy(dst, src32, 4 * width);
-				break;
-
-			case GE_FORMAT_INVALID:
-				_dbg_assert_msg_(G3D, false, "Invalid pixelFormat passed to DrawPixels().");
-				break;
-			}
-		}
-	};
-
-	// Hot Shot Golf (#12355) does tons of these in a frame in some situations! So actually,
-	// we do use an allocator. In fact, I've now banned allocator-less textures.
-
-	Draw::TextureDesc desc{
-		Draw::TextureType::LINEAR2D,
-		Draw::DataFormat::R8G8B8A8_UNORM,
-		width,
-		height,
-		1,
-		1,
-		false,
-		"DrawPixels",
-		{ (uint8_t *)srcPixels },
-		generateTexture,
-	};
-	// TODO: Use allocator_ somehow?
-	Draw::Texture *tex = draw_->CreateTexture(desc);
-	if (!tex)
-		ERROR_LOG(G3D, "Failed to create drawpixels texture");
-	return tex;
-}
-
 void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {
 	float texCoords[8] = {
 		u0,v0,

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -21,10 +21,8 @@
 #include "profiler/profiler.h"
 
 #include "base/display.h"
-#include "base/timeutil.h"
 #include "math/lin/matrix4x4.h"
 #include "math/dataconv.h"
-#include "ext/native/file/vfs.h"
 #include "ext/native/thin3d/thin3d.h"
 
 #include "Common/Vulkan/VulkanContext.h"
@@ -32,7 +30,6 @@
 #include "Common/Vulkan/VulkanImage.h"
 #include "thin3d/VulkanRenderManager.h"
 #include "Common/ColorConv.h"
-#include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -40,17 +37,12 @@
 #include "Core/Reporting.h"
 #include "Core/HLE/sceDisplay.h"
 #include "GPU/ge_constants.h"
+#include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
-#include "GPU/Common/ShaderTranslation.h"
-#include "GPU/Common/PostShader.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Common/FramebufferCommon.h"
 #include "GPU/Debugger/Stepping.h"
-
-#include "GPU/GPUInterface.h"
-#include "GPU/GPUState.h"
-#include "Common/Vulkan/VulkanImage.h"
 #include "GPU/Vulkan/FramebufferVulkan.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Vulkan/TextureCacheVulkan.h"

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -46,14 +46,11 @@ public:
 	// x,y,w,h are relative to destW, destH which fill out the target completely.
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) override;
 
-	void DestroyAllFBOs();
-
 	virtual void Init() override;
 
 	void BeginFrameVulkan();  // there's a BeginFrame in the base class, which this calls
 	void EndFrame();
 
-	void Resized() override;
 	void DeviceLost();
 	void DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw);
 	int GetLineWidth();

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -70,9 +70,7 @@ public:
 	void NotifyClear(bool clearColor, bool clearAlpha, bool clearDepth, uint32_t color, float depth);
 
 protected:
-	void CompilePostShader();
 	void Bind2DShader() override;
-	void BindPostShader(const PostShaderUniforms &uniforms) override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
@@ -120,12 +118,6 @@ private:
 
 
 	VkPipeline cur2DPipeline_ = VK_NULL_HANDLE;
-
-	// Postprocessing
-	VkShaderModule postVs_ = VK_NULL_HANDLE;
-	VkShaderModule postFs_ = VK_NULL_HANDLE;
-	VkPipeline pipelinePostShader_ = VK_NULL_HANDLE;
-	PostShaderUniforms postShaderUniforms_;
 
 	VkSampler linearSampler_;
 	VkSampler nearestSampler_;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -104,9 +104,6 @@ private:
 		MAX_COMMAND_BUFFERS = 32,
 	};
 
-	// This gets copied to the current frame's push buffer as needed.
-	PostShaderUniforms postUniforms_;
-
 	VkPipelineCache pipelineCache2D_;
 
 	// Basic shaders
@@ -115,7 +112,6 @@ private:
 
 	VkShaderModule stencilVs_ = VK_NULL_HANDLE;
 	VkShaderModule stencilFs_ = VK_NULL_HANDLE;
-
 
 	VkPipeline cur2DPipeline_ = VK_NULL_HANDLE;
 

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -18,9 +18,10 @@
 #pragma once
 
 #include "Common/Vulkan/VulkanLoader.h"
-#include "GPU/Common/FramebufferCommon.h"
 #include "GPU/GPUInterface.h"
+#include "GPU/Common/FramebufferCommon.h"
 #include "GPU/Common/GPUDebugInterface.h"
+#include "GPU/Common/PresentationCommon.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 #include "GPU/Vulkan/DepalettizeShaderVulkan.h"
 
@@ -72,7 +73,6 @@ protected:
 	void CompilePostShader();
 	void Bind2DShader() override;
 	void BindPostShader(const PostShaderUniforms &uniforms) override;
-	void SetViewport2D(int x, int y, int w, int h) override;
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -79,7 +79,7 @@ protected:
 
 private:
 	// The returned texture does not need to be free'd, might be returned from a pool (currently single entry)
-	void MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
+	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
 
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
@@ -87,12 +87,6 @@ private:
 	VulkanContext *vulkan_;
 
 	// Used to keep track of command buffers here but have moved all that into Thin3D.
-
-	// Used by DrawPixels
-	VulkanTexture *drawPixelsTex_ = nullptr;
-	GEBufferFormat drawPixelsTexFormat_ = GE_FORMAT_INVALID;
-	u8 *convBuf_ = nullptr;
-	u32 convBufSize_ = 0;
 
 	TextureCacheVulkan *textureCacheVulkan_ = nullptr;
 	ShaderManagerVulkan *shaderManagerVulkan_ = nullptr;
@@ -117,9 +111,6 @@ private:
 
 	VkSampler linearSampler_;
 	VkSampler nearestSampler_;
-
-	// hack!
-	VkImageView overrideImageView_ = VK_NULL_HANDLE;
 
 	// Simple 2D drawing engine.
 	Vulkan2D *vulkan2D_;

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -78,9 +78,6 @@ protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:
-	// The returned texture does not need to be free'd, might be returned from a pool (currently single entry)
-	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height, float &u1, float &v1) override;
-
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -413,9 +413,7 @@ void GPU_Vulkan::BuildReportingInfo() {
 
 void GPU_Vulkan::Reinitialize() {
 	GPUCommon::Reinitialize();
-	textureCacheVulkan_->Clear(true);
 	depalShaderCache_.Clear();
-	framebufferManagerVulkan_->DestroyAllFBOs();
 }
 
 void GPU_Vulkan::InitClear() {
@@ -613,11 +611,11 @@ void GPU_Vulkan::DoState(PointerWrap &p) {
 	// None of these are necessary when saving.
 	// In Freeze-Frame mode, we don't want to do any of this.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCacheVulkan_->Clear(true);
+		textureCache_->Clear(true);
 		depalShaderCache_.Clear();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManagerVulkan_->DestroyAllFBOs();
+		framebufferManager_->DestroyAllFBOs();
 	}
 }
 

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -164,6 +164,9 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, bool skip
 	float u1 = 1.0f;
 	float v1 = 1.0f;
 	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->bufferWidth, dstBuffer->bufferHeight, u1, v1);
+	if (!tex)
+		return false;
+
 	if (dstBuffer->fbo) {
 		draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR });
 	} else {

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -259,7 +259,7 @@ void DisplayLayoutScreen::CreateViews() {
 	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, vertPreviewPadding - vertBoundariesHeight, NONE, NONE)));
 	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, NONE, NONE, vertPreviewPadding - vertBoundariesHeight)));
 
-	bool displayRotEnable = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+	bool displayRotEnable = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) || g_Config.bSoftwareRendering;
 	bRotated_ = false;
 	if (displayRotEnable && (g_Config.iInternalScreenRotation == ROTATION_LOCKED_VERTICAL || g_Config.iInternalScreenRotation == ROTATION_LOCKED_VERTICAL180)) {
 		bRotated_ = true;
@@ -355,7 +355,7 @@ void DisplayLayoutScreen::CreateViews() {
 	static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
 	auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, previewWidth - 200.0f, 10, NONE, bounds.h - 64 - 10));
 	rotation->SetEnabledFunc([] {
-		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE || g_Config.bSoftwareRendering;
 	});
 	root_->Add(rotation);
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -287,7 +287,7 @@ void GameSettingsScreen::CreateViews() {
 	postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), &PostShaderTranslateName));
 	postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
 	postProcChoice_->SetEnabledFunc([] {
-		return !g_Config.bSoftwareRendering && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	});
 
 #if !defined(MOBILE_DEVICE)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -161,6 +161,7 @@ void GameSettingsScreen::CreateViews() {
 	auto ms = GetI18NCategory("MainSettings");
 	auto dev = GetI18NCategory("Developer");
 	auto ri = GetI18NCategory("RemoteISO");
+	auto ps = GetI18NCategory("PostShaders");
 
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 
@@ -283,15 +284,11 @@ void GameSettingsScreen::CreateViews() {
 	altSpeed2->SetNegativeDisable(gr->T("Disabled"));
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Features")));
-	// Hide postprocess option on unsupported backends to avoid confusion.
-	if (GetGPUBackend() != GPUBackend::DIRECT3D9) {
-		auto ps = GetI18NCategory("PostShaders");
-		postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), &PostShaderTranslateName));
-		postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
-		postProcChoice_->SetEnabledFunc([] {
-			return !g_Config.bSoftwareRendering && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
-		});
-	}
+	postProcChoice_ = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sPostShaderName, gr->T("Postprocessing Shader"), &PostShaderTranslateName));
+	postProcChoice_->OnClick.Handle(this, &GameSettingsScreen::OnPostProcShader);
+	postProcChoice_->SetEnabledFunc([] {
+		return !g_Config.bSoftwareRendering && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
+	});
 
 #if !defined(MOBILE_DEVICE)
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gr->T("FullScreen", "Full Screen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -461,14 +461,13 @@ void GameSettingsScreen::CreateViews() {
 
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 	graphicsSettings->Add(new ItemHeader(gr->T("Cardboard VR Settings", "Cardboard VR Settings")));
-	CheckBox *cardboardMode = graphicsSettings->Add(new CheckBox(&g_Config.bEnableCardboardVR, gr->T("Enable Cardboard VR", "Enable Cardboard VR")));
-	cardboardMode->SetDisabledPtr(&g_Config.bSoftwareRendering);
-	PopupSliderChoice * cardboardScreenSize = graphicsSettings->Add(new PopupSliderChoice(&g_Config.iCardboardScreenSize, 30, 100, gr->T("Cardboard Screen Size", "Screen Size (in % of the viewport)"), 1, screenManager(), gr->T("% of viewport")));
-	cardboardScreenSize->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	graphicsSettings->Add(new CheckBox(&g_Config.bEnableCardboardVR, gr->T("Enable Cardboard VR", "Enable Cardboard VR")));
+	PopupSliderChoice *cardboardScreenSize = graphicsSettings->Add(new PopupSliderChoice(&g_Config.iCardboardScreenSize, 30, 100, gr->T("Cardboard Screen Size", "Screen Size (in % of the viewport)"), 1, screenManager(), gr->T("% of viewport")));
+	cardboardScreenSize->SetEnabledPtr(&g_Config.bEnableCardboardVR);
 	PopupSliderChoice *cardboardXShift = graphicsSettings->Add(new PopupSliderChoice(&g_Config.iCardboardXShift, -100, 100, gr->T("Cardboard Screen X Shift", "X Shift (in % of the void)"), 1, screenManager(), gr->T("% of the void")));
-	cardboardXShift->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	cardboardXShift->SetEnabledPtr(&g_Config.bEnableCardboardVR);
 	PopupSliderChoice *cardboardYShift = graphicsSettings->Add(new PopupSliderChoice(&g_Config.iCardboardYShift, -100, 100, gr->T("Cardboard Screen Y Shift", "Y Shift (in % of the void)"), 1, screenManager(), gr->T("% of the void")));
-	cardboardYShift->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	cardboardYShift->SetEnabledPtr(&g_Config.bEnableCardboardVR);
 #endif
 
 	std::vector<std::string> cameraList = Camera::getDeviceList();

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj
@@ -382,6 +382,7 @@
     <ClInclude Include="..\..\GPU\Common\DepalettizeShaderCommon.h" />
     <ClInclude Include="..\..\GPU\Common\DrawEngineCommon.h" />
     <ClInclude Include="..\..\GPU\Common\FramebufferCommon.h" />
+    <ClInclude Include="..\..\GPU\Common\PresentationCommon.h" />
     <ClInclude Include="..\..\GPU\Common\GPUDebugInterface.h" />
     <ClInclude Include="..\..\GPU\Common\GPUStateUtils.h" />
     <ClInclude Include="..\..\GPU\Common\IndexGenerator.h" />
@@ -440,6 +441,7 @@
     <ClCompile Include="..\..\GPU\Common\DepalettizeShaderCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\DrawEngineCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\FramebufferCommon.cpp" />
+    <ClCompile Include="..\..\GPU\Common\PresentationCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\GPUDebugInterface.cpp" />
     <ClCompile Include="..\..\GPU\Common\GPUStateUtils.cpp" />
     <ClCompile Include="..\..\GPU\Common\IndexGenerator.cpp" />

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="..\..\GPU\Common\DepalettizeShaderCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\DrawEngineCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\FramebufferCommon.cpp" />
+    <ClCompile Include="..\..\GPU\Common\PresentationCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\GPUDebugInterface.cpp" />
     <ClCompile Include="..\..\GPU\Common\GPUStateUtils.cpp" />
     <ClCompile Include="..\..\GPU\Common\IndexGenerator.cpp" />
@@ -62,6 +63,7 @@
     <ClInclude Include="..\..\GPU\Common\DepalettizeShaderCommon.h" />
     <ClInclude Include="..\..\GPU\Common\DrawEngineCommon.h" />
     <ClInclude Include="..\..\GPU\Common\FramebufferCommon.h" />
+    <ClInclude Include="..\..\GPU\Common\PresentationCommon.h" />
     <ClInclude Include="..\..\GPU\Common\GPUDebugInterface.h" />
     <ClInclude Include="..\..\GPU\Common\GPUStateUtils.h" />
     <ClInclude Include="..\..\GPU\Common\IndexGenerator.h" />

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -180,21 +180,16 @@ namespace MainWindow {
 		const char *translatedShaderName = nullptr;
 
 		availableShaders.clear();
-		if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
-			translatedShaderName = ps->T("Not available in Direct3D9 backend");
-			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | MF_GRAYED, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
-		} else {
-			for (auto i = info.begin(); i != info.end(); ++i) {
-				int checkedStatus = MF_UNCHECKED;
-				availableShaders.push_back(i->section);
-				if (g_Config.sPostShaderName == i->section) {
-					checkedStatus = MF_CHECKED;
-				}
-
-				translatedShaderName = ps->T(i->section.c_str(), i->name.c_str());
-
-				AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
+		for (auto i = info.begin(); i != info.end(); ++i) {
+			int checkedStatus = MF_UNCHECKED;
+			availableShaders.push_back(i->section);
+			if (g_Config.sPostShaderName == i->section) {
+				checkedStatus = MF_CHECKED;
 			}
+
+			translatedShaderName = ps->T(i->section.c_str(), i->name.c_str());
+
+			AppendMenu(shaderMenu, MF_STRING | MF_BYPOSITION | checkedStatus, item++, ConvertUTF8ToWString(translatedShaderName).c_str());
 		}
 
 		menuShaderInfo = info;

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -225,6 +225,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/GPU/GeDisasm.cpp \
   $(SRC)/GPU/Common/DepalettizeShaderCommon.cpp \
   $(SRC)/GPU/Common/FramebufferCommon.cpp \
+  $(SRC)/GPU/Common/PresentationCommon.cpp \
   $(SRC)/GPU/Common/GPUDebugInterface.cpp \
   $(SRC)/GPU/Common/IndexGenerator.cpp.arm \
   $(SRC)/GPU/Common/ShaderId.cpp.arm \

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -1091,7 +1091,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			if (c.draw.vbuffer) {
 				vkCmdBindVertexBuffers(cmd, 0, 1, &c.draw.vbuffer, &c.draw.voffset);
 			}
-			vkCmdDraw(cmd, c.draw.count, 1, 0, 0);
+			vkCmdDraw(cmd, c.draw.count, 1, c.draw.offset, 0);
 			break;
 
 		case VKRRenderCommand::CLEAR:

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -109,6 +109,7 @@ struct VkRenderData {
 			VkBuffer vbuffer;
 			VkDeviceSize voffset;
 			uint32_t count;
+			uint32_t offset;
 		} draw;
 		struct {
 			VkPipelineLayout pipelineLayout;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -177,10 +177,11 @@ public:
 
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask);
 
-	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count) {
+	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count, int offset = 0) {
 		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		VkRenderData data{ VKRRenderCommand::DRAW };
 		data.draw.count = count;
+		data.draw.offset = offset;
 		data.draw.pipelineLayout = layout;
 		data.draw.ds = descSet;
 		data.draw.vbuffer = vbuffer;

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -140,7 +140,7 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"#extension GL_ARB_shading_language_420pack : enable\n"
 	"layout(location = 0) in vec4 oColor0;\n"
 	"layout(location = 1) in vec2 oTexCoord0;\n"
-	"layout(location = 0) out vec4 fragColor0\n;"
+	"layout(location = 0) out vec4 fragColor0;\n"
 	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
 	"void main() { fragColor0 = texture(Sampler0, oTexCoord0) * oColor0; }\n"
 	}
@@ -220,7 +220,7 @@ static const std::vector<ShaderSource> fsCol = {
 	"#extension GL_ARB_separate_shader_objects : enable\n"
 	"#extension GL_ARB_shading_language_420pack : enable\n"
 	"layout(location = 0) in vec4 oColor0;\n"
-	"layout(location = 0) out vec4 fragColor0\n;"
+	"layout(location = 0) out vec4 fragColor0;\n"
 	"void main() { fragColor0 = oColor0; }\n"
 	}
 };

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -402,6 +402,9 @@ struct InputLayoutDesc {
 class InputLayout : public RefCountedObject { };
 
 enum class UniformType : int8_t {
+	FLOAT1,
+	FLOAT2,
+	FLOAT3,
 	FLOAT4,
 	MATRIX4X4,
 };

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -520,9 +520,9 @@ struct DeviceCaps {
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };
 
-// Use to write data directly to memory.  initData is the pointer passed in TextureDesc.
+// Use to write data directly to texture memory.  initData is the pointer passed in TextureDesc.
 // Important: only write to the provided pointer, don't read from it.
-typedef std::function<void(uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride)> TextureCallback;
+typedef std::function<bool(uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride)> TextureCallback;
 
 struct TextureDesc {
 	TextureType type;

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -580,7 +580,7 @@ public:
 	// On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
 	virtual Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) = 0;
 
-	virtual ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize) = 0;
+	virtual ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const std::string &tag = "thin3d") = 0;
 	virtual Pipeline *CreateGraphicsPipeline(const PipelineDesc &desc) = 0;
 
 	// Copies data from the CPU over into the buffer, at a specific offset. This does not change the size of the buffer and cannot write outside it.

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -8,8 +8,9 @@
 
 #include <cstdint>
 #include <cstddef>
-#include <vector>
+#include <functional>
 #include <string>
+#include <vector>
 
 #include "base/logging.h"
 #include "DataFormat.h"
@@ -519,6 +520,10 @@ struct DeviceCaps {
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };
 
+// Use to write data directly to memory.  initData is the pointer passed in TextureDesc.
+// Important: only write to the provided pointer, don't read from it.
+typedef std::function<void(uint8_t *data, const uint8_t *initData, uint32_t w, uint32_t h, uint32_t d, uint32_t byteStride, uint32_t sliceByteStride)> TextureCallback;
+
 struct TextureDesc {
 	TextureType type;
 	DataFormat format;
@@ -530,7 +535,8 @@ struct TextureDesc {
 	// Optional, for tracking memory usage.
 	std::string tag;
 	// Does not take ownership over pointed-to data.
-	std::vector<uint8_t *> initData;
+	std::vector<const uint8_t *> initData;
+	TextureCallback initDataCallback;
 };
 
 enum class RPAction {

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -817,7 +817,8 @@ ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLang
 
 	ID3DBlob *compiledCode = nullptr;
 	ID3DBlob *errorMsgs = nullptr;
-	HRESULT result = ptr_D3DCompile(data, dataSize, nullptr, nullptr, nullptr, "main", target, 0, 0, &compiledCode, &errorMsgs);
+	int flags = D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY;
+	HRESULT result = ptr_D3DCompile(data, dataSize, nullptr, nullptr, nullptr, "main", target, flags, 0, &compiledCode, &errorMsgs);
 	if (compiledCode) {
 		compiled = std::string((const char *)compiledCode->GetBufferPointer(), compiledCode->GetBufferSize());
 		compiledCode->Release();

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -1059,6 +1059,7 @@ void D3D11DrawContext::ApplyCurrentState() {
 	}
 	if (curPipeline_->dynamicUniforms) {
 		context_->VSSetConstantBuffers(0, 1, &curPipeline_->dynamicUniforms);
+		context_->PSSetConstantBuffers(0, 1, &curPipeline_->dynamicUniforms);
 	}
 }
 
@@ -1330,6 +1331,7 @@ void D3D11DrawContext::BeginFrame() {
 		context_->IASetIndexBuffer(nextIndexBuffer_, DXGI_FORMAT_R32_UINT, nextIndexBufferOffset_);
 		if (curPipeline_->dynamicUniforms) {
 			context_->VSSetConstantBuffers(0, 1, &curPipeline_->dynamicUniforms);
+			context_->PSSetConstantBuffers(0, 1, &curPipeline_->dynamicUniforms);
 		}
 	}
 }

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -60,7 +60,7 @@ public:
 	Buffer *CreateBuffer(size_t size, uint32_t usageFlags) override;
 	Pipeline *CreateGraphicsPipeline(const PipelineDesc &desc) override;
 	Texture *CreateTexture(const TextureDesc &desc) override;
-	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize) override;
+	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const std::string &tag) override;
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
@@ -757,6 +757,8 @@ Texture *D3D11DrawContext::CreateTexture(const TextureDesc &desc) {
 
 class D3D11ShaderModule : public ShaderModule {
 public:
+	D3D11ShaderModule(const std::string &tag) : tag_(tag) {
+	}
 	~D3D11ShaderModule() {
 		if (vs)
 			vs->Release();
@@ -769,13 +771,14 @@ public:
 
 	std::vector<uint8_t> byteCode_;
 	ShaderStage stage;
+	std::string tag_;
 
 	ID3D11VertexShader *vs = nullptr;
 	ID3D11PixelShader *ps = nullptr;
 	ID3D11GeometryShader *gs = nullptr;
 };
 
-ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize) {
+ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const std::string &tag) {
 	if (language != ShaderLanguage::HLSL_D3D11) {
 		ELOG("Unsupported shader language");
 		return nullptr;
@@ -832,7 +835,7 @@ ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLang
 	// OK, we can now proceed
 	data = (const uint8_t *)compiled.c_str();
 	dataSize = compiled.size();
-	D3D11ShaderModule *module = new D3D11ShaderModule();
+	D3D11ShaderModule *module = new D3D11ShaderModule(tag);
 	module->stage = stage;
 	module->byteCode_ = std::vector<uint8_t>(data, data + dataSize);
 	switch (stage) {

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -429,10 +429,11 @@ void D3D9Texture::SetImageData(int x, int y, int z, int width, int height, int d
 			tex_->LockRect(level, &rect, NULL, D3DLOCK_DISCARD);
 
 			if (callback) {
-				callback((uint8_t *)rect.pBits, data, width, height, depth, rect.Pitch, height * rect.Pitch);
-				// Now this is the source.  All conversions below support in-place.
-				data = (const uint8_t *)rect.pBits;
-				stride = rect.Pitch;
+				if (callback((uint8_t *)rect.pBits, data, width, height, depth, rect.Pitch, height * rect.Pitch)) {
+					// Now this is the source.  All conversions below support in-place.
+					data = (const uint8_t *)rect.pBits;
+					stride = rect.Pitch;
+				}
 			}
 
 			for (int i = 0; i < height; i++) {

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -252,7 +252,7 @@ private:
 
 class D3D9ShaderModule : public ShaderModule {
 public:
-	D3D9ShaderModule(ShaderStage stage) : stage_(stage), vshader_(nullptr), pshader_(nullptr) {}
+	D3D9ShaderModule(ShaderStage stage, const std::string &tag) : stage_(stage), tag_(tag) {}
 	~D3D9ShaderModule() {
 		if (vshader_)
 			vshader_->Release();
@@ -271,8 +271,9 @@ public:
 
 private:
 	ShaderStage stage_;
-	LPDIRECT3DVERTEXSHADER9 vshader_;
-	LPDIRECT3DPIXELSHADER9 pshader_;
+	LPDIRECT3DVERTEXSHADER9 vshader_ = nullptr;
+	LPDIRECT3DPIXELSHADER9 pshader_ = nullptr;
+	std::string tag_;
 };
 
 class D3D9Pipeline : public Pipeline {
@@ -489,7 +490,7 @@ public:
 	}
 	uint32_t GetDataFormatSupport(DataFormat fmt) const override;
 
-	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize) override;
+	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const std::string &tag) override;
 	DepthStencilState *CreateDepthStencilState(const DepthStencilStateDesc &desc) override;
 	BlendState *CreateBlendState(const BlendStateDesc &desc) override;
 	SamplerState *CreateSamplerState(const SamplerStateDesc &desc) override;
@@ -650,8 +651,8 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 D3D9Context::~D3D9Context() {
 }
 
-ShaderModule *D3D9Context::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t size) {
-	D3D9ShaderModule *shader = new D3D9ShaderModule(stage);
+ShaderModule *D3D9Context::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t size, const std::string &tag) {
+	D3D9ShaderModule *shader = new D3D9ShaderModule(stage, tag);
 	if (shader->Compile(device_, data, size)) {
 		return shader;
 	} else {

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -873,6 +873,9 @@ void D3D9Context::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 	for (auto &uniform : curPipeline_->dynamicUniforms.uniforms) {
 		int count = 0;
 		switch (uniform.type) {
+		case UniformType::FLOAT1:
+		case UniformType::FLOAT2:
+		case UniformType::FLOAT3:
 		case UniformType::FLOAT4:
 			count = 1;
 			break;
@@ -883,8 +886,11 @@ void D3D9Context::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 		const float *srcPtr = (const float *)((const uint8_t *)ub + uniform.offset);
 		if (uniform.vertexReg != -1) {
 			float transp[16];
-			Transpose4x4(transp, srcPtr);
-			device_->SetVertexShaderConstantF(uniform.vertexReg, transp, count);
+			if (count == 4) {
+				Transpose4x4(transp, srcPtr);
+				srcPtr = transp;
+			}
+			device_->SetVertexShaderConstantF(uniform.vertexReg, srcPtr, count);
 		}
 		if (uniform.fragmentReg != -1) {
 			device_->SetPixelShaderConstantF(uniform.fragmentReg, srcPtr, count);

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -946,7 +946,7 @@ void D3D9Context::DrawIndexed(int vertexCount, int offset) {
 	curPipeline_->inputLayout->Apply(device_);
 	device_->SetStreamSource(0, curVBuffers_[0]->vbuffer_, curVBufferOffsets_[0], curPipeline_->inputLayout->GetStride(0));
 	device_->SetIndices(curIBuffer_->ibuffer_);
-	device_->DrawIndexedPrimitive(curPipeline_->prim, 0, 0, vertexCount, 0, vertexCount / curPipeline_->primDivisor);
+	device_->DrawIndexedPrimitive(curPipeline_->prim, 0, 0, vertexCount, offset, vertexCount / curPipeline_->primDivisor);
 }
 
 void D3D9Context::DrawUP(const void *vdata, int vertexCount) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1037,10 +1037,12 @@ bool OpenGLPipeline::LinkShaders() {
 
 void OpenGLContext::BindPipeline(Pipeline *pipeline) {
 	curPipeline_ = (OpenGLPipeline *)pipeline;
-	curPipeline_->blend->Apply(&renderManager_);
-	curPipeline_->depthStencil->Apply(&renderManager_, stencilRef_);
-	curPipeline_->raster->Apply(&renderManager_);
-	renderManager_.BindProgram(curPipeline_->program_);
+	if (curPipeline_) {
+		curPipeline_->blend->Apply(&renderManager_);
+		curPipeline_->depthStencil->Apply(&renderManager_, stencilRef_);
+		curPipeline_->raster->Apply(&renderManager_);
+		renderManager_.BindProgram(curPipeline_->program_);
+	}
 }
 
 void OpenGLContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -747,8 +747,11 @@ void OpenGLTexture::SetImageData(int x, int y, int z, int width, int height, int
 	// Make a copy of data with stride eliminated.
 	uint8_t *texData = new uint8_t[(size_t)(width * height * depth * alignment)];
 
+	bool texDataPopulated = false;
 	if (callback) {
-		callback(texData, data, width, height, depth, width * (int)alignment, height * width * (int)alignment);
+		texDataPopulated = callback(texData, data, width, height, depth, width * (int)alignment, height * width * (int)alignment);
+	}
+	if (texDataPopulated) {
 		if (format_ == DataFormat::A1R5G5B5_UNORM_PACK16) {
 			format_ = DataFormat::R5G5B5A1_UNORM_PACK16;
 			MoveABit((u16 *)texData, (const u16 *)texData, width * height * depth);

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1030,6 +1030,9 @@ bool OpenGLPipeline::LinkShaders() {
 	semantics.push_back({ SEM_NORMAL, "Normal" });
 	semantics.push_back({ SEM_TANGENT, "Tangent" });
 	semantics.push_back({ SEM_BINORMAL, "Binormal" });
+	// For postshaders.
+	semantics.push_back({ SEM_POSITION, "a_position" });
+	semantics.push_back({ SEM_TEXCOORD0, "a_texcoord0" });
 	std::vector<GLRProgram::UniformLocQuery> queries;
 	std::vector<GLRProgram::Initializer> initialize;
 	program_ = render_->CreateProgram(linkShaders, semantics, queries, initialize, false);
@@ -1054,8 +1057,11 @@ void OpenGLContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 	for (auto &uniform : curPipeline_->dynamicUniforms.uniforms) {
 		const float *data = (const float *)((uint8_t *)ub + uniform.offset);
 		switch (uniform.type) {
+		case UniformType::FLOAT1:
+		case UniformType::FLOAT2:
+		case UniformType::FLOAT3:
 		case UniformType::FLOAT4:
-			renderManager_.SetUniformF(uniform.name, 4, data);
+			renderManager_.SetUniformF(uniform.name, 1 + (int)uniform.type - (int)UniformType::FLOAT1, data);
 			break;
 		case UniformType::MATRIX4X4:
 			renderManager_.SetUniformM4x4(uniform.name, data);

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1083,7 +1083,7 @@ void OpenGLContext::DrawIndexed(int vertexCount, int offset) {
 	ApplySamplers();
 	renderManager_.BindVertexBuffer(curPipeline_->inputLayout->inputLayout_, curVBuffers_[0]->buffer_, curVBufferOffsets_[0]);
 	renderManager_.BindIndexBuffer(curIBuffer_->buffer_);
-	renderManager_.DrawIndexed(curPipeline_->prim, vertexCount, GL_UNSIGNED_INT, (void *)(intptr_t)curIBufferOffset_);
+	renderManager_.DrawIndexed(curPipeline_->prim, vertexCount, GL_UNSIGNED_INT, (void *)((intptr_t)curIBufferOffset_ + offset * sizeof(uint32_t)));
 }
 
 void OpenGLContext::DrawUP(const void *vdata, int vertexCount) {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -186,7 +186,7 @@ VkShaderStageFlagBits StageToVulkan(ShaderStage stage) {
 // invoke Compile again to recreate the shader then link them together.
 class VKShaderModule : public ShaderModule {
 public:
-	VKShaderModule(ShaderStage stage) : module_(VK_NULL_HANDLE), ok_(false), stage_(stage) {
+	VKShaderModule(ShaderStage stage, const std::string &tag) : stage_(stage), tag_(tag) {
 		vkstage_ = StageToVulkan(stage);
 	}
 	bool Compile(VulkanContext *vulkan, ShaderLanguage language, const uint8_t *data, size_t size);
@@ -203,11 +203,12 @@ public:
 
 private:
 	VulkanContext *vulkan_;
-	VkShaderModule module_;
+	VkShaderModule module_ = VK_NULL_HANDLE;
 	VkShaderStageFlagBits vkstage_;
-	bool ok_;
+	bool ok_ = false;
 	ShaderStage stage_;
 	std::string source_;  // So we can recompile in case of context loss.
+	std::string tag_;
 };
 
 bool VKShaderModule::Compile(VulkanContext *vulkan, ShaderLanguage language, const uint8_t *data, size_t size) {
@@ -367,7 +368,7 @@ public:
 	SamplerState *CreateSamplerState(const SamplerStateDesc &desc) override;
 	RasterState *CreateRasterState(const RasterStateDesc &desc) override;
 	Pipeline *CreateGraphicsPipeline(const PipelineDesc &desc) override;
-	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize) override;
+	ShaderModule *CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const std::string &tag) override;
 
 	Texture *CreateTexture(const TextureDesc &desc) override;
 	Buffer *CreateBuffer(size_t size, uint32_t usageFlags) override;
@@ -1196,8 +1197,8 @@ void VKContext::BindTextures(int start, int count, Texture **textures) {
 	}
 }
 
-ShaderModule *VKContext::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t size) {
-	VKShaderModule *shader = new VKShaderModule(stage);
+ShaderModule *VKContext::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t size, const std::string &tag) {
+	VKShaderModule *shader = new VKShaderModule(stage, tag);
 	if (shader->Compile(vulkan_, language, data, size)) {
 		return shader;
 	} else {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -719,7 +719,9 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 			size_t size = w * h * d * bytesPerPixel;
 			if (desc.initDataCallback) {
 				uint8_t *dest = (uint8_t *)push->PushAligned(size, &offset, &buf, 16);
-				desc.initDataCallback(dest, desc.initData[0], w, h, d, w * bytesPerPixel, h * w * bytesPerPixel);
+				if (!desc.initDataCallback(dest, desc.initData[i], w, h, d, w * bytesPerPixel, h * w * bytesPerPixel)) {
+					memcpy(dest, desc.initData[i], size);
+				}
 			} else {
 				offset = push->PushAligned((const void *)desc.initData[i], size, 16, &buf);
 			}

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1258,7 +1258,7 @@ void VKContext::DrawIndexed(int vertexCount, int offset) {
 
 	renderManager_.BindPipeline(curPipeline_->vkpipeline);
 	ApplyDynamicState();
-	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset, vulkanIbuf, (int)ibBindOffset, vertexCount, 1, VK_INDEX_TYPE_UINT32);
+	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset, vulkanIbuf, (int)ibBindOffset + offset * sizeof(uint32_t), vertexCount, 1, VK_INDEX_TYPE_UINT32);
 }
 
 void VKContext::DrawUP(const void *vdata, int vertexCount) {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -807,7 +807,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	bindings[0].descriptorCount = 1;
 	bindings[0].pImmutableSamplers = nullptr;
 	bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-	bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+	bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
 	bindings[0].binding = 0;
 	bindings[1].descriptorCount = 1;
 	bindings[1].pImmutableSamplers = nullptr;

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1242,7 +1242,7 @@ void VKContext::Draw(int vertexCount, int offset) {
 
 	renderManager_.BindPipeline(curPipeline_->vkpipeline);
 	ApplyDynamicState();
-	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset, vertexCount);
+	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount, offset);
 }
 
 void VKContext::DrawIndexed(int vertexCount, int offset) {
@@ -1258,7 +1258,7 @@ void VKContext::DrawIndexed(int vertexCount, int offset) {
 
 	renderManager_.BindPipeline(curPipeline_->vkpipeline);
 	ApplyDynamicState();
-	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset, vulkanIbuf, (int)ibBindOffset + offset * sizeof(uint32_t), vertexCount, 1, VK_INDEX_TYPE_UINT32);
+	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vulkanIbuf, (int)ibBindOffset + offset * sizeof(uint32_t), vertexCount, 1, VK_INDEX_TYPE_UINT32);
 }
 
 void VKContext::DrawUP(const void *vdata, int vertexCount) {
@@ -1270,7 +1270,7 @@ void VKContext::DrawUP(const void *vdata, int vertexCount) {
 
 	renderManager_.BindPipeline(curPipeline_->vkpipeline);
 	ApplyDynamicState();
-	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset, vertexCount);
+	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount);
 }
 
 void VKContext::Clear(int clearMask, uint32_t colorval, float depthVal, int stencilVal) {

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -157,6 +157,7 @@ SOURCES_CXX += \
 	$(GPUCOMMONDIR)/DrawEngineCommon.cpp \
 	$(GPUCOMMONDIR)/SplineCommon.cpp \
 	$(GPUCOMMONDIR)/FramebufferCommon.cpp \
+	$(GPUCOMMONDIR)/PresentationCommon.cpp \
 	$(GPUCOMMONDIR)/ShaderId.cpp \
 	$(GPUCOMMONDIR)/ShaderCommon.cpp \
 	$(GPUCOMMONDIR)/ShaderUniforms.cpp \


### PR DESCRIPTION
This splits out the FramebufferManagerCommon class, creating a PresentationCommon to handle things like post-processing shaders, Google Cardboard, and anything else with the final display.

With that split out, it's now used everywhere and more consistent.  Benefits:
 * Software renderer now supports Google Cardboard and post-processing shaders (fixes #12445.)
 * Google Cardboard now supports render rotation.
 * Direct3D 9 now supports (some) post-processing shaders.  All ours work if you have PS 3.0 hardware.
 * There are a bit less differences between backends in post-processing shader handling, so features like chaining shaders will be easier to add now.

Also some cleanup and code centralization.  

Some remaining concerns:
 * No idea if this actually works with DarkStalkers.
 * Flipped buffers are still a bit messy.
 * Some minor optimizations might need reapplying (currently does 2x triangles rather than a strip, for example.)
 * OpenGL (non-Core) and GLES may not report errors as well as before.
 * Vulkan now uses the thin3d texture allocator for draw pixels...

-[Unknown]