### PR TITLE
(Libretro) Add optimal input read codepath - bitmasks

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -376,6 +376,113 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	GL_LIB := opengl32.lib
 	LDFLAGS += ws2_32.lib user32.lib shell32.lib avcodec.lib avutil.lib swresample.lib swscale.lib avformat.lib advapi32.lib winmm.lib gdi32.lib d3d9.lib d3dx9.lib
 
+# Windows MSVC 2019 all architectures
+else ifneq (,$(findstring windows_msvc2019,$(platform)))
+
+	PlatformSuffix = $(subst windows_msvc2019_,,$(platform))
+	ifneq (,$(findstring desktop,$(PlatformSuffix)))
+		WinPartition = desktop
+		MSVC2019CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -D_UNICODE -DUNICODE -DWINVER=0x0501 -D_WIN32_WINNT=0x0501
+		LDFLAGS += -MANIFEST -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
+		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
+	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
+		WinPartition = uwp
+		MSVC2019CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DWINDLL -D_UNICODE -DUNICODE -DWRL_NO_DEFAULT_LIB
+		LDFLAGS += -APPCONTAINER -NXCOMPAT -DYNAMICBASE -MANIFEST:NO -OPT:REF -SUBSYSTEM:CONSOLE -MANIFESTUAC:NO -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1 -DEBUG:FULL -WINMD:NO
+		LIBS += WindowsApp.lib
+	endif
+
+	CFLAGS += $(MSVC2019CompileFlags) -nologo
+	CXXFLAGS += $(MSVC2019CompileFlags) -nologo -EHsc
+
+	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+
+	CC  = cl.exe
+	CXX = cl.exe
+
+	SPACE :=
+	SPACE := $(SPACE) $(SPACE)
+	BACKSLASH :=
+	BACKSLASH := \$(BACKSLASH)
+	filter_out1 = $(filter-out $(firstword $1),$1)
+	filter_out2 = $(call filter_out1,$(call filter_out1,$1))
+
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
+
+	b1 := (
+	b2 := )
+	ProgramFiles86w := $(ProgramFiles$(b1)x86$(b2))
+	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
+
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir := $(WindowsSdkDir)
+
+	WindowsSDKVersion ?= $(firstword $(foreach folder,$(subst $(subst \,/,$(WindowsSdkDir)Include/),,$(wildcard $(call fix_path,$(WindowsSdkDir)Include\*))),$(if $(wildcard $(call fix_path,$(WindowsSdkDir)Include/$(folder)/um/Windows.h)),$(folder),)))$(BACKSLASH)
+	WindowsSDKVersion := $(WindowsSDKVersion)
+
+	VsInstallBuildTools = $(ProgramFiles86)/Microsoft Visual Studio/2019/BuildTools
+	VsInstallEnterprise = $(ProgramFiles86)/Microsoft Visual Studio/2019/Enterprise
+	VsInstallProfessional = $(ProgramFiles86)/Microsoft Visual Studio/2019/Professional
+	VsInstallCommunity = $(ProgramFiles86)/Microsoft Visual Studio/2019/Community
+
+	VsInstallRoot ?= $(shell if [ -d "$(VsInstallBuildTools)" ]; then echo "$(VsInstallBuildTools)"; fi)
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallEnterprise)" ]; then echo "$(VsInstallEnterprise)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallProfessional)" ]; then echo "$(VsInstallProfessional)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallCommunity)" ]; then echo "$(VsInstallCommunity)"; fi)
+	endif
+	VsInstallRoot := $(VsInstallRoot)
+
+	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
+	VcCompilerLibDir := $(VcCompilerToolsDir)/lib/$(TargetArchMoniker)
+
+	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
+	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
+	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
+	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
+	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
+
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerLibDir)")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
+
+	# For some reason the HostX86 compiler doesn't like compiling for x64
+	# ("no such file" opening a shared library), and vice-versa.
+	# Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
+	# NOTE: What about ARM?
+	ifneq (,$(findstring x64,$(TargetArchMoniker)))
+		override TARGET_ARCH = x86_64
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX64/$(TargetArchMoniker)
+      LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x64
+	else
+		override TARGET_ARCH = x86
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)/bin/HostX86/$(TargetArchMoniker)
+      LIB := $(LIB);$(CORE_DIR)/dx9sdk/Lib/x86
+	endif
+
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+
+	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir);$(FFMPEGDIR)/Windows/$(TARGET_ARCH)/lib
+	TARGET := $(TARGET_NAME)_libretro.dll
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
+	PLATFORM_EXT := win32
+	FFMPEGINCFLAGS += -I$(FFMPEGDIR)/Windows/$(TARGET_ARCH)/include
+	FFMPEGLIBDIR := $(FFMPEGDIR)/Windows/$(TARGET_ARCH)/lib
+	FFMPEGLDFLAGS += -LIBPATH:$(FFMPEGLIBDIR)
+	GL_LIB := opengl32.lib
+	LDFLAGS += ws2_32.lib user32.lib shell32.lib avcodec.lib avutil.lib swresample.lib swscale.lib avformat.lib advapi32.lib winmm.lib gdi32.lib d3d9.lib d3dx9.lib
+
 # Windows
 else ifneq (,$(findstring win,$(platform)))   
 	TARGET := $(TARGET_NAME)_libretro.dll

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1,4 +1,3 @@
-
 #include <cstring>
 #include <cassert>
 #include <thread>
@@ -44,125 +43,144 @@
 
 static bool libretro_supports_bitmasks = false;
 
