### PR TITLE
DarkStalkers: Handle the "normal" screen stretch too, not just "wide".

### DIFF
--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -570,6 +570,13 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		}
 	}
 
+	if (flags & OutputFlags::PILLARBOX) {
+		for (int i = 0; i < 4; i++) {
+			// Looks about right.
+			verts[i].x *= 0.75f;
+		}
+	}
+
 	if (usePostShader) {
 		bool flipped = flags & OutputFlags::POSITION_FLIPPED;
 		float post_v0 = !flipped ? 1.0f : 0.0f;

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -58,6 +58,7 @@ enum class OutputFlags {
 	RB_SWIZZLE = 0x0002,
 	BACKBUFFER_FLIPPED = 0x0004,
 	POSITION_FLIPPED = 0x0008,
+	PILLARBOX = 0x0010,
 };
 
 inline OutputFlags operator | (const OutputFlags &lhs, const OutputFlags &rhs) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -132,7 +132,7 @@ void SoftGPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat for
 	GPURecord::NotifyDisplay(framebuf, stride, format);
 }
 
-bool g_DarkStalkerStretch;
+DSStretch g_DarkStalkerStretch;
 
 void SoftGPU::ConvertTextureDescFrom16(Draw::TextureDesc &desc, int srcwidth, int srcheight, u8 *overrideData) {
 	// TODO: This should probably be converted in a shader instead..
@@ -200,7 +200,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 	OutputFlags outputFlags = g_Config.iBufFilter == SCALE_NEAREST ? OutputFlags::NEAREST : OutputFlags::LINEAR;
 	bool hasPostShader = presentation_->HasPostShader();
 
-	if (PSP_CoreParameter().compat.flags().DarkStalkersPresentHack && displayFormat_ == GE_FORMAT_5551 && g_DarkStalkerStretch) {
+	if (PSP_CoreParameter().compat.flags().DarkStalkersPresentHack && displayFormat_ == GE_FORMAT_5551 && g_DarkStalkerStretch != DSStretch::Off) {
 		u8 *data = Memory::GetPointer(0x04088000);
 		bool fillDesc = true;
 		if (draw_->GetDataFormatSupport(Draw::DataFormat::A1B5G5R5_UNORM_PACK16) & Draw::FMT_TEXTURE) {
@@ -223,6 +223,9 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		u1 = 447.5f / (float)desc.width;
 		v0 = 16.0f / (float)desc.height;
 		v1 = 240.0f / (float)desc.height;
+		if (g_DarkStalkerStretch == DSStretch::Normal) {
+			outputFlags |= OutputFlags::PILLARBOX;
+		}
 	} else if (!Memory::IsValidAddress(displayFramebuf_) || srcwidth == 0 || srcheight == 0) {
 		hasImage = false;
 		u1 = 1.0f;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -121,3 +121,10 @@ private:
 extern u32 clut[4096];
 extern FormatBuffer fb;
 extern FormatBuffer depthbuf;
+
+// Type for the DarkStalkers stretch replacement.
+enum class DSStretch {
+	Off = 0,
+	Normal,
+	Wide,
+};


### PR DESCRIPTION
To avoid a surprising performance drop just from tweaking in-game settings. Plus, you could argue that the game is meant to be played this way anyway.

A followup to #12443 .

@LunaMoo  FYI :) Anything else it's missing?