### PR TITLE
Ge: Check stack depth based on args struct size

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -340,10 +340,9 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId, u32 optP
 	if ((int)listID >= 0)
 		listID = LIST_ID_MAGIC ^ listID;
 
-	DEBUG_LOG(SCEGE, "List %i enqueued.", listID);
 	hleEatCycles(490);
 	CoreTiming::ForceCheck();
-	return listID;
+	return hleLogSuccessX(SCEGE, listID);
 }
 
 u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 optParamAddr) {
@@ -353,13 +352,12 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
-	if ((int)listID >= 0) {
+	if ((int)listID >= 0)
 		listID = LIST_ID_MAGIC ^ listID;
-		DEBUG_LOG(SCEGE, "List %i enqueued at head.", listID);
-	}
+
 	hleEatCycles(480);
 	CoreTiming::ForceCheck();
-	return listID;
+	return hleLogSuccessX(SCEGE, listID);
 }
 
 static int sceGeListDeQueue(u32 listID) {
@@ -594,8 +592,8 @@ static u32 sceGeEdramSetAddrTranslation(int new_size) {
 
 const HLEFunction sceGe_user[] = {
 	{0XE47E40E4, &WrapU_V<sceGeEdramGetAddr>,            "sceGeEdramGetAddr",            'x', ""    },
-	{0XAB49E76A, &WrapU_UUIU<sceGeListEnQueue>,          "sceGeListEnQueue",             'x', "xxix"},
-	{0X1C0D95A6, &WrapU_UUIU<sceGeListEnQueueHead>,      "sceGeListEnQueueHead",         'x', "xxix"},
+	{0XAB49E76A, &WrapU_UUIU<sceGeListEnQueue>,          "sceGeListEnQueue",             'x', "xxip"},
+	{0X1C0D95A6, &WrapU_UUIU<sceGeListEnQueueHead>,      "sceGeListEnQueueHead",         'x', "xxip"},
 	{0XE0D68148, &WrapI_UU<sceGeListUpdateStallAddr>,    "sceGeListUpdateStallAddr",     'i', "xx"  },
 	{0X03444EB4, &WrapI_UU<sceGeListSync>,               "sceGeListSync",                'i', "xx"  },
 	{0XB287BD61, &WrapU_U<sceGeDrawSync>,                "sceGeDrawSync",                'x', "x"   },

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -679,17 +679,16 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
 	}
 
+	// If args->size is below 16, it's the old struct without stack info.
+	if (args.IsValid() && args->size >= 16 && args->numStacks >= 256) {
+		return hleLogError(G3D, SCE_KERNEL_ERROR_INVALID_SIZE, "invalid stack depth %d", args->numStacks);
+	}
+
 	int id = -1;
 	u64 currentTicks = CoreTiming::GetTicks();
-	u32_le stackAddr = args.IsValid() ? args->stackAddr : 0;
+	u32_le stackAddr = args.IsValid() && args->size >= 16 ? args->stackAddr : 0;
 	// Check compatibility
 	if (sceKernelGetCompiledSdkVersion() > 0x01FFFFFF) {
-		// See #12908.
-		if (args.IsValid() && args->numStacks >= 256) {
-			ERROR_LOG(G3D, "sceGeListEnqueue: invalid size %08x", args->numStacks);
-			return SCE_KERNEL_ERROR_INVALID_SIZE;
-		}
-
 		//numStacks = 0;
 		//stack = NULL;
 		for (int i = 0; i < DisplayListMaxCount; ++i) {


### PR DESCRIPTION
Matches tests against firmware - across SDK versions.  See #12908 and #12908.

See test: https://github.com/hrydgard/pspautotests/pull/204

-[Unknown]