### PR TITLE
http: Check cancel flag more often

### DIFF
--- a/ext/native/base/buffer.h
+++ b/ext/native/base/buffer.h
@@ -64,7 +64,7 @@ class Buffer {
 	// written.
 	bool Flush(int fd);
 	bool FlushToFile(const char *filename);
-	bool FlushSocket(uintptr_t sock, double timeout = -1.0);  // Windows portability
+	bool FlushSocket(uintptr_t sock, double timeout = -1.0, bool *cancelled = nullptr);  // Windows portability
 
   bool ReadAll(int fd, int hintSize = 0);
   bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);

--- a/ext/native/net/http_client.h
+++ b/ext/native/net/http_client.h
@@ -71,9 +71,9 @@ public:
 
 	// HEAD, PUT, DELETE aren't implemented yet, but can be done with SendRequest.
 
-	int SendRequest(const char *method, const char *resource, const char *otherHeaders = nullptr, float *progress = nullptr);
-	int SendRequestWithData(const char *method, const char *resource, const std::string &data, const char *otherHeaders = nullptr, float *progress = nullptr);
-	int ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress = nullptr);
+	int SendRequest(const char *method, const char *resource, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
+	int SendRequestWithData(const char *method, const char *resource, const std::string &data, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
+	int ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress = nullptr, bool *cancelled = nullptr);
 	// If your response contains a response, you must read it.
 	int ReadResponseEntity(Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
 


### PR DESCRIPTION
Would be better to use non-blocking sockets, but this code is working, so not planning to rewrite it right now.

This just makes us run `select()` on sockets before reading/writing to them.  Before, we would try to write, and only timeout if we got data slowly.  In a situation where the user loses signal, `recv()` will just block.  In other places, we were using a timeout - but only checking at the end of the entire timeout.

Now, we check the cancel flag in small chunks of 0.25s waits.  So if the user loses connectivity, it won't just wait and wait.

Actual behavior with a good connection should not be impacted.

-[Unknown]