### PR TITLE
Vulkan: Stencil initialization: Use the adreno path for Mali as well.

### DIFF
--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -24,7 +24,7 @@ static const std::vector<Draw::ShaderSource> fsDiscard = {
 	})"
 	},
 	{Draw::ShaderLanguage::GLSL_VULKAN,
-	R"(#version 140
+	R"(#version 450
 	#extension GL_ARB_separate_shader_objects : enable
 	#extension GL_ARB_shading_language_420pack : enable
 	layout(location = 0) in vec4 oColor0;


### PR DESCRIPTION
Appears to fix the Star Ocean issue and maybe more reported in #12890.

Strange though...