### PR TITLE
GPU: Never set safe size larger than the buffer

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1686,8 +1686,8 @@ void FramebufferManagerCommon::SetRenderSize(VirtualFramebuffer *vfb) {
 void FramebufferManagerCommon::SetSafeSize(u16 w, u16 h) {
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (vfb) {
-		vfb->safeWidth = std::max(vfb->safeWidth, w);
-		vfb->safeHeight = std::max(vfb->safeHeight, h);
+		vfb->safeWidth = std::min(vfb->bufferWidth, std::max(vfb->safeWidth, w));
+		vfb->safeHeight = std::min(vfb->bufferHeight, std::max(vfb->safeHeight, h));
 	}
 }
 


### PR DESCRIPTION
Maybe this indicates the buffer size is wrong, but a safe size larger than the buffer will make us try to download outside the buffer and lose the Vulkan device.

We sometimes intentionally estimate lower than the scissor, i.e. 481x273.

Saw this only because I was trying using safe size debugging #12858 and added additional cases.  I'm not sure if we hit this now, but better to be safe.

-[Unknown]