### PR TITLE
Real support Code Geass: Lost Colors chinese patched version

### DIFF
--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -83,13 +83,29 @@ static int sceKernelDeleteHeap(int heapId) {
 	}
 }
 
+static u32 sceKernelPartitionTotalFreeMemSize(int partitionId) {
+	ERROR_LOG(SCEKERNEL, "UNIMP sceKernelPartitionTotalFreeMemSize(%d)", partitionId);
+	//Need more work #13021
+	///We ignore partitionId for now
+	return userMemory.GetTotalFreeBytes();
+}
+
+static u32 sceKernelPartitionMaxFreeMemSize(int partitionId) {
+	ERROR_LOG(SCEKERNEL, "UNIMP sceKernelPartitionMaxFreeMemSize(%d)", partitionId);
+	//Need more work #13021
+	///We ignore partitionId for now
+	return userMemory.GetLargestFreeBlockSize();
+}
+
 const HLEFunction SysMemForKernel[] = {
-	{ 0X636C953B, &WrapI_II<sceKernelAllocHeapMemory>, "sceKernelAllocHeapMemory", 'x', "ii" },
-	{ 0XC9805775, &WrapI_I<sceKernelDeleteHeap>,       "sceKernelDeleteHeap",      'i', "i" },
-	{ 0X1C1FBFE7, &WrapI_IIIC<sceKernelCreateHeap>,    "sceKernelCreateHeap",      'i', "iixs" },
-	{ 0X237DBD4F, &WrapI_ICIUU<sceKernelAllocPartitionMemory>,     "sceKernelAllocPartitionMemory",         'i', "isixx",HLE_KERNEL_SYSCALL },
-	{ 0XB6D61D02, &WrapI_I<sceKernelFreePartitionMemory>,          "sceKernelFreePartitionMemory",          'i', "i",HLE_KERNEL_SYSCALL },
-	{ 0X9D9A5BA1, &WrapU_I<sceKernelGetBlockHeadAddr>,             "sceKernelGetBlockHeadAddr",             'x', "i",HLE_KERNEL_SYSCALL },
+	{ 0X636C953B, &WrapI_II<sceKernelAllocHeapMemory>, "sceKernelAllocHeapMemory", 'x', "ii",                                  HLE_KERNEL_SYSCALL },
+	{ 0XC9805775, &WrapI_I<sceKernelDeleteHeap>,       "sceKernelDeleteHeap",      'i', "i" ,                                  HLE_KERNEL_SYSCALL },
+	{ 0X1C1FBFE7, &WrapI_IIIC<sceKernelCreateHeap>,    "sceKernelCreateHeap",      'i', "iixs",                                HLE_KERNEL_SYSCALL },
+	{ 0X237DBD4F, &WrapI_ICIUU<sceKernelAllocPartitionMemory>,     "sceKernelAllocPartitionMemory",         'i', "isixx",      HLE_KERNEL_SYSCALL },
+	{ 0XB6D61D02, &WrapI_I<sceKernelFreePartitionMemory>,          "sceKernelFreePartitionMemory",          'i', "i",          HLE_KERNEL_SYSCALL },
+	{ 0X9D9A5BA1, &WrapU_I<sceKernelGetBlockHeadAddr>,             "sceKernelGetBlockHeadAddr",             'x', "i",          HLE_KERNEL_SYSCALL },
+	{ 0x9697CD32, &WrapU_I<sceKernelPartitionTotalFreeMemSize>,           "sceKernelPartitionTotalFreeMemSize",       'x', "i",HLE_KERNEL_SYSCALL },
+	{ 0xE6581468, &WrapU_I<sceKernelPartitionMaxFreeMemSize>,             "sceKernelPartitionMaxFreeMemSize",         'x', "i",HLE_KERNEL_SYSCALL },
 };
 
 void Register_SysMemForKernel() {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -212,7 +212,7 @@ static const char *altBootNames[] = {
 	"disc0:/PSP_GAME/SYSDIR/EBOOT.LEI",
 	"disc0:/PSP_GAME/SYSDIR/EBOOT.DNR",
 	"disc0:/PSP_GAME/SYSDIR/DBZ2.BIN",
-	"disc0:/PSP_GAME/SYSDIR/ss.RAW",
+	//"disc0:/PSP_GAME/SYSDIR/ss.RAW",//Code Geass: Lost Colors chinese version
 };
 
 bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {


### PR DESCRIPTION
Some work in #13021 

Modify log: https://gist.github.com/sum2012/d7bdc5fb2f41ff9bf347961dce9bbe92
Some interest log:

49:20:805 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:748 Untested sysclib_memset(dest=083fdce8, data=0 ,size=64)
49:20:805 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:737 Unimpl sysclib_sprintf(dest=083fdce8, src=08221a10)
49:20:805 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:717 Untested sysclib_strlen(src=083fdce8)
49:20:805 main_thread  I[SCEIO]: HLE\sceIo.cpp:1131 stdout: DisplayGetMode mode=%d w=%d h=%d
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:737 Unimpl sysclib_sprintf(dest=083fdce8, src=08221a34)
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:717 Untested sysclib_strlen(src=083fdce8)
49:20:806 main_thread  I[SCEIO]: HLE\sceIo.cpp:1131 stdout: bw=%d pixelformar=%d get vram OK!
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelHeap.cpp:87 UNIMP sceKernelPartitionTotalFreeMemSize(1)
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:737 Unimpl sysclib_sprintf(dest=083fdce8, src=08221a6c)
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:717 Untested sysclib_strlen(src=083fdce8)
49:20:806 main_thread  I[SCEIO]: HLE\sceIo.cpp:1131 stdout: par 1 free=%d byte
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelHeap.cpp:94 UNIMP sceKernelPartitionMaxFreeMemSize(1)
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:737 Unimpl sysclib_sprintf(dest=083fdce8, src=08221a80)
49:20:806 main_thread  E[SCEKERNEL]: HLE\sceKernelInterrupt.cpp:717 Untested sysclib_strlen(src=083fdce8)
49:20:807 main_thread  I[SCEIO]: HLE\sceIo.cpp:1131 stdout: par 1 MAX=%d byte