-namespace Libretro {
-LibretroGraphicsContext *ctx;
-retro_environment_t environ_cb;
-static retro_audio_sample_batch_t audio_batch_cb;
-static retro_input_poll_t input_poll_cb;
-static retro_input_state_t input_state_cb;
+namespace Libretro
+{
+   LibretroGraphicsContext *ctx;
+   retro_environment_t environ_cb;
+   static retro_audio_sample_batch_t audio_batch_cb;
+   static retro_input_poll_t input_poll_cb;
+   static retro_input_state_t input_state_cb;
 } // namespace Libretro
 
 using namespace Libretro;
 
-class LibretroHost : public Host {
-public:
-	LibretroHost() {}
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
-	void ShutdownGraphics() override {}
-	void InitSound() override {}
-	void UpdateSound() override {
-		extern int hostAttemptBlockSize;
-		const int blockSizeMax = 512;
-		static int16_t audio[blockSizeMax * 2];
-		assert(hostAttemptBlockSize <= blockSizeMax);
+class LibretroHost : public Host
+{
+   public:
+      LibretroHost() {}
+      bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
+      void ShutdownGraphics() override {}
+      void InitSound() override {}
+      void UpdateSound() override
+      {
+         extern int hostAttemptBlockSize;
+         const int blockSizeMax = 512;
+         static int16_t audio[blockSizeMax * 2];
+         assert(hostAttemptBlockSize <= blockSizeMax);
 
-		int samples = __AudioMix(audio, hostAttemptBlockSize, SAMPLERATE);
-		audio_batch_cb(audio, samples);
-	}
-	void ShutdownSound() override {}
-	bool IsDebuggingEnabled() override { return false; }
-	bool AttemptLoadSymbolMap() override { return false; }
+         int samples = __AudioMix(audio, hostAttemptBlockSize, SAMPLERATE);
+         audio_batch_cb(audio, samples);
+      }
+      void ShutdownSound() override {}
+      bool IsDebuggingEnabled() override { return false; }
+      bool AttemptLoadSymbolMap() override { return false; }
 };
 
-class PrintfLogger : public LogListener {
-public:
-	PrintfLogger(retro_log_callback log) : log_(log.log) {}
-	void Log(const LogMessage &message) {
-		switch (message.level) {
-		case LogTypes::LVERBOSE:
-		case LogTypes::LDEBUG:
-			log_(RETRO_LOG_DEBUG, "[%s] %s", message.log, message.msg.c_str());
-			return;
+class PrintfLogger : public LogListener
+{
+   public:
+      PrintfLogger(retro_log_callback log) : log_(log.log) {}
+      void Log(const LogMessage &message)
+      {
+         switch (message.level)
+         {
+            case LogTypes::LVERBOSE:
+            case LogTypes::LDEBUG:
+               log_(RETRO_LOG_DEBUG, "[%s] %s",
+                     message.log, message.msg.c_str());
+               break;
 
-		case LogTypes::LERROR:
-			log_(RETRO_LOG_ERROR, "[%s] %s", message.log, message.msg.c_str());
-			return;
+            case LogTypes::LERROR:
+               log_(RETRO_LOG_ERROR, "[%s] %s",
+                     message.log, message.msg.c_str());
+               break;
+            case LogTypes::LNOTICE:
+            case LogTypes::LWARNING:
+               log_(RETRO_LOG_WARN, "[%s] %s",
+                     message.log, message.msg.c_str());
+               break;
+            case LogTypes::LINFO:
+            default:
+               log_(RETRO_LOG_INFO, "[%s] %s",
+                     message.log, message.msg.c_str());
+               break;
+         }
+      }
 
-		case LogTypes::LNOTICE:
-		case LogTypes::LWARNING:
-			log_(RETRO_LOG_WARN, "[%s] %s", message.log, message.msg.c_str());
-			return;
-
-		case LogTypes::LINFO:
-		default:
-			log_(RETRO_LOG_INFO, "[%s] %s", message.log, message.msg.c_str());
-			return;
-		}
-	}
-
-private:
-	retro_log_printf_t log_;
+   private:
+      retro_log_printf_t log_;
 };
 static PrintfLogger *printfLogger;
 
-template <typename T> class RetroOption {
-public:
-	RetroOption(const char *id, const char *name, std::initializer_list<std::pair<const char *, T>> list) : id_(id), name_(name), list_(list.begin(), list.end()) {}
-	RetroOption(const char *id, const char *name, std::initializer_list<const char *> list) : id_(id), name_(name) {
-		for (auto option : list)
-			list_.push_back({ option, (T)list_.size() });
-	}
-	RetroOption(const char *id, const char *name, T first, std::initializer_list<const char *> list) : id_(id), name_(name) {
-		for (auto option : list)
-			list_.push_back({ option, first + (int)list_.size() });
-	}
-	RetroOption(const char *id, const char *name, T first, int count, int step = 1) : id_(id), name_(name) {
-		for (T i = first; i < first + count; i += step)
-			list_.push_back({ std::to_string(i), i });
-	}
-	RetroOption(const char *id, const char *name, bool initial) : id_(id), name_(name) {
-		list_.push_back({ initial ? "enabled" : "disabled", initial });
-		list_.push_back({ !initial ? "enabled" : "disabled", !initial });
-	}
-	retro_variable GetOptions() {
-		if (options_.empty()) {
-			options_ = name_;
-			options_.push_back(';');
-			for (auto &option : list_) {
-				if (option.first == list_.begin()->first)
-					options_ += std::string(" ") + option.first;
-				else
-					options_ += std::string("|") + option.first;
-			}
-		}
-		return { id_, options_.c_str() };
-	}
-	bool Update(T *dest) {
-		retro_variable var{ id_ };
-		T val = list_.front().second;
+template <typename T> class RetroOption
+{
+   public:
+      RetroOption(const char *id, const char *name, std::initializer_list<std::pair<const char *, T>> list) : id_(id), name_(name), list_(list.begin(), list.end()) {}
+      RetroOption(const char *id, const char *name, std::initializer_list<const char *> list) : id_(id), name_(name) {
+         for (auto option : list)
+            list_.push_back({ option, (T)list_.size() });
+      }
+      RetroOption(const char *id, const char *name, T first, std::initializer_list<const char *> list) : id_(id), name_(name) {
+         for (auto option : list)
+            list_.push_back({ option, first + (int)list_.size() });
+      }
+      RetroOption(const char *id, const char *name, T first, int count, int step = 1) : id_(id), name_(name) {
+         for (T i = first; i < first + count; i += step)
+            list_.push_back({ std::to_string(i), i });
+      }
+      RetroOption(const char *id, const char *name, bool initial) : id_(id), name_(name) {
+         list_.push_back({ initial ? "enabled" : "disabled", initial });
+         list_.push_back({ !initial ? "enabled" : "disabled", !initial });
+      }
 
-		if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
-			for (auto option : list_) {
-				if (option.first == var.value) {
-					val = option.second;
-					break;
-				}
-			}
-		}
+      retro_variable GetOptions()
+      {
+         if (options_.empty())
+         {
+            options_ = name_;
+            options_.push_back(';');
+            for (auto &option : list_)
+            {
+               if (option.first == list_.begin()->first)
+                  options_ += std::string(" ") + option.first;
+               else
+                  options_ += std::string("|") + option.first;
+            }
+         }
+         return { id_, options_.c_str() };
+      }
 
-		if (*dest != val) {
-			*dest = val;
-			return true;
-		}
+      bool Update(T *dest)
+      {
+         retro_variable var{ id_ };
+         T val = list_.front().second;
 
-		return false;
-	}
+         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+         {
+            for (auto option : list_)
+            {
+               if (option.first == var.value)
+               {
+                  val = option.second;
+                  break;
+               }
+            }
+         }
 
-private:
-	const char *id_;
-	const char *name_;
-	std::string options_;
-	std::vector<std::pair<std::string, T>> list_;
+         if (*dest != val)
+         {
+            *dest = val;
+            return true;
+         }
+
+         return false;
+      }
+
+   private:
+      const char *id_;
+      const char *name_;
+      std::string options_;
+      std::vector<std::pair<std::string, T>> list_;
 };
 
 static RetroOption<CPUCore> ppsspp_cpu_core("ppsspp_cpu_core", "CPU Core", { { "jit", CPUCore::JIT }, { "IR jit", CPUCore::IR_JIT }, { "interpreter", CPUCore::INTERPRETER } });
@@ -188,119 +206,127 @@ static RetroOption<bool> ppsspp_unsafe_func_replacements("ppsspp_unsafe_func_rep
 static RetroOption<bool> ppsspp_cheats("ppsspp_cheats", "Internal Cheats Support", false);
 static RetroOption<IOTimingMethods> ppsspp_io_timing_method("ppsspp_io_timing_method", "IO Timing Method", { { "Fast", IOTimingMethods::IOTIMING_FAST }, { "Host", IOTimingMethods::IOTIMING_HOST }, { "Simulate UMD delays", IOTimingMethods::IOTIMING_REALISTIC } });
 
-void retro_set_environment(retro_environment_t cb) {
-	std::vector<retro_variable> vars;
-	vars.push_back(ppsspp_cpu_core.GetOptions());
-	vars.push_back(ppsspp_locked_cpu_speed.GetOptions());
-	vars.push_back(ppsspp_language.GetOptions());
-	vars.push_back(ppsspp_rendering_mode.GetOptions());
-	vars.push_back(ppsspp_auto_frameskip.GetOptions());
-	vars.push_back(ppsspp_frameskip.GetOptions());
-	vars.push_back(ppsspp_frameskiptype.GetOptions());
-	vars.push_back(ppsspp_internal_resolution.GetOptions());
-	vars.push_back(ppsspp_button_preference.GetOptions());
-	vars.push_back(ppsspp_fast_memory.GetOptions());
-	vars.push_back(ppsspp_block_transfer_gpu.GetOptions());
-	vars.push_back(ppsspp_texture_scaling_level.GetOptions());
-	vars.push_back(ppsspp_texture_scaling_type.GetOptions());
-	vars.push_back(ppsspp_texture_filtering.GetOptions());
-	vars.push_back(ppsspp_texture_anisotropic_filtering.GetOptions());
-	vars.push_back(ppsspp_texture_deposterize.GetOptions());
-	vars.push_back(ppsspp_texture_replacement.GetOptions());
-	vars.push_back(ppsspp_gpu_hardware_transform.GetOptions());
-	vars.push_back(ppsspp_vertex_cache.GetOptions());
-	vars.push_back(ppsspp_unsafe_func_replacements.GetOptions());
-	vars.push_back(ppsspp_cheats.GetOptions());
-	vars.push_back(ppsspp_io_timing_method.GetOptions());
-	vars.push_back({});
+void retro_set_environment(retro_environment_t cb)
+{
+   std::vector<retro_variable> vars;
+   vars.push_back(ppsspp_cpu_core.GetOptions());
+   vars.push_back(ppsspp_locked_cpu_speed.GetOptions());
+   vars.push_back(ppsspp_language.GetOptions());
+   vars.push_back(ppsspp_rendering_mode.GetOptions());
+   vars.push_back(ppsspp_auto_frameskip.GetOptions());
+   vars.push_back(ppsspp_frameskip.GetOptions());
+   vars.push_back(ppsspp_frameskiptype.GetOptions());
+   vars.push_back(ppsspp_internal_resolution.GetOptions());
+   vars.push_back(ppsspp_button_preference.GetOptions());
+   vars.push_back(ppsspp_fast_memory.GetOptions());
+   vars.push_back(ppsspp_block_transfer_gpu.GetOptions());
+   vars.push_back(ppsspp_texture_scaling_level.GetOptions());
+   vars.push_back(ppsspp_texture_scaling_type.GetOptions());
+   vars.push_back(ppsspp_texture_filtering.GetOptions());
+   vars.push_back(ppsspp_texture_anisotropic_filtering.GetOptions());
+   vars.push_back(ppsspp_texture_deposterize.GetOptions());
+   vars.push_back(ppsspp_texture_replacement.GetOptions());
+   vars.push_back(ppsspp_gpu_hardware_transform.GetOptions());
+   vars.push_back(ppsspp_vertex_cache.GetOptions());
+   vars.push_back(ppsspp_unsafe_func_replacements.GetOptions());
+   vars.push_back(ppsspp_cheats.GetOptions());
+   vars.push_back(ppsspp_io_timing_method.GetOptions());
+   vars.push_back({});
 
-	environ_cb = cb;
+   environ_cb = cb;
 
-	cb(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars.data());
+   cb(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars.data());
 }
 
-static int get_language_auto(void) {
-	retro_language val = RETRO_LANGUAGE_ENGLISH;
-	environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &val);
+static int get_language_auto(void)
+{
+   retro_language val = RETRO_LANGUAGE_ENGLISH;
+   environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &val);
 
-	switch (val) {
-	default:
-	case RETRO_LANGUAGE_ENGLISH:
-		return PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
-	case RETRO_LANGUAGE_JAPANESE:
-		return PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
-	case RETRO_LANGUAGE_FRENCH:
-		return PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
-	case RETRO_LANGUAGE_GERMAN:
-		return PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
-	case RETRO_LANGUAGE_SPANISH:
-		return PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
-	case RETRO_LANGUAGE_ITALIAN:
-		return PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
-	case RETRO_LANGUAGE_PORTUGUESE_BRAZIL:
-	case RETRO_LANGUAGE_PORTUGUESE_PORTUGAL:
-		return PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
-	case RETRO_LANGUAGE_RUSSIAN:
-		return PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
-	case RETRO_LANGUAGE_DUTCH:
-		return PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
-	case RETRO_LANGUAGE_KOREAN:
-		return PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
-	case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
-		return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
-	case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
-		return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
-	}
+   switch (val)
+   {
+      default:
+      case RETRO_LANGUAGE_ENGLISH:
+         return PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+      case RETRO_LANGUAGE_JAPANESE:
+         return PSP_SYSTEMPARAM_LANGUAGE_JAPANESE;
+      case RETRO_LANGUAGE_FRENCH:
+         return PSP_SYSTEMPARAM_LANGUAGE_FRENCH;
+      case RETRO_LANGUAGE_GERMAN:
+         return PSP_SYSTEMPARAM_LANGUAGE_GERMAN;
+      case RETRO_LANGUAGE_SPANISH:
+         return PSP_SYSTEMPARAM_LANGUAGE_SPANISH;
+      case RETRO_LANGUAGE_ITALIAN:
+         return PSP_SYSTEMPARAM_LANGUAGE_ITALIAN;
+      case RETRO_LANGUAGE_PORTUGUESE_BRAZIL:
+      case RETRO_LANGUAGE_PORTUGUESE_PORTUGAL:
+         return PSP_SYSTEMPARAM_LANGUAGE_PORTUGUESE;
+      case RETRO_LANGUAGE_RUSSIAN:
+         return PSP_SYSTEMPARAM_LANGUAGE_RUSSIAN;
+      case RETRO_LANGUAGE_DUTCH:
+         return PSP_SYSTEMPARAM_LANGUAGE_DUTCH;
+      case RETRO_LANGUAGE_KOREAN:
+         return PSP_SYSTEMPARAM_LANGUAGE_KOREAN;
+      case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
+         return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
+      case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
+         return PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
+   }
 }
 
-static void check_variables(CoreParameter &coreParam) {
-	bool updated = false;
+static void check_variables(CoreParameter &coreParam)
+{
+   bool updated = false;
 
-	if (coreState != CORE_POWERUP && environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && !updated)
-		return;
+   if (     coreState != CORE_POWERUP 
+         && environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) 
+         && !updated)
+      return;
 
-	ppsspp_button_preference.Update(&g_Config.iButtonPreference);
-	ppsspp_fast_memory.Update(&g_Config.bFastMemory);
-	ppsspp_vertex_cache.Update(&g_Config.bVertexCache);
-	ppsspp_gpu_hardware_transform.Update(&g_Config.bHardwareTransform);
-	ppsspp_frameskip.Update(&g_Config.iFrameSkip);
-	ppsspp_frameskiptype.Update(&g_Config.iFrameSkipType);
-	ppsspp_auto_frameskip.Update(&g_Config.bAutoFrameSkip);
-	ppsspp_block_transfer_gpu.Update(&g_Config.bBlockTransferGPU);
-	ppsspp_texture_filtering.Update(&g_Config.iTexFiltering);
-	ppsspp_texture_anisotropic_filtering.Update(&g_Config.iAnisotropyLevel);
-	ppsspp_texture_deposterize.Update(&g_Config.bTexDeposterize);
-	ppsspp_texture_replacement.Update(&g_Config.bReplaceTextures);
-	ppsspp_unsafe_func_replacements.Update(&g_Config.bFuncReplacements);
-	ppsspp_cheats.Update(&g_Config.bEnableCheats);
-	ppsspp_locked_cpu_speed.Update(&g_Config.iLockedCPUSpeed);
-	ppsspp_rendering_mode.Update(&g_Config.iRenderingMode);
-	ppsspp_cpu_core.Update((CPUCore *)&g_Config.iCpuCore);
-	ppsspp_io_timing_method.Update((IOTimingMethods *)&g_Config.iIOTimingMethod);
+   ppsspp_button_preference.Update(&g_Config.iButtonPreference);
+   ppsspp_fast_memory.Update(&g_Config.bFastMemory);
+   ppsspp_vertex_cache.Update(&g_Config.bVertexCache);
+   ppsspp_gpu_hardware_transform.Update(&g_Config.bHardwareTransform);
+   ppsspp_frameskip.Update(&g_Config.iFrameSkip);
+   ppsspp_frameskiptype.Update(&g_Config.iFrameSkipType);
+   ppsspp_auto_frameskip.Update(&g_Config.bAutoFrameSkip);
+   ppsspp_block_transfer_gpu.Update(&g_Config.bBlockTransferGPU);
+   ppsspp_texture_filtering.Update(&g_Config.iTexFiltering);
+   ppsspp_texture_anisotropic_filtering.Update(&g_Config.iAnisotropyLevel);
+   ppsspp_texture_deposterize.Update(&g_Config.bTexDeposterize);
+   ppsspp_texture_replacement.Update(&g_Config.bReplaceTextures);
+   ppsspp_unsafe_func_replacements.Update(&g_Config.bFuncReplacements);
+   ppsspp_cheats.Update(&g_Config.bEnableCheats);
+   ppsspp_locked_cpu_speed.Update(&g_Config.iLockedCPUSpeed);
+   ppsspp_rendering_mode.Update(&g_Config.iRenderingMode);
+   ppsspp_cpu_core.Update((CPUCore *)&g_Config.iCpuCore);
+   ppsspp_io_timing_method.Update((IOTimingMethods *)&g_Config.iIOTimingMethod);
 
-	ppsspp_language.Update(&g_Config.iLanguage);
-	if (g_Config.iLanguage < 0) {
-		g_Config.iLanguage = get_language_auto();
-	}
+   ppsspp_language.Update(&g_Config.iLanguage);
+   if (g_Config.iLanguage < 0)
+      g_Config.iLanguage = get_language_auto();
 
-	if (!PSP_IsInited() && ppsspp_internal_resolution.Update(&g_Config.iInternalResolution)) {
-		coreParam.pixelWidth = coreParam.renderWidth = g_Config.iInternalResolution * 480;
-		coreParam.pixelHeight = coreParam.renderHeight = g_Config.iInternalResolution * 272;
-		if (gpu) {
-			retro_system_av_info av_info;
-			retro_get_system_av_info(&av_info);
-			environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
-			gpu->Resized();
-		}
-	}
+   if (!PSP_IsInited() && ppsspp_internal_resolution.Update(&g_Config.iInternalResolution))
+   {
+      coreParam.pixelWidth  = coreParam.renderWidth  = 
+         g_Config.iInternalResolution * 480;
+      coreParam.pixelHeight = coreParam.renderHeight = 
+         g_Config.iInternalResolution * 272;
 
-	if (ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType) && gpu) {
-		gpu->ClearCacheNextFrame();
-	}
+      if (gpu)
+      {
+         retro_system_av_info av_info;
+         retro_get_system_av_info(&av_info);
+         environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
+         gpu->Resized();
+      }
+   }
 
-	if (ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel) && gpu) {
-		gpu->ClearCacheNextFrame();
-	}
+   if (ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType) && gpu)
+      gpu->ClearCacheNextFrame();
+
+   if (ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel) && gpu)
+      gpu->ClearCacheNextFrame();
 }
 
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
@@ -310,287 +336,301 @@ void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 
 void retro_init(void)
 {
+   struct retro_log_callback log;
 #if 0
-	g_Config.Load("");
+   g_Config.Load("");
 #endif
 
-	g_Config.bEnableLogging = true;
-	g_Config.bFrameSkipUnthrottle = false;
-	g_Config.bMemStickInserted = PSP_MEMORYSTICK_STATE_INSERTED;
-	g_Config.iGlobalVolume = VOLUME_MAX - 1;
-	g_Config.iAltSpeedVolume = -1;
-	g_Config.bEnableSound = true;
-	g_Config.iCwCheatRefreshRate = 60;
+   g_Config.bEnableLogging = true;
+   g_Config.bFrameSkipUnthrottle = false;
+   g_Config.bMemStickInserted = PSP_MEMORYSTICK_STATE_INSERTED;
+   g_Config.iGlobalVolume = VOLUME_MAX - 1;
+   g_Config.iAltSpeedVolume = -1;
+   g_Config.bEnableSound = true;
+   g_Config.iCwCheatRefreshRate = 60;
 
-	g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
-	g_Config.iPSPModel = PSP_MODEL_SLIM;
+   g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
+   g_Config.iPSPModel = PSP_MODEL_SLIM;
 
-	LogManager::Init();
+   LogManager::Init();
 
-	host = new LibretroHost;
+   host = new LibretroHost;
 
-	struct retro_log_callback log;
-	if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log)) {
-		printfLogger = new PrintfLogger(log);
-		LogManager *logman = LogManager::GetInstance();
-		logman->RemoveListener(logman->GetConsoleListener());
-		logman->RemoveListener(logman->GetDebuggerListener());
-		logman->ChangeFileLog(nullptr);
-		logman->AddListener(printfLogger);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
+   {
+      printfLogger = new PrintfLogger(log);
+      LogManager *logman = LogManager::GetInstance();
+      logman->RemoveListener(logman->GetConsoleListener());
+      logman->RemoveListener(logman->GetDebuggerListener());
+      logman->ChangeFileLog(nullptr);
+      logman->AddListener(printfLogger);
 #if 1
-		logman->SetAllLogLevels(LogTypes::LINFO);
+      logman->SetAllLogLevels(LogTypes::LINFO);
 #endif
-	}
+   }
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 }
 
