### PR TITLE
UI: Lock around removal from dispatch queue

### DIFF
--- a/ext/native/ui/root.cpp
+++ b/ext/native/ui/root.cpp
@@ -50,6 +50,7 @@ void DispatchEvents() {
 }
 
 void RemoveQueuedEventsByView(View *view) {
+	std::unique_lock<std::mutex> guard(eventMutex_);
 	for (auto it = g_dispatchQueue.begin(); it != g_dispatchQueue.end(); ) {
 		if (it->params.v == view) {
 			it = g_dispatchQueue.erase(it);
@@ -60,6 +61,7 @@ void RemoveQueuedEventsByView(View *view) {
 }
 
 void RemoveQueuedEventsByEvent(Event *event) {
+	std::unique_lock<std::mutex> guard(eventMutex_);
 	for (auto it = g_dispatchQueue.begin(); it != g_dispatchQueue.end(); ) {
 		if (it->e == event) {
 			it = g_dispatchQueue.erase(it);


### PR DESCRIPTION
Happened to glance at this code and noticed the lock was missing.  Can't see any good reason not to have it here, although I guess a click during a view destruct ought to be pretty rare... people do double tap by accident sometimes...

-[Unknown]