### PR TITLE
GPU: Don't allow step id to decrease at a sync

### DIFF
--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -442,6 +442,7 @@ void GLRenderManager::BeginFrame() {
 	// In GL, we have to do deletes on the submission thread.
 
 	insideFrame_ = true;
+	renderStepOffset_ = 0;
 }
 
 void GLRenderManager::Finish() {
@@ -565,6 +566,8 @@ void GLRenderManager::Run(int frame) {
 
 void GLRenderManager::FlushSync() {
 	// TODO: Reset curRenderStep_?
+	renderStepOffset_ += (int)steps_.size();
+
 	int curFrame = curFrame_;
 	FrameData &frameData = frameData_[curFrame];
 	{

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -940,7 +940,7 @@ public:
 	// Gets a frame-unique ID of the current step being recorded. Can be used to figure out
 	// when the current step has changed, which means the caller will need to re-record its state.
 	int GetCurrentStepId() const {
-		return (int)steps_.size();
+		return renderStepOffset_ + (int)steps_.size();
 	}
 
 private:
@@ -989,6 +989,8 @@ private:
 
 	// Submission time state
 	bool insideFrame_ = false;
+	// This is the offset within this frame, in case of a mid-frame sync.
+	int renderStepOffset_ = 0;
 	GLRStep *curRenderStep_ = nullptr;
 	std::vector<GLRStep *> steps_;
 	std::vector<GLRInitStep> initSteps_;

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -422,6 +422,7 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling) {
 	vulkan_->BeginFrame();
 
 	insideFrame_ = true;
+	renderStepOffset_ = 0;
 
 	frameData.profile.timestampDescriptions.clear();
 	if (frameData_->profilingEnabled_) {
@@ -1173,6 +1174,8 @@ void VulkanRenderManager::EndSyncFrame(int frame) {
 
 void VulkanRenderManager::FlushSync() {
 	// TODO: Reset curRenderStep_?
+	renderStepOffset_ += (int)steps_.size();
+
 	int curFrame = vulkan_->GetCurFrame();
 	FrameData &frameData = frameData_[curFrame];
 	if (!useThread_) {

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -254,7 +254,7 @@ public:
 	// Gets a frame-unique ID of the current step being recorded. Can be used to figure out
 	// when the current step has changed, which means the caller will need to re-record its state.
 	int GetCurrentStepId() const {
-		return (int)steps_.size();
+		return renderStepOffset_ + (int)steps_.size();
 	}
 
 	void CreateBackbuffers();
@@ -341,6 +341,8 @@ private:
 	int curWidth_ = -1;
 	int curHeight_ = -1;
 	bool insideFrame_ = false;
+	// This is the offset within this frame, in case of a mid-frame sync.
+	int renderStepOffset_ = 0;
 	VKRStep *curRenderStep_ = nullptr;
 	bool curStepHasViewport_ = false;
 	bool curStepHasScissor_ = false;


### PR DESCRIPTION
This might've caused us to miss necessary dynamic state dirtying in games, but only in fairly specific cases.  But it happens a lot when stepping via the GE debugger, since that does so much downloading.

-[Unknown]