### PR TITLE
Allow chained post-processing shaders

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -791,10 +791,9 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, GEBu
 		flags |= OutputFlags::POSITION_FLIPPED;
 	}
 
-	PostShaderUniforms uniforms{};
-	presentation_->CalculatePostShaderUniforms(512, 272, textureCache_->VideoIsPlaying(), &uniforms);
-	presentation_->SourceTexture(pixelsTex);
-	presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1, uniforms);
+	presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
+	presentation_->SourceTexture(pixelsTex, 512, 272);
+	presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1);
 	pixelsTex->Release();
 
 	// PresentationCommon sets all kinds of state, we can't rely on anything.
@@ -954,12 +953,11 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 			flags |= OutputFlags::POSITION_FLIPPED;
 		}
 
-		PostShaderUniforms uniforms{};
 		int actualWidth = (vfb->bufferWidth * vfb->renderWidth) / vfb->width;
 		int actualHeight = (vfb->bufferHeight * vfb->renderHeight) / vfb->height;
-		presentation_->CalculatePostShaderUniforms(actualWidth, actualHeight, textureCache_->VideoIsPlaying(), &uniforms);
-		presentation_->SourceFramebuffer(vfb->fbo);
-		presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1, uniforms);
+		presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
+		presentation_->SourceFramebuffer(vfb->fbo, actualWidth, actualHeight);
+		presentation_->CopyToOutput(flags, uvRotation, u0, v0, u1, v1);
 	} else if (useBufferedRendering_) {
 		WARN_LOG(FRAMEBUF, "Current VFB lacks an FBO: %08x", vfb->fb_address);
 	}

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -383,7 +383,7 @@ protected:
 
 	bool useBufferedRendering_ = false;
 	bool postShaderIsUpscalingFilter_ = false;
-	int postShaderSSAAFilterLevel_ = 0;
+	bool postShaderIsSupersampling_ = false;
 
 	std::vector<VirtualFramebuffer *> vfbs_;
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -204,6 +204,11 @@ std::vector<const ShaderInfo *> GetPostShaderChain(const std::string &name) {
 		} else {
 			shaderInfo = nullptr;
 		}
+		auto dup = std::find(backwards.begin(), backwards.end(), shaderInfo);
+		if (dup != backwards.end()) {
+			// Don't loop forever.
+			break;
+		}
 	}
 
 	if (!backwards.empty())

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -43,30 +43,13 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 	off.visible = true;
 	off.name = "Off";
 	off.section = "Off";
