### PR TITLE
Exception handler context refactor

### DIFF
--- a/Common/ExceptionHandlerSetup.cpp
+++ b/Common/ExceptionHandlerSetup.cpp
@@ -19,22 +19,15 @@
 #include "Common/Log.h"
 #include "ext/native/thread/threadutil.h"
 
-#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include "Common/MachineContext.h"
-#endif
 
-#if PPSSPP_PLATFORM(IOS)
-#define USE_SIGACTION_ON_APPLE
-#endif
-
-#ifdef __FreeBSD__
-#include <signal.h>
-#endif
 #ifndef _WIN32
 #include <unistd.h>  // Needed for _POSIX_VERSION
 #endif
 
 static BadAccessHandler g_badAccessHandler;
+
+#ifdef MACHINE_CONTEXT_SUPPORTED
 
 // We cannot handle exceptions in UWP builds. Bleh.
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
@@ -106,7 +99,7 @@ void UninstallExceptionHandler() {
 	INFO_LOG(SYSTEM, "Removed exception handler");
 }
 
-#elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)
+#elif defined(__APPLE__)
 
 static void CheckKR(const char* name, kern_return_t kr) {
 	if (kr) {
@@ -339,9 +332,15 @@ void UninstallExceptionHandler() {
 
 #else  // Unsupported platform. Could also #error
 
+#error Shouldn't get here
+
+#endif
+
+#else  // !MACHINE_CONTEXT_SUPPORTED
+
 void InstallExceptionHandler(BadAccessHandler badAccessHandler) {
 	ERROR_LOG(SYSTEM, "Exception handler not implemented on this platform, can't install");
 }
 void UninstallExceptionHandler() { }
 
-#endif
+#endif  // MACHINE_CONTEXT_SUPPORTED

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -64,7 +64,7 @@ typedef CONTEXT SContext;
 
 #endif
 
-#elif PPSSPP_PLATFORM(MACOS)
+#elif PPSSPP_PLATFORM(MAC)
 
 // for modules:
 #define _XOPEN_SOURCE

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -56,6 +56,12 @@ typedef CONTEXT SContext;
 #define CTX_SP Sp
 #define CTX_PC Pc
 
+#elif PPSSPP_ARCH(ARM)
+
+//#define CTX_REG(x) R##x
+#define CTX_SP Sp
+#define CTX_PC Pc
+
 #endif
 
 #elif PPSSPP_PLATFORM(MACOS)

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -2,14 +2,22 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+// Note: If MACHINE_CONTEXT_SUPPORTED is not set after including this,
+// there is no access to the context from exception handlers (and possibly no exception handling support).
+
 #pragma once
 
 #include "ppsspp_config.h"
 
-#if PPSSPP_PLATFORM(WINDOWS)
+#if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
+
 #include <windows.h>
 typedef CONTEXT SContext;
+
 #if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX Rax
 #define CTX_RBX Rbx
 #define CTX_RCX Rcx
@@ -27,7 +35,11 @@ typedef CONTEXT SContext;
 #define CTX_R14 R14
 #define CTX_R15 R15
 #define CTX_RIP Rip
-#else
+
+#elif PPSSPP_ARCH(X86)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX Eax
 #define CTX_RBX Ebx
 #define CTX_RCX Ecx
@@ -38,15 +50,27 @@ typedef CONTEXT SContext;
 #define CTX_RSP Esp
 #define CTX_RIP Eip
 
+#elif PPSSPP_ARCH(ARM64)
+
+#define CTX_REG(x) X[x]
+#define CTX_SP Sp
+#define CTX_PC Pc
+
 #endif
-#elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)
+
+#elif PPSSPP_PLATFORM(MACOS)
+
 // for modules:
 #define _XOPEN_SOURCE
 #include <ucontext.h>
 
 #include <mach/mach.h>
 #include <mach/message.h>
+
 #if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 typedef x86_thread_state64_t SContext;
 #define CTX_RAX __rax
 #define CTX_RBX __rbx
@@ -65,36 +89,24 @@ typedef x86_thread_state64_t SContext;
 #define CTX_R14 __r14
 #define CTX_R15 __r15
 #define CTX_RIP __rip
+
 #else
-#error No context definition for architecture
+
+// No context definition for architecture
+
 #endif
-#elif defined(__APPLE__)
-#include <signal.h>
-typedef _STRUCT_MCONTEXT64 SContext;
-#define CTX_RAX __ss.__rax
-#define CTX_RBX __ss.__rbx
-#define CTX_RCX __ss.__rcx
-#define CTX_RDX __ss.__rdx
-#define CTX_RDI __ss.__rdi
-#define CTX_RSI __ss.__rsi
-#define CTX_RBP __ss.__rbp
-#define CTX_RSP __ss.__rsp
-#define CTX_R8 __ss.__r8
-#define CTX_R9 __ss.__r9
-#define CTX_R10 __ss.__r10
-#define CTX_R11 __ss.__r11
-#define CTX_R12 __ss.__r12
-#define CTX_R13 __ss.__r13
-#define CTX_R14 __ss.__r14
-#define CTX_R15 __ss.__r15
-#define CTX_RIP __ss.__rip
+
 #elif defined(__linux__)
+
 #include <signal.h>
+
+#if PPSSPP_ARCH(AMD64)
 
 #include <ucontext.h>
 typedef mcontext_t SContext;
 
-#if PPSSPP_ARCH(AMD64)
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX gregs[REG_RAX]
 #define CTX_RBX gregs[REG_RBX]
 #define CTX_RCX gregs[REG_RCX]
@@ -112,7 +124,14 @@ typedef mcontext_t SContext;
 #define CTX_R14 gregs[REG_R14]
 #define CTX_R15 gregs[REG_R15]
 #define CTX_RIP gregs[REG_RIP]
+
 #elif PPSSPP_ARCH(X86)
+
+#include <ucontext.h>
+typedef mcontext_t SContext;
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX gregs[REG_EAX]
 #define CTX_RBX gregs[REG_EBX]
 #define CTX_RCX gregs[REG_ECX]
@@ -122,13 +141,40 @@ typedef mcontext_t SContext;
 #define CTX_RBP gregs[REG_EBP]
 #define CTX_RSP gregs[REG_ESP]
 #define CTX_RIP gregs[REG_EIP]
+
+#elif PPSSPP_ARCH(ARM64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
+typedef sigcontext SContext;
+
+#define CTX_REG(x) regs[x]
+#define CTX_SP sp
+#define CTX_PC pc
+
+#elif PPSSPP_ARCH(ARM)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
+typedef sigcontext SContext;
+#define CTX_PC arm_pc
+#define CTX_REG(x) regs[x]
+
 #else
-#error No context definition for architecture
+
+// No context definition for architecture
+
 #endif
+
 #elif defined(__OpenBSD__)
+
+#if PPSSPP_ARCH(AMD64)
+
 #include <signal.h>
 typedef ucontext_t SContext;
-#if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX sc_rax
 #define CTX_RBX sc_rbx
 #define CTX_RCX sc_rcx
@@ -146,13 +192,22 @@ typedef ucontext_t SContext;
 #define CTX_R14 sc_r14
 #define CTX_R15 sc_r15
 #define CTX_RIP sc_rip
+
 #else
-#error No context definition for architecture
+
+// No context definition for architecture
+
 #endif
+
 #elif defined(__NetBSD__)
+
+#if PPSSPP_ARCH(AMD64)
+
 #include <ucontext.h>
 typedef mcontext_t SContext;
-#if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX __gregs[_REG_RAX]
 #define CTX_RBX __gregs[_REG_RBX]
 #define CTX_RCX __gregs[_REG_RCX]
@@ -170,13 +225,22 @@ typedef mcontext_t SContext;
 #define CTX_R14 __gregs[_REG_R14]
 #define CTX_R15 __gregs[_REG_R15]
 #define CTX_RIP __gregs[_REG_RIP]
+
 #else
-#error No context definition for architecture
+
+// No context definition for architecture
+
 #endif
+
 #elif defined(__FreeBSD__)
+
+#if PPSSPP_ARCH(AMD64)
+
 #include <ucontext.h>
 typedef mcontext_t SContext;
-#if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX mc_rax
 #define CTX_RBX mc_rbx
 #define CTX_RCX mc_rcx
@@ -194,13 +258,22 @@ typedef mcontext_t SContext;
 #define CTX_R14 mc_r14
 #define CTX_R15 mc_r15
 #define CTX_RIP mc_rip
+
 #else
-#error No context definition for architecture
+
+// No context definition for architecture
+
 #endif
+
 #elif defined(__HAIKU__)
+
+#if PPSSPP_ARCH(AMD64)
+
 #include <signal.h>
 typedef mcontext_t SContext;
-#if PPSSPP_ARCH(AMD64)
+
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_RAX rax
 #define CTX_RBX rbx
 #define CTX_RCX rcx
@@ -218,12 +291,20 @@ typedef mcontext_t SContext;
 #define CTX_R14 r14
 #define CTX_R15 r15
 #define CTX_RIP rip
+
 #else
-#error No context definition for machine
+
+// No context definition for machine
+
 #endif
+
 #else
-#error No context definition for OS
+
+// No context definition for OS
+
 #endif
+
+#ifdef MACHINE_CONTEXT_SUPPORTED
 
 #if PPSSPP_ARCH(AMD64)
 
@@ -254,4 +335,7 @@ static inline u32* ContextRN(SContext* ctx, int n)
 	  offsetof(SContext, CTX_RSI), offsetof(SContext, CTX_RDI)};
 	return (u32*)((char*)ctx + offsets[n]);
 }
-#endif
+
+#endif  // arch
+
+#endif  // MACHINE_CONTEXT_SUPPORTED

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -479,9 +479,7 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength) {
 	CBreakPoints::ExecMemCheck(_Address, true, _iLength, currentMIPS->pc);
 }
 
