### PR TITLE
Fix "Improved compatibility of sceGeListEnQueue: verify that stackDepth < 256"

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -679,7 +679,7 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
 	}
 	
-	if (args.IsValid() && args->numStacks >= 256 ) {
+	if (args.IsValid() && args->numStacks >= 256) {
 		ERROR_LOG_REPORT(G3D, "sceGeListEnqueue: invalid size %d", args->numStacks);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -679,8 +679,8 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
 	}
 	
-	if (args.IsValid() && args->size >= 256) {
-		ERROR_LOG_REPORT(G3D, "sceGeListEnqueue: invalid size %d", args->size);
+	if (args.IsValid() && args->numStacks >= 256 ) {
+		ERROR_LOG_REPORT(G3D, "sceGeListEnqueue: invalid size %d", args->numStacks);
 		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	}
 	


### PR DESCRIPTION
Fix #11660
based from
https://github.com/jpcsp/jpcsp/commit/f9a116f78a939f27440e5edd5fd0c70cddc78537
the variable name is difficult from jpcsp,so that I translate wrong.

37:45:269 user_main    E[G3D]: GPUCommon.cpp:683 sceGeListEnqueue: invalid size 1024