### PR TITLE
Simplify Vulkan initialization a little, don't recreate surface on resize

### DIFF
--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -145,14 +145,7 @@ public:
 	// The parameters are whatever the chosen window system wants.
 	// The extents will be automatically determined.
 	VkResult InitSurface(WindowSystem winsys, void *data1, void *data2);
-	VkResult ReinitSurface();
 
-	bool InitQueue();
-	bool InitObjects();
-	bool InitSwapchain();
-
-	// Also destroys the surface.
-	void DestroyObjects();
 	void DestroyDevice();
 
 	void PerformPendingDeletes();
@@ -272,8 +265,18 @@ public:
 
 	void GetImageMemoryRequirements(VkImage image, VkMemoryRequirements *mem_reqs, bool *dedicatedAllocation);
 
+	// Call this if the window was resized. Does not recreate the surface so can't switch windows (not sure why you'd
+	// want to do that though).
+	bool RecreateSwapchain();
+
+	// Only used on Android where we predictably lose the entire surface easily.
+	// This also tears down the swap chain.
+	void DestroySurface();
+
 private:
 	VkResult InitDebugUtilsCallback();
+	VkResult ReinitSurface();
+	bool InitQueue();
 
 	// A layer can expose extensions, keep track of those extensions here.
 	struct LayerProperties {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -114,7 +114,9 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 		}
 	}
 	if (audioDev <= 0) {
-		ILOG("SDL: Trying a different device");
+		if (!startDevice.empty()) {
+			ILOG("SDL: Trying a different audio device - '%s' was rejected", startDevice.c_str());
+		}
 		audioDev = SDL_OpenAudioDevice(nullptr, 0, &fmt, &g_retFmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	}
 	if (audioDev <= 0) {

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -92,11 +92,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 		break;
 	}
 
-	if (!vulkan_->InitObjects()) {
-		*error_message = vulkan_->InitError();
-		Shutdown();
-		return false;
-	}
+	vulkan_->RecreateSwapchain();
 
 	draw_ = Draw::T3DCreateVulkanContext(vulkan_, false);
 	SetGPUBackend(GPUBackend::VULKAN);
@@ -116,7 +112,6 @@ void SDLVulkanGraphicsContext::Shutdown() {
 	delete draw_;
 	draw_ = nullptr;
 	vulkan_->WaitUntilQueueIdle();
-	vulkan_->DestroyObjects();
 	vulkan_->DestroyDevice();
 	vulkan_->DestroyInstance();
 	delete vulkan_;
@@ -126,9 +121,7 @@ void SDLVulkanGraphicsContext::Shutdown() {
 
 void SDLVulkanGraphicsContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
-	vulkan_->DestroyObjects();
-	vulkan_->ReinitSurface();
-	vulkan_->InitObjects();
+	vulkan_->RecreateSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 }
 

--- a/SDL/SDLVulkanGraphicsContext.h
+++ b/SDL/SDLVulkanGraphicsContext.h
@@ -28,8 +28,8 @@ public:
 
 	void Poll() override;
 
-	void SwapInterval(int interval) override {
-	}
+	void SwapInterval(int interval) override {}
+
 	void *GetAPIContext() override {
 		return vulkan_;
 	}

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -24,6 +24,9 @@ static uint32_t FlagsFromConfig() {
 	if (g_Config.bVSync) {
 		return VULKAN_FLAG_PRESENT_FIFO;
 	}
+
+	// TODO: Config option to enable validation?
+
 	return VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED;
 }
 
@@ -59,11 +62,6 @@ bool AndroidVulkanContext::InitAPI() {
 		delete g_Vulkan;
 		g_Vulkan = nullptr;
 		return false;
-	}
-
-	if (g_validate_) {
-		int bits = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
-		g_Vulkan->InitDebugMsgCallback(&Vulkan_Dbg, bits, &g_LogOptions);
 	}
 
 	int physicalDevice = g_Vulkan->GetBestPhysicalDevice();

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -103,7 +103,7 @@ void VulkanQueueRunner::DestroyDeviceObjects() {
 }
 
 void VulkanQueueRunner::InitBackbufferRenderPass() {
-	VkAttachmentDescription attachments[2];
+	VkAttachmentDescription attachments[2]{};
 	attachments[0].format = vulkan_->GetSwapchainFormat();
 	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -180,7 +180,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 		return pass;
 	}
 
-	VkAttachmentDescription attachments[2] = {};
+	VkAttachmentDescription attachments[2]{};
 	attachments[0].format = VK_FORMAT_R8G8B8A8_UNORM;
 	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
 	switch (key.colorLoadAction) {

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -69,10 +69,6 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	vk->InitSurface(WINDOWSYSTEM_WAYLAND, nullptr, nullptr);
 #endif
 
-	if (!vk->InitQueue()) {
-		return false;
-	}
-
 	context->gpu = vk->GetPhysicalDevice(physical_device);
 	context->device = vk->GetDevice();
 	context->queue = vk->GetGraphicsQueue();
@@ -116,7 +112,6 @@ void LibretroVulkanContext::Shutdown() {
 
 	vk->WaitUntilQueueIdle();
 
-	vk->DestroyObjects();
 	vk->DestroyDevice();
 	vk->DestroyInstance();
 	delete vk;
@@ -140,9 +135,7 @@ void LibretroVulkanContext::CreateDrawContext() {
 	}
 	vk_libretro_set_hwrender_interface(vulkan);
 
-	vk->ReinitSurface();
-
-	if (!vk->InitSwapchain()) {
+	if (!vk->RecreateSwapchain()) {
 		return;
 	}
 


### PR DESCRIPTION
Except on Android, where we still do since the surface is lost on defocus/resize.

Might help #13009.

Not yet tested with SDL, will do shortly.