### PR TITLE
Show a better message dialog with scrollbar

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -198,6 +198,16 @@ bool PSPDialog::IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThr
 	return false;
 }
 
+PPGeStyle PSPDialog::FadedStyle(PPGeAlign align, float scale) {
+	PPGeStyle textStyle;
+	textStyle.align = align;
+	textStyle.scale = scale;
+	textStyle.color = CalcFadedColor(textStyle.color);
+	textStyle.hasShadow = true;
+	textStyle.shadowColor = CalcFadedColor(textStyle.shadowColor);
+	return textStyle;
+}
+
 void PSPDialog::DisplayButtons(int flags, const char *caption)
 {
 	bool useCaption = false;
@@ -207,6 +217,8 @@ void PSPDialog::DisplayButtons(int flags, const char *caption)
 		truncate_cpy(safeCaption, caption);
 	}
 
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_LEFT, FONT_SCALE);
+
 	auto di = GetI18NCategory("Dialog");
 	float x1 = 183.5f, x2 = 261.5f;
 	if (GetCommonParam()->buttonSwap == 1) {
@@ -215,16 +227,12 @@ void PSPDialog::DisplayButtons(int flags, const char *caption)
 	}
 	if (flags & DS_BUTTON_OK) {
 		const char *text = useCaption ? safeCaption : di->T("Enter");
-		PPGeDrawImage(okButtonImg, x2, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));
-		PPGeDrawImage(okButtonImg, x2, 256, 11.5f, 11.5f, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(text, x2 + 15.5f, 254, PPGeAlign::BOX_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(text, x2 + 14.5f, 252, PPGeAlign::BOX_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(okButtonImg, x2, 256, 11.5f, 11.5f, textStyle);
+		PPGeDrawText(text, x2 + 14.5f, 252, textStyle);
 	}
 	if (flags & DS_BUTTON_CANCEL) {
 		const char *text = useCaption ? safeCaption : di->T("Back");
-		PPGeDrawText(text, x1 + 15.5f, 254, PPGeAlign::BOX_LEFT, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(text, x1 + 14.5f, 252, PPGeAlign::BOX_LEFT, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(cancelButtonImg, x1, 258, 11.5f, 11.5f, 0, CalcFadedColor(0x80000000));
-		PPGeDrawImage(cancelButtonImg, x1, 256, 11.5f, 11.5f, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(cancelButtonImg, x1, 256, 11.5f, 11.5f, textStyle);
+		PPGeDrawText(text, x1 + 14.5f, 252, textStyle);
 	}
 }

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -22,6 +22,7 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
+#include "Core/Util/PPGeDraw.h"
 
 class PointerWrap;
 
@@ -83,6 +84,7 @@ public:
 	void StartDraw();
 	void EndDraw();
 protected:
+	PPGeStyle FadedStyle(PPGeAlign align, float scale);
 	void UpdateButtons();
 	bool IsButtonPressed(int checkButton);
 	bool IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold = 30, int framesHeldRepeatRate = 10);

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -153,23 +153,20 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
 	float h2 = h / 2.0f;
 	ey = y + h2 + 20.0f;
 
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);
+
 	if (hasYesNo)
 	{
 		auto di = GetI18NCategory("Dialog");
 		const char *choiceText;
-		u32 yesColor, noColor;
 		float x, w;
 		if (yesnoChoice == 1) {
 			choiceText = di->T("Yes");
 			x = 204.0f;
-			yesColor = 0xFFFFFFFF;
-			noColor  = 0xFFFFFFFF;
 		}
 		else {
 			choiceText = di->T("No");
 			x = 273.0f;
-			yesColor = 0xFFFFFFFF;
-			noColor  = 0xFFFFFFFF;
 		}
 		PPGeMeasureText(&w, &h, choiceText, FONT_SCALE);
 		w = 15.0f;
@@ -178,10 +175,8 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
 		h2 += h + 5.0f;
 		y = 135.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
-		PPGeDrawText(di->T("Yes"), 204.0f, y2 + 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(di->T("Yes"), 203.0f, y2 - 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
-		PPGeDrawText(di->T("No"), 273.0f, y2 + 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(di->T("No"), 272.0f, y2 - 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(noColor));
+		PPGeDrawText(di->T("Yes"), 203.0f, y2 - 1.0f, textStyle);
+		PPGeDrawText(di->T("No"), 272.0f, y2 - 1.0f, textStyle);
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {
 			yesnoChoice = 1;
 		}
@@ -201,13 +196,11 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK)
 		h2 += h + 5.0f;
 		y = 135.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x6DCFCFCF));
-		PPGeDrawText(di->T("OK"), 240.0f, y2 + 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(di->T("OK"), 239.0f, y2 - 1.0f, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText(di->T("OK"), 239.0f, y2 - 1.0f, textStyle);
 		ey = y2 + 25.0f;
 	}
 
-	PPGeDrawTextWrapped(text.c_str(), 241.0f, y+2, WRAP_WIDTH, 0, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-	PPGeDrawTextWrapped(text.c_str(), 240.0f, y, WRAP_WIDTH, 0, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawTextWrapped(text.c_str(), 240.0f, y, WRAP_WIDTH, 0, textStyle);
 	sy = 125.0f - h2;
 	PPGeDrawRect(40.0f, sy, 440.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawRect(40.0f, ey, 440.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -148,9 +148,17 @@ int PSPMsgDialog::Init(unsigned int paramAddr) {
 void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
 	auto di = GetI18NCategory("Dialog");
 
-	float WRAP_WIDTH = 300.0f;
-	if (UTF8StringNonASCIICount(text.c_str()) > 3)
-		WRAP_WIDTH = 372.0f;
+	PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);
+	PPGeStyle messageStyle = FadedStyle(PPGeAlign::BOX_HCENTER, FONT_SCALE);
+
+	// Without the scrollbar, we have 390 total pixels.
+	float WRAP_WIDTH = 340.0f;
+	if (UTF8StringNonASCIICount(text.c_str()) >= text.size() / 4) {
+		WRAP_WIDTH = 376.0f;
+		if (text.size() > 12) {
+			messageStyle.scale = 0.6f;
+		}
+	}
 
 	float totalHeight = 0.0f;
 	PPGeMeasureText(nullptr, &totalHeight, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
@@ -163,9 +171,6 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
 	float sy = centerY - h2 - 15.0f;
 	float ey = centerY + h2 + 20.0f;
 	float buttonY = centerY + h2 + 5.0f;
-
-	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);
-	PPGeStyle messageStyle = FadedStyle(PPGeAlign::BOX_HCENTER, FONT_SCALE);
 
 	auto drawSelectionBoxAndAdjust = [&](float x) {
 		// Box has a fixed size.
@@ -185,8 +190,8 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
 			drawSelectionBoxAndAdjust(273.0f);
 		}
 
-		PPGeDrawText(di->T("Yes"), 203.0f, buttonY - 1.0f, textStyle);
-		PPGeDrawText(di->T("No"), 272.0f, buttonY - 1.0f, textStyle);
+		PPGeDrawText(di->T("Yes"), 203.0f, buttonY - 1.0f, buttonStyle);
+		PPGeDrawText(di->T("No"), 272.0f, buttonY - 1.0f, buttonStyle);
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {
 			yesnoChoice = 1;
 		} else if (IsButtonPressed(CTRL_RIGHT) && yesnoChoice == 1) {
@@ -198,7 +203,7 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
 	if (hasOK) {
 		drawSelectionBoxAndAdjust(240.0f);
 
-		PPGeDrawText(di->T("OK"), 239.0f, buttonY - 1.0f, textStyle);
+		PPGeDrawText(di->T("OK"), 239.0f, buttonY - 1.0f, buttonStyle);
 		buttonY += 8.0f + 5.0f;
 	}
 

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include "Core/Dialog/PSPMsgDialog.h"
+#include "Core/Dialog/PSPSaveDialog.h"
 #include "Core/Util/PPGeDraw.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/MemMapHelpers.h"
@@ -133,7 +134,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr) {
 	}
 
 	if (flag & DS_ERRORMSG) {
-		snprintf(msgText, 512, "Error code: %08x", messageDialog.errorNum);
+		FormatErrorCode(messageDialog.errorNum);
 	} else {
 		truncate_cpy(msgText, messageDialog.string);
 	}
@@ -143,6 +144,40 @@ int PSPMsgDialog::Init(unsigned int paramAddr) {
 	UpdateButtons();
 	StartFade(true);
 	return 0;
+}
+
+
+void PSPMsgDialog::FormatErrorCode(uint32_t code) {
+	auto di = GetI18NCategory("Dialog");
+
+	switch (code) {
+	case SCE_UTILITY_SAVEDATA_ERROR_LOAD_DATA_BROKEN:
+		snprintf(msgText, 512, "%s (%08x)", di->T("MsgErrorSavedataDataBroken", "Save data was corrupt."), code);
+		break;
+
+	case SCE_UTILITY_SAVEDATA_ERROR_LOAD_NO_MS:
+	case SCE_UTILITY_SAVEDATA_ERROR_RW_NO_MEMSTICK:
+	case SCE_UTILITY_SAVEDATA_ERROR_SAVE_NO_MS:
+	case SCE_UTILITY_SAVEDATA_ERROR_DELETE_NO_MS:
+	case SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_MS:
+		snprintf(msgText, 512, "%s (%08x)", di->T("MsgErrorSavedataNoMS", "Memory stick not inserted."), code);
+		break;
+
+	case SCE_UTILITY_SAVEDATA_ERROR_LOAD_NO_DATA:
+	case SCE_UTILITY_SAVEDATA_ERROR_RW_NO_DATA:
+	case SCE_UTILITY_SAVEDATA_ERROR_DELETE_NO_DATA:
+	case SCE_UTILITY_SAVEDATA_ERROR_SIZES_NO_DATA:
+		snprintf(msgText, 512, "%s (%08x)", di->T("MsgErrorSavedataNoData", "Warning: no save data was found."), code);
+		break;
+
+	case SCE_UTILITY_SAVEDATA_ERROR_RW_MEMSTICK_FULL:
+	case SCE_UTILITY_SAVEDATA_ERROR_SAVE_MS_NOSPACE:
+		snprintf(msgText, 512, "%s (%08x)", di->T("MsgErrorSavedataMSFull", "Memory stick full.  Check your storage space."), code);
+		break;
+
+	default:
+		snprintf(msgText, 512, "%s %08x", di->T("MsgErrorCode", "Error code:"), code);
+	}
 }
 
 void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -74,7 +74,8 @@ protected:
 		return false;
 	}
 
-private :
+private:
+	void FormatErrorCode(uint32_t code);
 	void DisplayMessage(std::string text, bool hasYesNo = false, bool hasOK = false);
 
 	enum Flags

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -98,5 +98,8 @@ private :
 
 	char msgText[512];
 	int yesnoChoice;
+	float scrollPos_ = 0.0f;
+	int framesUpHeld_ = 0;
+	int framesDownHeld_ = 0;
 };
 

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -65,10 +65,13 @@ void PSPNetconfDialog::DrawBanner() {
 
 	PPGeDrawRect(0, 0, 480, 23, CalcFadedColor(0x65636358));
 
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_VCENTER, 0.6f);
+	textStyle.hasShadow = false;
+
 	// TODO: Draw a hexagon icon
-	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, textStyle.color);
 	auto di = GetI18NCategory("Dialog");
-	PPGeDrawText(di->T("Network Connection"), 30, 11, PPGeAlign::BOX_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(di->T("Network Connection"), 30, 11, textStyle);
 }
 
 int PSPNetconfDialog::Update(int animSpeed) {
@@ -83,14 +86,17 @@ int PSPNetconfDialog::Update(int animSpeed) {
 	const ImageID confirmBtnImage = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? ImageID("I_CROSS") : ImageID("I_CIRCLE");
 	const int confirmBtn = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, 0.5f);
+	PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);
+
 	if (request.netAction == NETCONF_CONNECT_APNET || request.netAction == NETCONF_STATUS_APNET || request.netAction == NETCONF_CONNECT_APNET_LAST) {
 		UpdateFade(animSpeed);
 		StartDraw();
 		DrawBanner();
 		PPGeDrawRect(0, 0, 480, 272, CalcFadedColor(0x63636363));
-		PPGeDrawTextWrapped(err->T("PPSSPPDoesNotSupportInternet", "PPSSPP currently does not support connecting to the Internet for DLC, PSN, or game updates."), 241, 132, WRAP_WIDTH, 0, PPGeAlign::BOX_CENTER, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(confirmBtnImage, 195, 250, 20, 20, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(di->T("OK"), 225, 252, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawTextWrapped(err->T("PPSSPPDoesNotSupportInternet", "PPSSPP currently does not support connecting to the Internet for DLC, PSN, or game updates."), 241, 132, WRAP_WIDTH, 0, textStyle);
+		PPGeDrawImage(confirmBtnImage, 195, 250, 20, 20, buttonStyle);
+		PPGeDrawText(di->T("OK"), 225, 252, buttonStyle);
 
 		if (IsButtonPressed(confirmBtn)) {
 			StartFade(false);

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -766,7 +766,18 @@ void PSPOskDialog::RenderKeyboard()
 	float previewLeftSide = (480.0f - (12.0f * drawLimit)) / 2.0f;
 	float title = (480.0f - (0.5f * drawLimit)) / 2.0f;
 
-	PPGeDrawText(oskDesc.c_str(), title , 20, PPGeAlign::BOX_CENTER, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeStyle descStyle = FadedStyle(PPGeAlign::BOX_CENTER, 0.5f);
+	descStyle.hasShadow = false;
+	PPGeDrawText(oskDesc.c_str(), title, 20, descStyle);
+
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.5f);
+	textStyle.hasShadow = false;
+
+	PPGeStyle keyStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.6f);
+	keyStyle.hasShadow = false;
+	PPGeStyle selectedKeyStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.6f);
+	selectedKeyStyle.color = CalcFadedColor(0xFF3060FF);
+	selectedKeyStyle.hasShadow = false;
 
 	std::u16string result;
 
@@ -776,12 +787,11 @@ void PSPOskDialog::RenderKeyboard()
 	drawIndex = result.size() == limit + 1 ? drawIndex - 1 : drawIndex;  // When the length reached limit, the last character don't fade in and out.
 	for (u32 i = 0; i < drawLimit; ++i, ++drawIndex)
 	{
-		u32 color = CalcFadedColor(0xFFFFFFFF);
 		if (drawIndex + 1 < result.size())
 		{
 			temp[0] = result[drawIndex];
 			ConvertUCS2ToUTF8(buffer, temp);
-			PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, PPGeAlign::BOX_HCENTER, 0.5f, color);
+			PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, textStyle);
 		}
 		else
 		{
@@ -794,25 +804,25 @@ void PSPOskDialog::RenderKeyboard()
 					float animStep = (float)(__DisplayGetNumVblanks() % 40) / 20.0f;
 					// Fade in and out the next character so they know it's not part of the string yet.
 					u32 alpha = (0.5f - (cosf(animStep * M_PI) / 2.0f)) * 128 + 127;
-					color = CalcFadedColor((alpha << 24) | 0xFFFFFF);
+					PPGeStyle animStyle = textStyle;
+					animStyle.color = CalcFadedColor((alpha << 24) | 0x00FFFFFF);
 
 					ConvertUCS2ToUTF8(buffer, temp);
 
-					PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, PPGeAlign::BOX_HCENTER, 0.5f, color);
+					PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, animStyle);
 
 					// Also draw the underline for the same reason.
-					color = CalcFadedColor(0xFFFFFFFF);
-					PPGeDrawText("_", previewLeftSide + (i * characterWidth), 40.0f, PPGeAlign::BOX_HCENTER, 0.5f, color);
+					PPGeDrawText("_", previewLeftSide + (i * characterWidth), 40.0f, textStyle);
 				}
 				else
 				{
 					ConvertUCS2ToUTF8(buffer, temp);
-					PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, PPGeAlign::BOX_HCENTER, 0.5f, color);
+					PPGeDrawText(buffer.c_str(), previewLeftSide + (i * characterWidth), 40.0f, textStyle);
 				}
 			}
 			else
 			{
-				PPGeDrawText("_", previewLeftSide + (i * characterWidth), 40.0f, PPGeAlign::BOX_HCENTER, 0.5f, color);
+				PPGeDrawText("_", previewLeftSide + (i * characterWidth), 40.0f, textStyle);
 			}
 		}
 	}
@@ -821,17 +831,16 @@ void PSPOskDialog::RenderKeyboard()
 	{
 		for (int col = 0; col < numKeyCols[currentKeyboard]; ++col)
 		{
-			u32 color = CalcFadedColor(0xFFFFFFFF);
-			if (selectedRow == row && col == selectedCol)
-				color = CalcFadedColor(0xFF3060FF);
-
 			temp[0] = oskKeys[currentKeyboard][row][col];
 
 			ConvertUCS2ToUTF8(buffer, temp);
-			PPGeDrawText(buffer.c_str(), keyboardLeftSide + (25.0f * col) + characterWidth / 2.0, 70.0f + (25.0f * row), PPGeAlign::BOX_HCENTER, 0.6f, color);
 
-			if (selectedRow == row && col == selectedCol)
-				PPGeDrawText("_", keyboardLeftSide + (25.0f * col) + characterWidth / 2.0, 70.0f + (25.0f * row), PPGeAlign::BOX_HCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
+			if (selectedRow == row && col == selectedCol) {
+				PPGeDrawText(buffer.c_str(), keyboardLeftSide + (25.0f * col) + characterWidth / 2.0, 70.0f + (25.0f * row), selectedKeyStyle);
+				PPGeDrawText("_", keyboardLeftSide + (25.0f * col) + characterWidth / 2.0, 70.0f + (25.0f * row), keyStyle);
+			} else {
+				PPGeDrawText(buffer.c_str(), keyboardLeftSide + (25.0f * col) + characterWidth / 2.0, 70.0f + (25.0f * row), keyStyle);
+			}
 		}
 	}
 }
@@ -944,22 +953,27 @@ int PSPOskDialog::Update(int animSpeed) {
 
 	auto di = GetI18NCategory("Dialog");
 
-	PPGeDrawImage(ImageID("I_SQUARE"), 365, 222, 16, 16, 0, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(di->T("Space"), 390, 222, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeStyle actionStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);
+	actionStyle.hasShadow = false;
+	PPGeStyle guideStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.6f);
+	guideStyle.hasShadow = false;
+
+	PPGeDrawImage(ImageID("I_SQUARE"), 365, 222, 16, 16, guideStyle);
+	PPGeDrawText(di->T("Space"), 390, 222, actionStyle);
 
 	if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE) {
-		PPGeDrawImage(ImageID("I_CROSS"), 45, 222, 16, 16, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(ImageID("I_CIRCLE"), 45, 247, 16, 16, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(ImageID("I_CROSS"), 45, 222, 16, 16, guideStyle);
+		PPGeDrawImage(ImageID("I_CIRCLE"), 45, 247, 16, 16, guideStyle);
 	} else {
-		PPGeDrawImage(ImageID("I_CIRCLE"), 45, 222, 16, 16, 0, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawImage(ImageID("I_CROSS"), 45, 247, 16, 16, 0, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawImage(ImageID("I_CIRCLE"), 45, 222, 16, 16, guideStyle);
+		PPGeDrawImage(ImageID("I_CROSS"), 45, 247, 16, 16, guideStyle);
 	}
 
-	PPGeDrawText(di->T("Select"), 75, 222, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(di->T("Delete"), 75, 247, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(di->T("Select"), 75, 222, actionStyle);
+	PPGeDrawText(di->T("Delete"), 75, 247, actionStyle);
 
-	PPGeDrawText("Start", 135, 220, PPGeAlign::BOX_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(di->T("Finish"), 185, 222, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText("Start", 135, 220, guideStyle);
+	PPGeDrawText(di->T("Finish"), 185, 222, actionStyle);
 
 	auto lookupLangName = [&](int direction) {
 		// First, find the valid one...
@@ -983,20 +997,20 @@ int PSPOskDialog::Update(int animSpeed) {
 	};
 
 	if (OskKeyboardNames[currentKeyboardLanguage] != "ko_KR" && IsKeyboardShiftValid(oskParams->fields[0].inputtype, currentKeyboardLanguage, currentKeyboard)) {
-		PPGeDrawText("Select", 135, 245, PPGeAlign::BOX_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(di->T("Shift"), 185, 247, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("Select", 135, 245, guideStyle);
+		PPGeDrawText(di->T("Shift"), 185, 247, actionStyle);
 	}
 
 	const char *prevLang = lookupLangName(-1);
 	if (prevLang) {
-		PPGeDrawText("L", 235, 220, PPGeAlign::BOX_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(prevLang, 255, 222, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("L", 235, 220, guideStyle);
+		PPGeDrawText(prevLang, 255, 222, actionStyle);
 	}
 
 	const char *nextLang = lookupLangName(1);
 	if (nextLang) {
-		PPGeDrawText("R", 235, 245, PPGeAlign::BOX_LEFT, 0.6f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(nextLang, 255, 247, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeDrawText("R", 235, 245, guideStyle);
+		PPGeDrawText(nextLang, 255, 247, actionStyle);
 	}
 
 	if (IsButtonPressed(CTRL_UP) || IsButtonHeld(CTRL_UP, upBtnFramesHeld, framesHeldThreshold, framesHeldRepeatRate)) {

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -767,17 +767,13 @@ void PSPOskDialog::RenderKeyboard()
 	float title = (480.0f - (0.5f * drawLimit)) / 2.0f;
 
 	PPGeStyle descStyle = FadedStyle(PPGeAlign::BOX_CENTER, 0.5f);
-	descStyle.hasShadow = false;
 	PPGeDrawText(oskDesc.c_str(), title, 20, descStyle);
 
 	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.5f);
-	textStyle.hasShadow = false;
 
 	PPGeStyle keyStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.6f);
-	keyStyle.hasShadow = false;
 	PPGeStyle selectedKeyStyle = FadedStyle(PPGeAlign::BOX_HCENTER, 0.6f);
 	selectedKeyStyle.color = CalcFadedColor(0xFF3060FF);
-	selectedKeyStyle.hasShadow = false;
 
 	std::u16string result;
 
@@ -954,9 +950,7 @@ int PSPOskDialog::Update(int animSpeed) {
 	auto di = GetI18NCategory("Dialog");
 
 	PPGeStyle actionStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);
-	actionStyle.hasShadow = false;
 	PPGeStyle guideStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.6f);
-	guideStyle.hasShadow = false;
 
 	PPGeDrawImage(ImageID("I_SQUARE"), 365, 222, 16, 16, guideStyle);
 	PPGeDrawText(di->T("Space"), 390, 222, actionStyle);

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -282,6 +282,10 @@ void PSPSaveDialog::DisplayBanner(int which)
 {
 	auto di = GetI18NCategory("Dialog");
 	PPGeDrawRect(0, 0, 480, 23, CalcFadedColor(0x65636358));
+
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_VCENTER, 0.6f);
+	textStyle.hasShadow = false;
+
 	const char *title;
 	switch (which)
 	{
@@ -299,8 +303,8 @@ void PSPSaveDialog::DisplayBanner(int which)
 		break;
 	}
 	// TODO: Draw a hexagon icon
-	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
-	PPGeDrawText(title, 30, 11, PPGeAlign::BOX_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, textStyle.color);
+	PPGeDrawText(title, 30, 11, textStyle);
 }
 
 void PSPSaveDialog::DisplaySaveList(bool canMove) {
@@ -395,7 +399,8 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 	std::lock_guard<std::mutex> guard(paramLock);
 	if (param.GetFileInfo(currentSelectedSave).size == 0) {
 		auto di = GetI18NCategory("Dialog");
-		PPGeDrawText(di->T("NEW DATA"), 180, 136, PPGeAlign::BOX_VCENTER, 0.6f, CalcFadedColor(0xFFFFFFFF));
+		PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_VCENTER, 0.6f);
+		PPGeDrawText(di->T("NEW DATA"), 180, 136, textStyle);
 	} else {
 		char title[512];
 		char time[512];
@@ -452,14 +457,15 @@ void PSPSaveDialog::DisplaySaveDataInfo1()
 		std::string saveTitleTxt = saveTitle;
 		std::string saveDetailTxt = saveDetail;
 
-		PPGeDrawText(titleTxt.c_str(), 181, 138, PPGeAlign::BOX_BOTTOM, 0.6f, CalcFadedColor(0x80000000));
-		PPGeDrawText(titleTxt.c_str(), 180, 136, PPGeAlign::BOX_BOTTOM, 0.6f, CalcFadedColor(0xFFC0C0C0));
-		PPGeDrawText(timeTxt.c_str(), 181, 139, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0x80000000));
-		PPGeDrawText(timeTxt.c_str(), 180, 137, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawText(saveTitleTxt.c_str(), 176, 162, PPGeAlign::BOX_LEFT, 0.55f, CalcFadedColor(0x80000000));
-		PPGeDrawText(saveTitleTxt.c_str(), 175, 159, PPGeAlign::BOX_LEFT, 0.55f, CalcFadedColor(0xFFFFFFFF));
-		PPGeDrawTextWrapped(saveDetailTxt.c_str(), 176, 183, 480 - 175, 250 - 183, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0x80000000));
-		PPGeDrawTextWrapped(saveDetailTxt.c_str(), 175, 181, 480 - 175, 250 - 181, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+		PPGeStyle titleStyle = FadedStyle(PPGeAlign::BOX_BOTTOM, 0.6f);
+		PPGeStyle saveTitleStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.55f);
+		titleStyle.color = CalcFadedColor(0xFFC0C0C0);
+		PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);
+
+		PPGeDrawText(titleTxt.c_str(), 180, 136, titleStyle);
+		PPGeDrawText(timeTxt.c_str(), 180, 137, textStyle);
+		PPGeDrawText(saveTitleTxt.c_str(), 175, 159, saveTitleStyle);
+		PPGeDrawTextWrapped(saveDetailTxt.c_str(), 175, 181, 480 - 175, 250 - 181, textStyle);
 	}
 }
 
@@ -525,13 +531,15 @@ void PSPSaveDialog::DisplaySaveDataInfo2(bool showNewData) {
 		snprintf(date, 256, "%d/%02d/%02d", year, month, day);
 	}
 
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);
 	std::string saveinfoTxt = StringFromFormat("%.128s\n%s  %s\n%lld KB", save_title, date, hour_time, sizeK);
-	PPGeDrawText(saveinfoTxt.c_str(), 9, 202, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0x80000000));
-	PPGeDrawText(saveinfoTxt.c_str(), 8, 200, PPGeAlign::BOX_LEFT, 0.5f, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawText(saveinfoTxt.c_str(), 8, 200, textStyle);
 }
 
 void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 {
+	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);
+
 	const float WRAP_WIDTH = 254.0f;
 	float y = 136.0f, h;
 	PPGeMeasureText(nullptr, &h, text.c_str(), FONT_SCALE, PPGE_LINE_WRAP_WORD, WRAP_WIDTH);
@@ -540,19 +548,14 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 	{
 		auto di = GetI18NCategory("Dialog");
 		const char *choiceText;
-		u32 yesColor, noColor;
 		float x, w;
 		if (yesnoChoice == 1) {
 			choiceText = di->T("Yes");
 			x = 302.0f;
-			yesColor = 0xFFFFFFFF;
-			noColor  = 0xFFFFFFFF;
 		}
 		else {
 			choiceText = di->T("No");
 			x = 366.0f;
-			yesColor = 0xFFFFFFFF;
-			noColor  = 0xFFFFFFFF;
 		}
 		PPGeMeasureText(&w, &h, choiceText, FONT_SCALE);
 		w = w / 2.0f + 5.5f;
@@ -561,10 +564,8 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 		h2 += h + 4.0f;
 		y = 132.0f - h;
 		PPGeDrawRect(x - w, y2 - h, x + w, y2 + h, CalcFadedColor(0x40C0C0C0));
-		PPGeDrawText(di->T("Yes"), 303.0f, y2+2, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(di->T("Yes"), 302.0f, y2, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(yesColor));
-		PPGeDrawText(di->T("No"), 367.0f, y2+2, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-		PPGeDrawText(di->T("No"), 366.0f, y2, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(noColor));
+		PPGeDrawText(di->T("Yes"), 302.0f, y2, textStyle);
+		PPGeDrawText(di->T("No"), 366.0f, y2, textStyle);
 		if (IsButtonPressed(CTRL_LEFT) && yesnoChoice == 0) {
 			yesnoChoice = 1;
 		}
@@ -572,8 +573,7 @@ void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
 			yesnoChoice = 0;
 		}
 	}
-	PPGeDrawTextWrapped(text.c_str(), 335.0f, y+2, WRAP_WIDTH, 0, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0x80000000));
-	PPGeDrawTextWrapped(text.c_str(), 334.0f, y, WRAP_WIDTH, 0, PPGeAlign::BOX_CENTER, FONT_SCALE, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawTextWrapped(text.c_str(), 334.0f, y, WRAP_WIDTH, 0, textStyle);
 	float sy = 122.0f - h2, ey = 150.0f + h2;
 	PPGeDrawRect(202.0f, sy, 466.0f, sy + 1.0f, CalcFadedColor(0xFFFFFFFF));
 	PPGeDrawRect(202.0f, ey, 466.0f, ey + 1.0f, CalcFadedColor(0xFFFFFFFF));

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <set>
 #include "Common/CommonTypes.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/sceRtc.h"

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -387,8 +387,7 @@ void PPGeBegin()
 
 	PPGeSetDefaultTexture();
 
-	WriteCmd(GE_CMD_SCISSOR1, (0 << 10) | 0);
-	WriteCmd(GE_CMD_SCISSOR2, (271 << 10) | 479);
+	PPGeScissor(0, 0, 480, 272);
 	WriteCmd(GE_CMD_MINZ, 0);
 	WriteCmd(GE_CMD_MAXZ, 0xFFFF);
 
@@ -418,6 +417,17 @@ void PPGeEnd()
 		DEBUG_LOG(SCEGE, "PPGe enqueued display list %i", list);
 		gpu->EnableInterrupts(true);
 	}
+}
+
+void PPGeScissor(int x1, int y1, int x2, int y2) {
+	assert(x1 >= 0 && x1 <= 480 && x2 >= 0 && x2 <= 480);
+	assert(y1 >= 0 && y1 <= 272 && y2 >= 0 && y2 <= 272);
+	WriteCmd(GE_CMD_SCISSOR1, (y1 << 10) | x1);
+	WriteCmd(GE_CMD_SCISSOR2, ((y2 - 1) << 10) | (x2 - 1));
+}
+
+void PPGeScissorReset() {
+	PPGeScissor(0, 0, 480, 272);
 }
 
 static const AtlasChar *PPGeGetChar(const AtlasFont &atlasfont, unsigned int cval)

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -69,20 +69,28 @@ enum {
 	PPGE_LINE_WRAP_CHAR    = 4,
 };
 
+struct PPGeStyle {
+	PPGeAlign align = PPGeAlign::BOX_LEFT;
+	float scale = 1.0f;
+	uint32_t color = 0xFFFFFFFF;
+	bool hasShadow = false;
+	uint32_t shadowColor = 0x80000000;
+};
+
 // Get the metrics of the bounding box of the text without changing the buffer or state.
 void PPGeMeasureText(float *w, float *h, const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
 // Draws some text using the one font we have.
 // Clears the text buffer when done.
-void PPGeDrawText(const char *text, float x, float y, PPGeAlign align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
-void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, float wrapHeight, PPGeAlign align, float scale = 1.0f, u32 color = 0xFFFFFFFF);
+void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style);
+void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, float wrapHeight, const PPGeStyle &style);
 
 // Draws a "4-patch" for button-like things that can be resized.
 void PPGeDraw4Patch(ImageID atlasImage, float x, float y, float w, float h, u32 color = 0xFFFFFFFF);
 
 // Just blits an image to the screen, multiplied with the color.
-void PPGeDrawImage(ImageID atlasImage, float x, float y, int align, u32 color = 0xFFFFFFFF);
-void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, int align, u32 color = 0xFFFFFFFF);
+void PPGeDrawImage(ImageID atlasImage, float x, float y, const PPGeStyle &style);
+void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, const PPGeStyle &style);
 void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color);
 
 void PPGeNotifyFrame();

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -93,6 +93,10 @@ void PPGeDrawImage(ImageID atlasImage, float x, float y, const PPGeStyle &style)
 void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, const PPGeStyle &style);
 void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color);
 
+// Note: x2/y2 are exclusive.
+void PPGeScissor(int x1, int y1, int x2, int y2);
+void PPGeScissorReset();
+
 void PPGeNotifyFrame();
 
 class PPGeImage {


### PR DESCRIPTION
PSP firmware shows a scrollbar in Final Fantasy 3 on start (the game hard wraps the text.)  Here's what we showed before this pull:

![FF3 showing all message lines at once](https://user-images.githubusercontent.com/191233/82747137-278ecf00-9d4b-11ea-8706-a6e61cce19ab.png)

#12959 left aligns this which is better, but it's still all mashed together.  With the scrollbar, we now show:

![FF3 showing only first 8 lines of message](https://user-images.githubusercontent.com/191233/82747151-5016c900-9d4b-11ea-8c4c-60107fedaa00.png)

One thing I'll note: the scrollbar is currently aligned to the text, not the barriers.  I think it's fine, but it's not ideal - feels a bit odd either way, really.  I thought about showing a darker box for the unscrolled area, which would probably fix it, but is also not as "minimalist" as the typical dialog style.

That the PSP ever showed a scrollbar indicates to me that we must consider text that could be taller than the screen (though it can only be 512 characters long.)

Aside from that, this makes some other changes:
 * Drop shadow handling is now more consistent and simpler to apply.  They're now shown on the net conf and OSK dialogs, as well as for "NEW DATA" in savedata.
 * Drop shadows now look nicer if you have a TextDrawer.
 * Text is allowed to be wider, which should help #12764.  It's also drawn smaller if a large chunk is non-ASCII.
 * Error codes are no longer only just shown as numbers.  Common error codes are shown as translated strings.  Also "Error code:" can now be translated.

Since I'm pasting images, here's one of the drop shadows on OSK:
![PixelJunk Monsters showing an on screen keyboard](https://user-images.githubusercontent.com/191233/82747365-f31c1280-9d4c-11ea-88e6-62f1f2e6d574.png)

-[Unknown]