### PR TITLE
Vulkan: Create FB compatible pipelines in Draw

### DIFF
--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -352,6 +352,7 @@ Draw::Pipeline *PresentationCommon::CreatePipeline(std::vector<Draw::ShaderModul
 
 void PresentationCommon::CreateDeviceObjects() {
 	using namespace Draw;
+	assert(vdata_ == nullptr);
 
 	vdata_ = draw_->CreateBuffer(sizeof(Vertex) * 8, BufferUsageFlag::DYNAMIC | BufferUsageFlag::VERTEXDATA);
 

--- a/GPU/Vulkan/FramebufferVulkan.h
+++ b/GPU/Vulkan/FramebufferVulkan.h
@@ -84,7 +84,6 @@ private:
 	TextureCacheVulkan *textureCacheVulkan_ = nullptr;
 	ShaderManagerVulkan *shaderManagerVulkan_ = nullptr;
 	DrawEngineVulkan *drawEngineVulkan_ = nullptr;
-	VulkanDeviceAllocator *allocator_ = nullptr;
 	VulkanPushBuffer *push_;
 
 	enum {


### PR DESCRIPTION
This just does the easy thing and creates both backbuffer and framebuffer passes at the same time.

Alternatively, we could potentially set a flag in the pipeline desc, not sure if it's worth the trouble?

-[Unknown]