### PR TITLE
Vulkan: Recreate the swapchain if we get too many "out of date" frames

### DIFF
--- a/Common/GraphicsContext.h
+++ b/Common/GraphicsContext.h
@@ -34,6 +34,10 @@ public:
 	virtual void ThreadEnd() {}
 	virtual void StopThread() {}
 
+	// Useful for checks that need to be performed every frame.
+	// Should strive to get rid of these.
+	virtual void Poll() {}
+
 	virtual Draw::DrawContext *GetDrawContext() = 0;
 };
 

--- a/SDL/SDLVulkanGraphicsContext.h
+++ b/SDL/SDLVulkanGraphicsContext.h
@@ -7,6 +7,8 @@
 
 #include "thin3d/thin3d.h"
 
+class VulkanRenderManager;
+
 class SDLVulkanGraphicsContext : public GraphicsContext {
 public:
 	SDLVulkanGraphicsContext() {}
@@ -22,13 +24,9 @@ public:
 		// We don't do it this way.
 	}
 
-	void Resize() override {
-		draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
-		vulkan_->DestroyObjects();
-		vulkan_->ReinitSurface();
-		vulkan_->InitObjects();
-		draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
-	}
+	void Resize() override;
+
+	void Poll() override;
 
 	void SwapInterval(int interval) override {
 	}
@@ -42,4 +40,5 @@ public:
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	VulkanContext *vulkan_ = nullptr;
+	VulkanRenderManager *renderManager_ = nullptr;
 };

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1095,6 +1095,8 @@ void NativeRender(GraphicsContext *graphicsContext) {
 			NativeMessageReceived("gpu_resized", "");
 		}
 #endif
+	} else {
+		graphicsContext->Poll();
 	}
 
 	ui_draw2d.PopDrawMatrix();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1096,6 +1096,7 @@ void NativeRender(GraphicsContext *graphicsContext) {
 		}
 #endif
 	} else {
+		// ILOG("Polling graphics context");
 		graphicsContext->Poll();
 	}
 

--- a/Windows/GPU/WindowsVulkanContext.h
+++ b/Windows/GPU/WindowsVulkanContext.h
@@ -21,6 +21,8 @@
 #include "Windows/GPU/WindowsGraphicsContext.h"
 #include "thin3d/thin3d.h"
 
+class VulkanRenderManager;
+
 class WindowsVulkanContext : public WindowsGraphicsContext {
 public:
 	WindowsVulkanContext() : draw_(nullptr) {}
@@ -29,11 +31,13 @@ public:
 	void SwapInterval(int interval) override {}
 	void SwapBuffers() override {}
 	void Resize() override;
+	void Poll() override;
 
 	void *GetAPIContext();
 
 	Draw::DrawContext *GetDrawContext() override { return draw_; }
 private:
 	Draw::DrawContext *draw_;
+	VulkanRenderManager *renderManager_ = nullptr;
 };
 

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -209,6 +209,8 @@ void VulkanRenderManager::CreateBackbuffers() {
 		newInflightFrames_ = -1;
 	}
 
+	outOfDateFrames_ = 0;
+
 	// Start the thread.
 	if (useThread_ && HasBackbuffers()) {
 		run_ = true;
@@ -1029,11 +1031,14 @@ void VulkanRenderManager::BeginSubmitFrame(int frame) {
 		if (res == VK_SUBOPTIMAL_KHR) {
 			// Hopefully the resize will happen shortly. Ignore - one frame might look bad or something.
 			WLOG("VK_SUBOPTIMAL_KHR returned - ignoring");
+			outOfDateFrames_++;
 		} else if (res == VK_ERROR_OUT_OF_DATE_KHR) {
 			WLOG("VK_ERROR_OUT_OF_DATE_KHR returned - not presenting");
 			frameData.skipSwap = true;
+			outOfDateFrames_++;
 		} else {
 			_assert_msg_(G3D, res == VK_SUCCESS, "vkAcquireNextImageKHR failed! result=%s", VulkanResultToString(res));
+			outOfDateFrames_ = 0;
 		}
 
 		VkCommandBufferBeginInfo begin{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -285,6 +285,11 @@ public:
 		return frameData_[vulkan_->GetCurFrame()].profile.profileSummary;
 	}
 
+	bool NeedsSwapchainRecreate() const {
+		// Accepting a few of these makes shutdown simpler.
+		return outOfDateFrames_ > VulkanContext::MAX_INFLIGHT_FRAMES;
+	}
+
 private:
 	bool InitBackbufferFramebuffers(int width, int height);
 	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
@@ -336,6 +341,8 @@ private:
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
 	int newInflightFrames_ = -1;
 	int inflightFramesAtStart_ = 0;
+
+	int outOfDateFrames_ = 0;
 
 	// Submission time state
 	int curWidth_ = -1;


### PR DESCRIPTION
Fixes an issue switching to/from fullscreen on my Ubuntu 20.04 laptop with Intel GPU (well it has an NV GPU too but I haven't installed drivers for it).