-void retro_deinit(void) {
-	LogManager::Shutdown();
+void retro_deinit(void)
+{
+   LogManager::Shutdown();
 
-	delete printfLogger;
-	printfLogger = nullptr;
+   delete printfLogger;
+   printfLogger = nullptr;
 
-	delete host;
-	host = nullptr;
+   delete host;
+   host = nullptr;
 
    libretro_supports_bitmasks = false;
 }
 
-void retro_set_controller_port_device(unsigned port, unsigned device) {
+void retro_set_controller_port_device(unsigned port, unsigned device)
+{
 	(void)port;
 	(void)device;
 }
 
-void retro_get_system_info(struct retro_system_info *info) {
-	*info = {};
-	info->library_name = "PPSSPP";
-	info->library_version = PPSSPP_GIT_VERSION;
-	info->need_fullpath = true;
-	info->valid_extensions = "elf|iso|cso|prx|pbp";
+void retro_get_system_info(struct retro_system_info *info)
+{
+   *info = {};
+   info->library_name     = "PPSSPP";
+   info->library_version  = PPSSPP_GIT_VERSION;
+   info->need_fullpath    = true;
+   info->valid_extensions = "elf|iso|cso|prx|pbp";
 }
 
-void retro_get_system_av_info(struct retro_system_av_info *info) {
-	*info = {};
-	info->timing.fps = 60.0f / 1.001f;
-	info->timing.sample_rate = SAMPLERATE;
+void retro_get_system_av_info(struct retro_system_av_info *info)
+{
+   *info = {};
+   info->timing.fps            = 60.0f / 1.001f;
+   info->timing.sample_rate    = SAMPLERATE;
 
-	info->geometry.base_width = g_Config.iInternalResolution * 480;
-	info->geometry.base_height = g_Config.iInternalResolution * 272;
-	info->geometry.max_width = g_Config.iInternalResolution * 480;
-	info->geometry.max_height = g_Config.iInternalResolution * 272;
-	info->geometry.aspect_ratio = 16.0 / 9.0;
+   info->geometry.base_width   = g_Config.iInternalResolution * 480;
+   info->geometry.base_height  = g_Config.iInternalResolution * 272;
+   info->geometry.max_width    = g_Config.iInternalResolution * 480;
+   info->geometry.max_height   = g_Config.iInternalResolution * 272;
+   info->geometry.aspect_ratio = 16.0 / 9.0;
 }
 
 unsigned retro_api_version(void) { return RETRO_API_VERSION; }
-namespace Libretro {
 
-bool useEmuThread = false;
-std::atomic<EmuThreadState> emuThreadState(EmuThreadState::DISABLED);
+namespace Libretro
+{
+   bool useEmuThread = false;
+   std::atomic<EmuThreadState> emuThreadState(EmuThreadState::DISABLED);
 
-static std::thread emuThread;
-static void EmuFrame() {
-	ctx->SetRenderTarget();
-	if (ctx->GetDrawContext()) {
-		ctx->GetDrawContext()->BeginFrame();
-	}
+   static std::thread emuThread;
+   static void EmuFrame()
+   {
+      ctx->SetRenderTarget();
+      if (ctx->GetDrawContext())
+         ctx->GetDrawContext()->BeginFrame();
 
-	gpu->BeginHostFrame();
+      gpu->BeginHostFrame();
 
-	coreState = CORE_RUNNING;
-	PSP_RunLoopUntil(UINT64_MAX);
+      coreState = CORE_RUNNING;
+      PSP_RunLoopUntil(UINT64_MAX);
 
-	gpu->EndHostFrame();
+      gpu->EndHostFrame();
 
-	if (ctx->GetDrawContext()) {
-		ctx->GetDrawContext()->EndFrame();
-	}
-}
+      if (ctx->GetDrawContext())
+         ctx->GetDrawContext()->EndFrame();
+   }
 
-static void EmuThreadFunc() {
-	setCurrentThreadName("Emu");
+   static void EmuThreadFunc()
+   {
+      setCurrentThreadName("Emu");
 
-	while (true) {
-		switch ((EmuThreadState)emuThreadState) {
-		case EmuThreadState::START_REQUESTED:
-			emuThreadState = EmuThreadState::RUNNING;
-			/* fallthrough */
-		case EmuThreadState::RUNNING:
-			EmuFrame();
-			break;
-		case EmuThreadState::PAUSE_REQUESTED:
-			emuThreadState = EmuThreadState::PAUSED;
-			/* fallthrough */
-		case EmuThreadState::PAUSED:
-			sleep_ms(1);
-			break;
-		default:
-		case EmuThreadState::QUIT_REQUESTED:
-			emuThreadState = EmuThreadState::STOPPED;
-			ctx->StopThread();
-			return;
-		}
-	}
-}
+      for (;;)
+      {
+         switch ((EmuThreadState)emuThreadState)
+         {
+            case EmuThreadState::START_REQUESTED:
+               emuThreadState = EmuThreadState::RUNNING;
+               /* fallthrough */
+            case EmuThreadState::RUNNING:
+               EmuFrame();
+               break;
+            case EmuThreadState::PAUSE_REQUESTED:
+               emuThreadState = EmuThreadState::PAUSED;
+               /* fallthrough */
+            case EmuThreadState::PAUSED:
+               sleep_ms(1);
+               break;
+            default:
+            case EmuThreadState::QUIT_REQUESTED:
+               emuThreadState = EmuThreadState::STOPPED;
+               ctx->StopThread();
+               return;
+         }
+      }
+   }
 
-void EmuThreadStart() {
-	bool wasPaused = emuThreadState == EmuThreadState::PAUSED;
-	emuThreadState = EmuThreadState::START_REQUESTED;
+   void EmuThreadStart()
+   {
+      bool wasPaused = emuThreadState == EmuThreadState::PAUSED;
+      emuThreadState = EmuThreadState::START_REQUESTED;
 
-	if (!wasPaused) {
-		ctx->ThreadStart();
-		emuThread = std::thread(&EmuThreadFunc);
-	}
-}
+      if (!wasPaused)
+      {
+         ctx->ThreadStart();
+         emuThread = std::thread(&EmuThreadFunc);
+      }
+   }
 
-void EmuThreadStop() {
-	if (emuThreadState != EmuThreadState::RUNNING) {
-		return;
-	}
+   void EmuThreadStop()
+   {
+      if (emuThreadState != EmuThreadState::RUNNING)
+         return;
 
-	emuThreadState = EmuThreadState::QUIT_REQUESTED;
+      emuThreadState = EmuThreadState::QUIT_REQUESTED;
 
-	while (ctx->ThreadFrame()) {
-		// Need to keep eating frames to allow the EmuThread to exit correctly.
-		continue;
-	}
+      // Need to keep eating frames to allow the EmuThread to exit correctly.
+      while (ctx->ThreadFrame())
+         continue;
 
-	emuThread.join();
-	emuThread = std::thread();
-	ctx->ThreadEnd();
-}
+      emuThread.join();
+      emuThread = std::thread();
+      ctx->ThreadEnd();
+   }
 
-void EmuThreadPause() {
-	if (emuThreadState != EmuThreadState::RUNNING) {
-		return;
-	}
+   void EmuThreadPause()
+   {
+      if (emuThreadState != EmuThreadState::RUNNING)
+         return;
 
-	emuThreadState = EmuThreadState::PAUSE_REQUESTED;
+      emuThreadState = EmuThreadState::PAUSE_REQUESTED;
 
-	ctx->ThreadFrame(); // Eat 1 frame
+      ctx->ThreadFrame(); // Eat 1 frame
 
-	while (emuThreadState != EmuThreadState::PAUSED) {
-		sleep_ms(1);
-	}
-}
+      while (emuThreadState != EmuThreadState::PAUSED)
+         sleep_ms(1);
+   }
 
 } // namespace Libretro
 
-bool retro_load_game(const struct retro_game_info *game) {
-	struct retro_input_descriptor desc[] = {
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "D-Pad Left" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "D-Pad Up" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN, "D-Pad Down" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Cross" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Circle" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Triangle" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Square" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 0 },
-	};
-	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
+bool retro_load_game(const struct retro_game_info *game)
+{
+   static std::string retro_base_dir;
+   static std::string retro_save_dir;
+   std::string error_string;
+   enum retro_pixel_format fmt          = RETRO_PIXEL_FORMAT_XRGB8888;
+   const char *nickname                 = NULL;
+   const char *dir_ptr                  = NULL;
+   struct retro_input_descriptor desc[] = {
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "D-Pad Left" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "D-Pad Up" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN, "D-Pad Down" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Cross" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Circle" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Triangle" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Square" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 0 },
+   };
 
-	enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
-	if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt)) {
-		ERROR_LOG(SYSTEM, "XRGB8888 is not supported.\n");
-		return false;
-	}
+   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
-	const char *nickname = NULL;
-	if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &nickname) && nickname) {
-		g_Config.sNickName = std::string(nickname);
-	}
+   if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
+   {
+      ERROR_LOG(SYSTEM, "XRGB8888 is not supported.\n");
+      return false;
+   }
 
-	const char *dir_ptr = NULL;
-	static std::string retro_base_dir;
-	static std::string retro_save_dir;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &nickname) && nickname)
+      g_Config.sNickName = std::string(nickname);
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir_ptr) && dir_ptr) {
-		retro_base_dir = dir_ptr;
-		// Make sure that we don't have any lingering slashes, etc, as they break Windows.
-		size_t last = retro_base_dir.find_last_not_of(DIR_SEP_CHRS);
-		if (last != std::string::npos)
-			last++;
 
-		retro_base_dir = retro_base_dir.substr(0, last) + DIR_SEP;
-	}
+   if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir_ptr) 
+         && dir_ptr)
+   {
+      size_t last;
+      retro_base_dir = dir_ptr;
+      // Make sure that we don't have any lingering slashes, etc, as they break Windows.
+      last = retro_base_dir.find_last_not_of(DIR_SEP_CHRS);
+      if (last != std::string::npos)
+         last++;
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir_ptr) && dir_ptr) {
-		retro_save_dir = dir_ptr;
-		// Make sure that we don't have any lingering slashes, etc, as they break Windows.
-		size_t last = retro_save_dir.find_last_not_of(DIR_SEP_CHRS);
-		if (last != std::string::npos)
-			last++;
+      retro_base_dir = retro_base_dir.substr(0, last) + DIR_SEP;
+   }
 
