### PR TITLE
Display layout editor inset fix/workaround

### DIFF
--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -84,7 +84,9 @@ private:
 };
 
 DisplayLayoutScreen::DisplayLayoutScreen() {
-};
+	// Ignore insets - just couldn't get the logic to work.
+	ignoreInsets_ = true;
+}
 
 bool DisplayLayoutScreen::touch(const TouchInput &touch) {
 	UIScreen::touch(touch);
@@ -253,11 +255,14 @@ void DisplayLayoutScreen::CreateViews() {
 	// This makes it have at least 10.0f padding below at 1x.
 	const float vertBoundariesHeight = 52.0f;
 
+	// We manually implement insets here for the buttons. This file defied refactoring :(
+	float leftInset = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
+
 	// Left side, right, top, bottom.
-	root_->Add(new Boundary(new AnchorLayoutParams(horizBoundariesWidth, FILL_PARENT, NONE, 0, horizPreviewPadding + previewWidth, 0)));
+	root_->Add(new Boundary(new AnchorLayoutParams(horizBoundariesWidth, FILL_PARENT, horizPreviewPadding - horizBoundariesWidth, 0, NONE, 0)));
 	root_->Add(new Boundary(new AnchorLayoutParams(horizBoundariesWidth, FILL_PARENT, horizPreviewPadding + previewWidth, 0, NONE, 0)));
 	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, vertPreviewPadding - vertBoundariesHeight, NONE, NONE)));
-	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, NONE, NONE, vertPreviewPadding - vertBoundariesHeight)));
+	root_->Add(new Boundary(new AnchorLayoutParams(previewWidth, vertBoundariesHeight, horizPreviewPadding, vertPreviewPadding + previewHeight, NONE, NONE)));
 
 	bool displayRotEnable = (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) || g_Config.bSoftwareRendering;
 	bRotated_ = false;
@@ -290,16 +295,16 @@ void DisplayLayoutScreen::CreateViews() {
 			g_Config.fSmallDisplayOffsetX = 0.5f;
 			g_Config.fSmallDisplayOffsetY = 0.5f;
 		} else { // Manual Scaling
-			Choice *center = new Choice(di->T("Center"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 74));
+			Choice *center = new Choice(di->T("Center"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 74));
 			center->OnClick.Handle(this, &DisplayLayoutScreen::OnCenter);
 			root_->Add(center);
 			float minZoom = 1.0f;
 			if (g_dpi_scale_x > 1.0f) {
 				minZoom /= g_dpi_scale_x;
 			}
-			PopupSliderChoiceFloat *zoomlvl = new PopupSliderChoiceFloat(&g_Config.fSmallDisplayZoomLevel, minZoom, 10.0f, di->T("Zoom"), 1.0f, screenManager(), di->T("* PSP res"), new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10 + 64 + 64));
+			PopupSliderChoiceFloat *zoomlvl = new PopupSliderChoiceFloat(&g_Config.fSmallDisplayZoomLevel, minZoom, 10.0f, di->T("Zoom"), 1.0f, screenManager(), di->T("* PSP res"), new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 10 + 64 + 64));
 			root_->Add(zoomlvl);
-			mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 158 + 64 + 10));
+			mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 158 + 64 + 10));
 			mode_->AddChoice(di->T("Move"));
 			mode_->AddChoice(di->T("Resize"));
 			mode_->SetSelection(0);
@@ -359,7 +364,7 @@ void DisplayLayoutScreen::CreateViews() {
 	});
 	root_->Add(rotation);
 
-	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10));
+	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 10));
 	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 	root_->Add(back);
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1487,7 +1487,7 @@ void EmuScreen::renderUI() {
 
 	DrawBuffer *draw2d = ctx->Draw();
 	if (root_) {
-		UI::LayoutViewHierarchy(*ctx, root_);
+		UI::LayoutViewHierarchy(*ctx, root_, false);
 		root_->Draw(*ctx);
 	}
 

--- a/ext/native/ui/root.cpp
+++ b/ext/native/ui/root.cpp
@@ -102,13 +102,13 @@ bool IsFocusMovementEnabled() {
 	return focusMovementEnabled;
 }
 
-void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root) {
+void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets) {
 	if (!root) {
 		ELOG("Tried to layout a view hierarchy from a zero pointer root");
 		return;
 	}
 
-	Bounds rootBounds = dc.GetLayoutBounds();
+	Bounds rootBounds = ignoreInsets ? dc.GetBounds() : dc.GetLayoutBounds();
 
 	MeasureSpec horiz(EXACTLY, rootBounds.w);
 	MeasureSpec vert(EXACTLY, rootBounds.h);

--- a/ext/native/ui/root.h
+++ b/ext/native/ui/root.h
@@ -19,7 +19,7 @@ void DispatchEvents();
 
 class ViewGroup;
 
-void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root);
+void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets);
 void UpdateViewHierarchy(ViewGroup *root);
 // Hooks arrow keys for navigation
 bool KeyEvent(const KeyInput &key, ViewGroup *root);

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -45,7 +45,7 @@ void UIScreen::DoRecreateViews() {
 
 			// Update layout and refocus so things scroll into view.
 			// This is for resizing down, when focused on something now offscreen.
-			UI::LayoutViewHierarchy(*screenManager()->getUIContext(), root_);
+			UI::LayoutViewHierarchy(*screenManager()->getUIContext(), root_, ignoreInsets_);
 			UI::View *focused = UI::GetFocusedView();
 			if (focused) {
 				root_->SubviewFocused(focused);
@@ -107,7 +107,7 @@ void UIScreen::render() {
 
 	if (root_) {
 		UIContext *uiContext = screenManager()->getUIContext();
-		UI::LayoutViewHierarchy(*uiContext, root_);
+		UI::LayoutViewHierarchy(*uiContext, root_, ignoreInsets_);
 
 		uiContext->PushTransform({translation_, scale_, alpha_});
 

--- a/ext/native/ui/ui_screen.h
+++ b/ext/native/ui/ui_screen.h
@@ -48,6 +48,7 @@ protected:
 	Vec3 translation_ = Vec3(0.0f);
 	Vec3 scale_ = Vec3(1.0f);
 	float alpha_ = 1.0f;
+	bool ignoreInsets_ = false;
 
 private:
 	void DoRecreateViews();


### PR DESCRIPTION
Tried to refactor and fix the Display Layout Editor for proper inset (camera notch) bounds multiple times but it just resists and the bugs get weirder and weirder. It needs a rewrite, but for 10.0, I just try to avoid regressions and simply move the buttons by the left inset and leave it as is. A bit sad but works.

Fixes #12797  (kind of)