-// We do not support crash catching on UWP and iOS.
-// On iOS, the sigcontext struct seems to be missing??
-#if !PPSSPP_PLATFORM(IOS) && !PPSSPP_PLATFORM(UWP)
+#ifdef MACHINE_CONTEXT_SUPPORTED
 
 bool HandleFault(uintptr_t hostAddress, void *ctx) {
 	SContext *context = (SContext *)ctx;

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -29,24 +29,14 @@
 #include "Common/MemArena.h"
 #include "Common/ChunkFile.h"
 
-#ifdef __FreeBSD__
-#include <signal.h>
-#endif
-#ifndef _WIN32
-#include <unistd.h>  // Needed for _POSIX_VERSION
-#endif
+#include "Common/MachineContext.h"
 
 #if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
-#include "Common/MachineContext.h"
 #include "Common/x64Analyzer.h"
-#elif PPSSPP_ARCH(ARM64) && !PPSSPP_PLATFORM(IOS)
+#elif PPSSPP_ARCH(ARM64)
 #include "Core/Util/DisArm64.h"
-typedef sigcontext SContext;
-#define CTX_PC pc
-#elif PPSSPP_ARCH(ARM) && !PPSSPP_PLATFORM(IOS)
+#elif PPSSPP_ARCH(ARM)
 #include "ext/disarm.h"
-typedef sigcontext SContext;
-#define CTX_PC arm_pc
 #endif
 
 #include "Core/MemMap.h"

--- a/GPU/Common/ShaderTranslation.cpp
+++ b/GPU/Common/ShaderTranslation.cpp
@@ -29,6 +29,11 @@
 #undef realloc
 #endif
 
+// Weird issue
+#if PPSSPP_PLATFORM(WINDOWS) && PPSSPP_ARCH(ARM)
+#undef free
+#endif
+
 #include "base/logging.h"
 #include "base/basictypes.h"
 #include "base/stringutil.h"

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -248,7 +248,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRTDBG_MAP_ALLOC;USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;_ARCH_64=1;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\aarch64\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
@@ -269,7 +269,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRTDBG_MAP_ALLOC;USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;_ARCH_32=1;WIN32;_DEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86_64\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\arm\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
@@ -346,7 +346,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;_ARCH_64=1;WIN32;NDEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\aarch64\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
@@ -373,7 +373,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>USING_WIN_UI;_CRT_SECURE_NO_WARNINGS;_ARCH_32=1;WIN32;NDEBUG;_LIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86_64\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\arm\include;../common;..;../ext/native;../ext/glew;../ext/snappy;../ext/zlib;../ext/native/ext</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -119,7 +119,6 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <SpectreMitigation>Spectre</SpectreMitigation>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
@@ -349,7 +348,6 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <OmitFramePointers>false</OmitFramePointers>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
@@ -513,7 +511,6 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/ext/native/native.vcxproj
+++ b/ext/native/native.vcxproj
@@ -310,7 +310,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\ext;..\..;..\..\dx9sdk\Include;..\..\dx9sdk\Include\DX11;..\native\ext\libpng17;..\zlib;..\ext\zlib;..\native;..\RollerballGL;..\glew;..\SDL\include;..\native\ext;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/headless/Headless.vcxproj
+++ b/headless/Headless.vcxproj
@@ -243,7 +243,6 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRTDBG_MAP_ALLOC;USING_WIN_UI;GLEW_STATIC;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_ARCH_64=1;_CONSOLE;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../ffmpeg/Windows/aarch64/include;../dx9sdk/Include/DX11;../Common;..;../Core;../ext/glew;../ext/native</AdditionalIncludeDirectories>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <OmitFramePointers>false</OmitFramePointers>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -273,7 +272,6 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRTDBG_MAP_ALLOC;USING_WIN_UI;GLEW_STATIC;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_ARCH_32=1;_CONSOLE;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../ffmpeg/Windows/arm/include;../dx9sdk/Include/DX11;../Common;..;../Core;../ext/glew;../ext/native</AdditionalIncludeDirectories>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <OmitFramePointers>false</OmitFramePointers>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -381,7 +379,6 @@
       <PreprocessorDefinitions>USING_WIN_UI;GLEW_STATIC;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_ARCH_64=1;_CONSOLE;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../ffmpeg/Windows/aarch64/include;../dx9sdk/Include/DX11;../Common;..;../Core;../ext/glew;../ext/native</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>
@@ -416,7 +413,6 @@
       <PreprocessorDefinitions>USING_WIN_UI;GLEW_STATIC;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_ARCH_32=1;_CONSOLE;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../ffmpeg/Windows/arm/include;../dx9sdk/Include/DX11;../Common;..;../Core;../ext/glew;../ext/native</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>


### PR DESCRIPTION
MachineContext.h can now be included unconditionally, but if there's no system support for accessing CPU contexts during exceptions, it'll simply not define MACHINE_CONTEXT_SUPPORTED.

This allows some cleanup in MemMap.cpp and easy support for exception handling in Windows for ARM builds, which might become more relevant in the future.

Fixes Windows for ARM builds too, which have been slightly broken for some time it seems.