### PR TITLE
Centralize a bit, track render pass dependencies better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1070,6 +1070,7 @@ add_library(native STATIC
 	ext/native/util/text/wrap_text.h
 	ext/native/util/text/wrap_text.cpp
 	ext/native/util/const_map.h
+	ext/native/util/tiny_set.h
 	ext/native/ext/jpge/jpgd.cpp
 	ext/native/ext/jpge/jpgd.h
 	ext/native/ext/jpge/jpge.cpp

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -339,7 +339,7 @@ protected:
 	void DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb);
 	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp);
 	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
-	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) = 0;
+	virtual bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb);
 	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) = 0;
 
 	VirtualFramebuffer *CreateRAMFramebuffer(uint32_t fbAddress, int width, int height, int stride, GEBufferFormat format);

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -366,19 +366,6 @@ void FramebufferManagerD3D11::BindFramebufferAsColorTexture(int stage, VirtualFr
 	}
 }
 
-bool FramebufferManagerD3D11::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
-	nvfb->colorDepth = Draw::FBO_8888;
-
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
-	if (!(nvfb->fbo)) {
-		ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
-		return false;
-	}
-
-	draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });
-	return true;
-}
-
 void FramebufferManagerD3D11::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	// Nothing to do here.
 }

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -60,7 +60,6 @@ protected:
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:

--- a/GPU/Directx9/FramebufferDX9.cpp
+++ b/GPU/Directx9/FramebufferDX9.cpp
@@ -379,19 +379,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 		}
 	}
 
-	bool FramebufferManagerDX9::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
-		nvfb->colorDepth = Draw::FBO_8888;
-
-		nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
-		if (!(nvfb->fbo)) {
-			ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
-			return false;
-		}
-
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });
-		return true;
-	}
-
 	void FramebufferManagerDX9::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 		// Nothing to do here.
 	}

--- a/GPU/Directx9/FramebufferDX9.h
+++ b/GPU/Directx9/FramebufferDX9.h
@@ -71,7 +71,6 @@ protected:
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -317,7 +317,7 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 	_assert_msg_(G3D, nvfb->fbo, "Expecting a valid nvfb in UpdateDownloadTempBuffer");
 
 	// Discard the previous contents of this buffer where possible.
-	if (gl_extensions.GLES3 && glInvalidateFramebuffer != nullptr) {
+	if (gl_extensions.GLES3) {
 		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE });
 	} else if (gl_extensions.IsGLES) {
 		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -313,34 +313,6 @@ void FramebufferManagerGLES::BindFramebufferAsColorTexture(int stage, VirtualFra
 	}
 }
 
-bool FramebufferManagerGLES::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
-	// When updating VRAM, it need to be exact format.
-	if (!gstate_c.Supports(GPU_PREFER_CPU_DOWNLOAD)) {
-		switch (nvfb->format) {
-		case GE_FORMAT_4444:
-			nvfb->colorDepth = Draw::FBO_4444;
-			break;
-		case GE_FORMAT_5551:
-			nvfb->colorDepth = Draw::FBO_5551;
-			break;
-		case GE_FORMAT_565:
-			nvfb->colorDepth = Draw::FBO_565;
-			break;
-		case GE_FORMAT_8888:
-		default:
-			nvfb->colorDepth = Draw::FBO_8888;
-			break;
-		}
-	}
-
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, false, (Draw::FBColorDepth)nvfb->colorDepth });
-	if (!nvfb->fbo) {
-		ERROR_LOG(FRAMEBUF, "Error creating GL FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
-		return false;
-	}
-	return true;
-}
-
 void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	_assert_msg_(G3D, nvfb->fbo, "Expecting a valid nvfb in UpdateDownloadTempBuffer");
 

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -64,7 +64,6 @@ protected:
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
 
-	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:

--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -325,19 +325,6 @@ VkImageView FramebufferManagerVulkan::BindFramebufferAsColorTexture(int stage, V
 	}
 }
 
-bool FramebufferManagerVulkan::CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
-	nvfb->colorDepth = Draw::FBO_8888;
-
-	nvfb->fbo = draw_->CreateFramebuffer({ nvfb->bufferWidth, nvfb->bufferHeight, 1, 1, true, (Draw::FBColorDepth)nvfb->colorDepth });
-	if (!(nvfb->fbo)) {
-		ERROR_LOG(FRAMEBUF, "Error creating FBO! %i x %i", nvfb->renderWidth, nvfb->renderHeight);
-		return false;
-	}
-
-	draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR });
-	return true;
-}
-
 void FramebufferManagerVulkan::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
 	// Nothing to do here.
 }

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -71,7 +71,6 @@ protected:
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) override;
-	bool CreateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
 
 private:

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -231,6 +231,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_INSTANCE_RENDERING;
 	features |= GPU_SUPPORTS_VERTEX_TEXTURE_FETCH;
 	features |= GPU_SUPPORTS_TEXTURE_FLOAT;
