### PR TITLE
Add exec crash checks and minor cleanup

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -94,6 +94,7 @@ void Core_ListenStopRequest(CoreStopRequestFunc func) {
 }
 
 void Core_Stop() {
+	g_exceptionInfo.type = ExceptionType::NONE;
 	Core_UpdateState(CORE_POWERDOWN);
 	for (auto func : stopFuncs) {
 		func();
@@ -264,6 +265,7 @@ void Core_UpdateSingleStep() {
 }
 
 void Core_SingleStep() {
+	g_exceptionInfo.type = ExceptionType::NONE;
 	currentMIPS->SingleStep();
 	if (coreState == CORE_STEPPING)
 		steppingCounter++;
@@ -361,6 +363,8 @@ void Core_EnableStepping(bool step) {
 		steppingCounter++;
 	} else {
 		host->SetDebugMode(false);
+		// Clear the exception if we resume.
+		g_exceptionInfo.type = ExceptionType::NONE;
 		coreState = CORE_RUNNING;
 		coreStatePending = false;
 		m_StepCond.notify_all();

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -404,6 +404,15 @@ const char *MemoryExceptionTypeAsString(MemoryExceptionType type) {
 	}
 }
 
+const char *ExecExceptionTypeAsString(ExecExceptionType type) {
+	switch (type) {
+	case ExecExceptionType::JUMP: return "CPU Jump";
+	case ExecExceptionType::THREAD: return "Thread switch";
+	default:
+		return "N/A";
+	}
+}
+
 void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type) {
 	const char *desc = MemoryExceptionTypeAsString(type);
 	// In jit, we only flush PC when bIgnoreBadMemAccess is off.
@@ -419,6 +428,23 @@ void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type) {
 		e.type = ExceptionType::MEMORY;
 		e.info = "";
 		e.memory_type = type;
+		e.address = address;
+		e.pc = pc;
+		Core_EnableStepping(true);
+		host->SetDebugMode(true);
+	}
+}
+
+void Core_ExecException(u32 address, u32 pc, ExecExceptionType type) {
+	const char *desc = ExecExceptionTypeAsString(type);
+	WARN_LOG(MEMMAP, "%s: Invalid destination %08x PC %08x LR %08x", desc, address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
+
+	if (!g_Config.bIgnoreBadMemAccess) {
+		ExceptionInfo &e = g_exceptionInfo;
+		e = {};
+		e.type = ExceptionType::BAD_EXEC_ADDR;
+		e.info = "";
+		e.exec_type = type;
 		e.address = address;
 		e.pc = pc;
 		Core_EnableStepping(true);

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -85,8 +85,13 @@ enum class MemoryExceptionType {
 	READ_BLOCK,
 	WRITE_BLOCK,
 };
+enum class ExecExceptionType {
+	JUMP,
+	THREAD,
+};
 
 void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type);
+void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
 void Core_Break();
 
 enum class ExceptionType {
@@ -104,9 +109,13 @@ struct ExceptionInfo {
 	MemoryExceptionType memory_type;
 	uint32_t pc;
 	uint32_t address;
+
+	// Reuses pc and address from memory type, where address is the failed destination.
+	ExecExceptionType exec_type;
 };
 
 const ExceptionInfo &Core_GetExceptionInfo();
 
 const char *ExceptionTypeAsString(ExceptionType type);
 const char *MemoryExceptionTypeAsString(MemoryExceptionType type);
+const char *ExecExceptionTypeAsString(ExecExceptionType type);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1183,7 +1183,8 @@ void __KernelThreadingShutdown() {
 }
 
 std::string __KernelThreadingSummary() {
-	return StringFromFormat("Cur thread: %s", __GetCurrentThread()->GetName());
+	PSPThread *t = __GetCurrentThread();
+	return StringFromFormat("Cur thread: %s (attr %08x)", t ? t->GetName() : "(null)", t ? t->nt.attr : 0);
 }
 
 const char *__KernelGetThreadName(SceUID threadID)

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1468,11 +1468,9 @@ void __KernelLoadContext(PSPThreadContext *ctx, bool vfpuEnabled) {
 		memcpy(currentMIPS->vfpuCtrl, ctx->vfpuCtrl, sizeof(ctx->vfpuCtrl));
 	}
 
-#ifdef _DEBUG
 	if (!Memory::IsValidAddress(ctx->pc)) {
 		Core_ExecException(ctx->pc, currentMIPS->pc, ExecExceptionType::THREAD);
 	}
-#endif
 
 	memcpy(currentMIPS->other, ctx->other, sizeof(ctx->other));
 	if (MIPSComp::jit) {

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -31,6 +31,7 @@
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
@@ -1142,6 +1143,10 @@ bool __KernelSwitchToThread(SceUID threadID, const char *reason)
 		if (current && current->isRunning())
 			__KernelChangeReadyState(current, currentThread, true);
 
+		if (!Memory::IsValidAddress(t->context.pc)) {
+			Core_ExecException(t->context.pc, currentMIPS->pc, ExecExceptionType::THREAD);
+		}
+
 		__KernelSwitchContext(t, reason);
 		return true;
 	}
@@ -1462,6 +1467,12 @@ void __KernelLoadContext(PSPThreadContext *ctx, bool vfpuEnabled) {
 		memcpy(currentMIPS->v, ctx->v, sizeof(ctx->v));
 		memcpy(currentMIPS->vfpuCtrl, ctx->vfpuCtrl, sizeof(ctx->vfpuCtrl));
 	}
+
+#ifdef _DEBUG
+	if (!Memory::IsValidAddress(ctx->pc)) {
+		Core_ExecException(ctx->pc, currentMIPS->pc, ExecExceptionType::THREAD);
+	}
+#endif
 
 	memcpy(currentMIPS->other, ctx->other, sizeof(ctx->other));
 	if (MIPSComp::jit) {
@@ -1912,6 +1923,10 @@ SceUID __KernelSetupRootThread(SceUID moduleID, int args, const char *argp, int 
 
 	strcpy(thread->nt.name, "root");
 
+	if (!Memory::IsValidAddress(thread->context.pc)) {
+		Core_ExecException(thread->context.pc, currentMIPS->pc, ExecExceptionType::THREAD);
+	}
+
 	__KernelLoadContext(&thread->context, (attr & PSP_THREAD_ATTR_VFPU) != 0);
 	currentMIPS->r[MIPS_REG_A0] = args;
 	currentMIPS->r[MIPS_REG_SP] -= (args + 0xf) & ~0xf;
@@ -2041,6 +2056,9 @@ int __KernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr, bo
 
 	// Smaller is better for priority.  Only switch if the new thread is better.
 	if (cur && cur->nt.currentPriority > startThread->nt.currentPriority) {
+		if (!Memory::IsValidAddress(startThread->context.pc)) {
+			Core_ExecException(startThread->context.pc, currentMIPS->pc, ExecExceptionType::THREAD);
+		}
 		__KernelChangeReadyState(cur, currentThread, true);
 		hleReSchedule("thread started");
 	}
@@ -2903,6 +2921,10 @@ u32 sceKernelExtendThreadStack(u32 size, u32 entryAddr, u32 entryParameter)
 	Memory::Write_U32(currentMIPS->r[MIPS_REG_SP], thread->currentStack.end - 8);
 	Memory::Write_U32(currentMIPS->pc, thread->currentStack.end - 12);
 
+	if (!Memory::IsValidAddress(entryAddr)) {
+		Core_ExecException(entryAddr, currentMIPS->pc, ExecExceptionType::THREAD);
+	}
+
 	currentMIPS->pc = entryAddr;
 	currentMIPS->r[MIPS_REG_A0] = entryParameter;
 	currentMIPS->r[MIPS_REG_RA] = extendReturnHackAddr;
@@ -2933,6 +2955,10 @@ void __KernelReturnFromExtendStack()
 	{
 		ERROR_LOG_REPORT(SCEKERNEL, "__KernelReturnFromExtendStack() - no stack to restore?");
 		return;
+	}
+
+	if (!Memory::IsValidAddress(restorePC)) {
+		Core_ExecException(restorePC, currentMIPS->pc, ExecExceptionType::THREAD);
 	}
 
 	DEBUG_LOG(SCEKERNEL, "__KernelReturnFromExtendStack()");
@@ -3215,6 +3241,10 @@ bool __KernelExecuteMipsCallOnCurrentThread(u32 callId, bool reschedAfter)
 	call->savedId = cur->currentMipscallId;
 	call->reschedAfter = reschedAfter;
 
+	if (!Memory::IsValidAddress(call->entryPoint)) {
+		Core_ExecException(call->entryPoint, currentMIPS->pc, ExecExceptionType::THREAD);
+	}
+
 	// Set up the new state
 	currentMIPS->pc = call->entryPoint;
 	currentMIPS->r[MIPS_REG_RA] = __KernelCallbackReturnAddress();
@@ -3263,6 +3293,10 @@ void __KernelReturnFromMipsCall()
 	currentMIPS->r[MIPS_REG_T9] = Memory::Read_U32(sp + MIPS_REG_T9 * 4);
 	currentMIPS->r[MIPS_REG_RA] = Memory::Read_U32(sp + MIPS_REG_RA * 4);
 	sp += 32 * 4;
+
+	if (!Memory::IsValidAddress(call->savedPc)) {
+		Core_ExecException(call->savedPc, currentMIPS->pc, ExecExceptionType::THREAD);
+	}
 
 	currentMIPS->pc = call->savedPc;
 	// This is how we set the return value.

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -703,6 +703,7 @@ void ArmJit::UpdateRoundingMode(u32 fcr31) {
 // I don't think this gives us that much benefit.
 void ArmJit::WriteExit(u32 destination, int exit_num)
 {
+	// TODO: Check destination is valid and trigger exception.
 	WriteDownCount(); 
 	//If nobody has taken care of this yet (this can be removed when all branches are done)
 	JitBlock *b = js.curBlock;
@@ -723,6 +724,7 @@ void ArmJit::WriteExit(u32 destination, int exit_num)
 
 void ArmJit::WriteExitDestInR(ARMReg Reg) 
 {
+	// TODO: If not fast memory, check for invalid address in reg and trigger exception.
 	MovToPC(Reg);
 	WriteDownCount();
 	// TODO: shouldn't need an indirect branch here...

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -677,6 +677,7 @@ void Arm64Jit::UpdateRoundingMode(u32 fcr31) {
 // though, as we need to have the SUBS flag set in the end. So with block linking in the mix,
 // I don't think this gives us that much benefit.
 void Arm64Jit::WriteExit(u32 destination, int exit_num) {
+	// TODO: Check destination is valid and trigger exception.
 	WriteDownCount(); 
 	//If nobody has taken care of this yet (this can be removed when all branches are done)
 	JitBlock *b = js.curBlock;
@@ -696,6 +697,7 @@ void Arm64Jit::WriteExit(u32 destination, int exit_num) {
 }
 
 void Arm64Jit::WriteExitDestInR(ARM64Reg Reg) {
+	// TODO: If not fast memory, check for invalid address in reg and trigger exception.
 	MovToPC(Reg);
 	WriteDownCount();
 	// TODO: shouldn't need an indirect branch here...

--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -300,9 +300,8 @@ void IRFrontend::Comp_Jump(MIPSOpcode op) {
 			js.cancel = true;
 		else
 			ERROR_LOG_REPORT(JIT, "Jump to invalid address: %08x", targetAddr);
-		js.compiling = false;
 		// TODO: Mark this block dirty or something?  May be indication it will be changed by imports.
-		return;
+		// Continue so the block gets completed and crashes properly.
 	}
 
 	switch (op >> 26) {

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -224,6 +224,10 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 				u32 data = inst & 0xFFFFFF;
 				IRBlock *block = blocks_.GetBlock(data);
 				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetNumInstructions());
+				if (!Memory::IsValidAddress(mips_->pc)) {
+					Core_ExecException(mips_->pc, mips_->pc, ExecExceptionType::JUMP);
+					break;
+				}
 			} else {
 				// RestoreRoundingMode(true);
 				Compile(mips_->pc);

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -55,6 +55,7 @@
 static inline void DelayBranchTo(u32 where)
 {
 	if (!Memory::IsValidAddress(where)) {
+		// TODO: What about misaligned?
 		Core_ExecException(where, PC, ExecExceptionType::JUMP);
 	}
 	PC += 4;

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -54,6 +54,9 @@
 
 static inline void DelayBranchTo(u32 where)
 {
+	if (!Memory::IsValidAddress(where)) {
+		Core_ExecException(where, PC, ExecExceptionType::JUMP);
+	}
 	PC += 4;
 	mipsr4k.nextPC = where;
 	mipsr4k.inDelaySlot = true;

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1019,13 +1019,14 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 
 				if (curMips->inDelaySlot)
 				{
+					curMips->downcount -= 1;
 					// The reason we have to check this is the delay slot hack in Int_Syscall.
 					if (wasInDelaySlot)
 					{
 						curMips->pc = curMips->nextPC;
 						curMips->inDelaySlot = false;
+						continue;
 					}
-					curMips->downcount -= 1;
 					goto again;
 				}
 			}

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -617,7 +617,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 		CompileDelaySlot(DELAYSLOT_NICE);
 		FlushAll();
 		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC() + 8));
-		ABI_CallFunctionC((const void *)&HitInvalidJump, targetAddr);
+		ABI_CallFunctionC(&HitInvalidJump, targetAddr);
 		WriteSyscallExit();
 		return;
 	}

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -20,8 +20,9 @@
 
 #include "profiler/profiler.h"
 
-#include "Core/Reporting.h"
 #include "Core/Config.h"
+#include "Core/Core.h"
+#include "Core/Reporting.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/HLETables.h"
 #include "Core/Host.h"
@@ -591,6 +592,10 @@ void Jit::Comp_VBranch(MIPSOpcode op)
 	}
 }
 
+static void HitInvalidJump(uint32_t dest) {
+	Core_ExecException(dest, currentMIPS->pc - 8, ExecExceptionType::JUMP);
+}
+
 void Jit::Comp_Jump(MIPSOpcode op) {
 	CONDITIONAL_LOG;
 	if (js.inDelaySlot) {
@@ -608,6 +613,12 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 			js.compiling = false;
 		}
 		// TODO: Mark this block dirty or something?  May be indication it will be changed by imports.
+
+		CompileDelaySlot(DELAYSLOT_NICE);
+		FlushAll();
+		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC() + 8));
+		ABI_CallFunctionC((const void *)&HitInvalidJump, targetAddr);
+		WriteSyscallExit();
 		return;
 	}
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -656,11 +656,18 @@ void Jit::Comp_Generic(MIPSOpcode op) {
 	}
 }
 
+static void HitInvalidBranch(uint32_t dest) {
+	Core_ExecException(dest, currentMIPS->pc, ExecExceptionType::JUMP);
+}
+
 void Jit::WriteExit(u32 destination, int exit_num) {
 	_dbg_assert_msg_(JIT, exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num");
 
 	if (!Memory::IsValidAddress(destination)) {
 		ERROR_LOG_REPORT(JIT, "Trying to write block exit to illegal destination %08x: pc = %08x", destination, currentMIPS->pc);
+		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));
+		ABI_CallFunctionC(&HitInvalidBranch, destination);
+		js.afterOp |= JitState::AFTER_CORE_STATE;
 	}
 	// If we need to verify coreState and rewind, we may not jump yet.
 	if (js.afterOp & (JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE)) {
@@ -751,7 +758,7 @@ void Jit::WriteExitDestInReg(X64Reg reg) {
 		// If we're ignoring, coreState didn't trip - so trip it now.
 		CMP(32, R(EAX), Imm32(0));
 		FixupBranch skip = J_CC(CC_NE);
-		ABI_CallFunctionC((const void *)&HitInvalidJumpReg, GetCompilerPC());
+		ABI_CallFunctionC(&HitInvalidJumpReg, GetCompilerPC());
 		SetJumpTarget(skip);
 
 		SUB(32, MIPSSTATE_VAR(downcount), Imm8(0));

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1293,7 +1293,7 @@ PPSSPP build: %s (%s)
 	draw2d->SetFontScale(.7f, .7f);
 	int x = 20;
 	int y = 50;
-	draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
 	y += 100;
 
 	if (info.type == ExceptionType::MEMORY) {
@@ -1303,7 +1303,7 @@ PC: %08x)",
 			MemoryExceptionTypeAsString(info.memory_type),
 			info.address,
 			info.pc);
-		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
 		y += 120;
 	} else if (info.type == ExceptionType::BAD_EXEC_ADDR) {
 		snprintf(statbuf, sizeof(statbuf), R"(
@@ -1312,13 +1312,13 @@ PC: %08x)",
 			ExecExceptionTypeAsString(info.exec_type),
 			info.address,
 			info.pc);
-		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
 		y += 120;
 	}
 
 	std::string kernelState = __KernelStateSummary();
 
-	draw2d->DrawTextShadow(ubuntu24, kernelState.c_str(), x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	draw2d->DrawTextShadow(ubuntu24, kernelState.c_str(), x, y, 0xFFFFFFFF);
 }
 
 static void DrawAudioDebugStats(DrawBuffer *draw2d, const Bounds &bounds) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1305,6 +1305,15 @@ PC: %08x)",
 			info.pc);
 		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 		y += 120;
+	} else if (info.type == ExceptionType::BAD_EXEC_ADDR) {
+		snprintf(statbuf, sizeof(statbuf), R"(
+Destination: %s to %08x
+PC: %08x)",
+			ExecExceptionTypeAsString(info.exec_type),
+			info.address,
+			info.pc);
+		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+		y += 120;
 	}
 
 	std::string kernelState = __KernelStateSummary();


### PR DESCRIPTION
When debugging, the crash checks were fairly annoying as the blue screen wouldn't go away, even on restart.  This fixes that.

It also tries to catch exec jump crashes, mainly on x86.  Didn't really do arm yet.

An easy way to test on arm/arm64:
 * Enable remote debugging on your phone.
 * Start a game and hit Break in the web debugger.
 * Replace the next instruction with `jr v0` or `j 0` or similar.

An edge case that is trickier (should probably setup a prx for it) is a *branch* into the wilderness.  This is possibly even more unlikely than a bad jump, but could happen if code was loaded into the scratchpad and branched from there, for example.

I didn't really test that, but I setup code that should catch it on x86 at least.

-[Unknown]