### PR TITLE
More check size in EnqueueList

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -684,6 +684,12 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	}
 	
+	if (stall == 0 & subIntrBase == 0) {
+		ERROR_LOG_REPORT(G3D, "sceGeListEnqueue: invalid size stall=%08x, subIntrBase=%d)",
+			stall, subIntrBase);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	}
+
 	int id = -1;
 	u64 currentTicks = CoreTiming::GetTicks();
 	u32_le stackAddr = args.IsValid() ? args->stackAddr : 0;


### PR DESCRIPTION
Based on jpcsptrace log of this game
22:04:57.771 user_main - sceGeListEnQueue 0x89A9A80, 0x0, 0x0, 0x9FFF4B0 = 0x80000104
https://gist.github.com/sum2012/20550452620f9eb88c565297be8dd1ed
edit:add modify log https://drive.google.com/file/d/1ZO_9_lqLxo8mDBG3RaE0z9HNUcY2uuni/view?usp=sharing

fix #11660