### PR TITLE
Make file open timing a bit more accurate

### DIFF
--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -109,7 +109,7 @@ int BlobFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 out
 }
 
 int BlobFileSystem::DevType(u32 handle) {
-	return -1;
+	return PSP_DEV_TYPE_FILE;
 }
 
 bool BlobFileSystem::MkDir(const std::string &dirname) {

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -108,8 +108,8 @@ int BlobFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 out
 	return -1;
 }
 
-int BlobFileSystem::DevType(u32 handle) {
-	return PSP_DEV_TYPE_FILE;
+PSPDevType BlobFileSystem::DevType(u32 handle) {
+	return PSPDevType::FILE;
 }
 
 bool BlobFileSystem::MkDir(const std::string &dirname) {

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -44,7 +44,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int      DevType(u32 handle) override;
-	int      Flags() override { return 0; }
+	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 
 	bool MkDir(const std::string &dirname) override;
 	bool RmDir(const std::string &dirname) override;

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -43,7 +43,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int      DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 
 	bool MkDir(const std::string &dirname) override;

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -44,7 +44,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int      DevType(u32 handle) override;
-	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
+	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 
 	bool MkDir(const std::string &dirname) override;
 	bool RmDir(const std::string &dirname) override;

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -45,6 +45,7 @@ public:
 	}
 	int GetBlockSize() const { return 2048;}  // forced, it cannot be changed by subclasses
 	virtual u32 GetNumBlocks() = 0;
+	virtual bool IsDisc() = 0;
 
 	u32 CalculateCRC();
 	void NotifyReadError();
@@ -60,6 +61,7 @@ public:
 	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() override { return numBlocks; }
+	bool IsDisc() override { return true; }
 
 private:
 	FileLoader *fileLoader_;
@@ -83,6 +85,7 @@ public:
 	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() override {return (u32)(filesize_ / GetBlockSize());}
+	bool IsDisc() override { return true; }
 
 private:
 	FileLoader *fileLoader_;
@@ -107,6 +110,7 @@ public:
 
 	bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) override;
 	u32 GetNumBlocks() override {return (u32)lbaSize;}
+	bool IsDisc() override { return false; }
 
 private:
 	FileLoader *fileLoader_;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -150,7 +150,7 @@ bool FixPathCase(const std::string &basePath, std::string &path, FixPathCaseBeha
 
 #endif
 
-DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, int _flags) : basePath(_basePath), flags(_flags) {
+DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, FileSystemFlags _flags) : basePath(_basePath), flags(_flags) {
 	File::CreateFullPath(basePath);
 	hAlloc = _hAlloc;
 }
@@ -874,7 +874,9 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 			entry.size = 4096;
 		else
 			entry.size = findData.nFileSizeLow | ((u64)findData.nFileSizeHigh<<32);