-	off.outputResolution = false;
-	off.isUpscalingFilter = false;
-	off.SSAAFilterLevel = 0;
-	off.requires60fps = false;
-	off.settingName1 = "";
-	off.settingValue1 = 0.0f;
-	off.minSettingValue1 = -1.0f;
-	off.maxSettingValue1 = 1.0f;
-	off.settingStep1 = 0.01f;
-	off.settingName2 = "";
-	off.settingValue2 = 0.0f;
-	off.minSettingValue2 = -1.0f;
-	off.maxSettingValue2 = 1.0f;
-	off.settingStep2 = 0.01f;
-	off.settingName3 = "";
-	off.settingValue3 = 0.0f;
-	off.minSettingValue3 = -1.0f;
-	off.maxSettingValue3 = 1.0f;
-	off.settingStep3 = 0.01f;
-	off.settingName4 = "";
-	off.settingValue4 = 0.0f;
-	off.minSettingValue4 = -1.0f;
-	off.maxSettingValue4 = 1.0f;
-	off.settingStep4 = 0.01f;
+	for (size_t i = 0; i < ARRAY_SIZE(off.settings); ++i) {
+		off.settings[i].name = "";
+		off.settings[i].value = 0.0f;
+		off.settings[i].minValue = -1.0f;
+		off.settings[i].maxValue = 1.0f;
+		off.settings[i].step = 0.01f;
+	}
 	shaderInfo.push_back(off);
 
 	auto appendShader = [&](const ShaderInfo &info) {
@@ -123,35 +106,21 @@ void LoadPostShaderInfo(std::vector<std::string> directories) {
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
 					section.Get("SSAA", &info.SSAAFilterLevel, 0);
 					section.Get("60fps", &info.requires60fps, false);
-					section.Get("SettingName1", &info.settingName1, "");
-					section.Get("SettingDefaultValue1", &info.settingValue1, 0.0f);
-					section.Get("SettingMinValue1", &info.minSettingValue1, -1.0f);
-					section.Get("SettingMaxValue1", &info.maxSettingValue1, 1.0f);
-					section.Get("SettingStep1", &info.settingStep1, 0.01f);
-					section.Get("SettingName2", &info.settingName2, "");
-					section.Get("SettingDefaultValue2", &info.settingValue2, 0.0f);
-					section.Get("SettingMinValue2", &info.minSettingValue2, -1.0f);
-					section.Get("SettingMaxValue2", &info.maxSettingValue2, 1.0f);
-					section.Get("SettingStep2", &info.settingStep2, 0.01f);
-					section.Get("SettingName3", &info.settingName3, "");
-					section.Get("SettingDefaultValue3", &info.settingValue3, 0.0f);
-					section.Get("SettingMinValue3", &info.minSettingValue3, -1.0f);
-					section.Get("SettingMaxValue3", &info.maxSettingValue3, 1.0f);
-					section.Get("SettingStep3", &info.settingStep3, 0.01f);
-					section.Get("SettingName4", &info.settingName4, "");
-					section.Get("SettingDefaultValue4", &info.settingValue4, 0.0f);
-					section.Get("SettingMinValue4", &info.minSettingValue4, -1.0f);
-					section.Get("SettingMaxValue4", &info.maxSettingValue4, 1.0f);
-					section.Get("SettingStep4", &info.settingStep4, 0.01f);
 
-					if (g_Config.mPostShaderSetting.find(info.section + "SettingValue1") == g_Config.mPostShaderSetting.end())
-						g_Config.mPostShaderSetting.insert(std::pair<std::string, float>(info.section + "SettingValue1", info.settingValue1));
-					if (g_Config.mPostShaderSetting.find(info.section + "SettingValue2") == g_Config.mPostShaderSetting.end())
-						g_Config.mPostShaderSetting.insert(std::pair<std::string, float>(info.section + "SettingValue2", info.settingValue2));
-					if (g_Config.mPostShaderSetting.find(info.section + "SettingValue3") == g_Config.mPostShaderSetting.end())
-						g_Config.mPostShaderSetting.insert(std::pair<std::string, float>(info.section + "SettingValue3", info.settingValue3));
-					if (g_Config.mPostShaderSetting.find(info.section + "SettingValue4") == g_Config.mPostShaderSetting.end())
-						g_Config.mPostShaderSetting.insert(std::pair<std::string, float>(info.section + "SettingValue4", info.settingValue4));
+					for (size_t i = 0; i < ARRAY_SIZE(info.settings); ++i) {
+						auto &setting = info.settings[i];
+						section.Get(StringFromFormat("SettingName%d", i + 1).c_str(), &setting.name, "");
+						section.Get(StringFromFormat("SettingDefaultValue%d", i + 1).c_str(), &setting.value, 0.0f);
+						section.Get(StringFromFormat("SettingMinValue%d", i + 1).c_str(), &setting.minValue, -1.0f);
+						section.Get(StringFromFormat("SettingMaxValue%d", i + 1).c_str(), &setting.maxValue, 1.0f);
+						section.Get(StringFromFormat("SettingStep%d", i + 1).c_str(), &setting.step, 0.01f);
+
+						// Populate the default setting value.
+						std::string section = StringFromFormat("%sSettingValue%d", info.section.c_str(), i + 1);
+						if (!setting.name.empty() && g_Config.mPostShaderSetting.find(section) == g_Config.mPostShaderSetting.end()) {
+							g_Config.mPostShaderSetting.insert(std::pair<std::string, float>(section, setting.value));
+						}
+					}
 
 					// Let's ignore shaders we can't support. TODO: Not a very good check
 					if (gl_extensions.IsGLES && !gl_extensions.GLES3) {

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -44,26 +44,14 @@ struct ShaderInfo {
 	// Force constant/max refresh for animated filters
 	bool requires60fps;
 
-	std::string settingName1;
-	float settingValue1;
-	float maxSettingValue1;
-	float minSettingValue1;
-	float settingStep1;
-	std::string settingName2;
-	float settingValue2;
-	float maxSettingValue2;
-	float minSettingValue2;
-	float settingStep2;
-	std::string settingName3;
-	float settingValue3;
-	float maxSettingValue3;
-	float minSettingValue3;
-	float settingStep3;
-	std::string settingName4;
-	float settingValue4;
-	float maxSettingValue4;
-	float minSettingValue4;
-	float settingStep4;
+	struct Setting {
+		std::string name;
+		float value;
+		float maxValue;
+		float minValue;
+		float step;
+	};
+	Setting settings[4];
 
 	// TODO: Add support for all kinds of fun options like mapping the depth buffer,
 	// SRGB texture reads, etc.

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -28,10 +28,13 @@ struct ShaderInfo {
 	std::string iniFile;  // which ini file was this definition in? So we can write settings back later
 	std::string section;  // ini file section. This is saved.
 	std::string name;     // Fancy display name.
+	std::string parent;   // Parent shader ini section name.
 
 	std::string fragmentShaderFile;
 	std::string vertexShaderFile;
 
+	// Show this shader in lists (i.e. not just for chaining.)
+	bool visible;
 	// Run at output instead of input resolution
 	bool outputResolution;
 	// Use x1 rendering res + nearest screen scaling filter
@@ -63,7 +66,7 @@ struct ShaderInfo {
 	float settingStep4;
 
 	// TODO: Add support for all kinds of fun options like mapping the depth buffer,
-	// SRGB texture reads, multiple shaders chained, etc.
+	// SRGB texture reads, etc.
 
 	bool operator == (const std::string &other) {
 		return name == other;
@@ -75,5 +78,6 @@ struct ShaderInfo {
 
 void ReloadAllPostShaderInfo();
 
-const ShaderInfo *GetPostShaderInfo(std::string name);
+const ShaderInfo *GetPostShaderInfo(const std::string &name);
+std::vector<const ShaderInfo *> GetPostShaderChain(const std::string &name);
 const std::vector<ShaderInfo> &GetAllPostShaderInfo();

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -237,6 +237,10 @@ bool PresentationCommon::BuildPostShader(const ShaderInfo *shaderInfo, const Sha
 		int nextWidth = renderWidth_;
 		int nextHeight = renderHeight_;
 
+		// When chaining, we use the previous resolution as a base, rather than the render resolution.
+		if (!postShaderFramebuffers_.empty())
+			draw_->GetFramebufferDimensions(postShaderFramebuffers_.back(), &nextWidth, &nextHeight);
+
 		if (next && next->isUpscalingFilter) {
 			// Force 1x for this shader, so the next can upscale.
 			const bool isPortrait = g_Config.IsPortrait();

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -159,10 +159,10 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	uniforms->gl_HalfPixel[0] = u_pixel_delta * 0.5f;
 	uniforms->gl_HalfPixel[1] = v_pixel_delta * 0.5f;
 
-	uniforms->setting[0] = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue1"];;
-	uniforms->setting[1] = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue2"];
-	uniforms->setting[2] = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue3"];
-	uniforms->setting[3] = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue4"];
+	uniforms->setting[0] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue1"];;
+	uniforms->setting[1] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue2"];
+	uniforms->setting[2] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue3"];
+	uniforms->setting[3] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue4"];
 }
 
 static std::string ReadShaderSrc(const std::string &filename) {

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -355,9 +355,9 @@ void PresentationCommon::CreateDeviceObjects() {
 	using namespace Draw;
 
 	vdata_ = draw_->CreateBuffer(sizeof(Vertex) * 8, BufferUsageFlag::DYNAMIC | BufferUsageFlag::VERTEXDATA);
-	// TODO: Use 4 and a strip?  shorts?
-	idata_ = draw_->CreateBuffer(sizeof(uint16_t) * 6, BufferUsageFlag::DYNAMIC | BufferUsageFlag::INDEXDATA);
 
+	// TODO: Use 4 and a strip?
+	idata_ = draw_->CreateBuffer(sizeof(uint16_t) * 6, BufferUsageFlag::DYNAMIC | BufferUsageFlag::INDEXDATA);
 	uint16_t indexes[] = { 0, 1, 2, 0, 2, 3 };
 	draw_->UpdateBuffer(idata_, (const uint8_t *)indexes, 0, sizeof(indexes), Draw::UPDATE_DISCARD);
 

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -599,7 +599,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 			draw_->BindPipeline(postShaderPipeline);
 			draw_->UpdateDynamicUniformBuffer(&uniforms, sizeof(uniforms));
 
-			Draw::SamplerState *sampler = useNearest ? samplerNearest_ : samplerLinear_;
+			Draw::SamplerState *sampler = useNearest || shaderInfo->isUpscalingFilter ? samplerNearest_ : samplerLinear_;
 			draw_->BindSamplerStates(0, 1, &sampler);
 
 			draw_->BindVertexBuffers(0, 1, &vdata_, &postVertsOffset);
@@ -610,9 +610,10 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 			usePostShaderOutput = true;
 			lastWidth = nextWidth;
 			lastHeight = nextHeight;
-			if (shaderInfo->isUpscalingFilter)
-				useNearest = true;
 		}
+
+		if (isFinalAtOutputResolution && postShaderInfo_.back().isUpscalingFilter)
+			useNearest = true;
 	} else {
 		draw_->UpdateBuffer(vdata_, (const uint8_t *)verts, 0, postVertsOffset, Draw::UPDATE_DISCARD);
 	}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -560,26 +560,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		}
 	}
 
-	Draw::Pipeline *postShaderPipeline = usePostShader ? postShaderPipelines_.front() : nullptr;
-	const ShaderInfo *shaderInfo = usePostShader ? &postShaderInfo_[0] : nullptr;
-	Draw::Framebuffer *postShaderFramebuffer = usePostShader && postShaderFramebuffers_.size() >= 1 ? postShaderFramebuffers_.front() : nullptr;
-
-	if (usePostShader && postShaderFramebuffer) {
-		draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
-		BindSource();
-
-		int fbo_w, fbo_h;
-		draw_->GetFramebufferDimensions(postShaderFramebuffer, &fbo_w, &fbo_h);
-		Draw::Viewport viewport{ 0, 0, (float)fbo_w, (float)fbo_h, 0.0f, 1.0f };
-		draw_->SetViewports(1, &viewport);
-		draw_->SetScissorRect(0, 0, fbo_w, fbo_h);
-
-		draw_->BindPipeline(postShaderPipeline);
-		draw_->UpdateDynamicUniformBuffer(&uniforms, sizeof(uniforms));
-
-		Draw::SamplerState *sampler = useNearest ? samplerNearest_ : samplerLinear_;
-		draw_->BindSamplerStates(0, 1, &sampler);
-
+	if (usePostShader) {
 		bool flipped = flags & OutputFlags::POSITION_FLIPPED;
 		float post_v0 = !flipped ? 1.0f : 0.0f;
 		float post_v1 = !flipped ? 0.0f : 1.0f;
@@ -587,25 +568,48 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		verts[5] = { -1, 1, 0, 0, post_v0, 0xFFFFFFFF }; // BL
 		verts[6] = { 1, 1, 0, 1, post_v0, 0xFFFFFFFF }; // BR
 		verts[7] = { 1, -1, 0, 1, post_v1, 0xFFFFFFFF }; // TR
-
 		draw_->UpdateBuffer(vdata_, (const uint8_t *)verts, 0, sizeof(verts), Draw::UPDATE_DISCARD);
 
-		draw_->BindVertexBuffers(0, 1, &vdata_, &postVertsOffset);
-		draw_->BindIndexBuffer(idata_, 0);
-		draw_->DrawIndexed(6, 0);
-		draw_->BindIndexBuffer(nullptr, 0);
+		for (size_t i = 0; i < postShaderFramebuffers_.size(); ++i) {
+			Draw::Pipeline *postShaderPipeline = postShaderPipelines_[i];
+			const ShaderInfo *shaderInfo = &postShaderInfo_[i];
+			Draw::Framebuffer *postShaderFramebuffer = postShaderFramebuffers_[i];
 
-		usePostShaderOutput = true;
+			draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
+			if (usePostShaderOutput) {
+				draw_->BindFramebufferAsTexture(postShaderFramebuffers_[i - 1], 0, Draw::FB_COLOR_BIT, 0);
+			} else {
+				BindSource();
+			}
+
+			int fbo_w, fbo_h;
+			draw_->GetFramebufferDimensions(postShaderFramebuffer, &fbo_w, &fbo_h);
+			Draw::Viewport viewport{ 0, 0, (float)fbo_w, (float)fbo_h, 0.0f, 1.0f };
+			draw_->SetViewports(1, &viewport);
+			draw_->SetScissorRect(0, 0, fbo_w, fbo_h);
+
+			draw_->BindPipeline(postShaderPipeline);
+			draw_->UpdateDynamicUniformBuffer(&uniforms, sizeof(uniforms));
+
+			Draw::SamplerState *sampler = useNearest ? samplerNearest_ : samplerLinear_;
+			draw_->BindSamplerStates(0, 1, &sampler);
+
+			draw_->BindVertexBuffers(0, 1, &vdata_, &postVertsOffset);
+			draw_->BindIndexBuffer(idata_, 0);
+			draw_->DrawIndexed(6, 0);
+			draw_->BindIndexBuffer(nullptr, 0);
+
+			usePostShaderOutput = true;
+			if (shaderInfo->isUpscalingFilter)
+				useNearest = true;
+		}
 	} else {
 		draw_->UpdateBuffer(vdata_, (const uint8_t *)verts, 0, postVertsOffset, Draw::UPDATE_DISCARD);
 	}
 
-	if (usePostShader && shaderInfo->isUpscalingFilter)
-		useNearest = true;
-
 	Draw::Pipeline *pipeline = flags & OutputFlags::RB_SWIZZLE ? texColorRBSwizzle_ : texColor_;
 	if (isFinalAtOutputResolution) {
-		pipeline = postShaderPipeline;
+		pipeline = postShaderPipelines_.back();
 	}
 
 	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -178,20 +178,22 @@ static std::string ReadShaderSrc(const std::string &filename) {
 
 // Note: called on resize and settings changes.
 bool PresentationCommon::UpdatePostShader() {
-	const ShaderInfo *shaderInfo = nullptr;
+	std::vector<const ShaderInfo *> shaderInfo;
 	if (g_Config.sPostShaderName != "Off") {
 		ReloadAllPostShaderInfo();
-		shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
+		shaderInfo = GetPostShaderChain(g_Config.sPostShaderName);
 	}
 
 	DestroyPostShader();
-	if (shaderInfo == nullptr)
+	if (shaderInfo.empty())
 		return false;
 
-	bool pipeline = BuildPostShader(shaderInfo, nullptr);
-	if (!pipeline) {
-		DestroyPostShader();
-		return false;
+	for (int i = 0; i < shaderInfo.size(); ++i) {
+		const ShaderInfo *next = i + 1 < shaderInfo.size() ? shaderInfo[i + 1] : nullptr;
+		if (!BuildPostShader(shaderInfo[i], next)) {
+			DestroyPostShader();
+			return false;
+		}
 	}
 
 	usePostShader_ = true;

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -95,12 +95,10 @@ public:
 	void DeviceLost();
 	void DeviceRestore(Draw::DrawContext *draw);
 
-	void GetCardboardSettings(CardboardSettings *cardboardSettings);
-	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, bool hasVideo, PostShaderUniforms *uniforms);
-
-	void SourceTexture(Draw::Texture *texture);
-	void SourceFramebuffer(Draw::Framebuffer *fb);
-	void CopyToOutput(OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1, const PostShaderUniforms &uniforms);
+	void UpdateUniforms(bool hasVideo);
+	void SourceTexture(Draw::Texture *texture, int bufferWidth, int bufferHeight);
+	void SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight);
+	void CopyToOutput(OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
 
 protected:
 	void CreateDeviceObjects();
@@ -114,6 +112,9 @@ protected:
 	bool BuildPostShader(const ShaderInfo *shaderInfo, const ShaderInfo *next);
 
 	void BindSource();
+
+	void GetCardboardSettings(CardboardSettings *cardboardSettings);
+	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int targetWidth, int targetHeight, const ShaderInfo *shaderInfo, PostShaderUniforms *uniforms);
 
 	Draw::DrawContext *draw_;
 	Draw::Pipeline *texColor_ = nullptr;
@@ -130,6 +131,9 @@ protected:
 
 	Draw::Texture *srcTexture_ = nullptr;
 	Draw::Framebuffer *srcFramebuffer_ = nullptr;
+	int srcWidth_ = 0;
+	int srcHeight_ = 0;
+	bool hasVideo_ = false;
 
 	int pixelWidth_ = 0;
 	int pixelHeight_ = 0;
@@ -138,6 +142,5 @@ protected:
 
 	bool usePostShader_ = false;
 	bool restorePostShader_ = false;
-	bool postShaderAtOutputResolution_ = false;
 	ShaderLanguage lang_;
 };

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -91,7 +91,6 @@ public:
 	}
 
 	bool UpdatePostShader();
-	void UpdateShaderInfo(const ShaderInfo *shaderInfo);
 
 	void DeviceLost();
 	void DeviceRestore(Draw::DrawContext *draw);
@@ -112,6 +111,7 @@ protected:
 
 	Draw::ShaderModule *CompileShaderModule(Draw::ShaderStage stage, ShaderLanguage lang, const std::string &src, std::string *errorString);
 	Draw::Pipeline *CreatePipeline(std::vector<Draw::ShaderModule *> shaders, bool postShader, const Draw::UniformBufferDesc *uniformDesc);
+	bool BuildPostShader(const ShaderInfo *shaderInfo, const ShaderInfo *next);
 
 	void BindSource();
 
@@ -126,6 +126,7 @@ protected:
 	std::vector<Draw::ShaderModule *> postShaderModules_;
 	std::vector<Draw::Pipeline *> postShaderPipelines_;
 	std::vector<Draw::Framebuffer *> postShaderFramebuffers_;
+	std::vector<ShaderInfo> postShaderInfo_;
 
 	Draw::Texture *srcTexture_ = nullptr;
 	Draw::Framebuffer *srcFramebuffer_ = nullptr;
@@ -138,6 +139,5 @@ protected:
 	bool usePostShader_ = false;
 	bool restorePostShader_ = false;
 	bool postShaderAtOutputResolution_ = false;
-	bool postShaderIsUpscalingFilter_ = false;
 	ShaderLanguage lang_;
 };

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -100,6 +100,8 @@ public:
 	void SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight);
 	void CopyToOutput(OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
 
+	void CalculateRenderResolution(int *width, int *height, bool *upscaling, bool *ssaa);
+
 protected:
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -275,10 +275,8 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		break;
 	}
 
-	PostShaderUniforms uniforms{};
-	presentation_->CalculatePostShaderUniforms(desc.width, desc.height, false, &uniforms);
-	presentation_->SourceTexture(fbTex);
-	presentation_->CopyToOutput(outputFlags, g_Config.iInternalScreenRotation, u0, v0, u1, v1, uniforms);
+	presentation_->SourceTexture(fbTex, desc.width, desc.height);
+	presentation_->CopyToOutput(outputFlags, g_Config.iInternalScreenRotation, u0, v0, u1, v1);
 }
 
 void SoftGPU::CopyDisplayToOutput(bool reallyDirty) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -290,12 +290,14 @@ void GameSettingsScreen::CreateViews() {
 		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 	});
 
-	const ShaderInfo *shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
-	for (size_t i = 0; shaderInfo && i < ARRAY_SIZE(shaderInfo->settings); ++i) {
-		auto &setting = shaderInfo->settings[i];
-		if (!setting.name.empty()) {
-			auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
-			graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+	auto shaderChain = GetPostShaderChain(g_Config.sPostShaderName);
+	for (auto shaderInfo : shaderChain) {
+		for (size_t i = 0; i < ARRAY_SIZE(shaderInfo->settings); ++i) {
+			auto &setting = shaderInfo->settings[i];
+			if (!setting.name.empty()) {
+				auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+				graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+			}
 		}
 	}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -291,21 +291,12 @@ void GameSettingsScreen::CreateViews() {
 	});
 
 	const ShaderInfo *shaderInfo = GetPostShaderInfo(g_Config.sPostShaderName);
-	if (shaderInfo && !shaderInfo->settingName1.empty()) {
-		auto &value = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue1"];
-		graphicsSettings->Add(new PopupSliderChoiceFloat(&value, shaderInfo->minSettingValue1, shaderInfo->maxSettingValue1, shaderInfo->settingName1, shaderInfo->settingStep1, screenManager()));
-	}
-	if (shaderInfo && !shaderInfo->settingName2.empty()) {
-		auto &value = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue2"];
-		graphicsSettings->Add(new PopupSliderChoiceFloat(&value, shaderInfo->minSettingValue2, shaderInfo->maxSettingValue2, shaderInfo->settingName2, shaderInfo->settingStep2, screenManager()));
-	}
-	if (shaderInfo && !shaderInfo->settingName3.empty()) {
-		auto &value = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue3"];
-		graphicsSettings->Add(new PopupSliderChoiceFloat(&value, shaderInfo->minSettingValue3, shaderInfo->maxSettingValue3, shaderInfo->settingName3, shaderInfo->settingStep3, screenManager()));
-	}
-	if (shaderInfo && !shaderInfo->settingName4.empty()) {
-		auto &value = g_Config.mPostShaderSetting[g_Config.sPostShaderName + "SettingValue4"];
-		graphicsSettings->Add(new PopupSliderChoiceFloat(&value, shaderInfo->minSettingValue4, shaderInfo->maxSettingValue4, shaderInfo->settingName4, shaderInfo->settingStep4, screenManager()));
+	for (size_t i = 0; shaderInfo && i < ARRAY_SIZE(shaderInfo->settings); ++i) {
+		auto &setting = shaderInfo->settings[i];
+		if (!setting.name.empty()) {
+			auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+			graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+		}
 	}
 
 #if !defined(MOBILE_DEVICE)

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -306,6 +306,8 @@ PostProcScreen::PostProcScreen(const std::string &title) : ListPopupScreen(title
 	std::vector<std::string> items;
 	int selected = -1;
 	for (int i = 0; i < (int)shaders_.size(); i++) {
+		if (!shaders_[i].visible)
+			continue;
 		if (shaders_[i].section == g_Config.sPostShaderName)
 			selected = i;
 		items.push_back(ps->T(shaders_[i].section.c_str(), shaders_[i].name.c_str()));

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -181,6 +181,8 @@ namespace MainWindow {
 
 		availableShaders.clear();
 		for (auto i = info.begin(); i != info.end(); ++i) {
+			if (!i->visible)
+				continue;
 			int checkedStatus = MF_UNCHECKED;
 			availableShaders.push_back(i->section);
 			if (g_Config.sPostShaderName == i->section) {


### PR DESCRIPTION
With #12883 merged, this was the next step.  Required a little reorganization of render target size and uniforms, but pretty straight forward now.

I can fix this up after #12901 is merged, or tweak that to handle each layer's settings.

Basically, here are some examples:

```
[InverseVignette]
Name=Inverse Colors + Vignette
Parent=InverseColors
Fragment=vignette.fsh
Vertex=fxaa.vsh

[Complex]
Name=Complex
Parent=ComplexHelper1
OutputResolution=True
Fragment=vignette.fsh
Vertex=fxaa.vsh

[ComplexHelper1]
Visible=False
Parent=5xBR-lv2
OutputResolution=True
Fragment=natural.fsh
Vertex=natural.vsh
```

In this case, "ComplexHelper" would not show up in menus.  "Complex" wouild, and it would first apply 5xBR-lv2, then natural colors blur, then finally a vignette.  The visible flag makes it possible to add a link in the chain that isn't useful alone.

One thing I wasn't sure about is upscaling shaders.  Currently, we use nearest after we see the first one.  I don't know if that always makes sense, i.e. if you apply vignette after an upscaler.

Should it maybe only use nearest if it's the last shader?  Or only for the next one?

-[Unknown]