### PR TITLE
More audio buffering fixes (primarily affects SDL)

### DIFF
--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -19,15 +19,16 @@
 
 // 16 bit Stereo
 
-#define MAX_SAMPLES_DEFAULT (4096) // 2*64ms - had to double it for nVidia Shield which has huge buffers
-#define MAX_SAMPLES_EXTRA   (8192)
+// These must be powers of 2.
+#define MAX_BUFSIZE_DEFAULT (4096) // 2*64ms - had to double it for nVidia Shield which has huge buffers
+#define MAX_BUFSIZE_EXTRA   (8192)
 
-#define LOW_WATERMARK_DEFAULT   1680 // 40 ms
-#define LOW_WATERMARK_EXTRA 3360 // 80 ms
+#define TARGET_BUFSIZE_DEFAULT 1680 // 40 ms
+#define TARGET_BUFSIZE_EXTRA 3360 // 80 ms
 
-#define MAX_FREQ_SHIFT  200  // per 32000 Hz
+#define MAX_FREQ_SHIFT  600.0f  // how far off can we be from 44100 Hz
 #define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
-#define CONTROL_AVG     32
+#define CONTROL_AVG     32.0f
 
 #include <cstring>
 #include <atomic>
@@ -56,10 +57,10 @@
 #endif
 
 StereoResampler::StereoResampler()