-		retro_save_dir = retro_save_dir.substr(0, last) + DIR_SEP;
-	}
+   if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir_ptr) 
+         && dir_ptr)
+   {
+      retro_save_dir = dir_ptr;
+      // Make sure that we don't have any lingering slashes, etc, as they break Windows.
+      size_t last = retro_save_dir.find_last_not_of(DIR_SEP_CHRS);
+      if (last != std::string::npos)
+         last++;
 
-	if (retro_base_dir.empty()) {
-		retro_base_dir = File::GetDir(game->path);
-	}
+      retro_save_dir = retro_save_dir.substr(0, last) + DIR_SEP;
+   }
 
-	retro_base_dir += "PPSSPP" DIR_SEP;
+   if (retro_base_dir.empty())
+      retro_base_dir = File::GetDir(game->path);
 
-	if (retro_save_dir.empty()) {
-		retro_save_dir = File::GetDir(game->path);
-	}
+   retro_base_dir            += "PPSSPP" DIR_SEP;
 
-	g_Config.currentDirectory = retro_base_dir;
-	g_Config.externalDirectory = retro_base_dir;
-	g_Config.memStickDirectory = retro_save_dir;
-	g_Config.flash0Directory = retro_base_dir + "flash0" DIR_SEP;
-	g_Config.internalDataDirectory = retro_base_dir;
+   if (retro_save_dir.empty())
+      retro_save_dir = File::GetDir(game->path);
 
-	VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
+   g_Config.currentDirectory      = retro_base_dir;
+   g_Config.externalDirectory     = retro_base_dir;
+   g_Config.memStickDirectory     = retro_save_dir;
+   g_Config.flash0Directory       = retro_base_dir + "flash0" DIR_SEP;
+   g_Config.internalDataDirectory = retro_base_dir;
 
-	coreState = CORE_POWERUP;
-	ctx = LibretroGraphicsContext::CreateGraphicsContext();
-	INFO_LOG(SYSTEM, "Using %s backend", ctx->Ident());
+   VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
 
-	Core_SetGraphicsContext(ctx);
-	SetGPUBackend((GPUBackend)g_Config.iGPUBackend);
+   coreState = CORE_POWERUP;
+   ctx       = LibretroGraphicsContext::CreateGraphicsContext();
+   INFO_LOG(SYSTEM, "Using %s backend", ctx->Ident());
 
-	useEmuThread = ctx->GetGPUCore() == GPUCORE_GLES;
+   Core_SetGraphicsContext(ctx);
+   SetGPUBackend((GPUBackend)g_Config.iGPUBackend);
 
-	CoreParameter coreParam = {};
-	coreParam.enableSound = true;
-	coreParam.fileToStart = std::string(game->path);
-	coreParam.mountIso = "";
-	coreParam.startBreak = false;
-	coreParam.printfEmuLog = true;
-	coreParam.headLess = true;
-	coreParam.unthrottle = true;
-	coreParam.graphicsContext = ctx;
-	coreParam.gpuCore = ctx->GetGPUCore();
-	coreParam.cpuCore = CPUCore::JIT;
-	check_variables(coreParam);
+   useEmuThread              = ctx->GetGPUCore() == GPUCORE_GLES;
+
+   CoreParameter coreParam   = {};
+   coreParam.enableSound     = true;
+   coreParam.fileToStart     = std::string(game->path);
+   coreParam.mountIso        = "";
+   coreParam.startBreak      = false;
+   coreParam.printfEmuLog    = true;
+   coreParam.headLess        = true;
+   coreParam.unthrottle      = true;
+   coreParam.graphicsContext = ctx;
+   coreParam.gpuCore         = ctx->GetGPUCore();
+   coreParam.cpuCore         = CPUCore::JIT;
+   check_variables(coreParam);
 
 #if 0
-	g_Config.bVertexDecoderJit = (coreParam.cpuCore == CPU_JIT) ? true : false;
+   g_Config.bVertexDecoderJit = (coreParam.cpuCore == CPU_JIT) ? true : false;
 #endif
 
-	std::string error_string;
-	if (!PSP_InitStart(coreParam, &error_string)) {
-		ERROR_LOG(BOOT, "%s", error_string.c_str());
-		return false;
-	}
+   if (!PSP_InitStart(coreParam, &error_string))
+   {
+      ERROR_LOG(BOOT, "%s", error_string.c_str());
+      return false;
+   }
 
-	return true;
+   return true;
 }
 
-void retro_unload_game(void) {
-	if (Libretro::useEmuThread) {
+void retro_unload_game(void)
+{
+	if (Libretro::useEmuThread)
 		Libretro::EmuThreadStop();
-	}
 
 	PSP_Shutdown();
 	VFSShutdown();
@@ -600,56 +640,58 @@ void retro_unload_game(void) {
 	PSP_CoreParameter().graphicsContext = nullptr;
 }
 
-void retro_reset(void) {
-	std::string error_string;
+void retro_reset(void)
+{
+   std::string error_string;
 
-	PSP_Shutdown();
+   PSP_Shutdown();
 
 #if 0
-	coreState = CORE_POWERUP;
-	if (!PSP_InitStart(PSP_CoreParameter(), &error_string))
-	{
-		ERROR_LOG(BOOT, "%s", error_string.c_str());
-		environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
-	}
+   coreState = CORE_POWERUP;
+   if (!PSP_InitStart(PSP_CoreParameter(), &error_string))
+   {
+      ERROR_LOG(BOOT, "%s", error_string.c_str());
+      environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
+   }
 #else
-	if (!PSP_Init(PSP_CoreParameter(), &error_string)) {
-		ERROR_LOG(BOOT, "%s", error_string.c_str());
-		environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
-	}
+   if (!PSP_Init(PSP_CoreParameter(), &error_string))
+   {
+      ERROR_LOG(BOOT, "%s", error_string.c_str());
+      environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
+   }
 #endif
 }
 
-static void retro_input(void) {
-	// clang-format off
-	static struct
-	{
-		u32 retro;
-		u32 sceCtrl;
-	} map[] = {
-		{ RETRO_DEVICE_ID_JOYPAD_UP,     CTRL_UP },
-		{ RETRO_DEVICE_ID_JOYPAD_DOWN,   CTRL_DOWN },
-		{ RETRO_DEVICE_ID_JOYPAD_LEFT,   CTRL_LEFT },
-		{ RETRO_DEVICE_ID_JOYPAD_RIGHT,  CTRL_RIGHT },
-		{ RETRO_DEVICE_ID_JOYPAD_X,      CTRL_TRIANGLE },
-		{ RETRO_DEVICE_ID_JOYPAD_A,      CTRL_CIRCLE },
-		{ RETRO_DEVICE_ID_JOYPAD_B,      CTRL_CROSS },
-		{ RETRO_DEVICE_ID_JOYPAD_Y,      CTRL_SQUARE },
-		{ RETRO_DEVICE_ID_JOYPAD_L,      CTRL_LTRIGGER },
-		{ RETRO_DEVICE_ID_JOYPAD_R,      CTRL_RTRIGGER },
-		{ RETRO_DEVICE_ID_JOYPAD_START,  CTRL_START },
-		{ RETRO_DEVICE_ID_JOYPAD_SELECT, CTRL_SELECT },
-	};
-	// clang-format on
-
-	input_poll_cb();
-
+static void retro_input(void)
+{
    unsigned i;
    int16_t ret = 0;
-   if (libretro_supports_bitmasks)
+   // clang-format off
+   static struct
    {
-      ret = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_MASK);
-   }
+      u32 retro;
+      u32 sceCtrl;
+   } map[] = {
+      { RETRO_DEVICE_ID_JOYPAD_UP,     CTRL_UP },
+      { RETRO_DEVICE_ID_JOYPAD_DOWN,   CTRL_DOWN },
+      { RETRO_DEVICE_ID_JOYPAD_LEFT,   CTRL_LEFT },
+      { RETRO_DEVICE_ID_JOYPAD_RIGHT,  CTRL_RIGHT },
+      { RETRO_DEVICE_ID_JOYPAD_X,      CTRL_TRIANGLE },
+      { RETRO_DEVICE_ID_JOYPAD_A,      CTRL_CIRCLE },
+      { RETRO_DEVICE_ID_JOYPAD_B,      CTRL_CROSS },
+      { RETRO_DEVICE_ID_JOYPAD_Y,      CTRL_SQUARE },
+      { RETRO_DEVICE_ID_JOYPAD_L,      CTRL_LTRIGGER },
+      { RETRO_DEVICE_ID_JOYPAD_R,      CTRL_RTRIGGER },
+      { RETRO_DEVICE_ID_JOYPAD_START,  CTRL_START },
+      { RETRO_DEVICE_ID_JOYPAD_SELECT, CTRL_SELECT },
+   };
+   // clang-format on
+
+   input_poll_cb();
+
+   if (libretro_supports_bitmasks)
+      ret = input_state_cb(0, RETRO_DEVICE_JOYPAD,
+            0, RETRO_DEVICE_ID_JOYPAD_MASK);
    else
    {
       for (i = RETRO_DEVICE_ID_JOYPAD_B; i <= RETRO_DEVICE_ID_JOYPAD_R; i++)
@@ -657,170 +699,181 @@ static void retro_input(void) {
             ret |= (1 << i);
    }
 
-	for (i = 0; i < sizeof(map) / sizeof(*map); i++)
+   for (i = 0; i < sizeof(map) / sizeof(*map); i++)
    {
       bool pressed          = ret & (1 << map[i].retro);
 
-		if (pressed)
+      if (pressed)
       {
-			__CtrlButtonDown(map[i].sceCtrl);
-		}
+         __CtrlButtonDown(map[i].sceCtrl);
+      }
       else
       {
-			__CtrlButtonUp(map[i].sceCtrl);
-		}
-	}
+         __CtrlButtonUp(map[i].sceCtrl);
+      }
+   }
 
-	__CtrlSetAnalogX(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X) / 32768.0f, CTRL_STICK_LEFT);
-	__CtrlSetAnalogY(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / -32768.0f, CTRL_STICK_LEFT);
-	__CtrlSetAnalogX(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 32768.0f, CTRL_STICK_RIGHT);
-	__CtrlSetAnalogY(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / -32768.0f, CTRL_STICK_RIGHT);
+   __CtrlSetAnalogX(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X) / 32768.0f, CTRL_STICK_LEFT);
+   __CtrlSetAnalogY(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / -32768.0f, CTRL_STICK_LEFT);
+   __CtrlSetAnalogX(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 32768.0f, CTRL_STICK_RIGHT);
+   __CtrlSetAnalogY(input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / -32768.0f, CTRL_STICK_RIGHT);
 }
 
-void retro_run(void) {
-	if (PSP_IsIniting()) {
-		std::string error_string;
+void retro_run(void)
+{
+   if (PSP_IsIniting())
+   {
+      std::string error_string;
 #if 0
-		if (!PSP_InitUpdate(&error_string))
-		{
-			graphics_context->SwapBuffers();
-			return;
-		}
+      if (!PSP_InitUpdate(&error_string))
+      {
+         graphics_context->SwapBuffers();
+         return;
+      }
 #else
-		while (!PSP_InitUpdate(&error_string)) {
-			sleep_ms(4);
-		}
+      while (!PSP_InitUpdate(&error_string))
+         sleep_ms(4);
 #endif
 
-		if (!PSP_IsInited()) {
-			ERROR_LOG(BOOT, "%s", error_string.c_str());
-			environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
-			return;
-		}
-	}
+      if (!PSP_IsInited())
+      {
+         ERROR_LOG(BOOT, "%s", error_string.c_str());
+         environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, nullptr);
+         return;
+      }
+   }
 
-	check_variables(PSP_CoreParameter());
+   check_variables(PSP_CoreParameter());
 
-	retro_input();
+   retro_input();
 
-	if (useEmuThread) {
-		if(emuThreadState == EmuThreadState::PAUSED || emuThreadState == EmuThreadState::PAUSE_REQUESTED) {
-			ctx->SwapBuffers();
-			return;
-		}
+   if (useEmuThread)
+   {
+      if(   emuThreadState == EmuThreadState::PAUSED || 
+            emuThreadState == EmuThreadState::PAUSE_REQUESTED)
+      {
+         ctx->SwapBuffers();
+         return;
+      }
 
-		if (emuThreadState != EmuThreadState::RUNNING) {
-			EmuThreadStart();
-		}
+      if (emuThreadState != EmuThreadState::RUNNING)
+         EmuThreadStart();
 
-		if (!ctx->ThreadFrame()) {
-			return;
-		}
-	} else {
-		EmuFrame();
-	}
+      if (!ctx->ThreadFrame())
+         return;
+   }
+   else
+      EmuFrame();
 
-	ctx->SwapBuffers();
+   ctx->SwapBuffers();
 }
 
 unsigned retro_get_region(void) { return RETRO_REGION_NTSC; }
 
