### PR TITLE
SaveState: Make sure to default init net data

### DIFF
--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -778,11 +778,10 @@ public:
 	}
 	void run(MipsCall &call) override;
 	void SetContextID(u32 ContextID, u32 eventId);
-	void SetContext(SceNetAdhocMatchingContext *Context, u32 eventId) { context = Context; EventID = eventId; }
 
 private:
-	u32 EventID;
-	SceNetAdhocMatchingContext *context;
+	u32 EventID = 0;
+	SceNetAdhocMatchingContext *context = nullptr;
 };
 
 extern int actionAfterMatchingMipsCall;

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -361,6 +361,8 @@ public:
 		p.Do(fontLibID_);
 		if (s >= 2) {
 			p.Do(errorCodePtr_);
+		} else {
+			errorCodePtr_ = 0;
 		}
 	}
 	void run(MipsCall &call) override;
@@ -721,7 +723,8 @@ void PostAllocCallback::run(MipsCall &call) {
 	u32 v0 = currentMIPS->r[MIPS_REG_V0];
 	if (v0 == 0) {
 		// TODO: Who deletes fontLib?
-		Memory::Write_U32(ERROR_FONT_OUT_OF_MEMORY, errorCodePtr_);
+		if (errorCodePtr_)
+			Memory::Write_U32(ERROR_FONT_OUT_OF_MEMORY, errorCodePtr_);
 		call.setReturnValue(0);
 	} else {
 		FontLib *fontLib = fontLibList[fontLibID_];


### PR DESCRIPTION
Hoping this helps the crash seen in #13057.

Ideally it should probably restore the context pointer, but you're probably already disconnected by then anyway, so I'm not sure the correct behavior.  Still, we shouldn't outright crash.

-[Unknown]