### PR TITLE
Label steps using GL debug groups

### DIFF
--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -276,6 +276,7 @@ enum class GLRStepType : uint8_t {
 	BLIT,
 	READBACK,
 	READBACK_IMAGE,
+	RENDER_SKIP,
 };
 
 enum class GLRRenderPassAction {
@@ -372,7 +373,7 @@ private:
 	void InitCreateFramebuffer(const GLRInitStep &step);
 
 	void PerformBindFramebufferAsRenderTarget(const GLRStep &pass);
-	void PerformRenderPass(const GLRStep &pass);
+	void PerformRenderPass(const GLRStep &pass, bool first, bool last);
 	void PerformCopy(const GLRStep &pass);
 	void PerformBlit(const GLRStep &pass);
 	void PerformReadback(const GLRStep &pass);

--- a/ext/native/thin3d/GLQueueRunner.h
+++ b/ext/native/thin3d/GLQueueRunner.h
@@ -421,4 +421,5 @@ private:
 	std::unordered_map<int, std::string> glStrings_;
 
 	bool sawOutOfMemory_ = false;
+	bool useDebugGroups_ = false;
 };


### PR DESCRIPTION
Basically the same as Vulkan, shows nicely in RenderDoc.

Also, cut a few redundant calls between renderpasses (i.e. flipping scissor off/on etc.)  It's minor, but it cuts noise out of the trace.

-[Unknown]