### PR TITLE
Vulkan: Some surface code cleanup

### DIFF
--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -1083,6 +1083,13 @@ void VulkanContext::PerformPendingDeletes() {
 }
 
 void VulkanContext::DestroyDevice() {
+	if (swapchain_) {
+		ELOG("DestroyDevice: Swapchain should have been destroyed.");
+	}
+	if (surface_) {
+		ELOG("DestroyDevice: Surface should have been destroyed.");
+	}
+
 	ILOG("VulkanContext::DestroyDevice (performing deletes)");
 	PerformPendingDeletes();
 

--- a/Common/Vulkan/VulkanContext.h
+++ b/Common/Vulkan/VulkanContext.h
@@ -147,12 +147,11 @@ public:
 	VkResult InitSurface(WindowSystem winsys, void *data1, void *data2);
 	VkResult ReinitSurface();
 
-	bool InitQueue();
-	bool InitObjects();
 	bool InitSwapchain();
 
-	// Also destroys the surface.
-	void DestroyObjects();
+	void DestroySwapchain();
+	void DestroySurface();
+
 	void DestroyDevice();
 
 	void PerformPendingDeletes();
@@ -273,6 +272,8 @@ public:
 	void GetImageMemoryRequirements(VkImage image, VkMemoryRequirements *mem_reqs, bool *dedicatedAllocation);
 
 private:
+	bool ChooseQueue();
+
 	VkResult InitDebugUtilsCallback();
 
 	// A layer can expose extensions, keep track of those extensions here.

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -758,8 +758,14 @@ void __DisplayFlip(int cyclesLate) {
 
 	bool duplicateFrames = g_Config.bRenderDuplicateFrames && g_Config.iFrameSkip == 0;
 
+	bool unthrottleNeedsSkip = g_Config.bFrameSkipUnthrottle;
+	if (g_Config.bVSync && GetGPUBackend() == GPUBackend::VULKAN) {
+		// Vulkan doesn't support the interval setting, so we force frameskip.
+		unthrottleNeedsSkip = true;
+	}
+
 	// postEffectRequiresFlip is not compatible with frameskip unthrottling, see #12325.
-	if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !(g_Config.bFrameSkipUnthrottle && !FrameTimingThrottled())) {
+	if (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !(unthrottleNeedsSkip && !FrameTimingThrottled())) {
 		if (shaderInfo) {
 			postEffectRequiresFlip = (shaderInfo->requires60fps || duplicateFrames);
 		} else {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -114,11 +114,11 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 		}
 	}
 	if (audioDev <= 0) {
-		ILOG("SDL: Trying a different device");
+		ILOG("SDL: Trying a different audio device");
 		audioDev = SDL_OpenAudioDevice(nullptr, 0, &fmt, &g_retFmt, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	}
 	if (audioDev <= 0) {
-		ELOG("Failed to open audio: %s", SDL_GetError());
+		ELOG("Failed to open audio device: %s", SDL_GetError());
 	} else {
 		if (g_retFmt.samples != fmt.samples) // Notify, but still use it
 			ELOG("Output audio samples: %d (requested: %d)", g_retFmt.samples, fmt.samples);

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -144,9 +144,7 @@ void SDLVulkanGraphicsContext::Shutdown() {
 void SDLVulkanGraphicsContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 	vulkan_->DestroySwapchain();
-	vulkan_->DestroySurface();
 	vulkan_->UpdateFlags(FlagsFromConfig());
-	vulkan_->ReinitSurface();
 	vulkan_->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 }

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -20,6 +20,15 @@ static const bool g_Validate = true;
 static const bool g_Validate = false;
 #endif
 
+static uint32_t FlagsFromConfig() {
+	uint32_t flags = 0;
+	flags = g_Config.bVSync ? VULKAN_FLAG_PRESENT_FIFO : VULKAN_FLAG_PRESENT_MAILBOX;
+	if (g_Validate) {
+		flags |= VULKAN_FLAG_VALIDATE;
+	}
+	return flags;
+}
+
 bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std::string *error_message) {
 	window = SDL_CreateWindow("Initializing Vulkan...", x, y, pixel_xres, pixel_yres, mode);
 	if (!window) {
@@ -41,10 +50,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 	}
 
 	vulkan_ = new VulkanContext();
-	int vulkanFlags = VULKAN_FLAG_PRESENT_MAILBOX;
-	if (g_Validate) {
-		vulkanFlags |= VULKAN_FLAG_VALIDATE;
-	}
+	int vulkanFlags = FlagsFromConfig();
 
 	VulkanContext::CreateInfo info{};
 	info.app_name = "PPSSPP";
@@ -102,7 +108,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 		break;
 	}
 
-	if (!vulkan_->InitObjects()) {
+	if (!vulkan_->InitSwapchain()) {
 		*error_message = vulkan_->InitError();
 		Shutdown();
 		return false;
@@ -126,7 +132,8 @@ void SDLVulkanGraphicsContext::Shutdown() {
 	delete draw_;
 	draw_ = nullptr;
 	vulkan_->WaitUntilQueueIdle();
-	vulkan_->DestroyObjects();
+	vulkan_->DestroySwapchain();
+	vulkan_->DestroySurface();
 	vulkan_->DestroyDevice();
 	vulkan_->DestroyInstance();
 	delete vulkan_;
@@ -136,9 +143,11 @@ void SDLVulkanGraphicsContext::Shutdown() {
 
 void SDLVulkanGraphicsContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
-	vulkan_->DestroyObjects();
+	vulkan_->DestroySwapchain();
+	vulkan_->DestroySurface();
+	vulkan_->UpdateFlags(FlagsFromConfig());
 	vulkan_->ReinitSurface();
-	vulkan_->InitObjects();
+	vulkan_->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -350,13 +350,14 @@ void GameSettingsScreen::CreateViews() {
 	}
 #endif
 
-#ifdef _WIN32
+#if !PPSSPP_PLATFORM(ANDROID)
 	CheckBox *vSync = graphicsSettings->Add(new CheckBox(&g_Config.bVSync, gr->T("VSync")));
 	vSync->OnClick.Add([=](EventParams &e) {
 		NativeResized();
 		return UI::EVENT_CONTINUE;
 	});
 #endif
+
 	CheckBox *frameDuplication = graphicsSettings->Add(new CheckBox(&g_Config.bRenderDuplicateFrames, gr->T("Render duplicate frames to 60hz")));
 	frameDuplication->SetEnabledFunc([] {
 		return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE || (g_Config.bSoftwareRendering && g_Config.iFrameSkip != 0);

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -175,9 +175,7 @@ void WindowsVulkanContext::Shutdown() {
 void WindowsVulkanContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	g_Vulkan->DestroySwapchain();
-	g_Vulkan->DestroySurface();
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
-	g_Vulkan->ReinitSurface();
 	g_Vulkan->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 }

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -129,7 +129,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	}
 
 	g_Vulkan->InitSurface(WINDOWSYSTEM_WIN32, (void *)hInst, (void *)hWnd);
-	if (!g_Vulkan->InitObjects()) {
+	if (!g_Vulkan->InitSwapchain()) {
 		*error_message = g_Vulkan->InitError();
 		Shutdown();
 		return false;
@@ -160,7 +160,8 @@ void WindowsVulkanContext::Shutdown() {
 	draw_ = nullptr;
 
 	g_Vulkan->WaitUntilQueueIdle();
-	g_Vulkan->DestroyObjects();
+	g_Vulkan->DestroySwapchain();
+	g_Vulkan->DestroySurface();
 	g_Vulkan->DestroyDevice();
 	g_Vulkan->DestroyInstance();
 
@@ -174,6 +175,7 @@ void WindowsVulkanContext::Shutdown() {
 void WindowsVulkanContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	g_Vulkan->DestroySwapchain();
+	g_Vulkan->DestroySurface();
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
 	g_Vulkan->ReinitSurface();
 	g_Vulkan->InitSwapchain();

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -69,8 +69,6 @@ static const bool g_validate_ = true;
 static const bool g_validate_ = false;
 #endif
 
-static VulkanContext *g_Vulkan;
-
 static uint32_t FlagsFromConfig() {
 	uint32_t flags = 0;
 	flags = g_Config.bVSync ? VULKAN_FLAG_PRESENT_FIFO : VULKAN_FLAG_PRESENT_MAILBOX;
@@ -83,7 +81,7 @@ static uint32_t FlagsFromConfig() {
 bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_message) {
 	*error_message = "N/A";
 
-	if (g_Vulkan) {
+	if (vulkan_) {
 		*error_message = "Already initialized";
 		return false;
 	}
@@ -101,47 +99,47 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 		return false;
 	}
 
-	g_Vulkan = new VulkanContext();
+	vulkan_ = new VulkanContext();
 
 	VulkanContext::CreateInfo info{};
 	info.app_name = "PPSSPP";
 	info.app_ver = gitVer.ToInteger();
 	info.flags = FlagsFromConfig();
-	if (VK_SUCCESS != g_Vulkan->CreateInstance(info)) {
-		*error_message = g_Vulkan->InitError();
-		delete g_Vulkan;
-		g_Vulkan = nullptr;
+	if (VK_SUCCESS != vulkan_->CreateInstance(info)) {
+		*error_message = vulkan_->InitError();
+		delete vulkan_;
+		vulkan_ = nullptr;
 		return false;
 	}
-	int deviceNum = g_Vulkan->GetPhysicalDeviceByName(g_Config.sVulkanDevice);
+	int deviceNum = vulkan_->GetPhysicalDeviceByName(g_Config.sVulkanDevice);
 	if (deviceNum < 0) {
-		deviceNum = g_Vulkan->GetBestPhysicalDevice();
+		deviceNum = vulkan_->GetBestPhysicalDevice();
 		if (!g_Config.sVulkanDevice.empty())
-			g_Config.sVulkanDevice = g_Vulkan->GetPhysicalDeviceProperties(deviceNum).properties.deviceName;
+			g_Config.sVulkanDevice = vulkan_->GetPhysicalDeviceProperties(deviceNum).properties.deviceName;
 	}
 
-	g_Vulkan->ChooseDevice(deviceNum);
-	if (g_Vulkan->CreateDevice() != VK_SUCCESS) {
-		*error_message = g_Vulkan->InitError();
-		delete g_Vulkan;
-		g_Vulkan = nullptr;
+	vulkan_->ChooseDevice(deviceNum);
+	if (vulkan_->CreateDevice() != VK_SUCCESS) {
+		*error_message = vulkan_->InitError();
+		delete vulkan_;
+		vulkan_ = nullptr;
 		return false;
 	}
 
-	g_Vulkan->InitSurface(WINDOWSYSTEM_WIN32, (void *)hInst, (void *)hWnd);
-	if (!g_Vulkan->InitSwapchain()) {
-		*error_message = g_Vulkan->InitError();
+	vulkan_->InitSurface(WINDOWSYSTEM_WIN32, (void *)hInst, (void *)hWnd);
+	if (!vulkan_->InitSwapchain()) {
+		*error_message = vulkan_->InitError();
 		Shutdown();
 		return false;
 	}
 
 	bool splitSubmit = g_Config.bGfxDebugSplitSubmit;
 
-	draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, splitSubmit);
-	SetGPUBackend(GPUBackend::VULKAN, g_Vulkan->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
+	draw_ = Draw::T3DCreateVulkanContext(vulkan_, splitSubmit);
+	SetGPUBackend(GPUBackend::VULKAN, vulkan_->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
 	bool success = draw_->CreatePresets();
 	_assert_msg_(G3D, success, "Failed to compile preset shaders");
-	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 
 	renderManager_ = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
@@ -154,39 +152,39 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 
 void WindowsVulkanContext::Shutdown() {
 	if (draw_)
-		draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+		draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 
 	delete draw_;
 	draw_ = nullptr;
 
-	g_Vulkan->WaitUntilQueueIdle();
-	g_Vulkan->DestroySwapchain();
-	g_Vulkan->DestroySurface();
-	g_Vulkan->DestroyDevice();
-	g_Vulkan->DestroyInstance();
+	vulkan_->WaitUntilQueueIdle();
+	vulkan_->DestroySwapchain();
+	vulkan_->DestroySurface();
+	vulkan_->DestroyDevice();
+	vulkan_->DestroyInstance();
 
-	delete g_Vulkan;
-	g_Vulkan = nullptr;
+	delete vulkan_;
+	vulkan_ = nullptr;
 	renderManager_ = nullptr;
 
 	finalize_glslang();
 }
 
 void WindowsVulkanContext::Resize() {
-	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
-	g_Vulkan->DestroySwapchain();
-	g_Vulkan->UpdateFlags(FlagsFromConfig());
-	g_Vulkan->InitSwapchain();
-	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
+	vulkan_->DestroySwapchain();
+	vulkan_->UpdateFlags(FlagsFromConfig());
+	vulkan_->InitSwapchain();
+	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 }
 
 void WindowsVulkanContext::Poll() {
 	// Check for existing swapchain to avoid issues during shutdown.
-	if (g_Vulkan->GetSwapchain() && renderManager_->NeedsSwapchainRecreate()) {
+	if (vulkan_->GetSwapchain() && renderManager_->NeedsSwapchainRecreate()) {
 		Resize();
 	}
 }
 
 void *WindowsVulkanContext::GetAPIContext() {
-	return g_Vulkan;
+	return vulkan_;
 }

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -173,12 +173,10 @@ void WindowsVulkanContext::Shutdown() {
 
 void WindowsVulkanContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
-	g_Vulkan->DestroyObjects();
-
+	g_Vulkan->DestroySwapchain();
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
-	g_Vulkan->ReinitSurface();
-
-	g_Vulkan->InitObjects();
+	g_Vulkan_->ReinitSurface();
+	g_Vulkan_->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 }
 

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -175,8 +175,8 @@ void WindowsVulkanContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	g_Vulkan->DestroySwapchain();
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
-	g_Vulkan_->ReinitSurface();
-	g_Vulkan_->InitSwapchain();
+	g_Vulkan->ReinitSurface();
+	g_Vulkan->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 }
 

--- a/Windows/GPU/WindowsVulkanContext.h
+++ b/Windows/GPU/WindowsVulkanContext.h
@@ -21,6 +21,7 @@
 #include "Windows/GPU/WindowsGraphicsContext.h"
 #include "thin3d/thin3d.h"
 
+class VulkanContext;
 class VulkanRenderManager;
 
 class WindowsVulkanContext : public WindowsGraphicsContext {
@@ -38,6 +39,7 @@ public:
 	Draw::DrawContext *GetDrawContext() override { return draw_; }
 private:
 	Draw::DrawContext *draw_;
+	VulkanContext *vulkan_ = nullptr;
 	VulkanRenderManager *renderManager_ = nullptr;
 };
 

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -100,7 +100,7 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 	}
 
 	bool success = true;
-	if (g_Vulkan->InitObjects()) {
+	if (g_Vulkan->InitSwapchain()) {
 		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, g_Config.bGfxDebugSplitSubmit);
 		SetGPUBackend(GPUBackend::VULKAN);
 		success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -156,6 +156,7 @@ void AndroidVulkanContext::Resize() {
 	g_Vulkan->DestroySurface();
 
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
+
 	g_Vulkan->ReinitSurface();
 	g_Vulkan->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -116,7 +116,8 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 
 	ILOG("AndroidVulkanContext::Init completed, %s", success ? "successfully" : "but failed");
 	if (!success) {
-		g_Vulkan->DestroyObjects();
+		g_Vulkan->DestroySwapchain();
+		g_Vulkan->DestroySurface();
 		g_Vulkan->DestroyDevice();
 		g_Vulkan->DestroyInstance();
 	}
@@ -130,7 +131,8 @@ void AndroidVulkanContext::ShutdownFromRenderThread() {
 	draw_ = nullptr;
 	g_Vulkan->WaitUntilQueueIdle();
 	g_Vulkan->PerformPendingDeletes();
-	g_Vulkan->DestroyObjects();  // Also destroys the surface, a bit asymmetric
+	g_Vulkan->DestroySwapchain();
+	g_Vulkan->DestroySurface();
 	ILOG("Done with ShutdownFromRenderThread");
 }
 
@@ -150,11 +152,12 @@ void AndroidVulkanContext::Resize() {
 	ILOG("AndroidVulkanContext::Resize begin (oldsize: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
-	g_Vulkan->DestroyObjects();
+	g_Vulkan->DestroySwapchain();
+	g_Vulkan->DestroySurface();
 
 	g_Vulkan->UpdateFlags(FlagsFromConfig());
 	g_Vulkan->ReinitSurface();
-	g_Vulkan->InitObjects();
+	g_Vulkan->InitSwapchain();
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	ILOG("AndroidVulkanContext::Resize end (final size: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 }

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -69,7 +69,7 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	vk->InitSurface(WINDOWSYSTEM_WAYLAND, nullptr, nullptr);
 #endif
 
-	if (!vk->InitQueue()) {
+	if (!vk->InitSwapchain()) {
 		return false;
 	}
 
@@ -116,7 +116,8 @@ void LibretroVulkanContext::Shutdown() {
 
 	vk->WaitUntilQueueIdle();
 
-	vk->DestroyObjects();
+	vk->DestroySwapchain();
+	vk->DestroySurface();
 	vk->DestroyDevice();
 	vk->DestroyInstance();
 	delete vk;


### PR DESCRIPTION
Replaces #13041 . Did it somewhat differently, now works flawlessly on Linux for some reason, even when not recreating the surface on resize. Doesn't yet use oldSwapchain though, which will be required for switching vsync mode without stalling the GPU in the future.

Also enables the VSync setting on more platforms. There's more work to be done there though.

Shortens some logging, too.

The end goal of this stuff is better control over the swapchain, including seamless switches between vsync and not, for better unthrottle when vsynced, this is just a step on the way there though.


Also (accidentally, but decided to go with it) includes the fix for the issue @Anuskuss found with Vulkan and vsync and unthrottling.