### PR TITLE
Vulkan: Switch to a fence to synchronize readbacks

### DIFF
--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -1188,8 +1188,8 @@ void VulkanRenderManager::EndSyncFrame(int frame) {
 	Submit(frame, false);
 
 	// This is brutal! Should probably wait for a fence instead, not that it'll matter much since we'll
-	// still stall everything.
-	vkDeviceWaitIdle(vulkan_->GetDevice());
+	// still stall everything on our queue.
+	vkQueueWaitIdle(vulkan_->GetGraphicsQueue());
 
 	// At this point we can resume filling the command buffers for the current frame since
 	// we know the device is idle - and thus all previously enqueued command buffers have been processed.

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -321,6 +321,9 @@ private:
 		VKRRunType type = VKRRunType::END;
 
 		VkFence fence;
+		VkFence readbackFence;  // Strictly speaking we might only need one of these.
+		bool readbackFenceUsed = false;
+
 		// These are on different threads so need separate pools.
 		VkCommandPool cmdPoolInit;
 		VkCommandPool cmdPoolMain;


### PR DESCRIPTION
Some sources suggest this is better than idling a queue or device, like https://stackoverflow.com/questions/39537176/in-what-situations-is-vkfence-better-than-vkqueuewaitidle-for-vkqueuesubmit .

Don't know if it's actually better, hard to detect, but this is at least easier to refactor and loosen up if we can find ways in the future (delay by a frame or whatever else we can cook up).

The readbackFenceUsed flag I have a plan for, but kinda unrelated.