### PR TITLE
(Libretro) Buildfixes for Windows

### DIFF
--- a/Core/HLE/sceUsbCam.cpp
+++ b/Core/HLE/sceUsbCam.cpp
@@ -26,7 +26,11 @@
 #include "Core/HW/Camera.h"
 #include "Core/MemMapHelpers.h"
 
-#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
+#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP) && !defined(__LIBRETRO__)
+#define HAVE_WIN32_CAMERA
+#endif
+
+#ifdef HAVE_WIN32_CAMERA
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -300,7 +304,7 @@ void Register_sceUsbCam()
 }
 
 std::vector<std::string> Camera::getDeviceList() {
-	#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
+   #ifdef HAVE_WIN32_CAMERA
 		if (winCamera) {
 			return winCamera->getDeviceList();
 		}
@@ -320,7 +324,7 @@ int Camera::startCapture() {
 	INFO_LOG(HLE, "%s resolution: %dx%d", __FUNCTION__, width, height);
 
 	config->mode = Camera::Mode::Video;
-	#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
+   #ifdef HAVE_WIN32_CAMERA
 		if (winCamera) {
 			if (winCamera->isShutDown()) {
 				delete winCamera;
@@ -344,7 +348,7 @@ int Camera::startCapture() {
 
 int Camera::stopCapture() {
 	INFO_LOG(HLE, "%s", __FUNCTION__);
-	#if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
+   #ifdef HAVE_WIN32_CAMERA
 		if (winCamera) {
 			winCamera->sendMessage({ CAPTUREDEVIDE_COMMAND::STOP, nullptr });
 		}

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -308,6 +308,7 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
           $(NATIVEDIR)/thin3d/DataFormatGL.cpp \
 	       $(NATIVEDIR)/thread/threadutil.cpp \
 	       $(NATIVEDIR)/thread/threadpool.cpp \
+	       $(NATIVEDIR)/thread/prioritizedworkqueue.cpp \
 	       $(NATIVEDIR)/ui/root.cpp \
 	       $(NATIVEDIR)/ui/screen.cpp \
 	       $(NATIVEDIR)/ui/ui.cpp \
@@ -478,7 +479,8 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
 	       $(COREDIR)/Util/PPGeDraw.cpp \
 	       $(COREDIR)/Util/AudioFormat.cpp \
           $(EXTDIR)/disarm.cpp \
-          $(CORE_DIR)/UI/TextureUtil.cpp
+          $(CORE_DIR)/UI/TextureUtil.cpp \
+          $(CORE_DIR)/UI/GameInfoCache.cpp
 
 SOURCES_CXX += $(COREDIR)/HLE/__sceAudio.cpp
 


### PR DESCRIPTION
Hi there, we'd appreciate if this could be merged as soon as possible. It would fix the Windows build again on our end.

Also, looking at the code, perhaps it would be worthwhile if in the future we could build around PPSSPP_PLATFORM(LIBRETRO) in the codebase ( I assume this doesn't work yet), since for some of these platform-specific bits, a libretro-specific implementation (usually implemented on the frontend side) is preferred.