-		entry.name = SimulateVFATBug(ConvertWStringToUTF8(findData.cFileName));
+		entry.name = ConvertWStringToUTF8(findData.cFileName);
+		if (Flags() & FileSystemFlags::SIMULATE_FAT32)
+			entry.name = SimulateVFATBug(entry.name);
 
 		bool hideFile = false;
 		if (hideISOFiles && (endsWithNoCase(entry.name, ".cso") || endsWithNoCase(entry.name, ".iso"))) {
@@ -921,7 +923,9 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 		else
 			entry.type = FILETYPE_NORMAL;
 		entry.access = s.st_mode & 0x1FF;
-		entry.name = SimulateVFATBug(dirp->d_name);
+		entry.name = dirp->d_name;
+		if (Flags() & FileSystemFlags::SIMULATE_FAT32)
+			entry.name = SimulateVFATBug(entry.name);
 		entry.size = s.st_size;
 
 		bool hideFile = false;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -663,8 +663,8 @@ int DirectoryFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u3
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
-int DirectoryFileSystem::DevType(u32 handle) {
-	return PSP_DEV_TYPE_FILE;
+PSPDevType DirectoryFileSystem::DevType(u32 handle) {
+	return PSPDevType::FILE;
 }
 
 size_t DirectoryFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {
@@ -1121,8 +1121,8 @@ int VFSFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
-int VFSFileSystem::DevType(u32 handle) {
-	return PSP_DEV_TYPE_FILE;
+PSPDevType VFSFileSystem::DevType(u32 handle) {
+	return PSPDevType::FILE;
 }
 
 size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -742,11 +742,6 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 		File::FileDetails details;
 		if (!File::GetFileDetails(fullName, &details)) {
 			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: GetFileDetails failed: %s", fullName.c_str());
-			x.size = 0;
-			x.access = 0;
-			memset(&x.atime, 0, sizeof(x.atime));
-			memset(&x.ctime, 0, sizeof(x.ctime));
-			memset(&x.mtime, 0, sizeof(x.mtime));
 		} else {
 			x.size = details.size;
 			x.access = details.access;
@@ -1094,6 +1089,7 @@ PSPFileInfo VFSFileSystem::GetFileInfo(std::string filename) {
 		if (x.exists) {
 			x.size = fo.size;
 			x.type = fo.isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
+			x.access = fo.isWritable ? 0666 : 0444;
 		}
 	} else {
 		x.exists = false;

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -154,7 +154,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
-	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
+	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 	u64 FreeSpace(const std::string &path) override { return 0; }
 
 private:

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -20,8 +20,7 @@
 // TODO: Remove the Windows-specific code, FILE is fine there too.
 
 #include <map>
-
-#include "../Core/FileSystems/FileSystem.h"
+#include "Core/FileSystems/FileSystem.h"
 
 #ifdef _WIN32
 typedef void * HANDLE;
@@ -102,7 +101,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int      DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 
 	bool MkDir(const std::string &dirname) override;
 	bool RmDir(const std::string &dirname) override;
@@ -147,7 +146,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int      DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 
 	bool MkDir(const std::string &dirname) override;
 	bool RmDir(const std::string &dirname) override;

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -85,7 +85,7 @@ struct DirectoryFileHandle {
 
 class DirectoryFileSystem : public IFileSystem {
 public:
-	DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, int _flags = 0);
+	DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, FileSystemFlags _flags = FileSystemFlags::NONE);
 	~DirectoryFileSystem();
 
 	void CloseAll();
@@ -109,7 +109,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
-	int Flags() override { return flags; }
+	FileSystemFlags Flags() override { return flags; }
 	u64 FreeSpace(const std::string &path) override;
 
 private:
@@ -123,7 +123,7 @@ private:
 	EntryMap entries;
 	std::string basePath;
 	IHandleAllocator *hAlloc;
-	int flags;
+	FileSystemFlags flags;
 	// In case of Windows: Translate slashes, etc.
 	std::string GetLocalPath(std::string localpath);
 };
@@ -154,7 +154,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
-	int Flags() override { return 0; }
+	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	u64 FreeSpace(const std::string &path) override { return 0; }
 
 private:

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -88,29 +88,25 @@ private:
 };
 
 struct PSPFileInfo {
-	PSPFileInfo()
-		: size(0), access(0), exists(false), type(FILETYPE_NORMAL), isOnSectorSystem(false), startSector(0), numSectors(0), sectorSize(0) {
-		memset(&ctime, 0, sizeof(ctime));
-		memset(&atime, 0, sizeof(atime));
-		memset(&mtime, 0, sizeof(mtime));
+	PSPFileInfo() {
 	}
 
 	void DoState(PointerWrap &p);
 
 	std::string name;
-	s64 size;
-	u32 access; //unix 777
-	bool exists;
-	FileType type;
+	s64 size = 0;
+	u32 access = 0; //unix 777
+	bool exists = false;
+	FileType type = FILETYPE_NORMAL;
 
-	tm atime;
-	tm ctime;
-	tm mtime;
+	tm atime{};
+	tm ctime{};
+	tm mtime{};
 
-	bool isOnSectorSystem;
-	u32 startSector;
-	u32 numSectors;
-	u32 sectorSize;
+	bool isOnSectorSystem = false;
+	u32 startSector = 0;
+	u32 numSectors = 0;
+	u32 sectorSize = 0;
 };
 
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -53,6 +53,9 @@ enum DevType {
 enum class FileSystemFlags {
 	NONE = 0,
 	SIMULATE_FAT32 = 1,
+	UMD = 2,
+	CARD = 4,
+	FLASH = 8,
 };
 
 inline FileSystemFlags operator |(const FileSystemFlags &lhs, const FileSystemFlags &rhs) {

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include "base/basictypes.h"
 
 #include "Core/HLE/sceKernel.h"
 
@@ -44,11 +45,15 @@ enum FileType {
 	FILETYPE_DIRECTORY = 2
 };
 
-enum DevType {
-	PSP_DEV_TYPE_BLOCK = 0x04,
-	PSP_DEV_TYPE_FILE  = 0x10,
-	PSP_DEV_TYPE_ALIAS = 0x20,
+enum class PSPDevType {
+	INVALID = 0,
+	BLOCK = 0x04,
+	FILE  = 0x10,
+	ALIAS = 0x20,
+	EMU_MASK = 0xFF,
+	EMU_LBN = 0x10000,
 };
+ENUM_CLASS_BITOPS(PSPDevType);
 
 enum class FileSystemFlags {
 	NONE = 0,
@@ -57,13 +62,7 @@ enum class FileSystemFlags {
 	CARD = 4,
 	FLASH = 8,
 };
-
-inline FileSystemFlags operator |(const FileSystemFlags &lhs, const FileSystemFlags &rhs) {
-	return FileSystemFlags((int)lhs | (int)rhs);
-}
-inline bool operator &(const FileSystemFlags &lhs, const FileSystemFlags &rhs) {
-	return ((int)lhs & (int)rhs) != 0;
-}
+ENUM_CLASS_BITOPS(FileSystemFlags);
 
 class IHandleAllocator {
 public:
@@ -136,7 +135,7 @@ public:
 	virtual bool     RemoveFile(const std::string &filename) = 0;
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
-	virtual int      DevType(u32 handle) = 0;
+	virtual PSPDevType DevType(u32 handle) = 0;
 	virtual FileSystemFlags Flags() = 0;
 	virtual u64      FreeSpace(const std::string &path) = 0;
 };
@@ -162,7 +161,7 @@ public:
 	virtual bool RemoveFile(const std::string &filename) override {return false;}
 	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) override {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
-	virtual int DevType(u32 handle) override { return 0; }
+	virtual PSPDevType DevType(u32 handle) override { return PSPDevType::INVALID; }
 	virtual FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	virtual u64 FreeSpace(const std::string &path) override { return 0; }
 };

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -50,9 +50,17 @@ enum DevType {
 	PSP_DEV_TYPE_ALIAS = 0x20,
 };
 
-enum FileSystemFlags {
-	FILESYSTEM_SIMULATE_FAT32 = 1,
+enum class FileSystemFlags {
+	NONE = 0,
+	SIMULATE_FAT32 = 1,
 };
+
+inline FileSystemFlags operator |(const FileSystemFlags &lhs, const FileSystemFlags &rhs) {
+	return FileSystemFlags((int)lhs | (int)rhs);
+}
+inline bool operator &(const FileSystemFlags &lhs, const FileSystemFlags &rhs) {
+	return ((int)lhs & (int)rhs) != 0;
+}
 
 class IHandleAllocator {
 public:
@@ -126,7 +134,7 @@ public:
 	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 	virtual int      DevType(u32 handle) = 0;
-	virtual int      Flags() = 0;
+	virtual FileSystemFlags Flags() = 0;
 	virtual u64      FreeSpace(const std::string &path) = 0;
 };
 
@@ -152,7 +160,7 @@ public:
 	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) override {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
 	virtual int DevType(u32 handle) override { return 0; }
-	virtual int Flags() override { return 0; }
+	virtual FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	virtual u64 FreeSpace(const std::string &path) override { return 0; }
 };
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -467,6 +467,12 @@ int ISOFileSystem::DevType(u32 handle)
 	return iter->second.isBlockSectorMode ? PSP_DEV_TYPE_BLOCK : PSP_DEV_TYPE_FILE;
 }
 
+FileSystemFlags ISOFileSystem::Flags() {
+	// TODO: Here may be a good place to force things, in case users recompress games
+	// as PBP or CSO when they were originally the other type.
+	return blockDevice->IsDisc() ? FileSystemFlags::UMD : FileSystemFlags::CARD;
+}
+
 size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size)
 {
 	int ignored;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -461,10 +461,12 @@ int ISOFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
-int ISOFileSystem::DevType(u32 handle)
-{
+PSPDevType ISOFileSystem::DevType(u32 handle) {
 	EntryMap::iterator iter = entries.find(handle);
-	return iter->second.isBlockSectorMode ? PSP_DEV_TYPE_BLOCK : PSP_DEV_TYPE_FILE;
+	PSPDevType type = iter->second.isBlockSectorMode ? PSPDevType::BLOCK : PSPDevType::FILE;
+	if (iter->second.isRawSector)
+		type |= PSPDevType::EMU_LBN;
+	return type;
 }
 
 FileSystemFlags ISOFileSystem::Flags() {
@@ -613,6 +615,7 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename) {
 		PSPFileInfo fileInfo;
 		fileInfo.name = filename;
 		fileInfo.exists = true;
+		fileInfo.type = FILETYPE_NORMAL;
 		fileInfo.size = readSize;
 		fileInfo.startSector = sectorStart;
 		fileInfo.isOnSectorSystem = true;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -617,6 +617,7 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename) {
 		fileInfo.exists = true;
 		fileInfo.type = FILETYPE_NORMAL;
 		fileInfo.size = readSize;
+		fileInfo.access = 0444;
 		fileInfo.startSector = sectorStart;
 		fileInfo.isOnSectorSystem = true;
 		fileInfo.numSectors = (readSize + sectorSize - 1) / sectorSize;
@@ -625,12 +626,10 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename) {
 
 	TreeEntry *entry = GetFromPath(filename, false);
 	PSPFileInfo x; 
-	if (!entry) {
-		x.size = 0;
-		x.exists = false;
-	} else {
+	if (entry) {
 		x.name = entry->name;
-		x.access = FILEACCESS_READ;
+		// Strangely, it seems to be executable even for files.
+		x.access = 0555;
 		x.size = entry->size;
 		x.exists = true;
 		x.type = entry->isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
@@ -658,16 +657,14 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path) {
 
 		PSPFileInfo x;
 		x.name = e->name;
-		x.access = FILEACCESS_READ;
+		// Strangely, it seems to be executable even for files.
+		x.access = 0555;
 		x.size = e->size;
 		x.type = e->isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 		x.isOnSectorSystem = true;
 		x.startSector = e->startingPosition/2048;
 		x.sectorSize = sectorSize;
 		x.numSectors = (u32)((e->size + sectorSize - 1) / sectorSize);
-		memset(&x.atime, 0, sizeof(x.atime));
-		memset(&x.mtime, 0, sizeof(x.mtime));
-		memset(&x.ctime, 0, sizeof(x.ctime));
 		myVector.push_back(x);
 	}
 	return myVector;

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -42,7 +42,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int      DevType(u32 handle) override;
-	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
+	FileSystemFlags Flags() override;
 	u64      FreeSpace(const std::string &path) override { return 0; }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -41,7 +41,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int      DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 	FileSystemFlags Flags() override;
 	u64      FreeSpace(const std::string &path) override { return 0; }
 
@@ -134,7 +134,7 @@ public:
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override {
 		return isoFileSystem_->Ioctl(handle, cmd, indataPtr, inlen, outdataPtr, outlen, usec);
 	}
-	int      DevType(u32 handle) override {
+	PSPDevType DevType(u32 handle) override {
 		return isoFileSystem_->DevType(handle);
 	}
 	FileSystemFlags Flags() override { return isoFileSystem_->Flags(); }

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -42,7 +42,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int      DevType(u32 handle) override;
-	int      Flags() override { return 0; }
+	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	u64      FreeSpace(const std::string &path) override { return 0; }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;
@@ -137,7 +137,7 @@ public:
 	int      DevType(u32 handle) override {
 		return isoFileSystem_->DevType(handle);
 	}
-	int      Flags() override { return isoFileSystem_->Flags(); }
+	FileSystemFlags Flags() override { return isoFileSystem_->Flags(); }
 	u64      FreeSpace(const std::string &path) override { return isoFileSystem_->FreeSpace(path); }
 
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override {

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -178,7 +178,7 @@ IFileSystem *MetaFileSystem::GetHandleOwner(u32 handle)
 
 int MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpath, MountPoint **system)
 {
-	int error = -1;
+	int error = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	std::string realpath;
 
@@ -246,6 +246,8 @@ int MetaFileSystem::MapFilePath(const std::string &_inpath, std::string &outpath
 				return error == SCE_KERNEL_ERROR_NOCWD ? error : 0;
 			}
 		}
+
+		error = SCE_KERNEL_ERROR_NODEV;
 	}
 
 	DEBUG_LOG(FILESYS, "MapFilePath: failed mapping \"%s\", returning false", inpath.c_str());
@@ -353,7 +355,7 @@ int MetaFileSystem::OpenFile(std::string filename, FileAccess access, const char
 	if (error == 0)
 		return mount->system->OpenFile(of, access, mount->prefix.c_str());
 	else
-		return error == -1 ? SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND : error;
+		return error;
 }
 
 PSPFileInfo MetaFileSystem::GetFileInfo(std::string filename)

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -538,13 +538,13 @@ int MetaFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 out
 	return SCE_KERNEL_ERROR_ERROR;
 }
 
-int MetaFileSystem::DevType(u32 handle)
+PSPDevType MetaFileSystem::DevType(u32 handle)
 {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	IFileSystem *sys = GetHandleOwner(handle);
 	if (sys)
 		return sys->DevType(handle);
-	return SCE_KERNEL_ERROR_ERROR;
+	return PSPDevType::INVALID;
 }
 
 void MetaFileSystem::CloseFile(u32 handle)

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -258,8 +258,8 @@ std::string MetaFileSystem::NormalizePrefix(std::string prefix) const {
 	// Let's apply some mapping here since it won't break savestates.
 	if (prefix == "memstick:")
 		prefix = "ms0:";
-	// Seems like umd00: etc. work just fine...
-	if (startsWith(prefix, "umd"))
+	// Seems like umd00: etc. work just fine... avoid umd1/umd for tests.
+	if (startsWith(prefix, "umd") && prefix != "umd1:" && prefix != "umd:")
 		prefix = "umd0:";
 	// Seems like umd00: etc. work just fine...
 	if (startsWith(prefix, "host"))

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -370,7 +370,7 @@ PSPFileInfo MetaFileSystem::GetFileInfo(std::string filename)
 	}
 	else
 	{
-		PSPFileInfo bogus; // TODO
+		PSPFileInfo bogus;
 		return bogus; 
 	}
 }

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -115,7 +115,7 @@ public:
 	bool RemoveFile(const std::string &filename) override;
 	int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	int  DevType(u32 handle) override;
-	int  Flags() override { return 0; }
+	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	u64  FreeSpace(const std::string &path) override;
 
 	// Convenience helper - returns < 0 on failure.

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -56,6 +56,10 @@ public:
 
 	IFileSystem *GetSystem(const std::string &prefix);
 	IFileSystem *GetSystemFromFilename(const std::string &filename);
+	FileSystemFlags FlagsFromFilename(const std::string &filename) {
+		IFileSystem *sys = GetSystemFromFilename(filename);
+		return sys ? sys->Flags() : FileSystemFlags::NONE;
+	}
 
 	void ThreadEnded(int threadID);
 

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -118,7 +118,7 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
 	int  Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int  DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	u64  FreeSpace(const std::string &path) override;
 

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -554,7 +554,10 @@ int VirtualDiscFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, 
 
 PSPDevType VirtualDiscFileSystem::DevType(u32 handle) {
 	EntryMap::iterator iter = entries.find(handle);
-	return iter->second.type == VFILETYPE_ISO ? PSPDevType::BLOCK : PSPDevType::FILE;
+	PSPDevType type = iter->second.type == VFILETYPE_ISO ? PSPDevType::BLOCK : PSPDevType::FILE;
+	if (iter->second.type == VFILETYPE_LBN)
+		type |= PSPDevType::EMU_LBN;
+	return type;
 }
 
 PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -552,9 +552,9 @@ int VirtualDiscFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, 
 	return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED;
 }
 
-int VirtualDiscFileSystem::DevType(u32 handle) {
+PSPDevType VirtualDiscFileSystem::DevType(u32 handle) {
 	EntryMap::iterator iter = entries.find(handle);
-	return iter->second.type == VFILETYPE_ISO ? PSP_DEV_TYPE_BLOCK : PSP_DEV_TYPE_FILE;
+	return iter->second.type == VFILETYPE_ISO ? PSPDevType::BLOCK : PSPDevType::FILE;
 }
 
 PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
@@ -569,6 +569,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		PSPFileInfo fileInfo;
 		fileInfo.name = filename;
 		fileInfo.exists = true;
+		fileInfo.type = FILETYPE_NORMAL;
 		fileInfo.size = readSize;
 		fileInfo.startSector = sectorStart;
 		fileInfo.isOnSectorSystem = true;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -571,6 +571,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		fileInfo.exists = true;
 		fileInfo.type = FILETYPE_NORMAL;
 		fileInfo.size = readSize;
+		fileInfo.access = 0444;
 		fileInfo.startSector = sectorStart;
 		fileInfo.isOnSectorSystem = true;
 		fileInfo.numSectors = (readSize + 2047) / 2048;
@@ -582,6 +583,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		x.type = FILETYPE_NORMAL;
 		x.isOnSectorSystem = true;
 		x.startSector = fileList[fileIndex].firstBlock;
+		x.access = 0555;
 
 		HandlerFileHandle temp = fileList[fileIndex].handler;
 		if (temp.Open(basePath, filename, FILEACCESS_READ)) {
@@ -610,6 +612,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 
 	x.type = File::IsDirectory(fullName) ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 	x.exists = true;
+	x.access = 0555;
 	if (fileIndex != -1) {
 		x.isOnSectorSystem = true;
 		x.startSector = fileList[fileIndex].firstBlock;
@@ -621,12 +624,8 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: GetFileDetails failed: %s", fullName.c_str());
 			x.size = 0;
 			x.access = 0;
-			memset(&x.atime, 0, sizeof(x.atime));
-			memset(&x.ctime, 0, sizeof(x.ctime));
-			memset(&x.mtime, 0, sizeof(x.mtime));
 		} else {
 			x.size = details.size;
-			x.access = details.access;
 			time_t atime = details.atime;
 			time_t ctime = details.ctime;
 			time_t mtime = details.mtime;
@@ -691,7 +690,7 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 			entry.type = FILETYPE_NORMAL;
 		}
 
-		entry.access = FILEACCESS_READ;
+		entry.access = 0555;
 		entry.size = findData.nFileSizeLow | ((u64)findData.nFileSizeHigh<<32);
 		entry.name = ConvertWStringToUTF8(findData.cFileName);
 		tmFromFiletime(entry.atime, findData.ftLastAccessTime);
@@ -737,7 +736,7 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 			entry.type = FILETYPE_DIRECTORY;
 		else
 			entry.type = FILETYPE_NORMAL;
-		entry.access = s.st_mode & 0x1FF;
+		entry.access = 0555;
 		entry.name = dirp->d_name;
 		entry.size = s.st_size;
 		localtime_r((time_t*)&s.st_atime,&entry.atime);

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -41,7 +41,7 @@ public:
 	int      DevType(u32 handle) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	int  Flags() override { return 0; }
+	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	u64  FreeSpace(const std::string &path) override { return 0; }
 
 	// unsupported operations

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -38,7 +38,7 @@ public:
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
-	int      DevType(u32 handle) override;
+	PSPDevType DevType(u32 handle) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::UMD; }

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -41,7 +41,7 @@ public:
 	int      DevType(u32 handle) override;
 	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
-	FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
+	FileSystemFlags Flags() override { return FileSystemFlags::UMD; }
 	u64  FreeSpace(const std::string &path) override { return 0; }
 
 	// unsupported operations

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -621,7 +621,7 @@ void __IoInit() {
 	asyncNotifyEvent = CoreTiming::RegisterEvent("IoAsyncNotify", __IoAsyncNotify);
 	syncNotifyEvent = CoreTiming::RegisterEvent("IoSyncNotify", __IoSyncNotify);
 
-	memstickSystem = new DirectoryFileSystem(&pspFileSystem, g_Config.memStickDirectory, FILESYSTEM_SIMULATE_FAT32);
+	memstickSystem = new DirectoryFileSystem(&pspFileSystem, g_Config.memStickDirectory, FileSystemFlags::SIMULATE_FAT32);
 #if defined(USING_WIN_UI) || defined(APPLE)
 	flash0System = new DirectoryFileSystem(&pspFileSystem, g_Config.flash0Directory);
 #else
@@ -637,7 +637,7 @@ void __IoInit() {
 		const std::string gameId = g_paramSFO.GetValueString("DISC_ID");
 		const std::string exdataPath = g_Config.memStickDirectory + "exdata/" + gameId + "/";
 		if (File::Exists(exdataPath)) {
-			exdataSystem = new DirectoryFileSystem(&pspFileSystem, exdataPath, FILESYSTEM_SIMULATE_FAT32);
+			exdataSystem = new DirectoryFileSystem(&pspFileSystem, exdataPath, FileSystemFlags::SIMULATE_FAT32);
 			pspFileSystem.Mount("exdata0:", exdataSystem);
 			INFO_LOG(SCEIO, "Mounted exdata/%s/ under memstick for exdata0:/", gameId.c_str());
 		} else {
@@ -1423,8 +1423,7 @@ static u32 sceIoLseek32Async(int id, int offset, int whence) {
 	return 0;
 }
 
-static FileNode *__IoOpen(int &error, const char* filename, int flags, int mode) {
-	//memory stick filename
+static FileNode *__IoOpen(int &error, const char *filename, int flags, int mode) {
 	int access = FILEACCESS_NONE;
 	if (flags & PSP_O_RDONLY)
 		access |= FILEACCESS_READ;
@@ -2290,7 +2289,7 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		
 		bool isFAT = false;
 		IFileSystem *sys = pspFileSystem.GetSystemFromFilename(dir->name);
-		if (sys && (sys->Flags() & FILESYSTEM_SIMULATE_FAT32))
+		if (sys && (sys->Flags() & FileSystemFlags::SIMULATE_FAT32))
 			isFAT = true;
 		else
 			isFAT = false;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -386,7 +386,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
-	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path, FileSystemFlags::SIMULATE_FAT32);
+	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
 	pspFileSystem.Mount("umd0:", fs);
 
 	std::string finalName = ms_path + file + extension;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -386,7 +386,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
-	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path);
+	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path, FileSystemFlags::SIMULATE_FAT32);
 	pspFileSystem.Mount("umd0:", fs);
 
 	std::string finalName = ms_path + file + extension;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -340,10 +340,11 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		auto bd = constructBlockDevice(PSP_CoreParameter().mountIsoLoader);
 		if (bd != NULL) {
 			ISOFileSystem *umd2 = new ISOFileSystem(&pspFileSystem, bd);
+			ISOBlockSystem *blockSystem = new ISOBlockSystem(umd2);
 
-			pspFileSystem.Mount("umd1:", umd2);
+			pspFileSystem.Mount("umd1:", blockSystem);
 			pspFileSystem.Mount("disc0:", umd2);
-			pspFileSystem.Mount("umd:", umd2);
+			pspFileSystem.Mount("umd:", blockSystem);
 		}
 	}
 

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "base/basictypes.h"
 #include "GPU/Common/ShaderCommon.h"
 
 struct CardboardSettings {
@@ -59,17 +60,7 @@ enum class OutputFlags {
 	BACKBUFFER_FLIPPED = 0x0004,
 	POSITION_FLIPPED = 0x0008,
 };
-
-inline OutputFlags operator | (const OutputFlags &lhs, const OutputFlags &rhs) {
-	return OutputFlags((int)lhs | (int)rhs);
-}
-inline OutputFlags operator |= (OutputFlags &lhs, const OutputFlags &rhs) {
-	lhs = lhs | rhs;
-	return lhs;
-}
-inline bool operator & (const OutputFlags &lhs, const OutputFlags &rhs) {
-	return ((int)lhs & (int)rhs) != 0;
-}
+ENUM_CLASS_BITOPS(OutputFlags);
 
 class PresentationCommon {
 public:

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -36,14 +36,7 @@ enum class BrowseFlags {
 	HOMEBREW_STORE = 8,
 	STANDARD = 1 | 2 | 4,
 };
-
-static inline BrowseFlags operator |(const BrowseFlags &lhs, const BrowseFlags &rhs) {
-	return BrowseFlags((int)lhs | (int)rhs);
-}
-
-static inline bool operator &(const BrowseFlags &lhs, const BrowseFlags &rhs) {
-	return ((int)lhs & (int)rhs) != 0;
-}
+ENUM_CLASS_BITOPS(BrowseFlags);
 
 class GameBrowser : public UI::LinearLayout {
 public:

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -928,7 +928,7 @@ namespace MainWindow {
 				u32 handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ, "");
 				// Note: len may be in blocks.
 				size_t len = pspFileSystem.SeekFile(handle, 0, FILEMOVE_END);
-				bool isBlockMode = pspFileSystem.DevType(handle) == PSP_DEV_TYPE_BLOCK;
+				bool isBlockMode = pspFileSystem.DevType(handle) & PSPDevType::BLOCK;
 
 				FILE *fp = File::OpenCFile(fn, "wb");
 				pspFileSystem.SeekFile(handle, 0, FILEMOVE_BEGIN);

--- a/ext/native/base/basictypes.h
+++ b/ext/native/base/basictypes.h
@@ -14,6 +14,20 @@
 	void operator =(const t &other) = delete;
 #endif
 
+#ifndef ENUM_CLASS_BITOPS
+#define ENUM_CLASS_BITOPS(T) \
+	static inline T operator |(const T &lhs, const T &rhs) { \
+		return T((int)lhs | (int)rhs); \
+	} \
+	static inline T &operator |= (T &lhs, const T &rhs) { \
+		lhs = lhs | rhs; \
+		return lhs; \
+	} \
+	static inline bool operator &(const T &lhs, const T &rhs) { \
+		return ((int)lhs & (int)rhs) != 0; \
+	}
+#endif
+
 #ifdef _WIN32
 
 typedef intptr_t ssize_t;


### PR DESCRIPTION
I think this will help #6582.

This makes filesystems expose flags indicating UMD/CARD/FLASH to make it easier to deviate timing depending on what's mounted.  PBPs are treated as CARD while ISOs are treated as UMD.

Also, I found that PSP OFW allows enabling/disabling the UMD cache, but CFW disables it anyway for homebrew.  In the past have seen some timing using JpcspTrace/etc. but gonna need to find a better way...

This mostly aims for the mid-fast end of actual timing metrics.  There are some differences from observed reality:

 * If the UMD spins down, Open/OpenAsync could take 1.5s or so, but mainly not found ones (I think it caches the path table even without cache, not sure.)
 * Uses 4ms (low end average of many runs) for UMD open, but it can be as fast as 1.2ms without cache.
 * Didn't have a great way to carefully time with cache.
 * Memory Stick access should get slower (around 0.8ms per path component) for deeper files, but there's also clearly a file table cache that makes this faster after first access.
 * Didn't test nocwd or other less common errors.

-[Unknown]