+	features |= GPU_PREFER_CPU_DOWNLOAD;
 
 	if (vulkan_->GetDeviceFeatures().enabled.wideLines) {
 		features |= GPU_SUPPORTS_WIDE_LINES;

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -489,6 +489,7 @@
     <ClInclude Include="util\text\shiftjis.h" />
     <ClInclude Include="util\text\utf16.h" />
     <ClInclude Include="util\text\utf8.h" />
+    <ClInclude Include="util\tiny_set.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="base\backtrace.cpp" />

--- a/ext/native/native.vcxproj.filters
+++ b/ext/native/native.vcxproj.filters
@@ -350,6 +350,9 @@
     <ClInclude Include="ui\root.h">
       <Filter>ui</Filter>
     </ClInclude>
+    <ClInclude Include="util\tiny_set.h">
+      <Filter>util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -827,13 +827,14 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 		{
 			GLenum attachments[3];
 			int count = 0;
-			bool hasDepth = step.render.framebuffer ? step.render.framebuffer->z_stencil_ : false;
+			bool isFBO = step.render.framebuffer != nullptr;
+			bool hasDepth = isFBO ? step.render.framebuffer->z_stencil_ : false;
 			if (c.clear.clearMask & GL_COLOR_BUFFER_BIT)
-				attachments[count++] = GL_COLOR_ATTACHMENT0;
+				attachments[count++] = isFBO ? GL_COLOR_ATTACHMENT0 : GL_COLOR;
 			if (hasDepth && (c.clear.clearMask & GL_DEPTH_BUFFER_BIT))
-				attachments[count++] = GL_DEPTH_ATTACHMENT;
+				attachments[count++] = isFBO ? GL_DEPTH_ATTACHMENT : GL_DEPTH;
 			if (hasDepth && (c.clear.clearMask & GL_STENCIL_BUFFER_BIT))
-				attachments[count++] = GL_STENCIL_BUFFER_BIT;
+				attachments[count++] = isFBO ? GL_STENCIL_ATTACHMENT : GL_STENCIL;
 			if (glInvalidateFramebuffer != nullptr && count != 0)
 				glInvalidateFramebuffer(GL_FRAMEBUFFER, count, attachments);
 			CHECK_GL_ERROR_IF_DEBUG();

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -827,13 +827,15 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 		{
 			GLenum attachments[3];
 			int count = 0;
+			bool hasDepth = step.render.framebuffer ? step.render.framebuffer->z_stencil_ : false;
 			if (c.clear.clearMask & GL_COLOR_BUFFER_BIT)
 				attachments[count++] = GL_COLOR_ATTACHMENT0;
-			if (c.clear.clearMask & GL_DEPTH_BUFFER_BIT)
+			if (hasDepth && (c.clear.clearMask & GL_DEPTH_BUFFER_BIT))
 				attachments[count++] = GL_DEPTH_ATTACHMENT;
-			if (c.clear.clearMask & GL_STENCIL_BUFFER_BIT)
+			if (hasDepth && (c.clear.clearMask & GL_STENCIL_BUFFER_BIT))
 				attachments[count++] = GL_STENCIL_BUFFER_BIT;
-			glInvalidateFramebuffer(GL_FRAMEBUFFER, count, attachments);
+			if (glInvalidateFramebuffer != nullptr && count != 0)
+				glInvalidateFramebuffer(GL_FRAMEBUFFER, count, attachments);
 			CHECK_GL_ERROR_IF_DEBUG();
 			break;
 		}

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -6,6 +6,7 @@
 
 #include "gfx/gl_common.h"
 #include "thin3d/DataFormat.h"
+#include "util/tiny_set.h"
 
 struct GLRViewport {
 	float x, y, w, h, minZ, maxZ;
@@ -295,9 +296,14 @@ struct GLRStep {
 	GLRStep(GLRStepType _type) : stepType(_type) {}
 	GLRStepType stepType;
 	std::vector<GLRRenderData> commands;
+	TinySet<const GLRFramebuffer *, 8> dependencies;
 	union {
 		struct {
 			GLRFramebuffer *framebuffer;
+			GLRRenderPassAction color;
+			GLRRenderPassAction depth;
+			GLRRenderPassAction stencil;
+			// Note: not accurate.
 			int numDraws;
 		} render;
 		struct {

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -6,6 +6,7 @@
 #include "Common/Vulkan/VulkanContext.h"
 #include "math/dataconv.h"
 #include "thin3d/DataFormat.h"
+#include "util/tiny_set.h"
 
 class VKRFramebuffer;
 struct VKRImage;
@@ -15,70 +16,6 @@ enum {
 	QUEUE_HACK_SONIC = 2,
 	// Killzone PR = 4.
 	QUEUE_HACK_RENDERPASS_MERGE = 8,
-};
-
-// Insert-only small-set implementation. Performs no allocation unless MaxFastSize is exceeded.
-template <class T, int MaxFastSize>
-struct TinySet {
-	~TinySet() { delete slowLookup_; }
-	inline void insert(T t) {
-		// Fast linear scan.
-		for (int i = 0; i < fastCount; i++) {
-			if (fastLookup_[i] == t)
-				return;  // We already have it.
-		}
-		// Fast insertion
-		if (fastCount < MaxFastSize) {
-			fastLookup_[fastCount++] = t;
-			return;
-		}
-		// Fall back to slow path.
-		insertSlow(t);
-	}
-	bool contains(T t) const {
-		for (int i = 0; i < fastCount; i++) {
-			if (fastLookup_[i] == t)
-				return true;
-		}
-		if (slowLookup_) {
-			for (auto x : *slowLookup_) {
-				if (x == t)
-					return true;
-			}
-		}
-		return false;
-	}
-	bool contains(const TinySet<T, MaxFastSize> &otherSet) {
-		// Awkward, kind of ruins the fun.
-		for (int i = 0; i < fastCount; i++) {
-			if (otherSet.contains(fastLookup_[i]))
-				return true;
-		}
-		if (slowLookup_) {
-			for (auto x : *slowLookup_) {
-				if (otherSet.contains(x))
-					return true;
-			}
-		}
-		return false;
-	}
-
-private:
-	void insertSlow(T t) {
-		if (!slowLookup_) {
-			slowLookup_ = new std::vector<T>();
-		} else {
-			for (size_t i = 0; i < slowLookup_->size(); i++) {
-				if ((*slowLookup_)[i] == t)
-					return;
-			}
-		}
-		slowLookup_->push_back(t);
-	}
-	T fastLookup_[MaxFastSize];
-	int fastCount = 0;
-	int slowCount = 0;
-	std::vector<T> *slowLookup_ = nullptr;
 };
 
 enum class VKRRenderCommand : uint8_t {

--- a/ext/native/util/tiny_set.h
+++ b/ext/native/util/tiny_set.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <vector>
+
+// Insert-only small-set implementation. Performs no allocation unless MaxFastSize is exceeded.
+template <class T, int MaxFastSize>
+struct TinySet {
+	~TinySet() { delete slowLookup_; }
+	inline void insert(T t) {
+		// Fast linear scan.
+		for (int i = 0; i < fastCount; i++) {
+			if (fastLookup_[i] == t)
+				return;  // We already have it.
+		}
+		// Fast insertion
+		if (fastCount < MaxFastSize) {
+			fastLookup_[fastCount++] = t;
+			return;
+		}
+		// Fall back to slow path.
+		insertSlow(t);
+	}
+	bool contains(T t) const {
+		for (int i = 0; i < fastCount; i++) {
+			if (fastLookup_[i] == t)
+				return true;
+		}
+		if (slowLookup_) {
+			for (auto x : *slowLookup_) {
+				if (x == t)
+					return true;
+			}
+		}
+		return false;
+	}
+	bool contains(const TinySet<T, MaxFastSize> &otherSet) {
+		// Awkward, kind of ruins the fun.
+		for (int i = 0; i < fastCount; i++) {
+			if (otherSet.contains(fastLookup_[i]))
+				return true;
+		}
+		if (slowLookup_) {
+			for (auto x : *slowLookup_) {
+				if (otherSet.contains(x))
+					return true;
+			}
+		}
+		return false;
+	}
+
+private:
+	void insertSlow(T t) {
+		if (!slowLookup_) {
+			slowLookup_ = new std::vector<T>();
+		} else {
+			for (size_t i = 0; i < slowLookup_->size(); i++) {
+				if ((*slowLookup_)[i] == t)
+					return;
+			}
+		}
+		slowLookup_->push_back(t);
+	}
+	T fastLookup_[MaxFastSize];
+	int fastCount = 0;
+	int slowCount = 0;
+	std::vector<T> *slowLookup_ = nullptr;
+};

--- a/ext/native/util/tiny_set.h
+++ b/ext/native/util/tiny_set.h
@@ -47,6 +47,11 @@ struct TinySet {
 		}
 		return false;
 	}
+	void clear() {
+		delete slowLookup_;
+		slowLookup_ = nullptr;
+		fastCount = 0;
+	}
 
 private:
 	void insertSlow(T t) {
@@ -62,6 +67,5 @@ private:
 	}
 	T fastLookup_[MaxFastSize];
 	int fastCount = 0;
-	int slowCount = 0;
 	std::vector<T> *slowLookup_ = nullptr;
 };


### PR DESCRIPTION
This takes most of the original #12913, without actually doing any invalidation on GLES.

While this changes INVALIDATE, nothing actually triggers that right now.  Also it was buggy and wrong before (used the wrong bits for stencil, etc.)  No reason to keep it wrong.

This also keeps the dependency tracking added to GLES, but doesn't use it for anything yet.

-[Unknown]