### PR TITLE
Vulkan: Make sure textures/samplers are unbound at the end of PresentationCommon::CopyToOutput

### DIFF
--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -748,6 +748,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 	DoRelease(srcFramebuffer_);
 	DoRelease(srcTexture_);
 
+	// Unbinds all textures and samplers too, needed since sometimes a MakePixelTexture is deleted etc.
 	draw_->BindPipeline(nullptr);
 }
 

--- a/ext/native/thin3d/thin3d.h
+++ b/ext/native/thin3d/thin3d.h
@@ -643,7 +643,7 @@ public:
 		BindTextures(stage, 1, textures);
 	}  // from sampler 0 and upwards
 
-	// Call this with 0 to signal that you have been drawing on your own, and need the state reset on the next pipeline bind.
+	// Call this with nullptr to signal that you're done with the stuff you've bound, like textures and samplers and stuff.
 	virtual void BindPipeline(Pipeline *pipeline) = 0;
 
 	virtual void Draw(int vertexCount, int offset) = 0;
@@ -652,7 +652,7 @@ public:
 	
 	// Frame management (for the purposes of sync and resource management, necessary with modern APIs). Default implementations here.
 	virtual void BeginFrame() {}
-	virtual void EndFrame() {}
+	virtual void EndFrame() = 0;
 	virtual void WipeQueue() {}
 
 	// This should be avoided as much as possible, in favor of clearing when binding a render target, which is native

--- a/ext/native/thin3d/thin3d_d3d11.cpp
+++ b/ext/native/thin3d/thin3d_d3d11.cpp
@@ -100,6 +100,8 @@ public:
 		stencilRefDirty_ = true;
 	}
 
+	void EndFrame() override;
+
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
@@ -361,6 +363,10 @@ void D3D11DrawContext::HandleEvent(Event ev, int width, int height, void *param1
 		stepId_ = 0;
 		break;
 	}
+}
+
+void D3D11DrawContext::EndFrame() {
+	curPipeline_ = nullptr;
 }
 
 void D3D11DrawContext::SetViewports(int count, Viewport *viewports) {

--- a/ext/native/thin3d/thin3d_d3d9.cpp
+++ b/ext/native/thin3d/thin3d_d3d9.cpp
@@ -559,6 +559,8 @@ public:
 		curPipeline_ = (D3D9Pipeline *)pipeline;
 	}
 
+	void EndFrame() override;
+
 	void UpdateDynamicUniformBuffer(const void *ub, size_t size) override;
 
 	// Raster state
@@ -800,6 +802,10 @@ void D3D9Context::BindTextures(int start, int count, Texture **textures) {
 			device_->SetTexture(i, nullptr);
 		}
 	}
+}
+
+void D3D9Context::EndFrame() {
+	curPipeline_ = nullptr;
 }
 
 static void SemanticToD3D9UsageAndIndex(int semantic, BYTE *usage, BYTE *index) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -618,6 +618,15 @@ void OpenGLContext::EndFrame() {
 	FrameData &frameData = frameData_[renderManager_.GetCurFrame()];
 	renderManager_.EndPushBuffer(frameData.push);  // upload the data!
 	renderManager_.Finish();
+
+	// Unbind stuff.
+	for (auto &texture : boundTextures_) {
+		texture = nullptr;
+	}
+	for (auto &sampler : boundSamplers_) {
+		sampler = nullptr;
+	}
+	curPipeline_ = nullptr;
 }
 
 InputLayout *OpenGLContext::CreateInputLayout(const InputLayoutDesc &desc) {


### PR DESCRIPTION
Validation caught an issue (and I had a crash in a Debug build, too) where old stuff lingered in sampler 1 and texture 1.

Bug probably introduced in #12921, but could also be others.

This could maybe be done more elegantly in some other way, like unbinding stuff when we bind a new pipeline that uses less samplers, or something like that. But we don't have a clear view how many samplers a pipeline uses here.

Also started doing some similar cleanup in the other backends but likely not necessary.