### PR TITLE
When debugging, expose pass tags to RenderDoc

### DIFF
--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -23,7 +23,7 @@
 #include "Common/Vulkan/VulkanDebug.h"
 #include "base/logging.h"
 
-const char *ObjTypeToString(VkDebugReportObjectTypeEXT type) {
+const char *VulkanObjTypeToString(VkDebugReportObjectTypeEXT type) {
 	switch (type) {
 	case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT: return "Instance";
 	case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT: return "PhysicalDevice";
@@ -71,7 +71,7 @@ VkBool32 VKAPI_CALL VulkanDebugReportCallback(VkDebugReportFlagsEXT msgFlags, Vk
 	} else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
 		message << "DEBUG: ";
 	}
-	message << "[" << pLayerPrefix << "] " << ObjTypeToString(objType) << " Code " << msgCode << " : " << pMsg << "\n";
+	message << "[" << pLayerPrefix << "] " << VulkanObjTypeToString(objType) << " Code " << msgCode << " : " << pMsg << "\n";
 
 	if (msgCode == 64)  // Another useless perf warning that will be seen less and less as we optimize -  vkCmdClearAttachments() issued on command buffer object 0x00000195296C6D40 prior to any Draw Cmds. It is recommended you use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.
 		return false;

--- a/Common/Vulkan/VulkanDebug.h
+++ b/Common/Vulkan/VulkanDebug.h
@@ -27,3 +27,5 @@ struct VulkanLogOptions {
 
 VkBool32 VKAPI_CALL VulkanDebugReportCallback(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData);
 VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData);
+
+const char *VulkanObjTypeToString(VkDebugReportObjectTypeEXT type);

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -3,8 +3,9 @@
 #include "AndroidVulkanContext.h"
 #include "base/NativeApp.h"
 #include "base/display.h"
-#include "Common/Vulkan/VulkanLoader.h"
 #include "Common/Vulkan/VulkanContext.h"
+#include "Common/Vulkan/VulkanDebug.h"
+#include "Common/Vulkan/VulkanLoader.h"
 #include "thin3d/VulkanRenderManager.h"
 #include "thin3d/thin3d_create.h"
 #include "util/text/parsers.h"
@@ -13,39 +14,6 @@
 #include "Core/System.h"
 
 static VulkanLogOptions g_LogOptions;
-
-const char *ObjTypeToString(VkDebugReportObjectTypeEXT type) {
-	switch (type) {
-	case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT: return "Instance";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT: return "PhysicalDevice";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT: return "Device";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT: return "Queue";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT: return "CommandBuffer";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT: return "DeviceMemory";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT: return "Buffer";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT: return "BufferView";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT: return "Image";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT: return "ImageView";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT: return "ShaderModule";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT: return "Pipeline";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT: return "PipelineLayout";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT: return "Sampler";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT: return "DescriptorSet";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT: return "DescriptorSetLayout";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT: return "DescriptorPool";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT: return "Fence";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT: return "Semaphore";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT: return "Event";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT: return "QueryPool";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT: return "Framebuffer";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT: return "RenderPass";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT: return "PipelineCache";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT: return "SurfaceKHR";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT: return "SwapChainKHR";
-	case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT: return "CommandPool";
-	default: return "Unknown";
-	}
-}
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject, size_t location, int32_t msgCode, const char* pLayerPrefix, const char* pMsg, void *pUserData) {
 	const VulkanLogOptions *options = (const VulkanLogOptions *)pUserData;
@@ -63,7 +31,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL Vulkan_Dbg(VkDebugReportFlagsEXT msgFlags,
 	}
 
 	__android_log_print(loglevel, APP_NAME, "[%s] %s Code %d : %s",
-						pLayerPrefix, ObjTypeToString(objType), msgCode, pMsg);
+						pLayerPrefix, VulkanObjTypeToString(objType), msgCode, pMsg);
 
 	// false indicates that layer should not bail-out of an
 	// API call that had validation failures. This may mean that the

--- a/android/jni/AndroidVulkanContext.h
+++ b/android/jni/AndroidVulkanContext.h
@@ -34,9 +34,3 @@ private:
 	VulkanContext *g_Vulkan = nullptr;
 	Draw::DrawContext *draw_ = nullptr;
 };
-
-struct VulkanLogOptions {
-	bool breakOnWarning;
-	bool breakOnError;
-	bool msgBoxOnError;
-};


### PR DESCRIPTION
See #12939.  Why not also expose to RenderDoc?

-[Unknown]