### PR TITLE
Switch: Be more consistent about writable code pointers

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -278,7 +278,6 @@ static int EncodeSize(int size) {
 void ARM64XEmitter::SetCodePointer(u8* ptr)
 {
 	m_code = ptr;
-	m_startcode = m_code;
 	m_lastCacheFlushEnd = ptr;
 }
 
@@ -911,7 +910,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
 			inst = ((branch.bit & 0x20) << 26) | (0x1B << 25) | (Not << 24) | ((branch.bit & 0x1F) << 19) | (MaskImm14(distance) << 5) | reg;
 		}
 		break;
-		case 5: // B (uncoditional)
+		case 5: // B (unconditional)
 			_assert_msg_(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			inst = (0x5 << 26) | MaskImm26(distance);
 		break;

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -340,9 +340,8 @@ class ARM64XEmitter
 	friend class ARM64FloatEmitter;
 
 private:
-	u8* m_code;
-	u8* m_startcode;
-	u8* m_lastCacheFlushEnd;
+	u8 *m_code = nullptr;
+	u8 *m_lastCacheFlushEnd = nullptr;
 
 	void EncodeCompareBranchInst(u32 op, ARM64Reg Rt, const void* ptr);
 	void EncodeTestBranchInst(u32 op, ARM64Reg Rt, u8 bits, const void* ptr);
@@ -382,14 +381,12 @@ protected:
 
 public:
 	ARM64XEmitter()
-		: m_code(nullptr), m_startcode(nullptr), m_lastCacheFlushEnd(nullptr)
 	{
 	}
 
-	ARM64XEmitter(u8* code_ptr) {
+	ARM64XEmitter(u8 *code_ptr) {
 		m_code = code_ptr;
 		m_lastCacheFlushEnd = code_ptr;
-		m_startcode = code_ptr;
 	}
 
 	virtual ~ARM64XEmitter()

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -162,7 +162,8 @@ enum RoundingMode {
 
 struct FixupBranch
 {
-	u8* ptr;
+	// Pointer to executable code address.
+	const u8 *ptr;
 	// Type defines
 	// 0 = CBZ (32bit)
 	// 1 = CBNZ (32bit)
@@ -338,10 +339,12 @@ public:
 class ARM64XEmitter
 {
 	friend class ARM64FloatEmitter;
+	friend class ARM64CodeBlock;
 
 private:
-	u8 *m_code = nullptr;
-	u8 *m_lastCacheFlushEnd = nullptr;
+	const u8 *m_code = nullptr;
+	u8 *m_writable = nullptr;
+	const u8 *m_lastCacheFlushEnd = nullptr;
 
 	void EncodeCompareBranchInst(u32 op, ARM64Reg Rt, const void* ptr);
 	void EncodeTestBranchInst(u32 op, ARM64Reg Rt, u8 bits, const void* ptr);
@@ -375,8 +378,9 @@ private:
 protected:
 	inline void Write32(u32 value)
 	{
-		*(u32*)m_code = value;
+		*(u32 *)m_writable = value;
 		m_code += 4;
+		m_writable += 4;
 	}
 
 public:
@@ -384,23 +388,20 @@ public:
 	{
 	}
 
-	ARM64XEmitter(u8 *code_ptr) {
-		m_code = code_ptr;
-		m_lastCacheFlushEnd = code_ptr;
-	}
+	ARM64XEmitter(const u8 *codePtr, u8 *writablePtr);
 
 	virtual ~ARM64XEmitter()
 	{
 	}
 
-	void SetCodePointer(u8* ptr);
+	void SetCodePointer(const u8 *ptr, u8 *writePtr);
 	const u8* GetCodePointer() const;
 
 	void ReserveCodeSpace(u32 bytes);
 	const u8* AlignCode16();
 	const u8* AlignCodePage();
 	void FlushIcache();
-	void FlushIcacheSection(u8* start, u8* end);
+	void FlushIcacheSection(const u8* start, const u8* end);
 	u8* GetWritableCodePtr();
 
 	// FixupBranch branching

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -586,7 +586,7 @@ void ARMXEmitter::QuickCallFunction(ARMReg reg, const void *func) {
 	}
 }
 
-void ARMXEmitter::SetCodePointer(u8 *ptr)
+void ARMXEmitter::SetCodePointer(u8 *ptr, u8 *writePtr)
 {
 	code = ptr;
 	startcode = code;

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -443,7 +443,7 @@ public:
 	}
 	virtual ~ARMXEmitter() {}
 
-	void SetCodePointer(u8 *ptr);
+	void SetCodePointer(u8 *ptr, u8 *writePtr);
 	const u8 *GetCodePointer() const;
 
 	void ReserveCodeSpace(u32 bytes);

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -15,7 +15,7 @@
 
 class CodeBlockCommon {
 public:
-	CodeBlockCommon() : region(nullptr), region_size(0) {}
+	CodeBlockCommon() {}
 	virtual ~CodeBlockCommon() {}
 
 	bool IsInSpace(const u8 *ptr) {
@@ -34,8 +34,8 @@ public:
 	}
 
 protected:
-	u8 *region;
-	size_t region_size;
+	u8 *region = nullptr;
+	size_t region_size = 0;
 };
 
 template<class T> class CodeBlock : public CodeBlockCommon, public T {
@@ -48,14 +48,14 @@ private:
 	virtual void PoisonMemory(int offset) = 0;
 
 public:
-	CodeBlock() : writeStart_(nullptr) {}
+	CodeBlock() {}
 	virtual ~CodeBlock() { if (region) FreeCodeSpace(); }
 
 	// Call this before you generate any code.
 	void AllocCodeSpace(int size) {
 		region_size = size;
 		// The protection will be set to RW if PlatformIsWXExclusive.
-		region = (u8*)AllocateExecutableMemory(region_size);
+		region = (u8 *)AllocateExecutableMemory(region_size);
 		T::SetCodePointer(region);
 	}
 
@@ -124,6 +124,7 @@ public:
 	}
 
 private:
-	const uint8_t *writeStart_;
+	// Note: this is a readable pointer.
+	const uint8_t *writeStart_ = nullptr;
 };
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -96,7 +96,7 @@ enum NormalSSEOps
 };
 
 
-void XEmitter::SetCodePointer(u8 *ptr)
+void XEmitter::SetCodePointer(u8 *ptr, u8 *writePtr)
 {
 	code = ptr;
 }

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -372,7 +372,7 @@ public:
 	void WriteModRM(int mod, int rm, int reg);
 	void WriteSIB(int scale, int index, int base);
 
-	void SetCodePointer(u8 *ptr);
+	void SetCodePointer(u8 *ptr, u8 *writePtr);
 	const u8 *GetCodePointer() const;
 
 	void ReserveCodeSpace(int bytes);

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -304,17 +304,17 @@ const u8 *ArmJit::DoJit(u32 em_address, JitBlock *b)
 		JumpTarget backJump = GetCodePtr();
 		gpr.SetRegImm(R0, js.blockStart);
 		B((const void *)outerLoopPCInR0);
-		b->checkedEntry = (u8 *)GetCodePtr();
+		b->checkedEntry = GetCodePtr();
 		SetCC(CC_LT);
 		B(backJump);
 		SetCC(CC_AL);
 	} else if (jo.useForwardJump) {
-		b->checkedEntry = (u8 *)GetCodePtr();
+		b->checkedEntry = GetCodePtr();
 		SetCC(CC_LT);
 		bail = B();
 		SetCC(CC_AL);
 	} else {
-		b->checkedEntry = (u8 *)GetCodePtr();
+		b->checkedEntry = GetCodePtr();
 		SetCC(CC_LT);
 		gpr.SetRegImm(R0, js.blockStart);
 		B((const void *)outerLoopPCInR0);

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -186,7 +186,7 @@ void JitBlockCache::ProxyBlock(u32 rootAddress, u32 startAddress, u32 size, cons
 
 	// Make binary searches and stuff work ok
 	b.normalEntry = codePtr;
-	b.checkedEntry = (u8 *)codePtr;  // Ugh, casting away const..
+	b.checkedEntry = codePtr;
 	proxyBlockMap_.insert(std::make_pair(startAddress, num_blocks_));
 	AddBlockMap(num_blocks_);
 
@@ -541,7 +541,8 @@ void JitBlockCache::DestroyBlock(int block_num, DestroyType type) {
 	if (b->checkedEntry) {
 		// We can skip this if we're clearing anyway, which cuts down on protect back and forth on WX exclusive.
 		if (type != DestroyType::CLEAR) {
-			MIPSComp::jit->UnlinkBlock(b->checkedEntry, b->originalAddress);
+			u8 *writableEntry = codeBlock_->GetWritablePtrFromCodePtr(b->checkedEntry);
+			MIPSComp::jit->UnlinkBlock(writableEntry, b->originalAddress);
 		}
 	} else {
 		ERROR_LOG(JIT, "Unlinking block with no entry: %08x (%d)", b->originalAddress, block_num);

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -59,7 +59,7 @@ enum class DestroyType {
 struct JitBlock {
 	bool ContainsAddress(u32 em_address);
 
-	u8 *checkedEntry;  // not const, may need to write through this to unlink
+	const u8 *checkedEntry;  // const, we have to translate to writable.
 	const u8 *normalEntry;
 
 	u8 *exitPtrs[MAX_JIT_BLOCK_EXITS];      // to be able to rewrite the exit jump

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -335,7 +335,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 	js.PrefixStart();
 
 	// We add a check before the block, used when entering from a linked block.
-	b->checkedEntry = (u8 *)GetCodePtr();
+	b->checkedEntry = GetCodePtr();
 	// Downcount flag check. The last block decremented downcounter, and the flag should still be available.
 	FixupBranch skip = J_CC(CC_NS);
 	MOV(32, MIPSSTATE_VAR(pc), Imm32(js.blockStart));

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -285,7 +285,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		if (!CompileStep(dec, i)) {
 			EndWrite();
 			// Reset the code ptr and return zero to indicate that we failed.
-			SetCodePtr(const_cast<u8 *>(start));
+			ResetCodePtr(GetOffset(start));
 			char temp[1024] = {0};
 			dec.ToString(temp);
 			INFO_LOG(G3D, "Could not compile vertex decoder: %s", temp);

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -248,7 +248,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		if (!CompileStep(dec, i)) {
 			EndWrite();
 			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
-			SetCodePtr(const_cast<u8 *>(start));
+			ResetCodePtr(GetOffset(start));
 			char temp[1024] = {0};
 			dec.ToString(temp);
 			ERROR_LOG(G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -251,7 +251,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		if (!CompileStep(dec, i)) {
 			EndWrite();
 			// Reset the code ptr and return zero to indicate that we failed.
-			SetCodePtr(const_cast<u8 *>(start));
+			ResetCodePtr(GetOffset(start));
 			return 0;
 		}
 	}

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -79,7 +79,7 @@ NearestFunc SamplerJitCache::Compile(const SamplerID &id) {
 
 	if (!Jit_ReadTextureFormat(id)) {
 		EndWrite();
-		SetCodePtr(const_cast<u8 *>(start));
+		ResetCodePtr(GetOffset(start));
 		return nullptr;
 	}
 
@@ -106,7 +106,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 
 	if (!Jit_ReadTextureFormat(id)) {
 		EndWrite();
-		SetCodePtr(const_cast<u8 *>(nearest));
+		ResetCodePtr(GetOffset(nearest));
 		return nullptr;
 	}
 

--- a/unittest/TestArm64Emitter.cpp
+++ b/unittest/TestArm64Emitter.cpp
@@ -38,7 +38,7 @@ bool TestArm64Emitter() {
 
 
 	u32 code[512];
-	ARM64XEmitter emitter((u8 *)code);
+	ARM64XEmitter emitter((u8 *)code, (u8 *)code);
 	ARM64FloatEmitter fp(&emitter);
 
 	emitter.MOVfromSP(X3);


### PR DESCRIPTION
We cheat and cast away the constness in several places.  Even though we have a concept of "writable" code pointers, we abuse it.

This changes that so we (at least in arm64) track a read and write pointer.  They could be the same (Android) or different (Switch).  This should simplify jit management for #12323 without requiring a global or hacks.

This does assume that the base pointers both use the same offsets, though.

@m4xw with these changes, you shouldn't need `activeJitController` anymore at all.  You should just be able to set `region = (u8 *)jitController.rx_addr;` and `writableRegion = (u8 *)jitController.rw_addr;` - everything else should just work.  I didn't have a way to test, though (which is why I didn't pull in the `Jit` etc.)

I'm hoping this may help the vertexjit problems.  I'm worried it gets confused when a block link happens after a vertexjit generation or something.

-[Unknown]