### PR TITLE
Vulkan: After binding a new framebuffer, we always need to dirty the viewport/scissor state.

### DIFF
--- a/GPU/Vulkan/FramebufferVulkan.cpp
+++ b/GPU/Vulkan/FramebufferVulkan.cpp
@@ -337,8 +337,10 @@ void FramebufferManagerVulkan::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb
 void FramebufferManagerVulkan::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp) {
 	if (!dst->fbo || !src->fbo || !useBufferedRendering_) {
 		// This can happen if they recently switched from non-buffered.
-		if (useBufferedRendering_)
+		if (useBufferedRendering_) {
 			draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitFramebuffer_Fail");
+			gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Updated version of https://github.com/hrydgard/ppsspp/pull/12937 .


Currently a whole bunch of games hit those hasViewport/hasScissor asserts, including Wipeout Pure.

This dirties after switching render target so that viewport and scissor commands get written to the new render pass.

Temporary solution until I can figure out how to abstract this away in the RenderManager without losing perf... That GLES blend thing should also be abstracted similarly.