### PR TITLE
Add CWCHEAT for postprocessing

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -971,16 +971,16 @@ void CWCheatEngine::ExecuteOp(const CheatOperation &op, const CheatCode &cheat, 
 				std::string shaderName = shaderChain[op.PostShaderUniform.shader]->section;
 				if (shaderName != "Off") {
 					switch (op.PostShaderUniform.format) {
-					case (0):
+					case 0:
 						g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x000000FF;
 						break;
-					case (1):
+					case 1:
 						g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x0000FFFF;
 						break;
-					case (2):
+					case 2:
 						g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u;
 						break;
-					case (3):
+					case 3:
 						g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.f;
 						break;
 					}


### PR DESCRIPTION
This allow to set uniform with CWCHEAT with 0xA2 code:

```
0xA20000UU 0xVVVVVVVV

U: uniform number [0..3]
V: float value in hex
```

Example on MHFU (EU version) using Color Correction shader
```
_C0 Low HP saturation fade
_L 0xA2000001 0x3F800000
_L 0xD08B3724 0x20200010
_L 0xA2000001 0x3E4CCCCD
```
![output](https://user-images.githubusercontent.com/13517524/82129505-afad2b80-97c3-11ea-9483-6f054371d621.gif)

This should allow to edit the first shader of the chain with #12905 (will test after it's merged) that it's probably fine for the use case (CWCHEAT handling a chain could be done with a offset, but not sure if is worth the trouble).