### PR TITLE
Fix reliability of the CMake generated version

### DIFF
--- a/git-version.cmake
+++ b/git-version.cmake
@@ -23,13 +23,6 @@ if(EXISTS ${GIT_VERSION_FILE})
 	if(NOT ${match} EQUAL "")
 		set(GIT_VERSION_UPDATE "0")
 	endif()
-
-	# Don't update if it's already the same.
-	file(STRINGS ${GIT_VERSION_FILE} match
-		REGEX "${GIT_VERSION}")
-	if(NOT ${match} EQUAL "")
-		set(GIT_VERSION_UPDATE "0")
-	endif()	
 endif()
 
 set(code_string "// This is a generated file.\n\n"


### PR DESCRIPTION
steps to reproduce :

git checkout v1.10.1~3
git describe --always
--> v1.10-19-g9aab3d986
[build now]
PPSSPPSDL --version
--> v1.10-19-g9aab3d986

git checkout v1.10.1
git describe --always
--> v1.10.1
[build now]
PPSSPPSDL --version
--> v1.10-19-g9aab3d986

Indeed, the "v1.10.1" regex matches the "v1.10-19-g9aab3d986" string. How unfortunate!
So I just deleted that check, building the same commit twice should not happen that often :)