### PR TITLE
Dirty state from each DrawEngine

### DIFF
--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012- PPSSPP Project.
 
-4// This program is free software: you can redistribute it and/or modify
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, version 2.0 or later versions.
 
@@ -450,13 +450,13 @@ void FramebufferManagerCommon::DestroyFramebuf(VirtualFramebuffer *v) {
 
 	// Wipe some pointers
 	if (currentRenderVfb_ == v)
-		currentRenderVfb_ = 0;
+		currentRenderVfb_ = nullptr;
 	if (displayFramebuf_ == v)
-		displayFramebuf_ = 0;
+		displayFramebuf_ = nullptr;
 	if (prevDisplayFramebuf_ == v)
-		prevDisplayFramebuf_ = 0;
+		prevDisplayFramebuf_ = nullptr;
 	if (prevPrevDisplayFramebuf_ == v)
-		prevPrevDisplayFramebuf_ = 0;
+		prevPrevDisplayFramebuf_ = nullptr;
 
 	delete v;
 }
@@ -471,7 +471,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 
 	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED);
 
-	// ugly...
+	// Ugly...
 	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
 		gstate_c.Dirty(DIRTY_PROJTHROUGHMATRIX | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_CULLRANGE);
 	}
@@ -1075,7 +1075,6 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 		}
 	} else {
 		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
-		// GLES resets the blend state on clears.
 		gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
 	}
 

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -216,4 +216,6 @@ private:
 
 	// Hardware tessellation
 	TessellationDataTransferD3D11 *tessDataTransferD3D11;
+
+	int lastRenderStepId_ = -1;
 };

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -123,7 +123,8 @@ public:
 	void DestroyDeviceObjects();
 
 	void ClearTrackedVertexArrays() override;
-	void DecimateTrackedVertexArrays();
+
+	void BeginFrame();
 
 	// So that this can be inlined
 	void Flush() {
@@ -143,6 +144,7 @@ public:
 protected:
 	// Not currently supported.
 	bool UpdateUseHWTessellation(bool enable) override { return false; }
+	void DecimateTrackedVertexArrays();
 
 private:
 	void DoFlush();
@@ -156,6 +158,7 @@ private:
 	void MarkUnreliable(VertexArrayInfoDX9 *vai);
 
 	LPDIRECT3DDEVICE9 device_ = nullptr;
+	Draw::DrawContext *draw_;
 
 	PrehashMap<VertexArrayInfoDX9 *, nullptr> vai_;
 	DenseHashMap<u32, IDirect3DVertexDeclaration9 *, nullptr> vertexDeclMap_;
@@ -170,6 +173,8 @@ private:
 
 	// Hardware tessellation
 	TessellationDataTransferDX9 *tessDataTransferDX9;
+
+	int lastRenderStepId_ = -1;
 };
 
 }  // namespace

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -282,7 +282,7 @@ void GPU_DX9::ReapplyGfxState() {
 
 void GPU_DX9::BeginFrame() {
 	textureCacheDX9_->StartFrame();
-	drawEngine_.DecimateTrackedVertexArrays();
+	drawEngine_.BeginFrame();
 	depalShaderCache_.Decimate();
 	// fragmentTestCache_.Decimate();
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -156,6 +156,8 @@ void DrawEngineGLES::ClearInputLayoutMap() {
 }
 
 void DrawEngineGLES::BeginFrame() {
+	DecimateTrackedVertexArrays();
+
 	FrameData &frameData = frameData_[render_->GetCurFrame()];
 	render_->BeginPushBuffer(frameData.pushIndex);
 	render_->BeginPushBuffer(frameData.pushVertex);

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -229,6 +229,8 @@ private:
 
 	int bufferDecimationCounter_ = 0;
 
+	int lastRenderStepId_ = -1;
+
 	// Hardware tessellation
 	TessellationDataTransferGLES *tessDataTransferGLES;
 };

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -150,7 +150,6 @@ public:
 	void DeviceRestore(Draw::DrawContext *draw);
 
 	void ClearTrackedVertexArrays() override;
-	void DecimateTrackedVertexArrays();
 
 	void BeginFrame();
 	void EndFrame();
@@ -186,6 +185,7 @@ public:
 
 protected:
 	bool UpdateUseHWTessellation(bool enable) override;
+	void DecimateTrackedVertexArrays();
 
 private:
 	void InitDeviceObjects();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -373,7 +373,6 @@ void GPU_GLES::ReapplyGfxState() {
 
 void GPU_GLES::BeginFrame() {
 	textureCacheGL_->StartFrame();
-	drawEngine_.DecimateTrackedVertexArrays();
 	depalShaderCache_.Decimate();
 	fragmentTestCache_.Decimate();
 

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -320,8 +320,8 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 	}
 }
 
-void DrawEngineGLES::ApplyDrawStateLate(bool setStencil, int stencilValue) {
-	if (setStencil) {
+void DrawEngineGLES::ApplyDrawStateLate(bool setStencilValue, int stencilValue) {
+	if (setStencilValue) {
 		render_->SetStencilFunc(GL_TRUE, GL_ALWAYS, stencilValue, 255);
 	}
 

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -302,4 +302,6 @@ private:
 
 	// Hardware tessellation
 	TessellationDataTransferVulkan *tessDataTransferVulkan;
+
+	int lastRenderStepId_ = -1;
 };

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -796,7 +796,6 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 			}
 			if (c.clear.colorMask != colorMask) {
 				glColorMask(c.clear.colorMask & 1, (c.clear.colorMask >> 1) & 1, (c.clear.colorMask >> 2) & 1, (c.clear.colorMask >> 3) & 1);
-				colorMask = c.clear.colorMask;
 			}
 			if (c.clear.clearMask & GL_COLOR_BUFFER_BIT) {
 				float color[4];
@@ -818,6 +817,10 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step) {
 				glClearStencil(c.clear.clearStencil);
 			}
 			glClear(c.clear.clearMask);
+			// Restore the color mask if it was different.
+			if (c.clear.colorMask != colorMask) {
+				glColorMask(colorMask & 1, (colorMask >> 1) & 1, (colorMask >> 2) & 1, (colorMask >> 3) & 1);
+			}
 			if (c.clear.scissorW == 0) {
 				glEnable(GL_SCISSOR_TEST);
 			}

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -5,7 +5,6 @@
 #include "thin3d/thin3d.h"
 #include "thread/threadutil.h"
 #include "base/logging.h"
-#include "GPU/GPUState.h"
 #include "Common/MemoryUtil.h"
 
 #if 0 // def _DEBUG
@@ -318,9 +317,6 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 			step->dependencies.insert(fb);
 		}
 	}
-
-	// Every step clears this state.
-	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE);
 }
 
 void GLRenderManager::BindFramebufferAsTexture(GLRFramebuffer *fb, int binding, int aspectBit, int attachment) {
@@ -346,9 +342,6 @@ void GLRenderManager::CopyFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLR
 	if (dstPos.x != 0 || dstPos.y != 0 || !fillsDst)
 		step->dependencies.insert(dst);
 	steps_.push_back(step);
-
-	// Every step clears this state.
-	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE);
 }
 
 void GLRenderManager::BlitFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLRFramebuffer *dst, GLRect2D dstRect, int aspectMask, bool filter, const char *tag) {
@@ -365,9 +358,6 @@ void GLRenderManager::BlitFramebuffer(GLRFramebuffer *src, GLRect2D srcRect, GLR
 	if (!fillsDst)
 		step->dependencies.insert(dst);
 	steps_.push_back(step);
-
-	// Every step clears this state.
-	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE);
 }
 
 bool GLRenderManager::CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspectBits, int x, int y, int w, int h, Draw::DataFormat destFormat, uint8_t *pixels, int pixelStride, const char *tag) {
@@ -381,9 +371,6 @@ bool GLRenderManager::CopyFramebufferToMemorySync(GLRFramebuffer *src, int aspec
 	step->dependencies.insert(src);
 	step->tag = tag;
 	steps_.push_back(step);
-
-	// Every step clears this state.
-	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE);
 
 	curRenderStep_ = nullptr;
 	FlushSync();
@@ -413,9 +400,6 @@ void GLRenderManager::CopyImageToMemorySync(GLRTexture *texture, int mipLevel, i
 	step->readback_image.srcRect = { x, y, w, h };
 	step->tag = tag;
 	steps_.push_back(step);
-
-	// Every step clears this state.
-	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE);
 
 	curRenderStep_ = nullptr;
 	FlushSync();

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -812,7 +812,7 @@ public:
 		curRenderStep_->commands.push_back(data);
 	}
 