-		: m_bufsize(MAX_SAMPLES_DEFAULT)
-	  , m_lowwatermark(LOW_WATERMARK_DEFAULT) {
+		: m_maxBufsize(MAX_BUFSIZE_DEFAULT)
+	  , m_targetBufsize(TARGET_BUFSIZE_DEFAULT) {
 	// Need to have space for the worst case in case it changes.
-	m_buffer = new int16_t[MAX_SAMPLES_EXTRA * 2]();
+	m_buffer = new int16_t[MAX_BUFSIZE_EXTRA * 2]();
 
 	// Some Android devices are v-synced to non-60Hz framerates. We simply timestretch audio to fit.
 	// TODO: should only do this if auto frameskip is off?
@@ -82,11 +83,11 @@ StereoResampler::~StereoResampler() {
 
 void StereoResampler::UpdateBufferSize() {
 	if (g_Config.bExtraAudioBuffering) {
-		m_bufsize = MAX_SAMPLES_EXTRA;
-		m_lowwatermark = LOW_WATERMARK_EXTRA;
+		m_maxBufsize = MAX_BUFSIZE_EXTRA;
+		m_targetBufsize = TARGET_BUFSIZE_EXTRA;
 	} else {
-		m_bufsize = MAX_SAMPLES_DEFAULT;
-		m_lowwatermark = LOW_WATERMARK_DEFAULT;
+		m_maxBufsize = MAX_BUFSIZE_DEFAULT;
+		m_targetBufsize = TARGET_BUFSIZE_DEFAULT;
 	}
 }
 
@@ -148,10 +149,10 @@ inline void ClampBufferToS16WithVolume(s16 *out, const s32 *in, size_t size) {
 }
 
 void StereoResampler::Clear() {
-	memset(m_buffer, 0, m_bufsize * 2 * sizeof(int16_t));
+	memset(m_buffer, 0, m_maxBufsize * 2 * sizeof(int16_t));
 }
 
-// Executed from sound stream thread
+// Executed from sound stream thread, pulling sound out of the buffer.
 unsigned int StereoResampler::Mix(short* samples, unsigned int numSamples, bool consider_framelimit, int sample_rate) {
 	if (!samples)
 		return 0;
@@ -162,13 +163,18 @@ unsigned int StereoResampler::Mix(short* samples, unsigned int numSamples, bool 
 	// This is the only function changing the read value, so it's safe to
 	// cache it locally although it's written here.
 	// The writing pointer will be modified outside, but it will only increase,
-	// so we will just ignore new written data while interpolating.
+	// so we will just ignore new written data while interpolating (until it wraps...).
 	// Without this cache, the compiler wouldn't be allowed to optimize the
 	// interpolation loop.
 	u32 indexR = m_indexR.load();
 	u32 indexW = m_indexW.load();
 
-	const int INDEX_MASK = (m_bufsize * 2 - 1);
+	//if (realSamples != numSamples * 2) {
+	//	ILOG("Underrun! %i / %i", realSamples / 2, numSamples);
+	//}
+
+	const int INDEX_MASK = (m_maxBufsize * 2 - 1);
+	lastBufSize_ = (indexR - m_indexW) & INDEX_MASK;
 
 	// We force on the audio resampler if the output sample rate doesn't match the input.
 	if (!g_Config.bAudioResampler && sample_rate == (int)m_input_sample_rate) {
@@ -179,18 +185,32 @@ unsigned int StereoResampler::Mix(short* samples, unsigned int numSamples, bool 
 			samples[currentSample + 1] = r1;
 			indexR += 2;
 		}
-		sample_rate_ = (float)sample_rate;
+		output_sample_rate_ = (float)sample_rate;
+		droppedSamples_ = 0;
 	} else {
-		// Drift prevention mechanism
+		// Drift prevention mechanism.
 		float numLeft = (float)(((indexW - indexR) & INDEX_MASK) / 2);
-		m_numLeftI = (numLeft + m_numLeftI*(CONTROL_AVG - 1)) / CONTROL_AVG;
-		float offset = (m_numLeftI - m_lowwatermark) * CONTROL_FACTOR;
+		// If we had to discard samples the last frame due to underrun,
+		// apply an adjustment here. Otherwise we'll overestimate how many
+		// samples we need.
+		numLeft -= droppedSamples_;
+		droppedSamples_ = 0;
+
+		// m_numLeftI here becomes a lowpass filtered version of numLeft.
+		m_numLeftI = (numLeft + m_numLeftI * (CONTROL_AVG - 1.0f)) / CONTROL_AVG;
+
+		// Here we try to keep the buffer size around m_lowwatermark (which is
+		// really now more like desired_buffer_size) by adjusting the speed.
+		// Note that the speed of adjustment here does not take the buffer size into
+		// account. Since this is called once per "output frame", the frame size
+		// will affect how fast this algorithm reacts, which can't be a good thing.
+		float offset = (m_numLeftI - (float)m_targetBufsize) * CONTROL_FACTOR;
 		if (offset > MAX_FREQ_SHIFT) offset = MAX_FREQ_SHIFT;
 		if (offset < -MAX_FREQ_SHIFT) offset = -MAX_FREQ_SHIFT;
 
-		sample_rate_ = (float)(m_input_sample_rate + offset);
-		const u32 ratio = (u32)(65536.0 * sample_rate_ / (double)sample_rate);
-
+		output_sample_rate_ = (float)(m_input_sample_rate + offset);
+		const u32 ratio = (u32)(65536.0 * output_sample_rate_ / (double)sample_rate);
+		ratio_ = ratio;
 		// TODO: consider a higher-quality resampling algorithm.
 		// TODO: Add a fast path for 1:1.
 		for (; currentSample < numSamples * 2 && ((indexW - indexR) & INDEX_MASK) > 2; currentSample += 2) {
@@ -228,49 +248,45 @@ unsigned int StereoResampler::Mix(short* samples, unsigned int numSamples, bool 
 	// Flush cached variable
 	m_indexR.store(indexR);
 
-	//if (realSamples != numSamples * 2) {
-	//	ILOG("Underrun! %i / %i", realSamples / 2, numSamples);
-	//}
-	lastBufSize_ = (m_indexW - m_indexR) & INDEX_MASK;
-
 	return realSamples / 2;
 }
 
-void StereoResampler::PushSamples(const s32 *samples, unsigned int num_samples) {
-	inputSampleCount_ += num_samples;
+// Executes on the emulator thread, pushing sound into the buffer.
+void StereoResampler::PushSamples(const s32 *samples, unsigned int numSamples) {
+	inputSampleCount_ += numSamples;
 
 	UpdateBufferSize();
-	const int INDEX_MASK = (m_bufsize * 2 - 1);
+	const int INDEX_MASK = (m_maxBufsize * 2 - 1);
 	// Cache access in non-volatile variable
 	// indexR isn't allowed to cache in the audio throttling loop as it
 	// needs to get updates to not deadlock.
 	u32 indexW = m_indexW.load();
 
-	u32 cap = m_bufsize * 2;
+	u32 cap = m_maxBufsize * 2;
 	// If unthrottling, no need to fill up the entire buffer, just screws up timing after releasing unthrottle.
 	if (PSP_CoreParameter().unthrottle) {
-		cap = m_lowwatermark * 2;
+		cap = m_targetBufsize * 2;
 	}
 
 	// Check if we have enough free space
 	// indexW == m_indexR results in empty buffer, so indexR must always be smaller than indexW
-	if (num_samples * 2 + ((indexW - m_indexR.load()) & INDEX_MASK) >= cap) {
+	if (numSamples * 2 + ((indexW - m_indexR.load()) & INDEX_MASK) >= cap) {
 		if (!PSP_CoreParameter().unthrottle)
 			overrunCount_++;
 		// TODO: "Timestretch" by doing a windowed overlap with existing buffer content?
 		return;
 	}
 
-	int over_bytes = num_samples * 4 - (m_bufsize * 2 - (indexW & INDEX_MASK)) * sizeof(short);
+	int over_bytes = numSamples * 4 - (m_maxBufsize * 2 - (indexW & INDEX_MASK)) * sizeof(short);
 	if (over_bytes > 0) {
-		ClampBufferToS16WithVolume(&m_buffer[indexW & INDEX_MASK], samples, (num_samples * 4 - over_bytes) / 2);
-		ClampBufferToS16WithVolume(&m_buffer[0], samples + (num_samples * 4 - over_bytes) / sizeof(short), over_bytes / 2);
+		ClampBufferToS16WithVolume(&m_buffer[indexW & INDEX_MASK], samples, (numSamples * 4 - over_bytes) / 2);
+		ClampBufferToS16WithVolume(&m_buffer[0], samples + (numSamples * 4 - over_bytes) / sizeof(short), over_bytes / 2);
 	} else {
-		ClampBufferToS16WithVolume(&m_buffer[indexW & INDEX_MASK], samples, num_samples * 2);
+		ClampBufferToS16WithVolume(&m_buffer[indexW & INDEX_MASK], samples, numSamples * 2);
 	}
 
-	m_indexW += num_samples * 2;
-	lastPushSize_ = num_samples;
+	m_indexW += numSamples * 2;
+	lastPushSize_ = numSamples;
 }
 
 void StereoResampler::GetAudioDebugStats(char *buf, size_t bufSize) {
@@ -279,23 +295,27 @@ void StereoResampler::GetAudioDebugStats(char *buf, size_t bufSize) {
 	double effective_input_sample_rate = (double)inputSampleCount_ / elapsed;
 	double effective_output_sample_rate = (double)outputSampleCount_ / elapsed;
 	snprintf(buf, bufSize,
-		"Audio buffer: %d/%d (low watermark: %d)\n"
+		"Audio buffer: %d/%d (target: %d)\n"
+		"Filtered: %0.2f\n"
 		"Underruns: %d\n"
 		"Overruns: %d\n"
 		"Sample rate: %d (input: %d)\n"
 		"Effective input sample rate: %0.2f\n"
 		"Effective output sample rate: %0.2f\n"
-		"Push size: %d\n",
+		"Push size: %d\n"
+		"Ratio: %0.6f\n",
 		lastBufSize_,
-		m_bufsize * 2,
-		m_lowwatermark,
+		m_maxBufsize,
+		m_targetBufsize,
+		m_numLeftI,
 		underrunCountTotal_,
 		overrunCountTotal_,
-		(int)sample_rate_,
+		(int)output_sample_rate_,
 		m_input_sample_rate,
 		effective_input_sample_rate,
 		effective_output_sample_rate,
-		lastPushSize_);
+		lastPushSize_,
+		(float)ratio_ / 65536.0f);
 	underrunCountTotal_ += underrunCount_;
 	overrunCountTotal_ += overrunCount_;
 	underrunCount_ = 0;

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -46,9 +46,8 @@ public:
 	void GetAudioDebugStats(char *buf, size_t bufSize);
 	void ResetStatCounters();
 
-protected:
+private:
 	void UpdateBufferSize();
-	void SetInputSampleRate(unsigned int rate);
 
 	int m_maxBufsize;
 	int m_targetBufsize;

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <string>
+#include <cstdint>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -57,11 +57,17 @@ protected:
 	volatile u32 m_indexR = 0;
 	float m_numLeftI = 0.0f;
 	u32 m_frac = 0;
+	float sample_rate_ = 0.0;
+	int lastBufSize_ = 0;
+	int lastPushSize_ = 0;
+
 	int underrunCount_ = 0;
 	int overrunCount_ = 0;
 	int underrunCountTotal_ = 0;
 	int overrunCountTotal_ = 0;
-	float sample_rate_ = 0.0;
-	int lastBufSize_ = 0;
-	int lastPushSize_ = 0;
+
+	int64_t inputSampleCount_ = 0;
+	int64_t outputSampleCount_ = 0;
+
+	double startTime_ = 0.0;
 };

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdint>
+#include <atomic>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -53,8 +54,8 @@ protected:
 	int m_lowwatermark;
 	unsigned int m_input_sample_rate = 44100;
 	int16_t *m_buffer;
-	volatile u32 m_indexW = 0;
-	volatile u32 m_indexR = 0;
+	std::atomic<u32> m_indexW;
+	std::atomic<u32> m_indexR;
 	float m_numLeftI = 0.0f;
 	u32 m_frac = 0;
 	float sample_rate_ = 0.0;

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -50,22 +50,27 @@ protected:
 	void UpdateBufferSize();
 	void SetInputSampleRate(unsigned int rate);
 
-	int m_bufsize;
-	int m_lowwatermark;
+	int m_maxBufsize;
+	int m_targetBufsize;
+
 	unsigned int m_input_sample_rate = 44100;
 	int16_t *m_buffer;
 	std::atomic<u32> m_indexW;
 	std::atomic<u32> m_indexR;
 	float m_numLeftI = 0.0f;
+
 	u32 m_frac = 0;
-	float sample_rate_ = 0.0;
+	float output_sample_rate_ = 0.0;
 	int lastBufSize_ = 0;
 	int lastPushSize_ = 0;
+	u32 ratio_ = 0;
 
 	int underrunCount_ = 0;
 	int overrunCount_ = 0;
 	int underrunCountTotal_ = 0;
 	int overrunCountTotal_ = 0;
+
+	int droppedSamples_ = 0;
 
 	int64_t inputSampleCount_ = 0;
 	int64_t outputSampleCount_ = 0;

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -48,6 +48,8 @@ static int browseFileEvent = -1;
 static int browseFolderEvent = -1;
 QTCamera *qtcamera = nullptr;
 
+SDL_AudioSpec g_retFmt;
+
 #ifdef SDL
 static SDL_AudioDeviceID audioDev = 0;
 
@@ -56,35 +58,35 @@ extern void mixaudio(void *userdata, Uint8 *stream, int len) {
 }
 
 static void InitSDLAudioDevice() {
-	SDL_AudioSpec fmt, ret_fmt;
+	SDL_AudioSpec fmt;
 	memset(&fmt, 0, sizeof(fmt));
 	fmt.freq = 44100;
 	fmt.format = AUDIO_S16;
 	fmt.channels = 2;
-	fmt.samples = 2048;
+	fmt.samples = 1024;
 	fmt.callback = &mixaudio;
 	fmt.userdata = nullptr;
 
 	audioDev = 0;
 	if (!g_Config.sAudioDevice.empty()) {
-		audioDev = SDL_OpenAudioDevice(g_Config.sAudioDevice.c_str(), 0, &fmt, &ret_fmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+		audioDev = SDL_OpenAudioDevice(g_Config.sAudioDevice.c_str(), 0, &fmt, &g_retFmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 		if (audioDev <= 0) {
 			WLOG("Failed to open preferred audio device %s", g_Config.sAudioDevice.c_str());
 		}
 	}
 	if (audioDev <= 0) {
-		audioDev = SDL_OpenAudioDevice(nullptr, 0, &fmt, &ret_fmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+		audioDev = SDL_OpenAudioDevice(nullptr, 0, &fmt, &g_retFmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	}
 	if (audioDev <= 0) {
 		ELOG("Failed to open audio: %s", SDL_GetError());
 	} else {
-		if (ret_fmt.samples != fmt.samples) // Notify, but still use it
-			ELOG("Output audio samples: %d (requested: %d)", ret_fmt.samples, fmt.samples);
-		if (ret_fmt.freq != fmt.freq || ret_fmt.format != fmt.format || ret_fmt.channels != fmt.channels) {
+		if (g_retFmt.samples != fmt.samples) // Notify, but still use it
+			ELOG("Output audio samples: %d (requested: %d)", g_retFmt.samples, fmt.samples);
+		if (g_retFmt.format != fmt.format || g_retFmt.channels != fmt.channels) {
 			ELOG("Sound buffer format does not match requested format.");
-			ELOG("Output audio freq: %d (requested: %d)", ret_fmt.freq, fmt.freq);
-			ELOG("Output audio format: %d (requested: %d)", ret_fmt.format, fmt.format);
-			ELOG("Output audio channels: %d (requested: %d)", ret_fmt.channels, fmt.channels);
+			ELOG("Output audio freq: %d (requested: %d)", g_retFmt.freq, fmt.freq);
+			ELOG("Output audio format: %d (requested: %d)", g_retFmt.format, fmt.format);
+			ELOG("Output audio channels: %d (requested: %d)", g_retFmt.channels, fmt.channels);
 			ELOG("Provided output format does not match requirement, turning audio off");
 			SDL_CloseAudioDevice(audioDev);
 		}
@@ -146,7 +148,9 @@ std::string System_GetProperty(SystemProperty prop) {
 int System_GetPropertyInt(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_AUDIO_SAMPLE_RATE:
-		return 44100;
+		return g_retFmt.freq;
+	case SYSPROP_AUDIO_FRAMES_PER_BUFFER:
+		return g_retFmt.samples;
 	case SYSPROP_DEVICE_TYPE:
 #if defined(__ANDROID__)
 		return DEVICE_TYPE_MOBILE;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -97,7 +97,7 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 	fmt.freq = 44100;
 	fmt.format = AUDIO_S16;
 	fmt.channels = 2;
-	fmt.samples = 2048;
+	fmt.samples = 1024;
 	fmt.callback = &sdl_mixaudio_callback;
 	fmt.userdata = nullptr;
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -84,8 +84,8 @@ int getDisplayNumber(void) {
 	return displayNumber;
 }
 
-extern void mixaudio(void *userdata, Uint8 *stream, int len) {
-	NativeMix((short *)stream, len / 4);
+void sdl_mixaudio_callback(void *userdata, Uint8 *stream, int len) {
+	NativeMix((short *)stream, len / (2 * 2));
 }
 
 static SDL_AudioDeviceID audioDev = 0;
@@ -98,7 +98,7 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 	fmt.format = AUDIO_S16;
 	fmt.channels = 2;
 	fmt.samples = 2048;
-	fmt.callback = &mixaudio;
+	fmt.callback = &sdl_mixaudio_callback;
 	fmt.userdata = nullptr;
 
 	std::string startDevice = name;
@@ -122,7 +122,7 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 	} else {
 		if (g_retFmt.samples != fmt.samples) // Notify, but still use it
 			ELOG("Output audio samples: %d (requested: %d)", g_retFmt.samples, fmt.samples);
-		if (g_retFmt.freq != fmt.freq || g_retFmt.format != fmt.format || g_retFmt.channels != fmt.channels) {
+		if (g_retFmt.format != fmt.format || g_retFmt.channels != fmt.channels) {
 			ELOG("Sound buffer format does not match requested format.");
 			ELOG("Output audio freq: %d (requested: %d)", g_retFmt.freq, fmt.freq);
 			ELOG("Output audio format: %d (requested: %d)", g_retFmt.format, fmt.format);


### PR DESCRIPTION
Started with the assumption that something was wrong with the rate adjustment logic, but couldn't find anything, just bad variable names not describing what was going on. Instead it turned out that the target buffer size (which is what lowwatermark really was) simply was lower than the default buffer size in SDL, which can never work reliably, leading to #12705. 

Eventually ended up clamping the target buffer size so it's always larger than the SDL buffer size with some margin, and also reduced the SDL buffer size from 2048 to 1024.

So this change could have been a bit smaller but I want to keep the renaming and minor refactorings I did.

I want to later change to SDL_QueueAudio but really wanted to get this solid first.

Ported the changes to the SDL audio code used by Qt, too (we should really share that...)

Fixes #12705 , hopefully.