### PR TITLE
Travis: Use the default macOS image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ addons:
       - sourceline: 'ppa:ubuntu-sdk-team/ppa'
   homebrew:
     update: true
+    packages:
+      - ccache
+      - python
+      - sdl2
 
 cache:
   apt: true
@@ -85,6 +89,14 @@ jobs:
       compiler: "clang"
       env: PPSSPP_BUILD_TYPE=Linux
            LIBRETRO=TRUE
+    - os: osx
+      osx_image: xcode9.4
+      compiler: "clang"
+      env: PPSSPP_BUILD_TYPE=macOS
+    - os: osx
+      osx_image: xcode9.4
+      compiler: "clang"
+      env: PPSSPP_BUILD_TYPE=iOS
     - os: windows
       compiler: "msvc2017"
       env: PPSSPP_BUILD_TYPE=Windows
@@ -92,14 +104,6 @@ jobs:
       compiler: "msvc2017"
       env: PPSSPP_BUILD_TYPE=Windows
            UWP=TRUE
-#    - os: osx
-#      osx_image: xcode9
-#      compiler: "clang"
-#      env: PPSSPP_BUILD_TYPE=macOS
-#    - os: osx
-#      osx_image: xcode9
-#      compiler: "clang"
-#      env: PPSSPP_BUILD_TYPE=iOS
 
 before_install:
   - travis_retry bash .travis.sh travis_before_install


### PR DESCRIPTION
We don't need to try to build and cache bottles since brew still supports this version with new binaries.  Replaces #13126.

The previous change didn't really handle falling back to brew-provided binaries, was just focused on caching our binaries.  Note that there will be problems again if brew drops macOS 10.13.  Apple will drop support for it on 2020-12-01, so Brew may do the same.

-[Unknown]