### PR TITLE
GPU: Don't reapply LoadClut each frame

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1141,7 +1141,9 @@ void GPUCommon::ReapplyGfxState() {
 	// There are a few here in the middle that we shouldn't execute...
 
 	for (int i = GE_CMD_VIEWPORTXSCALE; i < GE_CMD_TRANSFERSTART; i++) {
-		ExecuteOp(gstate.cmdmem[i], 0xFFFFFFFF);
+		if (i != GE_CMD_LOADCLUT) {
+			ExecuteOp(gstate.cmdmem[i], 0xFFFFFFFF);
+		}
 	}
 
 	// Let's just skip the transfer size stuff, it's just values.


### PR DESCRIPTION
Definitely don't need to reapply this one.

This does not explain the crash in #12960, but either way we shouldn't be reapplying so let's not.

-[Unknown]