-	// If scissorW == 0, no scissor is applied.
+	// If scissorW == 0, no scissor is applied (the whole render target is cleared).
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask, int colorMask, int scissorX, int scissorY, int scissorW, int scissorH) {
 		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		if (!clearMask)

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -673,6 +673,8 @@ public:
 	// Flush state like scissors etc so the caller can do its own custom drawing.
 	virtual void FlushState() {}
 
+	virtual int GetCurrentStepId() const = 0;
+
 protected:
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -478,6 +478,10 @@ public:
 
 	void HandleEvent(Event ev, int width, int height, void *param1, void *param2) override {}
 
+	int GetCurrentStepId() const {
+		return renderManager_.GetCurrentStepId();
+	}
+
 private:
 	void ApplySamplers();
 

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -482,6 +482,10 @@ public:
 
 	void HandleEvent(Event ev, int width, int height, void *param1, void *param2) override;
 
+	int GetCurrentStepId() const {
+		return renderManager_.GetCurrentStepId();
+	}
+
 private:
 	VulkanTexture *GetNullTexture();
 	VulkanContext *vulkan_ = nullptr;


### PR DESCRIPTION
This is to get rid of the annoying state dirtying we have sprinkled around each draw_->BindFramebufferAsRenderTarget, which had ugly backend specific stuff etc.

Instead of doing extra state tracking inside the RenderManagers, I decided to make a way for the DrawEngines to figure out during Flush whether the render target has changed (there's a new render step). In that case, it can do whatever dirtying that its render manager specifies is necessary. It does this by checking a "step id".  This will also later allow us to enable an optimization for the Vulkan backend that has been disabled for way too long (proper pipeline dirtying).

The D3D backends don't have a rendermanager, they just go straight through so I had to invent a fake step number inside each thin3d instance instead, but turned out pretty neat.

This lets us remove a lot of strange dirtying after binding new rendertargets from the common code.

Since in nearly all cases I can see this adds more dirtying (except d3d which loses some BLEND dirtying it didn't need), this feels fairly safe at least...