### PR TITLE
Libretro: Add libpng17 to include flags

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -21,6 +21,7 @@ INCFLAGS += \
 	-I$(EXTDIR)/armips \
 	-I$(NATIVEDIR)/ext \
 	-I$(NATIVEDIR) \
+	-I$(NATIVEDIR)/ext/libpng17 \
 	-I$(EXTDIR)/libkirk \
 	-I$(EXTDIR)/xbrz \
 	-I$(EXTDIR)/xxhash \


### PR DESCRIPTION
We compile in libpng17, so we should be using those headers.

May fix libretro compile on Windows.  Not tested.

See build log in #12893.

-[Unknown]