### PR TITLE
cmake: don't install bundled glslang

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -13,7 +13,7 @@ if(ANDROID)
 set(ENABLE_HLSL OFF CACHE BOOL "let's not build HLSL support we don't need" FORCE)
 endif()
 
-add_subdirectory(glslang)
+add_subdirectory(glslang EXCLUDE_FROM_ALL)
 add_subdirectory(snappy)
 add_subdirectory(udis86)
 add_subdirectory(SPIRV-Cross-build)


### PR DESCRIPTION
Not a recent regression. Defining `set(SKIP_GLSLANG_INSTALL OFF ... FORCE)` doesn't seem to help.

ppsspp (cmake) doesn't define install target, so nothing is installed. However, glslang cannot be installed as part of ppsspp as it'd conflict with system glslang package.

```
$ cmake -DCMAKE_INSTALL_PREFIX=/tmp/ppsspp_install -B /tmp/ppsspp_build -G Ninja
$ cmake --build /tmp/ppsspp_build
$ cmake --install /tmp/ppsspp_build
-- Install configuration: "Release"
-- Installing: /tmp/ppsspp_install/lib/libglslang.a
-- Installing: /tmp/ppsspp_install/lib/cmake/glslangTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/glslangTargets-release.cmake
-- Installing: /tmp/ppsspp_install/include/glslang/Public/ShaderLang.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/arrays.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/BaseTypes.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/Common.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/ConstantUnion.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/glslang_c_interface.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/glslang_c_shader_types.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/InfoSink.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/InitializeGlobals.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/intermediate.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/PoolAlloc.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/ResourceLimits.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/revision.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/ShHandle.h
-- Installing: /tmp/ppsspp_install/include/glslang/Include/Types.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/attribute.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/glslang_tab.cpp.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/gl_types.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/Initialize.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/iomapper.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/LiveTraverser.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/localintermediate.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/ParseHelper.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/reflection.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/RemoveTree.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/Scan.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/ScanContext.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/SymbolTable.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/Versions.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/parseVersions.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/propagateNoContraction.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/preprocessor/PpContext.h
-- Installing: /tmp/ppsspp_install/include/glslang/MachineIndependent/preprocessor/PpTokens.h
-- Installing: /tmp/ppsspp_install/lib/libOSDependent.a
-- Installing: /tmp/ppsspp_install/lib/cmake/OSDependentTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/OSDependentTargets-release.cmake
-- Installing: /tmp/ppsspp_install/lib/libOGLCompiler.a
-- Installing: /tmp/ppsspp_install/lib/cmake/OGLCompilerTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/OGLCompilerTargets-release.cmake
-- Installing: /tmp/ppsspp_install/lib/libSPVRemapper.a
-- Installing: /tmp/ppsspp_install/lib/libSPIRV.a
-- Installing: /tmp/ppsspp_install/lib/cmake/SPVRemapperTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/SPVRemapperTargets-release.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/SPIRVTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/SPIRVTargets-release.cmake
-- Installing: /tmp/ppsspp_install/include/SPIRV/bitutils.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/spirv.hpp
-- Installing: /tmp/ppsspp_install/include/SPIRV/GLSL.std.450.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/GLSL.ext.EXT.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/GLSL.ext.KHR.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/GlslangToSpv.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/hex_float.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/Logger.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/SpvBuilder.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/spvIR.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/doc.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/SpvTools.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/disassemble.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/GLSL.ext.AMD.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/GLSL.ext.NV.h
-- Installing: /tmp/ppsspp_install/include/SPIRV/SPVRemapper.h
-- Up-to-date: /tmp/ppsspp_install/include/SPIRV/doc.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/bitutils.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/spirv.hpp
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GLSL.std.450.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GLSL.ext.EXT.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GLSL.ext.KHR.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GlslangToSpv.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/hex_float.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/Logger.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/SpvBuilder.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/spvIR.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/doc.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/SpvTools.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/disassemble.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GLSL.ext.AMD.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/GLSL.ext.NV.h
-- Installing: /tmp/ppsspp_install/include/glslang/SPIRV/SPVRemapper.h
-- Up-to-date: /tmp/ppsspp_install/include/glslang/SPIRV/doc.h
-- Installing: /tmp/ppsspp_install/lib/libHLSL.a
-- Installing: /tmp/ppsspp_install/lib/cmake/HLSLTargets.cmake
-- Installing: /tmp/ppsspp_install/lib/cmake/HLSLTargets-release.cmake
```
