### PR TITLE
Refactor and fix touch control layout screen for notch

### DIFF
--- a/UI/TouchControlLayoutScreen.h
+++ b/UI/TouchControlLayoutScreen.h
@@ -24,31 +24,24 @@
 #include "ui/viewgroup.h"
 #include "MiscScreens.h"
 
-class DragDropButton;
+class ControlLayoutView;
 
 class TouchControlLayoutScreen : public UIDialogScreenWithBackground {
 public:
 	TouchControlLayoutScreen();
 
 	virtual void CreateViews() override;
-	virtual bool touch(const TouchInput &touch) override;
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 	virtual void onFinish(DialogResult reason) override;
+	virtual void update() override;
 	virtual void resized() override;
 
 protected:
 	virtual UI::EventReturn OnReset(UI::EventParams &e);
 	virtual UI::EventReturn OnVisibility(UI::EventParams &e);
+	virtual UI::EventReturn OnMode(UI::EventParams &e);
 
 private:
-	DragDropButton *pickedControl_;
-	std::vector<DragDropButton *> controls_;
-	UI::ChoiceStrip *mode_;
-	DragDropButton *getPickedControl(const int x, const int y);
-
-	// Touch down state for drag to resize etc
-	float startX_;
-	float startY_;
-	float startScale_;
-	float startSpacing_;
+	UI::ChoiceStrip *mode_ = nullptr;
+	ControlLayoutView *layoutView_ = nullptr;
 };


### PR DESCRIPTION
Break out the actual editor into a separate view, removing the need to offset as many calculations.

This solves most or all offset issues seen on notched screens.

Also improve drag comfort by taking the initial offset from the control being dragged into account.

Fixes #13122 