### PR TITLE
Show more info on crash screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1740,6 +1740,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/MIPS/MIPSVFPUUtils.h
 	Core/MIPS/MIPSAsm.cpp
 	Core/MIPS/MIPSAsm.h
+	Core/MemFault.cpp
+	Core/MemFault.h
 	Core/MemMap.cpp
 	Core/MemMap.h
 	Core/MemMapFunctions.cpp

--- a/Common/ExceptionHandlerSetup.cpp
+++ b/Common/ExceptionHandlerSetup.cpp
@@ -21,10 +21,6 @@
 
 #include "Common/MachineContext.h"
 
-#ifndef _WIN32
-#include <unistd.h>  // Needed for _POSIX_VERSION
-#endif
-
 static BadAccessHandler g_badAccessHandler;
 
 #ifdef MACHINE_CONTEXT_SUPPORTED
@@ -225,7 +221,7 @@ void InstallExceptionHandler(BadAccessHandler badAccessHandler) {
 void UninstallExceptionHandler() {
 }
 
-#elif defined(_POSIX_VERSION)
+#else
 
 static struct sigaction old_sa_segv;
 static struct sigaction old_sa_bus;
@@ -329,10 +325,6 @@ void UninstallExceptionHandler() {
 	NOTICE_LOG(SYSTEM, "Uninstalled exception handler");
 	g_badAccessHandler = nullptr;
 }
-
-#else  // Unsupported platform. Could also #error
-
-#error Shouldn't get here
 
 #endif
 

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -315,6 +315,7 @@ typedef mcontext_t SContext;
 #if PPSSPP_ARCH(AMD64)
 
 #include <cstdint>
+#include <stddef.h>
 #define CTX_PC CTX_RIP
 static inline uint64_t *ContextRN(SContext* ctx, int n) {
 	static const uint8_t offsets[] = {
@@ -330,6 +331,7 @@ static inline uint64_t *ContextRN(SContext* ctx, int n) {
 #elif PPSSPP_ARCH(X86)
 
 #include <cstdint>
+#include <stddef.h>
 #define CTX_PC CTX_RIP
 
 static inline uint32_t *ContextRN(SContext* ctx, int n) {

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -314,32 +314,30 @@ typedef mcontext_t SContext;
 
 #if PPSSPP_ARCH(AMD64)
 
-#include <stddef.h>
+#include <cstdint>
 #define CTX_PC CTX_RIP
-static inline u64* ContextRN(SContext* ctx, int n)
-{
-	static const u8 offsets[] = {
+static inline uint64_t *ContextRN(SContext* ctx, int n) {
+	static const uint8_t offsets[] = {
 		offsetof(SContext, CTX_RAX), offsetof(SContext, CTX_RCX), offsetof(SContext, CTX_RDX),
 		offsetof(SContext, CTX_RBX), offsetof(SContext, CTX_RSP), offsetof(SContext, CTX_RBP),
 		offsetof(SContext, CTX_RSI), offsetof(SContext, CTX_RDI), offsetof(SContext, CTX_R8),
 		offsetof(SContext, CTX_R9),  offsetof(SContext, CTX_R10), offsetof(SContext, CTX_R11),
 		offsetof(SContext, CTX_R12), offsetof(SContext, CTX_R13), offsetof(SContext, CTX_R14),
 		offsetof(SContext, CTX_R15)};
-	return (u64*)((char*)ctx + offsets[n]);
+	return (uint64_t *)((char *)ctx + offsets[n]);
 }
 
 #elif PPSSPP_ARCH(X86)
 
-#include <stddef.h>
+#include <cstdint>
 #define CTX_PC CTX_RIP
 
-static inline u32* ContextRN(SContext* ctx, int n)
-{
-	static const u8 offsets[] = {
+static inline uint32_t *ContextRN(SContext* ctx, int n) {
+	static const uint8_t offsets[] = {
 	  offsetof(SContext, CTX_RAX), offsetof(SContext, CTX_RCX), offsetof(SContext, CTX_RDX),
 	  offsetof(SContext, CTX_RBX), offsetof(SContext, CTX_RSP), offsetof(SContext, CTX_RBP),
 	  offsetof(SContext, CTX_RSI), offsetof(SContext, CTX_RDI)};
-	return (u32*)((char*)ctx + offsets[n]);
+	return (uint32_t *)((char*)ctx + offsets[n]);
 }
 
 #endif  // arch

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Core/System.h"
 #include "Core/CoreParameter.h"
 
@@ -92,7 +94,11 @@ enum class ExecExceptionType {
 	THREAD,
 };
 
+// Separate one for without info, to avoid having to allocate a string
 void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type);
+
+void Core_MemoryExceptionInfo(u32 address, u32 pc, MemoryExceptionType type, std::string additionalInfo);
+
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
 void Core_Break();
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -129,8 +129,7 @@
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <Target Name="CreateTlogDir"
-          BeforeTargets="CustomBuildStep">
+  <Target Name="CreateTlogDir" BeforeTargets="CustomBuildStep">
     <MakeDir Directories="$(TLogLocation)" />
   </Target>
   <PropertyGroup>
@@ -389,6 +388,7 @@
     <ClCompile Include="HLE\sceUsbCam.cpp" />
     <ClCompile Include="HLE\sceUsbMic.cpp" />
     <ClCompile Include="HW\Camera.cpp" />
+    <ClCompile Include="MemFault.cpp" />
     <ClCompile Include="MIPS\IR\IRAsm.cpp" />
     <ClCompile Include="MIPS\IR\IRCompALU.cpp" />
     <ClCompile Include="MIPS\IR\IRCompBranch.cpp" />
@@ -918,6 +918,7 @@
     <ClInclude Include="HLE\sceUsbCam.h" />
     <ClInclude Include="HLE\sceUsbMic.h" />
     <ClInclude Include="HW\Camera.h" />
+    <ClInclude Include="MemFault.h" />
     <ClInclude Include="MIPS\IR\IRFrontend.h" />
     <ClInclude Include="MIPS\IR\IRInst.h" />
     <ClInclude Include="MIPS\IR\IRInterpreter.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -743,6 +743,9 @@
     <ClCompile Include="HLE\sceKernelHeap.cpp">
       <Filter>HLE\Kernel</Filter>
     </ClCompile>
+    <ClCompile Include="MemFault.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1378,6 +1381,9 @@
     </ClInclude>
     <ClInclude Include="HLE\sceKernelHeap.h">
       <Filter>HLE\Kernel</Filter>
+    </ClInclude>
+    <ClInclude Include="MemFault.h">
+      <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -1,0 +1,143 @@
+// Copyright (C) 2020 PPSSPP Project
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+
+#include "Common/MachineContext.h"
+
+#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
+#include "Common/x64Analyzer.h"
+#elif PPSSPP_ARCH(ARM64)
+#include "Core/Util/DisArm64.h"
+#elif PPSSPP_ARCH(ARM)
+#include "ext/disarm.h"
+#endif
+
+#include "Core/Core.h"
+#include "Core/MemFault.h"
+#include "Core/MemMap.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+
+namespace Memory {
+
+static int64_t g_numReportedBadAccesses = 0;
+
+void MemFault_Init() {
+	g_numReportedBadAccesses = 0;
+}
+
+#ifdef MACHINE_CONTEXT_SUPPORTED
+
+bool HandleFault(uintptr_t hostAddress, void *ctx) {
+	SContext *context = (SContext *)ctx;
+	const uint8_t *codePtr = (uint8_t *)(context->CTX_PC);
+
+	// TODO: Check that codePtr is within the current JIT space.
+	bool inJitSpace = MIPSComp::jit && MIPSComp::jit->CodeInRange(codePtr);
+	if (!inJitSpace) {
+		// This is a crash in non-jitted code. Not something we want to handle here, ignore.
+		return false;
+	}
+
+	uintptr_t baseAddress = (uintptr_t)base;
+#ifdef MASKED_PSP_MEMORY
+	const uintptr_t addressSpaceSize = 0x40000000ULL;
+#else
+	const uintptr_t addressSpaceSize = 0x100000000ULL;
+#endif
+
+	// Check whether hostAddress is within the PSP memory space, which (likely) means it was a guest executable that did the bad access.
+	if (hostAddress < baseAddress || hostAddress >= baseAddress + addressSpaceSize) {
+		// Host address outside - this was a different kind of crash.
+		return false;
+	}
+
+	// OK, a guest executable did a bad access. Take care of it.
+
+	uint32_t guestAddress = hostAddress - baseAddress;
+
+	// TODO: Share the struct between the various analyzers, that will allow us to share most of
+	// the implementations here.
+	bool success = false;
+
+	MemoryExceptionType type = MemoryExceptionType::NONE;
+
+	std::string disassembly;
+
+#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
+	// X86, X86-64. Variable instruction size so need to analyze the mov instruction in detail.
+
+	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
+	LSInstructionInfo info;
+	success = X86AnalyzeMOV(codePtr, info);
+
+#elif PPSSPP_ARCH(ARM64)
+	uint32_t word;
+	memcpy(&word, codePtr, 4);
+	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
+	Arm64LSInstructionInfo info;
+	success = Arm64AnalyzeLoadStore((uint64_t)codePtr, word, &info);
+#elif PPSSPP_ARCH(ARM)
+	uint32_t word;
+	memcpy(&word, codePtr, 4);
+	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
+	ArmLSInstructionInfo info;
+	success = ArmAnalyzeLoadStore((uint32_t)codePtr, word, &info);
+#endif
+	if (success) {
+		if (info.isMemoryWrite) {
+			type = MemoryExceptionType::WRITE_WORD;
+		} else {
+			type = MemoryExceptionType::READ_WORD;
+		}
+	} else {
+		type = MemoryExceptionType::UNKNOWN;
+	}
+
+	if (success && g_Config.bIgnoreBadMemAccess) {
+		if (!info.isMemoryWrite) {
+			// It was a read. Fill the destination register with 0.
+			// TODO
+		}
+		// Move on to the next instruction. Note that handling bad accesses like this is pretty slow.
+		context->CTX_PC += info.instructionSize;
+		g_numReportedBadAccesses++;
+		if (g_numReportedBadAccesses < 100) {
+			ERROR_LOG(MEMMAP, "Bad memory access detected and ignored: %08x (%p)", guestAddress, (void *)hostAddress);
+		}
+	} else {
+		// Either bIgnoreBadMemAccess is off, or we failed recovery analysis.
+		uint32_t approximatePC = currentMIPS->pc;
+		Core_MemoryException(guestAddress, currentMIPS->pc, type);
+
+		// Redirect execution to a crash handler that will exit the game.
+		context->CTX_PC = (uintptr_t)MIPSComp::jit->GetCrashHandler();
+		ERROR_LOG(MEMMAP, "Bad memory access detected! %08x (%p) Stopping emulation.", guestAddress, (void *)hostAddress);
+	}
+	return true;
+}
+
+#else
+
+bool HandleFault(uintptr_t hostAddress, void *ctx) {
+	ERROR_LOG(MEMMAP, "Exception handling not supported");
+	return false;
+}
+
+#endif
+
+}  // namespace Memory

--- a/Core/MemFault.h
+++ b/Core/MemFault.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Memory {
+
+void MemFault_Init();
+
+// Called by exception handlers. We simply filter out accesses to PSP RAM and otherwise
+// just leave it as-is.
+bool HandleFault(uintptr_t hostAddress, void *context);
+
+}

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -29,17 +29,8 @@
 #include "Common/MemArena.h"
 #include "Common/ChunkFile.h"
 
-#include "Common/MachineContext.h"
-
-#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
-#include "Common/x64Analyzer.h"
-#elif PPSSPP_ARCH(ARM64)
-#include "Core/Util/DisArm64.h"
-#elif PPSSPP_ARCH(ARM)
-#include "ext/disarm.h"
-#endif
-
 #include "Core/MemMap.h"
+#include "Core/MemFault.h"
 #include "Core/HDRemaster.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/HLE/HLE.h"
@@ -57,7 +48,7 @@
 namespace Memory {
 
 // The base pointer to the auto-mirrored arena.
-u8* base = NULL;
+u8* base = nullptr;
 
 // The MemArena class
 MemArena g_arena;
@@ -96,8 +87,6 @@ u32 g_MemorySize;
 u32 g_PSPModel;
 
 std::recursive_mutex g_shutdownLock;
-
-static int64_t g_numReportedBadAccesses = 0;
 
 // We don't declare the IO region in here since its handled by other means.
 static MemoryView views[] =
@@ -311,7 +300,7 @@ void Init() {
 	INFO_LOG(MEMMAP, "Memory system initialized. Base at %p (RAM at @ %p, uncached @ %p)",
 		base, m_pPhysicalRAM, m_pUncachedRAM);
 
-	g_numReportedBadAccesses = 0;
+	MemFault_Init();
 }
 
 void Reinit() {
@@ -478,102 +467,5 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength) {
 
 	CBreakPoints::ExecMemCheck(_Address, true, _iLength, currentMIPS->pc);
 }
-
-#ifdef MACHINE_CONTEXT_SUPPORTED
-
-bool HandleFault(uintptr_t hostAddress, void *ctx) {
-	SContext *context = (SContext *)ctx;
-	const uint8_t *codePtr = (uint8_t *)(context->CTX_PC);
-
-	// TODO: Check that codePtr is within the current JIT space.
-	bool inJitSpace = MIPSComp::jit && MIPSComp::jit->CodeInRange(codePtr);
-	if (!inJitSpace) {
-		// This is a crash in non-jitted code. Not something we want to handle here, ignore.
-		return false;
-	}
-
-	uintptr_t baseAddress = (uintptr_t)base;
-#ifdef MASKED_PSP_MEMORY
-	const uintptr_t addressSpaceSize = 0x40000000ULL;
-#else
-	const uintptr_t addressSpaceSize = 0x100000000ULL;
-#endif
-
-	// Check whether hostAddress is within the PSP memory space, which (likely) means it was a guest executable that did the bad access.
-	if (hostAddress < baseAddress || hostAddress >= baseAddress + addressSpaceSize) {
-		// Host address outside - this was a different kind of crash.
-		return false;
-	}
-
-	// OK, a guest executable did a bad access. Take care of it.
-
-	uint32_t guestAddress = hostAddress - baseAddress;
-
-	// TODO: Share the struct between the various analyzers, that will allow us to share most of
-	// the implementations here.
-	bool success = false;
-
-	MemoryExceptionType type = MemoryExceptionType::NONE;
-
-#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
-	// X86, X86-64. Variable instruction size so need to analyze the mov instruction in detail.
-
-	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
-	LSInstructionInfo info;
-	success = X86AnalyzeMOV(codePtr, info);
-#elif PPSSPP_ARCH(ARM64)
-	uint32_t word;
-	memcpy(&word, codePtr, 4);
-	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
-	Arm64LSInstructionInfo info;
-	success = Arm64AnalyzeLoadStore((uint64_t)codePtr, word, &info);
-#elif PPSSPP_ARCH(ARM)
-	uint32_t word;
-	memcpy(&word, codePtr, 4);
-	// To ignore the access, we need to disassemble the instruction and modify context->CTX_PC
-	ArmLSInstructionInfo info;
-	success = ArmAnalyzeLoadStore((uint32_t)codePtr, word, &info);
-#endif
-	if (success) {
-		if (info.isMemoryWrite) {
-			type = MemoryExceptionType::WRITE_WORD;
-		} else {
-			type = MemoryExceptionType::READ_WORD;
-		}
-	} else {
-		type = MemoryExceptionType::UNKNOWN;
-	}
-
-	if (success && g_Config.bIgnoreBadMemAccess) {
-		if (!info.isMemoryWrite) {
-			// It was a read. Fill the destination register with 0.
-			// TODO
-		}
-		// Move on to the next instruction. Note that handling bad accesses like this is pretty slow.
-		context->CTX_PC += info.instructionSize;
-		g_numReportedBadAccesses++;
-		if (g_numReportedBadAccesses < 100) {
-			ERROR_LOG(MEMMAP, "Bad memory access detected and ignored: %08x (%p)", guestAddress, (void *)hostAddress);
-		}
-	} else {
-		// Either bIgnoreBadMemAccess is off, or we failed recovery analysis.
-		uint32_t approximatePC = currentMIPS->pc;
-		Core_MemoryException(guestAddress, currentMIPS->pc, type);
-
-		// Redirect execution to a crash handler that will exit the game.
-		context->CTX_PC = (uintptr_t)MIPSComp::jit->GetCrashHandler();
-		ERROR_LOG(MEMMAP, "Bad memory access detected! %08x (%p) Stopping emulation.", guestAddress, (void *)hostAddress);
-	}
-	return true;
-}
-
-#else
-
-bool HandleFault(uintptr_t hostAddress, void *ctx) {
-	ERROR_LOG(MEMMAP, "Exception handling not supported");
-	return false;
-}
-
-#endif
 
 } // namespace

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -148,10 +148,6 @@ Opcode Read_Opcode_JIT(const u32 _Address);
 // used by JIT. Reads in the "Locked cache" mode
 void Write_Opcode_JIT(const u32 _Address, const Opcode& _Value);
 
-// Called by exception handlers. We simply filter out accesses to PSP RAM and otherwise
-// just leave it as-is.
-bool HandleFault(uintptr_t hostAddress, void *context);
-
 // Should be used by analyzers, disassemblers etc. Does resolve replacements.
 Opcode Read_Instruction(const u32 _Address, bool resolveReplacements = false);
 Opcode ReadUnchecked_Instruction(const u32 _Address, bool resolveReplacements = false);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -39,7 +39,7 @@
 #include "util/text/utf8.h"
 
 #include "Common/GraphicsContext.h"
-#include "Core/MemMap.h"
+#include "Core/MemFault.h"
 #include "Core/HDRemaster.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -182,3 +182,4 @@ private:
 };
 
 void DrawProfile(UIContext &ui);
+const char *GetCompilerABI();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1283,12 +1283,14 @@ static void DrawCrashDump(DrawBuffer *draw2d) {
 	snprintf(statbuf, sizeof(statbuf), R"(%s
 Game ID (Title): %s (%s)
 PPSSPP build: %s (%s)
+ABI: %s
 )",
 		ExceptionTypeAsString(info.type),
 		g_paramSFO.GetDiscID().c_str(),
 		g_paramSFO.GetValueString("TITLE").c_str(),
 		versionString,
-		build
+		build,
+		GetCompilerABI()
 	);
 
 	draw2d->SetFontScale(.7f, .7f);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1302,12 +1302,14 @@ ABI: %s
 	if (info.type == ExceptionType::MEMORY) {
 		snprintf(statbuf, sizeof(statbuf), R"(
 Access: %s at %08x
-PC: %08x)",
+PC: %08x
+%s)",
 			MemoryExceptionTypeAsString(info.memory_type),
 			info.address,
-			info.pc);
+			info.pc,
+			info.info.c_str());
 		draw2d->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
-		y += 120;
+		y += 180;
 	} else if (info.type == ExceptionType::BAD_EXEC_ADDR) {
 		snprintf(statbuf, sizeof(statbuf), R"(
 Destination: %s to %08x

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -519,6 +519,7 @@
     <ClInclude Include="..\..\Core\HW\SimpleAudioDec.h" />
     <ClInclude Include="..\..\Core\HW\StereoResampler.h" />
     <ClInclude Include="..\..\Core\Loaders.h" />
+    <ClInclude Include="..\..\Core\MemFault.h" />
     <ClInclude Include="..\..\Core\MemMap.h" />
     <ClInclude Include="..\..\Core\MemMapHelpers.h" />
     <ClInclude Include="..\..\Core\MIPS\ARM64\Arm64Jit.h" />
@@ -730,6 +731,7 @@
     <ClCompile Include="..\..\Core\HW\SimpleAudioDec.cpp" />
     <ClCompile Include="..\..\Core\HW\StereoResampler.cpp" />
     <ClCompile Include="..\..\Core\Loaders.cpp" />
+    <ClCompile Include="..\..\Core\MemFault.cpp" />
     <ClCompile Include="..\..\Core\MemMap.cpp" />
     <ClCompile Include="..\..\Core\MemMapFunctions.cpp" />
     <ClCompile Include="..\..\Core\MIPS\ARM64\Arm64Asm.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -82,6 +82,7 @@
     <ClCompile Include="..\..\Core\HDRemaster.cpp" />
     <ClCompile Include="..\..\Core\Host.cpp" />
     <ClCompile Include="..\..\Core\Loaders.cpp" />
+    <ClCompile Include="..\..\Core\MemFault.cpp" />
     <ClCompile Include="..\..\Core\MemMap.cpp" />
     <ClCompile Include="..\..\Core\MemMapFunctions.cpp" />
     <ClCompile Include="..\..\Core\PSPLoaders.cpp" />
@@ -719,6 +720,7 @@
     <ClInclude Include="..\..\Core\HDRemaster.h" />
     <ClInclude Include="..\..\Core\Host.h" />
     <ClInclude Include="..\..\Core\Loaders.h" />
+    <ClInclude Include="..\..\Core\MemFault.h" />
     <ClInclude Include="..\..\Core\MemMap.h" />
     <ClInclude Include="..\..\Core\MemMapHelpers.h" />
     <ClInclude Include="..\..\Core\Opcode.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -300,6 +300,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/FileLoaders/LocalFileLoader.cpp \
   $(SRC)/Core/FileLoaders/RamCachingFileLoader.cpp \
   $(SRC)/Core/FileLoaders/RetryingFileLoader.cpp \
+  $(SRC)/Core/MemFault.cpp \
   $(SRC)/Core/MemMap.cpp \
   $(SRC)/Core/MemMapFunctions.cpp \
   $(SRC)/Core/Reporting.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -472,6 +472,7 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
 	       $(COREDIR)/MIPS/MIPSIntVFPU.cpp \
 	       $(COREDIR)/MIPS/MIPSTables.cpp \
 	       $(COREDIR)/MIPS/MIPSVFPUUtils.cpp \
+	       $(COREDIR)/MemFault.cpp \
 	       $(COREDIR)/MemMap.cpp \
 	       $(COREDIR)/MemMapFunctions.cpp \
 	       $(COREDIR)/PSPLoaders.cpp \


### PR DESCRIPTION
If JIT is enabled and the game does a bad memory access, shows disassembly of the native (not PSP) instruction causing the crash, and the symbol name.

![disasm](https://user-images.githubusercontent.com/130929/87535736-3ed9a100-c698-11ea-8c51-ac2192238a2d.png)

(Need to work a bit on the layout in the future..)

Also split up the fault handler from MemMap.cpp.