### PR TITLE
TextureDecoder: Fix misuse of NEON on all armv7

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -614,7 +614,7 @@ CheckAlphaResult CheckAlphaRGBA8888Basic(const u32 *pixelData, int stride, int w
 	if ((w & 3) == 0 && (stride & 3) == 0) {
 #ifdef _M_SSE
 		return CheckAlphaRGBA8888SSE2(pixelData, stride, w, h);
-#elif PPSSPP_ARCH(ARMV7) || PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM_NEON)
 		if (cpu_info.bNEON) {
 			return CheckAlphaRGBA8888NEON(pixelData, stride, w, h);
 		}
@@ -644,7 +644,7 @@ CheckAlphaResult CheckAlphaABGR4444Basic(const u32 *pixelData, int stride, int w
 	if ((w & 7) == 0 && (stride & 7) == 0) {
 #ifdef _M_SSE
 		return CheckAlphaABGR4444SSE2(pixelData, stride, w, h);
-#elif PPSSPP_ARCH(ARMV7) || PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM_NEON)
 		if (cpu_info.bNEON) {
 			return CheckAlphaABGR4444NEON(pixelData, stride, w, h);
 		}
@@ -677,7 +677,7 @@ CheckAlphaResult CheckAlphaABGR1555Basic(const u32 *pixelData, int stride, int w
 	if ((w & 7) == 0 && (stride & 7) == 0) {
 #ifdef _M_SSE
 		return CheckAlphaABGR1555SSE2(pixelData, stride, w, h);
-#elif PPSSPP_ARCH(ARMV7) || PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM_NEON)
 		if (cpu_info.bNEON) {
 			return CheckAlphaABGR1555NEON(pixelData, stride, w, h);
 		}
@@ -709,7 +709,7 @@ CheckAlphaResult CheckAlphaRGBA4444Basic(const u32 *pixelData, int stride, int w
 	if ((w & 7) == 0 && (stride & 7) == 0) {
 #ifdef _M_SSE
 		return CheckAlphaRGBA4444SSE2(pixelData, stride, w, h);
-#elif PPSSPP_ARCH(ARMV7) || PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM_NEON)
 		if (cpu_info.bNEON) {
 			return CheckAlphaRGBA4444NEON(pixelData, stride, w, h);
 		}
@@ -742,7 +742,7 @@ CheckAlphaResult CheckAlphaRGBA5551Basic(const u32 *pixelData, int stride, int w
 	if ((w & 7) == 0 && (stride & 7) == 0) {
 #ifdef _M_SSE
 		return CheckAlphaRGBA5551SSE2(pixelData, stride, w, h);
-#elif PPSSPP_ARCH(ARMV7) || PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM_NEON)
 		if (cpu_info.bNEON) {
 			return CheckAlphaRGBA5551NEON(pixelData, stride, w, h);
 		}


### PR DESCRIPTION
`ppsspp_config.h` properly defines `PPSSPP_ARCH(ARM_NEON)` already for
arm64v8 and armv7+NEON, so we use that instead of using NEON instructions
on all armv7.

Fixes this build issue on Mageia Linux `armv7hl`:
```
[100%] Linking CXX executable PPSSPPSDL
/usr/bin/cmake -E cmake_link_script CMakeFiles/PPSSPPSDL.dir/link.txt --verbose=1
/usr/bin/c++  -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -march=armv7-a -mfloat-abi=hard -mfpu=vfpv3-d16 -DNDEBUG -O2 -g -D_NDEBUG  -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags CMakeFiles/PPSSPPSDL.dir/android/jni/TestRunner.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/DiscordIntegration.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/NativeApp.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/BackgroundAudio.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/ChatScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/DevScreens.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/DisplayLayoutEditor.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/DisplayLayoutScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/EmuScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/GameInfoCache.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/MainScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/MiscScreens.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/PauseScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/GameScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/GameSettingsScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/GPUDriverTestScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/TiltAnalogSettingsScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/TiltEventProcessor.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/TouchControlLayoutScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/TouchControlVisibilityScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/GamepadEmu.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/OnScreenDisplay.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/ControlMappingScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/RemoteISOScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/ReportScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/SavedataScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/Store.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/CwCheatScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/InstallZipScreen.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/ProfilerDraw.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/TextureUtil.cpp.o CMakeFiles/PPSSPPSDL.dir/UI/ComboKeyMappingScreen.cpp.o  -o PPSSPPSDL  lib/libCore.a -lpthread lib/libCommon.a /lib/libsnappy.so lib/libnative.a /usr/lib/libSDL2.so /usr/lib/libzip.so lib/libpng17.a lib/libgason.a lib/libudis86.a -lrt -lpthread /usr/lib/libGLEW.so lib/libkirk.a lib/libcityhash.a lib/libsfmt19937.a lib/libxbrz.a lib/libxxhash.a lib/libSPIRV.a lib/libglslang.a lib/libOGLCompiler.a lib/libOSDependent.a -lpthread lib/libHLSL.a lib/libSPVRemapper.a lib/libspirv-cross-glsl.a lib/libspirv-cross-core.a lib/libarmips.a /usr/lib/libGL.so /usr/lib/libGLU.so -lEGL /usr/lib/libX11.so /usr/lib/libXext.so -ldl /usr/lib/libavformat.so /usr/lib/libavcodec.so /usr/lib/libswresample.so /usr/lib/libswscale.so /usr/lib/libavutil.so /usr/lib/libz.so lib/libdiscord-rpc.a 
/usr/bin/ld: lib/libCore.a(TextureDecoder.cpp.o): in function `CheckAlphaRGBA8888Basic(unsigned int const*, int, int, int)':
/home/iurt/rpmbuild/BUILD/ppsspp-1.10/GPU/Common/TextureDecoder.cpp:619: undefined reference to `CheckAlphaRGBA8888NEON(unsigned int const*, int, int, int)'
/usr/bin/ld: lib/libCore.a(TextureDecoder.cpp.o): in function `CheckAlphaABGR4444Basic(unsigned int const*, int, int, int)':
/home/iurt/rpmbuild/BUILD/ppsspp-1.10/GPU/Common/TextureDecoder.cpp:649: undefined reference to `CheckAlphaABGR4444NEON(unsigned int const*, int, int, int)'
/usr/bin/ld: lib/libCore.a(TextureDecoder.cpp.o): in function `CheckAlphaABGR1555Basic(unsigned int const*, int, int, int)':
/home/iurt/rpmbuild/BUILD/ppsspp-1.10/GPU/Common/TextureDecoder.cpp:682: undefined reference to `CheckAlphaABGR1555NEON(unsigned int const*, int, int, int)'
/usr/bin/ld: lib/libCore.a(TextureDecoder.cpp.o): in function `CheckAlphaRGBA4444Basic(unsigned int const*, int, int, int)':
/home/iurt/rpmbuild/BUILD/ppsspp-1.10/GPU/Common/TextureDecoder.cpp:714: undefined reference to `CheckAlphaRGBA4444NEON(unsigned int const*, int, int, int)'
/usr/bin/ld: lib/libCore.a(TextureDecoder.cpp.o): in function `CheckAlphaRGBA5551Basic(unsigned int const*, int, int, int)':
/home/iurt/rpmbuild/BUILD/ppsspp-1.10/GPU/Common/TextureDecoder.cpp:747: undefined reference to `CheckAlphaRGBA5551NEON(unsigned int const*, int, int, int)'
```