### PR TITLE
Display: Allow unthrottle to skip only flipping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,7 @@ charset = utf-8-bom
 
 [Windows/{aboutbox.rc,version.rc}]
 charset = utf-16le
+
+[libretro/**.{cpp,h}]
+indent_style = space
+indent_size = 3

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -529,11 +529,11 @@ static int DefaultInternalResolution() {
 #endif
 }
 
-static bool DefaultFrameskipUnthrottle() {
+static int DefaultUnthrottleMode() {
 #if !PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(UWP)
-	return true;
+	return (int)UnthrottleMode::SKIP_DRAW;
 #else
-	return false;
+	return (int)UnthrottleMode::CONTINUOUS;
 #endif
 }
 
@@ -705,6 +705,28 @@ struct ConfigTranslator {
 
 typedef ConfigTranslator<GPUBackend, GPUBackendToString, GPUBackendFromString> GPUBackendTranslator;
 
+static int UnthrottleModeFromString(const std::string &s) {
+	if (!strcasecmp(s.c_str(), "CONTINUOUS"))
+		return (int)UnthrottleMode::CONTINUOUS;
+	if (!strcasecmp(s.c_str(), "SKIP_DRAW"))
+		return (int)UnthrottleMode::SKIP_DRAW;
+	if (!strcasecmp(s.c_str(), "SKIP_FLIP"))
+		return (int)UnthrottleMode::SKIP_FLIP;
+	return DefaultUnthrottleMode();
+}
+
+std::string UnthrottleModeToString(int v) {
+	switch (UnthrottleMode(v)) {
+	case UnthrottleMode::CONTINUOUS:
+		return "CONTINUOUS";
+	case UnthrottleMode::SKIP_DRAW:
+		return "SKIP_DRAW";
+	case UnthrottleMode::SKIP_FLIP:
+		return "SKIP_FLIP";
+	}
+	return "CONTINUOUS";
+}
+
 static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("EnableCardboardVR", &g_Config.bEnableCardboardVR, false, true, true),
 	ConfigSetting("CardboardScreenSize", &g_Config.iCardboardScreenSize, 50, true, true),
@@ -734,7 +756,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false, true, true),
 	ConfigSetting("FrameRate", &g_Config.iFpsLimit1, 0, true, true),
 	ConfigSetting("FrameRate2", &g_Config.iFpsLimit2, -1, true, true),
-	ConfigSetting("FrameSkipUnthrottle", &g_Config.bFrameSkipUnthrottle, &DefaultFrameskipUnthrottle, true, false),
+	ConfigSetting("UnthrottleMode", &g_Config.iUnthrottleMode, &DefaultUnthrottleMode, &UnthrottleModeToString, &UnthrottleModeFromString, true, true),
 #if defined(USING_WIN_UI)
 	ConfigSetting("RestartRequired", &g_Config.bRestartRequired, false, false),
 #endif

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -161,8 +161,8 @@ public:
 	bool bVSync;
 	int iFrameSkip;
 	int iFrameSkipType;
+	int iUnthrottleMode; // See UnthrottleMode in ConfigValues.h.
 	bool bAutoFrameSkip;
-	bool bFrameSkipUnthrottle;
 
 	bool bEnableCardboardVR; // Cardboard Master Switch
 	int iCardboardScreenSize; // Screen Size (in %)

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -110,3 +110,9 @@ enum class AutoLoadSaveState {
 	OLDEST = 1,
 	NEWEST = 2,
 };
+
+enum class UnthrottleMode {
+	CONTINUOUS = 0,
+	SKIP_DRAW = 1,
+	SKIP_FLIP = 2,
+};

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -382,7 +382,7 @@ int main(int argc, const char* argv[])
 	g_Config.iButtonPreference = PSP_SYSTEMPARAM_BUTTON_CROSS;
 	g_Config.iLockParentalLevel = 9;
 	g_Config.iInternalResolution = 1;
-	g_Config.bFrameSkipUnthrottle = false;
+	g_Config.iUnthrottleMode = (int)UnthrottleMode::CONTINUOUS;
 	g_Config.bEnableLogging = fullLog;
 	g_Config.iNumWorkerThreads = 1;
 	g_Config.bSoftwareSkinning = true;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -342,7 +342,7 @@ void retro_init(void)
 #endif
 
    g_Config.bEnableLogging = true;
-   g_Config.bFrameSkipUnthrottle = false;
+   g_Config.iUnthrottleMode = (int)UnthrottleMode::CONTINUOUS;
    g_Config.bMemStickInserted = PSP_MEMORYSTICK_STATE_INSERTED;
    g_Config.iGlobalVolume = VOLUME_MAX - 1;
    g_Config.iAltSpeedVolume = -1;


### PR DESCRIPTION
Before, it either flipped continuously, or forced frameskip on.  This makes it so you can still draw frames, but skip actual flips.

This is useful when games draw things only in a single frame and reuse later.  It's also useful when measuring speed improvements if you already get 100% speed on a device.

This resets the previous FrameskipUnthrottle setting.  That said, this may be a good thing because some users changed it when vsync/postshaders were not interacting as well with it, and I think those problems are fixed.

-[Unknown]