-bool retro_load_game_special(unsigned type, const struct retro_game_info *info, size_t num) {
-	(void)type;
-	(void)info;
-	(void)num;
-	return false;
-}
+bool retro_load_game_special(unsigned type, const struct retro_game_info *info, size_t num) { return false; }
 
-namespace SaveState {
-struct SaveStart {
-	void DoState(PointerWrap &p);
-};
+namespace SaveState
+{
+   struct SaveStart
+   {
+      void DoState(PointerWrap &p);
+   };
 } // namespace SaveState
 
-size_t retro_serialize_size(void) {
-	// TODO: Libretro API extension to use the savestate queue
-	if (useEmuThread) {
-		EmuThreadPause();
-	}
+size_t retro_serialize_size(void)
+{
+   SaveState::SaveStart state;
+   // TODO: Libretro API extension to use the savestate queue
+   if (useEmuThread)
+      EmuThreadPause();
 
-	SaveState::SaveStart state;
-	return (CChunkFileReader::MeasurePtr(state) + 0x800000) & ~0x7FFFFF; // We don't unpause intentionally
+   return (CChunkFileReader::MeasurePtr(state) + 0x800000) 
+      & ~0x7FFFFF; // We don't unpause intentionally
 }
 
-bool retro_serialize(void *data, size_t size) {
-	// TODO: Libretro API extension to use the savestate queue
-	if (useEmuThread) {
-		EmuThreadPause(); // Does nothing if already paused
-	}
+bool retro_serialize(void *data, size_t size)
+{
+   bool retVal;
+   SaveState::SaveStart state;
+   // TODO: Libretro API extension to use the savestate queue
+   if (useEmuThread)
+      EmuThreadPause(); // Does nothing if already paused
 
-	SaveState::SaveStart state;
-	assert(CChunkFileReader::MeasurePtr(state) <= size);
-	bool retVal = CChunkFileReader::SavePtr((u8 *)data, state) == CChunkFileReader::ERROR_NONE;
+   assert(CChunkFileReader::MeasurePtr(state) <= size);
+   retVal = CChunkFileReader::SavePtr((u8 *)data, state) 
+      == CChunkFileReader::ERROR_NONE;
 
-	if (useEmuThread) {
-		EmuThreadStart();
-		sleep_ms(4);
-	}
+   if (useEmuThread)
+   {
+      EmuThreadStart();
+      sleep_ms(4);
+   }
 
-	return retVal;
+   return retVal;
 }
 
-bool retro_unserialize(const void *data, size_t size) {
-	// TODO: Libretro API extension to use the savestate queue
-	if (useEmuThread) {
-		EmuThreadPause(); // Does nothing if already paused
-	}
+bool retro_unserialize(const void *data, size_t size)
+{
+   bool retVal;
+   SaveState::SaveStart state;
+   // TODO: Libretro API extension to use the savestate queue
+   if (useEmuThread)
+      EmuThreadPause(); // Does nothing if already paused
 
-	SaveState::SaveStart state;
-	bool retVal = CChunkFileReader::LoadPtr((u8 *)data, state) == CChunkFileReader::ERROR_NONE;
+   retVal = CChunkFileReader::LoadPtr((u8 *)data, state) 
+      == CChunkFileReader::ERROR_NONE;
 
-	if (useEmuThread) {
-		EmuThreadStart();
-		sleep_ms(4);
-	}
+   if (useEmuThread)
+   {
+      EmuThreadStart();
+      sleep_ms(4);
+   }
 
-	return retVal;
+   return retVal;
 }
 
-void *retro_get_memory_data(unsigned id) {
-	if ( id == RETRO_MEMORY_SYSTEM_RAM ) {
-		return Memory::GetPointerUnchecked(PSP_GetKernelMemoryBase()) ;
-	}
-	return NULL;
+void *retro_get_memory_data(unsigned id)
+{
+   if ( id == RETRO_MEMORY_SYSTEM_RAM )
+      return Memory::GetPointerUnchecked(PSP_GetKernelMemoryBase()) ;
+   return NULL;
 }
 
-size_t retro_get_memory_size(unsigned id) {
-	if ( id == RETRO_MEMORY_SYSTEM_RAM ) {
+size_t retro_get_memory_size(unsigned id)
+{
+	if ( id == RETRO_MEMORY_SYSTEM_RAM )
 		return Memory::g_MemorySize ;
-	}
 	return 0;
 }
 
 void retro_cheat_reset(void) {}
 
-void retro_cheat_set(unsigned index, bool enabled, const char *code) {
-	(void)index;
-	(void)enabled;
-	(void)code;
+void retro_cheat_set(unsigned index, bool enabled, const char *code) { }
+
+int System_GetPropertyInt(SystemProperty prop)
+{
+   switch (prop)
+   {
+      case SYSPROP_AUDIO_SAMPLE_RATE:
+         return SAMPLERATE;
+      default:
+         break;
+   }
+
+   return -1;
 }
 
-int System_GetPropertyInt(SystemProperty prop) {
-	switch (prop) {
-	case SYSPROP_AUDIO_SAMPLE_RATE:
-		return SAMPLERATE;
-	default:
-		return -1;
-	}
-}
+float System_GetPropertyFloat(SystemProperty prop)
+{
+   switch (prop)
+   {
+      case SYSPROP_DISPLAY_REFRESH_RATE:
+         return 60.f;
+      default:
+         break;
+   }
 
-float System_GetPropertyFloat(SystemProperty prop) {
-	switch (prop) {
-	case SYSPROP_DISPLAY_REFRESH_RATE:
-		return 60.f;
-	default:
-		return -1;
-	}
+   return -1;
 }
 
 std::string System_GetProperty(SystemProperty prop) { return ""; }
@@ -832,7 +885,5 @@ void NativeResized() {}
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 std::vector<std::string> __cameraGetDeviceList() { return std::vector<std::string>(); }
 
-void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) {
-	cb(false, "");
-}
+void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 #endif

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2017 The RetroArch team
+/* Copyright (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this libretro API header (libretro.h).
@@ -128,7 +128,8 @@ extern "C" {
 
 /* LIGHTGUN device is similar to Guncon-2 for PlayStation 2.
  * It reports X/Y coordinates in screen space (similar to the pointer)
- * in the range [-0x8000, 0x7fff] in both axes, with zero being center.
+ * in the range [-0x8000, 0x7fff] in both axes, with zero being center and
+ * -0x8000 being out of bounds.
  * As well as reporting on/off screen state. It features a trigger,
  * start/select buttons, auxiliary action buttons and a
  * directional pad. A forced off-screen shot can be requested for
@@ -139,7 +140,8 @@ extern "C" {
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
  * Similar to DualShock2 it adds two analog sticks and all buttons can
  * be analog. This is treated as a separate device type as it returns
- * axis values in the full analog range of [-0x8000, 0x7fff].
+ * axis values in the full analog range of [-0x7fff, 0x7fff],
+ * although some devices may return -0x8000.
  * Positive X axis is right. Positive Y axis is down.
  * Buttons are returned in the range [0, 0x7fff].
  * Only use ANALOG type when polling for analog values.
@@ -200,6 +202,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_L3      14
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
 
+#define RETRO_DEVICE_ID_JOYPAD_MASK    256
+
 /* Index / Id values for ANALOG device. */
 #define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
 #define RETRO_DEVICE_INDEX_ANALOG_RIGHT      1
@@ -246,6 +250,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0
@@ -271,6 +276,12 @@ enum retro_language
    RETRO_LANGUAGE_POLISH              = 14,
    RETRO_LANGUAGE_VIETNAMESE          = 15,
    RETRO_LANGUAGE_ARABIC              = 16,
+   RETRO_LANGUAGE_GREEK               = 17,
+   RETRO_LANGUAGE_TURKISH             = 18,
+   RETRO_LANGUAGE_SLOVAK              = 19,
+   RETRO_LANGUAGE_PERSIAN             = 20,
+   RETRO_LANGUAGE_HEBREW              = 21,
+   RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -450,6 +461,7 @@ enum retro_key
    RETROK_POWER          = 320,
    RETROK_EURO           = 321,
    RETROK_UNDO           = 322,
+   RETROK_OEM_102        = 323,
 
    RETROK_LAST,
 
@@ -481,11 +493,13 @@ enum retro_mod
 /* Environment commands. */
 #define RETRO_ENVIRONMENT_SET_ROTATION  1  /* const unsigned * --
                                             * Sets screen rotation of graphics.
-                                            * Is only implemented if rotation can be accelerated by hardware.
                                             * Valid values are 0, 1, 2, 3, which rotates screen by 0, 90, 180,
                                             * 270 degrees counter-clockwise respectively.
                                             */
 #define RETRO_ENVIRONMENT_GET_OVERSCAN  2  /* bool * --
+                                            * NOTE: As of 2019 this callback is considered deprecated in favor of
+                                            * using core options to manage overscan in a more nuanced, core-specific way.
+                                            *
                                             * Boolean value whether or not the implementation should use overscan,
                                             * or crop away overscan.
                                             */
@@ -599,8 +613,11 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should be called as early as possible (ideally in
-                                            * retro_set_environment).
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterward it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
                                             *
                                             * 'data' points to an array of retro_variable structs
                                             * terminated by a { NULL, NULL } element.
@@ -654,6 +671,15 @@ enum retro_mod
                                            /* Environment 20 was an obsolete version of SET_AUDIO_CALLBACK.
                                             * It was not used by any known core at the time,
                                             * and was removed from the API. */
+#define RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK 21
+                                           /* const struct retro_frame_time_callback * --
+                                            * Lets the core know how much time has passed since last
+                                            * invocation of retro_run().
+                                            * The frontend can tamper with the timing to fake fast-forward,
+                                            * slow-motion, frame stepping, etc.
+                                            * In this case the delta time will use the reference value
+                                            * in frame_time_callback..
+                                            */
 #define RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK 22
                                            /* const struct retro_audio_callback * --
                                             * Sets an interface which is used to notify a libretro core about audio
@@ -679,15 +705,6 @@ enum retro_mod
                                             *
                                             * A libretro core using SET_AUDIO_CALLBACK should also make use of
                                             * SET_FRAME_TIME_CALLBACK.
-                                            */
-#define RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK 21
-                                           /* const struct retro_frame_time_callback * --
-                                            * Lets the core know how much time has passed since last
-                                            * invocation of retro_run().
-                                            * The frontend can tamper with the timing to fake fast-forward,
-                                            * slow-motion, frame stepping, etc.
-                                            * In this case the delta time will use the reference value
-                                            * in frame_time_callback..
                                             */
 #define RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE 23
                                            /* struct retro_rumble_interface * --
@@ -775,17 +792,18 @@ enum retro_mod
                                             */
 #define RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY 31
                                            /* const char ** --
-                                            * Returns the "save" directory of the frontend.
-                                            * This directory can be used to store SRAM, memory cards,
-                                            * high scores, etc, if the libretro core
+                                            * Returns the "save" directory of the frontend, unless there is no
+                                            * save directory available. The save directory should be used to
+                                            * store SRAM, memory cards, high scores, etc, if the libretro core
                                             * cannot use the regular memory interface (retro_get_memory_data()).
                                             *
-                                            * NOTE: libretro cores used to check GET_SYSTEM_DIRECTORY for
-                                            * similar things before.
-                                            * They should still check GET_SYSTEM_DIRECTORY if they want to
-                                            * be backwards compatible.
-                                            * The path here can be NULL. It should only be non-NULL if the
-                                            * frontend user has set a specific save path.
+                                            * If the frontend cannot designate a save directory, it will return
+                                            * NULL to indicate that the core should attempt to operate without a
+                                            * save directory set.
+                                            *
+                                            * NOTE: early libretro cores used the system directory for save
+                                            * files. Cores that need to be backwards-compatible can still check
+                                            * GET_SYSTEM_DIRECTORY.
                                             */
 #define RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO 32
                                            /* const struct retro_system_av_info * --
@@ -853,26 +871,39 @@ enum retro_mod
 #define RETRO_ENVIRONMENT_SET_CONTROLLER_INFO 35
                                            /* const struct retro_controller_info * --
                                             * This environment call lets a libretro core tell the frontend
-                                            * which controller types are recognized in calls to
+                                            * which controller subclasses are recognized in calls to
                                             * retro_set_controller_port_device().
                                             *
-                                            * Some emulators such as Super Nintendo
-                                            * support multiple lightgun types which must be specifically
-                                            * selected from.
-                                            * It is therefore sometimes necessary for a frontend to be able
-                                            * to tell the core about a special kind of input device which is
-                                            * not covered by the libretro input API.
+                                            * Some emulators such as Super Nintendo support multiple lightgun
+                                            * types which must be specifically selected from. It is therefore
+                                            * sometimes necessary for a frontend to be able to tell the core
+                                            * about a special kind of input device which is not specifcally
+                                            * provided by the Libretro API.
                                             *
-                                            * In order for a frontend to understand the workings of an input device,
-                                            * it must be a specialized type
-                                            * of the generic device types already defined in the libretro API.
+                                            * In order for a frontend to understand the workings of those devices,
+                                            * they must be defined as a specialized subclass of the generic device
+                                            * types already defined in the libretro API.
                                             *
-                                            * Which devices are supported can vary per input port.
                                             * The core must pass an array of const struct retro_controller_info which
-                                            * is terminated with a blanked out struct. Each element of the struct
-                                            * corresponds to an ascending port index to
-                                            * retro_set_controller_port_device().
-                                            * Even if special device types are set in the libretro core,
+                                            * is terminated with a blanked out struct. Each element of the
+                                            * retro_controller_info struct corresponds to the ascending port index
+                                            * that is passed to retro_set_controller_port_device() when that function
+                                            * is called to indicate to the core that the frontend has changed the
+                                            * active device subclass. SEE ALSO: retro_set_controller_port_device()
+                                            *
+                                            * The ascending input port indexes provided by the core in the struct
+                                            * are generally presented by frontends as ascending User # or Player #,
+                                            * such as Player 1, Player 2, Player 3, etc. Which device subclasses are
+                                            * supported can vary per input port.
+                                            *
+                                            * The first inner element of each entry in the retro_controller_info array
+                                            * is a retro_controller_description struct that specifies the names and
+                                            * codes of all device subclasses that are available for the corresponding
+                                            * User or Player, beginning with the generic Libretro device that the
+                                            * subclasses are derived from. The second inner element of each entry is the
+                                            * total number of subclasses that are listed in the retro_controller_description.
+                                            *
+                                            * NOTE: Even if special device types are set in the libretro core,
                                             * libretro should only poll input based on the base input device types.
                                             */
 #define RETRO_ENVIRONMENT_SET_MEMORY_MAPS (36 | RETRO_ENVIRONMENT_EXPERIMENTAL)
@@ -951,7 +982,37 @@ enum retro_mod
                                             * A frontend must make sure that the pointer obtained from this function is
                                             * writeable (and readable).
                                             */
-
+#define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE (41 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* const struct retro_hw_render_interface ** --
+                                            * Returns an API specific rendering interface for accessing API specific data.
+                                            * Not all HW rendering APIs support or need this.
+                                            * The contents of the returned pointer is specific to the rendering API
+                                            * being used. See the various headers like libretro_vulkan.h, etc.
+                                            *
+                                            * GET_HW_RENDER_INTERFACE cannot be called before context_reset has been called.
+                                            * Similarly, after context_destroyed callback returns,
+                                            * the contents of the HW_RENDER_INTERFACE are invalidated.
+                                            */
+#define RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS (42 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* const bool * --
+                                            * If true, the libretro implementation supports achievements
+                                            * either via memory descriptors set with RETRO_ENVIRONMENT_SET_MEMORY_MAPS
+                                            * or via retro_get_memory_data/retro_get_memory_size.
+                                            *
+                                            * This must be called before the first call to retro_run.
+                                            */
+#define RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE (43 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* const struct retro_hw_render_context_negotiation_interface * --
+                                            * Sets an interface which lets the libretro core negotiate with frontend how a context is created.
+                                            * The semantics of this interface depends on which API is used in SET_HW_RENDER earlier.
+                                            * This interface will be used when the frontend is trying to create a HW rendering context,
+                                            * so it will be used after SET_HW_RENDER, but before the context_reset callback.
+                                            */
+#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS 44
+                                           /* uint64_t * --
+                                            * Sets quirk flags associated with serialization. The frontend will zero any flags it doesn't
+                                            * recognize or support. Should be set in either retro_init or retro_load_game, but not both.
+                                            */
 #define RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT (44 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* N/A (null) * --
                                             * The frontend will try to use a 'shared' hardware context (mostly applicable
@@ -963,19 +1024,307 @@ enum retro_mod
                                             * This will do nothing on its own until SET_HW_RENDER env callbacks are
                                             * being used.
                                             */
-
 #define RETRO_ENVIRONMENT_GET_VFS_INTERFACE (45 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* struct retro_vfs_interface_info * --
                                             * Gets access to the VFS interface.
                                             * VFS presence needs to be queried prior to load_game or any
                                             * get_system/save/other_directory being called to let front end know
                                             * core supports VFS before it starts handing out paths.
-                                            * It is recomended to do so in retro_set_environment */
+                                            * It is recomended to do so in retro_set_environment
+                                            */
+#define RETRO_ENVIRONMENT_GET_LED_INTERFACE (46 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_led_interface * --
+                                            * Gets an interface which is used by a libretro core to set
+                                            * state of LEDs.
+                                            */
+#define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* int * --
+                                            * Tells the core if the frontend wants audio or video.
+                                            * If disabled, the frontend will discard the audio or video,
+                                            * so the core may decide to skip generating a frame or generating audio.
+                                            * This is mainly used for increasing performance.
+                                            * Bit 0 (value 1): Enable Video
+                                            * Bit 1 (value 2): Enable Audio
+                                            * Bit 2 (value 4): Use Fast Savestates.
+                                            * Bit 3 (value 8): Hard Disable Audio
+                                            * Other bits are reserved for future use and will default to zero.
+                                            * If video is disabled:
+                                            * * The frontend wants the core to not generate any video,
+                                            *   including presenting frames via hardware acceleration.
+                                            * * The frontend's video frame callback will do nothing.
+                                            * * After running the frame, the video output of the next frame should be
+                                            *   no different than if video was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * If audio is disabled:
+                                            * * The frontend wants the core to not generate any audio.
+                                            * * The frontend's audio callbacks will do nothing.
+                                            * * After running the frame, the audio output of the next frame should be
+                                            *   no different than if audio was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * Fast Savestates:
+                                            * * Guaranteed to be created by the same binary that will load them.
+                                            * * Will not be written to or read from the disk.
+                                            * * Suggest that the core assumes loading state will succeed.
+                                            * * Suggest that the core updates its memory buffers in-place if possible.
+                                            * * Suggest that the core skips clearing memory.
+                                            * * Suggest that the core skips resetting the system.
+                                            * * Suggest that the core may skip validation steps.
+                                            * Hard Disable Audio:
+                                            * * Used for a secondary core when running ahead.
+                                            * * Indicates that the frontend will never need audio from the core.
+                                            * * Suggests that the core may stop synthesizing audio, but this should not
+                                            *   compromise emulation accuracy.
+                                            * * Audio output for the next frame does not matter, and the frontend will
+                                            *   never need an accurate audio state in the future.
+                                            * * State will never be saved when using Hard Disable Audio.
+                                            */
+#define RETRO_ENVIRONMENT_GET_MIDI_INTERFACE (48 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_midi_interface ** --
+                                            * Returns a MIDI interface that can be used for raw data I/O.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_FASTFORWARDING (49 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* bool * --
+                                            * Boolean value that indicates whether or not the frontend is in
+                                            * fastforwarding mode.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* float * --
+                                            * Float value that lets us know what target refresh rate
+                                            * is curently in use by the frontend.
+                                            *
+                                            * The core can use the returned value to set an ideal
+                                            * refresh rate/framerate.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_BITMASKS (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* bool * --
+                                            * Boolean value that indicates whether or not the frontend supports
+                                            * input bitmasks being returned by retro_input_state_t. The advantage
+                                            * of this is that retro_input_state_t has to be only called once to
+                                            * grab all button states instead of multiple times.
+                                            *
+                                            * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
+                                            * to retro_input_state_t (make sure 'device' is set to RETRO_DEVICE_JOYPAD).
+                                            * It will return a bitmask of all the digital buttons.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION 52
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the core options
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, core options are set by passing an array of
+                                            * retro_variable structs to RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This may be still be done regardless of the core options
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, core options may instead be set by
+                                            * passing an array of retro_core_option_definition structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
+                                            * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This allows the core to additionally set option sublabel information
+                                            * and/or provide localisation support.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
+                                           /* const struct retro_core_option_definition ** --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            *
+                                            * 'data' points to an array of retro_core_option_definition structs
+                                            * terminated by a { NULL, NULL, NULL, {{0}}, NULL } element.
+                                            * retro_core_option_definition::key should be namespaced to not collide
+                                            * with other implementations' keys. e.g. A core called
+                                            * 'foo' should use keys named as 'foo_option'.
+                                            * retro_core_option_definition::desc should contain a human readable
+                                            * description of the key.
+                                            * retro_core_option_definition::info should contain any additional human
+                                            * readable information text that a typical user may need to
+                                            * understand the functionality of the option.
+                                            * retro_core_option_definition::values is an array of retro_core_option_value
+                                            * structs terminated by a { NULL, NULL } element.
+                                            * > retro_core_option_definition::values[index].value is an expected option
+                                            *   value.
+                                            * > retro_core_option_definition::values[index].label is a human readable
+                                            *   label used when displaying the value on screen. If NULL,
+                                            *   the value itself is used.
+                                            * retro_core_option_definition::default_value is the default core option
+                                            * setting. It must match one of the expected option values in the
+                                            * retro_core_option_definition::values array. If it does not, or the
+                                            * default value is NULL, the first entry in the
+                                            * retro_core_option_definition::values array is treated as the default.
+                                            *
+                                            * The number of possible options should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Provides increased performance at the expense of reduced accuracy",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL 54
+                                           /* const struct retro_core_options_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_intl struct.
+                                            *
+                                            * retro_core_options_intl::us is a pointer to an array of
+                                            * retro_core_option_definition structs defining the US English
+                                            * core options implementation. It must point to a valid array.
+                                            *
+                                            * retro_core_options_intl::local is a pointer to an array of
+                                            * retro_core_option_definition structs defining core options for
+                                            * the current frontend language. It may be NULL (in which case
+                                            * retro_core_options_intl::us is used by the frontend). Any items
+                                            * missing from this array will be read from retro_core_options_intl::us
+                                            * instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_intl::us array. Any default values in
+                                            * retro_core_options_intl::local array will be ignored.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY 55
+                                           /* struct retro_core_option_display * --
+                                            *
+                                            * Allows an implementation to signal the environment to show
+                                            * or hide a variable when displaying core options. This is
+                                            * considered a *suggestion*. The frontend is free to ignore
+                                            * this callback, and its implementation not considered mandatory.
+                                            *
+                                            * 'data' points to a retro_core_option_display struct
+                                            *
+                                            * retro_core_option_display::key is a variable identifier
+                                            * which has already been set by SET_VARIABLES/SET_CORE_OPTIONS.
+                                            *
+                                            * retro_core_option_display::visible is a boolean, specifying
+                                            * whether variable should be displayed
+                                            *
+                                            * Note that all core option variables will be set visible by
+                                            * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER 56
+                                           /* unsigned * --
+                                            *
+                                            * Allows an implementation to ask frontend preferred hardware
+                                            * context to use. Core should use this information to deal
+                                            * with what specific context to request with SET_HW_RENDER.
+                                            *
+                                            * 'data' points to an unsigned variable
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION 57
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the disk control
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, the disk control interface is defined by passing
+                                            * a struct of type retro_disk_control_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+                                            * This may be still be done regardless of the disk control
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, the disk control interface may
+                                            * instead be defined by passing a struct of type
+                                            * retro_disk_control_ext_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
+                                            * This allows the core to provide additional information about
+                                            * disk images to the frontend and/or enables extra
+                                            * disk control functionality by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE 58
+                                           /* const struct retro_disk_control_ext_callback * --
+                                            * Sets an interface which frontend can use to eject and insert
+                                            * disk images, and also obtain information about individual
+                                            * disk image files registered by the core.
+                                            * This is used for games which consist of multiple images and
+                                            * must be manually swapped out by the user (e.g. PSX, floppy disk
+                                            * based systems).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the message
+                                            * interface supported by the frontend. If callback returns
+                                            * false, API version is assumed to be 0.
+                                            *
+                                            * In legacy code, messages may be displayed in an
+                                            * implementation-specific manner by passing a struct
+                                            * of type retro_message to RETRO_ENVIRONMENT_SET_MESSAGE.
+                                            * This may be still be done regardless of the message
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, messages may instead be
+                                            * displayed by passing a struct of type retro_message_ext
+                                            * to RETRO_ENVIRONMENT_SET_MESSAGE_EXT. This allows the
+                                            * core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MESSAGE_EXT 60
+                                           /* const struct retro_message_ext * --
+                                            * Sets a message to be displayed in an implementation-specific
+                                            * manner for a certain amount of 'frames'. Additionally allows
+                                            * the core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            * Should not be used for trivial messages, which should simply be
+                                            * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
+                                            * fallback, stderr).
+                                            */
 
 /* VFS functionality */
 
 /* File paths:
- * File paths passed as parameters when using this api shall be well formed unix-style,
+ * File paths passed as parameters when using this API shall be well formed UNIX-style,
  * using "/" (unquoted forward slash) as directory separator regardless of the platform's native separator.
  * Paths shall also include at least one forward slash ("game.bin" is an invalid path, use "./game.bin" instead).
  * Other than the directory separator, cores shall not make assumptions about path format:
@@ -992,6 +1341,10 @@ enum retro_mod
 /* Opaque file handle
  * Introduced in VFS API v1 */
 struct retro_vfs_file_handle;
+
+/* Opaque directory handle
+ * Introduced in VFS API v3 */
+struct retro_vfs_dir_handle;
 
 /* File open flags
  * Introduced in VFS API v1 */
@@ -1012,6 +1365,12 @@ struct retro_vfs_file_handle;
 #define RETRO_VFS_SEEK_POSITION_CURRENT  1
 #define RETRO_VFS_SEEK_POSITION_END      2
 
+/* stat() result flags
+ * Introduced in VFS API v3 */
+#define RETRO_VFS_STAT_IS_VALID               (1 << 0)
+#define RETRO_VFS_STAT_IS_DIRECTORY           (1 << 1)
+#define RETRO_VFS_STAT_IS_CHARACTER_SPECIAL   (1 << 2)
+
 /* Get path from opaque handle. Returns the exact same path passed to file_open when getting the handle
  * Introduced in VFS API v1 */
 typedef const char *(RETRO_CALLCONV *retro_vfs_get_path_t)(struct retro_vfs_file_handle *stream);
@@ -1021,7 +1380,7 @@ typedef const char *(RETRO_CALLCONV *retro_vfs_get_path_t)(struct retro_vfs_file
  * Introduced in VFS API v1 */
 typedef struct retro_vfs_file_handle *(RETRO_CALLCONV *retro_vfs_open_t)(const char *path, unsigned mode, unsigned hints);
 
-/* Close the file and release its resources. Must be called if open_file returns non-NULL. Returns 0 on succes, -1 on failure.
+/* Close the file and release its resources. Must be called if open_file returns non-NULL. Returns 0 on success, -1 on failure.
  * Whether the call succeeds ot not, the handle passed as parameter becomes invalid and should no longer be used.
  * Introduced in VFS API v1 */
 typedef int (RETRO_CALLCONV *retro_vfs_close_t)(struct retro_vfs_file_handle *stream);
@@ -1030,7 +1389,11 @@ typedef int (RETRO_CALLCONV *retro_vfs_close_t)(struct retro_vfs_file_handle *st
  * Introduced in VFS API v1 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_size_t)(struct retro_vfs_file_handle *stream);
 
-/* Get the current read / write position for the file. Returns - 1 for error.
+/* Truncate file to specified size. Returns 0 on success or -1 on error
+ * Introduced in VFS API v2 */
+typedef int64_t (RETRO_CALLCONV *retro_vfs_truncate_t)(struct retro_vfs_file_handle *stream, int64_t length);
+
+/* Get the current read / write position for the file. Returns -1 for error.
  * Introduced in VFS API v1 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_tell_t)(struct retro_vfs_file_handle *stream);
 
@@ -1058,8 +1421,42 @@ typedef int (RETRO_CALLCONV *retro_vfs_remove_t)(const char *path);
  * Introduced in VFS API v1 */
 typedef int (RETRO_CALLCONV *retro_vfs_rename_t)(const char *old_path, const char *new_path);
 
+/* Stat the specified file. Retruns a bitmask of RETRO_VFS_STAT_* flags, none are set if path was not valid.
+ * Additionally stores file size in given variable, unless NULL is given.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_stat_t)(const char *path, int32_t *size);
+
+/* Create the specified directory. Returns 0 on success, -1 on unknown failure, -2 if already exists.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_mkdir_t)(const char *dir);
+
+/* Open the specified directory for listing. Returns the opaque dir handle, or NULL for error.
+ * Support for the include_hidden argument may vary depending on the platform.
+ * Introduced in VFS API v3 */
+typedef struct retro_vfs_dir_handle *(RETRO_CALLCONV *retro_vfs_opendir_t)(const char *dir, bool include_hidden);
+
+/* Read the directory entry at the current position, and move the read pointer to the next position.
+ * Returns true on success, false if already on the last entry.
+ * Introduced in VFS API v3 */
+typedef bool (RETRO_CALLCONV *retro_vfs_readdir_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Get the name of the last entry read. Returns a string on success, or NULL for error.
+ * The returned string pointer is valid until the next call to readdir or closedir.
+ * Introduced in VFS API v3 */
+typedef const char *(RETRO_CALLCONV *retro_vfs_dirent_get_name_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Check if the last entry read was a directory. Returns true if it was, false otherwise (or on error).
+ * Introduced in VFS API v3 */
+typedef bool (RETRO_CALLCONV *retro_vfs_dirent_is_dir_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Close the directory and release its resources. Must be called if opendir returns non-NULL. Returns 0 on success, -1 on failure.
+ * Whether the call succeeds ot not, the handle passed as parameter becomes invalid and should no longer be used.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_closedir_t)(struct retro_vfs_dir_handle *dirstream);
+
 struct retro_vfs_interface
 {
+   /* VFS API v1 */
 	retro_vfs_get_path_t get_path;
 	retro_vfs_open_t open;
 	retro_vfs_close_t close;
@@ -1071,6 +1468,16 @@ struct retro_vfs_interface
 	retro_vfs_flush_t flush;
 	retro_vfs_remove_t remove;
 	retro_vfs_rename_t rename;
+   /* VFS API v2 */
+   retro_vfs_truncate_t truncate;
+   /* VFS API v3 */
+   retro_vfs_stat_t stat;
+   retro_vfs_mkdir_t mkdir;
+   retro_vfs_opendir_t opendir;
+   retro_vfs_readdir_t readdir;
+   retro_vfs_dirent_get_name_t dirent_get_name;
+   retro_vfs_dirent_is_dir_t dirent_is_dir;
+   retro_vfs_closedir_t closedir;
 };
 
 struct retro_vfs_interface_info
@@ -1093,6 +1500,7 @@ enum retro_hw_render_interface_type
 	RETRO_HW_RENDER_INTERFACE_D3D10  = 2,
 	RETRO_HW_RENDER_INTERFACE_D3D11  = 3,
 	RETRO_HW_RENDER_INTERFACE_D3D12  = 4,
+   RETRO_HW_RENDER_INTERFACE_GSKIT_PS2  = 5,
    RETRO_HW_RENDER_INTERFACE_DUMMY  = INT_MAX
 };
 
@@ -1104,49 +1512,41 @@ struct retro_hw_render_interface
    unsigned interface_version;
 };
 
-
-#define RETRO_ENVIRONMENT_GET_LED_INTERFACE (46 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* struct retro_led_interface * --
-                                            * Gets an interface which is used by a libretro core to set
-                                            * state of LEDs.
-                                            */
-
 typedef void (RETRO_CALLCONV *retro_set_led_state_t)(int led, int state);
 struct retro_led_interface
 {
     retro_set_led_state_t set_led_state;
 };
 
-#define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* int * --
-                                            * Queries the frontend if audio and video are enabled or not.
-                                            * If not enabled, the frontend will discard the audio or video,
-                                            * so the core may decide to skip producing audio or video.
-                                            * Bit 0 (value 1) is set if Video is enabled,
-                                            * Bit 1 (value 2) is set if Audio is enabled.
-                                            * Other bits are reserved for future use.
-                                            */
+/* Retrieves the current state of the MIDI input.
+ * Returns true if it's enabled, false otherwise. */
+typedef bool (RETRO_CALLCONV *retro_midi_input_enabled_t)(void);
 
-#define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE (41 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* const struct retro_hw_render_interface ** --
-                                            * Returns an API specific rendering interface for accessing API specific data.
-                                            * Not all HW rendering APIs support or need this.
-                                            * The contents of the returned pointer is specific to the rendering API
-                                            * being used. See the various headers like libretro_vulkan.h, etc.
-                                            *
-                                            * GET_HW_RENDER_INTERFACE cannot be called before context_reset has been called.
-                                            * Similarly, after context_destroyed callback returns,
-                                            * the contents of the HW_RENDER_INTERFACE are invalidated.
-                                            */
+/* Retrieves the current state of the MIDI output.
+ * Returns true if it's enabled, false otherwise */
+typedef bool (RETRO_CALLCONV *retro_midi_output_enabled_t)(void);
 
-#define RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS (42 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* const bool * --
-                                            * If true, the libretro implementation supports achievements
-                                            * either via memory descriptors set with RETRO_ENVIRONMENT_SET_MEMORY_MAPS
-                                            * or via retro_get_memory_data/retro_get_memory_size.
-                                            *
-                                            * This must be called before the first call to retro_run.
-                                            */
+/* Reads next byte from the input stream.
+ * Returns true if byte is read, false otherwise. */
+typedef bool (RETRO_CALLCONV *retro_midi_read_t)(uint8_t *byte);
+
+/* Writes byte to the output stream.
+ * 'delta_time' is in microseconds and represent time elapsed since previous write.
+ * Returns true if byte is written, false otherwise. */
+typedef bool (RETRO_CALLCONV *retro_midi_write_t)(uint8_t byte, uint32_t delta_time);
+
+/* Flushes previously written data.
+ * Returns true if successful, false otherwise. */
+typedef bool (RETRO_CALLCONV *retro_midi_flush_t)(void);
+
+struct retro_midi_interface
+{
+   retro_midi_input_enabled_t input_enabled;
+   retro_midi_output_enabled_t output_enabled;
+   retro_midi_read_t read;
+   retro_midi_write_t write;
+   retro_midi_flush_t flush;
+};
 
 enum retro_hw_render_context_negotiation_interface_type
 {
@@ -1161,13 +1561,6 @@ struct retro_hw_render_context_negotiation_interface
    enum retro_hw_render_context_negotiation_interface_type interface_type;
    unsigned interface_version;
 };
-#define RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE (43 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* const struct retro_hw_render_context_negotiation_interface * --
-                                            * Sets an interface which lets the libretro core negotiate with frontend how a context is created.
-                                            * The semantics of this interface depends on which API is used in SET_HW_RENDER earlier.
-                                            * This interface will be used when the frontend is trying to create a HW rendering context,
-                                            * so it will be used after SET_HW_RENDER, but before the context_reset callback.
-                                            */
 
 /* Serialized state is incomplete in some way. Set if serialization is
  * usable in typical end-user cases but should not be relied upon to
@@ -1193,20 +1586,17 @@ struct retro_hw_render_context_negotiation_interface
  * dependence */
 #define RETRO_SERIALIZATION_QUIRK_PLATFORM_DEPENDENT (1 << 6)
 
-#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS 44
-                                           /* uint64_t * --
-                                            * Sets quirk flags associated with serialization. The frontend will zero any flags it doesn't
-                                            * recognize or support. Should be set in either retro_init or retro_load_game, but not both.
-                                            */
-
-#define RETRO_MEMDESC_CONST     (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
-#define RETRO_MEMDESC_BIGENDIAN (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
-#define RETRO_MEMDESC_ALIGN_2   (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */
-#define RETRO_MEMDESC_ALIGN_4   (2 << 16)
-#define RETRO_MEMDESC_ALIGN_8   (3 << 16)
-#define RETRO_MEMDESC_MINSIZE_2 (1 << 24)  /* All memory in this region is accessed at least 2 bytes at the time. */
-#define RETRO_MEMDESC_MINSIZE_4 (2 << 24)
-#define RETRO_MEMDESC_MINSIZE_8 (3 << 24)
+#define RETRO_MEMDESC_CONST      (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
+#define RETRO_MEMDESC_BIGENDIAN  (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
+#define RETRO_MEMDESC_SYSTEM_RAM (1 << 2)   /* The memory area is system RAM.  This is main RAM of the gaming system. */
+#define RETRO_MEMDESC_SAVE_RAM   (1 << 3)   /* The memory area is save RAM. This RAM is usually found on a game cartridge, backed up by a battery. */
+#define RETRO_MEMDESC_VIDEO_RAM  (1 << 4)   /* The memory area is video RAM (VRAM) */
+#define RETRO_MEMDESC_ALIGN_2    (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */
+#define RETRO_MEMDESC_ALIGN_4    (2 << 16)
+#define RETRO_MEMDESC_ALIGN_8    (3 << 16)
+#define RETRO_MEMDESC_MINSIZE_2  (1 << 24)  /* All memory in this region is accessed at least 2 bytes at the time. */
+#define RETRO_MEMDESC_MINSIZE_4  (2 << 24)
+#define RETRO_MEMDESC_MINSIZE_8  (3 << 24)
 struct retro_memory_descriptor
 {
    uint64_t flags;
@@ -1607,6 +1997,10 @@ enum retro_sensor_action
 {
    RETRO_SENSOR_ACCELEROMETER_ENABLE = 0,
    RETRO_SENSOR_ACCELEROMETER_DISABLE,
+   RETRO_SENSOR_GYROSCOPE_ENABLE,
+   RETRO_SENSOR_GYROSCOPE_DISABLE,
+   RETRO_SENSOR_ILLUMINANCE_ENABLE,
+   RETRO_SENSOR_ILLUMINANCE_DISABLE,
 
    RETRO_SENSOR_DUMMY = INT_MAX
 };
@@ -1615,6 +2009,10 @@ enum retro_sensor_action
 #define RETRO_SENSOR_ACCELEROMETER_X 0
 #define RETRO_SENSOR_ACCELEROMETER_Y 1
 #define RETRO_SENSOR_ACCELEROMETER_Z 2
+#define RETRO_SENSOR_GYROSCOPE_X 3
+#define RETRO_SENSOR_GYROSCOPE_Y 4
+#define RETRO_SENSOR_GYROSCOPE_Z 5
+#define RETRO_SENSOR_ILLUMINANCE 6
 
 typedef bool (RETRO_CALLCONV *retro_set_sensor_state_t)(unsigned port,
       enum retro_sensor_action action, unsigned rate);
@@ -1972,7 +2370,8 @@ struct retro_keyboard_callback
    retro_keyboard_event_t callback;
 };
 
-/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE &
+ * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
  * Should be set for implementations which can swap out multiple disk
  * images in runtime.
  *
@@ -2030,6 +2429,53 @@ typedef bool (RETRO_CALLCONV *retro_replace_image_index_t)(unsigned index,
  * with replace_image_index. */
 typedef bool (RETRO_CALLCONV *retro_add_image_index_t)(void);
 
+/* Sets initial image to insert in drive when calling
+ * core_load_game().
+ * Since we cannot pass the initial index when loading
+ * content (this would require a major API change), this
+ * is set by the frontend *before* calling the core's
+ * retro_load_game()/retro_load_game_special() implementation.
+ * A core should therefore cache the index/path values and handle
+ * them inside retro_load_game()/retro_load_game_special().
+ * - If 'index' is invalid (index >= get_num_images()), the
+ *   core should ignore the set value and instead use 0
+ * - 'path' is used purely for error checking - i.e. when
+ *   content is loaded, the core should verify that the
+ *   disk specified by 'index' has the specified file path.
+ *   This is to guard against auto selecting the wrong image
+ *   if (for example) the user should modify an existing M3U
+ *   playlist. We have to let the core handle this because
+ *   set_initial_image() must be called before loading content,
+ *   i.e. the frontend cannot access image paths in advance
+ *   and thus cannot perform the error check itself.
+ *   If set path and content path do not match, the core should
+ *   ignore the set 'index' value and instead use 0
+ * Returns 'false' if index or 'path' are invalid, or core
+ * does not support this functionality
+ */
+typedef bool (RETRO_CALLCONV *retro_set_initial_image_t)(unsigned index, const char *path);
+
+/* Fetches the path of the specified disk image file.
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or path is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_path_t)(unsigned index, char *path, size_t len);
+
+/* Fetches a core-provided 'label' for the specified disk
+ * image file. In the simplest case this may be a file name
+ * (without extension), but for cores with more complex
+ * content requirements information may be provided to
+ * facilitate user disk swapping - for example, a core
+ * running floppy-disk-based content may uniquely label
+ * save disks, data disks, level disks, etc. with names
+ * corresponding to in-game disk change prompts (so the
+ * frontend can provide better user guidance than a 'dumb'
+ * disk index value).
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or label is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_label_t)(unsigned index, char *label, size_t len);
+
 struct retro_disk_control_callback
 {
    retro_set_eject_state_t set_eject_state;
@@ -2041,6 +2487,27 @@ struct retro_disk_control_callback
 
    retro_replace_image_index_t replace_image_index;
    retro_add_image_index_t add_image_index;
+};
+
+struct retro_disk_control_ext_callback
+{
+   retro_set_eject_state_t set_eject_state;
+   retro_get_eject_state_t get_eject_state;
+
+   retro_get_image_index_t get_image_index;
+   retro_set_image_index_t set_image_index;
+   retro_get_num_images_t  get_num_images;
+
+   retro_replace_image_index_t replace_image_index;
+   retro_add_image_index_t add_image_index;
+
+   /* NOTE: Frontend will only attempt to record/restore
+    * last used disk index if both set_initial_image()
+    * and get_image_path() are implemented */
+   retro_set_initial_image_t set_initial_image; /* Optional - may be NULL */
+
+   retro_get_image_path_t get_image_path;       /* Optional - may be NULL */
+   retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
 enum retro_pixel_format
@@ -2071,6 +2538,104 @@ struct retro_message
 {
    const char *msg;        /* Message to be displayed. */
    unsigned    frames;     /* Duration in frames of message. */
+};
+
+enum retro_message_target
+{
+   RETRO_MESSAGE_TARGET_ALL = 0,
+   RETRO_MESSAGE_TARGET_OSD,
+   RETRO_MESSAGE_TARGET_LOG
+};
+
+enum retro_message_type
+{
+   RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
+   RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+   RETRO_MESSAGE_TYPE_STATUS,
+   RETRO_MESSAGE_TYPE_PROGRESS
+};
+
+struct retro_message_ext
+{
+   /* Message string to be displayed/logged */
+   const char *msg;
+   /* Duration (in ms) of message when targeting the OSD */
+   unsigned duration;
+   /* Message priority when targeting the OSD
+    * > When multiple concurrent messages are sent to
+    *   the frontend and the frontend does not have the
+    *   capacity to display them all, messages with the
+    *   *highest* priority value should be shown
+    * > There is no upper limit to a message priority
+    *   value (within the bounds of the unsigned data type)
+    * > In the reference frontend (RetroArch), the same
+    *   priority values are used for frontend-generated
+    *   notifications, which are typically assigned values
+    *   between 0 and 3 depending upon importance */
+   unsigned priority;
+   /* Message logging level (info, warn, error, etc.) */
+   enum retro_log_level level;
+   /* Message destination: OSD, logging interface or both */
+   enum retro_message_target target;
+   /* Message 'type' when targeting the OSD
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION: Specifies that a
+    *   message should be handled in identical fashion to
+    *   a standard frontend-generated notification
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION_ALT: Specifies that
+    *   message is a notification that requires user attention
+    *   or action, but that it should be displayed in a manner
+    *   that differs from standard frontend-generated notifications.
+    *   This would typically correspond to messages that should be
+    *   displayed immediately (independently from any internal
+    *   frontend message queue), and/or which should be visually
+    *   distinguishable from frontend-generated notifications.
+    *   For example, a core may wish to inform the user of
+    *   information related to a disk-change event. It is
+    *   expected that the frontend itself may provide a
+    *   notification in this case; if the core sends a
+    *   message of type RETRO_MESSAGE_TYPE_NOTIFICATION, an
+    *   uncomfortable 'double-notification' may occur. A message
+    *   of RETRO_MESSAGE_TYPE_NOTIFICATION_ALT should therefore
+    *   be presented such that visual conflict with regular
+    *   notifications does not occur
+    * > RETRO_MESSAGE_TYPE_STATUS: Indicates that message
+    *   is not a standard notification. This typically
+    *   corresponds to 'status' indicators, such as a core's
+    *   internal FPS, which are intended to be displayed
+    *   either permanently while a core is running, or in
+    *   a manner that does not suggest user attention or action
+    *   is required. 'Status' type messages should therefore be
+    *   displayed in a different on-screen location and in a manner
+    *   easily distinguishable from both standard frontend-generated
+    *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * > RETRO_MESSAGE_TYPE_PROGRESS: Indicates that message reports
+    *   the progress of an internal core task. For example, in cases
+    *   where a core itself handles the loading of content from a file,
+    *   this may correspond to the percentage of the file that has been
+    *   read. Alternatively, an audio/video playback core may use a
+    *   message of type RETRO_MESSAGE_TYPE_PROGRESS to display the current
+    *   playback position as a percentage of the runtime. 'Progress' type
+    *   messages should therefore be displayed as a literal progress bar,
+    *   where:
+    *   - 'retro_message_ext.msg' is the progress bar title/label
+    *   - 'retro_message_ext.progress' determines the length of
+    *     the progress bar
+    * NOTE: Message type is a *hint*, and may be ignored
+    * by the frontend. If a frontend lacks support for
+    * displaying messages via alternate means than standard
+    * frontend-generated notifications, it will treat *all*
+    * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
+   enum retro_message_type type;
+   /* Task progress when targeting the OSD and message is
+    * of type RETRO_MESSAGE_TYPE_PROGRESS
+    * > -1:    Unmetered/indeterminate
+    * > 0-100: Current progress percentage
+    * NOTE: Since message type is a hint, a frontend may ignore
+    * progress values. Where relevant, a core should therefore
+    * include progress percentage within the message string,
+    * such that the message intent remains clear when displayed
+    * as a standard frontend-generated notification */
+   int8_t progress;
 };
 
 /* Describes how the libretro implementation maps a libretro input bind
@@ -2106,17 +2671,26 @@ struct retro_system_info
                                    * Typically used for a GUI to filter
                                    * out extensions. */
 
-   /* If true, retro_load_game() is guaranteed to provide a valid pathname
-    * in retro_game_info::path.
-    * ::data and ::size are both invalid.
+   /* Libretro cores that need to have direct access to their content
+    * files, including cores which use the path of the content files to
+    * determine the paths of other files, should set need_fullpath to true.
     *
-    * If false, ::data and ::size are guaranteed to be valid, but ::path
-    * might not be valid.
+    * Cores should strive for setting need_fullpath to false,
+    * as it allows the frontend to perform patching, etc.
     *
-    * This is typically set to true for libretro implementations that must
-    * load from file.
-    * Implementations should strive for setting this to false, as it allows
-    * the frontend to perform patching, etc. */
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to have a valid path
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * See also:
+    *    - RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY
+    *    - RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY
+    */
    bool        need_fullpath;
 
    /* If true, the frontend is not allowed to extract any archives before
@@ -2165,6 +2739,76 @@ struct retro_variable
 
    /* Value to be obtained. If key does not exist, it is set to NULL. */
    const char *value;
+};
+
+struct retro_core_option_display
+{
+   /* Variable to configure in RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY */
+   const char *key;
+
+   /* Specifies whether variable should be displayed
+    * when presenting core options to the user */
+   bool visible;
+};
+
+/* Maximum number of values permitted for a core option
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
+#define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
+
+struct retro_core_option_value
+{
+   /* Expected option value */
+   const char *value;
+
+   /* Human-readable value label. If NULL, value itself
+    * will be displayed by the frontend */
+   const char *label;
+};
+
+struct retro_core_option_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE. */
+   const char *key;
+
+   /* Human-readable core option description (used as menu label) */
+   const char *desc;
+
+   /* Human-readable core option information (used as menu sublabel) */
+   const char *info;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_intl
+{
+   /* Pointer to an array of retro_core_option_definition structs
+    * - US English implementation
+    * - Must point to a valid array */
+   struct retro_core_option_definition *us;
+
+   /* Pointer to an array of retro_core_option_definition structs
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_option_definition *local;
 };
 
 struct retro_game_info
@@ -2301,7 +2945,13 @@ RETRO_API void retro_get_system_av_info(struct retro_system_av_info *info);
  * will only poll input based on that particular device type. It is only a
  * hint to the libretro core when a core cannot automatically detect the
  * appropriate input device type on its own. It is also relevant when a
- * core can change its behavior depending on device type. */
+ * core can change its behavior depending on device type.
+ *
+ * As part of the core's implementation of retro_set_controller_port_device,
+ * the core should call RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS to notify the
+ * frontend if the descriptions for any controls have changed as a
+ * result of changing the device type.
+ */
 RETRO_API void retro_set_controller_port_device(unsigned port, unsigned device);
 
 /* Resets the current game. */
@@ -2333,7 +2983,9 @@ RETRO_API bool retro_unserialize(const void *data, size_t size);
 RETRO_API void retro_cheat_reset(void);
 RETRO_API void retro_cheat_set(unsigned index, bool enabled, const char *code);
 
-/* Loads a game. */
+/* Loads a game.
+ * Return true to indicate successful loading and false to indicate load failure.
+ */
 RETRO_API bool retro_load_game(const struct retro_game_info *game);
 
 /* Loads a "special" kind of game. Should not be used,
@@ -2343,7 +2995,7 @@ RETRO_API bool retro_load_game_special(
   const struct retro_game_info *info, size_t num_info
 );
 
-/* Unloads a currently loaded game. */
+/* Unloads the currently loaded game. Called before retro_deinit(void). */
 RETRO_API void retro_unload_game(void);
 
 /* Gets region of game. */


### PR DESCRIPTION
This is an optimal codepath for libretro that allows us to grab the entire button state (sans analogs) in one function call instead of having to query a function callback for each individual button. It also has a fallback path for libretro frontends that don't implement this environment  callback.